### PR TITLE
[codex] Add strict coercion modes for GTSF

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -1,9 +1,10 @@
 module All where
 
 -- File Charter:
---   * Aggregate checker for the public GTSF metatheory modules.
+--   * Aggregate checker for the public GTSF metatheory and compiler modules.
 --   * Imports both the original and Nu metatheory wrappers so that a single
---     Agda invocation checks both developments.
+--     Agda invocation checks both developments, plus the compiler path.
 
+import Compile
 import MetaTheory
 import NuMetaTheory

--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -1,0 +1,9 @@
+module All where
+
+-- File Charter:
+--   * Aggregate checker for the public GTSF metatheory modules.
+--   * Imports both the original and Nu metatheory wrappers so that a single
+--     Agda invocation checks both developments.
+
+import MetaTheory
+import NuMetaTheory

--- a/GTSF/Coercions.agda
+++ b/GTSF/Coercions.agda
@@ -186,9 +186,6 @@ mutual
   tagTyAllowed μ (A ⇒ B) = tyAllowed μ A ∧ tyAllowed μ B
   tagTyAllowed μ (`∀ A) = tyAllowed (extᵈ μ) A
 
-sealTyAllowed : DualEnv → TyVar → Bool
-sealTyAllowed μ α = sealModeAllowed (μ α)
-
 dualTag : DualEnv → Ty → Coercion
 dualTag μ (＇ α) with μ α
 dualTag μ (＇ α) | tag-to-seal = seal ★ α
@@ -223,20 +220,20 @@ dualUnseal μ α A | tag-to-seal = (＇ α) ？
 
 infix 8 -_
 
-dualWith : DualEnv → Coercion → Coercion
-dualWith μ (id A) = id A
-dualWith μ (c ︔ d) = dualWith μ d ︔ dualWith μ c
-dualWith μ (c ↦ d) = dualWith μ c ↦ dualWith μ d
-dualWith μ (`∀ c) = `∀ (dualWith (extᵈ μ) c)
-dualWith μ (G !) = dualTag μ G
-dualWith μ (G ？) = dualUntag μ G
-dualWith μ (seal A α) = dualSeal μ A α
-dualWith μ (unseal α A) = dualUnseal μ α A
-dualWith μ (gen A c) = inst A (dualWith (genᵈ μ) c)
-dualWith μ (inst B c) = gen B (dualWith (instᵈ μ) c)
+dual : DualEnv → Coercion → Coercion
+dual μ (id A) = id A
+dual μ (c ︔ d) = dual μ d ︔ dual μ c
+dual μ (c ↦ d) = dual μ c ↦ dual μ d
+dual μ (`∀ c) = `∀ (dual (extᵈ μ) c)
+dual μ (G !) = dualTag μ G
+dual μ (G ？) = dualUntag μ G
+dual μ (seal A α) = dualSeal μ A α
+dual μ (unseal α A) = dualUnseal μ α A
+dual μ (gen A c) = inst A (dual (genᵈ μ) c)
+dual μ (inst B c) = gen B (dual (instᵈ μ) c)
 
 -_ : Coercion → Coercion
--_ = dualWith normalᵈ
+-_ = dual normalᵈ
 
 ⇑ᶜ : Coercion → Coercion
 ⇑ᶜ = renameᶜ suc
@@ -254,7 +251,7 @@ data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty �
 
   cast-id : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A : Ty}
     → WfTy Δ A
-    → {ok : tyAllowed μ A ≡ true}
+    → tyAllowed μ A ≡ true
     -- fvs(A) ∩ dom(Σ) = ∅
      -------------------
     → μ ∣ Δ ∣ Σ ⊢ id A ∶ A =⇒ A
@@ -262,16 +259,16 @@ data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty �
   cast-seal : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{α : TyVar}{A : Ty}
     → WfTy Δ A
     → (α , A) ∈ Σ
-    → {A-ok : tyAllowed μ A ≡ true}
-    → {α-ok : sealTyAllowed μ α ≡ true}
+    → tyAllowed μ A ≡ true
+    → sealModeAllowed (μ α) ≡ true
      ---------------------------
     → μ ∣ Δ ∣ Σ ⊢ seal A α ∶ A =⇒ (＇ α)
 
   cast-unseal : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{α : TyVar}{A : Ty}
     → WfTy Δ A
     → (α , A) ∈ Σ
-    → {A-ok : tyAllowed μ A ≡ true}
-    → {α-ok : sealTyAllowed μ α ≡ true}
+    → tyAllowed μ A ≡ true
+    → sealModeAllowed (μ α) ≡ true
      -----------------------------
     → μ ∣ Δ ∣ Σ ⊢ unseal α A ∶ (＇ α) =⇒ A
 
@@ -285,7 +282,7 @@ data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty �
   cast-tag : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{G : Ty}
     → WfTy Δ G
     → Ground G
-    → {ok : tagTyAllowed μ G ≡ true}
+    → tagTyAllowed μ G ≡ true
     -- If G is α, then α ∉ dom(Σ)
      ---------------------
     → μ ∣ Δ ∣ Σ ⊢ G ! ∶ G =⇒ ★
@@ -293,7 +290,7 @@ data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty �
   cast-untag : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{H : Ty}
     → WfTy Δ H
     → Ground H
-    → {ok : tagTyAllowed μ H ≡ true}
+    → tagTyAllowed μ H ≡ true
      -----------------------
     → μ ∣ Δ ∣ Σ ⊢ H ？ ∶ ★ =⇒ H
 
@@ -311,7 +308,7 @@ data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty �
   -- ν̅ 
   cast-inst : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
     → WfTy Δ B
-    → {B-ok : tyAllowed μ B ≡ true}
+    → tyAllowed μ B ≡ true
     → instᵈ μ ∣ suc Δ ∣ (0 , ★) ∷ ⟰ᵗ Σ ⊢ s ∶ A =⇒ ⇑ᵗ B
      ----------------------------------------
     → μ ∣ Δ ∣ Σ ⊢ (inst B s) ∶ (`∀ A) =⇒ B
@@ -319,7 +316,7 @@ data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty �
   -- ν
   cast-gen : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
     → WfTy Δ A
-    → {A-ok : tyAllowed μ A ≡ true}
+    → tyAllowed μ A ≡ true
     → genᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ ⇑ᵗ A =⇒ B
      ----------------------------------
     → μ ∣ Δ ∣ Σ ⊢ (gen A s) ∶ A =⇒ (`∀ B)

--- a/GTSF/Coercions.agda
+++ b/GTSF/Coercions.agda
@@ -3,6 +3,7 @@
 module Coercions where
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (Bool; false; true; _∧_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List using (List; []; _∷_; _++_; length; replicate; map)
 open import Data.Nat using (ℕ; _<_; zero; suc; z<s; s<s)
@@ -131,6 +132,63 @@ instᵈ : DualEnv → DualEnv
 instᵈ μ zero = seal-to-tag
 instᵈ μ (suc X) = μ X
 
+mode≤ : DualMode → DualMode → Bool
+mode≤ normal normal = true
+mode≤ normal tag-to-seal = false
+mode≤ normal seal-to-tag = false
+mode≤ tag-to-seal normal = true
+mode≤ tag-to-seal tag-to-seal = true
+mode≤ tag-to-seal seal-to-tag = false
+mode≤ seal-to-tag normal = true
+mode≤ seal-to-tag tag-to-seal = false
+mode≤ seal-to-tag seal-to-tag = true
+
+ModeIncl : DualEnv → DualEnv → Set
+ModeIncl μ ν = ∀ X → mode≤ (μ X) (ν X) ≡ true
+
+modeIncl-refl : ∀ {μ} → ModeIncl μ μ
+modeIncl-refl {μ} X with μ X
+modeIncl-refl X | normal = refl
+modeIncl-refl X | tag-to-seal = refl
+modeIncl-refl X | seal-to-tag = refl
+
+modeIncl-normal : ∀ {μ} → ModeIncl μ normalᵈ
+modeIncl-normal {μ = μ} X with μ X
+modeIncl-normal X | normal = refl
+modeIncl-normal X | tag-to-seal = refl
+modeIncl-normal X | seal-to-tag = refl
+
+tagModeAllowed : DualMode → Bool
+tagModeAllowed normal = true
+tagModeAllowed tag-to-seal = true
+tagModeAllowed seal-to-tag = false
+
+sealModeAllowed : DualMode → Bool
+sealModeAllowed normal = true
+sealModeAllowed tag-to-seal = false
+sealModeAllowed seal-to-tag = true
+
+mutual
+  tyAllowed : DualEnv → Ty → Bool
+  tyAllowed μ (＇ α) with μ α
+  tyAllowed μ (＇ α) | normal = true
+  tyAllowed μ (＇ α) | tag-to-seal = false
+  tyAllowed μ (＇ α) | seal-to-tag = false
+  tyAllowed μ (‵ ι) = true
+  tyAllowed μ ★ = true
+  tyAllowed μ (A ⇒ B) = tyAllowed μ A ∧ tyAllowed μ B
+  tyAllowed μ (`∀ A) = tyAllowed (extᵈ μ) A
+
+  tagTyAllowed : DualEnv → Ty → Bool
+  tagTyAllowed μ (＇ α) = tagModeAllowed (μ α)
+  tagTyAllowed μ (‵ ι) = true
+  tagTyAllowed μ ★ = true
+  tagTyAllowed μ (A ⇒ B) = tyAllowed μ A ∧ tyAllowed μ B
+  tagTyAllowed μ (`∀ A) = tyAllowed (extᵈ μ) A
+
+sealTyAllowed : DualEnv → TyVar → Bool
+sealTyAllowed μ α = sealModeAllowed (μ α)
+
 dualTag : DualEnv → Ty → Coercion
 dualTag μ (＇ α) with μ α
 dualTag μ (＇ α) | tag-to-seal = seal ★ α
@@ -190,71 +248,85 @@ c [ X ]ᶜ = renameᶜ (singleRenameᵗ X) c
 -- Typing
 ------------------------------------------------------------------------
 
-infix 4 _∣_⊢_∶_=⇒_
+infix 4 _∣_∣_⊢_∶_=⇒_
 
-data _∣_⊢_∶_=⇒_ : TyCtx → Store → Coercion → Ty → Ty → Set where
+data _∣_∣_⊢_∶_=⇒_ : DualEnv → TyCtx → Store → Coercion → Ty → Ty → Set where
 
-  cast-id : ∀{Δ : TyCtx}{Σ : Store}{A : Ty}
+  cast-id : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A : Ty}
     → WfTy Δ A
+    → {ok : tyAllowed μ A ≡ true}
     -- fvs(A) ∩ dom(Σ) = ∅
      -------------------
-    → Δ ∣ Σ ⊢ id A ∶ A =⇒ A
+    → μ ∣ Δ ∣ Σ ⊢ id A ∶ A =⇒ A
 
-  cast-seal : ∀{Δ : TyCtx}{Σ : Store}{α : TyVar}{A : Ty}
+  cast-seal : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{α : TyVar}{A : Ty}
     → WfTy Δ A
     → (α , A) ∈ Σ
+    → {A-ok : tyAllowed μ A ≡ true}
+    → {α-ok : sealTyAllowed μ α ≡ true}
      ---------------------------
-    → Δ ∣ Σ ⊢ seal A α ∶ A =⇒ (＇ α)
+    → μ ∣ Δ ∣ Σ ⊢ seal A α ∶ A =⇒ (＇ α)
 
-  cast-unseal : ∀{Δ : TyCtx}{Σ : Store}{α : TyVar}{A : Ty}
+  cast-unseal : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{α : TyVar}{A : Ty}
     → WfTy Δ A
     → (α , A) ∈ Σ
+    → {A-ok : tyAllowed μ A ≡ true}
+    → {α-ok : sealTyAllowed μ α ≡ true}
      -----------------------------
-    → Δ ∣ Σ ⊢ unseal α A ∶ (＇ α) =⇒ A
+    → μ ∣ Δ ∣ Σ ⊢ unseal α A ∶ (＇ α) =⇒ A
 
   -- Phil: s and t have different Σ's, they combine, with side condition
-  cast-seq : ∀{Δ : TyCtx}{Σ : Store}{A B C : Ty}{s t : Coercion}
-    → Δ ∣ Σ ⊢ s ∶ A =⇒ B
-    → Δ ∣ Σ ⊢ t ∶ B =⇒ C
+  cast-seq : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A B C : Ty}{s t : Coercion}
+    → μ ∣ Δ ∣ Σ ⊢ s ∶ A =⇒ B
+    → μ ∣ Δ ∣ Σ ⊢ t ∶ B =⇒ C
      -------------------------
-    → Δ ∣ Σ ⊢ (s ︔ t) ∶ A =⇒ C
+    → μ ∣ Δ ∣ Σ ⊢ (s ︔ t) ∶ A =⇒ C
 
-  cast-tag : ∀{Δ : TyCtx}{Σ : Store}{G : Ty}
+  cast-tag : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{G : Ty}
     → WfTy Δ G
     → Ground G
+    → {ok : tagTyAllowed μ G ≡ true}
     -- If G is α, then α ∉ dom(Σ)
      ---------------------
-    → Δ ∣ Σ ⊢ G ! ∶ G =⇒ ★
+    → μ ∣ Δ ∣ Σ ⊢ G ! ∶ G =⇒ ★
 
-  cast-untag : ∀{Δ : TyCtx}{Σ : Store}{H : Ty}
+  cast-untag : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{H : Ty}
     → WfTy Δ H
     → Ground H
+    → {ok : tagTyAllowed μ H ≡ true}
      -----------------------
-    → Δ ∣ Σ ⊢ H ？ ∶ ★ =⇒ H
+    → μ ∣ Δ ∣ Σ ⊢ H ？ ∶ ★ =⇒ H
 
-  cast-fun : ∀{Δ : TyCtx}{Σ : Store}{A A′ B B′ : Ty}{s t : Coercion}
-    → Δ ∣ Σ ⊢ s ∶ A′ =⇒ A
-    → Δ ∣ Σ ⊢ t ∶ B =⇒ B′
+  cast-fun : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A A′ B B′ : Ty}{s t : Coercion}
+    → μ ∣ Δ ∣ Σ ⊢ s ∶ A′ =⇒ A
+    → μ ∣ Δ ∣ Σ ⊢ t ∶ B =⇒ B′
      ---------------------------------------
-    → Δ ∣ Σ ⊢ (s ↦ t) ∶ (A ⇒ B) =⇒ (A′ ⇒ B′)
+    → μ ∣ Δ ∣ Σ ⊢ (s ↦ t) ∶ (A ⇒ B) =⇒ (A′ ⇒ B′)
 
-  cast-all : ∀{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
-    → suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ A =⇒ B
+  cast-all : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
+    → extᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ A =⇒ B
      ----------------------------------
-    → Δ ∣ Σ ⊢ (`∀ s) ∶ (`∀ A) =⇒ (`∀ B)
+    → μ ∣ Δ ∣ Σ ⊢ (`∀ s) ∶ (`∀ A) =⇒ (`∀ B)
 
   -- ν̅ 
-  cast-inst : ∀{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
+  cast-inst : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
     → WfTy Δ B
-    → suc Δ ∣ (0 , ★) ∷ ⟰ᵗ Σ ⊢ s ∶ A =⇒ ⇑ᵗ B
+    → {B-ok : tyAllowed μ B ≡ true}
+    → instᵈ μ ∣ suc Δ ∣ (0 , ★) ∷ ⟰ᵗ Σ ⊢ s ∶ A =⇒ ⇑ᵗ B
      ----------------------------------------
-    → Δ ∣ Σ ⊢ (inst B s) ∶ (`∀ A) =⇒ B
+    → μ ∣ Δ ∣ Σ ⊢ (inst B s) ∶ (`∀ A) =⇒ B
 
   -- ν
-  cast-gen : ∀{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
+  cast-gen : ∀{μ : DualEnv}{Δ : TyCtx}{Σ : Store}{A B : Ty}{s : Coercion}
     → WfTy Δ A
-    → suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ ⇑ᵗ A =⇒ B
+    → {A-ok : tyAllowed μ A ≡ true}
+    → genᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ s ∶ ⇑ᵗ A =⇒ B
      ----------------------------------
-    → Δ ∣ Σ ⊢ (gen A s) ∶ A =⇒ (`∀ B)
+    → μ ∣ Δ ∣ Σ ⊢ (gen A s) ∶ A =⇒ (`∀ B)
+
+infix 4 _∣_⊢_∶_=⇒_
+
+_∣_⊢_∶_=⇒_ : TyCtx → Store → Coercion → Ty → Ty → Set
+Δ ∣ Σ ⊢ c ∶ A =⇒ B = normalᵈ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
 
   

--- a/GTSF/Compile.agda
+++ b/GTSF/Compile.agda
@@ -2,7 +2,7 @@ module Compile where
 
 -- File Charter:
 --   * Compilation from source gradual GTSF terms to target explicit-coercion terms.
---   * Exports the maximal-lower-bound cast-plan specification, `compile`, and
+--   * Exports the common-lower-bound cast-plan specification, `compile`, and
 --     `compile-value`.
 --   * The store is empty at compile time; target reduction allocates store cells
 --     later for polymorphic/seal behavior.
@@ -20,16 +20,6 @@ open import Primitives using (Const; Prim; constTy)
 open import proof.CompileCoercions using (coerce-up; coerce-down; realizes-idᵢ)
 open import proof.ImprecisionProperties
   using (⊑-src-wf-idᵢ; ⊑-tgt-wf-idᵢ; ~-sym)
-open import proof.MaximalLowerBounds public using
-  ( CommonLowerBound
-  ; StrictlyBelow
-  ; MaximalLowerBound
-  ; lower
-  ; lower-left
-  ; lower-right
-  ; maximal
-  ; choose-mlb
-  )
 open import proof.TermProperties using (CtxWf-⤊)
 
 open import GradualTerms
@@ -82,13 +72,12 @@ open import Terms
 
 record CastPlan (Δ : TyCtx) (Σ : Store) (A B : Ty) : Set₁ where
   field
-    mlb : MaximalLowerBound Δ A B
-
+    lower : Ty
     down : Coercion
-    down⊢ : Δ ∣ Σ ⊢ down ∶ A =⇒ lower mlb
+    down⊢ : Δ ∣ Σ ⊢ down ∶ A =⇒ lower
 
     up : Coercion
-    up⊢ : Δ ∣ Σ ⊢ up ∶ lower mlb =⇒ B
+    up⊢ : Δ ∣ Σ ⊢ up ∶ lower =⇒ B
 
 open CastPlan public
 
@@ -97,21 +86,21 @@ consistency-cast-plan :
   Label →
   Δ ⊢ A ~ B →
   CastPlan Δ [] A B
-consistency-cast-plan {Δ = Δ} ℓ A~B with choose-mlb A~B
-consistency-cast-plan {Δ = Δ} ℓ A~B | mlb
+consistency-cast-plan {Δ = Δ} ℓ (C , C⊑A , C⊑B)
     with coerce-down ℓ
-           (⊑-src-wf-idᵢ (lower-left mlb))
-           (⊑-tgt-wf-idᵢ (lower-left mlb))
+           (⊑-src-wf-idᵢ C⊑A)
+           (⊑-tgt-wf-idᵢ C⊑A)
            (realizes-idᵢ Δ)
-           (lower-left mlb)
+           C⊑A
        | coerce-up ℓ
-           (⊑-src-wf-idᵢ (lower-right mlb))
-           (⊑-tgt-wf-idᵢ (lower-right mlb))
+           (⊑-src-wf-idᵢ C⊑B)
+           (⊑-tgt-wf-idᵢ C⊑B)
            (realizes-idᵢ Δ)
-           (lower-right mlb)
-consistency-cast-plan {Δ = Δ} ℓ A~B | mlb | down , down⊢ | up , up⊢ =
+           C⊑B
+consistency-cast-plan {Δ = Δ} ℓ (C , C⊑A , C⊑B)
+    | down , down⊢ | up , up⊢ =
   record
-    { mlb = mlb
+    { lower = C
     ; down = down
     ; down⊢ = down⊢
     ; up = up

--- a/GTSF/Imprecision.agda
+++ b/GTSF/Imprecision.agda
@@ -83,7 +83,7 @@ data _⊢_⊑_ (Φ : ImpCtx) : Ty → Ty → Set where
 
   ν : ∀ {A B}
     → occurs zero A ≡ true      -- Phil: keep this, need for unique derivations
-    → (0 ˣ⊑★) ∷ ⇑ᴸᵢ Φ ⊢ A ⊑ B
+    → (0 ˣ⊑★) ∷ ⇑ᵢ Φ ⊢ A ⊑ ⇑ᵗ B
     -------------------------
     → Φ ⊢ (`∀ A) ⊑ B
 

--- a/GTSF/notes.md
+++ b/GTSF/notes.md
@@ -40,48 +40,43 @@ The nominal notation below writes binders explicitly in each syntactic
 form that binds a type variable:
 
     ∀X. c[X]
-    gen β. A c[β]
-    inst β. B c[β]
+    gen β. c[β]
+    inst β. c[β]
 
-These correspond to the Agda constructors ``∀``, ``gen A c``, and
-``inst B c``; the displayed variable marks the scope that Agda handles
-with ``extᵗ`` in renaming and substitution.
+These correspond to the Agda constructors ``∀``, ``gen``, and
+``inst``; the displayed variable marks the scope that Agda handles
+with ``extᵗ`` in renaming and substitution.  The informal forms omit
+the endpoint annotations carried by the Agda constructors.
 
 Concrete preservation problem: ``gen``
 -------------------------------------
 
-Consider the body coercion
+Consider a ``gen`` coercion whose body is ``β ？``:
 
-    c[β] = (＇ β) ？
-
-under a ``gen`` coercion:
-
-    gen β. ★ c[β]
+    gen β. (β ？)
 
 In the body of ``gen``, the newly bound variable ``β`` is intended to be
 tag-like.  The body coercion has shape
 
-    Δ, β ∣ Σ ⊢ (＇ β) ？ ∶ ★ =⇒ β
+    Δ, β ∣ Σ ⊢ β ？ ∶ ★ =⇒ β
 
 because ``β`` is bound by the coercion and is not a store seal in
 ``Σ``.  Thus
 
-    Δ ∣ Σ ⊢ gen β. ★ c[β] ∶ ★ =⇒ ∀β.β
+    Δ ∣ Σ ⊢ gen β. (β ？) ∶ ★ =⇒ ∀β.β
 
 The Nu reduction rule for ``gen`` is
 
-    V ⟨ gen β. C c[β] ⟩ • α  —→  V ⟨ c[α] ⟩
+    V ⟨ gen β. c[β] ⟩ • α  —→  V ⟨ c[α] ⟩
 
 so the example reduces to
 
-    V ⟨ gen β. ★ c[β] ⟩ • α
+    V ⟨ gen β. (β ？) ⟩ • α
       —→
-    V ⟨ c[α] ⟩
-      =
-    V ⟨ (＇ α) ？ ⟩
+    V ⟨ α ？ ⟩
 
 If ``α`` is already in the store, the cambridge22 side condition for
-``tag_α``/``-tag_α`` rejects the reduct coercion ``(＇ α) ？``.  But the
+``tag_α``/``-tag_α`` rejects the reduct coercion ``α ？``.  But the
 source term can be well typed: the ``gen`` body only mentioned the
 bound variable ``β`` in its tag-like role.  Preservation would need
 to show that opening a tag-like bound variable at an arbitrary in-scope
@@ -92,13 +87,13 @@ tracking whether the occurrence came from the tag-like ``gen`` binder.
 
 The same issue appears in the older store-allocating reduction rule:
 
-    Σ ∣ V ⟨ gen β. C c[β] ⟩ ⦂∀ B • A
+    Σ ∣ V ⟨ gen β. c[β] ⟩ ⦂∀ B • A
       —→
     (α , A) ∷ Σ ∣ V ⟨ c[α] ⟩ ⟨ reveal B[α] α A ⟩
 
 Here ``α`` is fresh for the old store ``Σ``, but the reduct is typed in
 the new store ``(α , A) ∷ Σ``.  Thus a reduct coercion such as
-``(＇ α) ？`` is again rejected by the side condition precisely because
+``α ？`` is again rejected by the side condition precisely because
 preservation has moved to the store that now contains ``α``.
 
 Concrete preservation problem: ``inst``
@@ -108,9 +103,7 @@ Now consider the opposite binder.  In an ``inst`` coercion, the freshly
 bound variable is seal-like, because type instantiation creates an
 abstract runtime representation.  For example:
 
-    d[β] = seal ★ β ︔ unseal β ★
-
-    inst β. ★ d[β]
+    inst β. (seal ★ β ︔ unseal β ★)
 
 The body coercion is typed under a store extended with the new
 ``β`` seal:
@@ -120,7 +113,7 @@ The body coercion is typed under a store extended with the new
 
 The Nu reduction rule is
 
-    V ⟨ inst β. B c[β] ⟩
+    V ⟨ inst β. c[β] ⟩
       —→
     ν β := ★. ((V • β) ⟨ c[β] ⟩)
 
@@ -148,7 +141,7 @@ Why the mode context solves preservation
 ----------------------------------------
 
 The mode-based design replaces the global store-domain side condition
-with a local mode context:
+with a local mode context μ:
 
     μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
 
@@ -181,24 +174,33 @@ store-domain side condition:
 
     genᵈ μ ∣ Δ, β ∣ Σ ⊢ c[β] ∶ A =⇒ B[β]
     ------------------------------------------------
-    μ ∣ Δ ∣ Σ ⊢ gen β. A c[β] ∶ A =⇒ ∀β.B[β]
+    μ ∣ Δ ∣ Σ ⊢ gen β. c[β] ∶ A =⇒ ∀β.B[β]
 
     instᵈ μ ∣ Δ, β ∣ (β , ★) ∷ Σ
       ⊢ c[β] ∶ A[β] =⇒ B
     ------------------------------------------------
-    μ ∣ Δ ∣ Σ ⊢ inst β. B c[β] ∶ ∀β.A[β] =⇒ B
+    μ ∣ Δ ∣ Σ ⊢ inst β. c[β] ∶ ∀β.A[β] =⇒ B
 
 Here ``β`` is chosen fresh, so types from the surrounding scope can be
 used under the binder without writing an explicit shift.
 
-The side checks are now mode checks:
+The side checks are now mode checks.  Writing ``TyOK_μ``,
+``TagOK_μ``, and ``SealOK_μ`` for the corresponding Agda checks
+``tyAllowed μ``, ``tagTyAllowed μ``, and ``sealModeAllowed ∘ μ``:
 
-* ``tyAllowed μ A`` says that endpoint type ``A`` does not mention a
-  currently special variable in an ordinary way.
-* ``tagTyAllowed μ G`` permits a variable ground type only in ``normal``
-  or ``tag-to-seal`` mode.
-* ``sealModeAllowed (μ α)`` permits ``seal``/``unseal`` only in ``normal``
-  or ``seal-to-tag`` mode.
+    TyOK_μ(＇ α)       ≜  μ(α) = normal
+    TyOK_μ(‵ ι)       ≜  ⊤
+    TyOK_μ(★)         ≜  ⊤
+    TyOK_μ(A ⇒ B)     ≜  TyOK_μ(A) ∧ TyOK_μ(B)
+    TyOK_μ(∀X. A[X])  ≜  TyOK_{μ, X : normal}(A[X])
+
+    TagOK_μ(＇ α)       ≜  μ(α) = normal ∨ μ(α) = tag-to-seal
+    TagOK_μ(‵ ι)       ≜  ⊤
+    TagOK_μ(★)         ≜  ⊤
+    TagOK_μ(A ⇒ B)     ≜  TyOK_μ(A) ∧ TyOK_μ(B)
+    TagOK_μ(∀X. A[X])  ≜  TyOK_{μ, X : normal}(A[X])
+
+    SealOK_μ(α)  ≜  μ(α) = normal ∨ μ(α) = seal-to-tag
 
 This is enough for preservation because opening and mode-renaming now
 have mode-aware lemmas.
@@ -250,7 +252,7 @@ from ``A`` to ``B``, then its dual is well typed from ``B`` to ``A``:
 
 The theorem is false for raw coercions.  For example, the raw coercion
 
-    gen β. ★ (seal (‵ `ℕ) β)
+    gen β. (seal (‵ `ℕ) β)
 
 is not well typed, and indeed duality is not an involution on that raw
 term.  The typing discipline is what makes duality meaningful.
@@ -268,12 +270,12 @@ swaps the representation of the bound variable:
 
 For the concrete typed coercion
 
-    inst β. ★ (seal ★ β ︔ unseal β ★)
+    inst β. (seal ★ β ︔ unseal β ★)
       : ∀β.★ =⇒ ★
 
 the dual is
 
-    gen β. ★ (((＇ β) ？) ︔ ((＇ β) !))
+    gen β. ((β ？) ︔ (β !))
       : ★ =⇒ ∀β.★
 
 The source body is legal because ``β`` is in ``seal-to-tag`` mode and
@@ -314,30 +316,30 @@ proved structurally over the coercion typing derivation.
 Suggested changes to the cambridge22 coercion typing presentation
 ----------------------------------------------------------------
 
-The cambridge22 notes should keep the existing coercion typing shape:
+The cambridge22 notes have this coercion typing shape:
 
     c : A =⇒_Σ B
 
-The only suggested presentation change is to refine this judgment with
-a mode context when stating the side conditions:
+The suggested change is to refine this judgment with a mode context
+when stating the side conditions:
 
     μ ⊢ c : A =⇒_Σ B
 
-The store ``Σ`` stays as the subscript on the arrow, and no separate
-type-variable context needs to be introduced.  The unqualified judgment
-can be read as the normal-mode instance, where every free type variable
-that is not specially bound by a coercion rule is ordinary:
+The unqualified judgment can be read as the normal-mode instance,
+where every free type variable that is not specially bound by a
+coercion rule is ordinary:
 
     c : A =⇒_Σ B
       means
     normal ⊢ c : A =⇒_Σ B
 
-The mode context only records how variables bound by coercion structure
-may be used inside the body coercion:
+The mode context records how variables bound by coercion structure may
+be used inside the body coercion:
 
-    μ, X : normal   -- the variable bound by ∀X. c[X]
-    μ, α : tag      -- α may occur as tag_α or -tag_α
-    μ, α : seal     -- α may occur as seal_α or -seal_α
+    μ, X : normal   -- the variable bound by ∀X. c[X],
+                    --    may occur in id, tags, and seals
+    μ, α : tag      -- α may occur in tags, but not in seals and id
+    μ, α : seal     -- α may occur in seals, but not in tags and id
 
 Equivalently, the existing informal annotations
 ``c[tag_α]`` and ``c[seal_α]`` become tracked side conditions rather
@@ -349,25 +351,34 @@ as a seal.  In ``c[seal_α]``, the bound ``α`` may occur as
 as a tag.
 
 The side conditions that currently mention ``dom(Σ)`` should be
-replaced by mode admissibility checks:
+replaced by mode admissibility checks.  In this informal presentation,
+write ``tag`` for Agda's ``tag-to-seal`` mode and ``seal`` for Agda's
+``seal-to-tag`` mode.
 
     TyOK_μ(A)
     TagOK_μ(G)
     SealOK_μ(α)
 
-``TyOK_μ(A)`` says that no variable currently in tag mode or seal mode
-appears as an ordinary type endpoint in ``A``.  Thus ``TyOK_μ(α)``
-holds when ``α`` is normal, and fails when ``α`` is the special
-variable of an enclosing ``ν α. c[tag_α]`` or ``-ν α. c[seal_α]``
-annotation.
+The admissibility checks are defined by:
 
-``TagOK_μ(G)`` says that ``G`` is legal in ``tag_G`` and ``-tag_G``.
-For variable ground types, ``TagOK_μ(α)`` holds when ``α`` is normal or
-in tag mode, and fails when ``α`` is in seal mode.
+    TyOK_μ(α)          ≜  μ(α) = normal
+    TyOK_μ(ι)          ≜  ⊤
+    TyOK_μ(★)          ≜  ⊤
+    TyOK_μ(A → B)      ≜  TyOK_μ(A) ∧ TyOK_μ(B)
+    TyOK_μ(∀X. A[X])   ≜  TyOK_{μ, X : normal}(A[X])
 
-``SealOK_μ(α)`` says that ``α`` is legal in ``seal_α`` and
-``-seal_α``.  It holds when ``α`` is normal or in seal mode, and fails
-when ``α`` is in tag mode.
+    TagOK_μ(α)         ≜  μ(α) = normal ∨ μ(α) = tag
+    TagOK_μ(ι)         ≜  ⊤
+    TagOK_μ(★)         ≜  ⊤
+    TagOK_μ(A → B)     ≜  TyOK_μ(A) ∧ TyOK_μ(B)
+    TagOK_μ(∀X. A[X])  ≜  TyOK_{μ, X : normal}(A[X])
+
+    SealOK_μ(α)        ≜  μ(α) = normal ∨ μ(α) = seal
+
+Only the ground-type instances of ``TagOK_μ`` are used by the tag and
+untag rules.  Thus ``TagOK_μ(α)`` allows ``tag_α`` exactly when ``α`` is
+normal or tag-like, and ``SealOK_μ(α)`` allows ``seal_α`` exactly when
+``α`` is normal or seal-like.
 
 With those predicates, the rules whose side conditions change are:
 

--- a/GTSF/notes.md
+++ b/GTSF/notes.md
@@ -32,9 +32,9 @@ rejected after the reduction, even though the reduction is exactly the
 one that creates the store entry needed by the operational semantics.
 
 This note uses named type variables informally.  The Agda development
-uses de Bruijn indices: a named binder ``β`` below corresponds to index
-``zero`` in the mechanization, ``Δ, β`` corresponds to ``suc Δ``, and
-``Σ↑`` corresponds to the lifted store ``⟰ᵗ Σ``.
+uses de Bruijn indices internally, so the mechanization uses shifting
+when it goes under binders.  The nominal presentation below does not
+write those shifts; it assumes bound variables are chosen fresh.
 
 The nominal notation below writes binders explicitly in each syntactic
 form that binds a type variable:
@@ -61,10 +61,10 @@ under a ``gen`` coercion:
 In the body of ``gen``, the newly bound variable ``β`` is intended to be
 tag-like.  The body coercion has shape
 
-    Δ, β ∣ Σ↑ ⊢ (＇ β) ？ ∶ ★ =⇒ β
+    Δ, β ∣ Σ ⊢ (＇ β) ？ ∶ ★ =⇒ β
 
 because ``β`` is bound by the coercion and is not a store seal in
-``Σ↑``.  Thus
+``Σ``.  Thus
 
     Δ ∣ Σ ⊢ gen β. ★ c[β] ∶ ★ =⇒ ∀β.β
 
@@ -115,14 +115,14 @@ abstract runtime representation.  For example:
 The body coercion is typed under a store extended with the new
 ``β`` seal:
 
-    instᵈ normalᵈ ∣ Δ, β ∣ (β , ★) ∷ Σ↑
+    instᵈ normalᵈ ∣ Δ, β ∣ (β , ★) ∷ Σ
       ⊢ seal ★ β ︔ unseal β ★ ∶ ★ =⇒ ★
 
 The Nu reduction rule is
 
     V ⟨ inst β. B c[β] ⟩
       —→
-    ν β := ★. (((V↑) • β) ⟨ c[β] ⟩)
+    ν β := ★. ((V • β) ⟨ c[β] ⟩)
 
 Inside the body of ``ν β := ★``, the term typing rule supplies the
 matching store entry ``(β , ★)``.  So the reduct is operationally
@@ -175,21 +175,21 @@ but it is an abbreviation for normal mode:
 The binder rules change the mode context instead of relying on a
 store-domain side condition:
 
-    extᵈ μ ∣ Δ, X ∣ Σ↑ ⊢ c[X] ∶ A[X] =⇒ B[X]
+    extᵈ μ ∣ Δ, X ∣ Σ ⊢ c[X] ∶ A[X] =⇒ B[X]
     ------------------------------------------------
     μ ∣ Δ ∣ Σ ⊢ ∀X. c[X] ∶ ∀X.A[X] =⇒ ∀X.B[X]
 
-    genᵈ μ ∣ Δ, β ∣ Σ↑ ⊢ c[β] ∶ A↑ =⇒ B[β]
+    genᵈ μ ∣ Δ, β ∣ Σ ⊢ c[β] ∶ A =⇒ B[β]
     ------------------------------------------------
     μ ∣ Δ ∣ Σ ⊢ gen β. A c[β] ∶ A =⇒ ∀β.B[β]
 
-    instᵈ μ ∣ Δ, β ∣ (β , ★) ∷ Σ↑
-      ⊢ c[β] ∶ A[β] =⇒ B↑
+    instᵈ μ ∣ Δ, β ∣ (β , ★) ∷ Σ
+      ⊢ c[β] ∶ A[β] =⇒ B
     ------------------------------------------------
     μ ∣ Δ ∣ Σ ⊢ inst β. B c[β] ∶ ∀β.A[β] =⇒ B
 
-Here ``A↑`` and ``B↑`` mean the outer type has been weakened under the
-new binder.
+Here ``β`` is chosen fresh, so types from the surrounding scope can be
+used under the binder without writing an explicit shift.
 
 The side checks are now mode checks:
 
@@ -200,12 +200,12 @@ The side checks are now mode checks:
 * ``sealTyAllowed μ α`` permits ``seal``/``unseal`` only in ``normal``
   or ``seal-to-tag`` mode.
 
-This is enough for preservation because opening and weakening now have
-mode-aware lemmas.
+This is enough for preservation because opening and mode-renaming now
+have mode-aware lemmas.
 
 For the ``gen`` example, preservation uses a lemma of this form:
 
-    μ ∣ Δ, β ∣ Σ↑ ⊢ c[β] ∶ A[β] =⇒ B[β]
+    μ ∣ Δ, β ∣ Σ ⊢ c[β] ∶ A[β] =⇒ B[β]
     ------------------------------------------------
     Δ ∣ Σ ⊢ c[α] ∶ A[α] =⇒ B[α]
 
@@ -297,13 +297,13 @@ source mode/store and target mode/store.  Its important clauses are:
 
 The binder cases extend this relation in the way duality requires:
 
-    genᵈ μ over Σ↑
+    genᵈ μ over Σ
       flips to
-    instᵈ ν over (β , ★) ∷ Π↑
+    instᵈ ν over (β , ★) ∷ Π
 
-    instᵈ μ over (β , ★) ∷ Σ↑
+    instᵈ μ over (β , ★) ∷ Σ
       flips to
-    genᵈ ν over Π↑
+    genᵈ ν over Π
 
 Thus the proof does not need to guess after the fact whether a variable
 should be a tag or a seal.  The mode context records that information

--- a/GTSF/notes.md
+++ b/GTSF/notes.md
@@ -197,7 +197,7 @@ The side checks are now mode checks:
   currently special variable in an ordinary way.
 * ``tagTyAllowed μ G`` permits a variable ground type only in ``normal``
   or ``tag-to-seal`` mode.
-* ``sealTyAllowed μ α`` permits ``seal``/``unseal`` only in ``normal``
+* ``sealModeAllowed (μ α)`` permits ``seal``/``unseal`` only in ``normal``
   or ``seal-to-tag`` mode.
 
 This is enough for preservation because opening and mode-renaming now
@@ -437,16 +437,6 @@ body with seal-like occurrences.  The preservation benefit is that
 opening no longer depends on whether the opened variable happens to be
 absent from ``dom(Σ)``; legality follows from the mode assigned by the
 binder.
-
-Open cleanup notes
-------------------
-
-Inline and remove sealTyAllowed. It's too short.
-
-Rename dualWith to dual.
-
-In the coercion typing relation, change the new side conditions
-to be explicit parameters instead of implicit.
 
 --------------------------------------------------------------------------------
 Maximal Lower Bounds

--- a/GTSF/notes.md
+++ b/GTSF/notes.md
@@ -1,4 +1,442 @@
+--------------------------------------------------------------------------------
+Strict Coercions
 
+The cambridge22 notes use store-domain side conditions to keep the
+``tag`` and ``seal`` views of a type variable from being mixed in the
+same coercion/imprecision derivation.  The intended invariant is
+roughly:
+
+* If a variable ``α`` is represented by a store seal, then coercions
+  should use ``seal_α`` and ``-seal_α``.
+* If a variable ``α`` is represented as an ordinary ground tag, then
+  coercions should use ``tag_α`` and ``-tag_α``.
+* The same variable should not be usable as both an ordinary ground tag
+  and a store seal in one derivation.
+
+The notes express this by side conditions such as:
+
+* ``id_α`` is not allowed when ``α`` is in the store.
+* ``tag_α`` and ``-tag_α`` are not allowed when ``α`` is in the store.
+* ``seal_α`` and ``-seal_α`` require ``α`` to be in the store.
+* In ``να.c[α]``, all occurrences of the bound ``α`` should be tag-like,
+  written ``c[tag_α]``.
+* In ``-να.c[α]``, all occurrences of the bound ``α`` should be
+  seal-like, written ``c[seal_α]``.
+
+Those side conditions are natural for a static description of coercions,
+but they are awkward for preservation because preservation repeatedly
+opens a binder into a store that has just gained the opened variable.
+The problem is not that a bad coercion can be typed in isolation.  The
+problem is that a coercion that is well-typed before a reduction can be
+rejected after the reduction, even though the reduction is exactly the
+one that creates the store entry needed by the operational semantics.
+
+This note uses named type variables informally.  The Agda development
+uses de Bruijn indices: a named binder ``β`` below corresponds to index
+``zero`` in the mechanization, ``Δ, β`` corresponds to ``suc Δ``, and
+``Σ↑`` corresponds to the lifted store ``⟰ᵗ Σ``.
+
+Concrete preservation problem: ``gen``
+-------------------------------------
+
+Consider the body coercion
+
+    c[β] = (＇ β) ？
+
+under a ``gen`` coercion:
+
+    gen ★ c[β]
+
+In the body of ``gen``, the newly bound variable ``β`` is intended to be
+tag-like.  The body coercion has shape
+
+    Δ, β ∣ Σ↑ ⊢ (＇ β) ？ ∶ ★ =⇒ β
+
+because ``β`` is bound by the coercion and is not a store seal in
+``Σ↑``.  Thus
+
+    Δ ∣ Σ ⊢ gen ★ c[β] ∶ ★ =⇒ ∀β.β
+
+The Nu reduction rule for ``gen`` is
+
+    V ⟨ gen C c[β] ⟩ • α  —→  V ⟨ c[α] ⟩
+
+so the example reduces to
+
+    V ⟨ gen ★ c[β] ⟩ • α
+      —→
+    V ⟨ c[α] ⟩
+      =
+    V ⟨ (＇ α) ？ ⟩
+
+If ``α`` is already in the store, the cambridge22 side condition for
+``tag_α``/``-tag_α`` rejects the reduct coercion ``(＇ α) ？``.  But the
+source term can be well typed: the ``gen`` body only mentioned the
+bound variable ``β`` in its tag-like role.  Preservation would need
+to show that opening a tag-like bound variable at an arbitrary in-scope
+type variable preserves coercion typing.  A store-domain side condition
+cannot prove that, because it asks the wrong question after opening:
+it asks whether the chosen ``α`` is in the store, while the reduction is
+tracking whether the occurrence came from the tag-like ``gen`` binder.
+
+The same issue appears in the older store-allocating reduction rule:
+
+    Σ ∣ V ⟨ gen C c ⟩ ⦂∀ B • A
+      —→
+    (α , A) ∷ Σ ∣ V ⟨ c[α] ⟩ ⟨ reveal B[α] α A ⟩
+
+Here ``α`` is fresh for the old store ``Σ``, but the reduct is typed in
+the new store ``(α , A) ∷ Σ``.  Thus a reduct coercion such as
+``(＇ α) ？`` is again rejected by the side condition precisely because
+preservation has moved to the store that now contains ``α``.
+
+Concrete preservation problem: ``inst``
+--------------------------------------
+
+Now consider the opposite binder.  In an ``inst`` coercion, the freshly
+bound variable is seal-like, because type instantiation creates an
+abstract runtime representation.  For example:
+
+    d[β] = seal ★ β ︔ unseal β ★
+
+    inst ★ d[β]
+
+The body coercion is typed under a store extended with the new
+``β`` seal:
+
+    instᵈ normalᵈ ∣ Δ, β ∣ (β , ★) ∷ Σ↑
+      ⊢ seal ★ β ︔ unseal β ★ ∶ ★ =⇒ ★
+
+The Nu reduction rule is
+
+    V ⟨ inst B c[β] ⟩
+      —→
+    ν β := ★. (((V↑) • β) ⟨ c[β] ⟩)
+
+Inside the body of ``ν β := ★``, the term typing rule supplies the
+matching store entry ``(β , ★)``.  So the reduct is operationally
+sensible: the body coercion can use ``seal ★ β`` and ``unseal β ★``
+because the ``ν`` binder has created the seal.
+
+The preservation proof still has to move between two views of the same
+body coercion:
+
+* As the body of ``inst``, it is checked under the special seal-like
+  binder discipline.
+* As a term cast inside the body of ``ν``, the term typing rule expects
+  the ordinary coercion typing judgment.
+
+With global side conditions, this conversion is not a structural lemma.
+One has to re-check all the store-domain side conditions after moving
+the coercion under ``ν``.  In larger bodies, that re-checking is where
+the proof gets stuck, because the side conditions do not remember which
+occurrences came from the ``inst`` binder and which were ordinary store
+variables.
+
+Why the mode context solves preservation
+----------------------------------------
+
+The mode-based design replaces the global store-domain side condition
+with a local mode context:
+
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
+
+where ``μ`` maps type variables to one of three modes:
+
+* ``normal``: ordinary coercion typing.  Endpoint occurrences and
+  tags/untags are allowed; seals/unseals are allowed when the ordinary
+  store membership premise holds.
+* ``tag-to-seal``: the variable is currently the tag-like variable bound
+  by ``gen``.  Tags/untags of the variable are allowed; seals/unseals
+  and arbitrary endpoint occurrences are rejected.
+* ``seal-to-tag``: the variable is currently the seal-like variable
+  bound by ``inst``.  Seals/unseals of the variable are allowed;
+  tags/untags and arbitrary endpoint occurrences are rejected.
+
+The public judgment remains the old one:
+
+    Δ ∣ Σ ⊢ c ∶ A =⇒ B
+
+but it is an abbreviation for normal mode:
+
+    normalᵈ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
+
+The binder rules change the mode context instead of relying on a
+store-domain side condition:
+
+    extᵈ μ ∣ Δ, X ∣ Σ↑ ⊢ c[X] ∶ A[X] =⇒ B[X]
+    ------------------------------------------------
+    μ ∣ Δ ∣ Σ ⊢ ∀X.c[X] ∶ ∀X.A[X] =⇒ ∀X.B[X]
+
+    genᵈ μ ∣ Δ, β ∣ Σ↑ ⊢ c[β] ∶ A↑ =⇒ B[β]
+    ------------------------------------------------
+    μ ∣ Δ ∣ Σ ⊢ gen A c[β] ∶ A =⇒ ∀β.B[β]
+
+    instᵈ μ ∣ Δ, β ∣ (β , ★) ∷ Σ↑
+      ⊢ c[β] ∶ A[β] =⇒ B↑
+    ------------------------------------------------
+    μ ∣ Δ ∣ Σ ⊢ inst B c[β] ∶ ∀β.A[β] =⇒ B
+
+Here ``A↑`` and ``B↑`` mean the outer type has been weakened under the
+new binder.
+
+The side checks are now mode checks:
+
+* ``tyAllowed μ A`` says that endpoint type ``A`` does not mention a
+  currently special variable in an ordinary way.
+* ``tagTyAllowed μ G`` permits a variable ground type only in ``normal``
+  or ``tag-to-seal`` mode.
+* ``sealTyAllowed μ α`` permits ``seal``/``unseal`` only in ``normal``
+  or ``seal-to-tag`` mode.
+
+This is enough for preservation because opening and weakening now have
+mode-aware lemmas.
+
+For the ``gen`` example, preservation uses a lemma of this form:
+
+    μ ∣ Δ, β ∣ Σ↑ ⊢ c[β] ∶ A[β] =⇒ B[β]
+    ------------------------------------------------
+    Δ ∣ Σ ⊢ c[α] ∶ A[α] =⇒ B[α]
+
+The proof uses ``ModeRename-to-normal``.  Intuitively, the special
+bound variable is consumed by opening; after substitution by an
+ordinary in-scope variable ``α``, the resulting coercion is checked in
+normal mode.  We do not ask whether ``α`` is in the store.  We ask
+whether the occurrence was legal in the binder mode before opening.
+Thus the reduct
+
+    V ⟨ (＇ α) ？ ⟩
+
+can be typed even when ``α`` is in ``Σ``, because the occurrence came
+from a tag-like ``gen`` binder.
+
+For the ``inst`` example, preservation uses mode relaxation:
+
+    ModeIncl μ normalᵈ
+
+Every restricted mode can be relaxed to normal mode after the
+restricted body has already been checked.  Thus, inside the body of
+``ν β := ★``, the coercion ``c`` from ``inst`` can be used by the ordinary
+term cast rule:
+
+    ⊢⟨⟩ (coercion-mode-relax modeIncl-normal c⊢) app-src⊢
+
+This does not weaken the design unsafely.  The restriction was enforced
+when ``c`` was checked under ``instᵈ``.  Relaxation only says that a
+coercion that has passed the stricter local discipline is also usable
+at an ordinary cast site once the surrounding term rule has provided
+the necessary store entry.
+
+How the mode context enables endpoint flipping
+----------------------------------------------
+
+The endpoint-flipping theorem says that if a coercion is well typed
+from ``A`` to ``B``, then its dual is well typed from ``B`` to ``A``:
+
+    StoreWfAt Δ Σ →
+    Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+    Δ ∣ Σ ⊢ - c ∶ B =⇒ A
+
+The theorem is false for raw coercions.  For example, the raw coercion
+
+    gen ★ (seal (‵ `ℕ) β)
+
+is not well typed, and indeed duality is not an involution on that raw
+term.  The typing discipline is what makes duality meaningful.
+
+The hard cases are exactly the bound ``gen``/``inst`` cases.  Duality
+swaps the representation of the bound variable:
+
+* Under ``gen``, occurrences of the bound variable are tag-like.  When
+  dualized, ``tag_β`` becomes a seal of the same bound variable, so the
+  target proof must type the dual body under ``inst`` with a fresh
+  ``(β , ★)`` store entry.
+* Under ``inst``, occurrences of the bound variable are seal-like.  When
+  dualized, ``seal_β`` becomes a tag of the same bound variable, so the
+  target proof must type the dual body under ``gen``.
+
+For the concrete typed coercion
+
+    inst ★ (seal ★ β ︔ unseal β ★)
+      : ∀X.★ =⇒ ★
+
+the dual is
+
+    gen ★ (((＇ β) ？) ︔ ((＇ β) !))
+      : ★ =⇒ ∀X.★
+
+The source body is legal because ``β`` is in ``seal-to-tag`` mode and
+the store contains ``(β , ★)``.  The dual body is legal because ``β``
+is in ``tag-to-seal`` mode and tags/untags of ``β`` are
+allowed there.  A store-domain-only side condition cannot see this
+mode switch; it only sees whether ``β`` is in the store at a
+particular point.
+
+The proof uses an internal relation ``DualStore μ Σ ν Π`` between the
+source mode/store and target mode/store.  Its important clauses are:
+
+* If ``μ α = tag-to-seal``, then the target store ``Π`` contains
+  ``(α , ★)``.  This is exactly what is needed when a tag becomes a
+  seal in the dual.
+* If ``μ α = seal-to-tag``, then the source store ``Σ`` contains
+  ``(α , ★)``.  This is exactly what is needed when a seal becomes a
+  tag in the dual.
+* If ``μ α = normal``, ordinary store membership is carried from the
+  source store to the target store.
+
+The binder cases extend this relation in the way duality requires:
+
+    genᵈ μ over Σ↑
+      flips to
+    instᵈ ν over (β , ★) ∷ Π↑
+
+    instᵈ μ over (β , ★) ∷ Σ↑
+      flips to
+    genᵈ ν over Π↑
+
+Thus the proof does not need to guess after the fact whether a variable
+should be a tag or a seal.  The mode context records that information
+at the binder, and ``DualStore`` records the store entry that will be
+needed after the flip.  This is the reason endpoint flipping can be
+proved structurally over the coercion typing derivation.
+
+Suggested changes to the cambridge22 coercion typing presentation
+----------------------------------------------------------------
+
+The cambridge22 notes should keep the existing coercion typing shape:
+
+    c : A =⇒_Σ B
+
+The only suggested presentation change is to refine this judgment with
+a mode context when stating the side conditions:
+
+    μ ⊢ c : A =⇒_Σ B
+
+The store ``Σ`` stays as the subscript on the arrow, and no separate
+type-variable context needs to be introduced.  The unqualified judgment
+can be read as the normal-mode instance, where every free type variable
+that is not specially bound by a coercion rule is ordinary:
+
+    c : A =⇒_Σ B
+      means
+    normal ⊢ c : A =⇒_Σ B
+
+The mode context only records how variables bound by coercion structure
+may be used inside the body coercion:
+
+    μ, X : normal   -- the variable bound by ∀X.c[X]
+    μ, α : tag      -- α may occur as tag_α or -tag_α
+    μ, α : seal     -- α may occur as seal_α or -seal_α
+
+Equivalently, the existing informal annotations
+``c[tag_α]`` and ``c[seal_α]`` become tracked side conditions rather
+than comments.  In ``c[tag_α]``, the bound ``α`` may occur as
+``tag_α`` or ``-tag_α``, but not as an ordinary type endpoint and not
+as a seal.  In ``c[seal_α]``, the bound ``α`` may occur as
+``seal_α`` or ``-seal_α``, but not as an ordinary type endpoint and not
+as a tag.
+
+The side conditions that currently mention ``dom(Σ)`` should be
+replaced by mode admissibility checks:
+
+    TyOK_μ(A)
+    TagOK_μ(G)
+    SealOK_μ(α)
+
+``TyOK_μ(A)`` says that no variable currently in tag mode or seal mode
+appears as an ordinary type endpoint in ``A``.  Thus ``TyOK_μ(α)``
+holds when ``α`` is normal, and fails when ``α`` is the special
+variable of an enclosing ``c[tag_α]`` or ``c[seal_α]`` annotation.
+
+``TagOK_μ(G)`` says that ``G`` is legal in ``tag_G`` and ``-tag_G``.
+For variable ground types, ``TagOK_μ(α)`` holds when ``α`` is normal or
+in tag mode, and fails when ``α`` is in seal mode.
+
+``SealOK_μ(α)`` says that ``α`` is legal in ``seal_α`` and
+``-seal_α``.  It holds when ``α`` is normal or in seal mode, and fails
+when ``α`` is in tag mode.
+
+With those predicates, the rules whose side conditions change are:
+
+    ---------------- TyOK_μ(A)
+    μ ⊢ id_A : A =⇒_Σ A
+
+    ---------------- TagOK_μ(G)
+    μ ⊢ tag_G : G =⇒_Σ ★
+
+    ------------------- TagOK_μ(G)
+    μ ⊢ -tag_G^ℓ : ★ =⇒_Σ G
+
+    ----------------- (α:=A) ∈ Σ, TyOK_μ(A), SealOK_μ(α)
+    μ ⊢ seal_α : A =⇒_Σ α
+
+    ------------------ (α:=A) ∈ Σ, TyOK_μ(A), SealOK_μ(α)
+    μ ⊢ -seal_α : α =⇒_Σ A
+
+The important difference from the current cambridge22 side conditions
+is this replacement:
+
+    ftv(A) ∩ dom(Σ) = ∅
+      becomes
+    TyOK_μ(A)
+
+and
+
+    if G = α then α ∉ dom(Σ)
+      becomes
+    TagOK_μ(G)
+
+The store-membership premises for ``seal_α`` and ``-seal_α`` remain
+unchanged.  In particular, the mode discipline does not try to replace
+``(α:=A) ∈ Σ``; it only replaces the freshness checks that were using
+``dom(Σ)`` to approximate where tags and ordinary endpoints were
+allowed.
+
+The structural rules should keep their cambridge22 conclusions and only
+thread the mode context through their premises.  For example:
+
+    μ ⊢ c : A =⇒_Σ B    μ ⊢ d : B =⇒_Π C
+    ---------------------------- (if α:=A ∈ Σ and α:=B ∈ Π then A = B)
+    μ ⊢ (c ; d) : A =⇒_{Σ,Π} C
+
+    μ ⊢ c : A′ =⇒_Σ A    μ ⊢ d : B =⇒_Σ B′
+    ------------------------------
+    μ ⊢ (c→d) : (A→B) =⇒_Σ (A′→B′)
+
+    μ, X : normal ⊢ c[X] : A[X] =⇒_Σ B[X]
+    ------------------------------------
+    μ ⊢ (∀X.c[X]) : (∀X.A[X]) =⇒_Σ (∀X.B[X])
+
+The two ``ν`` rules are where the mode annotations matter most:
+
+    μ, α : tag ⊢ c[tag_α] : A =⇒_Σ B[α]
+    ---------------------------- α ∉ fv(A), α ∈ fv(B[α])
+    μ ⊢ (να.c[tag_α]) : A =⇒_Σ (∀X.B[X])
+
+    μ, α : seal ⊢ c[seal_α] : A[α] =⇒_{Σ,α:=⋆} B
+    ----------------------------- α ∈ fv(A[α]), α ∉ fv(B)
+    μ ⊢ (-να.c[seal_α]) : (∀X.A[X]) =⇒_Σ B
+
+This keeps the cambridge22 presentation intact while making explicit
+the invariant already suggested by the notation: ``να.c[tag_α]`` opens
+the body with tag-like occurrences, while ``-να.c[seal_α]`` opens the
+body with seal-like occurrences.  The preservation benefit is that
+opening no longer depends on whether the opened variable happens to be
+absent from ``dom(Σ)``; legality follows from the mode assigned by the
+binder.
+
+Open cleanup notes
+------------------
+
+Inline and remove sealTyAllowed. It's too short.
+
+Rename dualWith to dual.
+
+In the coercion typing relation, change the new side conditions
+to be explicit parameters instead of implicit.
+
+--------------------------------------------------------------------------------
+Maximal Lower Bounds
 
 A = ∀Y. ★ → Y → ★ → ★
 B = ∀X. X → ★ → ★ → X
@@ -10,14 +448,11 @@ B = ∀Y.∀Z.∀W.∀T.∀U. ★ → Y → Z → W → ★ → T → U → ★ 
 C = ∀X.∀Y.∀Z.∀W.∀S.∀T.∀U.∀V.∀R. X → Y → Z → W → S → T → U → V → R → X
 MLB = ?
 
+--------------------------------------------------------------------------------
 
-
-
-
-
-What does the compilation from the source language to the poly. blame calculus look like?
-We need to make sure it satisfies the static gradual guarantee.
-
+What does the compilation from the source language to the poly. blame
+calculus look like?  We need to make sure it satisfies the static
+gradual guarantee.
 
 F = λf:∀X.X→X. ΛY. λy:Y. f[Y] y
   = λf:∀X.X→X. ΛY. λy:Y. να:=Y. (f[α] @+(seal_α → seal_a)) y
@@ -30,11 +465,8 @@ F⋆ =  λf:⋆→⋆. ΛY. λy:Y. f[Y] y
    Also, would we have to use a kind of bidirectional typing to have
    the type of y influence the compilation of the type application.
 
-
 id : ∀X.X→X = ΛX. λx:X. x
 id⋆ : ⋆ → ⋆ = λx:⋆. x
 
 F id [ℕ] 42 -->* 42
 F id⋆ [ℕ] 42 -->* 42
-
-

--- a/GTSF/notes.md
+++ b/GTSF/notes.md
@@ -18,9 +18,9 @@ The notes express this by side conditions such as:
 * ``id_α`` is not allowed when ``α`` is in the store.
 * ``tag_α`` and ``-tag_α`` are not allowed when ``α`` is in the store.
 * ``seal_α`` and ``-seal_α`` require ``α`` to be in the store.
-* In ``να.c[α]``, all occurrences of the bound ``α`` should be tag-like,
-  written ``c[tag_α]``.
-* In ``-να.c[α]``, all occurrences of the bound ``α`` should be
+* In ``ν α. c[α]``, all occurrences of the bound ``α`` should be
+  tag-like, written ``c[tag_α]``.
+* In ``-ν α. c[α]``, all occurrences of the bound ``α`` should be
   seal-like, written ``c[seal_α]``.
 
 Those side conditions are natural for a static description of coercions,
@@ -36,6 +36,17 @@ uses de Bruijn indices: a named binder ``β`` below corresponds to index
 ``zero`` in the mechanization, ``Δ, β`` corresponds to ``suc Δ``, and
 ``Σ↑`` corresponds to the lifted store ``⟰ᵗ Σ``.
 
+The nominal notation below writes binders explicitly in each syntactic
+form that binds a type variable:
+
+    ∀X. c[X]
+    gen β. A c[β]
+    inst β. B c[β]
+
+These correspond to the Agda constructors ``∀``, ``gen A c``, and
+``inst B c``; the displayed variable marks the scope that Agda handles
+with ``extᵗ`` in renaming and substitution.
+
 Concrete preservation problem: ``gen``
 -------------------------------------
 
@@ -45,7 +56,7 @@ Consider the body coercion
 
 under a ``gen`` coercion:
 
-    gen ★ c[β]
+    gen β. ★ c[β]
 
 In the body of ``gen``, the newly bound variable ``β`` is intended to be
 tag-like.  The body coercion has shape
@@ -55,15 +66,15 @@ tag-like.  The body coercion has shape
 because ``β`` is bound by the coercion and is not a store seal in
 ``Σ↑``.  Thus
 
-    Δ ∣ Σ ⊢ gen ★ c[β] ∶ ★ =⇒ ∀β.β
+    Δ ∣ Σ ⊢ gen β. ★ c[β] ∶ ★ =⇒ ∀β.β
 
 The Nu reduction rule for ``gen`` is
 
-    V ⟨ gen C c[β] ⟩ • α  —→  V ⟨ c[α] ⟩
+    V ⟨ gen β. C c[β] ⟩ • α  —→  V ⟨ c[α] ⟩
 
 so the example reduces to
 
-    V ⟨ gen ★ c[β] ⟩ • α
+    V ⟨ gen β. ★ c[β] ⟩ • α
       —→
     V ⟨ c[α] ⟩
       =
@@ -81,7 +92,7 @@ tracking whether the occurrence came from the tag-like ``gen`` binder.
 
 The same issue appears in the older store-allocating reduction rule:
 
-    Σ ∣ V ⟨ gen C c ⟩ ⦂∀ B • A
+    Σ ∣ V ⟨ gen β. C c[β] ⟩ ⦂∀ B • A
       —→
     (α , A) ∷ Σ ∣ V ⟨ c[α] ⟩ ⟨ reveal B[α] α A ⟩
 
@@ -99,7 +110,7 @@ abstract runtime representation.  For example:
 
     d[β] = seal ★ β ︔ unseal β ★
 
-    inst ★ d[β]
+    inst β. ★ d[β]
 
 The body coercion is typed under a store extended with the new
 ``β`` seal:
@@ -109,7 +120,7 @@ The body coercion is typed under a store extended with the new
 
 The Nu reduction rule is
 
-    V ⟨ inst B c[β] ⟩
+    V ⟨ inst β. B c[β] ⟩
       —→
     ν β := ★. (((V↑) • β) ⟨ c[β] ⟩)
 
@@ -166,16 +177,16 @@ store-domain side condition:
 
     extᵈ μ ∣ Δ, X ∣ Σ↑ ⊢ c[X] ∶ A[X] =⇒ B[X]
     ------------------------------------------------
-    μ ∣ Δ ∣ Σ ⊢ ∀X.c[X] ∶ ∀X.A[X] =⇒ ∀X.B[X]
+    μ ∣ Δ ∣ Σ ⊢ ∀X. c[X] ∶ ∀X.A[X] =⇒ ∀X.B[X]
 
     genᵈ μ ∣ Δ, β ∣ Σ↑ ⊢ c[β] ∶ A↑ =⇒ B[β]
     ------------------------------------------------
-    μ ∣ Δ ∣ Σ ⊢ gen A c[β] ∶ A =⇒ ∀β.B[β]
+    μ ∣ Δ ∣ Σ ⊢ gen β. A c[β] ∶ A =⇒ ∀β.B[β]
 
     instᵈ μ ∣ Δ, β ∣ (β , ★) ∷ Σ↑
       ⊢ c[β] ∶ A[β] =⇒ B↑
     ------------------------------------------------
-    μ ∣ Δ ∣ Σ ⊢ inst B c[β] ∶ ∀β.A[β] =⇒ B
+    μ ∣ Δ ∣ Σ ⊢ inst β. B c[β] ∶ ∀β.A[β] =⇒ B
 
 Here ``A↑`` and ``B↑`` mean the outer type has been weakened under the
 new binder.
@@ -239,7 +250,7 @@ from ``A`` to ``B``, then its dual is well typed from ``B`` to ``A``:
 
 The theorem is false for raw coercions.  For example, the raw coercion
 
-    gen ★ (seal (‵ `ℕ) β)
+    gen β. ★ (seal (‵ `ℕ) β)
 
 is not well typed, and indeed duality is not an involution on that raw
 term.  The typing discipline is what makes duality meaningful.
@@ -257,13 +268,13 @@ swaps the representation of the bound variable:
 
 For the concrete typed coercion
 
-    inst ★ (seal ★ β ︔ unseal β ★)
-      : ∀X.★ =⇒ ★
+    inst β. ★ (seal ★ β ︔ unseal β ★)
+      : ∀β.★ =⇒ ★
 
 the dual is
 
-    gen ★ (((＇ β) ？) ︔ ((＇ β) !))
-      : ★ =⇒ ∀X.★
+    gen β. ★ (((＇ β) ？) ︔ ((＇ β) !))
+      : ★ =⇒ ∀β.★
 
 The source body is legal because ``β`` is in ``seal-to-tag`` mode and
 the store contains ``(β , ★)``.  The dual body is legal because ``β``
@@ -324,13 +335,14 @@ that is not specially bound by a coercion rule is ordinary:
 The mode context only records how variables bound by coercion structure
 may be used inside the body coercion:
 
-    μ, X : normal   -- the variable bound by ∀X.c[X]
+    μ, X : normal   -- the variable bound by ∀X. c[X]
     μ, α : tag      -- α may occur as tag_α or -tag_α
     μ, α : seal     -- α may occur as seal_α or -seal_α
 
 Equivalently, the existing informal annotations
 ``c[tag_α]`` and ``c[seal_α]`` become tracked side conditions rather
-than comments.  In ``c[tag_α]``, the bound ``α`` may occur as
+than comments on the binding forms ``ν α. c[tag_α]`` and
+``-ν α. c[seal_α]``.  In ``c[tag_α]``, the bound ``α`` may occur as
 ``tag_α`` or ``-tag_α``, but not as an ordinary type endpoint and not
 as a seal.  In ``c[seal_α]``, the bound ``α`` may occur as
 ``seal_α`` or ``-seal_α``, but not as an ordinary type endpoint and not
@@ -346,7 +358,8 @@ replaced by mode admissibility checks:
 ``TyOK_μ(A)`` says that no variable currently in tag mode or seal mode
 appears as an ordinary type endpoint in ``A``.  Thus ``TyOK_μ(α)``
 holds when ``α`` is normal, and fails when ``α`` is the special
-variable of an enclosing ``c[tag_α]`` or ``c[seal_α]`` annotation.
+variable of an enclosing ``ν α. c[tag_α]`` or ``-ν α. c[seal_α]``
+annotation.
 
 ``TagOK_μ(G)`` says that ``G`` is legal in ``tag_G`` and ``-tag_G``.
 For variable ground types, ``TagOK_μ(α)`` holds when ``α`` is normal or
@@ -405,21 +418,21 @@ thread the mode context through their premises.  For example:
 
     μ, X : normal ⊢ c[X] : A[X] =⇒_Σ B[X]
     ------------------------------------
-    μ ⊢ (∀X.c[X]) : (∀X.A[X]) =⇒_Σ (∀X.B[X])
+    μ ⊢ (∀X. c[X]) : (∀X.A[X]) =⇒_Σ (∀X.B[X])
 
 The two ``ν`` rules are where the mode annotations matter most:
 
     μ, α : tag ⊢ c[tag_α] : A =⇒_Σ B[α]
     ---------------------------- α ∉ fv(A), α ∈ fv(B[α])
-    μ ⊢ (να.c[tag_α]) : A =⇒_Σ (∀X.B[X])
+    μ ⊢ (ν α. c[tag_α]) : A =⇒_Σ (∀X.B[X])
 
     μ, α : seal ⊢ c[seal_α] : A[α] =⇒_{Σ,α:=⋆} B
     ----------------------------- α ∈ fv(A[α]), α ∉ fv(B)
-    μ ⊢ (-να.c[seal_α]) : (∀X.A[X]) =⇒_Σ B
+    μ ⊢ (-ν α. c[seal_α]) : (∀X.A[X]) =⇒_Σ B
 
 This keeps the cambridge22 presentation intact while making explicit
-the invariant already suggested by the notation: ``να.c[tag_α]`` opens
-the body with tag-like occurrences, while ``-να.c[seal_α]`` opens the
+the invariant already suggested by the notation: ``ν α. c[tag_α]`` opens
+the body with tag-like occurrences, while ``-ν α. c[seal_α]`` opens the
 body with seal-like occurrences.  The preservation benefit is that
 opening no longer depends on whether the opened variable happens to be
 absent from ``dom(Σ)``; legality follows from the mode assigned by the

--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -8,6 +8,7 @@ module proof.CoercionProperties where
 --   * Term substitution/renaming lemmas belong in `proof.TermProperties`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (true; false)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_; length)
 open import Data.List.Relation.Unary.Any using (here; there)
@@ -16,7 +17,7 @@ open import Data.Nat using (zero; suc; _<_; _≤_; z<s; s<s; z≤n; s≤s)
 open import Data.Nat.Properties
   using (_≟_; ≤-refl; n≤1+n; n<1+n; <-≤-trans; <-irrefl;
          m<n⇒m<1+n; suc-injective)
-open import Data.Product using (_×_; _,_)
+open import Data.Product using (_×_; _,_; ∃; ∃-syntax)
 open import Relation.Nullary using (yes; no)
 open import Relation.Binary.PropositionalEquality
   using (_≢_; cong; cong₂; subst; sym; trans)
@@ -46,48 +47,62 @@ renameᶜ-preserves-Inert ρ (gen A c) =
 -- Coercion typing under store/type-context weakening
 ------------------------------------------------------------------------
 
+coercion-weakenᵐ :
+  ∀ {μ Δ Δ′ Σ Σ′ c A B} →
+  Δ ≤ Δ′ →
+  StoreIncl Σ Σ′ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  μ ∣ Δ′ ∣ Σ′ ⊢ c ∶ A =⇒ B
+coercion-weakenᵐ Δ≤Δ′ incl (cast-id hA {ok = ok}) =
+  cast-id (WfTy-weakenᵗ hA Δ≤Δ′) {ok = ok}
+coercion-weakenᵐ Δ≤Δ′ incl
+    (cast-seal hA α∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
+  cast-seal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ)
+    {A-ok = A-ok} {α-ok = α-ok}
+coercion-weakenᵐ Δ≤Δ′ incl
+    (cast-unseal hA α∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
+  cast-unseal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ)
+    {A-ok = A-ok} {α-ok = α-ok}
+coercion-weakenᵐ Δ≤Δ′ incl (cast-seq c⊢ d⊢) =
+  cast-seq (coercion-weakenᵐ Δ≤Δ′ incl c⊢)
+           (coercion-weakenᵐ Δ≤Δ′ incl d⊢)
+coercion-weakenᵐ Δ≤Δ′ incl (cast-tag hG gG {ok = ok}) =
+  cast-tag (WfTy-weakenᵗ hG Δ≤Δ′) gG {ok = ok}
+coercion-weakenᵐ Δ≤Δ′ incl (cast-untag hH gH {ok = ok}) =
+  cast-untag (WfTy-weakenᵗ hH Δ≤Δ′) gH {ok = ok}
+coercion-weakenᵐ Δ≤Δ′ incl (cast-fun c⊢ d⊢) =
+  cast-fun (coercion-weakenᵐ Δ≤Δ′ incl c⊢)
+           (coercion-weakenᵐ Δ≤Δ′ incl d⊢)
+coercion-weakenᵐ Δ≤Δ′ incl (cast-all c⊢) =
+  cast-all
+    (coercion-weakenᵐ
+      (s≤s Δ≤Δ′)
+      (renameStoreᵗ-incl suc incl)
+      c⊢)
+coercion-weakenᵐ Δ≤Δ′ incl (cast-inst hB {B-ok = B-ok} c⊢) =
+  cast-inst
+    (WfTy-weakenᵗ hB Δ≤Δ′)
+    {B-ok = B-ok}
+    (coercion-weakenᵐ
+      (s≤s Δ≤Δ′)
+      (StoreIncl-cons (renameStoreᵗ-incl suc incl))
+      c⊢)
+coercion-weakenᵐ Δ≤Δ′ incl (cast-gen hA {A-ok = A-ok} c⊢) =
+  cast-gen
+    (WfTy-weakenᵗ hA Δ≤Δ′)
+    {A-ok = A-ok}
+    (coercion-weakenᵐ
+      (s≤s Δ≤Δ′)
+      (renameStoreᵗ-incl suc incl)
+      c⊢)
+
 coercion-weaken :
   ∀ {Δ Δ′ Σ Σ′ c A B} →
   Δ ≤ Δ′ →
   StoreIncl Σ Σ′ →
   Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   Δ′ ∣ Σ′ ⊢ c ∶ A =⇒ B
-coercion-weaken Δ≤Δ′ incl (cast-id hA) =
-  cast-id (WfTy-weakenᵗ hA Δ≤Δ′)
-coercion-weaken Δ≤Δ′ incl (cast-seal hA α∈Σ) =
-  cast-seal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ)
-coercion-weaken Δ≤Δ′ incl (cast-unseal hA α∈Σ) =
-  cast-unseal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ)
-coercion-weaken Δ≤Δ′ incl (cast-seq c⊢ d⊢) =
-  cast-seq (coercion-weaken Δ≤Δ′ incl c⊢)
-           (coercion-weaken Δ≤Δ′ incl d⊢)
-coercion-weaken Δ≤Δ′ incl (cast-tag hG gG) =
-  cast-tag (WfTy-weakenᵗ hG Δ≤Δ′) gG
-coercion-weaken Δ≤Δ′ incl (cast-untag hH gH) =
-  cast-untag (WfTy-weakenᵗ hH Δ≤Δ′) gH
-coercion-weaken Δ≤Δ′ incl (cast-fun c⊢ d⊢) =
-  cast-fun (coercion-weaken Δ≤Δ′ incl c⊢)
-           (coercion-weaken Δ≤Δ′ incl d⊢)
-coercion-weaken Δ≤Δ′ incl (cast-all c⊢) =
-  cast-all
-    (coercion-weaken
-      (s≤s Δ≤Δ′)
-      (renameStoreᵗ-incl suc incl)
-      c⊢)
-coercion-weaken Δ≤Δ′ incl (cast-inst hB c⊢) =
-  cast-inst
-    (WfTy-weakenᵗ hB Δ≤Δ′)
-    (coercion-weaken
-      (s≤s Δ≤Δ′)
-      (StoreIncl-cons (renameStoreᵗ-incl suc incl))
-      c⊢)
-coercion-weaken Δ≤Δ′ incl (cast-gen hA c⊢) =
-  cast-gen
-    (WfTy-weakenᵗ hA Δ≤Δ′)
-    (coercion-weaken
-      (s≤s Δ≤Δ′)
-      (renameStoreᵗ-incl suc incl)
-      c⊢)
+coercion-weaken = coercion-weakenᵐ
 
 coercion-weaken-suc :
   ∀ {Δ Σ c A B α C} →
@@ -103,8 +118,9 @@ coercion-weaken-suc {Δ = Δ} c⊢ =
 dual-inst-example⊢ :
   zero ∣ [] ⊢ inst ★ (seal ★ zero ︔ unseal zero ★) ∶ `∀ ★ =⇒ ★
 dual-inst-example⊢ =
-  cast-inst wf★
-    (cast-seq (cast-seal wf★ (here refl)) (cast-unseal wf★ (here refl)))
+  cast-inst wf★ {B-ok = refl}
+    (cast-seq (cast-seal wf★ (here refl) {A-ok = refl} {α-ok = refl})
+              (cast-unseal wf★ (here refl) {A-ok = refl} {α-ok = refl}))
 
 dual-inst-example-dual≡ :
   - inst ★ (seal ★ zero ︔ unseal zero ★)
@@ -114,14 +130,15 @@ dual-inst-example-dual≡ = refl
 dual-inst-example-dual⊢ :
   zero ∣ [] ⊢ - inst ★ (seal ★ zero ︔ unseal zero ★) ∶ ★ =⇒ `∀ ★
 dual-inst-example-dual⊢ =
-  cast-gen wf★
-    (cast-seq (cast-untag (wfVar z<s) (＇ zero))
-              (cast-tag (wfVar z<s) (＇ zero)))
+  cast-gen wf★ {A-ok = refl}
+    (cast-seq (cast-untag (wfVar z<s) (＇ zero) {ok = refl})
+              (cast-tag (wfVar z<s) (＇ zero) {ok = refl}))
 
-dual-inst-tag-counterexample⊢ :
-  zero ∣ [] ⊢ inst ★ ((＇ zero) !) ∶ `∀ (＇ zero) =⇒ ★
-dual-inst-tag-counterexample⊢ =
-  cast-inst wf★ (cast-tag (wfVar z<s) (＇ zero))
+dual-inst-tag-counterexample-not-typable :
+  zero ∣ [] ⊢ inst ★ ((＇ zero) !) ∶ `∀ (＇ zero) =⇒ ★ →
+  ⊥
+dual-inst-tag-counterexample-not-typable
+    (cast-inst h★ (cast-tag hα (＇ zero) {ok = ()}))
 
 dual-inst-tag-counterexample-dual≡ :
   - inst ★ ((＇ zero) !) ≡ gen ★ (seal ★ zero)
@@ -267,7 +284,7 @@ store-dual-safe-instᵈ safeΣ (there α∈Σ) =
 coercion-dual-safe :
   ∀ {Δ Σ c A B μ} →
   StoreDualSafe μ Σ →
-  Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   DualSafe μ c
 coercion-dual-safe safeΣ (cast-id hA) = safe-id
 coercion-dual-safe safeΣ (cast-seal hA α∈Σ) =
@@ -417,60 +434,391 @@ dual-raw-involutive-counterexample-not-typable (cast-gen h★ ())
 -- Coercion typing under type renaming
 ------------------------------------------------------------------------
 
+ModeRename : Renameᵗ → DualEnv → DualEnv → Set
+ModeRename ρ μ ν = ∀ X → mode≤ (μ X) (ν (ρ X)) ≡ true
+
+ModeRename-normal :
+  ∀ {ρ} →
+  ModeRename ρ normalᵈ normalᵈ
+ModeRename-normal X = refl
+
+ModeRename-to-normal :
+  ∀ {ρ μ} →
+  ModeRename ρ μ normalᵈ
+ModeRename-to-normal {μ = μ} X with μ X
+ModeRename-to-normal X | normal = refl
+ModeRename-to-normal X | tag-to-seal = refl
+ModeRename-to-normal X | seal-to-tag = refl
+
+ModeRename-ext :
+  ∀ {ρ μ ν} →
+  ModeRename ρ μ ν →
+  ModeRename (extᵗ ρ) (extᵈ μ) (extᵈ ν)
+ModeRename-ext rel zero = refl
+ModeRename-ext rel (suc X) = rel X
+
+ModeRename-gen :
+  ∀ {ρ μ ν} →
+  ModeRename ρ μ ν →
+  ModeRename (extᵗ ρ) (genᵈ μ) (genᵈ ν)
+ModeRename-gen rel zero = refl
+ModeRename-gen rel (suc X) = rel X
+
+ModeRename-inst :
+  ∀ {ρ μ ν} →
+  ModeRename ρ μ ν →
+  ModeRename (extᵗ ρ) (instᵈ μ) (instᵈ ν)
+ModeRename-inst rel zero = refl
+ModeRename-inst rel (suc X) = rel X
+
+mode≤-tag :
+  ∀ {m n} →
+  mode≤ m n ≡ true →
+  tagModeAllowed m ≡ true →
+  tagModeAllowed n ≡ true
+mode≤-tag {normal} {normal} rel ok = refl
+mode≤-tag {normal} {tag-to-seal} () ok
+mode≤-tag {normal} {seal-to-tag} () ok
+mode≤-tag {tag-to-seal} {normal} rel ok = refl
+mode≤-tag {tag-to-seal} {tag-to-seal} rel ok = refl
+mode≤-tag {tag-to-seal} {seal-to-tag} () ok
+mode≤-tag {seal-to-tag} {normal} rel ()
+mode≤-tag {seal-to-tag} {tag-to-seal} () ok
+mode≤-tag {seal-to-tag} {seal-to-tag} rel ()
+
+mode≤-seal :
+  ∀ {m n} →
+  mode≤ m n ≡ true →
+  sealModeAllowed m ≡ true →
+  sealModeAllowed n ≡ true
+mode≤-seal {normal} {normal} rel ok = refl
+mode≤-seal {normal} {tag-to-seal} () ok
+mode≤-seal {normal} {seal-to-tag} () ok
+mode≤-seal {tag-to-seal} {normal} rel ()
+mode≤-seal {tag-to-seal} {tag-to-seal} rel ()
+mode≤-seal {tag-to-seal} {seal-to-tag} () ok
+mode≤-seal {seal-to-tag} {normal} rel ok = refl
+mode≤-seal {seal-to-tag} {tag-to-seal} () ok
+mode≤-seal {seal-to-tag} {seal-to-tag} rel ok = refl
+
+modeRename-tyAllowed :
+  ∀ {ρ μ ν A} →
+  ModeRename ρ μ ν →
+  tyAllowed μ A ≡ true →
+  tyAllowed ν (renameᵗ ρ A) ≡ true
+modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = ＇ α} rel ok
+    with μ α | ν (ρ α) | rel α | ok
+modeRename-tyAllowed rel ok | normal | normal | relα | okα = refl
+modeRename-tyAllowed rel ok | normal | tag-to-seal | () | okα
+modeRename-tyAllowed rel ok | normal | seal-to-tag | () | okα
+modeRename-tyAllowed rel ok | tag-to-seal | n | relα | ()
+modeRename-tyAllowed rel ok | seal-to-tag | n | relα | ()
+modeRename-tyAllowed {A = ‵ ι} rel ok = refl
+modeRename-tyAllowed {A = ★} rel ok = refl
+modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = A ⇒ B} rel ok
+    with tyAllowed μ A in okA | tyAllowed μ B in okB
+modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = A ⇒ B} rel ok
+    | true | true
+    with modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel okA
+       | modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = B} rel okB
+modeRename-tyAllowed {A = A ⇒ B} rel ok | true | true | okA′ | okB′
+    rewrite okA′ | okB′ = refl
+modeRename-tyAllowed rel () | false | b
+modeRename-tyAllowed rel () | true | false
+modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = `∀ A} rel ok =
+  modeRename-tyAllowed
+    {ρ = extᵗ ρ} {μ = extᵈ μ} {ν = extᵈ ν} {A = A}
+    (ModeRename-ext rel) ok
+
+modeRename-tagTyAllowed :
+  ∀ {ρ μ ν G} →
+  ModeRename ρ μ ν →
+  tagTyAllowed μ G ≡ true →
+  tagTyAllowed ν (renameᵗ ρ G) ≡ true
+modeRename-tagTyAllowed {ρ = ρ} {μ = μ} {ν = ν} {G = ＇ α} rel ok =
+  mode≤-tag (rel α) ok
+modeRename-tagTyAllowed {G = ‵ ι} rel ok = refl
+modeRename-tagTyAllowed {G = ★} rel ok = refl
+modeRename-tagTyAllowed {ρ = ρ} {μ = μ} {ν = ν} {G = A ⇒ B} rel ok
+    with tyAllowed μ A in okA | tyAllowed μ B in okB
+modeRename-tagTyAllowed {ρ = ρ} {μ = μ} {ν = ν} {G = A ⇒ B} rel ok
+    | true | true
+    with modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel okA
+       | modeRename-tyAllowed {ρ = ρ} {μ = μ} {ν = ν} {A = B} rel okB
+modeRename-tagTyAllowed {G = A ⇒ B} rel ok | true | true | okA′ | okB′
+    rewrite okA′ | okB′ = refl
+modeRename-tagTyAllowed rel () | false | b
+modeRename-tagTyAllowed rel () | true | false
+modeRename-tagTyAllowed {ρ = ρ} {μ = μ} {ν = ν} {G = `∀ A} rel ok =
+  modeRename-tyAllowed
+    {ρ = extᵗ ρ} {μ = extᵈ μ} {ν = extᵈ ν} {A = A}
+    (ModeRename-ext rel) ok
+
+modeRename-sealTyAllowed :
+  ∀ {ρ μ ν α} →
+  ModeRename ρ μ ν →
+  sealTyAllowed μ α ≡ true →
+  sealTyAllowed ν (ρ α) ≡ true
+modeRename-sealTyAllowed {α = α} rel ok =
+  mode≤-seal (rel α) ok
+
+ModeAllNormal : DualEnv → Set
+ModeAllNormal μ = ∀ X → μ X ≡ normal
+
+ModeAllNormal-normal :
+  ModeAllNormal normalᵈ
+ModeAllNormal-normal X = refl
+
+ModeAllNormal-ext :
+  ∀ {μ} →
+  ModeAllNormal μ →
+  ModeAllNormal (extᵈ μ)
+ModeAllNormal-ext all zero = refl
+ModeAllNormal-ext all (suc X) = all X
+
+tyAllowed-allNormal :
+  ∀ {μ} →
+  ModeAllNormal μ →
+  ∀ A →
+  tyAllowed μ A ≡ true
+tyAllowed-allNormal all (＇ α) rewrite all α = refl
+tyAllowed-allNormal all (‵ ι) = refl
+tyAllowed-allNormal all ★ = refl
+tyAllowed-allNormal all (A ⇒ B)
+  rewrite tyAllowed-allNormal all A
+        | tyAllowed-allNormal all B = refl
+tyAllowed-allNormal all (`∀ A) =
+  tyAllowed-allNormal (ModeAllNormal-ext all) A
+
+tagTyAllowed-allNormal :
+  ∀ {μ} →
+  ModeAllNormal μ →
+  ∀ G →
+  tagTyAllowed μ G ≡ true
+tagTyAllowed-allNormal all (＇ α) rewrite all α = refl
+tagTyAllowed-allNormal all (‵ ι) = refl
+tagTyAllowed-allNormal all ★ = refl
+tagTyAllowed-allNormal all (A ⇒ B)
+  rewrite tyAllowed-allNormal all A
+        | tyAllowed-allNormal all B = refl
+tagTyAllowed-allNormal all (`∀ A) =
+  tyAllowed-allNormal (ModeAllNormal-ext all) A
+
+tyAllowed-normal :
+  ∀ A →
+  tyAllowed normalᵈ A ≡ true
+tyAllowed-normal = tyAllowed-allNormal ModeAllNormal-normal
+
+tagTyAllowed-normal :
+  ∀ G →
+  tagTyAllowed normalᵈ G ≡ true
+tagTyAllowed-normal = tagTyAllowed-allNormal ModeAllNormal-normal
+
+sealTyAllowed-normal :
+  ∀ α →
+  sealTyAllowed normalᵈ α ≡ true
+sealTyAllowed-normal α = refl
+
+ModeIncl-ext :
+  ∀ {μ ν} →
+  ModeIncl μ ν →
+  ModeIncl (extᵈ μ) (extᵈ ν)
+ModeIncl-ext incl zero = refl
+ModeIncl-ext incl (suc X) = incl X
+
+ModeIncl-gen :
+  ∀ {μ ν} →
+  ModeIncl μ ν →
+  ModeIncl (genᵈ μ) (genᵈ ν)
+ModeIncl-gen incl zero = refl
+ModeIncl-gen incl (suc X) = incl X
+
+ModeIncl-inst :
+  ∀ {μ ν} →
+  ModeIncl μ ν →
+  ModeIncl (instᵈ μ) (instᵈ ν)
+ModeIncl-inst incl zero = refl
+ModeIncl-inst incl (suc X) = incl X
+
+modeIncl-tyAllowed :
+  ∀ {μ ν A} →
+  ModeIncl μ ν →
+  tyAllowed μ A ≡ true →
+  tyAllowed ν A ≡ true
+modeIncl-tyAllowed {μ = μ} {ν = ν} {A = A} incl ok =
+  subst
+    (λ T → tyAllowed ν T ≡ true)
+    (renameᵗ-id A)
+    (modeRename-tyAllowed
+      {ρ = λ X → X} {μ = μ} {ν = ν} {A = A} incl ok)
+
+modeIncl-tagTyAllowed :
+  ∀ {μ ν G} →
+  ModeIncl μ ν →
+  tagTyAllowed μ G ≡ true →
+  tagTyAllowed ν G ≡ true
+modeIncl-tagTyAllowed {μ = μ} {ν = ν} {G = G} incl ok =
+  subst
+    (λ T → tagTyAllowed ν T ≡ true)
+    (renameᵗ-id G)
+    (modeRename-tagTyAllowed
+      {ρ = λ X → X} {μ = μ} {ν = ν} {G = G} incl ok)
+
+modeIncl-sealTyAllowed :
+  ∀ {μ ν α} →
+  ModeIncl μ ν →
+  sealTyAllowed μ α ≡ true →
+  sealTyAllowed ν α ≡ true
+modeIncl-sealTyAllowed {μ = μ} {ν = ν} {α = α} incl ok =
+  modeRename-sealTyAllowed
+    {ρ = λ X → X} {μ = μ} {ν = ν} {α = α} incl ok
+
+coercion-mode-relax :
+  ∀ {μ ν Δ Σ c A B} →
+  ModeIncl μ ν →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  ν ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
+coercion-mode-relax incl (cast-id {A = A} hA {ok = ok}) =
+  cast-id hA {ok = modeIncl-tyAllowed {A = A} incl ok}
+coercion-mode-relax incl
+    (cast-seal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
+      {α-ok = α-ok}) =
+  cast-seal hA α∈Σ
+    {A-ok = modeIncl-tyAllowed {A = A} incl A-ok}
+    {α-ok = modeIncl-sealTyAllowed {α = α} incl α-ok}
+coercion-mode-relax incl
+    (cast-unseal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
+      {α-ok = α-ok}) =
+  cast-unseal hA α∈Σ
+    {A-ok = modeIncl-tyAllowed {A = A} incl A-ok}
+    {α-ok = modeIncl-sealTyAllowed {α = α} incl α-ok}
+coercion-mode-relax incl (cast-seq c⊢ d⊢) =
+  cast-seq (coercion-mode-relax incl c⊢)
+           (coercion-mode-relax incl d⊢)
+coercion-mode-relax incl (cast-tag {G = G} hG gG {ok = ok}) =
+  cast-tag hG gG {ok = modeIncl-tagTyAllowed {G = G} incl ok}
+coercion-mode-relax incl (cast-untag {H = H} hH gH {ok = ok}) =
+  cast-untag hH gH {ok = modeIncl-tagTyAllowed {G = H} incl ok}
+coercion-mode-relax incl (cast-fun c⊢ d⊢) =
+  cast-fun (coercion-mode-relax incl c⊢)
+           (coercion-mode-relax incl d⊢)
+coercion-mode-relax incl (cast-all c⊢) =
+  cast-all (coercion-mode-relax (ModeIncl-ext incl) c⊢)
+coercion-mode-relax incl (cast-inst {B = B} hB {B-ok = B-ok} c⊢) =
+  cast-inst hB
+    {B-ok = modeIncl-tyAllowed {A = B} incl B-ok}
+    (coercion-mode-relax (ModeIncl-inst incl) c⊢)
+coercion-mode-relax incl (cast-gen {A = A} hA {A-ok = A-ok} c⊢) =
+  cast-gen hA
+    {A-ok = modeIncl-tyAllowed {A = A} incl A-ok}
+    (coercion-mode-relax (ModeIncl-gen incl) c⊢)
+
+coercion-renameᵗᵐ :
+  ∀ {Δ Δ′ Σ c A B ρ μ ν} →
+  TyRenameWf Δ Δ′ ρ →
+  ModeRename ρ μ ν →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  ν ∣ Δ′ ∣ renameStoreᵗ ρ Σ ⊢ renameᶜ ρ c
+    ∶ renameᵗ ρ A =⇒ renameᵗ ρ B
+coercion-renameᵗᵐ hρ rel (cast-id {A = A} hA {ok = ok}) =
+  cast-id (renameᵗ-preserves-WfTy hA hρ)
+    {ok = modeRename-tyAllowed {A = A} rel ok}
+coercion-renameᵗᵐ {ρ = ρ} {μ = μ} {ν = ν} hρ rel
+    (cast-seal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
+      {α-ok = α-ok}) =
+  cast-seal
+    (renameᵗ-preserves-WfTy hA hρ)
+    (∈-renameStoreᵗ _ α∈Σ)
+    {A-ok = modeRename-tyAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel A-ok}
+    {α-ok = modeRename-sealTyAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {α = α} rel α-ok}
+coercion-renameᵗᵐ {ρ = ρ} {μ = μ} {ν = ν} hρ rel
+    (cast-unseal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
+      {α-ok = α-ok}) =
+  cast-unseal
+    (renameᵗ-preserves-WfTy hA hρ)
+    (∈-renameStoreᵗ _ α∈Σ)
+    {A-ok = modeRename-tyAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel A-ok}
+    {α-ok = modeRename-sealTyAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {α = α} rel α-ok}
+coercion-renameᵗᵐ hρ rel (cast-seq c⊢ d⊢) =
+  cast-seq (coercion-renameᵗᵐ hρ rel c⊢)
+           (coercion-renameᵗᵐ hρ rel d⊢)
+coercion-renameᵗᵐ hρ rel (cast-tag {G = G} hG gG {ok = ok}) =
+  cast-tag
+    (renameᵗ-preserves-WfTy hG hρ)
+    (renameᵗ-ground _ gG)
+    {ok = modeRename-tagTyAllowed {G = G} rel ok}
+coercion-renameᵗᵐ hρ rel (cast-untag {H = H} hH gH {ok = ok}) =
+  cast-untag
+    (renameᵗ-preserves-WfTy hH hρ)
+    (renameᵗ-ground _ gH)
+    {ok = modeRename-tagTyAllowed {G = H} rel ok}
+coercion-renameᵗᵐ hρ rel (cast-fun c⊢ d⊢) =
+  cast-fun (coercion-renameᵗᵐ hρ rel c⊢)
+           (coercion-renameᵗᵐ hρ rel d⊢)
+coercion-renameᵗᵐ {ρ = ρ} hρ rel
+    (cast-all {A = A} {B = B} c⊢) =
+  cast-all
+    (subst
+      (λ Σ′ → _ ∣ _ ∣ Σ′ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ _)
+      (renameStoreᵗ-ext-suc-comm ρ _)
+      (coercion-renameᵗᵐ (TyRenameWf-ext hρ)
+        (ModeRename-ext rel) c⊢))
+coercion-renameᵗᵐ {ρ = ρ} hρ rel
+    (cast-inst {B = B} hB {B-ok = B-ok} c⊢) =
+  cast-inst
+    (renameᵗ-preserves-WfTy hB hρ)
+    {B-ok = modeRename-tyAllowed {A = B} rel B-ok}
+    (subst
+      (λ T → _ ∣ _ ∣ _ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ T)
+      (renameᵗ-ext-suc-comm ρ B)
+      (subst
+        (λ Σ′ → _ ∣ _ ∣ (0 , ★) ∷ Σ′
+          ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ _)
+        (renameStoreᵗ-ext-suc-comm ρ _)
+        (coercion-renameᵗᵐ (TyRenameWf-ext hρ)
+          (ModeRename-inst rel) c⊢)))
+coercion-renameᵗᵐ {ρ = ρ} hρ rel
+    (cast-gen {A = A} hA {A-ok = A-ok} c⊢) =
+  cast-gen
+    (renameᵗ-preserves-WfTy hA hρ)
+    {A-ok = modeRename-tyAllowed {A = A} rel A-ok}
+    (subst
+      (λ T → _ ∣ _ ∣ _ ⊢ renameᶜ (extᵗ ρ) _ ∶ T =⇒ _)
+      (renameᵗ-ext-suc-comm ρ A)
+      (subst
+        (λ Σ′ → _ ∣ _ ∣ Σ′ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ _)
+        (renameStoreᵗ-ext-suc-comm ρ _)
+        (coercion-renameᵗᵐ (TyRenameWf-ext hρ)
+          (ModeRename-gen rel) c⊢)))
+
 coercion-renameᵗ :
   ∀ {Δ Δ′ Σ c A B ρ} →
   TyRenameWf Δ Δ′ ρ →
   Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   Δ′ ∣ renameStoreᵗ ρ Σ ⊢ renameᶜ ρ c
     ∶ renameᵗ ρ A =⇒ renameᵗ ρ B
-coercion-renameᵗ hρ (cast-id hA) =
-  cast-id (renameᵗ-preserves-WfTy hA hρ)
-coercion-renameᵗ hρ (cast-seal hA α∈Σ) =
-  cast-seal (renameᵗ-preserves-WfTy hA hρ)
-            (∈-renameStoreᵗ _ α∈Σ)
-coercion-renameᵗ hρ (cast-unseal hA α∈Σ) =
-  cast-unseal (renameᵗ-preserves-WfTy hA hρ)
-              (∈-renameStoreᵗ _ α∈Σ)
-coercion-renameᵗ hρ (cast-seq c⊢ d⊢) =
-  cast-seq (coercion-renameᵗ hρ c⊢)
-           (coercion-renameᵗ hρ d⊢)
-coercion-renameᵗ hρ (cast-tag hG gG) =
-  cast-tag (renameᵗ-preserves-WfTy hG hρ) (renameᵗ-ground _ gG)
-coercion-renameᵗ hρ (cast-untag hH gH) =
-  cast-untag (renameᵗ-preserves-WfTy hH hρ) (renameᵗ-ground _ gH)
-coercion-renameᵗ hρ (cast-fun c⊢ d⊢) =
-  cast-fun (coercion-renameᵗ hρ c⊢)
-           (coercion-renameᵗ hρ d⊢)
-coercion-renameᵗ {ρ = ρ} hρ
-    (cast-all {A = A} {B = B} c⊢) =
-  cast-all
+coercion-renameᵗ {ρ = ρ} hρ c⊢ =
+  coercion-renameᵗᵐ hρ (ModeRename-normal {ρ = ρ}) c⊢
+
+coercion-openᵐ :
+  ∀ {μ Δ Σ c A B α C} →
+  α < suc Δ →
+  μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ c ∶ A =⇒ B →
+  suc Δ ∣ (α , C) ∷ Σ ⊢ c [ α ]ᶜ
+    ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ
+coercion-openᵐ {μ = μ} {Σ = Σ} {α = α} α<sucΔ c⊢ =
+  coercion-weaken ≤-refl StoreIncl-drop
     (subst
-      (λ Σ′ → _ ∣ Σ′ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ _)
-      (renameStoreᵗ-ext-suc-comm ρ _)
-      (coercion-renameᵗ (TyRenameWf-ext hρ) c⊢))
-coercion-renameᵗ {ρ = ρ} hρ
-    (cast-inst {B = B} hB c⊢) =
-  cast-inst
-    (renameᵗ-preserves-WfTy hB hρ)
-    (subst
-      (λ T → _ ∣ _ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ T)
-      (renameᵗ-ext-suc-comm ρ B)
-      (subst
-        (λ Σ′ → _ ∣ (0 , ★) ∷ Σ′
-          ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ _)
-        (renameStoreᵗ-ext-suc-comm ρ _)
-        (coercion-renameᵗ (TyRenameWf-ext hρ) c⊢)))
-coercion-renameᵗ {ρ = ρ} hρ
-    (cast-gen {A = A} hA c⊢) =
-  cast-gen
-    (renameᵗ-preserves-WfTy hA hρ)
-    (subst
-      (λ T → _ ∣ _ ⊢ renameᶜ (extᵗ ρ) _ ∶ T =⇒ _)
-      (renameᵗ-ext-suc-comm ρ A)
-      (subst
-        (λ Σ′ → _ ∣ Σ′ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ _)
-        (renameStoreᵗ-ext-suc-comm ρ _)
-        (coercion-renameᵗ (TyRenameWf-ext hρ) c⊢)))
+      (λ Σ′ → _ ∣ Σ′ ⊢ _ ∶ _ =⇒ _)
+      (renameStoreᵗ-single-suc-cancel α Σ)
+      (coercion-renameᵗᵐ
+        (singleRenameᵗ-Wf α<sucΔ)
+        (ModeRename-to-normal {ρ = singleRenameᵗ α} {μ = μ})
+        c⊢))
 
 coercion-open :
   ∀ {Δ Σ c A B α C} →
@@ -478,12 +826,24 @@ coercion-open :
   suc Δ ∣ ⟰ᵗ Σ ⊢ c ∶ A =⇒ B →
   suc Δ ∣ (α , C) ∷ Σ ⊢ c [ α ]ᶜ
     ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ
-coercion-open {Σ = Σ} {α = α} α<sucΔ c⊢ =
-  coercion-weaken ≤-refl StoreIncl-drop
-    (subst
-      (λ Σ′ → _ ∣ Σ′ ⊢ _ ∶ _ =⇒ _)
-      (renameStoreᵗ-single-suc-cancel α Σ)
-      (coercion-renameᵗ (singleRenameᵗ-Wf α<sucΔ) c⊢))
+coercion-open = coercion-openᵐ
+
+coercion-open-headᵐ :
+  ∀ {μ Δ Σ c A B α C} →
+  α < suc Δ →
+  μ ∣ suc Δ ∣ (0 , C) ∷ ⟰ᵗ Σ ⊢ c ∶ A =⇒ B →
+  suc Δ ∣ (α , renameᵗ (singleRenameᵗ α) C) ∷ Σ
+    ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ
+coercion-open-headᵐ
+    {μ = μ} {Δ = Δ} {Σ = Σ} {c = c} {A = A} {B = B} {α = α}
+    α<sucΔ c⊢ =
+  subst
+    (λ Σ′ → suc Δ ∣ Σ′ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ)
+    (cong₂ _∷_ refl (renameStoreᵗ-single-suc-cancel α Σ))
+    (coercion-renameᵗᵐ
+      (singleRenameᵗ-Wf α<sucΔ)
+      (ModeRename-to-normal {ρ = singleRenameᵗ α} {μ = μ})
+      c⊢)
 
 coercion-open-head :
   ∀ {Δ Σ c A B α C} →
@@ -491,53 +851,492 @@ coercion-open-head :
   suc Δ ∣ (0 , C) ∷ ⟰ᵗ Σ ⊢ c ∶ A =⇒ B →
   suc Δ ∣ (α , renameᵗ (singleRenameᵗ α) C) ∷ Σ
     ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ
-coercion-open-head
-    {Δ = Δ} {Σ = Σ} {c = c} {A = A} {B = B} {α = α} α<sucΔ c⊢ =
-  subst
-    (λ Σ′ → suc Δ ∣ Σ′ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ)
-    (cong₂ _∷_ refl (renameStoreᵗ-single-suc-cancel α Σ))
-    (coercion-renameᵗ (singleRenameᵗ-Wf α<sucΔ) c⊢)
+coercion-open-head = coercion-open-headᵐ
+
+------------------------------------------------------------------------
+-- Coercion duality flips typed endpoints
+------------------------------------------------------------------------
+
+zero∉-⟰ᵗ :
+  ∀ {Σ A} →
+  (zero , A) ∈ ⟰ᵗ Σ →
+  ⊥
+zero∉-⟰ᵗ {Σ = []} ()
+zero∉-⟰ᵗ {Σ = (α , A) ∷ Σ} (here ())
+zero∉-⟰ᵗ {Σ = (α , A) ∷ Σ} (there x∈) =
+  zero∉-⟰ᵗ x∈
+
+suc∈-cons-zero-tail :
+  ∀ {Σ α A C} →
+  (suc α , A) ∈ ((zero , C) ∷ ⟰ᵗ Σ) →
+  (suc α , A) ∈ ⟰ᵗ Σ
+suc∈-cons-zero-tail (here ())
+suc∈-cons-zero-tail (there x∈) = x∈
+
+∈-⟰ᵗ-inv :
+  ∀ {Σ α A} →
+  (suc α , A) ∈ ⟰ᵗ Σ →
+  ∃[ B ] ((α , B) ∈ Σ × A ≡ renameᵗ suc B)
+∈-⟰ᵗ-inv {Σ = []} ()
+∈-⟰ᵗ-inv {Σ = (α , A) ∷ Σ} (here refl) =
+  A , here refl , refl
+∈-⟰ᵗ-inv {Σ = (β , C) ∷ Σ} (there x∈) with ∈-⟰ᵗ-inv x∈
+∈-⟰ᵗ-inv {Σ = (β , C) ∷ Σ} (there x∈) | A , αA∈Σ , eq =
+  A , there αA∈Σ , eq
+
+record DualStore
+    (μ : DualEnv) (Σ : Store) (ν : DualEnv) (Π : Store) : Set where
+  field
+    tagSeal∈ :
+      ∀ {α} →
+      μ α ≡ tag-to-seal →
+      (α , ★) ∈ Π
+    sealTag∈ :
+      ∀ {α} →
+      μ α ≡ seal-to-tag →
+      (α , ★) ∈ Σ
+    sealTag★ :
+      ∀ {α A} →
+      μ α ≡ seal-to-tag →
+      (α , A) ∈ Σ →
+      A ≡ ★
+    normal∈ :
+      ∀ {α A} →
+      μ α ≡ normal →
+      (α , A) ∈ Σ →
+      (α , A) ∈ Π
+
+open DualStore
+
+dualStore-normal :
+  ∀ {Σ} →
+  DualStore normalᵈ Σ normalᵈ Σ
+dualStore-normal =
+  record
+    { tagSeal∈ = λ ()
+    ; sealTag∈ = λ ()
+    ; sealTag★ = λ ()
+    ; normal∈ = λ eq αA∈Σ → αA∈Σ
+    }
+
+dualStore-ext :
+  ∀ {μ ν Σ Π} →
+  DualStore μ Σ ν Π →
+  DualStore (extᵈ μ) (⟰ᵗ Σ) (extᵈ ν) (⟰ᵗ Π)
+dualStore-ext ds =
+  record
+    { tagSeal∈ = tag
+    ; sealTag∈ = sealCase
+    ; sealTag★ = seal★Case
+    ; normal∈ = norm
+    }
+  where
+    tag :
+      ∀ {α} →
+      extᵈ _ α ≡ tag-to-seal →
+      (α , ★) ∈ ⟰ᵗ _
+    tag {zero} ()
+    tag {suc α} eq = ∈-renameStoreᵗ suc (tagSeal∈ ds eq)
+
+    sealCase :
+      ∀ {α} →
+      extᵈ _ α ≡ seal-to-tag →
+      (α , ★) ∈ ⟰ᵗ _
+    sealCase {zero} ()
+    sealCase {suc α} eq = ∈-renameStoreᵗ suc (sealTag∈ ds eq)
+
+    seal★Case :
+      ∀ {α A} →
+      extᵈ _ α ≡ seal-to-tag →
+      (α , A) ∈ ⟰ᵗ _ →
+      A ≡ ★
+    seal★Case {zero} () αA∈Σ
+    seal★Case {suc α} {A} eq αA∈Σ with ∈-⟰ᵗ-inv αA∈Σ
+    seal★Case {suc α} eq αA∈Σ | B , αB∈Σ , refl
+      rewrite sealTag★ ds eq αB∈Σ = refl
+
+    norm :
+      ∀ {α A} →
+      extᵈ _ α ≡ normal →
+      (α , A) ∈ ⟰ᵗ _ →
+      (α , A) ∈ ⟰ᵗ _
+    norm {zero} eq αA∈Σ = ⊥-elim (zero∉-⟰ᵗ αA∈Σ)
+    norm {suc α} {A} eq αA∈Σ with ∈-⟰ᵗ-inv αA∈Σ
+    norm {suc α} eq αA∈Σ | B , αB∈Σ , refl =
+      ∈-renameStoreᵗ suc (normal∈ ds eq αB∈Σ)
+
+dualStore-gen-inst :
+  ∀ {μ ν Σ Π} →
+  DualStore μ Σ ν Π →
+  DualStore (genᵈ μ) (⟰ᵗ Σ) (instᵈ ν) ((zero , ★) ∷ ⟰ᵗ Π)
+dualStore-gen-inst ds =
+  record
+    { tagSeal∈ = tag
+    ; sealTag∈ = sealCase
+    ; sealTag★ = seal★Case
+    ; normal∈ = norm
+    }
+  where
+    tag :
+      ∀ {α} →
+      genᵈ _ α ≡ tag-to-seal →
+      (α , ★) ∈ ((zero , ★) ∷ ⟰ᵗ _)
+    tag {zero} eq = here refl
+    tag {suc α} eq = there (∈-renameStoreᵗ suc (tagSeal∈ ds eq))
+
+    sealCase :
+      ∀ {α} →
+      genᵈ _ α ≡ seal-to-tag →
+      (α , ★) ∈ ⟰ᵗ _
+    sealCase {zero} ()
+    sealCase {suc α} eq = ∈-renameStoreᵗ suc (sealTag∈ ds eq)
+
+    seal★Case :
+      ∀ {α A} →
+      genᵈ _ α ≡ seal-to-tag →
+      (α , A) ∈ ⟰ᵗ _ →
+      A ≡ ★
+    seal★Case {zero} () αA∈Σ
+    seal★Case {suc α} {A} eq αA∈Σ with ∈-⟰ᵗ-inv αA∈Σ
+    seal★Case {suc α} eq αA∈Σ | B , αB∈Σ , refl
+      rewrite sealTag★ ds eq αB∈Σ = refl
+
+    norm :
+      ∀ {α A} →
+      genᵈ _ α ≡ normal →
+      (α , A) ∈ ⟰ᵗ _ →
+      (α , A) ∈ ((zero , ★) ∷ ⟰ᵗ _)
+    norm {zero} () αA∈Σ
+    norm {suc α} {A} eq αA∈Σ with ∈-⟰ᵗ-inv αA∈Σ
+    norm {suc α} eq αA∈Σ | B , αB∈Σ , refl =
+      there (∈-renameStoreᵗ suc (normal∈ ds eq αB∈Σ))
+
+dualStore-inst-gen :
+  ∀ {μ ν Σ Π} →
+  DualStore μ Σ ν Π →
+  DualStore (instᵈ μ) ((zero , ★) ∷ ⟰ᵗ Σ) (genᵈ ν) (⟰ᵗ Π)
+dualStore-inst-gen ds =
+  record
+    { tagSeal∈ = tag
+    ; sealTag∈ = sealCase
+    ; sealTag★ = seal★Case
+    ; normal∈ = norm
+    }
+  where
+    tag :
+      ∀ {α} →
+      instᵈ _ α ≡ tag-to-seal →
+      (α , ★) ∈ ⟰ᵗ _
+    tag {zero} ()
+    tag {suc α} eq = ∈-renameStoreᵗ suc (tagSeal∈ ds eq)
+
+    sealCase :
+      ∀ {α} →
+      instᵈ _ α ≡ seal-to-tag →
+      (α , ★) ∈ ((zero , ★) ∷ ⟰ᵗ _)
+    sealCase {zero} eq = here refl
+    sealCase {suc α} eq = there (∈-renameStoreᵗ suc (sealTag∈ ds eq))
+
+    seal★Case :
+      ∀ {α A} →
+      instᵈ _ α ≡ seal-to-tag →
+      (α , A) ∈ ((zero , ★) ∷ ⟰ᵗ _) →
+      A ≡ ★
+    seal★Case {zero} eq (here refl) = refl
+    seal★Case {zero} eq (there αA∈Σ) = ⊥-elim (zero∉-⟰ᵗ αA∈Σ)
+    seal★Case {suc α} {A} eq αA∈Σ
+        with ∈-⟰ᵗ-inv (suc∈-cons-zero-tail αA∈Σ)
+    seal★Case {suc α} eq αA∈Σ | B , αB∈Σ , refl
+      rewrite sealTag★ ds eq αB∈Σ = refl
+
+    norm :
+      ∀ {α A} →
+      instᵈ _ α ≡ normal →
+      (α , A) ∈ ((zero , ★) ∷ ⟰ᵗ _) →
+      (α , A) ∈ ⟰ᵗ _
+    norm {zero} () αA∈Σ
+    norm {suc α} {A} eq αA∈Σ
+        with ∈-⟰ᵗ-inv (suc∈-cons-zero-tail αA∈Σ)
+    norm {suc α} eq αA∈Σ | B , αB∈Σ , refl =
+      ∈-renameStoreᵗ suc (normal∈ ds eq αB∈Σ)
+
+opp-tyAllowed :
+  ∀ {μ ν A} →
+  Oppᵈ μ ν →
+  tyAllowed μ A ≡ true →
+  tyAllowed ν A ≡ true
+opp-tyAllowed {μ = μ} {ν = ν} {A = ＇ α} opp ok
+    with μ α | ν α | opp α | ok
+opp-tyAllowed opp ok | normal | normal | opp-normal | okα = refl
+opp-tyAllowed opp ok | tag-to-seal | seal-to-tag | opp-gen-inst | ()
+opp-tyAllowed opp ok | seal-to-tag | tag-to-seal | opp-inst-gen | ()
+opp-tyAllowed {A = ‵ ι} opp ok = refl
+opp-tyAllowed {A = ★} opp ok = refl
+opp-tyAllowed {μ = μ} {ν = ν} {A = A ⇒ B} opp ok
+    with tyAllowed μ A in okA | tyAllowed μ B in okB
+opp-tyAllowed {μ = μ} {ν = ν} {A = A ⇒ B} opp ok
+    | true | true
+    with opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp okA
+       | opp-tyAllowed {μ = μ} {ν = ν} {A = B} opp okB
+opp-tyAllowed {A = A ⇒ B} opp ok | true | true | okA′ | okB′
+    rewrite okA′ | okB′ = refl
+opp-tyAllowed opp () | false | b
+opp-tyAllowed opp () | true | false
+opp-tyAllowed {A = `∀ A} opp ok =
+  opp-tyAllowed {A = A} (opp-extᵈ opp) ok
+
+tagTyAllowed-var-normal :
+  ∀ {ν α} →
+  ν α ≡ normal →
+  tagTyAllowed ν (＇ α) ≡ true
+tagTyAllowed-var-normal eq rewrite eq = refl
+
+tagTyAllowed-var-tag :
+  ∀ {ν α} →
+  ν α ≡ tag-to-seal →
+  tagTyAllowed ν (＇ α) ≡ true
+tagTyAllowed-var-tag eq rewrite eq = refl
+
+sealTyAllowed-var-normal :
+  ∀ {ν α} →
+  ν α ≡ normal →
+  sealTyAllowed ν α ≡ true
+sealTyAllowed-var-normal eq rewrite eq = refl
+
+sealTyAllowed-var-seal :
+  ∀ {ν α} →
+  ν α ≡ seal-to-tag →
+  sealTyAllowed ν α ≡ true
+sealTyAllowed-var-seal eq rewrite eq = refl
+
+dualTag-typing :
+  ∀ {μ ν Δ Σ Π G} →
+  Oppᵈ μ ν →
+  DualStore μ Σ ν Π →
+  WfTy Δ G →
+  Ground G →
+  tagTyAllowed μ G ≡ true →
+  ν ∣ Δ ∣ Π ⊢ dualTag μ G ∶ ★ =⇒ G
+dualTag-typing {μ = μ} {ν = ν} {G = ＇ α} opp ds hG gG ok
+    with μ α in μα | ν α in να | opp α | ok
+dualTag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
+    | normal | normal | opp-normal | okα
+    rewrite μα | να =
+  cast-untag {μ = ν} hG gG
+    {ok = tagTyAllowed-var-normal {ν = ν} {α = α} να}
+dualTag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
+    | tag-to-seal | seal-to-tag | opp-gen-inst | okα
+    rewrite μα | να =
+  cast-seal {μ = ν} wf★ (tagSeal∈ ds μα)
+    {A-ok = refl}
+    {α-ok = sealTyAllowed-var-seal {ν = ν} {α = α} να}
+dualTag-typing {G = ＇ α} opp ds hG gG ok
+    | seal-to-tag | tag-to-seal | opp-inst-gen | ()
+dualTag-typing {ν = ν} {G = ‵ ι} opp ds hG gG ok =
+  cast-untag {μ = ν} hG gG {ok = refl}
+dualTag-typing {ν = ν} {G = ★ ⇒ ★} opp ds hG gG ok =
+  cast-untag {μ = ν} hG gG {ok = refl}
+
+dualUntag-typing :
+  ∀ {μ ν Δ Σ Π G} →
+  Oppᵈ μ ν →
+  DualStore μ Σ ν Π →
+  WfTy Δ G →
+  Ground G →
+  tagTyAllowed μ G ≡ true →
+  ν ∣ Δ ∣ Π ⊢ dualUntag μ G ∶ G =⇒ ★
+dualUntag-typing {μ = μ} {ν = ν} {G = ＇ α} opp ds hG gG ok
+    with μ α in μα | ν α in να | opp α | ok
+dualUntag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
+    | normal | normal | opp-normal | okα
+    rewrite μα | να =
+  cast-tag {μ = ν} hG gG
+    {ok = tagTyAllowed-var-normal {ν = ν} {α = α} να}
+dualUntag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
+    | tag-to-seal | seal-to-tag | opp-gen-inst | okα
+    rewrite μα | να =
+  cast-unseal {μ = ν} wf★ (tagSeal∈ ds μα)
+    {A-ok = refl}
+    {α-ok = sealTyAllowed-var-seal {ν = ν} {α = α} να}
+dualUntag-typing {G = ＇ α} opp ds hG gG ok
+    | seal-to-tag | tag-to-seal | opp-inst-gen | ()
+dualUntag-typing {ν = ν} {G = ‵ ι} opp ds hG gG ok =
+  cast-tag {μ = ν} hG gG {ok = refl}
+dualUntag-typing {ν = ν} {G = ★ ⇒ ★} opp ds hG gG ok =
+  cast-tag {μ = ν} hG gG {ok = refl}
+
+dualSeal-typing :
+  ∀ {μ ν Δ Σ Π A α} →
+  Oppᵈ μ ν →
+  DualStore μ Σ ν Π →
+  StoreWfAt Δ Σ →
+  WfTy Δ A →
+  (α , A) ∈ Σ →
+  tyAllowed μ A ≡ true →
+  sealTyAllowed μ α ≡ true →
+  ν ∣ Δ ∣ Π ⊢ dualSeal μ A α ∶ ＇ α =⇒ A
+dualSeal-typing {μ = μ} {ν = ν} {A = A} {α = α}
+    opp ds wfΣ hA αA∈Σ A-ok α-ok
+    with μ α in μα | ν α in να | opp α | α-ok
+dualSeal-typing {μ = μ} {ν = ν} {A = A} {α = α}
+    opp ds wfΣ hA αA∈Σ A-ok α-ok
+    | normal | normal | opp-normal | okα
+    rewrite μα | να =
+  cast-unseal {μ = ν} hA (normal∈ ds μα αA∈Σ)
+    {A-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok}
+    {α-ok = sealTyAllowed-var-normal {ν = ν} {α = α} να}
+dualSeal-typing {A = A} {α = α} opp ds wfΣ hA αA∈Σ A-ok α-ok
+    | tag-to-seal | seal-to-tag | opp-gen-inst | ()
+dualSeal-typing {ν = ν} {A = A} {α = α}
+    opp ds wfΣ hA αA∈Σ A-ok α-ok
+    | seal-to-tag | tag-to-seal | opp-inst-gen | okα
+    rewrite sealTag★ ds μα αA∈Σ | μα | να =
+  cast-tag {μ = ν} (wfVar (bound wfΣ αA∈Σ)) (＇ α)
+    {ok = tagTyAllowed-var-tag {ν = ν} {α = α} να}
+
+dualUnseal-typing :
+  ∀ {μ ν Δ Σ Π A α} →
+  Oppᵈ μ ν →
+  DualStore μ Σ ν Π →
+  StoreWfAt Δ Σ →
+  WfTy Δ A →
+  (α , A) ∈ Σ →
+  tyAllowed μ A ≡ true →
+  sealTyAllowed μ α ≡ true →
+  ν ∣ Δ ∣ Π ⊢ dualUnseal μ α A ∶ A =⇒ ＇ α
+dualUnseal-typing {μ = μ} {ν = ν} {A = A} {α = α}
+    opp ds wfΣ hA αA∈Σ A-ok α-ok
+    with μ α in μα | ν α in να | opp α | α-ok
+dualUnseal-typing {μ = μ} {ν = ν} {A = A} {α = α}
+    opp ds wfΣ hA αA∈Σ A-ok α-ok
+    | normal | normal | opp-normal | okα
+    rewrite μα | να =
+  cast-seal {μ = ν} hA (normal∈ ds μα αA∈Σ)
+    {A-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok}
+    {α-ok = sealTyAllowed-var-normal {ν = ν} {α = α} να}
+dualUnseal-typing {A = A} {α = α} opp ds wfΣ hA αA∈Σ A-ok α-ok
+    | tag-to-seal | seal-to-tag | opp-gen-inst | ()
+dualUnseal-typing {ν = ν} {A = A} {α = α}
+    opp ds wfΣ hA αA∈Σ A-ok α-ok
+    | seal-to-tag | tag-to-seal | opp-inst-gen | okα
+    rewrite sealTag★ ds μα αA∈Σ | μα | να =
+  cast-untag {μ = ν} (wfVar (bound wfΣ αA∈Σ)) (＇ α)
+    {ok = tagTyAllowed-var-tag {ν = ν} {α = α} να}
+
+coercion-dual-flipᵐ :
+  ∀ {μ ν Δ Σ Π c A B} →
+  Oppᵈ μ ν →
+  DualStore μ Σ ν Π →
+  StoreWfAt Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  ν ∣ Δ ∣ Π ⊢ dualWith μ c ∶ B =⇒ A
+coercion-dual-flipᵐ {μ = μ} {ν = ν} opp ds wfΣ
+    (cast-id {A = A} hA {ok = ok}) =
+  cast-id hA {ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp ok}
+coercion-dual-flipᵐ opp ds wfΣ
+    (cast-seal hA αA∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
+  dualSeal-typing opp ds wfΣ hA αA∈Σ A-ok α-ok
+coercion-dual-flipᵐ opp ds wfΣ
+    (cast-unseal hA αA∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
+  dualUnseal-typing opp ds wfΣ hA αA∈Σ A-ok α-ok
+coercion-dual-flipᵐ opp ds wfΣ (cast-seq c⊢ d⊢) =
+  cast-seq (coercion-dual-flipᵐ opp ds wfΣ d⊢)
+           (coercion-dual-flipᵐ opp ds wfΣ c⊢)
+coercion-dual-flipᵐ opp ds wfΣ (cast-tag hG gG {ok = ok}) =
+  dualTag-typing opp ds hG gG ok
+coercion-dual-flipᵐ opp ds wfΣ (cast-untag hG gG {ok = ok}) =
+  dualUntag-typing opp ds hG gG ok
+coercion-dual-flipᵐ opp ds wfΣ (cast-fun c⊢ d⊢) =
+  cast-fun (coercion-dual-flipᵐ opp ds wfΣ c⊢)
+           (coercion-dual-flipᵐ opp ds wfΣ d⊢)
+coercion-dual-flipᵐ opp ds wfΣ (cast-all c⊢) =
+  cast-all
+    (coercion-dual-flipᵐ
+      (opp-extᵈ opp)
+      (dualStore-ext ds)
+      (StoreWfAt-⟰ᵗ wfΣ)
+      c⊢)
+coercion-dual-flipᵐ {μ = μ} {ν = ν} opp ds wfΣ
+    (cast-inst {B = B} hB {B-ok = B-ok} c⊢) =
+  cast-gen hB
+    {A-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = B} opp B-ok}
+    (coercion-dual-flipᵐ
+      (opp-inst-genᵈ opp)
+      (dualStore-inst-gen ds)
+      (StoreWfAt-cons z<s wf★ (StoreWfAt-⟰ᵗ wfΣ))
+      c⊢)
+coercion-dual-flipᵐ {μ = μ} {ν = ν} opp ds wfΣ
+    (cast-gen {A = A} hA {A-ok = A-ok} c⊢) =
+  cast-inst hA
+    {B-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok}
+    (coercion-dual-flipᵐ
+      (opp-gen-instᵈ opp)
+      (dualStore-gen-inst ds)
+      (StoreWfAt-⟰ᵗ wfΣ)
+      c⊢)
+
+coercion-dual-flip :
+  ∀ {Δ Σ c A B} →
+  StoreWfAt Δ Σ →
+  Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  Δ ∣ Σ ⊢ - c ∶ B =⇒ A
+coercion-dual-flip wfΣ c⊢ =
+  coercion-dual-flipᵐ opp-normalᵈ dualStore-normal wfΣ c⊢
+
+dual-flips-typing :
+  ∀ {Δ Σ c A B} →
+  StoreWfAt Δ Σ →
+  Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  Δ ∣ Σ ⊢ - c ∶ B =⇒ A
+dual-flips-typing = coercion-dual-flip
 
 ------------------------------------------------------------------------
 -- Coercion endpoint well-formedness
 ------------------------------------------------------------------------
+
+coercion-wfᵐ :
+  ∀ {μ Δ Σ c A B} →
+  StoreWfAt Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  WfTy Δ A × WfTy Δ B
+coercion-wfᵐ wfΣ (cast-id hA) = hA , hA
+coercion-wfᵐ wfΣ (cast-seal hA α∈Σ) =
+  hA , wfVar (bound wfΣ α∈Σ)
+coercion-wfᵐ wfΣ (cast-unseal hA α∈Σ) =
+  wfVar (bound wfΣ α∈Σ) , hA
+coercion-wfᵐ wfΣ (cast-seq c⊢ d⊢)
+    with coercion-wfᵐ wfΣ c⊢ | coercion-wfᵐ wfΣ d⊢
+coercion-wfᵐ wfΣ (cast-seq c⊢ d⊢)
+    | hA , hB | hB′ , hC =
+  hA , hC
+coercion-wfᵐ wfΣ (cast-tag hG gG) = hG , wf★
+coercion-wfᵐ wfΣ (cast-untag hH gH) = wf★ , hH
+coercion-wfᵐ wfΣ (cast-fun c⊢ d⊢)
+    with coercion-wfᵐ wfΣ c⊢ | coercion-wfᵐ wfΣ d⊢
+coercion-wfᵐ wfΣ (cast-fun c⊢ d⊢)
+    | hA′ , hA | hB , hB′ =
+  wf⇒ hA hB , wf⇒ hA′ hB′
+coercion-wfᵐ wfΣ (cast-all c⊢)
+    with coercion-wfᵐ (StoreWfAt-⟰ᵗ wfΣ) c⊢
+coercion-wfᵐ wfΣ (cast-all c⊢) | hA , hB =
+  wf∀ hA , wf∀ hB
+coercion-wfᵐ wfΣ (cast-inst hB c⊢)
+    with coercion-wfᵐ
+      (StoreWfAt-cons z<s wf★ (StoreWfAt-⟰ᵗ wfΣ))
+      c⊢
+coercion-wfᵐ wfΣ (cast-inst hB c⊢) | hA , hB′ =
+  wf∀ hA , hB
+coercion-wfᵐ wfΣ (cast-gen hA c⊢)
+    with coercion-wfᵐ (StoreWfAt-⟰ᵗ wfΣ) c⊢
+coercion-wfᵐ wfΣ (cast-gen hA c⊢) | hA′ , hB =
+  hA , wf∀ hB
 
 coercion-wf :
   ∀ {Δ Σ c A B} →
   StoreWfAt Δ Σ →
   Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   WfTy Δ A × WfTy Δ B
-coercion-wf wfΣ (cast-id hA) = hA , hA
-coercion-wf wfΣ (cast-seal hA α∈Σ) =
-  hA , wfVar (bound wfΣ α∈Σ)
-coercion-wf wfΣ (cast-unseal hA α∈Σ) =
-  wfVar (bound wfΣ α∈Σ) , hA
-coercion-wf wfΣ (cast-seq c⊢ d⊢)
-    with coercion-wf wfΣ c⊢ | coercion-wf wfΣ d⊢
-coercion-wf wfΣ (cast-seq c⊢ d⊢)
-    | hA , hB | hB′ , hC =
-  hA , hC
-coercion-wf wfΣ (cast-tag hG gG) = hG , wf★
-coercion-wf wfΣ (cast-untag hH gH) = wf★ , hH
-coercion-wf wfΣ (cast-fun c⊢ d⊢)
-    with coercion-wf wfΣ c⊢ | coercion-wf wfΣ d⊢
-coercion-wf wfΣ (cast-fun c⊢ d⊢)
-    | hA′ , hA | hB , hB′ =
-  wf⇒ hA hB , wf⇒ hA′ hB′
-coercion-wf wfΣ (cast-all c⊢)
-    with coercion-wf (StoreWfAt-⟰ᵗ wfΣ) c⊢
-coercion-wf wfΣ (cast-all c⊢) | hA , hB =
-  wf∀ hA , wf∀ hB
-coercion-wf wfΣ (cast-inst hB c⊢)
-    with coercion-wf
-      (StoreWfAt-cons z<s wf★ (StoreWfAt-⟰ᵗ wfΣ))
-      c⊢
-coercion-wf wfΣ (cast-inst hB c⊢) | hA , hB′ =
-  wf∀ hA , hB
-coercion-wf wfΣ (cast-gen hA c⊢)
-    with coercion-wf (StoreWfAt-⟰ᵗ wfΣ) c⊢
-coercion-wf wfΣ (cast-gen hA c⊢) | hA′ , hB =
-  hA , wf∀ hB
+coercion-wf = coercion-wfᵐ
 
 ------------------------------------------------------------------------
 -- Typing the reveal/conceal coercions generated after fresh allocation
@@ -593,8 +1392,10 @@ reveal-var-hit :
   (α , C) ∈ Σ →
   Δ ∣ Σ ⊢ reveal (＇ α) α C ∶ ＇ α =⇒ C
 reveal-var-hit {α = α} hC α∈Σ with α ≟ α
-reveal-var-hit {α = α} hC α∈Σ | yes refl =
+reveal-var-hit {α = α} {C = C} hC α∈Σ | yes refl =
   cast-unseal hC α∈Σ
+    {A-ok = tyAllowed-normal C}
+    {α-ok = sealTyAllowed-normal α}
 reveal-var-hit {α = α} hC α∈Σ | no α≢α =
   ⊥-elim (α≢α refl)
 
@@ -604,8 +1405,10 @@ conceal-var-hit :
   (α , C) ∈ Σ →
   Δ ∣ Σ ⊢ conceal (＇ α) α C ∶ C =⇒ ＇ α
 conceal-var-hit {α = α} hC α∈Σ with α ≟ α
-conceal-var-hit {α = α} hC α∈Σ | yes refl =
+conceal-var-hit {α = α} {C = C} hC α∈Σ | yes refl =
   cast-seal hC α∈Σ
+    {A-ok = tyAllowed-normal C}
+    {α-ok = sealTyAllowed-normal α}
 conceal-var-hit {α = α} hC α∈Σ | no α≢α =
   ⊥-elim (α≢α refl)
 
@@ -618,7 +1421,7 @@ reveal-var-miss {α = α} {Y = Y} Y≢α hY with α ≟ Y
 reveal-var-miss {α = α} {Y = Y} Y≢α hY | yes α≡Y =
   ⊥-elim (Y≢α (sym α≡Y))
 reveal-var-miss {α = α} {Y = Y} Y≢α hY | no α≢Y =
-  cast-id hY
+  cast-id hY {ok = refl}
 
 conceal-var-miss :
   ∀ {Δ Σ α C Y} →
@@ -629,7 +1432,7 @@ conceal-var-miss {α = α} {Y = Y} Y≢α hY with α ≟ Y
 conceal-var-miss {α = α} {Y = Y} Y≢α hY | yes α≡Y =
   ⊥-elim (Y≢α (sym α≡Y))
 conceal-var-miss {α = α} {Y = Y} Y≢α hY | no α≢Y =
-  cast-id hY
+  cast-id hY {ok = refl}
 
 mutual
   reveal-typing-env :
@@ -653,9 +1456,9 @@ mutual
       rewrite σX≡var =
     reveal-var-miss ρX≢α (wfVar (hρ X<Θ))
   reveal-typing-env wfBase hρ hσ env hC α∈Σ =
-    cast-id wfBase
+    cast-id wfBase {ok = refl}
   reveal-typing-env wf★ hρ hσ env hC α∈Σ =
-    cast-id wf★
+    cast-id wf★ {ok = refl}
   reveal-typing-env (wf⇒ hA hB) hρ hσ env hC α∈Σ =
     cast-fun
       (conceal-typing-env hA hρ hσ env hC α∈Σ)
@@ -663,13 +1466,15 @@ mutual
   reveal-typing-env {B = `∀ B} {ρ = ρ} {σ = σ}
       (wf∀ hB) hρ hσ env hC α∈Σ =
     cast-all
-      (reveal-typing-env
-        hB
-        (TyRenameWf-ext hρ)
-        (TySubstWf-exts hσ)
-        (RevealEnv-ext env)
-        (renameᵗ-preserves-WfTy hC TyRenameWf-suc)
-        (∈-renameStoreᵗ suc α∈Σ))
+      (coercion-mode-relax
+        (λ { zero → refl ; (suc X) → refl })
+        (reveal-typing-env
+          hB
+          (TyRenameWf-ext hρ)
+          (TySubstWf-exts hσ)
+          (RevealEnv-ext env)
+          (renameᵗ-preserves-WfTy hC TyRenameWf-suc)
+          (∈-renameStoreᵗ suc α∈Σ)))
 
   conceal-typing-env :
     ∀ {Θ Δ Σ B α C ρ σ} →
@@ -692,9 +1497,9 @@ mutual
       rewrite σX≡var =
     conceal-var-miss ρX≢α (wfVar (hρ X<Θ))
   conceal-typing-env wfBase hρ hσ env hC α∈Σ =
-    cast-id wfBase
+    cast-id wfBase {ok = refl}
   conceal-typing-env wf★ hρ hσ env hC α∈Σ =
-    cast-id wf★
+    cast-id wf★ {ok = refl}
   conceal-typing-env (wf⇒ hA hB) hρ hσ env hC α∈Σ =
     cast-fun
       (reveal-typing-env hA hρ hσ env hC α∈Σ)
@@ -702,13 +1507,15 @@ mutual
   conceal-typing-env {B = `∀ B} {ρ = ρ} {σ = σ}
       (wf∀ hB) hρ hσ env hC α∈Σ =
     cast-all
-      (conceal-typing-env
-        hB
-        (TyRenameWf-ext hρ)
-        (TySubstWf-exts hσ)
-        (RevealEnv-ext env)
-        (renameᵗ-preserves-WfTy hC TyRenameWf-suc)
-        (∈-renameStoreᵗ suc α∈Σ))
+      (coercion-mode-relax
+        (λ { zero → refl ; (suc X) → refl })
+        (conceal-typing-env
+          hB
+          (TyRenameWf-ext hρ)
+          (TySubstWf-exts hσ)
+          (RevealEnv-ext env)
+          (renameᵗ-preserves-WfTy hC TyRenameWf-suc)
+          (∈-renameStoreᵗ suc α∈Σ)))
 
 reveal-fresh-typing :
   ∀ {Δ Σ A B} →
@@ -758,34 +1565,40 @@ conceal-fresh-typing {Δ = Δ} hA hB =
 -- Syntactic endpoints agree with typed endpoints
 ------------------------------------------------------------------------
 
+coercion-src-tgtᵐ :
+  ∀ {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  src c ≡ A × tgt c ≡ B
+coercion-src-tgtᵐ (cast-id hA) = refl , refl
+coercion-src-tgtᵐ (cast-seal hA α∈Σ) = refl , refl
+coercion-src-tgtᵐ (cast-unseal hA α∈Σ) = refl , refl
+coercion-src-tgtᵐ (cast-seq c⊢ d⊢)
+    with coercion-src-tgtᵐ c⊢ | coercion-src-tgtᵐ d⊢
+coercion-src-tgtᵐ (cast-seq c⊢ d⊢)
+    | src-c , tgt-c | src-d , tgt-d rewrite src-c | tgt-d =
+  refl , refl
+coercion-src-tgtᵐ (cast-tag hG gG) = refl , refl
+coercion-src-tgtᵐ (cast-untag hH gH) = refl , refl
+coercion-src-tgtᵐ (cast-fun c⊢ d⊢)
+    with coercion-src-tgtᵐ c⊢ | coercion-src-tgtᵐ d⊢
+coercion-src-tgtᵐ (cast-fun c⊢ d⊢)
+    | src-c , tgt-c | src-d , tgt-d rewrite tgt-c | src-d | src-c | tgt-d =
+  refl , refl
+coercion-src-tgtᵐ (cast-all c⊢)
+    with coercion-src-tgtᵐ c⊢
+coercion-src-tgtᵐ (cast-all c⊢) | src-c , tgt-c rewrite src-c | tgt-c =
+  refl , refl
+coercion-src-tgtᵐ (cast-inst hB c⊢)
+    with coercion-src-tgtᵐ c⊢
+coercion-src-tgtᵐ (cast-inst hB c⊢) | src-c , tgt-c rewrite src-c =
+  refl , refl
+coercion-src-tgtᵐ (cast-gen hA c⊢)
+    with coercion-src-tgtᵐ c⊢
+coercion-src-tgtᵐ (cast-gen hA c⊢) | src-c , tgt-c rewrite tgt-c =
+  refl , refl
+
 coercion-src-tgt :
   ∀ {Δ Σ c A B} →
   Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   src c ≡ A × tgt c ≡ B
-coercion-src-tgt (cast-id hA) = refl , refl
-coercion-src-tgt (cast-seal hA α∈Σ) = refl , refl
-coercion-src-tgt (cast-unseal hA α∈Σ) = refl , refl
-coercion-src-tgt (cast-seq c⊢ d⊢)
-    with coercion-src-tgt c⊢ | coercion-src-tgt d⊢
-coercion-src-tgt (cast-seq c⊢ d⊢)
-    | src-c , tgt-c | src-d , tgt-d rewrite src-c | tgt-d =
-  refl , refl
-coercion-src-tgt (cast-tag hG gG) = refl , refl
-coercion-src-tgt (cast-untag hH gH) = refl , refl
-coercion-src-tgt (cast-fun c⊢ d⊢)
-    with coercion-src-tgt c⊢ | coercion-src-tgt d⊢
-coercion-src-tgt (cast-fun c⊢ d⊢)
-    | src-c , tgt-c | src-d , tgt-d rewrite tgt-c | src-d | src-c | tgt-d =
-  refl , refl
-coercion-src-tgt (cast-all c⊢)
-    with coercion-src-tgt c⊢
-coercion-src-tgt (cast-all c⊢) | src-c , tgt-c rewrite src-c | tgt-c =
-  refl , refl
-coercion-src-tgt (cast-inst hB c⊢)
-    with coercion-src-tgt c⊢
-coercion-src-tgt (cast-inst hB c⊢) | src-c , tgt-c rewrite src-c =
-  refl , refl
-coercion-src-tgt (cast-gen hA c⊢)
-    with coercion-src-tgt c⊢
-coercion-src-tgt (cast-gen hA c⊢) | src-c , tgt-c rewrite tgt-c =
-  refl , refl
+coercion-src-tgt = coercion-src-tgtᵐ

--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -53,23 +53,21 @@ coercion-weakenᵐ :
   StoreIncl Σ Σ′ →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   μ ∣ Δ′ ∣ Σ′ ⊢ c ∶ A =⇒ B
-coercion-weakenᵐ Δ≤Δ′ incl (cast-id hA {ok = ok}) =
-  cast-id (WfTy-weakenᵗ hA Δ≤Δ′) {ok = ok}
+coercion-weakenᵐ Δ≤Δ′ incl (cast-id hA ok) =
+  cast-id (WfTy-weakenᵗ hA Δ≤Δ′) ok
 coercion-weakenᵐ Δ≤Δ′ incl
-    (cast-seal hA α∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
-  cast-seal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ)
-    {A-ok = A-ok} {α-ok = α-ok}
+    (cast-seal hA α∈Σ A-ok α-ok) =
+  cast-seal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ) A-ok α-ok
 coercion-weakenᵐ Δ≤Δ′ incl
-    (cast-unseal hA α∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
-  cast-unseal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ)
-    {A-ok = A-ok} {α-ok = α-ok}
+    (cast-unseal hA α∈Σ A-ok α-ok) =
+  cast-unseal (WfTy-weakenᵗ hA Δ≤Δ′) (incl α∈Σ) A-ok α-ok
 coercion-weakenᵐ Δ≤Δ′ incl (cast-seq c⊢ d⊢) =
   cast-seq (coercion-weakenᵐ Δ≤Δ′ incl c⊢)
            (coercion-weakenᵐ Δ≤Δ′ incl d⊢)
-coercion-weakenᵐ Δ≤Δ′ incl (cast-tag hG gG {ok = ok}) =
-  cast-tag (WfTy-weakenᵗ hG Δ≤Δ′) gG {ok = ok}
-coercion-weakenᵐ Δ≤Δ′ incl (cast-untag hH gH {ok = ok}) =
-  cast-untag (WfTy-weakenᵗ hH Δ≤Δ′) gH {ok = ok}
+coercion-weakenᵐ Δ≤Δ′ incl (cast-tag hG gG ok) =
+  cast-tag (WfTy-weakenᵗ hG Δ≤Δ′) gG ok
+coercion-weakenᵐ Δ≤Δ′ incl (cast-untag hH gH ok) =
+  cast-untag (WfTy-weakenᵗ hH Δ≤Δ′) gH ok
 coercion-weakenᵐ Δ≤Δ′ incl (cast-fun c⊢ d⊢) =
   cast-fun (coercion-weakenᵐ Δ≤Δ′ incl c⊢)
            (coercion-weakenᵐ Δ≤Δ′ incl d⊢)
@@ -79,18 +77,18 @@ coercion-weakenᵐ Δ≤Δ′ incl (cast-all c⊢) =
       (s≤s Δ≤Δ′)
       (renameStoreᵗ-incl suc incl)
       c⊢)
-coercion-weakenᵐ Δ≤Δ′ incl (cast-inst hB {B-ok = B-ok} c⊢) =
+coercion-weakenᵐ Δ≤Δ′ incl (cast-inst hB B-ok c⊢) =
   cast-inst
     (WfTy-weakenᵗ hB Δ≤Δ′)
-    {B-ok = B-ok}
+    B-ok
     (coercion-weakenᵐ
       (s≤s Δ≤Δ′)
       (StoreIncl-cons (renameStoreᵗ-incl suc incl))
       c⊢)
-coercion-weakenᵐ Δ≤Δ′ incl (cast-gen hA {A-ok = A-ok} c⊢) =
+coercion-weakenᵐ Δ≤Δ′ incl (cast-gen hA A-ok c⊢) =
   cast-gen
     (WfTy-weakenᵗ hA Δ≤Δ′)
-    {A-ok = A-ok}
+    A-ok
     (coercion-weakenᵐ
       (s≤s Δ≤Δ′)
       (renameStoreᵗ-incl suc incl)
@@ -118,9 +116,9 @@ coercion-weaken-suc {Δ = Δ} c⊢ =
 dual-inst-example⊢ :
   zero ∣ [] ⊢ inst ★ (seal ★ zero ︔ unseal zero ★) ∶ `∀ ★ =⇒ ★
 dual-inst-example⊢ =
-  cast-inst wf★ {B-ok = refl}
-    (cast-seq (cast-seal wf★ (here refl) {A-ok = refl} {α-ok = refl})
-              (cast-unseal wf★ (here refl) {A-ok = refl} {α-ok = refl}))
+  cast-inst wf★ refl
+    (cast-seq (cast-seal wf★ (here refl) refl refl)
+              (cast-unseal wf★ (here refl) refl refl))
 
 dual-inst-example-dual≡ :
   - inst ★ (seal ★ zero ︔ unseal zero ★)
@@ -130,15 +128,15 @@ dual-inst-example-dual≡ = refl
 dual-inst-example-dual⊢ :
   zero ∣ [] ⊢ - inst ★ (seal ★ zero ︔ unseal zero ★) ∶ ★ =⇒ `∀ ★
 dual-inst-example-dual⊢ =
-  cast-gen wf★ {A-ok = refl}
-    (cast-seq (cast-untag (wfVar z<s) (＇ zero) {ok = refl})
-              (cast-tag (wfVar z<s) (＇ zero) {ok = refl}))
+  cast-gen wf★ refl
+    (cast-seq (cast-untag (wfVar z<s) (＇ zero) refl)
+              (cast-tag (wfVar z<s) (＇ zero) refl))
 
 dual-inst-tag-counterexample-not-typable :
   zero ∣ [] ⊢ inst ★ ((＇ zero) !) ∶ `∀ (＇ zero) =⇒ ★ →
   ⊥
 dual-inst-tag-counterexample-not-typable
-    (cast-inst h★ (cast-tag hα (＇ zero) {ok = ()}))
+    (cast-inst h★ _ (cast-tag hα (＇ zero) ()))
 
 dual-inst-tag-counterexample-dual≡ :
   - inst ★ ((＇ zero) !) ≡ gen ★ (seal ★ zero)
@@ -147,7 +145,8 @@ dual-inst-tag-counterexample-dual≡ = refl
 dual-inst-tag-counterexample-dual-not-typable :
   zero ∣ [] ⊢ - inst ★ ((＇ zero) !) ∶ ★ =⇒ `∀ (＇ zero) →
   ⊥
-dual-inst-tag-counterexample-dual-not-typable (cast-gen h★ (cast-seal hA ()))
+dual-inst-tag-counterexample-dual-not-typable
+    (cast-gen h★ _ (cast-seal hA () _ _))
 
 ------------------------------------------------------------------------
 -- Duality as an involution
@@ -286,30 +285,30 @@ coercion-dual-safe :
   StoreDualSafe μ Σ →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   DualSafe μ c
-coercion-dual-safe safeΣ (cast-id hA) = safe-id
-coercion-dual-safe safeΣ (cast-seal hA α∈Σ) =
+coercion-dual-safe safeΣ (cast-id hA _) = safe-id
+coercion-dual-safe safeΣ (cast-seal hA α∈Σ _ _) =
   safe-seal (safeΣ α∈Σ)
-coercion-dual-safe safeΣ (cast-unseal hA α∈Σ) =
+coercion-dual-safe safeΣ (cast-unseal hA α∈Σ _ _) =
   safe-unseal (safeΣ α∈Σ)
 coercion-dual-safe safeΣ (cast-seq c⊢ d⊢) =
   safe-seq (coercion-dual-safe safeΣ c⊢)
            (coercion-dual-safe safeΣ d⊢)
-coercion-dual-safe safeΣ (cast-tag hG gG) = safe-tag
-coercion-dual-safe safeΣ (cast-untag hH gH) = safe-untag
+coercion-dual-safe safeΣ (cast-tag hG gG _) = safe-tag
+coercion-dual-safe safeΣ (cast-untag hH gH _) = safe-untag
 coercion-dual-safe safeΣ (cast-fun c⊢ d⊢) =
   safe-fun (coercion-dual-safe safeΣ c⊢)
            (coercion-dual-safe safeΣ d⊢)
 coercion-dual-safe safeΣ (cast-all c⊢) =
   safe-all (coercion-dual-safe (store-dual-safe-⟰ᵗ-extᵈ safeΣ) c⊢)
-coercion-dual-safe safeΣ (cast-inst hB c⊢) =
+coercion-dual-safe safeΣ (cast-inst hB _ c⊢) =
   safe-inst (coercion-dual-safe (store-dual-safe-instᵈ safeΣ) c⊢)
-coercion-dual-safe safeΣ (cast-gen hA c⊢) =
+coercion-dual-safe safeΣ (cast-gen hA _ c⊢) =
   safe-gen (coercion-dual-safe (store-dual-safe-⟰ᵗ-genᵈ safeΣ) c⊢)
 
 dualTag-involutive :
   ∀ {μ ν G} →
   Oppᵈ μ ν →
-  dualWith ν (dualTag μ G) ≡ G !
+  dual ν (dualTag μ G) ≡ G !
 dualTag-involutive {μ = μ} {ν = ν} {G = ＇ α} opp
     with μ α in μα | ν α in να | opp α
 dualTag-involutive {G = ＇ α} opp | normal | normal | opp-normal
@@ -328,7 +327,7 @@ dualTag-involutive {G = `∀ A} opp = refl
 dualUntag-involutive :
   ∀ {μ ν G} →
   Oppᵈ μ ν →
-  dualWith ν (dualUntag μ G) ≡ G ？
+  dual ν (dualUntag μ G) ≡ G ？
 dualUntag-involutive {μ = μ} {ν = ν} {G = ＇ α} opp
     with μ α in μα | ν α in να | opp α
 dualUntag-involutive {G = ＇ α} opp | normal | normal | opp-normal
@@ -348,7 +347,7 @@ dualSeal-involutive :
   ∀ {μ ν A α} →
   Oppᵈ μ ν →
   SealOk μ A α →
-  dualWith ν (dualSeal μ A α) ≡ seal A α
+  dual ν (dualSeal μ A α) ≡ seal A α
 dualSeal-involutive {μ = μ} {ν = ν} {A = A} {α = α} opp ok
     with μ α in μα | ν α in να | opp α | ok
 dualSeal-involutive opp ok | normal | normal | opp-normal | _
@@ -370,7 +369,7 @@ dualUnseal-involutive :
   ∀ {μ ν α A} →
   Oppᵈ μ ν →
   SealOk μ A α →
-  dualWith ν (dualUnseal μ α A) ≡ unseal α A
+  dual ν (dualUnseal μ α A) ≡ unseal α A
 dualUnseal-involutive {μ = μ} {ν = ν} {α = α} {A = A} opp ok
     with μ α in μα | ν α in να | opp α | ok
 dualUnseal-involutive opp ok | normal | normal | opp-normal | _
@@ -388,35 +387,35 @@ dualUnseal-involutive opp ok
     | seal-to-tag | tag-to-seal | opp-inst-gen | seal-ok-★ refl
     rewrite μα | να = refl
 
-dualWith-involutive :
+dualᵐ-involutive :
   ∀ {μ ν c} →
   Oppᵈ μ ν →
   DualSafe μ c →
-  dualWith ν (dualWith μ c) ≡ c
-dualWith-involutive opp safe-id = refl
-dualWith-involutive opp (safe-seq safe-c safe-d) =
-  cong₂ _︔_ (dualWith-involutive opp safe-c)
-             (dualWith-involutive opp safe-d)
-dualWith-involutive opp (safe-fun safe-c safe-d) =
-  cong₂ _↦_ (dualWith-involutive opp safe-c)
-             (dualWith-involutive opp safe-d)
-dualWith-involutive opp (safe-all safe-c) =
-  cong `∀ (dualWith-involutive (opp-extᵈ opp) safe-c)
-dualWith-involutive opp safe-tag = dualTag-involutive opp
-dualWith-involutive opp safe-untag = dualUntag-involutive opp
-dualWith-involutive opp (safe-seal ok) = dualSeal-involutive opp ok
-dualWith-involutive opp (safe-unseal ok) = dualUnseal-involutive opp ok
-dualWith-involutive opp (safe-gen safe-c) =
-  cong (gen _) (dualWith-involutive (opp-gen-instᵈ opp) safe-c)
-dualWith-involutive opp (safe-inst safe-c) =
-  cong (inst _) (dualWith-involutive (opp-inst-genᵈ opp) safe-c)
+  dual ν (dual μ c) ≡ c
+dualᵐ-involutive opp safe-id = refl
+dualᵐ-involutive opp (safe-seq safe-c safe-d) =
+  cong₂ _︔_ (dualᵐ-involutive opp safe-c)
+             (dualᵐ-involutive opp safe-d)
+dualᵐ-involutive opp (safe-fun safe-c safe-d) =
+  cong₂ _↦_ (dualᵐ-involutive opp safe-c)
+             (dualᵐ-involutive opp safe-d)
+dualᵐ-involutive opp (safe-all safe-c) =
+  cong `∀ (dualᵐ-involutive (opp-extᵈ opp) safe-c)
+dualᵐ-involutive opp safe-tag = dualTag-involutive opp
+dualᵐ-involutive opp safe-untag = dualUntag-involutive opp
+dualᵐ-involutive opp (safe-seal ok) = dualSeal-involutive opp ok
+dualᵐ-involutive opp (safe-unseal ok) = dualUnseal-involutive opp ok
+dualᵐ-involutive opp (safe-gen safe-c) =
+  cong (gen _) (dualᵐ-involutive (opp-gen-instᵈ opp) safe-c)
+dualᵐ-involutive opp (safe-inst safe-c) =
+  cong (inst _) (dualᵐ-involutive (opp-inst-genᵈ opp) safe-c)
 
 dual-involutive :
   ∀ {Δ Σ c A B} →
   Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   - (- c) ≡ c
 dual-involutive c⊢ =
-  dualWith-involutive opp-normalᵈ
+  dualᵐ-involutive opp-normalᵈ
     (coercion-dual-safe store-dual-safe-normal c⊢)
 
 dual-raw-involutive-counterexample :
@@ -428,7 +427,7 @@ dual-raw-involutive-counterexample-not-typable :
   ∀ {Δ Σ A B} →
   Δ ∣ Σ ⊢ gen ★ (seal (‵ `ℕ) zero) ∶ A =⇒ B →
   ⊥
-dual-raw-involutive-counterexample-not-typable (cast-gen h★ ())
+dual-raw-involutive-counterexample-not-typable (cast-gen h★ _ ())
 
 ------------------------------------------------------------------------
 -- Coercion typing under type renaming
@@ -554,12 +553,12 @@ modeRename-tagTyAllowed {ρ = ρ} {μ = μ} {ν = ν} {G = `∀ A} rel ok =
     {ρ = extᵗ ρ} {μ = extᵈ μ} {ν = extᵈ ν} {A = A}
     (ModeRename-ext rel) ok
 
-modeRename-sealTyAllowed :
+modeRename-sealModeAllowed :
   ∀ {ρ μ ν α} →
   ModeRename ρ μ ν →
-  sealTyAllowed μ α ≡ true →
-  sealTyAllowed ν (ρ α) ≡ true
-modeRename-sealTyAllowed {α = α} rel ok =
+  sealModeAllowed (μ α) ≡ true →
+  sealModeAllowed (ν (ρ α)) ≡ true
+modeRename-sealModeAllowed {α = α} rel ok =
   mode≤-seal (rel α) ok
 
 ModeAllNormal : DualEnv → Set
@@ -614,10 +613,10 @@ tagTyAllowed-normal :
   tagTyAllowed normalᵈ G ≡ true
 tagTyAllowed-normal = tagTyAllowed-allNormal ModeAllNormal-normal
 
-sealTyAllowed-normal :
+sealModeAllowed-normal :
   ∀ α →
-  sealTyAllowed normalᵈ α ≡ true
-sealTyAllowed-normal α = refl
+  sealModeAllowed (normalᵈ α) ≡ true
+sealModeAllowed-normal α = refl
 
 ModeIncl-ext :
   ∀ {μ ν} →
@@ -664,13 +663,13 @@ modeIncl-tagTyAllowed {μ = μ} {ν = ν} {G = G} incl ok =
     (modeRename-tagTyAllowed
       {ρ = λ X → X} {μ = μ} {ν = ν} {G = G} incl ok)
 
-modeIncl-sealTyAllowed :
+modeIncl-sealModeAllowed :
   ∀ {μ ν α} →
   ModeIncl μ ν →
-  sealTyAllowed μ α ≡ true →
-  sealTyAllowed ν α ≡ true
-modeIncl-sealTyAllowed {μ = μ} {ν = ν} {α = α} incl ok =
-  modeRename-sealTyAllowed
+  sealModeAllowed (μ α) ≡ true →
+  sealModeAllowed (ν α) ≡ true
+modeIncl-sealModeAllowed {μ = μ} {ν = ν} {α = α} incl ok =
+  modeRename-sealModeAllowed
     {ρ = λ X → X} {μ = μ} {ν = ν} {α = α} incl ok
 
 coercion-mode-relax :
@@ -678,39 +677,37 @@ coercion-mode-relax :
   ModeIncl μ ν →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   ν ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
-coercion-mode-relax incl (cast-id {A = A} hA {ok = ok}) =
-  cast-id hA {ok = modeIncl-tyAllowed {A = A} incl ok}
+coercion-mode-relax incl (cast-id {A = A} hA ok) =
+  cast-id hA (modeIncl-tyAllowed {A = A} incl ok)
 coercion-mode-relax incl
-    (cast-seal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
-      {α-ok = α-ok}) =
+    (cast-seal {α = α} {A = A} hA α∈Σ A-ok α-ok) =
   cast-seal hA α∈Σ
-    {A-ok = modeIncl-tyAllowed {A = A} incl A-ok}
-    {α-ok = modeIncl-sealTyAllowed {α = α} incl α-ok}
+    (modeIncl-tyAllowed {A = A} incl A-ok)
+    (modeIncl-sealModeAllowed {α = α} incl α-ok)
 coercion-mode-relax incl
-    (cast-unseal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
-      {α-ok = α-ok}) =
+    (cast-unseal {α = α} {A = A} hA α∈Σ A-ok α-ok) =
   cast-unseal hA α∈Σ
-    {A-ok = modeIncl-tyAllowed {A = A} incl A-ok}
-    {α-ok = modeIncl-sealTyAllowed {α = α} incl α-ok}
+    (modeIncl-tyAllowed {A = A} incl A-ok)
+    (modeIncl-sealModeAllowed {α = α} incl α-ok)
 coercion-mode-relax incl (cast-seq c⊢ d⊢) =
   cast-seq (coercion-mode-relax incl c⊢)
            (coercion-mode-relax incl d⊢)
-coercion-mode-relax incl (cast-tag {G = G} hG gG {ok = ok}) =
-  cast-tag hG gG {ok = modeIncl-tagTyAllowed {G = G} incl ok}
-coercion-mode-relax incl (cast-untag {H = H} hH gH {ok = ok}) =
-  cast-untag hH gH {ok = modeIncl-tagTyAllowed {G = H} incl ok}
+coercion-mode-relax incl (cast-tag {G = G} hG gG ok) =
+  cast-tag hG gG (modeIncl-tagTyAllowed {G = G} incl ok)
+coercion-mode-relax incl (cast-untag {H = H} hH gH ok) =
+  cast-untag hH gH (modeIncl-tagTyAllowed {G = H} incl ok)
 coercion-mode-relax incl (cast-fun c⊢ d⊢) =
   cast-fun (coercion-mode-relax incl c⊢)
            (coercion-mode-relax incl d⊢)
 coercion-mode-relax incl (cast-all c⊢) =
   cast-all (coercion-mode-relax (ModeIncl-ext incl) c⊢)
-coercion-mode-relax incl (cast-inst {B = B} hB {B-ok = B-ok} c⊢) =
+coercion-mode-relax incl (cast-inst {B = B} hB B-ok c⊢) =
   cast-inst hB
-    {B-ok = modeIncl-tyAllowed {A = B} incl B-ok}
+    (modeIncl-tyAllowed {A = B} incl B-ok)
     (coercion-mode-relax (ModeIncl-inst incl) c⊢)
-coercion-mode-relax incl (cast-gen {A = A} hA {A-ok = A-ok} c⊢) =
+coercion-mode-relax incl (cast-gen {A = A} hA A-ok c⊢) =
   cast-gen hA
-    {A-ok = modeIncl-tyAllowed {A = A} incl A-ok}
+    (modeIncl-tyAllowed {A = A} incl A-ok)
     (coercion-mode-relax (ModeIncl-gen incl) c⊢)
 
 coercion-renameᵗᵐ :
@@ -720,42 +717,40 @@ coercion-renameᵗᵐ :
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   ν ∣ Δ′ ∣ renameStoreᵗ ρ Σ ⊢ renameᶜ ρ c
     ∶ renameᵗ ρ A =⇒ renameᵗ ρ B
-coercion-renameᵗᵐ hρ rel (cast-id {A = A} hA {ok = ok}) =
+coercion-renameᵗᵐ hρ rel (cast-id {A = A} hA ok) =
   cast-id (renameᵗ-preserves-WfTy hA hρ)
-    {ok = modeRename-tyAllowed {A = A} rel ok}
+    (modeRename-tyAllowed {A = A} rel ok)
 coercion-renameᵗᵐ {ρ = ρ} {μ = μ} {ν = ν} hρ rel
-    (cast-seal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
-      {α-ok = α-ok}) =
+    (cast-seal {α = α} {A = A} hA α∈Σ A-ok α-ok) =
   cast-seal
     (renameᵗ-preserves-WfTy hA hρ)
     (∈-renameStoreᵗ _ α∈Σ)
-    {A-ok = modeRename-tyAllowed
-      {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel A-ok}
-    {α-ok = modeRename-sealTyAllowed
-      {ρ = ρ} {μ = μ} {ν = ν} {α = α} rel α-ok}
+    (modeRename-tyAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel A-ok)
+    (modeRename-sealModeAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {α = α} rel α-ok)
 coercion-renameᵗᵐ {ρ = ρ} {μ = μ} {ν = ν} hρ rel
-    (cast-unseal {α = α} {A = A} hA α∈Σ {A-ok = A-ok}
-      {α-ok = α-ok}) =
+    (cast-unseal {α = α} {A = A} hA α∈Σ A-ok α-ok) =
   cast-unseal
     (renameᵗ-preserves-WfTy hA hρ)
     (∈-renameStoreᵗ _ α∈Σ)
-    {A-ok = modeRename-tyAllowed
-      {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel A-ok}
-    {α-ok = modeRename-sealTyAllowed
-      {ρ = ρ} {μ = μ} {ν = ν} {α = α} rel α-ok}
+    (modeRename-tyAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {A = A} rel A-ok)
+    (modeRename-sealModeAllowed
+      {ρ = ρ} {μ = μ} {ν = ν} {α = α} rel α-ok)
 coercion-renameᵗᵐ hρ rel (cast-seq c⊢ d⊢) =
   cast-seq (coercion-renameᵗᵐ hρ rel c⊢)
            (coercion-renameᵗᵐ hρ rel d⊢)
-coercion-renameᵗᵐ hρ rel (cast-tag {G = G} hG gG {ok = ok}) =
+coercion-renameᵗᵐ hρ rel (cast-tag {G = G} hG gG ok) =
   cast-tag
     (renameᵗ-preserves-WfTy hG hρ)
     (renameᵗ-ground _ gG)
-    {ok = modeRename-tagTyAllowed {G = G} rel ok}
-coercion-renameᵗᵐ hρ rel (cast-untag {H = H} hH gH {ok = ok}) =
+    (modeRename-tagTyAllowed {G = G} rel ok)
+coercion-renameᵗᵐ hρ rel (cast-untag {H = H} hH gH ok) =
   cast-untag
     (renameᵗ-preserves-WfTy hH hρ)
     (renameᵗ-ground _ gH)
-    {ok = modeRename-tagTyAllowed {G = H} rel ok}
+    (modeRename-tagTyAllowed {G = H} rel ok)
 coercion-renameᵗᵐ hρ rel (cast-fun c⊢ d⊢) =
   cast-fun (coercion-renameᵗᵐ hρ rel c⊢)
            (coercion-renameᵗᵐ hρ rel d⊢)
@@ -768,10 +763,10 @@ coercion-renameᵗᵐ {ρ = ρ} hρ rel
       (coercion-renameᵗᵐ (TyRenameWf-ext hρ)
         (ModeRename-ext rel) c⊢))
 coercion-renameᵗᵐ {ρ = ρ} hρ rel
-    (cast-inst {B = B} hB {B-ok = B-ok} c⊢) =
+    (cast-inst {B = B} hB B-ok c⊢) =
   cast-inst
     (renameᵗ-preserves-WfTy hB hρ)
-    {B-ok = modeRename-tyAllowed {A = B} rel B-ok}
+    (modeRename-tyAllowed {A = B} rel B-ok)
     (subst
       (λ T → _ ∣ _ ∣ _ ⊢ renameᶜ (extᵗ ρ) _ ∶ _ =⇒ T)
       (renameᵗ-ext-suc-comm ρ B)
@@ -782,10 +777,10 @@ coercion-renameᵗᵐ {ρ = ρ} hρ rel
         (coercion-renameᵗᵐ (TyRenameWf-ext hρ)
           (ModeRename-inst rel) c⊢)))
 coercion-renameᵗᵐ {ρ = ρ} hρ rel
-    (cast-gen {A = A} hA {A-ok = A-ok} c⊢) =
+    (cast-gen {A = A} hA A-ok c⊢) =
   cast-gen
     (renameᵗ-preserves-WfTy hA hρ)
-    {A-ok = modeRename-tyAllowed {A = A} rel A-ok}
+    (modeRename-tyAllowed {A = A} rel A-ok)
     (subst
       (λ T → _ ∣ _ ∣ _ ⊢ renameᶜ (extᵗ ρ) _ ∶ T =⇒ _)
       (renameᵗ-ext-suc-comm ρ A)
@@ -1097,17 +1092,17 @@ tagTyAllowed-var-tag :
   tagTyAllowed ν (＇ α) ≡ true
 tagTyAllowed-var-tag eq rewrite eq = refl
 
-sealTyAllowed-var-normal :
-  ∀ {ν α} →
+sealModeAllowed-var-normal :
+  ∀ {ν : DualEnv}{α : TyVar} →
   ν α ≡ normal →
-  sealTyAllowed ν α ≡ true
-sealTyAllowed-var-normal eq rewrite eq = refl
+  sealModeAllowed (ν α) ≡ true
+sealModeAllowed-var-normal eq rewrite eq = refl
 
-sealTyAllowed-var-seal :
-  ∀ {ν α} →
+sealModeAllowed-var-seal :
+  ∀ {ν : DualEnv}{α : TyVar} →
   ν α ≡ seal-to-tag →
-  sealTyAllowed ν α ≡ true
-sealTyAllowed-var-seal eq rewrite eq = refl
+  sealModeAllowed (ν α) ≡ true
+sealModeAllowed-var-seal eq rewrite eq = refl
 
 dualTag-typing :
   ∀ {μ ν Δ Σ Π G} →
@@ -1123,19 +1118,19 @@ dualTag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
     | normal | normal | opp-normal | okα
     rewrite μα | να =
   cast-untag {μ = ν} hG gG
-    {ok = tagTyAllowed-var-normal {ν = ν} {α = α} να}
+    (tagTyAllowed-var-normal {ν = ν} {α = α} να)
 dualTag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
     | tag-to-seal | seal-to-tag | opp-gen-inst | okα
     rewrite μα | να =
   cast-seal {μ = ν} wf★ (tagSeal∈ ds μα)
-    {A-ok = refl}
-    {α-ok = sealTyAllowed-var-seal {ν = ν} {α = α} να}
+    refl
+    (sealModeAllowed-var-seal {ν = ν} {α = α} να)
 dualTag-typing {G = ＇ α} opp ds hG gG ok
     | seal-to-tag | tag-to-seal | opp-inst-gen | ()
 dualTag-typing {ν = ν} {G = ‵ ι} opp ds hG gG ok =
-  cast-untag {μ = ν} hG gG {ok = refl}
+  cast-untag {μ = ν} hG gG refl
 dualTag-typing {ν = ν} {G = ★ ⇒ ★} opp ds hG gG ok =
-  cast-untag {μ = ν} hG gG {ok = refl}
+  cast-untag {μ = ν} hG gG refl
 
 dualUntag-typing :
   ∀ {μ ν Δ Σ Π G} →
@@ -1151,19 +1146,19 @@ dualUntag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
     | normal | normal | opp-normal | okα
     rewrite μα | να =
   cast-tag {μ = ν} hG gG
-    {ok = tagTyAllowed-var-normal {ν = ν} {α = α} να}
+    (tagTyAllowed-var-normal {ν = ν} {α = α} να)
 dualUntag-typing {ν = ν} {G = ＇ α} opp ds hG gG ok
     | tag-to-seal | seal-to-tag | opp-gen-inst | okα
     rewrite μα | να =
   cast-unseal {μ = ν} wf★ (tagSeal∈ ds μα)
-    {A-ok = refl}
-    {α-ok = sealTyAllowed-var-seal {ν = ν} {α = α} να}
+    refl
+    (sealModeAllowed-var-seal {ν = ν} {α = α} να)
 dualUntag-typing {G = ＇ α} opp ds hG gG ok
     | seal-to-tag | tag-to-seal | opp-inst-gen | ()
 dualUntag-typing {ν = ν} {G = ‵ ι} opp ds hG gG ok =
-  cast-tag {μ = ν} hG gG {ok = refl}
+  cast-tag {μ = ν} hG gG refl
 dualUntag-typing {ν = ν} {G = ★ ⇒ ★} opp ds hG gG ok =
-  cast-tag {μ = ν} hG gG {ok = refl}
+  cast-tag {μ = ν} hG gG refl
 
 dualSeal-typing :
   ∀ {μ ν Δ Σ Π A α} →
@@ -1173,7 +1168,7 @@ dualSeal-typing :
   WfTy Δ A →
   (α , A) ∈ Σ →
   tyAllowed μ A ≡ true →
-  sealTyAllowed μ α ≡ true →
+  sealModeAllowed (μ α) ≡ true →
   ν ∣ Δ ∣ Π ⊢ dualSeal μ A α ∶ ＇ α =⇒ A
 dualSeal-typing {μ = μ} {ν = ν} {A = A} {α = α}
     opp ds wfΣ hA αA∈Σ A-ok α-ok
@@ -1183,8 +1178,8 @@ dualSeal-typing {μ = μ} {ν = ν} {A = A} {α = α}
     | normal | normal | opp-normal | okα
     rewrite μα | να =
   cast-unseal {μ = ν} hA (normal∈ ds μα αA∈Σ)
-    {A-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok}
-    {α-ok = sealTyAllowed-var-normal {ν = ν} {α = α} να}
+    (opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok)
+    (sealModeAllowed-var-normal {ν = ν} {α = α} να)
 dualSeal-typing {A = A} {α = α} opp ds wfΣ hA αA∈Σ A-ok α-ok
     | tag-to-seal | seal-to-tag | opp-gen-inst | ()
 dualSeal-typing {ν = ν} {A = A} {α = α}
@@ -1192,7 +1187,7 @@ dualSeal-typing {ν = ν} {A = A} {α = α}
     | seal-to-tag | tag-to-seal | opp-inst-gen | okα
     rewrite sealTag★ ds μα αA∈Σ | μα | να =
   cast-tag {μ = ν} (wfVar (bound wfΣ αA∈Σ)) (＇ α)
-    {ok = tagTyAllowed-var-tag {ν = ν} {α = α} να}
+    (tagTyAllowed-var-tag {ν = ν} {α = α} να)
 
 dualUnseal-typing :
   ∀ {μ ν Δ Σ Π A α} →
@@ -1202,7 +1197,7 @@ dualUnseal-typing :
   WfTy Δ A →
   (α , A) ∈ Σ →
   tyAllowed μ A ≡ true →
-  sealTyAllowed μ α ≡ true →
+  sealModeAllowed (μ α) ≡ true →
   ν ∣ Δ ∣ Π ⊢ dualUnseal μ α A ∶ A =⇒ ＇ α
 dualUnseal-typing {μ = μ} {ν = ν} {A = A} {α = α}
     opp ds wfΣ hA αA∈Σ A-ok α-ok
@@ -1212,8 +1207,8 @@ dualUnseal-typing {μ = μ} {ν = ν} {A = A} {α = α}
     | normal | normal | opp-normal | okα
     rewrite μα | να =
   cast-seal {μ = ν} hA (normal∈ ds μα αA∈Σ)
-    {A-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok}
-    {α-ok = sealTyAllowed-var-normal {ν = ν} {α = α} να}
+    (opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok)
+    (sealModeAllowed-var-normal {ν = ν} {α = α} να)
 dualUnseal-typing {A = A} {α = α} opp ds wfΣ hA αA∈Σ A-ok α-ok
     | tag-to-seal | seal-to-tag | opp-gen-inst | ()
 dualUnseal-typing {ν = ν} {A = A} {α = α}
@@ -1221,7 +1216,7 @@ dualUnseal-typing {ν = ν} {A = A} {α = α}
     | seal-to-tag | tag-to-seal | opp-inst-gen | okα
     rewrite sealTag★ ds μα αA∈Σ | μα | να =
   cast-untag {μ = ν} (wfVar (bound wfΣ αA∈Σ)) (＇ α)
-    {ok = tagTyAllowed-var-tag {ν = ν} {α = α} να}
+    (tagTyAllowed-var-tag {ν = ν} {α = α} να)
 
 coercion-dual-flipᵐ :
   ∀ {μ ν Δ Σ Π c A B} →
@@ -1229,22 +1224,22 @@ coercion-dual-flipᵐ :
   DualStore μ Σ ν Π →
   StoreWfAt Δ Σ →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
-  ν ∣ Δ ∣ Π ⊢ dualWith μ c ∶ B =⇒ A
+  ν ∣ Δ ∣ Π ⊢ dual μ c ∶ B =⇒ A
 coercion-dual-flipᵐ {μ = μ} {ν = ν} opp ds wfΣ
-    (cast-id {A = A} hA {ok = ok}) =
-  cast-id hA {ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp ok}
+    (cast-id {A = A} hA ok) =
+  cast-id hA (opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp ok)
 coercion-dual-flipᵐ opp ds wfΣ
-    (cast-seal hA αA∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
+    (cast-seal hA αA∈Σ A-ok α-ok) =
   dualSeal-typing opp ds wfΣ hA αA∈Σ A-ok α-ok
 coercion-dual-flipᵐ opp ds wfΣ
-    (cast-unseal hA αA∈Σ {A-ok = A-ok} {α-ok = α-ok}) =
+    (cast-unseal hA αA∈Σ A-ok α-ok) =
   dualUnseal-typing opp ds wfΣ hA αA∈Σ A-ok α-ok
 coercion-dual-flipᵐ opp ds wfΣ (cast-seq c⊢ d⊢) =
   cast-seq (coercion-dual-flipᵐ opp ds wfΣ d⊢)
            (coercion-dual-flipᵐ opp ds wfΣ c⊢)
-coercion-dual-flipᵐ opp ds wfΣ (cast-tag hG gG {ok = ok}) =
+coercion-dual-flipᵐ opp ds wfΣ (cast-tag hG gG ok) =
   dualTag-typing opp ds hG gG ok
-coercion-dual-flipᵐ opp ds wfΣ (cast-untag hG gG {ok = ok}) =
+coercion-dual-flipᵐ opp ds wfΣ (cast-untag hG gG ok) =
   dualUntag-typing opp ds hG gG ok
 coercion-dual-flipᵐ opp ds wfΣ (cast-fun c⊢ d⊢) =
   cast-fun (coercion-dual-flipᵐ opp ds wfΣ c⊢)
@@ -1257,18 +1252,18 @@ coercion-dual-flipᵐ opp ds wfΣ (cast-all c⊢) =
       (StoreWfAt-⟰ᵗ wfΣ)
       c⊢)
 coercion-dual-flipᵐ {μ = μ} {ν = ν} opp ds wfΣ
-    (cast-inst {B = B} hB {B-ok = B-ok} c⊢) =
+    (cast-inst {B = B} hB B-ok c⊢) =
   cast-gen hB
-    {A-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = B} opp B-ok}
+    (opp-tyAllowed {μ = μ} {ν = ν} {A = B} opp B-ok)
     (coercion-dual-flipᵐ
       (opp-inst-genᵈ opp)
       (dualStore-inst-gen ds)
       (StoreWfAt-cons z<s wf★ (StoreWfAt-⟰ᵗ wfΣ))
       c⊢)
 coercion-dual-flipᵐ {μ = μ} {ν = ν} opp ds wfΣ
-    (cast-gen {A = A} hA {A-ok = A-ok} c⊢) =
+    (cast-gen {A = A} hA A-ok c⊢) =
   cast-inst hA
-    {B-ok = opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok}
+    (opp-tyAllowed {μ = μ} {ν = ν} {A = A} opp A-ok)
     (coercion-dual-flipᵐ
       (opp-gen-instᵈ opp)
       (dualStore-gen-inst ds)
@@ -1299,18 +1294,18 @@ coercion-wfᵐ :
   StoreWfAt Δ Σ →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   WfTy Δ A × WfTy Δ B
-coercion-wfᵐ wfΣ (cast-id hA) = hA , hA
-coercion-wfᵐ wfΣ (cast-seal hA α∈Σ) =
+coercion-wfᵐ wfΣ (cast-id hA _) = hA , hA
+coercion-wfᵐ wfΣ (cast-seal hA α∈Σ _ _) =
   hA , wfVar (bound wfΣ α∈Σ)
-coercion-wfᵐ wfΣ (cast-unseal hA α∈Σ) =
+coercion-wfᵐ wfΣ (cast-unseal hA α∈Σ _ _) =
   wfVar (bound wfΣ α∈Σ) , hA
 coercion-wfᵐ wfΣ (cast-seq c⊢ d⊢)
     with coercion-wfᵐ wfΣ c⊢ | coercion-wfᵐ wfΣ d⊢
 coercion-wfᵐ wfΣ (cast-seq c⊢ d⊢)
     | hA , hB | hB′ , hC =
   hA , hC
-coercion-wfᵐ wfΣ (cast-tag hG gG) = hG , wf★
-coercion-wfᵐ wfΣ (cast-untag hH gH) = wf★ , hH
+coercion-wfᵐ wfΣ (cast-tag hG gG _) = hG , wf★
+coercion-wfᵐ wfΣ (cast-untag hH gH _) = wf★ , hH
 coercion-wfᵐ wfΣ (cast-fun c⊢ d⊢)
     with coercion-wfᵐ wfΣ c⊢ | coercion-wfᵐ wfΣ d⊢
 coercion-wfᵐ wfΣ (cast-fun c⊢ d⊢)
@@ -1320,15 +1315,15 @@ coercion-wfᵐ wfΣ (cast-all c⊢)
     with coercion-wfᵐ (StoreWfAt-⟰ᵗ wfΣ) c⊢
 coercion-wfᵐ wfΣ (cast-all c⊢) | hA , hB =
   wf∀ hA , wf∀ hB
-coercion-wfᵐ wfΣ (cast-inst hB c⊢)
+coercion-wfᵐ wfΣ (cast-inst hB _ c⊢)
     with coercion-wfᵐ
       (StoreWfAt-cons z<s wf★ (StoreWfAt-⟰ᵗ wfΣ))
       c⊢
-coercion-wfᵐ wfΣ (cast-inst hB c⊢) | hA , hB′ =
+coercion-wfᵐ wfΣ (cast-inst hB _ c⊢) | hA , hB′ =
   wf∀ hA , hB
-coercion-wfᵐ wfΣ (cast-gen hA c⊢)
+coercion-wfᵐ wfΣ (cast-gen hA _ c⊢)
     with coercion-wfᵐ (StoreWfAt-⟰ᵗ wfΣ) c⊢
-coercion-wfᵐ wfΣ (cast-gen hA c⊢) | hA′ , hB =
+coercion-wfᵐ wfΣ (cast-gen hA _ c⊢) | hA′ , hB =
   hA , wf∀ hB
 
 coercion-wf :
@@ -1394,8 +1389,8 @@ reveal-var-hit :
 reveal-var-hit {α = α} hC α∈Σ with α ≟ α
 reveal-var-hit {α = α} {C = C} hC α∈Σ | yes refl =
   cast-unseal hC α∈Σ
-    {A-ok = tyAllowed-normal C}
-    {α-ok = sealTyAllowed-normal α}
+    (tyAllowed-normal C)
+    (sealModeAllowed-normal α)
 reveal-var-hit {α = α} hC α∈Σ | no α≢α =
   ⊥-elim (α≢α refl)
 
@@ -1407,8 +1402,8 @@ conceal-var-hit :
 conceal-var-hit {α = α} hC α∈Σ with α ≟ α
 conceal-var-hit {α = α} {C = C} hC α∈Σ | yes refl =
   cast-seal hC α∈Σ
-    {A-ok = tyAllowed-normal C}
-    {α-ok = sealTyAllowed-normal α}
+    (tyAllowed-normal C)
+    (sealModeAllowed-normal α)
 conceal-var-hit {α = α} hC α∈Σ | no α≢α =
   ⊥-elim (α≢α refl)
 
@@ -1421,7 +1416,7 @@ reveal-var-miss {α = α} {Y = Y} Y≢α hY with α ≟ Y
 reveal-var-miss {α = α} {Y = Y} Y≢α hY | yes α≡Y =
   ⊥-elim (Y≢α (sym α≡Y))
 reveal-var-miss {α = α} {Y = Y} Y≢α hY | no α≢Y =
-  cast-id hY {ok = refl}
+  cast-id hY refl
 
 conceal-var-miss :
   ∀ {Δ Σ α C Y} →
@@ -1432,7 +1427,7 @@ conceal-var-miss {α = α} {Y = Y} Y≢α hY with α ≟ Y
 conceal-var-miss {α = α} {Y = Y} Y≢α hY | yes α≡Y =
   ⊥-elim (Y≢α (sym α≡Y))
 conceal-var-miss {α = α} {Y = Y} Y≢α hY | no α≢Y =
-  cast-id hY {ok = refl}
+  cast-id hY refl
 
 mutual
   reveal-typing-env :
@@ -1456,9 +1451,9 @@ mutual
       rewrite σX≡var =
     reveal-var-miss ρX≢α (wfVar (hρ X<Θ))
   reveal-typing-env wfBase hρ hσ env hC α∈Σ =
-    cast-id wfBase {ok = refl}
+    cast-id wfBase refl
   reveal-typing-env wf★ hρ hσ env hC α∈Σ =
-    cast-id wf★ {ok = refl}
+    cast-id wf★ refl
   reveal-typing-env (wf⇒ hA hB) hρ hσ env hC α∈Σ =
     cast-fun
       (conceal-typing-env hA hρ hσ env hC α∈Σ)
@@ -1497,9 +1492,9 @@ mutual
       rewrite σX≡var =
     conceal-var-miss ρX≢α (wfVar (hρ X<Θ))
   conceal-typing-env wfBase hρ hσ env hC α∈Σ =
-    cast-id wfBase {ok = refl}
+    cast-id wfBase refl
   conceal-typing-env wf★ hρ hσ env hC α∈Σ =
-    cast-id wf★ {ok = refl}
+    cast-id wf★ refl
   conceal-typing-env (wf⇒ hA hB) hρ hσ env hC α∈Σ =
     cast-fun
       (reveal-typing-env hA hρ hσ env hC α∈Σ)
@@ -1569,16 +1564,16 @@ coercion-src-tgtᵐ :
   ∀ {μ Δ Σ c A B} →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
   src c ≡ A × tgt c ≡ B
-coercion-src-tgtᵐ (cast-id hA) = refl , refl
-coercion-src-tgtᵐ (cast-seal hA α∈Σ) = refl , refl
-coercion-src-tgtᵐ (cast-unseal hA α∈Σ) = refl , refl
+coercion-src-tgtᵐ (cast-id hA _) = refl , refl
+coercion-src-tgtᵐ (cast-seal hA α∈Σ _ _) = refl , refl
+coercion-src-tgtᵐ (cast-unseal hA α∈Σ _ _) = refl , refl
 coercion-src-tgtᵐ (cast-seq c⊢ d⊢)
     with coercion-src-tgtᵐ c⊢ | coercion-src-tgtᵐ d⊢
 coercion-src-tgtᵐ (cast-seq c⊢ d⊢)
     | src-c , tgt-c | src-d , tgt-d rewrite src-c | tgt-d =
   refl , refl
-coercion-src-tgtᵐ (cast-tag hG gG) = refl , refl
-coercion-src-tgtᵐ (cast-untag hH gH) = refl , refl
+coercion-src-tgtᵐ (cast-tag hG gG _) = refl , refl
+coercion-src-tgtᵐ (cast-untag hH gH _) = refl , refl
 coercion-src-tgtᵐ (cast-fun c⊢ d⊢)
     with coercion-src-tgtᵐ c⊢ | coercion-src-tgtᵐ d⊢
 coercion-src-tgtᵐ (cast-fun c⊢ d⊢)
@@ -1588,13 +1583,13 @@ coercion-src-tgtᵐ (cast-all c⊢)
     with coercion-src-tgtᵐ c⊢
 coercion-src-tgtᵐ (cast-all c⊢) | src-c , tgt-c rewrite src-c | tgt-c =
   refl , refl
-coercion-src-tgtᵐ (cast-inst hB c⊢)
+coercion-src-tgtᵐ (cast-inst hB _ c⊢)
     with coercion-src-tgtᵐ c⊢
-coercion-src-tgtᵐ (cast-inst hB c⊢) | src-c , tgt-c rewrite src-c =
+coercion-src-tgtᵐ (cast-inst hB _ c⊢) | src-c , tgt-c rewrite src-c =
   refl , refl
-coercion-src-tgtᵐ (cast-gen hA c⊢)
+coercion-src-tgtᵐ (cast-gen hA _ c⊢)
     with coercion-src-tgtᵐ c⊢
-coercion-src-tgtᵐ (cast-gen hA c⊢) | src-c , tgt-c rewrite tgt-c =
+coercion-src-tgtᵐ (cast-gen hA _ c⊢) | src-c , tgt-c rewrite tgt-c =
   refl , refl
 
 coercion-src-tgt :

--- a/GTSF/proof/CompileCoercions.agda
+++ b/GTSF/proof/CompileCoercions.agda
@@ -8,11 +8,12 @@ module proof.CompileCoercions where
 --     turns a chosen imprecision witness into typed target coercions.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (true; false)
 open import Data.List using ([]; _∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.Nat using (zero; suc; z<s)
-open import Data.Nat.Properties using (n≤1+n; ≤-refl)
+open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (Σ-syntax; _,_)
 
 open import Types
@@ -20,8 +21,18 @@ open import Store using (StoreIncl; StoreIncl-drop)
 open import Coercions
   using
     ( Coercion
+    ; DualEnv
+    ; normal
+    ; tag-to-seal
+    ; seal-to-tag
+    ; normalᵈ
+    ; extᵈ
+    ; genᵈ
+    ; instᵈ
     ; Label
+    ; _∣_∣_⊢_∶_=⇒_
     ; _∣_⊢_∶_=⇒_
+    ; tyAllowed
     ; cast-id
     ; cast-seq
     ; cast-tag
@@ -46,38 +57,92 @@ open import Coercions
     ; gen to genᶜ
     )
 open import Imprecision
-open import proof.CoercionProperties using (coercion-renameᵗ; coercion-weaken)
+open import proof.CoercionProperties
+  using
+    ( ModeRename
+    ; coercion-renameᵗᵐ
+    ; coercion-weakenᵐ
+    ; modeRename-tyAllowed
+    ; tyAllowed-normal
+    )
 open import proof.TypeProperties
-  using (TyRenameWf-suc; WfTy-weakenᵗ; renameᵗ-preserves-WfTy)
+  using (TyRenameWf-suc; renameᵗ-preserves-WfTy)
 
 ------------------------------------------------------------------------
 -- Realizing imprecision assumptions as target coercions
 ------------------------------------------------------------------------
 
-data Realizes (Δ : TyCtx) (Σ : Store) : ImpCtx → Set₁ where
+ModeRename-suc-ext :
+  ∀ {μ} →
+  ModeRename suc μ (extᵈ μ)
+ModeRename-suc-ext {μ} X with μ X
+ModeRename-suc-ext X | normal = refl
+ModeRename-suc-ext X | tag-to-seal = refl
+ModeRename-suc-ext X | seal-to-tag = refl
+
+ModeRename-suc-gen :
+  ∀ {μ} →
+  ModeRename suc μ (genᵈ μ)
+ModeRename-suc-gen {μ} X with μ X
+ModeRename-suc-gen X | normal = refl
+ModeRename-suc-gen X | tag-to-seal = refl
+ModeRename-suc-gen X | seal-to-tag = refl
+
+ModeRename-suc-inst :
+  ∀ {μ} →
+  ModeRename suc μ (instᵈ μ)
+ModeRename-suc-inst {μ} X with μ X
+ModeRename-suc-inst X | normal = refl
+ModeRename-suc-inst X | tag-to-seal = refl
+ModeRename-suc-inst X | seal-to-tag = refl
+
+ModeRename-suc-normal :
+  ModeRename suc normalᵈ normalᵈ
+ModeRename-suc-normal X = refl
+
+tyAllowed-shift-gen :
+  ∀ {μ B} →
+  tyAllowed μ B ≡ true →
+  tyAllowed (genᵈ μ) (⇑ᵗ B) ≡ true
+tyAllowed-shift-gen {μ = μ} {B = B} ok =
+  modeRename-tyAllowed {ρ = suc} {μ = μ} {ν = genᵈ μ} {A = B}
+    ModeRename-suc-gen ok
+
+tyAllowed-shift-inst :
+  ∀ {μ B} →
+  tyAllowed μ B ≡ true →
+  tyAllowed (instᵈ μ) (⇑ᵗ B) ≡ true
+tyAllowed-shift-inst {μ = μ} {B = B} ok =
+  modeRename-tyAllowed {ρ = suc} {μ = μ} {ν = instᵈ μ} {A = B}
+    ModeRename-suc-inst ok
+
+data Realizesᵐ (μ : DualEnv) (Δ : TyCtx) (Σ : Store) : ImpCtx → Set₁ where
   real-[] :
-    Realizes Δ Σ []
+    Realizesᵐ μ Δ Σ []
 
   real-xx : ∀ {Φ X Y c d} →
     WfTy Δ (＇ X) →
     WfTy Δ (＇ Y) →
-    Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ＇ Y →
-    Δ ∣ Σ ⊢ d ∶ ＇ Y =⇒ ＇ X →
-    Realizes Δ Σ Φ →
-    Realizes Δ Σ ((X ˣ⊑ˣ Y) ∷ Φ)
+    μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ＇ Y →
+    μ ∣ Δ ∣ Σ ⊢ d ∶ ＇ Y =⇒ ＇ X →
+    Realizesᵐ μ Δ Σ Φ →
+    Realizesᵐ μ Δ Σ ((X ˣ⊑ˣ Y) ∷ Φ)
 
   real-star : ∀ {Φ X c d} →
     WfTy Δ (＇ X) →
-    Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ★ →
-    Δ ∣ Σ ⊢ d ∶ ★ =⇒ ＇ X →
-    Realizes Δ Σ Φ →
-    Realizes Δ Σ ((X ˣ⊑★) ∷ Φ)
+    μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ★ →
+    μ ∣ Δ ∣ Σ ⊢ d ∶ ★ =⇒ ＇ X →
+    Realizesᵐ μ Δ Σ Φ →
+    Realizesᵐ μ Δ Σ ((X ˣ⊑★) ∷ Φ)
+
+Realizes : TyCtx → Store → ImpCtx → Set₁
+Realizes Δ Σ Φ = Realizesᵐ normalᵈ Δ Σ Φ
 
 realizes-xx-up :
-  ∀ {Δ Σ Φ X Y} →
-  Realizes Δ Σ Φ →
+  ∀ {μ Δ Σ Φ X Y} →
+  Realizesᵐ μ Δ Σ Φ →
   (X ˣ⊑ˣ Y) ∈ Φ →
-  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ＇ Y
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ＇ Y
 realizes-xx-up (real-xx hX hY c⊢ d⊢ r) (here refl) = _ , c⊢
 realizes-xx-up (real-xx hX hY c⊢ d⊢ r) (there x∈) =
   realizes-xx-up r x∈
@@ -86,10 +151,10 @@ realizes-xx-up (real-star hX c⊢ d⊢ r) (there x∈) =
   realizes-xx-up r x∈
 
 realizes-xx-down :
-  ∀ {Δ Σ Φ X Y} →
-  Realizes Δ Σ Φ →
+  ∀ {μ Δ Σ Φ X Y} →
+  Realizesᵐ μ Δ Σ Φ →
   (X ˣ⊑ˣ Y) ∈ Φ →
-  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ ＇ Y =⇒ ＇ X
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ Y =⇒ ＇ X
 realizes-xx-down (real-xx hX hY c⊢ d⊢ r) (here refl) = _ , d⊢
 realizes-xx-down (real-xx hX hY c⊢ d⊢ r) (there x∈) =
   realizes-xx-down r x∈
@@ -98,10 +163,10 @@ realizes-xx-down (real-star hX c⊢ d⊢ r) (there x∈) =
   realizes-xx-down r x∈
 
 realizes-star-up :
-  ∀ {Δ Σ Φ X} →
-  Realizes Δ Σ Φ →
+  ∀ {μ Δ Σ Φ X} →
+  Realizesᵐ μ Δ Σ Φ →
   (X ˣ⊑★) ∈ Φ →
-  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ★
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ★
 realizes-star-up (real-xx hX hY c⊢ d⊢ r) (here ())
 realizes-star-up (real-xx hX hY c⊢ d⊢ r) (there x∈) =
   realizes-star-up r x∈
@@ -110,10 +175,10 @@ realizes-star-up (real-star hX c⊢ d⊢ r) (there x∈) =
   realizes-star-up r x∈
 
 realizes-star-down :
-  ∀ {Δ Σ Φ X} →
-  Realizes Δ Σ Φ →
+  ∀ {μ Δ Σ Φ X} →
+  Realizesᵐ μ Δ Σ Φ →
   (X ˣ⊑★) ∈ Φ →
-  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ ★ =⇒ ＇ X
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ★ =⇒ ＇ X
 realizes-star-down (real-xx hX hY c⊢ d⊢ r) (here ())
 realizes-star-down (real-xx hX hY c⊢ d⊢ r) (there x∈) =
   realizes-star-down r x∈
@@ -122,124 +187,89 @@ realizes-star-down (real-star hX c⊢ d⊢ r) (there x∈) =
   realizes-star-down r x∈
 
 Realizes-store-weaken :
-  ∀ {Δ Σ Σ′ Φ} →
+  ∀ {μ Δ Σ Σ′ Φ} →
   StoreIncl Σ Σ′ →
-  Realizes Δ Σ Φ →
-  Realizes Δ Σ′ Φ
+  Realizesᵐ μ Δ Σ Φ →
+  Realizesᵐ μ Δ Σ′ Φ
 Realizes-store-weaken incl real-[] = real-[]
 Realizes-store-weaken incl (real-xx hX hY c⊢ d⊢ r) =
   real-xx
     hX
     hY
-    (coercion-weaken ≤-refl incl c⊢)
-    (coercion-weaken ≤-refl incl d⊢)
+    (coercion-weakenᵐ ≤-refl incl c⊢)
+    (coercion-weakenᵐ ≤-refl incl d⊢)
     (Realizes-store-weaken incl r)
 Realizes-store-weaken incl (real-star hX c⊢ d⊢ r) =
   real-star
     hX
-    (coercion-weaken ≤-refl incl c⊢)
-    (coercion-weaken ≤-refl incl d⊢)
+    (coercion-weakenᵐ ≤-refl incl c⊢)
+    (coercion-weakenᵐ ≤-refl incl d⊢)
     (Realizes-store-weaken incl r)
 
-Realizes-⇑ᵢ :
-  ∀ {Δ Σ Φ} →
-  Realizes Δ Σ Φ →
-  Realizes (suc Δ) (⟰ᵗ Σ) (⇑ᵢ Φ)
-Realizes-⇑ᵢ real-[] = real-[]
-Realizes-⇑ᵢ (real-xx hX hY c⊢ d⊢ r) =
+Realizes-rename-suc :
+  ∀ {μ ν Δ Σ Φ} →
+  ModeRename suc μ ν →
+  Realizesᵐ μ Δ Σ Φ →
+  Realizesᵐ ν (suc Δ) (⟰ᵗ Σ) (⇑ᵢ Φ)
+Realizes-rename-suc rel real-[] = real-[]
+Realizes-rename-suc rel (real-xx hX hY c⊢ d⊢ r) =
   real-xx
     (renameᵗ-preserves-WfTy hX TyRenameWf-suc)
     (renameᵗ-preserves-WfTy hY TyRenameWf-suc)
-    (coercion-renameᵗ TyRenameWf-suc c⊢)
-    (coercion-renameᵗ TyRenameWf-suc d⊢)
-    (Realizes-⇑ᵢ r)
-Realizes-⇑ᵢ (real-star hX c⊢ d⊢ r) =
+    (coercion-renameᵗᵐ TyRenameWf-suc rel c⊢)
+    (coercion-renameᵗᵐ TyRenameWf-suc rel d⊢)
+    (Realizes-rename-suc rel r)
+Realizes-rename-suc rel (real-star hX c⊢ d⊢ r) =
   real-star
     (renameᵗ-preserves-WfTy hX TyRenameWf-suc)
-    (coercion-renameᵗ TyRenameWf-suc c⊢)
-    (coercion-renameᵗ TyRenameWf-suc d⊢)
-    (Realizes-⇑ᵢ r)
+    (coercion-renameᵗᵐ TyRenameWf-suc rel c⊢)
+    (coercion-renameᵗᵐ TyRenameWf-suc rel d⊢)
+    (Realizes-rename-suc rel r)
 
-var-to-shift :
-  ∀ {Δ Σ X} →
-  (ℓ : Label) →
-  WfTy Δ (＇ X) →
-  Σ[ c ∈ Coercion ] suc Δ ∣ Σ ⊢ c ∶ ＇ X =⇒ ＇ suc X
-var-to-shift {Δ = Δ} {X = X} ℓ hX =
-  (((＇ X) !ᶜ) ︔ᶜ ((＇ (suc X)) ？ᶜ)) ,
-  cast-seq
-    (cast-tag (WfTy-weakenᵗ hX (n≤1+n Δ)) (＇ X))
-    (cast-untag (renameᵗ-preserves-WfTy hX TyRenameWf-suc) (＇ (suc X)))
-
-var-from-shift :
-  ∀ {Δ Σ X} →
-  (ℓ : Label) →
-  WfTy Δ (＇ X) →
-  Σ[ c ∈ Coercion ] suc Δ ∣ Σ ⊢ c ∶ ＇ suc X =⇒ ＇ X
-var-from-shift {Δ = Δ} {X = X} ℓ hX =
-  (((＇ (suc X)) !ᶜ) ︔ᶜ ((＇ X) ？ᶜ)) ,
-  cast-seq
-    (cast-tag (renameᵗ-preserves-WfTy hX TyRenameWf-suc) (＇ (suc X)))
-    (cast-untag (WfTy-weakenᵗ hX (n≤1+n Δ)) (＇ X))
-
-Realizes-⇑ᴸᵢ :
-  ∀ {Δ Σ Φ} →
-  (ℓ : Label) →
-  Realizes Δ Σ Φ →
-  Realizes (suc Δ) (⟰ᵗ Σ) (⇑ᴸᵢ Φ)
-Realizes-⇑ᴸᵢ ℓ real-[] = real-[]
-Realizes-⇑ᴸᵢ {Δ = Δ} ℓ (real-xx hX hY c⊢ d⊢ r)
-    with var-from-shift ℓ hY | var-to-shift ℓ hY
-Realizes-⇑ᴸᵢ {Δ = Δ} ℓ (real-xx hX hY c⊢ d⊢ r)
-    | y↓ , y↓⊢ | y↑ , y↑⊢ =
-  real-xx
-    (renameᵗ-preserves-WfTy hX TyRenameWf-suc)
-    (WfTy-weakenᵗ hY (n≤1+n Δ))
-    (cast-seq (coercion-renameᵗ TyRenameWf-suc c⊢) y↓⊢)
-    (cast-seq y↑⊢ (coercion-renameᵗ TyRenameWf-suc d⊢))
-    (Realizes-⇑ᴸᵢ ℓ r)
-Realizes-⇑ᴸᵢ ℓ (real-star hX c⊢ d⊢ r) =
-  real-star
-    (renameᵗ-preserves-WfTy hX TyRenameWf-suc)
-    (coercion-renameᵗ TyRenameWf-suc c⊢)
-    (coercion-renameᵗ TyRenameWf-suc d⊢)
-    (Realizes-⇑ᴸᵢ ℓ r)
+Realizes-⇑ᵢ :
+  ∀ {μ Δ Σ Φ} →
+  Realizesᵐ μ Δ Σ Φ →
+  Realizesᵐ (extᵈ μ) (suc Δ) (⟰ᵗ Σ) (⇑ᵢ Φ)
+Realizes-⇑ᵢ = Realizes-rename-suc ModeRename-suc-ext
 
 Realizes-∀ⁱ :
-  ∀ {Δ Σ Φ} →
-  Realizes Δ Σ Φ →
-  Realizes (suc Δ) (⟰ᵗ Σ) ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+  ∀ {μ Δ Σ Φ} →
+  Realizesᵐ μ Δ Σ Φ →
+  Realizesᵐ (extᵈ μ) (suc Δ) (⟰ᵗ Σ)
+    ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
 Realizes-∀ⁱ r =
   real-xx
     (wfVar z<s)
     (wfVar z<s)
-    (cast-id (wfVar z<s))
-    (cast-id (wfVar z<s))
+    (cast-id (wfVar z<s) refl)
+    (cast-id (wfVar z<s) refl)
     (Realizes-⇑ᵢ r)
 
 Realizes-ν-inst :
-  ∀ {Δ Σ Φ} →
+  ∀ {μ Δ Σ Φ} →
   (ℓ : Label) →
-  Realizes Δ Σ Φ →
-  Realizes (suc Δ) ((zero , ★) ∷ ⟰ᵗ Σ) ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+  Realizesᵐ μ Δ Σ Φ →
+  Realizesᵐ (instᵈ μ) (suc Δ) ((zero , ★) ∷ ⟰ᵗ Σ)
+    ((zero ˣ⊑★) ∷ ⇑ᵢ Φ)
 Realizes-ν-inst ℓ r =
   real-star
     (wfVar z<s)
-    (cast-unseal wf★ (here refl))
-    (cast-seal wf★ (here refl))
-    (Realizes-store-weaken StoreIncl-drop (Realizes-⇑ᴸᵢ ℓ r))
+    (cast-unseal wf★ (here refl) refl refl)
+    (cast-seal wf★ (here refl) refl refl)
+    (Realizes-store-weaken StoreIncl-drop
+      (Realizes-rename-suc ModeRename-suc-inst r))
 
 Realizes-ν-gen :
-  ∀ {Δ Σ Φ} →
+  ∀ {μ Δ Σ Φ} →
   (ℓ : Label) →
-  Realizes Δ Σ Φ →
-  Realizes (suc Δ) (⟰ᵗ Σ) ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+  Realizesᵐ μ Δ Σ Φ →
+  Realizesᵐ (genᵈ μ) (suc Δ) (⟰ᵗ Σ) ((zero ˣ⊑★) ∷ ⇑ᵢ Φ)
 Realizes-ν-gen ℓ r =
   real-star
     (wfVar z<s)
-    (cast-tag (wfVar z<s) (＇ zero))
-    (cast-untag (wfVar z<s) (＇ zero))
-    (Realizes-⇑ᴸᵢ ℓ r)
+    (cast-tag (wfVar z<s) (＇ zero) refl)
+    (cast-untag (wfVar z<s) (＇ zero) refl)
+    (Realizes-rename-suc ModeRename-suc-gen r)
 
 realizes-idᵢ :
   ∀ Δ →
@@ -249,99 +279,151 @@ realizes-idᵢ (suc Δ) =
   real-xx
     (wfVar z<s)
     (wfVar z<s)
-    (cast-id (wfVar z<s))
-    (cast-id (wfVar z<s))
-    (Realizes-⇑ᵢ (realizes-idᵢ Δ))
+    (cast-id (wfVar z<s) (tyAllowed-normal (＇ zero)))
+    (cast-id (wfVar z<s) (tyAllowed-normal (＇ zero)))
+    (Realizes-rename-suc ModeRename-suc-normal (realizes-idᵢ Δ))
 
 ------------------------------------------------------------------------
 -- Coercion synthesis from imprecision
 ------------------------------------------------------------------------
 
 mutual
-  coerce-up :
-    ∀ {Δ Σ Φ C A} →
+  coerce-upᵐ :
+    ∀ {μ Δ Σ Φ C A} →
     (ℓ : Label) →
     WfTy Δ C →
     WfTy Δ A →
-    Realizes Δ Σ Φ →
+    tyAllowed μ A ≡ true →
+    Realizesᵐ μ Δ Σ Φ →
     Φ ⊢ C ⊑ A →
-    Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ C =⇒ A
-  coerce-up ℓ wf★ wf★ r id★ =
-    idᶜ ★ , cast-id wf★
-  coerce-up {C = ＇ X} {A = ＇ Y} ℓ hX hY r (idˣ X⊑Y) =
+    Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ C =⇒ A
+  coerce-upᵐ ℓ wf★ wf★ ok r id★ =
+    idᶜ ★ , cast-id wf★ refl
+  coerce-upᵐ {C = ＇ X} {A = ＇ Y} ℓ hX hY ok r (idˣ X⊑Y) =
     realizes-xx-up r X⊑Y
-  coerce-up {C = ‵ ι} ℓ wfBase wfBase r idι =
-    idᶜ (‵ ι) , cast-id wfBase
-  coerce-up ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) r (p ↦ q)
-      with coerce-down ℓ hA hA′ r p | coerce-up ℓ hB hB′ r q
-  coerce-up ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) r (p ↦ q)
-      | s , s⊢ | t , t⊢ =
+  coerce-upᵐ {C = ‵ ι} ℓ wfBase wfBase ok r idι =
+    idᶜ (‵ ι) , cast-id wfBase refl
+  coerce-upᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      with tyAllowed μ A′ in okA′ | tyAllowed μ B′ in okB′
+  coerce-upᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true
+      with coerce-downᵐ ℓ hA hA′ okA′ r p
+         | coerce-upᵐ ℓ hB hB′ okB′ r q
+  coerce-upᵐ ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true | s , s⊢ | t , t⊢ =
     (s ↦ᶜ t) , cast-fun s⊢ t⊢
-  coerce-up ℓ (wf∀ hA) (wf∀ hB) r (∀ⁱ p)
-      with coerce-up ℓ hA hB (Realizes-∀ⁱ r) p
-  coerce-up ℓ (wf∀ hA) (wf∀ hB) r (∀ⁱ p)
+  coerce-upᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | false | b
+  coerce-upᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | true | false
+  coerce-upᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
+      with coerce-upᵐ ℓ hA hB ok (Realizes-∀ⁱ r) p
+  coerce-upᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
       | c , c⊢ =
     `∀ᶜ c , cast-all c⊢
-  coerce-up {C = ‵ ι} ℓ wfBase wf★ r (tag ι) =
-    ((‵ ι) !ᶜ) , cast-tag wfBase (‵ ι)
-  coerce-up ℓ (wf⇒ hA hB) wf★ r (tag_⇒_ p q)
-      with coerce-down ℓ hA wf★ r p | coerce-up ℓ hB wf★ r q
-  coerce-up ℓ (wf⇒ hA hB) wf★ r (tag_⇒_ p q)
+  coerce-upᵐ {C = ‵ ι} ℓ wfBase wf★ ok r (tag ι) =
+    ((‵ ι) !ᶜ) , cast-tag wfBase (‵ ι) refl
+  coerce-upᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
+      with coerce-downᵐ ℓ hA wf★ refl r p
+         | coerce-upᵐ ℓ hB wf★ refl r q
+  coerce-upᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
       | s , s⊢ | t , t⊢ =
     ((s ↦ᶜ t) ︔ᶜ ((★ ⇒ ★) !ᶜ)) ,
-    cast-seq (cast-fun s⊢ t⊢) (cast-tag (wf⇒ wf★ wf★) ★⇒★)
-  coerce-up {C = ＇ X} ℓ hX wf★ r (tagˣ X⊑★) =
+    cast-seq (cast-fun s⊢ t⊢) (cast-tag (wf⇒ wf★ wf★) ★⇒★ refl)
+  coerce-upᵐ {C = ＇ X} ℓ hX wf★ ok r (tagˣ X⊑★) =
     realizes-star-up r X⊑★
-  coerce-up {A = B} ℓ (wf∀ hA) hB r (ν occ p)
-      with coerce-up ℓ
+  coerce-upᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
+      with coerce-upᵐ ℓ
              hA
              (renameᵗ-preserves-WfTy hB TyRenameWf-suc)
+             (tyAllowed-shift-inst {μ = μ} {B = B} ok)
              (Realizes-ν-inst ℓ r)
              p
-  coerce-up {A = B} ℓ (wf∀ hA) hB r (ν occ p)
+  coerce-upᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
       | c , c⊢ =
-    instᶜ B c , cast-inst hB c⊢
+    instᶜ B c , cast-inst hB ok c⊢
 
-  coerce-down :
-    ∀ {Δ Σ Φ C A} →
+  coerce-downᵐ :
+    ∀ {μ Δ Σ Φ C A} →
     (ℓ : Label) →
     WfTy Δ C →
     WfTy Δ A →
-    Realizes Δ Σ Φ →
+    tyAllowed μ A ≡ true →
+    Realizesᵐ μ Δ Σ Φ →
     Φ ⊢ C ⊑ A →
-    Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ A =⇒ C
-  coerce-down ℓ wf★ wf★ r id★ =
-    idᶜ ★ , cast-id wf★
-  coerce-down {C = ＇ X} {A = ＇ Y} ℓ hX hY r (idˣ X⊑Y) =
+    Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ C
+  coerce-downᵐ ℓ wf★ wf★ ok r id★ =
+    idᶜ ★ , cast-id wf★ refl
+  coerce-downᵐ {C = ＇ X} {A = ＇ Y} ℓ hX hY ok r (idˣ X⊑Y) =
     realizes-xx-down r X⊑Y
-  coerce-down {C = ‵ ι} ℓ wfBase wfBase r idι =
-    idᶜ (‵ ι) , cast-id wfBase
-  coerce-down ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) r (p ↦ q)
-      with coerce-up ℓ hA hA′ r p | coerce-down ℓ hB hB′ r q
-  coerce-down ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) r (p ↦ q)
-      | s , s⊢ | t , t⊢ =
+  coerce-downᵐ {C = ‵ ι} ℓ wfBase wfBase ok r idι =
+    idᶜ (‵ ι) , cast-id wfBase refl
+  coerce-downᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      with tyAllowed μ A′ in okA′ | tyAllowed μ B′ in okB′
+  coerce-downᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true
+      with coerce-upᵐ ℓ hA hA′ okA′ r p
+         | coerce-downᵐ ℓ hB hB′ okB′ r q
+  coerce-downᵐ ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true | s , s⊢ | t , t⊢ =
     (s ↦ᶜ t) , cast-fun s⊢ t⊢
-  coerce-down ℓ (wf∀ hA) (wf∀ hB) r (∀ⁱ p)
-      with coerce-down ℓ hA hB (Realizes-∀ⁱ r) p
-  coerce-down ℓ (wf∀ hA) (wf∀ hB) r (∀ⁱ p)
+  coerce-downᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | false | b
+  coerce-downᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | true | false
+  coerce-downᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
+      with coerce-downᵐ ℓ hA hB ok (Realizes-∀ⁱ r) p
+  coerce-downᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
       | c , c⊢ =
     `∀ᶜ c , cast-all c⊢
-  coerce-down {C = ‵ ι} ℓ wfBase wf★ r (tag ι) =
-    ((‵ ι) ？ᶜ) , cast-untag wfBase (‵ ι)
-  coerce-down ℓ (wf⇒ hA hB) wf★ r (tag_⇒_ p q)
-      with coerce-up ℓ hA wf★ r p | coerce-down ℓ hB wf★ r q
-  coerce-down ℓ (wf⇒ hA hB) wf★ r (tag_⇒_ p q)
+  coerce-downᵐ {C = ‵ ι} ℓ wfBase wf★ ok r (tag ι) =
+    ((‵ ι) ？ᶜ) , cast-untag wfBase (‵ ι) refl
+  coerce-downᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
+      with coerce-upᵐ ℓ hA wf★ refl r p
+         | coerce-downᵐ ℓ hB wf★ refl r q
+  coerce-downᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
       | s , s⊢ | t , t⊢ =
     (((★ ⇒ ★) ？ᶜ) ︔ᶜ (s ↦ᶜ t)) ,
-    cast-seq (cast-untag (wf⇒ wf★ wf★) ★⇒★) (cast-fun s⊢ t⊢)
-  coerce-down {C = ＇ X} ℓ hX wf★ r (tagˣ X⊑★) =
+    cast-seq (cast-untag (wf⇒ wf★ wf★) ★⇒★ refl) (cast-fun s⊢ t⊢)
+  coerce-downᵐ {C = ＇ X} ℓ hX wf★ ok r (tagˣ X⊑★) =
     realizes-star-down r X⊑★
-  coerce-down {A = B} ℓ (wf∀ hA) hB r (ν occ p)
-      with coerce-down ℓ
+  coerce-downᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
+      with coerce-downᵐ ℓ
              hA
              (renameᵗ-preserves-WfTy hB TyRenameWf-suc)
+             (tyAllowed-shift-gen {μ = μ} {B = B} ok)
              (Realizes-ν-gen ℓ r)
              p
-  coerce-down {A = B} ℓ (wf∀ hA) hB r (ν occ p)
+  coerce-downᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
       | c , c⊢ =
-    genᶜ B c , cast-gen hB c⊢
+    genᶜ B c , cast-gen hB ok c⊢
+
+coerce-up :
+  ∀ {Δ Σ Φ C A} →
+  (ℓ : Label) →
+  WfTy Δ C →
+  WfTy Δ A →
+  Realizes Δ Σ Φ →
+  Φ ⊢ C ⊑ A →
+  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ C =⇒ A
+coerce-up {A = A} ℓ hC hA r p =
+  coerce-upᵐ ℓ hC hA (tyAllowed-normal A) r p
+
+coerce-down :
+  ∀ {Δ Σ Φ C A} →
+  (ℓ : Label) →
+  WfTy Δ C →
+  WfTy Δ A →
+  Realizes Δ Σ Φ →
+  Φ ⊢ C ⊑ A →
+  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ A =⇒ C
+coerce-down {A = A} ℓ hC hA r p =
+  coerce-downᵐ ℓ hC hA (tyAllowed-normal A) r p

--- a/GTSF/proof/ImprecisionProperties.agda
+++ b/GTSF/proof/ImprecisionProperties.agda
@@ -140,9 +140,9 @@ WfImpCtx-to² hΦ {a = X ˣ⊑ˣ Y} a∈ = hΦ a∈
 νᵢ-wf :
   ∀ {Δ Φ} →
   WfImpCtx Δ Φ →
-  WfImpCtx (suc Δ) ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+  WfImpCtx (suc Δ) ((zero ˣ⊑★) ∷ ⇑ᵢ Φ)
 νᵢ-wf hΦ (here refl) = z<s
-νᵢ-wf hΦ (there a∈) = ⇑ᴸᵢ-wf hΦ a∈
+νᵢ-wf hΦ (there a∈) = ⇑ᵢ-wf hΦ a∈
 
 ⇑ᵢ-wf² :
   ∀ {Δᴸ Δᴿ Φ} →
@@ -182,9 +182,9 @@ WfImpCtx-to² hΦ {a = X ˣ⊑ˣ Y} a∈ = hΦ a∈
 νᵢ-wf² :
   ∀ {Δᴸ Δᴿ Φ} →
   WfImpCtx² Δᴸ Δᴿ Φ →
-  WfImpCtx² (suc Δᴸ) Δᴿ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+  WfImpCtx² (suc Δᴸ) (suc Δᴿ) ((zero ˣ⊑★) ∷ ⇑ᵢ Φ)
 νᵢ-wf² hΦ (here refl) = z<s
-νᵢ-wf² hΦ (there a∈) = ⇑ᴸᵢ-wf² hΦ a∈
+νᵢ-wf² hΦ (there a∈) = ⇑ᵢ-wf² hΦ a∈
 
 idᵢ-wf :
   ∀ Δ →
@@ -381,7 +381,7 @@ mutual
   imp? Φ (`∀ A) (＇ X) | no ¬occA =
     no λ { (ν occ A⊑X) → ¬occA occ }
   imp? Φ (`∀ A) (＇ X) | yes occA
-      with imp? ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) A (＇ X)
+      with imp? ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) A (⇑ᵗ (＇ X))
   imp? Φ (`∀ A) (＇ X) | yes occA | yes A⊑X = yes (ν occA A⊑X)
   imp? Φ (`∀ A) (＇ X) | yes occA | no A⋢X =
     no λ { (ν occ A⊑X) → A⋢X A⊑X }
@@ -389,7 +389,7 @@ mutual
   imp? Φ (`∀ A) (‵ ι) | no ¬occA =
     no λ { (ν occ A⊑ι) → ¬occA occ }
   imp? Φ (`∀ A) (‵ ι) | yes occA
-      with imp? ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) A (‵ ι)
+      with imp? ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) A (⇑ᵗ (‵ ι))
   imp? Φ (`∀ A) (‵ ι) | yes occA | yes A⊑ι = yes (ν occA A⊑ι)
   imp? Φ (`∀ A) (‵ ι) | yes occA | no A⋢ι =
     no λ { (ν occ A⊑ι) → A⋢ι A⊑ι }
@@ -397,7 +397,7 @@ mutual
   imp? Φ (`∀ A) ★ | no ¬occA =
     no λ { (ν occ A⊑★) → ¬occA occ }
   imp? Φ (`∀ A) ★ | yes occA
-      with imp? ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) A ★
+      with imp? ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) A (⇑ᵗ ★)
   imp? Φ (`∀ A) ★ | yes occA | yes A⊑★ = yes (ν occA A⊑★)
   imp? Φ (`∀ A) ★ | yes occA | no A⋢★ =
     no λ { (ν occ A⊑★) → A⋢★ A⊑★ }
@@ -405,7 +405,7 @@ mutual
   imp? Φ (`∀ A) (B₁ ⇒ B₂) | no ¬occA =
     no λ { (ν occ A⊑B) → ¬occA occ }
   imp? Φ (`∀ A) (B₁ ⇒ B₂) | yes occA
-      with imp? ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) A (B₁ ⇒ B₂)
+      with imp? ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) A (⇑ᵗ (B₁ ⇒ B₂))
   imp? Φ (`∀ A) (B₁ ⇒ B₂) | yes occA | yes A⊑B =
     yes (ν occA A⊑B)
   imp? Φ (`∀ A) (B₁ ⇒ B₂) | yes occA | no A⋢B =
@@ -420,7 +420,7 @@ mutual
       ; (ν occ A⊑∀B) → ¬occA occ
       }
   imp? Φ (`∀ A) (`∀ B) | no A⋢B | yes occA
-      with imp? ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) A (`∀ B)
+      with imp? ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) A (⇑ᵗ (`∀ B))
   imp? Φ (`∀ A) (`∀ B) | no A⋢B | yes occA | yes A⊑∀B =
     yes (ν occA A⊑∀B)
   imp? Φ (`∀ A) (`∀ B) | no A⋢B | yes occA | no A⋢∀B =
@@ -470,7 +470,8 @@ mutual
   ⊑-tgt-wf² hΦ (tag ι) = wf★
   ⊑-tgt-wf² hΦ (tag_⇒_ p q) = wf★
   ⊑-tgt-wf² hΦ (tagˣ X⊑★∈) = wf★
-  ⊑-tgt-wf² hΦ (ν occA p) = ⊑-tgt-wf² (νᵢ-wf² hΦ) p
+  ⊑-tgt-wf² hΦ (ν occA p) =
+    WfTy-un⇑ᵗ (⊑-tgt-wf² (νᵢ-wf² hΦ) p)
 
 ⊑-src-wf :
   ∀ {Δ Φ A B} →
@@ -539,14 +540,17 @@ no-⇑ᴸᵢ-zero-left {Φ = (_ ˣ⊑ˣ _) ∷ Φ} (there x∈) =
 
 νctx-no-var-left-zero :
   ∀ {Φ} →
-  NoVarLeft ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) zero
-νctx-no-var-left-zero (there x∈) = no-⇑ᴸᵢ-zero-left x∈
+  NoVarLeft ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) zero
+νctx-no-var-left-zero (there x∈) = no-⇑ᵢ-zero-left x∈
 
 νctx-no-var-left-suc :
   ∀ {Φ X} →
   NoVarLeft Φ X →
-  NoVarLeft ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc X)
-νctx-no-var-left-suc noX (there x∈) = noX (un⇑ᴸᵢ-ˣ∈ x∈)
+  NoVarLeft ((zero ˣ⊑★) ∷ ⇑ᵢ Φ) (suc X)
+νctx-no-var-left-suc noX {Y = zero} (there x∈) =
+  no-⇑ᵢ-zero-right x∈
+νctx-no-var-left-suc noX {Y = suc Y} (there x∈) =
+  noX (un⇑ᵢ-ˣ∈ x∈)
 
 ⊑-to-var-occurs-false :
   ∀ {Φ C X} Y →
@@ -602,7 +606,7 @@ data ArrowTargetInv (Δ : TyCtx) : Ty → Ty → Ty → Set where
   arrow-target-ν :
     ∀ {A B C} →
     (occ : occurs zero C ≡ true) →
-    (zero ˣ⊑★) ∷ ⇑ᴸᵢ (idᵢ Δ) ⊢ C ⊑ A ⇒ B →
+    (zero ˣ⊑★) ∷ ⇑ᵢ (idᵢ Δ) ⊢ C ⊑ ⇑ᵗ (A ⇒ B) →
     ArrowTargetInv Δ (`∀ C) A B
 
 ⊑-arrow-inv-idᵢ :
@@ -621,7 +625,7 @@ data ForallTargetInv (Δ : TyCtx) : Ty → Ty → Set where
   forall-target-ν :
     ∀ {A C} →
     (occ : occurs zero C ≡ true) →
-    (zero ˣ⊑★) ∷ ⇑ᴸᵢ (idᵢ Δ) ⊢ C ⊑ `∀ A →
+    (zero ˣ⊑★) ∷ ⇑ᵢ (idᵢ Δ) ⊢ C ⊑ ⇑ᵗ (`∀ A) →
     ForallTargetInv Δ (`∀ C) A
 
 ⊑-forall-inv-idᵢ :
@@ -767,6 +771,4 @@ data ForallTargetInv (Δ : TyCtx) : Ty → Ty → Set where
   idᵢ Δ ⊢ C ⊑ B →
   WfTy Δ C
 ~-lower-wf C⊑A C⊑B = ⊑-src-wf-idᵢ C⊑A
-
-
 

--- a/GTSF/proof/NuPreservation.agda
+++ b/GTSF/proof/NuPreservation.agda
@@ -46,15 +46,18 @@ record PreservationResult
 open PreservationResult public
 
 coercion-open-existing :
-  ∀ {Δ Σ c A B α} →
+  ∀ {μ Δ Σ c A B α} →
   α < Δ →
-  suc Δ ∣ ⟰ᵗ Σ ⊢ c ∶ A =⇒ B →
+  μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ c ∶ A =⇒ B →
   Δ ∣ Σ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ =⇒ B [ α ]ᴿ
-coercion-open-existing {Σ = Σ} {α = α} α<Δ c⊢ =
+coercion-open-existing {μ = μ} {Σ = Σ} {α = α} α<Δ c⊢ =
   subst
     (λ Σ′ → _ ∣ Σ′ ⊢ _ ∶ _ =⇒ _)
     (renameStoreᵗ-single-suc-cancel α Σ)
-    (coercion-renameᵗ (singleRenameᵗ-Wf-< α<Δ) c⊢)
+    (coercion-renameᵗᵐ
+      (singleRenameᵗ-Wf-< α<Δ)
+      (ModeRename-to-normal {ρ = singleRenameᵗ α} {μ = μ})
+      c⊢)
 
 ------------------------------------------------------------------------
 -- Raw redex preservation
@@ -96,13 +99,13 @@ pure-preservation wfΣ hΓ
   where
     src-open-eq :
       (src c) [ α ]ᴿ ≡ A₀ [ α ]ᴿ
-    src-open-eq with coercion-src-tgt c⊢
+    src-open-eq with coercion-src-tgtᵐ c⊢
     src-open-eq | src-eq , tgt-eq =
       cong (λ T → T [ α ]ᴿ) src-eq
 
     V-src⊢ :
       _ ∣ _ ∣ _ ⊢ V ⦂ `∀ (src c)
-    V-src⊢ with coercion-src-tgt c⊢
+    V-src⊢ with coercion-src-tgtᵐ c⊢
     V-src⊢ | src-eq , tgt-eq =
       subst (λ U → _ ∣ _ ∣ _ ⊢ V ⦂ `∀ U) (sym src-eq) V⊢
 
@@ -129,7 +132,7 @@ pure-preservation wfΣ hΓ
     (β-inst vV) =
   ⊢ν
     wf★
-    (⊢⟨⟩ c⊢ app-src⊢)
+    (⊢⟨⟩ (coercion-mode-relax modeIncl-normal c⊢) app-src⊢)
   where
     app-src-eq :
       (renameᵗ (extᵗ suc) A) [ zero ]ᴿ ≡ A

--- a/GTSF/proof/NuPreservation.agda
+++ b/GTSF/proof/NuPreservation.agda
@@ -80,7 +80,7 @@ pure-preservation wfΣ hΓ
     (⊢• {B = B} (⊢Λ {A = B′} vV V⊢) α<Δ)
     β-Λ =
   typing-open-existingᵀ α<Δ V⊢
-pure-preservation wfΣ hΓ (⊢⟨⟩ (cast-id hA) hV) (β-id vV) =
+pure-preservation wfΣ hΓ (⊢⟨⟩ (cast-id hA _) hV) (β-id vV) =
   hV
 pure-preservation wfΣ hΓ (⊢⟨⟩ (cast-seq p⊢ q⊢) hV) (β-seq vV) =
   ⊢⟨⟩ q⊢ (⊢⟨⟩ p⊢ hV)
@@ -118,7 +118,7 @@ pure-preservation wfΣ hΓ
         (⊢• V-src⊢ α<Δ)
 pure-preservation wfΣ hΓ
     (⊢• {α = α}
-      (⊢⟨⟩ (gen⊢@(cast-gen {s = c} hC c⊢)) V⊢)
+      (⊢⟨⟩ (gen⊢@(cast-gen {s = c} hC _ c⊢)) V⊢)
       α<Δ)
     (β-gen vV) =
   ⊢⟨⟩
@@ -128,7 +128,7 @@ pure-preservation wfΣ hΓ
       (coercion-open-existing α<Δ c⊢))
     V⊢
 pure-preservation wfΣ hΓ
-    (⊢⟨⟩ {M = V} (cast-inst {A = A} {B = B} {s = c} hB c⊢) V⊢)
+    (⊢⟨⟩ {M = V} (cast-inst {A = A} {B = B} {s = c} hB _ c⊢) V⊢)
     (β-inst vV) =
   ⊢ν
     wf★
@@ -159,18 +159,18 @@ pure-preservation wfΣ hΓ
         app-src-eq
         (⊢• shifted-V⊢ z<s)
 pure-preservation wfΣ hΓ
-    (⊢⟨⟩ (cast-unseal hB αB∈Σ)
-      (⊢⟨⟩ (cast-seal hA αA∈Σ) hV))
+    (⊢⟨⟩ (cast-unseal hB αB∈Σ _ _)
+      (⊢⟨⟩ (cast-seal hA αA∈Σ _ _) hV))
     (seal-unseal vV) =
   subst (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
         (unique wfΣ αA∈Σ αB∈Σ)
         hV
 pure-preservation wfΣ hΓ
-    (⊢⟨⟩ (cast-untag hG gG) (⊢⟨⟩ (cast-tag hG′ gG′) hV))
+    (⊢⟨⟩ (cast-untag hG gG _) (⊢⟨⟩ (cast-tag hG′ gG′ _) hV))
     (tag-untag-ok vV) =
   hV
 pure-preservation wfΣ hΓ
-    (⊢⟨⟩ (cast-untag hH gH) (⊢⟨⟩ (cast-tag hG gG) hV))
+    (⊢⟨⟩ (cast-untag hH gH _) (⊢⟨⟩ (cast-tag hG gG _) hV))
     (tag-untag-bad vV G≢H) =
   ⊢blame hH
 pure-preservation wfΣ hΓ (⊢· (⊢blame (wf⇒ hA hB)) hM) blame-·₁ =

--- a/GTSF/proof/NuProgress.agda
+++ b/GTSF/proof/NuProgress.agda
@@ -125,7 +125,7 @@ canonical-∀ (_⟨_⟩ {V = W} vW (seal A α)) (⊢⟨⟩ () hW)
 canonical-∀ (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢⟨⟩ () hW)
 canonical-∀ (_⟨_⟩ {V = W} vW (`∀ c)) (⊢⟨⟩ (cast-all cwt) hW) =
   av-∀ vW refl
-canonical-∀ (_⟨_⟩ {V = W} vW (gen A c)) (⊢⟨⟩ (cast-gen _ cwt) hW) =
+canonical-∀ (_⟨_⟩ {V = W} vW (gen A c)) (⊢⟨⟩ (cast-gen _ _ cwt) hW) =
   av-gen vW refl
 
 data NatView (V : Term) : Set where
@@ -163,7 +163,7 @@ canonical-★ :
 canonical-★ (ƛ N) ()
 canonical-★ (Λ vV) ()
 canonical-★ ($ (κℕ n)) ()
-canonical-★ (_⟨_⟩ {V = W} vW (G !)) (⊢⟨⟩ (cast-tag _ _) hW) =
+canonical-★ (_⟨_⟩ {V = W} vW (G !)) (⊢⟨⟩ (cast-tag _ _ _) hW) =
   sv-tag vW refl
 canonical-★ (_⟨_⟩ {V = W} vW (seal A α)) (⊢⟨⟩ () hW)
 canonical-★ (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢⟨⟩ () hW)
@@ -186,7 +186,7 @@ canonical-＇ (ƛ N) ()
 canonical-＇ (Λ vV) ()
 canonical-＇ ($ (κℕ n)) ()
 canonical-＇ (_⟨_⟩ {V = W} vW (G !)) (⊢⟨⟩ () hW)
-canonical-＇ (_⟨_⟩ {V = W} vW (seal A α)) (⊢⟨⟩ (cast-seal _ _) hW) =
+canonical-＇ (_⟨_⟩ {V = W} vW (seal A α)) (⊢⟨⟩ (cast-seal _ _ _ _) hW) =
   sv-seal vW refl
 canonical-＇ (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢⟨⟩ () hW)
 canonical-＇ (_⟨_⟩ {V = W} vW (`∀ c)) (⊢⟨⟩ () hW)
@@ -289,21 +289,21 @@ progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | step M→M′ =
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | crash refl =
   step (pure-step blame-⟨⟩)
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM with c⊢
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-id hA =
+progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-id hA _ =
   step (pure-step (β-id vM))
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-seal hA hα =
+    | cast-seal hA hα _ _ =
   done (vM ⟨ seal _ _ ⟩)
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-unseal hA hα =
+    | cast-unseal hA hα _ _ =
   unseal-progress vM M⊢
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
     | cast-seq p⊢ q⊢ =
   step (pure-step (β-seq vM))
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-tag hG gG =
+progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-tag hG gG _ =
   done (vM ⟨ _ ! ⟩)
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-untag hG gG =
+    | cast-untag hG gG _ =
   untag-progress vM M⊢
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
     | cast-fun p⊢ q⊢ =
@@ -311,8 +311,8 @@ progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
 progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-all cwt =
   done (vM ⟨ `∀ _ ⟩)
 progress {Σ = Σ} (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢)
-    | done vM | cast-inst _ cwt =
+    | done vM | cast-inst _ _ cwt =
   step (pure-step (β-inst {Σ = Σ} vM))
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-gen _ cwt =
+progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-gen _ _ cwt =
   done (vM ⟨ gen _ _ ⟩)
 progress (⊢blame hA) = crash refl

--- a/GTSF/proof/Preservation.agda
+++ b/GTSF/proof/Preservation.agda
@@ -70,23 +70,23 @@ pure-preservation wfΣ hΓ
     (⊢· (⊢up (cast-fun p⊢ q⊢) hV) hW)
     (β-↦ vV vW) =
   ⊢up q⊢ (⊢· hV (⊢up p⊢ hW))
-pure-preservation wfΣ hΓ (⊢up (cast-id hA) hV) (β-id vV) =
+pure-preservation wfΣ hΓ (⊢up (cast-id hA _) hV) (β-id vV) =
   hV
 pure-preservation wfΣ hΓ (⊢up (cast-seq p⊢ q⊢) hV) (β-seq vV) =
   ⊢up q⊢ (⊢up p⊢ hV)
 pure-preservation wfΣ hΓ
-    (⊢up (cast-unseal hB αB∈Σ)
-      (⊢up (cast-seal hA αA∈Σ) hV))
+    (⊢up (cast-unseal hB αB∈Σ _ _)
+      (⊢up (cast-seal hA αA∈Σ _ _) hV))
     (seal-unseal vV) =
   subst (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
         (unique wfΣ αA∈Σ αB∈Σ)
         hV
 pure-preservation wfΣ hΓ
-    (⊢up (cast-untag hG gG) (⊢up (cast-tag hG′ gG′) hV))
+    (⊢up (cast-untag hG gG _) (⊢up (cast-tag hG′ gG′ _) hV))
     (tag-untag-ok vV) =
   hV
 pure-preservation wfΣ hΓ
-    (⊢up (cast-untag hH gH) (⊢up (cast-tag hG gG) hV))
+    (⊢up (cast-untag hH gH _) (⊢up (cast-tag hG gG _) hV))
     (tag-untag-bad vV G≢H) =
   ⊢blame hH
 pure-preservation wfΣ hΓ
@@ -187,7 +187,7 @@ preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
              (wfVar (n<1+n Δ)))
 preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
     (⊢• {B = B} {A = T}
-      (⊢up (gen⊢@(cast-gen hC c⊢)) V⊢)
+      (⊢up (gen⊢@(cast-gen hC _ c⊢)) V⊢)
       hT)
     (β-down-ν vV)
     rewrite len wfΣ =
@@ -210,7 +210,7 @@ preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
     hB with typing-wf (at wfΣ) hΓ (⊢up gen⊢ V⊢)
     hB | wf∀ hB′ = hB′
 preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
-    (⊢up {M = V} (cast-inst {s = c} hB c⊢) V⊢)
+    (⊢up {M = V} (cast-inst {s = c} hB _ c⊢) V⊢)
     (β-up-ν vV)
     rewrite len wfΣ =
   preserve

--- a/GTSF/proof/Preservation.agda
+++ b/GTSF/proof/Preservation.agda
@@ -157,7 +157,7 @@ preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
     (⊢up
       (reveal-fresh-typing hT hB)
       (⊢up
-        (coercion-open (n<1+n Δ) c⊢)
+        (coercion-openᵐ (n<1+n Δ) c⊢)
         app-src⊢))
   where
     hB : WfTy (suc Δ) B
@@ -166,14 +166,14 @@ preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
 
     src-open-eq :
       (src c) [ ＇ Δ ]ᵗ ≡ _ [ Δ ]ᴿ
-    src-open-eq with coercion-src-tgt c⊢
+    src-open-eq with coercion-src-tgtᵐ c⊢
     src-open-eq | src-eq , tgt-eq =
       trans (cong (λ T → T [ ＇ Δ ]ᵗ) src-eq)
             (subst-var-rename Δ _)
 
     V-src⊢ :
       Δ ∣ Σ ∣ Γ ⊢ V ⦂ `∀ (src c)
-    V-src⊢ with coercion-src-tgt c⊢
+    V-src⊢ with coercion-src-tgtᵐ c⊢
     V-src⊢ | src-eq , tgt-eq =
       subst (λ U → Δ ∣ Σ ∣ Γ ⊢ V ⦂ `∀ U) (sym src-eq) V⊢
 
@@ -200,7 +200,7 @@ preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
     (⊢up
       (reveal-fresh-typing hT hB)
       (⊢up
-        (coercion-open (n<1+n Δ) c⊢)
+        (coercion-openᵐ (n<1+n Δ) c⊢)
         (subst
           (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
           (sym (renameᵗ-single-suc-cancel Δ _))
@@ -223,19 +223,19 @@ preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
       (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
       (renameᵗ-single-suc-cancel Δ _)
       (⊢up
-        (coercion-open-head (n<1+n Δ) c⊢)
+        (coercion-open-headᵐ (n<1+n Δ) c⊢)
         app-src⊢))
   where
     src-open-eq :
       (src c) [ ＇ Δ ]ᵗ ≡ _ [ Δ ]ᴿ
-    src-open-eq with coercion-src-tgt c⊢
+    src-open-eq with coercion-src-tgtᵐ c⊢
     src-open-eq | src-eq , tgt-eq =
       trans (cong (λ T → T [ ＇ Δ ]ᵗ) src-eq)
             (subst-var-rename Δ _)
 
     V-src⊢ :
       Δ ∣ Σ ∣ Γ ⊢ V ⦂ `∀ (src c)
-    V-src⊢ with coercion-src-tgt c⊢
+    V-src⊢ with coercion-src-tgtᵐ c⊢
     V-src⊢ | src-eq , tgt-eq =
       subst (λ U → Δ ∣ Σ ∣ Γ ⊢ V ⦂ `∀ U) (sym src-eq) V⊢
 

--- a/GTSF/proof/Progress.agda
+++ b/GTSF/proof/Progress.agda
@@ -95,7 +95,7 @@ canonical-∀ (_⟨_⟩ {V = W} vW (seal A α)) (⊢up () hW)
 canonical-∀ (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢up () hW)
 canonical-∀ (_⟨_⟩ {V = W} vW (`∀ c)) (⊢up (cast-all cwt) hW) =
   av-∀ vW refl
-canonical-∀ (_⟨_⟩ {V = W} vW (gen A c)) (⊢up (cast-gen _ cwt) hW) =
+canonical-∀ (_⟨_⟩ {V = W} vW (gen A c)) (⊢up (cast-gen _ _ cwt) hW) =
   av-gen vW refl
 
 data NatView (V : Term) : Set where
@@ -133,7 +133,7 @@ canonical-★ :
 canonical-★ (ƛ N) ()
 canonical-★ (Λ vV) ()
 canonical-★ ($ (κℕ n)) ()
-canonical-★ (_⟨_⟩ {V = W} vW (G !)) (⊢up (cast-tag _ _) hW) =
+canonical-★ (_⟨_⟩ {V = W} vW (G !)) (⊢up (cast-tag _ _ _) hW) =
   sv-tag vW refl
 canonical-★ (_⟨_⟩ {V = W} vW (seal A α)) (⊢up () hW)
 canonical-★ (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢up () hW)
@@ -156,7 +156,7 @@ canonical-＇ (ƛ N) ()
 canonical-＇ (Λ vV) ()
 canonical-＇ ($ (κℕ n)) ()
 canonical-＇ (_⟨_⟩ {V = W} vW (G !)) (⊢up () hW)
-canonical-＇ (_⟨_⟩ {V = W} vW (seal A α)) (⊢up (cast-seal _ _) hW) =
+canonical-＇ (_⟨_⟩ {V = W} vW (seal A α)) (⊢up (cast-seal _ _ _ _) hW) =
   sv-seal vW refl
 canonical-＇ (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢up () hW)
 canonical-＇ (_⟨_⟩ {V = W} vW (`∀ c)) (⊢up () hW)
@@ -257,29 +257,29 @@ progress (⊢up {M = M} {c = c} c⊢ M⊢) | step M→M′ =
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | crash refl =
   step (pure-step blame-⟨⟩)
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM with c⊢
-progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-id hA =
+progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-id hA _ =
   step (pure-step (β-id vM))
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-seal hA hα =
+    | cast-seal hA hα _ _ =
   done (vM ⟨ seal _ _ ⟩)
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-unseal hA hα =
+    | cast-unseal hA hα _ _ =
   unseal-progress vM M⊢
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM
     | cast-seq p⊢ q⊢ =
   step (pure-step (β-seq vM))
-progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-tag hG gG =
+progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-tag hG gG _ =
   done (vM ⟨ _ ! ⟩)
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-untag hG gG =
+    | cast-untag hG gG _ =
   untag-progress vM M⊢
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM
     | cast-fun p⊢ q⊢ =
   done (vM ⟨ _ ↦ _ ⟩)
 progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-all cwt =
   done (vM ⟨ `∀ _ ⟩)
-progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-inst _ cwt =
+progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-inst _ _ cwt =
   step (β-up-ν vM)
-progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-gen _ cwt =
+progress (⊢up {M = M} {c = c} c⊢ M⊢) | done vM | cast-gen _ _ cwt =
   done (vM ⟨ gen _ _ ⟩)
 progress (⊢blame hA) = crash refl


### PR DESCRIPTION
## Summary

- add mode-indexed strict coercion typing for GTSF, with the old public coercion judgment preserved as the normal-mode instance
- update coercion metatheory, endpoint flipping, and preservation proofs to use the mode-aware lemmas
- document the cambridge22 side-condition problem and the mode-based alternative in `GTSF/notes.md`
- add `GTSF/All.agda` to aggregate-check both `MetaTheory` and `NuMetaTheory`

## Validation

- `agda -v0 All.agda` from `GTSF/`
- `git diff --check -- GTSF/Coercions.agda GTSF/notes.md GTSF/proof/CoercionProperties.agda GTSF/proof/NuPreservation.agda GTSF/proof/Preservation.agda`