### PR TITLE
[codex] Refute right seal inversion

### DIFF
--- a/GTSF/cambridge25.lagda.md
+++ b/GTSF/cambridge25.lagda.md
@@ -3293,6 +3293,50 @@ Proof by induction on the derivation.
     Or r = α?, in which case α:=A and q : ★ ⊒ A exists.
     (Because A is typed under σ, it has no X's.)
 
+    Erratum.  This last case analysis is incomplete.  It assumes a
+    cancellation/decomposition property for
+
+        s ⨾ r ≈ q₀ ⨾ α♯
+
+    that fails when the left cast itself is the seal α♯.
+
+    Counterexample.  Let ι = ℕ, let 0 : ι, and let
+
+        σ = α:=id_ι.
+
+    Then the following derivation is valid:
+
+        σ ⊢ 0 ⊒ 0 : id_ι
+        ------------------------------ ⊒-    id_ι ⨾ α♯ ≈ α♯
+        σ ⊢ 0 ⊒ 0⟨α♯⟩ : α♯
+        ------------------------------ -⊒    α♯ ⨾ id_α ≈ α♯
+        σ ⊢ 0⟨α♯⟩ ⊒ 0⟨α♯⟩ : id_α
+
+    Thus Right Seal Inversion 1 would have to produce some q such that
+
+        σ ⊢ 0⟨α♯⟩ ⊒ 0 : q
+
+    and, in the stated strengthened form,
+
+        q ⨾ α♯ ≈ id_α.
+
+    No such q exists.  To derive the stripped judgment, the last rule would
+    have to introduce the visible left seal.
+
+    In the +⊒ case, matching 0⟨s̅⟩ with 0⟨α♯⟩ forces s̅ = α♯, hence
+    s = α♭.  But s must be a narrowing, and α♭ is a widening.
+
+    In the -⊒ case, the premise relates bare constants, so its index is
+    id_ι.  The side condition therefore requires
+
+        α♯ ⨾ q ≈ id_ι,
+
+    so q would have to be a narrowing q : α ⊒ ι.  The only coercion that
+    goes from α back to ι is α♭, which is again a widening, not a narrowing.
+
+    The missing case in the proof is r = id_α with s = α♯.  It is neither
+    r = q′ ⨾ α♯ for any narrowing q′, nor r = α?.
+
 
 Right Seal Inversion 2.
 

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -45,10 +45,10 @@ postulate
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ id ★
 
   -- Refuted by `proof.RightSealInversionCounterexample`.
-  right-seal-inversion₁ :
-    ∀ {Δ σ γ M V r A α} →
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
-    ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q
+  -- right-seal-inversion₁ :
+  --   ∀ {Δ σ γ M V r A α} →
+  --   Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  --   ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q
 
   right-seal-inversion₂ :
     ∀ {Δ σ γ M V q A α} →
@@ -361,12 +361,7 @@ dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
 dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
     | r , M⊒Vseal
-    with right-seal-inversion₁ M⊒Vseal
-dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (seal-unseal vV))
-    | r , M⊒Vseal
-    | q , M⊒V =
-  {!!}
+  = {!!}
 dynamicGradualGuarantee (⊒cast+ qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
 dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
@@ -412,12 +407,7 @@ dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
 dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
     | r , M⊒Vseal
-    with right-seal-inversion₁ M⊒Vseal
-dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (seal-unseal vV))
-    | r , M⊒Vseal
-    | q , M⊒V =
-  {!!}
+  = {!!}
 dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
 

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -44,6 +44,7 @@ postulate
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ G ？ ⟩ ∶ r →
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ id ★
 
+  -- Refuted by `proof.RightSealInversionCounterexample`.
   right-seal-inversion₁ :
     ∀ {Δ σ γ M V r A α} →
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →

--- a/GTSF/proof/RightSealInversionCounterexample.agda
+++ b/GTSF/proof/RightSealInversionCounterexample.agda
@@ -1,0 +1,215 @@
+module proof.RightSealInversionCounterexample where
+
+-- File Charter:
+--   * Counterexample for `right-seal-inversion₁`.
+--   * The premise relates the same sealed numeric constant on both sides via
+--     a right seal followed by a left cast.
+--   * The contradiction is that stripping the right seal requires a relation
+--     from the sealed source constant to the bare numeric constant.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here)
+open import Data.Nat using (zero; z<s)
+open import Data.Product using (_,_; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; sym; trans; subst)
+
+open import Types
+open import Coercions
+open import Primitives
+open import NuTerms
+open import NarrowWiden
+open import NarrowWidenComposition
+open import TermNarrowing
+open import proof.NarrowWidenProperties
+  using (StoreDetWf; narrowing-var-to-older⊥)
+
+private
+  NatTy : Ty
+  NatTy = ‵ `ℕ
+
+  alpha0 : TyVar
+  alpha0 = 0
+
+  k0 : Const
+  k0 = κℕ 0
+
+  Store0 : Store
+  Store0 = (alpha0 , NatTy) ∷ []
+
+  Sigma0 : StoreNrw
+  Sigma0 = (alpha0 ꞉ id NatTy) ∷ []
+
+  seal0 : Coercion
+  seal0 = seal NatTy alpha0
+
+  idAlpha0 : Coercion
+  idAlpha0 = id (＇ alpha0)
+
+  wfStore0 : StoreDetWf 1 Store0
+  wfStore0 =
+    record
+      { at = record
+          { bound = λ { (here refl) → z<s }
+          ; wfTy = λ { (here refl) → wfBase }
+          }
+      ; wfOlder = λ { (here refl) → wfBase }
+      ; unique = λ { (here refl) (here refl) → refl }
+      }
+
+  Sigma0⊒ : 1 ⊢ Sigma0 ꞉ Store0 ⊒ˢ Store0
+  Sigma0⊒ =
+    ⊒ˢ-both wfBase wfBase
+      (id-onlyᵈ , (cast-id wfBase refl , cross (id-‵ `ℕ)))
+      ⊒ˢ-nil
+
+  endpoints0 : EndpointWf 1 Store0 NatTy (＇ alpha0)
+  endpoints0 = wfBaseˢ , wfVarˢ (here refl)
+
+  idNatᶜ : 1 ∣ Store0 ⊢ id NatTy ∶ᶜ NatTy ⊒ NatTy
+  idNatᶜ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+  idNat⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ id NatTy ∶ NatTy ⊒ NatTy
+  idNat⊒ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+  idAlphaᶜ : 1 ∣ Store0 ⊢ idAlpha0 ∶ᶜ ＇ alpha0 ⊒ ＇ alpha0
+  idAlphaᶜ = cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+  idAlpha⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ idAlpha0 ∶ ＇ alpha0 ⊒ ＇ alpha0
+  idAlpha⊒ = cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+  seal0⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ seal0 ∶ NatTy ⊒ ＇ alpha0
+  seal0⊒ = cast-seal wfBase (here refl) refl , sealⁿ NatTy alpha0
+
+  right-seal-compose :
+    1 ∣ Sigma0 ⊢ id NatTy ⨾ⁿ seal0 ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
+  right-seal-compose =
+    compose-leftⁿ wfStore0 idNat⊒ seal0⊒
+      (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+        (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
+        (seal-or-idᵈ , seal0⊒))
+
+  left-seal-compose :
+    1 ∣ Sigma0 ⊢ seal0 ≈ seal0 ⨾ⁿ idAlpha0 ∶ NatTy ⊒ ＇ alpha0
+  left-seal-compose =
+    compose-rightⁿ wfStore0 seal0⊒ idAlpha⊒
+      (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+        (seal-or-idᵈ , seal0⊒)
+        (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} seal0⊒ idAlpha⊒)))
+
+  right-sealed-constant :
+    1 ∣ Sigma0 ∣ [] ⊢ $ k0 ⊒ ($ k0) ⟨ seal0 ⟩ ∶ seal0
+  right-sealed-constant =
+    ⊒cast- idNatᶜ right-seal-compose (κ⊒κ k0)
+
+  bare-constant-index-source :
+    ∀ {A q M M′} →
+    M ≡ $ k0 →
+    M′ ≡ $ k0 →
+    1 ∣ (alpha0 ꞉= A ⊒) ∷ [] ∣ [] ⊢ M ⊒ M′ ∶ q →
+    q ≡ id NatTy
+  bare-constant-index-source refl refl (κ⊒κ (κℕ n)) = refl
+
+  bare-constant-index :
+    ∀ {q M M′} →
+    M ≡ $ k0 →
+    M′ ≡ $ k0 →
+    1 ∣ Sigma0 ∣ [] ⊢ M ⊒ M′ ∶ q →
+    q ≡ id NatTy
+  bare-constant-index eqM eqM′ (extend qᶜ pαᶜ M⊒M′) =
+    bare-constant-index-source eqM eqM′ M⊒M′
+  bare-constant-index refl refl (κ⊒κ (κℕ n)) = refl
+
+  left-cast-plus-seal⊥ :
+    ∀ {μ Δ Σ L t A B} →
+    L ⟨ - t ⟩ ≡ ($ k0) ⟨ seal0 ⟩ →
+    μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ B →
+    ⊥
+  left-cast-plus-seal⊥ {t = (＇ α) ？} () (t⊢ , untag (＇ .α))
+  left-cast-plus-seal⊥ {t = (‵ ι) ？} () (t⊢ , untag (‵ .ι))
+  left-cast-plus-seal⊥ {t = (★ ⇒ ★) ？} () (t⊢ , untag ★⇒★)
+  left-cast-plus-seal⊥ {t = unseal α A} refl (t⊢ , cross ())
+
+  idNat-target :
+    ∀ {r B} →
+    r ≡ id NatTy →
+    tgt r ≡ B →
+    B ≡ NatTy
+  idNat-target r≡idNat tgt-r =
+    trans (sym tgt-r) (cong tgt r≡idNat)
+
+  stripped-impossible-source :
+    ∀ {A q M M′} →
+    M ≡ ($ k0) ⟨ seal0 ⟩ →
+    M′ ≡ $ k0 →
+    1 ∣ (alpha0 ꞉= A ⊒) ∷ [] ∣ [] ⊢ M ⊒ M′ ∶ q →
+    ⊥
+  stripped-impossible-source eqM eqM′
+      (cast+⊒ pᶜ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) M⊒M′) =
+    left-cast-plus-seal⊥ eqM t⊒
+  stripped-impossible-source refl refl
+      (cast-⊒ pᶜ
+        (compose-rightⁿ wfΣ
+          t⊒@(cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+          p⊒
+          (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+        M⊒M′) =
+    let
+      r≡idNat = bare-constant-index-source refl refl M⊒M′
+      B≡Nat = idNat-target r≡idNat tgt-r
+      p⊒Nat = subst (λ B → _ ∣ _ ∣ _ ⊢ _ ∶ ＇ alpha0 ⊒ B) B≡Nat p⊒
+    in
+    narrowing-var-to-older⊥ wfΣ wfBase p⊒Nat
+
+  stripped-impossible-aux :
+    ∀ {q M M′} →
+    M ≡ ($ k0) ⟨ seal0 ⟩ →
+    M′ ≡ $ k0 →
+    1 ∣ Sigma0 ∣ [] ⊢ M ⊒ M′ ∶ q →
+    ⊥
+  stripped-impossible-aux eqM eqM′ (extend qᶜ pαᶜ M⊒M′) =
+    stripped-impossible-source eqM eqM′ M⊒M′
+  stripped-impossible-aux eqM eqM′
+      (cast+⊒ pᶜ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) M⊒M′) =
+    left-cast-plus-seal⊥ eqM t⊒
+  stripped-impossible-aux refl refl
+      (cast-⊒ pᶜ
+        (compose-rightⁿ wfΣ
+          t⊒@(cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+          p⊒
+          (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+        M⊒M′) =
+    let
+      r≡idNat = bare-constant-index refl refl M⊒M′
+      B≡Nat = idNat-target r≡idNat tgt-r
+      p⊒Nat = subst (λ B → _ ∣ _ ∣ _ ⊢ _ ∶ ＇ alpha0 ⊒ B) B≡Nat p⊒
+    in
+    narrowing-var-to-older⊥ wfΣ wfBase p⊒Nat
+
+counterexample-premise :
+  1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
+    ⊢ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩
+      ⊒ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩
+    ∶ id (＇ 0)
+counterexample-premise =
+  cast-⊒ idAlphaᶜ left-seal-compose right-sealed-constant
+
+stripped-impossible :
+  ∀ {q} →
+  1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
+    ⊢ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩ ⊒ $ (κℕ 0) ∶ q →
+  ⊥
+stripped-impossible M⊒M′ =
+  stripped-impossible-aux refl refl M⊒M′
+
+right-seal-inversion₁-counterexample :
+  (∀ {Δ σ γ M V r A α} →
+    Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+    ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q) →
+  ⊥
+right-seal-inversion₁-counterexample right-seal-inversion₁
+    with right-seal-inversion₁ counterexample-premise
+right-seal-inversion₁-counterexample right-seal-inversion₁
+    | q , M⊒M′ =
+  stripped-impossible M⊒M′

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -1,0 +1,164 @@
+# `right-seal-inversion₁` proof notes
+
+These notes record the local proof search for the postulate in
+`proof.DynamicGradualGuarantee`:
+
+```agda
+right-seal-inversion₁ :
+  ∀ {Δ σ γ M V r A α} →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q
+```
+
+No new postulates were added during this exploration.
+
+## Attempt 1. Direct structural inversion
+
+The first direct definition tried only the two right-cast constructors:
+
+```agda
+right-seal-inversion₁ (⊒cast+ qᶜ q⨟s≈r M⊒M′) = _ , M⊒M′
+right-seal-inversion₁ (⊒cast- qᶜ q⨟s≈r M⊒M′) = _ , M⊒M′
+```
+
+Agda rejected the `⊒cast+` split because it could not solve
+`M′ ⟨ - s ⟩ ≟ V ⟨ seal A α ⟩`.  The blocker is the defined dual
+operation `-_`, not the term shape itself.
+
+## Attempt 2. Equality-indexed outer cast
+
+The next attempt used an auxiliary with an arbitrary outer coercion `c` and a
+separate equality `c ≡ seal A α`:
+
+```agda
+right-seal-inversion₁-aux :
+  ∀ {Δ σ γ M V c r A α} →
+  c ≡ seal A α →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ c ⟩ ∶ r →
+  ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q
+```
+
+This avoids asking coverage to reduce `- s`.  Agda then exposed the real
+frontier: `extend`, where the right term is stuck as `N′ [ α ]ᵀ`.
+
+## Attempt 3. Equality-indexed right term
+
+The auxiliary was generalized again to carry an arbitrary right term `T`:
+
+```agda
+right-seal-inversion₁-aux :
+  ∀ {Δ σ γ M T V c r A α} →
+  T ≡ V ⟨ c ⟩ →
+  c ≡ seal A α →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ r →
+  ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q
+```
+
+With this shape, the `extend` case can use the existing transport
+`extendReplaceRel-term (replace-here qᶜ)` from `proof.Catchup` after the
+recursive call:
+
+```agda
+right-seal-inversion₁-aux eq c≡seal (extend qᶜ pαᶜ M⊒Vseal)
+    with right-seal-inversion₁-aux eq c≡seal M⊒Vseal
+... | q , M⊒V =
+  q , extendReplaceRel-term (replace-here qᶜ) M⊒V
+```
+
+This got past `extend`.  Agda then stopped at `split`.
+
+## Frontier. `split`
+
+For `split`, the premise strips under `(α ꞉ q) ∷ σ`, but the conclusion must
+live under `(α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ` and changes the source opening from
+`N [ α ]ᵀ` to `N [ αᵢ ]ᵀ`.
+
+The obvious recursive call gives:
+
+```agda
+Δ ∣ (α ꞉ q) ∷ σ ∣ γ ⊢ N [ α ]ᵀ ⊒ V ∶ q′
+```
+
+The desired conclusion is:
+
+```agda
+Δ ∣ (α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ ∣ γ
+  ⊢ N [ αᵢ ]ᵀ ⊒ V ∶ q″
+```
+
+This is not the same transport as `extendReplaceRel-term`: it must both change
+the source opening and retype or reindex the exposed coercion.  This matches
+the existing split warning in `proof.Catchup`, where `catchup-split-catchup`
+is still postulated because the split-specific opening transport has not been
+mechanized.
+
+## Counterexample search
+
+After merging the latest `main`, the stricter narrowing/widening grammar made
+one proof branch clearer: a right `⊒cast+` cannot hide a right seal, because it
+would require a `Narrowing (unseal α A)`.  Splitting on the possible ground
+casts closes the analogous tag-looking cases.
+
+The actual counterexample is simpler than the earlier `split` search.  It is
+mechanized in `proof.RightSealInversionCounterexample`:
+
+```agda
+counterexample-premise :
+  1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
+    ⊢ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩
+      ⊒ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩
+    ∶ id (＇ 0)
+```
+
+The premise is built by adding a right seal to the bare constant relation and
+then adding the same seal on the left:
+
+```agda
+right-sealed-constant =
+  ⊒cast- idNatᶜ right-seal-compose (κ⊒κ k0)
+
+counterexample-premise =
+  cast-⊒ idAlphaᶜ left-seal-compose right-sealed-constant
+```
+
+If `right-seal-inversion₁` were true, applying it to
+`counterexample-premise` would produce:
+
+```agda
+∃[ q ]
+  1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
+    ⊢ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩ ⊒ $ (κℕ 0) ∶ q
+```
+
+The module proves this stripped relation impossible:
+
+```agda
+stripped-impossible :
+  ∀ {q} →
+  1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []
+    ⊢ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩ ⊒ $ (κℕ 0) ∶ q →
+  ⊥
+```
+
+The two nontrivial stripped cases are:
+
+- `cast+⊒`: the displayed left seal would have to be `- t`, so `t` would be
+  `unseal`.  The post-merge grammar has no `Narrowing (unseal α A)`.
+- `cast-⊒`: the premise relates bare constants, forcing its index to be
+  `id (‵ `ℕ)`.  The composition side condition then forces the remaining
+  narrowing after the visible seal to have type `＇ 0 ⊒ ‵ `ℕ`, which is ruled
+  out by `narrowing-var-to-older⊥`.
+
+The final checked statement is:
+
+```agda
+right-seal-inversion₁-counterexample :
+  (∀ {Δ σ γ M V r A α} →
+    Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+    ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q) →
+  ⊥
+```
+
+So `right-seal-inversion₁` is false as currently stated.  Any replacement
+lemma must exclude left-cast wrappers like this example, or return a weaker
+conclusion that permits a compensating left seal.


### PR DESCRIPTION
## Summary

- Adds `proof.RightSealInversionCounterexample`, a checked counterexample to the `right-seal-inversion₁` postulate.
- Records the proof-search attempts and why the direct proof strategies fail in `RightSealInversionNotes.md`.
- Marks the postulate in `DynamicGradualGuarantee.agda` as refuted by the counterexample module.

## Root Cause

`right-seal-inversion₁` assumes a right seal can be stripped while preserving some term-narrowing relation. A left-cast wrapper can relate a sealed constant to the same right-sealed constant at `id (＇ 0)`, but stripping the right seal would require relating the sealed source constant to the bare constant. That stripped relation is impossible: `cast+⊒` would require narrowing an `unseal`, and `cast-⊒` forces a narrowing from `＇ 0` to `ℕ`.

## Validation

- `agda -v0 proof/RightSealInversionCounterexample.agda`
- `agda -v0 proof/DynamicGradualGuarantee.agda`