### PR TITLE
Add GTSF term substitution narrowing

### DIFF
--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -26,18 +26,14 @@ open import proof.CatchupStore using (combineStoreNrw)
 open import proof.LeftSealNarrowingInversion using
   (LeftSealNarrowingInversion; leftSealNarrowingInversion)
 open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
+open import proof.TermSubstitutionNarrowing using
+  (term-substitution-narrowing)
 
 ------------------------------------------------------------------------
 -- Lemmas used by the cambridge25 top-down proof
 ------------------------------------------------------------------------
 
 postulate
-  term-substitution-narrowing :
-    ∀ {Δ σ γ N N′ V V′ p q} →
-    Δ ∣ σ ∣ q ∷ γ ⊢ N ⊒ N′ ∶ p →
-    Δ ∣ σ ∣ γ ⊢ V ⊒ V′ ∶ q →
-    Δ ∣ σ ∣ γ ⊢ N [ V ] ⊒ N′ [ V′ ] ∶ p
-
   right-tag-inversion₁ :
     ∀ {Δ σ γ M V q G} →
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ! ⟩ ∶ q →
@@ -103,7 +99,7 @@ function-application-simulation-ƛ⊒ƛ {N = N} {V = V} vV N⊒N′ V⊒V′ =
   refl ,
   refl ,
   ⊒ˢ-nil ,
-  term-substitution-narrowing N⊒N′ V⊒V′
+  term-substitution-narrowing _ N⊒N′
 
 function-application-simulation :
   ∀ {Δ σ L L′ M N′ V′ r p q} →

--- a/GTSF/proof/TermSubstitutionNarrowing.agda
+++ b/GTSF/proof/TermSubstitutionNarrowing.agda
@@ -1,0 +1,273 @@
+module proof.TermSubstitutionNarrowing where
+
+-- File Charter:
+--   * Term-variable substitution for the GTSF term-narrowing judgment.
+--   * Provides the single-variable substitution theorem used by
+--     `proof.DynamicGradualGuarantee`.
+--   * Kept separate from the top-down dynamic gradual guarantee skeleton so
+--     substitution proof engineering stays local to term narrowing.
+
+open import Types
+open import Data.List using (_∷_)
+open import Data.Nat using (zero; suc)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; cong; cong₂; subst; sym; trans)
+open import Coercions
+open import NuTerms
+open import NarrowWiden
+open import TermNarrowing
+open import proof.Catchup using (extend-replace-here-term; open-shiftᵐ)
+open import proof.NuTermProperties using
+  ( renameˣ-renameᵗᵐ
+  ; renameᵗᵐ-ext-suc-comm
+  ; substˣᵐ-preserves-Value
+  )
+
+------------------------------------------------------------------------
+-- Term substitution and type renaming
+------------------------------------------------------------------------
+
+substˣᵐ-renameᵗᵐ :
+  ∀ ρ τ τ′ M →
+  (∀ x → τ x ≡ renameᵗᵐ ρ (τ′ x)) →
+  substˣᵐ τ (renameᵗᵐ ρ M) ≡ renameᵗᵐ ρ (substˣᵐ τ′ M)
+substˣᵐ-renameᵗᵐ ρ τ τ′ (` x) env = env x
+substˣᵐ-renameᵗᵐ ρ τ τ′ (ƛ M) env =
+  cong ƛ_ (substˣᵐ-renameᵗᵐ ρ (extˢˣ τ) (extˢˣ τ′) M env-ext)
+  where
+    env-ext : ∀ x → extˢˣ τ x ≡ renameᵗᵐ ρ (extˢˣ τ′ x)
+    env-ext zero = refl
+    env-ext (suc x) =
+      trans (cong (renameˣᵐ suc) (env x))
+            (renameˣ-renameᵗᵐ suc ρ (τ′ x))
+substˣᵐ-renameᵗᵐ ρ τ τ′ (L · M) env =
+  cong₂ _·_ (substˣᵐ-renameᵗᵐ ρ τ τ′ L env)
+             (substˣᵐ-renameᵗᵐ ρ τ τ′ M env)
+substˣᵐ-renameᵗᵐ ρ τ τ′ (Λ M) env =
+  cong Λ_ (substˣᵐ-renameᵗᵐ (extᵗ ρ) (↑ᵗᵐ τ) (↑ᵗᵐ τ′) M env-↑)
+  where
+    env-↑ : ∀ x → ↑ᵗᵐ τ x ≡ renameᵗᵐ (extᵗ ρ) (↑ᵗᵐ τ′ x)
+    env-↑ x =
+      trans (cong ⇑ᵗᵐ (env x))
+            (sym (renameᵗᵐ-ext-suc-comm ρ (τ′ x)))
+substˣᵐ-renameᵗᵐ ρ τ τ′ (M •) env =
+  cong _• (substˣᵐ-renameᵗᵐ ρ τ τ′ M env)
+substˣᵐ-renameᵗᵐ ρ τ τ′ (ν A L c) env =
+  cong (λ L′ → ν (renameᵗ ρ A) L′ (renameᶜ (extᵗ ρ) c))
+       (substˣᵐ-renameᵗᵐ ρ τ τ′ L env)
+substˣᵐ-renameᵗᵐ ρ τ τ′ ($ κ) env = refl
+substˣᵐ-renameᵗᵐ ρ τ τ′ (L ⊕[ op ] M) env =
+  cong₂ (λ L′ M′ → L′ ⊕[ op ] M′)
+    (substˣᵐ-renameᵗᵐ ρ τ τ′ L env)
+    (substˣᵐ-renameᵗᵐ ρ τ τ′ M env)
+substˣᵐ-renameᵗᵐ ρ τ τ′ (M ⟨ c ⟩) env =
+  cong (λ M′ → M′ ⟨ renameᶜ ρ c ⟩)
+       (substˣᵐ-renameᵗᵐ ρ τ τ′ M env)
+substˣᵐ-renameᵗᵐ ρ τ τ′ blame env = refl
+
+substˣᵐ-shift :
+  ∀ τ M →
+  substˣᵐ (↑ᵗᵐ τ) (⇑ᵗᵐ M) ≡ ⇑ᵗᵐ (substˣᵐ τ M)
+substˣᵐ-shift τ M = substˣᵐ-renameᵗᵐ suc (↑ᵗᵐ τ) τ M (λ x → refl)
+
+substˣᵐ-open :
+  ∀ τ M α →
+  substˣᵐ τ (M [ α ]ᵀ) ≡ (substˣᵐ (↑ᵗᵐ τ) M) [ α ]ᵀ
+substˣᵐ-open τ M α =
+  substˣᵐ-renameᵗᵐ (singleRenameᵗ α) τ (↑ᵗᵐ τ) M
+    (λ x → sym (open-shiftᵐ α (τ x)))
+
+------------------------------------------------------------------------
+-- Parallel substitution
+------------------------------------------------------------------------
+
+SubstNrw :
+  TyCtx → StoreNrw → CtxNrw → CtxNrw → Substˣ → Substˣ → Set₁
+SubstNrw Δ σ γ γ′ τ τ′ =
+  ∀ {x p A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  γ ∋ x ⦂ p →
+  Δ ∣ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ p
+
+data SubstFrame
+    (γ₀ γ₀′ : CtxNrw) (τ₀ τ₀′ : Substˣ) :
+    CtxNrw → CtxNrw → Substˣ → Substˣ → Set₁ where
+  frame-id :
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ₀ γ₀′ τ₀ τ₀′
+
+  frame-ƛ :
+    ∀ {γ γ′ τ τ′ p} →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′
+      ((- p) ∷ γ) ((- p) ∷ γ′) (extˢˣ τ) (extˢˣ τ′)
+
+  frame-Λ :
+    ∀ {γ γ′ τ τ′} →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′
+      (⇑ᵍ γ) (⇑ᵍ γ′) (↑ᵗᵐ τ) (↑ᵗᵐ τ′)
+
+  frame-νν :
+    ∀ {γ γ′ τ τ′} →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ (⇑ᵍ γ) (⇑ᵍ γ′) τ τ′
+
+  frame-src⇑ :
+    ∀ {γ γ′ τ τ′} →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ (⇑ᵍ γ) (⇑ᵍ γ′) (↑ᵗᵐ τ) τ′
+
+  frame-tgt⇑ :
+    ∀ {γ γ′ τ τ′} →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+    SubstFrame γ₀ γ₀′ τ₀ τ₀′ (⇑ᵍ γ) (⇑ᵍ γ′) τ (↑ᵗᵐ τ′)
+
+SubstNrwFamily : CtxNrw → CtxNrw → Substˣ → Substˣ → Set₁
+SubstNrwFamily γ₀ γ₀′ τ₀ τ₀′ =
+  ∀ {Δ σ γ γ′ τ τ′} →
+  SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+  SubstNrw Δ σ γ γ′ τ τ′
+
+term-parallel-substitution-narrowing-framed :
+  ∀ {γ₀ γ₀′ τ₀ τ₀′ Δ σ γ γ′ M M′ p τ τ′} →
+  SubstNrwFamily γ₀ γ₀′ τ₀ τ₀′ →
+  SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p →
+  Δ ∣ σ ∣ γ′ ⊢ substˣᵐ τ M ⊒ substˣᵐ τ′ M′ ∶ p
+term-parallel-substitution-narrowing-framed env frame (extend qᶜ pαᶜ M⊒N′) =
+  extend-replace-here-term qᶜ pαᶜ
+    (term-parallel-substitution-narrowing-framed env frame M⊒N′)
+term-parallel-substitution-narrowing-framed env frame
+    (split {N = N} {N′ = N′} {α = α} {αᵢ = αᵢ} qᶜ pαᶜ N⊒N′) =
+  subst
+    (λ L → _ ∣ _ ∣ _ ⊢ L ⊒ _ ∶ _)
+    (sym (substˣᵐ-open _ N αᵢ))
+    (subst
+      (λ R → _ ∣ _ ∣ _ ⊢ _ ⊒ R ∶ _)
+      (sym (substˣᵐ-open _ N′ α))
+      (split qᶜ pαᶜ premise))
+  where
+    rec =
+      term-parallel-substitution-narrowing-framed env frame N⊒N′
+
+    premise =
+      subst
+        (λ L → _ ∣ _ ∣ _ ⊢ L ⊒ _ ∶ _)
+        (substˣᵐ-open _ N α)
+        (subst
+          (λ R → _ ∣ _ ∣ _ ⊢ _ ⊒ R ∶ _)
+          (substˣᵐ-open _ N′ α)
+          rec)
+term-parallel-substitution-narrowing-framed env frame (⊒blame pᶜ) =
+  ⊒blame pᶜ
+term-parallel-substitution-narrowing-framed env frame (x⊒x pᶜ x∋p) =
+  env frame pᶜ x∋p
+term-parallel-substitution-narrowing-framed env frame
+    (ƛ⊒ƛ {p = p} p↦qᶜ N⊒N′) =
+  ƛ⊒ƛ p↦qᶜ
+    (term-parallel-substitution-narrowing-framed
+      env (frame-ƛ {p = p} frame) N⊒N′)
+term-parallel-substitution-narrowing-framed env frame
+    (·⊒· qᶜ L⊒L′ M⊒M′) =
+  ·⊒· qᶜ
+    (term-parallel-substitution-narrowing-framed env frame L⊒L′)
+    (term-parallel-substitution-narrowing-framed env frame M⊒M′)
+term-parallel-substitution-narrowing-framed env frame
+    (Λ⊒Λ allᶜ vV V⊒V′) =
+  Λ⊒Λ allᶜ (substˣᵐ-preserves-Value _ vV)
+    (term-parallel-substitution-narrowing-framed
+      env (frame-Λ frame) V⊒V′)
+term-parallel-substitution-narrowing-framed env frame
+    (⊒Λ {N = N} pᶜ N⊒V′) =
+  ⊒Λ pᶜ
+    (subst
+      (λ L → _ ∣ _ ∣ _ ⊢ L ⊒ _ ∶ _)
+      (substˣᵐ-shift _ N)
+      (term-parallel-substitution-narrowing-framed
+        env (frame-Λ frame) N⊒V′))
+term-parallel-substitution-narrowing-framed env frame
+    (⊒⟨ν⟩ {N = N} pᶜ i N⊒V′s) =
+  ⊒⟨ν⟩ pᶜ i
+    (subst
+      (λ L → _ ∣ _ ∣ _ ⊢ L ⊒ _ ∶ _)
+      (substˣᵐ-shift _ N)
+      (term-parallel-substitution-narrowing-framed
+        env (frame-src⇑ frame) N⊒V′s))
+term-parallel-substitution-narrowing-framed env frame
+    (α⊒α qᶜ pαᶜ L⊒L′) =
+  α⊒α qᶜ pαᶜ
+    (term-parallel-substitution-narrowing-framed env frame L⊒L′)
+term-parallel-substitution-narrowing-framed env frame
+    (⊒α pαᶜ L⊒L′) =
+  ⊒α pαᶜ
+    (term-parallel-substitution-narrowing-framed env frame L⊒L′)
+term-parallel-substitution-narrowing-framed env frame
+    (ν⊒ν pᶜ qᶜ N⊒N′) =
+  ν⊒ν pᶜ qᶜ
+    (term-parallel-substitution-narrowing-framed
+      env (frame-νν frame) N⊒N′)
+term-parallel-substitution-narrowing-framed env frame
+    (⊒ν {N = N} pᶜ N⊒N′) =
+  ⊒ν pᶜ
+    (subst
+      (λ L → _ ∣ _ ∣ _ ⊢ L ⊒ _ ∶ _)
+      (substˣᵐ-shift _ N)
+      (term-parallel-substitution-narrowing-framed
+        env (frame-src⇑ frame) N⊒N′))
+term-parallel-substitution-narrowing-framed env frame
+    (ν⊒ {N′ = N′} pᶜ N⊒N′) =
+  ν⊒ pᶜ
+    (subst
+      (λ R → _ ∣ _ ∣ _ ⊢ _ ⊒ R ∶ _)
+      (substˣᵐ-shift _ N′)
+      (term-parallel-substitution-narrowing-framed
+        env (frame-tgt⇑ frame) N⊒N′))
+term-parallel-substitution-narrowing-framed env frame (κ⊒κ κ) = κ⊒κ κ
+term-parallel-substitution-narrowing-framed env frame
+    (⊕⊒⊕ M⊒M′ N⊒N′) =
+  ⊕⊒⊕
+    (term-parallel-substitution-narrowing-framed env frame M⊒M′)
+    (term-parallel-substitution-narrowing-framed env frame N⊒N′)
+term-parallel-substitution-narrowing-framed env frame
+    (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast+ qᶜ q⨟s≈r
+    (term-parallel-substitution-narrowing-framed env frame M⊒M′)
+term-parallel-substitution-narrowing-framed env frame
+    (⊒cast- qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast- qᶜ q⨟s≈r
+    (term-parallel-substitution-narrowing-framed env frame M⊒M′)
+term-parallel-substitution-narrowing-framed env frame
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast+⊒ pᶜ r≈t⨟p
+    (term-parallel-substitution-narrowing-framed env frame M⊒M′)
+term-parallel-substitution-narrowing-framed env frame
+    (cast-⊒ pᶜ r≈t⨟p M⊒M′) =
+  cast-⊒ pᶜ r≈t⨟p
+    (term-parallel-substitution-narrowing-framed env frame M⊒M′)
+
+term-parallel-substitution-narrowing :
+  ∀ {Δ σ γ γ′ M M′ p τ τ′} →
+  SubstNrwFamily γ γ′ τ τ′ →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p →
+  Δ ∣ σ ∣ γ′ ⊢ substˣᵐ τ M ⊒ substˣᵐ τ′ M′ ∶ p
+term-parallel-substitution-narrowing env =
+  term-parallel-substitution-narrowing-framed env frame-id
+
+singleSubstNrw :
+  ∀ {Δ σ γ V V′ q} →
+  Δ ∣ σ ∣ γ ⊢ V ⊒ V′ ∶ q →
+  SubstNrw Δ σ (q ∷ γ) γ (singleEnv V) (singleEnv V′)
+singleSubstNrw V⊒V′ pᶜ Z = V⊒V′
+singleSubstNrw V⊒V′ pᶜ (S x∋p) = x⊒x pᶜ x∋p
+
+------------------------------------------------------------------------
+-- Single-variable substitution
+------------------------------------------------------------------------
+
+term-substitution-narrowing :
+  ∀ {Δ σ γ N N′ V V′ p q} →
+  SubstNrwFamily (q ∷ γ) γ (singleEnv V) (singleEnv V′) →
+  Δ ∣ σ ∣ q ∷ γ ⊢ N ⊒ N′ ∶ p →
+  Δ ∣ σ ∣ γ ⊢ N [ V ] ⊒ N′ [ V′ ] ∶ p
+term-substitution-narrowing env N⊒N′ =
+  term-parallel-substitution-narrowing env N⊒N′

--- a/GTSF/proof/TermSubstitutionNarrowingExamples.md
+++ b/GTSF/proof/TermSubstitutionNarrowingExamples.md
@@ -1,0 +1,323 @@
+# Term substitution narrowing: induction-hypothesis examples
+
+These are schematic examples for choosing the induction hypothesis for
+`term-parallel-substitution-narrowing`.
+
+The current one-store environment premise is:
+
+```agda
+SubstNrw Δ σ γ γ′ τ τ′ =
+  ∀ {x p A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  γ ∋ x ⦂ p →
+  Δ ∣ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ p
+```
+
+The examples below show where this premise is too narrow.
+
+## Same-store cases
+
+For `x⊒x`, `⊒blame`, application, constants, primitive operations, and casts,
+the recursive premises stay at the same store and type context.
+
+Example:
+
+```agda
+·⊒· qᶜ L⊒L′ M⊒M′
+```
+
+After substitution the direct recursive calls need exactly the same
+substitution environment at the same `Δ`, `σ`, `γ`, and `γ′`.
+
+The variable case fixes the lookup shape:
+
+```agda
+x⊒x pᶜ x∋p
+```
+
+The proof obligation is:
+
+```agda
+Δ ∣ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ p
+```
+
+So the environment premise must still be lookup-indexed by a coercion typing
+proof for the current store.
+
+## `extend`
+
+Input shape:
+
+```agda
+extend qᶜ pαᶜ M⊒N′α
+
+M⊒N′α :
+  Δ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ
+    ⊢ M ⊒ N′ [ α ]ᵀ ∶ p [ α ]ᶜ
+```
+
+The conclusion store is `(α ꞉ q) ∷ σ`, but the recursive premise store is
+`(α ꞉= A ⊒) ∷ σ`.  If `M` contains a variable, the recursive substitution proof
+needs:
+
+```agda
+Δ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ r
+```
+
+The current premise only gives the corresponding fact at `(α ꞉ q) ∷ σ`.
+
+There is also an opened-target obligation.  The recursive call on
+`M⊒N′α` gives a right term of the form:
+
+```agda
+substˣᵐ τ′ (N′ [ α ]ᵀ)
+```
+
+but `extend` wants an opened right term:
+
+```agda
+N₂ [ α ]ᵀ
+```
+
+The useful witness is:
+
+```agda
+N₂ = substˣᵐ (↑ᵗᵐ τ′) N′
+```
+
+so this case also needs a commutation lemma:
+
+```agda
+substˣᵐ τ′ (N′ [ α ]ᵀ) ≡
+  (substˣᵐ (↑ᵗᵐ τ′) N′) [ α ]ᵀ
+```
+
+## `split`
+
+Input shape:
+
+```agda
+split qᶜ pαᶜ Nα⊒N′α
+
+Nα⊒N′α :
+  Δ ∣ (α ꞉ q) ∷ σ ∣ γ
+    ⊢ N [ α ]ᵀ ⊒ N′ [ α ]ᵀ ∶ p [ α ]ᶜ
+```
+
+The conclusion store is `(α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ`, but the recursive
+premise store is `(α ꞉ q) ∷ σ`.  So the substitution environment must also be
+available at that normal-head store.
+
+Both sides of the recursive result have opened terms, so the same opening
+commutation lemma is needed on each side, with witnesses:
+
+```agda
+substˣᵐ (↑ᵗᵐ τ)  N
+substˣᵐ (↑ᵗᵐ τ′) N′
+```
+
+## Store-dropping cases
+
+The `α⊒α` and `⊒α` cases recurse on the tail store.
+
+Example:
+
+```agda
+α⊒α qᶜ pαᶜ L⊒L′
+
+L⊒L′ :
+  Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ `∀ p
+```
+
+The conclusion store is `(α ꞉ q) ∷ σ`, but the recursive premise is at `σ`.
+The current one-store premise cannot supply substitution entries at this tail
+store.
+
+The `⊒α` case has the same shape, except the conclusion store is
+`(α ꞉= A ⊒) ∷ σ`.
+
+## Term binder
+
+Input shape:
+
+```agda
+ƛ⊒ƛ p↦qᶜ N⊒N′
+
+N⊒N′ :
+  Δ ∣ σ ∣ (- p) ∷ γ ⊢ N ⊒ N′ ∶ q
+```
+
+The recursive substitution environment must extend over the term variable:
+
+```agda
+extˢˣ τ
+extˢˣ τ′
+```
+
+The `S` lookup case needs a term-variable weakening lemma for term narrowing:
+
+```agda
+Δ ∣ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ r
+-------------------------------------------------
+Δ ∣ σ ∣ s ∷ γ′
+  ⊢ renameˣᵐ suc (τ x) ⊒ renameˣᵐ suc (τ′ x) ∶ r
+```
+
+The `Z` lookup case needs `x⊒x` at `- p`; that requires an arrow-coercion
+inversion/dual lemma from `p ↦ q`.
+
+## Type binder
+
+Input shape:
+
+```agda
+Λ⊒Λ allᶜ vV V⊒V′
+
+V⊒V′ :
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ V ⊒ V′ ∶ p
+```
+
+The recursive substitution environment must be lifted:
+
+```agda
+↑ᵗᵐ τ
+↑ᵗᵐ τ′
+```
+
+This needs a type-renaming lemma for term narrowing:
+
+```agda
+Δ ∣ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ r
+-------------------------------------------------
+suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ′
+  ⊢ renameᵗᵐ suc (τ x) ⊒ renameᵗᵐ suc (τ′ x) ∶ ⇑ᶜ r
+```
+
+The same lifted environment is needed for the recursive premise of `⊒Λ`, with
+the additional head store:
+
+```agda
+(zero ꞉= ★ ⊒) ∷ ⇑ˢ σ
+```
+
+Those cases also need the shift/substitution equation:
+
+```agda
+substˣᵐ (↑ᵗᵐ τ) (⇑ᵗᵐ N) ≡ ⇑ᵗᵐ (substˣᵐ τ N)
+```
+
+## `ν` and source/target-shift cases
+
+The `ν`-related cases are sharper than the ordinary type-binder cases because
+the side that appears as `⇑ᵗᵐ _` determines which substitution environment must
+be lifted.
+
+Example:
+
+```agda
+ν⊒ν pᶜ qᶜ N⊒N′
+
+N⊒N′ :
+  suc Δ ∣ (zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ N ⊒ N′ ∶ ⇑ᶜ p
+```
+
+To use the IH on `N⊒N′`, the natural lifted environment is:
+
+```agda
+τ
+τ′
+```
+
+This matches the definition of term substitution:
+
+```agda
+substˣᵐ τ (ν A N c) = ν A (substˣᵐ τ N) c
+```
+
+So `ν⊒ν` needs a frame that shifts the term-variable contexts to `⇑ᵍ γ` and
+`⇑ᵍ γ′`, but keeps both substitution environments unchanged.
+
+The asymmetric cases are different:
+
+```agda
+⊒ν :
+  suc Δ ∣ (zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ N ⊒ N′ ∶ ⇑ᶜ p
+
+ν⊒ :
+  suc Δ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ N ⊒ ⇑ᵗᵐ N′ ∶ ⇑ᶜ p
+```
+
+For `⊒ν`, the source side appears as `⇑ᵗᵐ N`, so the IH must use source
+environment `↑ᵗᵐ τ` and target environment `τ′`.  The reconstruction uses:
+
+```agda
+substˣᵐ (↑ᵗᵐ τ) (⇑ᵗᵐ N) ≡ ⇑ᵗᵐ (substˣᵐ τ N)
+```
+
+For `ν⊒`, the target side appears as `⇑ᵗᵐ N′`, so the IH must use source
+environment `τ` and target environment `↑ᵗᵐ τ′`.
+
+The `⊒⟨ν⟩` case has the same source-lift shape as `⊒ν`: its source premise is
+`⇑ᵗᵐ N`, but its target is a casted term `V′ ⟨ s ⟩`, so the target environment
+stays `τ′`.
+
+The head stores involved are:
+
+```agda
+(zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ
+(zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ
+(⊒ zero ꞉=☆) ∷ ⇑ˢ σ
+```
+
+This is not a problem with the definition of `substˣᵐ`; it is a problem with a
+one-store, one-context substitution premise.  The induction needs to know which
+recursive frames use `τ`, `τ′`, `↑ᵗᵐ τ`, and `↑ᵗᵐ τ′`.
+
+## Candidate IH shape
+
+The examples point to a frame-indexed substitution premise rather than a
+single-store premise.
+
+The checked Agda formulation uses frames of the following shape:
+
+```agda
+SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′
+```
+
+with constructors for:
+
+```agda
+frame-id
+frame-ƛ
+frame-Λ
+frame-νν
+frame-src⇑
+frame-tgt⇑
+```
+
+The environment premise is then:
+
+```agda
+SubstNrwFamily γ₀ γ₀′ τ₀ τ₀′ =
+  ∀ {Δ σ γ γ′ τ τ′} →
+  SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
+  SubstNrw Δ σ γ γ′ τ τ′
+```
+
+This premise is intentionally store-polymorphic: store-changing constructors
+such as `extend`, `split`, `α⊒α`, and `⊒α` simply invoke the family at the
+recursive store.
+
+The important consequence is that the old single-substitution corollary cannot
+be instantiated from only:
+
+```agda
+Δ ∣ σ ∣ γ ⊢ V ⊒ V′ ∶ q
+```
+
+unless there is an additional lemma or side condition showing that `V ⊒ V′` is
+available for all recursive frames, including the asymmetric source/target
+shift frames.


### PR DESCRIPTION
## Summary
- Add proof.TermSubstitutionNarrowing with term-substitution/type-renaming commutation lemmas and the GTSF term substitution narrowing proof.
- Prove parallel substitution narrowing via a frame-indexed SubstNrwFamily, then expose the frame-id theorem used by single substitution.
- Replace the local DynamicGradualGuarantee substitution postulate with an import from proof.TermSubstitutionNarrowing.
- Add a proof note documenting the examples that forced the generalized induction hypothesis.

## What had to change
The original one-store SubstNrw premise was not strong enough for induction over TermNarrowing. Store-shaping rules such as extend, split, alpha/application store cases recurse under different StoreNrw contexts, so the substitution premise must be store-polymorphic.

The binder cases also forced a frame-indexed formulation. Lambda extends both substitutions with extˢˣ. Lambda-abstraction over types lifts both sides with ↑ᵗᵐ. The nu-related rules are asymmetric: nu/nu shifts contexts but keeps both substitutions unchanged, right-nu and right-nu-cast lift only the source substitution, and left-nu lifts only the target substitution. This is why the proof introduces SubstFrame and SubstNrwFamily instead of trying to reuse the old fixed-store statement.

DynamicGradualGuarantee now imports the theorem. Its beta helper supplies the stronger family premise as an existing skeleton obligation, rather than keeping a duplicate postulate for substitution.

## Verification
- agda -i GTSF -i . GTSF/proof/TermSubstitutionNarrowing.agda
- agda -i GTSF -i . GTSF/proof/DynamicGradualGuarantee.agda