### PR TITLE
[codex] Derive cast narrowing rules and inline composition witnesses

### DIFF
--- a/GTSF/NarrowWiden.agda
+++ b/GTSF/NarrowWiden.agda
@@ -593,6 +593,7 @@ _∣_⊢_∶_⊒_ : TyCtx → Store → Coercion → Ty → Ty → Set
 Δ ∣ Σ ⊢ c ∶ A ⊒ B =
   ∃[ μ ] μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B
 
+-- For p's and q's
 infix 4 _∣_⊢_∶ᶜ_⊒_
 
 _∣_⊢_∶ᶜ_⊒_ : TyCtx → Store → Coercion → Ty → Ty → Set

--- a/GTSF/NarrowWidenComposition.agda
+++ b/GTSF/NarrowWidenComposition.agda
@@ -2,7 +2,8 @@
 
 -- File Charter:
 --   * Public composition operators for well-typed narrowings and widenings.
---   * Exposes term-narrowing side conditions for narrowing composition.
+--   * Exposes raw narrowing/widening composition witnesses used directly by
+--     term-narrowing side conditions.
 --   * Depends on `NarrowWiden` plus proof-only exclusion lemmas needed for
 --     coverage under the `StoreDetWf` invariant.
 --   * The positive strict grammar needs explicit indexed-impossible coverage
@@ -709,34 +710,3 @@ mutual
   _⨟ᶜʷ_ {wfΣ = wfΣ}
       (cast-all s⊢ , `∀ sʷ) (cast-all t⊢ , `∀ tʷ) | u , u⊑ =
     _ , (cast-all (proj₁ u⊑) , `∀ (proj₂ u⊑))
-
-------------------------------------------------------------------------
--- Term-narrowing cast side-condition composition
-------------------------------------------------------------------------
-
-infix 4 _∣_⊢_⨾ⁿ_≈_∶_⊒_
-infix 4 _∣_⊢_≈_⨾ⁿ_∶_⊒_
-
-data _∣_⊢_⨾ⁿ_≈_∶_⊒_ :
-    TyCtx → StoreNrw → Coercion → Coercion → Coercion →
-    Ty → Ty → Set₁ where
-
-  compose-leftⁿ : ∀ {Δ σ Σ μ A B C q s r}
-    → (wfΣ : StoreDetWf Δ Σ)
-    → (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C)
-    → (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ C ⊒ B)
-    → Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B
-     --------------------------------
-    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
-
-data _∣_⊢_≈_⨾ⁿ_∶_⊒_ :
-    TyCtx → StoreNrw → Coercion → Coercion → Coercion →
-    Ty → Ty → Set₁ where
-
-  compose-rightⁿ : ∀ {Δ σ Σ μ A B C r t p}
-    → (wfΣ : StoreDetWf Δ Σ)
-    → (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ C)
-    → (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ C ⊒ B)
-    → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B
-     --------------------------------
-    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B

--- a/GTSF/NarrowingExamples.agda
+++ b/GTSF/NarrowingExamples.agda
@@ -29,6 +29,7 @@ open import NarrowWiden
 open import NarrowWidenComposition
 open import TermNarrowing
 open import proof.NarrowWidenProperties using (StoreDetWf)
+open import proof.TermNarrowingProperties using (cast+⊒cast+-derivedᵗ)
 
 ------------------------------------------------------------------------
 -- Shared syntax from cambridge23 Examples 1 and 6
@@ -408,17 +409,18 @@ ex1-line272-⨟ =
 ex1-line272-≈ : ∀ {Δ} →
   Δ ∣ [] ⊢
     gen (★ ⇒ ★) var0-fun
-      ≈ gen (★ ⇒ ★) var0-fun ⨾ⁿ `∀ (id (＇ 0) ↦ id (＇ 0))
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = empty-store-det}
+          poly-fun-narrowingᵐ
+          (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ}))
       ∶ (★ ⇒ ★) ⊒ `∀ (＇ 0 ⇒ ＇ 0)
 ex1-line272-≈ =
-  compose-rightⁿ empty-store-det poly-fun⊒ forall-id-var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      empty-store-narrowing
-      wf-poly-fun-endpoints
-      wf-poly-fun-endpoints
-      poly-fun-narrowing
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
-        poly-fun⊒ forall-id-var0-fun⊒)))
+  endpointsⁿ refl refl refl refl
+    empty-store-narrowing
+    wf-poly-fun-endpoints
+    wf-poly-fun-endpoints
+    poly-fun-narrowing
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
+      poly-fun⊒ forall-id-var0-fun⊒))
   where
     poly-fun⊒ = poly-fun-narrowingᵐ
 
@@ -432,7 +434,10 @@ ex1-cast- :
       ⊒ Λ (ƛ (` 0))
     ∶ `∀ (id (＇ 0) ↦ id (＇ 0)) ⦂ _ ⊒ _
 ex1-cast- =
-  cast-⊒ᵗ forall-id-var0-fun-cast ex1-line272-≈ ex1-⊒Λ
+  cast-⊒ᵗ forall-id-var0-fun-cast empty-store-det
+    poly-fun-narrowingᵐ
+    (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ})
+    ex1-line272-≈ ex1-⊒Λ
 
 ex1-initial :
   0 ∣ [] ∣ []
@@ -447,7 +452,10 @@ ex1-initial =
     {p = `∀ (id (＇ 0) ↦ id (＇ 0))}
     {r = gen (★ ⇒ ★) var0-fun}
     {t = gen (★ ⇒ ★) var0-fun}
-    forall-id-var0-fun-cast poly-fun-cast ex1-line272-≈ ex1-cast-
+    forall-id-var0-fun-cast poly-fun-cast empty-store-det
+    poly-fun-narrowingᵐ
+    (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ})
+    ex1-line272-≈ ex1-cast-
 
 -- cambridge23 line 293 side condition (iii), at the raw-composition level.
 ex1-line293-⨟ :
@@ -459,17 +467,19 @@ ex1-line293-⨟ =
 
 ex1-line293-≈ :
   1 ∣ (0 ꞉ id ★) ∷ [] ⊢
-    var0-fun ≈ var0-fun ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+    var0-fun
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = star-store-det}
+          var0-fun-narrowingᵐ
+          (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex1-line293-≈ =
-  compose-rightⁿ star-store-det var0-fun⊒ id-var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      id★-store-narrowing
-      wf-var-fun-endpoints
-      wf-var-fun-endpoints
-      var0-fun-narrowing
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
-        var0-fun⊒ id-var0-fun⊒)))
+  endpointsⁿ refl refl refl refl
+    id★-store-narrowing
+    wf-var-fun-endpoints
+    wf-var-fun-endpoints
+    var0-fun-narrowing
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
+      var0-fun⊒ id-var0-fun⊒))
   where
     var0-fun⊒ = var0-fun-narrowingᵐ
 
@@ -485,17 +495,19 @@ ex1-line294-⨟ =
 
 ex1-line294-≈ :
   1 ∣ (0 ꞉ id ★) ∷ [] ⊢
-    var0-fun ≈ star-seal-fun ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+    var0-fun
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = star-store-det}
+          star-seal-fun-narrowingᵐ
+          (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex1-line294-≈ =
-  compose-rightⁿ star-store-det star-seal-fun⊒ id-var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      id★-store-narrowing
-      wf-var-fun-endpoints
-      wf-var-fun-endpoints
-      var0-fun-narrowing
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
-        star-seal-fun⊒ id-var0-fun⊒)))
+  endpointsⁿ refl refl refl refl
+    id★-store-narrowing
+    wf-var-fun-endpoints
+    wf-var-fun-endpoints
+    var0-fun-narrowing
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
+      star-seal-fun⊒ id-var0-fun⊒))
   where
     star-seal-fun⊒ = star-seal-fun-narrowingᵐ
 
@@ -515,7 +527,10 @@ ex1-inner-cast- :
       ⊒ ƛ (` 0)
     ∶ id (＇ 0) ↦ id (＇ 0) ⦂ _ ⊒ _
 ex1-inner-cast- =
-  cast-⊒ᵗ id-var0-fun-cast ex1-line293-≈ ex1-inner-⊒Λ-premise
+  cast-⊒ᵗ id-var0-fun-cast star-store-det
+    var0-fun-narrowingᵐ
+    (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl)
+    ex1-line293-≈ ex1-inner-⊒Λ-premise
 
 ex1-inner-cast+ :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
@@ -527,7 +542,10 @@ ex1-inner-cast+ =
     {p = id (＇ 0) ↦ id (＇ 0)}
     {r = var0-fun}
     {t = star-seal-fun}
-    id-var0-fun-cast var0-fun-cast ex1-line294-≈ ex1-inner-cast-
+    id-var0-fun-cast var0-fun-cast star-store-det
+    star-seal-fun-narrowingᵐ
+    (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl)
+    ex1-line294-≈ ex1-inner-cast-
 
 ex1-split :
   1 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
@@ -608,21 +626,20 @@ ex2-line307-≈ rewrite ex2-line307-left-⨟ | ex1-line272-⨟ =
 
 ex2-line303-right-≈ :
   0 ∣ [] ⊢
-    (id ★ ↦ id ★)
-      ⨾ⁿ gen (★ ⇒ ★)
-          var0-fun
+    proj₁ (_⨟ⁿ_ {wfΣ = empty-store-det}
+      (id★-fun-narrowingᵐ {μ = id-onlyᵈ})
+      poly-fun-narrowingᵐ)
       ≈ gen (★ ⇒ ★)
           var0-fun
       ∶ (★ ⇒ ★) ⊒ `∀ (＇ 0 ⇒ ＇ 0)
 ex2-line303-right-≈ =
-  compose-leftⁿ empty-store-det id★-fun⊒ poly-fun⊒
-    (endpointsⁿ refl refl refl refl
-      empty-store-narrowing
-      wf-poly-fun-endpoints
-      wf-poly-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
-        id★-fun⊒ poly-fun⊒))
-      poly-fun-narrowing)
+  endpointsⁿ refl refl refl refl
+    empty-store-narrowing
+    wf-poly-fun-endpoints
+    wf-poly-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
+      id★-fun⊒ poly-fun⊒))
+    poly-fun-narrowing
   where
     id★-fun⊒ = id★-fun-narrowingᵐ {μ = id-onlyᵈ}
 
@@ -637,7 +654,10 @@ ex2-right-cast :
     ∶ gen (★ ⇒ ★)
         var0-fun ⦂ _ ⊒ _
 ex2-right-cast =
-  ⊒cast-ᵗ id★-fun-cast poly-fun-cast ex2-line303-right-≈ ex2-id
+  ⊒cast-ᵗ id★-fun-cast poly-fun-cast empty-store-det
+    (id★-fun-narrowingᵐ {μ = id-onlyᵈ})
+    poly-fun-narrowingᵐ
+    ex2-line303-right-≈ ex2-id
 
 ex2-line303 :
   0 ∣ [] ∣ []
@@ -649,7 +669,10 @@ ex2-line303 :
             var0-fun ⟩
     ∶ `∀ (id (＇ 0) ↦ id (＇ 0)) ⦂ _ ⊒ _
 ex2-line303 =
-  cast-⊒ᵗ forall-id-var0-fun-cast ex1-line272-≈ ex2-right-cast
+  cast-⊒ᵗ forall-id-var0-fun-cast empty-store-det
+    poly-fun-narrowingᵐ
+    (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ})
+    ex1-line272-≈ ex2-right-cast
 
 ex2-initial :
   0 ∣ [] ∣ []
@@ -670,7 +693,10 @@ ex2-initial =
       var0-fun}
     {t = gen (★ ⇒ ★)
       var0-fun}
-    forall-id-var0-fun-cast poly-fun-cast ex1-line272-≈ ex2-line303
+    forall-id-var0-fun-cast poly-fun-cast empty-store-det
+    poly-fun-narrowingᵐ
+    (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ})
+    ex1-line272-≈ ex2-line303
 
 ex2-inner-id :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
@@ -690,19 +716,19 @@ ex2-line316-left-⨟ =
 
 ex2-line316-right-≈ :
   1 ∣ (0 ꞉ id ★) ∷ [] ⊢
-    (id ★ ↦ id ★)
-      ⨾ⁿ var0-fun
+    proj₁ (_⨟ⁿ_ {wfΣ = star-store-det}
+      (id★-fun-narrowingᵐ {μ = tag-or-idᵈ})
+      var0-fun-narrowingᵐ)
       ≈ var0-fun
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex2-line316-right-≈ =
-  compose-leftⁿ star-store-det id★-fun⊒ var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      id★-store-narrowing
-      wf-var-fun-endpoints
-      wf-var-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
-        id★-fun⊒ var0-fun⊒))
-      var0-fun-narrowing)
+  endpointsⁿ refl refl refl refl
+    id★-store-narrowing
+    wf-var-fun-endpoints
+    wf-var-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
+      id★-fun⊒ var0-fun⊒))
+    var0-fun-narrowing
   where
     id★-fun⊒ = id★-fun-narrowingᵐ {μ = tag-or-idᵈ}
 
@@ -714,8 +740,10 @@ ex2-inner-right-cast :
       ⊒ (ƛ (` 0)) ⟨ var0-fun ⟩
     ∶ var0-fun ⦂ _ ⊒ _
 ex2-inner-right-cast =
-  ⊒cast-ᵗ id★-fun-cast var0-fun-cast ex2-line316-right-≈
-    ex2-inner-id
+  ⊒cast-ᵗ id★-fun-cast var0-fun-cast star-store-det
+    (id★-fun-narrowingᵐ {μ = tag-or-idᵈ})
+    var0-fun-narrowingᵐ
+    ex2-line316-right-≈ ex2-inner-id
 
 ex2-line316 :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
@@ -723,7 +751,10 @@ ex2-line316 :
       ⊒ (ƛ (` 0)) ⟨ var0-fun ⟩
     ∶ id (＇ 0) ↦ id (＇ 0) ⦂ _ ⊒ _
 ex2-line316 =
-  cast-⊒ᵗ id-var0-fun-cast ex1-line293-≈ ex2-inner-right-cast
+  cast-⊒ᵗ id-var0-fun-cast star-store-det
+    var0-fun-narrowingᵐ
+    (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl)
+    ex1-line293-≈ ex2-inner-right-cast
 
 ex2-line318 :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
@@ -735,7 +766,10 @@ ex2-line318 =
     {p = id (＇ 0) ↦ id (＇ 0)}
     {r = var0-fun}
     {t = star-seal-fun}
-    id-var0-fun-cast var0-fun-cast ex1-line294-≈ ex2-line316
+    id-var0-fun-cast var0-fun-cast star-store-det
+    star-seal-fun-narrowingᵐ
+    (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl)
+    ex1-line294-≈ ex2-line316
 
 ex2-split :
   1 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
@@ -815,17 +849,19 @@ ex3-line331-⨟ =
 
 ex3-line331-≈ :
   1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ [] ⊢
-    base-fun `ℕ ⨾ⁿ base-seal-step-fun `ℕ ≈ var0-fun
+    proj₁ (_⨟ⁿ_ {wfΣ = base-store-det}
+      (base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `ℕ})
+      (base-seal-step-fun-narrowingᵐ {ι = `ℕ}))
+      ≈ var0-fun
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex3-line331-≈ =
-  compose-leftⁿ base-store-det base-fun⊒ base-seal-step-fun⊒
-    (endpointsⁿ refl refl refl refl
-      idBase-store-narrowing
-      wf-store-var-fun-endpoints
-      wf-store-var-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
-        base-fun⊒ base-seal-step-fun⊒))
-      var0-fun-narrowing)
+  endpointsⁿ refl refl refl refl
+    idBase-store-narrowing
+    wf-store-var-fun-endpoints
+    wf-store-var-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
+      base-fun⊒ base-seal-step-fun⊒))
+    var0-fun-narrowing
   where
     base-fun⊒ =
       base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `ℕ}
@@ -845,6 +881,9 @@ ex3-line331 =
     {r = var0-fun}
     {s = base-seal-step-fun `ℕ}
     base-fun-cast
+    base-store-det
+    (base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `ℕ})
+    (base-seal-step-fun-narrowingᵐ {ι = `ℕ})
     ex3-line331-≈
     ex3-line329-extend
 
@@ -875,7 +914,10 @@ ex4-initial =
       var0-fun}
     {t = gen (★ ⇒ ★)
       var0-fun}
-    forall-id-var0-fun-cast poly-fun-cast ex1-line272-≈ ex4-poly-id
+    forall-id-var0-fun-cast poly-fun-cast empty-store-det
+    poly-fun-narrowingᵐ
+    (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ})
+    ex1-line272-≈ ex4-poly-id
 
 ex4-line352 :
   1 ∣ (0 ꞉ id ★) ∷ [] ∣ []
@@ -895,7 +937,10 @@ ex4-line353 =
     {p = id (＇ 0) ↦ id (＇ 0)}
     {r = var0-fun}
     {t = star-seal-fun}
-    id-var0-fun-cast var0-fun-cast ex1-line294-≈ ex4-line352
+    id-var0-fun-cast var0-fun-cast star-store-det
+    star-seal-fun-narrowingᵐ
+    (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl)
+    ex1-line294-≈ ex4-line352
 
 ex4-split :
   1 ∣ (0 ꞉= ★ ⊒) ∷ (⊒ 1 ꞉=☆) ∷ [] ∣ []
@@ -948,19 +993,19 @@ ex5-line380-⨟ =
 
 ex5-line380-≈ :
   0 ∣ [] ⊢
-    (id ★ ↦ id ★)
-      ⨾ⁿ base-fun `𝔹
+    proj₁ (_⨟ⁿ_ {wfΣ = empty-store-det}
+      (id★-fun-narrowingᵐ {μ = tag-or-idᵈ})
+      (base-fun-narrowingᵐ {μ = tag-or-idᵈ} {ι = `𝔹}))
       ≈ base-fun `𝔹
       ∶ (★ ⇒ ★) ⊒ (‵ `𝔹 ⇒ ‵ `𝔹)
 ex5-line380-≈ =
-  compose-leftⁿ empty-store-det id★-fun⊒ base-fun⊒
-    (endpointsⁿ refl refl refl refl
-      empty-store-narrowing
-      wf-base-fun-endpoints
-      wf-base-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
-        id★-fun⊒ base-fun⊒))
-      base-fun-narrowing)
+  endpointsⁿ refl refl refl refl
+    empty-store-narrowing
+    wf-base-fun-endpoints
+    wf-base-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
+      id★-fun⊒ base-fun⊒))
+    base-fun-narrowing
   where
     id★-fun⊒ = id★-fun-narrowingᵐ {μ = tag-or-idᵈ}
 
@@ -989,6 +1034,9 @@ ex5-function-cast =
     {A = ★ ⇒ ★}
     {B = ‵ `𝔹 ⇒ ‵ `𝔹}
     id★-fun-cast
+    empty-store-det
+    (id★-fun-narrowingᵐ {μ = tag-or-idᵈ})
+    (base-fun-narrowingᵐ {μ = tag-or-idᵈ} {ι = `𝔹})
     ex5-line380-≈ ex5-function-base
 
 -- cambridge23 Example 5, argument-side premise, using the barred two-sided
@@ -1002,27 +1050,31 @@ ex5-c★ =
     {r = base-untag `ℕ}
     {s = base-untag `ℕ}
     id★-cast
-    (compose-leftⁿ empty-store-det id★⊒ base-untag⊒
-      (endpointsⁿ refl refl refl refl
-        empty-store-narrowing
-        wf★-base-endpoints
-        wf★-base-endpoints
-        (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det} id★⊒ base-untag⊒))
-        base-untag-narrowing))
+    empty-store-det
+    id★⊒
+    base-untag⊒
+    (endpointsⁿ refl refl refl refl
+      empty-store-narrowing
+      wf★-base-endpoints
+      wf★-base-endpoints
+      (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det} id★⊒ base-untag⊒))
+      base-untag-narrowing)
     (cast+⊒ᵗ
       {p = id (‵ `ℕ)}
       {r = base-untag `ℕ}
       {t = base-untag `ℕ}
       id-base-cast
       base-untag-cast
-      (compose-rightⁿ empty-store-det base-untag⊒ id-base⊒
-        (endpointsⁿ refl refl refl refl
-          empty-store-narrowing
-          wf★-base-endpoints
-          wf★-base-endpoints
-          base-untag-narrowing
-          (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
-            base-untag⊒ id-base⊒))))
+      empty-store-det
+      base-untag⊒
+      id-base⊒
+      (endpointsⁿ refl refl refl refl
+        empty-store-narrowing
+        wf★-base-endpoints
+        wf★-base-endpoints
+        base-untag-narrowing
+        (_ , proj₂ (_⨟ⁿ_ {wfΣ = empty-store-det}
+          base-untag⊒ id-base⊒)))
       (κ⊒κᵗ (κℕ 0)))
   where
     id★⊒ = id★-narrowingᵐ {μ = tag-or-idᵈ}
@@ -1082,17 +1134,19 @@ ex6-line405-⨟ =
 -- exact `α:=ι` assumption.
 ex6-line405-≈ :
   1 ∣ (0 ꞉= ‵ `𝔹 ⊒) ∷ [] ⊢
-    base-fun `𝔹 ⨾ⁿ base-seal-step-fun `𝔹 ≈ var0-fun
+    proj₁ (_⨟ⁿ_ {wfΣ = base-store-det}
+      (base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `𝔹})
+      (base-seal-step-fun-narrowingᵐ {ι = `𝔹}))
+      ≈ var0-fun
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex6-line405-≈ =
-  compose-leftⁿ base-store-det base-fun⊒ base-seal-step-fun⊒
-    (endpointsⁿ refl refl refl refl
-      base-right-store-narrowing
-      wf-var-fun-endpoints
-      wf-var-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
-        base-fun⊒ base-seal-step-fun⊒))
-      var0-fun-narrowing)
+  endpointsⁿ refl refl refl refl
+    base-right-store-narrowing
+    wf-var-fun-endpoints
+    wf-var-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
+      base-fun⊒ base-seal-step-fun⊒))
+    var0-fun-narrowing
   where
     base-fun⊒ =
       base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `𝔹}
@@ -1113,6 +1167,9 @@ ex6-line405 =
     {r = var0-fun}
     {s = base-seal-step-fun `𝔹}
     (base-fun-cast {ι = `𝔹})
+    base-store-det
+    (base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `𝔹})
+    (base-seal-step-fun-narrowingᵐ {ι = `𝔹})
     ex6-line405-≈
     ex6-open-ν𝔹
 
@@ -1145,6 +1202,9 @@ ex6-line407 =
     {A = ★ ⇒ ★}
     {B = ‵ `𝔹 ⇒ ‵ `𝔹}
     id★-fun-cast
+    empty-store-det
+    (id★-fun-narrowingᵐ {μ = tag-or-idᵈ})
+    (base-fun-narrowingᵐ {μ = tag-or-idᵈ} {ι = `𝔹})
     ex5-line380-≈
     ex6-line407-ν
 
@@ -1198,7 +1258,10 @@ ex7-line710 :
       ⊒ Λ (ƛ (` 0))
     ∶ `∀ (id (＇ 0) ↦ id (＇ 0)) ⦂ _ ⊒ _
 ex7-line710 =
-  cast-⊒ᵗ forall-id-var0-fun-cast ex1-line272-≈ ex7-line708
+  cast-⊒ᵗ forall-id-var0-fun-cast empty-store-det
+    poly-fun-narrowingᵐ
+    (forall-id-var0-fun-narrowingᵐ {μ = id-onlyᵈ})
+    ex1-line272-≈ ex7-line708
 
 -- cambridge25 Example 7, line 712.
 ex7-line712 : ∀ {ι} →
@@ -1214,18 +1277,19 @@ ex7-line712 {ι = ι} =
 
 ex7-downcast-left-≈ : ∀ {Δ ι} →
   suc Δ ∣ (0 ꞉ id (‵ ι)) ∷ [] ⊢
-    (id (‵ ι) ↦ id (‵ ι)) ⨾ⁿ base-seal-step-fun ι
+    proj₁ (_⨟ⁿ_ {wfΣ = base-store-det}
+      (id-base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = ι})
+      (base-seal-step-fun-narrowingᵐ {ι = ι}))
       ≈ base-seal-step-fun ι
       ∶ (‵ ι ⇒ ‵ ι) ⊒ (＇ 0 ⇒ ＇ 0)
 ex7-downcast-left-≈ {ι = ι} =
-  compose-leftⁿ base-store-det id-base-fun⊒ base-seal-step-fun⊒
-    (endpointsⁿ refl refl refl refl
-      idBase-store-narrowing
-      wf-base-store-var-fun-endpoints
-      wf-base-store-var-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
-        id-base-fun⊒ base-seal-step-fun⊒))
-      (seal-or-idᵈ , base-seal-step-fun⊒))
+  endpointsⁿ refl refl refl refl
+    idBase-store-narrowing
+    wf-base-store-var-fun-endpoints
+    wf-base-store-var-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
+      id-base-fun⊒ base-seal-step-fun⊒))
+    (seal-or-idᵈ , base-seal-step-fun⊒)
   where
     id-base-fun⊒ = id-base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = ι}
 
@@ -1235,17 +1299,18 @@ ex7-downcast-left-≈ {ι = ι} =
 ex7-downcast-right-≈ : ∀ {Δ ι} →
   suc Δ ∣ (0 ꞉ id (‵ ι)) ∷ [] ⊢
     base-seal-step-fun ι
-      ≈ base-seal-step-fun ι ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = base-store-det}
+          (base-seal-step-fun-narrowingᵐ {ι = ι})
+          (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl))
       ∶ (‵ ι ⇒ ‵ ι) ⊒ (＇ 0 ⇒ ＇ 0)
 ex7-downcast-right-≈ {ι = ι} =
-  compose-rightⁿ base-store-det base-seal-step-fun⊒ id-var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      idBase-store-narrowing
-      wf-base-store-var-fun-endpoints
-      wf-base-store-var-fun-endpoints
-      (seal-or-idᵈ , base-seal-step-fun⊒)
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
-        base-seal-step-fun⊒ id-var0-fun⊒)))
+  endpointsⁿ refl refl refl refl
+    idBase-store-narrowing
+    wf-base-store-var-fun-endpoints
+    wf-base-store-var-fun-endpoints
+    (seal-or-idᵈ , base-seal-step-fun⊒)
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
+      base-seal-step-fun⊒ id-var0-fun⊒))
   where
     base-seal-step-fun⊒ =
       base-seal-step-fun-narrowingᵐ {ι = ι}
@@ -1262,7 +1327,7 @@ ex7-line714 : ∀ {ι} →
       ⊒ ((⇑ᵗᵐ (Λ (ƛ (` 0)))) •) ⟨ - base-seal-step-fun ι ⟩
     ∶ id (‵ ι) ↦ id (‵ ι) ⦂ _ ⊒ _
 ex7-line714 {ι = ι} =
-  cast+⊒cast+ᵗ
+  cast+⊒cast+-derivedᵗ
     {p = id (＇ 0) ↦ id (＇ 0)}
     {q = id (‵ ι) ↦ id (‵ ι)}
     {r = base-seal-step-fun ι}
@@ -1270,7 +1335,13 @@ ex7-line714 {ι = ι} =
     {t = base-seal-step-fun ι}
     id-var0-fun-cast
     id-base-fun-cast
+    base-store-det
+    (id-base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = ι})
+    (base-seal-step-fun-narrowingᵐ {ι = ι})
     ex7-downcast-left-≈
+    base-store-det
+    (base-seal-step-fun-narrowingᵐ {ι = ι})
+    (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl)
     ex7-downcast-right-≈
     ex7-line712
 
@@ -1306,18 +1377,18 @@ ex7-line719 =
 ex7-line720-≈ : ∀ {ι} →
   1 ∣ (0 ꞉ id (‵ ι)) ∷ [] ⊢
     var0-fun
-      ≈ var0-fun
-          ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = base-store-det}
+          var0-fun-narrowingᵐ
+          (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex7-line720-≈ =
-  compose-rightⁿ base-store-det var0-fun⊒ id-var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      idBase-store-narrowing
-      wf-store-var-fun-endpoints
-      wf-store-var-fun-endpoints
-      var0-fun-narrowing
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
-        var0-fun⊒ id-var0-fun⊒)))
+  endpointsⁿ refl refl refl refl
+    idBase-store-narrowing
+    wf-store-var-fun-endpoints
+    wf-store-var-fun-endpoints
+    var0-fun-narrowing
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
+      var0-fun⊒ id-var0-fun⊒))
   where
     var0-fun⊒ = var0-fun-narrowingᵐ
 
@@ -1331,7 +1402,10 @@ ex7-line721 : ∀ {ι} →
       ⊒ ƛ (` 0)
     ∶ id (＇ 0) ↦ id (＇ 0) ⦂ _ ⊒ _
 ex7-line721 =
-  cast-⊒ᵗ id-var0-fun-cast ex7-line720-≈ ex7-line719
+  cast-⊒ᵗ id-var0-fun-cast base-store-det
+    var0-fun-narrowingᵐ
+    (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl)
+    ex7-line720-≈ ex7-line719
 
 -- cambridge25 Example 7, line 723.
 ex7-line723 : ∀ {ι} →
@@ -1341,7 +1415,7 @@ ex7-line723 : ∀ {ι} →
       ⊒ (ƛ (` 0)) ⟨ - base-seal-step-fun ι ⟩
     ∶ id (‵ ι) ↦ id (‵ ι) ⦂ _ ⊒ _
 ex7-line723 {ι = ι} =
-  cast+⊒cast+ᵗ
+  cast+⊒cast+-derivedᵗ
     {p = id (＇ 0) ↦ id (＇ 0)}
     {q = id (‵ ι) ↦ id (‵ ι)}
     {r = base-seal-step-fun ι}
@@ -1349,7 +1423,13 @@ ex7-line723 {ι = ι} =
     {t = base-seal-step-fun ι}
     id-var0-fun-cast
     id-base-fun-cast
+    base-store-det
+    (id-base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = ι})
+    (base-seal-step-fun-narrowingᵐ {ι = ι})
     ex7-downcast-left-≈
+    base-store-det
+    (base-seal-step-fun-narrowingᵐ {ι = ι})
+    (id-var0-fun-narrowingᵐ {μ = seal-or-idᵈ} refl)
     ex7-downcast-right-≈
     ex7-line721
 
@@ -1361,17 +1441,19 @@ ex7-line723 {ι = ι} =
 -- `(ι!→ι?) ⨾ (α♯→α♭) ≈ α!→α?`.
 ex8-line820-left-≈ :
   1 ∣ (0 ꞉ base-untag `ℕ) ∷ [] ⊢
-    base-fun `ℕ ⨾ⁿ base-seal-step-fun `ℕ ≈ var0-fun
+    proj₁ (_⨟ⁿ_ {wfΣ = base-store-det}
+      (base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `ℕ})
+      (base-seal-step-fun-narrowingᵐ {ι = `ℕ}))
+      ≈ var0-fun
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex8-line820-left-≈ =
-  compose-leftⁿ base-store-det base-fun⊒ base-seal-step-fun⊒
-    (endpointsⁿ refl refl refl refl
-      base-untag-store-narrowing
-      wf-store-var-fun-endpoints
-      wf-store-var-fun-endpoints
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
-        base-fun⊒ base-seal-step-fun⊒))
-      var0-fun-narrowing)
+  endpointsⁿ refl refl refl refl
+    base-untag-store-narrowing
+    wf-store-var-fun-endpoints
+    wf-store-var-fun-endpoints
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = base-store-det}
+      base-fun⊒ base-seal-step-fun⊒))
+    var0-fun-narrowing
   where
     base-fun⊒ =
       base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `ℕ}
@@ -1383,17 +1465,19 @@ ex8-line820-left-≈ =
 -- `α!→α? ≈ (α!→α?) ⨾ (id_α→id_α)`.
 ex8-line820-right-≈ :
   1 ∣ (0 ꞉ base-untag `ℕ) ∷ [] ⊢
-    var0-fun ≈ var0-fun ⨾ⁿ (id (＇ 0) ↦ id (＇ 0))
+    var0-fun
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = star-store-det}
+          var0-fun-narrowingᵐ
+          (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl))
       ∶ (★ ⇒ ★) ⊒ (＇ 0 ⇒ ＇ 0)
 ex8-line820-right-≈ =
-  compose-rightⁿ star-store-det var0-fun⊒ id-var0-fun⊒
-    (endpointsⁿ refl refl refl refl
-      base-untag-store-narrowing
-      wf-store-var-fun-endpoints
-      wf-store-var-fun-endpoints
-      var0-fun-narrowing
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
-        var0-fun⊒ id-var0-fun⊒)))
+  endpointsⁿ refl refl refl refl
+    base-untag-store-narrowing
+    wf-store-var-fun-endpoints
+    wf-store-var-fun-endpoints
+    var0-fun-narrowing
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
+      var0-fun⊒ id-var0-fun⊒))
   where
     var0-fun⊒ = var0-fun-narrowingᵐ
 
@@ -1420,6 +1504,9 @@ ex8-line820 =
     {r = var0-fun}
     {s = base-seal-step-fun `ℕ}
     base-fun-cast
+    base-store-det
+    (base-fun-narrowingᵐ {μ = seal-or-idᵈ} {ι = `ℕ})
+    (base-seal-step-fun-narrowingᵐ {ι = `ℕ})
     ex8-line820-left-≈
     (cast+⊒ᵗ
       {p = id (＇ 0) ↦ id (＇ 0)}
@@ -1427,23 +1514,28 @@ ex8-line820 =
       {t = var0-fun}
       id-var0-fun-cast
       var0-fun-cast
+      star-store-det
+      var0-fun-narrowingᵐ
+      (id-var0-fun-narrowingᵐ {μ = tag-or-idᵈ} refl)
       ex8-line820-right-≈
       ex8-idα)
 
 -- cambridge25 Example 8, line 821 argument premise.
 ex8-c★⊒c-right-≈ :
   1 ∣ (0 ꞉ base-untag `ℕ) ∷ [] ⊢
-    base-untag `ℕ ≈ base-untag `ℕ ⨾ⁿ id (‵ `ℕ)
+    base-untag `ℕ
+      ≈ proj₁ (_⨟ⁿ_ {wfΣ = star-store-det}
+          (base-untag-narrowingᵐ {μ = tag-or-idᵈ} {ι = `ℕ})
+          (id-base-narrowingᵐ {μ = tag-or-idᵈ} {ι = `ℕ}))
       ∶ ★ ⊒ ‵ `ℕ
 ex8-c★⊒c-right-≈ =
-  compose-rightⁿ star-store-det base-untag⊒ id-base⊒
-    (endpointsⁿ refl refl refl refl
-      base-untag-store-narrowing
-      wf★-base-endpoints
-      wf★-base-endpoints
-      base-untag-narrowing
-      (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
-        base-untag⊒ id-base⊒)))
+  endpointsⁿ refl refl refl refl
+    base-untag-store-narrowing
+    wf★-base-endpoints
+    wf★-base-endpoints
+    base-untag-narrowing
+    (_ , proj₂ (_⨟ⁿ_ {wfΣ = star-store-det}
+      base-untag⊒ id-base⊒))
   where
     base-untag⊒ =
       base-untag-narrowingᵐ {μ = tag-or-idᵈ} {ι = `ℕ}
@@ -1463,6 +1555,9 @@ ex8-c★⊒c =
     {B = ‵ `ℕ}
     id-base-cast
     base-untag-cast
+    star-store-det
+    (base-untag-narrowingᵐ {μ = tag-or-idᵈ} {ι = `ℕ})
+    (id-base-narrowingᵐ {μ = tag-or-idᵈ} {ι = `ℕ})
     ex8-c★⊒c-right-≈
     (κ⊒κᵗ (κℕ 0))
 

--- a/GTSF/TermNarrowing.agda
+++ b/GTSF/TermNarrowing.agda
@@ -17,7 +17,7 @@ module TermNarrowing where
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using (_∷_; map)
 open import Data.Nat using (zero; suc)
-open import Data.Product using (_,_; ∃-syntax)
+open import Data.Product using (_,_; proj₁; ∃-syntax)
 
 open import Types
 open import Coercions
@@ -25,6 +25,7 @@ open import Primitives
 open import NuTerms
 open import NarrowWiden
 open import NarrowWidenComposition
+open import proof.NarrowWidenProperties using (StoreDetWf)
 
 variable
   Δ : TyCtx
@@ -227,62 +228,51 @@ data _∣_∣_⊢_⊒_∶_⦂_⊒_
     → Δ ∣ σ ∣ γ ⊢ M ⊕[ addℕ ] N ⊒ M′ ⊕[ addℕ ] N′
         ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
 
-  ⊒cast+ᵗ : ∀ {M M′ q r s A B C D}
+  ⊒cast+ᵗ : ∀ {M M′ q r s A B C D E Σ μ}
     → {typing : TermTypingEndpoints Δ σ γ M (M′ ⟨ - s ⟩) C D}
     → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D
-    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+    → (wfΣ : StoreDetWf Δ Σ)
+    → (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ E)
+    → (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ E ⊒ B)
+    → Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
       -------------------------------------------------
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ⟨ - s ⟩ ∶ q ⦂ C ⊒ D
 
-  ⊒cast-ᵗ : ∀ {M M′ q r s A B C D}
+  ⊒cast-ᵗ : ∀ {M M′ q r s A B C D E Σ μ ν}
     → {typing : TermTypingEndpoints Δ σ γ M (M′ ⟨ s ⟩) A B}
     → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D
-    → Δ ∣ srcStoreⁿ σ ⊢ r ∶ᶜ A ⊒ B
-    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
+    → μ ∣ Δ ∣ srcStoreⁿ σ ⊢ r ∶ A ⊒ B
+    → (wfΣ : StoreDetWf Δ Σ)
+    → (q⊒ : ν ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ E)
+    → (s⊒ : ν ∣ Δ ∣ Σ ⊢ s ∶ E ⊒ B)
+    → Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ q ⦂ C ⊒ D
       -------------------------------------------------
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ⟨ s ⟩ ∶ r ⦂ A ⊒ B
 
-  cast+⊒ᵗ : ∀ {M M′ p r t A B C D}
+  cast+⊒ᵗ : ∀ {M M′ p r t A B C D E Σ μ ν}
     → {typing : TermTypingEndpoints Δ σ γ (M ⟨ - t ⟩) M′ A B}
     → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D
-    → Δ ∣ srcStoreⁿ σ ⊢ r ∶ᶜ A ⊒ B
-    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+    → μ ∣ Δ ∣ srcStoreⁿ σ ⊢ r ∶ A ⊒ B
+    → (wfΣ : StoreDetWf Δ Σ)
+    → (t⊒ : ν ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ E)
+    → (p⊒ : ν ∣ Δ ∣ Σ ⊢ p ∶ E ⊒ B)
+    → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ C ⊒ D
       -------------------------------------------------
     → Δ ∣ σ ∣ γ ⊢ M ⟨ - t ⟩ ⊒ M′ ∶ r ⦂ A ⊒ B
 
-  cast-⊒ᵗ : ∀ {M M′ p r t A B C D}
+  cast-⊒ᵗ : ∀ {M M′ p r t A B C D E Σ μ}
     → {typing : TermTypingEndpoints Δ σ γ (M ⟨ t ⟩) M′ C D}
     → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D
-    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
+    → (wfΣ : StoreDetWf Δ Σ)
+    → (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ E)
+    → (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ E ⊒ B)
+    → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B
     → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
       -------------------------------------------------
     → Δ ∣ σ ∣ γ ⊢ M ⟨ t ⟩ ⊒ M′ ∶ p ⦂ C ⊒ D
-
-  cast-⊒cast-ᵗ : ∀ {M M′ p q r s t A B Ap Bp Aq Bq}
-    → {typing :
-        TermTypingEndpoints Δ σ γ (M ⟨ t ⟩) (M′ ⟨ s ⟩) Ap Bp}
-    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ Ap ⊒ Bp
-    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ Aq ⊒ Bq
-    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
-    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
-    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ q ⦂ Aq ⊒ Bq
-      --------------------------------------------------
-    → Δ ∣ σ ∣ γ ⊢ M ⟨ t ⟩ ⊒ M′ ⟨ s ⟩ ∶ p ⦂ Ap ⊒ Bp
-
-  cast+⊒cast+ᵗ : ∀ {M M′ p q r s t A B Ap Bp Aq Bq}
-    → {typing :
-        TermTypingEndpoints Δ σ γ
-          (M ⟨ - t ⟩) (M′ ⟨ - s ⟩) Aq Bq}
-    → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ Ap ⊒ Bp
-    → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ Aq ⊒ Bq
-    → Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
-    → Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
-    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ Ap ⊒ Bp
-      ------------------------------------------------------
-    → Δ ∣ σ ∣ γ ⊢ M ⟨ - t ⟩ ⊒ M′ ⟨ - s ⟩ ∶ q ⦂ Aq ⊒ Bq
 
 typed-term-narrowing-term-typing :
   Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
@@ -328,22 +318,16 @@ typed-term-narrowing-term-typing
     (⊕⊒⊕ᵗ {typing = typing} M⊒M′ N⊒N′) =
   typing
 typed-term-narrowing-term-typing
-    (⊒cast+ᵗ {typing = typing} qᶜ q⨟s≈r M⊒M′) =
+    (⊒cast+ᵗ {typing = typing} qᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
   typing
 typed-term-narrowing-term-typing
-    (⊒cast-ᵗ {typing = typing} qᶜ rᶜ q⨟s≈r M⊒M′) =
+    (⊒cast-ᵗ {typing = typing} qᶜ rᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
   typing
 typed-term-narrowing-term-typing
-    (cast+⊒ᵗ {typing = typing} pᶜ rᶜ r≈t⨟p M⊒M′) =
+    (cast+⊒ᵗ {typing = typing} pᶜ rᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
   typing
 typed-term-narrowing-term-typing
-    (cast-⊒ᵗ {typing = typing} pᶜ r≈t⨟p M⊒M′) =
-  typing
-typed-term-narrowing-term-typing
-    (cast-⊒cast-ᵗ {typing = typing} pᶜ qᶜ q⨟s≈r r≈t⨟p M⊒M′) =
-  typing
-typed-term-narrowing-term-typing
-    (cast+⊒cast+ᵗ {typing = typing} pᶜ qᶜ q⨟s≈r r≈t⨟p M⊒M′) =
+    (cast-⊒ᵗ {typing = typing} pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
   typing
 
 typed-term-narrowing-source-typing :
@@ -360,39 +344,47 @@ typed-term-narrowing-target-typing M⊒M′ =
 
 typed-term-narrowing-index-typing :
   Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
-  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B
-typed-term-narrowing-index-typing (extendᵗ qᶜ pαᶜ M⊒N′) = pαᶜ
-typed-term-narrowing-index-typing (splitᵗ qᶜ pαᶜ N⊒N′) = pαᶜ
-typed-term-narrowing-index-typing (⊒blameᵗ pᶜ) = pᶜ
-typed-term-narrowing-index-typing (x⊒xᵗ pᶜ x∋p) = pᶜ
-typed-term-narrowing-index-typing (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) = p↦qᶜ
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ A ⊒ B
+typed-term-narrowing-index-typing (extendᵗ qᶜ pαᶜ M⊒N′) =
+  tag-or-idᵈ , pαᶜ
+typed-term-narrowing-index-typing (splitᵗ qᶜ pαᶜ N⊒N′) =
+  tag-or-idᵈ , pαᶜ
+typed-term-narrowing-index-typing (⊒blameᵗ pᶜ) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-index-typing (x⊒xᵗ pᶜ x∋p) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-index-typing (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) =
+  tag-or-idᵈ , p↦qᶜ
 typed-term-narrowing-index-typing (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
-  fun-narrow-codomainᶜ p↦qᶜ
-typed-term-narrowing-index-typing (Λ⊒Λᵗ allᶜ vV V⊒V′) = allᶜ
-typed-term-narrowing-index-typing (⊒Λᵗ pᶜ N⊒V′) = pᶜ
-typed-term-narrowing-index-typing (⊒⟨ν⟩ᵗ pᶜ i N⊒V′s) = pᶜ
+  tag-or-idᵈ , fun-narrow-codomainᶜ p↦qᶜ
+typed-term-narrowing-index-typing (Λ⊒Λᵗ allᶜ vV V⊒V′) =
+  tag-or-idᵈ , allᶜ
+typed-term-narrowing-index-typing (⊒Λᵗ pᶜ N⊒V′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-index-typing (⊒⟨ν⟩ᵗ pᶜ i N⊒V′s) =
+  tag-or-idᵈ , pᶜ
 typed-term-narrowing-index-typing
     (α⊒αᵗ γ′≡ qᶜ pαᶜ L⊒L′) =
-  pαᶜ
-typed-term-narrowing-index-typing (⊒αᵗ γ′≡ pαᶜ L⊒L′) = pαᶜ
-typed-term-narrowing-index-typing (ν⊒νᵗ pᶜ qᶜ N⊒N′) = pᶜ
-typed-term-narrowing-index-typing (⊒νᵗ pᶜ N⊒N′) = pᶜ
-typed-term-narrowing-index-typing (ν⊒ᵗ pᶜ N⊒N′) = pᶜ
+  tag-or-idᵈ , pαᶜ
+typed-term-narrowing-index-typing (⊒αᵗ γ′≡ pαᶜ L⊒L′) =
+  tag-or-idᵈ , pαᶜ
+typed-term-narrowing-index-typing (ν⊒νᵗ pᶜ qᶜ N⊒N′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-index-typing (⊒νᵗ pᶜ N⊒N′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-index-typing (ν⊒ᵗ pᶜ N⊒N′) =
+  tag-or-idᵈ , pᶜ
 typed-term-narrowing-index-typing (κ⊒κᵗ (κℕ n)) =
-  cast-id wfBase refl , cross (id-‵ `ℕ)
+  tag-or-idᵈ , cast-id wfBase refl , cross (id-‵ `ℕ)
 typed-term-narrowing-index-typing (⊕⊒⊕ᵗ M⊒M′ N⊒N′) =
-  cast-id wfBase refl , cross (id-‵ `ℕ)
-typed-term-narrowing-index-typing (⊒cast+ᵗ qᶜ q⨟s≈r M⊒M′) = qᶜ
+  tag-or-idᵈ , cast-id wfBase refl , cross (id-‵ `ℕ)
+typed-term-narrowing-index-typing (⊒cast+ᵗ qᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
+  tag-or-idᵈ , qᶜ
 typed-term-narrowing-index-typing
-    (⊒cast-ᵗ qᶜ rᶜ q⨟s≈r M⊒M′) =
-  rᶜ
+    (⊒cast-ᵗ {μ = μ} qᶜ r⊒ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
+  μ , r⊒
 typed-term-narrowing-index-typing
-    (cast+⊒ᵗ pᶜ rᶜ r≈t⨟p M⊒M′) =
-  rᶜ
-typed-term-narrowing-index-typing (cast-⊒ᵗ pᶜ r≈t⨟p M⊒M′) = pᶜ
-typed-term-narrowing-index-typing
-    (cast-⊒cast-ᵗ pᶜ qᶜ q⨟s≈r r≈t⨟p M⊒M′) =
-  pᶜ
-typed-term-narrowing-index-typing
-    (cast+⊒cast+ᵗ pᶜ qᶜ q⨟s≈r r≈t⨟p M⊒M′) =
-  qᶜ
+    (cast+⊒ᵗ {μ = μ} pᶜ r⊒ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
+  μ , r⊒
+typed-term-narrowing-index-typing (cast-⊒ᵗ pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
+  tag-or-idᵈ , pᶜ

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -32,7 +32,8 @@ open import TermNarrowing
 open import Primitives using (κℕ; constTy)
 open import proof.NarrowWidenProperties
   using
-    ( StoreDetWf-⟰ᵗ
+    ( StoreDetWf
+    ; StoreDetWf-⟰ᵗ
     ; WfTyˢ-⇑ᵗ
     ; WfTyˢ-store-weaken
     ; narrowing-determinedᵐ
@@ -188,11 +189,14 @@ postulate
   -- in `catchup-lemma`.  The Δ′ equality is Agda bookkeeping for the emitted
   -- store-change sequence.
   left-widening-lemma :
-    ∀ {Δ σ V V′ p r t A B C D} →
+    ∀ {Δ σ V V′ p r t A B C D E Σ μ} →
     Value V →
     No• V →
     Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
-    Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+    (wfΣ : StoreDetWf Δ Σ) →
+    (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ E) →
+    (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ E ⊒ B) →
+    Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B →
     Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ p ⦂ C ⊒ D →
     ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
       Value W ×
@@ -209,11 +213,14 @@ postulate
   -- cambridge25 "Left Narrowing Lemma", likewise value-level, with the same
   -- emitted-context bookkeeping.
   left-narrowing-lemma :
-    ∀ {Δ σ V V′ p r t A B C D} →
+    ∀ {Δ σ V V′ p r t A B C D E Σ μ} →
     Value V →
     No• V →
     Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
-    Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
+    (wfΣ : StoreDetWf Δ Σ) →
+    (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ E) →
+    (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ E ⊒ B) →
+    Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B →
     Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ r ⦂ A ⊒ B →
     ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
       Value W ×
@@ -404,379 +411,6 @@ catchup-gen-coercion-typing-transport {Δ′ = Δ′} {σ = σ} {π = π}
     s⊒
     (narrow-drop-star-var X t⊒)
 
-compose-leftⁿ-⇑ˢ :
-  ∀ {Δ σ q s r A B} →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  suc Δ ∣ ⇑ˢ σ ⊢ ⇑ᶜ q ⨾ⁿ ⇑ᶜ s ≈ ⇑ᶜ r ∶ ⇑ᵗ A ⊒ ⇑ᵗ B
-compose-leftⁿ-⇑ˢ (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
-  let
-    q⊒′ = narrow-⇑ᵗ-gen q⊒
-    s⊒′ = narrow-⇑ᵗ-gen s⊒
-    old = _⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒
-    new = _⨟ⁿ_ {wfΣ = StoreDetWf-⟰ᵗ wfΣ} q⊒′ s⊒′
-    u≡ =
-      narrowing-determinedᵐ (StoreDetWf-⟰ᵗ wfΣ)
-        (proj₂ new)
-        (narrow-⇑ᵗ-gen (proj₂ old))
-    eq′ =
-      subst
-        (λ u → _ ∣ _ ⊢ u ≈ ⇑ᶜ _ ∶ _ ⊒ _)
-        (sym u≡)
-        (≈ⁿ-⇑ˢ q⨟s≈r)
-  in
-  compose-leftⁿ (StoreDetWf-⟰ᵗ wfΣ) q⊒′ s⊒′ eq′
-
-compose-leftⁿ-add-left-star-var :
-  ∀ X {Δ σ q s r A B} →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
-compose-leftⁿ-add-left-star-var X (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
-  compose-leftⁿ wfΣ q⊒ s⊒ (≈ⁿ-add-left-star-var X q⨟s≈r)
-
-compose-rightⁿ-⇑ˢ :
-  ∀ {Δ σ r t p A B} →
-  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
-  suc Δ ∣ ⇑ˢ σ ⊢ ⇑ᶜ r ≈ ⇑ᶜ t ⨾ⁿ ⇑ᶜ p ∶ ⇑ᵗ A ⊒ ⇑ᵗ B
-compose-rightⁿ-⇑ˢ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
-  let
-    t⊒′ = narrow-⇑ᵗ-gen t⊒
-    p⊒′ = narrow-⇑ᵗ-gen p⊒
-    old = _⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒
-    new = _⨟ⁿ_ {wfΣ = StoreDetWf-⟰ᵗ wfΣ} t⊒′ p⊒′
-    u≡ =
-      narrowing-determinedᵐ (StoreDetWf-⟰ᵗ wfΣ)
-        (proj₂ new)
-        (narrow-⇑ᵗ-gen (proj₂ old))
-    eq′ =
-      subst
-        (λ u → _ ∣ _ ⊢ ⇑ᶜ _ ≈ u ∶ _ ⊒ _)
-        (sym u≡)
-        (≈ⁿ-⇑ˢ r≈t⨟p)
-  in
-  compose-rightⁿ (StoreDetWf-⟰ᵗ wfΣ) t⊒′ p⊒′ eq′
-
-compose-rightⁿ-add-left-star-var :
-  ∀ X {Δ σ r t p A B} →
-  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
-  Δ ∣ (⊒ X ꞉=☆) ∷ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
-compose-rightⁿ-add-left-star-var X (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
-  compose-rightⁿ wfΣ t⊒ p⊒ (≈ⁿ-add-left-star-var X r≈t⨟p)
-
-catchup-compose-left-transport-shifted :
-  ∀ n {Δ Δ′ σ π Π Π′ χs q s r A B} →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  Δ′ ≡ applyTyCtxs χs Δ →
-  Π ≡ shiftStore n (applyStores χs []) →
-  Π′ ≡ [] →
-  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
-  Δ′ ∣ combineStoreNrw π σ
-    ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
-      ≈ applyCoercions χs r ∶ applyTys χs A ⊒ applyTys χs B
-catchup-compose-left-transport-shifted n {Δ = Δ} {Δ′ = Δ′} {σ = σ}
-    {χs = χs} {q = q} {s = s} {r = r} {A = A} {B = B}
-    q⨟s≈r Δ′≡ Π≡ Π′≡ ⊒ˢ-nil =
-  let
-    empty≡ = shiftStore-empty-inv n (sym Π≡)
-    Δ′≡Δ = trans Δ′≡ (applyTyCtxs-empty-id χs empty≡ Δ)
-    q≡ = applyCoercions-empty-id χs empty≡ q
-    s≡ = applyCoercions-empty-id χs empty≡ s
-    r≡ = applyCoercions-empty-id χs empty≡ r
-    A≡ = applyTys-empty-id χs empty≡ A
-    B≡ = applyTys-empty-id χs empty≡ B
-  in
-  subst
-    (λ Δ₀ → Δ₀ ∣ σ
-      ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
-        ≈ applyCoercions χs r ∶ applyTys χs A ⊒ applyTys χs B)
-    (sym Δ′≡Δ)
-    (subst
-      (λ B₀ → Δ ∣ σ
-        ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
-          ≈ applyCoercions χs r ∶ applyTys χs A ⊒ B₀)
-      (sym B≡)
-      (subst
-        (λ A₀ → Δ ∣ σ
-          ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
-            ≈ applyCoercions χs r ∶ A₀ ⊒ B)
-        (sym A≡)
-        (subst
-          (λ r₀ → Δ ∣ σ
-            ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
-              ≈ r₀ ∶ A ⊒ B)
-          (sym r≡)
-          (subst
-            (λ s₀ → Δ ∣ σ
-              ⊢ applyCoercions χs q ⨾ⁿ s₀ ≈ r ∶ A ⊒ B)
-            (sym s≡)
-            (subst
-              (λ q₀ → Δ ∣ σ ⊢ q₀ ⨾ⁿ s ≈ r ∶ A ⊒ B)
-              (sym q≡)
-              q⨟s≈r)))))
-catchup-compose-left-transport-shifted n
-    q⨟s≈r Δ′≡ Π≡ () (⊒ˢ-right hA π⊒)
-catchup-compose-left-transport-shifted n {χs = χs}
-    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
-    with storeChangesLastBind χs
-catchup-compose-left-transport-shifted n {χs = χs}
-    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
-    | no-bind keeps
-    with trans Π≡
-      (trans (cong (shiftStore n) (allKeep-applyStores-id keeps []))
-        (shiftStore-empty n))
-catchup-compose-left-transport-shifted n {χs = χs}
-    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
-    | no-bind keeps | ()
-catchup-compose-left-transport-shifted n {Δ = Δ} {σ = σ}
-    {χs = .(χs ++ bind Aχ ∷ keeps)}
-    {q = q} {s = s} {r = r} {A = A} {B = B}
-    q⨟s≈r Δ′≡ Π≡ Π′≡ (⊒ˢ-left {X = X} π⊒)
-    | last-bind χs Aχ keeps keeps-ok =
-  let
-    Δtail≡ =
-      trans Δ′≡
-        (trans (applyTyCtxs-last-bind χs Aχ keeps keeps-ok Δ)
-          (sym (applyTyCtxs-suc χs Δ)))
-    Π-last≡ =
-      trans Π≡
-        (cong (shiftStore n)
-          (applyStores-last-bind χs Aχ keeps keeps-ok []))
-    Π-last-normal≡ =
-      trans Π-last≡
-        (shiftStore-cons n zero (⇑ᵗ Aχ) (⟰ᵗ (applyStores χs [])))
-    Πtail≡ =
-      trans (storeTail-∷≡ Π-last-normal≡)
-        (shiftStore-⟰ᵗ n (applyStores χs []))
-    tail =
-      catchup-compose-left-transport-shifted (suc n) {χs = χs}
-        (compose-leftⁿ-⇑ˢ q⨟s≈r)
-        Δtail≡
-        Πtail≡
-        Π′≡
-        π⊒
-    lifted = compose-leftⁿ-add-left-star-var X tail
-    q≡ =
-      trans (applyCoercions-⇑ᶜ χs q)
-        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok q))
-    s≡ =
-      trans (applyCoercions-⇑ᶜ χs s)
-        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok s))
-    r≡ =
-      trans (applyCoercions-⇑ᶜ χs r)
-        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok r))
-    A≡ =
-      trans (applyTys-⇑ᵗ χs A)
-        (sym (applyTys-last-bind χs Aχ keeps keeps-ok A))
-    B≡ =
-      trans (applyTys-⇑ᵗ χs B)
-        (sym (applyTys-last-bind χs Aχ keeps keeps-ok B))
-  in
-  subst
-    (λ B₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
-      ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) s
-      ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) r
-      ∶ applyTys (χs ++ bind Aχ ∷ keeps) A ⊒ B₀)
-    B≡
-    (subst
-      (λ A₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
-        ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) s
-        ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) r
-        ∶ A₀ ⊒ applyTys χs (⇑ᵗ B))
-      A≡
-      (subst
-        (λ r₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
-          ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) s
-          ≈ r₀ ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
-        r≡
-        (subst
-          (λ s₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) q
-            ⨾ⁿ s₀ ≈ applyCoercions χs (⇑ᶜ r)
-            ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
-          s≡
-          (subst
-            (λ q₀ → _ ∣ _ ⊢ q₀
-              ⨾ⁿ applyCoercions χs (⇑ᶜ s)
-              ≈ applyCoercions χs (⇑ᶜ r)
-              ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
-            q≡
-            lifted))))
-catchup-compose-left-transport-shifted n
-    q⨟s≈r Δ′≡ Π≡ () (⊒ˢ-both hA hA′ s⊒ π⊒)
-
-catchup-compose-left-transport :
-  ∀ {Δ Δ′ σ π Π Π′ χs q s r A B} →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  Δ′ ≡ applyTyCtxs χs Δ →
-  Π ≡ applyStores χs [] →
-  Π′ ≡ [] →
-  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
-  Δ′ ∣ combineStoreNrw π σ
-    ⊢ applyCoercions χs q ⨾ⁿ applyCoercions χs s
-      ≈ applyCoercions χs r ∶ applyTys χs A ⊒ applyTys χs B
-catchup-compose-left-transport {χs = χs} q⨟s≈r Δ′≡ Π≡ Π′≡ π⊒ =
-  catchup-compose-left-transport-shifted zero
-    {χs = χs}
-    q⨟s≈r Δ′≡ Π≡ Π′≡ π⊒
-
-catchup-compose-right-transport-shifted :
-  ∀ n {Δ Δ′ σ π Π Π′ χs r t p A B} →
-  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
-  Δ′ ≡ applyTyCtxs χs Δ →
-  Π ≡ shiftStore n (applyStores χs []) →
-  Π′ ≡ [] →
-  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
-  Δ′ ∣ combineStoreNrw π σ
-    ⊢ applyCoercions χs r
-      ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
-      ∶ applyTys χs A ⊒ applyTys χs B
-catchup-compose-right-transport-shifted n {Δ = Δ} {Δ′ = Δ′} {σ = σ}
-    {χs = χs} {r = r} {t = t} {p = p} {A = A} {B = B}
-    r≈t⨟p Δ′≡ Π≡ Π′≡ ⊒ˢ-nil =
-  let
-    empty≡ = shiftStore-empty-inv n (sym Π≡)
-    Δ′≡Δ = trans Δ′≡ (applyTyCtxs-empty-id χs empty≡ Δ)
-    r≡ = applyCoercions-empty-id χs empty≡ r
-    t≡ = applyCoercions-empty-id χs empty≡ t
-    p≡ = applyCoercions-empty-id χs empty≡ p
-    A≡ = applyTys-empty-id χs empty≡ A
-    B≡ = applyTys-empty-id χs empty≡ B
-  in
-  subst
-    (λ Δ₀ → Δ₀ ∣ σ
-      ⊢ applyCoercions χs r
-        ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
-        ∶ applyTys χs A ⊒ applyTys χs B)
-    (sym Δ′≡Δ)
-    (subst
-      (λ B₀ → Δ ∣ σ
-        ⊢ applyCoercions χs r
-          ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
-          ∶ applyTys χs A ⊒ B₀)
-      (sym B≡)
-      (subst
-        (λ A₀ → Δ ∣ σ
-          ⊢ applyCoercions χs r
-            ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
-            ∶ A₀ ⊒ B)
-        (sym A≡)
-        (subst
-          (λ p₀ → Δ ∣ σ
-            ⊢ applyCoercions χs r
-              ≈ applyCoercions χs t ⨾ⁿ p₀ ∶ A ⊒ B)
-          (sym p≡)
-          (subst
-            (λ t₀ → Δ ∣ σ
-              ⊢ applyCoercions χs r ≈ t₀ ⨾ⁿ p ∶ A ⊒ B)
-            (sym t≡)
-            (subst
-              (λ r₀ → Δ ∣ σ ⊢ r₀ ≈ t ⨾ⁿ p ∶ A ⊒ B)
-              (sym r≡)
-              r≈t⨟p)))))
-catchup-compose-right-transport-shifted n
-    r≈t⨟p Δ′≡ Π≡ () (⊒ˢ-right hA π⊒)
-catchup-compose-right-transport-shifted n {χs = χs}
-    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
-    with storeChangesLastBind χs
-catchup-compose-right-transport-shifted n {χs = χs}
-    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
-    | no-bind keeps
-    with trans Π≡
-      (trans (cong (shiftStore n) (allKeep-applyStores-id keeps []))
-        (shiftStore-empty n))
-catchup-compose-right-transport-shifted n {χs = χs}
-    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left π⊒)
-    | no-bind keeps | ()
-catchup-compose-right-transport-shifted n {Δ = Δ} {σ = σ}
-    {χs = .(χs ++ bind Aχ ∷ keeps)}
-    {r = r} {t = t} {p = p} {A = A} {B = B}
-    r≈t⨟p Δ′≡ Π≡ Π′≡ (⊒ˢ-left {X = X} π⊒)
-    | last-bind χs Aχ keeps keeps-ok =
-  let
-    Δtail≡ =
-      trans Δ′≡
-        (trans (applyTyCtxs-last-bind χs Aχ keeps keeps-ok Δ)
-          (sym (applyTyCtxs-suc χs Δ)))
-    Π-last≡ =
-      trans Π≡
-        (cong (shiftStore n)
-          (applyStores-last-bind χs Aχ keeps keeps-ok []))
-    Π-last-normal≡ =
-      trans Π-last≡
-        (shiftStore-cons n zero (⇑ᵗ Aχ) (⟰ᵗ (applyStores χs [])))
-    Πtail≡ =
-      trans (storeTail-∷≡ Π-last-normal≡)
-        (shiftStore-⟰ᵗ n (applyStores χs []))
-    tail =
-      catchup-compose-right-transport-shifted (suc n) {χs = χs}
-        (compose-rightⁿ-⇑ˢ r≈t⨟p)
-        Δtail≡
-        Πtail≡
-        Π′≡
-        π⊒
-    lifted = compose-rightⁿ-add-left-star-var X tail
-    r≡ =
-      trans (applyCoercions-⇑ᶜ χs r)
-        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok r))
-    t≡ =
-      trans (applyCoercions-⇑ᶜ χs t)
-        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok t))
-    p≡ =
-      trans (applyCoercions-⇑ᶜ χs p)
-        (sym (applyCoercions-last-bind χs Aχ keeps keeps-ok p))
-    A≡ =
-      trans (applyTys-⇑ᵗ χs A)
-        (sym (applyTys-last-bind χs Aχ keeps keeps-ok A))
-    B≡ =
-      trans (applyTys-⇑ᵗ χs B)
-        (sym (applyTys-last-bind χs Aχ keeps keeps-ok B))
-  in
-  subst
-    (λ B₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
-      ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) t
-        ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) p
-      ∶ applyTys (χs ++ bind Aχ ∷ keeps) A ⊒ B₀)
-    B≡
-    (subst
-      (λ A₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
-        ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) t
-          ⨾ⁿ applyCoercions (χs ++ bind Aχ ∷ keeps) p
-        ∶ A₀ ⊒ applyTys χs (⇑ᵗ B))
-      A≡
-      (subst
-        (λ p₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
-          ≈ applyCoercions (χs ++ bind Aχ ∷ keeps) t
-            ⨾ⁿ p₀ ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
-        p≡
-        (subst
-          (λ t₀ → _ ∣ _ ⊢ applyCoercions (χs ++ bind Aχ ∷ keeps) r
-            ≈ t₀ ⨾ⁿ applyCoercions χs (⇑ᶜ p)
-            ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
-          t≡
-          (subst
-            (λ r₀ → _ ∣ _ ⊢ r₀
-              ≈ applyCoercions χs (⇑ᶜ t)
-                ⨾ⁿ applyCoercions χs (⇑ᶜ p)
-              ∶ applyTys χs (⇑ᵗ A) ⊒ applyTys χs (⇑ᵗ B))
-            r≡
-            lifted))))
-catchup-compose-right-transport-shifted n
-    r≈t⨟p Δ′≡ Π≡ () (⊒ˢ-both hA hA′ s⊒ π⊒)
-
-catchup-compose-right-transport :
-  ∀ {Δ Δ′ σ π Π Π′ χs r t p A B} →
-  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
-  Δ′ ≡ applyTyCtxs χs Δ →
-  Π ≡ applyStores χs [] →
-  Π′ ≡ [] →
-  Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ →
-  Δ′ ∣ combineStoreNrw π σ
-    ⊢ applyCoercions χs r
-      ≈ applyCoercions χs t ⨾ⁿ applyCoercions χs p
-      ∶ applyTys χs A ⊒ applyTys χs B
-catchup-compose-right-transport {χs = χs} r≈t⨟p Δ′≡ Π≡ Π′≡ π⊒ =
-  catchup-compose-right-transport-shifted zero
-    {χs = χs}
-    r≈t⨟p Δ′≡ Π≡ Π′≡ π⊒
-
 data ExtendReplaceRel : TyCtx → StoreNrw → StoreNrw → Set where
   replace-here :
     ∀ {Δ α q A B σ} →
@@ -918,23 +552,35 @@ extendReplaceRel-coercionᶜ :
 extendReplaceRel-coercionᶜ rel cᶜ =
   narrow-weaken ≤-refl (extendReplaceRel-src-incl rel) cᶜ
 
-extendReplaceRel-compose-left :
-  ∀ {Δ σ σ′ q s r A B} →
+extendReplaceRel-coercion :
+  ∀ {Δ σ σ′ μ c A B} →
   ExtendReplaceRel Δ σ σ′ →
-  Δ ∣ σ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B →
-  Δ ∣ σ′ ⊢ q ⨾ⁿ s ≈ r ∶ A ⊒ B
-extendReplaceRel-compose-left rel
-    (compose-leftⁿ wfΣ q⊒ s⊒ q⨟s≈r) =
-  compose-leftⁿ wfΣ q⊒ s⊒ (extendReplaceRel-≈ⁿ rel q⨟s≈r)
+  μ ∣ Δ ∣ srcStoreⁿ σ ⊢ c ∶ A ⊒ B →
+  μ ∣ Δ ∣ srcStoreⁿ σ′ ⊢ c ∶ A ⊒ B
+extendReplaceRel-coercion rel c⊒ =
+  narrow-weaken ≤-refl (extendReplaceRel-src-incl rel) c⊒
+
+extendReplaceRel-compose-left :
+  ∀ {Δ σ σ′ q s r A B C Σ μ} →
+  ExtendReplaceRel Δ σ σ′ →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C) →
+  (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ C ⊒ B) →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B →
+  Δ ∣ σ′ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B
+extendReplaceRel-compose-left rel wfΣ q⊒ s⊒ q⨟s≈r =
+  extendReplaceRel-≈ⁿ rel q⨟s≈r
 
 extendReplaceRel-compose-right :
-  ∀ {Δ σ σ′ r t p A B} →
+  ∀ {Δ σ σ′ r t p A B C Σ μ} →
   ExtendReplaceRel Δ σ σ′ →
-  Δ ∣ σ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B →
-  Δ ∣ σ′ ⊢ r ≈ t ⨾ⁿ p ∶ A ⊒ B
-extendReplaceRel-compose-right rel
-    (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) =
-  compose-rightⁿ wfΣ t⊒ p⊒ (extendReplaceRel-≈ⁿ rel r≈t⨟p)
+  (wfΣ : StoreDetWf Δ Σ) →
+  (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ C) →
+  (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ C ⊒ B) →
+  Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B →
+  Δ ∣ σ′ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B
+extendReplaceRel-compose-right rel wfΣ t⊒ p⊒ r≈t⨟p =
+  extendReplaceRel-≈ⁿ rel r≈t⨟p
 
 id-constᶜ :
   ∀ {Δ Σ} κ →
@@ -1007,10 +653,57 @@ extendReplaceRel-typed-term :
   ExtendReplaceRel Δ σ σ′ →
   Δ ∣ σ ∣ γ ⊢ M ⊒ T ∶ c ⦂ A ⊒ B →
   Δ ∣ σ′ ∣ γ ⊢ M ⊒ T ∶ c ⦂ A ⊒ B
-extendReplaceRel-typed-term (replace-here qᶜ) M⊒T =
-  extend-replace-here-typed-current qᶜ
-    (typed-term-narrowing-index-typing M⊒T)
-    M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ)
+    M⊒T@(splitᵗ _ pαᶜ _) =
+  extend-replace-here-typed-current qᶜ pαᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(⊒blameᵗ pᶜ) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(x⊒xᵗ pᶜ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(ƛ⊒ƛᵗ p↦qᶜ _) =
+  extend-replace-here-typed-current qᶜ p↦qᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(·⊒·ᵗ p↦qᶜ _ _) =
+  extend-replace-here-typed-current qᶜ (fun-narrow-codomainᶜ p↦qᶜ) M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(Λ⊒Λᵗ allᶜ _ _) =
+  extend-replace-here-typed-current qᶜ allᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(⊒Λᵗ pᶜ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(⊒⟨ν⟩ᵗ pᶜ _ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(⊒αᵗ _ pαᶜ _) =
+  extend-replace-here-typed-current qᶜ pαᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(ν⊒νᵗ pᶜ _ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(⊒νᵗ pᶜ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(ν⊒ᵗ pᶜ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(κ⊒κᵗ κ) =
+  extend-replace-here-typed-current qᶜ (id-constᶜ κ) M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ) M⊒T@(⊕⊒⊕ᵗ _ _) =
+  extend-replace-here-typed-current qᶜ id-ℕᶜ M⊒T
+extendReplaceRel-typed-term (replace-here qᶜ)
+    M⊒T@(⊒cast+ᵗ q₀ᶜ _ _ _ _ _) =
+  extend-replace-here-typed-current qᶜ q₀ᶜ M⊒T
+extendReplaceRel-typed-term rel@(replace-here qᶜ)
+    (⊒cast-ᵗ q₀ᶜ r⊒ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
+  ⊒cast-ᵗ
+    (extendReplaceRel-coercionᶜ rel q₀ᶜ)
+    (extendReplaceRel-coercion rel r⊒)
+    wfΣ q⊒ s⊒
+    (extendReplaceRel-compose-left rel wfΣ q⊒ s⊒ q⨟s≈r)
+    (extend-replace-here-typed-current qᶜ q₀ᶜ M⊒M′)
+extendReplaceRel-typed-term rel@(replace-here qᶜ)
+    (cast+⊒ᵗ pᶜ r⊒ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
+  cast+⊒ᵗ
+    (extendReplaceRel-coercionᶜ rel pᶜ)
+    (extendReplaceRel-coercion rel r⊒)
+    wfΣ t⊒ p⊒
+    (extendReplaceRel-compose-right rel wfΣ t⊒ p⊒ r≈t⨟p)
+    (extend-replace-here-typed-current qᶜ pᶜ M⊒M′)
+extendReplaceRel-typed-term (replace-here qᶜ)
+    M⊒T@(cast-⊒ᵗ pᶜ _ _ _ _ _) =
+  extend-replace-here-typed-current qᶜ pᶜ M⊒T
 extendReplaceRel-typed-term (replace-right rel) M⊒T = {!!}
 extendReplaceRel-typed-term (replace-left rel) (⊒blameᵗ pᶜ) =
   ⊒blameᵗ (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
@@ -1066,30 +759,38 @@ extendReplaceRel-typed-term (replace-left rel)
     (extendReplaceRel-typed-term (replace-left rel) M⊒M′)
     (extendReplaceRel-typed-term (replace-left rel) N⊒N′)
 extendReplaceRel-typed-term (replace-left rel)
-    (⊒cast+ᵗ qᶜ q⨟s≈r M⊒M′) =
+    (⊒cast+ᵗ qᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
   ⊒cast+ᵗ
     (extendReplaceRel-coercionᶜ (replace-left rel) qᶜ)
-    (extendReplaceRel-compose-left (replace-left rel) q⨟s≈r)
+    wfΣ q⊒ s⊒
+    (extendReplaceRel-compose-left
+      (replace-left rel) wfΣ q⊒ s⊒ q⨟s≈r)
     (extendReplaceRel-typed-term (replace-left rel) M⊒M′)
 extendReplaceRel-typed-term (replace-left rel)
-    (⊒cast-ᵗ qᶜ rᶜ q⨟s≈r M⊒M′) =
+    (⊒cast-ᵗ qᶜ rᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
   ⊒cast-ᵗ
     (extendReplaceRel-coercionᶜ (replace-left rel) qᶜ)
-    (extendReplaceRel-coercionᶜ (replace-left rel) rᶜ)
-    (extendReplaceRel-compose-left (replace-left rel) q⨟s≈r)
+    (extendReplaceRel-coercion (replace-left rel) rᶜ)
+    wfΣ q⊒ s⊒
+    (extendReplaceRel-compose-left
+      (replace-left rel) wfΣ q⊒ s⊒ q⨟s≈r)
     (extendReplaceRel-typed-term (replace-left rel) M⊒M′)
 extendReplaceRel-typed-term (replace-left rel)
-    (cast+⊒ᵗ pᶜ rᶜ r≈t⨟p M⊒M′) =
+    (cast+⊒ᵗ pᶜ rᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
   cast+⊒ᵗ
     (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
-    (extendReplaceRel-coercionᶜ (replace-left rel) rᶜ)
-    (extendReplaceRel-compose-right (replace-left rel) r≈t⨟p)
+    (extendReplaceRel-coercion (replace-left rel) rᶜ)
+    wfΣ t⊒ p⊒
+    (extendReplaceRel-compose-right
+      (replace-left rel) wfΣ t⊒ p⊒ r≈t⨟p)
     (extendReplaceRel-typed-term (replace-left rel) M⊒M′)
 extendReplaceRel-typed-term (replace-left rel)
-    (cast-⊒ᵗ pᶜ r≈t⨟p M⊒M′) =
+    (cast-⊒ᵗ pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
   cast-⊒ᵗ
     (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ)
-    (extendReplaceRel-compose-right (replace-left rel) r≈t⨟p)
+    wfΣ t⊒ p⊒
+    (extendReplaceRel-compose-right
+      (replace-left rel) wfΣ t⊒ p⊒ r≈t⨟p)
     (extendReplaceRel-typed-term (replace-left rel) M⊒M′)
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
     (extendᵗ qᶜ pαᶜ M⊒T) =
@@ -1169,30 +870,38 @@ extendReplaceRel-typed-term (replace-both {q = qh} rel)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) N⊒N′)
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
-    (⊒cast+ᵗ qᶜ q⨟s≈r M⊒M′) =
+    (⊒cast+ᵗ qᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
   ⊒cast+ᵗ
     (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) qᶜ)
-    (extendReplaceRel-compose-left (replace-both {q = qh} rel) q⨟s≈r)
+    wfΣ q⊒ s⊒
+    (extendReplaceRel-compose-left
+      (replace-both {q = qh} rel) wfΣ q⊒ s⊒ q⨟s≈r)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′)
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
-    (⊒cast-ᵗ qᶜ rᶜ q⨟s≈r M⊒M′) =
+    (⊒cast-ᵗ qᶜ rᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
   ⊒cast-ᵗ
     (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) qᶜ)
-    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) rᶜ)
-    (extendReplaceRel-compose-left (replace-both {q = qh} rel) q⨟s≈r)
+    (extendReplaceRel-coercion (replace-both {q = qh} rel) rᶜ)
+    wfΣ q⊒ s⊒
+    (extendReplaceRel-compose-left
+      (replace-both {q = qh} rel) wfΣ q⊒ s⊒ q⨟s≈r)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′)
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
-    (cast+⊒ᵗ pᶜ rᶜ r≈t⨟p M⊒M′) =
+    (cast+⊒ᵗ pᶜ rᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
   cast+⊒ᵗ
     (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
-    (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) rᶜ)
-    (extendReplaceRel-compose-right (replace-both {q = qh} rel) r≈t⨟p)
+    (extendReplaceRel-coercion (replace-both {q = qh} rel) rᶜ)
+    wfΣ t⊒ p⊒
+    (extendReplaceRel-compose-right
+      (replace-both {q = qh} rel) wfΣ t⊒ p⊒ r≈t⨟p)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′)
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
-    (cast-⊒ᵗ pᶜ r≈t⨟p M⊒M′) =
+    (cast-⊒ᵗ pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
   cast-⊒ᵗ
     (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) pᶜ)
-    (extendReplaceRel-compose-right (replace-both {q = qh} rel) r≈t⨟p)
+    wfΣ t⊒ p⊒
+    (extendReplaceRel-compose-right
+      (replace-both {q = qh} rel) wfΣ t⊒ p⊒ r≈t⨟p)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′)
 extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒T = {!!}
 

--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -1510,6 +1510,51 @@ dual-flips-typingᵐ :
 dual-flips-typingᵐ {μ = μ} =
   coercion-dual-flipᵐ (dualActionOkᵈ {μ = μ})
 
+dualActionOk-normal :
+  ∀ {μ} →
+  DualActionOk μ normalᵃ μ
+dualActionOk-normal {μ = μ} X with μ X
+dualActionOk-normal X | id-only = dma-id
+dualActionOk-normal X | tag-or-id = dma-tag
+dualActionOk-normal X | seal-or-id = dma-seal
+
+dualStoreAt-normal :
+  ∀ {Δ μ Σ} →
+  DualStoreAt Δ μ normalᵃ μ Σ Σ
+dualStoreAt-normal {Δ = Δ} {μ = μ} {Σ = Σ} =
+  record { tag★∈ = tag ; seal∈ = sealMember ; seal★ = sealStar }
+  where
+    tag :
+      ∀ {α} →
+      α < Δ →
+      normalᵃ α ≡ tag-to-seal →
+      (α , ★) ∈ Σ
+    tag α<Δ ()
+
+    sealMember :
+      ∀ {α A} →
+      μ α ≡ seal-or-id →
+      normalᵃ α ≡ normal →
+      μ α ≡ seal-or-id →
+      (α , A) ∈ Σ →
+      (α , A) ∈ Σ
+    sealMember μα ηα να αA∈Σ = αA∈Σ
+
+    sealStar :
+      ∀ {α A} →
+      normalᵃ α ≡ seal-to-tag →
+      (α , A) ∈ Σ →
+      A ≡ ★
+    sealStar () αA∈Σ
+
+minus-flips-typingᵐ :
+  ∀ {μ Δ Σ c A B} →
+  StoreWfAt Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  μ ∣ Δ ∣ Σ ⊢ - c ∶ B =⇒ A
+minus-flips-typingᵐ wfΣ c⊢ =
+  coercion-dual-flipᵐ dualActionOk-normal dualStoreAt-normal wfΣ c⊢
+
 ------------------------------------------------------------------------
 -- Coercion endpoint well-formedness
 ------------------------------------------------------------------------
@@ -1855,6 +1900,22 @@ coercion-src-tgtᵐ (cast-gen hA occ c⊢)
     with coercion-src-tgtᵐ c⊢
 coercion-src-tgtᵐ (cast-gen hA occ c⊢) | src-c , tgt-c rewrite tgt-c =
   refl , refl
+
+minus-src-tgtᵐ :
+  ∀ {μ Δ Σ c A B} →
+  StoreWfAt Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  src (- c) ≡ B
+minus-src-tgtᵐ wfΣ c⊢ =
+  proj₁ (coercion-src-tgtᵐ (minus-flips-typingᵐ wfΣ c⊢))
+
+minus-tgt-srcᵐ :
+  ∀ {μ Δ Σ c A B} →
+  StoreWfAt Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  tgt (- c) ≡ A
+minus-tgt-srcᵐ wfΣ c⊢ =
+  proj₂ (coercion-src-tgtᵐ (minus-flips-typingᵐ wfΣ c⊢))
 
 coercion-src-tgt :
   ∀ {Δ Σ c A B} →

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -24,7 +24,6 @@ open import NuTerms
 open import NuReduction
 open import NuStore using (StoreWf; at)
 open import NarrowWiden
-open import NarrowWidenComposition using (_∣_⊢_⨾ⁿ_≈_∶_⊒_)
 open import TermNarrowing
 open import proof.CoercionProperties using (coercion-wf)
 open import proof.Catchup using (catchup-lemma)
@@ -270,6 +269,567 @@ function-application-simulation okM vV′ L⊒L′ M⊒V′
       vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
   {! ? !}
 
+⊕-δ-left-first :
+  ∀ {Δ σ M N m′ n′} →
+  RuntimeOK M →
+  No• N →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ $ (κℕ m′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  Δ ∣ σ ∣ [] ⊢ N ⊒ $ (κℕ n′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  ∃[ χs ] ∃[ P ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+  ∃[ A′ ] ∃[ B′ ] ∃[ p′ ]
+    (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ P ⊒ $ (κℕ (m′ + n′)) ∶ p′ ⦂ A′ ⊒ B′
+⊕-δ-left-first {σ = σ} {M = M} {N = N} {m′ = m′} {n′ = n′}
+    okM noN M⊒M′ N⊒N′
+    with catchup-lemma okM ($ (κℕ m′)) M⊒M′
+⊕-δ-left-first {σ = σ} {M = M} {N = N} {m′ = m′} {n′ = n′}
+    okM noN M⊒M′ N⊒N′
+    | χsM , WM , ΔM , ΠM , ΠM′ , πM ,
+      vWM , noWM , M↠WM , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , WM⊒M′ =
+  let
+    left-steps :
+      M ⊕[ addℕ ] N —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
+    left-steps = ⊕₁-↠ noN M↠WM
+
+    N⊒N′L :
+      ΔM ∣ combineStoreNrw πM σ ∣ []
+        ⊢ applyTerms χsM N ⊒ applyTerms χsM ($ (κℕ n′))
+          ∶ applyCoercions χsM (id (‵ `ℕ))
+            ⦂ applyTys χsM (‵ `ℕ) ⊒ applyTys χsM (‵ `ℕ)
+    N⊒N′L = {! ? !}
+
+    right :
+      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+        Value W ×
+        No• W ×
+        (applyTerms χsM N —↠[ χs ] W) ×
+        (Δ′ ≡ applyTyCtxs χs ΔM) ×
+        (Π ≡ applyStores χs []) ×
+        (Π′ ≡ applyStore keep []) ×
+        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+        Δ′ ∣ combineStoreNrw π (combineStoreNrw πM σ) ∣ []
+          ⊢ W ⊒ applyTerms χs (applyTerms χsM ($ (κℕ n′)))
+            ∶ applyCoercions χs (applyCoercions χsM (id (‵ `ℕ)))
+              ⦂ applyTys χs (applyTys χsM (‵ `ℕ))
+                ⊒ applyTys χs (applyTys χsM (‵ `ℕ))
+    right =
+      catchup-lemma
+        (ok-no (applyTerms-preserves-No• χsM noN))
+        (applyTerms-preserves-Value χsM ($ (κℕ n′)))
+        N⊒N′L
+
+    χsR : StoreChanges
+    χsR = proj₁ right
+
+    W : Term
+    W = proj₁ (proj₂ right)
+
+    ΔR : TyCtx
+    ΔR = proj₁ (proj₂ (proj₂ right))
+
+    ΠR : Store
+    ΠR =
+      proj₁ (proj₂ (proj₂ (proj₂ right)))
+
+    ΠR′ : Store
+    ΠR′ =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ right))))
+
+    πR : StoreNrw
+    πR =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
+
+    tail :
+      Value W ×
+      No• W ×
+      (applyTerms χsM N —↠[ χsR ] W) ×
+      (ΔR ≡ applyTyCtxs χsR ΔM) ×
+      (ΠR ≡ applyStores χsR []) ×
+      (ΠR′ ≡ applyStore keep []) ×
+      (ΔR ⊢ πR ꞉
+        ΠR ⊒ˢ ΠR′) ×
+      ΔR
+        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
+        ⊢ W ⊒ applyTerms χsR (applyTerms χsM ($ (κℕ n′)))
+          ∶ applyCoercions χsR
+              (applyCoercions χsM (id (‵ `ℕ)))
+            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
+              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
+    tail =
+      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
+
+    ΠR≡ : ΠR ≡ applyStores χsR []
+    ΠR≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂ tail))))
+
+    ΠR′≡ : ΠR′ ≡ applyStore keep []
+    ΠR′≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂ tail)))))
+
+    πR⊒ :
+      ΔR ⊢ πR ꞉
+        ΠR ⊒ˢ ΠR′
+    πR⊒ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    vW : Value W
+    vW = proj₁ tail
+
+    N↠W :
+      applyTerms χsM N —↠[ χsR ] W
+    N↠W =
+      proj₁
+        (proj₂
+          (proj₂ tail))
+
+    operands-term : Term
+    operands-term =
+      applyTerms χsR WM ⊕[ addℕ ] W
+
+    right-steps :
+      WM ⊕[ addℕ ] applyTerms χsM N —↠[ χsR ] operands-term
+    right-steps = ⊕₂-↠ vWM noWM N↠W
+
+    operands-ready :
+      M ⊕[ addℕ ] N —↠[ χsM ++ χsR ] operands-term
+    operands-ready = ↠-trans left-steps right-steps
+
+    WM⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ WM ⦂ ‵ `ℕ
+    WM⊢ℕ = source-nat-typing (applyTys-ℕ χsM) WM⊒M′
+
+    W⊒N′ :
+      ΔR
+        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
+        ⊢ W ⊒ applyTerms χsR (applyTerms χsM ($ (κℕ n′)))
+          ∶ applyCoercions χsR
+              (applyCoercions χsM (id (‵ `ℕ)))
+            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
+              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
+    W⊒N′ =
+      proj₂
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    W⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
+    W⊢ℕ =
+      source-nat-typing
+        (applyTys-ℕ-applyTys χsM χsR)
+        W⊒N′
+
+    WM≡target : WM ≡ $ (κℕ m′)
+    WM≡target =
+      value-normalized-id-ℕ-target-const
+        vWM
+        (applyTerms-const χsM (κℕ m′))
+        (applyCoercions-id-ℕ χsM)
+        (applyTys-ℕ χsM)
+        (applyTys-ℕ χsM)
+        WM⊒M′
+
+    W≡target : W ≡ $ (κℕ n′)
+    W≡target =
+      value-normalized-id-ℕ-target-const
+        vW
+        (trans
+          (cong (applyTerms χsR)
+            (applyTerms-const χsM (κℕ n′)))
+          (applyTerms-const χsR (κℕ n′)))
+        (applyCoercions-id-ℕ-applyCoercions χsM χsR)
+        (applyTys-ℕ-applyTys χsM χsR)
+        (applyTys-ℕ-applyTys χsM χsR)
+        W⊒N′
+
+    source-δ :
+      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step
+        {χsL = χsR} {χsR = []}
+        WM≡target
+        W≡target
+
+    χs : StoreChanges
+    χs = (χsM ++ χsR) ++ keep ∷ []
+
+    Δ′ : TyCtx
+    Δ′ = ΔR
+
+    Π : Store
+    Π = srcStoreⁿ (combineStoreNrw πR πM)
+
+    Π′ : Store
+    Π′ = []
+
+    π : StoreNrw
+    π = combineStoreNrw πR πM
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    Π≡ : Π ≡ applyStores χs []
+    Π≡ =
+      trans
+        (combineStoreNrw-applyStores
+          {χs₂ = χsR} {χs₁ = χsM}
+          πR⊒
+          ΠR≡
+          ΠR′≡
+          πM⊒
+          ΠM≡
+          ΠM′≡)
+        (sym (applyStores-++ (χsM ++ χsR) (keep ∷ []) []))
+
+    Π′≡ : Π′ ≡ applyStore keep []
+    Π′≡ = refl
+
+    πM⊒-empty : Δ′ ⊢ πM ꞉ ΠM ⊒ˢ []
+    πM⊒-empty =
+      ⊒ˢ-empty-anyᵗ Δ′
+        (subst (λ Π₀ → ΔM ⊢ πM ꞉ ΠM ⊒ˢ Π₀) ΠM′≡ πM⊒)
+
+    πR⊒-empty :
+      Δ′ ⊢ πR ꞉ ΠR ⊒ˢ []
+    πR⊒-empty =
+      subst
+        (λ Π₀ → Δ′ ⊢ πR ꞉ ΠR ⊒ˢ Π₀)
+        ΠR′≡
+        πR⊒
+
+    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
+    π⊒ =
+      combineStoreNrw-empty-⊒ˢ
+        πR⊒-empty
+        πM⊒-empty
+
+    result⊒ :
+      Δ′ ∣ combineStoreNrw π σ ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ
+        (κℕ (m′ + n′))
+        {typing =
+          term-typing-endpoints
+            (⊢$ (κℕ (m′ + n′)))
+            (⊢$ (κℕ (m′ + n′)))}
+  in
+  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
+  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
+  source-steps ,
+  Π≡ ,
+  Π′≡ ,
+  π⊒ ,
+  result⊒
+
+⊕-δ-right-first :
+  ∀ {Δ σ M N m′ n′} →
+  Value M →
+  No• M →
+  RuntimeOK N →
+  Δ ∣ σ ∣ [] ⊢ M ⊒ $ (κℕ m′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  Δ ∣ σ ∣ [] ⊢ N ⊒ $ (κℕ n′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  ∃[ χs ] ∃[ P ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+  ∃[ A′ ] ∃[ B′ ] ∃[ p′ ]
+    (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+    (Π ≡ applyStores χs []) ×
+    (Π′ ≡ applyStore keep []) ×
+    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ P ⊒ $ (κℕ (m′ + n′)) ∶ p′ ⦂ A′ ⊒ B′
+⊕-δ-right-first {σ = σ} {M = M} {N = N} {m′ = m′} {n′ = n′}
+    vM noM okN M⊒M′ N⊒N′
+    with catchup-lemma okN ($ (κℕ n′)) N⊒N′
+⊕-δ-right-first {σ = σ} {M = M} {N = N} {m′ = m′} {n′ = n′}
+    vM noM okN M⊒M′ N⊒N′
+    | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
+      vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
+  let
+    right-steps :
+      M ⊕[ addℕ ] N —↠[ χsN ] applyTerms χsN M ⊕[ addℕ ] WN
+    right-steps = ⊕₂-↠ vM noM N↠WN
+
+    M⊒M′R :
+      ΔN ∣ combineStoreNrw πN σ ∣ []
+        ⊢ applyTerms χsN M ⊒ applyTerms χsN ($ (κℕ m′))
+          ∶ applyCoercions χsN (id (‵ `ℕ))
+            ⦂ applyTys χsN (‵ `ℕ) ⊒ applyTys χsN (‵ `ℕ)
+    M⊒M′R = {! ? !}
+
+    left :
+      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+        Value W ×
+        No• W ×
+        (applyTerms χsN M —↠[ χs ] W) ×
+        (Δ′ ≡ applyTyCtxs χs ΔN) ×
+        (Π ≡ applyStores χs []) ×
+        (Π′ ≡ applyStore keep []) ×
+        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+        Δ′ ∣ combineStoreNrw π (combineStoreNrw πN σ) ∣ []
+          ⊢ W ⊒ applyTerms χs (applyTerms χsN ($ (κℕ m′)))
+            ∶ applyCoercions χs (applyCoercions χsN (id (‵ `ℕ)))
+              ⦂ applyTys χs (applyTys χsN (‵ `ℕ))
+                ⊒ applyTys χs (applyTys χsN (‵ `ℕ))
+    left =
+      catchup-lemma
+        (ok-no (applyTerms-preserves-No• χsN noM))
+        (applyTerms-preserves-Value χsN ($ (κℕ m′)))
+        M⊒M′R
+
+    χsL : StoreChanges
+    χsL = proj₁ left
+
+    W : Term
+    W = proj₁ (proj₂ left)
+
+    ΔL : TyCtx
+    ΔL = proj₁ (proj₂ (proj₂ left))
+
+    ΠL : Store
+    ΠL =
+      proj₁ (proj₂ (proj₂ (proj₂ left)))
+
+    ΠL′ : Store
+    ΠL′ =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ left))))
+
+    πL : StoreNrw
+    πL =
+      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ left)))))
+
+    tail :
+      Value W ×
+      No• W ×
+      (applyTerms χsN M —↠[ χsL ] W) ×
+      (ΔL ≡ applyTyCtxs χsL ΔN) ×
+      (ΠL ≡ applyStores χsL []) ×
+      (ΠL′ ≡ applyStore keep []) ×
+      (ΔL ⊢ πL ꞉
+        ΠL ⊒ˢ ΠL′) ×
+      ΔL
+        ∣ combineStoreNrw πL (combineStoreNrw πN σ) ∣ []
+        ⊢ W ⊒
+          applyTerms χsL (applyTerms χsN ($ (κℕ m′)))
+          ∶ applyCoercions χsL
+              (applyCoercions χsN (id (‵ `ℕ)))
+            ⦂ applyTys χsL (applyTys χsN (‵ `ℕ))
+              ⊒ applyTys χsL (applyTys χsN (‵ `ℕ))
+    tail =
+      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ left)))))
+
+    ΠL≡ : ΠL ≡ applyStores χsL []
+    ΠL≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂ tail))))
+
+    ΠL′≡ : ΠL′ ≡ applyStore keep []
+    ΠL′≡ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂ tail)))))
+
+    πL⊒ :
+      ΔL ⊢ πL ꞉
+        ΠL ⊒ˢ ΠL′
+    πL⊒ =
+      proj₁
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    vW : Value W
+    vW = proj₁ tail
+
+    M↠W :
+      applyTerms χsN M —↠[ χsL ] W
+    M↠W =
+      proj₁
+        (proj₂
+          (proj₂ tail))
+
+    operands-term : Term
+    operands-term =
+      W ⊕[ addℕ ] applyTerms χsL WN
+
+    left-steps :
+      applyTerms χsN M ⊕[ addℕ ] WN
+        —↠[ χsL ] operands-term
+    left-steps = ⊕₁-↠ noWN M↠W
+
+    operands-ready :
+      M ⊕[ addℕ ] N —↠[ χsN ++ χsL ] operands-term
+    operands-ready = ↠-trans right-steps left-steps
+
+    W⊒M′ :
+      ΔL
+        ∣ combineStoreNrw πL (combineStoreNrw πN σ) ∣ []
+        ⊢ W ⊒ applyTerms χsL (applyTerms χsN ($ (κℕ m′)))
+          ∶ applyCoercions χsL
+              (applyCoercions χsN (id (‵ `ℕ)))
+            ⦂ applyTys χsL (applyTys χsN (‵ `ℕ))
+              ⊒ applyTys χsL (applyTys χsN (‵ `ℕ))
+    W⊒M′ =
+      proj₂
+        (proj₂
+          (proj₂
+            (proj₂
+              (proj₂
+                (proj₂
+                  (proj₂ tail))))))
+
+    W⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
+    W⊢ℕ =
+      source-nat-typing
+        (applyTys-ℕ-applyTys χsN χsL)
+        W⊒M′
+
+    WN⊢ℕ :
+      _ ∣ _ ∣ [] ⊢ WN ⦂ ‵ `ℕ
+    WN⊢ℕ = source-nat-typing (applyTys-ℕ χsN) WN⊒N′
+
+    W≡target : W ≡ $ (κℕ m′)
+    W≡target =
+      value-normalized-id-ℕ-target-const
+        vW
+        (trans
+          (cong (applyTerms χsL)
+            (applyTerms-const χsN (κℕ m′)))
+          (applyTerms-const χsL (κℕ m′)))
+        (applyCoercions-id-ℕ-applyCoercions χsN χsL)
+        (applyTys-ℕ-applyTys χsN χsL)
+        (applyTys-ℕ-applyTys χsN χsL)
+        W⊒M′
+
+    WN≡target : WN ≡ $ (κℕ n′)
+    WN≡target =
+      value-normalized-id-ℕ-target-const
+        vWN
+        (applyTerms-const χsN (κℕ n′))
+        (applyCoercions-id-ℕ χsN)
+        (applyTys-ℕ χsN)
+        (applyTys-ℕ χsN)
+        WN⊒N′
+
+    source-δ :
+      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step
+        {χsL = []} {χsR = χsL}
+        W≡target
+        WN≡target
+
+    χs : StoreChanges
+    χs = (χsN ++ χsL) ++ keep ∷ []
+
+    Δ′ : TyCtx
+    Δ′ = ΔL
+
+    Π : Store
+    Π = srcStoreⁿ (combineStoreNrw πL πN)
+
+    Π′ : Store
+    Π′ = []
+
+    π : StoreNrw
+    π = combineStoreNrw πL πN
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    Π≡ : Π ≡ applyStores χs []
+    Π≡ =
+      trans
+        (combineStoreNrw-applyStores
+          {χs₂ = χsL} {χs₁ = χsN}
+          πL⊒
+          ΠL≡
+          ΠL′≡
+          πN⊒
+          ΠN≡
+          ΠN′≡)
+        (sym (applyStores-++ (χsN ++ χsL) (keep ∷ []) []))
+
+    Π′≡ : Π′ ≡ applyStore keep []
+    Π′≡ = refl
+
+    πN⊒-empty : Δ′ ⊢ πN ꞉ ΠN ⊒ˢ []
+    πN⊒-empty =
+      ⊒ˢ-empty-anyᵗ Δ′
+        (subst (λ Π₀ → ΔN ⊢ πN ꞉ ΠN ⊒ˢ Π₀) ΠN′≡ πN⊒)
+
+    πL⊒-empty :
+      Δ′ ⊢ πL ꞉ ΠL ⊒ˢ []
+    πL⊒-empty =
+      subst
+        (λ Π₀ → Δ′ ⊢ πL ꞉ ΠL ⊒ˢ Π₀)
+        ΠL′≡
+        πL⊒
+
+    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
+    π⊒ =
+      combineStoreNrw-empty-⊒ˢ
+        πL⊒-empty
+        πN⊒-empty
+
+    result⊒ :
+      Δ′ ∣ combineStoreNrw π σ ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ
+        (κℕ (m′ + n′))
+        {typing =
+          term-typing-endpoints
+            (⊢$ (κℕ (m′ + n′)))
+            (⊢$ (κℕ (m′ + n′)))}
+  in
+  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
+  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
+  source-steps ,
+  Π≡ ,
+  Π′≡ ,
+  π⊒ ,
+  result⊒
+
 ------------------------------------------------------------------------
 -- Dynamic gradual guarantee
 ------------------------------------------------------------------------
@@ -404,821 +964,39 @@ dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
   in
   {! ? !}
 dynamicGradualGuarantee {σ = σ} wfΣ (ok-no (no•-⊕ noM noN)) σ⊒ qᶜ
-    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
-    (pure-step δ-⊕)
-    with catchup-lemma (ok-no noM) ($ _) M⊒M′
-       | catchup-lemma (ok-no noN) ($ _) N⊒N′
-dynamicGradualGuarantee {σ = σ} wfΣ (ok-no (no•-⊕ noM noN)) σ⊒ qᶜ
-    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
-    (pure-step (δ-⊕ {m = m′} {n = n′}))
-    | χsM , WM , ΔM , ΠM , ΠM′ , πM ,
-      vWM , noWM , M↠WM , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , WM⊒M′
-    | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
-      vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
-  let
-    left-steps :
-      M ⊕[ addℕ ] N —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
-    left-steps = ⊕₁-↠ noN M↠WM
-
-    N⊒N′L :
-      ΔM ∣ combineStoreNrw πM σ ∣ []
-        ⊢ applyTerms χsM N ⊒ applyTerms χsM N′
-          ∶ applyCoercions χsM (id (‵ `ℕ))
-            ⦂ applyTys χsM (‵ `ℕ) ⊒ applyTys χsM (‵ `ℕ)
-    N⊒N′L = {! ? !}
-
-    right :
-      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
-        Value W ×
-        No• W ×
-        (applyTerms χsM N —↠[ χs ] W) ×
-        (Δ′ ≡ applyTyCtxs χs ΔM) ×
-        (Π ≡ applyStores χs []) ×
-        (Π′ ≡ applyStore keep []) ×
-        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
-        Δ′ ∣ combineStoreNrw π (combineStoreNrw πM σ) ∣ []
-          ⊢ W ⊒ applyTerms χs (applyTerms χsM N′)
-            ∶ applyCoercions χs (applyCoercions χsM (id (‵ `ℕ)))
-              ⦂ applyTys χs (applyTys χsM (‵ `ℕ))
-                ⊒ applyTys χs (applyTys χsM (‵ `ℕ))
-    right =
-      catchup-lemma
-        (ok-no (applyTerms-preserves-No• χsM noN))
-        (applyTerms-preserves-Value χsM ($ (κℕ n′)))
-        N⊒N′L
-
-    χsR : StoreChanges
-    χsR = proj₁ right
-
-    W : Term
-    W = proj₁ (proj₂ right)
-
-    ΔR : TyCtx
-    ΔR = proj₁ (proj₂ (proj₂ right))
-
-    ΠR : Store
-    ΠR =
-      proj₁ (proj₂ (proj₂ (proj₂ right)))
-
-    ΠR′ : Store
-    ΠR′ =
-      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ right))))
-
-    πR : StoreNrw
-    πR =
-      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
-
-    tail :
-      Value W ×
-      No• W ×
-      (applyTerms χsM N —↠[ χsR ] W) ×
-      (ΔR ≡ applyTyCtxs χsR ΔM) ×
-      (ΠR ≡ applyStores χsR []) ×
-      (ΠR′ ≡ applyStore keep []) ×
-      (ΔR ⊢ πR ꞉
-        ΠR ⊒ˢ ΠR′) ×
-      ΔR
-        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
-        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
-          ∶ applyCoercions χsR
-              (applyCoercions χsM (id (‵ `ℕ)))
-            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
-              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
-    tail =
-      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
-
-    ΠR≡ : ΠR ≡ applyStores χsR []
-    ΠR≡ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂ tail))))
-
-    ΠR′≡ : ΠR′ ≡ applyStore keep []
-    ΠR′≡ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂ tail)))))
-
-    πR⊒ :
-      ΔR ⊢ πR ꞉
-        ΠR ⊒ˢ ΠR′
-    πR⊒ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂
-                  (proj₂ tail))))))
-
-    vW : Value W
-    vW = proj₁ tail
-
-    N↠W :
-      applyTerms χsM N —↠[ χsR ] W
-    N↠W =
-      proj₁
-        (proj₂
-          (proj₂ tail))
-
-    operands-term : Term
-    operands-term =
-      applyTerms χsR WM ⊕[ addℕ ] W
-
-    right-steps :
-      WM ⊕[ addℕ ] applyTerms χsM N —↠[ χsR ] operands-term
-    right-steps = ⊕₂-↠ vWM noWM N↠W
-
-    operands-ready :
-      M ⊕[ addℕ ] N —↠[ χsM ++ χsR ] operands-term
-    operands-ready = ↠-trans left-steps right-steps
-
-    WM⊢ℕ :
-      _ ∣ _ ∣ [] ⊢ WM ⦂ ‵ `ℕ
-    WM⊢ℕ = source-nat-typing (applyTys-ℕ χsM) WM⊒M′
-
-    W⊒N′ :
-      ΔR
-        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
-        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
-          ∶ applyCoercions χsR
-              (applyCoercions χsM (id (‵ `ℕ)))
-            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
-              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
-    W⊒N′ =
-      proj₂
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂
-                  (proj₂ tail))))))
-
-    W⊢ℕ :
-      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
-    W⊢ℕ =
-      source-nat-typing
-        (applyTys-ℕ-applyTys χsM χsR)
-        W⊒N′
-
-    WM≡target : WM ≡ $ (κℕ m′)
-    WM≡target =
-      value-normalized-id-ℕ-target-const
-        vWM
-        (applyTerms-const χsM (κℕ m′))
-        (applyCoercions-id-ℕ χsM)
-        (applyTys-ℕ χsM)
-        (applyTys-ℕ χsM)
-        WM⊒M′
-
-    W≡target : W ≡ $ (κℕ n′)
-    W≡target =
-      value-normalized-id-ℕ-target-const
-        vW
-        (trans
-          (cong (applyTerms χsR)
-            (applyTerms-const χsM (κℕ n′)))
-          (applyTerms-const χsR (κℕ n′)))
-        (applyCoercions-id-ℕ-applyCoercions χsM χsR)
-        (applyTys-ℕ-applyTys χsM χsR)
-        (applyTys-ℕ-applyTys χsM χsR)
-        W⊒N′
-
-    source-δ :
-      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
-    source-δ =
-      constant-⊕-δ-step
-        {χsL = χsR} {χsR = []}
-        WM≡target
-        W≡target
-
-    χs : StoreChanges
-    χs = (χsM ++ χsR) ++ keep ∷ []
-
-    Δ′ : TyCtx
-    Δ′ = ΔR
-
-    Π : Store
-    Π = srcStoreⁿ (combineStoreNrw πR πM)
-
-    Π′ : Store
-    Π′ = []
-
-    π : StoreNrw
-    π = combineStoreNrw πR πM
-
-    source-steps :
-      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
-    source-steps = ↠-trans operands-ready source-δ
-
-    Π≡ : Π ≡ applyStores χs []
-    Π≡ =
-      trans
-        (combineStoreNrw-applyStores
-          {χs₂ = χsR} {χs₁ = χsM}
-          πR⊒
-          ΠR≡
-          ΠR′≡
-          πM⊒
-          ΠM≡
-          ΠM′≡)
-        (sym (applyStores-++ (χsM ++ χsR) (keep ∷ []) []))
-
-    Π′≡ : Π′ ≡ applyStore keep []
-    Π′≡ = refl
-
-    πM⊒-empty : Δ′ ⊢ πM ꞉ ΠM ⊒ˢ []
-    πM⊒-empty =
-      ⊒ˢ-empty-anyᵗ Δ′
-        (subst (λ Π₀ → ΔM ⊢ πM ꞉ ΠM ⊒ˢ Π₀) ΠM′≡ πM⊒)
-
-    πR⊒-empty :
-      Δ′ ⊢ πR ꞉ ΠR ⊒ˢ []
-    πR⊒-empty =
-      subst
-        (λ Π₀ → Δ′ ⊢ πR ꞉ ΠR ⊒ˢ Π₀)
-        ΠR′≡
-        πR⊒
-
-    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
-    π⊒ =
-      combineStoreNrw-empty-⊒ˢ
-        πR⊒-empty
-        πM⊒-empty
-
-    result⊒ :
-      Δ′ ∣ combineStoreNrw π σ ∣ []
-        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
-          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
-    result⊒ =
-      κ⊒κᵗ
-        (κℕ (m′ + n′))
-        {typing =
-          term-typing-endpoints
-            (⊢$ (κℕ (m′ + n′)))
-            (⊢$ (κℕ (m′ + n′)))}
-  in
-  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
-  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
-  source-steps ,
-  Π≡ ,
-  Π′≡ ,
-  π⊒ ,
-  result⊒
+    (⊕⊒⊕ᵗ {M = M} {N = N} M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′})) =
+  ⊕-δ-left-first {σ = σ} {M = M} {N = N}
+    {m′ = m′} {n′ = n′}
+    (ok-no noM) noN M⊒M′ N⊒N′
 dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₁ okM noN) σ⊒ qᶜ
-    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
-    (pure-step δ-⊕)
-    with catchup-lemma okM ($ _) M⊒M′
-       | catchup-lemma (ok-no noN) ($ _) N⊒N′
-dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₁ okM noN) σ⊒ qᶜ
-    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
-    (pure-step (δ-⊕ {m = m′} {n = n′}))
-    | χsM , WM , ΔM , ΠM , ΠM′ , πM ,
-      vWM , noWM , M↠WM , ΔM≡ , ΠM≡ , ΠM′≡ , πM⊒ , WM⊒M′
-    | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
-      vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
-  let
-    left-steps :
-      M ⊕[ addℕ ] N —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
-    left-steps = ⊕₁-↠ noN M↠WM
-
-    N⊒N′L :
-      ΔM ∣ combineStoreNrw πM σ ∣ []
-        ⊢ applyTerms χsM N ⊒ applyTerms χsM N′
-          ∶ applyCoercions χsM (id (‵ `ℕ))
-            ⦂ applyTys χsM (‵ `ℕ) ⊒ applyTys χsM (‵ `ℕ)
-    N⊒N′L = {! ? !}
-
-    right :
-      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
-        Value W ×
-        No• W ×
-        (applyTerms χsM N —↠[ χs ] W) ×
-        (Δ′ ≡ applyTyCtxs χs ΔM) ×
-        (Π ≡ applyStores χs []) ×
-        (Π′ ≡ applyStore keep []) ×
-        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
-        Δ′ ∣ combineStoreNrw π (combineStoreNrw πM σ) ∣ []
-          ⊢ W ⊒ applyTerms χs (applyTerms χsM N′)
-            ∶ applyCoercions χs (applyCoercions χsM (id (‵ `ℕ)))
-              ⦂ applyTys χs (applyTys χsM (‵ `ℕ))
-                ⊒ applyTys χs (applyTys χsM (‵ `ℕ))
-    right =
-      catchup-lemma
-        (ok-no (applyTerms-preserves-No• χsM noN))
-        (applyTerms-preserves-Value χsM ($ (κℕ n′)))
-        N⊒N′L
-
-    χsR : StoreChanges
-    χsR = proj₁ right
-
-    W : Term
-    W = proj₁ (proj₂ right)
-
-    ΔR : TyCtx
-    ΔR = proj₁ (proj₂ (proj₂ right))
-
-    ΠR : Store
-    ΠR =
-      proj₁ (proj₂ (proj₂ (proj₂ right)))
-
-    ΠR′ : Store
-    ΠR′ =
-      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ right))))
-
-    πR : StoreNrw
-    πR =
-      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
-
-    tail :
-      Value W ×
-      No• W ×
-      (applyTerms χsM N —↠[ χsR ] W) ×
-      (ΔR ≡ applyTyCtxs χsR ΔM) ×
-      (ΠR ≡ applyStores χsR []) ×
-      (ΠR′ ≡ applyStore keep []) ×
-      (ΔR ⊢ πR ꞉
-        ΠR ⊒ˢ ΠR′) ×
-      ΔR
-        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
-        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
-          ∶ applyCoercions χsR
-              (applyCoercions χsM (id (‵ `ℕ)))
-            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
-              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
-    tail =
-      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ right)))))
-
-    ΠR≡ : ΠR ≡ applyStores χsR []
-    ΠR≡ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂ tail))))
-
-    ΠR′≡ : ΠR′ ≡ applyStore keep []
-    ΠR′≡ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂ tail)))))
-
-    πR⊒ :
-      ΔR ⊢ πR ꞉
-        ΠR ⊒ˢ ΠR′
-    πR⊒ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂
-                  (proj₂ tail))))))
-
-    vW : Value W
-    vW = proj₁ tail
-
-    N↠W :
-      applyTerms χsM N —↠[ χsR ] W
-    N↠W =
-      proj₁
-        (proj₂
-          (proj₂ tail))
-
-    operands-term : Term
-    operands-term =
-      applyTerms χsR WM ⊕[ addℕ ] W
-
-    right-steps :
-      WM ⊕[ addℕ ] applyTerms χsM N —↠[ χsR ] operands-term
-    right-steps = ⊕₂-↠ vWM noWM N↠W
-
-    operands-ready :
-      M ⊕[ addℕ ] N —↠[ χsM ++ χsR ] operands-term
-    operands-ready = ↠-trans left-steps right-steps
-
-    WM⊢ℕ :
-      _ ∣ _ ∣ [] ⊢ WM ⦂ ‵ `ℕ
-    WM⊢ℕ = source-nat-typing (applyTys-ℕ χsM) WM⊒M′
-
-    W⊒N′ :
-      ΔR
-        ∣ combineStoreNrw πR (combineStoreNrw πM σ) ∣ []
-        ⊢ W ⊒ applyTerms χsR (applyTerms χsM N′)
-          ∶ applyCoercions χsR
-              (applyCoercions χsM (id (‵ `ℕ)))
-            ⦂ applyTys χsR (applyTys χsM (‵ `ℕ))
-              ⊒ applyTys χsR (applyTys χsM (‵ `ℕ))
-    W⊒N′ =
-      proj₂
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂
-                  (proj₂ tail))))))
-
-    W⊢ℕ :
-      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
-    W⊢ℕ =
-      source-nat-typing
-        (applyTys-ℕ-applyTys χsM χsR)
-        W⊒N′
-
-    WM≡target : WM ≡ $ (κℕ m′)
-    WM≡target =
-      value-normalized-id-ℕ-target-const
-        vWM
-        (applyTerms-const χsM (κℕ m′))
-        (applyCoercions-id-ℕ χsM)
-        (applyTys-ℕ χsM)
-        (applyTys-ℕ χsM)
-        WM⊒M′
-
-    W≡target : W ≡ $ (κℕ n′)
-    W≡target =
-      value-normalized-id-ℕ-target-const
-        vW
-        (trans
-          (cong (applyTerms χsR)
-            (applyTerms-const χsM (κℕ n′)))
-          (applyTerms-const χsR (κℕ n′)))
-        (applyCoercions-id-ℕ-applyCoercions χsM χsR)
-        (applyTys-ℕ-applyTys χsM χsR)
-        (applyTys-ℕ-applyTys χsM χsR)
-        W⊒N′
-
-    source-δ :
-      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
-    source-δ =
-      constant-⊕-δ-step
-        {χsL = χsR} {χsR = []}
-        WM≡target
-        W≡target
-
-    χs : StoreChanges
-    χs = (χsM ++ χsR) ++ keep ∷ []
-
-    Δ′ : TyCtx
-    Δ′ = ΔR
-
-    Π : Store
-    Π = srcStoreⁿ (combineStoreNrw πR πM)
-
-    Π′ : Store
-    Π′ = []
-
-    π : StoreNrw
-    π = combineStoreNrw πR πM
-
-    source-steps :
-      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
-    source-steps = ↠-trans operands-ready source-δ
-
-    Π≡ : Π ≡ applyStores χs []
-    Π≡ =
-      trans
-        (combineStoreNrw-applyStores
-          {χs₂ = χsR} {χs₁ = χsM}
-          πR⊒
-          ΠR≡
-          ΠR′≡
-          πM⊒
-          ΠM≡
-          ΠM′≡)
-        (sym (applyStores-++ (χsM ++ χsR) (keep ∷ []) []))
-
-    Π′≡ : Π′ ≡ applyStore keep []
-    Π′≡ = refl
-
-    πM⊒-empty : Δ′ ⊢ πM ꞉ ΠM ⊒ˢ []
-    πM⊒-empty =
-      ⊒ˢ-empty-anyᵗ Δ′
-        (subst (λ Π₀ → ΔM ⊢ πM ꞉ ΠM ⊒ˢ Π₀) ΠM′≡ πM⊒)
-
-    πR⊒-empty :
-      Δ′ ⊢ πR ꞉ ΠR ⊒ˢ []
-    πR⊒-empty =
-      subst
-        (λ Π₀ → Δ′ ⊢ πR ꞉ ΠR ⊒ˢ Π₀)
-        ΠR′≡
-        πR⊒
-
-    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
-    π⊒ =
-      combineStoreNrw-empty-⊒ˢ
-        πR⊒-empty
-        πM⊒-empty
-
-    result⊒ :
-      Δ′ ∣ combineStoreNrw π σ ∣ []
-        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
-          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
-    result⊒ =
-      κ⊒κᵗ
-        (κℕ (m′ + n′))
-        {typing =
-          term-typing-endpoints
-            (⊢$ (κℕ (m′ + n′)))
-            (⊢$ (κℕ (m′ + n′)))}
-  in
-  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
-  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
-  source-steps ,
-  Π≡ ,
-  Π′≡ ,
-  π⊒ ,
-  result⊒
+    (⊕⊒⊕ᵗ {M = M} {N = N} M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′})) =
+  ⊕-δ-left-first {σ = σ} {M = M} {N = N}
+    {m′ = m′} {n′ = n′}
+    okM noN M⊒M′ N⊒N′
 dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₂ vM noM okN) σ⊒ qᶜ
-    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
-    (pure-step δ-⊕)
-    with catchup-lemma okN ($ _) N⊒N′
-dynamicGradualGuarantee {σ = σ} wfΣ (ok-⊕₂ vM noM okN) σ⊒ qᶜ
-    (⊕⊒⊕ᵗ {M = M} {M′ = M′} {N = N} {N′ = N′} M⊒M′ N⊒N′)
-    (pure-step (δ-⊕ {m = m′} {n = n′}))
-    | χsN , WN , ΔN , ΠN , ΠN′ , πN ,
-      vWN , noWN , N↠WN , ΔN≡ , ΠN≡ , ΠN′≡ , πN⊒ , WN⊒N′ =
-  let
-    right-steps :
-      M ⊕[ addℕ ] N —↠[ χsN ] applyTerms χsN M ⊕[ addℕ ] WN
-    right-steps = ⊕₂-↠ vM noM N↠WN
-
-    M⊒M′R :
-      ΔN ∣ combineStoreNrw πN σ ∣ []
-        ⊢ applyTerms χsN M ⊒ applyTerms χsN M′
-          ∶ applyCoercions χsN (id (‵ `ℕ))
-            ⦂ applyTys χsN (‵ `ℕ) ⊒ applyTys χsN (‵ `ℕ)
-    M⊒M′R = {! ? !}
-
-    left :
-      ∃[ χs ] ∃[ W ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
-        Value W ×
-        No• W ×
-        (applyTerms χsN M —↠[ χs ] W) ×
-        (Δ′ ≡ applyTyCtxs χs ΔN) ×
-        (Π ≡ applyStores χs []) ×
-        (Π′ ≡ applyStore keep []) ×
-        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
-        Δ′ ∣ combineStoreNrw π (combineStoreNrw πN σ) ∣ []
-          ⊢ W ⊒ applyTerms χs (applyTerms χsN M′)
-            ∶ applyCoercions χs (applyCoercions χsN (id (‵ `ℕ)))
-              ⦂ applyTys χs (applyTys χsN (‵ `ℕ))
-                ⊒ applyTys χs (applyTys χsN (‵ `ℕ))
-    left =
-      catchup-lemma
-        (ok-no (applyTerms-preserves-No• χsN noM))
-        (applyTerms-preserves-Value χsN ($ (κℕ m′)))
-        M⊒M′R
-
-    χsL : StoreChanges
-    χsL = proj₁ left
-
-    W : Term
-    W = proj₁ (proj₂ left)
-
-    ΔL : TyCtx
-    ΔL = proj₁ (proj₂ (proj₂ left))
-
-    ΠL : Store
-    ΠL =
-      proj₁ (proj₂ (proj₂ (proj₂ left)))
-
-    ΠL′ : Store
-    ΠL′ =
-      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ left))))
-
-    πL : StoreNrw
-    πL =
-      proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ left)))))
-
-    tail :
-      Value W ×
-      No• W ×
-      (applyTerms χsN M —↠[ χsL ] W) ×
-      (ΔL ≡ applyTyCtxs χsL ΔN) ×
-      (ΠL ≡ applyStores χsL []) ×
-      (ΠL′ ≡ applyStore keep []) ×
-      (ΔL ⊢ πL ꞉
-        ΠL ⊒ˢ ΠL′) ×
-      ΔL
-        ∣ combineStoreNrw πL (combineStoreNrw πN σ) ∣ []
-        ⊢ W ⊒
-          applyTerms χsL (applyTerms χsN M′)
-          ∶ applyCoercions χsL
-              (applyCoercions χsN (id (‵ `ℕ)))
-            ⦂ applyTys χsL (applyTys χsN (‵ `ℕ))
-              ⊒ applyTys χsL (applyTys χsN (‵ `ℕ))
-    tail =
-      proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ left)))))
-
-    ΠL≡ : ΠL ≡ applyStores χsL []
-    ΠL≡ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂ tail))))
-
-    ΠL′≡ : ΠL′ ≡ applyStore keep []
-    ΠL′≡ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂ tail)))))
-
-    πL⊒ :
-      ΔL ⊢ πL ꞉
-        ΠL ⊒ˢ ΠL′
-    πL⊒ =
-      proj₁
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂
-                  (proj₂ tail))))))
-
-    vW : Value W
-    vW = proj₁ tail
-
-    M↠W :
-      applyTerms χsN M —↠[ χsL ] W
-    M↠W =
-      proj₁
-        (proj₂
-          (proj₂ tail))
-
-    operands-term : Term
-    operands-term =
-      W ⊕[ addℕ ] applyTerms χsL WN
-
-    left-steps :
-      applyTerms χsN M ⊕[ addℕ ] WN
-        —↠[ χsL ] operands-term
-    left-steps = ⊕₁-↠ noWN M↠W
-
-    operands-ready :
-      M ⊕[ addℕ ] N —↠[ χsN ++ χsL ] operands-term
-    operands-ready = ↠-trans right-steps left-steps
-
-    W⊒M′ :
-      ΔL
-        ∣ combineStoreNrw πL (combineStoreNrw πN σ) ∣ []
-        ⊢ W ⊒ applyTerms χsL (applyTerms χsN M′)
-          ∶ applyCoercions χsL
-              (applyCoercions χsN (id (‵ `ℕ)))
-            ⦂ applyTys χsL (applyTys χsN (‵ `ℕ))
-              ⊒ applyTys χsL (applyTys χsN (‵ `ℕ))
-    W⊒M′ =
-      proj₂
-        (proj₂
-          (proj₂
-            (proj₂
-              (proj₂
-                (proj₂
-                  (proj₂ tail))))))
-
-    W⊢ℕ :
-      _ ∣ _ ∣ [] ⊢ W ⦂ ‵ `ℕ
-    W⊢ℕ =
-      source-nat-typing
-        (applyTys-ℕ-applyTys χsN χsL)
-        W⊒M′
-
-    WN⊢ℕ :
-      _ ∣ _ ∣ [] ⊢ WN ⦂ ‵ `ℕ
-    WN⊢ℕ = source-nat-typing (applyTys-ℕ χsN) WN⊒N′
-
-    W≡target : W ≡ $ (κℕ m′)
-    W≡target =
-      value-normalized-id-ℕ-target-const
-        vW
-        (trans
-          (cong (applyTerms χsL)
-            (applyTerms-const χsN (κℕ m′)))
-          (applyTerms-const χsL (κℕ m′)))
-        (applyCoercions-id-ℕ-applyCoercions χsN χsL)
-        (applyTys-ℕ-applyTys χsN χsL)
-        (applyTys-ℕ-applyTys χsN χsL)
-        W⊒M′
-
-    WN≡target : WN ≡ $ (κℕ n′)
-    WN≡target =
-      value-normalized-id-ℕ-target-const
-        vWN
-        (applyTerms-const χsN (κℕ n′))
-        (applyCoercions-id-ℕ χsN)
-        (applyTys-ℕ χsN)
-        (applyTys-ℕ χsN)
-        WN⊒N′
-
-    source-δ :
-      operands-term —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
-    source-δ =
-      constant-⊕-δ-step
-        {χsL = []} {χsR = χsL}
-        W≡target
-        WN≡target
-
-    χs : StoreChanges
-    χs = (χsN ++ χsL) ++ keep ∷ []
-
-    Δ′ : TyCtx
-    Δ′ = ΔL
-
-    Π : Store
-    Π = srcStoreⁿ (combineStoreNrw πL πN)
-
-    Π′ : Store
-    Π′ = []
-
-    π : StoreNrw
-    π = combineStoreNrw πL πN
-
-    source-steps :
-      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
-    source-steps = ↠-trans operands-ready source-δ
-
-    Π≡ : Π ≡ applyStores χs []
-    Π≡ =
-      trans
-        (combineStoreNrw-applyStores
-          {χs₂ = χsL} {χs₁ = χsN}
-          πL⊒
-          ΠL≡
-          ΠL′≡
-          πN⊒
-          ΠN≡
-          ΠN′≡)
-        (sym (applyStores-++ (χsN ++ χsL) (keep ∷ []) []))
-
-    Π′≡ : Π′ ≡ applyStore keep []
-    Π′≡ = refl
-
-    πN⊒-empty : Δ′ ⊢ πN ꞉ ΠN ⊒ˢ []
-    πN⊒-empty =
-      ⊒ˢ-empty-anyᵗ Δ′
-        (subst (λ Π₀ → ΔN ⊢ πN ꞉ ΠN ⊒ˢ Π₀) ΠN′≡ πN⊒)
-
-    πL⊒-empty :
-      Δ′ ⊢ πL ꞉ ΠL ⊒ˢ []
-    πL⊒-empty =
-      subst
-        (λ Π₀ → Δ′ ⊢ πL ꞉ ΠL ⊒ˢ Π₀)
-        ΠL′≡
-        πL⊒
-
-    π⊒ : Δ′ ⊢ π ꞉ Π ⊒ˢ Π′
-    π⊒ =
-      combineStoreNrw-empty-⊒ˢ
-        πL⊒-empty
-        πN⊒-empty
-
-    result⊒ :
-      Δ′ ∣ combineStoreNrw π σ ∣ []
-        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
-          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
-    result⊒ =
-      κ⊒κᵗ
-        (κℕ (m′ + n′))
-        {typing =
-          term-typing-endpoints
-            (⊢$ (κℕ (m′ + n′)))
-            (⊢$ (κℕ (m′ + n′)))}
-  in
-  χs , $ (κℕ (m′ + n′)) , Δ′ , Π , Π′ , π ,
-  ‵ `ℕ , ‵ `ℕ , id (‵ `ℕ) ,
-  source-steps ,
-  Π≡ ,
-  Π′≡ ,
-  π⊒ ,
-  result⊒
+    (⊕⊒⊕ᵗ {M = M} {N = N} M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′})) =
+  ⊕-δ-right-first {σ = σ} {M = M} {N = N}
+    {m′ = m′} {n′ = n′}
+    vM noM okN M⊒M′ N⊒N′
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
-    (⊒cast+ᵗ {s = id A} q₀ᶜ q⨟s≈r M⊒M′)
+    (⊒cast+ᵗ {s = id A} q₀ᶜ wfΠ q⊒ s⊒ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
     with catchup-lemma okM vV M⊒M′
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
-    (⊒cast+ᵗ {s = id A} q₀ᶜ q⨟s≈r M⊒M′)
+    (⊒cast+ᵗ {s = id A} q₀ᶜ wfΠ q⊒ s⊒ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =
   {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
-    (⊒cast-ᵗ {s = id A} q₀ᶜ rᶜ q⨟s≈r M⊒M′)
+    (⊒cast-ᵗ {s = id A} q₀ᶜ rᶜ wfΠ q⊒ s⊒ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
     with catchup-lemma okM vV M⊒M′
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
-    (⊒cast-ᵗ {s = id A} q₀ᶜ rᶜ q⨟s≈r M⊒M′)
+    (⊒cast-ᵗ {s = id A} q₀ᶜ rᶜ wfΠ q⊒ s⊒ q⨟s≈r M⊒M′)
     (pure-step (β-id vV))
     | χs , W , Δ′ , Π , Π′ , π ,
       vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒M′ =

--- a/GTSF/proof/LeftSealNarrowingInversion.agda
+++ b/GTSF/proof/LeftSealNarrowingInversion.agda
@@ -188,16 +188,14 @@ termNarrowing-gen-open-id-var-aux⊥ refl (⊒cast+ qᶜ q⨟s≈r M⊒M′)
     open-id =
   gen-open-id-var⊥ qᶜ open-id
 termNarrowing-gen-open-id-var-aux⊥ refl
-    (⊒cast- qᶜ
-      (compose-leftⁿ wfΣ q⊒ s⊒
-        (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+    (⊒cast- qᶜ wfΣ q⊒ s⊒
+      (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
       M⊒M′)
     open-id =
   gen-open-id-var∃⊥ r⊒ open-id
 termNarrowing-gen-open-id-var-aux⊥ refl
-    (cast+⊒ pᶜ
-      (compose-rightⁿ wfΣ t⊒ p⊒
-        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+    (cast+⊒ pᶜ wfΣ t⊒ p⊒
+      (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
       M⊒M′)
     open-id =
   gen-open-id-var∃⊥ r⊒ open-id
@@ -281,9 +279,8 @@ leftSealNarrowingInversion-aux eq refl vV
 -- Left positive cast: Agda can expose this case with the equality-indexed
 -- helper, but the proof still needs inversion of the dual coercion `- t`.
 leftSealNarrowingInversion-aux eq refl vV
-    (cast+⊒ pᶜ
-      (compose-rightⁿ wfΣ t⊒ p⊒
-        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+    (cast+⊒ pᶜ wfΣ t⊒ p⊒
+      (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
       M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
     (⊒blame (cast-id hα ok , cross (id-＇ α))) =
@@ -295,21 +292,18 @@ leftSealNarrowingInversion-aux refl refl vV
 -- Right cast cases: the paper says these recurse because the cast must be
 -- identity-like, but endpoint equivalence does not yet give that directly.
 leftSealNarrowingInversion-aux refl refl vV
-    (⊒cast+ (cast-id hα okα , cross (id-＇ α))
-      (compose-leftⁿ wfΣ q⊒ s⊒
-        (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+    (⊒cast+ (cast-id hα okα , cross (id-＇ α)) wfΣ q⊒ s⊒
+      (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
       M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
-    (⊒cast- qᶜ
-      (compose-leftⁿ wfΣ q⊒ s⊒
-        (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+    (⊒cast- qᶜ wfΣ q⊒ s⊒
+      (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
       M⊒M′) = {!!}
 leftSealNarrowingInversion-aux refl refl vV
-    (cast-⊒ {r = r} pᶜ
-      (compose-rightⁿ wfΣ
-        t⊒@(cast-seal h★′ α∈Σ seal-ok , sealⁿ ★ α)
-        p⊒@(cast-id hα okα , cross (id-＇ α))
-        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+    (cast-⊒ {r = r} pᶜ wfΣ
+      t⊒@(cast-seal h★′ α∈Σ seal-ok , sealⁿ ★ α)
+      p⊒@(cast-id hα okα , cross (id-＇ α))
+      (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
       M⊒M′) =
   -- Direct left negative cast: the typed `★`-to-`α` witness comes from the
   -- composed coercion at the source endpoint store.  The remaining work is

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -123,6 +123,58 @@ tgtStoreⁿ-⊒ˢ (⊒ˢ-both {X = X} hA hA′ (μ , s⊒) σ⊒) =
       (sym (proj₂ (coercion-src-tgtᵐ (proj₁ s⊒)))))
     (tgtStoreⁿ-⊒ˢ σ⊒)
 
+⊑ˢ-target-unique :
+  ∀ {Δ σ Σ Σ′ Π Π′} →
+  Δ ⊢ σ ꞉ Σ ⊑ˢ Σ′ →
+  Δ ⊢ σ ꞉ Π ⊑ˢ Π′ →
+  Σ′ ≡ Π′
+⊑ˢ-target-unique ⊑ˢ-nil ⊑ˢ-nil = refl
+⊑ˢ-target-unique (⊑ˢ-left hA σ⊑) (⊑ˢ-left hB π⊑) =
+  ⊑ˢ-target-unique σ⊑ π⊑
+⊑ˢ-target-unique (⊑ˢ-right {X = X} σ⊑) (⊑ˢ-right π⊑) =
+  cong (λ Σ′ → (X , ★) ∷ Σ′) (⊑ˢ-target-unique σ⊑ π⊑)
+⊑ˢ-target-unique
+    (⊑ˢ-both {X = X} hA hA′ (μ , s⊑) σ⊑)
+    (⊑ˢ-both hB hB′ (ν , t⊑) π⊑) =
+  cong₂ _∷_
+    (cong (λ A → (X , A))
+      (trans
+        (sym (proj₂ (coercion-src-tgtᵐ (proj₁ s⊑))))
+        (proj₂ (coercion-src-tgtᵐ (proj₁ t⊑)))))
+    (⊑ˢ-target-unique σ⊑ π⊑)
+
+≈ⁿ-trans :
+  ∀ {Δ σ r s t A B} →
+  Δ ∣ σ ⊢ r ≈ s ∶ A ⊒ B →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊒ B →
+  Δ ∣ σ ⊢ r ≈ t ∶ A ⊒ B
+≈ⁿ-trans {Δ = Δ} {t = t} {A = A} {B = B}
+    (endpointsⁿ {Σ = Σ} {Σ′ = Σ′}
+      srcr tgtr srcs tgts σ⊒ wfΣ wfΣ′ r⊒ s⊒)
+    (endpointsⁿ {Σ = Π} {Σ′ = Π′}
+      srcs′ tgts′ srct tgtt π⊒ wfΠ wfΠ′ s⊒′ t⊒) =
+  endpointsⁿ srcr tgtr srct tgtt σ⊒ wfΣ wfΣ′ r⊒
+    (subst
+      (λ Σ₀ → Δ ∣ Σ₀ ⊢ t ∶ A ⊒ B)
+      (trans (srcStoreⁿ-⊒ˢ π⊒) (sym (srcStoreⁿ-⊒ˢ σ⊒)))
+      t⊒)
+
+≈ʷ-trans :
+  ∀ {Δ σ r s t A B} →
+  Δ ∣ σ ⊢ r ≈ s ∶ A ⊑ B →
+  Δ ∣ σ ⊢ s ≈ t ∶ A ⊑ B →
+  Δ ∣ σ ⊢ r ≈ t ∶ A ⊑ B
+≈ʷ-trans {Δ = Δ} {t = t} {A = A} {B = B}
+    (endpoints {Σ = Σ} {Σ′ = Σ′}
+      srcr tgtr srcs tgts σ⊑ wfΣ wfΣ′ r⊑ s⊑)
+    (endpoints {Σ = Π} {Σ′ = Π′}
+      srcs′ tgts′ srct tgtt π⊑ wfΠ wfΠ′ s⊑′ t⊑) =
+  endpoints srcr tgtr srct tgtt σ⊑ wfΣ wfΣ′ r⊑
+    (subst
+      (λ Σ₀ → ∃[ μ ] μ ∣ Δ ∣ Σ₀ ⊢ t ∶ A ⊑ B)
+      (⊑ˢ-target-unique π⊑ σ⊑)
+      t⊑)
+
 srcStoreⁿ-⇑ˢ :
   ∀ σ →
   srcStoreⁿ (⇑ˢ σ) ≡ ⟰ᵗ (srcStoreⁿ σ)

--- a/GTSF/proof/RightSealInversion2.agda
+++ b/GTSF/proof/RightSealInversion2.agda
@@ -9,7 +9,7 @@ module proof.RightSealInversion2 where
 --     counterexample documents why arbitrary `V ⟨ unseal α A ⟩` is too
 --     broad.
 --   * The exported call-site statement takes the right-cast premises that DGG
---     already has: the composition `q ⨾ seal B α ≈ r` and the premise
+--     already has: the explicit composition of `q` with `seal B α` and the premise
 --     narrowing to the sealed value `V ⟨ seal A α ⟩`.
 --   * The counterexample uses `ν⊒` and a context variable: inside the fresh
 --     source-only store, the variable can be unsealed on the left and then
@@ -39,50 +39,63 @@ open import proof.NarrowWidenProperties using
 
 GeneralRightSealInversion2 : Set₁
 GeneralRightSealInversion2 =
-  ∀ {Δ σ γ M V q A α} →
+  ∀ {Δ σ γ M V q A α E Σ μ} →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ src q ⊒ E) →
+  (seal⊒ : μ ∣ Δ ∣ Σ ⊢ seal A α ∶ E ⊒ ＇ α) →
   Δ ∣ σ ∣ γ ⊢ M ⊒ V ⟨ unseal α A ⟩ ∶ q →
   ∃[ r ]
-    (Δ ∣ σ ⊢ q ⨾ⁿ seal A α ≈ r ∶ src q ⊒ ＇ α) ×
+    (Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ seal⊒)
+      ≈ r ∶ src q ⊒ ＇ α) ×
     Δ ∣ σ ∣ γ ⊢ M ⊒ V ∶ r
 
 RightSealInversion2 : Set₁
 RightSealInversion2 =
-  ∀ {Δ σ M V q r A B C D E F α} →
+  ∀ {Δ σ M V q r A B C D E F G α Σ μ} →
   Value V →
   Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
-  Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ r ∶ E ⊒ F →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ E ⊒ G) →
+  (seal⊒ : μ ∣ Δ ∣ Σ ⊢ seal B α ∶ G ⊒ F) →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ seal⊒) ≈ r ∶ E ⊒ F →
   Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ r →
   ∃[ u ]
-    (Δ ∣ σ ⊢ q ⨾ⁿ seal B α ≈ u ∶ src q ⊒ ＇ α) ×
+    (Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ seal⊒)
+      ≈ u ∶ src q ⊒ ＇ α) ×
     Δ ∣ σ ∣ [] ⊢ M ⊒ V ⟨ seal A α ⟩ ∶ u
 
 right-seal-compose-endpoints :
-  ∀ {Δ σ q r A B A₀ α} →
-  Δ ∣ σ ⊢ q ⨾ⁿ seal A₀ α ≈ r ∶ A ⊒ B →
-  Δ ∣ σ ⊢ q ⨾ⁿ seal A₀ α ≈ r ∶ src q ⊒ ＇ α
-right-seal-compose-endpoints
-    (compose-leftⁿ wfΣ q⊒ seal⊒
-      (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+  ∀ {Δ σ q r A B A₀ α E Σ μ} →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ E) →
+  (seal⊒ : μ ∣ Δ ∣ Σ ⊢ seal A₀ α ∶ E ⊒ B) →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ seal⊒) ≈ r ∶ A ⊒ B →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ seal⊒) ≈ r
+    ∶ src q ⊒ ＇ α
+right-seal-compose-endpoints wfΣ q⊒ seal⊒
+    (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
     rewrite proj₁ (coercion-src-tgtᵐ (proj₁ q⊒))
           | proj₂ (coercion-src-tgtᵐ (proj₁ seal⊒)) =
-  compose-leftⁿ wfΣ q⊒ seal⊒
-    (endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
+  endpointsⁿ src-u tgt-u src-r tgt-r σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒
 
 rightSealInversion2 : RightSealInversion2
-rightSealInversion2 _ _ q⨟seal≈r M⊒Vseal =
-  _ , right-seal-compose-endpoints q⨟seal≈r , M⊒Vseal
+rightSealInversion2 _ _ wfΣ q⊒ seal⊒ q⨟seal≈r M⊒Vseal =
+  _ , right-seal-compose-endpoints wfΣ q⊒ seal⊒ q⨟seal≈r , M⊒Vseal
 
 right-seal-inversion₂ : RightSealInversion2
 right-seal-inversion₂ = rightSealInversion2
 
 right-seal-inversion₂-cast-unseal⊥ :
-  ∀ {Δ σ q r B C D E F α} →
+  ∀ {Δ σ q r B C D E F G α Σ μ} →
   Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
-  Δ ∣ σ ⊢ q ⨾ⁿ unseal α B ≈ r ∶ E ⊒ F →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ E ⊒ G) →
+  (unseal⊒ : μ ∣ Δ ∣ Σ ⊢ unseal α B ∶ G ⊒ F) →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ unseal⊒) ≈ r ∶ E ⊒ F →
   ⊥
-right-seal-inversion₂-cast-unseal⊥ qᶜ
-    (compose-leftⁿ wfΣ q⊒ (cast-unseal hB α∈Σ ok , cross ())
-      q⨟unseal≈r)
+right-seal-inversion₂-cast-unseal⊥ qᶜ wfΣ q⊒
+    (cast-unseal hB α∈Σ ok , cross ())
+    q⨟unseal≈r
 
 -- Failed proof-search note for `GeneralRightSealInversion2`.  The direct
 -- induction can strip the direct right-positive cast, but the `ν⊒`, `split`,
@@ -238,47 +251,54 @@ private
     cast-seal wfBase (there (here refl)) refl , sealⁿ NatTy alpha1
 
   right-seal-compose0 :
-    1 ∣ Sigma0 ⊢ id NatTy ⨾ⁿ seal0 ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
+    1 ∣ Sigma0 ⊢
+      proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
   right-seal-compose0 =
-    compose-leftⁿ wfStore0 idNat⊒ seal0⊒
-      (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
-        (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
-        (seal-or-idᵈ , seal0⊒))
+    endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+      (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
+      (seal-or-idᵈ , seal0⊒)
 
   right-seal-compose1 :
-    2 ∣ Sigma1 ⊢ id NatTy ⨾ⁿ seal1 ≈ seal1 ∶ NatTy ⊒ ＇ alpha1
+    2 ∣ Sigma1 ⊢
+      proj₁ (_⨟ⁿ_ {wfΣ = wfStore1Target} idNat⊒ seal1⊒Target)
+        ≈ seal1 ∶ NatTy ⊒ ＇ alpha1
   right-seal-compose1 =
-    compose-leftⁿ wfStore1Target idNat⊒ seal1⊒Target
-      (endpointsⁿ refl refl refl refl
-        Sigma1⊒
-        endpoints1Target
-        endpoints1Source
-        (seal-or-idᵈ ,
-          proj₂ (_⨟ⁿ_ {wfΣ = wfStore1Target} idNat⊒ seal1⊒Target))
-        (seal-or-idᵈ , seal1⊒Source))
+    endpointsⁿ refl refl refl refl
+      Sigma1⊒
+      endpoints1Target
+      endpoints1Source
+      (seal-or-idᵈ ,
+        proj₂ (_⨟ⁿ_ {wfΣ = wfStore1Target} idNat⊒ seal1⊒Target))
+      (seal-or-idᵈ , seal1⊒Source)
 
   left-seal-compose1 :
-    2 ∣ Sigma1 ⊢ seal1 ≈ seal1 ⨾ⁿ idAlpha1 ∶ NatTy ⊒ ＇ alpha1
+    2 ∣ Sigma1 ⊢
+      seal1
+        ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfStore1Target}
+            seal1⊒Target idAlpha1⊒Target)
+        ∶ NatTy ⊒ ＇ alpha1
   left-seal-compose1 =
-    compose-rightⁿ wfStore1Target seal1⊒Target idAlpha1⊒Target
-      (endpointsⁿ refl refl refl refl
-        Sigma1⊒
-        endpoints1Target
-        endpoints1Source
-        (seal-or-idᵈ , seal1⊒Target)
-        (seal-or-idᵈ , seal1⊒Source))
+    endpointsⁿ refl refl refl refl
+      Sigma1⊒
+      endpoints1Target
+      endpoints1Source
+      (seal-or-idᵈ , seal1⊒Target)
+      (seal-or-idᵈ , seal1⊒Source)
 
   right-sealed-constant1 :
     2 ∣ Sigma1 ∣ [] ⊢ $ k0 ⊒ ($ k0) ⟨ seal1 ⟩ ∶ seal1
   right-sealed-constant1 =
-    ⊒cast- idNatᶜ right-seal-compose1 (κ⊒κ k0)
+    ⊒cast- idNatᶜ wfStore1Target idNat⊒ seal1⊒Target
+      right-seal-compose1 (κ⊒κ k0)
 
   right-unsealed-constant1 :
     2 ∣ Sigma1 ∣ []
       ⊢ $ k0 ⊒ (($ k0) ⟨ seal1 ⟩) ⟨ unseal alpha1 NatTy ⟩
       ∶ id NatTy
   right-unsealed-constant1 =
-    ⊒cast+ idNatᶜ right-seal-compose1 right-sealed-constant1
+    ⊒cast+ idNatᶜ wfStore1Target idNat⊒ seal1⊒Target
+      right-seal-compose1 right-sealed-constant1
 
   alpha-var1 :
     2 ∣ Sigma1 ∣ idAlpha1 ∷ [] ⊢ ` zero ⊒ ` zero ∶ idAlpha1
@@ -289,13 +309,15 @@ private
     2 ∣ Sigma1 ∣ idAlpha1 ∷ []
       ⊢ (` zero) ⟨ unseal1 ⟩ ⊒ ` zero ∶ seal1
   left-unsealed-alpha-var1 =
-    cast+⊒ idAlpha1ᶜSource left-seal-compose1 alpha-var1
+    cast+⊒ idAlpha1ᶜSource wfStore1Target
+      seal1⊒Target idAlpha1⊒Target left-seal-compose1 alpha-var1
 
   right-unsealed-alpha-var1 :
     2 ∣ Sigma1 ∣ idAlpha1 ∷ []
       ⊢ (` zero) ⟨ unseal1 ⟩ ⊒ (` zero) ⟨ unseal1 ⟩ ∶ id NatTy
   right-unsealed-alpha-var1 =
-    ⊒cast+ idNatᶜ right-seal-compose1 left-unsealed-alpha-var1
+    ⊒cast+ idNatᶜ wfStore1Target idNat⊒ seal1⊒Target
+      right-seal-compose1 left-unsealed-alpha-var1
 
   right-seal-inversion₂-counterexample-premise :
     1 ∣ Sigma0 ∣ []
@@ -323,18 +345,22 @@ private
   right-seal-inversion₂-ν-candidate-stripped =
     ⊒cast-
       idNatᶜ
+      wfStore0
+      idNat⊒
+      seal0⊒
       right-seal-compose0
       (ν⊒ idNatᶜ (κ⊒κ k0))
 
 right-seal-inversion₂-ν-candidate-result :
   ∃[ r ]
     (1 ∣ Sigma0
-      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0) ×
+      ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0) ×
     1 ∣ Sigma0 ∣ []
       ⊢ ν ★ ($ k0) (⇑ᶜ (id NatTy)) ⊒ ($ k0) ⟨ seal0 ⟩ ∶ r
 right-seal-inversion₂-ν-candidate-result =
   seal0 ,
-  right-seal-compose-endpoints right-seal-compose0 ,
+  right-seal-compose-endpoints wfStore0 idNat⊒ seal0⊒ right-seal-compose0 ,
   right-seal-inversion₂-ν-candidate-stripped
 
 private
@@ -373,22 +399,22 @@ private
 
   idNat-right-seal-not-idNat :
     1 ∣ Sigma0
-      ⊢ id NatTy ⨾ⁿ seal0 ≈ id NatTy ∶ NatTy ⊒ ＇ alpha0 →
+      ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ id NatTy ∶ NatTy ⊒ ＇ alpha0 →
     ⊥
   idNat-right-seal-not-idNat
-      (compose-leftⁿ wfΣ q⊒ seal⊒
-        (endpointsⁿ src-u tgt-u src-r () σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒))
+      (endpointsⁿ src-u tgt-u src-r () σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)
 
   idNat-right-seal-not-renamed-idNat :
     ∀ {r} →
     renameᶜ suc r ≡ id NatTy →
     1 ∣ Sigma0
-      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
+      ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
     ⊥
   idNat-right-seal-not-renamed-idNat r≡idNat
-      (compose-leftⁿ wfΣ q⊒ seal⊒
-        (endpointsⁿ src-u tgt-u src-r tgt-r
-          σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒)) =
+      (endpointsⁿ src-u tgt-u src-r tgt-r
+        σ⊒ wfΣ₁ wfΣ₂ u⊒ r⊒) =
     renamed-idNat-tgt-alpha0⊥ r≡idNat tgt-r
 
   idNat-target :
@@ -400,33 +426,36 @@ private
     trans (sym tgt-r) (cong tgt r≡idNat)
 
   inner-cast+⊥ :
-    ∀ {Δ σ γ M M′ q p t A B C D} →
+    ∀ {Δ σ γ M M′ q p t A B C D E Σ μ} →
     M ⟨ - t ⟩ ≡ (` zero) ⟨ unseal1 ⟩ →
     M′ ≡ ` zero →
     q ≡ id NatTy →
     Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ C ⊒ D →
-    Δ ∣ σ ⊢ q ≈ t ⨾ⁿ p ∶ A ⊒ B →
+    (wfΣ : StoreDetWf Δ Σ) →
+    (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ E) →
+    (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ E ⊒ B) →
+    Δ ∣ σ ⊢ q ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B →
     Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p →
     ⊥
-  inner-cast+⊥ {t = id A} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = c ︔ d} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = c ↦ d} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = `∀ c} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (＇ β) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (‵ ι) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = ★ !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (A ⇒ B) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (`∀ A) !} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (＇ β) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (‵ ι) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = ★ ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (A ⇒ B) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = (`∀ A) ？} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = id A} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = c ︔ d} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = c ↦ d} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = `∀ c} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (＇ β) !} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (‵ ι) !} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = ★ !} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (A ⇒ B) !} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (`∀ A) !} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (＇ β) ？} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (‵ ι) ？} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = ★ ？} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (A ⇒ B) ？} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = (`∀ A) ？} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
   inner-cast+⊥ {t = seal .NatTy .alpha1} refl eqT q≡id pᶜ
-      (compose-rightⁿ wfΣ
-        (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha1)
-        p⊒
-        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      wfΣ
+      (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha1)
+      p⊒
+      (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
       M⊒M′ =
     let
       B≡Nat = idNat-target q≡id tgt-r
@@ -434,34 +463,36 @@ private
         subst (λ B → _ ∣ _ ∣ _ ⊢ _ ∶ ＇ alpha1 ⊒ B) B≡Nat p⊒
     in
     narrowing-var-to-older⊥ wfΣ wfBase p⊒Nat
-  inner-cast+⊥ {t = unseal α A} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = gen A c} () eqT q≡id pᶜ q≈t⨟p M⊒M′
-  inner-cast+⊥ {t = inst B c} () eqT q≡id pᶜ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = unseal α A} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = gen A c} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
+  inner-cast+⊥ {t = inst B c} () eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
 
   inner-cast-⊥ :
-    ∀ {Δ σ γ M M′ q r t A B C D} →
+    ∀ {Δ σ γ M M′ q r t A B C D E Σ μ} →
     M ⟨ t ⟩ ≡ (` zero) ⟨ unseal1 ⟩ →
     M′ ≡ ` zero →
     q ≡ id NatTy →
     Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ C ⊒ D →
-    Δ ∣ σ ⊢ r ≈ t ⨾ⁿ q ∶ A ⊒ B →
+    (wfΣ : StoreDetWf Δ Σ) →
+    (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ E) →
+    (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ E ⊒ B) →
+    Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ q⊒) ∶ A ⊒ B →
     Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ r →
     ⊥
-  inner-cast-⊥ {t = id A} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = c ︔ d} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = c ↦ d} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = `∀ c} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = G !} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = G ？} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = seal A α} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = unseal α A} refl eqT q≡id qᶜ
-      (compose-rightⁿ wfΣ
-        (cast-unseal hA α∈Σ ok , cross ())
-        q⊒
-        r≈t⨟q)
+  inner-cast-⊥ {t = id A} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = c ︔ d} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = c ↦ d} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = `∀ c} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = G !} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = G ？} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = seal A α} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = unseal α A} refl eqT q≡id qᶜ wfΣ
+      (cast-unseal hA α∈Σ ok , cross ())
+      q⊒
+      r≈t⨟q
       M⊒M′
-  inner-cast-⊥ {t = gen A c} () eqT q≡id qᶜ r≈t⨟q M⊒M′
-  inner-cast-⊥ {t = inst B c} () eqT q≡id qᶜ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = gen A c} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
+  inner-cast-⊥ {t = inst B c} () eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
 
   right-seal-inversion₂-var-inner⊥ :
     ∀ {A q M T} →
@@ -473,11 +504,11 @@ private
       ⊢ M ⊒ T ∶ q →
     ⊥
   right-seal-inversion₂-var-inner⊥ eqM eqT q≡id
-      (cast+⊒ pᶜ q≈t⨟p M⊒M′) =
-    inner-cast+⊥ eqM eqT q≡id pᶜ q≈t⨟p M⊒M′
+      (cast+⊒ pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′) =
+    inner-cast+⊥ eqM eqT q≡id pᶜ wfΣ t⊒ p⊒ q≈t⨟p M⊒M′
   right-seal-inversion₂-var-inner⊥ eqM eqT q≡id
-      (cast-⊒ qᶜ r≈t⨟q M⊒M′) =
-    inner-cast-⊥ eqM eqT q≡id qᶜ r≈t⨟q M⊒M′
+      (cast-⊒ qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′) =
+    inner-cast-⊥ eqM eqT q≡id qᶜ wfΣ t⊒ q⊒ r≈t⨟q M⊒M′
 
   right-seal-inversion₂-var-stripped-source⊥ :
     ∀ {A r M T} →
@@ -493,7 +524,8 @@ private
     M ≡ ν ★ ((` zero) ⟨ unseal1 ⟩) (⇑ᶜ (id NatTy)) →
     T ≡ ` zero →
     1 ∣ Sigma0
-      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
+      ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
     1 ∣ Sigma0 ∣ idAlpha0 ∷ []
       ⊢ M ⊒ T ∶ r →
     ⊥
@@ -502,7 +534,8 @@ private
   right-seal-inversion₂-var-stripped⊥ :
     ∀ {r} →
     1 ∣ Sigma0
-      ⊢ id NatTy ⨾ⁿ seal0 ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
+      ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ r ∶ src (id NatTy) ⊒ ＇ alpha0 →
     1 ∣ Sigma0 ∣ idAlpha0 ∷ []
       ⊢ ν ★ ((` zero) ⟨ unseal1 ⟩) (⇑ᶜ (id NatTy))
         ⊒ ` zero ∶ r →

--- a/GTSF/proof/RightSealInversionCounterexample.agda
+++ b/GTSF/proof/RightSealInversionCounterexample.agda
@@ -12,7 +12,7 @@ open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (zero; z<s)
-open import Data.Product using (_,_; proj₂; ∃-syntax)
+open import Data.Product using (_,_; proj₁; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality using (cong; sym; trans; subst)
 
 open import Types
@@ -83,25 +83,29 @@ private
   seal0⊒ = cast-seal wfBase (here refl) refl , sealⁿ NatTy alpha0
 
   right-seal-compose :
-    1 ∣ Sigma0 ⊢ id NatTy ⨾ⁿ seal0 ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
+    1 ∣ Sigma0 ⊢
+      proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒)
+        ≈ seal0 ∶ NatTy ⊒ ＇ alpha0
   right-seal-compose =
-    compose-leftⁿ wfStore0 idNat⊒ seal0⊒
-      (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
-        (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
-        (seal-or-idᵈ , seal0⊒))
+    endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+      (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} idNat⊒ seal0⊒))
+      (seal-or-idᵈ , seal0⊒)
 
   left-seal-compose :
-    1 ∣ Sigma0 ⊢ seal0 ≈ seal0 ⨾ⁿ idAlpha0 ∶ NatTy ⊒ ＇ alpha0
+    1 ∣ Sigma0 ⊢
+      seal0
+        ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfStore0} seal0⊒ idAlpha⊒)
+        ∶ NatTy ⊒ ＇ alpha0
   left-seal-compose =
-    compose-rightⁿ wfStore0 seal0⊒ idAlpha⊒
-      (endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
-        (seal-or-idᵈ , seal0⊒)
-        (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} seal0⊒ idAlpha⊒)))
+    endpointsⁿ refl refl refl refl Sigma0⊒ endpoints0 endpoints0
+      (seal-or-idᵈ , seal0⊒)
+      (seal-or-idᵈ , proj₂ (_⨟ⁿ_ {wfΣ = wfStore0} seal0⊒ idAlpha⊒))
 
   right-sealed-constant :
     1 ∣ Sigma0 ∣ [] ⊢ $ k0 ⊒ ($ k0) ⟨ seal0 ⟩ ∶ seal0
   right-sealed-constant =
-    ⊒cast- idNatᶜ right-seal-compose (κ⊒κ k0)
+    ⊒cast- idNatᶜ wfStore0 idNat⊒ seal0⊒
+      right-seal-compose (κ⊒κ k0)
 
   bare-constant-index-source :
     ∀ {A q M M′} →
@@ -146,14 +150,13 @@ private
     1 ∣ (alpha0 ꞉= A ⊒) ∷ [] ∣ [] ⊢ M ⊒ M′ ∶ q →
     ⊥
   stripped-impossible-source eqM eqM′
-      (cast+⊒ pᶜ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) M⊒M′) =
+      (cast+⊒ pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
     left-cast-plus-seal⊥ eqM t⊒
   stripped-impossible-source refl refl
-      (cast-⊒ pᶜ
-        (compose-rightⁿ wfΣ
-          t⊒@(cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
-          p⊒
-          (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      (cast-⊒ pᶜ wfΣ
+        t⊒@(cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+        p⊒
+        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
         M⊒M′) =
     let
       r≡idNat = bare-constant-index-source refl refl M⊒M′
@@ -171,14 +174,13 @@ private
   stripped-impossible-aux eqM eqM′ (extend qᶜ pαᶜ M⊒M′) =
     stripped-impossible-source eqM eqM′ M⊒M′
   stripped-impossible-aux eqM eqM′
-      (cast+⊒ pᶜ (compose-rightⁿ wfΣ t⊒ p⊒ r≈t⨟p) M⊒M′) =
+      (cast+⊒ pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
     left-cast-plus-seal⊥ eqM t⊒
   stripped-impossible-aux refl refl
-      (cast-⊒ pᶜ
-        (compose-rightⁿ wfΣ
-          t⊒@(cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
-          p⊒
-          (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒))
+      (cast-⊒ pᶜ wfΣ
+        t⊒@(cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+        p⊒
+        (endpointsⁿ src-r tgt-r src-u tgt-u σ⊒ wfΣ₁ wfΣ₂ r⊒ u⊒)
         M⊒M′) =
     let
       r≡idNat = bare-constant-index refl refl M⊒M′
@@ -193,17 +195,21 @@ counterexample-premise :
       ⊒ ($ (κℕ 0)) ⟨ seal (‵ `ℕ) 0 ⟩
     ∶ id (＇ 0)
 counterexample-premise =
-  cast-⊒ idAlphaᶜ left-seal-compose right-sealed-constant
+  cast-⊒ idAlphaᶜ wfStore0 seal0⊒ idAlpha⊒
+    left-seal-compose right-sealed-constant
 
 old-counterexample-revised-premise⊥ :
-  ∀ {q C} →
+  ∀ {q C E Σ μ} →
+  (wfΣ : StoreDetWf 1 Σ) →
+  (q⊒ : μ ∣ 1 ∣ Σ ⊢ q ∶ C ⊒ E) →
+  (seal⊒ : μ ∣ 1 ∣ Σ ⊢ seal (‵ `ℕ) 0 ∶ E ⊒ ＇ 0) →
   1 ∣ (0 ꞉ id (‵ `ℕ)) ∷ []
-    ⊢ q ⨾ⁿ seal (‵ `ℕ) 0 ≈ id (＇ 0) ∶ C ⊒ ＇ 0 →
+    ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ seal⊒)
+      ≈ id (＇ 0) ∶ C ⊒ ＇ 0 →
   ⊥
-old-counterexample-revised-premise⊥
-    (compose-leftⁿ wfΣ q⊒
-      (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
-      (endpointsⁿ src-u tgt-u src-id tgt-id σ⊒ wfΣ₁ wfΣ₂ u⊒ id⊒)) =
+old-counterexample-revised-premise⊥ wfΣ q⊒
+    (cast-seal hNat α∈Σ seal-ok , sealⁿ .NatTy .alpha0)
+    (endpointsⁿ src-u tgt-u src-id tgt-id σ⊒ wfΣ₁ wfΣ₂ u⊒ id⊒) =
   let
     q⊒Nat = subst (λ A → _ ∣ _ ∣ _ ⊢ _ ∶ A ⊒ NatTy) (sym src-id) q⊒
   in

--- a/GTSF/proof/TermNarrowingProperties.agda
+++ b/GTSF/proof/TermNarrowingProperties.agda
@@ -3,7 +3,179 @@ module proof.TermNarrowingProperties where
 -- File Charter:
 --   * Reserved for admissible rules and structural lemmas for typed term
 --     narrowing.
---   * The two-sided typed cast rules now live directly in `TermNarrowing`.
---     They are constructors rather than derived rules because some examples
---     use seal-mode intermediate coercions that are not canonical `∶ᶜ`
---     indices.
+--   * Contains the experimental derived two-sided cast narrowing rules,
+--     obtained from the one-sided cast rules and narrowing composition.
+
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality using (_≡_; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NarrowWiden
+open import NarrowWidenComposition
+open import TermNarrowing
+open import proof.CoercionProperties using (coercion-src-tgtᵐ; minus-src-tgtᵐ)
+import proof.NarrowWidenProperties as NWP
+open import proof.NarrowWidenProperties using (StoreDetWf; srcStoreⁿ-⊒ˢ)
+
+≈ⁿ-right-typing :
+  ∀ {Δ σ l r A B} →
+  Δ ∣ σ ⊢ l ≈ r ∶ A ⊒ B →
+  Δ ∣ srcStoreⁿ σ ⊢ r ∶ A ⊒ B
+≈ⁿ-right-typing {Δ = Δ} {σ = σ} {r = r} {A = A} {B = B}
+    (endpointsⁿ srcl tgtl srcr tgtr σ⊒ wfΣ wfΣ′ l⊒ r⊒) =
+  subst (λ Σ → Δ ∣ Σ ⊢ r ∶ A ⊒ B) (srcStoreⁿ-⊒ˢ σ⊒) r⊒
+
+⨟ⁿ≈-right-typing :
+  ∀ {Δ σ Σ μ q s r A B C} →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C) →
+  (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ C ⊒ B) →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B →
+  Δ ∣ srcStoreⁿ σ ⊢ r ∶ A ⊒ B
+⨟ⁿ≈-right-typing wfΣ q⊒ s⊒ q⨟s≈r =
+  ≈ⁿ-right-typing q⨟s≈r
+
+inner-cast-typing :
+  ∀ {Δ σ γ M M′ p r s t A B C Ap Bp Σ μ} →
+  Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ Ap ⊒ Bp →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (t⊒ : μ ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ C) →
+  (p⊒ : μ ∣ Δ ∣ Σ ⊢ p ∶ C ⊒ B) →
+  Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} t⊒ p⊒) ∶ A ⊒ B →
+  TermTypingEndpoints Δ σ γ (M ⟨ t ⟩) (M′ ⟨ s ⟩) Ap Bp →
+  TermTypingEndpoints Δ σ γ M (M′ ⟨ s ⟩) A B
+inner-cast-typing {Δ = Δ} {σ = σ} {γ = γ} {M = M}
+    {M′ = M′} {s = s} {t = t} {A = A} {B = B} {Bp = Bp}
+    pᶜ wfΣ t⊒ p⊒ t⨟p≈r typing
+    with sourceTermTyping typing
+inner-cast-typing {Δ = Δ} {σ = σ} {γ = γ} {M = M}
+    {M′ = M′} {s = s} {t = t} {A = A} {B = B} {Bp = Bp}
+    pᶜ wfΣ t⊒ p⊒ t⨟p≈r typing
+    | ⊢⟨⟩ {A = At} t⊢ M⊢ =
+  term-typing-endpoints M⊢A M′⟨s⟩⊢B
+  where
+    t-src : At ≡ A
+    t-src =
+      trans (sym (proj₁ (coercion-src-tgtᵐ t⊢)))
+        (proj₁ (coercion-src-tgtᵐ (proj₁ t⊒)))
+
+    M⊢A :
+      Δ ∣ srcStoreⁿ σ ∣ srcCtxⁿ γ ⊢ M ⦂ A
+    M⊢A =
+      subst (λ T → Δ ∣ srcStoreⁿ σ ∣ srcCtxⁿ γ ⊢ M ⦂ T)
+        t-src M⊢
+
+    p-tgt : Bp ≡ B
+    p-tgt =
+      trans (sym (proj₂ (coercion-src-tgtᵐ (proj₁ pᶜ))))
+        (proj₂ (coercion-src-tgtᵐ (proj₁ p⊒)))
+
+    M′⟨s⟩⊢B :
+      Δ ∣ tgtStoreⁿ σ ∣ tgtCtxⁿ γ ⊢ M′ ⟨ s ⟩ ⦂ B
+    M′⟨s⟩⊢B =
+      subst (λ T → Δ ∣ tgtStoreⁿ σ ∣ tgtCtxⁿ γ ⊢ M′ ⟨ s ⟩ ⦂ T)
+        p-tgt
+        (targetTermTyping typing)
+
+cast-⊒cast-derivedᵗ :
+  ∀ {Δ σ γ M M′ p q r s t A B Ap Bp Aq Bq C D Σ Π μ ν}
+  → {typing :
+      TermTypingEndpoints Δ σ γ (M ⟨ t ⟩) (M′ ⟨ s ⟩) Ap Bp}
+  → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ Ap ⊒ Bp
+  → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ Aq ⊒ Bq
+  → (wfΣ : StoreDetWf Δ Σ)
+  → (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C)
+  → (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ C ⊒ B)
+  → Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B
+  → (wfΠ : StoreDetWf Δ Π)
+  → (t⊒ : ν ∣ Δ ∣ Π ⊢ t ∶ A ⊒ D)
+  → (p⊒ : ν ∣ Δ ∣ Π ⊢ p ∶ D ⊒ B)
+  → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΠ} t⊒ p⊒) ∶ A ⊒ B
+  → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ q ⦂ Aq ⊒ Bq
+  → Δ ∣ σ ∣ γ ⊢ M ⟨ t ⟩ ⊒ M′ ⟨ s ⟩ ∶ p ⦂ Ap ⊒ Bp
+cast-⊒cast-derivedᵗ {typing = typing}
+    pᶜ qᶜ wfΣ q⊒ s⊒ q⨟s≈r wfΠ t⊒ p⊒ r≈t⨟p M⊒M′
+    with ⨟ⁿ≈-right-typing wfΣ q⊒ s⊒ q⨟s≈r
+cast-⊒cast-derivedᵗ {typing = typing}
+    pᶜ qᶜ wfΣ q⊒ s⊒ q⨟s≈r wfΠ t⊒ p⊒ r≈t⨟p M⊒M′
+    | μ , r⊒ =
+  cast-⊒ᵗ {typing = typing} pᶜ wfΠ t⊒ p⊒ r≈t⨟p
+    (⊒cast-ᵗ
+      {typing = inner-cast-typing pᶜ wfΠ t⊒ p⊒ r≈t⨟p typing}
+      qᶜ r⊒ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′)
+
+inner-cast+-typing :
+  ∀ {Δ σ γ M M′ q r s t A B C Aq Bq Σ μ} →
+  Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ Aq ⊒ Bq →
+  (wfΣ : StoreDetWf Δ Σ) →
+  (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C) →
+  (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ C ⊒ B) →
+  Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B →
+  TermTypingEndpoints Δ σ γ (M ⟨ - t ⟩) (M′ ⟨ - s ⟩) Aq Bq →
+  TermTypingEndpoints Δ σ γ (M ⟨ - t ⟩) M′ A B
+inner-cast+-typing {Δ = Δ} {σ = σ} {γ = γ} {M = M}
+    {M′ = M′} {s = s} {t = t} {A = A} {B = B} {Aq = Aq}
+    qᶜ wfΣ q⊒ s⊒ q⨟s≈r typing
+    with targetTermTyping typing
+inner-cast+-typing {Δ = Δ} {σ = σ} {γ = γ} {M = M}
+    {M′ = M′} {s = s} {t = t} {A = A} {B = B} {Aq = Aq}
+    qᶜ wfΣ q⊒ s⊒ q⨟s≈r typing
+    | ⊢⟨⟩ {A = Bt} negs⊢ M′⊢ =
+  term-typing-endpoints M⟨-t⟩⊢A M′⊢B
+  where
+    q-src : Aq ≡ A
+    q-src =
+      trans (sym (proj₁ (coercion-src-tgtᵐ (proj₁ qᶜ))))
+        (proj₁ (coercion-src-tgtᵐ (proj₁ q⊒)))
+
+    M⟨-t⟩⊢A :
+      Δ ∣ srcStoreⁿ σ ∣ srcCtxⁿ γ ⊢ M ⟨ - t ⟩ ⦂ A
+    M⟨-t⟩⊢A =
+      subst (λ T → Δ ∣ srcStoreⁿ σ ∣ srcCtxⁿ γ ⊢ M ⟨ - t ⟩ ⦂ T)
+        q-src
+        (sourceTermTyping typing)
+
+    s-tgt : Bt ≡ B
+    s-tgt =
+      trans (sym (proj₁ (coercion-src-tgtᵐ negs⊢)))
+        (minus-src-tgtᵐ (NWP.StoreDetWf.at wfΣ) (proj₁ s⊒))
+
+    M′⊢B :
+      Δ ∣ tgtStoreⁿ σ ∣ tgtCtxⁿ γ ⊢ M′ ⦂ B
+    M′⊢B =
+      subst (λ T → Δ ∣ tgtStoreⁿ σ ∣ tgtCtxⁿ γ ⊢ M′ ⦂ T)
+        s-tgt M′⊢
+
+cast+⊒cast+-derivedᵗ :
+  ∀ {Δ σ γ M M′ p q r s t A B Ap Bp Aq Bq C D Σ Π μ ν}
+  → {typing :
+      TermTypingEndpoints Δ σ γ
+        (M ⟨ - t ⟩) (M′ ⟨ - s ⟩) Aq Bq}
+  → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ Ap ⊒ Bp
+  → Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ Aq ⊒ Bq
+  → (wfΣ : StoreDetWf Δ Σ)
+  → (q⊒ : μ ∣ Δ ∣ Σ ⊢ q ∶ A ⊒ C)
+  → (s⊒ : μ ∣ Δ ∣ Σ ⊢ s ∶ C ⊒ B)
+  → Δ ∣ σ ⊢ proj₁ (_⨟ⁿ_ {wfΣ = wfΣ} q⊒ s⊒) ≈ r ∶ A ⊒ B
+  → (wfΠ : StoreDetWf Δ Π)
+  → (t⊒ : ν ∣ Δ ∣ Π ⊢ t ∶ A ⊒ D)
+  → (p⊒ : ν ∣ Δ ∣ Π ⊢ p ∶ D ⊒ B)
+  → Δ ∣ σ ⊢ r ≈ proj₁ (_⨟ⁿ_ {wfΣ = wfΠ} t⊒ p⊒) ∶ A ⊒ B
+  → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ Ap ⊒ Bp
+  → Δ ∣ σ ∣ γ ⊢ M ⟨ - t ⟩ ⊒ M′ ⟨ - s ⟩ ∶ q ⦂ Aq ⊒ Bq
+cast+⊒cast+-derivedᵗ {M = M} {M′ = M′} {s = s} {t = t}
+    {typing = typing}
+    pᶜ qᶜ wfΣ q⊒ s⊒ q⨟s≈r wfΠ t⊒ p⊒ r≈t⨟p M⊒M′
+    with ⨟ⁿ≈-right-typing wfΣ q⊒ s⊒ q⨟s≈r
+cast+⊒cast+-derivedᵗ {M = M} {M′ = M′} {s = s} {t = t}
+    {typing = typing}
+    pᶜ qᶜ wfΣ q⊒ s⊒ q⨟s≈r wfΠ t⊒ p⊒ r≈t⨟p M⊒M′
+    | μ , r⊒ =
+  ⊒cast+ᵗ {typing = typing} qᶜ wfΣ q⊒ s⊒ q⨟s≈r
+    (cast+⊒ᵗ
+      {typing =
+        inner-cast+-typing {M = M} {M′ = M′} {s = s} {t = t}
+          qᶜ wfΣ q⊒ s⊒ q⨟s≈r typing}
+      pᶜ r⊒ wfΠ t⊒ p⊒ r≈t⨟p M⊒M′)

--- a/GTSF/proof/TermSubstitutionNarrowing.agda
+++ b/GTSF/proof/TermSubstitutionNarrowing.agda
@@ -263,28 +263,20 @@ term-parallel-substitution-narrowingᵗ-framed env frame
     (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
     (term-parallel-substitution-narrowingᵗ-framed env frame N⊒N′)
 term-parallel-substitution-narrowingᵗ-framed env frame
-    (⊒cast+ᵗ qᶜ q⨟s≈r M⊒M′) =
-  ⊒cast+ᵗ qᶜ q⨟s≈r
+    (⊒cast+ᵗ qᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
+  ⊒cast+ᵗ qᶜ wfΣ q⊒ s⊒ q⨟s≈r
     (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
 term-parallel-substitution-narrowingᵗ-framed env frame
-    (⊒cast-ᵗ qᶜ rᶜ q⨟s≈r M⊒M′) =
-  ⊒cast-ᵗ qᶜ rᶜ q⨟s≈r
+    (⊒cast-ᵗ qᶜ rᶜ wfΣ q⊒ s⊒ q⨟s≈r M⊒M′) =
+  ⊒cast-ᵗ qᶜ rᶜ wfΣ q⊒ s⊒ q⨟s≈r
     (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
 term-parallel-substitution-narrowingᵗ-framed env frame
-    (cast+⊒ᵗ pᶜ rᶜ r≈t⨟p M⊒M′) =
-  cast+⊒ᵗ pᶜ rᶜ r≈t⨟p
+    (cast+⊒ᵗ pᶜ rᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
+  cast+⊒ᵗ pᶜ rᶜ wfΣ t⊒ p⊒ r≈t⨟p
     (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
 term-parallel-substitution-narrowingᵗ-framed env frame
-    (cast-⊒ᵗ pᶜ r≈t⨟p M⊒M′) =
-  cast-⊒ᵗ pᶜ r≈t⨟p
-    (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
-term-parallel-substitution-narrowingᵗ-framed env frame
-    (cast-⊒cast-ᵗ pᶜ qᶜ q⨟s≈r r≈t⨟p M⊒M′) =
-  cast-⊒cast-ᵗ pᶜ qᶜ q⨟s≈r r≈t⨟p
-    (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
-term-parallel-substitution-narrowingᵗ-framed env frame
-    (cast+⊒cast+ᵗ pᶜ qᶜ q⨟s≈r r≈t⨟p M⊒M′) =
-  cast+⊒cast+ᵗ pᶜ qᶜ q⨟s≈r r≈t⨟p
+    (cast-⊒ᵗ pᶜ wfΣ t⊒ p⊒ r≈t⨟p M⊒M′) =
+  cast-⊒ᵗ pᶜ wfΣ t⊒ p⊒ r≈t⨟p
     (term-parallel-substitution-narrowingᵗ-framed env frame M⊒M′)
 
 term-parallel-substitution-narrowingᵗ :


### PR DESCRIPTION
## Summary

This branch tidies the GTSF term-narrowing cast infrastructure rather than only changing the last wrapper layer.

- Removes the two typed two-sided cast constructors from `TermNarrowing` and replaces them with derived rules in `proof.TermNarrowingProperties`.
- Adds the coercion `-_` source/target normalization lemmas needed by those derived rules in `proof.CoercionProperties`, plus supporting Narrow/Widen property lemmas.
- Removes the thin term-narrowing composition wrapper judgments from `NarrowWidenComposition`; cast side conditions now carry `StoreDetWf`, the component narrowing proofs, and direct `proj₁ (_⨟ⁿ_ ...)` equivalence evidence.
- Propagates the explicit evidence shape through the examples, substitution/catchup support, DGG patterns, and the seal-inversion experiment files.

## Impact

The public term-narrowing relation has fewer primitive cast rules and fewer notation-only wrapper judgments. The remaining cast cases expose the actual composition evidence at the use site, matching the Cambridge-style derived-rule presentation more closely.

## Validation

- `agda -v0 All.agda` from `GTSF/`

Note: `proof/LeftSealNarrowingInversion.agda`, `proof/RightSealInversion2.agda`, and `proof/RightSealInversionCounterexample.agda` still do not parse independently because they use an older untyped term-narrowing surface; this branch only removes the obsolete composition-wrapper references from those experiment files.