### PR TITLE
Add GTSF seal-unseal DGG counterexample

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -20,4 +20,5 @@ import TermNarrowing
 import NarrowingExamples
 import NuMetaTheory
 import proof.RightSealBroadCounterexample
+import proof.ExactSealUnsealCounterexample
 import proof.DynamicGradualGuarantee

--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -19,4 +19,5 @@ import proof.NWTermReduction
 import TermNarrowing
 import NarrowingExamples
 import NuMetaTheory
+import proof.RightSealBroadCounterexample
 import proof.DynamicGradualGuarantee

--- a/GTSF/proof/ExactSealUnsealCounterexample.agda
+++ b/GTSF/proof/ExactSealUnsealCounterexample.agda
@@ -1,0 +1,816 @@
+{-# OPTIONS --warning=noUnreachableClauses #-}
+
+module proof.ExactSealUnsealCounterexample where
+
+-- File Charter:
+--   * Checked counterexample for the exact right-hand `seal-unseal` dynamic
+--     gradual guarantee case.
+--   * Constructs a source value that narrows to the target seal-unseal redex,
+--     but cannot narrow to the target's reduct after any source reduction.
+--   * Depends on the broad right-seal counterexample and small cast-factor
+--     impossibility lemmas, without adding postulates.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here)
+open import Data.Nat using (zero; suc; z<s)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import Primitives
+open import NuTerms
+open import NuReduction
+open import NarrowWiden
+open import NarrowWidenComposition
+open import TermNarrowing
+open import proof.NarrowWidenProperties
+  using
+    ( narrowing-target-star-source-star
+    ; narrowing-var-to-older⊥
+    ; narrowing-var-to-star⊥
+    )
+open import proof.CoercionProperties using (coercion-src-tgtᵐ)
+open import proof.CatchupStore using (combineStoreNrw)
+open import proof.NuPreservation using (value-no-step)
+open import proof.RightSealBroadCounterexample
+open import proof.TermNarrowingProperties
+
+NatTy : Ty
+NatTy = ‵ `ℕ
+
+k0 : Const
+k0 = κℕ 0
+
+c★ : Term
+c★ = $ k0 ⟨ NatTy ! ⟩
+
+c★-value : Value c★
+c★-value = ($ k0) ⟨ NatTy ! ⟩
+
+c★-no• : No• c★
+c★-no• = no•-⟨⟩ no•-$
+
+baseUntag : Coercion
+baseUntag = NatTy ？
+
+idNatᶜ : 1 ∣ StoreStar ⊢ id NatTy ∶ᶜ NatTy ⊒ NatTy
+idNatᶜ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+idNat⊒ : tag-or-idᵈ ∣ 1 ∣ StoreStar ⊢ id NatTy ∶ NatTy ⊒ NatTy
+idNat⊒ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+idStarᶜ : 1 ∣ StoreStar ⊢ id ★ ∶ᶜ ★ ⊒ ★
+idStarᶜ = cast-id wf★ refl , id★
+
+idStarTag⊒ : tag-or-idᵈ ∣ 1 ∣ StoreStar ⊢ id ★ ∶ ★ ⊒ ★
+idStarTag⊒ = cast-id wf★ refl , id★
+
+baseUntag⊒ : tag-or-idᵈ ∣ 1 ∣ StoreStar ⊢ baseUntag ∶ ★ ⊒ NatTy
+baseUntag⊒ = cast-untag wfBase (‵ `ℕ) refl , untag (‵ `ℕ)
+
+endpointsBase : EndpointWf 1 StoreStar ★ NatTy
+endpointsBase = wf★ˢ , wfBaseˢ
+
+base-untag-left :
+  1 ∣ SigmaStar ⊢ id ★ ⨾ⁿ baseUntag ≈ baseUntag ∶ ★ ⊒ NatTy
+base-untag-left =
+  compose-leftⁿ wfStoreStar idStarTag⊒ baseUntag⊒
+    (endpointsⁿ refl refl refl refl SigmaStar⊒ endpointsBase endpointsBase
+      (tag-or-idᵈ ,
+       proj₂ (_⨟ⁿ_ {wfΣ = wfStoreStar} idStarTag⊒ baseUntag⊒))
+      (tag-or-idᵈ , baseUntag⊒))
+
+base-untag-right :
+  1 ∣ SigmaStar ⊢ baseUntag ≈ baseUntag ⨾ⁿ id NatTy ∶ ★ ⊒ NatTy
+base-untag-right =
+  compose-rightⁿ wfStoreStar baseUntag⊒ idNat⊒
+    (endpointsⁿ refl refl refl refl SigmaStar⊒ endpointsBase endpointsBase
+      (tag-or-idᵈ , baseUntag⊒)
+      (tag-or-idᵈ ,
+       proj₂ (_⨟ⁿ_ {wfΣ = wfStoreStar} baseUntag⊒ idNat⊒)))
+
+c★-self-id★ :
+  1 ∣ SigmaStar ∣ [] ⊢ c★ ⊒ c★ ∶ id ★
+c★-self-id★ =
+  cast+⊒cast+
+    {p = id NatTy}
+    {q = id ★}
+    {r = baseUntag}
+    {s = baseUntag}
+    {t = baseUntag}
+    idNatᶜ
+    idStarᶜ
+    base-untag-left
+    base-untag-right
+    (κ⊒κ k0)
+
+c★-right-sealed-at-untag :
+  1 ∣ SigmaStar ∣ [] ⊢ c★ ⊒ c★ ⟨ sealStar0 ⟩ ∶ untagAlpha0
+c★-right-sealed-at-untag =
+  ⊒cast- idStarᶜ right-seal-compose-to-untag c★-self-id★
+
+exact-broad-premise :
+  1 ∣ SigmaStar ∣ []
+    ⊢ c★ ⊒ c★ ⟨ sealStar0 ⟩ ⟨ unseal alpha0 ★ ⟩ ∶ id ★
+exact-broad-premise =
+  ⊒cast+ idStarᶜ right-seal-compose-to-untag c★-right-sealed-at-untag
+
+idAlpha0 : Coercion
+idAlpha0 = id (＇ alpha0)
+
+idAlphaᶜ : 1 ∣ StoreStar ⊢ idAlpha0 ∶ᶜ ＇ alpha0 ⊒ ＇ alpha0
+idAlphaᶜ = cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+idAlpha⊒ : seal-or-idᵈ ∣ 1 ∣ StoreStar ⊢ idAlpha0 ∶ ＇ alpha0 ⊒ ＇ alpha0
+idAlpha⊒ = cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+idAlphaTag⊒ :
+  tag-or-idᵈ ∣ 1 ∣ StoreStar ⊢ idAlpha0 ∶ ＇ alpha0 ⊒ ＇ alpha0
+idAlphaTag⊒ = cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+untagAlpha-right :
+  1 ∣ SigmaStar ⊢ untagAlpha0 ≈ untagAlpha0 ⨾ⁿ idAlpha0
+    ∶ ★ ⊒ ＇ alpha0
+untagAlpha-right =
+  compose-rightⁿ wfStoreStar untagAlpha⊒ᶜ idAlphaTag⊒
+    (endpointsⁿ refl refl refl refl SigmaStar⊒ endpointsStar endpointsStar
+      (tag-or-idᵈ , untagAlpha⊒ᶜ)
+      (tag-or-idᵈ ,
+       proj₂ (_⨟ⁿ_ {wfΣ = wfStoreStar} untagAlpha⊒ᶜ idAlphaTag⊒)))
+
+right-seal-compose-to-seal :
+  1 ∣ SigmaStar ⊢ id ★ ⨾ⁿ sealStar0 ≈ sealStar0 ∶ ★ ⊒ ＇ alpha0
+right-seal-compose-to-seal =
+  compose-leftⁿ wfStoreStar idStar⊒ sealStar⊒
+    (endpointsⁿ refl refl refl refl SigmaStar⊒ endpointsStar endpointsStar
+      (seal-or-idᵈ ,
+       proj₂ (_⨟ⁿ_ {wfΣ = wfStoreStar} idStar⊒ sealStar⊒))
+      (seal-or-idᵈ , sealStar⊒))
+
+left-seal-compose :
+  1 ∣ SigmaStar ⊢ sealStar0 ≈ sealStar0 ⨾ⁿ idAlpha0
+    ∶ ★ ⊒ ＇ alpha0
+left-seal-compose =
+  compose-rightⁿ wfStoreStar sealStar⊒ idAlpha⊒
+    (endpointsⁿ refl refl refl refl SigmaStar⊒ endpointsStar endpointsStar
+      (seal-or-idᵈ , sealStar⊒)
+      (seal-or-idᵈ ,
+       proj₂ (_⨟ⁿ_ {wfΣ = wfStoreStar} sealStar⊒ idAlpha⊒)))
+
+c★-right-sealed-at-seal :
+  1 ∣ SigmaStar ∣ [] ⊢ c★ ⊒ c★ ⟨ sealStar0 ⟩ ∶ sealStar0
+c★-right-sealed-at-seal =
+  ⊒cast- idStarᶜ right-seal-compose-to-seal c★-self-id★
+
+c★-sealed-self-idAlpha :
+  1 ∣ SigmaStar ∣ []
+    ⊢ c★ ⟨ sealStar0 ⟩ ⊒ c★ ⟨ sealStar0 ⟩ ∶ idAlpha0
+c★-sealed-self-idAlpha =
+  cast-⊒ idAlphaᶜ left-seal-compose c★-right-sealed-at-seal
+
+c★-tagged-sealed-to-sealed :
+  1 ∣ SigmaStar ∣ []
+    ⊢ c★ ⟨ sealStar0 ⟩ ⟨ - untagAlpha0 ⟩
+      ⊒ c★ ⟨ sealStar0 ⟩ ∶ untagAlpha0
+c★-tagged-sealed-to-sealed =
+  cast+⊒ idAlphaᶜ untagAlpha-right c★-sealed-self-idAlpha
+
+exact-tagged-sealed-source-premise :
+  1 ∣ SigmaStar ∣ []
+    ⊢ c★ ⟨ sealStar0 ⟩ ⟨ - untagAlpha0 ⟩
+      ⊒ c★ ⟨ sealStar0 ⟩ ⟨ unseal alpha0 ★ ⟩ ∶ id ★
+exact-tagged-sealed-source-premise =
+  ⊒cast+ idStarᶜ right-seal-compose-to-untag
+    c★-tagged-sealed-to-sealed
+
+sealedSource : Term
+sealedSource = c★ ⟨ sealStar0 ⟩
+
+badSource : Term
+badSource = sealedSource ⟨ - untagAlpha0 ⟩
+
+sealedTarget : Term
+sealedTarget = sealedSource ⟨ unseal alpha0 ★ ⟩
+
+badSource-value : Value badSource
+badSource-value =
+  ((($ k0) ⟨ NatTy ! ⟩) ⟨ seal ★ alpha0 ⟩) ⟨ (＇ alpha0) ! ⟩
+
+badSource-runtime-ok : RuntimeOK badSource
+badSource-runtime-ok = ok-no (no•-⟨⟩ (no•-⟨⟩ c★-no•))
+
+sealedTarget-step : sealedTarget —→[ keep ] c★
+sealedTarget-step = pure-step (seal-unseal c★-value)
+
+exact-tagged-sealed-source-premise′ :
+  1 ∣ SigmaStar ∣ [] ⊢ badSource ⊒ sealedTarget ∶ id ★
+exact-tagged-sealed-source-premise′ = exact-tagged-sealed-source-premise
+
+term-cast-inj-term :
+  ∀ {M N : Term} {c d : Coercion} →
+  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
+  M ≡ N
+term-cast-inj-term refl = refl
+
+term-cast-inj-coercion :
+  ∀ {M N : Term} {c d : Coercion} →
+  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
+  c ≡ d
+term-cast-inj-coercion refl = refl
+
+value-multistep-refl :
+  ∀ {V N χs} →
+  Value V →
+  V —↠[ χs ] N →
+  χs ≡ [] × N ≡ V
+value-multistep-refl vV ↠-refl = refl , refl
+value-multistep-refl vV (↠-step V→M M↠N) =
+  ⊥-elim (value-no-step vV V→M)
+
+compose-left-tag-factor⊥ :
+  ∀ {Δ σ q r G E F} →
+  Δ ∣ σ ⊢ q ⨾ⁿ G ! ≈ r ∶ E ⊒ F →
+  ⊥
+compose-left-tag-factor⊥
+    (compose-leftⁿ wfΣ q⊒ (cast-tag hG gG tag-ok , cross ())
+      q⨟tag≈r)
+
+source-left-tag-factor⊥ :
+  ∀ {Δ σ r p G E F} →
+  Δ ∣ σ ⊢ r ≈ G ! ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+source-left-tag-factor⊥ = compose-right-tag-factor⊥
+
+data RelevantStore : StoreNrw → Set where
+  rel-star : RelevantStore SigmaStar
+  rel-source : ∀ {A} → RelevantStore ((alpha0 ꞉= A ⊒) ∷ [])
+
+narrowing-target-idNat :
+  ∀ {μ Δ Σ p A B} →
+  p ≡ id NatTy →
+  μ ∣ Δ ∣ Σ ⊢ p ∶ A ⊒ B →
+  B ≡ NatTy
+narrowing-target-idNat p≡idNat p⊒ =
+  trans (sym (proj₂ (coercion-src-tgtᵐ (proj₁ p⊒))))
+        (cong tgt p≡idNat)
+
+Nat≢★ : NatTy ≡ ★ → ⊥
+Nat≢★ ()
+
+bare-constant-index-relevant :
+  ∀ {Δ σ M M′ p} →
+  RelevantStore σ →
+  M ≡ $ k0 →
+  M′ ≡ $ k0 →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  p ≡ id NatTy
+bare-constant-index-relevant rel-star eqM eqM′
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  bare-constant-index-relevant (rel-source {A = A}) eqM eqM′ M⊒M′
+bare-constant-index-relevant () eqM eqM′ (split qᶜ pαᶜ M⊒M′)
+bare-constant-index-relevant rs eqM () (⊒blame pᶜ)
+bare-constant-index-relevant rs eqM () (x⊒x pᶜ x∋p)
+bare-constant-index-relevant rs () eqM′ (ƛ⊒ƛ p↦qᶜ M⊒M′)
+bare-constant-index-relevant rs () eqM′ (·⊒· qᶜ L⊒L′ M⊒M′)
+bare-constant-index-relevant rs () eqM′ (Λ⊒Λ allᶜ vV M⊒M′)
+bare-constant-index-relevant rs eqM () (⊒Λ pᶜ M⊒M′)
+bare-constant-index-relevant rs eqM () (⊒⟨ν⟩ pᶜ x M⊒M′)
+bare-constant-index-relevant rs () eqM′ (α⊒α qᶜ pαᶜ L⊒L′)
+bare-constant-index-relevant rs eqM () (⊒α pαᶜ L⊒L′)
+bare-constant-index-relevant rs () eqM′ (ν⊒ν pᶜ qᶜ M⊒M′)
+bare-constant-index-relevant rs eqM () (⊒ν pᶜ M⊒M′)
+bare-constant-index-relevant rs () eqM′ (ν⊒ pᶜ M⊒M′)
+bare-constant-index-relevant rs refl refl (κ⊒κ (κℕ zero)) = refl
+bare-constant-index-relevant rs () () (κ⊒κ (κℕ (suc n)))
+bare-constant-index-relevant rs () eqM′ (⊕⊒⊕ M⊒M′ N⊒N′)
+bare-constant-index-relevant rs eqM () (⊒cast+ qᶜ q⨟s≈r M⊒M′)
+bare-constant-index-relevant rs eqM () (⊒cast- qᶜ q⨟s≈r M⊒M′)
+bare-constant-index-relevant rs () eqM′ (cast+⊒ pᶜ r≈t⨟p M⊒M′)
+bare-constant-index-relevant rs () eqM′ (cast-⊒ pᶜ r≈t⨟p M⊒M′)
+
+dual-eq-seal-factor⊥ :
+  ∀ {Δ σ r p t A B} →
+  - t ≡ sealStar0 →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+  ⊥
+dual-eq-seal-factor⊥ {t = id A} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = c ︔ d} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = c ↦ d} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = `∀ c} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (＇ α) !} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (‵ ι) !} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = ★ !} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (A ⇒ B) !} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (`∀ A) !} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (＇ α) ？} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (‵ ι) ？} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = ★ ？} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (A ⇒ B) ？} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = (`∀ A) ？} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = seal A α} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = unseal α A} refl r≈t⨟p =
+  compose-right-unseal-factor⊥ r≈t⨟p
+dual-eq-seal-factor⊥ {t = gen A c} () r≈t⨟p
+dual-eq-seal-factor⊥ {t = inst B c} () r≈t⨟p
+
+seal-factor-then-dual-nat-tag⊥ :
+  ∀ {Δ τ σ q r p s A B C D} →
+  - s ≡ NatTy ! →
+  Δ ∣ τ ⊢ q ≈ sealStar0 ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ C ⊒ D →
+  ⊥
+seal-factor-then-dual-nat-tag⊥ {s = id A} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = c ︔ d} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = c ↦ d} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = `∀ c} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (＇ α) !} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (‵ ι) !} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = ★ !} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (A ⇒ B) !} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (`∀ A) !} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (＇ α) ？} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (‵ `ℕ) ？} refl
+    (compose-rightⁿ wfΣ₀
+      (cast-seal h★ α∈Σ seal-ok , sealⁿ .★ .alpha0)
+      p⊒
+      (endpointsⁿ src-q₀ tgt-q₀ src-u₀ tgt-u₀
+        σ⊒₀ wfΣ₁ wfΣ₂ q⊒₀ u⊒₀))
+    (compose-leftⁿ wfΣ
+      q⊒
+      s⊒@(cast-untag hNat (‵ .`ℕ) untag-ok , untag (‵ .`ℕ))
+      q⨟s≈r) =
+  let
+    B≡★ =
+      trans (sym (proj₂ (coercion-src-tgtᵐ (proj₁ (proj₂ q⊒₀)))))
+        (trans (proj₂ (coercion-src-tgtᵐ (proj₁ q⊒)))
+          (sym (proj₁ (coercion-src-tgtᵐ (proj₁ s⊒)))))
+    p⊒★ = subst (λ T → _ ∣ _ ∣ _ ⊢ _ ∶ ＇ alpha0 ⊒ T) B≡★ p⊒
+  in
+  narrowing-var-to-star⊥ p⊒★
+seal-factor-then-dual-nat-tag⊥ {s = (‵ `𝔹) ？} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = ★ ？} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (A ⇒ B) ？} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = (`∀ A) ？} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = seal A α} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = unseal α A} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = gen A c} () outer q⨟s≈r
+seal-factor-then-dual-nat-tag⊥ {s = inst B c} () outer q⨟s≈r
+
+c★-left-neg-bare-seal-factor⊥ :
+  ∀ {Δ σ τ M M′ p₀ r p t A B C D} →
+  RelevantStore σ →
+  M ⟨ - t ⟩ ≡ c★ →
+  M′ ≡ $ k0 →
+  Δ ∣ τ ⊢ r ≈ sealStar0 ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p₀ ∶ C ⊒ D →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p₀ →
+  ⊥
+c★-left-neg-bare-seal-factor⊥ {t = id A}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = c ︔ d}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = c ↦ d}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = `∀ c}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (＇ α) !}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (‵ ι) !}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = ★ !}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (A ⇒ B) !}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (`∀ A) !}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (＇ α) ？}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (‵ `ℕ) ？} rs refl refl
+    (compose-rightⁿ wfΣ
+      (cast-seal h★ α∈Σ seal-ok , sealⁿ .★ .alpha0)
+      p⊒
+      (endpointsⁿ src-r₁ tgt-r₁ src-u₁ tgt-u₁
+        σ⊒₁ wfΣ₁ wfΣ₂ r⊒₁ u⊒₁))
+    (compose-rightⁿ wfΣ′
+      (cast-untag hNat (‵ .`ℕ) untag-ok , untag (‵ .`ℕ))
+      p₀⊒
+      (endpointsⁿ src-r₂ tgt-r₂ src-u₂ tgt-u₂
+        σ⊒₂ wfΣ₃ wfΣ₄ r⊒₂ u⊒₂))
+    M⊒M′ =
+  let
+    p₀≡idNat = bare-constant-index-relevant rs refl refl M⊒M′
+    B₂≡Nat = narrowing-target-idNat p₀≡idNat p₀⊒
+    B₁≡B₂ = trans (sym tgt-r₁) tgt-r₂
+    B₁≡Nat = trans B₁≡B₂ B₂≡Nat
+    p⊒Nat = subst (λ B → _ ∣ _ ∣ _ ⊢ _ ∶ ＇ alpha0 ⊒ B)
+                    B₁≡Nat p⊒
+  in
+  narrowing-var-to-older⊥ wfΣ wfBase p⊒Nat
+c★-left-neg-bare-seal-factor⊥ {t = (‵ `𝔹) ？}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = ★ ？}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (A ⇒ B) ？}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = (`∀ A) ？}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = seal A α}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = unseal α A}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = gen A c}
+    rs () eqM′ outer inner M⊒M′
+c★-left-neg-bare-seal-factor⊥ {t = inst B c}
+    rs () eqM′ outer inner M⊒M′
+
+c★⊒bare-seal-factor⊥ :
+  ∀ {Δ σ τ M M′ r p A B} →
+  RelevantStore σ →
+  M ≡ c★ →
+  M′ ≡ $ k0 →
+  Δ ∣ τ ⊢ r ≈ sealStar0 ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ r →
+  ⊥
+c★⊒bare-seal-factor⊥ rel-star eqM eqM′ outer
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  c★⊒bare-seal-factor⊥ (rel-source {A = A}) eqM eqM′ outer M⊒M′
+c★⊒bare-seal-factor⊥ () eqM eqM′ outer (split qᶜ pαᶜ M⊒M′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒blame pᶜ)
+c★⊒bare-seal-factor⊥ rs eqM () outer (x⊒x pᶜ x∋p)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (ƛ⊒ƛ p↦qᶜ M⊒M′)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (·⊒· qᶜ L⊒L′ M⊒M′)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (Λ⊒Λ allᶜ vV M⊒M′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒Λ pᶜ M⊒M′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒⟨ν⟩ pᶜ x M⊒M′)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (α⊒α qᶜ pαᶜ L⊒L′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒α pαᶜ L⊒L′)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (ν⊒ν pᶜ qᶜ M⊒M′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒ν pᶜ M⊒M′)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (ν⊒ pᶜ M⊒M′)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (κ⊒κ κ)
+c★⊒bare-seal-factor⊥ rs () eqM′ outer (⊕⊒⊕ M⊒M′ N⊒N′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒cast+ qᶜ q⨟s≈r M⊒M′)
+c★⊒bare-seal-factor⊥ rs eqM () outer (⊒cast- qᶜ q⨟s≈r M⊒M′)
+c★⊒bare-seal-factor⊥ rs eqM refl outer
+    (cast+⊒ {p = p₀} {t = t} pᶜ r≈t⨟p M⊒M′) =
+  c★-left-neg-bare-seal-factor⊥ rs eqM refl outer r≈t⨟p M⊒M′
+c★⊒bare-seal-factor⊥ {σ = σ} rs eqM refl outer
+    (cast-⊒ {p = p} {r = r} {t = t} {A = A} {B = B}
+      pᶜ r≈t⨟p M⊒M′) =
+  compose-right-tag-factor⊥
+    (subst
+      (λ t₀ → _ ∣ σ ⊢ r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM)
+      r≈t⨟p)
+
+sealedSource⊒bare-aux⊥ :
+  ∀ {Δ σ M M′ p} →
+  RelevantStore σ →
+  M ≡ sealedSource →
+  M′ ≡ $ k0 →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  ⊥
+sealedSource⊒bare-aux⊥ rel-star eqM eqM′
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  sealedSource⊒bare-aux⊥ (rel-source {A = A}) eqM eqM′ M⊒M′
+sealedSource⊒bare-aux⊥ () eqM eqM′ (split qᶜ pαᶜ M⊒M′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒blame pᶜ)
+sealedSource⊒bare-aux⊥ rs eqM () (x⊒x pᶜ x∋p)
+sealedSource⊒bare-aux⊥ rs () eqM′ (ƛ⊒ƛ p↦qᶜ M⊒M′)
+sealedSource⊒bare-aux⊥ rs () eqM′ (·⊒· qᶜ L⊒L′ M⊒M′)
+sealedSource⊒bare-aux⊥ rs () eqM′ (Λ⊒Λ allᶜ vV M⊒M′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒Λ pᶜ M⊒M′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒⟨ν⟩ pᶜ x M⊒M′)
+sealedSource⊒bare-aux⊥ rs () eqM′ (α⊒α qᶜ pαᶜ L⊒L′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒α pαᶜ L⊒L′)
+sealedSource⊒bare-aux⊥ rs () eqM′ (ν⊒ν pᶜ qᶜ M⊒M′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒ν pᶜ M⊒M′)
+sealedSource⊒bare-aux⊥ rs () eqM′ (ν⊒ pᶜ M⊒M′)
+sealedSource⊒bare-aux⊥ rs () eqM′ (κ⊒κ κ)
+sealedSource⊒bare-aux⊥ rs () eqM′ (⊕⊒⊕ M⊒M′ N⊒N′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒cast+ qᶜ q⨟s≈r M⊒M′)
+sealedSource⊒bare-aux⊥ rs eqM () (⊒cast- qᶜ q⨟s≈r M⊒M′)
+sealedSource⊒bare-aux⊥ rs eqM refl
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  dual-eq-seal-factor⊥ (term-cast-inj-coercion eqM) r≈t⨟p
+sealedSource⊒bare-aux⊥ {σ = σ} rs eqM refl
+    (cast-⊒ {p = p} {r = r} {t = t} {A = A} {B = B}
+      pᶜ r≈t⨟p M⊒M′) =
+  c★⊒bare-seal-factor⊥ rs (term-cast-inj-term eqM) refl
+    (subst
+      (λ t₀ → _ ∣ σ ⊢ r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM)
+      r≈t⨟p)
+    M⊒M′
+
+bare-right-neg-c★⊥ :
+  ∀ {Δ σ M M′ q r s A B} →
+  RelevantStore σ →
+  M ≡ $ k0 →
+  M′ ⟨ - s ⟩ ≡ c★ →
+  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ r →
+  ⊥
+bare-right-neg-c★⊥ {s = id A} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = c ︔ d} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = c ↦ d} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = `∀ c} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (＇ α) !} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (‵ ι) !} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = ★ !} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (A ⇒ B) !} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (`∀ A) !} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (＇ α) ？} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (‵ `ℕ) ？} rs refl refl
+    (compose-leftⁿ wfΣ
+      q⊒
+      (cast-untag hNat (‵ .`ℕ) untag-ok , untag (‵ .`ℕ))
+      (endpointsⁿ src-u tgt-u src-r tgt-r
+        σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+    M⊒M′ =
+  let
+    r≡idNat = bare-constant-index-relevant rs refl refl M⊒M′
+    A≡★ = narrowing-target-star-source-star q⊒
+    A≡Nat = trans (sym src-r) (cong src r≡idNat)
+  in
+  Nat≢★ (trans (sym A≡Nat) A≡★)
+bare-right-neg-c★⊥ {s = (‵ `𝔹) ？} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = ★ ？} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (A ⇒ B) ？} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = (`∀ A) ？} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = seal A α} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = unseal α A} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = gen A c} rs eqM () q⨟s≈r M⊒M′
+bare-right-neg-c★⊥ {s = inst B c} rs eqM () q⨟s≈r M⊒M′
+
+bare⊒c★-aux⊥ :
+  ∀ {Δ σ M M′ p} →
+  RelevantStore σ →
+  M ≡ $ k0 →
+  M′ ≡ c★ →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  ⊥
+bare⊒c★-aux⊥ rel-star eqM eqM′
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  bare⊒c★-aux⊥ (rel-source {A = A}) eqM eqM′ M⊒M′
+bare⊒c★-aux⊥ () eqM eqM′ (split qᶜ pαᶜ M⊒M′)
+bare⊒c★-aux⊥ rs eqM () (⊒blame pᶜ)
+bare⊒c★-aux⊥ rs eqM () (x⊒x pᶜ x∋p)
+bare⊒c★-aux⊥ rs () eqM′ (ƛ⊒ƛ p↦qᶜ M⊒M′)
+bare⊒c★-aux⊥ rs () eqM′ (·⊒· qᶜ L⊒L′ M⊒M′)
+bare⊒c★-aux⊥ rs () eqM′ (Λ⊒Λ allᶜ vV M⊒M′)
+bare⊒c★-aux⊥ rs eqM () (⊒Λ pᶜ M⊒M′)
+bare⊒c★-aux⊥ rs eqM () (⊒⟨ν⟩ pᶜ x M⊒M′)
+bare⊒c★-aux⊥ rs () eqM′ (α⊒α qᶜ pαᶜ L⊒L′)
+bare⊒c★-aux⊥ rs eqM () (⊒α pαᶜ L⊒L′)
+bare⊒c★-aux⊥ rs () eqM′ (ν⊒ν pᶜ qᶜ M⊒M′)
+bare⊒c★-aux⊥ rs eqM () (⊒ν pᶜ M⊒M′)
+bare⊒c★-aux⊥ rs () eqM′ (ν⊒ pᶜ M⊒M′)
+bare⊒c★-aux⊥ rs eqM () (κ⊒κ κ)
+bare⊒c★-aux⊥ rs () eqM′ (⊕⊒⊕ M⊒M′ N⊒N′)
+bare⊒c★-aux⊥ rs refl eqM′
+    (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  bare-right-neg-c★⊥ rs refl eqM′ q⨟s≈r M⊒M′
+bare⊒c★-aux⊥ {σ = σ} rs refl eqM′
+    (⊒cast- {q = q} {r = r} {s = s} {A = A} {B = B}
+      qᶜ q⨟s≈r M⊒M′) =
+  compose-left-tag-factor⊥
+    (subst
+      (λ s₀ → _ ∣ σ ⊢ q ⨾ⁿ s₀ ≈ r ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM′)
+      q⨟s≈r)
+bare⊒c★-aux⊥ rs () eqM′ (cast+⊒ pᶜ r≈t⨟p M⊒M′)
+bare⊒c★-aux⊥ rs () eqM′ (cast-⊒ pᶜ r≈t⨟p M⊒M′)
+
+c★⊒c★-seal-factor⊥ :
+  ∀ {Δ σ τ M M′ r p A B} →
+  RelevantStore σ →
+  M ≡ c★ →
+  M′ ≡ c★ →
+  Δ ∣ τ ⊢ r ≈ sealStar0 ⨾ⁿ p ∶ A ⊒ B →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ r →
+  ⊥
+c★⊒c★-seal-factor⊥ rel-star eqM eqM′ outer
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  c★⊒c★-seal-factor⊥ (rel-source {A = A}) eqM eqM′ outer M⊒M′
+c★⊒c★-seal-factor⊥ () eqM eqM′ outer (split qᶜ pαᶜ M⊒M′)
+c★⊒c★-seal-factor⊥ rs eqM () outer (⊒blame pᶜ)
+c★⊒c★-seal-factor⊥ rs eqM () outer (x⊒x pᶜ x∋p)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (ƛ⊒ƛ p↦qᶜ M⊒M′)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (·⊒· qᶜ L⊒L′ M⊒M′)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (Λ⊒Λ allᶜ vV M⊒M′)
+c★⊒c★-seal-factor⊥ rs eqM () outer (⊒Λ pᶜ M⊒M′)
+c★⊒c★-seal-factor⊥ rs eqM () outer (⊒⟨ν⟩ pᶜ x M⊒M′)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (α⊒α qᶜ pαᶜ L⊒L′)
+c★⊒c★-seal-factor⊥ rs eqM () outer (⊒α pαᶜ L⊒L′)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (ν⊒ν pᶜ qᶜ M⊒M′)
+c★⊒c★-seal-factor⊥ rs eqM () outer (⊒ν pᶜ M⊒M′)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (ν⊒ pᶜ M⊒M′)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (κ⊒κ κ)
+c★⊒c★-seal-factor⊥ rs () eqM′ outer (⊕⊒⊕ M⊒M′ N⊒N′)
+c★⊒c★-seal-factor⊥ rs refl eqM′ outer
+    (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  seal-factor-then-dual-nat-tag⊥
+    (term-cast-inj-coercion eqM′) outer q⨟s≈r
+c★⊒c★-seal-factor⊥ {σ = σ} rs refl eqM′ outer
+    (⊒cast- {q = q} {r = r} {s = s} {A = A} {B = B}
+      qᶜ q⨟s≈r M⊒M′) =
+  compose-left-tag-factor⊥
+    (subst
+      (λ s₀ → _ ∣ σ ⊢ q ⨾ⁿ s₀ ≈ r ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM′)
+      q⨟s≈r)
+c★⊒c★-seal-factor⊥ rs eqM eqM′ outer
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  bare⊒c★-aux⊥ rs (term-cast-inj-term eqM) eqM′ M⊒M′
+c★⊒c★-seal-factor⊥ {σ = σ} rs eqM refl outer
+    (cast-⊒ {p = p} {r = r} {t = t} {A = A} {B = B}
+      pᶜ r≈t⨟p M⊒M′) =
+  compose-right-tag-factor⊥
+    (subst
+      (λ t₀ → _ ∣ σ ⊢ r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM)
+      r≈t⨟p)
+
+sealedSource⊒c★-aux⊥ :
+  ∀ {Δ σ M M′ p} →
+  RelevantStore σ →
+  M ≡ sealedSource →
+  M′ ≡ c★ →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  ⊥
+sealedSource⊒c★-aux⊥ rel-star eqM eqM′
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  sealedSource⊒c★-aux⊥ (rel-source {A = A}) eqM eqM′ M⊒M′
+sealedSource⊒c★-aux⊥ () eqM eqM′ (split qᶜ pαᶜ M⊒M′)
+sealedSource⊒c★-aux⊥ rs eqM () (⊒blame pᶜ)
+sealedSource⊒c★-aux⊥ rs eqM () (x⊒x pᶜ x∋p)
+sealedSource⊒c★-aux⊥ rs () eqM′ (ƛ⊒ƛ p↦qᶜ M⊒M′)
+sealedSource⊒c★-aux⊥ rs () eqM′ (·⊒· qᶜ L⊒L′ M⊒M′)
+sealedSource⊒c★-aux⊥ rs () eqM′ (Λ⊒Λ allᶜ vV M⊒M′)
+sealedSource⊒c★-aux⊥ rs eqM () (⊒Λ pᶜ M⊒M′)
+sealedSource⊒c★-aux⊥ rs eqM () (⊒⟨ν⟩ pᶜ x M⊒M′)
+sealedSource⊒c★-aux⊥ rs () eqM′ (α⊒α qᶜ pαᶜ L⊒L′)
+sealedSource⊒c★-aux⊥ rs eqM () (⊒α pαᶜ L⊒L′)
+sealedSource⊒c★-aux⊥ rs () eqM′ (ν⊒ν pᶜ qᶜ M⊒M′)
+sealedSource⊒c★-aux⊥ rs eqM () (⊒ν pᶜ M⊒M′)
+sealedSource⊒c★-aux⊥ rs () eqM′ (ν⊒ pᶜ M⊒M′)
+sealedSource⊒c★-aux⊥ rs () eqM′ (κ⊒κ κ)
+sealedSource⊒c★-aux⊥ rs () eqM′ (⊕⊒⊕ M⊒M′ N⊒N′)
+sealedSource⊒c★-aux⊥ rs refl eqM′
+    (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  sealedSource⊒bare-aux⊥ rs refl (term-cast-inj-term eqM′) M⊒M′
+sealedSource⊒c★-aux⊥ {σ = σ} rs refl eqM′
+    (⊒cast- {q = q} {r = r} {s = s} {A = A} {B = B}
+      qᶜ q⨟s≈r M⊒M′) =
+  compose-left-tag-factor⊥
+    (subst
+      (λ s₀ → _ ∣ σ ⊢ q ⨾ⁿ s₀ ≈ r ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM′)
+      q⨟s≈r)
+sealedSource⊒c★-aux⊥ rs eqM refl
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  dual-eq-seal-factor⊥ (term-cast-inj-coercion eqM) r≈t⨟p
+sealedSource⊒c★-aux⊥ {σ = σ} rs eqM refl
+    (cast-⊒ {p = p} {r = r} {t = t} {A = A} {B = B}
+      pᶜ r≈t⨟p M⊒M′) =
+  c★⊒c★-seal-factor⊥ rs (term-cast-inj-term eqM) refl
+    (subst
+      (λ t₀ → _ ∣ σ ⊢ r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM)
+      r≈t⨟p)
+    M⊒M′
+
+badSource⊒bare-aux⊥ :
+  ∀ {Δ σ M M′ p} →
+  RelevantStore σ →
+  M ≡ badSource →
+  M′ ≡ $ k0 →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  ⊥
+badSource⊒bare-aux⊥ rel-star eqM eqM′
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  badSource⊒bare-aux⊥ (rel-source {A = A}) eqM eqM′ M⊒M′
+badSource⊒bare-aux⊥ () eqM eqM′ (split qᶜ pαᶜ M⊒M′)
+badSource⊒bare-aux⊥ rs eqM () (⊒blame pᶜ)
+badSource⊒bare-aux⊥ rs eqM () (x⊒x pᶜ x∋p)
+badSource⊒bare-aux⊥ rs () eqM′ (ƛ⊒ƛ p↦qᶜ M⊒M′)
+badSource⊒bare-aux⊥ rs () eqM′ (·⊒· qᶜ L⊒L′ M⊒M′)
+badSource⊒bare-aux⊥ rs () eqM′ (Λ⊒Λ allᶜ vV M⊒M′)
+badSource⊒bare-aux⊥ rs eqM () (⊒Λ pᶜ M⊒M′)
+badSource⊒bare-aux⊥ rs eqM () (⊒⟨ν⟩ pᶜ x M⊒M′)
+badSource⊒bare-aux⊥ rs () eqM′ (α⊒α qᶜ pαᶜ L⊒L′)
+badSource⊒bare-aux⊥ rs eqM () (⊒α pαᶜ L⊒L′)
+badSource⊒bare-aux⊥ rs () eqM′ (ν⊒ν pᶜ qᶜ M⊒M′)
+badSource⊒bare-aux⊥ rs eqM () (⊒ν pᶜ M⊒M′)
+badSource⊒bare-aux⊥ rs () eqM′ (ν⊒ pᶜ M⊒M′)
+badSource⊒bare-aux⊥ rs () refl (κ⊒κ (κℕ zero))
+badSource⊒bare-aux⊥ rs () () (κ⊒κ (κℕ (suc n)))
+badSource⊒bare-aux⊥ rs () eqM′ (⊕⊒⊕ M⊒M′ N⊒N′)
+badSource⊒bare-aux⊥ rs eqM () (⊒cast+ qᶜ q⨟s≈r M⊒M′)
+badSource⊒bare-aux⊥ rs eqM () (⊒cast- qᶜ q⨟s≈r M⊒M′)
+badSource⊒bare-aux⊥ rs eqM refl
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  sealedSource⊒bare-aux⊥ rs (term-cast-inj-term eqM) refl M⊒M′
+badSource⊒bare-aux⊥ {σ = σ} rs eqM refl
+    (cast-⊒ {p = p} {r = r} {t = t} {A = A} {B = B}
+      pᶜ r≈t⨟p M⊒M′) =
+  compose-right-tag-factor⊥
+    (subst
+      (λ t₀ → _ ∣ σ ⊢ r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM)
+      r≈t⨟p)
+
+badSource⊒bare⊥ :
+  ∀ {Δ p} →
+  Δ ∣ SigmaStar ∣ [] ⊢ badSource ⊒ $ k0 ∶ p →
+  ⊥
+badSource⊒bare⊥ = badSource⊒bare-aux⊥ rel-star refl refl
+
+badSource⊒c★-aux⊥ :
+  ∀ {Δ σ M M′ p} →
+  RelevantStore σ →
+  M ≡ badSource →
+  M′ ≡ c★ →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  ⊥
+badSource⊒c★-aux⊥ rel-star eqM eqM′
+    (extend {A = A} qᶜ pαᶜ M⊒M′) =
+  badSource⊒c★-aux⊥ (rel-source {A = A}) eqM eqM′ M⊒M′
+badSource⊒c★-aux⊥ () eqM eqM′ (split qᶜ pαᶜ M⊒M′)
+badSource⊒c★-aux⊥ rs eqM () (⊒blame pᶜ)
+badSource⊒c★-aux⊥ rs eqM () (x⊒x pᶜ x∋p)
+badSource⊒c★-aux⊥ rs () eqM′ (ƛ⊒ƛ p↦qᶜ M⊒M′)
+badSource⊒c★-aux⊥ rs () eqM′ (·⊒· qᶜ L⊒L′ M⊒M′)
+badSource⊒c★-aux⊥ rs () eqM′ (Λ⊒Λ allᶜ vV M⊒M′)
+badSource⊒c★-aux⊥ rs eqM () (⊒Λ pᶜ M⊒M′)
+badSource⊒c★-aux⊥ rs eqM () (⊒⟨ν⟩ pᶜ x M⊒M′)
+badSource⊒c★-aux⊥ rs () eqM′ (α⊒α qᶜ pαᶜ L⊒L′)
+badSource⊒c★-aux⊥ rs eqM () (⊒α pαᶜ L⊒L′)
+badSource⊒c★-aux⊥ rs () eqM′ (ν⊒ν pᶜ qᶜ M⊒M′)
+badSource⊒c★-aux⊥ rs eqM () (⊒ν pᶜ M⊒M′)
+badSource⊒c★-aux⊥ rs () eqM′ (ν⊒ pᶜ M⊒M′)
+badSource⊒c★-aux⊥ rs () () (κ⊒κ κ)
+badSource⊒c★-aux⊥ rs () eqM′ (⊕⊒⊕ M⊒M′ N⊒N′)
+badSource⊒c★-aux⊥ rs refl eqM′
+    (⊒cast+ qᶜ q⨟s≈r M⊒M′) =
+  badSource⊒bare-aux⊥ rs refl (term-cast-inj-term eqM′) M⊒M′
+badSource⊒c★-aux⊥ {σ = σ} rs refl eqM′
+    (⊒cast- {q = q} {r = r} {s = s} {A = A} {B = B}
+      qᶜ q⨟s≈r M⊒M′) =
+  compose-left-tag-factor⊥
+    (subst
+      (λ s₀ → _ ∣ σ ⊢ q ⨾ⁿ s₀ ≈ r ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM′)
+      q⨟s≈r)
+badSource⊒c★-aux⊥ rs eqM refl
+    (cast+⊒ pᶜ r≈t⨟p M⊒M′) =
+  sealedSource⊒c★-aux⊥ rs (term-cast-inj-term eqM) refl M⊒M′
+badSource⊒c★-aux⊥ {σ = σ} rs eqM refl
+    (cast-⊒ {p = p} {r = r} {t = t} {A = A} {B = B}
+      pᶜ r≈t⨟p M⊒M′) =
+  compose-right-tag-factor⊥
+    (subst
+      (λ t₀ → _ ∣ σ ⊢ r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
+      (term-cast-inj-coercion eqM)
+      r≈t⨟p)
+
+badSource⊒c★⊥ :
+  ∀ {Δ p} →
+  Δ ∣ SigmaStar ∣ [] ⊢ badSource ⊒ c★ ∶ p →
+  ⊥
+badSource⊒c★⊥ = badSource⊒c★-aux⊥ rel-star refl refl
+
+right-seal-to-idAlpha⊥ :
+  ∀ {Δ q C} →
+  Δ ∣ SigmaStar ⊢ q ⨾ⁿ sealStar0 ≈ idAlpha0 ∶ C ⊒ ＇ alpha0 →
+  ⊥
+right-seal-to-idAlpha⊥
+    (compose-leftⁿ wfΣ q⊒
+      (cast-seal h★ α∈Σ seal-ok , sealⁿ .★ .alpha0)
+      (endpointsⁿ src-u tgt-u src-id tgt-id σ⊒ wfΣ₁ wfΣ₂ u⊒ id⊒)) =
+  narrowing-var-to-older⊥ wfΣ wf★
+    (subst (λ A → _ ∣ _ ∣ _ ⊢ _ ∶ A ⊒ ★) (sym src-id) q⊒)
+
+ExactSealUnsealDGGResult : Set₁
+ExactSealUnsealDGGResult =
+  ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
+    (badSource —↠[ χs ] N) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π SigmaStar ∣ [] ⊢ N ⊒ c★ ∶ p′
+
+exact-seal-unseal-dgg-result⊥ :
+  ExactSealUnsealDGGResult → ⊥
+exact-seal-unseal-dgg-result⊥
+    (χs , N , Δ′ , Π , Π′ , π , p′ ,
+      badSource↠N , Π≡ , Π′≡ , π⊒ , N⊒c★)
+    with value-multistep-refl badSource-value badSource↠N
+... | χs≡[] , N≡badSource
+    rewrite χs≡[] | N≡badSource | Π≡ | Π′≡
+    with π⊒
+... | ⊒ˢ-nil = badSource⊒c★⊥ N⊒c★

--- a/GTSF/proof/ExactSealUnsealCounterexample.agda
+++ b/GTSF/proof/ExactSealUnsealCounterexample.agda
@@ -814,3 +814,23 @@ exact-seal-unseal-dgg-result⊥
     rewrite χs≡[] | N≡badSource | Π≡ | Π′≡
     with π⊒
 ... | ⊒ˢ-nil = badSource⊒c★⊥ N⊒c★
+
+DynamicGradualGuaranteeStatement : Set₁
+DynamicGradualGuaranteeStatement =
+  ∀ {Δ σ M M′ N′ p χ′} →
+  RuntimeOK M →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  M′ —→[ χ′ ] N′ →
+  ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
+    (M —↠[ χs ] N) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore χ′ []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ ∶ p′
+
+dynamic-gradual-guarantee-statement⊥ :
+  DynamicGradualGuaranteeStatement → ⊥
+dynamic-gradual-guarantee-statement⊥ dgg =
+  exact-seal-unseal-dgg-result⊥
+    (dgg badSource-runtime-ok exact-tagged-sealed-source-premise′
+      sealedTarget-step)

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -1834,6 +1834,17 @@ narrowing-var≢-to-var-tag⊥ {μ = μ} {α = α} β≢α tag-ok
      sⁿ ︔seal _) =
   tag-or-id-seal-conflict {μ = μ} {α = α} tag-ok seal-ok
 
+castlike-var-var-endpoints :
+  ∀ {Δ Σ α β c} →
+  Δ ∣ Σ ⊢ c ∶ᶜ (＇ β) ⊒ (＇ α) →
+  β ≡ α
+castlike-var-var-endpoints {α = α} {β = β} cᶜ with β ≟ α
+castlike-var-var-endpoints cᶜ | yes β≡α = β≡α
+castlike-var-var-endpoints {α = α} cᶜ | no β≢α =
+  ⊥-elim
+    (narrowing-var≢-to-var-tag⊥ {α = α}
+      β≢α refl cᶜ)
+
 narrowing-skew-var-to-var-tag⊥ :
   ∀ {μ Δ Σ α β c} →
   μ α ≡ tag-or-id →

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -108,6 +108,27 @@ srcStoreⁿ-⊒ˢ (⊒ˢ-both {X = X} hA hA′ (μ , s⊒) σ⊒) =
       (sym (proj₁ (coercion-src-tgtᵐ (proj₁ s⊒)))))
     (srcStoreⁿ-⊒ˢ σ⊒)
 
+tgtStoreⁿ : StoreNrw → Store
+tgtStoreⁿ [] = []
+tgtStoreⁿ ((X ꞉ p) ∷ σ) = (X , tgt p) ∷ tgtStoreⁿ σ
+tgtStoreⁿ ((X ꞉= A ⊒) ∷ σ) = (X , A) ∷ tgtStoreⁿ σ
+tgtStoreⁿ ((⊒ X ꞉=☆) ∷ σ) = tgtStoreⁿ σ
+
+tgtStoreⁿ-⊒ˢ :
+  ∀ {Δ σ Σ Σ′} →
+  Δ ⊢ σ ꞉ Σ ⊒ˢ Σ′ →
+  Σ′ ≡ tgtStoreⁿ σ
+tgtStoreⁿ-⊒ˢ ⊒ˢ-nil = refl
+tgtStoreⁿ-⊒ˢ (⊒ˢ-right hA σ⊒) =
+  cong (_∷_ _) (tgtStoreⁿ-⊒ˢ σ⊒)
+tgtStoreⁿ-⊒ˢ (⊒ˢ-left σ⊒) =
+  tgtStoreⁿ-⊒ˢ σ⊒
+tgtStoreⁿ-⊒ˢ (⊒ˢ-both {X = X} hA hA′ (μ , s⊒) σ⊒) =
+  cong₂ _∷_
+    (cong (λ A → (X , A))
+      (sym (proj₂ (coercion-src-tgtᵐ (proj₁ s⊒)))))
+    (tgtStoreⁿ-⊒ˢ σ⊒)
+
 srcStoreⁿ-⇑ˢ :
   ∀ σ →
   srcStoreⁿ (⇑ˢ σ) ≡ ⟰ᵗ (srcStoreⁿ σ)

--- a/GTSF/proof/ReductionProperties.agda
+++ b/GTSF/proof/ReductionProperties.agda
@@ -578,6 +578,26 @@ applyCoercions-⇑ᶜ [] c = refl
 applyCoercions-⇑ᶜ (keep ∷ χs) c = applyCoercions-⇑ᶜ χs c
 applyCoercions-⇑ᶜ (bind A ∷ χs) c = applyCoercions-⇑ᶜ χs (⇑ᶜ c)
 
+applyCoercions-seal :
+  ∀ χs A α →
+  applyCoercions χs (seal A α) ≡
+    seal (applyTys χs A) (applyTyVars χs α)
+applyCoercions-seal [] A α = refl
+applyCoercions-seal (keep ∷ χs) A α =
+  applyCoercions-seal χs A α
+applyCoercions-seal (bind B ∷ χs) A α =
+  applyCoercions-seal χs (⇑ᵗ A) (suc α)
+
+applyCoercions-unseal :
+  ∀ χs α A →
+  applyCoercions χs (unseal α A) ≡
+    unseal (applyTyVars χs α) (applyTys χs A)
+applyCoercions-unseal [] α A = refl
+applyCoercions-unseal (keep ∷ χs) α A =
+  applyCoercions-unseal χs α A
+applyCoercions-unseal (bind B ∷ χs) α A =
+  applyCoercions-unseal χs (suc α) (⇑ᵗ A)
+
 applyCoercion-preserves-Inert :
   ∀ χ {c} →
   Inert c →
@@ -730,6 +750,24 @@ applyTerms-cast-dual :
 applyTerms-cast-dual χs M c =
   trans (applyTerms-cast χs M (- c))
     (cong (λ d → applyTerms χs M ⟨ d ⟩) (applyCoercions-dual χs c))
+
+applyTerms-cast-seal :
+  ∀ χs M A α →
+  applyTerms χs (M ⟨ seal A α ⟩) ≡
+    applyTerms χs M ⟨ seal (applyTys χs A) (applyTyVars χs α) ⟩
+applyTerms-cast-seal χs M A α =
+  trans (applyTerms-cast χs M (seal A α))
+    (cong (λ c → applyTerms χs M ⟨ c ⟩)
+      (applyCoercions-seal χs A α))
+
+applyTerms-cast-unseal :
+  ∀ χs M α A →
+  applyTerms χs (M ⟨ unseal α A ⟩) ≡
+    applyTerms χs M ⟨ unseal (applyTyVars χs α) (applyTys χs A) ⟩
+applyTerms-cast-unseal χs M α A =
+  trans (applyTerms-cast χs M (unseal α A))
+    (cong (λ c → applyTerms χs M ⟨ c ⟩)
+      (applyCoercions-unseal χs α A))
 
 ------------------------------------------------------------------------
 -- Multi-step reduction

--- a/GTSF/proof/RightSealBroadCounterexample.agda
+++ b/GTSF/proof/RightSealBroadCounterexample.agda
@@ -9,19 +9,22 @@ module proof.RightSealBroadCounterexample where
 --   * Uses only existing coercion/narrowing infrastructure and adds no
 --     postulates.
 
-open import Agda.Builtin.Equality using (refl)
+open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥)
 open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (z<s)
-open import Data.Product using (_,_; proj₂)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
 open import NarrowWiden
 open import NarrowWidenComposition
+open import proof.CoercionProperties using (coercion-src-tgtᵐ)
 open import proof.NarrowWidenProperties
-  using (StoreDetWf; narrowing-var-to-older⊥)
+  using (StoreDetWf; castlike-var-var-endpoints; narrowing-var-to-older⊥)
 
 alpha0 : TyVar
 alpha0 = 0
@@ -100,3 +103,58 @@ right-seal-compose-source-var⊥
       (cast-seal hB α∈Σ seal-ok , sealⁿ B α)
       q⨟seal≈r) =
   narrowing-var-to-older⊥ wfΣ (StoreDetWf.wfOlder wfΣ α∈Σ) q⊒
+
+right-seal-compose-left-seal-factor⊥ :
+  ∀ {Δ σ q p r A B C D E F α β} →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ src q ⊒ ＇ α →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ seal A β ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+right-seal-compose-left-seal-factor⊥
+    {Δ = Δ} {σ = σ} {q = q} {p = p} {B = B}
+    {C = C} {D = D} {α = α} {β = β}
+    outer@(compose-leftⁿ wfΣ₀ q⊒ seal⊒
+      (endpointsⁿ src-u tgt-u src-p tgt-p
+        σ⊒ wfΣ₁ wfΣ₂ u⊒ p⊒outer))
+    pᶜ
+    (compose-rightⁿ wfΣ
+      (cast-seal hA β∈Σ seal-ok , sealⁿ A β)
+      p⊒
+      r≈seal⨟p) =
+  right-seal-compose-source-var⊥
+    (subst
+      (λ S → Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ S ⊒ ＇ α)
+      src-q≡＇α
+      outer)
+  where
+    pᶜ-src : src p ≡ C
+    pᶜ-src = proj₁ (coercion-src-tgtᵐ (proj₁ pᶜ))
+
+    pᶜ-tgt : tgt p ≡ D
+    pᶜ-tgt = proj₂ (coercion-src-tgtᵐ (proj₁ pᶜ))
+
+    p-src-β : src p ≡ ＇ β
+    p-src-β = proj₁ (coercion-src-tgtᵐ (proj₁ p⊒))
+
+    pᶜ-var-src :
+      Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ ＇ β ⊒ D
+    pᶜ-var-src =
+      subst
+        (λ S → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ S ⊒ D)
+        (trans (sym pᶜ-src) p-src-β)
+        pᶜ
+
+    pᶜ-var :
+      Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ ＇ β ⊒ ＇ α
+    pᶜ-var =
+      subst
+        (λ T → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ ＇ β ⊒ T)
+        (trans (sym pᶜ-tgt) tgt-p)
+        pᶜ-var-src
+
+    β≡α : β ≡ α
+    β≡α = castlike-var-var-endpoints pᶜ-var
+
+    src-q≡＇α : src q ≡ ＇ α
+    src-q≡＇α =
+      trans (sym src-p) (trans p-src-β (cong ＇_ β≡α))

--- a/GTSF/proof/RightSealBroadCounterexample.agda
+++ b/GTSF/proof/RightSealBroadCounterexample.agda
@@ -1,0 +1,102 @@
+module proof.RightSealBroadCounterexample where
+
+-- File Charter:
+--   * Small checked counterexample to the broad claim that a tag/id-mode
+--     narrowing can never be endpoint-equivalent to a right-seal composite.
+--   * The counterexample uses `id ★ ⨾ seal ★ α ≈ (＇ α) ？`: the composition
+--     itself is typed in seal mode, while the right endpoint witness is the
+--     tag/id-mode untag-like narrowing.
+--   * Uses only existing coercion/narrowing infrastructure and adds no
+--     postulates.
+
+open import Agda.Builtin.Equality using (refl)
+open import Data.Empty using (⊥)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here)
+open import Data.Nat using (z<s)
+open import Data.Product using (_,_; proj₂)
+
+open import Types
+open import Coercions
+open import NarrowWiden
+open import NarrowWidenComposition
+open import proof.NarrowWidenProperties
+  using (StoreDetWf; narrowing-var-to-older⊥)
+
+alpha0 : TyVar
+alpha0 = 0
+
+StoreStar : Store
+StoreStar = (alpha0 , ★) ∷ []
+
+SigmaStar : StoreNrw
+SigmaStar = (alpha0 ꞉ id ★) ∷ []
+
+sealStar0 : Coercion
+sealStar0 = seal ★ alpha0
+
+untagAlpha0 : Coercion
+untagAlpha0 = (＇ alpha0) ？
+
+wfStoreStar : StoreDetWf 1 StoreStar
+wfStoreStar =
+  record
+    { at = record
+        { bound = λ { (here refl) → z<s }
+        ; wfTy = λ { (here refl) → wf★ }
+        }
+    ; wfOlder = λ { (here refl) → wf★ }
+    ; unique = λ { (here refl) (here refl) → refl }
+    }
+
+SigmaStar⊒ : 1 ⊢ SigmaStar ꞉ StoreStar ⊒ˢ StoreStar
+SigmaStar⊒ =
+  ⊒ˢ-both wf★ wf★
+    (id-onlyᵈ , (cast-id wf★ refl , id★))
+    ⊒ˢ-nil
+
+endpointsStar : EndpointWf 1 StoreStar ★ (＇ alpha0)
+endpointsStar = wf★ˢ , wfVarˢ (here refl)
+
+idStar⊒ : seal-or-idᵈ ∣ 1 ∣ StoreStar ⊢ id ★ ∶ ★ ⊒ ★
+idStar⊒ = cast-id wf★ refl , id★
+
+sealStar⊒ : seal-or-idᵈ ∣ 1 ∣ StoreStar ⊢ sealStar0 ∶ ★ ⊒ ＇ alpha0
+sealStar⊒ = cast-seal wf★ (here refl) refl , sealⁿ ★ alpha0
+
+untagAlpha⊒ᶜ : 1 ∣ StoreStar ⊢ untagAlpha0 ∶ᶜ ★ ⊒ ＇ alpha0
+untagAlpha⊒ᶜ =
+  cast-untag (wfVar z<s) (＇ alpha0) refl , untag (＇ alpha0)
+
+right-seal-compose-to-untag :
+  1 ∣ SigmaStar
+    ⊢ id ★ ⨾ⁿ sealStar0 ≈ untagAlpha0 ∶ src (id ★) ⊒ ＇ alpha0
+right-seal-compose-to-untag =
+  compose-leftⁿ wfStoreStar idStar⊒ sealStar⊒
+    (endpointsⁿ refl refl refl refl SigmaStar⊒ endpointsStar endpointsStar
+      (seal-or-idᵈ ,
+        proj₂ (_⨟ⁿ_ {wfΣ = wfStoreStar} idStar⊒ sealStar⊒))
+      (tag-or-idᵈ , untagAlpha⊒ᶜ))
+
+BroadRightSealContradiction : Set₁
+BroadRightSealContradiction =
+  ∀ {Δ σ p q B C D α} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ src q ⊒ ＇ α →
+  ⊥
+
+broad-right-seal-contradiction-is-false :
+  BroadRightSealContradiction →
+  ⊥
+broad-right-seal-contradiction-is-false broad =
+  broad untagAlpha⊒ᶜ right-seal-compose-to-untag
+
+right-seal-compose-source-var⊥ :
+  ∀ {Δ σ q r B α} →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ ＇ α ⊒ ＇ α →
+  ⊥
+right-seal-compose-source-var⊥
+    (compose-leftⁿ wfΣ q⊒
+      (cast-seal hB α∈Σ seal-ok , sealⁿ B α)
+      q⨟seal≈r) =
+  narrowing-var-to-older⊥ wfΣ (StoreDetWf.wfOlder wfΣ α∈Σ) q⊒

--- a/GTSF/proof/RightSealBroadCounterexample.agda
+++ b/GTSF/proof/RightSealBroadCounterexample.agda
@@ -158,3 +158,30 @@ right-seal-compose-left-seal-factor⊥
     src-q≡＇α : src q ≡ ＇ α
     src-q≡＇α =
       trans (sym src-p) (trans p-src-β (cong ＇_ β≡α))
+
+compose-right-unseal-factor⊥ :
+  ∀ {Δ σ r p A E F β} →
+  Δ ∣ σ ⊢ r ≈ unseal β A ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+compose-right-unseal-factor⊥
+    (compose-rightⁿ wfΣ
+      (cast-unseal hA β∈Σ seal-ok , cross ())
+      p⊒ r≈unseal⨟p)
+
+compose-right-inst-factor⊥ :
+  ∀ {Δ σ r p B c E F} →
+  Δ ∣ σ ⊢ r ≈ inst B c ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+compose-right-inst-factor⊥
+    (compose-rightⁿ wfΣ
+      (cast-inst hB occ c⊢ , cross ())
+      p⊒ r≈inst⨟p)
+
+compose-right-tag-factor⊥ :
+  ∀ {Δ σ r p G E F} →
+  Δ ∣ σ ⊢ r ≈ G ! ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+compose-right-tag-factor⊥
+    (compose-rightⁿ wfΣ
+      (cast-tag hG gG tag-ok , cross ())
+      p⊒ r≈tag⨟p)

--- a/GTSF/proof/RightSealFactorCounterexample.agda
+++ b/GTSF/proof/RightSealFactorCounterexample.agda
@@ -1,0 +1,134 @@
+module proof.RightSealFactorCounterexample where
+
+-- File Charter:
+--   * Counterexample for exact right-seal factorization in source-left
+--     cast cases.
+--   * Shows that the case needed by `cast+⊒` is false even with an exact
+--     `q ⨾ⁿ seal ... ≈ r` premise: `id Nat ⨾ seal ≈ seal` and
+--     `seal ≈ seal ⨾ id α`, but `id α` is not itself a right-seal composite.
+--   * Uses only existing coercion/narrowing infrastructure and adds no
+--     postulates.
+
+open import Agda.Builtin.Equality using (refl)
+open import Data.Empty using (⊥)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here)
+open import Data.Nat using (z<s)
+open import Data.Product using (_,_; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (subst; sym)
+
+open import Types
+open import Coercions
+open import Primitives
+open import NarrowWiden
+open import NarrowWidenComposition
+open import proof.NarrowWidenProperties
+  using (StoreDetWf; narrowing-var-to-older⊥)
+
+NatTy : Ty
+NatTy = ‵ `ℕ
+
+alpha0 : TyVar
+alpha0 = 0
+
+Store0 : Store
+Store0 = (alpha0 , NatTy) ∷ []
+
+Sigma0 : StoreNrw
+Sigma0 = (alpha0 ꞉ id NatTy) ∷ []
+
+seal0 : Coercion
+seal0 = seal NatTy alpha0
+
+idAlpha0 : Coercion
+idAlpha0 = id (＇ alpha0)
+
+wfStore0 : StoreDetWf 1 Store0
+wfStore0 =
+  record
+    { at = record
+        { bound = λ { (here refl) → z<s }
+        ; wfTy = λ { (here refl) → wfBase }
+        }
+    ; wfOlder = λ { (here refl) → wfBase }
+    ; unique = λ { (here refl) (here refl) → refl }
+    }
+
+Sigma0⊒ : 1 ⊢ Sigma0 ꞉ Store0 ⊒ˢ Store0
+Sigma0⊒ =
+  ⊒ˢ-both wfBase wfBase
+    (id-onlyᵈ , (cast-id wfBase refl , cross (id-‵ `ℕ)))
+    ⊒ˢ-nil
+
+endpoints0 : EndpointWf 1 Store0 NatTy (＇ alpha0)
+endpoints0 = wfBaseˢ , wfVarˢ (here refl)
+
+idNat⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ id NatTy ∶ NatTy ⊒ NatTy
+idNat⊒ = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+idAlpha0⊒ :
+  seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ idAlpha0 ∶ ＇ alpha0 ⊒ ＇ alpha0
+idAlpha0⊒ = cast-id (wfVar z<s) refl , cross (id-＇ alpha0)
+
+seal0⊒ : seal-or-idᵈ ∣ 1 ∣ Store0 ⊢ seal0 ∶ NatTy ⊒ ＇ alpha0
+seal0⊒ = cast-seal wfBase (here refl) refl , sealⁿ NatTy alpha0
+
+right-seal-compose :
+  1 ∣ Sigma0 ⊢ id NatTy ⨾ⁿ seal0 ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
+right-seal-compose =
+  compose-leftⁿ wfStore0 idNat⊒ seal0⊒
+    (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+      (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
+      (seal-or-idᵈ , seal0⊒))
+
+left-seal-compose :
+  1 ∣ Sigma0 ⊢ seal0 ≈ seal0 ⨾ⁿ idAlpha0 ∶ NatTy ⊒ ＇ alpha0
+left-seal-compose =
+  compose-rightⁿ wfStore0 seal0⊒ idAlpha0⊒
+    (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+      (seal-or-idᵈ , seal0⊒)
+      (seal-or-idᵈ ,
+        proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} seal0⊒ idAlpha0⊒)))
+
+idAlpha-not-right-seal-factor :
+  ∀ {q} →
+  1 ∣ Sigma0 ⊢ q ⨾ⁿ seal0 ≈ idAlpha0 ∶ src q ⊒ ＇ alpha0 →
+  ⊥
+idAlpha-not-right-seal-factor {q = q}
+    (compose-leftⁿ {Σ = Σ} {μ = μ} wfΣ q⊒
+      (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+      (endpointsⁿ src-u tgt-u src-idα tgt-idα
+        σ⊒ wfΣ₁ wfΣ₂ u⊒ idα⊒)) =
+  narrowing-var-to-older⊥
+    {μ = μ}
+    {Δ = 1}
+    {Σ = Σ}
+    {c = q}
+    {α = alpha0}
+    {B = NatTy}
+    wfΣ
+    wfBase
+    (subst (λ A → μ ∣ 1 ∣ Σ ⊢ q ∶ A ⊒ NatTy) (sym src-idα) q⊒)
+
+Case1Factorization : Set₁
+Case1Factorization =
+  ∀ {q r t p B α} →
+  1 ∣ Sigma0 ⊢ q ⨾ⁿ seal B α ≈ r ∶ src q ⊒ ＇ α →
+  1 ∣ Sigma0 ⊢ r ≈ t ⨾ⁿ p ∶ src q ⊒ ＇ α →
+  ∃[ q′ ] 1 ∣ Sigma0 ⊢ q′ ⨾ⁿ seal B α ≈ p ∶ src q′ ⊒ ＇ α
+
+case1-factorization-is-false :
+  Case1Factorization →
+  ⊥
+case1-factorization-is-false factor
+    with factor
+      {q = id NatTy}
+      {r = seal0}
+      {t = seal0}
+      {p = idAlpha0}
+      {B = NatTy}
+      {α = alpha0}
+      right-seal-compose
+      left-seal-compose
+case1-factorization-is-false factor | q′ , q′⨟seal≈idα =
+  idAlpha-not-right-seal-factor q′⨟seal≈idα

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -849,3 +849,27 @@ and the target step `seal-unseal`.  The conclusion is refuted after
 post-step contradiction is generalized over the existentially chosen `Δ′`;
 otherwise the DGG result could hide behind an arbitrary context choice even
 though the source and target stores are both empty after the step.
+
+The module also checks the stronger refutation
+
+```agda
+dynamic-gradual-guarantee-statement⊥ :
+  DynamicGradualGuaranteeStatement → ⊥
+```
+
+where `DynamicGradualGuaranteeStatement` is the current theorem statement of
+`dynamicGradualGuarantee`.  Thus the obstruction is not only the local proof
+script for the seal-unseal branch: any proof of the current statement would
+produce the impossible `ExactSealUnsealDGGResult` on this instance.
+
+Consequently, the missing algebra for the original proof cannot be a
+right-seal cancellation lemma that excludes the source-left tag case.  Such a
+lemma would contradict the checked algebraic witness
+
+```agda
+id ★ ⨾ⁿ seal ★ 0 ≈ (＇ 0) ？
+```
+
+and the checked term-level premise built from it.  A repair must change the
+statement or one of the relations/operational rules so this exact
+source-left-tag value is no longer an admissible premise for DGG.

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -435,6 +435,178 @@ a genuinely dynamic helper that lets source-left casts take their own source
 steps, probably using the existing value-level `left-widening-lemma` and
 `left-narrowing-lemma`, rather than trying to prove a zero-step strip theorem.
 
+### Attempt 7. Value-restricted right-seal continuation
+
+The next scratch theorem restricted the strip to source values:
+
+```agda
+rightSealValueStrip :
+  Value W →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  Δ ∣ σ ∣ [] ⊢ W ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ p ] Δ ∣ σ ∣ [] ⊢ W ⊒ V ∶ p
+```
+
+This restriction is meaningful: the checked
+`proof.RightSealFactorCounterexample` uses a source-left `cast+⊒` whose source
+cast is `- seal`, i.e. `unseal`, so the source term is not a value.  The
+value-restricted theorem therefore avoids that exact counterexample.
+
+The equality-indexed scratch version closed these cases:
+
+- all target-shape contradictions (`⊒blame`, variables, lambdas, applications,
+  `Λ`, `⊒Λ`, `⊒⟨ν⟩`, `⊒α`, `⊒ν`, constants, and primitive operations);
+- right `⊒cast+`: cast-term injectivity gives the premise target `V`, so the
+  premise relation is the witness;
+- right `⊒cast-`: the same cast-term injectivity argument gives the premise
+  relation.
+
+The remaining value-restricted goals are:
+
+```agda
+extend
+split
+ν⊒
+cast+⊒
+cast-⊒
+```
+
+This is a better target than the original zero-step strip, but it still does
+not directly fill the DGG hole after a `catchup-lemma` call.  Catchup relates
+the source value to `applyTerms χs (V ⟨ seal A α ⟩)`, so the continuation must
+be stated over the renamed target value and transported through the emitted
+store prefix.  The likely DGG-shaped helper has final right side
+`applyTerms χs V`:
+
+```agda
+right-seal-unseal-catchup :
+  RuntimeOK M →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
+    (M —↠[ χs ] N) ×
+    (Δ′ ≡ applyTyCtxs χs Δ) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ N ⊒ applyTerms χs V ∶ p′
+```
+
+The literal `dynamicGradualGuarantee` conclusion currently wants bare `V`, so
+after this helper there is still a global target-transport issue unless the
+helper can prove that the emitted source changes leave `V` unchanged in the
+needed cases.
+
+A dynamic scratch probe confirmed this mismatch mechanically: after
+`catchup-lemma okM (vV ⟨ seal A α ⟩) M⊒Vseal`, the available relation is to
+the sealed target, not to `V`; attempting to finish the branch with a reflexive
+placeholder fails at exactly the required term-narrowing derivation
+`W ⊒ V`.
+
+As a small checked algebraic step toward the renamed continuation,
+`proof.ReductionProperties` now proves
+
+```agda
+applyCoercions-seal :
+  ∀ χs A α →
+  applyCoercions χs (seal A α) ≡
+    seal (applyTys χs A) (applyTyVars χs α)
+
+applyCoercions-unseal :
+  ∀ χs α A →
+  applyCoercions χs (unseal α A) ≡
+    unseal (applyTyVars χs α) (applyTys χs A)
+
+applyTerms-cast-seal :
+  ∀ χs M A α →
+  applyTerms χs (M ⟨ seal A α ⟩) ≡
+    applyTerms χs M ⟨ seal (applyTys χs A) (applyTyVars χs α) ⟩
+
+applyTerms-cast-unseal :
+  ∀ χs M α A →
+  applyTerms χs (M ⟨ unseal α A ⟩) ≡
+    applyTerms χs M ⟨ unseal (applyTyVars χs α) (applyTys χs A) ⟩
+```
+
+These lemmas remove the coercion-shape ambiguity after rewriting the
+store-changed sealed or unsealed target term.
+
+### Attempt 8. Refine the value-source strip by source cast shape
+
+A follow-up scratch proof tightened Attempt 7 by pattern matching on the source
+`Value` evidence.  This closed the `ν⊒` branch: its source is syntactically
+`ν ★ N (⇑ᶜ p)`, and `ν` is not a `Value` constructor.  The ordinary right-cast
+branches remained as before:
+
+- right `⊒cast+` is either syntactically impossible or, for the hidden
+  `unseal`, contradictory by `right-seal-inversion₂-cast-unseal⊥`;
+- right `⊒cast-` strips directly to its premise relation.
+
+After splitting source-left casts against `Inert`, the only remaining
+source-left shapes are the ones whose visible source cast can be a value:
+
+```agda
+cast+⊒ with t = c ↦ d
+cast+⊒ with t = `∀ c
+cast+⊒ with t = G ？
+cast+⊒ with t = unseal β A
+cast+⊒ with t = inst B c
+
+cast-⊒ with t = c ↦ d
+cast-⊒ with t = `∀ c
+cast-⊒ with t = G !
+cast-⊒ with t = seal A β
+cast-⊒ with t = gen B c
+```
+
+So the value-source strip is not blocked by arbitrary source-left casts; it is
+blocked by exactly the inert cast forms.  These are also exactly the forms that
+would require either typed endpoint contradictions or a dynamic move via
+`left-widening-lemma`/`left-narrowing-lemma`.
+
+The typed composition code points at the likely algebraic boundary.  In
+`_⨟ⁿ_`, composing any narrowing on the right with a seal goes through
+`wrap-sealⁿ`, yielding either a literal `seal A α` or a strict narrowing
+followed by `︔ seal A α`.  A useful next algebraic lemma would expose this
+trailing-seal shape for the computed composite in `compose-leftⁿ`; the existing
+raw coercion lemma `⨟-sealʳ` is the untyped analogue.
+
+A read-only algebra pass narrowed the source-left obligations further.  The
+existing library already has the endpoint facts that most of these branches
+need:
+
+```agda
+narrowing-cross-var-source-target
+widening-cross-var-target-source
+narrowing-target-star-source-star
+widening-source-star-target-star
+narrowing-var-to-star⊥
+widening-star-to-var⊥
+narrowing-cross-ground-target-seal-var⊥
+widening-cross-ground-source-seal-var⊥
+```
+
+The expected reusable corollary is not just a raw syntax fact.  It must combine
+the endpoint stores from `endpointsⁿ`, `srcStoreⁿ-⊒ˢ`/`tgtStoreⁿ-⊒ˢ`, and mode
+conflicts such as `tag-or-id-seal-conflict`.  An over-broad first statement
+
+```agda
+right-seal-compose-castlike-result⊥ :
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ src q ⊒ ＇ α →
+  ⊥
+```
+
+was accepted as a scratch goal but not proved directly; its proof needs to
+expose the `endpointsⁿ` stores and compare the cast-like typing of `p` with
+the right-seal composite typing in the correct endpoint store.  This is the
+next concrete algebraic lemma to mechanize before returning to the DGG branch.
+
 ### Counterexample search
 
 The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -302,6 +302,57 @@ stripping/contraction fact to obtain a relation to `applyTerms χs V`.  The
 existing left widening/narrowing lemmas move casts on the source side; they do
 not remove this remaining right seal.
 
+### Attempt 5. Cancel two right-seal compositions
+
+The direct `⊒cast-` strip branch first suggested the algebraic cancellation
+
+```agda
+right-seal-compose-cancelᶜ :
+  Δ ∣ srcStoreⁿ σ ⊢ q  ∶ᶜ C  ⊒ D →
+  Δ ∣ srcStoreⁿ σ ⊢ q₀ ∶ᶜ C₀ ⊒ D₀ →
+  Δ ∣ σ ⊢ q  ⨾ⁿ seal B  α ≈ r ∶ E  ⊒ F →
+  Δ ∣ σ ⊢ q₀ ⨾ⁿ seal A₀ α ≈ r ∶ E₀ ⊒ F₀ →
+  q₀ ≡ q .
+```
+
+A first proof tried to use the `StoreDetWf` carried by `compose-leftⁿ` and the
+seal memberships from the internal composition.  This is not sufficient:
+`endpointsⁿ` has its own target store for the computed composite, and that
+store is the one constrained by the store narrowing `σ`.  The internal
+composition store and the endpoint target store are related only through the
+fact that both type the computed composite.
+
+The useful algebraic fact added during this attempt is the dual of
+`srcStoreⁿ-⊒ˢ`:
+
+```agda
+tgtStoreⁿ-⊒ˢ :
+  Δ ⊢ σ ꞉ Σ ⊒ˢ Σ′ →
+  Σ′ ≡ tgtStoreⁿ σ .
+```
+
+The next cancellation attempt should first prove a shape lemma for the computed
+composite `proj₁ (_⨟ⁿ_ q⊒ seal⊒)`: any endpoint typing of that computed
+coercion must expose the final seal membership in the endpoint target store.
+Only after extracting those endpoint-store memberships can `tgtStoreⁿ-⊒ˢ` and
+store uniqueness force the two seal payloads to agree.  Trying to use the
+internal `cast-seal` memberships repeats the wrong-store mistake.
+
+For the DGG redex itself this cancellation is less central than it first
+appeared, because the theorem conclusion existentially chooses the post-step
+index `p′`.  In the direct `⊒cast-` branch the proof can return the inner
+relation at its original index.  The cancellation lemma would still be useful
+for a stronger exact-index strip theorem, but the DGG-oriented strip theorem
+mainly needs the store-shaping cases (`extend` and `split`) and a way to handle
+or exclude remaining left-cast wrappers after catchup.
+
+For `extend`, `extendReplaceRel-term` and `extendReplaceRel-compose-left`
+transport from the source-only store `(α ꞉= A ⊒) ∷ σ` to the ordinary store
+`(α ꞉ q) ∷ σ`.  The recursive strip premise would need the opposite direction:
+from the outer composition in `(α ꞉ q) ∷ σ` to a composition premise in
+`(α ꞉= A ⊒) ∷ σ`.  Reusing the existing transport directly therefore repeats
+the wrong-direction mistake.
+
 ### Counterexample search
 
 The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -679,6 +679,33 @@ source-left `cast+⊒` and `cast-⊒` branches are the places where a source val
 may need to reduce through the inert cast before the post-step relation to `V`
 can be built.
 
+One source-left branch is now especially concrete.  In
+
+```agda
+cast-⊒ {t = seal A β} pᶜ r≈seal⨟p M⊒Vseal₀
+```
+
+the exact outer premise has result `p`:
+
+```agda
+q⨾seal≈p : Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ src q ⊒ ＇ α
+```
+
+The branch would close by `right-seal-compose-source-var⊥` if the endpoints can
+be rewritten to `＇ α ⊒ ＇ α`.  The missing algebraic fact is a cast-like
+variable-to-variable endpoint inversion:
+
+```agda
+castlike-var-var-endpoints :
+  Δ ∣ Σ ⊢ p ∶ᶜ ＇ β ⊒ ＇ α →
+  β ≡ α
+```
+
+Equivalently, prove that a tag-or-id-mode narrowing from one type variable to
+another must be an identity variable narrowing.  Then `p`'s source `＇ β` from
+the left `seal A β` composition rewrites to `＇ α`, and the outer exact
+right-seal premise contradicts `right-seal-compose-source-var⊥`.
+
 ### Counterexample search
 
 The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -776,8 +776,76 @@ seal coercion.  Agda rejects this shape for the DGG premises: `ν⊒` requires i
 index premise to be cast-like, and `∶ᶜ` is `tag-or-idᵈ`, so literal seals are
 excluded by `tag-or-id-seal-conflict`.
 
-No exact counterexample to the DGG redex was found.  The checked
-factorization counterexample only refutes a tempting zero-step proof strategy:
-it does not refute the dynamic branch, because DGG may still reduce the source
-side through the problematic left cast before relating it to the unsealed
-target.
+Before the source-left tag candidate below, no exact counterexample to the DGG
+redex had been found.  The checked factorization counterexample only refutes a
+tempting zero-step proof strategy: it does not refute the dynamic branch,
+because DGG may still reduce the source side through the problematic left cast
+before relating it to the unsealed target.
+
+### Attempt 10. Broad exact source-left tag candidate
+
+The broad algebraic witness
+
+```agda
+id ★ ⨾ⁿ seal ★ 0 ≈ (＇ 0) ？
+```
+
+is term-realizable.  `proof.ExactSealUnsealCounterexample` first checks the
+benign direct premise
+
+```agda
+c★ ⊒ c★ ⟨ seal ★ 0 ⟩ ⟨ unseal 0 ★ ⟩ ∶ id ★
+```
+
+where `c★ = ($ 0) ⟨ (‵ `ℕ) ! ⟩`.  This is not a counterexample, because
+after the right `seal-unseal` step the source and target are both `c★`, and
+the existing two-sided cast example gives `c★ ⊒ c★ ∶ id ★`.
+
+A more dangerous exact premise adds a real source-side tag:
+
+```agda
+c★ ⟨ seal ★ 0 ⟩ ⟨ (＇ 0) ! ⟩
+  ⊒ c★ ⟨ seal ★ 0 ⟩ ⟨ unseal 0 ★ ⟩ ∶ id ★
+```
+
+This also type-checks in `proof.ExactSealUnsealCounterexample`.  It uses
+`c★ ⟨ seal ★ 0 ⟩ ⊒ c★ ⟨ seal ★ 0 ⟩ ∶ id (＇ 0)`, then a source-left
+`cast+⊒` with `t = (＇ 0) ？`, and finally the broad right-seal composition
+above.  The source is a value, so any counterexample proof reduces to the
+post-step impossibility
+
+```agda
+∀ Δ p →
+  Δ ∣ (0 ꞉ id ★) ∷ [] ∣ []
+    ⊢ c★ ⟨ seal ★ 0 ⟩ ⟨ (＇ 0) ! ⟩ ⊒ c★ ∶ p →
+  ⊥ .
+```
+
+The inversion discharges the outer right-cast and source `cast-⊒` tag cases
+using term-cast injectivity plus
+`compose-left-tag-factor⊥`/`compose-right-tag-factor⊥`.  The source-left
+`cast+⊒` branch peels the tag and then proves
+`c★ ⟨ seal ★ 0 ⟩ ⊒ c★` impossible by a second inversion: the only productive
+route would force either a tag factor in the wrong composition position or a
+seal/untag endpoint contradiction.
+
+The final checked theorem is
+
+```agda
+exact-seal-unseal-dgg-result⊥ :
+  ExactSealUnsealDGGResult → ⊥
+```
+
+where `ExactSealUnsealDGGResult` is the DGG conclusion instantiated with the
+checked premise
+
+```agda
+c★ ⟨ seal ★ 0 ⟩ ⟨ (＇ 0) ! ⟩
+  ⊒ c★ ⟨ seal ★ 0 ⟩ ⟨ unseal 0 ★ ⟩ ∶ id ★
+```
+
+and the target step `seal-unseal`.  The conclusion is refuted after
+`value-multistep-refl` forces the source reduction to be zero steps.  The
+post-step contradiction is generalized over the existentially chosen `Δ′`;
+otherwise the DGG result could hide behind an arbitrary context choice even
+though the source and target stores are both empty after the step.

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -162,3 +162,184 @@ right-seal-inversion₁-counterexample :
 So `right-seal-inversion₁` is false as currently stated.  Any replacement
 lemma must exclude left-cast wrappers like this example, or return a weaker
 conclusion that permits a compensating left seal.
+
+## Exact DGG `seal-unseal` case search
+
+The DGG redex case is narrower than `right-seal-inversion₁`.  The local goal is
+the branch
+
+```agda
+dynamicGradualGuarantee okM
+    (⊒cast+ {s = seal B α} qᶜ q⨟seal≈r M⊒Vseal)
+    (pure-step (seal-unseal vV))
+```
+
+where `M⊒Vseal` relates `M` to `V ⟨ seal A α ⟩` and the outer
+`⊒cast+` supplies the side condition
+
+```agda
+Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F .
+```
+
+The paper proof uses zero source steps and contracts the relation itself:
+
+```agda
+σ ⊢ M ⊒ V ⟨ α♯ ⟩ ⟨ α♭ ⟩ : q
+=/⊢→
+σ ⊢ M ⊒ V : q .
+```
+
+### Attempt 1. Reuse `right-seal-inversion₂`
+
+The current mechanized lemma `right-seal-inversion₂` is intentionally weak.  It
+only re-exposes the premise relation at endpoint-normalized composition:
+
+```agda
+∃[ u ]
+  (Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ u ∶ src q ⊒ ＇ α) ×
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ u
+```
+
+This is enough to document that the right redex was introduced by the exact
+outer cast, but it does not strip the remaining right seal.  Returning
+`M⊒Vseal` in DGG therefore gives a relation to the pre-step term, not the
+right-hand reduct `V`.
+
+### Attempt 2. Prove a `q`-specific zero-step contraction
+
+The strongest DGG-shaped helper is:
+
+```agda
+right-seal-strip-zero :
+  ∀ {Δ σ M V q r A B C D E F α} →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ∶ q
+```
+
+The direct `⊒cast-` branch exposes a premise
+`M ⊒ V ∶ q₀`.  To return exactly `q`, the proof must cancel two right-seal
+compositions:
+
+```agda
+q  ⨾ⁿ seal B α ≈ r
+q₀ ⨾ⁿ seal A α ≈ r
+```
+
+and then reindex the term-narrowing derivation from `q₀` to `q`.  No such
+right-seal cancellation lemma currently exists.  Even after cancellation, the
+needed reindexing resembles the unfinished `termNarrowing-resp-≈` hole in
+`proof.LeftSealNarrowingInversion`.
+
+Left-cast cases need more than cancellation.  For example, a branch shaped by
+`cast+⊒` requires a factorization lemma turning
+
+```agda
+q ⨾ⁿ seal B α ≈ p
+r ≈ t ⨾ⁿ p
+```
+
+into some `u` such that
+
+```agda
+u ⨾ⁿ seal B α ≈ r
+u ≈ t ⨾ⁿ q .
+```
+
+The current composition API packages `_⨟ⁿ_` and endpoint equivalence, but it
+does not provide this associativity/factorization principle.
+
+### Attempt 3. Weaken the final index existentially
+
+DGG only existentially quantifies the final index, so the branch could use the
+weaker helper:
+
+```agda
+right-seal-strip-some :
+  ∀ {Δ σ M V q r A B C D E F α} →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ p ] Δ ∣ σ ∣ [] ⊢ M ⊒ V ∶ p
+```
+
+This removes the `q₀ ≡ q` cancellation obligation in the direct `⊒cast-`
+branch, but it still gets stuck before the proof reaches that branch.  Agda's
+coverage checker exposes `extend`:
+
+```text
+N′ [ α ]ᵀ ≟ V ⟨ seal A α₁ ⟩
+p [ α ]ᶜ ≟ r
+```
+
+An equality-indexed auxiliary can expose `extend`, and the output can move from
+the source-only store to the ordinary store with `extendReplaceRel-term`.  The
+corresponding `split` branch still needs the same source-opening transport that
+is called out by `catchup-split-catchup`: the proof must change the source term
+from `N [ α ]ᵀ` to `N [ αᵢ ]ᵀ` while preserving or reconstructing the stripped
+right term and index.
+
+### Attempt 4. Catch up the source first
+
+Another route catches `M` up to a source value using
+
+```agda
+catchup-lemma okM (vV ⟨ seal A α ⟩) M⊒Vseal .
+```
+
+This produces a value `W` with
+
+```agda
+W ⊒ applyTerms χs (V ⟨ seal A α ⟩)
+  ∶ applyCoercions χs r .
+```
+
+However, this route still needs a value-level version of the same right-seal
+stripping/contraction fact to obtain a relation to `applyTerms χs V`.  The
+existing left widening/narrowing lemmas move casts on the source side; they do
+not remove this remaining right seal.
+
+### Counterexample search
+
+The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG
+outer-cast premise.  In that example the sealed relation has index
+`id (＇ 0)`, but the DGG branch would require some `q` with
+
+```agda
+q ⨾ⁿ seal (‵ `ℕ) 0 ≈ id (＇ 0) .
+```
+
+`proof.RightSealInversionCounterexample` already proves this impossible in
+`old-counterexample-revised-premise⊥`.
+
+The `right-seal-inversion₂` variable counterexample is also not an exact DGG
+counterexample: its right-side core is a variable rather than a `Value`, the
+term context is nonempty, and the top-level derivation is `ν⊒`, not the exact
+outer `⊒cast+` redex used by DGG.
+
+The closed exact candidates that do type check are harmless.  The basic
+constant case
+
+```agda
+$ 0 ⊒ (($ 0) ⟨ seal (‵ `ℕ) 0 ⟩) ⟨ unseal 0 (‵ `ℕ) ⟩
+```
+
+has the expected post-step relation `$ 0 ⊒ $ 0`.  The closed `ν⊒` candidate
+with an admissible identity annotation also has a post-step relation:
+
+```agda
+ν ★ ($ 0) (⇑ᶜ (id (‵ `ℕ))) ⊒ $ 0 .
+```
+
+The tempting `ν⊒` counterexample would annotate the source `ν` with a shifted
+seal coercion.  Agda rejects this shape for the DGG premises: `ν⊒` requires its
+index premise to be cast-like, and `∶ᶜ` is `tag-or-idᵈ`, so literal seals are
+excluded by `tag-or-id-seal-conflict`.
+
+No exact counterexample was found.  The next productive proof step appears to
+be an algebraic package for right-seal composition cancellation/factorization,
+paired with a term-narrowing reindexing lemma and the split-specific
+source-opening transport already identified by `catchup-split-catchup`.

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -637,6 +637,48 @@ This is the useful algebraic boundary for the old closed
 `id (＇ α)`, and an exact DGG outer premise would force precisely the impossible
 source endpoint `＇ α ⊒ ＇ α`.
 
+### Attempt 9. Use the source-endpoint contradiction on source-left casts
+
+The checked lemma `right-seal-compose-source-var⊥` is too narrow to close all
+of the inert source-left branches by itself.  It applies when the exact outer
+right-seal premise has endpoints
+
+```agda
+＇ α ⊒ ＇ α
+```
+
+That is exactly why the old closed `right-seal-inversion₁` counterexample cannot
+be wrapped in the DGG `⊒cast+ {s = seal B α}` branch.  It does not by itself
+cover source-left casts whose post-cast index has source endpoint `★`, a base
+type, a function type, or a different store variable.
+
+So the next helper should be DGG-shaped rather than a blanket contradiction:
+first expose the right-seal exactness, then handle the source-left branches with
+the value-level left widening/narrowing lemmas that already appear in
+`catchup-lemma`.  A useful target statement is:
+
+```agda
+right-seal-unseal-catchup :
+  RuntimeOK M →
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
+    (M —↠[ χs ] N) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ V ∶ p′
+```
+
+The direct `⊒cast-` branch of this helper should strip the target seal with
+zero source steps.  The `⊒cast+` branch whose hidden target cast is `unseal`
+is contradictory by `right-seal-inversion₂-cast-unseal⊥`.  The remaining
+source-left `cast+⊒` and `cast-⊒` branches are the places where a source value
+may need to reduce through the inert cast before the post-step relation to `V`
+can be built.
+
 ### Counterexample search
 
 The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -593,7 +593,7 @@ widening-cross-ground-source-seal-var⊥
 
 The expected reusable corollary is not just a raw syntax fact.  It must combine
 the endpoint stores from `endpointsⁿ`, `srcStoreⁿ-⊒ˢ`/`tgtStoreⁿ-⊒ˢ`, and mode
-conflicts such as `tag-or-id-seal-conflict`.  An over-broad first statement
+conflicts such as `tag-or-id-seal-conflict`.  The over-broad first statement
 
 ```agda
 right-seal-compose-castlike-result⊥ :
@@ -602,10 +602,40 @@ right-seal-compose-castlike-result⊥ :
   ⊥
 ```
 
-was accepted as a scratch goal but not proved directly; its proof needs to
-expose the `endpointsⁿ` stores and compare the cast-like typing of `p` with
-the right-seal composite typing in the correct endpoint store.  This is the
-next concrete algebraic lemma to mechanize before returning to the DGG branch.
+is false.  The checked module `proof.RightSealBroadCounterexample` gives the
+witness
+
+```agda
+p = (＇ 0) ？
+q = id ★
+B = ★
+α = 0
+```
+
+and proves
+
+```agda
+right-seal-compose-to-untag :
+  1 ∣ (0 ꞉ id ★) ∷ []
+    ⊢ id ★ ⨾ⁿ seal ★ 0 ≈ (＇ 0) ？ ∶ src (id ★) ⊒ ＇ 0
+```
+
+The reason is that `∶ᶜ` uses `tag-or-idᵈ`, while the computed right-seal
+composite is typed under `seal-or-idᵈ`; `endpointsⁿ` relates the endpoints
+without requiring the same mode witness on both sides.
+
+The same checked module proves the narrower source-endpoint contradiction:
+
+```agda
+right-seal-compose-source-var⊥ :
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ ＇ α ⊒ ＇ α →
+  ⊥
+```
+
+This is the useful algebraic boundary for the old closed
+`right-seal-inversion₁` counterexample: that counterexample's stripped index is
+`id (＇ α)`, and an exact DGG outer premise would force precisely the impossible
+source endpoint `＇ α ⊒ ＇ α`.
 
 ### Counterexample search
 

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -691,9 +691,9 @@ the exact outer premise has result `p`:
 q⨾seal≈p : Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ src q ⊒ ＇ α
 ```
 
-The branch would close by `right-seal-compose-source-var⊥` if the endpoints can
-be rewritten to `＇ α ⊒ ＇ α`.  The missing algebraic fact is a cast-like
-variable-to-variable endpoint inversion:
+The branch closes by `right-seal-compose-source-var⊥` once the endpoints are
+rewritten to `＇ α ⊒ ＇ α`.  The algebraic fact needed for this rewrite is a
+cast-like variable-to-variable endpoint inversion:
 
 ```agda
 castlike-var-var-endpoints :
@@ -701,10 +701,20 @@ castlike-var-var-endpoints :
   β ≡ α
 ```
 
-Equivalently, prove that a tag-or-id-mode narrowing from one type variable to
-another must be an identity variable narrowing.  Then `p`'s source `＇ β` from
-the left `seal A β` composition rewrites to `＇ α`, and the outer exact
-right-seal premise contradicts `right-seal-compose-source-var⊥`.
+This is now proved in `proof.NarrowWidenProperties` using
+`narrowing-var≢-to-var-tag⊥`.  The branch packaging is also checked:
+
+```agda
+right-seal-compose-left-seal-factor⊥ :
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ p ∶ src q ⊒ ＇ α →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ r ≈ seal A β ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+```
+
+The proof transports the cast-like typing of `p` to endpoints
+`＇ β ⊒ ＇ α`, applies `castlike-var-var-endpoints`, and then transports the
+outer right-seal composition to the impossible endpoint `＇ α ⊒ ＇ α`.
 
 ### Counterexample search
 

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -716,6 +716,29 @@ The proof transports the cast-like typing of `p` to endpoints
 `＇ β ⊒ ＇ α`, applies `castlike-var-var-endpoints`, and then transports the
 outer right-seal composition to the impossible endpoint `＇ α ⊒ ＇ α`.
 
+Three other source-left inert shapes are impossible before using the outer
+right-seal premise, because `compose-rightⁿ` requires its left factor to be a
+narrowing:
+
+```agda
+compose-right-unseal-factor⊥ :
+  Δ ∣ σ ⊢ r ≈ unseal β A ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+
+compose-right-inst-factor⊥ :
+  Δ ∣ σ ⊢ r ≈ inst B c ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+
+compose-right-tag-factor⊥ :
+  Δ ∣ σ ⊢ r ≈ G ! ⨾ⁿ p ∶ E ⊒ F →
+  ⊥
+```
+
+These remove the `cast+⊒` branches with `t = unseal β A` and `t = inst B c`,
+and the `cast-⊒` branch with `t = G !`.  The remaining source-left branches
+are therefore the dynamically meaningful function, universal, ground untag,
+and generic `gen` cases, plus any endpoint-specific refinements of those.
+
 ### Counterexample search
 
 The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG

--- a/GTSF/proof/RightSealInversionNotes.md
+++ b/GTSF/proof/RightSealInversionNotes.md
@@ -353,6 +353,88 @@ from the outer composition in `(α ꞉ q) ∷ σ` to a composition premise in
 `(α ꞉= A ⊒) ∷ σ`.  Reusing the existing transport directly therefore repeats
 the wrong-direction mistake.
 
+### Attempt 6. Existential strip goals after exposing Agda holes
+
+The equality-indexed scratch theorem was checked far enough to expose the exact
+remaining goals for
+
+```agda
+right-seal-strip-some :
+  Value V →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
+  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
+  ∃[ p ] Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ p
+```
+
+The easy cases are:
+
+- direct `⊒cast-`: return the premise relation to `V`;
+- right `⊒cast+` with `unseal`: impossible by
+  `right-seal-inversion₂-cast-unseal⊥`;
+- right `⊒cast+` with tag/untag: syntactically impossible after exposing
+  small dual-shape contradictions for `-(G !)` and `-(G ？)` versus `seal`.
+
+The remaining Agda goals are exactly the structural and source-left wrappers:
+
+```agda
+∃[ p ] Δ ∣ (α ꞉ q) ∷ σ ∣ γ ⊢ M ⊒ V ∶ p
+∃[ p ] Δ ∣ (α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ ∣ γ
+  ⊢ N [ αᵢ ]ᵀ ⊒ V ∶ p
+∃[ p ] Δ ∣ σ ∣ γ ⊢ ν ★ N (⇑ᶜ r) ⊒ V ∶ p
+∃[ p ] Δ ∣ σ ∣ γ ⊢ M ⟨ - t ⟩ ⊒ V ∶ p
+∃[ p ] Δ ∣ σ ∣ γ ⊢ M ⟨ t ⟩ ⊒ V ∶ p
+```
+
+This rules out a purely local fix to the DGG hole.  The source-left goals need
+the factorization that cambridge25 calls out in the erratum:
+
+```agda
+q ⨾ⁿ seal B α ≈ r
+r ≈ t ⨾ⁿ p
+```
+
+must decompose so the induction can strip the premise and rebuild `cast+⊒`.
+Similarly, the `cast-⊒` branch needs a decomposition of
+
+```agda
+q ⨾ⁿ seal B α ≈ p
+r ≈ t ⨾ⁿ p .
+```
+
+No existing lemma proves either factorization.  The raw coercion lemma
+`⨟-sealʳ` suggests the intended trailing-seal algebra, but the typed
+`_⨟ⁿ_` composition only exposes the computed composite inside
+`compose-leftⁿ`/`compose-rightⁿ`.
+
+The most direct factorization for the `cast+⊒` source-left case is false.  The
+module `proof.RightSealFactorCounterexample` proves
+
+```agda
+case1-factorization-is-false :
+  Case1Factorization →
+  ⊥
+```
+
+using the exact premises
+
+```agda
+id (‵ `ℕ) ⨾ⁿ seal (‵ `ℕ) 0 ≈ seal (‵ `ℕ) 0
+seal (‵ `ℕ) 0 ≈ seal (‵ `ℕ) 0 ⨾ⁿ id (＇ 0)
+```
+
+and showing that no `q′` can satisfy
+
+```agda
+q′ ⨾ⁿ seal (‵ `ℕ) 0 ≈ id (＇ 0) .
+```
+
+So the DGG proof cannot proceed by simply decomposing every source-left cast
+into a smaller right-seal composite.  The next proof attempt should instead be
+a genuinely dynamic helper that lets source-left casts take their own source
+steps, probably using the existing value-level `left-widening-lemma` and
+`left-narrowing-lemma`, rather than trying to prove a zero-step strip theorem.
+
 ### Counterexample search
 
 The known `right-seal-inversion₁` counterexample does not satisfy the exact DGG
@@ -390,7 +472,8 @@ seal coercion.  Agda rejects this shape for the DGG premises: `ν⊒` requires i
 index premise to be cast-like, and `∶ᶜ` is `tag-or-idᵈ`, so literal seals are
 excluded by `tag-or-id-seal-conflict`.
 
-No exact counterexample was found.  The next productive proof step appears to
-be an algebraic package for right-seal composition cancellation/factorization,
-paired with a term-narrowing reindexing lemma and the split-specific
-source-opening transport already identified by `catchup-split-catchup`.
+No exact counterexample to the DGG redex was found.  The checked
+factorization counterexample only refutes a tempting zero-step proof strategy:
+it does not refute the dynamic branch, because DGG may still reduce the source
+side through the problematic left cast before relating it to the unsealed
+target.


### PR DESCRIPTION
## Summary
- adds a checked exact counterexample for the GTSF DGG right-hand seal-unseal case
- shows the source premise, source RuntimeOK evidence, target seal-unseal step, and refutes the instantiated DGG conclusion
- adds dynamic-gradual-guarantee-statement⊥, showing any proof of the current full DGG statement would imply ⊥ on this instance
- records the proof-search path and failed proof strategies in RightSealInversionNotes

## Result
The requested case is not provable as stated.  The module proof.ExactSealUnsealCounterexample constructs the exact premise and proves exact-seal-unseal-dgg-result⊥: the DGG conclusion for that premise and target step is impossible.  The stronger dynamic-gradual-guarantee-statement⊥ packages this as a refutation of the current theorem statement itself.

## Checks
- cd GTSF && agda -v0 proof/ExactSealUnsealCounterexample.agda
- cd GTSF && agda -v0 All.agda
- git diff --check
- git diff --cached --check