### PR TITLE
Close the beta endpoint-tracking holes in the separated DGG

### DIFF
--- a/GTSF/proof/DGGBetaCastSeparated.agda
+++ b/GTSF/proof/DGGBetaCastSeparated.agda
@@ -1366,6 +1366,8 @@ separated-dgg-beta-cast-value :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
 separated-dgg-beta-cast-value
@@ -1386,6 +1388,8 @@ separated-dgg-beta-cast-value
   red ,
   ΔL′≡ ,
   ρ′≡ ,
+  refl ,
+  refl ,
   N⊒target
 
 separated-dgg-beta-cast-left-first :
@@ -1403,6 +1407,8 @@ separated-dgg-beta-cast-left-first :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
 separated-dgg-beta-cast-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -1469,6 +1475,8 @@ separated-dgg-beta-cast-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (ρ′ ≡
           applyLeftChanges χs (applyLeftChanges χsR
             (applyLeftChanges χsL ρ))) ×
+        (C ≡ applyTys χs (applyTys χsR (applyTys χsL B))) ×
+        (D ≡ B′) ×
         ΔL′ ∣ ΔR ∣ ρ′ ∣ []
           ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
     tail =
@@ -1485,7 +1493,7 @@ separated-dgg-beta-cast-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   in
   let
     χsT , N , ΔL′ , ρ′ , C , D , r ,
-      tail-red , ΔT≡ , ρT≡ , N⊒target = tail
+      tail-red , ΔT≡ , ρT≡ , C≡ᵀ , D≡ᵀ , N⊒target = tail
 
     source-steps :
       L · R —↠[ (χsL ++ χsR) ++ χsT ] N
@@ -1515,6 +1523,15 @@ separated-dgg-beta-cast-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
             (applyLeftChanges-++ (χsL ++ χsR) χsT ρ)
             (cong (applyLeftChanges χsT)
               (applyLeftChanges-++ χsL χsR ρ))))
+
+    C≡ :
+      C ≡ applyTys ((χsL ++ χsR) ++ χsT) B
+    C≡ =
+      trans C≡ᵀ
+        (sym
+          (trans
+            (applyTys-++ (χsL ++ χsR) χsT B)
+            (cong (applyTys χsT) (applyTys-++ χsL χsR B))))
   in
   (χsL ++ χsR) ++ χsT ,
   N ,
@@ -1526,6 +1543,8 @@ separated-dgg-beta-cast-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   source-steps ,
   ΔL′≡ ,
   ρ′≡ ,
+  C≡ ,
+  D≡ᵀ ,
   N⊒target
 
 separated-dgg-beta-cast-right-first :
@@ -1543,6 +1562,8 @@ separated-dgg-beta-cast-right-first :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
 separated-dgg-beta-cast-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -1571,6 +1592,8 @@ separated-dgg-beta-cast-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         (applyTerms χsR L · WR —↠[ χs ] N) ×
         (ΔL′ ≡ applyTyCtxs χs ΔL₁) ×
         (ρ′ ≡ applyLeftChanges χs (applyLeftChanges χsR ρ)) ×
+        (C ≡ applyTys χs (applyTys χsR B)) ×
+        (D ≡ B′) ×
         ΔL′ ∣ ΔR ∣ ρ′ ∣ []
           ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
     tail =
@@ -1587,7 +1610,7 @@ separated-dgg-beta-cast-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   in
   let
     χsT , N , ΔL′ , ρ′ , C , D , r ,
-      tail-red , ΔT≡ , ρT≡ , N⊒target = tail
+      tail-red , ΔT≡ , ρT≡ , C≡ᵀ , D≡ᵀ , N⊒target = tail
 
     source-steps :
       L · R —↠[ χsR ++ χsT ] N
@@ -1605,6 +1628,10 @@ separated-dgg-beta-cast-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ρ′ ≡ applyLeftChanges (χsR ++ χsT) ρ
     ρ′≡ =
       trans ρT≡ (sym (applyLeftChanges-++ χsR χsT ρ))
+
+    C≡ :
+      C ≡ applyTys (χsR ++ χsT) B
+    C≡ = trans C≡ᵀ (sym (applyTys-++ χsR χsT B))
   in
   χsR ++ χsT ,
   N ,
@@ -1616,6 +1643,8 @@ separated-dgg-beta-cast-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   source-steps ,
   ΔL′≡ ,
   ρ′≡ ,
+  C≡ ,
+  D≡ᵀ ,
   N⊒target
 
 separated-dgg-beta-cast :
@@ -1631,6 +1660,8 @@ separated-dgg-beta-cast :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ (V′ · (W′ ⟨ c ⟩)) ⟨ d ⟩ ∶ r ⦂ C ⊒ D
 separated-dgg-beta-cast okLR@(ok-no (no•-· noL noR))

--- a/GTSF/proof/DGGBetaSeparated.agda
+++ b/GTSF/proof/DGGBetaSeparated.agda
@@ -125,6 +125,8 @@ separated-dgg-beta-left-first :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
 separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -270,6 +272,15 @@ separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
             (applyLeftChanges-++ (χsL ++ χsR) χsT ρ)
             (cong (applyLeftChanges χsT)
               (applyLeftChanges-++ χsL χsR ρ))))
+
+    C≡ :
+      applyTys χsT (applyTys χsR (applyTys χsL B)) ≡
+        applyTys ((χsL ++ χsR) ++ χsT) B
+    C≡ =
+      sym
+        (trans
+          (applyTys-++ (χsL ++ χsR) χsT B)
+          (cong (applyTys χsT) (applyTys-++ χsL χsR B)))
   in
   (χsL ++ χsR) ++ χsT ,
   N ,
@@ -281,6 +292,8 @@ separated-dgg-beta-left-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   source-steps ,
   ΔL′≡ ,
   ρ′≡ ,
+  C≡ ,
+  refl ,
   N⊒N′[V′]
 
 separated-dgg-beta-right-first :
@@ -299,6 +312,8 @@ separated-dgg-beta-right-first :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
 separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
@@ -378,6 +393,10 @@ separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
       ρ′ ≡ applyLeftChanges (χsR ++ χsT) ρ
     ρ′≡ =
       trans ρT≡ (sym (applyLeftChanges-++ χsR χsT ρ))
+
+    C≡ :
+      applyTys χsT (applyTys χsR B) ≡ applyTys (χsR ++ χsT) B
+    C≡ = sym (applyTys-++ χsR χsT B)
   in
   χsR ++ χsT ,
   N ,
@@ -389,6 +408,8 @@ separated-dgg-beta-right-first {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   source-steps ,
   ΔL′≡ ,
   ρ′≡ ,
+  C≡ ,
+  refl ,
   N⊒N′[V′]
 
 separated-dgg-beta :
@@ -405,6 +426,8 @@ separated-dgg-beta :
     (L · R —↠[ χs ] N) ×
     (ΔL′ ≡ applyTyCtxs χs ΔL) ×
     (ρ′ ≡ applyLeftChanges χs ρ) ×
+    (C ≡ applyTys χs B) ×
+    (D ≡ B′) ×
     ΔL′ ∣ ΔR ∣ ρ′ ∣ []
       ⊢ N ⊒ N′ [ V′ ] ∶ r ⦂ C ⊒ D
 separated-dgg-beta okLR@(ok-no (no•-· noL noR))

--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -284,6 +284,8 @@ Proof notes:
   `separated-dgg-beta-cast`) do not yet track endpoints; the two clauses
   carry `β-*-endpoint-tracking` holes until the extension is threaded
   through those helpers and `sim-beta`.
+  Resolved 2026-07-06: both delegation chains now return
+  `(C ≡ applyTys χs B) × (D ≡ B′)` — see the entry below.
 - The local `obligation` tuple ascriptions that duplicated the theorem's
   ∃-type were removed where the tuple is immediately returned; the clause
   type determines them, and the duplicated ascriptions could not name the
@@ -450,3 +452,30 @@ Highlights:
   `{! …-composition !}` holes mirroring the discharged `sim-beta`
   sites; filling them needs the same compᵏ-threading surgery on that
   file's local helpers.
+
+## β and β-↦ endpoint tracking closed, 2026-07-06
+
+The `β-*-endpoint-tracking` holes in the main theorem's β and β-↦
+clauses are filled; both clauses are now hole-free.  No new lemmas or
+postulates were needed: the innermost helpers (`sim-beta`,
+`separated-dgg-beta-cast-value-shape`) already state their result
+relations at concrete indices (`applyCoercions χs q ⦂ applyTys χs B ⊒
+B′`), and only the delegation wrappers erased them into bare
+existentials.  Every function in the two chains
+(`separated-dgg-beta{,-left-first,-right-first}` and
+`separated-dgg-beta-cast{,-value,-left-first,-right-first}`) now also
+returns `(C ≡ applyTys χs B) × (D ≡ B′)`:
+
+- `refl` at the concrete layer (`-cast-value`, next to the
+  value-shape call);
+- `sym (applyTys-++ …)` re-association chains where the catchup
+  layers nest store changes, mirroring the existing `ΔL′≡`
+  constructions (`trans C≡ᵀ (sym (trans (applyTys-++ (χsL ++ χsR) χsT
+  B) (cong (applyTys χsT) (applyTys-++ χsL χsR B))))` in the two-layer
+  case);
+- the dispatchers forward by tail call, so only their signatures
+  changed.
+
+At the theorem, the β/β-↦ steps are `pure-step`s, so `χ′ = keep` and
+`applyTy keep B = B` holds definitionally; the helper equalities fill
+both conclusion components directly.

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -163,7 +163,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   in
   let
     χs , N , ΔL′ , ρ′ , C , D , r ,
-      source-steps , ΔL′≡ , ρ′≡ , N⊒N′[V′] = rec
+      source-steps , ΔL′≡ , ρ′≡ , C≡ , D≡ , N⊒N′[V′] = rec
   in
   χs ,
   N ,
@@ -177,8 +177,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
-  {! β-source-endpoint-tracking !} ,
-  {! β-target-endpoint-tracking !} ,
+  C≡ ,
+  D≡ ,
   N⊒N′[V′]
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}
@@ -197,7 +197,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   in
   let
     χs , N , ΔL′ , ρ′ , C , D , r ,
-      source-steps , ΔL′≡ , ρ′≡ , N⊒target = rec
+      source-steps , ΔL′≡ , ρ′≡ , C≡ , D≡ , N⊒target = rec
   in
   χs ,
   N ,
@@ -211,8 +211,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
   ΔL′≡ ,
   refl ,
   ρ′≡ ,
-  {! β-cast-source-endpoint-tracking !} ,
-  {! β-cast-target-endpoint-tracking !} ,
+  C≡ ,
+  D≡ ,
   N⊒target
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = L · R}


### PR DESCRIPTION
## Why

PR #40 added endpoint-tracking equalities `(C ≡ applyTys χs A) × (D ≡ applyTy χ′ B)` to `dynamicGradualGuarantee`'s conclusion, but the β and β-↦ clauses could not yet produce them: their delegation helpers (`separated-dgg-beta`, `separated-dgg-beta-cast`) returned relations under bare existentials `∃ C ∃ D ∃ r`, discarding the link between the result indices and the inputs. Both clauses carried `β-*-endpoint-tracking` holes.

This PR targets exactly those two cases of the theorem, working top-down per the current plan. **The β and β-↦ clauses of `dynamicGradualGuarantee` are now hole-free.**

## How

No new lemmas or postulates were needed, and there was nothing to counterexample-check: the innermost helpers already prove relations at *concrete* indices — `sim-beta` concludes at `applyCoercions χs q ⦂ applyTys χs B ⊒ B′`, and `separated-dgg-beta-cast-value-shape` likewise. Only the wrappers between them and the theorem erased that information. So every function in the two delegation chains

- `separated-dgg-beta` / `-left-first` / `-right-first` (`DGGBetaSeparated.agda`)
- `separated-dgg-beta-cast` / `-value` / `-left-first` / `-right-first` (`DGGBetaCastSeparated.agda`)

now additionally returns `(C ≡ applyTys χs B) × (D ≡ B′)`:

- at the concrete layer (`-cast-value`, directly over the value-shape result) the equalities are `refl`;
- where the catchup layers nest store changes, the source-side equality is an `applyTys-++` re-association chain mirroring the existing `ΔL′≡` constructions, e.g. two-layer: `trans C≡ᵀ (sym (trans (applyTys-++ (χsL ++ χsR) χsT B) (cong (applyTys χsT) (applyTys-++ χsL χsR B))))`;
- the top dispatchers forward by tail call, so only their signatures changed.

In the main theorem, β and β-↦ are `pure-step`s, so `χ′ = keep` and `applyTy keep B = B` holds definitionally — the helper equalities fill both conclusion components with no further conversion.

## Status

- `GTSF/All.agda` checks green (`make -C GTSF agda`).
- Main-theorem holes: 41 → 37; the β and β-↦ cases are complete.
- `DynamicGradualGuaranteeProofLog.md` records the design; the earlier "beta delegation sites do not yet track endpoints" note is marked resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)