### PR TITLE
[codex] Add typed term narrowing index

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -17,6 +17,7 @@ import NuExamplesFresh
 import NuReduction
 import proof.NWTermReduction
 import TermNarrowing
+import proof.TermNarrowingTypingCounterexample
 import NarrowingExamples
 import NuMetaTheory
 import proof.DynamicGradualGuarantee

--- a/GTSF/TermNarrowing.agda
+++ b/GTSF/TermNarrowing.agda
@@ -14,10 +14,10 @@
 
 module TermNarrowing where
 
-open import Agda.Builtin.Equality using (_≡_)
+open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using (_∷_; map)
 open import Data.Nat using (zero; suc)
-open import Data.Product using (∃-syntax)
+open import Data.Product using (_,_; ∃-syntax)
 
 open import Types
 open import Coercions
@@ -40,7 +40,14 @@ variable
 ⇑ᵍ : CtxNrw → CtxNrw
 ⇑ᵍ = map ⇑ᶜ
 
+fun-narrow-codomainᶜ :
+  Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Δ ∣ Σ ⊢ q ∶ᶜ B ⊒ B′
+fun-narrow-codomainᶜ (cast-fun p⊢ q⊢ , cross (p⊑ ↦ q⊒)) =
+  q⊢ , q⊒
+
 infix 4 _∣_∣_⊢_⊒_∶_
+infix 4 _∣_∣_⊢_⊒_∶_⦂_⊒_
 
 data _∣_∣_⊢_⊒_∶_
     : TyCtx → StoreNrw → CtxNrw → Term → Term → Coercion → Set₁ where
@@ -183,3 +190,242 @@ data _∣_∣_⊢_⊒_∶_
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r
       ----------------------------------
     → Δ ∣ σ ∣ γ ⊢ M ⟨ t ⟩ ⊒ M′ ∶ p
+
+------------------------------------------------------------------------
+-- Typed/well-indexed term narrowing
+------------------------------------------------------------------------
+
+data _∣_∣_⊢_⊒_∶_⦂_⊒_
+    : TyCtx → StoreNrw → CtxNrw →
+      Term → Term → Coercion → Ty → Ty → Set₁ where
+
+  extendᵗ : ∀ {M N′ p q A B C D α}
+    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ B ⊒ A
+    → Δ ∣ srcStoreⁿ ((α ꞉ q) ∷ σ) ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D
+    → Δ ∣ (α ꞉= A ⊒) ∷ σ ∣ γ
+        ⊢ M ⊒ N′ [ α ]ᵀ ∶ p [ α ]ᶜ ⦂ C ⊒ D
+      ------------------------------------------------------
+    → Δ ∣ (α ꞉ q) ∷ σ ∣ γ
+        ⊢ M ⊒ N′ [ α ]ᵀ ∶ p [ α ]ᶜ ⦂ C ⊒ D
+
+  splitᵗ : ∀ {N N′ p q A C D α αᵢ}
+    → Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ)
+        ⊢ q ∶ᶜ ★ ⊒ A
+    → Δ ∣ srcStoreⁿ ((α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ)
+        ⊢ p [ α ]ᶜ ∶ᶜ C ⊒ D
+    → Δ ∣ (α ꞉ q) ∷ σ ∣ γ
+        ⊢ N [ α ]ᵀ ⊒ N′ [ α ]ᵀ ∶ p [ α ]ᶜ ⦂ C ⊒ D
+      ----------------------------------------------------------
+    → Δ ∣ (α ꞉= A ⊒) ∷ (⊒ αᵢ ꞉=☆) ∷ σ ∣ γ
+        ⊢ N [ αᵢ ]ᵀ ⊒ N′ [ α ]ᵀ ∶ p [ α ]ᶜ ⦂ C ⊒ D
+
+  ⊒blameᵗ : ∀ {M p A B}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ blame ∶ p ⦂ A ⊒ B
+
+  x⊒xᵗ : ∀ {x p A B}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B
+    → γ ∋ x ⦂ p
+      --------------------------------
+    → Δ ∣ σ ∣ γ ⊢ ` x ⊒ ` x ∶ p ⦂ A ⊒ B
+
+  ƛ⊒ƛᵗ : ∀ {N N′ p q A A′ B B′}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)
+    → Δ ∣ σ ∣ ((- p) ∷ γ) ⊢ N ⊒ N′ ∶ q ⦂ B ⊒ B′
+      ----------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ ƛ N ⊒ ƛ N′ ∶ p ↦ q
+        ⦂ A ⇒ B ⊒ A′ ⇒ B′
+
+  ·⊒·ᵗ : ∀ {L L′ M M′ p q A A′ B B′}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)
+    → Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ p ↦ q
+        ⦂ A ⇒ B ⊒ A′ ⇒ B′
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ - p ⦂ A′ ⊒ A
+      -------------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ L · M ⊒ L′ · M′ ∶ q ⦂ B ⊒ B′
+
+  Λ⊒Λᵗ : ∀ {V V′ p A B}
+    → Δ ∣ srcStoreⁿ σ ⊢ `∀ p ∶ᶜ `∀ A ⊒ `∀ B
+    → Value V
+    → suc Δ ∣ ⇑ˢ σ ∣ ⇑ᵍ γ ⊢ V ⊒ V′ ∶ p ⦂ A ⊒ B
+      -------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ Λ V ⊒ Λ V′ ∶ `∀ p ⦂ `∀ A ⊒ `∀ B
+
+  ⊒Λᵗ : ∀ {A B N V′ p}
+    → Δ ∣ srcStoreⁿ σ ⊢ gen A p ∶ᶜ A ⊒ `∀ B
+    → suc Δ ∣ (zero ꞉= ★ ⊒) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+        ⊢ ⇑ᵗᵐ N ⊒ V′ ∶ p ⦂ ⇑ᵗ A ⊒ B
+      --------------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ N ⊒ Λ V′ ∶ gen A p ⦂ A ⊒ `∀ B
+
+  ⊒⟨ν⟩ᵗ : ∀ {A B N V′ p s}
+    → Δ ∣ srcStoreⁿ σ ⊢ gen A p ∶ᶜ A ⊒ `∀ B
+    → Inert s
+    → suc Δ ∣ (zero ꞉= ★ ⊒) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+        ⊢ ⇑ᵗᵐ N ⊒ V′ ⟨ s ⟩ ∶ p ⦂ ⇑ᵗ A ⊒ B
+      -----------------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ N ⊒ V′ ⟨ gen A s ⟩ ∶ gen A p
+        ⦂ A ⊒ `∀ B
+
+  α⊒αᵗ : ∀ {L L′ p q A B C D E F}
+    → γ′ ≡ ⇑ᵍ γ
+    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ B
+    → suc Δ ∣ srcStoreⁿ ((zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ)
+        ⊢ p ∶ᶜ C ⊒ D
+    → Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ `∀ p ⦂ E ⊒ F
+      ------------------------------------------------
+    → suc Δ ∣ (zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ ∣ γ′
+        ⊢ (⇑ᵗᵐ L) • ⊒ (⇑ᵗᵐ L′) • ∶ p ⦂ C ⊒ D
+
+  ⊒αᵗ : ∀ {L L′ p A B C D E F}
+    → γ′ ≡ ⇑ᵍ γ
+    → suc Δ ∣ srcStoreⁿ ((zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ)
+        ⊢ p ∶ᶜ C ⊒ D
+    → Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ gen B p ⦂ E ⊒ F
+      -----------------------------------------------
+    → suc Δ ∣ (zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ ∣ γ′
+        ⊢ ⇑ᵗᵐ L ⊒ (⇑ᵗᵐ L′) • ∶ p ⦂ C ⊒ D
+
+  ν⊒νᵗ : ∀ {A A′ B B′ N N′ p q}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ B ⊒ B′
+    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ A′
+    → suc Δ ∣ (zero ꞉ ⇑ᶜ q) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+        ⊢ N ⊒ N′ ∶ ⇑ᶜ p ⦂ ⇑ᵗ B ⊒ ⇑ᵗ B′
+      ------------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ ν A N (⇑ᶜ p) ⊒ ν A′ N′ (⇑ᶜ p) ∶ p
+        ⦂ B ⊒ B′
+
+  ⊒νᵗ : ∀ {A B B′ N N′ p}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ B ⊒ B′
+    → suc Δ ∣ (zero ꞉= ⇑ᵗ A ⊒) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+        ⊢ ⇑ᵗᵐ N ⊒ N′ ∶ ⇑ᶜ p ⦂ ⇑ᵗ B ⊒ ⇑ᵗ B′
+      ---------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ N ⊒ ν A N′ (⇑ᶜ p) ∶ p ⦂ B ⊒ B′
+
+  ν⊒ᵗ : ∀ {N N′ p A B}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B
+    → suc Δ ∣ (⊒ zero ꞉=☆) ∷ ⇑ˢ σ ∣ ⇑ᵍ γ
+        ⊢ N ⊒ ⇑ᵗᵐ N′ ∶ ⇑ᶜ p ⦂ ⇑ᵗ A ⊒ ⇑ᵗ B
+      ---------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ ν ★ N (⇑ᶜ p) ⊒ N′ ∶ p ⦂ A ⊒ B
+
+  κ⊒κᵗ : ∀ κ
+      ---------------------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ $ κ ⊒ $ κ ∶ id (constTy κ)
+        ⦂ constTy κ ⊒ constTy κ
+
+  ⊕⊒⊕ᵗ : ∀ {M M′ N N′}
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ id (‵ `ℕ)
+        ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    → Δ ∣ σ ∣ γ ⊢ N ⊒ N′ ∶ id (‵ `ℕ)
+        ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+      ----------------------------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ M ⊕[ addℕ ] N ⊒ M′ ⊕[ addℕ ] N′
+        ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+
+  ⊒cast+ᵗ : ∀ {M M′ q r s A B C D}
+    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D
+    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
+      -------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ⟨ - s ⟩ ∶ q ⦂ C ⊒ D
+
+  ⊒cast-ᵗ : ∀ {M M′ q r s A B C D}
+    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D
+    → Δ ∣ srcStoreⁿ σ ⊢ r ∶ᶜ A ⊒ B
+    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ q ⦂ C ⊒ D
+      -------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ⟨ s ⟩ ∶ r ⦂ A ⊒ B
+
+  cast+⊒ᵗ : ∀ {M M′ p r t A B C D}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D
+    → Δ ∣ srcStoreⁿ σ ⊢ r ∶ᶜ A ⊒ B
+    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ C ⊒ D
+      -------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ M ⟨ - t ⟩ ⊒ M′ ∶ r ⦂ A ⊒ B
+
+  cast-⊒ᵗ : ∀ {M M′ p r t A B C D}
+    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D
+    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
+      -------------------------------------------------
+    → Δ ∣ σ ∣ γ ⊢ M ⟨ t ⟩ ⊒ M′ ∶ p ⦂ C ⊒ D
+
+typed-term-narrowing-erasure :
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p
+typed-term-narrowing-erasure (extendᵗ qᶜ pαᶜ M⊒N′) =
+  extend qᶜ pαᶜ (typed-term-narrowing-erasure M⊒N′)
+typed-term-narrowing-erasure (splitᵗ qᶜ pαᶜ N⊒N′) =
+  split qᶜ pαᶜ (typed-term-narrowing-erasure N⊒N′)
+typed-term-narrowing-erasure (⊒blameᵗ pᶜ) = ⊒blame pᶜ
+typed-term-narrowing-erasure (x⊒xᵗ pᶜ x∋p) = x⊒x pᶜ x∋p
+typed-term-narrowing-erasure (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) =
+  ƛ⊒ƛ p↦qᶜ (typed-term-narrowing-erasure N⊒N′)
+typed-term-narrowing-erasure (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
+  ·⊒· (fun-narrow-codomainᶜ p↦qᶜ)
+       (typed-term-narrowing-erasure L⊒L′)
+       (typed-term-narrowing-erasure M⊒M′)
+typed-term-narrowing-erasure (Λ⊒Λᵗ allᶜ vV V⊒V′) =
+  Λ⊒Λ allᶜ vV (typed-term-narrowing-erasure V⊒V′)
+typed-term-narrowing-erasure (⊒Λᵗ pᶜ N⊒V′) =
+  ⊒Λ pᶜ (typed-term-narrowing-erasure N⊒V′)
+typed-term-narrowing-erasure (⊒⟨ν⟩ᵗ pᶜ i N⊒V′s) =
+  ⊒⟨ν⟩ pᶜ i (typed-term-narrowing-erasure N⊒V′s)
+typed-term-narrowing-erasure (α⊒αᵗ γ′≡ qᶜ pαᶜ L⊒L′) =
+  α⊒α γ′≡ qᶜ pαᶜ (typed-term-narrowing-erasure L⊒L′)
+typed-term-narrowing-erasure (⊒αᵗ γ′≡ pαᶜ L⊒L′) =
+  ⊒α γ′≡ pαᶜ (typed-term-narrowing-erasure L⊒L′)
+typed-term-narrowing-erasure (ν⊒νᵗ pᶜ qᶜ N⊒N′) =
+  ν⊒ν pᶜ qᶜ (typed-term-narrowing-erasure N⊒N′)
+typed-term-narrowing-erasure (⊒νᵗ pᶜ N⊒N′) =
+  ⊒ν pᶜ (typed-term-narrowing-erasure N⊒N′)
+typed-term-narrowing-erasure (ν⊒ᵗ pᶜ N⊒N′) =
+  ν⊒ pᶜ (typed-term-narrowing-erasure N⊒N′)
+typed-term-narrowing-erasure (κ⊒κᵗ κ) = κ⊒κ κ
+typed-term-narrowing-erasure (⊕⊒⊕ᵗ M⊒M′ N⊒N′) =
+  ⊕⊒⊕ (typed-term-narrowing-erasure M⊒M′)
+       (typed-term-narrowing-erasure N⊒N′)
+typed-term-narrowing-erasure (⊒cast+ᵗ qᶜ q⨟s≈r M⊒M′) =
+  ⊒cast+ qᶜ q⨟s≈r (typed-term-narrowing-erasure M⊒M′)
+typed-term-narrowing-erasure (⊒cast-ᵗ qᶜ rᶜ q⨟s≈r M⊒M′) =
+  ⊒cast- qᶜ q⨟s≈r (typed-term-narrowing-erasure M⊒M′)
+typed-term-narrowing-erasure (cast+⊒ᵗ pᶜ rᶜ r≈t⨟p M⊒M′) =
+  cast+⊒ pᶜ r≈t⨟p (typed-term-narrowing-erasure M⊒M′)
+typed-term-narrowing-erasure (cast-⊒ᵗ pᶜ r≈t⨟p M⊒M′) =
+  cast-⊒ pᶜ r≈t⨟p (typed-term-narrowing-erasure M⊒M′)
+
+typed-term-narrowing-index-typing :
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B
+typed-term-narrowing-index-typing (extendᵗ qᶜ pαᶜ M⊒N′) = pαᶜ
+typed-term-narrowing-index-typing (splitᵗ qᶜ pαᶜ N⊒N′) = pαᶜ
+typed-term-narrowing-index-typing (⊒blameᵗ pᶜ) = pᶜ
+typed-term-narrowing-index-typing (x⊒xᵗ pᶜ x∋p) = pᶜ
+typed-term-narrowing-index-typing (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) = p↦qᶜ
+typed-term-narrowing-index-typing (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
+  fun-narrow-codomainᶜ p↦qᶜ
+typed-term-narrowing-index-typing (Λ⊒Λᵗ allᶜ vV V⊒V′) = allᶜ
+typed-term-narrowing-index-typing (⊒Λᵗ pᶜ N⊒V′) = pᶜ
+typed-term-narrowing-index-typing (⊒⟨ν⟩ᵗ pᶜ i N⊒V′s) = pᶜ
+typed-term-narrowing-index-typing
+    (α⊒αᵗ γ′≡ qᶜ pαᶜ L⊒L′) =
+  pαᶜ
+typed-term-narrowing-index-typing (⊒αᵗ γ′≡ pαᶜ L⊒L′) = pαᶜ
+typed-term-narrowing-index-typing (ν⊒νᵗ pᶜ qᶜ N⊒N′) = pᶜ
+typed-term-narrowing-index-typing (⊒νᵗ pᶜ N⊒N′) = pᶜ
+typed-term-narrowing-index-typing (ν⊒ᵗ pᶜ N⊒N′) = pᶜ
+typed-term-narrowing-index-typing (κ⊒κᵗ (κℕ n)) =
+  cast-id wfBase refl , cross (id-‵ `ℕ)
+typed-term-narrowing-index-typing (⊕⊒⊕ᵗ M⊒M′ N⊒N′) =
+  cast-id wfBase refl , cross (id-‵ `ℕ)
+typed-term-narrowing-index-typing (⊒cast+ᵗ qᶜ q⨟s≈r M⊒M′) = qᶜ
+typed-term-narrowing-index-typing
+    (⊒cast-ᵗ qᶜ rᶜ q⨟s≈r M⊒M′) =
+  rᶜ
+typed-term-narrowing-index-typing
+    (cast+⊒ᵗ pᶜ rᶜ r≈t⨟p M⊒M′) =
+  rᶜ
+typed-term-narrowing-index-typing (cast-⊒ᵗ pᶜ r≈t⨟p M⊒M′) = pᶜ

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -148,7 +148,7 @@ dynamicGradualGuarantee :
   Δ ∣ srcStoreⁿ σ ∣ [] ⊢ M ⦂ A →
   Δ ∣ Σ′ ∣ [] ⊢ M′ ⦂ B →
   Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
-  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
   M′ —→[ χ′ ] N′ →
   ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ] ∃[ p′ ]
     (M —↠[ χs ] N) ×
@@ -158,7 +158,7 @@ dynamicGradualGuarantee :
     Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ ∶ p′
 
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (α⊒α {L′ = blame} γ′≡ qᶜ pαᶜ L⊒L′)
+    (α⊒αᵗ {L′ = blame} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step blame-•) =
   [] , _ , _ , [] , [] , [] , _ ,
   ↠-refl ,
@@ -167,21 +167,21 @@ dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
   ⊒ˢ-nil ,
   ⊒blame pαᶜ
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (α⊒α {L′ = Λ V′} γ′≡ qᶜ pαᶜ L⊒L′)
+    (α⊒αᵗ {L′ = Λ V′} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′)) =
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (α⊒α {L′ = V′ ⟨ `∀ c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
+    (α⊒αᵗ {L′ = V′ ⟨ `∀ c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′)) =
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (α⊒α {L′ = V′ ⟨ gen A c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
+    (α⊒αᵗ {L′ = V′ ⟨ gen A c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′)) =
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (α⊒α γ′≡ qᶜ pαᶜ L⊒L′) red = {!!}
+    (α⊒αᵗ γ′≡ qᶜ pαᶜ L⊒L′) red = {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (⊒α {L′ = blame} γ′≡ pαᶜ L⊒L′) (pure-step blame-•) =
+    (⊒αᵗ {L′ = blame} γ′≡ pαᶜ L⊒L′) (pure-step blame-•) =
   [] , _ , _ , [] , [] , [] , _ ,
   ↠-refl ,
   refl ,
@@ -189,18 +189,35 @@ dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
   ⊒ˢ-nil ,
   ⊒blame pαᶜ
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (⊒α {L′ = Λ V′} γ′≡ pαᶜ L⊒L′)
+    (⊒αᵗ {L′ = Λ V′} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′)) =
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (⊒α {L′ = V′ ⟨ `∀ c ⟩} γ′≡ pαᶜ L⊒L′)
+    (⊒αᵗ {L′ = V′ ⟨ `∀ c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′)) =
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (⊒α {L′ = V′ ⟨ gen A c ⟩} γ′≡ pαᶜ L⊒L′)
+    (⊒αᵗ {L′ = V′ ⟨ gen A c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′)) =
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ
-    (⊒α γ′≡ pαᶜ L⊒L′) red =
+    (⊒αᵗ γ′≡ pαᶜ L⊒L′) red =
+  {!!}
+dynamicGradualGuarantee wfΣ okM σ⊒
+    (⊢· L⊢ M⊢) (⊢· L′⊢ M′⊢) qᶜ
+    (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′)
+    (ξ-·₁ L′→N′ shiftM) =
+  let
+    rec =
+      dynamicGradualGuarantee
+        wfΣ
+        (runtime-·₁ okM)
+        σ⊒
+        {!!}
+        {!!}
+        p↦qᶜ
+        L⊒L′
+        L′→N′
+  in
   {!!}
 dynamicGradualGuarantee wfΣ okM σ⊒ M⊢ M′⊢ pᶜ M⊒M′ M′→N′ = {!!}

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -113,3 +113,41 @@ Remaining β cases:
 - The next missing lemma should invert the value-shaped premise relation,
   e.g. from `Value L` and `L ⊒ Λ V′ ∶ `∀ p`, recover the source shape needed
   for the matching bullet step and the post-step term narrowing relation.
+
+## Typed term-narrowing index, 2026-06-30
+
+Implemented staged typed relation:
+
+- Added `Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B` in `TermNarrowing`.
+- The new `·⊒·ᵗ` constructor stores the full function-index typing
+  `Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)`.
+- Added `typed-term-narrowing-index-typing`, which projects the typed coercion
+  evidence at the conclusion endpoints.
+- Added `typed-term-narrowing-erasure`, which forgets the endpoint indices back
+  to the legacy raw relation for existing catchup and example code.
+
+Counterexample documentation:
+
+- Added `proof.TermNarrowingTypingCounterexample`.
+- It checks the raw witness `$ 0 ⊒ blame ∶ id 𝔹`, while separately recording
+  `$ 0 : ℕ`, `blame : 𝔹`, and `ℕ ≢ 𝔹`.
+- This documents why endpoint recovery from the raw relation should not be
+  attempted.
+
+DGG integration:
+
+- The public `dynamicGradualGuarantee` premise now consumes the typed relation.
+- The application-left branch now inverts `·⊒·ᵗ` and the recursive call uses
+  the exposed `p ↦ q` typing evidence directly.
+
+Remaining alignment issue:
+
+- The application-left recursive call still has two typing-transport holes.
+  The separate application typing premises expose the source/target function
+  domains, while `·⊒·ᵗ` exposes the relation endpoints.  The staged typed
+  relation does not yet bundle source/target typing projections for subterms,
+  and this repo does not currently expose a term typing uniqueness lemma to
+  identify those domains.
+- Do not patch this by adding a postulate.  The next clean step is either to
+  bundle source/target typing evidence in the typed relation, or to prove a
+  focused typing-alignment lemma for typed term narrowing.

--- a/GTSF/proof/TermNarrowingTypingCounterexample.agda
+++ b/GTSF/proof/TermNarrowingTypingCounterexample.agda
@@ -1,0 +1,49 @@
+module proof.TermNarrowingTypingCounterexample where
+
+-- File Charter:
+--   * Checked documentation that endpoint recovery is false for the raw
+--     term-narrowing relation in `TermNarrowing`.
+--   * Exhibits `$ 0 ⊒ blame ∶ id 𝔹` even though `$ 0` has type `ℕ`.
+--   * This module is intentionally about the legacy raw relation; the typed
+--     relation added in `TermNarrowing` avoids relying on such recovery.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥)
+open import Data.List using ([])
+open import Data.Product using (_,_)
+
+open import Types
+open import Coercions
+open import Primitives
+open import NuTerms
+open import NarrowWiden
+open import TermNarrowing
+
+BoolTy : Ty
+BoolTy = ‵ `𝔹
+
+NatTy : Ty
+NatTy = ‵ `ℕ
+
+idBoolᶜ :
+  ∀ {Δ σ} →
+  Δ ∣ srcStoreⁿ σ ⊢ id BoolTy ∶ᶜ BoolTy ⊒ BoolTy
+idBoolᶜ = cast-id wfBase refl , cross (id-‵ `𝔹)
+
+zero-⊢ℕ :
+  ∀ {Δ Σ} →
+  Δ ∣ Σ ∣ [] ⊢ $ (κℕ 0) ⦂ NatTy
+zero-⊢ℕ = ⊢$ (κℕ 0)
+
+blame-⊢𝔹 :
+  ∀ {Δ Σ} →
+  Δ ∣ Σ ∣ [] ⊢ blame ⦂ BoolTy
+blame-⊢𝔹 = ⊢blame wfBase
+
+raw-counterexample :
+  ∀ {Δ σ} →
+  Δ ∣ σ ∣ [] ⊢ $ (κℕ 0) ⊒ blame ∶ id BoolTy
+raw-counterexample {σ = σ} = ⊒blame (idBoolᶜ {σ = σ})
+
+Nat≢Bool : NatTy ≡ BoolTy → ⊥
+Nat≢Bool ()


### PR DESCRIPTION
## Summary

Adds a typed/well-indexed term-narrowing judgment alongside the legacy raw relation:

- introduces `Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B` in `GTSF/TermNarrowing.agda`;
- makes the typed application constructor expose the full `p ↦ q` coercion typing needed by DGG;
- adds erasure and index-typing projections for the typed relation;
- changes `dynamicGradualGuarantee` to consume the typed relation and adds the application-left recursive-call shape using the exposed `p↦qᶜ` premise;
- adds `proof.TermNarrowingTypingCounterexample` documenting why endpoint recovery from the raw relation is false.

## Notes

This is a staged integration. The application-left branch now reaches the intended typed recursive call, but two typing-transport holes remain where the separate application typing premises need to be aligned with the typed relation endpoints. The proof log records why this should be solved by bundling source/target typing evidence in typed narrowing or by proving a focused typing-alignment lemma, not by adding a postulate.

## Validation

- `agda -v0 proof/TermNarrowingTypingCounterexample.agda`
- `agda -v0 proof/DynamicGradualGuarantee.agda`
- `agda -v0 All.agda`