### PR TITLE
[codex] Add separated-store GTSF DGG skeleton

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -11,13 +11,17 @@ import GradualTypeCheck
 import GradualTypeCheckExamples
 import Coercions
 import NarrowWiden
+import StoreCorrespondence
 import NuTerms
 import TypeCheck
+import TermNarrowingSeparated
 import NuExamplesFresh
 import NuReduction
 import proof.NWTermReduction
 import TermNarrowing
 import proof.TermNarrowingProperties
+--import proof.CatchupSeparated
+--import proof.DynamicGradualGuaranteeSeparated
 import NarrowingExamples
 import NuMetaTheory
 import proof.DynamicGradualGuarantee

--- a/GTSF/StoreCorrespondence.agda
+++ b/GTSF/StoreCorrespondence.agda
@@ -1,0 +1,375 @@
+module StoreCorrespondence where
+
+-- File Charter:
+--   * Separate-store replacement core for the old shared `StoreNrw` encoding.
+--   * Defines explicit left/right seal correspondence entries and projections
+--     to the left and right runtime stores.
+--   * Provides a compatibility embedding from the existing shared `StoreNrw`
+--     so proofs can be migrated one surface at a time.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using (List; []; _∷_; map)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (_<_; suc)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (cong; sym)
+
+open import Types
+open import Store using (StoreWfAt)
+open import Coercions
+open import NarrowWiden using
+  ( StoreNrw
+  ; _꞉_
+  ; _꞉=_⊒
+  ; ⊒_꞉=☆
+  ; srcStoreⁿ
+  ; tgtStoreⁿ
+  )
+import proof.NarrowWidenProperties as NWP
+open import proof.NarrowWidenProperties using (StoreDetWf)
+
+------------------------------------------------------------------------
+-- Explicit seal correspondence
+------------------------------------------------------------------------
+
+data SealCorrEntry : Set where
+  matched : TyVar → Ty → TyVar → Ty → SealCorrEntry
+  left-only : TyVar → Ty → SealCorrEntry
+  right-only : TyVar → Ty → SealCorrEntry
+
+SealCorr : Set
+SealCorr = List SealCorrEntry
+
+leftStoreEntry : SealCorrEntry → Store → Store
+leftStoreEntry (matched α A β B) Σ = (α , A) ∷ Σ
+leftStoreEntry (left-only α A) Σ = (α , A) ∷ Σ
+leftStoreEntry (right-only β B) Σ = Σ
+
+rightStoreEntry : SealCorrEntry → Store → Store
+rightStoreEntry (matched α A β B) Σ = (β , B) ∷ Σ
+rightStoreEntry (left-only α A) Σ = Σ
+rightStoreEntry (right-only β B) Σ = (β , B) ∷ Σ
+
+leftStore : SealCorr → Store
+leftStore [] = []
+leftStore (entry ∷ ρ) = leftStoreEntry entry (leftStore ρ)
+
+rightStore : SealCorr → Store
+rightStore [] = []
+rightStore (entry ∷ ρ) = rightStoreEntry entry (rightStore ρ)
+
+shiftSealCorrEntry : SealCorrEntry → SealCorrEntry
+shiftSealCorrEntry (matched α A β B) =
+  matched (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+shiftSealCorrEntry (left-only α A) = left-only (suc α) (⇑ᵗ A)
+shiftSealCorrEntry (right-only β B) = right-only (suc β) (⇑ᵗ B)
+
+⇑ᶜorr : SealCorr → SealCorr
+⇑ᶜorr = map shiftSealCorrEntry
+
+shiftLeftSealCorrEntry : SealCorrEntry → SealCorrEntry
+shiftLeftSealCorrEntry (matched α A β B) =
+  matched (suc α) (⇑ᵗ A) β B
+shiftLeftSealCorrEntry (left-only α A) = left-only (suc α) (⇑ᵗ A)
+shiftLeftSealCorrEntry (right-only β B) = right-only β B
+
+⇑ˡᶜorr : SealCorr → SealCorr
+⇑ˡᶜorr = map shiftLeftSealCorrEntry
+
+shiftRightSealCorrEntry : SealCorrEntry → SealCorrEntry
+shiftRightSealCorrEntry (matched α A β B) =
+  matched α A (suc β) (⇑ᵗ B)
+shiftRightSealCorrEntry (left-only α A) = left-only α A
+shiftRightSealCorrEntry (right-only β B) = right-only (suc β) (⇑ᵗ B)
+
+⇑ʳᶜorr : SealCorr → SealCorr
+⇑ʳᶜorr = map shiftRightSealCorrEntry
+
+-- Well-scoped correspondence
+------------------------------------------------------------------------
+
+record StoreCorr (ΔL ΔR : TyCtx) (ρ : SealCorr) : Set₁ where
+  constructor store-corr
+  field
+    leftStore-det : StoreDetWf ΔL (leftStore ρ)
+    rightStore-det : StoreDetWf ΔR (rightStore ρ)
+
+open StoreCorr public
+
+corr-nil : ∀ {ΔL ΔR} →
+  StoreCorr ΔL ΔR []
+corr-nil =
+  store-corr
+    (record
+      { at = record { bound = λ (); wfTy = λ () }
+      ; wfOlder = λ ()
+      ; unique = λ ()
+      })
+    (record
+      { at = record { bound = λ (); wfTy = λ () }
+      ; wfOlder = λ ()
+      ; unique = λ ()
+      })
+
+corr-matched : ∀ {ΔL ΔR ρ α β A B} →
+  α < ΔL →
+  β < ΔR →
+  WfTy ΔL A →
+  WfTy ΔR B →
+  WfTy α A →
+  WfTy β B →
+  (∀ {C} → (α , C) ∈ leftStore ρ → A ≡ C) →
+  (∀ {D} → (β , D) ∈ rightStore ρ → B ≡ D) →
+  StoreCorr ΔL ΔR ρ →
+    -----------------------------------------
+  StoreCorr ΔL ΔR (matched α A β B ∷ ρ)
+corr-matched α< β< hA hB hA-old hB-old left-unique right-unique corr =
+  store-corr
+    (record
+      { at =
+          record
+            { bound = λ
+                { (here refl) → α<
+                ; (there α∈ρ) →
+                    StoreWfAt.bound
+                      (NWP.StoreDetWf.at (leftStore-det corr)) α∈ρ
+                }
+            ; wfTy = λ
+                { (here refl) → hA
+                ; (there α∈ρ) →
+                    StoreWfAt.wfTy
+                      (NWP.StoreDetWf.at (leftStore-det corr)) α∈ρ
+                }
+            }
+      ; wfOlder = λ
+          { (here refl) → hA-old
+          ; (there α∈ρ) → NWP.StoreDetWf.wfOlder (leftStore-det corr) α∈ρ
+          }
+      ; unique = λ
+          { (here refl) (here refl) → refl
+          ; (here refl) (there α∈ρ) → left-unique α∈ρ
+          ; (there α∈ρ) (here refl) → sym (left-unique α∈ρ)
+          ; (there α∈ρ) (there α∈ρ′) →
+              NWP.StoreDetWf.unique (leftStore-det corr) α∈ρ α∈ρ′
+          }
+      })
+    (record
+      { at =
+          record
+            { bound = λ
+                { (here refl) → β<
+                ; (there β∈ρ) →
+                    StoreWfAt.bound
+                      (NWP.StoreDetWf.at (rightStore-det corr)) β∈ρ
+                }
+            ; wfTy = λ
+                { (here refl) → hB
+                ; (there β∈ρ) →
+                    StoreWfAt.wfTy
+                      (NWP.StoreDetWf.at (rightStore-det corr)) β∈ρ
+                }
+            }
+      ; wfOlder = λ
+          { (here refl) → hB-old
+          ; (there β∈ρ) → NWP.StoreDetWf.wfOlder (rightStore-det corr) β∈ρ
+          }
+      ; unique = λ
+          { (here refl) (here refl) → refl
+          ; (here refl) (there β∈ρ) → right-unique β∈ρ
+          ; (there β∈ρ) (here refl) → sym (right-unique β∈ρ)
+          ; (there β∈ρ) (there β∈ρ′) →
+              NWP.StoreDetWf.unique (rightStore-det corr) β∈ρ β∈ρ′
+          }
+      })
+
+corr-left : ∀ {ΔL ΔR ρ α A} →
+  α < ΔL →
+  WfTy ΔL A →
+  WfTy α A →
+  (∀ {C} → (α , C) ∈ leftStore ρ → A ≡ C) →
+  StoreCorr ΔL ΔR ρ →
+    ------------------------------------
+  StoreCorr ΔL ΔR (left-only α A ∷ ρ)
+corr-left α< hA hA-old left-unique corr =
+  store-corr
+    (record
+      { at =
+          record
+            { bound = λ
+                { (here refl) → α<
+                ; (there α∈ρ) →
+                    StoreWfAt.bound
+                      (NWP.StoreDetWf.at (leftStore-det corr)) α∈ρ
+                }
+            ; wfTy = λ
+                { (here refl) → hA
+                ; (there α∈ρ) →
+                    StoreWfAt.wfTy
+                      (NWP.StoreDetWf.at (leftStore-det corr)) α∈ρ
+                }
+            }
+      ; wfOlder = λ
+          { (here refl) → hA-old
+          ; (there α∈ρ) → NWP.StoreDetWf.wfOlder (leftStore-det corr) α∈ρ
+          }
+      ; unique = λ
+          { (here refl) (here refl) → refl
+          ; (here refl) (there α∈ρ) → left-unique α∈ρ
+          ; (there α∈ρ) (here refl) → sym (left-unique α∈ρ)
+          ; (there α∈ρ) (there α∈ρ′) →
+              NWP.StoreDetWf.unique (leftStore-det corr) α∈ρ α∈ρ′
+          }
+      })
+    (rightStore-det corr)
+
+corr-right : ∀ {ΔL ΔR ρ β B} →
+  β < ΔR →
+  WfTy ΔR B →
+  WfTy β B →
+  (∀ {D} → (β , D) ∈ rightStore ρ → B ≡ D) →
+  StoreCorr ΔL ΔR ρ →
+    -------------------------------------
+  StoreCorr ΔL ΔR (right-only β B ∷ ρ)
+corr-right β< hB hB-old right-unique corr =
+  store-corr
+    (leftStore-det corr)
+    (record
+      { at =
+          record
+            { bound = λ
+                { (here refl) → β<
+                ; (there β∈ρ) →
+                    StoreWfAt.bound
+                      (NWP.StoreDetWf.at (rightStore-det corr)) β∈ρ
+                }
+            ; wfTy = λ
+                { (here refl) → hB
+                ; (there β∈ρ) →
+                    StoreWfAt.wfTy
+                      (NWP.StoreDetWf.at (rightStore-det corr)) β∈ρ
+                }
+            }
+      ; wfOlder = λ
+          { (here refl) → hB-old
+          ; (there β∈ρ) → NWP.StoreDetWf.wfOlder (rightStore-det corr) β∈ρ
+          }
+      ; unique = λ
+          { (here refl) (here refl) → refl
+          ; (here refl) (there β∈ρ) → right-unique β∈ρ
+          ; (there β∈ρ) (here refl) → sym (right-unique β∈ρ)
+          ; (there β∈ρ) (there β∈ρ′) →
+              NWP.StoreDetWf.unique (rightStore-det corr) β∈ρ β∈ρ′
+          }
+      })
+
+leftStore-wf :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreWfAt ΔL (leftStore ρ)
+leftStore-wf corr = NWP.StoreDetWf.at (leftStore-det corr)
+
+rightStore-wf :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreWfAt ΔR (rightStore ρ)
+rightStore-wf corr = NWP.StoreDetWf.at (rightStore-det corr)
+
+------------------------------------------------------------------------
+-- Compatibility with the old shared representation
+------------------------------------------------------------------------
+
+fromStoreNrw : StoreNrw → SealCorr
+fromStoreNrw [] = []
+fromStoreNrw ((α ꞉ p) ∷ σ) =
+  matched α (src p) α (tgt p) ∷ fromStoreNrw σ
+fromStoreNrw ((α ꞉= A ⊒) ∷ σ) = right-only α A ∷ fromStoreNrw σ
+fromStoreNrw ((⊒ α ꞉=☆) ∷ σ) = left-only α ★ ∷ fromStoreNrw σ
+
+leftStore-fromStoreNrw :
+  ∀ σ →
+  leftStore (fromStoreNrw σ) ≡ srcStoreⁿ σ
+leftStore-fromStoreNrw [] = refl
+leftStore-fromStoreNrw ((α ꞉ p) ∷ σ) =
+  cong ((α , src p) ∷_) (leftStore-fromStoreNrw σ)
+leftStore-fromStoreNrw ((α ꞉= A ⊒) ∷ σ) =
+  leftStore-fromStoreNrw σ
+leftStore-fromStoreNrw ((⊒ α ꞉=☆) ∷ σ) =
+  cong ((α , ★) ∷_) (leftStore-fromStoreNrw σ)
+
+rightStore-fromStoreNrw :
+  ∀ σ →
+  rightStore (fromStoreNrw σ) ≡ tgtStoreⁿ σ
+rightStore-fromStoreNrw [] = refl
+rightStore-fromStoreNrw ((α ꞉ p) ∷ σ) =
+  cong ((α , tgt p) ∷_) (rightStore-fromStoreNrw σ)
+rightStore-fromStoreNrw ((α ꞉= A ⊒) ∷ σ) =
+  cong ((α , A) ∷_) (rightStore-fromStoreNrw σ)
+rightStore-fromStoreNrw ((⊒ α ꞉=☆) ∷ σ) =
+  rightStore-fromStoreNrw σ
+
+leftStore-⇑ᶜorr :
+  ∀ ρ →
+  leftStore (⇑ᶜorr ρ) ≡ ⟰ᵗ (leftStore ρ)
+leftStore-⇑ᶜorr [] = refl
+leftStore-⇑ᶜorr (matched α A β B ∷ ρ) =
+  cong ((suc α , ⇑ᵗ A) ∷_) (leftStore-⇑ᶜorr ρ)
+leftStore-⇑ᶜorr (left-only α A ∷ ρ) =
+  cong ((suc α , ⇑ᵗ A) ∷_) (leftStore-⇑ᶜorr ρ)
+leftStore-⇑ᶜorr (right-only β B ∷ ρ) =
+  leftStore-⇑ᶜorr ρ
+
+rightStore-⇑ᶜorr :
+  ∀ ρ →
+  rightStore (⇑ᶜorr ρ) ≡ ⟰ᵗ (rightStore ρ)
+rightStore-⇑ᶜorr [] = refl
+rightStore-⇑ᶜorr (matched α A β B ∷ ρ) =
+  cong ((suc β , ⇑ᵗ B) ∷_) (rightStore-⇑ᶜorr ρ)
+rightStore-⇑ᶜorr (left-only α A ∷ ρ) =
+  rightStore-⇑ᶜorr ρ
+rightStore-⇑ᶜorr (right-only β B ∷ ρ) =
+  cong ((suc β , ⇑ᵗ B) ∷_) (rightStore-⇑ᶜorr ρ)
+
+leftStore-⇑ˡᶜorr :
+  ∀ ρ →
+  leftStore (⇑ˡᶜorr ρ) ≡ ⟰ᵗ (leftStore ρ)
+leftStore-⇑ˡᶜorr [] = refl
+leftStore-⇑ˡᶜorr (matched α A β B ∷ ρ) =
+  cong ((suc α , ⇑ᵗ A) ∷_) (leftStore-⇑ˡᶜorr ρ)
+leftStore-⇑ˡᶜorr (left-only α A ∷ ρ) =
+  cong ((suc α , ⇑ᵗ A) ∷_) (leftStore-⇑ˡᶜorr ρ)
+leftStore-⇑ˡᶜorr (right-only β B ∷ ρ) =
+  leftStore-⇑ˡᶜorr ρ
+
+rightStore-⇑ˡᶜorr :
+  ∀ ρ →
+  rightStore (⇑ˡᶜorr ρ) ≡ rightStore ρ
+rightStore-⇑ˡᶜorr [] = refl
+rightStore-⇑ˡᶜorr (matched α A β B ∷ ρ) =
+  cong ((β , B) ∷_) (rightStore-⇑ˡᶜorr ρ)
+rightStore-⇑ˡᶜorr (left-only α A ∷ ρ) =
+  rightStore-⇑ˡᶜorr ρ
+rightStore-⇑ˡᶜorr (right-only β B ∷ ρ) =
+  cong ((β , B) ∷_) (rightStore-⇑ˡᶜorr ρ)
+
+leftStore-⇑ʳᶜorr :
+  ∀ ρ →
+  leftStore (⇑ʳᶜorr ρ) ≡ leftStore ρ
+leftStore-⇑ʳᶜorr [] = refl
+leftStore-⇑ʳᶜorr (matched α A β B ∷ ρ) =
+  cong ((α , A) ∷_) (leftStore-⇑ʳᶜorr ρ)
+leftStore-⇑ʳᶜorr (left-only α A ∷ ρ) =
+  cong ((α , A) ∷_) (leftStore-⇑ʳᶜorr ρ)
+leftStore-⇑ʳᶜorr (right-only β B ∷ ρ) =
+  leftStore-⇑ʳᶜorr ρ
+
+rightStore-⇑ʳᶜorr :
+  ∀ ρ →
+  rightStore (⇑ʳᶜorr ρ) ≡ ⟰ᵗ (rightStore ρ)
+rightStore-⇑ʳᶜorr [] = refl
+rightStore-⇑ʳᶜorr (matched α A β B ∷ ρ) =
+  cong ((suc β , ⇑ᵗ B) ∷_) (rightStore-⇑ʳᶜorr ρ)
+rightStore-⇑ʳᶜorr (left-only α A ∷ ρ) =
+  rightStore-⇑ʳᶜorr ρ
+rightStore-⇑ʳᶜorr (right-only β B ∷ ρ) =
+  cong ((suc β , ⇑ᵗ B) ∷_) (rightStore-⇑ʳᶜorr ρ)

--- a/GTSF/TermNarrowingSeparated.agda
+++ b/GTSF/TermNarrowingSeparated.agda
@@ -1,0 +1,504 @@
+module TermNarrowingSeparated where
+
+-- File Charter:
+--   * First separated-store term-narrowing surface for GTSF.
+--   * Uses independent left/right type contexts and stores, connected by the
+--     explicit `SealCorr` relation from `StoreCorrespondence`.
+--   * Covers the value, lambda, application, and primitive forms needed to start
+--     migrating the DGG beta proof away from shared-store target shifting.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using (List; []; _∷_; map)
+open import Data.Nat using (suc)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; subst)
+
+open import Types
+open import Ctx using (⤊ᵗ)
+open import Coercions
+open import NarrowWiden using (cross; dualⁿ; dualʷ; _∣_∣_⊢_∶_⊒_)
+  renaming (_↦_ to _↦ⁿʷ_)
+open import Primitives
+open import NuTerms
+open import StoreCorrespondence
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualⁿ-flips-typingᵐ
+  ; dualʷ-flips-typingᵐ
+  )
+
+------------------------------------------------------------------------
+-- Separate term-context correspondence
+------------------------------------------------------------------------
+
+data CtxCorrEntry : Set where
+  ctx-entry : Ty → Ty → Coercion → CtxCorrEntry
+
+CtxCorr : Set
+CtxCorr = List CtxCorrEntry
+
+leftCtxEntry : CtxCorrEntry → Ty
+leftCtxEntry (ctx-entry A B p) = A
+
+rightCtxEntry : CtxCorrEntry → Ty
+rightCtxEntry (ctx-entry A B p) = B
+
+corrCtxEntry : CtxCorrEntry → Coercion
+corrCtxEntry (ctx-entry A B p) = p
+
+leftCtx : CtxCorr → Ctx
+leftCtx = map leftCtxEntry
+
+rightCtx : CtxCorr → Ctx
+rightCtx = map rightCtxEntry
+
+shiftCtxCorrEntry : CtxCorrEntry → CtxCorrEntry
+shiftCtxCorrEntry (ctx-entry A B p) =
+  ctx-entry (⇑ᵗ A) (⇑ᵗ B) (⇑ᶜ p)
+
+⇑ᵍᶜ : CtxCorr → CtxCorr
+⇑ᵍᶜ = map shiftCtxCorrEntry
+
+leftCtx-∋ :
+  ∀ {γ x A B p} →
+  γ ∋ x ⦂ ctx-entry A B p →
+  leftCtx γ ∋ x ⦂ A
+leftCtx-∋ Z = Z
+leftCtx-∋ (S x∋p) = S (leftCtx-∋ x∋p)
+
+rightCtx-∋ :
+  ∀ {γ x A B p} →
+  γ ∋ x ⦂ ctx-entry A B p →
+  rightCtx γ ∋ x ⦂ B
+rightCtx-∋ Z = Z
+rightCtx-∋ (S x∋p) = S (rightCtx-∋ x∋p)
+
+leftCtx-⇑ᵍᶜ :
+  ∀ γ →
+  leftCtx (⇑ᵍᶜ γ) ≡ ⤊ᵗ (leftCtx γ)
+leftCtx-⇑ᵍᶜ [] = refl
+leftCtx-⇑ᵍᶜ (ctx-entry A B p ∷ γ) =
+  cong (⇑ᵗ A ∷_) (leftCtx-⇑ᵍᶜ γ)
+
+rightCtx-⇑ᵍᶜ :
+  ∀ γ →
+  rightCtx (⇑ᵍᶜ γ) ≡ ⤊ᵗ (rightCtx γ)
+rightCtx-⇑ᵍᶜ [] = refl
+rightCtx-⇑ᵍᶜ (ctx-entry A B p ∷ γ) =
+  cong (⇑ᵗ B ∷_) (rightCtx-⇑ᵍᶜ γ)
+
+shift-left-term-typing :
+  ∀ {Δ ρ γ M A} →
+  suc Δ ∣ leftStore (⇑ᶜorr ρ) ∣ leftCtx (⇑ᵍᶜ γ) ⊢ M ⦂ A →
+  suc Δ ∣ ⟰ᵗ (leftStore ρ) ∣ ⤊ᵗ (leftCtx γ) ⊢ M ⦂ A
+shift-left-term-typing {ρ = ρ} {γ = γ} M⊢ =
+  subst (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+    (leftCtx-⇑ᵍᶜ γ)
+    (subst (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+      (leftStore-⇑ᶜorr ρ)
+      M⊢)
+
+shift-right-term-typing :
+  ∀ {Δ ρ γ M A} →
+  suc Δ ∣ rightStore (⇑ᶜorr ρ) ∣ rightCtx (⇑ᵍᶜ γ) ⊢ M ⦂ A →
+  suc Δ ∣ ⟰ᵗ (rightStore ρ) ∣ ⤊ᵗ (rightCtx γ) ⊢ M ⦂ A
+shift-right-term-typing {ρ = ρ} {γ = γ} M⊢ =
+  subst (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+    (rightCtx-⇑ᵍᶜ γ)
+    (subst (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+      (rightStore-⇑ᶜorr ρ)
+      M⊢)
+
+------------------------------------------------------------------------
+-- Cross-store coercion evidence
+------------------------------------------------------------------------
+
+infix 4 _∣_∣_⊢_∶ᶜ_⊒_
+infix 4 _∣_∣_∣_⊢_∶_⊒_
+
+_∣_∣_∣_⊢_∶_⊒_ :
+  ModeEnv → TyCtx → TyCtx → SealCorr → Coercion → Ty → Ty → Set₁
+μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B =
+  StoreCorr ΔL ΔR ρ ×
+  src r ≡ A ×
+  tgt r ≡ B ×
+  WfTy ΔL A ×
+  WfTy ΔR B ×
+  (μ ∣ ΔL ∣ leftStore ρ ⊢ r ∶ A ⊒ B) ×
+  (μ ∣ ΔR ∣ rightStore ρ ⊢ r ∶ A ⊒ B)
+
+_∣_∣_⊢_∶ᶜ_⊒_ :
+  TyCtx → TyCtx → SealCorr → Coercion → Ty → Ty → Set₁
+ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B =
+  tag-or-idᵈ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ∶ A ⊒ B
+
+fun-narrow-domain-dual :
+  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Coercion
+fun-narrow-domain-dual
+    (_ , _ , _ , _ , _ ,
+      (_ , cross (pʷ ↦ⁿʷ _)) ,
+      _) =
+  proj₁ (dualʷ normalᵃ pʷ)
+
+fun-narrow-domain-dualᶜ :
+  ∀ {ΔL ΔR ρ p q A A′ B B′} →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Coercion
+fun-narrow-domain-dualᶜ = fun-narrow-domain-dual
+
+fun-narrow-domain-dual-typingᶜ :
+  ∀ {ΔL ΔR ρ p q A A′ B B′} →
+  (p↦qᶜ : ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q
+             ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+  ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dualᶜ p↦qᶜ ∶ᶜ A ⊒ A′
+fun-narrow-domain-dual-typingᶜ
+    (stores , _ , _ , wf⇒ hA hB , wf⇒ hA′ hB′ ,
+      (cast-fun p⊢L _ , cross (pʷL ↦ⁿʷ _)) ,
+      (cast-fun p⊢R _ , cross (_ ↦ⁿʷ _))) =
+  let
+    pᵈ⊒L =
+      dualʷ-flips-typingᵐ
+        {μ = tag-or-idᵈ}
+        {η = normalᵃ}
+        {ν = tag-or-idᵈ}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (leftStore-wf stores)
+        (p⊢L , pʷL)
+
+    pᵈ⊒R =
+      dualʷ-flips-typingᵐ
+        {μ = tag-or-idᵈ}
+        {η = normalᵃ}
+        {ν = tag-or-idᵈ}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (rightStore-wf stores)
+        (p⊢R , pʷL)
+  in
+  stores ,
+  proj₁ (coercion-src-tgtᵐ (proj₁ pᵈ⊒L)) ,
+  proj₂ (coercion-src-tgtᵐ (proj₁ pᵈ⊒L)) ,
+  hA ,
+  hA′ ,
+  pᵈ⊒L ,
+  pᵈ⊒R
+
+fun-narrow-codomainᶜ :
+  ∀ {ΔL ΔR ρ p q A A′ B B′} →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ B ⊒ B′
+fun-narrow-codomainᶜ
+    (stores , _ , _ , wf⇒ hA hB , wf⇒ hA′ hB′ ,
+      (cast-fun _ q⊢L , cross (_ ↦ⁿʷ qⁿL)) ,
+      (cast-fun _ q⊢R , cross (_ ↦ⁿʷ qⁿR))) =
+  stores ,
+  proj₁ (coercion-src-tgtᵐ q⊢L) ,
+  proj₂ (coercion-src-tgtᵐ q⊢L) ,
+  hB ,
+  hB′ ,
+  (q⊢L , qⁿL) ,
+  (q⊢R , qⁿR)
+
+narrowing-store-corrᶜ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  StoreCorr ΔL ΔR ρ
+narrowing-store-corrᶜ (stores , _ , _ , _ , _ , _ , _) = stores
+
+narrowing-dual :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  Coercion
+narrowing-dual (_ , _ , _ , _ , _ , (_ , cⁿ) , _) =
+  proj₁ (dualⁿ normalᵃ cⁿ)
+
+narrowing-left-coercion-typingᶜ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  ∃[ μ′ ] μ′ ∣ ΔL ∣ leftStore ρ ⊢ c ∶ A =⇒ B
+narrowing-left-coercion-typingᶜ {μ = μ} (_ , _ , _ , _ , _ , c⊒L , _) =
+  μ , proj₁ c⊒L
+
+narrowing-right-coercion-typingᶜ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  ∃[ μ′ ] μ′ ∣ ΔR ∣ rightStore ρ ⊢ c ∶ A =⇒ B
+narrowing-right-coercion-typingᶜ {μ = μ} (_ , _ , _ , _ , _ , _ , c⊒R) =
+  μ , proj₁ c⊒R
+
+narrowing-left-dual-coercion-typingᶜ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  (c⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B) →
+  ∃[ μ′ ] μ′ ∣ ΔL ∣ leftStore ρ ⊢ narrowing-dual c⊒ ∶ B =⇒ A
+narrowing-left-dual-coercion-typingᶜ {μ = μ}
+    (stores , _ , _ , _ , _ , (c⊢L , cⁿL) , _) =
+  μ ,
+  proj₁
+    (dualⁿ-flips-typingᵐ
+      {μ = μ}
+      {η = normalᵃ}
+      {ν = μ}
+      dualActionOk-normal
+      dualStoreAt-normal
+      (leftStore-wf stores)
+      (c⊢L , cⁿL))
+
+narrowing-right-dual-coercion-typingᶜ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  (c⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B) →
+  ∃[ μ′ ] μ′ ∣ ΔR ∣ rightStore ρ ⊢ narrowing-dual c⊒ ∶ B =⇒ A
+narrowing-right-dual-coercion-typingᶜ {μ = μ}
+    (stores , _ , _ , _ , _ , (_ , cⁿL) , (c⊢R , _)) =
+  μ ,
+  proj₁
+    (dualⁿ-flips-typingᵐ
+      {μ = μ}
+      {η = normalᵃ}
+      {ν = μ}
+      dualActionOk-normal
+      dualStoreAt-normal
+      (rightStore-wf stores)
+      (c⊢R , cⁿL))
+
+------------------------------------------------------------------------
+-- Typed/well-indexed separated term narrowing
+------------------------------------------------------------------------
+
+TermTypingEndpointsᶜ :
+  (ΔL ΔR : TyCtx) (ρ : SealCorr) (γ : CtxCorr) →
+  (M M′ : Term) (A B : Ty) → Set₁
+TermTypingEndpointsᶜ ΔL ΔR ρ γ M M′ A B =
+  (ΔL ∣ leftStore ρ ∣ leftCtx γ ⊢ M ⦂ A) ×
+  (ΔR ∣ rightStore ρ ∣ rightCtx γ ⊢ M′ ⦂ B)
+
+infix 4 _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
+
+data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
+    : TyCtx → TyCtx → SealCorr → CtxCorr →
+      Term → Term → Coercion → Ty → Ty → Set₁ where
+
+  -- The Cambridge25 notation uses p and q for coercions whose evidence is
+  -- restricted to `∶ᶜ` (the tag-or-id mode).  It uses r for cast-composed
+  -- result coercions, whose evidence is the general μ-indexed narrowing
+  -- typing.  The separated rules below keep that naming convention visible:
+  -- p/q premises use `_⊢_∶ᶜ_⊒_`, while r premises use `_∣_∣_∣_⊢_∶_⊒_`.
+
+  ⊒blameᵗ : ∀ {ΔL ΔR ρ γ M p A B}
+    → ΔL ∣ leftStore ρ ∣ leftCtx γ ⊢ M ⦂ A
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B
+      ------------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ blame ∶ p ⦂ A ⊒ B
+
+  x⊒xᵗ : ∀ {ΔL ΔR ρ γ x p A B}
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B
+    → γ ∋ x ⦂ ctx-entry A B p
+      ---------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ ` x ⊒ ` x ∶ p ⦂ A ⊒ B
+
+  ƛ⊒ƛᵗ : ∀ {ΔL ΔR ρ γ N N′ p q A A′ B B′}
+    → (p↦qᶜ : ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q
+                   ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′))
+    → ΔL ∣ ΔR ∣ ρ ∣
+        ctx-entry A A′ (fun-narrow-domain-dualᶜ p↦qᶜ) ∷ γ
+        ⊢ N ⊒ N′ ∶ q ⦂ B ⊒ B′
+      -------------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ ƛ N ⊒ ƛ N′ ∶ p ↦ q
+        ⦂ A ⇒ B ⊒ A′ ⇒ B′
+
+  ·⊒·ᵗ : ∀ {ΔL ΔR ρ γ L L′ M M′ p q A A′ B B′}
+    → (p↦qᶜ : ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q
+                   ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′))
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ L′ ∶ p ↦ q
+        ⦂ A ⇒ B ⊒ A′ ⇒ B′
+    → ΔL ∣ ΔR ∣ ρ ∣ γ
+        ⊢ M ⊒ M′ ∶ fun-narrow-domain-dualᶜ p↦qᶜ ⦂ A ⊒ A′
+      -----------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L · M ⊒ L′ · M′ ∶ q ⦂ B ⊒ B′
+
+  Λ⊒Λᵗ : ∀ {ΔL ΔR ρ γ V V′ p A B}
+    → ΔL ∣ ΔR ∣ ρ ⊢ `∀ p ∶ᶜ `∀ A ⊒ `∀ B
+    → Value V
+    → Value V′
+    → suc ΔL ∣ suc ΔR ∣ ⇑ᶜorr ρ ∣ ⇑ᵍᶜ γ
+        ⊢ V ⊒ V′ ∶ p ⦂ A ⊒ B
+      -----------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ Λ V ⊒ Λ V′ ∶ `∀ p
+        ⦂ `∀ A ⊒ `∀ B
+
+  κ⊒κᵗ : ∀ {ΔL ΔR ρ γ} κ
+    → ΔL ∣ ΔR ∣ ρ ⊢ id (constTy κ) ∶ᶜ constTy κ ⊒ constTy κ
+      -----------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ $ κ ⊒ $ κ ∶ id (constTy κ)
+        ⦂ constTy κ ⊒ constTy κ
+
+  ⊕⊒⊕ᵗ : ∀ {ΔL ΔR ρ γ M M′ N N′}
+    → ΔL ∣ ΔR ∣ ρ ⊢ id (‵ `ℕ) ∶ᶜ ‵ `ℕ ⊒ ‵ `ℕ
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ id (‵ `ℕ)
+        ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ N ⊒ N′ ∶ id (‵ `ℕ)
+        ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+      ------------------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊕[ addℕ ] N ⊒ M′ ⊕[ addℕ ] N′
+        ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+
+  ⊒cast+ᵗ : ∀ {ΔL ΔR ρ γ M M′ p r t A B C μ η}
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ C
+    → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
+    → (t⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ C ⊒ B)
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
+      -------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ
+        ⊢ M ⊒ M′ ⟨ narrowing-dual t⊒ ⟩ ∶ p ⦂ A ⊒ C
+
+  ⊒cast-ᵗ : ∀ {ΔL ΔR ρ γ M M′ p r t A B C μ η}
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ C
+    → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
+    → η ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ C ⊒ B
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ C
+      ---------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ⟨ t ⟩ ∶ r ⦂ A ⊒ B
+
+  cast+⊒ᵗ : ∀ {ΔL ΔR ρ γ M M′ q r s A B C μ η}
+    → ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ C ⊒ B
+    → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
+    → (s⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ s ∶ A ⊒ C)
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ q ⦂ C ⊒ B
+      -------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ
+        ⊢ M ⟨ narrowing-dual s⊒ ⟩ ⊒ M′ ∶ r ⦂ A ⊒ B
+
+  cast-⊒ᵗ : ∀ {ΔL ΔR ρ γ M M′ q r s A B C μ η}
+    → ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ C ⊒ B
+    → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
+    → η ∣ ΔL ∣ ΔR ∣ ρ ⊢ s ∶ A ⊒ C
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
+      ---------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⟨ s ⟩ ⊒ M′ ∶ q ⦂ C ⊒ B
+
+typed-term-narrowing-term-typingᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ p A B} →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  TermTypingEndpointsᶜ ΔL ΔR ρ γ M M′ A B
+typed-term-narrowing-term-typingᶜ
+    (⊒blameᵗ M⊢ (_ , _ , _ , _ , hB , _ , _)) =
+  M⊢ , ⊢blame hB
+typed-term-narrowing-term-typingᶜ
+    (x⊒xᵗ pᶜ x∋p) =
+  ⊢` (leftCtx-∋ x∋p) , ⊢` (rightCtx-∋ x∋p)
+typed-term-narrowing-term-typingᶜ
+    (ƛ⊒ƛᵗ (_ , _ , _ , wf⇒ hA hB , wf⇒ hA′ hB′ , _ , _)
+      N⊒N′) =
+  let
+    N⊢ , N′⊢ = typed-term-narrowing-term-typingᶜ N⊒N′
+  in
+  ⊢ƛ hA N⊢ , ⊢ƛ hA′ N′⊢
+typed-term-narrowing-term-typingᶜ
+    (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
+  let
+    L⊢ , L′⊢ = typed-term-narrowing-term-typingᶜ L⊒L′
+    M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
+  in
+  ⊢· L⊢ M⊢ , ⊢· L′⊢ M′⊢
+typed-term-narrowing-term-typingᶜ {ρ = ρ} {γ = γ}
+    (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′) =
+  let
+    V⊢ , V′⊢ = typed-term-narrowing-term-typingᶜ V⊒V′
+  in
+  ⊢Λ vV (shift-left-term-typing {ρ = ρ} {γ = γ} V⊢) ,
+  ⊢Λ vV′ (shift-right-term-typing {ρ = ρ} {γ = γ} V′⊢)
+typed-term-narrowing-term-typingᶜ
+    (κ⊒κᵗ κ pᶜ) =
+  ⊢$ κ , ⊢$ κ
+typed-term-narrowing-term-typingᶜ
+    (⊕⊒⊕ᵗ pᶜ M⊒M′ N⊒N′) =
+  let
+    M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
+    N⊢ , N′⊢ = typed-term-narrowing-term-typingᶜ N⊒N′
+  in
+  ⊢⊕ M⊢ addℕ N⊢ , ⊢⊕ M′⊢ addℕ N′⊢
+typed-term-narrowing-term-typingᶜ
+    (⊒cast+ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′)
+    with narrowing-right-dual-coercion-typingᶜ {μ = η} t⊒
+typed-term-narrowing-term-typingᶜ
+    (⊒cast+ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′) | μ′ , t⊢ =
+  let
+    M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
+  in
+  M⊢ , ⊢⟨⟩ t⊢ M′⊢
+typed-term-narrowing-term-typingᶜ
+    (⊒cast-ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′)
+    with narrowing-right-coercion-typingᶜ {μ = η} t⊒
+typed-term-narrowing-term-typingᶜ
+    (⊒cast-ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′) | μ′ , t⊢ =
+  let
+    M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
+  in
+  M⊢ , ⊢⟨⟩ t⊢ M′⊢
+typed-term-narrowing-term-typingᶜ
+    (cast+⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′)
+    with narrowing-left-dual-coercion-typingᶜ {μ = η} s⊒
+typed-term-narrowing-term-typingᶜ
+    (cast+⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′) | μ′ , s⊢ =
+  let
+    M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
+  in
+  ⊢⟨⟩ s⊢ M⊢ , M′⊢
+typed-term-narrowing-term-typingᶜ
+    (cast-⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′)
+    with narrowing-left-coercion-typingᶜ {μ = η} s⊒
+typed-term-narrowing-term-typingᶜ
+    (cast-⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′) | μ′ , s⊢ =
+  let
+    M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
+  in
+  ⊢⟨⟩ s⊢ M⊢ , M′⊢
+
+typed-term-narrowing-coercion :
+  ∀ {ΔL ΔR ρ γ M M′ p A B} →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ∃[ μ ] μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ∶ A ⊒ B
+typed-term-narrowing-coercion (⊒blameᵗ M⊢ pᶜ) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (x⊒xᵗ pᶜ x∋p) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) =
+  tag-or-idᵈ , p↦qᶜ
+typed-term-narrowing-coercion (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
+  tag-or-idᵈ , fun-narrow-codomainᶜ p↦qᶜ
+typed-term-narrowing-coercion (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′) =
+  tag-or-idᵈ , allᶜ
+typed-term-narrowing-coercion (κ⊒κᵗ κ pᶜ) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (⊕⊒⊕ᵗ pᶜ M⊒M′ N⊒N′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (⊒cast+ᵗ pᶜ r⊒ t⊒ M⊒M′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (⊒cast-ᵗ {μ = μ} pᶜ r⊒ t⊒ M⊒M′) =
+  μ , r⊒
+typed-term-narrowing-coercion (cast+⊒ᵗ {μ = μ} qᶜ r⊒ s⊒ M⊒M′) =
+  μ , r⊒
+typed-term-narrowing-coercion (cast-⊒ᵗ qᶜ r⊒ s⊒ M⊒M′) =
+  tag-or-idᵈ , qᶜ
+
+typed-term-narrowing-source-typingᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ p A B} →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ΔL ∣ leftStore ρ ∣ leftCtx γ ⊢ M ⦂ A
+typed-term-narrowing-source-typingᶜ M⊒M′
+    with typed-term-narrowing-term-typingᶜ M⊒M′
+typed-term-narrowing-source-typingᶜ M⊒M′ | M⊢ , M′⊢ = M⊢
+
+typed-term-narrowing-target-typingᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ p A B} →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ΔR ∣ rightStore ρ ∣ rightCtx γ ⊢ M′ ⦂ B
+typed-term-narrowing-target-typingᶜ M⊒M′
+    with typed-term-narrowing-term-typingᶜ M⊒M′
+typed-term-narrowing-target-typingᶜ M⊒M′ | M⊢ , M′⊢ = M′⊢

--- a/GTSF/proof/CatchupSeparated.agda
+++ b/GTSF/proof/CatchupSeparated.agda
@@ -1,0 +1,161 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.CatchupSeparated where
+
+-- File Charter:
+--   * Separated-store catchup surface for migrating DGG away from the shared
+--     `StoreNrw` namespace.
+--   * Defines left-side store-change application on `SealCorr`, with projection
+--     lemmas showing only the left runtime store changes.
+--   * States the left catchup lemma with an unchanged target term.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Nat using (zero)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; trans)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NuReduction using
+  ( StoreChange
+  ; StoreChanges
+  ; keep
+  ; bind
+  ; applyStore
+  ; applyStores
+  ; applyTys
+  ; applyTyCtxs
+  ; _—↠[_]_
+  )
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.ReductionProperties using (applyCoercions)
+
+------------------------------------------------------------------------
+-- Left-side catchup store changes
+------------------------------------------------------------------------
+
+applyLeftChange : StoreChange → SealCorr → SealCorr
+applyLeftChange keep ρ = ρ
+applyLeftChange (bind A) ρ = left-only zero (⇑ᵗ A) ∷ ⇑ˡᶜorr ρ
+
+applyLeftChanges : StoreChanges → SealCorr → SealCorr
+applyLeftChanges [] ρ = ρ
+applyLeftChanges (χ ∷ χs) ρ =
+  applyLeftChanges χs (applyLeftChange χ ρ)
+
+applyLeftChanges-++ :
+  ∀ χs χs′ ρ →
+  applyLeftChanges (χs ++ χs′) ρ ≡
+    applyLeftChanges χs′ (applyLeftChanges χs ρ)
+applyLeftChanges-++ [] χs′ ρ = refl
+applyLeftChanges-++ (χ ∷ χs) χs′ ρ =
+  applyLeftChanges-++ χs χs′ (applyLeftChange χ ρ)
+
+leftStore-applyLeftChange :
+  ∀ χ ρ →
+  leftStore (applyLeftChange χ ρ) ≡ applyStore χ (leftStore ρ)
+leftStore-applyLeftChange keep ρ = refl
+leftStore-applyLeftChange (bind A) ρ =
+  cong ((zero , ⇑ᵗ A) ∷_) (leftStore-⇑ˡᶜorr ρ)
+
+rightStore-applyLeftChange :
+  ∀ χ ρ →
+  rightStore (applyLeftChange χ ρ) ≡ rightStore ρ
+rightStore-applyLeftChange keep ρ = refl
+rightStore-applyLeftChange (bind A) ρ = rightStore-⇑ˡᶜorr ρ
+
+leftStore-applyLeftChanges :
+  ∀ χs ρ →
+  leftStore (applyLeftChanges χs ρ) ≡ applyStores χs (leftStore ρ)
+leftStore-applyLeftChanges [] ρ = refl
+leftStore-applyLeftChanges (χ ∷ χs) ρ =
+  trans
+    (leftStore-applyLeftChanges χs (applyLeftChange χ ρ))
+    (cong (applyStores χs) (leftStore-applyLeftChange χ ρ))
+
+rightStore-applyLeftChanges :
+  ∀ χs ρ →
+  rightStore (applyLeftChanges χs ρ) ≡ rightStore ρ
+rightStore-applyLeftChanges [] ρ = refl
+rightStore-applyLeftChanges (χ ∷ χs) ρ =
+  trans
+    (rightStore-applyLeftChanges χs (applyLeftChange χ ρ))
+    (rightStore-applyLeftChange χ ρ)
+
+------------------------------------------------------------------------
+-- Right-side target store changes
+------------------------------------------------------------------------
+
+applyRightChange : StoreChange → SealCorr → SealCorr
+applyRightChange keep ρ = ρ
+applyRightChange (bind A) ρ = right-only zero (⇑ᵗ A) ∷ ⇑ʳᶜorr ρ
+
+applyRightChanges : StoreChanges → SealCorr → SealCorr
+applyRightChanges [] ρ = ρ
+applyRightChanges (χ ∷ χs) ρ =
+  applyRightChanges χs (applyRightChange χ ρ)
+
+leftStore-applyRightChange :
+  ∀ χ ρ →
+  leftStore (applyRightChange χ ρ) ≡ leftStore ρ
+leftStore-applyRightChange keep ρ = refl
+leftStore-applyRightChange (bind A) ρ = leftStore-⇑ʳᶜorr ρ
+
+rightStore-applyRightChange :
+  ∀ χ ρ →
+  rightStore (applyRightChange χ ρ) ≡ applyStore χ (rightStore ρ)
+rightStore-applyRightChange keep ρ = refl
+rightStore-applyRightChange (bind A) ρ =
+  cong ((zero , ⇑ᵗ A) ∷_) (rightStore-⇑ʳᶜorr ρ)
+
+leftStore-applyRightChanges :
+  ∀ χs ρ →
+  leftStore (applyRightChanges χs ρ) ≡ leftStore ρ
+leftStore-applyRightChanges [] ρ = refl
+leftStore-applyRightChanges (χ ∷ χs) ρ =
+  trans
+    (leftStore-applyRightChanges χs (applyRightChange χ ρ))
+    (leftStore-applyRightChange χ ρ)
+
+rightStore-applyRightChanges :
+  ∀ χs ρ →
+  rightStore (applyRightChanges χs ρ) ≡ applyStores χs (rightStore ρ)
+rightStore-applyRightChanges [] ρ = refl
+rightStore-applyRightChanges (χ ∷ χs) ρ =
+  trans
+    (rightStore-applyRightChanges χs (applyRightChange χ ρ))
+    (cong (applyStores χs) (rightStore-applyRightChange χ ρ))
+
+------------------------------------------------------------------------
+-- Separated left catchup
+------------------------------------------------------------------------
+
+catchup-lemmaˡ :
+  ∀ {ΔL ΔR ρ M V p A B} →
+  RuntimeOK M →
+  Value V →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ V ∶ p ⦂ A ⊒ B →
+  ∃[ χs ] ∃[ W ] ∃[ ΔL′ ]
+    Value W ×
+    No• W ×
+    (M —↠[ χs ] W) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) ×
+    (leftStore (applyLeftChanges χs ρ) ≡
+      applyStores χs (leftStore ρ)) ×
+    (rightStore (applyLeftChanges χs ρ) ≡ rightStore ρ) ×
+    (ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+      ⊢ applyCoercions χs p ∶ᶜ applyTys χs A ⊒ B) ×
+    ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+      ⊢ W ⊒ V ∶ applyCoercions χs p ⦂ applyTys χs A ⊒ B
+catchup-lemmaˡ (ok-no noM) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-• vW noW) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-·₁ okL noR) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-·₂ vL noL okR) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-ν okL) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-⊕₁ okL noR) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-⊕₂ vL noL okR) vV M⊒V = {! ? !}
+catchup-lemmaˡ (ok-⟨⟩ okM) vV M⊒V = {! ? !}

--- a/GTSF/proof/DynamicGradualGuarantee.agda
+++ b/GTSF/proof/DynamicGradualGuarantee.agda
@@ -26,7 +26,7 @@ open import NuStore using (StoreWf; at)
 open import NarrowWiden
 open import TermNarrowing
 open import proof.CoercionProperties using (coercion-wf)
-open import proof.Catchup using (catchup-lemma)
+open import proof.Catchup using (catchup-lemma; runtime-⇑ᵗᵐ)
 open import proof.CatchupStore using
   ( combineStoreNrw
   ; combineStoreNrw-empty-⊒ˢ
@@ -38,6 +38,7 @@ open import proof.NarrowWidenProperties using
   )
 open import proof.ReductionProperties using
   ( applyCoercions
+  ; applyCoercions-dual
   ; applyStores-++
   ; applyTerms-const
   ; applyTerms-preserves-No•
@@ -46,6 +47,7 @@ open import proof.ReductionProperties using
   ; applyTys-ℕ-applyTys
   ; type-rename-step-⇑ᵗᵐ
   ; ↠-trans
+  ; ·₂-↠
   ; ⊕₁-↠
   ; ⊕₂-↠
   )
@@ -63,6 +65,21 @@ runtime-·₂-any :
 runtime-·₂-any (ok-no (no•-· noL noM)) = ok-no noM
 runtime-·₂-any (ok-·₁ okL noM) = ok-no noM
 runtime-·₂-any (ok-·₂ vL noL okM) = okM
+
+applyTerm-preserves-RuntimeOK :
+  ∀ χ {M} →
+  RuntimeOK M →
+  RuntimeOK (applyTerm χ M)
+applyTerm-preserves-RuntimeOK keep okM = okM
+applyTerm-preserves-RuntimeOK (bind A) okM = runtime-⇑ᵗᵐ okM
+
+applyTerms-preserves-RuntimeOK :
+  ∀ χs {M} →
+  RuntimeOK M →
+  RuntimeOK (applyTerms χs M)
+applyTerms-preserves-RuntimeOK [] okM = okM
+applyTerms-preserves-RuntimeOK (χ ∷ χs) okM =
+  applyTerms-preserves-RuntimeOK χs (applyTerm-preserves-RuntimeOK χ okM)
 
 runtime-⊕₂-any :
   ∀ {L op M} →
@@ -227,47 +244,57 @@ value-normalized-id-ℕ-target-const target-value T≡ p≡ A≡ B≡ W⊒ =
 -- Function application simulation
 ------------------------------------------------------------------------
 
-function-application-simulation-ƛ⊒ƛᵗ :
-  ∀ {Δ σ N N′ V V′ a q A B C D} →
-  Value V →
-  Δ ∣ srcStoreⁿ σ ⊢ a ∶ᶜ A ⊒ B →
-  Δ ∣ σ ∣ a ∷ [] ⊢ N ⊒ N′ ∶ q ⦂ C ⊒ D →
-  Δ ∣ σ ∣ [] ⊢ V ⊒ V′ ∶ a ⦂ A ⊒ B →
-  ∃[ χs ] ∃[ P ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
-  ∃[ C′ ] ∃[ D′ ] ∃[ q′ ]
-    ((ƛ N) · V —↠[ χs ] P) ×
-    (Π ≡ applyStores χs []) ×
-    (Π′ ≡ applyStore keep []) ×
-    Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
-    Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ P ⊒ N′ [ V′ ] ∶ q′ ⦂ C′ ⊒ D′
-function-application-simulation-ƛ⊒ƛᵗ {N = N} {V = V}
-    vV aᶜ N⊒N′ V⊒V′ =
-  keep ∷ [] , N [ V ] , _ , [] , [] , [] , _ , _ , _ ,
-  ↠-step (pure-step (β vV)) ↠-refl ,
-  refl ,
-  refl ,
-  ⊒ˢ-nil ,
-  term-substitution-narrowingᵗ {! ? !} N⊒N′
+applyTerms-ƛ :
+  ∀ χs N →
+  applyTerms χs (ƛ N) ≡ ƛ applyTerms χs N
+applyTerms-ƛ [] N = refl
+applyTerms-ƛ (keep ∷ χs) N = applyTerms-ƛ χs N
+applyTerms-ƛ (bind A ∷ χs) N = applyTerms-ƛ χs (⇑ᵗᵐ N)
 
-function-application-simulation :
-  ∀ {Δ σ L M N′ V′ p q A A′ B B′} →
-  RuntimeOK M →
-  Value V′ →
-  Δ ∣ σ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  Δ ∣ σ ∣ [] ⊢ M ⊒ V′ ∶ - p ⦂ A ⊒ A′ →
+applyCoercions-↦ :
+  ∀ χs p q →
+  applyCoercions χs (p ↦ q) ≡ applyCoercions χs p ↦ applyCoercions χs q
+applyCoercions-↦ [] p q = refl
+applyCoercions-↦ (keep ∷ χs) p q = applyCoercions-↦ χs p q
+applyCoercions-↦ (bind A ∷ χs) p q =
+  applyCoercions-↦ χs (⇑ᶜ p) (⇑ᶜ q)
+
+applyCoercions-dual-applyCoercions :
+  ∀ χs χs′ p →
+  applyCoercions χs′ (applyCoercions χs (- p)) ≡
+    - applyCoercions χs′ (applyCoercions χs p)
+applyCoercions-dual-applyCoercions χs χs′ p =
+  trans
+    (cong (applyCoercions χs′) (applyCoercions-dual χs p))
+    (applyCoercions-dual χs′ (applyCoercions χs p))
+
+sim-beta :
+  ∀ {σ WL NL WR VR}
+    {ΔL σL pL qL AL BL}
+    {ΔR σR AR BR} →
+  ΔL ∣ σL ∣ [] ⊢ WL ⊒ ƛ NL ∶ pL ↦ qL ⦂ AL ⊒ BL →
+  Value WL →
+  No• WL →
+  ΔR ∣ σR ∣ [] ⊢ WR ⊒ VR ∶ - pL ⦂ AR ⊒ BR →
+  Value WR →
+  No• WR →
+  Value VR →
   ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
-  ∃[ C′ ] ∃[ D′ ] ∃[ q′ ]
-    (L · M —↠[ χs ] N) ×
+  ∃[ C ] ∃[ D ] ∃[ r ]
+    (WL · WR —↠[ χs ] N) ×
     (Π ≡ applyStores χs []) ×
-    (Π′ ≡ applyStore keep []) ×
+    (Π′ ≡ []) ×
     Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
-    Δ′ ∣ combineStoreNrw π σ ∣ [] ⊢ N ⊒ N′ [ V′ ] ∶ q′ ⦂ C′ ⊒ D′
-function-application-simulation okM vV′ L⊒L′ M⊒V′
-    with catchup-lemma okM vV′ M⊒V′
-function-application-simulation okM vV′ L⊒L′ M⊒V′
-    | χs , W , Δ′ , Π , Π′ , π ,
-      vW , noW , M↠W , Δ′≡ , Π≡ , Π′≡ , π⊒ , W⊒V′ =
+    Δ′ ∣ combineStoreNrw π σ ∣ []
+      ⊢ N ⊒ NL [ VR ] ∶ r ⦂ C ⊒ D
+sim-beta
+    WL⊒ƛ vWL noWL
+    WR⊒VR vWR noWR vVR =
   {! ? !}
+
+------------------------------------------------------------------------
+-- Primitive application
+------------------------------------------------------------------------
 
 ⊕-δ-left-first :
   ∀ {Δ σ M N m′ n′} →
@@ -945,10 +972,116 @@ dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
 dynamicGradualGuarantee wfΣ okM σ⊒ pᶜ
     (⊒αᵗ γ′≡ pαᶜ L⊒L′) red =
   {! ? !}
-dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
+dynamicGradualGuarantee {Δ = Δ} {σ = σ}
+    {M = L · R} {M′ = (ƛ N′) · V′}
+    wfΣ okM σ⊒ qᶜ
     (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′)
     (pure-step (β vV)) =
-  function-application-simulation (runtime-·₂-any okM) vV L⊒L′ M⊒M′
+  let
+    χsL , WL , ΔL , _ , _ , πL ,
+      vWL , noWL , L↠WL , _ , _ , _ , _ , WL⊒ƛraw =
+      catchup-lemma
+        (runtime-·₁ okM)
+        (ƛ N′)
+        L⊒L′
+
+    WL⊒ƛ :
+      ΔL ∣ combineStoreNrw πL σ ∣ []
+        ⊢ WL ⊒ ƛ applyTerms χsL N′
+          ∶ applyCoercions χsL _ ↦ applyCoercions χsL _
+            ⦂ applyTys χsL _ ⊒ applyTys χsL _
+    WL⊒ƛ =
+      subst
+        (λ c →
+          ΔL ∣ combineStoreNrw πL σ ∣ []
+            ⊢ WL ⊒ ƛ applyTerms χsL N′ ∶ c
+              ⦂ applyTys χsL _ ⊒ applyTys χsL _)
+        (applyCoercions-↦ χsL _ _)
+        (subst
+          (λ T →
+            ΔL ∣ combineStoreNrw πL σ ∣ []
+              ⊢ WL ⊒ T ∶ applyCoercions χsL _
+                ⦂ applyTys χsL _ ⊒ applyTys χsL _)
+          (applyTerms-ƛ χsL N′)
+          WL⊒ƛraw)
+
+    R⊒V′L :
+      ΔL ∣ combineStoreNrw πL σ ∣ []
+        ⊢ applyTerms χsL R ⊒ applyTerms χsL V′
+          ∶ applyCoercions χsL _
+            ⦂ applyTys χsL _ ⊒ applyTys χsL _
+    R⊒V′L = {! ? !}
+
+    χsR , WR , ΔR , _ , _ , πR ,
+      vWR , noWR , R↠WR , _ , _ , _ , _ , WR⊒V′raw =
+      catchup-lemma
+        (applyTerms-preserves-RuntimeOK χsL (runtime-·₂-any okM))
+        (applyTerms-preserves-Value χsL vV)
+        R⊒V′L
+
+    WLF⊒ƛ :
+      ΔR ∣ combineStoreNrw πR (combineStoreNrw πL σ) ∣ []
+        ⊢ applyTerms χsR WL
+          ⊒ ƛ applyTerms χsR (applyTerms χsL N′)
+          ∶ applyCoercions χsR (applyCoercions χsL _)
+              ↦ applyCoercions χsR (applyCoercions χsL _)
+            ⦂ applyTys χsR (applyTys χsL _)
+              ⊒ applyTys χsR (applyTys χsL _)
+    WLF⊒ƛ = {! ? !}
+
+    WR⊒V′ :
+      ΔR ∣ combineStoreNrw πR (combineStoreNrw πL σ) ∣ []
+        ⊢ WR ⊒ applyTerms χsR (applyTerms χsL V′)
+          ∶ - applyCoercions χsR (applyCoercions χsL _)
+            ⦂ applyTys χsR (applyTys χsL _)
+              ⊒ applyTys χsR (applyTys χsL _)
+    WR⊒V′ =
+      subst
+        (λ c →
+          ΔR ∣ combineStoreNrw πR (combineStoreNrw πL σ) ∣ []
+            ⊢ WR ⊒ applyTerms χsR (applyTerms χsL V′) ∶ c
+              ⦂ applyTys χsR (applyTys χsL _)
+                ⊒ applyTys χsR (applyTys χsL _))
+        (applyCoercions-dual-applyCoercions χsL χsR _)
+        WR⊒V′raw
+
+    left-ready :
+      L · R —↠[ χsL ] WL · applyTerms χsL R
+    left-ready = {! ? !}
+
+    right-ready :
+      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · WR
+    right-ready = ·₂-↠ vWL noWL R↠WR
+
+    ready :
+      ∃[ χs₀ ] (L · R —↠[ χs₀ ] applyTerms χsR WL · WR)
+    ready = χsL ++ χsR , ↠-trans left-ready right-ready
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ Δ′ ] ∃[ Π ] ∃[ Π′ ] ∃[ π ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (applyTerms χsR WL · WR —↠[ χs ] N) ×
+        (Π ≡ applyStores χs []) ×
+        (Π′ ≡ []) ×
+        Δ′ ⊢ π ꞉ Π ⊒ˢ Π′ ×
+        Δ′ ∣ combineStoreNrw π
+               (combineStoreNrw πR (combineStoreNrw πL σ)) ∣ []
+          ⊢ N ⊒
+              (applyTerms χsR (applyTerms χsL N′))
+              [ applyTerms χsR (applyTerms χsL V′) ]
+            ∶ r ⦂ C ⊒ D
+    tail =
+      sim-beta
+        WLF⊒ƛ
+        (applyTerms-preserves-Value χsR vWL)
+        (applyTerms-preserves-No• χsR noWL)
+        WR⊒V′
+        vWR
+        noWR
+        (applyTerms-preserves-Value χsR
+          (applyTerms-preserves-Value χsL vV))
+  in
+  {! ? !}
 dynamicGradualGuarantee wfΣ okM σ⊒ qᶜ
     (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′)
     (ξ-·₁ L′→N′ shiftM) =

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -1,0 +1,506 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.DynamicGradualGuaranteeSeparated where
+
+-- File Charter:
+--   * Top-down separated-store surface for resuming the DGG beta proof.
+--   * Keeps the target term/store unchanged while left-side catchup advances
+--     the source term through `SealCorr`.
+--   * Wires the separated beta caller to `proof.SimBetaSeparated` while the
+--     full DGG skeleton is migrated top-down.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import Primitives using (addℕ)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyLeftChanges-++
+  ; applyRightChange
+  ; catchup-lemmaˡ
+  )
+open import proof.NuPreservation using (runtime-⟨⟩)
+open import proof.ReductionProperties using
+  ( applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyCoercions
+  ; applyCoercions-dual
+  ; applyTyCtxs-++
+  ; ↠-trans
+  ; ·₁-↠
+  ; ·₂-↠
+  )
+open import proof.SimBetaSeparated using
+  ( applyTerms-preserves-RuntimeOK
+  ; applyTys-⇒
+  ; applyCoercions-↦
+  ; applyCoercions-dual-applyCoercions
+  ; advance-left-term-narrowing
+  ; advance-left-lambda-narrowing
+  ; sim-beta
+  )
+
+------------------------------------------------------------------------
+-- Application beta caller
+------------------------------------------------------------------------
+
+separated-dgg-beta-left-first :
+  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  RuntimeOK L →
+  RuntimeOK R →
+  No• R →
+  Value V′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
+separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {N′ = N′} {V′ = V′}
+    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {B = B} {B′ = B′}
+    okL okR noR-ready vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  let
+    χsL , WL , ΔL₁ ,
+      vWL , noWL , L↠WL , ΔL₁≡ , ρL-corr ,
+      leftL≡ , rightL≡ , p₁ᶜ , WL⊒ƛraw =
+      catchup-lemmaˡ
+        okL
+        (ƛ N′)
+        L⊒ƛ
+
+    WL⊒ƛ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ WL ⊒ ƛ N′
+          ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+          ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+    WL⊒ƛ =
+      subst
+        (λ c →
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ ƛ N′ ∶ c
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′)
+        (applyCoercions-↦ χsL p q)
+        (subst
+          (λ C →
+            ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+              ⊢ WL ⊒ ƛ N′ ∶ applyCoercions χsL (p ↦ q)
+                ⦂ C ⊒ A′ ⇒ B′)
+          (applyTys-⇒ χsL A B)
+          WL⊒ƛraw)
+
+    R⊒V′L =
+      advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒V′
+
+    χsR , WR , ΔL₂ ,
+      vWR , noWR , R↠WR , ΔL₂≡ , ρR-corr ,
+      leftR≡ , rightR≡ , p₂ᶜ , WR⊒V′raw =
+      catchup-lemmaˡ
+        (applyTerms-preserves-RuntimeOK χsL okR)
+        vV′
+        R⊒V′L
+
+    WLF⊒ƛ =
+      advance-left-lambda-narrowing χsR ΔL₂≡ ρR-corr WL⊒ƛ
+
+    WR⊒V′ :
+      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ) ∣ []
+        ⊢ WR ⊒ V′
+          ∶ applyCoercions χsR (applyCoercions χsL pᵈ)
+          ⦂ applyTys χsR (applyTys χsL A) ⊒ A′
+    WR⊒V′ = WR⊒V′raw
+
+    p₂-domainᶜ :
+      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ)
+        ⊢ applyCoercions χsR (applyCoercions χsL pᵈ)
+          ∶ᶜ applyTys χsR (applyTys χsL A) ⊒ A′
+    p₂-domainᶜ = p₂ᶜ
+
+    left-ready :
+      L · R —↠[ χsL ] WL · applyTerms χsL R
+    left-ready = ·₁-↠ noR-ready L↠WL
+
+    right-ready :
+      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · WR
+    right-ready = ·₂-↠ vWL noWL R↠WR
+
+    ready :
+      ∃[ χs₀ ] (L · R —↠[ χs₀ ] applyTerms χsR WL · WR)
+    ready = χsL ++ χsR , ↠-trans left-ready right-ready
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+        (applyTerms χsR WL · WR —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL₂) ×
+        (ρ′ ≡
+          applyLeftChanges χs (applyLeftChanges χsR
+            (applyLeftChanges χsL ρ))) ×
+        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+          ⊢ N ⊒ N′ [ V′ ]
+            ∶ applyCoercions χs
+                (applyCoercions χsR (applyCoercions χsL q))
+            ⦂ applyTys χs (applyTys χsR (applyTys χsL B)) ⊒ B′
+    tail =
+      sim-beta
+        WLF⊒ƛ
+        (applyTerms-preserves-Value χsR vWL)
+        (applyTerms-preserves-No• χsR noWL)
+        WR⊒V′
+        p₂-domainᶜ
+        vWR
+        noWR
+        vV′
+  in
+  let
+    χsT , N , ΔL′ , ρ′ ,
+      tail-red , ΔT≡ , ρT≡ , N⊒N′[V′] = tail
+
+    source-steps :
+      L · R —↠[ (χsL ++ χsR) ++ χsT ] N
+    source-steps = ↠-trans (↠-trans left-ready right-ready) tail-red
+
+    ΔL′≡ :
+      ΔL′ ≡ applyTyCtxs ((χsL ++ χsR) ++ χsT) ΔL
+    ΔL′≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔL₂≡)
+          (trans
+            (cong (λ Δ → applyTyCtxs χsT (applyTyCtxs χsR Δ))
+              ΔL₁≡)
+            (sym
+              (trans
+                (applyTyCtxs-++ (χsL ++ χsR) χsT ΔL)
+                (cong (applyTyCtxs χsT)
+                  (applyTyCtxs-++ χsL χsR ΔL))))))
+
+    ρ′≡ :
+      ρ′ ≡ applyLeftChanges ((χsL ++ χsR) ++ χsT) ρ
+    ρ′≡ =
+      trans ρT≡
+        (sym
+          (trans
+            (applyLeftChanges-++ (χsL ++ χsR) χsT ρ)
+            (cong (applyLeftChanges χsT)
+              (applyLeftChanges-++ χsL χsR ρ))))
+  in
+  (χsL ++ χsR) ++ χsT ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  _ ,
+  _ ,
+  _ ,
+  source-steps ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒N′[V′]
+
+separated-dgg-beta-right-first :
+  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  Value L →
+  No• L →
+  RuntimeOK R →
+  Value V′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
+separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {N′ = N′} {V′ = V′}
+    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {B = B} {B′ = B′}
+    vL noL okR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  let
+    χsR , WR , ΔL₁ ,
+      vWR , noWR , R↠WR , ΔL₁≡ , ρR-corr ,
+      leftR≡ , rightR≡ , p₁ᶜ , WR⊒V′raw =
+      catchup-lemmaˡ
+        okR
+        vV′
+        R⊒V′
+
+    LF⊒ƛ =
+      advance-left-lambda-narrowing χsR ΔL₁≡ ρR-corr L⊒ƛ
+
+    WR⊒V′ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ ∣ []
+        ⊢ WR ⊒ V′
+          ∶ applyCoercions χsR pᵈ ⦂ applyTys χsR A ⊒ A′
+    WR⊒V′ = WR⊒V′raw
+
+    p₁-domainᶜ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ
+        ⊢ applyCoercions χsR pᵈ ∶ᶜ applyTys χsR A ⊒ A′
+    p₁-domainᶜ = p₁ᶜ
+
+    ready :
+      L · R —↠[ χsR ] applyTerms χsR L · WR
+    ready = ·₂-↠ vL noL R↠WR
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+        (applyTerms χsR L · WR —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL₁) ×
+        (ρ′ ≡ applyLeftChanges χs (applyLeftChanges χsR ρ)) ×
+        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+          ⊢ N ⊒ N′ [ V′ ]
+            ∶ applyCoercions χs (applyCoercions χsR q)
+            ⦂ applyTys χs (applyTys χsR B) ⊒ B′
+    tail =
+      sim-beta
+        LF⊒ƛ
+        (applyTerms-preserves-Value χsR vL)
+        (applyTerms-preserves-No• χsR noL)
+        WR⊒V′
+        p₁-domainᶜ
+        vWR
+        noWR
+        vV′
+  in
+  let
+    χsT , N , ΔL′ , ρ′ ,
+      tail-red , ΔT≡ , ρT≡ , N⊒N′[V′] = tail
+
+    source-steps :
+      L · R —↠[ χsR ++ χsT ] N
+    source-steps = ↠-trans ready tail-red
+
+    ΔL′≡ :
+      ΔL′ ≡ applyTyCtxs (χsR ++ χsT) ΔL
+    ΔL′≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsR χsT ΔL)))
+
+    ρ′≡ :
+      ρ′ ≡ applyLeftChanges (χsR ++ χsT) ρ
+    ρ′≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsR χsT ρ))
+  in
+  χsR ++ χsT ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  _ ,
+  _ ,
+  _ ,
+  source-steps ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒N′[V′]
+
+separated-dgg-beta :
+  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  RuntimeOK (L · R) →
+  Value V′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
+separated-dgg-beta okLR@(ok-no (no•-· noL noR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-left-first
+    (ok-no noL) (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta okLR@(ok-·₁ okL noR)
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-left-first
+    okL (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta okLR@(ok-·₂ vL noL (ok-no noR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-left-first
+    (ok-no noL) (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-• vV noV))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-• vV noV) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-·₁ okR₁ noR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-·₁ okR₁ noR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-·₂ vR₁ noR₁ okR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-·₂ vR₁ noR₁ okR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-ν okR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-ν okR) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-⊕₁ okR₁ noR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-⊕₁ okR₁ noR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-⊕₂ vR₁ noR₁ okR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-⊕₂ vR₁ noR₁ okR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-⟨⟩ okR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-⟨⟩ okR) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+
+------------------------------------------------------------------------
+-- Full separated DGG skeleton
+------------------------------------------------------------------------
+
+dynamicGradualGuarantee :
+  ∀ {ΔL ΔR ρ M M′ N′ A B p χ′} →
+  RuntimeOK M →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  M′ —→[ χ′ ] N′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+  ∃[ C ] ∃[ D ] ∃[ r ]
+    (M —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+    (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+    ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+dynamicGradualGuarantee okM pᶜ (⊒blameᵗ M⊢ qᶜ)
+    (pure-step ())
+dynamicGradualGuarantee okM pᶜ (x⊒xᵗ qᶜ x∋q)
+    (pure-step ())
+dynamicGradualGuarantee okM pᶜ
+    (ƛ⊒ƛᵗ p↦qᶜ N⊒N′)
+    (pure-step ())
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = (ƛ N′) · V′}
+    okLR qᶜ
+    (·⊒·ᵗ p↦q-wholeᶜ L⊒ƛ R⊒V′)
+    (pure-step (β vV′)) =
+  let
+    rec =
+      separated-dgg-beta
+        okLR
+        vV′
+        p↦q-wholeᶜ
+        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
+        L⊒ƛ
+        R⊒V′
+  in
+  let
+    χs , N , ΔL′ , ρ′ , C , D , r ,
+      source-steps , ΔL′≡ , ρ′≡ , N⊒N′[V′] = rec
+  in
+  χs ,
+  N ,
+  ΔL′ ,
+  ΔR ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  refl ,
+  ρ′≡ ,
+  N⊒N′[V′]
+dynamicGradualGuarantee okM qᶜ
+    (·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
+    (pure-step (β-↦ vV vW)) =
+  {! ? !}
+dynamicGradualGuarantee okM qᶜ
+    (·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
+    (pure-step blame-·₁) =
+  {! ? !}
+dynamicGradualGuarantee okM qᶜ
+    (·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
+    (pure-step (blame-·₂ vV)) =
+  {! ? !}
+dynamicGradualGuarantee okM qᶜ
+    (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₁ L′→N′ shiftR′) =
+  let
+    rec = dynamicGradualGuarantee {! ? !} p↦q-wholeᶜ L⊒L′ L′→N′
+  in
+  {! ? !}
+dynamicGradualGuarantee okM qᶜ
+    (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₂ vL′ shiftL′ R′→N′) =
+  let
+    rec =
+      dynamicGradualGuarantee
+        {! ? !}
+        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
+        R⊒R′
+        R′→N′
+  in
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′)
+    (pure-step ())
+dynamicGradualGuarantee okM pᶜ (κ⊒κᵗ κ qᶜ)
+    (pure-step ())
+dynamicGradualGuarantee okM pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (pure-step δ-⊕) =
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (pure-step blame-⊕₁) =
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (pure-step (blame-⊕₂ vV)) =
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (ξ-⊕₁ M′→P′ shiftN′) =
+  let
+    rec = dynamicGradualGuarantee {! ? !} pᶜ M⊒M′ M′→P′
+  in
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (ξ-⊕₂ vM′ shiftM′ N′→P′) =
+  let
+    rec = dynamicGradualGuarantee {! ? !} pᶜ N⊒N′ N′→P′
+  in
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (⊒cast+ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    M′⟨s⟩→N′ =
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    M′⟨s⟩→N′ =
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
+  let
+    rec = dynamicGradualGuarantee (runtime-⟨⟩ okM) qᶜ M⊒M′ M′→N′
+  in
+  {! ? !}
+dynamicGradualGuarantee okM pᶜ
+    (cast-⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
+  {! ? !}

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -1,0 +1,191 @@
+# Separated Stores DGG Checklist
+
+## Working Policy
+
+- Prioritize getting back to the DGG beta case and the `sim-beta` lemma.
+- Work top-down where that clarifies the target proof shape.
+- Let `catchup-lemmaˡ` remain unfinished while the DGG caller and simulation
+  lemma surface are being shaped.
+- Avoid new redundant postulates; use existing proof holes in modules that
+  already allow unsolved metas while the proof is under construction.
+
+## Progress Snapshot
+
+- [x] Add explicit seal correspondence with `leftStore` and `rightStore`.
+- [x] Add side-specific seal correspondence shifts.
+- [x] Add the initial separated term narrowing relation.
+- [x] Make separated term narrowing endpoint typing witnesses explicit
+  constructor arguments.
+- [x] Replace the separated endpoint-typing record with product-shaped
+  evidence and pattern match on pairs at term-narrowing use sites.
+- [x] Add left-side catchup store-change operations.
+- [x] State `catchup-lemmaˡ` with the target term unchanged.
+- [x] Add the new separated-store modules to `All.agda`.
+- [x] Add the separated DGG beta proof surface to `All.agda`.
+
+## Track A. Back To DGG Beta
+
+- [x] Add a separated DGG theorem skeleton focused on application beta.
+- [x] Add a full separated `dynamicGradualGuarantee` skeleton over the current
+  separated term-narrowing relation.
+- [x] Add a separated `sim-beta` statement.
+- [x] Adapt the DGG beta case to call `catchup-lemmaˡ` sequentially.
+- [x] Split the value-left beta caller case on `RuntimeOK R`.
+- [x] Add an argument-first beta caller helper for runtime-active arguments.
+- [x] Preserve the domain/argument relation across catchup.
+- [x] Compose the `ready` and `tail` reductions in separated stores.
+- [x] Identify the exact separated constructors needed by `sim-beta`.
+
+Current named obligations in `proof.DynamicGradualGuaranteeSeparated`:
+
+- `catchup-lemmaˡ`, `advance-left-term-narrowing`, and
+  `advance-left-lambda-narrowing` now preserve source-side changes with
+  `applyCoercions` and `applyTys`, while the target term/type stay fixed.
+- The left-first and argument-first beta helpers now maintain the domain
+  relation through catchup. Their `WR⊒V′` premises are obtained by rewriting
+  `applyCoercions` through duality, so the argument reaches `sim-beta` at the
+  dual of the caught-up function domain.
+- `left-ready` now uses `·₁-↠` directly in the left-first helper
+  `separated-dgg-beta-left-first`.
+- `separated-dgg-beta` now cases on `RuntimeOK (L · R)`: the `ok-no` and
+  `ok-·₁` cases provide `No• R` directly and call the left-first helper. The
+  `ok-·₂` value-left case now cases again on `RuntimeOK R`; its `ok-no`
+  subcase also calls the left-first helper, while the remaining subcases are
+  routed through `separated-dgg-beta-right-first`.
+- `separated-dgg-beta-left-first` now takes the exposed `RuntimeOK L` and
+  `RuntimeOK R` facts directly. This removes the local runtime projection
+  helpers from the beta caller and keeps both sequential catchups tied to the
+  `RuntimeOK` cases chosen by `separated-dgg-beta`.
+- `separated-dgg-beta-right-first` handles the value-left/runtime-argument
+  path by catching up `R` first, advancing the already-value function relation
+  across those left-side changes, and calling `sim-beta` with the resulting
+  premises.
+- `dynamicGradualGuarantee` in `proof.DynamicGradualGuaranteeSeparated` now
+  gives the full theorem-shaped caller for the separated-store relation. Its
+  result tracks a source-side sequence `χs`, the target one-step store change
+  `χ′`, the advanced left namespace `ΔL′`, the advanced right namespace
+  `ΔR′`, and the combined seal correspondence
+  `applyRightChange χ′ (applyLeftChanges χs ρ)`.
+- The pure application beta case of this full skeleton is wired to
+  `separated-dgg-beta`. This is now the top-down caller that checks whether
+  the `sim-beta` statement is usable by the full theorem.
+- The application and primitive congruence cases already invoke the recursive
+  `dynamicGradualGuarantee` call before their reconstruction holes, preserving
+  the induction-hypothesis opportunity in the skeleton.
+- The two target-cast constructors currently remain constructor-level holes in
+  the full skeleton. Splitting their target reductions exhaustively requires
+  first inverting the shape of the target cast coercion, because Agda cannot
+  decide redexes like `β-id` under an unknown `- s`.
+- `applyLeftChanges-++` is now available from `proof.CatchupSeparated`.
+  Both beta caller helpers use it with `applyTyCtxs-++` and `↠-trans` to
+  return a single composed source reduction after the call to `sim-beta`.
+- `sim-beta-lambda` proves the direct lambda beta simulation shape, modulo the
+  separated substitution lemma.
+- `sim-beta` now has explicit coverage for the direct lambda case
+  (`ƛ⊒ƛᵗ`) and the two remaining source-cast cases (`cast+⊒ᵗ`,
+  `cast-⊒ᵗ`). Agda accepts this as exhaustive for the current separated
+  relation.
+- The source-cast cases now expose the recursive `sim-beta` call directly in
+  each clause. In the `t = c ↦ d` branches, the argument cast is caught up
+  first, the inner function relation is advanced across those left-side
+  changes, and the recursive call uses the resulting value argument evidence.
+  The argument-cast relation is now built at the call site from two explicit
+  evidence holes. Those holes sit beside the `cast-fun c⊢ d⊢` typing
+  information and the existing argument relation instead of being hidden behind
+  reusable endpoint-projection lemmas.
+- The final source-cast wrappers are now structurally present: each branch
+  destructs the recursive `sim-beta` result, lifts the recursive tail reduction
+  through the codomain cast, composes it with the `β-↦` head step and the
+  argument-ready reduction, and returns the composed reduction.
+- The source-cast branches still have two final codomain-correlation holes,
+  one in each outer result-cast wrapper. The old reusable endpoint-projection
+  helpers have been removed; the remaining holes now sit directly at the cast
+  constructors where the relevant term/coercion typing information is in
+  scope.
+- `lambda-target-function-narrowing` now proves the direct `ƛ⊒ƛᵗ` case. Its
+  two remaining source-cast cases invoke the recursive inversion immediately
+  before the reconstruction hole, keeping the intended structural recursion
+  visible.
+- `advance-left-term-narrowing` now proves the zero-change base case by
+  returning the existing relation directly. Its only remaining hole is the
+  non-empty store-change case.
+- `advance-left-lambda-narrowing` now proves the zero-change base case by
+  returning the existing function relation directly. Its only remaining hole
+  is the non-empty store-change case.
+- `sim-beta` is temporarily marked `TERMINATING` while
+  `lambda-target-function-narrowing` and `advance-left-lambda-narrowing` are
+  still top-down holes. The recursive calls are on the intended inner function
+  relation, but Agda cannot see that structural decrease through those
+  placeholder surfaces yet.
+- The source-cast cases are split on the source cast coercion `t`; the
+  recursive `sim-beta` call appears only in the `t = c ↦ d` branch. The other
+  coercion forms are now visible as separate cases to be ruled out or handled
+  by their own typing/canonical-form facts.
+- In each `t = c ↦ d` branch, the source `β-↦` head reduction is now explicit:
+  `(V ⟨ - (c ↦ d) ⟩) · WR` steps to
+  `(V · (WR ⟨ - c ⟩)) ⟨ - d ⟩`, and `(V ⟨ c ↦ d ⟩) · WR`
+  steps to `(V · (WR ⟨ c ⟩)) ⟨ d ⟩`.
+- The same branches now also have the argument-ready reductions lifted through
+  the result cast with `cast-dual-↠` and `cast-↠`, respectively.
+- Several non-function source-cast branches are now discharged by impossible
+  `Value` patterns: `id`, sequencing, cast+ `gen`, and cast- `？`,
+  `unseal`, and `inst`.
+- `TermNarrowingSeparated` now has source/target typing extractors, so
+  separated narrowing proofs can feed canonical-form lemmas.
+- The endpoint typing witnesses in `TermNarrowingSeparated` are now explicit
+  product-shaped constructor arguments. The `sim-beta` and separated DGG
+  clauses pattern match through the pair and then expose the top typing
+  constructor, such as `⊢⟨⟩` for source casts and `⊢ƛ` for target lambdas.
+- The cast+ and cast- `∀` source-cast branches now use `canonical-⇒` plus
+  impossible `FunView` equalities to discharge the function-type contradiction.
+- The same canonical-form pattern now discharges cast+ `unseal` and `inst`,
+  plus cast- tag, `seal`, and `gen` source-cast branches.
+- The cast+ tag/untag source-cast branches are now split by the underlying
+  type shape. The tag case is impossible by value evidence after dualizing to
+  an untag; the untag case dualizes to an inert tag and is discharged by
+  `canonical-⇒`.
+
+## Track B. Term Narrowing Surface Needed By `sim-beta`
+
+- [x] Add separated cast-left and cast-right constructors.
+- [ ] Add separated `ν` and polymorphic constructors needed by catchup results.
+- [ ] Add separated substitution narrowing for the beta body.
+- [x] Remove the lightweight coercion-correlation records; separated
+  constructors now carry explicit endpoint products.
+
+The current full separated DGG skeleton ranges over the current
+`TermNarrowingSeparated` relation. That relation still lacks the shared-store
+constructors for `⊒Λᵗ`, `⊒⟨ν⟩ᵗ`, `α⊒αᵗ`, `⊒αᵗ`, `ν⊒νᵗ`, `⊒νᵗ`, and
+`ν⊒ᵗ`, so the skeleton is full for the current separated relation but not yet
+full-language complete.
+
+The separated cast constructors currently carry explicit endpoint-product
+evidence for the endpoint coercions. They intentionally leave the old
+shared-store composition premises to the future two-sided coercion relation.
+
+The separated substitution lemma is now stated as
+`term-substitution-narrowingᶜ`; its proof is still a hole. The direct lambda
+case is factored as `sim-beta-lambda` and already performs the one-step
+`β` reduction.
+
+## Track C. Catchup Proof
+
+- [x] Add right-side store-change operations.
+- [ ] Add a right catchup statement, if needed.
+- [ ] Port catchup helper lemmas to separated stores.
+- [ ] Prove `catchup-lemmaˡ`.
+- [ ] Prove right catchup if needed by DGG.
+
+Current catchup progress:
+
+- `catchup-lemmaˡ` now splits first on `RuntimeOK`, exposing the recursive
+  proof shape before introducing any named obligations. The remaining cases are
+  the eight runtime constructors: `ok-no`, `ok-•`, `ok-·₁`, `ok-·₂`, `ok-ν`,
+  `ok-⊕₁`, `ok-⊕₂`, and `ok-⟨⟩`.
+
+## Track D. Migration And Cleanup
+
+- [ ] Port the DGG theorem from shared `StoreNrw` to separated stores.
+- [ ] Remove old shared-store-only beta scaffolding once the separated proof
+  supersedes it.
+- [ ] Decide whether old `StoreNrw` remains internal support or is deleted.

--- a/GTSF/proof/SimBetaSeparated.agda
+++ b/GTSF/proof/SimBetaSeparated.agda
@@ -1,0 +1,1236 @@
+--{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.SimBetaSeparated where
+
+-- File Charter:
+--   * Isolates the separated-store function-application simulation proof.
+--   * Keeps the target term/store unchanged while left-side catchup advances
+--     the source term through `SealCorr`.
+--   * Provides `sim-beta` and the left-advancement helpers used by the
+--     separated DGG beta caller.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_; _++_; map)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import NarrowWiden using
+  ( cross
+  ; dualⁿ
+  ; dualʷ
+  ; Widening
+  ; _？︔_
+  ; _︔seal_
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.Catchup using (runtime-⇑ᵗᵐ)
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyLeftChanges-++
+  ; catchup-lemmaˡ
+  )
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; coercion-wfᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  ; minus-flips-typingᵐ
+  )
+open import proof.NarrowWidenProperties using
+  ( dualⁿ-flips-typingᵐ
+  ; dualʷ-flips-typingᵐ
+  ; narrowing-determinedᵐ
+  )
+open import proof.NuProgress using (canonical-⇒; fv-ƛ; fv-↦)
+open import proof.ReductionProperties using
+  ( applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyCoercions
+  ; applyCoercions-++
+  ; applyCoercions-dual
+  ; applyTys-++
+  ; applyTyCtxs-++
+  ; cast-↠
+  ; cast-dual-↠
+  ; ↠-trans
+  ; ·₁-↠
+  ; ·₂-↠
+  )
+
+applyTerm-preserves-RuntimeOK :
+  ∀ χ {M} →
+  RuntimeOK M →
+  RuntimeOK (applyTerm χ M)
+applyTerm-preserves-RuntimeOK keep okM = okM
+applyTerm-preserves-RuntimeOK (bind A) okM = runtime-⇑ᵗᵐ okM
+
+applyTerms-preserves-RuntimeOK :
+  ∀ χs {M} →
+  RuntimeOK M →
+  RuntimeOK (applyTerms χs M)
+applyTerms-preserves-RuntimeOK [] okM = okM
+applyTerms-preserves-RuntimeOK (χ ∷ χs) okM =
+  applyTerms-preserves-RuntimeOK χs (applyTerm-preserves-RuntimeOK χ okM)
+
+applyTys-⇒ :
+  ∀ χs A B →
+  applyTys χs (A ⇒ B) ≡ applyTys χs A ⇒ applyTys χs B
+applyTys-⇒ [] A B = refl
+applyTys-⇒ (keep ∷ χs) A B = applyTys-⇒ χs A B
+applyTys-⇒ (bind C ∷ χs) A B = applyTys-⇒ χs (⇑ᵗ A) (⇑ᵗ B)
+
+applyCoercions-↦ :
+  ∀ χs p q →
+  applyCoercions χs (p ↦ q) ≡ applyCoercions χs p ↦ applyCoercions χs q
+applyCoercions-↦ [] p q = refl
+applyCoercions-↦ (keep ∷ χs) p q = applyCoercions-↦ χs p q
+applyCoercions-↦ (bind A ∷ χs) p q =
+  applyCoercions-↦ χs (⇑ᶜ p) (⇑ᶜ q)
+
+applyCoercions-dual-applyCoercions :
+  ∀ χs χs′ p →
+  applyCoercions χs′ (applyCoercions χs (- p)) ≡
+    - applyCoercions χs′ (applyCoercions χs p)
+applyCoercions-dual-applyCoercions χs χs′ p =
+  trans
+    (cong (applyCoercions χs′) (applyCoercions-dual χs p))
+    (applyCoercions-dual χs′ (applyCoercions χs p))
+
+------------------------------------------------------------------------
+-- Left-side advancement surfaces
+------------------------------------------------------------------------
+
+applyLeftCtxEntry : StoreChanges → CtxCorrEntry → CtxCorrEntry
+applyLeftCtxEntry χs (ctx-entry A B p) =
+  ctx-entry (applyTys χs A) B (applyCoercions χs p)
+
+applyLeftCtx : StoreChanges → CtxCorr → CtxCorr
+applyLeftCtx χs γ = map (applyLeftCtxEntry χs) γ
+
+no•-cast-inv : ∀ {M c} → No• (M ⟨ c ⟩) → No• M
+no•-cast-inv (no•-⟨⟩ noM) = noM
+
+⟨⟩-term-injective :
+  ∀ {M N : Term} {c d : Coercion} →
+  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
+  M ≡ N
+⟨⟩-term-injective refl = refl
+
+⟨⟩-coercion-injective :
+  ∀ {M N : Term} {c d : Coercion} →
+  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
+  c ≡ d
+⟨⟩-coercion-injective refl = refl
+
+widen-fun-domainᵐ :
+  ∀ {μ Δ Σ c d A A′ B B′} →
+  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ A ⇒ B ⊑ A′ ⇒ B′ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A′ ⊒ A
+widen-fun-domainᵐ (cast-fun c⊢ _ , cross (cⁿ ↦ⁿʷ _)) = c⊢ , cⁿ
+
+narrow-fun-codomainᵐ :
+  ∀ {μ Δ Σ c d A A′ B B′} →
+  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ A ⇒ B ⊒ A′ ⇒ B′ →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ B ⊒ B′
+narrow-fun-codomainᵐ (cast-fun _ d⊢ , cross (_ ↦ⁿʷ dⁿ)) = d⊢ , dⁿ
+
+separated-fun-codomain :
+  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ A ⇒ B ⊒ A′ ⇒ B′ →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ q ∶ B ⊒ B′
+separated-fun-codomain
+    (stores , _ , _ , wf⇒ _ hB , wf⇒ _ hB′ ,
+      (cast-fun _ q⊢L , cross (_ ↦ⁿʷ qⁿL)) ,
+      (cast-fun _ q⊢R , cross (_ ↦ⁿʷ qⁿR))) =
+  stores ,
+  proj₁ (coercion-src-tgtᵐ q⊢L) ,
+  proj₂ (coercion-src-tgtᵐ q⊢L) ,
+  hB ,
+  hB′ ,
+  (q⊢L , qⁿL) ,
+  (q⊢R , qⁿR)
+
+↦-codomain : Coercion → Coercion
+↦-codomain (id A) = id A
+↦-codomain (c ︔ d) = c ︔ d
+↦-codomain (c ↦ d) = d
+↦-codomain (`∀ c) = `∀ c
+↦-codomain (G !) = G !
+↦-codomain (G ？) = G ？
+↦-codomain (seal A α) = seal A α
+↦-codomain (unseal α A) = unseal α A
+↦-codomain (gen A c) = gen A c
+↦-codomain (inst B c) = inst B c
+
+↦-right-injective :
+  ∀ {c c′ d d′ : Coercion} →
+  c ↦ d ≡ c′ ↦ d′ →
+  d ≡ d′
+↦-right-injective eq = cong ↦-codomain eq
+
+separated-left-coercionᵐ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ ΔL ∣ leftStore ρ ⊢ c ∶ A ⊒ B
+separated-left-coercionᵐ (_ , _ , _ , _ , _ , c⊒L , _) = c⊒L
+
+separated-right-coercionᵐ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ ΔR ∣ rightStore ρ ⊢ c ∶ A ⊒ B
+separated-right-coercionᵐ (_ , _ , _ , _ , _ , _ , c⊒R) = c⊒R
+
+postulate
+  left-change-term-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ γ M M′ p A B} →
+    ΔL′ ≡ applyTyCtxs χs ΔL →
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+    ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+    ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ applyLeftCtx χs γ
+      ⊢ applyTerms χs M ⊒ M′ ∶ applyCoercions χs p
+        ⦂ applyTys χs A ⊒ B
+
+  left-change-coercion-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ} →
+    ΔL′ ≡ applyTyCtxs χs ΔL →
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+    μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+    μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+      ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ B
+
+  left-change-source-coercion-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ} →
+    ΔL′ ≡ applyTyCtxs χs ΔL →
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+    μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+    μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+      ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ applyTys χs B
+
+  left-change-source-coercion-narrowing-dual :
+    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ}
+      (ΔL′≡ : ΔL′ ≡ applyTyCtxs χs ΔL)
+      (ρ′-corr : StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ))
+      (c⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B) →
+    narrowing-dual
+      (left-change-source-coercion-narrowing χs ΔL′≡ ρ′-corr c⊒)
+    ≡ applyCoercions χs (narrowing-dual c⊒)
+
+  dualʷ-raw-determined :
+    ∀ η {c} (cʷ₁ cʷ₂ : Widening c) →
+    proj₁ (dualʷ η cʷ₁) ≡ proj₁ (dualʷ η cʷ₂)
+
+  dualʷ-involutive-raw :
+    ∀ {c} (cʷ : Widening c) →
+    proj₁ (dualⁿ normalᵃ (proj₂ (dualʷ normalᵃ cʷ))) ≡ c
+
+advance-left-term-narrowing :
+  ∀ χs {ΔL ΔL′ ΔR ρ M M′ p A B} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+    ⊢ applyTerms χs M ⊒ M′ ∶ applyCoercions χs p
+      ⦂ applyTys χs A ⊒ B
+advance-left-term-narrowing χs ΔL′≡ ρ′-corr M⊒M′ =
+  left-change-term-narrowing χs ΔL′≡ ρ′-corr M⊒M′
+
+advance-left-lambda-narrowing :
+  ∀ χs {ΔL ΔL′ ΔR ρ W N′ p q A A′ B B′} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+    ⊢ applyTerms χs W ⊒ ƛ N′
+      ∶ applyCoercions χs p ↦ applyCoercions χs q
+      ⦂ applyTys χs A ⇒ applyTys χs B ⊒ A′ ⇒ B′
+advance-left-lambda-narrowing χs {p = p} {q = q} {A = A} {B = B}
+    ΔL′≡ ρ′-corr W⊒ƛ =
+  subst
+    (λ c →
+      _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ c
+        ⦂ applyTys χs A ⇒ applyTys χs B ⊒ _)
+    (applyCoercions-↦ χs p q)
+    (subst
+      (λ C →
+        _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ applyCoercions χs (p ↦ q)
+          ⦂ C ⊒ _)
+      (applyTys-⇒ χs A B)
+      (left-change-term-narrowing χs ΔL′≡ ρ′-corr W⊒ƛ))
+
+------------------------------------------------------------------------
+-- Function application simulation
+------------------------------------------------------------------------
+
+postulate
+  term-substitution-narrowingᶜ :
+    ∀ {ΔL ΔR ρ N N′ V V′ p q A A′ B B′} →
+    ΔL ∣ ΔR ∣ ρ ∣ ctx-entry A A′ p ∷ []
+      ⊢ N ⊒ N′ ∶ q ⦂ B ⊒ B′ →
+    ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ V ⊒ V′ ∶ p ⦂ A ⊒ A′ →
+    ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ N [ V ] ⊒ N′ [ V′ ] ∶ q ⦂ B ⊒ B′
+
+sim-beta-cast-tail :
+  ∀ {ΔL ΔR ρ M₀ M₁ NL V WRA VR qᵢ qₒ d Bₒ BL BR D₁ D₂ μq μd}
+    {χsA ΔLA} →
+  (castN : StoreChanges → Term → Term) →
+  M₀ —↠[ keep ∷ χsA ] M₁ →
+  (∀ {χsT N} →
+    applyTerms χsA V · WRA —↠[ χsT ] N →
+    M₁ —↠[ χsT ] castN χsT N) →
+  μq ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR →
+  μd ∣ ΔL ∣ ΔR ∣ ρ ⊢ d ∶ D₁ ⊒ D₂ →
+  ΔLA ≡ applyTyCtxs χsA ΔL →
+  StoreCorr ΔLA ΔR (applyLeftChanges χsA ρ) →
+  (∀ {χsT N ΔLT ρT} →
+    ρT ≡ applyLeftChanges χsT (applyLeftChanges χsA ρ) →
+    ΔLT ∣ ΔR ∣ ρT ∣ []
+      ⊢ N ⊒ NL [ VR ] ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+        ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR →
+    μq ∣ ΔLT ∣ ΔR ∣ ρT
+      ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+        ∶ applyTys χsT (applyTys χsA Bₒ) ⊒ BR →
+    μd ∣ ΔLT ∣ ΔR ∣ ρT
+      ⊢ applyCoercions χsT (applyCoercions χsA d)
+        ∶ applyTys χsT (applyTys χsA D₁)
+        ⊒ applyTys χsT (applyTys χsA D₂) →
+    ΔLT ∣ ΔR ∣ ρT ∣ []
+      ⊢ castN χsT N ⊒ NL [ VR ]
+        ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+        ⦂ applyTys χsT (applyTys χsA Bₒ) ⊒ BR) →
+  (∃[ χsT ] ∃[ N ] ∃[ ΔLT ] ∃[ ρT ]
+    (applyTerms χsA V · WRA —↠[ χsT ] N) ×
+    (ΔLT ≡ applyTyCtxs χsT ΔLA) ×
+    (ρT ≡ applyLeftChanges χsT (applyLeftChanges χsA ρ)) ×
+    ΔLT ∣ ΔR ∣ ρT ∣ []
+      ⊢ N ⊒ NL [ VR ] ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+        ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR) →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+    (M₀ —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ NL [ VR ] ∶ applyCoercions χs qₒ
+        ⦂ applyTys χs Bₒ ⊒ BR
+sim-beta-cast-tail {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {M₀ = M₀}
+    {NL = NL} {VR = VR} {qₒ = qₒ} {d = d} {Bₒ = Bₒ}
+    {BR = BR} {D₁ = D₁} {D₂ = D₂} {μq = μq} {μd = μd}
+    {χsA = χsA} {ΔLA = ΔLA}
+    castN prefix-red tail-cast qₒ⊒ d⊒ ΔLA≡ ρA-corr wrap rec =
+  let
+    χsT , N , ΔLT , ρT ,
+      tail-red , ΔT≡ , ρT≡ , N⊒NL[VR] = rec
+
+    μN , nᶜ = typed-term-narrowing-coercion N⊒NL[VR]
+
+    ρT-corr :
+      StoreCorr ΔLT ΔR
+        (applyLeftChanges χsT (applyLeftChanges χsA ρ))
+    ρT-corr =
+      subst (StoreCorr ΔLT ΔR)
+        ρT≡
+        (narrowing-store-corrᶜ {μ = μN} nᶜ)
+
+    qₒ⊒A :
+      μq ∣ ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA qₒ ∶ applyTys χsA Bₒ ⊒ BR
+    qₒ⊒A =
+      left-change-coercion-narrowing χsA {μ = μq} ΔLA≡ ρA-corr qₒ⊒
+
+    qₒ⊒T :
+      μq ∣ ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+          ∶ applyTys χsT (applyTys χsA Bₒ) ⊒ BR
+    qₒ⊒T =
+      left-change-coercion-narrowing χsT {μ = μq} ΔT≡ ρT-corr qₒ⊒A
+
+    qₒ⊒Tρ :
+      μq ∣ ΔLT ∣ ΔR ∣ ρT
+        ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+          ∶ applyTys χsT (applyTys χsA Bₒ) ⊒ BR
+    qₒ⊒Tρ =
+      subst
+        (λ ρ₀ →
+          μq ∣ ΔLT ∣ ΔR ∣ ρ₀
+            ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+              ∶ applyTys χsT (applyTys χsA Bₒ) ⊒ BR)
+        (sym ρT≡)
+        qₒ⊒T
+
+    d⊒A :
+      μd ∣ ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA d
+          ∶ applyTys χsA D₁ ⊒ applyTys χsA D₂
+    d⊒A =
+      left-change-source-coercion-narrowing χsA {μ = μd}
+        ΔLA≡ ρA-corr d⊒
+
+    d⊒T :
+      μd ∣ ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA d)
+          ∶ applyTys χsT (applyTys χsA D₁)
+          ⊒ applyTys χsT (applyTys χsA D₂)
+    d⊒T =
+      left-change-source-coercion-narrowing χsT {μ = μd}
+        ΔT≡ ρT-corr d⊒A
+
+    d⊒Tρ :
+      μd ∣ ΔLT ∣ ΔR ∣ ρT
+        ⊢ applyCoercions χsT (applyCoercions χsA d)
+          ∶ applyTys χsT (applyTys χsA D₁)
+          ⊒ applyTys χsT (applyTys χsA D₂)
+    d⊒Tρ =
+      subst
+        (λ ρ₀ →
+          μd ∣ ΔLT ∣ ΔR ∣ ρ₀
+            ⊢ applyCoercions χsT (applyCoercions χsA d)
+              ∶ applyTys χsT (applyTys χsA D₁)
+              ⊒ applyTys χsT (applyTys χsA D₂))
+        (sym ρT≡)
+        d⊒T
+
+    source-steps :
+      M₀ —↠[ (keep ∷ χsA) ++ χsT ] castN χsT N
+    source-steps = ↠-trans prefix-red (tail-cast tail-red)
+
+    ΔLT≡ :
+      ΔLT ≡ applyTyCtxs ((keep ∷ χsA) ++ χsT) ΔL
+    ΔLT≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔLA≡)
+          (sym (applyTyCtxs-++ χsA χsT ΔL)))
+
+    ρT-total≡ :
+      ρT ≡ applyLeftChanges ((keep ∷ χsA) ++ χsT) ρ
+    ρT-total≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
+
+    N-cast⊒ =
+      wrap ρT≡ N⊒NL[VR] qₒ⊒Tρ d⊒Tρ
+
+    N-cast⊒total :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ castN χsT N ⊒ NL [ VR ]
+          ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+          ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR
+    N-cast⊒total =
+      subst
+        (λ p →
+          ΔLT ∣ ΔR ∣ ρT ∣ []
+            ⊢ castN χsT N ⊒ NL [ VR ] ∶ p
+              ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR)
+        (sym (applyCoercions-++ χsA χsT qₒ))
+        (subst
+          (λ A₀ →
+            ΔLT ∣ ΔR ∣ ρT ∣ []
+              ⊢ castN χsT N ⊒ NL [ VR ]
+                ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+                ⦂ A₀ ⊒ BR)
+          (sym (applyTys-++ χsA χsT Bₒ))
+          N-cast⊒)
+  in
+  (keep ∷ χsA) ++ χsT ,
+  castN χsT N ,
+  ΔLT ,
+  ρT ,
+  source-steps ,
+  ΔLT≡ ,
+  ρT-total≡ ,
+  N-cast⊒total
+
+sim-beta-cast+-result :
+  ∀ {ΔL ΔR ρ ΔLA ΔLT ρT NL VR N qᵢ qₒ dₛ d Bₒ BL BR μq μd}
+    {χsA χsT} →
+  ΔL ∣ ΔR ∣ ρ ⊢ qᵢ ∶ᶜ BL ⊒ BR →
+  μq ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR →
+  (dₛ⊒ : μd ∣ ΔL ∣ ΔR ∣ ρ ⊢ dₛ ∶ Bₒ ⊒ BL) →
+  narrowing-dual dₛ⊒ ≡ d →
+  ΔLA ≡ applyTyCtxs χsA ΔL →
+  StoreCorr ΔLA ΔR (applyLeftChanges χsA ρ) →
+  ΔLT ≡ applyTyCtxs χsT ΔLA →
+  ρT ≡ applyLeftChanges χsT (applyLeftChanges χsA ρ) →
+  ΔLT ∣ ΔR ∣ ρT ∣ []
+    ⊢ N ⊒ NL [ VR ] ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+      ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR →
+  ΔLT ∣ ΔR ∣ ρT ∣ []
+    ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+      ⊒ NL [ VR ] ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+      ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR
+sim-beta-cast+-result {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {ΔLA = ΔLA} {ΔLT = ΔLT} {ρT = ρT} {NL = NL}
+    {VR = VR} {N = N} {qᵢ = qᵢ} {qₒ = qₒ} {dₛ = dₛ}
+    {d = d} {Bₒ = Bₒ} {BL = BL} {BR = BR} {μq = μq}
+    {μd = μd} {χsA = χsA} {χsT = χsT}
+    qᵢᶜ qₒ⊒ dₛ⊒ dₛ-dual-eq ΔLA≡ ρA-corr ΔT≡ ρT≡
+    N⊒NL[VR] =
+  let
+    μN , nᶜ = typed-term-narrowing-coercion N⊒NL[VR]
+
+    ρT-corr :
+      StoreCorr ΔLT ΔR
+        (applyLeftChanges χsT (applyLeftChanges χsA ρ))
+    ρT-corr =
+      subst (StoreCorr ΔLT ΔR)
+        ρT≡
+        (narrowing-store-corrᶜ {μ = μN} nᶜ)
+
+    N⊒NL[VR]T :
+      ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+        ⊢ N ⊒ NL [ VR ]
+          ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+          ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR
+    N⊒NL[VR]T =
+      subst
+        (λ ρ₀ →
+          ΔLT ∣ ΔR ∣ ρ₀ ∣ []
+            ⊢ N ⊒ NL [ VR ]
+              ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+              ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR)
+        ρT≡
+        N⊒NL[VR]
+
+    qᵢᶜA :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA qᵢ ∶ᶜ applyTys χsA BL ⊒ BR
+    qᵢᶜA =
+      left-change-coercion-narrowing χsA {μ = tag-or-idᵈ}
+        ΔLA≡ ρA-corr qᵢᶜ
+
+    qᵢᶜT :
+      ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA qᵢ)
+          ∶ᶜ applyTys χsT (applyTys χsA BL) ⊒ BR
+    qᵢᶜT =
+      left-change-coercion-narrowing χsT {μ = tag-or-idᵈ}
+        ΔT≡ ρT-corr qᵢᶜA
+
+    qₒ⊒A :
+      μq ∣ ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA qₒ ∶ applyTys χsA Bₒ ⊒ BR
+    qₒ⊒A =
+      left-change-coercion-narrowing χsA {μ = μq}
+        ΔLA≡ ρA-corr qₒ⊒
+
+    qₒ⊒T :
+      μq ∣ ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+          ∶ applyTys χsT (applyTys χsA Bₒ) ⊒ BR
+    qₒ⊒T =
+      left-change-coercion-narrowing χsT {μ = μq}
+        ΔT≡ ρT-corr qₒ⊒A
+
+    dₛ⊒A :
+      μd ∣ ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA dₛ
+          ∶ applyTys χsA Bₒ ⊒ applyTys χsA BL
+    dₛ⊒A =
+      left-change-source-coercion-narrowing χsA {μ = μd}
+        ΔLA≡ ρA-corr dₛ⊒
+
+    dₛ⊒T :
+      μd ∣ ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA dₛ)
+          ∶ applyTys χsT (applyTys χsA Bₒ)
+          ⊒ applyTys χsT (applyTys χsA BL)
+    dₛ⊒T =
+      left-change-source-coercion-narrowing χsT {μ = μd}
+        ΔT≡ ρT-corr dₛ⊒A
+
+    dₛ-dual-A :
+      narrowing-dual dₛ⊒A ≡ applyCoercions χsA (narrowing-dual dₛ⊒)
+    dₛ-dual-A =
+      left-change-source-coercion-narrowing-dual
+        χsA ΔLA≡ ρA-corr dₛ⊒
+
+    dₛ-dual-T :
+      narrowing-dual dₛ⊒T ≡ applyCoercions χsT (applyCoercions χsA d)
+    dₛ-dual-T =
+      trans
+        (left-change-source-coercion-narrowing-dual
+          χsT ΔT≡ ρT-corr dₛ⊒A)
+        (trans
+          (cong (applyCoercions χsT) dₛ-dual-A)
+          (cong
+            (λ d₀ → applyCoercions χsT (applyCoercions χsA d₀))
+            dₛ-dual-eq))
+
+    N-cast⊒T :
+      ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+          ⊒ NL [ VR ] ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+          ⦂ applyTys χsT (applyTys χsA Bₒ) ⊒ BR
+    N-cast⊒T =
+      subst
+        (λ d₀ →
+          ΔLT ∣ ΔR
+            ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+            ⊢ N ⟨ d₀ ⟩ ⊒ NL [ VR ]
+              ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+              ⦂ applyTys χsT (applyTys χsA Bₒ) ⊒ BR)
+        dₛ-dual-T
+        (cast+⊒ᵗ
+          {ΔL = ΔLT}
+          {ΔR = ΔR}
+          {ρ = applyLeftChanges χsT (applyLeftChanges χsA ρ)}
+          {γ = []}
+          {M = N}
+          {M′ = NL [ VR ]}
+          {q = applyCoercions χsT (applyCoercions χsA qᵢ)}
+          {r = applyCoercions χsT (applyCoercions χsA qₒ)}
+          {s = applyCoercions χsT (applyCoercions χsA dₛ)}
+          {A = applyTys χsT (applyTys χsA Bₒ)}
+          {B = BR}
+          {C = applyTys χsT (applyTys χsA BL)}
+          {μ = μq}
+          {η = μd}
+          qᵢᶜT
+          qₒ⊒T
+          dₛ⊒T
+          N⊒NL[VR]T)
+  in
+  subst
+    (λ ρ₀ →
+      ΔLT ∣ ΔR ∣ ρ₀ ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+          ⊒ NL [ VR ]
+          ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+          ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR)
+    (sym ρT≡)
+    (subst
+      (λ p →
+        ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+          ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+            ⊒ NL [ VR ] ∶ p
+            ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR)
+      (sym (applyCoercions-++ χsA χsT qₒ))
+      (subst
+        (λ B →
+          ΔLT ∣ ΔR
+            ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+            ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+              ⊒ NL [ VR ]
+              ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+              ⦂ B ⊒ BR)
+        (sym (applyTys-++ χsA χsT Bₒ))
+        N-cast⊒T))
+
+term-function-domain-dual :
+  ∀ {ΔL ΔR ρ WL NL p q A A′ B B′} →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WL ⊒ ƛ NL ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  Coercion
+term-function-domain-dual (ƛ⊒ƛᵗ p↦qᶜ N⊒NL) =
+  fun-narrow-domain-dualᶜ p↦qᶜ
+term-function-domain-dual (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) =
+  fun-narrow-domain-dual rᶜ
+term-function-domain-dual (cast-⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) =
+  fun-narrow-domain-dual qᶜ
+
+{-# TERMINATING #-}
+sim-beta :
+  ∀ {ΔL ΔR ρ WL NL WR VR pᵈ p q A A′ B B′} →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WL ⊒ ƛ NL ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  Value WL →
+  No• WL →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WR ⊒ VR ∶ pᵈ ⦂ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  Value WR →
+  No• WR →
+  Value VR →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+    (WL · WR —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ NL [ VR ] ∶ applyCoercions χs q
+        ⦂ applyTys χs B ⊒ B′
+sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {WR = WR} {VR = VR} {A = A} {A′ = A′}
+    (ƛ⊒ƛᵗ p↦qᶜ N⊒NL)
+    (ƛ N) noWL WR⊒VR p-domainᶜ vWR noWR vVR =
+  let
+    WR⊒VR′ :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ WR ⊒ VR ∶ fun-narrow-domain-dualᶜ p↦qᶜ
+          ⦂ A ⊒ A′
+    WR⊒VR′ =
+      subst
+        (λ p → ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WR ⊒ VR ∶ p ⦂ A ⊒ A′)
+        (narrowing-determinedᵐ
+          (leftStore-det (narrowing-store-corrᶜ p-domainᶜ))
+          (let _ , _ , _ , _ , _ , pᵈ⊒L , _ = p-domainᶜ in pᵈ⊒L)
+          (let _ , _ , _ , _ , _ , pᵈ⊒L , _ =
+                 fun-narrow-domain-dual-typingᶜ p↦qᶜ
+           in pᵈ⊒L))
+        WR⊒VR
+  in
+  keep ∷ [] ,
+  N [ WR ] ,
+  ΔL ,
+  ρ ,
+  ↠-step (pure-step (β vWR)) ↠-refl ,
+  refl ,
+  refl ,
+  term-substitution-narrowingᶜ N⊒NL WR⊒VR′
+sim-beta castCase@(cast+⊒ᵗ rᶜ p↦qᶜ t⊒ V⊒ƛ)
+    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    with canonical-⇒ vWL (typed-term-narrowing-source-typingᶜ castCase)
+sim-beta castCase@(cast+⊒ᵗ rᶜ p↦qᶜ t⊒ V⊒ƛ)
+    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-ƛ ()
+sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
+    {WR = WR} {VR = VR} {A′ = AR}
+    castCase@(cast+⊒ᵗ {M = M} {q = pᵢ ↦ qᵢ} {r = pₒ ↦ qₒ}
+      {s = cₛ ↦ dₛ}
+      {A = Aₒ ⇒ Bₒ} {B = AR ⇒ BR} {C = AL ⇒ BL}
+      {μ = μOuter} {η = ηCast}
+      pᵢ↦qᵢᶜ pₒ↦qₒᶜ
+      t⊒@(storesCast , _ , _ , _ , _ ,
+        (cast-fun cₛ⊢L dₛ⊢L , cross (cₛʷL ↦ⁿʷ dₛⁿL)) ,
+        (cast-fun cₛ⊢R dₛ⊢R , cross (cₛʷR ↦ⁿʷ dₛⁿR)))
+      V⊒ƛ)
+    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ {W = VF} {c = c} {d = d} vVF eq =
+  let
+    M≡VF : M ≡ VF
+    M≡VF = ⟨⟩-term-injective eq
+
+    noVF : No• VF
+    noVF = no•-cast-inv (subst No• eq noWL)
+
+    VF⊒ƛ :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ VF ⊒ ƛ NL ∶ pᵢ ↦ qᵢ ⦂ AL ⇒ BL ⊒ AR ⇒ BR
+    VF⊒ƛ =
+      subst
+        (λ F →
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ F ⊒ ƛ NL ∶ pᵢ ↦ qᵢ ⦂ AL ⇒ BL ⊒ AR ⇒ BR)
+        M≡VF
+        V⊒ƛ
+
+    head-β↦ :
+      (VF ⟨ c ↦ d ⟩) · WR —↠[ keep ∷ [] ]
+        (VF · (WR ⟨ c ⟩)) ⟨ d ⟩
+    head-β↦ = ↠-step (pure-step (β-↦ vVF vWR)) ↠-refl
+
+    head-ready :
+      WL · WR —↠[ keep ∷ [] ] (VF · (WR ⟨ c ⟩)) ⟨ d ⟩
+    head-ready =
+      subst
+        (λ L → L · WR —↠[ keep ∷ [] ] (VF · (WR ⟨ c ⟩)) ⟨ d ⟩)
+        (sym eq)
+        head-β↦
+
+    t⊒L = separated-left-coercionᵐ t⊒
+
+    t⊒R = separated-right-coercionᵐ t⊒
+
+    dₛ⊒L = dₛ⊢L , dₛⁿL
+
+    dₛ⊒R = dₛ⊢R , dₛⁿR
+
+    dₛ⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ dₛ ∶ Bₒ ⊒ BL
+    dₛ⊒ =
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ (proj₁ dₛ⊒L)) ,
+      proj₂ (coercion-src-tgtᵐ (proj₁ dₛ⊒L)) ,
+      proj₁ (coercion-wfᵐ (leftStore-wf storesCast) (proj₁ dₛ⊒L)) ,
+      proj₂ (coercion-wfᵐ (rightStore-wf storesCast) (proj₁ dₛ⊒R)) ,
+      dₛ⊒L ,
+      dₛ⊒R
+
+    cast-eq : narrowing-dual t⊒ ≡ c ↦ d
+    cast-eq = ⟨⟩-coercion-injective eq
+
+    dₛ-dual-eq : narrowing-dual dₛ⊒ ≡ d
+    dₛ-dual-eq =
+      ↦-right-injective
+        {c = proj₁ (dualʷ normalᵃ cₛʷL)}
+        {c′ = c}
+        {d = proj₁ (dualⁿ normalᵃ dₛⁿL)}
+        {d′ = d}
+        cast-eq
+
+    t-dual-left :
+      ηCast ∣ ΔL ∣ leftStore ρ
+        ⊢ narrowing-dual t⊒ ∶ AL ⇒ BL ⊑ Aₒ ⇒ Bₒ
+    t-dual-left =
+      dualⁿ-flips-typingᵐ
+        {μ = ηCast}
+        {η = normalᵃ}
+        {ν = ηCast}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (leftStore-wf storesCast)
+        t⊒L
+
+    t-dual-right :
+      ηCast ∣ ΔR ∣ rightStore ρ
+        ⊢ narrowing-dual t⊒ ∶ AL ⇒ BL ⊑ Aₒ ⇒ Bₒ
+    t-dual-right =
+      dualⁿ-flips-typingᵐ
+        {μ = ηCast}
+        {η = normalᵃ}
+        {ν = ηCast}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (rightStore-wf storesCast)
+        (proj₁ t⊒R , proj₂ t⊒L)
+
+    c⊒L :
+      ηCast ∣ ΔL ∣ leftStore ρ ⊢ c ∶ Aₒ ⊒ AL
+    c⊒L =
+      widen-fun-domainᵐ
+        (subst
+          (λ s → ηCast ∣ ΔL ∣ leftStore ρ
+            ⊢ s ∶ AL ⇒ BL ⊑ Aₒ ⇒ Bₒ)
+          cast-eq
+          t-dual-left)
+
+    c⊒R :
+      ηCast ∣ ΔR ∣ rightStore ρ ⊢ c ∶ Aₒ ⊒ AL
+    c⊒R =
+      widen-fun-domainᵐ
+        (subst
+          (λ s → ηCast ∣ ΔR ∣ rightStore ρ
+            ⊢ s ∶ AL ⇒ BL ⊑ Aₒ ⇒ Bₒ)
+          cast-eq
+          t-dual-right)
+
+    c⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ Aₒ ⊒ AL
+    c⊒ =
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ (proj₁ c⊒L)) ,
+      proj₂ (coercion-src-tgtᵐ (proj₁ c⊒L)) ,
+      proj₁ (coercion-wfᵐ (leftStore-wf storesCast) (proj₁ c⊒L)) ,
+      proj₂ (coercion-wfᵐ (rightStore-wf storesCast) (proj₁ c⊒R)) ,
+      c⊒L ,
+      c⊒R
+
+    WR-c⊒VR :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ WR ⟨ c ⟩ ⊒ VR ∶ fun-narrow-domain-dualᶜ pᵢ↦qᵢᶜ
+          ⦂ AL ⊒ AR
+    WR-c⊒VR =
+      cast-⊒ᵗ
+        (fun-narrow-domain-dual-typingᶜ pᵢ↦qᵢᶜ)
+        p-domainᶜ
+        c⊒
+        WR⊒VR
+
+    χsA , WRA , ΔLA ,
+      vWRA , noWRA , WR-c↠WRA , ΔLA≡ , ρA-corr ,
+      leftA≡ , rightA≡ , pAᶜ , WRA⊒VR =
+      catchup-lemmaˡ
+        (ok-⟨⟩ (ok-no noWR))
+        vVR
+        WR-c⊒VR
+
+    VFA⊒ƛ =
+      advance-left-lambda-narrowing χsA ΔLA≡ ρA-corr VF⊒ƛ
+
+    arg-ready :
+      VF · (WR ⟨ c ⟩) —↠[ χsA ] applyTerms χsA VF · WRA
+    arg-ready = ·₂-↠ vVF noVF WR-c↠WRA
+
+    cast-arg-ready :
+      (VF · (WR ⟨ c ⟩)) ⟨ d ⟩ —↠[ χsA ]
+        (applyTerms χsA VF · WRA) ⟨ applyCoercions χsA d ⟩
+    cast-arg-ready = cast-↠ {c = d} arg-ready
+
+    prefix-ready :
+      WL · WR —↠[ keep ∷ χsA ]
+        (applyTerms χsA VF · WRA) ⟨ applyCoercions χsA d ⟩
+    prefix-ready = ↠-trans head-ready cast-arg-ready
+
+    rec =
+      sim-beta
+        VFA⊒ƛ
+        (applyTerms-preserves-Value χsA vVF)
+        (applyTerms-preserves-No• χsA noVF)
+        WRA⊒VR
+        pAᶜ
+        vWRA
+        noWRA
+        vVR
+
+    χsT , N , ΔLT , ρT ,
+      tail-red , ΔT≡ , ρT≡ , N⊒NL[VR] = rec
+
+    tail-ready :
+      (applyTerms χsA VF · WRA) ⟨ applyCoercions χsA d ⟩
+        —↠[ χsT ]
+      N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+    tail-ready = cast-↠ {c = applyCoercions χsA d} tail-red
+
+    source-steps :
+      WL · WR —↠[ (keep ∷ χsA) ++ χsT ]
+        N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+    source-steps = ↠-trans prefix-ready tail-ready
+
+    ΔLT-total≡ :
+      ΔLT ≡ applyTyCtxs ((keep ∷ χsA) ++ χsT) ΔL
+    ΔLT-total≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔLA≡)
+          (sym (applyTyCtxs-++ χsA χsT ΔL)))
+
+    ρT-total≡ :
+      ρT ≡ applyLeftChanges ((keep ∷ χsA) ++ χsT) ρ
+    ρT-total≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
+
+    N-cast⊒ :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+          ⊒ NL [ VR ] ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+          ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR
+    N-cast⊒ =
+      sim-beta-cast+-result
+        {ΔL = ΔL}
+        {ΔR = ΔR}
+        {ρ = ρ}
+        {ΔLA = ΔLA}
+        {ΔLT = ΔLT}
+        {ρT = ρT}
+        {NL = NL}
+        {VR = VR}
+        {N = N}
+        {qᵢ = qᵢ}
+        {qₒ = qₒ}
+        {dₛ = dₛ}
+        {d = d}
+        {Bₒ = Bₒ}
+        {BL = BL}
+        {BR = BR}
+        {μq = μOuter}
+        {μd = ηCast}
+        {χsA = χsA}
+        {χsT = χsT}
+        (fun-narrow-codomainᶜ pᵢ↦qᵢᶜ)
+        (separated-fun-codomain pₒ↦qₒᶜ)
+        dₛ⊒
+        dₛ-dual-eq
+        ΔLA≡
+        ρA-corr
+        ΔT≡
+        ρT≡
+        N⊒NL[VR]
+  in
+  (keep ∷ χsA) ++ χsT ,
+  N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩ ,
+  ΔLT ,
+  ρT ,
+  source-steps ,
+  ΔLT-total≡ ,
+  ρT-total≡ ,
+  N-cast⊒
+sim-beta
+    (cast+⊒ᵗ {q = id A}
+      (_ , _ , _ , _ , _ , (cast-id _ _ , cross ()) , _)
+      p↦qᶜ
+      (storesCast , _ , _ , _ , _ ,
+        (cast-fun _ _ , cross (_ ↦ⁿʷ _)) ,
+        (cast-fun _ _ , cross (_ ↦ⁿʷ _)))
+      V⊒ƛ)
+    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vVF eq
+sim-beta
+    (cast+⊒ᵗ {q = (G ？) ︔ g}
+      (_ , _ , _ , _ , _ , (cast-seq () _ , _ ？︔ _) , _)
+      p↦qᶜ
+      (storesCast , _ , _ , _ , _ ,
+        (cast-fun _ _ , cross (_ ↦ⁿʷ _)) ,
+        (cast-fun _ _ , cross (_ ↦ⁿʷ _)))
+      V⊒ƛ)
+    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vVF eq
+sim-beta
+    (cast+⊒ᵗ {q = g ︔ seal A α}
+      (_ , _ , _ , _ , _ , (cast-seq _ () , _ ︔seal _) , _)
+      p↦qᶜ
+      (storesCast , _ , _ , _ , _ ,
+        (cast-fun _ _ , cross (_ ↦ⁿʷ _)) ,
+        (cast-fun _ _ , cross (_ ↦ⁿʷ _)))
+      V⊒ƛ)
+    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vVF eq
+sim-beta
+    (cast-⊒ᵗ {s = id A} p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ () ⟩)
+sim-beta
+    (cast-⊒ᵗ {s = c ︔ d} p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ () ⟩)
+sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL}
+    {WR = WR} {VR = VR}
+    (cast-⊒ᵗ {M = V} {q = pₒ ↦ qₒ} {r = pᵢ ↦ qᵢ}
+      {s = c ↦ d} {A = AL ⇒ BL}
+      {B = AR ⇒ BR} {C = Aₒ ⇒ Bₒ} {η = ηCast}
+      (storesOuter , _ , _ , wf⇒ hAₒ hBₒ , wf⇒ hAR hBR ,
+        (cast-fun _ qₒ⊢L , cross (_ ↦ⁿʷ qₒⁿL)) ,
+        (cast-fun _ qₒ⊢R , cross (_ ↦ⁿʷ qₒⁿR)))
+      rInner@(storesInner , _ , _ , wf⇒ hAL hBL , _ ,
+        (cast-fun pᵢ⊢L _ , cross (pᵢʷL ↦ⁿʷ _)) ,
+        (cast-fun pᵢ⊢R _ , cross (pᵢʷR ↦ⁿʷ _)))
+      (storesCast , _ , _ , _ , wf⇒ hAₒʳ hBₒʳ ,
+        (cast-fun c⊢L d⊢L , cross (cʷL ↦ⁿʷ dⁿL)) ,
+        (cast-fun c⊢R d⊢R , cross (cʷR ↦ⁿʷ dⁿR)))
+      V⊒ƛ)
+    (vV ⟨ i ⟩)
+    (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR =
+  let
+    head-β↦ :
+      (V ⟨ c ↦ d ⟩) · WR —↠[ keep ∷ [] ]
+        (V · (WR ⟨ c ⟩)) ⟨ d ⟩
+    head-β↦ = ↠-step (pure-step (β-↦ vV vWR)) ↠-refl
+
+    qₒ⊒ :
+      tag-or-idᵈ ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR
+    qₒ⊒ =
+      storesOuter ,
+      proj₁ (coercion-src-tgtᵐ qₒ⊢L) ,
+      proj₂ (coercion-src-tgtᵐ qₒ⊢L) ,
+      hBₒ ,
+      hBR ,
+      (qₒ⊢L , qₒⁿL) ,
+      (qₒ⊢R , qₒⁿR)
+
+    d⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ d ∶ BL ⊒ Bₒ
+    d⊒ =
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ d⊢L) ,
+      proj₂ (coercion-src-tgtᵐ d⊢L) ,
+      hBL ,
+      hBₒʳ ,
+      (d⊢L , dⁿL) ,
+      (d⊢R , dⁿR)
+
+    pᵢ-domain⊒ :
+      _ ∣ ΔL ∣ ΔR ∣ ρ
+        ⊢ fun-narrow-domain-dual rInner ∶ AL ⊒ AR
+    pᵢ-domain⊒ =
+      let
+        pᵢᵈ⊒L =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (leftStore-wf storesInner)
+              (pᵢ⊢L , pᵢʷL)) ,
+          proj₂ (dualʷ normalᵃ pᵢʷL)
+
+        pᵢᵈ⊒R =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (rightStore-wf storesInner)
+              (pᵢ⊢R , pᵢʷR)) ,
+          proj₂ (dualʷ normalᵃ pᵢʷR)
+      in
+      storesInner ,
+      proj₁ (coercion-src-tgtᵐ (proj₁ pᵢᵈ⊒L)) ,
+      proj₂ (coercion-src-tgtᵐ (proj₁ pᵢᵈ⊒L)) ,
+      hAL ,
+      hAR ,
+      pᵢᵈ⊒L ,
+      subst
+        (λ p → _ ∣ ΔR ∣ rightStore ρ ⊢ p ∶ AL ⊒ AR)
+        (dualʷ-raw-determined normalᵃ pᵢʷR pᵢʷL)
+        pᵢᵈ⊒R
+
+    c-dual⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ
+        ⊢ proj₁ (dualʷ normalᵃ cʷL) ∶ AL ⊒ Aₒ
+    c-dual⊒ =
+      let
+        cᵈ⊒L =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (leftStore-wf storesCast)
+              (c⊢L , cʷL)) ,
+          proj₂ (dualʷ normalᵃ cʷL)
+
+        cᵈ⊒R =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (rightStore-wf storesCast)
+              (c⊢R , cʷR)) ,
+          proj₂ (dualʷ normalᵃ cʷR)
+      in
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ (proj₁ cᵈ⊒L)) ,
+      proj₂ (coercion-src-tgtᵐ (proj₁ cᵈ⊒L)) ,
+      hAL ,
+      hAₒʳ ,
+      cᵈ⊒L ,
+      subst
+        (λ d → ηCast ∣ ΔR ∣ rightStore ρ ⊢ d ∶ AL ⊒ Aₒ)
+        (dualʷ-raw-determined normalᵃ cʷR cʷL)
+        cᵈ⊒R
+
+    c-dual-eq :
+      narrowing-dual c-dual⊒ ≡ c
+    c-dual-eq = dualʷ-involutive-raw cʷL
+
+    WR-c⊒VR :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ WR ⟨ c ⟩ ⊒ VR ∶ fun-narrow-domain-dual rInner
+          ⦂ AL ⊒ AR
+    WR-c⊒VR =
+      subst
+        (λ s →
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ WR ⟨ s ⟩ ⊒ VR ∶ fun-narrow-domain-dual rInner
+              ⦂ AL ⊒ AR)
+        c-dual-eq
+        (cast+⊒ᵗ p-domainᶜ pᵢ-domain⊒ c-dual⊒ WR⊒VR)
+
+    χsA , WRA , ΔLA ,
+      vWRA , noWRA , WR-c↠WRA , ΔLA≡ , ρA-corr ,
+      leftA≡ , rightA≡ , pAᶜ , WRA⊒VRraw =
+      catchup-lemmaˡ
+        (ok-⟨⟩ (ok-no noWR))
+        vVR
+        WR-c⊒VR
+
+    VFA⊒ƛ =
+      advance-left-lambda-narrowing χsA ΔLA≡ ρA-corr V⊒ƛ
+
+    WRA⊒VR :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ ∣ []
+        ⊢ WRA ⊒ VR ∶ applyCoercions χsA
+            (fun-narrow-domain-dual rInner)
+          ⦂ applyTys χsA AL ⊒ AR
+    WRA⊒VR = WRA⊒VRraw
+
+    arg-ready :
+      V · (WR ⟨ c ⟩) —↠[ χsA ] applyTerms χsA V · WRA
+    arg-ready = ·₂-↠ vV noV WR-c↠WRA
+
+    cast-arg-ready :
+      (V · (WR ⟨ c ⟩)) ⟨ d ⟩ —↠[ χsA ]
+        (applyTerms χsA V · WRA) ⟨ applyCoercions χsA d ⟩
+    cast-arg-ready = cast-↠ {c = d} arg-ready
+
+    rec =
+      sim-beta
+        VFA⊒ƛ
+        (applyTerms-preserves-Value χsA vV)
+        (applyTerms-preserves-No• χsA noV)
+        WRA⊒VR
+        pAᶜ
+        vWRA
+        noWRA
+        vVR
+  in
+  sim-beta-cast-tail
+    {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M₀ = (V ⟨ c ↦ d ⟩) · WR}
+    {NL = NL} {V = V} {WRA = WRA} {VR = VR}
+    {qᵢ = qᵢ} {qₒ = qₒ} {d = d} {Bₒ = Bₒ}
+    {BL = BL} {BR = BR} {D₁ = BL} {D₂ = Bₒ}
+    {μq = tag-or-idᵈ} {μd = ηCast} {χsA = χsA} {ΔLA = ΔLA}
+    (λ χsT N → N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩)
+    (↠-trans head-β↦ cast-arg-ready)
+    (λ tail-red → cast-↠ {c = applyCoercions χsA d} tail-red)
+    qₒ⊒
+    d⊒
+    ΔLA≡
+    ρA-corr
+    (λ _ N⊒NL[VR] qₒ⊒Tρ d⊒Tρ →
+      let μN , nᶜ = typed-term-narrowing-coercion N⊒NL[VR] in
+      cast-⊒ᵗ {μ = μN} {η = ηCast}
+        qₒ⊒Tρ
+        nᶜ
+        d⊒Tρ
+        N⊒NL[VR])
+    rec
+sim-beta castCase@(cast-⊒ᵗ {s = `∀ c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    with canonical-⇒ (vV ⟨ `∀ c ⟩)
+           (typed-term-narrowing-source-typingᶜ castCase)
+sim-beta castCase@(cast-⊒ᵗ {s = `∀ c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-ƛ ()
+sim-beta castCase@(cast-⊒ᵗ {s = `∀ c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vW ()
+sim-beta castCase@(cast-⊒ᵗ {s = G !}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    with canonical-⇒ (vV ⟨ G ! ⟩)
+           (typed-term-narrowing-source-typingᶜ castCase)
+sim-beta castCase@(cast-⊒ᵗ {s = G !}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-ƛ ()
+sim-beta castCase@(cast-⊒ᵗ {s = G !}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vW ()
+sim-beta
+    (cast-⊒ᵗ {s = G ？} p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ () ⟩)
+sim-beta castCase@(cast-⊒ᵗ {s = seal A α}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    with canonical-⇒ (vV ⟨ seal A α ⟩)
+           (typed-term-narrowing-source-typingᶜ castCase)
+sim-beta castCase@(cast-⊒ᵗ {s = seal A α}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-ƛ ()
+sim-beta castCase@(cast-⊒ᵗ {s = seal A α}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vW ()
+sim-beta
+    (cast-⊒ᵗ {s = unseal α A}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ () ⟩)
+sim-beta castCase@(cast-⊒ᵗ {s = gen A c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    with canonical-⇒ (vV ⟨ gen A c ⟩)
+           (typed-term-narrowing-source-typingᶜ castCase)
+sim-beta castCase@(cast-⊒ᵗ {s = gen A c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-ƛ ()
+sim-beta castCase@(cast-⊒ᵗ {s = gen A c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+    | fv-↦ vW ()
+sim-beta
+    (cast-⊒ᵗ {s = inst A c}
+      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (vV ⟨ () ⟩)


### PR DESCRIPTION
## Summary

Adds the separated-store surface for continuing the GTSF dynamic gradual guarantee
proof:

- introduces `StoreCorrespondence` with explicit left/right seal correspondence,
  store projections, side-specific shifts, and a compatibility path from the old
  shared `StoreNrw`;
- introduces `TermNarrowingSeparated`, where term narrowing carries independent
  left/right type contexts and stores connected by `SealCorr`;
- adds separated catchup, DGG, and sim-beta proof surfaces and wires the new
  modules into `All.agda`;
- records the top-down migration checklist in
  `proof/SeparatedStoresDGGChecklist.md`.

## Why Separated Stores

The shared-store narrowing setup forced both sides of the relation to share one
namespace. During DGG beta/catchup, that made source-side catchup change terms
and seal names on the side that was not reducing. It also made it hard to relate
the function-domain coercions exposed by sequential catchups, because the
namespace updates for left and right computations were collapsed into a single
store change.

The separated design keeps the source and target stores independent and tracks
the intended relationship explicitly with `SealCorr`. A left catchup now advances
only `leftStore`, while the target term/store remain fixed; right-side target
steps can later advance only `rightStore`. This matches the proof shape needed
by DGG: reductions happen on one side at a time, while the seal correspondence
records which runtime names still match and which names are one-sided.

This also makes the beta simulation more local. The caller catches up the
function and argument sequentially, then `sim-beta` can reason about the
argument cast introduced by `β-↦` using the typed domain/codomain evidence in
the separated term narrowing constructors.

## Notes

This is still a top-down proof surface. `catchup-lemmaˡ`, left-change weakening,
separated substitution, and two raw-dual facts used by `sim-beta` remain explicit
proof obligations/postulates. The point of this branch is to make the full DGG
caller and the function-application simulation agree on the separated-store
shape before filling those lower-level lemmas.

## Validation

- `agda -v0 proof/SimBetaSeparated.agda` from `GTSF/`
- `agda -v0 proof/DynamicGradualGuaranteeSeparated.agda` from `GTSF/`
