### PR TITLE
[codex] Define strict GTSF narrowings and widenings

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -15,6 +15,7 @@ import NuTerms
 import TypeCheck
 import NuExamplesFresh
 import NuReduction
+import proof.NWTermReduction
 import TermNarrowing
 import NarrowingExamples
 import NuMetaTheory

--- a/GTSF/NarrowWiden.agda
+++ b/GTSF/NarrowWiden.agda
@@ -59,6 +59,21 @@ mutual
       Narrowing s →
       CrossNarrowing (`∀ s)
 
+  data StrictCrossNarrowing : Coercion → Set where
+    cn-funˡ : ∀ {s t} →
+      StrictWidening s →
+      Narrowing t →
+      StrictCrossNarrowing (s ↦ t)
+
+    cn-funʳ : ∀ {s t} →
+      Widening s →
+      StrictNarrowing t →
+      StrictCrossNarrowing (s ↦ t)
+
+    cn-all : ∀ {s} →
+      StrictNarrowing s →
+      StrictCrossNarrowing (`∀ s)
+
   data Narrowing : Coercion → Set where
     cross : ∀ {g} →
       CrossNarrowing g →
@@ -71,15 +86,50 @@ mutual
       Narrowing s →
       Narrowing (gen A s)
 
+    untag : ∀ {G} →
+      Ground G →
+      Narrowing (G ？)
+
     _？︔_ : ∀ {G g} →
       Ground G →
-      CrossNarrowing g →
+      StrictCrossNarrowing g →
       Narrowing ((G ？) ︔ g)
 
+    sealⁿ : (A : Ty) →
+      (α : TyVar) →
+      Narrowing (seal A α)
+
     _︔seal_ : ∀ {A s} →
-      Narrowing s →
+      StrictNarrowing s →
       (α : TyVar) →
       Narrowing (s ︔ seal A α)
+
+  data StrictNarrowing : Coercion → Set where
+    strict-crossⁿ : ∀ {g} →
+      StrictCrossNarrowing g →
+      StrictNarrowing g
+
+    strict-gen : ∀ {A s} →
+      Narrowing s →
+      StrictNarrowing (gen A s)
+
+    strict-untag : ∀ {G} →
+      Ground G →
+      StrictNarrowing (G ？)
+
+    strict-untag-seq : ∀ {G g} →
+      Ground G →
+      StrictCrossNarrowing g →
+      StrictNarrowing ((G ？) ︔ g)
+
+    strict-seal : (A : Ty) →
+      (α : TyVar) →
+      StrictNarrowing (seal A α)
+
+    strict-seal-seq : ∀ {A s} →
+      StrictNarrowing s →
+      (α : TyVar) →
+      StrictNarrowing (s ︔ seal A α)
 
   data CrossWidening : Coercion → Set where
     id-＇ : (α : TyVar) →
@@ -97,6 +147,21 @@ mutual
       Widening s →
       CrossWidening (`∀ s)
 
+  data StrictCrossWidening : Coercion → Set where
+    cw-funˡ : ∀ {s t} →
+      StrictNarrowing s →
+      Widening t →
+      StrictCrossWidening (s ↦ t)
+
+    cw-funʳ : ∀ {s t} →
+      Narrowing s →
+      StrictWidening t →
+      StrictCrossWidening (s ↦ t)
+
+    cw-all : ∀ {s} →
+      StrictWidening s →
+      StrictCrossWidening (`∀ s)
+
   data Widening : Coercion → Set where
     cross : ∀ {g} →
       CrossWidening g →
@@ -109,14 +174,95 @@ mutual
       Widening s →
       Widening (inst B s)
 
+    tag : ∀ {G} →
+      Ground G →
+      Widening (G !)
+
     _︔_! : ∀ {G g} →
-      CrossWidening g →
+      StrictCrossWidening g →
       Ground G →
       Widening (g ︔ (G !))
 
+    unsealʷ : (α : TyVar) →
+      (A : Ty) →
+      Widening (unseal α A)
+
     unseal︔_ : (α : TyVar) → ∀ {A s} →
-      Widening s →
+      StrictWidening s →
       Widening (unseal α A ︔ s)
+
+  data StrictWidening : Coercion → Set where
+    strict-crossʷ : ∀ {g} →
+      StrictCrossWidening g →
+      StrictWidening g
+
+    strict-inst : ∀ {B s} →
+      Widening s →
+      StrictWidening (inst B s)
+
+    strict-tag : ∀ {G} →
+      Ground G →
+      StrictWidening (G !)
+
+    strict-tag-seq : ∀ {G g} →
+      StrictCrossWidening g →
+      Ground G →
+      StrictWidening (g ︔ (G !))
+
+    strict-unseal : (α : TyVar) →
+      (A : Ty) →
+      StrictWidening (unseal α A)
+
+    strict-unseal-seq : (α : TyVar) → ∀ {A s} →
+      StrictWidening s →
+      StrictWidening (unseal α A ︔ s)
+
+mutual
+  strictCrossⁿ→cross :
+    ∀ {c} →
+    StrictCrossNarrowing c →
+    CrossNarrowing c
+  strictCrossⁿ→cross (cn-funˡ sˢ tⁿ) =
+    strictʷ→widen sˢ ↦ tⁿ
+  strictCrossⁿ→cross (cn-funʳ sʷ tˢ) =
+    sʷ ↦ strictⁿ→narrow tˢ
+  strictCrossⁿ→cross (cn-all sˢ) =
+    `∀ (strictⁿ→narrow sˢ)
+
+  strictⁿ→narrow :
+    ∀ {c} →
+    StrictNarrowing c →
+    Narrowing c
+  strictⁿ→narrow (strict-crossⁿ gˢ) =
+    cross (strictCrossⁿ→cross gˢ)
+  strictⁿ→narrow (strict-gen sⁿ) = gen sⁿ
+  strictⁿ→narrow (strict-untag gG) = untag gG
+  strictⁿ→narrow (strict-untag-seq gG gˢ) = gG ？︔ gˢ
+  strictⁿ→narrow (strict-seal A α) = sealⁿ A α
+  strictⁿ→narrow (strict-seal-seq sˢ α) = sˢ ︔seal α
+
+  strictCrossʷ→cross :
+    ∀ {c} →
+    StrictCrossWidening c →
+    CrossWidening c
+  strictCrossʷ→cross (cw-funˡ sˢ tʷ) =
+    strictⁿ→narrow sˢ ↦ tʷ
+  strictCrossʷ→cross (cw-funʳ sⁿ tˢ) =
+    sⁿ ↦ strictʷ→widen tˢ
+  strictCrossʷ→cross (cw-all sˢ) =
+    `∀ (strictʷ→widen sˢ)
+
+  strictʷ→widen :
+    ∀ {c} →
+    StrictWidening c →
+    Widening c
+  strictʷ→widen (strict-crossʷ gˢ) =
+    cross (strictCrossʷ→cross gˢ)
+  strictʷ→widen (strict-inst sʷ) = inst sʷ
+  strictʷ→widen (strict-tag gG) = tag gG
+  strictʷ→widen (strict-tag-seq gˢ gG) = gˢ ︔ gG !
+  strictʷ→widen (strict-unseal α A) = unsealʷ α A
+  strictʷ→widen (strict-unseal-seq α sˢ) = unseal︔_ α sˢ
 
 ------------------------------------------------------------------------
 -- Grammar-directed duality for narrowing and widening
@@ -140,6 +286,26 @@ mutual
     where
       sʷ = dualⁿ (extᵃ η) sⁿ
 
+  dualStrictCrossNarrowing :
+    DualActionEnv →
+    ∀ {c} →
+    StrictCrossNarrowing c →
+    ∃[ d ] StrictCrossWidening d
+  dualStrictCrossNarrowing η (cn-funˡ sʷ tⁿ) =
+    (proj₁ sⁿ ↦ proj₁ tʷ) , cw-funˡ (proj₂ sⁿ) (proj₂ tʷ)
+    where
+      sⁿ = dualStrictʷ η sʷ
+      tʷ = dualⁿ η tⁿ
+  dualStrictCrossNarrowing η (cn-funʳ sʷ tⁿ) =
+    (proj₁ sⁿ ↦ proj₁ tʷ) , cw-funʳ (proj₂ sⁿ) (proj₂ tʷ)
+    where
+      sⁿ = dualʷ η sʷ
+      tʷ = dualStrictⁿ η tⁿ
+  dualStrictCrossNarrowing η (cn-all sⁿ) =
+    `∀ (proj₁ sʷ) , cw-all (proj₂ sʷ)
+    where
+      sʷ = dualStrictⁿ (extᵃ η) sⁿ
+
   dualⁿ :
     DualActionEnv →
     ∀ {c} →
@@ -154,36 +320,106 @@ mutual
     inst A (proj₁ sʷ) , inst (proj₂ sʷ)
     where
       sʷ = dualⁿ (genᵃ η) sⁿ
+  dualⁿ η (untag (＇ α)) with η α
+  dualⁿ η (untag (＇ α)) | normal = (＇ α) ! , tag (＇ α)
+  dualⁿ η (untag (＇ α)) | tag-to-seal = unseal α ★ , unsealʷ α ★
+  dualⁿ η (untag (＇ α)) | seal-to-tag = (＇ α) ! , tag (＇ α)
+  dualⁿ η (untag (‵ ι)) = (‵ ι) ! , tag (‵ ι)
+  dualⁿ η (untag ★⇒★) = (★ ⇒ ★) ! , tag ★⇒★
   dualⁿ η ((＇ α) ？︔ gⁿ) with η α
   dualⁿ η ((＇ α) ？︔ gⁿ) | normal =
     (proj₁ gʷ ︔ ((＇ α) !)) , (proj₂ gʷ ︔ (＇ α) !)
     where
-      gʷ = dualCrossNarrowing η gⁿ
+      gʷ = dualStrictCrossNarrowing η gⁿ
   dualⁿ η ((＇ α) ？︔ gⁿ) | tag-to-seal =
-    (unseal α ★ ︔ id ★) , unseal︔_ α id★
+    unseal α ★ , unsealʷ α ★
   dualⁿ η ((＇ α) ？︔ gⁿ) | seal-to-tag =
     (proj₁ gʷ ︔ ((＇ α) !)) , (proj₂ gʷ ︔ (＇ α) !)
     where
-      gʷ = dualCrossNarrowing η gⁿ
+      gʷ = dualStrictCrossNarrowing η gⁿ
   dualⁿ η ((‵ ι) ？︔ gⁿ) =
     (proj₁ gʷ ︔ ((‵ ι) !)) , (proj₂ gʷ ︔ (‵ ι) !)
     where
-      gʷ = dualCrossNarrowing η gⁿ
+      gʷ = dualStrictCrossNarrowing η gⁿ
   dualⁿ η (★⇒★ ？︔ gⁿ) =
     (proj₁ gʷ ︔ ((★ ⇒ ★) !)) , (proj₂ gʷ ︔ ★⇒★ !)
     where
-      gʷ = dualCrossNarrowing η gⁿ
+      gʷ = dualStrictCrossNarrowing η gⁿ
+  dualⁿ η (sealⁿ A α) with η α
+  dualⁿ η (sealⁿ A α) | normal = unseal α A , unsealʷ α A
+  dualⁿ η (sealⁿ A α) | tag-to-seal = unseal α A , unsealʷ α A
+  dualⁿ η (sealⁿ A α) | seal-to-tag = (＇ α) ! , tag (＇ α)
   dualⁿ η (_︔seal_ {A = A} sⁿ α) with η α
   dualⁿ η (_︔seal_ {A = A} sⁿ α) | normal =
     (unseal α A ︔ proj₁ sʷ) , unseal︔_ α (proj₂ sʷ)
     where
-      sʷ = dualⁿ η sⁿ
+      sʷ = dualStrictⁿ η sⁿ
   dualⁿ η (_︔seal_ {A = A} sⁿ α) | tag-to-seal =
     (unseal α A ︔ proj₁ sʷ) , unseal︔_ α (proj₂ sʷ)
     where
-      sʷ = dualⁿ η sⁿ
+      sʷ = dualStrictⁿ η sⁿ
   dualⁿ η (_︔seal_ {A = A} sⁿ α) | seal-to-tag =
-    (id (＇ α) ︔ ((＇ α) !)) , (id-＇ α ︔ (＇ α) !)
+    (＇ α) ! , tag (＇ α)
+
+  dualStrictⁿ :
+    DualActionEnv →
+    ∀ {c} →
+    StrictNarrowing c →
+    ∃[ d ] StrictWidening d
+  dualStrictⁿ η (strict-crossⁿ gⁿ) =
+    proj₁ gʷ , strict-crossʷ (proj₂ gʷ)
+    where
+      gʷ = dualStrictCrossNarrowing η gⁿ
+  dualStrictⁿ η (strict-gen {A = A} sⁿ) =
+    inst A (proj₁ sʷ) , strict-inst (proj₂ sʷ)
+    where
+      sʷ = dualⁿ (genᵃ η) sⁿ
+  dualStrictⁿ η (strict-untag (＇ α)) with η α
+  dualStrictⁿ η (strict-untag (＇ α)) | normal =
+    (＇ α) ! , strict-tag (＇ α)
+  dualStrictⁿ η (strict-untag (＇ α)) | tag-to-seal =
+    unseal α ★ , strict-unseal α ★
+  dualStrictⁿ η (strict-untag (＇ α)) | seal-to-tag =
+    (＇ α) ! , strict-tag (＇ α)
+  dualStrictⁿ η (strict-untag (‵ ι)) = (‵ ι) ! , strict-tag (‵ ι)
+  dualStrictⁿ η (strict-untag ★⇒★) = (★ ⇒ ★) ! , strict-tag ★⇒★
+  dualStrictⁿ η (strict-untag-seq (＇ α) gⁿ) with η α
+  dualStrictⁿ η (strict-untag-seq (＇ α) gⁿ) | normal =
+    (proj₁ gʷ ︔ ((＇ α) !)) , strict-tag-seq (proj₂ gʷ) (＇ α)
+    where
+      gʷ = dualStrictCrossNarrowing η gⁿ
+  dualStrictⁿ η (strict-untag-seq (＇ α) gⁿ) | tag-to-seal =
+    unseal α ★ , strict-unseal α ★
+  dualStrictⁿ η (strict-untag-seq (＇ α) gⁿ) | seal-to-tag =
+    (proj₁ gʷ ︔ ((＇ α) !)) , strict-tag-seq (proj₂ gʷ) (＇ α)
+    where
+      gʷ = dualStrictCrossNarrowing η gⁿ
+  dualStrictⁿ η (strict-untag-seq (‵ ι) gⁿ) =
+    (proj₁ gʷ ︔ ((‵ ι) !)) , strict-tag-seq (proj₂ gʷ) (‵ ι)
+    where
+      gʷ = dualStrictCrossNarrowing η gⁿ
+  dualStrictⁿ η (strict-untag-seq ★⇒★ gⁿ) =
+    (proj₁ gʷ ︔ ((★ ⇒ ★) !)) , strict-tag-seq (proj₂ gʷ) ★⇒★
+    where
+      gʷ = dualStrictCrossNarrowing η gⁿ
+  dualStrictⁿ η (strict-seal A α) with η α
+  dualStrictⁿ η (strict-seal A α) | normal =
+    unseal α A , strict-unseal α A
+  dualStrictⁿ η (strict-seal A α) | tag-to-seal =
+    unseal α A , strict-unseal α A
+  dualStrictⁿ η (strict-seal A α) | seal-to-tag =
+    (＇ α) ! , strict-tag (＇ α)
+  dualStrictⁿ η (strict-seal-seq {A = A} sⁿ α) with η α
+  dualStrictⁿ η (strict-seal-seq {A = A} sⁿ α) | normal =
+    (unseal α A ︔ proj₁ sʷ) , strict-unseal-seq α (proj₂ sʷ)
+    where
+      sʷ = dualStrictⁿ η sⁿ
+  dualStrictⁿ η (strict-seal-seq {A = A} sⁿ α) | tag-to-seal =
+    (unseal α A ︔ proj₁ sʷ) , strict-unseal-seq α (proj₂ sʷ)
+    where
+      sʷ = dualStrictⁿ η sⁿ
+  dualStrictⁿ η (strict-seal-seq {A = A} sⁿ α) | seal-to-tag =
+    (＇ α) ! , strict-tag (＇ α)
 
   dualCrossWidening :
     DualActionEnv →
@@ -202,6 +438,26 @@ mutual
     where
       sⁿ = dualʷ (extᵃ η) sʷ
 
+  dualStrictCrossWidening :
+    DualActionEnv →
+    ∀ {c} →
+    StrictCrossWidening c →
+    ∃[ d ] StrictCrossNarrowing d
+  dualStrictCrossWidening η (cw-funˡ sⁿ tʷ) =
+    (proj₁ sʷ ↦ proj₁ tⁿ) , cn-funˡ (proj₂ sʷ) (proj₂ tⁿ)
+    where
+      sʷ = dualStrictⁿ η sⁿ
+      tⁿ = dualʷ η tʷ
+  dualStrictCrossWidening η (cw-funʳ sⁿ tʷ) =
+    (proj₁ sʷ ↦ proj₁ tⁿ) , cn-funʳ (proj₂ sʷ) (proj₂ tⁿ)
+    where
+      sʷ = dualⁿ η sⁿ
+      tⁿ = dualStrictʷ η tʷ
+  dualStrictCrossWidening η (cw-all sʷ) =
+    `∀ (proj₁ sⁿ) , cn-all (proj₂ sⁿ)
+    where
+      sⁿ = dualStrictʷ (extᵃ η) sʷ
+
   dualʷ :
     DualActionEnv →
     ∀ {c} →
@@ -216,36 +472,106 @@ mutual
     gen B (proj₁ sⁿ) , gen (proj₂ sⁿ)
     where
       sⁿ = dualʷ (instᵃ η) sʷ
+  dualʷ η (tag (＇ α)) with η α
+  dualʷ η (tag (＇ α)) | normal = (＇ α) ？ , untag (＇ α)
+  dualʷ η (tag (＇ α)) | tag-to-seal = seal ★ α , sealⁿ ★ α
+  dualʷ η (tag (＇ α)) | seal-to-tag = (＇ α) ？ , untag (＇ α)
+  dualʷ η (tag (‵ ι)) = (‵ ι) ？ , untag (‵ ι)
+  dualʷ η (tag ★⇒★) = (★ ⇒ ★) ？ , untag ★⇒★
   dualʷ η (gʷ ︔ (＇ α) !) with η α
   dualʷ η (gʷ ︔ (＇ α) !) | normal =
     (((＇ α) ？) ︔ proj₁ gⁿ) , ((＇ α) ？︔ proj₂ gⁿ)
     where
-      gⁿ = dualCrossWidening η gʷ
+      gⁿ = dualStrictCrossWidening η gʷ
   dualʷ η (gʷ ︔ (＇ α) !) | tag-to-seal =
-    (id ★ ︔ seal ★ α) , (id★ ︔seal α)
+    seal ★ α , sealⁿ ★ α
   dualʷ η (gʷ ︔ (＇ α) !) | seal-to-tag =
     (((＇ α) ？) ︔ proj₁ gⁿ) , ((＇ α) ？︔ proj₂ gⁿ)
     where
-      gⁿ = dualCrossWidening η gʷ
+      gⁿ = dualStrictCrossWidening η gʷ
   dualʷ η (gʷ ︔ (‵ ι) !) =
     (((‵ ι) ？) ︔ proj₁ gⁿ) , ((‵ ι) ？︔ proj₂ gⁿ)
     where
-      gⁿ = dualCrossWidening η gʷ
+      gⁿ = dualStrictCrossWidening η gʷ
   dualʷ η (gʷ ︔ ★⇒★ !) =
     (((★ ⇒ ★) ？) ︔ proj₁ gⁿ) , (★⇒★ ？︔ proj₂ gⁿ)
     where
-      gⁿ = dualCrossWidening η gʷ
+      gⁿ = dualStrictCrossWidening η gʷ
+  dualʷ η (unsealʷ α A) with η α
+  dualʷ η (unsealʷ α A) | normal = seal A α , sealⁿ A α
+  dualʷ η (unsealʷ α A) | tag-to-seal = seal A α , sealⁿ A α
+  dualʷ η (unsealʷ α A) | seal-to-tag = (＇ α) ？ , untag (＇ α)
   dualʷ η (unseal︔_ α {A = A} sʷ) with η α
   dualʷ η (unseal︔_ α {A = A} sʷ) | normal =
     (proj₁ sⁿ ︔ seal A α) , (proj₂ sⁿ ︔seal α)
     where
-      sⁿ = dualʷ η sʷ
+      sⁿ = dualStrictʷ η sʷ
   dualʷ η (unseal︔_ α {A = A} sʷ) | tag-to-seal =
     (proj₁ sⁿ ︔ seal A α) , (proj₂ sⁿ ︔seal α)
     where
-      sⁿ = dualʷ η sʷ
+      sⁿ = dualStrictʷ η sʷ
   dualʷ η (unseal︔_ α {A = A} sʷ) | seal-to-tag =
-    (((＇ α) ？) ︔ id (＇ α)) , ((＇ α) ？︔ id-＇ α)
+    (＇ α) ？ , untag (＇ α)
+
+  dualStrictʷ :
+    DualActionEnv →
+    ∀ {c} →
+    StrictWidening c →
+    ∃[ d ] StrictNarrowing d
+  dualStrictʷ η (strict-crossʷ gʷ) =
+    proj₁ gⁿ , strict-crossⁿ (proj₂ gⁿ)
+    where
+      gⁿ = dualStrictCrossWidening η gʷ
+  dualStrictʷ η (strict-inst {B = B} sʷ) =
+    gen B (proj₁ sⁿ) , strict-gen (proj₂ sⁿ)
+    where
+      sⁿ = dualʷ (instᵃ η) sʷ
+  dualStrictʷ η (strict-tag (＇ α)) with η α
+  dualStrictʷ η (strict-tag (＇ α)) | normal =
+    (＇ α) ？ , strict-untag (＇ α)
+  dualStrictʷ η (strict-tag (＇ α)) | tag-to-seal =
+    seal ★ α , strict-seal ★ α
+  dualStrictʷ η (strict-tag (＇ α)) | seal-to-tag =
+    (＇ α) ？ , strict-untag (＇ α)
+  dualStrictʷ η (strict-tag (‵ ι)) = (‵ ι) ？ , strict-untag (‵ ι)
+  dualStrictʷ η (strict-tag ★⇒★) = (★ ⇒ ★) ？ , strict-untag ★⇒★
+  dualStrictʷ η (strict-tag-seq gʷ (＇ α)) with η α
+  dualStrictʷ η (strict-tag-seq gʷ (＇ α)) | normal =
+    (((＇ α) ？) ︔ proj₁ gⁿ) , strict-untag-seq (＇ α) (proj₂ gⁿ)
+    where
+      gⁿ = dualStrictCrossWidening η gʷ
+  dualStrictʷ η (strict-tag-seq gʷ (＇ α)) | tag-to-seal =
+    seal ★ α , strict-seal ★ α
+  dualStrictʷ η (strict-tag-seq gʷ (＇ α)) | seal-to-tag =
+    (((＇ α) ？) ︔ proj₁ gⁿ) , strict-untag-seq (＇ α) (proj₂ gⁿ)
+    where
+      gⁿ = dualStrictCrossWidening η gʷ
+  dualStrictʷ η (strict-tag-seq gʷ (‵ ι)) =
+    (((‵ ι) ？) ︔ proj₁ gⁿ) , strict-untag-seq (‵ ι) (proj₂ gⁿ)
+    where
+      gⁿ = dualStrictCrossWidening η gʷ
+  dualStrictʷ η (strict-tag-seq gʷ ★⇒★) =
+    (((★ ⇒ ★) ？) ︔ proj₁ gⁿ) , strict-untag-seq ★⇒★ (proj₂ gⁿ)
+    where
+      gⁿ = dualStrictCrossWidening η gʷ
+  dualStrictʷ η (strict-unseal α A) with η α
+  dualStrictʷ η (strict-unseal α A) | normal =
+    seal A α , strict-seal A α
+  dualStrictʷ η (strict-unseal α A) | tag-to-seal =
+    seal A α , strict-seal A α
+  dualStrictʷ η (strict-unseal α A) | seal-to-tag =
+    (＇ α) ？ , strict-untag (＇ α)
+  dualStrictʷ η (strict-unseal-seq α {A = A} sʷ) with η α
+  dualStrictʷ η (strict-unseal-seq α {A = A} sʷ) | normal =
+    (proj₁ sⁿ ︔ seal A α) , strict-seal-seq (proj₂ sⁿ) α
+    where
+      sⁿ = dualStrictʷ η sʷ
+  dualStrictʷ η (strict-unseal-seq α {A = A} sʷ) | tag-to-seal =
+    (proj₁ sⁿ ︔ seal A α) , strict-seal-seq (proj₂ sⁿ) α
+    where
+      sⁿ = dualStrictʷ η sʷ
+  dualStrictʷ η (strict-unseal-seq α {A = A} sʷ) | seal-to-tag =
+    (＇ α) ？ , strict-untag (＇ α)
 
 ------------------------------------------------------------------------
 -- Well-Typed Mode-Indexed Narrowing and Widening
@@ -327,6 +653,17 @@ mutual
   renameCrossNarrowing ρ (`∀ sⁿ) =
     `∀ (renameⁿ (extᵗ ρ) sⁿ)
 
+  renameStrictCrossNarrowing :
+    ∀ ρ {c} →
+    StrictCrossNarrowing c →
+    StrictCrossNarrowing (renameᶜ ρ c)
+  renameStrictCrossNarrowing ρ (cn-funˡ sʷ tⁿ) =
+    cn-funˡ (renameStrictʷ ρ sʷ) (renameⁿ ρ tⁿ)
+  renameStrictCrossNarrowing ρ (cn-funʳ sʷ tⁿ) =
+    cn-funʳ (renameʷ ρ sʷ) (renameStrictⁿ ρ tⁿ)
+  renameStrictCrossNarrowing ρ (cn-all sⁿ) =
+    cn-all (renameStrictⁿ (extᵗ ρ) sⁿ)
+
   renameⁿ :
     ∀ ρ {c} →
     Narrowing c →
@@ -334,9 +671,30 @@ mutual
   renameⁿ ρ (cross gⁿ) = cross (renameCrossNarrowing ρ gⁿ)
   renameⁿ ρ id★ = id★
   renameⁿ ρ (gen sⁿ) = gen (renameⁿ (extᵗ ρ) sⁿ)
+  renameⁿ ρ (untag gG) = untag (renameᵗ-ground ρ gG)
   renameⁿ ρ (gG ？︔ gⁿ) =
-    renameᵗ-ground ρ gG ？︔ renameCrossNarrowing ρ gⁿ
-  renameⁿ ρ (_︔seal_ sⁿ α) = renameⁿ ρ sⁿ ︔seal ρ α
+    renameᵗ-ground ρ gG ？︔ renameStrictCrossNarrowing ρ gⁿ
+  renameⁿ ρ (sealⁿ A α) = sealⁿ (renameᵗ ρ A) (ρ α)
+  renameⁿ ρ (_︔seal_ sⁿ α) = renameStrictⁿ ρ sⁿ ︔seal ρ α
+
+  renameStrictⁿ :
+    ∀ ρ {c} →
+    StrictNarrowing c →
+    StrictNarrowing (renameᶜ ρ c)
+  renameStrictⁿ ρ (strict-crossⁿ gⁿ) =
+    strict-crossⁿ (renameStrictCrossNarrowing ρ gⁿ)
+  renameStrictⁿ ρ (strict-gen sⁿ) =
+    strict-gen (renameⁿ (extᵗ ρ) sⁿ)
+  renameStrictⁿ ρ (strict-untag gG) =
+    strict-untag (renameᵗ-ground ρ gG)
+  renameStrictⁿ ρ (strict-untag-seq gG gⁿ) =
+    strict-untag-seq
+      (renameᵗ-ground ρ gG)
+      (renameStrictCrossNarrowing ρ gⁿ)
+  renameStrictⁿ ρ (strict-seal A α) =
+    strict-seal (renameᵗ ρ A) (ρ α)
+  renameStrictⁿ ρ (strict-seal-seq sⁿ α) =
+    strict-seal-seq (renameStrictⁿ ρ sⁿ) (ρ α)
 
   renameCrossWidening :
     ∀ ρ {c} →
@@ -349,6 +707,17 @@ mutual
   renameCrossWidening ρ (`∀ sʷ) =
     `∀ (renameʷ (extᵗ ρ) sʷ)
 
+  renameStrictCrossWidening :
+    ∀ ρ {c} →
+    StrictCrossWidening c →
+    StrictCrossWidening (renameᶜ ρ c)
+  renameStrictCrossWidening ρ (cw-funˡ sⁿ tʷ) =
+    cw-funˡ (renameStrictⁿ ρ sⁿ) (renameʷ ρ tʷ)
+  renameStrictCrossWidening ρ (cw-funʳ sⁿ tʷ) =
+    cw-funʳ (renameⁿ ρ sⁿ) (renameStrictʷ ρ tʷ)
+  renameStrictCrossWidening ρ (cw-all sʷ) =
+    cw-all (renameStrictʷ (extᵗ ρ) sʷ)
+
   renameʷ :
     ∀ ρ {c} →
     Widening c →
@@ -356,9 +725,31 @@ mutual
   renameʷ ρ (cross gʷ) = cross (renameCrossWidening ρ gʷ)
   renameʷ ρ id★ = id★
   renameʷ ρ (inst sʷ) = inst (renameʷ (extᵗ ρ) sʷ)
+  renameʷ ρ (tag gG) = tag (renameᵗ-ground ρ gG)
   renameʷ ρ (gʷ ︔ gG !) =
-    renameCrossWidening ρ gʷ ︔ renameᵗ-ground ρ gG !
-  renameʷ ρ (unseal︔_ α sʷ) = unseal︔_ (ρ α) (renameʷ ρ sʷ)
+    renameStrictCrossWidening ρ gʷ ︔ renameᵗ-ground ρ gG !
+  renameʷ ρ (unsealʷ α A) = unsealʷ (ρ α) (renameᵗ ρ A)
+  renameʷ ρ (unseal︔_ α sʷ) =
+    unseal︔_ (ρ α) (renameStrictʷ ρ sʷ)
+
+  renameStrictʷ :
+    ∀ ρ {c} →
+    StrictWidening c →
+    StrictWidening (renameᶜ ρ c)
+  renameStrictʷ ρ (strict-crossʷ gʷ) =
+    strict-crossʷ (renameStrictCrossWidening ρ gʷ)
+  renameStrictʷ ρ (strict-inst sʷ) =
+    strict-inst (renameʷ (extᵗ ρ) sʷ)
+  renameStrictʷ ρ (strict-tag gG) =
+    strict-tag (renameᵗ-ground ρ gG)
+  renameStrictʷ ρ (strict-tag-seq gʷ gG) =
+    strict-tag-seq
+      (renameStrictCrossWidening ρ gʷ)
+      (renameᵗ-ground ρ gG)
+  renameStrictʷ ρ (strict-unseal α A) =
+    strict-unseal (ρ α) (renameᵗ ρ A)
+  renameStrictʷ ρ (strict-unseal-seq α sʷ) =
+    strict-unseal-seq (ρ α) (renameStrictʷ ρ sʷ)
 
 narrow-mode-relax :
   ∀ {μ ν Δ Σ A B c} →
@@ -451,12 +842,14 @@ mutual
     wf∀ (narrow-src-wf (s⊢ , sⁿ))
   narrow-src-wf (cast-id hA ok , id★) = hA
   narrow-src-wf (cast-gen hA occ s⊢ , gen sⁿ) = hA
+  narrow-src-wf (cast-untag hG gG ok , untag gG′) = wf★
   narrow-src-wf
       (cast-seq (cast-untag hG gG ok) s⊢ , gG′ ？︔ sⁿ) =
     wf★
+  narrow-src-wf (cast-seal hA α∈Σ ok , sealⁿ A α) = hA
   narrow-src-wf
       (cast-seq s⊢ (cast-seal hA α∈Σ ok) , _︔seal_ sⁿ α) =
-    narrow-src-wf (s⊢ , sⁿ)
+    narrow-src-wf (s⊢ , strictⁿ→narrow sⁿ)
 
   widen-tgt-wf :
     ∀ {μ Δ Σ A B c} →
@@ -471,12 +864,14 @@ mutual
     wf∀ (widen-tgt-wf (s⊢ , sʷ))
   widen-tgt-wf (cast-id hA ok , id★) = hA
   widen-tgt-wf (cast-inst hB occ s⊢ , inst sʷ) = hB
+  widen-tgt-wf (cast-tag hG gG ok , tag gG′) = wf★
   widen-tgt-wf
       (cast-seq s⊢ (cast-tag hG gG ok) , sʷ ︔ gG′ !) =
     wf★
+  widen-tgt-wf (cast-unseal hA α∈Σ ok , unsealʷ α A) = hA
   widen-tgt-wf
       (cast-seq (cast-unseal hA α∈Σ ok) s⊢ , unseal︔_ α sʷ) =
-    widen-tgt-wf (s⊢ , sʷ)
+    widen-tgt-wf (s⊢ , strictʷ→widen sʷ)
 
 ------------------------------------------------------------------------
 -- Occurrence preservation for shifted-store composition
@@ -570,8 +965,21 @@ mutual
       (cast-gen {A = A} hA occB s⊢ , gen sⁿ) occ =
     narrowing-source-occurs (StoreNoOccurs-⟰ᵗ noOcc) (s⊢ , sⁿ)
       (trans (occurs-raise zero α A) occ)
+  narrowing-source-occurs noOcc (cast-untag hG gG ok , untag gG′) ()
   narrowing-source-occurs noOcc
       (cast-seq (cast-untag hG gG ok) s⊢ , gG′ ？︔ sⁿ) ()
+  narrowing-source-occurs {α = α} noOcc
+      (cast-seal {α = β} hA β∈Σ ok , sealⁿ A β)
+      occ
+      with α ≟ β
+  narrowing-source-occurs {α = α} noOcc
+      (cast-seal {α = .α} hA β∈Σ ok , sealⁿ A .α)
+      occ | yes refl =
+    refl
+  narrowing-source-occurs {α = α} noOcc
+      (cast-seal {α = β} hA β∈Σ ok , sealⁿ A β)
+      occ | no α≢β =
+    ⊥-elim (occurs-true-false⊥ occ (noOcc β∈Σ))
   narrowing-source-occurs {α = α} noOcc
       (cast-seq s⊢ (cast-seal {α = β} hA β∈Σ ok) ,
        _︔seal_ sⁿ β)
@@ -588,7 +996,7 @@ mutual
       occ | no α≢β =
     ⊥-elim
       (occurs-true-false⊥
-        (narrowing-source-occurs noOcc (s⊢ , sⁿ) occ)
+        (narrowing-source-occurs noOcc (s⊢ , strictⁿ→narrow sⁿ) occ)
         (noOcc β∈Σ))
 
   widening-target-occurs :
@@ -633,8 +1041,21 @@ mutual
       (cast-inst {B = B} hB occA s⊢ , inst sʷ) occ =
     widening-target-occurs (StoreNoOccurs-inst noOcc) (s⊢ , sʷ)
       (trans (occurs-raise zero α B) occ)
+  widening-target-occurs noOcc (cast-tag hG gG ok , tag gG′) ()
   widening-target-occurs noOcc
       (cast-seq s⊢ (cast-tag hG gG ok) , sʷ ︔ gG′ !) ()
+  widening-target-occurs {α = α} noOcc
+      (cast-unseal {α = β} hA β∈Σ ok , unsealʷ β A)
+      occ
+      with α ≟ β
+  widening-target-occurs {α = α} noOcc
+      (cast-unseal {α = .α} hA β∈Σ ok , unsealʷ .α A)
+      occ | yes refl =
+    refl
+  widening-target-occurs {α = α} noOcc
+      (cast-unseal {α = β} hA β∈Σ ok , unsealʷ β A)
+      occ | no α≢β =
+    ⊥-elim (occurs-true-false⊥ occ (noOcc β∈Σ))
   widening-target-occurs {α = α} noOcc
       (cast-seq (cast-unseal {α = β} hA β∈Σ ok) s⊢ ,
        unseal︔_ β sʷ)
@@ -651,7 +1072,7 @@ mutual
       occ | no α≢β =
     ⊥-elim
       (occurs-true-false⊥
-        (widening-target-occurs noOcc (s⊢ , sʷ) occ)
+        (widening-target-occurs noOcc (s⊢ , strictʷ→widen sʷ) occ)
         (noOcc β∈Σ))
 
 ------------------------------------------------------------------------

--- a/GTSF/NarrowWidenComposition.agda
+++ b/GTSF/NarrowWidenComposition.agda
@@ -1,14 +1,23 @@
+{-# OPTIONS --warning=noUnreachableClauses #-}
+
 -- File Charter:
 --   * Public composition operators for well-typed narrowings and widenings.
 --   * Exposes term-narrowing side conditions for narrowing composition.
 --   * Depends on `NarrowWiden` plus proof-only exclusion lemmas needed for
 --     coverage under the `StoreDetWf` invariant.
+--   * The positive strict grammar needs explicit indexed-impossible coverage
+--     clauses for tag/unseal composition; Agda also reports those clauses as
+--     unreachable, so this module locally disables that warning.
 
 module NarrowWidenComposition where
 
+open import Data.Bool using (true)
+open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_,_; proj₁; proj₂; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Data.Empty using (⊥; ⊥-elim)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym; cong; cong₂)
 
 open import Types
 open import Store using (StoreIncl-drop)
@@ -58,6 +67,251 @@ widening-inst-star-source⊥ :
   ⊥
 widening-inst-star-source⊥ ()
 
+narrowing-cross-target-star⊥ :
+  ∀ {μ Δ Σ A s} →
+  μ ∣ Δ ∣ Σ ⊢ s ∶ A =⇒ ★ →
+  CrossNarrowing s →
+  ⊥
+narrowing-cross-target-star⊥ () (id-＇ α)
+narrowing-cross-target-star⊥ () (id-‵ ι)
+narrowing-cross-target-star⊥ () (sʷ ↦ tⁿ)
+narrowing-cross-target-star⊥ () (`∀ sⁿ)
+
+------------------------------------------------------------------------
+-- Identity/strict views for the positive grammar
+------------------------------------------------------------------------
+
+mutual
+  data IdCrossNarrowing : Coercion → Set where
+    idcn-＇ : (α : TyVar) →
+      IdCrossNarrowing (id (＇ α))
+
+    idcn-‵ : (ι : Base) →
+      IdCrossNarrowing (id (‵ ι))
+
+    idcn-fun : ∀ {s t} →
+      IdWidening s →
+      IdNarrowing t →
+      IdCrossNarrowing (s ↦ t)
+
+    idcn-all : ∀ {s} →
+      IdNarrowing s →
+      IdCrossNarrowing (`∀ s)
+
+  data IdNarrowing : Coercion → Set where
+    idn-cross : ∀ {g} →
+      IdCrossNarrowing g →
+      IdNarrowing g
+
+    idn-★ :
+      IdNarrowing (id ★)
+
+  data IdCrossWidening : Coercion → Set where
+    idcw-＇ : (α : TyVar) →
+      IdCrossWidening (id (＇ α))
+
+    idcw-‵ : (ι : Base) →
+      IdCrossWidening (id (‵ ι))
+
+    idcw-fun : ∀ {s t} →
+      IdNarrowing s →
+      IdWidening t →
+      IdCrossWidening (s ↦ t)
+
+    idcw-all : ∀ {s} →
+      IdWidening s →
+      IdCrossWidening (`∀ s)
+
+  data IdWidening : Coercion → Set where
+    idw-cross : ∀ {g} →
+      IdCrossWidening g →
+      IdWidening g
+
+    idw-★ :
+      IdWidening (id ★)
+
+mutual
+  narrowing-view :
+    ∀ {c} →
+    Narrowing c →
+    StrictNarrowing c ⊎ IdNarrowing c
+  narrowing-view (cross cⁿ) with cross-narrowing-view cⁿ
+  narrowing-view (cross cⁿ) | inj₁ cˢ =
+    inj₁ (strict-crossⁿ cˢ)
+  narrowing-view (cross cⁿ) | inj₂ cⁱ =
+    inj₂ (idn-cross cⁱ)
+  narrowing-view id★ = inj₂ idn-★
+  narrowing-view (gen cⁿ) = inj₁ (strict-gen cⁿ)
+  narrowing-view (untag gG) = inj₁ (strict-untag gG)
+  narrowing-view (gG ？︔ cˢ) = inj₁ (strict-untag-seq gG cˢ)
+  narrowing-view (sealⁿ A α) = inj₁ (strict-seal A α)
+  narrowing-view (cˢ ︔seal α) = inj₁ (strict-seal-seq cˢ α)
+
+  cross-narrowing-view :
+    ∀ {c} →
+    CrossNarrowing c →
+    StrictCrossNarrowing c ⊎ IdCrossNarrowing c
+  cross-narrowing-view (id-＇ α) =
+    inj₂ (idcn-＇ α)
+  cross-narrowing-view (id-‵ ι) =
+    inj₂ (idcn-‵ ι)
+  cross-narrowing-view (sʷ ↦ tⁿ) with widening-view sʷ | narrowing-view tⁿ
+  cross-narrowing-view (sʷ ↦ tⁿ) | inj₁ sˢ | _ =
+    inj₁ (cn-funˡ sˢ tⁿ)
+  cross-narrowing-view (sʷ ↦ tⁿ) | inj₂ sⁱ | inj₁ tˢ =
+    inj₁ (cn-funʳ sʷ tˢ)
+  cross-narrowing-view (sʷ ↦ tⁿ) | inj₂ sⁱ | inj₂ tⁱ =
+    inj₂ (idcn-fun sⁱ tⁱ)
+  cross-narrowing-view (`∀ cⁿ) with narrowing-view cⁿ
+  cross-narrowing-view (`∀ cⁿ) | inj₁ cˢ =
+    inj₁ (cn-all cˢ)
+  cross-narrowing-view (`∀ cⁿ) | inj₂ cⁱ =
+    inj₂ (idcn-all cⁱ)
+
+  widening-view :
+    ∀ {c} →
+    Widening c →
+    StrictWidening c ⊎ IdWidening c
+  widening-view (cross cʷ) with cross-widening-view cʷ
+  widening-view (cross cʷ) | inj₁ cˢ =
+    inj₁ (strict-crossʷ cˢ)
+  widening-view (cross cʷ) | inj₂ cⁱ =
+    inj₂ (idw-cross cⁱ)
+  widening-view id★ = inj₂ idw-★
+  widening-view (inst cʷ) = inj₁ (strict-inst cʷ)
+  widening-view (tag gG) = inj₁ (strict-tag gG)
+  widening-view (cˢ ︔ gG !) = inj₁ (strict-tag-seq cˢ gG)
+  widening-view (unsealʷ α A) = inj₁ (strict-unseal α A)
+  widening-view (unseal︔_ α cˢ) = inj₁ (strict-unseal-seq α cˢ)
+
+  cross-widening-view :
+    ∀ {c} →
+    CrossWidening c →
+    StrictCrossWidening c ⊎ IdCrossWidening c
+  cross-widening-view (id-＇ α) =
+    inj₂ (idcw-＇ α)
+  cross-widening-view (id-‵ ι) =
+    inj₂ (idcw-‵ ι)
+  cross-widening-view (sⁿ ↦ tʷ) with narrowing-view sⁿ | widening-view tʷ
+  cross-widening-view (sⁿ ↦ tʷ) | inj₁ sˢ | _ =
+    inj₁ (cw-funˡ sˢ tʷ)
+  cross-widening-view (sⁿ ↦ tʷ) | inj₂ sⁱ | inj₁ tˢ =
+    inj₁ (cw-funʳ sⁿ tˢ)
+  cross-widening-view (sⁿ ↦ tʷ) | inj₂ sⁱ | inj₂ tⁱ =
+    inj₂ (idcw-fun sⁱ tⁱ)
+  cross-widening-view (`∀ cʷ) with widening-view cʷ
+  cross-widening-view (`∀ cʷ) | inj₁ cˢ =
+    inj₁ (cw-all cˢ)
+  cross-widening-view (`∀ cʷ) | inj₂ cⁱ =
+    inj₂ (idcw-all cⁱ)
+
+mutual
+  id-narrowing-src≡tgt :
+    ∀ {μ Δ Σ A B c} →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+    IdNarrowing c →
+    A ≡ B
+  id-narrowing-src≡tgt c⊢ (idn-cross cⁱ) =
+    id-cross-narrowing-src≡tgt c⊢ cⁱ
+  id-narrowing-src≡tgt (cast-id hA ok) idn-★ = refl
+
+  id-cross-narrowing-src≡tgt :
+    ∀ {μ Δ Σ A B c} →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+    IdCrossNarrowing c →
+    A ≡ B
+  id-cross-narrowing-src≡tgt (cast-id hA ok) (idcn-＇ α) = refl
+  id-cross-narrowing-src≡tgt (cast-id hA ok) (idcn-‵ ι) = refl
+  id-cross-narrowing-src≡tgt (cast-fun s⊢ t⊢) (idcn-fun sⁱ tⁱ) =
+    cong₂ _⇒_
+      (sym (id-widening-src≡tgt s⊢ sⁱ))
+      (id-narrowing-src≡tgt t⊢ tⁱ)
+  id-cross-narrowing-src≡tgt (cast-all c⊢) (idcn-all cⁱ) =
+    cong `∀ (id-narrowing-src≡tgt c⊢ cⁱ)
+
+  id-widening-src≡tgt :
+    ∀ {μ Δ Σ A B c} →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+    IdWidening c →
+    A ≡ B
+  id-widening-src≡tgt c⊢ (idw-cross cⁱ) =
+    id-cross-widening-src≡tgt c⊢ cⁱ
+  id-widening-src≡tgt (cast-id hA ok) idw-★ = refl
+
+  id-cross-widening-src≡tgt :
+    ∀ {μ Δ Σ A B c} →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+    IdCrossWidening c →
+    A ≡ B
+  id-cross-widening-src≡tgt (cast-id hA ok) (idcw-＇ α) = refl
+  id-cross-widening-src≡tgt (cast-id hA ok) (idcw-‵ ι) = refl
+  id-cross-widening-src≡tgt (cast-fun s⊢ t⊢) (idcw-fun sⁱ tⁱ) =
+    cong₂ _⇒_
+      (sym (id-narrowing-src≡tgt s⊢ sⁱ))
+      (id-widening-src≡tgt t⊢ tⁱ)
+  id-cross-widening-src≡tgt (cast-all c⊢) (idcw-all cⁱ) =
+    cong `∀ (id-widening-src≡tgt c⊢ cⁱ)
+
+wrap-untagⁿ :
+  ∀ {μ Δ Σ G C c} →
+  WfTy Δ G →
+  (gG : Ground G) →
+  tagTyAllowed μ G ≡ true →
+  μ ∣ Δ ∣ Σ ⊢ᶜ c ∶ G ⊒ C →
+  ∃[ u ] μ ∣ Δ ∣ Σ ⊢ u ∶ ★ ⊒ C
+wrap-untagⁿ hG gG okG (c⊢ , cⁿ) with cross-narrowing-view cⁿ
+wrap-untagⁿ hG gG okG (c⊢ , cⁿ) | inj₁ cˢ =
+  _ , (cast-seq (cast-untag hG gG okG) c⊢ , gG ？︔ cˢ)
+wrap-untagⁿ hG gG okG (c⊢ , cⁿ) | inj₂ cⁱ
+    with id-cross-narrowing-src≡tgt c⊢ cⁱ
+wrap-untagⁿ hG gG okG (c⊢ , cⁿ) | inj₂ cⁱ | refl =
+  _ , (cast-untag hG gG okG , untag gG)
+
+wrap-sealⁿ :
+  ∀ {μ Δ Σ A B α c} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  WfTy Δ B →
+  (α , B) ∈ Σ →
+  sealModeAllowed (μ α) ≡ true →
+  ∃[ u ] μ ∣ Δ ∣ Σ ⊢ u ∶ A ⊒ ＇ α
+wrap-sealⁿ (c⊢ , cⁿ) hB α∈Σ ok with narrowing-view cⁿ
+wrap-sealⁿ (c⊢ , cⁿ) hB α∈Σ ok | inj₁ cˢ =
+  _ , (cast-seq c⊢ (cast-seal hB α∈Σ ok) , cˢ ︔seal _)
+wrap-sealⁿ (c⊢ , cⁿ) hB α∈Σ ok | inj₂ cⁱ
+    with id-narrowing-src≡tgt c⊢ cⁱ
+wrap-sealⁿ (c⊢ , cⁿ) hB α∈Σ ok | inj₂ cⁱ | refl =
+  _ , (cast-seal hB α∈Σ ok , sealⁿ _ _)
+
+wrap-tagʷ :
+  ∀ {μ Δ Σ A G c} →
+  μ ∣ Δ ∣ Σ ⊢ᶜ c ∶ A ⊑ G →
+  WfTy Δ G →
+  (gG : Ground G) →
+  tagTyAllowed μ G ≡ true →
+  ∃[ u ] μ ∣ Δ ∣ Σ ⊢ u ∶ A ⊑ ★
+wrap-tagʷ (c⊢ , cʷ) hG gG okG with cross-widening-view cʷ
+wrap-tagʷ (c⊢ , cʷ) hG gG okG | inj₁ cˢ =
+  _ , (cast-seq c⊢ (cast-tag hG gG okG) , cˢ ︔ gG !)
+wrap-tagʷ (c⊢ , cʷ) hG gG okG | inj₂ cⁱ
+    with id-cross-widening-src≡tgt c⊢ cⁱ
+wrap-tagʷ (c⊢ , cʷ) hG gG okG | inj₂ cⁱ | refl =
+  _ , (cast-tag hG gG okG , tag gG)
+
+wrap-unsealʷ :
+  ∀ {μ Δ Σ A B α c} →
+  WfTy Δ A →
+  (α , A) ∈ Σ →
+  sealModeAllowed (μ α) ≡ true →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊑ B →
+  ∃[ u ] μ ∣ Δ ∣ Σ ⊢ u ∶ ＇ α ⊑ B
+wrap-unsealʷ hA α∈Σ ok (c⊢ , cʷ) with widening-view cʷ
+wrap-unsealʷ hA α∈Σ ok (c⊢ , cʷ) | inj₁ cˢ =
+  _ , (cast-seq (cast-unseal hA α∈Σ ok) c⊢ , unseal︔_ _ cˢ)
+wrap-unsealʷ hA α∈Σ ok (c⊢ , cʷ) | inj₂ cⁱ
+    with id-widening-src≡tgt c⊢ cⁱ
+wrap-unsealʷ hA α∈Σ ok (c⊢ , cʷ) | inj₂ cⁱ | refl =
+  _ , (cast-unseal hA α∈Σ ok , unsealʷ _ _)
+
 ------------------------------------------------------------------------
 -- Composition for narrowing and widening
 ------------------------------------------------------------------------
@@ -84,17 +338,27 @@ mutual
       | u , u⊒ =
     u , (proj₁ u⊒ , cross (proj₂ u⊒))
   _⨟ⁿ_ {wfΣ = wfΣ}
-      (() , cross (id-＇ α))
-      (cast-seq (cast-untag hG gG okG) t⊢ , gG′ ？︔ tᶜ)
+      (cast-id hA ok , id★)
+      (cast-untag hG gG okG , untag gG′) =
+    _ , (cast-untag hG gG okG , untag gG′)
   _⨟ⁿ_ {wfΣ = wfΣ}
-      (() , cross (id-‵ ι))
-      (cast-seq (cast-untag hG gG okG) t⊢ , gG′ ？︔ tᶜ)
+      (cast-untag hG gG okG , untag gG′)
+      (t⊢ , cross tᶜ) =
+    wrap-untagⁿ hG gG okG (t⊢ , tᶜ)
   _⨟ⁿ_ {wfΣ = wfΣ}
-      (() , cross (sʷ ↦ tⁿ))
-      (cast-seq (cast-untag hG gG okG) t⊢ , gG′ ？︔ tᶜ)
+      (cast-untag hG () okG , untag gG′)
+      (cast-untag hH gH okH , untag gH′)
   _⨟ⁿ_ {wfΣ = wfΣ}
-      (() , cross (`∀ sⁿ))
-      (cast-seq (cast-untag hG gG okG) t⊢ , gG′ ？︔ tᶜ)
+      (s⊢ , cross sᶜ)
+      (cast-untag hG gG okG , untag gG′) =
+    ⊥-elim (narrowing-cross-target-star⊥ s⊢ sᶜ)
+  _⨟ⁿ_ {wfΣ = wfΣ}
+      (s⊢ , cross sᶜ)
+      (cast-seq (cast-untag hG gG okG) t⊢ , gG′ ？︔ tᶜ) =
+    ⊥-elim (narrowing-cross-target-star⊥ s⊢ sᶜ)
+  _⨟ⁿ_ {wfΣ = wfΣ}
+      (cast-untag hG () okG , untag gG′)
+      (cast-seq (cast-untag hH gH okH) t⊢ , hG′ ？︔ tᶜ)
   _⨟ⁿ_ {wfΣ = wfΣ}
       (cast-id hA ok , id★)
       (cast-seq (cast-untag hG gG okG) t⊢ , gG′ ？︔ tᶜ) =
@@ -102,16 +366,31 @@ mutual
   _⨟ⁿ_ {wfΣ = wfΣ}
       (cast-seq (cast-untag hG gG okG) s⊢ , gG′ ？︔ sᶜ)
       (t⊢ , cross tᶜ)
-      with _⨟ᶜⁿ_ {wfΣ = wfΣ} (s⊢ , sᶜ) (t⊢ , tᶜ)
+      with _⨟ᶜⁿ_ {wfΣ = wfΣ}
+             (s⊢ , strictCrossⁿ→cross sᶜ) (t⊢ , tᶜ)
   _⨟ⁿ_ {wfΣ = wfΣ}
       (cast-seq (cast-untag hG gG okG) s⊢ , gG′ ？︔ sᶜ)
       (t⊢ , cross tᶜ) | u , u⊒ =
-    _ , (cast-seq (cast-untag hG gG okG) (proj₁ u⊒) ,
-         gG′ ？︔ proj₂ u⊒)
+    wrap-untagⁿ hG gG okG u⊒
+  _⨟ⁿ_ {wfΣ = wfΣ}
+      (cast-seq (cast-untag hG gG okG) s⊢ , gG′ ？︔ sᶜ)
+      (cast-untag hH gH okH , untag gH′) =
+    ⊥-elim
+      (narrowing-cross-ground-target-star⊥ gG
+        (s⊢ , strictCrossⁿ→cross sᶜ))
   _⨟ⁿ_ {wfΣ = wfΣ}
       (cast-seq (cast-untag hG gG okG) s⊢ , gG′ ？︔ sᶜ)
       (cast-seq (cast-untag hH gH okH) t⊢ , hG′ ？︔ tᶜ) =
-    ⊥-elim (narrowing-cross-ground-target-star⊥ gG (s⊢ , sᶜ))
+    ⊥-elim
+      (narrowing-cross-ground-target-star⊥ gG
+        (s⊢ , strictCrossⁿ→cross sᶜ))
+  _⨟ⁿ_ {wfΣ = wfΣ}
+      (cast-seal hA α∈Σ ok , sealⁿ A α)
+      (cast-id hB okB , cross (id-＇ β)) =
+    _ , (cast-seal hA α∈Σ ok , sealⁿ A α)
+  _⨟ⁿ_ {wfΣ = wfΣ}
+      (cast-seal hA α∈Σ ok , sealⁿ A α)
+      (cast-seq () t⊢ , hG′ ？︔ tᶜ)
   _⨟ⁿ_ {wfΣ = wfΣ}
       (cast-seq s⊢ (cast-seal hA α∈Σ ok) , _︔seal_ sⁿ α)
       (cast-id hB okB , cross (id-＇ β)) =
@@ -165,13 +444,15 @@ mutual
     _ , (cast-gen (narrow-src-wf s⊒) occ (proj₁ u⊒) ,
          gen (proj₂ u⊒))
   _⨟ⁿ_ {wfΣ = wfΣ}
+      s⊒ (cast-seal hC α∈Σ ok , sealⁿ A α) =
+    wrap-sealⁿ s⊒ hC α∈Σ ok
+  _⨟ⁿ_ {wfΣ = wfΣ}
       s⊒ (cast-seq t⊢ (cast-seal hC α∈Σ ok) , _︔seal_ tⁿ α)
-      with _⨟ⁿ_ {wfΣ = wfΣ} s⊒ (t⊢ , tⁿ)
+      with _⨟ⁿ_ {wfΣ = wfΣ} s⊒ (t⊢ , strictⁿ→narrow tⁿ)
   _⨟ⁿ_ {wfΣ = wfΣ}
       s⊒ (cast-seq t⊢ (cast-seal hC α∈Σ ok) ,
       _︔seal_ tⁿ α) | u , u⊒ =
-    _ , (cast-seq (proj₁ u⊒) (cast-seal hC α∈Σ ok) ,
-         proj₂ u⊒ ︔seal α)
+    wrap-sealⁿ u⊒ hC α∈Σ ok
 
   _⨟ᶜⁿ_ :
     ∀ {μ Δ Σ A B C s t} →
@@ -217,6 +498,37 @@ mutual
       | u , u⊑ =
     u , (proj₁ u⊑ , cross (proj₂ u⊑))
   _⨟ʷ_ {wfΣ = wfΣ}
+      (s⊢ , cross sᶜ)
+      (cast-tag hG gG okG , tag gG′) =
+    wrap-tagʷ (s⊢ , sᶜ) hG gG okG
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-id hA ok , id★)
+      (cast-tag hG () okG , tag gG′)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-tag hG gG okG , tag gG′)
+      (t⊢ , cross (sⁿ ↦ tʷ)) =
+    ⊥-elim (widening-cross-star-source-fun⊥ t⊢ (sⁿ ↦ tʷ))
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-tag hG gG okG , tag gG′)
+      (t⊢ , cross (`∀ tʷ)) =
+    ⊥-elim (widening-cross-star-source-all⊥ t⊢ (`∀ tʷ))
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-tag hG gG okG , tag gG′)
+      (t⊢ , inst tʷ) =
+    ⊥-elim (widening-inst-star-source⊥ t⊢ (inst tʷ))
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-tag hG gG okG , tag gG′)
+      (cast-seq t⊢ (cast-tag hH gH okH) , tᶜ ︔ hG′ !) =
+    ⊥-elim
+      (widening-cross-ground-source-star⊥ gH
+        (t⊢ , strictCrossʷ→cross tᶜ))
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-tag hG gG okG , tag gG′)
+      (cast-tag hH () okH , tag hG′)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-seq s⊢ (cast-tag hG gG okG) , sᶜ ︔ gG′ !)
+      (cast-tag hH () okH , tag hG′)
+  _⨟ʷ_ {wfΣ = wfΣ}
       (cast-id hA ok , id★)
       (cast-seq t⊢ (cast-tag hG gG okG) , tᶜ ︔ gG′ !) =
     _ , (cast-seq t⊢ (cast-tag hG gG okG) , tᶜ ︔ gG′ !)
@@ -253,7 +565,38 @@ mutual
   _⨟ʷ_ {wfΣ = wfΣ}
       (cast-seq s⊢ (cast-tag hG gG okG) , sᶜ ︔ gG′ !)
       (cast-seq t⊢ (cast-tag hH gH okH) , tᶜ ︔ hG′ !) =
-    ⊥-elim (widening-cross-ground-source-star⊥ gH (t⊢ , tᶜ))
+    ⊥-elim
+      (widening-cross-ground-source-star⊥ gH
+        (t⊢ , strictCrossʷ→cross tᶜ))
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-id hA ok , cross (id-＇ α))
+      (cast-unseal hB β∈Σ β-ok , unsealʷ β B) =
+    _ , (cast-unseal hB β∈Σ β-ok , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-id hA ok , cross (id-‵ ι))
+      (() , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-id hA ok , id★)
+      (() , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-fun s⊢ t⊢ , cross (sⁿ ↦ tʷ))
+      (() , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-all s⊢ , cross (`∀ sʷ))
+      (() , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-seq s⊢ (cast-tag hG gG okG) , sᶜ ︔ gG′ !)
+      (() , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-seq (cast-unseal hA α∈Σ ok) s⊢ , unseal︔_ α sʷ)
+      (cast-unseal hB β∈Σ β-ok , unsealʷ β B)
+      with _⨟ʷ_ {wfΣ = wfΣ}
+             (s⊢ , strictʷ→widen sʷ)
+             (cast-unseal hB β∈Σ β-ok , unsealʷ β B)
+  _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-seq (cast-unseal hA α∈Σ ok) s⊢ , unseal︔_ α sʷ)
+      (cast-unseal hB β∈Σ β-ok , unsealʷ β B) | u , u⊑ =
+    wrap-unsealʷ hA α∈Σ ok u⊑
   _⨟ʷ_ {wfΣ = wfΣ}
       (cast-id hA ok , cross (id-＇ α))
       (cast-seq (cast-unseal hB β∈Σ β-ok) t⊢ ,
@@ -301,14 +644,17 @@ mutual
     _ , (cast-inst (widen-tgt-wf t⊑) occ (proj₁ u⊑) ,
          inst (proj₂ u⊑))
   _⨟ʷ_ {wfΣ = wfΣ}
+      (cast-unseal hA α∈Σ ok , unsealʷ α A)
+      t⊑ =
+    wrap-unsealʷ hA α∈Σ ok t⊑
+  _⨟ʷ_ {wfΣ = wfΣ}
       (cast-seq (cast-unseal hA α∈Σ ok) s⊢ , unseal︔_ α sʷ)
       t⊑
-      with _⨟ʷ_ {wfΣ = wfΣ} (s⊢ , sʷ) t⊑
+      with _⨟ʷ_ {wfΣ = wfΣ} (s⊢ , strictʷ→widen sʷ) t⊑
   _⨟ʷ_ {wfΣ = wfΣ}
       (cast-seq (cast-unseal hA α∈Σ ok) s⊢ , unseal︔_ α sʷ)
       t⊑ | u , u⊑ =
-    _ , (cast-seq (cast-unseal hA α∈Σ ok) (proj₁ u⊑) ,
-         unseal︔_ α (proj₂ u⊑))
+    wrap-unsealʷ hA α∈Σ ok u⊑
   _⨟ʷ_ {wfΣ = wfΣ}
       (cast-all s⊢ , cross (`∀ sʷ))
       (cast-inst hC occ t⊢ , inst tʷ)
@@ -327,13 +673,13 @@ mutual
   _⨟ʷ_ {wfΣ = wfΣ}
       (s⊢ , cross sᶜ)
       (cast-seq t⊢ (cast-tag hG gG okG) , tᶜ ︔ gG′ !)
-      with _⨟ᶜʷ_ {wfΣ = wfΣ} (s⊢ , sᶜ) (t⊢ , tᶜ)
+      with _⨟ᶜʷ_ {wfΣ = wfΣ}
+             (s⊢ , sᶜ) (t⊢ , strictCrossʷ→cross tᶜ)
   _⨟ʷ_ {wfΣ = wfΣ}
       (s⊢ , cross sᶜ)
       (cast-seq t⊢ (cast-tag hG gG okG) ,
       tᶜ ︔ gG′ !) | u , u⊑ =
-    _ , (cast-seq (proj₁ u⊑) (cast-tag hG gG okG) ,
-         proj₂ u⊑ ︔ gG′ !)
+    wrap-tagʷ u⊑ hG gG okG
 
   _⨟ᶜʷ_ :
     ∀ {μ Δ Σ A B C s t} →

--- a/GTSF/NarrowingExamples.agda
+++ b/GTSF/NarrowingExamples.agda
@@ -32,32 +32,31 @@ open import proof.TermNarrowingProperties
 ------------------------------------------------------------------------
 
 c★ : Term
-c★ = $ (κℕ 0) ⟨ id (‵ `ℕ) ︔ ((‵ `ℕ) !) ⟩
+c★ = $ (κℕ 0) ⟨ (‵ `ℕ) ! ⟩
 
 var0-fun : Coercion
 var0-fun =
-  (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+  ((＇ 0) !) ↦ ((＇ 0) ？)
 
 base-fun : Base → Coercion
 base-fun ι =
-  (id (‵ ι) ︔ ((‵ ι) !)) ↦ (((‵ ι) ？) ︔ id (‵ ι))
+  ((‵ ι) !) ↦ ((‵ ι) ？)
 
 star-seal-fun : Coercion
 star-seal-fun =
-  (unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)
+  (unseal 0 ★) ↦ (seal ★ 0)
 
 base-seal-fun : Base → Coercion
 base-seal-fun ι =
-  ((unseal 0 (‵ ι) ︔ id (‵ ι)) ︔ ((‵ ι) !))
-    ↦ ((((‵ ι) ？) ︔ id (‵ ι)) ︔ seal (‵ ι) 0)
+  (unseal 0 (‵ ι) ︔ ((‵ ι) !))
+    ↦ (((‵ ι) ？) ︔ seal (‵ ι) 0)
 
 base-seal-step-fun : Base → Coercion
 base-seal-step-fun ι =
-  (unseal 0 (‵ ι) ︔ id (‵ ι)) ↦
-  (id (‵ ι) ︔ seal (‵ ι) 0)
+  (unseal 0 (‵ ι)) ↦ (seal (‵ ι) 0)
 
 base-untag : Base → Coercion
-base-untag ι = ((‵ ι) ？) ︔ id (‵ ι)
+base-untag ι = (‵ ι) ？
 
 base-store-det : ∀ {ι} →
   StoreDetWf 1 ((0 , ‵ ι) ∷ [])
@@ -117,8 +116,7 @@ base-untag-store-narrowing : ∀ {Δ ι} →
 base-untag-store-narrowing {ι = ι} =
   ⊒ˢ-both wf★ wfBase
     (tag-or-idᵈ ,
-      (cast-seq (cast-untag wfBase (‵ ι) refl) (cast-id wfBase refl) ,
-       (‵ ι) ？︔ id-‵ ι))
+      (cast-untag wfBase (‵ ι) refl , untag (‵ ι)))
     ⊒ˢ-nil
 
 base-right-store-narrowing : ∀ {Δ ι} →
@@ -166,7 +164,7 @@ wf★-base-endpoints = wf★ˢ , wfBaseˢ
 
 var0-fun-grammar : Narrowing var0-fun
 var0-fun-grammar =
-  cross ((id-＇ 0 ︔ (＇ 0) !) ↦ ((＇ 0) ？︔ id-＇ 0))
+  cross (tag (＇ 0) ↦ untag (＇ 0))
 
 var0-fun-typing :
   ∀ {μ Δ Σ} →
@@ -176,8 +174,8 @@ var0-fun-typing :
   μ ∣ Δ ∣ Σ ⊢ var0-fun ∶ (★ ⇒ ★) =⇒ (＇ 0 ⇒ ＇ 0)
 var0-fun-typing hX id-ok tag-ok =
   cast-fun
-    (cast-seq (cast-id hX id-ok) (cast-tag hX (＇ 0) tag-ok))
-    (cast-seq (cast-untag hX (＇ 0) tag-ok) (cast-id hX id-ok))
+    (cast-tag hX (＇ 0) tag-ok)
+    (cast-untag hX (＇ 0) tag-ok)
 
 var0-fun-narrowingᵐ :
   ∀ {Δ Σ} →
@@ -254,15 +252,14 @@ poly-fun-narrowing = id-onlyᵈ , poly-fun-narrowingᵐ
 base-fun-grammar : ∀ {ι} →
   Narrowing (base-fun ι)
 base-fun-grammar {ι = ι} =
-  cross ((id-‵ ι ︔ (‵ ι) !) ↦ ((‵ ι) ？︔ id-‵ ι))
+  cross (tag (‵ ι) ↦ untag (‵ ι))
 
 base-fun-narrowingᵐ : ∀ {μ Δ Σ ι} →
   μ ∣ Δ ∣ Σ ⊢ base-fun ι ∶ (★ ⇒ ★) ⊒ (‵ ι ⇒ ‵ ι)
 base-fun-narrowingᵐ {ι = ι} =
     (cast-fun
-      (cast-seq (cast-id wfBase refl) (cast-tag wfBase (‵ ι) refl))
-      (cast-seq (cast-untag wfBase (‵ ι) refl)
-        (cast-id wfBase refl)) ,
+      (cast-tag wfBase (‵ ι) refl)
+      (cast-untag wfBase (‵ ι) refl) ,
      base-fun-grammar)
 
 base-fun-narrowing : ∀ {Δ Σ ι} →
@@ -273,18 +270,15 @@ base-fun-narrowing =
 base-seal-step-fun-grammar : ∀ {ι} →
   Narrowing (base-seal-step-fun ι)
 base-seal-step-fun-grammar {ι = ι} =
-  cross ((unseal︔_ 0 (cross (id-‵ ι))) ↦
-         (cross (id-‵ ι) ︔seal 0))
+  cross (unsealʷ 0 (‵ ι) ↦ sealⁿ (‵ ι) 0)
 
 base-seal-step-fun-narrowingᵐ : ∀ {Δ Σ ι} →
   seal-or-idᵈ ∣ Δ ∣ ((0 , ‵ ι) ∷ Σ)
     ⊢ base-seal-step-fun ι ∶ (‵ ι ⇒ ‵ ι) ⊒ (＇ 0 ⇒ ＇ 0)
 base-seal-step-fun-narrowingᵐ {ι = ι} =
   cast-fun
-    (cast-seq (cast-unseal wfBase (here refl) refl)
-      (cast-id wfBase refl))
-    (cast-seq (cast-id wfBase refl)
-      (cast-seal wfBase (here refl) refl)) ,
+    (cast-unseal wfBase (here refl) refl)
+    (cast-seal wfBase (here refl) refl) ,
   base-seal-step-fun-grammar
 
 star-seal-fun-narrowingᵐ : ∀ {Δ Σ} →
@@ -292,11 +286,9 @@ star-seal-fun-narrowingᵐ : ∀ {Δ Σ} →
     (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 star-seal-fun-narrowingᵐ =
   cast-fun
-    (cast-seq (cast-unseal wf★ (here refl) refl)
-      (cast-id wf★ refl))
-    (cast-seq (cast-id wf★ refl)
-      (cast-seal wf★ (here refl) refl)) ,
-  cross ((unseal︔_ 0 id★) ↦ (id★ ︔seal 0))
+    (cast-unseal wf★ (here refl) refl)
+    (cast-seal wf★ (here refl) refl) ,
+  cross (unsealʷ 0 ★ ↦ sealⁿ ★ 0)
 
 star-seal-fun-narrowing : ∀ {Δ Σ} →
   Δ ∣ ((0 , ★) ∷ Σ) ⊢ star-seal-fun ∶
@@ -305,13 +297,12 @@ star-seal-fun-narrowing = seal-or-idᵈ , star-seal-fun-narrowingᵐ
 
 base-untag-grammar : ∀ {ι} →
   Narrowing (base-untag ι)
-base-untag-grammar {ι = ι} = (‵ ι) ？︔ id-‵ ι
+base-untag-grammar {ι = ι} = untag (‵ ι)
 
 base-untag-narrowingᵐ : ∀ {μ Δ Σ ι} →
   μ ∣ Δ ∣ Σ ⊢ base-untag ι ∶ ★ ⊒ (‵ ι)
 base-untag-narrowingᵐ {ι = ι} =
-  cast-seq (cast-untag wfBase (‵ ι) refl)
-    (cast-id wfBase refl) ,
+  cast-untag wfBase (‵ ι) refl ,
   base-untag-grammar
 
 base-untag-narrowing : ∀ {Δ Σ ι} →
@@ -334,11 +325,10 @@ id-var0-cast =
   cast-id (wfVar z<s) refl , cross (id-＇ 0)
 
 var0-untag-cast : ∀ {Δ Σ} →
-  suc Δ ∣ Σ ⊢ ((＇ 0) ？) ︔ id (＇ 0) ∶ᶜ ★ ⊒ ＇ 0
+  suc Δ ∣ Σ ⊢ (＇ 0) ？ ∶ᶜ ★ ⊒ ＇ 0
 var0-untag-cast =
-  cast-seq (cast-untag (wfVar z<s) (＇ 0) refl)
-    (cast-id (wfVar z<s) refl) ,
-  (＇ 0) ？︔ id-＇ 0
+  cast-untag (wfVar z<s) (＇ 0) refl ,
+  untag (＇ 0)
 
 id★-fun-cast : ∀ {Δ Σ} →
   Δ ∣ Σ ⊢ id ★ ↦ id ★ ∶ᶜ (★ ⇒ ★) ⊒ (★ ⇒ ★)
@@ -394,39 +384,28 @@ base-untag-cast =
 ex1-⊒Λ :
   0 ∣ [] ∣ []
     ⊢ ƛ (` 0) ⊒ Λ (ƛ (` 0))
-    ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+    ∶ gen (★ ⇒ ★) var0-fun
 ex1-⊒Λ =
   ⊒Λ poly-fun-cast
     (ƛ⊒ƛ var0-fun-cast (x⊒x var0-untag-cast Z))
 
 -- cambridge23 line 272 side condition (i), at the raw-composition level.
 ex1-line272-⨟ :
-  gen (★ ⇒ ★)
-    ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+  gen (★ ⇒ ★) var0-fun
     ⨟ `∀ (id (＇ 0) ↦ id (＇ 0))
-    ≡ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+    ≡ gen (★ ⇒ ★) var0-fun
 ex1-line272-⨟ =
   trans
-    (⨟-gen-∀ (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-      (id (＇ 0) ↦ id (＇ 0)))
+    (⨟-gen-∀ (★ ⇒ ★) var0-fun (id (＇ 0) ↦ id (＇ 0)))
     (cong (gen (★ ⇒ ★))
       (trans
-        (⨟-↦ (id (＇ 0) ︔ ((＇ 0) !))
-          (((＇ 0) ？) ︔ id (＇ 0)) (id (＇ 0)) (id (＇ 0)))
-        (cong₂ _↦_
-          (trans (⨟-tagʳ (id (＇ 0)) (id (＇ 0)) (＇ 0)) refl)
-          refl)))
+        (⨟-↦ ((＇ 0) !) ((＇ 0) ？) (id (＇ 0)) (id (＇ 0)))
+        refl))
 
 ex1-line272-≈ : ∀ {Δ} →
   Δ ∣ [] ⊢
-    gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-      ≈ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-          ⨾ⁿ `∀ (id (＇ 0) ↦ id (＇ 0))
+    gen (★ ⇒ ★) var0-fun
+      ≈ gen (★ ⇒ ★) var0-fun ⨾ⁿ `∀ (id (＇ 0) ↦ id (＇ 0))
       ∶ (★ ⇒ ★) ⊒ `∀ (＇ 0 ⇒ ＇ 0)
 ex1-line272-≈ =
   compose-rightⁿ empty-store-det poly-fun⊒ forall-id-var0-fun⊒
@@ -446,8 +425,7 @@ ex1-line272-≈ =
 ex1-cast- :
   0 ∣ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+        ⟨ gen (★ ⇒ ★) var0-fun ⟩
       ⊒ Λ (ƛ (` 0))
     ∶ `∀ (id (＇ 0) ↦ id (＇ 0))
 ex1-cast- =
@@ -456,38 +434,29 @@ ex1-cast- =
 ex1-initial :
   0 ∣ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+        ⟨ gen (★ ⇒ ★) var0-fun ⟩
         ⟨ inst (★ ⇒ ★)
-          ((seal ★ 0 ︔ id (＇ 0)) ↦ (id (＇ 0) ︔ unseal 0 ★)) ⟩
+          ((seal ★ 0) ↦ (unseal 0 ★)) ⟩
       ⊒ Λ (ƛ (` 0))
-    ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+    ∶ gen (★ ⇒ ★) var0-fun
 ex1-initial =
   cast+⊒
     {p = `∀ (id (＇ 0) ↦ id (＇ 0))}
-    {r = gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))}
-    {t = gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))}
+    {r = gen (★ ⇒ ★) var0-fun}
+    {t = gen (★ ⇒ ★) var0-fun}
     forall-id-var0-fun-cast ex1-line272-≈ ex1-cast-
 
 -- cambridge23 line 293 side condition (iii), at the raw-composition level.
 ex1-line293-⨟ :
-  ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-    ⨟ (id (＇ 0) ↦ id (＇ 0))
-    ≡ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+  var0-fun ⨟ (id (＇ 0) ↦ id (＇ 0)) ≡ var0-fun
 ex1-line293-⨟ =
   trans
-    (⨟-↦ (id (＇ 0) ︔ ((＇ 0) !)) (((＇ 0) ？) ︔ id (＇ 0))
-      (id (＇ 0)) (id (＇ 0)))
-    (cong₂ _↦_ (trans (⨟-tagʳ (id (＇ 0)) (id (＇ 0)) (＇ 0)) refl) refl)
+    (⨟-↦ ((＇ 0) !) ((＇ 0) ？) (id (＇ 0)) (id (＇ 0)))
+    refl
 
 ex1-line293-≈ :
   1 ∣ (0 ꞉ id ★) ∷ [] ⊢
-    (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
-      ≈ ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-          ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+    var0-fun ≈ var0-fun ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex1-line293-≈ =
   compose-rightⁿ star-store-det var0-fun⊒ id-var0-fun⊒
@@ -505,20 +474,15 @@ ex1-line293-≈ =
       id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl
 
 ex1-line294-⨟ :
-  ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0))
-    ⨟ (id (＇ 0) ↦ id (＇ 0))
-    ≡ (unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)
+  star-seal-fun ⨟ (id (＇ 0) ↦ id (＇ 0)) ≡ star-seal-fun
 ex1-line294-⨟ =
   trans
-    (⨟-↦ (unseal 0 ★ ︔ id ★) (id ★ ︔ seal ★ 0)
-      (id (＇ 0)) (id (＇ 0)))
+    (⨟-↦ (unseal 0 ★) (seal ★ 0) (id (＇ 0)) (id (＇ 0)))
     refl
 
 ex1-line294-≈ :
   1 ∣ (0 ꞉ id ★) ∷ [] ⊢
-    (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
-      ≈ ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0))
-          ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+    var0-fun ≈ star-seal-fun ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex1-line294-≈ =
   compose-rightⁿ star-store-det star-seal-fun⊒ id-var0-fun⊒
@@ -538,14 +502,13 @@ ex1-line294-≈ =
 ex1-inner-⊒Λ-premise :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
     ⊢ ƛ (` 0) ⊒ ƛ (` 0)
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex1-inner-⊒Λ-premise =
   ƛ⊒ƛ var0-fun-cast (x⊒x var0-untag-cast Z)
 
 ex1-inner-cast- :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
-    ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
+    ⊢ (ƛ (` 0)) ⟨ var0-fun ⟩
       ⊒ ƛ (` 0)
     ∶ id (＇ 0) ↦ id (＇ 0)
 ex1-inner-cast- =
@@ -553,33 +516,29 @@ ex1-inner-cast- =
 
 ex1-inner-cast+ :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
-    ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩
+    ⊢ (ƛ (` 0)) ⟨ var0-fun ⟩ ⟨ - star-seal-fun ⟩
       ⊒ ƛ (` 0)
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex1-inner-cast+ =
   cast+⊒
     {p = id (＇ 0) ↦ id (＇ 0)}
-    {r = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
-    {t = (unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)}
+    {r = var0-fun}
+    {t = star-seal-fun}
     id-var0-fun-cast ex1-line294-≈ ex1-inner-cast-
 
 ex1-split :
   1 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 1) ︔ ((＇ 1) !)) ↦ (((＇ 1) ？) ︔ id (＇ 1)) ⟩
-        ⟨ - ((unseal 1 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 1)) ⟩
+        ⟨ ((＇ 1) !) ↦ ((＇ 1) ？) ⟩
+        ⟨ - ((unseal 1 ★) ↦ (seal ★ 1)) ⟩
       ⊒ ƛ (` 0)
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex1-split =
   split
     {N =
-      (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩}
+      (ƛ (` 0)) ⟨ var0-fun ⟩ ⟨ - star-seal-fun ⟩}
     {N′ = ƛ (` 0)}
-    {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+    {p = var0-fun}
     {q = id ★}
     {A = ★}
     {α = 0}
@@ -593,11 +552,10 @@ ex1-split =
 ex1-after-reduction :
   0 ∣ (⊒ 0 ꞉=☆) ∷ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩
+        ⟨ var0-fun ⟩
+        ⟨ - star-seal-fun ⟩
       ⊒ Λ (ƛ (` 0))
-    ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+    ∶ gen (★ ⇒ ★) var0-fun
 ex1-after-reduction =
   ⊒Λ poly-fun-cast ex1-split
 
@@ -616,26 +574,25 @@ ex2-id =
 ex2-line307-left-⨟ :
   (id ★ ↦ id ★)
     ⨟ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
     ≡ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
 ex2-line307-left-⨟ =
   trans
     (⨟-genʳ (id ★ ↦ id ★) (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))))
+      var0-fun)
     (cong (gen (★ ⇒ ★))
       (trans
-        (⨟-↦ (id ★) (id ★) (id (＇ 0) ︔ ((＇ 0) !))
-          (((＇ 0) ？) ︔ id (＇ 0)))
-        (cong₂ _↦_ (⨟-idʳ (id (＇ 0) ︔ ((＇ 0) !)) {A = ★}) refl)))
+        (⨟-↦ (id ★) (id ★) ((＇ 0) !) ((＇ 0) ？))
+        refl))
 
 ex2-line307-≈ :
   0 ∣ [] ⊢
     (id ★ ↦ id ★)
       ⨟ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+          var0-fun
       ≈ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+          var0-fun
           ⨟ `∀ (id (＇ 0) ↦ id (＇ 0))
       ∶ (★ ⇒ ★) ⊒ `∀ (＇ 0 ⇒ ＇ 0)
 ex2-line307-≈ rewrite ex2-line307-left-⨟ | ex1-line272-⨟ =
@@ -650,9 +607,9 @@ ex2-line303-right-≈ :
   0 ∣ [] ⊢
     (id ★ ↦ id ★)
       ⨾ⁿ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+          var0-fun
       ≈ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+          var0-fun
       ∶ (★ ⇒ ★) ⊒ `∀ (＇ 0 ⇒ ＇ 0)
 ex2-line303-right-≈ =
   compose-leftⁿ empty-store-det id★-fun⊒ poly-fun⊒
@@ -673,9 +630,9 @@ ex2-right-cast :
     ⊢ ƛ (` 0)
       ⊒ (ƛ (` 0))
           ⟨ gen (★ ⇒ ★)
-            ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+            var0-fun ⟩
     ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
 ex2-right-cast =
   ⊒cast- id★-fun-cast ex2-line303-right-≈ ex2-id
 
@@ -683,10 +640,10 @@ ex2-line303 :
   0 ∣ [] ∣ []
     ⊢ (ƛ (` 0))
         ⟨ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+          var0-fun ⟩
       ⊒ (ƛ (` 0))
           ⟨ gen (★ ⇒ ★)
-            ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+            var0-fun ⟩
     ∶ `∀ (id (＇ 0) ↦ id (＇ 0))
 ex2-line303 =
   cast-⊒ forall-id-var0-fun-cast ex1-line272-≈ ex2-right-cast
@@ -695,21 +652,21 @@ ex2-initial :
   0 ∣ [] ∣ []
     ⊢ (ƛ (` 0))
         ⟨ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+          var0-fun ⟩
         ⟨ inst (★ ⇒ ★)
-          ((seal ★ 0 ︔ id (＇ 0)) ↦ (id (＇ 0) ︔ unseal 0 ★)) ⟩
+          ((seal ★ 0) ↦ (unseal 0 ★)) ⟩
       ⊒ (ƛ (` 0))
           ⟨ gen (★ ⇒ ★)
-            ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+            var0-fun ⟩
     ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
 ex2-initial =
   cast+⊒
     {p = `∀ (id (＇ 0) ↦ id (＇ 0))}
     {r = gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))}
+      var0-fun}
     {t = gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))}
+      var0-fun}
     forall-id-var0-fun-cast ex1-line272-≈ ex2-line303
 
 ex2-inner-id :
@@ -721,19 +678,18 @@ ex2-inner-id =
 
 ex2-line316-left-⨟ :
   (id ★ ↦ id ★)
-    ⨟ ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-    ≡ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ⨟ var0-fun
+    ≡ var0-fun
 ex2-line316-left-⨟ =
   trans
-    (⨟-↦ (id ★) (id ★) (id (＇ 0) ︔ ((＇ 0) !))
-      (((＇ 0) ？) ︔ id (＇ 0)))
-    (cong₂ _↦_ (⨟-idʳ (id (＇ 0) ︔ ((＇ 0) !)) {A = ★}) refl)
+    (⨟-↦ (id ★) (id ★) ((＇ 0) !) ((＇ 0) ？))
+    refl
 
 ex2-line316-right-≈ :
   1 ∣ (0 ꞉ id ★) ∷ [] ⊢
     (id ★ ↦ id ★)
-      ⨾ⁿ ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
-      ≈ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+      ⨾ⁿ var0-fun
+      ≈ var0-fun
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex2-line316-right-≈ =
   compose-leftⁿ star-store-det id★-fun⊒ var0-fun⊒
@@ -752,55 +708,44 @@ ex2-line316-right-≈ =
 ex2-inner-right-cast :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
     ⊢ ƛ (` 0)
-      ⊒ (ƛ (` 0))
-          ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+      ⊒ (ƛ (` 0)) ⟨ var0-fun ⟩
+    ∶ var0-fun
 ex2-inner-right-cast =
   ⊒cast- id★-fun-cast ex2-line316-right-≈ ex2-inner-id
 
 ex2-line316 :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
-    ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-      ⊒ (ƛ (` 0))
-          ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
+    ⊢ (ƛ (` 0)) ⟨ var0-fun ⟩
+      ⊒ (ƛ (` 0)) ⟨ var0-fun ⟩
     ∶ id (＇ 0) ↦ id (＇ 0)
 ex2-line316 =
   cast-⊒ id-var0-fun-cast ex1-line293-≈ ex2-inner-right-cast
 
 ex2-line318 :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
-    ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩
-      ⊒ (ƛ (` 0))
-          ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ⊢ (ƛ (` 0)) ⟨ var0-fun ⟩ ⟨ - star-seal-fun ⟩
+      ⊒ (ƛ (` 0)) ⟨ var0-fun ⟩
+    ∶ var0-fun
 ex2-line318 =
   cast+⊒
     {p = id (＇ 0) ↦ id (＇ 0)}
-    {r = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
-    {t = (unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)}
+    {r = var0-fun}
+    {t = star-seal-fun}
     id-var0-fun-cast ex1-line294-≈ ex2-line316
 
 ex2-split :
   1 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 1) ︔ ((＇ 1) !)) ↦ (((＇ 1) ？) ︔ id (＇ 1)) ⟩
-        ⟨ - ((unseal 1 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 1)) ⟩
-      ⊒ (ƛ (` 0))
-          ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+        ⟨ ((＇ 1) !) ↦ ((＇ 1) ？) ⟩
+        ⟨ - ((unseal 1 ★) ↦ (seal ★ 1)) ⟩
+      ⊒ (ƛ (` 0)) ⟨ var0-fun ⟩
+    ∶ var0-fun
 ex2-split =
   split
     {N =
-      (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩}
-    {N′ =
-      (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩}
-    {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+      (ƛ (` 0)) ⟨ var0-fun ⟩ ⟨ - star-seal-fun ⟩}
+    {N′ = (ƛ (` 0)) ⟨ var0-fun ⟩}
+    {p = var0-fun}
     {q = id ★}
     {A = ★}
     {α = 0}
@@ -813,14 +758,9 @@ ex2-split =
 -- reductions, not after the first reduction step.
 ex2-after-reduction :
   0 ∣ (⊒ 0 ꞉=☆) ∷ [] ∣ []
-    ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)) ⟩
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩
-      ⊒ (ƛ (` 0))
-          ⟨ gen (★ ⇒ ★)
-            ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
-    ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+    ⊢ (ƛ (` 0)) ⟨ var0-fun ⟩ ⟨ - star-seal-fun ⟩
+      ⊒ (ƛ (` 0)) ⟨ gen (★ ⇒ ★) var0-fun ⟩
+    ∶ gen (★ ⇒ ★) var0-fun
 ex2-after-reduction =
   ⊒⟨ν⟩ poly-fun-cast (_ ↦ _) ex2-split
 
@@ -831,26 +771,26 @@ ex2-after-reduction =
 ex3-line329 :
   1 ∣ (0 ꞉= ‵ `ℕ ⊒) ∷ [] ∣ []
     ⊢ ƛ (` 0) ⊒ (Λ (ƛ (` 0))) • 0
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex3-line329 =
-  ⊒α {A = ‵ `ℕ} {α = 0} var0-fun-cast
+  ⊒α {p = var0-fun} {A = ‵ `ℕ} {α = 0} var0-fun-cast
     (⊒Λ
       {A = ★ ⇒ ★}
       {N = ƛ (` 0)}
       {V′ = ƛ (` 0)}
-      {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+      {p = var0-fun}
       poly-fun-cast
       (ƛ⊒ƛ var0-fun-cast (x⊒x var0-untag-cast Z)))
 
 ex3-line329-extend :
   1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
     ⊢ ƛ (` 0) ⊒ (Λ (ƛ (` 0))) • 0
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex3-line329-extend =
   extend
     {M = ƛ (` 0)}
     {N′ = (Λ (ƛ (` 0))) • 0}
-    {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+    {p = var0-fun}
     {q = id (‵ `ℕ)}
     {A = ‵ `ℕ}
     {B = ‵ `ℕ}
@@ -860,26 +800,14 @@ ex3-line329-extend =
     ex3-line329
 
 ex3-line331-⨟ :
-  ((id (‵ `ℕ) ︔ ((‵ `ℕ) !)) ↦ (((‵ `ℕ) ？) ︔ id (‵ `ℕ)))
-    ⨟ ((unseal 0 (‵ `ℕ) ︔ id (‵ `ℕ))
-         ↦ (id (‵ `ℕ) ︔ seal (‵ `ℕ) 0))
-    ≡ (((unseal 0 (‵ `ℕ) ︔ id (‵ `ℕ)) ︔ ((‵ `ℕ) !))
-        ↦ ((((‵ `ℕ) ？) ︔ id (‵ `ℕ)) ︔ seal (‵ `ℕ) 0))
+  base-fun `ℕ
+    ⨟ base-seal-step-fun `ℕ
+    ≡ base-seal-fun `ℕ
 ex3-line331-⨟ =
   trans
-    (⨟-↦ (id (‵ `ℕ) ︔ ((‵ `ℕ) !))
-      (((‵ `ℕ) ？) ︔ id (‵ `ℕ))
-      (unseal 0 (‵ `ℕ) ︔ id (‵ `ℕ))
-      (id (‵ `ℕ) ︔ seal (‵ `ℕ) 0))
-    (cong₂ _↦_
-      (trans
-        (⨟-tagʳ (unseal 0 (‵ `ℕ) ︔ id (‵ `ℕ))
-          (id (‵ `ℕ)) (‵ `ℕ))
-        refl)
-      (trans
-        (⨟-sealʳ (((‵ `ℕ) ？) ︔ id (‵ `ℕ))
-          (id (‵ `ℕ)) (‵ `ℕ) 0)
-        refl))
+    (⨟-↦ ((‵ `ℕ) !) ((‵ `ℕ) ？)
+      (unseal 0 (‵ `ℕ)) (seal (‵ `ℕ) 0))
+    refl
 
 ex3-line331-≈ :
   1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ⊢
@@ -905,18 +833,13 @@ ex3-line331 :
   1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
     ⊢ ƛ (` 0)
       ⊒ ((Λ (ƛ (` 0))) • 0)
-          ⟨ -
-            ((unseal 0 (‵ `ℕ) ︔ id (‵ `ℕ))
-              ↦ (id (‵ `ℕ) ︔ seal (‵ `ℕ) 0)) ⟩
-    ∶ (id (‵ `ℕ) ︔ ((‵ `ℕ) !)) ↦ (((‵ `ℕ) ？) ︔ id (‵ `ℕ))
+          ⟨ - base-seal-step-fun `ℕ ⟩
+    ∶ base-fun `ℕ
 ex3-line331 =
   ⊒cast+
-    {q = (id (‵ `ℕ) ︔ ((‵ `ℕ) !))
-      ↦ (((‵ `ℕ) ？) ︔ id (‵ `ℕ))}
-    {r = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
-    {s =
-      (unseal 0 (‵ `ℕ) ︔ id (‵ `ℕ))
-        ↦ (id (‵ `ℕ) ︔ seal (‵ `ℕ) 0)}
+    {q = base-fun `ℕ}
+    {r = var0-fun}
+    {s = base-seal-step-fun `ℕ}
     base-fun-cast
     ex3-line331-≈
     ex3-line329-extend
@@ -937,17 +860,17 @@ ex4-initial :
   0 ∣ [] ∣ []
     ⊢ (Λ (ƛ (` 0)))
         ⟨ inst (★ ⇒ ★)
-          ((seal ★ 0 ︔ id (＇ 0)) ↦ (id (＇ 0) ︔ unseal 0 ★)) ⟩
+          ((seal ★ 0) ↦ (unseal 0 ★)) ⟩
       ⊒ Λ (ƛ (` 0))
     ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
 ex4-initial =
   cast+⊒
     {p = `∀ (id (＇ 0) ↦ id (＇ 0))}
     {r = gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))}
+      var0-fun}
     {t = gen (★ ⇒ ★)
-      ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))}
+      var0-fun}
     forall-id-var0-fun-cast ex1-line272-≈ ex4-poly-id
 
 ex4-line352 :
@@ -960,29 +883,29 @@ ex4-line352 =
 ex4-line353 :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩
+        ⟨ - star-seal-fun ⟩
       ⊒ ƛ (` 0)
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex4-line353 =
   cast+⊒
     {p = id (＇ 0) ↦ id (＇ 0)}
-    {r = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
-    {t = (unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)}
+    {r = var0-fun}
+    {t = star-seal-fun}
     id-var0-fun-cast ex1-line294-≈ ex4-line352
 
 ex4-split :
   1 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ - ((unseal 1 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 1)) ⟩
+        ⟨ - ((unseal 1 ★) ↦ (seal ★ 1)) ⟩
       ⊒ ƛ (` 0)
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex4-split =
   split
     {N =
       (ƛ (` 0))
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩}
+        ⟨ - star-seal-fun ⟩}
     {N′ = ƛ (` 0)}
-    {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+    {p = var0-fun}
     {q = id ★}
     {A = ★}
     {α = 0}
@@ -996,10 +919,10 @@ ex4-split =
 ex4-after-reduction :
   0 ∣ (⊒ 0 ꞉=☆) ∷ [] ∣ []
     ⊢ (ƛ (` 0))
-        ⟨ - ((unseal 0 ★ ︔ id ★) ↦ (id ★ ︔ seal ★ 0)) ⟩
+        ⟨ - star-seal-fun ⟩
       ⊒ Λ (ƛ (` 0))
     ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
 ex4-after-reduction =
   ⊒Λ poly-fun-cast ex4-split
 
@@ -1012,26 +935,18 @@ ex4-after-reduction =
 -- at ℕ, so the function side below uses 𝔹 for the mismatching ground type.
 ex5-line380-⨟ :
   (id ★ ↦ id ★)
-    ⨟ ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹)))
-    ≡ (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
+    ⨟ base-fun `𝔹
+    ≡ base-fun `𝔹
 ex5-line380-⨟ =
   trans
-    (⨟-↦ (id ★) (id ★)
-      (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      (((‵ `𝔹) ？) ︔ id (‵ `𝔹)))
-    (cong₂ _↦_
-      (⨟-idʳ (id (‵ `𝔹) ︔ ((‵ `𝔹) !)) {A = ★})
-      refl)
+    (⨟-↦ (id ★) (id ★) ((‵ `𝔹) !) ((‵ `𝔹) ？))
+    refl
 
 ex5-line380-≈ :
   0 ∣ [] ⊢
     (id ★ ↦ id ★)
-      ⨾ⁿ ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-        ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹)))
-      ≈ (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-        ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
+      ⨾ⁿ base-fun `𝔹
+      ≈ base-fun `𝔹
       ∶ (★ ⇒ ★) ⊒ (‵ `𝔹 ⇒ ‵ `𝔹)
 ex5-line380-≈ =
   compose-leftⁿ empty-store-det id★-fun⊒ base-fun⊒
@@ -1050,8 +965,7 @@ ex5-line380-≈ =
 ex5-function-base :
   0 ∣ [] ∣ []
     ⊢ ƛ (` 0) ⊒ ƛ (` 0)
-    ∶ (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
+    ∶ base-fun `𝔹
 ex5-function-base =
   ƛ⊒ƛ (base-fun-cast {ι = `𝔹})
     (x⊒x (base-untag-cast {ι = `𝔹}) Z)
@@ -1061,17 +975,13 @@ ex5-function-cast :
   0 ∣ [] ∣ []
     ⊢ ƛ (` 0)
       ⊒ (ƛ (` 0))
-          ⟨ -
-            ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-              ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))) ⟩
+          ⟨ - base-fun `𝔹 ⟩
     ∶ id ★ ↦ id ★
 ex5-function-cast =
   ⊒cast+
     {q = id ★ ↦ id ★}
-    {r = (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))}
-    {s = (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))}
+    {r = base-fun `𝔹}
+    {s = base-fun `𝔹}
     {A = ★ ⇒ ★}
     {B = ‵ `𝔹 ⇒ ‵ `𝔹}
     id★-fun-cast
@@ -1086,9 +996,9 @@ ex5-c★ =
   cast+⊒cast+
     {p = id (‵ `ℕ)}
     {q = id ★}
-    {r = ((‵ `ℕ) ？) ︔ id (‵ `ℕ)}
-    {s = ((‵ `ℕ) ？) ︔ id (‵ `ℕ)}
-    {t = ((‵ `ℕ) ？) ︔ id (‵ `ℕ)}
+    {r = base-untag `ℕ}
+    {s = base-untag `ℕ}
+    {t = base-untag `ℕ}
     id-base-cast
     id★-cast
     (compose-leftⁿ empty-store-det id★⊒ base-untag⊒
@@ -1118,10 +1028,7 @@ ex5-c★ =
 ex5-initial :
   0 ∣ [] ∣ []
     ⊢ (ƛ (` 0)) · c★
-      ⊒ ((ƛ (` 0))
-          ⟨ -
-            ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-              ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))) ⟩)
+      ⊒ ((ƛ (` 0)) ⟨ - base-fun `𝔹 ⟩)
         · c★
     ∶ id ★
 ex5-initial =
@@ -1142,38 +1049,26 @@ ex5-after-reduction =
 ex6-open-ν𝔹 :
   1 ∣ (0 ꞉= ‵ `𝔹 ⊒) ∷ [] ∣ []
     ⊢ ƛ (` 0) ⊒ (Λ (ƛ (` 0))) • 0
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex6-open-ν𝔹 =
-  ⊒α {A = ‵ `𝔹} {α = 0} var0-fun-cast
+  ⊒α {p = var0-fun} {A = ‵ `𝔹} {α = 0} var0-fun-cast
     (⊒Λ
       {A = ★ ⇒ ★}
       {N = ƛ (` 0)}
       {V′ = ƛ (` 0)}
-      {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+      {p = var0-fun}
       poly-fun-cast
       (ƛ⊒ƛ var0-fun-cast (x⊒x var0-untag-cast Z)))
 
 ex6-line405-⨟ :
-  ((id (‵ `𝔹) ︔ ((‵ `𝔹) !)) ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹)))
-    ⨟ ((unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-         ↦ (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0))
-    ≡ (((unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹)) ︔ ((‵ `𝔹) !))
-        ↦ ((((‵ `𝔹) ？) ︔ id (‵ `𝔹)) ︔ seal (‵ `𝔹) 0))
+  base-fun `𝔹
+    ⨟ base-seal-step-fun `𝔹
+    ≡ base-seal-fun `𝔹
 ex6-line405-⨟ =
   trans
-    (⨟-↦ (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
-      (unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-      (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0))
-    (cong₂ _↦_
-      (trans
-        (⨟-tagʳ (unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-          (id (‵ `𝔹)) (‵ `𝔹))
-        refl)
-      (trans
-        (⨟-sealʳ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
-          (id (‵ `𝔹)) (‵ `𝔹) 0)
-        refl))
+    (⨟-↦ ((‵ `𝔹) !) ((‵ `𝔹) ？)
+      (unseal 0 (‵ `𝔹)) (seal (‵ `𝔹) 0))
+    refl
 
 -- cambridge23 Example 6, line 405 side condition (i), with the corrected
 -- result `ι!→ι?`.  The seal/tag bridge reads identity-like evidence from the
@@ -1203,18 +1098,13 @@ ex6-line405 :
   1 ∣ (0 ꞉= ‵ `𝔹 ⊒) ∷ [] ∣ []
     ⊢ ƛ (` 0)
       ⊒ ((Λ (ƛ (` 0))) • 0)
-          ⟨ -
-            ((unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-              ↦ (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0)) ⟩
-    ∶ (id (‵ `𝔹) ︔ ((‵ `𝔹) !)) ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
+          ⟨ - base-seal-step-fun `𝔹 ⟩
+    ∶ base-fun `𝔹
 ex6-line405 =
   ⊒cast+
-    {q = (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))}
-    {r = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
-    {s =
-      (unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-        ↦ (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0)}
+    {q = base-fun `𝔹}
+    {r = var0-fun}
+    {s = base-seal-step-fun `𝔹}
     (base-fun-cast {ι = `𝔹})
     ex6-line405-≈
     ex6-open-ν𝔹
@@ -1224,12 +1114,9 @@ ex6-line407-ν :
     ⊢ ƛ (` 0)
       ⊒ ν (‵ `𝔹)
           (((Λ (ƛ (` 0))) • 0)
-            ⟨ -
-              ((unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-                ↦ (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0)) ⟩)
-          (⇑ᶜ ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-            ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))))
-    ∶ (id (‵ `𝔹) ︔ ((‵ `𝔹) !)) ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))
+            ⟨ - base-seal-step-fun `𝔹 ⟩)
+          (⇑ᶜ (base-fun `𝔹))
+    ∶ base-fun `𝔹
 ex6-line407-ν =
   ⊒ν (base-fun-cast {ι = `𝔹}) ex6-line405
 
@@ -1239,22 +1126,15 @@ ex6-line407 :
     ⊢ ƛ (` 0)
       ⊒ (ν (‵ `𝔹)
           (((Λ (ƛ (` 0))) • 0)
-            ⟨ -
-              ((unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-                ↦ (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0)) ⟩)
-          (⇑ᶜ ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-            ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹)))))
-          ⟨ -
-            ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-              ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))) ⟩
+            ⟨ - base-seal-step-fun `𝔹 ⟩)
+          (⇑ᶜ (base-fun `𝔹)))
+          ⟨ - base-fun `𝔹 ⟩
     ∶ id ★ ↦ id ★
 ex6-line407 =
   ⊒cast+
     {q = id ★ ↦ id ★}
-    {r = (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))}
-    {s = (id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-      ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))}
+    {r = base-fun `𝔹}
+    {s = base-fun `𝔹}
     {A = ★ ⇒ ★}
     {B = ‵ `𝔹 ⇒ ‵ `𝔹}
     id★-fun-cast
@@ -1266,15 +1146,10 @@ ex6-initial :
     ⊢ (ƛ (` 0)) · c★
       ⊒ ((ν (‵ `𝔹)
           (((Λ (ƛ (` 0))) • 0)
-            ⟨ -
-              ((unseal 0 (‵ `𝔹) ︔ id (‵ `𝔹))
-                ↦ (id (‵ `𝔹) ︔ seal (‵ `𝔹) 0)) ⟩)
-          (⇑ᶜ ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-            ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹)))))
-          ⟨ -
-            ((id (‵ `𝔹) ︔ ((‵ `𝔹) !))
-              ↦ (((‵ `𝔹) ？) ︔ id (‵ `𝔹))) ⟩)
-        · c★
+            ⟨ - base-seal-step-fun `𝔹 ⟩)
+          (⇑ᶜ (base-fun `𝔹))
+            ⟨ - base-fun `𝔹 ⟩)
+        · c★)
     ∶ id ★
 ex6-initial =
   ·⊒· id★-cast ex6-line407 ex5-c★
@@ -1297,13 +1172,13 @@ ex7-line708 :
   1 ∣ [] ∣ []
     ⊢ ƛ (` 0) ⊒ Λ (ƛ (` 0))
     ∶ gen (★ ⇒ ★)
-        ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+        var0-fun
 ex7-line708 =
   ⊒Λ
     {A = ★ ⇒ ★}
     {N = ƛ (` 0)}
     {V′ = ƛ (` 0)}
-    {p = (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))}
+    {p = var0-fun}
     poly-fun-cast
     (ƛ⊒ƛ var0-fun-cast (x⊒x var0-untag-cast Z))
 
@@ -1312,7 +1187,7 @@ ex7-line710 :
   1 ∣ [] ∣ []
     ⊢ (ƛ (` 0))
         ⟨ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩
+          var0-fun ⟩
       ⊒ Λ (ƛ (` 0))
     ∶ `∀ (id (＇ 0) ↦ id (＇ 0))
 ex7-line710 =
@@ -1323,7 +1198,7 @@ ex7-line712 : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ∣ []
     ⊢ ((ƛ (` 0))
         ⟨ gen (★ ⇒ ★)
-          ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))) ⟩) • 0
+          var0-fun ⟩) • 0
       ⊒ (Λ (ƛ (` 0))) • 0
     ∶ id (＇ 0) ↦ id (＇ 0)
 ex7-line712 {ι = ι} =
@@ -1375,9 +1250,7 @@ ex7-downcast-right-≈ {ι = ι} =
 ex7-line714 : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ∣ []
     ⊢ (((ƛ (` 0))
-          ⟨ gen (★ ⇒ ★)
-            ((id (＇ 0) ︔ ((＇ 0) !)) ↦
-             (((＇ 0) ？) ︔ id (＇ 0))) ⟩) • 0)
+          ⟨ gen (★ ⇒ ★) var0-fun ⟩) • 0)
         ⟨ - base-seal-step-fun ι ⟩
       ⊒ ((Λ (ƛ (` 0))) • 0) ⟨ - base-seal-step-fun ι ⟩
     ∶ id (‵ ι) ↦ id (‵ ι)
@@ -1401,9 +1274,7 @@ ex7-line716 : ∀ {ι} →
   0 ∣ [] ∣ []
     ⊢ ν (‵ ι)
         ((((ƛ (` 0))
-            ⟨ gen (★ ⇒ ★)
-              ((id (＇ 0) ︔ ((＇ 0) !)) ↦
-               (((＇ 0) ？) ︔ id (＇ 0))) ⟩) • 0)
+            ⟨ gen (★ ⇒ ★) var0-fun ⟩) • 0)
           ⟨ - base-seal-step-fun ι ⟩)
         (⇑ᶜ (id (‵ ι) ↦ id (‵ ι)))
       ⊒ ν (‵ ι)
@@ -1422,15 +1293,15 @@ ex7-line716 {ι = ι} =
 ex7-line719 : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ∣ []
     ⊢ ƛ (` 0) ⊒ ƛ (` 0)
-    ∶ (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
+    ∶ var0-fun
 ex7-line719 =
   ƛ⊒ƛ var0-fun-cast (x⊒x var0-untag-cast Z)
 
 -- cambridge25 Example 7, line 720.
 ex7-line720-≈ : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ⊢
-    (id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0))
-      ≈ ((id (＇ 0) ︔ ((＇ 0) !)) ↦ (((＇ 0) ？) ︔ id (＇ 0)))
+    var0-fun
+      ≈ var0-fun
           ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex7-line720-≈ =
@@ -1451,9 +1322,7 @@ ex7-line720-≈ =
 -- cambridge25 Example 7, line 721.
 ex7-line721 : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ∣ []
-    ⊢ (ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦
-          (((＇ 0) ？) ︔ id (＇ 0)) ⟩
+    ⊢ (ƛ (` 0)) ⟨ var0-fun ⟩
       ⊒ ƛ (` 0)
     ∶ id (＇ 0) ↦ id (＇ 0)
 ex7-line721 =
@@ -1462,9 +1331,7 @@ ex7-line721 =
 -- cambridge25 Example 7, line 723.
 ex7-line723 : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ∣ []
-    ⊢ ((ƛ (` 0))
-        ⟨ (id (＇ 0) ︔ ((＇ 0) !)) ↦
-          (((＇ 0) ？) ︔ id (＇ 0)) ⟩)
+    ⊢ ((ƛ (` 0)) ⟨ var0-fun ⟩)
         ⟨ - base-seal-step-fun ι ⟩
       ⊒ (ƛ (` 0)) ⟨ - base-seal-step-fun ι ⟩
     ∶ id (‵ ι) ↦ id (‵ ι)

--- a/GTSF/proof/LeftSealNarrowingInversion.agda
+++ b/GTSF/proof/LeftSealNarrowingInversion.agda
@@ -217,7 +217,7 @@ LeftSealNarrowingInversion : Set₁
 LeftSealNarrowingInversion =
   ∀ {Δ σ γ V V′ α} →
   Value V →
-  Δ ∣ σ ∣ γ ⊢ V ⟨ id ★ ︔ seal ★ α ⟩ ⊒ V′ ∶ id (＇ α) →
+  Δ ∣ σ ∣ γ ⊢ V ⟨ seal ★ α ⟩ ⊒ V′ ∶ id (＇ α) →
   ∃[ r ] (Δ ∣ srcStoreⁿ σ ⊢ r ∶ ★ ⊒ ＇ α) ×
     Δ ∣ σ ∣ γ ⊢ V ⊒ V′ ∶ r
 
@@ -244,7 +244,7 @@ termNarrowing-resp-source p⊒ qᶜ M⊒M′ = {!!}
 
 leftSealNarrowingInversion-aux :
   ∀ {Δ σ γ M V V′ p α} →
-  M ≡ V ⟨ id ★ ︔ seal ★ α ⟩ →
+  M ≡ V ⟨ seal ★ α ⟩ →
   p ≡ id (＇ α) →
   Value V →
     Δ ∣ σ ∣ γ ⊢ M ⊒ V′ ∶ p →
@@ -288,13 +288,11 @@ leftSealNarrowingInversion-aux eq refl vV
       M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
     (⊒blame (cast-id hα ok , cross (id-＇ α))) =
-  (((＇ α) ？) ︔ id (＇ α)) ,
+  (＇ α) ？ ,
   (tag-or-idᵈ ,
-    (cast-seq (cast-untag hα (＇ α) refl) (cast-id hα refl) ,
-     (＇ α) ？︔ id-＇ α)) ,
+    (cast-untag hα (＇ α) refl , untag (＇ α))) ,
   ⊒blame
-    (cast-seq (cast-untag hα (＇ α) refl) (cast-id hα refl) ,
-     (＇ α) ？︔ id-＇ α)
+    (cast-untag hα (＇ α) refl , untag (＇ α))
 -- Right cast cases: the paper says these recurse because the cast must be
 -- identity-like, but endpoint equivalence does not yet give that directly.
 leftSealNarrowingInversion-aux refl refl vV
@@ -310,8 +308,7 @@ leftSealNarrowingInversion-aux refl refl vV
 leftSealNarrowingInversion-aux refl refl vV
     (cast-⊒ {r = r} pᶜ
       (compose-rightⁿ wfΣ
-        t⊒@(cast-seq (cast-id h★ ok★) (cast-seal h★′ α∈Σ seal-ok) ,
-             id★ ︔seal α)
+        t⊒@(cast-seal h★′ α∈Σ seal-ok , sealⁿ ★ α)
         p⊒@(cast-id hα okα , cross (id-＇ α))
         (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
       M⊒M′) =

--- a/GTSF/proof/NWTermReduction.agda
+++ b/GTSF/proof/NWTermReduction.agda
@@ -1,0 +1,345 @@
+module proof.NWTermReduction where
+
+-- File Charter:
+--   * Defines the syntactic invariant that every coercion occurrence in a Nu
+--     term is a narrowing or a widening.
+--   * Proves that the invariant is preserved by pure and store-change
+--     reduction.
+--   * Depends on the positive strict NarrowWiden grammar for decomposition of
+--     sequence, function, quantifier, gen, and inst coercions.
+
+open import Data.Nat using (zero; suc)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NuReduction
+open import NarrowWiden
+
+NWCoercion : Coercion → Set
+NWCoercion c = Narrowing c ⊎ Widening c
+
+data NWTerm : Term → Set where
+  nw-` : ∀ {x} →
+    NWTerm (` x)
+
+  nw-ƛ : ∀ {M} →
+    NWTerm M →
+    NWTerm (ƛ M)
+
+  nw-· : ∀ {L M} →
+    NWTerm L →
+    NWTerm M →
+    NWTerm (L · M)
+
+  nw-Λ : ∀ {M} →
+    NWTerm M →
+    NWTerm (Λ M)
+
+  nw-• : ∀ {M} →
+    NWTerm M →
+    NWTerm (M •)
+
+  nw-ν : ∀ {A M c} →
+    NWTerm M →
+    NWCoercion c →
+    NWTerm (ν A M c)
+
+  nw-$ : ∀ {κ} →
+    NWTerm ($ κ)
+
+  nw-⊕ : ∀ {L op M} →
+    NWTerm L →
+    NWTerm M →
+    NWTerm (L ⊕[ op ] M)
+
+  nw-⟨⟩ : ∀ {M c} →
+    NWTerm M →
+    NWCoercion c →
+    NWTerm (M ⟨ c ⟩)
+
+  nw-blame :
+    NWTerm blame
+
+renameᶜ-preserves-NWCoercion :
+  ∀ ρ {c} →
+  NWCoercion c →
+  NWCoercion (renameᶜ ρ c)
+renameᶜ-preserves-NWCoercion ρ (inj₁ cⁿ) = inj₁ (renameⁿ ρ cⁿ)
+renameᶜ-preserves-NWCoercion ρ (inj₂ cʷ) = inj₂ (renameʷ ρ cʷ)
+
+⇑ᶜ-preserves-NWCoercion :
+  ∀ {c} →
+  NWCoercion c →
+  NWCoercion (⇑ᶜ c)
+⇑ᶜ-preserves-NWCoercion = renameᶜ-preserves-NWCoercion suc
+
+renameᵗᵐ-preserves-NWTerm :
+  ∀ ρ {M} →
+  NWTerm M →
+  NWTerm (renameᵗᵐ ρ M)
+renameᵗᵐ-preserves-NWTerm ρ nw-` = nw-`
+renameᵗᵐ-preserves-NWTerm ρ (nw-ƛ nwM) =
+  nw-ƛ (renameᵗᵐ-preserves-NWTerm ρ nwM)
+renameᵗᵐ-preserves-NWTerm ρ (nw-· nwL nwM) =
+  nw-· (renameᵗᵐ-preserves-NWTerm ρ nwL)
+       (renameᵗᵐ-preserves-NWTerm ρ nwM)
+renameᵗᵐ-preserves-NWTerm ρ (nw-Λ nwM) =
+  nw-Λ (renameᵗᵐ-preserves-NWTerm (extᵗ ρ) nwM)
+renameᵗᵐ-preserves-NWTerm ρ (nw-• nwM) =
+  nw-• (renameᵗᵐ-preserves-NWTerm ρ nwM)
+renameᵗᵐ-preserves-NWTerm ρ (nw-ν nwM nwc) =
+  nw-ν
+    (renameᵗᵐ-preserves-NWTerm ρ nwM)
+    (renameᶜ-preserves-NWCoercion (extᵗ ρ) nwc)
+renameᵗᵐ-preserves-NWTerm ρ nw-$ = nw-$
+renameᵗᵐ-preserves-NWTerm ρ (nw-⊕ nwL nwM) =
+  nw-⊕ (renameᵗᵐ-preserves-NWTerm ρ nwL)
+       (renameᵗᵐ-preserves-NWTerm ρ nwM)
+renameᵗᵐ-preserves-NWTerm ρ (nw-⟨⟩ nwM nwc) =
+  nw-⟨⟩
+    (renameᵗᵐ-preserves-NWTerm ρ nwM)
+    (renameᶜ-preserves-NWCoercion ρ nwc)
+renameᵗᵐ-preserves-NWTerm ρ nw-blame = nw-blame
+
+⇑ᵗᵐ-preserves-NWTerm :
+  ∀ {M} →
+  NWTerm M →
+  NWTerm (⇑ᵗᵐ M)
+⇑ᵗᵐ-preserves-NWTerm = renameᵗᵐ-preserves-NWTerm suc
+
+renameˣᵐ-preserves-NWTerm :
+  ∀ ρ {M} →
+  NWTerm M →
+  NWTerm (renameˣᵐ ρ M)
+renameˣᵐ-preserves-NWTerm ρ nw-` = nw-`
+renameˣᵐ-preserves-NWTerm ρ (nw-ƛ nwM) =
+  nw-ƛ (renameˣᵐ-preserves-NWTerm (extʳ ρ) nwM)
+renameˣᵐ-preserves-NWTerm ρ (nw-· nwL nwM) =
+  nw-· (renameˣᵐ-preserves-NWTerm ρ nwL)
+       (renameˣᵐ-preserves-NWTerm ρ nwM)
+renameˣᵐ-preserves-NWTerm ρ (nw-Λ nwM) =
+  nw-Λ (renameˣᵐ-preserves-NWTerm ρ nwM)
+renameˣᵐ-preserves-NWTerm ρ (nw-• nwM) =
+  nw-• (renameˣᵐ-preserves-NWTerm ρ nwM)
+renameˣᵐ-preserves-NWTerm ρ (nw-ν nwM nwc) =
+  nw-ν (renameˣᵐ-preserves-NWTerm ρ nwM) nwc
+renameˣᵐ-preserves-NWTerm ρ nw-$ = nw-$
+renameˣᵐ-preserves-NWTerm ρ (nw-⊕ nwL nwM) =
+  nw-⊕ (renameˣᵐ-preserves-NWTerm ρ nwL)
+       (renameˣᵐ-preserves-NWTerm ρ nwM)
+renameˣᵐ-preserves-NWTerm ρ (nw-⟨⟩ nwM nwc) =
+  nw-⟨⟩ (renameˣᵐ-preserves-NWTerm ρ nwM) nwc
+renameˣᵐ-preserves-NWTerm ρ nw-blame = nw-blame
+
+NWSubst : Substˣ → Set
+NWSubst σ = ∀ x → NWTerm (σ x)
+
+extˢˣ-preserves-NWSubst :
+  ∀ {σ} →
+  NWSubst σ →
+  NWSubst (extˢˣ σ)
+extˢˣ-preserves-NWSubst nwσ zero = nw-`
+extˢˣ-preserves-NWSubst nwσ (suc x) =
+  renameˣᵐ-preserves-NWTerm suc (nwσ x)
+
+↑ᵗᵐ-preserves-NWSubst :
+  ∀ {σ} →
+  NWSubst σ →
+  NWSubst (↑ᵗᵐ σ)
+↑ᵗᵐ-preserves-NWSubst nwσ x =
+  ⇑ᵗᵐ-preserves-NWTerm (nwσ x)
+
+substˣᵐ-preserves-NWTerm :
+  ∀ {σ M} →
+  NWSubst σ →
+  NWTerm M →
+  NWTerm (substˣᵐ σ M)
+substˣᵐ-preserves-NWTerm nwσ nw-` = nwσ _
+substˣᵐ-preserves-NWTerm nwσ (nw-ƛ nwM) =
+  nw-ƛ (substˣᵐ-preserves-NWTerm (extˢˣ-preserves-NWSubst nwσ) nwM)
+substˣᵐ-preserves-NWTerm nwσ (nw-· nwL nwM) =
+  nw-· (substˣᵐ-preserves-NWTerm nwσ nwL)
+       (substˣᵐ-preserves-NWTerm nwσ nwM)
+substˣᵐ-preserves-NWTerm nwσ (nw-Λ nwM) =
+  nw-Λ (substˣᵐ-preserves-NWTerm (↑ᵗᵐ-preserves-NWSubst nwσ) nwM)
+substˣᵐ-preserves-NWTerm nwσ (nw-• nwM) =
+  nw-• (substˣᵐ-preserves-NWTerm nwσ nwM)
+substˣᵐ-preserves-NWTerm nwσ (nw-ν nwM nwc) =
+  nw-ν (substˣᵐ-preserves-NWTerm nwσ nwM) nwc
+substˣᵐ-preserves-NWTerm nwσ nw-$ = nw-$
+substˣᵐ-preserves-NWTerm nwσ (nw-⊕ nwL nwM) =
+  nw-⊕ (substˣᵐ-preserves-NWTerm nwσ nwL)
+       (substˣᵐ-preserves-NWTerm nwσ nwM)
+substˣᵐ-preserves-NWTerm nwσ (nw-⟨⟩ nwM nwc) =
+  nw-⟨⟩ (substˣᵐ-preserves-NWTerm nwσ nwM) nwc
+substˣᵐ-preserves-NWTerm nwσ nw-blame = nw-blame
+
+singleEnv-preserves-NWSubst :
+  ∀ {V} →
+  NWTerm V →
+  NWSubst (singleEnv V)
+singleEnv-preserves-NWSubst nwV zero = nwV
+singleEnv-preserves-NWSubst nwV (suc x) = nw-`
+
+single-subst-preserves-NWTerm :
+  ∀ {M V} →
+  NWTerm M →
+  NWTerm V →
+  NWTerm (M [ V ])
+single-subst-preserves-NWTerm nwM nwV =
+  substˣᵐ-preserves-NWTerm (singleEnv-preserves-NWSubst nwV) nwM
+
+nw-seq-left :
+  ∀ {p q} →
+  NWCoercion (p ︔ q) →
+  NWCoercion p
+nw-seq-left (inj₁ (gG ？︔ gⁿ)) = inj₁ (untag gG)
+nw-seq-left (inj₁ (_︔seal_ sⁿ α)) = inj₁ (strictⁿ→narrow sⁿ)
+nw-seq-left (inj₂ (gʷ ︔ gG !)) =
+  inj₂ (cross (strictCrossʷ→cross gʷ))
+nw-seq-left (inj₂ (unseal︔_ α {A = A} sʷ)) =
+  inj₂ (unsealʷ α A)
+
+nw-seq-right :
+  ∀ {p q} →
+  NWCoercion (p ︔ q) →
+  NWCoercion q
+nw-seq-right (inj₁ (gG ？︔ gⁿ)) =
+  inj₁ (cross (strictCrossⁿ→cross gⁿ))
+nw-seq-right (inj₁ (_︔seal_ {A = A} sⁿ α)) =
+  inj₁ (sealⁿ A α)
+nw-seq-right (inj₂ (gʷ ︔ gG !)) = inj₂ (tag gG)
+nw-seq-right (inj₂ (unseal︔_ α sʷ)) =
+  inj₂ (strictʷ→widen sʷ)
+
+nw-fun-left :
+  ∀ {p q} →
+  NWCoercion (p ↦ q) →
+  NWCoercion p
+nw-fun-left (inj₁ (cross (pʷ ↦ qⁿ))) = inj₂ pʷ
+nw-fun-left (inj₂ (cross (pⁿ ↦ qʷ))) = inj₁ pⁿ
+
+nw-fun-right :
+  ∀ {p q} →
+  NWCoercion (p ↦ q) →
+  NWCoercion q
+nw-fun-right (inj₁ (cross (pʷ ↦ qⁿ))) = inj₁ qⁿ
+nw-fun-right (inj₂ (cross (pⁿ ↦ qʷ))) = inj₂ qʷ
+
+nw-all-body :
+  ∀ {c} →
+  NWCoercion (`∀ c) →
+  NWCoercion c
+nw-all-body (inj₁ (cross (`∀ cⁿ))) = inj₁ cⁿ
+nw-all-body (inj₂ (cross (`∀ cʷ))) = inj₂ cʷ
+
+nw-gen-body :
+  ∀ {A c} →
+  NWCoercion (gen A c) →
+  NWCoercion c
+nw-gen-body (inj₁ (gen cⁿ)) = inj₁ cⁿ
+nw-gen-body (inj₂ (cross ()))
+
+nw-inst-body :
+  ∀ {A c} →
+  NWCoercion (inst A c) →
+  NWCoercion c
+nw-inst-body (inj₁ (cross ()))
+nw-inst-body (inj₂ (inst cʷ)) = inj₂ cʷ
+
+applyCoercion-preserves-NWCoercion :
+  ∀ χ {c} →
+  NWCoercion c →
+  NWCoercion (applyCoercion χ c)
+applyCoercion-preserves-NWCoercion keep nwc = nwc
+applyCoercion-preserves-NWCoercion (bind A) nwc =
+  ⇑ᶜ-preserves-NWCoercion nwc
+
+applyCoercionUnderTyBinder-preserves-NWCoercion :
+  ∀ χ {c} →
+  NWCoercion c →
+  NWCoercion (applyCoercionUnderTyBinder χ c)
+applyCoercionUnderTyBinder-preserves-NWCoercion keep nwc = nwc
+applyCoercionUnderTyBinder-preserves-NWCoercion (bind A) nwc =
+  renameᶜ-preserves-NWCoercion (extᵗ suc) nwc
+
+applyTerm-preserves-NWTerm :
+  ∀ χ {M} →
+  NWTerm M →
+  NWTerm (applyTerm χ M)
+applyTerm-preserves-NWTerm keep nwM = nwM
+applyTerm-preserves-NWTerm (bind A) nwM = ⇑ᵗᵐ-preserves-NWTerm nwM
+
+pure-step-preserves-NWTerm :
+  ∀ {M N} →
+  M —→ N →
+  NWTerm M →
+  NWTerm N
+pure-step-preserves-NWTerm δ-⊕ (nw-⊕ nw-$ nw-$) = nw-$
+pure-step-preserves-NWTerm (β vV) (nw-· (nw-ƛ nwN) nwV) =
+  single-subst-preserves-NWTerm nwN nwV
+pure-step-preserves-NWTerm (β-Λ• vV) (nw-• (nw-Λ nwV)) =
+  renameᵗᵐ-preserves-NWTerm (singleRenameᵗ zero) nwV
+pure-step-preserves-NWTerm (β-∀• vV) (nw-• (nw-⟨⟩ nwV nwc)) =
+  nw-⟨⟩ (nw-• nwV)
+    (renameᶜ-preserves-NWCoercion (singleRenameᵗ zero)
+      (nw-all-body nwc))
+pure-step-preserves-NWTerm (β-gen• vV) (nw-• (nw-⟨⟩ nwV nwc)) =
+  nw-⟨⟩ nwV
+    (renameᶜ-preserves-NWCoercion (singleRenameᵗ zero)
+      (nw-gen-body nwc))
+pure-step-preserves-NWTerm (β-id vV) (nw-⟨⟩ nwV nwc) = nwV
+pure-step-preserves-NWTerm (β-seq vV) (nw-⟨⟩ nwV nwc) =
+  nw-⟨⟩ (nw-⟨⟩ nwV (nw-seq-left nwc)) (nw-seq-right nwc)
+pure-step-preserves-NWTerm (β-↦ vV vW)
+    (nw-· (nw-⟨⟩ nwV nwc) nwW) =
+  nw-⟨⟩ (nw-· nwV (nw-⟨⟩ nwW (nw-fun-left nwc)))
+    (nw-fun-right nwc)
+pure-step-preserves-NWTerm (β-inst vV) (nw-⟨⟩ nwV nwc) =
+  nw-ν nwV (nw-inst-body nwc)
+pure-step-preserves-NWTerm (tag-untag-ok vV)
+    (nw-⟨⟩ (nw-⟨⟩ nwV nwc₁) nwc₂) =
+  nwV
+pure-step-preserves-NWTerm (tag-untag-bad vV G≢H)
+    (nw-⟨⟩ (nw-⟨⟩ nwV nwc₁) nwc₂) =
+  nw-blame
+pure-step-preserves-NWTerm (seal-unseal vV)
+    (nw-⟨⟩ (nw-⟨⟩ nwV nwc₁) nwc₂) =
+  nwV
+pure-step-preserves-NWTerm blame-·₁ (nw-· nw-blame nwM) = nw-blame
+pure-step-preserves-NWTerm (blame-·₂ vV) (nw-· nwV nw-blame) = nw-blame
+pure-step-preserves-NWTerm blame-• (nw-• nw-blame) = nw-blame
+pure-step-preserves-NWTerm blame-⟨⟩ (nw-⟨⟩ nw-blame nwc) = nw-blame
+pure-step-preserves-NWTerm blame-⊕₁ (nw-⊕ nw-blame nwM) = nw-blame
+pure-step-preserves-NWTerm (blame-⊕₂ vV) (nw-⊕ nwV nw-blame) = nw-blame
+
+step-preserves-NWTerm :
+  ∀ {M N χ} →
+  M —→[ χ ] N →
+  NWTerm M →
+  NWTerm N
+step-preserves-NWTerm (pure-step red) nwM =
+  pure-step-preserves-NWTerm red nwM
+step-preserves-NWTerm (ν-step vV noV) (nw-ν nwV nwc) =
+  nw-⟨⟩ (nw-• (⇑ᵗᵐ-preserves-NWTerm nwV)) nwc
+step-preserves-NWTerm {χ = χ} (ξ-·₁ red shiftM) (nw-· nwL nwM) =
+  nw-· (step-preserves-NWTerm red nwL)
+       (applyTerm-preserves-NWTerm χ nwM)
+step-preserves-NWTerm {χ = χ} (ξ-·₂ vV shiftV red) (nw-· nwV nwM) =
+  nw-· (applyTerm-preserves-NWTerm χ nwV)
+       (step-preserves-NWTerm red nwM)
+step-preserves-NWTerm {χ = χ} (ξ-⟨⟩ red) (nw-⟨⟩ nwM nwc) =
+  nw-⟨⟩ (step-preserves-NWTerm red nwM)
+    (applyCoercion-preserves-NWCoercion χ nwc)
+step-preserves-NWTerm {χ = χ} (ξ-ν red) (nw-ν nwM nwc) =
+  nw-ν (step-preserves-NWTerm red nwM)
+    (applyCoercionUnderTyBinder-preserves-NWCoercion χ nwc)
+step-preserves-NWTerm blame-ν (nw-ν nw-blame nwc) = nw-blame
+step-preserves-NWTerm {χ = χ} (ξ-⊕₁ red shiftM) (nw-⊕ nwL nwM) =
+  nw-⊕ (step-preserves-NWTerm red nwL)
+       (applyTerm-preserves-NWTerm χ nwM)
+step-preserves-NWTerm {χ = χ} (ξ-⊕₂ vV shiftV red) (nw-⊕ nwL nwM) =
+  nw-⊕ (applyTerm-preserves-NWTerm χ nwL)
+       (step-preserves-NWTerm red nwM)

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -489,12 +489,19 @@ mutual
       (c⊢ , cross ())
   narrowing-var-to-older⊥ wfΣ hB
       (cast-seq () s⊢ , _？︔_ gG′ sⁿ)
+  narrowing-var-to-older⊥ {α = α} wfΣ (wfVar β<α)
+      (cast-seal {α = β} hA β∈Σ seal-ok , sealⁿ _ _) with
+      wfOlder wfΣ β∈Σ
+  narrowing-var-to-older⊥ {α = α} wfΣ (wfVar β<α)
+      (cast-seal {α = β} hA β∈Σ seal-ok , sealⁿ _ _) |
+      wfVar α<β =
+    <-irrefl refl (≤-trans α<β (≤-trans (n≤1+n β) β<α))
   narrowing-var-to-older⊥ wfΣ (wfVar β<α)
       (cast-seq s⊢ (cast-seal hA β∈Σ seal-ok) , sⁿ ︔seal _) =
     narrowing-var-to-older⊥
       wfΣ
       (WfTy-weakenᵗ (wfOlder wfΣ β∈Σ) (≤-from-< β<α))
-      (s⊢ , sⁿ)
+      (s⊢ , strictⁿ→narrow sⁿ)
 
   widening-older-to-var⊥ :
     ∀ {μ Δ Σ c α A} →
@@ -527,12 +534,19 @@ mutual
       (c⊢ , cross ())
   widening-older-to-var⊥ wfΣ hA
       (cast-seq s⊢ () , ((sʷ ︔ gG′ !)))
+  widening-older-to-var⊥ {α = α} wfΣ (wfVar β<α)
+      (cast-unseal {α = β} hA β∈Σ seal-ok , unsealʷ _ _) with
+      wfOlder wfΣ β∈Σ
+  widening-older-to-var⊥ {α = α} wfΣ (wfVar β<α)
+      (cast-unseal {α = β} hA β∈Σ seal-ok , unsealʷ _ _) |
+      wfVar α<β =
+    <-irrefl refl (≤-trans α<β (≤-trans (n≤1+n β) β<α))
   widening-older-to-var⊥ wfΣ (wfVar β<α)
       (cast-seq (cast-unseal hA β∈Σ seal-ok) s⊢ , unseal︔_ _ sʷ) =
     widening-older-to-var⊥
       wfΣ
       (WfTy-weakenᵗ (wfOlder wfΣ β∈Σ) (≤-from-< β<α))
-      (s⊢ , sʷ)
+      (s⊢ , strictʷ→widen sʷ)
 
 ------------------------------------------------------------------------
 -- Endpoint exclusions used by the expanded determinacy proof
@@ -540,6 +554,14 @@ mutual
 
 false≢true : false ≡ true → ⊥
 false≢true ()
+
+star≢all : ∀ {B : Ty} → ★ ≢ `∀ B
+star≢all ()
+
+star≢var : ∀ {α : TyVar} → ★ ≢ ＇ α
+star≢var {α = α} eq with ★ ≟Ty ＇ α
+star≢var {α = α} eq | no neq = neq eq
+star≢var {α = α} eq | yes ()
 
 tag-seal-conflict :
   ∀ {m} →
@@ -732,13 +754,26 @@ mutual
     np-gen
       (narrowing-target-path-id-only {α = suc α} α-id (c⊢ , cⁿ) occ)
   narrowing-target-path-id-only α-id
+      (cast-untag hG gG tag-ok , untag gG′)
+      occ =
+    ⊥-elim
+      (id-only-ground-tag-occurs⊥
+        α-id gG tag-ok (Occurs→occurs-true occ))
+  narrowing-target-path-id-only α-id
       (cast-seq (cast-untag hG gG tag-ok) c⊢ , _？︔_ gG′ cⁿ)
       occ =
     ⊥-elim
       (id-only-ground-tag-occurs⊥
         α-id gG tag-ok
         (narrowing-cross-target-id-only
-          α-id (c⊢ , cⁿ) (Occurs→occurs-true occ)))
+          α-id (c⊢ , strictCrossⁿ→cross cⁿ)
+          (Occurs→occurs-true occ)))
+  narrowing-target-path-id-only α-id
+      (cast-seal hA β∈Σ seal-ok , sealⁿ A β)
+      occ =
+    ⊥-elim
+      (id-only-seal-var-occurs⊥
+        α-id seal-ok (Occurs→occurs-true occ))
   narrowing-target-path-id-only α-id
       (cast-seq c⊢ (cast-seal {α = β} hA β∈Σ seal-ok) ,
        cⁿ ︔seal _)
@@ -783,13 +818,26 @@ mutual
     wp-inst
       (widening-source-path-id-only {α = suc α} α-id (c⊢ , cʷ) occ)
   widening-source-path-id-only α-id
+      (cast-tag hG gG tag-ok , tag gG′)
+      occ =
+    ⊥-elim
+      (id-only-ground-tag-occurs⊥
+        α-id gG tag-ok (Occurs→occurs-true occ))
+  widening-source-path-id-only α-id
       (cast-seq c⊢ (cast-tag hG gG tag-ok) , ((cʷ ︔ gG′ !)))
       occ =
     ⊥-elim
       (id-only-ground-tag-occurs⊥
         α-id gG tag-ok
         (widening-cross-source-id-only
-          α-id (c⊢ , cʷ) (Occurs→occurs-true occ)))
+          α-id (c⊢ , strictCrossʷ→cross cʷ)
+          (Occurs→occurs-true occ)))
+  widening-source-path-id-only α-id
+      (cast-unseal hA β∈Σ seal-ok , unsealʷ β A)
+      occ =
+    ⊥-elim
+      (id-only-seal-var-occurs⊥
+        α-id seal-ok (Occurs→occurs-true occ))
   widening-source-path-id-only α-id
       (cast-seq (cast-unseal {α = β} hA β∈Σ seal-ok) c⊢ ,
        unseal︔_ _ cʷ)
@@ -835,12 +883,21 @@ mutual
       (sym (occurs-raise zero α A))
       (narrowing-target-id-only {α = suc α} α-id (c⊢ , cⁿ) occ)
   narrowing-target-id-only α-id
+      (cast-untag hG gG tag-ok , untag gG′)
+      occ =
+    ⊥-elim (id-only-ground-tag-occurs⊥ α-id gG tag-ok occ)
+  narrowing-target-id-only α-id
       (cast-seq (cast-untag hG gG tag-ok) c⊢ , _？︔_ gG′ cⁿ)
       occ =
     ⊥-elim
       (id-only-ground-tag-occurs⊥
         α-id gG tag-ok
-        (narrowing-cross-target-id-only α-id (c⊢ , cⁿ) occ))
+        (narrowing-cross-target-id-only
+          α-id (c⊢ , strictCrossⁿ→cross cⁿ) occ))
+  narrowing-target-id-only α-id
+      (cast-seal hA β∈Σ seal-ok , sealⁿ A β)
+      occ =
+    ⊥-elim (id-only-seal-var-occurs⊥ α-id seal-ok occ)
   narrowing-target-id-only α-id
       (cast-seq c⊢ (cast-seal {α = β} hA β∈Σ seal-ok) , cⁿ ︔seal _)
       occ =
@@ -893,12 +950,21 @@ mutual
       (sym (occurs-raise zero α B))
       (widening-source-id-only {α = suc α} α-id (c⊢ , cʷ) occ)
   widening-source-id-only α-id
+      (cast-tag hG gG tag-ok , tag gG′)
+      occ =
+    ⊥-elim (id-only-ground-tag-occurs⊥ α-id gG tag-ok occ)
+  widening-source-id-only α-id
       (cast-seq c⊢ (cast-tag hG gG tag-ok) , ((cʷ ︔ gG′ !)))
       occ =
     ⊥-elim
       (id-only-ground-tag-occurs⊥
         α-id gG tag-ok
-        (widening-cross-source-id-only α-id (c⊢ , cʷ) occ))
+        (widening-cross-source-id-only
+          α-id (c⊢ , strictCrossʷ→cross cʷ) occ))
+  widening-source-id-only α-id
+      (cast-unseal hA β∈Σ seal-ok , unsealʷ β A)
+      occ =
+    ⊥-elim (id-only-seal-var-occurs⊥ α-id seal-ok occ)
   widening-source-id-only α-id
       (cast-seq (cast-unseal {α = β} hA β∈Σ seal-ok) c⊢ ,
        unseal︔_ _ cʷ)
@@ -976,7 +1042,9 @@ narrowing-target-star-source-star (() , cross (`∀ cⁿ))
 narrowing-target-star-source-star (cast-id hA ok , id★) = refl
 narrowing-target-star-source-star
     (cast-seq (cast-untag hG gG okG) c⊢ , _？︔_ gG′ cⁿ) =
-  ⊥-elim (narrowing-cross-ground-target-star⊥ gG (c⊢ , cⁿ))
+  ⊥-elim
+    (narrowing-cross-ground-target-star⊥
+      gG (c⊢ , strictCrossⁿ→cross cⁿ))
 narrowing-target-star-source-star
     (cast-seq c⊢ () , cⁿ ︔seal _)
 
@@ -991,7 +1059,9 @@ widening-source-star-target-star (() , cross (`∀ cʷ))
 widening-source-star-target-star (cast-id hA ok , id★) = refl
 widening-source-star-target-star
     (cast-seq c⊢ (cast-tag hG gG okG) , ((cʷ ︔ gG′ !))) =
-  ⊥-elim (widening-cross-ground-source-star⊥ gG (c⊢ , cʷ))
+  ⊥-elim
+    (widening-cross-ground-source-star⊥
+      gG (c⊢ , strictCrossʷ→cross cʷ))
 widening-source-star-target-star
     (cast-seq () c⊢ , unseal︔_ _ cʷ)
 
@@ -1006,6 +1076,89 @@ widening-cross-var-target-source :
   (μ ∣ Δ ∣ Σ ⊢ g ∶ A =⇒ (＇ α)) × CrossWidening g →
   A ≡ ＇ α
 widening-cross-var-target-source (cast-id hA ok , id-＇ _) = refl
+
+mutual
+  dualStrictCrossNarrowing-raw :
+    ∀ η {c} →
+    (g : StrictCrossNarrowing c) →
+    proj₁ (dualCrossNarrowing η (strictCrossⁿ→cross g)) ≡
+    proj₁ (dualStrictCrossNarrowing η g)
+  dualStrictCrossNarrowing-raw η (cn-funˡ sʷ tⁿ) =
+    cong₂ _↦_ (dualStrictʷ-raw η sʷ) refl
+  dualStrictCrossNarrowing-raw η (cn-funʳ sʷ tⁿ) =
+    cong₂ _↦_ refl (dualStrictⁿ-raw η tⁿ)
+  dualStrictCrossNarrowing-raw η (cn-all sⁿ) =
+    cong `∀ (dualStrictⁿ-raw (extᵃ η) sⁿ)
+
+  dualStrictⁿ-raw :
+    ∀ η {c} →
+    (s : StrictNarrowing c) →
+    proj₁ (dualⁿ η (strictⁿ→narrow s)) ≡
+    proj₁ (dualStrictⁿ η s)
+  dualStrictⁿ-raw η (strict-crossⁿ gⁿ) =
+    dualStrictCrossNarrowing-raw η gⁿ
+  dualStrictⁿ-raw η (strict-gen sⁿ) = refl
+  dualStrictⁿ-raw η (strict-untag (＇ α)) with η α
+  dualStrictⁿ-raw η (strict-untag (＇ α)) | normal = refl
+  dualStrictⁿ-raw η (strict-untag (＇ α)) | tag-to-seal = refl
+  dualStrictⁿ-raw η (strict-untag (＇ α)) | seal-to-tag = refl
+  dualStrictⁿ-raw η (strict-untag (‵ ι)) = refl
+  dualStrictⁿ-raw η (strict-untag ★⇒★) = refl
+  dualStrictⁿ-raw η (strict-untag-seq (＇ α) gⁿ) with η α
+  dualStrictⁿ-raw η (strict-untag-seq (＇ α) gⁿ) | normal = refl
+  dualStrictⁿ-raw η (strict-untag-seq (＇ α) gⁿ) | tag-to-seal = refl
+  dualStrictⁿ-raw η (strict-untag-seq (＇ α) gⁿ) | seal-to-tag = refl
+  dualStrictⁿ-raw η (strict-untag-seq (‵ ι) gⁿ) = refl
+  dualStrictⁿ-raw η (strict-untag-seq ★⇒★ gⁿ) = refl
+  dualStrictⁿ-raw η (strict-seal A α) with η α
+  dualStrictⁿ-raw η (strict-seal A α) | normal = refl
+  dualStrictⁿ-raw η (strict-seal A α) | tag-to-seal = refl
+  dualStrictⁿ-raw η (strict-seal A α) | seal-to-tag = refl
+  dualStrictⁿ-raw η (strict-seal-seq {A = A} sⁿ α) with η α
+  dualStrictⁿ-raw η (strict-seal-seq {A = A} sⁿ α) | normal = refl
+  dualStrictⁿ-raw η (strict-seal-seq {A = A} sⁿ α) | tag-to-seal = refl
+  dualStrictⁿ-raw η (strict-seal-seq {A = A} sⁿ α) | seal-to-tag = refl
+
+  dualStrictCrossWidening-raw :
+    ∀ η {c} →
+    (g : StrictCrossWidening c) →
+    proj₁ (dualCrossWidening η (strictCrossʷ→cross g)) ≡
+    proj₁ (dualStrictCrossWidening η g)
+  dualStrictCrossWidening-raw η (cw-funˡ sⁿ tʷ) =
+    cong₂ _↦_ (dualStrictⁿ-raw η sⁿ) refl
+  dualStrictCrossWidening-raw η (cw-funʳ sⁿ tʷ) =
+    cong₂ _↦_ refl (dualStrictʷ-raw η tʷ)
+  dualStrictCrossWidening-raw η (cw-all sʷ) =
+    cong `∀ (dualStrictʷ-raw (extᵃ η) sʷ)
+
+  dualStrictʷ-raw :
+    ∀ η {c} →
+    (s : StrictWidening c) →
+    proj₁ (dualʷ η (strictʷ→widen s)) ≡
+    proj₁ (dualStrictʷ η s)
+  dualStrictʷ-raw η (strict-crossʷ gʷ) =
+    dualStrictCrossWidening-raw η gʷ
+  dualStrictʷ-raw η (strict-inst sʷ) = refl
+  dualStrictʷ-raw η (strict-tag (＇ α)) with η α
+  dualStrictʷ-raw η (strict-tag (＇ α)) | normal = refl
+  dualStrictʷ-raw η (strict-tag (＇ α)) | tag-to-seal = refl
+  dualStrictʷ-raw η (strict-tag (＇ α)) | seal-to-tag = refl
+  dualStrictʷ-raw η (strict-tag (‵ ι)) = refl
+  dualStrictʷ-raw η (strict-tag ★⇒★) = refl
+  dualStrictʷ-raw η (strict-tag-seq gʷ (＇ α)) with η α
+  dualStrictʷ-raw η (strict-tag-seq gʷ (＇ α)) | normal = refl
+  dualStrictʷ-raw η (strict-tag-seq gʷ (＇ α)) | tag-to-seal = refl
+  dualStrictʷ-raw η (strict-tag-seq gʷ (＇ α)) | seal-to-tag = refl
+  dualStrictʷ-raw η (strict-tag-seq gʷ (‵ ι)) = refl
+  dualStrictʷ-raw η (strict-tag-seq gʷ ★⇒★) = refl
+  dualStrictʷ-raw η (strict-unseal α A) with η α
+  dualStrictʷ-raw η (strict-unseal α A) | normal = refl
+  dualStrictʷ-raw η (strict-unseal α A) | tag-to-seal = refl
+  dualStrictʷ-raw η (strict-unseal α A) | seal-to-tag = refl
+  dualStrictʷ-raw η (strict-unseal-seq α {A = A} sʷ) with η α
+  dualStrictʷ-raw η (strict-unseal-seq α {A = A} sʷ) | normal = refl
+  dualStrictʷ-raw η (strict-unseal-seq α {A = A} sʷ) | tag-to-seal = refl
+  dualStrictʷ-raw η (strict-unseal-seq α {A = A} sʷ) | seal-to-tag = refl
 
 ------------------------------------------------------------------------
 -- Grammar duality flips well-typed narrowing/widening endpoints
@@ -1042,6 +1195,22 @@ mutual
           (StoreWfAt-⟰ᵗ wfΣ)
           (c⊢ , cⁿ)))
 
+  dualStrictCrossNarrowing-flips-coercionᵐ :
+    ∀ {μ η ν Δ Σ Π c A B} →
+    DualActionOk μ η ν →
+    DualStoreAt Δ μ η ν Σ Π →
+    StoreWfAt Δ Σ →
+    (p : (μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B) × StrictCrossNarrowing c) →
+    ν ∣ Δ ∣ Π ⊢ proj₁ (dualStrictCrossNarrowing η (proj₂ p)) ∶ B =⇒ A
+  dualStrictCrossNarrowing-flips-coercionᵐ
+      {η = η} {ν = ν} {Δ = Δ} {Π = Π} {A = A} {B = B}
+      rel ds wfΣ (c⊢ , cⁿ) =
+    subst
+      (λ d → ν ∣ Δ ∣ Π ⊢ d ∶ B =⇒ A)
+      (dualStrictCrossNarrowing-raw η cⁿ)
+      (dualCrossNarrowing-flips-coercionᵐ
+        rel ds wfΣ (c⊢ , strictCrossⁿ→cross cⁿ))
+
   dualⁿ-flips-typingᵐ :
     ∀ {μ η ν Δ Σ Π c A B} →
     DualActionOk μ η ν →
@@ -1070,6 +1239,38 @@ mutual
     inst (proj₂ (dualⁿ (genᵃ η) cⁿ))
   dualⁿ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
       rel ds wfΣ
+      (cast-untag (wfVar α<Δ) (＇ α) ok , untag (＇ .α))
+      with μ α in μα | η α in ηα | ν α in να | rel α | ok
+  dualⁿ-flips-typingᵐ rel ds wfΣ
+      (cast-untag (wfVar α<Δ) (＇ α) ok , untag (＇ .α))
+      | id-only | normal | id-only | dma-id | ()
+  dualⁿ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-untag (wfVar α<Δ) (＇ α) ok , untag (＇ .α))
+      | tag-or-id | normal | tag-or-id | dma-tag | refl =
+    cast-tag (wfVar α<Δ) (＇ α)
+      (tagModeAllowed-var-tag {ν = ν} {α = α} να) ,
+    tag (＇ α)
+  dualⁿ-flips-typingᵐ rel ds wfΣ
+      (cast-untag (wfVar α<Δ) (＇ α) ok , untag (＇ .α))
+      | seal-or-id | normal | seal-or-id | dma-seal | ()
+  dualⁿ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-untag (wfVar α<Δ) (＇ α) ok , untag (＇ .α))
+      | tag-or-id | tag-to-seal | seal-or-id | dma-tag-seal | refl =
+    cast-unseal {μ = ν} wf★
+      (CoercionProof.DualStoreAt.tag★∈ ds α<Δ ηα)
+      (sealModeAllowed-var-seal {ν = ν} {α = α} να) ,
+    unsealʷ α ★
+  dualⁿ-flips-typingᵐ rel ds wfΣ
+      (cast-untag (wfVar α<Δ) (＇ α) ok , untag (＇ .α))
+      | seal-or-id | seal-to-tag | tag-or-id | dma-seal-tag | ()
+  dualⁿ-flips-typingᵐ {η = η} rel ds wfΣ
+      (cast-untag hG (‵ ι) ok , untag (‵ .ι)) =
+    cast-tag hG (‵ ι) refl , tag (‵ ι)
+  dualⁿ-flips-typingᵐ {η = η} rel ds wfΣ
+      (cast-untag hG ★⇒★ ok , untag ★⇒★) =
+    cast-tag hG ★⇒★ refl , tag ★⇒★
+  dualⁿ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
+      rel ds wfΣ
       (cast-seq (cast-untag (wfVar α<Δ) (＇ α) ok) g⊢ ,
        _？︔_ (＇ .α) gⁿ)
       with μ α in μα | η α in ηα | ν α in να | rel α | ok
@@ -1082,10 +1283,11 @@ mutual
        _？︔_ (＇ .α) gⁿ)
       | tag-or-id | normal | tag-or-id | dma-tag | refl =
     cast-seq
-      (dualCrossNarrowing-flips-coercionᵐ rel ds wfΣ (g⊢ , gⁿ))
+      (dualStrictCrossNarrowing-flips-coercionᵐ
+        rel ds wfΣ (g⊢ , gⁿ))
       (cast-tag (wfVar α<Δ) (＇ α)
         (tagModeAllowed-var-tag {ν = ν} {α = α} να)) ,
-    (proj₂ (dualCrossNarrowing η gⁿ) ︔ (＇ α) !)
+    (proj₂ (dualStrictCrossNarrowing η gⁿ) ︔ (＇ α) !)
   dualⁿ-flips-typingᵐ rel ds wfΣ
       (cast-seq (cast-untag (wfVar α<Δ) (＇ α) ok) g⊢ ,
        _？︔_ (＇ .α) gⁿ)
@@ -1094,13 +1296,12 @@ mutual
       (cast-seq (cast-untag (wfVar α<Δ) (＇ α) ok) g⊢ ,
        _？︔_ (＇ .α) gⁿ)
       | tag-or-id | tag-to-seal | seal-or-id | dma-tag-seal | refl
-      rewrite narrowing-cross-var-source-target (g⊢ , gⁿ) =
-    cast-seq
-      (cast-unseal {μ = ν} wf★
-        (CoercionProof.DualStoreAt.tag★∈ ds α<Δ ηα)
-        (sealModeAllowed-var-seal {ν = ν} {α = α} να))
-      (cast-id wf★ refl) ,
-    unseal︔_ _ id★
+      rewrite narrowing-cross-var-source-target
+                (g⊢ , strictCrossⁿ→cross gⁿ) =
+    cast-unseal {μ = ν} wf★
+      (CoercionProof.DualStoreAt.tag★∈ ds α<Δ ηα)
+      (sealModeAllowed-var-seal {ν = ν} {α = α} να) ,
+    unsealʷ α ★
   dualⁿ-flips-typingᵐ rel ds wfΣ
       (cast-seq (cast-untag (wfVar α<Δ) (＇ α) ok) g⊢ ,
        _？︔_ (＇ .α) gⁿ)
@@ -1109,16 +1310,45 @@ mutual
       (cast-seq (cast-untag hG (‵ ι) ok) g⊢ ,
        _？︔_ (‵ .ι) gⁿ) =
     cast-seq
-      (dualCrossNarrowing-flips-coercionᵐ rel ds wfΣ (g⊢ , gⁿ))
+      (dualStrictCrossNarrowing-flips-coercionᵐ
+        rel ds wfΣ (g⊢ , gⁿ))
       (cast-tag hG (‵ ι) refl) ,
-    (proj₂ (dualCrossNarrowing η gⁿ) ︔ (‵ ι) !)
+    (proj₂ (dualStrictCrossNarrowing η gⁿ) ︔ (‵ ι) !)
   dualⁿ-flips-typingᵐ {η = η} rel ds wfΣ
       (cast-seq (cast-untag hG ★⇒★ ok) g⊢ ,
        _？︔_ ★⇒★ gⁿ) =
     cast-seq
-      (dualCrossNarrowing-flips-coercionᵐ rel ds wfΣ (g⊢ , gⁿ))
+      (dualStrictCrossNarrowing-flips-coercionᵐ
+        rel ds wfΣ (g⊢ , gⁿ))
       (cast-tag hG ★⇒★ refl) ,
-    (proj₂ (dualCrossNarrowing η gⁿ) ︔ ★⇒★ !)
+    (proj₂ (dualStrictCrossNarrowing η gⁿ) ︔ ★⇒★ !)
+  dualⁿ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
+      rel ds wfΣ
+      (cast-seal {α = α} hA αA∈Σ ok , sealⁿ A .α)
+      with μ α in μα | η α in ηα | ν α in να | rel α | ok
+  dualⁿ-flips-typingᵐ rel ds wfΣ
+      (cast-seal hA αA∈Σ ok , sealⁿ A α)
+      | id-only | normal | id-only | dma-id | ()
+  dualⁿ-flips-typingᵐ rel ds wfΣ
+      (cast-seal hA αA∈Σ ok , sealⁿ A α)
+      | tag-or-id | normal | tag-or-id | dma-tag | ()
+  dualⁿ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-seal {α = α} hA αA∈Σ ok , sealⁿ A .α)
+      | seal-or-id | normal | seal-or-id | dma-seal | refl =
+    cast-unseal {μ = ν} hA
+      (CoercionProof.DualStoreAt.seal∈ ds μα ηα να αA∈Σ)
+      (sealModeAllowed-var-seal {ν = ν} {α = α} να) ,
+    unsealʷ α A
+  dualⁿ-flips-typingᵐ rel ds wfΣ
+      (cast-seal hA αA∈Σ ok , sealⁿ A α)
+      | tag-or-id | tag-to-seal | seal-or-id | dma-tag-seal | ()
+  dualⁿ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-seal {α = α} hA αA∈Σ ok , sealⁿ A .α)
+      | seal-or-id | seal-to-tag | tag-or-id | dma-seal-tag | refl
+      rewrite CoercionProof.DualStoreAt.seal★ ds ηα αA∈Σ =
+    cast-tag (wfVar (bound wfΣ αA∈Σ)) (＇ α)
+      (tagModeAllowed-var-tag {ν = ν} {α = α} να) ,
+    tag (＇ α)
   dualⁿ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
       rel ds wfΣ
       (cast-seq s⊢ (cast-seal {α = α} hA αA∈Σ ok) ,
@@ -1140,8 +1370,9 @@ mutual
       (cast-unseal {μ = ν} hA
         (CoercionProof.DualStoreAt.seal∈ ds μα ηα να αA∈Σ)
         (sealModeAllowed-var-seal {ν = ν} {α = α} να))
-      (proj₁ (dualⁿ-flips-typingᵐ rel ds wfΣ (s⊢ , sⁿ))) ,
-    unseal︔_ α (proj₂ (dualⁿ η sⁿ))
+      (proj₁
+        (dualStrictⁿ-flips-typingᵐ rel ds wfΣ (s⊢ , sⁿ))) ,
+    unseal︔_ α (proj₂ (dualStrictⁿ η sⁿ))
   dualⁿ-flips-typingᵐ rel ds wfΣ
       (cast-seq s⊢ (cast-seal hA αA∈Σ ok) ,
        sⁿ ︔seal _)
@@ -1151,12 +1382,30 @@ mutual
        sⁿ ︔seal _)
       | seal-or-id | seal-to-tag | tag-or-id | dma-seal-tag | refl
       rewrite CoercionProof.DualStoreAt.seal★ ds ηα αA∈Σ
-            | narrowing-target-star-source-star (s⊢ , sⁿ) =
-    cast-seq
-      (cast-id (wfVar (bound wfΣ αA∈Σ)) (idModeAllowed-any (ν α)))
-      (cast-tag (wfVar (bound wfΣ αA∈Σ)) (＇ α)
-        (tagModeAllowed-var-tag {ν = ν} {α = α} να)) ,
-    (id-＇ α ︔ (＇ α) !)
+            | narrowing-target-star-source-star
+                (s⊢ , strictⁿ→narrow sⁿ) =
+    cast-tag (wfVar (bound wfΣ αA∈Σ)) (＇ α)
+      (tagModeAllowed-var-tag {ν = ν} {α = α} να) ,
+    tag (＇ α)
+
+  dualStrictⁿ-flips-typingᵐ :
+    ∀ {μ η ν Δ Σ Π c A B} →
+    DualActionOk μ η ν →
+    DualStoreAt Δ μ η ν Σ Π →
+    StoreWfAt Δ Σ →
+    (p : (μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B) × StrictNarrowing c) →
+    (ν ∣ Δ ∣ Π ⊢ proj₁ (dualStrictⁿ η (proj₂ p)) ∶ B =⇒ A) ×
+    StrictWidening (proj₁ (dualStrictⁿ η (proj₂ p)))
+  dualStrictⁿ-flips-typingᵐ
+      {η = η} {ν = ν} {Δ = Δ} {Π = Π} {A = A} {B = B}
+      rel ds wfΣ (c⊢ , cⁿ) =
+    subst
+      (λ d → ν ∣ Δ ∣ Π ⊢ d ∶ B =⇒ A)
+      (dualStrictⁿ-raw η cⁿ)
+      (proj₁
+        (dualⁿ-flips-typingᵐ
+          rel ds wfΣ (c⊢ , strictⁿ→narrow cⁿ))) ,
+    proj₂ (dualStrictⁿ η cⁿ)
 
   dualCrossWidening-flips-coercionᵐ :
     ∀ {μ η ν Δ Σ Π c A B} →
@@ -1188,6 +1437,22 @@ mutual
           (StoreWfAt-⟰ᵗ wfΣ)
           (c⊢ , cʷ)))
 
+  dualStrictCrossWidening-flips-coercionᵐ :
+    ∀ {μ η ν Δ Σ Π c A B} →
+    DualActionOk μ η ν →
+    DualStoreAt Δ μ η ν Σ Π →
+    StoreWfAt Δ Σ →
+    (p : (μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B) × StrictCrossWidening c) →
+    ν ∣ Δ ∣ Π ⊢ proj₁ (dualStrictCrossWidening η (proj₂ p)) ∶ B =⇒ A
+  dualStrictCrossWidening-flips-coercionᵐ
+      {η = η} {ν = ν} {Δ = Δ} {Π = Π} {A = A} {B = B}
+      rel ds wfΣ (c⊢ , cʷ) =
+    subst
+      (λ d → ν ∣ Δ ∣ Π ⊢ d ∶ B =⇒ A)
+      (dualStrictCrossWidening-raw η cʷ)
+      (dualCrossWidening-flips-coercionᵐ
+        rel ds wfΣ (c⊢ , strictCrossʷ→cross cʷ))
+
   dualʷ-flips-typingᵐ :
     ∀ {μ η ν Δ Σ Π c A B} →
     DualActionOk μ η ν →
@@ -1216,6 +1481,38 @@ mutual
     gen (proj₂ (dualʷ (instᵃ η) cʷ))
   dualʷ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
       rel ds wfΣ
+      (cast-tag (wfVar α<Δ) (＇ α) ok , tag (＇ .α))
+      with μ α in μα | η α in ηα | ν α in να | rel α | ok
+  dualʷ-flips-typingᵐ rel ds wfΣ
+      (cast-tag (wfVar α<Δ) (＇ α) ok , tag (＇ .α))
+      | id-only | normal | id-only | dma-id | ()
+  dualʷ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-tag (wfVar α<Δ) (＇ α) ok , tag (＇ .α))
+      | tag-or-id | normal | tag-or-id | dma-tag | refl =
+    cast-untag (wfVar α<Δ) (＇ α)
+      (tagModeAllowed-var-tag {ν = ν} {α = α} να) ,
+    untag (＇ α)
+  dualʷ-flips-typingᵐ rel ds wfΣ
+      (cast-tag (wfVar α<Δ) (＇ α) ok , tag (＇ .α))
+      | seal-or-id | normal | seal-or-id | dma-seal | ()
+  dualʷ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-tag (wfVar α<Δ) (＇ α) ok , tag (＇ .α))
+      | tag-or-id | tag-to-seal | seal-or-id | dma-tag-seal | refl =
+    cast-seal {μ = ν} wf★
+      (CoercionProof.DualStoreAt.tag★∈ ds α<Δ ηα)
+      (sealModeAllowed-var-seal {ν = ν} {α = α} να) ,
+    sealⁿ ★ α
+  dualʷ-flips-typingᵐ rel ds wfΣ
+      (cast-tag (wfVar α<Δ) (＇ α) ok , tag (＇ .α))
+      | seal-or-id | seal-to-tag | tag-or-id | dma-seal-tag | ()
+  dualʷ-flips-typingᵐ {η = η} rel ds wfΣ
+      (cast-tag hG (‵ ι) ok , tag (‵ .ι)) =
+    cast-untag hG (‵ ι) refl , untag (‵ ι)
+  dualʷ-flips-typingᵐ {η = η} rel ds wfΣ
+      (cast-tag hG ★⇒★ ok , tag ★⇒★) =
+    cast-untag hG ★⇒★ refl , untag ★⇒★
+  dualʷ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
+      rel ds wfΣ
       (cast-seq g⊢ (cast-tag (wfVar α<Δ) (＇ α) ok) ,
        (gʷ ︔ (＇ .α) !))
       with μ α in μα | η α in ηα | ν α in να | rel α | ok
@@ -1230,8 +1527,8 @@ mutual
     cast-seq
       (cast-untag (wfVar α<Δ) (＇ α)
         (tagModeAllowed-var-tag {ν = ν} {α = α} να))
-      (dualCrossWidening-flips-coercionᵐ rel ds wfΣ (g⊢ , gʷ)) ,
-    _？︔_ (＇ α) (proj₂ (dualCrossWidening η gʷ))
+      (dualStrictCrossWidening-flips-coercionᵐ rel ds wfΣ (g⊢ , gʷ)) ,
+    _？︔_ (＇ α) (proj₂ (dualStrictCrossWidening η gʷ))
   dualʷ-flips-typingᵐ rel ds wfΣ
       (cast-seq g⊢ (cast-tag (wfVar α<Δ) (＇ α) ok) ,
        (gʷ ︔ (＇ .α) !))
@@ -1240,13 +1537,12 @@ mutual
       (cast-seq g⊢ (cast-tag (wfVar α<Δ) (＇ α) ok) ,
        (gʷ ︔ (＇ .α) !))
       | tag-or-id | tag-to-seal | seal-or-id | dma-tag-seal | refl
-      rewrite widening-cross-var-target-source (g⊢ , gʷ) =
-    cast-seq
-      (cast-id wf★ refl)
-      (cast-seal {μ = ν} wf★
-        (CoercionProof.DualStoreAt.tag★∈ ds α<Δ ηα)
-        (sealModeAllowed-var-seal {ν = ν} {α = α} να)) ,
-    id★ ︔seal _
+      rewrite widening-cross-var-target-source
+                (g⊢ , strictCrossʷ→cross gʷ) =
+    cast-seal {μ = ν} wf★
+      (CoercionProof.DualStoreAt.tag★∈ ds α<Δ ηα)
+      (sealModeAllowed-var-seal {ν = ν} {α = α} να) ,
+    sealⁿ ★ α
   dualʷ-flips-typingᵐ rel ds wfΣ
       (cast-seq g⊢ (cast-tag (wfVar α<Δ) (＇ α) ok) ,
        (gʷ ︔ (＇ .α) !))
@@ -1256,15 +1552,42 @@ mutual
        (gʷ ︔ (‵ .ι) !)) =
     cast-seq
       (cast-untag hG (‵ ι) refl)
-      (dualCrossWidening-flips-coercionᵐ rel ds wfΣ (g⊢ , gʷ)) ,
-    _？︔_ (‵ ι) (proj₂ (dualCrossWidening η gʷ))
+      (dualStrictCrossWidening-flips-coercionᵐ rel ds wfΣ (g⊢ , gʷ)) ,
+    _？︔_ (‵ ι) (proj₂ (dualStrictCrossWidening η gʷ))
   dualʷ-flips-typingᵐ {η = η} rel ds wfΣ
       (cast-seq g⊢ (cast-tag hG ★⇒★ ok) ,
        ((gʷ ︔ ★⇒★ !))) =
     cast-seq
       (cast-untag hG ★⇒★ refl)
-      (dualCrossWidening-flips-coercionᵐ rel ds wfΣ (g⊢ , gʷ)) ,
-    _？︔_ ★⇒★ (proj₂ (dualCrossWidening η gʷ))
+      (dualStrictCrossWidening-flips-coercionᵐ rel ds wfΣ (g⊢ , gʷ)) ,
+    _？︔_ ★⇒★ (proj₂ (dualStrictCrossWidening η gʷ))
+  dualʷ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
+      rel ds wfΣ
+      (cast-unseal {α = α} hA αA∈Σ ok , unsealʷ .α A)
+      with μ α in μα | η α in ηα | ν α in να | rel α | ok
+  dualʷ-flips-typingᵐ rel ds wfΣ
+      (cast-unseal hA αA∈Σ ok , unsealʷ α A)
+      | id-only | normal | id-only | dma-id | ()
+  dualʷ-flips-typingᵐ rel ds wfΣ
+      (cast-unseal hA αA∈Σ ok , unsealʷ α A)
+      | tag-or-id | normal | tag-or-id | dma-tag | ()
+  dualʷ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-unseal {α = α} hA αA∈Σ ok , unsealʷ .α A)
+      | seal-or-id | normal | seal-or-id | dma-seal | refl =
+    cast-seal {μ = ν} hA
+      (CoercionProof.DualStoreAt.seal∈ ds μα ηα να αA∈Σ)
+      (sealModeAllowed-var-seal {ν = ν} {α = α} να) ,
+    sealⁿ A α
+  dualʷ-flips-typingᵐ rel ds wfΣ
+      (cast-unseal hA αA∈Σ ok , unsealʷ α A)
+      | tag-or-id | tag-to-seal | seal-or-id | dma-tag-seal | ()
+  dualʷ-flips-typingᵐ {ν = ν} rel ds wfΣ
+      (cast-unseal {α = α} hA αA∈Σ ok , unsealʷ .α A)
+      | seal-or-id | seal-to-tag | tag-or-id | dma-seal-tag | refl
+      rewrite CoercionProof.DualStoreAt.seal★ ds ηα αA∈Σ =
+    cast-untag (wfVar (bound wfΣ αA∈Σ)) (＇ α)
+      (tagModeAllowed-var-tag {ν = ν} {α = α} να) ,
+    untag (＇ α)
   dualʷ-flips-typingᵐ {μ = μ} {η = η} {ν = ν}
       rel ds wfΣ
       (cast-seq (cast-unseal {α = α} hA αA∈Σ ok) s⊢ ,
@@ -1283,11 +1606,11 @@ mutual
        unseal︔_ _ sʷ)
       | seal-or-id | normal | seal-or-id | dma-seal | refl =
     cast-seq
-      (proj₁ (dualʷ-flips-typingᵐ rel ds wfΣ (s⊢ , sʷ)))
+      (proj₁ (dualStrictʷ-flips-typingᵐ rel ds wfΣ (s⊢ , sʷ)))
       (cast-seal {μ = ν} hA
         (CoercionProof.DualStoreAt.seal∈ ds μα ηα να αA∈Σ)
         (sealModeAllowed-var-seal {ν = ν} {α = α} να)) ,
-    proj₂ (dualʷ η sʷ) ︔seal α
+    proj₂ (dualStrictʷ η sʷ) ︔seal α
   dualʷ-flips-typingᵐ rel ds wfΣ
       (cast-seq (cast-unseal hA αA∈Σ ok) s⊢ ,
        unseal︔_ _ sʷ)
@@ -1297,12 +1620,30 @@ mutual
        unseal︔_ _ sʷ)
       | seal-or-id | seal-to-tag | tag-or-id | dma-seal-tag | refl
       rewrite CoercionProof.DualStoreAt.seal★ ds ηα αA∈Σ
-            | widening-source-star-target-star (s⊢ , sʷ) =
-    cast-seq
-      (cast-untag (wfVar (bound wfΣ αA∈Σ)) (＇ α)
-        (tagModeAllowed-var-tag {ν = ν} {α = α} να))
-      (cast-id (wfVar (bound wfΣ αA∈Σ)) (idModeAllowed-any (ν α))) ,
-    _？︔_ (＇ α) (id-＇ α)
+            | widening-source-star-target-star
+                (s⊢ , strictʷ→widen sʷ) =
+    cast-untag (wfVar (bound wfΣ αA∈Σ)) (＇ α)
+      (tagModeAllowed-var-tag {ν = ν} {α = α} να) ,
+    untag (＇ α)
+
+  dualStrictʷ-flips-typingᵐ :
+    ∀ {μ η ν Δ Σ Π c A B} →
+    DualActionOk μ η ν →
+    DualStoreAt Δ μ η ν Σ Π →
+    StoreWfAt Δ Σ →
+    (p : (μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B) × StrictWidening c) →
+    (ν ∣ Δ ∣ Π ⊢ proj₁ (dualStrictʷ η (proj₂ p)) ∶ B =⇒ A) ×
+    StrictNarrowing (proj₁ (dualStrictʷ η (proj₂ p)))
+  dualStrictʷ-flips-typingᵐ
+      {η = η} {ν = ν} {Δ = Δ} {Π = Π} {A = A} {B = B}
+      rel ds wfΣ (c⊢ , cʷ) =
+    subst
+      (λ d → ν ∣ Δ ∣ Π ⊢ d ∶ B =⇒ A)
+      (dualStrictʷ-raw η cʷ)
+      (proj₁
+        (dualʷ-flips-typingᵐ
+          rel ds wfΣ (c⊢ , strictʷ→widen cʷ))) ,
+    proj₂ (dualStrictʷ η cʷ)
 
 widening-cross-ground-source-all⊥ :
   ∀ {μ Δ Σ A G g} →
@@ -1407,6 +1748,9 @@ narrowing-all-to-var-tag⊥ tag-ok (() , id★)
 narrowing-all-to-var-tag⊥ tag-ok (() , gen sⁿ)
 narrowing-all-to-var-tag⊥ tag-ok (cast-seq () s⊢ , _？︔_ gG sⁿ)
 narrowing-all-to-var-tag⊥ {μ = μ} {α = α} tag-ok
+    (cast-seal {α = .α} hA α∈Σ seal-ok , sealⁿ _ _) =
+  tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
+narrowing-all-to-var-tag⊥ {μ = μ} {α = α} tag-ok
     (cast-seq s⊢ (cast-seal {α = .α} hA α∈Σ seal-ok) ,
      sⁿ ︔seal _) =
   tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
@@ -1462,6 +1806,9 @@ narrowing-var≢-to-var-tag⊥ β≢α tag-ok
 narrowing-var≢-to-var-tag⊥ β≢α tag-ok
     (cast-seq () s⊢ , _？︔_ gG sⁿ)
 narrowing-var≢-to-var-tag⊥ {μ = μ} {α = α} β≢α tag-ok
+    (cast-seal {α = .α} hA α∈Σ seal-ok , sealⁿ _ _) =
+  tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
+narrowing-var≢-to-var-tag⊥ {μ = μ} {α = α} β≢α tag-ok
     (cast-seq s⊢ (cast-seal {α = .α} hA α∈Σ seal-ok) ,
      sⁿ ︔seal _) =
   tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
@@ -1490,6 +1837,9 @@ widening-var-to-all-tag⊥ tag-ok (() , id★)
 widening-var-to-all-tag⊥ tag-ok (() , inst sʷ)
 widening-var-to-all-tag⊥ tag-ok (cast-seq s⊢ () , ((sʷ ︔ gG !)))
 widening-var-to-all-tag⊥ {μ = μ} {α = α} tag-ok
+    (cast-unseal {α = .α} hA α∈Σ seal-ok , unsealʷ _ _) =
+  tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
+widening-var-to-all-tag⊥ {μ = μ} {α = α} tag-ok
     (cast-seq (cast-unseal {α = .α} hA α∈Σ seal-ok) s⊢ ,
      unseal︔_ _ sʷ) =
   tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
@@ -1505,6 +1855,9 @@ widening-var≢-to-var-tag⊥ β≢α tag-ok
   β≢α refl
 widening-var≢-to-var-tag⊥ β≢α tag-ok
     (cast-seq s⊢ () , ((sʷ ︔ gG !)))
+widening-var≢-to-var-tag⊥ {μ = μ} {α = α} β≢α tag-ok
+    (cast-unseal {α = .α} hA α∈Σ seal-ok , unsealʷ _ _) =
+  tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
 widening-var≢-to-var-tag⊥ {μ = μ} {α = α} β≢α tag-ok
     (cast-seq (cast-unseal {α = .α} hA α∈Σ seal-ok) s⊢ ,
      unseal︔_ _ sʷ) =
@@ -1580,9 +1933,12 @@ widening-var-to-all-seal⊥ wfΣ α↦★ seal-ok (() , inst sʷ)
 widening-var-to-all-seal⊥ wfΣ α↦★ seal-ok
     (cast-seq s⊢ () , ((sʷ ︔ gG !)))
 widening-var-to-all-seal⊥ wfΣ α↦★ seal-ok
+    (cast-unseal hA α∈Σ seal-ok′ , unsealʷ _ _) =
+  star≢all (unique wfΣ α↦★ α∈Σ)
+widening-var-to-all-seal⊥ wfΣ α↦★ seal-ok
     (cast-seq (cast-unseal hA α∈Σ seal-ok′) t⊢ , unseal︔_ _ tʷ)
     rewrite sym (unique wfΣ α↦★ α∈Σ) =
-  widening-star-to-all⊥ (t⊢ , tʷ)
+  widening-star-to-all⊥ (t⊢ , strictʷ→widen tʷ)
 
 widening-var≢-to-var-seal⊥ :
   ∀ {μ Δ Σ α β c} →
@@ -1597,10 +1953,13 @@ widening-var≢-to-var-seal⊥ wfΣ α↦★ β≢α seal-ok
   β≢α refl
 widening-var≢-to-var-seal⊥ wfΣ α↦★ β≢α seal-ok
     (cast-seq s⊢ () , ((sʷ ︔ gG !)))
+widening-var≢-to-var-seal⊥ {β = β} wfΣ α↦★ β≢α seal-ok
+    (cast-unseal hA α∈Σ seal-ok′ , unsealʷ _ _) =
+  star≢var {α = β} (unique wfΣ α↦★ α∈Σ)
 widening-var≢-to-var-seal⊥ wfΣ α↦★ β≢α seal-ok
     (cast-seq (cast-unseal hA α∈Σ seal-ok′) t⊢ , unseal︔_ _ tʷ)
     rewrite sym (unique wfΣ α↦★ α∈Σ) =
-  widening-star-to-var⊥ (t⊢ , tʷ)
+  widening-star-to-var⊥ (t⊢ , strictʷ→widen tʷ)
 
 widening-var-to-skew-var-seal⊥ :
   ∀ {μ Δ Σ α β c} →
@@ -1636,11 +1995,14 @@ narrowing-all-to-var-seal⊥ wfΣ α↦★ seal-ok
 narrowing-all-to-var-seal⊥ wfΣ α↦★ seal-ok (() , id★)
 narrowing-all-to-var-seal⊥ wfΣ α↦★ seal-ok (() , gen sⁿ)
 narrowing-all-to-var-seal⊥ wfΣ α↦★ seal-ok
+    (cast-seal hA α∈Σ seal-ok′ , sealⁿ _ _) =
+  star≢all (unique wfΣ α↦★ α∈Σ)
+narrowing-all-to-var-seal⊥ wfΣ α↦★ seal-ok
     (cast-seq () s⊢ , _？︔_ gG sⁿ)
 narrowing-all-to-var-seal⊥ wfΣ α↦★ seal-ok
     (cast-seq s⊢ (cast-seal hA α∈Σ seal-ok′) , sⁿ ︔seal _)
     rewrite sym (unique wfΣ α↦★ α∈Σ) =
-  narrowing-all-to-star⊥ (s⊢ , sⁿ)
+  narrowing-all-to-star⊥ (s⊢ , strictⁿ→narrow sⁿ)
 
 narrowing-var≢-to-var-seal⊥ :
   ∀ {μ Δ Σ α β c} →
@@ -1653,12 +2015,15 @@ narrowing-var≢-to-var-seal⊥ :
 narrowing-var≢-to-var-seal⊥ wfΣ α↦★ β≢α seal-ok
     (cast-id hA id-ok , cross (id-＇ _)) =
   β≢α refl
+narrowing-var≢-to-var-seal⊥ {β = β} wfΣ α↦★ β≢α seal-ok
+    (cast-seal hA α∈Σ seal-ok′ , sealⁿ _ _) =
+  star≢var {α = β} (unique wfΣ α↦★ α∈Σ)
 narrowing-var≢-to-var-seal⊥ wfΣ α↦★ β≢α seal-ok
     (cast-seq () s⊢ , _？︔_ gG sⁿ)
 narrowing-var≢-to-var-seal⊥ wfΣ α↦★ β≢α seal-ok
     (cast-seq s⊢ (cast-seal hA α∈Σ seal-ok′) , sⁿ ︔seal _)
     rewrite sym (unique wfΣ α↦★ α∈Σ) =
-  narrowing-var-to-star⊥ (s⊢ , sⁿ)
+  narrowing-var-to-star⊥ (s⊢ , strictⁿ→narrow sⁿ)
 
 narrowing-skew-var-to-var-seal⊥ :
   ∀ {μ Δ Σ α β c} →
@@ -2055,7 +2420,7 @@ mutual
       (t⊢ , tⁿ)
   narrowing-tag-spine-overlap⊥ tag-ok (np-all p) sp fresh
       (cast-seq (cast-untag hG gG okG) t⊢ , _？︔_ gG′ tⁿ) =
-    narrowing-cross-ground-target-all⊥ gG (t⊢ , tⁿ)
+    narrowing-cross-ground-target-all⊥ gG (t⊢ , strictCrossⁿ→cross tⁿ)
   narrowing-tag-spine-overlap⊥ tag-ok (np-all p) sp fresh
       (cast-id hA ok , cross ())
   narrowing-tag-spine-overlap⊥ tag-ok (np-all p) sp fresh
@@ -2077,7 +2442,7 @@ mutual
       (t⊢ , tⁿ)
   narrowing-tag-spine-overlap⊥ tag-ok (np-gen p) sp fresh
       (cast-seq (cast-untag hG gG okG) t⊢ , _？︔_ gG′ tⁿ) =
-    narrowing-cross-ground-target-all⊥ gG (t⊢ , tⁿ)
+    narrowing-cross-ground-target-all⊥ gG (t⊢ , strictCrossⁿ→cross tⁿ)
   narrowing-tag-spine-overlap⊥ tag-ok (np-gen p) sp fresh
       (cast-id hA ok , cross ())
   narrowing-tag-spine-overlap⊥ tag-ok (np-gen p) sp fresh
@@ -2152,7 +2517,7 @@ mutual
       (t⊢ , tʷ)
   widening-tag-spine-overlap⊥ tag-ok (wp-all p) sp fresh
       (cast-seq t⊢ (cast-tag hG gG okG) , ((tʷ ︔ gG′ !))) =
-    widening-cross-ground-source-all⊥ gG (t⊢ , tʷ)
+    widening-cross-ground-source-all⊥ gG (t⊢ , strictCrossʷ→cross tʷ)
   widening-tag-spine-overlap⊥ tag-ok (wp-all p) sp fresh
       (cast-id hA ok , cross ())
   widening-tag-spine-overlap⊥ tag-ok (wp-all p) sp fresh
@@ -2173,7 +2538,7 @@ mutual
       (t⊢ , tʷ)
   widening-tag-spine-overlap⊥ tag-ok (wp-inst p) sp fresh
       (cast-seq t⊢ (cast-tag hG gG okG) , ((tʷ ︔ gG′ !))) =
-    widening-cross-ground-source-all⊥ gG (t⊢ , tʷ)
+    widening-cross-ground-source-all⊥ gG (t⊢ , strictCrossʷ→cross tʷ)
   widening-tag-spine-overlap⊥ tag-ok (wp-inst p) sp fresh
       (cast-id hA ok , cross ())
   widening-tag-spine-overlap⊥ tag-ok (wp-inst p) sp fresh
@@ -2259,7 +2624,7 @@ mutual
   narrowing-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (np-all p)
       sp fresh (cast-seq (cast-untag hG gG okG) t⊢ ,
                 _？︔_ gG′ tⁿ) =
-    narrowing-cross-ground-target-all⊥ gG (t⊢ , tⁿ)
+    narrowing-cross-ground-target-all⊥ gG (t⊢ , strictCrossⁿ→cross tⁿ)
   narrowing-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (np-all p)
       sp fresh (cast-id hA ok , cross ())
   narrowing-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (np-all p)
@@ -2289,7 +2654,7 @@ mutual
   narrowing-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (np-gen p)
       sp fresh (cast-seq (cast-untag hG gG okG) t⊢ ,
                 _？︔_ gG′ tⁿ) =
-    narrowing-cross-ground-target-all⊥ gG (t⊢ , tⁿ)
+    narrowing-cross-ground-target-all⊥ gG (t⊢ , strictCrossⁿ→cross tⁿ)
   narrowing-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (np-gen p)
       sp fresh (cast-id hA ok , cross ())
   narrowing-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (np-gen p)
@@ -2375,7 +2740,7 @@ mutual
   widening-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (wp-all p)
       sp fresh (cast-seq t⊢ (cast-tag hG gG okG) ,
                 ((tʷ ︔ gG′ !))) =
-    widening-cross-ground-source-all⊥ gG (t⊢ , tʷ)
+    widening-cross-ground-source-all⊥ gG (t⊢ , strictCrossʷ→cross tʷ)
   widening-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (wp-all p)
       sp fresh (cast-id hA ok , cross ())
   widening-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (wp-all p)
@@ -2405,7 +2770,7 @@ mutual
   widening-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (wp-inst p)
       sp fresh (cast-seq t⊢ (cast-tag hG gG okG) ,
                 ((tʷ ︔ gG′ !))) =
-    widening-cross-ground-source-all⊥ gG (t⊢ , tʷ)
+    widening-cross-ground-source-all⊥ gG (t⊢ , strictCrossʷ→cross tʷ)
   widening-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (wp-inst p)
       sp fresh (cast-id hA ok , cross ())
   widening-seal-spine-overlap⊥ wfΣ α↦★ seal-ok (wp-inst p)
@@ -2514,9 +2879,198 @@ widening-all-inst-overlap-det⊥ {B = B} wfΣ occA s⊑ t⊑
     (trans (sym noB) (widening-source-id-only refl s⊑ occA))
 
 ------------------------------------------------------------------------
+-- Canonical identity narrowings/widenings
+------------------------------------------------------------------------
+
+idModeAllowed-true : (m : Mode) → idModeAllowed m ≡ true
+idModeAllowed-true id-only = refl
+idModeAllowed-true tag-or-id = refl
+idModeAllowed-true seal-or-id = refl
+
+idTyAllowed-true : (μ : ModeEnv) → (A : Ty) → idTyAllowed μ A ≡ true
+idTyAllowed-true μ (＇ α) = idModeAllowed-true (μ α)
+idTyAllowed-true μ (‵ ι) = refl
+idTyAllowed-true μ ★ = refl
+idTyAllowed-true μ (A ⇒ B)
+    rewrite idTyAllowed-true μ A | idTyAllowed-true μ B =
+  refl
+idTyAllowed-true μ (`∀ A) = idTyAllowed-true (extᵈ μ) A
+
+mutual
+  id-narrowingᵐ :
+    ∀ {μ Δ Σ A} →
+    WfTy Δ A →
+    ∃[ c ] μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ A
+  id-narrowingᵐ {μ = μ} (wfVar {X = α} α<Δ) =
+    id (＇ α) ,
+    cast-id (wfVar α<Δ) (idTyAllowed-true μ (＇ α)) ,
+    cross (id-＇ α)
+  id-narrowingᵐ {μ = μ} (wfBase {ι = ι}) =
+    id (‵ ι) , cast-id wfBase refl , cross (id-‵ ι)
+  id-narrowingᵐ {μ = μ} wf★ =
+    id ★ , cast-id wf★ refl , id★
+  id-narrowingᵐ {μ = μ} {Σ = Σ} (wf⇒ hA hB) with
+      id-wideningᵐ {μ = μ} {Σ = Σ} hA |
+      id-narrowingᵐ {μ = μ} {Σ = Σ} hB
+  id-narrowingᵐ {μ = μ} {Σ = Σ} (wf⇒ hA hB) |
+      s , s⊑ | t , t⊒ =
+    s ↦ t , cast-fun (proj₁ s⊑) (proj₁ t⊒) ,
+    cross (proj₂ s⊑ ↦ proj₂ t⊒)
+  id-narrowingᵐ {μ = μ} {Σ = Σ} (wf∀ hA) with
+      id-narrowingᵐ {μ = extᵈ μ} {Σ = ⟰ᵗ Σ} hA
+  id-narrowingᵐ {μ = μ} {Σ = Σ} (wf∀ hA) | s , s⊒ =
+    `∀ s , cast-all (proj₁ s⊒) , cross (`∀ (proj₂ s⊒))
+
+  id-wideningᵐ :
+    ∀ {μ Δ Σ A} →
+    WfTy Δ A →
+    ∃[ c ] μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊑ A
+  id-wideningᵐ {μ = μ} (wfVar {X = α} α<Δ) =
+    id (＇ α) ,
+    cast-id (wfVar α<Δ) (idTyAllowed-true μ (＇ α)) ,
+    cross (id-＇ α)
+  id-wideningᵐ {μ = μ} (wfBase {ι = ι}) =
+    id (‵ ι) , cast-id wfBase refl , cross (id-‵ ι)
+  id-wideningᵐ {μ = μ} wf★ =
+    id ★ , cast-id wf★ refl , id★
+  id-wideningᵐ {μ = μ} {Σ = Σ} (wf⇒ hA hB) with
+      id-narrowingᵐ {μ = μ} {Σ = Σ} hA |
+      id-wideningᵐ {μ = μ} {Σ = Σ} hB
+  id-wideningᵐ {μ = μ} {Σ = Σ} (wf⇒ hA hB) |
+      s , s⊒ | t , t⊑ =
+    s ↦ t , cast-fun (proj₁ s⊒) (proj₁ t⊑) ,
+    cross (proj₂ s⊒ ↦ proj₂ t⊑)
+  id-wideningᵐ {μ = μ} {Σ = Σ} (wf∀ hA) with
+      id-wideningᵐ {μ = extᵈ μ} {Σ = ⟰ᵗ Σ} hA
+  id-wideningᵐ {μ = μ} {Σ = Σ} (wf∀ hA) | s , s⊑ =
+    `∀ s , cast-all (proj₁ s⊑) , cross (`∀ (proj₂ s⊑))
+
+id-cross-narrowingᵐ :
+  ∀ {μ Δ Σ G} →
+  Ground G →
+  WfTy Δ G →
+  ∃[ c ] (μ ∣ Δ ∣ Σ ⊢ c ∶ G =⇒ G) × CrossNarrowing c
+id-cross-narrowingᵐ {μ = μ} (＇ α) hG =
+  id (＇ α) , cast-id hG (idTyAllowed-true μ (＇ α)) , id-＇ α
+id-cross-narrowingᵐ (‵ ι) hG =
+  id (‵ ι) , cast-id hG refl , id-‵ ι
+id-cross-narrowingᵐ ★⇒★ hG =
+  id ★ ↦ id ★ ,
+  cast-fun (cast-id wf★ refl) (cast-id wf★ refl) ,
+  id★ ↦ id★
+
+id-cross-wideningᵐ :
+  ∀ {μ Δ Σ G} →
+  Ground G →
+  WfTy Δ G →
+  ∃[ c ] (μ ∣ Δ ∣ Σ ⊢ c ∶ G =⇒ G) × CrossWidening c
+id-cross-wideningᵐ {μ = μ} (＇ α) hG =
+  id (＇ α) , cast-id hG (idTyAllowed-true μ (＇ α)) , id-＇ α
+id-cross-wideningᵐ (‵ ι) hG =
+  id (‵ ι) , cast-id hG refl , id-‵ ι
+id-cross-wideningᵐ ★⇒★ hG =
+  id ★ ↦ id ★ ,
+  cast-fun (cast-id wf★ refl) (cast-id wf★ refl) ,
+  id★ ↦ id★
+
+strictⁿ-id⊥ : ∀ {A} → StrictNarrowing (id A) → ⊥
+strictⁿ-id⊥ (strict-crossⁿ ())
+
+strictʷ-id⊥ : ∀ {A} → StrictWidening (id A) → ⊥
+strictʷ-id⊥ (strict-crossʷ ())
+
+strictCrossⁿ-id⊥ : ∀ {A} → StrictCrossNarrowing (id A) → ⊥
+strictCrossⁿ-id⊥ ()
+
+strictCrossʷ-id⊥ : ∀ {A} → StrictCrossWidening (id A) → ⊥
+strictCrossʷ-id⊥ ()
+
+mutual
+  strictⁿ≢idⁿ :
+    ∀ {μ Δ Σ A c} →
+    (hA : WfTy Δ A) →
+    StrictNarrowing c →
+    c ≢ proj₁ (id-narrowingᵐ {μ = μ} {Σ = Σ} hA)
+  strictⁿ≢idⁿ (wfVar α<Δ) sⁿ refl = strictⁿ-id⊥ sⁿ
+  strictⁿ≢idⁿ wfBase sⁿ refl = strictⁿ-id⊥ sⁿ
+  strictⁿ≢idⁿ wf★ sⁿ refl = strictⁿ-id⊥ sⁿ
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-crossⁿ (cn-funˡ sʷ tⁿ)) refl =
+    strictʷ≢idʷ hA sʷ refl
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-crossⁿ (cn-funʳ sʷ tⁿ)) refl =
+    strictⁿ≢idⁿ hB tⁿ refl
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-gen sⁿ) ()
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-untag gG) ()
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-untag-seq gG gⁿ) ()
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-seal A α) ()
+  strictⁿ≢idⁿ (wf⇒ hA hB) (strict-seal-seq sⁿ α) ()
+  strictⁿ≢idⁿ (wf∀ hA) (strict-crossⁿ (cn-all sⁿ)) refl =
+    strictⁿ≢idⁿ hA sⁿ refl
+  strictⁿ≢idⁿ (wf∀ hA) (strict-gen sⁿ) ()
+  strictⁿ≢idⁿ (wf∀ hA) (strict-untag gG) ()
+  strictⁿ≢idⁿ (wf∀ hA) (strict-untag-seq gG gⁿ) ()
+  strictⁿ≢idⁿ (wf∀ hA) (strict-seal A α) ()
+  strictⁿ≢idⁿ (wf∀ hA) (strict-seal-seq sⁿ α) ()
+
+  strictʷ≢idʷ :
+    ∀ {μ Δ Σ A c} →
+    (hA : WfTy Δ A) →
+    StrictWidening c →
+    c ≢ proj₁ (id-wideningᵐ {μ = μ} {Σ = Σ} hA)
+  strictʷ≢idʷ (wfVar α<Δ) sʷ refl = strictʷ-id⊥ sʷ
+  strictʷ≢idʷ wfBase sʷ refl = strictʷ-id⊥ sʷ
+  strictʷ≢idʷ wf★ sʷ refl = strictʷ-id⊥ sʷ
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-crossʷ (cw-funˡ sⁿ tʷ)) refl =
+    strictⁿ≢idⁿ hA sⁿ refl
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-crossʷ (cw-funʳ sⁿ tʷ)) refl =
+    strictʷ≢idʷ hB tʷ refl
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-inst sʷ) ()
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-tag gG) ()
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-tag-seq gʷ gG) ()
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-unseal α A) ()
+  strictʷ≢idʷ (wf⇒ hA hB) (strict-unseal-seq α sʷ) ()
+  strictʷ≢idʷ (wf∀ hA) (strict-crossʷ (cw-all sʷ)) refl =
+    strictʷ≢idʷ hA sʷ refl
+  strictʷ≢idʷ (wf∀ hA) (strict-inst sʷ) ()
+  strictʷ≢idʷ (wf∀ hA) (strict-tag gG) ()
+  strictʷ≢idʷ (wf∀ hA) (strict-tag-seq gʷ gG) ()
+  strictʷ≢idʷ (wf∀ hA) (strict-unseal α A) ()
+  strictʷ≢idʷ (wf∀ hA) (strict-unseal-seq α sʷ) ()
+
+strictCrossⁿ≢idGroundⁿ :
+  ∀ {μ Δ Σ G c} →
+  (gG : Ground G) →
+  (hG : WfTy Δ G) →
+  StrictCrossNarrowing c →
+  c ≢ proj₁ (id-cross-narrowingᵐ {μ = μ} {Σ = Σ} gG hG)
+strictCrossⁿ≢idGroundⁿ (＇ α) hG cⁿ refl = strictCrossⁿ-id⊥ cⁿ
+strictCrossⁿ≢idGroundⁿ (‵ ι) hG cⁿ refl = strictCrossⁿ-id⊥ cⁿ
+strictCrossⁿ≢idGroundⁿ {μ = μ} {Δ = Δ} {Σ = Σ} ★⇒★ hG
+    (cn-funˡ sʷ tⁿ) refl =
+  strictʷ≢idʷ {μ = μ} {Δ = Δ} {Σ = Σ} {A = ★} wf★ sʷ refl
+strictCrossⁿ≢idGroundⁿ {μ = μ} {Δ = Δ} {Σ = Σ} ★⇒★ hG
+    (cn-funʳ sʷ tⁿ) refl =
+  strictⁿ≢idⁿ {μ = μ} {Δ = Δ} {Σ = Σ} {A = ★} wf★ tⁿ refl
+
+strictCrossʷ≢idGroundʷ :
+  ∀ {μ Δ Σ G c} →
+  (gG : Ground G) →
+  (hG : WfTy Δ G) →
+  StrictCrossWidening c →
+  c ≢ proj₁ (id-cross-wideningᵐ {μ = μ} {Σ = Σ} gG hG)
+strictCrossʷ≢idGroundʷ (＇ α) hG cʷ refl = strictCrossʷ-id⊥ cʷ
+strictCrossʷ≢idGroundʷ (‵ ι) hG cʷ refl = strictCrossʷ-id⊥ cʷ
+strictCrossʷ≢idGroundʷ {μ = μ} {Δ = Δ} {Σ = Σ} ★⇒★ hG
+    (cw-funˡ sⁿ tʷ) refl =
+  strictⁿ≢idⁿ {μ = μ} {Δ = Δ} {Σ = Σ} {A = ★} wf★ sⁿ refl
+strictCrossʷ≢idGroundʷ {μ = μ} {Δ = Δ} {Σ = Σ} ★⇒★ hG
+    (cw-funʳ sⁿ tʷ) refl =
+  strictʷ≢idʷ {μ = μ} {Δ = Δ} {Σ = Σ} {A = ★} wf★ tʷ refl
+
+------------------------------------------------------------------------
 -- Mode-indexed narrowing/widening determinacy under StoreDetWf
 ------------------------------------------------------------------------
 
+{-# TERMINATING #-}
 mutual
   narrowing-determinedᵐ-det :
     ∀ {μ Δ Σ A B s t} →
@@ -2568,14 +3122,125 @@ mutual
       (cast-id hA ok , id★)
       (cast-id hA′ ok′ , id★) =
     refl
+  narrowing-determinedᵐ-det {μ = μ} wfΣ
+      (cast-id {A = ＇ α} hA id-ok , cross (id-＇ _))
+      (cast-seal hB α∈Σ seal-ok , sealⁿ .(＇ α) .α) =
+    ⊥-elim
+      (narrowing-var-to-older⊥ {μ = μ} {c = seal (＇ α) α}
+        {α = α} {B = ＇ α}
+        wfΣ (wfOlder wfΣ α∈Σ)
+        (cast-seal {μ = μ} hB α∈Σ seal-ok , sealⁿ (＇ α) α))
+  narrowing-determinedᵐ-det {μ = μ} wfΣ
+      (cast-seal hA α∈Σ seal-ok , sealⁿ .(＇ α) .α)
+      (cast-id {A = ＇ α} hB id-ok , cross (id-＇ _)) =
+    ⊥-elim
+      (narrowing-var-to-older⊥ {μ = μ} {c = seal (＇ α) α}
+        {α = α} {B = ＇ α}
+        wfΣ (wfOlder wfΣ α∈Σ)
+        (cast-seal {μ = μ} hA α∈Σ seal-ok , sealⁿ (＇ α) α))
+  narrowing-determinedᵐ-det wfΣ
+      (cast-seal hA α∈Σ seal-ok , sealⁿ _ _)
+      (cast-seal hB β∈Σ β-ok , sealⁿ _ _)
+      rewrite unique wfΣ α∈Σ β∈Σ =
+    refl
+  narrowing-determinedᵐ-det wfΣ
+      (cast-seal hA α∈Σ seal-ok , sealⁿ _ _)
+      (cast-seq (cast-untag hG gG okG) t⊢ , _？︔_ gG′ tᶜ) =
+    ⊥-elim
+      (narrowing-cross-ground-target-seal-var⊥
+        wfΣ gG okG α∈Σ seal-ok
+        (t⊢ , strictCrossⁿ→cross tᶜ))
+  narrowing-determinedᵐ-det wfΣ
+      (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
+      (cast-seal hA α∈Σ seal-ok , sealⁿ _ _) =
+    ⊥-elim
+      (narrowing-cross-ground-target-seal-var⊥
+        wfΣ gG okG α∈Σ seal-ok
+        (s⊢ , strictCrossⁿ→cross sᶜ))
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seal hA α∈Σ seal-ok , sealⁿ _ _)
+      (cast-seq t⊢ (cast-seal hB β∈Σ β-ok) , tⁿ ︔seal _)
+      rewrite unique wfΣ α∈Σ β∈Σ
+      with narrowing-determinedᵐ-det
+             wfΣ
+             (t⊢ , strictⁿ→narrow tⁿ)
+             (proj₂ (id-narrowingᵐ {μ = μ} {Σ = Σ} hA))
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seal hA α∈Σ seal-ok , sealⁿ _ _)
+      (cast-seq t⊢ (cast-seal hB β∈Σ β-ok) , tⁿ ︔seal _)
+      | eq =
+    ⊥-elim (strictⁿ≢idⁿ {μ = μ} {Σ = Σ} hA tⁿ eq)
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq s⊢ (cast-seal hA α∈Σ α-ok) , sⁿ ︔seal _)
+      (cast-seal hB β∈Σ β-ok , sealⁿ _ _)
+      rewrite unique wfΣ α∈Σ β∈Σ
+      with narrowing-determinedᵐ-det
+             wfΣ
+             (s⊢ , strictⁿ→narrow sⁿ)
+             (proj₂ (id-narrowingᵐ {μ = μ} {Σ = Σ} hB))
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq s⊢ (cast-seal hA α∈Σ α-ok) , sⁿ ︔seal _)
+      (cast-seal hB β∈Σ β-ok , sealⁿ _ _)
+      | eq =
+    ⊥-elim (strictⁿ≢idⁿ {μ = μ} {Σ = Σ} hB sⁿ eq)
+  narrowing-determinedᵐ-det wfΣ
+      (cast-seal {α = α} hA α∈Σ seal-ok , sealⁿ .★ .α)
+      (cast-untag hG (＇ .α) tag-ok , untag (＇ .α)) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
+  narrowing-determinedᵐ-det wfΣ
+      (cast-untag hG (＇ α) tag-ok , untag (＇ .α))
+      (cast-seal {α = .α} hA α∈Σ seal-ok , sealⁿ .★ .α) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
+  narrowing-determinedᵐ-det wfΣ
+      (cast-untag hG gG okG , untag gG′)
+      (cast-untag hH gH okH , untag gH′) =
+    refl
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-untag hG gG okG , untag gG′)
+      (cast-seq (cast-untag hH gH okH) t⊢ , _？︔_ gH′ tᶜ)
+      with narrowing-cross-ground-source-determinedᵐ-det
+             wfΣ gH gG
+             (t⊢ , strictCrossⁿ→cross tᶜ)
+             (proj₂ (id-cross-narrowingᵐ {μ = μ} {Σ = Σ} gG hG))
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-untag hG gG okG , untag gG′)
+      (cast-seq (cast-untag hH gH okH) t⊢ , _？︔_ gH′ tᶜ)
+      | refl , eq =
+    ⊥-elim
+      (strictCrossⁿ≢idGroundⁿ {μ = μ} {Σ = Σ} gG hG tᶜ eq)
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
+      (cast-untag hH gH okH , untag gH′)
+      with narrowing-cross-ground-source-determinedᵐ-det
+             wfΣ gG gH
+             (s⊢ , strictCrossⁿ→cross sᶜ)
+             (proj₂ (id-cross-narrowingᵐ {μ = μ} {Σ = Σ} gH hH))
+  narrowing-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
+      (cast-untag hH gH okH , untag gH′)
+      | refl , eq =
+    ⊥-elim
+      (strictCrossⁿ≢idGroundⁿ {μ = μ} {Σ = Σ} gH hH sᶜ eq)
+  narrowing-determinedᵐ-det wfΣ
+      (cast-untag hG (＇ α) tag-ok , untag (＇ .α))
+      (cast-seq s⊢ (cast-seal hA α∈Σ seal-ok) , sⁿ ︔seal _) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
+  narrowing-determinedᵐ-det wfΣ
+      (cast-seq s⊢ (cast-seal hA α∈Σ seal-ok) , sⁿ ︔seal _)
+      (cast-untag hG (＇ α) tag-ok , untag (＇ .α)) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
   narrowing-determinedᵐ-det wfΣ
       (cast-id {A = ＇ α} hA id-ok , cross (id-＇ _))
       (cast-seq t⊢ (cast-seal hB α∈Σ seal-ok) , tⁿ ︔seal _) =
-    ⊥-elim (narrowing-var-to-older⊥ wfΣ (wfOlder wfΣ α∈Σ) (t⊢ , tⁿ))
+    ⊥-elim
+      (narrowing-var-to-older⊥
+        wfΣ (wfOlder wfΣ α∈Σ) (t⊢ , strictⁿ→narrow tⁿ))
   narrowing-determinedᵐ-det wfΣ
       (cast-id hA ok , id★)
       (cast-seq (cast-untag hG gG okG) t⊢ , _？︔_ gG′ tᶜ) =
-    ⊥-elim (narrowing-cross-ground-target-star⊥ gG (t⊢ , tᶜ))
+    ⊥-elim
+      (narrowing-cross-ground-target-star⊥
+        gG (t⊢ , strictCrossⁿ→cross tᶜ))
   narrowing-determinedᵐ-det wfΣ
       (cast-fun s⊢ t⊢ , cross (_↦_ sʷ tⁿ))
       (cast-fun s⊢′ t⊢′ , cross (_↦_ sʷ′ tⁿ′)) =
@@ -2610,7 +3275,9 @@ mutual
       (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
       (cast-seq (cast-untag hH gH okH) t⊢ , _？︔_ gH′ tᶜ)
       with narrowing-cross-ground-source-determinedᵐ-det
-             wfΣ gG gH (s⊢ , sᶜ) (t⊢ , tᶜ)
+             wfΣ gG gH
+             (s⊢ , strictCrossⁿ→cross sᶜ)
+             (t⊢ , strictCrossⁿ→cross tᶜ)
   narrowing-determinedᵐ-det wfΣ
       (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
       (cast-seq (cast-untag hH gH okH) t⊢ , _？︔_ gH′ tᶜ)
@@ -2619,11 +3286,15 @@ mutual
   narrowing-determinedᵐ-det wfΣ
       (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
       (cast-id hA ok , id★) =
-    ⊥-elim (narrowing-cross-ground-target-star⊥ gG (s⊢ , sᶜ))
+    ⊥-elim
+      (narrowing-cross-ground-target-star⊥
+        gG (s⊢ , strictCrossⁿ→cross sᶜ))
   narrowing-determinedᵐ-det wfΣ
       (cast-seq (cast-untag hG gG okG) s⊢ , _？︔_ gG′ sᶜ)
       (cast-gen hA occ t⊢ , gen tⁿ) =
-    ⊥-elim (narrowing-cross-ground-target-all⊥ gG (s⊢ , sᶜ))
+    ⊥-elim
+      (narrowing-cross-ground-target-all⊥
+        gG (s⊢ , strictCrossⁿ→cross sᶜ))
   narrowing-determinedᵐ-det wfΣ
       (cast-all s⊢ , cross (`∀ sⁿ))
       (cast-seq () t⊢ , _？︔_ gG′ tᶜ)
@@ -2633,7 +3304,9 @@ mutual
   narrowing-determinedᵐ-det wfΣ
       (cast-gen hA occ s⊢ , gen sⁿ)
       (cast-seq (cast-untag hG gG okG) t⊢ , _？︔_ gG′ tᶜ) =
-    ⊥-elim (narrowing-cross-ground-target-all⊥ gG (t⊢ , tᶜ))
+    ⊥-elim
+      (narrowing-cross-ground-target-all⊥
+        gG (t⊢ , strictCrossⁿ→cross tᶜ))
   narrowing-determinedᵐ-det wfΣ
       (cast-gen hA occ s⊢ , gen sⁿ)
       (cast-seq t⊢ () , tⁿ ︔seal _)
@@ -2642,24 +3315,29 @@ mutual
       (cast-seq t⊢ (cast-seal hA α∈Σ seal-ok) , tⁿ ︔seal _) =
     ⊥-elim
       (narrowing-cross-ground-target-seal-var⊥
-        wfΣ gG okG α∈Σ seal-ok (s⊢ , sᶜ))
+        wfΣ gG okG α∈Σ seal-ok
+        (s⊢ , strictCrossⁿ→cross sᶜ))
   narrowing-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-seal hA α∈Σ α-ok) , sⁿ ︔seal _)
       (cast-seq t⊢ (cast-seal hB β∈Σ β-ok) , tⁿ ︔seal _)
       rewrite unique wfΣ α∈Σ β∈Σ =
     cong₂ _︔_
-      (narrowing-determinedᵐ-det wfΣ (s⊢ , sⁿ) (t⊢ , tⁿ))
+      (narrowing-determinedᵐ-det
+        wfΣ (s⊢ , strictⁿ→narrow sⁿ) (t⊢ , strictⁿ→narrow tⁿ))
       refl
   narrowing-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-seal hA α∈Σ seal-ok) , sⁿ ︔seal _)
       (cast-id {A = ＇ α} hB id-ok , cross (id-＇ _)) =
-    ⊥-elim (narrowing-var-to-older⊥ wfΣ (wfOlder wfΣ α∈Σ) (s⊢ , sⁿ))
+    ⊥-elim
+      (narrowing-var-to-older⊥
+        wfΣ (wfOlder wfΣ α∈Σ) (s⊢ , strictⁿ→narrow sⁿ))
   narrowing-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-seal hA α∈Σ seal-ok) , sⁿ ︔seal _)
       (cast-seq (cast-untag hG gG okG) t⊢ , _？︔_ gG′ tᶜ) =
     ⊥-elim
       (narrowing-cross-ground-target-seal-var⊥
-        wfΣ gG okG α∈Σ seal-ok (t⊢ , tᶜ))
+        wfΣ gG okG α∈Σ seal-ok
+        (t⊢ , strictCrossⁿ→cross tᶜ))
 
   narrowing-cross-determinedᵐ-det :
     ∀ {μ Δ Σ A B s t} →
@@ -2767,14 +3445,125 @@ mutual
       (cast-id hA ok , id★)
       (cast-id hA′ ok′ , id★) =
     refl
+  widening-determinedᵐ-det {μ = μ} wfΣ
+      (cast-id {A = ＇ α} hA id-ok , cross (id-＇ _))
+      (cast-unseal hB α∈Σ seal-ok , unsealʷ .α .(＇ α)) =
+    ⊥-elim
+      (widening-older-to-var⊥ {μ = μ} {c = id (＇ α)}
+        {α = α} {A = ＇ α}
+        wfΣ (wfOlder wfΣ α∈Σ)
+        (cast-id {μ = μ} hA id-ok , cross (id-＇ _)))
+  widening-determinedᵐ-det {μ = μ} wfΣ
+      (cast-unseal hA α∈Σ seal-ok , unsealʷ .α .(＇ α))
+      (cast-id {A = ＇ α} hB id-ok , cross (id-＇ _)) =
+    ⊥-elim
+      (widening-older-to-var⊥ {μ = μ} {c = id (＇ α)}
+        {α = α} {A = ＇ α}
+        wfΣ (wfOlder wfΣ α∈Σ)
+        (cast-id {μ = μ} hB id-ok , cross (id-＇ _)))
+  widening-determinedᵐ-det wfΣ
+      (cast-unseal hA α∈Σ seal-ok , unsealʷ _ _)
+      (cast-unseal hB β∈Σ β-ok , unsealʷ _ _)
+      rewrite unique wfΣ α∈Σ β∈Σ =
+    refl
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-unseal hA α∈Σ seal-ok , unsealʷ _ _)
+      (cast-seq (cast-unseal hB β∈Σ β-ok) t⊢ , unseal︔_ _ tʷ)
+      rewrite unique wfΣ α∈Σ β∈Σ
+      with widening-determinedᵐ-det
+             wfΣ
+             (t⊢ , strictʷ→widen tʷ)
+             (proj₂ (id-wideningᵐ {μ = μ} {Σ = Σ} hA))
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-unseal hA α∈Σ seal-ok , unsealʷ _ _)
+      (cast-seq (cast-unseal hB β∈Σ β-ok) t⊢ , unseal︔_ _ tʷ)
+      | eq =
+    ⊥-elim (strictʷ≢idʷ {μ = μ} {Σ = Σ} hA tʷ eq)
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq (cast-unseal hA α∈Σ α-ok) s⊢ , unseal︔_ _ sʷ)
+      (cast-unseal hB β∈Σ β-ok , unsealʷ _ _)
+      rewrite unique wfΣ α∈Σ β∈Σ
+      with widening-determinedᵐ-det
+             wfΣ
+             (s⊢ , strictʷ→widen sʷ)
+             (proj₂ (id-wideningᵐ {μ = μ} {Σ = Σ} hB))
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq (cast-unseal hA α∈Σ α-ok) s⊢ , unseal︔_ _ sʷ)
+      (cast-unseal hB β∈Σ β-ok , unsealʷ _ _)
+      | eq =
+    ⊥-elim (strictʷ≢idʷ {μ = μ} {Σ = Σ} hB sʷ eq)
+  widening-determinedᵐ-det wfΣ
+      (cast-unseal hA α∈Σ seal-ok , unsealʷ _ _)
+      (cast-seq t⊢ (cast-tag hG gG okG) , ((tᶜ ︔ gG′ !))) =
+    ⊥-elim
+      (widening-cross-ground-source-seal-var⊥
+        wfΣ gG okG α∈Σ seal-ok
+        (t⊢ , strictCrossʷ→cross tᶜ))
+  widening-determinedᵐ-det wfΣ
+      (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
+      (cast-unseal hA α∈Σ seal-ok , unsealʷ _ _) =
+    ⊥-elim
+      (widening-cross-ground-source-seal-var⊥
+        wfΣ gG okG α∈Σ seal-ok
+        (s⊢ , strictCrossʷ→cross sᶜ))
+  widening-determinedᵐ-det wfΣ
+      (cast-unseal {α = α} hA α∈Σ seal-ok , unsealʷ .α .★)
+      (cast-tag hG (＇ .α) tag-ok , tag (＇ .α)) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
+  widening-determinedᵐ-det wfΣ
+      (cast-tag hG (＇ α) tag-ok , tag (＇ .α))
+      (cast-unseal {α = .α} hA α∈Σ seal-ok , unsealʷ .α .★) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
+  widening-determinedᵐ-det wfΣ
+      (cast-tag hG gG okG , tag gG′)
+      (cast-tag hH gH okH , tag gH′) =
+    refl
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-tag hG gG okG , tag gG′)
+      (cast-seq t⊢ (cast-tag hH gH okH) , ((tᶜ ︔ gH′ !)))
+      with widening-cross-ground-target-determinedᵐ-det
+             wfΣ gG gH
+             (proj₂ (id-cross-wideningᵐ {μ = μ} {Σ = Σ} gG hG))
+             (t⊢ , strictCrossʷ→cross tᶜ)
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-tag hG gG okG , tag gG′)
+      (cast-seq t⊢ (cast-tag hH gH okH) , ((tᶜ ︔ gH′ !)))
+      | refl , eq =
+    ⊥-elim
+      (strictCrossʷ≢idGroundʷ {μ = μ} {Σ = Σ} gG hG tᶜ (sym eq))
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
+      (cast-tag hH gH okH , tag gH′)
+      with widening-cross-ground-target-determinedᵐ-det
+             wfΣ gG gH
+             (s⊢ , strictCrossʷ→cross sᶜ)
+             (proj₂ (id-cross-wideningᵐ {μ = μ} {Σ = Σ} gH hH))
+  widening-determinedᵐ-det {μ = μ} {Σ = Σ} wfΣ
+      (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
+      (cast-tag hH gH okH , tag gH′)
+      | refl , eq =
+    ⊥-elim
+      (strictCrossʷ≢idGroundʷ {μ = μ} {Σ = Σ} gH hH sᶜ eq)
+  widening-determinedᵐ-det wfΣ
+      (cast-tag hG (＇ α) tag-ok , tag (＇ .α))
+      (cast-seq (cast-unseal hA α∈Σ seal-ok) s⊢ , unseal︔_ _ sʷ) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
+  widening-determinedᵐ-det wfΣ
+      (cast-seq (cast-unseal hA α∈Σ seal-ok) s⊢ , unseal︔_ _ sʷ)
+      (cast-tag hG (＇ α) tag-ok , tag (＇ .α)) =
+    ⊥-elim (tag-seal-conflict tag-ok seal-ok)
   widening-determinedᵐ-det wfΣ
       (cast-id {A = ＇ α} hA id-ok , cross (id-＇ _))
       (cast-seq (cast-unseal hB α∈Σ seal-ok) t⊢ , unseal︔_ _ tʷ) =
-    ⊥-elim (widening-older-to-var⊥ wfΣ (wfOlder wfΣ α∈Σ) (t⊢ , tʷ))
+    ⊥-elim
+      (widening-older-to-var⊥
+        wfΣ (wfOlder wfΣ α∈Σ) (t⊢ , strictʷ→widen tʷ))
   widening-determinedᵐ-det wfΣ
       (cast-id hA ok , id★)
       (cast-seq t⊢ (cast-tag hG gG okG) , ((tᶜ ︔ gG′ !))) =
-    ⊥-elim (widening-cross-ground-source-star⊥ gG (t⊢ , tᶜ))
+    ⊥-elim
+      (widening-cross-ground-source-star⊥
+        gG (t⊢ , strictCrossʷ→cross tᶜ))
   widening-determinedᵐ-det wfΣ
       (cast-fun s⊢ t⊢ , cross (_↦_ sⁿ tʷ))
       (cast-fun s⊢′ t⊢′ , cross (_↦_ sⁿ′ tʷ′)) =
@@ -2817,7 +3606,9 @@ mutual
       (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
       (cast-seq t⊢ (cast-tag hH gH okH) , ((tᶜ ︔ gH′ !)))
       with widening-cross-ground-target-determinedᵐ-det
-             wfΣ gG gH (s⊢ , sᶜ) (t⊢ , tᶜ)
+             wfΣ gG gH
+             (s⊢ , strictCrossʷ→cross sᶜ)
+             (t⊢ , strictCrossʷ→cross tᶜ)
   widening-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
       (cast-seq t⊢ (cast-tag hH gH okH) , ((tᶜ ︔ gH′ !)))
@@ -2826,37 +3617,48 @@ mutual
   widening-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
       (cast-id hA ok , id★) =
-    ⊥-elim (widening-cross-ground-source-star⊥ gG (s⊢ , sᶜ))
+    ⊥-elim
+      (widening-cross-ground-source-star⊥
+        gG (s⊢ , strictCrossʷ→cross sᶜ))
   widening-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
       (cast-seq (cast-unseal hA α∈Σ seal-ok) t⊢ , unseal︔_ _ tʷ) =
     ⊥-elim
       (widening-cross-ground-source-seal-var⊥
-        wfΣ gG okG α∈Σ seal-ok (s⊢ , sᶜ))
+        wfΣ gG okG α∈Σ seal-ok
+        (s⊢ , strictCrossʷ→cross sᶜ))
   widening-determinedᵐ-det wfΣ
       (cast-seq s⊢ (cast-tag hG gG okG) , ((sᶜ ︔ gG′ !)))
       (cast-inst hB occ t⊢ , inst tʷ) =
-    ⊥-elim (widening-cross-ground-source-all⊥ gG (s⊢ , sᶜ))
+    ⊥-elim
+      (widening-cross-ground-source-all⊥
+        gG (s⊢ , strictCrossʷ→cross sᶜ))
   widening-determinedᵐ-det wfΣ
       (cast-seq (cast-unseal hA α∈Σ α-ok) s⊢ , unseal︔_ _ sʷ)
       (cast-seq (cast-unseal hB β∈Σ β-ok) t⊢ , unseal︔_ _ tʷ)
       rewrite unique wfΣ α∈Σ β∈Σ =
     cong₂ _︔_ refl
-      (widening-determinedᵐ-det wfΣ (s⊢ , sʷ) (t⊢ , tʷ))
+      (widening-determinedᵐ-det
+        wfΣ (s⊢ , strictʷ→widen sʷ) (t⊢ , strictʷ→widen tʷ))
   widening-determinedᵐ-det wfΣ
       (cast-seq (cast-unseal hA α∈Σ seal-ok) s⊢ , unseal︔_ _ sʷ)
       (cast-id {A = ＇ α} hB id-ok , cross (id-＇ _)) =
-    ⊥-elim (widening-older-to-var⊥ wfΣ (wfOlder wfΣ α∈Σ) (s⊢ , sʷ))
+    ⊥-elim
+      (widening-older-to-var⊥
+        wfΣ (wfOlder wfΣ α∈Σ) (s⊢ , strictʷ→widen sʷ))
   widening-determinedᵐ-det wfΣ
       (cast-seq (cast-unseal hA α∈Σ seal-ok) s⊢ , unseal︔_ _ sʷ)
       (cast-seq t⊢ (cast-tag hG gG okG) , ((tᶜ ︔ gG′ !))) =
     ⊥-elim
       (widening-cross-ground-source-seal-var⊥
-        wfΣ gG okG α∈Σ seal-ok (t⊢ , tᶜ))
+        wfΣ gG okG α∈Σ seal-ok
+        (t⊢ , strictCrossʷ→cross tᶜ))
   widening-determinedᵐ-det wfΣ
       (cast-inst hB occ s⊢ , inst sʷ)
       (cast-seq t⊢ (cast-tag hG gG okG) , ((tᶜ ︔ gG′ !))) =
-    ⊥-elim (widening-cross-ground-source-all⊥ gG (t⊢ , tᶜ))
+    ⊥-elim
+      (widening-cross-ground-source-all⊥
+        gG (t⊢ , strictCrossʷ→cross tᶜ))
   widening-determinedᵐ-det wfΣ
       (cast-inst hB occ s⊢ , inst sʷ)
       (cast-seq () t⊢ , unseal︔_ _ tʷ)


### PR DESCRIPTION
## Summary

- define positive strict GTSF narrowing and widening grammars so direct `?`, `!`, `seal`, and `unseal` coercions appear without redundant identity wrappers
- update narrowing/widening composition and determinacy support for the strict forms
- add `NWTermReduction` showing reduction preserves the invariant that term coercions are narrowings or widenings
- refresh GTSF narrowing examples and seal inversion support for the new direct forms

## Motivation

The previous grammar admitted forms such as `(N ?; id N)` where the identity component was only administrative. The revised definitions make the direct coercions first-class while keeping determinacy and the reduction preservation property available for terms whose coercions are all narrowings or widenings.

## Validation

- `cd GTSF && agda All.agda`