### PR TITLE
[codex] Develop GTSF DGG plus case

### DIFF
--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -60,6 +60,21 @@ renameᶜ-preserves-Inert ρ (`∀ c) = `∀ (renameᶜ (extᵗ ρ) c)
 renameᶜ-preserves-Inert ρ (gen A c) =
   gen (renameᵗ ρ A) (renameᶜ (extᵗ ρ) c)
 
+renameᶜ-reflects-Inert :
+  ∀ ρ c →
+  Inert (renameᶜ ρ c) →
+  Inert c
+renameᶜ-reflects-Inert ρ (id A) ()
+renameᶜ-reflects-Inert ρ (c ︔ d) ()
+renameᶜ-reflects-Inert ρ (c ↦ d) (c′ ↦ d′) = c ↦ d
+renameᶜ-reflects-Inert ρ (`∀ c) (`∀ c′) = `∀ c
+renameᶜ-reflects-Inert ρ (G !) i = G !
+renameᶜ-reflects-Inert ρ (G ？) ()
+renameᶜ-reflects-Inert ρ (seal A α) i = seal A α
+renameᶜ-reflects-Inert ρ (unseal α A) ()
+renameᶜ-reflects-Inert ρ (gen A c) i = gen A c
+renameᶜ-reflects-Inert ρ (inst B c) ()
+
 mutual
   src-renameᶜ :
     ∀ ρ c →

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -12,24 +12,48 @@ module proof.DynamicGradualGuarantee where
 --     catch-up, inversion, wrapping, and cast movement.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
-open import Relation.Binary.PropositionalEquality using (subst; sym)
-open import Data.List using ([]; _∷_)
-open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; subst; sym; trans)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Nat using (ℕ; suc; _+_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 
 open import Types
 open import Coercions
+open import Primitives using (addℕ; κℕ)
 open import NuTerms
 open import NuReduction
-open import NuStore using (StoreWf)
+open import NuStore using (StoreWf; at)
 open import NarrowWiden
 open import NarrowWidenComposition using (_∣_⊢_⨾ⁿ_≈_∶_⊒_)
 open import TermNarrowing
+open import proof.CoercionProperties using (coercion-wf)
 open import proof.Catchup using (catchup-lemma)
-open import proof.CatchupStore using (combineStoreNrw)
-open import proof.NarrowWidenProperties using (tgtStoreⁿ-⊒ˢ)
-open import proof.ReductionProperties using (type-rename-step-⇑ᵗᵐ)
+open import proof.CatchupStore using
+  ( combineStoreNrw
+  ; combineStoreNrw-empty-⊒ˢ
+  ; combineStoreNrw-applyStores
+  )
+open import proof.NarrowWidenProperties using
+  ( tgtStoreⁿ-⊒ˢ
+  ; ⊒ˢ-empty-anyᵗ
+  )
+open import proof.ReductionProperties using
+  ( applyCoercions
+  ; applyStores-++
+  ; applyTerms-const
+  ; applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyTys-ℕ
+  ; applyTys-ℕ-applyTys
+  ; type-rename-step-⇑ᵗᵐ
+  ; ↠-trans
+  ; ⊕₁-↠
+  ; ⊕₂-↠
+  )
 open import proof.TermSubstitutionNarrowing using
   (term-substitution-narrowingᵗ)
+open import proof.NuTermProperties using (renameᵗᵐ-reflects-Value)
+open import proof.NuProgress using (canonical-ℕ; NatView; nv-const)
 open import proof.NuPreservation using
   (runtime-·₁; runtime-•; runtime-⟨⟩; runtime-ν; runtime-⊕₁)
 
@@ -65,6 +89,141 @@ typed-term-narrowing-target-typing-⊒ˢ {Δ = Δ} {σ = σ} {Σ′ = Σ′}
     (sym (tgtStoreⁿ-⊒ˢ σ⊒))
     (typed-term-narrowing-target-typing M⊒M′)
 
+source-nat-typing :
+  ∀ {Δ σ W V p A B} →
+  A ≡ ‵ `ℕ →
+  Δ ∣ σ ∣ [] ⊢ W ⊒ V ∶ p ⦂ A ⊒ B →
+  Δ ∣ srcStoreⁿ σ ∣ [] ⊢ W ⦂ ‵ `ℕ
+source-nat-typing {Δ = Δ} {σ = σ} {W = W} A≡ℕ W⊒V =
+  subst (λ A → Δ ∣ srcStoreⁿ σ ∣ [] ⊢ W ⦂ A) A≡ℕ
+    (typed-term-narrowing-source-typing W⊒V)
+
+canonical-⊕-δ-step :
+  ∀ {ΔL ΔR ΣL ΣR χsL χsR L R} →
+  Value L →
+  ΔL ∣ ΣL ∣ [] ⊢ L ⦂ ‵ `ℕ →
+  Value R →
+  ΔR ∣ ΣR ∣ [] ⊢ R ⦂ ‵ `ℕ →
+  ∃[ m ] ∃[ n ]
+    (applyTerms χsL L ⊕[ addℕ ] applyTerms χsR R
+      —↠[ keep ∷ [] ] $ (κℕ (m + n)))
+canonical-⊕-δ-step {χsL = χsL} {χsR = χsR} vL L⊢ vR R⊢
+    with canonical-ℕ vL L⊢ | canonical-ℕ vR R⊢
+canonical-⊕-δ-step {χsL = χsL} {χsR = χsR} vL L⊢ vR R⊢
+    | nv-const {n = m} L≡ | nv-const {n = n} R≡
+    rewrite L≡ | applyTerms-const χsL (κℕ m)
+          | R≡ | applyTerms-const χsR (κℕ n) =
+  m , n , ↠-step (pure-step δ-⊕) ↠-refl
+
+constant-⊕-δ-step :
+  ∀ {χsL χsR L R m n} →
+  L ≡ $ (κℕ m) →
+  R ≡ $ (κℕ n) →
+  applyTerms χsL L ⊕[ addℕ ] applyTerms χsR R
+    —↠[ keep ∷ [] ] $ (κℕ (m + n))
+constant-⊕-δ-step {χsL = χsL} {χsR = χsR} {m = m} {n = n}
+    L≡ R≡
+    rewrite L≡ | applyTerms-const χsL (κℕ m)
+          | R≡ | applyTerms-const χsR (κℕ n) =
+  ↠-step (pure-step δ-⊕) ↠-refl
+
+applyCoercion-id-ℕ :
+  ∀ χ →
+  applyCoercion χ (id (‵ `ℕ)) ≡ id (‵ `ℕ)
+applyCoercion-id-ℕ keep = refl
+applyCoercion-id-ℕ (bind A) = refl
+
+applyCoercions-id-ℕ :
+  ∀ χs →
+  applyCoercions χs (id (‵ `ℕ)) ≡ id (‵ `ℕ)
+applyCoercions-id-ℕ [] = refl
+applyCoercions-id-ℕ (χ ∷ χs) rewrite applyCoercion-id-ℕ χ =
+  applyCoercions-id-ℕ χs
+
+applyCoercions-id-ℕ-applyCoercions :
+  ∀ χs χs′ →
+  applyCoercions χs′ (applyCoercions χs (id (‵ `ℕ))) ≡ id (‵ `ℕ)
+applyCoercions-id-ℕ-applyCoercions χs χs′ =
+  trans (cong (applyCoercions χs′) (applyCoercions-id-ℕ χs))
+    (applyCoercions-id-ℕ χs′)
+
+const-narrowing-target :
+  ∀ {Δ σ γ M M′ p A B m n} →
+  M ≡ $ (κℕ m) →
+  M′ ≡ $ (κℕ n) →
+  Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  m ≡ n
+const-narrowing-target eqM eqM′ (extendᵗ qᶜ pαᶜ M⊒N′) =
+  const-narrowing-target eqM eqM′ M⊒N′
+const-narrowing-target eqM eqM′
+    (splitᵗ {N = N} {α = α} {αᵢ = αᵢ} qᶜ pαᶜ N⊒N′) =
+  const-narrowing-target
+    (renameᵗᵐ-const-change (singleRenameᵗ αᵢ) (singleRenameᵗ α) eqM)
+    eqM′
+    N⊒N′
+  where
+    renameᵗᵐ-const-reflect :
+      ∀ {ρ M κ} →
+      renameᵗᵐ ρ M ≡ $ κ →
+      M ≡ $ κ
+    renameᵗᵐ-const-reflect {M = ` x} ()
+    renameᵗᵐ-const-reflect {M = ƛ M} ()
+    renameᵗᵐ-const-reflect {M = L · M} ()
+    renameᵗᵐ-const-reflect {M = Λ M} ()
+    renameᵗᵐ-const-reflect {M = M •} ()
+    renameᵗᵐ-const-reflect {M = ν A L c} ()
+    renameᵗᵐ-const-reflect {M = $ κ} refl = refl
+    renameᵗᵐ-const-reflect {M = L ⊕[ op ] M} ()
+    renameᵗᵐ-const-reflect {M = M ⟨ c ⟩} ()
+    renameᵗᵐ-const-reflect {M = blame} ()
+
+    renameᵗᵐ-const-change :
+      ∀ ρ ρ′ {M κ} →
+      renameᵗᵐ ρ M ≡ $ κ →
+      renameᵗᵐ ρ′ M ≡ $ κ
+    renameᵗᵐ-const-change ρ ρ′ eq
+        rewrite renameᵗᵐ-const-reflect eq =
+      refl
+const-narrowing-target refl refl (κ⊒κᵗ (κℕ n)) = refl
+
+value-id-ℕ-narrowing-target-const :
+  ∀ {Δ σ W n} →
+  Value W →
+  Δ ∣ σ ∣ [] ⊢ W ⊒ $ (κℕ n)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  W ≡ $ (κℕ n)
+value-id-ℕ-narrowing-target-const {W = W} vW W⊒
+    with canonical-ℕ vW (typed-term-narrowing-source-typing W⊒)
+value-id-ℕ-narrowing-target-const {W = W} vW W⊒
+    | nv-const {n = m} W≡
+    rewrite W≡ | const-narrowing-target refl refl W⊒ =
+  refl
+
+value-normalized-id-ℕ-target-const :
+  ∀ {Δ σ W T p A B n} →
+  Value W →
+  T ≡ $ (κℕ n) →
+  p ≡ id (‵ `ℕ) →
+  A ≡ ‵ `ℕ →
+  B ≡ ‵ `ℕ →
+  Δ ∣ σ ∣ [] ⊢ W ⊒ T ∶ p ⦂ A ⊒ B →
+  W ≡ $ (κℕ n)
+value-normalized-id-ℕ-target-const target-value T≡ p≡ A≡ B≡ W⊒ =
+  value-id-ℕ-narrowing-target-const target-value
+    (subst
+      (λ T → _ ∣ _ ∣ [] ⊢ _ ⊒ T ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ)
+      T≡
+      (subst
+        (λ p → _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ p ⦂ ‵ `ℕ ⊒ ‵ `ℕ)
+        p≡
+        (subst
+          (λ A → _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ _ ⦂ A ⊒ ‵ `ℕ)
+          A≡
+          (subst
+            (λ B → _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ _ ⦂ _ ⊒ B)
+            B≡
+            W⊒))))
+
 ------------------------------------------------------------------------
 -- Function application simulation
 ------------------------------------------------------------------------
@@ -89,7 +248,7 @@ function-application-simulation-ƛ⊒ƛᵗ {N = N} {V = V}
   refl ,
   refl ,
   ⊒ˢ-nil ,
-  term-substitution-narrowingᵗ _ N⊒N′
+  term-substitution-narrowingᵗ {! ? !} N⊒N′
 
 function-application-simulation :
   ∀ {Δ σ L M N′ V′ p q A A′ B B′} →
@@ -109,7 +268,7 @@ function-application-simulation okM vV′ L⊒L′ M⊒V′
 function-application-simulation okM vV′ L⊒L′ M⊒V′
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
-  {!!}
+  {! ? !}
 
 ------------------------------------------------------------------------
 -- Dynamic gradual guarantee
@@ -131,87 +290,101 @@ dynamicGradualGuarantee :
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
     Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ ∶ p′ ⦂ A′ ⊒ B′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
-    (α⊒αᵗ {L′ = blame} γ′≡ qᶜ pαᶜ L⊒L′)
+    M⊒M′@(α⊒αᵗ {L′ = blame} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step blame-•) =
   [] , _ , _ , [] , [] , [] , _ , _ , _ ,
   ↠-refl ,
   refl ,
   refl ,
   ⊒ˢ-nil ,
-  ⊒blameᵗ pαᶜ
+  ⊒blameᵗ
+    {typing =
+      term-typing-endpoints
+        (typed-term-narrowing-source-typing M⊒M′)
+        (⊢blame
+          (proj₂ (coercion-wf (at wfΣ) (tag-or-idᵈ , proj₁ pαᶜ))))}
+    pαᶜ
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (α⊒αᵗ {γ = []} {L′ = Λ V′} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′))
-    with catchup-lemma (runtime-• okM) {!!} L⊒L′
+    with catchup-lemma (runtime-• okM)
+         (Λ (renameᵗᵐ-reflects-Value (extᵗ suc) V′ vV′))
+         L⊒L′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (α⊒αᵗ {γ = []} {L′ = Λ V′} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , L↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒Λ =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (α⊒αᵗ {γ = []} {L′ = V′ ⟨ `∀ c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′))
-    with catchup-lemma (runtime-• okM) {!!} L⊒L′
+    with catchup-lemma (runtime-• okM) {! ? !} L⊒L′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (α⊒αᵗ {γ = []} {L′ = V′ ⟨ `∀ c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , L↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒∀ =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (α⊒αᵗ {γ = []} {L′ = V′ ⟨ gen A c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′))
-    with catchup-lemma (runtime-• okM) {!!} L⊒L′
+    with catchup-lemma (runtime-• okM) {! ? !} L⊒L′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (α⊒αᵗ {γ = []} {L′ = V′ ⟨ gen A c ⟩} γ′≡ qᶜ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , L↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒gen =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
-    (α⊒αᵗ γ′≡ qᶜ pαᶜ L⊒L′) red = {!!}
+    (α⊒αᵗ γ′≡ qᶜ pαᶜ L⊒L′) red = {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
-    (⊒αᵗ {L′ = blame} γ′≡ pαᶜ L⊒L′) (pure-step blame-•) =
+    M⊒M′@(⊒αᵗ {L′ = blame} γ′≡ pαᶜ L⊒L′) (pure-step blame-•) =
   [] , _ , _ , [] , [] , [] , _ , _ , _ ,
   ↠-refl ,
   refl ,
   refl ,
   ⊒ˢ-nil ,
-  ⊒blameᵗ pαᶜ
+  ⊒blameᵗ
+    {typing =
+      term-typing-endpoints
+        (typed-term-narrowing-source-typing M⊒M′)
+        (⊢blame
+          (proj₂ (coercion-wf (at wfΣ) (tag-or-idᵈ , proj₁ pαᶜ))))}
+    pαᶜ
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ {γ = []} {L′ = Λ V′} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′))
-    with catchup-lemma {!!} {!!} L⊒L′
+    with catchup-lemma {! ? !} {! ? !} L⊒L′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ {γ = []} {L′ = Λ V′} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-Λ• vV′))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , L↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒Λ =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ {γ = []} {L′ = V′ ⟨ `∀ c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′))
-    with catchup-lemma {!!} {!!} L⊒L′
+    with catchup-lemma {! ? !} {! ? !} L⊒L′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ {γ = []} {L′ = V′ ⟨ `∀ c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-∀• vV′))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , L↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒∀ =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ {γ = []} {L′ = V′ ⟨ gen A c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′))
-    with catchup-lemma {!!} {!!} L⊒L′
+    with catchup-lemma {! ? !} {! ? !} L⊒L′
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ {γ = []} {L′ = V′ ⟨ gen A c ⟩} γ′≡ pαᶜ L⊒L′)
     (pure-step (β-gen• vV′))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , L↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒gen =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ γ′≡ pαᶜ L⊒L′) red =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
     (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′)
     (pure-step (β vV)) =
@@ -229,20 +402,807 @@ dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
         L⊒L′
         L′→N′
   in
-  {!!}
-dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
-    (⊕⊒⊕ᵗ M⊒M′ N⊒N′)
+  {! ? !}
+dynamicGradualGuarantee {σ = σ} wfΣ (ok-no (no•-⊕ noM noN)) σ⊒ qᶜ
+    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
     (pure-step δ-⊕)
-    with catchup-lemma (runtime-⊕₁ okM) ($ _) M⊒M′
-       | catchup-lemma (runtime-⊕₂-any okM) ($ _) N⊒N′
-dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
-    (⊕⊒⊕ᵗ M⊒M′ N⊒N′)
-    (pure-step δ-⊕)
+    with catchup-lemma (ok-no noM) ($ _) M⊒M′
+       | catchup-lemma (ok-no noN) ($ _) N⊒N′
+dynamicGradualGuarantee {σ = σ} wfΣ (ok-no (no•-⊕ noM noN)) σ⊒ qᶜ
+    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′}))
     | χsM , WM , ΔM , ΠM , ΠM′ , πM ,
       vWM , noWM , M↠WM , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , WM⊒M′
     | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
       vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
-  {!!}
+  let
+    left-steps :
+      M ⊕[ addℕ ] N —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
+    left-steps = ⊕₁-↠ noN M↠WM
+
+    N⊒N′L :
+      ΔM ∣ combineStoreNrw πM σ ∣ []
+        ⊢ applyTerms χsM N ⊒ applyTerms χsM N′
+          ∶ applyCoercions χsM (id (‵ `ℕ))
+            ⦂ applyTys χsM (‵ `ℕ) ⊒ applyTys χsM (‵ `ℕ)
+    N⊒N′L = {! ? !}
+
+    right :
+      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+        Value W ×
+        No• W ×
+        (applyTerms χsM N —↠[ χs ] W) ×
+        (Δ′ ≡ applyTyCtxs χs ΔM) ×
+        (Π ≡ applyStores χs []) ×
+        (Π′ ≡ applyStore keep []) ×
+        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+        Δ′ ∣ combineStoreNrw π (combineStoreNrw πM σ) ∣ []
+          ⊢ W ⊒ applyTerms χs (applyTerms χsM N′)
+            ∶ applyCoercions χs (applyCoercions χsM (id (‵ `ℕ)))
+              ⦂ applyTys χs (applyTys χsM (‵ `ℕ))
+                ⊒ applyTys χs (applyTys χsM (‵ `ℕ))
+    right =
+      catchup-lemma
+        (ok-no (applyTerms-preserves-No• χsM noN))
+        (applyTerms-preserves-Value χsM ($ (κℕ n′)))
+        N⊒N′L
+
+    χsR : StoreChanges
+    χsR = proj₁ right
+
+    W : Term
+    W = proj₁ (proj₂ right)
+
+    ΔR : TyCtx
+    ΔR = proj₁ (proj₂ (proj₂ right))
+
+    ΠR : Store
+    ΠR =
+      proj₁ (proj₂ (proj₂ (proj₂ right)))
+
+    ΠR′ : Store
+    ΠR′ =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ right))))
+
+    πR : StoreNrw
+    πR =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
+
+    tail :
+      Value W ×
+      No• W ×
+      (applyTerms χsM N —↠[ χsR ] W) ×
+      (ΔR ≡ applyTyCtxs χsR ΔM) ×
+      (ΠR ≡ applyStores χsR []) ×
+      (ΠR′ ≡ applyStore keep []) ×
+      (ΔR ⊢ πR ꞉
+        ΠR ⊒ˢ ΠR′) ×
+      ΔR
+        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
+        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
+          ∶ applyCoercions χsR
+              (applyCoercions χsM (id (‵ `ℕ)))
+            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
+              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
+    tail =
+      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
+
+    ΠR≡ : ΠR ≡ applyStores χsR []
+    ΠR≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂ tail))))
+
+    ΠR′≡ : ΠR′ ≡ applyStore keep []
+    ΠR′≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂ tail)))))
+
+    πR⊒ :
+      ΔR ⊢ πR ꞉
+        ΠR ⊒ˢ ΠR′
+    πR⊒ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    vW : Value W
+    vW = proj₁ tail
+
+    N↠W :
+      applyTerms χsM N —↠[ χsR ] W
+    N↠W =
+      proj₁
+        (proj₂
+          (proj₂ tail))
+
+    operands-term : Term
+    operands-term =
+      applyTerms χsR WM ⊕[ addℕ ] W
+
+    right-steps :
+      WM ⊕[ addℕ ] applyTerms χsM N —↠[ χsR ] operands-term
+    right-steps = ⊕₂-↠ vWM noWM N↠W
+
+    operands-ready :
+      M ⊕[ addℕ ] N —↠[ χsM ++ χsR ] operands-term
+    operands-ready = ↠-trans left-steps right-steps
+
+    WM⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ WM ⦂ ‵ `ℕ
+    WM⊢ℕ = source-nat-typing (applyTys-ℕ χsM) WM⊒M′
+
+    W⊒N′ :
+      ΔR
+        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
+        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
+          ∶ applyCoercions χsR
+              (applyCoercions χsM (id (‵ `ℕ)))
+            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
+              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
+    W⊒N′ =
+      proj₂
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    W⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
+    W⊢ℕ =
+      source-nat-typing
+        (applyTys-ℕ-applyTys χsM χsR)
+        W⊒N′
+
+    WM≡target : WM ≡ $ (κℕ m′)
+    WM≡target =
+      value-normalized-id-ℕ-target-const
+        vWM
+        (applyTerms-const χsM (κℕ m′))
+        (applyCoercions-id-ℕ χsM)
+        (applyTys-ℕ χsM)
+        (applyTys-ℕ χsM)
+        WM⊒M′
+
+    W≡target : W ≡ $ (κℕ n′)
+    W≡target =
+      value-normalized-id-ℕ-target-const
+        vW
+        (trans
+          (cong (applyTerms χsR)
+            (applyTerms-const χsM (κℕ n′)))
+          (applyTerms-const χsR (κℕ n′)))
+        (applyCoercions-id-ℕ-applyCoercions χsM χsR)
+        (applyTys-ℕ-applyTys χsM χsR)
+        (applyTys-ℕ-applyTys χsM χsR)
+        W⊒N′
+
+    source-δ :
+      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step
+        {χsL = χsR} {χsR = []}
+        WM≡target
+        W≡target
+
+    χs : StoreChanges
+    χs = (χsM ++ χsR) ++ keep ∷ []
+
+    Δ′ : TyCtx
+    Δ′ = ΔR
+
+    Π : Store
+    Π = srcStoreⁿ (combineStoreNrw πR πM)
+
+    Π′ : Store
+    Π′ = []
+
+    π : StoreNrw
+    π = combineStoreNrw πR πM
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    Π≡ : Π ≡ applyStores χs []
+    Π≡ =
+      trans
+        (combineStoreNrw-applyStores
+          {χs₂ = χsR} {χs₁ = χsM}
+          πR⊒
+          ΠR≡
+          ΠR′≡
+          πM⊒
+          ΠM≡
+          ΠM′≡)
+        (sym (applyStores-++ (χsM ++ χsR) (keep ∷ []) []))
+
+    Π′≡ : Π′ ≡ applyStore keep []
+    Π′≡ = refl
+
+    πM⊒-empty : Δ′ ⊢ πM ꞉ ΠM ⊒ˢ []
+    πM⊒-empty =
+      ⊒ˢ-empty-anyᵗ Δ′
+        (subst (λ Π₀ → ΔM ⊢ πM ꞉ ΠM ⊒ˢ Π₀) ΠM′≡ πM⊒)
+
+    πR⊒-empty :
+      Δ′ ⊢ πR ꞉ ΠR ⊒ˢ []
+    πR⊒-empty =
+      subst
+        (λ Π₀ → Δ′ ⊢ πR ꞉ ΠR ⊒ˢ Π₀)
+        ΠR′≡
+        πR⊒
+
+    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
+    π⊒ =
+      combineStoreNrw-empty-⊒ˢ
+        πR⊒-empty
+        πM⊒-empty
+
+    result⊒ :
+      Δ′ ∣ combineStoreNrw π σ ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ
+        (κℕ (m′ + n′))
+        {typing =
+          term-typing-endpoints
+            (⊢$ (κℕ (m′ + n′)))
+            (⊢$ (κℕ (m′ + n′)))}
+  in
+  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
+  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
+  source-steps ,
+  Π≡ ,
+  Π′≡ ,
+  π⊒ ,
+  result⊒
+dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₁ okM noN) σ⊒ qᶜ
+    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
+    (pure-step δ-⊕)
+    with catchup-lemma okM ($ _) M⊒M′
+       | catchup-lemma (ok-no noN) ($ _) N⊒N′
+dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₁ okM noN) σ⊒ qᶜ
+    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′}))
+    | χsM , WM , ΔM , ΠM , ΠM′ , πM ,
+      vWM , noWM , M↠WM , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , WM⊒M′
+    | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
+      vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
+  let
+    left-steps :
+      M ⊕[ addℕ ] N —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
+    left-steps = ⊕₁-↠ noN M↠WM
+
+    N⊒N′L :
+      ΔM ∣ combineStoreNrw πM σ ∣ []
+        ⊢ applyTerms χsM N ⊒ applyTerms χsM N′
+          ∶ applyCoercions χsM (id (‵ `ℕ))
+            ⦂ applyTys χsM (‵ `ℕ) ⊒ applyTys χsM (‵ `ℕ)
+    N⊒N′L = {! ? !}
+
+    right :
+      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+        Value W ×
+        No• W ×
+        (applyTerms χsM N —↠[ χs ] W) ×
+        (Δ′ ≡ applyTyCtxs χs ΔM) ×
+        (Π ≡ applyStores χs []) ×
+        (Π′ ≡ applyStore keep []) ×
+        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+        Δ′ ∣ combineStoreNrw π (combineStoreNrw πM σ) ∣ []
+          ⊢ W ⊒ applyTerms χs (applyTerms χsM N′)
+            ∶ applyCoercions χs (applyCoercions χsM (id (‵ `ℕ)))
+              ⦂ applyTys χs (applyTys χsM (‵ `ℕ))
+                ⊒ applyTys χs (applyTys χsM (‵ `ℕ))
+    right =
+      catchup-lemma
+        (ok-no (applyTerms-preserves-No• χsM noN))
+        (applyTerms-preserves-Value χsM ($ (κℕ n′)))
+        N⊒N′L
+
+    χsR : StoreChanges
+    χsR = proj₁ right
+
+    W : Term
+    W = proj₁ (proj₂ right)
+
+    ΔR : TyCtx
+    ΔR = proj₁ (proj₂ (proj₂ right))
+
+    ΠR : Store
+    ΠR =
+      proj₁ (proj₂ (proj₂ (proj₂ right)))
+
+    ΠR′ : Store
+    ΠR′ =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ right))))
+
+    πR : StoreNrw
+    πR =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
+
+    tail :
+      Value W ×
+      No• W ×
+      (applyTerms χsM N —↠[ χsR ] W) ×
+      (ΔR ≡ applyTyCtxs χsR ΔM) ×
+      (ΠR ≡ applyStores χsR []) ×
+      (ΠR′ ≡ applyStore keep []) ×
+      (ΔR ⊢ πR ꞉
+        ΠR ⊒ˢ ΠR′) ×
+      ΔR
+        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
+        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
+          ∶ applyCoercions χsR
+              (applyCoercions χsM (id (‵ `ℕ)))
+            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
+              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
+    tail =
+      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
+
+    ΠR≡ : ΠR ≡ applyStores χsR []
+    ΠR≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂ tail))))
+
+    ΠR′≡ : ΠR′ ≡ applyStore keep []
+    ΠR′≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂ tail)))))
+
+    πR⊒ :
+      ΔR ⊢ πR ꞉
+        ΠR ⊒ˢ ΠR′
+    πR⊒ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    vW : Value W
+    vW = proj₁ tail
+
+    N↠W :
+      applyTerms χsM N —↠[ χsR ] W
+    N↠W =
+      proj₁
+        (proj₂
+          (proj₂ tail))
+
+    operands-term : Term
+    operands-term =
+      applyTerms χsR WM ⊕[ addℕ ] W
+
+    right-steps :
+      WM ⊕[ addℕ ] applyTerms χsM N —↠[ χsR ] operands-term
+    right-steps = ⊕₂-↠ vWM noWM N↠W
+
+    operands-ready :
+      M ⊕[ addℕ ] N —↠[ χsM ++ χsR ] operands-term
+    operands-ready = ↠-trans left-steps right-steps
+
+    WM⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ WM ⦂ ‵ `ℕ
+    WM⊢ℕ = source-nat-typing (applyTys-ℕ χsM) WM⊒M′
+
+    W⊒N′ :
+      ΔR
+        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
+        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
+          ∶ applyCoercions χsR
+              (applyCoercions χsM (id (‵ `ℕ)))
+            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
+              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
+    W⊒N′ =
+      proj₂
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    W⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
+    W⊢ℕ =
+      source-nat-typing
+        (applyTys-ℕ-applyTys χsM χsR)
+        W⊒N′
+
+    WM≡target : WM ≡ $ (κℕ m′)
+    WM≡target =
+      value-normalized-id-ℕ-target-const
+        vWM
+        (applyTerms-const χsM (κℕ m′))
+        (applyCoercions-id-ℕ χsM)
+        (applyTys-ℕ χsM)
+        (applyTys-ℕ χsM)
+        WM⊒M′
+
+    W≡target : W ≡ $ (κℕ n′)
+    W≡target =
+      value-normalized-id-ℕ-target-const
+        vW
+        (trans
+          (cong (applyTerms χsR)
+            (applyTerms-const χsM (κℕ n′)))
+          (applyTerms-const χsR (κℕ n′)))
+        (applyCoercions-id-ℕ-applyCoercions χsM χsR)
+        (applyTys-ℕ-applyTys χsM χsR)
+        (applyTys-ℕ-applyTys χsM χsR)
+        W⊒N′
+
+    source-δ :
+      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step
+        {χsL = χsR} {χsR = []}
+        WM≡target
+        W≡target
+
+    χs : StoreChanges
+    χs = (χsM ++ χsR) ++ keep ∷ []
+
+    Δ′ : TyCtx
+    Δ′ = ΔR
+
+    Π : Store
+    Π = srcStoreⁿ (combineStoreNrw πR πM)
+
+    Π′ : Store
+    Π′ = []
+
+    π : StoreNrw
+    π = combineStoreNrw πR πM
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    Π≡ : Π ≡ applyStores χs []
+    Π≡ =
+      trans
+        (combineStoreNrw-applyStores
+          {χs₂ = χsR} {χs₁ = χsM}
+          πR⊒
+          ΠR≡
+          ΠR′≡
+          πM⊒
+          ΠM≡
+          ΠM′≡)
+        (sym (applyStores-++ (χsM ++ χsR) (keep ∷ []) []))
+
+    Π′≡ : Π′ ≡ applyStore keep []
+    Π′≡ = refl
+
+    πM⊒-empty : Δ′ ⊢ πM ꞉ ΠM ⊒ˢ []
+    πM⊒-empty =
+      ⊒ˢ-empty-anyᵗ Δ′
+        (subst (λ Π₀ → ΔM ⊢ πM ꞉ ΠM ⊒ˢ Π₀) ΠM′≡ πM⊒)
+
+    πR⊒-empty :
+      Δ′ ⊢ πR ꞉ ΠR ⊒ˢ []
+    πR⊒-empty =
+      subst
+        (λ Π₀ → Δ′ ⊢ πR ꞉ ΠR ⊒ˢ Π₀)
+        ΠR′≡
+        πR⊒
+
+    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
+    π⊒ =
+      combineStoreNrw-empty-⊒ˢ
+        πR⊒-empty
+        πM⊒-empty
+
+    result⊒ :
+      Δ′ ∣ combineStoreNrw π σ ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ
+        (κℕ (m′ + n′))
+        {typing =
+          term-typing-endpoints
+            (⊢$ (κℕ (m′ + n′)))
+            (⊢$ (κℕ (m′ + n′)))}
+  in
+  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
+  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
+  source-steps ,
+  Π≡ ,
+  Π′≡ ,
+  π⊒ ,
+  result⊒
+dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₂ vM noM okN) σ⊒ qᶜ
+    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
+    (pure-step δ-⊕)
+    with catchup-lemma okN ($ _) N⊒N′
+dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₂ vM noM okN) σ⊒ qᶜ
+    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′}))
+    | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
+      vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
+  let
+    right-steps :
+      M ⊕[ addℕ ] N —↠[ χsN ] applyTerms χsN M ⊕[ addℕ ] WN
+    right-steps = ⊕₂-↠ vM noM N↠WN
+
+    M⊒M′R :
+      ΔN ∣ combineStoreNrw πN σ ∣ []
+        ⊢ applyTerms χsN M ⊒ applyTerms χsN M′
+          ∶ applyCoercions χsN (id (‵ `ℕ))
+            ⦂ applyTys χsN (‵ `ℕ) ⊒ applyTys χsN (‵ `ℕ)
+    M⊒M′R = {! ? !}
+
+    left :
+      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+        Value W ×
+        No• W ×
+        (applyTerms χsN M —↠[ χs ] W) ×
+        (Δ′ ≡ applyTyCtxs χs ΔN) ×
+        (Π ≡ applyStores χs []) ×
+        (Π′ ≡ applyStore keep []) ×
+        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+        Δ′ ∣ combineStoreNrw π (combineStoreNrw πN σ) ∣ []
+          ⊢ W ⊒ applyTerms χs (applyTerms χsN M′)
+            ∶ applyCoercions χs (applyCoercions χsN (id (‵ `ℕ)))
+              ⦂ applyTys χs (applyTys χsN (‵ `ℕ))
+                ⊒ applyTys χs (applyTys χsN (‵ `ℕ))
+    left =
+      catchup-lemma
+        (ok-no (applyTerms-preserves-No• χsN noM))
+        (applyTerms-preserves-Value χsN ($ (κℕ m′)))
+        M⊒M′R
+
+    χsL : StoreChanges
+    χsL = proj₁ left
+
+    W : Term
+    W = proj₁ (proj₂ left)
+
+    ΔL : TyCtx
+    ΔL = proj₁ (proj₂ (proj₂ left))
+
+    ΠL : Store
+    ΠL =
+      proj₁ (proj₂ (proj₂ (proj₂ left)))
+
+    ΠL′ : Store
+    ΠL′ =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ left))))
+
+    πL : StoreNrw
+    πL =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ left)))))
+
+    tail :
+      Value W ×
+      No• W ×
+      (applyTerms χsN M —↠[ χsL ] W) ×
+      (ΔL ≡ applyTyCtxs χsL ΔN) ×
+      (ΠL ≡ applyStores χsL []) ×
+      (ΠL′ ≡ applyStore keep []) ×
+      (ΔL ⊢ πL ꞉
+        ΠL ⊒ˢ ΠL′) ×
+      ΔL
+        ∣ combineStoreNrw πL (combineStoreNrw πN σ) ∣ []
+        ⊢ W ⊒
+          applyTerms χsL (applyTerms χsN M′)
+          ∶ applyCoercions χsL
+              (applyCoercions χsN (id (‵ `ℕ)))
+            ⦂ applyTys χsL (applyTys χsN (‵ `ℕ))
+              ⊒ applyTys χsL (applyTys χsN (‵ `ℕ))
+    tail =
+      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ left)))))
+
+    ΠL≡ : ΠL ≡ applyStores χsL []
+    ΠL≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂ tail))))
+
+    ΠL′≡ : ΠL′ ≡ applyStore keep []
+    ΠL′≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂ tail)))))
+
+    πL⊒ :
+      ΔL ⊢ πL ꞉
+        ΠL ⊒ˢ ΠL′
+    πL⊒ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    vW : Value W
+    vW = proj₁ tail
+
+    M↠W :
+      applyTerms χsN M —↠[ χsL ] W
+    M↠W =
+      proj₁
+        (proj₂
+          (proj₂ tail))
+
+    operands-term : Term
+    operands-term =
+      W ⊕[ addℕ ] applyTerms χsL WN
+
+    left-steps :
+      applyTerms χsN M ⊕[ addℕ ] WN
+        —↠[ χsL ] operands-term
+    left-steps = ⊕₁-↠ noWN M↠W
+
+    operands-ready :
+      M ⊕[ addℕ ] N —↠[ χsN ++ χsL ] operands-term
+    operands-ready = ↠-trans right-steps left-steps
+
+    W⊒M′ :
+      ΔL
+        ∣ combineStoreNrw πL (combineStoreNrw πN σ) ∣ []
+        ⊢ W ⊒ applyTerms χsL (applyTerms χsN M′)
+          ∶ applyCoercions χsL
+              (applyCoercions χsN (id (‵ `ℕ)))
+            ⦂ applyTys χsL (applyTys χsN (‵ `ℕ))
+              ⊒ applyTys χsL (applyTys χsN (‵ `ℕ))
+    W⊒M′ =
+      proj₂
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    W⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
+    W⊢ℕ =
+      source-nat-typing
+        (applyTys-ℕ-applyTys χsN χsL)
+        W⊒M′
+
+    WN⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ WN ⦂ ‵ `ℕ
+    WN⊢ℕ = source-nat-typing (applyTys-ℕ χsN) WN⊒N′
+
+    W≡target : W ≡ $ (κℕ m′)
+    W≡target =
+      value-normalized-id-ℕ-target-const
+        vW
+        (trans
+          (cong (applyTerms χsL)
+            (applyTerms-const χsN (κℕ m′)))
+          (applyTerms-const χsL (κℕ m′)))
+        (applyCoercions-id-ℕ-applyCoercions χsN χsL)
+        (applyTys-ℕ-applyTys χsN χsL)
+        (applyTys-ℕ-applyTys χsN χsL)
+        W⊒M′
+
+    WN≡target : WN ≡ $ (κℕ n′)
+    WN≡target =
+      value-normalized-id-ℕ-target-const
+        vWN
+        (applyTerms-const χsN (κℕ n′))
+        (applyCoercions-id-ℕ χsN)
+        (applyTys-ℕ χsN)
+        (applyTys-ℕ χsN)
+        WN⊒N′
+
+    source-δ :
+      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step
+        {χsL = []} {χsR = χsL}
+        W≡target
+        WN≡target
+
+    χs : StoreChanges
+    χs = (χsN ++ χsL) ++ keep ∷ []
+
+    Δ′ : TyCtx
+    Δ′ = ΔL
+
+    Π : Store
+    Π = srcStoreⁿ (combineStoreNrw πL πN)
+
+    Π′ : Store
+    Π′ = []
+
+    π : StoreNrw
+    π = combineStoreNrw πL πN
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    Π≡ : Π ≡ applyStores χs []
+    Π≡ =
+      trans
+        (combineStoreNrw-applyStores
+          {χs₂ = χsL} {χs₁ = χsN}
+          πL⊒
+          ΠL≡
+          ΠL′≡
+          πN⊒
+          ΠN≡
+          ΠN′≡)
+        (sym (applyStores-++ (χsN ++ χsL) (keep ∷ []) []))
+
+    Π′≡ : Π′ ≡ applyStore keep []
+    Π′≡ = refl
+
+    πN⊒-empty : Δ′ ⊢ πN ꞉ ΠN ⊒ˢ []
+    πN⊒-empty =
+      ⊒ˢ-empty-anyᵗ Δ′
+        (subst (λ Π₀ → ΔN ⊢ πN ꞉ ΠN ⊒ˢ Π₀) ΠN′≡ πN⊒)
+
+    πL⊒-empty :
+      Δ′ ⊢ πL ꞉ ΠL ⊒ˢ []
+    πL⊒-empty =
+      subst
+        (λ Π₀ → Δ′ ⊢ πL ꞉ ΠL ⊒ˢ Π₀)
+        ΠL′≡
+        πL⊒
+
+    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
+    π⊒ =
+      combineStoreNrw-empty-⊒ˢ
+        πL⊒-empty
+        πN⊒-empty
+
+    result⊒ :
+      Δ′ ∣ combineStoreNrw π σ ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ
+        (κℕ (m′ + n′))
+        {typing =
+          term-typing-endpoints
+            (⊢$ (κℕ (m′ + n′)))
+            (⊢$ (κℕ (m′ + n′)))}
+  in
+  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
+  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
+  source-steps ,
+  Π≡ ,
+  Π′≡ ,
+  π⊒ ,
+  result⊒
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
     (⊒cast+ᵗ {s = id A} q₀ᶜ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
@@ -252,7 +1212,7 @@ dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
     (pure-step (β-id vV))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
-  {!!}
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
     (⊒cast-ᵗ {s = id A} q₀ᶜ rᶜ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
@@ -262,5 +1222,5 @@ dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
     (pure-step (β-id vV))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
-  {!!}
-dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ M⊒M′ M′→N′ = {!!}
+  {! ? !}
+dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ M⊒M′ M′→N′ = {! ? !}

--- a/GTSF/proof/NuTermProperties.agda
+++ b/GTSF/proof/NuTermProperties.agda
@@ -326,6 +326,23 @@ renameᵗᵐ-preserves-Value ρ ($ κ) = $ κ
 renameᵗᵐ-preserves-Value ρ (vV ⟨ i ⟩) =
   renameᵗᵐ-preserves-Value ρ vV ⟨ renameᶜ-preserves-Inert ρ i ⟩
 
+renameᵗᵐ-reflects-Value :
+  ∀ ρ V →
+  Value (renameᵗᵐ ρ V) →
+  Value V
+renameᵗᵐ-reflects-Value ρ (` x) ()
+renameᵗᵐ-reflects-Value ρ (ƛ N) vV = ƛ N
+renameᵗᵐ-reflects-Value ρ (L · M) ()
+renameᵗᵐ-reflects-Value ρ (Λ V) (Λ vV) =
+  Λ (renameᵗᵐ-reflects-Value (extᵗ ρ) V vV)
+renameᵗᵐ-reflects-Value ρ (M •) ()
+renameᵗᵐ-reflects-Value ρ (ν A L c) ()
+renameᵗᵐ-reflects-Value ρ ($ κ) vV = $ κ
+renameᵗᵐ-reflects-Value ρ (L ⊕[ op ] M) ()
+renameᵗᵐ-reflects-Value ρ (V ⟨ c ⟩) (vV ⟨ i ⟩) =
+  renameᵗᵐ-reflects-Value ρ V vV ⟨ renameᶜ-reflects-Inert ρ c i ⟩
+renameᵗᵐ-reflects-Value ρ blame ()
+
 renameˣᵐ-preserves-Value :
   ∀ ρ {V} →
   Value V →

--- a/GTSF/proof/ReductionProperties.agda
+++ b/GTSF/proof/ReductionProperties.agda
@@ -12,12 +12,13 @@ open import Data.Empty using (⊥-elim)
 open import Data.List using ([]; _∷_; _++_)
 open import Data.Nat using (ℕ; _≤_; zero; suc)
 open import Data.Nat.Properties using (≤-refl; ≤-trans; n≤1+n; suc-injective)
-open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Product using (Σ; _×_; _,_; ∃-syntax; proj₁)
 open import Relation.Binary.PropositionalEquality
   using (_≢_; cong; cong₂; subst; sym; trans)
 
 open import Types
 open import Coercions
+open import Primitives using (Const)
 open import NuTerms
 open import NuReduction
 open import proof.CoercionProperties
@@ -251,6 +252,24 @@ applyTys-★ :
 applyTys-★ [] = refl
 applyTys-★ (χ ∷ χs) rewrite applyTy-★ χ = applyTys-★ χs
 
+applyTy-ℕ :
+  ∀ χ →
+  applyTy χ (‵ `ℕ) ≡ ‵ `ℕ
+applyTy-ℕ keep = refl
+applyTy-ℕ (bind A) = refl
+
+applyTys-ℕ :
+  ∀ χs →
+  applyTys χs (‵ `ℕ) ≡ ‵ `ℕ
+applyTys-ℕ [] = refl
+applyTys-ℕ (χ ∷ χs) rewrite applyTy-ℕ χ = applyTys-ℕ χs
+
+applyTys-ℕ-applyTys :
+  ∀ χs χs′ →
+  applyTys χs′ (applyTys χs (‵ `ℕ)) ≡ ‵ `ℕ
+applyTys-ℕ-applyTys χs χs′ =
+  trans (cong (applyTys χs′) (applyTys-ℕ χs)) (applyTys-ℕ χs′)
+
 applyTerms-empty-id :
   ∀ χs →
   applyStores χs [] ≡ [] →
@@ -429,6 +448,13 @@ applyTerms-preserves-No• :
 applyTerms-preserves-No• [] noM = noM
 applyTerms-preserves-No• (χ ∷ χs) noM =
   applyTerms-preserves-No• χs (applyTerm-preserves-No• χ noM)
+
+applyTerms-const :
+  ∀ χs κ →
+  applyTerms χs ($ κ) ≡ $ κ
+applyTerms-const [] κ = refl
+applyTerms-const (keep ∷ χs) κ = applyTerms-const χs κ
+applyTerms-const (bind A ∷ χs) κ = applyTerms-const χs κ
 
 applyTermUnderTyBinder : StoreChange → Term → Term
 applyTermUnderTyBinder keep M = M
@@ -933,6 +959,141 @@ type-rename-step-⇑ᵗᵐ red =
   M —↠[ χs ++ χs′ ] P
 ↠-trans ↠-refl N↠P = N↠P
 ↠-trans (↠-step M→N N↠P) P↠Q = ↠-step M→N (↠-trans N↠P P↠Q)
+
+applyFrameChanges :
+  ∀ {Frame : Set} →
+  (StoreChange → Frame → Frame) →
+  StoreChanges →
+  Frame →
+  Frame
+applyFrameChanges applyFrame [] F = F
+applyFrameChanges applyFrame (χ ∷ χs) F =
+  applyFrameChanges applyFrame χs (applyFrame χ F)
+
+frame-↠ :
+  ∀ {Frame : Set}
+    (plug : Frame → Term → Term)
+    (applyFrame : StoreChange → Frame → Frame) →
+  (∀ {F M N χ} →
+    M —→[ χ ] N →
+    plug F M —→[ χ ] plug (applyFrame χ F) N) →
+  ∀ {F M N χs} →
+  M —↠[ χs ] N →
+  plug F M —↠[ χs ] plug (applyFrameChanges applyFrame χs F) N
+frame-↠ plug applyFrame lift-step ↠-refl = ↠-refl
+frame-↠ plug applyFrame lift-step (↠-step red reds) =
+  ↠-step (lift-step red) (frame-↠ plug applyFrame lift-step reds)
+
+shiftable-No• :
+  ∀ {χ M} →
+  No• M →
+  Shiftable χ M
+shiftable-No• {χ = keep} noM = shift-keep
+shiftable-No• {χ = bind A} noM = shift-bind noM
+
+No•Frame : Set
+No•Frame = Σ Term No•
+
+applyNo•Frame : StoreChange → No•Frame → No•Frame
+applyNo•Frame χ (M , noM) =
+  applyTerm χ M , applyTerm-preserves-No• χ noM
+
+applyNo•Frame-term :
+  ∀ χs F →
+  proj₁ (applyFrameChanges applyNo•Frame χs F) ≡
+    applyTerms χs (proj₁ F)
+applyNo•Frame-term [] F = refl
+applyNo•Frame-term (χ ∷ χs) (M , noM) =
+  applyNo•Frame-term χs
+    (applyTerm χ M , applyTerm-preserves-No• χ noM)
+
+ValueFrame : Set
+ValueFrame = Σ Term (λ V → Value V × No• V)
+
+applyValueFrame : StoreChange → ValueFrame → ValueFrame
+applyValueFrame χ (V , vV , noV) =
+  applyTerm χ V ,
+  applyTerm-preserves-Value χ vV ,
+  applyTerm-preserves-No• χ noV
+
+applyValueFrame-term :
+  ∀ χs F →
+  proj₁ (applyFrameChanges applyValueFrame χs F) ≡
+    applyTerms χs (proj₁ F)
+applyValueFrame-term [] F = refl
+applyValueFrame-term (χ ∷ χs) (V , vV , noV) =
+  applyValueFrame-term χs
+    (applyTerm χ V ,
+     applyTerm-preserves-Value χ vV ,
+     applyTerm-preserves-No• χ noV)
+
+·₁-↠ :
+  ∀ {L W M χs} →
+  No• M →
+  L —↠[ χs ] W →
+  L · M —↠[ χs ] W · applyTerms χs M
+·₁-↠ {L = L} {W = W} {M = M} {χs = χs} noM L↠W =
+  subst
+    (λ M′ → L · M —↠[ χs ] W · M′)
+    (applyNo•Frame-term χs (M , noM))
+    (frame-↠
+      (λ { (M′ , noM′) L′ → L′ · M′ })
+      applyNo•Frame
+      (λ { {F = M′ , noM′} red → ξ-·₁ red (shiftable-No• noM′) })
+      {F = M , noM}
+      L↠W)
+
+·₂-↠ :
+  ∀ {V M W χs} →
+  Value V →
+  No• V →
+  M —↠[ χs ] W →
+  V · M —↠[ χs ] applyTerms χs V · W
+·₂-↠ {V = V} {M = M} {W = W} {χs = χs} vV noV M↠W =
+  subst
+    (λ V′ → V · M —↠[ χs ] V′ · W)
+    (applyValueFrame-term χs (V , vV , noV))
+    (frame-↠
+      (λ { (V′ , vV′ , noV′) M′ → V′ · M′ })
+      applyValueFrame
+      (λ { {F = V′ , vV′ , noV′} red →
+        ξ-·₂ vV′ (shiftable-No• noV′) red })
+      {F = V , vV , noV}
+      M↠W)
+
+⊕₁-↠ :
+  ∀ {L W M op χs} →
+  No• M →
+  L —↠[ χs ] W →
+  L ⊕[ op ] M —↠[ χs ] W ⊕[ op ] applyTerms χs M
+⊕₁-↠ {L = L} {W = W} {M = M} {op = op} {χs = χs} noM L↠W =
+  subst
+    (λ M′ → L ⊕[ op ] M —↠[ χs ] W ⊕[ op ] M′)
+    (applyNo•Frame-term χs (M , noM))
+    (frame-↠
+      (λ { (M′ , noM′) L′ → L′ ⊕[ op ] M′ })
+      applyNo•Frame
+      (λ { {F = M′ , noM′} red → ξ-⊕₁ red (shiftable-No• noM′) })
+      {F = M , noM}
+      L↠W)
+
+⊕₂-↠ :
+  ∀ {V M W op χs} →
+  Value V →
+  No• V →
+  M —↠[ χs ] W →
+  V ⊕[ op ] M —↠[ χs ] applyTerms χs V ⊕[ op ] W
+⊕₂-↠ {V = V} {M = M} {W = W} {op = op} {χs = χs} vV noV M↠W =
+  subst
+    (λ V′ → V ⊕[ op ] M —↠[ χs ] V′ ⊕[ op ] W)
+    (applyValueFrame-term χs (V , vV , noV))
+    (frame-↠
+      (λ { (V′ , vV′ , noV′) M′ → V′ ⊕[ op ] M′ })
+      applyValueFrame
+      (λ { {F = V′ , vV′ , noV′} red →
+        ξ-⊕₂ vV′ (shiftable-No• noV′) red })
+      {F = V , vV , noV}
+      M↠W)
 
 cast-↠ :
   ∀ {M N c χs} →


### PR DESCRIPTION
## Summary

Develops the GTSF dynamic gradual guarantee proof around the `⊕⊒⊕ᵗ` / `δ-⊕` case. The branch adds the catch-up/framing skeleton for all `RuntimeOK` splits, proves the completed arithmetic result narrowing once both operands are canonical naturals, and keeps the remaining sibling operand transport obligations as explicit `?` holes.

Supporting proof infrastructure includes:

- rename reflection lemmas for inert coercions and term values;
- store-change application facts for natural types and constants;
- general multi-step framing lemmas for application and primitive-operation frames;
- explicit blame endpoint witnesses in the DGG skeleton to avoid hidden Agda metas.

The PR intentionally does not include unrelated untracked scratch/worktree files from the local checkout.

## Validation

- `agda -v0 proof/DynamicGradualGuarantee.agda` from `GTSF/`

`DynamicGradualGuarantee.agda` currently has `--allow-unsolved-metas` enabled, so this validates the developed skeleton while preserving the remaining planned proof holes.