### PR TITLE
[codex] Add GTSF gradual run examples

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -8,7 +8,7 @@ module All where
 import Compile
 import Types
 import GradualTypeCheck
-import GradualTypeCheckExamples
+import GradualExamples
 import Coercions
 import NarrowWiden
 import StoreCorrespondence

--- a/GTSF/GradualExamples.agda
+++ b/GTSF/GradualExamples.agda
@@ -1,22 +1,28 @@
-module GradualTypeCheckExamples where
+module GradualExamples where
 
 -- File Charter:
---   * Closed GTSF source examples checked by `GradualTypeCheck`.
+--   * Closed GTSF source examples checked by `GradualTypeCheck` and run
+--     through source checking, compilation, and target evaluation.
 --   * Adapted from the PolyUpDown fresh examples by dropping explicit
---     up/down coercion syntax and checking source gradual typing only.
---   * No execution tests live here because the source evaluator is not present.
+--     up/down coercion syntax.
+--   * Each directly executable source program has both typing evidence and a
+--     fuel-bounded `Run` regression for its expected target value.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([])
-open import Data.Maybe using (nothing)
+open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat using (ℕ)
 
 open import Types
 open import Ctx using (ctxWf-[])
+open import Coercions using () renaming (_! to _!ᶜ)
+import Eval as Eval
 open import GradualTerms
 open import GradualTypeCheck
   using (IsJust; is-just; toWitness; type-check; type-check-expect)
+open import NuTerms using (Term) renaming ($ to $ᵀ; _⟨_⟩ to _⟨ᵀ_⟩)
 open import Primitives
+import Run as Run
 
 ------------------------------------------------------------------------
 -- Shared terms and helpers
@@ -24,6 +30,12 @@ open import Primitives
 
 nat : ℕ → GTerm
 nat n = $ (κℕ n)
+
+natᵀ : ℕ → Term
+natᵀ n = $ᵀ (κℕ n)
+
+taggedNatᵀ : ℕ → Term
+taggedNatᵀ n = natᵀ n ⟨ᵀ (‵ `ℕ) !ᶜ ⟩
 
 c : GTerm
 c = nat 7
@@ -66,6 +78,13 @@ expect-⊢ :
   IsJust (type-check-expect 0 [] ctxWf-[] M A) →
   0 ∣ [] ⊢ M ⦂ A
 expect-⊢ M A ok = toWitness ok
+
+run-term : ∀ {M} → Maybe (Run.RunResult M) → Maybe Term
+run-term nothing = nothing
+run-term (just r) = just (Eval.term (Run.evaluation r))
+
+run-gas : ℕ
+run-gas = 100
 
 ------------------------------------------------------------------------
 -- Basic source examples
@@ -135,6 +154,42 @@ sec6-K-base =
 
 sec6-K-base-⊢ : 0 ∣ [] ⊢ sec6-K-base ⦂ (‵ `ℕ)
 sec6-K-base-⊢ = expect-⊢ sec6-K-base (‵ `ℕ) is-just
+
+------------------------------------------------------------------------
+-- Successful execution tests
+------------------------------------------------------------------------
+
+example-dyn-id-run :
+  run-term (Run.run run-gas example-dyn-id) ≡ just (taggedNatᵀ 7)
+example-dyn-id-run = refl
+
+example-nat-id-run :
+  run-term (Run.run run-gas example-nat-id) ≡ just (natᵀ 7)
+example-nat-id-run = refl
+
+example-poly-id-run :
+  run-term (Run.run run-gas example-poly-id) ≡ just (natᵀ 7)
+example-poly-id-run = refl
+
+sec2-app-dyn-run :
+  run-term (Run.run run-gas sec2-app-dyn) ≡ just (taggedNatᵀ 7)
+sec2-app-dyn-run = refl
+
+sec2-app-base-run :
+  run-term (Run.run run-gas sec2-app-base) ≡ just (natᵀ 7)
+sec2-app-base-run = refl
+
+sec5-β-run :
+  run-term (Run.run run-gas sec5-β) ≡ just (natᵀ 7)
+sec5-β-run = refl
+
+sec6-K-dyn-run :
+  run-term (Run.run run-gas sec6-K-dyn) ≡ just (taggedNatᵀ 42)
+sec6-K-dyn-run = refl
+
+sec6-K-base-run :
+  run-term (Run.run run-gas sec6-K-base) ≡ just (natᵀ 42)
+sec6-K-base-run = refl
 
 ------------------------------------------------------------------------
 -- Rejection tests

--- a/GTSF/Run.agda
+++ b/GTSF/Run.agda
@@ -1,20 +1,20 @@
 module Run where
 
 -- File Charter:
---   * Connects source gradual type checking, compilation, and target evaluation.
---   * Exports `runWithLabel`/`run` for fuel-bounded execution of closed gradual
---     programs and typed variants for callers that already have source typing.
+--   * Connects source gradual type checking, compilation, and target
+--     evaluation.
+--   * Exports `run` for fuel-bounded execution of closed gradual programs and
+--     `runTyped` for callers that already have source typing.
 --   * Packages source typing, compiled target typing, the runtime invariant,
 --     and the final `EvalResult` in one result record.
 
 open import Data.List using ([])
 open import Data.Maybe using (Maybe; just; nothing)
-open import Data.Nat using (ℕ; zero)
+open import Data.Nat using (ℕ)
 open import Data.Product using (Σ-syntax; _×_; _,_; proj₁)
 
 open import Types
 open import Ctx using (CtxWf; ctxWf-[]; ctxWf-∷)
-open import Coercions using (Label)
 open import Compile
   using
     ( arrow★-consistent
@@ -71,62 +71,59 @@ empty-store-wf =
 
 compile-no• :
   ∀ {Δ Γ M A} →
-  (ℓ : Label) →
   (hΓ : CtxWf Δ Γ) →
   (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
-  No• (proj₁ (compile ℓ hΓ M⊢))
-compile-no• ℓ hΓ (⊢ᴳ` x∈) =
+  No• (proj₁ (compile hΓ M⊢))
+compile-no• hΓ (⊢ᴳ` x∈) =
   no•-`
-compile-no• ℓ hΓ (⊢ᴳƛ wfA M⊢)
-    with compile ℓ (ctxWf-∷ wfA hΓ) M⊢
-       | compile-no• ℓ (ctxWf-∷ wfA hΓ) M⊢
+compile-no• hΓ (⊢ᴳƛ wfA M⊢)
+    with compile (ctxWf-∷ wfA hΓ) M⊢
+       | compile-no• (ctxWf-∷ wfA hΓ) M⊢
 ... | N , N⊢ | noN =
   no•-ƛ noN
-compile-no• ℓ hΓ (⊢ᴳ· L⊢ M⊢ A~A′)
-    with compile ℓ hΓ L⊢ | compile ℓ hΓ M⊢
+compile-no• hΓ (⊢ᴳ· {ℓ = ℓ} L⊢ M⊢ A~A′)
+    with compile hΓ L⊢ | compile hΓ M⊢
        | consistency-cast-plan ℓ (~-sym A~A′)
-       | compile-no• ℓ hΓ L⊢ | compile-no• ℓ hΓ M⊢
+       | compile-no• hΓ L⊢ | compile-no• hΓ M⊢
 ... | L′ , L′⊢ | M′ , M′⊢ | plan | noL | noM =
   no•-· noL (no•-⟨⟩ (no•-⟨⟩ noM))
-compile-no• ℓ hΓ (⊢ᴳ·★ L⊢ M⊢ A′~★)
-    with compile ℓ hΓ L⊢ | compile ℓ hΓ M⊢
+compile-no• hΓ (⊢ᴳ·★ {ℓ = ℓ} L⊢ M⊢ A′~★)
+    with compile hΓ L⊢ | compile hΓ M⊢
        | consistency-cast-plan ℓ (~-sym (arrow★-consistent A′~★))
-       | compile-no• ℓ hΓ L⊢ | compile-no• ℓ hΓ M⊢
+       | compile-no• hΓ L⊢ | compile-no• hΓ M⊢
 ... | L′ , L′⊢ | M′ , M′⊢ | plan | noL | noM =
   no•-· (no•-⟨⟩ (no•-⟨⟩ noL)) noM
-compile-no• ℓ hΓ (⊢ᴳΛ {occ = occ} vM M⊢)
-    with compile ℓ (CtxWf-⤊ hΓ) M⊢
-       | compile-value ℓ (CtxWf-⤊ hΓ) vM M⊢
-       | compile-no• ℓ (CtxWf-⤊ hΓ) M⊢
+compile-no• hΓ (⊢ᴳΛ {occ = occ} vM M⊢)
+    with compile (CtxWf-⤊ hΓ) M⊢
+       | compile-value (CtxWf-⤊ hΓ) vM M⊢
+       | compile-no• (CtxWf-⤊ hΓ) M⊢
 ... | N , N⊢ | vN | noN =
   no•-Λ noN
-compile-no• ℓ hΓ (⊢ᴳ• {B = B} {A = A} M⊢ wfB wfA)
-    with compile ℓ hΓ M⊢ | compile-no• ℓ hΓ M⊢
+compile-no• hΓ (⊢ᴳ• {B = B} {A = A} M⊢ wfB wfA)
+    with compile hΓ M⊢ | compile-no• hΓ M⊢
 ... | M′ , M′⊢ | noM =
   no•-ν noM
-compile-no• ℓ hΓ (⊢ᴳ$ κ) =
+compile-no• hΓ (⊢ᴳ$ κ) =
   no•-$
-compile-no• ℓ hΓ (⊢ᴳ⊕ L⊢ A~ℕ op M⊢ B~ℕ)
-    with compile ℓ hΓ L⊢ | compile ℓ hΓ M⊢
+compile-no• hΓ (⊢ᴳ⊕ {ℓ = ℓ} L⊢ A~ℕ op M⊢ B~ℕ)
+    with compile hΓ L⊢ | compile hΓ M⊢
        | consistency-cast-plan ℓ A~ℕ | consistency-cast-plan ℓ B~ℕ
-       | compile-no• ℓ hΓ L⊢ | compile-no• ℓ hΓ M⊢
+       | compile-no• hΓ L⊢ | compile-no• hΓ M⊢
 ... | L′ , L′⊢ | M′ , M′⊢ | planL | planM | noL | noM =
   no•-⊕ (no•-⟨⟩ (no•-⟨⟩ noL)) (no•-⟨⟩ (no•-⟨⟩ noM))
 
 compile-runtime :
   ∀ {Δ Γ M A} →
-  (ℓ : Label) →
   (hΓ : CtxWf Δ Γ) →
   (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
-  RuntimeOK (proj₁ (compile ℓ hΓ M⊢))
-compile-runtime ℓ hΓ M⊢ = ok-no (compile-no• ℓ hΓ M⊢)
+  RuntimeOK (proj₁ (compile hΓ M⊢))
+compile-runtime hΓ M⊢ = ok-no (compile-no• hΓ M⊢)
 
 compile-closed :
   ∀ {M A} →
-  (ℓ : Label) →
   0 ∣ [] ⊢ᴳ M ⦂ A →
   Σ[ N ∈ Term ] RuntimeOK N × (0 ∣ [] ∣ [] ⊢ᵀ N ⦂ A)
-compile-closed ℓ M⊢ with compile ℓ ctxWf-[] M⊢ | compile-runtime ℓ ctxWf-[] M⊢
+compile-closed M⊢ with compile ctxWf-[] M⊢ | compile-runtime ctxWf-[] M⊢
 ... | N , N⊢ | okN = N , okN , N⊢
 
 ------------------------------------------------------------------------
@@ -145,38 +142,20 @@ record RunResult (M : GTerm) : Set₁ where
 
 open RunResult public
 
-runTypedWithLabel :
-  ∀ {M A} →
-  (ℓ : Label) →
-  (gas : ℕ) →
-  0 ∣ [] ⊢ᴳ M ⦂ A →
-  Maybe (RunResult M)
-runTypedWithLabel ℓ gas M⊢ with compile-closed ℓ M⊢
-... | N , okN , N⊢ with eval gas empty-store-wf okN N⊢
-...   | just result = just (ran _ M⊢ N okN N⊢ result)
-...   | nothing = nothing
-
-default-label : Label
-default-label = zero
-
 runTyped :
   ∀ {M A} →
   (gas : ℕ) →
   0 ∣ [] ⊢ᴳ M ⦂ A →
   Maybe (RunResult M)
-runTyped gas M⊢ = runTypedWithLabel default-label gas M⊢
-
-runWithLabel :
-  (ℓ : Label) →
-  (gas : ℕ) →
-  (M : GTerm) →
-  Maybe (RunResult M)
-runWithLabel ℓ gas M with type-check 0 [] ctxWf-[] M
-... | just (A , M⊢) = runTypedWithLabel ℓ gas M⊢
-... | nothing = nothing
+runTyped gas M⊢ with compile-closed M⊢
+... | N , okN , N⊢ with eval gas empty-store-wf okN N⊢
+...   | just result = just (ran _ M⊢ N okN N⊢ result)
+...   | nothing = nothing
 
 run :
   (gas : ℕ) →
   (M : GTerm) →
   Maybe (RunResult M)
-run gas M = runWithLabel default-label gas M
+run gas M with type-check 0 [] ctxWf-[] M
+... | just (A , M⊢) = runTyped gas M⊢
+... | nothing = nothing


### PR DESCRIPTION
## Summary

- Rename `GradualTypeCheckExamples` to `GradualExamples` to reflect that the module now covers both type checking and execution.
- Add `Run`-based regression checks for each closed executable gradual example, including expected bare natural and dynamically tagged natural results.
- Update `Run` for the current `compile hΓ M⊢` API after the global label argument was removed.

## Validation

- `agda -v0 Run.agda` from `GTSF/`
- `agda -v0 GradualExamples.agda` from `GTSF/`

Skipped `All.agda` per request; only touched files were checked.