### PR TITLE
[codex] Refine GTSF alpha narrowing indices

### DIFF
--- a/GTSF/NarrowingExamples.agda
+++ b/GTSF/NarrowingExamples.agda
@@ -773,7 +773,7 @@ ex3-line329 :
     ⊢ ƛ (` 0) ⊒ (Λ (ƛ (` 0))) •
     ∶ var0-fun
 ex3-line329 =
-  ⊒α {p = var0-fun} {A = ‵ `ℕ} var0-fun-cast
+  ⊒α {p = var0-fun} {A = ‵ `ℕ} refl var0-fun-cast
     (⊒Λ
       {A = ★ ⇒ ★}
       {N = ƛ (` 0)}
@@ -1051,7 +1051,7 @@ ex6-open-ν𝔹 :
     ⊢ ƛ (` 0) ⊒ (Λ (ƛ (` 0))) •
     ∶ var0-fun
 ex6-open-ν𝔹 =
-  ⊒α {p = var0-fun} {A = ‵ `𝔹} var0-fun-cast
+  ⊒α {p = var0-fun} {A = ‵ `𝔹} refl var0-fun-cast
     (⊒Λ
       {A = ★ ⇒ ★}
       {N = ƛ (` 0)}
@@ -1202,7 +1202,7 @@ ex7-line712 : ∀ {ι} →
       ⊒ (⇑ᵗᵐ (Λ (ƛ (` 0)))) •
     ∶ id (＇ 0) ↦ id (＇ 0)
 ex7-line712 {ι = ι} =
-  α⊒α {q = id (‵ ι)}
+  α⊒α {q = id (‵ ι)} refl
     id-base-cast id-var0-fun-cast ex7-line710
 
 ex7-downcast-left-≈ : ∀ {Δ ι} →

--- a/GTSF/TermNarrowing.agda
+++ b/GTSF/TermNarrowing.agda
@@ -14,6 +14,7 @@
 
 module TermNarrowing where
 
+open import Agda.Builtin.Equality using (_≡_)
 open import Data.List using (_∷_; map)
 open import Data.Nat using (zero; suc)
 open import Data.Product using (∃-syntax)
@@ -29,7 +30,7 @@ variable
   Δ : TyCtx
   Σ : Store
   σ : StoreNrw
-  γ : CtxNrw
+  γ γ′ : CtxNrw
   A A′ B B′ C D : Ty
   p q r s t : Coercion
   M M′ N N′ L L′ V V′ : Term
@@ -108,18 +109,20 @@ data _∣_∣_⊢_⊒_∶_
     → Δ ∣ σ ∣ γ ⊢ N ⊒ V′ ⟨ gen A s ⟩ ∶ gen A p
 
   α⊒α : ∀ {L L′ p q A B C D}
+    → γ′ ≡ ⇑ᵍ γ
     → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ B
     → suc Δ ∣ srcStoreⁿ ((zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ) ⊢ p ∶ᶜ C ⊒ D
     → Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ `∀ p
       ------------------------------------------------
-    → suc Δ ∣ (zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+    → suc Δ ∣ (zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ ∣ γ′
         ⊢ (⇑ᵗᵐ L) • ⊒ (⇑ᵗᵐ L′) • ∶ p
 
   ⊒α : ∀ {L L′ p A B C D}
+    → γ′ ≡ ⇑ᵍ γ
     → suc Δ ∣ srcStoreⁿ ((zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ) ⊢ p ∶ᶜ C ⊒ D
     → Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ gen B p
       -----------------------------------------------
-    → suc Δ ∣ (zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+    → suc Δ ∣ (zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ ∣ γ′
         ⊢ ⇑ᵗᵐ L ⊒ (⇑ᵗᵐ L′) • ∶ p
 
   ν⊒ν : ∀ {A A′ B B′ N N′ p q}

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -1013,8 +1013,8 @@ extendReplaceRel-term (replace-here qᶜ) (⊒Λ pᶜ N⊒V′) =
   extend-replace-here-current qᶜ pᶜ (⊒Λ pᶜ N⊒V′)
 extendReplaceRel-term (replace-here qᶜ) (⊒⟨ν⟩ pᶜ i N⊒V′s) =
   extend-replace-here-current qᶜ pᶜ (⊒⟨ν⟩ pᶜ i N⊒V′s)
-extendReplaceRel-term (replace-here qᶜ) (⊒α pαᶜ L⊒L′) =
-  extend-replace-here-current qᶜ pαᶜ (⊒α pαᶜ L⊒L′)
+extendReplaceRel-term (replace-here qᶜ) (⊒α γ′≡ pαᶜ L⊒L′) =
+  extend-replace-here-current qᶜ pαᶜ (⊒α γ′≡ pαᶜ L⊒L′)
 extendReplaceRel-term (replace-here qᶜ) (ν⊒ν pᶜ q₀ᶜ N⊒N′) =
   extend-replace-here-current qᶜ pᶜ (ν⊒ν pᶜ q₀ᶜ N⊒N′)
 extendReplaceRel-term (replace-here qᶜ) (⊒ν pᶜ N⊒N′) =

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -33,7 +33,7 @@ open import proof.RightSealInversion2 using
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowing)
 open import proof.NuPreservation using
-  (runtime-·₁; runtime-⟨⟩; runtime-ν; runtime-⊕₁)
+  (runtime-·₁; runtime-•; runtime-⟨⟩; runtime-ν; runtime-⊕₁)
 
 runtime-·₂-any :
   ∀ {L M} →
@@ -151,4 +151,48 @@ dynamicGradualGuarantee :
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
     Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ ∶ p′
 
+dynamicGradualGuarantee okM
+    (α⊒α {L′ = blame} γ′≡ qᶜ pαᶜ L⊒L′)
+    (pure-step blame-•) =
+  [] , _ , _ , [] , [] , [] , _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  ⊒blame pαᶜ
+dynamicGradualGuarantee okM
+    (α⊒α {L′ = Λ V′} γ′≡ qᶜ pαᶜ L⊒L′)
+    (pure-step (β-Λ• vV′)) =
+  {!!}
+dynamicGradualGuarantee okM
+    (α⊒α {L′ = V′ ⟨ `∀ c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
+    (pure-step (β-∀• vV′)) =
+  {!!}
+dynamicGradualGuarantee okM
+    (α⊒α {L′ = V′ ⟨ gen A c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
+    (pure-step (β-gen• vV′)) =
+  {!!}
+dynamicGradualGuarantee okM
+    (α⊒α γ′≡ qᶜ pαᶜ L⊒L′) red = {!!}
+dynamicGradualGuarantee okM
+    (⊒α {L′ = blame} γ′≡ pαᶜ L⊒L′) (pure-step blame-•) =
+  [] , _ , _ , [] , [] , [] , _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  ⊒ˢ-nil ,
+  ⊒blame pαᶜ
+dynamicGradualGuarantee okM
+    (⊒α {L′ = Λ V′} γ′≡ pαᶜ L⊒L′)
+    (pure-step (β-Λ• vV′)) =
+  {!!}
+dynamicGradualGuarantee okM
+    (⊒α {L′ = V′ ⟨ `∀ c ⟩} γ′≡ pαᶜ L⊒L′)
+    (pure-step (β-∀• vV′)) =
+  {!!}
+dynamicGradualGuarantee okM
+    (⊒α {L′ = V′ ⟨ gen A c ⟩} γ′≡ pαᶜ L⊒L′)
+    (pure-step (β-gen• vV′)) =
+  {!!}
+dynamicGradualGuarantee okM (⊒α γ′≡ pαᶜ L⊒L′) red = {!!}
 dynamicGradualGuarantee okM M⊒M′ M′→N′ = {!!}

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -37,25 +37,57 @@ Strategies considered and avoided:
 
 Discovery:
 
-- The term-narrowing rules `α⊒α` and `⊒α` still used the older named-opening
-  presentation `L • α`, encoded as a `ν` term.
-- The typing rule for runtime type application now uses the actual unary
-  runtime bullet `M •`, so the narrowing conclusions must introduce that form
-  directly under a freshly bound type variable.
+- The attempted `α⊒α`/right-`ν-step` counterexample relied on the old
+  term-narrowing rules, where type application was encoded as a named opening
+  `L • α = ν (＇ α) L (id (＇ zero))`.
+- After the typing rule for `⊢•` changed, the narrowing rules also need to
+  introduce the runtime bullet directly:
+  `(⇑ᵗᵐ L) • ⊒ (⇑ᵗᵐ L′) •`.
+- With that correction, the old `RuntimeBulletTarget` counterexample is false:
+  `α⊒α` and `⊒α` are precisely the constructors that introduce runtime-bullet
+  targets.
 
 Implemented adjustment:
 
 - Removed the local binary `_•_` abbreviation from `TermNarrowing`.
 - Updated `α⊒α` to conclude in `suc Δ` under
-  `(zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ` and `⇑ᵍ γ`, with result
-  `(⇑ᵗᵐ L) • ⊒ (⇑ᵗᵐ L′) • ∶ p`.
+  `(zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ`, with coercion index `p` directly.
 - Updated `⊒α` similarly under `(zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ`.
+- Kept the shifted term-variable context out of the constructor result index:
+  both rules conclude at an explicit `γ′` and carry `γ′ ≡ ⇑ᵍ γ` as an
+  argument.  Directly indexing the result by `⇑ᵍ γ` made Agda unable to split
+  closed DGG goals because it had to solve `⇑ᵍ γ ≟ []`.
 
 Proof obligations exposed:
 
-- Generic catch-up replacement transport cannot treat a shifted tail as an
-  arbitrary store tail; replacing inside it must preserve the `⇑ˢ σ` shape.
-- Parallel term substitution has the analogous shifted-context obligation for
-  these two rules.
-- The DGG skeleton now needs runtime-bullet reduction cases rather than the old
-  `ν-step` cases for `α⊒α` and `⊒α`.
+- Generic catch-up replacement transport is now too broad: replacing an
+  arbitrary entry inside a shifted tail can destroy the invariant that the tail
+  is `⇑ˢ σ`.
+- Parallel term substitution has the same shifted-context issue for the two
+  corrected α rules.
+- The DGG skeleton now needs the real runtime-bullet reduction cases instead
+  of the old `ν-step` cases.
+
+## Runtime-bullet DGG cases
+
+Working facts:
+
+- `RuntimeOK ((⇑ᵗᵐ L) •)` does not invert by direct pattern matching because
+  Agda cannot infer through `⇑ᵗᵐ`.  The usable inversion first generalizes over
+  the whole term and an equality to `(⇑ᵗᵐ L) •`, then uses `•` injectivity and
+  `renameᵗᵐ-pred-suc`.
+- The helper facts are now in `proof.NuPreservation`:
+  `runtime-•-value`, `runtime-•-No•`, and `runtime-•`.
+- The `blame-•` cases for both corrected α rules are immediate: take zero
+  source steps and rebuild the final relation with `⊒blame pαᶜ`.
+
+Remaining β cases:
+
+- `β-Λ•`, `β-∀•`, and `β-gen•` are now explicit DGG branches for both
+  `α⊒α` and `⊒α`.
+- These are not catch-up-under-bullet problems.  There is no contextual
+  reduction under `_•`; the source must already be a runtime-bullet value by
+  `runtime-•-value`.
+- The next missing lemma should invert the value-shaped premise relation,
+  e.g. from `Value L` and `L ⊒ Λ V′ ∶ `∀ p`, recover the source shape needed
+  for the matching bullet step and the post-step term narrowing relation.

--- a/GTSF/proof/LeftSealNarrowingInversion.agda
+++ b/GTSF/proof/LeftSealNarrowingInversion.agda
@@ -168,10 +168,10 @@ termNarrowing-gen-open-id-var-aux⊥ refl
     (⊒⟨ν⟩ pᶜ sᵢ N⊒V′) open-id =
   gen-open-id-var⊥ pᶜ open-id
 termNarrowing-gen-open-id-var-aux⊥ c≡gen
-    (α⊒α qᶜ pαᶜ L⊒L′) open-id =
+    (α⊒α γ′≡ qᶜ pαᶜ L⊒L′) open-id =
   castLike-gen-open-id-var⊥ c≡gen pαᶜ open-id
 termNarrowing-gen-open-id-var-aux⊥ c≡gen
-    (⊒α pαᶜ L⊒L′) open-id =
+    (⊒α γ′≡ pαᶜ L⊒L′) open-id =
   castLike-gen-open-id-var⊥ c≡gen pαᶜ open-id
 termNarrowing-gen-open-id-var-aux⊥ refl
     (ν⊒ν pᶜ qᶜ N⊒N′) open-id =
@@ -259,9 +259,9 @@ leftSealNarrowingInversion-aux eq idx-eq vV
 -- Type-application/ν-opening cases: `⊒α` is impossible by the gen/open
 -- endpoint-shifting lemma above; `⊒ν` still has the substitution issue.
 leftSealNarrowingInversion-aux () idx-eq vV
-    (α⊒α qᶜ pαᶜ L⊒L′)
+    (α⊒α γ′≡ qᶜ pαᶜ L⊒L′)
 leftSealNarrowingInversion-aux eq idx-eq vV
-    (⊒α pαᶜ L⊒L′) = {!!}
+    (⊒α γ′≡ pαᶜ L⊒L′) = {!!}
 leftSealNarrowingInversion-aux eq refl vV
     (⊒ν {A = A} (cast-id hα ok , cross (id-＇ α)) N⊒N′)
     with leftSealNarrowingInversion-aux

--- a/GTSF/proof/NuPreservation.agda
+++ b/GTSF/proof/NuPreservation.agda
@@ -414,6 +414,65 @@ value-runtime-No• vV (ok-no noV) = noV
 value-runtime-No• (vV ⟨ i ⟩) (ok-⟨⟩ okV) =
   no•-⟨⟩ (value-runtime-No• vV okV)
 
+•-injective :
+  ∀ {M N} →
+  M • ≡ N • →
+  M ≡ N
+•-injective refl = refl
+
+no•-bullet-impossible :
+  ∀ {M} →
+  No• (M •) →
+  ⊥
+no•-bullet-impossible ()
+
+⇑ᵗᵐ-injective :
+  ∀ {M N} →
+  ⇑ᵗᵐ M ≡ ⇑ᵗᵐ N →
+  M ≡ N
+⇑ᵗᵐ-injective {M = M} {N = N} eq =
+  trans (sym (renameᵗᵐ-pred-suc M))
+    (trans (cong (renameᵗᵐ predᵗ) eq)
+      (renameᵗᵐ-pred-suc N))
+
+runtime-•-value :
+  ∀ {M L} →
+  RuntimeOK M →
+  M ≡ (⇑ᵗᵐ L) • →
+  Value L
+runtime-•-value (ok-no noM) refl =
+  ⊥-elim (no•-bullet-impossible noM)
+runtime-•-value (ok-• {V = V} vV noV) eq =
+  subst Value (⇑ᵗᵐ-injective (•-injective eq)) vV
+runtime-•-value (ok-·₁ okL noM) ()
+runtime-•-value (ok-·₂ vV noV okM) ()
+runtime-•-value (ok-ν okL) ()
+runtime-•-value (ok-⊕₁ okL noM) ()
+runtime-•-value (ok-⊕₂ vL noL okM) ()
+runtime-•-value (ok-⟨⟩ okM) ()
+
+runtime-•-No• :
+  ∀ {M L} →
+  RuntimeOK M →
+  M ≡ (⇑ᵗᵐ L) • →
+  No• L
+runtime-•-No• (ok-no noM) refl =
+  ⊥-elim (no•-bullet-impossible noM)
+runtime-•-No• (ok-• {V = V} vV noV) eq =
+  subst No• (⇑ᵗᵐ-injective (•-injective eq)) noV
+runtime-•-No• (ok-·₁ okL noM) ()
+runtime-•-No• (ok-·₂ vV noV okM) ()
+runtime-•-No• (ok-ν okL) ()
+runtime-•-No• (ok-⊕₁ okL noM) ()
+runtime-•-No• (ok-⊕₂ vL noL okM) ()
+runtime-•-No• (ok-⟨⟩ okM) ()
+
+runtime-• :
+  ∀ {L} →
+  RuntimeOK ((⇑ᵗᵐ L) •) →
+  RuntimeOK L
+runtime-• okM = ok-no (runtime-•-No• okM refl)
+
 pure-runtime-preservation :
   ∀ {Δ Σ M N A} →
   StoreWf Δ Σ →

--- a/GTSF/proof/TermSubstitutionNarrowing.agda
+++ b/GTSF/proof/TermSubstitutionNarrowing.agda
@@ -196,10 +196,10 @@ term-parallel-substitution-narrowing-framed env frame
       (term-parallel-substitution-narrowing-framed
         env (frame-src⇑ frame) N⊒V′s))
 term-parallel-substitution-narrowing-framed env frame
-    (α⊒α qᶜ pαᶜ L⊒L′) =
+    (α⊒α γ′≡ qᶜ pαᶜ L⊒L′) =
   {!!}
 term-parallel-substitution-narrowing-framed env frame
-    (⊒α pαᶜ L⊒L′) =
+    (⊒α γ′≡ pαᶜ L⊒L′) =
   {!!}
 term-parallel-substitution-narrowing-framed env frame
     (ν⊒ν pᶜ qᶜ N⊒N′) =


### PR DESCRIPTION
## Summary

Follow-up to the runtime-bullet alpha narrowing rule update:

- moves the shifted term-variable context out of the alpha-rule result index by adding an explicit `γ′ ≡ ⇑ᵍ γ` premise
- updates the existing alpha-rule uses/patterns with the new equality argument
- adds runtime-bullet inversion helpers (`runtime-•-value`, `runtime-•-No•`, `runtime-•`) using existing `renameᵗᵐ-pred-suc`
- records and exposes the corrected DGG runtime-bullet alpha cases; the `blame-•` branches are proved, beta branches remain explicit obligations

## Validation

- `agda -v0 TermNarrowing.agda` from `GTSF/`
- `agda -v0 All.agda` from `GTSF/`