### PR TITLE
[codex] Thread RuntimeOK through GTSF DGG

### DIFF
--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -56,7 +56,14 @@ open import proof.CoercionProperties
 open import proof.NuTermProperties
   using
     ( renameᵗᵐ-left-inverse
+    ; renameᵗᵐ-preserves-No•
     ; renameᵗᵐ-preserves-Value
+    )
+open import proof.NuPreservation
+  using
+    ( runtime-⟨⟩
+    ; runtime-ν
+    ; value-runtime-No•
     )
 open import proof.ReductionProperties
   using
@@ -127,6 +134,39 @@ open import proof.CatchupStore
     ; combineStoreNrw-applyStores-store
     )
 
+runtime-⇑ᵗᵐ :
+  ∀ {M} →
+  RuntimeOK M →
+  RuntimeOK (⇑ᵗᵐ M)
+runtime-⇑ᵗᵐ (ok-no noM) =
+  ok-no (renameᵗᵐ-preserves-No• suc noM)
+runtime-⇑ᵗᵐ (ok-• vV noV) =
+  ok-• (renameᵗᵐ-preserves-Value suc vV)
+       (renameᵗᵐ-preserves-No• suc noV)
+runtime-⇑ᵗᵐ (ok-·₁ okL noM) =
+  ok-·₁ (runtime-⇑ᵗᵐ okL) (renameᵗᵐ-preserves-No• suc noM)
+runtime-⇑ᵗᵐ (ok-·₂ vV noV okM) =
+  ok-·₂ (renameᵗᵐ-preserves-Value suc vV)
+        (renameᵗᵐ-preserves-No• suc noV)
+        (runtime-⇑ᵗᵐ okM)
+runtime-⇑ᵗᵐ (ok-ν okL) = ok-ν (runtime-⇑ᵗᵐ okL)
+runtime-⇑ᵗᵐ (ok-⊕₁ okL noM) =
+  ok-⊕₁ (runtime-⇑ᵗᵐ okL) (renameᵗᵐ-preserves-No• suc noM)
+runtime-⇑ᵗᵐ (ok-⊕₂ vL noL okM) =
+  ok-⊕₂ (renameᵗᵐ-preserves-Value suc vL)
+        (renameᵗᵐ-preserves-No• suc noL)
+        (runtime-⇑ᵗᵐ okM)
+runtime-⇑ᵗᵐ (ok-⟨⟩ okM) = ok-⟨⟩ (runtime-⇑ᵗᵐ okM)
+
+postulate
+  -- `split` changes which fresh type variable the source term is opened at.
+  -- This should follow from `RuntimeOK` depending on the term/bullet shape
+  -- rather than the particular type-variable names in casts and annotations.
+  runtime-open-change :
+    ∀ {N α β} →
+    RuntimeOK (N [ α ]ᵀ) →
+    RuntimeOK (N [ β ]ᵀ)
+
 ------------------------------------------------------------------------
 -- Catchup
 ------------------------------------------------------------------------
@@ -147,11 +187,13 @@ postulate
   left-widening-lemma :
     ∀ {Δ σ V V′ p r t A B C D} →
     Value V →
+    No• V →
     Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
     Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
     Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p →
     ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
       Value W ×
+      No• W ×
       (V ⟨ - t ⟩ —↠[ χs ] W) ×
       (Δ′ ≡ applyTyCtxs χs Δ) ×
       (Π ≡ applyStores χs []) ×
@@ -165,11 +207,13 @@ postulate
   left-narrowing-lemma :
     ∀ {Δ σ V V′ p r t A B C D} →
     Value V →
+    No• V →
     Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
     Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
     Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ r →
     ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
       Value W ×
+      No• W ×
       (V ⟨ t ⟩ —↠[ χs ] W) ×
       (Δ′ ≡ applyTyCtxs χs Δ) ×
       (Π ≡ applyStores χs []) ×
@@ -200,6 +244,7 @@ postulate
       ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs p →
     ∃[ χs′ ] ∃[ W′ ] ∃[ Δ″ ] ∃[ Π″ ] ∃[ Π″′ ] ∃[ π′ ]
       Value W′ ×
+      No• W′ ×
       (N —↠[ χs′ ] W′) ×
       (Δ″ ≡ applyTyCtxs χs′ Δ) ×
       (Π″ ≡ applyStores χs′ []) ×
@@ -227,6 +272,7 @@ postulate
       ⊢ W ⊒ applyTerms χs (V′ ⟨ s ⟩) ∶ applyCoercions χs p →
     ∃[ χs′ ] ∃[ W′ ] ∃[ Δ″ ] ∃[ Π″ ] ∃[ Π″′ ] ∃[ π′ ]
       Value W′ ×
+      No• W′ ×
       (N —↠[ χs′ ] W′) ×
       (Δ″ ≡ applyTyCtxs χs′ Δ) ×
       (Π″ ≡ applyStores χs′ []) ×
@@ -1352,6 +1398,7 @@ postulate
   catchup-split-catchup :
     ∀ {Δ σ χs W Δ′ Π Π′ π N N′ α αᵢ p q A C D} →
     Value W →
+    No• W →
     (N [ α ]ᵀ —↠[ χs ] W) →
     Δ′ ≡ applyTyCtxs χs Δ →
     Π ≡ applyStores χs [] →
@@ -1366,6 +1413,7 @@ postulate
         ∶ applyCoercions χs (p [ α ]ᶜ) →
     ∃[ χs′ ] ∃[ W′ ] ∃[ Δ″ ] ∃[ Π″ ] ∃[ Π″′ ] ∃[ π′ ]
       Value W′ ×
+      No• W′ ×
       (N [ αᵢ ]ᵀ —↠[ χs′ ] W′) ×
       (Δ″ ≡ applyTyCtxs χs′ Δ) ×
       (Π″ ≡ applyStores χs′ []) ×
@@ -1379,6 +1427,7 @@ postulate
 catchup-⊒Λ-catchup :
   ∀ {Δ σ χs W Δ′ Π Π′ π A B N V′ p} →
   Value W →
+  No• W →
   (⇑ᵗᵐ N —↠[ χs ] W) →
   Δ′ ≡ applyTyCtxs χs (suc Δ) →
   Π ≡ applyStores χs [] →
@@ -1389,6 +1438,7 @@ catchup-⊒Λ-catchup :
     ⊢ W ⊒ applyTerms χs V′ ∶ applyCoercions χs p →
   ∃[ χs′ ] ∃[ W′ ] ∃[ Δ″ ] ∃[ Π″ ] ∃[ Π″′ ] ∃[ π′ ]
     Value W′ ×
+    No• W′ ×
     (N —↠[ χs′ ] W′) ×
     (Δ″ ≡ applyTyCtxs χs′ Δ) ×
     (Π″ ≡ applyStores χs′ []) ×
@@ -1398,13 +1448,13 @@ catchup-⊒Λ-catchup :
       ⊢ W′ ⊒ applyTerms χs′ (Λ V′)
         ∶ applyCoercions χs′ (gen A p)
 catchup-⊒Λ-catchup {σ = σ} {A = A} {B = B} {V′ = V′} {p = p}
-    vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒V′
+    vW noW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒V′
     with shifted-source-catchup-Λ-inversion
       vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ W⊒V′
 catchup-⊒Λ-catchup {σ = σ} {A = A} {B = B} {V′ = V′} {p = p}
-    vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒V′
+    vW noW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒V′
     | χs′ , W′ , Δ″ , Π″ , Π″′ , π′ ,
-      vW′ , N↠W′ , Δ″≡ , Π″≡ , Π″′≡ , π′⊒ , body =
+      vW′ , noW′ , N↠W′ , Δ″≡ , Π″≡ , Π″′≡ , π′⊒ , body =
   let
     pᶜ′ =
       catchup-gen-coercion-typing-transport
@@ -1416,6 +1466,7 @@ catchup-⊒Λ-catchup {σ = σ} {A = A} {B = B} {V′ = V′} {p = p}
   in
   χs′ , W′ , Δ″ , Π″ , Π″′ , π′ ,
   vW′ ,
+  noW′ ,
   N↠W′ ,
   Δ″≡ ,
   Π″≡ ,
@@ -1435,6 +1486,7 @@ catchup-⊒Λ-catchup {σ = σ} {A = A} {B = B} {V′ = V′} {p = p}
 catchup-⊒⟨ν⟩-catchup :
   ∀ {Δ σ χs W Δ′ Π Π′ π A B N V′ p s} →
   Value W →
+  No• W →
   (⇑ᵗᵐ N —↠[ χs ] W) →
   Δ′ ≡ applyTyCtxs χs (suc Δ) →
   Π ≡ applyStores χs [] →
@@ -1446,6 +1498,7 @@ catchup-⊒⟨ν⟩-catchup :
     ⊢ W ⊒ applyTerms χs (V′ ⟨ s ⟩) ∶ applyCoercions χs p →
   ∃[ χs′ ] ∃[ W′ ] ∃[ Δ″ ] ∃[ Π″ ] ∃[ Π″′ ] ∃[ π′ ]
     Value W′ ×
+    No• W′ ×
     (N —↠[ χs′ ] W′) ×
     (Δ″ ≡ applyTyCtxs χs′ Δ) ×
     (Π″ ≡ applyStores χs′ []) ×
@@ -1456,14 +1509,14 @@ catchup-⊒⟨ν⟩-catchup :
         ∶ applyCoercions χs′ (gen A p)
 catchup-⊒⟨ν⟩-catchup
     {σ = σ} {A = A} {B = B} {V′ = V′} {p = p} {s = s}
-    vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ i W⊒V′s
+    vW noW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ i W⊒V′s
     with shifted-source-catchup-⟨ν⟩-inversion
       vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ W⊒V′s
 catchup-⊒⟨ν⟩-catchup
     {σ = σ} {A = A} {B = B} {V′ = V′} {p = p} {s = s}
-    vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ i W⊒V′s
+    vW noW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ i W⊒V′s
     | χs′ , W′ , Δ″ , Π″ , Π″′ , π′ ,
-      vW′ , N↠W′ , Δ″≡ , Π″≡ , Π″′≡ , π′⊒ , body =
+      vW′ , noW′ , N↠W′ , Δ″≡ , Π″≡ , Π″′≡ , π′⊒ , body =
   let
     pᶜ′ =
       catchup-gen-coercion-typing-transport
@@ -1479,6 +1532,7 @@ catchup-⊒⟨ν⟩-catchup
   in
   χs′ , W′ , Δ″ , Π″ , Π″′ , π′ ,
   vW′ ,
+  noW′ ,
   N↠W′ ,
   Δ″≡ ,
   Π″≡ ,
@@ -1515,6 +1569,7 @@ postulate
     ∀ {Δ σ χs W Δ′ Π Π′ π N V p A B} →
     Value V →
     Value W →
+    No• W →
     (N —↠[ χs ] W) →
     Δ′ ≡ applyTyCtxs χs (suc Δ) →
     Π ≡ applyStores χs [] →
@@ -1525,6 +1580,7 @@ postulate
       ⊢ W ⊒ applyTerms χs (⇑ᵗᵐ V) ∶ applyCoercions χs (⇑ᶜ p) →
     ∃[ χs′ ] ∃[ W′ ] ∃[ Δ″ ] ∃[ Π″ ] ∃[ Π″′ ] ∃[ π′ ]
       Value W′ ×
+      No• W′ ×
       (ν ★ N (⇑ᶜ p) —↠[ χs′ ] W′) ×
       (Δ″ ≡ applyTyCtxs χs′ Δ) ×
       (Π″ ≡ applyStores χs′ []) ×
@@ -1535,10 +1591,12 @@ postulate
 
 catchup-lemma :
   ∀ {Δ σ M V p} →
+  RuntimeOK M →
   Value V →
   Δ ∣ σ ∣ [] ⊢ M ⊒ V ∶ p →
   ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
     Value W ×
+    No• W ×
     (M —↠[ χs ] W) ×
     (Δ′ ≡ applyTyCtxs χs Δ) ×
     (Π ≡ applyStores χs []) ×
@@ -1546,11 +1604,11 @@ catchup-lemma :
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
     Δ′ ∣ combineStoreNrw π σ ∣ []
       ⊢ W ⊒ applyTerms χs V ∶ applyCoercions χs p
-catchup-lemma vV (extend qᶜ pαᶜ M⊒V)
-    with catchup-lemma vV M⊒V
-catchup-lemma vV (extend qᶜ pαᶜ M⊒V)
+catchup-lemma okM vV (extend qᶜ pαᶜ M⊒V)
+    with catchup-lemma okM vV M⊒V
+catchup-lemma okM vV (extend qᶜ pαᶜ M⊒V)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V =
+      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V =
   -- Need transport for catchup evidence through the de Bruijn store-prefix
   -- change made by `extend`: rebuild `extend` after moving the emitted
   -- narrowing `π` under the existing fresh α entry.  The side conditions
@@ -1560,6 +1618,7 @@ catchup-lemma vV (extend qᶜ pαᶜ M⊒V)
   -- source and target stores.
   χs , W , Δ′ , Π , Π′ , π ,
   vW ,
+  noW ,
   M↠W ,
   Δ′≡ ,
   Π≡ ,
@@ -1568,13 +1627,14 @@ catchup-lemma vV (extend qᶜ pαᶜ M⊒V)
   catchup-extend-transport
     {π = π} {χs = χs}
     qᶜ pαᶜ Δ′≡ Π≡ Π′≡ π⊒ W⊒V
-catchup-lemma vV (split qᶜ pαᶜ M⊒V)
-    with catchup-lemma vV M⊒V
-catchup-lemma vV (split qᶜ pαᶜ M⊒V)
+catchup-lemma okM vV (split qᶜ pαᶜ M⊒V)
+    with catchup-lemma (runtime-open-change okM) vV M⊒V
+catchup-lemma okM vV (split qᶜ pαᶜ M⊒V)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V =
+      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V =
   catchup-split-catchup
     vW
+    noW
     M↠W
     Δ′≡
     Π≡
@@ -1583,71 +1643,77 @@ catchup-lemma vV (split qᶜ pαᶜ M⊒V)
     qᶜ
     pαᶜ
     W⊒V
-catchup-lemma () (⊒blame pᶜ)
-catchup-lemma () (x⊒x pᶜ x∋p)
-catchup-lemma (ƛ N′) (ƛ⊒ƛ {N = N} p↦qᶜ N⊒N′) =
+catchup-lemma okM () (⊒blame pᶜ)
+catchup-lemma okM () (x⊒x pᶜ x∋p)
+catchup-lemma okM (ƛ N′) (ƛ⊒ƛ {N = N} p↦qᶜ N⊒N′) =
   [] , ƛ N , _ , [] , [] , [] ,
   ƛ N ,
+  value-runtime-No• (ƛ N) okM ,
   ↠-refl ,
   refl ,
   refl ,
   refl ,
   ⊒ˢ-nil ,
   ƛ⊒ƛ p↦qᶜ N⊒N′
-catchup-lemma () (·⊒· qᶜ L⊒L′ M⊒M′)
-catchup-lemma (Λ vV′) (Λ⊒Λ allᶜ vV V⊒V′) =
+catchup-lemma okM () (·⊒· qᶜ L⊒L′ M⊒M′)
+catchup-lemma okM (Λ vV′) (Λ⊒Λ allᶜ vV V⊒V′) =
   [] , Λ _ , _ , [] , [] , [] ,
   Λ vV ,
+  value-runtime-No• (Λ vV) okM ,
   ↠-refl ,
   refl ,
   refl ,
   refl ,
   ⊒ˢ-nil ,
   Λ⊒Λ allᶜ vV V⊒V′
-catchup-lemma (Λ vV′) (⊒Λ pᶜ N⊒V′)
-    with catchup-lemma vV′ N⊒V′
-catchup-lemma (Λ vV′) (⊒Λ pᶜ N⊒V′)
+catchup-lemma okM (Λ vV′) (⊒Λ pᶜ N⊒V′)
+    with catchup-lemma (runtime-⇑ᵗᵐ okM) vV′ N⊒V′
+catchup-lemma okM (Λ vV′) (⊒Λ pᶜ N⊒V′)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , ⇑N↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
-  catchup-⊒Λ-catchup vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒V′
-catchup-lemma (vV′ ⟨ i ⟩) (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
-    with catchup-lemma (vV′ ⟨ sᵢ ⟩) N⊒V′
-catchup-lemma (vV′ ⟨ i ⟩) (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
+      vW , noW , ⇑N↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
+  catchup-⊒Λ-catchup vW noW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒V′
+catchup-lemma okM (vV′ ⟨ i ⟩) (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
+    with catchup-lemma (runtime-⇑ᵗᵐ okM) (vV′ ⟨ sᵢ ⟩) N⊒V′
+catchup-lemma okM (vV′ ⟨ i ⟩) (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , ⇑N↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′s =
-  catchup-⊒⟨ν⟩-catchup vW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ sᵢ W⊒V′s
-catchup-lemma () (α⊒α qᶜ pαᶜ L⊒L′)
-catchup-lemma () (⊒α pαᶜ L⊒L′)
-catchup-lemma () (ν⊒ν pᶜ qᶜ N⊒N′)
-catchup-lemma () (⊒ν pᶜ N⊒N′)
-catchup-lemma vV (ν⊒ {p = p} pᶜ N⊒V)
-    with catchup-lemma (renameᵗᵐ-preserves-Value suc vV) N⊒V
-catchup-lemma vV (ν⊒ {p = p} pᶜ N⊒V)
+      vW , noW , ⇑N↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′s =
+  catchup-⊒⟨ν⟩-catchup
+    vW noW ⇑N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ sᵢ W⊒V′s
+catchup-lemma okM () (α⊒α qᶜ pαᶜ L⊒L′)
+catchup-lemma okM () (⊒α pαᶜ L⊒L′)
+catchup-lemma okM () (ν⊒ν pᶜ qᶜ N⊒N′)
+catchup-lemma okM () (⊒ν pᶜ N⊒N′)
+catchup-lemma okM vV (ν⊒ {p = p} pᶜ N⊒V)
+    with catchup-lemma (runtime-ν okM)
+           (renameᵗᵐ-preserves-Value suc vV) N⊒V
+catchup-lemma okM vV (ν⊒ {p = p} pᶜ N⊒V)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , N↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒⇑V =
-  catchup-ν⊒-catchup vV vW N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒⇑V
-catchup-lemma {Δ = Δ} ($ κ) (κ⊒κ κ) =
+      vW , noW , N↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒⇑V =
+  catchup-ν⊒-catchup vV vW noW N↠W Δ′≡ Π≡ Π′≡ π⊒ pᶜ W⊒⇑V
+catchup-lemma {Δ = Δ} okM ($ κ) (κ⊒κ κ) =
   [] , $ κ , Δ , [] , [] , [] ,
   $ κ ,
+  no•-$ ,
   ↠-refl ,
   refl ,
   refl ,
   refl ,
   ⊒ˢ-nil ,
   κ⊒κ κ
-catchup-lemma () (⊕⊒⊕ M⊒M′ N⊒N′)
-catchup-lemma {σ = σ} (vV′ ⟨ i ⟩)
+catchup-lemma okM () (⊕⊒⊕ M⊒M′ N⊒N′)
+catchup-lemma {σ = σ} okM (vV′ ⟨ i ⟩)
     (⊒cast+ {M′ = M′} {q = q} {s = s} qᶜ q⨟s≈r M⊒M′)
-    with catchup-lemma vV′ M⊒M′
-catchup-lemma {σ = σ} (vV′ ⟨ i ⟩)
+    with catchup-lemma okM vV′ M⊒M′
+catchup-lemma {σ = σ} okM (vV′ ⟨ i ⟩)
     (⊒cast+ {M′ = M′} {q = q} {s = s} qᶜ q⨟s≈r M⊒M′)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
+      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
   -- Rebuild `⊒cast+` after transporting the side conditions through the
   -- emitted store changes, then rewrite the weakened target cast into the
   -- syntactic shape of `applyTerms χs`.
   χs , W , Δ′ , Π , Π′ , π ,
   vW ,
+  noW ,
   M↠W ,
   Δ′≡ ,
   Π≡ ,
@@ -1665,20 +1731,21 @@ catchup-lemma {σ = σ} (vV′ ⟨ i ⟩)
         {σ = σ} {π = π} {χs = χs} {q = q} {s = s}
         q⨟s≈r Δ′≡ Π≡ Π′≡ π⊒)
       W⊒M′)
-catchup-lemma {σ = σ} (vV′ ⟨ i ⟩)
+catchup-lemma {σ = σ} okM (vV′ ⟨ i ⟩)
     (⊒cast- {M′ = M′} {q = q} {r = r} {s = s}
       qᶜ q⨟s≈r M⊒M′)
-    with catchup-lemma vV′ M⊒M′
-catchup-lemma {σ = σ} (vV′ ⟨ i ⟩)
+    with catchup-lemma okM vV′ M⊒M′
+catchup-lemma {σ = σ} okM (vV′ ⟨ i ⟩)
     (⊒cast- {M′ = M′} {q = q} {r = r} {s = s}
       qᶜ q⨟s≈r M⊒M′)
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
+      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
   -- Same as `⊒cast+`: the recursive narrowing is available, but the cast
   -- typing/equivalence side conditions must be transported to the emitted
   -- Δ′/store-prefix context before `⊒cast-` can be rebuilt.
   χs , W , Δ′ , Π , Π′ , π ,
   vW ,
+  noW ,
   M↠W ,
   Δ′≡ ,
   Π≡ ,
@@ -1696,18 +1763,18 @@ catchup-lemma {σ = σ} (vV′ ⟨ i ⟩)
         {σ = σ} {π = π} {χs = χs} {q = q} {s = s} {r = r}
         q⨟s≈r Δ′≡ Π≡ Π′≡ π⊒)
       W⊒M′)
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast+⊒ {p = p} {r = r} {t = t} pᶜ r≈t⨟p M⊒V)
-    with catchup-lemma vV M⊒V
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+    with catchup-lemma (runtime-⟨⟩ okM) vV M⊒V
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast+⊒ {p = p} {r = r} {t = t} pᶜ r≈t⨟p M⊒V)
     | χs₁ , W₁ , Δ₁ , Π₁ , Π₁′ , π₁ ,
-      vW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
+      vW₁ , noW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
     with cast-dual-↠ {c = t} M↠W₁
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast+⊒ {p = p} {r = r} {t = t} pᶜ r≈t⨟p M⊒V)
     | χs₁ , W₁ , Δ₁ , Π₁ , Π₁′ , π₁ ,
-      vW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
+      vW₁ , noW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
     | M-t↠W₁-t
     with left-widening-lemma
            {Δ = Δ₁} {σ = combineStoreNrw π₁ σ}
@@ -1715,6 +1782,7 @@ catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
            {r = applyCoercions χs₁ r}
            {t = applyCoercions χs₁ t}
            vW₁
+           noW₁
            (catchup-coercion-typing-transport
              {σ = σ} {π = π₁} {χs = χs₁} {p = p}
              pᶜ Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
@@ -1723,13 +1791,13 @@ catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
              {r = r} {t = t} {p = p}
              r≈t⨟p Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
            W₁⊒V
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast+⊒ {p = p} {r = r} {t = t} pᶜ r≈t⨟p M⊒V)
     | χs₁ , W₁ , Δ₁ , Π₁ , Π₁′ , π₁ ,
-      vW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
+      vW₁ , noW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
     | M-t↠W₁-t
     | χs₂ , W₂ , Δ₂ , Π₂ , Π₂′ , π₂ ,
-      vW₂ , W₁-t↠W₂ , Δ₂≡ , Π₂≡ , Π₂′≡ , π₂⊒ , W₂⊒V =
+      vW₂ , noW₂ , W₁-t↠W₂ , Δ₂≡ , Π₂≡ , Π₂′≡ , π₂⊒ , W₂⊒V =
   -- Catch up `M` to the value `W₁`, lift that reduction through the surrounding
   -- dual cast, invoke the value-level Left Widening Lemma on the transformed
   -- cast, and combine the two emitted source-only store prefixes.
@@ -1737,6 +1805,7 @@ catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
   srcStoreⁿ (combineStoreNrw π₂ π₁) , [] ,
   combineStoreNrw π₂ π₁ ,
   vW₂ ,
+  noW₂ ,
   ↠-trans M-t↠W₁-t W₁-t↠W₂ ,
   trans Δ₂≡
     (trans (cong (applyTyCtxs χs₂) Δ₁≡)
@@ -1763,24 +1832,25 @@ catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
             applyCoercions χs₂ (applyCoercions χs₁ r))
         (sym (combineStoreNrw-assoc π₂ π₁ σ))
         W₂⊒V))
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast-⊒ {p = p} {t = t} pᶜ r≈t⨟p M⊒V)
-    with catchup-lemma vV M⊒V
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+    with catchup-lemma (runtime-⟨⟩ okM) vV M⊒V
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast-⊒ {p = p} {t = t} pᶜ r≈t⨟p M⊒V)
     | χs₁ , W₁ , Δ₁ , Π₁ , Π₁′ , π₁ ,
-      vW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
+      vW₁ , noW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
     with cast-↠ {c = t} M↠W₁
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast-⊒ {p = p} {t = t} pᶜ r≈t⨟p M⊒V)
     | χs₁ , W₁ , Δ₁ , Π₁ , Π₁′ , π₁ ,
-      vW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
+      vW₁ , noW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
     | Mt↠W₁t
     with left-narrowing-lemma
            {Δ = Δ₁} {σ = combineStoreNrw π₁ σ}
            {p = applyCoercions χs₁ p}
            {t = applyCoercions χs₁ t}
            vW₁
+           noW₁
            (catchup-coercion-typing-transport
              {σ = σ} {π = π₁} {χs = χs₁} {p = p}
              pᶜ Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
@@ -1789,13 +1859,13 @@ catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
              {t = t} {p = p}
              r≈t⨟p Δ₁≡ Π₁≡ Π₁′≡ π₁⊒)
            W₁⊒V
-catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
+catchup-lemma {Δ = Δ} {σ = σ} {V = V} okM vV
     (cast-⊒ {p = p} {t = t} pᶜ r≈t⨟p M⊒V)
     | χs₁ , W₁ , Δ₁ , Π₁ , Π₁′ , π₁ ,
-      vW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
+      vW₁ , noW₁ , M↠W₁ , Δ₁≡ , Π₁≡ , Π₁′≡ , π₁⊒ , W₁⊒V
     | Mt↠W₁t
     | χs₂ , W₂ , Δ₂ , Π₂ , Π₂′ , π₂ ,
-      vW₂ , W₁t↠W₂ , Δ₂≡ , Π₂≡ , Π₂′≡ , π₂⊒ , W₂⊒V =
+      vW₂ , noW₂ , W₁t↠W₂ , Δ₂≡ , Π₂≡ , Π₂′≡ , π₂⊒ , W₂⊒V =
   -- Same structure for Left Narrowing: the non-value source is handled by the
   -- recursive catchup call, and the paper lemma is applied only to the caught-up
   -- value, again using the transformed cast and composed source-only prefix.
@@ -1803,6 +1873,7 @@ catchup-lemma {Δ = Δ} {σ = σ} {V = V} vV
   srcStoreⁿ (combineStoreNrw π₂ π₁) , [] ,
   combineStoreNrw π₂ π₁ ,
   vW₂ ,
+  noW₂ ,
   ↠-trans Mt↠W₁t W₁t↠W₂ ,
   trans Δ₂≡
     (trans (cong (applyTyCtxs χs₂) Δ₁≡)

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -21,13 +21,32 @@ open import NuTerms
 open import NuReduction
 open import NarrowWiden
 open import TermNarrowing
-open import proof.Catchup using (catchup-lemma)
+open import proof.Catchup
+  using (catchup-lemma; runtime-open-change; runtime-⇑ᵗᵐ)
 open import proof.CatchupStore using (combineStoreNrw)
 open import proof.LeftSealNarrowingInversion using
   (LeftSealNarrowingInversion; leftSealNarrowingInversion)
 open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowing)
+open import proof.NuPreservation using
+  (runtime-·₁; runtime-⟨⟩; runtime-ν; runtime-⊕₁)
+
+runtime-·₂-any :
+  ∀ {L M} →
+  RuntimeOK (L · M) →
+  RuntimeOK M
+runtime-·₂-any (ok-no (no•-· noL noM)) = ok-no noM
+runtime-·₂-any (ok-·₁ okL noM) = ok-no noM
+runtime-·₂-any (ok-·₂ vL noL okM) = okM
+
+runtime-⊕₂-any :
+  ∀ {L op M} →
+  RuntimeOK (L ⊕[ op ] M) →
+  RuntimeOK M
+runtime-⊕₂-any (ok-no (no•-⊕ noL noM)) = ok-no noM
+runtime-⊕₂-any (ok-⊕₁ okL noM) = ok-no noM
+runtime-⊕₂-any (ok-⊕₂ vL noL okM) = okM
 
 ------------------------------------------------------------------------
 -- Lemmas used by the cambridge25 top-down proof
@@ -104,6 +123,7 @@ function-application-simulation-ƛ⊒ƛ {N = N} {V = V} vV N⊒N′ V⊒V′ =
 
 function-application-simulation :
   ∀ {Δ σ L L′ M N′ V′ r p q} →
+  RuntimeOK M →
   Value V′ →
   Δ ∣ σ ∣ [] ⊢ L ⊒ L′ ∶ r →
   L′ ≡ ƛ N′ →
@@ -115,47 +135,63 @@ function-application-simulation :
     (Π′ ≡ applyStore keep []) ×
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
     Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ [ V′ ] ∶ q′
-function-application-simulation vV′ (extend qᶜ pαᶜ L⊒L′) eq eqr M⊒V′ =
+function-application-simulation okM vV′
+    (extend qᶜ pαᶜ L⊒L′) eq eqr M⊒V′ =
   {!!}
-function-application-simulation vV′ (split qᶜ pαᶜ L⊒L′) eq eqr M⊒V′ =
+function-application-simulation okM vV′
+    (split qᶜ pαᶜ L⊒L′) eq eqr M⊒V′ =
   {!!}
-function-application-simulation vV′ (⊒blame pᶜ) () eqr M⊒V′
-function-application-simulation vV′ (x⊒x pᶜ x∋p) () eqr M⊒V′
+function-application-simulation okM vV′ (⊒blame pᶜ) () eqr M⊒V′
+function-application-simulation okM vV′ (x⊒x pᶜ x∋p) () eqr M⊒V′
 -- The direct λ/λ case reduces to the beta helper once the source argument is
 -- known to be a value.  The full proof should obtain that value by catchup.
-function-application-simulation vV′ (ƛ⊒ƛ {N = N} {N′ = N′} p↦qᶜ N⊒N′)
+function-application-simulation okM vV′
+    (ƛ⊒ƛ {N = N} {N′ = N′} p↦qᶜ N⊒N′)
     refl refl M⊒V′
-    with catchup-lemma vV′ M⊒V′
-function-application-simulation vV′ (ƛ⊒ƛ {N = N} {N′ = N′} p↦qᶜ N⊒N′)
+    with catchup-lemma okM vV′ M⊒V′
+function-application-simulation okM vV′
+    (ƛ⊒ƛ {N = N} {N′ = N′} p↦qᶜ N⊒N′)
     refl refl M⊒V′
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′
+      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′
     with function-application-simulation-ƛ⊒ƛ
            {N = N} {N′ = N′} {V = W} {V′ = _} vW {!!} W⊒V′
-function-application-simulation vV′ (ƛ⊒ƛ {N = N} {N′ = N′} p↦qᶜ N⊒N′)
+function-application-simulation okM vV′
+    (ƛ⊒ƛ {N = N} {N′ = N′} p↦qᶜ N⊒N′)
     refl refl M⊒V′
     | χs , W , Δ′ , Π , Π′ , π ,
-      vW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′
+      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′
     | χsβ , P , Δβ , Πβ , Πβ′ , πβ , qβ ,
       β↠ , Πβ≡ , Πβ′≡ , πβ⊒ , P⊒N′ =
   {!!}
-function-application-simulation vV′ (·⊒· qᶜ L⊒L′ M⊒M′) () eqr M⊒V′
-function-application-simulation vV′ (Λ⊒Λ allᶜ vV V⊒V′) () eqr M⊒V′
-function-application-simulation vV′ (⊒Λ pᶜ N⊒V′) () eqr M⊒V′
-function-application-simulation vV′ (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) () eqr M⊒V′
-function-application-simulation vV′ (α⊒α qᶜ pαᶜ L⊒L′) () eqr M⊒V′
-function-application-simulation vV′ (⊒α pαᶜ L⊒L′) () eqr M⊒V′
-function-application-simulation vV′ (ν⊒ν pᶜ qᶜ N⊒N′) () eqr M⊒V′
-function-application-simulation vV′ (⊒ν pᶜ L⊒L′) () eqr M⊒V′
-function-application-simulation vV′ (ν⊒ pᶜ L⊒L′) refl eqr M⊒V′ =
+function-application-simulation okM vV′
+    (·⊒· qᶜ L⊒L′ M⊒M′) () eqr M⊒V′
+function-application-simulation okM vV′
+    (Λ⊒Λ allᶜ vV V⊒V′) () eqr M⊒V′
+function-application-simulation okM vV′ (⊒Λ pᶜ N⊒V′) () eqr M⊒V′
+function-application-simulation okM vV′ (⊒⟨ν⟩ pᶜ sᵢ N⊒V′)
+    () eqr M⊒V′
+function-application-simulation okM vV′
+    (α⊒α qᶜ pαᶜ L⊒L′) () eqr M⊒V′
+function-application-simulation okM vV′ (⊒α pαᶜ L⊒L′)
+    () eqr M⊒V′
+function-application-simulation okM vV′ (ν⊒ν pᶜ qᶜ N⊒N′)
+    () eqr M⊒V′
+function-application-simulation okM vV′ (⊒ν pᶜ L⊒L′) () eqr M⊒V′
+function-application-simulation okM vV′ (ν⊒ pᶜ L⊒L′) refl eqr M⊒V′ =
   {!!}
-function-application-simulation vV′ (κ⊒κ κ) () eqr M⊒V′
-function-application-simulation vV′ (⊕⊒⊕ M⊒M′ N⊒N′) () eqr M⊒V′
-function-application-simulation vV′ (⊒cast+ qᶜ q⨟s≈r L⊒L′) () eqr M⊒V′
-function-application-simulation vV′ (⊒cast- qᶜ q⨟s≈r L⊒L′) () eqr M⊒V′
-function-application-simulation vV′ (cast+⊒ pᶜ r≈t⨟p L⊒L′) refl eqr M⊒V′ =
+function-application-simulation okM vV′ (κ⊒κ κ) () eqr M⊒V′
+function-application-simulation okM vV′ (⊕⊒⊕ M⊒M′ N⊒N′)
+    () eqr M⊒V′
+function-application-simulation okM vV′
+    (⊒cast+ qᶜ q⨟s≈r L⊒L′) () eqr M⊒V′
+function-application-simulation okM vV′
+    (⊒cast- qᶜ q⨟s≈r L⊒L′) () eqr M⊒V′
+function-application-simulation okM vV′
+    (cast+⊒ pᶜ r≈t⨟p L⊒L′) refl eqr M⊒V′ =
   {!!}
-function-application-simulation vV′ (cast-⊒ pᶜ r≈t⨟p L⊒L′) refl eqr M⊒V′ =
+function-application-simulation okM vV′
+    (cast-⊒ pᶜ r≈t⨟p L⊒L′) refl eqr M⊒V′ =
   {!!}
 
 ------------------------------------------------------------------------
@@ -164,6 +200,7 @@ function-application-simulation vV′ (cast-⊒ pᶜ r≈t⨟p L⊒L′) refl eq
 
 dynamicGradualGuarantee :
   ∀ {Δ σ M M′ N′ p χ′} →
+  RuntimeOK M →
   Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
   M′ —→[ χ′ ] N′ →
   ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
@@ -176,116 +213,117 @@ dynamicGradualGuarantee :
 -- Store/context-shaping rules.  The recursive call is on the contained term
 -- narrowing derivation; the missing part is transport through the de Bruijn
 -- type-variable opening/substitution used by the store rule.
-dynamicGradualGuarantee (extend qᶜ pαᶜ M⊒N′) red
-    with dynamicGradualGuarantee M⊒N′ red
-dynamicGradualGuarantee (extend qᶜ pαᶜ M⊒N′) red
+dynamicGradualGuarantee okM (extend qᶜ pαᶜ M⊒N′) red
+    with dynamicGradualGuarantee okM M⊒N′ red
+dynamicGradualGuarantee okM (extend qᶜ pαᶜ M⊒N′) red
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (split qᶜ pαᶜ N⊒N′) red
-    with dynamicGradualGuarantee N⊒N′ red
-dynamicGradualGuarantee (split qᶜ pαᶜ N⊒N′) red
+dynamicGradualGuarantee okM (split qᶜ pαᶜ N⊒N′) red
+    with dynamicGradualGuarantee (runtime-open-change okM) N⊒N′ red
+dynamicGradualGuarantee okM (split qᶜ pαᶜ N⊒N′) red
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′′ =
   {!!}
 
 -- Atomic right-hand terms cannot step.
-dynamicGradualGuarantee (⊒blame pᶜ) (pure-step ())
-dynamicGradualGuarantee (x⊒x pᶜ x∋p) (pure-step ())
-dynamicGradualGuarantee (κ⊒κ κ) (pure-step ())
+dynamicGradualGuarantee okM (⊒blame pᶜ) (pure-step ())
+dynamicGradualGuarantee okM (x⊒x pᶜ x∋p) (pure-step ())
+dynamicGradualGuarantee okM (κ⊒κ κ) (pure-step ())
 
 -- Lambda application.  Contextual right reduction recurses on the matching
 -- subderivation; the β redex uses function-application simulation, and the
 -- casted-function redex is handled by the wrapping lemma.
-dynamicGradualGuarantee (ƛ⊒ƛ p↦qᶜ N⊒N′) (pure-step ())
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (β vV))
-  = function-application-simulation vV L⊒L′ refl refl M⊒M′
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′)
+dynamicGradualGuarantee okM (ƛ⊒ƛ p↦qᶜ N⊒N′) (pure-step ())
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (β vV))
+  = function-application-simulation
+      (runtime-·₂-any okM) vV L⊒L′ refl refl M⊒M′
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′)
     (pure-step (β-↦ vV vW)) =
   wrap-widening-lemma L⊒L′ M⊒M′
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step blame-·₁) =
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step blame-·₁) =
   {!!}
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (blame-·₂ vV)) =
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (blame-·₂ vV)) =
   {!!}
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)
-    with dynamicGradualGuarantee L⊒L′ L′→N′
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)
+    with dynamicGradualGuarantee (runtime-·₁ okM) L⊒L′ L′→N′
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₂ vV shiftV M′→N′)
-    with dynamicGradualGuarantee M⊒M′ M′→N′
-dynamicGradualGuarantee (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₂ vV shiftV M′→N′)
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₂ vV shiftV M′→N′)
+    with dynamicGradualGuarantee (runtime-·₂-any okM) M⊒M′ M′→N′
+dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₂ vV shiftV M′→N′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
 
 -- Universal introduction and elimination.  The pure type-application redexes
 -- use the α/ν cases from the paper; contextual ν steps recurse under the
 -- stored body.
-dynamicGradualGuarantee (Λ⊒Λ allᶜ vV V⊒V′) (pure-step ())
-dynamicGradualGuarantee (⊒Λ pᶜ N⊒V′) (pure-step ())
-dynamicGradualGuarantee (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) (pure-step red) =
+dynamicGradualGuarantee okM (Λ⊒Λ allᶜ vV V⊒V′) (pure-step ())
+dynamicGradualGuarantee okM (⊒Λ pᶜ N⊒V′) (pure-step ())
+dynamicGradualGuarantee okM (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) (pure-step red) =
   {!!}
-dynamicGradualGuarantee (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) (ξ-⟨⟩ V′→N′) =
+dynamicGradualGuarantee okM (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) (ξ-⟨⟩ V′→N′) =
   {!!}
-dynamicGradualGuarantee (α⊒α qᶜ pαᶜ L⊒L′) (ν-step vV noV)
-    with catchup-lemma vV L⊒L′
-dynamicGradualGuarantee (α⊒α qᶜ pαᶜ L⊒L′) (ν-step vV noV)
+dynamicGradualGuarantee okM (α⊒α qᶜ pαᶜ L⊒L′) (ν-step vV noV)
+    with catchup-lemma (runtime-ν okM) vV L⊒L′
+dynamicGradualGuarantee okM (α⊒α qᶜ pαᶜ L⊒L′) (ν-step vV noV)
     | χs , N , Δ′ , Π , Π′ , π ,
-      vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒L′ =
+      vN , noN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒L′ =
   {!!}
-dynamicGradualGuarantee (α⊒α qᶜ pαᶜ L⊒L′) (ξ-ν L′→N′)
-    with dynamicGradualGuarantee L⊒L′ L′→N′
-dynamicGradualGuarantee (α⊒α qᶜ pαᶜ L⊒L′) (ξ-ν L′→N′)
+dynamicGradualGuarantee okM (α⊒α qᶜ pαᶜ L⊒L′) (ξ-ν L′→N′)
+    with dynamicGradualGuarantee (runtime-ν okM) L⊒L′ L′→N′
+dynamicGradualGuarantee okM (α⊒α qᶜ pαᶜ L⊒L′) (ξ-ν L′→N′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (α⊒α qᶜ pαᶜ L⊒L′) blame-ν =
+dynamicGradualGuarantee okM (α⊒α qᶜ pαᶜ L⊒L′) blame-ν =
   {!!}
-dynamicGradualGuarantee (⊒α pαᶜ L⊒L′) (ν-step vV noV)
-    with catchup-lemma vV L⊒L′
-dynamicGradualGuarantee (⊒α pαᶜ L⊒L′) (ν-step vV noV)
+dynamicGradualGuarantee okM (⊒α pαᶜ L⊒L′) (ν-step vV noV)
+    with catchup-lemma okM vV L⊒L′
+dynamicGradualGuarantee okM (⊒α pαᶜ L⊒L′) (ν-step vV noV)
     | χs , N , Δ′ , Π , Π′ , π ,
-      vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒L′ =
+      vN , noN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒L′ =
   {!!}
-dynamicGradualGuarantee (⊒α pαᶜ L⊒L′) (ξ-ν L′→N′)
-    with dynamicGradualGuarantee L⊒L′ L′→N′
-dynamicGradualGuarantee (⊒α pαᶜ L⊒L′) (ξ-ν L′→N′)
+dynamicGradualGuarantee okM (⊒α pαᶜ L⊒L′) (ξ-ν L′→N′)
+    with dynamicGradualGuarantee okM L⊒L′ L′→N′
+dynamicGradualGuarantee okM (⊒α pαᶜ L⊒L′) (ξ-ν L′→N′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (⊒α pαᶜ L⊒L′) blame-ν =
+dynamicGradualGuarantee okM (⊒α pαᶜ L⊒L′) blame-ν =
   {!!}
 
 -- ν cases.  The `ν⊒ν` and `ν⊒` bind steps are the direct store-extension
 -- cases at the end of the cambridge25 proof.  Contextual body steps recurse.
-dynamicGradualGuarantee (ν⊒ν pᶜ qᶜ N⊒N′) (ν-step vV noV)
-    with catchup-lemma vV N⊒N′
-dynamicGradualGuarantee (ν⊒ν pᶜ qᶜ N⊒N′) (ν-step vV noV)
+dynamicGradualGuarantee okM (ν⊒ν pᶜ qᶜ N⊒N′) (ν-step vV noV)
+    with catchup-lemma (runtime-ν okM) vV N⊒N′
+dynamicGradualGuarantee okM (ν⊒ν pᶜ qᶜ N⊒N′) (ν-step vV noV)
     | χs , N , Δ′ , Π , Π′ , π ,
-      vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒N′ =
+      vN , noN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒N′ =
   {!!}
-dynamicGradualGuarantee (ν⊒ν pᶜ qᶜ N⊒N′) (ξ-ν N′→P′)
-    with dynamicGradualGuarantee N⊒N′ N′→P′
-dynamicGradualGuarantee (ν⊒ν pᶜ qᶜ N⊒N′) (ξ-ν N′→P′)
+dynamicGradualGuarantee okM (ν⊒ν pᶜ qᶜ N⊒N′) (ξ-ν N′→P′)
+    with dynamicGradualGuarantee (runtime-ν okM) N⊒N′ N′→P′
+dynamicGradualGuarantee okM (ν⊒ν pᶜ qᶜ N⊒N′) (ξ-ν N′→P′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒P′ =
   {!!}
-dynamicGradualGuarantee (ν⊒ν pᶜ qᶜ N⊒N′) blame-ν =
+dynamicGradualGuarantee okM (ν⊒ν pᶜ qᶜ N⊒N′) blame-ν =
   {!!}
-dynamicGradualGuarantee (⊒ν pᶜ N⊒N′) (ν-step vV noV)
-    with catchup-lemma vV N⊒N′
-dynamicGradualGuarantee (⊒ν pᶜ N⊒N′) (ν-step vV noV)
+dynamicGradualGuarantee okM (⊒ν pᶜ N⊒N′) (ν-step vV noV)
+    with catchup-lemma (runtime-⇑ᵗᵐ okM) vV N⊒N′
+dynamicGradualGuarantee okM (⊒ν pᶜ N⊒N′) (ν-step vV noV)
     | χs , N , Δ′ , Π , Π′ , π ,
-      vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒N′ =
+      vN , noN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒N′ =
   {!!}
-dynamicGradualGuarantee (⊒ν pᶜ N⊒N′) (ξ-ν N′→P′)
-    with dynamicGradualGuarantee N⊒N′ N′→P′
-dynamicGradualGuarantee (⊒ν pᶜ N⊒N′) (ξ-ν N′→P′)
+dynamicGradualGuarantee okM (⊒ν pᶜ N⊒N′) (ξ-ν N′→P′)
+    with dynamicGradualGuarantee (runtime-⇑ᵗᵐ okM) N⊒N′ N′→P′
+dynamicGradualGuarantee okM (⊒ν pᶜ N⊒N′) (ξ-ν N′→P′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒P′ =
   {!!}
-dynamicGradualGuarantee (⊒ν pᶜ N⊒N′) blame-ν =
+dynamicGradualGuarantee okM (⊒ν pᶜ N⊒N′) blame-ν =
   {!!}
-dynamicGradualGuarantee (ν⊒ pᶜ N⊒N′) red
+dynamicGradualGuarantee okM (ν⊒ pᶜ N⊒N′) red
     with type-rename-step-⇑ᵗᵐ red
-dynamicGradualGuarantee (ν⊒ pᶜ N⊒N′) red
+dynamicGradualGuarantee okM (ν⊒ pᶜ N⊒N′) red
     | χ′ , P′ , red′
-    with dynamicGradualGuarantee N⊒N′ red′
-dynamicGradualGuarantee (ν⊒ pᶜ N⊒N′) red
+    with dynamicGradualGuarantee (runtime-ν okM) N⊒N′ red′
+dynamicGradualGuarantee okM (ν⊒ pᶜ N⊒N′) red
     | χ′ , P′ , red′
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒P′ =
   {!!}
@@ -293,133 +331,134 @@ dynamicGradualGuarantee (ν⊒ pᶜ N⊒N′) red
 -- Primitive arithmetic.  The pure δ case first catches both source operands up
 -- to the right-hand constants; contextual substeps recurse on the corresponding
 -- premise.
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step δ-⊕)
-    with catchup-lemma ($ _) M⊒M′ | catchup-lemma ($ _) N⊒N′
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step δ-⊕)
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step δ-⊕)
+    with catchup-lemma (runtime-⊕₁ okM) ($ _) M⊒M′
+       | catchup-lemma (runtime-⊕₂-any okM) ($ _) N⊒N′
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step δ-⊕)
     | χsM , M , ΔM , ΠM , ΠM′ , πM ,
-      vM , M↠ , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , W⊒M′
+      vM , noM , M↠ , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , W⊒M′
     | χsN , N , ΔN , ΠN , ΠN′ , πN ,
-      vN , N↠ , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , W⊒N′ =
+      vN , noN , N↠ , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , W⊒N′ =
   {!!}
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step blame-⊕₁) =
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step blame-⊕₁) =
   {!!}
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step (blame-⊕₂ vV)) =
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (pure-step (blame-⊕₂ vV)) =
   {!!}
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₁ M′→P′ shiftN)
-    with dynamicGradualGuarantee M⊒M′ M′→P′
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₁ M′→P′ shiftN)
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₁ M′→P′ shiftN)
+    with dynamicGradualGuarantee (runtime-⊕₁ okM) M⊒M′ M′→P′
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₁ M′→P′ shiftN)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒P′ =
   {!!}
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₂ vV shiftM N′→P′)
-    with dynamicGradualGuarantee N⊒N′ N′→P′
-dynamicGradualGuarantee (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₂ vV shiftM N′→P′)
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₂ vV shiftM N′→P′)
+    with dynamicGradualGuarantee (runtime-⊕₂-any okM) N⊒N′ N′→P′
+dynamicGradualGuarantee okM (⊕⊒⊕ M⊒M′ N⊒N′) (ξ-⊕₂ vV shiftM N′→P′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒P′ =
   {!!}
 
 -- Right-cast reductions.  The ξ case recurses; the redex cases invoke the
 -- right-tag, right-seal, sequence, ν-widening, and catch-up lemmas.
-dynamicGradualGuarantee (⊒cast+ qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
-    with dynamicGradualGuarantee M⊒M′ M′→N′
-dynamicGradualGuarantee (⊒cast+ qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
+dynamicGradualGuarantee okM (⊒cast+ qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
+    with dynamicGradualGuarantee okM M⊒M′ M′→N′
+dynamicGradualGuarantee okM (⊒cast+ qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (⊒cast+ {s = id A} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = id A} qᶜ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
-    with catchup-lemma vV M⊒M′
-dynamicGradualGuarantee (⊒cast+ {s = id A} qᶜ q⨟s≈r M⊒M′)
+    with catchup-lemma okM vV M⊒M′
+dynamicGradualGuarantee okM (⊒cast+ {s = id A} qᶜ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
     | χs , N , Δ′ , Π , Π′ , π ,
-      vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒M′ =
+      vN , noN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒M′ =
   {!!}
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-ok vV))
     with right-tag-inversion₂ (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-ok vV))
     | M⊒V!
     with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-ok vV))
     | M⊒V!
     | M⊒V =
   {!!}
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-bad vV H≢G))
     with right-tag-inversion₂ (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-bad vV H≢G))
     | M⊒V!
     with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = (‵ ι) !} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-bad vV H≢G))
     | M⊒V!
     | M⊒V =
   {!!}
-dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
     with right-seal-inversion₂ (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast+ {s = seal B α} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
     | r , M⊒Vseal
   = {!!}
-dynamicGradualGuarantee (⊒cast+ qᶜ q⨟s≈r M⊒M′) (pure-step red) =
+dynamicGradualGuarantee okM (⊒cast+ qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
-dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
-    with dynamicGradualGuarantee M⊒M′ M′→N′
-dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
+dynamicGradualGuarantee okM (⊒cast- qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
+    with dynamicGradualGuarantee okM M⊒M′ M′→N′
+dynamicGradualGuarantee okM (⊒cast- qᶜ q⨟s≈r M⊒M′) (ξ-⟨⟩ M′→N′)
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (⊒cast- {s = id A} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = id A} qᶜ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
-    with catchup-lemma vV M⊒M′
-dynamicGradualGuarantee (⊒cast- {s = id A} qᶜ q⨟s≈r M⊒M′)
+    with catchup-lemma okM vV M⊒M′
+dynamicGradualGuarantee okM (⊒cast- {s = id A} qᶜ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
     | χs , N , Δ′ , Π , Π′ , π ,
-      vN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒M′ =
+      vN , noN , N↠ , Δ′≡ , Π≡ , Π′≡ , π⊒ , N⊒M′ =
   {!!}
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-ok vV))
     with right-tag-inversion₂ (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-ok vV))
     | M⊒V!
     with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-ok vV))
     | M⊒V!
     | M⊒V =
   {!!}
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-bad vV H≢G))
     with right-tag-inversion₂ (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-bad vV H≢G))
     | M⊒V!
     with right-tag-inversion₁ M⊒V!
-dynamicGradualGuarantee (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = G ？} qᶜ q⨟s≈r M⊒M′)
     (pure-step (tag-untag-bad vV H≢G))
     | M⊒V!
     | M⊒V =
   {!!}
-dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
     with right-seal-inversion₂ (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
-dynamicGradualGuarantee (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
+dynamicGradualGuarantee okM (⊒cast- {s = unseal α B} qᶜ q⨟s≈r M⊒M′)
     (pure-step (seal-unseal vV))
     | r , M⊒Vseal
   = {!!}
-dynamicGradualGuarantee (⊒cast- qᶜ q⨟s≈r M⊒M′) (pure-step red) =
+dynamicGradualGuarantee okM (⊒cast- qᶜ q⨟s≈r M⊒M′) (pure-step red) =
   {!!}
 
 -- Left-cast administrative cases recurse on the premise, then move the cast
 -- across the resulting multi-step evidence.
-dynamicGradualGuarantee (cast+⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
-    with dynamicGradualGuarantee M⊒M′ red
-dynamicGradualGuarantee (cast+⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
+dynamicGradualGuarantee okM (cast+⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
+    with dynamicGradualGuarantee (runtime-⟨⟩ okM) M⊒M′ red
+dynamicGradualGuarantee okM (cast+⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}
-dynamicGradualGuarantee (cast-⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
-    with dynamicGradualGuarantee M⊒M′ red
-dynamicGradualGuarantee (cast-⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
+dynamicGradualGuarantee okM (cast-⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
+    with dynamicGradualGuarantee (runtime-⟨⟩ okM) M⊒M′ red
+dynamicGradualGuarantee okM (cast-⊒ {t = t} pᶜ r≈t⨟p M⊒M′) red
     | χs , N , Δ′ , Π , Π′ , π , p′ , N↠ , Π≡ , Π′≡ , π⊒ , N⊒N′ =
   {!!}


### PR DESCRIPTION
## Summary

Thread `RuntimeOK` through the GTSF catchup and dynamic gradual guarantee proof skeletons.

- Add `RuntimeOK` as a premise to `catchup-lemma` and `dynamicGradualGuarantee`.
- Strengthen catchup-shaped results with `No•` evidence so left widening/narrowing can consume it directly.
- Add `No•` premises/results to the left widening and narrowing lemma interfaces.
- Propagate subterm runtime evidence through recursive DGG and catchup calls, including shifted/opened source cases.

## Why

Several catchup/DGG cases need to call lemmas such as `left-widening-lemma`, which require `No•` or runtime-shape evidence that was not previously available at the call site. Carrying `RuntimeOK` through the theorem interfaces makes those invariants explicit and gives a path to `No•` for caught-up values.

## Validation

- `agda -v0 proof/Catchup.agda`
- `agda -v0 proof/DynamicGradualGuarantee.agda`
- `agda -v0 All.agda`
- `git diff --check`