### PR TITLE
Add typing premises to GTSF dynamic gradual guarantee

### DIFF
--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -19,6 +19,7 @@ open import Types
 open import Coercions
 open import NuTerms
 open import NuReduction
+open import NuStore using (StoreWf)
 open import NarrowWiden
 open import NarrowWidenComposition using (_∣_⊢_⨾ⁿ_≈_∶_⊒_)
 open import TermNarrowing
@@ -140,8 +141,13 @@ function-application-simulation okM vV′ L⊒L′ eq eqr M⊒V′ = {!!}
 ------------------------------------------------------------------------
 
 dynamicGradualGuarantee :
-  ∀ {Δ σ M M′ N′ p χ′} →
+  ∀ {Δ σ Σ′ M M′ N′ A B p χ′} →
+  StoreWf Δ (srcStoreⁿ σ) →
   RuntimeOK M →
+  Δ ⊢ σ ꞉ srcStoreⁿ σ ⊒ˢ Σ′ →
+  Δ ∣ srcStoreⁿ σ ∣ [] ⊢ M ⦂ A →
+  Δ ∣ Σ′ ∣ [] ⊢ M′ ⦂ B →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
   Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
   M′ —→[ χ′ ] N′ →
   ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
@@ -151,7 +157,7 @@ dynamicGradualGuarantee :
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
     Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ ∶ p′
 
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (α⊒α {L′ = blame} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step blame-•) =
   [] , _ , _ , [] , [] , [] , _ ,
@@ -160,21 +166,21 @@ dynamicGradualGuarantee okM
   refl ,
   ⊒ˢ-nil ,
   ⊒blame pαᶜ
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (α⊒α {L′ = Λ V′} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′)) =
   {!!}
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (α⊒α {L′ = V′ ⟨ `∀ c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′)) =
   {!!}
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (α⊒α {L′ = V′ ⟨ gen A c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′)) =
   {!!}
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (α⊒α γ′≡ qᶜ pαᶜ L⊒L′) red = {!!}
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (⊒α {L′ = blame} γ′≡ pαᶜ L⊒L′) (pure-step blame-•) =
   [] , _ , _ , [] , [] , [] , _ ,
   ↠-refl ,
@@ -182,17 +188,19 @@ dynamicGradualGuarantee okM
   refl ,
   ⊒ˢ-nil ,
   ⊒blame pαᶜ
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (⊒α {L′ = Λ V′} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′)) =
   {!!}
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (⊒α {L′ = V′ ⟨ `∀ c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′)) =
   {!!}
-dynamicGradualGuarantee okM
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
     (⊒α {L′ = V′ ⟨ gen A c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′)) =
   {!!}
-dynamicGradualGuarantee okM (⊒α γ′≡ pαᶜ L⊒L′) red = {!!}
-dynamicGradualGuarantee okM M⊒M′ M′→N′ = {!!}
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
+    (⊒α γ′≡ pαᶜ L⊒L′) red =
+  {!!}
+dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ M⊒M′ M′→N′ = {!!}

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -1,5 +1,27 @@
 # Dynamic Gradual Guarantee Proof Log
 
+## Typed DGG statement
+
+Correction:
+
+- The public `dynamicGradualGuarantee` statement now carries the source store
+  well-formedness, the explicit target store `Σ′`, source and target typing
+  derivations, and the typed coercion premise
+  `Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B`.
+- The store narrowing premise is fixed at
+  `Δ ⊢ σ ꞉ srcStoreⁿ σ ⊒ˢ Σ′`, so the term-narrowing witness and both typing
+  derivations talk about the same source/target stores.
+
+Old right-`ν` counterexample:
+
+- The checked example on `codex/gtsf-dgg-app-left-step` is useful evidence that
+  the earlier untyped skeleton was too weak.
+- It is not a semantic counterexample to typed DGG. Its source term uses
+  `ν ★ 0 idℕ`, but the `ν` typing rule requires the body to have a universal
+  type `∀X. A`; the constant `0` has type `ℕ`.
+- Under the typed statement there is no source typing derivation for that term,
+  so the example is rejected before the dynamic simulation obligation begins.
+
 ## Application blame cases
 
 Targets:


### PR DESCRIPTION
## Summary

Adds explicit typing premises to the GTSF `dynamicGradualGuarantee` skeleton:

- source store well-formedness for `srcStoreⁿ σ`
- explicit target store `Σ′` with `Δ ⊢ σ ꞉ srcStoreⁿ σ ⊒ˢ Σ′`
- source and target term typing derivations
- typed coercion evidence `Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B`

The existing runtime-bullet DGG case skeleton from `main` is preserved and threaded with the new premises.

## Counterexample note

The previous right-`ν` “counterexample” only refutes the old untyped DGG skeleton. It is not a semantic counterexample to typed DGG: the example uses `ν ★ 0 idℕ`, but `0` has type `ℕ`, while the `ν` typing rule requires the body to have a universal type. The proof log now records that the typed statement rejects this example before simulation begins.

## Validation

- `agda -v0 proof/DynamicGradualGuarantee.agda` from `GTSF/`
- `agda -v0 All.agda` from `GTSF/`