### PR TITLE
Fill the sim-betaᵐ arrow cast bodies via the ⨟ˡ record projections

### DIFF
--- a/GTSF/MediatedNarrowing.agda
+++ b/GTSF/MediatedNarrowing.agda
@@ -150,6 +150,42 @@ fun-narrow-codomainᵐᶜ
       (cast-fun p⊢ q⊢ , cross (pʷ ↦ⁿʷ qⁿ))) =
   stores , hB , hB′ , _ , medB , (q⊢ , qⁿ)
 
+-- Mode-generic variants of the two projections above, for the cast
+-- evidences the sim-beta cast branches project (their mode is the
+-- cast rule's implicit, not tag-or-idᵈ).
+fun-narrow-domain-dual-typingᵐ :
+  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
+  (p↦q⊒ : μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q
+             ∶ (A ⇒ B) ⊒ᵐ (A′ ⇒ B′)) →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ fun-narrow-domain-dualᵐ p↦q⊒ ∶ A ⊒ᵐ A′
+fun-narrow-domain-dual-typingᵐ {μ = μ}
+    (stores , wf⇒ hA hB , wf⇒ hA′ hB′ , _ ,
+      med-⇒ medA medB ,
+      (cast-fun p⊢ q⊢ , cross (pʷ ↦ⁿʷ qⁿ))) =
+  stores ,
+  hA ,
+  hA′ ,
+  _ ,
+  medA ,
+  dualʷ-flips-typingᵐ
+    {μ = μ}
+    {η = normalᵃ}
+    {ν = μ}
+    dualActionOk-normal
+    dualStoreAt-normal
+    (rightStore-wf stores)
+    (p⊢ , pʷ)
+
+fun-narrow-codomainᵐ :
+  ∀ {μ ΔL ΔR ρ p q A A′ B B′} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ (A ⇒ B) ⊒ᵐ (A′ ⇒ B′) →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ q ∶ B ⊒ᵐ B′
+fun-narrow-codomainᵐ
+    (stores , wf⇒ hA hB , wf⇒ hA′ hB′ , _ ,
+      med-⇒ medA medB ,
+      (cast-fun p⊢ q⊢ , cross (pʷ ↦ⁿʷ qⁿ))) =
+  stores , hB , hB′ , _ , medB , (q⊢ , qⁿ)
+
 ------------------------------------------------------------------------
 -- Composition side conditions
 ------------------------------------------------------------------------

--- a/GTSF/Mediation.agda
+++ b/GTSF/Mediation.agda
@@ -197,6 +197,43 @@ medTy-⇑ :
   ∀ {V A B} → MedTy V A B → MedTy (ExtVar V) (⇑ᵗ A) (⇑ᵗ B)
 medTy-⇑ = medTy-map² suc suc ev-suc
 
+-- The binder extension of a left-sided variable-correspondence map,
+-- hoisted from the `where` blocks above for reuse by `medCo-mapˡ`.
+extVar-mapˡ :
+  ∀ {V W : VarCorr} (r : Renameᵗ) →
+  (∀ {α β} → V α β → W (r α) β) →
+  ∀ {α β} → ExtVar V α β → ExtVar W (extᵗ r α) β
+extVar-mapˡ r f ev-zero = ev-zero
+extVar-mapˡ r f (ev-suc v) = ev-suc (f v)
+
+-- The coercion sibling of `medTy-mapˡ`: renaming the left raw of a
+-- mediated coercion pair along a variable-correspondence map.
+medCo-mapˡ :
+  ∀ {V W : VarCorr} (r : Renameᵗ) →
+  (∀ {α β} → V α β → W (r α) β) →
+  ∀ {c c′} → MedCo V c c′ → MedCo W (renameᶜ r c) c′
+medCo-mapˡ r f (medc-id med) = medc-id (medTy-mapˡ r f med)
+medCo-mapˡ r f (medc-seq ms mt) =
+  medc-seq (medCo-mapˡ r f ms) (medCo-mapˡ r f mt)
+medCo-mapˡ r f (medc-fun ms mt) =
+  medc-fun (medCo-mapˡ r f ms) (medCo-mapˡ r f mt)
+medCo-mapˡ {V} {W} r f (medc-all ms) =
+  medc-all (medCo-mapˡ (extᵗ r) (extVar-mapˡ {V} {W} r f) ms)
+medCo-mapˡ r f (medc-tag med) = medc-tag (medTy-mapˡ r f med)
+medCo-mapˡ r f (medc-untag med) = medc-untag (medTy-mapˡ r f med)
+medCo-mapˡ r f (medc-seal v med) =
+  medc-seal (f v) (medTy-mapˡ r f med)
+medCo-mapˡ r f (medc-unseal v med) =
+  medc-unseal (f v) (medTy-mapˡ r f med)
+medCo-mapˡ {V} {W} r f (medc-gen med ms) =
+  medc-gen
+    (medTy-mapˡ r f med)
+    (medCo-mapˡ (extᵗ r) (extVar-mapˡ {V} {W} r f) ms)
+medCo-mapˡ {V} {W} r f (medc-inst med ms) =
+  medc-inst
+    (medTy-mapˡ r f med)
+    (medCo-mapˡ (extᵗ r) (extVar-mapˡ {V} {W} r f) ms)
+
 ------------------------------------------------------------------------
 -- Allocation-shaped inclusions on MatchedVar
 ------------------------------------------------------------------------

--- a/GTSF/proof/MediationProperties.agda
+++ b/GTSF/proof/MediationProperties.agda
@@ -20,18 +20,42 @@ open import Relation.Binary.PropositionalEquality using
 
 open import Types
 open import Coercions
-open import NarrowWiden using (Narrowing; _∣_∣_⊢_∶_⊒_)
+open import Store using (StoreWfAt)
+open import NarrowWiden using
+  ( Narrowing
+  ; Widening
+  ; cross
+  ; dualʷ
+  ; dualⁿ
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+  renaming (_↦_ to _↦ⁿʷ_)
 open import NuReduction using
   (StoreChange; keep; bind; StoreChanges;
-   applyTy; applyTys; applyTyCtx; applyTyCtxs; applyCoercion)
+   applyTy; applyTys; applyTyCtx; applyTyCtxs; applyCoercion;
+   applyStores; applyTerms)
 open import StoreCorrespondence
 open import Mediation
 open import MediatedNarrowing
+open import proof.TypeProperties using (predᵗ)
+open import proof.CoercionProperties using
+  ( dualActionOk-normal
+  ; dualStoreAt-normal
+  )
+open import proof.NarrowWidenProperties using
+  ( dualʷ-flips-typingᵐ
+  )
+open import proof.ReductionProperties using (applyCoercions)
 open import proof.CatchupSeparated using
   ( applyLeftChange
   ; applyLeftChanges
   ; applyRightChange
   ; rightStore-applyLeftChange
+  ; leftStore-applyLeftChanges
+  )
+open import proof.LeftChangeNarrowingSeparated using
+  ( dualʷ-raw-determined
   )
 
 ------------------------------------------------------------------------
@@ -270,3 +294,251 @@ right-change-transportᵐ keep {μ = μ}
   μ , (corr′ , wfA , wfB , Aʳ , med , r⊒)
 right-change-transportᵐ (bind X) {μ = μ} corr′ ev =
   instᵈ μ , right-alloc-transportᵐ corr′ ev
+
+------------------------------------------------------------------------
+-- Mediation and coercion duals
+------------------------------------------------------------------------
+
+-- MedCo is closed under the grammar-directed duals: dualizing a pair
+-- of mediated raws (each through its own side's witness) yields
+-- mediated raws again.  Shape-only structural transport over the
+-- witness grammars, like `med-narrowing-witness`; left as a named
+-- hole.  (A direct proof generalizes the two dual-action
+-- environments over a correspondence invariant — `normalᵃ` turns
+-- into `extᵃ`/`genᵃ`/`instᵃ` on both sides in lockstep with the
+-- `ExtVar` binder extension of the variable correspondence.)
+medCo-dualʷ :
+  ∀ {V c c′} →
+  MedCo V c c′ →
+  (w : Widening c) →
+  (w′ : Widening c′) →
+  MedCo V (proj₁ (dualʷ normalᵃ w)) (proj₁ (dualʷ normalᵃ w′))
+medCo-dualʷ med w w′ = {! medCo-dualʷ !}
+
+------------------------------------------------------------------------
+-- One-store left transports (source-cast evidence)
+------------------------------------------------------------------------
+
+-- The deterministic mode-environment image of a store change: `bind`
+-- shifts the store, so the modes of the old variables are read one
+-- binder down (this is the mode `applyCoercion-typing` produces).
+-- Exposed as a function so the three factors of a transported
+-- composition record stay at ONE shared mode environment.
+applyModeEnv : StoreChange → ModeEnv → ModeEnv
+applyModeEnv keep μ = μ
+applyModeEnv (bind A) μ = λ Y → μ (predᵗ Y)
+
+applyModeEnvs : StoreChanges → ModeEnv → ModeEnv
+applyModeEnvs [] μ = μ
+applyModeEnvs (χ ∷ χs) μ = applyModeEnvs χs (applyModeEnv χ μ)
+
+-- One-store transport of a left-store narrowing judgment across
+-- emitted left store changes: raw, endpoints, and store shift
+-- together (contrast `left-changes-transportᵐ`, where the home raw
+-- is untouched).  Base-language plumbing — `applyCoercion-typing`
+-- shapes plus the `renameⁿ` witness renaming; hole-bodied pending
+-- the store-wf chaining question recorded in the checklist.
+left-changes-narrowingˡ :
+  ∀ χs {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  applyModeEnvs χs μ ∣ applyTyCtxs χs Δ ∣ applyStores χs Σ
+    ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ applyTys χs B
+left-changes-narrowingˡ χs c⊒ = {! left-changes-narrowingˡ !}
+
+-- The dual raw of a narrowing is determined by the raw alone and
+-- commutes with the store-change shifts.  Stated over two
+-- independent witnesses (at `χs = []` this is a narrowing sibling of
+-- `dualʷ-raw-determined`).
+narrowing-dual¹-applyCoercions :
+  ∀ χs {μ μ′ Δ Δ′ Σ Σ′ c A B A′ B′} →
+  (e : μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B) →
+  (e′ : μ′ ∣ Δ′ ∣ Σ′ ⊢ applyCoercions χs c ∶ A′ ⊒ B′) →
+  narrowing-dual¹ e′ ≡ applyCoercions χs (narrowing-dual¹ e)
+narrowing-dual¹-applyCoercions χs e e′ =
+  {! narrowing-dual¹-applyCoercions !}
+
+------------------------------------------------------------------------
+-- One-store arrow projections
+------------------------------------------------------------------------
+
+-- The domain dual of one-store arrow cast evidence: the raw that
+-- β-↦ exposes as the argument-position cast when the source function
+-- is a casted value.
+fun-narrow-domain-dual¹ :
+  ∀ {μ Δ Σ c d A B A′ B′} →
+  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Coercion
+fun-narrow-domain-dual¹ (cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) =
+  proj₁ (dualʷ normalᵃ cʷ)
+
+fun-narrow-domain-dual-typing¹ :
+  ∀ {μ Δ Σ c d A B A′ B′} →
+  StoreWfAt Δ Σ →
+  (e : μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+  μ ∣ Δ ∣ Σ ⊢ fun-narrow-domain-dual¹ e ∶ A ⊒ A′
+fun-narrow-domain-dual-typing¹ {μ = μ} wfΣ
+    (cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) =
+  dualʷ-flips-typingᵐ
+    {μ = μ}
+    {η = normalᵃ}
+    {ν = μ}
+    dualActionOk-normal
+    dualStoreAt-normal
+    wfΣ
+    (c⊢ , cʷ)
+
+fun-narrow-codomain¹ :
+  ∀ {μ Δ Σ c d A B A′ B′} →
+  μ ∣ Δ ∣ Σ ⊢ c ↦ d ∶ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ B ⊒ B′
+fun-narrow-codomain¹ (cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) =
+  d⊢ , dⁿ
+
+------------------------------------------------------------------------
+-- Source-side composition record projections (⨟ˡ)
+------------------------------------------------------------------------
+
+-- Domain-dual projection of an arrow-level source composition.  The
+-- record's left images are inverted field-wise (MedCo/MedTy are
+-- structural, so the left images of arrow raws are arrows), their
+-- domain widenings are dualized in the left store, and the mediation
+-- of the dual raws comes from `medCo-dualʷ`.  This answers the
+-- recorded open question positively: the ⨟ˡ record's fields DO
+-- produce the inner-domain composition that the argument-cast node
+-- of `sim-betaᵐ` needs, with no field change.
+comp-src-fun-domain-dualᵐ :
+  ∀ {μ₁ μ₂ η ΔL ΔR ρ cₛ dₛ p₁ q₁ p₂ q₂
+     A₀ B₀ AL BL AR BR A₁ B₁ A₁′ B₁′ A₂ B₂ A₂′ B₂′} →
+  StoreCorr ΔL ΔR ρ →
+  ΔL ∣ ΔR ∣ ρ ⊢ (cₛ ↦ dₛ) ⨟ˡ (p₁ ↦ q₁) ≈ (p₂ ↦ q₂)
+    ∶ (A₀ ⇒ B₀) ⊒ᵐ (AR ⇒ BR) →
+  (s⊒ˡ : η ∣ ΔL ∣ leftStore ρ ⊢ cₛ ↦ dₛ
+           ∶ (A₀ ⇒ B₀) ⊒ (AL ⇒ BL)) →
+  (e₁ : μ₁ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p₁ ↦ q₁
+          ∶ (A₁ ⇒ B₁) ⊒ᵐ (A₁′ ⇒ B₁′)) →
+  (e₂ : μ₂ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p₂ ↦ q₂
+          ∶ (A₂ ⇒ B₂) ⊒ᵐ (A₂′ ⇒ B₂′)) →
+  ΔL ∣ ΔR ∣ ρ
+    ⊢ fun-narrow-domain-dual¹ s⊒ˡ
+        ⨟ˡ fun-narrow-domain-dualᵐ e₁
+        ≈ fun-narrow-domain-dualᵐ e₂ ∶ A₀ ⊒ᵐ AR
+comp-src-fun-domain-dualᵐ {ρ = ρ} corr
+    (composed-index-src {νᶜᵒᵐᵖ = ν}
+      (med-⇒ mAR mBR)
+      (medc-fun mp₁ mq₁)
+      (medc-fun mp₂ mq₂)
+      (cast-fun cₛ⊢ᶠ dₛ⊢ᶠ , cross (cₛʷᶠ ↦ⁿʷ dₛⁿᶠ))
+      (cast-fun p₁ᴸ⊢ q₁ᴸ⊢ , cross (p₁ᴸʷ ↦ⁿʷ q₁ᴸⁿ))
+      (cast-fun p₂ᴸ⊢ q₂ᴸ⊢ , cross (p₂ᴸʷ ↦ⁿʷ q₂ᴸⁿ)))
+    (cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ))
+    (_ , _ , _ , _ , med-⇒ _ _ ,
+      (cast-fun p₁⊢ q₁⊢ , cross (p₁ʷ ↦ⁿʷ q₁ⁿ)))
+    (_ , _ , _ , _ , med-⇒ _ _ ,
+      (cast-fun p₂⊢ q₂⊢ , cross (p₂ʷ ↦ⁿʷ q₂ⁿ))) =
+  composed-index-src
+    mAR
+    (medCo-dualʷ mp₁ p₁ᴸʷ p₁ʷ)
+    (medCo-dualʷ mp₂ p₂ᴸʷ p₂ʷ)
+    (subst
+      (λ c₀ → ν ∣ _ ∣ leftStore ρ ⊢ c₀ ∶ _ ⊒ _)
+      (dualʷ-raw-determined normalᵃ cₛʷᶠ cʷ)
+      (dualʷ-flips-typingᵐ
+        {μ = ν} {η = normalᵃ} {ν = ν}
+        dualActionOk-normal
+        dualStoreAt-normal
+        (leftStore-wf corr)
+        (cₛ⊢ᶠ , cₛʷᶠ)))
+    (dualʷ-flips-typingᵐ
+      {μ = ν} {η = normalᵃ} {ν = ν}
+      dualActionOk-normal
+      dualStoreAt-normal
+      (leftStore-wf corr)
+      (p₁ᴸ⊢ , p₁ᴸʷ))
+    (dualʷ-flips-typingᵐ
+      {μ = ν} {η = normalᵃ} {ν = ν}
+      dualActionOk-normal
+      dualStoreAt-normal
+      (leftStore-wf corr)
+      (p₂ᴸ⊢ , p₂ᴸʷ))
+
+-- Codomain projection of an arrow-level source composition: pure
+-- field inversion — every output field is a sub-field of the input
+-- record.
+comp-src-fun-codomainᵐ :
+  ∀ {ΔL ΔR ρ cₛ dₛ p₁ q₁ p₂ q₂ A₀ B₀ AR BR} →
+  ΔL ∣ ΔR ∣ ρ ⊢ (cₛ ↦ dₛ) ⨟ˡ (p₁ ↦ q₁) ≈ (p₂ ↦ q₂)
+    ∶ (A₀ ⇒ B₀) ⊒ᵐ (AR ⇒ BR) →
+  ΔL ∣ ΔR ∣ ρ ⊢ dₛ ⨟ˡ q₁ ≈ q₂ ∶ B₀ ⊒ᵐ BR
+comp-src-fun-codomainᵐ
+    (composed-index-src
+      (med-⇒ mAR mBR)
+      (medc-fun mp₁ mq₁)
+      (medc-fun mp₂ mq₂)
+      (cast-fun cₛ⊢ᶠ dₛ⊢ᶠ , cross (cₛʷᶠ ↦ⁿʷ dₛⁿᶠ))
+      (cast-fun p₁ᴸ⊢ q₁ᴸ⊢ , cross (p₁ᴸʷ ↦ⁿʷ q₁ᴸⁿ))
+      (cast-fun p₂ᴸ⊢ q₂ᴸ⊢ , cross (p₂ᴸʷ ↦ⁿʷ q₂ᴸⁿ))) =
+  composed-index-src
+    mBR
+    mq₁
+    mq₂
+    (dₛ⊢ᶠ , dₛⁿᶠ)
+    (q₁ᴸ⊢ , q₁ᴸⁿ)
+    (q₂ᴸ⊢ , q₂ᴸⁿ)
+
+------------------------------------------------------------------------
+-- Left-change transports of the ⨟ˡ record and the term relation
+------------------------------------------------------------------------
+
+medCo-applyLeftChanges :
+  ∀ χs {ρ c cʳ} →
+  MedCo (MatchedVar ρ) c cʳ →
+  MedCo (MatchedVar (applyLeftChanges χs ρ)) (applyCoercions χs c) cʳ
+medCo-applyLeftChanges [] med = med
+medCo-applyLeftChanges (keep ∷ χs) med =
+  medCo-applyLeftChanges χs med
+medCo-applyLeftChanges (bind X ∷ χs) med =
+  medCo-applyLeftChanges χs (medCo-mapˡ suc mv-left-alloc med)
+
+-- A source-cast composition record crosses left store changes
+-- field-wise: the left images and their typings shift with the left
+-- store, while the mediated (home) raws are untouched.
+left-changes-comp-srcᵐ :
+  ∀ χs {ΔL ΔR ρ s q r A B} →
+  ΔL ∣ ΔR ∣ ρ ⊢ s ⨟ˡ q ≈ r ∶ A ⊒ᵐ B →
+  applyTyCtxs χs ΔL ∣ ΔR ∣ applyLeftChanges χs ρ
+    ⊢ applyCoercions χs s ⨟ˡ q ≈ r ∶ applyTys χs A ⊒ᵐ B
+left-changes-comp-srcᵐ χs {ΔL = ΔL} {ρ = ρ}
+    (composed-index-src {νᶜᵒᵐᵖ = ν} med-B med-q med-r s⊒ˡ q⊒ˡ r⊒ˡ) =
+  composed-index-src
+    (medTy-applyLeftChanges χs med-B)
+    (medCo-applyLeftChanges χs med-q)
+    (medCo-applyLeftChanges χs med-r)
+    (reindex (left-changes-narrowingˡ χs s⊒ˡ))
+    (reindex (left-changes-narrowingˡ χs q⊒ˡ))
+    (reindex (left-changes-narrowingˡ χs r⊒ˡ))
+  where
+  reindex :
+    ∀ {c A B} →
+    applyModeEnvs χs ν ∣ applyTyCtxs χs ΔL ∣ applyStores χs (leftStore ρ)
+      ⊢ c ∶ A ⊒ B →
+    applyModeEnvs χs ν ∣ applyTyCtxs χs ΔL
+      ∣ leftStore (applyLeftChanges χs ρ) ⊢ c ∶ A ⊒ B
+  reindex =
+    subst
+      (λ Σ → applyModeEnvs χs ν ∣ applyTyCtxs χs ΔL ∣ Σ ⊢ _ ∶ _ ⊒ _)
+      (sym (leftStore-applyLeftChanges χs ρ))
+
+-- The mediated term-relation transport across left store changes:
+-- the ⊒ᵐ replacement for the old postulated
+-- `left-change-term-narrowing`.  Note the index raw `p` is untouched
+-- — the point of the mediated design.  Structural induction over the
+-- relation (binder cases shift the correspondence); hole-bodied, to
+-- be discharged with the rest of the mediated left-change family.
+left-changes-term-narrowingᵐ :
+  ∀ χs {ΔL ΔR ρ M M′ p A B} →
+  StoreCorr (applyTyCtxs χs ΔL) ΔR (applyLeftChanges χs ρ) →
+  ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ M ⊒ M′ ∶ p ⦂ A ⊒ᵐ B →
+  applyTyCtxs χs ΔL ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+    ⊢ applyTerms χs M ⊒ M′ ∶ p ⦂ applyTys χs A ⊒ᵐ B
+left-changes-term-narrowingᵐ χs corr M⊒M′ =
+  {! left-changes-term-narrowingᵐ !}

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -419,6 +419,50 @@ DGG proof stack (`SimBeta`, `DGGBeta*`, the main theorem) file by
 file, and finally delete `TermNarrowingSeparated`'s two-store
 judgment and relation.
 
+Migration step 2 progress (2026-07-06, sim-betaᵐ cast bodies): the
+two real source-cast arrow branches of `sim-betaᵐ` (the `cast+⊒ᵗ` and
+`cast-⊒ᵗ` clauses at `s = cₛ ↦ dₛ`) are filled, mirroring the old
+proof's shape — β-↦, an argument-position cast node at the inner
+domain, catchup, recursion, then the codomain tail — with the index
+plumbing collapsed: the recursion's conclusion keeps the original
+codomain raw, so the `applyCoercions-++`/dual-commutation rewrites of
+the old proof survive only at the two term-level cast positions.
+
+- The recorded open question about the `⨟ˡ` record is **answered
+  positively — no field change is needed**.  The argument-cast node's
+  `∶ᶜ` inner-domain index comes straight off the constructor's own
+  `∶ᶜ` premise (`fun-narrow-domain-dual-typingᵐᶜ`), and the record's
+  fields project to the domain-dual composition by pure inversion
+  (`proof/MediationProperties.comp-src-fun-domain-dualᵐ`): MedCo/
+  MedTy are structural, so the left images of arrow raws are arrows,
+  and their domain factors dualize in the left store.  The only new
+  mediation metatheory is `medCo-dualʷ` — MedCo is closed under the
+  grammar-directed duals — a shape-only structural lemma left as a
+  named hole (same flavor as `med-narrowing-witness`).  The codomain
+  projection (`comp-src-fun-codomainᵐ`) is pure field inversion, no
+  new lemmas.
+- The exotic source-cast shapes are refuted locally, without the old
+  canonical-⇒/FunView detour: seq(？︔) by its ★-sourced untag
+  typing, seq(︔seal)/gen/seal by computing their duals through
+  `normalᵃ` to non-inert raws (the Value premise refutes), and the
+  non-arrow inner-index shapes through the mediated evidence — the
+  structural `MedTy` of the arrow middle type refutes the ★/seal-
+  variable/∀ mediated sources that ？/unseal/inst/？︔ force.
+- New hole-bodied plumbing in `proof/MediationProperties.agda`, to be
+  discharged with the mediated left-change family: `medCo-dualʷ`,
+  `left-changes-narrowingˡ` (one-store left transport; NOTE the
+  store-wf chaining question — iterating `applyCoercion-typing` needs
+  well-formedness of the bound types at each intermediate step, which
+  a bare `StoreChanges` does not carry), its dual-raw commutation
+  `narrowing-dual¹-applyCoercions`, and the term-relation transport
+  `left-changes-term-narrowingᵐ` (the ⊒ᵐ replacement of the old
+  postulated `left-change-term-narrowing`; the index raw is
+  untouched).  Proved outright: `medCo-mapˡ`/`extVar-mapˡ`
+  (`Mediation.agda`), `medCo-applyLeftChanges`, the ⨟ˡ record
+  transport `left-changes-comp-srcᵐ`, the one-store arrow
+  projections, and the mode-generic `fun-narrow-codomainᵐ`/
+  `fun-narrow-domain-dual-typingᵐ`.
+
 ## Track C. Catchup Proof
 
 - [x] Add right-side store-change operations.

--- a/GTSF/proof/SimBetaMediated.agda
+++ b/GTSF/proof/SimBetaMediated.agda
@@ -14,40 +14,77 @@ module proof.SimBetaMediated where
 --     `left-change-fun-coercion-narrowing` postulate) through every
 --     cast branch; the mediated conclusion keeps the original `q`,
 --     since source store changes never touch a mediated index raw
---     (`left-changes-transportᵐ`).  The proof skeleton splits on the
---     function relation like the old proof; the branch bodies migrate
---     incrementally from SimBetaSeparated.
+--     (`left-changes-transportᵐ`).  The proof splits on the function
+--     relation like the old proof; all branches are filled — the two
+--     arrow cast branches recurse through catchup and the ⨟ˡ record
+--     projections, and the exotic coercion shapes are refuted locally
+--     by their own witnesses (no canonical-⇒/FunView detour).
 
 open import Agda.Builtin.Equality using (_≡_; refl)
-open import Data.List using ([]; _∷_)
-open import Data.Product using (_×_; _,_; ∃-syntax)
-open import Relation.Binary.PropositionalEquality using (subst)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Product using
+  (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
-open import NarrowWiden using (cross) renaming (_↦_ to _↦ⁿʷ_)
+open import NarrowWiden using
+  (cross; dualⁿ; dualʷ; sealⁿ; _︔seal_; _？︔_; _∣_∣_⊢_∶_⊒_)
+  renaming (_↦_ to _↦ⁿʷ_; gen to genⁿʷ)
 open import NuTerms
 open import NuReduction
 open import StoreCorrespondence
 open import Mediation
 open import MediatedNarrowing
 open import TermNarrowingSeparated using (ctx-entry)
-open import proof.CatchupSeparated using (applyLeftChanges)
+open import proof.CatchupSeparated using
+  ( applyLeftChanges
+  ; applyLeftChanges-++
+  ; leftStore-applyLeftChanges
+  )
 open import proof.CatchupMediated using (catchup-lemmaᵐ)
 open import proof.MediationProperties using
   ( left-changes-transportᵐ
+  ; applyModeEnvs
+  ; left-changes-narrowingˡ
+  ; left-changes-comp-srcᵐ
+  ; left-changes-term-narrowingᵐ
+  ; narrowing-dual¹-applyCoercions
+  ; fun-narrow-domain-dual¹
+  ; fun-narrow-domain-dual-typing¹
+  ; comp-src-fun-domain-dualᵐ
+  ; comp-src-fun-codomainᵐ
+  )
+open import proof.ReductionProperties using
+  ( applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyCoercions
+  ; applyCoercions-++
+  ; applyTys-++
+  ; applyTyCtxs-++
+  ; cast-↠
+  ; ↠-trans
+  ; ·₂-↠
   )
 open import proof.LeftChangeNarrowingSeparated using
   ( dualʷ-raw-determined
+  ; dualʷ-involutive-raw
+  ; applyTys-⇒
+  ; no•-cast-inv
   )
 
--- The domain dual of a mediated arrow index is witness- and
--- mode-independent: it is computed from the home witness of the raw,
--- and dual raws are determined across witnesses.
+-- The domain dual of a mediated arrow index is witness-, mode-, and
+-- store-independent: it is computed from the home witness of the
+-- raw, and dual raws are determined across witnesses.  (The two
+-- evidences may live at different stores — the transported inner
+-- index of the recursion is compared against the original.)
 fun-narrow-domain-dualᵐ-determined :
-  ∀ {μ₁ μ₂ ΔL ΔR ρ p q A A′ B B′ A₁ A₁′ B₁ B₁′} →
-  (e₁ : μ₁ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ (A ⇒ B) ⊒ᵐ (A′ ⇒ B′)) →
-  (e₂ : μ₂ ∣ ΔL ∣ ΔR ∣ ρ ⊢ p ↦ q ∶ (A₁ ⇒ B₁) ⊒ᵐ (A₁′ ⇒ B₁′)) →
+  ∀ {μ₁ μ₂ ΔL₁ ΔR₁ ρ₁ ΔL₂ ΔR₂ ρ₂ p q
+     A A′ B B′ A₁ A₁′ B₁ B₁′} →
+  (e₁ : μ₁ ∣ ΔL₁ ∣ ΔR₁ ∣ ρ₁ ⊢ p ↦ q ∶ (A ⇒ B) ⊒ᵐ (A′ ⇒ B′)) →
+  (e₂ : μ₂ ∣ ΔL₂ ∣ ΔR₂ ∣ ρ₂ ⊢ p ↦ q ∶ (A₁ ⇒ B₁) ⊒ᵐ (A₁′ ⇒ B₁′)) →
   fun-narrow-domain-dualᵐ e₁ ≡ fun-narrow-domain-dualᵐ e₂
 fun-narrow-domain-dualᵐ-determined
     (_ , _ , _ , _ , _ , (_ , cross (p₁ʷ ↦ⁿʷ _)))
@@ -66,6 +103,121 @@ postulate
     ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ V ⊒ V′ ∶ p ⦂ A ⊒ᵐ A′ →
     ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ N [ V ] ⊒ N′ [ V′ ] ∶ q ⦂ B ⊒ᵐ B′
 
+-- The codomain tail of a source-cast branch (cast+⊒ᵗ shape): after
+-- the recursion returns the beta result at the inner codomain, wrap
+-- it with the shifted dual of the source cast's codomain factor.
+-- All the codomain-side evidence enters at the ORIGINAL stores and
+-- is transported across the accumulated left changes here — hoisted
+-- out of the clause bodies as in the old proof (elaboration size).
+sim-betaᵐ-cast-plus-tail :
+  ∀ χs {ΔL ΔR ρ ΔL′ ρ′ N NL VR qᵢ q dₛ Bₒ BL BR μO ηC} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  ρ′ ≡ applyLeftChanges χs ρ →
+  StoreCorr ΔL′ ΔR ρ′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ qᵢ ∶ᶜ BL ⊒ᵐ BR →
+  μO ∣ ΔL ∣ ΔR ∣ ρ ⊢ q ∶ Bₒ ⊒ᵐ BR →
+  (dₛ⊒ˡ : ηC ∣ ΔL ∣ leftStore ρ ⊢ dₛ ∶ Bₒ ⊒ BL) →
+  ΔL ∣ ΔR ∣ ρ ⊢ dₛ ⨟ˡ qᵢ ≈ q ∶ Bₒ ⊒ᵐ BR →
+  ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+    ⊢ N ⊒ NL [ VR ] ∶ qᵢ ⦂ applyTys χs BL ⊒ᵐ BR →
+  ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+    ⊢ N ⟨ applyCoercions χs (narrowing-dual¹ dₛ⊒ˡ) ⟩ ⊒ NL [ VR ]
+      ∶ q ⦂ applyTys χs Bₒ ⊒ᵐ BR
+sim-betaᵐ-cast-plus-tail χs {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {N = N} {NL = NL} {VR = VR} {qᵢ = qᵢ} {q = q} {dₛ = dₛ}
+    {Bₒ = Bₒ} {BL = BL} {BR = BR} {μO = μO} {ηC = ηC}
+    refl refl corr′ qᵢᶜ q⊒ dₛ⊒ˡ comp-cod N⊒NL =
+  let
+    dₛ⊒ˡ′ :
+      applyModeEnvs χs ηC ∣ applyTyCtxs χs ΔL
+        ∣ leftStore (applyLeftChanges χs ρ)
+        ⊢ applyCoercions χs dₛ
+          ∶ applyTys χs Bₒ ⊒ applyTys χs BL
+    dₛ⊒ˡ′ =
+      subst
+        (λ Σ →
+          applyModeEnvs χs ηC ∣ applyTyCtxs χs ΔL ∣ Σ
+            ⊢ applyCoercions χs dₛ
+              ∶ applyTys χs Bₒ ⊒ applyTys χs BL)
+        (sym (leftStore-applyLeftChanges χs ρ))
+        (left-changes-narrowingˡ χs dₛ⊒ˡ)
+  in
+  subst
+    (λ c₀ →
+      applyTyCtxs χs ΔL ∣ ΔR ∣ applyLeftChanges χs ρ ∣ []
+        ⊢ N ⟨ c₀ ⟩ ⊒ NL [ VR ]
+          ∶ q ⦂ applyTys χs Bₒ ⊒ᵐ BR)
+    (narrowing-dual¹-applyCoercions χs dₛ⊒ˡ dₛ⊒ˡ′)
+    (cast+⊒ᵗ
+      (left-changes-transportᵐ χs corr′ qᵢᶜ)
+      (left-changes-transportᵐ χs corr′ q⊒)
+      dₛ⊒ˡ′
+      (left-changes-comp-srcᵐ χs comp-cod)
+      N⊒NL)
+
+-- The codomain tail of the other source-cast branch (cast-⊒ᵗ shape):
+-- the tail cast raw is the codomain factor itself, so no dual
+-- commutation is needed; the composite's evidence comes off the
+-- recursion result directly.
+sim-betaᵐ-cast-minus-tail :
+  ∀ χs {ΔL ΔR ρ ΔL′ ρ′ N NL VR qᵢ q dₛ BV Bₒ BR ηC μN} →
+  ΔL′ ≡ applyTyCtxs χs ΔL →
+  ρ′ ≡ applyLeftChanges χs ρ →
+  StoreCorr ΔL′ ΔR ρ′ →
+  ΔL ∣ ΔR ∣ ρ ⊢ q ∶ᶜ Bₒ ⊒ᵐ BR →
+  (dₛ⊒ˡ : ηC ∣ ΔL ∣ leftStore ρ ⊢ dₛ ∶ BV ⊒ Bₒ) →
+  ΔL ∣ ΔR ∣ ρ ⊢ dₛ ⨟ˡ q ≈ qᵢ ∶ BV ⊒ᵐ BR →
+  μN ∣ ΔL′ ∣ ΔR ∣ ρ′ ⊢ qᵢ ∶ applyTys χs BV ⊒ᵐ BR →
+  ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+    ⊢ N ⊒ NL [ VR ] ∶ qᵢ ⦂ applyTys χs BV ⊒ᵐ BR →
+  ΔL′ ∣ ΔR ∣ ρ′ ∣ []
+    ⊢ N ⟨ applyCoercions χs dₛ ⟩ ⊒ NL [ VR ]
+      ∶ q ⦂ applyTys χs Bₒ ⊒ᵐ BR
+sim-betaᵐ-cast-minus-tail χs {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ}
+    {N = N} {NL = NL} {VR = VR} {qᵢ = qᵢ} {q = q} {dₛ = dₛ}
+    {BV = BV} {Bₒ = Bₒ} {BR = BR} {ηC = ηC}
+    refl refl corr′ qᶜ dₛ⊒ˡ comp-cod qᵢ⊒ N⊒NL =
+  cast-⊒ᵗ
+    (left-changes-transportᵐ χs corr′ qᶜ)
+    qᵢ⊒
+    (subst
+      (λ Σ →
+        applyModeEnvs χs ηC ∣ applyTyCtxs χs ΔL ∣ Σ
+          ⊢ applyCoercions χs dₛ
+            ∶ applyTys χs BV ⊒ applyTys χs Bₒ)
+      (sym (leftStore-applyLeftChanges χs ρ))
+      (left-changes-narrowingˡ χs dₛ⊒ˡ))
+    (left-changes-comp-srcᵐ χs comp-cod)
+    N⊒NL
+
+-- A sequence coercion cannot be the source cast of a value at an
+-- arrow source: its ？︔ witness types the head untag from ★ (not an
+-- arrow), and its ︔seal witness dualizes through `normalᵃ` to a
+-- non-inert sequence, which the Value premise refutes.  Hoisted so
+-- the witness split happens here and not in the sim-betaᵐ coverage.
+plus-seq-cast-impossible :
+  ∀ {η Δ Σ s₁ s₂ A B C M} →
+  (e : η ∣ Δ ∣ Σ ⊢ s₁ ︔ s₂ ∶ (A ⇒ B) ⊒ C) →
+  Value (M ⟨ narrowing-dual¹ e ⟩) →
+  ⊥
+plus-seq-cast-impossible (cast-seq () _ , _ ？︔ _)
+plus-seq-cast-impossible (s⊢ , _︔seal_ sⁿ α) (vM ⟨ () ⟩)
+
+-- A mediated index of sequence shape cannot sit between arrow
+-- endpoints: its ？︔ witness forces a ★ mediated source (refuted by
+-- the structural MedTy of the arrow left type), and its ︔seal
+-- witness forces a seal-variable target (refuted by the arrow
+-- target).
+inner-seq-index-impossible :
+  ∀ {μ ΔL ΔR ρ q₁ q₂ AL BL AR BR} →
+  μ ∣ ΔL ∣ ΔR ∣ ρ ⊢ q₁ ︔ q₂ ∶ (AL ⇒ BL) ⊒ᵐ (AR ⇒ BR) →
+  ⊥
+inner-seq-index-impossible
+  (_ , _ , _ , _ , med-⇒ _ _ , (cast-seq () _ , _ ？︔ _))
+inner-seq-index-impossible
+  (_ , _ , _ , _ , _ , (cast-seq _ () , _ ︔seal _))
+
+{-# TERMINATING #-}
 sim-betaᵐ :
   ∀ {ΔL ΔR ρ WL NL WR VR p q A A′ B B′ μsim} →
   ΔL ∣ ΔR ∣ ρ ∣ [] ⊢ WL ⊒ ƛ NL ∶ p ↦ q
@@ -107,38 +259,241 @@ sim-betaᵐ {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {WR = WR} {VR = VR}
   refl ,
   term-substitution-narrowingᵐ N⊒NL WR⊒VR′
 -- Source-cast branches.  The one-store cast evidence carried by the
--- mediated constructors makes the shape analysis local: the deriv and
--- witness in the premise refute the impossible coercion shapes
+-- mediated constructors makes the shape analysis local: the deriv
+-- and witness in the premise refute the impossible coercion shapes
 -- directly, where the old proof routed every shape through
 -- canonical-⇒/FunView on the term typing.
 --
 -- cast+⊒ᵗ: the source term is V ⟨ narrowing-dual¹ s⊒ˡ ⟩ with
 -- s ∶ (A ⇒ B) ⊒ C.  A source-typed narrowing witness at an arrow
--- source is either an arrow cross witness or refuted.
+-- source is either an arrow cross witness or refuted: the seq/gen/
+-- seal shapes compute (through `normalᵃ`) to non-inert duals, so the
+-- Value premise refutes them; the ？︔ seq shape is refuted by its
+-- ★-sourced untag typing.
 sim-betaᵐ
   (cast+⊒ᵗ {s = id X} qᶜ r⊒ (cast-id _ _ , cross ()) comp V⊒ƛ)
 sim-betaᵐ (cast+⊒ᵗ {s = s₁ ︔ s₂} qᶜ r⊒ s⊒ˡ comp V⊒ƛ)
     vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
-  {! sim-beta-mediated-cast-plus-seq !}
+  ⊥-elim (plus-seq-cast-impossible s⊒ˡ vWL)
 sim-betaᵐ (cast+⊒ᵗ {s = unseal α X} qᶜ r⊒ (_ , cross ()) comp V⊒ƛ)
 sim-betaᵐ (cast+⊒ᵗ {s = inst X s} qᶜ r⊒ (_ , cross ()) comp V⊒ƛ)
-sim-betaᵐ (cast+⊒ᵗ {s = gen X s} qᶜ r⊒ s⊒ˡ comp V⊒ƛ)
-    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
-  {! sim-beta-mediated-cast-plus-gen !}
-sim-betaᵐ (cast+⊒ᵗ {s = X !} qᶜ r⊒ (_ , cross ()) comp V⊒ƛ)
-sim-betaᵐ (cast+⊒ᵗ {s = seal X α} qᶜ r⊒ s⊒ˡ comp V⊒ƛ)
-    vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
-  {! sim-beta-mediated-cast-plus-seal !}
 sim-betaᵐ
-    (cast+⊒ᵗ {s = cₛ ↦ dₛ} qᶜ r⊒
-      (cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) comp V⊒ƛ)
+    (cast+⊒ᵗ {s = gen X s} qᶜ r⊒ (s⊢ , genⁿʷ sⁿ) comp V⊒ƛ)
+    (vV ⟨ () ⟩)
+sim-betaᵐ (cast+⊒ᵗ {s = X !} qᶜ r⊒ (_ , cross ()) comp V⊒ƛ)
+sim-betaᵐ
+    (cast+⊒ᵗ {s = seal X α} qᶜ r⊒ (s⊢ , sealⁿ .X .α) comp V⊒ƛ)
+    (vV ⟨ () ⟩)
+-- Non-arrow inner-index shapes under an arrow source cast, refuted
+-- through the inner ∶ᶜ evidence: the id shape has no witness at an
+-- arrow endpoint, and the ？/unseal/inst/？︔ shapes force a
+-- non-arrow mediated source (★, a seal variable, or a ∀), which the
+-- structural MedTy of the arrow middle type refutes.  The ︔seal
+-- shape's tail types at a seal variable, not the arrow target.
+sim-betaᵐ
+  (cast+⊒ᵗ {q = id X} (_ , _ , _ , _ , _ , (cast-id _ _ , cross ()))
+    r⊒ s⊒ˡ comp V⊒ƛ)
+sim-betaᵐ
+    (cast+⊒ᵗ {q = q₁ ︔ q₂} qᶜ r⊒ (cast-fun _ _ , _) comp V⊒ƛ)
     vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
-  {! sim-beta-mediated-cast-plus-fun !}
-  -- obligations: β-↦ on (V ⟨ dual cₛ ↦ dual dₛ ⟩) · WR, cast-⊒ᵗ node
-  -- for WR ⟨ dual cₛ ⟩ against the inner domain, recursive sim-betaᵐ
-  -- on V⊒ƛ via catchup-lemmaᵐ, and the ⊒cast-ᵗ tail at dual dₛ; the
-  -- composition side conditions come from `comp`'s left-store record
-  -- projected to domain/codomain.
+  ⊥-elim (inner-seq-index-impossible qᶜ)
+sim-betaᵐ
+  (cast+⊒ᵗ {q = X ？}
+    (_ , _ , _ , _ , () , (cast-untag _ _ _ , _))
+    r⊒ (cast-fun _ _ , _) comp V⊒ƛ)
+sim-betaᵐ
+  (cast+⊒ᵗ {q = unseal α X}
+    (_ , _ , _ , _ , () , (cast-unseal _ _ _ , _))
+    r⊒ (cast-fun _ _ , _) comp V⊒ƛ)
+sim-betaᵐ
+  (cast+⊒ᵗ {q = inst X q₁}
+    (_ , _ , _ , _ , () , (cast-inst _ _ _ , _))
+    r⊒ (cast-fun _ _ , _) comp V⊒ƛ)
+sim-betaᵐ {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL} {WR = WR}
+    {VR = VR} {p = p} {q = q}
+    {A = Aₒ} {A′ = AR} {B = Bₒ} {B′ = BR}
+    (cast+⊒ᵗ {M = V} {q = pᵢ ↦ qᵢ} {s = cₛ ↦ dₛ}
+      {C = AL ⇒ BL} {μ = μO} {η = ηC}
+      qᶜ r⊒ s⊒ˡ@(cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) comp V⊒ƛ)
+    (vV ⟨ i ⟩) (no•-⟨⟩ noV)
+    p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
+  let
+    stores = narrowing-store-corrᵐᶜ qᶜ
+
+    cᵈ = proj₁ (dualʷ normalᵃ cʷ)
+    dᵈ = proj₁ (dualⁿ normalᵃ dⁿ)
+
+    -- The argument-position cast node at the inner domain.
+    WR-c⊒VR :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ WR ⟨ cᵈ ⟩ ⊒ VR ∶ fun-narrow-domain-dualᵐᶜ qᶜ
+          ⦂ AL ⊒ᵐ AR
+    WR-c⊒VR =
+      cast-⊒ᵗ
+        (fun-narrow-domain-dual-typingᵐᶜ qᶜ)
+        p-domainᶜ
+        (fun-narrow-domain-dual-typing¹ (leftStore-wf stores) s⊒ˡ)
+        (comp-src-fun-domain-dualᵐ stores comp s⊒ˡ qᶜ p↦q-sim⊒)
+        WR⊒VR
+
+    χsA , WRA , ΔLA , vWRA , noWRA , WR↠WRA , ΔLA≡ , ρA-corr ,
+      leftA≡ , rightA≡ , pdᶜᴬ , WRA⊒VRᴬ =
+      catchup-lemmaᵐ (ok-⟨⟩ (ok-no noWR)) vVR WR-c⊒VR
+
+    ρA = applyLeftChanges χsA ρ
+
+    corrA : StoreCorr (applyTyCtxs χsA ΔL) ΔR ρA
+    corrA = subst (λ Δ → StoreCorr Δ ΔR ρA) ΔLA≡ ρA-corr
+
+    -- Advance the function relation and the inner arrow evidence
+    -- across the catchup's left store changes; the coercion indices
+    -- are untouched (the point of the mediated relation).
+    VA⊒ƛ :
+      ΔLA ∣ ΔR ∣ ρA ∣ []
+        ⊢ applyTerms χsA V ⊒ ƛ NL ∶ pᵢ ↦ qᵢ
+          ⦂ applyTys χsA AL ⇒ applyTys χsA BL ⊒ᵐ AR ⇒ BR
+    VA⊒ƛ =
+      subst
+        (λ C₀ →
+          ΔLA ∣ ΔR ∣ ρA ∣ []
+            ⊢ applyTerms χsA V ⊒ ƛ NL ∶ pᵢ ↦ qᵢ
+              ⦂ C₀ ⊒ᵐ AR ⇒ BR)
+        (applyTys-⇒ χsA AL BL)
+        (subst
+          (λ Δ →
+            Δ ∣ ΔR ∣ ρA ∣ []
+              ⊢ applyTerms χsA V ⊒ ƛ NL ∶ pᵢ ↦ qᵢ
+                ⦂ applyTys χsA (AL ⇒ BL) ⊒ᵐ AR ⇒ BR)
+          (sym ΔLA≡)
+          (left-changes-term-narrowingᵐ χsA corrA V⊒ƛ))
+
+    qᶜᴬ :
+      ΔLA ∣ ΔR ∣ ρA
+        ⊢ pᵢ ↦ qᵢ
+          ∶ᶜ applyTys χsA AL ⇒ applyTys χsA BL ⊒ᵐ AR ⇒ BR
+    qᶜᴬ =
+      subst
+        (λ C₀ →
+          ΔLA ∣ ΔR ∣ ρA ⊢ pᵢ ↦ qᵢ ∶ᶜ C₀ ⊒ᵐ AR ⇒ BR)
+        (applyTys-⇒ χsA AL BL)
+        (subst
+          (λ Δ →
+            Δ ∣ ΔR ∣ ρA ⊢ pᵢ ↦ qᵢ
+              ∶ᶜ applyTys χsA (AL ⇒ BL) ⊒ᵐ AR ⇒ BR)
+          (sym ΔLA≡)
+          (left-changes-transportᵐ χsA corrA qᶜ))
+
+    pd-eq :
+      fun-narrow-domain-dualᵐ qᶜᴬ ≡ fun-narrow-domain-dualᵐᶜ qᶜ
+    pd-eq = fun-narrow-domain-dualᵐ-determined qᶜᴬ qᶜ
+
+    p-domainᶜᴬ :
+      ΔLA ∣ ΔR ∣ ρA
+        ⊢ fun-narrow-domain-dualᵐ qᶜᴬ ∶ᶜ applyTys χsA AL ⊒ᵐ AR
+    p-domainᶜᴬ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ ρA ⊢ pd ∶ᶜ applyTys χsA AL ⊒ᵐ AR)
+        (sym pd-eq)
+        pdᶜᴬ
+
+    WRA⊒VR′ :
+      ΔLA ∣ ΔR ∣ ρA ∣ []
+        ⊢ WRA ⊒ VR ∶ fun-narrow-domain-dualᵐ qᶜᴬ
+          ⦂ applyTys χsA AL ⊒ᵐ AR
+    WRA⊒VR′ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ ρA ∣ []
+            ⊢ WRA ⊒ VR ∶ pd ⦂ applyTys χsA AL ⊒ᵐ AR)
+        (sym pd-eq)
+        WRA⊒VRᴬ
+
+    χsT , N , ΔLT , ρT , tail-red , ΔT≡ , ρT≡ , N⊒NL =
+      sim-betaᵐ
+        VA⊒ƛ
+        (applyTerms-preserves-Value χsA vV)
+        (applyTerms-preserves-No• χsA noV)
+        qᶜᴬ
+        p-domainᶜᴬ
+        WRA⊒VR′
+        vWRA
+        noWRA
+        vVR
+
+    -- Reductions: β-↦, catchup on the casted argument, recursion
+    -- tail — all under the codomain cast.
+    head-red :
+      (V ⟨ cᵈ ↦ dᵈ ⟩) · WR —↠[ keep ∷ [] ]
+        (V · (WR ⟨ cᵈ ⟩)) ⟨ dᵈ ⟩
+    head-red = ↠-step (pure-step (β-↦ vV vWR)) ↠-refl
+
+    source-steps :
+      (V ⟨ cᵈ ↦ dᵈ ⟩) · WR —↠[ (keep ∷ χsA) ++ χsT ]
+        N ⟨ applyCoercions χsT (applyCoercions χsA dᵈ) ⟩
+    source-steps =
+      ↠-trans
+        (↠-trans head-red (cast-↠ {c = dᵈ} (·₂-↠ vV noV WR↠WRA)))
+        (cast-↠ {c = applyCoercions χsA dᵈ} tail-red)
+
+    ΔLT-total≡ :
+      ΔLT ≡ applyTyCtxs ((keep ∷ χsA) ++ χsT) ΔL
+    ΔLT-total≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔLA≡)
+          (sym (applyTyCtxs-++ χsA χsT ΔL)))
+
+    ρT-total≡ :
+      ρT ≡ applyLeftChanges ((keep ∷ χsA) ++ χsT) ρ
+    ρT-total≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
+
+    μN , qᵢ⊒T = typed-term-narrowing-coercionᵐ N⊒NL
+
+    ρT-corr : StoreCorr ΔLT ΔR ρT
+    ρT-corr = narrowing-store-corrᵐᶜ {μ = μN} qᵢ⊒T
+
+    N⊒NL′ :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⊒ NL [ VR ] ∶ qᵢ
+          ⦂ applyTys (χsA ++ χsT) BL ⊒ᵐ BR
+    N⊒NL′ =
+      subst
+        (λ X →
+          ΔLT ∣ ΔR ∣ ρT ∣ [] ⊢ N ⊒ NL [ VR ] ∶ qᵢ ⦂ X ⊒ᵐ BR)
+        (sym (applyTys-++ χsA χsT BL))
+        N⊒NL
+
+    N-tail :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ applyCoercions (χsA ++ χsT) dᵈ ⟩ ⊒ NL [ VR ]
+          ∶ q ⦂ applyTys (χsA ++ χsT) Bₒ ⊒ᵐ BR
+    N-tail =
+      sim-betaᵐ-cast-plus-tail (χsA ++ χsT)
+        ΔLT-total≡
+        ρT-total≡
+        ρT-corr
+        (fun-narrow-codomainᵐᶜ qᶜ)
+        (fun-narrow-codomainᵐ r⊒)
+        (d⊢ , dⁿ)
+        (comp-src-fun-codomainᵐ comp)
+        N⊒NL′
+  in
+  (keep ∷ χsA) ++ χsT ,
+  N ⟨ applyCoercions χsT (applyCoercions χsA dᵈ) ⟩ ,
+  ΔLT ,
+  ρT ,
+  source-steps ,
+  ΔLT-total≡ ,
+  ρT-total≡ ,
+  subst
+    (λ c₀ →
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ c₀ ⟩ ⊒ NL [ VR ]
+          ∶ q ⦂ applyTys (χsA ++ χsT) Bₒ ⊒ᵐ BR)
+    (applyCoercions-++ χsA χsT dᵈ)
+    N-tail
 --
 -- cast-⊒ᵗ: the source term is V ⟨ s ⟩ with s ∶ A₀ ⊒ (A ⇒ B); the
 -- value premise (Inert s) and the witness refute the non-arrow
@@ -153,12 +508,227 @@ sim-betaᵐ (cast-⊒ᵗ {s = unseal α X} qᶜ r⊒ s⊒ˡ comp V⊒ƛ)
     (vV ⟨ () ⟩)
 sim-betaᵐ (cast-⊒ᵗ {s = inst X s} qᶜ r⊒ s⊒ˡ comp V⊒ƛ)
     (vV ⟨ () ⟩)
+-- Non-arrow inner-index shapes, refuted through the ⊒ᵐ evidence of
+-- the cast premise exactly as in the cast+⊒ᵗ branch above.
 sim-betaᵐ
-    (cast-⊒ᵗ {s = cₛ ↦ dₛ} qᶜ r⊒
-      (cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) comp V⊒ƛ)
+  (cast-⊒ᵗ {r = id X} qᶜ
+    (_ , _ , _ , _ , _ , (cast-id _ _ , cross ()))
+    s⊒ˡ comp V⊒ƛ)
+sim-betaᵐ
+    (cast-⊒ᵗ {r = r₁ ︔ r₂} qᶜ r⊒ (cast-fun _ _ , _) comp V⊒ƛ)
     vWL noWL p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
-  {! sim-beta-mediated-cast-minus-fun !}
-  -- obligations: β-↦ on (V ⟨ cₛ ↦ dₛ ⟩) · WR, cast-⊒ᵗ node for
-  -- WR ⟨ cₛ ⟩ against the inner domain, recursive sim-betaᵐ on V⊒ƛ
-  -- via catchup-lemmaᵐ, and the ⊒cast-ᵗ tail at dₛ; compositions from
-  -- `comp` projected to domain/codomain.
+  ⊥-elim (inner-seq-index-impossible r⊒)
+sim-betaᵐ
+  (cast-⊒ᵗ {r = X ？} qᶜ
+    (_ , _ , _ , _ , () , (cast-untag _ _ _ , _))
+    (cast-fun _ _ , _) comp V⊒ƛ)
+sim-betaᵐ
+  (cast-⊒ᵗ {r = unseal α X} qᶜ
+    (_ , _ , _ , _ , () , (cast-unseal _ _ _ , _))
+    (cast-fun _ _ , _) comp V⊒ƛ)
+sim-betaᵐ
+  (cast-⊒ᵗ {r = inst X r₁} qᶜ
+    (_ , _ , _ , _ , () , (cast-inst _ _ _ , _))
+    (cast-fun _ _ , _) comp V⊒ƛ)
+sim-betaᵐ {ΔL = ΔL} {ΔR = ΔR} {ρ = ρ} {NL = NL} {WR = WR}
+    {VR = VR} {p = p} {q = q}
+    {A = Aₒ} {A′ = AR} {B = Bₒ} {B′ = BR}
+    (cast-⊒ᵗ {M = V} {r = pᵢ ↦ qᵢ} {s = cₛ ↦ dₛ}
+      {A = AV ⇒ BV} {μ = μO} {η = ηC}
+      qᶜ r⊒ s⊒ˡ@(cast-fun c⊢ d⊢ , cross (cʷ ↦ⁿʷ dⁿ)) comp V⊒ƛ)
+    (vV ⟨ i ⟩) (no•-⟨⟩ noV)
+    p↦q-sim⊒ p-domainᶜ WR⊒VR vWR noWR vVR =
+  let
+    stores = narrowing-store-corrᵐᶜ qᶜ
+
+    cᵈ = proj₁ (dualʷ normalᵃ cʷ)
+    cᵈⁿ = proj₂ (dualʷ normalᵃ cʷ)
+
+    -- The argument-position cast node, through the double dual: the
+    -- source-side cast+⊒ᵗ node concludes at the dual of the dual of
+    -- the domain factor, which is the domain factor itself.
+    cᵈ⊒ˡ : ηC ∣ ΔL ∣ leftStore ρ ⊢ cᵈ ∶ AV ⊒ Aₒ
+    cᵈ⊒ˡ =
+      proj₁ (fun-narrow-domain-dual-typing¹ (leftStore-wf stores) s⊒ˡ) ,
+      cᵈⁿ
+
+    WR-c⊒VR :
+      ΔL ∣ ΔR ∣ ρ ∣ []
+        ⊢ WR ⟨ cₛ ⟩ ⊒ VR ∶ fun-narrow-domain-dualᵐ r⊒
+          ⦂ AV ⊒ᵐ AR
+    WR-c⊒VR =
+      subst
+        (λ c₀ →
+          ΔL ∣ ΔR ∣ ρ ∣ []
+            ⊢ WR ⟨ c₀ ⟩ ⊒ VR ∶ fun-narrow-domain-dualᵐ r⊒
+              ⦂ AV ⊒ᵐ AR)
+        (dualʷ-involutive-raw cʷ)
+        (cast+⊒ᵗ
+          p-domainᶜ
+          (fun-narrow-domain-dual-typingᵐ r⊒)
+          cᵈ⊒ˡ
+          (comp-src-fun-domain-dualᵐ stores comp s⊒ˡ p↦q-sim⊒ r⊒)
+          WR⊒VR)
+
+    χsA , WRA , ΔLA , vWRA , noWRA , WR↠WRA , ΔLA≡ , ρA-corr ,
+      leftA≡ , rightA≡ , pdᶜᴬ , WRA⊒VRᴬ =
+      catchup-lemmaᵐ (ok-⟨⟩ (ok-no noWR)) vVR WR-c⊒VR
+
+    ρA = applyLeftChanges χsA ρ
+
+    corrA : StoreCorr (applyTyCtxs χsA ΔL) ΔR ρA
+    corrA = subst (λ Δ → StoreCorr Δ ΔR ρA) ΔLA≡ ρA-corr
+
+    VA⊒ƛ :
+      ΔLA ∣ ΔR ∣ ρA ∣ []
+        ⊢ applyTerms χsA V ⊒ ƛ NL ∶ pᵢ ↦ qᵢ
+          ⦂ applyTys χsA AV ⇒ applyTys χsA BV ⊒ᵐ AR ⇒ BR
+    VA⊒ƛ =
+      subst
+        (λ C₀ →
+          ΔLA ∣ ΔR ∣ ρA ∣ []
+            ⊢ applyTerms χsA V ⊒ ƛ NL ∶ pᵢ ↦ qᵢ
+              ⦂ C₀ ⊒ᵐ AR ⇒ BR)
+        (applyTys-⇒ χsA AV BV)
+        (subst
+          (λ Δ →
+            Δ ∣ ΔR ∣ ρA ∣ []
+              ⊢ applyTerms χsA V ⊒ ƛ NL ∶ pᵢ ↦ qᵢ
+                ⦂ applyTys χsA (AV ⇒ BV) ⊒ᵐ AR ⇒ BR)
+          (sym ΔLA≡)
+          (left-changes-term-narrowingᵐ χsA corrA V⊒ƛ))
+
+    r⊒ᴬ :
+      μO ∣ ΔLA ∣ ΔR ∣ ρA
+        ⊢ pᵢ ↦ qᵢ
+          ∶ applyTys χsA AV ⇒ applyTys χsA BV ⊒ᵐ AR ⇒ BR
+    r⊒ᴬ =
+      subst
+        (λ C₀ →
+          μO ∣ ΔLA ∣ ΔR ∣ ρA ⊢ pᵢ ↦ qᵢ ∶ C₀ ⊒ᵐ AR ⇒ BR)
+        (applyTys-⇒ χsA AV BV)
+        (subst
+          (λ Δ →
+            μO ∣ Δ ∣ ΔR ∣ ρA ⊢ pᵢ ↦ qᵢ
+              ∶ applyTys χsA (AV ⇒ BV) ⊒ᵐ AR ⇒ BR)
+          (sym ΔLA≡)
+          (left-changes-transportᵐ χsA corrA r⊒))
+
+    pd-eq :
+      fun-narrow-domain-dualᵐ r⊒ᴬ ≡ fun-narrow-domain-dualᵐ r⊒
+    pd-eq = fun-narrow-domain-dualᵐ-determined r⊒ᴬ r⊒
+
+    p-domainᶜᴬ :
+      ΔLA ∣ ΔR ∣ ρA
+        ⊢ fun-narrow-domain-dualᵐ r⊒ᴬ ∶ᶜ applyTys χsA AV ⊒ᵐ AR
+    p-domainᶜᴬ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ ρA ⊢ pd ∶ᶜ applyTys χsA AV ⊒ᵐ AR)
+        (sym pd-eq)
+        pdᶜᴬ
+
+    WRA⊒VR′ :
+      ΔLA ∣ ΔR ∣ ρA ∣ []
+        ⊢ WRA ⊒ VR ∶ fun-narrow-domain-dualᵐ r⊒ᴬ
+          ⦂ applyTys χsA AV ⊒ᵐ AR
+    WRA⊒VR′ =
+      subst
+        (λ pd →
+          ΔLA ∣ ΔR ∣ ρA ∣ []
+            ⊢ WRA ⊒ VR ∶ pd ⦂ applyTys χsA AV ⊒ᵐ AR)
+        (sym pd-eq)
+        WRA⊒VRᴬ
+
+    χsT , N , ΔLT , ρT , tail-red , ΔT≡ , ρT≡ , N⊒NL =
+      sim-betaᵐ
+        VA⊒ƛ
+        (applyTerms-preserves-Value χsA vV)
+        (applyTerms-preserves-No• χsA noV)
+        r⊒ᴬ
+        p-domainᶜᴬ
+        WRA⊒VR′
+        vWRA
+        noWRA
+        vVR
+
+    head-red :
+      (V ⟨ cₛ ↦ dₛ ⟩) · WR —↠[ keep ∷ [] ]
+        (V · (WR ⟨ cₛ ⟩)) ⟨ dₛ ⟩
+    head-red = ↠-step (pure-step (β-↦ vV vWR)) ↠-refl
+
+    source-steps :
+      (V ⟨ cₛ ↦ dₛ ⟩) · WR —↠[ (keep ∷ χsA) ++ χsT ]
+        N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩
+    source-steps =
+      ↠-trans
+        (↠-trans head-red (cast-↠ {c = dₛ} (·₂-↠ vV noV WR↠WRA)))
+        (cast-↠ {c = applyCoercions χsA dₛ} tail-red)
+
+    ΔLT-total≡ :
+      ΔLT ≡ applyTyCtxs ((keep ∷ χsA) ++ χsT) ΔL
+    ΔLT-total≡ =
+      trans ΔT≡
+        (trans
+          (cong (applyTyCtxs χsT) ΔLA≡)
+          (sym (applyTyCtxs-++ χsA χsT ΔL)))
+
+    ρT-total≡ :
+      ρT ≡ applyLeftChanges ((keep ∷ χsA) ++ χsT) ρ
+    ρT-total≡ =
+      trans ρT≡ (sym (applyLeftChanges-++ χsA χsT ρ))
+
+    μN , qᵢ⊒T = typed-term-narrowing-coercionᵐ N⊒NL
+
+    ρT-corr : StoreCorr ΔLT ΔR ρT
+    ρT-corr = narrowing-store-corrᵐᶜ {μ = μN} qᵢ⊒T
+
+    qᵢ⊒′ :
+      μN ∣ ΔLT ∣ ΔR ∣ ρT
+        ⊢ qᵢ ∶ applyTys (χsA ++ χsT) BV ⊒ᵐ BR
+    qᵢ⊒′ =
+      subst
+        (λ X → μN ∣ ΔLT ∣ ΔR ∣ ρT ⊢ qᵢ ∶ X ⊒ᵐ BR)
+        (sym (applyTys-++ χsA χsT BV))
+        qᵢ⊒T
+
+    N⊒NL′ :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⊒ NL [ VR ] ∶ qᵢ
+          ⦂ applyTys (χsA ++ χsT) BV ⊒ᵐ BR
+    N⊒NL′ =
+      subst
+        (λ X →
+          ΔLT ∣ ΔR ∣ ρT ∣ [] ⊢ N ⊒ NL [ VR ] ∶ qᵢ ⦂ X ⊒ᵐ BR)
+        (sym (applyTys-++ χsA χsT BV))
+        N⊒NL
+
+    N-tail :
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ applyCoercions (χsA ++ χsT) dₛ ⟩ ⊒ NL [ VR ]
+          ∶ q ⦂ applyTys (χsA ++ χsT) Bₒ ⊒ᵐ BR
+    N-tail =
+      sim-betaᵐ-cast-minus-tail (χsA ++ χsT)
+        ΔLT-total≡
+        ρT-total≡
+        ρT-corr
+        (fun-narrow-codomainᵐᶜ qᶜ)
+        (d⊢ , dⁿ)
+        (comp-src-fun-codomainᵐ comp)
+        qᵢ⊒′
+        N⊒NL′
+  in
+  (keep ∷ χsA) ++ χsT ,
+  N ⟨ applyCoercions χsT (applyCoercions χsA dₛ) ⟩ ,
+  ΔLT ,
+  ρT ,
+  source-steps ,
+  ΔLT-total≡ ,
+  ρT-total≡ ,
+  subst
+    (λ c₀ →
+      ΔLT ∣ ΔR ∣ ρT ∣ []
+        ⊢ N ⟨ c₀ ⟩ ⊒ NL [ VR ]
+          ∶ q ⦂ applyTys (χsA ++ χsT) Bₒ ⊒ᵐ BR)
+    (applyCoercions-++ χsA χsT dₛ)
+    N-tail


### PR DESCRIPTION
## Why

Step 2 of the mediated migration (PR #47): move the DGG proof stack onto the `⊒ᵐ` relation. This PR fills the two real source-cast arrow branches of `sim-betaᵐ` and, in doing so, settles the migration question PR #47 recorded: **can the `⨟ˡ` composition record's fields produce the inner-domain composition that the argument-cast node needs?**

**Answer: yes — no field change is needed.** The argument node's `∶ᶜ` inner-domain index comes straight off the constructor's own `∶ᶜ` premise, and the record projects to the domain-dual composition by pure field inversion: `MedCo`/`MedTy` are structural, so the left images of arrow raws are arrows, and their domain factors dualize in the left store. The only genuinely new mediation metatheory is `medCo-dualʷ` — *mediation is closed under the grammar-directed duals* — a shape-only structural lemma (same flavor as the accepted `med-narrowing-witness` hole).

## What

**[`GTSF/proof/SimBetaMediated.agda`](../blob/claude/mediated-simbeta-cast-bodies/GTSF/proof/SimBetaMediated.agda)** — now **hole-free**:
- `sim-betaᵐ`'s `cast+⊒ᵗ` and `cast-⊒ᵗ` arrow branches are filled, mirroring the old proof's shape (β-↦ → argument-position cast node at the inner domain → `catchup-lemmaᵐ` → recursion → codomain tail). The mediated index discipline collapses the old plumbing: the recursion's conclusion keeps the original codomain raw, so the `applyCoercions-++`/dual-commutation rewrites survive only at the two term-level cast positions (vs. every index in `SimBetaSeparated`).
- The exotic coercion shapes are refuted **locally by their own witnesses** — no `canonical-⇒`/`FunView` detour: seq(？︔) by its ★-sourced untag typing, seq(︔seal)/gen/seal by computing their duals through `normalᵃ` to non-inert raws (the `Value` premise refutes), and the non-arrow inner-index shapes through the mediated evidence (the structural `MedTy` of the arrow middle type refutes the ★/seal-variable/∀ sources forced by ？/unseal/inst). Two hoisted ⊥-helpers (`plus-seq-cast-impossible`, `inner-seq-index-impossible`) keep the witness splits out of the top-level coverage, which otherwise enumerates every sequence sub-shape.
- Codomain tails hoisted as `sim-betaᵐ-cast-plus-tail`/`sim-betaᵐ-cast-minus-tail` (elaboration size, as in the old proof).
- `fun-narrow-domain-dualᵐ-determined` generalized to compare evidences across stores (the transported inner index vs. the original).

**[`GTSF/proof/MediationProperties.agda`](../blob/claude/mediated-simbeta-cast-bodies/GTSF/proof/MediationProperties.agda)**:
- **Proved**: the ⨟ˡ projections `comp-src-fun-domain-dualᵐ` (modulo `medCo-dualʷ`) and `comp-src-fun-codomainᵐ` (pure inversion); the ⨟ˡ record's left-change transport `left-changes-comp-srcᵐ`; `medCo-applyLeftChanges`; the one-store arrow projections (`fun-narrow-domain-dual¹`, its typing, `fun-narrow-codomain¹`); the deterministic mode image `applyModeEnv(s)`.
- **New named holes** (the mediated left-change family's remaining plumbing): `medCo-dualʷ`; `left-changes-narrowingˡ` (one-store left transport — note the recorded store-wf chaining question: iterating `applyCoercion-typing` needs well-formedness of the bound types at intermediate steps, which bare `StoreChanges` does not carry); `narrowing-dual¹-applyCoercions`; and `left-changes-term-narrowingᵐ` — the `⊒ᵐ` replacement for the old *postulated* `left-change-term-narrowing`, now with the index raw untouched.

**[`GTSF/Mediation.agda`](../blob/claude/mediated-simbeta-cast-bodies/GTSF/Mediation.agda)** (hole-free): `medCo-mapˡ` — the coercion sibling of `medTy-mapˡ` — plus the hoisted `extVar-mapˡ`.

**[`GTSF/MediatedNarrowing.agda`](../blob/claude/mediated-simbeta-cast-bodies/GTSF/MediatedNarrowing.agda)** (hole-free): mode-generic `fun-narrow-domain-dual-typingᵐ` and `fun-narrow-codomainᵐ` for the cast rules' non-`∶ᶜ` evidences.

The checklist's migration-status section records all of the above.

## Validation

- `make -C GTSF check` (All.agda) green.
- No new postulates (the pre-approved `term-substitution-narrowingᵐ` is unchanged); all new unfinished obligations are named `{! !}` holes in `proof/` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
