### PR TITLE
[codex] Prove GTSF DGG application blame cases

### DIFF
--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -245,7 +245,12 @@ dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step blame-·
   ⊒ˢ-nil ,
   ⊒blame qᶜ
 dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (blame-·₂ vV)) =
-  {!!}
+  [] , _ , _ , [] , [] , [] , _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  ⊒blame qᶜ
 dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)
     with dynamicGradualGuarantee (runtime-·₁ okM) L⊒L′ L′→N′
 dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -238,7 +238,12 @@ dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′)
     (pure-step (β-↦ vV vW)) =
   wrap-widening-lemma L⊒L′ M⊒M′
 dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step blame-·₁) =
-  {!!}
+  [] , _ , _ , [] , [] , [] , _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  ⊒blame qᶜ
 dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (blame-·₂ vV)) =
   {!!}
 dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (ξ-·₁ L′→N′ shiftM)

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -1,0 +1,29 @@
+# Dynamic Gradual Guarantee Proof Log
+
+## Application left-blame case
+
+Target:
+
+`dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step blame-·₁)`
+
+Result: proved directly.
+
+Working strategy:
+
+- The right-hand step is `blame · M′ —→ blame`, so the simulated right result is
+  exactly `blame`.
+- No source catch-up is required. Choose zero source steps with `χs = []` and
+  `N = L · M`.
+- Both source and target store changes are empty: `Π = []`, `Π′ = []`, and
+  `π = []` with `⊒ˢ-nil`.
+- The final term narrowing witness is `⊒blame qᶜ`, using the coercion evidence
+  already supplied by the `·⊒·` constructor.
+
+Strategies considered and avoided:
+
+- Catching up the source function `L` to a blame-like term is unnecessary. It
+  would add obligations through `catchup-lemma` even though `⊒blame` already
+  relates the unchanged source application to right-hand `blame`.
+- A counterexample search is not needed for this case after the direct witness:
+  the rule `⊒blame` intentionally permits any left source term at the typed
+  coercion, so the left-blame right reduction has an immediate simulation.

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -1,17 +1,19 @@
 # Dynamic Gradual Guarantee Proof Log
 
-## Application left-blame case
+## Application blame cases
 
-Target:
+Targets:
 
 `dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step blame-·₁)`
 
-Result: proved directly.
+`dynamicGradualGuarantee okM (·⊒· qᶜ L⊒L′ M⊒M′) (pure-step (blame-·₂ vV))`
+
+Result: both proved directly.
 
 Working strategy:
 
-- The right-hand step is `blame · M′ —→ blame`, so the simulated right result is
-  exactly `blame`.
+- In both cases, the right-hand step produces exactly `blame`:
+  `blame · M′ —→ blame` and `V · blame —→ blame`.
 - No source catch-up is required. Choose zero source steps with `χs = []` and
   `N = L · M`.
 - Both source and target store changes are empty: `Π = []`, `Π′ = []`, and
@@ -24,6 +26,9 @@ Strategies considered and avoided:
 - Catching up the source function `L` to a blame-like term is unnecessary. It
   would add obligations through `catchup-lemma` even though `⊒blame` already
   relates the unchanged source application to right-hand `blame`.
+- The `Value` evidence in the right-blame case is only needed by the
+  right-hand reduction rule. The simulation witness does not need to inspect it.
 - A counterexample search is not needed for this case after the direct witness:
   the rule `⊒blame` intentionally permits any left source term at the typed
-  coercion, so the left-blame right reduction has an immediate simulation.
+  coercion, so both blame-producing application reductions have immediate
+  simulations.


### PR DESCRIPTION
## Summary

Proves the two `dynamicGradualGuarantee` application cases where the right-hand reduction produces `blame`:

- `pure-step blame-·₁`
- `pure-step (blame-·₂ vV)`

Both cases use the existing `⊒blame` constructor directly: the source application takes zero steps, both store-change witnesses are empty, and `qᶜ` supplies the final typed coercion evidence.

Also updates the proof log to record the shared strategy and the avoided catch-up/counterexample routes.

## Validation

- `agda -v0 proof/DynamicGradualGuarantee.agda` from `GTSF/`
- `agda -v0 All.agda` from `GTSF/`