### PR TITLE
Wire the ξ-⟨⟩ target-cast cases of the separated DGG

### DIFF
--- a/GTSF/proof/DynamicGradualGuaranteeProofLog.md
+++ b/GTSF/proof/DynamicGradualGuaranteeProofLog.md
@@ -479,3 +479,23 @@ returns `(C ≡ applyTys χs B) × (D ≡ B′)`:
 At the theorem, the β/β-↦ steps are `pure-step`s, so `χ′ = keep` and
 `applyTy keep B = B` holds definitionally; the helper equalities fill
 both conclusion components directly.
+
+## ξ-⟨⟩ target-cast cases wired, 2026-07-06
+
+The `target-cast-plus-inner-step-result` and
+`target-cast-minus-inner-step-result` holes in the main theorem are
+replaced by calls into the new `proof/InnerStepCastSeparated.agda`.
+Each case lemma rebuilds the ⊒cast±ᵗ node over the IH's store-changed
+contexts (`applyTyCtxs χs ΔL`, `applyTyCtx χ′ ΔR`,
+`applyRightChange χ′ (applyLeftChanges χs ρ)`), taking the IH's own
+coercion evidence for the inner index and gluing it in with a
+transported composition record; the plus case rewrites its target term
+along the transported dual raw, the minus case re-indexes the IH by
+canonicity.  Both case lemmas and the theorem check green; the open
+content is isolated in four named holes — the three store-change
+transports of sibling cast evidence and one canonicity application —
+deliberately NOT postulated: the counterexample check found a design
+tension between the shared-raw 7-tuple judgment and one-sided de
+Bruijn store changes that also affects the existing left-change
+postulate family.  See "Right store changes and shared coercion raws"
+in the checklist for the analysis and candidate resolutions.

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -108,6 +108,10 @@ open import proof.DGGPrimitiveSeparated using
   ; value-normalized-id-ℕ-target-constᶜ
   ; nat-endpoints-id-coercionᶜ
   )
+open import proof.InnerStepCastSeparated using
+  ( target-cast-plus-inner-step-result
+  ; target-cast-minus-inner-step-result
+  )
 open import proof.DGGBetaSeparated using (separated-dgg-beta)
 open import proof.DGGBetaCastSeparated using (separated-dgg-beta-cast)
 open import proof.DGGDeltaSeparated using
@@ -1471,7 +1475,8 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
     okM
-    (⊒cast+ᵗ {M′ = M′} {t = t} {A = A} {B = Bᵢ} p′ᶜ rᶜ t⊒ _ M⊒M′)
+    (⊒cast+ᵗ {M′ = M′} {t = t} {A = A} {B = Bᵢ} p′ᶜ rᶜ t⊒ compᵏ
+      M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
     rec :
@@ -1496,10 +1501,23 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
           ∶ _ ⦂ _ ⊒ _
     cast-result⊒ =
       let
-        ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
-        ih = N⊒S′
+        ih :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ N ⊒ S′ ∶ r ⦂ applyTys χs A ⊒ applyTy χ′ Bᵢ
+        ih =
+          subst
+            (λ Y →
+              ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+                ⊢ N ⊒ S′ ∶ r ⦂ applyTys χs A ⊒ Y)
+            D≡
+            (subst
+              (λ X →
+                ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ X ⊒ D)
+              C≡
+              N⊒S′)
       in
-      {! target-cast-plus-inner-step-result !}
+      target-cast-plus-inner-step-result
+        p′ᶜ t⊒ compᵏ ΔL′≡ ΔR′≡ ρ′≡ ih
 
     obligation =
       χs ,
@@ -1567,7 +1585,7 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
 dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
     {M = M} {χ′ = χ′}
     okM
-    (⊒cast-ᵗ {t = t} p′ᶜ rᶜ t⊒ _ M⊒M′)
+    (⊒cast-ᵗ {t = t} {A = A} p′ᶜ rᶜ t⊒ compᵏ M⊒M′)
     (ξ-⟨⟩ {M′ = S′} M′→S′) =
   let
     rec = dynamicGradualGuarantee okM M⊒M′ M′→S′
@@ -1581,10 +1599,23 @@ dynamicGradualGuarantee {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
         ⊢ N ⊒ S′ ⟨ applyCoercion χ′ t ⟩ ∶ _ ⦂ _ ⊒ _
     cast-result⊒ =
       let
-        ih : ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ C ⊒ D
-        ih = N⊒S′
+        ih :
+          ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+            ⊢ N ⊒ S′ ∶ r ⦂ applyTys χs A ⊒ _
+        ih =
+          subst
+            (λ Y →
+              ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+                ⊢ N ⊒ S′ ∶ r ⦂ applyTys χs A ⊒ Y)
+            D≡
+            (subst
+              (λ X →
+                ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ N ⊒ S′ ∶ r ⦂ X ⊒ D)
+              C≡
+              N⊒S′)
       in
-      {! target-cast-minus-inner-step-result !}
+      target-cast-minus-inner-step-result
+        p′ᶜ rᶜ t⊒ compᵏ ΔL′≡ ΔR′≡ ρ′≡ ih
 
     obligation =
       χs ,

--- a/GTSF/proof/InnerStepCastSeparated.agda
+++ b/GTSF/proof/InnerStepCastSeparated.agda
@@ -1,0 +1,189 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.InnerStepCastSeparated where
+
+-- File Charter:
+--   * ξ-⟨⟩ simulation for target-side casts in the separated DGG: when
+--     the target term steps under a cast (possibly allocating, χ′), the
+--     ⊒cast±ᵗ relation is rebuilt over the store-changed contexts that
+--     the induction hypothesis produces.
+--   * The store-change transports of the sibling cast evidence are
+--     hole-bodied lemmas here — not postulates.  See the checklist
+--     ("Right store changes and shared coercion raws") for the
+--     counterexample analysis behind their statements.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([])
+open import Data.Product using (_×_; _,_; proj₁; proj₂; Σ-syntax)
+open import Relation.Binary.PropositionalEquality using (subst)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NuReduction
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyRightChange
+  )
+open import proof.ReductionProperties using (applyCoercions)
+
+------------------------------------------------------------------------
+-- Store-change transports for cast evidence
+------------------------------------------------------------------------
+
+-- A relation-indexing coercion moves with both stores: its source
+-- endpoint and raw follow the source changes χs, its target endpoint
+-- follows the single target change χ′ of the simulated step.  The
+-- χ′-side raw shift matches ξ-⟨⟩, which shifts the coercions it steps
+-- under.
+change-relation-coercion-narrowing :
+  ∀ χs χ′ {μ ΔL ΔR ρ c A B} →
+  StoreCorr (applyTyCtxs χs ΔL) (applyTyCtx χ′ ΔR)
+    (applyRightChange χ′ (applyLeftChanges χs ρ)) →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+    ∣ applyRightChange χ′ (applyLeftChanges χs ρ)
+    ⊢ applyCoercion χ′ (applyCoercions χs c)
+      ∶ applyTys χs A ⊒ applyTy χ′ B
+change-relation-coercion-narrowing χs χ′ corr c⊒ =
+  {! change-relation-coercion-transport !}
+
+-- A target-side mediating coercion: both endpoints are types of the
+-- target-side cast, so both move by χ′, and the raw is untouched by the
+-- source changes χs — the target term does not move when the source
+-- steps — and shifted by χ′ exactly as ξ-⟨⟩ shifts the cast it steps
+-- under.  The Σ-component transports the dual raw the same way, which
+-- is what lets the ⊒cast+ᵗ caller rewrite its target term.
+change-target-coercion-narrowing :
+  ∀ χs χ′ {μ ΔL ΔR ρ c A B} →
+  StoreCorr (applyTyCtxs χs ΔL) (applyTyCtx χ′ ΔR)
+    (applyRightChange χ′ (applyLeftChanges χs ρ)) →
+  (c⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ c ∶ A ⊒ B) →
+  Σ[ e ∈ (μ ∣ applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+            ∣ applyRightChange χ′ (applyLeftChanges χs ρ)
+            ⊢ applyCoercion χ′ c
+              ∶ applyTy χ′ A ⊒ applyTy χ′ B) ]
+    narrowing-dual e ≡ applyCoercion χ′ (narrowing-dual c⊒)
+change-target-coercion-narrowing χs χ′ corr c⊒ =
+  {! change-target-coercion-transport !}
+
+-- Composition transport.  The composite of the transported factors is
+-- canonical at the transported endpoints (`narrowing-determinedᵐ`), so
+-- the factors compose to any coercion well-typed at that index — in
+-- particular to the coercion the induction hypothesis produced.
+change-composed-index :
+  ∀ χs χ′ {ΔL ΔR ρ p t r r₁ A B μ₁} →
+  ΔL ∣ ΔR ∣ ρ ⊢ p ⨟ t ≈ r ∶ A ⊒ B →
+  μ₁ ∣ applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+    ∣ applyRightChange χ′ (applyLeftChanges χs ρ)
+    ⊢ r₁ ∶ applyTys χs A ⊒ applyTy χ′ B →
+  applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+    ∣ applyRightChange χ′ (applyLeftChanges χs ρ)
+    ⊢ applyCoercion χ′ (applyCoercions χs p) ⨟ applyCoercion χ′ t
+      ≈ r₁ ∶ applyTys χs A ⊒ applyTy χ′ B
+change-composed-index χs χ′ comp r₁⊒ =
+  {! change-composed-index-transport !}
+
+------------------------------------------------------------------------
+-- ξ-⟨⟩ case lemmas
+------------------------------------------------------------------------
+
+-- Target cast on the right of a ⊒cast+ᵗ node, inner target step.  The
+-- result relation is indexed by the transported outer coercion; its
+-- inner coercion is whatever the induction hypothesis produced, glued
+-- in by the composition transport.
+target-cast-plus-inner-step-result :
+  ∀ {χs χ′ ΔL ΔR ρ ΔL′ ΔR′ ρ′ N S′ p′ r t A B C rᶦʰ η} →
+  ΔL ∣ ΔR ∣ ρ ⊢ p′ ∶ᶜ A ⊒ C →
+  (t⊒ : η ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ C ⊒ B) →
+  ΔL ∣ ΔR ∣ ρ ⊢ p′ ⨟ t ≈ r ∶ A ⊒ B →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  ΔR′ ≡ applyTyCtx χ′ ΔR →
+  ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ) →
+  ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+    ⊢ N ⊒ S′ ∶ rᶦʰ ⦂ applyTys χs A ⊒ applyTy χ′ B →
+  ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+    ⊢ N ⊒ S′ ⟨ applyCoercion χ′ (narrowing-dual t⊒) ⟩
+      ∶ applyCoercion χ′ (applyCoercions χs p′)
+      ⦂ applyTys χs A ⊒ applyTy χ′ C
+target-cast-plus-inner-step-result {χs} {χ′} {ΔL} {ΔR} {ρ}
+    {N = N} {S′ = S′} {p′ = p′} {t = t}
+    {A = A} {B = B} {C = C}
+    p′ᶜ t⊒ comp refl refl refl ih =
+  let
+    μih , rᶦʰ⊒ = typed-term-narrowing-coercion ih
+
+    corr = narrowing-store-corrᶜ rᶦʰ⊒
+
+    p₁ᶜ = change-relation-coercion-narrowing χs χ′ corr p′ᶜ
+
+    t₁⊒dual = change-target-coercion-narrowing χs χ′ corr t⊒
+
+    comp₁ = change-composed-index χs χ′ comp rᶦʰ⊒
+  in
+  subst
+    (λ d →
+      applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+        ∣ applyRightChange χ′ (applyLeftChanges χs ρ) ∣ []
+        ⊢ N ⊒ S′ ⟨ d ⟩
+          ∶ applyCoercion χ′ (applyCoercions χs p′)
+          ⦂ applyTys χs A ⊒ applyTy χ′ C)
+    (proj₂ t₁⊒dual)
+    (⊒cast+ᵗ p₁ᶜ rᶦʰ⊒ (proj₁ t₁⊒dual) comp₁ ih)
+
+-- Target cast on the right of a ⊒cast-ᵗ node, inner target step.  The
+-- inner relation of the rebuilt node must be indexed by the transported
+-- p′; the induction hypothesis's coercion index is identified with it
+-- by canonicity (the named hole below).
+target-cast-minus-inner-step-result :
+  ∀ {χs χ′ ΔL ΔR ρ ΔL′ ΔR′ ρ′ N S′ p′ r t A B C pᶦʰ μ η} →
+  ΔL ∣ ΔR ∣ ρ ⊢ p′ ∶ᶜ A ⊒ C →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ r ∶ A ⊒ B →
+  η ∣ ΔL ∣ ΔR ∣ ρ ⊢ t ∶ C ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ⊢ p′ ⨟ t ≈ r ∶ A ⊒ B →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  ΔR′ ≡ applyTyCtx χ′ ΔR →
+  ρ′ ≡ applyRightChange χ′ (applyLeftChanges χs ρ) →
+  ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+    ⊢ N ⊒ S′ ∶ pᶦʰ ⦂ applyTys χs A ⊒ applyTy χ′ C →
+  ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+    ⊢ N ⊒ S′ ⟨ applyCoercion χ′ t ⟩
+      ∶ applyCoercion χ′ (applyCoercions χs r)
+      ⦂ applyTys χs A ⊒ applyTy χ′ B
+target-cast-minus-inner-step-result {χs} {χ′} {ΔL} {ΔR} {ρ}
+    {N = N} {S′ = S′} {p′ = p′} {r = r} {t = t}
+    {A = A} {B = B} {C = C} {pᶦʰ = pᶦʰ}
+    p′ᶜ r⊒ t⊒ comp refl refl refl ih =
+  let
+    μih , pᶦʰ⊒ = typed-term-narrowing-coercion ih
+
+    corr = narrowing-store-corrᶜ pᶦʰ⊒
+
+    p₁ᶜ = change-relation-coercion-narrowing χs χ′ corr p′ᶜ
+
+    r₁⊒ = change-relation-coercion-narrowing χs χ′ corr r⊒
+
+    t₁⊒dual = change-target-coercion-narrowing χs χ′ corr t⊒
+
+    comp₁ = change-composed-index χs χ′ comp r₁⊒
+
+    pᶦʰ≡p₁ : pᶦʰ ≡ applyCoercion χ′ (applyCoercions χs p′)
+    pᶦʰ≡p₁ = {! inner-step-coercion-index-determined !}
+
+    ih′ :
+      applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+        ∣ applyRightChange χ′ (applyLeftChanges χs ρ) ∣ []
+        ⊢ N ⊒ S′ ∶ applyCoercion χ′ (applyCoercions χs p′)
+          ⦂ applyTys χs A ⊒ applyTy χ′ C
+    ih′ =
+      subst
+        (λ c →
+          applyTyCtxs χs ΔL ∣ applyTyCtx χ′ ΔR
+            ∣ applyRightChange χ′ (applyLeftChanges χs ρ) ∣ []
+            ⊢ N ⊒ S′ ∶ c ⦂ applyTys χs A ⊒ applyTy χ′ C)
+        pᶦʰ≡p₁
+        ih
+  in
+  ⊒cast-ᵗ p₁ᶜ r₁⊒ (proj₁ t₁⊒dual) comp₁ ih′

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -302,6 +302,46 @@ The separated substitution lemma is now stated as
 case is factored as `sim-beta-lambda` and already performs the one-step
 `β` reduction.
 
+## Right store changes and shared coercion raws (2026-07-06)
+
+The ξ-⟨⟩ target-cast cases of the main theorem are wired through
+`proof/InnerStepCastSeparated.agda`: the ⊒cast±ᵗ node is rebuilt over
+the IH's store-changed contexts, with the sibling evidence moved by
+three transport lemmas (`change-relation-coercion-narrowing`,
+`change-target-coercion-narrowing`, `change-composed-index`).  These
+are stated as hole-bodied lemmas, **not** postulates, because the
+counterexample check surfaced a real design tension:
+
+- The separated coercion judgment is a 7-tuple sharing **one raw**
+  between the two store typings
+  (`μ ∣ ΔL ∣ leftStore ρ ⊢ r ∶ A ⊒ B` and
+  `μ ∣ ΔR ∣ rightStore ρ ⊢ r ∶ A ⊒ B`).
+- Store changes are one-sided and shift de Bruijn indices at the front
+  (`applyStore (bind A) Σ = (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ`), and `cast-seal`
+  resolves seal references positionally (`(α , A) ∈ Σ`).
+- Hence a right-only `bind` demands the raw be shifted for the right
+  typing (the ξ-⟨⟩ reduction indeed rewrites the stepped-under cast to
+  `applyCoercion χ c`) while the unchanged left store types the
+  *unshifted* raw.  One shared raw cannot satisfy both whenever it
+  mentions a seal: `seal A α` needs `(α , A)` in both stores before the
+  bind, and `(suc α , ⇑ᵗ A)` in the right store but still `(α , A)` in
+  the left store after it.
+- The **existing left-change postulate family has the mirrored
+  problem**: `left-change-term-narrowing` keeps the target term (with
+  its embedded `narrowing-dual t⊒` raws) fixed while `applyLeftChanges`
+  shifts the left store those raws are 7-tuple-typed against.
+
+Conclusion recorded for discussion: before the transport holes (and,
+retroactively, the left-change postulates) can be discharged, the
+separated coercion judgment likely needs either (a) per-side raws
+related by a correspondence, or (b) seal references resolved through
+`ρ` (names, not positions), or (c) an invariant that the mediating
+coercions of ⊒cast±ᵗ nodes are seal-free on the opposite side.  Note
+the mode system already distinguishes the sides (`tag-or-idᵈ` vs `μ`),
+so (c) may be closest to cambridge25's `Γ | ∅ ⊢ p, q` discipline: the
+`∶ᶜ`-side coercions cannot be seals, and the `Γ | Φ`-side raws are
+exactly the ones the store changes rewrite.
+
 ## Track C. Catchup Proof
 
 - [x] Add right-side store-change operations.


### PR DESCRIPTION
## Why

Continuing top-down on `dynamicGradualGuarantee` (separated). After PR #41 closed the β cases, the recommended next targets were the ξ-⟨⟩ inner-step cases for target-side casts — the two holes `target-cast-plus-inner-step-result` and `target-cast-minus-inner-step-result`. These are the first cases where the target step's store change `χ′` can be an allocation, so the sibling cast evidence (`t⊒`, `p′ᶜ`, and the PR #40 composition record) must be transported to the induction hypothesis's changed contexts on **both** sides — a transport surface that did not exist for the right side.

## What

**New module [`GTSF/proof/InnerStepCastSeparated.agda`](../blob/claude/dgg-separated-xi-cast/GTSF/proof/InnerStepCastSeparated.agda):**

- Two case lemmas, `target-cast-plus-inner-step-result` and `target-cast-minus-inner-step-result`, with statements read directly off the theorem holes. Each rebuilds the `⊒cast±ᵗ` node over the IH's contexts (`applyTyCtxs χs ΔL`, `applyTyCtx χ′ ΔR`, `applyRightChange χ′ (applyLeftChanges χs ρ)`). The IH's own coercion evidence is the inner index; a transported composition record glues it to the transported outer coercion. The plus case rewrites its target term along the transported dual raw (`Σ`-packaged equality, mirroring `left-change-fun-coercion-narrowing`); the minus case re-indexes the IH by canonicity. **Both case lemmas fully type-check** — the assembly is real, not a hole.
- Three transport lemmas carrying the open content, plus one canonicity application, all as **named holes, not postulates**:
  - `change-relation-coercion-narrowing` — relation-indexing coercion: source endpoint/raw by `χs`, target endpoint by `χ′`;
  - `change-target-coercion-narrowing` — target-side mediating coercion: both endpoints and raw by `χ′` only (matching how `ξ-⟨⟩` rewrites the cast it steps under), with the dual-raw equality;
  - `change-composed-index` — the composition record, concluding at any coercion well-typed at the transported index (canonicity of composites);
  - `inner-step-coercion-index-determined` (inline, minus case) — the IH's coercion index equals the transported `p′`.

**Main theorem:** the two ξ-⟨⟩ clauses bind the composition premise (`compᵏ`), re-index the IH along the PR #41 endpoint equalities (two `subst`s), and call the case lemmas. Holes: 37 → 35, and these two cases now depend only on the named transport obligations.

## Counterexample check (the substantive finding)

Per the working agreement, the transport lemmas were checked for counterexamples before being added — and the check surfaced a real design tension, which is why they are holes rather than postulates:

- The separated coercion judgment shares **one raw** between its two store typings (`… ∣ leftStore ρ ⊢ r …` × `… ∣ rightStore ρ ⊢ r …`).
- Store changes are one-sided and shift de Bruijn indices at the front (`applyStore (bind A) Σ = (zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ`); `cast-seal` resolves seal references positionally (`(α , A) ∈ Σ`).
- So a right-only `bind` needs the raw shifted for the right store while the unchanged left store types the unshifted raw — impossible for one shared raw as soon as it mentions a seal.
- The **existing left-change postulate family has the mirrored problem** (target terms with embedded `narrowing-dual` raws held fixed while the left store shifts).

The checklist section "Right store changes and shared coercion raws" records this with candidate resolutions: (a) per-side raws related by a correspondence, (b) seal references resolved through `ρ` (names, not positions), or (c) a seal-freeness invariant for the `∶ᶜ`-side coercions — (c) looks closest to cambridge25's `Γ | ∅ ⊢ p, q` discipline. This is a design decision worth discussing before the transport holes (and, retroactively, the left-change postulates) are discharged.

## Status

- `GTSF/All.agda` checks green (`make -C GTSF agda`).
- No new postulates.
- Proof log updated with the case-wiring entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)