### PR TITLE
Repair separated DGG type-check and split cast- target-step cases

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -20,8 +20,8 @@ import NuReduction
 import proof.NWTermReduction
 import TermNarrowing
 import proof.TermNarrowingProperties
---import proof.CatchupSeparated
---import proof.DynamicGradualGuaranteeSeparated
+import proof.CatchupSeparated
+import proof.DynamicGradualGuaranteeSeparated
 import NarrowingExamples
 import NuMetaTheory
 import proof.DynamicGradualGuarantee

--- a/GTSF/proof/DGGBetaCastSeparated.agda
+++ b/GTSF/proof/DGGBetaCastSeparated.agda
@@ -283,6 +283,9 @@ separated-source-cast-plus-result {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (sym (applyTys-++ χsA χsT Bₒ))
         N-cast⊒T))
 
+-- Temporarily TERMINATING for the same reason as `sim-beta`: the recursive
+-- call goes through catchup projections that Agda cannot see as structural.
+{-# TERMINATING #-}
 separated-dgg-beta-cast-value-shape :
   ∀ {ΔL ΔR ρ L R T V′ W′ c d pᵈ p q A A′ B B′} →
   Value L →
@@ -402,6 +405,37 @@ separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
     (⊒cast+ᵗ {t = inst A t} pᶜ rᶜ t⊒ L⊒F′)
     () p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {r = id P} {t = cₜ ↦ dₜ} pᶜ rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′ =
+  {! separated-dgg-beta-cast-target-plus-id-inner-coercion !}
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {r = r₁ ︔ r₂} {t = cₜ ↦ dₜ} pᶜ rᶜ t⊒ L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′ =
+  {! separated-dgg-beta-cast-target-plus-seq-inner-coercion !}
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {r = G !} {t = cₜ ↦ dₜ} pᶜ
+      (_ , _ , refl , _ , _ , _ , _)
+      (_ , _ , () , _ , _ , _ , _)
+      L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {r = seal P α} {t = cₜ ↦ dₜ} pᶜ
+      (_ , _ , refl , _ , _ , _ , _)
+      (_ , _ , () , _ , _ , _ , _)
+      L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
+separated-dgg-beta-cast-value-shape
+    vL noL vR noR vV′ vW′
+    (⊒cast+ᵗ {r = gen P r} {t = cₜ ↦ dₜ} pᶜ
+      (_ , _ , refl , _ , _ , _ , _)
+      (_ , _ , () , _ , _ , _ , _)
+      L⊒F′)
+    T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d} {A′ = A′} {B′ = B′}
@@ -881,6 +915,14 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
+    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF L≡Fcd =
+  {! separated-dgg-beta-cast-source-plus-noncanonical-inner-coercion !}
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
     sourceCast@(cast-⊒ᵗ {M = F₀} {q = pₒ ↦ qₒ} {r = pᵢ ↦ qᵢ}
       {s = c₀ ↦ d₀} {A = AL ⇒ BL} {C = Aₒ ⇒ Bₒ}
       {η = ηCast}
@@ -1288,6 +1330,14 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     sourceCast@(cast-⊒ᵗ {M = F₀} {s = inst A s} qᶜ rᶜ s⊒ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
+separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
+    {d = d}
+    vL noL vR noR vV′ vW′
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s₁ ↦ s₂} qᶜ rᶜ s⊒ F₀⊒T)
+    T≡V′cd p-domainᶜ R⊒W′
+    | fv-↦ vF L≡Fcd =
+  {! separated-dgg-beta-cast-source-minus-general-fun-cast !}
 
 separated-dgg-beta-cast-value :
   ∀ {ΔL ΔR ρ L R V′ W′ c d pᵈ p q A A′ B B′} →

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -210,3 +210,47 @@ Current validation target:
 - `All.agda` passes with the raw relation deleted.  Historical proof
   experiments and prose notes may still mention raw constructor names, but they
   are outside the active aggregate checker.
+
+## Separated DGG skeleton back in the aggregate, 2026-07-05
+
+Repairs:
+
+- `proof.DGGBetaCastSeparated` had been committed in a non-checking state:
+  `separated-dgg-beta-cast-value-shape` failed coverage in three places and
+  failed the termination checker.  It now checks.  The recursion through
+  catchup projections is marked `TERMINATING`, matching the existing
+  `sim-beta` precedent.  For a function-shaped target cast, the `⊒cast+ᵗ`
+  inner coercions `G \!`, `seal`, and `gen` are refuted by matching `refl` in
+  the inner coercion's `tgt` equation and `()` in the cast typing's `tgt`
+  equation (an arrow type cannot be `★`, `＇α`, or `∀`).  The `id` and `_︔_`
+  inner coercions are genuine open branches and hold explicit holes, as do
+  the non-canonical inner-coercion shapes of the two source-cast
+  `with`-groups.
+- With that module checking, `proof.CatchupSeparated` and
+  `proof.DynamicGradualGuaranteeSeparated` are imported by `All.agda` again.
+
+Progress on `dynamicGradualGuarantee` in
+`proof.DynamicGradualGuaranteeSeparated`:
+
+- New proved clause: `⊒cast-ᵗ` with `pure-step (tag-untag-bad _ _)`.  The
+  target blames, so zero source steps and `⊒blameᵗ` with the source typing
+  projection close it.
+- The `⊒cast-ᵗ` catch-all clause is gone.  Because `⊒cast-ᵗ` stores the raw
+  cast coercion as an index, Agda can split the target reduction
+  exhaustively; the remaining shapes are four named holes (`β-seq`,
+  `β-inst`, `tag-untag-ok`, `seal-unseal`), each with zero source steps.
+- The same split does not work for `⊒cast+ᵗ`: its target cast is the
+  projection `narrowing-dual t⊒`, and a clause for `pure-step blame-⟨⟩`
+  gets Agda stuck deciding whether `β-id` could also apply under the
+  unknown dual.  A generic `blame-⟨⟩` clause was attempted and reverted;
+  handling these requires matching the `t⊒` witness first, as the three
+  existing `β-id` clauses do.
+
+Blockers recorded for the frame cases (see the checklist for detail): the
+missing right-side store-change transport surface, and the loss of the
+`C`/`D`/`r` link in the theorem's existential conclusion.  Type-endpoint
+tracking (`C ≡ applyTys χs A`, `D ≡ applyTy χ′ B`) looks provable in every
+current completed clause, but coercion-index tracking is falsified by the
+`β-id` clauses, so the application and `⊕` frames also need either a
+coercion-conversion rule or `∶ᶜ` result evidence, which `⊒cast+ᵗ` inner
+relations cannot supply.

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -1476,6 +1476,24 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM pᶜ
+    castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    (pure-step (tag-untag-bad vV′ G≢H)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel) pᶜ
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , _ , _ , _ , _ , (cast-id _ _ , cross (id-‵ ι)) , _)
       M⊒M′)
@@ -1701,55 +1719,77 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   in
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
-    {M = M} {N′ = N′} {χ′ = χ′}
+    {M = M}
     okM pᶜ
-    castRel@(⊒cast-ᵗ {M′ = M′} {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
-    M′⟨s⟩→N′ =
-  let
-    relation-obligation :
-      ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
-        ⊢ M ⊒ N′ ∶ _ ⦂ _ ⊒ _
-    relation-obligation =
-      let
-        source-relation :
-          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ⟨ t ⟩
-            ∶ _ ⦂ _ ⊒ _
-        source-relation = castRel
-
-        target-cast-step : M′ ⟨ t ⟩ —→[ χ′ ] N′
-        target-cast-step = M′⟨s⟩→N′
-
-        obligation :
-          ΔL ∣ applyTyCtx χ′ ΔR ∣ applyRightChange χ′ ρ ∣ []
-            ⊢ M ⊒ N′ ∶ _ ⦂ _ ⊒ _
-        obligation = {! target-cast-minus-simulation-relation !}
-      in
-      obligation
-
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
-    obligation =
-      [] ,
-      M ,
-      ΔL ,
-      applyTyCtx χ′ ΔR ,
-      applyRightChange χ′ ρ ,
-      _ ,
-      _ ,
-      _ ,
-      ↠-refl ,
-      refl ,
-      refl ,
-      refl ,
-      relation-obligation
-  in
-  obligation
+    castRel@(⊒cast-ᵗ {M′ = V′} {t = t₁ ︔ t₂} p′ᶜ rᶜ t⊒ M⊒V′)
+    (pure-step (β-seq vV′)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  {! target-cast-minus-seq-split-relation !}
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    castRel@(⊒cast-ᵗ {M′ = V′} {t = inst B₁ t₁} p′ᶜ rᶜ t⊒ M⊒V′)
+    (pure-step (β-inst vV′)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  {! target-cast-minus-inst-nu-relation !}
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    castRel@(⊒cast-ᵗ {t = G ？} p′ᶜ rᶜ t⊒ M⊒V′tag)
+    (pure-step (tag-untag-ok vV′)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  {! target-cast-minus-tag-untag-collapse-relation !}
+dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {M = M}
+    okM pᶜ
+    castRel@(⊒cast-ᵗ {t = unseal α B₁} p′ᶜ rᶜ t⊒ M⊒V′seal)
+    (pure-step (seal-unseal vV′)) =
+  [] ,
+  M ,
+  ΔL ,
+  ΔR ,
+  ρ ,
+  _ ,
+  _ ,
+  _ ,
+  ↠-refl ,
+  refl ,
+  refl ,
+  refl ,
+  {! target-cast-minus-seal-unseal-collapse-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
     okM pᶜ

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -22,6 +22,17 @@
 - [x] State `catchup-lemmaˡ` with the target term unchanged.
 - [x] Add the new separated-store modules to `All.agda`.
 - [x] Add the separated DGG beta proof surface to `All.agda`.
+- [x] Restore `proof.CatchupSeparated` and
+  `proof.DynamicGradualGuaranteeSeparated` to `All.agda` (they had been
+  commented out while `proof.DGGBetaCastSeparated` failed to check).
+- [x] Repair `proof.DGGBetaCastSeparated`:
+  `separated-dgg-beta-cast-value-shape` is marked `TERMINATING` (same
+  catchup-projection recursion as `sim-beta`), the missing `⊒cast+ᵗ`
+  inner-coercion branches for a function-shaped target cast are covered
+  (`G !`, `seal`, and `gen` are refuted through their `tgt` equations
+  against the arrow-typed cast; `id` and `_︔_` are explicit holes), and
+  the source-cast `with`-groups have explicit fallback holes for the
+  non-canonical inner-coercion shapes.
 
 ## Track A. Back To DGG Beta
 
@@ -72,10 +83,33 @@ Current named obligations in `proof.DynamicGradualGuaranteeSeparated`:
 - The application and primitive congruence cases already invoke the recursive
   `dynamicGradualGuarantee` call before their reconstruction holes, preserving
   the induction-hypothesis opportunity in the skeleton.
-- The two target-cast constructors currently remain constructor-level holes in
-  the full skeleton. Splitting their target reductions exhaustively requires
-  first inverting the shape of the target cast coercion, because Agda cannot
-  decide redexes like `β-id` under an unknown `- s`.
+- The `⊒cast-ᵗ` target-step coverage is now split exhaustively, because its
+  cast coercion is a raw index: `blame-⟨⟩`, `β-id`, and `tag-untag-bad` are
+  proved (the latter blames, so `⊒blameᵗ` closes it), and `β-seq`, `β-inst`,
+  `tag-untag-ok`, and `seal-unseal` are now four named relation holes with
+  zero source steps. Only `⊒cast+ᵗ` retains a constructor-level catch-all:
+  its target cast is `narrowing-dual t⊒`, and Agda cannot decide redexes
+  like `β-id` or `blame-⟨⟩` under that projection without first matching the
+  `t⊒` witness shape (adding a generic `blame-⟨⟩` clause for `⊒cast+ᵗ` fails
+  with a stuck unification on `narrowing-dual`).
+- The remaining `⊒cast-ᵗ` step holes need: a seq-component story for
+  `β-seq` (an `∶ᶜ`-typed intermediate coercion to stack two `⊒cast-ᵗ`
+  layers), a target-cast-stripping inversion for `tag-untag-ok` and
+  `seal-unseal` (a right-side analogue of catchup), and separated `ν`
+  constructors for `β-inst` (Track B).
+- Every ξ-frame reconstruction hole is blocked on two structural gaps:
+  (a) there is no right-side store-change transport surface (the mirror of
+  the postulated `left-change-term-narrowing` family) to advance the
+  untouched subterm across `applyRightChange χ′` / `applyTerm χ′`; and
+  (b) the theorem's conclusion existentially quantifies `C`, `D`, `r` with
+  no link back to the inputs, so the IH cannot be reframed. The natural
+  strengthening returns `C ≡ applyTys χs A` and `D ≡ applyTy χ′ B` (true in
+  all current completed cases, including `β-id` via the `src`/`tgt`
+  components of the id-cast typing), but coercion-index tracking is false
+  (`β-id` swaps the relation to the inner `∶ᶜ` coercion), so the
+  application/`⊕` frames additionally need either a coercion-conversion
+  rule in the relation or `∶ᶜ` evidence in the conclusion, which `⊒cast+ᵗ`
+  inner relations cannot supply.
 - `applyLeftChanges-++` is now available from `proof.CatchupSeparated`.
   Both beta caller helpers use it with `applyTyCtxs-++` and `↠-trans` to
   return a single composed source reduction after the call to `sim-beta`.


### PR DESCRIPTION
## What changed

**Repaired `GTSF/proof/DGGBetaCastSeparated.agda`, which did not type-check as committed** (three incomplete pattern matches and a termination failure). This was blocking `agda` on `proof/DynamicGradualGuaranteeSeparated.agda` entirely, and is why both separated modules were commented out of `All.agda`.

- `separated-dgg-beta-cast-value-shape` is marked `{-# TERMINATING #-}` — the recursion goes through catchup projections, the same situation as the existing `sim-beta` precedent.
- For a function-shaped target cast, the `⊒cast+ᵗ` inner coercions `G \!`, `seal`, and `gen` are refuted outright by matching `refl` in the inner coercion's `tgt` equation against `()` in the arrow-typed cast's `tgt` equation (an arrow type cannot be `★`, `＇α`, or `∀`).
- The genuinely open branches (`id` and `_︔_` inner coercions, and the non-canonical inner-coercion shapes of the two source-cast `with`-groups) are explicit named holes.

**Progress on `dynamicGradualGuarantee` in `proof/DynamicGradualGuaranteeSeparated.agda`:**

- New fully-proved clause: `⊒cast-ᵗ` + `pure-step (tag-untag-bad _ _)` — the target blames, so zero source steps and `⊒blameᵗ` close it.
- The opaque `target-cast-minus-simulation-relation` catch-all is replaced by an exhaustive split of the remaining target reductions. Because `⊒cast-ᵗ` stores the raw cast coercion as an index, Agda can decide the split; the leftovers are four precise named holes (`β-seq`, `β-inst`, `tag-untag-ok`, `seal-unseal`).
- The analogous split for `⊒cast+ᵗ` is not possible: its target cast is the projection `narrowing-dual t⊒`, and even a generic `blame-⟨⟩` clause leaves Agda stuck deciding whether `β-id` overlaps (attempted and reverted). Handling these requires matching the `t⊒` witness first, as the three existing `β-id` clauses do; recorded in the checklist.

**Re-enabled** `proof.CatchupSeparated` and `proof.DynamicGradualGuaranteeSeparated` in `GTSF/All.agda`. The full aggregate type-checks.

## Notes for reviewers

- No new postulates; all open obligations are `{\! named holes \!}` in `--allow-unsolved-metas` modules, per the working policy.
- The checklist and proof log now document the two structural blockers behind every remaining ξ-frame reconstruction hole: (a) there is no right-side store-change transport surface (mirror of the postulated `left-change-term-narrowing` family), and (b) the theorem's existential conclusion drops the link between `C`/`D`/`r` and the inputs. Type-endpoint tracking (`C ≡ applyTys χs A`, `D ≡ applyTy χ′ B`) looks provable in every completed clause, but coercion-index tracking is falsified by the `β-id` clauses, so the application/`⊕` frames also need either a coercion-conversion rule in the relation or `∶ᶜ` result evidence — a relation-design decision left open.
- Verified with `agda -v0 All.agda` (exit 0) in `GTSF/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)