### PR TITLE
[codex] Split separated DGG helper proofs

### DIFF
--- a/GTSF/StoreCorrespondence.agda
+++ b/GTSF/StoreCorrespondence.agda
@@ -8,12 +8,13 @@ module StoreCorrespondence where
 --     so proofs can be migrated one surface at a time.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥)
 open import Data.List using (List; []; _∷_; map)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here; there)
-open import Data.Nat using (_<_; suc)
+open import Data.Nat using (_<_; zero; suc)
 open import Data.Product using (_,_)
-open import Relation.Binary.PropositionalEquality using (cong; sym)
+open import Relation.Binary.PropositionalEquality using (cong; subst; sym)
 
 open import Types
 open import Store using (StoreWfAt)
@@ -373,3 +374,76 @@ rightStore-⇑ʳᶜorr (left-only α A ∷ ρ) =
   rightStore-⇑ʳᶜorr ρ
 rightStore-⇑ʳᶜorr (right-only β B ∷ ρ) =
   cong ((suc β , ⇑ᵗ B) ∷_) (rightStore-⇑ʳᶜorr ρ)
+
+leftStore-⇑ˡᶜorr-zero∉ :
+  ∀ {ρ A} →
+  (zero , A) ∈ leftStore (⇑ˡᶜorr ρ) →
+  ⊥
+leftStore-⇑ˡᶜorr-zero∉ {ρ = []} ()
+leftStore-⇑ˡᶜorr-zero∉ {ρ = matched α A β B ∷ ρ} (here ())
+leftStore-⇑ˡᶜorr-zero∉ {ρ = matched α A β B ∷ ρ} (there h) =
+  leftStore-⇑ˡᶜorr-zero∉ {ρ = ρ} h
+leftStore-⇑ˡᶜorr-zero∉ {ρ = left-only α A ∷ ρ} (here ())
+leftStore-⇑ˡᶜorr-zero∉ {ρ = left-only α A ∷ ρ} (there h) =
+  leftStore-⇑ˡᶜorr-zero∉ {ρ = ρ} h
+leftStore-⇑ˡᶜorr-zero∉ {ρ = right-only β B ∷ ρ} h =
+  leftStore-⇑ˡᶜorr-zero∉ {ρ = ρ} h
+
+rightStore-⇑ʳᶜorr-zero∉ :
+  ∀ {ρ A} →
+  (zero , A) ∈ rightStore (⇑ʳᶜorr ρ) →
+  ⊥
+rightStore-⇑ʳᶜorr-zero∉ {ρ = []} ()
+rightStore-⇑ʳᶜorr-zero∉ {ρ = matched α A β B ∷ ρ} (here ())
+rightStore-⇑ʳᶜorr-zero∉ {ρ = matched α A β B ∷ ρ} (there h) =
+  rightStore-⇑ʳᶜorr-zero∉ {ρ = ρ} h
+rightStore-⇑ʳᶜorr-zero∉ {ρ = left-only α A ∷ ρ} h =
+  rightStore-⇑ʳᶜorr-zero∉ {ρ = ρ} h
+rightStore-⇑ʳᶜorr-zero∉ {ρ = right-only β B ∷ ρ} (here ())
+rightStore-⇑ʳᶜorr-zero∉ {ρ = right-only β B ∷ ρ} (there h) =
+  rightStore-⇑ʳᶜorr-zero∉ {ρ = ρ} h
+
+corr-⇑ᶜorr :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr (suc ΔL) (suc ΔR) (⇑ᶜorr ρ)
+corr-⇑ᶜorr {ρ = ρ} corr =
+  store-corr
+    (subst
+      (λ Σ → StoreDetWf _ Σ)
+      (sym (leftStore-⇑ᶜorr ρ))
+      (NWP.StoreDetWf-⟰ᵗ (leftStore-det corr)))
+    (subst
+      (λ Σ → StoreDetWf _ Σ)
+      (sym (rightStore-⇑ᶜorr ρ))
+      (NWP.StoreDetWf-⟰ᵗ (rightStore-det corr)))
+
+corr-⇑ˡᶜorr :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr (suc ΔL) ΔR (⇑ˡᶜorr ρ)
+corr-⇑ˡᶜorr {ρ = ρ} corr =
+  store-corr
+    (subst
+      (λ Σ → StoreDetWf _ Σ)
+      (sym (leftStore-⇑ˡᶜorr ρ))
+      (NWP.StoreDetWf-⟰ᵗ (leftStore-det corr)))
+    (subst
+      (λ Σ → StoreDetWf _ Σ)
+      (sym (rightStore-⇑ˡᶜorr ρ))
+      (rightStore-det corr))
+
+corr-⇑ʳᶜorr :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr ΔL (suc ΔR) (⇑ʳᶜorr ρ)
+corr-⇑ʳᶜorr {ρ = ρ} corr =
+  store-corr
+    (subst
+      (λ Σ → StoreDetWf _ Σ)
+      (sym (leftStore-⇑ʳᶜorr ρ))
+      (leftStore-det corr))
+    (subst
+      (λ Σ → StoreDetWf _ Σ)
+      (sym (rightStore-⇑ʳᶜorr ρ))
+      (NWP.StoreDetWf-⟰ᵗ (rightStore-det corr)))

--- a/GTSF/proof/CatchupSeparated.agda
+++ b/GTSF/proof/CatchupSeparated.agda
@@ -10,8 +10,9 @@ module proof.CatchupSeparated where
 --   * States the left catchup lemma with an unchanged target term.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥-elim)
 open import Data.List using ([]; _∷_; _++_)
-open import Data.Nat using (zero)
+open import Data.Nat using (zero; suc; z<s)
 open import Data.Product using (_×_; _,_; ∃-syntax)
 open import Relation.Binary.PropositionalEquality using (cong; trans)
 
@@ -25,6 +26,7 @@ open import NuReduction using
   ; bind
   ; applyStore
   ; applyStores
+  ; applyTyCtx
   ; applyTys
   ; applyTyCtxs
   ; _—↠[_]_
@@ -98,6 +100,14 @@ applyRightChanges [] ρ = ρ
 applyRightChanges (χ ∷ χs) ρ =
   applyRightChanges χs (applyRightChange χ ρ)
 
+applyRightChanges-++ :
+  ∀ χs χs′ ρ →
+  applyRightChanges (χs ++ χs′) ρ ≡
+    applyRightChanges χs′ (applyRightChanges χs ρ)
+applyRightChanges-++ [] χs′ ρ = refl
+applyRightChanges-++ (χ ∷ χs) χs′ ρ =
+  applyRightChanges-++ χs χs′ (applyRightChange χ ρ)
+
 leftStore-applyRightChange :
   ∀ χ ρ →
   leftStore (applyRightChange χ ρ) ≡ leftStore ρ
@@ -128,6 +138,40 @@ rightStore-applyRightChanges (χ ∷ χs) ρ =
   trans
     (rightStore-applyRightChanges χs (applyRightChange χ ρ))
     (cong (applyStores χs) (rightStore-applyRightChange χ ρ))
+
+store-corr-applyLeftKeep :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr (applyTyCtx keep ΔL) ΔR (applyLeftChange keep ρ)
+store-corr-applyLeftKeep corr = corr
+
+store-corr-applyLeftBind :
+  ∀ {ΔL ΔR ρ A} →
+  WfTy (suc ΔL) (⇑ᵗ A) →
+  WfTy zero (⇑ᵗ A) →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr (applyTyCtx (bind A) ΔL) ΔR (applyLeftChange (bind A) ρ)
+store-corr-applyLeftBind hA hA-old corr =
+  corr-left z<s hA hA-old
+    (λ h → ⊥-elim (leftStore-⇑ˡᶜorr-zero∉ h))
+    (corr-⇑ˡᶜorr corr)
+
+store-corr-applyRightKeep :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr ΔL (applyTyCtx keep ΔR) (applyRightChange keep ρ)
+store-corr-applyRightKeep corr = corr
+
+store-corr-applyRightBind :
+  ∀ {ΔL ΔR ρ A} →
+  WfTy (suc ΔR) (⇑ᵗ A) →
+  WfTy zero (⇑ᵗ A) →
+  StoreCorr ΔL ΔR ρ →
+  StoreCorr ΔL (applyTyCtx (bind A) ΔR) (applyRightChange (bind A) ρ)
+store-corr-applyRightBind hA hA-old corr =
+  corr-right z<s hA hA-old
+    (λ h → ⊥-elim (rightStore-⇑ʳᶜorr-zero∉ h))
+    (corr-⇑ʳᶜorr corr)
 
 ------------------------------------------------------------------------
 -- Separated left catchup

--- a/GTSF/proof/DGGBetaCastSeparated.agda
+++ b/GTSF/proof/DGGBetaCastSeparated.agda
@@ -1,0 +1,1614 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.DGGBetaCastSeparated where
+
+-- File Charter:
+--   * Separated-store DGG helpers for application beta-through-cast steps.
+--   * Handles function-cast value shapes and source/target catchup packaging.
+--   * Keeps the large beta-cast proof separate from the main recursive DGG.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Nat using (_+_)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import NarrowWiden using
+  ( cross
+  ; dualʷ
+  ; id★
+  ; id-＇
+  ; id-‵
+  ; _？︔_
+  ; _︔seal_
+  ; _∣_∣_⊢_∶_⊒_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
+open import Primitives using (addℕ; κℕ)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyLeftChanges-++
+  ; applyRightChange
+  ; catchup-lemmaˡ
+  )
+open import proof.NuPreservation using (runtime-⟨⟩)
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualʷ-flips-typingᵐ
+  )
+open import proof.ReductionProperties using
+  ( applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyCoercions
+  ; applyCoercions-++
+  ; applyCoercions-dual
+  ; applyTys-++
+  ; applyTys-ℕ
+  ; applyTys-ℕ-applyTys
+  ; applyTyCtxs-++
+  ; ↠-trans
+  ; cast-↠
+  ; ·₁-↠
+  ; ·₂-↠
+  ; ⊕₁-↠
+  ; ⊕₂-↠
+  )
+open import proof.SimBetaSeparated using
+  ( applyTerms-preserves-RuntimeOK
+  ; applyTys-⇒
+  ; applyCoercions-↦
+  ; applyCoercions-dual-applyCoercions
+  ; no•-cast-inv
+  ; ⟨⟩-term-injective
+  ; ⟨⟩-coercion-injective
+  ; left-change-coercion-narrowing
+  ; left-change-source-coercion-narrowing
+  ; left-change-source-coercion-narrowing-dual
+  ; advance-left-term-narrowing
+  ; advance-left-function-term-narrowing
+  ; advance-left-lambda-narrowing
+  ; widen-fun-domainᵐ
+  ; separated-fun-domain-dual
+  ; separated-fun-codomain
+  ; separated-left-coercionᵐ
+  ; separated-right-coercionᵐ
+  ; ↦-domain
+  ; ↦-codomain
+  ; ↦-left-injective
+  ; ↦-right-injective
+  ; dualʷ-raw-determined
+  ; dualʷ-involutive-raw
+  ; sim-beta
+  )
+open import proof.NuProgress using
+  (FunView; fv-ƛ; fv-↦; canonical-⇒)
+open import proof.DGGPrimitiveSeparated using
+  ( id-ℕ-narrowingᶜ
+  ; applyCoercions-id-ℕ
+  ; applyCoercions-id-ℕ-applyCoercions
+  ; source-nat-typingᶜ
+  ; typed-term-narrowing-endpointsᶜ
+  ; typed-term-narrowing-coercion-endpointsᶜ
+  ; constant-⊕-δ-step
+  ; const-narrowing-targetᶜ
+  ; value-id-ℕ-narrowing-target-constᶜ
+  ; value-normalized-id-ℕ-target-constᶜ
+  )
+
+separated-source-cast-plus-result :
+  ∀ {ΔL ΔR ρ ΔLA ΔLT ρT Target N qᵢ qₒ dₛ d Bₒ BL BR μq μd}
+    {χsA χsT} →
+  ΔL ∣ ΔR ∣ ρ ⊢ qᵢ ∶ᶜ BL ⊒ BR →
+  μq ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR →
+  (dₛ⊒ : μd ∣ ΔL ∣ ΔR ∣ ρ ⊢ dₛ ∶ Bₒ ⊒ BL) →
+  narrowing-dual dₛ⊒ ≡ d →
+  ΔLA ≡ applyTyCtxs χsA ΔL →
+  StoreCorr ΔLA ΔR (applyLeftChanges χsA ρ) →
+  ΔLT ≡ applyTyCtxs χsT ΔLA →
+  ρT ≡ applyLeftChanges χsT (applyLeftChanges χsA ρ) →
+  ΔLT ∣ ΔR ∣ ρT ∣ []
+    ⊢ N ⊒ Target ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+      ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR →
+  ΔLT ∣ ΔR ∣ ρT ∣ []
+    ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+      ⊒ Target ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+      ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR
+separated-source-cast-plus-result {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {ΔLA = ΔLA} {ΔLT = ΔLT} {ρT = ρT} {Target = Target}
+    {N = N} {qᵢ = qᵢ} {qₒ = qₒ} {dₛ = dₛ} {d = d}
+    {Bₒ = Bₒ} {BL = BL} {BR = BR} {μq = μq} {μd = μd}
+    {χsA = χsA} {χsT = χsT}
+    qᵢᶜ qₒ⊒ dₛ⊒ dₛ-dual-eq ΔLA≡ ρA-corr ΔT≡ ρT≡
+    N⊒Target =
+  let
+    μN , nᶜ = typed-term-narrowing-coercion N⊒Target
+
+    ρT-corr :
+      StoreCorr ΔLT ΔR
+        (applyLeftChanges χsT (applyLeftChanges χsA ρ))
+    ρT-corr =
+      subst (StoreCorr ΔLT ΔR)
+        ρT≡
+        (narrowing-store-corrᶜ {μ = μN} nᶜ)
+
+    N⊒TargetT :
+      ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+        ⊢ N ⊒ Target ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+          ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR
+    N⊒TargetT =
+      subst
+        (λ ρ₀ →
+          ΔLT ∣ ΔR ∣ ρ₀ ∣ []
+            ⊢ N ⊒ Target
+              ∶ applyCoercions χsT (applyCoercions χsA qᵢ)
+              ⦂ applyTys χsT (applyTys χsA BL) ⊒ BR)
+        ρT≡
+        N⊒Target
+
+    qᵢᶜA :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA qᵢ ∶ᶜ applyTys χsA BL ⊒ BR
+    qᵢᶜA =
+      left-change-coercion-narrowing χsA {μ = tag-or-idᵈ}
+        ΔLA≡ ρA-corr qᵢᶜ
+
+    qᵢᶜT :
+      ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA qᵢ)
+          ∶ᶜ applyTys χsT (applyTys χsA BL) ⊒ BR
+    qᵢᶜT =
+      left-change-coercion-narrowing χsT {μ = tag-or-idᵈ}
+        ΔT≡ ρT-corr qᵢᶜA
+
+    qₒ⊒A :
+      μq ∣ ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA qₒ ∶ applyTys χsA Bₒ ⊒ BR
+    qₒ⊒A =
+      left-change-coercion-narrowing χsA {μ = μq}
+        ΔLA≡ ρA-corr qₒ⊒
+
+    qₒ⊒T :
+      μq ∣ ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+          ∶ applyTys χsT (applyTys χsA Bₒ) ⊒ BR
+    qₒ⊒T =
+      left-change-coercion-narrowing χsT {μ = μq}
+        ΔT≡ ρT-corr qₒ⊒A
+
+    dₛ⊒A :
+      μd ∣ ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA dₛ
+          ∶ applyTys χsA Bₒ ⊒ applyTys χsA BL
+    dₛ⊒A =
+      left-change-source-coercion-narrowing χsA {μ = μd}
+        ΔLA≡ ρA-corr dₛ⊒
+
+    dₛ⊒T :
+      μd ∣ ΔLT ∣ ΔR
+        ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA dₛ)
+          ∶ applyTys χsT (applyTys χsA Bₒ)
+          ⊒ applyTys χsT (applyTys χsA BL)
+    dₛ⊒T =
+      left-change-source-coercion-narrowing χsT {μ = μd}
+        ΔT≡ ρT-corr dₛ⊒A
+
+    dₛ-dual-A :
+      narrowing-dual dₛ⊒A ≡ applyCoercions χsA (narrowing-dual dₛ⊒)
+    dₛ-dual-A =
+      left-change-source-coercion-narrowing-dual
+        χsA ΔLA≡ ρA-corr dₛ⊒
+
+    dₛ-dual-T :
+      narrowing-dual dₛ⊒T ≡ applyCoercions χsT (applyCoercions χsA d)
+    dₛ-dual-T =
+      trans
+        (left-change-source-coercion-narrowing-dual
+          χsT ΔT≡ ρT-corr dₛ⊒A)
+        (trans
+          (cong (applyCoercions χsT) dₛ-dual-A)
+          (cong
+            (λ d₀ → applyCoercions χsT (applyCoercions χsA d₀))
+            dₛ-dual-eq))
+
+    N-cast⊒T :
+      ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+          ⊒ Target ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+          ⦂ applyTys χsT (applyTys χsA Bₒ) ⊒ BR
+    N-cast⊒T =
+      subst
+        (λ d₀ →
+          ΔLT ∣ ΔR
+            ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+            ⊢ N ⟨ d₀ ⟩ ⊒ Target
+              ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+              ⦂ applyTys χsT (applyTys χsA Bₒ) ⊒ BR)
+        dₛ-dual-T
+        (cast+⊒ᵗ
+          {ΔL = ΔLT}
+          {ΔR = ΔR}
+          {ρ = applyLeftChanges χsT (applyLeftChanges χsA ρ)}
+          {γ = []}
+          {M = N}
+          {M′ = Target}
+          {q = applyCoercions χsT (applyCoercions χsA qᵢ)}
+          {r = applyCoercions χsT (applyCoercions χsA qₒ)}
+          {s = applyCoercions χsT (applyCoercions χsA dₛ)}
+          {A = applyTys χsT (applyTys χsA Bₒ)}
+          {B = BR}
+          {C = applyTys χsT (applyTys χsA BL)}
+          {μ = μq}
+          {η = μd}
+          qᵢᶜT
+          qₒ⊒T
+          dₛ⊒T
+          N⊒TargetT)
+  in
+  subst
+    (λ ρ₀ →
+      ΔLT ∣ ΔR ∣ ρ₀ ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+          ⊒ Target ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+          ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR)
+    (sym ρT≡)
+    (subst
+      (λ q →
+        ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+          ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+            ⊒ Target ∶ q
+            ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR)
+      (sym (applyCoercions-++ χsA χsT qₒ))
+      (subst
+        (λ B →
+          ΔLT ∣ ΔR
+            ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ) ∣ []
+            ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA d) ⟩
+              ⊒ Target
+              ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+              ⦂ B ⊒ BR)
+        (sym (applyTys-++ χsA χsT Bₒ))
+        N-cast⊒T))
+
+separated-dgg-beta-cast-value-shape :
+  ∀ {ΔL ΔR ρ L R T V′ W′ c d pᵈ p q A A′ B B′} →
+  Value L →
+  No• L →
+  Value R →
+  No• R →
+  Value V′ →
+  Value W′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ T ∶ p ↦ q ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  T ≡ V′ ⟨ c ↦ d ⟩ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩
+        ∶ applyCoercions χs q ⦂ applyTys χs B ⊒ B′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′ (⊒blameᵗ M⊢ pᶜ) () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′ (x⊒xᵗ pᶜ x∋p) () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′ (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′ (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d} {A′ = A′} {B′ = B′}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast+ᵗ {M′ = F′} {r = pᵢ ↦ qᵢ}
+      {t = cₜ ↦ dₜ} {B = Aᵢ ⇒ Bᵢ} {η = ηCast}
+      pᶜ rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′ =
+  let
+    relation-obligation :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ L · R ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ _ ⦂ _ ⊒ _
+    relation-obligation =
+      let
+        target-shape : T ≡ V′ ⟨ c ↦ d ⟩
+        target-shape = T≡V′cd
+
+        target-head-eq : F′ ≡ V′
+        target-head-eq = ⟨⟩-term-injective T≡V′cd
+
+        target-cast-eq : narrowing-dual t⊒ ≡ c ↦ d
+        target-cast-eq = ⟨⟩-coercion-injective T≡V′cd
+
+        target-domain-eq : ↦-domain (narrowing-dual t⊒) ≡ c
+        target-domain-eq = cong ↦-domain target-cast-eq
+
+        target-codomain-eq : ↦-codomain (narrowing-dual t⊒) ≡ d
+        target-codomain-eq = cong ↦-codomain target-cast-eq
+
+        target-function-cast :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ T ∶ _ ⦂ _ ⊒ _
+        target-function-cast = targetCast
+
+        inner-function-relation :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ F′ ∶ _ ⦂ _ ⊒ _
+        inner-function-relation = L⊒F′
+
+        target-argument :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ _ ⦂ _ ⊒ _
+        target-argument = R⊒W′
+
+        obligation :
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ L · R ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ _ ⦂ _ ⊒ _
+        obligation = {! separated-dgg-beta-cast-target-plus-relation !}
+      in
+      obligation
+  in
+  [] ,
+  L · R ,
+  ΔL ,
+  ρ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  relation-obligation
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = id A} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = t₁ ︔ t₂} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = `∀ t} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = G !} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = G ？} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = seal A α} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = unseal α A} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = gen A t} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {t = inst A t} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d} {A′ = A′} {B′ = B′}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast-ᵗ {M′ = F′} {p = pᵢ ↦ qᵢ}
+      {t = cₜ ↦ dₜ} {C = Aᵢ ⇒ Bᵢ} {η = ηCast}
+      pᶜ rᶜ
+      t⊒@(storesCast , _ , _ , wf⇒ hAᵢ hBᵢ , wf⇒ hA′ hB′ ,
+        (cast-fun cₜ⊢L _ , cross (cₜʷL ↦ⁿʷ _)) ,
+        (cast-fun cₜ⊢R _ , cross (cₜʷR ↦ⁿʷ _)))
+      L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′ =
+  let
+    relation-obligation :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ L · R ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ _ ⦂ _ ⊒ _
+    relation-obligation =
+      let
+        target-shape : T ≡ V′ ⟨ c ↦ d ⟩
+        target-shape = T≡V′cd
+
+        target-head-eq : F′ ≡ V′
+        target-head-eq = ⟨⟩-term-injective T≡V′cd
+
+        target-cast-eq : cₜ ↦ dₜ ≡ c ↦ d
+        target-cast-eq = ⟨⟩-coercion-injective T≡V′cd
+
+        target-domain-eq : cₜ ≡ c
+        target-domain-eq = ↦-left-injective target-cast-eq
+
+        target-codomain-eq : dₜ ≡ d
+        target-codomain-eq = ↦-right-injective target-cast-eq
+
+        target-function-cast :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ T ∶ _ ⦂ _ ⊒ _
+        target-function-cast = targetCast
+
+        inner-function-relation :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ F′ ∶ _ ⦂ _ ⊒ _
+        inner-function-relation = L⊒F′
+
+        target-argument :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ _ ⦂ _ ⊒ _
+        target-argument = R⊒W′
+
+        target-domain-cast :
+          ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dual t⊒ ∶ Aᵢ ⊒ A′
+        target-domain-cast =
+          let
+            cₜᵈ⊒L =
+              proj₁
+                (dualʷ-flips-typingᵐ
+                  dualActionOk-normal
+                  dualStoreAt-normal
+                  (leftStore-wf storesCast)
+                  (cₜ⊢L , cₜʷL)) ,
+              proj₂ (dualʷ normalᵃ cₜʷL)
+
+            cₜᵈ⊒R =
+              proj₁
+                (dualʷ-flips-typingᵐ
+                  dualActionOk-normal
+                  dualStoreAt-normal
+                  (rightStore-wf storesCast)
+                  (cₜ⊢R , cₜʷR)) ,
+              proj₂ (dualʷ normalᵃ cₜʷR)
+          in
+          storesCast ,
+          proj₁ (coercion-src-tgtᵐ (proj₁ cₜᵈ⊒L)) ,
+          proj₂ (coercion-src-tgtᵐ (proj₁ cₜᵈ⊒L)) ,
+          hAᵢ ,
+          hA′ ,
+          cₜᵈ⊒L ,
+          subst
+            (λ p₀ → ηCast ∣ ΔR ∣ rightStore ρ ⊢ p₀ ∶ Aᵢ ⊒ A′)
+            (dualʷ-raw-determined normalᵃ cₜʷR cₜʷL)
+            cₜᵈ⊒R
+
+        target-domain-dual-eq :
+          narrowing-dual target-domain-cast ≡ c
+        target-domain-dual-eq =
+          trans (dualʷ-involutive-raw cₜʷL) target-domain-eq
+
+        target-codomain-cast :
+          ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ d ∶ Bᵢ ⊒ B′
+        target-codomain-cast =
+          subst
+            (λ d₀ → ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ d₀ ∶ Bᵢ ⊒ B′)
+            target-codomain-eq
+            (separated-fun-codomain t⊒)
+
+        target-argument-cast :
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ R ⊒ W′ ⟨ c ⟩
+              ∶ fun-narrow-domain-dualᶜ pᶜ ⦂ _ ⊒ _
+        target-argument-cast =
+          subst
+            (λ c₀ →
+              ΔL ∣ ΔR ∣ ρ ∣ []
+                ⊢ R ⊒ W′ ⟨ c₀ ⟩
+                  ∶ fun-narrow-domain-dualᶜ pᶜ ⦂ _ ⊒ _)
+            target-domain-dual-eq
+            (⊒cast+ᵗ
+              (fun-narrow-domain-dual-typingᶜ pᶜ)
+              p-domainᶜ
+              target-domain-cast
+              R⊒W′)
+
+        inner-application :
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ L · R ⊒ F′ · (W′ ⟨ c ⟩)
+              ∶ qᵢ ⦂ _ ⊒ _
+        inner-application =
+          ·⊒·ᵗ pᶜ L⊒F′ target-argument-cast
+
+        target-result-cast :
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ L · R ⊒ (F′ · (W′ ⟨ c ⟩)) ⟨ d ⟩
+              ∶ _ ⦂ _ ⊒ _
+        target-result-cast =
+          ⊒cast-ᵗ
+            (fun-narrow-codomainᶜ pᶜ)
+            (separated-fun-codomain rᶜ)
+            target-codomain-cast
+            inner-application
+
+        obligation :
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ L · R ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ _ ⦂ _ ⊒ _
+        obligation =
+          subst
+            (λ F →
+              ΔL ∣ ΔR ∣ ρ ∣ []
+                ⊢ L · R ⊒ (F · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ _ ⦂ _ ⊒ _)
+            target-head-eq
+            target-result-cast
+      in
+      obligation
+  in
+  [] ,
+  L · R ,
+  ΔL ,
+  ρ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  relation-obligation
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = id A} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = t₁ ︔ t₂} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = `∀ t} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = G !} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = G ？} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = seal A α} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = unseal α A} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = gen A t} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast-ᵗ {t = inst A t} pᶜ rᶜ t⊒ L⊒F′)
+    () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast-ᵗ {M′ = F′} {p = id P}
+      {t = cₜ ↦ dₜ}
+      (_ , () , _ , _ , _ , (_ , cross (id-＇ α)) , _)
+      rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast-ᵗ {M′ = F′} {p = id P}
+      {t = cₜ ↦ dₜ}
+      (_ , () , _ , _ , _ , (_ , cross (id-‵ ι)) , _)
+      rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast-ᵗ {M′ = F′} {p = id P}
+      {t = cₜ ↦ dₜ}
+      (_ , () , _ , _ , _ , (_ , id★) , _)
+      rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast-ᵗ {M′ = F′} {p = p₀ ︔ p₁}
+      {t = cₜ ↦ dₜ}
+      (_ , () , _ , _ , _ , (_ , G ？︔ gⁿ) , _)
+      rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    vL noL vR noR vV′ vW′
+    targetCast@(⊒cast-ᵗ {M′ = F′} {p = p₀ ︔ p₁}
+      {t = cₜ ↦ dₜ}
+      (_ , _ , refl , _ , _ , (_ , gⁿ ︔seal α) , _)
+      rᶜ (_ , () , _ , _ , _ , _ , _) L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    with canonical-⇒ vL (typed-term-narrowing-source-typingᶜ sourceCast)
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-ƛ ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast+⊒ᵗ {M = F₀} {q = pᵢ ↦ qᵢ}
+      {r = pₒ ↦ qₒ} {s = c₀ ↦ d₀}
+      {A = Aₒ ⇒ Bₒ} {B = AR ⇒ BR} {C = AL ⇒ BL}
+      {μ = μOuter} {η = ηCast}
+      qInner
+      rOuter
+      sCast@(storesCast , _ , _ , wf⇒ hAₒs hBₒs ,
+        wf⇒ hALs hBLs ,
+        (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
+        (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ {W = F} {c = cₛ} {d = dₛ} vF L≡Fcd =
+  let
+    source-cast-shape : L ≡ F ⟨ cₛ ↦ dₛ ⟩
+    source-cast-shape = L≡Fcd
+
+    source-head-eq : F₀ ≡ F
+    source-head-eq = ⟨⟩-term-injective L≡Fcd
+
+    source-cast-eq : narrowing-dual sCast ≡ cₛ ↦ dₛ
+    source-cast-eq = ⟨⟩-coercion-injective L≡Fcd
+
+    source-domain-eq : ↦-domain (narrowing-dual sCast) ≡ cₛ
+    source-domain-eq = cong ↦-domain source-cast-eq
+
+    source-codomain-eq : ↦-codomain (narrowing-dual sCast) ≡ dₛ
+    source-codomain-eq = cong ↦-codomain source-cast-eq
+
+    source-head-no• : No• F
+    source-head-no• = no•-cast-inv (subst No• L≡Fcd noL)
+
+    source-head-step :
+      L · R —↠[ keep ∷ [] ] (F · (R ⟨ cₛ ⟩)) ⟨ dₛ ⟩
+    source-head-step =
+      subst
+        (λ H → H · R —↠[ keep ∷ [] ] (F · (R ⟨ cₛ ⟩)) ⟨ dₛ ⟩)
+        (sym L≡Fcd)
+        (↠-step (pure-step (β-↦ vF vR)) ↠-refl)
+
+    source-head-relation :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ F ⊒ T ∶ pᵢ ↦ qᵢ ⦂ AL ⇒ BL ⊒ AR ⇒ BR
+    source-head-relation =
+      subst
+        (λ F₁ →
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ F₁ ⊒ T ∶ pᵢ ↦ qᵢ ⦂ AL ⇒ BL ⊒ AR ⇒ BR)
+        source-head-eq
+        F₀⊒T
+
+    qₒ⊒ :
+      μOuter ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR
+    qₒ⊒ = separated-fun-codomain rOuter
+
+    d₀⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ d₀ ∶ Bₒ ⊒ BL
+    d₀⊒ =
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ d₀⊢L) ,
+      proj₂ (coercion-src-tgtᵐ d₀⊢L) ,
+      hBₒs ,
+      hBLs ,
+      (d₀⊢L , d₀ⁿL) ,
+      (d₀⊢R , d₀ⁿR)
+
+    d₀-dual-eq :
+      narrowing-dual d₀⊒ ≡ dₛ
+    d₀-dual-eq = source-codomain-eq
+
+    c₀-dual⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ
+        ⊢ proj₁ (dualʷ normalᵃ c₀ʷL) ∶ Aₒ ⊒ AL
+    c₀-dual⊒ =
+      let
+        c₀ᵈ⊒L =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (leftStore-wf storesCast)
+              (c₀⊢L , c₀ʷL)) ,
+          proj₂ (dualʷ normalᵃ c₀ʷL)
+
+        c₀ᵈ⊒R =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (rightStore-wf storesCast)
+              (c₀⊢R , c₀ʷR)) ,
+          proj₂ (dualʷ normalᵃ c₀ʷR)
+      in
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ (proj₁ c₀ᵈ⊒L)) ,
+      proj₂ (coercion-src-tgtᵐ (proj₁ c₀ᵈ⊒L)) ,
+      hAₒs ,
+      hALs ,
+      c₀ᵈ⊒L ,
+      subst
+        (λ c₁ → ηCast ∣ ΔR ∣ rightStore ρ ⊢ c₁ ∶ Aₒ ⊒ AL)
+        (dualʷ-raw-determined normalᵃ c₀ʷR c₀ʷL)
+        c₀ᵈ⊒R
+
+    cₛ⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ∶ Aₒ ⊒ AL
+    cₛ⊒ =
+      subst
+        (λ c₁ → ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ c₁ ∶ Aₒ ⊒ AL)
+        source-domain-eq
+        c₀-dual⊒
+
+    R-c⊒W′ :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ R ⟨ cₛ ⟩ ⊒ W′ ∶ fun-narrow-domain-dualᶜ qInner
+          ⦂ AL ⊒ AR
+    R-c⊒W′ =
+      cast-⊒ᵗ
+        (fun-narrow-domain-dual-typingᶜ qInner)
+        p-domainᶜ
+        cₛ⊒
+        R⊒W′
+
+    χsA , WRA , ΔLA ,
+      vWRA , noWRA , R-c↠WRA , ΔLA≡ , ρA-corr ,
+      leftA≡ , rightA≡ , pAᶜ , WRA⊒W′ =
+      catchup-lemmaˡ
+        (ok-⟨⟩ (ok-no noR))
+        vW′
+        R-c⊒W′
+
+    F-left⊒T =
+      advance-left-function-term-narrowing
+        χsA ΔLA≡ ρA-corr source-head-relation
+
+    arg-ready :
+      F · (R ⟨ cₛ ⟩) —↠[ χsA ] applyTerms χsA F · WRA
+    arg-ready = ·₂-↠ vF source-head-no• R-c↠WRA
+
+    cast-arg-ready :
+      (F · (R ⟨ cₛ ⟩)) ⟨ dₛ ⟩ —↠[ χsA ]
+        (applyTerms χsA F · WRA) ⟨ applyCoercions χsA dₛ ⟩
+    cast-arg-ready = cast-↠ {c = dₛ} arg-ready
+
+    prefix-ready :
+      L · R —↠[ keep ∷ χsA ]
+        (applyTerms χsA F · WRA) ⟨ applyCoercions χsA dₛ ⟩
+    prefix-ready = ↠-trans source-head-step cast-arg-ready
+
+    rec =
+      separated-dgg-beta-cast-value-shape
+        (applyTerms-preserves-Value χsA vF)
+        (applyTerms-preserves-No• χsA source-head-no•)
+        vWRA
+        noWRA
+        vV′
+        vW′
+        F-left⊒T
+        T≡V′cd
+        pAᶜ
+        WRA⊒W′
+
+    χsT , N , ΔLT , ρT ,
+      tail-red , ΔT≡ , ρT≡ , N⊒target = rec
+
+    tail-ready :
+      (applyTerms χsA F · WRA) ⟨ applyCoercions χsA dₛ ⟩
+        —↠[ χsT ]
+      N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+    tail-ready = cast-↠ {c = applyCoercions χsA dₛ} tail-red
+
+    source-steps :
+      L · R —↠[ (keep ∷ χsA) ++ χsT ]
+        N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+    source-steps = ↠-trans prefix-ready tail-ready
+
+    ΔLT-total≡ :
+      ΔLT ≡ applyTyCtxs ((keep ∷ χsA) ++ χsT) ΔL
+    ΔLT-total≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔLA≡)
+          (sym (applyTyCtxs-++ χsA χsT ΔL)))
+
+    ρT-total≡ :
+      ρT ≡ applyLeftChanges ((keep ∷ χsA) ++ χsT) ρ
+    ρT-total≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
+
+    final⊒ :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+          ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩
+          ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+          ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ BR
+    final⊒ =
+      separated-source-cast-plus-result
+        {ΔL = ΔL}
+        {ΔR = ΔR}
+        {ρ = ρ}
+        {ΔLA = ΔLA}
+        {ΔLT = ΔLT}
+        {ρT = ρT}
+        {Target = (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩}
+        {N = N}
+        {qᵢ = qᵢ}
+        {qₒ = qₒ}
+        {dₛ = d₀}
+        {d = dₛ}
+        {Bₒ = Bₒ}
+        {BL = BL}
+        {BR = BR}
+        {μq = μOuter}
+        {μd = ηCast}
+        {χsA = χsA}
+        {χsT = χsT}
+        (fun-narrow-codomainᶜ qInner)
+        qₒ⊒
+        d₀⊒
+        d₀-dual-eq
+        ΔLA≡
+        ρA-corr
+        ΔT≡
+        ρT≡
+        N⊒target
+  in
+  (keep ∷ χsA) ++ χsT ,
+  N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩ ,
+  ΔLT ,
+  ρT ,
+  source-steps ,
+  ΔLT-total≡ ,
+  ρT-total≡ ,
+  final⊒
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {q = pₒ ↦ qₒ} {r = pᵢ ↦ qᵢ}
+      {s = c₀ ↦ d₀} {A = AL ⇒ BL} {C = Aₒ ⇒ Bₒ}
+      {η = ηCast}
+      (storesOuter , _ , _ , wf⇒ hAₒ hBₒ , wf⇒ hAR hBR ,
+        (cast-fun _ qₒ⊢L , cross (_ ↦ⁿʷ qₒⁿL)) ,
+        (cast-fun _ qₒ⊢R , cross (_ ↦ⁿʷ qₒⁿR)))
+      rInner@(storesInner , _ , _ , wf⇒ hAL hBL , wf⇒ hARᵢ hBRᵢ ,
+        (cast-fun pᵢ⊢L _ , cross (pᵢʷL ↦ⁿʷ _)) ,
+        (cast-fun pᵢ⊢R _ , cross (pᵢʷR ↦ⁿʷ _)))
+      (storesCast , _ , _ , wf⇒ hALs hBLs , wf⇒ hAₒs hBₒs ,
+        (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
+        (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    with canonical-⇒ vL (typed-term-narrowing-source-typingᶜ sourceCast)
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {q = pₒ ↦ qₒ} {r = pᵢ ↦ qᵢ}
+      {s = c₀ ↦ d₀} {A = AL ⇒ BL} {C = Aₒ ⇒ Bₒ}
+      {η = ηCast}
+      (storesOuter , _ , _ , wf⇒ hAₒ hBₒ , wf⇒ hAR hBR ,
+        (cast-fun _ qₒ⊢L , cross (_ ↦ⁿʷ qₒⁿL)) ,
+        (cast-fun _ qₒ⊢R , cross (_ ↦ⁿʷ qₒⁿR)))
+      rInner@(storesInner , _ , _ , wf⇒ hAL hBL , wf⇒ hARᵢ hBRᵢ ,
+        (cast-fun pᵢ⊢L _ , cross (pᵢʷL ↦ⁿʷ _)) ,
+        (cast-fun pᵢ⊢R _ , cross (pᵢʷR ↦ⁿʷ _)))
+      (storesCast , _ , _ , wf⇒ hALs hBLs , wf⇒ hAₒs hBₒs ,
+        (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
+        (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-ƛ ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {q = pₒ ↦ qₒ} {r = pᵢ ↦ qᵢ}
+      {s = c₀ ↦ d₀} {A = AL ⇒ BL} {C = Aₒ ⇒ Bₒ}
+      {η = ηCast}
+      (storesOuter , _ , _ , wf⇒ hAₒ hBₒ , wf⇒ hAR hBR ,
+        (cast-fun _ qₒ⊢L , cross (_ ↦ⁿʷ qₒⁿL)) ,
+        (cast-fun _ qₒ⊢R , cross (_ ↦ⁿʷ qₒⁿR)))
+      rInner@(storesInner , _ , _ , wf⇒ hAL hBL , wf⇒ hARᵢ hBRᵢ ,
+        (cast-fun pᵢ⊢L _ , cross (pᵢʷL ↦ⁿʷ _)) ,
+        (cast-fun pᵢ⊢R _ , cross (pᵢʷR ↦ⁿʷ _)))
+      (storesCast , _ , _ , wf⇒ hALs hBLs , wf⇒ hAₒs hBₒs ,
+        (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
+        (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ {W = F} {c = cₛ} {d = dₛ} vF L≡Fcd =
+  let
+    source-head-eq : F₀ ≡ F
+    source-head-eq = ⟨⟩-term-injective L≡Fcd
+
+    source-cast-eq : c₀ ↦ d₀ ≡ cₛ ↦ dₛ
+    source-cast-eq = ⟨⟩-coercion-injective L≡Fcd
+
+    source-domain-eq : c₀ ≡ cₛ
+    source-domain-eq = ↦-left-injective source-cast-eq
+
+    source-codomain-eq : d₀ ≡ dₛ
+    source-codomain-eq = ↦-right-injective source-cast-eq
+
+    source-head-no• : No• F
+    source-head-no• = no•-cast-inv (subst No• L≡Fcd noL)
+
+    source-head-step :
+      L · R —↠[ keep ∷ [] ] (F · (R ⟨ cₛ ⟩)) ⟨ dₛ ⟩
+    source-head-step =
+      subst
+        (λ H → H · R —↠[ keep ∷ [] ] (F · (R ⟨ cₛ ⟩)) ⟨ dₛ ⟩)
+        (sym L≡Fcd)
+        (↠-step (pure-step (β-↦ vF vR)) ↠-refl)
+
+    source-head-relation :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ F ⊒ T ∶ pᵢ ↦ qᵢ ⦂ AL ⇒ BL ⊒ _ ⇒ _
+    source-head-relation =
+      subst
+        (λ F₁ →
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ F₁ ⊒ T ∶ pᵢ ↦ qᵢ ⦂ AL ⇒ BL ⊒ _ ⇒ _)
+        source-head-eq
+        F₀⊒T
+
+    qₒ⊒ :
+      tag-or-idᵈ ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ _
+    qₒ⊒ =
+      storesOuter ,
+      proj₁ (coercion-src-tgtᵐ qₒ⊢L) ,
+      proj₂ (coercion-src-tgtᵐ qₒ⊢L) ,
+      hBₒ ,
+      hBR ,
+      (qₒ⊢L , qₒⁿL) ,
+      (qₒ⊢R , qₒⁿR)
+
+    d₀⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ d₀ ∶ BL ⊒ Bₒ
+    d₀⊒ =
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ d₀⊢L) ,
+      proj₂ (coercion-src-tgtᵐ d₀⊢L) ,
+      hBLs ,
+      hBₒs ,
+      (d₀⊢L , d₀ⁿL) ,
+      (d₀⊢R , d₀ⁿR)
+
+    dₛ⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ dₛ ∶ BL ⊒ Bₒ
+    dₛ⊒ =
+      subst
+        (λ d₁ → ηCast ∣ ΔL ∣ ΔR ∣ ρ ⊢ d₁ ∶ BL ⊒ Bₒ)
+        source-codomain-eq
+        d₀⊒
+
+    pᵢ-domain⊒ :
+      _ ∣ ΔL ∣ ΔR ∣ ρ
+        ⊢ fun-narrow-domain-dual rInner ∶ AL ⊒ _
+    pᵢ-domain⊒ = separated-fun-domain-dual rInner
+
+    c-dual⊒ :
+      ηCast ∣ ΔL ∣ ΔR ∣ ρ
+        ⊢ proj₁ (dualʷ normalᵃ c₀ʷL) ∶ AL ⊒ Aₒ
+    c-dual⊒ =
+      let
+        cᵈ⊒L =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (leftStore-wf storesCast)
+              (c₀⊢L , c₀ʷL)) ,
+          proj₂ (dualʷ normalᵃ c₀ʷL)
+
+        cᵈ⊒R =
+          proj₁
+            (dualʷ-flips-typingᵐ
+              dualActionOk-normal
+              dualStoreAt-normal
+              (rightStore-wf storesCast)
+              (c₀⊢R , c₀ʷR)) ,
+          proj₂ (dualʷ normalᵃ c₀ʷR)
+      in
+      storesCast ,
+      proj₁ (coercion-src-tgtᵐ (proj₁ cᵈ⊒L)) ,
+      proj₂ (coercion-src-tgtᵐ (proj₁ cᵈ⊒L)) ,
+      hALs ,
+      hAₒs ,
+      cᵈ⊒L ,
+      subst
+        (λ c₁ → ηCast ∣ ΔR ∣ rightStore ρ ⊢ c₁ ∶ AL ⊒ Aₒ)
+        (dualʷ-raw-determined normalᵃ c₀ʷR c₀ʷL)
+        cᵈ⊒R
+
+    c-dual-eq :
+      narrowing-dual c-dual⊒ ≡ cₛ
+    c-dual-eq = trans (dualʷ-involutive-raw c₀ʷL) source-domain-eq
+
+    R-c⊒W′ :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ R ⟨ cₛ ⟩ ⊒ W′ ∶ fun-narrow-domain-dual rInner
+          ⦂ AL ⊒ _
+    R-c⊒W′ =
+      subst
+        (λ c₁ →
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ R ⟨ c₁ ⟩ ⊒ W′ ∶ fun-narrow-domain-dual rInner
+              ⦂ AL ⊒ _)
+        c-dual-eq
+        (cast+⊒ᵗ p-domainᶜ pᵢ-domain⊒ c-dual⊒ R⊒W′)
+
+    χsA , WRA , ΔLA ,
+      vWRA , noWRA , R-c↠WRA , ΔLA≡ , ρA-corr ,
+      leftA≡ , rightA≡ , pAᶜ , WRA⊒W′ =
+      catchup-lemmaˡ
+        (ok-⟨⟩ (ok-no noR))
+        vW′
+        R-c⊒W′
+
+    F-left⊒T =
+      advance-left-function-term-narrowing
+        χsA ΔLA≡ ρA-corr source-head-relation
+
+    arg-ready :
+      F · (R ⟨ cₛ ⟩) —↠[ χsA ] applyTerms χsA F · WRA
+    arg-ready = ·₂-↠ vF source-head-no• R-c↠WRA
+
+    cast-arg-ready :
+      (F · (R ⟨ cₛ ⟩)) ⟨ dₛ ⟩ —↠[ χsA ]
+        (applyTerms χsA F · WRA) ⟨ applyCoercions χsA dₛ ⟩
+    cast-arg-ready = cast-↠ {c = dₛ} arg-ready
+
+    prefix-ready :
+      L · R —↠[ keep ∷ χsA ]
+        (applyTerms χsA F · WRA) ⟨ applyCoercions χsA dₛ ⟩
+    prefix-ready = ↠-trans source-head-step cast-arg-ready
+
+    rec =
+      separated-dgg-beta-cast-value-shape
+        (applyTerms-preserves-Value χsA vF)
+        (applyTerms-preserves-No• χsA source-head-no•)
+        vWRA
+        noWRA
+        vV′
+        vW′
+        F-left⊒T
+        T≡V′cd
+        pAᶜ
+        WRA⊒W′
+
+    χsT , N , ΔLT , ρT ,
+      tail-red , ΔT≡ , ρT≡ , N⊒target = rec
+
+    tail-ready :
+      (applyTerms χsA F · WRA) ⟨ applyCoercions χsA dₛ ⟩
+        —↠[ χsT ]
+      N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+    tail-ready = cast-↠ {c = applyCoercions χsA dₛ} tail-red
+
+    source-steps :
+      L · R —↠[ (keep ∷ χsA) ++ χsT ]
+        N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+    source-steps = ↠-trans prefix-ready tail-ready
+
+    ΔLT-total≡ :
+      ΔLT ≡ applyTyCtxs ((keep ∷ χsA) ++ χsT) ΔL
+    ΔLT-total≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔLA≡)
+          (sym (applyTyCtxs-++ χsA χsT ΔL)))
+
+    ρT-total≡ :
+      ρT ≡ applyLeftChanges ((keep ∷ χsA) ++ χsT) ρ
+    ρT-total≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
+
+    final⊒ :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+          ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩
+          ∶ applyCoercions ((keep ∷ χsA) ++ χsT) qₒ
+          ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ _
+    final⊒ =
+      let
+        μN , nᶜ = typed-term-narrowing-coercion N⊒target
+
+        ρT-corr :
+          StoreCorr ΔLT ΔR
+            (applyLeftChanges χsT (applyLeftChanges χsA ρ))
+        ρT-corr =
+          subst (StoreCorr ΔLT ΔR)
+            ρT≡
+            (narrowing-store-corrᶜ {μ = μN} nᶜ)
+
+        qₒ⊒A =
+          left-change-coercion-narrowing χsA {μ = tag-or-idᵈ}
+            ΔLA≡ ρA-corr qₒ⊒
+
+        qₒ⊒T =
+          left-change-coercion-narrowing χsT {μ = tag-or-idᵈ}
+            ΔT≡ ρT-corr qₒ⊒A
+
+        qₒ⊒Tρ =
+          subst
+            (λ ρ₀ →
+              tag-or-idᵈ ∣ ΔLT ∣ ΔR ∣ ρ₀
+                ⊢ applyCoercions χsT (applyCoercions χsA qₒ)
+                  ∶ _ ⊒ _)
+            (sym ρT≡)
+            qₒ⊒T
+
+        dₛ⊒A =
+          left-change-source-coercion-narrowing χsA {μ = ηCast}
+            ΔLA≡ ρA-corr dₛ⊒
+
+        dₛ⊒T =
+          left-change-source-coercion-narrowing χsT {μ = ηCast}
+            ΔT≡ ρT-corr dₛ⊒A
+
+        dₛ⊒Tρ =
+          subst
+            (λ ρ₀ →
+              ηCast ∣ ΔLT ∣ ΔR ∣ ρ₀
+                ⊢ applyCoercions χsT (applyCoercions χsA dₛ)
+                  ∶ applyTys χsT (applyTys χsA BL)
+                  ⊒ applyTys χsT (applyTys χsA Bₒ))
+            (sym ρT≡)
+            dₛ⊒T
+        casted :
+          ΔLT ∣ ΔR ∣ ρT ∣ []
+            ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+              ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩
+              ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+              ⦂ applyTys χsT (applyTys χsA Bₒ) ⊒ _
+        casted =
+          cast-⊒ᵗ {μ = μN} {η = ηCast}
+            qₒ⊒Tρ
+            nᶜ
+            dₛ⊒Tρ
+            N⊒target
+      in
+      subst
+        (λ qT →
+          ΔLT ∣ ΔR ∣ ρT ∣ []
+            ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+              ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ qT
+              ⦂ applyTys ((keep ∷ χsA) ++ χsT) Bₒ ⊒ _)
+        (sym (applyCoercions-++ χsA χsT qₒ))
+        (subst
+          (λ BT →
+            ΔLT ∣ ΔR ∣ ρT ∣ []
+              ⊢ N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+                ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩
+                ∶ applyCoercions χsT (applyCoercions χsA qₒ)
+                ⦂ BT ⊒ _)
+          (sym (applyTys-++ χsA χsT Bₒ))
+          casted)
+  in
+  (keep ∷ χsA) ++ χsT ,
+  N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩ ,
+  ΔLT ,
+  ρT ,
+  source-steps ,
+  ΔLT-total≡ ,
+  ρT-total≡ ,
+  final⊒
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    with canonical-⇒ vL (typed-term-narrowing-source-typingᶜ sourceCast)
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-ƛ ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = id A} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s₁ ︔ s₂} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = `∀ s} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = G !} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = G ？} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = seal A α} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = unseal α A} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = gen A s} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = inst A s} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF ()
+
+separated-dgg-beta-cast-value :
+  ∀ {ΔL ΔR ρ L R V′ W′ c d pᵈ p q A A′ B B′} →
+  Value L →
+  No• L →
+  Value R →
+  No• R →
+  Value V′ →
+  Value W′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ V′ ⟨ c ↦ d ⟩ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
+separated-dgg-beta-cast-value
+    vL noL vR noR vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  let
+    χs , N , ΔL′ , ρ′ ,
+      red , ΔL′≡ , ρ′≡ , N⊒target =
+      separated-dgg-beta-cast-value-shape
+        vL noL vR noR vV′ vW′ L⊒V′cd refl p-domainᶜ R⊒W′
+  in
+  χs ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  _ ,
+  _ ,
+  _ ,
+  red ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒target
+
+separated-dgg-beta-cast-left-first :
+  ∀ {ΔL ΔR ρ L R V′ W′ c d pᵈ p q A A′ B B′} →
+  RuntimeOK L →
+  RuntimeOK R →
+  No• R →
+  Value V′ →
+  Value W′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ V′ ⟨ c ↦ d ⟩ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
+separated-dgg-beta-cast-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {B = B} {B′ = B′}
+    okL okR noR-ready vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  let
+    χsL , WL , ΔL₁ ,
+      vWL , noWL , L↠WL , ΔL₁≡ , ρL-corr ,
+      leftL≡ , rightL≡ , p₁ᶜ , WL⊒V′cdraw =
+      catchup-lemmaˡ
+        okL
+        (vV′ ⟨ c ↦ d ⟩)
+        L⊒V′cd
+
+    WL⊒V′cd :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ WL ⊒ V′ ⟨ c ↦ d ⟩
+          ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+          ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+    WL⊒V′cd =
+      subst
+        (λ pc →
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ V′ ⟨ c ↦ d ⟩ ∶ pc
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′)
+        (applyCoercions-↦ χsL p q)
+        (subst
+          (λ C →
+            ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+              ⊢ WL ⊒ V′ ⟨ c ↦ d ⟩
+                ∶ applyCoercions χsL (p ↦ q) ⦂ C ⊒ A′ ⇒ B′)
+          (applyTys-⇒ χsL A B)
+          WL⊒V′cdraw)
+
+    R⊒W′L =
+      advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒W′
+
+    χsR , WR , ΔL₂ ,
+      vWR , noWR , R↠WR , ΔL₂≡ , ρR-corr ,
+      leftR≡ , rightR≡ , p₂ᶜ , WR⊒W′ =
+      catchup-lemmaˡ
+        (applyTerms-preserves-RuntimeOK χsL okR)
+        vW′
+        R⊒W′L
+
+    WLF⊒V′cd =
+      advance-left-function-term-narrowing χsR ΔL₂≡ ρR-corr
+        WL⊒V′cd
+
+    left-ready :
+      L · R —↠[ χsL ] WL · applyTerms χsL R
+    left-ready = ·₁-↠ noR-ready L↠WL
+
+    right-ready :
+      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · WR
+    right-ready = ·₂-↠ vWL noWL R↠WR
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+        (applyTerms χsR WL · WR —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL₂) ×
+        (ρ′ ≡
+          applyLeftChanges χs (applyLeftChanges χsR
+            (applyLeftChanges χsL ρ))) ×
+        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+          ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
+    tail =
+      separated-dgg-beta-cast-value
+        (applyTerms-preserves-Value χsR vWL)
+        (applyTerms-preserves-No• χsR noWL)
+        vWR
+        noWR
+        vV′
+        vW′
+        WLF⊒V′cd
+        p₂ᶜ
+        WR⊒W′
+  in
+  let
+    χsT , N , ΔL′ , ρ′ , C , D , r ,
+      tail-red , ΔT≡ , ρT≡ , N⊒target = tail
+
+    source-steps :
+      L · R —↠[ (χsL ++ χsR) ++ χsT ] N
+    source-steps = ↠-trans (↠-trans left-ready right-ready) tail-red
+
+    ΔL′≡ :
+      ΔL′ ≡ applyTyCtxs ((χsL ++ χsR) ++ χsT) ΔL
+    ΔL′≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔL₂≡)
+          (trans
+            (cong (λ Δ → applyTyCtxs χsT (applyTyCtxs χsR Δ))
+              ΔL₁≡)
+            (sym
+              (trans
+                (applyTyCtxs-++ (χsL ++ χsR) χsT ΔL)
+                (cong (applyTyCtxs χsT)
+                  (applyTyCtxs-++ χsL χsR ΔL))))))
+
+    ρ′≡ :
+      ρ′ ≡ applyLeftChanges ((χsL ++ χsR) ++ χsT) ρ
+    ρ′≡ =
+      trans ρT≡
+        (sym
+          (trans
+            (applyLeftChanges-++ (χsL ++ χsR) χsT ρ)
+            (cong (applyLeftChanges χsT)
+              (applyLeftChanges-++ χsL χsR ρ))))
+  in
+  (χsL ++ χsR) ++ χsT ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒target
+
+separated-dgg-beta-cast-right-first :
+  ∀ {ΔL ΔR ρ L R V′ W′ c d pᵈ p q A A′ B B′} →
+  Value L →
+  No• L →
+  RuntimeOK R →
+  Value V′ →
+  Value W′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ V′ ⟨ c ↦ d ⟩ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
+separated-dgg-beta-cast-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
+    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {B = B} {B′ = B′}
+    vL noL okR vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  let
+    χsR , WR , ΔL₁ ,
+      vWR , noWR , R↠WR , ΔL₁≡ , ρR-corr ,
+      leftR≡ , rightR≡ , p₁ᶜ , WR⊒W′ =
+      catchup-lemmaˡ
+        okR
+        vW′
+        R⊒W′
+
+    LF⊒V′cd =
+      advance-left-function-term-narrowing χsR ΔL₁≡ ρR-corr L⊒V′cd
+
+    ready :
+      L · R —↠[ χsR ] applyTerms χsR L · WR
+    ready = ·₂-↠ vL noL R↠WR
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+        (applyTerms χsR L · WR —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL₁) ×
+        (ρ′ ≡ applyLeftChanges χs (applyLeftChanges χsR ρ)) ×
+        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+          ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
+    tail =
+      separated-dgg-beta-cast-value
+        (applyTerms-preserves-Value χsR vL)
+        (applyTerms-preserves-No• χsR noL)
+        vWR
+        noWR
+        vV′
+        vW′
+        LF⊒V′cd
+        p₁ᶜ
+        WR⊒W′
+  in
+  let
+    χsT , N , ΔL′ , ρ′ , C , D , r ,
+      tail-red , ΔT≡ , ρT≡ , N⊒target = tail
+
+    source-steps :
+      L · R —↠[ χsR ++ χsT ] N
+    source-steps = ↠-trans ready tail-red
+
+    ΔL′≡ :
+      ΔL′ ≡ applyTyCtxs (χsR ++ χsT) ΔL
+    ΔL′≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsR χsT ΔL)))
+
+    ρ′≡ :
+      ρ′ ≡ applyLeftChanges (χsR ++ χsT) ρ
+    ρ′≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsR χsT ρ))
+  in
+  χsR ++ χsT ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒target
+
+separated-dgg-beta-cast :
+  ∀ {ΔL ΔR ρ L R V′ W′ c d pᵈ p q A A′ B B′} →
+  RuntimeOK (L · R) →
+  Value V′ →
+  Value W′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ V′ ⟨ c ↦ d ⟩ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ W′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
+separated-dgg-beta-cast okLR@(ok-no (no•-· noL noR))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-left-first
+    (ok-no noL) (ok-no noR) noR vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast okLR@(ok-·₁ okL noR)
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-left-first
+    okL (ok-no noR) noR vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast okLR@(ok-·₂ vL noL (ok-no noR))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-left-first
+    (ok-no noL) (ok-no noR) noR vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-• vV noV))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-• vV noV) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-·₁ okR₁ noR₂))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-·₁ okR₁ noR₂) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-·₂ vR₁ noR₁ okR₂))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-·₂ vR₁ noR₁ okR₂) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-ν okR))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-ν okR) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-⊕₁ okR₁ noR₂))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-⊕₁ okR₁ noR₂) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-⊕₂ vR₁ noR₁ okR₂))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-⊕₂ vR₁ noR₁ okR₂) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast (ok-·₂ vL noL (ok-⟨⟩ okR))
+    vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′ =
+  separated-dgg-beta-cast-right-first
+    vL noL (ok-⟨⟩ okR) vV′ vW′ L⊒V′cd p-domainᶜ R⊒W′

--- a/GTSF/proof/DGGBetaSeparated.agda
+++ b/GTSF/proof/DGGBetaSeparated.agda
@@ -1,0 +1,425 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.DGGBetaSeparated where
+
+-- File Charter:
+--   * Separated-store DGG helpers for application beta steps.
+--   * Packages catchup on the source function/argument with sim-beta.
+--   * Exported by proof.DynamicGradualGuaranteeSeparated for the main DGG.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Nat using (_+_)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import NarrowWiden using
+  ( cross
+  ; dualʷ
+  ; id★
+  ; id-＇
+  ; id-‵
+  ; _？︔_
+  ; _︔seal_
+  ; _∣_∣_⊢_∶_⊒_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
+open import Primitives using (addℕ; κℕ)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyLeftChanges-++
+  ; applyRightChange
+  ; catchup-lemmaˡ
+  )
+open import proof.NuPreservation using (runtime-⟨⟩)
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualʷ-flips-typingᵐ
+  )
+open import proof.ReductionProperties using
+  ( applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyCoercions
+  ; applyCoercions-++
+  ; applyCoercions-dual
+  ; applyTys-++
+  ; applyTys-ℕ
+  ; applyTys-ℕ-applyTys
+  ; applyTyCtxs-++
+  ; ↠-trans
+  ; cast-↠
+  ; ·₁-↠
+  ; ·₂-↠
+  ; ⊕₁-↠
+  ; ⊕₂-↠
+  )
+open import proof.SimBetaSeparated using
+  ( applyTerms-preserves-RuntimeOK
+  ; applyTys-⇒
+  ; applyCoercions-↦
+  ; applyCoercions-dual-applyCoercions
+  ; no•-cast-inv
+  ; ⟨⟩-term-injective
+  ; ⟨⟩-coercion-injective
+  ; left-change-coercion-narrowing
+  ; left-change-source-coercion-narrowing
+  ; advance-left-term-narrowing
+  ; advance-left-function-term-narrowing
+  ; advance-left-lambda-narrowing
+  ; widen-fun-domainᵐ
+  ; separated-fun-domain-dual
+  ; separated-fun-codomain
+  ; separated-left-coercionᵐ
+  ; separated-right-coercionᵐ
+  ; ↦-domain
+  ; ↦-codomain
+  ; ↦-left-injective
+  ; ↦-right-injective
+  ; dualʷ-raw-determined
+  ; dualʷ-involutive-raw
+  ; sim-beta
+  )
+open import proof.NuProgress using
+  (FunView; fv-ƛ; fv-↦; canonical-⇒)
+open import proof.DGGPrimitiveSeparated using
+  ( id-ℕ-narrowingᶜ
+  ; applyCoercions-id-ℕ
+  ; applyCoercions-id-ℕ-applyCoercions
+  ; source-nat-typingᶜ
+  ; typed-term-narrowing-endpointsᶜ
+  ; typed-term-narrowing-coercion-endpointsᶜ
+  ; constant-⊕-δ-step
+  ; const-narrowing-targetᶜ
+  ; value-id-ℕ-narrowing-target-constᶜ
+  ; value-normalized-id-ℕ-target-constᶜ
+  )
+------------------------------------------------------------------------
+-- Application beta caller
+------------------------------------------------------------------------
+
+separated-dgg-beta-left-first :
+  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  RuntimeOK L →
+  RuntimeOK R →
+  No• R →
+  Value V′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
+separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {N′ = N′} {V′ = V′}
+    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {B = B} {B′ = B′}
+    okL okR noR-ready vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  let
+    χsL , WL , ΔL₁ ,
+      vWL , noWL , L↠WL , ΔL₁≡ , ρL-corr ,
+      leftL≡ , rightL≡ , p₁ᶜ , WL⊒ƛraw =
+      catchup-lemmaˡ
+        okL
+        (ƛ N′)
+        L⊒ƛ
+
+    WL⊒ƛ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ WL ⊒ ƛ N′
+          ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+          ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+    WL⊒ƛ =
+      subst
+        (λ c →
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ ƛ N′ ∶ c
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′)
+        (applyCoercions-↦ χsL p q)
+        (subst
+          (λ C →
+            ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+              ⊢ WL ⊒ ƛ N′ ∶ applyCoercions χsL (p ↦ q)
+                ⦂ C ⊒ A′ ⇒ B′)
+          (applyTys-⇒ χsL A B)
+          WL⊒ƛraw)
+
+    R⊒V′L =
+      advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒V′
+
+    χsR , WR , ΔL₂ ,
+      vWR , noWR , R↠WR , ΔL₂≡ , ρR-corr ,
+      leftR≡ , rightR≡ , p₂ᶜ , WR⊒V′raw =
+      catchup-lemmaˡ
+        (applyTerms-preserves-RuntimeOK χsL okR)
+        vV′
+        R⊒V′L
+
+    WLF⊒ƛ =
+      advance-left-lambda-narrowing χsR ΔL₂≡ ρR-corr WL⊒ƛ
+
+    WR⊒V′ :
+      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ) ∣ []
+        ⊢ WR ⊒ V′
+          ∶ applyCoercions χsR (applyCoercions χsL pᵈ)
+          ⦂ applyTys χsR (applyTys χsL A) ⊒ A′
+    WR⊒V′ = WR⊒V′raw
+
+    p₂-domainᶜ :
+      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ)
+        ⊢ applyCoercions χsR (applyCoercions χsL pᵈ)
+          ∶ᶜ applyTys χsR (applyTys χsL A) ⊒ A′
+    p₂-domainᶜ = p₂ᶜ
+
+    left-ready :
+      L · R —↠[ χsL ] WL · applyTerms χsL R
+    left-ready = ·₁-↠ noR-ready L↠WL
+
+    right-ready :
+      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · WR
+    right-ready = ·₂-↠ vWL noWL R↠WR
+
+    ready :
+      ∃[ χs₀ ] (L · R —↠[ χs₀ ] applyTerms χsR WL · WR)
+    ready = χsL ++ χsR , ↠-trans left-ready right-ready
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+        (applyTerms χsR WL · WR —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL₂) ×
+        (ρ′ ≡
+          applyLeftChanges χs (applyLeftChanges χsR
+            (applyLeftChanges χsL ρ))) ×
+        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+          ⊢ N ⊒ N′ [ V′ ]
+            ∶ applyCoercions χs
+                (applyCoercions χsR (applyCoercions χsL q))
+            ⦂ applyTys χs (applyTys χsR (applyTys χsL B)) ⊒ B′
+    tail =
+      sim-beta
+        WLF⊒ƛ
+        (applyTerms-preserves-Value χsR vWL)
+        (applyTerms-preserves-No• χsR noWL)
+        WR⊒V′
+        p₂-domainᶜ
+        vWR
+        noWR
+        vV′
+  in
+  let
+    χsT , N , ΔL′ , ρ′ ,
+      tail-red , ΔT≡ , ρT≡ , N⊒N′[V′] = tail
+
+    source-steps :
+      L · R —↠[ (χsL ++ χsR) ++ χsT ] N
+    source-steps = ↠-trans (↠-trans left-ready right-ready) tail-red
+
+    ΔL′≡ :
+      ΔL′ ≡ applyTyCtxs ((χsL ++ χsR) ++ χsT) ΔL
+    ΔL′≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔL₂≡)
+          (trans
+            (cong (λ Δ → applyTyCtxs χsT (applyTyCtxs χsR Δ))
+              ΔL₁≡)
+            (sym
+              (trans
+                (applyTyCtxs-++ (χsL ++ χsR) χsT ΔL)
+                (cong (applyTyCtxs χsT)
+                  (applyTyCtxs-++ χsL χsR ΔL))))))
+
+    ρ′≡ :
+      ρ′ ≡ applyLeftChanges ((χsL ++ χsR) ++ χsT) ρ
+    ρ′≡ =
+      trans ρT≡
+        (sym
+          (trans
+            (applyLeftChanges-++ (χsL ++ χsR) χsT ρ)
+            (cong (applyLeftChanges χsT)
+              (applyLeftChanges-++ χsL χsR ρ))))
+  in
+  (χsL ++ χsR) ++ χsT ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  _ ,
+  _ ,
+  _ ,
+  source-steps ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒N′[V′]
+
+separated-dgg-beta-right-first :
+  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  Value L →
+  No• L →
+  RuntimeOK R →
+  Value V′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
+separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {N′ = N′} {V′ = V′}
+    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {B = B} {B′ = B′}
+    vL noL okR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  let
+    χsR , WR , ΔL₁ ,
+      vWR , noWR , R↠WR , ΔL₁≡ , ρR-corr ,
+      leftR≡ , rightR≡ , p₁ᶜ , WR⊒V′raw =
+      catchup-lemmaˡ
+        okR
+        vV′
+        R⊒V′
+
+    LF⊒ƛ =
+      advance-left-lambda-narrowing χsR ΔL₁≡ ρR-corr L⊒ƛ
+
+    WR⊒V′ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ ∣ []
+        ⊢ WR ⊒ V′
+          ∶ applyCoercions χsR pᵈ ⦂ applyTys χsR A ⊒ A′
+    WR⊒V′ = WR⊒V′raw
+
+    p₁-domainᶜ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ
+        ⊢ applyCoercions χsR pᵈ ∶ᶜ applyTys χsR A ⊒ A′
+    p₁-domainᶜ = p₁ᶜ
+
+    ready :
+      L · R —↠[ χsR ] applyTerms χsR L · WR
+    ready = ·₂-↠ vL noL R↠WR
+
+    tail :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
+        (applyTerms χsR L · WR —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL₁) ×
+        (ρ′ ≡ applyLeftChanges χs (applyLeftChanges χsR ρ)) ×
+        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+          ⊢ N ⊒ N′ [ V′ ]
+            ∶ applyCoercions χs (applyCoercions χsR q)
+            ⦂ applyTys χs (applyTys χsR B) ⊒ B′
+    tail =
+      sim-beta
+        LF⊒ƛ
+        (applyTerms-preserves-Value χsR vL)
+        (applyTerms-preserves-No• χsR noL)
+        WR⊒V′
+        p₁-domainᶜ
+        vWR
+        noWR
+        vV′
+  in
+  let
+    χsT , N , ΔL′ , ρ′ ,
+      tail-red , ΔT≡ , ρT≡ , N⊒N′[V′] = tail
+
+    source-steps :
+      L · R —↠[ χsR ++ χsT ] N
+    source-steps = ↠-trans ready tail-red
+
+    ΔL′≡ :
+      ΔL′ ≡ applyTyCtxs (χsR ++ χsT) ΔL
+    ΔL′≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsR χsT ΔL)))
+
+    ρ′≡ :
+      ρ′ ≡ applyLeftChanges (χsR ++ χsT) ρ
+    ρ′≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsR χsT ρ))
+  in
+  χsR ++ χsT ,
+  N ,
+  ΔL′ ,
+  ρ′ ,
+  _ ,
+  _ ,
+  _ ,
+  source-steps ,
+  ΔL′≡ ,
+  ρ′≡ ,
+  N⊒N′[V′]
+
+separated-dgg-beta :
+  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  RuntimeOK (L · R) →
+  Value V′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (L · R —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
+separated-dgg-beta okLR@(ok-no (no•-· noL noR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-left-first
+    (ok-no noL) (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta okLR@(ok-·₁ okL noR)
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-left-first
+    okL (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta okLR@(ok-·₂ vL noL (ok-no noR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-left-first
+    (ok-no noL) (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-• vV noV))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-• vV noV) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-·₁ okR₁ noR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-·₁ okR₁ noR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-·₂ vR₁ noR₁ okR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-·₂ vR₁ noR₁ okR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-ν okR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-ν okR) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-⊕₁ okR₁ noR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-⊕₁ okR₁ noR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-⊕₂ vR₁ noR₁ okR₂))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-⊕₂ vR₁ noR₁ okR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+separated-dgg-beta (ok-·₂ vL noL (ok-⟨⟩ okR))
+    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
+  separated-dgg-beta-right-first
+    vL noL (ok-⟨⟩ okR) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′

--- a/GTSF/proof/DGGDeltaSeparated.agda
+++ b/GTSF/proof/DGGDeltaSeparated.agda
@@ -1,0 +1,374 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.DGGDeltaSeparated where
+
+-- File Charter:
+--   * Separated-store DGG helpers for primitive addition delta steps.
+--   * Packages operand catchup and constant delta reduction.
+--   * Exported by proof.DynamicGradualGuaranteeSeparated for the main DGG.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Nat using (_+_)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import NarrowWiden using
+  ( cross
+  ; dualʷ
+  ; id★
+  ; id-＇
+  ; id-‵
+  ; _？︔_
+  ; _︔seal_
+  ; _∣_∣_⊢_∶_⊒_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
+open import Primitives using (addℕ; κℕ)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyLeftChanges-++
+  ; applyRightChange
+  ; catchup-lemmaˡ
+  )
+open import proof.NuPreservation using (runtime-⟨⟩)
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualʷ-flips-typingᵐ
+  )
+open import proof.ReductionProperties using
+  ( applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyCoercions
+  ; applyCoercions-++
+  ; applyCoercions-dual
+  ; applyTys-++
+  ; applyTys-ℕ
+  ; applyTys-ℕ-applyTys
+  ; applyTyCtxs-++
+  ; ↠-trans
+  ; cast-↠
+  ; ·₁-↠
+  ; ·₂-↠
+  ; ⊕₁-↠
+  ; ⊕₂-↠
+  )
+open import proof.SimBetaSeparated using
+  ( applyTerms-preserves-RuntimeOK
+  ; applyTys-⇒
+  ; applyCoercions-↦
+  ; applyCoercions-dual-applyCoercions
+  ; no•-cast-inv
+  ; ⟨⟩-term-injective
+  ; ⟨⟩-coercion-injective
+  ; left-change-coercion-narrowing
+  ; left-change-source-coercion-narrowing
+  ; advance-left-term-narrowing
+  ; advance-left-function-term-narrowing
+  ; advance-left-lambda-narrowing
+  ; widen-fun-domainᵐ
+  ; separated-fun-domain-dual
+  ; separated-fun-codomain
+  ; separated-left-coercionᵐ
+  ; separated-right-coercionᵐ
+  ; ↦-domain
+  ; ↦-codomain
+  ; ↦-left-injective
+  ; ↦-right-injective
+  ; dualʷ-raw-determined
+  ; dualʷ-involutive-raw
+  ; sim-beta
+  )
+open import proof.NuProgress using
+  (FunView; fv-ƛ; fv-↦; canonical-⇒)
+open import proof.DGGPrimitiveSeparated using
+  ( id-ℕ-narrowingᶜ
+  ; applyCoercions-id-ℕ
+  ; applyCoercions-id-ℕ-applyCoercions
+  ; source-nat-typingᶜ
+  ; typed-term-narrowing-endpointsᶜ
+  ; typed-term-narrowing-coercion-endpointsᶜ
+  ; constant-⊕-δ-step
+  ; const-narrowing-targetᶜ
+  ; value-id-ℕ-narrowing-target-constᶜ
+  ; value-normalized-id-ℕ-target-constᶜ
+  )
+------------------------------------------------------------------------
+-- Primitive addition simulation
+------------------------------------------------------------------------
+
+separated-⊕-δ-left-first :
+  ∀ {ΔL ΔR ρ M N m′ n′} →
+  RuntimeOK M →
+  No• N →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ $ (κℕ m′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ N ⊒ $ (κℕ n′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ P ⊒ $ (κℕ (m′ + n′)) ∶ r ⦂ C ⊒ D
+separated-⊕-δ-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M} {N = N} {m′ = m′} {n′ = n′}
+    okM noN M⊒M′ N⊒N′ =
+  let
+    χsM , WM , ΔM ,
+      vWM , noWM , M↠WM , ΔM≡ , ρM-corr ,
+      leftM≡ , rightM≡ , pMᶜ , WM⊒M′ =
+      catchup-lemmaˡ
+        okM
+        ($ (κℕ m′))
+        M⊒M′
+
+    N⊒N′L :
+      ΔM ∣ ΔR ∣ applyLeftChanges χsM ρ ∣ []
+        ⊢ applyTerms χsM N ⊒ $ (κℕ n′)
+          ∶ applyCoercions χsM (id (‵ `ℕ))
+            ⦂ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+    N⊒N′L =
+      advance-left-term-narrowing χsM ΔM≡ ρM-corr N⊒N′
+
+    χsN , WN , ΔN ,
+      vWN , noWN , N↠WN , ΔN≡ , ρN-corr ,
+      leftN≡ , rightN≡ , pNᶜ , WN⊒N′ =
+      catchup-lemmaˡ
+        (applyTerms-preserves-RuntimeOK χsM (ok-no noN))
+        ($ (κℕ n′))
+        N⊒N′L
+
+    left-steps :
+      M ⊕[ addℕ ] N —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
+    left-steps = ⊕₁-↠ noN M↠WM
+
+    right-steps :
+      WM ⊕[ addℕ ] applyTerms χsM N
+        —↠[ χsN ] applyTerms χsN WM ⊕[ addℕ ] WN
+    right-steps = ⊕₂-↠ vWM noWM N↠WN
+
+    operands-ready :
+      M ⊕[ addℕ ] N
+        —↠[ χsM ++ χsN ] applyTerms χsN WM ⊕[ addℕ ] WN
+    operands-ready = ↠-trans left-steps right-steps
+
+    WM≡target : WM ≡ $ (κℕ m′)
+    WM≡target =
+      value-normalized-id-ℕ-target-constᶜ
+        vWM
+        refl
+        (applyCoercions-id-ℕ χsM)
+        (applyTys-ℕ χsM)
+        refl
+        WM⊒M′
+
+    WN≡target : WN ≡ $ (κℕ n′)
+    WN≡target =
+      value-normalized-id-ℕ-target-constᶜ
+        vWN
+        refl
+        (applyCoercions-id-ℕ-applyCoercions χsM χsN)
+        (applyTys-ℕ-applyTys χsM χsN)
+        refl
+        WN⊒N′
+
+    source-δ :
+      applyTerms χsN WM ⊕[ addℕ ] WN
+        —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step {χsL = χsN} {χsR = []}
+        WM≡target
+        WN≡target
+
+    χs : StoreChanges
+    χs = (χsM ++ χsN) ++ keep ∷ []
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    ΔN≡total :
+      ΔN ≡ applyTyCtxs χs ΔL
+    ΔN≡total =
+      trans ΔN≡
+        (trans
+          (cong (applyTyCtxs χsN) ΔM≡)
+          (sym
+            (trans
+              (applyTyCtxs-++ (χsM ++ χsN) (keep ∷ []) ΔL)
+              (cong (applyTyCtxs (keep ∷ []))
+                (applyTyCtxs-++ χsM χsN ΔL)))))
+
+    ρN≡total :
+      applyLeftChanges χsN (applyLeftChanges χsM ρ) ≡
+        applyLeftChanges χs ρ
+    ρN≡total =
+      sym
+        (trans
+          (applyLeftChanges-++ (χsM ++ χsN) (keep ∷ []) ρ)
+          (cong (applyLeftChanges (keep ∷ []))
+            (applyLeftChanges-++ χsM χsN ρ)))
+
+    result⊒ :
+      ΔN ∣ ΔR ∣ applyLeftChanges χsN (applyLeftChanges χsM ρ) ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ (κℕ (m′ + n′)) (id-ℕ-narrowingᶜ ρN-corr)
+  in
+  χs ,
+  $ (κℕ (m′ + n′)) ,
+  ΔN ,
+  applyLeftChanges χsN (applyLeftChanges χsM ρ) ,
+  ‵ `ℕ ,
+  ‵ `ℕ ,
+  id (‵ `ℕ) ,
+  source-steps ,
+  ΔN≡total ,
+  ρN≡total ,
+  result⊒
+
+separated-⊕-δ-right-first :
+  ∀ {ΔL ΔR ρ M N m′ n′} →
+  Value M →
+  No• M →
+  RuntimeOK N →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ $ (κℕ m′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ N ⊒ $ (κℕ n′)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
+    (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ρ′ ≡ applyLeftChanges χs ρ) ×
+    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+      ⊢ P ⊒ $ (κℕ (m′ + n′)) ∶ r ⦂ C ⊒ D
+separated-⊕-δ-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M} {N = N} {m′ = m′} {n′ = n′}
+    vM noM okN M⊒M′ N⊒N′ =
+  let
+    χsN , WN , ΔN ,
+      vWN , noWN , N↠WN , ΔN≡ , ρN-corr ,
+      leftN≡ , rightN≡ , pNᶜ , WN⊒N′ =
+      catchup-lemmaˡ
+        okN
+        ($ (κℕ n′))
+        N⊒N′
+
+    M⊒M′N :
+      ΔN ∣ ΔR ∣ applyLeftChanges χsN ρ ∣ []
+        ⊢ applyTerms χsN M ⊒ $ (κℕ m′)
+          ∶ applyCoercions χsN (id (‵ `ℕ))
+            ⦂ applyTys χsN (‵ `ℕ) ⊒ ‵ `ℕ
+    M⊒M′N =
+      advance-left-term-narrowing χsN ΔN≡ ρN-corr M⊒M′
+
+    χsM , WM , ΔM ,
+      vWM , noWM , M↠WM , ΔM≡ , ρM-corr ,
+      leftM≡ , rightM≡ , pMᶜ , WM⊒M′ =
+      catchup-lemmaˡ
+        (ok-no (applyTerms-preserves-No• χsN noM))
+        ($ (κℕ m′))
+        M⊒M′N
+
+    right-steps :
+      M ⊕[ addℕ ] N —↠[ χsN ] applyTerms χsN M ⊕[ addℕ ] WN
+    right-steps = ⊕₂-↠ vM noM N↠WN
+
+    left-steps :
+      applyTerms χsN M ⊕[ addℕ ] WN
+        —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM WN
+    left-steps = ⊕₁-↠ noWN M↠WM
+
+    operands-ready :
+      M ⊕[ addℕ ] N
+        —↠[ χsN ++ χsM ] WM ⊕[ addℕ ] applyTerms χsM WN
+    operands-ready = ↠-trans right-steps left-steps
+
+    WN≡target : WN ≡ $ (κℕ n′)
+    WN≡target =
+      value-normalized-id-ℕ-target-constᶜ
+        vWN
+        refl
+        (applyCoercions-id-ℕ χsN)
+        (applyTys-ℕ χsN)
+        refl
+        WN⊒N′
+
+    WM≡target : WM ≡ $ (κℕ m′)
+    WM≡target =
+      value-normalized-id-ℕ-target-constᶜ
+        vWM
+        refl
+        (applyCoercions-id-ℕ-applyCoercions χsN χsM)
+        (applyTys-ℕ-applyTys χsN χsM)
+        refl
+        WM⊒M′
+
+    source-δ :
+      WM ⊕[ addℕ ] applyTerms χsM WN
+        —↠[ keep ∷ [] ] $ (κℕ (m′ + n′))
+    source-δ =
+      constant-⊕-δ-step {χsL = []} {χsR = χsM}
+        WM≡target
+        WN≡target
+
+    χs : StoreChanges
+    χs = (χsN ++ χsM) ++ keep ∷ []
+
+    source-steps :
+      M ⊕[ addℕ ] N —↠[ χs ] $ (κℕ (m′ + n′))
+    source-steps = ↠-trans operands-ready source-δ
+
+    ΔM≡total :
+      ΔM ≡ applyTyCtxs χs ΔL
+    ΔM≡total =
+      trans ΔM≡
+        (trans
+          (cong (applyTyCtxs χsM) ΔN≡)
+          (sym
+            (trans
+              (applyTyCtxs-++ (χsN ++ χsM) (keep ∷ []) ΔL)
+              (cong (applyTyCtxs (keep ∷ []))
+                (applyTyCtxs-++ χsN χsM ΔL)))))
+
+    ρM≡total :
+      applyLeftChanges χsM (applyLeftChanges χsN ρ) ≡
+        applyLeftChanges χs ρ
+    ρM≡total =
+      sym
+        (trans
+          (applyLeftChanges-++ (χsN ++ χsM) (keep ∷ []) ρ)
+          (cong (applyLeftChanges (keep ∷ []))
+            (applyLeftChanges-++ χsN χsM ρ)))
+
+    result⊒ :
+      ΔM ∣ ΔR ∣ applyLeftChanges χsM (applyLeftChanges χsN ρ) ∣ []
+        ⊢ $ (κℕ (m′ + n′)) ⊒ $ (κℕ (m′ + n′))
+          ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    result⊒ =
+      κ⊒κᵗ (κℕ (m′ + n′)) (id-ℕ-narrowingᶜ ρM-corr)
+  in
+  χs ,
+  $ (κℕ (m′ + n′)) ,
+  ΔM ,
+  applyLeftChanges χsM (applyLeftChanges χsN ρ) ,
+  ‵ `ℕ ,
+  ‵ `ℕ ,
+  id (‵ `ℕ) ,
+  source-steps ,
+  ΔM≡total ,
+  ρM≡total ,
+  result⊒

--- a/GTSF/proof/DGGPrimitiveSeparated.agda
+++ b/GTSF/proof/DGGPrimitiveSeparated.agda
@@ -1,0 +1,168 @@
+module proof.DGGPrimitiveSeparated where
+
+-- File Charter:
+--   * Primitive/nat helper lemmas for the separated dynamic gradual guarantee.
+--   * Provides the `ℕ` identity coercion facts and constant-shape inversions
+--     used by the arithmetic congruence and delta cases.
+--   * Keeps primitive-specific proof plumbing out of the main separated DGG
+--     module.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (_+_)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
+
+open import Types
+open import Coercions
+open import NarrowWiden using
+  ( cross
+  ; id-‵
+  ; _∣_∣_⊢_∶_⊒_
+  )
+open import Primitives using (addℕ; κℕ)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.NuProgress using (canonical-ℕ; nv-const)
+open import proof.ReductionProperties using
+  ( applyCoercions
+  ; applyTerms-const
+  )
+
+id-ℕ-narrowingᶜ :
+  ∀ {ΔL ΔR ρ} →
+  StoreCorr ΔL ΔR ρ →
+  ΔL ∣ ΔR ∣ ρ ⊢ id (‵ `ℕ) ∶ᶜ ‵ `ℕ ⊒ ‵ `ℕ
+id-ℕ-narrowingᶜ stores =
+  stores ,
+  refl ,
+  refl ,
+  wfBase ,
+  wfBase ,
+  (cast-id wfBase refl , cross (id-‵ `ℕ)) ,
+  (cast-id wfBase refl , cross (id-‵ `ℕ))
+
+applyCoercion-id-ℕ :
+  ∀ χ →
+  applyCoercion χ (id (‵ `ℕ)) ≡ id (‵ `ℕ)
+applyCoercion-id-ℕ keep = refl
+applyCoercion-id-ℕ (bind A) = refl
+
+applyCoercions-id-ℕ :
+  ∀ χs →
+  applyCoercions χs (id (‵ `ℕ)) ≡ id (‵ `ℕ)
+applyCoercions-id-ℕ [] = refl
+applyCoercions-id-ℕ (χ ∷ χs) rewrite applyCoercion-id-ℕ χ =
+  applyCoercions-id-ℕ χs
+
+applyCoercions-id-ℕ-applyCoercions :
+  ∀ χs χs′ →
+  applyCoercions χs′ (applyCoercions χs (id (‵ `ℕ))) ≡ id (‵ `ℕ)
+applyCoercions-id-ℕ-applyCoercions χs χs′ =
+  trans (cong (applyCoercions χs′) (applyCoercions-id-ℕ χs))
+    (applyCoercions-id-ℕ χs′)
+
+source-nat-typingᶜ :
+  ∀ {ΔL ΔR ρ W V p A B} →
+  A ≡ ‵ `ℕ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ V ∶ p ⦂ A ⊒ B →
+  ΔL ∣ leftStore ρ ∣ [] ⊢ W ⦂ ‵ `ℕ
+source-nat-typingᶜ A≡ℕ W⊒V =
+  subst (λ A → _ ∣ _ ∣ [] ⊢ _ ⦂ A) A≡ℕ
+    (typed-term-narrowing-source-typingᶜ W⊒V)
+
+typed-term-narrowing-endpointsᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ p A B A′ B′} →
+  A ≡ A′ →
+  B ≡ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A′ ⊒ B′
+typed-term-narrowing-endpointsᶜ refl refl M⊒M′ = M⊒M′
+
+typed-term-narrowing-coercion-endpointsᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ p A B A′ B′} →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A′ ⊒ B′ →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A′ ⊒ B′
+typed-term-narrowing-coercion-endpointsᶜ
+    (_ , src′ , tgt′ , _ , _ , _ , _) M⊒M′ =
+  let
+    _ , (_ , src , tgt , _ , _ , _ , _) =
+      typed-term-narrowing-coercion M⊒M′
+  in
+  typed-term-narrowing-endpointsᶜ
+    (trans (sym src) src′)
+    (trans (sym tgt) tgt′)
+    M⊒M′
+
+constant-⊕-δ-step :
+  ∀ {χsL χsR L R m n} →
+  L ≡ $ (κℕ m) →
+  R ≡ $ (κℕ n) →
+  applyTerms χsL L ⊕[ addℕ ] applyTerms χsR R
+    —↠[ keep ∷ [] ] $ (κℕ (m + n))
+constant-⊕-δ-step {χsL = χsL} {χsR = χsR} {m = m} {n = n}
+    L≡ R≡
+    rewrite L≡ | applyTerms-const χsL (κℕ m)
+          | R≡ | applyTerms-const χsR (κℕ n) =
+  ↠-step (pure-step δ-⊕) ↠-refl
+
+const-narrowing-targetᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ p A B m n} →
+  M ≡ $ (κℕ m) →
+  M′ ≡ $ (κℕ n) →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  m ≡ n
+const-narrowing-targetᶜ eqM () (⊒blameᵗ M⊢ pᶜ)
+const-narrowing-targetᶜ () eqM′ (x⊒xᵗ pᶜ x∋p)
+const-narrowing-targetᶜ () eqM′ (ƛ⊒ƛᵗ p↦qᶜ N⊒N′)
+const-narrowing-targetᶜ () eqM′ (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′)
+const-narrowing-targetᶜ () eqM′ (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′)
+const-narrowing-targetᶜ refl refl (κ⊒κᵗ (κℕ n) pᶜ) = refl
+const-narrowing-targetᶜ () eqM′ (⊕⊒⊕ᵗ pᶜ M⊒M′ N⊒N′)
+const-narrowing-targetᶜ eqM () (⊒cast+ᵗ pᶜ rᶜ t⊒ M⊒M′)
+const-narrowing-targetᶜ eqM () (⊒cast-ᵗ pᶜ rᶜ t⊒ M⊒M′)
+const-narrowing-targetᶜ () eqM′ (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′)
+const-narrowing-targetᶜ () eqM′ (cast-⊒ᵗ qᶜ rᶜ s⊒ M⊒M′)
+
+value-id-ℕ-narrowing-target-constᶜ :
+  ∀ {ΔL ΔR ρ W n} →
+  Value W →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ $ (κℕ n)
+    ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ →
+  W ≡ $ (κℕ n)
+value-id-ℕ-narrowing-target-constᶜ {W = W} vW W⊒
+    with canonical-ℕ vW (typed-term-narrowing-source-typingᶜ W⊒)
+value-id-ℕ-narrowing-target-constᶜ {W = W} vW W⊒
+    | nv-const {n = m} W≡
+    rewrite W≡ | const-narrowing-targetᶜ refl refl W⊒ =
+  refl
+
+value-normalized-id-ℕ-target-constᶜ :
+  ∀ {ΔL ΔR ρ W T p A B n} →
+  Value W →
+  T ≡ $ (κℕ n) →
+  p ≡ id (‵ `ℕ) →
+  A ≡ ‵ `ℕ →
+  B ≡ ‵ `ℕ →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ T ∶ p ⦂ A ⊒ B →
+  W ≡ $ (κℕ n)
+value-normalized-id-ℕ-target-constᶜ target-value T≡ p≡ A≡ B≡ W⊒ =
+  value-id-ℕ-narrowing-target-constᶜ target-value
+    (subst
+      (λ T → _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ T
+        ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ)
+      T≡
+      (subst
+        (λ p → _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ p ⦂ ‵ `ℕ ⊒ ‵ `ℕ)
+        p≡
+        (subst
+          (λ A → _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ _ ⦂ A ⊒ ‵ `ℕ)
+          A≡
+          (subst
+            (λ B → _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ _ ⦂ _ ⊒ B)
+            B≡
+            W⊒))))

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -3,21 +3,33 @@
 module proof.DynamicGradualGuaranteeSeparated where
 
 -- File Charter:
---   * Top-down separated-store surface for resuming the DGG beta proof.
+--   * Main recursive separated-store dynamic gradual guarantee skeleton.
+--   * Delegates beta, beta-cast, and primitive delta packaging to focused
+--     helper modules so this file stays centered on the induction cases.
 --   * Keeps the target term/store unchanged while left-side catchup advances
 --     the source term through `SealCorr`.
---   * Wires the separated beta caller to `proof.SimBetaSeparated` while the
---     full DGG skeleton is migrated top-down.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Nat using (_+_)
 open import Data.List using ([]; _∷_; _++_)
-open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
   using (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
-open import Primitives using (addℕ)
+open import NarrowWiden using
+  ( cross
+  ; dualʷ
+  ; id★
+  ; id-＇
+  ; id-‵
+  ; _？︔_
+  ; _︔seal_
+  ; _∣_∣_⊢_∶_⊒_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
+open import Primitives using (addℕ; κℕ)
 open import NuTerms
 open import NuReduction
 open import StoreCorrespondence
@@ -29,345 +41,77 @@ open import proof.CatchupSeparated using
   ; catchup-lemmaˡ
   )
 open import proof.NuPreservation using (runtime-⟨⟩)
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualʷ-flips-typingᵐ
+  )
 open import proof.ReductionProperties using
   ( applyTerms-preserves-No•
   ; applyTerms-preserves-Value
   ; applyCoercions
+  ; applyCoercions-++
   ; applyCoercions-dual
+  ; applyTys-++
+  ; applyTys-ℕ
+  ; applyTys-ℕ-applyTys
   ; applyTyCtxs-++
   ; ↠-trans
+  ; cast-↠
   ; ·₁-↠
   ; ·₂-↠
+  ; ⊕₁-↠
+  ; ⊕₂-↠
   )
 open import proof.SimBetaSeparated using
   ( applyTerms-preserves-RuntimeOK
   ; applyTys-⇒
   ; applyCoercions-↦
   ; applyCoercions-dual-applyCoercions
+  ; no•-cast-inv
+  ; ⟨⟩-term-injective
+  ; ⟨⟩-coercion-injective
+  ; left-change-coercion-narrowing
+  ; left-change-source-coercion-narrowing
   ; advance-left-term-narrowing
+  ; advance-left-function-term-narrowing
   ; advance-left-lambda-narrowing
+  ; widen-fun-domainᵐ
+  ; separated-fun-domain-dual
+  ; separated-fun-codomain
+  ; separated-left-coercionᵐ
+  ; separated-right-coercionᵐ
+  ; ↦-domain
+  ; ↦-codomain
+  ; ↦-left-injective
+  ; ↦-right-injective
+  ; dualʷ-raw-determined
+  ; dualʷ-involutive-raw
   ; sim-beta
   )
-
-------------------------------------------------------------------------
--- Application beta caller
-------------------------------------------------------------------------
-
-separated-dgg-beta-left-first :
-  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
-  RuntimeOK L →
-  RuntimeOK R →
-  No• R →
-  Value V′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
-    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
-  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
-    (L · R —↠[ χs ] N) ×
-    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-    (ρ′ ≡ applyLeftChanges χs ρ) ×
-    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
-      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
-separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
-    {L = L} {R = R} {N′ = N′} {V′ = V′}
-    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
-    {B = B} {B′ = B′}
-    okL okR noR-ready vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  let
-    χsL , WL , ΔL₁ ,
-      vWL , noWL , L↠WL , ΔL₁≡ , ρL-corr ,
-      leftL≡ , rightL≡ , p₁ᶜ , WL⊒ƛraw =
-      catchup-lemmaˡ
-        okL
-        (ƛ N′)
-        L⊒ƛ
-
-    WL⊒ƛ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
-        ⊢ WL ⊒ ƛ N′
-          ∶ applyCoercions χsL p ↦ applyCoercions χsL q
-          ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
-    WL⊒ƛ =
-      subst
-        (λ c →
-          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
-            ⊢ WL ⊒ ƛ N′ ∶ c
-              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′)
-        (applyCoercions-↦ χsL p q)
-        (subst
-          (λ C →
-            ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
-              ⊢ WL ⊒ ƛ N′ ∶ applyCoercions χsL (p ↦ q)
-                ⦂ C ⊒ A′ ⇒ B′)
-          (applyTys-⇒ χsL A B)
-          WL⊒ƛraw)
-
-    R⊒V′L =
-      advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒V′
-
-    χsR , WR , ΔL₂ ,
-      vWR , noWR , R↠WR , ΔL₂≡ , ρR-corr ,
-      leftR≡ , rightR≡ , p₂ᶜ , WR⊒V′raw =
-      catchup-lemmaˡ
-        (applyTerms-preserves-RuntimeOK χsL okR)
-        vV′
-        R⊒V′L
-
-    WLF⊒ƛ =
-      advance-left-lambda-narrowing χsR ΔL₂≡ ρR-corr WL⊒ƛ
-
-    WR⊒V′ :
-      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ) ∣ []
-        ⊢ WR ⊒ V′
-          ∶ applyCoercions χsR (applyCoercions χsL pᵈ)
-          ⦂ applyTys χsR (applyTys χsL A) ⊒ A′
-    WR⊒V′ = WR⊒V′raw
-
-    p₂-domainᶜ :
-      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ)
-        ⊢ applyCoercions χsR (applyCoercions χsL pᵈ)
-          ∶ᶜ applyTys χsR (applyTys χsL A) ⊒ A′
-    p₂-domainᶜ = p₂ᶜ
-
-    left-ready :
-      L · R —↠[ χsL ] WL · applyTerms χsL R
-    left-ready = ·₁-↠ noR-ready L↠WL
-
-    right-ready :
-      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · WR
-    right-ready = ·₂-↠ vWL noWL R↠WR
-
-    ready :
-      ∃[ χs₀ ] (L · R —↠[ χs₀ ] applyTerms χsR WL · WR)
-    ready = χsL ++ χsR , ↠-trans left-ready right-ready
-
-    tail :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
-        (applyTerms χsR WL · WR —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL₂) ×
-        (ρ′ ≡
-          applyLeftChanges χs (applyLeftChanges χsR
-            (applyLeftChanges χsL ρ))) ×
-        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
-          ⊢ N ⊒ N′ [ V′ ]
-            ∶ applyCoercions χs
-                (applyCoercions χsR (applyCoercions χsL q))
-            ⦂ applyTys χs (applyTys χsR (applyTys χsL B)) ⊒ B′
-    tail =
-      sim-beta
-        WLF⊒ƛ
-        (applyTerms-preserves-Value χsR vWL)
-        (applyTerms-preserves-No• χsR noWL)
-        WR⊒V′
-        p₂-domainᶜ
-        vWR
-        noWR
-        vV′
-  in
-  let
-    χsT , N , ΔL′ , ρ′ ,
-      tail-red , ΔT≡ , ρT≡ , N⊒N′[V′] = tail
-
-    source-steps :
-      L · R —↠[ (χsL ++ χsR) ++ χsT ] N
-    source-steps = ↠-trans (↠-trans left-ready right-ready) tail-red
-
-    ΔL′≡ :
-      ΔL′ ≡ applyTyCtxs ((χsL ++ χsR) ++ χsT) ΔL
-    ΔL′≡ =
-      trans ΔT≡
-        (trans
-          (cong (applyTyCtxs χsT) ΔL₂≡)
-          (trans
-            (cong (λ Δ → applyTyCtxs χsT (applyTyCtxs χsR Δ))
-              ΔL₁≡)
-            (sym
-              (trans
-                (applyTyCtxs-++ (χsL ++ χsR) χsT ΔL)
-                (cong (applyTyCtxs χsT)
-                  (applyTyCtxs-++ χsL χsR ΔL))))))
-
-    ρ′≡ :
-      ρ′ ≡ applyLeftChanges ((χsL ++ χsR) ++ χsT) ρ
-    ρ′≡ =
-      trans ρT≡
-        (sym
-          (trans
-            (applyLeftChanges-++ (χsL ++ χsR) χsT ρ)
-            (cong (applyLeftChanges χsT)
-              (applyLeftChanges-++ χsL χsR ρ))))
-  in
-  (χsL ++ χsR) ++ χsT ,
-  N ,
-  ΔL′ ,
-  ρ′ ,
-  _ ,
-  _ ,
-  _ ,
-  source-steps ,
-  ΔL′≡ ,
-  ρ′≡ ,
-  N⊒N′[V′]
-
-separated-dgg-beta-right-first :
-  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
-  Value L →
-  No• L →
-  RuntimeOK R →
-  Value V′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
-    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
-  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
-    (L · R —↠[ χs ] N) ×
-    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-    (ρ′ ≡ applyLeftChanges χs ρ) ×
-    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
-      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
-separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
-    {L = L} {R = R} {N′ = N′} {V′ = V′}
-    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
-    {B = B} {B′ = B′}
-    vL noL okR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  let
-    χsR , WR , ΔL₁ ,
-      vWR , noWR , R↠WR , ΔL₁≡ , ρR-corr ,
-      leftR≡ , rightR≡ , p₁ᶜ , WR⊒V′raw =
-      catchup-lemmaˡ
-        okR
-        vV′
-        R⊒V′
-
-    LF⊒ƛ =
-      advance-left-lambda-narrowing χsR ΔL₁≡ ρR-corr L⊒ƛ
-
-    WR⊒V′ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ ∣ []
-        ⊢ WR ⊒ V′
-          ∶ applyCoercions χsR pᵈ ⦂ applyTys χsR A ⊒ A′
-    WR⊒V′ = WR⊒V′raw
-
-    p₁-domainᶜ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ
-        ⊢ applyCoercions χsR pᵈ ∶ᶜ applyTys χsR A ⊒ A′
-    p₁-domainᶜ = p₁ᶜ
-
-    ready :
-      L · R —↠[ χsR ] applyTerms χsR L · WR
-    ready = ·₂-↠ vL noL R↠WR
-
-    tail :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ]
-        (applyTerms χsR L · WR —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL₁) ×
-        (ρ′ ≡ applyLeftChanges χs (applyLeftChanges χsR ρ)) ×
-        ΔL′ ∣ ΔR ∣ ρ′ ∣ []
-          ⊢ N ⊒ N′ [ V′ ]
-            ∶ applyCoercions χs (applyCoercions χsR q)
-            ⦂ applyTys χs (applyTys χsR B) ⊒ B′
-    tail =
-      sim-beta
-        LF⊒ƛ
-        (applyTerms-preserves-Value χsR vL)
-        (applyTerms-preserves-No• χsR noL)
-        WR⊒V′
-        p₁-domainᶜ
-        vWR
-        noWR
-        vV′
-  in
-  let
-    χsT , N , ΔL′ , ρ′ ,
-      tail-red , ΔT≡ , ρT≡ , N⊒N′[V′] = tail
-
-    source-steps :
-      L · R —↠[ χsR ++ χsT ] N
-    source-steps = ↠-trans ready tail-red
-
-    ΔL′≡ :
-      ΔL′ ≡ applyTyCtxs (χsR ++ χsT) ΔL
-    ΔL′≡ =
-      trans ΔT≡
-        (trans
-          (cong (applyTyCtxs χsT) ΔL₁≡)
-          (sym (applyTyCtxs-++ χsR χsT ΔL)))
-
-    ρ′≡ :
-      ρ′ ≡ applyLeftChanges (χsR ++ χsT) ρ
-    ρ′≡ =
-      trans ρT≡ (sym (applyLeftChanges-++ χsR χsT ρ))
-  in
-  χsR ++ χsT ,
-  N ,
-  ΔL′ ,
-  ρ′ ,
-  _ ,
-  _ ,
-  _ ,
-  source-steps ,
-  ΔL′≡ ,
-  ρ′≡ ,
-  N⊒N′[V′]
-
-separated-dgg-beta :
-  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
-  RuntimeOK (L · R) →
-  Value V′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
-    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
-  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
-    (L · R —↠[ χs ] N) ×
-    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-    (ρ′ ≡ applyLeftChanges χs ρ) ×
-    ΔL′ ∣ ΔR ∣ ρ′ ∣ []
-      ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
-separated-dgg-beta okLR@(ok-no (no•-· noL noR))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-left-first
-    (ok-no noL) (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta okLR@(ok-·₁ okL noR)
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-left-first
-    okL (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta okLR@(ok-·₂ vL noL (ok-no noR))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-left-first
-    (ok-no noL) (ok-no noR) noR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-• vV noV))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-• vV noV) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-·₁ okR₁ noR₂))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-·₁ okR₁ noR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-·₂ vR₁ noR₁ okR₂))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-·₂ vR₁ noR₁ okR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-ν okR))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-ν okR) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-⊕₁ okR₁ noR₂))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-⊕₁ okR₁ noR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-⊕₂ vR₁ noR₁ okR₂))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-⊕₂ vR₁ noR₁ okR₂) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
-separated-dgg-beta (ok-·₂ vL noL (ok-⟨⟩ okR))
-    vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
-  separated-dgg-beta-right-first
-    vL noL (ok-⟨⟩ okR) vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′
+open import proof.NuProgress using
+  (FunView; fv-ƛ; fv-↦; canonical-⇒)
+open import proof.DGGPrimitiveSeparated using
+  ( id-ℕ-narrowingᶜ
+  ; applyCoercions-id-ℕ
+  ; applyCoercions-id-ℕ-applyCoercions
+  ; source-nat-typingᶜ
+  ; typed-term-narrowing-endpointsᶜ
+  ; typed-term-narrowing-coercion-endpointsᶜ
+  ; constant-⊕-δ-step
+  ; const-narrowing-targetᶜ
+  ; value-id-ℕ-narrowing-target-constᶜ
+  ; value-normalized-id-ℕ-target-constᶜ
+  )
+open import proof.DGGBetaSeparated using (separated-dgg-beta)
+open import proof.DGGBetaCastSeparated using (separated-dgg-beta-cast)
+open import proof.DGGDeltaSeparated using
+  ( separated-⊕-δ-left-first
+  ; separated-⊕-δ-right-first
+  )
 
 ------------------------------------------------------------------------
 -- Full separated DGG skeleton
@@ -425,82 +169,1703 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   ρ′≡ ,
   N⊒N′[V′]
-dynamicGradualGuarantee okM qᶜ
-    (·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
-    (pure-step (β-↦ vV vW)) =
-  {! ? !}
-dynamicGradualGuarantee okM qᶜ
-    (·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
-    (pure-step blame-·₁) =
-  {! ? !}
-dynamicGradualGuarantee okM qᶜ
-    (·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
-    (pure-step (blame-·₂ vV)) =
-  {! ? !}
-dynamicGradualGuarantee okM qᶜ
-    (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
-    (ξ-·₁ L′→N′ shiftR′) =
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R}
+    okM qᶜ
+    app@(·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
+    (pure-step (β-↦ {V = V′} {W = W′} {p = c′} {q = d′} vV′ vW′)) =
   let
-    rec = dynamicGradualGuarantee {! ? !} p↦q-wholeᶜ L⊒L′ L′→N′
+    rec =
+      separated-dgg-beta-cast
+        okM
+        vV′
+        vW′
+        L⊒L′
+        (fun-narrow-domain-dual-typingᶜ p↦qᶜ)
+        R⊒R′
   in
-  {! ? !}
-dynamicGradualGuarantee okM qᶜ
+  let
+    χs , N , ΔL′ , ρ′ , C , D , r ,
+      source-steps , ΔL′≡ , ρ′≡ , N⊒target = rec
+  in
+  χs ,
+  N ,
+  ΔL′ ,
+  ΔR ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  refl ,
+  ρ′≡ ,
+  N⊒target
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R}
+    okM qᶜ
+    app@(·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
+    (pure-step blame-·₁) =
+  [] ,
+  L · R ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app) qᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R}
+    okM qᶜ
+    app@(·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
+    (pure-step (blame-·₂ vV)) =
+  [] ,
+  L · R ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app) qᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
+    (ok-no (no•-· noL noR)) qᶜ
     (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
-    (ξ-·₂ vL′ shiftL′ R′→N′) =
+    (ξ-·₁ {L′ = S′} L′→N′ shiftR′) =
   let
     rec =
       dynamicGradualGuarantee
-        {! ? !}
+        (ok-no noL)
+        p↦q-wholeᶜ
+        L⊒L′
+        L′→N′
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      L↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+
+    framed⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ N · applyTerms χs R ⊒ S′ · applyTerm χ′ R′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        N⊒S′-fun :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ N ⊒ S′ ∶ _ ↦ _ ⦂ _ ⇒ _ ⊒ _ ⇒ _
+        N⊒S′-fun =
+          let
+            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
+            ih = N⊒N′
+          in
+          {! ξ-·₁-IH-result-function !}
+
+        p↦q′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ⊢ _ ↦ _ ∶ᶜ _ ⇒ _ ⊒ _ ⇒ _
+        p↦q′ = {! ξ-·₁-updated-function-coercion !}
+
+        R⊒R′′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χs R ⊒ applyTerm χ′ R′
+              ∶ fun-narrow-domain-dualᶜ p↦q′ ⦂ _ ⊒ _
+        R⊒R′′ = {! ξ-·₁-updated-argument-narrowing !}
+      in
+      ·⊒·ᵗ p↦q′ N⊒S′-fun R⊒R′′
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (L · R —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ S′ · applyTerm χ′ R′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      N · applyTerms χs R ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      ·₁-↠ noR L↠N ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
+    (ok-·₁ okL noR) qᶜ
+    (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₁ {L′ = S′} L′→N′ shiftR′) =
+  let
+    rec =
+      dynamicGradualGuarantee
+        okL
+        p↦q-wholeᶜ
+        L⊒L′
+        L′→N′
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      L↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+
+    framed⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ N · applyTerms χs R ⊒ S′ · applyTerm χ′ R′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        N⊒S′-fun :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ N ⊒ S′ ∶ _ ↦ _ ⦂ _ ⇒ _ ⊒ _ ⇒ _
+        N⊒S′-fun =
+          let
+            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
+            ih = N⊒N′
+          in
+          {! ξ-·₁-IH-result-function !}
+
+        p↦q′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ⊢ _ ↦ _ ∶ᶜ _ ⇒ _ ⊒ _ ⇒ _
+        p↦q′ = {! ξ-·₁-updated-function-coercion !}
+
+        R⊒R′′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χs R ⊒ applyTerm χ′ R′
+              ∶ fun-narrow-domain-dualᶜ p↦q′ ⦂ _ ⊒ _
+        R⊒R′′ = {! ξ-·₁-updated-argument-narrowing !}
+      in
+      ·⊒·ᵗ p↦q′ N⊒S′-fun R⊒R′′
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (L · R —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ S′ · applyTerm χ′ R′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      N · applyTerms χs R ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      ·₁-↠ noR L↠N ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
+    (ok-·₂ vL noL okR) qᶜ
+    app@(·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₁ {L′ = S′} L′→S′ shiftR′) =
+  let
+    relation-obligation :
+      ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+        ⊢ L · R ⊒ S′ · applyTerm χ′ R′ ∶ _ ⦂ _ ⊒ _
+    relation-obligation =
+      let
+        source-relation :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L · R ⊒ L′ · R′
+            ∶ _ ⦂ _ ⊒ _
+        source-relation = app
+
+        target-left-step : L′ —→[ χ′ ] S′
+        target-left-step = L′→S′
+
+        target-right-shift : Shiftable χ′ R′
+        target-right-shift = shiftR′
+
+        obligation :
+          ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+            ⊢ L · R ⊒ S′ · applyTerm χ′ R′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! ξ-·₁-source-left-already-value-relation !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (L · R —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ S′ · applyTerm χ′ R′ ∶ r ⦂ C ⊒ D
+    obligation =
+      [] ,
+      L · R ,
+      ΔL ,
+      applyTyCtx χ′ ΔR ,
+      applyRightChange χ′ ρ ,
+      _ ,
+      _ ,
+      _ ,
+      ↠-refl ,
+      refl ,
+      refl ,
+      refl ,
+      relation-obligation
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
+    (ok-no (no•-· noL noR)) qᶜ
+    (·⊒·ᵗ {p = p} {q = q} {A = A} {A′ = A′}
+      {B = B} {B′ = B′} p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₂ {M′ = S′} vL′ shiftL′ R′→S′) =
+  let
+    χsL , WL , ΔL₁ ,
+      vWL , noWL , L↠WL , ΔL₁≡ , ρL-corr ,
+      leftL≡ , rightL≡ , pLᶜ , WL⊒L′raw =
+      catchup-lemmaˡ
+        (ok-no noL)
+        vL′
+        L⊒L′
+
+    WL⊒L′ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ WL ⊒ L′
+          ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+          ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+    WL⊒L′ =
+      subst
+        (λ c →
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ L′ ∶ c
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′)
+        (applyCoercions-↦ χsL p q)
+        (subst
+          (λ C →
+            ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+              ⊢ WL ⊒ L′ ∶ applyCoercions χsL (p ↦ q)
+                ⦂ C ⊒ A′ ⇒ B′)
+          (applyTys-⇒ χsL A B)
+          WL⊒L′raw)
+
+    R⊒R′L :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ applyTerms χsL R ⊒ R′
+          ∶ applyCoercions χsL (fun-narrow-domain-dualᶜ p↦q-wholeᶜ)
+          ⦂ applyTys χsL A ⊒ A′
+    R⊒R′L =
+      advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒R′
+
+    p-domain-Lᶜ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ
+        ⊢ applyCoercions χsL (fun-narrow-domain-dualᶜ p↦q-wholeᶜ)
+          ∶ᶜ applyTys χsL A ⊒ A′
+    p-domain-Lᶜ =
+      left-change-coercion-narrowing
+        χsL
+        ΔL₁≡
+        ρL-corr
+        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
+
+    rec =
+      dynamicGradualGuarantee
+        (applyTerms-preserves-RuntimeOK χsL (ok-no noR))
+        p-domain-Lᶜ
+        R⊒R′L
+        R′→S′
+
+    χsR , P , ΔL₂ , ΔR′ , ρ′ ,
+      C , D , r ,
+      R↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+
+    source-left :
+      L · R —↠[ χsL ] WL · applyTerms χsL R
+    source-left = ·₁-↠ noR L↠WL
+
+    source-right :
+      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · P
+    source-right = ·₂-↠ vWL noWL R↠P
+
+    source-steps :
+      L · R —↠[ χsL ++ χsR ] applyTerms χsR WL · P
+    source-steps = ↠-trans source-left source-right
+
+    ΔL₂≡total :
+      ΔL₂ ≡ applyTyCtxs (χsL ++ χsR) ΔL
+    ΔL₂≡total =
+      trans ΔL₂≡
+        (trans
+          (cong (applyTyCtxs χsR) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsL χsR ΔL)))
+
+    ρ′≡total :
+      ρ′ ≡ applyRightChange χ′ (applyLeftChanges (χsL ++ χsR) ρ)
+    ρ′≡total =
+      trans ρ′≡
+        (cong (applyRightChange χ′)
+          (sym (applyLeftChanges-++ χsL χsR ρ)))
+
+    framed⊒ :
+      ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ applyTerms χsR WL · P ⊒ applyTerm χ′ L′ · S′
+          ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        ih : ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+        ih = P⊒S′
+
+        function-before-right-change :
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ L′
+              ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+        function-before-right-change = WL⊒L′
+
+        obligation :
+          ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χsR WL · P ⊒ applyTerm χ′ L′ · S′
+              ∶ _ ⦂ _ ⊒ _
+        obligation = {! ξ-·₂-source-left-not-yet-value-frame !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (L · R —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ applyTerm χ′ L′ · S′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χsL ++ χsR ,
+      applyTerms χsR WL · P ,
+      ΔL₂ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      source-steps ,
+      ΔL₂≡total ,
+      ΔR′≡ ,
+      ρ′≡total ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
+    (ok-·₁ okL noR) qᶜ
+    (·⊒·ᵗ {p = p} {q = q} {A = A} {A′ = A′}
+      {B = B} {B′ = B′} p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₂ {M′ = S′} vL′ shiftL′ R′→S′) =
+  let
+    χsL , WL , ΔL₁ ,
+      vWL , noWL , L↠WL , ΔL₁≡ , ρL-corr ,
+      leftL≡ , rightL≡ , pLᶜ , WL⊒L′raw =
+      catchup-lemmaˡ
+        okL
+        vL′
+        L⊒L′
+
+    WL⊒L′ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ WL ⊒ L′
+          ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+          ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+    WL⊒L′ =
+      subst
+        (λ c →
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ L′ ∶ c
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′)
+        (applyCoercions-↦ χsL p q)
+        (subst
+          (λ C →
+            ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+              ⊢ WL ⊒ L′ ∶ applyCoercions χsL (p ↦ q)
+                ⦂ C ⊒ A′ ⇒ B′)
+          (applyTys-⇒ χsL A B)
+          WL⊒L′raw)
+
+    R⊒R′L :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+        ⊢ applyTerms χsL R ⊒ R′
+          ∶ applyCoercions χsL (fun-narrow-domain-dualᶜ p↦q-wholeᶜ)
+          ⦂ applyTys χsL A ⊒ A′
+    R⊒R′L =
+      advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒R′
+
+    p-domain-Lᶜ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ
+        ⊢ applyCoercions χsL (fun-narrow-domain-dualᶜ p↦q-wholeᶜ)
+          ∶ᶜ applyTys χsL A ⊒ A′
+    p-domain-Lᶜ =
+      left-change-coercion-narrowing
+        χsL
+        ΔL₁≡
+        ρL-corr
+        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
+
+    rec =
+      dynamicGradualGuarantee
+        (applyTerms-preserves-RuntimeOK χsL (ok-no noR))
+        p-domain-Lᶜ
+        R⊒R′L
+        R′→S′
+
+    χsR , P , ΔL₂ , ΔR′ , ρ′ ,
+      C , D , r ,
+      R↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+
+    source-left :
+      L · R —↠[ χsL ] WL · applyTerms χsL R
+    source-left = ·₁-↠ noR L↠WL
+
+    source-right :
+      WL · applyTerms χsL R —↠[ χsR ] applyTerms χsR WL · P
+    source-right = ·₂-↠ vWL noWL R↠P
+
+    source-steps :
+      L · R —↠[ χsL ++ χsR ] applyTerms χsR WL · P
+    source-steps = ↠-trans source-left source-right
+
+    ΔL₂≡total :
+      ΔL₂ ≡ applyTyCtxs (χsL ++ χsR) ΔL
+    ΔL₂≡total =
+      trans ΔL₂≡
+        (trans
+          (cong (applyTyCtxs χsR) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsL χsR ΔL)))
+
+    ρ′≡total :
+      ρ′ ≡ applyRightChange χ′ (applyLeftChanges (χsL ++ χsR) ρ)
+    ρ′≡total =
+      trans ρ′≡
+        (cong (applyRightChange χ′)
+          (sym (applyLeftChanges-++ χsL χsR ρ)))
+
+    framed⊒ :
+      ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ applyTerms χsR WL · P ⊒ applyTerm χ′ L′ · S′
+          ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        ih : ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+        ih = P⊒S′
+
+        function-before-right-change :
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ ∣ []
+            ⊢ WL ⊒ L′
+              ∶ applyCoercions χsL p ↦ applyCoercions χsL q
+              ⦂ applyTys χsL A ⇒ applyTys χsL B ⊒ A′ ⇒ B′
+        function-before-right-change = WL⊒L′
+
+        obligation :
+          ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χsR WL · P ⊒ applyTerm χ′ L′ · S′
+              ∶ _ ⦂ _ ⊒ _
+        obligation = {! ξ-·₂-source-left-still-reducing-frame !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (L · R —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ applyTerm χ′ L′ · S′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χsL ++ χsR ,
+      applyTerms χsR WL · P ,
+      ΔL₂ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      source-steps ,
+      ΔL₂≡total ,
+      ΔR′≡ ,
+      ρ′≡total ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = L · R} {M′ = L′ · R′} {N′ = T′} {χ′ = χ′}
+    (ok-·₂ vL noL okR) qᶜ
+    (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
+    (ξ-·₂ {M′ = S′} vL′ shiftL′ R′→N′) =
+  let
+    runtimeR : RuntimeOK R
+    runtimeR = okR
+
+    rec =
+      dynamicGradualGuarantee
+        runtimeR
         (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
         R⊒R′
         R′→N′
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      R↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+
+    framed⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ applyTerms χs L · N ⊒ applyTerm χ′ L′ · S′
+          ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        p↦q′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ⊢ _ ↦ _ ∶ᶜ _ ⇒ _ ⊒ _ ⇒ _
+        p↦q′ = {! ξ-·₂-updated-function-coercion !}
+
+        L⊒L′′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χs L ⊒ applyTerm χ′ L′
+              ∶ _ ↦ _ ⦂ _ ⇒ _ ⊒ _ ⇒ _
+        L⊒L′′ = {! ξ-·₂-updated-function-narrowing !}
+
+        N⊒S′-arg :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ N ⊒ S′ ∶ fun-narrow-domain-dualᶜ p↦q′ ⦂ _ ⊒ _
+        N⊒S′-arg =
+          let
+            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
+            ih = N⊒N′
+          in
+          {! ξ-·₂-IH-result-argument !}
+      in
+      ·⊒·ᵗ p↦q′ L⊒L′′ N⊒S′-arg
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (L · R —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ T′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      applyTerms χs L · N ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      ·₂-↠ vL noL R↠N ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      framed⊒
   in
-  {! ? !}
+  obligation
 dynamicGradualGuarantee okM pᶜ
     (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′)
     (pure-step ())
 dynamicGradualGuarantee okM pᶜ (κ⊒κᵗ κ qᶜ)
     (pure-step ())
-dynamicGradualGuarantee okM pᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N}
+    (ok-no (no•-⊕ noM noN)) pᶜ
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
-    (pure-step δ-⊕) =
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
+    (pure-step (δ-⊕ {m = m′} {n = n′})) =
+  let
+    rec =
+      separated-⊕-δ-left-first
+        (ok-no noM)
+        noN
+        M⊒M′
+        N⊒N′
+
+    χs , P , ΔL′ , ρ′ , C , D , r ,
+      source-steps , ΔL′≡ , ρ′≡ , P⊒P′ = rec
+  in
+  χs ,
+  P ,
+  ΔL′ ,
+  ΔR ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  refl ,
+  ρ′≡ ,
+  P⊒P′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N}
+    (ok-⊕₁ okM noN) pᶜ
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′})) =
+  let
+    rec =
+      separated-⊕-δ-left-first
+        okM
+        noN
+        M⊒M′
+        N⊒N′
+
+    χs , P , ΔL′ , ρ′ , C , D , r ,
+      source-steps , ΔL′≡ , ρ′≡ , P⊒P′ = rec
+  in
+  χs ,
+  P ,
+  ΔL′ ,
+  ΔR ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  refl ,
+  ρ′≡ ,
+  P⊒P′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N}
+    (ok-⊕₂ vM noM okN) pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (pure-step (δ-⊕ {m = m′} {n = n′})) =
+  let
+    rec =
+      separated-⊕-δ-right-first
+        vM
+        noM
+        okN
+        M⊒M′
+        N⊒N′
+
+    χs , P , ΔL′ , ρ′ , C , D , r ,
+      source-steps , ΔL′≡ , ρ′≡ , P⊒P′ = rec
+  in
+  χs ,
+  P ,
+  ΔL′ ,
+  ΔR ,
+  ρ′ ,
+  C ,
+  D ,
+  r ,
+  source-steps ,
+  ΔL′≡ ,
+  refl ,
+  ρ′≡ ,
+  P⊒P′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N}
+    okM pᶜ
+    add@(⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step blame-⊕₁) =
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
-    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+  [] ,
+  M ⊕[ addℕ ] N ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add) pᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N}
+    okM pᶜ
+    add@(⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step (blame-⊕₂ vV)) =
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
+  [] ,
+  M ⊕[ addℕ ] N ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add) pᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
+    {N′ = P′} {χ′ = χ′}
+    (ok-no (no•-⊕ noM noN)) pᶜ
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
-    (ξ-⊕₁ M′→P′ shiftN′) =
+    (ξ-⊕₁ {L′ = S′} M′→P′ shiftN′) =
   let
-    rec = dynamicGradualGuarantee {! ? !} pᶜ M⊒M′ M′→P′
+    rec =
+      dynamicGradualGuarantee
+        (ok-no noM)
+        pᶜ
+        M⊒M′
+        M′→P′
+
+    χs , P , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      M↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , P⊒P′ = rec
+
+    framed⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ P ⊕[ addℕ ] applyTerms χs N
+          ⊒ S′ ⊕[ addℕ ] applyTerm χ′ N′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        pℕ′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ⊢ id (‵ `ℕ) ∶ᶜ ‵ `ℕ ⊒ ‵ `ℕ
+        pℕ′ =
+          let μ , p′ᶜ = typed-term-narrowing-coercion P⊒P′ in
+          id-ℕ-narrowingᶜ (narrowing-store-corrᶜ p′ᶜ)
+
+        N⊒N′′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χs N ⊒ applyTerm χ′ N′
+              ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+        N⊒N′′ = {! ξ-⊕₁-updated-right-narrowing !}
+
+        P⊒P′ℕ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ P ⊒ S′
+              ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+        P⊒P′ℕ =
+          let
+            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+            ih = P⊒P′
+          in
+          {! ξ-⊕₁-IH-result-nat !}
+      in
+      ⊕⊒⊕ᵗ pℕ′ P⊒P′ℕ N⊒N′′
+
+    obligation :
+      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ P′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      P ⊕[ addℕ ] applyTerms χs N ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      ⊕₁-↠ noN M↠P ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      framed⊒
   in
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
+    {N′ = P′} {χ′ = χ′}
+    (ok-⊕₁ okM noN) pᶜ
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
-    (ξ-⊕₂ vM′ shiftM′ N′→P′) =
+    (ξ-⊕₁ {L′ = S′} M′→P′ shiftN′) =
   let
-    rec = dynamicGradualGuarantee {! ? !} pᶜ N⊒N′ N′→P′
+    rec =
+      dynamicGradualGuarantee
+        okM
+        pᶜ
+        M⊒M′
+        M′→P′
+
+    χs , P , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      M↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , P⊒P′ = rec
+
+    framed⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ P ⊕[ addℕ ] applyTerms χs N
+          ⊒ S′ ⊕[ addℕ ] applyTerm χ′ N′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        pℕ′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ⊢ id (‵ `ℕ) ∶ᶜ ‵ `ℕ ⊒ ‵ `ℕ
+        pℕ′ =
+          let μ , p′ᶜ = typed-term-narrowing-coercion P⊒P′ in
+          id-ℕ-narrowingᶜ (narrowing-store-corrᶜ p′ᶜ)
+
+        N⊒N′′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χs N ⊒ applyTerm χ′ N′
+              ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+        N⊒N′′ = {! ξ-⊕₁-updated-right-narrowing !}
+
+        P⊒P′ℕ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ P ⊒ S′ ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+        P⊒P′ℕ =
+          let
+            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+            ih = P⊒P′
+          in
+          {! ξ-⊕₁-IH-result-nat !}
+      in
+      ⊕⊒⊕ᵗ pℕ′ P⊒P′ℕ N⊒N′′
+
+    obligation :
+      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ P′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      P ⊕[ addℕ ] applyTerms χs N ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      ⊕₁-↠ noN M↠P ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      framed⊒
   in
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
-    (⊒cast+ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
-    M′⟨s⟩→N′ =
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
+    {χ′ = χ′}
+    (ok-⊕₂ vM noM okN) pᶜ
+    add@(⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (ξ-⊕₁ {L′ = S′} M′→S′ shiftN′) =
+  let
+    relation-obligation :
+      ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+        ⊢ M ⊕[ addℕ ] N
+          ⊒ S′ ⊕[ addℕ ] applyTerm χ′ N′ ∶ _ ⦂ _ ⊒ _
+    relation-obligation =
+      let
+        source-relation :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊕[ addℕ ] N
+            ⊒ M′ ⊕[ addℕ ] N′ ∶ _ ⦂ _ ⊒ _
+        source-relation = add
+
+        target-left-step : M′ —→[ χ′ ] S′
+        target-left-step = M′→S′
+
+        target-right-shift : Shiftable χ′ N′
+        target-right-shift = shiftN′
+
+        obligation :
+          ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+            ⊢ M ⊕[ addℕ ] N
+              ⊒ S′ ⊕[ addℕ ] applyTerm χ′ N′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! ξ-⊕₁-source-left-already-value-relation !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ P ⊒ S′ ⊕[ addℕ ] applyTerm χ′ N′ ∶ r ⦂ C ⊒ D
+    obligation =
+      [] ,
+      M ⊕[ addℕ ] N ,
+      ΔL ,
+      applyTyCtx χ′ ΔR ,
+      applyRightChange χ′ ρ ,
+      _ ,
+      _ ,
+      _ ,
+      ↠-refl ,
+      refl ,
+      refl ,
+      refl ,
+      relation-obligation
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
+    {χ′ = χ′}
+    (ok-no (no•-⊕ noM noN)) pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (ξ-⊕₂ {M′ = S′} vM′ shiftM′ N′→S′) =
+  let
+    χsM , WM , ΔL₁ ,
+      vWM , noWM , M↠WM , ΔL₁≡ , ρM-corr ,
+      leftM≡ , rightM≡ , pMᶜ , WM⊒M′ =
+      catchup-lemmaˡ
+        (ok-no noM)
+        vM′
+        M⊒M′
+
+    N⊒N′M :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ ∣ []
+        ⊢ applyTerms χsM N ⊒ N′
+          ∶ applyCoercions χsM (id (‵ `ℕ))
+          ⦂ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+    N⊒N′M =
+      advance-left-term-narrowing χsM ΔL₁≡ ρM-corr N⊒N′
+
+    pℕMᶜ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ
+        ⊢ applyCoercions χsM (id (‵ `ℕ))
+          ∶ᶜ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+    pℕMᶜ =
+      left-change-coercion-narrowing
+        χsM
+        ΔL₁≡
+        ρM-corr
+        pℕᶜ
+
+    rec =
+      dynamicGradualGuarantee
+        (applyTerms-preserves-RuntimeOK χsM (ok-no noN))
+        pℕMᶜ
+        N⊒N′M
+        N′→S′
+
+    χsN , P , ΔL₂ , ΔR′ , ρ′ ,
+      C , D , r ,
+      N↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+
+    source-left :
+      M ⊕[ addℕ ] N
+        —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
+    source-left = ⊕₁-↠ noN M↠WM
+
+    source-right :
+      WM ⊕[ addℕ ] applyTerms χsM N
+        —↠[ χsN ] applyTerms χsN WM ⊕[ addℕ ] P
+    source-right = ⊕₂-↠ vWM noWM N↠P
+
+    source-steps :
+      M ⊕[ addℕ ] N
+        —↠[ χsM ++ χsN ] applyTerms χsN WM ⊕[ addℕ ] P
+    source-steps = ↠-trans source-left source-right
+
+    ΔL₂≡total :
+      ΔL₂ ≡ applyTyCtxs (χsM ++ χsN) ΔL
+    ΔL₂≡total =
+      trans ΔL₂≡
+        (trans
+          (cong (applyTyCtxs χsN) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsM χsN ΔL)))
+
+    ρ′≡total :
+      ρ′ ≡ applyRightChange χ′ (applyLeftChanges (χsM ++ χsN) ρ)
+    ρ′≡total =
+      trans ρ′≡
+        (cong (applyRightChange χ′)
+          (sym (applyLeftChanges-++ χsM χsN ρ)))
+
+    framed⊒ :
+      ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ applyTerms χsN WM ⊕[ addℕ ] P
+          ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        ih : ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+        ih = P⊒S′
+
+        left-before-right-change :
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ ∣ []
+            ⊢ WM ⊒ M′
+              ∶ applyCoercions χsM (id (‵ `ℕ))
+              ⦂ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+        left-before-right-change = WM⊒M′
+
+        obligation :
+          ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χsN WM ⊕[ addℕ ] P
+              ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! ξ-⊕₂-source-left-not-yet-value-frame !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ P ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χsM ++ χsN ,
+      applyTerms χsN WM ⊕[ addℕ ] P ,
+      ΔL₂ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      source-steps ,
+      ΔL₂≡total ,
+      ΔR′≡ ,
+      ρ′≡total ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
+    {χ′ = χ′}
+    (ok-⊕₁ okM noN) pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (ξ-⊕₂ {M′ = S′} vM′ shiftM′ N′→S′) =
+  let
+    χsM , WM , ΔL₁ ,
+      vWM , noWM , M↠WM , ΔL₁≡ , ρM-corr ,
+      leftM≡ , rightM≡ , pMᶜ , WM⊒M′ =
+      catchup-lemmaˡ
+        okM
+        vM′
+        M⊒M′
+
+    N⊒N′M :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ ∣ []
+        ⊢ applyTerms χsM N ⊒ N′
+          ∶ applyCoercions χsM (id (‵ `ℕ))
+          ⦂ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+    N⊒N′M =
+      advance-left-term-narrowing χsM ΔL₁≡ ρM-corr N⊒N′
+
+    pℕMᶜ :
+      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ
+        ⊢ applyCoercions χsM (id (‵ `ℕ))
+          ∶ᶜ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+    pℕMᶜ =
+      left-change-coercion-narrowing
+        χsM
+        ΔL₁≡
+        ρM-corr
+        pℕᶜ
+
+    rec =
+      dynamicGradualGuarantee
+        (applyTerms-preserves-RuntimeOK χsM (ok-no noN))
+        pℕMᶜ
+        N⊒N′M
+        N′→S′
+
+    χsN , P , ΔL₂ , ΔR′ , ρ′ ,
+      C , D , r ,
+      N↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+
+    source-left :
+      M ⊕[ addℕ ] N
+        —↠[ χsM ] WM ⊕[ addℕ ] applyTerms χsM N
+    source-left = ⊕₁-↠ noN M↠WM
+
+    source-right :
+      WM ⊕[ addℕ ] applyTerms χsM N
+        —↠[ χsN ] applyTerms χsN WM ⊕[ addℕ ] P
+    source-right = ⊕₂-↠ vWM noWM N↠P
+
+    source-steps :
+      M ⊕[ addℕ ] N
+        —↠[ χsM ++ χsN ] applyTerms χsN WM ⊕[ addℕ ] P
+    source-steps = ↠-trans source-left source-right
+
+    ΔL₂≡total :
+      ΔL₂ ≡ applyTyCtxs (χsM ++ χsN) ΔL
+    ΔL₂≡total =
+      trans ΔL₂≡
+        (trans
+          (cong (applyTyCtxs χsN) ΔL₁≡)
+          (sym (applyTyCtxs-++ χsM χsN ΔL)))
+
+    ρ′≡total :
+      ρ′ ≡ applyRightChange χ′ (applyLeftChanges (χsM ++ χsN) ρ)
+    ρ′≡total =
+      trans ρ′≡
+        (cong (applyRightChange χ′)
+          (sym (applyLeftChanges-++ χsM χsN ρ)))
+
+    framed⊒ :
+      ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ applyTerms χsN WM ⊕[ addℕ ] P
+          ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        ih : ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+        ih = P⊒S′
+
+        left-before-right-change :
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ ∣ []
+            ⊢ WM ⊒ M′
+              ∶ applyCoercions χsM (id (‵ `ℕ))
+              ⦂ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
+        left-before-right-change = WM⊒M′
+
+        obligation :
+          ΔL₂ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χsN WM ⊕[ addℕ ] P
+              ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! ξ-⊕₂-source-left-still-reducing-frame !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ P ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χsM ++ χsN ,
+      applyTerms χsN WM ⊕[ addℕ ] P ,
+      ΔL₂ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      source-steps ,
+      ΔL₂≡total ,
+      ΔR′≡ ,
+      ρ′≡total ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
+    {N′ = P′} {χ′ = χ′}
+    (ok-⊕₂ vM noM okN) pᶜ
+    (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
+    (ξ-⊕₂ {M′ = S′} vM′ shiftM′ N′→P′) =
+  let
+    runtimeN : RuntimeOK N
+    runtimeN = okN
+
+    rec =
+      dynamicGradualGuarantee
+        runtimeN
+        pᶜ
+        N⊒N′
+        N′→P′
+
+    χs , P , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      N↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , P⊒P′ = rec
+
+    framed⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ applyTerms χs M ⊕[ addℕ ] P
+          ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ _ ⦂ _ ⊒ _
+    framed⊒ =
+      let
+        pℕ′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ⊢ id (‵ `ℕ) ∶ᶜ ‵ `ℕ ⊒ ‵ `ℕ
+        pℕ′ =
+          let μ , p′ᶜ = typed-term-narrowing-coercion P⊒P′ in
+          id-ℕ-narrowingᶜ (narrowing-store-corrᶜ p′ᶜ)
+
+        M⊒M′′ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ applyTerms χs M ⊒ applyTerm χ′ M′
+              ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+        M⊒M′′ = {! ξ-⊕₂-updated-left-narrowing !}
+
+        P⊒P′ℕ :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ P ⊒ S′ ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+        P⊒P′ℕ =
+          let
+            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
+            ih = P⊒P′
+          in
+          {! ξ-⊕₂-IH-result-nat !}
+      in
+      ⊕⊒⊕ᵗ pℕ′ M⊒M′′ P⊒P′ℕ
+
+    obligation :
+      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ P′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      applyTerms χs M ⊕[ addℕ ] P ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      ⊕₂-↠ vM noM N↠P ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      framed⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    (pure-step blame-⟨⟩) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel) pᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
     (⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    (pure-step (β-id vV)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  M⊒M′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    (⊒cast+ᵗ p′ᶜ rᶜ
+      (_ , _ , _ , _ , _ , (cast-id _ _ , cross (id-‵ ι)) , _)
+      M⊒M′)
+    (pure-step (β-id vV)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  M⊒M′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    (⊒cast+ᵗ p′ᶜ rᶜ
+      (_ , _ , _ , _ , _ , (cast-id _ _ , cross (id-＇ α)) , _)
+      M⊒M′)
+    (pure-step (β-id vV)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  M⊒M′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    (⊒cast+ᵗ p′ᶜ rᶜ
+      (_ , _ , _ , _ , _ , (cast-id _ _ , id★) , _)
+      M⊒M′)
+    (pure-step (β-id vV)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  M⊒M′
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M} {χ′ = χ′}
+    okM pᶜ
+    (⊒cast+ᵗ {M′ = M′} {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
+    (ξ-⟨⟩ {M′ = S′} M′→S′) =
+  let
+    rec :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
+    rec =
+      let
+        inner-runtime : RuntimeOK M
+        inner-runtime = okM
+
+        inner-step : M′ —→[ χ′ ] S′
+        inner-step = M′→S′
+
+        inner-narrowing :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ _ ⦂ _ ⊒ _
+        inner-narrowing = M⊒M′
+      in
+      {! target-cast-plus-inner-step-simulation !}
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒S′ = rec
+
+    cast-result⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ N ⊒ S′ ⟨ applyCoercion χ′ (narrowing-dual t⊒) ⟩
+          ∶ _ ⦂ _ ⊒ _
+    cast-result⊒ =
+      let
+        ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
+        ih = N⊒S′
+      in
+      {! target-cast-plus-inner-step-result !}
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ S′ ⟨ applyCoercion χ′ (narrowing-dual t⊒) ⟩
+            ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      N ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      source-steps ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      cast-result⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M} {N′ = N′} {χ′ = χ′}
+    okM pᶜ
+    castRel@(⊒cast+ᵗ {M′ = M′} p′ᶜ rᶜ t⊒ M⊒M′)
     M′⟨s⟩→N′ =
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
+  let
+    relation-obligation :
+      ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+        ⊢ M ⊒ N′ ∶ _ ⦂ _ ⊒ _
+    relation-obligation =
+      let
+        source-relation :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M
+            ⊒ M′ ⟨ narrowing-dual t⊒ ⟩ ∶ _ ⦂ _ ⊒ _
+        source-relation = castRel
+
+        target-cast-step :
+          M′ ⟨ narrowing-dual t⊒ ⟩ —→[ χ′ ] N′
+        target-cast-step = M′⟨s⟩→N′
+
+        obligation :
+          ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+            ⊢ M ⊒ N′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! target-cast-plus-simulation-relation !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+    obligation =
+      [] ,
+      M ,
+      ΔL ,
+      applyTyCtx χ′ ΔR ,
+      applyRightChange χ′ ρ ,
+      _ ,
+      _ ,
+      _ ,
+      ↠-refl ,
+      refl ,
+      refl ,
+      refl ,
+      relation-obligation
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M} {χ′ = χ′}
+    okM pᶜ
+    (⊒cast-ᵗ {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
+    (ξ-⟨⟩ {M′ = S′} M′→S′) =
+  let
+    rec = dynamicGradualGuarantee okM p′ᶜ M⊒M′ M′→S′
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒S′ = rec
+
+    cast-result⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ N ⊒ S′ ⟨ applyCoercion χ′ t ⟩ ∶ _ ⦂ _ ⊒ _
+    cast-result⊒ =
+      let
+        ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
+        ih = N⊒S′
+      in
+      {! target-cast-minus-inner-step-result !}
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+          ⊢ N ⊒ S′ ⟨ applyCoercion χ′ t ⟩ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      N ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      source-steps ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      cast-result⊒
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M} {N′ = N′} {χ′ = χ′}
+    okM pᶜ
+    castRel@(⊒cast-ᵗ {M′ = M′} {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
+    M′⟨s⟩→N′ =
+  let
+    relation-obligation :
+      ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+        ⊢ M ⊒ N′ ∶ _ ⦂ _ ⊒ _
+    relation-obligation =
+      let
+        source-relation :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ⟨ t ⟩
+            ∶ _ ⦂ _ ⊒ _
+        source-relation = castRel
+
+        target-cast-step : M′ ⟨ t ⟩ —→[ χ′ ] N′
+        target-cast-step = M′⟨s⟩→N′
+
+        obligation :
+          ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
+            ⊢ M ⊒ N′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! target-cast-minus-simulation-relation !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+    obligation =
+      [] ,
+      M ,
+      ΔL ,
+      applyTyCtx χ′ ΔR ,
+      applyRightChange χ′ ρ ,
+      _ ,
+      _ ,
+      _ ,
+      ↠-refl ,
+      refl ,
+      refl ,
+      refl ,
+      relation-obligation
+  in
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
+    okM pᶜ
     (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
   let
     rec = dynamicGradualGuarantee (runtime-⟨⟩ okM) qᶜ M⊒M′ M′→N′
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+
+    cast-result⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ N ⟨ applyCoercions χs c ⟩ ⊒ N′ ∶ _ ⦂ _ ⊒ _
+    cast-result⊒ =
+      let
+        ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+        ih = N⊒N′
+
+        source-cast-evidence :
+          _ ∣ ΔL ∣ ΔR ∣ ρ ⊢ _ ∶ _ ⊒ _
+        source-cast-evidence = s⊒
+
+        obligation :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ N ⟨ applyCoercions χs c ⟩ ⊒ N′ ∶ _ ⦂ _ ⊒ _
+        obligation = {! source-cast-plus-result-narrowing !}
+      in
+      obligation
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⟨ c ⟩ —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      N ⟨ applyCoercions χs c ⟩ ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      cast-↠ {c = c} source-steps ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      cast-result⊒
   in
-  {! ? !}
-dynamicGradualGuarantee okM pᶜ
-    (cast-⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
-  {! ? !}
+  obligation
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
+    okM pᶜ
+    (cast-⊒ᵗ {M′ = M′} qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
+  let
+    rec :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+    rec =
+      let
+        inner-runtime : RuntimeOK M
+        inner-runtime = runtime-⟨⟩ okM
+
+        inner-step : M′ —→[ χ′ ] N′
+        inner-step = M′→N′
+
+        inner-narrowing :
+          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ _ ⦂ _ ⊒ _
+        inner-narrowing = M⊒M′
+      in
+      {! source-cast-minus-inner-simulation !}
+
+    χs , N , ΔL′ , ΔR′ , ρ′ ,
+      C , D , r ,
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+
+    cast-result⊒ :
+      ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+        ⊢ N ⟨ applyCoercions χs c ⟩ ⊒ N′ ∶ _ ⦂ _ ⊒ _
+    cast-result⊒ =
+      let
+        ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+        ih = N⊒N′
+      in
+      {! source-cast-minus-result-narrowing !}
+
+    obligation :
+      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+      ∃[ C ] ∃[ D ] ∃[ r ]
+        (M ⟨ c ⟩ —↠[ χs ] N) ×
+        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
+        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
+    obligation =
+      χs ,
+      N ⟨ applyCoercions χs c ⟩ ,
+      ΔL′ ,
+      ΔR′ ,
+      ρ′ ,
+      _ ,
+      _ ,
+      _ ,
+      cast-↠ {c = c} source-steps ,
+      ΔL′≡ ,
+      ΔR′≡ ,
+      ρ′≡ ,
+      cast-result⊒
+  in
+  obligation

--- a/GTSF/proof/LeftChangeNarrowingSeparated.agda
+++ b/GTSF/proof/LeftChangeNarrowingSeparated.agda
@@ -1,0 +1,322 @@
+module proof.LeftChangeNarrowingSeparated where
+
+-- File Charter:
+--   * Shared left-store-change transport facts for separated-store narrowing.
+--   * Collects function-coercion projections, cast-shape injectivity, and the
+--     left-advancement surfaces used by beta simulation and the separated DGG.
+--   * Keeps these helper obligations out of the larger simulation scripts so
+--     Agda can cache them independently.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_; map)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; trans)
+
+open import Types
+open import Coercions
+open import NarrowWiden using
+  ( cross
+  ; dualⁿ
+  ; dualʷ
+  ; Widening
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.Catchup using (runtime-⇑ᵗᵐ)
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  )
+open import proof.CoercionProperties using
+  ( coercion-src-tgtᵐ
+  ; dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualʷ-flips-typingᵐ
+  )
+open import proof.ReductionProperties using
+  ( applyCoercions
+  ; applyCoercions-dual
+  )
+
+applyTerm-preserves-RuntimeOK :
+  ∀ χ {M} →
+  RuntimeOK M →
+  RuntimeOK (applyTerm χ M)
+applyTerm-preserves-RuntimeOK keep okM = okM
+applyTerm-preserves-RuntimeOK (bind A) okM = runtime-⇑ᵗᵐ okM
+
+applyTerms-preserves-RuntimeOK :
+  ∀ χs {M} →
+  RuntimeOK M →
+  RuntimeOK (applyTerms χs M)
+applyTerms-preserves-RuntimeOK [] okM = okM
+applyTerms-preserves-RuntimeOK (χ ∷ χs) okM =
+  applyTerms-preserves-RuntimeOK χs (applyTerm-preserves-RuntimeOK χ okM)
+
+applyTys-⇒ :
+  ∀ χs A B →
+  applyTys χs (A ⇒ B) ≡ applyTys χs A ⇒ applyTys χs B
+applyTys-⇒ [] A B = refl
+applyTys-⇒ (keep ∷ χs) A B = applyTys-⇒ χs A B
+applyTys-⇒ (bind C ∷ χs) A B = applyTys-⇒ χs (⇑ᵗ A) (⇑ᵗ B)
+
+applyCoercions-↦ :
+  ∀ χs p q →
+  applyCoercions χs (p ↦ q) ≡ applyCoercions χs p ↦ applyCoercions χs q
+applyCoercions-↦ [] p q = refl
+applyCoercions-↦ (keep ∷ χs) p q = applyCoercions-↦ χs p q
+applyCoercions-↦ (bind A ∷ χs) p q =
+  applyCoercions-↦ χs (⇑ᶜ p) (⇑ᶜ q)
+
+applyCoercions-dual-applyCoercions :
+  ∀ χs χs′ p →
+  applyCoercions χs′ (applyCoercions χs (- p)) ≡
+    - applyCoercions χs′ (applyCoercions χs p)
+applyCoercions-dual-applyCoercions χs χs′ p =
+  trans
+    (cong (applyCoercions χs′) (applyCoercions-dual χs p))
+    (applyCoercions-dual χs′ (applyCoercions χs p))
+
+applyLeftCtxEntry : StoreChanges → CtxCorrEntry → CtxCorrEntry
+applyLeftCtxEntry χs (ctx-entry A B p) =
+  ctx-entry (applyTys χs A) B (applyCoercions χs p)
+
+applyLeftCtx : StoreChanges → CtxCorr → CtxCorr
+applyLeftCtx χs γ = map (applyLeftCtxEntry χs) γ
+
+no•-cast-inv : ∀ {M c} → No• (M ⟨ c ⟩) → No• M
+no•-cast-inv (no•-⟨⟩ noM) = noM
+
+⟨⟩-term-injective :
+  ∀ {M N : Term} {c d : Coercion} →
+  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
+  M ≡ N
+⟨⟩-term-injective refl = refl
+
+⟨⟩-coercion-injective :
+  ∀ {M N : Term} {c d : Coercion} →
+  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
+  c ≡ d
+⟨⟩-coercion-injective refl = refl
+
+widen-fun-domainᵐ :
+  ∀ {μ Δ Σ c d A A′ B B′} →
+  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ A ⇒ B ⊑ A′ ⇒ B′ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A′ ⊒ A
+widen-fun-domainᵐ (cast-fun c⊢ _ , cross (cⁿ ↦ⁿʷ _)) = c⊢ , cⁿ
+
+narrow-fun-codomainᵐ :
+  ∀ {μ Δ Σ c d A A′ B B′} →
+  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ A ⇒ B ⊒ A′ ⇒ B′ →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ B ⊒ B′
+narrow-fun-codomainᵐ (cast-fun _ d⊢ , cross (_ ↦ⁿʷ dⁿ)) = d⊢ , dⁿ
+
+separated-fun-codomain :
+  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ A ⇒ B ⊒ A′ ⇒ B′ →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ q ∶ B ⊒ B′
+separated-fun-codomain
+    (stores , _ , _ , wf⇒ _ hB , wf⇒ _ hB′ ,
+      (cast-fun _ q⊢L , cross (_ ↦ⁿʷ qⁿL)) ,
+      (cast-fun _ q⊢R , cross (_ ↦ⁿʷ qⁿR))) =
+  stores ,
+  proj₁ (coercion-src-tgtᵐ q⊢L) ,
+  proj₂ (coercion-src-tgtᵐ q⊢L) ,
+  hB ,
+  hB′ ,
+  (q⊢L , qⁿL) ,
+  (q⊢R , qⁿR)
+
+↦-codomain : Coercion → Coercion
+↦-codomain (id A) = id A
+↦-codomain (c ︔ d) = c ︔ d
+↦-codomain (c ↦ d) = d
+↦-codomain (`∀ c) = `∀ c
+↦-codomain (G !) = G !
+↦-codomain (G ？) = G ？
+↦-codomain (seal A α) = seal A α
+↦-codomain (unseal α A) = unseal α A
+↦-codomain (gen A c) = gen A c
+↦-codomain (inst B c) = inst B c
+
+↦-right-injective :
+  ∀ {c c′ d d′ : Coercion} →
+  c ↦ d ≡ c′ ↦ d′ →
+  d ≡ d′
+↦-right-injective eq = cong ↦-codomain eq
+
+↦-domain : Coercion → Coercion
+↦-domain (id A) = id A
+↦-domain (c ︔ d) = c ︔ d
+↦-domain (c ↦ d) = c
+↦-domain (`∀ c) = `∀ c
+↦-domain (G !) = G !
+↦-domain (G ？) = G ？
+↦-domain (seal A α) = seal A α
+↦-domain (unseal α A) = unseal α A
+↦-domain (gen A c) = gen A c
+↦-domain (inst B c) = inst B c
+
+↦-left-injective :
+  ∀ {c c′ d d′ : Coercion} →
+  c ↦ d ≡ c′ ↦ d′ →
+  c ≡ c′
+↦-left-injective eq = cong ↦-domain eq
+
+separated-left-coercionᵐ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ ΔL ∣ leftStore ρ ⊢ c ∶ A ⊒ B
+separated-left-coercionᵐ (_ , _ , _ , _ , _ , c⊒L , _) = c⊒L
+
+separated-right-coercionᵐ :
+  ∀ {μ ΔL ΔR ρ c A B} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ ΔR ∣ rightStore ρ ⊢ c ∶ A ⊒ B
+separated-right-coercionᵐ (_ , _ , _ , _ , _ , _ , c⊒R) = c⊒R
+
+postulate
+  left-change-term-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ γ M M′ p A B} →
+    ΔL′ ≡ applyTyCtxs χs ΔL →
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+    ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+    ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ applyLeftCtx χs γ
+      ⊢ applyTerms χs M ⊒ M′ ∶ applyCoercions χs p
+        ⦂ applyTys χs A ⊒ B
+
+  left-change-coercion-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ} →
+    ΔL′ ≡ applyTyCtxs χs ΔL →
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+    μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+    μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+      ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ B
+
+  left-change-source-coercion-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ} →
+    ΔL′ ≡ applyTyCtxs χs ΔL →
+    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+    μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+    μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+      ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ applyTys χs B
+
+  left-change-source-coercion-narrowing-dual :
+    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ}
+      (ΔL′≡ : ΔL′ ≡ applyTyCtxs χs ΔL)
+      (ρ′-corr : StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ))
+      (c⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B) →
+    narrowing-dual
+      (left-change-source-coercion-narrowing χs ΔL′≡ ρ′-corr c⊒)
+    ≡ applyCoercions χs (narrowing-dual c⊒)
+
+  dualʷ-raw-determined :
+    ∀ η {c} (cʷ₁ cʷ₂ : Widening c) →
+    proj₁ (dualʷ η cʷ₁) ≡ proj₁ (dualʷ η cʷ₂)
+
+  dualʷ-involutive-raw :
+    ∀ {c} (cʷ : Widening c) →
+    proj₁ (dualⁿ normalᵃ (proj₂ (dualʷ normalᵃ cʷ))) ≡ c
+
+separated-fun-domain-dual :
+  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
+  (p↦q : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ A ⇒ B ⊒ A′ ⇒ B′) →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dual p↦q ∶ A ⊒ A′
+separated-fun-domain-dual {μ = μ} {ΔR = ΔR} {ρ = ρ}
+    {A = A} {A′ = A′}
+    (stores , _ , _ , wf⇒ hA hB , wf⇒ hA′ hB′ ,
+      (cast-fun p⊢L _ , cross (pʷL ↦ⁿʷ _)) ,
+      (cast-fun p⊢R _ , cross (pʷR ↦ⁿʷ _))) =
+  let
+    pᵈ⊒L =
+      dualʷ-flips-typingᵐ
+        {η = normalᵃ}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (leftStore-wf stores)
+        (p⊢L , pʷL)
+
+    pᵈ⊒R =
+      dualʷ-flips-typingᵐ
+        {η = normalᵃ}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (rightStore-wf stores)
+        (p⊢R , pʷR)
+  in
+  stores ,
+  proj₁ (coercion-src-tgtᵐ (proj₁ pᵈ⊒L)) ,
+  proj₂ (coercion-src-tgtᵐ (proj₁ pᵈ⊒L)) ,
+  hA ,
+  hA′ ,
+  pᵈ⊒L ,
+  subst
+    (λ p → μ ∣ ΔR ∣ rightStore ρ ⊢ p ∶ A ⊒ A′)
+    (dualʷ-raw-determined normalᵃ pʷR pʷL)
+    pᵈ⊒R
+
+advance-left-term-narrowing :
+  ∀ χs {ΔL ΔL′ ΔR ρ M M′ p A B} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+    ⊢ applyTerms χs M ⊒ M′ ∶ applyCoercions χs p
+      ⦂ applyTys χs A ⊒ B
+advance-left-term-narrowing χs ΔL′≡ ρ′-corr M⊒M′ =
+  left-change-term-narrowing χs ΔL′≡ ρ′-corr M⊒M′
+
+advance-left-function-term-narrowing :
+  ∀ χs {ΔL ΔL′ ΔR ρ W W′ p q A A′ B B′} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ W′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+    ⊢ applyTerms χs W ⊒ W′
+      ∶ applyCoercions χs p ↦ applyCoercions χs q
+      ⦂ applyTys χs A ⇒ applyTys χs B ⊒ A′ ⇒ B′
+advance-left-function-term-narrowing χs {p = p} {q = q} {A = A}
+    {B = B} ΔL′≡ ρ′-corr W⊒W′ =
+  subst
+    (λ c →
+      _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ c
+        ⦂ applyTys χs A ⇒ applyTys χs B ⊒ _)
+    (applyCoercions-↦ χs p q)
+    (subst
+      (λ C →
+        _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ applyCoercions χs (p ↦ q)
+          ⦂ C ⊒ _)
+      (applyTys-⇒ χs A B)
+      (advance-left-term-narrowing χs ΔL′≡ ρ′-corr W⊒W′))
+
+advance-left-lambda-narrowing :
+  ∀ χs {ΔL ΔL′ ΔR ρ W N′ p q A A′ B B′} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ ƛ N′ ∶ p ↦ q
+    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
+  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+    ⊢ applyTerms χs W ⊒ ƛ N′
+      ∶ applyCoercions χs p ↦ applyCoercions χs q
+      ⦂ applyTys χs A ⇒ applyTys χs B ⊒ A′ ⇒ B′
+advance-left-lambda-narrowing χs {p = p} {q = q} {A = A} {B = B}
+    ΔL′≡ ρ′-corr W⊒ƛ =
+  subst
+    (λ c →
+      _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ c
+        ⦂ applyTys χs A ⇒ applyTys χs B ⊒ _)
+    (applyCoercions-↦ χs p q)
+    (subst
+      (λ C →
+        _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ applyCoercions χs (p ↦ q)
+          ⦂ C ⊒ _)
+      (applyTys-⇒ χs A B)
+      (advance-left-term-narrowing χs ΔL′≡ ρ′-corr W⊒ƛ))

--- a/GTSF/proof/SimBetaSeparated.agda
+++ b/GTSF/proof/SimBetaSeparated.agda
@@ -1,5 +1,3 @@
---{-# OPTIONS --allow-unsolved-metas #-}
-
 module proof.SimBetaSeparated where
 
 -- File Charter:
@@ -65,207 +63,37 @@ open import proof.ReductionProperties using
   ; ·₁-↠
   ; ·₂-↠
   )
-
-applyTerm-preserves-RuntimeOK :
-  ∀ χ {M} →
-  RuntimeOK M →
-  RuntimeOK (applyTerm χ M)
-applyTerm-preserves-RuntimeOK keep okM = okM
-applyTerm-preserves-RuntimeOK (bind A) okM = runtime-⇑ᵗᵐ okM
-
-applyTerms-preserves-RuntimeOK :
-  ∀ χs {M} →
-  RuntimeOK M →
-  RuntimeOK (applyTerms χs M)
-applyTerms-preserves-RuntimeOK [] okM = okM
-applyTerms-preserves-RuntimeOK (χ ∷ χs) okM =
-  applyTerms-preserves-RuntimeOK χs (applyTerm-preserves-RuntimeOK χ okM)
-
-applyTys-⇒ :
-  ∀ χs A B →
-  applyTys χs (A ⇒ B) ≡ applyTys χs A ⇒ applyTys χs B
-applyTys-⇒ [] A B = refl
-applyTys-⇒ (keep ∷ χs) A B = applyTys-⇒ χs A B
-applyTys-⇒ (bind C ∷ χs) A B = applyTys-⇒ χs (⇑ᵗ A) (⇑ᵗ B)
-
-applyCoercions-↦ :
-  ∀ χs p q →
-  applyCoercions χs (p ↦ q) ≡ applyCoercions χs p ↦ applyCoercions χs q
-applyCoercions-↦ [] p q = refl
-applyCoercions-↦ (keep ∷ χs) p q = applyCoercions-↦ χs p q
-applyCoercions-↦ (bind A ∷ χs) p q =
-  applyCoercions-↦ χs (⇑ᶜ p) (⇑ᶜ q)
-
-applyCoercions-dual-applyCoercions :
-  ∀ χs χs′ p →
-  applyCoercions χs′ (applyCoercions χs (- p)) ≡
-    - applyCoercions χs′ (applyCoercions χs p)
-applyCoercions-dual-applyCoercions χs χs′ p =
-  trans
-    (cong (applyCoercions χs′) (applyCoercions-dual χs p))
-    (applyCoercions-dual χs′ (applyCoercions χs p))
-
-------------------------------------------------------------------------
--- Left-side advancement surfaces
-------------------------------------------------------------------------
-
-applyLeftCtxEntry : StoreChanges → CtxCorrEntry → CtxCorrEntry
-applyLeftCtxEntry χs (ctx-entry A B p) =
-  ctx-entry (applyTys χs A) B (applyCoercions χs p)
-
-applyLeftCtx : StoreChanges → CtxCorr → CtxCorr
-applyLeftCtx χs γ = map (applyLeftCtxEntry χs) γ
-
-no•-cast-inv : ∀ {M c} → No• (M ⟨ c ⟩) → No• M
-no•-cast-inv (no•-⟨⟩ noM) = noM
-
-⟨⟩-term-injective :
-  ∀ {M N : Term} {c d : Coercion} →
-  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
-  M ≡ N
-⟨⟩-term-injective refl = refl
-
-⟨⟩-coercion-injective :
-  ∀ {M N : Term} {c d : Coercion} →
-  M ⟨ c ⟩ ≡ N ⟨ d ⟩ →
-  c ≡ d
-⟨⟩-coercion-injective refl = refl
-
-widen-fun-domainᵐ :
-  ∀ {μ Δ Σ c d A A′ B B′} →
-  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ A ⇒ B ⊑ A′ ⇒ B′ →
-  μ ∣ Δ ∣ Σ ⊢ c ∶ A′ ⊒ A
-widen-fun-domainᵐ (cast-fun c⊢ _ , cross (cⁿ ↦ⁿʷ _)) = c⊢ , cⁿ
-
-narrow-fun-codomainᵐ :
-  ∀ {μ Δ Σ c d A A′ B B′} →
-  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ A ⇒ B ⊒ A′ ⇒ B′ →
-  μ ∣ Δ ∣ Σ ⊢ d ∶ B ⊒ B′
-narrow-fun-codomainᵐ (cast-fun _ d⊢ , cross (_ ↦ⁿʷ dⁿ)) = d⊢ , dⁿ
-
-separated-fun-codomain :
-  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
-  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ A ⇒ B ⊒ A′ ⇒ B′ →
-  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ q ∶ B ⊒ B′
-separated-fun-codomain
-    (stores , _ , _ , wf⇒ _ hB , wf⇒ _ hB′ ,
-      (cast-fun _ q⊢L , cross (_ ↦ⁿʷ qⁿL)) ,
-      (cast-fun _ q⊢R , cross (_ ↦ⁿʷ qⁿR))) =
-  stores ,
-  proj₁ (coercion-src-tgtᵐ q⊢L) ,
-  proj₂ (coercion-src-tgtᵐ q⊢L) ,
-  hB ,
-  hB′ ,
-  (q⊢L , qⁿL) ,
-  (q⊢R , qⁿR)
-
-↦-codomain : Coercion → Coercion
-↦-codomain (id A) = id A
-↦-codomain (c ︔ d) = c ︔ d
-↦-codomain (c ↦ d) = d
-↦-codomain (`∀ c) = `∀ c
-↦-codomain (G !) = G !
-↦-codomain (G ？) = G ？
-↦-codomain (seal A α) = seal A α
-↦-codomain (unseal α A) = unseal α A
-↦-codomain (gen A c) = gen A c
-↦-codomain (inst B c) = inst B c
-
-↦-right-injective :
-  ∀ {c c′ d d′ : Coercion} →
-  c ↦ d ≡ c′ ↦ d′ →
-  d ≡ d′
-↦-right-injective eq = cong ↦-codomain eq
-
-separated-left-coercionᵐ :
-  ∀ {μ ΔL ΔR ρ c A B} →
-  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
-  μ ∣ ΔL ∣ leftStore ρ ⊢ c ∶ A ⊒ B
-separated-left-coercionᵐ (_ , _ , _ , _ , _ , c⊒L , _) = c⊒L
-
-separated-right-coercionᵐ :
-  ∀ {μ ΔL ΔR ρ c A B} →
-  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
-  μ ∣ ΔR ∣ rightStore ρ ⊢ c ∶ A ⊒ B
-separated-right-coercionᵐ (_ , _ , _ , _ , _ , _ , c⊒R) = c⊒R
-
-postulate
-  left-change-term-narrowing :
-    ∀ χs {ΔL ΔL′ ΔR ρ γ M M′ p A B} →
-    ΔL′ ≡ applyTyCtxs χs ΔL →
-    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
-    ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
-    ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ applyLeftCtx χs γ
-      ⊢ applyTerms χs M ⊒ M′ ∶ applyCoercions χs p
-        ⦂ applyTys χs A ⊒ B
-
-  left-change-coercion-narrowing :
-    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ} →
-    ΔL′ ≡ applyTyCtxs χs ΔL →
-    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
-    μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
-    μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
-      ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ B
-
-  left-change-source-coercion-narrowing :
-    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ} →
-    ΔL′ ≡ applyTyCtxs χs ΔL →
-    StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
-    μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
-    μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
-      ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ applyTys χs B
-
-  left-change-source-coercion-narrowing-dual :
-    ∀ χs {ΔL ΔL′ ΔR ρ c A B μ}
-      (ΔL′≡ : ΔL′ ≡ applyTyCtxs χs ΔL)
-      (ρ′-corr : StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ))
-      (c⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B) →
-    narrowing-dual
-      (left-change-source-coercion-narrowing χs ΔL′≡ ρ′-corr c⊒)
-    ≡ applyCoercions χs (narrowing-dual c⊒)
-
-  dualʷ-raw-determined :
-    ∀ η {c} (cʷ₁ cʷ₂ : Widening c) →
-    proj₁ (dualʷ η cʷ₁) ≡ proj₁ (dualʷ η cʷ₂)
-
-  dualʷ-involutive-raw :
-    ∀ {c} (cʷ : Widening c) →
-    proj₁ (dualⁿ normalᵃ (proj₂ (dualʷ normalᵃ cʷ))) ≡ c
-
-advance-left-term-narrowing :
-  ∀ χs {ΔL ΔL′ ΔR ρ M M′ p A B} →
-  ΔL′ ≡ applyTyCtxs χs ΔL →
-  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
-  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
-    ⊢ applyTerms χs M ⊒ M′ ∶ applyCoercions χs p
-      ⦂ applyTys χs A ⊒ B
-advance-left-term-narrowing χs ΔL′≡ ρ′-corr M⊒M′ =
-  left-change-term-narrowing χs ΔL′≡ ρ′-corr M⊒M′
-
-advance-left-lambda-narrowing :
-  ∀ χs {ΔL ΔL′ ΔR ρ W N′ p q A A′ B B′} →
-  ΔL′ ≡ applyTyCtxs χs ΔL →
-  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ W ⊒ ƛ N′ ∶ p ↦ q
-    ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
-    ⊢ applyTerms χs W ⊒ ƛ N′
-      ∶ applyCoercions χs p ↦ applyCoercions χs q
-      ⦂ applyTys χs A ⇒ applyTys χs B ⊒ A′ ⇒ B′
-advance-left-lambda-narrowing χs {p = p} {q = q} {A = A} {B = B}
-    ΔL′≡ ρ′-corr W⊒ƛ =
-  subst
-    (λ c →
-      _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ c
-        ⦂ applyTys χs A ⇒ applyTys χs B ⊒ _)
-    (applyCoercions-↦ χs p q)
-    (subst
-      (λ C →
-        _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ applyCoercions χs (p ↦ q)
-          ⦂ C ⊒ _)
-      (applyTys-⇒ χs A B)
-      (left-change-term-narrowing χs ΔL′≡ ρ′-corr W⊒ƛ))
+open import proof.LeftChangeNarrowingSeparated public using
+  ( applyTerm-preserves-RuntimeOK
+  ; applyTerms-preserves-RuntimeOK
+  ; applyTys-⇒
+  ; applyCoercions-↦
+  ; applyCoercions-dual-applyCoercions
+  ; applyLeftCtxEntry
+  ; applyLeftCtx
+  ; no•-cast-inv
+  ; ⟨⟩-term-injective
+  ; ⟨⟩-coercion-injective
+  ; widen-fun-domainᵐ
+  ; narrow-fun-codomainᵐ
+  ; separated-fun-codomain
+  ; ↦-codomain
+  ; ↦-right-injective
+  ; ↦-domain
+  ; ↦-left-injective
+  ; separated-left-coercionᵐ
+  ; separated-right-coercionᵐ
+  ; left-change-term-narrowing
+  ; left-change-coercion-narrowing
+  ; left-change-source-coercion-narrowing
+  ; left-change-source-coercion-narrowing-dual
+  ; dualʷ-raw-determined
+  ; dualʷ-involutive-raw
+  ; separated-fun-domain-dual
+  ; advance-left-term-narrowing
+  ; advance-left-function-term-narrowing
+  ; advance-left-lambda-narrowing
+  )
 
 ------------------------------------------------------------------------
 -- Function application simulation


### PR DESCRIPTION
## Summary

- Extract beta-only, beta-cast, primitive/delta, and left-change helper lemmas into separate separated-DGG proof modules.
- Wire DynamicGradualGuaranteeSeparated to the helper modules so the main file is smaller and imports the new proof clusters.
- Preserve annotated holes for the remaining beta-cast target-plus obligation and the separated DGG xi/cast-frame work, without adding new postulates.

## Validation

- agda -v0 proof/LeftChangeNarrowingSeparated.agda
- agda -v0 proof/DGGPrimitiveSeparated.agda
- agda -v0 proof/DGGBetaSeparated.agda
- agda -v0 proof/DGGDeltaSeparated.agda
- agda --only-scope-checking proof/DGGBetaCastSeparated.agda
- agda -v0 proof/SimBetaSeparated.agda

## Notes

- Full DGGBetaCastSeparated checking was avoided because an earlier run remained silent/slow after 90 seconds; scope-checking passes.
- Unrelated untracked workspace files were left out of this PR.