### PR TITLE
[codex] Record GTSF DGG ν-step counterexample

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -20,3 +20,4 @@ import TermNarrowing
 import NarrowingExamples
 import NuMetaTheory
 import proof.DynamicGradualGuarantee
+import proof.DynamicGradualGuaranteeCounterexample

--- a/GTSF/proof/DynamicGradualGuaranteeCounterexample.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeCounterexample.agda
@@ -1,0 +1,69 @@
+module proof.DynamicGradualGuaranteeCounterexample where
+
+-- File Charter:
+--   * Documents and mechanizes the counterexample shape for the current
+--     `dynamicGradualGuarantee` statement.
+--   * The obstruction is syntactic: right-hand `ν-step` produces a runtime
+--     bullet target, but `TermNarrowing` has no constructor whose conclusion
+--     can introduce such a target.
+--   * No postulates are introduced here.
+
+open import Data.Empty using (⊥)
+open import Data.Nat using (zero)
+
+open import Coercions
+open import NuTerms
+open import TermNarrowing
+open import Types
+
+data RuntimeBulletTarget : Term → Set where
+  bullet-target : ∀ {V} → RuntimeBulletTarget (V •)
+  cast-target : ∀ {V c} → RuntimeBulletTarget ((V •) ⟨ c ⟩)
+
+runtimeBulletTarget-⇑ᵗᵐ :
+  ∀ {M} →
+  RuntimeBulletTarget M →
+  RuntimeBulletTarget (⇑ᵗᵐ M)
+runtimeBulletTarget-⇑ᵗᵐ bullet-target = bullet-target
+runtimeBulletTarget-⇑ᵗᵐ cast-target = cast-target
+
+no-runtime-bullet-target :
+  ∀ {Δ σ γ M M′ p} →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p →
+  RuntimeBulletTarget M′ →
+  ⊥
+no-runtime-bullet-target (extend qᶜ pαᶜ M⊒N′) target =
+  no-runtime-bullet-target M⊒N′ target
+no-runtime-bullet-target (split qᶜ pαᶜ N⊒N′) target =
+  no-runtime-bullet-target N⊒N′ target
+no-runtime-bullet-target (⊒blame pᶜ) ()
+no-runtime-bullet-target (x⊒x pᶜ x∋p) ()
+no-runtime-bullet-target (ƛ⊒ƛ p↦qᶜ N⊒N′) ()
+no-runtime-bullet-target (·⊒· qᶜ L⊒L′ M⊒M′) ()
+no-runtime-bullet-target (Λ⊒Λ allᶜ vV V⊒V′) ()
+no-runtime-bullet-target (⊒Λ pᶜ N⊒V′) ()
+no-runtime-bullet-target (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) cast-target =
+  no-runtime-bullet-target N⊒V′ cast-target
+no-runtime-bullet-target (α⊒α qᶜ pαᶜ L⊒L′) ()
+no-runtime-bullet-target (⊒α pαᶜ L⊒L′) ()
+no-runtime-bullet-target (ν⊒ν pᶜ qᶜ N⊒N′) ()
+no-runtime-bullet-target (⊒ν pᶜ N⊒N′) ()
+no-runtime-bullet-target (ν⊒ pᶜ N⊒N′) target =
+  no-runtime-bullet-target N⊒N′ (runtimeBulletTarget-⇑ᵗᵐ target)
+no-runtime-bullet-target (κ⊒κ κ) ()
+no-runtime-bullet-target (⊕⊒⊕ M⊒M′ N⊒N′) ()
+no-runtime-bullet-target (⊒cast+ qᶜ q⨟s≈r M⊒M′) cast-target =
+  no-runtime-bullet-target M⊒M′ bullet-target
+no-runtime-bullet-target (⊒cast- qᶜ q⨟s≈r M⊒M′) cast-target =
+  no-runtime-bullet-target M⊒M′ bullet-target
+no-runtime-bullet-target (cast+⊒ pᶜ r≈t⨟p M⊒M′) target =
+  no-runtime-bullet-target M⊒M′ target
+no-runtime-bullet-target (cast-⊒ pᶜ r≈t⨟p M⊒M′) target =
+  no-runtime-bullet-target M⊒M′ target
+
+α⊒α-ν-step-target-impossible :
+  ∀ {Δ σ γ M L′ p} →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ ((⇑ᵗᵐ L′) •) ⟨ id (＇ zero) ⟩ ∶ p →
+  ⊥
+α⊒α-ν-step-target-impossible M⊒ν-target =
+  no-runtime-bullet-target M⊒ν-target cast-target

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -32,3 +32,44 @@ Strategies considered and avoided:
   the rule `⊒blame` intentionally permits any left source term at the typed
   coercion, so both blame-producing application reductions have immediate
   simulations.
+
+## `α⊒α` right `ν-step`
+
+Target:
+
+`dynamicGradualGuarantee okM (α⊒α qᶜ pαᶜ L⊒L′) (ν-step vV noV)`
+
+Result: counterexample obstruction recorded in
+`proof.DynamicGradualGuaranteeCounterexample`.
+
+Working strategy tried:
+
+- Use `catchup-lemma (runtime-ν okM) vV L⊒L′` to catch the source `L` up to a
+  value `N` related to `L′`.
+- Lift the catch-up sequence through the source abbreviation
+  `L • α = ν (＇ α) L (id (＇ zero))`.
+- Take the matching source `ν-step`, producing
+  `((⇑ᵗᵐ N) •) ⟨ ... ⟩`.
+- Compose the store-change prefix as `χs ++ bind ... ∷ []` using the existing
+  multi-step append algebra.
+
+Why it fails:
+
+- The right-hand `ν-step` target is
+  `((⇑ᵗᵐ L′) •) ⟨ id (＇ zero) ⟩`, a runtime-bullet term under a cast.
+- The current `TermNarrowing` grammar has no constructor that can introduce a
+  runtime-bullet target. Cast-target constructors can only wrap an existing
+  target premise, and the only constructor with an arbitrary target (`ν⊒`)
+  recurses to the shifted target, preserving the same obstruction.
+- This is independent of the store-prefix algebra: even if the emitted source
+  and target stores are aligned, the final term-narrowing witness demanded by
+  `dynamicGradualGuarantee` cannot be built.
+
+Mechanized check:
+
+- `RuntimeBulletTarget` classifies target terms of the form `V •` and
+  `(V •) ⟨ c ⟩`.
+- `no-runtime-bullet-target` proves by induction on term narrowing that no
+  derivation can target a `RuntimeBulletTarget`.
+- `α⊒α-ν-step-target-impossible` instantiates that result to the exact target
+  produced by the right-hand `ν-step`.


### PR DESCRIPTION
## Summary

Records a mechanized obstruction for the `α⊒α` / right `ν-step` case of `dynamicGradualGuarantee`.

- Adds `proof.DynamicGradualGuaranteeCounterexample`, proving that current `TermNarrowing` cannot target runtime-bullet terms such as `((⇑ᵗᵐ L′) •) ⟨ id (＇ zero) ⟩`.
- Imports the counterexample module from `GTSF/All.agda`.
- Updates the DGG proof log with the attempted catch-up/source-ν-step strategy and why it fails.

## Why

The requested proof case appears blocked for a syntactic reason rather than missing store algebra: right `ν-step` produces a runtime-bullet target, but the current term-narrowing grammar has no constructor that can introduce such a target. Cast rules only propagate the obstruction through premises, and `ν⊒` shifts the target while preserving the same runtime-bullet shape.

## Validation

- `agda -v0 proof/DynamicGradualGuaranteeCounterexample.agda`
- `agda -v0 All.agda`