### PR TITLE
Discharge three of the four mediated plumbing holes (migration step 4)

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -25,6 +25,7 @@ import proof.TermNarrowingProperties
 import proof.CatchupSeparated
 import Mediation
 import MediatedNarrowing
+import proof.DualRawProperties
 import proof.MediationProperties
 import proof.CatchupMediated
 import proof.SimBetaMediated

--- a/GTSF/proof/DualRawProperties.agda
+++ b/GTSF/proof/DualRawProperties.agda
@@ -1,0 +1,692 @@
+module proof.DualRawProperties where
+
+-- File Charter:
+--   * The raw computed by the witness-directed duals
+--     (`NarrowWiden.dualⁿ`/`dualʷ` and their cross/strict variants)
+--     is determined by the raw coercion and the action environment
+--     alone: it equals the total raw-level functions
+--     `dualRawⁿ`/`dualRawʷ` below, which mirror the witness duals'
+--     case tree — including the collapsing tag-to-seal/seal-to-tag
+--     branches — by raw shape.  (The witness dual is NOT the
+--     `Coercions.dual` operator: on collapsed sequences the two
+--     disagree, so the raw-level mirror has to carry the same
+--     collapses.)
+--   * Corollaries: dual raws are determined across witnesses of any
+--     sort (proving, for the mediated surface, the statement the old
+--     two-store surface postulates as `dualʷ-raw-determined`), and
+--     dual raws commute with type renaming over an action-environment
+--     renaming relation (`ActionRename`).
+--   * Everything here is proved.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Nat using (zero; suc)
+open import Data.Product using (proj₁)
+open import Relation.Binary.PropositionalEquality using
+  (cong; cong₂; trans; sym)
+
+open import Types
+open import Coercions
+open import NarrowWiden
+
+------------------------------------------------------------------------
+-- The raw dual functions
+------------------------------------------------------------------------
+
+-- One function per polarity: all four narrowing witness sorts
+-- (`Narrowing`, `StrictNarrowing`, `CrossNarrowing`,
+-- `StrictCrossNarrowing`) compute the same dual raw, and likewise for
+-- the widening sorts.  On raws no witness inhabits, the value is
+-- junk, chosen renaming-naturally so the commutation lemma below
+-- needs no side conditions.
+
+mutual
+  dualRawⁿ : DualActionEnv → Coercion → Coercion
+  dualRawⁿ η (id A) = id A
+  dualRawⁿ η (c ︔ d) = dualRawSeqⁿ η c d
+  dualRawⁿ η (c ↦ d) = dualRawʷ η c ↦ dualRawⁿ η d
+  dualRawⁿ η (`∀ c) = `∀ (dualRawⁿ (extᵃ η) c)
+  dualRawⁿ η (G !) = G !
+  dualRawⁿ η (G ？) = dualUntag η G
+  dualRawⁿ η (seal A α) = dualSeal η A α
+  dualRawⁿ η (unseal α A) = unseal α A
+  dualRawⁿ η (gen A c) = inst A (dualRawⁿ (genᵃ η) c)
+  dualRawⁿ η (inst B c) = gen B (dualRawⁿ (instᵃ η) c)
+
+  -- A narrowing sequence witness either seals on the right
+  -- (`_︔seal_`) or untags on the left (`_？︔_`); the seal shape wins
+  -- the dispatch because the untag witness's tail (a strict cross
+  -- narrowing) cannot be a seal.
+  dualRawSeqⁿ : DualActionEnv → Coercion → Coercion → Coercion
+  dualRawSeqⁿ η c (seal A α) with η α
+  ... | normal = unseal α A ︔ dualRawⁿ η c
+  ... | tag-to-seal = unseal α A ︔ dualRawⁿ η c
+  ... | seal-to-tag = (＇ α) !
+  dualRawSeqⁿ η c d = dualRawUntagSeqⁿ η c d
+
+  dualRawUntagSeqⁿ : DualActionEnv → Coercion → Coercion → Coercion
+  dualRawUntagSeqⁿ η ((＇ α) ？) d with η α
+  ... | normal = dualRawⁿ η d ︔ ((＇ α) !)
+  ... | tag-to-seal = unseal α ★
+  ... | seal-to-tag = dualRawⁿ η d ︔ ((＇ α) !)
+  dualRawUntagSeqⁿ η (G ？) d = dualRawⁿ η d ︔ (G !)
+  dualRawUntagSeqⁿ η c d = dualRawⁿ η d ︔ dualRawⁿ η c
+
+  dualRawʷ : DualActionEnv → Coercion → Coercion
+  dualRawʷ η (id A) = id A
+  dualRawʷ η (c ︔ d) = dualRawSeqʷ η c d
+  dualRawʷ η (c ↦ d) = dualRawⁿ η c ↦ dualRawʷ η d
+  dualRawʷ η (`∀ c) = `∀ (dualRawʷ (extᵃ η) c)
+  dualRawʷ η (G !) = dualTag η G
+  dualRawʷ η (G ？) = G ？
+  dualRawʷ η (seal A α) = seal A α
+  dualRawʷ η (unseal α A) = dualUnseal η α A
+  dualRawʷ η (gen A c) = inst A (dualRawʷ (genᵃ η) c)
+  dualRawʷ η (inst B c) = gen B (dualRawʷ (instᵃ η) c)
+
+  -- A widening sequence witness either unseals on the left
+  -- (`unseal︔_`) or tags on the right (`_︔_!`); the unseal shape
+  -- wins the dispatch because the tag witness's head (a strict cross
+  -- widening) cannot be an unseal.
+  dualRawSeqʷ : DualActionEnv → Coercion → Coercion → Coercion
+  dualRawSeqʷ η (unseal α A) d with η α
+  ... | normal = dualRawʷ η d ︔ seal A α
+  ... | tag-to-seal = dualRawʷ η d ︔ seal A α
+  ... | seal-to-tag = (＇ α) ？
+  dualRawSeqʷ η c d = dualRawTagSeqʷ η c d
+
+  dualRawTagSeqʷ : DualActionEnv → Coercion → Coercion → Coercion
+  dualRawTagSeqʷ η c ((＇ α) !) with η α
+  ... | normal = ((＇ α) ？) ︔ dualRawʷ η c
+  ... | tag-to-seal = seal ★ α
+  ... | seal-to-tag = ((＇ α) ？) ︔ dualRawʷ η c
+  dualRawTagSeqʷ η c (G !) = (G ？) ︔ dualRawʷ η c
+  dualRawTagSeqʷ η c d = dualRawʷ η d ︔ dualRawʷ η c
+
+------------------------------------------------------------------------
+-- Dispatch reductions
+------------------------------------------------------------------------
+
+-- The sequence dispatchers step to their second stage when the
+-- witness pins the discriminating factor away from the seal/unseal
+-- shape.
+
+dualRawSeqⁿ-nonseal :
+  ∀ η c {d} →
+  StrictCrossNarrowing d →
+  dualRawSeqⁿ η c d ≡ dualRawUntagSeqⁿ η c d
+dualRawSeqⁿ-nonseal η c (cn-funˡ _ _) = refl
+dualRawSeqⁿ-nonseal η c (cn-funʳ _ _) = refl
+dualRawSeqⁿ-nonseal η c (cn-all _) = refl
+
+dualRawSeqʷ-nonunseal :
+  ∀ η {c} →
+  StrictCrossWidening c →
+  ∀ d →
+  dualRawSeqʷ η c d ≡ dualRawTagSeqʷ η c d
+dualRawSeqʷ-nonunseal η (cw-funˡ _ _) d = refl
+dualRawSeqʷ-nonunseal η (cw-funʳ _ _) d = refl
+dualRawSeqʷ-nonunseal η (cw-all _) d = refl
+
+------------------------------------------------------------------------
+-- The witness-directed duals compute the raw dual
+------------------------------------------------------------------------
+
+mutual
+  dualCrossⁿ-raw :
+    ∀ η {c} (w : CrossNarrowing c) →
+    proj₁ (dualCrossNarrowing η w) ≡ dualRawⁿ η c
+  dualCrossⁿ-raw η (id-＇ α) = refl
+  dualCrossⁿ-raw η (id-‵ ι) = refl
+  dualCrossⁿ-raw η (sʷ ↦ tⁿ) =
+    cong₂ _↦_ (dualʷ-raw η sʷ) (dualⁿ-raw η tⁿ)
+  dualCrossⁿ-raw η (`∀ sⁿ) =
+    cong `∀ (dualⁿ-raw (extᵃ η) sⁿ)
+
+  dualStrictCrossⁿ-raw :
+    ∀ η {c} (w : StrictCrossNarrowing c) →
+    proj₁ (dualStrictCrossNarrowing η w) ≡ dualRawⁿ η c
+  dualStrictCrossⁿ-raw η (cn-funˡ sʷ tⁿ) =
+    cong₂ _↦_ (dualStrictʷ-raw η sʷ) (dualⁿ-raw η tⁿ)
+  dualStrictCrossⁿ-raw η (cn-funʳ sʷ tⁿ) =
+    cong₂ _↦_ (dualʷ-raw η sʷ) (dualStrictⁿ-raw η tⁿ)
+  dualStrictCrossⁿ-raw η (cn-all sⁿ) =
+    cong `∀ (dualStrictⁿ-raw (extᵃ η) sⁿ)
+
+  dualⁿ-raw :
+    ∀ η {c} (w : Narrowing c) →
+    proj₁ (dualⁿ η w) ≡ dualRawⁿ η c
+  dualⁿ-raw η (cross gⁿ) = dualCrossⁿ-raw η gⁿ
+  dualⁿ-raw η id★ = refl
+  dualⁿ-raw η (gen {A = A} sⁿ) =
+    cong (inst A) (dualⁿ-raw (genᵃ η) sⁿ)
+  dualⁿ-raw η (untag (＇ α)) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualⁿ-raw η (untag (‵ ι)) = refl
+  dualⁿ-raw η (untag ★⇒★) = refl
+  dualⁿ-raw η (_？︔_ (＇ α) gⁿ)
+    with dualRawSeqⁿ-nonseal η ((＇ α) ？) gⁿ
+  ... | eq with η α
+  ...   | normal =
+    trans
+      (cong (_︔ ((＇ α) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym eq)
+  ...   | tag-to-seal = sym eq
+  ...   | seal-to-tag =
+    trans
+      (cong (_︔ ((＇ α) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym eq)
+  dualⁿ-raw η (_？︔_ (‵ ι) gⁿ) =
+    trans
+      (cong (_︔ ((‵ ι) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym (dualRawSeqⁿ-nonseal η ((‵ ι) ？) gⁿ))
+  dualⁿ-raw η (_？︔_ ★⇒★ gⁿ) =
+    trans
+      (cong (_︔ ((★ ⇒ ★) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym (dualRawSeqⁿ-nonseal η ((★ ⇒ ★) ？) gⁿ))
+  dualⁿ-raw η (sealⁿ A α) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualⁿ-raw η (_︔seal_ {A = A} sⁿ α) with η α
+  ... | normal = cong (unseal α A ︔_) (dualStrictⁿ-raw η sⁿ)
+  ... | tag-to-seal = cong (unseal α A ︔_) (dualStrictⁿ-raw η sⁿ)
+  ... | seal-to-tag = refl
+
+  dualStrictⁿ-raw :
+    ∀ η {c} (w : StrictNarrowing c) →
+    proj₁ (dualStrictⁿ η w) ≡ dualRawⁿ η c
+  dualStrictⁿ-raw η (strict-crossⁿ gⁿ) = dualStrictCrossⁿ-raw η gⁿ
+  dualStrictⁿ-raw η (strict-gen {A = A} sⁿ) =
+    cong (inst A) (dualⁿ-raw (genᵃ η) sⁿ)
+  dualStrictⁿ-raw η (strict-untag (＇ α)) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualStrictⁿ-raw η (strict-untag (‵ ι)) = refl
+  dualStrictⁿ-raw η (strict-untag ★⇒★) = refl
+  dualStrictⁿ-raw η (strict-untag-seq (＇ α) gⁿ)
+    with dualRawSeqⁿ-nonseal η ((＇ α) ？) gⁿ
+  ... | eq with η α
+  ...   | normal =
+    trans
+      (cong (_︔ ((＇ α) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym eq)
+  ...   | tag-to-seal = sym eq
+  ...   | seal-to-tag =
+    trans
+      (cong (_︔ ((＇ α) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym eq)
+  dualStrictⁿ-raw η (strict-untag-seq (‵ ι) gⁿ) =
+    trans
+      (cong (_︔ ((‵ ι) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym (dualRawSeqⁿ-nonseal η ((‵ ι) ？) gⁿ))
+  dualStrictⁿ-raw η (strict-untag-seq ★⇒★ gⁿ) =
+    trans
+      (cong (_︔ ((★ ⇒ ★) !)) (dualStrictCrossⁿ-raw η gⁿ))
+      (sym (dualRawSeqⁿ-nonseal η ((★ ⇒ ★) ？) gⁿ))
+  dualStrictⁿ-raw η (strict-seal A α) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualStrictⁿ-raw η (strict-seal-seq {A = A} sⁿ α) with η α
+  ... | normal = cong (unseal α A ︔_) (dualStrictⁿ-raw η sⁿ)
+  ... | tag-to-seal = cong (unseal α A ︔_) (dualStrictⁿ-raw η sⁿ)
+  ... | seal-to-tag = refl
+
+  dualCrossʷ-raw :
+    ∀ η {c} (w : CrossWidening c) →
+    proj₁ (dualCrossWidening η w) ≡ dualRawʷ η c
+  dualCrossʷ-raw η (id-＇ α) = refl
+  dualCrossʷ-raw η (id-‵ ι) = refl
+  dualCrossʷ-raw η (sⁿ ↦ tʷ) =
+    cong₂ _↦_ (dualⁿ-raw η sⁿ) (dualʷ-raw η tʷ)
+  dualCrossʷ-raw η (`∀ sʷ) =
+    cong `∀ (dualʷ-raw (extᵃ η) sʷ)
+
+  dualStrictCrossʷ-raw :
+    ∀ η {c} (w : StrictCrossWidening c) →
+    proj₁ (dualStrictCrossWidening η w) ≡ dualRawʷ η c
+  dualStrictCrossʷ-raw η (cw-funˡ sⁿ tʷ) =
+    cong₂ _↦_ (dualStrictⁿ-raw η sⁿ) (dualʷ-raw η tʷ)
+  dualStrictCrossʷ-raw η (cw-funʳ sⁿ tʷ) =
+    cong₂ _↦_ (dualⁿ-raw η sⁿ) (dualStrictʷ-raw η tʷ)
+  dualStrictCrossʷ-raw η (cw-all sʷ) =
+    cong `∀ (dualStrictʷ-raw (extᵃ η) sʷ)
+
+  dualʷ-raw :
+    ∀ η {c} (w : Widening c) →
+    proj₁ (dualʷ η w) ≡ dualRawʷ η c
+  dualʷ-raw η (cross gʷ) = dualCrossʷ-raw η gʷ
+  dualʷ-raw η id★ = refl
+  dualʷ-raw η (inst {B = B} sʷ) =
+    cong (gen B) (dualʷ-raw (instᵃ η) sʷ)
+  dualʷ-raw η (tag (＇ α)) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualʷ-raw η (tag (‵ ι)) = refl
+  dualʷ-raw η (tag ★⇒★) = refl
+  dualʷ-raw η (_︔_! {g = g} gʷ (＇ α))
+    with dualRawSeqʷ-nonunseal η gʷ ((＇ α) !)
+  ... | eq with η α
+  ...   | normal =
+    trans
+      (cong (((＇ α) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym eq)
+  ...   | tag-to-seal = sym eq
+  ...   | seal-to-tag =
+    trans
+      (cong (((＇ α) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym eq)
+  dualʷ-raw η (_︔_! gʷ (‵ ι)) =
+    trans
+      (cong (((‵ ι) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym (dualRawSeqʷ-nonunseal η gʷ ((‵ ι) !)))
+  dualʷ-raw η (_︔_! gʷ ★⇒★) =
+    trans
+      (cong (((★ ⇒ ★) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym (dualRawSeqʷ-nonunseal η gʷ ((★ ⇒ ★) !)))
+  dualʷ-raw η (unsealʷ α A) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualʷ-raw η (unseal︔_ α {A = A} sʷ) with η α
+  ... | normal = cong (_︔ seal A α) (dualStrictʷ-raw η sʷ)
+  ... | tag-to-seal = cong (_︔ seal A α) (dualStrictʷ-raw η sʷ)
+  ... | seal-to-tag = refl
+
+  dualStrictʷ-raw :
+    ∀ η {c} (w : StrictWidening c) →
+    proj₁ (dualStrictʷ η w) ≡ dualRawʷ η c
+  dualStrictʷ-raw η (strict-crossʷ gʷ) = dualStrictCrossʷ-raw η gʷ
+  dualStrictʷ-raw η (strict-inst {B = B} sʷ) =
+    cong (gen B) (dualʷ-raw (instᵃ η) sʷ)
+  dualStrictʷ-raw η (strict-tag (＇ α)) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualStrictʷ-raw η (strict-tag (‵ ι)) = refl
+  dualStrictʷ-raw η (strict-tag ★⇒★) = refl
+  dualStrictʷ-raw η (strict-tag-seq gʷ (＇ α))
+    with dualRawSeqʷ-nonunseal η gʷ ((＇ α) !)
+  ... | eq with η α
+  ...   | normal =
+    trans
+      (cong (((＇ α) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym eq)
+  ...   | tag-to-seal = sym eq
+  ...   | seal-to-tag =
+    trans
+      (cong (((＇ α) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym eq)
+  dualStrictʷ-raw η (strict-tag-seq gʷ (‵ ι)) =
+    trans
+      (cong (((‵ ι) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym (dualRawSeqʷ-nonunseal η gʷ ((‵ ι) !)))
+  dualStrictʷ-raw η (strict-tag-seq gʷ ★⇒★) =
+    trans
+      (cong (((★ ⇒ ★) ？) ︔_) (dualStrictCrossʷ-raw η gʷ))
+      (sym (dualRawSeqʷ-nonunseal η gʷ ((★ ⇒ ★) !)))
+  dualStrictʷ-raw η (strict-unseal α A) with η α
+  ... | normal = refl
+  ... | tag-to-seal = refl
+  ... | seal-to-tag = refl
+  dualStrictʷ-raw η (strict-unseal-seq α {A = A} sʷ) with η α
+  ... | normal = cong (_︔ seal A α) (dualStrictʷ-raw η sʷ)
+  ... | tag-to-seal = cong (_︔ seal A α) (dualStrictʷ-raw η sʷ)
+  ... | seal-to-tag = refl
+
+------------------------------------------------------------------------
+-- Determinacy corollaries
+------------------------------------------------------------------------
+
+-- The dual raw does not depend on the witness — of any sort.  The
+-- widening instance is the statement the old two-store surface
+-- postulates (`LeftChangeNarrowingSeparated.dualʷ-raw-determined`).
+
+dualⁿ-raw-determined :
+  ∀ η {c} (w₁ w₂ : Narrowing c) →
+  proj₁ (dualⁿ η w₁) ≡ proj₁ (dualⁿ η w₂)
+dualⁿ-raw-determined η w₁ w₂ =
+  trans (dualⁿ-raw η w₁) (sym (dualⁿ-raw η w₂))
+
+dualʷ-raw-determined :
+  ∀ η {c} (w₁ w₂ : Widening c) →
+  proj₁ (dualʷ η w₁) ≡ proj₁ (dualʷ η w₂)
+dualʷ-raw-determined η w₁ w₂ =
+  trans (dualʷ-raw η w₁) (sym (dualʷ-raw η w₂))
+
+------------------------------------------------------------------------
+-- Renaming commutation
+------------------------------------------------------------------------
+
+-- Renaming a coercion and taking its dual raw commute, over a
+-- renaming relation between the action environments.  The relation
+-- extends under all three binder actions, and the identity instance
+-- `ActionRename ρ normalᵃ normalᵃ` holds by `refl`.
+
+ActionRename : Renameᵗ → DualActionEnv → DualActionEnv → Set
+ActionRename ρ η η′ = ∀ α → η′ (ρ α) ≡ η α
+
+-- The environments are explicit throughout this section: they only
+-- ever occur applied (never as patterns), so Agda cannot recover them
+-- from the goal.
+
+ActionRename-ext :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ActionRename (extᵗ ρ) (extᵃ η) (extᵃ η′)
+ActionRename-ext ρ η η′ rel zero = refl
+ActionRename-ext ρ η η′ rel (suc α) = rel α
+
+ActionRename-gen :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ActionRename (extᵗ ρ) (genᵃ η) (genᵃ η′)
+ActionRename-gen ρ η η′ rel zero = refl
+ActionRename-gen ρ η η′ rel (suc α) = rel α
+
+ActionRename-inst :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ActionRename (extᵗ ρ) (instᵃ η) (instᵃ η′)
+ActionRename-inst ρ η η′ rel zero = refl
+ActionRename-inst ρ η η′ rel (suc α) = rel α
+
+dualUntag-renameᵗ :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ∀ G →
+  dualUntag η′ (renameᵗ ρ G) ≡ renameᶜ ρ (dualUntag η G)
+dualUntag-renameᵗ ρ η η′ rel (＇ α) rewrite rel α with η α
+... | normal = refl
+... | tag-to-seal = refl
+... | seal-to-tag = refl
+dualUntag-renameᵗ ρ η η′ rel (‵ ι) = refl
+dualUntag-renameᵗ ρ η η′ rel ★ = refl
+dualUntag-renameᵗ ρ η η′ rel (A ⇒ B) = refl
+dualUntag-renameᵗ ρ η η′ rel (`∀ A) = refl
+
+dualTag-renameᵗ :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ∀ G →
+  dualTag η′ (renameᵗ ρ G) ≡ renameᶜ ρ (dualTag η G)
+dualTag-renameᵗ ρ η η′ rel (＇ α) rewrite rel α with η α
+... | normal = refl
+... | tag-to-seal = refl
+... | seal-to-tag = refl
+dualTag-renameᵗ ρ η η′ rel (‵ ι) = refl
+dualTag-renameᵗ ρ η η′ rel ★ = refl
+dualTag-renameᵗ ρ η η′ rel (A ⇒ B) = refl
+dualTag-renameᵗ ρ η η′ rel (`∀ A) = refl
+
+dualSeal-renameᵗ :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ∀ A α →
+  dualSeal η′ (renameᵗ ρ A) (ρ α) ≡ renameᶜ ρ (dualSeal η A α)
+dualSeal-renameᵗ ρ η η′ rel A α rewrite rel α with η α
+... | normal = refl
+... | tag-to-seal = refl
+... | seal-to-tag = refl
+
+dualUnseal-renameᵗ :
+  ∀ ρ η η′ →
+  ActionRename ρ η η′ →
+  ∀ α A →
+  dualUnseal η′ (ρ α) (renameᵗ ρ A) ≡ renameᶜ ρ (dualUnseal η α A)
+dualUnseal-renameᵗ ρ η η′ rel α A rewrite rel α with η α
+... | normal = refl
+... | tag-to-seal = refl
+... | seal-to-tag = refl
+
+mutual
+  dualRawⁿ-renameᶜ :
+    ∀ ρ η η′ →
+    ActionRename ρ η η′ →
+    ∀ c →
+    dualRawⁿ η′ (renameᶜ ρ c) ≡ renameᶜ ρ (dualRawⁿ η c)
+  dualRawⁿ-renameᶜ ρ η η′ rel (id A) = refl
+  dualRawⁿ-renameᶜ ρ η η′ rel (c ︔ d) =
+    dualRawSeqⁿ-renameᶜ ρ η η′ rel c d
+  dualRawⁿ-renameᶜ ρ η η′ rel (c ↦ d) =
+    cong₂ _↦_
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  dualRawⁿ-renameᶜ ρ η η′ rel (`∀ c) =
+    cong `∀
+      (dualRawⁿ-renameᶜ (extᵗ ρ) (extᵃ η) (extᵃ η′)
+        (ActionRename-ext ρ η η′ rel) c)
+  dualRawⁿ-renameᶜ ρ η η′ rel (G !) = refl
+  dualRawⁿ-renameᶜ ρ η η′ rel (G ？) = dualUntag-renameᵗ ρ η η′ rel G
+  dualRawⁿ-renameᶜ ρ η η′ rel (seal A α) =
+    dualSeal-renameᵗ ρ η η′ rel A α
+  dualRawⁿ-renameᶜ ρ η η′ rel (unseal α A) = refl
+  dualRawⁿ-renameᶜ ρ η η′ rel (gen A c) =
+    cong (inst _)
+      (dualRawⁿ-renameᶜ (extᵗ ρ) (genᵃ η) (genᵃ η′)
+        (ActionRename-gen ρ η η′ rel) c)
+  dualRawⁿ-renameᶜ ρ η η′ rel (inst B c) =
+    cong (gen _)
+      (dualRawⁿ-renameᶜ (extᵗ ρ) (instᵃ η) (instᵃ η′)
+        (ActionRename-inst ρ η η′ rel) c)
+
+  dualRawSeqⁿ-renameᶜ :
+    ∀ ρ η η′ →
+    ActionRename ρ η η′ →
+    ∀ c d →
+    dualRawSeqⁿ η′ (renameᶜ ρ c) (renameᶜ ρ d)
+      ≡ renameᶜ ρ (dualRawSeqⁿ η c d)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (seal A α) rewrite rel α with η α
+  ... | normal =
+    cong (unseal (ρ α) (renameᵗ ρ A) ︔_)
+      (dualRawⁿ-renameᶜ ρ η η′ rel c)
+  ... | tag-to-seal =
+    cong (unseal (ρ α) (renameᵗ ρ A) ︔_)
+      (dualRawⁿ-renameᶜ ρ η η′ rel c)
+  ... | seal-to-tag = refl
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (id A) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (id A)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (d₁ ︔ d₂) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (d₁ ︔ d₂)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (d₁ ↦ d₂) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (d₁ ↦ d₂)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (`∀ d) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (`∀ d)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (G !) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (G !)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (G ？) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (G ？)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (unseal α A) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (unseal α A)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (gen A d) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (gen A d)
+  dualRawSeqⁿ-renameᶜ ρ η η′ rel c (inst B d) =
+    dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel c (inst B d)
+
+  dualRawUntagSeqⁿ-renameᶜ :
+    ∀ ρ η η′ →
+    ActionRename ρ η η′ →
+    ∀ c d →
+    dualRawUntagSeqⁿ η′ (renameᶜ ρ c) (renameᶜ ρ d)
+      ≡ renameᶜ ρ (dualRawUntagSeqⁿ η c d)
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel ((＇ α) ？) d
+      rewrite rel α with η α
+  ... | normal =
+    cong (_︔ ((＇ (ρ α)) !)) (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  ... | tag-to-seal = refl
+  ... | seal-to-tag =
+    cong (_︔ ((＇ (ρ α)) !)) (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel ((‵ ι) ？) d =
+    cong (_︔ ((‵ ι) !)) (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (★ ？) d =
+    cong (_︔ (★ !)) (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel ((A ⇒ B) ？) d =
+    cong (_︔ ((renameᵗ ρ A ⇒ renameᵗ ρ B) !))
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel ((`∀ A) ？) d =
+    cong (_︔ ((`∀ (renameᵗ (extᵗ ρ) A)) !))
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (id A) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (id A))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (c₁ ︔ c₂) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (c₁ ︔ c₂))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (c₁ ↦ c₂) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (c₁ ↦ c₂))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (`∀ c) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (`∀ c))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (G !) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (G !))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (seal A α) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (seal A α))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (unseal α A) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (unseal α A))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (gen A c) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (gen A c))
+  dualRawUntagSeqⁿ-renameᶜ ρ η η′ rel (inst B c) d =
+    cong₂ _︔_
+      (dualRawⁿ-renameᶜ ρ η η′ rel d)
+      (dualRawⁿ-renameᶜ ρ η η′ rel (inst B c))
+
+  dualRawʷ-renameᶜ :
+    ∀ ρ η η′ →
+    ActionRename ρ η η′ →
+    ∀ c →
+    dualRawʷ η′ (renameᶜ ρ c) ≡ renameᶜ ρ (dualRawʷ η c)
+  dualRawʷ-renameᶜ ρ η η′ rel (id A) = refl
+  dualRawʷ-renameᶜ ρ η η′ rel (c ︔ d) =
+    dualRawSeqʷ-renameᶜ ρ η η′ rel c d
+  dualRawʷ-renameᶜ ρ η η′ rel (c ↦ d) =
+    cong₂ _↦_
+      (dualRawⁿ-renameᶜ ρ η η′ rel c)
+      (dualRawʷ-renameᶜ ρ η η′ rel d)
+  dualRawʷ-renameᶜ ρ η η′ rel (`∀ c) =
+    cong `∀
+      (dualRawʷ-renameᶜ (extᵗ ρ) (extᵃ η) (extᵃ η′)
+        (ActionRename-ext ρ η η′ rel) c)
+  dualRawʷ-renameᶜ ρ η η′ rel (G !) = dualTag-renameᵗ ρ η η′ rel G
+  dualRawʷ-renameᶜ ρ η η′ rel (G ？) = refl
+  dualRawʷ-renameᶜ ρ η η′ rel (seal A α) = refl
+  dualRawʷ-renameᶜ ρ η η′ rel (unseal α A) =
+    dualUnseal-renameᵗ ρ η η′ rel α A
+  dualRawʷ-renameᶜ ρ η η′ rel (gen A c) =
+    cong (inst _)
+      (dualRawʷ-renameᶜ (extᵗ ρ) (genᵃ η) (genᵃ η′)
+        (ActionRename-gen ρ η η′ rel) c)
+  dualRawʷ-renameᶜ ρ η η′ rel (inst B c) =
+    cong (gen _)
+      (dualRawʷ-renameᶜ (extᵗ ρ) (instᵃ η) (instᵃ η′)
+        (ActionRename-inst ρ η η′ rel) c)
+
+  dualRawSeqʷ-renameᶜ :
+    ∀ ρ η η′ →
+    ActionRename ρ η η′ →
+    ∀ c d →
+    dualRawSeqʷ η′ (renameᶜ ρ c) (renameᶜ ρ d)
+      ≡ renameᶜ ρ (dualRawSeqʷ η c d)
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (unseal α A) d rewrite rel α
+      with η α
+  ... | normal =
+    cong (_︔ seal (renameᵗ ρ A) (ρ α))
+      (dualRawʷ-renameᶜ ρ η η′ rel d)
+  ... | tag-to-seal =
+    cong (_︔ seal (renameᵗ ρ A) (ρ α))
+      (dualRawʷ-renameᶜ ρ η η′ rel d)
+  ... | seal-to-tag = refl
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (id A) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (id A) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (c₁ ︔ c₂) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (c₁ ︔ c₂) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (c₁ ↦ c₂) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (c₁ ↦ c₂) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (`∀ c) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (`∀ c) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (G !) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (G !) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (G ？) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (G ？) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (seal A α) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (seal A α) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (gen A c) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (gen A c) d
+  dualRawSeqʷ-renameᶜ ρ η η′ rel (inst B c) d =
+    dualRawTagSeqʷ-renameᶜ ρ η η′ rel (inst B c) d
+
+  dualRawTagSeqʷ-renameᶜ :
+    ∀ ρ η η′ →
+    ActionRename ρ η η′ →
+    ∀ c d →
+    dualRawTagSeqʷ η′ (renameᶜ ρ c) (renameᶜ ρ d)
+      ≡ renameᶜ ρ (dualRawTagSeqʷ η c d)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c ((＇ α) !)
+      rewrite rel α with η α
+  ... | normal =
+    cong (((＇ (ρ α)) ？) ︔_) (dualRawʷ-renameᶜ ρ η η′ rel c)
+  ... | tag-to-seal = refl
+  ... | seal-to-tag =
+    cong (((＇ (ρ α)) ？) ︔_) (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c ((‵ ι) !) =
+    cong (((‵ ι) ？) ︔_) (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (★ !) =
+    cong ((★ ？) ︔_) (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c ((A ⇒ B) !) =
+    cong (((renameᵗ ρ A ⇒ renameᵗ ρ B) ？) ︔_)
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c ((`∀ A) !) =
+    cong (((`∀ (renameᵗ (extᵗ ρ) A)) ？) ︔_)
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (id A) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (id A))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (d₁ ︔ d₂) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (d₁ ︔ d₂))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (d₁ ↦ d₂) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (d₁ ↦ d₂))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (`∀ d) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (`∀ d))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (G ？) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (G ？))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (seal A α) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (seal A α))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (unseal α A) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (unseal α A))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (gen A d) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (gen A d))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)
+  dualRawTagSeqʷ-renameᶜ ρ η η′ rel c (inst B d) =
+    cong₂ _︔_
+      (dualRawʷ-renameᶜ ρ η η′ rel (inst B d))
+      (dualRawʷ-renameᶜ ρ η η′ rel c)

--- a/GTSF/proof/MediationProperties.agda
+++ b/GTSF/proof/MediationProperties.agda
@@ -6,43 +6,50 @@ module proof.MediationProperties where
 --   * Store-typing properties of the mediated judgment: its
 --     store-change transports, the one-store and composition-record
 --     arrow projections, and the left-change transport family.
---   * Holes: the one-store left-change transports (base-language
---     lemmas, independent of mediation), the mediated term-relation
---     left-change transport, and the one-store weakening used by the
---     home-side allocation transport.
+--   * One hole: the mediated term-relation left-change transport
+--     (`left-changes-term-narrowingᵐ`), pending a left-insertion
+--     weakening of the relation — see the proof-design note at the
+--     hole.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Nat using (zero; suc; _<_; s≤s; z≤n)
+open import Data.Nat.Properties using (≤-refl)
 open import Data.List using ([]; _∷_)
 open import Data.Product using
-  (_×_; _,_; proj₁; ∃-syntax)
+  (_×_; _,_; proj₁; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality using
-  (subst; sym; trans)
+  (cong; subst; sym; trans)
 
 open import Types
 open import Coercions
-open import Store using (StoreWfAt)
+open import Store using (StoreWfAt; StoreIncl-drop)
 open import NarrowWiden using
   ( cross
   ; dualʷ
+  ; renameⁿ
+  ; modeRename-suc-inst
   ; _∣_∣_⊢_∶_⊒_
   )
   renaming (_↦_ to _↦ⁿʷ_)
 open import NuReduction using
   (StoreChange; keep; bind; StoreChanges;
    applyTy; applyTys; applyTyCtx; applyTyCtxs; applyCoercion;
-   applyStores; applyTerms)
+   applyStore; applyStores; applyTerms)
 open import StoreCorrespondence
 open import Mediation
 open import MediatedNarrowing
-open import proof.TypeProperties using (predᵗ)
+open import proof.TypeProperties using
+  (predᵗ; TyRenameWf-suc; RenameLeftInverse-suc)
 open import proof.CoercionProperties using
   ( dualActionOk-normal
   ; dualStoreAt-normal
+  ; coercion-weakenᵐ
+  ; coercion-renameᵗᵐ
   )
 open import proof.NarrowWidenProperties using
   ( dualʷ-flips-typingᵐ
   )
+open import proof.NuTermProperties using (modeRename-left-inverse)
 open import proof.ReductionProperties using (applyCoercions)
 open import proof.CatchupSeparated using
   ( applyLeftChange
@@ -51,8 +58,11 @@ open import proof.CatchupSeparated using
   ; rightStore-applyLeftChange
   ; leftStore-applyLeftChanges
   )
-open import proof.LeftChangeNarrowingSeparated using
-  ( dualʷ-raw-determined
+open import proof.DualRawProperties using
+  ( dualRawⁿ
+  ; dualⁿ-raw
+  ; dualʷ-raw-determined
+  ; dualRawⁿ-renameᶜ
   )
 
 ------------------------------------------------------------------------
@@ -101,8 +111,11 @@ left-alloc-transportᵐ {ρ = ρ} {r = r} {B = B}
 
 -- Home (right) store allocation: the home raw and its endpoints shift
 -- together with the home store, exactly as ξ-⟨⟩ rewrites the coercion
--- it steps under.  The mediation side is proved; the one-store
--- weakening of the home typing is a base-language lemma.
+-- it steps under.  The home typing weakens by the same
+-- shift-then-drop composition as `applyCoercion-typing`'s bind case,
+-- except at mode `instᵈ μ` — which agrees with `μ` on all shifted
+-- variables, so `modeRename-suc-inst` discharges the mode-renaming
+-- side condition.
 right-alloc-transportᵐ :
   ∀ {μ ΔL ΔR ρ r A B X} →
   StoreCorr ΔL (suc ΔR) (right-only zero (⇑ᵗ X) ∷ ⇑ʳᶜorr ρ) →
@@ -110,21 +123,23 @@ right-alloc-transportᵐ :
   instᵈ μ ∣ ΔL ∣ suc ΔR ∣ (right-only zero (⇑ᵗ X) ∷ ⇑ʳᶜorr ρ)
     ⊢ ⇑ᶜ r ∶ A ⊒ᵐ ⇑ᵗ B
 right-alloc-transportᵐ {μ = μ} {ρ = ρ} {r = r} {A = A} {B = B} {X = X}
-    corr′ (corr , wfA , wfB , Aʳ , med , r⊒) =
+    corr′ (corr , wfA , wfB , Aʳ , med , (r⊢ , rⁿ)) =
   corr′ ,
   wfA ,
   wfTy-⇑ wfB ,
   ⇑ᵗ Aʳ ,
   medTy-mapʳ suc mv-right-alloc med ,
-  {! right-store-shift-weakening !}
-  -- needed:
-  --   instᵈ μ ∣ suc ΔR ∣ (0 , ⇑ᵗ X) ∷ ⟰ᵗ (rightStore ρ)
-  --     ⊢ ⇑ᶜ r ∶ ⇑ᵗ Aʳ ⊒ ⇑ᵗ B
-  -- from r⊒ : μ ∣ ΔR ∣ rightStore ρ ⊢ r ∶ Aʳ ⊒ B, modulo
-  -- rightStore (right-only zero (⇑ᵗ X) ∷ ⇑ʳᶜorr ρ) ≡
-  --   (0 , ⇑ᵗ X) ∷ ⟰ᵗ (rightStore ρ)  (rightStore-⇑ʳᶜorr).
-  -- Ordinary one-store weakening in the base language, independent of
-  -- the mediation design.
+  subst
+    (λ Σ →
+      instᵈ μ ∣ suc _ ∣ (zero , ⇑ᵗ X) ∷ Σ ⊢ ⇑ᶜ r ∶ ⇑ᵗ Aʳ ⊒ ⇑ᵗ B)
+    (sym (rightStore-⇑ʳᶜorr ρ))
+    ( coercion-weakenᵐ ≤-refl StoreIncl-drop
+        (coercion-renameᵗᵐ
+          {ρ = suc} {μ = μ} {ν = instᵈ μ}
+          TyRenameWf-suc
+          (modeRename-suc-inst {μ = μ})
+          r⊢)
+    , renameⁿ suc rⁿ )
 
 ------------------------------------------------------------------------
 -- The mediated left-change family
@@ -218,18 +233,65 @@ applyModeEnvs : StoreChanges → ModeEnv → ModeEnv
 applyModeEnvs [] μ = μ
 applyModeEnvs (χ ∷ χs) μ = applyModeEnvs χs (applyModeEnv χ μ)
 
+-- Single-step transport of a left-store narrowing judgment: `keep`
+-- is the identity; `bind` weakens the typing by the same
+-- shift-then-drop composition as `applyCoercion-typing`'s bind case
+-- and renames the witness.  No store well-formedness is needed — the
+-- underlying weakening lemmas (`coercion-renameᵗᵐ`,
+-- `coercion-weakenᵐ`) never were, so the store-wf chaining question
+-- recorded in the checklist dissolves.
+left-change-narrowing¹ :
+  ∀ χ {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  applyModeEnv χ μ ∣ applyTyCtx χ Δ ∣ applyStore χ Σ
+    ⊢ applyCoercion χ c ∶ applyTy χ A ⊒ applyTy χ B
+left-change-narrowing¹ keep e = e
+left-change-narrowing¹ (bind X) {μ = μ} (c⊢ , cⁿ) =
+  coercion-weakenᵐ ≤-refl StoreIncl-drop
+    (coercion-renameᵗᵐ
+      {ρ = suc} {μ = μ} {ν = applyModeEnv (bind X) μ}
+      TyRenameWf-suc
+      (modeRename-left-inverse
+        {ρ = suc} {ψ = predᵗ}
+        RenameLeftInverse-suc)
+      c⊢) ,
+  renameⁿ suc cⁿ
+
 -- One-store transport of a left-store narrowing judgment across
 -- emitted left store changes: raw, endpoints, and store shift
 -- together (contrast `left-changes-transportᵐ`, where the home raw
--- is untouched).  Base-language plumbing — `applyCoercion-typing`
--- shapes plus the `renameⁿ` witness renaming; hole-bodied pending
--- the store-wf chaining question recorded in the checklist.
+-- is untouched).
 left-changes-narrowingˡ :
   ∀ χs {μ Δ Σ c A B} →
   μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
   applyModeEnvs χs μ ∣ applyTyCtxs χs Δ ∣ applyStores χs Σ
     ⊢ applyCoercions χs c ∶ applyTys χs A ⊒ applyTys χs B
-left-changes-narrowingˡ χs c⊒ = {! left-changes-narrowingˡ !}
+left-changes-narrowingˡ [] e = e
+left-changes-narrowingˡ (χ ∷ χs) e =
+  left-changes-narrowingˡ χs (left-change-narrowing¹ χ e)
+
+-- The dual raw of a narrowing witness is `dualRawⁿ` of the raw — in
+-- particular, independent of the witness and of everything else in
+-- the judgment.
+narrowing-dual¹-raw :
+  ∀ {μ Δ Σ c A B} →
+  (e : μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B) →
+  narrowing-dual¹ e ≡ dualRawⁿ normalᵃ c
+narrowing-dual¹-raw (_ , cⁿ) = dualⁿ-raw normalᵃ cⁿ
+
+-- The raw dual commutes with the store-change shifts (each `bind` is
+-- a `suc` renaming, and `normalᵃ` renames to itself).
+dualRawⁿ-applyCoercions :
+  ∀ χs c →
+  dualRawⁿ normalᵃ (applyCoercions χs c)
+    ≡ applyCoercions χs (dualRawⁿ normalᵃ c)
+dualRawⁿ-applyCoercions [] c = refl
+dualRawⁿ-applyCoercions (keep ∷ χs) c = dualRawⁿ-applyCoercions χs c
+dualRawⁿ-applyCoercions (bind X ∷ χs) c =
+  trans
+    (dualRawⁿ-applyCoercions χs (⇑ᶜ c))
+    (cong (applyCoercions χs)
+      (dualRawⁿ-renameᶜ suc normalᵃ normalᵃ (λ α → refl) c))
 
 -- The dual raw of a narrowing is determined by the raw alone and
 -- commutes with the store-change shifts.  Stated over two
@@ -240,8 +302,12 @@ narrowing-dual¹-applyCoercions :
   (e : μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B) →
   (e′ : μ′ ∣ Δ′ ∣ Σ′ ⊢ applyCoercions χs c ∶ A′ ⊒ B′) →
   narrowing-dual¹ e′ ≡ applyCoercions χs (narrowing-dual¹ e)
-narrowing-dual¹-applyCoercions χs e e′ =
-  {! narrowing-dual¹-applyCoercions !}
+narrowing-dual¹-applyCoercions χs {c = c} e e′ =
+  trans
+    (narrowing-dual¹-raw e′)
+    (trans
+      (dualRawⁿ-applyCoercions χs c)
+      (cong (applyCoercions χs) (sym (narrowing-dual¹-raw e))))
 
 ------------------------------------------------------------------------
 -- One-store arrow projections
@@ -398,9 +464,23 @@ left-changes-comp-srcᵐ χs {ΔL = ΔL} {ρ = ρ} corr′
 -- The mediated term-relation transport across left store changes:
 -- the ⊒ᵐ replacement for the old postulated
 -- `left-change-term-narrowing`.  Note the index raw `p` is untouched
--- — the point of the mediated design.  Structural induction over the
--- relation (binder cases shift the correspondence); hole-bodied, to
--- be discharged with the rest of the mediated left-change family.
+-- — the point of the mediated design.
+--
+-- Proof design (recorded 2026-07-06, with the rest of the family
+-- discharged): reduce to a single `bind`, which is a LEFT-ONLY
+-- INSERTION WEAKENING of the relation — the statement as given
+-- cannot be proved by direct induction, because the type-binder
+-- constructors (Λ⊒Λᵗ, ⊒Λᵗ, ⊒⟨ν⟩ᵗ, α⊒αᵗ, ⊒αᵗ, ν⊒νᵗ, ⊒νᵗ) put their
+-- sub-derivations (and for α⊒αᵗ/⊒αᵗ their conclusions) at
+-- `entry ∷ ⇑ᶜorr ρ`-shaped correspondences, where the outer change
+-- must land BELOW the binder entry, while `applyLeftChange` only
+-- inserts at position zero.  The single-bind lemma therefore needs
+-- the standard weakening generalization: an insertion renaming of
+-- the left side at arbitrary depth (a left sibling of `mv-lockstep`
+-- for `MatchedVar`, `medTy-mapˡ` for the mediation, renameⁿ/
+-- `coercion-renameᵗᵐ` for the left one-store evidence, and
+-- `shift-left-term-typing` for the term typings).  That is its own
+-- work item; hole-bodied until then.
 left-changes-term-narrowingᵐ :
   ∀ χs {ΔL ΔR ρ M M′ p A B} →
   StoreCorr (applyTyCtxs χs ΔL) ΔR (applyLeftChanges χs ρ) →

--- a/GTSF/proof/SeparatedStoresDGGChecklist.md
+++ b/GTSF/proof/SeparatedStoresDGGChecklist.md
@@ -494,6 +494,47 @@ no coercion mediation at all:
   the "left-mediability" open question is dissolved rather than
   answered.
 
+Migration step 4 (2026-07-06, mediated plumbing holes): three of the
+four `MediationProperties` holes are discharged; one remains.
+
+- New module `proof/DualRawProperties.agda` (hole-free): the raw
+  computed by the witness-directed duals equals the total raw-level
+  functions `dualRawⁿ`/`dualRawʷ`, which mirror the witness duals'
+  case tree by raw shape — including the collapsing
+  tag-to-seal/seal-to-tag branches, which is why the mirror is NOT
+  the `Coercions.dual` operator.  One function per polarity covers
+  all four witness sorts, so determinacy across witnesses of ANY
+  sorts is a two-line corollary — in particular
+  `dualʷ-raw-determined`, which the old surface postulates, is now
+  proved, and the mediated surface imports the proved one.  Dual raws
+  also commute with type renaming over an `ActionRename` relation
+  between action environments (explicit-environment formulation:
+  the environments only ever occur applied, so they cannot stay
+  implicit).
+- `left-changes-narrowingˡ` proved via a single-change
+  `left-change-narrowing¹`: `bind` is the same shift-then-drop
+  composition as `applyCoercion-typing`'s bind case plus `renameⁿ`
+  on the witness.  The recorded store-wf chaining question
+  DISSOLVES: the underlying weakening lemmas (`coercion-renameᵗᵐ`,
+  `coercion-weakenᵐ`) never needed store well-formedness —
+  `applyCoercion-typing`'s `StoreWfAt` premise is vestigial.
+- `narrowing-dual¹-applyCoercions` proved as a corollary:
+  `narrowing-dual¹ ≡ dualRawⁿ normalᵃ` kills the witness dependence,
+  and `dualRawⁿ-renameᶜ` iterates over the changes.
+- `right-store-shift-weakening` discharged inside
+  `right-alloc-transportᵐ`: the mode-renaming side condition at
+  `instᵈ μ` is `modeRename-suc-inst` (`instᵈ μ` agrees with `μ` on
+  all shifted variables).
+- REMAINING: `left-changes-term-narrowingᵐ`, now with a recorded
+  proof design — a single `bind` is a left-only insertion weakening
+  of the relation, and the type-binder constructors force the
+  standard generalization over an insertion renaming at arbitrary
+  depth (the outer change lands BELOW `entry ∷ ⇑ᶜorr ρ`-shaped
+  extensions, while `applyLeftChange` only inserts at position
+  zero).  Ingredients: an insertion sibling of `mv-lockstep`,
+  `medTy-mapˡ`, `renameⁿ`/`coercion-renameᵗᵐ`,
+  `shift-left-term-typing`.
+
 ## Track C. Catchup Proof
 
 - [x] Add right-side store-change operations.

--- a/TODO.md
+++ b/TODO.md
@@ -25,43 +25,30 @@ their postulates:
 New proof work goes to the `⊒ᵐ` ports (`proof/*Mediated.agda`,
 `proof/MediationProperties.agda`).
 
-[ ] Discharge the mediated plumbing holes in
-    `GTSF/proof/MediationProperties.agda` (left by PR #48, step 2 of
-    the mediated migration, plus one left over from step 1).  All
-    four are named `{! !}` holes; background is in the "Migration
-    step 2 progress" and "Migration step 3" entries of
-    `GTSF/proof/SeparatedStoresDGGChecklist.md`.  (A fifth hole,
-    `medCo-dualʷ`, was deleted along with `MedCo` itself by the ⨟ˡ
-    record simplification — migration step 3 — as was
-    `med-narrowing-witness`.)
-    1. `left-changes-narrowingˡ` — one-store left-store transport of
-       a narrowing judgment across `StoreChanges`.  Build from the
-       `applyCoercion-typing` shapes (proof/NuPreservation.agda) plus
-       `renameⁿ` witness renaming.  Open design point recorded in the
-       checklist: iterating needs StoreWfAt at each intermediate
-       step, but bare `StoreChanges` does not carry wf of the bound
-       types — either thread a wf-chain invariant or drop the wf
-       requirement from the underlying weakening lemmas.
-    2. `narrowing-dual¹-applyCoercions` — the dual raw of a narrowing
-       is determined by the raw and commutes with the store-change
-       shifts (a narrowing sibling of `dualʷ-raw-determined`, plus
-       dual/rename commutation generalized over the action env).
-    3. `left-changes-term-narrowingᵐ` — the ⊒ᵐ replacement of the old
-       postulated `left-change-term-narrowing`: structural induction
-       over `MediatedNarrowing._∣_∣_∣_⊢_⊒_∶_⦂_⊒ᵐ_` with the index
-       raw untouched; `left-changes-transportᵐ` handles the coercion
-       fields, binder cases shift the correspondence
-       (`⇑ᶜorr`/`⇑ᵍᶜ`-style, cf. `medTy-applyLeftChanges` and
-       `mv-lockstep`).
-    4. `right-store-shift-weakening` (inside
-       `right-alloc-transportᵐ`, left over from step 1) — ordinary
-       one-store weakening of the home typing under a right-store
-       allocation, modulo the `rightStore-⇑ʳᶜorr` reindexing; base
-       language, independent of mediation (see the comment at the
-       hole).
+[ ] Prove `left-changes-term-narrowingᵐ`, the last `{! !}` hole in
+    `GTSF/proof/MediationProperties.agda` (the ⊒ᵐ replacement of the
+    old postulated `left-change-term-narrowing`; the index raw is
+    untouched).  The other three holes of the mediated plumbing
+    family (`left-changes-narrowingˡ`,
+    `narrowing-dual¹-applyCoercions` via the new
+    `proof/DualRawProperties.agda`, and
+    `right-store-shift-weakening`) were discharged in migration
+    step 4 — see that checklist entry.
+    Proof design (recorded at the hole): reduce to a single `bind`,
+    which is a LEFT-ONLY INSERTION WEAKENING of the relation.  Direct
+    induction over the statement fails at the type-binder
+    constructors (Λ⊒Λᵗ, ⊒Λᵗ, ⊒⟨ν⟩ᵗ, α⊒αᵗ, ⊒αᵗ, ν⊒νᵗ, ⊒νᵗ): their
+    sub-derivations (and for α⊒αᵗ/⊒αᵗ their conclusions) sit at
+    `entry ∷ ⇑ᶜorr ρ`-shaped correspondences, where the outer change
+    must land BELOW the binder entry, while `applyLeftChange` only
+    inserts at position zero.  Generalize over a left-side insertion
+    renaming at arbitrary depth, with: an insertion sibling of
+    `mv-lockstep` for `MatchedVar`, `medTy-mapˡ` for the mediation,
+    `renameⁿ`/`coercion-renameᵗᵐ` for the left one-store evidence,
+    and `shift-left-term-typing` for the term typings.
     Constraints: no new postulates without explicit approval; holes
     OK; `make -C GTSF check` green before commit; commit + PR at the
-    end.  After these, the next migration step is moving the DGG
+    end.  After this, the next migration step is moving the DGG
     proof stack (`DGGBeta*`, `InnerStepCastSeparated`, the main
     theorem) onto ⊒ᵐ and deleting `TermNarrowingSeparated`.
 


### PR DESCRIPTION
## Why

The top TODO item — the mediated plumbing holes in [`GTSF/proof/MediationProperties.agda`](../blob/claude/mediated-left-change-plumbing/GTSF/proof/MediationProperties.agda) (migration step 4). Three of the four holes are discharged; the fourth gets a recorded proof design and stays as the one remaining hole.

## What

**New: [`GTSF/proof/DualRawProperties.agda`](../blob/claude/mediated-left-change-plumbing/GTSF/proof/DualRawProperties.agda)** (hole-free). The raw computed by the witness-directed duals (`dualⁿ`/`dualʷ` and the cross/strict variants) equals total raw-level functions `dualRawⁿ`/`dualRawʷ` that mirror the witness duals' case tree by raw shape — **including the collapsing tag-to-seal/seal-to-tag branches**, which is why the mirror is not the `Coercions.dual` operator (on collapsed sequences the two disagree). One function per polarity covers all four witness sorts, so:

- **dual-raw determinacy across witnesses of any sorts is a two-line corollary** — in particular `dualʷ-raw-determined`, which the old two-store surface *postulates*, is now **proved**, and the mediated surface imports the proved one (one postulate dependency of the mediated stack gone);
- dual raws commute with type renaming over an `ActionRename` relation between action environments (stated with explicit environments — they only ever occur applied, so Agda cannot recover them as implicits).

**[`GTSF/proof/MediationProperties.agda`](../blob/claude/mediated-left-change-plumbing/GTSF/proof/MediationProperties.agda)** — three holes discharged:

1. `left-changes-narrowingˡ` — via a new single-change `left-change-narrowing¹`: `bind` is the same shift-then-drop composition as `applyCoercion-typing`'s bind case plus `renameⁿ` on the witness. **The recorded store-wf chaining question dissolves**: the underlying weakening lemmas (`coercion-renameᵗᵐ`, `coercion-weakenᵐ`) never needed store well-formedness — `applyCoercion-typing`'s `StoreWfAt` premise is vestigial.
2. `narrowing-dual¹-applyCoercions` — corollary of the new module: `narrowing-dual¹ ≡ dualRawⁿ normalᵃ` kills the witness dependence, `dualRawⁿ-renameᶜ` iterates over the changes.
3. `right-store-shift-weakening` (inside `right-alloc-transportᵐ`, left over from step 1) — the mode-renaming side condition at `instᵈ μ` is exactly `modeRename-suc-inst`, since `instᵈ μ` agrees with `μ` on all shifted variables.

**Remaining: `left-changes-term-narrowingᵐ`** — kept as the single hole, now with a proof design recorded at the hole, in the checklist, and in the rescoped TODO item: a single `bind` is a **left-only insertion weakening** of the relation, and direct induction fails at the type-binder constructors (their sub-derivations sit at `entry ∷ ⇑ᶜorr ρ`-shaped correspondences, where the outer change must land *below* the binder entry, while `applyLeftChange` only inserts at position zero) — so it needs the standard generalization over an insertion renaming at arbitrary depth. That is its own work item.

The checklist gains a "Migration step 4" entry; TODO.md's top item is rescoped to the remaining hole.

## Validation

- `make -C GTSF check` (All.agda, now also listing the new module) green.
- No new postulates; one fewer postulate *dependency* (the mediated surface no longer imports the postulated `dualʷ-raw-determined`). Hole count in `proof/MediationProperties.agda`: 4 → 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
