### PR TITLE
[codex] Specialize GTSF compile narrowing proof

### DIFF
--- a/GTSF/Compile.agda
+++ b/GTSF/Compile.agda
@@ -12,7 +12,7 @@ open import Data.Bool using (true)
 open import Data.List using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (zero; suc; z<s; s<s)
-open import Data.Product using (Σ-syntax; _,_; proj₁)
+open import Data.Product using (Σ-syntax; _,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality using (subst; sym; trans)
 
 open import Types
@@ -20,13 +20,25 @@ open import Ctx using (CtxWf; ctxWf-∷; ⤊ᵗ)
 open import Coercions
   using
     ( Coercion
+    ; ModeEnv
     ; _∣_⊢_∶_=⇒_
     ; _∣_∣_⊢_∶_=⇒_
+    ; normalᵃ
     ; reveal
     )
 open import Imprecision using (_⊢_~_; id★; _↦_; tag_⇒_)
+open import NarrowWiden
+  using
+    ( _∣_∣_⊢_∶_⊒_
+    ; _∣_⊢_∶_⊒_
+    ; _∣_∣_⊢_∶_⊑_
+    ; dualⁿ
+    ; dualʷ
+    )
 open import Primitives using (Const; Prim; constTy)
-open import proof.CompileCoercions using (coerce-up; coerce-down; realizes-idᵢ)
+open import Store using (StoreWfAt)
+open import proof.CompileCoercions
+  using (coerce-upʷ; coerce-downⁿ; realizesCast-idᵢ)
 open import proof.CoercionProperties
   using
     ( RevealEnv
@@ -35,9 +47,13 @@ open import proof.CoercionProperties
     ; rv-miss
     ; singleSealᵈ
     ; singleSealMode
+    ; dualActionOk-normal
+    ; dualStoreAt-normal
     )
 open import proof.ImprecisionProperties
   using (⊑-src-wf-idᵢ; ⊑-tgt-wf-idᵢ; ~-sym)
+open import proof.NarrowWidenProperties
+  using (dualⁿ-flips-typingᵐ; dualʷ-flips-typingᵐ)
 open import proof.NuTermProperties using (CtxWf-⤊)
 open import proof.TypeProperties
   using
@@ -175,16 +191,50 @@ open import NuTerms
 -- Cast plans for compiling consistency
 ------------------------------------------------------------------------
 
+narrowing-dual-one :
+  ∀ {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  Coercion
+narrowing-dual-one (_ , cⁿ) = proj₁ (dualⁿ normalᵃ cⁿ)
+
+empty-store-wf-at :
+  ∀ {Δ} →
+  StoreWfAt Δ []
+StoreWfAt.bound empty-store-wf-at ()
+StoreWfAt.wfTy empty-store-wf-at ()
+
 record CastPlan (Δ : TyCtx) (Σ : Store) (A B : Ty) : Set₁ where
   field
     lower : Ty
     down : Coercion
     down⊢ : Δ ∣ Σ ⊢ down ∶ A =⇒ lower
+    down⊒ : Δ ∣ Σ ⊢ down ∶ A ⊒ lower
 
-    up : Coercion
-    up⊢ : Δ ∣ Σ ⊢ up ∶ lower =⇒ B
+    upDual⊒ : Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ B ⊒ lower
+    up⊑ :
+      Σ[ μ ∈ ModeEnv ]
+        μ ∣ Δ ∣ Σ
+          ⊢ narrowing-dual-one (proj₂ (proj₂ upDual⊒)) ∶ lower ⊑ B
 
 open CastPlan public
+
+upDual :
+  ∀ {Δ Σ A B} →
+  CastPlan Δ Σ A B →
+  Coercion
+upDual plan = proj₁ (upDual⊒ plan)
+
+up :
+  ∀ {Δ Σ A B} →
+  CastPlan Δ Σ A B →
+  Coercion
+up plan = narrowing-dual-one (proj₂ (proj₂ (upDual⊒ plan)))
+
+up⊢ :
+  ∀ {Δ Σ A B} →
+  (plan : CastPlan Δ Σ A B) →
+  Δ ∣ Σ ⊢ up plan ∶ lower plan =⇒ B
+up⊢ plan = proj₁ (up⊑ plan) , proj₁ (proj₂ (up⊑ plan))
 
 consistency-cast-plan :
   ∀ {Δ A B} →
@@ -192,24 +242,42 @@ consistency-cast-plan :
   Δ ⊢ A ~ B →
   CastPlan Δ [] A B
 consistency-cast-plan {Δ = Δ} ℓ (C , C⊑A , C⊑B)
-    with coerce-down ℓ
+    with coerce-downⁿ ℓ
            (⊑-src-wf-idᵢ C⊑A)
            (⊑-tgt-wf-idᵢ C⊑A)
-           (realizes-idᵢ Δ)
+           (realizesCast-idᵢ Δ)
            C⊑A
-       | coerce-up ℓ
+       | coerce-upʷ ℓ
            (⊑-src-wf-idᵢ C⊑B)
            (⊑-tgt-wf-idᵢ C⊑B)
-           (realizes-idᵢ Δ)
+           (realizesCast-idᵢ Δ)
            C⊑B
 consistency-cast-plan {Δ = Δ} ℓ (C , C⊑A , C⊑B)
-    | down , down⊢ | up , up⊢ =
+    | down , down⊒ | up , up⊑ =
   record
     { lower = C
     ; down = down
-    ; down⊢ = down⊢
-    ; up = up
-    ; up⊢ = up⊢
+    ; down⊢ = proj₁ down⊒ , proj₁ (proj₂ down⊒)
+    ; down⊒ = down⊒
+    ; upDual⊒ =
+        proj₁ (dualʷ normalᵃ (proj₂ (proj₂ up⊑))) ,
+        proj₁ up⊑ ,
+        dualʷ-flips-typingᵐ
+          dualActionOk-normal
+          dualStoreAt-normal
+          empty-store-wf-at
+          (proj₂ up⊑)
+    ; up⊑ =
+        proj₁ up⊑ ,
+        dualⁿ-flips-typingᵐ
+          dualActionOk-normal
+          dualStoreAt-normal
+          empty-store-wf-at
+          (dualʷ-flips-typingᵐ
+            dualActionOk-normal
+            dualStoreAt-normal
+            empty-store-wf-at
+            (proj₂ up⊑))
     }
 
 arrow★-consistent :

--- a/GTSF/proof/CompileCoercions.agda
+++ b/GTSF/proof/CompileCoercions.agda
@@ -14,7 +14,7 @@ open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.Nat using (zero; suc; z<s)
 open import Data.Nat.Properties using (≤-refl)
-open import Data.Product using (Σ-syntax; _,_)
+open import Data.Product using (Σ-syntax; _,_; proj₁; proj₂)
 
 open import Types
 open import Store using (StoreIncl; StoreIncl-drop)
@@ -56,6 +56,34 @@ open import Coercions
     ; gen to genᶜ
     )
 open import Imprecision
+open import NarrowWiden
+  using
+    ( _∣_∣_⊢_∶_⊒_
+    ; _∣_∣_⊢_∶_⊑_
+    ; _∣_⊢_∶_⊒_
+    ; narrow-renameᵗ
+    ; widen-renameᵗ
+    ; narrow-weaken
+    ; widen-weaken
+    )
+  renaming
+    ( cross to nw-cross
+    ; id-＇ to id-＇ⁿʷ
+    ; id-‵ to id-‵ⁿʷ
+    ; id★ to nw-id★
+    ; _↦_ to _↦ⁿʷ_
+    ; `∀ to ∀ⁿʷ
+    ; gen to genⁿ
+    ; untag to untagⁿ
+    ; sealⁿ to sealⁿ
+    ; inst to instʷ
+    ; tag to tagʷ
+    ; unsealʷ to unsealʷ
+    )
+open import NarrowWidenComposition using
+  ( wrap-untagⁿ
+  ; wrap-tagʷ
+  )
 open import proof.CoercionProperties
   using
     ( ModeRename
@@ -165,6 +193,29 @@ data Realizesᵐ (μ : ModeEnv) (Δ : TyCtx) (Σ : Store) : ImpCtx → Set₁ wh
 Realizes : TyCtx → Store → ImpCtx → Set₁
 Realizes Δ Σ Φ = Realizesᵐ id-onlyᵈ Δ Σ Φ
 
+data RealizesCastᵐ
+    (μ : ModeEnv) (Δ : TyCtx) (Σ : Store) : ImpCtx → Set₁ where
+  real-cast-[] :
+    RealizesCastᵐ μ Δ Σ []
+
+  real-cast-xx : ∀ {Φ X Y c d} →
+    WfTy Δ (＇ X) →
+    WfTy Δ (＇ Y) →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X ⊑ ＇ Y →
+    μ ∣ Δ ∣ Σ ⊢ d ∶ ＇ Y ⊒ ＇ X →
+    RealizesCastᵐ μ Δ Σ Φ →
+    RealizesCastᵐ μ Δ Σ ((X ˣ⊑ˣ Y) ∷ Φ)
+
+  real-cast-star : ∀ {Φ X c d} →
+    WfTy Δ (＇ X) →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X ⊑ ★ →
+    μ ∣ Δ ∣ Σ ⊢ d ∶ ★ ⊒ ＇ X →
+    RealizesCastᵐ μ Δ Σ Φ →
+    RealizesCastᵐ μ Δ Σ ((X ˣ⊑★) ∷ Φ)
+
+RealizesCast : TyCtx → Store → ImpCtx → Set₁
+RealizesCast Δ Σ Φ = RealizesCastᵐ id-onlyᵈ Δ Σ Φ
+
 realizes-xx-up :
   ∀ {μ Δ Σ Φ X Y} →
   Realizesᵐ μ Δ Σ Φ →
@@ -213,6 +264,54 @@ realizes-star-down (real-star hX c⊢ d⊢ r) (here refl) = _ , d⊢
 realizes-star-down (real-star hX c⊢ d⊢ r) (there x∈) =
   realizes-star-down r x∈
 
+realizes-cast-xx-up :
+  ∀ {μ Δ Σ Φ X Y} →
+  RealizesCastᵐ μ Δ Σ Φ →
+  (X ˣ⊑ˣ Y) ∈ Φ →
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X ⊑ ＇ Y
+realizes-cast-xx-up (real-cast-xx hX hY c⊑ d⊒ r) (here refl) = _ , c⊑
+realizes-cast-xx-up (real-cast-xx hX hY c⊑ d⊒ r) (there x∈) =
+  realizes-cast-xx-up r x∈
+realizes-cast-xx-up (real-cast-star hX c⊑ d⊒ r) (here ())
+realizes-cast-xx-up (real-cast-star hX c⊑ d⊒ r) (there x∈) =
+  realizes-cast-xx-up r x∈
+
+realizes-cast-xx-down :
+  ∀ {μ Δ Σ Φ X Y} →
+  RealizesCastᵐ μ Δ Σ Φ →
+  (X ˣ⊑ˣ Y) ∈ Φ →
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ Y ⊒ ＇ X
+realizes-cast-xx-down (real-cast-xx hX hY c⊑ d⊒ r) (here refl) = _ , d⊒
+realizes-cast-xx-down (real-cast-xx hX hY c⊑ d⊒ r) (there x∈) =
+  realizes-cast-xx-down r x∈
+realizes-cast-xx-down (real-cast-star hX c⊑ d⊒ r) (here ())
+realizes-cast-xx-down (real-cast-star hX c⊑ d⊒ r) (there x∈) =
+  realizes-cast-xx-down r x∈
+
+realizes-cast-star-up :
+  ∀ {μ Δ Σ Φ X} →
+  RealizesCastᵐ μ Δ Σ Φ →
+  (X ˣ⊑★) ∈ Φ →
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ＇ X ⊑ ★
+realizes-cast-star-up (real-cast-xx hX hY c⊑ d⊒ r) (here ())
+realizes-cast-star-up (real-cast-xx hX hY c⊑ d⊒ r) (there x∈) =
+  realizes-cast-star-up r x∈
+realizes-cast-star-up (real-cast-star hX c⊑ d⊒ r) (here refl) = _ , c⊑
+realizes-cast-star-up (real-cast-star hX c⊑ d⊒ r) (there x∈) =
+  realizes-cast-star-up r x∈
+
+realizes-cast-star-down :
+  ∀ {μ Δ Σ Φ X} →
+  RealizesCastᵐ μ Δ Σ Φ →
+  (X ˣ⊑★) ∈ Φ →
+  Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ ★ ⊒ ＇ X
+realizes-cast-star-down (real-cast-xx hX hY c⊑ d⊒ r) (here ())
+realizes-cast-star-down (real-cast-xx hX hY c⊑ d⊒ r) (there x∈) =
+  realizes-cast-star-down r x∈
+realizes-cast-star-down (real-cast-star hX c⊑ d⊒ r) (here refl) = _ , d⊒
+realizes-cast-star-down (real-cast-star hX c⊑ d⊒ r) (there x∈) =
+  realizes-cast-star-down r x∈
+
 Realizes-store-weaken :
   ∀ {μ Δ Σ Σ′ Φ} →
   StoreIncl Σ Σ′ →
@@ -232,6 +331,26 @@ Realizes-store-weaken incl (real-star hX c⊢ d⊢ r) =
     (coercion-weakenᵐ ≤-refl incl c⊢)
     (coercion-weakenᵐ ≤-refl incl d⊢)
     (Realizes-store-weaken incl r)
+
+RealizesCast-store-weaken :
+  ∀ {μ Δ Σ Σ′ Φ} →
+  StoreIncl Σ Σ′ →
+  RealizesCastᵐ μ Δ Σ Φ →
+  RealizesCastᵐ μ Δ Σ′ Φ
+RealizesCast-store-weaken incl real-cast-[] = real-cast-[]
+RealizesCast-store-weaken incl (real-cast-xx hX hY c⊑ d⊒ r) =
+  real-cast-xx
+    hX
+    hY
+    (widen-weaken ≤-refl incl c⊑)
+    (narrow-weaken ≤-refl incl d⊒)
+    (RealizesCast-store-weaken incl r)
+RealizesCast-store-weaken incl (real-cast-star hX c⊑ d⊒ r) =
+  real-cast-star
+    hX
+    (widen-weaken ≤-refl incl c⊑)
+    (narrow-weaken ≤-refl incl d⊒)
+    (RealizesCast-store-weaken incl r)
 
 Realizes-rename-suc :
   ∀ {μ ν Δ Σ Φ} →
@@ -253,11 +372,37 @@ Realizes-rename-suc rel (real-star hX c⊢ d⊢ r) =
     (coercion-renameᵗᵐ TyRenameWf-suc rel d⊢)
     (Realizes-rename-suc rel r)
 
+RealizesCast-rename-suc :
+  ∀ {μ ν Δ Σ Φ} →
+  ModeRename suc μ ν →
+  RealizesCastᵐ μ Δ Σ Φ →
+  RealizesCastᵐ ν (suc Δ) (⟰ᵗ Σ) (⇑ᵢ Φ)
+RealizesCast-rename-suc rel real-cast-[] = real-cast-[]
+RealizesCast-rename-suc rel (real-cast-xx hX hY c⊑ d⊒ r) =
+  real-cast-xx
+    (renameᵗ-preserves-WfTy hX TyRenameWf-suc)
+    (renameᵗ-preserves-WfTy hY TyRenameWf-suc)
+    (widen-renameᵗ TyRenameWf-suc rel c⊑)
+    (narrow-renameᵗ TyRenameWf-suc rel d⊒)
+    (RealizesCast-rename-suc rel r)
+RealizesCast-rename-suc rel (real-cast-star hX c⊑ d⊒ r) =
+  real-cast-star
+    (renameᵗ-preserves-WfTy hX TyRenameWf-suc)
+    (widen-renameᵗ TyRenameWf-suc rel c⊑)
+    (narrow-renameᵗ TyRenameWf-suc rel d⊒)
+    (RealizesCast-rename-suc rel r)
+
 Realizes-⇑ᵢ :
   ∀ {μ Δ Σ Φ} →
   Realizesᵐ μ Δ Σ Φ →
   Realizesᵐ (extᵈ μ) (suc Δ) (⟰ᵗ Σ) (⇑ᵢ Φ)
 Realizes-⇑ᵢ = Realizes-rename-suc ModeRename-suc-ext
+
+RealizesCast-⇑ᵢ :
+  ∀ {μ Δ Σ Φ} →
+  RealizesCastᵐ μ Δ Σ Φ →
+  RealizesCastᵐ (extᵈ μ) (suc Δ) (⟰ᵗ Σ) (⇑ᵢ Φ)
+RealizesCast-⇑ᵢ = RealizesCast-rename-suc ModeRename-suc-ext
 
 Realizes-∀ⁱ :
   ∀ {μ Δ Σ Φ} →
@@ -271,6 +416,19 @@ Realizes-∀ⁱ r =
     (cast-id (wfVar z<s) refl)
     (cast-id (wfVar z<s) refl)
     (Realizes-⇑ᵢ r)
+
+RealizesCast-∀ⁱ :
+  ∀ {μ Δ Σ Φ} →
+  RealizesCastᵐ μ Δ Σ Φ →
+  RealizesCastᵐ (extᵈ μ) (suc Δ) (⟰ᵗ Σ)
+    ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+RealizesCast-∀ⁱ r =
+  real-cast-xx
+    (wfVar z<s)
+    (wfVar z<s)
+    (cast-id (wfVar z<s) refl , nw-cross (id-＇ⁿʷ zero))
+    (cast-id (wfVar z<s) refl , nw-cross (id-＇ⁿʷ zero))
+    (RealizesCast-⇑ᵢ r)
 
 Realizes-ν-inst :
   ∀ {μ Δ Σ Φ} →
@@ -286,6 +444,20 @@ Realizes-ν-inst ℓ r =
     (Realizes-store-weaken StoreIncl-drop
       (Realizes-rename-suc ModeRename-suc-inst r))
 
+RealizesCast-ν-inst :
+  ∀ {μ Δ Σ Φ} →
+  (ℓ : Label) →
+  RealizesCastᵐ μ Δ Σ Φ →
+  RealizesCastᵐ (instᵈ μ) (suc Δ) ((zero , ★) ∷ ⟰ᵗ Σ)
+    ((zero ˣ⊑★) ∷ ⇑ᵢ Φ)
+RealizesCast-ν-inst ℓ r =
+  real-cast-star
+    (wfVar z<s)
+    (cast-unseal wf★ (here refl) refl , unsealʷ zero ★)
+    (cast-seal wf★ (here refl) refl , sealⁿ ★ zero)
+    (RealizesCast-store-weaken StoreIncl-drop
+      (RealizesCast-rename-suc ModeRename-suc-inst r))
+
 Realizes-ν-gen :
   ∀ {μ Δ Σ Φ} →
   (ℓ : Label) →
@@ -298,6 +470,18 @@ Realizes-ν-gen ℓ r =
     (cast-untag (wfVar z<s) (＇ zero) refl)
     (Realizes-rename-suc ModeRename-suc-gen r)
 
+RealizesCast-ν-gen :
+  ∀ {μ Δ Σ Φ} →
+  (ℓ : Label) →
+  RealizesCastᵐ μ Δ Σ Φ →
+  RealizesCastᵐ (genᵈ μ) (suc Δ) (⟰ᵗ Σ) ((zero ˣ⊑★) ∷ ⇑ᵢ Φ)
+RealizesCast-ν-gen ℓ r =
+  real-cast-star
+    (wfVar z<s)
+    (cast-tag (wfVar z<s) (＇ zero) refl , tagʷ (＇ zero))
+    (cast-untag (wfVar z<s) (＇ zero) refl , untagⁿ (＇ zero))
+    (RealizesCast-rename-suc ModeRename-suc-gen r)
+
 realizes-idᵢ :
   ∀ Δ →
   Realizes Δ [] (idᵢ Δ)
@@ -309,6 +493,20 @@ realizes-idᵢ (suc Δ) =
     (cast-id (wfVar z<s) (idTyAllowed-id-only (＇ zero)))
     (cast-id (wfVar z<s) (idTyAllowed-id-only (＇ zero)))
     (Realizes-rename-suc ModeRename-suc-id-only (realizes-idᵢ Δ))
+
+realizesCast-idᵢ :
+  ∀ Δ →
+  RealizesCast Δ [] (idᵢ Δ)
+realizesCast-idᵢ zero = real-cast-[]
+realizesCast-idᵢ (suc Δ) =
+  real-cast-xx
+    (wfVar z<s)
+    (wfVar z<s)
+    (cast-id (wfVar z<s) (idTyAllowed-id-only (＇ zero)) ,
+      nw-cross (id-＇ⁿʷ zero))
+    (cast-id (wfVar z<s) (idTyAllowed-id-only (＇ zero)) ,
+      nw-cross (id-＇ⁿʷ zero))
+    (RealizesCast-rename-suc ModeRename-suc-id-only (realizesCast-idᵢ Δ))
 
 ------------------------------------------------------------------------
 -- Coercion synthesis from imprecision
@@ -433,6 +631,135 @@ mutual
       | c , c⊢ =
     genᶜ B c , cast-gen hB occ c⊢
 
+mutual
+  coerce-upʷᵐ :
+    ∀ {μ Δ Σ Φ C A} →
+    (ℓ : Label) →
+    WfTy Δ C →
+    WfTy Δ A →
+    idTyAllowed μ A ≡ true →
+    RealizesCastᵐ μ Δ Σ Φ →
+    Φ ⊢ C ⊑ A →
+    Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ C ⊑ A
+  coerce-upʷᵐ ℓ wf★ wf★ ok r id★ =
+    idᶜ ★ , cast-id wf★ refl , nw-id★
+  coerce-upʷᵐ {C = ＇ X} {A = ＇ Y} ℓ hX hY ok r (idˣ X⊑Y) =
+    realizes-cast-xx-up r X⊑Y
+  coerce-upʷᵐ {C = ‵ ι} ℓ wfBase wfBase ok r idι =
+    idᶜ (‵ ι) , cast-id wfBase refl , nw-cross (id-‵ⁿʷ ι)
+  coerce-upʷᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      with idTyAllowed μ A′ in okA′ | idTyAllowed μ B′ in okB′
+  coerce-upʷᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true
+      with coerce-downⁿᵐ ℓ hA hA′ okA′ r p
+         | coerce-upʷᵐ ℓ hB hB′ okB′ r q
+  coerce-upʷᵐ ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true | s , s⊒ | t , t⊑ =
+    (s ↦ᶜ t) , cast-fun (proj₁ s⊒) (proj₁ t⊑) ,
+    nw-cross (proj₂ s⊒ ↦ⁿʷ proj₂ t⊑)
+  coerce-upʷᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | false | b
+  coerce-upʷᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | true | false
+  coerce-upʷᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
+      with coerce-upʷᵐ ℓ hA hB ok (RealizesCast-∀ⁱ r) p
+  coerce-upʷᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
+      | c , c⊑ =
+    `∀ᶜ c , cast-all (proj₁ c⊑) , nw-cross (∀ⁿʷ (proj₂ c⊑))
+  coerce-upʷᵐ {C = ‵ ι} ℓ wfBase wf★ ok r (tag ι) =
+    (‵ ι) !ᶜ , cast-tag wfBase (‵ ι) refl , tagʷ (‵ ι)
+  coerce-upʷᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
+      with coerce-downⁿᵐ ℓ hA wf★ refl r p
+         | coerce-upʷᵐ ℓ hB wf★ refl r q
+  coerce-upʷᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
+      | s , s⊒ | t , t⊑ =
+    wrap-tagʷ
+      (cast-fun (proj₁ s⊒) (proj₁ t⊑) ,
+        proj₂ s⊒ ↦ⁿʷ proj₂ t⊑)
+      (wf⇒ wf★ wf★)
+      ★⇒★
+      refl
+  coerce-upʷᵐ {C = ＇ X} ℓ hX wf★ ok r (tagˣ X⊑★) =
+    realizes-cast-star-up r X⊑★
+  coerce-upʷᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
+      with coerce-upʷᵐ ℓ
+             hA
+             (renameᵗ-preserves-WfTy hB TyRenameWf-suc)
+             (idTyAllowed-shift-inst {μ = μ} {B = B} ok)
+             (RealizesCast-ν-inst ℓ r)
+             p
+  coerce-upʷᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
+      | c , c⊑ =
+    instᶜ B c , cast-inst hB occ (proj₁ c⊑) , instʷ (proj₂ c⊑)
+
+  coerce-downⁿᵐ :
+    ∀ {μ Δ Σ Φ C A} →
+    (ℓ : Label) →
+    WfTy Δ C →
+    WfTy Δ A →
+    idTyAllowed μ A ≡ true →
+    RealizesCastᵐ μ Δ Σ Φ →
+    Φ ⊢ C ⊑ A →
+    Σ[ c ∈ Coercion ] μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ C
+  coerce-downⁿᵐ ℓ wf★ wf★ ok r id★ =
+    idᶜ ★ , cast-id wf★ refl , nw-id★
+  coerce-downⁿᵐ {C = ＇ X} {A = ＇ Y} ℓ hX hY ok r (idˣ X⊑Y) =
+    realizes-cast-xx-down r X⊑Y
+  coerce-downⁿᵐ {C = ‵ ι} ℓ wfBase wfBase ok r idι =
+    idᶜ (‵ ι) , cast-id wfBase refl , nw-cross (id-‵ⁿʷ ι)
+  coerce-downⁿᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      with idTyAllowed μ A′ in okA′ | idTyAllowed μ B′ in okB′
+  coerce-downⁿᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true
+      with coerce-upʷᵐ ℓ hA hA′ okA′ r p
+         | coerce-downⁿᵐ ℓ hB hB′ okB′ r q
+  coerce-downⁿᵐ ℓ (wf⇒ hA hB) (wf⇒ hA′ hB′) ok r (p ↦ q)
+      | true | true | s , s⊑ | t , t⊒ =
+    (s ↦ᶜ t) , cast-fun (proj₁ s⊑) (proj₁ t⊒) ,
+    nw-cross (proj₂ s⊑ ↦ⁿʷ proj₂ t⊒)
+  coerce-downⁿᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | false | b
+  coerce-downⁿᵐ {μ = μ} {A = A′ ⇒ B′} ℓ
+      (wf⇒ hA hB) (wf⇒ hA′ hB′) () r (p ↦ q)
+      | true | false
+  coerce-downⁿᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
+      with coerce-downⁿᵐ ℓ hA hB ok (RealizesCast-∀ⁱ r) p
+  coerce-downⁿᵐ ℓ (wf∀ hA) (wf∀ hB) ok r (∀ⁱ p)
+      | c , c⊒ =
+    `∀ᶜ c , cast-all (proj₁ c⊒) , nw-cross (∀ⁿʷ (proj₂ c⊒))
+  coerce-downⁿᵐ {C = ‵ ι} ℓ wfBase wf★ ok r (tag ι) =
+    (‵ ι) ？ᶜ , cast-untag wfBase (‵ ι) refl , untagⁿ (‵ ι)
+  coerce-downⁿᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
+      with coerce-upʷᵐ ℓ hA wf★ refl r p
+         | coerce-downⁿᵐ ℓ hB wf★ refl r q
+  coerce-downⁿᵐ ℓ (wf⇒ hA hB) wf★ ok r (tag_⇒_ p q)
+      | s , s⊑ | t , t⊒ =
+    wrap-untagⁿ
+      (wf⇒ wf★ wf★)
+      ★⇒★
+      refl
+      (cast-fun (proj₁ s⊑) (proj₁ t⊒) ,
+        proj₂ s⊑ ↦ⁿʷ proj₂ t⊒)
+  coerce-downⁿᵐ {C = ＇ X} ℓ hX wf★ ok r (tagˣ X⊑★) =
+    realizes-cast-star-down r X⊑★
+  coerce-downⁿᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
+      with coerce-downⁿᵐ ℓ
+             hA
+             (renameᵗ-preserves-WfTy hB TyRenameWf-suc)
+             (idTyAllowed-shift-gen {μ = μ} {B = B} ok)
+             (RealizesCast-ν-gen ℓ r)
+             p
+  coerce-downⁿᵐ {μ = μ} {A = B} ℓ (wf∀ hA) hB ok r (ν occ p)
+      | c , c⊒ =
+    genᶜ B c , cast-gen hB occ (proj₁ c⊒) , genⁿ (proj₂ c⊒)
+
 coerce-up :
   ∀ {Δ Σ Φ C A} →
   (ℓ : Label) →
@@ -462,3 +789,34 @@ coerce-down {A = A} ℓ hC hA r p =
     result : Σ[ c ∈ Coercion ] _ ∣ _ ⊢ c ∶ A =⇒ _
     result with coerce-downᵐ ℓ hC hA (idTyAllowed-id-only A) r p
     result | c , c⊢ = c , id-onlyᵈ , c⊢
+
+coerce-upʷ :
+  ∀ {Δ Σ Φ C A} →
+  (ℓ : Label) →
+  WfTy Δ C →
+  WfTy Δ A →
+  RealizesCast Δ Σ Φ →
+  Φ ⊢ C ⊑ A →
+  Σ[ c ∈ Coercion ] Σ[ μ ∈ ModeEnv ] μ ∣ Δ ∣ Σ ⊢ c ∶ C ⊑ A
+coerce-upʷ {A = A} ℓ hC hA r p =
+  result
+  where
+    result :
+      Σ[ c ∈ Coercion ] Σ[ μ ∈ ModeEnv ] μ ∣ _ ∣ _ ⊢ c ∶ _ ⊑ A
+    result with coerce-upʷᵐ ℓ hC hA (idTyAllowed-id-only A) r p
+    result | c , c⊑ = c , id-onlyᵈ , c⊑
+
+coerce-downⁿ :
+  ∀ {Δ Σ Φ C A} →
+  (ℓ : Label) →
+  WfTy Δ C →
+  WfTy Δ A →
+  RealizesCast Δ Σ Φ →
+  Φ ⊢ C ⊑ A →
+  Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ∶ A ⊒ C
+coerce-downⁿ {A = A} ℓ hC hA r p =
+  result
+  where
+    result : Σ[ c ∈ Coercion ] _ ∣ _ ⊢ c ∶ A ⊒ _
+    result with coerce-downⁿᵐ ℓ hC hA (idTyAllowed-id-only A) r p
+    result | c , c⊒ = c , id-onlyᵈ , c⊒

--- a/GTSF/proof/CompileTermNarrowing.agda
+++ b/GTSF/proof/CompileTermNarrowing.agda
@@ -11,13 +11,23 @@ module proof.CompileTermNarrowing where
 
 open import Data.List using ([]; _∷_; map)
 open import Data.Nat using (suc)
+open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; refl; cong; cong₂; subst; sym)
 
 open import Types
 open import Ctx using (CtxWf; ctxWf-∷)
-open import Compile using (compile; compile-value)
+open import Compile
+  using
+    ( CastPlan
+    ; cast
+    ; compile
+    ; compile-value
+    ; down⊒
+    ; lower
+    ; upDual⊒
+    )
 open import NuTerms
   using (Term)
   renaming
@@ -46,13 +56,18 @@ open import NarrowWiden using
   ; ctx-nrw
   ; cross
   ; id-‵
+  ; _∣_∣_⊢_∶_⊒_
   ; _∣_⊢_∶ᶜ_⊒_
   ; fun-narrow-domain-dualᶜ
+  ; narrow-weaken
   )
 open import Coercions using (Coercion; id; _↦_; cast-id)
 open import Primitives using (Const; Prim; κℕ; constTy)
 open import proof.NuTermProperties using (CtxWf-⤊)
+open import Store using (StoreIncl)
 open import StoreCorrespondence using (SealCorr; ⇑ᶜorr)
+open import proof.ImprecisionProperties using (~-left-wf; ~-refl; ~-right-wf)
+open import proof.TypeProperties using (singleTyEnv-Wf; substᵗ-preserves-WfTy)
 open import TermNarrowingSeparated using
   ( CtxCorr
   ; CtxCorrEntry
@@ -86,12 +101,17 @@ open import GradualTermNarrowing
 open import MediatedNarrowing
   using
     ( _∣_∣_∣_⊢_⊒_∶_⦂_⊒ᵐ_
+    ; _∣_∣_∣_⊢_∶_⊒ᵐ_
     ; _∣_∣_⊢_∶ᶜ_⊒ᵐ_
     ; fun-narrow-domain-dualᵐᶜ
     ; x⊒xᵗ
     ; ƛ⊒ƛᵗ
     ; Λ⊒Λᵗ
     ; κ⊒κᵗ
+    ; cast+⊒ᵗ
+    ; cast-⊒ᵗ
+    ; ⊒cast+ᵗ
+    ; ⊒cast-ᵗ
     )
 
 ctxNrwToCorrEntry : CtxNrwEntry → CtxCorrEntry
@@ -174,6 +194,75 @@ const-indexᶜ :
   ∀ {Δ} κ →
   Δ ∣ [] ⊢ id (constTy κ) ∶ᶜ constTy κ ⊒ constTy κ
 const-indexᶜ (κℕ n) = cast-id wfBase refl , cross (id-‵ `ℕ)
+
+gradual-typing-wf :
+  ∀ {Δ Γ M A} →
+  CtxWf Δ Γ →
+  Δ ∣ Γ ⊢ᴳ M ⦂ A →
+  WfTy Δ A
+gradual-typing-wf Γ-wf (⊢ᴳ` x∈) = Γ-wf x∈
+gradual-typing-wf Γ-wf (⊢ᴳƛ wfA M⊢) =
+  wf⇒ wfA (gradual-typing-wf (ctxWf-∷ wfA Γ-wf) M⊢)
+gradual-typing-wf Γ-wf (⊢ᴳ· L⊢ M⊢ A~A′)
+    with gradual-typing-wf Γ-wf L⊢
+gradual-typing-wf Γ-wf (⊢ᴳ· L⊢ M⊢ A~A′)
+    | wf⇒ hA hB = hB
+gradual-typing-wf Γ-wf (⊢ᴳ·★ L⊢ M⊢ A′~★) = wf★
+gradual-typing-wf Γ-wf (⊢ᴳΛ vM M⊢) =
+  wf∀ (gradual-typing-wf (CtxWf-⤊ Γ-wf) M⊢)
+gradual-typing-wf Γ-wf (⊢ᴳ• M⊢ wfB wfA) =
+  substᵗ-preserves-WfTy wfB (singleTyEnv-Wf wfA)
+gradual-typing-wf Γ-wf (⊢ᴳ$ (κℕ n)) = wfBase
+gradual-typing-wf Γ-wf (⊢ᴳ⊕ L⊢ A~ℕ op M⊢ B~ℕ) = wfBase
+
+empty-store-incl :
+  ∀ {Σ} →
+  StoreIncl [] Σ
+empty-store-incl ()
+
+narrow-empty-weaken :
+  ∀ {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ [] ⊢ c ∶ A ⊒ B →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B
+narrow-empty-weaken = narrow-weaken ≤-refl empty-store-incl
+
+cast-plan-left-narrowing :
+  ∀ {Δ ρ γ M M′ A B C q r s μ ν} →
+  (plan : CastPlan Δ [] A B) →
+  Δ ∣ Δ ∣ ρ ⊢ q ∶ᶜ lower plan ⊒ᵐ C →
+  μ ∣ Δ ∣ Δ ∣ ρ ⊢ r ∶ A ⊒ᵐ C →
+  ν ∣ Δ ∣ Δ ∣ ρ ⊢ s ∶ B ⊒ᵐ C →
+  Δ ∣ Δ ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ r ⦂ A ⊒ᵐ C →
+  Δ ∣ Δ ∣ ρ ∣ γ ⊢ cast plan M ⊒ M′ ∶ s ⦂ B ⊒ᵐ C
+cast-plan-left-narrowing plan qᶜ r⊒ s⊒ M⊒M′ =
+  cast+⊒ᵗ
+    qᶜ
+    s⊒
+    (narrow-empty-weaken (proj₂ (proj₂ (upDual⊒ plan))))
+    (cast-⊒ᵗ
+      qᶜ
+      r⊒
+      (narrow-empty-weaken (proj₂ (down⊒ plan)))
+      M⊒M′)
+
+cast-plan-right-narrowing :
+  ∀ {Δ ρ γ M M′ A B C p q r μ} →
+  (plan : CastPlan Δ [] A B) →
+  Δ ∣ Δ ∣ ρ ⊢ p ∶ᶜ C ⊒ᵐ A →
+  μ ∣ Δ ∣ Δ ∣ ρ ⊢ q ∶ C ⊒ᵐ lower plan →
+  Δ ∣ Δ ∣ ρ ⊢ r ∶ᶜ C ⊒ᵐ B →
+  Δ ∣ Δ ∣ ρ ∣ γ ⊢ M ⊒ M′ ∶ p ⦂ C ⊒ᵐ A →
+  Δ ∣ Δ ∣ ρ ∣ γ ⊢ M ⊒ cast plan M′ ∶ r ⦂ C ⊒ᵐ B
+cast-plan-right-narrowing plan pᶜ q⊒ rᶜ M⊒M′ =
+  ⊒cast+ᵗ
+    rᶜ
+    q⊒
+    (narrow-empty-weaken (proj₂ (proj₂ (upDual⊒ plan))))
+    (⊒cast-ᵗ
+      pᶜ
+      q⊒
+      (narrow-empty-weaken (proj₂ (down⊒ plan)))
+      M⊒M′)
 
 -- These are the remaining compiler-specific proof obligations from issue #58.
 -- They are stated over `MediatedNarrowing`, not the obsolete shared-store

--- a/GTSF/proof/CompileTermNarrowing.agda
+++ b/GTSF/proof/CompileTermNarrowing.agda
@@ -14,7 +14,7 @@ open import Data.Nat using (suc)
 open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality using
-  (_≡_; refl; cong; cong₂; subst; sym)
+  (_≡_; refl; cong; cong₂; inspect; subst; sym; trans; [_])
 
 open import Types
 open import Ctx using (CtxWf; ctxWf-∷)
@@ -24,12 +24,13 @@ open import Compile
     ; cast
     ; compile
     ; compile-value
+    ; consistency-cast-plan
     ; down⊒
+    ; empty-store-wf-at
     ; lower
     ; upDual⊒
     )
 open import NuTerms
-  using (Term)
   renaming
     ( _∣_∣_⊢_⦂_ to _∣_∣_⊢ᵀ_⦂_
     ; ⊢` to ⊢ᵀ`
@@ -44,9 +45,7 @@ open import GradualTerms
     ; ⊢` to ⊢ᴳ`
     ; ⊢ƛ to ⊢ᴳƛ
     ; ⊢· to ⊢ᴳ·
-    ; ⊢·★ to ⊢ᴳ·★
     ; ⊢Λ to ⊢ᴳΛ
-    ; ⊢• to ⊢ᴳ•
     ; ⊢$ to ⊢ᴳ$
     ; ⊢⊕ to ⊢ᴳ⊕
     )
@@ -62,18 +61,16 @@ open import NarrowWiden using
   ; narrow-weaken
   )
 open import Coercions using (Coercion; id; _↦_; cast-id)
-open import Primitives using (Const; Prim; κℕ; constTy)
+open import Primitives using (addℕ; κℕ; constTy)
 open import proof.NuTermProperties using (CtxWf-⤊)
+open import proof.CoercionProperties using (coercion-wfᵐ)
 open import Store using (StoreIncl)
 open import StoreCorrespondence using (SealCorr; ⇑ᶜorr)
-open import proof.ImprecisionProperties using (~-left-wf; ~-refl; ~-right-wf)
-open import proof.TypeProperties using (singleTyEnv-Wf; substᵗ-preserves-WfTy)
+open import proof.ImprecisionProperties using (~-refl; ~-sym)
 open import TermNarrowingSeparated using
   ( CtxCorr
   ; CtxCorrEntry
   ; ctx-entry
-  ; leftCtx
-  ; rightCtx
   ; ⇑ᵍᶜ
   )
 
@@ -104,10 +101,13 @@ open import MediatedNarrowing
     ; _∣_∣_∣_⊢_∶_⊒ᵐ_
     ; _∣_∣_⊢_∶ᶜ_⊒ᵐ_
     ; fun-narrow-domain-dualᵐᶜ
+    ; fun-narrow-domain-dual-typingᵐᶜ
     ; x⊒xᵗ
     ; ƛ⊒ƛᵗ
+    ; ·⊒·ᵗ
     ; Λ⊒Λᵗ
     ; κ⊒κᵗ
+    ; ⊕⊒⊕ᵗ
     ; cast+⊒ᵗ
     ; cast-⊒ᵗ
     ; ⊒cast+ᵗ
@@ -119,16 +119,6 @@ ctxNrwToCorrEntry (ctx-nrw A B p) = ctx-entry A B p
 
 ctxNrwToCorr : CtxNrw → CtxCorr
 ctxNrwToCorr = map ctxNrwToCorrEntry
-
-leftCtx-ctxNrwToCorr : ∀ γ → leftCtx (ctxNrwToCorr γ) ≡ srcCtxⁿ γ
-leftCtx-ctxNrwToCorr [] = refl
-leftCtx-ctxNrwToCorr (ctx-nrw A B p ∷ γ) =
-  cong₂ _∷_ refl (leftCtx-ctxNrwToCorr γ)
-
-rightCtx-ctxNrwToCorr : ∀ γ → rightCtx (ctxNrwToCorr γ) ≡ tgtCtxⁿ γ
-rightCtx-ctxNrwToCorr [] = refl
-rightCtx-ctxNrwToCorr (ctx-nrw A B p ∷ γ) =
-  cong₂ _∷_ refl (rightCtx-ctxNrwToCorr γ)
 
 ctxNrwToCorr-⇑ :
   ∀ γ →
@@ -143,6 +133,20 @@ ctxNrwToCorr-∋ :
   ctxNrwToCorr γ ∋ x ⦂ ctx-entry A B p
 ctxNrwToCorr-∋ Z = Z
 ctxNrwToCorr-∋ (S x∋p) = S (ctxNrwToCorr-∋ x∋p)
+
+srcCtxⁿ-∋ :
+  ∀ {γ x A B p} →
+  γ ∋ x ⦂ ctx-nrw A B p →
+  srcCtxⁿ γ ∋ x ⦂ A
+srcCtxⁿ-∋ Z = Z
+srcCtxⁿ-∋ (S x∋p) = S (srcCtxⁿ-∋ x∋p)
+
+tgtCtxⁿ-∋ :
+  ∀ {γ x A B p} →
+  γ ∋ x ⦂ ctx-nrw A B p →
+  tgtCtxⁿ γ ∋ x ⦂ B
+tgtCtxⁿ-∋ Z = Z
+tgtCtxⁿ-∋ (S x∋p) = S (tgtCtxⁿ-∋ x∋p)
 
 record CompileIndexMediation (Δ : TyCtx) (ρ : SealCorr) : Set₁ where
   inductive
@@ -175,6 +179,14 @@ compile-context-subst-term :
       ≡ proj₁ (compile Γ-wf M⊢)
 compile-context-subst-term refl Γ-wf M⊢ = refl
 
+gradual-typing-subst-sym-subst :
+  ∀ {Δ Γ Γ′ M A} →
+  (Γ≡Γ′ : Γ ≡ Γ′) →
+  (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
+  subst (λ Γ₀ → Δ ∣ Γ₀ ⊢ᴳ M ⦂ A) (sym Γ≡Γ′)
+    (subst (λ Γ₀ → Δ ∣ Γ₀ ⊢ᴳ M ⦂ A) Γ≡Γ′ M⊢) ≡ M⊢
+gradual-typing-subst-sym-subst refl M⊢ = refl
+
 mediated-narrowing-cong-terms :
   ∀ {ΔL ΔR ρ γ L L′ R R′ p A B}
   → L ≡ L′
@@ -190,30 +202,125 @@ mediated-narrowing-context-cong :
   → ΔL ∣ ΔR ∣ ρ ∣ γ′ ⊢ L ⊒ R ∶ p ⦂ A ⊒ᵐ B
 mediated-narrowing-context-cong refl L⊒R = L⊒R
 
+mediated-narrowing-index-cong :
+  ∀ {ΔL ΔR ρ γ L R p p′ A B}
+  → p ≡ p′
+  → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ R ∶ p ⦂ A ⊒ᵐ B
+  → ΔL ∣ ΔR ∣ ρ ∣ γ ⊢ L ⊒ R ∶ p′ ⦂ A ⊒ᵐ B
+mediated-narrowing-index-cong refl L⊒R = L⊒R
+
 const-indexᶜ :
   ∀ {Δ} κ →
   Δ ∣ [] ⊢ id (constTy κ) ∶ᶜ constTy κ ⊒ constTy κ
 const-indexᶜ (κℕ n) = cast-id wfBase refl , cross (id-‵ `ℕ)
 
-gradual-typing-wf :
-  ∀ {Δ Γ M A} →
-  CtxWf Δ Γ →
-  Δ ∣ Γ ⊢ᴳ M ⦂ A →
+fun-source-domain-wf :
+  ∀ {Δ p q A A′ B B′} →
+  Δ ∣ [] ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
   WfTy Δ A
-gradual-typing-wf Γ-wf (⊢ᴳ` x∈) = Γ-wf x∈
-gradual-typing-wf Γ-wf (⊢ᴳƛ wfA M⊢) =
-  wf⇒ wfA (gradual-typing-wf (ctxWf-∷ wfA Γ-wf) M⊢)
-gradual-typing-wf Γ-wf (⊢ᴳ· L⊢ M⊢ A~A′)
-    with gradual-typing-wf Γ-wf L⊢
-gradual-typing-wf Γ-wf (⊢ᴳ· L⊢ M⊢ A~A′)
-    | wf⇒ hA hB = hB
-gradual-typing-wf Γ-wf (⊢ᴳ·★ L⊢ M⊢ A′~★) = wf★
-gradual-typing-wf Γ-wf (⊢ᴳΛ vM M⊢) =
-  wf∀ (gradual-typing-wf (CtxWf-⤊ Γ-wf) M⊢)
-gradual-typing-wf Γ-wf (⊢ᴳ• M⊢ wfB wfA) =
-  substᵗ-preserves-WfTy wfB (singleTyEnv-Wf wfA)
-gradual-typing-wf Γ-wf (⊢ᴳ$ (κℕ n)) = wfBase
-gradual-typing-wf Γ-wf (⊢ᴳ⊕ L⊢ A~ℕ op M⊢ B~ℕ) = wfBase
+fun-source-domain-wf p↦qᶜ
+    with coercion-wfᵐ empty-store-wf-at (proj₁ p↦qᶜ)
+fun-source-domain-wf p↦qᶜ | wf⇒ hA hB , wf⇒ hA′ hB′ = hA
+
+fun-target-domain-wf :
+  ∀ {Δ p q A A′ B B′} →
+  Δ ∣ [] ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′) →
+  WfTy Δ A′
+fun-target-domain-wf p↦qᶜ
+    with coercion-wfᵐ empty-store-wf-at (proj₁ p↦qᶜ)
+fun-target-domain-wf p↦qᶜ | wf⇒ hA hB , wf⇒ hA′ hB′ = hA′
+
+gradual-term-narrowing-canonical-source-typing :
+  ∀ {Δ γ M M′ p A B} →
+  Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  Δ ∣ srcCtxⁿ γ ⊢ᴳ M ⦂ A
+gradual-term-narrowing-canonical-source-typing (x⊒xᴳ pᶜ x∋p) =
+  ⊢ᴳ` (srcCtxⁿ-∋ x∋p)
+gradual-term-narrowing-canonical-source-typing
+    (ƛ⊒ƛᴳ p↦qᶜ N⊒N′) =
+  ⊢ᴳƛ
+    (fun-source-domain-wf p↦qᶜ)
+    (gradual-term-narrowing-canonical-source-typing N⊒N′)
+gradual-term-narrowing-canonical-source-typing
+    (·⊒·ᴳ p↦qᶜ L⊒L′ M⊒M′) =
+  ⊢ᴳ·
+    (gradual-term-narrowing-canonical-source-typing L⊒L′)
+    (gradual-term-narrowing-canonical-source-typing M⊒M′)
+    (~-refl (fun-source-domain-wf p↦qᶜ))
+gradual-term-narrowing-canonical-source-typing
+    (Λ⊒Λᴳ {typing = gradual-term-typing-endpoints
+      (⊢ᴳΛ {occ = occ} vV V⊢) V′⊢}
+      allᶜ vVₙ vV′ₙ V⊒V′) =
+  ⊢ᴳΛ {occ = occ} vVₙ
+    (subst
+      (λ Γ → _ ∣ Γ ⊢ᴳ _ ⦂ _)
+      (srcCtxⁿ-⇑ᵍ _)
+      (gradual-term-narrowing-canonical-source-typing V⊒V′))
+gradual-term-narrowing-canonical-source-typing
+    rel@(⊒Λᴳ pᶜ vV′ N⊒V′) =
+  gradual-term-narrowing-source-typing rel
+gradual-term-narrowing-canonical-source-typing
+    rel@([]⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  gradual-term-narrowing-source-typing rel
+gradual-term-narrowing-canonical-source-typing
+    rel@(⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  gradual-term-narrowing-source-typing rel
+gradual-term-narrowing-canonical-source-typing (κ⊒κᴳ κ) =
+  ⊢ᴳ$ κ
+gradual-term-narrowing-canonical-source-typing
+    (⊕⊒⊕ᴳ {op = op} M⊒M′ N⊒N′) =
+  ⊢ᴳ⊕
+    (gradual-term-narrowing-canonical-source-typing M⊒M′)
+    (~-refl wfBase)
+    op
+    (gradual-term-narrowing-canonical-source-typing N⊒N′)
+    (~-refl wfBase)
+
+gradual-term-narrowing-canonical-target-typing :
+  ∀ {Δ γ M M′ p A B} →
+  Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ p ⦂ A ⊒ B →
+  Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ ⦂ B
+gradual-term-narrowing-canonical-target-typing (x⊒xᴳ pᶜ x∋p) =
+  ⊢ᴳ` (tgtCtxⁿ-∋ x∋p)
+gradual-term-narrowing-canonical-target-typing
+    (ƛ⊒ƛᴳ p↦qᶜ N⊒N′) =
+  ⊢ᴳƛ
+    (fun-target-domain-wf p↦qᶜ)
+    (gradual-term-narrowing-canonical-target-typing N⊒N′)
+gradual-term-narrowing-canonical-target-typing
+    (·⊒·ᴳ p↦qᶜ L⊒L′ M⊒M′) =
+  ⊢ᴳ·
+    (gradual-term-narrowing-canonical-target-typing L⊒L′)
+    (gradual-term-narrowing-canonical-target-typing M⊒M′)
+    (~-refl (fun-target-domain-wf p↦qᶜ))
+gradual-term-narrowing-canonical-target-typing
+    (Λ⊒Λᴳ {typing = gradual-term-typing-endpoints
+      V⊢ (⊢ᴳΛ {occ = occ} vV′ V′⊢)}
+      allᶜ vVₙ vV′ₙ V⊒V′) =
+  ⊢ᴳΛ {occ = occ} vV′ₙ
+    (subst
+      (λ Γ → _ ∣ Γ ⊢ᴳ _ ⦂ _)
+      (tgtCtxⁿ-⇑ᵍ _)
+      (gradual-term-narrowing-canonical-target-typing V⊒V′))
+gradual-term-narrowing-canonical-target-typing
+    rel@(⊒Λᴳ pᶜ vV′ N⊒V′) =
+  gradual-term-narrowing-target-typing rel
+gradual-term-narrowing-canonical-target-typing
+    rel@([]⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  gradual-term-narrowing-target-typing rel
+gradual-term-narrowing-canonical-target-typing
+    rel@(⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  gradual-term-narrowing-target-typing rel
+gradual-term-narrowing-canonical-target-typing (κ⊒κᴳ κ) =
+  ⊢ᴳ$ κ
+gradual-term-narrowing-canonical-target-typing
+    (⊕⊒⊕ᴳ {op = op} M⊒M′ N⊒N′) =
+  ⊢ᴳ⊕
+    (gradual-term-narrowing-canonical-target-typing M⊒M′)
+    (~-refl wfBase)
+    op
+    (gradual-term-narrowing-canonical-target-typing N⊒N′)
+    (~-refl wfBase)
 
 empty-store-incl :
   ∀ {Σ} →
@@ -264,83 +371,6 @@ cast-plan-right-narrowing plan pᶜ q⊒ rᶜ M⊒M′ =
       (narrow-empty-weaken (proj₂ (down⊒ plan)))
       M⊒M′)
 
--- These are the remaining compiler-specific proof obligations from issue #58.
--- They are stated over `MediatedNarrowing`, not the obsolete shared-store
--- `TermNarrowing` relation.
-postulate
-  compile-preserves-application-narrowing :
-    ∀ {Δ ρ γ L L′ R R′ p A B ℓ} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (LR⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ L ·[ ℓ ] R ⦂ A) →
-    (L′R′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ L′ ·[ ℓ ] R′ ⦂ B) →
-    (LR⊒L′R′ : Δ ∣ [] ∣ γ ⊢ᴳ L ·[ ℓ ] R ⊒ L′ ·[ ℓ ] R′
-                  ∶ p ⦂ A ⊒ B) →
-    let
-      N = proj₁ (compile srcΓ-wf LR⊢)
-      N′ = proj₁ (compile tgtΓ-wf L′R′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
-
-  compile-preserves-target-forall-narrowing :
-    ∀ {Δ ρ γ N V′ p A B} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (N⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ N ⦂ A) →
-    (ΛV′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ Λ V′ ⦂ B) →
-    (N⊒ΛV′ : Δ ∣ [] ∣ γ ⊢ᴳ N ⊒ Λ V′ ∶ p ⦂ A ⊒ B) →
-    let
-      L = proj₁ (compile srcΓ-wf N⊢)
-      L′ = proj₁ (compile tgtΓ-wf ΛV′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ᵐ B
-
-  compile-preserves-type-application-narrowing :
-    ∀ {Δ ρ γ M M′ T T′ p A B} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (MT⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M `[ T ] ⦂ A) →
-    (M′T′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ `[ T′ ] ⦂ B) →
-    (MT⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M `[ T ] ⊒ M′ `[ T′ ]
-                  ∶ p ⦂ A ⊒ B) →
-    let
-      N = proj₁ (compile srcΓ-wf MT⊢)
-      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
-
-  compile-preserves-target-type-application-narrowing :
-    ∀ {Δ ρ γ M M′ T′ p A B} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (M⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M ⦂ A) →
-    (M′T′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ `[ T′ ] ⦂ B) →
-    (M⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ `[ T′ ] ∶ p ⦂ A ⊒ B) →
-    let
-      N = proj₁ (compile srcΓ-wf M⊢)
-      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
-
-  compile-preserves-primitive-narrowing :
-    ∀ {Δ ρ γ L L′ R R′ p A B op ℓ} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (LR⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ L ⊕[ op at ℓ ] R ⦂ A) →
-    (L′R′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ L′ ⊕[ op at ℓ ] R′ ⦂ B) →
-    (LR⊒L′R′ : Δ ∣ [] ∣ γ ⊢ᴳ L ⊕[ op at ℓ ] R ⊒
-                  L′ ⊕[ op at ℓ ] R′ ∶ p ⦂ A ⊒ B) →
-    let
-      N = proj₁ (compile srcΓ-wf LR⊢)
-      N′ = proj₁ (compile tgtΓ-wf L′R′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
-
 variable
   Δ : TyCtx
   ρ : SealCorr
@@ -349,91 +379,294 @@ variable
   p : Coercion
   M M′ : GTerm
 
-compile-preserves-term-narrowing-typed :
+-- These are the remaining compiler-specific proof obligations from issue #58.
+-- They are stated over canonical endpoint typings reconstructed from
+-- `GradualTermNarrowing`, not arbitrary external typing derivations.
+postulate
+  compile-preserves-target-forall-narrowing-canonical :
+    ∀ {Δ ρ γ N V′ p A B} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (N⊒ΛV′ : Δ ∣ [] ∣ γ ⊢ᴳ N ⊒ Λ V′ ∶ p ⦂ A ⊒ B) →
+    let
+      N⊢ = gradual-term-narrowing-canonical-source-typing N⊒ΛV′
+      ΛV′⊢ = gradual-term-narrowing-canonical-target-typing N⊒ΛV′
+      L = proj₁ (compile srcΓ-wf N⊢)
+      L′ = proj₁ (compile tgtΓ-wf ΛV′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ᵐ B
+
+  compile-preserves-type-application-narrowing-canonical :
+    ∀ {Δ ρ γ M M′ T T′ p A B} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (MT⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M `[ T ] ⊒ M′ `[ T′ ]
+                  ∶ p ⦂ A ⊒ B) →
+    let
+      MT⊢ = gradual-term-narrowing-canonical-source-typing MT⊒M′T′
+      M′T′⊢ = gradual-term-narrowing-canonical-target-typing MT⊒M′T′
+      N = proj₁ (compile srcΓ-wf MT⊢)
+      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+
+  compile-preserves-target-type-application-narrowing-canonical :
+    ∀ {Δ ρ γ M M′ T′ p A B} →
+    (med : CompileIndexMediation Δ ρ) →
+    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+    (M⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ `[ T′ ] ∶ p ⦂ A ⊒ B) →
+    let
+      M⊢ = gradual-term-narrowing-canonical-source-typing M⊒M′T′
+      M′T′⊢ = gradual-term-narrowing-canonical-target-typing M⊒M′T′
+      N = proj₁ (compile srcΓ-wf M⊢)
+      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
+    in
+    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+
+compile-preserves-term-narrowing-canonical :
   (med : CompileIndexMediation Δ ρ) →
   (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
   (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-  (M⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M ⦂ A) →
-  (M′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ ⦂ B) →
   (M⊒M′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ p ⦂ A ⊒ B) →
   let
+    M⊢ = gradual-term-narrowing-canonical-source-typing M⊒M′
+    M′⊢ = gradual-term-narrowing-canonical-target-typing M⊒M′
     N = proj₁ (compile srcΓ-wf M⊢)
     N′ = proj₁ (compile tgtΓ-wf M′⊢)
   in
   Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ (x⊒xᴳ pᶜ x∋p)
-    with M⊢ | M′⊢
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    _ _ (x⊒xᴳ pᶜ x∋p) | ⊢ᴳ` x∈ˢ | ⊢ᴳ` x∈ᵗ =
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    (x⊒xᴳ pᶜ x∋p) =
   x⊒xᵗ (indexᵐᶜ med pᶜ) (ctxNrwToCorr-∋ x∋p)
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ (κ⊒κᴳ κ)
-    with M⊢ | M′⊢
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    _ _ (κ⊒κᴳ κ) | ⊢ᴳ$ .κ | ⊢ᴳ$ .κ =
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    (κ⊒κᴳ κ) =
   κ⊒κᵗ κ (indexᵐᶜ med (const-indexᶜ κ))
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ (ƛ⊒ƛᴳ {p = p} {q = q} {A = A} {A′ = A′}
-      {B = B} {B′ = B′} p↦qᶜ N⊒N′)
-    with M⊢ | M′⊢
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    _ _
-    (ƛ⊒ƛᴳ {p = p} {q = q} {A = A} {A′ = A′} {B = B} {B′ = B′}
-      p↦qᶜ N⊒N′)
-    | ⊢ᴳƛ wfA N⊢ | ⊢ᴳƛ wfA′ N′⊢ =
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    (ƛ⊒ƛᴳ {p = p} {q = q} {A = A} {A′ = A′}
+      {B = B} {B′ = B′} p↦qᶜ N⊒N′) =
   ƛ⊒ƛᵗ {p = p} {q = q}
     {A = A} {A′ = A′} {B = B} {B′ = B′}
     (indexᵐᶜ med p↦qᶜ)
     (mediated-narrowing-context-cong
       (cong (λ c → ctx-entry A A′ c ∷ ctxNrwToCorr _)
         (sym (fun-domain-dualᵐᶜ med p↦qᶜ)))
-      (compile-preserves-term-narrowing-typed med
-        (ctxWf-∷ wfA srcΓ-wf)
-        (ctxWf-∷ wfA′ tgtΓ-wf)
-        N⊢
-        N′⊢
+      (compile-preserves-term-narrowing-canonical med
+        (ctxWf-∷ (fun-source-domain-wf p↦qᶜ) srcΓ-wf)
+        (ctxWf-∷ (fun-target-domain-wf p↦qᶜ) tgtΓ-wf)
         N⊒N′))
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ (Λ⊒Λᴳ allᶜ vVₙ vV′ₙ V⊒V′)
-    with M⊢ | M′⊢
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    _ _ (Λ⊒Λᴳ allᶜ vVₙ vV′ₙ V⊒V′)
-    | ⊢ᴳΛ vV V⊢ | ⊢ᴳΛ vV′ V′⊢ =
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    (Λ⊒Λᴳ {typing = gradual-term-typing-endpoints
+      (⊢ᴳΛ vV V₀⊢) (⊢ᴳΛ vV′ V′₀⊢)}
+      allᶜ vVₙ vV′ₙ V⊒V′) =
   Λ⊒Λᵗ
     (indexᵐᶜ med allᶜ)
-    (compile-value (CtxWf-⤊ srcΓ-wf) vV V⊢)
-    (compile-value (CtxWf-⤊ tgtΓ-wf) vV′ V′⊢)
+    (compile-value (CtxWf-⤊ srcΓ-wf) vVₙ V⊢)
+    (compile-value (CtxWf-⤊ tgtΓ-wf) vV′ₙ V′⊢)
     (mediated-narrowing-cong-terms
-      (compile-context-subst-term
-        (sym (srcCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ srcΓ-wf) V⊢)
-      (compile-context-subst-term
-        (sym (tgtCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ tgtΓ-wf) V′⊢)
+      src-body-eq
+      tgt-body-eq
       (mediated-narrowing-context-cong
         (ctxNrwToCorr-⇑ _)
-        (compile-preserves-term-narrowing-typed (shiftᵐ med)
-          (subst (CtxWf _) (sym (srcCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ srcΓ-wf))
-          (subst (CtxWf _) (sym (tgtCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ tgtΓ-wf))
-          (subst (λ Γ₀ → _ ∣ Γ₀ ⊢ᴳ _ ⦂ _) (sym (srcCtxⁿ-⇑ᵍ _)) V⊢)
-          (subst (λ Γ₀ → _ ∣ Γ₀ ⊢ᴳ _ ⦂ _) (sym (tgtCtxⁿ-⇑ᵍ _)) V′⊢)
+        (compile-preserves-term-narrowing-canonical (shiftᵐ med)
+          srcΓ⇑-wf
+          tgtΓ⇑-wf
           V⊒V′)))
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ app@(·⊒·ᴳ p↦qᶜ L⊒L′ N⊒N′) =
-  compile-preserves-application-narrowing med srcΓ-wf tgtΓ-wf M⊢ M′⊢ app
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ rel@(⊒Λᴳ pᶜ vV′ N⊒V′) =
-  compile-preserves-target-forall-narrowing med srcΓ-wf tgtΓ-wf M⊢ M′⊢ rel
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ rel@([]⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
-  compile-preserves-type-application-narrowing med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ rel
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ rel@(⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
-  compile-preserves-target-type-application-narrowing med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ rel
-compile-preserves-term-narrowing-typed med srcΓ-wf tgtΓ-wf
-    M⊢ M′⊢ prim@(⊕⊒⊕ᴳ M⊒M′ N⊒N′) =
-  compile-preserves-primitive-narrowing med srcΓ-wf tgtΓ-wf M⊢ M′⊢ prim
+  where
+    V⊢ =
+      subst
+        (λ Γ₀ → _ ∣ Γ₀ ⊢ᴳ _ ⦂ _)
+        (srcCtxⁿ-⇑ᵍ _)
+        (gradual-term-narrowing-canonical-source-typing V⊒V′)
+    V′⊢ =
+      subst
+        (λ Γ₀ → _ ∣ Γ₀ ⊢ᴳ _ ⦂ _)
+        (tgtCtxⁿ-⇑ᵍ _)
+        (gradual-term-narrowing-canonical-target-typing V⊒V′)
+    srcΓ⇑-wf =
+      subst (CtxWf _) (sym (srcCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ srcΓ-wf)
+    tgtΓ⇑-wf =
+      subst (CtxWf _) (sym (tgtCtxⁿ-⇑ᵍ _)) (CtxWf-⤊ tgtΓ-wf)
+    src-body-eq =
+      trans
+        (cong
+          (λ V⊢₀ → proj₁ (compile srcΓ⇑-wf V⊢₀))
+          (sym
+            (gradual-typing-subst-sym-subst
+              (srcCtxⁿ-⇑ᵍ _)
+              (gradual-term-narrowing-canonical-source-typing V⊒V′))))
+        (compile-context-subst-term
+          (sym (srcCtxⁿ-⇑ᵍ _))
+          (CtxWf-⤊ srcΓ-wf)
+          V⊢)
+    tgt-body-eq =
+      trans
+        (cong
+          (λ V′⊢₀ → proj₁ (compile tgtΓ⇑-wf V′⊢₀))
+          (sym
+            (gradual-typing-subst-sym-subst
+              (tgtCtxⁿ-⇑ᵍ _)
+              (gradual-term-narrowing-canonical-target-typing V⊒V′))))
+        (compile-context-subst-term
+          (sym (tgtCtxⁿ-⇑ᵍ _))
+          (CtxWf-⤊ tgtΓ-wf)
+          V′⊢)
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    (·⊒·ᴳ {p = p} {q = q} {A = A} {A′ = A′} {ℓ = ℓ}
+      p↦qᶜ L⊒L′ R⊒R′)
+    with compile srcΓ-wf
+           (gradual-term-narrowing-canonical-source-typing L⊒L′)
+       | inspect
+           (compile srcΓ-wf)
+           (gradual-term-narrowing-canonical-source-typing L⊒L′)
+       | compile tgtΓ-wf
+           (gradual-term-narrowing-canonical-target-typing L⊒L′)
+       | inspect
+           (compile tgtΓ-wf)
+           (gradual-term-narrowing-canonical-target-typing L⊒L′)
+       | compile srcΓ-wf
+           (gradual-term-narrowing-canonical-source-typing R⊒R′)
+       | inspect
+           (compile srcΓ-wf)
+           (gradual-term-narrowing-canonical-source-typing R⊒R′)
+       | compile tgtΓ-wf
+           (gradual-term-narrowing-canonical-target-typing R⊒R′)
+       | inspect
+           (compile tgtΓ-wf)
+           (gradual-term-narrowing-canonical-target-typing R⊒R′)
+       | consistency-cast-plan ℓ
+           (~-sym (~-refl (fun-source-domain-wf p↦qᶜ)))
+       | inspect
+           (consistency-cast-plan ℓ)
+           (~-sym (~-refl (fun-source-domain-wf p↦qᶜ)))
+       | consistency-cast-plan ℓ
+           (~-sym (~-refl (fun-target-domain-wf p↦qᶜ)))
+       | inspect
+           (consistency-cast-plan ℓ)
+           (~-sym (~-refl (fun-target-domain-wf p↦qᶜ)))
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    (·⊒·ᴳ {p = p} {q = q} {A = A} {A′ = A′} {ℓ = ℓ}
+      p↦qᶜ L⊒L′ R⊒R′)
+    | Lᵀ , L⊢ | [ eqL ]
+    | L′ᵀ , L′⊢ | [ eqL′ ]
+    | Rᵀ , R⊢ | [ eqR ]
+    | R′ᵀ , R′⊢ | [ eqR′ ]
+    | plan | [ eqPlan ]
+    | plan′ | [ eqPlan′ ] =
+  ·⊒·ᵗ
+    (indexᵐᶜ med p↦qᶜ)
+    (mediated-narrowing-cong-terms
+      {L = proj₁ (compile srcΓ-wf
+        (gradual-term-narrowing-canonical-source-typing L⊒L′))}
+      {R = proj₁ (compile tgtΓ-wf
+        (gradual-term-narrowing-canonical-target-typing L⊒L′))}
+      {R′ = L′ᵀ}
+      (cong proj₁ eqL)
+      (cong proj₁ eqL′)
+      (compile-preserves-term-narrowing-canonical med
+        srcΓ-wf tgtΓ-wf L⊒L′))
+    (cast-plan-right-narrowing
+      tgtPlan
+      domainᶜ
+      domainᶜ
+      domainᶜ
+      (cast-plan-left-narrowing
+        srcPlan
+        domainᶜ
+        domainᶜ
+        domainᶜ
+        (mediated-narrowing-index-cong
+          (sym (fun-domain-dualᵐᶜ med p↦qᶜ))
+          (mediated-narrowing-cong-terms
+            {L = proj₁ (compile srcΓ-wf
+              (gradual-term-narrowing-canonical-source-typing R⊒R′))}
+            {R = proj₁ (compile tgtΓ-wf
+              (gradual-term-narrowing-canonical-target-typing R⊒R′))}
+            {R′ = R′ᵀ}
+            (cong proj₁ eqR)
+            (cong proj₁ eqR′)
+            (compile-preserves-term-narrowing-canonical med
+              srcΓ-wf tgtΓ-wf R⊒R′)))))
+  where
+    domainᶜ =
+      fun-narrow-domain-dual-typingᵐᶜ (indexᵐᶜ med p↦qᶜ)
+    srcPlan =
+      consistency-cast-plan ℓ (~-sym (~-refl (fun-source-domain-wf p↦qᶜ)))
+    tgtPlan =
+      consistency-cast-plan ℓ (~-sym (~-refl (fun-target-domain-wf p↦qᶜ)))
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    rel@(⊒Λᴳ pᶜ vV′ N⊒V′) =
+  compile-preserves-target-forall-narrowing-canonical
+    med srcΓ-wf tgtΓ-wf rel
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    rel@([]⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  compile-preserves-type-application-narrowing-canonical
+    med srcΓ-wf tgtΓ-wf rel
+compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
+    rel@(⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
+  compile-preserves-target-type-application-narrowing-canonical
+    med srcΓ-wf tgtΓ-wf rel
+compile-preserves-term-narrowing-canonical {Δ = Δ} med srcΓ-wf tgtΓ-wf
+    (⊕⊒⊕ᴳ {op = addℕ} {ℓ = ℓ} M⊒M′ N⊒N′)
+    with compile srcΓ-wf
+           (gradual-term-narrowing-canonical-source-typing M⊒M′)
+       | inspect
+           (compile srcΓ-wf)
+           (gradual-term-narrowing-canonical-source-typing M⊒M′)
+       | compile tgtΓ-wf
+           (gradual-term-narrowing-canonical-target-typing M⊒M′)
+       | inspect
+           (compile tgtΓ-wf)
+           (gradual-term-narrowing-canonical-target-typing M⊒M′)
+       | compile srcΓ-wf
+           (gradual-term-narrowing-canonical-source-typing N⊒N′)
+       | inspect
+           (compile srcΓ-wf)
+           (gradual-term-narrowing-canonical-source-typing N⊒N′)
+       | compile tgtΓ-wf
+           (gradual-term-narrowing-canonical-target-typing N⊒N′)
+       | inspect
+           (compile tgtΓ-wf)
+           (gradual-term-narrowing-canonical-target-typing N⊒N′)
+       | consistency-cast-plan ℓ (~-refl {Δ = Δ} {A = ‵ `ℕ} wfBase)
+compile-preserves-term-narrowing-canonical {Δ = Δ} med srcΓ-wf tgtΓ-wf
+    (⊕⊒⊕ᴳ {op = addℕ} {ℓ = ℓ} M⊒M′ N⊒N′)
+    | Mᵀ , M⊢ | [ eqM ]
+    | M′ᵀ , M′⊢ | [ eqM′ ]
+    | Nᵀ , N⊢ | [ eqN ]
+    | N′ᵀ , N′⊢ | [ eqN′ ]
+    | plan =
+  ⊕⊒⊕ᵗ
+    ℕᶜ
+    (cast-plan-right-narrowing natPlan ℕᶜ ℕᶜ ℕᶜ
+      (cast-plan-left-narrowing natPlan ℕᶜ ℕᶜ ℕᶜ
+        (mediated-narrowing-cong-terms
+          {L = proj₁ (compile srcΓ-wf
+            (gradual-term-narrowing-canonical-source-typing M⊒M′))}
+          {R = proj₁ (compile tgtΓ-wf
+            (gradual-term-narrowing-canonical-target-typing M⊒M′))}
+          {R′ = M′ᵀ}
+          (cong proj₁ eqM)
+          (cong proj₁ eqM′)
+          (compile-preserves-term-narrowing-canonical med
+            srcΓ-wf tgtΓ-wf M⊒M′))))
+    (cast-plan-right-narrowing natPlan ℕᶜ ℕᶜ ℕᶜ
+      (cast-plan-left-narrowing natPlan ℕᶜ ℕᶜ ℕᶜ
+        (mediated-narrowing-cong-terms
+          {L = proj₁ (compile srcΓ-wf
+            (gradual-term-narrowing-canonical-source-typing N⊒N′))}
+          {R = proj₁ (compile tgtΓ-wf
+            (gradual-term-narrowing-canonical-target-typing N⊒N′))}
+          {R′ = N′ᵀ}
+          (cong proj₁ eqN)
+          (cong proj₁ eqN′)
+          (compile-preserves-term-narrowing-canonical med
+            srcΓ-wf tgtΓ-wf N⊒N′))))
+  where
+    ℕᶜ = indexᵐᶜ med (cast-id wfBase refl , cross (id-‵ `ℕ))
+    natPlan = consistency-cast-plan ℓ (~-refl {Δ = Δ} {A = ‵ `ℕ} wfBase)
 
 compile-preserves-term-narrowing :
   (med : CompileIndexMediation Δ ρ) →
@@ -441,17 +674,15 @@ compile-preserves-term-narrowing :
   (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
   (M⊒M′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ p ⦂ A ⊒ B) →
   let
-    M⊢ = gradual-term-narrowing-source-typing M⊒M′
-    M′⊢ = gradual-term-narrowing-target-typing M⊒M′
+    M⊢ = gradual-term-narrowing-canonical-source-typing M⊒M′
+    M′⊢ = gradual-term-narrowing-canonical-target-typing M⊒M′
     N = proj₁ (compile srcΓ-wf M⊢)
     N′ = proj₁ (compile tgtΓ-wf M′⊢)
   in
   Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
 compile-preserves-term-narrowing med srcΓ-wf tgtΓ-wf M⊒M′ =
-  compile-preserves-term-narrowing-typed
+  compile-preserves-term-narrowing-canonical
     med
     srcΓ-wf
     tgtΓ-wf
-    (gradual-term-narrowing-source-typing M⊒M′)
-    (gradual-term-narrowing-target-typing M⊒M′)
     M⊒M′

--- a/GTSF/proof/CompileTermNarrowing.agda
+++ b/GTSF/proof/CompileTermNarrowing.agda
@@ -5,22 +5,23 @@ module proof.CompileTermNarrowing where
 --   * States that compiling two source terms related by
 --     `GradualTermNarrowing` yields target terms related by
 --     `MediatedNarrowing`.
---   * The easy structural cases are proved directly.  The remaining
---     compiler-specific cases are named postulate boundaries isolating the
---     needed cast-plan composition and type-application/ν algebra.
+--   * Structural and cast-plan cases are proved directly; the remaining
+--     right-only polymorphic and ν bridges are explicit fields of the
+--     specialized `CompileIndexMediation` plan.
 
 open import Data.List using ([]; _∷_; map)
-open import Data.Nat using (suc)
+open import Data.Nat using (zero; suc)
 open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; refl; cong; cong₂; inspect; subst; sym; trans; [_])
 
 open import Types
-open import Ctx using (CtxWf; ctxWf-∷)
+open import Ctx using (CtxWf; ctxWf-∷; ⤊ᵗ)
 open import Compile
   using
     ( CastPlan
+    ; arrow★-consistent
     ; cast
     ; compile
     ; compile-value
@@ -45,7 +46,9 @@ open import GradualTerms
     ; ⊢` to ⊢ᴳ`
     ; ⊢ƛ to ⊢ᴳƛ
     ; ⊢· to ⊢ᴳ·
+    ; ⊢·★ to ⊢ᴳ·★
     ; ⊢Λ to ⊢ᴳΛ
+    ; ⊢• to ⊢ᴳ•
     ; ⊢$ to ⊢ᴳ$
     ; ⊢⊕ to ⊢ᴳ⊕
     )
@@ -58,19 +61,41 @@ open import NarrowWiden using
   ; _∣_∣_⊢_∶_⊒_
   ; _∣_⊢_∶ᶜ_⊒_
   ; fun-narrow-domain-dualᶜ
+  ; narrow-mode-relax
   ; narrow-weaken
   )
-open import Coercions using (Coercion; id; _↦_; cast-id)
+  renaming (gen to genⁿ)
+open import Coercions using
+  ( Coercion
+  ; ModeIncl
+  ; cast-gen
+  ; gen
+  ; genᵈ
+  ; id
+  ; tag-or-idᵈ
+  ; _↦_
+  ; cast-id
+  )
+  renaming (`∀ to `∀ᶜ)
 open import Primitives using (addℕ; κℕ; constTy)
-open import proof.NuTermProperties using (CtxWf-⤊)
+open import proof.NuTermProperties using (CtxWf-⤊; term-weaken)
 open import proof.CoercionProperties using (coercion-wfᵐ)
 open import Store using (StoreIncl)
-open import StoreCorrespondence using (SealCorr; ⇑ᶜorr)
+open import StoreCorrespondence using
+  ( SealCorr
+  ; ⇑ᶜorr
+  ; ⇑ʳᶜorr
+  ; corr-⇑ʳᶜorr
+  ; leftStore
+  ; rightStore-⇑ʳᶜorr
+  )
+open import Mediation using (medTy-mapʳ; mv-shiftʳ)
 open import proof.ImprecisionProperties using (~-refl; ~-sym)
 open import TermNarrowingSeparated using
   ( CtxCorr
   ; CtxCorrEntry
   ; ctx-entry
+  ; leftCtx
   ; ⇑ᵍᶜ
   )
 
@@ -102,10 +127,12 @@ open import MediatedNarrowing
     ; _∣_∣_⊢_∶ᶜ_⊒ᵐ_
     ; fun-narrow-domain-dualᵐᶜ
     ; fun-narrow-domain-dual-typingᵐᶜ
+    ; ⇑ʳᵍᶜ
     ; x⊒xᵗ
     ; ƛ⊒ƛᵗ
     ; ·⊒·ᵗ
     ; Λ⊒Λᵗ
+    ; ⊒Λᵗ
     ; κ⊒κᵗ
     ; ⊕⊒⊕ᵗ
     ; cast+⊒ᵗ
@@ -148,6 +175,13 @@ tgtCtxⁿ-∋ :
 tgtCtxⁿ-∋ Z = Z
 tgtCtxⁿ-∋ (S x∋p) = S (tgtCtxⁿ-∋ x∋p)
 
+leftCtx-ctxNrwToCorr :
+  ∀ γ →
+  leftCtx (ctxNrwToCorr γ) ≡ srcCtxⁿ γ
+leftCtx-ctxNrwToCorr [] = refl
+leftCtx-ctxNrwToCorr (ctx-nrw A B p ∷ γ) =
+  cong (A ∷_) (leftCtx-ctxNrwToCorr γ)
+
 record CompileIndexMediation (Δ : TyCtx) (ρ : SealCorr) : Set₁ where
   inductive
   field
@@ -161,6 +195,48 @@ record CompileIndexMediation (Δ : TyCtx) (ρ : SealCorr) : Set₁ where
       (p↦qᶜ : Δ ∣ [] ⊢ p ↦ q ∶ᶜ (A ⇒ B) ⊒ (A′ ⇒ B′)) →
       fun-narrow-domain-dualᵐᶜ (indexᵐᶜ p↦qᶜ) ≡
         fun-narrow-domain-dualᶜ p↦qᶜ
+
+    right-only-forall-bodyᵐ :
+      ∀ {γ N V′ p A Aʳ B} →
+      (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+      (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+      (N⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ N ⦂ A) →
+      (V′⊢ : suc Δ ∣ ⤊ᵗ (tgtCtxⁿ γ) ⊢ᴳ V′ ⦂ B) →
+      Δ ∣ Δ ∣ ρ ⊢ gen Aʳ p ∶ᶜ A ⊒ᵐ `∀ B →
+      suc Δ ∣ [] ∣ GradualTermNarrowing.⇑ᵍ γ
+        ⊢ᴳ GradualTermNarrowing.⇑ᵗᴳ N ⊒ V′ ∶ p ⦂ ⇑ᵗ A ⊒ B →
+      Δ ∣ suc Δ ∣ ⇑ʳᶜorr ρ ∣ ⇑ʳᵍᶜ (ctxNrwToCorr γ) ⊢
+        proj₁ (compile srcΓ-wf N⊢) ⊒
+        proj₁ (compile (CtxWf-⤊ tgtΓ-wf) V′⊢)
+          ∶ p ⦂ A ⊒ᵐ B
+
+    type-applicationνᵐ :
+      ∀ {γ M M′ T T′ A B p q r} →
+      (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+      (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+      (MT⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M `[ T ] ⦂ A [ T ]ᵗ) →
+      (M′T′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ `[ T′ ] ⦂ B [ T′ ]ᵗ) →
+      Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ `∀ᶜ p ⦂ `∀ A ⊒ `∀ B →
+      Δ ∣ Δ ∣ ρ ⊢ q ∶ᶜ T ⊒ᵐ T′ →
+      Δ ∣ Δ ∣ ρ ⊢ r ∶ᶜ A [ T ]ᵗ ⊒ᵐ B [ T′ ]ᵗ →
+      Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢
+        proj₁ (compile srcΓ-wf MT⊢) ⊒
+        proj₁ (compile tgtΓ-wf M′T′⊢)
+          ∶ r ⦂ A [ T ]ᵗ ⊒ᵐ B [ T′ ]ᵗ
+
+    target-type-applicationνᵐ :
+      ∀ {γ M M′ T′ A B p q r} →
+      (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+      (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+      (M⊢ : Δ ∣ srcCtxⁿ γ ⊢ᴳ M ⦂ A) →
+      (M′T′⊢ : Δ ∣ tgtCtxⁿ γ ⊢ᴳ M′ `[ T′ ] ⦂ B [ T′ ]ᵗ) →
+      Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ ∶ gen A p ⦂ A ⊒ `∀ B →
+      Δ ∣ Δ ∣ ρ ⊢ q ∶ᶜ ★ ⊒ᵐ T′ →
+      Δ ∣ Δ ∣ ρ ⊢ r ∶ᶜ A ⊒ᵐ B [ T′ ]ᵗ →
+      Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢
+        proj₁ (compile srcΓ-wf M⊢) ⊒
+        proj₁ (compile tgtΓ-wf M′T′⊢)
+          ∶ r ⦂ A ⊒ᵐ B [ T′ ]ᵗ
 
     shiftᵐ :
       CompileIndexMediation (suc Δ) (⇑ᶜorr ρ)
@@ -333,6 +409,98 @@ narrow-empty-weaken :
   μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B
 narrow-empty-weaken = narrow-weaken ≤-refl empty-store-incl
 
+narrow-store-cong :
+  ∀ {μ Δ Σ Σ′ c A B} →
+  Σ ≡ Σ′ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  μ ∣ Δ ∣ Σ′ ⊢ c ∶ A ⊒ B
+narrow-store-cong refl c⊒ = c⊒
+
+gen-tag-or-id-incl :
+  ModeIncl (genᵈ tag-or-idᵈ) tag-or-idᵈ
+gen-tag-or-id-incl zero = refl
+gen-tag-or-id-incl (suc X) = refl
+
+gen-body-indexᵐᶜ :
+  ∀ {Δ ρ p A Aʳ B} →
+  Δ ∣ Δ ∣ ρ ⊢ gen Aʳ p ∶ᶜ A ⊒ᵐ `∀ B →
+  Δ ∣ suc Δ ∣ ⇑ʳᶜorr ρ ⊢ p ∶ᶜ A ⊒ᵐ B
+gen-body-indexᵐᶜ {ρ = ρ}
+    (stores , hA , wf∀ hB , Aʳ ,
+      med , (cast-gen hAʳ occ p⊢ , genⁿ pⁿ)) =
+  corr-⇑ʳᶜorr stores ,
+  hA ,
+  hB ,
+  ⇑ᵗ Aʳ ,
+  medTy-mapʳ suc mv-shiftʳ med ,
+  narrow-store-cong
+    (sym (rightStore-⇑ʳᶜorr ρ))
+    (narrow-mode-relax gen-tag-or-id-incl (p⊢ , pⁿ))
+
+compile-no• :
+  ∀ {Δ Γ M A} →
+  (hΓ : CtxWf Δ Γ) →
+  (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
+  No• (proj₁ (compile hΓ M⊢))
+compile-no• hΓ (⊢ᴳ` x∈) = no•-`
+compile-no• hΓ (⊢ᴳƛ wfA M⊢)
+    with compile (ctxWf-∷ wfA hΓ) M⊢
+       | compile-no• (ctxWf-∷ wfA hΓ) M⊢
+compile-no• hΓ (⊢ᴳƛ wfA M⊢) | N , N⊢ | noN =
+  no•-ƛ noN
+compile-no• hΓ (⊢ᴳ· {ℓ = ℓ} L⊢ M⊢ A~A′)
+    with compile hΓ L⊢
+       | compile-no• hΓ L⊢
+       | compile hΓ M⊢
+       | compile-no• hΓ M⊢
+       | consistency-cast-plan ℓ (~-sym A~A′)
+compile-no• hΓ (⊢ᴳ· L⊢ M⊢ A~A′)
+    | L′ , L′⊢ | noL′ | M′ , M′⊢ | noM′ | plan =
+  no•-· noL′ (no•-⟨⟩ (no•-⟨⟩ noM′))
+compile-no• hΓ (⊢ᴳ·★ {ℓ = ℓ} L⊢ M⊢ A′~★)
+    with compile hΓ L⊢
+       | compile-no• hΓ L⊢
+       | compile hΓ M⊢
+       | compile-no• hΓ M⊢
+       | consistency-cast-plan ℓ (~-sym (arrow★-consistent A′~★))
+compile-no• hΓ (⊢ᴳ·★ L⊢ M⊢ A′~★)
+    | L′ , L′⊢ | noL′ | M′ , M′⊢ | noM′ | plan =
+  no•-· (no•-⟨⟩ (no•-⟨⟩ noL′)) noM′
+compile-no• hΓ (⊢ᴳΛ vM M⊢)
+    with compile (CtxWf-⤊ hΓ) M⊢
+       | compile-no• (CtxWf-⤊ hΓ) M⊢
+compile-no• hΓ (⊢ᴳΛ vM M⊢) | N , N⊢ | noN =
+  no•-Λ noN
+compile-no• hΓ (⊢ᴳ• M⊢ wfB wfA)
+    with compile hΓ M⊢
+       | compile-no• hΓ M⊢
+compile-no• hΓ (⊢ᴳ• M⊢ wfB wfA) | M′ , M′⊢ | noM′ =
+  no•-ν noM′
+compile-no• hΓ (⊢ᴳ$ κ) = no•-$
+compile-no• hΓ (⊢ᴳ⊕ {ℓ = ℓ} L⊢ A~ℕ op M⊢ B~ℕ)
+    with compile hΓ L⊢
+       | compile-no• hΓ L⊢
+       | compile hΓ M⊢
+       | compile-no• hΓ M⊢
+       | consistency-cast-plan ℓ A~ℕ
+       | consistency-cast-plan ℓ B~ℕ
+compile-no• hΓ (⊢ᴳ⊕ L⊢ A~ℕ op M⊢ B~ℕ)
+    | L′ , L′⊢ | noL′ | M′ , M′⊢ | noM′ | planL | planM =
+  no•-⊕
+    (no•-⟨⟩ (no•-⟨⟩ noL′))
+    (no•-⟨⟩ (no•-⟨⟩ noM′))
+
+compile-source-left-typing :
+  ∀ {Δ ρ γ N A} →
+  (N⊢ : Δ ∣ [] ∣ srcCtxⁿ γ ⊢ᵀ N ⦂ A) →
+  No• N →
+  Δ ∣ leftStore ρ ∣ leftCtx (ctxNrwToCorr γ) ⊢ᵀ N ⦂ A
+compile-source-left-typing {ρ = ρ} {γ = γ} N⊢ noN =
+  subst
+    (λ Γ → _ ∣ leftStore ρ ∣ Γ ⊢ᵀ _ ⦂ _)
+    (sym (leftCtx-ctxNrwToCorr γ))
+    (term-weaken ≤-refl empty-store-incl noN N⊢)
+
 cast-plan-left-narrowing :
   ∀ {Δ ρ γ M M′ A B C q r s μ ν} →
   (plan : CastPlan Δ [] A B) →
@@ -379,52 +547,38 @@ variable
   p : Coercion
   M M′ : GTerm
 
--- These are the remaining compiler-specific proof obligations from issue #58.
--- They are stated over canonical endpoint typings reconstructed from
--- `GradualTermNarrowing`, not arbitrary external typing derivations.
-postulate
-  compile-preserves-target-forall-narrowing-canonical :
-    ∀ {Δ ρ γ N V′ p A B} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (N⊒ΛV′ : Δ ∣ [] ∣ γ ⊢ᴳ N ⊒ Λ V′ ∶ p ⦂ A ⊒ B) →
-    let
-      N⊢ = gradual-term-narrowing-canonical-source-typing N⊒ΛV′
-      ΛV′⊢ = gradual-term-narrowing-canonical-target-typing N⊒ΛV′
-      L = proj₁ (compile srcΓ-wf N⊢)
-      L′ = proj₁ (compile tgtΓ-wf ΛV′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ L ⊒ L′ ∶ p ⦂ A ⊒ᵐ B
-
-  compile-preserves-type-application-narrowing-canonical :
-    ∀ {Δ ρ γ M M′ T T′ p A B} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (MT⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M `[ T ] ⊒ M′ `[ T′ ]
-                  ∶ p ⦂ A ⊒ B) →
-    let
-      MT⊢ = gradual-term-narrowing-canonical-source-typing MT⊒M′T′
-      M′T′⊢ = gradual-term-narrowing-canonical-target-typing MT⊒M′T′
-      N = proj₁ (compile srcΓ-wf MT⊢)
-      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
-
-  compile-preserves-target-type-application-narrowing-canonical :
-    ∀ {Δ ρ γ M M′ T′ p A B} →
-    (med : CompileIndexMediation Δ ρ) →
-    (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
-    (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
-    (M⊒M′T′ : Δ ∣ [] ∣ γ ⊢ᴳ M ⊒ M′ `[ T′ ] ∶ p ⦂ A ⊒ B) →
-    let
-      M⊢ = gradual-term-narrowing-canonical-source-typing M⊒M′T′
-      M′T′⊢ = gradual-term-narrowing-canonical-target-typing M⊒M′T′
-      N = proj₁ (compile srcΓ-wf M⊢)
-      N′ = proj₁ (compile tgtΓ-wf M′T′⊢)
-    in
-    Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ N ⊒ N′ ∶ p ⦂ A ⊒ᵐ B
+compile-preserves-target-forall-narrowing-canonical :
+  ∀ {Δ ρ γ N V′ p A B} →
+  (med : CompileIndexMediation Δ ρ) →
+  (srcΓ-wf : CtxWf Δ (srcCtxⁿ γ)) →
+  (tgtΓ-wf : CtxWf Δ (tgtCtxⁿ γ)) →
+  (N⊒ΛV′ : Δ ∣ [] ∣ γ ⊢ᴳ N ⊒ Λ V′ ∶ gen A p ⦂ A ⊒ `∀ B) →
+  let
+    N⊢ = gradual-term-narrowing-canonical-source-typing N⊒ΛV′
+    ΛV′⊢ = gradual-term-narrowing-canonical-target-typing N⊒ΛV′
+    L = proj₁ (compile srcΓ-wf N⊢)
+    L′ = proj₁ (compile tgtΓ-wf ΛV′⊢)
+  in
+  Δ ∣ Δ ∣ ρ ∣ ctxNrwToCorr γ ⊢ L ⊒ L′ ∶ gen A p ⦂ A ⊒ᵐ `∀ B
+compile-preserves-target-forall-narrowing-canonical {ρ = ρ}
+    med srcΓ-wf tgtΓ-wf
+    (⊒Λᴳ {typing = gradual-term-typing-endpoints N⊢ (⊢ᴳΛ vV′ V′⊢)}
+      pᶜ vV′ₙ N⊒V′) =
+  ⊒Λᵗ
+    (compile-source-left-typing {ρ = ρ}
+      (proj₂ (compile srcΓ-wf N⊢))
+      (compile-no• srcΓ-wf N⊢))
+    genᶜ
+    (compile-value (CtxWf-⤊ tgtΓ-wf) vV′ₙ V′⊢)
+    (right-only-forall-bodyᵐ med
+      srcΓ-wf
+      tgtΓ-wf
+      N⊢
+      V′⊢
+      genᶜ
+      N⊒V′)
+  where
+    genᶜ = indexᵐᶜ med pᶜ
 
 compile-preserves-term-narrowing-canonical :
   (med : CompileIndexMediation Δ ρ) →
@@ -601,13 +755,27 @@ compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
   compile-preserves-target-forall-narrowing-canonical
     med srcΓ-wf tgtΓ-wf rel
 compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
-    rel@([]⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
-  compile-preserves-type-application-narrowing-canonical
-    med srcΓ-wf tgtΓ-wf rel
+    ([]⊒[]ᴳ {typing = gradual-term-typing-endpoints MT⊢ M′T′⊢}
+      M⊒M′ qᶜ rᶜ) =
+  type-applicationνᵐ med
+    srcΓ-wf
+    tgtΓ-wf
+    MT⊢
+    M′T′⊢
+    M⊒M′
+    (indexᵐᶜ med qᶜ)
+    (indexᵐᶜ med rᶜ)
 compile-preserves-term-narrowing-canonical med srcΓ-wf tgtΓ-wf
-    rel@(⊒[]ᴳ M⊒M′ qᶜ rᶜ) =
-  compile-preserves-target-type-application-narrowing-canonical
-    med srcΓ-wf tgtΓ-wf rel
+    (⊒[]ᴳ {typing = gradual-term-typing-endpoints M⊢ M′T′⊢}
+      M⊒M′ qᶜ rᶜ) =
+  target-type-applicationνᵐ med
+    srcΓ-wf
+    tgtΓ-wf
+    M⊢
+    M′T′⊢
+    M⊒M′
+    (indexᵐᶜ med qᶜ)
+    (indexᵐᶜ med rᶜ)
 compile-preserves-term-narrowing-canonical {Δ = Δ} med srcΓ-wf tgtΓ-wf
     (⊕⊒⊕ᴳ {op = addℕ} {ℓ = ℓ} M⊒M′ N⊒N′)
     with compile srcΓ-wf

--- a/GTSF/proof/CompileTermNarrowing.agda
+++ b/GTSF/proof/CompileTermNarrowing.agda
@@ -9,8 +9,9 @@ module proof.CompileTermNarrowing where
 --     right-only polymorphic and ν bridges are explicit fields of the
 --     specialized `CompileIndexMediation` plan.
 
+open import Data.Empty using (⊥)
 open import Data.List using ([]; _∷_; map)
-open import Data.Nat using (zero; suc)
+open import Data.Nat using (zero; suc; z<s)
 open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_,_; proj₁; proj₂)
 open import Relation.Binary.PropositionalEquality using
@@ -57,6 +58,7 @@ open import NarrowWiden using
   ; CtxNrwEntry
   ; ctx-nrw
   ; cross
+  ; id-＇
   ; id-‵
   ; _∣_∣_⊢_∶_⊒_
   ; _∣_⊢_∶ᶜ_⊒_
@@ -89,7 +91,14 @@ open import StoreCorrespondence using
   ; leftStore
   ; rightStore-⇑ʳᶜorr
   )
-open import Mediation using (medTy-mapʳ; mv-shiftʳ)
+open import Mediation using
+  ( MedTy
+  ; MatchedVar
+  ; med-var
+  ; med-⇒
+  ; medTy-mapʳ
+  ; mv-shiftʳ
+  )
 open import proof.ImprecisionProperties using (~-refl; ~-sym)
 open import TermNarrowingSeparated using
   ( CtxCorr
@@ -242,6 +251,56 @@ record CompileIndexMediation (Δ : TyCtx) (ρ : SealCorr) : Set₁ where
       CompileIndexMediation (suc Δ) (⇑ᶜorr ρ)
 
 open CompileIndexMediation
+
+no-empty-var-med :
+  ∀ {Aʳ} →
+  MedTy (MatchedVar []) (＇ zero) Aʳ →
+  ⊥
+no-empty-var-med (med-var ())
+
+empty-var-indexᵐ-impossible :
+  suc zero ∣ suc zero ∣ [] ⊢ id (＇ zero) ∶ᶜ ＇ zero ⊒ᵐ ＇ zero →
+  ⊥
+empty-var-indexᵐ-impossible (stores , hA , hB , Aʳ , medA , home) =
+  no-empty-var-med medA
+
+empty-var-lambdaᵐ-impossible :
+  suc zero ∣ suc zero ∣ [] ∣ [] ⊢
+    ƛ (` zero) ⊒ ƛ (` zero)
+      ∶ id (＇ zero) ↦ id (＇ zero)
+      ⦂ (＇ zero ⇒ ＇ zero) ⊒ᵐ (＇ zero ⇒ ＇ zero) →
+  ⊥
+empty-var-lambdaᵐ-impossible
+    (ƛ⊒ƛᵗ (stores , hA , hB , Aʳ , med-⇒ medA medB , home) body) =
+  no-empty-var-med medA
+
+-- Consequently the current mediated relation cannot express the
+-- shared-store polymorphic identity example at the empty correspondence.
+empty-poly-idᵐ-impossible :
+  zero ∣ zero ∣ [] ∣ [] ⊢
+    Λ (ƛ (` zero)) ⊒ Λ (ƛ (` zero))
+      ∶ `∀ᶜ (id (＇ zero) ↦ id (＇ zero))
+      ⦂ `∀ (＇ zero ⇒ ＇ zero) ⊒ᵐ `∀ (＇ zero ⇒ ＇ zero) →
+  ⊥
+empty-poly-idᵐ-impossible (Λ⊒Λᵗ allᶜ vV vV′ V⊒V′) =
+  empty-var-lambdaᵐ-impossible V⊒V′
+
+-- The plan cannot be instantiated by the bare empty correspondence:
+-- after shifting under a type binder, the source index `id (＇ zero)`
+-- needs a matched variable witness, but `MatchedVar []` has none.
+empty-shift-index-plan-impossible :
+  CompileIndexMediation (suc zero) [] →
+  ⊥
+empty-shift-index-plan-impossible med
+    with indexᵐᶜ med (cast-id (wfVar z<s) refl , cross (id-＇ zero))
+empty-shift-index-plan-impossible med | varᶜ =
+  empty-var-indexᵐ-impossible varᶜ
+
+empty-compile-index-plan-impossible :
+  CompileIndexMediation zero [] →
+  ⊥
+empty-compile-index-plan-impossible med =
+  empty-shift-index-plan-impossible (shiftᵐ med)
 
 compile-context-subst-term :
   ∀ {Δ Γ Γ′ M A}


### PR DESCRIPTION
## Summary

Progress toward issue #58 using the specialized compiler-plan route, while keeping `MediatedNarrowing` unchanged so far.

This branch now:

- specializes `proof.CompileTermNarrowing` around canonical endpoint typings induced by `GradualTermNarrowing`;
- proves the variable, constant, lambda, application, primitive, and symmetric type-abstraction compile cases over the mediated relation;
- moves compiler-generated cast behavior into `Compile.CastPlan` evidence and proof-layer cast-plan helpers;
- removes the old theorem-level postulate block from `proof.CompileTermNarrowing`;
- records a checked obstruction for the current `CompileIndexMediation` plan.

## Latest Finding

Commit `5f5ffcf8` proves that the current plan record is too strong: `CompileIndexMediation zero [] -> ⊥`. More sharply, it proves the current `MediatedNarrowing` relation cannot express the closed polymorphic identity relation at the empty correspondence:

```agda
zero ∣ zero ∣ [] ∣ [] ⊢
  Λ (ƛ (` zero)) ⊒ Λ (ƛ (` zero))
    ∶ `∀ᶜ (id (＇ zero) ↦ id (＇ zero))
    ⦂ `∀ (＇ zero ⇒ ＇ zero) ⊒ᵐ `∀ (＇ zero ⇒ ＇ zero)
  -> ⊥
```

The failure is not in `MediatedNarrowing` proof plumbing alone: `MedTy (MatchedVar []) (＇ zero) _` is impossible after the `Λ` body enters `⇑ᶜorr [] = []`. A viable plan likely needs a separate lexical type-variable correspondence, distinct from runtime seal correspondence `ρ`.

## Remaining Work

The remaining design choice is now explicit:

- either refine `MediatedNarrowing` so lexical binders are mediated separately from runtime store/seal correspondences;
- or keep `MediatedNarrowing` unchanged and treat the polymorphic bridges as explicit compiler-specific assumptions, knowing the closed `Λ` identity case is otherwise unconstructible.

## Validation

- `agda --no-allow-unsolved-metas proof/CompileTermNarrowing.agda` from `GTSF/`
- `agda -v0 All.agda` from `GTSF/`
- `git diff --check`