### PR TITLE
[codex] Revise GTSF Nu runtime type application

### DIFF
--- a/GTSF/NuMetaTheory.agda
+++ b/GTSF/NuMetaTheory.agda
@@ -9,7 +9,6 @@ module NuMetaTheory where
 
 open import Agda.Builtin.Equality using (_≡_)
 open import Data.List using ([])
-open import Data.Nat using (_≤_)
 open import Data.Product using (_×_; _,_; ∃-syntax)
 
 open import Types
@@ -17,7 +16,7 @@ open import Ctx
 open import Coercions
 open import NarrowWiden
   using (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_; dualⁿ; dualʷ)
-open import NuStore using (StoreIncl; StoreWf)
+open import NuStore using (StoreWf)
 open import NuTerms
 open import NuReduction
 
@@ -28,27 +27,34 @@ import proof.NuPreservation as PreservationProof
 
 progress :
   ∀ {Δ : TyCtx}{Σ : Store}{M : Term}{A : Ty} →
+  RuntimeOK M →
   Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
   ProgressProof.Progress {Δ = Δ} {Σ = Σ} M
 progress = ProgressProof.progress
 
 preservation :
-  ∀ {Δ Δ′ : TyCtx}{Σ Σ′ : Store}{Γ : Ctx}{M N : Term}{A : Ty} →
+  ∀ {Δ : TyCtx}{Σ : Store}{M N : Term}{A : Ty}
+    {χ : StoreChange} →
   StoreWf Δ Σ →
-  CtxWf Δ Γ →
-  Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
-  Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ N →
-  StoreWf Δ′ Σ′ × Δ ≤ Δ′ × StoreIncl Σ Σ′ ×
-  CtxWf Δ′ Γ × Δ′ ∣ Σ′ ∣ Γ ⊢ N ⦂ A
-preservation wfΣ hΓ M⊢ red
-    with PreservationProof.preservation wfΣ hΓ M⊢ red
-preservation wfΣ hΓ M⊢ red
-    | PreservationProof.preserve wfΣ′ Δ≤Δ′ incl hΓ′ N⊢ =
-  wfΣ′ , Δ≤Δ′ , incl , hΓ′ , N⊢
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —→[ χ ] N →
+  applyTyCtx χ Δ ∣ applyStore χ Σ ∣ [] ⊢ N ⦂ applyTy χ A
+preservation = PreservationProof.preservation
+
+multi-preservation :
+  ∀ {Δ : TyCtx}{Σ : Store}{M N : Term}{A : Ty}
+    {χs : StoreChanges} →
+  StoreWf Δ Σ →
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —↠[ χs ] N →
+  applyTyCtxs χs Δ ∣ applyStores χs Σ ∣ [] ⊢ N ⦂ applyTys χs A
+multi-preservation = PreservationProof.multi-preservation
 
 narrowing-determinedᵐ :
   ∀ {μ Δ Σ A B s t} →
-  StoreWf Δ Σ →
+  NarrowWidenProof.StoreDetWf Δ Σ →
   μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊒ B →
   μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ B →
   s ≡ t
@@ -57,7 +63,7 @@ narrowing-determinedᵐ =
 
 widening-determinedᵐ :
   ∀ {μ Δ Σ A B s t} →
-  StoreWf Δ Σ →
+  NarrowWidenProof.StoreDetWf Δ Σ →
   μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊑ B →
   μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊑ B →
   s ≡ t

--- a/GTSF/NuReduction.agda
+++ b/GTSF/NuReduction.agda
@@ -1,12 +1,16 @@
 module NuReduction where
 
+-- File Charter:
+--   * Small-step reduction for Nu GTSF terms.
+--   * Defines store-change steps, runtime bullet type-application redexes,
+--     context-shifting side conditions, and the multi-step closure.
+--   * Store changes are interpreted by `applyTyCtx`, `applyStore`, and related
+--     syntax actions used by preservation.
+
 open import Data.List using (List; []; _∷_)
-open import Data.Nat using (ℕ; _+_; _≤_; suc)
-open import Data.Product using (_×_; _,_; ∃-syntax)
-open import Data.Sum using (_⊎_)
-open import Relation.Nullary using (¬_)
+open import Data.Nat using (ℕ; _+_; zero; suc)
+open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
-open import Data.List.Membership.Propositional using (_∈_; _∉_)
 
 
 
@@ -16,48 +20,59 @@ open import NuTerms
 open import Primitives
 
 --------------------------------------------------------------------------------
--- Type-application reduction
+-- Store changes emitted by a step
 --------------------------------------------------------------------------------
 
-applyCoercions : Term → List Coercion → Term
-applyCoercions M [] = M
-applyCoercions M (c ∷ cs) = applyCoercions (M ⟨ c ⟩) cs
+data StoreChange : Set where
+  keep : StoreChange
+  bind : Ty → StoreChange
 
-data TypeApp : Set where
-  app : Term → TyVar → List Coercion → TypeApp
-  val : Term → List Coercion → TypeApp
+data Shiftable : StoreChange → Term → Set where
+  shift-keep : ∀ {M} → Shiftable keep M
+  shift-bind : ∀ {A M} → No• M → Shiftable (bind A) M
 
-infix 2 _—→ᵀ_
-data _—→ᵀ_ : TypeApp → TypeApp → Set where
+applyTyCtx : StoreChange → TyCtx → TyCtx
+applyTyCtx keep Δ = Δ
+applyTyCtx (bind A) Δ = suc Δ
 
-  β-Λᵀ : ∀ {V : Term}{α : TyVar}{cs : List Coercion}
-    → Value V
-    ---------------------------------------------
-    → app (Λ V) α cs —→ᵀ val (V [ α ]ᵀ) cs
+applyStore : StoreChange → Store → Store
+applyStore keep Σ = Σ
+applyStore (bind A) Σ = (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ
 
-  β-∀ᵀ : ∀ {V : Term}{c : Coercion}{α : TyVar}{cs : List Coercion}
-    → Value V
-    ----------------------------------------------------------------
-    → app (V ⟨ `∀ c ⟩) α cs —→ᵀ app V α ((c [ α ]ᶜ) ∷ cs)
+applyTy : StoreChange → Ty → Ty
+applyTy keep A = A
+applyTy (bind B) A = ⇑ᵗ A
 
-  β-genᵀ : ∀ {A : Ty}{V : Term}{c : Coercion}{α : TyVar}
-      {cs : List Coercion}
-    → Value V
-    ---------------------------------------------------------------
-    → app (V ⟨ gen A c ⟩) α cs —→ᵀ val V ((c [ α ]ᶜ) ∷ cs)
+applyTerm : StoreChange → Term → Term
+applyTerm keep M = M
+applyTerm (bind A) M = ⇑ᵗᵐ M
 
-infix 2 _—↠ᵀ_
-data _—↠ᵀ_ : TypeApp → TypeApp → Set where
+applyCoercion : StoreChange → Coercion → Coercion
+applyCoercion keep c = c
+applyCoercion (bind A) c = ⇑ᶜ c
 
-  doneᵀ : ∀ {S : TypeApp}
-      ------------
-    → S —↠ᵀ S
+applyCoercionUnderTyBinder : StoreChange → Coercion → Coercion
+applyCoercionUnderTyBinder keep c = c
+applyCoercionUnderTyBinder (bind A) c = renameᶜ (extᵗ suc) c
 
-  stepᵀ : ∀ {S T U : TypeApp}
-    → S —→ᵀ T
-    → T —↠ᵀ U
-      ------------
-    → S —↠ᵀ U
+StoreChanges : Set
+StoreChanges = List StoreChange
+
+applyTyCtxs : StoreChanges → TyCtx → TyCtx
+applyTyCtxs [] Δ = Δ
+applyTyCtxs (χ ∷ χs) Δ = applyTyCtxs χs (applyTyCtx χ Δ)
+
+applyStores : StoreChanges → Store → Store
+applyStores [] Σ = Σ
+applyStores (χ ∷ χs) Σ = applyStores χs (applyStore χ Σ)
+
+applyTys : StoreChanges → Ty → Ty
+applyTys [] A = A
+applyTys (χ ∷ χs) A = applyTys χs (applyTy χ A)
+
+applyTerms : StoreChanges → Term → Term
+applyTerms [] M = M
+applyTerms (χ ∷ χs) M = applyTerms χs (applyTerm χ M)
 
 --------------------------------------------------------------------------------
 -- One-step reduction
@@ -74,6 +89,21 @@ data _—→_ : Term → Term → Set where
     → Value V
     ---------------------
     → (ƛ N) · V —→ N [ V ]
+
+  β-Λ• : ∀ {V : Term}
+    → Value V
+    ---------------------
+    → (Λ V) • —→ V [ zero ]ᵀ
+
+  β-∀• : ∀ {V : Term}{c : Coercion}
+    → Value V
+    ---------------------------------------
+    → (V ⟨ `∀ c ⟩) • —→ (V •) ⟨ c [ zero ]ᶜ ⟩
+
+  β-gen• : ∀ {A : Ty}{V : Term}{c : Coercion}
+    → Value V
+    -------------------------------------
+    → (V ⟨ gen A c ⟩) • —→ V ⟨ c [ zero ]ᶜ ⟩
 
   β-id : ∀ {V}{A}
     → Value V
@@ -117,6 +147,8 @@ data _—→_ : Term → Term → Set where
     Value V →
     (V · blame) —→ blame
 
+  blame-• : blame • —→ blame
+
   blame-⟨⟩ : ∀ {c : Coercion} →
     (blame ⟨ c ⟩) —→ blame
 
@@ -129,58 +161,64 @@ data _—→_ : Term → Term → Set where
 
 
 --------------------------------------------------------------------------------
--- Store-threaded one-step reduction
+-- Store-change one-step reduction
 --------------------------------------------------------------------------------
 
-infix 2 _∣_∣_—→_∣_∣_
-data _∣_∣_—→_∣_∣_ :
-    TyCtx → Store → Term → TyCtx → Store → Term → Set where
+infix 2 _—→[_]_
+data _—→[_]_ : Term → StoreChange → Term → Set where
 
-  pure-step : ∀ {Δ : TyCtx} {Σ : Store} {M M′ : Term}
+  pure-step : ∀ {M M′ : Term}
     → M —→ M′
     -----------------
-    → Δ ∣ Σ ∣ M —→ Δ ∣ Σ ∣ M′
+    → M —→[ keep ] M′
 
-  -- Allow non-deterministic choice of α here so that in the proof of the
-  -- Gradual Guarantee, we can choose a matching α in the simulating program.
-  ν-step : ∀ {Δ : TyCtx} {Σ : Store} {A : Ty} {L V : Term}
-      {c : Coercion} {α : TyVar} {cs : List Coercion}
-   → Δ ≤ α
-   → α ∉ domˢ Σ
-   → app L α ((c [ α ]ᶜ) ∷ []) —↠ᵀ val V cs
+  ν-step : ∀ {A : Ty} {V : Term} {c : Coercion}
+   → Value V
+   → No• V
     -------------------------------------
-   → Δ ∣ Σ ∣ ν A L c —→ suc α ∣ (α , A) ∷ Σ
-       ∣ applyCoercions V cs
+   → ν A V c —→[ bind A ] ((⇑ᵗᵐ V) •) ⟨ c ⟩
 
-  ξ-·₁ : ∀ {Δ Δ′ : TyCtx} {Σ Σ′ : Store} {L M L′ : Term} →
-    Δ ∣ Σ ∣ L —→ Δ′ ∣ Σ′ ∣ L′ →
-    Δ ∣ Σ ∣ (L · M) —→ Δ′ ∣ Σ′ ∣ (L′ · M)
+  ξ-·₁ : ∀ {χ : StoreChange} {L M L′ : Term} →
+    L —→[ χ ] L′ →
+    Shiftable χ M →
+    (L · M) —→[ χ ] (L′ · applyTerm χ M)
 
-  ξ-·₂ : ∀ {Δ Δ′ : TyCtx} {Σ Σ′ : Store} {V M M′ : Term} →
+  ξ-·₂ : ∀ {χ : StoreChange} {V M M′ : Term} →
     Value V →
-    Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ M′ →
-    Δ ∣ Σ ∣ (V · M) —→ Δ′ ∣ Σ′ ∣ (V · M′)
+    Shiftable χ V →
+    M —→[ χ ] M′ →
+    (V · M) —→[ χ ] (applyTerm χ V · M′)
 
-  ξ-⟨⟩ : ∀ {Δ Δ′ : TyCtx} {Σ Σ′ : Store}
-      {c : Coercion} {M M′ : Term} →
-    Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ M′ →
-    Δ ∣ Σ ∣ (M ⟨ c ⟩) —→ Δ′ ∣ Σ′ ∣ (M′ ⟨ c ⟩)
+  ξ-⟨⟩ : ∀ {χ : StoreChange} {c : Coercion} {M M′ : Term} →
+    M —→[ χ ] M′ →
+    (M ⟨ c ⟩) —→[ χ ] (M′ ⟨ applyCoercion χ c ⟩)
 
-  ξ-ν : ∀ {Δ Δ′ : TyCtx} {Σ Σ′ : Store}
-      {A : Ty} {L L′ : Term} {c : Coercion} →
-    Δ ∣ Σ ∣ L —→ Δ′ ∣ Σ′ ∣ L′ →
-    Δ ∣ Σ ∣ ν A L c —→ Δ′ ∣ Σ′ ∣ ν A L′ c
+  ξ-ν : ∀ {χ : StoreChange} {A : Ty} {L L′ : Term}
+      {c : Coercion} →
+    L —→[ χ ] L′ →
+    ν A L c —→[ χ ] ν (applyTy χ A) L′
+      (applyCoercionUnderTyBinder χ c)
 
-  blame-ν : ∀ {Δ : TyCtx} {Σ : Store} {A : Ty} {c : Coercion} →
-    Δ ∣ Σ ∣ ν A blame c —→ Δ ∣ Σ ∣ blame
+  blame-ν : ∀ {A : Ty} {c : Coercion} →
+    ν A blame c —→[ keep ] blame
 
-  ξ-⊕₁ : ∀ {Δ Δ′ : TyCtx} {Σ Σ′ : Store}
-      {L M L′ : Term} {op : Prim} →
-    Δ ∣ Σ ∣ L —→ Δ′ ∣ Σ′ ∣ L′ →
-    Δ ∣ Σ ∣ (L ⊕[ op ] M) —→ Δ′ ∣ Σ′ ∣ (L′ ⊕[ op ] M)
+  ξ-⊕₁ : ∀ {χ : StoreChange} {L M L′ : Term} {op : Prim} →
+    L —→[ χ ] L′ →
+    Shiftable χ M →
+    (L ⊕[ op ] M) —→[ χ ] (L′ ⊕[ op ] applyTerm χ M)
 
-  ξ-⊕₂ : ∀ {Δ Δ′ : TyCtx} {Σ Σ′ : Store}
-      {L M M′ : Term} {op : Prim} →
+  ξ-⊕₂ : ∀ {χ : StoreChange} {L M M′ : Term} {op : Prim} →
     Value L →
-    Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ M′ →
-    Δ ∣ Σ ∣ (L ⊕[ op ] M) —→ Δ′ ∣ Σ′ ∣ (L ⊕[ op ] M′)
+    Shiftable χ L →
+    M —→[ χ ] M′ →
+    (L ⊕[ op ] M) —→[ χ ] (applyTerm χ L ⊕[ op ] M′)
+
+infix 2 _—↠[_]_
+data _—↠[_]_ : Term → StoreChanges → Term → Set where
+  ↠-refl : ∀ {M : Term} →
+    M —↠[ [] ] M
+
+  ↠-step : ∀ {M N P : Term}{χ : StoreChange}{χs : StoreChanges} →
+    M —→[ χ ] N →
+    N —↠[ χs ] P →
+    M —↠[ χ ∷ χs ] P

--- a/GTSF/NuStore.agda
+++ b/GTSF/NuStore.agda
@@ -26,7 +26,6 @@ open import Store public
 record StoreWf (Δ : TyCtx) (Σ : Store) : Set₁ where
   field
     at : StoreWfAt Δ Σ
-    wfOlder : ∀ {α A} → (α , A) ∈ Σ → WfTy α A
     unique : ∀ {α A B} → (α , A) ∈ Σ → (α , B) ∈ Σ → A ≡ B
 
 open StoreWf public

--- a/GTSF/NuTerms.agda
+++ b/GTSF/NuTerms.agda
@@ -17,6 +17,7 @@ open import Primitives
 infix  5 ƛ_
 infix  5 Λ_
 infixl 7 _·_
+infixl 7 _•
 infixl 7 _⟨_⟩
 infixl 6 _⊕[_]_
 infix  9 `_
@@ -26,6 +27,7 @@ data Term : Set where
   ƛ_      : Term → Term
   _·_     : Term → Term → Term
   Λ_      : Term → Term
+  _•      : Term → Term
   ν       : Ty → Term → Coercion → Term
   $       : Const → Term
   _⊕[_]_  : Term → Prim → Term → Term
@@ -43,6 +45,36 @@ data Value : Term → Set where
   _⟨_⟩ : {V : Term}{c : Coercion} → Value V → Inert c → Value (V ⟨ c ⟩)
 
 ------------------------------------------------------------------------
+-- Runtime-bullet invariants
+------------------------------------------------------------------------
+
+data No• : Term → Set where
+  no•-` : ∀ {x} → No• (` x)
+  no•-ƛ : ∀ {M} → No• M → No• (ƛ M)
+  no•-· : ∀ {L M} → No• L → No• M → No• (L · M)
+  no•-Λ : ∀ {M} → No• M → No• (Λ M)
+  no•-ν : ∀ {A L c} → No• L → No• (ν A L c)
+  no•-$ : ∀ {κ} → No• ($ κ)
+  no•-⊕ : ∀ {L op M} → No• L → No• M → No• (L ⊕[ op ] M)
+  no•-⟨⟩ : ∀ {M c} → No• M → No• (M ⟨ c ⟩)
+  no•-blame : No• blame
+
+data One• : Term → Set where
+  one•-here : ∀ {M} → No• M → One• (M •)
+  one•-ƛ : ∀ {M} → One• M → One• (ƛ M)
+  one•-·₁ : ∀ {L M} → One• L → No• M → One• (L · M)
+  one•-·₂ : ∀ {L M} → No• L → One• M → One• (L · M)
+  one•-Λ : ∀ {M} → One• M → One• (Λ M)
+  one•-ν : ∀ {A L c} → One• L → One• (ν A L c)
+  one•-⊕₁ : ∀ {L op M} → One• L → No• M → One• (L ⊕[ op ] M)
+  one•-⊕₂ : ∀ {L op M} → No• L → One• M → One• (L ⊕[ op ] M)
+  one•-⟨⟩ : ∀ {M c} → One• M → One• (M ⟨ c ⟩)
+
+data AtMostOne• : Term → Set where
+  zero• : ∀ {M} → No• M → AtMostOne• M
+  one• : ∀ {M} → One• M → AtMostOne• M
+
+------------------------------------------------------------------------
 -- Type-variable substitution
 ------------------------------------------------------------------------
 
@@ -51,6 +83,7 @@ renameᵗᵐ ρ (` x) = ` x
 renameᵗᵐ ρ (ƛ M) = ƛ renameᵗᵐ ρ M
 renameᵗᵐ ρ (L · M) = renameᵗᵐ ρ L · renameᵗᵐ ρ M
 renameᵗᵐ ρ (Λ M) = Λ (renameᵗᵐ (extᵗ ρ) M)
+renameᵗᵐ ρ (M •) = renameᵗᵐ ρ M •
 renameᵗᵐ ρ (ν A L c) =
   ν (renameᵗ ρ A) (renameᵗᵐ ρ L) (renameᶜ (extᵗ ρ) c)
 renameᵗᵐ ρ ($ κ) = $ κ
@@ -60,6 +93,17 @@ renameᵗᵐ ρ blame = blame
 
 ⇑ᵗᵐ : Term → Term
 ⇑ᵗᵐ = renameᵗᵐ suc
+
+data RuntimeOK : Term → Set where
+  ok-no : ∀ {M} → No• M → RuntimeOK M
+  ok-• : ∀ {V} → Value V → No• V → RuntimeOK ((⇑ᵗᵐ V) •)
+  ok-·₁ : ∀ {L M} → RuntimeOK L → No• M → RuntimeOK (L · M)
+  ok-·₂ : ∀ {V M} → Value V → No• V → RuntimeOK M → RuntimeOK (V · M)
+  ok-ν : ∀ {A L c} → RuntimeOK L → RuntimeOK (ν A L c)
+  ok-⊕₁ : ∀ {L op M} → RuntimeOK L → No• M → RuntimeOK (L ⊕[ op ] M)
+  ok-⊕₂ : ∀ {L op M} → Value L → No• L → RuntimeOK M
+    → RuntimeOK (L ⊕[ op ] M)
+  ok-⟨⟩ : ∀ {M c} → RuntimeOK M → RuntimeOK (M ⟨ c ⟩)
 
 infixl 8 _[_]ᵀ
 _[_]ᵀ : Term → TyVar → Term
@@ -84,6 +128,7 @@ renameˣᵐ ρ (` x) = ` (ρ x)
 renameˣᵐ ρ (ƛ M) = ƛ renameˣᵐ (extʳ ρ) M
 renameˣᵐ ρ (L · M) = renameˣᵐ ρ L · renameˣᵐ ρ M
 renameˣᵐ ρ (Λ M) = Λ (renameˣᵐ ρ M)
+renameˣᵐ ρ (M •) = renameˣᵐ ρ M •
 renameˣᵐ ρ (ν A L c) = ν A (renameˣᵐ ρ L) c
 renameˣᵐ ρ ($ κ) = $ κ
 renameˣᵐ ρ (L ⊕[ op ] M) = renameˣᵐ ρ L ⊕[ op ] renameˣᵐ ρ M
@@ -102,6 +147,7 @@ substˣᵐ σ (` x) = σ x
 substˣᵐ σ (ƛ M) = ƛ substˣᵐ (extˢˣ σ) M
 substˣᵐ σ (L · M) = substˣᵐ σ L · substˣᵐ σ M
 substˣᵐ σ (Λ M) = Λ (substˣᵐ (↑ᵗᵐ σ) M)
+substˣᵐ σ (M •) = substˣᵐ σ M •
 substˣᵐ σ (ν A L c) = ν A (substˣᵐ σ L) c
 substˣᵐ σ ($ κ) = $ κ
 substˣᵐ σ (L ⊕[ op ] M) = substˣᵐ σ L ⊕[ op ] substˣᵐ σ M
@@ -146,6 +192,16 @@ data _∣_∣_⊢_⦂_ (Δ : TyCtx) (Σ : Store) (Γ : Ctx) : Term → Ty → Se
      → suc Δ ∣ ⟰ᵗ Σ ∣ ⤊ᵗ Γ ⊢ M ⦂ A
       ----------------------------
      → Δ ∣ Σ ∣ Γ ⊢ (Λ M) ⦂ (`∀ A)
+
+  ⊢• : ∀ {Δ₀ Σ₀ V A C}
+     → Δ ≡ suc Δ₀
+     → Σ ≡ (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ₀
+     → WfTy (suc Δ₀) C
+     → Value V
+     → No• V
+     → Δ₀ ∣ Σ₀ ∣ Γ ⊢ V ⦂ `∀ C
+      ----------------------------------------
+     → Δ ∣ Σ ∣ Γ ⊢ (⇑ᵗᵐ V) • ⦂ C
 
   ⊢ν : ∀ {L A B C c μ}
      → WfTy Δ A

--- a/GTSF/TypeCheck.agda
+++ b/GTSF/TypeCheck.agda
@@ -127,6 +127,7 @@ value? (L · M) = nothing
 value? (Λ M) with value? M
 ... | just vM = just (Λ vM)
 ... | nothing = nothing
+value? (M •) = nothing
 value? (ν A L c) = nothing
 value? ($ κ) = just ($ κ)
 value? (L ⊕[ op ] M) = nothing
@@ -134,6 +135,30 @@ value? (M ⟨ c ⟩) with value? M | inert? c
 ... | just vM | just ic = just (vM ⟨ ic ⟩)
 ... | _ | _ = nothing
 value? blame = nothing
+
+no•? : (M : Term) → Maybe (No• M)
+no•? (` x) = just no•-`
+no•? (ƛ M) with no•? M
+... | just noM = just (no•-ƛ noM)
+... | nothing = nothing
+no•? (L · M) with no•? L | no•? M
+... | just noL | just noM = just (no•-· noL noM)
+... | _ | _ = nothing
+no•? (Λ M) with no•? M
+... | just noM = just (no•-Λ noM)
+... | nothing = nothing
+no•? (M •) = nothing
+no•? (ν A L c) with no•? L
+... | just noL = just (no•-ν noL)
+... | nothing = nothing
+no•? ($ κ) = just no•-$
+no•? (L ⊕[ op ] M) with no•? L | no•? M
+... | just noL | just noM = just (no•-⊕ noL noM)
+... | _ | _ = nothing
+no•? (M ⟨ c ⟩) with no•? M
+... | just noM = just (no•-⟨⟩ noM)
+... | nothing = nothing
+no•? blame = just no•-blame
 
 ------------------------------------------------------------------------
 -- Inverting `⇑ᵗ`
@@ -326,6 +351,8 @@ mutual
   ... | just vM with type-check (suc Δ) (⟰ᵗ Σ) (⤊ᵗ Γ) M
   ...   | just (A , M⊢) = just ((`∀ A) , ⊢Λ vM M⊢)
   ...   | nothing = nothing
+
+  type-check Δ Σ Γ (M •) = nothing
 
   type-check Δ Σ Γ (ν A L c) with wfTy? Δ A
   ... | nothing = nothing

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -161,17 +161,6 @@ StoreWf⇒det wfΣ =
     ; unique = Store.unique wfΣ
     }
 
-nuStoreWf⇒det :
-  ∀ {Δ Σ} →
-  NuStore.StoreWf Δ Σ →
-  StoreDetWf Δ Σ
-nuStoreWf⇒det wfΣ =
-  record
-    { at = NuStore.at wfΣ
-    ; wfOlder = NuStore.wfOlder wfΣ
-    ; unique = NuStore.unique wfΣ
-    }
-
 ∈-⟰ᵗ-inv :
   ∀ {Σ α B} →
   (suc α , B) ∈ ⟰ᵗ Σ →
@@ -2749,18 +2738,18 @@ store-widening-determinedᵐ wfΣ =
 
 narrowing-determinedᵐ :
   ∀ {μ Δ Σ A B s t} →
-  NuStore.StoreWf Δ Σ →
+  StoreDetWf Δ Σ →
   μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊒ B →
   μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ B →
   s ≡ t
 narrowing-determinedᵐ wfΣ =
-  narrowing-determinedᵐ-det (nuStoreWf⇒det wfΣ)
+  narrowing-determinedᵐ-det wfΣ
 
 widening-determinedᵐ :
   ∀ {μ Δ Σ A B s t} →
-  NuStore.StoreWf Δ Σ →
+  StoreDetWf Δ Σ →
   μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊑ B →
   μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊑ B →
   s ≡ t
 widening-determinedᵐ wfΣ =
-  widening-determinedᵐ-det (nuStoreWf⇒det wfΣ)
+  widening-determinedᵐ-det wfΣ

--- a/GTSF/proof/NuPreservation.agda
+++ b/GTSF/proof/NuPreservation.agda
@@ -1,20 +1,21 @@
 module proof.NuPreservation where
 
 -- File Charter:
---   * Type preservation for Nu GTSF one-step reduction.
---   * Keeps store growth, fresh type-variable allocation, and redex typing
---     obligations local to preservation.
---   * Uses the type/coercion/term metatheory factored into sibling proof files.
+--   * Type preservation for the Nu GTSF store-change reduction.
+--   * Proves one-step and multi-step preservation for closed `RuntimeOK`
+--     terms, including the active runtime bullet introduced by `ν-step`.
+--   * Also proves preservation of the runtime-bullet invariant and Nu store
+--     well-formedness across emitted store changes.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
-open import Data.List using (List; []; _∷_)
-open import Data.List.Membership.Propositional using (_∉_)
-open import Data.Nat using (suc; _<_; _≤_; _⊔_; zero; z<s; s≤s)
-open import Data.Nat.Properties
-  using (≤-refl; n≤1+n; <-≤-trans; ≤-trans; m≤m⊔n; m≤n⊔m)
-open import Data.Product using (_×_; _,_)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (suc; zero; z<s; s≤s; _≤_)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product as Product using (_,_)
 open import Relation.Binary.PropositionalEquality
-  using (cong; subst; sym; trans)
+  using (cong; cong₂; subst; sym; trans)
 
 open import Types
 open import Ctx
@@ -29,320 +30,918 @@ open import proof.CoercionProperties
 open import proof.NuTermProperties
 
 ------------------------------------------------------------------------
--- Preservation result for store-threaded steps
+-- Small renaming equalities
 ------------------------------------------------------------------------
 
-record PreservationResult
-    (Δ : TyCtx) (Σ : Store) (Γ : Ctx) (Δ′ : TyCtx)
-    (Σ′ : Store) (N : Term) (A : Ty) : Set₁ where
-  constructor preserve
-  field
-    storeWf : StoreWf Δ′ Σ′
-    ctx≤ : Δ ≤ Δ′
-    storeIncl : StoreIncl Σ Σ′
-    ctxWf : CtxWf Δ′ Γ
-    typed : Δ′ ∣ Σ′ ∣ Γ ⊢ N ⦂ A
+open0-ext-suc-cancel :
+  ∀ A →
+  renameᵗ (singleRenameᵗ zero) (renameᵗ (extᵗ suc) A) ≡ A
+open0-ext-suc-cancel A =
+  trans (renameᵗ-compose (extᵗ suc) (singleRenameᵗ zero) A)
+        (trans (rename-cong env-eq A) (renameᵗ-id A))
+  where
+    env-eq :
+      ∀ X →
+      singleRenameᵗ zero (extᵗ suc X) ≡ X
+    env-eq zero = refl
+    env-eq (suc X) = refl
 
-open PreservationResult public
+renameᵗ-left-inverse :
+  ∀ {ρ ψ} →
+  RenameLeftInverse ρ ψ →
+  ∀ A →
+  renameᵗ ψ (renameᵗ ρ A) ≡ A
+renameᵗ-left-inverse {ρ = ρ} {ψ = ψ} inv A =
+  trans (renameᵗ-compose ρ ψ A)
+        (trans (rename-cong inv A) (renameᵗ-id A))
+
+open0-ext-suc-inv :
+  RenameLeftInverse (extᵗ suc) (singleRenameᵗ zero)
+open0-ext-suc-inv zero = refl
+open0-ext-suc-inv (suc X) = refl
+
+renameᶜ-left-inverse :
+  ∀ {ρ ψ} →
+  RenameLeftInverse ρ ψ →
+  ∀ c →
+  renameᶜ ψ (renameᶜ ρ c) ≡ c
+renameᶜ-left-inverse inv (id A) =
+  cong id (renameᵗ-left-inverse inv A)
+renameᶜ-left-inverse inv (p ︔ q) =
+  cong₂ _︔_ (renameᶜ-left-inverse inv p)
+             (renameᶜ-left-inverse inv q)
+renameᶜ-left-inverse inv (A !) =
+  cong _! (renameᵗ-left-inverse inv A)
+renameᶜ-left-inverse inv (A ？) =
+  cong _？ (renameᵗ-left-inverse inv A)
+renameᶜ-left-inverse inv (unseal α A) =
+  cong₂ unseal (inv α) (renameᵗ-left-inverse inv A)
+renameᶜ-left-inverse inv (seal A α) =
+  cong₂ seal (renameᵗ-left-inverse inv A) (inv α)
+renameᶜ-left-inverse inv (p ↦ q) =
+  cong₂ _↦_ (renameᶜ-left-inverse inv p)
+             (renameᶜ-left-inverse inv q)
+renameᶜ-left-inverse inv (`∀ p) =
+  cong `∀ (renameᶜ-left-inverse (RenameLeftInverse-ext inv) p)
+renameᶜ-left-inverse inv (gen A p) =
+  cong₂ gen (renameᵗ-left-inverse inv A)
+             (renameᶜ-left-inverse (RenameLeftInverse-ext inv) p)
+renameᶜ-left-inverse inv (inst B p) =
+  cong₂ inst (renameᵗ-left-inverse inv B)
+              (renameᶜ-left-inverse (RenameLeftInverse-ext inv) p)
+
+renameᵗᵐ-left-inverse :
+  ∀ {ρ ψ} →
+  RenameLeftInverse ρ ψ →
+  ∀ M →
+  renameᵗᵐ ψ (renameᵗᵐ ρ M) ≡ M
+renameᵗᵐ-left-inverse inv (` x) = refl
+renameᵗᵐ-left-inverse inv (ƛ M) =
+  cong ƛ_ (renameᵗᵐ-left-inverse inv M)
+renameᵗᵐ-left-inverse inv (L · M) =
+  cong₂ _·_ (renameᵗᵐ-left-inverse inv L)
+             (renameᵗᵐ-left-inverse inv M)
+renameᵗᵐ-left-inverse inv (Λ M) =
+  cong Λ_ (renameᵗᵐ-left-inverse (RenameLeftInverse-ext inv) M)
+renameᵗᵐ-left-inverse inv (M •) =
+  cong _• (renameᵗᵐ-left-inverse inv M)
+renameᵗᵐ-left-inverse inv (ν A L c) =
+  trans
+    (cong₂ (λ A′ L′ →
+       ν A′ L′ (renameᶜ _ (renameᶜ _ c)))
+      (renameᵗ-left-inverse inv A)
+      (renameᵗᵐ-left-inverse inv L))
+    (cong (ν A L) (renameᶜ-left-inverse (RenameLeftInverse-ext inv) c))
+renameᵗᵐ-left-inverse inv ($ κ) = refl
+renameᵗᵐ-left-inverse inv (L ⊕[ op ] M) =
+  cong₂ (λ L′ M′ → L′ ⊕[ op ] M′)
+        (renameᵗᵐ-left-inverse inv L)
+        (renameᵗᵐ-left-inverse inv M)
+renameᵗᵐ-left-inverse inv (M ⟨ c ⟩) =
+  cong₂ _⟨_⟩ (renameᵗᵐ-left-inverse inv M)
+              (renameᶜ-left-inverse inv c)
+renameᵗᵐ-left-inverse inv blame = refl
+
+open0-ext-suc-cancelᵐ :
+  ∀ M →
+  renameᵗᵐ (singleRenameᵗ zero) (renameᵗᵐ (extᵗ suc) M) ≡ M
+open0-ext-suc-cancelᵐ = renameᵗᵐ-left-inverse open0-ext-suc-inv
+
+open0-ext-suc-cancelᶜ :
+  ∀ c →
+  renameᶜ (singleRenameᵗ zero) (renameᶜ (extᵗ suc) c) ≡ c
+open0-ext-suc-cancelᶜ = renameᶜ-left-inverse open0-ext-suc-inv
 
 ------------------------------------------------------------------------
--- Typing the type-application machine
+-- Typing under an emitted store change
 ------------------------------------------------------------------------
 
-data CastStack (Δ : TyCtx) (Σ : Store) :
-    List Coercion → Ty → Ty → Set₁ where
+closedCtxWf : ∀ {Δ} → CtxWf Δ []
+closedCtxWf ()
 
-  stack[] : ∀ {A} →
-      --------------------
-      CastStack Δ Σ [] A A
-
-  stack∷ : ∀ {μ c cs A B C}
-    → μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B
-    → CastStack Δ Σ cs B C
-      -------------------------------
-    → CastStack Δ Σ (c ∷ cs) A C
-
-applyCoercions-typing :
-  ∀ {Δ Σ Γ M cs A B} →
-  CastStack Δ Σ cs A B →
-  Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
-  Δ ∣ Σ ∣ Γ ⊢ applyCoercions M cs ⦂ B
-applyCoercions-typing stack[] M⊢ = M⊢
-applyCoercions-typing (stack∷ c⊢ cs⊢) M⊢ =
-  applyCoercions-typing cs⊢ (⊢⟨⟩ c⊢ M⊢)
-
-data TypeAppTyping
-    (Δ₀ Δ′ : TyCtx) (Σ : Store) (Γ : Ctx) (α : TyVar)
-    (Aν : Ty) :
-    TypeApp → Ty → Set₁ where
-
-  app⊢ : ∀ {L C cs B}
-    → Δ₀ ∣ Σ ∣ Γ ⊢ L ⦂ `∀ C
-    → CastStack Δ′ ((α , Aν) ∷ Σ) cs (C [ α ]ᴿ) B
-      ------------------------------------
-    → TypeAppTyping Δ₀ Δ′ Σ Γ α Aν (app L α cs) B
-
-  val⊢ : ∀ {V cs A B}
-    → Δ′ ∣ (α , Aν) ∷ Σ ∣ Γ ⊢ V ⦂ A
-    → CastStack Δ′ ((α , Aν) ∷ Σ) cs A B
-      ------------------------------------
-    → TypeAppTyping Δ₀ Δ′ Σ Γ α Aν (val V cs) B
-
-type-app-preservation-step :
-  ∀ {Δ Δ′ Σ Γ α A S T B} →
+applyTerm-typing :
+  ∀ {χ : StoreChange}{Δ Σ M A} →
   StoreWfAt Δ Σ →
-  CtxWf Δ Γ →
-  Δ ≤ Δ′ →
-  Δ ≤ α →
-  α < Δ′ →
-  α ∉ domˢ Σ →
-  StoreWf Δ′ ((α , A) ∷ Σ) →
-  CtxWf Δ′ Γ →
-  TypeAppTyping Δ Δ′ Σ Γ α A S B →
-  S —→ᵀ T →
-  TypeAppTyping Δ Δ′ Σ Γ α A T B
-type-app-preservation-step wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′
-    (app⊢ (⊢Λ vV V⊢) stack⊢)
-    (β-Λᵀ vV′) =
-  val⊢
-    (typing-open-freshᵀ wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ V⊢)
-    stack⊢
-type-app-preservation-step wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′
-    (app⊢ (⊢⟨⟩ (cast-all c⊢) V⊢) stack⊢)
-    (β-∀ᵀ vV)
-    with coercion-open-store-fresh wfΣ Δ≤Δ′ Δ≤α α<Δ′ c⊢
-... | μ′ , cα⊢ =
-  app⊢ V⊢ (stack∷ cα⊢ stack⊢)
-type-app-preservation-step wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′
-    (app⊢ (⊢⟨⟩ (cast-gen hA occ c⊢) V⊢) stack⊢)
-    (β-genᵀ vV)
-    with coercion-open-shift-fresh wfΣ Δ≤Δ′ Δ≤α α<Δ′ c⊢
-... | μ′ , cα⊢ =
-  val⊢
-    (term-weaken Δ≤Δ′ StoreIncl-drop V⊢)
-    (stack∷ cα⊢ stack⊢)
+  No• M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  applyTyCtx χ Δ ∣ applyStore χ Σ ∣ [] ⊢ applyTerm χ M ⦂ applyTy χ A
+applyTerm-typing {χ = keep} wfΣ noM M⊢ = M⊢
+applyTerm-typing {χ = bind Aν} {Δ = Δ} wfΣ noM M⊢ =
+  term-weaken ≤-refl StoreIncl-drop
+    (renameᵗᵐ-preserves-No• suc noM)
+    (typing-renameᵀ
+      {ρ = suc} {ψ = predᵗ}
+      TyRenameWf-suc
+      RenameLeftInverse-suc
+      noM
+      M⊢)
 
-type-app-preservation-closure :
-  ∀ {Δ Δ′ Σ Γ α A S T B} →
-  StoreWfAt Δ Σ →
-  CtxWf Δ Γ →
-  Δ ≤ Δ′ →
-  Δ ≤ α →
-  α < Δ′ →
-  α ∉ domˢ Σ →
-  StoreWf Δ′ ((α , A) ∷ Σ) →
-  CtxWf Δ′ Γ →
-  TypeAppTyping Δ Δ′ Σ Γ α A S B →
-  S —↠ᵀ T →
-  TypeAppTyping Δ Δ′ Σ Γ α A T B
-type-app-preservation-closure
-    wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′ S⊢ doneᵀ = S⊢
-type-app-preservation-closure
-    wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′ S⊢ (stepᵀ S→T T↠U) =
-  type-app-preservation-closure
-    wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′
-    (type-app-preservation-step
-      wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′ S⊢ S→T)
-    T↠U
+⊢·-applyTy :
+  ∀ χ {Δ Σ L M A B} →
+  Δ ∣ Σ ∣ [] ⊢ L ⦂ applyTy χ (A ⇒ B) →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ applyTy χ A →
+  Δ ∣ Σ ∣ [] ⊢ L · M ⦂ applyTy χ B
+⊢·-applyTy keep hL hM = ⊢· hL hM
+⊢·-applyTy (bind Aχ) hL hM = ⊢· hL hM
 
-type-app-initial :
-  ∀ {Δ Δ′ Σ Γ A B C L c α μ} →
+⊢⊕-applyTy :
+  ∀ χ {Δ Σ L M} →
+  Δ ∣ Σ ∣ [] ⊢ L ⦂ applyTy χ (‵ `ℕ) →
+  (op : Prim) →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ applyTy χ (‵ `ℕ) →
+  Δ ∣ Σ ∣ [] ⊢ L ⊕[ op ] M ⦂ applyTy χ (‵ `ℕ)
+⊢⊕-applyTy keep hL op hM = ⊢⊕ hL op hM
+⊢⊕-applyTy (bind Aχ) hL op hM = ⊢⊕ hL op hM
+
+applyTyUnderTyBinder : StoreChange → Ty → Ty
+applyTyUnderTyBinder keep A = A
+applyTyUnderTyBinder (bind B) A = renameᵗ (extᵗ suc) A
+
+⊢ν-applyTy :
+  ∀ χ {Δ Σ A B C L c μ} →
+  WfTy (applyTyCtx χ Δ) (applyTy χ A) →
+  applyTyCtx χ Δ ∣ applyStore χ Σ ∣ [] ⊢ L ⦂ applyTy χ (`∀ C) →
+  μ ∣ suc (applyTyCtx χ Δ)
+    ∣ (zero , ⇑ᵗ (applyTy χ A)) ∷ ⟰ᵗ (applyStore χ Σ)
+    ⊢ c ∶ applyTyUnderTyBinder χ C =⇒ ⇑ᵗ (applyTy χ B) →
+  applyTyCtx χ Δ ∣ applyStore χ Σ ∣ []
+    ⊢ ν (applyTy χ A) L c ⦂ applyTy χ B
+⊢ν-applyTy keep hA hL c⊢ = ⊢ν hA hL c⊢
+⊢ν-applyTy (bind Aχ) hA hL c⊢ = ⊢ν hA hL c⊢
+
+applyCoercion-typing :
+  ∀ {χ : StoreChange}{μ Δ Σ c A B} →
   StoreWfAt Δ Σ →
-  Δ ≤ Δ′ →
-  Δ ≤ α →
-  α < Δ′ →
-  α ∉ domˢ Σ →
-  StoreWf Δ′ ((α , A) ∷ Σ) →
-  CtxWf Δ′ Γ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  Product.Σ ModeEnv
+    (λ ν →
+      ν ∣ applyTyCtx χ Δ ∣ applyStore χ Σ
+        ⊢ applyCoercion χ c ∶ applyTy χ A =⇒ applyTy χ B)
+applyCoercion-typing {χ = keep} {μ = μ} wfΣ c⊢ = μ , c⊢
+applyCoercion-typing {χ = bind Aν} {μ = μ} wfΣ c⊢ =
+  (λ Y → μ (predᵗ Y)) ,
+    coercion-weakenᵐ ≤-refl StoreIncl-drop
+      (coercion-renameᵗᵐ
+        TyRenameWf-suc
+        (modeRename-left-inverse
+          {ρ = suc} {ψ = predᵗ}
+          RenameLeftInverse-suc)
+        c⊢)
+
+applyCoercionUnderTyBinder-typing :
+  ∀ {χ : StoreChange}{μ Δ Σ c B C Aν} →
+  StoreWfAt Δ Σ →
+  WfTy Δ Aν →
+  μ ∣ suc Δ ∣ (zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ ⊢ c ∶ C =⇒ ⇑ᵗ B →
+  Product.Σ ModeEnv
+    (λ ν →
+      ν ∣ suc (applyTyCtx χ Δ)
+        ∣ (zero , ⇑ᵗ (applyTy χ Aν)) ∷ ⟰ᵗ (applyStore χ Σ)
+        ⊢ applyCoercionUnderTyBinder χ c
+        ∶ applyTyUnderTyBinder χ C =⇒ ⇑ᵗ (applyTy χ B))
+applyCoercionUnderTyBinder-typing {χ = keep} {μ = μ} wfΣ hA c⊢ =
+  μ , c⊢
+applyCoercionUnderTyBinder-typing {χ = bind Aχ} {μ = μ}
+    {Δ = Δ} {Σ = Σ}
+    {c = c} {B = Bout} {C = C} {Aν = Aν} wfΣ hA c⊢ =
+  νmode ,
+    subst
+      (λ T →
+        νmode ∣ suc (suc Δ)
+          ∣ (zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ ((zero , ⇑ᵗ Aχ) ∷ ⟰ᵗ Σ)
+          ⊢ renameᶜ (extᵗ suc) c ∶ renameᵗ (extᵗ suc) C =⇒ T)
+      (renameᵗ-ext-suc-comm suc Bout)
+      (coercion-weakenᵐ
+        ≤-refl
+        incl
+        renamed-store)
+  where
+    νmode : ModeEnv
+    νmode Y = μ (extᵗ predᵗ Y)
+
+    renamed-store :
+      νmode ∣ suc (suc Δ)
+        ∣ (zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ (⟰ᵗ Σ)
+        ⊢ renameᶜ (extᵗ suc) c
+        ∶ renameᵗ (extᵗ suc) C =⇒ renameᵗ (extᵗ suc) (⇑ᵗ Bout)
+    renamed-store =
+      subst
+        (λ Σ′ →
+          νmode ∣ suc (suc Δ) ∣ Σ′
+            ⊢ renameᶜ (extᵗ suc) c
+            ∶ renameᵗ (extᵗ suc) C =⇒ renameᵗ (extᵗ suc) (⇑ᵗ Bout))
+        (renameStoreᵗ-ext-suc-cons-comm suc Σ Aν)
+        (coercion-renameᵗᵐ
+          (TyRenameWf-ext TyRenameWf-suc)
+          (modeRename-left-inverse
+            {ρ = extᵗ suc} {ψ = extᵗ predᵗ}
+            (RenameLeftInverse-ext RenameLeftInverse-suc))
+          c⊢)
+
+    incl :
+      StoreIncl
+        ((zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ (⟰ᵗ Σ))
+        ((zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ ((zero , ⇑ᵗ Aχ) ∷ ⟰ᵗ Σ))
+    incl (here refl) = here refl
+    incl (there h) = there (there h)
+
+typing-wf-∀-body :
+  ∀ {Δ Σ V C} →
+  StoreWfAt Δ Σ →
+  Δ ∣ Σ ∣ [] ⊢ V ⦂ `∀ C →
+  WfTy (suc Δ) C
+typing-wf-∀-body wfΣ V⊢ with typing-wf wfΣ closedCtxWf V⊢
+typing-wf-∀-body wfΣ V⊢ | wf∀ hC = hC
+
+StoreWfAt-tail :
+  ∀ {Δ α A Σ} →
+  StoreWfAt Δ ((α , A) ∷ Σ) →
+  StoreWfAt Δ Σ
+StoreWfAt-tail wfΣ =
+  record
+    { bound = λ x∈ → bound wfΣ (there x∈)
+    ; wfTy = λ x∈ → wfTy wfΣ (there x∈)
+    }
+
+ν-step-typing :
+  ∀ {Δ : TyCtx}{Σ : Store}{A B C : Ty}{V : Term}
+    {c : Coercion}{μ : ModeEnv} →
+  StoreWfAt Δ Σ →
   WfTy Δ A →
-  Δ ∣ Σ ∣ Γ ⊢ L ⦂ `∀ C →
+  No• V →
+  Value V →
+  Δ ∣ Σ ∣ [] ⊢ V ⦂ `∀ C →
   μ ∣ suc Δ ∣ (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ ⊢ c ∶ C =⇒ ⇑ᵗ B →
-  TypeAppTyping Δ Δ′ Σ Γ α A
-    (app L α ((c [ α ]ᶜ) ∷ [])) B
-type-app-initial wfΣ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′ hA hL c⊢
-    with coercion-open-fresh wfΣ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ hA c⊢
-... | μ′ , cα⊢ =
-  app⊢
-    hL
-    (stack∷ cα⊢ stack[])
-
-type-app-preservation :
-  ∀ {Δ Δ′ Σ Γ A B C L c V cs α μ} →
-  StoreWfAt Δ Σ →
-  Δ ≤ Δ′ →
-  Δ ≤ α →
-  α < Δ′ →
-  α ∉ domˢ Σ →
-  StoreWf Δ′ ((α , A) ∷ Σ) →
-  CtxWf Δ Γ →
-  CtxWf Δ′ Γ →
-  WfTy Δ A →
-  Δ ∣ Σ ∣ Γ ⊢ L ⦂ `∀ C →
-  μ ∣ suc Δ ∣ (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ ⊢ c ∶ C =⇒ ⇑ᵗ B →
-  app L α ((c [ α ]ᶜ) ∷ []) —↠ᵀ val V cs →
-  Δ′ ∣ (α , A) ∷ Σ ∣ Γ ⊢ applyCoercions V cs ⦂ B
-type-app-preservation {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {A = A}
-    {B = B} {C = C} {L = L} {c = c} {V = V} {cs = cs}
-    {α = α} wfΣ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ hΓ′ hA hL c⊢ L↠V
-    with type-app-preservation-closure
-      wfΣ
-      hΓ
-      Δ≤Δ′
-      Δ≤α
-      α<Δ′
-      α∉Σ
-      wfΣ′
-      hΓ′
-      (type-app-initial
-        wfΣ Δ≤Δ′ Δ≤α α<Δ′ α∉Σ wfΣ′ hΓ′ hA hL c⊢)
-      L↠V
-... | val⊢ V⊢ stack⊢ = applyCoercions-typing stack⊢ V⊢
+  suc Δ ∣ (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ ∣ []
+    ⊢ ((⇑ᵗᵐ V) •) ⟨ c ⟩ ⦂ ⇑ᵗ B
+ν-step-typing {C = C} wfΣ hA noV vV V⊢ c⊢ =
+  ⊢⟨⟩ c⊢ bullet⊢
+  where
+    bullet⊢ :
+      _ ∣ _ ∣ [] ⊢ (⇑ᵗᵐ _) • ⦂ C
+    bullet⊢ =
+      ⊢• refl refl
+        (typing-wf-∀-body wfΣ V⊢)
+        vV
+        noV
+        V⊢
 
 ------------------------------------------------------------------------
--- Raw redex preservation
+-- Raw redex preservation for bullet-free source redexes
 ------------------------------------------------------------------------
 
 pure-preservation :
-  ∀ {Δ Σ Γ M N A} →
+  ∀ {Δ Σ M N A} →
   StoreWf Δ Σ →
-  CtxWf Δ Γ →
-  Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
+  No• M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
   M —→ N →
-  Δ ∣ Σ ∣ Γ ⊢ N ⦂ A
-pure-preservation wfΣ hΓ
+  Δ ∣ Σ ∣ [] ⊢ N ⦂ A
+pure-preservation wfΣ (no•-⊕ noL noM)
     (⊢⊕ (⊢$ (κℕ m)) addℕ (⊢$ (κℕ n)))
     δ-⊕ =
   ⊢$ _
-pure-preservation wfΣ hΓ (⊢· (⊢ƛ hA hN) hV) (β vV) =
-  typing-single-subst hN hV
-pure-preservation wfΣ hΓ (⊢⟨⟩ (cast-id hA _) hV) (β-id vV) =
+pure-preservation wfΣ (no•-· (no•-ƛ noN) noV)
+    (⊢· (⊢ƛ hA hN) hV) (β vV) =
+  typing-single-subst noN noV hN hV
+pure-preservation wfΣ () M⊢ (β-Λ• vV′)
+pure-preservation wfΣ () M⊢ (β-∀• vV′)
+pure-preservation wfΣ () M⊢ (β-gen• vV′)
+pure-preservation wfΣ (no•-⟨⟩ noV)
+    (⊢⟨⟩ (cast-id hA _) hV) (β-id vV) =
   hV
-pure-preservation wfΣ hΓ (⊢⟨⟩ (cast-seq p⊢ q⊢) hV) (β-seq vV) =
+pure-preservation wfΣ (no•-⟨⟩ noV)
+    (⊢⟨⟩ (cast-seq p⊢ q⊢) hV) (β-seq vV) =
   ⊢⟨⟩ q⊢ (⊢⟨⟩ p⊢ hV)
-pure-preservation wfΣ hΓ
+pure-preservation wfΣ (no•-· (no•-⟨⟩ noV) noW)
     (⊢· (⊢⟨⟩ (cast-fun p⊢ q⊢) hV) hW)
     (β-↦ vV vW) =
   ⊢⟨⟩ q⊢ (⊢· hV (⊢⟨⟩ p⊢ hW))
-pure-preservation wfΣ hΓ
+pure-preservation wfΣ (no•-⟨⟩ noV)
     (⊢⟨⟩ {M = V}
       (cast-inst {A = A} {B = B} {s = c} hB occ c⊢) V⊢)
     (β-inst vV) =
   ⊢ν wf★ V⊢ c⊢
-pure-preservation wfΣ hΓ
+pure-preservation wfΣ (no•-⟨⟩ (no•-⟨⟩ noV))
     (⊢⟨⟩ (cast-unseal hB αB∈Σ _)
       (⊢⟨⟩ (cast-seal hA αA∈Σ _) hV))
     (seal-unseal vV) =
   subst (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
         (unique wfΣ αA∈Σ αB∈Σ)
         hV
-pure-preservation wfΣ hΓ
+pure-preservation wfΣ (no•-⟨⟩ (no•-⟨⟩ noV))
     (⊢⟨⟩ (cast-untag hG gG _) (⊢⟨⟩ (cast-tag hG′ gG′ _) hV))
     (tag-untag-ok vV) =
   hV
-pure-preservation wfΣ hΓ
+pure-preservation wfΣ (no•-⟨⟩ (no•-⟨⟩ noV))
     (⊢⟨⟩ (cast-untag hH gH _) (⊢⟨⟩ (cast-tag hG gG _) hV))
     (tag-untag-bad vV G≢H) =
   ⊢blame hH
-pure-preservation wfΣ hΓ (⊢· (⊢blame (wf⇒ hA hB)) hM) blame-·₁ =
+pure-preservation wfΣ (no•-· noB noM)
+    (⊢· (⊢blame (wf⇒ hA hB)) hM) blame-·₁ =
   ⊢blame hB
-pure-preservation wfΣ hΓ (⊢· hV (⊢blame hA)) (blame-·₂ vV)
-    with typing-wf (at wfΣ) hΓ hV
-pure-preservation wfΣ hΓ (⊢· hV (⊢blame hA)) (blame-·₂ vV)
+pure-preservation wfΣ (no•-· noV noB)
+    (⊢· hV (⊢blame hA)) (blame-·₂ vV)
+    with typing-wf (at wfΣ) closedCtxWf hV
+pure-preservation wfΣ (no•-· noV noB)
+    (⊢· hV (⊢blame hA)) (blame-·₂ vV)
     | wf⇒ hA′ hB =
   ⊢blame hB
-pure-preservation wfΣ hΓ (⊢⟨⟩ c⊢ (⊢blame hA)) blame-⟨⟩
+pure-preservation wfΣ () M⊢ blame-•
+pure-preservation wfΣ (no•-⟨⟩ noB)
+    (⊢⟨⟩ c⊢ (⊢blame hA)) blame-⟨⟩
     with coercion-wfᵐ (at wfΣ) c⊢
-pure-preservation wfΣ hΓ (⊢⟨⟩ c⊢ (⊢blame hA)) blame-⟨⟩
+pure-preservation wfΣ (no•-⟨⟩ noB)
+    (⊢⟨⟩ c⊢ (⊢blame hA)) blame-⟨⟩
     | hA′ , hB =
   ⊢blame hB
-pure-preservation wfΣ hΓ (⊢⊕ (⊢blame hA) op hM) blame-⊕₁ =
+pure-preservation wfΣ (no•-⊕ noB noM)
+    (⊢⊕ (⊢blame hA) op hM) blame-⊕₁ =
   ⊢blame wfBase
-pure-preservation wfΣ hΓ (⊢⊕ hL op (⊢blame hA)) (blame-⊕₂ vL) =
+pure-preservation wfΣ (no•-⊕ noL noB)
+    (⊢⊕ hL op (⊢blame hA)) (blame-⊕₂ vL) =
   ⊢blame wfBase
 
+pure-preserves-No•-typed :
+  ∀ {Δ Σ M N A} →
+  StoreWf Δ Σ →
+  No• M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —→ N →
+  No• N
+pure-preserves-No•-typed wfΣ (no•-⊕ noL noM)
+    (⊢⊕ (⊢$ (κℕ m)) addℕ (⊢$ (κℕ n)))
+    δ-⊕ =
+  no•-$
+pure-preserves-No•-typed wfΣ (no•-· (no•-ƛ noN) noV)
+    (⊢· (⊢ƛ hA hN) hV) (β vV) =
+  substˣᵐ-preserves-No•-typed (singleSubstNo• noV) noN hN
+pure-preserves-No•-typed wfΣ () M⊢ (β-Λ• vV)
+pure-preserves-No•-typed wfΣ () M⊢ (β-∀• vV)
+pure-preserves-No•-typed wfΣ () M⊢ (β-gen• vV)
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ noV) M⊢ (β-id vV) =
+  noV
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ noV) M⊢ (β-seq vV) =
+  no•-⟨⟩ (no•-⟨⟩ noV)
+pure-preserves-No•-typed wfΣ (no•-· (no•-⟨⟩ noV) noW)
+    M⊢ (β-↦ vV vW) =
+  no•-⟨⟩ (no•-· noV (no•-⟨⟩ noW))
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ noV) M⊢ (β-inst vV) =
+  no•-ν noV
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ (no•-⟨⟩ noV))
+    M⊢ (tag-untag-ok vV) =
+  noV
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ (no•-⟨⟩ noV))
+    M⊢ (tag-untag-bad vV G≢H) =
+  no•-blame
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ (no•-⟨⟩ noV))
+    M⊢ (seal-unseal vV) =
+  noV
+pure-preserves-No•-typed wfΣ (no•-· noB noM) M⊢ blame-·₁ =
+  no•-blame
+pure-preserves-No•-typed wfΣ (no•-· noV noB) M⊢
+    (blame-·₂ vV) =
+  no•-blame
+pure-preserves-No•-typed wfΣ () M⊢ blame-•
+pure-preserves-No•-typed wfΣ (no•-⟨⟩ noB) M⊢ blame-⟨⟩ =
+  no•-blame
+pure-preserves-No•-typed wfΣ (no•-⊕ noB noM) M⊢ blame-⊕₁ =
+  no•-blame
+pure-preserves-No•-typed wfΣ (no•-⊕ noL noB) M⊢
+    (blame-⊕₂ vL) =
+  no•-blame
+
+pure-preservation-runtime :
+  ∀ {Δ Σ M N A} →
+  StoreWf Δ Σ →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  RuntimeOK M →
+  M —→ N →
+  Δ ∣ Σ ∣ [] ⊢ N ⦂ A
+
+bullet-pure-preservation :
+  ∀ {Δ Σ Aν V C N} →
+  StoreWf (suc Δ) ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ) →
+  WfTy (suc Δ) C →
+  Value V →
+  No• V →
+  Δ ∣ Σ ∣ [] ⊢ V ⦂ `∀ C →
+  ((⇑ᵗᵐ V) •) —→ N →
+  suc Δ ∣ (zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ ∣ [] ⊢ N ⦂ C
+bullet-pure-preservation wfΣ hC (ƛ N) noV () red
+bullet-pure-preservation {C = C} wfΣ hC
+    (Λ vW) (no•-Λ noW) (⊢Λ vW′ W⊢) (β-Λ• vW↑) =
+  subst
+    (λ T → _ ∣ _ ∣ [] ⊢ T ⦂ C)
+    (sym (open0-ext-suc-cancelᵐ _))
+    (term-weaken ≤-refl StoreIncl-drop noW W⊢)
+bullet-pure-preservation wfΣ hC ($ (κℕ n)) noV () red
+bullet-pure-preservation wfΣ hC (vW ⟨ G ! ⟩) noV (⊢⟨⟩ () W⊢) red
+bullet-pure-preservation wfΣ hC (vW ⟨ seal A α ⟩) noV
+    (⊢⟨⟩ () W⊢) red
+bullet-pure-preservation wfΣ hC (vW ⟨ c ↦ d ⟩) noV
+    (⊢⟨⟩ () W⊢) red
+bullet-pure-preservation {C = C} wfΣ hC
+    (_⟨_⟩ {V = W} vW (`∀ c)) (no•-⟨⟩ noW)
+    (⊢⟨⟩ (cast-all c⊢) W⊢) (β-∀• vW↑) =
+  subst
+    (λ d → _ ∣ _ ∣ [] ⊢ ((⇑ᵗᵐ W) •) ⟨ d ⟩ ⦂ C)
+    (sym (open0-ext-suc-cancelᶜ c))
+    (⊢⟨⟩
+      (coercion-weakenᵐ ≤-refl StoreIncl-drop c⊢)
+      (⊢• refl refl hA vW noW W⊢))
+  where
+    hA : WfTy _ _
+    hA with coercion-wfᵐ (StoreWfAt-tail (at wfΣ)) c⊢
+    hA | hA′ , hC′ = hA′
+bullet-pure-preservation {C = C} wfΣ hC
+    (_⟨_⟩ {V = W} vW (gen A c)) (no•-⟨⟩ noW)
+    (⊢⟨⟩ (cast-gen hA occ c⊢) W⊢) (β-gen• vW↑) =
+  subst
+    (λ d → _ ∣ _ ∣ [] ⊢ (⇑ᵗᵐ W) ⟨ d ⟩ ⦂ C)
+    (sym (open0-ext-suc-cancelᶜ c))
+    (⊢⟨⟩
+      (coercion-weakenᵐ ≤-refl StoreIncl-drop c⊢)
+      (term-weaken ≤-refl StoreIncl-drop
+        (renameᵗᵐ-preserves-No• suc noW)
+        (typing-renameᵀ {ρ = suc} {ψ = predᵗ}
+          TyRenameWf-suc RenameLeftInverse-suc noW W⊢)))
+
+bullet-runtime-preservation :
+  ∀ {Δ Σ Aν V C N} →
+  StoreWf (suc Δ) ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ) →
+  WfTy (suc Δ) C →
+  Value V →
+  No• V →
+  Δ ∣ Σ ∣ [] ⊢ V ⦂ `∀ C →
+  ((⇑ᵗᵐ V) •) —→ N →
+  RuntimeOK N
+bullet-runtime-preservation wfΣ hC (ƛ N) noV () red
+bullet-runtime-preservation wfΣ hC
+    (Λ vW) (no•-Λ noW) (⊢Λ vW′ W⊢) (β-Λ• vW↑) =
+  subst RuntimeOK (sym (open0-ext-suc-cancelᵐ _)) (ok-no noW)
+bullet-runtime-preservation wfΣ hC ($ (κℕ n)) noV () red
+bullet-runtime-preservation wfΣ hC (vW ⟨ G ! ⟩) noV
+    (⊢⟨⟩ () W⊢) red
+bullet-runtime-preservation wfΣ hC (vW ⟨ seal A α ⟩) noV
+    (⊢⟨⟩ () W⊢) red
+bullet-runtime-preservation wfΣ hC (vW ⟨ c ↦ d ⟩) noV
+    (⊢⟨⟩ () W⊢) red
+bullet-runtime-preservation wfΣ hC
+    (_⟨_⟩ {V = W} vW (`∀ c)) (no•-⟨⟩ noW)
+    (⊢⟨⟩ (cast-all c⊢) W⊢) (β-∀• vW↑) =
+  ok-⟨⟩ (ok-• vW noW)
+bullet-runtime-preservation wfΣ hC
+    (_⟨_⟩ {V = W} vW (gen A c)) (no•-⟨⟩ noW)
+    (⊢⟨⟩ (cast-gen hA occ c⊢) W⊢) (β-gen• vW↑) =
+  ok-no (no•-⟨⟩ (renameᵗᵐ-preserves-No• suc noW))
+
+value-runtime-No• :
+  ∀ {V} →
+  Value V →
+  RuntimeOK V →
+  No• V
+value-runtime-No• vV (ok-no noV) = noV
+value-runtime-No• (vV ⟨ i ⟩) (ok-⟨⟩ okV) =
+  no•-⟨⟩ (value-runtime-No• vV okV)
+
+pure-runtime-preservation :
+  ∀ {Δ Σ M N A} →
+  StoreWf Δ Σ →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  RuntimeOK M →
+  M —→ N →
+  RuntimeOK N
+pure-runtime-preservation wfΣ
+    (⊢• refl refl hC vV noV V⊢) okM red =
+  bullet-runtime-preservation wfΣ hC vV noV V⊢ red
+pure-runtime-preservation wfΣ M⊢ (ok-no noM) red =
+  ok-no (pure-preserves-No•-typed wfΣ noM M⊢ red)
+pure-runtime-preservation wfΣ M⊢ (ok-·₁ okL noM) (β vV) =
+  ok-no
+    (pure-preserves-No•-typed wfΣ
+      (no•-· (value-runtime-No• (ƛ _) okL) noM) M⊢ (β vV))
+pure-runtime-preservation wfΣ M⊢ (ok-·₁ okL noM)
+    (β-↦ vV vW) =
+  ok-no
+    (pure-preserves-No•-typed wfΣ
+      (no•-· (value-runtime-No• (vV ⟨ _ ↦ _ ⟩) okL) noM)
+      M⊢
+      (β-↦ vV vW))
+pure-runtime-preservation wfΣ M⊢ (ok-·₁ okL noM) blame-·₁ =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-· no•-blame noM) M⊢ blame-·₁)
+pure-runtime-preservation wfΣ M⊢ (ok-·₁ okL noM)
+    (blame-·₂ vV) =
+  ok-no
+    (pure-preserves-No•-typed wfΣ
+      (no•-· (value-runtime-No• vV okL) noM) M⊢ (blame-·₂ vV))
+pure-runtime-preservation wfΣ M⊢ (ok-·₂ vV noV okM) (β vW) =
+  ok-no
+    (pure-preserves-No•-typed wfΣ
+      (no•-· noV (value-runtime-No• vW okM)) M⊢ (β vW))
+pure-runtime-preservation wfΣ M⊢ (ok-·₂ vV noV okM)
+    (β-↦ vV′ vW) =
+  ok-no
+    (pure-preserves-No•-typed wfΣ
+      (no•-· noV (value-runtime-No• vW okM)) M⊢ (β-↦ vV′ vW))
+pure-runtime-preservation wfΣ M⊢ (ok-·₂ vV noV okM)
+    (blame-·₂ vV′) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-· noV no•-blame) M⊢ (blame-·₂ vV′))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM) (β-id vV) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ (value-runtime-No• vV okM)) M⊢ (β-id vV))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM) (β-seq vV) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ (value-runtime-No• vV okM)) M⊢ (β-seq vV))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM) (β-inst vV) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ (value-runtime-No• vV okM)) M⊢ (β-inst vV))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM) (seal-unseal vV) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ (value-runtime-No• (vV ⟨ seal _ _ ⟩) okM))
+    M⊢
+    (seal-unseal vV))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM) (tag-untag-ok vV) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ (value-runtime-No• (vV ⟨ _ ! ⟩) okM))
+    M⊢
+    (tag-untag-ok vV))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM)
+    (tag-untag-bad vV G≢H) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ (value-runtime-No• (vV ⟨ _ ! ⟩) okM))
+    M⊢
+    (tag-untag-bad vV G≢H))
+pure-runtime-preservation wfΣ M⊢ (ok-⟨⟩ okM) blame-⟨⟩ =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⟨⟩ no•-blame) M⊢ blame-⟨⟩)
+pure-runtime-preservation wfΣ M⊢ (ok-⊕₁ okL noM) δ-⊕ =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⊕ (value-runtime-No• ($ _) okL) noM) M⊢ δ-⊕)
+pure-runtime-preservation wfΣ M⊢ (ok-⊕₁ okL noM) blame-⊕₁ =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⊕ no•-blame noM) M⊢ blame-⊕₁)
+pure-runtime-preservation wfΣ M⊢ (ok-⊕₁ okL noM)
+    (blame-⊕₂ vL) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⊕ (value-runtime-No• vL okL) noM) M⊢ (blame-⊕₂ vL))
+pure-runtime-preservation wfΣ M⊢ (ok-⊕₂ vL noL okM) δ-⊕ =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⊕ noL (value-runtime-No• ($ _) okM)) M⊢ δ-⊕)
+pure-runtime-preservation wfΣ M⊢ (ok-⊕₂ vL noL okM)
+    (blame-⊕₂ vL′) =
+  ok-no (pure-preserves-No•-typed wfΣ
+    (no•-⊕ noL no•-blame) M⊢ (blame-⊕₂ vL′))
+
+pure-preservation-runtime wfΣ
+    (⊢• refl refl hC vV noV V⊢) okM red =
+  bullet-pure-preservation wfΣ hC vV noV V⊢ red
+pure-preservation-runtime wfΣ M⊢ (ok-no noM) red =
+  pure-preservation wfΣ noM M⊢ red
+pure-preservation-runtime wfΣ M⊢ (ok-·₁ okL noM) (β vV) =
+  pure-preservation wfΣ
+    (no•-· (value-runtime-No• (ƛ _) okL) noM) M⊢ (β vV)
+pure-preservation-runtime wfΣ M⊢ (ok-·₁ okL noM)
+    (β-↦ vV vW) =
+  pure-preservation wfΣ
+    (no•-· (value-runtime-No• (vV ⟨ _ ↦ _ ⟩) okL) noM)
+    M⊢
+    (β-↦ vV vW)
+pure-preservation-runtime wfΣ M⊢ (ok-·₁ okL noM) blame-·₁ =
+  pure-preservation wfΣ (no•-· no•-blame noM) M⊢ blame-·₁
+pure-preservation-runtime wfΣ M⊢ (ok-·₁ okL noM)
+    (blame-·₂ vV) =
+  pure-preservation wfΣ
+    (no•-· (value-runtime-No• vV okL) noM) M⊢ (blame-·₂ vV)
+pure-preservation-runtime wfΣ M⊢ (ok-·₂ vV noV okM) (β vW) =
+  pure-preservation wfΣ
+    (no•-· noV (value-runtime-No• vW okM)) M⊢ (β vW)
+pure-preservation-runtime wfΣ M⊢ (ok-·₂ vV noV okM)
+    (β-↦ vV′ vW) =
+  pure-preservation wfΣ
+    (no•-· noV (value-runtime-No• vW okM)) M⊢ (β-↦ vV′ vW)
+pure-preservation-runtime wfΣ M⊢ (ok-·₂ vV noV okM)
+    (blame-·₂ vV′) =
+  pure-preservation wfΣ (no•-· noV no•-blame) M⊢ (blame-·₂ vV′)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM) (β-id vV) =
+  pure-preservation wfΣ
+    (no•-⟨⟩ (value-runtime-No• vV okM)) M⊢ (β-id vV)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM) (β-seq vV) =
+  pure-preservation wfΣ
+    (no•-⟨⟩ (value-runtime-No• vV okM)) M⊢ (β-seq vV)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM) (β-inst vV) =
+  pure-preservation wfΣ
+    (no•-⟨⟩ (value-runtime-No• vV okM)) M⊢ (β-inst vV)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM) (seal-unseal vV) =
+  pure-preservation wfΣ
+    (no•-⟨⟩ (value-runtime-No• (vV ⟨ seal _ _ ⟩) okM))
+    M⊢
+    (seal-unseal vV)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM) (tag-untag-ok vV) =
+  pure-preservation wfΣ
+    (no•-⟨⟩ (value-runtime-No• (vV ⟨ _ ! ⟩) okM))
+    M⊢
+    (tag-untag-ok vV)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM)
+    (tag-untag-bad vV G≢H) =
+  pure-preservation wfΣ
+    (no•-⟨⟩ (value-runtime-No• (vV ⟨ _ ! ⟩) okM))
+    M⊢
+    (tag-untag-bad vV G≢H)
+pure-preservation-runtime wfΣ M⊢ (ok-⟨⟩ okM) blame-⟨⟩ =
+  pure-preservation wfΣ (no•-⟨⟩ no•-blame) M⊢ blame-⟨⟩
+pure-preservation-runtime wfΣ M⊢ (ok-⊕₁ okL noM) δ-⊕ =
+  pure-preservation wfΣ
+    (no•-⊕ (value-runtime-No• ($ _) okL) noM) M⊢ δ-⊕
+pure-preservation-runtime wfΣ M⊢ (ok-⊕₁ okL noM) blame-⊕₁ =
+  pure-preservation wfΣ (no•-⊕ no•-blame noM) M⊢ blame-⊕₁
+pure-preservation-runtime wfΣ M⊢ (ok-⊕₁ okL noM)
+    (blame-⊕₂ vL) =
+  pure-preservation wfΣ
+    (no•-⊕ (value-runtime-No• vL okL) noM) M⊢ (blame-⊕₂ vL)
+pure-preservation-runtime wfΣ M⊢ (ok-⊕₂ vL noL okM) δ-⊕ =
+  pure-preservation wfΣ
+    (no•-⊕ noL (value-runtime-No• ($ _) okM)) M⊢ δ-⊕
+pure-preservation-runtime wfΣ M⊢ (ok-⊕₂ vL noL okM)
+    (blame-⊕₂ vL′) =
+  pure-preservation wfΣ (no•-⊕ noL no•-blame) M⊢ (blame-⊕₂ vL′)
+
+applyTerm-typing-shiftable :
+  ∀ {χ : StoreChange}{Δ Σ M A} →
+  StoreWfAt Δ Σ →
+  Shiftable χ M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  applyTyCtx χ Δ ∣ applyStore χ Σ ∣ [] ⊢ applyTerm χ M ⦂ applyTy χ A
+applyTerm-typing-shiftable wfΣ shift-keep M⊢ = M⊢
+applyTerm-typing-shiftable wfΣ (shift-bind noM) M⊢ =
+  applyTerm-typing wfΣ noM M⊢
+
+runtime-·₁ :
+  ∀ {L M} →
+  RuntimeOK (L · M) →
+  RuntimeOK L
+runtime-·₁ (ok-no (no•-· noL noM)) = ok-no noL
+runtime-·₁ (ok-·₁ okL noM) = okL
+runtime-·₁ (ok-·₂ vL noL okM) = ok-no noL
+
+runtime-·₂ :
+  ∀ {L M} →
+  Value L →
+  RuntimeOK (L · M) →
+  RuntimeOK M
+runtime-·₂ vL (ok-no (no•-· noL noM)) = ok-no noM
+runtime-·₂ vL (ok-·₁ okL noM) = ok-no noM
+runtime-·₂ vL (ok-·₂ vL′ noL okM) = okM
+
+runtime-⟨⟩ :
+  ∀ {M c} →
+  RuntimeOK (M ⟨ c ⟩) →
+  RuntimeOK M
+runtime-⟨⟩ (ok-no (no•-⟨⟩ noM)) = ok-no noM
+runtime-⟨⟩ (ok-⟨⟩ okM) = okM
+
+runtime-ν :
+  ∀ {A L c} →
+  RuntimeOK (ν A L c) →
+  RuntimeOK L
+runtime-ν (ok-no (no•-ν noL)) = ok-no noL
+runtime-ν (ok-ν okL) = okL
+
+runtime-⊕₁ :
+  ∀ {L op M} →
+  RuntimeOK (L ⊕[ op ] M) →
+  RuntimeOK L
+runtime-⊕₁ (ok-no (no•-⊕ noL noM)) = ok-no noL
+runtime-⊕₁ (ok-⊕₁ okL noM) = okL
+runtime-⊕₁ (ok-⊕₂ vL noL okM) = ok-no noL
+
+runtime-⊕₂ :
+  ∀ {L op M} →
+  Value L →
+  RuntimeOK (L ⊕[ op ] M) →
+  RuntimeOK M
+runtime-⊕₂ vL (ok-no (no•-⊕ noL noM)) = ok-no noM
+runtime-⊕₂ vL (ok-⊕₁ okL noM) = ok-no noM
+runtime-⊕₂ vL (ok-⊕₂ vL′ noL okM) = okM
+
+applyTerm-preserves-No• :
+  ∀ {χ M} →
+  No• M →
+  Shiftable χ M →
+  No• (applyTerm χ M)
+applyTerm-preserves-No• noM shift-keep = noM
+applyTerm-preserves-No• noM (shift-bind noM′) =
+  renameᵗᵐ-preserves-No• suc noM′
+
+applyTerm-preserves-Value :
+  ∀ {χ V} →
+  Shiftable χ V →
+  Value V →
+  Value (applyTerm χ V)
+applyTerm-preserves-Value shift-keep vV = vV
+applyTerm-preserves-Value (shift-bind noV) vV =
+  renameᵗᵐ-preserves-Value suc vV
+
+value-no-pure-step :
+  ∀ {V N} →
+  Value V →
+  V —→ N →
+  ⊥
+value-no-pure-step (ƛ N) ()
+value-no-pure-step (Λ vV) ()
+value-no-pure-step ($ κ) ()
+value-no-pure-step (() ⟨ G ! ⟩) blame-⟨⟩
+value-no-pure-step (() ⟨ seal A α ⟩) blame-⟨⟩
+value-no-pure-step (() ⟨ c ↦ d ⟩) blame-⟨⟩
+value-no-pure-step (() ⟨ `∀ c ⟩) blame-⟨⟩
+value-no-pure-step (() ⟨ gen A c ⟩) blame-⟨⟩
+
+value-no-step :
+  ∀ {χ V N} →
+  Value V →
+  V —→[ χ ] N →
+  ⊥
+value-no-step vV (pure-step red) =
+  value-no-pure-step vV red
+value-no-step (vV ⟨ i ⟩) (ξ-⟨⟩ red) =
+  value-no-step vV red
+
+runtime-preservation :
+  ∀ {Δ Σ M N A χ} →
+  StoreWf Δ Σ →
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —→[ χ ] N →
+  RuntimeOK N
+runtime-preservation wfΣ okM M⊢ (pure-step red) =
+  pure-runtime-preservation wfΣ M⊢ okM red
+runtime-preservation wfΣ okM (⊢ν hA V⊢ c⊢)
+    (ν-step vV noV) =
+  ok-⟨⟩ (ok-• vV noV)
+runtime-preservation wfΣ (ok-no (no•-· noL noM)) (⊢· L⊢ M⊢)
+    (ξ-·₁ red shiftM) =
+  ok-·₁
+    (runtime-preservation wfΣ (ok-no noL) L⊢ red)
+    (applyTerm-preserves-No• noM shiftM)
+runtime-preservation wfΣ (ok-·₁ okL noM) (⊢· L⊢ M⊢)
+    (ξ-·₁ red shiftM) =
+  ok-·₁
+    (runtime-preservation wfΣ okL L⊢ red)
+    (applyTerm-preserves-No• noM shiftM)
+runtime-preservation wfΣ (ok-·₂ vL noL okM) (⊢· L⊢ M⊢)
+    (ξ-·₁ red shiftM) =
+  ⊥-elim (value-no-step vL red)
+runtime-preservation wfΣ okM (⊢· V⊢ M⊢)
+    (ξ-·₂ vV shiftV red) =
+  ok-·₂
+    (applyTerm-preserves-Value shiftV vV)
+    (applyTerm-preserves-No•
+      (value-runtime-No• vV (runtime-·₁ okM))
+      shiftV)
+    (runtime-preservation wfΣ (runtime-·₂ vV okM) M⊢ red)
+runtime-preservation wfΣ okM (⊢⟨⟩ c⊢ M⊢)
+    (ξ-⟨⟩ red) =
+  ok-⟨⟩ (runtime-preservation wfΣ (runtime-⟨⟩ okM) M⊢ red)
+runtime-preservation wfΣ okM (⊢ν hA L⊢ c⊢)
+    (ξ-ν red) =
+  ok-ν (runtime-preservation wfΣ (runtime-ν okM) L⊢ red)
+runtime-preservation wfΣ okM (⊢ν hA (⊢blame hB) c⊢) blame-ν =
+  ok-no no•-blame
+runtime-preservation wfΣ (ok-no (no•-⊕ noL noM)) (⊢⊕ L⊢ op M⊢)
+    (ξ-⊕₁ red shiftM) =
+  ok-⊕₁
+    (runtime-preservation wfΣ (ok-no noL) L⊢ red)
+    (applyTerm-preserves-No• noM shiftM)
+runtime-preservation wfΣ (ok-⊕₁ okL noM) (⊢⊕ L⊢ op M⊢)
+    (ξ-⊕₁ red shiftM) =
+  ok-⊕₁
+    (runtime-preservation wfΣ okL L⊢ red)
+    (applyTerm-preserves-No• noM shiftM)
+runtime-preservation wfΣ (ok-⊕₂ vL noL okM) (⊢⊕ L⊢ op M⊢)
+    (ξ-⊕₁ red shiftM) =
+  ⊥-elim (value-no-step vL red)
+runtime-preservation wfΣ okM (⊢⊕ L⊢ op M⊢)
+    (ξ-⊕₂ vL shiftL red) =
+  ok-⊕₂
+    (applyTerm-preserves-Value shiftL vL)
+    (applyTerm-preserves-No•
+      (value-runtime-No• vL (runtime-⊕₁ okM))
+      shiftL)
+    (runtime-preservation wfΣ (runtime-⊕₂ vL okM) M⊢ red)
+
+store-preservation :
+  ∀ {Δ Σ M N A χ} →
+  StoreWf Δ Σ →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —→[ χ ] N →
+  StoreWf (applyTyCtx χ Δ) (applyStore χ Σ)
+store-preservation wfΣ M⊢ (pure-step red) = wfΣ
+store-preservation wfΣ (⊢ν hA V⊢ c⊢) (ν-step vV noV) =
+  StoreWf-bind wfΣ hA
+store-preservation wfΣ (⊢· L⊢ M⊢) (ξ-·₁ red shiftM) =
+  store-preservation wfΣ L⊢ red
+store-preservation wfΣ (⊢· V⊢ M⊢) (ξ-·₂ vV shiftV red) =
+  store-preservation wfΣ M⊢ red
+store-preservation wfΣ (⊢⟨⟩ c⊢ M⊢) (ξ-⟨⟩ red) =
+  store-preservation wfΣ M⊢ red
+store-preservation wfΣ (⊢ν hA L⊢ c⊢) (ξ-ν red) =
+  store-preservation wfΣ L⊢ red
+store-preservation wfΣ (⊢ν hA (⊢blame hB) c⊢) blame-ν = wfΣ
+store-preservation wfΣ (⊢⊕ L⊢ op M⊢) (ξ-⊕₁ red shiftM) =
+  store-preservation wfΣ L⊢ red
+store-preservation wfΣ (⊢⊕ L⊢ op M⊢) (ξ-⊕₂ vL shiftL red) =
+  store-preservation wfΣ M⊢ red
+
 ------------------------------------------------------------------------
--- Store-threaded preservation
+-- Store-change preservation
 ------------------------------------------------------------------------
 
 preservation :
-  ∀ {Δ Δ′ Σ Σ′ Γ M N A} →
+  ∀ {Δ Σ M N A χ} →
   StoreWf Δ Σ →
-  CtxWf Δ Γ →
-  Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
-  Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ N →
-  PreservationResult Δ Σ Γ Δ′ Σ′ N A
-preservation wfΣ hΓ M⊢ (pure-step red) =
-  preserve wfΣ ≤-refl StoreIncl-refl hΓ
-    (pure-preservation wfΣ hΓ M⊢ red)
-preservation {Δ = Δ} {Σ = Σ} {Γ = Γ} wfΣ hΓ
-    (⊢ν {A = A} hA hL c⊢)
-    (ν-step {α = α} Δ≤α α∉Σ L↠V) =
-  let
-    Δ≤sα = ≤-trans Δ≤α (n≤1+n α)
-    α<sα = s≤s ≤-refl
-    wfΣ′ = StoreWf-fresh-ext wfΣ Δ≤sα Δ≤α α<sα hA α∉Σ
-    hΓ′ = CtxWf-weaken hΓ Δ≤sα
-  in
-  preserve
-    wfΣ′
-    Δ≤sα
-    StoreIncl-drop
-    hΓ′
-    (type-app-preservation
-      (at wfΣ)
-      Δ≤sα
-      Δ≤α
-      α<sα
-      α∉Σ
-      wfΣ′
-      hΓ
-      hΓ′
-      hA
-      hL
-      c⊢
-      L↠V)
-preservation wfΣ hΓ (⊢· L⊢ M⊢) (ξ-·₁ red)
-    with preservation wfΣ hΓ L⊢ red
-preservation wfΣ hΓ (⊢· L⊢ M⊢) (ξ-·₁ red)
-    | preserve wfΣ′ Δ≤Δ′ incl hΓ′ L′⊢ =
-  preserve wfΣ′ Δ≤Δ′ incl hΓ′
-    (⊢· L′⊢ (term-weaken Δ≤Δ′ incl M⊢))
-preservation wfΣ hΓ (⊢· L⊢ M⊢) (ξ-·₂ vV red)
-    with preservation wfΣ hΓ M⊢ red
-preservation wfΣ hΓ (⊢· L⊢ M⊢) (ξ-·₂ vV red)
-    | preserve wfΣ′ Δ≤Δ′ incl hΓ′ M′⊢ =
-  preserve wfΣ′ Δ≤Δ′ incl hΓ′
-    (⊢· (term-weaken Δ≤Δ′ incl L⊢) M′⊢)
-preservation wfΣ hΓ (⊢⟨⟩ c⊢ M⊢) (ξ-⟨⟩ red)
-    with preservation wfΣ hΓ M⊢ red
-preservation wfΣ hΓ (⊢⟨⟩ c⊢ M⊢) (ξ-⟨⟩ red)
-    | preserve wfΣ′ Δ≤Δ′ incl hΓ′ M′⊢ =
-  preserve wfΣ′ Δ≤Δ′ incl hΓ′
-    (⊢⟨⟩ (coercion-weakenᵐ Δ≤Δ′ incl c⊢) M′⊢)
-preservation wfΣ hΓ (⊢ν hA hL c⊢) (ξ-ν red)
-    with preservation wfΣ hΓ hL red
-preservation wfΣ hΓ (⊢ν hA hL c⊢) (ξ-ν red)
-    | preserve wfΣ′ Δ≤Δ′ incl hΓ′ L′⊢ =
-  preserve wfΣ′ Δ≤Δ′ incl hΓ′
-    (⊢ν
-      (WfTy-weakenᵗ hA Δ≤Δ′)
-      L′⊢
-      (coercion-weakenᵐ
-        (s≤s Δ≤Δ′)
-        (StoreIncl-cons (renameStoreᵗ-incl suc incl))
-        c⊢))
-preservation wfΣ hΓ (⊢ν hA (⊢blame (wf∀ hC)) c⊢) blame-ν =
-  preserve wfΣ ≤-refl StoreIncl-refl hΓ
-    (⊢blame (typing-wf (at wfΣ) hΓ (⊢ν hA (⊢blame (wf∀ hC)) c⊢)))
-preservation wfΣ hΓ (⊢⊕ L⊢ op M⊢) (ξ-⊕₁ red)
-    with preservation wfΣ hΓ L⊢ red
-preservation wfΣ hΓ (⊢⊕ L⊢ op M⊢) (ξ-⊕₁ red)
-    | preserve wfΣ′ Δ≤Δ′ incl hΓ′ L′⊢ =
-  preserve wfΣ′ Δ≤Δ′ incl hΓ′
-    (⊢⊕ L′⊢ op (term-weaken Δ≤Δ′ incl M⊢))
-preservation wfΣ hΓ (⊢⊕ L⊢ op M⊢) (ξ-⊕₂ vL red)
-    with preservation wfΣ hΓ M⊢ red
-preservation wfΣ hΓ (⊢⊕ L⊢ op M⊢) (ξ-⊕₂ vL red)
-    | preserve wfΣ′ Δ≤Δ′ incl hΓ′ M′⊢ =
-  preserve wfΣ′ Δ≤Δ′ incl hΓ′
-    (⊢⊕ (term-weaken Δ≤Δ′ incl L⊢) op M′⊢)
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —→[ χ ] N →
+  applyTyCtx χ Δ ∣ applyStore χ Σ ∣ [] ⊢ N ⦂ applyTy χ A
+preservation wfΣ okM M⊢ (pure-step red) =
+  pure-preservation-runtime wfΣ M⊢ okM red
+preservation wfΣ okM (⊢ν hA V⊢ c⊢)
+    (ν-step vV noV′) =
+  ν-step-typing (at wfΣ) hA noV′ vV V⊢ c⊢
+preservation wfΣ okM (⊢· L⊢ M⊢)
+    (ξ-·₁ {χ = χ} red shiftM) =
+  ⊢·-applyTy χ
+    (preservation wfΣ (runtime-·₁ okM) L⊢ red)
+    (applyTerm-typing-shiftable (at wfΣ) shiftM M⊢)
+preservation wfΣ okM (⊢· V⊢ M⊢)
+    (ξ-·₂ {χ = χ} vV shiftV red) =
+  ⊢·-applyTy χ
+    (applyTerm-typing-shiftable (at wfΣ) shiftV V⊢)
+    (preservation wfΣ (runtime-·₂ vV okM) M⊢ red)
+preservation wfΣ okM (⊢⟨⟩ c⊢ M⊢)
+    (ξ-⟨⟩ {χ = χ} red)
+    with applyCoercion-typing {χ = χ} (at wfΣ) c⊢
+... | μ′ , c′⊢ =
+  ⊢⟨⟩ c′⊢ (preservation wfΣ (runtime-⟨⟩ okM) M⊢ red)
+preservation wfΣ okM (⊢ν hA L⊢ c⊢)
+    (ξ-ν {χ = χ} red)
+    with applyCoercionUnderTyBinder-typing {χ = χ} (at wfΣ) hA c⊢
+... | μ′ , c′⊢ =
+  ⊢ν-applyTy χ
+    (renameA χ hA)
+    (preservation wfΣ (runtime-ν okM) L⊢ red)
+    c′⊢
+  where
+    renameA : ∀ χ → WfTy _ _ → WfTy (applyTyCtx χ _) (applyTy χ _)
+    renameA keep h = h
+    renameA (bind Aχ) h = renameᵗ-preserves-WfTy h TyRenameWf-suc
+preservation wfΣ okM (⊢ν hA (⊢blame (wf∀ hC)) c⊢)
+    blame-ν =
+  ⊢blame (typing-wf (at wfΣ) closedCtxWf (⊢ν hA (⊢blame (wf∀ hC)) c⊢))
+preservation wfΣ okM (⊢⊕ L⊢ op M⊢)
+    (ξ-⊕₁ {χ = χ} red shiftM) =
+  ⊢⊕-applyTy χ
+    (preservation wfΣ (runtime-⊕₁ okM) L⊢ red) op
+    (applyTerm-typing-shiftable (at wfΣ) shiftM M⊢)
+preservation wfΣ okM (⊢⊕ L⊢ op M⊢)
+    (ξ-⊕₂ {χ = χ} vL shiftL red) =
+  ⊢⊕-applyTy χ
+    (applyTerm-typing-shiftable (at wfΣ) shiftL L⊢) op
+    (preservation wfΣ (runtime-⊕₂ vL okM) M⊢ red)
+
+multi-preservation :
+  ∀ {Δ Σ M N A χs} →
+  StoreWf Δ Σ →
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —↠[ χs ] N →
+  applyTyCtxs χs Δ ∣ applyStores χs Σ ∣ [] ⊢ N ⦂ applyTys χs A
+multi-preservation wfΣ okM M⊢ ↠-refl = M⊢
+multi-preservation wfΣ okM M⊢ (↠-step red reds) =
+  multi-preservation
+    (store-preservation wfΣ M⊢ red)
+    (runtime-preservation wfΣ okM M⊢ red)
+    (preservation wfΣ okM M⊢ red)
+    reds

--- a/GTSF/proof/NuProgress.agda
+++ b/GTSF/proof/NuProgress.agda
@@ -2,7 +2,7 @@ module proof.NuProgress where
 
 -- File Charter:
 --   * Canonical-form lemmas and progress for closed Nu GTSF terms.
---   * Produces values, blame crashes, or one store-threaded reduction step.
+--   * Produces values, blame crashes, or one store-change reduction step.
 --   * Uses the `NuTerms`/`NuReduction` formulation of the dynamic semantics.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
@@ -23,6 +23,7 @@ open import Coercions
 open import Primitives
 open import NuTerms
 open import NuReduction
+open import proof.NuTermProperties using (renameᵗᵐ-preserves-Value)
 
 ------------------------------------------------------------------------
 -- Fresh seal choice for progress
@@ -67,8 +68,8 @@ freshSealAbove∉ Δ Σ fresh∈Σ =
 data Progress {Δ : TyCtx}{Σ : Store} (M : Term) : Set where
   done : Value M → Progress M
   step :
-    ∀ {Δ′ : TyCtx}{Σ′ : Store}{N : Term} →
-    Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ N →
+    ∀ {χ : StoreChange}{N : Term} →
+    M —→[ χ ] N →
     Progress M
   crash :
     M ≡ blame →
@@ -233,137 +234,202 @@ unseal-progress vM M⊢ with canonical-＇ vM M⊢
 unseal-progress vM M⊢ | sv-seal vW refl =
   step (pure-step (seal-unseal vW))
 
-data TypeAppProgress (S : TypeApp) : Set where
-  tap :
-    ∀ {V : Term}{cs : List Coercion} →
-    S —↠ᵀ val V cs →
-    TypeAppProgress S
-
 type-app-progress :
-  ∀ {Δ : TyCtx}{Σ : Store}{L : Term}{C : Ty}{α : TyVar}
-    {cs : List Coercion} →
-  Value L →
-  Δ ∣ Σ ∣ [] ⊢ L ⦂ `∀ C →
-  TypeAppProgress (app L α cs)
-type-app-progress (ƛ N) ()
-type-app-progress (Λ vV) (⊢Λ _ hV) =
-  tap (stepᵀ (β-Λᵀ vV) doneᵀ)
-type-app-progress ($ (κℕ n)) ()
-type-app-progress (_⟨_⟩ {V = W} vW (G !)) (⊢⟨⟩ () hW)
-type-app-progress (_⟨_⟩ {V = W} vW (seal A α)) (⊢⟨⟩ () hW)
-type-app-progress (_⟨_⟩ {V = W} vW (c ↦ d)) (⊢⟨⟩ () hW)
-type-app-progress (_⟨_⟩ {V = W} vW (`∀ c))
-    (⊢⟨⟩ (cast-all c⊢) hW)
-    with type-app-progress vW hW
-type-app-progress (_⟨_⟩ {V = W} vW (`∀ c))
-    (⊢⟨⟩ (cast-all c⊢) hW)
-    | tap W↠V =
-  tap (stepᵀ (β-∀ᵀ vW) W↠V)
-type-app-progress (_⟨_⟩ {V = W} vW (gen A c))
+  ∀ {Δ : TyCtx}{Σ : Store}{V : Term}{A C : Ty} →
+  Value V →
+  No• V →
+  Δ ∣ Σ ∣ [] ⊢ V ⦂ `∀ C →
+  Progress {Δ = suc Δ} {Σ = (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ} ((⇑ᵗᵐ V) •)
+type-app-progress (ƛ N) noV ()
+type-app-progress (Λ vV) (no•-Λ noV) (⊢Λ _ hV) =
+  step (pure-step (β-Λ• (renameᵗᵐ-preserves-Value (extᵗ suc) vV)))
+type-app-progress ($ (κℕ n)) noV ()
+type-app-progress (_⟨_⟩ {V = W} vW (G !)) noV (⊢⟨⟩ () hW)
+type-app-progress (_⟨_⟩ {V = W} vW (seal A α)) noV (⊢⟨⟩ () hW)
+type-app-progress (_⟨_⟩ {V = W} vW (c ↦ d)) noV (⊢⟨⟩ () hW)
+type-app-progress (_⟨_⟩ {V = W} vW (`∀ c)) (no•-⟨⟩ noW)
+    (⊢⟨⟩ (cast-all c⊢) hW) =
+  step (pure-step (β-∀• (renameᵗᵐ-preserves-Value suc vW)))
+type-app-progress (_⟨_⟩ {V = W} vW (gen A c)) (no•-⟨⟩ noW)
     (⊢⟨⟩ (cast-gen _ _ c⊢) hW) =
-  tap (stepᵀ (β-genᵀ vW) doneᵀ)
+  step (pure-step (β-gen• (renameᵗᵐ-preserves-Value suc vW)))
+
+shiftable-no :
+  ∀ {χ : StoreChange}{M : Term} →
+  No• M →
+  Shiftable χ M
+shiftable-no {χ = keep} noM = shift-keep
+shiftable-no {χ = bind A} noM = shift-bind noM
+
+runtime-value-no• :
+  ∀ {V : Term} →
+  RuntimeOK V →
+  Value V →
+  No• V
+runtime-value-no• (ok-no noV) vV = noV
+runtime-value-no• (ok-• vV noV) ()
+runtime-value-no• (ok-·₁ okL noM) ()
+runtime-value-no• (ok-·₂ vV noV okM) ()
+runtime-value-no• (ok-ν okL) ()
+runtime-value-no• (ok-⊕₁ okL noM) ()
+runtime-value-no• (ok-⊕₂ vL noL okM) ()
+runtime-value-no• (ok-⟨⟩ okM) (vM ⟨ i ⟩) =
+  no•-⟨⟩ (runtime-value-no• okM vM)
 
 ------------------------------------------------------------------------
 -- Progress
 ------------------------------------------------------------------------
 
-progress :
-  ∀ {Δ : TyCtx}{Σ : Store}{M : Term}{A : Ty} →
-  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
-  Progress {Δ = Δ} {Σ = Σ} M
-progress (⊢` ())
-progress (⊢ƛ hA hM) = done (ƛ _)
-progress (⊢· {L = L} {M = M} L⊢ M⊢) with progress L⊢
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | step L→L′ =
-  step (ξ-·₁ L→L′)
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | crash refl =
-  step (pure-step blame-·₁)
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | done vL with progress M⊢
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | done vL | step M→M′ =
-  step (ξ-·₂ vL M→M′)
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | done vL | crash refl =
-  step (pure-step (blame-·₂ vL))
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | done vL | done vM
-    with canonical-⇒ vL L⊢
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | done vL | done vM
-    | fv-ƛ refl =
-  step (pure-step (β vM))
-progress (⊢· {L = L} {M = M} L⊢ M⊢) | done vL | done vM
-    | fv-↦ vW refl =
-  step (pure-step (β-↦ vW vM))
-progress (⊢Λ vM hM) = done (Λ vM)
-progress {Δ = Δ} {Σ = Σ}
-    (⊢ν {L = L} {A = A} {c = c} hA L⊢ c⊢)
-    with progress L⊢
-progress {Δ = Δ} {Σ = Σ}
-    (⊢ν {L = L} {A = A} {c = c} hA L⊢ c⊢)
-    | step L→L′ =
-  step (ξ-ν L→L′)
-progress {Δ = Δ} {Σ = Σ}
-    (⊢ν {L = L} {A = A} {c = c} hA L⊢ c⊢)
-    | crash refl =
-  step blame-ν
-progress {Δ = Δ} {Σ = Σ}
-    (⊢ν {L = L} {A = A} {c = c} hA L⊢ c⊢)
-    | done vL with type-app-progress
-        {α = freshSealAbove Δ Σ}
-        {cs = (c [ freshSealAbove Δ Σ ]ᶜ) ∷ []}
-        vL L⊢
-progress {Δ = Δ} {Σ = Σ}
-    (⊢ν {L = L} {A = A} {c = c} hA L⊢ c⊢)
-    | done vL | tap L↠V =
-  step
-    (ν-step {A = A} {α = freshSealAbove Δ Σ}
-      (m≤m⊔n Δ (freshSeal Σ))
-      (freshSealAbove∉ Δ Σ)
-      L↠V)
-progress (⊢$ κ) = done ($ κ)
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) with progress L⊢
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) | step L→L′ =
-  step (ξ-⊕₁ L→L′)
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) | crash refl =
-  step (pure-step blame-⊕₁)
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) | done vL with progress M⊢
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) | done vL | step M→M′ =
-  step (ξ-⊕₂ vL M→M′)
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) | done vL | crash refl =
-  step (pure-step (blame-⊕₂ vL))
-progress (⊢⊕ {L = L} {M = M} L⊢ op M⊢) | done vL | done vM
-    with canonical-ℕ vL L⊢ | canonical-ℕ vM M⊢
-progress (⊢⊕ {L = L} {M = M} L⊢ addℕ M⊢)
-    | done vL | done vM | nv-const refl | nv-const refl =
-  step (pure-step δ-⊕)
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) with progress M⊢
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | step M→M′ =
-  step (ξ-⟨⟩ M→M′)
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | crash refl =
-  step (pure-step blame-⟨⟩)
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM with c⊢
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-id hA _ =
-  step (pure-step (β-id vM))
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-seal hA hα _ =
-  done (vM ⟨ seal _ _ ⟩)
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-unseal hA hα _ =
-  unseal-progress vM M⊢
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-seq p⊢ q⊢ =
-  step (pure-step (β-seq vM))
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-tag hG gG _ =
-  done (vM ⟨ _ ! ⟩)
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-untag hG gG _ =
-  untag-progress vM M⊢
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM
-    | cast-fun p⊢ q⊢ =
-  done (vM ⟨ _ ↦ _ ⟩)
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢) | done vM | cast-all cwt =
-  done (vM ⟨ `∀ _ ⟩)
-progress {Σ = Σ} (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢)
-    | done vM | cast-inst _ _ cwt =
-  step (pure-step (β-inst vM))
-progress (⊢⟨⟩ {M = M} {c = c} c⊢ M⊢)
-    | done vM | cast-gen _ _ cwt =
-  done (vM ⟨ gen _ _ ⟩)
-progress (⊢blame hA) = crash refl
+mutual
+
+  progress :
+    ∀ {Δ : TyCtx}{Σ : Store}{M : Term}{A : Ty} →
+    RuntimeOK M →
+    Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+    Progress {Δ = Δ} {Σ = Σ} M
+  progress ok (⊢` ())
+  progress ok (⊢ƛ hA hM) = done (ƛ _)
+  progress (ok-no (no•-· noL noM)) (⊢· L⊢ M⊢) =
+    progress-·₁ (ok-no noL) noM L⊢ M⊢
+  progress (ok-·₁ okL noM) (⊢· L⊢ M⊢) =
+    progress-·₁ okL noM L⊢ M⊢
+  progress (ok-·₂ vL noL okM) (⊢· L⊢ M⊢) =
+    progress-·₂ vL noL okM L⊢ M⊢
+  progress ok (⊢Λ vM hM) = done (Λ vM)
+  progress ok (⊢• refl refl hC vV noV hV) =
+    type-app-progress vV noV hV
+  progress (ok-no (no•-ν noL)) (⊢ν hA L⊢ c⊢) =
+    progress-ν (ok-no noL) hA L⊢ c⊢
+  progress (ok-ν okL) (⊢ν hA L⊢ c⊢) =
+    progress-ν okL hA L⊢ c⊢
+  progress ok (⊢$ κ) = done ($ κ)
+  progress (ok-no (no•-⊕ noL noM)) (⊢⊕ L⊢ op M⊢) =
+    progress-⊕₁ (ok-no noL) noM L⊢ M⊢
+  progress (ok-⊕₁ okL noM) (⊢⊕ L⊢ op M⊢) =
+    progress-⊕₁ okL noM L⊢ M⊢
+  progress (ok-⊕₂ vL noL okM) (⊢⊕ L⊢ op M⊢) =
+    progress-⊕₂ vL noL okM L⊢ M⊢
+  progress (ok-no (no•-⟨⟩ noM)) (⊢⟨⟩ c⊢ M⊢) =
+    progress-cast (ok-no noM) c⊢ M⊢
+  progress (ok-⟨⟩ okM) (⊢⟨⟩ c⊢ M⊢) =
+    progress-cast okM c⊢ M⊢
+  progress ok (⊢blame hA) = crash refl
+
+  progress-·₁ :
+    ∀ {Δ : TyCtx}{Σ : Store}{L M : Term}{A B : Ty} →
+    RuntimeOK L →
+    No• M →
+    Δ ∣ Σ ∣ [] ⊢ L ⦂ A ⇒ B →
+    Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+    Progress {Δ = Δ} {Σ = Σ} (L · M)
+  progress-·₁ okL noM L⊢ M⊢ with progress okL L⊢
+  progress-·₁ okL noM L⊢ M⊢ | step L→L′ =
+    step (ξ-·₁ L→L′ (shiftable-no noM))
+  progress-·₁ okL noM L⊢ M⊢ | crash refl =
+    step (pure-step blame-·₁)
+  progress-·₁ okL noM L⊢ M⊢ | done vL =
+    progress-·₂ vL (runtime-value-no• okL vL) (ok-no noM) L⊢ M⊢
+
+  progress-·₂ :
+    ∀ {Δ : TyCtx}{Σ : Store}{V M : Term}{A B : Ty} →
+    Value V →
+    No• V →
+    RuntimeOK M →
+    Δ ∣ Σ ∣ [] ⊢ V ⦂ A ⇒ B →
+    Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+    Progress {Δ = Δ} {Σ = Σ} (V · M)
+  progress-·₂ vV noV okM V⊢ M⊢ with progress okM M⊢
+  progress-·₂ vV noV okM V⊢ M⊢ | step M→M′ =
+    step (ξ-·₂ vV (shiftable-no noV) M→M′)
+  progress-·₂ vV noV okM V⊢ M⊢ | crash refl =
+    step (pure-step (blame-·₂ vV))
+  progress-·₂ vV noV okM V⊢ M⊢ | done vM
+      with canonical-⇒ vV V⊢
+  progress-·₂ vV noV okM V⊢ M⊢ | done vM | fv-ƛ refl =
+    step (pure-step (β vM))
+  progress-·₂ vV noV okM V⊢ M⊢ | done vM | fv-↦ vW refl =
+    step (pure-step (β-↦ vW vM))
+
+  progress-ν :
+    ∀ {Δ : TyCtx}{Σ : Store}{A B C : Ty}{L : Term}
+      {c : Coercion}{μ : ModeEnv} →
+    RuntimeOK L →
+    WfTy Δ A →
+    Δ ∣ Σ ∣ [] ⊢ L ⦂ `∀ C →
+    μ ∣ suc Δ ∣ (0 , ⇑ᵗ A) ∷ ⟰ᵗ Σ ⊢ c ∶ C =⇒ ⇑ᵗ B →
+    Progress {Δ = Δ} {Σ = Σ} (ν A L c)
+  progress-ν okL hA L⊢ c⊢ with progress okL L⊢
+  progress-ν okL hA L⊢ c⊢ | step L→L′ =
+    step (ξ-ν L→L′)
+  progress-ν okL hA L⊢ c⊢ | crash refl =
+    step blame-ν
+  progress-ν okL hA L⊢ c⊢ | done vL =
+    step (ν-step vL (runtime-value-no• okL vL))
+
+  progress-⊕₁ :
+    ∀ {Δ : TyCtx}{Σ : Store}{L M : Term}{op : Prim} →
+    RuntimeOK L →
+    No• M →
+    Δ ∣ Σ ∣ [] ⊢ L ⦂ ‵ `ℕ →
+    Δ ∣ Σ ∣ [] ⊢ M ⦂ ‵ `ℕ →
+    Progress {Δ = Δ} {Σ = Σ} (L ⊕[ op ] M)
+  progress-⊕₁ okL noM L⊢ M⊢ with progress okL L⊢
+  progress-⊕₁ okL noM L⊢ M⊢ | step L→L′ =
+    step (ξ-⊕₁ L→L′ (shiftable-no noM))
+  progress-⊕₁ okL noM L⊢ M⊢ | crash refl =
+    step (pure-step blame-⊕₁)
+  progress-⊕₁ okL noM L⊢ M⊢ | done vL =
+    progress-⊕₂ vL (runtime-value-no• okL vL) (ok-no noM) L⊢ M⊢
+
+  progress-⊕₂ :
+    ∀ {Δ : TyCtx}{Σ : Store}{L M : Term}{op : Prim} →
+    Value L →
+    No• L →
+    RuntimeOK M →
+    Δ ∣ Σ ∣ [] ⊢ L ⦂ ‵ `ℕ →
+    Δ ∣ Σ ∣ [] ⊢ M ⦂ ‵ `ℕ →
+    Progress {Δ = Δ} {Σ = Σ} (L ⊕[ op ] M)
+  progress-⊕₂ vL noL okM L⊢ M⊢ with progress okM M⊢
+  progress-⊕₂ vL noL okM L⊢ M⊢ | step M→M′ =
+    step (ξ-⊕₂ vL (shiftable-no noL) M→M′)
+  progress-⊕₂ vL noL okM L⊢ M⊢ | crash refl =
+    step (pure-step (blame-⊕₂ vL))
+  progress-⊕₂ {op = addℕ} vL noL okM L⊢ M⊢ | done vM
+      with canonical-ℕ vL L⊢ | canonical-ℕ vM M⊢
+  progress-⊕₂ {op = addℕ} vL noL okM L⊢ M⊢
+      | done vM | nv-const refl | nv-const refl =
+    step (pure-step δ-⊕)
+
+  progress-cast :
+    ∀ {Δ : TyCtx}{Σ : Store}{M : Term}{A B : Ty}
+      {c : Coercion}{μ : ModeEnv} →
+    RuntimeOK M →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+    Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+    Progress {Δ = Δ} {Σ = Σ} (M ⟨ c ⟩)
+  progress-cast okM c⊢ M⊢ with progress okM M⊢
+  progress-cast okM c⊢ M⊢ | step M→M′ =
+    step (ξ-⟨⟩ M→M′)
+  progress-cast okM c⊢ M⊢ | crash refl =
+    step (pure-step blame-⟨⟩)
+  progress-cast okM c⊢ M⊢ | done vM with c⊢
+  progress-cast okM c⊢ M⊢ | done vM | cast-id hA _ =
+    step (pure-step (β-id vM))
+  progress-cast okM c⊢ M⊢ | done vM | cast-seal hA hα _ =
+    done (vM ⟨ seal _ _ ⟩)
+  progress-cast okM c⊢ M⊢ | done vM | cast-unseal hA hα _ =
+    unseal-progress vM M⊢
+  progress-cast okM c⊢ M⊢ | done vM | cast-seq p⊢ q⊢ =
+    step (pure-step (β-seq vM))
+  progress-cast okM c⊢ M⊢ | done vM | cast-tag hG gG _ =
+    done (vM ⟨ _ ! ⟩)
+  progress-cast okM c⊢ M⊢ | done vM | cast-untag hG gG _ =
+    untag-progress vM M⊢
+  progress-cast okM c⊢ M⊢ | done vM | cast-fun p⊢ q⊢ =
+    done (vM ⟨ _ ↦ _ ⟩)
+  progress-cast okM c⊢ M⊢ | done vM | cast-all cwt =
+    done (vM ⟨ `∀ _ ⟩)
+  progress-cast okM c⊢ M⊢ | done vM | cast-inst _ _ cwt =
+    step (pure-step (β-inst vM))
+  progress-cast okM c⊢ M⊢ | done vM | cast-gen _ _ cwt =
+    done (vM ⟨ gen _ _ ⟩)

--- a/GTSF/proof/NuStoreProperties.agda
+++ b/GTSF/proof/NuStoreProperties.agda
@@ -12,9 +12,10 @@ open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_)
 open import Data.List.Membership.Propositional using (_∈_; _∉_)
 open import Data.List.Relation.Unary.Any using (here; there)
-open import Data.Nat using (suc; _<_; _≤_)
+open import Data.Nat using (zero; suc; _<_; _≤_; z<s)
 open import Data.Nat.Properties using (<-≤-trans)
-open import Data.Product using (_,_)
+open import Data.Product using (_×_; _,_; ∃; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; sym; trans)
 
 open import Types
 open import NuStore
@@ -110,17 +111,9 @@ StoreWf-fresh-ext wfΣ Δ≤Δ′ Δ≤α α<Δ′ hA α∉Σ =
   record
     { at = StoreWfAt-cons α<Δ′ (WfTy-weakenᵗ hA Δ≤Δ′)
              (StoreWfAt-weaken Δ≤Δ′ (at wfΣ))
-    ; wfOlder = wfOlder′
     ; unique = unique′
     }
   where
-    wfOlder′ :
-      ∀ {β B} →
-      (β , B) ∈ ((_ , _) ∷ _) →
-      WfTy β B
-    wfOlder′ (here refl) = WfTy-weakenᵗ hA Δ≤α
-    wfOlder′ (there hB) = wfOlder wfΣ hB
-
     unique′ :
       ∀ {β B C} →
       (β , B) ∈ ((_ , _) ∷ _) →
@@ -130,6 +123,65 @@ StoreWf-fresh-ext wfΣ Δ≤Δ′ Δ≤α α<Δ′ hA α∉Σ =
     unique′ (here refl) (there hB) = ⊥-elim (α∉Σ (∈-domˢ hB))
     unique′ (there hA) (here refl) = ⊥-elim (α∉Σ (∈-domˢ hA))
     unique′ (there hA) (there hB) = unique wfΣ hA hB
+
+∈-⟰ᵗ-inv :
+  ∀ {Σ α B} →
+  (suc α , B) ∈ ⟰ᵗ Σ →
+  ∃[ A ] (B ≡ ⇑ᵗ A × (α , A) ∈ Σ)
+∈-⟰ᵗ-inv {Σ = (α , A) ∷ Σ} (here refl) =
+  A , refl , here refl
+∈-⟰ᵗ-inv {Σ = (β , C) ∷ Σ} (there h)
+    with ∈-⟰ᵗ-inv h
+∈-⟰ᵗ-inv {Σ = (β , C) ∷ Σ} (there h)
+    | A , eq , h′ =
+  A , eq , there h′
+
+∈-⟰ᵗ-zero :
+  ∀ {Σ A} →
+  (zero , A) ∈ ⟰ᵗ Σ →
+  ⊥
+∈-⟰ᵗ-zero {Σ = (α , B) ∷ Σ} (there h) =
+  ∈-⟰ᵗ-zero h
+
+StoreUnique-⟰ᵗ :
+  ∀ {Σ} →
+  (∀ {α A B} → (α , A) ∈ Σ → (α , B) ∈ Σ → A ≡ B) →
+  ∀ {α A B} → (α , A) ∈ ⟰ᵗ Σ → (α , B) ∈ ⟰ᵗ Σ → A ≡ B
+StoreUnique-⟰ᵗ uniqueΣ {α = zero} h₁ h₂ =
+  ⊥-elim (∈-⟰ᵗ-zero h₁)
+StoreUnique-⟰ᵗ uniqueΣ {α = suc α} h₁ h₂
+    with ∈-⟰ᵗ-inv h₁ | ∈-⟰ᵗ-inv h₂
+StoreUnique-⟰ᵗ uniqueΣ {α = suc α} h₁ h₂
+    | A , eq₁ , h₁′ | B , eq₂ , h₂′ =
+  trans eq₁ (trans (cong ⇑ᵗ (uniqueΣ h₁′ h₂′)) (sym eq₂))
+
+StoreUnique-bind :
+  ∀ {Σ Aν} →
+  (∀ {α A B} → (α , A) ∈ Σ → (α , B) ∈ Σ → A ≡ B) →
+  ∀ {α A B} →
+  (α , A) ∈ ((zero , Aν) ∷ ⟰ᵗ Σ) →
+  (α , B) ∈ ((zero , Aν) ∷ ⟰ᵗ Σ) →
+  A ≡ B
+StoreUnique-bind uniqueΣ (here refl) (here refl) = refl
+StoreUnique-bind uniqueΣ (here refl) (there h) =
+  ⊥-elim (∈-⟰ᵗ-zero h)
+StoreUnique-bind uniqueΣ (there h) (here refl) =
+  ⊥-elim (∈-⟰ᵗ-zero h)
+StoreUnique-bind uniqueΣ (there h₁) (there h₂) =
+  StoreUnique-⟰ᵗ uniqueΣ h₁ h₂
+
+StoreWf-bind :
+  ∀ {Δ Σ A} →
+  StoreWf Δ Σ →
+  WfTy Δ A →
+  StoreWf (suc Δ) ((zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ)
+StoreWf-bind wfΣ hA =
+  record
+    { at = StoreWfAt-cons z<s
+             (renameᵗ-preserves-WfTy hA TyRenameWf-suc)
+             (StoreWfAt-⟰ᵗ (at wfΣ))
+    ; unique = StoreUnique-bind (unique wfΣ)
+    }
 
 ------------------------------------------------------------------------
 -- Store membership transport

--- a/GTSF/proof/NuTermProperties.agda
+++ b/GTSF/proof/NuTermProperties.agda
@@ -56,6 +56,16 @@ lookup-⤊-elim {Γ = A ∷ Γ} {x = zero} k Z = k Z refl
 lookup-⤊-elim {Γ = A ∷ Γ} {x = suc x} k (S h) =
   lookup-⤊-elim (λ hA eq → k (S hA) eq) h
 
+lookup-⤊-elim₀ :
+  ∀ {Γ x B} {R : Set} →
+  (∀ {A} → Γ ∋ x ⦂ A → B ≡ ⇑ᵗ A → R) →
+  ⤊ᵗ Γ ∋ x ⦂ B →
+  R
+lookup-⤊-elim₀ {Γ = []} k ()
+lookup-⤊-elim₀ {Γ = A ∷ Γ} {x = zero} k Z = k Z refl
+lookup-⤊-elim₀ {Γ = A ∷ Γ} {x = suc x} k (S h) =
+  lookup-⤊-elim₀ (λ hA eq → k (S hA) eq) h
+
 map-renameᵗ-⤊ :
   ∀ ρ Γ →
   map (renameᵗ (extᵗ ρ)) (⤊ᵗ Γ) ≡ ⤊ᵗ (map (renameᵗ ρ) Γ)
@@ -191,6 +201,75 @@ substˣᵐ-preserves-Value σ ($ κ) = $ κ
 substˣᵐ-preserves-Value σ (vV ⟨ i ⟩) =
   substˣᵐ-preserves-Value σ vV ⟨ i ⟩
 
+renameˣ-renameᵗᵐ :
+  ∀ ρ τ M →
+  renameˣᵐ ρ (renameᵗᵐ τ M) ≡ renameᵗᵐ τ (renameˣᵐ ρ M)
+renameˣ-renameᵗᵐ ρ τ (` x) = refl
+renameˣ-renameᵗᵐ ρ τ (ƛ M) =
+  cong ƛ_ (renameˣ-renameᵗᵐ (extʳ ρ) τ M)
+renameˣ-renameᵗᵐ ρ τ (L · M) =
+  cong₂ _·_ (renameˣ-renameᵗᵐ ρ τ L)
+             (renameˣ-renameᵗᵐ ρ τ M)
+renameˣ-renameᵗᵐ ρ τ (Λ M) =
+  cong Λ_ (renameˣ-renameᵗᵐ ρ (extᵗ τ) M)
+renameˣ-renameᵗᵐ ρ τ (M •) =
+  cong _• (renameˣ-renameᵗᵐ ρ τ M)
+renameˣ-renameᵗᵐ ρ τ (ν A L c) =
+  cong (λ L′ → ν (renameᵗ τ A) L′ (renameᶜ (extᵗ τ) c))
+       (renameˣ-renameᵗᵐ ρ τ L)
+renameˣ-renameᵗᵐ ρ τ ($ κ) = refl
+renameˣ-renameᵗᵐ ρ τ (L ⊕[ op ] M) =
+  cong₂ (λ L′ M′ → L′ ⊕[ op ] M′)
+        (renameˣ-renameᵗᵐ ρ τ L)
+        (renameˣ-renameᵗᵐ ρ τ M)
+renameˣ-renameᵗᵐ ρ τ (M ⟨ c ⟩) =
+  cong (λ M′ → M′ ⟨ renameᶜ τ c ⟩) (renameˣ-renameᵗᵐ ρ τ M)
+renameˣ-renameᵗᵐ ρ τ blame = refl
+
+renameᵗᵐ-preserves-No• :
+  ∀ ρ {M} →
+  No• M →
+  No• (renameᵗᵐ ρ M)
+renameᵗᵐ-preserves-No• ρ no•-` = no•-`
+renameᵗᵐ-preserves-No• ρ (no•-ƛ hM) =
+  no•-ƛ (renameᵗᵐ-preserves-No• ρ hM)
+renameᵗᵐ-preserves-No• ρ (no•-· hL hM) =
+  no•-· (renameᵗᵐ-preserves-No• ρ hL)
+        (renameᵗᵐ-preserves-No• ρ hM)
+renameᵗᵐ-preserves-No• ρ (no•-Λ hM) =
+  no•-Λ (renameᵗᵐ-preserves-No• (extᵗ ρ) hM)
+renameᵗᵐ-preserves-No• ρ (no•-ν hL) =
+  no•-ν (renameᵗᵐ-preserves-No• ρ hL)
+renameᵗᵐ-preserves-No• ρ no•-$ = no•-$
+renameᵗᵐ-preserves-No• ρ (no•-⊕ hL hM) =
+  no•-⊕ (renameᵗᵐ-preserves-No• ρ hL)
+         (renameᵗᵐ-preserves-No• ρ hM)
+renameᵗᵐ-preserves-No• ρ (no•-⟨⟩ hM) =
+  no•-⟨⟩ (renameᵗᵐ-preserves-No• ρ hM)
+renameᵗᵐ-preserves-No• ρ no•-blame = no•-blame
+
+renameˣᵐ-preserves-No• :
+  ∀ ρ {M} →
+  No• M →
+  No• (renameˣᵐ ρ M)
+renameˣᵐ-preserves-No• ρ no•-` = no•-`
+renameˣᵐ-preserves-No• ρ (no•-ƛ hM) =
+  no•-ƛ (renameˣᵐ-preserves-No• (extʳ ρ) hM)
+renameˣᵐ-preserves-No• ρ (no•-· hL hM) =
+  no•-· (renameˣᵐ-preserves-No• ρ hL)
+        (renameˣᵐ-preserves-No• ρ hM)
+renameˣᵐ-preserves-No• ρ (no•-Λ hM) =
+  no•-Λ (renameˣᵐ-preserves-No• ρ hM)
+renameˣᵐ-preserves-No• ρ (no•-ν hL) =
+  no•-ν (renameˣᵐ-preserves-No• ρ hL)
+renameˣᵐ-preserves-No• ρ no•-$ = no•-$
+renameˣᵐ-preserves-No• ρ (no•-⊕ hL hM) =
+  no•-⊕ (renameˣᵐ-preserves-No• ρ hL)
+         (renameˣᵐ-preserves-No• ρ hM)
+renameˣᵐ-preserves-No• ρ (no•-⟨⟩ hM) =
+  no•-⟨⟩ (renameˣᵐ-preserves-No• ρ hM)
+renameˣᵐ-preserves-No• ρ no•-blame = no•-blame
+
 ------------------------------------------------------------------------
 -- Weakening over type-context and store growth
 ------------------------------------------------------------------------
@@ -199,40 +278,45 @@ term-weaken :
   ∀ {Δ Δ′ Σ Σ′ Γ M A} →
   Δ ≤ Δ′ →
   StoreIncl Σ Σ′ →
+  No• M →
   Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
   Δ′ ∣ Σ′ ∣ Γ ⊢ M ⦂ A
-term-weaken Δ≤Δ′ incl (⊢` h) = ⊢` h
-term-weaken Δ≤Δ′ incl (⊢ƛ hA hM) =
-  ⊢ƛ (WfTy-weakenᵗ hA Δ≤Δ′) (term-weaken Δ≤Δ′ incl hM)
-term-weaken Δ≤Δ′ incl (⊢· hL hM) =
-  ⊢· (term-weaken Δ≤Δ′ incl hL) (term-weaken Δ≤Δ′ incl hM)
-term-weaken Δ≤Δ′ incl (⊢Λ vV hV) =
+term-weaken Δ≤Δ′ incl no•-` (⊢` h) = ⊢` h
+term-weaken Δ≤Δ′ incl (no•-ƛ noM) (⊢ƛ hA hM) =
+  ⊢ƛ (WfTy-weakenᵗ hA Δ≤Δ′) (term-weaken Δ≤Δ′ incl noM hM)
+term-weaken Δ≤Δ′ incl (no•-· noL noM) (⊢· hL hM) =
+  ⊢· (term-weaken Δ≤Δ′ incl noL hL)
+     (term-weaken Δ≤Δ′ incl noM hM)
+term-weaken Δ≤Δ′ incl (no•-Λ noM) (⊢Λ vV hV) =
   ⊢Λ vV
-    (term-weaken (s≤s Δ≤Δ′) (renameStoreᵗ-incl suc incl) hV)
-term-weaken Δ≤Δ′ incl (⊢ν hA hL c⊢) =
+    (term-weaken (s≤s Δ≤Δ′) (renameStoreᵗ-incl suc incl) noM hV)
+term-weaken Δ≤Δ′ incl () (⊢• eqΔ eqΣ hC vV noV hV)
+term-weaken Δ≤Δ′ incl (no•-ν noL) (⊢ν hA hL c⊢) =
   ⊢ν
     (WfTy-weakenᵗ hA Δ≤Δ′)
-    (term-weaken Δ≤Δ′ incl hL)
+    (term-weaken Δ≤Δ′ incl noL hL)
     (coercion-weakenᵐ
       (s≤s Δ≤Δ′)
       (StoreIncl-cons (renameStoreᵗ-incl suc incl))
       c⊢)
-term-weaken Δ≤Δ′ incl (⊢$ κ) = ⊢$ κ
-term-weaken Δ≤Δ′ incl (⊢⊕ hL op hM) =
-  ⊢⊕ (term-weaken Δ≤Δ′ incl hL) op (term-weaken Δ≤Δ′ incl hM)
-term-weaken Δ≤Δ′ incl (⊢⟨⟩ c⊢ hM) =
+term-weaken Δ≤Δ′ incl no•-$ (⊢$ κ) = ⊢$ κ
+term-weaken Δ≤Δ′ incl (no•-⊕ noL noM) (⊢⊕ hL op hM) =
+  ⊢⊕ (term-weaken Δ≤Δ′ incl noL hL) op
+      (term-weaken Δ≤Δ′ incl noM hM)
+term-weaken Δ≤Δ′ incl (no•-⟨⟩ noM) (⊢⟨⟩ c⊢ hM) =
   ⊢⟨⟩
     (coercion-weakenᵐ Δ≤Δ′ incl c⊢)
-    (term-weaken Δ≤Δ′ incl hM)
-term-weaken Δ≤Δ′ incl (⊢blame hA) =
+    (term-weaken Δ≤Δ′ incl noM hM)
+term-weaken Δ≤Δ′ incl no•-blame (⊢blame hA) =
   ⊢blame (WfTy-weakenᵗ hA Δ≤Δ′)
 
 term-weaken-suc :
   ∀ {Δ Σ Γ M A α C} →
+  No• M →
   Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
   suc Δ ∣ (α , C) ∷ Σ ∣ Γ ⊢ M ⦂ A
-term-weaken-suc {Δ = Δ} hM =
-  term-weaken (n≤1+n Δ) StoreIncl-drop hM
+term-weaken-suc {Δ = Δ} noM hM =
+  term-weaken (n≤1+n Δ) StoreIncl-drop noM hM
 
 ------------------------------------------------------------------------
 -- Renaming type variables in typing derivations
@@ -296,20 +380,22 @@ typing-renameᵀ-scoped :
   CtxWf Δ Γ →
   TyRenameWf Δ Δ′ ρ →
   ModeRenamer Δ ρ →
+  No• M →
   Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
   Δ′ ∣ renameStoreᵗ ρ Σ ∣ map (renameᵗ ρ) Γ
     ⊢ renameᵗᵐ ρ M ⦂ renameᵗ ρ A
-typing-renameᵀ-scoped wfΣ hΓ hρ η (⊢` h) =
+typing-renameᵀ-scoped wfΣ hΓ hρ η no•-` (⊢` h) =
   ⊢` (lookup-map-renameᵗ h)
-typing-renameᵀ-scoped wfΣ hΓ hρ η (⊢ƛ hA hM) =
+typing-renameᵀ-scoped wfΣ hΓ hρ η (no•-ƛ noM) (⊢ƛ hA hM) =
   ⊢ƛ (renameᵗ-preserves-WfTy hA hρ)
       (typing-renameᵀ-scoped
-        wfΣ (ctxWf-∷ hA hΓ) hρ η hM)
-typing-renameᵀ-scoped wfΣ hΓ hρ η (⊢· hL hM) =
-  ⊢· (typing-renameᵀ-scoped wfΣ hΓ hρ η hL)
-     (typing-renameᵀ-scoped wfΣ hΓ hρ η hM)
+        wfΣ (ctxWf-∷ hA hΓ) hρ η noM hM)
+typing-renameᵀ-scoped wfΣ hΓ hρ η (no•-· noL noM) (⊢· hL hM) =
+  ⊢· (typing-renameᵀ-scoped wfΣ hΓ hρ η noL hL)
+     (typing-renameᵀ-scoped wfΣ hΓ hρ η noM hM)
 typing-renameᵀ-scoped {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
-    wfΣ hΓ hρ η (⊢Λ {M = M} {A = A} vM hM) =
+    wfΣ hΓ hρ η (no•-Λ noM)
+    (⊢Λ {M = M} {A = A} vM hM) =
   ⊢Λ
     (renameᵗᵐ-preserves-Value (extᵗ ρ) vM)
     (subst
@@ -326,20 +412,24 @@ typing-renameᵀ-scoped {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
           (CtxWf-⤊ hΓ)
           (TyRenameWf-ext hρ)
           (ModeRenamer-ext η)
+          noM
           hM)))
+typing-renameᵀ-scoped wfΣ hΓ hρ η () (⊢• eqΔ eqΣ hC vV noV hV)
 typing-renameᵀ-scoped {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
     wfΣ hΓ hρ η
+    (no•-ν noL)
     (⊢ν {L = L} {A = A} {B = B} {C = C} {c = c} {μ = μ}
       hA hL c⊢)
     with ModeRenamer-ext η μ
 typing-renameᵀ-scoped {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
     wfΣ hΓ hρ η
+    (no•-ν noL)
     (⊢ν {L = L} {A = A} {B = B} {C = C} {c = c} {μ = μ}
       hA hL c⊢)
     | target , rel =
   ⊢ν {μ = target}
     (renameᵗ-preserves-WfTy hA hρ)
-    (typing-renameᵀ-scoped wfΣ hΓ hρ η hL)
+    (typing-renameᵀ-scoped wfΣ hΓ hρ η noL hL)
     (subst
       (λ T →
         target ∣ suc Δ′
@@ -361,23 +451,25 @@ typing-renameᵀ-scoped {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
           (TyRenameWf-ext hρ)
           rel
           c⊢)))
-typing-renameᵀ-scoped {ρ = ρ} wfΣ hΓ hρ η (⊢$ κ) =
+typing-renameᵀ-scoped {ρ = ρ} wfΣ hΓ hρ η no•-$ (⊢$ κ) =
   subst (λ T → _ ∣ _ ∣ _ ⊢ $ κ ⦂ T)
         (constTy-renameᵗ ρ κ)
         (⊢$ κ)
-typing-renameᵀ-scoped wfΣ hΓ hρ η (⊢⊕ hL op hM) =
-  ⊢⊕ (typing-renameᵀ-scoped wfΣ hΓ hρ η hL) op
-      (typing-renameᵀ-scoped wfΣ hΓ hρ η hM)
+typing-renameᵀ-scoped wfΣ hΓ hρ η (no•-⊕ noL noM) (⊢⊕ hL op hM) =
+  ⊢⊕ (typing-renameᵀ-scoped wfΣ hΓ hρ η noL hL) op
+      (typing-renameᵀ-scoped wfΣ hΓ hρ η noM hM)
 typing-renameᵀ-scoped {ρ = ρ} wfΣ hΓ hρ η
+    (no•-⟨⟩ noM)
     (⊢⟨⟩ {μ = μ} c⊢ hM)
     with η μ
 typing-renameᵀ-scoped {ρ = ρ} wfΣ hΓ hρ η
+    (no•-⟨⟩ noM)
     (⊢⟨⟩ {μ = μ} c⊢ hM)
     | target , rel =
   ⊢⟨⟩ {μ = target}
     (coercion-renameᵗᵐ-scoped wfΣ hρ rel c⊢)
-    (typing-renameᵀ-scoped wfΣ hΓ hρ η hM)
-typing-renameᵀ-scoped wfΣ hΓ hρ η (⊢blame hA) =
+    (typing-renameᵀ-scoped wfΣ hΓ hρ η noM hM)
+typing-renameᵀ-scoped wfΣ hΓ hρ η no•-blame (⊢blame hA) =
   ⊢blame (renameᵗ-preserves-WfTy hA hρ)
 
 typing-open-freshᵀ :
@@ -387,11 +479,13 @@ typing-open-freshᵀ :
   Δ ≤ Δ′ →
   Δ ≤ α →
   α < Δ′ →
+  No• M →
   suc Δ ∣ ⟰ᵗ Σ ∣ ⤊ᵗ Γ ⊢ M ⦂ A →
   Δ′ ∣ (α , C) ∷ Σ ∣ Γ ⊢ M [ α ]ᵀ ⦂ A [ α ]ᴿ
 typing-open-freshᵀ {Σ = Σ} {Γ = Γ} {M = M} {A = A} {α = α}
-    {C = C} wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ M⊢ =
+    {C = C} wfΣ hΓ Δ≤Δ′ Δ≤α α<Δ′ noM M⊢ =
   term-weaken ≤-refl StoreIncl-drop
+    (renameᵗᵐ-preserves-No• (singleRenameᵗ α) noM)
     (subst
       (λ Γ′ → _ ∣ Σ ∣ Γ′ ⊢ M [ α ]ᵀ ⦂ A [ α ]ᴿ)
       (map-singleRenameᵗ-⤊-cancel α Γ)
@@ -404,25 +498,29 @@ typing-open-freshᵀ {Σ = Σ} {Γ = Γ} {M = M} {A = A} {α = α}
           (CtxWf-⤊ hΓ)
           (singleRenameᵗ-Wf≤ Δ≤Δ′ α<Δ′)
           (openModeRenamer Δ≤α)
+          noM
           M⊢)))
 
 typing-renameᵀ :
   ∀ {Δ Δ′ Σ Γ M A ρ ψ} →
   TyRenameWf Δ Δ′ ρ →
   RenameLeftInverse ρ ψ →
+  No• M →
   Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
   Δ′ ∣ renameStoreᵗ ρ Σ ∣ map (renameᵗ ρ) Γ
     ⊢ renameᵗᵐ ρ M ⦂ renameᵗ ρ A
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢` h) =
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv no•-` (⊢` h) =
   ⊢` (lookup-map-renameᵗ h)
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢ƛ hA hM) =
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (no•-ƛ noM) (⊢ƛ hA hM) =
   ⊢ƛ (renameᵗ-preserves-WfTy hA hρ)
-      (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hM)
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢· hL hM) =
-  ⊢· (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hL)
-     (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hM)
+      (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noM hM)
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv
+    (no•-· noL noM) (⊢· hL hM) =
+  ⊢· (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noL hL)
+     (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noM hM)
 typing-renameᵀ {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
-    {ψ = ψ} hρ inv (⊢Λ {M = M} {A = A} vM hM) =
+    {ψ = ψ} hρ inv (no•-Λ noM)
+    (⊢Λ {M = M} {A = A} vM hM) =
   ⊢Λ
     (renameᵗᵐ-preserves-Value (extᵗ ρ) vM)
     (subst
@@ -438,14 +536,17 @@ typing-renameᵀ {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
           {ρ = extᵗ ρ} {ψ = extᵗ ψ}
           (TyRenameWf-ext hρ)
           (RenameLeftInverse-ext inv)
+          noM
           hM)))
+typing-renameᵀ hρ inv () (⊢• eqΔ eqΣ hC vV noV hV)
 typing-renameᵀ {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
     {ψ = ψ} hρ inv
+    (no•-ν noL)
     (⊢ν {L = L} {A = A} {B = B} {C = C} {c = c} {μ = μ}
       hA hL c⊢) =
   ⊢ν {μ = λ Y → μ (extᵗ ψ Y)}
     (renameᵗ-preserves-WfTy hA hρ)
-    (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hL)
+    (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noL hL)
     (subst
       (λ T →
         (λ Y → μ (extᵗ ψ Y)) ∣ suc Δ′
@@ -463,19 +564,21 @@ typing-renameᵀ {Δ′ = Δ′} {Σ = Σ} {Γ = Γ} {ρ = ρ}
           (modeRename-left-inverse
             {ρ = extᵗ ρ} {ψ = extᵗ ψ} (RenameLeftInverse-ext inv))
           c⊢)))
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢$ κ) =
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv no•-$ (⊢$ κ) =
   subst (λ T → _ ∣ _ ∣ _ ⊢ $ κ ⦂ T)
         (constTy-renameᵗ ρ κ)
         (⊢$ κ)
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢⊕ hL op hM) =
-  ⊢⊕ (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hL) op
-      (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hM)
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢⟨⟩ {μ = μ} c⊢ hM) =
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv
+    (no•-⊕ noL noM) (⊢⊕ hL op hM) =
+  ⊢⊕ (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noL hL) op
+      (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noM hM)
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv
+    (no•-⟨⟩ noM) (⊢⟨⟩ {μ = μ} c⊢ hM) =
   ⊢⟨⟩ {μ = λ Y → μ (ψ Y)}
         (coercion-renameᵗᵐ hρ
           (modeRename-left-inverse {ρ = ρ} {ψ = ψ} inv) c⊢)
-        (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv hM)
-typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv (⊢blame hA) =
+        (typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv noM hM)
+typing-renameᵀ {ρ = ρ} {ψ = ψ} hρ inv no•-blame (⊢blame hA) =
   ⊢blame (renameᵗ-preserves-WfTy hA hρ)
 
 -- The old unrestricted opening lemmas used `singleRenameᵗ`, which is
@@ -505,6 +608,8 @@ typing-wf wfΣ hΓ (⊢· hL hM) with typing-wf wfΣ hΓ hL
 typing-wf wfΣ hΓ (⊢· hL hM) | wf⇒ hA hB = hB
 typing-wf wfΣ hΓ (⊢Λ vM hM) =
   wf∀ (typing-wf (StoreWfAt-⟰ᵗ wfΣ) (CtxWf-⤊ hΓ) hM)
+typing-wf wfΣ hΓ (⊢• {C = C} refl refl hC vV noV hV) =
+  hC
 typing-wf wfΣ hΓ (⊢ν hA hL c⊢)
     with coercion-wfᵐ
       (StoreWfAt-cons
@@ -530,6 +635,9 @@ RenameWf Γ Γ′ ρ = ∀ {x A} → Γ ∋ x ⦂ A → Γ′ ∋ ρ x ⦂ A
 SubstWf : TyCtx → Store → Ctx → Ctx → Substˣ → Set₁
 SubstWf Δ Σ Γ Γ′ σ =
   ∀ {x A} → Γ ∋ x ⦂ A → Δ ∣ Σ ∣ Γ′ ⊢ σ x ⦂ A
+
+SubstNo• : Ctx → Substˣ → Set₁
+SubstNo• Γ σ = ∀ {x A} → Γ ∋ x ⦂ A → No• (σ x)
 
 RenameWf-ext :
   ∀ {Γ Γ′ B ρ} →
@@ -562,6 +670,14 @@ typing-renameˣ {Γ = Γ} {Γ′ = Γ′} {ρ = ρ} hρ
     (⊢Λ vM hM) =
   ⊢Λ (renameˣᵐ-preserves-Value ρ vM)
     (typing-renameˣ (RenameWf-⤊ hρ) hM)
+typing-renameˣ {ρ = ρ} hρ (⊢• {V = V} eqΔ eqΣ hC vV noV hV) =
+  subst
+    (λ M → _ ∣ _ ∣ _ ⊢ M • ⦂ _)
+    (sym (renameˣ-renameᵗᵐ ρ suc V))
+    (⊢• eqΔ eqΣ hC
+        (renameˣᵐ-preserves-Value ρ vV)
+        (renameˣᵐ-preserves-No• ρ noV)
+        (typing-renameˣ hρ hV))
 typing-renameˣ hρ (⊢ν hA hL c⊢) =
   ⊢ν hA (typing-renameˣ hρ hL) c⊢
 typing-renameˣ hρ (⊢$ κ) = ⊢$ κ
@@ -585,59 +701,115 @@ SubstWf-exts :
 SubstWf-exts hσ Z = ⊢` Z
 SubstWf-exts hσ (S h) = typing-renameˣ-shift (hσ h)
 
+SubstNo•-exts :
+  ∀ {Γ B σ} →
+  SubstNo• Γ σ →
+  SubstNo• (B ∷ Γ) (extˢˣ σ)
+SubstNo•-exts hσ Z = no•-`
+SubstNo•-exts hσ (S h) = renameˣᵐ-preserves-No• suc (hσ h)
+
+SubstNo•-⇑ :
+  ∀ {Γ σ} →
+  SubstNo• Γ σ →
+  SubstNo• (⤊ᵗ Γ) (↑ᵗᵐ σ)
+SubstNo•-⇑ hσ h =
+  lookup-⤊-elim₀
+    (λ hA eq → renameᵗᵐ-preserves-No• suc (hσ hA))
+    h
+
 SubstWf-⇑ :
   ∀ {Δ Σ Γ Γ′ σ} →
   SubstWf Δ Σ Γ Γ′ σ →
+  SubstNo• Γ σ →
   SubstWf (suc Δ) (⟰ᵗ Σ) (⤊ᵗ Γ) (⤊ᵗ Γ′) (↑ᵗᵐ σ)
-SubstWf-⇑ hσ h =
+SubstWf-⇑ hσ noσ h =
   lookup-⤊-elim
     (λ hA eq →
       subst (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
             (sym eq)
             (typing-renameᵀ {ρ = suc} {ψ = predᵗ}
-              TyRenameWf-suc RenameLeftInverse-suc (hσ hA)))
+              TyRenameWf-suc RenameLeftInverse-suc (noσ hA) (hσ hA)))
     h
 
 SubstWf-⇑ν :
   ∀ {Δ Σ Γ Γ′ σ A} →
   SubstWf Δ Σ Γ Γ′ σ →
+  SubstNo• Γ σ →
   SubstWf
     (suc Δ)
     ((zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ)
     (⤊ᵗ Γ)
     (⤊ᵗ Γ′)
     (↑ᵗᵐ σ)
-SubstWf-⇑ν hσ h =
+SubstWf-⇑ν hσ noσ h =
   lookup-⤊-elim
     (λ hA eq →
       subst (λ T → _ ∣ _ ∣ _ ⊢ _ ⦂ T)
             (sym eq)
             (term-weaken ≤-refl StoreIncl-drop
+              (renameᵗᵐ-preserves-No• suc (noσ hA))
               (typing-renameᵀ {ρ = suc} {ψ = predᵗ}
-                TyRenameWf-suc RenameLeftInverse-suc (hσ hA))))
+                TyRenameWf-suc RenameLeftInverse-suc
+                (noσ hA)
+                (hσ hA))))
     h
+
+substˣᵐ-preserves-No•-typed :
+  ∀ {Δ Σ Γ M A σ} →
+  SubstNo• Γ σ →
+  No• M →
+  Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
+  No• (substˣᵐ σ M)
+substˣᵐ-preserves-No•-typed noσ no•-` (⊢` h) = noσ h
+substˣᵐ-preserves-No•-typed noσ (no•-ƛ noM) (⊢ƛ hA hM) =
+  no•-ƛ (substˣᵐ-preserves-No•-typed (SubstNo•-exts noσ) noM hM)
+substˣᵐ-preserves-No•-typed noσ (no•-· noL noM) (⊢· hL hM) =
+  no•-· (substˣᵐ-preserves-No•-typed noσ noL hL)
+        (substˣᵐ-preserves-No•-typed noσ noM hM)
+substˣᵐ-preserves-No•-typed noσ (no•-Λ noM) (⊢Λ vM hM) =
+  no•-Λ
+    (substˣᵐ-preserves-No•-typed (SubstNo•-⇑ noσ) noM hM)
+substˣᵐ-preserves-No•-typed noσ () (⊢• eqΔ eqΣ hC vV noV hV)
+substˣᵐ-preserves-No•-typed noσ (no•-ν noL) (⊢ν hA hL c⊢) =
+  no•-ν (substˣᵐ-preserves-No•-typed noσ noL hL)
+substˣᵐ-preserves-No•-typed noσ no•-$ (⊢$ κ) = no•-$
+substˣᵐ-preserves-No•-typed noσ (no•-⊕ noL noM) (⊢⊕ hL op hM) =
+  no•-⊕ (substˣᵐ-preserves-No•-typed noσ noL hL)
+         (substˣᵐ-preserves-No•-typed noσ noM hM)
+substˣᵐ-preserves-No•-typed noσ (no•-⟨⟩ noM) (⊢⟨⟩ c⊢ hM) =
+  no•-⟨⟩ (substˣᵐ-preserves-No•-typed noσ noM hM)
+substˣᵐ-preserves-No•-typed noσ no•-blame (⊢blame hA) = no•-blame
 
 typing-substˣ :
   ∀ {Δ Σ Γ Γ′ M A σ} →
   SubstWf Δ Σ Γ Γ′ σ →
+  SubstNo• Γ σ →
+  No• M →
   Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
   Δ ∣ Σ ∣ Γ′ ⊢ substˣᵐ σ M ⦂ A
-typing-substˣ hσ (⊢` h) = hσ h
-typing-substˣ hσ (⊢ƛ hA hM) =
-  ⊢ƛ hA (typing-substˣ (SubstWf-exts hσ) hM)
-typing-substˣ hσ (⊢· hL hM) =
-  ⊢· (typing-substˣ hσ hL) (typing-substˣ hσ hM)
-typing-substˣ hσ (⊢Λ vM hM) =
+typing-substˣ hσ noσ no•-` (⊢` h) = hσ h
+typing-substˣ hσ noσ (no•-ƛ noM) (⊢ƛ hA hM) =
+  ⊢ƛ hA (typing-substˣ (SubstWf-exts hσ) (SubstNo•-exts noσ) noM hM)
+typing-substˣ hσ noσ (no•-· noL noM) (⊢· hL hM) =
+  ⊢· (typing-substˣ hσ noσ noL hL)
+     (typing-substˣ hσ noσ noM hM)
+typing-substˣ hσ noσ (no•-Λ noM) (⊢Λ vM hM) =
   ⊢Λ (substˣᵐ-preserves-Value _ vM)
-    (typing-substˣ (SubstWf-⇑ hσ) hM)
-typing-substˣ hσ (⊢ν hA hL c⊢) =
-  ⊢ν hA (typing-substˣ hσ hL) c⊢
-typing-substˣ hσ (⊢$ κ) = ⊢$ κ
-typing-substˣ hσ (⊢⊕ hL op hM) =
-  ⊢⊕ (typing-substˣ hσ hL) op (typing-substˣ hσ hM)
-typing-substˣ hσ (⊢⟨⟩ c⊢ hM) =
-  ⊢⟨⟩ c⊢ (typing-substˣ hσ hM)
-typing-substˣ hσ (⊢blame hA) = ⊢blame hA
+    (typing-substˣ
+      (SubstWf-⇑ hσ noσ)
+      (SubstNo•-⇑ noσ)
+      noM
+      hM)
+typing-substˣ hσ noσ () (⊢• eqΔ eqΣ hC vV noV hV)
+typing-substˣ hσ noσ (no•-ν noL) (⊢ν hA hL c⊢) =
+  ⊢ν hA (typing-substˣ hσ noσ noL hL) c⊢
+typing-substˣ hσ noσ no•-$ (⊢$ κ) = ⊢$ κ
+typing-substˣ hσ noσ (no•-⊕ noL noM) (⊢⊕ hL op hM) =
+  ⊢⊕ (typing-substˣ hσ noσ noL hL) op
+      (typing-substˣ hσ noσ noM hM)
+typing-substˣ hσ noσ (no•-⟨⟩ noM) (⊢⟨⟩ c⊢ hM) =
+  ⊢⟨⟩ c⊢ (typing-substˣ hσ noσ noM hM)
+typing-substˣ hσ noσ no•-blame (⊢blame hA) = ⊢blame hA
 
 singleSubstWf :
   ∀ {Δ Σ Γ A V} →
@@ -646,10 +818,19 @@ singleSubstWf :
 singleSubstWf hV Z = hV
 singleSubstWf hV (S h) = ⊢` h
 
+singleSubstNo• :
+  ∀ {Γ A V} →
+  No• V →
+  SubstNo• (A ∷ Γ) (singleEnv V)
+singleSubstNo• noV Z = noV
+singleSubstNo• noV (S h) = no•-`
+
 typing-single-subst :
   ∀ {Δ Σ Γ N V A B} →
+  No• N →
+  No• V →
   Δ ∣ Σ ∣ (A ∷ Γ) ⊢ N ⦂ B →
   Δ ∣ Σ ∣ Γ ⊢ V ⦂ A →
   Δ ∣ Σ ∣ Γ ⊢ N [ V ] ⦂ B
-typing-single-subst hN hV =
-  typing-substˣ (singleSubstWf hV) hN
+typing-single-subst noN noV hN hV =
+  typing-substˣ (singleSubstWf hV) (singleSubstNo• noV) noN hN


### PR DESCRIPTION
## Summary

This PR revises the GTSF Nu runtime semantics experiment to remove the separate type-application machine and replace store-threaded reduction configurations with emitted store changes.

The main changes are:

- Add a runtime-only bullet term `M •` and type it only in the post-ν shape where the operand is a shifted, bullet-free value from the pre-ν context.
- Replace `Δ ∣ Σ ∣ M —→ Δ′ ∣ Σ′ ∣ N` with `M —→[ χ ] N`, where `χ` is either `keep` or `bind A`.
- Interpret store changes through `applyTyCtx`, `applyStore`, `applyTy`, `applyTerm`, and related coercion actions.
- Turn type-application machine transitions into ordinary redex rules for `β-Λ•`, `β-∀•`, and `β-gen•`.
- Track the runtime bullet invariant with `RuntimeOK`, and prove that one-step preservation no longer needs a separate `No• M` premise.
- Add a multi-step closure over lists of store changes and prove multi-step preservation.
- Remove the old `wfOlder` field from Nu `StoreWf`, since fresh-at-zero bindings intentionally violate it.
- Keep the stronger older-than-store invariant as `StoreDetWf` for narrowing/widening determinacy, where it is still genuinely needed.

## Rationale

The design goal is to make `ν-step` allocate type variable `0` and immediately expose a regular runtime type-application redex instead of entering a special type-application machine. Choosing `0` means sibling terms must be shifted when a store binding is emitted, so a step now reports the store change rather than threading a whole resulting store through every rule.

The important invariant is not that every typed runtime term is bullet-free. After `ν-step`, the active term contains a bullet. Instead, `RuntimeOK` describes the intended runtime shape: at most one active bullet, with surrounding evaluation-context structure and bullet-free siblings. The `⊢•` rule records that the bullet operand came from the pre-ν context, which is what makes the zero-opening rules preserve types without requiring a global `No• M` theorem premise.

The previous `wfOlder` store invariant was incompatible with allocating `(0 , ⇑ᵗ A)` as the fresh binding. Preservation only needs store entries to be well-formed at the current type context and unique by variable, so Nu `StoreWf` now keeps those fields. Determinacy proofs that still rely on the older-than-store property now ask for `StoreDetWf` explicitly.

## Validation

- `agda -v0 All.agda` from `GTSF/`