### PR TITLE
Add GTSF-PT Agda development

### DIFF
--- a/GTSF-PT/CoercionTerms.agda
+++ b/GTSF-PT/CoercionTerms.agda
@@ -1,0 +1,315 @@
+-- File Charter:
+--   * Core syntax, values, and primitive operations for coercion terms.
+--   * Primary exports are intrinsically typed target terms plus term/type
+--     renaming and substitution operations.
+--   * Depends on labels, types, consistency, coercion typing, and source
+--     expression contexts.
+
+module CoercionTerms where
+
+open import Data.Nat using (ℕ; suc)
+open import Data.Bool using (Bool)
+open import Data.Fin.Subset using (Subset; Side; inside; outside; _∈_)
+open import Data.Product using (Σ; Σ-syntax; proj₁; proj₂)
+open import Data.Vec using ([] ; _∷_; here; there)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; cong₂; sym; trans)
+  renaming (subst to substEq)
+
+open import Label
+open import Types
+open import Consistency
+open import Coercions
+open import Terms using (ExCtx; ∅; _▷_; renameᵉ; ExVar; Zᵉ; Sᵉ)
+
+-- data ExCtx : TyCtx → Set where
+
+--   ∅ : ∀{Δ} → ExCtx Δ
+
+--   _▷_ : ∀{Δ} → ExCtx Δ → Ty Δ → ExCtx Δ
+
+-- renameᵉ : ∀ {Δ}{Δ′} → Renameᵗ Δ Δ′ → ExCtx Δ → ExCtx Δ′
+-- renameᵉ ρ ∅ = ∅
+-- renameᵉ ρ (Γ ▷ T) = renameᵉ ρ Γ ▷ renameᵗ ρ T
+
+-- data ExVar {Δ : TyCtx} : ExCtx Δ → Ty Δ → Set where
+
+--   Zᵉ : ∀ {Γ}{T} → ExVar (Γ ▷ T) T
+
+--   Sᵉ : ∀ {Γ} {T T′ : Ty Δ} → ExVar Γ T → ExVar (Γ ▷ T′) T
+
+data Ex {Δ : TyCtx} {Ψ : Subset Δ} : ExCtx Δ → Ty Δ → Set where
+
+  `_ : ∀ {Γ} {T}
+    → ExVar Γ T → Ex Γ T
+
+  cst : ∀ {Γ}
+    → (b : Σ Base base-type)
+    → Ex Γ (‵ b .proj₁)
+
+  λx:_⇒ : ∀ {Γ} {U}
+    → ∀ T
+    → Ex {Ψ = Ψ} (Γ ▷ T) U
+    → Ex Γ (T ⇒ U)
+
+  app : ∀ {Γ} {T U}
+      → Ex {Ψ = Ψ} Γ (T ⇒ U)
+      → Ex {Ψ = Ψ} Γ T
+      → Ex Γ U
+
+  ΛX : ∀ {Γ} {T}
+    → Ex {Ψ = outside ∷ Ψ}  (renameᵉ Sᵗ Γ) T
+    → Ex Γ (`∀ T)
+
+  tapp : ∀ {Γ} {T : Ty (ℕ.suc Δ)}
+       → Ex {Ψ = Ψ} Γ (`∀ T)
+       → (U : Ty Δ)
+       → Ex Γ (T [ U ]ᵗ)
+
+  capp : ∀ {Γ}{S T : Ty Δ}{s : Coercion Δ}
+    → Ex {Ψ = Ψ} Γ S
+    → Δ ∣ Ψ ⊢ s ∶ S =⇒ T
+    → Ex Γ T
+
+  blame : ∀ {Γ}{A} (ℓ : Label)
+    → Ex Γ A
+
+syntax app x y = x · y
+syntax capp x y = x ⟨ y ⟩
+
+data Value {Δ : TyCtx} {Ψ : Subset Δ} {Γ : ExCtx Δ} : ∀  {T : Ty Δ} → Ex {Ψ = Ψ} Γ T → Set where
+
+  v-cst : ∀ (b : Σ Base base-type) → Value (cst b)
+
+  v-λx:_⇒  : ∀ (A : Ty Δ) {B : Ty Δ} → (M : Ex (Γ ▷ A) B) → Value (λx: A ⇒ M)
+
+  v-ΛX : ∀ {A} (N : Ex {Ψ = outside ∷ Ψ} (renameᵉ Sᵗ Γ) A) → Value (ΛX N)
+
+  v-capp-seal :  ∀{α : TyVar Δ}{A : Ty Δ}{V : Ex Γ A}
+    → (α∈Ψ : tyVarToFin α ∈ Ψ)
+    → Value V
+    → Value (capp V (cast-seal α∈Ψ))
+
+  v-capp-tag : ∀ {T} {V : Ex {Ψ = Ψ} Γ T}
+    → (gT : Ground T)
+    → Value V
+    → Value (capp V (cast-tag gT))
+
+  v-capp-fun : ∀ {A}{B}{A′}{B′} {V : Ex {Ψ = Ψ} Γ (A ⇒ B)} {s}{t}
+    → {s⊢ : Δ ∣ Ψ ⊢ s ∶ A′ =⇒ A}
+    → {t⊢ : Δ ∣ Ψ ⊢ t ∶ B =⇒ B′}
+    → Value V
+    → Value (capp V (cast-fun s⊢ t⊢))
+
+  v-capp-gen :  ∀{A : Ty Δ}{B : Ty (suc Δ)}{V : Ex Γ A}{s : Coercion (suc Δ)}
+    → {s⊢ : suc Δ ∣ inside ∷ Ψ ⊢ s ∶ wkTy A =⇒ B}
+    → Value V
+    → Value (capp V (cast-gen s⊢))
+
+------------------------------------------------------------
+-- expression renaming
+------------------------------------------------------------
+
+Renameᶜᵗ : ∀ {Δ} → ExCtx Δ → ExCtx Δ → Set
+Renameᶜᵗ Γ Γ′ = ∀ {T} → ExVar Γ T → ExVar Γ′ T
+
+extᶜᵗ : ∀ {Δ}{Γ Γ′ : ExCtx Δ}{T : Ty Δ} →
+  Renameᶜᵗ Γ Γ′ →
+  Renameᶜᵗ (Γ ▷ T) (Γ′ ▷ T)
+extᶜᵗ ρ Zᵉ = Zᵉ
+extᶜᵗ ρ (Sᵉ x) = Sᵉ (ρ x)
+
+rename-varᵗ :
+  ∀ {Δ Δ′}{Γ : ExCtx Δ}{T : Ty Δ} →
+  (ρ : Renameᵗ Δ Δ′) →
+  ExVar Γ T →
+  ExVar (renameᵉ ρ Γ) (renameᵗ ρ T)
+rename-varᵗ ρ Zᵉ = Zᵉ
+rename-varᵗ ρ (Sᵉ x) = Sᵉ (rename-varᵗ ρ x)
+
+renameᵉ-Renameᶜᵗ :
+  ∀ {Δ Δ′}{Γ Γ′ : ExCtx Δ} →
+  (ρᵗ : Renameᵗ Δ Δ′) →
+  Renameᶜᵗ Γ Γ′ →
+  Renameᶜᵗ (renameᵉ ρᵗ Γ) (renameᵉ ρᵗ Γ′)
+renameᵉ-Renameᶜᵗ {Γ = ∅} ρᵗ ρ ()
+renameᵉ-Renameᶜᵗ {Γ = Γ ▷ T} ρᵗ ρ Zᵉ = rename-varᵗ ρᵗ (ρ Zᵉ)
+renameᵉ-Renameᶜᵗ {Γ = Γ ▷ T} ρᵗ ρ (Sᵉ x) =
+  renameᵉ-Renameᶜᵗ ρᵗ (λ y → ρ (Sᵉ y)) x
+
+renameᶜᵗ :
+  ∀ {Δ} {Ψ : Subset Δ} {Γ Γ′ : ExCtx Δ}{T : Ty Δ} →
+  Renameᶜᵗ Γ Γ′ →
+  Ex {Ψ = Ψ} Γ T →
+  Ex {Ψ = Ψ} Γ′ T
+renameᶜᵗ ρ (` x) = ` (ρ x)
+renameᶜᵗ ρ (cst b) = cst b
+renameᶜᵗ ρ (λx: T ⇒ M) = λx: T ⇒ (renameᶜᵗ (extᶜᵗ ρ) M)
+renameᶜᵗ ρ (app M N) = app (renameᶜᵗ ρ M) (renameᶜᵗ ρ N)
+renameᶜᵗ ρ (ΛX M) = ΛX (renameᶜᵗ (renameᵉ-Renameᶜᵗ Sᵗ ρ) M)
+renameᶜᵗ ρ (tapp M U) = tapp (renameᶜᵗ ρ M) U
+renameᶜᵗ ρ (capp M s⊢) = capp (renameᶜᵗ ρ M) s⊢
+renameᶜᵗ ρ (blame ℓ) = blame ℓ
+
+RenamesSubset : ∀ {Δ Δ′} → Renameᵗ Δ Δ′ → Subset Δ → Subset Δ′ → Set
+RenamesSubset ρ Ψ Ψ′ =
+  ∀ {X} → tyVarToFin X ∈ Ψ → tyVarToFin (ρ X) ∈ Ψ′
+
+renames-outside :
+  ∀ {Δ Δ′}{ρ : Renameᵗ Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′} →
+  RenamesSubset ρ Ψ Ψ′ →
+  RenamesSubset (extᵗ ρ) (outside ∷ Ψ) (outside ∷ Ψ′)
+renames-outside ρ⊆ {Zᵗ} ()
+renames-outside ρ⊆ {Sᵗ X} (there X∈Ψ) = there (ρ⊆ X∈Ψ)
+
+renames-inside :
+  ∀ {Δ Δ′}{ρ : Renameᵗ Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′} →
+  RenamesSubset ρ Ψ Ψ′ →
+  RenamesSubset (extᵗ ρ) (inside ∷ Ψ) (inside ∷ Ψ′)
+renames-inside ρ⊆ {Zᵗ} here = here
+renames-inside ρ⊆ {Sᵗ X} (there X∈Ψ) = there (ρ⊆ X∈Ψ)
+
+renames-wk : ∀ {Δ}{Ψ : Subset Δ} → RenamesSubset Sᵗ Ψ (outside ∷ Ψ)
+renames-wk X∈Ψ = there X∈Ψ
+
+rename-Ground :
+  ∀ {Δ Δ′}{G : Ty Δ} →
+  (ρ : Renameᵗ Δ Δ′) →
+  Ground G →
+  Ground (renameᵗ ρ G)
+rename-Ground ρ (‵ ι) = ‵ ι
+rename-Ground ρ ★⇒★ = ★⇒★
+
+rename-wkTy :
+  ∀ {Δ Δ′}(ρ : Renameᵗ Δ Δ′) (A : Ty Δ) →
+  renameᵗ (extᵗ ρ) (wkTy A) ≡ wkTy (renameᵗ ρ A)
+rename-wkTy ρ A =
+  trans (renameᵗ-comp (extᵗ ρ) Sᵗ A)
+        (sym (renameᵗ-comp Sᵗ ρ A))
+
+rename-cast :
+  ∀ {Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′}
+    {A B : Ty Δ}{s : Coercion Δ} →
+  (ρ : Renameᵗ Δ Δ′) →
+  RenamesSubset ρ Ψ Ψ′ →
+  Δ ∣ Ψ ⊢ s ∶ A =⇒ B →
+  Δ′ ∣ Ψ′ ⊢ renameᶜ ρ s ∶ renameᵗ ρ A =⇒ renameᵗ ρ B
+rename-cast ρ ρ⊆ cast-id = cast-id
+rename-cast ρ ρ⊆ (cast-seal α∈Ψ) = cast-seal (ρ⊆ α∈Ψ)
+rename-cast ρ ρ⊆ (cast-unseal α∈Ψ) = cast-unseal (ρ⊆ α∈Ψ)
+rename-cast ρ ρ⊆ (cast-seq s⊢ t⊢) =
+  cast-seq (rename-cast ρ ρ⊆ s⊢) (rename-cast ρ ρ⊆ t⊢)
+rename-cast ρ ρ⊆ (cast-tag G) = cast-tag (rename-Ground ρ G)
+rename-cast ρ ρ⊆ (cast-untag H) = cast-untag (rename-Ground ρ H)
+rename-cast ρ ρ⊆ (cast-fun s⊢ t⊢) =
+  cast-fun (rename-cast ρ ρ⊆ s⊢) (rename-cast ρ ρ⊆ t⊢)
+rename-cast ρ ρ⊆ (cast-all s⊢) =
+  cast-all (rename-cast (extᵗ ρ) (renames-outside ρ⊆) s⊢)
+rename-cast ρ ρ⊆ (cast-inst {A = A} {B = B} {s = s} s⊢) =
+  cast-inst
+    (substEq
+      (λ C → _ ∣ _ ⊢ renameᶜ (extᵗ ρ) s ∶ renameᵗ (extᵗ ρ) A =⇒ C)
+      (rename-wkTy ρ B)
+      (rename-cast (extᵗ ρ) (renames-inside ρ⊆) s⊢))
+rename-cast ρ ρ⊆ (cast-gen {A = A} {B = B} {s = s} s⊢) =
+  cast-gen
+    (substEq
+      (λ C → _ ∣ _ ⊢ renameᶜ (extᵗ ρ) s ∶ C =⇒ renameᵗ (extᵗ ρ) B)
+      (rename-wkTy ρ A)
+      (rename-cast (extᵗ ρ) (renames-inside ρ⊆) s⊢))
+
+singleTyEnv-rename :
+  ∀ {Δ Δ′}(ρ : Renameᵗ Δ Δ′)(U : Ty Δ)(X : TyVar (suc Δ)) →
+  renameᵗ ρ (singleTyEnv U X) ≡
+  singleTyEnv (renameᵗ ρ U) (extᵗ ρ X)
+singleTyEnv-rename ρ U Zᵗ = refl
+singleTyEnv-rename ρ U (Sᵗ X) = refl
+
+rename-[]ᵗ :
+  ∀ {Δ Δ′}(ρ : Renameᵗ Δ Δ′)(T : Ty (suc Δ))(U : Ty Δ) →
+  renameᵗ ρ (T [ U ]ᵗ) ≡ (renameᵗ (extᵗ ρ) T) [ renameᵗ ρ U ]ᵗ
+rename-[]ᵗ ρ T U =
+  trans (renameᵗ-subst ρ (singleTyEnv U) T)
+        (trans (substᵗ-cong-env (singleTyEnv-rename ρ U) T)
+               (sym (substᵗ-rename (extᵗ ρ)
+                                    (singleTyEnv (renameᵗ ρ U)) T)))
+
+renameᵉ-wk :
+  ∀ {Δ Δ′}(ρ : Renameᵗ Δ Δ′)(Γ : ExCtx Δ) →
+  renameᵉ (extᵗ ρ) (renameᵉ Sᵗ Γ) ≡ renameᵉ Sᵗ (renameᵉ ρ Γ)
+renameᵉ-wk ρ ∅ = refl
+renameᵉ-wk ρ (Γ ▷ T) =
+  cong₂ _▷_ (renameᵉ-wk ρ Γ) (rename-wkTy ρ T)
+
+renameᵗᶜᵗ :
+  ∀ {Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′}
+    {Γ : ExCtx Δ}{T : Ty Δ} →
+  (ρ : Renameᵗ Δ Δ′) →
+  RenamesSubset ρ Ψ Ψ′ →
+  Ex {Ψ = Ψ} Γ T →
+  Ex {Ψ = Ψ′} (renameᵉ ρ Γ) (renameᵗ ρ T)
+renameᵗᶜᵗ ρ ρ⊆ (` x) = ` (rename-varᵗ ρ x)
+renameᵗᶜᵗ ρ ρ⊆ (cst b) = cst b
+renameᵗᶜᵗ ρ ρ⊆ (λx: T ⇒ M) =
+  λx: renameᵗ ρ T ⇒ (renameᵗᶜᵗ ρ ρ⊆ M)
+renameᵗᶜᵗ ρ ρ⊆ (app M N) = app (renameᵗᶜᵗ ρ ρ⊆ M) (renameᵗᶜᵗ ρ ρ⊆ N)
+renameᵗᶜᵗ {Ψ′ = Ψ′} {Γ = Γ} ρ ρ⊆ (ΛX {T = T} M) =
+  ΛX
+    (substEq
+      (λ Γ₀ → Ex {Ψ = outside ∷ Ψ′} Γ₀ (renameᵗ (extᵗ ρ) T))
+      (renameᵉ-wk ρ Γ)
+      (renameᵗᶜᵗ (extᵗ ρ) (renames-outside ρ⊆) M))
+renameᵗᶜᵗ {Ψ′ = Ψ′} {Γ = Γ} ρ ρ⊆ (tapp {T = T} M U) =
+  substEq (Ex {Ψ = Ψ′} (renameᵉ ρ Γ)) (sym (rename-[]ᵗ ρ T U))
+          (tapp (renameᵗᶜᵗ ρ ρ⊆ M) (renameᵗ ρ U))
+renameᵗᶜᵗ ρ ρ⊆ (capp M s⊢) =
+  capp (renameᵗᶜᵗ ρ ρ⊆ M) (rename-cast ρ ρ⊆ s⊢)
+renameᵗᶜᵗ ρ ρ⊆ (blame ℓ) = blame ℓ
+
+Substᶜᵗ : ∀ {Δ} {Ψ : Subset Δ} → ExCtx Δ → ExCtx Δ → Set
+Substᶜᵗ {Ψ = Ψ} Γ Γ′ = ∀ {T} → ExVar Γ T → Ex {Ψ = Ψ} Γ′ T
+
+extsᶜᵗ :
+  ∀ {Δ}{Ψ : Subset Δ}{Γ Γ′ : ExCtx Δ}{T : Ty Δ} →
+  Substᶜᵗ {Ψ = Ψ} Γ Γ′ →
+  Substᶜᵗ {Ψ = Ψ} (Γ ▷ T) (Γ′ ▷ T)
+extsᶜᵗ σ Zᵉ = ` Zᵉ
+extsᶜᵗ σ (Sᵉ x) = renameᶜᵗ Sᵉ (σ x)
+
+wk-substᶜᵗ :
+  ∀ {Δ}{Ψ : Subset Δ}{Γ Γ′ : ExCtx Δ} →
+  Substᶜᵗ {Ψ = Ψ} Γ Γ′ →
+  Substᶜᵗ {Ψ = outside ∷ Ψ} (renameᵉ Sᵗ Γ) (renameᵉ Sᵗ Γ′)
+wk-substᶜᵗ {Γ = ∅} σ ()
+wk-substᶜᵗ {Γ = Γ ▷ T} σ Zᵉ = renameᵗᶜᵗ Sᵗ renames-wk (σ Zᵉ)
+wk-substᶜᵗ {Γ = Γ ▷ T} σ (Sᵉ x) =
+  wk-substᶜᵗ (λ y → σ (Sᵉ y)) x
+
+substᶜᵗ :
+  ∀ {Δ}{Ψ : Subset Δ}{Γ Γ′ : ExCtx Δ}{T : Ty Δ} →
+  Substᶜᵗ {Ψ = Ψ} Γ Γ′ →
+  Ex {Ψ = Ψ} Γ T →
+  Ex {Ψ = Ψ} Γ′ T
+substᶜᵗ σ (` x) = σ x
+substᶜᵗ σ (cst b) = cst b
+substᶜᵗ σ (λx: T ⇒ M) = λx: T ⇒ (substᶜᵗ (extsᶜᵗ σ) M)
+substᶜᵗ σ (app M N) = app (substᶜᵗ σ M) (substᶜᵗ σ N)
+substᶜᵗ σ (ΛX M) = ΛX (substᶜᵗ (wk-substᶜᵗ σ) M)
+substᶜᵗ σ (tapp M U) = tapp (substᶜᵗ σ M) U
+substᶜᵗ σ (capp M s⊢) = capp (substᶜᵗ σ M) s⊢
+substᶜᵗ σ (blame ℓ) = blame ℓ
+
+singleᶜᵗ :
+  ∀ {Δ}{Ψ : Subset Δ}{Γ : ExCtx Δ}{T : Ty Δ} →
+  Ex {Ψ = Ψ} Γ T →
+  Substᶜᵗ {Ψ = Ψ} (Γ ▷ T) Γ
+singleᶜᵗ N Zᵉ = N
+singleᶜᵗ N (Sᵉ x) = ` x
+
+infixl 8 _[_]
+_[_] :
+  ∀ {Δ}{Ψ : Subset Δ}{Γ : ExCtx Δ}{S T : Ty Δ} →
+  Ex {Ψ = Ψ} (Γ ▷ S) T →
+  Ex {Ψ = Ψ} Γ S →
+  Ex {Ψ = Ψ} Γ T
+M [ N ] = substᶜᵗ (singleᶜᵗ N) M

--- a/GTSF-PT/Coercions.agda
+++ b/GTSF-PT/Coercions.agda
@@ -1,0 +1,206 @@
+-- File Charter:
+--   * Raw coercion syntax, type-variable renaming, and coercion typing.
+--   * Primary exports are `Coercion`, `renameᶜ`, and `_∣_⊢_∶_=⇒_`.
+--   * Depends on labels and core type syntax.
+--   * This is based on the cambridge22 notes.
+
+module Coercions where
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (true)
+open import Data.List using (List; []; _∷_; _++_; length; replicate; map)
+open import Data.Vec using (Vec; []; _∷_)
+open import Data.Fin.Subset using (Subset; Side; inside; outside; _∈_)
+open import Data.Nat using (ℕ; _<_; zero; suc; z<s; s<s)
+open import Data.Nat.Properties using (_≟_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃; ∃-syntax)
+open import Relation.Nullary using (Dec; yes; no)
+
+open import Label
+open import Types
+
+------------------------------------------------------------------------
+-- Raw coercions
+------------------------------------------------------------------------
+
+data Coercion (Δ : TyCtx) : Set where
+ id : Ty Δ → Coercion Δ
+ _︔_ : Coercion Δ → Coercion Δ → Coercion Δ
+ _↦_ : Coercion Δ → Coercion Δ → Coercion Δ
+ `∀ : Coercion (suc Δ) → Coercion Δ
+ _! : Ty Δ → Coercion Δ
+ _？_ : Ty Δ → Label → Coercion Δ
+ seal : Ty Δ → TyVar Δ → Coercion Δ
+ unseal : TyVar Δ → Ty Δ → Coercion Δ
+ gen : Ty Δ → Coercion (suc Δ) → Coercion Δ
+ inst : Ty Δ → Coercion (suc Δ) → Coercion Δ
+
+
+-- ------------------------------------------------------------------------
+-- -- Source and target type of a coercion
+-- ------------------------------------------------------------------------
+
+-- src : Coercion → Ty
+-- tgt : Coercion → Ty
+
+-- src (id A) = A
+-- src (c ︔ d) = src c
+-- src (c ↦ d) = tgt c ⇒ src d
+-- src (`∀ c) = `∀ (src c)
+-- src (G !) = G
+-- src (G ？ ℓ) = ★
+-- src (seal A α) = A
+-- src (unseal α A) = ＇ α
+-- src (gen A c) = A
+-- src (inst B c) = `∀ (src c)
+
+-- tgt (id A) = A
+-- tgt (c ︔ d) = tgt d
+-- tgt (c ↦ d) = src c ⇒ tgt d
+-- tgt (`∀ c) = `∀ (tgt c)
+-- tgt (G !) = ★
+-- tgt (H ？ ℓ) = H
+-- tgt (seal A α) = ＇ α
+-- tgt (unseal α B) = B
+-- tgt (gen A c) = `∀ (tgt c)
+-- tgt (inst B c) = B
+
+-- ------------------------------------------------------------------------
+-- -- Inert coercions, i.e., part of a value
+-- ------------------------------------------------------------------------
+
+-- data Inert : Coercion → Set where
+--   _! : (G : Ty) → Inert (G !)
+--   seal : (A : Ty) → (α : TyVar) → Inert (seal A α)
+--   _↦_ : (c d : Coercion) → Inert (c ↦ d)
+--   `∀ : (c : Coercion) → Inert (`∀ c)
+--   gen : (A : Ty) → (c : Coercion) → Inert (gen A c)
+
+-- ------------------------------------------------------------------------
+-- -- reveal/conceal B α C generate coercions between B[α] and B[C]
+-- ------------------------------------------------------------------------
+
+-- mutual
+--   reveal : Ty → TyVar → Ty → Coercion
+--   reveal (＇ β) α C with α ≟ β
+--   reveal (＇ .α) α C | yes refl = unseal α C
+--   reveal (＇ β) α C | no neq = id (＇ β)
+--   reveal (‵ ι) α C = id (‵ ι)
+--   reveal ★ α C = id ★
+--   reveal (A ⇒ B) α C = conceal A α C ↦ reveal B α C
+--   reveal (`∀ A) α C = `∀ (reveal A (suc α) (⇑ᵗ C))
+
+--   conceal : Ty → TyVar → Ty → Coercion
+--   conceal (＇ β) α C with α ≟ β
+--   conceal (＇ .α) α C | yes refl = seal C α
+--   conceal (＇ β) α C | no neq = id (＇ β)
+--   conceal (‵ ι) α C = id (‵ ι)
+--   conceal ★ α C = id ★
+--   conceal (A ⇒ B) α C = reveal A α C ↦ conceal B α C
+--   conceal (`∀ A) α C = `∀ (conceal A (suc α) (⇑ᵗ C))
+
+-- ------------------------------------------------------------------------
+-- -- Renaming Type Variables
+-- ------------------------------------------------------------------------
+
+renameᶜ : ∀{Δ}{Δ′} → Renameᵗ Δ Δ′ → Coercion Δ → Coercion Δ′
+renameᶜ ρ (id A) = id (renameᵗ ρ A)
+renameᶜ ρ (p ︔ q) = renameᶜ ρ p ︔ renameᶜ ρ q
+renameᶜ ρ (A !) = renameᵗ ρ A !
+renameᶜ ρ (A ？ ℓ) = renameᵗ ρ A ？ ℓ
+renameᶜ ρ (unseal α A) = unseal (ρ α) (renameᵗ ρ A)
+renameᶜ ρ (seal A α) = seal (renameᵗ ρ A) (ρ α)
+renameᶜ ρ (p ↦ q) = renameᶜ ρ p ↦ renameᶜ ρ q
+renameᶜ ρ (`∀ p) = `∀ (renameᶜ (extᵗ ρ) p)
+renameᶜ ρ (gen A p) = gen (renameᵗ ρ A) (renameᶜ (extᵗ ρ) p)
+renameᶜ ρ (inst B p) = inst (renameᵗ ρ B) (renameᶜ (extᵗ ρ) p)
+
+⇑ᶜ : ∀ {Δ} → Coercion Δ → Coercion (suc Δ)
+⇑ᶜ = renameᶜ λ z → Zᵗ
+
+-- _[_]ᶜ : ∀ {Δ} → Coercion (suc Δ) → TyVar Δ → Coercion Δ
+-- c [ X ]ᶜ = renameᶜ (singleRenameᵗ X) c
+
+-- ------------------------------------------------------------------------
+-- -- Typing
+-- ------------------------------------------------------------------------
+
+infix 4 _∣_⊢_∶_=⇒_
+
+data _∣_⊢_∶_=⇒_ (Δ : TyCtx) (Ψ : Subset Δ) : Coercion Δ → Ty Δ → Ty Δ → Set where
+
+  cast-id : ∀{A : Ty Δ}
+     -------------------
+    → Δ ∣ Ψ ⊢ id A ∶ A =⇒ A
+
+  cast-seal : ∀{α : TyVar Δ}{A : Ty Δ}
+    → tyVarToFin α ∈ Ψ
+     ---------------------------
+    → Δ ∣ Ψ ⊢ seal A α ∶ A =⇒ (＇ α)
+
+  cast-unseal : ∀{α : TyVar Δ}{A : Ty Δ}
+    → tyVarToFin α ∈ Ψ
+     -----------------------------
+    → Δ ∣ Ψ ⊢ unseal α A ∶ (＇ α) =⇒ A
+
+  cast-seq : ∀{A B C : Ty Δ}{s t : Coercion Δ}
+    → Δ ∣ Ψ ⊢ s ∶ A =⇒ B
+    → Δ ∣ Ψ ⊢ t ∶ B =⇒ C
+     -------------------------
+    → Δ ∣ Ψ ⊢ (s ︔ t) ∶ A =⇒ C
+
+  cast-tag : ∀{G : Ty Δ}
+    → Ground G
+     ---------------------
+    → Δ ∣ Ψ ⊢ G ! ∶ G =⇒ `★
+
+  cast-untag : ∀{H : Ty Δ}{ℓ : Label}
+    → Ground H
+     -----------------------
+    → Δ ∣ Ψ ⊢ H ？ ℓ ∶ `★ =⇒ H
+
+  cast-fun : ∀{A A′ B B′ : Ty Δ}{s t : Coercion Δ}
+    → Δ ∣ Ψ ⊢ s ∶ A′ =⇒ A
+    → Δ ∣ Ψ ⊢ t ∶ B =⇒ B′
+     ---------------------------------------
+    → Δ ∣ Ψ ⊢ (s ↦ t) ∶ (A ⇒ B) =⇒ (A′ ⇒ B′)
+
+  -- cast-all : ∀{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
+  --   → {occA : occurs zero A ≡ true}
+  --   → {occB : occurs zero B ≡ true}
+  --   → suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ A =⇒ B
+  --    ----------------------------------
+  --   → Δ ∣ Σ ⊢ (`∀ s) ∶ (`∀ A) =⇒ (`∀ B)
+
+  cast-all : ∀{A B : Ty (suc Δ)}{s : Coercion (suc Δ)}
+    -- → {occA : occurs zero A ≡ true}
+    -- → {occB : occurs zero B ≡ true}
+    → suc Δ ∣ (outside ∷ Ψ) ⊢ s ∶ A =⇒ B
+     ----------------------------------
+    → Δ ∣ Ψ ⊢ (`∀ s) ∶ (`∀ A) =⇒ (`∀ B)
+
+--   cast-inst : ∀{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
+--     → {occA : occurs zero A ≡ true}
+--     → WfTy Δ B
+--     → suc Δ ∣ (0 , ★) ∷ ⟰ᵗ Σ ⊢ s ∶ A =⇒ ⇑ᵗ B
+--      --------------------------------
+--     → Δ ∣ Σ ⊢ (inst B s) ∶ (`∀ A) =⇒ B
+
+  cast-inst : ∀{A : Ty (suc Δ)}{B : Ty Δ}{s : Coercion (suc Δ)}
+    -- → {occA : occurs zero A ≡ true}
+    → suc Δ ∣ (inside ∷ Ψ) ⊢ s ∶ A =⇒ wkTy B
+     --------------------------------
+    → Δ ∣ Ψ ⊢ (inst B s) ∶ (`∀ A) =⇒ B
+
+--   cast-gen : ∀{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
+--     → {occB : occurs zero B ≡ true}
+--     → WfTy Δ A
+--     → suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ ⇑ᵗ A =⇒ B
+--      ----------------------------------
+--     → Δ ∣ Σ ⊢ (gen A s) ∶ A =⇒ (`∀ B)
+
+  cast-gen : ∀{A : Ty Δ}{B : Ty (suc Δ)}{s : Coercion (suc Δ)}
+    -- → {occB : occurs zero B ≡ true}
+    → suc Δ ∣ (inside ∷ Ψ) ⊢ s ∶ wkTy A =⇒ B
+     ----------------------------------
+    → Δ ∣ Ψ ⊢ (gen A s) ∶ A =⇒ (`∀ B)

--- a/GTSF-PT/Compile.agda
+++ b/GTSF-PT/Compile.agda
@@ -1,0 +1,73 @@
+-- File Charter:
+--   * Compilation from source consistency and typing evidence to coercions and
+--     typed coercion terms.
+--   * Primary exports are `~⇒coercion` and `compile`.
+--   * Depends on labels, types, coercions, consistency, source terms, and target
+--     coercion terms.
+
+module Compile where
+
+open import Data.Fin.Subset using (Subset; Side; inside; outside; _∈_)
+open import Data.Product using (Σ; _,_; proj₁; proj₂)
+
+open import Label using (Label)
+open import Types
+open import Coercions
+open import Consistency
+open import Terms as SRC
+import CoercionTerms as TGT
+
+~⇒coercion : ∀ {Δ}{Ψ : Subset Δ}{ℓ : Label}{A B : Ty Δ}
+  → Ψ ∣ ℓ ⊢ A ~ B
+  → Σ (Coercion Δ) λ s →
+      Δ ∣ Ψ ⊢ s ∶ A =⇒ B
+
+~⇒coercion X~X = id _ , cast-id
+~⇒coercion (α~✯ X∈Ψ) = unseal _ `★ , cast-unseal X∈Ψ
+~⇒coercion (✯~α X∈Ψ) = seal `★ _ , cast-seal X∈Ψ
+~⇒coercion ι~ι = id _ , cast-id
+~⇒coercion ★~★ = id _ , cast-id
+~⇒coercion {ℓ = ℓ} (★~ι {ι = ι}) =
+  ((‵ ι) ？ ℓ) , cast-untag (‵ ι)
+~⇒coercion {Δ} {Ψ} (ι~★ {ι = ι}) =
+  ((‵ ι) !) , cast-tag (‵ ι)
+~⇒coercion {ℓ = ℓ} (★~⇒ A~★ ★~B)
+  with ~⇒coercion A~★ | ~⇒coercion ★~B
+... | s , s⊢ | t , t⊢ =
+  (((`★ ⇒ `★) ？ ℓ) ︔ (s ↦ t)) ,
+  cast-seq (cast-untag ★⇒★) (cast-fun s⊢ t⊢)
+~⇒coercion {Δ} {Ψ} (⇒~★ ★~A B~★)
+  with ~⇒coercion ★~A | ~⇒coercion B~★
+... | s , s⊢ | t , t⊢ =
+  ((s ↦ t) ︔ ((`★ ⇒ `★) !)) ,
+  cast-seq (cast-fun s⊢ t⊢) (cast-tag ★⇒★)
+~⇒coercion (⇒~⇒ A′~A B~B′)
+  with ~⇒coercion A′~A | ~⇒coercion B~B′
+... | s , s⊢ | t , t⊢ = (s ↦ t) , cast-fun s⊢ t⊢
+~⇒coercion (∀~∀ A~B) with ~⇒coercion A~B
+... | s , s⊢ = `∀ s , cast-all s⊢
+~⇒coercion (∀~ _ A~B) with ~⇒coercion A~B
+... | s , s⊢ = inst _ s , cast-inst s⊢
+~⇒coercion (~∀ _ A~B) with ~⇒coercion A~B
+... | s , s⊢ = gen _ s , cast-gen s⊢
+
+
+compile : ∀  {Δ : TyCtx} {Ψ : Subset Δ} {Γ : SRC.ExCtx Δ} {T : Ty Δ}
+  → SRC.Ex{Δ}{Ψ} Γ T
+  → TGT.Ex{Δ}{Ψ} Γ T
+compile (` x) = TGT.` x
+compile (cst b) = TGT.cst b
+compile (λx: T ⇒ e) = TGT.λx: T ⇒ (compile e)
+compile {Δ = Δ} {Ψ = Ψ} {Γ = Γ}
+        (app {S = sTy} {T = tTy} {U = uTy} {V = vTy}
+             e S~T⇒U e′ V~T)
+  with ~⇒coercion S~T⇒U | ~⇒coercion V~T
+... | s , s⊢ | t , t⊢ =
+  TGT.app {Γ = Γ} {T = tTy} {U = uTy}
+          (TGT.capp (compile e) s⊢) (TGT.capp (compile e′) t⊢)
+compile (ΛX e) = TGT.ΛX (compile e)
+compile {Ψ = Ψ} {Γ = Γ} (tapp {T = tTy} e S~∀T U)
+  with ~⇒coercion S~∀T
+... | s , s⊢ =
+  TGT.tapp {Γ = Γ} {T = tTy}
+           (TGT.capp (compile e) s⊢) U

--- a/GTSF-PT/Consistency.agda
+++ b/GTSF-PT/Consistency.agda
@@ -1,0 +1,871 @@
+-- File Charter:
+--   * Definition of the GTSF type-consistency relation `~`.
+--   * Introduce the judgment only; transport/proof lemmas live in
+--     `ConsistencyProperties.agda`.
+--   * No coercion synthesis here.
+
+module Consistency where
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Nat using (zero; suc)
+open import Data.Fin.Subset using (Subset; Side; inside; outside; _∈_)
+open import Data.Fin.Subset.Properties using (_∈?_)
+open import Data.Product using (∃-syntax; _×_; _,_; proj₁; proj₂)
+open import Data.Vec using ([]; _∷_; here; there)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Binary.PropositionalEquality
+  using (cong; cong₂; sym; trans; inspect; [_])
+  renaming (subst to substEq)
+
+open import Types
+open import Label using (Label; push)
+-- open import TypeSubst
+-- open import TypePrecision
+
+------------------------------------------------------------------------
+-- Type Precision
+------------------------------------------------------------------------
+
+infix 5 _∣_⊢_~_
+
+data has★ {Δ : TyCtx} {Ψ : Subset Δ} : Ty Δ → Set where
+
+  has★-★ : has★ `★
+
+  has★-⇒ˡ : ∀ {A B : Ty Δ} → has★ {Δ}{Ψ} A → has★ (A ⇒ B)
+
+  has★-⇒ʳ : ∀ {A B : Ty Δ} → has★ {Δ}{Ψ} B → has★ (A ⇒ B)
+
+  has*-∀  : ∀ {A : Ty (suc Δ)} → has★ {suc Δ}{outside ∷ Ψ} A → has★ (`∀ A)
+
+has★-rename :
+  ∀ {Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′}
+    (ρ : Renameᵗ Δ Δ′) {A : Ty Δ} →
+  has★ {Δ}{Ψ} A →
+  has★ {Δ′}{Ψ′} (renameᵗ ρ A)
+has★-rename ρ has★-★ = has★-★
+has★-rename ρ (has★-⇒ˡ A★) = has★-⇒ˡ (has★-rename ρ A★)
+has★-rename ρ (has★-⇒ʳ B★) = has★-⇒ʳ (has★-rename ρ B★)
+has★-rename ρ (has*-∀ A★) = has*-∀ (has★-rename (extᵗ ρ) A★)
+
+has★-rename-inv :
+  ∀ {Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′}
+    (ρ : Renameᵗ Δ Δ′) {A : Ty Δ} →
+  has★ {Δ′}{Ψ′} (renameᵗ ρ A) →
+  has★ {Δ}{Ψ} A
+has★-rename-inv ρ {A = ＇ X} ()
+has★-rename-inv ρ {A = ‵ ι} ()
+has★-rename-inv ρ {A = `★} has★-★ = has★-★
+has★-rename-inv ρ {A = A ⇒ B} (has★-⇒ˡ A★) =
+  has★-⇒ˡ (has★-rename-inv ρ A★)
+has★-rename-inv ρ {A = A ⇒ B} (has★-⇒ʳ B★) =
+  has★-⇒ʳ (has★-rename-inv ρ B★)
+has★-rename-inv ρ {A = `∀ A} (has*-∀ A★) =
+  has*-∀ (has★-rename-inv (extᵗ ρ) A★)
+
+has★-ctx : ∀ {Δ}{Ψ Ψ′ : Subset Δ}{A : Ty Δ} →
+  has★ {Δ}{Ψ} A →
+  has★ {Δ}{Ψ′} A
+has★-ctx has★-★ = has★-★
+has★-ctx (has★-⇒ˡ A★) = has★-⇒ˡ (has★-ctx A★)
+has★-ctx (has★-⇒ʳ B★) = has★-⇒ʳ (has★-ctx B★)
+has★-ctx (has*-∀ A★) = has*-∀ (has★-ctx A★)
+
+has★-wkTy : ∀ {Δ}{Ψ : Subset Δ}{A : Ty Δ} →
+  has★ {Δ}{Ψ} A →
+  has★ {suc Δ}{inside ∷ Ψ} (wkTy A)
+has★-wkTy = has★-rename Sᵗ
+
+has★-subst :
+  ∀ {Δ Δ′}{Ψ : Subset Δ}{Ψ′ : Subset Δ′}
+    (σ : Substᵗ Δ Δ′) {A : Ty Δ} →
+  has★ {Δ}{Ψ} A →
+  has★ {Δ′}{Ψ′} (substᵗ σ A)
+has★-subst σ has★-★ = has★-★
+has★-subst σ (has★-⇒ˡ A★) = has★-⇒ˡ (has★-subst σ A★)
+has★-subst σ (has★-⇒ʳ B★) = has★-⇒ʳ (has★-subst σ B★)
+has★-subst σ (has*-∀ A★) = has*-∀ (has★-subst (extsᵗ σ) A★)
+
+has★? : ∀ {Δ}{Ψ : Subset Δ} (A : Ty Δ) → Dec (has★ {Δ}{Ψ} A)
+has★? (＇ X) = no λ ()
+has★? (‵ ι) = no λ ()
+has★? `★ = yes has★-★
+has★? (A ⇒ B) with has★? A
+has★? (A ⇒ B) | yes A★ = yes (has★-⇒ˡ A★)
+has★? (A ⇒ B) | no A≁★ with has★? B
+has★? (A ⇒ B) | no A≁★ | yes B★ = yes (has★-⇒ʳ B★)
+has★? (A ⇒ B) | no A≁★ | no B≁★ =
+  no λ { (has★-⇒ˡ A★) → A≁★ A★
+       ; (has★-⇒ʳ B★) → B≁★ B★ }
+has★? {Ψ = Ψ} (`∀ A) with has★? {Ψ = outside ∷ Ψ} A
+has★? {Ψ = Ψ} (`∀ A) | yes A★ = yes (has*-∀ A★)
+has★? {Ψ = Ψ} (`∀ A) | no A≁★ =
+  no λ { (has*-∀ A★) → A≁★ A★ }
+
+data _∣_⊢_~_ {Δ : TyCtx} (Ψ : Subset Δ) (ℓ : Label) :
+    Ty Δ → Ty Δ → Set where
+
+    X~X : ∀{X : TyVar Δ} → Ψ ∣ ℓ ⊢ ＇ X ~ ＇ X
+
+    α~✯ : ∀{X : TyVar Δ}
+      → tyVarToFin X ∈ Ψ
+      → Ψ ∣ ℓ ⊢ ＇ X ~ `★
+
+    ✯~α : ∀{X : TyVar Δ}
+      → tyVarToFin X ∈ Ψ
+      → Ψ ∣ ℓ ⊢ `★ ~ ＇ X
+
+    ι~ι : ∀{ι : Base}
+      → Ψ ∣ ℓ ⊢ ‵ ι ~ ‵ ι
+
+    ★~★ : Ψ ∣ ℓ ⊢ `★ ~ `★
+
+    ★~ι : ∀{ι : Base}
+      → Ψ ∣ ℓ ⊢ `★ ~ ‵ ι
+
+    ι~★ : ∀{ι : Base}
+      → Ψ ∣ ℓ ⊢ ‵ ι ~ `★
+
+    -- ★~G : ∀{G : Ty Δ}
+    --   → Ground G
+    --   → Ψ ∣ ℓ ⊢ `★ ~ G
+
+    -- G~★ : ∀{G : Ty Δ}
+    --   → Ground G
+    --   → Ψ ∣ ℓ ⊢ G ~ `★
+
+    ★~⇒ : ∀{A B : Ty Δ}
+      → Ψ ∣ push zero ℓ ⊢ A ~ `★
+      → Ψ ∣ push (suc zero) ℓ ⊢ `★ ~ B
+      → Ψ ∣ ℓ ⊢ `★ ~ (A ⇒ B)
+
+    ⇒~★ : ∀{A B : Ty Δ}
+      → Ψ ∣ push zero ℓ ⊢ `★ ~ A
+      → Ψ ∣ push (suc zero) ℓ ⊢ B ~ `★
+      → Ψ ∣ ℓ ⊢ (A ⇒ B) ~ `★
+
+    ⇒~⇒ : ∀{A A′ B B′ : Ty Δ}
+      → Ψ ∣ push zero ℓ ⊢ A′ ~ A
+      → Ψ ∣ push (suc zero) ℓ ⊢ B ~ B′
+      → Ψ ∣ ℓ ⊢ (A ⇒ B) ~ (A′ ⇒ B′)
+
+    ∀~∀ : ∀{A B : Ty (suc Δ)}
+      → (outside ∷ Ψ) ∣ ℓ ⊢ A ~ B
+      → Ψ ∣ ℓ ⊢ (`∀ A) ~ (`∀ B)
+
+    ∀~ : ∀{A : Ty (suc Δ)}{B : Ty Δ}
+      → has★ {suc Δ} {inside ∷ Ψ} (wkTy B)
+      → (inside ∷ Ψ) ∣ ℓ ⊢ A ~ wkTy B
+      → Ψ ∣ ℓ ⊢ (`∀ A) ~ B
+
+    ~∀ : ∀{A : Ty Δ}{B : Ty (suc Δ)}
+      → has★ {suc Δ} {inside ∷ Ψ} (wkTy A)
+      → (inside ∷ Ψ) ∣ ℓ ⊢ wkTy A ~ B
+      → Ψ ∣ ℓ ⊢ A ~ (`∀ B)
+
+~-refl : ∀ {Δ}{Ψ}{ℓ} {A : Ty Δ} → Ψ ∣ ℓ ⊢ A ~ A
+~-refl {A = ＇ X} = X~X
+~-refl {A = ‵ x} = ι~ι
+~-refl {A = `★} = ★~★
+~-refl {A = A ⇒ B} = ⇒~⇒ ~-refl ~-refl
+~-refl {A = `∀ A} = ∀~∀ ~-refl
+
+~-sym : ∀ {Δ}{Ψ}{ℓ} {A B : Ty Δ} → Ψ ∣ ℓ ⊢ A ~ B →  Ψ ∣ ℓ ⊢ B ~ A
+~-sym X~X = X~X
+~-sym (α~✯ X∈Ψ) = ✯~α X∈Ψ
+~-sym (✯~α X∈Ψ) = α~✯ X∈Ψ
+~-sym ι~ι = ι~ι
+~-sym ★~★ = ★~★
+~-sym ★~ι = ι~★
+~-sym ι~★ = ★~ι
+~-sym (★~⇒ A~★ ★~B) = ⇒~★ (~-sym A~★) (~-sym ★~B)
+~-sym (⇒~★ ★~A B~★) = ★~⇒ (~-sym ★~A) (~-sym B~★)
+~-sym (⇒~⇒ A′~A B~B′) = ⇒~⇒ (~-sym A′~A) (~-sym B~B′)
+~-sym (∀~∀ A~B) = ∀~∀ (~-sym A~B)
+~-sym (∀~ B★ A~B) = ~∀ B★ (~-sym A~B)
+~-sym (~∀ A★ A~B) = ∀~ A★ (~-sym A~B)
+
+_≟TyVar_ : ∀ {Δ} (X Y : TyVar Δ) → Dec (X ≡ Y)
+Zᵗ ≟TyVar Zᵗ = yes refl
+Zᵗ ≟TyVar Sᵗ Y = no (λ ())
+Sᵗ X ≟TyVar Zᵗ = no (λ ())
+Sᵗ X ≟TyVar Sᵗ Y with X ≟TyVar Y
+Sᵗ X ≟TyVar Sᵗ Y | yes refl = yes refl
+Sᵗ X ≟TyVar Sᵗ Y | no X≢Y = no λ { refl → X≢Y refl }
+
+{-# TERMINATING #-}
+A~B? : ∀ {Δ}{Ψ}{ℓ} (A B : Ty Δ) → Dec (Ψ ∣ ℓ ⊢ A ~ B)
+A~B? {Ψ = Ψ} (＇ X) (＇ Y) with X ≟TyVar Y
+A~B? {Ψ = Ψ} (＇ X) (＇ Y) | yes refl = yes X~X
+A~B? {Ψ = Ψ} (＇ X) (＇ Y) | no X≢Y =
+  no λ { X~X → X≢Y refl }
+A~B? (＇ X) (‵ ι) = no λ ()
+A~B? {Ψ = Ψ} (＇ X) `★ with tyVarToFin X ∈? Ψ
+A~B? {Ψ = Ψ} (＇ X) `★ | yes X∈Ψ = yes (α~✯ X∈Ψ)
+A~B? {Ψ = Ψ} (＇ X) `★ | no X∉Ψ =
+  no λ { (α~✯ X∈Ψ) → X∉Ψ X∈Ψ }
+A~B? (＇ X) (B₁ ⇒ B₂) = no λ ()
+A~B? (＇ X) (`∀ B) = no λ { (~∀ () _) }
+A~B? (‵ ι) (＇ X) = no λ ()
+A~B? (‵ ι) (‵ ι′) with ι ≟Base ι′
+A~B? (‵ ι) (‵ ι′) | yes refl = yes ι~ι
+A~B? (‵ ι) (‵ ι′) | no ι≢ι′ =
+  no λ { ι~ι → ι≢ι′ refl }
+A~B? (‵ ι) `★ = yes ι~★
+A~B? (‵ ι) (B₁ ⇒ B₂) = no λ ()
+A~B? (‵ ι) (`∀ B) = no λ { (~∀ () _) }
+A~B? {Ψ = Ψ} `★ (＇ X) with tyVarToFin X ∈? Ψ
+A~B? {Ψ = Ψ} `★ (＇ X) | yes X∈Ψ = yes (✯~α X∈Ψ)
+A~B? {Ψ = Ψ} `★ (＇ X) | no X∉Ψ =
+  no λ { (✯~α X∈Ψ) → X∉Ψ X∈Ψ }
+A~B? `★ (‵ ι) = yes ★~ι
+A~B? `★ `★ = yes ★~★
+A~B? {Ψ = Ψ} {ℓ = ℓ} `★ (B₁ ⇒ B₂)
+  with A~B? {Ψ = Ψ} {ℓ = push zero ℓ} B₁ `★
+     | A~B? {Ψ = Ψ} {ℓ = push (suc zero) ℓ} `★ B₂
+A~B? {Ψ = Ψ} {ℓ = ℓ} `★ (B₁ ⇒ B₂) | yes B₁~★ | yes ★~B₂ =
+  yes (★~⇒ B₁~★ ★~B₂)
+A~B? {Ψ = Ψ} {ℓ = ℓ} `★ (B₁ ⇒ B₂) | no B₁≁★ | _ =
+  no λ { (★~⇒ B₁~★ _) → B₁≁★ B₁~★ }
+A~B? {Ψ = Ψ} {ℓ = ℓ} `★ (B₁ ⇒ B₂) | yes _ | no ★≁B₂ =
+  no λ { (★~⇒ _ ★~B₂) → ★≁B₂ ★~B₂ }
+A~B? {Ψ = Ψ} `★ (`∀ B) with A~B? {Ψ = inside ∷ Ψ} (wkTy `★) B
+A~B? {Ψ = Ψ} `★ (`∀ B) | yes ★~B = yes (~∀ has★-★ ★~B)
+A~B? {Ψ = Ψ} `★ (`∀ B) | no ★≁B =
+  no λ { (~∀ _ ★~B) → ★≁B ★~B }
+A~B? (A₁ ⇒ A₂) (＇ X) = no λ ()
+A~B? (A₁ ⇒ A₂) (‵ ι) = no λ ()
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) `★
+  with A~B? {Ψ = Ψ} {ℓ = push zero ℓ} `★ A₁
+     | A~B? {Ψ = Ψ} {ℓ = push (suc zero) ℓ} A₂ `★
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) `★ | yes ★~A₁ | yes A₂~★ =
+  yes (⇒~★ ★~A₁ A₂~★)
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) `★ | no ★≁A₁ | _ =
+  no λ { (⇒~★ ★~A₁ _) → ★≁A₁ ★~A₁ }
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) `★ | yes _ | no A₂≁★ =
+  no λ { (⇒~★ _ A₂~★) → A₂≁★ A₂~★ }
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) (B₁ ⇒ B₂)
+  with A~B? {Ψ = Ψ} {ℓ = push zero ℓ} B₁ A₁
+     | A~B? {Ψ = Ψ} {ℓ = push (suc zero) ℓ} A₂ B₂
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) (B₁ ⇒ B₂) | yes B₁~A₁ | yes A₂~B₂ =
+  yes (⇒~⇒ B₁~A₁ A₂~B₂)
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) (B₁ ⇒ B₂) | no B₁≁A₁ | _ =
+  no λ { (⇒~⇒ B₁~A₁ _) → B₁≁A₁ B₁~A₁ }
+A~B? {Ψ = Ψ} {ℓ = ℓ} (A₁ ⇒ A₂) (B₁ ⇒ B₂) | yes _ | no A₂≁B₂ =
+  no λ { (⇒~⇒ _ A₂~B₂) → A₂≁B₂ A₂~B₂ }
+A~B? {Ψ = Ψ} (A₁ ⇒ A₂) (`∀ B)
+  with has★? {Ψ = inside ∷ Ψ} (wkTy (A₁ ⇒ A₂))
+A~B? {Ψ = Ψ} (A₁ ⇒ A₂) (`∀ B) | yes A★
+  with A~B? {Ψ = inside ∷ Ψ} (wkTy (A₁ ⇒ A₂)) B
+A~B? {Ψ = Ψ} (A₁ ⇒ A₂) (`∀ B) | yes A★ | yes A~B =
+  yes (~∀ A★ A~B)
+A~B? {Ψ = Ψ} (A₁ ⇒ A₂) (`∀ B) | yes A★ | no A≁B =
+  no λ { (~∀ _ A~B) → A≁B A~B }
+A~B? {Ψ = Ψ} (A₁ ⇒ A₂) (`∀ B) | no A≁★ =
+  no λ { (~∀ A★ _) → A≁★ A★ }
+A~B? (`∀ A) (＇ X) = no λ { (∀~ () _) }
+A~B? (`∀ A) (‵ ι) = no λ { (∀~ () _) }
+A~B? {Ψ = Ψ} (`∀ A) `★ with A~B? {Ψ = inside ∷ Ψ} A (wkTy `★)
+A~B? {Ψ = Ψ} (`∀ A) `★ | yes A~★ = yes (∀~ has★-★ A~★)
+A~B? {Ψ = Ψ} (`∀ A) `★ | no A≁★ =
+  no λ { (∀~ _ A~★) → A≁★ A~★ }
+A~B? {Ψ = Ψ} (`∀ A) (B₁ ⇒ B₂)
+  with has★? {Ψ = inside ∷ Ψ} (wkTy (B₁ ⇒ B₂))
+A~B? {Ψ = Ψ} (`∀ A) (B₁ ⇒ B₂) | yes B★
+  with A~B? {Ψ = inside ∷ Ψ} A (wkTy (B₁ ⇒ B₂))
+A~B? {Ψ = Ψ} (`∀ A) (B₁ ⇒ B₂) | yes B★ | yes A~B =
+  yes (∀~ B★ A~B)
+A~B? {Ψ = Ψ} (`∀ A) (B₁ ⇒ B₂) | yes B★ | no A≁B =
+  no λ { (∀~ _ A~B) → A≁B A~B }
+A~B? {Ψ = Ψ} (`∀ A) (B₁ ⇒ B₂) | no B≁★ =
+  no λ { (∀~ B★ _) → B≁★ B★ }
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) with A~B? {Ψ = outside ∷ Ψ} A B
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | yes A~B = yes (∀~∀ A~B)
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B
+  with has★? {Ψ = inside ∷ Ψ} (wkTy (`∀ B))
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★
+  with A~B? {Ψ = inside ∷ Ψ} A (wkTy (`∀ B))
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★ | yes A~∀B =
+  yes (∀~ B★ A~∀B)
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★ | no A≁∀B
+  with has★? {Ψ = inside ∷ Ψ} (wkTy (`∀ A))
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★ | no A≁∀B
+  | yes A★
+  with A~B? {Ψ = inside ∷ Ψ} (wkTy (`∀ A)) B
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★ | no A≁∀B
+  | yes A★ | yes ∀A~B =
+  yes (~∀ A★ ∀A~B)
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★ | no A≁∀B
+  | yes A★ | no ∀A≁B =
+  no λ
+    { (∀~∀ A~B) → A≁B A~B
+    ; (∀~ _ A~∀B) → A≁∀B A~∀B
+    ; (~∀ _ ∀A~B) → ∀A≁B ∀A~B
+    }
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | yes B★ | no A≁∀B
+  | no A≁★ =
+  no λ
+    { (∀~∀ A~B) → A≁B A~B
+    ; (∀~ _ A~∀B) → A≁∀B A~∀B
+    ; (~∀ A★ _) → A≁★ A★
+    }
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | no B≁★
+  with has★? {Ψ = inside ∷ Ψ} (wkTy (`∀ A))
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | no B≁★ | yes A★
+  with A~B? {Ψ = inside ∷ Ψ} (wkTy (`∀ A)) B
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | no B≁★ | yes A★
+  | yes ∀A~B =
+  yes (~∀ A★ ∀A~B)
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | no B≁★ | yes A★
+  | no ∀A≁B =
+  no λ
+    { (∀~∀ A~B) → A≁B A~B
+    ; (∀~ B★ _) → B≁★ B★
+    ; (~∀ _ ∀A~B) → ∀A≁B ∀A~B
+    }
+A~B? {Ψ = Ψ} (`∀ A) (`∀ B) | no A≁B | no B≁★ | no A≁★ =
+  no λ
+    { (∀~∀ A~B) → A≁B A~B
+    ; (∀~ B★ _) → B≁★ B★
+    ; (~∀ A★ _) → A≁★ A★
+    }
+
+close★ : ∀ {Δ} → Ty (suc Δ) → Ty Δ
+close★ A = A [ `★ ]ᵗ
+
+has★-close★ :
+  ∀ {Δ}{Ψ : Subset Δ}{A : Ty (suc Δ)} →
+  has★ {suc Δ}{inside ∷ Ψ} A →
+  has★ {Δ}{Ψ} (close★ A)
+has★-close★ A★ = has★-subst (singleTyEnv `★) A★
+
+close★-under-∀ : ∀ {Δ} → Ty (suc (suc Δ)) → Ty (suc Δ)
+close★-under-∀ A = substᵗ (extsᵗ (singleTyEnv `★)) A
+
+starAt : ∀ {Δ} → TyVar Δ → Substᵗ Δ Δ
+starAt Zᵗ Zᵗ = `★
+starAt Zᵗ (Sᵗ Y) = ＇ Sᵗ Y
+starAt (Sᵗ X) Zᵗ = ＇ Zᵗ
+starAt (Sᵗ X) (Sᵗ Y) = renameᵗ Sᵗ (starAt X Y)
+
+starAt-not-∀ :
+  ∀ {Δ} (X Y : TyVar Δ) {A : Ty (suc Δ)} →
+  starAt X Y ≡ `∀ A →
+  ⊥
+starAt-not-∀ Zᵗ Zᵗ ()
+starAt-not-∀ Zᵗ (Sᵗ Y) ()
+starAt-not-∀ (Sᵗ X) Zᵗ ()
+starAt-not-∀ (Sᵗ X) (Sᵗ Y) eq with starAt X Y | inspect (starAt X) Y
+starAt-not-∀ (Sᵗ X) (Sᵗ Y) () | ＇ Y′ | _
+starAt-not-∀ (Sᵗ X) (Sᵗ Y) () | ‵ x | _
+starAt-not-∀ (Sᵗ X) (Sᵗ Y) () | `★ | _
+starAt-not-∀ (Sᵗ X) (Sᵗ Y) () | A ⇒ B | _
+starAt-not-∀ (Sᵗ X) (Sᵗ Y) eq | `∀ A | [ eq′ ] =
+  starAt-not-∀ X Y eq′
+
+starAt-not-base :
+  ∀ {Δ} (X Y : TyVar Δ) {ι : Base} →
+  starAt X Y ≡ ‵ ι →
+  ⊥
+starAt-not-base Zᵗ Zᵗ ()
+starAt-not-base Zᵗ (Sᵗ Y) ()
+starAt-not-base (Sᵗ X) Zᵗ ()
+starAt-not-base (Sᵗ X) (Sᵗ Y) eq with starAt X Y | inspect (starAt X) Y
+starAt-not-base (Sᵗ X) (Sᵗ Y) () | ＇ Y′ | _
+starAt-not-base (Sᵗ X) (Sᵗ Y) eq | ‵ x | [ eq′ ] =
+  starAt-not-base X Y eq′
+starAt-not-base (Sᵗ X) (Sᵗ Y) () | `★ | _
+starAt-not-base (Sᵗ X) (Sᵗ Y) () | A ⇒ B | _
+starAt-not-base (Sᵗ X) (Sᵗ Y) () | `∀ A | _
+
+starAt-not-⇒ :
+  ∀ {Δ} (X Y : TyVar Δ) {A B : Ty Δ} →
+  starAt X Y ≡ A ⇒ B →
+  ⊥
+starAt-not-⇒ Zᵗ Zᵗ ()
+starAt-not-⇒ Zᵗ (Sᵗ Y) ()
+starAt-not-⇒ (Sᵗ X) Zᵗ ()
+starAt-not-⇒ (Sᵗ X) (Sᵗ Y) eq with starAt X Y | inspect (starAt X) Y
+starAt-not-⇒ (Sᵗ X) (Sᵗ Y) () | ＇ Y′ | _
+starAt-not-⇒ (Sᵗ X) (Sᵗ Y) () | ‵ x | _
+starAt-not-⇒ (Sᵗ X) (Sᵗ Y) () | `★ | _
+starAt-not-⇒ (Sᵗ X) (Sᵗ Y) eq | A ⇒ B | [ eq′ ] =
+  starAt-not-⇒ X Y eq′
+starAt-not-⇒ (Sᵗ X) (Sᵗ Y) () | `∀ A | _
+
+starAt-exts : ∀ {Δ} (X : TyVar Δ) (Y : TyVar (suc Δ)) →
+  starAt (Sᵗ X) Y ≡ extsᵗ (starAt X) Y
+starAt-exts X Zᵗ = refl
+starAt-exts X (Sᵗ Y) = refl
+
+renameᵗ-cong-env :
+  ∀ {Δ Δ′}{ρ τ : Renameᵗ Δ Δ′} →
+  (∀ X → ρ X ≡ τ X) →
+  (A : Ty Δ) →
+  renameᵗ ρ A ≡ renameᵗ τ A
+renameᵗ-cong-env ρ≡τ (＇ X) = cong ＇_ (ρ≡τ X)
+renameᵗ-cong-env ρ≡τ (‵ x) = refl
+renameᵗ-cong-env ρ≡τ `★ = refl
+renameᵗ-cong-env ρ≡τ (A ⇒ B) =
+  cong₂ _⇒_ (renameᵗ-cong-env ρ≡τ A) (renameᵗ-cong-env ρ≡τ B)
+renameᵗ-cong-env ρ≡τ (`∀ A) =
+  cong `∀ (renameᵗ-cong-env (λ { Zᵗ → refl ; (Sᵗ X) →
+    cong Sᵗ (ρ≡τ X) }) A)
+
+renameᵗ-comp :
+  ∀ {Δ Δ′ Δ″}
+    (ρ : Renameᵗ Δ′ Δ″) (τ : Renameᵗ Δ Δ′) (A : Ty Δ) →
+  renameᵗ ρ (renameᵗ τ A) ≡ renameᵗ (λ X → ρ (τ X)) A
+renameᵗ-comp ρ τ (＇ X) = refl
+renameᵗ-comp ρ τ (‵ x) = refl
+renameᵗ-comp ρ τ `★ = refl
+renameᵗ-comp ρ τ (A ⇒ B) =
+  cong₂ _⇒_ (renameᵗ-comp ρ τ A) (renameᵗ-comp ρ τ B)
+renameᵗ-comp ρ τ (`∀ A) =
+  cong `∀ (trans (renameᵗ-comp (extᵗ ρ) (extᵗ τ) A)
+                 (renameᵗ-cong-env (λ { Zᵗ → refl ; (Sᵗ X) → refl }) A))
+
+substᵗ-cong-env :
+  ∀ {Δ Δ′}{σ τ : Substᵗ Δ Δ′} →
+  (∀ X → σ X ≡ τ X) →
+  (A : Ty Δ) →
+  substᵗ σ A ≡ substᵗ τ A
+substᵗ-cong-env σ≡τ (＇ X) = σ≡τ X
+substᵗ-cong-env σ≡τ (‵ x) = refl
+substᵗ-cong-env σ≡τ `★ = refl
+substᵗ-cong-env σ≡τ (A ⇒ B) =
+  cong₂ _⇒_ (substᵗ-cong-env σ≡τ A) (substᵗ-cong-env σ≡τ B)
+substᵗ-cong-env σ≡τ (`∀ A) =
+  cong `∀ (substᵗ-cong-env (λ { Zᵗ → refl ; (Sᵗ X) →
+    cong (renameᵗ Sᵗ) (σ≡τ X) }) A)
+
+substᵗ-rename :
+  ∀ {Δ Δ′ Δ″}
+    (ρ : Renameᵗ Δ Δ′) (σ : Substᵗ Δ′ Δ″) (A : Ty Δ) →
+  substᵗ σ (renameᵗ ρ A) ≡ substᵗ (λ X → σ (ρ X)) A
+substᵗ-rename ρ σ (＇ X) = refl
+substᵗ-rename ρ σ (‵ x) = refl
+substᵗ-rename ρ σ `★ = refl
+substᵗ-rename ρ σ (A ⇒ B) =
+  cong₂ _⇒_ (substᵗ-rename ρ σ A) (substᵗ-rename ρ σ B)
+substᵗ-rename ρ σ (`∀ A) =
+  cong `∀ (trans (substᵗ-rename (extᵗ ρ) (extsᵗ σ) A)
+                 (substᵗ-cong-env (λ { Zᵗ → refl ; (Sᵗ X) → refl }) A))
+
+renameᵗ-subst :
+  ∀ {Δ Δ′ Δ″}
+    (ρ : Renameᵗ Δ′ Δ″) (σ : Substᵗ Δ Δ′) (A : Ty Δ) →
+  renameᵗ ρ (substᵗ σ A) ≡ substᵗ (λ X → renameᵗ ρ (σ X)) A
+renameᵗ-subst ρ σ (＇ X) = refl
+renameᵗ-subst ρ σ (‵ x) = refl
+renameᵗ-subst ρ σ `★ = refl
+renameᵗ-subst ρ σ (A ⇒ B) =
+  cong₂ _⇒_ (renameᵗ-subst ρ σ A) (renameᵗ-subst ρ σ B)
+renameᵗ-subst ρ σ (`∀ A) =
+  cong `∀ (trans (renameᵗ-subst (extᵗ ρ) (extsᵗ σ) A)
+                 (substᵗ-cong-env env-eq A))
+  where
+  env-eq : ∀ X →
+    renameᵗ (extᵗ ρ) (extsᵗ σ X) ≡
+    extsᵗ (λ Y → renameᵗ ρ (σ Y)) X
+  env-eq Zᵗ = refl
+  env-eq (Sᵗ X) =
+    trans (renameᵗ-comp (extᵗ ρ) Sᵗ (σ X))
+          (sym (renameᵗ-comp Sᵗ ρ (σ X)))
+
+substᵗ-wkTy :
+  ∀ {Δ Δ′} (σ : Substᵗ Δ Δ′) (A : Ty Δ) →
+  substᵗ (extsᵗ σ) (wkTy A) ≡ wkTy (substᵗ σ A)
+substᵗ-wkTy σ A =
+  trans (substᵗ-rename Sᵗ (extsᵗ σ) A)
+        (sym (renameᵗ-subst Sᵗ σ A))
+
+starAt-exts-subst :
+  ∀ {Δ} (X : TyVar Δ) (A : Ty (suc Δ)) →
+  substᵗ (starAt (Sᵗ X)) A ≡ substᵗ (extsᵗ (starAt X)) A
+starAt-exts-subst X A = substᵗ-cong-env (starAt-exts X) A
+
+wk-starAt-right-var :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{s X Y} →
+  Ψ ∣ ℓ ⊢ ＇ Y ~ starAt X Y →
+  (s ∷ Ψ) ∣ ℓ ⊢ ＇ Sᵗ Y ~ renameᵗ Sᵗ (starAt X Y)
+wk-starAt-right-var {X = X} {Y = Y} h
+  with starAt X Y | inspect (starAt X) Y
+wk-starAt-right-var {X = X} {Y = Y} X~X | ＇ .Y | _ = X~X
+wk-starAt-right-var {X = X} {Y = Y} (α~✯ Y∈Ψ) | `★ | _ =
+  α~✯ (there Y∈Ψ)
+wk-starAt-right-var {X = X} {Y = Y} h | `∀ A | [ eq ] =
+  ⊥-elim (starAt-not-∀ X Y eq)
+
+wk-starAt-left-var :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{s X Y} →
+  Ψ ∣ ℓ ⊢ starAt X Y ~ ＇ Y →
+  (s ∷ Ψ) ∣ ℓ ⊢ renameᵗ Sᵗ (starAt X Y) ~ ＇ Sᵗ Y
+wk-starAt-left-var {X = X} {Y = Y} h
+  with starAt X Y | inspect (starAt X) Y
+wk-starAt-left-var {X = X} {Y = Y} X~X | ＇ .Y | _ = X~X
+wk-starAt-left-var {X = X} {Y = Y} (✯~α Y∈Ψ) | `★ | _ =
+  ✯~α (there Y∈Ψ)
+wk-starAt-left-var {X = X} {Y = Y} h | `∀ A | [ eq ] =
+  ⊥-elim (starAt-not-∀ X Y eq)
+
+wk-starAt-left-★ :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{s X Y} →
+  Ψ ∣ ℓ ⊢ starAt X Y ~ `★ →
+  (s ∷ Ψ) ∣ ℓ ⊢ renameᵗ Sᵗ (starAt X Y) ~ `★
+wk-starAt-left-★ {X = X} {Y = Y} h
+  with starAt X Y | inspect (starAt X) Y
+wk-starAt-left-★ {X = X} {Y = Y} (α~✯ Y∈Ψ) | ＇ Y′ | _ =
+  α~✯ (there Y∈Ψ)
+wk-starAt-left-★ {X = X} {Y = Y} h | ‵ x | [ eq ] =
+  ⊥-elim (starAt-not-base X Y eq)
+wk-starAt-left-★ {X = X} {Y = Y} ★~★ | `★ | _ = ★~★
+wk-starAt-left-★ {X = X} {Y = Y} h | A ⇒ B | [ eq ] =
+  ⊥-elim (starAt-not-⇒ X Y eq)
+wk-starAt-left-★ {X = X} {Y = Y} h | `∀ A | [ eq ] =
+  ⊥-elim (starAt-not-∀ X Y eq)
+
+wk-starAt-right-★ :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{s X Y} →
+  Ψ ∣ ℓ ⊢ `★ ~ starAt X Y →
+  (s ∷ Ψ) ∣ ℓ ⊢ `★ ~ renameᵗ Sᵗ (starAt X Y)
+wk-starAt-right-★ {X = X} {Y = Y} h
+  with starAt X Y | inspect (starAt X) Y
+wk-starAt-right-★ {X = X} {Y = Y} (✯~α Y∈Ψ) | ＇ Y′ | _ =
+  ✯~α (there Y∈Ψ)
+wk-starAt-right-★ {X = X} {Y = Y} h | ‵ x | [ eq ] =
+  ⊥-elim (starAt-not-base X Y eq)
+wk-starAt-right-★ {X = X} {Y = Y} ★~★ | `★ | _ = ★~★
+wk-starAt-right-★ {X = X} {Y = Y} h | A ⇒ B | [ eq ] =
+  ⊥-elim (starAt-not-⇒ X Y eq)
+wk-starAt-right-★ {X = X} {Y = Y} h | `∀ A | [ eq ] =
+  ⊥-elim (starAt-not-∀ X Y eq)
+
+starAt-right-var :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{X : TyVar Δ} →
+  tyVarToFin X ∈ Ψ →
+  (Y : TyVar Δ) →
+  Ψ ∣ ℓ ⊢ ＇ Y ~ starAt X Y
+starAt-right-var {X = Zᵗ} X∈Ψ Zᵗ = α~✯ X∈Ψ
+starAt-right-var {X = Zᵗ} X∈Ψ (Sᵗ Y) = X~X
+starAt-right-var {Ψ = s ∷ Ψ} {X = Sᵗ X} (there X∈Ψ) Zᵗ = X~X
+starAt-right-var {Ψ = s ∷ Ψ} {X = Sᵗ X} (there X∈Ψ) (Sᵗ Y) =
+  wk-starAt-right-var {Ψ = Ψ} {s = s} {X = X} {Y = Y}
+                      (starAt-right-var {Ψ = Ψ} {X = X} X∈Ψ Y)
+
+starAt-left-var :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{X : TyVar Δ} →
+  tyVarToFin X ∈ Ψ →
+  (Y : TyVar Δ) →
+  Ψ ∣ ℓ ⊢ starAt X Y ~ ＇ Y
+starAt-left-var {X = Zᵗ} X∈Ψ Zᵗ = ✯~α X∈Ψ
+starAt-left-var {X = Zᵗ} X∈Ψ (Sᵗ Y) = X~X
+starAt-left-var {Ψ = s ∷ Ψ} {X = Sᵗ X} (there X∈Ψ) Zᵗ = X~X
+starAt-left-var {Ψ = s ∷ Ψ} {X = Sᵗ X} (there X∈Ψ) (Sᵗ Y) =
+  wk-starAt-left-var {Ψ = Ψ} {s = s} {X = X} {Y = Y}
+                     (starAt-left-var {Ψ = Ψ} {X = X} X∈Ψ Y)
+
+mutual
+  starAt-subst-left :
+    ∀ {Δ}{Ψ : Subset Δ}{ℓ}{X : TyVar Δ}{A B : Ty Δ} →
+    tyVarToFin X ∈ Ψ →
+    Ψ ∣ ℓ ⊢ A ~ B →
+    Ψ ∣ ℓ ⊢ substᵗ (starAt X) A ~ B
+  starAt-subst-left X∈Ψ X~X = starAt-left-var X∈Ψ _
+  starAt-subst-left X∈Ψ (α~✯ Y∈Ψ) =
+    starAt-subst-left-★ X∈Ψ Y∈Ψ
+  starAt-subst-left X∈Ψ (✯~α Y∈Ψ) = ✯~α Y∈Ψ
+  starAt-subst-left X∈Ψ ι~ι = ι~ι
+  starAt-subst-left X∈Ψ ★~★ = ★~★
+  starAt-subst-left X∈Ψ ★~ι = ★~ι
+  starAt-subst-left X∈Ψ ι~★ = ι~★
+  starAt-subst-left X∈Ψ (★~⇒ A~★ ★~B) = ★~⇒ A~★ ★~B
+  starAt-subst-left X∈Ψ (⇒~★ ★~A B~★) =
+    ⇒~★ (starAt-subst-right X∈Ψ ★~A)
+         (starAt-subst-left X∈Ψ B~★)
+  starAt-subst-left X∈Ψ (⇒~⇒ A′~A B~B′) =
+    ⇒~⇒ (starAt-subst-right X∈Ψ A′~A)
+        (starAt-subst-left X∈Ψ B~B′)
+  starAt-subst-left {ℓ = ℓ} {X = X} X∈Ψ
+                    (∀~∀ {A = A} {B = B} A~B) =
+    ∀~∀ (substEq (λ T → _ ∣ ℓ ⊢ T ~ B)
+                 (starAt-exts-subst X A)
+                 (starAt-subst-left (there X∈Ψ) A~B))
+  starAt-subst-left {ℓ = ℓ} {X = X} X∈Ψ
+                    (∀~ {A = A} {B = B} B★ A~B) =
+    ∀~ B★ (substEq (λ T → _ ∣ ℓ ⊢ T ~ wkTy B)
+                   (starAt-exts-subst X A)
+                   (starAt-subst-left (there X∈Ψ) A~B))
+  starAt-subst-left {ℓ = ℓ} {X = X} X∈Ψ
+                    (~∀ {A = A} {B = B} A★ A~B) =
+    ~∀ (substEq (λ T → has★ T)
+                (trans (starAt-exts-subst X (wkTy A))
+                       (substᵗ-wkTy (starAt X) A))
+                (has★-subst (starAt (Sᵗ X)) A★))
+        (substEq (λ T → _ ∣ ℓ ⊢ T ~ B)
+                 (trans (starAt-exts-subst X (wkTy A))
+                        (substᵗ-wkTy (starAt X) A))
+                 (starAt-subst-left (there X∈Ψ) A~B))
+
+  starAt-subst-right :
+    ∀ {Δ}{Ψ : Subset Δ}{ℓ}{X : TyVar Δ}{A B : Ty Δ} →
+    tyVarToFin X ∈ Ψ →
+    Ψ ∣ ℓ ⊢ A ~ B →
+    Ψ ∣ ℓ ⊢ A ~ substᵗ (starAt X) B
+  starAt-subst-right X∈Ψ X~X = starAt-right-var X∈Ψ _
+  starAt-subst-right X∈Ψ (α~✯ Y∈Ψ) = α~✯ Y∈Ψ
+  starAt-subst-right X∈Ψ (✯~α Y∈Ψ) =
+    starAt-subst-right-★ X∈Ψ Y∈Ψ
+  starAt-subst-right X∈Ψ ι~ι = ι~ι
+  starAt-subst-right X∈Ψ ★~★ = ★~★
+  starAt-subst-right X∈Ψ ★~ι = ★~ι
+  starAt-subst-right X∈Ψ ι~★ = ι~★
+  starAt-subst-right X∈Ψ (★~⇒ A~★ ★~B) =
+    ★~⇒ (starAt-subst-left X∈Ψ A~★)
+         (starAt-subst-right X∈Ψ ★~B)
+  starAt-subst-right X∈Ψ (⇒~★ ★~A B~★) = ⇒~★ ★~A B~★
+  starAt-subst-right X∈Ψ (⇒~⇒ A′~A B~B′) =
+    ⇒~⇒ (starAt-subst-left X∈Ψ A′~A)
+        (starAt-subst-right X∈Ψ B~B′)
+  starAt-subst-right {ℓ = ℓ} {X = X} X∈Ψ
+                     (∀~∀ {A = A} {B = B} A~B) =
+    ∀~∀ (substEq (λ T → _ ∣ ℓ ⊢ A ~ T)
+                 (starAt-exts-subst X B)
+                 (starAt-subst-right (there X∈Ψ) A~B))
+  starAt-subst-right {ℓ = ℓ} {X = X} X∈Ψ
+                     (∀~ {A = A} {B = B} B★ A~B) =
+    ∀~ (substEq (λ T → has★ T)
+                (trans (starAt-exts-subst X (wkTy B))
+                       (substᵗ-wkTy (starAt X) B))
+                (has★-subst (starAt (Sᵗ X)) B★))
+        (substEq (λ T → _ ∣ ℓ ⊢ A ~ T)
+                 (trans (starAt-exts-subst X (wkTy B))
+                        (substᵗ-wkTy (starAt X) B))
+                 (starAt-subst-right (there X∈Ψ) A~B))
+  starAt-subst-right {ℓ = ℓ} {X = X} X∈Ψ
+                     (~∀ {A = A} {B = B} A★ A~B) =
+    ~∀ A★ (substEq (λ T → _ ∣ ℓ ⊢ wkTy A ~ T)
+                   (starAt-exts-subst X B)
+                   (starAt-subst-right (there X∈Ψ) A~B))
+
+  starAt-subst-left-★ :
+    ∀ {Δ}{Ψ : Subset Δ}{ℓ}{X Y : TyVar Δ} →
+    tyVarToFin X ∈ Ψ →
+    tyVarToFin Y ∈ Ψ →
+    Ψ ∣ ℓ ⊢ starAt X Y ~ `★
+  starAt-subst-left-★ {X = Zᵗ} {Y = Zᵗ} X∈Ψ Y∈Ψ = ★~★
+  starAt-subst-left-★ {X = Zᵗ} {Y = Sᵗ Y} X∈Ψ Y∈Ψ = α~✯ Y∈Ψ
+  starAt-subst-left-★ {X = Sᵗ X} {Y = Zᵗ} X∈Ψ Y∈Ψ = α~✯ Y∈Ψ
+  starAt-subst-left-★ {Ψ = s ∷ Ψ} {X = Sᵗ X} {Y = Sᵗ Y}
+                      (there X∈Ψ) (there Y∈Ψ) =
+    wk-starAt-left-★ {Ψ = Ψ} {s = s} {X = X} {Y = Y}
+                     (starAt-subst-left-★ {Ψ = Ψ} {X = X} {Y = Y}
+                                          X∈Ψ Y∈Ψ)
+
+  starAt-subst-right-★ :
+    ∀ {Δ}{Ψ : Subset Δ}{ℓ}{X Y : TyVar Δ} →
+    tyVarToFin X ∈ Ψ →
+    tyVarToFin Y ∈ Ψ →
+    Ψ ∣ ℓ ⊢ `★ ~ starAt X Y
+  starAt-subst-right-★ {X = Zᵗ} {Y = Zᵗ} X∈Ψ Y∈Ψ = ★~★
+  starAt-subst-right-★ {X = Zᵗ} {Y = Sᵗ Y} X∈Ψ Y∈Ψ = ✯~α Y∈Ψ
+  starAt-subst-right-★ {X = Sᵗ X} {Y = Zᵗ} X∈Ψ Y∈Ψ = ✯~α Y∈Ψ
+  starAt-subst-right-★ {Ψ = s ∷ Ψ} {X = Sᵗ X} {Y = Sᵗ Y}
+                       (there X∈Ψ) (there Y∈Ψ) =
+    wk-starAt-right-★ {Ψ = Ψ} {s = s} {X = X} {Y = Y}
+                      (starAt-subst-right-★ {Ψ = Ψ} {X = X} {Y = Y}
+                                            X∈Ψ Y∈Ψ)
+
+starAt-close★ :
+  ∀ {Δ} (A : Ty (suc Δ)) →
+  substᵗ (starAt Zᵗ) A ≡ wkTy (close★ A)
+starAt-close★ A =
+  trans (substᵗ-cong-env (λ { Zᵗ → refl ; (Sᵗ X) → refl }) A)
+        (sym (renameᵗ-subst Sᵗ (singleTyEnv `★) A))
+
+close★-right :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{A B : Ty (suc Δ)} →
+  (inside ∷ Ψ) ∣ ℓ ⊢ A ~ B →
+  (inside ∷ Ψ) ∣ ℓ ⊢ A ~ wkTy (close★ B)
+close★-right {Ψ = Ψ} {ℓ = ℓ} {A = A} {B = B} h =
+  substEq (λ C → (inside ∷ Ψ) ∣ ℓ ⊢ A ~ C) (starAt-close★ B)
+          (starAt-subst-right {Ψ = inside ∷ Ψ} {X = Zᵗ} here h)
+
+has★-close★-right :
+  ∀ {Δ}{Ψ : Subset Δ}{A : Ty (suc Δ)} →
+  has★ {suc Δ}{inside ∷ Ψ} A →
+  has★ {suc Δ}{inside ∷ Ψ} (wkTy (close★ A))
+has★-close★-right {A = A} A★ =
+  substEq (λ B → has★ B) (starAt-close★ A)
+          (has★-subst (starAt Zᵗ) A★)
+
+close★-func :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{A T U : Ty (suc Δ)} →
+  (inside ∷ Ψ) ∣ ℓ ⊢ A ~ (T ⇒ U) →
+  (inside ∷ Ψ) ∣ ℓ ⊢ A ~ wkTy (close★ T ⇒ close★ U)
+close★-func h = close★-right h
+
+close★-poly :
+  ∀ {Δ}{Ψ : Subset Δ}{ℓ}{A : Ty (suc Δ)}{B : Ty (suc (suc Δ))} →
+  (inside ∷ Ψ) ∣ ℓ ⊢ A ~ (`∀ B) →
+  (inside ∷ Ψ) ∣ ℓ ⊢ A ~ wkTy (`∀ (close★-under-∀ B))
+close★-poly h = close★-right h
+
+~-star :
+  ∀ {Δ}{Ψ}{ℓ} (A : Ty Δ) →
+  Dec (∃[ B ] (has★ {Ψ = Ψ} B × (Ψ ∣ ℓ ⊢ A ~ B)))
+~-star {Ψ = Ψ} (＇ X) with tyVarToFin X ∈? Ψ
+~-star {Ψ = Ψ} (＇ X) | yes X∈Ψ =
+  yes (`★ , has★-★ , α~✯ X∈Ψ)
+~-star {Ψ = Ψ} (＇ X) | no X∉Ψ =
+  no λ { (.(＇ X) , () , X~X)
+       ; (`★ , has★-★ , α~✯ X∈Ψ) → X∉Ψ X∈Ψ
+       ; (`∀ B , B★ , ~∀ () _) }
+~-star (‵ ι) = yes (`★ , has★-★ , ι~★)
+~-star `★ = yes (`★ , has★-★ , ★~★)
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) with has★? {Ψ = Ψ} (A ⇒ B)
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | yes A⇒B★ =
+  yes (A ⇒ B , A⇒B★ , ~-refl)
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★
+  with ~-star {Ψ = Ψ} {ℓ = push zero ℓ} A
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★
+  | yes (A′ , A′★ , A~A′) =
+  yes (A′ ⇒ B , has★-⇒ˡ A′★ , ⇒~⇒ (~-sym A~A′) ~-refl)
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★ | no A≁★
+  with ~-star {Ψ = Ψ} {ℓ = push (suc zero) ℓ} B
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★ | no A≁★
+  | yes (B′ , B′★ , B~B′) =
+  yes (A ⇒ B′ , has★-⇒ʳ B′★ , ⇒~⇒ ~-refl B~B′)
+~-star {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★ | no A≁★
+  | no B≁★ =
+  no λ
+    { (`★ , has★-★ , ⇒~★ ★~A _) →
+        A≁★ (`★ , has★-★ , ~-sym ★~A)
+    ; (A′ ⇒ B′ , has★-⇒ˡ A′★ , ⇒~⇒ A′~A _) →
+        A≁★ (_ , A′★ , ~-sym A′~A)
+    ; (A′ ⇒ B′ , has★-⇒ʳ B′★ , ⇒~⇒ _ B~B′) →
+        B≁★ (_ , B′★ , B~B′)
+    ; (`∀ C , C★ , ~∀ A⇒B★ _) →
+        A⇒B≁★ (has★-rename-inv Sᵗ A⇒B★)
+    }
+~-star {Ψ = Ψ} (`∀ A) with has★? {Ψ = Ψ} (`∀ A)
+~-star {Ψ = Ψ} (`∀ A) | yes ∀A★ =
+  yes (`∀ A , ∀A★ , ~-refl)
+~-star {Ψ = Ψ} (`∀ A) | no ∀A≁★
+  with ~-star {Ψ = outside ∷ Ψ} A
+~-star {Ψ = Ψ} (`∀ A) | no ∀A≁★ | yes (B , B★ , A~B) =
+  yes (`∀ B , has*-∀ B★ , ∀~∀ A~B)
+~-star {Ψ = Ψ} (`∀ A) | no ∀A≁★ | no A≁★out
+  with ~-star {Ψ = inside ∷ Ψ} A
+~-star {Ψ = Ψ} (`∀ A) | no ∀A≁★ | no A≁★out
+  | yes (B , B★ , A~B) =
+  yes (close★ B , has★-close★ B★ ,
+       ∀~ (has★-wkTy (has★-close★ B★)) (close★-right A~B))
+~-star {Ψ = Ψ} (`∀ A) | no ∀A≁★ | no A≁★out | no A≁★in =
+  no λ
+    { (`∀ B , has*-∀ B★ , ∀~∀ A~B) →
+        A≁★out (B , B★ , A~B)
+    ; (B , B★ , ∀~ _ A~B) →
+        A≁★in (wkTy B , has★-wkTy B★ , A~B)
+    ; (`∀ B , B★ , ~∀ ∀A★ _) →
+        ∀A≁★ (has★-rename-inv Sᵗ ∀A★)
+    }
+
+~-poly★ :
+  ∀ {Δ}{Ψ}{ℓ} (A : Ty Δ) →
+  Dec (∃[ B ] (has★ {Δ}{Ψ} (`∀ B) × (Ψ ∣ ℓ ⊢ A ~ (`∀ B))))
+~-poly★ (＇ X) = no λ { (B , _ , ~∀ () _) }
+~-poly★ (‵ ι) = no λ { (B , _ , ~∀ () _) }
+~-poly★ `★ = yes (wkTy `★ , has*-∀ has★-★ , ~∀ has★-★ ~-refl)
+~-poly★ {Ψ = Ψ} (A ⇒ B) with has★? {Ψ = inside ∷ Ψ} (wkTy (A ⇒ B))
+~-poly★ {Ψ = Ψ} (A ⇒ B) | yes A⇒B★ =
+  yes (wkTy (A ⇒ B) , has*-∀ (has★-ctx A⇒B★) , ~∀ A⇒B★ ~-refl)
+~-poly★ {Ψ = Ψ} (A ⇒ B) | no A⇒B≁★ =
+  no λ { (C , _ , ~∀ A⇒B★ _) → A⇒B≁★ A⇒B★ }
+~-poly★ {Ψ = Ψ} (`∀ A) with ~-star {Ψ = outside ∷ Ψ} A
+~-poly★ {Ψ = Ψ} (`∀ A) | yes (B , B★ , A~B) =
+  yes (B , has*-∀ B★ , ∀~∀ A~B)
+~-poly★ {Ψ = Ψ} (`∀ A) | no A≁★out
+  with ~-poly★ {Ψ = inside ∷ Ψ} A
+~-poly★ {Ψ = Ψ} (`∀ A) | no A≁★out | yes (B , ∀B★ , A~∀B) =
+  yes (close★-under-∀ B , has★-close★ ∀B★ ,
+       ∀~ (has★-close★-right ∀B★) (close★-poly A~∀B))
+~-poly★ {Ψ = Ψ} (`∀ A) | no A≁★out | no A≁∀★in
+  with has★? {Ψ = inside ∷ Ψ} (wkTy (`∀ A))
+~-poly★ {Ψ = Ψ} (`∀ A) | no A≁★out | no A≁∀★in | yes ∀A★ =
+  yes (wkTy (`∀ A) , has*-∀ (has★-ctx ∀A★) , ~∀ ∀A★ ~-refl)
+~-poly★ {Ψ = Ψ} (`∀ A) | no A≁★out | no A≁∀★in | no ∀A≁★ =
+  no λ
+    { (B , has*-∀ B★ , ∀~∀ A~B) →
+        A≁★out (B , B★ , A~B)
+    ; (B , _ , ∀~ ∀B★ A~∀B) →
+        A≁∀★in (renameᵗ (extᵗ Sᵗ) B , ∀B★ , A~∀B)
+    ; (B , _ , ~∀ ∀A★ _) →
+        ∀A≁★ ∀A★
+    }
+
+~-func★ :
+  ∀ {Δ}{Ψ}{ℓ} (A : Ty Δ) →
+  Dec (∃[ T ] ∃[ U ]
+       (has★ {Ψ = Ψ} (T ⇒ U) × (Ψ ∣ ℓ ⊢ A ~ (T ⇒ U))))
+~-func★ (＇ X) = no λ ()
+~-func★ (‵ ι) = no λ ()
+~-func★ `★ =
+  yes (`★ , `★ , has★-⇒ˡ has★-★ , ★~⇒ ★~★ ★~★)
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) with has★? {Ψ = Ψ} (A ⇒ B)
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | yes A⇒B★ =
+  yes (A , B , A⇒B★ , ~-refl)
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★
+  with ~-star {Ψ = Ψ} {ℓ = push zero ℓ} A
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★
+  | yes (A′ , A′★ , A~A′) =
+  yes (A′ , B , has★-⇒ˡ A′★ , ⇒~⇒ (~-sym A~A′) ~-refl)
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★ | no A≁★
+  with ~-star {Ψ = Ψ} {ℓ = push (suc zero) ℓ} B
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★ | no A≁★
+  | yes (B′ , B′★ , B~B′) =
+  yes (A , B′ , has★-⇒ʳ B′★ , ⇒~⇒ ~-refl B~B′)
+~-func★ {Ψ = Ψ} {ℓ = ℓ} (A ⇒ B) | no A⇒B≁★ | no A≁★
+  | no B≁★ =
+  no λ
+    { (T , U , has★-⇒ˡ T★ , ⇒~⇒ T~A _) →
+        A≁★ (T , T★ , ~-sym T~A)
+    ; (T , U , has★-⇒ʳ U★ , ⇒~⇒ _ B~U) →
+        B≁★ (U , U★ , B~U)
+    }
+~-func★ {Ψ = Ψ} (`∀ A) with ~-func★ {Ψ = inside ∷ Ψ} A
+~-func★ {Ψ = Ψ} (`∀ A) | yes (T , U , T⇒U★ , A~T⇒U) =
+  yes (close★ T , close★ U , has★-close★ T⇒U★ ,
+       ∀~ (has★-wkTy (has★-close★ T⇒U★)) (close★-func A~T⇒U))
+~-func★ {Ψ = Ψ} (`∀ A) | no A≁⇒★ =
+  no λ { (T , U , T⇒U★ , ∀~ T⇒Uwk★ A~T⇒U) →
+           A≁⇒★ (wkTy T , wkTy U , T⇒Uwk★ , A~T⇒U) }
+
+~-func : ∀ {Δ}{Ψ}{ℓ} (A : Ty Δ) → Dec (∃[ T ] ∃[ U ] (Ψ ∣ ℓ ⊢ A ~ (T ⇒ U)))
+~-func (＇ X) = no λ ()
+~-func (‵ ι) = no λ ()
+~-func `★ = yes (`★ , `★ , ★~⇒ ★~★ ★~★)
+~-func (A ⇒ B) = yes (A , B , ~-refl)
+~-func {Ψ = Ψ} (`∀ A) with ~-func★ {Ψ = inside ∷ Ψ} A
+~-func {Ψ = Ψ} (`∀ A) | yes (T , U , T⇒U★ , A~T⇒U) =
+  yes (close★ T , close★ U ,
+       ∀~ (has★-wkTy (has★-close★ T⇒U★)) (close★-func A~T⇒U))
+~-func {Ψ = Ψ} (`∀ A) | no A≁⇒★ =
+  no λ { (T , U , ∀~ T⇒U★ A~wkT⇒U) →
+           A≁⇒★ (wkTy T , wkTy U , T⇒U★ , A~wkT⇒U) }
+
+~-poly : ∀ {Δ}{Ψ}{ℓ} (A : Ty Δ) → Dec (∃[ B ] (Ψ ∣ ℓ ⊢ A ~ (`∀ B)))
+~-poly {Ψ = Ψ} (`∀ A) with ~-poly★ {Ψ = inside ∷ Ψ} A
+~-poly {Ψ = Ψ} (`∀ A) | yes (B , ∀B★ , A~∀B) =
+  yes (close★-under-∀ B ,
+       ∀~ (has★-close★-right ∀B★) (close★-poly A~∀B))
+~-poly {Ψ = Ψ} (`∀ A) | no _ = yes (A , ∀~∀ ~-refl)
+~-poly (＇ X) = no λ { (B , ~∀ () _) }
+~-poly (‵ ι) = no λ { (B , ~∀ () _) }
+~-poly `★ = yes (wkTy `★ , ~∀ has★-★ ~-refl)
+~-poly {Ψ = Ψ} (A ⇒ B) with has★? {Ψ = inside ∷ Ψ} (wkTy (A ⇒ B))
+~-poly {Ψ = Ψ} (A ⇒ B) | yes A⇒B★ =
+  yes (wkTy (A ⇒ B) , ~∀ A⇒B★ ~-refl)
+~-poly {Ψ = Ψ} (A ⇒ B) | no A⇒B≁★ =
+  no λ { (B , ~∀ A⇒B★ _) → A⇒B≁★ A⇒B★ }

--- a/GTSF-PT/Label.agda
+++ b/GTSF-PT/Label.agda
@@ -1,0 +1,15 @@
+-- File Charter:
+--   * Blame labels represented as nonempty lists of natural-number positions.
+--   * Primary exports are `Label` and `push`.
+--   * Depends only on natural numbers and nonempty lists from the standard
+--     library.
+
+module Label where
+
+open import Data.Nat using (ℕ)
+open import Data.List.NonEmpty using (List⁺; _∷⁺_)
+
+Label = List⁺ ℕ
+
+push : ℕ → Label → Label
+push = _∷⁺_

--- a/GTSF-PT/RawTerms.agda
+++ b/GTSF-PT/RawTerms.agda
@@ -1,0 +1,40 @@
+-- File Charter:
+--   * Well-scoped raw terms used as the input syntax for type checking.
+--   * Primary exports are raw expression contexts, raw variables, and raw terms.
+--   * Depends on labels and core type syntax.
+
+module RawTerms where
+
+open import Data.Nat using (ℕ; suc)
+open import Data.Bool using (Bool)
+open import Data.Fin using (Fin)
+open import Data.Fin.Subset using (Subset; Side; inside; outside)
+open import Data.Product using (Σ; proj₁; proj₂)
+open import Data.Vec using ([] ; _∷_)
+
+open import Label
+open import Types
+
+-- well-scoped terms
+
+ExCtx = ℕ
+
+ExVar : ExCtx → Set
+ExVar = Fin
+
+_▷ : ExCtx → ExCtx
+_▷ = suc
+
+data Ex (Δ : TyCtx) (Γ : ExCtx) : Set where
+
+  `_ : ExVar Γ → Ex Δ Γ
+
+  cst : (b : Σ Base base-type) → Ex Δ Γ
+
+  λx:_⇒ : ∀ (T : Ty Δ) → Ex Δ (Γ ▷) → Ex Δ Γ
+
+  app : (ℓ : Label) → Ex Δ Γ → Ex Δ Γ → Ex Δ Γ
+
+  ΛX : Ex (Δ ▷) Γ → Ex Δ Γ
+
+  tapp : (ℓ : Label) → Ex Δ Γ → (U : Ty Δ) → Ex Δ Γ

--- a/GTSF-PT/Reduction.agda
+++ b/GTSF-PT/Reduction.agda
@@ -1,0 +1,170 @@
+-- File Charter:
+--   * One-step small-step reduction for typed coercion terms.
+--   * Primary export is the `_—→_` reduction relation.
+--   * Depends on labels, types, coercion typing, coercion terms, and expression
+--     contexts.
+
+module Reduction where
+
+open import Data.List using (length; _∷_)
+open import Data.Nat using (ℕ; _+_)
+open import Data.Fin.Subset using (Subset; _∈_)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Sum using (_⊎_)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
+
+open import Label
+open import Types
+open import Coercions
+open import CoercionTerms
+open import Terms using (ExCtx; ∅; _▷_; renameᵉ; ExVar)
+
+--------------------------------------------------------------------------------
+-- One-step reduction
+--------------------------------------------------------------------------------
+
+
+infix 2 _—→_
+data _—→_ {Δ}{Ψ : Subset Δ} {Γ : ExCtx Δ} : ∀  {B : Ty Δ} →
+  Ex {Ψ = Ψ} Γ B → Ex {Ψ = Ψ} Γ B → Set where
+
+  β : ∀ {A B : Ty Δ}{V : Ex {Ψ = Ψ} Γ A}{N : Ex (Γ ▷ A) B}
+    → Value V
+    ---------------------
+    → app (λx: A ⇒ N) V —→ N [ V ]
+
+
+  β-↦ : ∀{p q}{A A′ B B′} {V : Ex Γ (A ⇒ B)}{W : Ex Γ A′}
+    → Value V → Value W
+    → (p⊢ : Δ ∣ Ψ ⊢ p ∶ A′ =⇒ A)
+    → (q⊢ : Δ ∣ Ψ ⊢ q ∶ B =⇒ B′)
+    -- p ↦ q
+    --------------------------------------------
+    → (V ⟨ cast-fun p⊢ q⊢ ⟩) · W  —→ (V · (W ⟨ p⊢ ⟩)) ⟨ q⊢ ⟩
+
+
+  β-id : ∀{A} {V : Ex Γ A}
+    → Value V
+    -- id A
+    -------------------
+    → V ⟨ cast-id ⟩ —→  V
+
+
+  β-seq : ∀ {A B C} {V : Ex Γ A} {p q}
+    → Value V
+    → (p⊢ : Δ ∣ Ψ ⊢ p ∶ A =⇒ B)
+    → (q⊢ : Δ ∣ Ψ ⊢ q ∶ B =⇒ C)
+    -- p ︔ q
+    ------------------------------
+    → V ⟨ cast-seq p⊢ q⊢ ⟩ —→ V ⟨ p⊢ ⟩ ⟨ q⊢ ⟩
+
+  seal-unseal : ∀ {α A} {V : Ex Γ A}
+    → Value V
+    → (α∈Ψ : tyVarToFin α ∈ Ψ)
+    -- seal A α / unseal α B
+    ------------------------------------
+    → V ⟨ cast-seal α∈Ψ ⟩ ⟨ cast-unseal α∈Ψ ⟩ —→ V
+
+  tag-untag-ok : ∀ {G}{V : Ex Γ G}{ℓ}
+    → (gG : Ground G)
+    → Value V
+    -- G ! / G ？ ℓ
+    ------------------------------
+    → V ⟨ cast-tag gG ⟩ ⟨ cast-untag {ℓ = ℓ} gG ⟩  —→  V
+
+  tag-untag-bad : ∀ {G H} {V : Ex Γ G} {ℓ : Label}
+    → (gG : Ground G)
+    → (gH : Ground H)
+    → Value V → G ≢ H
+    -- G ! / H ？ ℓ
+    ----------------------------------------
+    → V ⟨ cast-tag gG ⟩ ⟨ cast-untag {ℓ = ℓ} gH ⟩ —→  blame ℓ
+
+--   δ-⊕ : ∀ {m n : ℕ} →
+--     -----------------------------------------------
+--     $ (κℕ m) ⊕[ addℕ ] $ (κℕ n)  —→  $ (κℕ (m + n))
+
+--   blame-·₁ : ∀ {ℓ : Label} {M : Term} →
+--     (blame ℓ · M) —→ blame ℓ
+
+--   blame-·₂ : ∀ {ℓ : Label} {V : Term} →
+--     Value V →
+--     (V · blame ℓ) —→ blame ℓ
+
+--   blame-·α : ∀ {ℓ : Label} {B T : Ty} →
+--     (blame ℓ ⦂∀ B • T) —→ blame ℓ
+
+--   blame-⟨⟩ : ∀ {c : Coercion} {ℓ : Label} →
+--     ((blame ℓ) ⟨ c ⟩) —→ blame ℓ
+
+--   blame-⊕₁ : ∀ {ℓ : Label} {M : Term} {op : Prim} →
+--     (blame ℓ ⊕[ op ] M) —→ blame ℓ
+
+--   blame-⊕₂ : ∀ {ℓ : Label} {L : Term} {op : Prim} →
+--     Value L →
+--     (L ⊕[ op ] blame ℓ) —→ blame ℓ
+
+
+-- --------------------------------------------------------------------------------
+-- -- Store-threaded one-step reduction
+-- --------------------------------------------------------------------------------
+
+-- infix 2 _∣_—→_∣_
+-- data _∣_—→_∣_ : Store → Term → Store → Term → Set where
+
+--   pure-step : ∀ {Σ : Store} {M M′ : Term} →
+--     M —→ M′ →
+--     ---------------
+--     Σ ∣ M —→ Σ ∣ M′
+
+--   β-∀ : ∀ {Σ : Store}{V : Term} {A B : Ty}{c : Coercion} →
+--    Value V →
+--    ----------------------------------------------------------------------------
+--    let α = length Σ in
+--    Σ ∣ V ⟨ `∀ c ⟩ ⦂∀ B • A
+--      —→ (α , A) ∷ Σ ∣ (V ⦂∀ src c • ＇ α) ⟨ c [ α ]ᶜ ⟩ ⟨ reveal (B [ α ]ᴿ) α A ⟩
+
+--   β-Λ : ∀ {Σ : Store} {A B : Ty} {V : Term} →
+--     ------------------------------------------------------------------------
+--     let α = length Σ in
+--     Σ ∣ (Λ V) ⦂∀ B • A  —→  (α , A) ∷ Σ ∣ V [ α ]ᵀ ⟨ reveal (B [ α ]ᴿ) α A ⟩
+
+--   β-down-ν : ∀ {Σ : Store} {A B C V c} →
+--     Value V →
+--     ------------------------------------------------------------
+--     let α = length Σ in
+--     Σ ∣ V ⟨ gen C c ⟩ ⦂∀ B • A
+--       —→ (α , A) ∷ Σ ∣ V ⟨ c [ α ]ᶜ ⟩ ⟨ reveal (B [ α ]ᴿ) α A ⟩
+
+--   β-up-ν : ∀ {Σ : Store} {V B c} →
+--     Value V →
+--     ---------------------------------------------------------------------
+--     let α = length Σ in
+--     Σ ∣ V ⟨ inst B c ⟩ —→ (α , ★) ∷ Σ ∣ (V ⦂∀ (src c) • ＇ α ) ⟨ c [ α ]ᶜ ⟩
+
+--   ξ-·₁ : ∀ {Σ Σ′ : Store} {L M L′ : Term} →
+--     Σ ∣ L —→ Σ′ ∣ L′ →
+--     Σ ∣ (L · M) —→ Σ′ ∣ (L′ · M)
+
+--   ξ-·₂ : ∀ {Σ Σ′ : Store} {V M M′ : Term} →
+--     Value V →
+--     Σ ∣ M —→ Σ′ ∣ M′ →
+--     Σ ∣ (V · M) —→ Σ′ ∣ (V · M′)
+
+--   ξ-·α : ∀ {Σ Σ′ : Store} {M M′ : Term} {B A : Ty} →
+--     Σ ∣ M —→ Σ′ ∣ M′ →
+--     Σ ∣ (M ⦂∀ B • A) —→ Σ′ ∣ (M′ ⦂∀ B • A)
+
+--   ξ-⟨⟩ : ∀ {Σ Σ′ : Store} {c : Coercion} {M M′ : Term} →
+--     Σ ∣ M —→ Σ′ ∣ M′ →
+--     Σ ∣ (M ⟨ c ⟩) —→ Σ′ ∣ (M′ ⟨ c ⟩)
+
+--   ξ-⊕₁ : ∀ {Σ Σ′ : Store} {L M L′ : Term} {op : Prim} →
+--     Σ ∣ L —→ Σ′ ∣ L′ →
+--     Σ ∣ (L ⊕[ op ] M) —→ Σ′ ∣ (L′ ⊕[ op ] M)
+
+--   ξ-⊕₂ : ∀ {Σ Σ′ : Store} {L M M′ : Term} {op : Prim} →
+--     Value L →
+--     Σ ∣ M —→ Σ′ ∣ M′ →
+--     Σ ∣ (L ⊕[ op ] M) —→ Σ′ ∣ (L ⊕[ op ] M′)

--- a/GTSF-PT/Terms.agda
+++ b/GTSF-PT/Terms.agda
@@ -1,0 +1,66 @@
+-- File Charter:
+--   * Core syntax and primitive operations for source terms.
+--   * Primary exports are typed expression contexts, variables, terms, and
+--     term/type renaming and substitution operations.
+--   * Depends on core types, labels, and consistency.
+
+module Terms where
+
+open import Data.Nat using (ℕ)
+open import Data.Bool using (Bool)
+open import Data.Fin.Subset using (Subset; Side; inside; outside)
+open import Data.Product using (Σ; proj₁; proj₂)
+open import Data.Vec using ([] ; _∷_)
+
+open import Types
+open import Label using (Label)
+open import Consistency
+
+
+data ExCtx : TyCtx → Set where
+
+  ∅ : ∀{Δ} → ExCtx Δ
+
+  _▷_ : ∀{Δ} → ExCtx Δ → Ty Δ → ExCtx Δ
+
+renameᵉ : ∀ {Δ}{Δ′} → Renameᵗ Δ Δ′ → ExCtx Δ → ExCtx Δ′
+renameᵉ ρ ∅ = ∅
+renameᵉ ρ (Γ ▷ T) = renameᵉ ρ Γ ▷ renameᵗ ρ T
+
+data ExVar {Δ : TyCtx} : ExCtx Δ → Ty Δ → Set where
+
+  Zᵉ : ∀ {Γ}{T} → ExVar (Γ ▷ T) T
+
+  Sᵉ : ∀ {Γ} {T T′ : Ty Δ} → ExVar Γ T → ExVar (Γ ▷ T′) T
+
+data Ex {Δ : TyCtx} {Ψ : Subset Δ} : ExCtx Δ → Ty Δ → Set where
+
+  `_ : ∀ {Γ} {T}
+    → ExVar Γ T → Ex Γ T
+
+  cst : ∀ {Γ}
+    → (b : Σ Base base-type)
+    → Ex Γ (‵ b .proj₁)
+
+  λx:_⇒ : ∀ {Γ} {U}
+    → ∀ T
+    → Ex {Ψ = Ψ} (Γ ▷ T) U
+    → Ex Γ (T ⇒ U)
+
+  app : ∀ {Γ} {S T U V} {ℓ : Label}
+      → Ex {Ψ = Ψ} Γ S
+      → Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)
+      → Ex {Ψ = Ψ} Γ V
+      → Ψ ∣ ℓ ⊢ V ~ T
+      → Ex Γ U
+
+  ΛX : ∀ {Γ} {T}
+    → Ex {Ψ = outside ∷ Ψ}  (renameᵉ Sᵗ Γ) T
+    → Ex Γ (`∀ T)
+
+  tapp : ∀ {Γ} {S : Ty Δ} {T : Ty (ℕ.suc Δ)}
+         {ℓ : Label}
+       → Ex {Ψ = Ψ} Γ S
+       → Ψ ∣ ℓ ⊢ S ~ (`∀ T)
+       → (U : Ty Δ)
+       → Ex Γ (T [ U ]ᵗ)

--- a/GTSF-PT/TypeCheck.agda
+++ b/GTSF-PT/TypeCheck.agda
@@ -1,0 +1,351 @@
+-- File Charter:
+--   * Type checking and synthesis for well-scoped raw terms.
+--   * Primary exports are context compatibility, elaboration evidence, `synth`,
+--     and `check`.
+--   * Depends on core types, labels, consistency, typed terms, and raw terms.
+
+module TypeCheck where
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Nat using (ℕ; zero; suc)
+open import Data.Fin using (Fin; zero; suc)
+open import Data.Fin.Subset using (Subset; Side; inside; outside; _∈_)
+open import Data.Vec using (_∷_)
+open import Data.Product using (∃-syntax; Σ; proj₁; proj₂; _,_; _×_; map)
+open import Relation.Binary.PropositionalEquality
+  using (cong; cong₂; sym; trans; inspect; [_])
+  renaming (subst to substEq)
+open import Relation.Nullary using (¬_; Dec; yes; no)
+open import Function using (id)
+
+open import Types
+open import Label using (Label)
+open import Consistency
+open import Terms as CT
+open import RawTerms as RT
+
+-- compatibility of scope and typing context
+
+data comp-Γ {Δ : TyCtx} : RT.ExCtx → CT.ExCtx Δ → Set where
+
+  comp-∅ : comp-Γ zero ∅
+
+  comp-▷ : ∀ {Γr}{Γc : CT.ExCtx Δ}{T : Ty Δ} → comp-Γ Γr Γc → comp-Γ (suc Γr) (Γc ▷ T)
+
+rename-comp-Γ :
+  ∀ {Δ Δ′ Γr}{Γc : CT.ExCtx Δ} →
+  (ρ : Renameᵗ Δ Δ′) →
+  comp-Γ Γr Γc →
+  comp-Γ Γr (renameᵉ ρ Γc)
+rename-comp-Γ ρ comp-∅ = comp-∅
+rename-comp-Γ ρ (comp-▷ comp) = comp-▷ (rename-comp-Γ ρ comp)
+
+data comp-var {Δ : TyCtx} :
+    ∀ {Γr Γc} →
+    comp-Γ Γr Γc → (x : RT.ExVar Γr) → {T : Ty Δ} →
+    CT.ExVar Γc T → Set where
+
+  comp-Z : ∀ {Γr Γc T}{comp : comp-Γ Γr Γc} →
+    comp-var {Γr = suc Γr} {Γc = Γc ▷ T}
+             (comp-▷ {T = T} comp) zero Zᵉ
+
+  comp-S : ∀ {Γr Γc T U x}{comp : comp-Γ Γr Γc}{xᵉ : CT.ExVar Γc T} →
+    comp-var comp x xᵉ →
+    comp-var {Γr = suc Γr} {Γc = Γc ▷ U}
+             (comp-▷ {T = U} comp) (suc x) (Sᵉ xᵉ)
+
+-- compatibility of expressions
+
+data comp-E {Δ : TyCtx} {Ψ : Subset Δ} {Γr Γc} (comp :
+     comp-Γ Γr Γc) : {T : Ty Δ} → RT.Ex Δ Γr → CT.Ex{Ψ = Ψ} Γc T → Set where
+
+  comp-` : ∀ {T}{x}{xᵉ} →
+    comp-var comp x xᵉ →
+    comp-E comp {T} (` x) (` xᵉ)
+
+  comp-cst : ∀ {b : Σ Base base-type} → comp-E comp {‵ b .proj₁} (cst b) (CT.cst b )
+
+  comp-λ : ∀ {T U rt ct} →
+    comp-E (comp-▷ comp) {U} rt ct →
+    comp-E comp {T ⇒ U} (λx: T ⇒ rt) (CT.λx: T ⇒ ct)
+
+  comp-app : ∀ {ℓ S T U V rt rt₁ ct ct₁}
+      {S~T⇒U : Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)} {V~T : Ψ ∣ ℓ ⊢ V ~ T} →
+    ~-func {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T , U , S~T⇒U) →
+    comp-E comp {S} rt ct →
+    comp-E comp {V} rt₁ ct₁ →
+    comp-E comp {U} (RT.app ℓ rt rt₁) (CT.app ct S~T⇒U ct₁ V~T)
+
+  comp-ΛX : ∀ {T rt ct} →
+    comp-E {Ψ = outside ∷ Ψ} (rename-comp-Γ Sᵗ comp) {T} rt ct →
+    comp-E comp {`∀ T} (RT.ΛX rt) (CT.ΛX ct)
+
+  comp-tapp : ∀ {ℓ S T U rt ct}{S~∀T : Ψ ∣ ℓ ⊢ S ~ (`∀ T)} →
+    ~-poly {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T , S~∀T) →
+    comp-E comp {S} rt ct →
+    comp-E comp {T [ U ]ᵗ} (RT.tapp ℓ rt U) (CT.tapp ct S~∀T U)
+
+comp-var-type-unique :
+  ∀ {Δ Γr Γc}{comp : comp-Γ Γr Γc}{x : RT.ExVar Γr}
+    {T U : Ty Δ}{xᵉ : CT.ExVar Γc T}{yᵉ : CT.ExVar Γc U} →
+  comp-var comp x xᵉ →
+  comp-var comp x yᵉ →
+  T ≡ U
+comp-var-type-unique comp-Z comp-Z = refl
+comp-var-type-unique (comp-S x-comp) (comp-S y-comp) =
+  comp-var-type-unique x-comp y-comp
+
+yes-func-result-unique :
+  ∀ {Δ Ψ}{ℓ : Label}{S T U T′ U′ : Ty Δ}
+    {S~T⇒U : Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)}
+    {S~T′⇒U′ : Ψ ∣ ℓ ⊢ S ~ (T′ ⇒ U′)} →
+  yes (T , U , S~T⇒U) ≡ yes (T′ , U′ , S~T′⇒U′) →
+  U ≡ U′
+yes-func-result-unique refl = refl
+
+yes-func-domain-unique :
+  ∀ {Δ Ψ}{ℓ : Label}{S T U T′ U′ : Ty Δ}
+    {S~T⇒U : Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)}
+    {S~T′⇒U′ : Ψ ∣ ℓ ⊢ S ~ (T′ ⇒ U′)} →
+  yes (T , U , S~T⇒U) ≡ yes (T′ , U′ , S~T′⇒U′) →
+  T ≡ T′
+yes-func-domain-unique refl = refl
+
+func-result-unique :
+  ∀ {Δ Ψ}{ℓ : Label}{S T U T′ U′ : Ty Δ}
+    {S~T⇒U : Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)}
+    {S~T′⇒U′ : Ψ ∣ ℓ ⊢ S ~ (T′ ⇒ U′)} →
+  ~-func {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T , U , S~T⇒U) →
+  ~-func {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T′ , U′ , S~T′⇒U′) →
+  U ≡ U′
+func-result-unique ok ok′ = yes-func-result-unique (trans (sym ok) ok′)
+
+func-domain-unique :
+  ∀ {Δ Ψ}{ℓ : Label}{S T U T′ U′ : Ty Δ}
+    {S~T⇒U : Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)}
+    {S~T′⇒U′ : Ψ ∣ ℓ ⊢ S ~ (T′ ⇒ U′)} →
+  ~-func {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T , U , S~T⇒U) →
+  ~-func {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T′ , U′ , S~T′⇒U′) →
+  T ≡ T′
+func-domain-unique ok ok′ = yes-func-domain-unique (trans (sym ok) ok′)
+
+yes-poly-result-unique :
+  ∀ {Δ Ψ}{ℓ : Label}{S : Ty Δ}{T T′ : Ty (suc Δ)}
+    {S~∀T : Ψ ∣ ℓ ⊢ S ~ (`∀ T)}
+    {S~∀T′ : Ψ ∣ ℓ ⊢ S ~ (`∀ T′)} →
+  yes (T , S~∀T) ≡ yes (T′ , S~∀T′) →
+  T ≡ T′
+yes-poly-result-unique refl = refl
+
+poly-result-unique :
+  ∀ {Δ Ψ}{ℓ : Label}{S : Ty Δ}{T T′ : Ty (suc Δ)}
+    {S~∀T : Ψ ∣ ℓ ⊢ S ~ (`∀ T)}
+    {S~∀T′ : Ψ ∣ ℓ ⊢ S ~ (`∀ T′)} →
+  ~-poly {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T , S~∀T) →
+  ~-poly {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T′ , S~∀T′) →
+  T ≡ T′
+poly-result-unique ok ok′ = yes-poly-result-unique (trans (sym ok) ok′)
+
+comp-E-type-unique :
+  ∀ {Δ Ψ Γr Γc}{comp : comp-Γ Γr Γc}{rt : RT.Ex Δ Γr}
+    {T U : Ty Δ}{ct : CT.Ex {Ψ = Ψ} Γc T}
+    {ct′ : CT.Ex {Ψ = Ψ} Γc U} →
+  comp-E comp rt ct →
+  comp-E comp rt ct′ →
+  T ≡ U
+comp-E-type-unique (comp-` x-comp) (comp-` y-comp) =
+  comp-var-type-unique x-comp y-comp
+comp-E-type-unique comp-cst comp-cst = refl
+comp-E-type-unique {rt = λx: T ⇒ rt} (comp-λ comp-ct)
+                   (comp-λ comp-ct′) =
+  cong (λ U → T ⇒ U) (comp-E-type-unique comp-ct comp-ct′)
+comp-E-type-unique (comp-app func-ok comp-f comp-a)
+                   (comp-app func-ok′ comp-f′ comp-a′)
+  with comp-E-type-unique comp-f comp-f′
+... | refl = func-result-unique func-ok func-ok′
+comp-E-type-unique (comp-ΛX comp-ct) (comp-ΛX comp-ct′) =
+  cong `∀ (comp-E-type-unique comp-ct comp-ct′)
+comp-E-type-unique {rt = RT.tapp ℓ rt U} (comp-tapp poly-ok comp-ct)
+                   (comp-tapp poly-ok′ comp-ct′)
+  with comp-E-type-unique comp-ct comp-ct′
+... | refl = cong (λ T → T [ U ]ᵗ) (poly-result-unique poly-ok poly-ok′)
+
+app-no-func :
+  ∀ {Δ Ψ}{ℓ : Label}{Γr Γc}{comp : comp-Γ Γr Γc}{rt rt₁ : RT.Ex Δ Γr}
+    {A S T U : Ty Δ}
+    {ct-f : CT.Ex {Ψ = Ψ} Γc A}
+    {ct-f′ : CT.Ex {Ψ = Ψ} Γc S}
+    {S~T⇒U : Ψ ∣ ℓ ⊢ S ~ (T ⇒ U)} →
+  ¬ (Σ (Ty Δ) λ T → Σ (Ty Δ) λ U → Ψ ∣ ℓ ⊢ A ~ (T ⇒ U)) →
+  comp-E comp rt ct-f →
+  comp-E comp rt ct-f′ →
+  ⊥
+app-no-func {S~T⇒U = S~T⇒U} A≁⇒ comp-f comp-f′
+  with comp-E-type-unique comp-f comp-f′
+... | refl = A≁⇒ (_ , _ , S~T⇒U)
+
+app-no-arg :
+  ∀ {Δ Ψ}{ℓ : Label}{Γr Γc}{comp : comp-Γ Γr Γc}{rt rt₁ : RT.Ex Δ Γr}
+    {A S T U T′ U′ V : Ty Δ}
+    {ct-f : CT.Ex {Ψ = Ψ} Γc A}
+    {ct-f′ : CT.Ex {Ψ = Ψ} Γc S}
+    {ct-a : CT.Ex {Ψ = Ψ} Γc V}
+    {A~T⇒U : Ψ ∣ ℓ ⊢ A ~ (T ⇒ U)}
+    {S~T′⇒U′ : Ψ ∣ ℓ ⊢ S ~ (T′ ⇒ U′)}
+    {V~T′ : Ψ ∣ ℓ ⊢ V ~ T′} →
+  ¬ (Σ (Ty Δ) λ V →
+     Σ (CT.Ex {Ψ = Ψ} Γc V) λ ct →
+     (Ψ ∣ ℓ ⊢ V ~ T) × comp-E comp rt₁ ct) →
+  ~-func {Ψ = Ψ} {ℓ = ℓ} A ≡ yes (T , U , A~T⇒U) →
+  ~-func {Ψ = Ψ} {ℓ = ℓ} S ≡ yes (T′ , U′ , S~T′⇒U′) →
+  comp-E comp rt ct-f →
+  comp-E comp rt ct-f′ →
+  comp-E comp rt₁ ct-a →
+  ⊥
+app-no-arg {ℓ = ℓ} {V~T′ = V~T′} arg≁ func-ok func-ok′ comp-f comp-f′ comp-a
+  with comp-E-type-unique comp-f comp-f′
+... | refl =
+  arg≁ (_ , _ ,
+        substEq (λ X → _ ∣ ℓ ⊢ _ ~ X)
+                (sym (func-domain-unique func-ok func-ok′))
+                V~T′ ,
+        comp-a)
+
+tapp-no-poly :
+  ∀ {Δ Ψ}{ℓ : Label}{Γr Γc}{comp : comp-Γ Γr Γc}{rt : RT.Ex Δ Γr}
+    {A S : Ty Δ}{B : Ty (suc Δ)}
+    {ct : CT.Ex {Ψ = Ψ} Γc A}
+    {ct′ : CT.Ex {Ψ = Ψ} Γc S}
+    {S~∀B : Ψ ∣ ℓ ⊢ S ~ (`∀ B)} →
+  ¬ (Σ (Ty (suc Δ)) λ B → Ψ ∣ ℓ ⊢ A ~ (`∀ B)) →
+  comp-E comp rt ct →
+  comp-E comp rt ct′ →
+  ⊥
+tapp-no-poly {S~∀B = S~∀B} A≁∀ comp-ct comp-ct′
+  with comp-E-type-unique comp-ct comp-ct′
+... | refl = A≁∀ (_ , S~∀B)
+
+-- translation of variables across compatibility
+
+mk-var : ∀ {Δ : TyCtx} {Γr : RT.ExCtx}
+  → (Γc : CT.ExCtx Δ)
+  → (comp : comp-Γ Γr Γc)
+  → (x : RT.ExVar Γr)
+  → Σ (Ty Δ) λ T
+    → Σ (CT.ExVar Γc T) λ cx
+    → comp-var comp x cx
+
+mk-var (Γc ▷ T) (comp-▷ _) zero = T , Zᵉ , comp-Z
+mk-var (Γc ▷ _) (comp-▷ comp) (suc x)
+  with mk-var Γc comp x
+... | T , cx , cx-comp = T , Sᵉ cx , comp-S cx-comp
+
+-- bidirectional type checking
+
+synth : ∀ {Δ : TyCtx} {Γr : RT.ExCtx}
+  → (rt : RT.Ex Δ Γr)
+  → (Γc : CT.ExCtx Δ)
+  → (Ψ : Subset Δ)
+  → (comp : comp-Γ Γr Γc)
+  → Dec (Σ (Ty Δ) λ T →
+         Σ (CT.Ex {Δ}{Ψ} Γc T) λ ct →
+         comp-E comp rt ct )
+
+check : ∀ {Δ : TyCtx} {Γr : RT.ExCtx}
+  → (rt : RT.Ex Δ Γr)
+  → (Γc : CT.ExCtx Δ)
+  → (Ψ : Subset Δ)
+  → (comp : comp-Γ Γr Γc)
+  → (ℓ : Label)
+  → (T : Ty Δ)
+  → Dec (Σ (Ty Δ) λ V →
+         Σ (CT.Ex {Δ}{Ψ} Γc V) λ ct →
+         (Ψ ∣ ℓ ⊢ V ~ T) × comp-E comp rt ct)
+
+synth (` x) Γc Ψ comp
+  with mk-var Γc comp x
+... | T , cx , cx-comp = yes (T , ` cx , comp-` cx-comp)
+
+synth (cst b) Γc Ψ comp = yes ((‵ b .proj₁) , CT.cst b , comp-cst)
+
+synth {Δ} (λx: T ⇒ rt) Γc Ψ comp
+  with synth rt (Γc ▷ T) Ψ (comp-▷ comp)
+... | yes (U , ct-body , comp-body) = yes ((T ⇒ U) , (λx: T ⇒ ct-body) , comp-λ comp-body)
+... | no ¬ih = no (neg-body ¬ih)
+    where
+      neg-body :
+        ¬ Σ (Ty Δ) (λ U → Σ (CT.Ex{Ψ = Ψ} (Γc ▷ T) U) (comp-E (comp-▷ comp) rt))
+        → Σ (Ty Δ) (λ T₁ → Σ (CT.Ex{Ψ = Ψ} Γc T₁) (comp-E comp (λx: T ⇒ rt)))
+        → ⊥
+      neg-body ¬ih (_ , λx: T ⇒ ct-body , comp-λ comp-body) = ¬ih (_ , ct-body , comp-body)
+
+synth (app ℓ rt rt₁) Γc Ψ comp
+  with synth rt Γc Ψ comp
+... | no ¬ih-f = no λ
+  { (_ , _ , comp-app {S = sTy} {ct = ct-f′} func-ok comp-f′ comp-a) →
+    ¬ih-f (sTy , ct-f′ , comp-f′) }
+... | yes (A , ct-f , comp-f)
+  with ~-func {Ψ = Ψ} {ℓ = ℓ} A
+     | inspect (λ A → ~-func {Ψ = Ψ} {ℓ = ℓ} A) A
+... | no r | _ = no λ
+  { (_ , _ , comp-app {S = sTy} {T = tTy} {U = uTy} {ct = ct-f′}
+                       {S~T⇒U = s~t⇒u} func-ok comp-f′ comp-a) →
+    app-no-func {Ψ = Ψ} {comp = comp} {rt = rt} {rt₁ = rt₁}
+                {A = A} {S = sTy} {T = tTy} {U = uTy}
+                {ct-f = ct-f} {ct-f′ = ct-f′} {S~T⇒U = s~t⇒u}
+                r comp-f comp-f′ }
+... | yes (T , U , A~T⇒U) | [ func-ok ]
+  with check rt₁ Γc Ψ comp ℓ T
+... | no r = no λ
+  { (_ , _ , comp-app {S = sTy} {T = tTy′} {U = uTy′} {V = vTy}
+                       {ct = ct-f′} {ct₁ = ct-a}
+                       {S~T⇒U = s~t′⇒u′} {V~T = v~t′}
+                       func-ok′ comp-f′ comp-a) →
+    app-no-arg {A = A} {S = sTy} {T = T} {U = U}
+               {T′ = tTy′} {U′ = uTy′} {V = vTy}
+               {ct-f = ct-f} {ct-f′ = ct-f′} {ct-a = ct-a}
+               {A~T⇒U = A~T⇒U} {S~T′⇒U′ = s~t′⇒u′}
+               {V~T′ = v~t′}
+               r func-ok func-ok′ comp-f comp-f′ comp-a }
+... | yes (V , ct-a , V~T , comp-a) =
+  yes (U , app ct-f A~T⇒U ct-a V~T ,
+       comp-app {S = A} {T = T} {U = U} {V = V}
+                {S~T⇒U = A~T⇒U} {V~T = V~T}
+                func-ok comp-f comp-a)
+
+synth (ΛX rt) Γc Ψ comp
+  with synth rt (renameᵉ Sᵗ Γc) (outside ∷ Ψ) (rename-comp-Γ Sᵗ comp)
+... | no r = no λ
+  { (_ , _ , comp-ΛX {ct = ct-body} comp-body) →
+    r (_ , ct-body , comp-body) }
+... | yes (B , ct-body , comp-body) = yes (`∀ B , ΛX ct-body , comp-ΛX comp-body)
+
+synth (tapp ℓ rt U) Γc Ψ comp
+  with synth rt Γc Ψ comp
+... | no r = no λ
+  { (_ , _ , comp-tapp {S = sTy} {ct = ct-body} poly-ok comp-body) →
+    r (sTy , ct-body , comp-body) }
+... | yes (A , ct-body , comp-body)
+  with ~-poly {Ψ = Ψ} {ℓ = ℓ} A
+     | inspect (λ A → ~-poly {Ψ = Ψ} {ℓ = ℓ} A) A
+... | no r | _ = no λ
+  { (_ , _ , comp-tapp {S = sTy} {T = bTy} {ct = ct-body′}
+                         {S~∀T = s~∀b} poly-ok comp-body′) →
+    tapp-no-poly {A = A} {S = sTy} {B = bTy}
+                 {ct = ct-body} {ct′ = ct-body′} {S~∀B = s~∀b}
+                 r comp-body comp-body′ }
+... | yes (B , A~∀B) | [ poly-ok ] =
+  yes (B [ U ]ᵗ , tapp ct-body A~∀B U , comp-tapp poly-ok comp-body)
+
+check rt Γc Ψ comp ℓ T
+  with synth rt Γc Ψ comp
+... | no ¬Tct = no λ { (V , ct , V~T , comp-ct) →
+  ¬Tct (V , ct , comp-ct) }
+... | yes (U , ct , comp-ct)
+  with A~B? {Ψ = Ψ} {ℓ = ℓ} U T
+... | yes U~T = yes (U , ct , U~T , comp-ct)
+... | no ¬U~T = no λ { (V , ct′ , V~T , comp-ct′) →
+  ¬U~T (substEq (λ X → Ψ ∣ ℓ ⊢ X ~ T)
+                (sym (comp-E-type-unique comp-ct comp-ct′))
+                V~T) }

--- a/GTSF-PT/Types.agda
+++ b/GTSF-PT/Types.agda
@@ -1,0 +1,165 @@
+-- File Charter:
+--   * Core syntax and primitive operations for types and type contexts.
+--   * Primary exports are type variables, types, ground types, renaming,
+--     substitution, and single-variable type substitution.
+--   * Depends only on standard-library data and equality utilities.
+
+module Types where
+
+-- Note to self:
+--   * Put new lemmas/proofs in the most specific module, not here, unless they are
+--     definitional properties of these core operations.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Sigma using (Σ; _,_)
+open import Data.Empty using (⊥)
+open import Data.List using (List; []; _∷_; _++_; map; length)
+open import Data.Bool using (Bool)
+open import Data.Nat using (ℕ; _<_; zero; suc)
+open import Data.Fin using (Fin; zero; suc)
+open import Data.Product using (_×_; _,_)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Binary.PropositionalEquality using (cong)
+
+------------------------------------------------------------------------
+-- Variables, contexts, base types
+------------------------------------------------------------------------
+
+Var : Set
+Var = ℕ
+
+TyCtx : Set
+TyCtx = ℕ
+
+data TyVar : (Δ : TyCtx) → Set where
+  Zᵗ : ∀{Δ} → TyVar (suc Δ)
+  Sᵗ : ∀{Δ}
+     → TyVar Δ
+       --------------
+     → TyVar (suc Δ)
+
+tyVarToFin : ∀ {Δ} → TyVar Δ → Fin Δ
+tyVarToFin Zᵗ = zero
+tyVarToFin (Sᵗ X) = suc (tyVarToFin X)
+
+data Base : Set where
+  `ℕ  : Base
+  `𝔹  : Base
+
+infixr 7 _⇒_
+infix  6 `∀
+
+data Ty : TyCtx → Set where
+  ＇_  : ∀{Δ} (X : TyVar Δ) → Ty Δ
+  ‵_   : ∀{Δ} → (ι : Base) → Ty Δ
+  `★   : ∀{Δ} → Ty Δ
+  _⇒_  : ∀{Δ} → Ty Δ → Ty Δ → Ty Δ
+  `∀   : ∀{Δ} → Ty (suc Δ) → Ty Δ
+
+data Cross : ∀{Δ} → Ty Δ → Set where
+  ＇_ : ∀{Δ} (X : TyVar Δ) → Cross{Δ} (＇ X)
+  ‵_ : ∀{Δ} → (ι : Base) → Cross{Δ} (‵ ι)
+  _⇒_ : ∀{Δ} → (A : Ty Δ) → (B : Ty Δ) → Cross (A ⇒ B)
+  `∀  : ∀{Δ} → (A : Ty (suc Δ)) → Cross (`∀ A)
+
+data Ground : ∀{Δ} → Ty Δ → Set where
+  ‵_ : ∀{Δ} → (ι : Base) → Ground{Δ} (‵ ι)
+  ★⇒★ : ∀{Δ} → Ground{Δ} (`★ ⇒ `★)
+
+infix 4 _≟Base_
+_≟Base_ : (ι ι′ : Base) → Dec (ι ≡ ι′)
+`ℕ ≟Base `ℕ = yes refl
+`ℕ ≟Base `𝔹 = no (λ ())
+`𝔹 ≟Base `ℕ = no (λ ())
+`𝔹 ≟Base `𝔹 = yes refl
+
+infix 4 _≟Ground_
+_≟Ground_ :
+  ∀{Δ}{G H : Ty Δ} →
+  Ground G →
+  Ground H →
+  Dec (G ≡ H)
+(‵ ι) ≟Ground (‵ ι′) with ι ≟Base ι′
+... | yes eq = yes (cong ‵_ eq)
+... | no neq = no (λ { refl → neq refl })
+(‵ ι) ≟Ground ★⇒★ = no (λ ())
+★⇒★ ≟Ground (‵ ι) = no (λ ())
+★⇒★ ≟Ground ★⇒★ = yes refl
+
+Ctx : TyCtx → Set
+Ctx Δ = List (Ty Δ)
+
+------------------------------------------------------------------------
+-- Type-variable substitution (de Bruijn X)
+------------------------------------------------------------------------
+
+Renameᵗ : TyCtx → TyCtx → Set
+Renameᵗ Δ Δ′ = TyVar Δ → TyVar Δ′
+
+Substᵗ : TyCtx → TyCtx → Set
+Substᵗ Δ Δ′ = TyVar Δ → Ty Δ′
+
+extᵗ : ∀{Δ}{Δ′} → Renameᵗ Δ Δ′ → Renameᵗ (suc Δ) (suc Δ′)
+extᵗ ρ Zᵗ = Zᵗ
+extᵗ ρ (Sᵗ X) = Sᵗ (ρ X)
+
+renameᵗ : ∀ {Δ}{Δ′} → Renameᵗ Δ Δ′ → Ty Δ → Ty Δ′
+renameᵗ ρ (＇ X) = ＇ (ρ X)
+renameᵗ ρ (‵ ι) = ‵ ι
+renameᵗ ρ `★ = `★
+renameᵗ ρ (A ⇒ B) = renameᵗ ρ A ⇒ renameᵗ ρ B
+renameᵗ ρ (`∀ A) = `∀ (renameᵗ (extᵗ ρ) A)
+
+extsᵗ : ∀ {Δ}{Δ′} → Substᵗ Δ Δ′ → Substᵗ (suc Δ) (suc Δ′)
+extsᵗ σ Zᵗ = ＇ Zᵗ
+extsᵗ σ (Sᵗ X) = renameᵗ Sᵗ (σ X)
+
+substᵗ : ∀ {Δ}{Δ′} → Substᵗ Δ Δ′ → Ty Δ → Ty Δ′
+substᵗ σ (＇ X) = σ X
+substᵗ σ (‵ ι) = ‵ ι
+substᵗ σ `★ = `★
+substᵗ σ (A ⇒ B) = substᵗ σ A ⇒ substᵗ σ B
+substᵗ σ (`∀ A) = `∀ (substᵗ (extsᵗ σ) A)
+
+singleTyEnv : ∀ {Δ} → Ty Δ → Substᵗ (suc Δ) Δ
+singleTyEnv B Zᵗ    = B
+singleTyEnv B (Sᵗ X) = ＇ X
+
+infixl 8 _[_]ᵗ
+_[_]ᵗ : ∀ {Δ} → Ty (suc Δ) → Ty Δ → Ty Δ
+A [ B ]ᵗ = substᵗ (singleTyEnv B) A
+
+------------------------------------------------------------------------
+-- Lift closed store types (Ty 0) into an arbitrary Δ
+------------------------------------------------------------------------
+
+lift0ᵗ : ∀{Δ} → Renameᵗ 0 Δ
+lift0ᵗ ()
+
+wkTy0 : ∀{Δ} → Ty 0 → Ty Δ
+wkTy0 = renameᵗ lift0ᵗ
+
+wkTy : ∀ {Δ} → Ty Δ → Ty (suc Δ)
+wkTy = renameᵗ Sᵗ
+
+------------------------------------------------------------------------
+-- Lookup term variable in context
+------------------------------------------------------------------------
+
+infix 4 _∋_⦂_
+
+data _∋_⦂_ : ∀{Δ} → Ctx Δ → Var → Ty Δ → Set where
+  Z : ∀{Δ}{Γ : Ctx Δ}{A : Ty Δ} →
+      (A ∷ Γ) ∋ zero ⦂ A
+
+  S : ∀{Δ}{Γ : Ctx Δ}{A B : Ty Δ}{x : Var} →
+      Γ ∋ x ⦂ A →
+      (B ∷ Γ) ∋ suc x ⦂ A
+
+----------------------------------------------------------------------
+-- base type interpretation
+----------------------------------------------------------------------
+
+base-type : Base → Set
+base-type `ℕ = ℕ
+base-type `𝔹 = Bool


### PR DESCRIPTION
Summary:
- Adds GTSF-PT Agda modules for types, source/raw/coercion terms, consistency, coercions, compilation, type checking, and reduction.
- Adds top-of-file charters and fixes the tag/untag-bad reduction rule holes.

Validation:
- agda -i GTSF-PT GTSF-PT/TypeCheck.agda
- agda -i GTSF-PT GTSF-PT/Compile.agda
- agda -i GTSF-PT GTSF-PT/Reduction.agda