### PR TITLE
Prove catchup extend transport

### DIFF
--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -19,13 +19,14 @@ open import Relation.Binary.PropositionalEquality
   using (cong; cong₂; subst; sym; trans)
 
 open import Types
-open import Store using (StoreIncl; StoreIncl-drop)
+open import Store using (StoreIncl; StoreIncl-cons; StoreIncl-drop)
 open import Coercions
 open import NuTerms
 open import NuReduction
 open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing
+open import Primitives using (κℕ; constTy)
 open import proof.NarrowWidenProperties
   using
     ( StoreDetWf-⟰ᵗ
@@ -35,7 +36,6 @@ open import proof.NarrowWidenProperties
     ; narrow-⇑ᵗ-ᶜ
     ; narrow-⇑ᵗ-ᶜ-srcStoreⁿ
     ; narrow-⇑ᵗ-ᶜ-srcStoreⁿ≤
-    ; narrow-⇑ᵗ-open-srcStoreⁿ
     ; narrow-⇑ᵗ-any
     ; narrow-drop-star-var
     ; narrow-drop-star
@@ -49,11 +49,15 @@ open import proof.NarrowWidenProperties
 open import proof.CoercionProperties
   using
     ( coercion-src-tgtᵐ
+    ; renameᶜ-left-inverse
     ; src-renameᶜ
     ; tgt-renameᶜ
-    ; renameᶜ-open-commute
     )
-open import proof.NuTermProperties using (renameᵗᵐ-preserves-Value)
+open import proof.NuTermProperties
+  using
+    ( renameᵗᵐ-left-inverse
+    ; renameᵗᵐ-preserves-Value
+    )
 open import proof.ReductionProperties
   using
     ( applyCoercions
@@ -718,42 +722,617 @@ catchup-compose-right-transport {χs = χs} r≈t⨟p Δ′≡ Π≡ Π′≡ π
     {χs = χs}
     r≈t⨟p Δ′≡ Π≡ Π′≡ π⊒
 
-postulate
-  -- [New] Extend Prefix Transport.
-  --
-  -- This is not a pre-existing named cambridge25 lemma.  It is the
-  -- mechanization obligation created by the `extend` catchup case after the
-  -- recursive call emits a store-change prefix.
-  --
-  -- Attempted proof notes.  I first tried a generic emitted-prefix transport
-  -- lemma for arbitrary right-hand targets.  That statement is too broad: in
-  -- the `⊒α` case the old target has shape `L′ • α`, but rebuilding
-  -- `extend` requires an opened target `N′ [ α ]ᵀ`.  The rule does not imply
-  -- that `L′ • α` arose from such an opening.  I also tried to make the
-  -- transport depend only on source-store inclusion, but the recursive case
-  -- for a freshly emitted source-only star needs shifted typings for both `q`
-  -- and `p [ α ]ᶜ`; those shifted typings come from the emitted type-context
-  -- history, not from store inclusion alone.
-  --
-  -- Likely path forward: prove this by induction on the emitted store-change
-  -- prefix while carrying the opened-target shape and the shifted side
-  -- typings for `q` and `p [ α ]ᶜ` at each suffix.  The right-only and
-  -- both-side emitted entries should be impossible because catchup emits an
-  -- empty target store.
-  catchup-extend-transport :
-    ∀ {Δ Δ′ σ π Π Π′ χs W N′ α p q A B C D} →
+data ExtendReplaceRel : TyCtx → StoreNrw → StoreNrw → Set where
+  replace-here :
+    ∀ {Δ α q A B σ} →
     Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A →
-    Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
-    Δ′ ≡ applyTyCtxs χs Δ →
-    Π ≡ applyStores χs [] →
-    Π′ ≡ [] →
-    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
-    Δ′ ∣ combineStoreNrw π ((α ꞉= A ⊒) ∷ σ) ∣ []
-      ⊢ W ⊒ applyTerms χs (N′ [ α ]ᵀ)
-        ∶ applyCoercions χs (p [ α ]ᶜ) →
-    Δ′ ∣ combineStoreNrw π ((α ꞉ q) ∷ σ) ∣ []
-      ⊢ W ⊒ applyTerms χs (N′ [ α ]ᵀ)
-        ∶ applyCoercions χs (p [ α ]ᶜ)
+    ExtendReplaceRel Δ ((α ꞉= A ⊒) ∷ σ) ((α ꞉ q) ∷ σ)
+
+  replace-right :
+    ∀ {Δ X A σ σ′} →
+    ExtendReplaceRel Δ σ σ′ →
+    ExtendReplaceRel Δ ((X ꞉= A ⊒) ∷ σ) ((X ꞉= A ⊒) ∷ σ′)
+
+  replace-left :
+    ∀ {Δ X σ σ′} →
+    ExtendReplaceRel Δ σ σ′ →
+    ExtendReplaceRel Δ ((⊒ X ꞉=☆) ∷ σ) ((⊒ X ꞉=☆) ∷ σ′)
+
+  replace-both :
+    ∀ {Δ X q σ σ′} →
+    ExtendReplaceRel Δ σ σ′ →
+    ExtendReplaceRel Δ ((X ꞉ q) ∷ σ) ((X ꞉ q) ∷ σ′)
+
+extendReplaceRel-⇑ˢ :
+  ∀ {Δ σ σ′} →
+  ExtendReplaceRel Δ σ σ′ →
+  ExtendReplaceRel (suc Δ) (⇑ˢ σ) (⇑ˢ σ′)
+extendReplaceRel-⇑ˢ (replace-here {σ = σ} qᶜ) =
+  replace-here (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} qᶜ)
+extendReplaceRel-⇑ˢ (replace-right rel) =
+  replace-right (extendReplaceRel-⇑ˢ rel)
+extendReplaceRel-⇑ˢ (replace-left rel) =
+  replace-left (extendReplaceRel-⇑ˢ rel)
+extendReplaceRel-⇑ˢ (replace-both rel) =
+  replace-both (extendReplaceRel-⇑ˢ rel)
+
+extendReplaceRel-src-incl :
+  ∀ {Δ σ σ′} →
+  ExtendReplaceRel Δ σ σ′ →
+  StoreIncl (srcStoreⁿ σ) (srcStoreⁿ σ′)
+extendReplaceRel-src-incl (replace-here qᶜ) = StoreIncl-drop
+extendReplaceRel-src-incl (replace-right rel) =
+  extendReplaceRel-src-incl rel
+extendReplaceRel-src-incl (replace-left rel) =
+  StoreIncl-cons (extendReplaceRel-src-incl rel)
+extendReplaceRel-src-incl (replace-both rel) =
+  StoreIncl-cons (extendReplaceRel-src-incl rel)
+
+storeIncl-substˡ :
+  ∀ {Σ Σ₀ Σ′} →
+  Σ ≡ Σ₀ →
+  StoreIncl Σ₀ Σ′ →
+  StoreIncl Σ Σ′
+storeIncl-substˡ refl incl = incl
+
+narrow-weaken-store :
+  ∀ {Δ Σ Σ′ c A B} →
+  StoreIncl Σ Σ′ →
+  Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  Δ ∣ Σ′ ⊢ c ∶ A ⊒ B
+narrow-weaken-store incl (μ , c⊒) = μ , narrow-weaken ≤-refl incl c⊒
+
+open-shiftᵐ :
+  ∀ α M →
+  (⇑ᵗᵐ M) [ α ]ᵀ ≡ M
+open-shiftᵐ α M = renameᵗᵐ-left-inverse (λ X → refl) M
+
+open-shiftᶜ :
+  ∀ α c →
+  (⇑ᶜ c) [ α ]ᶜ ≡ c
+open-shiftᶜ α c = renameᶜ-left-inverse (λ X → refl) c
+
+extend-replace-here-term :
+  ∀ {Δ α q A B σ γ M T c C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A →
+  Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ c ∶ᶜ C ⊒ D →
+  Δ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ ⊢ M ⊒ T ∶ c →
+  Δ ∣ (α ꞉ q) ∷ σ ∣ γ ⊢ M ⊒ T ∶ c
+extend-replace-here-term {α = α} {q = q} {A = A} {σ = σ}
+    {γ = γ} {M = M} {T = T} {c = c} qᶜ cᶜ M⊒T =
+  let
+    T≡ = open-shiftᵐ α T
+    c≡ = open-shiftᶜ α c
+    cᶜ′ =
+      subst
+        (λ c₀ → _ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ c₀ ∶ᶜ _ ⊒ _)
+        (sym c≡)
+        cᶜ
+    premise =
+      subst
+        (λ c₀ → _ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ
+          ⊢ M ⊒ (⇑ᵗᵐ T) [ α ]ᵀ ∶ c₀)
+        (sym c≡)
+        (subst
+          (λ T₀ → _ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ ⊢ M ⊒ T₀ ∶ c)
+          (sym T≡)
+          M⊒T)
+    rebuilt = extend qᶜ cᶜ′ premise
+  in
+  subst
+    (λ T₀ → _ ∣ (α ꞉ q) ∷ σ ∣ γ ⊢ M ⊒ T₀ ∶ c)
+    T≡
+    (subst
+      (λ c₀ → _ ∣ (α ꞉ q) ∷ σ ∣ γ
+        ⊢ M ⊒ (⇑ᵗᵐ T) [ α ]ᵀ ∶ c₀)
+      c≡
+      rebuilt)
+
+extendReplaceRel-⊒ˢ :
+  ∀ {Δ σ σ′ Σ Σ′} →
+  ExtendReplaceRel Δ σ σ′ →
+  Δ ⊢ σ ꞉ Σ ⊒ˢ Σ′ →
+  Δ ⊢ σ′ ꞉ srcStoreⁿ σ′ ⊒ˢ Σ′
+extendReplaceRel-⊒ˢ (replace-here {q = q} {A = A} qᶜ)
+    (⊒ˢ-right hA σ⊒) =
+  let
+    srcq≡ = proj₁ (coercion-src-tgtᵐ (proj₁ qᶜ))
+    qᶜ′ =
+      subst
+        (λ S → tag-or-idᵈ ∣ _ ∣ _ ⊢ q ∶ S ⊒ A)
+        (sym srcq≡)
+        qᶜ
+    hsrcq = subst (λ S → WfTy _ S) (sym srcq≡) (narrow-src-wf qᶜ)
+  in
+  ⊒ˢ-both hsrcq hA (tag-or-idᵈ , qᶜ′)
+    (subst (λ Σ₀ → _ ⊢ _ ꞉ Σ₀ ⊒ˢ _) (srcStoreⁿ-⊒ˢ σ⊒) σ⊒)
+extendReplaceRel-⊒ˢ (replace-right rel) (⊒ˢ-right hA σ⊒) =
+  ⊒ˢ-right hA (extendReplaceRel-⊒ˢ rel σ⊒)
+extendReplaceRel-⊒ˢ (replace-left rel) (⊒ˢ-left σ⊒) =
+  ⊒ˢ-left (extendReplaceRel-⊒ˢ rel σ⊒)
+extendReplaceRel-⊒ˢ (replace-both {q = q} rel)
+    (⊒ˢ-both hA hA′ s⊒ σ⊒) =
+  let
+    incl =
+      storeIncl-substˡ (srcStoreⁿ-⊒ˢ σ⊒)
+        (extendReplaceRel-src-incl rel)
+    srcq≡ = proj₁ (coercion-src-tgtᵐ (proj₁ (proj₂ s⊒)))
+    s⊒′ =
+      subst
+        (λ S → _ ∣ _ ⊢ q ∶ S ⊒ _)
+        (sym srcq≡)
+        (narrow-weaken-store incl s⊒)
+    hsrcq = subst (λ S → WfTy _ S) (sym srcq≡) hA
+  in
+  ⊒ˢ-both hsrcq hA′ s⊒′ (extendReplaceRel-⊒ˢ rel σ⊒)
+
+extendReplaceRel-≈ⁿ :
+  ∀ {Δ σ σ′ s t A B} →
+  ExtendReplaceRel Δ σ σ′ →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊒ B →
+  Δ ∣ σ′ ⊢ s ≈ t ∶ A ⊒ B
+extendReplaceRel-≈ⁿ rel
+    (endpointsⁿ srcs tgts srct tgtt σ⊒ wfΣ wfΣ′ s⊒ t⊒) =
+  let
+    incl =
+      storeIncl-substˡ (srcStoreⁿ-⊒ˢ σ⊒)
+        (extendReplaceRel-src-incl rel)
+  in
+  endpointsⁿ
+    srcs
+    tgts
+    srct
+    tgtt
+    (extendReplaceRel-⊒ˢ rel σ⊒)
+    wfΣ
+    ( WfTyˢ-store-weaken incl (proj₁ wfΣ′)
+    , WfTyˢ-store-weaken incl (proj₂ wfΣ′)
+    )
+    s⊒
+    (narrow-weaken-store incl t⊒)
+
+extendReplaceRel-coercionᶜ :
+  ∀ {Δ σ σ′ c A B} →
+  ExtendReplaceRel Δ σ σ′ →
+  Δ ∣ srcStoreⁿ σ ⊢ c ∶ᶜ A ⊒ B →
+  Δ ∣ srcStoreⁿ σ′ ⊢ c ∶ᶜ A ⊒ B
+extendReplaceRel-coercionᶜ rel cᶜ =
+  narrow-weaken ≤-refl (extendReplaceRel-src-incl rel) cᶜ
+
+extendReplaceRel-compose-left :
+  ∀ {Δ σ σ′ q s r A B} →
+  ExtendReplaceRel Δ σ σ′ →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ ∣ σ′ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+extendReplaceRel-compose-left rel
+    (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
+  compose-leftⁿ wfΣ q⊒ s⊒ (extendReplaceRel-≈ⁿ rel q⨟s≈r)
+
+extendReplaceRel-compose-right :
+  ∀ {Δ σ σ′ r t p A B} →
+  ExtendReplaceRel Δ σ σ′ →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ′ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+extendReplaceRel-compose-right rel
+    (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
+  compose-rightⁿ wfΣ t⊒ p⊒ (extendReplaceRel-≈ⁿ rel r≈t⨟p)
+
+id-constᶜ :
+  ∀ {Δ Σ} κ →
+  Δ ∣ Σ ⊢ id (constTy κ) ∶ᶜ constTy κ ⊒ constTy κ
+id-constᶜ (κℕ n) = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+id-ℕᶜ :
+  ∀ {Δ Σ} →
+  Δ ∣ Σ ⊢ id (‵ `ℕ) ∶ᶜ ‵ `ℕ ⊒ ‵ `ℕ
+id-ℕᶜ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+extend-replace-here-current :
+  ∀ {Δ α q A B σ γ M T c C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A →
+  Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ σ) ⊢ c ∶ᶜ C ⊒ D →
+  Δ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ ⊢ M ⊒ T ∶ c →
+  Δ ∣ (α ꞉ q) ∷ σ ∣ γ ⊢ M ⊒ T ∶ c
+extend-replace-here-current qᶜ cᶜ =
+  extend-replace-here-term qᶜ
+    (narrow-weaken ≤-refl StoreIncl-drop cᶜ)
+
+extendReplaceRel-term :
+  ∀ {Δ σ σ′ γ M T c} →
+  ExtendReplaceRel Δ σ σ′ →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ c →
+  Δ ∣ σ′ ∣ γ ⊢ M ⊒ T ∶ c
+extendReplaceRel-term (replace-here qᶜ) (split q₀ᶜ pαᶜ M⊒T) =
+  extend-replace-here-current qᶜ pαᶜ (split q₀ᶜ pαᶜ M⊒T)
+extendReplaceRel-term (replace-here qᶜ) (⊒blame pᶜ) =
+  extend-replace-here-current qᶜ pᶜ (⊒blame pᶜ)
+extendReplaceRel-term (replace-here qᶜ) (x⊒x pᶜ x∋p) =
+  extend-replace-here-current qᶜ pᶜ (x⊒x pᶜ x∋p)
+extendReplaceRel-term (replace-here qᶜ) (ƛ⊒ƛ p↦qᶜ N⊒N′) =
+  extend-replace-here-current qᶜ p↦qᶜ (ƛ⊒ƛ p↦qᶜ N⊒N′)
+extendReplaceRel-term (replace-here qᶜ) (·⊒· q₀ᶜ L⊒L′ M⊒M′) =
+  extend-replace-here-current qᶜ q₀ᶜ (·⊒· q₀ᶜ L⊒L′ M⊒M′)
+extendReplaceRel-term (replace-here qᶜ) (Λ⊒Λ allᶜ vV V⊒V′) =
+  extend-replace-here-current qᶜ allᶜ (Λ⊒Λ allᶜ vV V⊒V′)
+extendReplaceRel-term (replace-here qᶜ) (⊒Λ pᶜ N⊒V′) =
+  extend-replace-here-current qᶜ pᶜ (⊒Λ pᶜ N⊒V′)
+extendReplaceRel-term (replace-here qᶜ) (⊒⟨ν⟩ pᶜ i N⊒V′s) =
+  extend-replace-here-current qᶜ pᶜ (⊒⟨ν⟩ pᶜ i N⊒V′s)
+extendReplaceRel-term (replace-here qᶜ) (⊒α pαᶜ L⊒L′) =
+  extend-replace-here-current qᶜ pαᶜ (⊒α pαᶜ L⊒L′)
+extendReplaceRel-term (replace-here qᶜ) (ν⊒ν pᶜ q₀ᶜ N⊒N′) =
+  extend-replace-here-current qᶜ pᶜ (ν⊒ν pᶜ q₀ᶜ N⊒N′)
+extendReplaceRel-term (replace-here qᶜ) (⊒ν pᶜ N⊒N′) =
+  extend-replace-here-current qᶜ pᶜ (⊒ν pᶜ N⊒N′)
+extendReplaceRel-term (replace-here qᶜ) (ν⊒ pᶜ N⊒N′) =
+  extend-replace-here-current qᶜ pᶜ (ν⊒ pᶜ N⊒N′)
+extendReplaceRel-term (replace-here qᶜ) (κ⊒κ κ) =
+  extend-replace-here-current qᶜ (id-constᶜ κ) (κ⊒κ κ)
+extendReplaceRel-term (replace-here qᶜ) (⊕⊒⊕ M⊒M′ N⊒N′) =
+  extend-replace-here-current qᶜ id-ℕᶜ (⊕⊒⊕ M⊒M′ N⊒N′)
+extendReplaceRel-term (replace-here qᶜ) (⊒cast+ q₀ᶜ q⨟s≈r M⊒M′) =
+  extend-replace-here-current qᶜ q₀ᶜ
+    (⊒cast+ q₀ᶜ q⨟s≈r M⊒M′)
+extendReplaceRel-term (replace-here qᶜ)
+    (⊒cast- q₀ᶜ q⨟s≈r M⊒M′) =
+  ⊒cast-
+    (narrow-weaken ≤-refl StoreIncl-drop q₀ᶜ)
+    (extendReplaceRel-compose-left (replace-here qᶜ) q⨟s≈r)
+    (extendReplaceRel-term (replace-here qᶜ) M⊒M′)
+extendReplaceRel-term (replace-here qᶜ)
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast+⊒
+    (narrow-weaken ≤-refl StoreIncl-drop pᶜ)
+    (extendReplaceRel-compose-right (replace-here qᶜ) r≈t⨟p)
+    (extendReplaceRel-term (replace-here qᶜ) M⊒M′)
+extendReplaceRel-term (replace-here qᶜ) (cast-⊒ pᶜ r≈t⨟p M⊒M′) =
+  extend-replace-here-current qᶜ pᶜ
+    (cast-⊒ pᶜ r≈t⨟p M⊒M′)
+extendReplaceRel-term R@(replace-right (replace-left rel))
+    (split {q = q} qᶜ pαᶜ M⊒T) =
+  split
+    (extendReplaceRel-coercionᶜ R qᶜ)
+    (extendReplaceRel-coercionᶜ R pαᶜ)
+    (extendReplaceRel-term (replace-both {q = q} rel) M⊒T)
+extendReplaceRel-term R@(replace-right rel) (⊒blame pᶜ) =
+  ⊒blame (extendReplaceRel-coercionᶜ R pᶜ)
+extendReplaceRel-term R@(replace-right rel) (x⊒x pᶜ x∋p) =
+  x⊒x (extendReplaceRel-coercionᶜ R pᶜ) x∋p
+extendReplaceRel-term R@(replace-right rel) (ƛ⊒ƛ p↦qᶜ N⊒N′) =
+  ƛ⊒ƛ (extendReplaceRel-coercionᶜ R p↦qᶜ)
+    (extendReplaceRel-term (replace-right rel) N⊒N′)
+extendReplaceRel-term R@(replace-right rel) (·⊒· qᶜ L⊒L′ M⊒M′) =
+  ·⊒·
+    (extendReplaceRel-coercionᶜ R qᶜ)
+    (extendReplaceRel-term (replace-right rel) L⊒L′)
+    (extendReplaceRel-term (replace-right rel) M⊒M′)
+extendReplaceRel-term R@(replace-right rel) (Λ⊒Λ allᶜ vV V⊒V′) =
+  Λ⊒Λ (extendReplaceRel-coercionᶜ R allᶜ) vV
+    (extendReplaceRel-term (replace-right (extendReplaceRel-⇑ˢ rel))
+      V⊒V′)
+extendReplaceRel-term R@(replace-right rel) (⊒Λ pᶜ N⊒V′) =
+  ⊒Λ (extendReplaceRel-coercionᶜ R pᶜ)
+    (extendReplaceRel-term
+      (replace-right (replace-right (extendReplaceRel-⇑ˢ rel)))
+      N⊒V′)
+extendReplaceRel-term R@(replace-right rel) (⊒⟨ν⟩ pᶜ i N⊒V′s) =
+  ⊒⟨ν⟩ (extendReplaceRel-coercionᶜ R pᶜ) i
+    (extendReplaceRel-term
+      (replace-right (replace-right (extendReplaceRel-⇑ˢ rel)))
+      N⊒V′s)
+extendReplaceRel-term R@(replace-right rel) (⊒α pαᶜ L⊒L′) =
+  ⊒α
+    (extendReplaceRel-coercionᶜ R pαᶜ)
+    (extendReplaceRel-term rel L⊒L′)
+extendReplaceRel-term R@(replace-right rel)
+    (ν⊒ν {q = q} pᶜ qᶜ N⊒N′) =
+  ν⊒ν
+    (extendReplaceRel-coercionᶜ R pᶜ)
+    (extendReplaceRel-coercionᶜ R qᶜ)
+    (extendReplaceRel-term
+      (replace-both {q = ⇑ᶜ q}
+        (replace-right (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term R@(replace-right rel) (⊒ν pᶜ N⊒N′) =
+  ⊒ν (extendReplaceRel-coercionᶜ R pᶜ)
+    (extendReplaceRel-term
+      (replace-right (replace-right (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term R@(replace-right rel) (ν⊒ pᶜ N⊒N′) =
+  ν⊒ (extendReplaceRel-coercionᶜ R pᶜ)
+    (extendReplaceRel-term
+      (replace-left (replace-right (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-right rel) (κ⊒κ κ) = κ⊒κ κ
+extendReplaceRel-term (replace-right rel) (⊕⊒⊕ M⊒M′ N⊒N′) =
+  ⊕⊒⊕
+    (extendReplaceRel-term (replace-right rel) M⊒M′)
+    (extendReplaceRel-term (replace-right rel) N⊒N′)
+extendReplaceRel-term R@(replace-right rel) (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast+
+    (extendReplaceRel-coercionᶜ R qᶜ)
+    (extendReplaceRel-compose-left R q⨟s≈r)
+    (extendReplaceRel-term (replace-right rel) M⊒M′)
+extendReplaceRel-term R@(replace-right rel) (⊒cast- qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast-
+    (extendReplaceRel-coercionᶜ R qᶜ)
+    (extendReplaceRel-compose-left R q⨟s≈r)
+    (extendReplaceRel-term (replace-right rel) M⊒M′)
+extendReplaceRel-term R@(replace-right rel) (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast+⊒
+    (extendReplaceRel-coercionᶜ R pᶜ)
+    (extendReplaceRel-compose-right R r≈t⨟p)
+    (extendReplaceRel-term (replace-right rel) M⊒M′)
+extendReplaceRel-term R@(replace-right rel) (cast-⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast-⊒
+    (extendReplaceRel-coercionᶜ R pᶜ)
+    (extendReplaceRel-compose-right R r≈t⨟p)
+    (extendReplaceRel-term (replace-right rel) M⊒M′)
+extendReplaceRel-term (replace-left rel) (⊒blame pᶜ) =
+  ⊒blame (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+extendReplaceRel-term (replace-left rel) (x⊒x pᶜ x∋p) =
+  x⊒x (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ) x∋p
+extendReplaceRel-term (replace-left rel) (ƛ⊒ƛ p↦qᶜ N⊒N′) =
+  ƛ⊒ƛ (extendReplaceRel-coercionᶜ (replace-left rel) p↦qᶜ)
+    (extendReplaceRel-term (replace-left rel) N⊒N′)
+extendReplaceRel-term (replace-left rel) (·⊒· qᶜ L⊒L′ M⊒M′) =
+  ·⊒·
+    (extendReplaceRel-coercionᶜ (replace-left rel) qᶜ)
+    (extendReplaceRel-term (replace-left rel) L⊒L′)
+    (extendReplaceRel-term (replace-left rel) M⊒M′)
+extendReplaceRel-term (replace-left rel) (Λ⊒Λ allᶜ vV V⊒V′) =
+  Λ⊒Λ (extendReplaceRel-coercionᶜ (replace-left rel) allᶜ) vV
+    (extendReplaceRel-term (replace-left (extendReplaceRel-⇑ˢ rel))
+      V⊒V′)
+extendReplaceRel-term (replace-left rel) (⊒Λ pᶜ N⊒V′) =
+  ⊒Λ (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+    (extendReplaceRel-term
+      (replace-right (replace-left (extendReplaceRel-⇑ˢ rel)))
+      N⊒V′)
+extendReplaceRel-term (replace-left rel) (⊒⟨ν⟩ pᶜ i N⊒V′s) =
+  ⊒⟨ν⟩ (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ) i
+    (extendReplaceRel-term
+      (replace-right (replace-left (extendReplaceRel-⇑ˢ rel)))
+      N⊒V′s)
+extendReplaceRel-term (replace-left rel) (ν⊒ν {q = q} pᶜ qᶜ N⊒N′) =
+  ν⊒ν
+    (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+    (extendReplaceRel-coercionᶜ (replace-left rel) qᶜ)
+    (extendReplaceRel-term
+      (replace-both {q = ⇑ᶜ q}
+        (replace-left (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-left rel) (⊒ν pᶜ N⊒N′) =
+  ⊒ν (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+    (extendReplaceRel-term
+      (replace-right (replace-left (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-left rel) (ν⊒ pᶜ N⊒N′) =
+  ν⊒ (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+    (extendReplaceRel-term
+      (replace-left (replace-left (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-left rel) (κ⊒κ κ) = κ⊒κ κ
+extendReplaceRel-term (replace-left rel) (⊕⊒⊕ M⊒M′ N⊒N′) =
+  ⊕⊒⊕
+    (extendReplaceRel-term (replace-left rel) M⊒M′)
+    (extendReplaceRel-term (replace-left rel) N⊒N′)
+extendReplaceRel-term (replace-left rel) (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast+
+    (extendReplaceRel-coercionᶜ (replace-left rel) qᶜ)
+    (extendReplaceRel-compose-left (replace-left rel) q⨟s≈r)
+    (extendReplaceRel-term (replace-left rel) M⊒M′)
+extendReplaceRel-term (replace-left rel) (⊒cast- qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast-
+    (extendReplaceRel-coercionᶜ (replace-left rel) qᶜ)
+    (extendReplaceRel-compose-left (replace-left rel) q⨟s≈r)
+    (extendReplaceRel-term (replace-left rel) M⊒M′)
+extendReplaceRel-term (replace-left rel) (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast+⊒
+    (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+    (extendReplaceRel-compose-right (replace-left rel) r≈t⨟p)
+    (extendReplaceRel-term (replace-left rel) M⊒M′)
+extendReplaceRel-term (replace-left rel) (cast-⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast-⊒
+    (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
+    (extendReplaceRel-compose-right (replace-left rel) r≈t⨟p)
+    (extendReplaceRel-term (replace-left rel) M⊒M′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (extend qᶜ pαᶜ M⊒T) =
+  extend
+    (extendReplaceRel-coercionᶜ rel qᶜ)
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pαᶜ)
+    (extendReplaceRel-term (replace-right rel) M⊒T)
+extendReplaceRel-term (replace-both {q = qh} rel) (⊒blame pᶜ) =
+  ⊒blame (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+extendReplaceRel-term (replace-both {q = qh} rel) (x⊒x pᶜ x∋p) =
+  x⊒x
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    x∋p
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (ƛ⊒ƛ p↦qᶜ N⊒N′) =
+  ƛ⊒ƛ
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) p↦qᶜ)
+    (extendReplaceRel-term (replace-both {q = qh} rel) N⊒N′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (·⊒· qᶜ L⊒L′ M⊒M′) =
+  ·⊒·
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) qᶜ)
+    (extendReplaceRel-term (replace-both {q = qh} rel) L⊒L′)
+    (extendReplaceRel-term (replace-both {q = qh} rel) M⊒M′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (Λ⊒Λ allᶜ vV V⊒V′) =
+  Λ⊒Λ
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) allᶜ) vV
+    (extendReplaceRel-term
+      (replace-both {q = ⇑ᶜ qh} (extendReplaceRel-⇑ˢ rel))
+      V⊒V′)
+extendReplaceRel-term (replace-both {q = qh} rel) (⊒Λ pᶜ N⊒V′) =
+  ⊒Λ (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    (extendReplaceRel-term
+      (replace-right
+        (replace-both {q = ⇑ᶜ qh} (extendReplaceRel-⇑ˢ rel)))
+      N⊒V′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (⊒⟨ν⟩ pᶜ i N⊒V′s) =
+  ⊒⟨ν⟩
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ) i
+    (extendReplaceRel-term
+      (replace-right
+        (replace-both {q = ⇑ᶜ qh} (extendReplaceRel-⇑ˢ rel)))
+      N⊒V′s)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (α⊒α qᶜ pαᶜ L⊒L′) =
+  α⊒α
+    (extendReplaceRel-coercionᶜ rel qᶜ)
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pαᶜ)
+    (extendReplaceRel-term rel L⊒L′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (ν⊒ν {q = q} pᶜ qᶜ N⊒N′) =
+  ν⊒ν
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) qᶜ)
+    (extendReplaceRel-term
+      (replace-both {q = ⇑ᶜ q}
+        (replace-both {q = ⇑ᶜ qh} (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-both {q = qh} rel) (⊒ν pᶜ N⊒N′) =
+  ⊒ν (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    (extendReplaceRel-term
+      (replace-right
+        (replace-both {q = ⇑ᶜ qh} (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-both {q = qh} rel) (ν⊒ pᶜ N⊒N′) =
+  ν⊒ (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    (extendReplaceRel-term
+      (replace-left
+        (replace-both {q = ⇑ᶜ qh} (extendReplaceRel-⇑ˢ rel)))
+      N⊒N′)
+extendReplaceRel-term (replace-both {q = qh} rel) (κ⊒κ κ) = κ⊒κ κ
+extendReplaceRel-term (replace-both {q = qh} rel) (⊕⊒⊕ M⊒M′ N⊒N′) =
+  ⊕⊒⊕
+    (extendReplaceRel-term (replace-both {q = qh} rel) M⊒M′)
+    (extendReplaceRel-term (replace-both {q = qh} rel) N⊒N′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast+
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) qᶜ)
+    (extendReplaceRel-compose-left (replace-both {q = qh} rel) q⨟s≈r)
+    (extendReplaceRel-term (replace-both {q = qh} rel) M⊒M′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (⊒cast- qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast-
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) qᶜ)
+    (extendReplaceRel-compose-left (replace-both {q = qh} rel) q⨟s≈r)
+    (extendReplaceRel-term (replace-both {q = qh} rel) M⊒M′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast+⊒
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    (extendReplaceRel-compose-right (replace-both {q = qh} rel) r≈t⨟p)
+    (extendReplaceRel-term (replace-both {q = qh} rel) M⊒M′)
+extendReplaceRel-term (replace-both {q = qh} rel)
+    (cast-⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast-⊒
+    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
+    (extendReplaceRel-compose-right (replace-both {q = qh} rel) r≈t⨟p)
+    (extendReplaceRel-term (replace-both {q = qh} rel) M⊒M′)
+
+catchup-extend-rel-shifted :
+  ∀ n {Δ Δ′ σ π Π Π′ χs α q A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ shiftStore n (applyStores χs []) →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  ExtendReplaceRel Δ′
+    (combineStoreNrw π ((α ꞉= A ⊒) ∷ σ))
+    (combineStoreNrw π ((α ꞉ q) ∷ σ))
+catchup-extend-rel-shifted n {Δ = Δ} {χs = χs}
+    qᶜ Δ′≡ Π≡ Π′≡ ⊒ˢ-nil =
+  let
+    empty≡ = shiftStore-empty-inv n (sym Π≡)
+    Δ′≡Δ = trans Δ′≡ (applyTyCtxs-empty-id χs empty≡ Δ)
+    qᶜ′ =
+      subst
+        (λ Δ₀ → Δ₀ ∣ _ ⊢ _ ∶ᶜ _ ⊒ _)
+        (sym Δ′≡Δ)
+        qᶜ
+  in
+  replace-here qᶜ′
+catchup-extend-rel-shifted n qᶜ Δ′≡ Π≡ () (⊒ˢ-right hA π⊒)
+catchup-extend-rel-shifted n {χs = χs}
+    qᶜ Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    with storeChangesLastBind χs
+catchup-extend-rel-shifted n {χs = χs}
+    qᶜ Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | no-bind keeps
+    with trans Π≡
+      (trans (cong (shiftStore n) (allKeep-applyStores-id keeps []))
+        (shiftStore-empty n))
+catchup-extend-rel-shifted n {χs = χs}
+    qᶜ Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | no-bind keeps | ()
+catchup-extend-rel-shifted n {Δ = Δ} {σ = σ}
+    {χs = .(χs ++ bind Aχ ∷ keeps)}
+    {α = α} {q = q} {A = A}
+    qᶜ Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | last-bind χs Aχ keeps keeps-ok =
+  let
+    Δtail≡ =
+      trans Δ′≡
+        (trans (applyTyCtxs-last-bind χs Aχ keeps keeps-ok Δ)
+          (sym (applyTyCtxs-suc χs Δ)))
+    Π-last≡ =
+      trans Π≡
+        (cong (shiftStore n)
+          (applyStores-last-bind χs Aχ keeps keeps-ok []))
+    Π-last-normal≡ =
+      trans Π-last≡
+        (shiftStore-cons n zero (⇑ᵗ Aχ) (⟰ᵗ (applyStores χs [])))
+    Πtail≡ =
+      trans (storeTail-∷≡ Π-last-normal≡)
+        (shiftStore-⟰ᵗ n (applyStores χs []))
+    tail =
+      catchup-extend-rel-shifted (suc n) {χs = χs}
+        {α = suc α} {q = ⇑ᶜ q} {A = ⇑ᵗ A}
+        (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} qᶜ)
+        Δtail≡
+        Πtail≡
+        Π′≡
+        π⊒
+  in
+  replace-left tail
+catchup-extend-rel-shifted n qᶜ Δ′≡ Π≡ () (⊒ˢ-both hA hA′ s⊒ π⊒)
+
+-- [New] Extend Prefix Transport.
+--
+-- The emitted prefix determines a single hidden store replacement:
+-- `α ꞉= A ⊒` becomes `α ꞉ q`, shifted under every emitted source-only
+-- binder.  The structural transport above then moves the term-imprecision
+-- derivation across that replacement.  At the exact replacement head it wraps
+-- non-endpoint constructors with `extend`; the cast endpoint constructors are
+-- rebuilt structurally because their conclusion index is not necessarily
+-- `∶ᶜ`.
+catchup-extend-transport :
+  ∀ {Δ Δ′ σ π Π Π′ χs W N′ α p q A B C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A →
+  Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ applyStores χs [] →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ combineStoreNrw π ((α ꞉= A ⊒) ∷ σ) ∣ []
+    ⊢ W ⊒ applyTerms χs (N′ [ α ]ᵀ)
+      ∶ applyCoercions χs (p [ α ]ᶜ) →
+  Δ′ ∣ combineStoreNrw π ((α ꞉ q) ∷ σ) ∣ []
+    ⊢ W ⊒ applyTerms χs (N′ [ α ]ᵀ)
+      ∶ applyCoercions χs (p [ α ]ᶜ)
+catchup-extend-transport {χs = χs} qᶜ pαᶜ Δ′≡ Π≡ Π′≡ π⊒ W⊒V =
+  extendReplaceRel-term
+    (catchup-extend-rel-shifted zero {χs = χs}
+      qᶜ Δ′≡ Π≡ Π′≡ π⊒)
+    W⊒V
 
 postulate
   -- [New] Split Catchup Case.

--- a/GTSF/proof/CatchupExtendTransportAttempts.md
+++ b/GTSF/proof/CatchupExtendTransportAttempts.md
@@ -1,0 +1,306 @@
+# `catchup-extend-transport` proof attempts
+
+This note records proof paths tried while replacing the
+`catchup-extend-transport` postulate in `proof.Catchup`.
+
+## Attempt 1: generic emitted-prefix transport
+
+Rejected before implementation.  A statement for arbitrary target terms is too
+broad: in the `⊒α` case the target has shape `L′ • α`, but rebuilding
+`extend` needs an opened target `N′ [ α ]ᵀ`.  The relation does not imply that
+`L′ • α` came from such an opening.
+
+## Attempt 2: source-store inclusion only
+
+Rejected before implementation.  The recursive emitted-prefix case needs
+shifted typings for both `q` and `p [ α ]ᶜ`.  These typings come from the
+specific `StoreChanges` history (`χs`) rather than from a plain inclusion
+between source stores.
+
+## Attempt 3: direct induction on the emitted `π`
+
+Partial success, then blocked.  The base case can rewrite away an all-`keep`
+`χs` and rebuild `extend` directly.  Agda accepted this base case in an
+earlier helper, but the final proof subsumes it through `replace-here` in
+`ExtendReplaceRel` and the structural term transport.
+
+The source-only emitted case cannot use the recursive call directly: the
+available derivation is under
+`(⊒ X ꞉=☆) ∷ combineStoreNrw π ((suc α ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ)`,
+but the recursive call needs the same derivation with that leading
+source-only entry removed.  There is no inversion principle that drops a
+source-only store entry from an arbitrary term-imprecision derivation.
+
+## Attempt 4: pattern-match the source-only case directly
+
+Failed at the first constructor probe.  Replacing the source-only branch by a
+case on `W⊒V` such as `⊒blame pᶜ` fails before the case body is checked:
+Agda cannot split a derivation whose target is the stuck expression
+`applyTerms χs (N′ [ α ]ᵀ)`.
+
+The lesson is that any structural transport helper must abstract over the
+target term and coercion index before pattern matching, then recover the
+opened-target invariant only at the point where the hidden `extend` entry is
+actually consumed.
+
+## Attempt 5: buried source-only transport
+
+Promising but incomplete.  I introduced a `BuriedExtendTransport` relation for
+store pairs that differ only by replacing `α ꞉= A ⊒` with `α ꞉ q` below at
+least one source-only emitted entry.  The source-store inclusion projection
+type-checks.
+
+The blocker is casts/coercion equivalence.  Transporting a term derivation
+through this buried store change also requires transporting any
+`Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r` or `Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p` premise.  When that store
+precision proof reaches the hidden changed entry, rebuilding the corresponding
+both-side store entry needs the shifted typing of the original `q`.  That
+evidence depends on the same `χs`/`π` history as the catchup transport, not on
+the buried store-pair shape alone.
+
+## Intermediate helper: source-store inclusion
+
+The source store of
+`combineStoreNrw π ((α ꞉= A ⊒) ∷ σ)` is included in the source store of
+`combineStoreNrw π ((α ꞉ q) ∷ σ)`.  An earlier helper
+`srcStoreⁿ-extend-incl` proved this and was useful for understanding coercion
+side conditions, but the final proof no longer needs it directly.  Source-store
+inclusion alone is not enough for term-imprecision transport because term
+constructors inspect the `StoreNrw` shape, not only `srcStoreⁿ`.
+
+## Intermediate guarded structural path
+
+An intermediate version of `Catchup.agda` added `ExtendReplaceRel`, which
+records the precise replacement of one right-only `extend` store entry by the
+corresponding both-side entry, plus `GuardedExtendReplaceRel`, which said that
+replacement is guarded by at least one source-only emitted entry.  The
+source-store inclusion projections for both relations type-checked.  Shifting
+was deliberately a recursive function (`extendReplaceRel-⇑ˢ` /
+`guardedExtendReplaceRel-⇑ˢ`) rather than a constructor; making it a
+constructor produced nested-shift transport obligations that did not
+structurally decrease.
+
+This avoids the previous unstructured "buried" attempt: future transport
+lemmas can recurse over the `StoreNrw` shape and know whether reaching
+`replace-here` is allowed.
+
+Accepted in that intermediate branch:
+
+- `extendReplaceRel-⊒ˢ` and `guardedExtendReplaceRel-⊒ˢ`: store-precision
+  transport.  The `replace-here` case rebuilds the right-only store entry as a
+  both-side entry using the saved `qᶜ`, normalized with `coercion-src-tgtᵐ`.
+- `guardedExtendReplaceRel-≈ⁿ`: coercion-equivalence transport.
+- `guardedExtendReplaceRel-compose-left` and
+  `guardedExtendReplaceRel-compose-right`: transport for the composed cast side
+  conditions.
+- `guardedExtendReplaceRel-coercionᶜ` and
+  `guardedExtendReplaceRel-coercion`: direct coercion-typing transport.
+
+The guarded-only path was later pruned from the final code.  The useful piece
+that survived is the unguarded `ExtendReplaceRel` relation plus its store,
+coercion-equivalence, and term transports.
+
+## Attempt 6: exact opened-target guarded transport
+
+Failed as a proof shape.  I tried making the term transport conclusion keep
+the target index as `N′ [ α ]ᵀ` and the coercion as `p [ α ]ᶜ`, hoping that
+the opened shape would rule out the bad `split` case.  Agda instead refused to
+split on the `split` constructor at all: it gets stuck trying to unify the
+inferred target `N′₁ [ α₁ ]ᵀ` and coercion `p₁ [ α₁ ]ᶜ` with the fixed
+opened indices.
+
+This confirms the earlier lesson from Attempt 4 in a more focused setting:
+structural induction over term imprecision must abstract the target term and
+coercion before pattern matching.  The opened-target invariant has to be
+carried separately and reintroduced only at constructors such as `extend` that
+actually need it.
+
+## Attempt 7: open replacement relation
+
+Partial success, then a deeper blocker.  I added `ExtendOpenRel` and
+`GuardedOpenRel`, which refine the earlier store-pair relations by remembering
+the target/coercion indices at the hidden replacement.  The relation erases
+back to `ExtendReplaceRel`/`GuardedExtendReplaceRel`, shifts through `⇑ˢ`, and
+supports the same store-precision, coercion-typing, and coercion-equivalence
+transports.
+
+This fixes one missing piece from the broad guarded transport: when `split`
+consumes the only source-only guard, the remaining unguarded premise can in
+principle carry enough information to rebuild `extend` at `replace-here`.
+
+The next blocker is subterm decomposition.  For constructors such as `ƛ⊒ƛ`,
+`Λ⊒Λ`, applications, and casts, transporting under a prefixed store requires
+recursing into a subderivation whose target is a subterm of `N′ [ α ]ᵀ`, not
+the whole opened term.  The repository has inversion lemmas for type/coercion
+renaming, but not for term openings.  A full proof now appears to need a
+target-shape invariant or inversion lemmas showing, for example, that if
+`N′ [ α ]ᵀ` is a lambda/application/cast, then the corresponding subtarget is
+itself an opening of the matching subterm.
+
+## Attempt 8: cast-like index extraction
+
+Rejected as a complete proof route.  The attractive idea was to avoid carrying
+opened-target structure through every subderivation: prove that every
+term-imprecision derivation exposes a typing derivation for its coercion index,
+then, at `replace-here`, rebuild the goal immediately with `extend`.
+
+This works conceptually for constructors whose recursive premises are indexed
+by a coercion with an explicit `∶ᶜ` side condition.  It fails for cast-side
+constructors, especially `cast-⊒`: the conclusion index `p` is cast-like, but
+the premise is indexed by `r` from `r ≈ t ⨾ⁿ p`.  The equivalence evidence
+types `r` at the endpoint store from the equivalence relation, not as a
+cast-like source-index typing at `srcStoreⁿ σ`.  Rebuilding `extend` for that
+premise would therefore require an additional semantic reindexing lemma for
+term imprecision under coercion equivalence, not merely an index extraction
+lemma.
+
+This is close to the unfinished `termNarrowing-resp-≈` direction in
+`proof.LeftSealNarrowingInversion`: it suggests that a reusable response-to-
+coercion-equivalence theorem may be a prerequisite for a clean generic
+transport proof.
+
+## Attempt 9: direct induction on `π⊒` with source-only normalization
+
+Partial success, then the same core blocker resurfaced.  A direct probe by
+cases on the emitted store-precision derivation works in the `⊒ˢ-nil` branch
+by rewriting the empty target store equality and rebuilding `extend`.  The
+right-only and both-side emitted branches are impossible because the emitted
+target store is `[]`, and the no-bind source-only branch is impossible for the
+same reason.
+
+In the remaining source-only `bind` branch, the old derivation has type under
+
+`⊒ X ꞉=☆ ∷ combineStoreNrw σ₁ ((suc α ꞉= renameᵗ suc A ⊒) ∷ map ⇑ʷ σ)`
+
+but the desired result is under
+
+`⊒ X ꞉=☆ ∷ combineStoreNrw σ₁ ((suc α ꞉ renameᶜ suc q) ∷ map ⇑ʷ σ)`.
+
+Trying to reuse the premise directly gives the expected mismatch:
+
+`suc α ꞉= renameᵗ suc A ⊒ != suc α ꞉ renameᶜ suc q`.
+
+This confirms that the source-only branch is not a minor equality problem.  It
+reduces to the original hidden replacement under one more leading source-only
+entry, and the recursive call would need the premise with that guard peeled
+away.  A successful proof must carry structured transport through term
+constructors instead of performing a plain induction on the emitted store
+precision derivation.
+
+## Attempt 10: arbitrary opening at `replace-here`
+
+Useful partial success.  The hidden replacement itself does not need a stored
+`N′`/`p` witness: any target term `T` and coercion index `c` can be presented
+as `(⇑ᵗᵐ T) [ α ]ᵀ` and `(⇑ᶜ c) [ α ]ᶜ`.  The helper
+`extend-replace-here-term` uses those shift/open cancellation lemmas to wrap
+an old derivation with `extend` at the exact hidden head replacement.
+
+This removes the earlier need for an exact opened-target relation at the
+`replace-here` base case.  The remaining problem is recursive transport
+through prefixes and term constructors.
+
+## Attempt 11: cast-like index extraction
+
+Rejected as a global invariant.  A probe `term-indexᶜ` can return a
+tag-or-id (`∶ᶜ`) typing for most term-imprecision conclusions using the
+constructor side condition, but it stops at exactly the cast endpoint cases:
+`⊒cast-` and `cast+⊒`.  In those rules the conclusion index is the `r`
+endpoint of a coercion-equivalence premise, and that premise supplies only a
+general `∃ μ` narrowing typing for `r`, not a tag-or-id typing.
+
+This means a transport proof cannot rely on first extracting a cast-like
+typing for every current index and then wrapping with `extend` everywhere.
+The cast endpoint cases have to be rebuilt structurally, transporting their
+explicit cast-like side condition and coercion-equivalence premise, then
+recursing on the premise whose index is the explicit cast-like coercion.
+
+## Attempt 12: generic `ExtendReplaceRel` transport
+
+Rejected as too broad.  `ExtendReplaceRel` records only that a hidden entry was
+replaced somewhere below a prefix.  For binder-like term rules such as `ν⊒`,
+the recursive premise shifts the whole store relation under a fresh
+source-only entry.  Plain `ExtendReplaceRel` can be shifted syntactically, but
+it does not remember that the shifted tail came from the actual emitted
+`χs`/`π⊒` history with the corresponding shifted `q` evidence.
+
+The next viable invariant should describe emitted prefixes more precisely:
+each source-only entry is introduced as a fresh zero entry while shifting the
+entire previous replacement relation.  Older emitted entries can then appear
+as `suc`-shifted source-only entries that ordinary term constructors pass
+through.
+
+## Accepted helper: emitted-prefix replacement relation
+
+The helper `catchup-extend-rel-shifted` now proves the store-replacement
+relation that actually comes from the emitted `χs`/`π⊒` evidence.  It follows
+the same bookkeeping pattern as the compose-side transports:
+
+- the nil case rewrites away empty store changes and builds `replace-here`;
+- source-only emitted entries use `StoreChangesLastBind`, shift the hidden
+  `q` evidence, recurse on the tail, and add `replace-left`;
+- right-only and both-side emitted entries are impossible because the emitted
+  target store is `[]`.
+
+This closes the gap from Attempt 5: the shifted `q` evidence is now carried by
+the actual emitted-history induction rather than guessed from source-store
+inclusion.
+
+## Attempt 13: guarded term transport
+
+Partial success, then blocked at the expected `split` shape.  A probe of
+
+`GuardedExtendReplaceRel Δ σ σ′ -> Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ c -> Δ ∣ σ′ ∣ γ ⊢ M ⊒ T ∶ c`
+
+rebuilds the ordinary constructors directly: coercion typings and composition
+premises transport through the guarded relation, and binder constructors shift
+the guarded relation before recurring.  Cast constructors also rebuild using
+the existing guarded composition transports.
+
+The hard case is `split` under a right-only prefix introduced by a binder
+constructor such as `⊒Λ`.  If the guarded relation has exactly one source-only
+guard under that right-only prefix, `split` consumes both the right-only entry
+and the source-only guard.  Its premise is then under a both-side entry plus
+the unguarded hidden replacement.  A recursive call would need unguarded term
+transport with an explicit cast-like typing for the current index.
+
+That typing is not supplied by the `split` rule in the needed store.  The
+`p [ α ]ᶜ` side condition for `split` is typed in the source-only store
+`srcStoreⁿ ((α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ)`, while the premise to be
+transported is under `(α ꞉ q) ∷ σ`.  So the `extend-replace-here-term`
+wrapper cannot be applied to the premise after the guard is consumed.  This
+suggests the successful invariant must either be split-specific or must carry
+additional opening/source-store evidence through the single-guard `split`
+case, not just a guarded replacement relation.
+
+## Accepted proof: unguarded structural replacement transport
+
+The successful route was to stop trying to transport only guarded relations.
+Instead, prove a direct structural transport for `ExtendReplaceRel`:
+
+`ExtendReplaceRel Δ σ σ′ -> Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ c ->
+Δ ∣ σ′ ∣ γ ⊢ M ⊒ T ∶ c`.
+
+The key refinement is how the exact `replace-here` case is handled.  Most
+constructors carry an explicit cast-like typing for their conclusion index, so
+the proof can wrap the whole old derivation with `extend` using
+`extend-replace-here-term`.  The two cast endpoint constructors whose
+conclusion index is not explicitly `∶ᶜ`, namely `⊒cast-` and `cast+⊒`, are
+rebuilt structurally: their explicit cast-like side condition and coercion
+composition premise are transported, and the recursive premise is transported
+under the same replacement relation.
+
+For non-head replacements, the proof rebuilds the current term constructor and
+recurses on its premises.  Binder-like rules shift the whole replacement
+relation before adding their own fresh store entry.  The `split` case under a
+right-only prefix works once the tail relation is explicitly matched as
+`replace-left`: rebuilding `split` leaves a premise under `replace-both`, so
+the same unguarded transport applies recursively.  This is the split-specific
+shape that the guarded-only attempt was missing, but it does not require a
+separate split transport lemma.
+
+Finally, `catchup-extend-transport` itself is a short wrapper: build the
+replacement relation produced by the emitted store-change evidence using
+`catchup-extend-rel-shifted`, then apply the structural
+`extendReplaceRel-term` transport.  The original `p [ α ]ᶜ` side condition is
+still part of the public statement, matching the `extend` case call site, but
+the final wrapper does not need to inspect it.


### PR DESCRIPTION
## Summary
- Proves GTSF/proof/Catchup.agda catchup-extend-transport without adding postulates.
- Replaces the transport postulate with an ExtendReplaceRel proof that rebuilds emitted extend prefixes and transports term precision structurally.
- Adds CatchupExtendTransportAttempts.md with the proof strategies tried and why they failed.

## Verification
- agda -v0 proof/Catchup.agda
- git diff --check