### PR TITLE
Restore cambridge25 composition premises to the separated DGG

### DIFF
--- a/GTSF/Coercions.agda
+++ b/GTSF/Coercions.agda
@@ -116,6 +116,20 @@ renameᶜ ρ (`∀ p) = `∀ (renameᶜ (extᵗ ρ) p)
 renameᶜ ρ (gen A p) = gen (renameᵗ ρ A) (renameᶜ (extᵗ ρ) p)
 renameᶜ ρ (inst B p) = inst (renameᵗ ρ B) (renameᶜ (extᵗ ρ) p)
 
+-- Correspondence with the cambridge25 notes: the term-narrowing rules
+-- there type the structural indices p, q under `Γ | ∅` (no seal store,
+-- so p and q cannot contain seal or unseal coercions) while the
+-- cast-composed indices r, s, t are typed under `Γ | Φ`.  This Agda
+-- development instead types every coercion against the full store and
+-- encodes the ∅-versus-Φ split as a mode environment: `tag-or-idᵈ`
+-- (the `∶ᶜ` judgments used for p and q) forbids seal/unseal at every
+-- variable, playing the role of ∅, while a general `μ` may grant
+-- `seal-or-id` at store variables, playing the role of Φ.  The
+-- per-variable `Mode` records how that variable's imprecision is
+-- mediated: by nothing (`id-only`), by tags (`tag-or-id`), or by
+-- seals (`seal-or-id`); tag- and seal-mediation are deliberately
+-- incomparable in `mode≤`, which is what makes normal coercions
+-- canonical per mode environment (`narrowing-determinedᵐ`).
 data Mode : Set where
   id-only tag-or-id seal-or-id : Mode
 

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -1,0 +1,31 @@
+# GTSF build. The RTS flags matter: these files are GC-bound, and a
+# larger allocation area with a generous heap cap cuts checking time
+# substantially. No --safe: this development deliberately uses
+# --allow-unsolved-metas and a documented postulate surface
+# (proof/LeftChangeNarrowingSeparated.agda) while the separated-store
+# DGG is under construction.
+
+# -M18G: proof/SimBetaSeparated.agda's sim-beta definition alone needs
+# >14G transiently (see profile: ~275s, 90% of the file); the cap keeps
+# runaway checks from getting OS-killed while allowing that one through.
+AGDA = agda +RTS -A128M -M18G -RTS -v0
+
+# Check a single file with: make agda FILE=proof/SimBetaSeparated.agda
+FILE ?= All.agda
+
+check: agda
+
+agda:
+	$(AGDA) $(FILE)
+
+# Per-definition time report; pick the target with FILE=...
+profile:
+	$(AGDA) --profile=definitions $(FILE)
+
+profile-modules:
+	$(AGDA) --profile=modules $(FILE)
+
+clean:
+	rm -f *~ proof/*~
+
+.PHONY: check agda profile profile-modules clean

--- a/GTSF/TermNarrowingSeparated.agda
+++ b/GTSF/TermNarrowingSeparated.agda
@@ -290,9 +290,14 @@ data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
   -- typing.  The separated rules below keep that naming convention visible:
   -- p/q premises use `_⊢_∶ᶜ_⊒_`, while r premises use `_∣_∣_∣_⊢_∶_⊒_`.
 
-  ⊒blameᵗ : ∀ {ΔL ΔR ρ γ M p A B}
+  -- The coercion evidence is deliberately general-mode: blame sits on the
+  -- target side of any well-typed narrowing index, not only tag-or-id
+  -- ones.  (The `∶ᶜ` restriction here previously forced the separated DGG
+  -- theorem to demand `∶ᶜ` evidence for the relation index, which the
+  -- `⊒cast+ᵗ` inner relations cannot supply.)
+  ⊒blameᵗ : ∀ {ΔL ΔR ρ γ M p A B μ}
     → ΔL ∣ leftStore ρ ∣ leftCtx γ ⊢ M ⦂ A
-    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B
+    → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ∶ A ⊒ B
       ------------------------------------------------------------
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ blame ∶ p ⦂ A ⊒ B
 
@@ -464,8 +469,8 @@ typed-term-narrowing-coercion :
   ∀ {ΔL ΔR ρ γ M M′ p A B} →
   ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
   ∃[ μ ] μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ∶ A ⊒ B
-typed-term-narrowing-coercion (⊒blameᵗ M⊢ pᶜ) =
-  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (⊒blameᵗ {μ = μ} M⊢ p⊒) =
+  μ , p⊒
 typed-term-narrowing-coercion (x⊒xᵗ pᶜ x∋p) =
   tag-or-idᵈ , pᶜ
 typed-term-narrowing-coercion (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) =

--- a/GTSF/TermNarrowingSeparated.agda
+++ b/GTSF/TermNarrowingSeparated.agda
@@ -9,7 +9,7 @@ module TermNarrowingSeparated where
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using (List; []; _∷_; map)
-open import Data.Nat using (suc)
+open import Data.Nat using (zero; suc)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality using (cong; subst)
 
@@ -18,6 +18,7 @@ open import Ctx using (⤊ᵗ)
 open import Coercions
 open import NarrowWiden using (cross; dualⁿ; dualʷ; _∣_∣_⊢_∶_⊒_)
   renaming (_↦_ to _↦ⁿʷ_)
+open import NarrowWidenComposition using (_⨟ⁿ_)
 open import Primitives
 open import NuTerms
 open import StoreCorrespondence
@@ -29,6 +30,7 @@ open import proof.CoercionProperties using
 open import proof.NarrowWidenProperties using
   ( dualⁿ-flips-typingᵐ
   ; dualʷ-flips-typingᵐ
+  ; narrowing-determinedᵐ
   )
 
 ------------------------------------------------------------------------
@@ -278,6 +280,65 @@ TermTypingEndpointsᶜ ΔL ΔR ρ γ M M′ A B =
   (ΔL ∣ leftStore ρ ∣ leftCtx γ ⊢ M ⦂ A) ×
   (ΔR ∣ rightStore ρ ∣ rightCtx γ ⊢ M′ ⦂ B)
 
+------------------------------------------------------------------------
+-- Cambridge25 cast-rule composition side condition
+------------------------------------------------------------------------
+
+-- The cambridge25 cast rules (-⊒), (+⊒), (⊒-), (⊒+) all carry a side
+-- condition of the shape `s ⨾ t ≈ r`: the conclusion index is the
+-- composite of the structural index with the term-level cast coercion.
+-- The mixfix `ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ t ≈ r ∶ A ⊒ B` mirrors that notation.
+-- In the separated setting the record carries cross-store typings of
+-- the two factors and of `r` at one shared mode environment.  Because
+-- normal coercions are canonical per mode environment and endpoints
+-- (`narrowing-determinedᵐ`), this pins `r` to the `_⨟ⁿ_` composite of
+-- the factors; the equality is recovered by
+-- `composed-index-composite≡` below rather than stored as a field,
+-- since the stored form would not be transportable across the
+-- (postulated) store-change surfaces.  The middle type of the
+-- composition is an implicit field.  The `νL`/`νR` environments play
+-- the role of the shared-store port's auxiliary `Σ`-typings.
+
+infix 4 _∣_∣_⊢_⨟_≈_∶_⊒_
+
+record _∣_∣_⊢_⨟_≈_∶_⊒_
+    (ΔL ΔR : TyCtx) (ρ : SealCorr)
+    (s t r : Coercion) (A B : Ty) : Set₁ where
+  constructor composed-index
+  field
+    {midTy} : Ty
+    {νᶜᵒᵐᵖ} : ModeEnv
+    s⊒ : νᶜᵒᵐᵖ ∣ ΔL ∣ ΔR ∣ ρ ⊢ s ∶ A ⊒ midTy
+    t⊒ : νᶜᵒᵐᵖ ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ midTy ⊒ B
+    r⊒ : νᶜᵒᵐᵖ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
+
+-- Within one store and one mode environment, normal coercions at fixed
+-- endpoints are canonical, so the typings stored in the composition
+-- record pin `r` to the `_⨟ⁿ_` composite of the factors.
+composite-determinedˡ :
+  ∀ {ΔL ΔR ρ ν s t r A B E} →
+  (corr : StoreCorr ΔL ΔR ρ) →
+  (s⊒ : ν ∣ ΔL ∣ leftStore ρ ⊢ s ∶ A ⊒ E) →
+  (t⊒ : ν ∣ ΔL ∣ leftStore ρ ⊢ t ∶ E ⊒ B) →
+  ν ∣ ΔL ∣ leftStore ρ ⊢ r ∶ A ⊒ B →
+  proj₁ (_⨟ⁿ_ {wfΣ = leftStore-det corr} s⊒ t⊒) ≡ r
+composite-determinedˡ corr s⊒ t⊒ r⊒ =
+  narrowing-determinedᵐ (leftStore-det corr)
+    (proj₂ (_⨟ⁿ_ {wfΣ = leftStore-det corr} s⊒ t⊒))
+    r⊒
+
+composite-determinedʳ :
+  ∀ {ΔL ΔR ρ ν s t r A B E} →
+  (corr : StoreCorr ΔL ΔR ρ) →
+  (s⊒ : ν ∣ ΔR ∣ rightStore ρ ⊢ s ∶ A ⊒ E) →
+  (t⊒ : ν ∣ ΔR ∣ rightStore ρ ⊢ t ∶ E ⊒ B) →
+  ν ∣ ΔR ∣ rightStore ρ ⊢ r ∶ A ⊒ B →
+  proj₁ (_⨟ⁿ_ {wfΣ = rightStore-det corr} s⊒ t⊒) ≡ r
+composite-determinedʳ corr s⊒ t⊒ r⊒ =
+  narrowing-determinedᵐ (rightStore-det corr)
+    (proj₂ (_⨟ⁿ_ {wfΣ = rightStore-det corr} s⊒ t⊒))
+    r⊒
+
 infix 4 _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
 
 data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
@@ -337,6 +398,76 @@ data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ Λ V ⊒ Λ V′ ∶ `∀ p
         ⦂ `∀ A ⊒ `∀ B
 
+  -- Cambridge25 polymorphism and ν rules, ported from the shared-store
+  -- relation.  Target-only binders extend both type contexts but add a
+  -- `right-only` seal entry; matched seals carry their endpoint types in
+  -- the entry, with the correlating coercion as an explicit `∶ᶜ` premise
+  -- (the shared `α ꞉ q` entry made explicit).  Endpoint typing is an
+  -- explicit premise, following the separated policy.
+
+  ⊒Λᵗ : ∀ {ΔL ΔR ρ γ N V′ p A B}
+    → TermTypingEndpointsᶜ ΔL ΔR ρ γ N (Λ V′) A (`∀ B)
+    → ΔL ∣ ΔR ∣ ρ ⊢ gen A p ∶ᶜ A ⊒ `∀ B
+    → suc ΔL ∣ suc ΔR ∣ right-only zero ★ ∷ ⇑ᶜorr ρ ∣ ⇑ᵍᶜ γ
+        ⊢ ⇑ᵗᵐ N ⊒ V′ ∶ p ⦂ ⇑ᵗ A ⊒ B
+      --------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ N ⊒ Λ V′ ∶ gen A p ⦂ A ⊒ `∀ B
+
+  ⊒⟨ν⟩ᵗ : ∀ {ΔL ΔR ρ γ N V′ p s A B}
+    → TermTypingEndpointsᶜ ΔL ΔR ρ γ N (V′ ⟨ gen A s ⟩) A (`∀ B)
+    → ΔL ∣ ΔR ∣ ρ ⊢ gen A p ∶ᶜ A ⊒ `∀ B
+    → Inert s
+    → suc ΔL ∣ suc ΔR ∣ right-only zero ★ ∷ ⇑ᶜorr ρ ∣ ⇑ᵍᶜ γ
+        ⊢ ⇑ᵗᵐ N ⊒ V′ ⟨ s ⟩ ∶ p ⦂ ⇑ᵗ A ⊒ B
+      -----------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ N ⊒ V′ ⟨ gen A s ⟩ ∶ gen A p
+        ⦂ A ⊒ `∀ B
+
+  α⊒αᵗ : ∀ {ΔL ΔR ρ γ γ′ L L′ p q A B C D E F}
+    → γ′ ≡ ⇑ᵍᶜ γ
+    → TermTypingEndpointsᶜ (suc ΔL) (suc ΔR)
+        (matched zero (⇑ᵗ A) zero (⇑ᵗ B) ∷ ⇑ᶜorr ρ) γ′
+        ((⇑ᵗᵐ L) •) ((⇑ᵗᵐ L′) •) C D
+    → ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ A ⊒ B
+    → suc ΔL ∣ suc ΔR ∣ matched zero (⇑ᵗ A) zero (⇑ᵗ B) ∷ ⇑ᶜorr ρ
+        ⊢ p ∶ᶜ C ⊒ D
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ L′ ∶ `∀ p ⦂ E ⊒ F
+      ------------------------------------------------
+    → suc ΔL ∣ suc ΔR ∣ matched zero (⇑ᵗ A) zero (⇑ᵗ B) ∷ ⇑ᶜorr ρ ∣ γ′
+        ⊢ (⇑ᵗᵐ L) • ⊒ (⇑ᵗᵐ L′) • ∶ p ⦂ C ⊒ D
+
+  ⊒αᵗ : ∀ {ΔL ΔR ρ γ γ′ L L′ p A B C D E F}
+    → γ′ ≡ ⇑ᵍᶜ γ
+    → TermTypingEndpointsᶜ (suc ΔL) (suc ΔR)
+        (right-only zero (⇑ᵗ A) ∷ ⇑ᶜorr ρ) γ′
+        (⇑ᵗᵐ L) ((⇑ᵗᵐ L′) •) C D
+    → suc ΔL ∣ suc ΔR ∣ right-only zero (⇑ᵗ A) ∷ ⇑ᶜorr ρ
+        ⊢ p ∶ᶜ C ⊒ D
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ L′ ∶ gen B p ⦂ E ⊒ F
+      -----------------------------------------------
+    → suc ΔL ∣ suc ΔR ∣ right-only zero (⇑ᵗ A) ∷ ⇑ᶜorr ρ ∣ γ′
+        ⊢ ⇑ᵗᵐ L ⊒ (⇑ᵗᵐ L′) • ∶ p ⦂ C ⊒ D
+
+  ν⊒νᵗ : ∀ {ΔL ΔR ρ γ A A′ B B′ N N′ p q}
+    → TermTypingEndpointsᶜ ΔL ΔR ρ γ
+        (ν A N (⇑ᶜ p)) (ν A′ N′ (⇑ᶜ p)) B B′
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ B ⊒ B′
+    → ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ A ⊒ A′
+    → suc ΔL ∣ suc ΔR ∣ matched zero (⇑ᵗ A) zero (⇑ᵗ A′) ∷ ⇑ᶜorr ρ
+        ∣ ⇑ᵍᶜ γ
+        ⊢ N ⊒ N′ ∶ ⇑ᶜ p ⦂ ⇑ᵗ B ⊒ ⇑ᵗ B′
+      ------------------------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ ν A N (⇑ᶜ p) ⊒ ν A′ N′ (⇑ᶜ p) ∶ p
+        ⦂ B ⊒ B′
+
+  ⊒νᵗ : ∀ {ΔL ΔR ρ γ A B B′ N N′ p}
+    → TermTypingEndpointsᶜ ΔL ΔR ρ γ N (ν A N′ (⇑ᶜ p)) B B′
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ B ⊒ B′
+    → suc ΔL ∣ suc ΔR ∣ right-only zero (⇑ᵗ A) ∷ ⇑ᶜorr ρ ∣ ⇑ᵍᶜ γ
+        ⊢ ⇑ᵗᵐ N ⊒ N′ ∶ ⇑ᶜ p ⦂ ⇑ᵗ B ⊒ ⇑ᵗ B′
+      ---------------------------------------
+    → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ N ⊒ ν A N′ (⇑ᶜ p) ∶ p ⦂ B ⊒ B′
+
   κ⊒κᵗ : ∀ {ΔL ΔR ρ γ} κ
     → ΔL ∣ ΔR ∣ ρ ⊢ id (constTy κ) ∶ᶜ constTy κ ⊒ constTy κ
       -----------------------------------------------------------
@@ -353,10 +484,17 @@ data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊕[ addℕ ] N ⊒ M′ ⊕[ addℕ ] N′
         ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
 
+  -- The four cast rules carry the cambridge25 composition side
+  -- condition via `_∣_∣_⊢_⨟_≈_∶_⊒_`: the cast-composed index is the
+  -- store-wise composite of the structural index with the cast
+  -- coercion (`r ≈ p ⨾ t` for the target-cast rules, `s ⨾ q ≈ r` for
+  -- the source-cast rules).
+
   ⊒cast+ᵗ : ∀ {ΔL ΔR ρ γ M M′ p r t A B C μ η}
     → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ C
     → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
     → (t⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ C ⊒ B)
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ⨟ t ≈ r ∶ A ⊒ B
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
       -------------------------------------------------------
     → ΔL ∣ ΔR ∣ ρ ∣ γ
@@ -366,6 +504,7 @@ data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
     → ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ C
     → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
     → η ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ C ⊒ B
+    → ΔL ∣ ΔR ∣ ρ ⊢ p ⨟ t ≈ r ∶ A ⊒ B
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ C
       ---------------------------------------------------
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ⟨ t ⟩ ∶ r ⦂ A ⊒ B
@@ -374,6 +513,7 @@ data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
     → ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ C ⊒ B
     → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
     → (s⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ s ∶ A ⊒ C)
+    → ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ q ≈ r ∶ A ⊒ B
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ q ⦂ C ⊒ B
       -------------------------------------------------------
     → ΔL ∣ ΔR ∣ ρ ∣ γ
@@ -383,6 +523,7 @@ data _∣_∣_∣_⊢_⊒_∶_⦂_⊒_
     → ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ C ⊒ B
     → μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B
     → η ∣ ΔL ∣ ΔR ∣ ρ ⊢ s ∶ A ⊒ C
+    → ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ q ≈ r ∶ A ⊒ B
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ B
       ---------------------------------------------------
     → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⟨ s ⟩ ⊒ M′ ∶ q ⦂ C ⊒ B
@@ -418,6 +559,14 @@ typed-term-narrowing-term-typingᶜ {ρ = ρ} {γ = γ}
   in
   ⊢Λ vV (shift-left-term-typing {ρ = ρ} {γ = γ} V⊢) ,
   ⊢Λ vV′ (shift-right-term-typing {ρ = ρ} {γ = γ} V′⊢)
+typed-term-narrowing-term-typingᶜ (⊒Λᵗ typing genᶜ N⊒V′) = typing
+typed-term-narrowing-term-typingᶜ (⊒⟨ν⟩ᵗ typing genᶜ i N⊒V′s) =
+  typing
+typed-term-narrowing-term-typingᶜ (α⊒αᵗ γ′≡ typing qᶜ pᶜ L⊒L′) =
+  typing
+typed-term-narrowing-term-typingᶜ (⊒αᵗ γ′≡ typing pᶜ L⊒L′) = typing
+typed-term-narrowing-term-typingᶜ (ν⊒νᵗ typing pᶜ qᶜ N⊒N′) = typing
+typed-term-narrowing-term-typingᶜ (⊒νᵗ typing pᶜ N⊒N′) = typing
 typed-term-narrowing-term-typingᶜ
     (κ⊒κᵗ κ pᶜ) =
   ⊢$ κ , ⊢$ κ
@@ -429,37 +578,37 @@ typed-term-narrowing-term-typingᶜ
   in
   ⊢⊕ M⊢ addℕ N⊢ , ⊢⊕ M′⊢ addℕ N′⊢
 typed-term-narrowing-term-typingᶜ
-    (⊒cast+ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′)
+    (⊒cast+ᵗ {η = η} pᶜ rᶜ t⊒ _ M⊒M′)
     with narrowing-right-dual-coercion-typingᶜ {μ = η} t⊒
 typed-term-narrowing-term-typingᶜ
-    (⊒cast+ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′) | μ′ , t⊢ =
+    (⊒cast+ᵗ {η = η} pᶜ rᶜ t⊒ _ M⊒M′) | μ′ , t⊢ =
   let
     M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
   in
   M⊢ , ⊢⟨⟩ t⊢ M′⊢
 typed-term-narrowing-term-typingᶜ
-    (⊒cast-ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′)
+    (⊒cast-ᵗ {η = η} pᶜ rᶜ t⊒ _ M⊒M′)
     with narrowing-right-coercion-typingᶜ {μ = η} t⊒
 typed-term-narrowing-term-typingᶜ
-    (⊒cast-ᵗ {η = η} pᶜ rᶜ t⊒ M⊒M′) | μ′ , t⊢ =
+    (⊒cast-ᵗ {η = η} pᶜ rᶜ t⊒ _ M⊒M′) | μ′ , t⊢ =
   let
     M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
   in
   M⊢ , ⊢⟨⟩ t⊢ M′⊢
 typed-term-narrowing-term-typingᶜ
-    (cast+⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′)
+    (cast+⊒ᵗ {η = η} qᶜ rᶜ s⊒ _ M⊒M′)
     with narrowing-left-dual-coercion-typingᶜ {μ = η} s⊒
 typed-term-narrowing-term-typingᶜ
-    (cast+⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′) | μ′ , s⊢ =
+    (cast+⊒ᵗ {η = η} qᶜ rᶜ s⊒ _ M⊒M′) | μ′ , s⊢ =
   let
     M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
   in
   ⊢⟨⟩ s⊢ M⊢ , M′⊢
 typed-term-narrowing-term-typingᶜ
-    (cast-⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′)
+    (cast-⊒ᵗ {η = η} qᶜ rᶜ s⊒ _ M⊒M′)
     with narrowing-left-coercion-typingᶜ {μ = η} s⊒
 typed-term-narrowing-term-typingᶜ
-    (cast-⊒ᵗ {η = η} qᶜ rᶜ s⊒ M⊒M′) | μ′ , s⊢ =
+    (cast-⊒ᵗ {η = η} qᶜ rᶜ s⊒ _ M⊒M′) | μ′ , s⊢ =
   let
     M⊢ , M′⊢ = typed-term-narrowing-term-typingᶜ M⊒M′
   in
@@ -479,17 +628,29 @@ typed-term-narrowing-coercion (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
   tag-or-idᵈ , fun-narrow-codomainᶜ p↦qᶜ
 typed-term-narrowing-coercion (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′) =
   tag-or-idᵈ , allᶜ
+typed-term-narrowing-coercion (⊒Λᵗ typing genᶜ N⊒V′) =
+  tag-or-idᵈ , genᶜ
+typed-term-narrowing-coercion (⊒⟨ν⟩ᵗ typing genᶜ i N⊒V′s) =
+  tag-or-idᵈ , genᶜ
+typed-term-narrowing-coercion (α⊒αᵗ γ′≡ typing qᶜ pᶜ L⊒L′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (⊒αᵗ γ′≡ typing pᶜ L⊒L′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (ν⊒νᵗ typing pᶜ qᶜ N⊒N′) =
+  tag-or-idᵈ , pᶜ
+typed-term-narrowing-coercion (⊒νᵗ typing pᶜ N⊒N′) =
+  tag-or-idᵈ , pᶜ
 typed-term-narrowing-coercion (κ⊒κᵗ κ pᶜ) =
   tag-or-idᵈ , pᶜ
 typed-term-narrowing-coercion (⊕⊒⊕ᵗ pᶜ M⊒M′ N⊒N′) =
   tag-or-idᵈ , pᶜ
-typed-term-narrowing-coercion (⊒cast+ᵗ pᶜ r⊒ t⊒ M⊒M′) =
+typed-term-narrowing-coercion (⊒cast+ᵗ pᶜ r⊒ t⊒ _ M⊒M′) =
   tag-or-idᵈ , pᶜ
-typed-term-narrowing-coercion (⊒cast-ᵗ {μ = μ} pᶜ r⊒ t⊒ M⊒M′) =
+typed-term-narrowing-coercion (⊒cast-ᵗ {μ = μ} pᶜ r⊒ t⊒ _ M⊒M′) =
   μ , r⊒
-typed-term-narrowing-coercion (cast+⊒ᵗ {μ = μ} qᶜ r⊒ s⊒ M⊒M′) =
+typed-term-narrowing-coercion (cast+⊒ᵗ {μ = μ} qᶜ r⊒ s⊒ _ M⊒M′) =
   μ , r⊒
-typed-term-narrowing-coercion (cast-⊒ᵗ qᶜ r⊒ s⊒ M⊒M′) =
+typed-term-narrowing-coercion (cast-⊒ᵗ qᶜ r⊒ s⊒ _ M⊒M′) =
   tag-or-idᵈ , qᶜ
 
 typed-term-narrowing-source-typingᶜ :

--- a/GTSF/proof/DGGBetaCastSeparated.agda
+++ b/GTSF/proof/DGGBetaCastSeparated.agda
@@ -256,6 +256,7 @@ separated-source-cast-plus-result {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
           qᵢᶜT
           qₒ⊒T
           dₛ⊒T
+          {! beta-cast-tail-composition !}
           N⊒TargetT)
   in
   subst
@@ -319,7 +320,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     vL noL vR noR vV′ vW′
     targetCast@(⊒cast+ᵗ {M′ = F′} {r = pᵢ ↦ qᵢ}
       {t = cₜ ↦ dₜ} {B = Aᵢ ⇒ Bᵢ} {η = ηCast}
-      pᶜ rᶜ t⊒ L⊒F′)
+      pᶜ rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′ =
   let
     relation-obligation :
@@ -371,48 +372,48 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   relation-obligation
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = id A} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = id A} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = t₁ ︔ t₂} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = t₁ ︔ t₂} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = `∀ t} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = `∀ t} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = G !} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = G !} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = G ？} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = G ？} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = seal A α} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = seal A α} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = unseal α A} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = unseal α A} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = gen A t} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = gen A t} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {t = inst A t} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {t = inst A t} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {r = id P} {t = cₜ ↦ dₜ} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {r = id P} {t = cₜ ↦ dₜ} pᶜ rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′ =
   {! separated-dgg-beta-cast-target-plus-id-inner-coercion !}
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast+ᵗ {r = r₁ ︔ r₂} {t = cₜ ↦ dₜ} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast+ᵗ {r = r₁ ︔ r₂} {t = cₜ ↦ dₜ} pᶜ rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′ =
   {! separated-dgg-beta-cast-target-plus-seq-inner-coercion !}
 separated-dgg-beta-cast-value-shape
@@ -420,21 +421,21 @@ separated-dgg-beta-cast-value-shape
     (⊒cast+ᵗ {r = G !} {t = cₜ ↦ dₜ} pᶜ
       (_ , _ , refl , _ , _ , _ , _)
       (_ , _ , () , _ , _ , _ , _)
-      L⊒F′)
+      _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
     (⊒cast+ᵗ {r = seal P α} {t = cₜ ↦ dₜ} pᶜ
       (_ , _ , refl , _ , _ , _ , _)
       (_ , _ , () , _ , _ , _ , _)
-      L⊒F′)
+      _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
     (⊒cast+ᵗ {r = gen P r} {t = cₜ ↦ dₜ} pᶜ
       (_ , _ , refl , _ , _ , _ , _)
       (_ , _ , () , _ , _ , _ , _)
-      L⊒F′)
+      _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
@@ -446,7 +447,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       t⊒@(storesCast , _ , _ , wf⇒ hAᵢ hBᵢ , wf⇒ hA′ hB′ ,
         (cast-fun cₜ⊢L _ , cross (cₜʷL ↦ⁿʷ _)) ,
         (cast-fun cₜ⊢R _ , cross (cₜʷR ↦ⁿʷ _)))
-      L⊒F′)
+      _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′ =
   let
     relation-obligation :
@@ -542,6 +543,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
               (fun-narrow-domain-dual-typingᶜ pᶜ)
               p-domainᶜ
               target-domain-cast
+              {! target-argument-cast-composition !}
               R⊒W′)
 
         inner-application :
@@ -560,6 +562,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
             (fun-narrow-codomainᶜ pᶜ)
             (separated-fun-codomain rᶜ)
             target-codomain-cast
+            {! target-result-cast-composition !}
             inner-application
 
         obligation :
@@ -585,39 +588,39 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   relation-obligation
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = id A} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = id A} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = t₁ ︔ t₂} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = t₁ ︔ t₂} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = `∀ t} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = `∀ t} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = G !} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = G !} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = G ？} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = G ？} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = seal A α} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = seal A α} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = unseal α A} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = unseal α A} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = gen A t} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = gen A t} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape
     vL noL vR noR vV′ vW′
-    (⊒cast-ᵗ {t = inst A t} pᶜ rᶜ t⊒ L⊒F′)
+    (⊒cast-ᵗ {t = inst A t} pᶜ rᶜ t⊒ _ L⊒F′)
     () p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
@@ -625,7 +628,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     targetCast@(⊒cast-ᵗ {M′ = F′} {p = id P}
       {t = cₜ ↦ dₜ}
       (_ , () , _ , _ , _ , (_ , cross (id-＇ α)) , _)
-      rᶜ t⊒ L⊒F′)
+      rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
@@ -633,7 +636,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     targetCast@(⊒cast-ᵗ {M′ = F′} {p = id P}
       {t = cₜ ↦ dₜ}
       (_ , () , _ , _ , _ , (_ , cross (id-‵ ι)) , _)
-      rᶜ t⊒ L⊒F′)
+      rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
@@ -641,7 +644,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     targetCast@(⊒cast-ᵗ {M′ = F′} {p = id P}
       {t = cₜ ↦ dₜ}
       (_ , () , _ , _ , _ , (_ , id★) , _)
-      rᶜ t⊒ L⊒F′)
+      rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
@@ -649,7 +652,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     targetCast@(⊒cast-ᵗ {M′ = F′} {p = p₀ ︔ p₁}
       {t = cₜ ↦ dₜ}
       (_ , () , _ , _ , _ , (_ , G ？︔ gⁿ) , _)
-      rᶜ t⊒ L⊒F′)
+      rᶜ t⊒ _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {V′ = V′} {W′ = W′} {c = c} {d = d}
@@ -657,20 +660,20 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     targetCast@(⊒cast-ᵗ {M′ = F′} {p = p₀ ︔ p₁}
       {t = cₜ ↦ dₜ}
       (_ , _ , refl , _ , _ , (_ , gⁿ ︔seal α) , _)
-      rᶜ (_ , () , _ , _ , _ , _ , _) L⊒F′)
+      rᶜ (_ , () , _ , _ , _ , _ , _) _ L⊒F′)
     T≡V′cd p-domainᶜ R⊒W′
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     with canonical-⇒ vL (typed-term-narrowing-source-typingᶜ sourceCast)
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-ƛ ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -687,6 +690,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         wf⇒ hALs hBLs ,
         (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
         (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      compᵏ
       F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ {W = F} {c = cₛ} {d = dₛ} vF L≡Fcd =
@@ -798,6 +802,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (fun-narrow-domain-dual-typingᶜ qInner)
         p-domainᶜ
         cₛ⊒
+        {! source-argument-cast-composition !}
         R⊒W′
 
     χsA , WRA , ΔLA ,
@@ -915,7 +920,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast+⊒ᵗ {M = F₀} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF L≡Fcd =
   {! separated-dgg-beta-cast-source-plus-noncanonical-inner-coercion !}
@@ -935,6 +940,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       (storesCast , _ , _ , wf⇒ hALs hBLs , wf⇒ hAₒs hBₒs ,
         (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
         (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      compᵏ
       F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     with canonical-⇒ vL (typed-term-narrowing-source-typingᶜ sourceCast)
@@ -954,6 +960,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       (storesCast , _ , _ , wf⇒ hALs hBLs , wf⇒ hAₒs hBₒs ,
         (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
         (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      compᵏ
       F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-ƛ ()
@@ -973,6 +980,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       (storesCast , _ , _ , wf⇒ hALs hBLs , wf⇒ hAₒs hBₒs ,
         (cast-fun c₀⊢L d₀⊢L , cross (c₀ʷL ↦ⁿʷ d₀ⁿL)) ,
         (cast-fun c₀⊢R d₀⊢R , cross (c₀ʷR ↦ⁿʷ d₀ⁿR)))
+      compᵏ
       F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ {W = F} {c = cₛ} {d = dₛ} vF L≡Fcd =
@@ -1095,7 +1103,9 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
             ⊢ R ⟨ c₁ ⟩ ⊒ W′ ∶ fun-narrow-domain-dual rInner
               ⦂ AL ⊒ _)
         c-dual-eq
-        (cast+⊒ᵗ p-domainᶜ pᵢ-domain⊒ c-dual⊒ R⊒W′)
+        (cast+⊒ᵗ p-domainᶜ pᵢ-domain⊒ c-dual⊒
+          {! source-argument-domain-composition !}
+          R⊒W′)
 
     χsA , WRA , ΔLA ,
       vWRA , noWRA , R-c↠WRA , ΔLA≡ , ρA-corr ,
@@ -1226,6 +1236,7 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
             qₒ⊒Tρ
             nᶜ
             dₛ⊒Tρ
+            {! source-cast-tail-composition !}
             N⊒target
       in
       subst
@@ -1257,84 +1268,84 @@ separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     with canonical-⇒ vL (typed-term-narrowing-source-typingᶜ sourceCast)
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-ƛ ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = id A} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = id A} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s₁ ︔ s₂} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s₁ ︔ s₂} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = `∀ s} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = `∀ s} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = G !} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = G !} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = G ？} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = G ？} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = seal A α} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = seal A α} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = unseal α A} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = unseal α A} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = gen A s} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = gen A s} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = inst A s} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = inst A s} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF ()
 separated-dgg-beta-cast-value-shape {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {T = T} {V′ = V′} {W′ = W′} {c = c}
     {d = d}
     vL noL vR noR vV′ vW′
-    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s₁ ↦ s₂} qᶜ rᶜ s⊒ F₀⊒T)
+    sourceCast@(cast-⊒ᵗ {M = F₀} {s = s₁ ↦ s₂} qᶜ rᶜ s⊒ _ F₀⊒T)
     T≡V′cd p-domainᶜ R⊒W′
     | fv-↦ vF L≡Fcd =
   {! separated-dgg-beta-cast-source-minus-general-fun-cast !}

--- a/GTSF/proof/DGGBetaSeparated.agda
+++ b/GTSF/proof/DGGBetaSeparated.agda
@@ -74,6 +74,7 @@ open import proof.SimBetaSeparated using
   ; ⟨⟩-coercion-injective
   ; left-change-coercion-narrowing
   ; left-change-source-coercion-narrowing
+  ; left-change-fun-coercion-narrowing
   ; advance-left-term-narrowing
   ; advance-left-function-term-narrowing
   ; advance-left-lambda-narrowing
@@ -109,16 +110,17 @@ open import proof.DGGPrimitiveSeparated using
 ------------------------------------------------------------------------
 
 separated-dgg-beta-left-first :
-  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  ∀ {ΔL ΔR ρ L R N′ V′ p q A A′ B B′} →
   RuntimeOK L →
   RuntimeOK R →
   No• R →
   Value V′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  (p↦qᶜ : ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′) →
+  ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dualᶜ p↦qᶜ ∶ᶜ A ⊒ A′ →
   ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
     ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ []
+    ⊢ R ⊒ V′ ∶ fun-narrow-domain-dualᶜ p↦qᶜ ⦂ A ⊒ A′ →
   ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
@@ -127,7 +129,7 @@ separated-dgg-beta-left-first :
       ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
 separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {N′ = N′} {V′ = V′}
-    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {p = p} {q = q} {A = A} {A′ = A′}
     {B = B} {B′ = B′}
     okL okR noR-ready vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
   let
@@ -173,18 +175,32 @@ separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     WLF⊒ƛ =
       advance-left-lambda-narrowing χsR ΔL₂≡ ρR-corr WL⊒ƛ
 
+    p↦q₁ = left-change-fun-coercion-narrowing χsL ΔL₁≡ ρL-corr p↦qᶜ
+
+    p↦q₂ =
+      left-change-fun-coercion-narrowing χsR ΔL₂≡ ρR-corr
+        (proj₁ p↦q₁)
+
+    dual-eq :
+      fun-narrow-domain-dual (proj₁ p↦q₂) ≡
+        applyCoercions χsR
+          (applyCoercions χsL (fun-narrow-domain-dualᶜ p↦qᶜ))
+    dual-eq =
+      trans (proj₂ p↦q₂) (cong (applyCoercions χsR) (proj₂ p↦q₁))
+
     WR⊒V′ :
       ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ) ∣ []
         ⊢ WR ⊒ V′
-          ∶ applyCoercions χsR (applyCoercions χsL pᵈ)
+          ∶ fun-narrow-domain-dual (proj₁ p↦q₂)
           ⦂ applyTys χsR (applyTys χsL A) ⊒ A′
-    WR⊒V′ = WR⊒V′raw
-
-    p₂-domainᶜ :
-      ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ)
-        ⊢ applyCoercions χsR (applyCoercions χsL pᵈ)
-          ∶ᶜ applyTys χsR (applyTys χsL A) ⊒ A′
-    p₂-domainᶜ = p₂ᶜ
+    WR⊒V′ =
+      subst
+        (λ pd →
+          ΔL₂ ∣ ΔR ∣ applyLeftChanges χsR (applyLeftChanges χsL ρ)
+            ∣ [] ⊢ WR ⊒ V′ ∶ pd
+              ⦂ applyTys χsR (applyTys χsL A) ⊒ A′)
+        (sym dual-eq)
+        WR⊒V′raw
 
     left-ready :
       L · R —↠[ χsL ] WL · applyTerms χsL R
@@ -215,8 +231,9 @@ separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         WLF⊒ƛ
         (applyTerms-preserves-Value χsR vWL)
         (applyTerms-preserves-No• χsR noWL)
+        (proj₁ p↦q₂)
+        (separated-fun-domain-dual (proj₁ p↦q₂))
         WR⊒V′
-        p₂-domainᶜ
         vWR
         noWR
         vV′
@@ -267,16 +284,17 @@ separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   N⊒N′[V′]
 
 separated-dgg-beta-right-first :
-  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  ∀ {ΔL ΔR ρ L R N′ V′ p q A A′ B B′} →
   Value L →
   No• L →
   RuntimeOK R →
   Value V′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  (p↦qᶜ : ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′) →
+  ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dualᶜ p↦qᶜ ∶ᶜ A ⊒ A′ →
   ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
     ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ []
+    ⊢ R ⊒ V′ ∶ fun-narrow-domain-dualᶜ p↦qᶜ ⦂ A ⊒ A′ →
   ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
@@ -285,7 +303,7 @@ separated-dgg-beta-right-first :
       ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
 separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {L = L} {R = R} {N′ = N′} {V′ = V′}
-    {pᵈ = pᵈ} {p = p} {q = q} {A = A} {A′ = A′}
+    {p = p} {q = q} {A = A} {A′ = A′}
     {B = B} {B′ = B′}
     vL noL okR vV′ p↦qᶜ p-domainᶜ L⊒ƛ R⊒V′ =
   let
@@ -300,16 +318,20 @@ separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     LF⊒ƛ =
       advance-left-lambda-narrowing χsR ΔL₁≡ ρR-corr L⊒ƛ
 
+    p↦q₁ = left-change-fun-coercion-narrowing χsR ΔL₁≡ ρR-corr p↦qᶜ
+
     WR⊒V′ :
       ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ ∣ []
         ⊢ WR ⊒ V′
-          ∶ applyCoercions χsR pᵈ ⦂ applyTys χsR A ⊒ A′
-    WR⊒V′ = WR⊒V′raw
-
-    p₁-domainᶜ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ
-        ⊢ applyCoercions χsR pᵈ ∶ᶜ applyTys χsR A ⊒ A′
-    p₁-domainᶜ = p₁ᶜ
+          ∶ fun-narrow-domain-dual (proj₁ p↦q₁)
+          ⦂ applyTys χsR A ⊒ A′
+    WR⊒V′ =
+      subst
+        (λ pd →
+          ΔL₁ ∣ ΔR ∣ applyLeftChanges χsR ρ ∣ []
+            ⊢ WR ⊒ V′ ∶ pd ⦂ applyTys χsR A ⊒ A′)
+        (sym (proj₂ p↦q₁))
+        WR⊒V′raw
 
     ready :
       L · R —↠[ χsR ] applyTerms χsR L · WR
@@ -329,8 +351,9 @@ separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         LF⊒ƛ
         (applyTerms-preserves-Value χsR vL)
         (applyTerms-preserves-No• χsR noL)
+        (proj₁ p↦q₁)
+        (separated-fun-domain-dual (proj₁ p↦q₁))
         WR⊒V′
-        p₁-domainᶜ
         vWR
         noWR
         vV′
@@ -369,14 +392,15 @@ separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   N⊒N′[V′]
 
 separated-dgg-beta :
-  ∀ {ΔL ΔR ρ L R N′ V′ pᵈ p q A A′ B B′} →
+  ∀ {ΔL ΔR ρ L R N′ V′ p q A A′ B B′} →
   RuntimeOK (L · R) →
   Value V′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  (p↦qᶜ : ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ᶜ A ⇒ B ⊒ A′ ⇒ B′) →
+  ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dualᶜ p↦qᶜ ∶ᶜ A ⊒ A′ →
   ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ L ⊒ ƛ N′ ∶ p ↦ q
     ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ R ⊒ V′ ∶ pᵈ ⦂ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ []
+    ⊢ R ⊒ V′ ∶ fun-narrow-domain-dualᶜ p↦qᶜ ⦂ A ⊒ A′ →
   ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ρ′ ] ∃[ C ] ∃[ D ] ∃[ r ]
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×

--- a/GTSF/proof/DGGDeltaSeparated.agda
+++ b/GTSF/proof/DGGDeltaSeparated.agda
@@ -120,6 +120,8 @@ separated-⊕-δ-left-first :
     (M ⊕[ addℕ ] N —↠[ χs ] P) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs (‵ `ℕ)) ×
+    (D ≡ ‵ `ℕ) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ P ⊒ $ (κℕ (m′ + n′)) ∶ r ⦂ C ⊒ D
 separated-⊕-δ-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -238,6 +240,8 @@ separated-⊕-δ-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   source-steps ,
   ΔN≡total ,
   ρN≡total ,
+  sym (applyTys-ℕ χs) ,
+  refl ,
   result⊒
 
 separated-⊕-δ-right-first :
@@ -253,6 +257,8 @@ separated-⊕-δ-right-first :
     (M ⊕[ addℕ ] N —↠[ χs ] P) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs (‵ `ℕ)) ×
+    (D ≡ ‵ `ℕ) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ P ⊒ $ (κℕ (m′ + n′)) ∶ r ⦂ C ⊒ D
 separated-⊕-δ-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -371,4 +377,6 @@ separated-⊕-δ-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   source-steps ,
   ΔM≡total ,
   ρM≡total ,
+  sym (applyTys-ℕ χs) ,
+  refl ,
   result⊒

--- a/GTSF/proof/DGGPrimitiveSeparated.agda
+++ b/GTSF/proof/DGGPrimitiveSeparated.agda
@@ -124,10 +124,16 @@ const-narrowing-targetᶜ () eqM′ (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′)
 const-narrowing-targetᶜ () eqM′ (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′)
 const-narrowing-targetᶜ refl refl (κ⊒κᵗ (κℕ n) pᶜ) = refl
 const-narrowing-targetᶜ () eqM′ (⊕⊒⊕ᵗ pᶜ M⊒M′ N⊒N′)
-const-narrowing-targetᶜ eqM () (⊒cast+ᵗ pᶜ rᶜ t⊒ M⊒M′)
-const-narrowing-targetᶜ eqM () (⊒cast-ᵗ pᶜ rᶜ t⊒ M⊒M′)
-const-narrowing-targetᶜ () eqM′ (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′)
-const-narrowing-targetᶜ () eqM′ (cast-⊒ᵗ qᶜ rᶜ s⊒ M⊒M′)
+const-narrowing-targetᶜ eqM () (⊒Λᵗ typing genᶜ N⊒V′)
+const-narrowing-targetᶜ eqM () (⊒⟨ν⟩ᵗ typing genᶜ i N⊒V′s)
+const-narrowing-targetᶜ () eqM′ (α⊒αᵗ γ′≡ typing qᶜ pᶜ L⊒L′)
+const-narrowing-targetᶜ eqM () (⊒αᵗ γ′≡ typing pᶜ L⊒L′)
+const-narrowing-targetᶜ () eqM′ (ν⊒νᵗ typing pᶜ qᶜ N⊒N′)
+const-narrowing-targetᶜ eqM () (⊒νᵗ typing pᶜ N⊒N′)
+const-narrowing-targetᶜ eqM () (⊒cast+ᵗ pᶜ rᶜ t⊒ _ M⊒M′)
+const-narrowing-targetᶜ eqM () (⊒cast-ᵗ pᶜ rᶜ t⊒ _ M⊒M′)
+const-narrowing-targetᶜ () eqM′ (cast+⊒ᵗ qᶜ rᶜ s⊒ _ M⊒M′)
+const-narrowing-targetᶜ () eqM′ (cast-⊒ᵗ qᶜ rᶜ s⊒ _ M⊒M′)
 
 value-id-ℕ-narrowing-target-constᶜ :
   ∀ {ΔL ΔR ρ W n} →

--- a/GTSF/proof/DGGPrimitiveSeparated.agda
+++ b/GTSF/proof/DGGPrimitiveSeparated.agda
@@ -27,6 +27,7 @@ open import NuReduction
 open import StoreCorrespondence
 open import TermNarrowingSeparated
 open import proof.NuProgress using (canonical-ℕ; nv-const)
+open import proof.NarrowWidenProperties using (narrowing-determinedᵐ)
 open import proof.ReductionProperties using
   ( applyCoercions
   ; applyTerms-const
@@ -166,3 +167,38 @@ value-normalized-id-ℕ-target-constᶜ target-value T≡ p≡ A≡ B≡ W⊒ =
             (λ B → _ ∣ _ ∣ _ ∣ [] ⊢ _ ⊒ _ ∶ _ ⦂ _ ⊒ B)
             B≡
             W⊒))))
+
+-- Any narrowing relation whose endpoints are `ℕ` on both sides is a
+-- relation at the identity coercion: normal coercions are determined by
+-- mode and endpoints (`narrowing-determinedᵐ`), `cast-id` types
+-- `id (‵ ℕ)` in every mode (`idTyAllowed μ (‵ ι) = true`), so the
+-- relation's own coercion evidence pins its index to `id (‵ ℕ)`.
+nat-endpoints-id-coercionᶜ :
+  ∀ {ΔL ΔR ρ γ M M′ r C D} →
+  C ≡ ‵ `ℕ →
+  D ≡ ‵ `ℕ →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ C ⊒ D →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+nat-endpoints-id-coercionᶜ {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {γ = γ}
+    {M = M} {M′ = M′} {r = r} C≡ D≡ M⊒M′ =
+  let
+    M⊒M′ℕ :
+      ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ ‵ `ℕ ⊒ ‵ `ℕ
+    M⊒M′ℕ = typed-term-narrowing-endpointsᶜ C≡ D≡ M⊒M′
+
+    μ , r⊒ = typed-term-narrowing-coercion M⊒M′ℕ
+
+    stores , _ , _ , _ , _ , r⊒L , _ = r⊒
+
+    r≡id : r ≡ id (‵ `ℕ)
+    r≡id =
+      narrowing-determinedᵐ
+        (leftStore-det stores)
+        r⊒L
+        (cast-id wfBase refl , cross (id-‵ `ℕ))
+  in
+  subst
+    (λ c →
+      ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ c ⦂ ‵ `ℕ ⊒ ‵ `ℕ)
+    r≡id
+    M⊒M′ℕ

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -366,3 +366,31 @@ The remaining mode question is confined to the frame-reconstruction
 holes: determinacy-based coercion recovery needs the transported frame
 coercion and the IH's coercion typed at one common mode env.  That is
 now the only place where `∶ᶜ`-versus-`μ` matters in the theorem.
+
+## Cross-mode determinacy, 2026-07-05
+
+Unrestricted cross-mode determinacy is false: with `Δ = 1` and
+`Σ = (0 , ★) ∷ []`, the endpoints `★ ⊒ ＇ 0` are inhabited by `＇ 0 ？`
+(normal in `tag-or-idᵈ`) and by `seal ★ 0` (normal in `seal-or-idᵈ`),
+which differ.  The failure requires the two mode environments to
+disagree tag-versus-seal at a variable.
+
+`proof.NarrowWidenProperties` now proves the restricted version:
+
+- `modeCompat`/`ModeEnvCompat`: pointwise absence of tag/seal
+  disagreement.
+- `modeEnvJoin` with `modeIncl-joinˡ`/`modeIncl-joinʳ`: compatible
+  environments have a pointwise `mode≤` upper bound.
+- `compatible-narrowing-determinedᵐ` (and the `⊑` twin): relax both
+  typings into the join with `coercion-mode-relax`, then apply the
+  single-environment `narrowing-determinedᵐ`.
+- `seal-free-compat-tagᵈ`: a seal-free environment is compatible with
+  `tag-or-idᵈ` — the instance the DGG frames need, since they compare a
+  coercion at an unknown environment against a transported `∶ᶜ` one.
+
+For the frames this reduces the mode pinch to a residual fact about the
+relation: that the IH's existential mode environment can be chosen
+seal-free (or pointwise compatible with `tag-or-idᵈ`) at the frame's
+endpoints.  Where that fails, the counterexample shape (`★ ⊒ ＇ α` with
+`(α , ★)` in the store) shows tag- and seal-mediated evidence genuinely
+diverge, which is a relation-design fact, not a provability gap.

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -327,3 +327,42 @@ right-side transport surface is still missing), and its evidence is at
 Cross-mode determinacy should hold at seal-variable-free endpoints —
 modes only arbitrate the tag-versus-seal mediation at `＇α` — but that
 corollary is not yet stated.
+
+## Dropping the DGG coercion premise, 2026-07-05
+
+The separated `dynamicGradualGuarantee` demanded
+`ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B` alongside the relation `⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B`.
+Investigation confirmed the premise was inherited from the shared-store
+statement and is both redundant and harmful:
+
+- Redundant: `typed-term-narrowing-coercion` recovers (general-mode)
+  typing evidence for the relation's own index from the relation itself,
+  and the premise's only genuine consumers were the six `⊒blameᵗ`
+  reconstructions.
+- Harmful: it made the theorem stricter than the relation.  The inner
+  relations of `⊒cast+ᵗ` (and the premise relation of `cast-⊒ᵗ`) are
+  indexed by coercions with only general-`μ` typing, so the recursive
+  calls in the `ξ-⟨⟩` case for `⊒cast+ᵗ` and in the `cast-⊒ᵗ` source-cast
+  case could not be made at all — those were the
+  `target-cast-plus-inner-step-simulation` and
+  `source-cast-minus-inner-simulation` holes.
+
+Changes:
+
+- `⊒blameᵗ` in `TermNarrowingSeparated` now takes
+  `μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ∶ A ⊒ B` for an implicit `μ` instead of `∶ᶜ`;
+  blame is the target of any well-typed narrowing index.  All existing
+  constructions (which supply `∶ᶜ` evidence) still check, since
+  `tag-or-idᵈ` is an instance.  `typed-term-narrowing-coercion` returns
+  the constructor's `μ`.
+- The theorem premise is gone.  Blame reconstructions use
+  `proj₂ (typed-term-narrowing-coercion rel)`.  The `∶ᶜ`-transport
+  bindings that existed only to feed recursive calls
+  (`p-domain-Lᶜ`, `pℕMᶜ`) are deleted.
+- The two former inner-simulation holes are now literal recursive calls
+  (structural on the relation argument), closing them.
+
+The remaining mode question is confined to the frame-reconstruction
+holes: determinacy-based coercion recovery needs the transported frame
+coercion and the IH's coercion typed at one common mode env.  That is
+now the only place where `∶ᶜ`-versus-`μ` matters in the theorem.

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -220,7 +220,7 @@ Repairs:
   failed the termination checker.  It now checks.  The recursion through
   catchup projections is marked `TERMINATING`, matching the existing
   `sim-beta` precedent.  For a function-shaped target cast, the `⊒cast+ᵗ`
-  inner coercions `G \!`, `seal`, and `gen` are refuted by matching `refl` in
+  inner coercions `G !`, `seal`, and `gen` are refuted by matching `refl` in
   the inner coercion's `tgt` equation and `()` in the cast typing's `tgt`
   equation (an arrow type cannot be `★`, `＇α`, or `∀`).  The `id` and `_︔_`
   inner coercions are genuine open branches and hold explicit holes, as do
@@ -394,3 +394,59 @@ seal-free (or pointwise compatible with `tag-or-idᵈ`) at the frame's
 endpoints.  Where that fails, the counterexample shape (`★ ⊒ ＇ α` with
 `(α , ★)` in the store) shows tag- and seal-mediated evidence genuinely
 diverge, which is a relation-design fact, not a provability gap.
+
+## Composition side conditions and the six missing rules, 2026-07-05
+
+Comparing `TermNarrowingSeparated` with the cambridge25 term-narrowing
+rules exposed a partial port: the polymorphism/ν rules were absent and
+all four cast rules had dropped their composition side conditions.
+Both are now restored; see the checklist for the design details.
+Highlights:
+
+- New mixfix judgment `ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ t ≈ r ∶ A ⊒ B` mirroring the
+  paper's `s ⨾ t ≈ r`.  It stores cross-store typings of `s`, `t`, `r`
+  at one shared mode environment; canonicity (`narrowing-determinedᵐ`)
+  then pins `r` to the `_⨟ⁿ_` composite (`composite-determinedˡ/ʳ`,
+  proved).  Stored-composite forms were tried first and abandoned:
+  they do not transport across the postulated store-change surfaces.
+- Six constructors ported: `⊒Λᵗ`, `⊒⟨ν⟩ᵗ`, `α⊒αᵗ`, `⊒αᵗ`, `ν⊒νᵗ`,
+  `⊒νᵗ`, with explicit endpoint-typing premises.
+- `sim-beta` reworked: mode-generic function-coercion evidence plus the
+  `∶ᶜ` typing of its domain dual, argument relation indexed by that
+  dual.  `fun-narrow-domain-dual-determined` (proved) replaces
+  determinacy-based re-indexing; the two recursion sites consume the
+  new (approved) postulate `left-change-fun-coercion-narrowing`.
+- The composition witnesses at the `sim-beta` cast branches are real
+  proofs assembled from the matched constructor's own composition
+  record: `separated-fun-domain-dual` of its fields at the shared
+  environment, raw indices bridged by
+  `fun-narrow-domain-dual-determined`.
+- Checking-time note: `GTSF/Makefile` now runs Agda with
+  `+RTS -A128M -M8G -RTS`; one unflagged check of `SimBetaSeparated`
+  was killed by the OS (exit 137, memory pressure).
+
+## Downstream sweep of the composition premises, 2026-07-06
+
+- The last two `sim-beta` composition sites (the codomain sides of
+  `sim-beta-cast+-result` and `sim-beta-cast-tail`) are filled.  Both
+  helpers gained a codomain composition premise
+  `ΔL ∣ ΔR ∣ ρ ⊢ d ⨟ q ≈ q′ ∶ B ⊒ BR`, produced at the call sites by
+  `cast-fun-comp-codomain` (projects a codomain composition out of an
+  arrow-level record, pinning the middle type with the s-factor's
+  target equations) and transported through the two catchup
+  store-change layers with `left-change-composed-index` (both proved,
+  `LeftChangeNarrowingSeparated`).  `sim-beta` has no remaining holes.
+- `separated-dgg-beta{,-left-first,-right-first}` re-based on the new
+  `sim-beta` arity.  The generic `pᵈ` premise is gone: the argument
+  relation is now stated at `fun-narrow-domain-dualᶜ p↦qᶜ`, which is
+  what `·⊒·ᵗ` inversion hands the main theorem, so
+  `DynamicGradualGuaranteeSeparated`'s β case needed no change.
+  Inside, `left-change-fun-coercion-narrowing` transports the arrow
+  `∶ᶜ` typing along each catchup χs-chain and its dual equality
+  re-indexes the caught-up argument relation (one `subst` per layer).
+- `DGGBetaCastSeparated` and `DynamicGradualGuaranteeSeparated`
+  patterns arity-bumped (`_` for the new composition premise).  The
+  six cast constructions in `DGGBetaCastSeparated` carry named
+  `{! …-composition !}` holes mirroring the discharged `sim-beta`
+  sites; filling them needs the same compᵏ-threading surgery on that
+  file's local helpers.

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -294,3 +294,36 @@ Remaining gap for the frame cases: the resulting coercion `r` is still
 unlinked.  See the checklist entry — coercion-index preservation is false
 at `β-id`, so the fix must be a relation-level design change, not another
 conclusion equation.
+
+## Coercion recovery via determinacy, 2026-07-05
+
+The "coercion tracking" gap in the separated DGG frames is not a missing
+conclusion component: normal coercions are already canonical.
+`narrowing-determinedᵐ` (`proof.NarrowWidenProperties`) says a normal
+coercion is determined by its mode env, contexts, and endpoints, so the
+endpoint equalities added to the theorem's conclusion determine the result
+coercion as well.
+
+Implemented:
+
+- `nat-endpoints-id-coercionᶜ` (`proof.DGGPrimitiveSeparated`): any
+  separated narrowing relation whose endpoints equal `‵ ℕ` on both sides
+  is a relation at `id (‵ ℕ)`.  The proof rewrites the endpoints with
+  `typed-term-narrowing-endpointsᶜ`, extracts the relation's own coercion
+  typing with `typed-term-narrowing-coercion`, types `id (‵ ℕ)` at the
+  same (existential) mode env — `idTyAllowed μ (‵ ι) = true` for every
+  `μ`, so `cast-id` needs no mode assumption — and closes with
+  `narrowing-determinedᵐ` against the `leftStore-det` field of the
+  relation's `StoreCorr`.
+- The three `ξ-⊕`-IH holes (`ξ-⊕₁` twice, `ξ-⊕₂` once) are closed by the
+  lemma applied to the tracked equalities composed with `applyTys-ℕ` and
+  `applyTy-ℕ`.
+
+Not yet transferable to the application frames: the same recipe needs a
+comparison coercion typed in the changed stores at the IH's mode env.
+The transported `p ↦ q` is typed only in the pre-right-change stores (the
+right-side transport surface is still missing), and its evidence is at
+`tag-or-idᵈ` while the IH's coercion typing carries an existential mode.
+Cross-mode determinacy should hold at seal-variable-free endpoints —
+modes only arbitrate the tag-versus-seal mediation at `＇α` — but that
+corollary is not yet stated.

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -254,3 +254,43 @@ current completed clause, but coercion-index tracking is falsified by the
 `β-id` clauses, so the application and `⊕` frames also need either a
 coercion-conversion rule or `∶ᶜ` result evidence, which `⊒cast+ᵗ` inner
 relations cannot supply.
+
+## Endpoint-type tracking in the separated DGG conclusion, 2026-07-05
+
+The separated `dynamicGradualGuarantee` conclusion now returns
+`(C ≡ applyTys χs A) × (D ≡ applyTy χ′ B)` between the store-correspondence
+equation and the final narrowing relation.  This restores the link between
+the recursive call's existential endpoints and the inputs, which the
+ξ-frame reconstruction holes need.
+
+Proof notes:
+
+- Most clauses discharge both equalities with `refl`, either definitionally
+  (`χs = []`, `χ′ = keep`) or by letting `refl` pin the existential
+  endpoint metas of a frame hole to the tracked values.
+- The four `β-id` clauses return the inner relation at the inner target
+  type, so the target equation is not definitional.  It follows from the
+  id-cast typing tuple: with `t = id A₀`, the `src`/`tgt` components give
+  `A₀ ≡ C` and `A₀ ≡ B`, and `trans`/`sym` produce the needed equation.
+  This confirms endpoint tracking is genuinely true in the `β-id` cases,
+  where coercion-index tracking fails.
+- The `⊕` congruence frames use `sym (applyTys-ℕ χs)` and
+  `sym (applyTy-ℕ χ′)` because `⊕⊒⊕ᵗ` forces concrete `‵ ℕ` endpoints.
+- `separated-⊕-δ-left-first`/`-right-first` in `proof.DGGDeltaSeparated`
+  were extended to return `(C ≡ applyTys χs (‵ ℕ)) × (D ≡ ‵ ℕ)`; their
+  results are literal `κ⊒κᵗ` relations at `id (‵ ℕ)`, so the equalities
+  are `sym (applyTys-ℕ χs)` and `refl`.
+- The beta delegation sites (`separated-dgg-beta`,
+  `separated-dgg-beta-cast`) do not yet track endpoints; the two clauses
+  carry `β-*-endpoint-tracking` holes until the extension is threaded
+  through those helpers and `sim-beta`.
+- The local `obligation` tuple ascriptions that duplicated the theorem's
+  ∃-type were removed where the tuple is immediately returned; the clause
+  type determines them, and the duplicated ascriptions could not name the
+  per-clause endpoint instantiations without binding more constructor
+  implicits.
+
+Remaining gap for the frame cases: the resulting coercion `r` is still
+unlinked.  See the checklist entry — coercion-index preservation is false
+at `β-id`, so the fix must be a relation-level design change, not another
+conclusion equation.

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -119,10 +119,15 @@ open import proof.DGGDeltaSeparated using
 -- Full separated DGG skeleton
 ------------------------------------------------------------------------
 
+-- The relation premise already carries the typing evidence for its own
+-- coercion index (`typed-term-narrowing-coercion`), so the theorem takes
+-- no separate coercion premise.  In particular it must NOT demand `∶ᶜ`
+-- evidence: the inner relations of `⊒cast+ᵗ` and `cast+⊒ᵗ` are indexed by
+-- general-mode coercions, and the recursive calls on them would otherwise
+-- be unsatisfiable.
 dynamicGradualGuarantee :
   ∀ {ΔL ΔR ρ M M′ N′ A B p χ′} →
   RuntimeOK M →
-  ΔL ∣ ΔR ∣ ρ ⊢ p ∶ᶜ A ⊒ B →
   ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ B →
   M′ —→[ χ′ ] N′ →
   ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
@@ -134,16 +139,16 @@ dynamicGradualGuarantee :
     (C ≡ applyTys χs A) ×
     (D ≡ applyTy χ′ B) ×
     ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
-dynamicGradualGuarantee okM pᶜ (⊒blameᵗ M⊢ qᶜ)
+dynamicGradualGuarantee okM (⊒blameᵗ M⊢ q⊒)
     (pure-step ())
-dynamicGradualGuarantee okM pᶜ (x⊒xᵗ qᶜ x∋q)
+dynamicGradualGuarantee okM (x⊒xᵗ qᶜ x∋q)
     (pure-step ())
-dynamicGradualGuarantee okM pᶜ
+dynamicGradualGuarantee okM
     (ƛ⊒ƛᵗ p↦qᶜ N⊒N′)
     (pure-step ())
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = (ƛ N′) · V′}
-    okLR qᶜ
+    okLR
     (·⊒·ᵗ p↦q-wholeᶜ L⊒ƛ R⊒V′)
     (pure-step (β vV′)) =
   let
@@ -177,7 +182,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   N⊒N′[V′]
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}
-    okM qᶜ
+    okM
     app@(·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
     (pure-step (β-↦ {V = V′} {W = W′} {p = c′} {q = d′} vV′ vW′)) =
   let
@@ -211,7 +216,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   N⊒target
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}
-    okM qᶜ
+    okM
     app@(·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
     (pure-step blame-·₁) =
   [] ,
@@ -228,10 +233,11 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
-  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app) qᶜ
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app)
+    (proj₂ (typed-term-narrowing-coercion app))
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}
-    okM qᶜ
+    okM
     app@(·⊒·ᵗ p↦qᶜ L⊒L′ R⊒R′)
     (pure-step (blame-·₂ vV)) =
   [] ,
@@ -248,17 +254,17 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
-  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app) qᶜ
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app)
+    (proj₂ (typed-term-narrowing-coercion app))
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
-    (ok-no (no•-· noL noR)) qᶜ
+    (ok-no (no•-· noL noR))
     (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
     (ξ-·₁ {L′ = S′} L′→N′ shiftR′) =
   let
     rec =
       dynamicGradualGuarantee
         (ok-no noL)
-        p↦q-wholeᶜ
         L⊒L′
         L′→N′
 
@@ -313,14 +319,13 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
-    (ok-·₁ okL noR) qᶜ
+    (ok-·₁ okL noR)
     (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
     (ξ-·₁ {L′ = S′} L′→N′ shiftR′) =
   let
     rec =
       dynamicGradualGuarantee
         okL
-        p↦q-wholeᶜ
         L⊒L′
         L′→N′
 
@@ -375,7 +380,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
-    (ok-·₂ vL noL okR) qᶜ
+    (ok-·₂ vL noL okR)
     app@(·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
     (ξ-·₁ {L′ = S′} L′→S′ shiftR′) =
   let
@@ -422,7 +427,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
-    (ok-no (no•-· noL noR)) qᶜ
+    (ok-no (no•-· noL noR))
     (·⊒·ᵗ {p = p} {q = q} {A = A} {A′ = A′}
       {B = B} {B′ = B′} p↦q-wholeᶜ L⊒L′ R⊒R′)
     (ξ-·₂ {M′ = S′} vL′ shiftL′ R′→S′) =
@@ -463,21 +468,9 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     R⊒R′L =
       advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒R′
 
-    p-domain-Lᶜ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ
-        ⊢ applyCoercions χsL (fun-narrow-domain-dualᶜ p↦q-wholeᶜ)
-          ∶ᶜ applyTys χsL A ⊒ A′
-    p-domain-Lᶜ =
-      left-change-coercion-narrowing
-        χsL
-        ΔL₁≡
-        ρL-corr
-        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
-
     rec =
       dynamicGradualGuarantee
         (applyTerms-preserves-RuntimeOK χsL (ok-no noR))
-        p-domain-Lᶜ
         R⊒R′L
         R′→S′
 
@@ -556,7 +549,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
-    (ok-·₁ okL noR) qᶜ
+    (ok-·₁ okL noR)
     (·⊒·ᵗ {p = p} {q = q} {A = A} {A′ = A′}
       {B = B} {B′ = B′} p↦q-wholeᶜ L⊒L′ R⊒R′)
     (ξ-·₂ {M′ = S′} vL′ shiftL′ R′→S′) =
@@ -597,21 +590,9 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     R⊒R′L =
       advance-left-term-narrowing χsL ΔL₁≡ ρL-corr R⊒R′
 
-    p-domain-Lᶜ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsL ρ
-        ⊢ applyCoercions χsL (fun-narrow-domain-dualᶜ p↦q-wholeᶜ)
-          ∶ᶜ applyTys χsL A ⊒ A′
-    p-domain-Lᶜ =
-      left-change-coercion-narrowing
-        χsL
-        ΔL₁≡
-        ρL-corr
-        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
-
     rec =
       dynamicGradualGuarantee
         (applyTerms-preserves-RuntimeOK χsL (ok-no noR))
-        p-domain-Lᶜ
         R⊒R′L
         R′→S′
 
@@ -690,7 +671,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {N′ = T′} {χ′ = χ′}
-    (ok-·₂ vL noL okR) qᶜ
+    (ok-·₂ vL noL okR)
     (·⊒·ᵗ p↦q-wholeᶜ L⊒L′ R⊒R′)
     (ξ-·₂ {M′ = S′} vL′ shiftL′ R′→N′) =
   let
@@ -700,7 +681,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     rec =
       dynamicGradualGuarantee
         runtimeR
-        (fun-narrow-domain-dual-typingᶜ p↦q-wholeᶜ)
         R⊒R′
         R′→N′
 
@@ -754,14 +734,14 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       framed⊒
   in
   obligation
-dynamicGradualGuarantee okM pᶜ
+dynamicGradualGuarantee okM
     (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′)
     (pure-step ())
-dynamicGradualGuarantee okM pᶜ (κ⊒κᵗ κ qᶜ)
+dynamicGradualGuarantee okM (κ⊒κᵗ κ qᶜ)
     (pure-step ())
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
-    (ok-no (no•-⊕ noM noN)) pᶜ
+    (ok-no (no•-⊕ noM noN))
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step (δ-⊕ {m = m′} {n = n′})) =
   let
@@ -792,7 +772,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   P⊒P′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
-    (ok-⊕₁ okM noN) pᶜ
+    (ok-⊕₁ okM noN)
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step (δ-⊕ {m = m′} {n = n′})) =
   let
@@ -823,7 +803,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   P⊒P′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
-    (ok-⊕₂ vM noM okN) pᶜ
+    (ok-⊕₂ vM noM okN)
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step (δ-⊕ {m = m′} {n = n′})) =
   let
@@ -855,7 +835,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   P⊒P′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
-    okM pᶜ
+    okM
     add@(⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step blame-⊕₁) =
   [] ,
@@ -872,10 +852,11 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
-  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add) pᶜ
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add)
+    (proj₂ (typed-term-narrowing-coercion add))
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
-    okM pᶜ
+    okM
     add@(⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (pure-step (blame-⊕₂ vV)) =
   [] ,
@@ -892,18 +873,18 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
-  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add) pᶜ
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add)
+    (proj₂ (typed-term-narrowing-coercion add))
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
     {N′ = P′} {χ′ = χ′}
-    (ok-no (no•-⊕ noM noN)) pᶜ
+    (ok-no (no•-⊕ noM noN))
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (ξ-⊕₁ {L′ = S′} M′→P′ shiftN′) =
   let
     rec =
       dynamicGradualGuarantee
         (ok-no noM)
-        pᶜ
         M⊒M′
         M′→P′
 
@@ -962,14 +943,13 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
     {N′ = P′} {χ′ = χ′}
-    (ok-⊕₁ okM noN) pᶜ
+    (ok-⊕₁ okM noN)
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (ξ-⊕₁ {L′ = S′} M′→P′ shiftN′) =
   let
     rec =
       dynamicGradualGuarantee
         okM
-        pᶜ
         M⊒M′
         M′→P′
 
@@ -1027,7 +1007,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
     {χ′ = χ′}
-    (ok-⊕₂ vM noM okN) pᶜ
+    (ok-⊕₂ vM noM okN)
     add@(⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (ξ-⊕₁ {L′ = S′} M′→S′ shiftN′) =
   let
@@ -1077,7 +1057,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
     {χ′ = χ′}
-    (ok-no (no•-⊕ noM noN)) pᶜ
+    (ok-no (no•-⊕ noM noN))
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (ξ-⊕₂ {M′ = S′} vM′ shiftM′ N′→S′) =
   let
@@ -1097,21 +1077,9 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     N⊒N′M =
       advance-left-term-narrowing χsM ΔL₁≡ ρM-corr N⊒N′
 
-    pℕMᶜ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ
-        ⊢ applyCoercions χsM (id (‵ `ℕ))
-          ∶ᶜ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
-    pℕMᶜ =
-      left-change-coercion-narrowing
-        χsM
-        ΔL₁≡
-        ρM-corr
-        pℕᶜ
-
     rec =
       dynamicGradualGuarantee
         (applyTerms-preserves-RuntimeOK χsM (ok-no noN))
-        pℕMᶜ
         N⊒N′M
         N′→S′
 
@@ -1194,7 +1162,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
     {χ′ = χ′}
-    (ok-⊕₁ okM noN) pᶜ
+    (ok-⊕₁ okM noN)
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (ξ-⊕₂ {M′ = S′} vM′ shiftM′ N′→S′) =
   let
@@ -1214,21 +1182,9 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     N⊒N′M =
       advance-left-term-narrowing χsM ΔL₁≡ ρM-corr N⊒N′
 
-    pℕMᶜ :
-      ΔL₁ ∣ ΔR ∣ applyLeftChanges χsM ρ
-        ⊢ applyCoercions χsM (id (‵ `ℕ))
-          ∶ᶜ applyTys χsM (‵ `ℕ) ⊒ ‵ `ℕ
-    pℕMᶜ =
-      left-change-coercion-narrowing
-        χsM
-        ΔL₁≡
-        ρM-corr
-        pℕᶜ
-
     rec =
       dynamicGradualGuarantee
         (applyTerms-preserves-RuntimeOK χsM (ok-no noN))
-        pℕMᶜ
         N⊒N′M
         N′→S′
 
@@ -1311,7 +1267,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
     {N′ = P′} {χ′ = χ′}
-    (ok-⊕₂ vM noM okN) pᶜ
+    (ok-⊕₂ vM noM okN)
     (⊕⊒⊕ᵗ pℕᶜ M⊒M′ N⊒N′)
     (ξ-⊕₂ {M′ = S′} vM′ shiftM′ N′→P′) =
   let
@@ -1321,7 +1277,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     rec =
       dynamicGradualGuarantee
         runtimeN
-        pᶜ
         N⊒N′
         N′→P′
 
@@ -1378,7 +1333,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
     (pure-step blame-⟨⟩) =
   [] ,
@@ -1395,10 +1350,11 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
-  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel) pᶜ
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel)
+    (proj₂ (typed-term-narrowing-coercion castRel))
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     (⊒cast-ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ , _ , _)
       M⊒M′)
@@ -1420,7 +1376,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
     (pure-step (tag-untag-bad vV′ G≢H)) =
   [] ,
@@ -1437,10 +1393,11 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
-  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel) pᶜ
+  ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel)
+    (proj₂ (typed-term-narrowing-coercion castRel))
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ ,
         (cast-id _ _ , cross (id-‵ ι)) , _)
@@ -1463,7 +1420,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ ,
         (cast-id _ _ , cross (id-＇ α)) , _)
@@ -1486,7 +1443,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ ,
         (cast-id _ _ , id★) , _)
@@ -1509,7 +1466,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
-    okM pᶜ
+    okM
     (⊒cast+ᵗ {M′ = M′} {t = t} {A = A} {B = Bᵢ} p′ᶜ rᶜ t⊒ M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
@@ -1523,19 +1480,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (C ≡ applyTys χs A) ×
         (D ≡ applyTy χ′ Bᵢ) ×
         ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
-    rec =
-      let
-        inner-runtime : RuntimeOK M
-        inner-runtime = okM
-
-        inner-step : M′ —→[ χ′ ] S′
-        inner-step = M′→S′
-
-        inner-narrowing :
-          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ _ ⦂ _ ⊒ _
-        inner-narrowing = M⊒M′
-      in
-      {! target-cast-plus-inner-step-simulation !}
+    rec = dynamicGradualGuarantee okM M⊒M′ M′→S′
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
@@ -1572,7 +1517,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {N′ = N′} {χ′ = χ′}
-    okM pᶜ
+    okM
     castRel@(⊒cast+ᵗ {M′ = M′} p′ᶜ rᶜ t⊒ M⊒M′)
     M′⟨s⟩→N′ =
   let
@@ -1617,11 +1562,11 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
-    okM pᶜ
+    okM
     (⊒cast-ᵗ {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
-    rec = dynamicGradualGuarantee okM p′ᶜ M⊒M′ M′→S′
+    rec = dynamicGradualGuarantee okM M⊒M′ M′→S′
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
@@ -1657,7 +1602,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     castRel@(⊒cast-ᵗ {M′ = V′} {t = t₁ ︔ t₂} p′ᶜ rᶜ t⊒ M⊒V′)
     (pure-step (β-seq vV′)) =
   [] ,
@@ -1677,7 +1622,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   {! target-cast-minus-seq-split-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     castRel@(⊒cast-ᵗ {M′ = V′} {t = inst B₁ t₁} p′ᶜ rᶜ t⊒ M⊒V′)
     (pure-step (β-inst vV′)) =
   [] ,
@@ -1697,7 +1642,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   {! target-cast-minus-inst-nu-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     castRel@(⊒cast-ᵗ {t = G ？} p′ᶜ rᶜ t⊒ M⊒V′tag)
     (pure-step (tag-untag-ok vV′)) =
   [] ,
@@ -1717,7 +1662,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   {! target-cast-minus-tag-untag-collapse-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
-    okM pᶜ
+    okM
     castRel@(⊒cast-ᵗ {t = unseal α B₁} p′ᶜ rᶜ t⊒ M⊒V′seal)
     (pure-step (seal-unseal vV′)) =
   [] ,
@@ -1737,10 +1682,10 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   {! target-cast-minus-seal-unseal-collapse-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
-    okM pᶜ
+    okM
     (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
   let
-    rec = dynamicGradualGuarantee (runtime-⟨⟩ okM) qᶜ M⊒M′ M′→N′
+    rec = dynamicGradualGuarantee (runtime-⟨⟩ okM) M⊒M′ M′→N′
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
@@ -1785,7 +1730,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
-    okM pᶜ
+    okM
     (cast-⊒ᵗ {M′ = M′} {A = Aᵢ} {B = Bᵢ} qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
   let
     rec :
@@ -1798,19 +1743,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (C ≡ applyTys χs Aᵢ) ×
         (D ≡ applyTy χ′ Bᵢ) ×
         ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
-    rec =
-      let
-        inner-runtime : RuntimeOK M
-        inner-runtime = runtime-⟨⟩ okM
-
-        inner-step : M′ —→[ χ′ ] N′
-        inner-step = M′→N′
-
-        inner-narrowing :
-          ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ _ ⦂ _ ⊒ _
-        inner-narrowing = M⊒M′
-      in
-      {! source-cast-minus-inner-simulation !}
+    rec = dynamicGradualGuarantee (runtime-⟨⟩ okM) M⊒M′ M′→N′
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -1334,7 +1334,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM
-    castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ _ M⊒M′)
     (pure-step blame-⟨⟩) =
   [] ,
   M ,
@@ -1357,6 +1357,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     okM
     (⊒cast-ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ , _ , _)
+      _
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1377,7 +1378,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM
-    castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    castRel@(⊒cast-ᵗ p′ᶜ rᶜ t⊒ _ M⊒M′)
     (pure-step (tag-untag-bad vV′ G≢H)) =
   [] ,
   M ,
@@ -1401,6 +1402,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ ,
         (cast-id _ _ , cross (id-‵ ι)) , _)
+      _
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1424,6 +1426,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ ,
         (cast-id _ _ , cross (id-＇ α)) , _)
+      _
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1447,6 +1450,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     (⊒cast+ᵗ p′ᶜ rᶜ
       (_ , t-src≡ , t-tgt≡ , _ , _ ,
         (cast-id _ _ , id★) , _)
+      _
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1467,7 +1471,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
     okM
-    (⊒cast+ᵗ {M′ = M′} {t = t} {A = A} {B = Bᵢ} p′ᶜ rᶜ t⊒ M⊒M′)
+    (⊒cast+ᵗ {M′ = M′} {t = t} {A = A} {B = Bᵢ} p′ᶜ rᶜ t⊒ _ M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
     rec :
@@ -1518,7 +1522,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {N′ = N′} {χ′ = χ′}
     okM
-    castRel@(⊒cast+ᵗ {M′ = M′} p′ᶜ rᶜ t⊒ M⊒M′)
+    castRel@(⊒cast+ᵗ {M′ = M′} p′ᶜ rᶜ t⊒ _ M⊒M′)
     M′⟨s⟩→N′ =
   let
     relation-obligation :
@@ -1563,7 +1567,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
     okM
-    (⊒cast-ᵗ {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
+    (⊒cast-ᵗ {t = t} p′ᶜ rᶜ t⊒ _ M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
     rec = dynamicGradualGuarantee okM M⊒M′ M′→S′
@@ -1603,7 +1607,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM
-    castRel@(⊒cast-ᵗ {M′ = V′} {t = t₁ ︔ t₂} p′ᶜ rᶜ t⊒ M⊒V′)
+    castRel@(⊒cast-ᵗ {M′ = V′} {t = t₁ ︔ t₂} p′ᶜ rᶜ t⊒ _ M⊒V′)
     (pure-step (β-seq vV′)) =
   [] ,
   M ,
@@ -1623,7 +1627,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM
-    castRel@(⊒cast-ᵗ {M′ = V′} {t = inst B₁ t₁} p′ᶜ rᶜ t⊒ M⊒V′)
+    castRel@(⊒cast-ᵗ {M′ = V′} {t = inst B₁ t₁} p′ᶜ rᶜ t⊒ _ M⊒V′)
     (pure-step (β-inst vV′)) =
   [] ,
   M ,
@@ -1643,7 +1647,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM
-    castRel@(⊒cast-ᵗ {t = G ？} p′ᶜ rᶜ t⊒ M⊒V′tag)
+    castRel@(⊒cast-ᵗ {t = G ？} p′ᶜ rᶜ t⊒ _ M⊒V′tag)
     (pure-step (tag-untag-ok vV′)) =
   [] ,
   M ,
@@ -1663,7 +1667,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM
-    castRel@(⊒cast-ᵗ {t = unseal α B₁} p′ᶜ rᶜ t⊒ M⊒V′seal)
+    castRel@(⊒cast-ᵗ {t = unseal α B₁} p′ᶜ rᶜ t⊒ _ M⊒V′seal)
     (pure-step (seal-unseal vV′)) =
   [] ,
   M ,
@@ -1683,7 +1687,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
     okM
-    (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
+    (cast+⊒ᵗ qᶜ rᶜ s⊒ _ M⊒M′) M′→N′ =
   let
     rec = dynamicGradualGuarantee (runtime-⟨⟩ okM) M⊒M′ M′→N′
 
@@ -1731,7 +1735,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
     okM
-    (cast-⊒ᵗ {M′ = M′} {A = Aᵢ} {B = Bᵢ} qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
+    (cast-⊒ᵗ {M′ = M′} {A = Aᵢ} {B = Bᵢ} qᶜ rᶜ s⊒ _ M⊒M′) M′→N′ =
   let
     rec :
       ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
@@ -1777,3 +1781,27 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       cast-result⊒
   in
   obligation
+-- Simulation cases for the six 2026-07-05 term-narrowing constructors.
+-- `⊒Λᵗ` needs no clause (its target `Λ V′` cannot step).  The rest are
+-- genuine ν-allocation / seal-narrowing simulation obligations; their
+-- proofs are the next milestone (see the checklist, Track B).
+dynamicGradualGuarantee okM (⊒⟨ν⟩ᵗ _ _ _ _) (pure-step st) =
+  {! target-gen-cast-pure-step-simulation !}
+dynamicGradualGuarantee okM (⊒⟨ν⟩ᵗ _ _ _ _) (ξ-⟨⟩ st) =
+  {! target-gen-cast-inner-step-simulation !}
+dynamicGradualGuarantee okM (α⊒αᵗ _ _ _ _ _) (pure-step st) =
+  {! matched-seal-pure-step-simulation !}
+dynamicGradualGuarantee okM (⊒αᵗ _ _ _ _) (pure-step st) =
+  {! target-seal-pure-step-simulation !}
+dynamicGradualGuarantee okM (ν⊒νᵗ _ _ _ _) (ν-step st₁ st₂) =
+  {! nu-nu-allocation-simulation !}
+dynamicGradualGuarantee okM (ν⊒νᵗ _ _ _ _) (ξ-ν st) =
+  {! nu-nu-inner-step-simulation !}
+dynamicGradualGuarantee okM (ν⊒νᵗ _ _ _ _) blame-ν =
+  {! nu-nu-blame-simulation !}
+dynamicGradualGuarantee okM (⊒νᵗ _ _ _) (ν-step st₁ st₂) =
+  {! target-nu-allocation-simulation !}
+dynamicGradualGuarantee okM (⊒νᵗ _ _ _) (ξ-ν st) =
+  {! target-nu-inner-step-simulation !}
+dynamicGradualGuarantee okM (⊒νᵗ _ _ _) blame-ν =
+  {! target-nu-blame-simulation !}

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -106,6 +106,7 @@ open import proof.DGGPrimitiveSeparated using
   ; const-narrowing-targetᶜ
   ; value-id-ℕ-narrowing-target-constᶜ
   ; value-normalized-id-ℕ-target-constᶜ
+  ; nat-endpoints-id-coercionᶜ
   )
 open import proof.DGGBetaSeparated using (separated-dgg-beta)
 open import proof.DGGBetaCastSeparated using (separated-dgg-beta-cast)
@@ -933,11 +934,10 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
             ⊢ P ⊒ S′
               ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
         P⊒P′ℕ =
-          let
-            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
-            ih = P⊒P′
-          in
-          {! ξ-⊕₁-IH-result-nat !}
+          nat-endpoints-id-coercionᶜ
+            (trans C≡ (applyTys-ℕ χs))
+            (trans D≡ (applyTy-ℕ χ′))
+            P⊒P′
       in
       ⊕⊒⊕ᵗ pℕ′ P⊒P′ℕ N⊒N′′
 
@@ -999,11 +999,10 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
           ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
             ⊢ P ⊒ S′ ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
         P⊒P′ℕ =
-          let
-            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
-            ih = P⊒P′
-          in
-          {! ξ-⊕₁-IH-result-nat !}
+          nat-endpoints-id-coercionᶜ
+            (trans C≡ (applyTys-ℕ χs))
+            (trans D≡ (applyTy-ℕ χ′))
+            P⊒P′
       in
       ⊕⊒⊕ᵗ pℕ′ P⊒P′ℕ N⊒N′′
 
@@ -1352,11 +1351,10 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
           ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
             ⊢ P ⊒ S′ ∶ id (‵ `ℕ) ⦂ ‵ `ℕ ⊒ ‵ `ℕ
         P⊒P′ℕ =
-          let
-            ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ S′ ∶ r ⦂ C ⊒ D
-            ih = P⊒P′
-          in
-          {! ξ-⊕₂-IH-result-nat !}
+          nat-endpoints-id-coercionᶜ
+            (trans C≡ (applyTys-ℕ χs))
+            (trans D≡ (applyTy-ℕ χ′))
+            P⊒P′
       in
       ⊕⊒⊕ᵗ pℕ′ M⊒M′′ P⊒P′ℕ
 

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -56,6 +56,7 @@ open import proof.ReductionProperties using
   ; applyCoercions-++
   ; applyCoercions-dual
   ; applyTys-++
+  ; applyTy-ℕ
   ; applyTys-ℕ
   ; applyTys-ℕ-applyTys
   ; applyTyCtxs-++
@@ -129,6 +130,8 @@ dynamicGradualGuarantee :
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
     (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+    (C ≡ applyTys χs A) ×
+    (D ≡ applyTy χ′ B) ×
     ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
 dynamicGradualGuarantee okM pᶜ (⊒blameᵗ M⊢ qᶜ)
     (pure-step ())
@@ -168,6 +171,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
+  {! β-source-endpoint-tracking !} ,
+  {! β-target-endpoint-tracking !} ,
   N⊒N′[V′]
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}
@@ -200,6 +205,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
+  {! β-cast-source-endpoint-tracking !} ,
+  {! β-cast-target-endpoint-tracking !} ,
   N⊒target
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}
@@ -215,6 +222,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   _ ,
   _ ,
   ↠-refl ,
+  refl ,
+  refl ,
   refl ,
   refl ,
   refl ,
@@ -236,6 +245,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  refl ,
   ⊒blameᵗ (typed-term-narrowing-source-typingᶜ app) qᶜ
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R} {M′ = L′ · R′} {χ′ = χ′}
@@ -252,7 +263,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      L↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+      L↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒N′ = rec
 
     framed⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -281,15 +292,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       ·⊒·ᵗ p↦q′ N⊒S′-fun R⊒R′′
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (L · R —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ S′ · applyTerm χ′ R′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       N · applyTerms χs R ,
@@ -303,6 +305,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       framed⊒
   in
   obligation
@@ -321,7 +325,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      L↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+      L↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒N′ = rec
 
     framed⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -350,15 +354,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       ·⊒·ᵗ p↦q′ N⊒S′-fun R⊒R′′
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (L · R —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ S′ · applyTerm χ′ R′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       N · applyTerms χs R ,
@@ -372,6 +367,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       framed⊒
   in
   obligation
@@ -404,15 +401,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (L · R —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ S′ · applyTerm χ′ R′ ∶ r ⦂ C ⊒ D
     obligation =
       [] ,
       L · R ,
@@ -423,6 +411,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       _ ,
       _ ,
       ↠-refl ,
+      refl ,
+      refl ,
       refl ,
       refl ,
       refl ,
@@ -492,7 +482,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χsR , P , ΔL₂ , ΔR′ , ρ′ ,
       C , D , r ,
-      R↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+      R↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒S′ = rec
 
     source-left :
       L · R —↠[ χsL ] WL · applyTerms χsL R
@@ -545,15 +535,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (L · R —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ applyTerm χ′ L′ · S′ ∶ r ⦂ C ⊒ D
     obligation =
       χsL ++ χsR ,
       applyTerms χsR WL · P ,
@@ -567,6 +548,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL₂≡total ,
       ΔR′≡ ,
       ρ′≡total ,
+      refl ,
+      refl ,
       framed⊒
   in
   obligation
@@ -633,7 +616,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χsR , P , ΔL₂ , ΔR′ , ρ′ ,
       C , D , r ,
-      R↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+      R↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒S′ = rec
 
     source-left :
       L · R —↠[ χsL ] WL · applyTerms χsL R
@@ -686,15 +669,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (L · R —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ applyTerm χ′ L′ · S′ ∶ r ⦂ C ⊒ D
     obligation =
       χsL ++ χsR ,
       applyTerms χsR WL · P ,
@@ -708,6 +682,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL₂≡total ,
       ΔR′≡ ,
       ρ′≡total ,
+      refl ,
+      refl ,
       framed⊒
   in
   obligation
@@ -729,7 +705,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      R↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+      R↠N , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒N′ = rec
 
     framed⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -759,14 +735,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       ·⊒·ᵗ p↦q′ L⊒L′′ N⊒S′-arg
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (L · R —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ T′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       applyTerms χs L · N ,
@@ -780,6 +748,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       framed⊒
   in
   obligation
@@ -802,7 +772,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         N⊒N′
 
     χs , P , ΔL′ , ρ′ , C , D , r ,
-      source-steps , ΔL′≡ , ρ′≡ , P⊒P′ = rec
+      source-steps , ΔL′≡ , ρ′≡ , C≡ℕ , D≡ℕ , P⊒P′ = rec
   in
   χs ,
   P ,
@@ -816,6 +786,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
+  C≡ℕ ,
+  D≡ℕ ,
   P⊒P′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
@@ -831,7 +803,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         N⊒N′
 
     χs , P , ΔL′ , ρ′ , C , D , r ,
-      source-steps , ΔL′≡ , ρ′≡ , P⊒P′ = rec
+      source-steps , ΔL′≡ , ρ′≡ , C≡ℕ , D≡ℕ , P⊒P′ = rec
   in
   χs ,
   P ,
@@ -845,6 +817,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
+  C≡ℕ ,
+  D≡ℕ ,
   P⊒P′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
@@ -861,7 +835,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         N⊒N′
 
     χs , P , ΔL′ , ρ′ , C , D , r ,
-      source-steps , ΔL′≡ , ρ′≡ , P⊒P′ = rec
+      source-steps , ΔL′≡ , ρ′≡ , C≡ℕ , D≡ℕ , P⊒P′ = rec
   in
   χs ,
   P ,
@@ -875,6 +849,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
+  C≡ℕ ,
+  D≡ℕ ,
   P⊒P′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N}
@@ -890,6 +866,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   _ ,
   _ ,
   ↠-refl ,
+  refl ,
+  refl ,
   refl ,
   refl ,
   refl ,
@@ -911,6 +889,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  refl ,
   ⊒blameᵗ (typed-term-narrowing-source-typingᶜ add) pᶜ
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⊕[ addℕ ] N} {M′ = M′ ⊕[ addℕ ] N′}
@@ -928,7 +908,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , P , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      M↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , P⊒P′ = rec
+      M↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒P′ = rec
 
     framed⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -961,14 +941,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       ⊕⊒⊕ᵗ pℕ′ P⊒P′ℕ N⊒N′′
 
-    obligation :
-      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ P′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       P ⊕[ addℕ ] applyTerms χs N ,
@@ -982,6 +954,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      sym (applyTys-ℕ χs) ,
+      sym (applyTy-ℕ χ′) ,
       framed⊒
   in
   obligation
@@ -1001,7 +975,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , P , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      M↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , P⊒P′ = rec
+      M↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒P′ = rec
 
     framed⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -1033,14 +1007,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       ⊕⊒⊕ᵗ pℕ′ P⊒P′ℕ N⊒N′′
 
-    obligation :
-      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ P′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       P ⊕[ addℕ ] applyTerms χs N ,
@@ -1054,6 +1020,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      sym (applyTys-ℕ χs) ,
+      sym (applyTy-ℕ χ′) ,
       framed⊒
   in
   obligation
@@ -1089,15 +1057,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ P ⊒ S′ ⊕[ addℕ ] applyTerm χ′ N′ ∶ r ⦂ C ⊒ D
     obligation =
       [] ,
       M ⊕[ addℕ ] N ,
@@ -1111,6 +1070,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       refl ,
       refl ,
       refl ,
+      refl ,
+      sym (applyTy-ℕ χ′) ,
       relation-obligation
   in
   obligation
@@ -1157,7 +1118,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χsN , P , ΔL₂ , ΔR′ , ρ′ ,
       C , D , r ,
-      N↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+      N↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒S′ = rec
 
     source-left :
       M ⊕[ addℕ ] N
@@ -1213,15 +1174,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ P ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ r ⦂ C ⊒ D
     obligation =
       χsM ++ χsN ,
       applyTerms χsN WM ⊕[ addℕ ] P ,
@@ -1235,6 +1187,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL₂≡total ,
       ΔR′≡ ,
       ρ′≡total ,
+      sym (applyTys-ℕ (χsM ++ χsN)) ,
+      sym (applyTy-ℕ χ′) ,
       framed⊒
   in
   obligation
@@ -1281,7 +1235,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χsN , P , ΔL₂ , ΔR′ , ρ′ ,
       C , D , r ,
-      N↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , P⊒S′ = rec
+      N↠P , ΔL₂≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒S′ = rec
 
     source-left :
       M ⊕[ addℕ ] N
@@ -1337,15 +1291,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ P ⊒ applyTerm χ′ M′ ⊕[ addℕ ] S′ ∶ r ⦂ C ⊒ D
     obligation =
       χsM ++ χsN ,
       applyTerms χsN WM ⊕[ addℕ ] P ,
@@ -1359,6 +1304,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL₂≡total ,
       ΔR′≡ ,
       ρ′≡total ,
+      sym (applyTys-ℕ (χsM ++ χsN)) ,
+      sym (applyTy-ℕ χ′) ,
       framed⊒
   in
   obligation
@@ -1381,7 +1328,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , P , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      N↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , P⊒P′ = rec
+      N↠P , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , P⊒P′ = rec
 
     framed⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -1413,14 +1360,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       ⊕⊒⊕ᵗ pℕ′ M⊒M′′ P⊒P′ℕ
 
-    obligation :
-      ∃[ χs ] ∃[ P ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⊕[ addℕ ] N —↠[ χs ] P) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ P ⊒ P′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       applyTerms χs M ⊕[ addℕ ] P ,
@@ -1434,6 +1373,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      sym (applyTys-ℕ χs) ,
+      sym (applyTy-ℕ χ′) ,
       framed⊒
   in
   obligation
@@ -1454,11 +1395,15 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  refl ,
   ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel) pᶜ
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM pᶜ
-    (⊒cast-ᵗ p′ᶜ rᶜ t⊒ M⊒M′)
+    (⊒cast-ᵗ p′ᶜ rᶜ
+      (_ , t-src≡ , t-tgt≡ , _ , _ , _ , _)
+      M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
   M ,
@@ -1472,6 +1417,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  trans (sym t-src≡) t-tgt≡ ,
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
@@ -1490,12 +1437,15 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  refl ,
   ⊒blameᵗ (typed-term-narrowing-source-typingᶜ castRel) pᶜ
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM pᶜ
     (⊒cast+ᵗ p′ᶜ rᶜ
-      (_ , _ , _ , _ , _ , (cast-id _ _ , cross (id-‵ ι)) , _)
+      (_ , t-src≡ , t-tgt≡ , _ , _ ,
+        (cast-id _ _ , cross (id-‵ ι)) , _)
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1510,12 +1460,15 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  trans (sym t-tgt≡) t-src≡ ,
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM pᶜ
     (⊒cast+ᵗ p′ᶜ rᶜ
-      (_ , _ , _ , _ , _ , (cast-id _ _ , cross (id-＇ α)) , _)
+      (_ , t-src≡ , t-tgt≡ , _ , _ ,
+        (cast-id _ _ , cross (id-＇ α)) , _)
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1530,12 +1483,15 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  trans (sym t-tgt≡) t-src≡ ,
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
     okM pᶜ
     (⊒cast+ᵗ p′ᶜ rᶜ
-      (_ , _ , _ , _ , _ , (cast-id _ _ , id★) , _)
+      (_ , t-src≡ , t-tgt≡ , _ , _ ,
+        (cast-id _ _ , id★) , _)
       M⊒M′)
     (pure-step (β-id vV)) =
   [] ,
@@ -1550,11 +1506,13 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  trans (sym t-tgt≡) t-src≡ ,
   M⊒M′
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
     okM pᶜ
-    (⊒cast+ᵗ {M′ = M′} {t = t} p′ᶜ rᶜ t⊒ M⊒M′)
+    (⊒cast+ᵗ {M′ = M′} {t = t} {A = A} {B = Bᵢ} p′ᶜ rᶜ t⊒ M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
     rec :
@@ -1564,6 +1522,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (ΔL′ ≡ applyTyCtxs χs ΔL) ×
         (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
         (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        (C ≡ applyTys χs A) ×
+        (D ≡ applyTy χ′ Bᵢ) ×
         ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
     rec =
       let
@@ -1581,7 +1541,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒S′ = rec
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒S′ = rec
 
     cast-result⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -1594,16 +1554,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       {! target-cast-plus-inner-step-result !}
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ S′ ⟨ applyCoercion χ′ (narrowing-dual t⊒) ⟩
-            ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       N ,
@@ -1617,6 +1567,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       cast-result⊒
   in
   obligation
@@ -1647,14 +1599,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
     obligation =
       [] ,
       M ,
@@ -1665,6 +1609,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       _ ,
       _ ,
       ↠-refl ,
+      refl ,
+      refl ,
       refl ,
       refl ,
       refl ,
@@ -1681,7 +1627,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒S′ = rec
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒S′ = rec
 
     cast-result⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -1693,15 +1639,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       {! target-cast-minus-inner-step-result !}
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
-          ⊢ N ⊒ S′ ⟨ applyCoercion χ′ t ⟩ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       N ,
@@ -1715,6 +1652,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       cast-result⊒
   in
   obligation
@@ -1732,6 +1671,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   _ ,
   _ ,
   ↠-refl ,
+  refl ,
+  refl ,
   refl ,
   refl ,
   refl ,
@@ -1753,6 +1694,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  refl ,
   {! target-cast-minus-inst-nu-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M}
@@ -1768,6 +1711,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   _ ,
   _ ,
   ↠-refl ,
+  refl ,
+  refl ,
   refl ,
   refl ,
   refl ,
@@ -1789,6 +1734,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   refl ,
+  refl ,
+  refl ,
   {! target-cast-minus-seal-unseal-collapse-relation !}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
@@ -1799,7 +1746,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒N′ = rec
 
     cast-result⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -1820,14 +1767,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       obligation
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⟨ c ⟩ —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       N ⟨ applyCoercions χs c ⟩ ,
@@ -1841,13 +1780,15 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       cast-result⊒
   in
   obligation
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M ⟨ c ⟩} {N′ = N′} {χ′ = χ′}
     okM pᶜ
-    (cast-⊒ᵗ {M′ = M′} qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
+    (cast-⊒ᵗ {M′ = M′} {A = Aᵢ} {B = Bᵢ} qᶜ rᶜ s⊒ M⊒M′) M′→N′ =
   let
     rec :
       ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
@@ -1856,6 +1797,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (ΔL′ ≡ applyTyCtxs χs ΔL) ×
         (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
         (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
+        (C ≡ applyTys χs Aᵢ) ×
+        (D ≡ applyTy χ′ Bᵢ) ×
         ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
     rec =
       let
@@ -1873,7 +1816,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 
     χs , N , ΔL′ , ΔR′ , ρ′ ,
       C , D , r ,
-      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , N⊒N′ = rec
+      source-steps , ΔL′≡ , ΔR′≡ , ρ′≡ , C≡ , D≡ , N⊒N′ = rec
 
     cast-result⊒ :
       ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
@@ -1885,14 +1828,6 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       in
       {! source-cast-minus-result-narrowing !}
 
-    obligation :
-      ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
-      ∃[ C ] ∃[ D ] ∃[ r ]
-        (M ⟨ c ⟩ —↠[ χs ] N) ×
-        (ΔL′ ≡ applyTyCtxs χs ΔL) ×
-        (ΔR′ ≡ applyTyCtx χ′ ΔR) ×
-        (ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ)) ×
-        ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ N′ ∶ r ⦂ C ⊒ D
     obligation =
       χs ,
       N ⟨ applyCoercions χs c ⟩ ,
@@ -1906,6 +1841,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ΔL′≡ ,
       ΔR′≡ ,
       ρ′≡ ,
+      refl ,
+      refl ,
       cast-result⊒
   in
   obligation

--- a/GTSF/proof/LeftChangeNarrowingSeparated.agda
+++ b/GTSF/proof/LeftChangeNarrowingSeparated.agda
@@ -9,9 +9,9 @@ module proof.LeftChangeNarrowingSeparated where
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_; map)
-open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Product using (Σ-syntax; _,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality
-  using (cong; subst; trans)
+  using (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
@@ -225,6 +225,43 @@ postulate
     ∀ {c} (cʷ : Widening c) →
     proj₁ (dualⁿ normalᵃ (proj₂ (dualʷ normalᵃ cʷ))) ≡ c
 
+  -- Sibling of `left-change-source-coercion-narrowing-dual` for the
+  -- function-domain dual: transporting an arrow coercion across left
+  -- store changes commutes with taking its domain dual.  Packaged with
+  -- the arrow-reshaped transported typing so the `sim-beta` recursion
+  -- sites can consume both at once.  Approved as an extension of this
+  -- postulate family (2026-07-05); to be discharged together with the
+  -- rest of the family.
+  left-change-fun-coercion-narrowing :
+    ∀ χs {ΔL ΔL′ ΔR ρ p q A A′ B B′ μ}
+      (ΔL′≡ : ΔL′ ≡ applyTyCtxs χs ΔL)
+      (ρ′-corr : StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ))
+      (p↦q⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q
+                ∶ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+    Σ[ e ∈ (μ ∣ ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+              ⊢ applyCoercions χs p ↦ applyCoercions χs q
+                ∶ (applyTys χs A ⇒ applyTys χs B)
+                  ⊒ (A′ ⇒ B′)) ]
+      fun-narrow-domain-dual e ≡
+        applyCoercions χs (fun-narrow-domain-dual p↦q⊒)
+
+-- The raw domain dual is independent of which typing evidence (and
+-- which mode environment) it is computed from: it only inspects the
+-- left widening witness, and `dualʷ-raw-determined` identifies the
+-- dual across witnesses.
+fun-narrow-domain-dual-determined :
+  ∀ {μ₁ μ₂ ΔL₁ ΔR₁ ρ₁ ΔL₂ ΔR₂ ρ₂ p q
+     A₁ A₁′ B₁ B₁′ A₂ A₂′ B₂ B₂′} →
+  (e₁ : μ₁ ∣ ΔL₁ ∣ ΔR₁ ∣ ρ₁ ⊢ p ↦ q
+          ∶ (A₁ ⇒ B₁) ⊒ (A₁′ ⇒ B₁′)) →
+  (e₂ : μ₂ ∣ ΔL₂ ∣ ΔR₂ ∣ ρ₂ ⊢ p ↦ q
+          ∶ (A₂ ⇒ B₂) ⊒ (A₂′ ⇒ B₂′)) →
+  fun-narrow-domain-dual e₁ ≡ fun-narrow-domain-dual e₂
+fun-narrow-domain-dual-determined
+    (_ , _ , _ , _ , _ , (_ , cross (pʷ₁ ↦ⁿʷ _)) , _)
+    (_ , _ , _ , _ , _ , (_ , cross (pʷ₂ ↦ⁿʷ _)) , _) =
+  dualʷ-raw-determined normalᵃ pʷ₁ pʷ₂
+
 separated-fun-domain-dual :
   ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
   (p↦q : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ A ⇒ B ⊒ A′ ⇒ B′) →
@@ -320,3 +357,226 @@ advance-left-lambda-narrowing χs {p = p} {q = q} {A = A} {B = B}
           ⦂ C ⊒ _)
       (applyTys-⇒ χs A B)
       (advance-left-term-narrowing χs ΔL′≡ ρ′-corr W⊒ƛ))
+
+------------------------------------------------------------------------
+-- Composition-witness helpers
+------------------------------------------------------------------------
+
+-- Rewrite the three raw coercion indices of a composition witness in a
+-- single step; keeps the `sim-beta` clause bodies small so Agda does
+-- not carry three nested subst motives over the record type.
+composed-index-raws-≡ :
+  ∀ {ΔL ΔR ρ s t r s′ t′ r′ A B} →
+  s ≡ s′ →
+  t ≡ t′ →
+  r ≡ r′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ t ≈ r ∶ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ⊢ s′ ⨟ t′ ≈ r′ ∶ A ⊒ B
+composed-index-raws-≡ refl refl refl comp = comp
+
+-- Domain-dual projection of an arrow-level composition: the three
+-- factor typings of an incoming composition record, once pinned to
+-- arrow endpoints, yield the composition of their domain duals at the
+-- same shared mode environment.
+fun-domain-dual-composed :
+  ∀ {ν ΔL ΔR ρ cₛ dₛ pᵢ qᵢ pₒ qₒ Aₒ Bₒ AL BL AR BR} →
+  (s⊒ : ν ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ
+          ∶ (Aₒ ⇒ Bₒ) ⊒ (AL ⇒ BL)) →
+  (t⊒ : ν ∣ ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ
+          ∶ (AL ⇒ BL) ⊒ (AR ⇒ BR)) →
+  (r⊒ : ν ∣ ΔL ∣ ΔR ∣ ρ ⊢ pₒ ↦ qₒ
+          ∶ (Aₒ ⇒ Bₒ) ⊒ (AR ⇒ BR)) →
+  ΔL ∣ ΔR ∣ ρ
+    ⊢ fun-narrow-domain-dual s⊒ ⨟ fun-narrow-domain-dual t⊒
+      ≈ fun-narrow-domain-dual r⊒ ∶ Aₒ ⊒ AR
+fun-domain-dual-composed s⊒ t⊒ r⊒ =
+  composed-index
+    (separated-fun-domain-dual s⊒)
+    (separated-fun-domain-dual t⊒)
+    (separated-fun-domain-dual r⊒)
+
+-- The full site witness for wrapping a `sim-beta` argument in the
+-- source function cast's domain: the incoming arrow-level composition
+-- record of the matched cast constructor, projected to domain duals.
+-- Hoisted out of the `sim-beta` clause bodies deliberately — matching
+-- the record and normalizing the dual equations inside those huge
+-- clause contexts made elaboration blow past a 14G heap.
+cast-fun-comp-domain-dual :
+  ∀ {μ η ΔL ΔR ρ cₛ dₛ pᵢ qᵢ pₒ qₒ Aₒ Bₒ AL BL AR BR c d} →
+  ΔL ∣ ΔR ∣ ρ ⊢ (cₛ ↦ dₛ) ⨟ (pᵢ ↦ qᵢ) ≈ (pₒ ↦ qₒ)
+    ∶ (Aₒ ⇒ Bₒ) ⊒ (AR ⇒ BR) →
+  (t⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ
+          ∶ (Aₒ ⇒ Bₒ) ⊒ (AL ⇒ BL)) →
+  narrowing-dual t⊒ ≡ c ↦ d →
+  (pᵢ↦qᵢᶜ : ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ
+              ∶ᶜ (AL ⇒ BL) ⊒ (AR ⇒ BR)) →
+  (p↦q⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pₒ ↦ qₒ
+            ∶ (Aₒ ⇒ Bₒ) ⊒ (AR ⇒ BR)) →
+  ΔL ∣ ΔR ∣ ρ
+    ⊢ c ⨟ fun-narrow-domain-dualᶜ pᵢ↦qᵢᶜ
+      ≈ fun-narrow-domain-dual p↦q⊒ ∶ Aₒ ⊒ AR
+-- A composition witness transports across left store changes
+-- field-wise: the source-side transport for the first factor (its
+-- target is the composition's middle type) and the plain transport for
+-- the second factor and the composite.
+left-change-composed-index :
+  ∀ χs {ΔL ΔL′ ΔR ρ s t r A B} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  StoreCorr ΔL′ ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ t ≈ r ∶ A ⊒ B →
+  ΔL′ ∣ ΔR ∣ applyLeftChanges χs ρ
+    ⊢ applyCoercions χs s ⨟ applyCoercions χs t
+      ≈ applyCoercions χs r ∶ applyTys χs A ⊒ B
+left-change-composed-index χs ΔL′≡ corr
+    (composed-index s⊒ t⊒ r⊒) =
+  composed-index
+    (left-change-source-coercion-narrowing χs ΔL′≡ corr s⊒)
+    (left-change-coercion-narrowing χs ΔL′≡ corr t⊒)
+    (left-change-coercion-narrowing χs ΔL′≡ corr r⊒)
+
+-- Codomain projection of an arrow-level composition: unlike the
+-- domain-dual case, the raw indices are syntactic codomains, so no
+-- witness bridging is needed.  The middle type of the incoming record
+-- is pinned from the s-factor's target equation.
+cast-fun-comp-codomain :
+  ∀ {η ΔL ΔR ρ cₛ dₛ pᵢ qᵢ pₒ qₒ A₀ B₀ A₁ B₁ A₂ B₂} →
+  ΔL ∣ ΔR ∣ ρ ⊢ (cₛ ↦ dₛ) ⨟ (pᵢ ↦ qᵢ) ≈ (pₒ ↦ qₒ)
+    ∶ (A₀ ⇒ B₀) ⊒ (A₂ ⇒ B₂) →
+  (s⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ
+          ∶ (A₀ ⇒ B₀) ⊒ (A₁ ⇒ B₁)) →
+  ΔL ∣ ΔR ∣ ρ ⊢ dₛ ⨟ qᵢ ≈ qₒ ∶ B₀ ⊒ B₂
+cast-fun-comp-codomain {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {cₛ = cₛ} {dₛ = dₛ} {pᵢ = pᵢ} {qᵢ = qᵢ}
+    {A₀ = A₀} {B₀ = B₀} {A₁ = A₁} {B₁ = B₁}
+    {A₂ = A₂} {B₂ = B₂}
+    (composed-index {midTy = midᵏ} {νᶜᵒᵐᵖ = νᵏ} s⊒ᵏ t⊒ᵏ r⊒ᵏ)
+    s⊒ =
+  let
+    midᵏ≡ : midᵏ ≡ A₁ ⇒ B₁
+    midᵏ≡ =
+      let
+        _ , _ , sᵏtgt , _ , _ , _ , _ = s⊒ᵏ
+        _ , _ , stgt , _ , _ , _ , _ = s⊒
+      in
+      trans (sym sᵏtgt) stgt
+
+    s⊒ᵏ′ :
+      νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ
+        ∶ (A₀ ⇒ B₀) ⊒ (A₁ ⇒ B₁)
+    s⊒ᵏ′ =
+      subst
+        (λ X → νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ ∶ (A₀ ⇒ B₀) ⊒ X)
+        midᵏ≡
+        s⊒ᵏ
+
+    t⊒ᵏ′ :
+      νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ
+        ∶ (A₁ ⇒ B₁) ⊒ (A₂ ⇒ B₂)
+    t⊒ᵏ′ =
+      subst
+        (λ X → νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ ∶ X ⊒ (A₂ ⇒ B₂))
+        midᵏ≡
+        t⊒ᵏ
+  in
+  composed-index
+    (separated-fun-codomain s⊒ᵏ′)
+    (separated-fun-codomain t⊒ᵏ′)
+    (separated-fun-codomain r⊒ᵏ)
+
+-- Variant for the other wrap direction: all three output raw indices
+-- are `fun-narrow-domain-dual` of caller-supplied arrow evidence, so
+-- no term-level cast equation is needed.  The middle type of the
+-- incoming record is pinned from the s-factor's target equation.
+cast-fun-comp-domain-dual₂ :
+  ∀ {μ₁ μ₂ η ΔL ΔR ρ c d pₒ qₒ pᵢ qᵢ AL BL Aₒ Bₒ AR BR} →
+  ΔL ∣ ΔR ∣ ρ ⊢ (c ↦ d) ⨟ (pₒ ↦ qₒ) ≈ (pᵢ ↦ qᵢ)
+    ∶ (AL ⇒ BL) ⊒ (AR ⇒ BR) →
+  (s⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ↦ d
+          ∶ (AL ⇒ BL) ⊒ (Aₒ ⇒ Bₒ)) →
+  (t⊒ : μ₁ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pₒ ↦ qₒ
+          ∶ (Aₒ ⇒ Bₒ) ⊒ (AR ⇒ BR)) →
+  (r⊒ : μ₂ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ
+          ∶ (AL ⇒ BL) ⊒ (AR ⇒ BR)) →
+  ΔL ∣ ΔR ∣ ρ
+    ⊢ fun-narrow-domain-dual s⊒ ⨟ fun-narrow-domain-dual t⊒
+      ≈ fun-narrow-domain-dual r⊒ ∶ AL ⊒ AR
+cast-fun-comp-domain-dual₂ {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {c = c} {d = d} {pₒ = pₒ} {qₒ = qₒ}
+    {AL = AL} {BL = BL} {Aₒ = Aₒ} {Bₒ = Bₒ}
+    {AR = AR} {BR = BR}
+    (composed-index {midTy = midᵏ} {νᶜᵒᵐᵖ = νᵏ} s⊒ᵏ t⊒ᵏ r⊒ᵏ)
+    s⊒ t⊒ r⊒ =
+  let
+    midᵏ≡ : midᵏ ≡ Aₒ ⇒ Bₒ
+    midᵏ≡ =
+      let
+        _ , _ , sᵏtgt , _ , _ , _ , _ = s⊒ᵏ
+        _ , _ , stgt , _ , _ , _ , _ = s⊒
+      in
+      trans (sym sᵏtgt) stgt
+
+    s⊒ᵏ′ :
+      νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ↦ d
+        ∶ (AL ⇒ BL) ⊒ (Aₒ ⇒ Bₒ)
+    s⊒ᵏ′ =
+      subst
+        (λ X → νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ↦ d ∶ (AL ⇒ BL) ⊒ X)
+        midᵏ≡
+        s⊒ᵏ
+
+    t⊒ᵏ′ :
+      νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pₒ ↦ qₒ
+        ∶ (Aₒ ⇒ Bₒ) ⊒ (AR ⇒ BR)
+    t⊒ᵏ′ =
+      subst
+        (λ X → νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pₒ ↦ qₒ ∶ X ⊒ (AR ⇒ BR))
+        midᵏ≡
+        t⊒ᵏ
+  in
+  composed-index-raws-≡
+    (fun-narrow-domain-dual-determined s⊒ᵏ′ s⊒)
+    (fun-narrow-domain-dual-determined t⊒ᵏ′ t⊒)
+    (fun-narrow-domain-dual-determined r⊒ᵏ r⊒)
+    (fun-domain-dual-composed s⊒ᵏ′ t⊒ᵏ′ r⊒ᵏ)
+
+cast-fun-comp-domain-dual {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {cₛ = cₛ} {dₛ = dₛ} {pᵢ = pᵢ} {qᵢ = qᵢ}
+    {Aₒ = Aₒ} {Bₒ = Bₒ} {AL = AL} {BL = BL}
+    {AR = AR} {BR = BR}
+    (composed-index {midTy = midᵏ} {νᶜᵒᵐᵖ = νᵏ} s⊒ᵏ t⊒ᵏ r⊒ᵏ)
+    t⊒@(_ , _ , _ , _ , _ , (_ , cross (cₛʷ ↦ⁿʷ _)) , _)
+    cast-eq pᵢ↦qᵢᶜ p↦q⊒ =
+  let
+    midᵏ≡ : midᵏ ≡ AL ⇒ BL
+    midᵏ≡ =
+      let
+        _ , tᵏsrc , _ , _ , _ , _ , _ = t⊒ᵏ
+        _ , pᵢsrc , _ , _ , _ , _ , _ = pᵢ↦qᵢᶜ
+      in
+      trans (sym tᵏsrc) pᵢsrc
+
+    s⊒ᵏ′ :
+      νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ
+        ∶ (Aₒ ⇒ Bₒ) ⊒ (AL ⇒ BL)
+    s⊒ᵏ′ =
+      subst
+        (λ X → νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ cₛ ↦ dₛ ∶ (Aₒ ⇒ Bₒ) ⊒ X)
+        midᵏ≡
+        s⊒ᵏ
+
+    t⊒ᵏ′ :
+      νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ
+        ∶ (AL ⇒ BL) ⊒ (AR ⇒ BR)
+    t⊒ᵏ′ =
+      subst
+        (λ X → νᵏ ∣ ΔL ∣ ΔR ∣ ρ ⊢ pᵢ ↦ qᵢ ∶ X ⊒ (AR ⇒ BR))
+        midᵏ≡
+        t⊒ᵏ
+  in
+  composed-index-raws-≡
+    (trans
+      (fun-narrow-domain-dual-determined s⊒ᵏ′ t⊒)
+      (↦-left-injective cast-eq))
+    (fun-narrow-domain-dual-determined t⊒ᵏ′ pᵢ↦qᵢᶜ)
+    (fun-narrow-domain-dual-determined r⊒ᵏ p↦q⊒)
+    (fun-domain-dual-composed s⊒ᵏ′ t⊒ᵏ′ r⊒ᵏ)

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -6,7 +6,7 @@ module proof.NarrowWidenProperties where
 --   * Depends on the public definitions in `NarrowWiden`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
-open import Data.Bool using (false; true; _∨_)
+open import Data.Bool using (Bool; false; true; _∨_)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here; there)
@@ -29,6 +29,7 @@ open import proof.CoercionProperties
   using
     ( DualActionOk
     ; DualStoreAt
+    ; coercion-mode-relax
     ; coercion-src-tgtᵐ
     ; dma-id
     ; dma-tag
@@ -3821,3 +3822,113 @@ widening-determinedᵐ :
   s ≡ t
 widening-determinedᵐ wfΣ =
   widening-determinedᵐ-det wfΣ
+
+------------------------------------------------------------------------
+-- Cross-mode determinacy for compatible mode environments
+------------------------------------------------------------------------
+
+-- Determinacy across two DIFFERENT mode environments is false in
+-- general: with Δ = 1 and Σ = (0 , ★) ∷ [], both `＇ 0 ？` (normal in
+-- tag-or-idᵈ, by cast-untag and the witness `untag`) and `seal ★ 0`
+-- (normal in seal-or-idᵈ, by cast-seal and the witness `sealⁿ`) inhabit
+-- the endpoints ★ ⊒ ＇ 0.  The failure requires the two environments to
+-- disagree tag-versus-seal at a variable, so we restrict to pointwise
+-- compatible environments.  Compatible modes have a join in the mode≤
+-- order, both typings relax into the join (`coercion-mode-relax`), and
+-- the single-environment determinacy theorem closes the argument.
+
+modeCompat : Mode → Mode → Bool
+modeCompat id-only id-only = true
+modeCompat id-only tag-or-id = true
+modeCompat id-only seal-or-id = true
+modeCompat tag-or-id id-only = true
+modeCompat tag-or-id tag-or-id = true
+modeCompat tag-or-id seal-or-id = false
+modeCompat seal-or-id id-only = true
+modeCompat seal-or-id tag-or-id = false
+modeCompat seal-or-id seal-or-id = true
+
+ModeEnvCompat : ModeEnv → ModeEnv → Set
+ModeEnvCompat μ ν = ∀ X → modeCompat (μ X) (ν X) ≡ true
+
+-- The (tag , seal) and (seal , tag) results below are junk values;
+-- those inputs are excluded by ModeEnvCompat wherever the join is used.
+modeJoin : Mode → Mode → Mode
+modeJoin id-only id-only = id-only
+modeJoin id-only tag-or-id = tag-or-id
+modeJoin id-only seal-or-id = seal-or-id
+modeJoin tag-or-id id-only = tag-or-id
+modeJoin tag-or-id tag-or-id = tag-or-id
+modeJoin tag-or-id seal-or-id = tag-or-id
+modeJoin seal-or-id id-only = seal-or-id
+modeJoin seal-or-id tag-or-id = seal-or-id
+modeJoin seal-or-id seal-or-id = seal-or-id
+
+modeEnvJoin : ModeEnv → ModeEnv → ModeEnv
+modeEnvJoin μ ν X = modeJoin (μ X) (ν X)
+
+modeIncl-joinˡ :
+  ∀ {μ ν} →
+  ModeEnvCompat μ ν →
+  ModeIncl μ (modeEnvJoin μ ν)
+modeIncl-joinˡ {μ} {ν} compat X with μ X | ν X | compat X
+modeIncl-joinˡ {μ} {ν} compat X | id-only | id-only | _ = refl
+modeIncl-joinˡ {μ} {ν} compat X | id-only | tag-or-id | _ = refl
+modeIncl-joinˡ {μ} {ν} compat X | id-only | seal-or-id | _ = refl
+modeIncl-joinˡ {μ} {ν} compat X | tag-or-id | id-only | _ = refl
+modeIncl-joinˡ {μ} {ν} compat X | tag-or-id | tag-or-id | _ = refl
+modeIncl-joinˡ {μ} {ν} compat X | tag-or-id | seal-or-id | ()
+modeIncl-joinˡ {μ} {ν} compat X | seal-or-id | id-only | _ = refl
+modeIncl-joinˡ {μ} {ν} compat X | seal-or-id | tag-or-id | ()
+modeIncl-joinˡ {μ} {ν} compat X | seal-or-id | seal-or-id | _ = refl
+
+modeIncl-joinʳ :
+  ∀ {μ ν} →
+  ModeEnvCompat μ ν →
+  ModeIncl ν (modeEnvJoin μ ν)
+modeIncl-joinʳ {μ} {ν} compat X with μ X | ν X | compat X
+modeIncl-joinʳ {μ} {ν} compat X | id-only | id-only | _ = refl
+modeIncl-joinʳ {μ} {ν} compat X | id-only | tag-or-id | _ = refl
+modeIncl-joinʳ {μ} {ν} compat X | id-only | seal-or-id | _ = refl
+modeIncl-joinʳ {μ} {ν} compat X | tag-or-id | id-only | _ = refl
+modeIncl-joinʳ {μ} {ν} compat X | tag-or-id | tag-or-id | _ = refl
+modeIncl-joinʳ {μ} {ν} compat X | tag-or-id | seal-or-id | ()
+modeIncl-joinʳ {μ} {ν} compat X | seal-or-id | id-only | _ = refl
+modeIncl-joinʳ {μ} {ν} compat X | seal-or-id | tag-or-id | ()
+modeIncl-joinʳ {μ} {ν} compat X | seal-or-id | seal-or-id | _ = refl
+
+compatible-narrowing-determinedᵐ :
+  ∀ {μ ν Δ Σ A B s t} →
+  ModeEnvCompat μ ν →
+  StoreDetWf Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊒ B →
+  ν ∣ Δ ∣ Σ ⊢ t ∶ A ⊒ B →
+  s ≡ t
+compatible-narrowing-determinedᵐ compat wfΣ (s⊢ , sⁿ) (t⊢ , tⁿ) =
+  narrowing-determinedᵐ wfΣ
+    (coercion-mode-relax (modeIncl-joinˡ compat) s⊢ , sⁿ)
+    (coercion-mode-relax (modeIncl-joinʳ compat) t⊢ , tⁿ)
+
+compatible-widening-determinedᵐ :
+  ∀ {μ ν Δ Σ A B s t} →
+  ModeEnvCompat μ ν →
+  StoreDetWf Δ Σ →
+  μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊑ B →
+  ν ∣ Δ ∣ Σ ⊢ t ∶ A ⊑ B →
+  s ≡ t
+compatible-widening-determinedᵐ compat wfΣ (s⊢ , sʷ) (t⊢ , tʷ) =
+  widening-determinedᵐ wfΣ
+    (coercion-mode-relax (modeIncl-joinˡ compat) s⊢ , sʷ)
+    (coercion-mode-relax (modeIncl-joinʳ compat) t⊢ , tʷ)
+
+-- The DGG frames compare a coercion typed at an unknown mode
+-- environment against one typed at tag-or-idᵈ; seal-freeness of the
+-- unknown side is exactly compatibility with tag-or-idᵈ.
+seal-free-compat-tagᵈ :
+  ∀ {μ} →
+  (∀ X → sealModeAllowed (μ X) ≡ false) →
+  ModeEnvCompat μ tag-or-idᵈ
+seal-free-compat-tagᵈ {μ} seal-free X with μ X | seal-free X
+seal-free-compat-tagᵈ {μ} seal-free X | id-only | _ = refl
+seal-free-compat-tagᵈ {μ} seal-free X | tag-or-id | _ = refl
+seal-free-compat-tagᵈ {μ} seal-free X | seal-or-id | ()

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -115,10 +115,18 @@ Current named obligations in `proof.DynamicGradualGuaranteeSeparated`:
   false — the `β-id` clauses return the inner relation at its `∶ᶜ`
   coercion, not the incoming index — so the application/`⊕` frames need
   either a coercion-conversion rule in the relation or `∶ᶜ` evidence in the
-  conclusion, which `⊒cast+ᵗ` inner relations cannot supply. With endpoint
-  tracking in place, the `ξ-⊕`-IH holes can now fix their *types* to
-  `‵ ℕ ⊒ ‵ ℕ` via `typed-term-narrowing-endpointsᶜ`; only the coercion
-  index remains unrecoverable.
+  conclusion, which `⊒cast+ᵗ` inner relations cannot supply.
+- The coercion-recovery story is now: endpoint tracking + normal-form
+  determinacy (`narrowing-determinedᵐ` in `proof.NarrowWidenProperties`)
+  determine the result coercion from the endpoints, one mode env at a
+  time. `nat-endpoints-id-coercionᶜ` in `proof.DGGPrimitiveSeparated`
+  packages the recipe at `‵ ℕ ⊒ ‵ ℕ` (where `cast-id` types `id (‵ ℕ)` in
+  every mode), and the three `ξ-⊕`-IH holes are closed with it. The
+  application-frame analogue needs the transported function coercion typed
+  in the *changed* stores (blocked on the right-side transport surface)
+  and at the *same mode env* as the IH's existential coercion typing —
+  either a cross-mode determinacy corollary for seal-variable-free
+  endpoints or mode tracking through the theorem.
 - `applyLeftChanges-++` is now available from `proof.CatchupSeparated`.
   Both beta caller helpers use it with `applyTyCtxs-++` and `↠-trans` to
   return a single composed source reduction after the call to `sim-beta`.

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -97,19 +97,28 @@ Current named obligations in `proof.DynamicGradualGuaranteeSeparated`:
   layers), a target-cast-stripping inversion for `tag-untag-ok` and
   `seal-unseal` (a right-side analogue of catchup), and separated `ν`
   constructors for `β-inst` (Track B).
-- Every ξ-frame reconstruction hole is blocked on two structural gaps:
-  (a) there is no right-side store-change transport surface (the mirror of
-  the postulated `left-change-term-narrowing` family) to advance the
-  untouched subterm across `applyRightChange χ′` / `applyTerm χ′`; and
-  (b) the theorem's conclusion existentially quantifies `C`, `D`, `r` with
-  no link back to the inputs, so the IH cannot be reframed. The natural
-  strengthening returns `C ≡ applyTys χs A` and `D ≡ applyTy χ′ B` (true in
-  all current completed cases, including `β-id` via the `src`/`tgt`
-  components of the id-cast typing), but coercion-index tracking is false
-  (`β-id` swaps the relation to the inner `∶ᶜ` coercion), so the
-  application/`⊕` frames additionally need either a coercion-conversion
-  rule in the relation or `∶ᶜ` evidence in the conclusion, which `⊒cast+ᵗ`
-  inner relations cannot supply.
+- The theorem conclusion now tracks the endpoint types: it returns
+  `(C ≡ applyTys χs A) × (D ≡ applyTy χ′ B)` alongside the final relation.
+  Every completed clause proves these directly — the `β-id` clauses derive
+  the target-type equation from the `src`/`tgt` components of the id-cast
+  typing tuple, the `⊕` frames use `applyTys-ℕ`/`applyTy-ℕ`, and the
+  `separated-⊕-δ` helpers were extended to return the equalities. Only the
+  two beta helper delegation sites carry endpoint-tracking holes, pending
+  the same extension through `separated-dgg-beta`/`separated-dgg-beta-cast`
+  and `sim-beta`.
+- Every ξ-frame reconstruction hole is still blocked on two structural
+  gaps: (a) there is no right-side store-change transport surface (the
+  mirror of the postulated `left-change-term-narrowing` family) to advance
+  the untouched subterm across `applyRightChange χ′` / `applyTerm χ′`; and
+  (b) the resulting *coercion* `r` has no link back to the input coercion.
+  Coercion-index tracking (`r ≡ applyCoercion χ′ (applyCoercions χs p)`) is
+  false — the `β-id` clauses return the inner relation at its `∶ᶜ`
+  coercion, not the incoming index — so the application/`⊕` frames need
+  either a coercion-conversion rule in the relation or `∶ᶜ` evidence in the
+  conclusion, which `⊒cast+ᵗ` inner relations cannot supply. With endpoint
+  tracking in place, the `ξ-⊕`-IH holes can now fix their *types* to
+  `‵ ℕ ⊒ ‵ ℕ` via `typed-term-narrowing-endpointsᶜ`; only the coercion
+  index remains unrecoverable.
 - `applyLeftChanges-++` is now available from `proof.CatchupSeparated`.
   Both beta caller helpers use it with `applyTyCtxs-++` and `↠-trans` to
   return a single composed source reduction after the call to `sim-beta`.

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -206,10 +206,83 @@ Current named obligations in `proof.DynamicGradualGuaranteeSeparated`:
   an untag; the untag case dualizes to an inert tag and is discharged by
   `canonical-⇒`.
 
+## Partial-port findings (cambridge25 comparison, 2026-07-05)
+
+Comparing `TermNarrowingSeparated` against the cambridge25 term narrowing
+rules (`γ ⊢ M ⊒ M′ : r`):
+
+- Present: (⊒blame), (x⊒x), (λ⊒λ), (·⊒·), (Λ⊒Λ), (κ⊒κ), (⊕⊒⊕), and the
+  four cast rules.
+- Missing: (extend) and (split) — the seal-correspondence manipulation
+  rules; parts of their role live in the `SealCorr`/`applyLeftChanges`
+  machinery, but nobody has checked the machinery derives what the rules
+  provide.  Also missing: (⊒Λ), (⊒⟨ν⟩), (α⊒α), (⊒α), (ν⊒ν), (⊒ν) — the
+  Track B list below.
+- Weakened: all four separated cast rules dropped the cambridge25
+  composition side conditions (`s ⨾ q ≈ r`, `r ≈ p ⨾ t`), which the
+  shared-store `TermNarrowing` port keeps (via `_⨟ⁿ_` and `≈`).  The
+  dropped conditions are what made the separated conclusion indices free
+  relabelings; the coercion-tracking and mode-pinch analyses in this
+  checklist were partly artifacts of that.  Restored (2026-07-05) as
+  the mixfix judgment `ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ t ≈ r ∶ A ⊒ B`: a record with
+  cross-store typings of both factors and of `r` at one shared mode
+  environment (`νᶜᵒᵐᵖ`, an implicit field, like the middle type).  The
+  literal composite equality is recovered by `composite-determinedˡ/ʳ`
+  via `narrowing-determinedᵐ` rather than stored, because the stored
+  form would not transport across the postulated store-change surfaces.
+- Supporting `sim-beta` changes for the composition witnesses:
+  `sim-beta` now takes mode-generic function-coercion evidence
+  (`μsim ∣ … ⊢ p ↦ q ∶ …`) plus the `∶ᶜ` typing of its
+  `fun-narrow-domain-dual`, with the argument relation indexed by that
+  dual.  `fun-narrow-domain-dual-determined` (proved: duals are
+  witness- and mode-independent, by `dualʷ-raw-determined`) does the
+  index re-alignments.  One postulate was added with explicit approval:
+  `left-change-fun-coercion-narrowing`, the arrow/domain-dual sibling
+  of `left-change-source-coercion-narrowing-dual`, consumed by the two
+  `sim-beta` recursion sites.  The composition witnesses themselves are
+  assembled from the matched constructor's incoming record by taking
+  `separated-fun-domain-dual` of its three fields (all at `νᶜᵒᵐᵖ`) and
+  bridging the raw indices with `fun-narrow-domain-dual-determined`.
+- All four `sim-beta` composition sites are discharged (2026-07-06):
+  the two domain-side sites use `cast-fun-comp-domain-dual` /
+  `cast-fun-comp-domain-dual₂`, and the two codomain-side sites
+  (`sim-beta-cast+-result` and `sim-beta-cast-tail`) thread a
+  codomain composition premise obtained by `cast-fun-comp-codomain`
+  from the matched constructor's record, transported through the
+  catchup store changes with `left-change-composed-index` (both
+  proved in `LeftChangeNarrowingSeparated`; no new postulates).
+- `separated-dgg-beta{,-left-first,-right-first}` were re-based on the
+  new `sim-beta` arity: the free-floating `pᵈ` premise is replaced by
+  `fun-narrow-domain-dualᶜ p↦qᶜ` (exactly what `·⊒·ᵗ` inversion
+  supplies), and the `∶ᶜ` arrow typing is transported through the
+  catchup χs-chains with `left-change-fun-coercion-narrowing`, whose
+  returned dual equality re-indexes the caught-up argument relation.
+- `DGGBetaCastSeparated` cast patterns were arity-bumped for the new
+  composition premise; its six cast *construction* sites now carry
+  named `{! …-composition !}` holes (`beta-cast-tail-composition`,
+  `target-argument-cast-composition`, `target-result-cast-composition`,
+  `source-argument-cast-composition`,
+  `source-argument-domain-composition`,
+  `source-cast-tail-composition`).  They mirror the discharged
+  `sim-beta` sites and should be filled the same way once that file's
+  local helpers thread the incoming `compᵏ` records.
+- The cambridge25 N.B. types p, q under `Γ | ∅` but r, s, t under
+  `Γ | Φ`; the Agda encoding of that split is `tag-or-idᵈ`-versus-`μ`
+  mode environments over a shared store (documented at `Mode` in
+  `Coercions.agda`).
+
 ## Track B. Term Narrowing Surface Needed By `sim-beta`
 
 - [x] Add separated cast-left and cast-right constructors.
-- [ ] Add separated `ν` and polymorphic constructors needed by catchup results.
+- [x] Add separated `ν` and polymorphic constructors (`⊒Λᵗ`, `⊒⟨ν⟩ᵗ`,
+  `α⊒αᵗ`, `⊒αᵗ`, `ν⊒νᵗ`, `⊒νᵗ`, 2026-07-05).  Target-only binders
+  extend both type contexts with a `right-only` seal entry; the shared
+  `α ꞉ q` coercion entry becomes a `matched` entry carrying `q`'s
+  endpoint types with the correlating `q ∶ᶜ` as an explicit premise;
+  endpoint typing is an explicit `TermTypingEndpointsᶜ` premise so the
+  extractors stay total.  Downstream coverage clauses for the six new
+  constructors are still being swept through the proof modules.
+  (extend)/(split) deferred: let proof attempts guide their design.
 - [ ] Add separated substitution narrowing for the beta body.
 - [x] Remove the lightweight coercion-correlation records; separated
   constructors now carry explicit endpoint products.

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -127,6 +127,16 @@ Current named obligations in `proof.DynamicGradualGuaranteeSeparated`:
   and at the *same mode env* as the IH's existential coercion typing —
   either a cross-mode determinacy corollary for seal-variable-free
   endpoints or mode tracking through the theorem.
+- The theorem no longer takes a separate coercion premise. The old
+  `∶ᶜ` premise was inherited from the shared-store statement, was
+  consumed only by the `⊒blameᵗ` reconstructions, and made the theorem
+  stricter than the relation: recursive calls on the general-mode inner
+  relations of `⊒cast+ᵗ` and `cast-⊒ᵗ` had no `∶ᶜ` evidence to supply.
+  `⊒blameᵗ` now carries general-mode coercion evidence (matching the
+  other cast-composed positions), the blame cases recover it from the
+  relation via `typed-term-narrowing-coercion`, and the two former
+  `target-cast-plus-inner-step-simulation` /
+  `source-cast-minus-inner-simulation` holes are genuine recursive calls.
 - `applyLeftChanges-++` is now available from `proof.CatchupSeparated`.
   Both beta caller helpers use it with `applyTyCtxs-++` and `↠-trans` to
   return a single composed source reduction after the call to `sim-beta`.

--- a/GTSF/proof/SimBetaSeparated.agda
+++ b/GTSF/proof/SimBetaSeparated.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
 module proof.SimBetaSeparated where
 
 -- File Charter:
@@ -87,8 +89,16 @@ open import proof.LeftChangeNarrowingSeparated public using
   ; left-change-coercion-narrowing
   ; left-change-source-coercion-narrowing
   ; left-change-source-coercion-narrowing-dual
+  ; left-change-fun-coercion-narrowing
   ; dualʷ-raw-determined
   ; dualʷ-involutive-raw
+  ; fun-narrow-domain-dual-determined
+  ; composed-index-raws-≡
+  ; fun-domain-dual-composed
+  ; cast-fun-comp-domain-dual
+  ; cast-fun-comp-domain-dual₂
+  ; cast-fun-comp-codomain
+  ; left-change-composed-index
   ; separated-fun-domain-dual
   ; advance-left-term-narrowing
   ; advance-left-function-term-narrowing
@@ -117,6 +127,7 @@ sim-beta-cast-tail :
     M₁ —↠[ χsT ] castN χsT N) →
   μq ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR →
   μd ∣ ΔL ∣ ΔR ∣ ρ ⊢ d ∶ D₁ ⊒ D₂ →
+  ΔL ∣ ΔR ∣ ρ ⊢ d ⨟ qₒ ≈ qᵢ ∶ D₁ ⊒ BR →
   ΔLA ≡ applyTyCtxs χsA ΔL →
   StoreCorr ΔLA ΔR (applyLeftChanges χsA ρ) →
   (∀ {χsT N ΔLT ρT} →
@@ -131,6 +142,11 @@ sim-beta-cast-tail :
       ⊢ applyCoercions χsT (applyCoercions χsA d)
         ∶ applyTys χsT (applyTys χsA D₁)
         ⊒ applyTys χsT (applyTys χsA D₂) →
+    ΔLT ∣ ΔR ∣ ρT
+      ⊢ applyCoercions χsT (applyCoercions χsA d)
+        ⨟ applyCoercions χsT (applyCoercions χsA qₒ)
+        ≈ applyCoercions χsT (applyCoercions χsA qᵢ)
+        ∶ applyTys χsT (applyTys χsA D₁) ⊒ BR →
     ΔLT ∣ ΔR ∣ ρT ∣ []
       ⊢ castN χsT N ⊒ NL [ VR ]
         ∶ applyCoercions χsT (applyCoercions χsA qₒ)
@@ -150,10 +166,11 @@ sim-beta-cast-tail :
       ⊢ N ⊒ NL [ VR ] ∶ applyCoercions χs qₒ
         ⦂ applyTys χs Bₒ ⊒ BR
 sim-beta-cast-tail {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {M₀ = M₀}
-    {NL = NL} {VR = VR} {qₒ = qₒ} {d = d} {Bₒ = Bₒ}
+    {NL = NL} {VR = VR} {qᵢ = qᵢ} {qₒ = qₒ} {d = d} {Bₒ = Bₒ}
     {BR = BR} {D₁ = D₁} {D₂ = D₂} {μq = μq} {μd = μd}
     {χsA = χsA} {ΔLA = ΔLA}
-    castN prefix-red tail-cast qₒ⊒ d⊒ ΔLA≡ ρA-corr wrap rec =
+    castN prefix-red tail-cast qₒ⊒ d⊒ comp₀ ΔLA≡ ρA-corr wrap
+    rec =
   let
     χsT , N , ΔLT , ρT ,
       tail-red , ΔT≡ , ρT≡ , N⊒NL[VR] = rec
@@ -228,6 +245,37 @@ sim-beta-cast-tail {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {M₀ = M₀}
         (sym ρT≡)
         d⊒T
 
+    compA :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ applyCoercions χsA d ⨟ applyCoercions χsA qₒ
+          ≈ applyCoercions χsA qᵢ ∶ applyTys χsA D₁ ⊒ BR
+    compA = left-change-composed-index χsA ΔLA≡ ρA-corr comp₀
+
+    compT :
+      ΔLT ∣ ΔR ∣ applyLeftChanges χsT (applyLeftChanges χsA ρ)
+        ⊢ applyCoercions χsT (applyCoercions χsA d)
+          ⨟ applyCoercions χsT (applyCoercions χsA qₒ)
+          ≈ applyCoercions χsT (applyCoercions χsA qᵢ)
+          ∶ applyTys χsT (applyTys χsA D₁) ⊒ BR
+    compT = left-change-composed-index χsT ΔT≡ ρT-corr compA
+
+    compTρ :
+      ΔLT ∣ ΔR ∣ ρT
+        ⊢ applyCoercions χsT (applyCoercions χsA d)
+          ⨟ applyCoercions χsT (applyCoercions χsA qₒ)
+          ≈ applyCoercions χsT (applyCoercions χsA qᵢ)
+          ∶ applyTys χsT (applyTys χsA D₁) ⊒ BR
+    compTρ =
+      subst
+        (λ ρ₀ →
+          ΔLT ∣ ΔR ∣ ρ₀
+            ⊢ applyCoercions χsT (applyCoercions χsA d)
+              ⨟ applyCoercions χsT (applyCoercions χsA qₒ)
+              ≈ applyCoercions χsT (applyCoercions χsA qᵢ)
+              ∶ applyTys χsT (applyTys χsA D₁) ⊒ BR)
+        (sym ρT≡)
+        compT
+
     source-steps :
       M₀ —↠[ (keep ∷ χsA) ++ χsT ] castN χsT N
     source-steps = ↠-trans prefix-red (tail-cast tail-red)
@@ -246,7 +294,7 @@ sim-beta-cast-tail {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {M₀ = M₀}
       trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
 
     N-cast⊒ =
-      wrap ρT≡ N⊒NL[VR] qₒ⊒Tρ d⊒Tρ
+      wrap ρT≡ N⊒NL[VR] qₒ⊒Tρ d⊒Tρ compTρ
 
     N-cast⊒total :
       ΔLT ∣ ΔR ∣ ρT ∣ []
@@ -285,6 +333,7 @@ sim-beta-cast+-result :
   μq ∣ ΔL ∣ ΔR ∣ ρ ⊢ qₒ ∶ Bₒ ⊒ BR →
   (dₛ⊒ : μd ∣ ΔL ∣ ΔR ∣ ρ ⊢ dₛ ∶ Bₒ ⊒ BL) →
   narrowing-dual dₛ⊒ ≡ d →
+  ΔL ∣ ΔR ∣ ρ ⊢ dₛ ⨟ qᵢ ≈ qₒ ∶ Bₒ ⊒ BR →
   ΔLA ≡ applyTyCtxs χsA ΔL →
   StoreCorr ΔLA ΔR (applyLeftChanges χsA ρ) →
   ΔLT ≡ applyTyCtxs χsT ΔLA →
@@ -301,7 +350,7 @@ sim-beta-cast+-result {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {VR = VR} {N = N} {qᵢ = qᵢ} {qₒ = qₒ} {dₛ = dₛ}
     {d = d} {Bₒ = Bₒ} {BL = BL} {BR = BR} {μq = μq}
     {μd = μd} {χsA = χsA} {χsT = χsT}
-    qᵢᶜ qₒ⊒ dₛ⊒ dₛ-dual-eq ΔLA≡ ρA-corr ΔT≡ ρT≡
+    qᵢᶜ qₒ⊒ dₛ⊒ dₛ-dual-eq comp₀ ΔLA≡ ρA-corr ΔT≡ ρT≡
     N⊒NL[VR] =
   let
     μN , nᶜ = typed-term-narrowing-coercion N⊒NL[VR]
@@ -429,6 +478,9 @@ sim-beta-cast+-result {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
           qᵢᶜT
           qₒ⊒T
           dₛ⊒T
+          (left-change-composed-index χsT ΔT≡ ρT-corr
+            (left-change-composed-index χsA ΔLA≡ ρA-corr
+              comp₀))
           N⊒NL[VR]T)
   in
   subst
@@ -464,20 +516,24 @@ term-function-domain-dual :
   Coercion
 term-function-domain-dual (ƛ⊒ƛᵗ p↦qᶜ N⊒NL) =
   fun-narrow-domain-dualᶜ p↦qᶜ
-term-function-domain-dual (cast+⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) =
+term-function-domain-dual (cast+⊒ᵗ qᶜ rᶜ s⊒ _ M⊒M′) =
   fun-narrow-domain-dual rᶜ
-term-function-domain-dual (cast-⊒ᵗ qᶜ rᶜ s⊒ M⊒M′) =
+term-function-domain-dual (cast-⊒ᵗ qᶜ rᶜ s⊒ _ M⊒M′) =
   fun-narrow-domain-dual qᶜ
 
 {-# TERMINATING #-}
 sim-beta :
-  ∀ {ΔL ΔR ρ WL NL WR VR pᵈ p q A A′ B B′} →
+  ∀ {ΔL ΔR ρ WL NL WR VR p q A A′ B B′ μsim} →
   ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WL ⊒ ƛ NL ∶ p ↦ q
     ⦂ A ⇒ B ⊒ A′ ⇒ B′ →
   Value WL →
   No• WL →
-  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WR ⊒ VR ∶ pᵈ ⦂ A ⊒ A′ →
-  ΔL ∣ ΔR ∣ ρ ⊢ pᵈ ∶ᶜ A ⊒ A′ →
+  (p↦q-sim⊒ : μsim ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q
+                ∶ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+  ΔL ∣ ΔR ∣ ρ
+    ⊢ fun-narrow-domain-dual p↦q-sim⊒ ∶ᶜ A ⊒ A′ →
+  ΔL ∣ ΔR ∣ ρ ∣ []
+    ⊢ WR ⊒ VR ∶ fun-narrow-domain-dual p↦q-sim⊒ ⦂ A ⊒ A′ →
   Value WR →
   No• WR →
   Value VR →
@@ -491,7 +547,7 @@ sim-beta :
 sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {WR = WR} {VR = VR} {A = A} {A′ = A′}
     (ƛ⊒ƛᵗ p↦qᶜ N⊒NL)
-    (ƛ N) noWL WR⊒VR p-domainᶜ vWR noWR vVR =
+    (ƛ N) noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
   let
     WR⊒VR′ :
       ΔL ∣ ΔR ∣ ρ ∣ []
@@ -500,12 +556,7 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     WR⊒VR′ =
       subst
         (λ p → ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WR ⊒ VR ∶ p ⦂ A ⊒ A′)
-        (narrowing-determinedᵐ
-          (leftStore-det (narrowing-store-corrᶜ p-domainᶜ))
-          (let _ , _ , _ , _ , _ , pᵈ⊒L , _ = p-domainᶜ in pᵈ⊒L)
-          (let _ , _ , _ , _ , _ , pᵈ⊒L , _ =
-                 fun-narrow-domain-dual-typingᶜ p↦qᶜ
-           in pᵈ⊒L))
+        (fun-narrow-domain-dual-determined p↦q-sim⊒ p↦qᶜ)
         WR⊒VR
   in
   keep ∷ [] ,
@@ -516,11 +567,11 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   refl ,
   refl ,
   term-substitution-narrowingᶜ N⊒NL WR⊒VR′
-sim-beta castCase@(cast+⊒ᵗ rᶜ p↦qᶜ t⊒ V⊒ƛ)
-    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+sim-beta castCase@(cast+⊒ᵗ rᶜ p↦qᶜ t⊒ _ V⊒ƛ)
+    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     with canonical-⇒ vWL (typed-term-narrowing-source-typingᶜ castCase)
-sim-beta castCase@(cast+⊒ᵗ rᶜ p↦qᶜ t⊒ V⊒ƛ)
-    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+sim-beta castCase@(cast+⊒ᵗ rᶜ p↦qᶜ t⊒ _ V⊒ƛ)
+    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-ƛ ()
 sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
     {WR = WR} {VR = VR} {A′ = AR}
@@ -532,8 +583,9 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
       t⊒@(storesCast , _ , _ , _ , _ ,
         (cast-fun cₛ⊢L dₛ⊢L , cross (cₛʷL ↦ⁿʷ dₛⁿL)) ,
         (cast-fun cₛ⊢R dₛ⊢R , cross (cₛʷR ↦ⁿʷ dₛⁿR)))
+      compᵏ
       V⊒ƛ)
-    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ {W = VF} {c = c} {d = d} vVF eq =
   let
     M≡VF : M ≡ VF
@@ -654,6 +706,14 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
       c⊒L ,
       c⊒R
 
+    comp-final :
+      ΔL ∣ ΔR ∣ ρ
+        ⊢ c ⨟ fun-narrow-domain-dualᶜ pᵢ↦qᵢᶜ
+          ≈ fun-narrow-domain-dual p↦q-sim⊒ ∶ Aₒ ⊒ AR
+    comp-final =
+      cast-fun-comp-domain-dual compᵏ t⊒ cast-eq pᵢ↦qᵢᶜ
+        p↦q-sim⊒
+
     WR-c⊒VR :
       ΔL ∣ ΔR ∣ ρ ∣ []
         ⊢ WR ⟨ c ⟩ ⊒ VR ∶ fun-narrow-domain-dualᶜ pᵢ↦qᵢᶜ
@@ -663,6 +723,7 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
         (fun-narrow-domain-dual-typingᶜ pᵢ↦qᵢᶜ)
         p-domainᶜ
         c⊒
+        comp-final
         WR⊒VR
 
     χsA , WRA , ΔLA ,
@@ -675,6 +736,34 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
 
     VFA⊒ƛ =
       advance-left-lambda-narrowing χsA ΔLA≡ ρA-corr VF⊒ƛ
+
+    pᵢ↦qᵢ⊒A =
+      left-change-fun-coercion-narrowing χsA
+        ΔLA≡ ρA-corr pᵢ↦qᵢᶜ
+
+    pAᶜ′ :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ fun-narrow-domain-dual (proj₁ pᵢ↦qᵢ⊒A)
+          ∶ᶜ applyTys χsA AL ⊒ AR
+    pAᶜ′ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+            ⊢ pd ∶ᶜ applyTys χsA AL ⊒ AR)
+        (sym (proj₂ pᵢ↦qᵢ⊒A))
+        pAᶜ
+
+    WRA⊒VR′ :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ ∣ []
+        ⊢ WRA ⊒ VR ∶ fun-narrow-domain-dual (proj₁ pᵢ↦qᵢ⊒A)
+          ⦂ applyTys χsA AL ⊒ AR
+    WRA⊒VR′ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ ∣ []
+            ⊢ WRA ⊒ VR ∶ pd ⦂ applyTys χsA AL ⊒ AR)
+        (sym (proj₂ pᵢ↦qᵢ⊒A))
+        WRA⊒VR
 
     arg-ready :
       VF · (WR ⟨ c ⟩) —↠[ χsA ] applyTerms χsA VF · WRA
@@ -695,8 +784,9 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
         VFA⊒ƛ
         (applyTerms-preserves-Value χsA vVF)
         (applyTerms-preserves-No• χsA noVF)
-        WRA⊒VR
-        pAᶜ
+        (proj₁ pᵢ↦qᵢ⊒A)
+        pAᶜ′
+        WRA⊒VR′
         vWRA
         noWRA
         vVR
@@ -759,6 +849,7 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WL = WL} {NL = NL}
         (separated-fun-codomain pₒ↦qₒᶜ)
         dₛ⊒
         dₛ-dual-eq
+        (cast-fun-comp-codomain compᵏ t⊒)
         ΔLA≡
         ρA-corr
         ΔT≡
@@ -780,8 +871,9 @@ sim-beta
       (storesCast , _ , _ , _ , _ ,
         (cast-fun _ _ , cross (_ ↦ⁿʷ _)) ,
         (cast-fun _ _ , cross (_ ↦ⁿʷ _)))
+      _
       V⊒ƛ)
-    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vVF eq
 sim-beta
     (cast+⊒ᵗ {q = (G ？) ︔ g}
@@ -790,8 +882,9 @@ sim-beta
       (storesCast , _ , _ , _ , _ ,
         (cast-fun _ _ , cross (_ ↦ⁿʷ _)) ,
         (cast-fun _ _ , cross (_ ↦ⁿʷ _)))
+      _
       V⊒ƛ)
-    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vVF eq
 sim-beta
     (cast+⊒ᵗ {q = g ︔ seal A α}
@@ -800,14 +893,15 @@ sim-beta
       (storesCast , _ , _ , _ , _ ,
         (cast-fun _ _ , cross (_ ↦ⁿʷ _)) ,
         (cast-fun _ _ , cross (_ ↦ⁿʷ _)))
+      _
       V⊒ƛ)
-    vWL noWL WR⊒VR p-domainᶜ vWR noWR vVR
+    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vVF eq
 sim-beta
-    (cast-⊒ᵗ {s = id A} p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (cast-⊒ᵗ {s = id A} p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
     (vV ⟨ () ⟩)
 sim-beta
-    (cast-⊒ᵗ {s = c ︔ d} p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (cast-⊒ᵗ {s = c ︔ d} p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
     (vV ⟨ () ⟩)
 sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL}
     {WR = WR} {VR = VR}
@@ -820,12 +914,13 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL}
       rInner@(storesInner , _ , _ , wf⇒ hAL hBL , _ ,
         (cast-fun pᵢ⊢L _ , cross (pᵢʷL ↦ⁿʷ _)) ,
         (cast-fun pᵢ⊢R _ , cross (pᵢʷR ↦ⁿʷ _)))
-      (storesCast , _ , _ , _ , wf⇒ hAₒʳ hBₒʳ ,
+      s⊒ᵗᵘᵖ@(storesCast , _ , _ , _ , wf⇒ hAₒʳ hBₒʳ ,
         (cast-fun c⊢L d⊢L , cross (cʷL ↦ⁿʷ dⁿL)) ,
         (cast-fun c⊢R d⊢R , cross (cʷR ↦ⁿʷ dⁿR)))
+      compᵏ
       V⊒ƛ)
     (vV ⟨ i ⟩)
-    (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR =
+    (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
   let
     head-β↦ :
       (V ⟨ c ↦ d ⟩) · WR —↠[ keep ∷ [] ]
@@ -937,7 +1032,10 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL}
             ⊢ WR ⟨ s ⟩ ⊒ VR ∶ fun-narrow-domain-dual rInner
               ⦂ AL ⊒ AR)
         c-dual-eq
-        (cast+⊒ᵗ p-domainᶜ pᵢ-domain⊒ c-dual⊒ WR⊒VR)
+        (cast+⊒ᵗ p-domainᶜ pᵢ-domain⊒ c-dual⊒
+          (cast-fun-comp-domain-dual₂ compᵏ s⊒ᵗᵘᵖ p↦q-sim⊒
+            rInner)
+          WR⊒VR)
 
     χsA , WRA , ΔLA ,
       vWRA , noWRA , WR-c↠WRA , ΔLA≡ , ρA-corr ,
@@ -966,13 +1064,42 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL}
         (applyTerms χsA V · WRA) ⟨ applyCoercions χsA d ⟩
     cast-arg-ready = cast-↠ {c = d} arg-ready
 
+    pᵢ↦qᵢ⊒A =
+      left-change-fun-coercion-narrowing χsA
+        ΔLA≡ ρA-corr rInner
+
+    pAᶜ′ :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+        ⊢ fun-narrow-domain-dual (proj₁ pᵢ↦qᵢ⊒A)
+          ∶ᶜ applyTys χsA AL ⊒ AR
+    pAᶜ′ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ
+            ⊢ pd ∶ᶜ applyTys χsA AL ⊒ AR)
+        (sym (proj₂ pᵢ↦qᵢ⊒A))
+        pAᶜ
+
+    WRA⊒VR′ :
+      ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ ∣ []
+        ⊢ WRA ⊒ VR ∶ fun-narrow-domain-dual (proj₁ pᵢ↦qᵢ⊒A)
+          ⦂ applyTys χsA AL ⊒ AR
+    WRA⊒VR′ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ applyLeftChanges χsA ρ ∣ []
+            ⊢ WRA ⊒ VR ∶ pd ⦂ applyTys χsA AL ⊒ AR)
+        (sym (proj₂ pᵢ↦qᵢ⊒A))
+        WRA⊒VR
+
     rec =
       sim-beta
         VFA⊒ƛ
         (applyTerms-preserves-Value χsA vV)
         (applyTerms-preserves-No• χsA noV)
-        WRA⊒VR
-        pAᶜ
+        (proj₁ pᵢ↦qᵢ⊒A)
+        pAᶜ′
+        WRA⊒VR′
         vWRA
         noWRA
         vVR
@@ -989,76 +1116,78 @@ sim-beta {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL}
     (λ tail-red → cast-↠ {c = applyCoercions χsA d} tail-red)
     qₒ⊒
     d⊒
+    (cast-fun-comp-codomain compᵏ s⊒ᵗᵘᵖ)
     ΔLA≡
     ρA-corr
-    (λ _ N⊒NL[VR] qₒ⊒Tρ d⊒Tρ →
+    (λ _ N⊒NL[VR] qₒ⊒Tρ d⊒Tρ compTρ →
       let μN , nᶜ = typed-term-narrowing-coercion N⊒NL[VR] in
       cast-⊒ᵗ {μ = μN} {η = ηCast}
         qₒ⊒Tρ
         nᶜ
         d⊒Tρ
+        compTρ
         N⊒NL[VR])
     rec
 sim-beta castCase@(cast-⊒ᵗ {s = `∀ c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     with canonical-⇒ (vV ⟨ `∀ c ⟩)
            (typed-term-narrowing-source-typingᶜ castCase)
 sim-beta castCase@(cast-⊒ᵗ {s = `∀ c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-ƛ ()
 sim-beta castCase@(cast-⊒ᵗ {s = `∀ c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ `∀ c ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vW ()
 sim-beta castCase@(cast-⊒ᵗ {s = G !}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     with canonical-⇒ (vV ⟨ G ! ⟩)
            (typed-term-narrowing-source-typingᶜ castCase)
 sim-beta castCase@(cast-⊒ᵗ {s = G !}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-ƛ ()
 sim-beta castCase@(cast-⊒ᵗ {s = G !}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ G ! ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vW ()
 sim-beta
-    (cast-⊒ᵗ {s = G ？} p↦qᶜ rᶜ t⊒ V⊒ƛ)
+    (cast-⊒ᵗ {s = G ？} p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
     (vV ⟨ () ⟩)
 sim-beta castCase@(cast-⊒ᵗ {s = seal A α}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     with canonical-⇒ (vV ⟨ seal A α ⟩)
            (typed-term-narrowing-source-typingᶜ castCase)
 sim-beta castCase@(cast-⊒ᵗ {s = seal A α}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-ƛ ()
 sim-beta castCase@(cast-⊒ᵗ {s = seal A α}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ seal A α ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vW ()
 sim-beta
     (cast-⊒ᵗ {s = unseal α A}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
     (vV ⟨ () ⟩)
 sim-beta castCase@(cast-⊒ᵗ {s = gen A c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     with canonical-⇒ (vV ⟨ gen A c ⟩)
            (typed-term-narrowing-source-typingᶜ castCase)
 sim-beta castCase@(cast-⊒ᵗ {s = gen A c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-ƛ ()
 sim-beta castCase@(cast-⊒ᵗ {s = gen A c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
-    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) WR⊒VR p-domainᶜ vWR noWR vVR
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
+    (vV ⟨ gen A c ⟩) (no•-⟨⟩ noV) p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR
     | fv-↦ vW ()
 sim-beta
     (cast-⊒ᵗ {s = inst A c}
-      p↦qᶜ rᶜ t⊒ V⊒ƛ)
+      p↦qᶜ rᶜ t⊒ _ V⊒ƛ)
     (vV ⟨ () ⟩)


### PR DESCRIPTION
## Why

While comparing `GTSF/TermNarrowingSeparated.agda` against the cambridge25 term-narrowing rules, we found the separated-store port was **partial** in two ways:

1. **All four cast rules had dropped the composition side conditions** (`s ⨾ q ≈ r` in the paper). Without them the conclusion coercion index of a cast rule is a *free relabeling* — nothing ties the result coercion to the cast and the inner relation — so coercion tracking through the DGG simulation was unsound relative to the paper. (The earlier "coercion tracking is false" and mode-pinch analyses in the checklist turned out to be partly artifacts of this.)
2. **Six term-narrowing rules were missing**: (⊒Λ), (⊒⟨ν⟩), (α⊒α), (⊒α), (ν⊒ν), (⊒ν).

This PR restores both and sweeps the consequences through the separated DGG proof stack. It also carries four earlier commits from this line of work (endpoint tracking in the DGG conclusion, closing the ξ-⊕ IH holes via determinacy, dropping the over-strict `∶ᶜ` premise from the theorem, and cross-mode determinacy for compatible mode environments).

## What

**`TermNarrowingSeparated.agda`**
- New mixfix composition judgment `ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ t ≈ r ∶ A ⊒ B`, mirroring the paper's `s ⨾ t ≈ r`: a record holding cross-store typings of both factors and of `r` at one shared mode environment (implicit `νᶜᵒᵐᵖ`, like the middle type). The literal composite equality is *recovered* by `composite-determinedˡ/ʳ` via coercion canonicity (`narrowing-determinedᵐ`) rather than stored — a stored composite would not transport across the postulated store-change surfaces. All four cast constructors take the judgment as their fourth premise.
- The six missing constructors are ported, with explicit `TermTypingEndpointsᶜ` premises (separated policy: endpoint typing is explicit so extractors stay total). Target-only binders extend both type contexts with a `right-only` seal entry; the shared `α ꞉ q` entry becomes a `matched` entry carrying `q`'s endpoint types with `q ∶ᶜ` as an explicit premise. (extend)/(split) remain deferred by design — proof attempts will guide them.

**`SimBetaSeparated.agda`** — `sim-beta` now takes mode-generic function-coercion evidence plus the `∶ᶜ` typing of its `fun-narrow-domain-dual`, with the argument relation indexed by that dual. All four of its composition obligations are **discharged — the file has no remaining holes**:
- the two domain-side sites use `cast-fun-comp-domain-dual` / `cast-fun-comp-domain-dual₂`;
- the two codomain-side sites (`sim-beta-cast+-result`, `sim-beta-cast-tail`) thread a codomain composition premise built with `cast-fun-comp-codomain` from the matched constructor's own record and transported through the catchup store-change layers with `left-change-composed-index`.

**`LeftChangeNarrowingSeparated.agda`** — the supporting lemmas above are all *proved* (`fun-narrow-domain-dual-determined`, `composed-index-raws-≡`, `fun-domain-dual-composed`, `cast-fun-comp-domain-dual/₂`, `cast-fun-comp-codomain`, `left-change-composed-index`). One postulate was added **with explicit approval**: `left-change-fun-coercion-narrowing`, the arrow/domain-dual sibling of the existing `left-change-source-coercion-narrowing-dual` transport family; it returns the transported arrow typing together with the equality relating its domain dual to the transported dual, which is what re-indexes relations across catchup.

**`DGGBetaSeparated.agda`** — re-based on the new `sim-beta` arity. The free-floating `pᵈ` premise of `separated-dgg-beta{,-left-first,-right-first}` is replaced by `fun-narrow-domain-dualᶜ p↦qᶜ` — exactly what `·⊒·ᵗ` inversion supplies — so the main theorem's β case needed no changes. Internally, each catchup layer transports the arrow `∶ᶜ` typing with the new postulate and `subst`s the caught-up argument relation along the returned dual equality.

**`DGGBetaCastSeparated.agda` / `DynamicGradualGuaranteeSeparated.agda`** — cast patterns arity-bumped for the new premise. DGGBetaCast's six cast *construction* sites carry named `{\! …-composition \!}` holes that mirror the discharged `sim-beta` sites (same compᵏ-threading surgery, listed in the checklist). The main theorem gains hole-bodied coverage clauses for the new constructors' ν-allocation / seal-narrowing simulation cases — the next milestone; `⊒Λᵗ` needs no clause since `Λ V′` cannot step.

**`Coercions.agda`** — documents at `Mode` that the Agda encoding of the paper's `Γ | ∅` vs `Γ | Φ` split is `tag-or-idᵈ`-vs-`μ` mode environments over a shared store.

**`GTSF/Makefile`** (new) — `agda +RTS -A128M -M18G -RTS`; profiling showed the single `sim-beta` definition dominates checking time (~275s of ~305s) and transiently needs >14G, so uncapped runs risk silent OS kills.

**Docs** — `SeparatedStoresDGGChecklist.md` and `DynamicGradualGuaranteeProofLog.md` record the design decisions and the remaining-work inventory.

## Proof status

- `GTSF/All.agda` checks green (`make -C GTSF agda`).
- No new postulates beyond the one approved transport sibling.
- Remaining holes are the pre-existing catchup/substitution scaffolding plus the newly named composition holes in `DGGBetaCastSeparated` and the ν/seal simulation clauses in the main theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)