### PR TITLE
[codex] Formulate separated Left ν Widening Lemma

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -21,6 +21,7 @@ import proof.NWTermReduction
 import TermNarrowing
 import proof.TermNarrowingProperties
 import proof.CatchupSeparated
+import proof.LeftNuWideningSeparated
 import proof.DynamicGradualGuaranteeSeparated
 import NarrowingExamples
 import NuMetaTheory

--- a/GTSF/proof/DGGSepStatus.md
+++ b/GTSF/proof/DGGSepStatus.md
@@ -33,6 +33,10 @@ Notes:
   target-cast inner-step holes are closed by calls into
   `proof.InnerStepCastSeparated`. The affected cases still inherit
   `partial/holes` from the helper's transport/canonicity holes.
+- On `codex/issue-43` after merging `origin/main` at `b54acbd5`, the
+  `α⊒αᵗ` pure-step case is split on `β-gen•` and routed through
+  `matched-α-beta-gen-left-ν-widening-call` in
+  `proof.LeftNuWideningSeparated`.
 
 ## `dynamicGradualGuarantee`
 
@@ -76,24 +80,57 @@ Cambridge25 analogue: `Gradual Guarantee` (`close match`).
 | 1540 | `⊒cast+ᵗ` | general target cast step | `partial/holes` | Hole `target-cast-plus-simulation-relation`. |
 | 1585 | `⊒cast-ᵗ` | `ξ-⟨⟩` | `partial/holes` | Theorem clause now calls `target-cast-minus-inner-step-result`; helper has store-change transport and canonicity holes. |
 | 1638 | `⊒cast-ᵗ` | `pure-step (β-seq vV′)` | `partial/holes` | Hole `target-cast-minus-seq-split-relation`. |
-| 1658 | `⊒cast-ᵗ` | `pure-step (β-inst vV′)` | `partial/holes` | Hole `target-cast-minus-inst-nu-relation`. |
+| 1658 | `⊒cast-ᵗ` | `pure-step (β-inst vV′)` | `partial/holes` | Still `target-cast-minus-inst-nu-relation`; checked as the standalone target-cast-minus ν obligation, not the outer matched-α redex. |
 | 1678 | `⊒cast-ᵗ` | `pure-step (tag-untag-ok vV′)` | `partial/holes` | Hole `target-cast-minus-tag-untag-collapse-relation`. |
 | 1698 | `⊒cast-ᵗ` | `pure-step (seal-unseal vV′)` | `partial/holes` | Hole `target-cast-minus-seal-unseal-collapse-relation`. |
 | 1718 | `cast+⊒ᵗ` | target step under source cast | `partial/holes` | Hole `source-cast-plus-result-narrowing`. |
 | 1766 | `cast-⊒ᵗ` | target step under source cast | `partial/holes` | Hole `source-cast-minus-result-narrowing`. |
 | 1819 | `⊒⟨ν⟩ᵗ` | `pure-step st` | `todo` | Body is only `target-gen-cast-pure-step-simulation`. |
 | 1821 | `⊒⟨ν⟩ᵗ` | `ξ-⟨⟩ st` | `todo` | Body is only `target-gen-cast-inner-step-simulation`. |
-| 1823 | `α⊒αᵗ` | `pure-step st` | `todo` | Body is only `matched-seal-pure-step-simulation`. |
-| 1825 | `⊒αᵗ` | `pure-step st` | `todo` | Body is only `target-seal-pure-step-simulation`. |
-| 1827 | `ν⊒νᵗ` | `ν-step st₁ st₂` | `todo` | Body is only `nu-nu-allocation-simulation`. |
-| 1829 | `ν⊒νᵗ` | `ξ-ν st` | `todo` | Body is only `nu-nu-inner-step-simulation`. |
-| 1831 | `ν⊒νᵗ` | `blame-ν` | `todo` | Body is only `nu-nu-blame-simulation`. |
-| 1833 | `⊒νᵗ` | `ν-step st₁ st₂` | `todo` | Body is only `target-nu-allocation-simulation`. |
-| 1835 | `⊒νᵗ` | `ξ-ν st` | `todo` | Body is only `target-nu-inner-step-simulation`. |
-| 1837 | `⊒νᵗ` | `blame-ν` | `todo` | Body is only `target-nu-blame-simulation`. |
+| 1826 | `α⊒αᵗ` | `pure-step (β-gen• vV′)` | `partial/holes` | Calls `matched-α-beta-gen-left-ν-widening-call`, exposing the separated Left ν Widening use site. |
+| 1838 | `α⊒αᵗ` | other `pure-step st` | `todo` | Body is only `matched-seal-other-pure-step-simulation`. |
+| 1840 | `⊒αᵗ` | `pure-step st` | `todo` | Still `target-seal-pure-step-simulation`; target-only case should use a corollary or separate transport, not the current matched-α call directly. |
+| 1842 | `ν⊒νᵗ` | `ν-step st₁ st₂` | `todo` | Body is only `nu-nu-allocation-simulation`. |
+| 1844 | `ν⊒νᵗ` | `ξ-ν st` | `todo` | Body is only `nu-nu-inner-step-simulation`. |
+| 1846 | `ν⊒νᵗ` | `blame-ν` | `todo` | Body is only `nu-nu-blame-simulation`. |
+| 1848 | `⊒νᵗ` | `ν-step st₁ st₂` | `todo` | Body is only `target-nu-allocation-simulation`. |
+| 1850 | `⊒νᵗ` | `ξ-ν st` | `todo` | Body is only `target-nu-inner-step-simulation`. |
+| 1852 | `⊒νᵗ` | `blame-ν` | `todo` | Body is only `target-nu-blame-simulation`. |
 
 There is no explicit `⊒Λᵗ` DGG clause in this file. The target is `Λ V′`, so
 there is no target step for Agda to cover.
+
+## Left ν Widening Lemma Surface
+
+File: `GTSF/proof/LeftNuWideningSeparated.agda`.
+
+Cambridge25 analogue: `Left ν Widening Lemma`, mutually recursive with the
+ordinary `Left Widening Lemma` and `Left Narrowing Lemma` (`close match`).
+
+The separated statement keeps the Cambridge25 value-level shape: from a
+polymorphic value relation ``V ⊒ V′ ∶ `∀ p`` and composition witness
+``t ⨟ `∀ p ≈ r``, it reduces the source value under the dual left-widening
+cast `V ⟨ - t ⟩`.  The conclusion exposes the emitted source store changes
+`χs`, advanced left and right type contexts, updated separated store
+correspondence, endpoint equalities, and the transported result coercion.
+
+The DGG-specific helper `matched-α-beta-gen-left-ν-widening-call` is the
+call site for the `α⊒αᵗ` / `β-gen•` redex.  Its remaining holes are the
+inversions that extract the value-level relation, ν-widening cast, and
+composition witness needed to call the general lemma.
+
+| Surface/case | Status | Notes |
+| --- | --- | --- |
+| `left-widening-lemma-separated` | `todo` | Companion ordinary left-widening surface; body is `left-widening-lemma-separated-proof`. |
+| `left-narrowing-lemma-separated` | `todo` | Companion ordinary left-narrowing surface; body is `left-narrowing-lemma-separated-proof`. |
+| `left-ν-widening-lemma`, `Λ⊒Λᵗ` | `partial/holes` | Contains recursive call to `left-widening-lemma-separated` for the body relation. |
+| `left-ν-widening-lemma`, `⊒cast+ᵗ` | `partial/holes` | Contains recursive call to `left-widening-lemma-separated` for the target cast-wrapper case. |
+| `left-ν-widening-lemma`, `⊒cast-ᵗ` | `partial/holes` | Contains recursive call to `left-widening-lemma-separated` for the non-dual target cast-wrapper case. |
+| `left-ν-widening-lemma`, `cast+⊒ᵗ` | `partial/holes` | Contains recursive call to `left-narrowing-lemma-separated` for the source cast-wrapper / `⊒Λ/-⊒` shape. |
+| `left-ν-widening-lemma`, `cast-⊒ᵗ` | `partial/holes` | Contains recursive call to `left-narrowing-lemma-separated` for the non-dual source cast-wrapper shape. |
+| `left-ν-widening-lemma`, remaining separated cases | `todo` | Body is `left-ν-widening-remaining-case`. |
+| `matched-α-beta-gen-left-ν-widening-call` | `partial/holes` | Bridges the separated DGG redex to the general `left-ν-widening-lemma`. |
+| `left-ν-widening-induction-skeleton` | `partial/holes` | Auxiliary structural map over separated constructors, kept as a checklist for remaining recursive-premise coverage. |
 
 ## Major Separated Term-Narrowing Lemmas
 

--- a/GTSF/proof/DGGSepStatus.md
+++ b/GTSF/proof/DGGSepStatus.md
@@ -128,9 +128,11 @@ composition witness needed to call the general lemma.
 | `left-ν-widening-lemma`, `⊒cast-ᵗ` | `partial/holes` | Contains recursive call to `left-widening-lemma-separated` for the non-dual target cast-wrapper case. |
 | `left-ν-widening-lemma`, `cast+⊒ᵗ` | `partial/holes` | Contains recursive call to `left-narrowing-lemma-separated` for the source cast-wrapper / `⊒Λ/-⊒` shape. |
 | `left-ν-widening-lemma`, `cast-⊒ᵗ` | `partial/holes` | Contains recursive call to `left-narrowing-lemma-separated` for the non-dual source cast-wrapper shape. |
-| `left-ν-widening-lemma`, remaining separated cases | `todo` | Body is `left-ν-widening-remaining-case`. |
+| `left-ν-widening-lemma`, `⊒αᵗ` | `partial/holes` | Target-only constructor exposed separately; binds `left-ν-widening-induction-skeleton L⊒L′` for the recursive premise and leaves the transport/corollary obligation as `leftν-⊒α-target-only-case`. |
+| `left-ν-widening-lemma`, `⊒νᵗ` | `partial/holes` | Target-only ν constructor exposed separately; binds `left-ν-widening-induction-skeleton N⊒N′` for the recursive premise and leaves `leftν-⊒ν-target-only-case`. |
+| `left-ν-widening-lemma`, `⊒blameᵗ` | `partial/holes` | Nonrecursive base case, now explicit as `leftν-⊒blame-base-case`. |
 | `matched-α-beta-gen-left-ν-widening-call` | `partial/holes` | Bridges the separated DGG redex to the general `left-ν-widening-lemma`. |
-| `left-ν-widening-induction-skeleton` | `partial/holes` | Auxiliary structural map over separated constructors, kept as a checklist for remaining recursive-premise coverage. |
+| `left-ν-widening-induction-skeleton` | `partial/holes` | Auxiliary structural map over every separated constructor; recursive premises are explicit rather than hidden behind a catch-all. |
 
 ## Major Separated Term-Narrowing Lemmas
 

--- a/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
+++ b/GTSF/proof/DynamicGradualGuaranteeSeparated.agda
@@ -118,6 +118,9 @@ open import proof.DGGDeltaSeparated using
   ( separated-⊕-δ-left-first
   ; separated-⊕-δ-right-first
   )
+open import proof.LeftNuWideningSeparated using
+  ( matched-α-beta-gen-left-ν-widening-call
+  )
 
 ------------------------------------------------------------------------
 -- Full separated DGG skeleton
@@ -1820,8 +1823,20 @@ dynamicGradualGuarantee okM (⊒⟨ν⟩ᵗ _ _ _ _) (pure-step st) =
   {! target-gen-cast-pure-step-simulation !}
 dynamicGradualGuarantee okM (⊒⟨ν⟩ᵗ _ _ _ _) (ξ-⟨⟩ st) =
   {! target-gen-cast-inner-step-simulation !}
+dynamicGradualGuarantee okM
+    (α⊒αᵗ {L′ = V′ ⟨ gen Aν s ⟩}
+      γ′≡ endpoints qᶜ pᶜ L⊒V′gen)
+    (pure-step (β-gen• vV′)) =
+  matched-α-beta-gen-left-ν-widening-call
+    okM
+    (pure-step (β-gen• vV′))
+    γ′≡
+    endpoints
+    qᶜ
+    pᶜ
+    L⊒V′gen
 dynamicGradualGuarantee okM (α⊒αᵗ _ _ _ _ _) (pure-step st) =
-  {! matched-seal-pure-step-simulation !}
+  {! matched-seal-other-pure-step-simulation !}
 dynamicGradualGuarantee okM (⊒αᵗ _ _ _ _) (pure-step st) =
   {! target-seal-pure-step-simulation !}
 dynamicGradualGuarantee okM (ν⊒νᵗ _ _ _ _) (ν-step st₁ st₂) =

--- a/GTSF/proof/LeftNuWideningSeparated.agda
+++ b/GTSF/proof/LeftNuWideningSeparated.agda
@@ -1,0 +1,268 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
+module proof.LeftNuWideningSeparated where
+
+-- File Charter:
+--   * Separated-store statement and proof skeleton for the Cambridge25
+--     Left ν Widening Lemma.
+--   * Pins down the DGG call shape for the matched α/type-application
+--     `β-gen•` case.
+--   * Keeps every emitted source store change, right-step store change, and
+--     endpoint equality explicit in the theorem result.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (zero; suc)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+
+open import Types
+open import Coercions
+open import NuTerms
+open import NuReduction using
+  ( keep
+  ; applyTy
+  ; applyTyCtx
+  ; applyTys
+  ; applyTyCtxs
+  ; _—→[_]_
+  ; _—↠[_]_
+  )
+open import StoreCorrespondence
+open import TermNarrowingSeparated
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyRightChange
+  )
+open import proof.ReductionProperties using
+  ( applyCoercions
+  )
+
+------------------------------------------------------------------------
+-- Separated Left ν Widening Lemma
+------------------------------------------------------------------------
+
+left-widening-lemma-separated :
+  ∀ {ΔL ΔR ρ V V′ p r t A B C D} →
+  Value V →
+  No• V →
+  ΔL ∣ ΔR ∣ ρ ⊢ t ⨟ p ≈ r ∶ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ V ⊒ V′ ∶ p ⦂ C ⊒ D →
+  ∃[ χs ] ∃[ W ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+  ∃[ C′ ] ∃[ D′ ] ∃[ r′ ]
+    (V ⟨ - t ⟩ —↠[ χs ] W) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ΔR′ ≡ applyTyCtx keep ΔR) ×
+    (ρ′ ≡ applyRightChange keep (applyLeftChanges χs ρ)) ×
+    (C′ ≡ applyTys χs A) ×
+    (D′ ≡ applyTy keep B) ×
+    (r′ ≡ applyCoercions χs r) ×
+    ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ W ⊒ V′ ∶ r′ ⦂ C′ ⊒ D′
+left-widening-lemma-separated vV noV compᵏ V⊒V′ =
+  {! left-widening-lemma-separated-proof !}
+
+left-narrowing-lemma-separated :
+  ∀ {ΔL ΔR ρ V V′ p r t A B C D} →
+  Value V →
+  No• V →
+  ΔL ∣ ΔR ∣ ρ ⊢ t ⨟ p ≈ r ∶ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ V ⊒ V′ ∶ r ⦂ A ⊒ B →
+  ∃[ χs ] ∃[ W ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+  ∃[ C′ ] ∃[ D′ ] ∃[ p′ ]
+    (V ⟨ t ⟩ —↠[ χs ] W) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ΔR′ ≡ applyTyCtx keep ΔR) ×
+    (ρ′ ≡ applyRightChange keep (applyLeftChanges χs ρ)) ×
+    (C′ ≡ applyTys χs C) ×
+    (D′ ≡ applyTy keep D) ×
+    (p′ ≡ applyCoercions χs p) ×
+    ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ W ⊒ V′ ∶ p′ ⦂ C′ ⊒ D′
+left-narrowing-lemma-separated vV noV compᵏ V⊒V′ =
+  {! left-narrowing-lemma-separated-proof !}
+
+-- Cambridge25-shaped value-level lemma.  The premise relation is the
+-- polymorphic value relation `V ⊒ V′ : ∀ p`; the source term adds the
+-- dual of the left widening cast `t`; and the composition witness pins the
+-- resulting index `r`.  The ν-specific instantiation is supplied by the
+-- caller through the shape of `t`, `r`, and the composition witness.
+--
+-- This is intentionally more general than the DGG call-site theorem below:
+-- it does not mention the target `β-gen•` step or the matched-α type
+-- application.  Those belong to the caller that exposes where this lemma is
+-- needed.
+left-ν-widening-lemma :
+  ∀ {ΔL ΔR ρ V V′ p r t A B C D} →
+  Value V →
+  No• V →
+  ΔL ∣ ΔR ∣ ρ ⊢ t ⨟ `∀ p ≈ r ∶ A ⊒ B →
+  ΔL ∣ ΔR ∣ ρ ∣ []
+    ⊢ V ⊒ V′ ∶ `∀ p ⦂ C ⊒ D →
+  ∃[ χs ] ∃[ W ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+  ∃[ C′ ] ∃[ D′ ] ∃[ r′ ]
+    (V ⟨ - t ⟩ —↠[ χs ] W) ×
+    (ΔL′ ≡ applyTyCtxs χs ΔL) ×
+    (ΔR′ ≡ applyTyCtx keep ΔR) ×
+    (ρ′ ≡ applyRightChange keep (applyLeftChanges χs ρ)) ×
+    (C′ ≡ applyTys χs A) ×
+    (D′ ≡ applyTy keep B) ×
+    (r′ ≡ applyCoercions χs r) ×
+    ΔL′ ∣ ΔR′ ∣ ρ′ ∣ [] ⊢ W ⊒ V′ ∶ r′ ⦂ C′ ⊒ D′
+left-ν-widening-lemma vV noV compᵏ
+    (Λ⊒Λᵗ allᶜ vBody vBody′ body⊒) =
+  let
+    -- Cambridge25 `Λ⊒Λ`: the recursive work is delegated to the ordinary
+    -- left-widening lemma on the body-level relation and smaller cast.
+    ih =
+      left-widening-lemma-separated
+        {! leftν-Λ-value !}
+        {! leftν-Λ-no• !}
+        {! leftν-Λ-composition !}
+        body⊒
+  in
+  {! leftν-Λ⊒Λ-case !}
+left-ν-widening-lemma vV noV compᵏ
+    (⊒cast+ᵗ qᶜ rᶜ t⊒ compᵏ′ V⊒V′cast) =
+  let
+    -- Cambridge25 target cast wrapper (`⊒+`): recurse on the inner
+    -- relation, then rebuild the target cast wrapper around the result.
+    ih =
+      left-widening-lemma-separated
+        {! leftν-⊒cast+-value !}
+        {! leftν-⊒cast+-no• !}
+        {! leftν-⊒cast+-composition !}
+        V⊒V′cast
+  in
+  {! leftν-⊒cast+-case !}
+left-ν-widening-lemma vV noV compᵏ
+    (⊒cast-ᵗ qᶜ rᶜ t⊒ compᵏ′ V⊒V′cast) =
+  let
+    -- Cambridge25 target cast wrapper (`⊒+`), non-dual target cast form.
+    ih =
+      left-widening-lemma-separated
+        {! leftν-⊒cast--value !}
+        {! leftν-⊒cast--no• !}
+        {! leftν-⊒cast--composition !}
+        V⊒V′cast
+  in
+  {! leftν-⊒cast--case !}
+left-ν-widening-lemma vV noV compᵏ
+    (cast+⊒ᵗ qᶜ rᶜ s⊒ compᵏ′ Vcast⊒V′) =
+  let
+    -- Cambridge25 source cast wrapper (`+⊒` / `⊒Λ/-⊒`): the recursive
+    -- branch uses the ordinary left-narrowing shape when the source cast
+    -- must be peeled before the ν-widening cast is rebuilt.
+    ih =
+      left-narrowing-lemma-separated
+        {! leftν-cast+⊒-value !}
+        {! leftν-cast+⊒-no• !}
+        {! leftν-cast+⊒-composition !}
+        Vcast⊒V′
+  in
+  {! leftν-cast+⊒-case !}
+left-ν-widening-lemma vV noV compᵏ
+    (cast-⊒ᵗ qᶜ rᶜ s⊒ compᵏ′ Vcast⊒V′) =
+  let
+    -- Cambridge25 source cast wrapper (`+⊒` / `⊒Λ/-⊒`), non-dual source
+    -- cast form.
+    ih =
+      left-narrowing-lemma-separated
+        {! leftν-cast-⊒-value !}
+        {! leftν-cast-⊒-no• !}
+        {! leftν-cast-⊒-composition !}
+        Vcast⊒V′
+  in
+  {! leftν-cast-⊒-case !}
+left-ν-widening-lemma vV noV compᵏ V⊒V′ =
+  {! left-ν-widening-remaining-case !}
+
+-- DGG call-site obligation for the separated `α⊒αᵗ` / `β-gen•` case.
+-- The source begins at the matched fresh α type application
+-- `(⇑ᵗᵐ L) •`; the target one-step redex is an explicit premise, so the
+-- DGG caller pins it to `pure-step (β-gen• vV′)`.
+--
+-- The result mirrors `dynamicGradualGuarantee`: `χs` are the source-side
+-- store changes produced by the lemma, while the target-side change is the
+-- explicit `keep` from the pure target step.
+matched-α-beta-gen-left-ν-widening-call :
+  ∀ {ΔL ΔR ρ γ L L′ N′ p q Aα Bα C D E F} →
+  RuntimeOK ((⇑ᵗᵐ L) •) →
+  ((⇑ᵗᵐ L′) •) —→[ keep ] N′ →
+  [] ≡ ⇑ᵍᶜ γ →
+  TermTypingEndpointsᶜ (suc ΔL) (suc ΔR)
+    (matched zero (⇑ᵗ Aα) zero (⇑ᵗ Bα) ∷ ⇑ᶜorr ρ) []
+    ((⇑ᵗᵐ L) •) ((⇑ᵗᵐ L′) •) C D →
+  ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ Aα ⊒ Bα →
+  suc ΔL ∣ suc ΔR
+    ∣ matched zero (⇑ᵗ Aα) zero (⇑ᵗ Bα) ∷ ⇑ᶜorr ρ
+    ⊢ p ∶ᶜ C ⊒ D →
+  ΔL ∣ ΔR ∣ ρ ∣ γ
+    ⊢ L ⊒ L′ ∶ `∀ p ⦂ E ⊒ F →
+  ∃[ χs ] ∃[ N ] ∃[ ΔL′ ] ∃[ ΔR′ ] ∃[ ρ′ ]
+  ∃[ C′ ] ∃[ D′ ] ∃[ r ]
+    (((⇑ᵗᵐ L) •) —↠[ χs ] N) ×
+    (ΔL′ ≡ applyTyCtxs χs (suc ΔL)) ×
+    (ΔR′ ≡ applyTyCtx keep (suc ΔR)) ×
+    (ρ′ ≡ applyRightChange keep
+      (applyLeftChanges χs
+        (matched zero (⇑ᵗ Aα) zero (⇑ᵗ Bα) ∷ ⇑ᶜorr ρ))) ×
+    (C′ ≡ applyTys χs C) ×
+    (D′ ≡ applyTy keep D) ×
+    ΔL′ ∣ ΔR′ ∣ ρ′ ∣ []
+      ⊢ N ⊒ N′ ∶ r ⦂ C′ ⊒ D′
+matched-α-beta-gen-left-ν-widening-call
+    okM target-step γ′≡ endpoints qᶜ pᶜ L⊒L′ =
+  let
+    -- This is the intended bridge to the general Cambridge25 lemma.  The
+    -- remaining holes are precisely the inversions that expose the value `V`,
+    -- the ν-widening cast `gen Aν t`, and the composition witness from the
+    -- matched-α DGG premise.
+    general-leftν =
+      left-ν-widening-lemma
+        {! matched-α-leftν-value !}
+        {! matched-α-leftν-no• !}
+        {! matched-α-leftν-composition !}
+        {! matched-α-leftν-value-relation !}
+  in
+  {! matched-α-beta-gen-left-ν-widening-obligation !}
+
+-- Structural proof skeleton for the intended mutual induction.  The exact
+-- result transports are still the holes in the lemmas above; this
+-- helper records which separated constructors recurse into which premises
+-- before those transports are filled.
+{-# TERMINATING #-}
+left-ν-widening-induction-skeleton :
+  ∀ {ΔL ΔR ρ γ L L′ p A B} →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ B →
+  Set₁
+left-ν-widening-induction-skeleton (⊒blameᵗ _ _) = Set
+left-ν-widening-induction-skeleton (x⊒xᵗ _ _) = Set
+left-ν-widening-induction-skeleton (ƛ⊒ƛᵗ _ N⊒N′) =
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (·⊒·ᵗ _ L⊒L′ M⊒M′) =
+  left-ν-widening-induction-skeleton L⊒L′ ×
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (Λ⊒Λᵗ _ _ _ V⊒V′) =
+  left-ν-widening-induction-skeleton V⊒V′
+left-ν-widening-induction-skeleton (⊒Λᵗ _ _ N⊒V′) =
+  left-ν-widening-induction-skeleton N⊒V′
+left-ν-widening-induction-skeleton (⊒⟨ν⟩ᵗ _ _ _ N⊒V′s) =
+  left-ν-widening-induction-skeleton N⊒V′s
+left-ν-widening-induction-skeleton (α⊒αᵗ _ _ _ _ L⊒L′) =
+  left-ν-widening-induction-skeleton L⊒L′
+left-ν-widening-induction-skeleton (⊒αᵗ _ _ _ L⊒L′) =
+  left-ν-widening-induction-skeleton L⊒L′
+left-ν-widening-induction-skeleton (ν⊒νᵗ _ _ _ N⊒N′) =
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (⊒νᵗ _ _ N⊒N′) =
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (κ⊒κᵗ _ _) = Set
+left-ν-widening-induction-skeleton (⊕⊒⊕ᵗ _ M⊒M′ N⊒N′) =
+  left-ν-widening-induction-skeleton M⊒M′ ×
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (⊒cast+ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (⊒cast-ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (cast+⊒ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (cast-⊒ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′

--- a/GTSF/proof/LeftNuWideningSeparated.agda
+++ b/GTSF/proof/LeftNuWideningSeparated.agda
@@ -79,16 +79,60 @@ left-narrowing-lemma-separated :
 left-narrowing-lemma-separated vV noV compᵏ V⊒V′ =
   {! left-narrowing-lemma-separated-proof !}
 
+-- Structural proof skeleton for the intended mutual induction.  The exact
+-- result transports are still the holes in the lemmas below; this helper
+-- records which separated constructors recurse into which premises before
+-- those transports are filled.
+{-# TERMINATING #-}
+left-ν-widening-induction-skeleton :
+  ∀ {ΔL ΔR ρ γ L L′ p A B} →
+  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ B →
+  Set₁
+left-ν-widening-induction-skeleton (⊒blameᵗ _ _) = Set
+left-ν-widening-induction-skeleton (x⊒xᵗ _ _) = Set
+left-ν-widening-induction-skeleton (ƛ⊒ƛᵗ _ N⊒N′) =
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (·⊒·ᵗ _ L⊒L′ M⊒M′) =
+  left-ν-widening-induction-skeleton L⊒L′ ×
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (Λ⊒Λᵗ _ _ _ V⊒V′) =
+  left-ν-widening-induction-skeleton V⊒V′
+left-ν-widening-induction-skeleton (⊒Λᵗ _ _ N⊒V′) =
+  left-ν-widening-induction-skeleton N⊒V′
+left-ν-widening-induction-skeleton (⊒⟨ν⟩ᵗ _ _ _ N⊒V′s) =
+  left-ν-widening-induction-skeleton N⊒V′s
+left-ν-widening-induction-skeleton (α⊒αᵗ _ _ _ _ L⊒L′) =
+  left-ν-widening-induction-skeleton L⊒L′
+left-ν-widening-induction-skeleton (⊒αᵗ _ _ _ L⊒L′) =
+  left-ν-widening-induction-skeleton L⊒L′
+left-ν-widening-induction-skeleton (ν⊒νᵗ _ _ _ N⊒N′) =
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (⊒νᵗ _ _ N⊒N′) =
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (κ⊒κᵗ _ _) = Set
+left-ν-widening-induction-skeleton (⊕⊒⊕ᵗ _ M⊒M′ N⊒N′) =
+  left-ν-widening-induction-skeleton M⊒M′ ×
+  left-ν-widening-induction-skeleton N⊒N′
+left-ν-widening-induction-skeleton (⊒cast+ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (⊒cast-ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (cast+⊒ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+left-ν-widening-induction-skeleton (cast-⊒ᵗ _ _ _ _ M⊒M′) =
+  left-ν-widening-induction-skeleton M⊒M′
+
 -- Cambridge25-shaped value-level lemma.  The premise relation is the
 -- polymorphic value relation `V ⊒ V′ : ∀ p`; the source term adds the
 -- dual of the left widening cast `t`; and the composition witness pins the
 -- resulting index `r`.  The ν-specific instantiation is supplied by the
 -- caller through the shape of `t`, `r`, and the composition witness.
 --
--- This is intentionally more general than the DGG call-site theorem below:
--- it does not mention the target `β-gen•` step or the matched-α type
--- application.  Those belong to the caller that exposes where this lemma is
--- needed.
+-- This is the generalized Agda surface for the Cambridge25 ν instance:
+-- the statement quantifies over the left widening cast `t`, with the
+-- ν-specific case recovered when `t` is the widening form whose dual is
+-- the source-side `gen` cast.  The DGG call-site theorem below supplies
+-- that shape, the target `β-gen•` step, and the matched-α type application.
 left-ν-widening-lemma :
   ∀ {ΔL ΔR ρ V V′ p r t A B C D} →
   Value V →
@@ -171,8 +215,20 @@ left-ν-widening-lemma vV noV compᵏ
         Vcast⊒V′
   in
   {! leftν-cast-⊒-case !}
-left-ν-widening-lemma vV noV compᵏ V⊒V′ =
-  {! left-ν-widening-remaining-case !}
+left-ν-widening-lemma vV noV compᵏ
+    (⊒αᵗ γ′≡ endpoints pᶜ L⊒L′) =
+  let
+    ih = left-ν-widening-induction-skeleton L⊒L′
+  in
+  {! leftν-⊒α-target-only-case !}
+left-ν-widening-lemma vV noV compᵏ
+    (⊒νᵗ endpoints pᶜ N⊒N′) =
+  let
+    ih = left-ν-widening-induction-skeleton N⊒N′
+  in
+  {! leftν-⊒ν-target-only-case !}
+left-ν-widening-lemma vV noV compᵏ (⊒blameᵗ V⊢ rᶜ) =
+  {! leftν-⊒blame-base-case !}
 
 -- DGG call-site obligation for the separated `α⊒αᵗ` / `β-gen•` case.
 -- The source begins at the matched fresh α type application
@@ -223,46 +279,3 @@ matched-α-beta-gen-left-ν-widening-call
         {! matched-α-leftν-value-relation !}
   in
   {! matched-α-beta-gen-left-ν-widening-obligation !}
-
--- Structural proof skeleton for the intended mutual induction.  The exact
--- result transports are still the holes in the lemmas above; this
--- helper records which separated constructors recurse into which premises
--- before those transports are filled.
-{-# TERMINATING #-}
-left-ν-widening-induction-skeleton :
-  ∀ {ΔL ΔR ρ γ L L′ p A B} →
-  ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ B →
-  Set₁
-left-ν-widening-induction-skeleton (⊒blameᵗ _ _) = Set
-left-ν-widening-induction-skeleton (x⊒xᵗ _ _) = Set
-left-ν-widening-induction-skeleton (ƛ⊒ƛᵗ _ N⊒N′) =
-  left-ν-widening-induction-skeleton N⊒N′
-left-ν-widening-induction-skeleton (·⊒·ᵗ _ L⊒L′ M⊒M′) =
-  left-ν-widening-induction-skeleton L⊒L′ ×
-  left-ν-widening-induction-skeleton M⊒M′
-left-ν-widening-induction-skeleton (Λ⊒Λᵗ _ _ _ V⊒V′) =
-  left-ν-widening-induction-skeleton V⊒V′
-left-ν-widening-induction-skeleton (⊒Λᵗ _ _ N⊒V′) =
-  left-ν-widening-induction-skeleton N⊒V′
-left-ν-widening-induction-skeleton (⊒⟨ν⟩ᵗ _ _ _ N⊒V′s) =
-  left-ν-widening-induction-skeleton N⊒V′s
-left-ν-widening-induction-skeleton (α⊒αᵗ _ _ _ _ L⊒L′) =
-  left-ν-widening-induction-skeleton L⊒L′
-left-ν-widening-induction-skeleton (⊒αᵗ _ _ _ L⊒L′) =
-  left-ν-widening-induction-skeleton L⊒L′
-left-ν-widening-induction-skeleton (ν⊒νᵗ _ _ _ N⊒N′) =
-  left-ν-widening-induction-skeleton N⊒N′
-left-ν-widening-induction-skeleton (⊒νᵗ _ _ N⊒N′) =
-  left-ν-widening-induction-skeleton N⊒N′
-left-ν-widening-induction-skeleton (κ⊒κᵗ _ _) = Set
-left-ν-widening-induction-skeleton (⊕⊒⊕ᵗ _ M⊒M′ N⊒N′) =
-  left-ν-widening-induction-skeleton M⊒M′ ×
-  left-ν-widening-induction-skeleton N⊒N′
-left-ν-widening-induction-skeleton (⊒cast+ᵗ _ _ _ _ M⊒M′) =
-  left-ν-widening-induction-skeleton M⊒M′
-left-ν-widening-induction-skeleton (⊒cast-ᵗ _ _ _ _ M⊒M′) =
-  left-ν-widening-induction-skeleton M⊒M′
-left-ν-widening-induction-skeleton (cast+⊒ᵗ _ _ _ _ M⊒M′) =
-  left-ν-widening-induction-skeleton M⊒M′
-left-ν-widening-induction-skeleton (cast-⊒ᵗ _ _ _ _ M⊒M′) =
-  left-ν-widening-induction-skeleton M⊒M′


### PR DESCRIPTION
## Summary

- Adds `proof.LeftNuWideningSeparated` with separated-store statements for
  the Cambridge25 left widening, left narrowing, and Left ν Widening surfaces.
- Gives the actual `left-ν-widening-lemma` proof skeleton constructor cases
  with recursive IH calls through the companion left-widening/left-narrowing
  lemma surfaces for the translated Cambridge25 cases.
- Removes the old `left-ν-widening-remaining-case` catch-all: target-only
  `⊒αᵗ`/`⊒νᵗ` and the `⊒blameᵗ` base case are now explicit, with recursive
  premises routed through `left-ν-widening-induction-skeleton` where the
  current value-level theorem surface cannot directly call the companion
  lemma.
- Splits the separated DGG `α⊒αᵗ` / `pure-step` case to expose the
  `β-gen•` redex and route it through the matched-α Left ν Widening call-site
  obligation.
- Updates the now-existing `DGGSepStatus.md` from `main` to record the new
  lemma surface and affected DGG cases.

## Notes

- The nearby `⊒αᵗ` target-only DGG case remains a separate
  `target-seal-pure-step-simulation` obligation; the lemma skeleton now exposes
  its value-level counterpart separately rather than hiding it in a catch-all.
- The `⊒cast-ᵗ {t = inst ...}` / `β-inst` case remains the standalone
  `target-cast-minus-inst-nu-relation` obligation rather than the outer
  matched-α redex.

## Validation

- `agda -v0 proof/LeftNuWideningSeparated.agda`
- `git diff --check`
- Attempted `agda -v0 proof/DynamicGradualGuaranteeSeparated.agda`; it stayed
  silent for several minutes and was interrupted, so this PR does not claim
  that full DGG file check as passing.

## Codex session

codex://threads/019f378a-ccf1-70f1-881c-eb850fc700cb

```sh
open 'codex://threads/019f378a-ccf1-70f1-881c-eb850fc700cb'
```
