### PR TITLE
[codex] Advance GTSF compile term narrowing proof

### DIFF
--- a/GTSF/GradualTermNarrowing.agda
+++ b/GTSF/GradualTermNarrowing.agda
@@ -20,7 +20,6 @@ open import Coercions
 open import GradualTerms
 open import NarrowWiden
 open import Primitives
-open import proof.CoercionProperties using (src-renameᶜ; tgt-renameᶜ)
 
 variable
   Δ : TyCtx
@@ -54,24 +53,27 @@ renameᵗᴳ ρ (L ⊕[ op at ℓ ] M) =
 -- Term-context narrowing
 ------------------------------------------------------------------------
 
+⇑ᵍ-entry : CtxNrwEntry → CtxNrwEntry
+⇑ᵍ-entry (ctx-nrw A B p) = ctx-nrw (⇑ᵗ A) (⇑ᵗ B) (⇑ᶜ p)
+
 ⇑ᵍ : CtxNrw → CtxNrw
-⇑ᵍ = map ⇑ᶜ
+⇑ᵍ = map ⇑ᵍ-entry
 
 srcCtxⁿ : CtxNrw → Ctx
-srcCtxⁿ = map src
+srcCtxⁿ = map srcTy
 
 tgtCtxⁿ : CtxNrw → Ctx
-tgtCtxⁿ = map tgt
+tgtCtxⁿ = map tgtTy
 
 srcCtxⁿ-⇑ᵍ : ∀ γ → srcCtxⁿ (⇑ᵍ γ) ≡ ⤊ᵗ (srcCtxⁿ γ)
 srcCtxⁿ-⇑ᵍ [] = refl
-srcCtxⁿ-⇑ᵍ (p ∷ γ) =
-  cong₂ _∷_ (src-renameᶜ suc p) (srcCtxⁿ-⇑ᵍ γ)
+srcCtxⁿ-⇑ᵍ (entry ∷ γ) =
+  cong₂ _∷_ refl (srcCtxⁿ-⇑ᵍ γ)
 
 tgtCtxⁿ-⇑ᵍ : ∀ γ → tgtCtxⁿ (⇑ᵍ γ) ≡ ⤊ᵗ (tgtCtxⁿ γ)
 tgtCtxⁿ-⇑ᵍ [] = refl
-tgtCtxⁿ-⇑ᵍ (p ∷ γ) =
-  cong₂ _∷_ (tgt-renameᶜ suc p) (tgtCtxⁿ-⇑ᵍ γ)
+tgtCtxⁿ-⇑ᵍ (entry ∷ γ) =
+  cong₂ _∷_ refl (tgtCtxⁿ-⇑ᵍ γ)
 
 ------------------------------------------------------------------------
 -- Typed/well-indexed gradual term narrowing
@@ -102,7 +104,7 @@ data _∣_∣_⊢ᴳ_⊒_∶_⦂_⊒_
   x⊒xᴳ : ∀ {x p A B}
     → {typing : GradualTermTypingEndpoints Δ γ (` x) (` x) A B}
     → Δ ∣ Σ ⊢ p ∶ᶜ A ⊒ B
-    → γ ∋ x ⦂ p
+    → γ ∋ x ⦂ ctx-nrw A B p
       --------------------------------
     → Δ ∣ Σ ∣ γ ⊢ᴳ ` x ⊒ ` x ∶ p ⦂ A ⊒ B
 
@@ -110,8 +112,9 @@ data _∣_∣_⊢ᴳ_⊒_∶_⦂_⊒_
     → {typing :
         GradualTermTypingEndpoints Δ γ
           (ƛ A ⇒ N) (ƛ A′ ⇒ N′) (A ⇒ B) (A′ ⇒ B′)}
-    → Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)
-    → Δ ∣ Σ ∣ (- p) ∷ γ ⊢ᴳ N ⊒ N′ ∶ q ⦂ B ⊒ B′
+    → (p↦qᶜ : Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′))
+    → Δ ∣ Σ ∣ ctx-nrw A A′ (fun-narrow-domain-dualᶜ p↦qᶜ) ∷ γ
+        ⊢ᴳ N ⊒ N′ ∶ q ⦂ B ⊒ B′
       ----------------------------------------------------
     → Δ ∣ Σ ∣ γ ⊢ᴳ ƛ A ⇒ N ⊒ ƛ A′ ⇒ N′ ∶ p ↦ q
         ⦂ A ⇒ B ⊒ A′ ⇒ B′
@@ -120,10 +123,11 @@ data _∣_∣_⊢ᴳ_⊒_∶_⦂_⊒_
     → {typing :
         GradualTermTypingEndpoints Δ γ
           (L ·[ ℓ ] M) (L′ ·[ ℓ ] M′) B B′}
-    → Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)
+    → (p↦qᶜ : Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′))
     → Δ ∣ Σ ∣ γ ⊢ᴳ L ⊒ L′ ∶ p ↦ q
         ⦂ A ⇒ B ⊒ A′ ⇒ B′
-    → Δ ∣ Σ ∣ γ ⊢ᴳ M ⊒ M′ ∶ - p ⦂ A ⊒ A′
+    → Δ ∣ Σ ∣ γ ⊢ᴳ M ⊒ M′ ∶ fun-narrow-domain-dualᶜ p↦qᶜ
+        ⦂ A ⊒ A′
       -------------------------------------------------------
     → Δ ∣ Σ ∣ γ ⊢ᴳ L ·[ ℓ ] M ⊒ L′ ·[ ℓ ] M′ ∶ q ⦂ B ⊒ B′
 

--- a/GTSF/NarrowWiden.agda
+++ b/GTSF/NarrowWiden.agda
@@ -600,6 +600,19 @@ _∣_⊢_∶ᶜ_⊒_ : TyCtx → Store → Coercion → Ty → Ty → Set
 Δ ∣ Σ ⊢ c ∶ᶜ A ⊒ B =
   tag-or-idᵈ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B
 
+fun-narrow-domain-dual :
+  ∀ {Δ Σ p q A A′ B B′} →
+  Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Coercion
+fun-narrow-domain-dual (cast-fun p⊢ q⊢ , cross (pʷ ↦ qⁿ)) =
+  proj₁ (dualʷ normalᵃ pʷ)
+
+fun-narrow-domain-dualᶜ :
+  ∀ {Δ Σ p q A A′ B B′} →
+  Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  Coercion
+fun-narrow-domain-dualᶜ = fun-narrow-domain-dual
+
 infix 4 _∣_∣_⊢ᶜ_∶_⊒_
 infix 4 _∣_∣_⊢ᶜ_∶_⊑_
 
@@ -1165,8 +1178,17 @@ data _⊢_꞉_⊒ˢ_ : TyCtx → StoreNrw → Store → Store → Set where
 
 -- γ
 
+record CtxNrwEntry : Set where
+  constructor ctx-nrw
+  field
+    srcTy : Ty
+    tgtTy : Ty
+    coercion : Coercion
+
+open CtxNrwEntry public
+
 CtxNrw : Set
-CtxNrw = List Coercion
+CtxNrw = List CtxNrwEntry
 
 -- Γ ⊑ Γ′
 
@@ -1177,7 +1199,7 @@ data _∣_⊢_꞉_⊑ᵍ_ : TyCtx → Store → CtxNrw → Ctx → Ctx → Set w
     → ∃[ μ ] μ ∣ Δ ∣ Σ ⊢ s ∶ A ⊑ B
     → Δ ∣ Σ ⊢ γ ꞉ Γ ⊑ᵍ Γ′
      -------------------------------------
-    → Δ ∣ Σ ⊢ (s ∷ γ)꞉ (A ∷ Γ) ⊑ᵍ (B ∷ Γ′)
+    → Δ ∣ Σ ⊢ (ctx-nrw A B s ∷ γ)꞉ (A ∷ Γ) ⊑ᵍ (B ∷ Γ′)
 
 
 ------------------------------------------------------------------------

--- a/GTSF/TermNarrowing.agda
+++ b/GTSF/TermNarrowing.agda
@@ -1,6 +1,10 @@
 {-
   Term imprecision for the Nu syntax.
 
+  Legacy note: this shared-store relation is obsolete for new work.  New
+  proofs should target MediatedNarrowing; this module remains only because
+  older DGG files in the umbrella development still import it.
+
   This file mechanizes the term-imprecision relation from the cambridge22/23
   notes.  The paper presentation uses a combined environment for term variables
   and seal assumptions; here we split it into the store narrowing context from
@@ -38,14 +42,17 @@ variable
   x : Var
   α αᵢ : TyVar
 
+⇑ᵍ-entry : CtxNrwEntry → CtxNrwEntry
+⇑ᵍ-entry (ctx-nrw A B p) = ctx-nrw (⇑ᵗ A) (⇑ᵗ B) (⇑ᶜ p)
+
 ⇑ᵍ : CtxNrw → CtxNrw
-⇑ᵍ = map ⇑ᶜ
+⇑ᵍ = map ⇑ᵍ-entry
 
 srcCtxⁿ : CtxNrw → Ctx
-srcCtxⁿ = map src
+srcCtxⁿ = map srcTy
 
 tgtCtxⁿ : CtxNrw → Ctx
-tgtCtxⁿ = map tgt
+tgtCtxⁿ = map tgtTy
 
 fun-narrow-codomainᶜ :
   Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
@@ -107,14 +114,15 @@ data _∣_∣_⊢_⊒_∶_⦂_⊒_
   x⊒xᵗ : ∀ {x p A B}
     → {typing : TermTypingEndpoints Δ σ γ (` x) (` x) A B}
     → Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B
-    → γ ∋ x ⦂ p
+    → γ ∋ x ⦂ ctx-nrw A B p
       --------------------------------
     → Δ ∣ σ ∣ γ ⊢ ` x ⊒ ` x ∶ p ⦂ A ⊒ B
 
   ƛ⊒ƛᵗ : ∀ {N N′ p q A A′ B B′}
     → {typing : TermTypingEndpoints Δ σ γ (ƛ N) (ƛ N′) (A ⇒ B) (A′ ⇒ B′)}
-    → Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)
-    → Δ ∣ σ ∣ ((- p) ∷ γ) ⊢ N ⊒ N′ ∶ q ⦂ B ⊒ B′
+    → (p↦qᶜ : Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′))
+    → Δ ∣ σ ∣ ctx-nrw A A′ (fun-narrow-domain-dualᶜ p↦qᶜ) ∷ γ
+        ⊢ N ⊒ N′ ∶ q ⦂ B ⊒ B′
       ----------------------------------------------------
     → Δ ∣ σ ∣ γ ⊢ ƛ N ⊒ ƛ N′ ∶ p ↦ q
         ⦂ A ⇒ B ⊒ A′ ⇒ B′
@@ -122,10 +130,11 @@ data _∣_∣_⊢_⊒_∶_⦂_⊒_
   ·⊒·ᵗ : ∀ {L L′ M M′ p q A A′ B B′}
     → {typing :
         TermTypingEndpoints Δ σ γ (L · M) (L′ · M′) B B′}
-    → Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)
+    → (p↦qᶜ : Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′))
     → Δ ∣ σ ∣ γ ⊢ L ⊒ L′ ∶ p ↦ q
         ⦂ A ⇒ B ⊒ A′ ⇒ B′
-    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ - p ⦂ A ⊒ A′
+    → Δ ∣ σ ∣ γ ⊢ M ⊒ M′ ∶ fun-narrow-domain-dualᶜ p↦qᶜ
+        ⦂ A ⊒ A′
       -------------------------------------------------------
     → Δ ∣ σ ∣ γ ⊢ L · M ⊒ L′ · M′ ∶ q ⦂ B ⊒ B′
 

--- a/GTSF/proof/Catchup.agda
+++ b/GTSF/proof/Catchup.agda
@@ -552,6 +552,16 @@ extendReplaceRel-coercionᶜ :
 extendReplaceRel-coercionᶜ rel cᶜ =
   narrow-weaken ≤-refl (extendReplaceRel-src-incl rel) cᶜ
 
+extendReplaceRel-fun-domain-dualᶜ :
+  ∀ {Δ σ σ′ p q A A′ B B′} →
+  (rel : ExtendReplaceRel Δ σ σ′) →
+  (p↦qᶜ : Δ ∣ srcStoreⁿ σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+  fun-narrow-domain-dualᶜ (extendReplaceRel-coercionᶜ rel p↦qᶜ) ≡
+    fun-narrow-domain-dualᶜ p↦qᶜ
+extendReplaceRel-fun-domain-dualᶜ rel
+    (cast-fun p⊢ q⊢ , cross (pʷ ↦ qⁿ)) =
+  refl
+
 extendReplaceRel-coercion :
   ∀ {Δ σ σ′ μ c A B} →
   ExtendReplaceRel Δ σ σ′ →
@@ -711,13 +721,19 @@ extendReplaceRel-typed-term (replace-left rel) (x⊒xᵗ pᶜ x∋p) =
   x⊒xᵗ (extendReplaceRel-coercionᶜ (replace-left rel) pᶜ) x∋p
 extendReplaceRel-typed-term (replace-left rel) (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) =
   ƛ⊒ƛᵗ (extendReplaceRel-coercionᶜ (replace-left rel) p↦qᶜ)
-    (extendReplaceRel-typed-term (replace-left rel) N⊒N′)
+    (subst
+      (λ c → _ ∣ _ ∣ ctx-nrw _ _ c ∷ _ ⊢ _ ⊒ _ ∶ _ ⦂ _ ⊒ _)
+      (sym (extendReplaceRel-fun-domain-dualᶜ (replace-left rel) p↦qᶜ))
+      (extendReplaceRel-typed-term (replace-left rel) N⊒N′))
 extendReplaceRel-typed-term (replace-left rel)
     (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
   ·⊒·ᵗ
     (extendReplaceRel-coercionᶜ (replace-left rel) p↦qᶜ)
     (extendReplaceRel-typed-term (replace-left rel) L⊒L′)
-    (extendReplaceRel-typed-term (replace-left rel) M⊒M′)
+    (subst
+      (λ c → _ ∣ _ ∣ _ ⊢ _ ⊒ _ ∶ c ⦂ _ ⊒ _)
+      (sym (extendReplaceRel-fun-domain-dualᶜ (replace-left rel) p↦qᶜ))
+      (extendReplaceRel-typed-term (replace-left rel) M⊒M′))
 extendReplaceRel-typed-term (replace-left rel) (Λ⊒Λᵗ allᶜ vV V⊒V′) =
   Λ⊒Λᵗ (extendReplaceRel-coercionᶜ (replace-left rel) allᶜ) vV
     (extendReplaceRel-typed-term (replace-left (extendReplaceRel-⇑ˢ rel))
@@ -810,13 +826,25 @@ extendReplaceRel-typed-term (replace-both {q = qh} rel)
     (ƛ⊒ƛᵗ p↦qᶜ N⊒N′) =
   ƛ⊒ƛᵗ
     (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) p↦qᶜ)
-    (extendReplaceRel-typed-term (replace-both {q = qh} rel) N⊒N′)
+    (subst
+      (λ c → _ ∣ _ ∣ ctx-nrw _ _ c ∷ _ ⊢ _ ⊒ _ ∶ _ ⦂ _ ⊒ _)
+      (sym
+        (extendReplaceRel-fun-domain-dualᶜ
+          (replace-both {q = qh} rel)
+          p↦qᶜ))
+      (extendReplaceRel-typed-term (replace-both {q = qh} rel) N⊒N′))
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
     (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
   ·⊒·ᵗ
     (extendReplaceRel-coercionᶜ (replace-both {q = qh} rel) p↦qᶜ)
     (extendReplaceRel-typed-term (replace-both {q = qh} rel) L⊒L′)
-    (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′)
+    (subst
+      (λ c → _ ∣ _ ∣ _ ⊢ _ ⊒ _ ∶ c ⦂ _ ⊒ _)
+      (sym
+        (extendReplaceRel-fun-domain-dualᶜ
+          (replace-both {q = qh} rel)
+          p↦qᶜ))
+      (extendReplaceRel-typed-term (replace-both {q = qh} rel) M⊒M′))
 extendReplaceRel-typed-term (replace-both {q = qh} rel)
     (Λ⊒Λᵗ allᶜ vV V⊒V′) =
   Λ⊒Λᵗ

--- a/GTSF/proof/CompileTermNarrowing.agda
+++ b/GTSF/proof/CompileTermNarrowing.agda
@@ -1,55 +1,353 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 module proof.CompileTermNarrowing where
 
 -- File Charter:
 --   * Compile monotonicity for source-level gradual term narrowing.
 --   * States that compiling two source terms related by
---     `GradualTermNarrowing` yields target terms related by `TermNarrowing`.
---   * The theorem is currently a proof boundary: the remaining hole isolates
---     the needed compile-commutation/cast-composition work.
+--     `GradualTermNarrowing` yields target terms related by
+--     `MediatedNarrowing`.
+--   * The easy structural cases are proved directly.  The remaining
+--     compiler-specific cases are named postulate boundaries isolating the
+--     needed cast-plan composition and type-application/ν algebra.
 
-open import Data.List using ([])
-open import Data.Product using (proj₁)
+open import Data.List using ([]; _∷_; map)
+open import Data.Nat using (suc)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality using
+  (_≡_; refl; cong; cong₂; subst; sym)
 
 open import Types
-open import Ctx using (CtxWf)
-open import Compile using (compile)
-open import GradualTerms
-  using (GTerm)
+open import Ctx using (CtxWf; ctxWf-∷)
+open import Compile using (compile; compile-value)
+open import NuTerms
+  using (Term)
   renaming
-    ( ⊢` to ⊢ᴳ`
-    ; ⊢$ to ⊢ᴳ$
+    ( _∣_∣_⊢_⦂_ to _∣_∣_⊢ᵀ_⦂_
+    ; ⊢` to ⊢ᵀ`
+    ; ⊢ƛ to ⊢ᵀƛ
+    ; ⊢Λ to ⊢ᵀΛ
+    ; ⊢$ to ⊢ᵀ$
     )
-open import NarrowWiden using (CtxNrw)
-open import Coercions using (Coercion)
+open import GradualTerms
+  using (GTerm; _·[_]_; Λ_; _`[_]; _⊕[_at_]_)
+  renaming
+    ( _∣_⊢_⦂_ to _∣_⊢ᴳ_⦂_
+    ; ⊢` to ⊢ᴳ`
+    ; ⊢ƛ to ⊢ᴳƛ
+    ; ⊢· to ⊢ᴳ·
+    ; ⊢·★ to ⊢ᴳ·★
+    ; ⊢Λ to ⊢ᴳΛ
+    ; ⊢• to ⊢ᴳ•
+    ; ⊢$ to ⊢ᴳ$
+    ; ⊢⊕ to ⊢ᴳ⊕
+    )
+open import NarrowWiden using
+  ( CtxNrw
+  ; CtxNrwEntry
+  ; ctx-nrw
+  ; cross
+  ; id-‵
+  ; _∣_⊢_∶ᶜ_⊒_
+  ; fun-narrow-domain-dualᶜ
+  )
+open import Coercions using (Coercion; id; _↦_; cast-id)
+open import Primitives using (Const; Prim; κℕ; constTy)
+open import proof.NuTermProperties using (CtxWf-⤊)
+open import StoreCorrespondence using (SealCorr; ⇑ᶜorr)
+open import TermNarrowingSeparated using
+  ( CtxCorr
+  ; CtxCorrEntry
+  ; ctx-entry
+  ; leftCtx
+  ; rightCtx
+  ; ⇑ᵍᶜ
+  )
 
 open import GradualTermNarrowing
   using
     ( _∣_∣_⊢ᴳ_⊒_∶_⦂_⊒_
     ; gradual-term-typing-endpoints
     ; x⊒xᴳ
+    ; ƛ⊒ƛᴳ
+    ; ·⊒·ᴳ
+    ; Λ⊒Λᴳ
+    ; ⊒Λᴳ
+    ; []⊒[]ᴳ
+    ; ⊒[]ᴳ
     ; κ⊒κᴳ
+    ; ⊕⊒⊕ᴳ
     ; gradual-term-narrowing-source-typing
     ; gradual-term-narrowing-target-typing
+    ; gradual-term-narrowing-index-typing
     ; srcCtxⁿ
     ; tgtCtxⁿ
+    ; srcCtxⁿ-⇑ᵍ
+    ; tgtCtxⁿ-⇑ᵍ
     )
-open import TermNarrowing
+open import MediatedNarrowing
   using
-    ( _∣_∣_⊢_⊒_∶_⦂_⊒_
+    ( _∣_∣_∣_⊢_⊒_∶_⦂_⊒ᵐ_
+    ; _∣_∣_⊢_∶ᶜ_⊒ᵐ_
+    ; fun-narrow-domain-dualᵐᶜ
     ; x⊒xᵗ
+    ; ƛ⊒ƛᵗ
+    ; Λ⊒Λᵗ
     ; κ⊒κᵗ
     )
 
+ctxNrwToCorrEntry : CtxNrwEntry → CtxCorrEntry
+ctxNrwToCorrEntry (ctx-nrw A B p) = ctx-entry A B p
+
+ctxNrwToCorr : CtxNrw → CtxCorr
+ctxNrwToCorr = map ctxNrwToCorrEntry
+
+leftCtx-ctxNrwToCorr : ∀ γ → leftCtx (ctxNrwToCorr γ) ≡ srcCtxⁿ γ
+leftCtx-ctxNrwToCorr [] = refl
+leftCtx-ctxNrwToCorr (ctx-nrw A B p ∷ γ) =
+  cong₂ _∷_ refl (leftCtx-ctxNrwToCorr γ)
+
+rightCtx-ctxNrwToCorr : ∀ γ → rightCtx (ctxNrwToCorr γ) ≡ tgtCtxⁿ γ
+rightCtx-ctxNrwToCorr [] = refl
+rightCtx-ctxNrwToCorr (ctx-nrw A B p ∷ γ) =
+  cong₂ _∷_ refl (rightCtx-ctxNrwToCorr γ)
+
+ctxNrwToCorr-⇑ :
+  ∀ γ →
+  ctxNrwToCorr (GradualTermNarrowing.⇑ᵍ γ) ≡ ⇑ᵍᶜ (ctxNrwToCorr γ)
+ctxNrwToCorr-⇑ [] = refl
+ctxNrwToCorr-⇑ (ctx-nrw A B p ∷ γ) =
+  cong₂ _∷_ refl (ctxNrwToCorr-⇑ γ)
+
+ctxNrwToCorr-∋ :
+  ∀ {γ x A B p} →
+  γ ∋ x ⦂ ctx-nrw A B p →
+  ctxNrwToCorr γ ∋ x ⦂ ctx-entry A B p
+ctxNrwToCorr-∋ Z = Z
+ctxNrwToCorr-∋ (S x∋p) = S (ctxNrwToCorr-∋ x∋p)
+
+record CompileIndexMediation (Δ : TyCtx) (ρ : SealCorr) : Set₁ where
+  inductive
+  field
+    indexᵐᶜ :
+      ∀ {p A B} →
+      Δ ∣ [] ⊢ p ∶ᶜ A ⊒ B →
+      Δ ∣ Δ ∣ ρ ⊢ p ∶ᶜ A ⊒ᵐ B
+
+    fun-domain-dualᵐᶜ :
+      ∀ {p q A A′ B B′} →
+      (p↦qᶜ : Δ ∣ [] ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+      fun-narrow-domain-dualᵐᶜ (indexᵐᶜ p↦qᶜ) ≡
+        fun-narrow-domain-dualᶜ p↦qᶜ
+
+    shiftᵐ :
+      CompileIndexMediation (suc Δ) (⇑ᶜorr ρ)
+
+open CompileIndexMediation
+
+compile-context-subst-term :
+  ∀ {Δ Γ Γ′ M A}
+  → (Γ≡Γ′ : Γ ≡ Γ′)
+  → (Γ-wf : CtxWf Δ Γ)
+  → (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A)
+  → proj₁
+      (compile
+        (subst (CtxWf Δ) Γ≡Γ′ Γ-wf)
+        (subst (λ Γ₀ → Δ ∣ Γ₀ ⊢ᴳ M ⦂ A) Γ≡Γ′ M⊢))
+      ≡ proj₁ (compile Γ-wf M⊢)
+compile-context-subst-term refl Γ-wf M⊢ = refl
+
+mediated-narrowing-cong-terms :
+  ∀ {ΔL ΔR ρ γ L L′ R R′ p A B}
+  → L ≡ L′
+  → R ≡ R′
+  → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ R ∶ p ⦂ A ⊒ᵐ B
+  → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L′ ⊒ R′ ∶ p ⦂ A ⊒ᵐ B
+mediated-narrowing-cong-terms refl refl L⊒R = L⊒R
+
+mediated-narrowing-context-cong :
+  ∀ {ΔL ΔR ρ γ γ′ L R p A B}
+  → γ ≡ γ′
+  → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ R ∶ p ⦂ A ⊒ᵐ B
+  → ΔL ∣ ΔR ∣ ρ ∣ γ′ ⊢ L ⊒ R ∶ p ⦂ A ⊒ᵐ B
+mediated-narrowing-context-cong refl L⊒R = L⊒R
+
+const-indexᶜ :
+  ∀ {Δ} κ →
+  Δ ∣ [] ⊢ id (constTy κ) ∶ᶜ constTy κ ⊒ constTy κ
+const-indexᶜ (κℕ n) = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+-- These are the remaining compiler-specific proof obligations from issue #58.
+-- They are stated over `MediatedNarrowing`, not the obsolete shared-store
+-- `TermNarrowing` relation.
+postulate
+  compile-preserves-application-narrowing :
+    ∀ {Δ ρ γ L L′ R R′ p A B ℓ} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (LR⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ L ·[ ℓ ] R ⦂ A) →
+    (L′R′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ L′ ·[ ℓ ] R′ ⦂ B) →
+    (LR⊒L′R′ : Δ ∣ [] ∣ γ ⊢ᴳ L ·[ ℓ ] R ⊒ L′ ·[ ℓ ] R′
+                  ∶ p ⦂ A ⊒ B) →
+    let
+      N = proj₁ (compile srcΓ-wf LR⊢)
+      N′ = proj₁ (compile tgtΓ-wf L′R′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+
+  compile-preserves-target-forall-narrowing :
+    ∀ {Δ ρ γ N V′ p A B} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (N⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ N ⦂ A) →
+    (ΛV′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ Λ V′ ⦂ B) →
+    (N⊒ΛV′ : Δ ∣ [] ∣ γ ⊢ᴳ N ⊒ Λ V′ ∶ p ⦂ A ⊒ B) →
+    let
+      L = proj₁ (compile srcΓ-wf N⊢)
+      L′ = proj₁ (compile tgtΓ-wf ΛV′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ᵐ B
+
+  compile-preserves-type-application-narrowing :
+    ∀ {Δ ρ γ M M′ T T′ p A B} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (MT⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M `[ T ] ⦂ A) →
+    (M′T′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ `[ T′ ] ⦂ B) →
+    (MT⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M `[ T ] ⊒ M′ `[ T′ ]
+                  ∶ p ⦂ A ⊒ B) →
+    let
+      N = proj₁ (compile srcΓ-wf MT⊢)
+      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+
+  compile-preserves-target-type-application-narrowing :
+    ∀ {Δ ρ γ M M′ T′ p A B} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (M⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M ⦂ A) →
+    (M′T′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ `[ T′ ] ⦂ B) →
+    (M⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ `[ T′ ] ∶ p ⦂ A ⊒ B) →
+    let
+      N = proj₁ (compile srcΓ-wf M⊢)
+      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+
+  compile-preserves-primitive-narrowing :
+    ∀ {Δ ρ γ L L′ R R′ p A B op ℓ} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (LR⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ L ⊕[ op at ℓ ] R ⦂ A) →
+    (L′R′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ L′ ⊕[ op at ℓ ] R′ ⦂ B) →
+    (LR⊒L′R′ : Δ ∣ [] ∣ γ ⊢ᴳ L ⊕[ op at ℓ ] R ⊒
+                  L′ ⊕[ op at ℓ ] R′ ∶ p ⦂ A ⊒ B) →
+    let
+      N = proj₁ (compile srcΓ-wf LR⊢)
+      N′ = proj₁ (compile tgtΓ-wf L′R′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+
 variable
   Δ : TyCtx
+  ρ : SealCorr
   γ : CtxNrw
   A B : Ty
   p : Coercion
   M M′ : GTerm
 
+compile-preserves-term-narrowing-typed :
+  (med : CompileIndexMediation Δ ρ) →
+  (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+  (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+  (M⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M ⦂ A) →
+  (M′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ ⦂ B) →
+  (M⊒M′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ p ⦂ A ⊒ B) →
+  let
+    N = proj₁ (compile srcΓ-wf M⊢)
+    N′ = proj₁ (compile tgtΓ-wf M′⊢)
+  in
+  Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ (x⊒xᴳ pᶜ x∋p)
+    with M⊢ | M′⊢
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    _ _ (x⊒xᴳ pᶜ x∋p) | ⊢ᴳ` x∈ˢ | ⊢ᴳ` x∈ᵗ =
+  x⊒xᵗ (indexᵐᶜ med pᶜ) (ctxNrwToCorr-∋ x∋p)
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ (κ⊒κᴳ κ)
+    with M⊢ | M′⊢
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    _ _ (κ⊒κᴳ κ) | ⊢ᴳ$ .κ | ⊢ᴳ$ .κ =
+  κ⊒κᵗ κ (indexᵐᶜ med (const-indexᶜ κ))
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ (ƛ⊒ƛᴳ {p = p} {q = q} {A = A} {A′ = A′}
+      {B = B} {B′ = B′} p↦qᶜ N⊒N′)
+    with M⊢ | M′⊢
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    _ _
+    (ƛ⊒ƛᴳ {p = p} {q = q} {A = A} {A′ = A′} {B = B} {B′ = B′}
+      p↦qᶜ N⊒N′)
+    | ⊢ᴳƛ wfA N⊢ | ⊢ᴳƛ wfA′ N′⊢ =
+  ƛ⊒ƛᵗ {p = p} {q = q}
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    (indexᵐᶜ med p↦qᶜ)
+    (mediated-narrowing-context-cong
+      (cong (λ c → ctx-entry A A′ c ∷ ctxNrwToCorr _)
+        (sym (fun-domain-dualᵐᶜ med p↦qᶜ)))
+      (compile-preserves-term-narrowing-typed med
+        (ctxWf-∷ wfA srcΓ-wf)
+        (ctxWf-∷ wfA′ tgtΓ-wf)
+        N⊢
+        N′⊢
+        N⊒N′))
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ (Λ⊒Λᴳ allᶜ vVₙ vV′ₙ V⊒V′)
+    with M⊢ | M′⊢
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    _ _ (Λ⊒Λᴳ allᶜ vVₙ vV′ₙ V⊒V′)
+    | ⊢ᴳΛ vV V⊢ | ⊢ᴳΛ vV′ V′⊢ =
+  Λ⊒Λᵗ
+    (indexᵐᶜ med allᶜ)
+    (compile-value (CtxWf-⤊ srcΓ-wf) vV V⊢)
+    (compile-value (CtxWf-⤊ tgtΓ-wf) vV′ V′⊢)
+    (mediated-narrowing-cong-terms
+      (compile-context-subst-term
+        (sym (srcCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ srcΓ-wf) V⊢)
+      (compile-context-subst-term
+        (sym (tgtCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ tgtΓ-wf) V′⊢)
+      (mediated-narrowing-context-cong
+        (ctxNrwToCorr-⇑ _)
+        (compile-preserves-term-narrowing-typed (shiftᵐ med)
+          (subst (CtxWf _) (sym (srcCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ srcΓ-wf))
+          (subst (CtxWf _) (sym (tgtCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ tgtΓ-wf))
+          (subst (λ Γ₀ → _ ∣ Γ₀ ⊢ᴳ _ ⦂ _) (sym (srcCtxⁿ-⇑ᵍ _)) V⊢)
+          (subst (λ Γ₀ → _ ∣ Γ₀ ⊢ᴳ _ ⦂ _) (sym (tgtCtxⁿ-⇑ᵍ _)) V′⊢)
+          V⊒V′)))
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ app@(·⊒·ᴳ p↦qᶜ L⊒L′ N⊒N′) =
+  compile-preserves-application-narrowing med srcΓ-wf tgtΓ-wf M⊢ M′⊢ app
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ rel@(⊒Λᴳ pᶜ vV′ N⊒V′) =
+  compile-preserves-target-forall-narrowing med srcΓ-wf tgtΓ-wf M⊢ M′⊢ rel
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ rel@([]⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  compile-preserves-type-application-narrowing med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ rel
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ rel@(⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  compile-preserves-target-type-application-narrowing med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ rel
+compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
+    M⊢ M′⊢ prim@(⊕⊒⊕ᴳ M⊒M′ N⊒N′) =
+  compile-preserves-primitive-narrowing med srcΓ-wf tgtΓ-wf M⊢ M′⊢ prim
+
 compile-preserves-term-narrowing :
+  (med : CompileIndexMediation Δ ρ) →
   (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
   (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
   (M⊒M′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ p ⦂ A ⊒ B) →
@@ -59,13 +357,12 @@ compile-preserves-term-narrowing :
     N = proj₁ (compile srcΓ-wf M⊢)
     N′ = proj₁ (compile tgtΓ-wf M′⊢)
   in
-  Δ ∣ [] ∣ γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ B
-compile-preserves-term-narrowing srcΓ-wf tgtΓ-wf
-    (x⊒xᴳ {typing = gradual-term-typing-endpoints (⊢ᴳ` x∈ˢ) (⊢ᴳ` x∈ᵗ)}
-      pᶜ x∋p) =
-  x⊒xᵗ pᶜ x∋p
-compile-preserves-term-narrowing srcΓ-wf tgtΓ-wf
-    (κ⊒κᴳ κ {typing = gradual-term-typing-endpoints (⊢ᴳ$ .κ) (⊢ᴳ$ .κ)}) =
-  κ⊒κᵗ κ
-compile-preserves-term-narrowing srcΓ-wf tgtΓ-wf M⊒M′ =
-  {!!}
+  Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+compile-preserves-term-narrowing med srcΓ-wf tgtΓ-wf M⊒M′ =
+  compile-preserves-term-narrowing-typed
+    med
+    srcΓ-wf
+    tgtΓ-wf
+    (gradual-term-narrowing-source-typing M⊒M′)
+    (gradual-term-narrowing-target-typing M⊒M′)
+    M⊒M′

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -40,9 +40,11 @@ open import proof.CoercionProperties
     ; dualActionOk-gen-inst
     ; dualActionOk-idTyAllowed
     ; dualActionOk-inst-gen
+    ; dualActionOk-normal
     ; dualStoreAt-ext
     ; dualStoreAt-gen-inst
     ; dualStoreAt-inst-gen
+    ; dualStoreAt-normal
     ; ModeRename
     ; renameᶜ-open-commute
     ; sealModeAllowed-var-seal
@@ -1712,6 +1714,22 @@ mutual
         (dualʷ-flips-typingᵐ
           rel ds wfΣ (c⊢ , strictʷ→widen cʷ))) ,
     proj₂ (dualStrictʷ η cʷ)
+
+fun-narrow-domain-dual-typingᶜ :
+  ∀ {Δ Σ p q A A′ B B′} →
+  StoreWfAt Δ Σ →
+  (p↦qᶜ : Δ ∣ Σ ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
+  Δ ∣ Σ ⊢ fun-narrow-domain-dualᶜ p↦qᶜ ∶ᶜ A ⊒ A′
+fun-narrow-domain-dual-typingᶜ wfΣ
+    (cast-fun p⊢ q⊢ , cross (pʷ ↦ qⁿ)) =
+  dualʷ-flips-typingᵐ
+    {μ = tag-or-idᵈ}
+    {η = normalᵃ}
+    {ν = tag-or-idᵈ}
+    dualActionOk-normal
+    dualStoreAt-normal
+    wfΣ
+    (p⊢ , pʷ)
 
 widening-cross-ground-source-all⊥ :
   ∀ {μ Δ Σ A G g} →

--- a/GTSF/proof/TermSubstitutionNarrowing.agda
+++ b/GTSF/proof/TermSubstitutionNarrowing.agda
@@ -97,10 +97,10 @@ data SubstFrame
     SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ₀ γ₀′ τ₀ τ₀′
 
   frame-ƛ :
-    ∀ {γ γ′ τ τ′ p} →
+    ∀ {γ γ′ τ τ′ entry} →
     SubstFrame γ₀ γ₀′ τ₀ τ₀′ γ γ′ τ τ′ →
     SubstFrame γ₀ γ₀′ τ₀ τ₀′
-      ((- p) ∷ γ) ((- p) ∷ γ′) (extˢˣ τ) (extˢˣ τ′)
+      (entry ∷ γ) (entry ∷ γ′) (extˢˣ τ) (extˢˣ τ′)
 
   frame-Λ :
     ∀ {γ γ′ τ τ′} →
@@ -140,7 +140,7 @@ TypedSubstNrw :
 TypedSubstNrw Δ σ γ γ′ τ τ′ =
   ∀ {x p A B} →
   Δ ∣ srcStoreⁿ σ ⊢ p ∶ᶜ A ⊒ B →
-  γ ∋ x ⦂ p →
+  γ ∋ x ⦂ ctx-nrw A B p →
   Δ ∣ σ ∣ γ′ ⊢ τ x ⊒ τ′ x ∶ p ⦂ A ⊒ B
 
 TypedSubstNrwFamily : CtxNrw → CtxNrw → Substˣ → Substˣ → Set₁
@@ -201,7 +201,7 @@ term-parallel-substitution-narrowingᵗ-framed env frame
     (ƛ⊒ƛᵗ {p = p} p↦qᶜ N⊒N′) =
   ƛ⊒ƛᵗ p↦qᶜ
     (term-parallel-substitution-narrowingᵗ-framed
-      env (frame-ƛ {p = p} frame) N⊒N′)
+      env (frame-ƛ frame) N⊒N′)
 term-parallel-substitution-narrowingᵗ-framed env frame
     (·⊒·ᵗ p↦qᶜ L⊒L′ M⊒M′) =
   ·⊒·ᵗ p↦qᶜ
@@ -291,7 +291,8 @@ singleSubstNrwᵗ :
   ∀ {Δ σ γ V V′ q A B} →
   (qᶜ : Δ ∣ srcStoreⁿ σ ⊢ q ∶ᶜ A ⊒ B) →
   Δ ∣ σ ∣ γ ⊢ V ⊒ V′ ∶ q ⦂ A ⊒ B →
-  TypedSubstNrw Δ σ (q ∷ γ) γ (singleEnv V) (singleEnv V′)
+  TypedSubstNrw Δ σ (ctx-nrw A B q ∷ γ) γ
+    (singleEnv V) (singleEnv V′)
 singleSubstNrwᵗ qᶜ V⊒V′ pᶜ Z =
   typed-term-narrowing-endpoints
     (proj₁ endpoints≡)
@@ -303,8 +304,9 @@ singleSubstNrwᵗ qᶜ V⊒V′ pᶜ (S x∋p) = x⊒xᵗ pᶜ x∋p
 
 term-substitution-narrowingᵗ :
   ∀ {Δ σ γ N N′ V V′ p q A B} →
-  TypedSubstNrwFamily (q ∷ γ) γ (singleEnv V) (singleEnv V′) →
-  Δ ∣ σ ∣ q ∷ γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ B →
+  TypedSubstNrwFamily (ctx-nrw A B q ∷ γ) γ
+    (singleEnv V) (singleEnv V′) →
+  Δ ∣ σ ∣ ctx-nrw A B q ∷ γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ B →
   Δ ∣ σ ∣ γ ⊢ N [ V ] ⊒ N′ [ V′ ] ∶ p ⦂ A ⊒ B
 term-substitution-narrowingᵗ env N⊒N′ =
   term-parallel-substitution-narrowingᵗ env N⊒N′


### PR DESCRIPTION
## Summary

Progress on #58, but not a completed proof yet.

This branch:

- changes `CtxNrw` entries from raw coercions to typed narrowing entries;
- replaces the raw domain dual (`- p`) in gradual term narrowing contexts with the typed narrowing-domain dual;
- updates the legacy `TermNarrowing` consumers to use the typed context entries while marking `TermNarrowing` as obsolete for new work;
- moves `proof.CompileTermNarrowing` to target `MediatedNarrowing`;
- removes `--allow-unsolved-metas` from `proof.CompileTermNarrowing`;
- proves the variable, constant, lambda, and symmetric type-abstraction compile cases over the mediated relation.

## Remaining Work

The compile monotonicity proof still has named postulate boundaries for:

- application;
- target-forall narrowing;
- source/target type application;
- primitives.

Those obligations look blocked by real issues in the current mediated term narrowing surface, not just local proof plumbing. In particular:

- `TermTypingEndpoints` in `MediatedNarrowing` may be too rigid for the compiled shapes produced by `compile`;
- the compiler's `consistency-cast-plan` produces ordinary cast typings (`=⇒`), but the mediated cast rules need narrowing evidence plus composition records;
- the type-application cases need a clearer bridge from source gradual type application to the target `ν`, `α⊒αᵗ`, and `⊒αᵗ` mediated constructors;
- the compile theorem currently needs an explicit `CompileIndexMediation` bridge because arbitrary source narrowing indices cannot be canonically mediated by an empty or merely shifted seal correspondence.

## Validation

- `agda --no-allow-unsolved-metas proof/CompileTermNarrowing.agda` from `GTSF/`

`All.agda` was intentionally skipped because it is too slow for this checkpoint.

The focused check passes with the existing `proof/CompileCoercions.agda` warning about `Coercions` not exporting `Label`.

## Codex Session

`codex://threads/019f3937-f4e9-78d3-a947-d8f383b72a96`

```sh
open 'codex://threads/019f3937-f4e9-78d3-a947-d8f383b72a96'
```
