### PR TITLE
[codex] Check left widening No premise

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -18,5 +18,6 @@ import NuReduction
 import proof.NWTermReduction
 import TermNarrowing
 import NarrowingExamples
+import proof.LeftWidening
 import NuMetaTheory
 import proof.DynamicGradualGuarantee

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -178,6 +178,10 @@ postulate
 --   `proof.LeftWidening` shows that the older `left-widening-lemma`
 --   statement was false without the runtime/no-bullet premise: the
 --   `gen`/`inst` branch can reduce to a stuck `ν`.
+--   It also contains `left-widening-current-seal-counterexample`, which shows
+--   that the current `No•`-strengthened statement is still false: the
+--   `seal`/`unseal` branch can get stuck on a bare source value related to
+--   `blame`.
 -- * The other postulates in this file are not pre-existing named cambridge25
 --   lemmas.  They are newly documented proof obligations/cases in
 --   `cambridge25.lagda.md`, marked with `[New]`, and remain to be proved.

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -175,9 +175,9 @@ postulate
 -- * `left-widening-lemma` and `left-narrowing-lemma` correspond to named
 --   cambridge25 lemmas.  The Agda statements add the emitted-store bookkeeping
 --   (`χs`, `π`, and `combineStoreNrw`) needed by this mechanization.
---   `proof.LeftWidening` shows that the current `left-widening-lemma`
---   statement is false without an additional runtime/no-bullet premise:
---   the `gen`/`inst` branch can reduce to a stuck `ν`.
+--   `proof.LeftWidening` shows that the older `left-widening-lemma`
+--   statement was false without the runtime/no-bullet premise: the
+--   `gen`/`inst` branch can reduce to a stuck `ν`.
 -- * The other postulates in this file are not pre-existing named cambridge25
 --   lemmas.  They are newly documented proof obligations/cases in
 --   `cambridge25.lagda.md`, marked with `[New]`, and remain to be proved.

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -135,6 +135,9 @@ open import proof.CatchupStore
 -- * `left-widening-lemma` and `left-narrowing-lemma` correspond to named
 --   cambridge25 lemmas.  The Agda statements add the emitted-store bookkeeping
 --   (`χs`, `π`, and `combineStoreNrw`) needed by this mechanization.
+--   `proof.LeftWidening` shows that the current `left-widening-lemma`
+--   statement is false without an additional runtime/no-bullet premise:
+--   the `gen`/`inst` branch can reduce to a stuck `ν`.
 -- * The other postulates in this file are not pre-existing named cambridge25
 --   lemmas.  They are newly documented proof obligations/cases in
 --   `cambridge25.lagda.md`, marked with `[New]`, and remain to be proved.

--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -60,6 +60,21 @@ renameᶜ-preserves-Inert ρ (`∀ c) = `∀ (renameᶜ (extᵗ ρ) c)
 renameᶜ-preserves-Inert ρ (gen A c) =
   gen (renameᵗ ρ A) (renameᶜ (extᵗ ρ) c)
 
+renameᶜ-reflects-Inert :
+  ∀ ρ c →
+  Inert (renameᶜ ρ c) →
+  Inert c
+renameᶜ-reflects-Inert ρ (id A) ()
+renameᶜ-reflects-Inert ρ (c ︔ d) ()
+renameᶜ-reflects-Inert ρ (c ↦ d) (c′ ↦ d′) = c ↦ d
+renameᶜ-reflects-Inert ρ (`∀ c) (`∀ c′) = `∀ c
+renameᶜ-reflects-Inert ρ (G !) (H !) = G !
+renameᶜ-reflects-Inert ρ (G ？) ()
+renameᶜ-reflects-Inert ρ (seal A α) (seal B β) = seal A α
+renameᶜ-reflects-Inert ρ (unseal α A) ()
+renameᶜ-reflects-Inert ρ (gen A c) (gen B d) = gen A c
+renameᶜ-reflects-Inert ρ (inst B c) ()
+
 mutual
   src-renameᶜ :
     ∀ ρ c →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -88,6 +88,11 @@ module proof.LeftWidening where
 --     form expected by the `⊒Λ`/`⊒⟨ν⟩` package lemmas.  The source-facing
 --     gen package wrappers compose that transport with the existing packages;
 --     Example 4 now uses the `⊒Λ` source wrapper directly.
+--   * The same no-`proof.Catchup` rule now applies to right-composition
+--     witnesses: `left-widening-compose-right-transport` transports
+--     `r ≈ t ⨾ⁿ p` through emitted source-only store changes.  This is
+--     the algebra needed after the first recursive value-level catchup in
+--     cast and sequence branches.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -185,7 +190,13 @@ open import NarrowingExamples
     ; var0-fun-narrowing
     ; wf-var-fun-endpoints
     )
-open import proof.NarrowWidenProperties using (StoreDetWf; ⊒ˢ-empty-anyᵗ)
+open import proof.NarrowWidenProperties
+  using
+    ( StoreDetWf
+    ; WfTyˢ-store-weaken
+    ; narrow-drop-star-var
+    ; ⊒ˢ-empty-anyᵗ
+    )
 open import proof.CatchupStore
   using
     ( combineStoreNrw
@@ -197,19 +208,40 @@ open import proof.CatchupStore
 open import proof.ReductionProperties
   using
     ( applyCoercions
+    ; applyCoercions-empty-id
     ; applyCoercions-++
+    ; applyCoercions-⇑ᶜ
     ; applyCoercions-gen
+    ; applyCoercions-last-bind
     ; applyCoercionUnderTyBinders
     ; applyTerms-++
     ; applyTyCtxs-++
+    ; applyTyCtxs-empty-id
+    ; applyTyCtxs-last-bind
+    ; applyTyCtxs-suc
     ; applyTys-∀
+    ; applyTys-⇑ᵗ
+    ; applyTys-empty-id
     ; applyTysUnderTyBinders
+    ; applyTys-last-bind
+    ; applyStores-last-bind
+    ; allKeep-applyStores-id
     ; cast-dual-↠
+    ; last-bind
+    ; no-bind
+    ; shiftStore
+    ; shiftStore-⟰ᵗ
+    ; shiftStore-cons
+    ; shiftStore-empty
+    ; shiftStore-empty-inv
+    ; storeChangesLastBind
+    ; storeTail-∷≡
     ; ↠-trans
     )
 open import proof.NuTermProperties
   using (open0-ext-suc-cancelᵐ; renameᵗᵐ-preserves-Value)
 open import proof.CoercionProperties using (renameᶜ-preserves-Inert)
+open import proof.TermNarrowingProperties using (compose-rightⁿ-⇑ˢ)
 
 dual-untag-inert :
   ∀ {G} →
@@ -372,6 +404,198 @@ left-widening-gen-spine-coercion-typing {σ = σ} pᶜ =
     refl
     refl
     (⊒ˢ-left ⊒ˢ-nil)
+
+left-widening-≈ⁿ-add-left-star-var :
+  ∀ X {Δ σ s t A B} →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊒ B →
+  Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ s ≈ t ∶ A ⊒ B
+left-widening-≈ⁿ-add-left-star-var X (endpointsⁿ {t = t}
+    srcs tgts srct tgtt σ⊒ (hA , hB) (hA′ , hB′) s⊒ t⊒) =
+  endpointsⁿ
+    srcs
+    tgts
+    srct
+    tgtt
+    (⊒ˢ-left σ⊒)
+    (hA , hB)
+    ( WfTyˢ-store-weaken StoreIncl-drop hA′
+    , WfTyˢ-store-weaken StoreIncl-drop hB′
+    )
+    s⊒
+    (narrow-drop-star-var X t⊒)
+
+left-widening-compose-rightⁿ-add-left-star-var :
+  ∀ X {Δ σ r t p A B} →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+left-widening-compose-rightⁿ-add-left-star-var X
+    (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
+  compose-rightⁿ wfΣ t⊒ p⊒
+    (left-widening-≈ⁿ-add-left-star-var X r≈t⨟p)
+
+left-widening-compose-right-transport-shifted :
+  ∀ n {Δ Δ′ σ π Π Π′ χs r t p A B} →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ shiftStore n (applyStores χs []) →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ combineStoreNrw π σ
+    ⊢ applyCoercions χs r
+      ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
+      ∶ applyTys χs A ⊒ applyTys χs B
+left-widening-compose-right-transport-shifted n
+    {Δ = Δ} {Δ′ = Δ′} {σ = σ}
+    {χs = χs} {r = r} {t = t} {p = p} {A = A} {B = B}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ ⊒ˢ-nil =
+  let
+    empty≡ = shiftStore-empty-inv n (sym Π≡)
+    Δ′≡Δ = trans Δ′≡ (applyTyCtxs-empty-id χs empty≡ Δ)
+    r≡ = applyCoercions-empty-id χs empty≡ r
+    t≡ = applyCoercions-empty-id χs empty≡ t
+    p≡ = applyCoercions-empty-id χs empty≡ p
+    A≡ = applyTys-empty-id χs empty≡ A
+    B≡ = applyTys-empty-id χs empty≡ B
+  in
+  subst
+    (λ Δ₀ → Δ₀ ∣ σ
+      ⊢ applyCoercions χs r
+        ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
+        ∶ applyTys χs A ⊒ applyTys χs B)
+    (sym Δ′≡Δ)
+    (subst
+      (λ B₀ → Δ ∣ σ
+        ⊢ applyCoercions χs r
+          ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
+          ∶ applyTys χs A ⊒ B₀)
+      (sym B≡)
+      (subst
+        (λ A₀ → Δ ∣ σ
+          ⊢ applyCoercions χs r
+            ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
+            ∶ A₀ ⊒ B)
+        (sym A≡)
+        (subst
+          (λ p₀ → Δ ∣ σ
+            ⊢ applyCoercions χs r
+              ≈ applyCoercions χs t ⨾ⁿ p₀ ∶ A ⊒ B)
+          (sym p≡)
+          (subst
+            (λ t₀ → Δ ∣ σ
+              ⊢ applyCoercions χs r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+            (sym t≡)
+            (subst
+              (λ r₀ → Δ ∣ σ ⊢ r₀ ≈ t ⨾ⁿ p ∶ A ⊒ B)
+              (sym r≡)
+              r≈t⨟p)))))
+left-widening-compose-right-transport-shifted n
+    r≈t⨟p Δ′≡ Π≡ () (⊒ˢ-right hA π⊒)
+left-widening-compose-right-transport-shifted n {χs = χs}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    with storeChangesLastBind χs
+left-widening-compose-right-transport-shifted n {χs = χs}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | no-bind keeps
+    with trans Π≡
+      (trans (cong (shiftStore n) (allKeep-applyStores-id keeps []))
+        (shiftStore-empty n))
+left-widening-compose-right-transport-shifted n {χs = χs}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | no-bind keeps | ()
+left-widening-compose-right-transport-shifted n
+    {Δ = Δ} {σ = σ}
+    {χs = .(χs ++ bind Aχ ∷ keeps)}
+    {r = r} {t = t} {p = p} {A = A} {B = B}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left {X = X} π⊒)
+    | last-bind χs Aχ keeps keeps-ok =
+  let
+    Δtail≡ =
+      trans Δ′≡
+        (trans (applyTyCtxs-last-bind χs Aχ keeps keeps-ok Δ)
+          (sym (applyTyCtxs-suc χs Δ)))
+    Π-last≡ =
+      trans Π≡
+        (cong (shiftStore n)
+          (applyStores-last-bind χs Aχ keeps keeps-ok []))
+    Π-last-normal≡ =
+      trans Π-last≡
+        (shiftStore-cons n zero (⇑ᵗ Aχ) (⟰ᵗ (applyStores χs [])))
+    Πtail≡ =
+      trans (storeTail-∷≡ Π-last-normal≡)
+        (shiftStore-⟰ᵗ n (applyStores χs []))
+    tail =
+      left-widening-compose-right-transport-shifted (suc n)
+        {χs = χs}
+        (compose-rightⁿ-⇑ˢ r≈t⨟p)
+        Δtail≡
+        Πtail≡
+        Π′≡
+        π⊒
+    lifted = left-widening-compose-rightⁿ-add-left-star-var X tail
+    r≡ =
+      trans (applyCoercions-⇑ᶜ χs r)
+        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok r))
+    t≡ =
+      trans (applyCoercions-⇑ᶜ χs t)
+        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok t))
+    p≡ =
+      trans (applyCoercions-⇑ᶜ χs p)
+        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok p))
+    A≡ =
+      trans (applyTys-⇑ᵗ χs A)
+        (sym (applyTys-last-bind χs Aχ keeps keeps-ok A))
+    B≡ =
+      trans (applyTys-⇑ᵗ χs B)
+        (sym (applyTys-last-bind χs Aχ keeps keeps-ok B))
+  in
+  subst
+    (λ B₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
+      ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) t
+        ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) p
+      ∶ applyTys (χs ++ bind Aχ ∷ keeps) A ⊒ B₀)
+    B≡
+    (subst
+      (λ A₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
+        ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) t
+          ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) p
+        ∶ A₀ ⊒ applyTys χs (⇑ᵗ B))
+      A≡
+      (subst
+        (λ p₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
+          ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) t
+            ⨾ⁿ p₀ ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
+        p≡
+        (subst
+          (λ t₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
+            ≈ t₀ ⨾ⁿ applyCoercions χs (⇑ᶜ p)
+            ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
+          t≡
+          (subst
+            (λ r₀ → _ ∣ _ ⊢ r₀
+              ≈ applyCoercions χs (⇑ᶜ t)
+                ⨾ⁿ applyCoercions χs (⇑ᶜ p)
+              ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
+            r≡
+            lifted))))
+left-widening-compose-right-transport-shifted n
+    r≈t⨟p Δ′≡ Π≡ () (⊒ˢ-both hA hA′ s⊒ π⊒)
+
+left-widening-compose-right-transport :
+  ∀ {Δ Δ′ σ π Π Π′ χs r t p A B} →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ applyStores χs [] →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ combineStoreNrw π σ
+    ⊢ applyCoercions χs r
+      ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
+      ∶ applyTys χs A ⊒ applyTys χs B
+left-widening-compose-right-transport {χs = χs}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ π⊒ =
+  left-widening-compose-right-transport-shifted zero
+    {χs = χs}
+    r≈t⨟p Δ′≡ Π≡ Π′≡ π⊒
 
 left-widening-inert :
   ∀ {Δ σ V V′ p r t A B C D} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -82,7 +82,10 @@ module proof.LeftWidening where
 --     The recursive component calls also need coercion typing transported
 --     through emitted store changes; `left-widening-coercion-typing-transport`
 --     factors the small part of `proof.Catchup`'s transport infrastructure
---     needed here without importing `proof.Catchup` and its assumptions.
+--     needed here without importing `proof.Catchup` and its assumptions.  The
+--     `gen`-specific wrapper
+--     `left-widening-gen-coercion-typing-transport` exposes the constructor
+--     form expected by the `⊒Λ`/`⊒⟨ν⟩` package lemmas.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -193,8 +196,12 @@ open import proof.ReductionProperties
   using
     ( applyCoercions
     ; applyCoercions-++
+    ; applyCoercions-gen
+    ; applyCoercionUnderTyBinders
     ; applyTerms-++
     ; applyTyCtxs-++
+    ; applyTys-∀
+    ; applyTysUnderTyBinders
     ; cast-dual-↠
     ; ↠-trans
     )
@@ -317,6 +324,35 @@ left-widening-coercion-typing-transport
         (combineStoreNrw-applyStores-store
           {χs = χs} π⊒ Π≡ Π′≡ σ))
       (left-widening-applyCoercions-narrow χs pᶜ))
+
+left-widening-gen-coercion-typing-transport :
+  ∀ {Δ Δ′ σ π Π Π′ χs p A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ gen A p ∶ᶜ A ⊒ `∀ B →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ applyStores χs [] →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ srcStoreⁿ (combineStoreNrw π σ)
+    ⊢ gen (applyTys χs A) (applyCoercionUnderTyBinders χs p)
+      ∶ᶜ applyTys χs A ⊒ `∀ (applyTysUnderTyBinders χs B)
+left-widening-gen-coercion-typing-transport
+    {Δ′ = Δ′} {σ = σ} {π = π} {χs = χs}
+    {p = p} {A = A} {B = B} pᶜ Δ′≡ Π≡ Π′≡ π⊒ =
+  subst
+    (λ B₀ →
+      Δ′ ∣ srcStoreⁿ (combineStoreNrw π σ)
+        ⊢ gen (applyTys χs A) (applyCoercionUnderTyBinders χs p)
+          ∶ᶜ applyTys χs A ⊒ B₀)
+    (applyTys-∀ χs B)
+    (subst
+      (λ p₀ →
+        Δ′ ∣ srcStoreⁿ (combineStoreNrw π σ)
+          ⊢ p₀ ∶ᶜ applyTys χs A ⊒ applyTys χs (`∀ B))
+      (applyCoercions-gen χs A p)
+      (left-widening-coercion-typing-transport
+        {σ = σ} {π = π} {χs = χs} {p = gen A p}
+        {A = A} {B = `∀ B}
+        pᶜ Δ′≡ Π≡ Π′≡ π⊒))
 
 left-widening-inert :
   ∀ {Δ σ V V′ p r t A B C D} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -73,14 +73,19 @@ module proof.LeftWidening where
 --     mechanized in `proof.TermNarrowingProperties` as `narrow-renameᵗ-any`,
 --     `⊒ˢ-rename`, `≈ⁿ-rename`, `compose-leftⁿ-rename`,
 --     and `compose-rightⁿ-rename`.
+--     A usable `StoreDetWf` transport has to assume both order preservation
+--     and injectivity.  That refinement is mechanized as `TyRenameStrict`,
+--     `StoreDetWf-rename`, and the binder-preserving `StoreDetWf-ext-suc`,
+--     with direct `≈ⁿ-ext-suc`, `compose-leftⁿ-ext-suc`, and
+--     `compose-rightⁿ-ext-suc` corollaries.
 --     The `suc`-specific cast cases are still mechanized there via `≈ⁿ-⇑ˢ`,
 --     `compose-leftⁿ-⇑ˢ`, `compose-rightⁿ-⇑ˢ`, `shift-⊒cast+`,
 --     `shift-⊒cast-`, `shift-cast+⊒`, and `shift-cast-⊒`.
 --   * The cast constructors can also be renamed once the composition
 --     side-condition has already been transported.  The constructor-level
 --     lemmas `rename-⊒cast+`, `rename-⊒cast-`, `rename-cast+⊒`, and
---     `rename-cast-⊒` avoid rebuilding the dual-cast transports by hand in
---     the eventual induction.
+--     `rename-cast-⊒`, plus their `-det` wrappers, avoid rebuilding the
+--     dual-cast and composition transports by hand in the eventual induction.
 --   * The `ν` renaming helpers are intentionally stated in constructor-native
 --     form rather than as pointwise renamings of whole `ν` terms: `ν` renames
 --     its term body with `ρ`, while the narrowing premises under the fresh

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -79,6 +79,10 @@ module proof.LeftWidening where
 --     `left-widening-seq-compose-package` combines that transport with the
 --     sequence reduction package, so the future sequence branch can focus on
 --     producing the two recursive component witnesses.
+--     The recursive component calls also need coercion typing transported
+--     through emitted store changes; `left-widening-coercion-typing-transport`
+--     factors the small part of `proof.Catchup`'s transport infrastructure
+--     needed here without importing `proof.Catchup` and its assumptions.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -146,11 +150,13 @@ open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_; _++_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (zero; suc; z<s)
+open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_×_; _,_; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
   using (cong; subst; sym; trans)
 
 open import Types
+open import Store using (StoreIncl-drop)
 open import Coercions
 open import NuTerms
 open import NuReduction
@@ -181,6 +187,7 @@ open import proof.CatchupStore
     ; combineStoreNrw-assoc
     ; combineStoreNrw-empty-⊒ˢ
     ; combineStoreNrw-applyStores
+    ; combineStoreNrw-applyStores-store
     )
 open import proof.ReductionProperties
   using
@@ -258,6 +265,58 @@ LeftWidening =
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
     Δ′ ∣ combineStoreNrw π σ ∣ []
       ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+
+left-widening-gen-tag-or-id≤tag-or-id :
+  ModeIncl (genᵈ tag-or-idᵈ) tag-or-idᵈ
+left-widening-gen-tag-or-id≤tag-or-id zero = refl
+left-widening-gen-tag-or-id≤tag-or-id (suc X) = refl
+
+left-widening-applyCoercion-narrow :
+  ∀ χ {Δ Σ c A B} →
+  Δ ∣ Σ ⊢ c ∶ᶜ A ⊒ B →
+  applyTyCtx χ Δ ∣ applyStore χ Σ
+    ⊢ applyCoercion χ c ∶ᶜ applyTy χ A ⊒ applyTy χ B
+left-widening-applyCoercion-narrow keep c⊒ = c⊒
+left-widening-applyCoercion-narrow (bind Aν) c⊒ =
+  narrow-mode-relax left-widening-gen-tag-or-id≤tag-or-id
+    (narrow-weaken ≤-refl StoreIncl-drop (narrow-⇑ᵗ-gen c⊒))
+
+left-widening-applyCoercions-narrow :
+  ∀ χs {Δ Σ c A B} →
+  Δ ∣ Σ ⊢ c ∶ᶜ A ⊒ B →
+  applyTyCtxs χs Δ ∣ applyStores χs Σ
+    ⊢ applyCoercions χs c ∶ᶜ applyTys χs A ⊒ applyTys χs B
+left-widening-applyCoercions-narrow [] c⊒ = c⊒
+left-widening-applyCoercions-narrow (χ ∷ χs) c⊒ =
+  left-widening-applyCoercions-narrow χs
+    (left-widening-applyCoercion-narrow χ c⊒)
+
+left-widening-coercion-typing-transport :
+  ∀ {Δ Δ′ σ π Π Π′ χs p A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ applyStores χs [] →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ srcStoreⁿ (combineStoreNrw π σ)
+    ⊢ applyCoercions χs p ∶ᶜ applyTys χs A ⊒ applyTys χs B
+left-widening-coercion-typing-transport
+    {Δ = Δ} {σ = σ} {π = π} {χs = χs}
+    {p = p} {A = A} {B = B} pᶜ Δ′≡ Π≡ Π′≡ π⊒ =
+  subst
+    (λ Δ₀ →
+      Δ₀ ∣ srcStoreⁿ (combineStoreNrw π σ)
+        ⊢ applyCoercions χs p ∶ᶜ applyTys χs A ⊒ applyTys χs B)
+    (sym Δ′≡)
+    (subst
+      (λ Σ →
+        applyTyCtxs χs Δ ∣ Σ
+          ⊢ applyCoercions χs p
+            ∶ᶜ applyTys χs A ⊒ applyTys χs B)
+      (sym
+        (combineStoreNrw-applyStores-store
+          {χs = χs} π⊒ Π≡ Π′≡ σ))
+      (left-widening-applyCoercions-narrow χs pᶜ))
 
 left-widening-inert :
   ∀ {Δ σ V V′ p r t A B C D} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -64,11 +64,23 @@ module proof.LeftWidening where
 --     and `rename-⊕`.
 --   * Trying to make that renaming theorem fully arbitrary runs into the
 --     composition witnesses used by cast constructors: their internal mode
---     environment is existential, so a non-injective type renaming does not
---     obviously preserve it.  The `suc`-specific cast cases are still
---     mechanized in `proof.TermNarrowingProperties` via `≈ⁿ-⇑ˢ`,
+--     environment is existential, and `TyRenameWf` alone permits renamings
+--     that collapse or reorder store variables.  Such renamings do not
+--     preserve the `StoreDetWf` uniqueness/older-variable invariants needed by
+--     composition determinacy.  The surviving algebraic shape is therefore:
+--     carry an `AllModeRename` witness for existential mode environments and
+--     an explicit `StoreDetWf` transport for the renaming.  This is now
+--     mechanized in `proof.TermNarrowingProperties` as `narrow-renameᵗ-any`,
+--     `⊒ˢ-rename`, `≈ⁿ-rename`, `compose-leftⁿ-rename`,
+--     and `compose-rightⁿ-rename`.
+--     The `suc`-specific cast cases are still mechanized there via `≈ⁿ-⇑ˢ`,
 --     `compose-leftⁿ-⇑ˢ`, `compose-rightⁿ-⇑ˢ`, `shift-⊒cast+`,
 --     `shift-⊒cast-`, `shift-cast+⊒`, and `shift-cast-⊒`.
+--   * The cast constructors can also be renamed once the composition
+--     side-condition has already been transported.  The constructor-level
+--     lemmas `rename-⊒cast+`, `rename-⊒cast-`, `rename-cast+⊒`, and
+--     `rename-cast-⊒` avoid rebuilding the dual-cast transports by hand in
+--     the eventual induction.
 --   * The `ν` renaming helpers are intentionally stated in constructor-native
 --     form rather than as pointwise renamings of whole `ν` terms: `ν` renames
 --     its term body with `ρ`, while the narrowing premises under the fresh

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -91,6 +91,10 @@ module proof.LeftWidening where
 --     its term body with `ρ`, while the narrowing premises under the fresh
 --     store entry need `extᵗ ρ`.  Keeping that mismatch explicit avoids a
 --     false "obvious" helper.
+--   * The bindery store constructors need the same constructor-native shape:
+--     `rename-extend` and `rename-split` are now mechanized in
+--     `proof.TermNarrowingProperties`, using the parallel type-renaming/opening
+--     commutation lemmas for terms and coercions.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -55,6 +55,9 @@ module proof.LeftWidening where
 --     (`shift-var`, `shift-blame`, `shift-ƛ`, `shift-·`) should therefore be
 --     generalized to a parallel type-renaming theorem with an explicit
 --     store-narrowing renamer and mode-renamer premise.
+--     Current progress in that direction includes `renameStoreNrw`,
+--     `renameCtxNrw`, `rename-var`, `rename-blame`, `rename-ƛ`, `rename-·`,
+--     and `rename-Λ`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -59,7 +59,9 @@ module proof.LeftWidening where
 --     store-narrowing renamer and mode-renamer premise.
 --     Current progress in that direction includes `renameStoreNrw`,
 --     `renameCtxNrw`, `rename-var`, `rename-blame`, `rename-ƛ`, `rename-·`,
---     `rename-Λ`, `rename-⊒Λ`, `rename-κ`, and `rename-⊕`.
+--     `rename-Λ`, `rename-⊒Λ`, `rename-⊒⟨ν⟩`, `rename-α⊒α`,
+--     `rename-⊒α`, `rename-ν⊒ν`, `rename-⊒ν`, `rename-ν⊒`, `rename-κ`,
+--     and `rename-⊕`.
 --   * Trying to make that renaming theorem fully arbitrary runs into the
 --     composition witnesses used by cast constructors: their internal mode
 --     environment is existential, so a non-injective type renaming does not
@@ -67,6 +69,11 @@ module proof.LeftWidening where
 --     mechanized in `proof.TermNarrowingProperties` via `≈ⁿ-⇑ˢ`,
 --     `compose-leftⁿ-⇑ˢ`, `compose-rightⁿ-⇑ˢ`, `shift-⊒cast+`,
 --     `shift-⊒cast-`, `shift-cast+⊒`, and `shift-cast-⊒`.
+--   * The `ν` renaming helpers are intentionally stated in constructor-native
+--     form rather than as pointwise renamings of whole `ν` terms: `ν` renames
+--     its term body with `ρ`, while the narrowing premises under the fresh
+--     store entry need `extᵗ ρ`.  Keeping that mismatch explicit avoids a
+--     false "obvious" helper.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -14,9 +14,12 @@ module proof.LeftWidening where
 -- Strategy log:
 --   * Directly reusing `cast+⊒` works only when the dual cast is inert, since
 --     then `V ⟨ - t ⟩` is already a value.  This should cover function,
---     universal, tag, and generated-function/all inert cases.
---     The function, universal, and tag/untag forms below are now mechanized
---     as zero-step branches through `left-widening-inert`.
+--     universal, and tag/untag cases.  The raw `unseal` and `inst` forms also
+--     have inert duals, and are included below as zero-step edge cases, but the
+--     `r ≈ t ⨾ⁿ p` premise carries a narrowing proof for `t`, so the reachable
+--     hard heads are still `seal`, `s ︔ seal`, `gen`, and sequence variants.
+--     The function, universal, and tag/untag forms below are mechanized as
+--     zero-step branches through `left-widening-inert`.
 --   * The exact identity branch, where the result index is syntactically `p`,
 --     is mechanized below by one `β-id` step.  The general identity branch
 --     still requires turning the endpoint-equivalence premise
@@ -72,6 +75,16 @@ dual-untag-inert :
 dual-untag-inert (＇ α) = (＇ α) !
 dual-untag-inert (‵ ι) = (‵ ι) !
 dual-untag-inert ★⇒★ = (★ ⇒ ★) !
+
+dual-unseal-inert :
+  ∀ {α A} →
+  Inert (- unseal α A)
+dual-unseal-inert {α = α} {A = A} = seal A α
+
+dual-inst-inert :
+  ∀ {B c} →
+  Inert (- inst B c)
+dual-inst-inert {B = B} {c = c} = gen B (dual (instᵃ normalᵃ) c)
 
 LeftWideningWithoutNo• : Set₁
 LeftWideningWithoutNo• =
@@ -200,6 +213,48 @@ left-widening-untag :
       ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
 left-widening-untag gG vV noV pᶜ r≈t⨟p V⊒V′ =
   left-widening-inert (dual-untag-inert gG)
+    vV noV pᶜ r≈t⨟p V⊒V′
+
+left-widening-unseal :
+  ∀ {Δ σ V V′ p r α A A₀ B C D} →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ unseal α A ⨾ⁿ p ∶ A₀ ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (V ⟨ - unseal α A ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-unseal {α = α} {A = A} vV noV pᶜ r≈t⨟p V⊒V′ =
+  left-widening-inert (dual-unseal-inert {α = α} {A = A})
+    vV noV pᶜ r≈t⨟p V⊒V′
+
+left-widening-inst :
+  ∀ {Δ σ V V′ p r B c A₀ B₀ C D} →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ inst B c ⨾ⁿ p ∶ A₀ ⊒ B₀ →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (V ⟨ - inst B c ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-inst {B = B} {c = c} vV noV pᶜ r≈t⨟p V⊒V′ =
+  left-widening-inert (dual-inst-inert {B = B} {c = c})
     vV noV pᶜ r≈t⨟p V⊒V′
 
 left-widening-id-exact :

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -79,6 +79,10 @@ module proof.LeftWidening where
 --     `left-widening-seq-compose-package` combines that transport with the
 --     sequence reduction package, so the future sequence branch can focus on
 --     producing the two recursive component witnesses.
+--     `left-widening-seq-recursive-witness-package` now exposes that future
+--     branch interface directly: once the recursive witnesses for `d` and the
+--     transported `c` are produced, the remaining reduction/store bookkeeping
+--     is discharged.
 --     The recursive component calls also need coercion typing transported
 --     through emitted store changes; `left-widening-coercion-typing-transport`
 --     factors the small part of `proof.Catchup`'s transport infrastructure
@@ -1094,6 +1098,71 @@ left-widening-seq-compose-package {Δ = Δ} {σ = σ} {V = V}
   Π′≡ ,
   π⊒ ,
   U⊒V′′
+
+left-widening-seq-recursive-witness-package :
+  ∀ {Δ σ V V′ c d q r} →
+  Value V →
+  (∃[ χs₁ ] ∃[ W ] ∃[ Δ₁ ] ∃[ Π₁ ] ∃[ Π₁′ ] ∃[ π₁ ]
+    Value W ×
+    No• W ×
+    (V ⟨ - d ⟩ —↠[ χs₁ ] W) ×
+    (Δ₁ ≡ applyTyCtxs χs₁ Δ) ×
+    (Π₁ ≡ applyStores χs₁ []) ×
+    (Π₁′ ≡ applyStore keep []) ×
+    Δ₁ ⊢ π₁ ꞉ Π₁ ⊒ˢ Π₁′ ×
+    Δ₁ ∣ combineStoreNrw π₁ σ ∣ []
+      ⊢ W ⊒ applyTerms χs₁ V′ ∶ applyCoercions χs₁ q ×
+    ∃[ χs₂ ] ∃[ U ] ∃[ Δ₂ ] ∃[ Π₂ ] ∃[ Π₂′ ]
+    ∃[ π₂ ]
+      Value U ×
+      No• U ×
+      (W ⟨ - applyCoercions χs₁ c ⟩ —↠[ χs₂ ] U) ×
+      (Δ₂ ≡ applyTyCtxs χs₂ Δ₁) ×
+      (Π₂ ≡ applyStores χs₂ []) ×
+      (Π₂′ ≡ applyStore keep []) ×
+      Δ₂ ⊢ π₂ ꞉ Π₂ ⊒ˢ Π₂′ ×
+      Δ₂ ∣ combineStoreNrw π₂ (combineStoreNrw π₁ σ) ∣ []
+        ⊢ U ⊒ applyTerms χs₂ (applyTerms χs₁ V′)
+          ∶ applyCoercions χs₂ (applyCoercions χs₁ r)) →
+  ∃[ χs ] ∃[ U ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value U ×
+    No• U ×
+    (V ⟨ - (c ︔ d) ⟩ —↠[ χs ] U) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ U ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-seq-recursive-witness-package
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {c = c} {d = d}
+    {r = r} vV
+    (χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vd↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′ ,
+      χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Wc↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′) =
+  left-widening-seq-compose-package
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {c = c} {d = d}
+    {r = r} {χs₁ = χs₁} {χs₂ = χs₂} {W = W} {U = U}
+    {Δ₁ = Δ₁} {Δ₂ = Δ₂}
+    {Π₁ = Π₁} {Π₁′ = Π₁′} {Π₂ = Π₂} {Π₂′ = Π₂′}
+    {π₁ = π₁} {π₂ = π₂}
+    vV
+    Vd↠W
+    Wc↠U
+    vU
+    noU
+    Δ₁≡
+    Π₁≡
+    Π₁′≡
+    π₁⊒
+    Δ₂≡
+    Π₂≡
+    Π₂′≡
+    π₂⊒
+    U⊒V′
 
 left-widening-gen-reduction :
   ∀ {A c V} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -88,11 +88,12 @@ module proof.LeftWidening where
 --     form expected by the `⊒Λ`/`⊒⟨ν⟩` package lemmas.  The source-facing
 --     gen package wrappers compose that transport with the existing packages;
 --     Example 4 now uses the `⊒Λ` source wrapper directly.
---   * The same no-`proof.Catchup` rule now applies to right-composition
---     witnesses: `left-widening-compose-right-transport` transports
---     `r ≈ t ⨾ⁿ p` through emitted source-only store changes.  This is
---     the algebra needed after the first recursive value-level catchup in
---     cast and sequence branches.
+--   * The same no-`proof.Catchup` rule now applies to composition witnesses:
+--     `left-widening-compose-left-transport` and
+--     `left-widening-compose-right-transport` transport the two composition
+--     orientations through emitted source-only store changes.  This is the
+--     algebra needed after recursive value-level catchup in cast and sequence
+--     branches.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -241,7 +242,8 @@ open import proof.ReductionProperties
 open import proof.NuTermProperties
   using (open0-ext-suc-cancelᵐ; renameᵗᵐ-preserves-Value)
 open import proof.CoercionProperties using (renameᶜ-preserves-Inert)
-open import proof.TermNarrowingProperties using (compose-rightⁿ-⇑ˢ)
+open import proof.TermNarrowingProperties
+  using (compose-leftⁿ-⇑ˢ; compose-rightⁿ-⇑ˢ)
 
 dual-untag-inert :
   ∀ {G} →
@@ -432,6 +434,174 @@ left-widening-compose-rightⁿ-add-left-star-var X
     (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
   compose-rightⁿ wfΣ t⊒ p⊒
     (left-widening-≈ⁿ-add-left-star-var X r≈t⨟p)
+
+left-widening-compose-leftⁿ-add-left-star-var :
+  ∀ X {Δ σ q s r A B} →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+left-widening-compose-leftⁿ-add-left-star-var X
+    (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
+  compose-leftⁿ wfΣ q⊒ s⊒
+    (left-widening-≈ⁿ-add-left-star-var X q⨟s≈r)
+
+left-widening-compose-left-transport-shifted :
+  ∀ n {Δ Δ′ σ π Π Π′ χs q s r A B} →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ shiftStore n (applyStores χs []) →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ combineStoreNrw π σ
+    ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
+      ≈ applyCoercions χs r ∶ applyTys χs A ⊒ applyTys χs B
+left-widening-compose-left-transport-shifted n
+    {Δ = Δ} {Δ′ = Δ′} {σ = σ}
+    {χs = χs} {q = q} {s = s} {r = r} {A = A} {B = B}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ ⊒ˢ-nil =
+  let
+    empty≡ = shiftStore-empty-inv n (sym Π≡)
+    Δ′≡Δ = trans Δ′≡ (applyTyCtxs-empty-id χs empty≡ Δ)
+    q≡ = applyCoercions-empty-id χs empty≡ q
+    s≡ = applyCoercions-empty-id χs empty≡ s
+    r≡ = applyCoercions-empty-id χs empty≡ r
+    A≡ = applyTys-empty-id χs empty≡ A
+    B≡ = applyTys-empty-id χs empty≡ B
+  in
+  subst
+    (λ Δ₀ → Δ₀ ∣ σ
+      ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
+        ≈ applyCoercions χs r ∶ applyTys χs A ⊒ applyTys χs B)
+    (sym Δ′≡Δ)
+    (subst
+      (λ B₀ → Δ ∣ σ
+        ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
+          ≈ applyCoercions χs r ∶ applyTys χs A ⊒ B₀)
+      (sym B≡)
+      (subst
+        (λ A₀ → Δ ∣ σ
+          ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
+            ≈ applyCoercions χs r ∶ A₀ ⊒ B)
+        (sym A≡)
+        (subst
+          (λ r₀ → Δ ∣ σ
+            ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
+              ≈ r₀ ∶ A ⊒ B)
+          (sym r≡)
+          (subst
+            (λ s₀ → Δ ∣ σ
+              ⊢ applyCoercions χs q ⨾ⁿ s₀ ≈ r ∶ A ⊒ B)
+            (sym s≡)
+            (subst
+              (λ q₀ → Δ ∣ σ ⊢ q₀ ⨾ⁿ s ≈ r ∶ A ⊒ B)
+              (sym q≡)
+              q⨟s≈r)))))
+left-widening-compose-left-transport-shifted n
+    q⨟s≈r Δ′≡ Π≡ () (⊒ˢ-right hA π⊒)
+left-widening-compose-left-transport-shifted n {χs = χs}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    with storeChangesLastBind χs
+left-widening-compose-left-transport-shifted n {χs = χs}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | no-bind keeps
+    with trans Π≡
+      (trans (cong (shiftStore n) (allKeep-applyStores-id keeps []))
+        (shiftStore-empty n))
+left-widening-compose-left-transport-shifted n {χs = χs}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
+    | no-bind keeps | ()
+left-widening-compose-left-transport-shifted n
+    {Δ = Δ} {σ = σ}
+    {χs = .(χs ++ bind Aχ ∷ keeps)}
+    {q = q} {s = s} {r = r} {A = A} {B = B}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left {X = X} π⊒)
+    | last-bind χs Aχ keeps keeps-ok =
+  let
+    Δtail≡ =
+      trans Δ′≡
+        (trans (applyTyCtxs-last-bind χs Aχ keeps keeps-ok Δ)
+          (sym (applyTyCtxs-suc χs Δ)))
+    Π-last≡ =
+      trans Π≡
+        (cong (shiftStore n)
+          (applyStores-last-bind χs Aχ keeps keeps-ok []))
+    Π-last-normal≡ =
+      trans Π-last≡
+        (shiftStore-cons n zero (⇑ᵗ Aχ) (⟰ᵗ (applyStores χs [])))
+    Πtail≡ =
+      trans (storeTail-∷≡ Π-last-normal≡)
+        (shiftStore-⟰ᵗ n (applyStores χs []))
+    tail =
+      left-widening-compose-left-transport-shifted (suc n)
+        {χs = χs}
+        (compose-leftⁿ-⇑ˢ q⨟s≈r)
+        Δtail≡
+        Πtail≡
+        Π′≡
+        π⊒
+    lifted = left-widening-compose-leftⁿ-add-left-star-var X tail
+    q≡ =
+      trans (applyCoercions-⇑ᶜ χs q)
+        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok q))
+    s≡ =
+      trans (applyCoercions-⇑ᶜ χs s)
+        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok s))
+    r≡ =
+      trans (applyCoercions-⇑ᶜ χs r)
+        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok r))
+    A≡ =
+      trans (applyTys-⇑ᵗ χs A)
+        (sym (applyTys-last-bind χs Aχ keeps keeps-ok A))
+    B≡ =
+      trans (applyTys-⇑ᵗ χs B)
+        (sym (applyTys-last-bind χs Aχ keeps keeps-ok B))
+  in
+  subst
+    (λ B₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
+      ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) s
+      ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) r
+      ∶ applyTys (χs ++ bind Aχ ∷ keeps) A ⊒ B₀)
+    B≡
+    (subst
+      (λ A₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
+        ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) s
+        ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) r
+        ∶ A₀ ⊒ applyTys χs (⇑ᵗ B))
+      A≡
+      (subst
+        (λ r₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
+          ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) s
+          ≈ r₀ ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
+        r≡
+        (subst
+          (λ s₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
+            ⨾ⁿ s₀ ≈ applyCoercions χs (⇑ᶜ r)
+            ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
+          s≡
+          (subst
+            (λ q₀ → _ ∣ _ ⊢ q₀
+              ⨾ⁿ applyCoercions χs (⇑ᶜ s)
+              ≈ applyCoercions χs (⇑ᶜ r)
+              ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
+            q≡
+            lifted))))
+left-widening-compose-left-transport-shifted n
+    q⨟s≈r Δ′≡ Π≡ () (⊒ˢ-both hA hA′ s⊒ π⊒)
+
+left-widening-compose-left-transport :
+  ∀ {Δ Δ′ σ π Π Π′ χs q s r A B} →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ′ ≡ applyTyCtxs χs Δ →
+  Π ≡ applyStores χs [] →
+  Π′ ≡ [] →
+  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
+  Δ′ ∣ combineStoreNrw π σ
+    ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
+      ≈ applyCoercions χs r ∶ applyTys χs A ⊒ applyTys χs B
+left-widening-compose-left-transport {χs = χs}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ π⊒ =
+  left-widening-compose-left-transport-shifted zero
+    {χs = χs}
+    q⨟s≈r Δ′≡ Π≡ Π′≡ π⊒
 
 left-widening-compose-right-transport-shifted :
   ∀ n {Δ Δ′ σ π Π Π′ χs r t p A B} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -49,6 +49,12 @@ module proof.LeftWidening where
 --     that emitted `bind` steps raise `Δ`; for now the small Example 4
 --     derivation is replayed at the raised context.  A general `gen` proof
 --     should use a reusable term-narrowing type-context weakening lemma.
+--   * A direct suc-only induction for that weakening lemma is the wrong
+--     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
+--     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
+--     (`shift-var`, `shift-blame`, `shift-ƛ`, `shift-·`) should therefore be
+--     generalized to a parallel type-renaming theorem with an explicit
+--     store-narrowing renamer and mode-renamer premise.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -64,6 +64,21 @@ module proof.LeftWidening where
 --     The `⊒Λ` and `⊒⟨ν⟩` relation-side wrappers cover the two
 --     term-narrowing constructors that can consume an inert exposed body cast;
 --     Example 4 now goes through the `⊒Λ` wrapper.
+--     For the `seal` head, the dual `unseal` is active, so the inert helper
+--     cannot apply.  The checked helper `left-widening-seal-redex-package`
+--     packages the part that should remain after a left-seal inversion:
+--     when the source value is already visibly sealed, `seal-unseal` provides
+--     the reduction and the `No•` result follows by inversion on the casted
+--     value.
+--     `left-widening-seq-from-seal-redex-components` plugs that package into
+--     the actual narrowing sequence shape `s ︔ seal A α`: after inversion
+--     supplies the intermediate relation for the unsealed body, the helper
+--     performs the seal/unseal step, recursively widens through `s`, and
+--     reuses the existing sequence bookkeeping.
+--     `left-widening-seq-from-untag-components` does the analogous factoring
+--     for the other grammar sequence form, `G ？︔ g`: only the `g` component
+--     needs a recursive left-widening call, while the trailing `G ？` component
+--     is discharged by the inert `left-widening-untag` branch.
 --     For sequence variants, `dual-seq` and `left-widening-seq-prefix` factor
 --     only the initial `β-seq` step; the remaining recursive catchup/left-
 --     widening obligations are deliberately left explicit.
@@ -217,7 +232,9 @@ open import proof.CatchupStore
 open import proof.ReductionProperties
   using
     ( applyCoercions
+    ; applyCoercions-dual
     ; applyCoercions-empty-id
+    ; applyCoercions-preserves-Inert
     ; applyCoercions-++
     ; applyCoercions-⇑ᶜ
     ; applyCoercions-gen
@@ -868,6 +885,14 @@ left-widening-untag gG vV noV pᶜ r≈t⨟p V⊒V′ =
   left-widening-inert (dual-untag-inert gG)
     vV noV pᶜ r≈t⨟p V⊒V′
 
+left-widening-applyCoercions-dual-untag-inert :
+  ∀ χs {G} →
+  Ground G →
+  Inert (- applyCoercions χs (G ？))
+left-widening-applyCoercions-dual-untag-inert χs gG =
+  subst Inert (applyCoercions-dual χs (_ ？))
+    (applyCoercions-preserves-Inert χs (dual-untag-inert gG))
+
 left-widening-unseal :
   ∀ {Δ σ V V′ p r α A A₀ B C D} →
   Value V →
@@ -909,6 +934,33 @@ left-widening-inst :
 left-widening-inst {B = B} {c = c} vV noV pᶜ r≈t⨟p V⊒V′ =
   left-widening-inert (dual-inst-inert {B = B} {c = c})
     vV noV pᶜ r≈t⨟p V⊒V′
+
+left-widening-seal-redex-package :
+  ∀ {Δ σ W V′ r A α} →
+  Value W →
+  No• (W ⟨ seal A α ⟩) →
+  Δ ∣ σ ∣ [] ⊢ W ⊒ V′ ∶ r →
+  ∃[ χs ] ∃[ U ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value U ×
+    No• U ×
+    ((W ⟨ seal A α ⟩) ⟨ - seal A α ⟩ —↠[ χs ] U) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ U ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-seal-redex-package {Δ = Δ} {W = W}
+    vW (no•-⟨⟩ noW) W⊒V′ =
+  keep ∷ [] , W , Δ , [] , [] , [] ,
+  vW ,
+  noW ,
+  ↠-step (pure-step (seal-unseal vW)) ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  W⊒V′
 
 left-widening-seq-reduction :
   ∀ {c d V} →
@@ -1167,6 +1219,138 @@ left-widening-seq-recursive-witness-package
     Π₂′≡
     π₂⊒
     U⊒V′
+
+left-widening-seq-from-seal-redex-components :
+  LeftWidening →
+  ∀ {Δ σ W V′ q r s A α E F G H} →
+  Value W →
+  No• (W ⟨ seal A α ⟩) →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ E ⊒ F →
+  Δ ∣ σ ⊢ r ≈ s ⨾ⁿ q ∶ G ⊒ H →
+  Δ ∣ σ ∣ [] ⊢ W ⊒ V′ ∶ q →
+  ∃[ χs ] ∃[ U ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value U ×
+    No• U ×
+    ((W ⟨ seal A α ⟩) ⟨ - (s ︔ seal A α) ⟩ —↠[ χs ] U) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ U ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-seq-from-seal-redex-components left-widening
+    {Δ = Δ} {σ = σ} {W = W} {V′ = V′}
+    {q = q} {r = r} {s = s} {A = A} {α = α}
+    vW (no•-⟨⟩ noW) qᶜ r≈s⨟q W⊒V′
+    with left-widening
+           {Δ = Δ} {σ = σ} {V = W} {V′ = V′}
+           {p = q} {r = r} {t = s}
+           vW
+           noW
+           qᶜ
+           r≈s⨟q
+           W⊒V′
+left-widening-seq-from-seal-redex-components left-widening
+    {Δ = Δ} {σ = σ} {W = W} {V′ = V′}
+    {q = q} {r = r} {s = s} {A = A} {α = α}
+    vW (no•-⟨⟩ noW) qᶜ r≈s⨟q W⊒V′
+    | χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Ws↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′ =
+  left-widening-seq-recursive-witness-package
+    {Δ = Δ} {σ = σ} {V = W ⟨ seal A α ⟩} {V′ = V′}
+    {c = s} {d = seal A α} {q = q} {r = r}
+    (vW ⟨ seal A α ⟩)
+    (keep ∷ [] , W , Δ , [] , [] , [] ,
+      vW ,
+      noW ,
+      ↠-step (pure-step (seal-unseal vW)) ↠-refl ,
+      refl ,
+      refl ,
+      refl ,
+      ⊒ˢ-nil ,
+      W⊒V′ ,
+      χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Ws↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′)
+
+left-widening-seq-from-untag-components :
+  LeftWidening →
+  ∀ {Δ σ V V′ p q r g G A B C D E F G₀ H} →
+  Ground G →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ E ⊒ F →
+  Δ ∣ σ ⊢ q ≈ g ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ⊢ r ≈ (G ？) ⨾ⁿ q ∶ G₀ ⊒ H →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ U ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value U ×
+    No• U ×
+    (V ⟨ - ((G ？) ︔ g) ⟩ —↠[ χs ] U) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ U ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-seq-from-untag-components left-widening
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {p = p}
+    {q = q} {r = r} {g = g} {G = G}
+    gG vV noV pᶜ qᶜ q≈g⨟p r≈untag⨟q V⊒V′
+    with left-widening
+           {Δ = Δ} {σ = σ} {V = V} {V′ = V′}
+           {p = p} {r = q} {t = g}
+           vV
+           noV
+           pᶜ
+           q≈g⨟p
+           V⊒V′
+left-widening-seq-from-untag-components left-widening
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {p = p}
+    {q = q} {r = r} {g = g} {G = G}
+    gG vV noV pᶜ qᶜ q≈g⨟p r≈untag⨟q V⊒V′
+    | χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vg↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′
+    with left-widening-inert
+           {Δ = Δ₁} {σ = combineStoreNrw π₁ σ}
+           {V = W} {V′ = applyTerms χs₁ V′}
+           {p = applyCoercions χs₁ q}
+           {r = applyCoercions χs₁ r}
+           {t = applyCoercions χs₁ (G ？)}
+           (left-widening-applyCoercions-dual-untag-inert χs₁ gG)
+           vW
+           noW
+           (left-widening-coercion-typing-transport
+             {σ = σ} {π = π₁} {χs = χs₁} {p = q}
+             qᶜ Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
+           (left-widening-compose-right-transport
+             {σ = σ} {π = π₁} {χs = χs₁}
+             {r = r} {t = G ？} {p = q}
+             r≈untag⨟q Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
+           W⊒V′
+left-widening-seq-from-untag-components left-widening
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {p = p}
+    {q = q} {r = r} {g = g} {G = G}
+    gG vV noV pᶜ qᶜ q≈g⨟p r≈untag⨟q V⊒V′
+    | χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vg↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′
+    | χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Wuntag↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′ =
+  left-widening-seq-recursive-witness-package
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′}
+    {c = G ？} {d = g} {q = q} {r = r}
+    vV
+    (χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vg↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′ ,
+      χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Wuntag↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′)
 
 left-widening-seq-from-components :
   LeftWidening →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -73,6 +73,12 @@ module proof.LeftWidening where
 --     relation witness.  A full sequence branch still needs recursive
 --     left-widening evidence for both component casts and the composition
 --     algebra relating their indices.
+--     The reusable `left-widening-compose-witnesses` proof factors the
+--     store/relation transport needed to combine two emitted source-only
+--     prefixes, following the existing algebra in `proof.Catchup`.
+--     `left-widening-seq-compose-package` combines that transport with the
+--     sequence reduction package, so the future sequence branch can focus on
+--     producing the two recursive component witnesses.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -141,7 +147,8 @@ open import Data.List using ([]; _∷_; _++_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (zero; suc; z<s)
 open import Data.Product using (_×_; _,_; proj₂; ∃-syntax)
-open import Relation.Binary.PropositionalEquality using (subst)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
@@ -167,10 +174,23 @@ open import NarrowingExamples
     ; var0-fun-narrowing
     ; wf-var-fun-endpoints
     )
-open import proof.NarrowWidenProperties using (StoreDetWf)
-open import proof.CatchupStore using (combineStoreNrw)
+open import proof.NarrowWidenProperties using (StoreDetWf; ⊒ˢ-empty-anyᵗ)
+open import proof.CatchupStore
+  using
+    ( combineStoreNrw
+    ; combineStoreNrw-assoc
+    ; combineStoreNrw-empty-⊒ˢ
+    ; combineStoreNrw-applyStores
+    )
 open import proof.ReductionProperties
-  using (applyCoercions; cast-dual-↠; ↠-trans)
+  using
+    ( applyCoercions
+    ; applyCoercions-++
+    ; applyTerms-++
+    ; applyTyCtxs-++
+    ; cast-dual-↠
+    ; ↠-trans
+    )
 open import proof.NuTermProperties
   using (open0-ext-suc-cancelᵐ; renameᵗᵐ-preserves-Value)
 open import proof.CoercionProperties using (renameᶜ-preserves-Inert)
@@ -442,6 +462,130 @@ left-widening-seq-package {Δ = Δ} {σ = σ} {V = V}
   refl ,
   π⊒ ,
   U⊒V′
+
+left-widening-compose-witnesses :
+  ∀ {Δ σ V′ r χs₁ χs₂ W₂ Δ₁ Δ₂ Π₁ Π₁′}
+    {Π₂ Π₂′ π₁ π₂} →
+  Δ₁ ≡ applyTyCtxs χs₁ Δ →
+  Π₁ ≡ applyStores χs₁ [] →
+  Π₁′ ≡ applyStore keep [] →
+  Δ₁ ⊢ π₁ ꞉ Π₁ ⊒ˢ Π₁′ →
+  Δ₂ ≡ applyTyCtxs χs₂ Δ₁ →
+  Π₂ ≡ applyStores χs₂ [] →
+  Π₂′ ≡ applyStore keep [] →
+  Δ₂ ⊢ π₂ ꞉ Π₂ ⊒ˢ Π₂′ →
+  Δ₂ ∣ combineStoreNrw π₂ (combineStoreNrw π₁ σ) ∣ []
+    ⊢ W₂ ⊒ applyTerms χs₂ (applyTerms χs₁ V′)
+      ∶ applyCoercions χs₂ (applyCoercions χs₁ r) →
+  ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    (Δ′ ≡ applyTyCtxs (χs₁ ++ χs₂) Δ) ×
+    (Π ≡ applyStores (χs₁ ++ χs₂) []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W₂ ⊒ applyTerms (χs₁ ++ χs₂) V′
+        ∶ applyCoercions (χs₁ ++ χs₂) r
+left-widening-compose-witnesses {Δ = Δ} {σ = σ} {V′ = V′}
+    {r = r} {χs₁ = χs₁} {χs₂ = χs₂} {W₂ = W₂}
+    {Δ₁ = Δ₁} {Δ₂ = Δ₂} {π₁ = π₁} {π₂ = π₂}
+    Δ₁≡ Π₁≡ Π₁′≡ π₁⊒
+    Δ₂≡ Π₂≡ Π₂′≡ π₂⊒ W₂⊒V′ =
+  Δ₂ ,
+  srcStoreⁿ (combineStoreNrw π₂ π₁) ,
+  [] ,
+  combineStoreNrw π₂ π₁ ,
+  trans Δ₂≡
+    (trans (cong (applyTyCtxs χs₂) Δ₁≡)
+      (sym (applyTyCtxs-++ χs₁ χs₂ Δ))) ,
+  combineStoreNrw-applyStores
+    {χs₂ = χs₂} {χs₁ = χs₁}
+    π₂⊒ Π₂≡ Π₂′≡ π₁⊒ Π₁≡ Π₁′≡ ,
+  refl ,
+  combineStoreNrw-empty-⊒ˢ
+    (subst (λ Π′ → _ ⊢ π₂ ꞉ _ ⊒ˢ Π′) Π₂′≡ π₂⊒)
+    (⊒ˢ-empty-anyᵗ Δ₂
+      (subst
+        (λ Π′ → _ ⊢ π₁ ꞉ _ ⊒ˢ Π′)
+        Π₁′≡
+        π₁⊒)) ,
+  subst
+    (λ c → Δ₂ ∣ combineStoreNrw (combineStoreNrw π₂ π₁) σ ∣ []
+      ⊢ W₂ ⊒ applyTerms (χs₁ ++ χs₂) V′ ∶ c)
+    (sym (applyCoercions-++ χs₁ χs₂ r))
+    (subst
+      (λ T →
+        Δ₂ ∣ combineStoreNrw (combineStoreNrw π₂ π₁) σ ∣ []
+          ⊢ W₂ ⊒ T ∶ applyCoercions χs₂ (applyCoercions χs₁ r))
+      (sym (applyTerms-++ χs₁ χs₂ V′))
+      (subst
+        (λ τ → Δ₂ ∣ τ ∣ [] ⊢ W₂
+          ⊒ applyTerms χs₂ (applyTerms χs₁ V′) ∶
+            applyCoercions χs₂ (applyCoercions χs₁ r))
+        (sym (combineStoreNrw-assoc π₂ π₁ σ))
+        W₂⊒V′))
+
+left-widening-seq-compose-package :
+  ∀ {Δ σ V V′ c d r χs₁ χs₂ W U
+      Δ₁ Δ₂ Π₁ Π₁′ Π₂ Π₂′ π₁ π₂} →
+  Value V →
+  V ⟨ - d ⟩ —↠[ χs₁ ] W →
+  W ⟨ - applyCoercions χs₁ c ⟩ —↠[ χs₂ ] U →
+  Value U →
+  No• U →
+  Δ₁ ≡ applyTyCtxs χs₁ Δ →
+  Π₁ ≡ applyStores χs₁ [] →
+  Π₁′ ≡ applyStore keep [] →
+  Δ₁ ⊢ π₁ ꞉ Π₁ ⊒ˢ Π₁′ →
+  Δ₂ ≡ applyTyCtxs χs₂ Δ₁ →
+  Π₂ ≡ applyStores χs₂ [] →
+  Π₂′ ≡ applyStore keep [] →
+  Δ₂ ⊢ π₂ ꞉ Π₂ ⊒ˢ Π₂′ →
+  Δ₂ ∣ combineStoreNrw π₂ (combineStoreNrw π₁ σ) ∣ []
+    ⊢ U ⊒ applyTerms χs₂ (applyTerms χs₁ V′)
+      ∶ applyCoercions χs₂ (applyCoercions χs₁ r) →
+  ∃[ χs″ ] ∃[ W′ ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W′ ×
+    No• W′ ×
+    (V ⟨ - (c ︔ d) ⟩ —↠[ χs″ ] W′) ×
+    (Δ′ ≡ applyTyCtxs χs″ Δ) ×
+    (Π ≡ applyStores χs″ []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W′ ⊒ applyTerms χs″ V′ ∶ applyCoercions χs″ r
+left-widening-seq-compose-package {Δ = Δ} {σ = σ} {V = V}
+    {V′ = V′} {c = c} {d = d} {r = r} {χs₁ = χs₁}
+    {χs₂ = χs₂} {W = W} {U = U} vV Vd↠W Wc↠U vU noU
+    Δ₁≡ Π₁≡ Π₁′≡ π₁⊒
+    Δ₂≡ Π₂≡ Π₂′≡ π₂⊒ U⊒V′ =
+  let
+    composed =
+      left-widening-compose-witnesses
+        {Δ = Δ} {σ = σ} {V′ = V′} {r = r}
+        {χs₁ = χs₁} {χs₂ = χs₂} {W₂ = U}
+        Δ₁≡ Π₁≡ Π₁′≡ π₁⊒
+        Δ₂≡ Π₂≡ Π₂′≡ π₂⊒ U⊒V′
+
+    Δ′ , Π , Π′ , π ,
+      Δ′≡ , Π≡ , Π′≡ , π⊒ , U⊒V′′ =
+      composed
+  in
+  keep ∷ (χs₁ ++ χs₂) ,
+  U ,
+  Δ′ ,
+  Π ,
+  Π′ ,
+  π ,
+  vU ,
+  noU ,
+  ↠-trans
+    (left-widening-seq-inner-reduction {c = c} {d = d} vV Vd↠W)
+    Wc↠U ,
+  Δ′≡ ,
+  Π≡ ,
+  Π′≡ ,
+  π⊒ ,
+  U⊒V′′
 
 left-widening-gen-reduction :
   ∀ {A c V} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -67,6 +67,12 @@ module proof.LeftWidening where
 --     For sequence variants, `dual-seq` and `left-widening-seq-prefix` factor
 --     only the initial `β-seq` step; the remaining recursive catchup/left-
 --     widening obligations are deliberately left explicit.
+--     `left-widening-seq-inner-reduction` adds the emitted-store action on
+--     the outer dual cast while the inner dual cast reduces, and
+--     `left-widening-seq-package` packages the two-stage reduction plus final
+--     relation witness.  A full sequence branch still needs recursive
+--     left-widening evidence for both component casts and the composition
+--     algebra relating their indices.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -131,7 +137,7 @@ module proof.LeftWidening where
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)
-open import Data.List using ([]; _∷_)
+open import Data.List using ([]; _∷_; _++_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (zero; suc; z<s)
 open import Data.Product using (_×_; _,_; proj₂; ∃-syntax)
@@ -163,7 +169,8 @@ open import NarrowingExamples
     )
 open import proof.NarrowWidenProperties using (StoreDetWf)
 open import proof.CatchupStore using (combineStoreNrw)
-open import proof.ReductionProperties using (applyCoercions; ↠-trans)
+open import proof.ReductionProperties
+  using (applyCoercions; cast-dual-↠; ↠-trans)
 open import proof.NuTermProperties
   using (open0-ext-suc-cancelᵐ; renameᵗᵐ-preserves-Value)
 open import proof.CoercionProperties using (renameᶜ-preserves-Inert)
@@ -384,6 +391,57 @@ left-widening-seq-prefix :
   V ⟨ - (c ︔ d) ⟩ —↠[ keep ∷ χs ] W
 left-widening-seq-prefix {c = c} {d = d} vV V↠W =
   ↠-trans (left-widening-seq-reduction {c = c} {d = d} vV) V↠W
+
+left-widening-seq-inner-reduction :
+  ∀ {c d V χs W} →
+  Value V →
+  V ⟨ - d ⟩ —↠[ χs ] W →
+  V ⟨ - (c ︔ d) ⟩ —↠[ keep ∷ χs ] W ⟨ - applyCoercions χs c ⟩
+left-widening-seq-inner-reduction {c = c} {d = d} vV Vd↠W =
+  left-widening-seq-prefix {c = c} {d = d} vV
+    (cast-dual-↠ {c = c} Vd↠W)
+
+left-widening-seq-package :
+  ∀ {Δ σ V V′ c d r χs χs′ W U π} →
+  Value V →
+  V ⟨ - d ⟩ —↠[ χs ] W →
+  W ⟨ - applyCoercions χs c ⟩ —↠[ χs′ ] U →
+  Value U →
+  No• U →
+  applyTyCtxs (keep ∷ (χs ++ χs′)) Δ
+    ⊢ π ꞉ applyStores (keep ∷ (χs ++ χs′)) []
+      ⊒ˢ applyStore keep [] →
+  applyTyCtxs (keep ∷ (χs ++ χs′)) Δ ∣ combineStoreNrw π σ ∣ []
+    ⊢ U ⊒ applyTerms (keep ∷ (χs ++ χs′)) V′
+      ∶ applyCoercions (keep ∷ (χs ++ χs′)) r →
+  ∃[ χs″ ] ∃[ W′ ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π′ ]
+    Value W′ ×
+    No• W′ ×
+    (V ⟨ - (c ︔ d) ⟩ —↠[ χs″ ] W′) ×
+    (Δ′ ≡ applyTyCtxs χs″ Δ) ×
+    (Π ≡ applyStores χs″ []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π′ ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π′ σ ∣ []
+      ⊢ W′ ⊒ applyTerms χs″ V′ ∶ applyCoercions χs″ r
+left-widening-seq-package {Δ = Δ} {σ = σ} {V = V}
+    {c = c} {d = d} {χs = χs} {χs′ = χs′} {U = U} {π = π}
+    vV Vd↠W Wc↠U vU noU π⊒ U⊒V′ =
+  keep ∷ (χs ++ χs′) ,
+  U ,
+  applyTyCtxs (keep ∷ (χs ++ χs′)) Δ ,
+  applyStores (keep ∷ (χs ++ χs′)) [] ,
+  applyStore keep [] ,
+  π ,
+  vU ,
+  noU ,
+  ↠-trans (left-widening-seq-inner-reduction {c = c} {d = d} vV Vd↠W)
+          Wc↠U ,
+  refl ,
+  refl ,
+  refl ,
+  π⊒ ,
+  U⊒V′
 
 left-widening-gen-reduction :
   ∀ {A c V} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -41,8 +41,10 @@ module proof.LeftWidening where
 --     `No• V`.
 --     A lambda value can hide a runtime bullet in its body, so the reduction
 --     reaches a stuck non-value `ν ★ V c`.
---   * After main added the `No• V` premise, this particular counterexample is
---     blocked: `badPoly-no-No•` proves the bad value cannot satisfy it.
+--   * After main added the `RuntimeOK`/`No•` premises, this particular
+--     counterexample is blocked: `badPoly-no-No•` proves the bad value cannot
+--     satisfy the `No• V` premise, and `badPoly-no-RuntimeOK` proves the same
+--     term cannot arise from a `RuntimeOK` source at value shape.
 --   * The guarded sibling of that counterexample is positive:
 --     `left-widening-ex4-gen` follows the Example 4 `gen` branch through
 --     `β-inst`, `ν-step`, and `β-Λ•`.  The bookkeeping mismatch it exposed is
@@ -57,7 +59,7 @@ module proof.LeftWidening where
 --     store-narrowing renamer and mode-renamer premise.
 --     Current progress in that direction includes `renameStoreNrw`,
 --     `renameCtxNrw`, `rename-var`, `rename-blame`, `rename-ƛ`, `rename-·`,
---     and `rename-Λ`.
+--     `rename-Λ`, `rename-⊒Λ`, `rename-κ`, and `rename-⊕`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)
@@ -354,6 +356,12 @@ badPoly-no-No• :
   ⊥
 badPoly-no-No• (no•-Λ (no•-ƛ ()))
 
+badPoly-no-RuntimeOK :
+  RuntimeOK badPoly →
+  ⊥
+badPoly-no-RuntimeOK (ok-no no-bullet) =
+  badPoly-no-No• no-bullet
+
 badInstCast-no-value :
   Value (badPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩) →
   ⊥
@@ -416,6 +424,12 @@ left-widening-counterexample-prevented :
   ⊥
 left-widening-counterexample-prevented =
   badPoly-no-No•
+
+left-widening-counterexample-prevented-runtime :
+  RuntimeOK badPoly →
+  ⊥
+left-widening-counterexample-prevented-runtime =
+  badPoly-no-RuntimeOK
 
 goodPoly : Term
 goodPoly = Λ (ƛ (` zero))

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -5,6 +5,9 @@ module proof.LeftWidening where
 --     `proof.Catchup`.
 --   * The target statement matches the current `left-widening-lemma`
 --     postulate in `proof.Catchup`.
+--   * The old statement is kept as `LeftWideningWithoutNo•` because it was
+--     false; the current statement adds the missing source/result `No•`
+--     invariants.
 --   * The proof search is kept here to avoid obscuring the larger catchup
 --     proof and to make failed strategies explicit.
 --
@@ -24,6 +27,8 @@ module proof.LeftWidening where
 --     `No• V`.
 --     A lambda value can hide a runtime bullet in its body, so the reduction
 --     reaches a stuck non-value `ν ★ V c`.
+--   * After main added the `No• V` premise, this particular counterexample is
+--     blocked: `badPoly-no-No•` proves the bad value cannot satisfy it.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)
@@ -57,8 +62,8 @@ dual-untag-inert (＇ α) = (＇ α) !
 dual-untag-inert (‵ ι) = (‵ ι) !
 dual-untag-inert ★⇒★ = (★ ⇒ ★) !
 
-LeftWidening : Set₁
-LeftWidening =
+LeftWideningWithoutNo• : Set₁
+LeftWideningWithoutNo• =
   ∀ {Δ σ V V′ p r t A B C D} →
   Value V →
   Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
@@ -74,15 +79,36 @@ LeftWidening =
     Δ′ ∣ combineStoreNrw π σ ∣ []
       ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
 
-left-widening-inert :
+LeftWidening : Set₁
+LeftWidening =
   ∀ {Δ σ V V′ p r t A B C D} →
-  Inert (- t) →
   Value V →
+  No• V →
   Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
   Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
   Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
   ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
     Value W ×
+    No• W ×
+    (V ⟨ - t ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+
+left-widening-inert :
+  ∀ {Δ σ V V′ p r t A B C D} →
+  Inert (- t) →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
     (V ⟨ - t ⟩ —↠[ χs ] W) ×
     (Δ′ ≡ applyTyCtxs χs Δ) ×
     (Π ≡ applyStores χs []) ×
@@ -91,9 +117,10 @@ left-widening-inert :
     Δ′ ∣ combineStoreNrw π σ ∣ []
       ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
 left-widening-inert {Δ = Δ} {σ = σ} {V = V} {V′ = V′}
-    {p = p} {r = r} {t = t} inert-t vV pᶜ r≈t⨟p V⊒V′ =
+    {p = p} {r = r} {t = t} inert-t vV noV pᶜ r≈t⨟p V⊒V′ =
   [] , V ⟨ - t ⟩ , Δ , [] , [] , [] ,
   vV ⟨ inert-t ⟩ ,
+  no•-⟨⟩ noV ,
   ↠-refl ,
   refl ,
   refl ,
@@ -187,16 +214,22 @@ badInstCast-no-value-after (↠-step (pure-step (β-inst badPoly-value)) steps)
 badInstCast-no-value-after (↠-step (ξ-⟨⟩ badPoly-step) steps) vW =
   ⊥-elim (badPoly-no-step badPoly-step)
 
-left-widening-counterexample :
-  LeftWidening →
+left-widening-without-No•-counterexample :
+  LeftWideningWithoutNo• →
   ⊥
-left-widening-counterexample left-widening
+left-widening-without-No•-counterexample left-widening
     with left-widening
            badPoly-value
            forall-id-var0-fun-cast
            ex1-line272-≈
            badPoly-narrow
-left-widening-counterexample left-widening
+left-widening-without-No•-counterexample left-widening
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , bad↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
   badInstCast-no-value-after bad↠W vW
+
+left-widening-counterexample-prevented :
+  No• badPoly →
+  ⊥
+left-widening-counterexample-prevented =
+  badPoly-no-No•

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -15,6 +15,8 @@ module proof.LeftWidening where
 --   * Directly reusing `cast+⊒` works only when the dual cast is inert, since
 --     then `V ⟨ - t ⟩` is already a value.  This should cover function,
 --     universal, tag, and generated-function/all inert cases.
+--     The function, universal, and tag/untag forms below are now mechanized
+--     as zero-step branches through `left-widening-inert`.
 --   * Reducing identity casts requires turning the endpoint-equivalence
 --     premise into a syntactic index equality.  The intended route is the
 --     existing mode-indexed narrowing determinacy theorem.
@@ -127,6 +129,69 @@ left-widening-inert {Δ = Δ} {σ = σ} {V = V} {V′ = V′}
   refl ,
   ⊒ˢ-nil ,
   cast+⊒ pᶜ r≈t⨟p V⊒V′
+
+left-widening-fun :
+  ∀ {Δ σ V V′ p r s t A B C D} →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ (s ↦ t) ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (V ⟨ - (s ↦ t) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-fun {s = s} {t = t} vV noV pᶜ r≈t⨟p V⊒V′ =
+  left-widening-inert ((- s) ↦ (- t)) vV noV pᶜ r≈t⨟p V⊒V′
+
+left-widening-∀ :
+  ∀ {Δ σ V V′ p r s A B C D} →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ (`∀ s) ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (V ⟨ - (`∀ s) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-∀ {s = s} vV noV pᶜ r≈t⨟p V⊒V′ =
+  left-widening-inert (`∀ (dual (extᵃ normalᵃ) s))
+    vV noV pᶜ r≈t⨟p V⊒V′
+
+left-widening-untag :
+  ∀ {Δ σ V V′ p r G A B C D} →
+  Ground G →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ (G ？) ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (V ⟨ - (G ？) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-untag gG vV noV pᶜ r≈t⨟p V⊒V′ =
+  left-widening-inert (dual-untag-inert gG)
+    vV noV pᶜ r≈t⨟p V⊒V′
 
 badBody : Term
 badBody = ƛ ((` zero) •)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -95,6 +95,19 @@ module proof.LeftWidening where
 --     `rename-extend` and `rename-split` are now mechanized in
 --     `proof.TermNarrowingProperties`, using the parallel type-renaming/opening
 --     commutation lemmas for terms and coercions.
+--   * A full pointwise theorem
+--     `M ⊒ M′ ∶ p -> renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ p`
+--     is too strong for the current relation.  The `⊒⟨ν⟩` constructor exposes
+--     the mismatch: its recursive premise renames the target value under
+--     `extᵗ ρ`, but pointwise renaming of the conclusion
+--     `V′ ⟨ gen A s ⟩` renames `V′` under plain `ρ`.  The eventual reusable
+--     theorem needs a proof-directed target translation or a more local
+--     statement for the gen/nu cases, not ordinary whole-term renaming.
+--     The useful local support lemmas from this failed attempt are now in
+--     `proof.CoercionProperties` and `proof.NuTermProperties`:
+--     `renameᶜ-reflects-Inert`, `renameᵗᵐ-reflects-Value`, and
+--     `renameᵗᵐ-reflects-No•`.  They should help peel `⇑ᵗᵐ` values and
+--     no-bullet evidence in the shifted-source inversion lemmas.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -45,6 +45,12 @@ module proof.LeftWidening where
 --     counterexample is blocked: `badPoly-no-No•` proves the bad value cannot
 --     satisfy the `No• V` premise, and `badPoly-no-RuntimeOK` proves the same
 --     term cannot arise from a `RuntimeOK` source at value shape.
+--   * The strengthened statement is still false.  A new checked
+--     counterexample uses the `seal` head and `⊒blame`: a bare constant is a
+--     `Value` and satisfies `No•`, and `⊒blame` relates it at `id α`, but
+--     casting that constant by the dual `unseal α Nat` is stuck.  The theorem
+--     `left-widening-current-seal-counterexample` derives `⊥` from any proof
+--     of the current `LeftWidening` statement.
 --   * The guarded sibling of that counterexample is positive:
 --     `left-widening-ex4-gen` follows the Example 4 `gen` branch through
 --     `β-inst`, `ν-step`, and `β-Λ•`.  The bookkeeping mismatch it exposed is
@@ -192,6 +198,7 @@ open import Relation.Binary.PropositionalEquality
 open import Types
 open import Store using (StoreIncl-drop)
 open import Coercions
+open import Primitives
 open import NuTerms
 open import NuReduction
 open import NarrowWiden
@@ -1674,6 +1681,130 @@ left-widening-id-exact {Δ = Δ} {σ = σ} {V = V}
   refl ,
   ⊒ˢ-nil ,
   V⊒V′
+
+sealBadNatTy : Ty
+sealBadNatTy = ‵ `ℕ
+
+sealBadα : TyVar
+sealBadα = 0
+
+sealBadConst : Const
+sealBadConst = κℕ 0
+
+sealBadStore : Store
+sealBadStore = (sealBadα , sealBadNatTy) ∷ []
+
+sealBadσ : StoreNrw
+sealBadσ = (sealBadα ꞉ id sealBadNatTy) ∷ []
+
+sealBadSeal : Coercion
+sealBadSeal = seal sealBadNatTy sealBadα
+
+sealBadIdα : Coercion
+sealBadIdα = id (＇ sealBadα)
+
+sealBadStoreDet : StoreDetWf 1 sealBadStore
+sealBadStoreDet =
+  record
+    { at = record
+        { bound = λ { (here refl) → z<s }
+        ; wfTy = λ { (here refl) → wfBase }
+        }
+    ; wfOlder = λ { (here refl) → wfBase }
+    ; unique = λ { (here refl) (here refl) → refl }
+    }
+
+sealBadσ⊒ : 1 ⊢ sealBadσ ꞉ sealBadStore ⊒ˢ sealBadStore
+sealBadσ⊒ =
+  ⊒ˢ-both wfBase wfBase
+    (id-onlyᵈ , (cast-id wfBase refl , cross (id-‵ `ℕ)))
+    ⊒ˢ-nil
+
+sealBadEndpoints : EndpointWf 1 sealBadStore sealBadNatTy (＇ sealBadα)
+sealBadEndpoints = wfBaseˢ , wfVarˢ (here refl)
+
+sealBadIdαᶜ :
+  1 ∣ sealBadStore ⊢ sealBadIdα ∶ᶜ ＇ sealBadα ⊒ ＇ sealBadα
+sealBadIdαᶜ =
+  cast-id (wfVar z<s) refl , cross (id-＇ sealBadα)
+
+sealBadIdα⊒ :
+  seal-or-idᵈ ∣ 1 ∣ sealBadStore
+    ⊢ sealBadIdα ∶ ＇ sealBadα ⊒ ＇ sealBadα
+sealBadIdα⊒ =
+  cast-id (wfVar z<s) refl , cross (id-＇ sealBadα)
+
+sealBadSeal⊒ :
+  seal-or-idᵈ ∣ 1 ∣ sealBadStore
+    ⊢ sealBadSeal ∶ sealBadNatTy ⊒ ＇ sealBadα
+sealBadSeal⊒ =
+  cast-seal wfBase (here refl) refl , sealⁿ sealBadNatTy sealBadα
+
+sealBadCompose :
+  1 ∣ sealBadσ ⊢ sealBadSeal ≈ sealBadSeal ⨾ⁿ sealBadIdα
+    ∶ sealBadNatTy ⊒ ＇ sealBadα
+sealBadCompose =
+  compose-rightⁿ sealBadStoreDet sealBadSeal⊒ sealBadIdα⊒
+    (endpointsⁿ refl refl refl refl
+      sealBadσ⊒
+      sealBadEndpoints
+      sealBadEndpoints
+      (seal-or-idᵈ , sealBadSeal⊒)
+      (seal-or-idᵈ ,
+        proj₂ (_⨟ⁿ_ {wfΣ = sealBadStoreDet}
+          sealBadSeal⊒ sealBadIdα⊒)))
+
+sealBadPremise :
+  1 ∣ sealBadσ ∣ [] ⊢ $ sealBadConst ⊒ blame ∶ sealBadIdα
+sealBadPremise =
+  ⊒blame sealBadIdαᶜ
+
+sealBadCast-no-value :
+  Value (($ sealBadConst) ⟨ - sealBadSeal ⟩) →
+  ⊥
+sealBadCast-no-value (($ sealBadConst) ⟨ () ⟩)
+
+sealBadConst-no-step :
+  ∀ {χ M} →
+  $ sealBadConst —→[ χ ] M →
+  ⊥
+sealBadConst-no-step (pure-step ())
+
+sealBadCast-no-step :
+  ∀ {χ M} →
+  ($ sealBadConst) ⟨ - sealBadSeal ⟩ —→[ χ ] M →
+  ⊥
+sealBadCast-no-step (pure-step ())
+sealBadCast-no-step (ξ-⟨⟩ step) =
+  sealBadConst-no-step step
+
+sealBadCast-no-value-after :
+  ∀ {χs W} →
+  ($ sealBadConst) ⟨ - sealBadSeal ⟩ —↠[ χs ] W →
+  Value W →
+  ⊥
+sealBadCast-no-value-after ↠-refl vW =
+  sealBadCast-no-value vW
+sealBadCast-no-value-after (↠-step step steps) vW =
+  ⊥-elim (sealBadCast-no-step step)
+
+left-widening-current-seal-counterexample :
+  LeftWidening →
+  ⊥
+left-widening-current-seal-counterexample left-widening
+    with left-widening
+           {Δ = 1} {σ = sealBadσ}
+           {V = $ sealBadConst} {V′ = blame}
+           {p = sealBadIdα} {r = sealBadSeal} {t = sealBadSeal}
+           ($ sealBadConst)
+           no•-$
+           sealBadIdαᶜ
+           sealBadCompose
+           sealBadPremise
+left-widening-current-seal-counterexample left-widening
+    | χs , W , Δ′ , Π , Π′ , π ,
+      vW , noW , bad↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
+  sealBadCast-no-value-after bad↠W vW
 
 badBody : Term
 badBody = ƛ ((` zero) •)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -60,6 +60,13 @@ module proof.LeftWidening where
 --     Current progress in that direction includes `renameStoreNrw`,
 --     `renameCtxNrw`, `rename-var`, `rename-blame`, `rename-ƛ`, `rename-·`,
 --     `rename-Λ`, `rename-⊒Λ`, `rename-κ`, and `rename-⊕`.
+--   * Trying to make that renaming theorem fully arbitrary runs into the
+--     composition witnesses used by cast constructors: their internal mode
+--     environment is existential, so a non-injective type renaming does not
+--     obviously preserve it.  The `suc`-specific cast cases are still
+--     mechanized in `proof.TermNarrowingProperties` via `≈ⁿ-⇑ˢ`,
+--     `compose-leftⁿ-⇑ˢ`, `compose-rightⁿ-⇑ˢ`, `shift-⊒cast+`,
+--     `shift-⊒cast-`, `shift-cast+⊒`, and `shift-cast-⊒`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -83,6 +83,10 @@ module proof.LeftWidening where
 --     branch interface directly: once the recursive witnesses for `d` and the
 --     transported `c` are produced, the remaining reduction/store bookkeeping
 --     is discharged.
+--     `left-widening-seq-from-components` adds the next layer: assuming a
+--     recursive `LeftWidening` call is available, it performs the first call
+--     for `d`, transports the typing/composition side conditions, performs the
+--     second call for `c`, and then invokes the recursive-witness package.
 --     The recursive component calls also need coercion typing transported
 --     through emitted store changes; `left-widening-coercion-typing-transport`
 --     factors the small part of `proof.Catchup`'s transport infrastructure
@@ -1163,6 +1167,82 @@ left-widening-seq-recursive-witness-package
     Π₂′≡
     π₂⊒
     U⊒V′
+
+left-widening-seq-from-components :
+  LeftWidening →
+  ∀ {Δ σ V V′ p q r c d A B C D E F G H} →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ E ⊒ F →
+  Δ ∣ σ ⊢ q ≈ d ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ⊢ r ≈ c ⨾ⁿ q ∶ G ⊒ H →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ U ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value U ×
+    No• U ×
+    (V ⟨ - (c ︔ d) ⟩ —↠[ χs ] U) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ U ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-seq-from-components left-widening
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {p = p}
+    {q = q} {r = r} {c = c} {d = d}
+    vV noV pᶜ qᶜ q≈d⨟p r≈c⨟q V⊒V′
+    with left-widening
+           {Δ = Δ} {σ = σ} {V = V} {V′ = V′}
+           {p = p} {r = q} {t = d}
+           vV
+           noV
+           pᶜ
+           q≈d⨟p
+           V⊒V′
+left-widening-seq-from-components left-widening
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {p = p}
+    {q = q} {r = r} {c = c} {d = d}
+    vV noV pᶜ qᶜ q≈d⨟p r≈c⨟q V⊒V′
+    | χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vd↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′
+    with left-widening
+           {Δ = Δ₁} {σ = combineStoreNrw π₁ σ}
+           {V = W} {V′ = applyTerms χs₁ V′}
+           {p = applyCoercions χs₁ q}
+           {r = applyCoercions χs₁ r}
+           {t = applyCoercions χs₁ c}
+           vW
+           noW
+           (left-widening-coercion-typing-transport
+             {σ = σ} {π = π₁} {χs = χs₁} {p = q}
+             qᶜ Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
+           (left-widening-compose-right-transport
+             {σ = σ} {π = π₁} {χs = χs₁}
+             {r = r} {t = c} {p = q}
+             r≈c⨟q Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
+           W⊒V′
+left-widening-seq-from-components left-widening
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {p = p}
+    {q = q} {r = r} {c = c} {d = d}
+    vV noV pᶜ qᶜ q≈d⨟p r≈c⨟q V⊒V′
+    | χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vd↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′
+    | χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Wc↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′ =
+  left-widening-seq-recursive-witness-package
+    {Δ = Δ} {σ = σ} {V = V} {V′ = V′} {c = c} {d = d}
+    {q = q} {r = r}
+    vV
+    (χs₁ , W , Δ₁ , Π₁ , Π₁′ , π₁ ,
+      vW , noW , Vd↠W , Δ₁≡ , Π₁≡ , Π₁′≡ ,
+      π₁⊒ , W⊒V′ ,
+      χs₂ , U , Δ₂ , Π₂ , Π₂′ , π₂ ,
+      vU , noU , Wc↠U , Δ₂≡ , Π₂≡ , Π₂′≡ ,
+      π₂⊒ , U⊒V′)
 
 left-widening-gen-reduction :
   ∀ {A c V} →

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -17,9 +17,18 @@ module proof.LeftWidening where
 --     universal, tag, and generated-function/all inert cases.
 --     The function, universal, and tag/untag forms below are now mechanized
 --     as zero-step branches through `left-widening-inert`.
---   * Reducing identity casts requires turning the endpoint-equivalence
---     premise into a syntactic index equality.  The intended route is the
---     existing mode-indexed narrowing determinacy theorem.
+--   * The exact identity branch, where the result index is syntactically `p`,
+--     is mechanized below by one `β-id` step.  The general identity branch
+--     still requires turning the endpoint-equivalence premise
+--     `r ≈ id A ⨾ⁿ p` into a term-narrowing derivation at `r`.  A broad
+--     `termNarrowing-resp-≈` principle was checked in
+--     `proof.LeftSealNarrowingInversion`, but it is too strong as stated:
+--     constructors such as `⊒blame` require a cast-like index, not only an
+--     endpoint-equivalent narrowing.
+--     A candidate counterexample using
+--     `(unseal α (＇ α)) ↦ (seal (＇ α) α)` also fails: the store invariant
+--     requires a seal store entry `(α , A)` to have `WfTy α A`, so the
+--     self-reference `A = ＇ α` is not well formed.
 --   * The seal/unseal and inst/gen branches are not mere congruence cases:
 --     the paper handles them with right-seal/nu-specific reasoning.  These
 --     branches are the first place to look for either a missing algebraic
@@ -34,7 +43,7 @@ module proof.LeftWidening where
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)
-open import Data.List using ([])
+open import Data.List using ([]; _∷_)
 open import Data.Nat using (zero)
 open import Data.Product using (_×_; _,_; ∃-syntax)
 
@@ -192,6 +201,34 @@ left-widening-untag :
 left-widening-untag gG vV noV pᶜ r≈t⨟p V⊒V′ =
   left-widening-inert (dual-untag-inert gG)
     vV noV pᶜ r≈t⨟p V⊒V′
+
+left-widening-id-exact :
+  ∀ {Δ σ V V′ p A C D} →
+  Value V →
+  No• V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (V ⟨ - id A ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs p
+left-widening-id-exact {Δ = Δ} {σ = σ} {V = V}
+    vV noV pᶜ V⊒V′ =
+  keep ∷ [] , V , Δ , [] , [] , [] ,
+  vV ,
+  noV ,
+  ↠-step (pure-step (β-id vV)) ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  V⊒V′
 
 badBody : Term
 badBody = ƛ ((` zero) •)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -51,6 +51,15 @@ module proof.LeftWidening where
 --     that emitted `bind` steps raise `Δ`; for now the small Example 4
 --     derivation is replayed at the raised context.  A general `gen` proof
 --     should use a reusable term-narrowing type-context weakening lemma.
+--     The common operational spine is now factored as
+--     `left-widening-gen-reduction`, and `left-widening-gen-prefix` lets later
+--     reductions from the exposed body cast be prefixed by that spine.  This
+--     removes the old counterexample's only stuck step.  The wrapper
+--     `left-widening-gen-spine-package` also factors the emitted-store
+--     existential bookkeeping once a relation for the exposed body cast is
+--     available.  These lemmas do not by themselves build that final
+--     term-narrowing relation or prove the result is a value when the exposed
+--     body cast is active rather than inert.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -117,8 +126,9 @@ open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here)
-open import Data.Nat using (zero; z<s)
+open import Data.Nat using (zero; suc; z<s)
 open import Data.Product using (_×_; _,_; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (subst)
 
 open import Types
 open import Coercions
@@ -146,7 +156,9 @@ open import NarrowingExamples
     )
 open import proof.NarrowWidenProperties using (StoreDetWf)
 open import proof.CatchupStore using (combineStoreNrw)
-open import proof.ReductionProperties using (applyCoercions)
+open import proof.ReductionProperties using (applyCoercions; ↠-trans)
+open import proof.NuTermProperties
+  using (open0-ext-suc-cancelᵐ; renameᵗᵐ-preserves-Value)
 
 dual-untag-inert :
   ∀ {G} →
@@ -165,6 +177,11 @@ dual-inst-inert :
   ∀ {B c} →
   Inert (- inst B c)
 dual-inst-inert {B = B} {c = c} = gen B (dual (instᵃ normalᵃ) c)
+
+dual-gen :
+  ∀ A c →
+  - (gen A c) ≡ inst A (dual (genᵃ normalᵃ) c)
+dual-gen A c = refl
 
 LeftWideningWithoutNo• : Set₁
 LeftWideningWithoutNo• =
@@ -337,6 +354,81 @@ left-widening-inst {B = B} {c = c} vV noV pᶜ r≈t⨟p V⊒V′ =
   left-widening-inert (dual-inst-inert {B = B} {c = c})
     vV noV pᶜ r≈t⨟p V⊒V′
 
+left-widening-gen-reduction :
+  ∀ {A c V} →
+  Value V →
+  No• V →
+  (Λ V) ⟨ - (gen A c) ⟩
+    —↠[ keep ∷ bind ★ ∷ keep ∷ [] ]
+    V ⟨ dual (genᵃ normalᵃ) c ⟩
+left-widening-gen-reduction {A = A} {c = c} {V = V} vV noV
+    rewrite dual-gen A c =
+  subst
+    (λ T →
+      (Λ V) ⟨ inst A (dual (genᵃ normalᵃ) c) ⟩
+        —↠[ keep ∷ bind ★ ∷ keep ∷ [] ]
+        T ⟨ dual (genᵃ normalᵃ) c ⟩)
+    (open0-ext-suc-cancelᵐ V)
+    (↠-step
+      (pure-step
+        (β-inst {V = Λ V} {B = A} {c = dual (genᵃ normalᵃ) c}
+          (Λ vV)))
+      (↠-step (ν-step (Λ vV) (no•-Λ noV))
+        (↠-step
+          (ξ-⟨⟩
+            (pure-step
+              (β-Λ•
+                (renameᵗᵐ-preserves-Value (extᵗ suc) vV))))
+          ↠-refl)))
+
+left-widening-gen-prefix :
+  ∀ {A c V χs W} →
+  Value V →
+  No• V →
+  V ⟨ dual (genᵃ normalᵃ) c ⟩ —↠[ χs ] W →
+  (Λ V) ⟨ - (gen A c) ⟩
+    —↠[ keep ∷ bind ★ ∷ keep ∷ χs ]
+    W
+left-widening-gen-prefix {A = A} {c = c} vV noV V↠W =
+  ↠-trans (left-widening-gen-reduction {A = A} {c = c} vV noV) V↠W
+
+left-widening-gen-spine-package :
+  ∀ {Δ σ N V′ A c r} →
+  Value N →
+  No• N →
+  Value (N ⟨ dual (genᵃ normalᵃ) c ⟩) →
+  No• (N ⟨ dual (genᵃ normalᵃ) c ⟩) →
+  suc Δ ∣ combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ ∣ []
+    ⊢ N ⟨ dual (genᵃ normalᵃ) c ⟩
+      ⊒ applyTerms (keep ∷ bind ★ ∷ keep ∷ []) V′
+      ∶ applyCoercions (keep ∷ bind ★ ∷ keep ∷ []) r →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    ((Λ N) ⟨ - (gen A c) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-gen-spine-package {Δ = Δ} {σ = σ} {N = N}
+    {A = A} {c = c} vN noN vW noW W⊒V′ =
+  keep ∷ bind ★ ∷ keep ∷ [] ,
+  N ⟨ dual (genᵃ normalᵃ) c ⟩ ,
+  suc Δ ,
+  (zero , ★) ∷ [] ,
+  [] ,
+  (⊒ zero ꞉=☆) ∷ [] ,
+  vW ,
+  noW ,
+  left-widening-gen-reduction {A = A} {c = c} vN noN ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-left ⊒ˢ-nil ,
+  W⊒V′
+
 left-widening-id-exact :
   ∀ {Δ σ V V′ p A C D} →
   Value V →
@@ -415,7 +507,7 @@ badPoly-no-RuntimeOK (ok-no no-bullet) =
   badPoly-no-No• no-bullet
 
 badInstCast-no-value :
-  Value (badPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩) →
+  Value (badPoly ⟨ - (gen (★ ⇒ ★) var0-fun) ⟩) →
   ⊥
 badInstCast-no-value (badPoly-value ⟨ () ⟩)
 
@@ -446,7 +538,7 @@ badNu-no-value-after (↠-step step steps) vW =
 
 badInstCast-no-value-after :
   ∀ {χs W} →
-  badPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩ —↠[ χs ] W →
+  badPoly ⟨ - (gen (★ ⇒ ★) var0-fun) ⟩ —↠[ χs ] W →
   Value W →
   ⊥
 badInstCast-no-value-after ↠-refl vW =
@@ -578,7 +670,7 @@ left-widening-ex4-gen :
   ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
     Value W ×
     No• W ×
-    (goodPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩ —↠[ χs ] W) ×
+    (goodPoly ⟨ - (gen (★ ⇒ ★) var0-fun) ⟩ —↠[ χs ] W) ×
     (Δ′ ≡ applyTyCtxs χs 0) ×
     (Π ≡ applyStores χs []) ×
     (Π′ ≡ applyStore keep []) ×
@@ -587,20 +679,11 @@ left-widening-ex4-gen :
       ⊢ W ⊒ applyTerms χs goodPoly
       ∶ applyCoercions χs (gen (★ ⇒ ★) var0-fun)
 left-widening-ex4-gen =
-  keep ∷ bind ★ ∷ keep ∷ [] ,
-  (ƛ (` zero)) ⟨ - star-seal-fun ⟩ ,
-  1 ,
-  (zero , ★) ∷ [] ,
-  [] ,
-  (⊒ zero ꞉=☆) ∷ [] ,
-  (ƛ (` zero)) ⟨ _ ↦ _ ⟩ ,
-  no•-⟨⟩ (no•-ƛ no•-`) ,
-  ↠-step (pure-step (β-inst goodPoly-value))
-    (↠-step (ν-step goodPoly-value goodPoly-no•)
-      (↠-step (ξ-⟨⟩ (pure-step (β-Λ• (ƛ (` zero)))))
-        ↠-refl)) ,
-  refl ,
-  refl ,
-  refl ,
-  ⊒ˢ-left ⊒ˢ-nil ,
-  ex4-after-reduction-Δ1
+  left-widening-gen-spine-package
+    {Δ = 0} {σ = []} {N = ƛ (` zero)} {V′ = goodPoly}
+    {A = ★ ⇒ ★} {c = var0-fun} {r = gen (★ ⇒ ★) var0-fun}
+    (ƛ (` zero))
+    (no•-ƛ no•-`)
+    ((ƛ (` zero)) ⟨ _ ↦ _ ⟩)
+    (no•-⟨⟩ (no•-ƛ no•-`))
+    ex4-after-reduction-Δ1

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -43,12 +43,19 @@ module proof.LeftWidening where
 --     reaches a stuck non-value `ν ★ V c`.
 --   * After main added the `No• V` premise, this particular counterexample is
 --     blocked: `badPoly-no-No•` proves the bad value cannot satisfy it.
+--   * The guarded sibling of that counterexample is positive:
+--     `left-widening-ex4-gen` follows the Example 4 `gen` branch through
+--     `β-inst`, `ν-step`, and `β-Λ•`.  The bookkeeping mismatch it exposed is
+--     that emitted `bind` steps raise `Δ`; for now the small Example 4
+--     derivation is replayed at the raised context.  A general `gen` proof
+--     should use a reusable term-narrowing type-context weakening lemma.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_)
-open import Data.Nat using (zero)
-open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.List.Relation.Unary.Any using (here)
+open import Data.Nat using (zero; z<s)
+open import Data.Product using (_×_; _,_; proj₂; ∃-syntax)
 
 open import Types
 open import Coercions
@@ -61,10 +68,20 @@ open import NarrowingExamples
   using
     ( ex1-line272-≈
     ; forall-id-var0-fun-cast
+    ; id★-cast
+    ; id★-store-narrowing
     ; id-var0-cast
     ; id-var0-fun-cast
+    ; id-var0-fun-narrowingᵐ
+    ; poly-fun-cast
+    ; star-seal-fun
+    ; star-seal-fun-narrowingᵐ
     ; var0-fun
+    ; var0-fun-cast
+    ; var0-fun-narrowing
+    ; wf-var-fun-endpoints
     )
+open import proof.NarrowWidenProperties using (StoreDetWf)
 open import proof.CatchupStore using (combineStoreNrw)
 open import proof.ReductionProperties using (applyCoercions)
 
@@ -390,3 +407,125 @@ left-widening-counterexample-prevented :
   ⊥
 left-widening-counterexample-prevented =
   badPoly-no-No•
+
+goodPoly : Term
+goodPoly = Λ (ƛ (` zero))
+
+goodPoly-value : Value goodPoly
+goodPoly-value = Λ (ƛ (` zero))
+
+goodPoly-no• : No• goodPoly
+goodPoly-no• = no•-Λ (no•-ƛ no•-`)
+
+star-store-det-2 :
+  StoreDetWf 2 ((0 , ★) ∷ [])
+star-store-det-2 =
+  record
+    { at = record
+        { bound = λ { (here refl) → z<s }
+        ; wfTy = λ { (here refl) → wf★ }
+        }
+    ; wfOlder = λ { (here refl) → wf★ }
+    ; unique = λ { (here refl) (here refl) → refl }
+    }
+
+ex4-line294-≈-Δ2 :
+  2 ∣ (0 ꞉ id ★) ∷ [] ⊢
+    var0-fun ≈ star-seal-fun ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+      ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
+ex4-line294-≈-Δ2 =
+  compose-rightⁿ star-store-det-2 star-seal-fun⊒ id-var0-fun⊒
+    (endpointsⁿ refl refl refl refl
+      id★-store-narrowing
+      wf-var-fun-endpoints
+      wf-var-fun-endpoints
+      var0-fun-narrowing
+      (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det-2}
+        star-seal-fun⊒ id-var0-fun⊒)))
+  where
+    star-seal-fun⊒ = star-seal-fun-narrowingᵐ
+
+    id-var0-fun⊒ =
+      id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl
+
+ex4-line352-Δ2 :
+  2 ∣ (0 ꞉ id ★) ∷ [] ∣ []
+    ⊢ ƛ (` 0) ⊒ ƛ (` 0)
+    ∶ id (＇ 0) ↦ id (＇ 0)
+ex4-line352-Δ2 =
+  ƛ⊒ƛ id-var0-fun-cast (x⊒x id-var0-cast Z)
+
+ex4-line353-Δ2 :
+  2 ∣ (0 ꞉ id ★) ∷ [] ∣ []
+    ⊢ (ƛ (` 0))
+        ⟨ - star-seal-fun ⟩
+      ⊒ ƛ (` 0)
+    ∶ var0-fun
+ex4-line353-Δ2 =
+  cast+⊒
+    {p = id (＇ 0) ↦ id (＇ 0)}
+    {r = var0-fun}
+    {t = star-seal-fun}
+    id-var0-fun-cast ex4-line294-≈-Δ2 ex4-line352-Δ2
+
+ex4-split-Δ2 :
+  2 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
+    ⊢ (ƛ (` 0))
+        ⟨ - ((unseal 1 ★) ↦ (seal ★ 1)) ⟩
+      ⊒ ƛ (` 0)
+    ∶ var0-fun
+ex4-split-Δ2 =
+  split
+    {N =
+      (ƛ (` 0))
+        ⟨ - star-seal-fun ⟩}
+    {N′ = ƛ (` 0)}
+    {p = var0-fun}
+    {q = id ★}
+    {A = ★}
+    {α = 0}
+    {αᵢ = 1}
+    id★-cast
+    var0-fun-cast
+    ex4-line353-Δ2
+
+ex4-after-reduction-Δ1 :
+  1 ∣ (⊒ 0 ꞉=☆) ∷ [] ∣ []
+    ⊢ (ƛ (` 0))
+        ⟨ - star-seal-fun ⟩
+      ⊒ Λ (ƛ (` 0))
+    ∶ gen (★ ⇒ ★)
+        var0-fun
+ex4-after-reduction-Δ1 =
+  ⊒Λ poly-fun-cast ex4-split-Δ2
+
+left-widening-ex4-gen :
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    (goodPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs 0) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π [] ∣ []
+      ⊢ W ⊒ applyTerms χs goodPoly
+      ∶ applyCoercions χs (gen (★ ⇒ ★) var0-fun)
+left-widening-ex4-gen =
+  keep ∷ bind ★ ∷ keep ∷ [] ,
+  (ƛ (` zero)) ⟨ - star-seal-fun ⟩ ,
+  1 ,
+  (zero , ★) ∷ [] ,
+  [] ,
+  (⊒ zero ꞉=☆) ∷ [] ,
+  (ƛ (` zero)) ⟨ _ ↦ _ ⟩ ,
+  no•-⟨⟩ (no•-ƛ no•-`) ,
+  ↠-step (pure-step (β-inst goodPoly-value))
+    (↠-step (ν-step goodPoly-value goodPoly-no•)
+      (↠-step (ξ-⟨⟩ (pure-step (β-Λ• (ƛ (` zero)))))
+        ↠-refl)) ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-left ⊒ˢ-nil ,
+  ex4-after-reduction-Δ1

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -60,6 +60,13 @@ module proof.LeftWidening where
 --     available.  These lemmas do not by themselves build that final
 --     term-narrowing relation or prove the result is a value when the exposed
 --     body cast is active rather than inert.
+--     The relation-side wrappers
+--     The `⊒Λ` and `⊒⟨ν⟩` relation-side wrappers cover the two
+--     term-narrowing constructors that can consume an inert exposed body cast;
+--     Example 4 now goes through the `⊒Λ` wrapper.
+--     For sequence variants, `dual-seq` and `left-widening-seq-prefix` factor
+--     only the initial `β-seq` step; the remaining recursive catchup/left-
+--     widening obligations are deliberately left explicit.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -159,6 +166,7 @@ open import proof.CatchupStore using (combineStoreNrw)
 open import proof.ReductionProperties using (applyCoercions; ↠-trans)
 open import proof.NuTermProperties
   using (open0-ext-suc-cancelᵐ; renameᵗᵐ-preserves-Value)
+open import proof.CoercionProperties using (renameᶜ-preserves-Inert)
 
 dual-untag-inert :
   ∀ {G} →
@@ -182,6 +190,11 @@ dual-gen :
   ∀ A c →
   - (gen A c) ≡ inst A (dual (genᵃ normalᵃ) c)
 dual-gen A c = refl
+
+dual-seq :
+  ∀ c d →
+  - (c ︔ d) ≡ (- d) ︔ (- c)
+dual-seq c d = refl
 
 LeftWideningWithoutNo• : Set₁
 LeftWideningWithoutNo• =
@@ -354,6 +367,24 @@ left-widening-inst {B = B} {c = c} vV noV pᶜ r≈t⨟p V⊒V′ =
   left-widening-inert (dual-inst-inert {B = B} {c = c})
     vV noV pᶜ r≈t⨟p V⊒V′
 
+left-widening-seq-reduction :
+  ∀ {c d V} →
+  Value V →
+  V ⟨ - (c ︔ d) ⟩
+    —↠[ keep ∷ [] ]
+    (V ⟨ - d ⟩) ⟨ - c ⟩
+left-widening-seq-reduction {c = c} {d = d} vV
+    rewrite dual-seq c d =
+  ↠-step (pure-step (β-seq vV)) ↠-refl
+
+left-widening-seq-prefix :
+  ∀ {c d V χs W} →
+  Value V →
+  (V ⟨ - d ⟩) ⟨ - c ⟩ —↠[ χs ] W →
+  V ⟨ - (c ︔ d) ⟩ —↠[ keep ∷ χs ] W
+left-widening-seq-prefix {c = c} {d = d} vV V↠W =
+  ↠-trans (left-widening-seq-reduction {c = c} {d = d} vV) V↠W
+
 left-widening-gen-reduction :
   ∀ {A c V} →
   Value V →
@@ -428,6 +459,78 @@ left-widening-gen-spine-package {Δ = Δ} {σ = σ} {N = N}
   refl ,
   ⊒ˢ-left ⊒ˢ-nil ,
   W⊒V′
+
+left-widening-gen-inert-⊒Λ-package :
+  ∀ {Δ σ N V′ A B c} →
+  Value N →
+  No• N →
+  Inert (dual (genᵃ normalᵃ) c) →
+  suc Δ ∣ srcStoreⁿ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ)
+    ⊢ gen (⇑ᵗ A) (renameᶜ (extᵗ suc) c) ∶ᶜ ⇑ᵗ A ⊒ `∀ B →
+  suc (suc Δ) ∣ (zero ꞉= ★ ⊒)
+      ∷ ⇑ˢ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ) ∣ []
+    ⊢ ⇑ᵗᵐ (N ⟨ dual (genᵃ normalᵃ) c ⟩)
+      ⊒ renameᵗᵐ (extᵗ suc) V′
+      ∶ renameᶜ (extᵗ suc) c →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    ((Λ N) ⟨ - (gen A c) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs (Λ V′)
+        ∶ applyCoercions χs (gen A c)
+left-widening-gen-inert-⊒Λ-package {Δ = Δ} {σ = σ} {N = N}
+    {V′ = V′} {A = A} {c = c} vN noN inert-c genᶜ body⊒ =
+  left-widening-gen-spine-package
+    {Δ = Δ} {σ = σ} {N = N} {V′ = Λ V′}
+    {A = A} {c = c} {r = gen A c}
+    vN
+    noN
+    (vN ⟨ inert-c ⟩)
+    (no•-⟨⟩ noN)
+    (⊒Λ genᶜ body⊒)
+
+left-widening-gen-inert-⊒⟨ν⟩-package :
+  ∀ {Δ σ N V′ A B c s} →
+  Value N →
+  No• N →
+  Inert (dual (genᵃ normalᵃ) c) →
+  Inert s →
+  suc Δ ∣ srcStoreⁿ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ)
+    ⊢ gen (⇑ᵗ A) (renameᶜ (extᵗ suc) c) ∶ᶜ ⇑ᵗ A ⊒ `∀ B →
+  suc (suc Δ) ∣ (zero ꞉= ★ ⊒)
+      ∷ ⇑ˢ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ) ∣ []
+    ⊢ ⇑ᵗᵐ (N ⟨ dual (genᵃ normalᵃ) c ⟩)
+      ⊒ ⇑ᵗᵐ V′ ⟨ renameᶜ (extᵗ suc) s ⟩
+      ∶ renameᶜ (extᵗ suc) c →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    ((Λ N) ⟨ - (gen A c) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs (V′ ⟨ gen A s ⟩)
+        ∶ applyCoercions χs (gen A c)
+left-widening-gen-inert-⊒⟨ν⟩-package
+    {Δ = Δ} {σ = σ} {N = N} {V′ = V′} {A = A} {c = c}
+    {s = s} vN noN inert-c inert-s genᶜ body⊒ =
+  left-widening-gen-spine-package
+    {Δ = Δ} {σ = σ} {N = N} {V′ = V′ ⟨ gen A s ⟩}
+    {A = A} {c = c} {r = gen A c}
+    vN
+    noN
+    (vN ⟨ inert-c ⟩)
+    (no•-⟨⟩ noN)
+    (⊒⟨ν⟩ genᶜ
+      (renameᶜ-preserves-Inert (extᵗ suc) inert-s)
+      body⊒)
 
 left-widening-id-exact :
   ∀ {Δ σ V V′ p A C D} →
@@ -679,11 +782,11 @@ left-widening-ex4-gen :
       ⊢ W ⊒ applyTerms χs goodPoly
       ∶ applyCoercions χs (gen (★ ⇒ ★) var0-fun)
 left-widening-ex4-gen =
-  left-widening-gen-spine-package
-    {Δ = 0} {σ = []} {N = ƛ (` zero)} {V′ = goodPoly}
-    {A = ★ ⇒ ★} {c = var0-fun} {r = gen (★ ⇒ ★) var0-fun}
+  left-widening-gen-inert-⊒Λ-package
+    {Δ = 0} {σ = []} {N = ƛ (` zero)} {V′ = ƛ (` zero)}
+    {A = ★ ⇒ ★} {B = ＇ zero ⇒ ＇ zero} {c = var0-fun}
     (ƛ (` zero))
     (no•-ƛ no•-`)
-    ((ƛ (` zero)) ⟨ _ ↦ _ ⟩)
-    (no•-⟨⟩ (no•-ƛ no•-`))
-    ex4-after-reduction-Δ1
+    (_ ↦ _)
+    poly-fun-cast
+    ex4-split-Δ2

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -85,7 +85,9 @@ module proof.LeftWidening where
 --     needed here without importing `proof.Catchup` and its assumptions.  The
 --     `gen`-specific wrapper
 --     `left-widening-gen-coercion-typing-transport` exposes the constructor
---     form expected by the `⊒Λ`/`⊒⟨ν⟩` package lemmas.
+--     form expected by the `⊒Λ`/`⊒⟨ν⟩` package lemmas.  The source-facing
+--     gen package wrappers compose that transport with the existing packages;
+--     Example 4 now uses the `⊒Λ` source wrapper directly.
 --   * A direct suc-only induction for that weakening lemma is the wrong
 --     formulation: under `Λ`, the body is renamed by `extᵗ suc`, not plain
 --     `suc`.  The reusable pieces started in `proof.TermNarrowingProperties`
@@ -353,6 +355,23 @@ left-widening-gen-coercion-typing-transport
         {σ = σ} {π = π} {χs = χs} {p = gen A p}
         {A = A} {B = `∀ B}
         pᶜ Δ′≡ Π≡ Π′≡ π⊒))
+
+left-widening-gen-spine-coercion-typing :
+  ∀ {Δ σ A B c} →
+  Δ ∣ srcStoreⁿ σ ⊢ gen A c ∶ᶜ A ⊒ `∀ B →
+  suc Δ ∣ srcStoreⁿ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ)
+    ⊢ gen (⇑ᵗ A) (renameᶜ (extᵗ suc) c)
+      ∶ᶜ ⇑ᵗ A
+      ⊒ `∀ (applyTysUnderTyBinders (keep ∷ bind ★ ∷ keep ∷ []) B)
+left-widening-gen-spine-coercion-typing {σ = σ} pᶜ =
+  left-widening-gen-coercion-typing-transport
+    {σ = σ}
+    {χs = keep ∷ bind ★ ∷ keep ∷ []}
+    pᶜ
+    refl
+    refl
+    refl
+    (⊒ˢ-left ⊒ˢ-nil)
 
 left-widening-inert :
   ∀ {Δ σ V V′ p r t A B C D} →
@@ -791,6 +810,41 @@ left-widening-gen-inert-⊒Λ-package {Δ = Δ} {σ = σ} {N = N}
     (no•-⟨⟩ noN)
     (⊒Λ genᶜ body⊒)
 
+left-widening-gen-inert-⊒Λ-source-package :
+  ∀ {Δ σ N V′ A B c} →
+  Value N →
+  No• N →
+  Inert (dual (genᵃ normalᵃ) c) →
+  Δ ∣ srcStoreⁿ σ ⊢ gen A c ∶ᶜ A ⊒ `∀ B →
+  suc (suc Δ) ∣ (zero ꞉= ★ ⊒)
+      ∷ ⇑ˢ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ) ∣ []
+    ⊢ ⇑ᵗᵐ (N ⟨ dual (genᵃ normalᵃ) c ⟩)
+      ⊒ renameᵗᵐ (extᵗ suc) V′
+      ∶ renameᶜ (extᵗ suc) c →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    ((Λ N) ⟨ - (gen A c) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs (Λ V′)
+        ∶ applyCoercions χs (gen A c)
+left-widening-gen-inert-⊒Λ-source-package
+    {Δ = Δ} {σ = σ} {A = A} {B = B} {c = c}
+    vN noN inert-c genᶜ body⊒ =
+  left-widening-gen-inert-⊒Λ-package
+    {Δ = Δ} {σ = σ} {A = A}
+    {B = applyTysUnderTyBinders (keep ∷ bind ★ ∷ keep ∷ []) B}
+    {c = c}
+    vN
+    noN
+    inert-c
+    (left-widening-gen-spine-coercion-typing {σ = σ} genᶜ)
+    body⊒
+
 left-widening-gen-inert-⊒⟨ν⟩-package :
   ∀ {Δ σ N V′ A B c s} →
   Value N →
@@ -828,6 +882,43 @@ left-widening-gen-inert-⊒⟨ν⟩-package
     (⊒⟨ν⟩ genᶜ
       (renameᶜ-preserves-Inert (extᵗ suc) inert-s)
       body⊒)
+
+left-widening-gen-inert-⊒⟨ν⟩-source-package :
+  ∀ {Δ σ N V′ A B c s} →
+  Value N →
+  No• N →
+  Inert (dual (genᵃ normalᵃ) c) →
+  Inert s →
+  Δ ∣ srcStoreⁿ σ ⊢ gen A c ∶ᶜ A ⊒ `∀ B →
+  suc (suc Δ) ∣ (zero ꞉= ★ ⊒)
+      ∷ ⇑ˢ (combineStoreNrw ((⊒ zero ꞉=☆) ∷ []) σ) ∣ []
+    ⊢ ⇑ᵗᵐ (N ⟨ dual (genᵃ normalᵃ) c ⟩)
+      ⊒ ⇑ᵗᵐ V′ ⟨ renameᶜ (extᵗ suc) s ⟩
+      ∶ renameᶜ (extᵗ suc) c →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    No• W ×
+    ((Λ N) ⟨ - (gen A c) ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs (V′ ⟨ gen A s ⟩)
+        ∶ applyCoercions χs (gen A c)
+left-widening-gen-inert-⊒⟨ν⟩-source-package
+    {Δ = Δ} {σ = σ} {A = A} {B = B} {c = c}
+    vN noN inert-c inert-s genᶜ body⊒ =
+  left-widening-gen-inert-⊒⟨ν⟩-package
+    {Δ = Δ} {σ = σ} {A = A}
+    {B = applyTysUnderTyBinders (keep ∷ bind ★ ∷ keep ∷ []) B}
+    {c = c}
+    vN
+    noN
+    inert-c
+    inert-s
+    (left-widening-gen-spine-coercion-typing {σ = σ} genᶜ)
+    body⊒
 
 left-widening-id-exact :
   ∀ {Δ σ V V′ p A C D} →
@@ -1079,7 +1170,7 @@ left-widening-ex4-gen :
       ⊢ W ⊒ applyTerms χs goodPoly
       ∶ applyCoercions χs (gen (★ ⇒ ★) var0-fun)
 left-widening-ex4-gen =
-  left-widening-gen-inert-⊒Λ-package
+  left-widening-gen-inert-⊒Λ-source-package
     {Δ = 0} {σ = []} {N = ƛ (` zero)} {V′ = ƛ (` zero)}
     {A = ★ ⇒ ★} {B = ＇ zero ⇒ ＇ zero} {c = var0-fun}
     (ƛ (` zero))

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -108,6 +108,10 @@ module proof.LeftWidening where
 --     `renameᶜ-reflects-Inert`, `renameᵗᵐ-reflects-Value`, and
 --     `renameᵗᵐ-reflects-No•`.  They should help peel `⇑ᵗᵐ` values and
 --     no-bullet evidence in the shifted-source inversion lemmas.
+--     `proof.ReductionProperties` now lifts those to emitted store-change
+--     actions as `applyTerms-reflects-Value`, `applyTerms-reflects-No•`,
+--     `applyTermsUnderTyBinders-reflects-Value`, and
+--     `applyTermsUnderTyBinders-reflects-No•`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥; ⊥-elim)

--- a/GTSF/proof/LeftWidening.agda
+++ b/GTSF/proof/LeftWidening.agda
@@ -1,0 +1,202 @@
+module proof.LeftWidening where
+
+-- File Charter:
+--   * Mechanized work on the GTSF Left Widening Lemma used by
+--     `proof.Catchup`.
+--   * The target statement matches the current `left-widening-lemma`
+--     postulate in `proof.Catchup`.
+--   * The proof search is kept here to avoid obscuring the larger catchup
+--     proof and to make failed strategies explicit.
+--
+-- Strategy log:
+--   * Directly reusing `cast+⊒` works only when the dual cast is inert, since
+--     then `V ⟨ - t ⟩` is already a value.  This should cover function,
+--     universal, tag, and generated-function/all inert cases.
+--   * Reducing identity casts requires turning the endpoint-equivalence
+--     premise into a syntactic index equality.  The intended route is the
+--     existing mode-indexed narrowing determinacy theorem.
+--   * The seal/unseal and inst/gen branches are not mere congruence cases:
+--     the paper handles them with right-seal/nu-specific reasoning.  These
+--     branches are the first place to look for either a missing algebraic
+--     lemma or a counterexample.
+--   * Counterexample found in the inst/gen branch: the statement assumes only
+--     `Value V`, but the `ν-step` after `β-inst` additionally needs
+--     `No• V`.
+--     A lambda value can hide a runtime bullet in its body, so the reduction
+--     reaches a stuck non-value `ν ★ V c`.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([])
+open import Data.Nat using (zero)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NuReduction
+open import NarrowWiden
+open import NarrowWidenComposition
+open import TermNarrowing
+open import NarrowingExamples
+  using
+    ( ex1-line272-≈
+    ; forall-id-var0-fun-cast
+    ; id-var0-cast
+    ; id-var0-fun-cast
+    ; var0-fun
+    )
+open import proof.CatchupStore using (combineStoreNrw)
+open import proof.ReductionProperties using (applyCoercions)
+
+dual-untag-inert :
+  ∀ {G} →
+  Ground G →
+  Inert (- (G ？))
+dual-untag-inert (＇ α) = (＇ α) !
+dual-untag-inert (‵ ι) = (‵ ι) !
+dual-untag-inert ★⇒★ = (★ ⇒ ★) !
+
+LeftWidening : Set₁
+LeftWidening =
+  ∀ {Δ σ V V′ p r t A B C D} →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    (V ⟨ - t ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+
+left-widening-inert :
+  ∀ {Δ σ V V′ p r t A B C D} →
+  Inert (- t) →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
+  ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+    Value W ×
+    (V ⟨ - t ⟩ —↠[ χs ] W) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs r
+left-widening-inert {Δ = Δ} {σ = σ} {V = V} {V′ = V′}
+    {p = p} {r = r} {t = t} inert-t vV pᶜ r≈t⨟p V⊒V′ =
+  [] , V ⟨ - t ⟩ , Δ , [] , [] , [] ,
+  vV ⟨ inert-t ⟩ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  cast+⊒ pᶜ r≈t⨟p V⊒V′
+
+badBody : Term
+badBody = ƛ ((` zero) •)
+
+badBody′ : Term
+badBody′ = ƛ blame
+
+badPoly : Term
+badPoly = Λ badBody
+
+badPoly′ : Term
+badPoly′ = Λ badBody′
+
+badBody-value : Value badBody
+badBody-value = ƛ ((` zero) •)
+
+badPoly-value : Value badPoly
+badPoly-value = Λ badBody-value
+
+badBody-narrow :
+  1 ∣ [] ∣ []
+    ⊢ badBody ⊒ badBody′
+    ∶ id (＇ 0) ↦ id (＇ 0)
+badBody-narrow =
+  ƛ⊒ƛ id-var0-fun-cast (⊒blame id-var0-cast)
+
+badPoly-narrow :
+  0 ∣ [] ∣ []
+    ⊢ badPoly ⊒ badPoly′
+    ∶ `∀ (id (＇ 0) ↦ id (＇ 0))
+badPoly-narrow =
+  Λ⊒Λ forall-id-var0-fun-cast badBody-value badBody-narrow
+
+badPoly-no-step :
+  ∀ {χ M} →
+  badPoly —→[ χ ] M →
+  ⊥
+badPoly-no-step (pure-step ())
+
+badPoly-no-No• :
+  No• badPoly →
+  ⊥
+badPoly-no-No• (no•-Λ (no•-ƛ ()))
+
+badInstCast-no-value :
+  Value (badPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩) →
+  ⊥
+badInstCast-no-value (badPoly-value ⟨ () ⟩)
+
+badNu-no-value :
+  ∀ {c} →
+  Value (ν ★ badPoly c) →
+  ⊥
+badNu-no-value ()
+
+badNu-no-step :
+  ∀ {χ M c} →
+  ν ★ badPoly c —→[ χ ] M →
+  ⊥
+badNu-no-step (ν-step badPoly-value no-bullet) =
+  badPoly-no-No• no-bullet
+badNu-no-step (ξ-ν badPoly-step) =
+  badPoly-no-step badPoly-step
+
+badNu-no-value-after :
+  ∀ {χs W c} →
+  ν ★ badPoly c —↠[ χs ] W →
+  Value W →
+  ⊥
+badNu-no-value-after ↠-refl vW =
+  badNu-no-value vW
+badNu-no-value-after (↠-step step steps) vW =
+  ⊥-elim (badNu-no-step step)
+
+badInstCast-no-value-after :
+  ∀ {χs W} →
+  badPoly ⟨ - gen (★ ⇒ ★) var0-fun ⟩ —↠[ χs ] W →
+  Value W →
+  ⊥
+badInstCast-no-value-after ↠-refl vW =
+  badInstCast-no-value vW
+badInstCast-no-value-after (↠-step (pure-step (β-inst badPoly-value)) steps)
+    vW =
+  badNu-no-value-after steps vW
+badInstCast-no-value-after (↠-step (ξ-⟨⟩ badPoly-step) steps) vW =
+  ⊥-elim (badPoly-no-step badPoly-step)
+
+left-widening-counterexample :
+  LeftWidening →
+  ⊥
+left-widening-counterexample left-widening
+    with left-widening
+           badPoly-value
+           forall-id-var0-fun-cast
+           ex1-line272-≈
+           badPoly-narrow
+left-widening-counterexample left-widening
+    | χs , W , Δ′ , Π , Π′ , π ,
+      vW , bad↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
+  badInstCast-no-value-after bad↠W vW

--- a/GTSF/proof/NuTermProperties.agda
+++ b/GTSF/proof/NuTermProperties.agda
@@ -326,6 +326,23 @@ renameᵗᵐ-preserves-Value ρ ($ κ) = $ κ
 renameᵗᵐ-preserves-Value ρ (vV ⟨ i ⟩) =
   renameᵗᵐ-preserves-Value ρ vV ⟨ renameᶜ-preserves-Inert ρ i ⟩
 
+renameᵗᵐ-reflects-Value :
+  ∀ ρ M →
+  Value (renameᵗᵐ ρ M) →
+  Value M
+renameᵗᵐ-reflects-Value ρ (` x) ()
+renameᵗᵐ-reflects-Value ρ (ƛ M) (ƛ N) = ƛ M
+renameᵗᵐ-reflects-Value ρ (L · M) ()
+renameᵗᵐ-reflects-Value ρ (Λ M) (Λ vM) =
+  Λ (renameᵗᵐ-reflects-Value (extᵗ ρ) M vM)
+renameᵗᵐ-reflects-Value ρ (M •) ()
+renameᵗᵐ-reflects-Value ρ (ν A L c) ()
+renameᵗᵐ-reflects-Value ρ ($ κ) ($ k) = $ κ
+renameᵗᵐ-reflects-Value ρ (L ⊕[ op ] M) ()
+renameᵗᵐ-reflects-Value ρ (M ⟨ c ⟩) (vM ⟨ i ⟩) =
+  renameᵗᵐ-reflects-Value ρ M vM ⟨ renameᶜ-reflects-Inert ρ c i ⟩
+renameᵗᵐ-reflects-Value ρ blame ()
+
 renameˣᵐ-preserves-Value :
   ∀ ρ {V} →
   Value V →
@@ -394,6 +411,29 @@ renameᵗᵐ-preserves-No• ρ (no•-⊕ hL hM) =
 renameᵗᵐ-preserves-No• ρ (no•-⟨⟩ hM) =
   no•-⟨⟩ (renameᵗᵐ-preserves-No• ρ hM)
 renameᵗᵐ-preserves-No• ρ no•-blame = no•-blame
+
+renameᵗᵐ-reflects-No• :
+  ∀ ρ M →
+  No• (renameᵗᵐ ρ M) →
+  No• M
+renameᵗᵐ-reflects-No• ρ (` x) no•-` = no•-`
+renameᵗᵐ-reflects-No• ρ (ƛ M) (no•-ƛ noM) =
+  no•-ƛ (renameᵗᵐ-reflects-No• ρ M noM)
+renameᵗᵐ-reflects-No• ρ (L · M) (no•-· noL noM) =
+  no•-· (renameᵗᵐ-reflects-No• ρ L noL)
+        (renameᵗᵐ-reflects-No• ρ M noM)
+renameᵗᵐ-reflects-No• ρ (Λ M) (no•-Λ noM) =
+  no•-Λ (renameᵗᵐ-reflects-No• (extᵗ ρ) M noM)
+renameᵗᵐ-reflects-No• ρ (M •) ()
+renameᵗᵐ-reflects-No• ρ (ν A L c) (no•-ν noL) =
+  no•-ν (renameᵗᵐ-reflects-No• ρ L noL)
+renameᵗᵐ-reflects-No• ρ ($ κ) no•-$ = no•-$
+renameᵗᵐ-reflects-No• ρ (L ⊕[ op ] M) (no•-⊕ noL noM) =
+  no•-⊕ (renameᵗᵐ-reflects-No• ρ L noL)
+         (renameᵗᵐ-reflects-No• ρ M noM)
+renameᵗᵐ-reflects-No• ρ (M ⟨ c ⟩) (no•-⟨⟩ noM) =
+  no•-⟨⟩ (renameᵗᵐ-reflects-No• ρ M noM)
+renameᵗᵐ-reflects-No• ρ blame no•-blame = no•-blame
 
 renameˣᵐ-preserves-No• :
   ∀ ρ {M} →

--- a/GTSF/proof/ReductionProperties.agda
+++ b/GTSF/proof/ReductionProperties.agda
@@ -33,6 +33,8 @@ open import proof.NuTermProperties
     ; renameᵗᵐ-open-commute
     ; renameᵗᵐ-preserves-Value
     ; renameᵗᵐ-preserves-No•
+    ; renameᵗᵐ-reflects-Value
+    ; renameᵗᵐ-reflects-No•
     )
 open import proof.TypeProperties using (renameᵗ-ext-suc-comm)
 
@@ -415,6 +417,23 @@ applyTerms-preserves-Value [] vV = vV
 applyTerms-preserves-Value (χ ∷ χs) vV =
   applyTerms-preserves-Value χs (applyTerm-preserves-Value χ vV)
 
+applyTerm-reflects-Value :
+  ∀ χ M →
+  Value (applyTerm χ M) →
+  Value M
+applyTerm-reflects-Value keep M vM = vM
+applyTerm-reflects-Value (bind A) M vM =
+  renameᵗᵐ-reflects-Value suc M vM
+
+applyTerms-reflects-Value :
+  ∀ χs M →
+  Value (applyTerms χs M) →
+  Value M
+applyTerms-reflects-Value [] M vM = vM
+applyTerms-reflects-Value (χ ∷ χs) M vM =
+  applyTerm-reflects-Value χ M
+    (applyTerms-reflects-Value χs (applyTerm χ M) vM)
+
 applyTerm-preserves-No• :
   ∀ χ {M} →
   No• M →
@@ -429,6 +448,23 @@ applyTerms-preserves-No• :
 applyTerms-preserves-No• [] noM = noM
 applyTerms-preserves-No• (χ ∷ χs) noM =
   applyTerms-preserves-No• χs (applyTerm-preserves-No• χ noM)
+
+applyTerm-reflects-No• :
+  ∀ χ M →
+  No• (applyTerm χ M) →
+  No• M
+applyTerm-reflects-No• keep M noM = noM
+applyTerm-reflects-No• (bind A) M noM =
+  renameᵗᵐ-reflects-No• suc M noM
+
+applyTerms-reflects-No• :
+  ∀ χs M →
+  No• (applyTerms χs M) →
+  No• M
+applyTerms-reflects-No• [] M noM = noM
+applyTerms-reflects-No• (χ ∷ χs) M noM =
+  applyTerm-reflects-No• χ M
+    (applyTerms-reflects-No• χs (applyTerm χ M) noM)
 
 applyTermUnderTyBinder : StoreChange → Term → Term
 applyTermUnderTyBinder keep M = M
@@ -475,6 +511,24 @@ applyTermsUnderTyBinders-preserves-Value (χ ∷ χs) vV =
   applyTermsUnderTyBinders-preserves-Value χs
     (applyTermUnderTyBinder-preserves-Value χ vV)
 
+applyTermUnderTyBinder-reflects-Value :
+  ∀ χ M →
+  Value (applyTermUnderTyBinder χ M) →
+  Value M
+applyTermUnderTyBinder-reflects-Value keep M vM = vM
+applyTermUnderTyBinder-reflects-Value (bind A) M vM =
+  renameᵗᵐ-reflects-Value (extᵗ suc) M vM
+
+applyTermsUnderTyBinders-reflects-Value :
+  ∀ χs M →
+  Value (applyTermsUnderTyBinders χs M) →
+  Value M
+applyTermsUnderTyBinders-reflects-Value [] M vM = vM
+applyTermsUnderTyBinders-reflects-Value (χ ∷ χs) M vM =
+  applyTermUnderTyBinder-reflects-Value χ M
+    (applyTermsUnderTyBinders-reflects-Value χs
+      (applyTermUnderTyBinder χ M) vM)
+
 applyTermUnderTyBinder-preserves-No• :
   ∀ χ {M} →
   No• M →
@@ -491,6 +545,24 @@ applyTermsUnderTyBinders-preserves-No• [] noM = noM
 applyTermsUnderTyBinders-preserves-No• (χ ∷ χs) noM =
   applyTermsUnderTyBinders-preserves-No• χs
     (applyTermUnderTyBinder-preserves-No• χ noM)
+
+applyTermUnderTyBinder-reflects-No• :
+  ∀ χ M →
+  No• (applyTermUnderTyBinder χ M) →
+  No• M
+applyTermUnderTyBinder-reflects-No• keep M noM = noM
+applyTermUnderTyBinder-reflects-No• (bind A) M noM =
+  renameᵗᵐ-reflects-No• (extᵗ suc) M noM
+
+applyTermsUnderTyBinders-reflects-No• :
+  ∀ χs M →
+  No• (applyTermsUnderTyBinders χs M) →
+  No• M
+applyTermsUnderTyBinders-reflects-No• [] M noM = noM
+applyTermsUnderTyBinders-reflects-No• (χ ∷ χs) M noM =
+  applyTermUnderTyBinder-reflects-No• χ M
+    (applyTermsUnderTyBinders-reflects-No• χs
+      (applyTermUnderTyBinder χ M) noM)
 
 applyTerms-open :
   ∀ χs M α →

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -21,6 +21,7 @@ open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing using
   ( _∣_∣_⊢_⊒_∶_
+  ; _•_
   ; ⇑ᵍ
   ; ⊒blame
   ; x⊒x
@@ -28,6 +29,12 @@ open import TermNarrowing using
   ; ·⊒·
   ; Λ⊒Λ
   ; ⊒Λ
+  ; ⊒⟨ν⟩
+  ; α⊒α
+  ; ⊒α
+  ; ν⊒ν
+  ; ⊒ν
+  ; ν⊒
   ; κ⊒κ
   ; ⊕⊒⊕
   ; ⊒cast+
@@ -38,8 +45,10 @@ open import TermNarrowing using
 open import proof.CoercionProperties
   using
     ( ModeRename
+    ; renameᶜ-preserves-Inert
     ; renameᶜ-dual-normal
     ; renameᶜ-ext-suc-comm
+    ; renameᶜ-open-commute
     ; src-renameᶜ
     ; tgt-renameᶜ
     )
@@ -110,6 +119,31 @@ renameStoreNrw-open-star-comm :
     (zero ꞉= ★ ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ)
 renameStoreNrw-open-star-comm ρ σ =
   cong ((zero ꞉= ★ ⊒) ∷_) (renameStoreNrw-ext-suc-comm ρ σ)
+
+renameStoreNrw-open-coercion-comm :
+  ∀ ρ q σ →
+  renameStoreNrw (extᵗ ρ) ((zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ) ≡
+    (zero ꞉ ⇑ᶜ (renameᶜ ρ q)) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+renameStoreNrw-open-coercion-comm ρ q σ =
+  cong₂ _∷_
+    (cong (zero ꞉_) (renameᶜ-ext-suc-comm ρ q))
+    (renameStoreNrw-ext-suc-comm ρ σ)
+
+renameStoreNrw-open-widen-comm :
+  ∀ ρ A σ →
+  renameStoreNrw (extᵗ ρ) ((zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ) ≡
+    (zero ꞉= ⇑ᵗ (renameᵗ ρ A) ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+renameStoreNrw-open-widen-comm ρ A σ =
+  cong₂ _∷_
+    (cong (λ B → zero ꞉= B ⊒) (renameᵗ-ext-suc-comm ρ A))
+    (renameStoreNrw-ext-suc-comm ρ σ)
+
+renameStoreNrw-open-left-star-comm :
+  ∀ ρ σ →
+  renameStoreNrw (extᵗ ρ) ((⊒ zero ꞉=☆) ∷ ⇑ˢ σ) ≡
+    (⊒ zero ꞉=☆) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+renameStoreNrw-open-left-star-comm ρ σ =
+  cong ((⊒ zero ꞉=☆) ∷_) (renameStoreNrw-ext-suc-comm ρ σ)
 
 renameCtxNrw-ext-suc-comm :
   ∀ ρ γ →
@@ -286,6 +320,263 @@ rename-⊒Λ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ} {N = N}
                 ⊒ renameᵗᵐ (extᵗ ρ) V′ ∶ renameᶜ (extᵗ ρ) p)
           (renameStoreNrw-open-star-comm ρ σ)
           N⊒V′)))
+
+rename-⊒⟨ν⟩ :
+  ∀ {ρ Δ Δ′ σ γ A B N V′ p s} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ gen A p ∶ᶜ A ⊒ `∀ B →
+  Inert s →
+  suc Δ′ ∣ renameStoreNrw (extᵗ ρ) ((zero ꞉= ★ ⊒) ∷ ⇑ˢ σ)
+    ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+    ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+      ⊒ renameᵗᵐ (extᵗ ρ) (V′ ⟨ s ⟩)
+      ∶ renameᶜ (extᵗ ρ) p →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ N
+      ⊒ renameᵗᵐ (extᵗ ρ) V′
+          ⟨ gen (renameᵗ ρ A) (renameᶜ (extᵗ ρ) s) ⟩
+    ∶ renameᶜ ρ (gen A p)
+rename-⊒⟨ν⟩ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {A = A} {N = N} {V′ = V′} {p = p} {s = s}
+    hρ genpᶜ inert-s N⊒V′s =
+  ⊒⟨ν⟩ (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ genpᶜ)
+    (renameᶜ-preserves-Inert (extᵗ ρ) inert-s)
+    (subst
+      (λ L →
+        suc Δ′ ∣ (zero ꞉= ★ ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+          ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+          ⊢ L ⊒ renameᵗᵐ (extᵗ ρ) (V′ ⟨ s ⟩)
+          ∶ renameᶜ (extᵗ ρ) p)
+      (renameᵗᵐ-ext-suc-comm ρ N)
+      (subst
+        (λ γ′ →
+          suc Δ′ ∣ (zero ꞉= ★ ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ) ∣ γ′
+            ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+              ⊒ renameᵗᵐ (extᵗ ρ) (V′ ⟨ s ⟩)
+              ∶ renameᶜ (extᵗ ρ) p)
+        (renameCtxNrw-ext-suc-comm ρ γ)
+        (subst
+          (λ σ′ →
+            suc Δ′ ∣ σ′ ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+              ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+                ⊒ renameᵗᵐ (extᵗ ρ) (V′ ⟨ s ⟩)
+                ∶ renameᶜ (extᵗ ρ) p)
+          (renameStoreNrw-open-star-comm ρ σ)
+          N⊒V′s)))
+
+rename-ν⊒ν :
+  ∀ {ρ Δ Δ′ σ γ A A′ B B′ N N′ p q} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ B ⊒ B′ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ A′ →
+  suc Δ′ ∣ renameStoreNrw (extᵗ ρ) ((zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ)
+    ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+    ⊢ renameᵗᵐ (extᵗ ρ) N ⊒ renameᵗᵐ (extᵗ ρ) N′
+    ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ ν (renameᵗ ρ A) (renameᵗᵐ (extᵗ ρ) N)
+        (⇑ᶜ (renameᶜ ρ p))
+      ⊒ ν (renameᵗ ρ A′) (renameᵗᵐ (extᵗ ρ) N′)
+        (⇑ᶜ (renameᶜ ρ p))
+    ∶ renameᶜ ρ p
+rename-ν⊒ν {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {N = N} {N′ = N′} {p = p} {q = q} hρ pᶜ qᶜ N⊒N′ =
+  ν⊒ν
+    (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ pᶜ)
+    (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ qᶜ)
+    (subst
+      (λ c →
+        suc Δ′ ∣ (zero ꞉ ⇑ᶜ (renameᶜ ρ q))
+          ∷ ⇑ˢ (renameStoreNrw ρ σ)
+          ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+          ⊢ renameᵗᵐ (extᵗ ρ) N ⊒ renameᵗᵐ (extᵗ ρ) N′ ∶ c)
+      (renameᶜ-ext-suc-comm ρ p)
+      (subst
+        (λ γ′ →
+          suc Δ′ ∣ (zero ꞉ ⇑ᶜ (renameᶜ ρ q))
+            ∷ ⇑ˢ (renameStoreNrw ρ σ) ∣ γ′
+            ⊢ renameᵗᵐ (extᵗ ρ) N ⊒ renameᵗᵐ (extᵗ ρ) N′
+            ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p))
+        (renameCtxNrw-ext-suc-comm ρ γ)
+        (subst
+          (λ σ′ →
+            suc Δ′ ∣ σ′ ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+              ⊢ renameᵗᵐ (extᵗ ρ) N ⊒ renameᵗᵐ (extᵗ ρ) N′
+              ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p))
+          (renameStoreNrw-open-coercion-comm ρ q σ)
+          N⊒N′)))
+
+rename-⊒ν :
+  ∀ {ρ Δ Δ′ σ γ A B B′ N N′ p} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ B ⊒ B′ →
+  suc Δ′ ∣ renameStoreNrw (extᵗ ρ)
+      ((zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ)
+    ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+    ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N) ⊒ renameᵗᵐ (extᵗ ρ) N′
+    ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ N
+      ⊒ ν (renameᵗ ρ A) (renameᵗᵐ (extᵗ ρ) N′)
+        (⇑ᶜ (renameᶜ ρ p))
+    ∶ renameᶜ ρ p
+rename-⊒ν {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {A = A} {N = N} {N′ = N′} {p = p} hρ pᶜ N⊒N′ =
+  ⊒ν (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ pᶜ)
+    (subst
+      (λ L →
+        suc Δ′ ∣ (zero ꞉= ⇑ᵗ (renameᵗ ρ A) ⊒)
+          ∷ ⇑ˢ (renameStoreNrw ρ σ)
+          ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+          ⊢ L ⊒ renameᵗᵐ (extᵗ ρ) N′
+          ∶ ⇑ᶜ (renameᶜ ρ p))
+      (renameᵗᵐ-ext-suc-comm ρ N)
+      (subst
+        (λ c →
+          suc Δ′ ∣ (zero ꞉= ⇑ᵗ (renameᵗ ρ A) ⊒)
+            ∷ ⇑ˢ (renameStoreNrw ρ σ)
+            ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+            ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+              ⊒ renameᵗᵐ (extᵗ ρ) N′ ∶ c)
+        (renameᶜ-ext-suc-comm ρ p)
+        (subst
+          (λ γ′ →
+            suc Δ′ ∣ (zero ꞉= ⇑ᵗ (renameᵗ ρ A) ⊒)
+              ∷ ⇑ˢ (renameStoreNrw ρ σ) ∣ γ′
+              ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+                ⊒ renameᵗᵐ (extᵗ ρ) N′
+              ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p))
+          (renameCtxNrw-ext-suc-comm ρ γ)
+          (subst
+            (λ σ′ →
+              suc Δ′ ∣ σ′ ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+                ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+                  ⊒ renameᵗᵐ (extᵗ ρ) N′
+                ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p))
+            (renameStoreNrw-open-widen-comm ρ A σ)
+            N⊒N′))))
+
+rename-ν⊒ :
+  ∀ {ρ Δ Δ′ σ γ N N′ p A B} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  suc Δ′ ∣ renameStoreNrw (extᵗ ρ) ((⊒ zero ꞉=☆) ∷ ⇑ˢ σ)
+    ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+    ⊢ renameᵗᵐ (extᵗ ρ) N
+      ⊒ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N′)
+    ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ ν ★ (renameᵗᵐ (extᵗ ρ) N) (⇑ᶜ (renameᶜ ρ p))
+      ⊒ renameᵗᵐ ρ N′ ∶ renameᶜ ρ p
+rename-ν⊒ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {N = N} {N′ = N′} {p = p} hρ pᶜ N⊒N′ =
+  ν⊒ (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ pᶜ)
+    (subst
+      (λ R →
+        suc Δ′ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+          ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+          ⊢ renameᵗᵐ (extᵗ ρ) N ⊒ R ∶ ⇑ᶜ (renameᶜ ρ p))
+      (renameᵗᵐ-ext-suc-comm ρ N′)
+      (subst
+        (λ c →
+          suc Δ′ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+            ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+            ⊢ renameᵗᵐ (extᵗ ρ) N
+              ⊒ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N′) ∶ c)
+        (renameᶜ-ext-suc-comm ρ p)
+        (subst
+          (λ γ′ →
+            suc Δ′ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ (renameStoreNrw ρ σ) ∣ γ′
+              ⊢ renameᵗᵐ (extᵗ ρ) N
+                ⊒ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N′)
+              ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p))
+          (renameCtxNrw-ext-suc-comm ρ γ)
+          (subst
+            (λ σ′ →
+              suc Δ′ ∣ σ′ ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+                ⊢ renameᵗᵐ (extᵗ ρ) N
+                  ⊒ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N′)
+                ∶ renameᶜ (extᵗ ρ) (⇑ᶜ p))
+            (renameStoreNrw-open-left-star-comm ρ σ)
+            N⊒N′))))
+
+rename-open-cast-srcStore :
+  ∀ {ρ Δ Δ′ σ α q p C D} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ∣ srcStoreⁿ ((ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ)
+    ⊢ renameᶜ (extᵗ ρ) p [ ρ α ]ᶜ
+    ∶ᶜ renameᵗ ρ C ⊒ renameᵗ ρ D
+rename-open-cast-srcStore {ρ = ρ} {σ = σ} {α = α} {q = q}
+    {p = p} hρ pαᶜ =
+  subst
+    (λ c → _ ∣ srcStoreⁿ ((ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ)
+      ⊢ c ∶ᶜ _ ⊒ _)
+    (renameᶜ-open-commute ρ p α)
+    (rename-cast-srcStore {ρ = ρ} {σ = (α ꞉ q) ∷ σ} hρ pαᶜ)
+
+rename-open-widen-cast-srcStore :
+  ∀ {ρ Δ Δ′ σ α A p C D} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ∣ srcStoreⁿ ((ρ α ꞉= renameᵗ ρ A ⊒) ∷ renameStoreNrw ρ σ)
+    ⊢ renameᶜ (extᵗ ρ) p [ ρ α ]ᶜ
+    ∶ᶜ renameᵗ ρ C ⊒ renameᵗ ρ D
+rename-open-widen-cast-srcStore {ρ = ρ} {σ = σ} {α = α}
+    {A = A} {p = p} hρ pαᶜ =
+  subst
+    (λ c → _ ∣ srcStoreⁿ ((ρ α ꞉= renameᵗ ρ A ⊒)
+      ∷ renameStoreNrw ρ σ) ⊢ c ∶ᶜ _ ⊒ _)
+    (renameᶜ-open-commute ρ p α)
+    (rename-cast-srcStore {ρ = ρ} {σ = (α ꞉= A ⊒) ∷ σ} hρ pαᶜ)
+
+rename-α⊒α :
+  ∀ {ρ Δ Δ′ σ γ L L′ p q A B C D α} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ B →
+  Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ L ⊒ renameᵗᵐ ρ L′
+    ∶ renameᶜ ρ (`∀ p) →
+  Δ′ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+    ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ L • ρ α ⊒ renameᵗᵐ ρ L′ • ρ α
+    ∶ renameᶜ ρ (p [ α ]ᶜ)
+rename-α⊒α {ρ = ρ} {σ = σ} {γ = γ} {L = L} {L′ = L′}
+    {p = p} {q = q} {α = α} hρ qᶜ pαᶜ L⊒L′ =
+  subst
+    (λ c → _ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+      ∣ renameCtxNrw ρ γ
+      ⊢ renameᵗᵐ ρ L • ρ α ⊒ renameᵗᵐ ρ L′ • ρ α ∶ c)
+    (sym (renameᶜ-open-commute ρ p α))
+    (α⊒α
+      (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ qᶜ)
+      (rename-open-cast-srcStore
+        {ρ = ρ} {σ = σ} {α = α} {q = q} {p = p} hρ pαᶜ)
+      L⊒L′)
+
+rename-⊒α :
+  ∀ {ρ Δ Δ′ σ γ L L′ p A B C D α} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ L ⊒ renameᵗᵐ ρ L′
+    ∶ renameᶜ ρ (gen B p) →
+  Δ′ ∣ (ρ α ꞉= renameᵗ ρ A ⊒) ∷ renameStoreNrw ρ σ
+    ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ L ⊒ renameᵗᵐ ρ L′ • ρ α
+    ∶ renameᶜ ρ (p [ α ]ᶜ)
+rename-⊒α {ρ = ρ} {σ = σ} {γ = γ} {L = L} {L′ = L′}
+    {p = p} {A = A} {α = α} hρ pαᶜ L⊒L′ =
+  subst
+    (λ c → _ ∣ (ρ α ꞉= renameᵗ ρ A ⊒) ∷ renameStoreNrw ρ σ
+      ∣ renameCtxNrw ρ γ
+      ⊢ renameᵗᵐ ρ L ⊒ renameᵗᵐ ρ L′ • ρ α ∶ c)
+    (sym (renameᶜ-open-commute ρ p α))
+    (⊒α
+      (rename-open-widen-cast-srcStore
+        {ρ = ρ} {σ = σ} {α = α} {A = A} {p = p} hρ pαᶜ)
+      L⊒L′)
 
 rename-κ :
   ∀ {ρ Δ′ σ γ κ} →

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -2,8 +2,13 @@ module proof.TermNarrowingProperties where
 
 -- File Charter:
 --   * Admissible rules and structural lemmas for term narrowing.
---   * Currently provides the two cambridge23 two-sided cast derived rules.
+--   * Provides constructor-level type-context shifting helpers and the two
+--     cambridge23 two-sided cast derived rules.
 --   * Depends on the public definitions in `TermNarrowing` and `NarrowWiden`.
+
+open import Data.List using (_∷_)
+open import Data.Nat using (suc)
+open import Relation.Binary.PropositionalEquality using (cong; subst)
 
 open import Types
 open import Coercions
@@ -11,7 +16,19 @@ open import NuTerms
 open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing using
-  (_∣_∣_⊢_⊒_∶_; ⊒cast+; ⊒cast-; cast+⊒; cast-⊒)
+  ( _∣_∣_⊢_⊒_∶_
+  ; ⇑ᵍ
+  ; ⊒blame
+  ; x⊒x
+  ; ƛ⊒ƛ
+  ; ·⊒·
+  ; ⊒cast+
+  ; ⊒cast-
+  ; cast+⊒
+  ; cast-⊒
+  )
+open import proof.CoercionProperties using (renameᶜ-dual-normal)
+open import proof.NarrowWidenProperties using (narrow-⇑ᵗ-ᶜ-srcStoreⁿ)
 
 variable
   Δ : TyCtx
@@ -20,6 +37,79 @@ variable
   A B : Ty
   p q r s t : Coercion
   M M′ : Term
+
+------------------------------------------------------------------------
+-- Type-context shifting
+------------------------------------------------------------------------
+
+lookup-⇑ᵍ :
+  ∀ {γ x p} →
+  γ ∋ x ⦂ p →
+  ⇑ᵍ γ ∋ x ⦂ ⇑ᶜ p
+lookup-⇑ᵍ Z = Z
+lookup-⇑ᵍ (S h) = S (lookup-⇑ᵍ h)
+
+shift-blame :
+  ∀ {Δ σ γ M p A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ M ⊒ blame ∶ ⇑ᶜ p
+shift-blame {σ = σ} pᶜ =
+  ⊒blame (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} pᶜ)
+
+shift-var :
+  ∀ {Δ σ γ x p A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  γ ∋ x ⦂ p →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ` x ⊒ ` x ∶ ⇑ᶜ p
+shift-var {σ = σ} pᶜ h =
+  x⊒x (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} pᶜ) (lookup-⇑ᵍ h)
+
+shift-dual-index :
+  ∀ {Δ σ γ M M′ p} →
+  suc Δ ∣ ⇑ˢ σ ∣ γ ⊢ M ⊒ M′ ∶ ⇑ᶜ (- p) →
+  suc Δ ∣ ⇑ˢ σ ∣ γ ⊢ M ⊒ M′ ∶ - ⇑ᶜ p
+shift-dual-index {Δ = Δ} {σ = σ} {γ = γ} {M = M} {M′ = M′}
+    {p = p} M⊒M′ =
+  subst (λ c → suc Δ ∣ ⇑ˢ σ ∣ γ ⊢ M ⊒ M′ ∶ c)
+    (renameᶜ-dual-normal suc p)
+    M⊒M′
+
+shift-dual-context :
+  ∀ {Δ σ γ M M′ p q} →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ ((- p) ∷ γ) ⊢ M ⊒ M′ ∶ q →
+  suc Δ ∣ ⇑ˢ σ ∣ (- ⇑ᶜ p) ∷ ⇑ᵍ γ ⊢ M ⊒ M′ ∶ q
+shift-dual-context {Δ = Δ} {σ = σ} {γ = γ} {M = M} {M′ = M′}
+    {p = p} {q = q} M⊒M′ =
+  subst (λ γ′ → suc Δ ∣ ⇑ˢ σ ∣ γ′ ⊢ M ⊒ M′ ∶ q)
+    (cong (λ c → c ∷ ⇑ᵍ γ) (renameᶜ-dual-normal suc p))
+    M⊒M′
+
+shift-ƛ :
+  ∀ {Δ σ γ N N′ p q A A′ B B′} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ ((- p) ∷ γ)
+    ⊢ ⇑ᵗᵐ N ⊒ ⇑ᵗᵐ N′ ∶ ⇑ᶜ q →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ƛ ⇑ᵗᵐ N ⊒ ƛ ⇑ᵗᵐ N′ ∶ ⇑ᶜ (p ↦ q)
+shift-ƛ {σ = σ} {p = p} p↦qᶜ N⊒N′ =
+  ƛ⊒ƛ (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} p↦qᶜ)
+    (shift-dual-context {p = p} N⊒N′)
+
+shift-· :
+  ∀ {Δ σ γ L L′ M M′ p q A B} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ L ⊒ ⇑ᵗᵐ L′ ∶ ⇑ᶜ (p ↦ q) →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ (- p) →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ L · ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ L′ · ⇑ᵗᵐ M′ ∶ ⇑ᶜ q
+shift-· {σ = σ} {p = p} qᶜ L⊒L′ M⊒M′ =
+  ·⊒· (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} qᶜ)
+    L⊒L′
+    (shift-dual-index {p = p} M⊒M′)
 
 ------------------------------------------------------------------------
 -- Derived cast rules

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -7,7 +7,7 @@ module proof.TermNarrowingProperties where
 --   * Depends on the public definitions in `TermNarrowing` and `NarrowWiden`.
 
 open import Data.List using ([]; _∷_; map)
-open import Data.Nat using (suc)
+open import Data.Nat using (zero; suc)
 open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; cong; cong₂; refl; subst; sym)
@@ -15,6 +15,7 @@ open import Relation.Binary.PropositionalEquality
 open import Types
 open import Coercions
 open import NuTerms
+open import Primitives using (Const; addℕ; constTy; constTy-renameᵗ)
 open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing using
@@ -25,6 +26,9 @@ open import TermNarrowing using
   ; ƛ⊒ƛ
   ; ·⊒·
   ; Λ⊒Λ
+  ; ⊒Λ
+  ; κ⊒κ
+  ; ⊕⊒⊕
   ; ⊒cast+
   ; ⊒cast-
   ; cast+⊒
@@ -38,7 +42,8 @@ open import proof.CoercionProperties
     ; src-renameᶜ
     )
 open import proof.NarrowWidenProperties using (narrow-⇑ᵗ-ᶜ-srcStoreⁿ)
-open import proof.NuTermProperties using (renameᵗᵐ-preserves-Value)
+open import proof.NuTermProperties
+  using (renameᵗᵐ-ext-suc-comm; renameᵗᵐ-preserves-Value)
 open import proof.TypeProperties using (TyRenameWf; renameᵗ-ext-suc-comm)
 
 variable
@@ -47,6 +52,7 @@ variable
   σ : StoreNrw
   γ : CtxNrw
   A B : Ty
+  κ : Const
   p q r s t : Coercion
   M M′ : Term
 
@@ -87,6 +93,13 @@ renameStoreNrw-ext-suc-comm ρ (entry ∷ σ) =
   cong₂ _∷_
     (renameStNrw-ext-suc-comm ρ entry)
     (renameStoreNrw-ext-suc-comm ρ σ)
+
+renameStoreNrw-open-star-comm :
+  ∀ ρ σ →
+  renameStoreNrw (extᵗ ρ) ((zero ꞉= ★ ⊒) ∷ ⇑ˢ σ) ≡
+    (zero ꞉= ★ ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+renameStoreNrw-open-star-comm ρ σ =
+  cong ((zero ꞉= ★ ⊒) ∷_) (renameStoreNrw-ext-suc-comm ρ σ)
 
 renameCtxNrw-ext-suc-comm :
   ∀ ρ γ →
@@ -229,6 +242,63 @@ rename-Λ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ} {V = V}
             ∶ renameᶜ (extᵗ ρ) p)
         (renameStoreNrw-ext-suc-comm ρ σ)
         V⊒V′))
+
+rename-⊒Λ :
+  ∀ {ρ Δ Δ′ σ γ A B N V′ p} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ gen A p ∶ᶜ A ⊒ `∀ B →
+  suc Δ′ ∣ renameStoreNrw (extᵗ ρ) ((zero ꞉= ★ ⊒) ∷ ⇑ˢ σ)
+    ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+    ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+      ⊒ renameᵗᵐ (extᵗ ρ) V′ ∶ renameᶜ (extᵗ ρ) p →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ N ⊒ Λ (renameᵗᵐ (extᵗ ρ) V′)
+    ∶ renameᶜ ρ (gen A p)
+rename-⊒Λ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ} {N = N}
+    {V′ = V′} {p = p} hρ genpᶜ N⊒V′ =
+  ⊒Λ (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ genpᶜ)
+    (subst
+      (λ L →
+        suc Δ′ ∣ (zero ꞉= ★ ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ)
+          ∣ ⇑ᵍ (renameCtxNrw ρ γ)
+          ⊢ L ⊒ renameᵗᵐ (extᵗ ρ) V′ ∶ renameᶜ (extᵗ ρ) p)
+      (renameᵗᵐ-ext-suc-comm ρ N)
+      (subst
+        (λ γ′ →
+          suc Δ′ ∣ (zero ꞉= ★ ⊒) ∷ ⇑ˢ (renameStoreNrw ρ σ) ∣ γ′
+            ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+              ⊒ renameᵗᵐ (extᵗ ρ) V′ ∶ renameᶜ (extᵗ ρ) p)
+        (renameCtxNrw-ext-suc-comm ρ γ)
+        (subst
+          (λ σ′ →
+            suc Δ′ ∣ σ′ ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+              ⊢ renameᵗᵐ (extᵗ ρ) (⇑ᵗᵐ N)
+                ⊒ renameᵗᵐ (extᵗ ρ) V′ ∶ renameᶜ (extᵗ ρ) p)
+          (renameStoreNrw-open-star-comm ρ σ)
+          N⊒V′)))
+
+rename-κ :
+  ∀ {ρ Δ′ σ γ κ} →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ $ κ ⊒ $ κ ∶ renameᶜ ρ (id (constTy κ))
+rename-κ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ} {κ = κ} =
+  subst (λ c → Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+      ⊢ $ κ ⊒ $ κ ∶ c)
+    (cong id (constTy-renameᵗ ρ κ))
+    (κ⊒κ κ)
+
+rename-⊕ :
+  ∀ {ρ Δ′ σ γ M M′ N N′} →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ (id (‵ `ℕ)) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ N ⊒ renameᵗᵐ ρ N′ ∶ renameᶜ ρ (id (‵ `ℕ)) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊕[ addℕ ] renameᵗᵐ ρ N
+      ⊒ renameᵗᵐ ρ M′ ⊕[ addℕ ] renameᵗᵐ ρ N′
+    ∶ renameᶜ ρ (id (‵ `ℕ))
+rename-⊕ M⊒M′ N⊒N′ =
+  ⊕⊒⊕ M⊒M′ N⊒N′
 
 lookup-⇑ᵍ :
   ∀ {γ x p} →

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -9,7 +9,7 @@ module proof.TermNarrowingProperties where
 
 open import Data.List using ([]; _∷_; map)
 open import Data.Nat using (zero; suc)
-open import Data.Product using (_,_; proj₂)
+open import Data.Product using (_,_; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; cong; cong₂; refl; subst; sym; trans)
 
@@ -54,7 +54,9 @@ open import proof.CoercionProperties
     )
 open import proof.NarrowWidenProperties
   using
-    ( StoreDetWf-⟰ᵗ
+    ( StoreDetWf
+    ; StoreDetWf-⟰ᵗ
+    ; WfTyˢ-rename
     ; WfTyˢ-⇑ᵗ
     ; narrowing-determinedᵐ
     ; narrow-⇑ᵗ-ᶜ-srcStoreⁿ
@@ -63,7 +65,13 @@ open import proof.NarrowWidenProperties
     )
 open import proof.NuTermProperties
   using (renameᵗᵐ-ext-suc-comm; renameᵗᵐ-preserves-Value)
-open import proof.TypeProperties using (TyRenameWf; renameᵗ-ext-suc-comm)
+open import proof.TypeProperties
+  using
+    ( TyRenameWf
+    ; TyRenameWf-ext
+    ; renameᵗ-ext-suc-comm
+    ; renameᵗ-preserves-WfTy
+    )
 
 variable
   Δ : TyCtx
@@ -83,6 +91,45 @@ modeRename-tag-or-id :
   ∀ {ρ} →
   ModeRename ρ tag-or-idᵈ tag-or-idᵈ
 modeRename-tag-or-id X = refl
+
+tailᵈ : ModeEnv → ModeEnv
+tailᵈ μ X = μ (suc X)
+
+consᵈ : Mode → ModeEnv → ModeEnv
+consᵈ m ν′ zero = m
+consᵈ m ν′ (suc X) = ν′ X
+
+AllModeRename : Renameᵗ → Set
+AllModeRename ρ = ∀ μ → ∃[ ν′ ] ModeRename ρ μ ν′
+
+allModeRename-suc :
+  AllModeRename suc
+allModeRename-suc μ = genᵈ μ , modeRename-suc-gen
+
+allModeRename-ext :
+  ∀ {ρ} →
+  AllModeRename ρ →
+  AllModeRename (extᵗ ρ)
+allModeRename-ext all μ
+    with all (tailᵈ μ)
+allModeRename-ext all μ | ν′ , rel =
+  consᵈ (μ zero) ν′ , rel′
+  where
+    rel′ : ModeRename (extᵗ _) μ (consᵈ (μ zero) ν′)
+    rel′ zero = modeIncl-refl {μ = μ} zero
+    rel′ (suc X) = rel X
+
+narrow-renameᵗ-any :
+  ∀ {ρ Δ Δ′ Σ A B c} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  Δ′ ∣ renameStoreᵗ ρ Σ
+    ⊢ renameᶜ ρ c ∶ renameᵗ ρ A ⊒ renameᵗ ρ B
+narrow-renameᵗ-any hρ all (μ , c⊒)
+    with all μ
+narrow-renameᵗ-any hρ all (μ , c⊒) | ν′ , rel =
+  ν′ , narrow-renameᵗ hρ rel c⊒
 
 renameStNrw : Renameᵗ → StNrw → StNrw
 renameStNrw ρ (X ꞉ p) = ρ X ꞉ renameᶜ ρ p
@@ -166,6 +213,113 @@ srcStoreⁿ-renameStoreNrw ρ ((X ꞉= A ⊒) ∷ σ) =
   srcStoreⁿ-renameStoreNrw ρ σ
 srcStoreⁿ-renameStoreNrw ρ ((⊒ X ꞉=☆) ∷ σ) =
   cong₂ _∷_ refl (srcStoreⁿ-renameStoreNrw ρ σ)
+
+⊒ˢ-rename :
+  ∀ {ρ Δ Δ′ σ Σ Σ′} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  Δ ⊢ σ ꞉ Σ ⊒ˢ Σ′ →
+  Δ′ ⊢ renameStoreNrw ρ σ
+    ꞉ renameStoreᵗ ρ Σ ⊒ˢ renameStoreᵗ ρ Σ′
+⊒ˢ-rename hρ all ⊒ˢ-nil = ⊒ˢ-nil
+⊒ˢ-rename {ρ = ρ} hρ all (⊒ˢ-right hA σ⊒) =
+  ⊒ˢ-right
+    (renameᵗ-preserves-WfTy hA hρ)
+    (⊒ˢ-rename hρ all σ⊒)
+⊒ˢ-rename hρ all (⊒ˢ-left σ⊒) =
+  ⊒ˢ-left (⊒ˢ-rename hρ all σ⊒)
+⊒ˢ-rename hρ all (⊒ˢ-both hA hA′ s⊒ σ⊒) =
+  ⊒ˢ-both
+    (renameᵗ-preserves-WfTy hA hρ)
+    (renameᵗ-preserves-WfTy hA′ hρ)
+    (narrow-renameᵗ-any hρ all s⊒)
+    (⊒ˢ-rename hρ all σ⊒)
+
+≈ⁿ-rename :
+  ∀ {ρ Δ Δ′ σ s t A B} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ s ≈ renameᶜ ρ t ∶ renameᵗ ρ A ⊒ renameᵗ ρ B
+≈ⁿ-rename {ρ = ρ} hρ all (endpointsⁿ {s = s} {t = t}
+    srcs tgts srct tgtt σ⊒ (hA , hB) (hA′ , hB′) s⊒ t⊒) =
+  endpointsⁿ
+    (trans (src-renameᶜ ρ s) (cong (renameᵗ ρ) srcs))
+    (trans (tgt-renameᶜ ρ s) (cong (renameᵗ ρ) tgts))
+    (trans (src-renameᶜ ρ t) (cong (renameᵗ ρ) srct))
+    (trans (tgt-renameᶜ ρ t) (cong (renameᵗ ρ) tgtt))
+    (⊒ˢ-rename hρ all σ⊒)
+    (WfTyˢ-rename hρ hA , WfTyˢ-rename hρ hB)
+    (WfTyˢ-rename hρ hA′ , WfTyˢ-rename hρ hB′)
+    (narrow-renameᵗ-any hρ all s⊒)
+    (narrow-renameᵗ-any hρ all t⊒)
+
+compose-leftⁿ-rename :
+  ∀ {ρ Δ Δ′ σ q s r A B} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  (∀ {Σ} → StoreDetWf Δ Σ → StoreDetWf Δ′ (renameStoreᵗ ρ Σ)) →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ q ⨾ⁿ renameᶜ ρ s ≈ renameᶜ ρ r
+    ∶ renameᵗ ρ A ⊒ renameᵗ ρ B
+compose-leftⁿ-rename {ρ = ρ} hρ all det
+    (compose-leftⁿ {μ = μ} wfΣ q⊒ s⊒ q⨟s≈r)
+    with all μ
+compose-leftⁿ-rename {ρ = ρ} hρ all det
+    (compose-leftⁿ {μ = μ} wfΣ q⊒ s⊒ q⨟s≈r)
+    | ν′ , rel =
+  let
+    wfΣ′ = det wfΣ
+    q⊒′ = narrow-renameᵗ {ν = ν′} {ρ = ρ} hρ rel q⊒
+    s⊒′ = narrow-renameᵗ {ν = ν′} {ρ = ρ} hρ rel s⊒
+    old = _⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒
+    new = _⨟ⁿ_ {wfΣ = wfΣ′} q⊒′ s⊒′
+    u≡ =
+      narrowing-determinedᵐ wfΣ′
+        (proj₂ new)
+        (narrow-renameᵗ {ν = ν′} {ρ = ρ} hρ rel (proj₂ old))
+    eq′ =
+      subst
+        (λ u → _ ∣ _ ⊢ u ≈ renameᶜ ρ _ ∶ _ ⊒ _)
+        (sym u≡)
+        (≈ⁿ-rename hρ all q⨟s≈r)
+  in
+  compose-leftⁿ wfΣ′ q⊒′ s⊒′ eq′
+
+compose-rightⁿ-rename :
+  ∀ {ρ Δ Δ′ σ r t p A B} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  (∀ {Σ} → StoreDetWf Δ Σ → StoreDetWf Δ′ (renameStoreᵗ ρ Σ)) →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ r ≈ renameᶜ ρ t ⨾ⁿ renameᶜ ρ p
+    ∶ renameᵗ ρ A ⊒ renameᵗ ρ B
+compose-rightⁿ-rename {ρ = ρ} hρ all det
+    (compose-rightⁿ {μ = μ} wfΣ t⊒ p⊒ r≈t⨟p)
+    with all μ
+compose-rightⁿ-rename {ρ = ρ} hρ all det
+    (compose-rightⁿ {μ = μ} wfΣ t⊒ p⊒ r≈t⨟p)
+    | ν′ , rel =
+  let
+    wfΣ′ = det wfΣ
+    t⊒′ = narrow-renameᵗ {ν = ν′} {ρ = ρ} hρ rel t⊒
+    p⊒′ = narrow-renameᵗ {ν = ν′} {ρ = ρ} hρ rel p⊒
+    old = _⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒
+    new = _⨟ⁿ_ {wfΣ = wfΣ′} t⊒′ p⊒′
+    u≡ =
+      narrowing-determinedᵐ wfΣ′
+        (proj₂ new)
+        (narrow-renameᵗ {ν = ν′} {ρ = ρ} hρ rel (proj₂ old))
+    eq′ =
+      subst
+        (λ u → _ ∣ _ ⊢ renameᶜ ρ _ ≈ u ∶ _ ⊒ _)
+        (sym u≡)
+        (≈ⁿ-rename hρ all r≈t⨟p)
+  in
+  compose-rightⁿ wfΣ′ t⊒′ p⊒′ eq′
 
 lookup-renameCtxNrw :
   ∀ ρ {γ x p} →
@@ -600,6 +754,87 @@ rename-⊕ :
     ∶ renameᶜ ρ (id (‵ `ℕ))
 rename-⊕ M⊒M′ N⊒N′ =
   ⊕⊒⊕ M⊒M′ N⊒N′
+
+rename-⊒cast+ :
+  ∀ {ρ Δ Δ′ σ γ M M′ q r s A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ q ⨾ⁿ renameᶜ ρ s ≈ renameᶜ ρ r
+    ∶ renameᵗ ρ A ⊒ renameᵗ ρ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (M′ ⟨ - s ⟩) ∶ renameᶜ ρ q
+rename-⊒cast+ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {M = M} {M′ = M′} {q = q} {s = s} hρ qᶜ q⨟s≈r M⊒M′ =
+  subst
+    (λ T → Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+      ⊢ renameᵗᵐ ρ M ⊒ T ∶ renameᶜ ρ q)
+    (sym (cong (λ c → renameᵗᵐ ρ M′ ⟨ c ⟩)
+               (renameᶜ-dual-normal ρ s)))
+    (⊒cast+
+      (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ qᶜ)
+      q⨟s≈r
+      M⊒M′)
+
+rename-⊒cast- :
+  ∀ {ρ Δ Δ′ σ γ M M′ q r s A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ q ⨾ⁿ renameᶜ ρ s ≈ renameᶜ ρ r
+    ∶ renameᵗ ρ A ⊒ renameᵗ ρ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ q →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (M′ ⟨ s ⟩) ∶ renameᶜ ρ r
+rename-⊒cast- {ρ = ρ} {σ = σ} hρ qᶜ q⨟s≈r M⊒M′ =
+  ⊒cast-
+    (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ qᶜ)
+    q⨟s≈r
+    M⊒M′
+
+rename-cast+⊒ :
+  ∀ {ρ Δ Δ′ σ γ M M′ p r t A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ r ≈ renameᶜ ρ t ⨾ⁿ renameᶜ ρ p
+    ∶ renameᵗ ρ A ⊒ renameᵗ ρ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ p →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ (M ⟨ - t ⟩) ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r
+rename-cast+⊒ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {M = M} {M′ = M′} {p = p} {r = r} {t = t}
+    hρ pᶜ r≈t⨟p M⊒M′ =
+  subst
+    (λ T → Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+      ⊢ T ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r)
+    (sym (cong (λ c → renameᵗᵐ ρ M ⟨ c ⟩)
+               (renameᶜ-dual-normal ρ t)))
+    (cast+⊒
+      (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ pᶜ)
+      r≈t⨟p
+      M⊒M′)
+
+rename-cast-⊒ :
+  ∀ {ρ Δ Δ′ σ γ M M′ p r t A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ′ ∣ renameStoreNrw ρ σ
+    ⊢ renameᶜ ρ r ≈ renameᶜ ρ t ⨾ⁿ renameᶜ ρ p
+    ∶ renameᵗ ρ A ⊒ renameᵗ ρ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ (M ⟨ t ⟩) ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ p
+rename-cast-⊒ {ρ = ρ} {σ = σ} hρ pᶜ r≈t⨟p M⊒M′ =
+  cast-⊒
+    (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ pᶜ)
+    r≈t⨟p
+    M⊒M′
 
 lookup-⇑ᵍ :
   ∀ {γ x p} →

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -2,15 +2,16 @@ module proof.TermNarrowingProperties where
 
 -- File Charter:
 --   * Admissible rules and structural lemmas for term narrowing.
---   * Provides constructor-level type-context shifting helpers and the two
---     cambridge23 two-sided cast derived rules.
+--   * Provides constructor-level type-context shifting helpers, composition
+--     shifting for cast side conditions, and the two cambridge23 two-sided
+--     cast derived rules.
 --   * Depends on the public definitions in `TermNarrowing` and `NarrowWiden`.
 
 open import Data.List using ([]; _∷_; map)
 open import Data.Nat using (zero; suc)
-open import Data.Product using (_,_)
+open import Data.Product using (_,_; proj₂)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; cong; cong₂; refl; subst; sym)
+  using (_≡_; cong; cong₂; refl; subst; sym; trans)
 
 open import Types
 open import Coercions
@@ -40,8 +41,17 @@ open import proof.CoercionProperties
     ; renameᶜ-dual-normal
     ; renameᶜ-ext-suc-comm
     ; src-renameᶜ
+    ; tgt-renameᶜ
     )
-open import proof.NarrowWidenProperties using (narrow-⇑ᵗ-ᶜ-srcStoreⁿ)
+open import proof.NarrowWidenProperties
+  using
+    ( StoreDetWf-⟰ᵗ
+    ; WfTyˢ-⇑ᵗ
+    ; narrowing-determinedᵐ
+    ; narrow-⇑ᵗ-ᶜ-srcStoreⁿ
+    ; narrow-⇑ᵗ-any
+    ; ⊒ˢ-⇑ˢ
+    )
 open import proof.NuTermProperties
   using (renameᵗᵐ-ext-suc-comm; renameᵗᵐ-preserves-Value)
 open import proof.TypeProperties using (TyRenameWf; renameᵗ-ext-suc-comm)
@@ -368,6 +378,127 @@ shift-· {σ = σ} {p = p} qᶜ L⊒L′ M⊒M′ =
   ·⊒· (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} qᶜ)
     L⊒L′
     (shift-dual-index {p = p} M⊒M′)
+
+≈ⁿ-⇑ˢ :
+  ∀ {Δ σ s t A B} →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ⊢ ⇑ᶜ s ≈ ⇑ᶜ t ∶ ⇑ᵗ A ⊒ ⇑ᵗ B
+≈ⁿ-⇑ˢ (endpointsⁿ {s = s} {t = t}
+    srcs tgts srct tgtt σ⊒ (hA , hB) (hA′ , hB′) s⊒ t⊒) =
+  endpointsⁿ
+    (trans (src-renameᶜ suc s) (cong ⇑ᵗ srcs))
+    (trans (tgt-renameᶜ suc s) (cong ⇑ᵗ tgts))
+    (trans (src-renameᶜ suc t) (cong ⇑ᵗ srct))
+    (trans (tgt-renameᶜ suc t) (cong ⇑ᵗ tgtt))
+    (⊒ˢ-⇑ˢ σ⊒)
+    (WfTyˢ-⇑ᵗ hA , WfTyˢ-⇑ᵗ hB)
+    (WfTyˢ-⇑ᵗ hA′ , WfTyˢ-⇑ᵗ hB′)
+    (narrow-⇑ᵗ-any s⊒)
+    (narrow-⇑ᵗ-any t⊒)
+
+compose-leftⁿ-⇑ˢ :
+  ∀ {Δ σ q s r A B} →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ⊢ ⇑ᶜ q ⨾ⁿ ⇑ᶜ s ≈ ⇑ᶜ r ∶ ⇑ᵗ A ⊒ ⇑ᵗ B
+compose-leftⁿ-⇑ˢ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
+  let
+    q⊒′ = narrow-⇑ᵗ-gen q⊒
+    s⊒′ = narrow-⇑ᵗ-gen s⊒
+    old = _⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒
+    new = _⨟ⁿ_ {wfΣ = StoreDetWf-⟰ᵗ wfΣ} q⊒′ s⊒′
+    u≡ =
+      narrowing-determinedᵐ (StoreDetWf-⟰ᵗ wfΣ)
+        (proj₂ new)
+        (narrow-⇑ᵗ-gen (proj₂ old))
+    eq′ =
+      subst
+        (λ u → _ ∣ _ ⊢ u ≈ ⇑ᶜ _ ∶ _ ⊒ _)
+        (sym u≡)
+        (≈ⁿ-⇑ˢ q⨟s≈r)
+  in
+  compose-leftⁿ (StoreDetWf-⟰ᵗ wfΣ) q⊒′ s⊒′ eq′
+
+compose-rightⁿ-⇑ˢ :
+  ∀ {Δ σ r t p A B} →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ⊢ ⇑ᶜ r ≈ ⇑ᶜ t ⨾ⁿ ⇑ᶜ p ∶ ⇑ᵗ A ⊒ ⇑ᵗ B
+compose-rightⁿ-⇑ˢ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
+  let
+    t⊒′ = narrow-⇑ᵗ-gen t⊒
+    p⊒′ = narrow-⇑ᵗ-gen p⊒
+    old = _⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒
+    new = _⨟ⁿ_ {wfΣ = StoreDetWf-⟰ᵗ wfΣ} t⊒′ p⊒′
+    u≡ =
+      narrowing-determinedᵐ (StoreDetWf-⟰ᵗ wfΣ)
+        (proj₂ new)
+        (narrow-⇑ᵗ-gen (proj₂ old))
+    eq′ =
+      subst
+        (λ u → _ ∣ _ ⊢ ⇑ᶜ _ ≈ u ∶ _ ⊒ _)
+        (sym u≡)
+        (≈ⁿ-⇑ˢ r≈t⨟p)
+  in
+  compose-rightⁿ (StoreDetWf-⟰ᵗ wfΣ) t⊒′ p⊒′ eq′
+
+shift-⊒cast+ :
+  ∀ {Δ σ γ M M′ q r s A B C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ r →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ (M′ ⟨ - s ⟩) ∶ ⇑ᶜ q
+shift-⊒cast+ {Δ = Δ} {σ = σ} {γ = γ} {M = M} {M′ = M′}
+    {q = q} {s = s} qᶜ q⨟s≈r M⊒M′ =
+  subst
+    (λ T → suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ ⇑ᵗᵐ M ⊒ T ∶ ⇑ᶜ q)
+    (sym (cong (λ c → ⇑ᵗᵐ M′ ⟨ c ⟩) (renameᶜ-dual-normal suc s)))
+    (⊒cast+
+      (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} qᶜ)
+      (compose-leftⁿ-⇑ˢ q⨟s≈r)
+      M⊒M′)
+
+shift-⊒cast- :
+  ∀ {Δ σ γ M M′ q r s A B C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ q →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ (M′ ⟨ s ⟩) ∶ ⇑ᶜ r
+shift-⊒cast- {σ = σ} qᶜ q⨟s≈r M⊒M′ =
+  ⊒cast-
+    (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} qᶜ)
+    (compose-leftⁿ-⇑ˢ q⨟s≈r)
+    M⊒M′
+
+shift-cast+⊒ :
+  ∀ {Δ σ γ M M′ p r t A B C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ p →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ (M ⟨ - t ⟩) ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ r
+shift-cast+⊒ {Δ = Δ} {σ = σ} {γ = γ} {M = M} {M′ = M′}
+    {p = p} {r = r} {t = t} pᶜ r≈t⨟p M⊒M′ =
+  subst
+    (λ T → suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ T ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ r)
+    (sym (cong (λ c → ⇑ᵗᵐ M ⟨ c ⟩) (renameᶜ-dual-normal suc t)))
+    (cast+⊒
+      (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} pᶜ)
+      (compose-rightⁿ-⇑ˢ r≈t⨟p)
+      M⊒M′)
+
+shift-cast-⊒ :
+  ∀ {Δ σ γ M M′ p r t A B C D} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ ⇑ᵗᵐ M ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ r →
+  suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ ⇑ᵗᵐ (M ⟨ t ⟩) ⊒ ⇑ᵗᵐ M′ ∶ ⇑ᶜ p
+shift-cast-⊒ {σ = σ} pᶜ r≈t⨟p M⊒M′ =
+  cast-⊒
+    (narrow-⇑ᵗ-ᶜ-srcStoreⁿ {σ = σ} pᶜ)
+    (compose-rightⁿ-⇑ˢ r≈t⨟p)
+    M⊒M′
 
 ------------------------------------------------------------------------
 -- Derived cast rules

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -5,11 +5,15 @@ module proof.TermNarrowingProperties where
 --   * Provides constructor-level type-context shifting helpers, composition
 --     shifting for cast side conditions, and the two cambridge23 two-sided
 --     cast derived rules.
+--   * Includes the store-determinacy transport needed by composition renaming
+--     under strict/injective type renamings.
 --   * Depends on the public definitions in `TermNarrowing` and `NarrowWiden`.
 
 open import Data.List using ([]; _∷_; map)
-open import Data.Nat using (zero; suc)
-open import Data.Product using (_,_; proj₂; ∃-syntax)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (_<_; zero; suc; z<s; s<s)
+open import Data.Product using (_×_; _,_; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; cong; cong₂; refl; subst; sym; trans)
 
@@ -65,10 +69,16 @@ open import proof.NarrowWidenProperties
     )
 open import proof.NuTermProperties
   using (renameᵗᵐ-ext-suc-comm; renameᵗᵐ-preserves-Value)
+open import proof.StoreProperties using (StoreWfAt-rename)
 open import proof.TypeProperties
   using
-    ( TyRenameWf
+    ( RenameLeftInverse
+    ; RenameLeftInverse-ext-suc-pred
+    ; RenameLeftInverse-suc
+    ; TyRenameWf
     ; TyRenameWf-ext
+    ; TyRenameWf-suc
+    ; predᵗ
     ; renameᵗ-ext-suc-comm
     ; renameᵗ-preserves-WfTy
     )
@@ -91,6 +101,39 @@ modeRename-tag-or-id :
   ∀ {ρ} →
   ModeRename ρ tag-or-idᵈ tag-or-idᵈ
 modeRename-tag-or-id X = refl
+
+TyRenameStrict : Renameᵗ → Set
+TyRenameStrict ρ = ∀ {X Y} → X < Y → ρ X < ρ Y
+
+TyRenameStrict-suc :
+  TyRenameStrict suc
+TyRenameStrict-suc X<Y = s<s X<Y
+
+TyRenameStrict-ext :
+  ∀ {ρ} →
+  TyRenameStrict ρ →
+  TyRenameStrict (extᵗ ρ)
+TyRenameStrict-ext strict {zero} {zero} ()
+TyRenameStrict-ext strict {zero} {suc Y} z<s = z<s
+TyRenameStrict-ext strict {suc X} {zero} ()
+TyRenameStrict-ext strict {suc X} {suc Y} (s<s X<Y) =
+  s<s (strict X<Y)
+
+TyRenameWf-ext-suc :
+  ∀ {Δ} →
+  TyRenameWf Δ (suc Δ) (extᵗ suc)
+TyRenameWf-ext-suc {Δ = zero} ()
+TyRenameWf-ext-suc {Δ = suc Δ} {zero} z<s = z<s
+TyRenameWf-ext-suc {Δ = suc Δ} {suc X} (s<s X<Δ) =
+  s<s (TyRenameWf-suc X<Δ)
+
+rename-injective :
+  ∀ {ρ ψ X Y} →
+  RenameLeftInverse ρ ψ →
+  ρ X ≡ ρ Y →
+  X ≡ Y
+rename-injective {ρ = ρ} {ψ = ψ} {X = X} {Y = Y} inv eq =
+  trans (sym (inv X)) (trans (cong ψ eq) (inv Y))
 
 tailᵈ : ModeEnv → ModeEnv
 tailᵈ μ X = μ (suc X)
@@ -214,6 +257,76 @@ srcStoreⁿ-renameStoreNrw ρ ((X ꞉= A ⊒) ∷ σ) =
 srcStoreⁿ-renameStoreNrw ρ ((⊒ X ꞉=☆) ∷ σ) =
   cong₂ _∷_ refl (srcStoreⁿ-renameStoreNrw ρ σ)
 
+renameStoreᵗ-inv :
+  ∀ ρ {Σ β B} →
+  (β , B) ∈ renameStoreᵗ ρ Σ →
+  ∃[ α ] ∃[ A ] (β ≡ ρ α × B ≡ renameᵗ ρ A × (α , A) ∈ Σ)
+renameStoreᵗ-inv ρ {Σ = (α , A) ∷ Σ} (here refl) =
+  α , A , refl , refl , here refl
+renameStoreᵗ-inv ρ {Σ = (α , A) ∷ Σ} (there h)
+    with renameStoreᵗ-inv ρ h
+renameStoreᵗ-inv ρ {Σ = (α , A) ∷ Σ} (there h)
+    | β , B , eqβ , eqB , mem =
+  β , B , eqβ , eqB , there mem
+
+StoreDetWf-rename :
+  ∀ {ρ ψ Δ Δ′ Σ} →
+  TyRenameWf Δ Δ′ ρ →
+  TyRenameStrict ρ →
+  RenameLeftInverse ρ ψ →
+  StoreDetWf Δ Σ →
+  StoreDetWf Δ′ (renameStoreᵗ ρ Σ)
+StoreDetWf-rename {ρ = ρ} {ψ = ψ} hρ strict inv wfΣ =
+  record
+    { at = StoreWfAt-rename hρ (StoreDetWf.at wfΣ)
+    ; wfOlder = wfOlder′
+    ; unique = unique′
+    }
+  where
+    wfOlder′ :
+      ∀ {β B} →
+      (β , B) ∈ renameStoreᵗ ρ _ →
+      WfTy β B
+    wfOlder′ {β = β} {B = B} h
+        with renameStoreᵗ-inv ρ h
+    wfOlder′ {β = β} {B = B} h
+        | α , A , eqβ , eqB , mem =
+      subst (λ X → WfTy X B) (sym eqβ)
+        (subst (WfTy (ρ α)) (sym eqB)
+          (renameᵗ-preserves-WfTy (StoreDetWf.wfOlder wfΣ mem)
+            (λ X<α → strict X<α)))
+
+    unique′ :
+      ∀ {β A B} →
+      (β , A) ∈ renameStoreᵗ ρ _ →
+      (β , B) ∈ renameStoreᵗ ρ _ →
+      A ≡ B
+    unique′ h₁ h₂
+        with renameStoreᵗ-inv ρ h₁ | renameStoreᵗ-inv ρ h₂
+    unique′ h₁ h₂
+        | α₁ , A₁ , eqβ₁ , eqA₁ , mem₁
+        | α₂ , A₂ , eqβ₂ , eqA₂ , mem₂ =
+      trans eqA₁
+        (trans
+          (cong (renameᵗ ρ)
+            (StoreDetWf.unique wfΣ mem₁
+              (subst (λ X → (X , A₂) ∈ _) (sym α₁≡α₂) mem₂)))
+          (sym eqA₂))
+      where
+        α₁≡α₂ : α₁ ≡ α₂
+        α₁≡α₂ =
+          rename-injective {ψ = ψ} inv (trans (sym eqβ₁) eqβ₂)
+
+StoreDetWf-ext-suc :
+  ∀ {Δ Σ} →
+  StoreDetWf Δ Σ →
+  StoreDetWf (suc Δ) (renameStoreᵗ (extᵗ suc) Σ)
+StoreDetWf-ext-suc =
+  StoreDetWf-rename {ρ = extᵗ suc} {ψ = predᵗ}
+    TyRenameWf-ext-suc
+    (TyRenameStrict-ext TyRenameStrict-suc)
+    RenameLeftInverse-ext-suc-pred
+
 ⊒ˢ-rename :
   ∀ {ρ Δ Δ′ σ Σ Σ′} →
   TyRenameWf Δ Δ′ ρ →
@@ -320,6 +433,41 @@ compose-rightⁿ-rename {ρ = ρ} hρ all det
         (≈ⁿ-rename hρ all r≈t⨟p)
   in
   compose-rightⁿ wfΣ′ t⊒′ p⊒′ eq′
+
+≈ⁿ-ext-suc :
+  ∀ {Δ σ s t A B} →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊒ B →
+  suc Δ ∣ renameStoreNrw (extᵗ suc) σ
+    ⊢ renameᶜ (extᵗ suc) s ≈ renameᶜ (extᵗ suc) t
+    ∶ renameᵗ (extᵗ suc) A ⊒ renameᵗ (extᵗ suc) B
+≈ⁿ-ext-suc =
+  ≈ⁿ-rename TyRenameWf-ext-suc (allModeRename-ext allModeRename-suc)
+
+compose-leftⁿ-ext-suc :
+  ∀ {Δ σ q s r A B} →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  suc Δ ∣ renameStoreNrw (extᵗ suc) σ
+    ⊢ renameᶜ (extᵗ suc) q ⨾ⁿ renameᶜ (extᵗ suc) s
+      ≈ renameᶜ (extᵗ suc) r
+    ∶ renameᵗ (extᵗ suc) A ⊒ renameᵗ (extᵗ suc) B
+compose-leftⁿ-ext-suc =
+  compose-leftⁿ-rename
+    TyRenameWf-ext-suc
+    (allModeRename-ext allModeRename-suc)
+    StoreDetWf-ext-suc
+
+compose-rightⁿ-ext-suc :
+  ∀ {Δ σ r t p A B} →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  suc Δ ∣ renameStoreNrw (extᵗ suc) σ
+    ⊢ renameᶜ (extᵗ suc) r
+      ≈ renameᶜ (extᵗ suc) t ⨾ⁿ renameᶜ (extᵗ suc) p
+    ∶ renameᵗ (extᵗ suc) A ⊒ renameᵗ (extᵗ suc) B
+compose-rightⁿ-ext-suc =
+  compose-rightⁿ-rename
+    TyRenameWf-ext-suc
+    (allModeRename-ext allModeRename-suc)
+    StoreDetWf-ext-suc
 
 lookup-renameCtxNrw :
   ∀ ρ {γ x p} →
@@ -834,6 +982,70 @@ rename-cast-⊒ {ρ = ρ} {σ = σ} hρ pᶜ r≈t⨟p M⊒M′ =
   cast-⊒
     (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ pᶜ)
     r≈t⨟p
+    M⊒M′
+
+rename-⊒cast+-det :
+  ∀ {ρ Δ Δ′ σ γ M M′ q r s A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  (∀ {Σ} → StoreDetWf Δ Σ → StoreDetWf Δ′ (renameStoreᵗ ρ Σ)) →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (M′ ⟨ - s ⟩) ∶ renameᶜ ρ q
+rename-⊒cast+-det hρ all det qᶜ q⨟s≈r M⊒M′ =
+  rename-⊒cast+ hρ qᶜ
+    (compose-leftⁿ-rename hρ all det q⨟s≈r)
+    M⊒M′
+
+rename-⊒cast--det :
+  ∀ {ρ Δ Δ′ σ γ M M′ q r s A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  (∀ {Σ} → StoreDetWf Δ Σ → StoreDetWf Δ′ (renameStoreᵗ ρ Σ)) →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ q →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (M′ ⟨ s ⟩) ∶ renameᶜ ρ r
+rename-⊒cast--det hρ all det qᶜ q⨟s≈r M⊒M′ =
+  rename-⊒cast- hρ qᶜ
+    (compose-leftⁿ-rename hρ all det q⨟s≈r)
+    M⊒M′
+
+rename-cast+⊒-det :
+  ∀ {ρ Δ Δ′ σ γ M M′ p r t A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  (∀ {Σ} → StoreDetWf Δ Σ → StoreDetWf Δ′ (renameStoreᵗ ρ Σ)) →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ p →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ (M ⟨ - t ⟩) ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r
+rename-cast+⊒-det hρ all det pᶜ r≈t⨟p M⊒M′ =
+  rename-cast+⊒ hρ pᶜ
+    (compose-rightⁿ-rename hρ all det r≈t⨟p)
+    M⊒M′
+
+rename-cast-⊒-det :
+  ∀ {ρ Δ Δ′ σ γ M M′ p r t A B C D} →
+  TyRenameWf Δ Δ′ ρ →
+  AllModeRename ρ →
+  (∀ {Σ} → StoreDetWf Δ Σ → StoreDetWf Δ′ (renameStoreᵗ ρ Σ)) →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ r →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ (M ⟨ t ⟩) ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ p
+rename-cast-⊒-det hρ all det pᶜ r≈t⨟p M⊒M′ =
+  rename-cast-⊒ hρ pᶜ
+    (compose-rightⁿ-rename hρ all det r≈t⨟p)
     M⊒M′
 
 lookup-⇑ᵍ :

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -27,6 +27,8 @@ open import TermNarrowing using
   ( _∣_∣_⊢_⊒_∶_
   ; _•_
   ; ⇑ᵍ
+  ; extend
+  ; split
   ; ⊒blame
   ; x⊒x
   ; ƛ⊒ƛ
@@ -68,7 +70,11 @@ open import proof.NarrowWidenProperties
     ; ⊒ˢ-⇑ˢ
     )
 open import proof.NuTermProperties
-  using (renameᵗᵐ-ext-suc-comm; renameᵗᵐ-preserves-Value)
+  using
+    ( renameᵗᵐ-ext-suc-comm
+    ; renameᵗᵐ-open-commute
+    ; renameᵗᵐ-preserves-Value
+    )
 open import proof.StoreProperties using (StoreWfAt-rename)
 open import proof.TypeProperties
   using
@@ -831,6 +837,114 @@ rename-open-widen-cast-srcStore {ρ = ρ} {σ = σ} {α = α}
       ∷ renameStoreNrw ρ σ) ⊢ c ∶ᶜ _ ⊒ _)
     (renameᶜ-open-commute ρ p α)
     (rename-cast-srcStore {ρ = ρ} {σ = (α ꞉= A ⊒) ∷ σ} hρ pαᶜ)
+
+rename-extend :
+  ∀ {ρ Δ Δ′ σ γ M N′ p q A B C D α} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A →
+  Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ∣ (ρ α ꞉= renameᵗ ρ A ⊒) ∷ renameStoreNrw ρ σ
+    ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ)
+    ∶ renameᶜ ρ (p [ α ]ᶜ) →
+  Δ′ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+    ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ)
+    ∶ renameᶜ ρ (p [ α ]ᶜ)
+rename-extend {ρ = ρ} {σ = σ} {γ = γ} {M = M} {N′ = N′}
+    {p = p} {q = q} {A = A} {α = α} hρ qᶜ pαᶜ M⊒N′ =
+  subst
+    (λ T → _ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+      ∣ renameCtxNrw ρ γ
+      ⊢ renameᵗᵐ ρ M ⊒ T ∶ renameᶜ ρ (p [ α ]ᶜ))
+    (sym (renameᵗᵐ-open-commute ρ N′ α))
+    (subst
+      (λ c → _ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+        ∣ renameCtxNrw ρ γ
+        ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ (extᵗ ρ) N′ [ ρ α ]ᵀ
+        ∶ c)
+      (sym (renameᶜ-open-commute ρ p α))
+      (extend
+        (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ qᶜ)
+        (rename-open-cast-srcStore
+          {ρ = ρ} {σ = σ} {α = α} {q = q} {p = p} hρ pαᶜ)
+        (subst
+          (λ T → _ ∣ (ρ α ꞉= renameᵗ ρ A ⊒) ∷ renameStoreNrw ρ σ
+            ∣ renameCtxNrw ρ γ
+            ⊢ renameᵗᵐ ρ M ⊒ T
+            ∶ renameᶜ (extᵗ ρ) p [ ρ α ]ᶜ)
+          (renameᵗᵐ-open-commute ρ N′ α)
+          (subst
+            (λ c → _ ∣ (ρ α ꞉= renameᵗ ρ A ⊒)
+              ∷ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+              ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ) ∶ c)
+            (renameᶜ-open-commute ρ p α)
+            M⊒N′))))
+
+rename-split :
+  ∀ {ρ Δ Δ′ σ γ N N′ p q A C D α αᵢ} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ)
+    ⊢ q ∶ᶜ ★ ⊒ A →
+  Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ)
+    ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D →
+  Δ′ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+    ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ (N [ α ]ᵀ) ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ)
+    ∶ renameᶜ ρ (p [ α ]ᶜ) →
+  Δ′ ∣ (ρ α ꞉= renameᵗ ρ A ⊒)
+      ∷ (⊒ ρ αᵢ ꞉=☆) ∷ renameStoreNrw ρ σ
+    ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ (N [ αᵢ ]ᵀ) ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ)
+    ∶ renameᶜ ρ (p [ α ]ᶜ)
+rename-split {ρ = ρ} {σ = σ} {γ = γ} {N = N} {N′ = N′}
+    {p = p} {q = q} {A = A} {α = α} {αᵢ = αᵢ} hρ qᶜ pαᶜ N⊒N′ =
+  subst
+    (λ S → _ ∣ (ρ α ꞉= renameᵗ ρ A ⊒)
+        ∷ (⊒ ρ αᵢ ꞉=☆) ∷ renameStoreNrw ρ σ
+      ∣ renameCtxNrw ρ γ
+      ⊢ S ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ) ∶ renameᶜ ρ (p [ α ]ᶜ))
+    (sym (renameᵗᵐ-open-commute ρ N αᵢ))
+    (subst
+      (λ T → _ ∣ (ρ α ꞉= renameᵗ ρ A ⊒)
+          ∷ (⊒ ρ αᵢ ꞉=☆) ∷ renameStoreNrw ρ σ
+        ∣ renameCtxNrw ρ γ
+        ⊢ renameᵗᵐ (extᵗ ρ) N [ ρ αᵢ ]ᵀ ⊒ T
+        ∶ renameᶜ ρ (p [ α ]ᶜ))
+      (sym (renameᵗᵐ-open-commute ρ N′ α))
+      (subst
+        (λ c → _ ∣ (ρ α ꞉= renameᵗ ρ A ⊒)
+            ∷ (⊒ ρ αᵢ ꞉=☆) ∷ renameStoreNrw ρ σ
+          ∣ renameCtxNrw ρ γ
+          ⊢ renameᵗᵐ (extᵗ ρ) N [ ρ αᵢ ]ᵀ
+            ⊒ renameᵗᵐ (extᵗ ρ) N′ [ ρ α ]ᵀ ∶ c)
+        (sym (renameᶜ-open-commute ρ p α))
+        (split
+          (rename-cast-srcStore
+            {ρ = ρ} {σ = (α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ}
+            hρ qᶜ)
+          (rename-open-widen-cast-srcStore
+            {ρ = ρ} {σ = (⊒ αᵢ ꞉=☆) ∷ σ} {α = α}
+            {A = A} {p = p} hρ pαᶜ)
+          (subst
+            (λ T → _ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+              ∣ renameCtxNrw ρ γ
+              ⊢ renameᵗᵐ (extᵗ ρ) N [ ρ α ]ᵀ ⊒ T
+              ∶ renameᶜ (extᵗ ρ) p [ ρ α ]ᶜ)
+            (renameᵗᵐ-open-commute ρ N′ α)
+            (subst
+              (λ S → _ ∣ (ρ α ꞉ renameᶜ ρ q) ∷ renameStoreNrw ρ σ
+                ∣ renameCtxNrw ρ γ
+                ⊢ S ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ)
+                ∶ renameᶜ (extᵗ ρ) p [ ρ α ]ᶜ)
+              (renameᵗᵐ-open-commute ρ N α)
+              (subst
+                (λ c → _ ∣ (ρ α ꞉ renameᶜ ρ q)
+                  ∷ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+                  ⊢ renameᵗᵐ ρ (N [ α ]ᵀ)
+                    ⊒ renameᵗᵐ ρ (N′ [ α ]ᵀ) ∶ c)
+                (renameᶜ-open-commute ρ p α)
+                N⊒N′))))))
 
 rename-α⊒α :
   ∀ {ρ Δ Δ′ σ γ L L′ p q A B C D α} →

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -6,9 +6,11 @@ module proof.TermNarrowingProperties where
 --     cambridge23 two-sided cast derived rules.
 --   * Depends on the public definitions in `TermNarrowing` and `NarrowWiden`.
 
-open import Data.List using (_∷_)
+open import Data.List using ([]; _∷_; map)
 open import Data.Nat using (suc)
-open import Relation.Binary.PropositionalEquality using (cong; subst)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; cong; cong₂; refl; subst; sym)
 
 open import Types
 open import Coercions
@@ -22,16 +24,26 @@ open import TermNarrowing using
   ; x⊒x
   ; ƛ⊒ƛ
   ; ·⊒·
+  ; Λ⊒Λ
   ; ⊒cast+
   ; ⊒cast-
   ; cast+⊒
   ; cast-⊒
   )
-open import proof.CoercionProperties using (renameᶜ-dual-normal)
+open import proof.CoercionProperties
+  using
+    ( ModeRename
+    ; renameᶜ-dual-normal
+    ; renameᶜ-ext-suc-comm
+    ; src-renameᶜ
+    )
 open import proof.NarrowWidenProperties using (narrow-⇑ᵗ-ᶜ-srcStoreⁿ)
+open import proof.NuTermProperties using (renameᵗᵐ-preserves-Value)
+open import proof.TypeProperties using (TyRenameWf; renameᵗ-ext-suc-comm)
 
 variable
   Δ : TyCtx
+  Δ′ : TyCtx
   σ : StoreNrw
   γ : CtxNrw
   A B : Ty
@@ -41,6 +53,182 @@ variable
 ------------------------------------------------------------------------
 -- Type-context shifting
 ------------------------------------------------------------------------
+
+modeRename-tag-or-id :
+  ∀ {ρ} →
+  ModeRename ρ tag-or-idᵈ tag-or-idᵈ
+modeRename-tag-or-id X = refl
+
+renameStNrw : Renameᵗ → StNrw → StNrw
+renameStNrw ρ (X ꞉ p) = ρ X ꞉ renameᶜ ρ p
+renameStNrw ρ (X ꞉= A ⊒) = ρ X ꞉= renameᵗ ρ A ⊒
+renameStNrw ρ (⊒ X ꞉=☆) = ⊒ ρ X ꞉=☆
+
+renameStoreNrw : Renameᵗ → StoreNrw → StoreNrw
+renameStoreNrw ρ σ = map (renameStNrw ρ) σ
+
+renameCtxNrw : Renameᵗ → CtxNrw → CtxNrw
+renameCtxNrw ρ γ = map (renameᶜ ρ) γ
+
+renameStNrw-ext-suc-comm :
+  ∀ ρ entry →
+  renameStNrw (extᵗ ρ) (⇑ʷ entry) ≡ ⇑ʷ (renameStNrw ρ entry)
+renameStNrw-ext-suc-comm ρ (X ꞉ p) =
+  cong (λ c → suc (ρ X) ꞉ c) (renameᶜ-ext-suc-comm ρ p)
+renameStNrw-ext-suc-comm ρ (X ꞉= A ⊒) =
+  cong (λ B → suc (ρ X) ꞉= B ⊒) (renameᵗ-ext-suc-comm ρ A)
+renameStNrw-ext-suc-comm ρ (⊒ X ꞉=☆) = refl
+
+renameStoreNrw-ext-suc-comm :
+  ∀ ρ σ →
+  renameStoreNrw (extᵗ ρ) (⇑ˢ σ) ≡ ⇑ˢ (renameStoreNrw ρ σ)
+renameStoreNrw-ext-suc-comm ρ [] = refl
+renameStoreNrw-ext-suc-comm ρ (entry ∷ σ) =
+  cong₂ _∷_
+    (renameStNrw-ext-suc-comm ρ entry)
+    (renameStoreNrw-ext-suc-comm ρ σ)
+
+renameCtxNrw-ext-suc-comm :
+  ∀ ρ γ →
+  renameCtxNrw (extᵗ ρ) (⇑ᵍ γ) ≡ ⇑ᵍ (renameCtxNrw ρ γ)
+renameCtxNrw-ext-suc-comm ρ [] = refl
+renameCtxNrw-ext-suc-comm ρ (p ∷ γ) =
+  cong₂ _∷_
+    (renameᶜ-ext-suc-comm ρ p)
+    (renameCtxNrw-ext-suc-comm ρ γ)
+
+srcStoreⁿ-renameStoreNrw :
+  ∀ ρ σ →
+  srcStoreⁿ (renameStoreNrw ρ σ) ≡ renameStoreᵗ ρ (srcStoreⁿ σ)
+srcStoreⁿ-renameStoreNrw ρ [] = refl
+srcStoreⁿ-renameStoreNrw ρ ((X ꞉ p) ∷ σ) =
+  cong₂ _∷_
+    (cong₂ _,_ refl (src-renameᶜ ρ p))
+    (srcStoreⁿ-renameStoreNrw ρ σ)
+srcStoreⁿ-renameStoreNrw ρ ((X ꞉= A ⊒) ∷ σ) =
+  srcStoreⁿ-renameStoreNrw ρ σ
+srcStoreⁿ-renameStoreNrw ρ ((⊒ X ꞉=☆) ∷ σ) =
+  cong₂ _∷_ refl (srcStoreⁿ-renameStoreNrw ρ σ)
+
+lookup-renameCtxNrw :
+  ∀ ρ {γ x p} →
+  γ ∋ x ⦂ p →
+  renameCtxNrw ρ γ ∋ x ⦂ renameᶜ ρ p
+lookup-renameCtxNrw ρ Z = Z
+lookup-renameCtxNrw ρ (S h) = S (lookup-renameCtxNrw ρ h)
+
+rename-cast-srcStore :
+  ∀ {ρ Δ Δ′ σ p A B} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  Δ′ ∣ srcStoreⁿ (renameStoreNrw ρ σ)
+    ⊢ renameᶜ ρ p ∶ᶜ renameᵗ ρ A ⊒ renameᵗ ρ B
+rename-cast-srcStore {ρ = ρ} {Δ′ = Δ′} {σ = σ} {p = p}
+    {A = A} {B = B} hρ pᶜ =
+  subst (λ Σ → Δ′ ∣ Σ ⊢ renameᶜ ρ p ∶ᶜ renameᵗ ρ A ⊒ renameᵗ ρ B)
+    (sym (srcStoreⁿ-renameStoreNrw ρ σ))
+    (narrow-renameᵗ {ρ = ρ} hρ (modeRename-tag-or-id {ρ = ρ}) pᶜ)
+
+rename-blame :
+  ∀ {ρ Δ Δ′ σ γ M p A B} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ blame ∶ renameᶜ ρ p
+rename-blame {σ = σ} hρ pᶜ =
+  ⊒blame (rename-cast-srcStore {σ = σ} hρ pᶜ)
+
+rename-var :
+  ∀ {ρ Δ Δ′ σ γ x p A B} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  γ ∋ x ⦂ p →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ ` x ⊒ ` x ∶ renameᶜ ρ p
+rename-var {ρ = ρ} {σ = σ} hρ pᶜ h =
+  x⊒x (rename-cast-srcStore {σ = σ} hρ pᶜ)
+    (lookup-renameCtxNrw ρ h)
+
+rename-dual-index :
+  ∀ {ρ Δ′ σ γ M M′ p} →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ γ ⊢ M ⊒ M′ ∶ renameᶜ ρ (- p) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ γ ⊢ M ⊒ M′ ∶ - renameᶜ ρ p
+rename-dual-index {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {M = M} {M′ = M′} {p = p} M⊒M′ =
+  subst (λ c → Δ′ ∣ renameStoreNrw ρ σ ∣ γ ⊢ M ⊒ M′ ∶ c)
+    (renameᶜ-dual-normal ρ p)
+    M⊒M′
+
+rename-dual-context :
+  ∀ {ρ Δ′ σ γ M M′ p q} →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ ((- p) ∷ γ)
+    ⊢ M ⊒ M′ ∶ q →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ (- renameᶜ ρ p) ∷ renameCtxNrw ρ γ
+    ⊢ M ⊒ M′ ∶ q
+rename-dual-context {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ}
+    {M = M} {M′ = M′} {p = p} {q = q} M⊒M′ =
+  subst (λ γ′ → Δ′ ∣ renameStoreNrw ρ σ ∣ γ′ ⊢ M ⊒ M′ ∶ q)
+    (cong (λ c → c ∷ renameCtxNrw ρ γ) (renameᶜ-dual-normal ρ p))
+    M⊒M′
+
+rename-ƛ :
+  ∀ {ρ Δ Δ′ σ γ N N′ p q A A′ B B′} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ ((- p) ∷ γ)
+    ⊢ renameᵗᵐ ρ N ⊒ renameᵗᵐ ρ N′ ∶ renameᶜ ρ q →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ ƛ renameᵗᵐ ρ N ⊒ ƛ renameᵗᵐ ρ N′ ∶ renameᶜ ρ (p ↦ q)
+rename-ƛ {ρ = ρ} {σ = σ} {p = p} hρ p↦qᶜ N⊒N′ =
+  ƛ⊒ƛ (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ p↦qᶜ)
+    (rename-dual-context {ρ = ρ} {p = p} N⊒N′)
+
+rename-· :
+  ∀ {ρ Δ Δ′ σ γ L L′ M M′ p q A B} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ B →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ L ⊒ renameᵗᵐ ρ L′ ∶ renameᶜ ρ (p ↦ q) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ M ⊒ renameᵗᵐ ρ M′ ∶ renameᶜ ρ (- p) →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ renameᵗᵐ ρ L · renameᵗᵐ ρ M
+      ⊒ renameᵗᵐ ρ L′ · renameᵗᵐ ρ M′ ∶ renameᶜ ρ q
+rename-· {ρ = ρ} {σ = σ} {p = p} hρ qᶜ L⊒L′ M⊒M′ =
+  ·⊒· (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ qᶜ)
+    L⊒L′
+    (rename-dual-index {ρ = ρ} {p = p} M⊒M′)
+
+rename-Λ :
+  ∀ {ρ Δ Δ′ σ γ V V′ p A B} →
+  TyRenameWf Δ Δ′ ρ →
+  Δ ∣ srcStoreⁿ σ ⊢ `∀ p ∶ᶜ `∀ A ⊒ `∀ B →
+  Value V →
+  suc Δ′ ∣ renameStoreNrw (extᵗ ρ) (⇑ˢ σ)
+    ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+    ⊢ renameᵗᵐ (extᵗ ρ) V ⊒ renameᵗᵐ (extᵗ ρ) V′
+    ∶ renameᶜ (extᵗ ρ) p →
+  Δ′ ∣ renameStoreNrw ρ σ ∣ renameCtxNrw ρ γ
+    ⊢ Λ (renameᵗᵐ (extᵗ ρ) V)
+      ⊒ Λ (renameᵗᵐ (extᵗ ρ) V′)
+    ∶ renameᶜ ρ (`∀ p)
+rename-Λ {ρ = ρ} {Δ′ = Δ′} {σ = σ} {γ = γ} {V = V}
+    {V′ = V′} {p = p} hρ ∀pᶜ vV V⊒V′ =
+  Λ⊒Λ (rename-cast-srcStore {ρ = ρ} {σ = σ} hρ ∀pᶜ)
+    (renameᵗᵐ-preserves-Value (extᵗ ρ) vV)
+    (subst
+      (λ γ′ →
+        suc Δ′ ∣ ⇑ˢ (renameStoreNrw ρ σ) ∣ γ′
+          ⊢ renameᵗᵐ (extᵗ ρ) V ⊒ renameᵗᵐ (extᵗ ρ) V′
+          ∶ renameᶜ (extᵗ ρ) p)
+      (renameCtxNrw-ext-suc-comm ρ γ)
+      (subst
+        (λ σ′ →
+          suc Δ′ ∣ σ′ ∣ renameCtxNrw (extᵗ ρ) (⇑ᵍ γ)
+            ⊢ renameᵗᵐ (extᵗ ρ) V ⊒ renameᵗᵐ (extᵗ ρ) V′
+            ∶ renameᶜ (extᵗ ρ) p)
+        (renameStoreNrw-ext-suc-comm ρ σ)
+        V⊒V′))
 
 lookup-⇑ᵍ :
   ∀ {γ x p} →


### PR DESCRIPTION
## Summary

Updates the left-widening exploration after main added the RuntimeOK/No• premises.

The old statement is kept in `GTSF/proof/LeftWidening.agda` as `LeftWideningWithoutNo•`, with a mechanized counterexample `left-widening-without-No•-counterexample : LeftWideningWithoutNo• → ⊥`.

The current `LeftWidening` shape now matches the guarded `proof.Catchup.left-widening-lemma`: it requires `No• V` and returns `No• W`. The previous bad value `badPoly` is blocked by `left-widening-counterexample-prevented : No• badPoly → ⊥`.

## Changes

- Merged the latest `origin/main` RuntimeOK/No• updates into this branch.
- Updated `LeftWidening.agda` to distinguish the old false statement from the current guarded one.
- Updated the Catchup postulate audit comment to refer to the older false statement.

## Validation

- `agda -v0 proof/LeftWidening.agda`
- `agda -v0 All.agda`
