### PR TITLE
[codex] Specialize right seal inversion 2

### DIFF
--- a/GTSF/cambridge25.lagda.md
+++ b/GTSF/cambridge25.lagda.md
@@ -3340,66 +3340,20 @@ Proof by induction on the derivation.
 
 Right Seal Inversion 2.
 
-If σ ⊢ M ⊒ V ⟨ α♭ ⟩ : q
-then there exists a r such that
-q ⨾ α♯ ≈ r and σ ⊢ M ⊒ V : r.
+If
 
-Proof by induction on the derivation.
+    σ ⊢ M ⊒ V ⟨ α♯ ⟩ : r
+    --------------------------- ⊒+  r ≈ q ⨾ α♯
+    σ ⊢ M ⊒ V ⟨ α♯ ⟩ ⟨ α♭ ⟩ : q
 
-  Case ⊒+
+then there exists a u such that
+q ⨾ α♯ ≈ u and σ ⊢ M ⊒ V ⟨ α♯ ⟩ : u.
 
-      σ ⊢ M ⊒ V : r
-      -------------------- ⊒+  r ≈ q ⨾ α♯
-      σ ⊢ M ⊒ V ⟨ α♭ ⟩ : q
+Proof.  Immediate, taking u = r.
 
-    Immediate.
-
-  Case +⊒
-
-      σ ⊢ M ⊒ V ⟨ α♭ ⟩ : q₀
-      --------------------------- +⊒  s ⨾ q₀ ≈ q
-      σ ⊢ M ⟨ s̅ ⟩ ⊒ V ⟨ α♭ ⟩ : q
-
-    By induction
-
-      σ ⊢ M ⊒ V : r₀
-      -------------------- ⊒+  r₀ ≈ q₀ ⨾ α♯
-      σ ⊢ M ⊒ V ⟨ α♭ ⟩ : q₀
-
-    So we have
-
-      σ ⊢ M ⊒ V : r₀
-      ------------------- +⊒  s ⨾ r₀ ≈ r
-      σ ⊢ M ⟨ s̅ ⟩ ⊒ V : r
-      -------------------------- ⊒+  r ≈ q ⨾ α♯
-      σ ⊢ M ⟨ s̅ ⟩ ⊒ V ⟨ α♭ ⟩ : q
-
-    (We know r exists because we can take r = q ⨾ α♯.
-    Then s ⨾ r₀ ≈ s ⨾ q₀ ⨾ α♯ ≈ q ⨾ α♯ = r.)
-
-
-  Case -⊒
-
-      σ ⊢ M ⊒ V ⟨ α♭ ⟩ : q₀
-      --------------------------- -⊒  s ⨾ q ≈ q₀
-      σ ⊢ M ⟨ s ⟩ ⊒ V ⟨ α♭ ⟩ : q
-
-    By induction
-
-      σ ⊢ M ⊒ V : r₀
-      -------------------- ⊒+  r₀ ≈ q₀ ⨾ α♯
-      σ ⊢ M ⊒ V ⟨ α♭ ⟩ : q₀
-
-    So we have
-
-      σ ⊢ M ⊒ V : r₀
-      ------------------- -⊒  s ⨾ r ≈ r₀
-      σ ⊢ M ⟨ s ⟩ ⊒ V : r
-      -------------------------- ⊒+  r ≈ q ⨾ α♯
-      σ ⊢ M ⟨ s ⟩ ⊒ V ⟨ α♭ ⟩ : q
-
-    (We know r exists because we can take r = q ⨾ α♯.
-    Then r₀ ≈ q₀ ⨾ α♯ ≈ s ⨾ q ⨾ α♯ = s ⨾ r.)
+The corresponding `⊒-` case with a right α♭ cast is impossible, since
+composition on the right side of a narrowing judgment requires the composed
+coercion to be a narrowing, but α♭ is a widening.
 
 
 

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -27,7 +27,6 @@ open import proof.CatchupStore using (combineStoreNrw)
 open import proof.LeftSealNarrowingInversion using
   (LeftSealNarrowingInversion; leftSealNarrowingInversion)
 open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
-open import proof.RightSealInversion2 using (right-seal-inversion₂)
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowing)
 
@@ -353,12 +352,8 @@ dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     | M⊒V =
   {!!}
 dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (seal-unseal vV))
-    with right-seal-inversion₂ (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (seal-unseal vV))
-    | r , q⨟seal≈r , M⊒Vseal
-  = {!!}
+    (pure-step (seal-unseal vV)) =
+  {!!}
 dynamicGradualGuarantee (⊒cast+ qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
 dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
@@ -399,12 +394,8 @@ dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     | M⊒V =
   {!!}
 dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (seal-unseal vV))
-    with right-seal-inversion₂ (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
-    (pure-step (seal-unseal vV))
-    | r , q⨟seal≈r , M⊒Vseal
-  = {!!}
+    (pure-step (seal-unseal vV)) =
+  {!!}
 dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
 

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -20,12 +20,14 @@ open import Coercions
 open import NuTerms
 open import NuReduction
 open import NarrowWiden
+open import NarrowWidenComposition using (_∣_⊢_⨾ⁿ_≈_∶_⊒_)
 open import TermNarrowing
 open import proof.Catchup using (catchup-lemma)
 open import proof.CatchupStore using (combineStoreNrw)
 open import proof.LeftSealNarrowingInversion using
   (LeftSealNarrowingInversion; leftSealNarrowingInversion)
 open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
+open import proof.RightSealInversion2 using (right-seal-inversion₂)
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowing)
 
@@ -49,11 +51,6 @@ postulate
   --   ∀ {Δ σ γ M V r A α} →
   --   Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
   --   ∃[ q ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ q
-
-  right-seal-inversion₂ :
-    ∀ {Δ σ γ M V q A α} →
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ unseal α A ⟩ ∶ q →
-    ∃[ r ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
 
   wrap-narrowing-lemma :
     ∀ {Δ σ V′ V W′ W p q s t} →
@@ -360,7 +357,7 @@ dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
     with right-seal-inversion₂ (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
 dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
-    | r , M⊒Vseal
+    | r , q⨟seal≈r , M⊒Vseal
   = {!!}
 dynamicGradualGuarantee (⊒cast+ qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
@@ -406,7 +403,7 @@ dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
     with right-seal-inversion₂ (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
 dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
-    | r , M⊒Vseal
+    | r , q⨟seal≈r , M⊒Vseal
   = {!!}
 dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -1,0 +1,179 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.RightSealInversion2 where
+
+-- File Charter:
+--   * Attempts to prove the cambridge25 Right Seal Inversion 2 lemma.
+--   * The theorem keeps the composition equation in the conclusion: stripping
+--     a right `unseal α A` produces both a witness coercion and evidence that
+--     the original index composes with `seal A α`.
+--   * The direct `⊒cast+` seal case is immediate.  The remaining holes record
+--     the proof obligations that arise from store-shaping and left-cast cases.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NarrowWiden
+open import NarrowWidenComposition
+open import TermNarrowing
+open import proof.CoercionProperties using (coercion-src-tgtᵐ)
+
+RightSealInversion2 : Set₁
+RightSealInversion2 =
+  ∀ {Δ σ γ M V q A α} →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ unseal α A ⟩ ∶ q →
+  ∃[ r ]
+    (Δ ∣ σ ⊢ q ⨾ⁿ seal A α ≈ r ∶ src q ⊒ ＇ α) ×
+    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
+
+right-seal-compose-endpoints :
+  ∀ {Δ σ q r A B A₀ α} →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal A₀ α ≈ r ∶ A ⊒ B →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal A₀ α ≈ r ∶ src q ⊒ ＇ α
+right-seal-compose-endpoints
+    (compose-leftⁿ wfΣ q⊒ seal⊒
+      (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+    rewrite proj₁ (coercion-src-tgtᵐ (proj₁ q⊒))
+          | proj₂ (coercion-src-tgtᵐ (proj₁ seal⊒)) =
+  compose-leftⁿ wfΣ q⊒ seal⊒
+    (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
+
+rightSealInversion2-cast+ :
+  ∀ {Δ σ γ M M′ V q r s A B C D A₀ α} →
+  M′ ⟨ - s ⟩ ≡ V ⟨ unseal α A₀ ⟩ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r →
+  ∃[ u ]
+    (Δ ∣ σ ⊢ q ⨾ⁿ seal A₀ α ≈ u ∶ src q ⊒ ＇ α) ×
+    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ u
+rightSealInversion2-cast+ {s = id A} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = c ︔ d} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = c ↦ d} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = `∀ c} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = G !} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = G ？} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = seal A α} refl
+    qᶜ q⨟seal≈r M⊒V =
+  _ , right-seal-compose-endpoints q⨟seal≈r , M⊒V
+rightSealInversion2-cast+ {s = unseal α A} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = gen A c} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = inst B c} ()
+    qᶜ q⨟s≈r M⊒M′
+
+rightSealInversion2-cast- :
+  ∀ {Δ σ γ M M′ V q r s A B C D A₀ α} →
+  M′ ⟨ s ⟩ ≡ V ⟨ unseal α A₀ ⟩ →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ q →
+  ∃[ u ]
+    (Δ ∣ σ ⊢ r ⨾ⁿ seal A₀ α ≈ u ∶ src r ⊒ ＇ α) ×
+    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ u
+rightSealInversion2-cast- {s = id A} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = c ︔ d} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = c ↦ d} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = `∀ c} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = G !} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = G ？} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = seal A α} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = unseal α A} refl
+    qᶜ
+    (compose-leftⁿ wfΣ q⊒ (cast-unseal hA α∈Σ ok , cross ())
+      q⨟s≈r)
+    M⊒M′
+rightSealInversion2-cast- {s = gen A c} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast- {s = inst B c} ()
+    qᶜ q⨟s≈r M⊒M′
+
+rightSealInversion2-aux :
+  ∀ {Δ σ γ M T V q A α} →
+  T ≡ V ⟨ unseal α A ⟩ →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ q →
+  ∃[ r ]
+    (Δ ∣ σ ⊢ q ⨾ⁿ seal A α ≈ r ∶ src q ⊒ ＇ α) ×
+    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
+-- Store/context-shaping cases: the right term is exposed only after
+-- type-variable substitution.  The proof should recurse below the store
+-- transformation and then transport both the composition equation and the term
+-- narrowing witness back through the same substitution.
+rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T) = {!!}
+rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T) = {!!}
+rightSealInversion2-aux () (⊒blame pᶜ)
+rightSealInversion2-aux () (x⊒x pᶜ x∋p)
+rightSealInversion2-aux () (ƛ⊒ƛ p↦qᶜ N⊒N′)
+rightSealInversion2-aux () (·⊒· qᶜ L⊒L′ M⊒M′)
+rightSealInversion2-aux () (Λ⊒Λ allᶜ vV V⊒V′)
+rightSealInversion2-aux () (⊒Λ pᶜ N⊒V′)
+rightSealInversion2-aux () (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
+rightSealInversion2-aux () (α⊒α qᶜ pαᶜ L⊒L′)
+rightSealInversion2-aux () (⊒α pαᶜ L⊒L′)
+rightSealInversion2-aux () (ν⊒ν pᶜ qᶜ N⊒N′)
+rightSealInversion2-aux () (⊒ν pᶜ N⊒N′)
+-- The `ν⊒` case is a left wrapper: the right term is unconstrained, so
+-- the proof should recurse under `⇑ᵗᵐ` and then rebuild `ν⊒`.  The attempted
+-- recursive call produces a shifted composition
+-- `⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ r`; rebuilding needs an unshifting
+-- lemma that factors this through a witness for `p ⨾ⁿ seal A α`.
+rightSealInversion2-aux eq (ν⊒ pᶜ N⊒N′) = {!!}
+rightSealInversion2-aux () (κ⊒κ κ)
+rightSealInversion2-aux () (⊕⊒⊕ M⊒M′ N⊒N′)
+-- Direct right-positive seal cast.  Here the syntax of `- (seal A α)` is
+-- exactly `unseal α A`, so the constructor already carries the desired
+-- composition evidence and the stripped premise.
+-- Other right-positive casts can only reach `V ⟨ unseal α A ⟩` when the
+-- dual of their cast is definitionally an unseal.  The non-seal cases are
+-- expected to be syntactically impossible; they are left split out while the
+-- exact dual-action refinements are worked through.
+rightSealInversion2-aux eq (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  rightSealInversion2-cast+ eq qᶜ q⨟s≈r M⊒M′
+-- Right-negative casts would require the cast itself to be `unseal α A`, but
+-- the composition side condition classifies that cast as a narrowing.  Since
+-- `unseal` is a widening constructor, the main branch should close by the
+-- impossible narrowing evidence.
+rightSealInversion2-aux eq (⊒cast- qᶜ q⨟s≈r M⊒M′) =
+  rightSealInversion2-cast- eq qᶜ q⨟s≈r M⊒M′
+-- Left cast cases recurse on the premise.  After the recursive inversion, the
+-- first missing algebra is an associativity/factoring lemma for narrowing
+-- composition:
+--
+--   r ≈ t ⨾ⁿ p
+--   r ⨾ⁿ seal A α ≈ u
+--   --------------------
+--   ∃[ v ] p ⨾ⁿ seal A α ≈ v × u ≈ t ⨾ⁿ v
+--
+-- The direct rebuild attempt then hits a second obligation: `cast+⊒` and
+-- `cast-⊒` require the premise index to be cast-like (`∶ᶜ`), but the
+-- recursive inversion only returns a term relation at the composed witness.
+-- A complete proof needs either a strengthened IH that also returns enough
+-- typing for the witness, or a derived left-cast transport lemma that produces
+-- the stripped term relation without exposing that `∶ᶜ` requirement at the
+-- call site.
+rightSealInversion2-aux eq (cast+⊒ pᶜ r≈t⨟p M⊒M′) = {!!}
+rightSealInversion2-aux eq (cast-⊒ pᶜ r≈t⨟p M⊒M′) = {!!}
+
+rightSealInversion2 : RightSealInversion2
+rightSealInversion2 M⊒Vunseal =
+  rightSealInversion2-aux refl M⊒Vunseal
+
+right-seal-inversion₂ : RightSealInversion2
+right-seal-inversion₂ = rightSealInversion2

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -1,21 +1,24 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 module proof.RightSealInversion2 where
 
 -- File Charter:
---   * Attempts to prove the cambridge25 Right Seal Inversion 2 lemma.
---   * The theorem keeps the composition equation in the conclusion: stripping
---     a right `unseal α A` produces both a witness coercion and evidence that
---     the original index composes with `seal A α`.
---   * The direct `⊒cast+` seal case is immediate.  The remaining holes record
---     the proof obligations that arise from store-shaping and left-cast cases.
+--   * Counterexample for the cambridge25 Right Seal Inversion 2 lemma.
+--   * The refuted statement keeps the composition equation in the conclusion:
+--     stripping a right `unseal α A` should produce both a witness coercion
+--     and evidence that the original index composes with `seal A α`.
+--   * The counterexample uses `ν⊒` and a context variable: inside the fresh
+--     source-only store, the variable can be unsealed on the left and then
+--     re-sealed/unsealed on the right; after the outer `ν⊒`, the stripped
+--     conclusion would have to relate the ν source to the bare variable at a
+--     seal index, which is impossible.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥)
 open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.Nat using (zero; suc; z<s; s<s)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
-open import Relation.Binary.PropositionalEquality using (cong)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
@@ -32,7 +35,8 @@ open import proof.Catchup using
   ; extendReplaceRel-term
   )
 open import proof.CoercionProperties using (coercion-src-tgtᵐ)
-open import proof.NarrowWidenProperties using (StoreDetWf)
+open import proof.NarrowWidenProperties using
+  (StoreDetWf; narrowing-var-to-older⊥)
 
 RightSealInversion2 : Set₁
 RightSealInversion2 =
@@ -156,105 +160,11 @@ rightSealInversion2-cast- {s = gen A c} ()
 rightSealInversion2-cast- {s = inst B c} ()
     qᶜ q⨟s≈r M⊒M′
 
-rightSealInversion2-aux :
-  ∀ {Δ σ γ M T V q A α} →
-  T ≡ V ⟨ unseal α A ⟩ →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ q →
-  ∃[ r ]
-    (Δ ∣ σ ⊢ q ⨾ⁿ seal A α ≈ r ∶ src q ⊒ ＇ α) ×
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
--- The `extend` case is a direct store-replacement transport: recurse in the
--- exact-store premise, then replace the head store entry with its narrowing.
-rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T)
-    with rightSealInversion2-aux eq M⊒T
-rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T)
-    | r , q⨟seal≈r , M⊒V =
-  r ,
-  extendReplaceRel-compose-left (replace-here qᶜ) q⨟seal≈r ,
-  extendReplaceRel-term (replace-here qᶜ) M⊒V
--- The `split` case changes both the store and the left term's opened type
--- variable.  The recursive inversion strips the target cast under
--- `(α ꞉ q) ∷ σ`; the remaining step must transport both the composition
--- evidence and the stripped relation to
--- `(α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ`, changing the source
--- opening from `N [ α ]ᵀ` to `N [ αᵢ ]ᵀ`.
-rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T)
-    with rightSealInversion2-aux eq M⊒T
-rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T)
-    | r , pα⨟seal≈r , Nα⊒V =
-  {!!}
-rightSealInversion2-aux () (⊒blame pᶜ)
-rightSealInversion2-aux () (x⊒x pᶜ x∋p)
-rightSealInversion2-aux () (ƛ⊒ƛ p↦qᶜ N⊒N′)
-rightSealInversion2-aux () (·⊒· qᶜ L⊒L′ M⊒M′)
-rightSealInversion2-aux () (Λ⊒Λ allᶜ vV V⊒V′)
-rightSealInversion2-aux () (⊒Λ pᶜ N⊒V′)
-rightSealInversion2-aux () (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
-rightSealInversion2-aux () (α⊒α qᶜ pαᶜ L⊒L′)
-rightSealInversion2-aux () (⊒α pαᶜ L⊒L′)
-rightSealInversion2-aux () (ν⊒ν pᶜ qᶜ N⊒N′)
-rightSealInversion2-aux () (⊒ν pᶜ N⊒N′)
--- The `ν⊒` case is a left wrapper: the right term is unconstrained, so the
--- proof should recurse under `⇑ᵗᵐ` and then rebuild `ν⊒`.
--- The attempted recursive call produces a shifted composition
--- `⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ r`; rebuilding needs an
--- unshifting lemma that factors this through a witness for
--- `p ⨾ⁿ seal A α`.
-rightSealInversion2-aux {V = V} eq (ν⊒ pᶜ N⊒N′)
-    with rightSealInversion2-aux (cong ⇑ᵗᵐ eq) N⊒N′
-rightSealInversion2-aux {V = V} eq (ν⊒ pᶜ N⊒N′)
-    | r , ⇑p⨟seal≈r , N⊒⇑V =
-  {!!}
-rightSealInversion2-aux () (κ⊒κ κ)
-rightSealInversion2-aux () (⊕⊒⊕ M⊒M′ N⊒N′)
--- Direct right-positive seal cast.  Here the syntax of `- (seal A α)` is
--- exactly `unseal α A`, so the constructor already carries the desired
--- composition evidence and the stripped premise.
--- Other right-positive casts can only reach `V ⟨ unseal α A ⟩` when the
--- dual of their cast is definitionally an unseal.  The non-seal cases are
--- expected to be syntactically impossible; they are left split out while the
--- exact dual-action refinements are worked through.
-rightSealInversion2-aux eq (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
-  rightSealInversion2-cast+ eq qᶜ q⨟s≈r M⊒M′
--- Right-negative casts would require the cast itself to be `unseal α A`, but
--- the composition side condition classifies that cast as a narrowing.  Since
--- `unseal` is a widening constructor, the main branch should close by the
--- impossible narrowing evidence.
-rightSealInversion2-aux eq (⊒cast- qᶜ q⨟s≈r M⊒M′) =
-  rightSealInversion2-cast- eq qᶜ q⨟s≈r M⊒M′
--- Left cast cases recurse on the premise.  After the recursive inversion, the
--- first missing algebra is an associativity/factoring lemma for narrowing
--- composition:
---
---   r ≈ t ⨾ⁿ p
---   r ⨾ⁿ seal A α ≈ u
---   --------------------
---   ∃[ v ] p ⨾ⁿ seal A α ≈ v × u ≈ t ⨾ⁿ v
---
--- The direct rebuild attempt then hits a second obligation: `cast+⊒` and
--- `cast-⊒` require the premise index to be cast-like (`∶ᶜ`), but the
--- recursive inversion only returns a term relation at the composed witness.
--- A complete proof needs either a strengthened IH that also returns enough
--- typing for the witness, or a derived left-cast transport lemma that produces
--- the stripped term relation without exposing that `∶ᶜ` requirement at the
--- call site.
-rightSealInversion2-aux eq (cast+⊒ pᶜ r≈t⨟p M⊒M′)
-    with rightSealInversion2-aux eq M⊒M′
-rightSealInversion2-aux eq (cast+⊒ pᶜ r≈t⨟p M⊒M′)
-    | u , p⨟seal≈u , M⊒V =
-  {!!}
-rightSealInversion2-aux eq (cast-⊒ pᶜ r≈t⨟p M⊒M′)
-    with rightSealInversion2-aux eq M⊒M′
-rightSealInversion2-aux eq (cast-⊒ pᶜ r≈t⨟p M⊒M′)
-    | u , r⨟seal≈u , M⊒V =
-  {!!}
-
-rightSealInversion2 : RightSealInversion2
-rightSealInversion2 M⊒Vunseal =
-  rightSealInversion2-aux refl M⊒Vunseal
-
-right-seal-inversion₂ : RightSealInversion2
-right-seal-inversion₂ = rightSealInversion2
+-- Failed proof-search note.  The direct induction can strip right-positive
+-- casts, but the `ν⊒` branch reveals the false premise: a recursive call
+-- under the fresh source-only store gives a shifted composition index,
+-- while the outer `ν⊒` source annotation remains fixed at the original
+-- index.  The variable counterexample below isolates that mismatch.
 
 ------------------------------------------------------------------------
 -- Counterexample search: ν-wrapped right unseal
@@ -296,6 +206,9 @@ private
 
   unseal0 : Coercion
   unseal0 = unseal alpha0 NatTy
+
+  unseal1 : Coercion
+  unseal1 = unseal alpha1 NatTy
 
   wfStore0 : StoreDetWf 1 Store0
   wfStore0 =
@@ -367,6 +280,27 @@ private
     seal-or-idᵈ ∣ Δ ∣ Σ ⊢ id NatTy ∶ NatTy ⊒ NatTy
   idNat⊒ = cast-id wfBase refl , cross (id-‵ `ℕ)
 
+  idAlpha0 : Coercion
+  idAlpha0 = id (＇ alpha0)
+
+  idAlpha1 : Coercion
+  idAlpha1 = id (＇ alpha1)
+
+  idAlpha0ᶜ : 1 ∣ Store0 ⊢ idAlpha0 ∶ᶜ ＇ alpha0 ⊒ ＇ alpha0
+  idAlpha0ᶜ =
+    cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+  idAlpha1ᶜSource :
+    2 ∣ Store1Source ⊢ idAlpha1 ∶ᶜ ＇ alpha1 ⊒ ＇ alpha1
+  idAlpha1ᶜSource =
+    cast-id (wfVar (s<s z<s)) refl , cross (id-＇ alpha1)
+
+  idAlpha1⊒Target :
+    seal-or-idᵈ ∣ 2 ∣ Store1Target
+      ⊢ idAlpha1 ∶ ＇ alpha1 ⊒ ＇ alpha1
+  idAlpha1⊒Target =
+    cast-id (wfVar (s<s z<s)) refl , cross (id-＇ alpha1)
+
   seal0⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ seal0 ∶ NatTy ⊒ ＇ alpha0
   seal0⊒ = cast-seal wfBase (here refl) refl , sealⁿ NatTy alpha0
 
@@ -400,6 +334,17 @@ private
           proj₂ (_⨟ⁿ_ {wfΣ = wfStore1Target} idNat⊒ seal1⊒Target))
         (seal-or-idᵈ , seal1⊒Source))
 
+  left-seal-compose1 :
+    2 ∣ Sigma1 ⊢ seal1 ≈ seal1 ⨾ⁿ idAlpha1 ∶ NatTy ⊒ ＇ alpha1
+  left-seal-compose1 =
+    compose-rightⁿ wfStore1Target seal1⊒Target idAlpha1⊒Target
+      (endpointsⁿ refl refl refl refl
+        Sigma1⊒
+        endpoints1Target
+        endpoints1Source
+        (seal-or-idᵈ , seal1⊒Target)
+        (seal-or-idᵈ , seal1⊒Source))
+
   right-sealed-constant1 :
     2 ∣ Sigma1 ∣ [] ⊢ $ k0 ⊒ ($ k0) ⟨ seal1 ⟩ ∶ seal1
   right-sealed-constant1 =
@@ -412,6 +357,23 @@ private
   right-unsealed-constant1 =
     ⊒cast+ idNatᶜ right-seal-compose1 right-sealed-constant1
 
+  alpha-var1 :
+    2 ∣ Sigma1 ∣ idAlpha1 ∷ [] ⊢ ` zero ⊒ ` zero ∶ idAlpha1
+  alpha-var1 =
+    x⊒x idAlpha1ᶜSource Z
+
+  left-unsealed-alpha-var1 :
+    2 ∣ Sigma1 ∣ idAlpha1 ∷ []
+      ⊢ (` zero) ⟨ unseal1 ⟩ ⊒ ` zero ∶ seal1
+  left-unsealed-alpha-var1 =
+    cast+⊒ idAlpha1ᶜSource left-seal-compose1 alpha-var1
+
+  right-unsealed-alpha-var1 :
+    2 ∣ Sigma1 ∣ idAlpha1 ∷ []
+      ⊢ (` zero) ⟨ unseal1 ⟩ ⊒ (` zero) ⟨ unseal1 ⟩ ∶ id NatTy
+  right-unsealed-alpha-var1 =
+    ⊒cast+ idNatᶜ right-seal-compose1 left-unsealed-alpha-var1
+
   right-seal-inversion₂-counterexample-premise :
     1 ∣ Sigma0 ∣ []
       ⊢ ν ★ ($ k0) (⇑ᶜ (id NatTy))
@@ -419,6 +381,14 @@ private
       ∶ id NatTy
   right-seal-inversion₂-counterexample-premise =
     ν⊒ idNatᶜ right-unsealed-constant1
+
+  right-seal-inversion₂-var-counterexample-premise :
+    1 ∣ Sigma0 ∣ idAlpha0 ∷ []
+      ⊢ ν ★ ((` zero) ⟨ unseal1 ⟩) (⇑ᶜ (id NatTy))
+        ⊒ (` zero) ⟨ unseal0 ⟩
+      ∶ id NatTy
+  right-seal-inversion₂-var-counterexample-premise =
+    ν⊒ idNatᶜ right-unsealed-alpha-var1
 
   -- This was the first ν-shaped counterexample candidate.  It fails: the
   -- stripped conclusion is rebuilt by relating the ν term to the bare constant
@@ -443,3 +413,201 @@ right-seal-inversion₂-ν-candidate-result =
   seal0 ,
   right-seal-compose-endpoints right-seal-compose0 ,
   right-seal-inversion₂-ν-candidate-stripped
+
+private
+  ν-ann-injective :
+    ∀ {A N N′ c c′} →
+    ν A N c ≡ ν A N′ c′ →
+    c ≡ c′
+  ν-ann-injective refl = refl
+
+  ν-body-injective :
+    ∀ {A N N′ c c′} →
+    ν A N c ≡ ν A N′ c′ →
+    N ≡ N′
+  ν-body-injective refl = refl
+
+  renamed-idNat-tgt-alpha0⊥ :
+    ∀ {r} →
+    renameᶜ suc r ≡ id NatTy →
+    tgt r ≡ ＇ alpha0 →
+    ⊥
+  renamed-idNat-tgt-alpha0⊥ {r = id (＇ X)} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = id (‵ `ℕ)} eq ()
+  renamed-idNat-tgt-alpha0⊥ {r = id (‵ `𝔹)} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = id ★} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = id (A ⇒ B)} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = id (`∀ A)} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = c ︔ d} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = c ↦ d} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = `∀ c} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = G !} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = G ？} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = seal A α} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = unseal α A} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = gen A c} () tgt-r
+  renamed-idNat-tgt-alpha0⊥ {r = inst B c} () tgt-r
+
+  idNat-right-seal-not-idNat :
+    1 ∣ Sigma0
+      ⊢ id NatTy ⨾ⁿ seal0 ≈ id NatTy ∶ NatTy ⊒ ＇ alpha0 →
+    ⊥
+  idNat-right-seal-not-idNat
+      (compose-leftⁿ wfΣ q⊒ seal⊒
+        (endpointsⁿ src-u tgt-u src-r () σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+
+  idNat-right-seal-not-renamed-idNat :
+    ∀ {r} →
+    renameᶜ suc r ≡ id NatTy →
+    1 ∣ Sigma0
+      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
+    ⊥
+  idNat-right-seal-not-renamed-idNat r≡idNat
+      (compose-leftⁿ wfΣ q⊒ seal⊒
+        (endpointsⁿ src-u tgt-u src-r tgt-r
+          σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)) =
+    renamed-idNat-tgt-alpha0⊥ r≡idNat tgt-r
+
+  idNat-target :
+    ∀ {r B} →
+    r ≡ id NatTy →
+    tgt r ≡ B →
+    B ≡ NatTy
+  idNat-target r≡idNat tgt-r =
+    trans (sym tgt-r) (cong tgt r≡idNat)
+
+  inner-cast+⊥ :
+    ∀ {Δ σ γ M M′ q p t A B C D} →
+    M ⟨ - t ⟩ ≡ (` zero) ⟨ unseal1 ⟩ →
+    M′ ≡ ` zero →
+    q ≡ id NatTy →
+    Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+    Δ ∣ σ ⊢ q ≈ t ⨾ⁿ p ∶ A ⊒ B →
+    Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p →
+    ⊥
+  inner-cast+⊥ {t = id A} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = c ︔ d} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = c ↦ d} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = `∀ c} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (＇ β) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (‵ ι) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = ★ !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (A ⇒ B) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (`∀ A) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (＇ β) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (‵ ι) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = ★ ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (A ⇒ B) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (`∀ A) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = seal .NatTy .alpha1} refl eqT q≡id pᶜ
+      (compose-rightⁿ wfΣ
+        (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha1)
+        p⊒
+        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      M⊒M′ =
+    let
+      B≡Nat = idNat-target q≡id tgt-r
+      p⊒Nat =
+        subst (λ B → _ ∣ _ ∣ _ ⊢ _ ∶ ＇ alpha1 ⊒ B) B≡Nat p⊒
+    in
+    narrowing-var-to-older⊥ wfΣ wfBase p⊒Nat
+  inner-cast+⊥ {t = unseal α A} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = gen A c} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = inst B c} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+
+  inner-cast-⊥ :
+    ∀ {Δ σ γ M M′ q r t A B C D} →
+    M ⟨ t ⟩ ≡ (` zero) ⟨ unseal1 ⟩ →
+    M′ ≡ ` zero →
+    q ≡ id NatTy →
+    Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+    Δ ∣ σ ⊢ r ≈ t ⨾ⁿ q ∶ A ⊒ B →
+    Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r →
+    ⊥
+  inner-cast-⊥ {t = id A} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = c ︔ d} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = c ↦ d} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = `∀ c} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = G !} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = G ？} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = seal A α} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = unseal α A} refl eqT q≡id qᶜ
+      (compose-rightⁿ wfΣ
+        (cast-unseal hA α∈Σ ok , cross ())
+        q⊒
+        r≈t⨟q)
+      M⊒M′
+  inner-cast-⊥ {t = gen A c} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = inst B c} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+
+  right-seal-inversion₂-var-inner⊥ :
+    ∀ {A q M T} →
+    M ≡ (` zero) ⟨ unseal1 ⟩ →
+    T ≡ ` zero →
+    q ≡ id NatTy →
+    2 ∣ (⊒ zero ꞉=☆) ∷ (alpha1 ꞉= ⇑ᵗ A ⊒) ∷ []
+      ∣ idAlpha1 ∷ []
+      ⊢ M ⊒ T ∶ q →
+    ⊥
+  right-seal-inversion₂-var-inner⊥ eqM eqT q≡id
+      (cast+⊒ pᶜ q≈t⨟p M⊒M′) =
+    inner-cast+⊥ eqM eqT q≡id pᶜ q≈t⨟p M⊒M′
+  right-seal-inversion₂-var-inner⊥ eqM eqT q≡id
+      (cast-⊒ qᶜ r≈t⨟q M⊒M′) =
+    inner-cast-⊥ eqM eqT q≡id qᶜ r≈t⨟q M⊒M′
+
+  right-seal-inversion₂-var-stripped-source⊥ :
+    ∀ {A r M T} →
+    M ≡ ν ★ ((` zero) ⟨ unseal1 ⟩) (⇑ᶜ (id NatTy)) →
+    T ≡ ` zero →
+    1 ∣ (alpha0 ꞉= A ⊒) ∷ [] ∣ idAlpha0 ∷ []
+      ⊢ M ⊒ T ∶ r →
+    ⊥
+  right-seal-inversion₂-var-stripped-source⊥ eqM eqT
+      (ν⊒ pᶜ N⊒N′) =
+    right-seal-inversion₂-var-inner⊥
+      (ν-body-injective eqM)
+      (cong ⇑ᵗᵐ eqT)
+      (ν-ann-injective eqM)
+      N⊒N′
+
+  right-seal-inversion₂-var-stripped-aux⊥ :
+    ∀ {r M T} →
+    M ≡ ν ★ ((` zero) ⟨ unseal1 ⟩) (⇑ᶜ (id NatTy)) →
+    T ≡ ` zero →
+    1 ∣ Sigma0
+      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
+    1 ∣ Sigma0 ∣ idAlpha0 ∷ []
+      ⊢ M ⊒ T ∶ r →
+    ⊥
+  right-seal-inversion₂-var-stripped-aux⊥ eqM eqT comp
+      (extend qᶜ pαᶜ M⊒T) =
+    right-seal-inversion₂-var-stripped-source⊥ eqM eqT M⊒T
+  right-seal-inversion₂-var-stripped-aux⊥ eqM eqT comp
+      (ν⊒ pᶜ N⊒N′)
+      with eqT
+  right-seal-inversion₂-var-stripped-aux⊥ eqM eqT comp
+      (ν⊒ pᶜ N⊒N′)
+      | refl =
+    idNat-right-seal-not-renamed-idNat (ν-ann-injective eqM) comp
+
+  right-seal-inversion₂-var-stripped⊥ :
+    ∀ {r} →
+    1 ∣ Sigma0
+      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
+    1 ∣ Sigma0 ∣ idAlpha0 ∷ []
+      ⊢ ν ★ ((` zero) ⟨ unseal1 ⟩) (⇑ᶜ (id NatTy))
+        ⊒ ` zero ∶ r →
+    ⊥
+  right-seal-inversion₂-var-stripped⊥ comp M⊒T =
+    right-seal-inversion₂-var-stripped-aux⊥ refl refl comp M⊒T
+
+right-seal-inversion₂-var-counterexample :
+  RightSealInversion2 →
+  ⊥
+right-seal-inversion₂-var-counterexample right-seal-inversion₂′
+    with right-seal-inversion₂′
+      right-seal-inversion₂-var-counterexample-premise
+right-seal-inversion₂-var-counterexample right-seal-inversion₂′
+    | r , id⨟seal≈r , stripped =
+  right-seal-inversion₂-var-stripped⊥ id⨟seal≈r stripped

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -1,10 +1,14 @@
 module proof.RightSealInversion2 where
 
 -- File Charter:
---   * Counterexample for the cambridge25 Right Seal Inversion 2 lemma.
---   * The refuted statement keeps the composition equation in the conclusion:
---     stripping a right `unseal α A` should produce both a witness coercion
---     and evidence that the original index composes with `seal A α`.
+--   * Revised target statement for Right Seal Inversion 2, specialized to the
+--     seal-unseal redex shape available at the DGG call sites.
+--   * The old general statement is kept as `GeneralRightSealInversion2`; its
+--     counterexample documents why arbitrary `V ⟨ unseal α A ⟩` is too
+--     broad.
+--   * The exported call-site statement takes the right-cast premises that DGG
+--     already has: the composition `q ⨾ seal B α ≈ r` and the premise
+--     narrowing to the sealed value `V ⟨ seal A α ⟩`.
 --   * The counterexample uses `ν⊒` and a context variable: inside the fresh
 --     source-only store, the variable can be unsealed on the left and then
 --     re-sealed/unsealed on the right; after the outer `ν⊒`, the stripped
@@ -27,24 +31,28 @@ open import NuTerms
 open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing
-open import proof.Catchup using
-  ( replace-here
-  ; compose-leftⁿ-⇑ˢ
-  ; compose-leftⁿ-add-left-star-var
-  ; extendReplaceRel-compose-left
-  ; extendReplaceRel-term
-  )
 open import proof.CoercionProperties using (coercion-src-tgtᵐ)
 open import proof.NarrowWidenProperties using
   (StoreDetWf; narrowing-var-to-older⊥)
 
-RightSealInversion2 : Set₁
-RightSealInversion2 =
+GeneralRightSealInversion2 : Set₁
+GeneralRightSealInversion2 =
   ∀ {Δ σ γ M V q A α} →
   Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ unseal α A ⟩ ∶ q →
   ∃[ r ]
     (Δ ∣ σ ⊢ q ⨾ⁿ seal A α ≈ r ∶ src q ⊒ ＇ α) ×
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
+
+RightSealInversion2 : Set₁
+RightSealInversion2 =
+  ∀ {Δ σ M V q r A B C D α} →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ A ⊒ ＇ α →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ u ]
+    (Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ u ∶ src q ⊒ ＇ α) ×
+    Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ u
 
 right-seal-compose-endpoints :
   ∀ {Δ σ q r A B A₀ α} →
@@ -58,116 +66,29 @@ right-seal-compose-endpoints
   compose-leftⁿ wfΣ q⊒ seal⊒
     (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
 
-right-seal-compose-ν-lift :
-  ∀ {Δ σ p r A α} →
-  Δ ∣ σ ⊢ p ⨾ⁿ seal A α ≈ r ∶ src p ⊒ ＇ α →
-  suc Δ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ σ
-    ⊢ ⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ ⇑ᶜ r
-      ∶ ⇑ᵗ (src p) ⊒ ＇ suc α
-right-seal-compose-ν-lift p⨟seal≈r =
-  compose-leftⁿ-add-left-star-var zero
-    (compose-leftⁿ-⇑ˢ p⨟seal≈r)
+rightSealInversion2 : RightSealInversion2
+rightSealInversion2 _ _ q⨟seal≈r M⊒Vseal =
+  _ , right-seal-compose-endpoints q⨟seal≈r , M⊒Vseal
 
-rightSealInversion2-ν⊒-right-sealed :
-  ∀ {Δ σ γ N W p r A B A₀ α} →
-  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
-  Δ ∣ σ ⊢ p ⨾ⁿ seal A₀ α ≈ r ∶ src p ⊒ ＇ α →
-  suc Δ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
-    ⊢ N ⊒ ⇑ᵗᵐ W ∶ ⇑ᶜ p →
-  ∃[ u ]
-    (Δ ∣ σ ⊢ p ⨾ⁿ seal A₀ α ≈ u ∶ src p ⊒ ＇ α) ×
-    Δ ∣ σ ∣ γ ⊢ ν ★ N (⇑ᶜ p) ⊒ W ⟨ seal A₀ α ⟩ ∶ u
-rightSealInversion2-ν⊒-right-sealed pᶜ p⨟seal≈r N⊒W =
-  _ , p⨟seal≈r , ⊒cast- pᶜ p⨟seal≈r (ν⊒ pᶜ N⊒W)
+right-seal-inversion₂ : RightSealInversion2
+right-seal-inversion₂ = rightSealInversion2
 
-rightSealInversion2-cast+ :
-  ∀ {Δ σ γ M M′ V q r s A B C D A₀ α} →
-  M′ ⟨ - s ⟩ ≡ V ⟨ unseal α A₀ ⟩ →
+right-seal-inversion₂-cast-unseal⊥ :
+  ∀ {Δ σ q r A B C D α} →
   Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r →
-  ∃[ u ]
-    (Δ ∣ σ ⊢ q ⨾ⁿ seal A₀ α ≈ u ∶ src q ⊒ ＇ α) ×
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ u
-rightSealInversion2-cast+ {s = id A} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = c ︔ d} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = c ↦ d} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = `∀ c} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (＇ β) !} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (‵ ι) !} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = ★ !} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (A ⇒ B) !} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (`∀ A) !} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (＇ β) ？} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (‵ ι) ？} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = ★ ？} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (A ⇒ B) ？} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = (`∀ A) ？} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = seal A α} refl
-    qᶜ q⨟seal≈r M⊒V =
-  _ , right-seal-compose-endpoints q⨟seal≈r , M⊒V
-rightSealInversion2-cast+ {s = unseal α A} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = gen A c} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = inst B c} ()
-    qᶜ q⨟s≈r M⊒M′
+  Δ ∣ σ ⊢ q ⨾ⁿ unseal α B ≈ r ∶ A ⊒ B →
+  ⊥
+right-seal-inversion₂-cast-unseal⊥ qᶜ
+    (compose-leftⁿ wfΣ q⊒ (cast-unseal hB α∈Σ ok , cross ())
+      q⨟unseal≈r)
 
-rightSealInversion2-cast- :
-  ∀ {Δ σ γ M M′ V q r s A B C D A₀ α} →
-  M′ ⟨ s ⟩ ≡ V ⟨ unseal α A₀ ⟩ →
-  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ q →
-  ∃[ u ]
-    (Δ ∣ σ ⊢ r ⨾ⁿ seal A₀ α ≈ u ∶ src r ⊒ ＇ α) ×
-    Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ u
-rightSealInversion2-cast- {s = id A} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = c ︔ d} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = c ↦ d} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = `∀ c} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = G !} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = G ？} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = seal A α} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = unseal α A} refl
-    qᶜ
-    (compose-leftⁿ wfΣ q⊒ (cast-unseal hA α∈Σ ok , cross ())
-      q⨟s≈r)
-    M⊒M′
-rightSealInversion2-cast- {s = gen A c} ()
-    qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast- {s = inst B c} ()
-    qᶜ q⨟s≈r M⊒M′
-
--- Failed proof-search note.  The direct induction can strip right-positive
--- casts, but the `ν⊒` branch reveals the false premise: a recursive call
--- under the fresh source-only store gives a shifted composition index,
--- while the outer `ν⊒` source annotation remains fixed at the original
--- index.  The variable counterexample below isolates that mismatch.
+-- Failed proof-search note for `GeneralRightSealInversion2`.  The direct
+-- induction can strip the direct right-positive cast, but the `ν⊒`, `split`,
+-- and left-cast branches require facts that the DGG call sites do not need.
+-- The variable counterexample below isolates the false general premise.
 
 ------------------------------------------------------------------------
--- Counterexample search: ν-wrapped right unseal
+-- General-statement counterexample search: ν-wrapped right unseal
 ------------------------------------------------------------------------
 
 private
@@ -603,7 +524,7 @@ private
     right-seal-inversion₂-var-stripped-aux⊥ refl refl comp M⊒T
 
 right-seal-inversion₂-var-counterexample :
-  RightSealInversion2 →
+  GeneralRightSealInversion2 →
   ⊥
 right-seal-inversion₂-var-counterexample right-seal-inversion₂′
     with right-seal-inversion₂′

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -19,6 +19,11 @@ open import NuTerms
 open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing
+open import proof.Catchup using
+  ( replace-here
+  ; extendReplaceRel-compose-left
+  ; extendReplaceRel-term
+  )
 open import proof.CoercionProperties using (coercion-src-tgtᵐ)
 
 RightSealInversion2 : Set₁
@@ -112,11 +117,18 @@ rightSealInversion2-aux :
   ∃[ r ]
     (Δ ∣ σ ⊢ q ⨾ⁿ seal A α ≈ r ∶ src q ⊒ ＇ α) ×
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
--- Store/context-shaping cases: the right term is exposed only after
--- type-variable substitution.  The proof should recurse below the store
--- transformation and then transport both the composition equation and the term
--- narrowing witness back through the same substitution.
-rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T) = {!!}
+-- The `extend` case is a direct store-replacement transport: recurse in the
+-- exact-store premise, then replace the head store entry with its narrowing.
+rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T)
+    with rightSealInversion2-aux eq M⊒T
+rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T)
+    | r , q⨟seal≈r , M⊒V =
+  r ,
+  extendReplaceRel-compose-left (replace-here qᶜ) q⨟seal≈r ,
+  extendReplaceRel-term (replace-here qᶜ) M⊒V
+-- The `split` case changes both the store and the left term's opened type
+-- variable.  The same store replacement lemmas handle the store component,
+-- but the proof still needs an opening-transport lemma for the stripped term.
 rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T) = {!!}
 rightSealInversion2-aux () (⊒blame pᶜ)
 rightSealInversion2-aux () (x⊒x pᶜ x∋p)

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -13,7 +13,7 @@ module proof.RightSealInversion2 where
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here; there)
-open import Data.Nat using (z<s; s<s)
+open import Data.Nat using (zero; suc; z<s; s<s)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 
 open import Types
@@ -25,6 +25,8 @@ open import NarrowWidenComposition
 open import TermNarrowing
 open import proof.Catchup using
   ( replace-here
+  ; compose-leftⁿ-⇑ˢ
+  ; compose-leftⁿ-add-left-star-var
   ; extendReplaceRel-compose-left
   ; extendReplaceRel-term
   )
@@ -50,6 +52,28 @@ right-seal-compose-endpoints
           | proj₂ (coercion-src-tgtᵐ (proj₁ seal⊒)) =
   compose-leftⁿ wfΣ q⊒ seal⊒
     (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
+
+right-seal-compose-ν-lift :
+  ∀ {Δ σ p r A α} →
+  Δ ∣ σ ⊢ p ⨾ⁿ seal A α ≈ r ∶ src p ⊒ ＇ α →
+  suc Δ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ σ
+    ⊢ ⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ ⇑ᶜ r
+      ∶ ⇑ᵗ (src p) ⊒ ＇ suc α
+right-seal-compose-ν-lift p⨟seal≈r =
+  compose-leftⁿ-add-left-star-var zero
+    (compose-leftⁿ-⇑ˢ p⨟seal≈r)
+
+rightSealInversion2-ν⊒-right-sealed :
+  ∀ {Δ σ γ N W p r A B A₀ α} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
+  Δ ∣ σ ⊢ p ⨾ⁿ seal A₀ α ≈ r ∶ src p ⊒ ＇ α →
+  suc Δ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+    ⊢ N ⊒ ⇑ᵗᵐ W ∶ ⇑ᶜ p →
+  ∃[ u ]
+    (Δ ∣ σ ⊢ p ⨾ⁿ seal A₀ α ≈ u ∶ src p ⊒ ＇ α) ×
+    Δ ∣ σ ∣ γ ⊢ ν ★ N (⇑ᶜ p) ⊒ W ⟨ seal A₀ α ⟩ ∶ u
+rightSealInversion2-ν⊒-right-sealed pᶜ p⨟seal≈r N⊒W =
+  _ , p⨟seal≈r , ⊒cast- pᶜ p⨟seal≈r (ν⊒ pᶜ N⊒W)
 
 rightSealInversion2-cast+ :
   ∀ {Δ σ γ M M′ V q r s A B C D A₀ α} →

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -92,9 +92,25 @@ rightSealInversion2-cast+ {s = c ↦ d} ()
     qᶜ q⨟s≈r M⊒M′
 rightSealInversion2-cast+ {s = `∀ c} ()
     qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = G !} ()
+rightSealInversion2-cast+ {s = (＇ β) !} ()
     qᶜ q⨟s≈r M⊒M′
-rightSealInversion2-cast+ {s = G ？} ()
+rightSealInversion2-cast+ {s = (‵ ι) !} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = ★ !} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = (A ⇒ B) !} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = (`∀ A) !} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = (＇ β) ？} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = (‵ ι) ？} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = ★ ？} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = (A ⇒ B) ？} ()
+    qᶜ q⨟s≈r M⊒M′
+rightSealInversion2-cast+ {s = (`∀ A) ？} ()
     qᶜ q⨟s≈r M⊒M′
 rightSealInversion2-cast+ {s = seal A α} refl
     qᶜ q⨟seal≈r M⊒V =

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -15,6 +15,7 @@ open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.Nat using (zero; suc; z<s; s<s)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong)
 
 open import Types
 open import Coercions
@@ -172,9 +173,16 @@ rightSealInversion2-aux eq (extend qᶜ pαᶜ M⊒T)
   extendReplaceRel-compose-left (replace-here qᶜ) q⨟seal≈r ,
   extendReplaceRel-term (replace-here qᶜ) M⊒V
 -- The `split` case changes both the store and the left term's opened type
--- variable.  The same store replacement lemmas handle the store component,
--- but the proof still needs an opening-transport lemma for the stripped term.
-rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T) = {!!}
+-- variable.  The recursive inversion strips the target cast under
+-- `(α ꞉ q) ∷ σ`; the remaining step must transport both the composition
+-- evidence and the stripped relation to
+-- `(α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ`, changing the source
+-- opening from `N [ α ]ᵀ` to `N [ αᵢ ]ᵀ`.
+rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T)
+    with rightSealInversion2-aux eq M⊒T
+rightSealInversion2-aux eq (split qᶜ pαᶜ M⊒T)
+    | r , pα⨟seal≈r , Nα⊒V =
+  {!!}
 rightSealInversion2-aux () (⊒blame pᶜ)
 rightSealInversion2-aux () (x⊒x pᶜ x∋p)
 rightSealInversion2-aux () (ƛ⊒ƛ p↦qᶜ N⊒N′)
@@ -192,7 +200,11 @@ rightSealInversion2-aux () (⊒ν pᶜ N⊒N′)
 -- `⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ r`; rebuilding needs an
 -- unshifting lemma that factors this through a witness for
 -- `p ⨾ⁿ seal A α`.
-rightSealInversion2-aux eq (ν⊒ pᶜ N⊒N′) = {!!}
+rightSealInversion2-aux {V = V} eq (ν⊒ pᶜ N⊒N′)
+    with rightSealInversion2-aux (cong ⇑ᵗᵐ eq) N⊒N′
+rightSealInversion2-aux {V = V} eq (ν⊒ pᶜ N⊒N′)
+    | r , ⇑p⨟seal≈r , N⊒⇑V =
+  {!!}
 rightSealInversion2-aux () (κ⊒κ κ)
 rightSealInversion2-aux () (⊕⊒⊕ M⊒M′ N⊒N′)
 -- Direct right-positive seal cast.  Here the syntax of `- (seal A α)` is
@@ -226,8 +238,16 @@ rightSealInversion2-aux eq (⊒cast- qᶜ q⨟s≈r M⊒M′) =
 -- typing for the witness, or a derived left-cast transport lemma that produces
 -- the stripped term relation without exposing that `∶ᶜ` requirement at the
 -- call site.
-rightSealInversion2-aux eq (cast+⊒ pᶜ r≈t⨟p M⊒M′) = {!!}
-rightSealInversion2-aux eq (cast-⊒ pᶜ r≈t⨟p M⊒M′) = {!!}
+rightSealInversion2-aux eq (cast+⊒ pᶜ r≈t⨟p M⊒M′)
+    with rightSealInversion2-aux eq M⊒M′
+rightSealInversion2-aux eq (cast+⊒ pᶜ r≈t⨟p M⊒M′)
+    | u , p⨟seal≈u , M⊒V =
+  {!!}
+rightSealInversion2-aux eq (cast-⊒ pᶜ r≈t⨟p M⊒M′)
+    with rightSealInversion2-aux eq M⊒M′
+rightSealInversion2-aux eq (cast-⊒ pᶜ r≈t⨟p M⊒M′)
+    | u , r⨟seal≈u , M⊒V =
+  {!!}
 
 rightSealInversion2 : RightSealInversion2
 rightSealInversion2 M⊒Vunseal =

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -11,10 +11,14 @@ module proof.RightSealInversion2 where
 --     the proof obligations that arise from store-shaping and left-cast cases.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (z<s; s<s)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 
 open import Types
 open import Coercions
+open import Primitives
 open import NuTerms
 open import NarrowWiden
 open import NarrowWidenComposition
@@ -25,6 +29,7 @@ open import proof.Catchup using
   ; extendReplaceRel-term
   )
 open import proof.CoercionProperties using (coercion-src-tgtᵐ)
+open import proof.NarrowWidenProperties using (StoreDetWf)
 
 RightSealInversion2 : Set₁
 RightSealInversion2 =
@@ -141,11 +146,12 @@ rightSealInversion2-aux () (α⊒α qᶜ pαᶜ L⊒L′)
 rightSealInversion2-aux () (⊒α pαᶜ L⊒L′)
 rightSealInversion2-aux () (ν⊒ν pᶜ qᶜ N⊒N′)
 rightSealInversion2-aux () (⊒ν pᶜ N⊒N′)
--- The `ν⊒` case is a left wrapper: the right term is unconstrained, so
--- the proof should recurse under `⇑ᵗᵐ` and then rebuild `ν⊒`.  The attempted
--- recursive call produces a shifted composition
--- `⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ r`; rebuilding needs an unshifting
--- lemma that factors this through a witness for `p ⨾ⁿ seal A α`.
+-- The `ν⊒` case is a left wrapper: the right term is unconstrained, so the
+-- proof should recurse under `⇑ᵗᵐ` and then rebuild `ν⊒`.
+-- The attempted recursive call produces a shifted composition
+-- `⇑ᶜ p ⨾ⁿ seal (⇑ᵗ A) (suc α) ≈ r`; rebuilding needs an
+-- unshifting lemma that factors this through a witness for
+-- `p ⨾ⁿ seal A α`.
 rightSealInversion2-aux eq (ν⊒ pᶜ N⊒N′) = {!!}
 rightSealInversion2-aux () (κ⊒κ κ)
 rightSealInversion2-aux () (⊕⊒⊕ M⊒M′ N⊒N′)
@@ -189,3 +195,191 @@ rightSealInversion2 M⊒Vunseal =
 
 right-seal-inversion₂ : RightSealInversion2
 right-seal-inversion₂ = rightSealInversion2
+
+------------------------------------------------------------------------
+-- Counterexample search: ν-wrapped right unseal
+------------------------------------------------------------------------
+
+private
+  NatTy : Ty
+  NatTy = ‵ `ℕ
+
+  alpha0 : TyVar
+  alpha0 = 0
+
+  alpha1 : TyVar
+  alpha1 = 1
+
+  k0 : Const
+  k0 = κℕ 0
+
+  Store0 : Store
+  Store0 = (alpha0 , NatTy) ∷ []
+
+  Sigma0 : StoreNrw
+  Sigma0 = (alpha0 ꞉ id NatTy) ∷ []
+
+  Store1Target : Store
+  Store1Target = (alpha1 , NatTy) ∷ []
+
+  Store1Source : Store
+  Store1Source = (0 , ★) ∷ Store1Target
+
+  Sigma1 : StoreNrw
+  Sigma1 = (⊒ 0 ꞉=☆) ∷ (alpha1 ꞉ id NatTy) ∷ []
+
+  seal0 : Coercion
+  seal0 = seal NatTy alpha0
+
+  seal1 : Coercion
+  seal1 = seal NatTy alpha1
+
+  unseal0 : Coercion
+  unseal0 = unseal alpha0 NatTy
+
+  wfStore0 : StoreDetWf 1 Store0
+  wfStore0 =
+    record
+      { at = record
+          { bound = λ { (here refl) → z<s }
+          ; wfTy = λ { (here refl) → wfBase }
+          }
+      ; wfOlder = λ { (here refl) → wfBase }
+      ; unique = λ { (here refl) (here refl) → refl }
+      }
+
+  wfStore1Target : StoreDetWf 2 Store1Target
+  wfStore1Target =
+    record
+      { at = record
+          { bound = λ { (here refl) → s<s z<s }
+          ; wfTy = λ { (here refl) → wfBase }
+          }
+      ; wfOlder = λ { (here refl) → wfBase }
+      ; unique = λ { (here refl) (here refl) → refl }
+      }
+
+  wfStore1Source : StoreDetWf 2 Store1Source
+  wfStore1Source =
+    record
+      { at = record
+          { bound = λ { (here refl) → z<s ; (there (here refl)) → s<s z<s }
+          ; wfTy = λ { (here refl) → wf★ ; (there (here refl)) → wfBase }
+          }
+      ; wfOlder = λ
+          { (here refl) → wf★
+          ; (there (here refl)) → wfBase
+          }
+      ; unique = λ
+          { (here refl) (here refl) → refl
+          ; (here refl) (there (here ()))
+          ; (there (here ())) (here refl)
+          ; (there (here refl)) (there (here refl)) → refl
+          }
+      }
+
+  Sigma0⊒ : 1 ⊢ Sigma0 ꞉ Store0 ⊒ˢ Store0
+  Sigma0⊒ =
+    ⊒ˢ-both wfBase wfBase
+      (id-onlyᵈ , (cast-id wfBase refl , cross (id-‵ `ℕ)))
+      ⊒ˢ-nil
+
+  Sigma1⊒ : 2 ⊢ Sigma1 ꞉ Store1Source ⊒ˢ Store1Target
+  Sigma1⊒ =
+    ⊒ˢ-left
+      (⊒ˢ-both wfBase wfBase
+        (id-onlyᵈ , (cast-id wfBase refl , cross (id-‵ `ℕ)))
+        ⊒ˢ-nil)
+
+  endpoints0 : EndpointWf 1 Store0 NatTy (＇ alpha0)
+  endpoints0 = wfBaseˢ , wfVarˢ (here refl)
+
+  endpoints1Target : EndpointWf 2 Store1Target NatTy (＇ alpha1)
+  endpoints1Target = wfBaseˢ , wfVarˢ (here refl)
+
+  endpoints1Source : EndpointWf 2 Store1Source NatTy (＇ alpha1)
+  endpoints1Source = wfBaseˢ , wfVarˢ (there (here refl))
+
+  idNatᶜ : ∀ {Δ Σ} → Δ ∣ Σ ⊢ id NatTy ∶ᶜ NatTy ⊒ NatTy
+  idNatᶜ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+  idNat⊒ : ∀ {Δ Σ} →
+    seal-or-idᵈ ∣ Δ ∣ Σ ⊢ id NatTy ∶ NatTy ⊒ NatTy
+  idNat⊒ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+  seal0⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ seal0 ∶ NatTy ⊒ ＇ alpha0
+  seal0⊒ = cast-seal wfBase (here refl) refl , sealⁿ NatTy alpha0
+
+  seal1⊒Target :
+    seal-or-idᵈ ∣ 2 ∣ Store1Target ⊢ seal1 ∶ NatTy ⊒ ＇ alpha1
+  seal1⊒Target =
+    cast-seal wfBase (here refl) refl , sealⁿ NatTy alpha1
+
+  seal1⊒Source :
+    seal-or-idᵈ ∣ 2 ∣ Store1Source ⊢ seal1 ∶ NatTy ⊒ ＇ alpha1
+  seal1⊒Source =
+    cast-seal wfBase (there (here refl)) refl , sealⁿ NatTy alpha1
+
+  right-seal-compose0 :
+    1 ∣ Sigma0 ⊢ id NatTy ⨾ⁿ seal0 ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
+  right-seal-compose0 =
+    compose-leftⁿ wfStore0 idNat⊒ seal0⊒
+      (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+        (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
+        (seal-or-idᵈ , seal0⊒))
+
+  right-seal-compose1 :
+    2 ∣ Sigma1 ⊢ id NatTy ⨾ⁿ seal1 ≈ seal1 ∶ NatTy ⊒ ＇ alpha1
+  right-seal-compose1 =
+    compose-leftⁿ wfStore1Target idNat⊒ seal1⊒Target
+      (endpointsⁿ refl refl refl refl
+        Sigma1⊒
+        endpoints1Target
+        endpoints1Source
+        (seal-or-idᵈ ,
+          proj₂ (_⨟ⁿ_ {wfΣ = wfStore1Target} idNat⊒ seal1⊒Target))
+        (seal-or-idᵈ , seal1⊒Source))
+
+  right-sealed-constant1 :
+    2 ∣ Sigma1 ∣ [] ⊢ $ k0 ⊒ ($ k0) ⟨ seal1 ⟩ ∶ seal1
+  right-sealed-constant1 =
+    ⊒cast- idNatᶜ right-seal-compose1 (κ⊒κ k0)
+
+  right-unsealed-constant1 :
+    2 ∣ Sigma1 ∣ []
+      ⊢ $ k0 ⊒ (($ k0) ⟨ seal1 ⟩) ⟨ unseal alpha1 NatTy ⟩
+      ∶ id NatTy
+  right-unsealed-constant1 =
+    ⊒cast+ idNatᶜ right-seal-compose1 right-sealed-constant1
+
+  right-seal-inversion₂-counterexample-premise :
+    1 ∣ Sigma0 ∣ []
+      ⊢ ν ★ ($ k0) (⇑ᶜ (id NatTy))
+        ⊒ (($ k0) ⟨ seal0 ⟩) ⟨ unseal0 ⟩
+      ∶ id NatTy
+  right-seal-inversion₂-counterexample-premise =
+    ν⊒ idNatᶜ right-unsealed-constant1
+
+  -- This was the first ν-shaped counterexample candidate.  It fails: the
+  -- stripped conclusion is rebuilt by relating the ν term to the bare constant
+  -- at `id Nat`, then adding the right seal with `⊒cast-`.
+  right-seal-inversion₂-ν-candidate-stripped :
+    1 ∣ Sigma0 ∣ []
+      ⊢ ν ★ ($ k0) (⇑ᶜ (id NatTy)) ⊒ ($ k0) ⟨ seal0 ⟩
+      ∶ seal0
+  right-seal-inversion₂-ν-candidate-stripped =
+    ⊒cast-
+      idNatᶜ
+      right-seal-compose0
+      (ν⊒ idNatᶜ (κ⊒κ k0))
+
+right-seal-inversion₂-ν-candidate-result :
+  ∃[ r ]
+    (1 ∣ Sigma0
+      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0) ×
+    1 ∣ Sigma0 ∣ []
+      ⊢ ν ★ ($ k0) (⇑ᶜ (id NatTy)) ⊒ ($ k0) ⟨ seal0 ⟩ ∶ r
+right-seal-inversion₂-ν-candidate-result =
+  seal0 ,
+  right-seal-compose-endpoints right-seal-compose0 ,
+  right-seal-inversion₂-ν-candidate-stripped

--- a/GTSF/proof/RightSealInversionCounterexample.agda
+++ b/GTSF/proof/RightSealInversionCounterexample.agda
@@ -195,6 +195,20 @@ counterexample-premise :
 counterexample-premise =
   cast-⊒ idAlphaᶜ left-seal-compose right-sealed-constant
 
+old-counterexample-revised-premise⊥ :
+  ∀ {q C} →
+  1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ []
+    ⊢ q ⨾ⁿ seal (‵ `ℕ) 0 ≈ id (＇ 0) ∶ C ⊒ ＇ 0 →
+  ⊥
+old-counterexample-revised-premise⊥
+    (compose-leftⁿ wfΣ q⊒
+      (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+      (endpointsⁿ src-u tgt-u src-id tgt-id σ⊒ wfΣ₁ wfΣ₂ u⊒ id⊒)) =
+  let
+    q⊒Nat = subst (λ A → _ ∣ _ ∣ _ ⊢ _ ∶ A ⊒ NatTy) (sym src-id) q⊒
+  in
+  narrowing-var-to-older⊥ wfΣ wfBase q⊒Nat
+
 stripped-impossible :
   ∀ {q} →
   1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ∣ []


### PR DESCRIPTION
## Summary
- specialize `RightSealInversion2` to the facts already available at the DGG
  `⊒cast+ {s = seal B α}` call site
- keep the old broader claim as `GeneralRightSealInversion2` and leave the
  existing counterexample pointed at that false statement
- add `right-seal-inversion₂-cast-unseal⊥` for the impossible
  `⊒cast- {s = unseal α B}` DGG branch
- remove the abandoned induction skeleton and `--allow-unsolved-metas` from
  `proof.RightSealInversion2`

## Why
The general inversion over an arbitrary derivation of the seal/unseal redex
shape runs into unrelated wrapper cases such as `ν⊒`, `split`, and left casts.
The dynamic gradual guarantee site already pattern matches on the direct
right-cast constructor and has both the composition equation and the stripped
premise, so the useful lemma only needs to normalize the composition endpoints.

## Validation
- `agda -v0 proof/RightSealInversion2.agda`
- `agda -v0 proof/DynamicGradualGuarantee.agda`
- `git diff --check`
