### PR TITLE
[codex] Add filled raw cast narrowing

### DIFF
--- a/GTSF/NarrowWiden.agda
+++ b/GTSF/NarrowWiden.agda
@@ -119,6 +119,268 @@ mutual
       Widening (unseal α A ︔ s)
 
 ------------------------------------------------------------------------
+-- Filling raw identities into canonical narrowings and widenings
+------------------------------------------------------------------------
+
+mutual
+  idⁿᶜ : Ty → Coercion
+  idⁿᶜ (＇ α) = id (＇ α)
+  idⁿᶜ (‵ ι) = id (‵ ι)
+  idⁿᶜ ★ = id ★
+  idⁿᶜ (A ⇒ B) = idʷᶜ A ↦ idⁿᶜ B
+  idⁿᶜ (`∀ A) = `∀ (idⁿᶜ A)
+
+  idʷᶜ : Ty → Coercion
+  idʷᶜ (＇ α) = id (＇ α)
+  idʷᶜ (‵ ι) = id (‵ ι)
+  idʷᶜ ★ = id ★
+  idʷᶜ (A ⇒ B) = idⁿᶜ A ↦ idʷᶜ B
+  idʷᶜ (`∀ A) = `∀ (idʷᶜ A)
+
+mutual
+  idⁿ : (A : Ty) → Narrowing (idⁿᶜ A)
+  idⁿ (＇ α) = cross (id-＇ α)
+  idⁿ (‵ ι) = cross (id-‵ ι)
+  idⁿ ★ = id★
+  idⁿ (A ⇒ B) = cross (idʷ A ↦ idⁿ B)
+  idⁿ (`∀ A) = cross (`∀ (idⁿ A))
+
+  idʷ : (A : Ty) → Widening (idʷᶜ A)
+  idʷ (＇ α) = cross (id-＇ α)
+  idʷ (‵ ι) = cross (id-‵ ι)
+  idʷ ★ = id★
+  idʷ (A ⇒ B) = cross (idⁿ A ↦ idʷ B)
+  idʷ (`∀ A) = cross (`∀ (idʷ A))
+
+mutual
+  idⁿᶜ-rename : ∀ ρ A → renameᶜ ρ (idⁿᶜ A) ≡ idⁿᶜ (renameᵗ ρ A)
+  idⁿᶜ-rename ρ (＇ α) = refl
+  idⁿᶜ-rename ρ (‵ ι) = refl
+  idⁿᶜ-rename ρ ★ = refl
+  idⁿᶜ-rename ρ (A ⇒ B)
+      rewrite idʷᶜ-rename ρ A | idⁿᶜ-rename ρ B =
+    refl
+  idⁿᶜ-rename ρ (`∀ A) rewrite idⁿᶜ-rename (extᵗ ρ) A = refl
+
+  idʷᶜ-rename : ∀ ρ A → renameᶜ ρ (idʷᶜ A) ≡ idʷᶜ (renameᵗ ρ A)
+  idʷᶜ-rename ρ (＇ α) = refl
+  idʷᶜ-rename ρ (‵ ι) = refl
+  idʷᶜ-rename ρ ★ = refl
+  idʷᶜ-rename ρ (A ⇒ B)
+      rewrite idⁿᶜ-rename ρ A | idʷᶜ-rename ρ B =
+    refl
+  idʷᶜ-rename ρ (`∀ A) rewrite idʷᶜ-rename (extᵗ ρ) A = refl
+
+idTyAllowed-any : ∀ μ A → idTyAllowed μ A ≡ true
+idTyAllowed-any μ (＇ α) with μ α
+idTyAllowed-any μ (＇ α) | id-only = refl
+idTyAllowed-any μ (＇ α) | tag-or-id = refl
+idTyAllowed-any μ (＇ α) | seal-or-id = refl
+idTyAllowed-any μ (‵ ι) = refl
+idTyAllowed-any μ ★ = refl
+idTyAllowed-any μ (A ⇒ B)
+    rewrite idTyAllowed-any μ A | idTyAllowed-any μ B =
+  refl
+idTyAllowed-any μ (`∀ A) = idTyAllowed-any (extᵈ μ) A
+
+mutual
+  idⁿ-typed :
+    ∀ {μ Δ Σ A} →
+    WfTy Δ A →
+    (μ ∣ Δ ∣ Σ ⊢ idⁿᶜ A ∶ A =⇒ A) × Narrowing (idⁿᶜ A)
+  idⁿ-typed {μ = μ} {A = ＇ α} (wfVar α<Δ) =
+    cast-id (wfVar α<Δ) (idTyAllowed-any μ (＇ α)) , cross (id-＇ α)
+  idⁿ-typed {μ = μ} {A = ‵ ι} wfBase =
+    cast-id wfBase (idTyAllowed-any μ (‵ ι)) , cross (id-‵ ι)
+  idⁿ-typed {μ = μ} {A = ★} wf★ =
+    cast-id wf★ (idTyAllowed-any μ ★) , id★
+  idⁿ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = A ⇒ B} (wf⇒ hA hB) =
+    cast-fun (proj₁ s⊑) (proj₁ t⊒) , cross (proj₂ s⊑ ↦ proj₂ t⊒)
+    where
+      s⊑ = idʷ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = A} hA
+      t⊒ = idⁿ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = B} hB
+  idⁿ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = `∀ A} (wf∀ hA) =
+    cast-all (proj₁ s⊒) , cross (`∀ (proj₂ s⊒))
+    where
+      s⊒ = idⁿ-typed {μ = extᵈ μ} {Δ = suc Δ} {Σ = ⟰ᵗ Σ}
+                      {A = A} hA
+
+  idʷ-typed :
+    ∀ {μ Δ Σ A} →
+    WfTy Δ A →
+    (μ ∣ Δ ∣ Σ ⊢ idʷᶜ A ∶ A =⇒ A) × Widening (idʷᶜ A)
+  idʷ-typed {μ = μ} {A = ＇ α} (wfVar α<Δ) =
+    cast-id (wfVar α<Δ) (idTyAllowed-any μ (＇ α)) , cross (id-＇ α)
+  idʷ-typed {μ = μ} {A = ‵ ι} wfBase =
+    cast-id wfBase (idTyAllowed-any μ (‵ ι)) , cross (id-‵ ι)
+  idʷ-typed {μ = μ} {A = ★} wf★ =
+    cast-id wf★ (idTyAllowed-any μ ★) , id★
+  idʷ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = A ⇒ B} (wf⇒ hA hB) =
+    cast-fun (proj₁ s⊒) (proj₁ t⊑) , cross (proj₂ s⊒ ↦ proj₂ t⊑)
+    where
+      s⊒ = idⁿ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = A} hA
+      t⊑ = idʷ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = B} hB
+  idʷ-typed {μ = μ} {Δ = Δ} {Σ = Σ} {A = `∀ A} (wf∀ hA) =
+    cast-all (proj₁ s⊑) , cross (`∀ (proj₂ s⊑))
+    where
+      s⊑ = idʷ-typed {μ = extᵈ μ} {Δ = suc Δ} {Σ = ⟰ᵗ Σ}
+                      {A = A} hA
+
+mutual
+  data FillCrossNarrowing : Coercion → Coercion → Set where
+    fill-crossⁿ : ∀ {g} →
+      CrossNarrowing g →
+      FillCrossNarrowing g g
+
+    fill-↦ⁿ : ∀ {s s′ t t′} →
+      FillWidening s s′ →
+      FillNarrowing t t′ →
+      FillCrossNarrowing (s ↦ t) (s′ ↦ t′)
+
+    fill-∀ⁿ : ∀ {s s′} →
+      FillNarrowing s s′ →
+      FillCrossNarrowing (`∀ s) (`∀ s′)
+
+  data FillNarrowing : Coercion → Coercion → Set where
+    fill-narrowing : ∀ {s} →
+      Narrowing s →
+      FillNarrowing s s
+
+    fill-idⁿ : ∀ A →
+      FillNarrowing (id A) (idⁿᶜ A)
+
+    fill-cross : ∀ {g g′} →
+      FillCrossNarrowing g g′ →
+      FillNarrowing g g′
+
+    fill-gen : ∀ {s s′ A} →
+      FillNarrowing s s′ →
+      FillNarrowing (gen A s) (gen A s′)
+
+    fill-untag-id : ∀ {G} →
+      Ground G →
+      FillNarrowing (G ？) ((G ？) ︔ idⁿᶜ G)
+
+    fill-untag : ∀ {G g g′} →
+      Ground G →
+      FillCrossNarrowing g g′ →
+      FillNarrowing ((G ？) ︔ g) ((G ？) ︔ g′)
+
+    fill-seal-id : ∀ A α →
+      FillNarrowing (seal A α) (idⁿᶜ A ︔ seal A α)
+
+    fill-seal : ∀ {s s′ A α} →
+      FillNarrowing s s′ →
+      FillNarrowing (s ︔ seal A α) (s′ ︔ seal A α)
+
+  data FillCrossWidening : Coercion → Coercion → Set where
+    fill-crossʷ : ∀ {g} →
+      CrossWidening g →
+      FillCrossWidening g g
+
+    fill-↦ʷ : ∀ {s s′ t t′} →
+      FillNarrowing s s′ →
+      FillWidening t t′ →
+      FillCrossWidening (s ↦ t) (s′ ↦ t′)
+
+    fill-∀ʷ : ∀ {s s′} →
+      FillWidening s s′ →
+      FillCrossWidening (`∀ s) (`∀ s′)
+
+  data FillWidening : Coercion → Coercion → Set where
+    fill-widening : ∀ {s} →
+      Widening s →
+      FillWidening s s
+
+    fill-idʷ : ∀ A →
+      FillWidening (id A) (idʷᶜ A)
+
+    fill-crossʷ′ : ∀ {g g′} →
+      FillCrossWidening g g′ →
+      FillWidening g g′
+
+    fill-inst : ∀ {s s′ B} →
+      FillWidening s s′ →
+      FillWidening (inst B s) (inst B s′)
+
+    fill-tag-id : ∀ {G} →
+      Ground G →
+      FillWidening (G !) (idʷᶜ G ︔ (G !))
+
+    fill-tag : ∀ {G g g′} →
+      FillCrossWidening g g′ →
+      Ground G →
+      FillWidening (g ︔ (G !)) (g′ ︔ (G !))
+
+    fill-unseal-id : ∀ α A →
+      FillWidening (unseal α A) (unseal α A ︔ idʷᶜ A)
+
+    fill-unseal : ∀ {s s′ A α} →
+      FillWidening s s′ →
+      FillWidening (unseal α A ︔ s) (unseal α A ︔ s′)
+
+mutual
+  fillCrossNarrowing-narrowing :
+    ∀ {g g′} →
+    FillCrossNarrowing g g′ →
+    CrossNarrowing g′
+  fillCrossNarrowing-narrowing (fill-crossⁿ gⁿ) = gⁿ
+  fillCrossNarrowing-narrowing (fill-↦ⁿ s⇝ t⇝) =
+    fillWidening-widening s⇝ ↦ fillNarrowing-narrowing t⇝
+  fillCrossNarrowing-narrowing (fill-∀ⁿ s⇝) =
+    `∀ (fillNarrowing-narrowing s⇝)
+
+  fillNarrowing-narrowing :
+    ∀ {s s′} →
+    FillNarrowing s s′ →
+    Narrowing s′
+  fillNarrowing-narrowing (fill-narrowing sⁿ) = sⁿ
+  fillNarrowing-narrowing (fill-idⁿ A) = idⁿ A
+  fillNarrowing-narrowing (fill-cross g⇝) =
+    cross (fillCrossNarrowing-narrowing g⇝)
+  fillNarrowing-narrowing (fill-gen s⇝) =
+    gen (fillNarrowing-narrowing s⇝)
+  fillNarrowing-narrowing (fill-untag-id (＇ α)) = (＇ α) ？︔ id-＇ α
+  fillNarrowing-narrowing (fill-untag-id (‵ ι)) = (‵ ι) ？︔ id-‵ ι
+  fillNarrowing-narrowing (fill-untag-id ★⇒★) = ★⇒★ ？︔ (idʷ ★ ↦ idⁿ ★)
+  fillNarrowing-narrowing (fill-untag gG g⇝) =
+    gG ？︔ fillCrossNarrowing-narrowing g⇝
+  fillNarrowing-narrowing (fill-seal-id A α) =
+    fillNarrowing-narrowing (fill-idⁿ A) ︔seal α
+  fillNarrowing-narrowing (fill-seal s⇝) =
+    fillNarrowing-narrowing s⇝ ︔seal _
+
+  fillCrossWidening-widening :
+    ∀ {g g′} →
+    FillCrossWidening g g′ →
+    CrossWidening g′
+  fillCrossWidening-widening (fill-crossʷ gʷ) = gʷ
+  fillCrossWidening-widening (fill-↦ʷ s⇝ t⇝) =
+    fillNarrowing-narrowing s⇝ ↦ fillWidening-widening t⇝
+  fillCrossWidening-widening (fill-∀ʷ s⇝) =
+    `∀ (fillWidening-widening s⇝)
+
+  fillWidening-widening :
+    ∀ {s s′} →
+    FillWidening s s′ →
+    Widening s′
+  fillWidening-widening (fill-widening sʷ) = sʷ
+  fillWidening-widening (fill-idʷ A) = idʷ A
+  fillWidening-widening (fill-crossʷ′ g⇝) =
+    cross (fillCrossWidening-widening g⇝)
+  fillWidening-widening (fill-inst s⇝) =
+    inst (fillWidening-widening s⇝)
+  fillWidening-widening (fill-tag-id (＇ α)) = id-＇ α ︔ (＇ α) !
+  fillWidening-widening (fill-tag-id (‵ ι)) = id-‵ ι ︔ (‵ ι) !
+  fillWidening-widening (fill-tag-id ★⇒★) = (idⁿ ★ ↦ idʷ ★) ︔ ★⇒★ !
+  fillWidening-widening (fill-tag g⇝ gG) =
+    fillCrossWidening-widening g⇝ ︔ gG !
+  fillWidening-widening (fill-unseal-id α A) =
+    unseal︔_ α (fillWidening-widening (fill-idʷ A))
+  fillWidening-widening (fill-unseal s⇝) =
+    unseal︔_ _ (fillWidening-widening s⇝)
+
+------------------------------------------------------------------------
 -- Grammar-directed duality for narrowing and widening
 ------------------------------------------------------------------------
 
@@ -359,6 +621,81 @@ mutual
   renameʷ ρ (gʷ ︔ gG !) =
     renameCrossWidening ρ gʷ ︔ renameᵗ-ground ρ gG !
   renameʷ ρ (unseal︔_ α sʷ) = unseal︔_ (ρ α) (renameʷ ρ sʷ)
+
+mutual
+  renameFillCrossNarrowing :
+    ∀ ρ {c c′} →
+    FillCrossNarrowing c c′ →
+    FillCrossNarrowing (renameᶜ ρ c) (renameᶜ ρ c′)
+  renameFillCrossNarrowing ρ (fill-crossⁿ cⁿ) =
+    fill-crossⁿ (renameCrossNarrowing ρ cⁿ)
+  renameFillCrossNarrowing ρ (fill-↦ⁿ s⇝ t⇝) =
+    fill-↦ⁿ (renameFillWidening ρ s⇝) (renameFillNarrowing ρ t⇝)
+  renameFillCrossNarrowing ρ (fill-∀ⁿ s⇝) =
+    fill-∀ⁿ (renameFillNarrowing (extᵗ ρ) s⇝)
+
+  renameFillNarrowing :
+    ∀ ρ {c c′} →
+    FillNarrowing c c′ →
+    FillNarrowing (renameᶜ ρ c) (renameᶜ ρ c′)
+  renameFillNarrowing ρ (fill-narrowing cⁿ) =
+    fill-narrowing (renameⁿ ρ cⁿ)
+  renameFillNarrowing ρ (fill-idⁿ A) rewrite idⁿᶜ-rename ρ A =
+    fill-idⁿ (renameᵗ ρ A)
+  renameFillNarrowing ρ (fill-cross c⇝) =
+    fill-cross (renameFillCrossNarrowing ρ c⇝)
+  renameFillNarrowing ρ (fill-gen c⇝) =
+    fill-gen (renameFillNarrowing (extᵗ ρ) c⇝)
+  renameFillNarrowing ρ (fill-untag-id (＇ α)) =
+    fill-untag-id (＇ ρ α)
+  renameFillNarrowing ρ (fill-untag-id (‵ ι)) =
+    fill-untag-id (‵ ι)
+  renameFillNarrowing ρ (fill-untag-id ★⇒★) =
+    fill-untag-id ★⇒★
+  renameFillNarrowing ρ (fill-untag gG c⇝) =
+    fill-untag (renameᵗ-ground ρ gG) (renameFillCrossNarrowing ρ c⇝)
+  renameFillNarrowing ρ (fill-seal-id A α)
+      rewrite idⁿᶜ-rename ρ A =
+    fill-seal-id (renameᵗ ρ A) (ρ α)
+  renameFillNarrowing ρ (fill-seal c⇝) =
+    fill-seal (renameFillNarrowing ρ c⇝)
+
+  renameFillCrossWidening :
+    ∀ ρ {c c′} →
+    FillCrossWidening c c′ →
+    FillCrossWidening (renameᶜ ρ c) (renameᶜ ρ c′)
+  renameFillCrossWidening ρ (fill-crossʷ cʷ) =
+    fill-crossʷ (renameCrossWidening ρ cʷ)
+  renameFillCrossWidening ρ (fill-↦ʷ s⇝ t⇝) =
+    fill-↦ʷ (renameFillNarrowing ρ s⇝) (renameFillWidening ρ t⇝)
+  renameFillCrossWidening ρ (fill-∀ʷ s⇝) =
+    fill-∀ʷ (renameFillWidening (extᵗ ρ) s⇝)
+
+  renameFillWidening :
+    ∀ ρ {c c′} →
+    FillWidening c c′ →
+    FillWidening (renameᶜ ρ c) (renameᶜ ρ c′)
+  renameFillWidening ρ (fill-widening cʷ) =
+    fill-widening (renameʷ ρ cʷ)
+  renameFillWidening ρ (fill-idʷ A) rewrite idʷᶜ-rename ρ A =
+    fill-idʷ (renameᵗ ρ A)
+  renameFillWidening ρ (fill-crossʷ′ c⇝) =
+    fill-crossʷ′ (renameFillCrossWidening ρ c⇝)
+  renameFillWidening ρ (fill-inst c⇝) =
+    fill-inst (renameFillWidening (extᵗ ρ) c⇝)
+  renameFillWidening ρ (fill-tag-id (＇ α)) =
+    fill-tag-id (＇ ρ α)
+  renameFillWidening ρ (fill-tag-id (‵ ι)) =
+    fill-tag-id (‵ ι)
+  renameFillWidening ρ (fill-tag-id ★⇒★) =
+    fill-tag-id ★⇒★
+  renameFillWidening ρ (fill-tag c⇝ gG) =
+    fill-tag (renameFillCrossWidening ρ c⇝) (renameᵗ-ground ρ gG)
+  renameFillWidening ρ (fill-unseal-id α A)
+      rewrite idʷᶜ-rename ρ A =
+    fill-unseal-id (ρ α) (renameᵗ ρ A)
+  renameFillWidening ρ (fill-unseal c⇝) =
+    fill-unseal (renameFillWidening ρ c⇝)
 
 narrow-mode-relax :
   ∀ {μ ν Δ Σ A B c} →

--- a/GTSF/NarrowWidenComposition.agda
+++ b/GTSF/NarrowWidenComposition.agda
@@ -383,6 +383,15 @@ data _∣_⊢_⨾ⁿ_≈_∶_⊒_ :
      --------------------------------
     → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
 
+  compose-left-fillⁿ : ∀ {Δ σ Σ μ A B C q s s′ r}
+    → (wfΣ : StoreDetWf Δ Σ)
+    → (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C)
+    → FillNarrowing s s′
+    → (s′⊒ : μ ∣ Δ ∣ Σ ⊢ s′ ∶ C ⊒ B)
+    → Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s′⊒) ≈ r ∶ A ⊒ B
+     --------------------------------
+    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+
 data _∣_⊢_≈_⨾ⁿ_∶_⊒_ :
     TyCtx → StoreNrw → Coercion → Coercion → Coercion →
     Ty → Ty → Set₁ where
@@ -392,5 +401,14 @@ data _∣_⊢_≈_⨾ⁿ_∶_⊒_ :
     → (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ C)
     → (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ C ⊒ B)
     → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B
+     --------------------------------
+    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+
+  compose-right-fillⁿ : ∀ {Δ σ Σ μ A B C r t t′ p}
+    → (wfΣ : StoreDetWf Δ Σ)
+    → FillNarrowing t t′
+    → (t′⊒ : μ ∣ Δ ∣ Σ ⊢ t′ ∶ A ⊒ C)
+    → (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ C ⊒ B)
+    → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t′⊒ p⊒) ∶ A ⊒ B
      --------------------------------
     → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B

--- a/GTSF/TermNarrowing.agda
+++ b/GTSF/TermNarrowing.agda
@@ -8,8 +8,9 @@
 
   Freshness side conditions from the paper are not reified here.  The paper's
   +/- cast notation is represented using NuTerms' single raw cast form and the
-  coercion dual operator `-_`, with the corresponding coercion-equivalence
-  premise made explicit.
+  coercion dual operator `-_`.  Cast rules compose through the side-condition
+  relations from NarrowWidenComposition, which first fill raw identity/tag/seal
+  coercions into canonical narrowings before applying canonical composition.
 -}
 
 module TermNarrowing where

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -370,6 +370,28 @@ compose-leftⁿ-⇑ˢ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
         (≈ⁿ-⇑ˢ q⨟s≈r)
   in
   compose-leftⁿ (StoreDetWf-⟰ᵗ wfΣ) q⊒′ s⊒′ eq′
+compose-leftⁿ-⇑ˢ (compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒ q⨟s≈r) =
+  let
+    q⊒′ = narrow-⇑ᵗ-gen q⊒
+    s′⊒′ = narrow-⇑ᵗ-gen s′⊒
+    old = _⨟ⁿ_ {wfΣ = wfΣ} q⊒ s′⊒
+    new = _⨟ⁿ_ {wfΣ = StoreDetWf-⟰ᵗ wfΣ} q⊒′ s′⊒′
+    u≡ =
+      narrowing-determinedᵐ (StoreDetWf-⟰ᵗ wfΣ)
+        (proj₂ new)
+        (narrow-⇑ᵗ-gen (proj₂ old))
+    eq′ =
+      subst
+        (λ u → _ ∣ _ ⊢ u ≈ ⇑ᶜ _ ∶ _ ⊒ _)
+        (sym u≡)
+        (≈ⁿ-⇑ˢ q⨟s≈r)
+  in
+  compose-left-fillⁿ
+    (StoreDetWf-⟰ᵗ wfΣ)
+    q⊒′
+    (renameFillNarrowing suc s⇝)
+    s′⊒′
+    eq′
 
 compose-leftⁿ-add-left-star-var :
   ∀ X {Δ σ q s r A B} →
@@ -377,6 +399,10 @@ compose-leftⁿ-add-left-star-var :
   Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
 compose-leftⁿ-add-left-star-var X (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
   compose-leftⁿ wfΣ q⊒ s⊒ (≈ⁿ-add-left-star-var X q⨟s≈r)
+compose-leftⁿ-add-left-star-var X
+    (compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒ q⨟s≈r) =
+  compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒
+    (≈ⁿ-add-left-star-var X q⨟s≈r)
 
 compose-rightⁿ-⇑ˢ :
   ∀ {Δ σ r t p A B} →
@@ -399,6 +425,28 @@ compose-rightⁿ-⇑ˢ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
         (≈ⁿ-⇑ˢ r≈t⨟p)
   in
   compose-rightⁿ (StoreDetWf-⟰ᵗ wfΣ) t⊒′ p⊒′ eq′
+compose-rightⁿ-⇑ˢ (compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒ r≈t⨟p) =
+  let
+    t′⊒′ = narrow-⇑ᵗ-gen t′⊒
+    p⊒′ = narrow-⇑ᵗ-gen p⊒
+    old = _⨟ⁿ_ {wfΣ = wfΣ} t′⊒ p⊒
+    new = _⨟ⁿ_ {wfΣ = StoreDetWf-⟰ᵗ wfΣ} t′⊒′ p⊒′
+    u≡ =
+      narrowing-determinedᵐ (StoreDetWf-⟰ᵗ wfΣ)
+        (proj₂ new)
+        (narrow-⇑ᵗ-gen (proj₂ old))
+    eq′ =
+      subst
+        (λ u → _ ∣ _ ⊢ ⇑ᶜ _ ≈ u ∶ _ ⊒ _)
+        (sym u≡)
+        (≈ⁿ-⇑ˢ r≈t⨟p)
+  in
+  compose-right-fillⁿ
+    (StoreDetWf-⟰ᵗ wfΣ)
+    (renameFillNarrowing suc t⇝)
+    t′⊒′
+    p⊒′
+    eq′
 
 compose-rightⁿ-add-left-star-var :
   ∀ X {Δ σ r t p A B} →
@@ -406,6 +454,10 @@ compose-rightⁿ-add-left-star-var :
   Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
 compose-rightⁿ-add-left-star-var X (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
   compose-rightⁿ wfΣ t⊒ p⊒ (≈ⁿ-add-left-star-var X r≈t⨟p)
+compose-rightⁿ-add-left-star-var X
+    (compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒ r≈t⨟p) =
+  compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒
+    (≈ⁿ-add-left-star-var X r≈t⨟p)
 
 catchup-compose-left-transport-shifted :
   ∀ n {Δ Δ′ σ π Π Π′ χs q s r A B} →
@@ -907,6 +959,10 @@ extendReplaceRel-compose-left :
 extendReplaceRel-compose-left rel
     (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
   compose-leftⁿ wfΣ q⊒ s⊒ (extendReplaceRel-≈ⁿ rel q⨟s≈r)
+extendReplaceRel-compose-left rel
+    (compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒ q⨟s≈r) =
+  compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒
+    (extendReplaceRel-≈ⁿ rel q⨟s≈r)
 
 extendReplaceRel-compose-right :
   ∀ {Δ σ σ′ r t p A B} →
@@ -916,6 +972,10 @@ extendReplaceRel-compose-right :
 extendReplaceRel-compose-right rel
     (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
   compose-rightⁿ wfΣ t⊒ p⊒ (extendReplaceRel-≈ⁿ rel r≈t⨟p)
+extendReplaceRel-compose-right rel
+    (compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒ r≈t⨟p) =
+  compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒
+    (extendReplaceRel-≈ⁿ rel r≈t⨟p)
 
 id-constᶜ :
   ∀ {Δ Σ} κ →

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -25,6 +25,7 @@ open import proof.Catchup using (catchup-lemma)
 open import proof.CatchupStore using (combineStoreNrw)
 open import proof.LeftSealNarrowingInversion using
   (LeftSealNarrowingInversion; leftSealNarrowingInversion)
+open import proof.RightTagInversion using (right-tag-inversion₁)
 open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowing)
@@ -34,11 +35,6 @@ open import proof.TermSubstitutionNarrowing using
 ------------------------------------------------------------------------
 
 postulate
-  right-tag-inversion₁ :
-    ∀ {Δ σ γ M V q G} →
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ! ⟩ ∶ q →
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ G ？
-
   right-tag-inversion₂ :
     ∀ {Δ σ γ M V r G} →
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ？ ⟩ ∶ r →

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -25,7 +25,6 @@ open import proof.Catchup using (catchup-lemma)
 open import proof.CatchupStore using (combineStoreNrw)
 open import proof.LeftSealNarrowingInversion using
   (LeftSealNarrowingInversion; leftSealNarrowingInversion)
-open import proof.RightTagInversion using (right-tag-inversion₁)
 open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowing)
@@ -327,28 +326,10 @@ dynamicGradualGuarantee (⊒cast+ {s = id A} qᶜ q⨟s≈r M⊒M′)
       vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒M′ =
   {!!}
 dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-ok vV))
-    with right-tag-inversion₂ (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-ok vV))
-    | M⊒V!
-    with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-ok vV))
-    | M⊒V!
-    | M⊒V =
+    (pure-step (tag-untag-ok vV)) =
   {!!}
 dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-bad vV H≢G))
-    with right-tag-inversion₂ (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-bad vV H≢G))
-    | M⊒V!
-    with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-bad vV H≢G))
-    | M⊒V!
-    | M⊒V =
+    (pure-step (tag-untag-bad vV H≢G)) =
   {!!}
 dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
@@ -378,28 +359,10 @@ dynamicGradualGuarantee (⊒cast- {s = id A} qᶜ q⨟s≈r M⊒M′)
       vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒M′ =
   {!!}
 dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-ok vV))
-    with right-tag-inversion₂ (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-ok vV))
-    | M⊒V!
-    with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-ok vV))
-    | M⊒V!
-    | M⊒V =
+    (pure-step (tag-untag-ok vV)) =
   {!!}
 dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-bad vV H≢G))
-    with right-tag-inversion₂ (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-bad vV H≢G))
-    | M⊒V!
-    with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (tag-untag-bad vV H≢G))
-    | M⊒V!
-    | M⊒V =
+    (pure-step (tag-untag-bad vV H≢G)) =
   {!!}
 dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))

--- a/GTSF/proof/LeftSealNarrowingInversion.agda
+++ b/GTSF/proof/LeftSealNarrowingInversion.agda
@@ -195,8 +195,22 @@ termNarrowing-gen-open-id-var-aux⊥ refl
     open-id =
   gen-open-id-var∃⊥ r⊒ open-id
 termNarrowing-gen-open-id-var-aux⊥ refl
+    (⊒cast- qᶜ
+      (compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒
+        (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+      M⊒M′)
+    open-id =
+  gen-open-id-var∃⊥ r⊒ open-id
+termNarrowing-gen-open-id-var-aux⊥ refl
     (cast+⊒ pᶜ
       (compose-rightⁿ wfΣ t⊒ p⊒
+        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      M⊒M′)
+    open-id =
+  gen-open-id-var∃⊥ r⊒ open-id
+termNarrowing-gen-open-id-var-aux⊥ refl
+    (cast+⊒ pᶜ
+      (compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒
         (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
       M⊒M′)
     open-id =
@@ -286,6 +300,11 @@ leftSealNarrowingInversion-aux eq refl vV
       (compose-rightⁿ wfΣ t⊒ p⊒
         (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
       M⊒M′) = {!!}
+leftSealNarrowingInversion-aux eq refl vV
+    (cast+⊒ pᶜ
+      (compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒
+        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
     (⊒blame (cast-id hα ok , cross (id-＇ α))) =
   (((＇ α) ？) ︔ id (＇ α)) ,
@@ -303,8 +322,18 @@ leftSealNarrowingInversion-aux refl refl vV
         (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
       M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
+    (⊒cast+ (cast-id hα okα , cross (id-＇ α))
+      (compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒
+        (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+      M⊒M′) = {!!}
+leftSealNarrowingInversion-aux refl refl vV
     (⊒cast- qᶜ
       (compose-leftⁿ wfΣ q⊒ s⊒
+        (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+      M⊒M′) = {!!}
+leftSealNarrowingInversion-aux refl refl vV
+    (⊒cast- qᶜ
+      (compose-left-fillⁿ wfΣ q⊒ s⇝ s′⊒
         (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
       M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
@@ -327,6 +356,11 @@ leftSealNarrowingInversion-aux refl refl vV
   termNarrowing-resp-≈
     (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
     M⊒M′
+leftSealNarrowingInversion-aux refl refl vV
+    (cast-⊒ pᶜ
+      (compose-right-fillⁿ wfΣ t⇝ t′⊒ p⊒
+        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      M⊒M′) = {!!}
 
 leftSealNarrowingInversion : LeftSealNarrowingInversion
 leftSealNarrowingInversion vV M⊒V′ =

--- a/GTSF/proof/RightTagInversion.agda
+++ b/GTSF/proof/RightTagInversion.agda
@@ -1,150 +1,91 @@
 module proof.RightTagInversion where
 
 -- File Charter:
---   * Structural inversion lemmas for term narrowing whose target is a raw
+--   * Records why the old `right-tag-inversion₁` statement is not compatible
+--     with filled raw casts.
+--   * Provides a concrete term-narrowing derivation whose target is a raw
 --     right tag `V ⟨ G ! ⟩`.
---   * Proves `right-tag-inversion₁` used by the dynamic gradual guarantee.
 --   * Depends only on term narrowing, coercion grammar, and narrowing
 --     composition side conditions; it does not depend on catchup.
 
-open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (zero)
 open import Data.Product using (_,_)
+open import Agda.Builtin.Equality using (refl)
 
 open import Types
 open import Coercions
+open import Primitives
 open import NuTerms
 open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing
+open import proof.NarrowWidenProperties using (StoreDetWf)
 
 ------------------------------------------------------------------------
 -- Proof-strategy log
 ------------------------------------------------------------------------
 
--- 1. Direct inversion on `⊒cast+` first looked promising: a target
---    `V ⟨ G ! ⟩` would have to come from `- s`, so `s` must be raw
---    `G ？`.  This fails as a productive branch because raw `G ？` is not
---    a narrowing grammar form; only `(G ？) ︔ g` is.
--- 2. The symmetric `⊒cast-` branch would need raw `G !` as a narrowing.
---    That fails for the same reason: tags live in the widening grammar, not
---    as bare narrowing spines.
--- 3. Left-cast and store-prefix constructors do not introduce the right tag;
---    they only preserve the target shape, so recurse through them.
---
--- The resulting proof is vacuous: no valid term-narrowing derivation can have
--- a raw right target tag `G !`.
+-- 1. Direct inversion on `⊒cast+` was vacuous before filled raw casts:
+--    a target `V ⟨ G ! ⟩` forced the source cast argument to be raw `G ？`,
+--    and raw `G ？` was not a narrowing grammar form.
+-- 2. Filling raw `G ？` with `id_G` changes that branch into a real case:
+--    the cast side condition can compose with `(G ？) ︔ id_G`.
+-- 3. Therefore the old conclusion `M ⊒ V ∶ G ？` is the wrong shape.  The
+--    right inversion needs to expose the filled/composed narrowing instead.
 
-raw-untag-narrowing⊥ :
-  ∀ {μ Δ Σ A B G} →
-  μ ∣ Δ ∣ Σ ⊢ G ？ ∶ A ⊒ B →
-  ⊥
-raw-untag-narrowing⊥ (_ , cross ())
+------------------------------------------------------------------------
+-- A concrete right-tag derivation via filled raw untag
+------------------------------------------------------------------------
 
-raw-tag-narrowing⊥ :
-  ∀ {μ Δ Σ A B G} →
-  μ ∣ Δ ∣ Σ ⊢ G ! ∶ A ⊒ B →
-  ⊥
-raw-tag-narrowing⊥ (_ , cross ())
+ℕᵗ : Ty
+ℕᵗ = ‵ `ℕ
 
-compose-raw-untag-right⊥ :
-  ∀ {Δ σ q r A B G} →
-  Δ ∣ σ ⊢ q ⨾ⁿ G ？ ≈ r ∶ A ⊒ B →
-  ⊥
-compose-raw-untag-right⊥ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
-  raw-untag-narrowing⊥ s⊒
+ℕ? : Coercion
+ℕ? = ℕᵗ ？
 
-compose-raw-tag-right⊥ :
-  ∀ {Δ σ q r A B G} →
-  Δ ∣ σ ⊢ q ⨾ⁿ G ! ≈ r ∶ A ⊒ B →
-  ⊥
-compose-raw-tag-right⊥ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
-  raw-tag-narrowing⊥ s⊒
+ℕ?ⁿ : Coercion
+ℕ?ⁿ = ℕ? ︔ id ℕᵗ
 
-data RawRightTag : Term → Set where
-  raw-right-tag : ∀ {V G} → RawRightTag (V ⟨ G ! ⟩)
+empty-store-det : ∀ {Δ} → StoreDetWf Δ []
+empty-store-det =
+  record
+    { at = record
+        { bound = λ ()
+        ; wfTy = λ ()
+        }
+    ; wfOlder = λ ()
+    ; unique = λ ()
+    }
 
-raw-right-tag-cast+⊥ :
-  ∀ {Δ σ q r A B M s} →
-  RawRightTag (M ⟨ - s ⟩) →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  ⊥
-raw-right-tag-cast+⊥ {s = id A} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = s ︔ t} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = s ↦ t} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = `∀ s} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = (＇ α) !} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = (‵ ι) !} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = ★ !} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = (A ⇒ B) !} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = (`∀ A) !} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = (＇ α) ？} raw-right-tag q⨟s≈r =
-  compose-raw-untag-right⊥ q⨟s≈r
-raw-right-tag-cast+⊥ {s = (‵ ι) ？} raw-right-tag q⨟s≈r =
-  compose-raw-untag-right⊥ q⨟s≈r
-raw-right-tag-cast+⊥ {s = ★ ？} raw-right-tag q⨟s≈r =
-  compose-raw-untag-right⊥ q⨟s≈r
-raw-right-tag-cast+⊥ {s = (A ⇒ B) ？} raw-right-tag q⨟s≈r =
-  compose-raw-untag-right⊥ q⨟s≈r
-raw-right-tag-cast+⊥ {s = (`∀ A) ？} raw-right-tag q⨟s≈r =
-  compose-raw-untag-right⊥ q⨟s≈r
-raw-right-tag-cast+⊥ {s = seal A α} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = unseal α A} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = gen A s} () q⨟s≈r
-raw-right-tag-cast+⊥ {s = inst B s} () q⨟s≈r
+empty-store-narrowing : ∀ {Δ} → Δ ⊢ [] ꞉ [] ⊒ˢ []
+empty-store-narrowing = ⊒ˢ-nil
 
-raw-right-tag-cast-⊥ :
-  ∀ {Δ σ q r A B M s} →
-  RawRightTag (M ⟨ s ⟩) →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  ⊥
-raw-right-tag-cast-⊥ {s = id A} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = s ︔ t} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = s ↦ t} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = `∀ s} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = G !} raw-right-tag q⨟s≈r =
-  compose-raw-tag-right⊥ q⨟s≈r
-raw-right-tag-cast-⊥ {s = G ？} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = seal A α} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = unseal α A} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = gen A s} () q⨟s≈r
-raw-right-tag-cast-⊥ {s = inst B s} () q⨟s≈r
+id★⊒ : tag-or-idᵈ ∣ 0 ∣ [] ⊢ id ★ ∶ ★ ⊒ ★
+id★⊒ = cast-id wf★ refl , id★
 
-raw-right-tag-⇑ᵗᵐ :
-  ∀ {N} →
-  RawRightTag N →
-  RawRightTag (⇑ᵗᵐ N)
-raw-right-tag-⇑ᵗᵐ raw-right-tag = raw-right-tag
+ℕ?ⁿ⊒ : tag-or-idᵈ ∣ 0 ∣ [] ⊢ ℕ?ⁿ ∶ ★ ⊒ ℕᵗ
+ℕ?ⁿ⊒ =
+  cast-seq (cast-untag wfBase (‵ `ℕ) refl) (cast-id wfBase refl) ,
+  (‵ `ℕ) ？︔ id-‵ `ℕ
 
-raw-right-tag-target⊥ :
-  ∀ {Δ σ γ M N q} →
-  RawRightTag N →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ N ∶ q →
-  ⊥
-raw-right-tag-target⊥ tag (extend qᶜ pαᶜ M⊒N) =
-  raw-right-tag-target⊥ tag M⊒N
-raw-right-tag-target⊥ tag (split qᶜ pαᶜ M⊒N) =
-  raw-right-tag-target⊥ tag M⊒N
-raw-right-tag-target⊥ tag (⊒cast+ qᶜ q⨟s≈r M⊒V) =
-  raw-right-tag-cast+⊥ tag q⨟s≈r
-raw-right-tag-target⊥ tag (⊒cast- qᶜ q⨟s≈r M⊒V) =
-  raw-right-tag-cast-⊥ tag q⨟s≈r
-raw-right-tag-target⊥ tag (ν⊒ pᶜ N⊒N′) =
-  raw-right-tag-target⊥ (raw-right-tag-⇑ᵗᵐ tag) N⊒N′
-raw-right-tag-target⊥ tag (cast+⊒ pᶜ r≈t⨾p M⊒N) =
-  raw-right-tag-target⊥ tag M⊒N
-raw-right-tag-target⊥ tag (cast-⊒ pᶜ r≈t⨾p M⊒N) =
-  raw-right-tag-target⊥ tag M⊒N
+ℕ?ⁿ≈ℕ?ⁿ : 0 ∣ [] ⊢ ℕ?ⁿ ≈ ℕ?ⁿ ∶ ★ ⊒ ℕᵗ
+ℕ?ⁿ≈ℕ?ⁿ =
+  endpointsⁿ refl refl refl refl
+    empty-store-narrowing
+    (wf★ˢ , wfBaseˢ)
+    (wf★ˢ , wfBaseˢ)
+    (tag-or-idᵈ , ℕ?ⁿ⊒)
+    (tag-or-idᵈ , ℕ?ⁿ⊒)
 
-right-tag-target⊥ :
-  ∀ {Δ σ γ M V q G} →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ! ⟩ ∶ q →
-  ⊥
-right-tag-target⊥ M⊒V! =
-  raw-right-tag-target⊥ raw-right-tag M⊒V!
-
-right-tag-inversion₁ :
-  ∀ {Δ σ γ M V q G} →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ! ⟩ ∶ q →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ G ？
-right-tag-inversion₁ M⊒V! =
-  ⊥-elim (right-tag-target⊥ M⊒V!)
+raw-right-tag-counterexample :
+  0 ∣ [] ∣ ℕ?ⁿ ∷ [] ⊢ ` zero ⊒ ` zero ⟨ ℕᵗ ! ⟩ ∶ id ★
+raw-right-tag-counterexample =
+  ⊒cast+ id★⊒
+    (compose-left-fillⁿ
+      empty-store-det
+      id★⊒
+      (fill-untag-id (‵ `ℕ))
+      ℕ?ⁿ⊒
+      ℕ?ⁿ≈ℕ?ⁿ)
+    (x⊒x ℕ?ⁿ⊒ Z)

--- a/GTSF/proof/RightTagInversion.agda
+++ b/GTSF/proof/RightTagInversion.agda
@@ -1,0 +1,150 @@
+module proof.RightTagInversion where
+
+-- File Charter:
+--   * Structural inversion lemmas for term narrowing whose target is a raw
+--     right tag `V ⟨ G ! ⟩`.
+--   * Proves `right-tag-inversion₁` used by the dynamic gradual guarantee.
+--   * Depends only on term narrowing, coercion grammar, and narrowing
+--     composition side conditions; it does not depend on catchup.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Product using (_,_)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NarrowWiden
+open import NarrowWidenComposition
+open import TermNarrowing
+
+------------------------------------------------------------------------
+-- Proof-strategy log
+------------------------------------------------------------------------
+
+-- 1. Direct inversion on `⊒cast+` first looked promising: a target
+--    `V ⟨ G ! ⟩` would have to come from `- s`, so `s` must be raw
+--    `G ？`.  This fails as a productive branch because raw `G ？` is not
+--    a narrowing grammar form; only `(G ？) ︔ g` is.
+-- 2. The symmetric `⊒cast-` branch would need raw `G !` as a narrowing.
+--    That fails for the same reason: tags live in the widening grammar, not
+--    as bare narrowing spines.
+-- 3. Left-cast and store-prefix constructors do not introduce the right tag;
+--    they only preserve the target shape, so recurse through them.
+--
+-- The resulting proof is vacuous: no valid term-narrowing derivation can have
+-- a raw right target tag `G !`.
+
+raw-untag-narrowing⊥ :
+  ∀ {μ Δ Σ A B G} →
+  μ ∣ Δ ∣ Σ ⊢ G ？ ∶ A ⊒ B →
+  ⊥
+raw-untag-narrowing⊥ (_ , cross ())
+
+raw-tag-narrowing⊥ :
+  ∀ {μ Δ Σ A B G} →
+  μ ∣ Δ ∣ Σ ⊢ G ! ∶ A ⊒ B →
+  ⊥
+raw-tag-narrowing⊥ (_ , cross ())
+
+compose-raw-untag-right⊥ :
+  ∀ {Δ σ q r A B G} →
+  Δ ∣ σ ⊢ q ⨾ⁿ G ？ ≈ r ∶ A ⊒ B →
+  ⊥
+compose-raw-untag-right⊥ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
+  raw-untag-narrowing⊥ s⊒
+
+compose-raw-tag-right⊥ :
+  ∀ {Δ σ q r A B G} →
+  Δ ∣ σ ⊢ q ⨾ⁿ G ! ≈ r ∶ A ⊒ B →
+  ⊥
+compose-raw-tag-right⊥ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
+  raw-tag-narrowing⊥ s⊒
+
+data RawRightTag : Term → Set where
+  raw-right-tag : ∀ {V G} → RawRightTag (V ⟨ G ! ⟩)
+
+raw-right-tag-cast+⊥ :
+  ∀ {Δ σ q r A B M s} →
+  RawRightTag (M ⟨ - s ⟩) →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  ⊥
+raw-right-tag-cast+⊥ {s = id A} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = s ︔ t} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = s ↦ t} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = `∀ s} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = (＇ α) !} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = (‵ ι) !} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = ★ !} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = (A ⇒ B) !} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = (`∀ A) !} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = (＇ α) ？} raw-right-tag q⨟s≈r =
+  compose-raw-untag-right⊥ q⨟s≈r
+raw-right-tag-cast+⊥ {s = (‵ ι) ？} raw-right-tag q⨟s≈r =
+  compose-raw-untag-right⊥ q⨟s≈r
+raw-right-tag-cast+⊥ {s = ★ ？} raw-right-tag q⨟s≈r =
+  compose-raw-untag-right⊥ q⨟s≈r
+raw-right-tag-cast+⊥ {s = (A ⇒ B) ？} raw-right-tag q⨟s≈r =
+  compose-raw-untag-right⊥ q⨟s≈r
+raw-right-tag-cast+⊥ {s = (`∀ A) ？} raw-right-tag q⨟s≈r =
+  compose-raw-untag-right⊥ q⨟s≈r
+raw-right-tag-cast+⊥ {s = seal A α} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = unseal α A} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = gen A s} () q⨟s≈r
+raw-right-tag-cast+⊥ {s = inst B s} () q⨟s≈r
+
+raw-right-tag-cast-⊥ :
+  ∀ {Δ σ q r A B M s} →
+  RawRightTag (M ⟨ s ⟩) →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  ⊥
+raw-right-tag-cast-⊥ {s = id A} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = s ︔ t} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = s ↦ t} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = `∀ s} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = G !} raw-right-tag q⨟s≈r =
+  compose-raw-tag-right⊥ q⨟s≈r
+raw-right-tag-cast-⊥ {s = G ？} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = seal A α} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = unseal α A} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = gen A s} () q⨟s≈r
+raw-right-tag-cast-⊥ {s = inst B s} () q⨟s≈r
+
+raw-right-tag-⇑ᵗᵐ :
+  ∀ {N} →
+  RawRightTag N →
+  RawRightTag (⇑ᵗᵐ N)
+raw-right-tag-⇑ᵗᵐ raw-right-tag = raw-right-tag
+
+raw-right-tag-target⊥ :
+  ∀ {Δ σ γ M N q} →
+  RawRightTag N →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ N ∶ q →
+  ⊥
+raw-right-tag-target⊥ tag (extend qᶜ pαᶜ M⊒N) =
+  raw-right-tag-target⊥ tag M⊒N
+raw-right-tag-target⊥ tag (split qᶜ pαᶜ M⊒N) =
+  raw-right-tag-target⊥ tag M⊒N
+raw-right-tag-target⊥ tag (⊒cast+ qᶜ q⨟s≈r M⊒V) =
+  raw-right-tag-cast+⊥ tag q⨟s≈r
+raw-right-tag-target⊥ tag (⊒cast- qᶜ q⨟s≈r M⊒V) =
+  raw-right-tag-cast-⊥ tag q⨟s≈r
+raw-right-tag-target⊥ tag (ν⊒ pᶜ N⊒N′) =
+  raw-right-tag-target⊥ (raw-right-tag-⇑ᵗᵐ tag) N⊒N′
+raw-right-tag-target⊥ tag (cast+⊒ pᶜ r≈t⨾p M⊒N) =
+  raw-right-tag-target⊥ tag M⊒N
+raw-right-tag-target⊥ tag (cast-⊒ pᶜ r≈t⨾p M⊒N) =
+  raw-right-tag-target⊥ tag M⊒N
+
+right-tag-target⊥ :
+  ∀ {Δ σ γ M V q G} →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ! ⟩ ∶ q →
+  ⊥
+right-tag-target⊥ M⊒V! =
+  raw-right-tag-target⊥ raw-right-tag M⊒V!
+
+right-tag-inversion₁ :
+  ∀ {Δ σ γ M V q G} →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ! ⟩ ∶ q →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ G ？
+right-tag-inversion₁ M⊒V! =
+  ⊥-elim (right-tag-target⊥ M⊒V!)


### PR DESCRIPTION
## Summary

Adds canonical identity coercions plus `FillNarrowing`/`FillWidening`, and extends the term-narrowing cast side-condition relations so raw cast arguments can be filled before canonical narrowing composition.

This keeps the canonical narrowing/widening grammars deterministic. The old `right-tag-inversion₁` statement is no longer valid: with filled raw `G ?`, a right raw tag target is derivable. `proof.RightTagInversion` now records a concrete counterexample derivation instead of a vacuous proof.

I also removed the stale DGG dependency on `right-tag-inversion₁`; the affected DGG tag cases remain holes like the surrounding skeleton. `Catchup.agda` only needed mechanical transport clauses for the new filled composition constructors.

## Validation

- `agda -v0 NarrowWiden.agda`
- `agda -v0 NarrowWidenComposition.agda`
- `agda -v0 TermNarrowing.agda`
- `agda -v0 proof/RightTagInversion.agda`
- `agda -v0 proof/Catchup.agda`
- `agda -v0 All.agda`