### PR TITLE
Develop GTSF Nu DGG simulation spine

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -43,6 +43,10 @@ import proof.EndpointCanonicalMLBSimplePairedSpan
 import proof.EndpointCanonicalMLBSimpleFactorization
 import proof.EndpointCanonicalMLBSimpleFactorCounterexample
 import proof.QuotientedTermImprecisionTest
+import proof.NuImprecisionSimulation
+import proof.NuReductionDeterminism
+import proof.NuDGGTraceAlignment
+import proof.NuDGGSpine
 import proof.MaximalLowerBoundsWf
 import StoreCorrespondence
 import NuTerms
@@ -53,6 +57,7 @@ import TypeCheck
 -- import TermNarrowingSeparated
 import NuExamplesFresh
 import NuReduction
+import ReductionTrace
 import Eval
 import Run
 import proof.CompileTermNarrowing

--- a/GTSF/Compile.agda
+++ b/GTSF/Compile.agda
@@ -3,8 +3,8 @@ module Compile where
 -- File Charter:
 --   * Compilation from source gradual GTSF terms to target explicit-coercion
 --     terms.
---   * Exports the common-lower-bound cast-plan specification, `compile`, and
---     `compile-value`.
+--   * Exports the common-lower-bound cast-plan specification, `compile`,
+--     `compileᵀ`, their value proofs, and agreement of their output terms.
 --   * The store is empty at compile time; target reduction allocates store
 --     cells later for polymorphic/seal behavior.
 
@@ -517,3 +517,64 @@ compileᵀ-value hΓ (Λᴳ M) (⊢ᴳΛ vM M⊢)
        | compileᵀ-value (CtxWf-⤊ hΓ) vM M⊢
 compileᵀ-value hΓ (Λᴳ M) (⊢ᴳΛ vM M⊢) | N , N⊢ | vN =
   Λᵀ vN
+
+------------------------------------------------------------------------
+-- Agreement of the two compilation typing interfaces
+------------------------------------------------------------------------
+
+compile-term-agrees :
+  ∀ {Δ Γ M A} →
+  (hΓ : CtxWf Δ Γ) →
+  (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
+  proj₁ (compile hΓ M⊢) ≡ proj₁ (compileᵀ hΓ M⊢)
+compile-term-agrees hΓ (⊢ᴳ` x∈) = refl
+compile-term-agrees hΓ (⊢ᴳƛ wfA M⊢)
+    with compile (ctxWf-∷ wfA hΓ) M⊢
+       | compileᵀ (ctxWf-∷ wfA hΓ) M⊢
+       | compile-term-agrees (ctxWf-∷ wfA hΓ) M⊢
+compile-term-agrees hΓ (⊢ᴳƛ wfA M⊢)
+    | N , N⊢ | N′ , N′⊢ | refl = refl
+compile-term-agrees hΓ (⊢ᴳ· {ℓ = ℓ} L⊢ M⊢ A~A′)
+    with compile hΓ L⊢ | compileᵀ hΓ L⊢
+       | compile hΓ M⊢ | compileᵀ hΓ M⊢
+       | consistency-cast-plan ℓ (~-sym A~A′)
+       | compile-term-agrees hΓ L⊢
+       | compile-term-agrees hΓ M⊢
+compile-term-agrees hΓ (⊢ᴳ· L⊢ M⊢ A~A′)
+    | L , L⊢′ | L′ , L′⊢ | N , N⊢ | N′ , N′⊢
+    | plan | refl | refl = refl
+compile-term-agrees {Δ = Δ} hΓ (⊢ᴳ·★ {ℓ = ℓ} L⊢ M⊢ A′~★)
+    with compile hΓ L⊢ | compileᵀ hΓ L⊢
+       | compile hΓ M⊢ | compileᵀ hΓ M⊢
+       | consistency-cast-plan {Δ = Δ} ℓ
+           dynamic-application-function-consistent
+       | consistency-cast-plan {Δ = Δ} ℓ A′~★
+       | compile-term-agrees hΓ L⊢
+       | compile-term-agrees hΓ M⊢
+compile-term-agrees {Δ = Δ} hΓ (⊢ᴳ·★ L⊢ M⊢ A′~★)
+    | L , L⊢′ | L′ , L′⊢ | N , N⊢ | N′ , N′⊢
+    | fun-plan | arg-plan | refl | refl = refl
+compile-term-agrees hΓ (⊢ᴳΛ vM M⊢)
+    with compile (CtxWf-⤊ hΓ) M⊢
+       | compileᵀ (CtxWf-⤊ hΓ) M⊢
+       | compile-value (CtxWf-⤊ hΓ) vM M⊢
+       | compileᵀ-value (CtxWf-⤊ hΓ) vM M⊢
+       | compile-term-agrees (CtxWf-⤊ hΓ) M⊢
+compile-term-agrees hΓ (⊢ᴳΛ vM M⊢)
+    | N , N⊢ | N′ , N′⊢ | vN | vN′ | refl = refl
+compile-term-agrees hΓ (⊢ᴳ• M⊢ wfB wfA)
+    with compile hΓ M⊢ | compileᵀ hΓ M⊢
+       | compile-term-agrees hΓ M⊢
+compile-term-agrees hΓ (⊢ᴳ• M⊢ wfB wfA)
+    | N , N⊢ | N′ , N′⊢ | refl = refl
+compile-term-agrees hΓ (⊢ᴳ$ κ) = refl
+compile-term-agrees hΓ (⊢ᴳ⊕ {ℓ = ℓ} L⊢ A~ℕ op M⊢ B~ℕ)
+    with compile hΓ L⊢ | compileᵀ hΓ L⊢
+       | compile hΓ M⊢ | compileᵀ hΓ M⊢
+       | consistency-cast-plan ℓ A~ℕ
+       | consistency-cast-plan ℓ B~ℕ
+       | compile-term-agrees hΓ L⊢
+       | compile-term-agrees hΓ M⊢
+compile-term-agrees hΓ (⊢ᴳ⊕ L⊢ A~ℕ op M⊢ B~ℕ)
+    | L , L⊢′ | L′ , L′⊢ | N , N⊢ | N′ , N′⊢
+    | planL | planM | refl | refl = refl

--- a/GTSF/CompileTermImprecision.agda
+++ b/GTSF/CompileTermImprecision.agda
@@ -11,6 +11,7 @@ open import Data.Product using (proj₁)
 open import Types
 open import Ctx using (CtxWf)
 open import Compile using (compileᵀ)
+open import GradualTerms using (GTerm)
 import GradualTermImprecision as GTI
 open import GradualTermImprecision using
   (_∣_∣_∣_⊢ᴳ_⊑_⦂_⊑_∶_)
@@ -27,7 +28,7 @@ variable
   γ : GTI.CtxImp Φ Δᴸ Δᴿ
   A B : Ty
   p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ
-  M M′ : GTI.GTerm
+  M M′ : GTerm
 
 ctxImpToNu :
   GTI.CtxImp Φ Δᴸ Δᴿ →

--- a/GTSF/Conversion.agda
+++ b/GTSF/Conversion.agda
@@ -5,7 +5,8 @@ module Conversion where
 --   * Conversions reuse raw `Coercion` syntax but expose only identity,
 --     seal/unseal, arrow, and forall structure.
 --   * The embedding lemmas recover ordinary coercion typing, while the
---     reveal/conceal lemmas give a finer-grained surface for ν-generated casts.
+--     reveal/conceal provenance predicates track one seal name through arrows,
+--     forall binders, store extension, renaming, and binder opening.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (true)
@@ -13,7 +14,7 @@ open import Data.Empty using (⊥-elim)
 open import Data.List using (_∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here)
-open import Data.Nat using (zero; suc; z<s; s<s)
+open import Data.Nat using (_<_; zero; suc; z<s; s<s)
 open import Data.Nat.Properties using (_≟_; n≤1+n; n<1+n; m<n⇒m<1+n)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
@@ -21,10 +22,13 @@ open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
 
 open import Types
+open import Store using (StoreIncl)
 open import Coercions
 open import proof.CoercionProperties
   using
-    ( RevealEnv
+    ( ModeRename
+    ; ModeRename-ext
+    ; RevealEnv
     ; RevealEnv-ext
     ; RevealMode
     ; RevealMode-ext
@@ -34,8 +38,14 @@ open import proof.CoercionProperties
     ; singleRevealEnv
     ; singleSealᵈ
     ; singleSealMode
+    ; modeRename-idTyAllowed
+    ; modeRename-sealModeAllowed
+    ; single-mode-rename-lower
     )
-open import proof.StoreProperties using (∈-renameStoreᵗ)
+open import proof.StoreProperties using
+  ( ∈-renameStoreᵗ
+  ; renameStoreᵗ-incl
+  )
 open import proof.TypeProperties
   using
     ( TyRenameWf
@@ -45,7 +55,12 @@ open import proof.TypeProperties
     ; TySubstWf-exts
     ; WfTy-weakenᵗ
     ; renameᵗ-preserves-WfTy
+    ; renameStoreᵗ-ext-suc-comm
+    ; renameStoreᵗ-single-suc-cancel
+    ; renameᵗ-ext-suc-comm
+    ; renameᵗ-single-suc-cancel
     ; singleRenameᵗ-Wf
+    ; singleRenameᵗ-Wf-<
     )
 
 ------------------------------------------------------------------------
@@ -110,6 +125,289 @@ _∣_⊢_∶_↑ˢ_ : TyCtx → Store → Coercion → Ty → Ty → Set
 _∣_⊢_∶_↓ˢ_ : TyCtx → Store → Coercion → Ty → Ty → Set
 Δ ∣ Σ ⊢ c ∶ A ↓ˢ B =
   ∃[ μ ] μ ∣ Δ ∣ Σ ⊢ c ∶ A ↓ˢ B
+
+------------------------------------------------------------------------
+-- Single-name reveal/conceal provenance
+------------------------------------------------------------------------
+
+mutual
+  data RevealConversion
+      (μ : ModeEnv) (Δ : TyCtx) (Σ : Store) (α : TyVar) (C : Ty) :
+      Coercion → Ty → Ty → Set where
+    reveal-id-var : ∀ {Y} →
+      WfTy Δ (＇ Y) →
+      idModeAllowed (μ Y) ≡ true →
+      RevealConversion μ Δ Σ α C (id (＇ Y)) (＇ Y) (＇ Y)
+
+    reveal-id-base : ∀ {ι} →
+      RevealConversion μ Δ Σ α C (id (‵ ι)) (‵ ι) (‵ ι)
+
+    reveal-id-★ :
+      RevealConversion μ Δ Σ α C (id ★) ★ ★
+
+    reveal-unseal :
+      WfTy Δ C →
+      (α , C) ∈ Σ →
+      sealModeAllowed (μ α) ≡ true →
+      RevealConversion μ Δ Σ α C (unseal α C) (＇ α) C
+
+    reveal-fun : ∀ {A A′ B B′ s t} →
+      ConcealConversion μ Δ Σ α C s A′ A →
+      RevealConversion μ Δ Σ α C t B B′ →
+      RevealConversion μ Δ Σ α C (s ↦ t) (A ⇒ B) (A′ ⇒ B′)
+
+    reveal-all : ∀ {A B s} →
+      RevealConversion (extᵈ μ) (suc Δ) (⟰ᵗ Σ)
+        (suc α) (⇑ᵗ C) s A B →
+      RevealConversion μ Δ Σ α C (`∀ s) (`∀ A) (`∀ B)
+
+  data ConcealConversion
+      (μ : ModeEnv) (Δ : TyCtx) (Σ : Store) (α : TyVar) (C : Ty) :
+      Coercion → Ty → Ty → Set where
+    conceal-id-var : ∀ {Y} →
+      WfTy Δ (＇ Y) →
+      idModeAllowed (μ Y) ≡ true →
+      ConcealConversion μ Δ Σ α C (id (＇ Y)) (＇ Y) (＇ Y)
+
+    conceal-id-base : ∀ {ι} →
+      ConcealConversion μ Δ Σ α C (id (‵ ι)) (‵ ι) (‵ ι)
+
+    conceal-id-★ :
+      ConcealConversion μ Δ Σ α C (id ★) ★ ★
+
+    conceal-seal :
+      WfTy Δ C →
+      (α , C) ∈ Σ →
+      sealModeAllowed (μ α) ≡ true →
+      ConcealConversion μ Δ Σ α C (seal C α) C (＇ α)
+
+    conceal-fun : ∀ {A A′ B B′ s t} →
+      RevealConversion μ Δ Σ α C s A′ A →
+      ConcealConversion μ Δ Σ α C t B B′ →
+      ConcealConversion μ Δ Σ α C (s ↦ t) (A ⇒ B) (A′ ⇒ B′)
+
+    conceal-all : ∀ {A B s} →
+      ConcealConversion (extᵈ μ) (suc Δ) (⟰ᵗ Σ)
+        (suc α) (⇑ᵗ C) s A B →
+      ConcealConversion μ Δ Σ α C (`∀ s) (`∀ A) (`∀ B)
+
+mutual
+  reveal-conversion-typing :
+    ∀ {μ Δ Σ α C c A B} →
+    RevealConversion μ Δ Σ α C c A B →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A ↑ˢ B
+  reveal-conversion-typing (reveal-id-var hY ok) = conv↑-id hY ok
+  reveal-conversion-typing reveal-id-base = conv↑-id wfBase refl
+  reveal-conversion-typing reveal-id-★ = conv↑-id wf★ refl
+  reveal-conversion-typing (reveal-unseal hC α∈Σ ok) =
+    conv↑-unseal hC α∈Σ ok
+  reveal-conversion-typing (reveal-fun s↓ t↑) =
+    conv↑-fun (conceal-conversion-typing s↓)
+      (reveal-conversion-typing t↑)
+  reveal-conversion-typing (reveal-all s↑) =
+    conv↑-all (reveal-conversion-typing s↑)
+
+  conceal-conversion-typing :
+    ∀ {μ Δ Σ α C c A B} →
+    ConcealConversion μ Δ Σ α C c A B →
+    μ ∣ Δ ∣ Σ ⊢ c ∶ A ↓ˢ B
+  conceal-conversion-typing (conceal-id-var hY ok) = conv↓-id hY ok
+  conceal-conversion-typing conceal-id-base = conv↓-id wfBase refl
+  conceal-conversion-typing conceal-id-★ = conv↓-id wf★ refl
+  conceal-conversion-typing (conceal-seal hC α∈Σ ok) =
+    conv↓-seal hC α∈Σ ok
+  conceal-conversion-typing (conceal-fun s↑ t↓) =
+    conv↓-fun (reveal-conversion-typing s↑)
+      (conceal-conversion-typing t↓)
+  conceal-conversion-typing (conceal-all s↓) =
+    conv↓-all (conceal-conversion-typing s↓)
+
+mutual
+  reveal↑ :
+    ∀ {μ Δ Σ α C A B} →
+    μ ∣ Δ ∣ Σ ⊢ reveal A α C ∶ A ↑ˢ B →
+    RevealConversion μ Δ Σ α C (reveal A α C) A B
+  reveal↑ {α = α} {A = ＇ Y} c↑ with α ≟ Y
+  reveal↑ {α = α} {A = ＇ .α} (conv↑-unseal hC α∈Σ ok)
+      | yes refl =
+    reveal-unseal hC α∈Σ ok
+  reveal↑ {α = α} {A = ＇ Y} (conv↑-id hY ok) | no α≢Y =
+    reveal-id-var hY ok
+  reveal↑ {A = ‵ ι} (conv↑-id hι ok) = reveal-id-base
+  reveal↑ {A = ★} (conv↑-id h★ ok) = reveal-id-★
+  reveal↑ {A = A ⇒ B} (conv↑-fun s↓ t↑) =
+    reveal-fun (conceal↓ s↓) (reveal↑ t↑)
+  reveal↑ {A = `∀ A} (conv↑-all s↑) = reveal-all (reveal↑ s↑)
+
+  conceal↓ :
+    ∀ {μ Δ Σ α C A B} →
+    μ ∣ Δ ∣ Σ ⊢ conceal B α C ∶ A ↓ˢ B →
+    ConcealConversion μ Δ Σ α C (conceal B α C) A B
+  conceal↓ {α = α} {B = ＇ Y} c↓ with α ≟ Y
+  conceal↓ {α = α} {B = ＇ .α} (conv↓-seal hC α∈Σ ok)
+      | yes refl =
+    conceal-seal hC α∈Σ ok
+  conceal↓ {α = α} {B = ＇ Y} (conv↓-id hY ok) | no α≢Y =
+    conceal-id-var hY ok
+  conceal↓ {B = ‵ ι} (conv↓-id hι ok) = conceal-id-base
+  conceal↓ {B = ★} (conv↓-id h★ ok) = conceal-id-★
+  conceal↓ {B = A ⇒ B} (conv↓-fun s↑ t↓) =
+    conceal-fun (reveal↑ s↑) (conceal↓ t↓)
+  conceal↓ {B = `∀ B} (conv↓-all s↓) = conceal-all (conceal↓ s↓)
+
+mutual
+  rename-reveal-conversion :
+    ∀ {μ ν Δ Δ′ Σ α C c A B ρ} →
+    TyRenameWf Δ Δ′ ρ →
+    ModeRename ρ μ ν →
+    RevealConversion μ Δ Σ α C c A B →
+    RevealConversion ν Δ′ (renameStoreᵗ ρ Σ) (ρ α)
+      (renameᵗ ρ C) (renameᶜ ρ c) (renameᵗ ρ A) (renameᵗ ρ B)
+  rename-reveal-conversion {μ = μ} {ν = ν} {ρ = ρ} hρ hμ
+      (reveal-id-var {Y = Y} hY ok) =
+    reveal-id-var
+      (renameᵗ-preserves-WfTy hY hρ)
+      (modeRename-idTyAllowed
+        {ρ = ρ} {μ = μ} {ν = ν} {A = ＇ Y} hμ ok)
+  rename-reveal-conversion hρ hμ reveal-id-base = reveal-id-base
+  rename-reveal-conversion hρ hμ reveal-id-★ = reveal-id-★
+  rename-reveal-conversion {μ = μ} {ν = ν} {ρ = ρ} hρ hμ
+      (reveal-unseal hC α∈Σ ok) =
+    reveal-unseal
+      (renameᵗ-preserves-WfTy hC hρ)
+      (∈-renameStoreᵗ ρ α∈Σ)
+      (modeRename-sealModeAllowed
+        {ρ = ρ} {μ = μ} {ν = ν} hμ ok)
+  rename-reveal-conversion hρ hμ (reveal-fun s↓ t↑) =
+    reveal-fun
+      (rename-conceal-conversion hρ hμ s↓)
+      (rename-reveal-conversion hρ hμ t↑)
+  rename-reveal-conversion {ρ = ρ} hρ hμ (reveal-all s↑) =
+    reveal-all
+      (subst
+        (λ D → RevealConversion _ _ _ _ D _ _ _)
+        (renameᵗ-ext-suc-comm ρ _)
+        (subst
+          (λ Σ′ → RevealConversion _ _ Σ′ _ _ _ _ _)
+          (renameStoreᵗ-ext-suc-comm ρ _)
+          (rename-reveal-conversion
+            (TyRenameWf-ext hρ) (ModeRename-ext hμ) s↑)))
+
+  rename-conceal-conversion :
+    ∀ {μ ν Δ Δ′ Σ α C c A B ρ} →
+    TyRenameWf Δ Δ′ ρ →
+    ModeRename ρ μ ν →
+    ConcealConversion μ Δ Σ α C c A B →
+    ConcealConversion ν Δ′ (renameStoreᵗ ρ Σ) (ρ α)
+      (renameᵗ ρ C) (renameᶜ ρ c) (renameᵗ ρ A) (renameᵗ ρ B)
+  rename-conceal-conversion {μ = μ} {ν = ν} {ρ = ρ} hρ hμ
+      (conceal-id-var {Y = Y} hY ok) =
+    conceal-id-var
+      (renameᵗ-preserves-WfTy hY hρ)
+      (modeRename-idTyAllowed
+        {ρ = ρ} {μ = μ} {ν = ν} {A = ＇ Y} hμ ok)
+  rename-conceal-conversion hρ hμ conceal-id-base = conceal-id-base
+  rename-conceal-conversion hρ hμ conceal-id-★ = conceal-id-★
+  rename-conceal-conversion {μ = μ} {ν = ν} {ρ = ρ} hρ hμ
+      (conceal-seal hC α∈Σ ok) =
+    conceal-seal
+      (renameᵗ-preserves-WfTy hC hρ)
+      (∈-renameStoreᵗ ρ α∈Σ)
+      (modeRename-sealModeAllowed
+        {ρ = ρ} {μ = μ} {ν = ν} hμ ok)
+  rename-conceal-conversion hρ hμ (conceal-fun s↑ t↓) =
+    conceal-fun
+      (rename-reveal-conversion hρ hμ s↑)
+      (rename-conceal-conversion hρ hμ t↓)
+  rename-conceal-conversion {ρ = ρ} hρ hμ (conceal-all s↓) =
+    conceal-all
+      (subst
+        (λ D → ConcealConversion _ _ _ _ D _ _ _)
+        (renameᵗ-ext-suc-comm ρ _)
+        (subst
+          (λ Σ′ → ConcealConversion _ _ Σ′ _ _ _ _ _)
+          (renameStoreᵗ-ext-suc-comm ρ _)
+          (rename-conceal-conversion
+            (TyRenameWf-ext hρ) (ModeRename-ext hμ) s↓)))
+
+mutual
+  weaken-reveal-conversion :
+    ∀ {μ Δ Σ Σ′ α C c A B} →
+    StoreIncl Σ Σ′ →
+    RevealConversion μ Δ Σ α C c A B →
+    RevealConversion μ Δ Σ′ α C c A B
+  weaken-reveal-conversion incl (reveal-id-var hY ok) =
+    reveal-id-var hY ok
+  weaken-reveal-conversion incl reveal-id-base = reveal-id-base
+  weaken-reveal-conversion incl reveal-id-★ = reveal-id-★
+  weaken-reveal-conversion incl (reveal-unseal hC α∈Σ ok) =
+    reveal-unseal hC (incl α∈Σ) ok
+  weaken-reveal-conversion incl (reveal-fun s↓ t↑) =
+    reveal-fun
+      (weaken-conceal-conversion incl s↓)
+      (weaken-reveal-conversion incl t↑)
+  weaken-reveal-conversion incl (reveal-all s↑) =
+    reveal-all
+      (weaken-reveal-conversion (renameStoreᵗ-incl suc incl) s↑)
+
+  weaken-conceal-conversion :
+    ∀ {μ Δ Σ Σ′ α C c A B} →
+    StoreIncl Σ Σ′ →
+    ConcealConversion μ Δ Σ α C c A B →
+    ConcealConversion μ Δ Σ′ α C c A B
+  weaken-conceal-conversion incl (conceal-id-var hY ok) =
+    conceal-id-var hY ok
+  weaken-conceal-conversion incl conceal-id-base = conceal-id-base
+  weaken-conceal-conversion incl conceal-id-★ = conceal-id-★
+  weaken-conceal-conversion incl (conceal-seal hC α∈Σ ok) =
+    conceal-seal hC (incl α∈Σ) ok
+  weaken-conceal-conversion incl (conceal-fun s↑ t↓) =
+    conceal-fun
+      (weaken-reveal-conversion incl s↑)
+      (weaken-conceal-conversion incl t↓)
+  weaken-conceal-conversion incl (conceal-all s↓) =
+    conceal-all
+      (weaken-conceal-conversion (renameStoreᵗ-incl suc incl) s↓)
+
+open-reveal-conversion :
+  ∀ {μ Δ Σ α C c A B} →
+  α < Δ →
+  RevealConversion (extᵈ μ) (suc Δ) (⟰ᵗ Σ)
+    (suc α) (⇑ᵗ C) c A B →
+  RevealConversion μ Δ Σ α C
+    (c [ α ]ᶜ) (A [ α ]ᴿ) (B [ α ]ᴿ)
+open-reveal-conversion {μ = μ} {Σ = Σ} {α = α} {C = C}
+    α<Δ c↑ =
+  subst
+    (λ D → RevealConversion μ _ Σ α D _ _ _)
+    (renameᵗ-single-suc-cancel α C)
+    (subst
+      (λ Σ′ → RevealConversion μ _ Σ′ α _ _ _ _)
+      (renameStoreᵗ-single-suc-cancel α Σ)
+      (rename-reveal-conversion
+        (singleRenameᵗ-Wf-< α<Δ)
+        (single-mode-rename-lower μ α)
+        c↑))
+
+open-conceal-conversion :
+  ∀ {μ Δ Σ α C c A B} →
+  α < Δ →
+  ConcealConversion (extᵈ μ) (suc Δ) (⟰ᵗ Σ)
+    (suc α) (⇑ᵗ C) c A B →
+  ConcealConversion μ Δ Σ α C
+    (c [ α ]ᶜ) (A [ α ]ᴿ) (B [ α ]ᴿ)
+open-conceal-conversion {μ = μ} {Σ = Σ} {α = α} {C = C}
+    α<Δ c↓ =
+  subst
+    (λ D → ConcealConversion μ _ Σ α D _ _ _)
+    (renameᵗ-single-suc-cancel α C)
+    (subst
+      (λ Σ′ → ConcealConversion μ _ Σ′ α _ _ _ _)
+      (renameStoreᵗ-single-suc-cancel α Σ)
+      (rename-conceal-conversion
+        (singleRenameᵗ-Wf-< α<Δ)
+        (single-mode-rename-lower μ α)
+        c↓))
 
 ------------------------------------------------------------------------
 -- Embedding into ordinary coercion typing

--- a/GTSF/DynamicGradualGuarantee.agda
+++ b/GTSF/DynamicGradualGuarantee.agda
@@ -6,8 +6,8 @@ module DynamicGradualGuarantee where
 --     and classifies the compiled runs as related final values, left blame, or
 --     mutual divergence.
 --   * This is a checked statement surface only; the proof is expected to factor
---     through compile monotonicity into `NuTermImprecision` and then a ν-term
---     simulation theorem.
+--     through compile monotonicity into `QuotientedTermImprecision` and then a
+--     ν-term simulation theorem.
 
 open import Agda.Builtin.Equality using (_≡_)
 open import Data.List using ([])
@@ -17,7 +17,7 @@ open import Relation.Nullary using (¬_)
 
 open import Types
 open import Ctx using (ctxWf-[])
-open import Compile using (compile)
+open import Compile using (compileᵀ)
 open import GradualTermImprecision
   using
     ( _∣_∣_∣_⊢ᴳ_⊑_⦂_⊑_∶_
@@ -39,26 +39,11 @@ open import NuTermImprecision
     ( StoreImp
     ; leftStoreⁱ
     ; rightStoreⁱ
-    ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
     )
+open import QuotientedTermImprecision
+  using (_∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_)
 open import NuTerms using (Term; Value; blame)
 
-------------------------------------------------------------------------
--- Local aliases for applying store changes
-------------------------------------------------------------------------
-
-infixl 8 _∙Δ_ _∙Σ_ _∙ᵀ_
-
-_∙Δ_ : StoreChanges → TyCtx → TyCtx
-χs ∙Δ Δ = applyTyCtxs χs Δ
-
-_∙Σ_ : StoreChanges → Store → Store
-χs ∙Σ Σ = applyStores χs Σ
-
-_∙ᵀ_ : StoreChanges → Ty → Ty
-χs ∙ᵀ A = applyTys χs A
-
-------------------------------------------------------------------------
 -- Convergence and divergence for compiled Nu terms
 ------------------------------------------------------------------------
 
@@ -91,7 +76,7 @@ compiled-left :
   Term
 compiled-left M⊑M′ =
   proj₁
-    (compile ctxWf-[]
+    (compileᵀ ctxWf-[]
       (gradual-term-imprecision-source-typing M⊑M′))
 
 compiled-right :
@@ -100,7 +85,7 @@ compiled-right :
   Term
 compiled-right M⊑M′ =
   proj₁
-    (compile ctxWf-[]
+    (compileᵀ ctxWf-[]
       (gradual-term-imprecision-target-typing M⊑M′))
 
 GradualDGG : Set₁
@@ -113,15 +98,19 @@ GradualDGG =
       compiled-left M⊑M′ —↠[ χs ] V →
       Value V →
       ∃[ V′ ] (Σ[ χs′ ∈ StoreChanges ]
-      (∃[ Φ ] (Σ[ ρ ∈ StoreImp Φ (χs ∙Δ 0) (χs′ ∙Δ 0) ]
+      (∃[ Φ ] (Σ[ ρ ∈
+          StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
       (Σ[ q ∈
-          (Φ ∣ χs ∙Δ 0 ⊢ χs ∙ᵀ A ⊑ χs′ ∙ᵀ B ⊣ χs′ ∙Δ 0) ]
+          (Φ ∣ applyTyCtxs χs 0
+            ⊢ applyTys χs A ⊑ applyTys χs′ B
+            ⊣ applyTyCtxs χs′ 0) ]
         ((compiled-right M⊑M′ —↠[ χs′ ] V′) ×
          Value V′ ×
-         (leftStoreⁱ ρ ≡ χs ∙Σ []) ×
-         (rightStoreⁱ ρ ≡ χs′ ∙Σ []) ×
-         Φ ∣ χs ∙Δ 0 ∣ χs′ ∙Δ 0 ∣ ρ ∣ []
-           ⊢ᴺ V ⊑ V′ ⦂ χs ∙ᵀ A ⊑ χs′ ∙ᵀ B ∶ q))))))
+         (leftStoreⁱ ρ ≡ applyStores χs []) ×
+         (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+         Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+           ⊢ᴺ V ⊑ V′
+           ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q))))))
     -- Part 2: if the more precise side diverges, the less precise side
     -- diverges.
     × (Divergesᶜ (compiled-left M⊑M′) →
@@ -132,15 +121,19 @@ GradualDGG =
       compiled-right M⊑M′ —↠[ χs′ ] V′ →
       Value V′ →
         (∃[ V ] (Σ[ χs ∈ StoreChanges ]
-        (∃[ Φ ] (Σ[ ρ ∈ StoreImp Φ (χs ∙Δ 0) (χs′ ∙Δ 0) ]
+        (∃[ Φ ] (Σ[ ρ ∈
+            StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
         (Σ[ q ∈
-            (Φ ∣ χs ∙Δ 0 ⊢ χs ∙ᵀ A ⊑ χs′ ∙ᵀ B ⊣ χs′ ∙Δ 0) ]
+            (Φ ∣ applyTyCtxs χs 0
+              ⊢ applyTys χs A ⊑ applyTys χs′ B
+              ⊣ applyTyCtxs χs′ 0) ]
           ((compiled-left M⊑M′ —↠[ χs ] V) ×
            Value V ×
-           (leftStoreⁱ ρ ≡ χs ∙Σ []) ×
-           (rightStoreⁱ ρ ≡ χs′ ∙Σ []) ×
-           Φ ∣ χs ∙Δ 0 ∣ χs′ ∙Δ 0 ∣ ρ ∣ []
-             ⊢ᴺ V ⊑ V′ ⦂ χs ∙ᵀ A ⊑ χs′ ∙ᵀ B ∶ q)))))
+           (leftStoreⁱ ρ ≡ applyStores χs []) ×
+           (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+           Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+             ⊢ᴺ V ⊑ V′
+             ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q)))))
         ⊎ (∃[ χs ] (compiled-left M⊑M′ —↠[ χs ] blame))))
     -- Part 4: if the less precise side diverges, the more precise side keeps
     -- stepping forever unless it has already reached blame.

--- a/GTSF/Imprecision.agda
+++ b/GTSF/Imprecision.agda
@@ -1,7 +1,10 @@
 module Imprecision where
 
 -- File Charter:
---   * Imprecision on types
+--   * Defines type imprecision assumptions and the raw type relation.
+--   * Provides matched, source-only, and target-only shifts of assumption
+--     contexts for polymorphic runtime allocation.
+--   * Defines the crossed context for two logically permuted allocations.
 
 open import Types
 
@@ -29,6 +32,10 @@ ImpCtx = List ImpAssm
 ⇑ᴸᵢₐ (X ˣ⊑★) = suc X ˣ⊑★
 ⇑ᴸᵢₐ (X ˣ⊑ˣ Y) = suc X ˣ⊑ˣ Y
 
+⇑ᴿᵢₐ : ImpAssm → ImpAssm
+⇑ᴿᵢₐ (X ˣ⊑★) = X ˣ⊑★
+⇑ᴿᵢₐ (X ˣ⊑ˣ Y) = X ˣ⊑ˣ suc Y
+
 ⇑ᵢ : ImpCtx → ImpCtx
 ⇑ᵢ [] = []
 ⇑ᵢ (m ∷ Φ) = ⇑ᵢₐ m ∷ ⇑ᵢ Φ
@@ -36,6 +43,16 @@ ImpCtx = List ImpAssm
 ⇑ᴸᵢ : ImpCtx → ImpCtx
 ⇑ᴸᵢ [] = []
 ⇑ᴸᵢ (m ∷ Φ) = ⇑ᴸᵢₐ m ∷ ⇑ᴸᵢ Φ
+
+⇑ᴿᵢ : ImpCtx → ImpCtx
+⇑ᴿᵢ [] = []
+⇑ᴿᵢ (m ∷ Φ) = ⇑ᴿᵢₐ m ∷ ⇑ᴿᵢ Φ
+
+swapRight∀∀ᵢ : ImpCtx → ImpCtx
+swapRight∀∀ᵢ Φ =
+  (zero ˣ⊑ˣ suc zero) ∷
+  (suc zero ˣ⊑ˣ zero) ∷
+  ⇑ᵢ (⇑ᵢ Φ)
 
 ------------------------------------------------------------------------
 -- Type Imprecision
@@ -51,7 +68,7 @@ data _⊢_⊑_ (Φ : ImpCtx) : Ty → Ty → Set where
     → (X ˣ⊑ˣ Y) ∈ Φ
     ---------------------
     → Φ ⊢ ＇ X ⊑ ＇ Y
-    
+
   idι : ∀ {ι}
     -------------------
     → Φ ⊢ ‵ ι ⊑ ‵ ι

--- a/GTSF/ImprecisionWf.agda
+++ b/GTSF/ImprecisionWf.agda
@@ -7,6 +7,7 @@ module ImprecisionWf where
 --     derivation determines well-formed endpoints.
 --   * Exposes endpoint well-formedness theorems for the indexed judgment
 --     `Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ`.
+--   * Re-exports the crossed two-allocation context from `Imprecision`.
 
 open import Agda.Builtin.Equality using (_≡_)
 open import Data.Bool using (true)
@@ -23,8 +24,11 @@ open import Imprecision public using
   ; ImpCtx
   ; ⇑ᵢₐ
   ; ⇑ᴸᵢₐ
+  ; ⇑ᴿᵢₐ
   ; ⇑ᵢ
   ; ⇑ᴸᵢ
+  ; ⇑ᴿᵢ
+  ; swapRight∀∀ᵢ
   )
 
 ------------------------------------------------------------------------

--- a/GTSF/NuExamplesFresh.agda
+++ b/GTSF/NuExamplesFresh.agda
@@ -1,21 +1,24 @@
 module NuExamplesFresh where
 
 -- File Charter:
---   * Closed NuTerms examples that exercise the Maybe-based type checker.
---   * Adapted from the PolyUpDown extrinsic-inst fresh examples, but limited
---     to typing regressions because the NuTerms evaluator is not in place.
+--   * Closed NuTerms examples that exercise the Maybe-based type checker and
+--     the traced evaluator.
+--   * Adapted from the PolyUpDown extrinsic-inst fresh examples.
 --   * Covers base/dynamic casts, unannotated lambdas under expected types,
---     polymorphic `ν` instantiation, and representative rejection cases.
+--     polymorphic `ν` instantiation, successful seal behavior, tag blame, and
+--     representative rejection cases.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
-open import Data.List using ([])
-open import Data.Maybe using (nothing)
+open import Data.List using ([]; _∷_)
+open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat using (ℕ)
 
+import Eval as Eval
 open import Types
 open import Coercions
 open import Primitives
 open import NuTerms
+open import ReductionTrace
 open import TypeCheck using (IsJust; fromJust; is-just; type-check-expect)
 
 ------------------------------------------------------------------------
@@ -34,6 +37,10 @@ expect-⊢ :
   IsJust (type-check-expect 0 [] [] M A) →
   0 ∣ [] ∣ [] ⊢ M ⦂ A
 expect-⊢ M A ok = fromJust (type-check-expect 0 [] [] M A) ok
+
+eval-term : ∀ {M} → Maybe (Eval.EvalOutcome M) → Maybe Term
+eval-term nothing = nothing
+eval-term (just r) = just (Eval.finalTerm r)
 
 nat : ℕ → Term
 nat n = $ (κℕ n)
@@ -241,6 +248,61 @@ sec6-K-base = (polyKNat · n42) · n69
 
 sec6-K-base-⊢ : 0 ∣ [] ∣ [] ⊢ sec6-K-base ⦂ Nat
 sec6-K-base-⊢ = expect-⊢ sec6-K-base Nat is-just
+
+------------------------------------------------------------------------
+-- Paired `ν`, seal, and tag traces
+------------------------------------------------------------------------
+
+polyIdNat-app-result :
+  eval-term (Eval.eval 20 polyIdNat-app) ≡ just c
+polyIdNat-app-result = refl
+
+polyIdNat-app-trace :
+  outcome-step-names (Eval.eval 20 polyIdNat-app) ≡
+  just
+    ( under-app-left allocate-ν
+    ∷ under-app-left (under-cast (root β-Λ•-step))
+    ∷ root β-↦-step
+    ∷ under-cast (root β-ƛ-step)
+    ∷ root seal-unseal-step
+    ∷ [] )
+polyIdNat-app-trace = refl
+
+polyIdDyn-app-result :
+  eval-term (Eval.eval 20 polyIdDyn-app) ≡ just (c ⟨ Nat ! ⟩)
+polyIdDyn-app-result = refl
+
+polyIdDyn-app-trace :
+  outcome-step-names (Eval.eval 20 polyIdDyn-app) ≡
+  just
+    ( under-app-left allocate-ν
+    ∷ under-app-left (under-cast (root β-Λ•-step))
+    ∷ under-app-right (root β-seq-step)
+    ∷ under-app-right (under-cast (root β-id-step))
+    ∷ root β-↦-step
+    ∷ under-cast (root β-ƛ-step)
+    ∷ root seal-unseal-step
+    ∷ [] )
+polyIdDyn-app-trace = refl
+
+tag-mismatch : Term
+tag-mismatch = c★ ⟨ untagBool ⟩
+
+tag-mismatch-⊢ : 0 ∣ [] ∣ [] ⊢ tag-mismatch ⦂ BoolTy
+tag-mismatch-⊢ = expect-⊢ tag-mismatch BoolTy is-just
+
+tag-mismatch-result :
+  eval-term (Eval.eval 20 tag-mismatch) ≡ just blame
+tag-mismatch-result = refl
+
+tag-mismatch-trace :
+  outcome-step-names (Eval.eval 20 tag-mismatch) ≡
+  just
+    ( under-cast (root β-seq-step)
+    ∷ under-cast (under-cast (root β-id-step))
+    ∷ root tag-untag-bad-step
+    ∷ [] )
+tag-mismatch-trace = refl
 
 ------------------------------------------------------------------------
 -- Rejection checks

--- a/GTSF/NuMetaTheory.agda
+++ b/GTSF/NuMetaTheory.agda
@@ -52,6 +52,17 @@ multi-preservation :
   applyTyCtxs χs Δ ∣ applyStores χs Σ ∣ [] ⊢ N ⦂ applyTys χs A
 multi-preservation = PreservationProof.multi-preservation
 
+multi-runtime-preservation :
+  ∀ {Δ : TyCtx}{Σ : Store}{M N : Term}{A : Ty}
+    {χs : StoreChanges} →
+  StoreWf Δ Σ →
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —↠[ χs ] N →
+  RuntimeOK N
+multi-runtime-preservation =
+  PreservationProof.multi-runtime-preservation
+
 narrowing-determinedᵐ :
   ∀ {μ Δ Σ A B s t} →
   NarrowWidenProof.StoreDetWf Δ Σ →

--- a/GTSF/NuTermImprecision.agda
+++ b/GTSF/NuTermImprecision.agda
@@ -6,12 +6,16 @@ module NuTermImprecision where
 --   * Relates independent left/right runtime stores with explicit matched,
 --     left-only, and right-only allocation entries, so ν-step simulation cases
 --     have a visible place to extend the store relation.
+--   * Separates physical store entries from correspondence-only links, which
+--     permits swapped polymorphic allocations with independent store order.
 --   * Carries enough side conditions for the relation to project to ordinary
 --     `NuTerms` typing derivations for both related terms.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (true)
 open import Data.List using (List; []; _∷_; map)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.Nat using (zero; suc)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; Σ-syntax; ∃-syntax)
 open import Relation.Binary.PropositionalEquality using (cong; subst; sym)
@@ -126,6 +130,11 @@ data StoreImpEntry (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) : Set where
     WfTy Δᴿ B →
     StoreImpEntry Φ Δᴸ Δᴿ
 
+  store-link :
+    (α : TyVar) → (A : Ty) → (β : TyVar) → (B : Ty) →
+    Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+    StoreImpEntry Φ Δᴸ Δᴿ
+
 StoreImp : ImpCtx → TyCtx → TyCtx → Set
 StoreImp Φ Δᴸ Δᴿ = List (StoreImpEntry Φ Δᴸ Δᴿ)
 
@@ -133,11 +142,13 @@ leftStoreEntryⁱ : StoreImpEntry Φ Δᴸ Δᴿ → Store → Store
 leftStoreEntryⁱ (store-matched α A β B p) Σ = (α , A) ∷ Σ
 leftStoreEntryⁱ (store-left α A hA) Σ = (α , A) ∷ Σ
 leftStoreEntryⁱ (store-right β B hB) Σ = Σ
+leftStoreEntryⁱ (store-link α A β B p) Σ = Σ
 
 rightStoreEntryⁱ : StoreImpEntry Φ Δᴸ Δᴿ → Store → Store
 rightStoreEntryⁱ (store-matched α A β B p) Σ = (β , B) ∷ Σ
 rightStoreEntryⁱ (store-left α A hA) Σ = Σ
 rightStoreEntryⁱ (store-right β B hB) Σ = (β , B) ∷ Σ
+rightStoreEntryⁱ (store-link α A β B p) Σ = Σ
 
 leftStoreⁱ : StoreImp Φ Δᴸ Δᴿ → Store
 leftStoreⁱ [] = []
@@ -146,6 +157,88 @@ leftStoreⁱ (entry ∷ ρ) = leftStoreEntryⁱ entry (leftStoreⁱ ρ)
 rightStoreⁱ : StoreImp Φ Δᴸ Δᴿ → Store
 rightStoreⁱ [] = []
 rightStoreⁱ (entry ∷ ρ) = rightStoreEntryⁱ entry (rightStoreⁱ ρ)
+
+data StoreCorresponds
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (α : TyVar) (A : Ty) (β : TyVar) (B : Ty)
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) : Set where
+  correspondence-stored :
+    store-matched α A β B p ∈ ρ →
+    StoreCorresponds ρ α A β B p
+
+  correspondence-linked :
+    store-link α A β B p ∈ ρ →
+    StoreCorresponds ρ α A β B p
+
+crossedStoreⁱ :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ B₀ B₁} →
+  WfTy Δᴸ A₀ →
+  WfTy Δᴸ A₁ →
+  WfTy Δᴿ B₀ →
+  WfTy Δᴿ B₁ →
+  (p₀₁ : Φ ∣ Δᴸ ⊢ A₀ ⊑ B₁ ⊣ Δᴿ) →
+  (p₁₀ : Φ ∣ Δᴸ ⊢ A₁ ⊑ B₀ ⊣ Δᴿ) →
+  StoreImp Φ Δᴸ Δᴿ →
+  StoreImp Φ Δᴸ Δᴿ
+crossedStoreⁱ hA₀ hA₁ hB₀ hB₁ p₀₁ p₁₀ ρ =
+  store-left zero _ hA₀ ∷
+  store-left (suc zero) _ hA₁ ∷
+  store-right zero _ hB₀ ∷
+  store-right (suc zero) _ hB₁ ∷
+  store-link zero _ (suc zero) _ p₀₁ ∷
+  store-link (suc zero) _ zero _ p₁₀ ∷
+  ρ
+
+leftStoreⁱ-crossed :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ B₀ B₁}
+    {hA₀ : WfTy Δᴸ A₀} {hA₁ : WfTy Δᴸ A₁}
+    {hB₀ : WfTy Δᴿ B₀} {hB₁ : WfTy Δᴿ B₁}
+    {p₀₁ : Φ ∣ Δᴸ ⊢ A₀ ⊑ B₁ ⊣ Δᴿ}
+    {p₁₀ : Φ ∣ Δᴸ ⊢ A₁ ⊑ B₀ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  leftStoreⁱ (crossedStoreⁱ hA₀ hA₁ hB₀ hB₁ p₀₁ p₁₀ ρ)
+    ≡ (zero , A₀) ∷ (suc zero , A₁) ∷ leftStoreⁱ ρ
+leftStoreⁱ-crossed = refl
+
+rightStoreⁱ-crossed :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ B₀ B₁}
+    {hA₀ : WfTy Δᴸ A₀} {hA₁ : WfTy Δᴸ A₁}
+    {hB₀ : WfTy Δᴿ B₀} {hB₁ : WfTy Δᴿ B₁}
+    {p₀₁ : Φ ∣ Δᴸ ⊢ A₀ ⊑ B₁ ⊣ Δᴿ}
+    {p₁₀ : Φ ∣ Δᴸ ⊢ A₁ ⊑ B₀ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  rightStoreⁱ (crossedStoreⁱ hA₀ hA₁ hB₀ hB₁ p₀₁ p₁₀ ρ)
+    ≡ (zero , B₀) ∷ (suc zero , B₁) ∷ rightStoreⁱ ρ
+rightStoreⁱ-crossed = refl
+
+crossedStoreⁱ-new-old :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ B₀ B₁}
+    {hA₀ : WfTy Δᴸ A₀} {hA₁ : WfTy Δᴸ A₁}
+    {hB₀ : WfTy Δᴿ B₀} {hB₁ : WfTy Δᴿ B₁}
+    {p₀₁ : Φ ∣ Δᴸ ⊢ A₀ ⊑ B₁ ⊣ Δᴿ}
+    {p₁₀ : Φ ∣ Δᴸ ⊢ A₁ ⊑ B₀ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreCorresponds
+    (crossedStoreⁱ hA₀ hA₁ hB₀ hB₁ p₀₁ p₁₀ ρ)
+    zero A₀ (suc zero) B₁ p₀₁
+crossedStoreⁱ-new-old =
+  correspondence-linked
+    (there (there (there (there (here refl)))))
+
+crossedStoreⁱ-old-new :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ B₀ B₁}
+    {hA₀ : WfTy Δᴸ A₀} {hA₁ : WfTy Δᴸ A₁}
+    {hB₀ : WfTy Δᴿ B₀} {hB₁ : WfTy Δᴿ B₁}
+    {p₀₁ : Φ ∣ Δᴸ ⊢ A₀ ⊑ B₁ ⊣ Δᴿ}
+    {p₁₀ : Φ ∣ Δᴸ ⊢ A₁ ⊑ B₀ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreCorresponds
+    (crossedStoreⁱ hA₀ hA₁ hB₀ hB₁ p₀₁ p₁₀ ρ)
+    (suc zero) A₁ zero B₀ p₁₀
+crossedStoreⁱ-old-new =
+  correspondence-linked
+    (there (there (there (there (there (here refl))))))
 
 data LiftStoreⁱ {Φ Δᴸ Δᴿ} (Ψ : ImpCtx) :
     StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ (suc Δᴸ) (suc Δᴿ) → Set where
@@ -173,6 +266,13 @@ data LiftStoreⁱ {Φ Δᴸ Δᴿ} (Ψ : ImpCtx) :
         (store-right β B hB ∷ ρ)
         (store-right (suc β) (⇑ᵗ B) hB′ ∷ ρ′)
 
+  lift-store-link : ∀ {ρ ρ′ α β A B p p′}
+    → LiftStoreⁱ Ψ ρ ρ′
+      --------------------------------------------------------------
+    → LiftStoreⁱ Ψ
+        (store-link α A β B p ∷ ρ)
+        (store-link (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B) p′ ∷ ρ′)
+
 leftStoreⁱ-lift :
   ∀ {Φ Δᴸ Δᴿ Ψ} {ρ : StoreImp Φ Δᴸ Δᴿ}
     {ρ′ : StoreImp Ψ (suc Δᴸ) (suc Δᴿ)} →
@@ -184,6 +284,8 @@ leftStoreⁱ-lift (lift-store-∷ liftρ) =
 leftStoreⁱ-lift (lift-store-left liftρ) =
   cong ((_,_ _ _) ∷_) (leftStoreⁱ-lift liftρ)
 leftStoreⁱ-lift (lift-store-right liftρ) =
+  leftStoreⁱ-lift liftρ
+leftStoreⁱ-lift (lift-store-link liftρ) =
   leftStoreⁱ-lift liftρ
 
 rightStoreⁱ-lift :
@@ -198,6 +300,8 @@ rightStoreⁱ-lift (lift-store-left liftρ) =
   rightStoreⁱ-lift liftρ
 rightStoreⁱ-lift (lift-store-right liftρ) =
   cong ((_,_ _ _) ∷_) (rightStoreⁱ-lift liftρ)
+rightStoreⁱ-lift (lift-store-link liftρ) =
+  rightStoreⁱ-lift liftρ
 
 data LiftLeftStoreⁱ {Φ Δᴸ Δᴿ} (Ψ : ImpCtx) :
     StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ (suc Δᴸ) Δᴿ → Set where
@@ -225,6 +329,13 @@ data LiftLeftStoreⁱ {Φ Δᴸ Δᴿ} (Ψ : ImpCtx) :
         (store-right β B hB ∷ ρ)
         (store-right β B hB′ ∷ ρ′)
 
+  lift-left-store-link : ∀ {ρ ρ′ α β A B p p′}
+    → LiftLeftStoreⁱ Ψ ρ ρ′
+      --------------------------------------------------------------
+    → LiftLeftStoreⁱ Ψ
+        (store-link α A β B p ∷ ρ)
+        (store-link (suc α) (⇑ᵗ A) β B p′ ∷ ρ′)
+
 leftStoreⁱ-lift-left :
   ∀ {Φ Δᴸ Δᴿ Ψ} {ρ : StoreImp Φ Δᴸ Δᴿ}
     {ρ′ : StoreImp Ψ (suc Δᴸ) Δᴿ} →
@@ -236,6 +347,8 @@ leftStoreⁱ-lift-left (lift-left-store-∷ liftρ) =
 leftStoreⁱ-lift-left (lift-left-store-left liftρ) =
   cong ((_,_ _ _) ∷_) (leftStoreⁱ-lift-left liftρ)
 leftStoreⁱ-lift-left (lift-left-store-right liftρ) =
+  leftStoreⁱ-lift-left liftρ
+leftStoreⁱ-lift-left (lift-left-store-link liftρ) =
   leftStoreⁱ-lift-left liftρ
 
 rightStoreⁱ-lift-left :
@@ -250,6 +363,8 @@ rightStoreⁱ-lift-left (lift-left-store-left liftρ) =
   rightStoreⁱ-lift-left liftρ
 rightStoreⁱ-lift-left (lift-left-store-right liftρ) =
   cong ((_,_ _ _) ∷_) (rightStoreⁱ-lift-left liftρ)
+rightStoreⁱ-lift-left (lift-left-store-link liftρ) =
+  rightStoreⁱ-lift-left liftρ
 
 data LiftRightStoreⁱ {Φ Δᴸ Δᴿ} (Ψ : ImpCtx) :
     StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ Δᴸ (suc Δᴿ) → Set where
@@ -277,6 +392,13 @@ data LiftRightStoreⁱ {Φ Δᴸ Δᴿ} (Ψ : ImpCtx) :
         (store-right β B hB ∷ ρ)
         (store-right (suc β) (⇑ᵗ B) hB′ ∷ ρ′)
 
+  lift-right-store-link : ∀ {ρ ρ′ α β A B p p′}
+    → LiftRightStoreⁱ Ψ ρ ρ′
+      --------------------------------------------------------------
+    → LiftRightStoreⁱ Ψ
+        (store-link α A β B p ∷ ρ)
+        (store-link α A (suc β) (⇑ᵗ B) p′ ∷ ρ′)
+
 leftStoreⁱ-lift-right :
   ∀ {Φ Δᴸ Δᴿ Ψ} {ρ : StoreImp Φ Δᴸ Δᴿ}
     {ρ′ : StoreImp Ψ Δᴸ (suc Δᴿ)} →
@@ -288,6 +410,8 @@ leftStoreⁱ-lift-right (lift-right-store-∷ liftρ) =
 leftStoreⁱ-lift-right (lift-right-store-left liftρ) =
   cong ((_,_ _ _) ∷_) (leftStoreⁱ-lift-right liftρ)
 leftStoreⁱ-lift-right (lift-right-store-right liftρ) =
+  leftStoreⁱ-lift-right liftρ
+leftStoreⁱ-lift-right (lift-right-store-link liftρ) =
   leftStoreⁱ-lift-right liftρ
 
 rightStoreⁱ-lift-right :
@@ -302,6 +426,8 @@ rightStoreⁱ-lift-right (lift-right-store-left liftρ) =
   rightStoreⁱ-lift-right liftρ
 rightStoreⁱ-lift-right (lift-right-store-right liftρ) =
   cong ((_,_ _ _) ∷_) (rightStoreⁱ-lift-right liftρ)
+rightStoreⁱ-lift-right (lift-right-store-link liftρ) =
+  rightStoreⁱ-lift-right liftρ
 
 ------------------------------------------------------------------------
 -- Term-context imprecision

--- a/GTSF/QuotientedTermImprecision.agda
+++ b/GTSF/QuotientedTermImprecision.agda
@@ -9,23 +9,54 @@ module QuotientedTermImprecision where
 --     `NuTermImprecision`.
 --   * Uses quotiented imprecision only after paired narrowing casts, underneath
 --     paired widening casts.
+--   * Keeps paired `gen` bodies in that quotient after `β-gen•` exposes
+--     their tag-enabled narrowing modes.
+--   * Paired reveal/conceal evidence uses store correspondence links, so
+--     physical store order need not coincide across permuted allocations.
+--   * Factors runtime-bullet instantiation from single-name reveal/conceal
+--     conversions and paired conversion imprecision.
+--   * Includes repaired ordinary and `ν ★` allocation states for matched,
+--     left-only, and right-only executions.
+--   * Records the intermediate index for right-only allocation and permits
+--     body relations to cross the exact fresh-store extension it creates.
+--   * Includes an exact two-allocation boundary for adjacent-`∀`
+--     permutations, with independently ordered stores and crossed links.
+--   * Transports both orientations of that body boundary by renaming one
+--     endpoint and shifting the other.
+--   * Relates widening bodies exposed by crossed `inst∀` and `∀inst`
+--     coercions in both exact, differently ordered seal-mode orientations.
 
-open import Agda.Builtin.Equality using (_≡_)
+open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (true)
 open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (zero; suc)
-open import Data.Product using (_,_)
+open import Data.Product using (_×_; _,_)
+open import Relation.Binary.PropositionalEquality using (subst)
 
 open import Types
 open import Coercions
-open import Conversion using (_∣_∣_⊢_∶_↑ˢ_; _∣_∣_⊢_∶_↓ˢ_)
+open import Conversion using
+  ( ConcealConversion
+  ; RevealConversion
+  ; conceal-conversion-typing
+  ; reveal-conversion-typing
+  ; _∣_∣_⊢_∶_↑ˢ_
+  ; _∣_∣_⊢_∶_↓ˢ_
+  )
 open import ImprecisionWf
 open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
-open import NarrowWiden using (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
+open import NarrowWiden using
+  ( _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  ; narrow-mode-relax
+  ; widen-mode-relax
+  )
 open import NuTerms using
   ( Term
   ; Value
   ; No•
+  ; renameᵗᵐ
   ; ⇑ᵗᵐ
   ; `_
   ; ƛ_
@@ -40,21 +71,37 @@ open import NuTerms using
   )
 open import Primitives
 open import proof.CastImprecision using
-  ( LeftCastCtxCompatible
-  ; RightCastCtxCompatible
-  ; narrowing⇒⊑ᵢ
+  ( RightCastCtxCompatible
+  ; ∀ᵢᶜ
   ; widening⇒⊑ᵢ
-  ; ⊑-transˡ-castᵢ
   ; ⊑-transʳ-castᵢ
   )
 open import proof.NarrowWidenProperties using (StoreDetWf)
 open import TermTyping using
   ( CastMode
   ; SealModeStore★
+  ; cast-ext
+  ; cast-gen
+  ; cast-inst
+  ; cast-tag-or-id
   ; _∣_∣_⊢_⦂_
+  ; ⊢`
+  ; ⊢ƛ
+  ; ⊢·
+  ; ⊢Λ
+  ; ⊢ν↑
+  ; ⊢ν⊑
+  ; ⊢$
+  ; ⊢⊕
+  ; ⊢⟨⟩↑
+  ; ⊢⟨⟩↓
+  ; ⊢⟨⟩⊒
+  ; ⊢⟨⟩⊑
+  ; ⊢blame
   )
 open import NuTermImprecision using
   ( StoreImp
+  ; StoreCorresponds
   ; CtxImp
   ; ctx-imp
   ; leftStoreⁱ
@@ -68,8 +115,25 @@ open import NuTermImprecision using
   ; LiftRightStoreⁱ
   ; LiftRightCtxⁱ
   ; store-matched
-  ; left-id-only-compatible
+  ; store-left
+  ; store-right
+  ; store-link
   ; right-id-only-compatible
+  ; seal★-tag-or-id
+  ; leftStoreⁱ-lift
+  ; rightStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightStoreⁱ-lift-left
+  ; leftCtxⁱ-lift
+  ; rightCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; rightCtxⁱ-lift-left
+  ; leftStoreⁱ-lift-right
+  ; rightStoreⁱ-lift-right
+  ; leftCtxⁱ-lift-right
+  ; rightCtxⁱ-lift-right
+  ; leftCtxⁱ-∋
+  ; rightCtxⁱ-∋
   )
 
 variable
@@ -77,6 +141,50 @@ variable
   Δᴸ Δᴿ : TyCtx
   ρ : StoreImp Φ Δᴸ Δᴿ
   γ : CtxImp Φ Δᴸ Δᴿ
+
+------------------------------------------------------------------------
+-- Paired single-name conversions
+------------------------------------------------------------------------
+
+data PairedConversion
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) (ρ : StoreImp Φ Δᴸ Δᴿ) :
+    (c c′ : Coercion) → {A A′ B B′ : Ty} →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+    (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) → Set₁ where
+  paired-reveal :
+    ∀ {α β X X′ pX μ μ′ c c′ A A′ B B′ p q} →
+    StoreCorresponds ρ α X β X′ pX →
+    RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+    RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+    PairedConversion Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q
+
+  paired-conceal :
+    ∀ {α β X X′ pX μ μ′ c c′ A A′ B B′ p q} →
+    StoreCorresponds ρ α X β X′ pX →
+    ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+    ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+    PairedConversion Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q
+
+data PairedCast
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) (ρ : StoreImp Φ Δᴸ Δᴿ) :
+    (c c′ : Coercion) → {A A′ B B′ : Ty} →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+    (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) → Set₁ where
+  paired-conversion :
+    ∀ {c c′ A A′ B B′ p q} →
+    PairedConversion Φ Δᴸ Δᴿ ρ
+      c c′ {A} {A′} {B} {B′} p q →
+    PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q
+
+  paired-widening :
+    ∀ {μ μ′ c c′ A A′ B B′ p q} →
+    CastMode μ →
+    SealModeStore★ μ (leftStoreⁱ ρ) →
+    μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+    CastMode μ′ →
+    SealModeStore★ μ′ (rightStoreⁱ ρ) →
+    μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+    PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q
 
 ------------------------------------------------------------------------
 -- Nu-term imprecision with quotiented hidden cast intermediates
@@ -134,6 +242,38 @@ mutual
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ pA
 
+    crossed-up⊑upᵀ :
+        ∀ {N N′ A A′ D D′ qD u u′ μ}
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ qD
+      → CastMode μ
+      → SealModeStore★ μ (leftStoreⁱ ρ)
+      → μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A
+      → SealModeStore★
+          (instᵈ (extᵈ tag-or-idᵈ)) (rightStoreⁱ ρ)
+      → instᵈ (extᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
+          ⊢ u′ ∶ D′ ⊑ A′
+      → (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+        ------------------------------------------------------------
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ pA
+
+    crossed-left-up⊑upᵀ :
+        ∀ {N N′ A A′ D D′ qD u u′ μ}
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ qD
+      → CastMode μ
+      → SealModeStore★ μ (leftStoreⁱ ρ)
+      → μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A
+      → SealModeStore★
+          (extᵈ (instᵈ tag-or-idᵈ)) (rightStoreⁱ ρ)
+      → extᵈ (instᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
+          ⊢ u′ ∶ D′ ⊑ A′
+      → (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+        ------------------------------------------------------------
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ pA
+
     Λ⊑Λᵀ : ∀ {ρ′ γ′ V V′ A B p}
       → LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′
       → LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′
@@ -168,6 +308,7 @@ mutual
           ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
             ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ B ⊣ suc Δᴿ)
       → LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′
+      → LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ L ⊑ L′ ⦂ `∀ C ⊑ `∀ D ∶ ∀ⁱ p
       → suc Δᴸ
@@ -186,15 +327,188 @@ mutual
           ∣ γ′
           ⊢ᴺ (⇑ᵗᵐ L) • ⊑ (⇑ᵗᵐ L′) • ⦂ C ⊑ D ∶ p
 
+    α⊑ᵀ :
+        ∀ {ρ′ γ′ L N′ A B′ C p occ}
+      → Value L
+      → No• L
+      → (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A))
+      → LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
+      → LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ L ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ p
+      → suc Δᴸ
+          ∣ leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ∣ leftCtxⁱ γ′ ⊢ (⇑ᵗᵐ L) • ⦂ C
+      → Δᴿ
+          ∣ rightStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ∣ rightCtxⁱ γ′ ⊢ N′ ⦂ B′
+        ------------------------------------------------------------
+      → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+          store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ γ′
+          ⊢ᴺ (⇑ᵗᵐ L) • ⊑ N′ ⦂ C ⊑ B′ ∶ p
+
+    ⊑αᵀ :
+        ∀ {ρ′ γ′ N L′ A B C′ q}
+      → Value L′
+      → No• L′
+      → (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A))
+      → LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′
+      → LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γ′
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ N ⊑ L′ ⦂ B ⊑ `∀ C′ ∶ q
+      → (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ)
+      → Δᴸ
+          ∣ leftStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ∣ leftCtxⁱ γ′ ⊢ N ⦂ B
+      → suc Δᴿ
+          ∣ rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ∣ rightCtxⁱ γ′ ⊢ (⇑ᵗᵐ L′) • ⦂ C′
+        ------------------------------------------------------------
+      → ⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+          store-right zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ γ′
+          ⊢ᴺ N ⊑ (⇑ᵗᵐ L′) • ⦂ B ⊑ C′ ∶ r
+
+    allocation-matchedᵀ :
+        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A A′ B B′ M M′ p}
+          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
+          {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+            (suc Δᴸ₀) (suc Δᴿ₀)}
+          {γ′ : CtxImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+            (suc Δᴸ₀) (suc Δᴿ₀)} →
+      (pX : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+        ∣ suc Δᴸ₀ ⊢ A ⊑ A′ ⊣ suc Δᴿ₀) →
+      LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀) ρ₀ ρ′ →
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+        ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣ ρ′ ∣ γ′
+        ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p →
+      suc Δᴸ₀
+        ∣ leftStoreⁱ (store-matched zero A zero A′ pX ∷ ρ′)
+        ∣ leftCtxⁱ γ′ ⊢ M ⦂ B →
+      suc Δᴿ₀
+        ∣ rightStoreⁱ (store-matched zero A zero A′ pX ∷ ρ′)
+        ∣ rightCtxⁱ γ′ ⊢ M′ ⦂ B′
+        ------------------------------------------------------------
+      → ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣
+          store-matched zero A zero A′ pX ∷ ρ′ ∣ γ′
+          ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
+
+    allocation-crossedᵀ :
+        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A₀ A₁ B₀ B₁ C C′ M M′ p}
+          {p₀₁ p₁₀}
+          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
+          {ρ₁ : StoreImp (∀ᵢᶜ Φ₀) (suc Δᴸ₀) (suc Δᴿ₀)}
+          {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ₀)
+            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))}
+          {γ₂ : CtxImp (swapRight∀∀ᵢ Φ₀)
+            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))} →
+      (hA₀ : WfTy (suc (suc Δᴸ₀)) A₀) →
+      (hA₁ : WfTy (suc (suc Δᴸ₀)) A₁) →
+      (hB₀ : WfTy (suc (suc Δᴿ₀)) B₀) →
+      (hB₁ : WfTy (suc (suc Δᴿ₀)) B₁) →
+      LiftStoreⁱ (∀ᵢᶜ Φ₀) ρ₀ ρ₁ →
+      LiftStoreⁱ (swapRight∀∀ᵢ Φ₀) ρ₁ ρ₂ →
+      swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
+        ⊢ A₀ ⊑ B₁ ⊣ suc (suc Δᴿ₀) →
+      swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
+        ⊢ A₁ ⊑ B₀ ⊣ suc (suc Δᴿ₀) →
+      swapRight∀∀ᵢ Φ₀
+        ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣ ρ₂ ∣ γ₂
+        ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ p →
+      suc (suc Δᴸ₀) ∣
+        (zero , A₀) ∷ (suc zero , A₁) ∷ leftStoreⁱ ρ₂
+        ∣ leftCtxⁱ γ₂ ⊢ M ⦂ C →
+      suc (suc Δᴿ₀) ∣
+        (zero , B₀) ∷ (suc zero , B₁) ∷ rightStoreⁱ ρ₂
+        ∣ rightCtxⁱ γ₂ ⊢ M′ ⦂ C′
+        ------------------------------------------------------------
+      → swapRight∀∀ᵢ Φ₀
+          ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣
+          store-left zero A₀ hA₀ ∷
+          store-left (suc zero) A₁ hA₁ ∷
+          store-right zero B₀ hB₀ ∷
+          store-right (suc zero) B₁ hB₁ ∷
+          store-link zero A₀ (suc zero) B₁ p₀₁ ∷
+          store-link (suc zero) A₁ zero B₀ p₁₀ ∷ ρ₂
+          ∣ γ₂ ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ p
+
+    swapRight-bodyᵀ :
+        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A B C C′ W W′ M M′ p}
+          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
+          {ρ₁ : StoreImp (∀ᵢᶜ Φ₀) (suc Δᴸ₀) (suc Δᴿ₀)}
+          {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ₀)
+            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))} →
+      LiftStoreⁱ (∀ᵢᶜ Φ₀) ρ₀ ρ₁ →
+      LiftStoreⁱ (swapRight∀∀ᵢ Φ₀) ρ₁ ρ₂ →
+      ∀ᵢᶜ Φ₀ ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣ ρ₁ ∣ []
+        ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ p →
+      M ≡ ⇑ᵗᵐ W →
+      M′ ≡ renameᵗᵐ (extᵗ suc) W′ →
+      C ≡ ⇑ᵗ A →
+      C′ ≡ renameᵗ (extᵗ suc) B →
+      (q : swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
+        ⊢ C ⊑ C′ ⊣ suc (suc Δᴿ₀)) →
+      suc (suc Δᴸ₀) ∣ leftStoreⁱ ρ₂ ∣ [] ⊢ M ⦂ C →
+      suc (suc Δᴿ₀) ∣ rightStoreⁱ ρ₂ ∣ [] ⊢ M′ ⦂ C′
+        ------------------------------------------------------------
+      → swapRight∀∀ᵢ Φ₀
+          ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣ ρ₂ ∣ []
+          ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ q
+
+    swapLeft-bodyᵀ :
+        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A B C C′ W W′ M M′ p}
+          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
+          {ρ₁ : StoreImp (∀ᵢᶜ Φ₀) (suc Δᴸ₀) (suc Δᴿ₀)}
+          {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ₀)
+            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))} →
+      LiftStoreⁱ (∀ᵢᶜ Φ₀) ρ₀ ρ₁ →
+      LiftStoreⁱ (swapRight∀∀ᵢ Φ₀) ρ₁ ρ₂ →
+      ∀ᵢᶜ Φ₀ ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣ ρ₁ ∣ []
+        ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ p →
+      M ≡ renameᵗᵐ (extᵗ suc) W →
+      M′ ≡ ⇑ᵗᵐ W′ →
+      C ≡ renameᵗ (extᵗ suc) A →
+      C′ ≡ ⇑ᵗ B →
+      (q : swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
+        ⊢ C ⊑ C′ ⊣ suc (suc Δᴿ₀)) →
+      suc (suc Δᴸ₀) ∣ leftStoreⁱ ρ₂ ∣ [] ⊢ M ⦂ C →
+      suc (suc Δᴿ₀) ∣ rightStoreⁱ ρ₂ ∣ [] ⊢ M′ ⦂ C′
+        ------------------------------------------------------------
+      → swapRight∀∀ᵢ Φ₀
+          ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣ ρ₂ ∣ []
+          ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ q
+
+    allocation-leftᵀ :
+        ∀ {Φ₀ Δᴸ₀ Δᴿ α A B B′ M M′ p}
+          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ}
+          {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀)
+            (suc Δᴸ₀) Δᴿ}
+          {γ′ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀)
+            (suc Δᴸ₀) Δᴿ} →
+      (hA : WfTy (suc Δᴸ₀) A) →
+      LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀) ρ₀ ρ′ →
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀)
+        ∣ suc Δᴸ₀ ∣ Δᴿ ∣ ρ′ ∣ γ′
+        ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p →
+      suc Δᴸ₀ ∣ leftStoreⁱ (store-left α A hA ∷ ρ′)
+        ∣ leftCtxⁱ γ′ ⊢ M ⦂ B →
+      Δᴿ ∣ rightStoreⁱ (store-left α A hA ∷ ρ′)
+        ∣ rightCtxⁱ γ′ ⊢ M′ ⦂ B′
+        ------------------------------------------------------------
+      → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀) ∣ suc Δᴸ₀ ∣ Δᴿ ∣
+          store-left α A hA ∷ ρ′ ∣ γ′
+          ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
+
     ν⊑νᵀ :
         ∀ {ρ′ γ′ A A′ B B′ C C′ N N′ p q s s′ μ μ′}
       → WfTy Δᴸ A
       → WfTy Δᴿ A′
-      → μ ∣ suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-          ⊢ s ∶ C ↑ˢ ⇑ᵗ B
-      → μ′ ∣ suc Δᴿ
-          ∣ (zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-          ⊢ s′ ∶ C′ ↑ˢ ⇑ᵗ B′
+      → RevealConversion μ (suc Δᴸ)
+          ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+          zero (⇑ᵗ A) s C (⇑ᵗ B)
+      → RevealConversion μ′ (suc Δᴿ)
+          ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+          zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)
       → Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ
       → (A⇑⊑A′⇑ :
           ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
@@ -211,8 +525,9 @@ mutual
     ν⊑ᵀ : ∀ {ρ′ γ′ A B B′ C N N′ p q s μ}
       → WfTy Δᴸ A
       → (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A))
-      → μ ∣ suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-          ⊢ s ∶ C ↑ˢ ⇑ᵗ B
+      → RevealConversion μ (suc Δᴸ)
+          ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+          zero (⇑ᵗ A) s C (⇑ᵗ B)
       → LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
       → LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
@@ -224,10 +539,12 @@ mutual
     ⊑νᵀ : ∀ {ρ′ γ′ A B B′ C′ N N′ p q s μ}
       → WfTy Δᴿ A
       → (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A))
-      → μ ∣ suc Δᴿ ∣ (zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-          ⊢ s ∶ C′ ↑ˢ ⇑ᵗ B′
-      → LiftRightStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
-      → LiftRightCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
+      → RevealConversion μ (suc Δᴿ)
+          ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+          zero (⇑ᵗ A) s C′ (⇑ᵗ B′)
+      → LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′
+      → LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γ′
+      → ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q
         ------------------------------------------------------------
@@ -242,7 +559,8 @@ mutual
       → CastMode μ′
       → SealModeStore★ (instᵈ μ′)
           ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-      → instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+      → instᵈ μ ∣ suc Δᴸ
+          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
           ⊢ s ∶ C ⊑ ⇑ᵗ B
       → instᵈ μ′ ∣ suc Δᴿ
           ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
@@ -250,8 +568,7 @@ mutual
       → LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′
       → LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ N ⊑ N′
-          ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q
+          ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q
         ------------------------------------------------------------
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ ν ★ N s ⊑ ν ★ N′ s′ ⦂ B ⊑ B′ ∶ p
@@ -260,7 +577,8 @@ mutual
       → CastMode μ
       → SealModeStore★ (instᵈ μ)
           ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-      → instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+      → instᵈ μ ∣ suc Δᴸ
+          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
           ⊢ s ∶ C ⊑ ⇑ᵗ B
       → LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
       → LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
@@ -277,8 +595,9 @@ mutual
       → instᵈ μ ∣ suc Δᴿ
           ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
           ⊢ s ∶ C′ ⊑ ⇑ᵗ B′
-      → LiftRightStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
-      → LiftRightCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
+      → LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′
+      → LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γ′
+      → ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q
         ------------------------------------------------------------
@@ -302,28 +621,14 @@ mutual
 
     cast⊒⊑ᵀ : ∀ {M M′ A B B′ p c μ}
       → CastMode μ
-      → (wfΣ : StoreDetWf Δᴸ (leftStoreⁱ ρ))
-      → (seal★ : SealModeStore★ μ (leftStoreⁱ ρ))
-      → (okΦ : LeftCastCtxCompatible μ Δᴸ Φ)
+      → SealModeStore★ μ (leftStoreⁱ ρ)
       → (c⊒ : μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B)
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B′ ∶ p
+      → (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ)
         ------------------------------------------------------------
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′
-          ∶ ⊑-transˡ-castᵢ okΦ (narrowing⇒⊑ᵢ wfΣ seal★ c⊒) p
-
-    cast⊒⊑idᵀ : ∀ {M M′ A B B′ p c}
-      → (wfΣ : StoreDetWf Δᴸ (leftStoreⁱ ρ))
-      → (seal★ : SealModeStore★ id-onlyᵈ (leftStoreⁱ ρ))
-      → (c⊒ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B)
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B′ ∶ p
-        ------------------------------------------------------------
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′
-          ∶ ⊑-transˡ-castᵢ left-id-only-compatible
-              (narrowing⇒⊑ᵢ wfΣ seal★ c⊒) p
+          ⊢ᴺ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
 
     cast⊑⊑ᵀ : ∀ {M M′ A B B′ p c μ}
       → CastMode μ
@@ -349,9 +654,7 @@ mutual
 
     ⊑cast⊑ᵀ : ∀ {M M′ A A′ B′ p c′ μ′}
       → CastMode μ′
-      → (wfΣ′ : StoreDetWf Δᴿ (rightStoreⁱ ρ))
       → (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ))
-      → (okΦ : RightCastCtxCompatible μ′ Δᴿ Φ)
       → (c′⊑ :
           μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′)
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
@@ -373,8 +676,16 @@ mutual
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
 
-    conv↑⊑ᵀ : ∀ {M M′ A B B′ p c μ}
-      → μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ↑ˢ B
+    conv⊑convᵀ : ∀ {M M′ A A′ B B′ p q c c′}
+      → PairedCast Φ Δᴸ Δᴿ ρ c c′ p q
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+        ------------------------------------------------------------
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ⦂ B ⊑ B′ ∶ q
+
+    conv↑⊑ᵀ : ∀ {M M′ A B B′ p c μ α X}
+      → RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B′ ∶ p
       → (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ)
@@ -382,8 +693,8 @@ mutual
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
 
-    conv↓⊑ᵀ : ∀ {M M′ A B B′ p c μ}
-      → μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ↓ˢ B
+    conv↓⊑ᵀ : ∀ {M M′ A B B′ p c μ α X}
+      → ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B′ ∶ p
       → (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ)
@@ -391,8 +702,8 @@ mutual
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
 
-    ⊑conv↑ᵀ : ∀ {M M′ A A′ B′ p c′ μ′}
-      → μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ↑ˢ B′
+    ⊑conv↑ᵀ : ∀ {M M′ A A′ B′ p c′ μ′ β X′}
+      → RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
       → (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ)
@@ -400,8 +711,9 @@ mutual
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
 
-    ⊑conv↓ᵀ : ∀ {M M′ A A′ B′ p c′ μ′}
-      → μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ↓ˢ B′
+    ⊑conv↓ᵀ : ∀ {M M′ A A′ B′ p c′ μ′ β X′}
+      → ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ)
+          β X′ c′ A′ B′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
       → (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ)
@@ -425,3 +737,371 @@ mutual
         ------------------------------------------------------------
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺᵖ M ⟨ d ⟩ ⊑ M′ ⟨ d′ ⟩ ⦂ D ⊑ᵖ D′ ∶ qD
+
+    gen-down⊑gen-downᵀ :
+        ∀ {M M′ C C′ D D′ pC d d′}
+      → genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ
+          ⊢ d ∶ C ⊒ D
+      → genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+          ⊢ d′ ∶ C′ ⊒ D′
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ pC
+      → (qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ)
+        ------------------------------------------------------------
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺᵖ M ⟨ d ⟩ ⊑ M′ ⟨ d′ ⟩ ⦂ D ⊑ᵖ D′ ∶ qD
+
+seal★-gen-tag-or-id :
+  ∀ {Σ} →
+  SealModeStore★ (genᵈ tag-or-idᵈ) Σ
+seal★-gen-tag-or-id zero ()
+seal★-gen-tag-or-id (suc α) ()
+
+------------------------------------------------------------------------
+-- Typing projections
+------------------------------------------------------------------------
+
+mutual
+  nu-term-imprecision-source-typing :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A
+
+  nu-term-imprecision-target-typing :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B
+
+  quotiented-nu-term-imprecision-source-typing :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ D D′}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ D
+
+  quotiented-nu-term-imprecision-target-typing :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ D D′}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ D′
+
+  nu-term-imprecision-source-typing (blame⊑ᵀ {p = p} M′⊢) =
+    ⊢blame (⊑-src-wf p)
+  nu-term-imprecision-source-typing (x⊑xᵀ x∈) =
+    ⊢` (leftCtxⁱ-∋ x∈)
+  nu-term-imprecision-source-typing (ƛ⊑ƛᵀ hA hA′ N⊑N′) =
+    ⊢ƛ hA (nu-term-imprecision-source-typing N⊑N′)
+  nu-term-imprecision-source-typing (·⊑·ᵀ L⊑L′ M⊑M′) =
+    ⊢·
+      (nu-term-imprecision-source-typing L⊑L′)
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing (up⊑upᵀ M⊑M′ u⊑ u′⊑ p) =
+    ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
+      (widen-mode-relax id-only≤tag-or-idᵈ u⊑)
+      (quotiented-nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (crossed-up⊑upᵀ M⊑M′ mode seal★ u⊑ seal★′ u′⊑ p) =
+    ⊢⟨⟩⊑ mode seal★ u⊑
+      (quotiented-nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (crossed-left-up⊑upᵀ M⊑M′ mode seal★ u⊑
+        seal★′ u′⊑ p) =
+    ⊢⟨⟩⊑ mode seal★ u⊑
+      (quotiented-nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (Λ⊑Λᵀ {ρ = ρ} {γ = γ} liftρ liftγ vV vV′ V⊑V′) =
+    ⊢Λ vV
+      (subst
+        (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+        (leftCtxⁱ-lift liftγ)
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (leftStoreⁱ-lift liftρ)
+          (nu-term-imprecision-source-typing V⊑V′)))
+  nu-term-imprecision-source-typing
+      (Λ⊑ᵀ occ liftρ liftγ vV V⊑N′) =
+    ⊢Λ vV
+      (subst
+        (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+        (leftCtxⁱ-lift-left liftγ)
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (leftStoreⁱ-lift-left liftρ)
+          (nu-term-imprecision-source-typing V⊑N′)))
+  nu-term-imprecision-source-typing
+      (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
+        L•⊢ L′•⊢) =
+    L•⊢
+  nu-term-imprecision-source-typing
+      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+    L•⊢
+  nu-term-imprecision-source-typing
+      (⊑αᵀ vL′ noL′ h⇑A liftρ liftγ N⊑L′ r N⊢ L′•⊢) =
+    N⊢
+  nu-term-imprecision-source-typing
+      (allocation-matchedᵀ pX liftρ M⊑M′ M⊢ M′⊢) =
+    M⊢
+  nu-term-imprecision-source-typing
+      (allocation-crossedᵀ hA₀ hA₁ hB₀ hB₁ liftρ₁ liftρ₂
+        p₀₁ p₁₀ M⊑M′ M⊢ M′⊢) =
+    M⊢
+  nu-term-imprecision-source-typing
+      (swapRight-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
+        M⊢ M′⊢) =
+    M⊢
+  nu-term-imprecision-source-typing
+      (swapLeft-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
+        M⊢ M′⊢) =
+    M⊢
+  nu-term-imprecision-source-typing
+      (allocation-leftᵀ hA liftρ M⊑M′ M⊢ M′⊢) =
+    M⊢
+  nu-term-imprecision-source-typing
+      (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′) =
+    ⊢ν↑ hA (nu-term-imprecision-source-typing N⊑N′)
+      (reveal-conversion-typing s↑)
+  nu-term-imprecision-source-typing
+      (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑N′) =
+    ⊢ν↑ hA (nu-term-imprecision-source-typing N⊑N′)
+      (reveal-conversion-typing s↑)
+  nu-term-imprecision-source-typing
+      (⊑νᵀ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′) =
+    nu-term-imprecision-source-typing N⊑N′
+  nu-term-imprecision-source-typing
+      (νcast⊑νcastᵀ mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ
+        liftγ N⊑N′) =
+    ⊢ν⊑ mode seal★ (nu-term-imprecision-source-typing N⊑N′) s⊑
+  nu-term-imprecision-source-typing
+      (νcast⊑ᵀ mode seal★ s⊑ liftρ liftγ N⊑N′) =
+    ⊢ν⊑ mode seal★ (nu-term-imprecision-source-typing N⊑N′) s⊑
+  nu-term-imprecision-source-typing
+      (⊑νcastᵀ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′) =
+    nu-term-imprecision-source-typing N⊑N′
+  nu-term-imprecision-source-typing κ⊑κᵀ =
+    ⊢$ (κℕ _)
+  nu-term-imprecision-source-typing (⊕⊑⊕ᵀ L⊑L′ M⊑M′) =
+    ⊢⊕
+      (nu-term-imprecision-source-typing L⊑L′)
+      addℕ
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (cast⊒⊑ᵀ mode seal★ c⊒ M⊑M′ q) =
+    ⊢⟨⟩⊒ mode seal★ c⊒ (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (cast⊑⊑ᵀ mode seal★ c⊑ M⊑M′ q) =
+    ⊢⟨⟩⊑ mode seal★ c⊑ (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (⊑cast⊒ᵀ mode′ seal★′ c′⊒ M⊑M′ q) =
+    nu-term-imprecision-source-typing M⊑M′
+  nu-term-imprecision-source-typing
+      (⊑cast⊑ᵀ mode′ seal★′ c′⊑ M⊑M′ q) =
+    nu-term-imprecision-source-typing M⊑M′
+  nu-term-imprecision-source-typing
+      (⊑cast⊑idᵀ wfΣ′ seal★′ c′⊑ M⊑M′ q) =
+    nu-term-imprecision-source-typing M⊑M′
+  nu-term-imprecision-source-typing
+      (conv⊑convᵀ
+        (paired-conversion (paired-reveal x∈ c↑ c′↑)) M⊑M′) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c↑)
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (conv⊑convᵀ
+        (paired-conversion (paired-conceal x∈ c↓ c′↓)) M⊑M′) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c↓)
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing
+      (conv⊑convᵀ
+        (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑)
+        M⊑M′) =
+    ⊢⟨⟩⊑ mode seal★ c⊑
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing (conv↑⊑ᵀ c↑ M⊑M′ q) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c↑)
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing (conv↓⊑ᵀ c↓ M⊑M′ q) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c↓)
+      (nu-term-imprecision-source-typing M⊑M′)
+  nu-term-imprecision-source-typing (⊑conv↑ᵀ c′↑ M⊑M′ q) =
+    nu-term-imprecision-source-typing M⊑M′
+  nu-term-imprecision-source-typing (⊑conv↓ᵀ c′↓ M⊑M′ q) =
+    nu-term-imprecision-source-typing M⊑M′
+
+  nu-term-imprecision-target-typing (blame⊑ᵀ M′⊢) =
+    M′⊢
+  nu-term-imprecision-target-typing (x⊑xᵀ x∈) =
+    ⊢` (rightCtxⁱ-∋ x∈)
+  nu-term-imprecision-target-typing (ƛ⊑ƛᵀ hA hA′ N⊑N′) =
+    ⊢ƛ hA′ (nu-term-imprecision-target-typing N⊑N′)
+  nu-term-imprecision-target-typing (·⊑·ᵀ L⊑L′ M⊑M′) =
+    ⊢·
+      (nu-term-imprecision-target-typing L⊑L′)
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing (up⊑upᵀ M⊑M′ u⊑ u′⊑ p) =
+    ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
+      (widen-mode-relax id-only≤tag-or-idᵈ u′⊑)
+      (quotiented-nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (crossed-up⊑upᵀ M⊑M′ mode seal★ u⊑ seal★′ u′⊑ p) =
+    ⊢⟨⟩⊑ (cast-inst (cast-ext cast-tag-or-id)) seal★′ u′⊑
+      (quotiented-nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (crossed-left-up⊑upᵀ M⊑M′ mode seal★ u⊑
+        seal★′ u′⊑ p) =
+    ⊢⟨⟩⊑ (cast-ext (cast-inst cast-tag-or-id)) seal★′ u′⊑
+      (quotiented-nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (Λ⊑Λᵀ {ρ = ρ} {γ = γ} liftρ liftγ vV vV′ V⊑V′) =
+    ⊢Λ vV′
+      (subst
+        (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+        (rightCtxⁱ-lift liftγ)
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (rightStoreⁱ-lift liftρ)
+          (nu-term-imprecision-target-typing V⊑V′)))
+  nu-term-imprecision-target-typing
+      (Λ⊑ᵀ occ liftρ liftγ vV V⊑N′) =
+    subst
+      (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+      (rightCtxⁱ-lift-left liftγ)
+      (subst
+        (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+        (rightStoreⁱ-lift-left liftρ)
+        (nu-term-imprecision-target-typing V⊑N′))
+  nu-term-imprecision-target-typing
+      (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
+        L•⊢ L′•⊢) =
+    L′•⊢
+  nu-term-imprecision-target-typing
+      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+    N′⊢
+  nu-term-imprecision-target-typing
+      (⊑αᵀ vL′ noL′ h⇑A liftρ liftγ N⊑L′ r N⊢ L′•⊢) =
+    L′•⊢
+  nu-term-imprecision-target-typing
+      (allocation-matchedᵀ pX liftρ M⊑M′ M⊢ M′⊢) =
+    M′⊢
+  nu-term-imprecision-target-typing
+      (allocation-crossedᵀ hA₀ hA₁ hB₀ hB₁ liftρ₁ liftρ₂
+        p₀₁ p₁₀ M⊑M′ M⊢ M′⊢) =
+    M′⊢
+  nu-term-imprecision-target-typing
+      (swapRight-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
+        M⊢ M′⊢) =
+    M′⊢
+  nu-term-imprecision-target-typing
+      (swapLeft-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
+        M⊢ M′⊢) =
+    M′⊢
+  nu-term-imprecision-target-typing
+      (allocation-leftᵀ hA liftρ M⊑M′ M⊢ M′⊢) =
+    M′⊢
+  nu-term-imprecision-target-typing
+      (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′) =
+    ⊢ν↑ hA′ (nu-term-imprecision-target-typing N⊑N′)
+      (reveal-conversion-typing s′↑)
+  nu-term-imprecision-target-typing
+      (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑N′) =
+    nu-term-imprecision-target-typing N⊑N′
+  nu-term-imprecision-target-typing
+      (⊑νᵀ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′) =
+    ⊢ν↑ hA (nu-term-imprecision-target-typing N⊑N′)
+      (reveal-conversion-typing s↑)
+  nu-term-imprecision-target-typing
+      (νcast⊑νcastᵀ mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ
+        liftγ N⊑N′) =
+    ⊢ν⊑ mode′ seal★′
+      (nu-term-imprecision-target-typing N⊑N′) s′⊑
+  nu-term-imprecision-target-typing
+      (νcast⊑ᵀ mode seal★ s⊑ liftρ liftγ N⊑N′) =
+    nu-term-imprecision-target-typing N⊑N′
+  nu-term-imprecision-target-typing
+      (⊑νcastᵀ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′) =
+    ⊢ν⊑ mode seal★ (nu-term-imprecision-target-typing N⊑N′) s⊑
+  nu-term-imprecision-target-typing κ⊑κᵀ =
+    ⊢$ (κℕ _)
+  nu-term-imprecision-target-typing (⊕⊑⊕ᵀ L⊑L′ M⊑M′) =
+    ⊢⊕
+      (nu-term-imprecision-target-typing L⊑L′)
+      addℕ
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (cast⊒⊑ᵀ mode seal★ c⊒ M⊑M′ q) =
+    nu-term-imprecision-target-typing M⊑M′
+  nu-term-imprecision-target-typing
+      (cast⊑⊑ᵀ mode seal★ c⊑ M⊑M′ q) =
+    nu-term-imprecision-target-typing M⊑M′
+  nu-term-imprecision-target-typing
+      (⊑cast⊒ᵀ mode′ seal★′ c′⊒ M⊑M′ q) =
+    ⊢⟨⟩⊒ mode′ seal★′ c′⊒
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (⊑cast⊑ᵀ mode′ seal★′ c′⊑ M⊑M′ q) =
+    ⊢⟨⟩⊑ mode′ seal★′ c′⊑
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (⊑cast⊑idᵀ wfΣ′ seal★′ c′⊑ M⊑M′ q) =
+    ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
+      (widen-mode-relax id-only≤tag-or-idᵈ c′⊑)
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (conv⊑convᵀ
+        (paired-conversion (paired-reveal x∈ c↑ c′↑)) M⊑M′) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c′↑)
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (conv⊑convᵀ
+        (paired-conversion (paired-conceal x∈ c↓ c′↓)) M⊑M′) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c′↓)
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing
+      (conv⊑convᵀ
+        (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑)
+        M⊑M′) =
+    ⊢⟨⟩⊑ mode′ seal★′ c′⊑
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing (conv↑⊑ᵀ c↑ M⊑M′ q) =
+    nu-term-imprecision-target-typing M⊑M′
+  nu-term-imprecision-target-typing (conv↓⊑ᵀ c↓ M⊑M′ q) =
+    nu-term-imprecision-target-typing M⊑M′
+  nu-term-imprecision-target-typing (⊑conv↑ᵀ c′↑ M⊑M′ q) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c′↑)
+      (nu-term-imprecision-target-typing M⊑M′)
+  nu-term-imprecision-target-typing (⊑conv↓ᵀ c′↓ M⊑M′ q) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c′↓)
+      (nu-term-imprecision-target-typing M⊑M′)
+
+  quotiented-nu-term-imprecision-source-typing
+      (down⊑downᵀ d⊒ d′⊒ M⊑M′ q) =
+    ⊢⟨⟩⊒ cast-tag-or-id seal★-tag-or-id
+      (narrow-mode-relax id-only≤tag-or-idᵈ d⊒)
+      (nu-term-imprecision-source-typing M⊑M′)
+  quotiented-nu-term-imprecision-source-typing
+      (gen-down⊑gen-downᵀ d⊒ d′⊒ M⊑M′ q) =
+    ⊢⟨⟩⊒ (cast-gen cast-tag-or-id) seal★-gen-tag-or-id d⊒
+      (nu-term-imprecision-source-typing M⊑M′)
+
+  quotiented-nu-term-imprecision-target-typing
+      (down⊑downᵀ d⊒ d′⊒ M⊑M′ q) =
+    ⊢⟨⟩⊒ cast-tag-or-id seal★-tag-or-id
+      (narrow-mode-relax id-only≤tag-or-idᵈ d′⊒)
+      (nu-term-imprecision-target-typing M⊑M′)
+  quotiented-nu-term-imprecision-target-typing
+      (gen-down⊑gen-downᵀ d⊒ d′⊒ M⊑M′ q) =
+    ⊢⟨⟩⊒ (cast-gen cast-tag-or-id) seal★-gen-tag-or-id d′⊒
+      (nu-term-imprecision-target-typing M⊑M′)
+
+nu-term-imprecision-typing :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  (Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A) ×
+  (Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B)
+nu-term-imprecision-typing M⊑M′ =
+  nu-term-imprecision-source-typing M⊑M′ ,
+  nu-term-imprecision-target-typing M⊑M′

--- a/GTSF/ReductionTrace.agda
+++ b/GTSF/ReductionTrace.agda
@@ -1,0 +1,76 @@
+module ReductionTrace where
+
+-- File Charter:
+--   * Gives readable names to Nu reduction rules while preserving evaluation
+--     context nesting.
+--   * Converts checked multi-step and evaluator traces to lists suitable for
+--     executable regression examples.
+--   * Depends only on the Nu reduction semantics and raw evaluator.
+
+open import Data.List using (List; []; _∷_)
+open import Data.Maybe using (Maybe; just; nothing)
+
+import Eval as Eval
+open import NuReduction
+
+data PureStepName : Set where
+  δ-⊕-step β-ƛ-step β-Λ•-step : PureStepName
+  β-∀•-step β-gen•-step : PureStepName
+  β-id-step β-seq-step β-↦-step β-inst-step : PureStepName
+  tag-untag-ok-step tag-untag-bad-step seal-unseal-step : PureStepName
+  blame-·₁-step blame-·₂-step blame-•-step : PureStepName
+  blame-cast-step : PureStepName
+  blame-⊕₁-step blame-⊕₂-step : PureStepName
+
+pure-step-name : ∀ {M N} → M —→ N → PureStepName
+pure-step-name δ-⊕ = δ-⊕-step
+pure-step-name (β vV) = β-ƛ-step
+pure-step-name (β-Λ• vV) = β-Λ•-step
+pure-step-name (β-∀• vV) = β-∀•-step
+pure-step-name (β-gen• vV) = β-gen•-step
+pure-step-name (β-id vV) = β-id-step
+pure-step-name (β-seq vV) = β-seq-step
+pure-step-name (β-↦ vV vW) = β-↦-step
+pure-step-name (β-inst vV) = β-inst-step
+pure-step-name (tag-untag-ok vV) = tag-untag-ok-step
+pure-step-name (tag-untag-bad vV neq) = tag-untag-bad-step
+pure-step-name (seal-unseal vV) = seal-unseal-step
+pure-step-name blame-·₁ = blame-·₁-step
+pure-step-name (blame-·₂ vV) = blame-·₂-step
+pure-step-name blame-• = blame-•-step
+pure-step-name blame-⟨⟩ = blame-cast-step
+pure-step-name blame-⊕₁ = blame-⊕₁-step
+pure-step-name (blame-⊕₂ vV) = blame-⊕₂-step
+
+data StepName : Set where
+  root : PureStepName → StepName
+  allocate-ν : StepName
+  under-app-left under-app-right under-cast under-ν :
+    StepName → StepName
+  blame-ν-step : StepName
+  under-⊕-left under-⊕-right : StepName → StepName
+
+step-name : ∀ {M χ N} → M —→[ χ ] N → StepName
+step-name (pure-step M→N) = root (pure-step-name M→N)
+step-name (ν-step vV noV) = allocate-ν
+step-name (ξ-·₁ L→L′ shiftM) = under-app-left (step-name L→L′)
+step-name (ξ-·₂ vV shiftV M→M′) = under-app-right (step-name M→M′)
+step-name (ξ-⟨⟩ M→M′) = under-cast (step-name M→M′)
+step-name (ξ-ν L→L′) = under-ν (step-name L→L′)
+step-name blame-ν = blame-ν-step
+step-name (ξ-⊕₁ L→L′ shiftM) = under-⊕-left (step-name L→L′)
+step-name (ξ-⊕₂ vL shiftL M→M′) =
+  under-⊕-right (step-name M→M′)
+
+trace-step-names : ∀ {M χs N} → M —↠[ χs ] N → List StepName
+trace-step-names ↠-refl = []
+trace-step-names (↠-step M→N N↠P) =
+  step-name M→N ∷ trace-step-names N↠P
+
+outcome-step-names :
+  ∀ {M} →
+  Maybe (Eval.EvalOutcome M) →
+  Maybe (List StepName)
+outcome-step-names nothing = nothing
+outcome-step-names (just r) =
+  just (trace-step-names (Eval.outcomeTrace r))

--- a/GTSF/Run.agda
+++ b/GTSF/Run.agda
@@ -7,17 +7,23 @@ module Run where
 --     `runTyped` for callers that already have source typing.
 --   * Packages source typing, compiled target typing, the runtime invariant,
 --     and the final value-or-blame `EvalOutcome` in one result record.
+--   * Transfers the bullet-free/runtime invariant from `compile` to the
+--     refined `compileᵀ` interface used by compiler monotonicity.
 
+open import Agda.Builtin.Equality using (_≡_)
 open import Data.List using ([])
 open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat using (ℕ)
 open import Data.Product using (Σ-syntax; _×_; _,_; proj₁)
+open import Relation.Binary.PropositionalEquality using (subst)
 
 open import Types
 open import Ctx using (CtxWf; ctxWf-[]; ctxWf-∷)
 open import Compile
   using
     ( compile
+    ; compileᵀ
+    ; compile-term-agrees
     ; compile-value
     ; consistency-cast-plan
     ; dynamic-application-function-consistent
@@ -110,6 +116,21 @@ compile-runtime :
   (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
   RuntimeOK (proj₁ (compile hΓ M⊢))
 compile-runtime hΓ M⊢ = ok-no (compile-no• hΓ M⊢)
+
+compileᵀ-no• :
+  ∀ {Δ Γ M A} →
+  (hΓ : CtxWf Δ Γ) →
+  (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
+  No• (proj₁ (compileᵀ hΓ M⊢))
+compileᵀ-no• hΓ M⊢ =
+  subst No• (compile-term-agrees hΓ M⊢) (compile-no• hΓ M⊢)
+
+compileᵀ-runtime :
+  ∀ {Δ Γ M A} →
+  (hΓ : CtxWf Δ Γ) →
+  (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A) →
+  RuntimeOK (proj₁ (compileᵀ hΓ M⊢))
+compileᵀ-runtime hΓ M⊢ = ok-no (compileᵀ-no• hΓ M⊢)
 
 compile-closed :
   ∀ {M A} →

--- a/GTSF/notes.md
+++ b/GTSF/notes.md
@@ -1,11 +1,39 @@
+# Why implicit narrowing is not coherent for a gradually typed language
+
+
+Γ ⊢ M : A     A ⊒ B
+-------------------
+Γ ⊢ M : B
+
+
+let
+  f : ★ → ★ = λ x:★. x
+  x : ★ = 42             --- implicit up cast
+in
+  f x
+
+
+  ⊢ f : ★ → ★    ★ → ★ ⊒ 𝔹 → ★      ⊢ x : ★       ★ ⊒ 𝔹
+ -----------------------------      --------------------
+  ⊢ f : 𝔹 → ★                       ⊢ x : 𝔹
+  -----------------------------------------
+  ⊢ f x
+
+
+With these casts, f ⟨ ... ⟩ x ⟨ ... ⟩ reduces to blame.
+
+
+
+
+
 # Why compile monotonicity uses quotiented imprecision
 
 Here is a concrete pair of related applications whose compilations expose the
 bad-GLB problem.  The left program is the more precise one.
 
 ```text
-f  : (∀Y. ∀X. X → Y) → ℕ       x  : ∀Y. ∀X. X → Y
-f′ : (∀Y. ★ → Y) → ℕ           x′ : ∀X. X → ★
+f  : (∀Y. ∀X. X → Y) → ℕ     f′ : (∀Y. ★ → Y) → ℕ
+x  : ∀Y. ∀X. X → Y           x′ : ∀X. X → ★
 
 f x  ⊑  f′ x′
 ```

--- a/GTSF/proof/CastImprecision.agda
+++ b/GTSF/proof/CastImprecision.agda
@@ -9,6 +9,8 @@ module proof.CastImprecision where
 --     `ˣ⊑★` assumption.
 --   * Provides the one-sided transitivity principles needed to compose those
 --     local edges with ambient Nu-term imprecision indices.
+--   * Records why generic one-sided casts cannot cross a matched fresh-seal
+--     boundary: it supplies `zero ˣ⊑ˣ zero`, not `zero ˣ⊑★`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (Bool; false; true; _∨_)
@@ -337,6 +339,44 @@ RightCastCtxCompatible μ Δ Φ =
   Y < Δ →
   modeStarAllowed (μ Y) ≡ true →
   (X ˣ⊑★) ∈ Φ
+
+matched-gen-left-incompatible :
+  ∀ {μ Δ Φ} →
+  LeftCastCtxCompatible (genᵈ μ) (suc Δ)
+    ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) →
+  ⊥
+matched-gen-left-incompatible ok with ok z<s refl
+matched-gen-left-incompatible ok | there zero★∈ =
+  no-⇑ᵢ-zero-star zero★∈
+
+matched-gen-right-incompatible :
+  ∀ {μ Δ Φ} →
+  RightCastCtxCompatible (genᵈ μ) (suc Δ)
+    ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) →
+  ⊥
+matched-gen-right-incompatible ok
+    with ok (here refl) z<s refl
+matched-gen-right-incompatible ok | there zero★∈ =
+  no-⇑ᵢ-zero-star zero★∈
+
+matched-inst-left-incompatible :
+  ∀ {μ Δ Φ} →
+  LeftCastCtxCompatible (instᵈ μ) (suc Δ)
+    ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) →
+  ⊥
+matched-inst-left-incompatible ok with ok z<s refl
+matched-inst-left-incompatible ok | there zero★∈ =
+  no-⇑ᵢ-zero-star zero★∈
+
+matched-inst-right-incompatible :
+  ∀ {μ Δ Φ} →
+  RightCastCtxCompatible (instᵈ μ) (suc Δ)
+    ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) →
+  ⊥
+matched-inst-right-incompatible ok
+    with ok (here refl) z<s refl
+matched-inst-right-incompatible ok | there zero★∈ =
+  no-⇑ᵢ-zero-star zero★∈
 
 ∀ᵢᶜ : ImpCtx → ImpCtx
 ∀ᵢᶜ Φ = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ

--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -454,6 +454,18 @@ ModeRename-ext :
 ModeRename-ext rel zero = refl
 ModeRename-ext rel (suc X) = rel X
 
+single-mode-rename-lower :
+  ∀ μ α →
+  ModeRename (singleRenameᵗ α) (extᵈ μ) μ
+single-mode-rename-lower μ α zero with μ α
+single-mode-rename-lower μ α zero | id-only = refl
+single-mode-rename-lower μ α zero | tag-or-id = refl
+single-mode-rename-lower μ α zero | seal-or-id = refl
+single-mode-rename-lower μ α (suc X) with μ X
+single-mode-rename-lower μ α (suc X) | id-only = refl
+single-mode-rename-lower μ α (suc X) | tag-or-id = refl
+single-mode-rename-lower μ α (suc X) | seal-or-id = refl
+
 ModeRename-gen :
   ∀ {ρ μ ν} →
   ModeRename ρ μ ν →

--- a/GTSF/proof/CompileTermImprecision.agda
+++ b/GTSF/proof/CompileTermImprecision.agda
@@ -20,6 +20,7 @@ open import Relation.Binary.PropositionalEquality using
 open import Types
 open import Ctx using (CtxWf; ctxWf-∷)
 open import Coercions using (id-onlyᵈ; id-only≤tag-or-idᵈ)
+open import Conversion using (reveal↑)
 open import Compile using
   ( CastPlan
   ; cast
@@ -686,8 +687,8 @@ compile-preserves-term-imprecision-typed
         M⊑M′
   in
   QTI.ν⊑νᵀ hT hT′
-    (ν-reveal-conversion hT hA)
-    (ν-reveal-conversion hT′ hB)
+    (reveal↑ (ν-reveal-conversion hT hA))
+    (reveal↑ (ν-reveal-conversion hT′ hB))
     q
     (imp-lift q)
     NTI.lift-store-[]
@@ -706,7 +707,7 @@ compile-preserves-term-imprecision-typed
   in
   QTI.ν⊑ᵀ hT
     (renameᵗ-preserves-WfTy hT TyRenameWf-suc)
-    (ν-reveal-conversion hT hA)
+    (reveal↑ (ν-reveal-conversion hT hA))
     NTI.lift-left-store-[]
     (nuCtx⇑ᴸ-lift (ctxImpToNu γ))
     M⊑M′ᵀ

--- a/GTSF/proof/ForallPermutationProperties.agda
+++ b/GTSF/proof/ForallPermutationProperties.agda
@@ -8,9 +8,11 @@ module proof.ForallPermutationProperties where
 --   * Contains no selector-specific assumptions.
 
 open import Data.Empty using (⊥-elim)
+open import Data.Bool using (true)
 open import Data.List using (_∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (_<_; zero; suc; z<s; s<s)
+open import Data.Product using (_×_; _,_; ∃-syntax)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; cong; refl; subst; trans)
 
@@ -58,6 +60,109 @@ renameᵗ-ext-swap01-involutive A =
   trans
     (renameᵗ-compose (extᵗ swap01ᵗ) (extᵗ swap01ᵗ) A)
     (trans (rename-cong ext-swap01-involutive A) (renameᵗ-id A))
+
+------------------------------------------------------------------------
+-- Outer-forall shape is invariant under permutation equivalence
+------------------------------------------------------------------------
+
+mutual
+  ≈∀-preserves-all-shape :
+    ∀ {A B} →
+    A ≈∀ B →
+    ∃[ C ] A ≡ `∀ C →
+    ∃[ D ] B ≡ `∀ D
+  ≈∀-preserves-all-shape ≈∀-refl allA = allA
+  ≈∀-preserves-all-shape (≈∀-sym A≈B) allA =
+    ≈∀-reflects-all-shape A≈B allA
+  ≈∀-preserves-all-shape (≈∀-trans A≈B B≈C) allA =
+    ≈∀-preserves-all-shape B≈C
+      (≈∀-preserves-all-shape A≈B allA)
+  ≈∀-preserves-all-shape (≈∀-⇒ A≈A′ B≈B′) (C , ())
+  ≈∀-preserves-all-shape (≈∀-∀ {B = B} A≈B) allA =
+    B , refl
+  ≈∀-preserves-all-shape (≈∀-swap {A = A}) allA =
+    `∀ (renameᵗ swap01ᵗ A) , refl
+
+  ≈∀-reflects-all-shape :
+    ∀ {A B} →
+    A ≈∀ B →
+    ∃[ D ] B ≡ `∀ D →
+    ∃[ C ] A ≡ `∀ C
+  ≈∀-reflects-all-shape ≈∀-refl allB = allB
+  ≈∀-reflects-all-shape (≈∀-sym A≈B) allB =
+    ≈∀-preserves-all-shape A≈B allB
+  ≈∀-reflects-all-shape (≈∀-trans A≈B B≈C) allC =
+    ≈∀-reflects-all-shape A≈B
+      (≈∀-reflects-all-shape B≈C allC)
+  ≈∀-reflects-all-shape (≈∀-⇒ A≈A′ B≈B′) (D , ())
+  ≈∀-reflects-all-shape (≈∀-∀ {A = A} A≈B) allB =
+    A , refl
+  ≈∀-reflects-all-shape (≈∀-swap {A = A}) allB =
+    `∀ A , refl
+
+≈∀-all-right :
+  ∀ {A B} →
+  `∀ A ≈∀ B →
+  ∃[ C ] B ≡ `∀ C
+≈∀-all-right {A = A} A≈B =
+  ≈∀-preserves-all-shape A≈B (A , refl)
+
+≈∀-all-left :
+  ∀ {A B} →
+  A ≈∀ `∀ B →
+  ∃[ C ] A ≡ `∀ C
+≈∀-all-left {B = B} A≈B =
+  ≈∀-reflects-all-shape A≈B (B , refl)
+
+⊑ᵖ-all-representatives :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ `∀ A ⊑ᵖ `∀ B ⊣ Δᴿ →
+  ∃[ C ] ∃[ D ]
+    ((`∀ A ≈∀ `∀ C) ×
+     (Φ ∣ Δᴸ ⊢ `∀ C ⊑ `∀ D ⊣ Δᴿ) ×
+     (`∀ D ≈∀ `∀ B))
+⊑ᵖ-all-representatives
+    (quotientᵖ A≈A′ A′⊑B′ B′≈B)
+    with ≈∀-all-right A≈A′ | ≈∀-all-left B′≈B
+⊑ᵖ-all-representatives
+    (quotientᵖ A≈A′ A′⊑B′ B′≈B)
+    | C , refl | D , refl =
+  C , D , A≈A′ , A′⊑B′ , B′≈B
+
+data AllImprecisionView
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx} {A B : Ty} :
+    (Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ B ⊣ Δᴿ) → Set where
+  all-paired :
+    (p : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ
+      ⊢ A ⊑ B ⊣ suc Δᴿ) →
+    AllImprecisionView (∀ⁱ p)
+
+  all-source :
+    (occ : occurs zero A ≡ true) →
+    (p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ
+      ⊢ A ⊑ `∀ B ⊣ Δᴿ) →
+    AllImprecisionView (ν occ p)
+
+all-imprecision-view :
+  ∀ {Φ Δᴸ Δᴿ A B}
+    (p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ B ⊣ Δᴿ) →
+  AllImprecisionView p
+all-imprecision-view (∀ⁱ p) = all-paired p
+all-imprecision-view (ν occ p) = all-source occ p
+
+⊑ᵖ-all-view :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ `∀ A ⊑ᵖ `∀ B ⊣ Δᴿ →
+  ∃[ C ] ∃[ D ]
+    ((`∀ A ≈∀ `∀ C) ×
+     ∃[ p ]
+       (AllImprecisionView p × (`∀ D ≈∀ `∀ B)))
+⊑ᵖ-all-view (quotientᵖ A≈A′ A′⊑B′ B′≈B)
+    with ≈∀-all-right A≈A′ | ≈∀-all-left B′≈B
+⊑ᵖ-all-view (quotientᵖ A≈A′ A′⊑B′ B′≈B)
+    | C , refl | D , refl =
+  C , D , A≈A′ , A′⊑B′ ,
+    all-imprecision-view A′⊑B′ , B′≈B
 
 swap01-pres-< :
   ∀ {Δ X} →

--- a/GTSF/proof/MLBRouteOperationalExperiment.agda
+++ b/GTSF/proof/MLBRouteOperationalExperiment.agda
@@ -26,6 +26,7 @@ open import NarrowWiden using (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
 open import NuReduction
 open import NuTerms
 open import Primitives using (κℕ)
+open import ReductionTrace
 open import proof.CompileCoercions using
   (coerce-downⁿ; coerce-upʷ; realizes-idᵢᴺᵂ-id-only)
 open import proof.MLBGlbExample using
@@ -503,69 +504,6 @@ value-program-via-D-result = refl
 value-program-via-E-result :
   maybe-outcome-kind run-value-E ≡ just value-outcome
 value-program-via-E-result = refl
-
-------------------------------------------------------------------------
--- Readable views of the evaluator's reduction traces
-------------------------------------------------------------------------
-
-data PureStepName : Set where
-  δ-⊕-step β-ƛ-step β-Λ•-step : PureStepName
-  β-∀•-step β-gen•-step : PureStepName
-  β-id-step β-seq-step β-↦-step β-inst-step : PureStepName
-  tag-untag-ok-step tag-untag-bad-step seal-unseal-step : PureStepName
-  blame-·₁-step blame-·₂-step blame-•-step : PureStepName
-  blame-cast-step : PureStepName
-  blame-⊕₁-step blame-⊕₂-step : PureStepName
-
-pure-step-name : ∀ {M N} → M —→ N → PureStepName
-pure-step-name δ-⊕ = δ-⊕-step
-pure-step-name (β vV) = β-ƛ-step
-pure-step-name (β-Λ• vV) = β-Λ•-step
-pure-step-name (β-∀• vV) = β-∀•-step
-pure-step-name (β-gen• vV) = β-gen•-step
-pure-step-name (β-id vV) = β-id-step
-pure-step-name (β-seq vV) = β-seq-step
-pure-step-name (β-↦ vV vW) = β-↦-step
-pure-step-name (β-inst vV) = β-inst-step
-pure-step-name (tag-untag-ok vV) = tag-untag-ok-step
-pure-step-name (tag-untag-bad vV neq) = tag-untag-bad-step
-pure-step-name (seal-unseal vV) = seal-unseal-step
-pure-step-name blame-·₁ = blame-·₁-step
-pure-step-name (blame-·₂ vV) = blame-·₂-step
-pure-step-name blame-• = blame-•-step
-pure-step-name blame-⟨⟩ = blame-cast-step
-pure-step-name blame-⊕₁ = blame-⊕₁-step
-pure-step-name (blame-⊕₂ vV) = blame-⊕₂-step
-
-data StepName : Set where
-  root : PureStepName → StepName
-  allocate-ν : StepName
-  under-app-left under-app-right under-cast under-ν : StepName → StepName
-  blame-ν-step : StepName
-  under-⊕-left under-⊕-right : StepName → StepName
-
-step-name : ∀ {M χ N} → M —→[ χ ] N → StepName
-step-name (pure-step M→N) = root (pure-step-name M→N)
-step-name (ν-step vV noV) = allocate-ν
-step-name (ξ-·₁ L→L′ shiftM) = under-app-left (step-name L→L′)
-step-name (ξ-·₂ vV shiftV M→M′) = under-app-right (step-name M→M′)
-step-name (ξ-⟨⟩ M→M′) = under-cast (step-name M→M′)
-step-name (ξ-ν L→L′) = under-ν (step-name L→L′)
-step-name blame-ν = blame-ν-step
-step-name (ξ-⊕₁ L→L′ shiftM) = under-⊕-left (step-name L→L′)
-step-name (ξ-⊕₂ vL shiftL M→M′) = under-⊕-right (step-name M→M′)
-
-trace-step-names : ∀ {M χs N} → M —↠[ χs ] N → List StepName
-trace-step-names ↠-refl = []
-trace-step-names (↠-step M→N N↠P) =
-  step-name M→N ∷ trace-step-names N↠P
-
-outcome-step-names :
-  ∀ {M} →
-  Maybe (Eval.EvalOutcome M) →
-  Maybe (List StepName)
-outcome-step-names nothing = nothing
-outcome-step-names (just r) = just (trace-step-names (Eval.outcomeTrace r))
 
 trace-D :
   outcome-step-names run-D ≡

--- a/GTSF/proof/MaximalLowerBoundsWf.agda
+++ b/GTSF/proof/MaximalLowerBoundsWf.agda
@@ -54,6 +54,7 @@ open import proof.TypeProperties using
   ; renameᵗ-ext-suc-comm
   ; renameᵗ-id
   ; renameᵗ-single-suc-cancel
+  ; singleRenameᵗ-Wf-<
   )
 
 ∨-true-leftᵢ : ∀ {b c} → b ≡ true → b ∨ c ≡ true
@@ -386,6 +387,43 @@ rename-assm²-∀ᵢ {a = X ˣ⊑ˣ Y} x∈ = there (⇑ᵢ-ˣ∈ x∈)
     (λ X<Δ → s<s X<Δ)
     (λ Y<Δ → s<s Y<Δ)
 
+rename-assm²-open-shiftᵢ :
+  ∀ {Φ a α β} →
+  a ∈ ⇑ᵢ Φ →
+  rename-assm²ᵢ (singleRenameᵗ α) (singleRenameᵗ β) a ∈ Φ
+rename-assm²-open-shiftᵢ {Φ = []} ()
+rename-assm²-open-shiftᵢ {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-open-shiftᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-open-shiftᵢ {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-open-shiftᵢ a∈)
+rename-assm²-open-shiftᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-open-shiftᵢ a∈)
+
+rename-assm²-open∀ᵢ :
+  ∀ {Φ a α β} →
+  (α ˣ⊑ˣ β) ∈ Φ →
+  a ∈ ∀ᵢᶜ Φ →
+  rename-assm²ᵢ (singleRenameᵗ α) (singleRenameᵗ β) a ∈ Φ
+rename-assm²-open∀ᵢ α⊑β (here refl) = α⊑β
+rename-assm²-open∀ᵢ α⊑β (there a∈) =
+  rename-assm²-open-shiftᵢ a∈
+
+⊑-open∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B α β} →
+  (α ˣ⊑ˣ β) ∈ Φ →
+  α < Δᴸ →
+  β < Δᴿ →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  Φ ∣ Δᴸ ⊢ A [ α ]ᴿ ⊑ B [ β ]ᴿ ⊣ Δᴿ
+⊑-open∀ᵢ α⊑β α<Δᴸ β<Δᴿ p =
+  ⊑-renameᵗ²ᵢ
+    (rename-assm²-open∀ᵢ α⊑β)
+    (singleRenameᵗ-Wf-< α<Δᴸ)
+    (singleRenameᵗ-Wf-< β<Δᴿ)
+    p
+
 ⊑-source-liftνᵢ :
   ∀ {Φ Δᴸ Δᴿ A B} →
   Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
@@ -400,6 +438,36 @@ rename-assm²-∀ᵢ {a = X ˣ⊑ˣ Y} x∈ = there (⇑ᵢ-ˣ∈ x∈)
       rename-assm²-source-νᵢ
       (λ X<Δ → s<s X<Δ)
       (λ Y<Δ → Y<Δ)
+      p)
+
+rename-assm²-target-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ Φ →
+  rename-assm²ᵢ (λ X → X) suc a ∈ ⇑ᴿᵢ Φ
+rename-assm²-target-rightᵢ {Φ = []} ()
+rename-assm²-target-rightᵢ {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-target-rightᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-target-rightᵢ {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-target-rightᵢ a∈)
+rename-assm²-target-rightᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-target-rightᵢ a∈)
+
+⊑-target-lift-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ ⇑ᵗ B ⊣ suc Δᴿ
+⊑-target-lift-rightᵢ {A = A} {B = B} p =
+  subst
+    (λ A′ → ⇑ᴿᵢ _ ∣ _ ⊢ A′ ⊑ ⇑ᵗ B ⊣ _)
+    (renameᵗ-id A)
+    (⊑-renameᵗ²ᵢ
+      {ρ = λ X → X}
+      {σ = suc}
+      rename-assm²-target-rightᵢ
+      (λ X<Δ → X<Δ)
+      (λ Y<Δ → s<s Y<Δ)
       p)
 
 νᵣᵢ : Renameᵗ → Renameᵗ
@@ -821,6 +889,225 @@ swap01-pres-<ᵢ {X = suc zero} (s<s z<s) = z<s
 swap01-pres-<ᵢ {X = suc (suc X)} (s<s (s<s X<Δ)) =
   s<s (s<s X<Δ)
 
+rename-assm²-swapRight∀∀ᵢ :
+  ∀ {Φ a} →
+  a ∈ ∀ᵢᶜ (∀ᵢᶜ Φ) →
+  rename-assm²ᵢ (λ X → X) swap01ᵢ a ∈ swapRight∀∀ᵢ Φ
+rename-assm²-swapRight∀∀ᵢ {a = zero ˣ⊑★} =
+  λ { (here ()) ; (there a∈) → ⊥-elim (no-⇑ᵢ-zero-star a∈) }
+rename-assm²-swapRight∀∀ᵢ {a = suc zero ˣ⊑★}
+    (here ())
+rename-assm²-swapRight∀∀ᵢ {a = suc zero ˣ⊑★}
+    (there a∈) =
+  ⊥-elim (no-∀ctx-zero-starᵢ (un⇑ᵢ-★∈ a∈))
+rename-assm²-swapRight∀∀ᵢ {a = suc (suc X) ˣ⊑★}
+    (here ())
+rename-assm²-swapRight∀∀ᵢ {a = suc (suc X) ˣ⊑★}
+    (there (here ()))
+rename-assm²-swapRight∀∀ᵢ {a = suc (suc X) ˣ⊑★}
+    (there (there a∈)) =
+  there (there a∈)
+rename-assm²-swapRight∀∀ᵢ {a = zero ˣ⊑ˣ zero}
+    (here refl) =
+  here refl
+rename-assm²-swapRight∀∀ᵢ {a = zero ˣ⊑ˣ zero}
+    (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-left a∈)
+rename-assm²-swapRight∀∀ᵢ {a = zero ˣ⊑ˣ suc Y}
+    (here ())
+rename-assm²-swapRight∀∀ᵢ {a = zero ˣ⊑ˣ suc Y}
+    (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-left a∈)
+rename-assm²-swapRight∀∀ᵢ {a = suc zero ˣ⊑ˣ zero}
+    (here ())
+rename-assm²-swapRight∀∀ᵢ {a = suc zero ˣ⊑ˣ zero}
+    (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-right a∈)
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc zero} (here ())
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc zero} (there a∈) =
+  there (here refl)
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc (suc Y)} (here ())
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc (suc Y)} (there a∈) =
+  ⊥-elim (no-∀ctx-zero-leftᵢ (un⇑ᵢ-ˣ∈ a∈))
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ zero} (here ())
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ zero} (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-right a∈)
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc zero} (here ())
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc zero} (there a∈) =
+  ⊥-elim (no-∀ctx-zero-rightᵢ (un⇑ᵢ-ˣ∈ a∈))
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc (suc Y)} (here ())
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc (suc Y)}
+    (there (here ()))
+rename-assm²-swapRight∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc (suc Y)}
+    (there (there a∈)) =
+  there (there a∈)
+
+⊑-swapRight01∀∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ A ⊑ B ⊣ suc (suc Δᴿ) →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ A ⊑ renameᵗ swap01ᵢ B ⊣ suc (suc Δᴿ)
+⊑-swapRight01∀∀ᵢ {A = A} p =
+  subst
+    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ swap01ᵢ _ ⊣ _)
+    (renameᵗ-id A)
+    (⊑-renameᵗ²ᵢ
+      { ρ = λ X → X }
+      { σ = swap01ᵢ }
+      rename-assm²-swapRight∀∀ᵢ
+      (λ X<Δ → X<Δ)
+      swap01-pres-<ᵢ
+      p)
+
+rename-assm²-swapLeft∀∀ᵢ :
+  ∀ {Φ a} →
+  a ∈ ∀ᵢᶜ (∀ᵢᶜ Φ) →
+  rename-assm²ᵢ swap01ᵢ (λ X → X) a ∈ swapRight∀∀ᵢ Φ
+rename-assm²-swapLeft∀∀ᵢ {a = zero ˣ⊑★} =
+  λ { (here ()) ; (there a∈) → ⊥-elim (no-⇑ᵢ-zero-star a∈) }
+rename-assm²-swapLeft∀∀ᵢ {a = suc zero ˣ⊑★}
+    (here ())
+rename-assm²-swapLeft∀∀ᵢ {a = suc zero ˣ⊑★}
+    (there a∈) =
+  ⊥-elim (no-∀ctx-zero-starᵢ (un⇑ᵢ-★∈ a∈))
+rename-assm²-swapLeft∀∀ᵢ {a = suc (suc X) ˣ⊑★}
+    (here ())
+rename-assm²-swapLeft∀∀ᵢ {a = suc (suc X) ˣ⊑★}
+    (there (here ()))
+rename-assm²-swapLeft∀∀ᵢ {a = suc (suc X) ˣ⊑★}
+    (there (there a∈)) =
+  there (there a∈)
+rename-assm²-swapLeft∀∀ᵢ {a = zero ˣ⊑ˣ zero}
+    (here refl) =
+  there (here refl)
+rename-assm²-swapLeft∀∀ᵢ {a = zero ˣ⊑ˣ zero}
+    (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-left a∈)
+rename-assm²-swapLeft∀∀ᵢ {a = zero ˣ⊑ˣ suc Y}
+    (here ())
+rename-assm²-swapLeft∀∀ᵢ {a = zero ˣ⊑ˣ suc Y}
+    (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-left a∈)
+rename-assm²-swapLeft∀∀ᵢ {a = suc zero ˣ⊑ˣ zero}
+    (here ())
+rename-assm²-swapLeft∀∀ᵢ {a = suc zero ˣ⊑ˣ zero}
+    (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-right a∈)
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc zero} (here ())
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc zero} (there a∈) =
+  here refl
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc (suc Y)} (here ())
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc zero ˣ⊑ˣ suc (suc Y)} (there a∈) =
+  ⊥-elim (no-∀ctx-zero-leftᵢ (un⇑ᵢ-ˣ∈ a∈))
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ zero} (here ())
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ zero} (there a∈) =
+  ⊥-elim (no-⇑ᵢ-zero-right a∈)
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc zero} (here ())
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc zero} (there a∈) =
+  ⊥-elim (no-∀ctx-zero-rightᵢ (un⇑ᵢ-ˣ∈ a∈))
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc (suc Y)} (here ())
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc (suc Y)}
+    (there (here ()))
+rename-assm²-swapLeft∀∀ᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc (suc Y)}
+    (there (there a∈)) =
+  there (there a∈)
+
+⊑-swapLeft01∀∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ A ⊑ B ⊣ suc (suc Δᴿ) →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ renameᵗ swap01ᵢ A ⊑ B ⊣ suc (suc Δᴿ)
+⊑-swapLeft01∀∀ᵢ {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢ renameᵗ swap01ᵢ _ ⊑ T ⊣ _)
+    (renameᵗ-id B)
+    (⊑-renameᵗ²ᵢ
+      { ρ = swap01ᵢ }
+      { σ = λ X → X }
+      rename-assm²-swapLeft∀∀ᵢ
+      swap01-pres-<ᵢ
+      (λ X<Δ → X<Δ)
+      p)
+
+renameᵗ-swap01-liftᵢ :
+  ∀ B →
+  renameᵗ swap01ᵢ (⇑ᵗ B) ≡ renameᵗ (extᵗ suc) B
+renameᵗ-swap01-liftᵢ B =
+  trans
+    (renameᵗ-compose suc swap01ᵢ B)
+    (rename-cong
+      (λ { zero → refl ; (suc X) → refl })
+      B)
+
+renameᵗ-swap01-double-liftᵢ :
+  ∀ B →
+  renameᵗ swap01ᵢ (⇑ᵗ (⇑ᵗ B)) ≡ ⇑ᵗ (⇑ᵗ B)
+renameᵗ-swap01-double-liftᵢ B =
+  trans
+    (cong (renameᵗ swap01ᵢ) (renameᵗ-compose suc suc B))
+    (trans
+      (renameᵗ-compose (λ X → suc (suc X)) swap01ᵢ B)
+      (trans
+        (rename-cong (λ X → refl) B)
+        (sym (renameᵗ-compose suc suc B))))
+
+⊑-crossed-body-lift∀∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B ⊣ suc (suc Δᴿ)
+⊑-crossed-body-lift∀∀ᵢ {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢ ⇑ᵗ _ ⊑ T ⊣ _)
+    (renameᵗ-swap01-liftᵢ B)
+    (⊑-swapRight01∀∀ᵢ (⊑-lift∀ᵢ p))
+
+⊑-crossed-left-body-lift∀∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ renameᵗ (extᵗ suc) A ⊑ ⇑ᵗ B ⊣ suc (suc Δᴿ)
+⊑-crossed-left-body-lift∀∀ᵢ {A = A} p =
+  subst
+    (λ T → _ ∣ _ ⊢ T ⊑ ⇑ᵗ _ ⊣ _)
+    (renameᵗ-swap01-liftᵢ A)
+    (⊑-swapLeft01∀∀ᵢ (⊑-lift∀ᵢ p))
+
+⊑-crossed-double-lift∀∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ ⇑ᵗ (⇑ᵗ A) ⊑ ⇑ᵗ (⇑ᵗ B) ⊣ suc (suc Δᴿ)
+⊑-crossed-double-lift∀∀ᵢ {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢ ⇑ᵗ (⇑ᵗ _) ⊑ T ⊣ _)
+    (renameᵗ-swap01-double-liftᵢ B)
+    (⊑-swapRight01∀∀ᵢ (⊑-lift∀ᵢ (⊑-lift∀ᵢ p)))
+
 rename-assm²-swap∀∀ᵢ :
   ∀ {Φ a} →
   a ∈ ∀ᵢᶜ (∀ᵢᶜ Φ) →
@@ -1119,6 +1406,89 @@ rename-assm²-∀ν-to-ν∀ᵢ {a = suc (suc X) ˣ⊑ˣ suc Y} (there a∈) =
       {ρ = swap01ᵢ}
       {σ = λ X → X}
       rename-assm²-∀ν-to-ν∀ᵢ
+      swap01-pres-<ᵢ
+      (λ Y<Δ → Y<Δ)
+      p)
+
+rename-assm²-ν∀-to-∀νᵢ :
+  ∀ {Φ a} →
+  a ∈ νᵢᶜ (∀ᵢᶜ Φ) →
+  rename-assm²ᵢ swap01ᵢ (λ X → X) a ∈ ∀ᵢᶜ (νᵢᶜ Φ)
+rename-assm²-ν∀-to-∀νᵢ {a = zero ˣ⊑★} (here refl) =
+  there (⇑ᵢ-★∈ (here refl))
+rename-assm²-ν∀-to-∀νᵢ {a = zero ˣ⊑★} (there a∈) =
+  ⊥-elim (no-⇑ᴸᵢ-zero-star a∈)
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑★} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑★} (there a∈) =
+  ⊥-elim (no-∀ctx-zero-starᵢ (un⇑ᴸᵢ-★∈ a∈))
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑★} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑★} (there a∈)
+    with un⇑ᴸᵢ-★∈ a∈
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑★} (there a∈)
+    | here ()
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑★} (there a∈)
+    | there x∈ =
+  there
+    (⇑ᵢ-★∈
+      (there (⇑ᴸᵢ-★∈ (un⇑ᵢ-★∈ x∈))))
+rename-assm²-ν∀-to-∀νᵢ {a = zero ˣ⊑ˣ zero} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = zero ˣ⊑ˣ zero} (there a∈) =
+  ⊥-elim (no-⇑ᴸᵢ-zero-left a∈)
+rename-assm²-ν∀-to-∀νᵢ {a = zero ˣ⊑ˣ suc Y} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = zero ˣ⊑ˣ suc Y} (there a∈) =
+  ⊥-elim (no-⇑ᴸᵢ-zero-left a∈)
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ zero} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ zero} (there a∈)
+    with un⇑ᴸᵢ-ˣ∈ a∈
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ zero} (there a∈)
+    | here refl = here refl
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ zero} (there a∈)
+    | there x∈ = ⊥-elim (no-⇑ᵢ-zero-left x∈)
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ suc Y} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ suc Y} (there a∈)
+    with un⇑ᴸᵢ-ˣ∈ a∈
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ suc Y} (there a∈)
+    | here ()
+rename-assm²-ν∀-to-∀νᵢ {a = suc zero ˣ⊑ˣ suc Y} (there a∈)
+    | there x∈ = ⊥-elim (no-⇑ᵢ-zero-left x∈)
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑ˣ zero} (here ())
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑ˣ zero} (there a∈)
+    with un⇑ᴸᵢ-ˣ∈ a∈
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑ˣ zero} (there a∈)
+    | here ()
+rename-assm²-ν∀-to-∀νᵢ {a = suc (suc X) ˣ⊑ˣ zero} (there a∈)
+    | there x∈ = ⊥-elim (no-⇑ᵢ-zero-right x∈)
+rename-assm²-ν∀-to-∀νᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc Y} (here ())
+rename-assm²-ν∀-to-∀νᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc Y} (there a∈)
+    with un⇑ᴸᵢ-ˣ∈ a∈
+rename-assm²-ν∀-to-∀νᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc Y} (there a∈)
+    | here ()
+rename-assm²-ν∀-to-∀νᵢ
+    {a = suc (suc X) ˣ⊑ˣ suc Y} (there a∈)
+    | there x∈ =
+  there
+    (⇑ᵢ-ˣ∈
+      (there (⇑ᴸᵢ-ˣ∈ (un⇑ᵢ-ˣ∈ x∈))))
+
+⊑-ν∀-to-∀νᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  νᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ) ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (νᵢᶜ Φ)
+    ∣ suc (suc Δᴸ) ⊢ renameᵗ swap01ᵢ A ⊑ B ⊣ suc Δᴿ
+⊑-ν∀-to-∀νᵢ {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {A = A} {B = B} p =
+  subst
+    (λ B′ →
+      ∀ᵢᶜ (νᵢᶜ Φ)
+        ∣ suc (suc Δᴸ) ⊢ renameᵗ swap01ᵢ A ⊑ B′ ⊣ suc Δᴿ)
+    (renameᵗ-id B)
+    (⊑-renameᵗ²ᵢ
+      {ρ = swap01ᵢ}
+      {σ = λ X → X}
+      rename-assm²-ν∀-to-∀νᵢ
       swap01-pres-<ᵢ
       (λ Y<Δ → Y<Δ)
       p)

--- a/GTSF/proof/NarrowWidenProperties.agda
+++ b/GTSF/proof/NarrowWidenProperties.agda
@@ -48,6 +48,7 @@ open import proof.CoercionProperties
     ; ModeRename
     ; renameᶜ-open-commute
     ; sealModeAllowed-var-seal
+    ; single-mode-rename-lower
     ; src-renameᶜ
     ; tagModeAllowed-var-tag
     )
@@ -78,7 +79,79 @@ open import proof.TypeProperties
     ; renameᵗ-preserves-WfTy
     ; renameᵗ-ext-suc-comm
     ; renameStoreᵗ-ext-suc-comm
+    ; renameStoreᵗ-single-suc-cancel
+    ; singleRenameᵗ-Wf-<
     )
+
+------------------------------------------------------------------------
+-- Opening typed narrowing and widening at a fresh seal name
+------------------------------------------------------------------------
+
+open-narrowing :
+  ∀ {μ Δ Σ α c A B} →
+  α < Δ →
+  extᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ c ∶ A ⊒ B →
+  μ ∣ Δ ∣ Σ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ ⊒ B [ α ]ᴿ
+open-narrowing {μ = μ} {Σ = Σ} {α = α} α<Δ c⊒ =
+  subst
+    (λ Σ′ → μ ∣ _ ∣ Σ′ ⊢ _ ∶ _ ⊒ _)
+    (renameStoreᵗ-single-suc-cancel α Σ)
+    (narrow-renameᵗ
+      (singleRenameᵗ-Wf-< α<Δ)
+      (single-mode-rename-lower μ α)
+      c⊒)
+
+open-widening :
+  ∀ {μ Δ Σ α c A B} →
+  α < Δ →
+  extᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ c ∶ A ⊑ B →
+  μ ∣ Δ ∣ Σ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ ⊑ B [ α ]ᴿ
+open-widening {μ = μ} {Σ = Σ} {α = α} α<Δ c⊑ =
+  subst
+    (λ Σ′ → μ ∣ _ ∣ Σ′ ⊢ _ ∶ _ ⊑ _)
+    (renameStoreᵗ-single-suc-cancel α Σ)
+    (widen-renameᵗ
+      (singleRenameᵗ-Wf-< α<Δ)
+      (single-mode-rename-lower μ α)
+      c⊑)
+
+open-all-narrowing :
+  ∀ {μ Δ Σ α c A B} →
+  α < Δ →
+  μ ∣ Δ ∣ Σ ⊢ `∀ c ∶ `∀ A ⊒ `∀ B →
+  μ ∣ Δ ∣ Σ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ ⊒ B [ α ]ᴿ
+open-all-narrowing α<Δ (cast-all c⊢ , cross (`∀ cⁿ)) =
+  open-narrowing α<Δ (c⊢ , cⁿ)
+
+open-all-widening :
+  ∀ {μ Δ Σ α c A B} →
+  α < Δ →
+  μ ∣ Δ ∣ Σ ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  μ ∣ Δ ∣ Σ ⊢ c [ α ]ᶜ ∶ A [ α ]ᴿ ⊑ B [ α ]ᴿ
+open-all-widening α<Δ (cast-all c⊢ , cross (`∀ cʷ)) =
+  open-widening α<Δ (c⊢ , cʷ)
+
+allocate-all-narrowing :
+  ∀ {μ Δ Σ Aν c A B} →
+  μ ∣ Δ ∣ Σ ⊢ `∀ c ∶ `∀ A ⊒ `∀ B →
+  extᵈ μ ∣ suc Δ ∣ (zero , Aν) ∷ ⟰ᵗ Σ ⊢ c ∶ A ⊒ B
+allocate-all-narrowing (cast-all c⊢ , cross (`∀ cⁿ)) =
+  narrow-weaken ≤-refl StoreIncl-drop (c⊢ , cⁿ)
+
+allocate-all-widening :
+  ∀ {μ Δ Σ Aν c A B} →
+  μ ∣ Δ ∣ Σ ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  extᵈ μ ∣ suc Δ ∣ (zero , Aν) ∷ ⟰ᵗ Σ ⊢ c ∶ A ⊑ B
+allocate-all-widening (cast-all c⊢ , cross (`∀ cʷ)) =
+  widen-weaken ≤-refl StoreIncl-drop (c⊢ , cʷ)
+
+allocate-gen-narrowing :
+  ∀ {μ Δ Σ Aν c A B} →
+  μ ∣ Δ ∣ Σ ⊢ gen A c ∶ A ⊒ `∀ B →
+  genᵈ μ ∣ suc Δ ∣ (zero , Aν) ∷ ⟰ᵗ Σ
+    ⊢ c ∶ ⇑ᵗ A ⊒ B
+allocate-gen-narrowing (cast-gen hA occ c⊢ , gen cⁿ) =
+  narrow-weaken ≤-refl StoreIncl-drop (c⊢ , cⁿ)
 
 ------------------------------------------------------------------------
 -- Basic structural lemmas

--- a/GTSF/proof/NuDGGSpine.agda
+++ b/GTSF/proof/NuDGGSpine.agda
@@ -1,0 +1,415 @@
+module proof.NuDGGSpine where
+
+-- File Charter:
+--   * Connects the public gradual-language DGG statement to a closed Nu-term
+--     operational DGG theorem.
+--   * Checks that compiler monotonicity produces exactly the initial relation
+--     consumed by the operational theorem.
+--   * Leaves one explicit proof boundary: `ClosedNuDGG`, whose four clauses
+--     are the forward and backward convergence/divergence obligations.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥-elim)
+open import Data.List using ([])
+open import Data.Product using (_×_; _,_; Σ-syntax; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using (subst)
+
+open import Types
+open import Ctx using (ctxWf-[])
+open import CompileTermImprecision using
+  (compile-preserves-term-imprecision)
+open import DynamicGradualGuarantee using
+  ( Convergesᶜ
+  ; Divergesᶜ
+  ; DivergeOrBlameᶜ
+  ; GradualDGG
+  ; compiled-left
+  ; compiled-right
+  )
+open import GradualTermImprecision using
+  ( _∣_∣_∣_⊢ᴳ_⊑_⦂_⊑_∶_
+  ; gradual-term-imprecision-source-typing
+  ; gradual-term-imprecision-target-typing
+  )
+open import ImprecisionWf using (ImpCtx; _∣_⊢_⊑_⊣_)
+open import NuReduction using
+  ( StoreChanges
+  ; applyStores
+  ; applyTyCtxs
+  ; applyTys
+  ; _—→[_]_
+  ; _—↠[_]_
+  )
+open import NuTermImprecision using
+  ( CtxImp
+  ; StoreImp
+  ; leftCtxⁱ
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  )
+open import NuMetaTheory using
+  ( multi-preservation
+  ; multi-runtime-preservation
+  ; progress
+  )
+open import NuStore using (StoreWf)
+open import NuTerms using
+  ( RuntimeOK
+  ; Term
+  ; Value
+  ; blame
+  ; _∣_∣_⊢_⦂_
+  )
+open import proof.NuProgress using (Progress; crash; done; step)
+open import QuotientedTermImprecision using
+  ( _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  ; nu-term-imprecision-source-typing
+  )
+open import Run using (compileᵀ-runtime)
+open import TermTyping using (forget)
+
+------------------------------------------------------------------------
+-- Compiler boundary
+------------------------------------------------------------------------
+
+compiled-term-imprecision :
+  ∀ {M M′ A B} {p : [] ∣ 0 ⊢ A ⊑ B ⊣ 0} →
+  (M⊑M′ : [] ∣ 0 ∣ 0 ∣ [] ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p) →
+  [] ∣ 0 ∣ 0 ∣ [] ∣ []
+    ⊢ᴺ compiled-left M⊑M′ ⊑ compiled-right M⊑M′
+    ⦂ A ⊑ B ∶ p
+compiled-term-imprecision M⊑M′ =
+  compile-preserves-term-imprecision ctxWf-[] ctxWf-[] M⊑M′
+
+compiled-left-runtime :
+  ∀ {M M′ A B} {p : [] ∣ 0 ⊢ A ⊑ B ⊣ 0} →
+  (M⊑M′ : [] ∣ 0 ∣ 0 ∣ [] ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p) →
+  RuntimeOK (compiled-left M⊑M′)
+compiled-left-runtime M⊑M′ =
+  compileᵀ-runtime ctxWf-[]
+    (gradual-term-imprecision-source-typing M⊑M′)
+
+compiled-right-runtime :
+  ∀ {M M′ A B} {p : [] ∣ 0 ⊢ A ⊑ B ⊣ 0} →
+  (M⊑M′ : [] ∣ 0 ∣ 0 ∣ [] ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p) →
+  RuntimeOK (compiled-right M⊑M′)
+compiled-right-runtime M⊑M′ =
+  compileᵀ-runtime ctxWf-[]
+    (gradual-term-imprecision-target-typing M⊑M′)
+
+------------------------------------------------------------------------
+-- Observation-level consequences of terminal simulation
+------------------------------------------------------------------------
+
+empty-store-wf :
+  ∀ {Δ} →
+  StoreWf Δ []
+empty-store-wf =
+  record
+    { at = record { bound = λ (); wfTy = λ () }
+    ; unique = λ ()
+    }
+
+closed-left-store :
+  leftStoreⁱ {Φ = []} {Δᴸ = 0} {Δᴿ = 0} [] ≡ []
+closed-left-store = refl
+
+closed-left-ctx :
+  leftCtxⁱ {Φ = []} {Δᴸ = 0} {Δᴿ = 0} [] ≡ []
+closed-left-ctx = refl
+
+closed-nu-source-typing :
+  ∀ {N N′ A B p} →
+  [] ∣ 0 ∣ 0 ∣ [] ∣ [] ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+  0 ∣ [] ∣ [] ⊢ N ⦂ A
+closed-nu-source-typing {N = N} {N′ = N′} {A = A} {B = B} N⊑N′ =
+  subst (λ Σ → 0 ∣ Σ ∣ [] ⊢ N ⦂ A) closed-left-store
+    (subst (λ Γ →
+        0 ∣ leftStoreⁱ {Φ = []} {Δᴸ = 0} {Δᴿ = 0} []
+          ∣ Γ ⊢ N ⦂ A)
+      closed-left-ctx
+      (forget
+        (nu-term-imprecision-source-typing
+          {Φ = []} {Δᴸ = 0} {Δᴿ = 0} {ρ = []} {γ = []}
+          {M = N} {M′ = N′} {A = A} {B = B} N⊑N′)))
+
+target-convergence-implies-source-convergence :
+  ∀ {N N′} →
+  (∀ V′ χs′ →
+    N′ —↠[ χs′ ] V′ →
+    Value V′ →
+      (∃[ V ] (Σ[ χs ∈ StoreChanges ]
+        ((N —↠[ χs ] V) × Value V)))
+      ⊎ (∃[ χs ] (N —↠[ χs ] blame))) →
+  (∀ χs′ →
+    N′ —↠[ χs′ ] blame →
+    ∃[ χs ] (N —↠[ χs ] blame)) →
+  Convergesᶜ N′ →
+  Convergesᶜ N
+target-convergence-implies-source-convergence value-observation
+    blame-observation
+    (V′ , χs′ , N′↠V′ , inj₁ vV′)
+    with value-observation V′ χs′ N′↠V′ vV′
+target-convergence-implies-source-convergence value-observation
+    blame-observation
+    (V′ , χs′ , N′↠V′ , inj₁ vV′)
+    | inj₁ (V , χs , N↠V , vV) =
+  V , χs , N↠V , inj₁ vV
+target-convergence-implies-source-convergence value-observation
+    blame-observation
+    (V′ , χs′ , N′↠V′ , inj₁ vV′)
+    | inj₂ (χs , N↠blame) =
+  blame , χs , N↠blame , inj₂ refl
+target-convergence-implies-source-convergence value-observation
+    blame-observation
+    (V′ , χs′ , N′↠V′ , inj₂ refl)
+    with blame-observation χs′ N′↠V′
+target-convergence-implies-source-convergence value-observation
+    blame-observation
+    (V′ , χs′ , N′↠V′ , inj₂ refl)
+    | χs , N↠blame =
+  blame , χs , N↠blame , inj₂ refl
+
+source-divergence-follows-from-target-observations :
+  ∀ {N N′} →
+  (∀ V′ χs′ →
+    N′ —↠[ χs′ ] V′ →
+    Value V′ →
+      (∃[ V ] (Σ[ χs ∈ StoreChanges ]
+        ((N —↠[ χs ] V) × Value V)))
+      ⊎ (∃[ χs ] (N —↠[ χs ] blame))) →
+  (∀ χs′ →
+    N′ —↠[ χs′ ] blame →
+    ∃[ χs ] (N —↠[ χs ] blame)) →
+  Divergesᶜ N →
+  Divergesᶜ N′
+source-divergence-follows-from-target-observations
+    value-observation blame-observation N⇑ N′⇓ =
+  N⇑
+    (target-convergence-implies-source-convergence
+      value-observation blame-observation N′⇓)
+
+target-divergence-implies-source-diverge-or-blame :
+  ∀ {N N′ A B p} →
+  RuntimeOK N →
+  [] ∣ 0 ∣ 0 ∣ [] ∣ [] ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+  (∀ V χs →
+    N —↠[ χs ] V →
+    Value V →
+    ∃[ V′ ] (Σ[ χs′ ∈ StoreChanges ]
+      ((N′ —↠[ χs′ ] V′) × Value V′))) →
+  Divergesᶜ N′ →
+  DivergeOrBlameᶜ N
+target-divergence-implies-source-diverge-or-blame
+    {N = N} {N′ = N′} {A = A} {B = B}
+    okN N⊑N′ forward N′⇑ P { χs } N↠P
+    with progress
+      (multi-runtime-preservation
+        {Δ = 0} {Σ = []} {M = N} {A = A} {χs = χs}
+        empty-store-wf okN
+        (closed-nu-source-typing N⊑N′)
+        N↠P)
+      (multi-preservation
+        {Δ = 0} {Σ = []} {M = N} {A = A} {χs = χs}
+        empty-store-wf okN
+        (closed-nu-source-typing N⊑N′)
+        N↠P)
+target-divergence-implies-source-diverge-or-blame
+    {N = N} {N′ = N′} {A = A} {B = B}
+    okN N⊑N′ forward N′⇑ P { χs } N↠P
+    | crash P≡blame =
+  inj₁ P≡blame
+target-divergence-implies-source-diverge-or-blame
+    {N = N} {N′ = N′} {A = A} {B = B}
+    okN N⊑N′ forward N′⇑ P { χs } N↠P
+    | step { χ = χ } { N = Q } P→Q =
+  inj₂ (χ , Q , P→Q)
+target-divergence-implies-source-diverge-or-blame
+    {N = N} {N′ = N′} {A = A} {B = B}
+    okN N⊑N′ forward N′⇑ P { χs } N↠P
+    | done vP
+    with forward P χs N↠P vP
+target-divergence-implies-source-diverge-or-blame
+    {N = N} {N′ = N′} {A = A} {B = B}
+    okN N⊑N′ forward N′⇑ P { χs } N↠P
+    | done vP | V′ , χs′ , N′↠V′ , vV′ =
+  ⊥-elim (N′⇑ (V′ , χs′ , N′↠V′ , inj₁ vV′))
+
+------------------------------------------------------------------------
+-- Closed Nu operational theorem required by the public DGG
+------------------------------------------------------------------------
+
+ClosedNuDGG : Set₁
+ClosedNuDGG =
+  ∀ {N N′ A B} {p : [] ∣ 0 ⊢ A ⊑ B ⊣ 0} →
+  RuntimeOK N →
+  RuntimeOK N′ →
+  [] ∣ 0 ∣ 0 ∣ [] ∣ [] ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+    (∀ V χs →
+      N —↠[ χs ] V →
+      Value V →
+      ∃[ V′ ] (Σ[ χs′ ∈ StoreChanges ]
+      (∃[ Φ ] (Σ[ ρ ∈
+          StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
+      (Σ[ q ∈
+          (Φ ∣ applyTyCtxs χs 0
+            ⊢ applyTys χs A ⊑ applyTys χs′ B
+            ⊣ applyTyCtxs χs′ 0) ]
+        ((N′ —↠[ χs′ ] V′) ×
+         Value V′ ×
+         (leftStoreⁱ ρ ≡ applyStores χs []) ×
+         (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+         Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+           ⊢ᴺ V ⊑ V′
+           ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q))))))
+    × (Divergesᶜ N → Divergesᶜ N′)
+    × (∀ V′ χs′ →
+      N′ —↠[ χs′ ] V′ →
+      Value V′ →
+        (∃[ V ] (Σ[ χs ∈ StoreChanges ]
+        (∃[ Φ ] (Σ[ ρ ∈
+            StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
+        (Σ[ q ∈
+            (Φ ∣ applyTyCtxs χs 0
+              ⊢ applyTys χs A ⊑ applyTys χs′ B
+              ⊣ applyTyCtxs χs′ 0) ]
+          ((N —↠[ χs ] V) ×
+           Value V ×
+           (leftStoreⁱ ρ ≡ applyStores χs []) ×
+           (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+           Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+             ⊢ᴺ V ⊑ V′
+             ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q)))))
+        ⊎ (∃[ χs ] (N —↠[ χs ] blame))))
+    × (Divergesᶜ N′ → DivergeOrBlameᶜ N)
+
+
+forget-forward-terminal-worlds :
+  ∀ {N′ V A B χs} →
+  (∃[ V′ ] (Σ[ χs′ ∈ StoreChanges ]
+    (∃[ Φ ] (Σ[ ρ ∈
+        StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
+    (Σ[ q ∈
+        (Φ ∣ applyTyCtxs χs 0
+          ⊢ applyTys χs A ⊑ applyTys χs′ B
+          ⊣ applyTyCtxs χs′ 0) ]
+      ((N′ —↠[ χs′ ] V′) ×
+       Value V′ ×
+       (leftStoreⁱ ρ ≡ applyStores χs []) ×
+       (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+       Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+         ⊢ᴺ V ⊑ V′
+         ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q)))))) →
+  ∃[ V′ ] (Σ[ χs′ ∈ StoreChanges ]
+    ((N′ —↠[ χs′ ] V′) × Value V′))
+forget-forward-terminal-worlds
+    (V′ , χs′ , Φ , ρ , q , N′↠V′ , vV′ ,
+      left-eq , right-eq , V⊑V′) =
+  V′ , χs′ , N′↠V′ , vV′
+
+forget-backward-terminal-worlds :
+  ∀ {N V′ A B χs′} →
+  (∃[ V ] (Σ[ χs ∈ StoreChanges ]
+    (∃[ Φ ] (Σ[ ρ ∈
+        StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
+    (Σ[ q ∈
+        (Φ ∣ applyTyCtxs χs 0
+          ⊢ applyTys χs A ⊑ applyTys χs′ B
+          ⊣ applyTyCtxs χs′ 0) ]
+      ((N —↠[ χs ] V) ×
+       Value V ×
+       (leftStoreⁱ ρ ≡ applyStores χs []) ×
+       (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+       Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+         ⊢ᴺ V ⊑ V′
+         ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q)))))
+    ⊎ (∃[ χs ] (N —↠[ χs ] blame))) →
+  (∃[ V ] (Σ[ χs ∈ StoreChanges ]
+    ((N —↠[ χs ] V) × Value V)))
+    ⊎ (∃[ χs ] (N —↠[ χs ] blame))
+forget-backward-terminal-worlds
+    (inj₁ (V , χs , Φ , ρ , q , N↠V , vV ,
+      left-eq , right-eq , V⊑V′)) =
+  inj₁ (V , χs , N↠V , vV)
+forget-backward-terminal-worlds (inj₂ N↠blame) = inj₂ N↠blame
+
+
+closed-nu-terminal-simulation⇒closed-nu-dgg :
+  (∀ {N N′ A B} {p : [] ∣ 0 ⊢ A ⊑ B ⊣ 0} →
+    RuntimeOK N →
+    RuntimeOK N′ →
+    [] ∣ 0 ∣ 0 ∣ [] ∣ [] ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+      ( (∀ V χs →
+          N —↠[ χs ] V →
+          Value V →
+          ∃[ V′ ] (Σ[ χs′ ∈ StoreChanges ]
+          (∃[ Φ ] (Σ[ ρ ∈
+              StoreImp Φ (applyTyCtxs χs 0) (applyTyCtxs χs′ 0) ]
+          (Σ[ q ∈
+              (Φ ∣ applyTyCtxs χs 0
+                ⊢ applyTys χs A ⊑ applyTys χs′ B
+                ⊣ applyTyCtxs χs′ 0) ]
+            ((N′ —↠[ χs′ ] V′) ×
+             Value V′ ×
+             (leftStoreⁱ ρ ≡ applyStores χs []) ×
+             (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+             Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+               ⊢ᴺ V ⊑ V′
+               ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q))))))
+      × (∀ V′ χs′ →
+          N′ —↠[ χs′ ] V′ →
+          Value V′ →
+            (∃[ V ] (Σ[ χs ∈ StoreChanges ]
+            (∃[ Φ ] (Σ[ ρ ∈
+                StoreImp Φ (applyTyCtxs χs 0)
+                  (applyTyCtxs χs′ 0) ]
+            (Σ[ q ∈
+                (Φ ∣ applyTyCtxs χs 0
+                  ⊢ applyTys χs A ⊑ applyTys χs′ B
+                  ⊣ applyTyCtxs χs′ 0) ]
+              ((N —↠[ χs ] V) ×
+               Value V ×
+               (leftStoreⁱ ρ ≡ applyStores χs []) ×
+               (rightStoreⁱ ρ ≡ applyStores χs′ []) ×
+               Φ ∣ applyTyCtxs χs 0 ∣ applyTyCtxs χs′ 0 ∣ ρ ∣ []
+                 ⊢ᴺ V ⊑ V′
+                 ⦂ applyTys χs A ⊑ applyTys χs′ B ∶ q)))))
+              ⊎ (∃[ χs ] (N —↠[ χs ] blame))))
+      × (∀ χs′ →
+          N′ —↠[ χs′ ] blame →
+          ∃[ χs ] (N —↠[ χs ] blame)))) →
+  ClosedNuDGG
+closed-nu-terminal-simulation⇒closed-nu-dgg terminal
+    {N = N} {N′ = N′} {A = A} {B = B} okN okN′ N⊑N′
+    with terminal okN okN′ N⊑N′
+closed-nu-terminal-simulation⇒closed-nu-dgg terminal
+    {N = N} {N′ = N′} {A = A} {B = B} okN okN′ N⊑N′
+    | forward , backward , target-blame =
+  forward ,
+  source-divergence-follows-from-target-observations
+    (λ V′ χs′ N′↠V′ vV′ →
+      forget-backward-terminal-worlds
+        {N = N} {V′ = V′} {A = A} {B = B} {χs′ = χs′}
+        (backward V′ χs′ N′↠V′ vV′))
+    target-blame ,
+  backward ,
+  target-divergence-implies-source-diverge-or-blame
+    okN N⊑N′
+    (λ V χs N↠V vV →
+      forget-forward-terminal-worlds
+        {N′ = N′} {V = V} {A = A} {B = B} {χs = χs}
+        (forward V χs N↠V vV))
+
+------------------------------------------------------------------------
+-- Public theorem reduction
+------------------------------------------------------------------------
+
+closed-nu-dgg⇒gradual-dgg :
+  ClosedNuDGG →
+  GradualDGG
+closed-nu-dgg⇒gradual-dgg nu-dgg M⊑M′ =
+  nu-dgg
+    (compiled-left-runtime M⊑M′)
+    (compiled-right-runtime M⊑M′)
+    (compiled-term-imprecision M⊑M′)

--- a/GTSF/proof/NuDGGTraceAlignment.agda
+++ b/GTSF/proof/NuDGGTraceAlignment.agda
@@ -1,0 +1,90 @@
+module proof.NuDGGTraceAlignment where
+
+-- File Charter:
+--   * Connects weak one-step simulation results to terminal target traces.
+--   * Aligns each administrative target tail with an observed trace to a
+--     value or blame, and preserves the sound source-blame alternative.
+--   * Depends on Nu reduction determinism and the weak simulation interface.
+
+open import Agda.Builtin.Equality using (_≡_)
+open import Data.List using (_++_)
+open import Data.Product using (_×_; _,_; Σ-syntax; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+
+open import NuReduction using (_—↠[_]_)
+open import NuTermImprecision using (StoreImp)
+open import NuTerms using (Term; Value; blame)
+open import proof.NuImprecisionSimulation using
+  ( WeakOneStepOutcome
+  ; WeakOneStepResult
+  ; outcome-related
+  ; outcome-source-blame
+  )
+open WeakOneStepResult using
+  (targetResult; targetTail; targetTailChanges)
+open import proof.NuReductionDeterminism using
+  (target-tail-prefix-blame; target-tail-prefix-value)
+
+
+weak-result-target-prefix-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ ψs V}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : WeakOneStepResult ρ M N′ A B χ) →
+  N′ —↠[ ψs ] V →
+  Value V →
+  ∃[ θs ]
+    ((targetResult result —↠[ θs ] V) ×
+      (ψs ≡ targetTailChanges result ++ θs))
+weak-result-target-prefix-valueᵀ result N′↠V vV =
+  target-tail-prefix-value (targetTail result) N′↠V vV
+
+weak-result-target-prefix-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ ψs}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : WeakOneStepResult ρ M N′ A B χ) →
+  N′ —↠[ ψs ] blame →
+  ∃[ θs ]
+    ((targetResult result —↠[ θs ] blame) ×
+      (ψs ≡ targetTailChanges result ++ θs))
+weak-result-target-prefix-blameᵀ result N′↠blame =
+  target-tail-prefix-blame (targetTail result) N′↠blame
+
+
+weak-outcome-target-value-alignedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ ψs V}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepOutcome ρ M N′ A B χ →
+  N′ —↠[ ψs ] V →
+  Value V →
+  (Σ[ result ∈ WeakOneStepResult ρ M N′ A B χ ]
+    ∃[ θs ]
+      ((targetResult result —↠[ θs ] V) ×
+        (ψs ≡ targetTailChanges result ++ θs)))
+  ⊎ ∃[ χs ] (M —↠[ χs ] blame)
+weak-outcome-target-value-alignedᵀ (outcome-related result) N′↠V vV
+  with weak-result-target-prefix-valueᵀ result N′↠V vV
+weak-outcome-target-value-alignedᵀ (outcome-related result) N′↠V vV
+  | θs , result↠V , trace-eq =
+    inj₁ (result , θs , result↠V , trace-eq)
+weak-outcome-target-value-alignedᵀ
+    (outcome-source-blame {χs = χs} M↠blame) N′↠V vV =
+  inj₂ (χs , M↠blame)
+
+weak-outcome-target-blame-alignedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ ψs}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepOutcome ρ M N′ A B χ →
+  N′ —↠[ ψs ] blame →
+  (Σ[ result ∈ WeakOneStepResult ρ M N′ A B χ ]
+    ∃[ θs ]
+      ((targetResult result —↠[ θs ] blame) ×
+        (ψs ≡ targetTailChanges result ++ θs)))
+  ⊎ ∃[ χs ] (M —↠[ χs ] blame)
+weak-outcome-target-blame-alignedᵀ (outcome-related result) N′↠blame
+  with weak-result-target-prefix-blameᵀ result N′↠blame
+weak-outcome-target-blame-alignedᵀ (outcome-related result) N′↠blame
+  | θs , result↠blame , trace-eq =
+    inj₁ (result , θs , result↠blame , trace-eq)
+weak-outcome-target-blame-alignedᵀ
+    (outcome-source-blame {χs = χs} M↠blame) N′↠blame =
+  inj₂ (χs , M↠blame)

--- a/GTSF/proof/NuImprecisionDGG.md
+++ b/GTSF/proof/NuImprecisionDGG.md
@@ -1,0 +1,237 @@
+# Dynamic gradual guarantee via Nu-term imprecision
+
+## Checked definition boundary
+
+The compiler monotonicity theorem produces `QuotientedTermImprecision`, and
+the public DGG statement uses that same relation. The relation has checked
+source- and target-typing projections.
+
+### Reveal and conceal provenance
+
+The one-sided `conv↑` and `conv↓` rules no longer accept every structural
+conversion. They use `RevealConversion` and `ConcealConversion`. Each
+derivation records one seal name `α` and one sealed type `C`, and permits
+exactly:
+
+- identity at variables and atomic types;
+- unseal or seal at `α` and `C`;
+- contravariant conceal/reveal through arrows;
+- the corresponding shifted provenance beneath `∀`.
+
+In nominal notation, the essential clauses are
+
+\[
+\begin{aligned}
+  \mathsf{reveal}_{\alpha,C}(\alpha) &= \mathsf{unseal}\;\alpha\;C,\\
+  \mathsf{reveal}_{\alpha,C}(X) &= \mathsf{id}\;X,\\
+  \mathsf{reveal}_{\alpha,C}(A\to B)
+    &= \mathsf{conceal}_{\alpha,C}(A)
+       \to \mathsf{reveal}_{\alpha,C}(B),\\
+  \mathsf{reveal}_{\alpha,C}(\forall X.A)
+    &= \forall X.\mathsf{reveal}_{\alpha,C}(A),
+\end{aligned}
+\]
+
+with the dual clauses for conceal. The mechanized `∀` clause shifts the
+de Bruijn name and sealed type.
+
+Atomic identity deliberately remains legal when its *current* variable name
+equals the recorded seal name. This is required after opening a binder: a
+variable that was distinct from the seal before opening can collide with it,
+but the coercion must remain `id`.
+
+The checked renaming theorems are
+
+\[
+\begin{aligned}
+  \mathsf{renameReveal}&:
+    \mathsf{RevealConversion}(\mu,\alpha,C,c,A,B)
+    \Longrightarrow
+    \mathsf{RevealConversion}(\nu,\rho\alpha,\rho C,
+      \rho c,\rho A,\rho B),\\
+  \mathsf{renameConceal}&:
+    \mathsf{ConcealConversion}(\mu,\alpha,C,c,A,B)
+    \Longrightarrow
+    \mathsf{ConcealConversion}(\nu,\rho\alpha,\rho C,
+      \rho c,\rho A,\rho B),
+\end{aligned}
+\]
+
+assuming the type renaming and mode renaming are well formed. Their
+single-variable opening corollaries are `open-reveal-conversion` and
+`open-conceal-conversion`.
+
+### Paired conversions
+
+The quotiented relation has a paired-conversion judgment
+
+\[
+  \mathsf{PairedConversion}
+    (\Phi,\Delta_L,\Delta_R,\rho,c,c',p,q),
+\]
+
+where `p` relates the input types and `q` relates the output types. A paired
+reveal or conceal must refer to one `StoreCorresponds` witness. The witness
+may come from a physical `store-matched` entry or a correspondence-only link
+when the two stores allocated permuted binders in different orders. The
+generic term rule is
+
+\[
+  \frac{M \sqsubseteq_p M' \qquad c \mathrel{\sim_{p,q}} c'}
+       {M\langle c\rangle \sqsubseteq_q M'\langle c'\rangle}.
+\]
+
+The old special states that combined runtime-bullet instantiation and reveal
+casts have been removed. Matched allocation now produces a bare `α⊑αᵀ`
+derivation and then applies the paired-conversion rule. Left-only allocation
+produces `α⊑ᵀ` and then applies the one-sided reveal rule.
+
+### Right-only lifting
+
+Right-only `ν` and `ν ★` states use a repaired context transformation:
+
+\[
+\begin{aligned}
+  \Uparrow_R(X\mathrel{\sqsubseteq}\star)
+    &= X\mathrel{\sqsubseteq}\star,\\
+  \Uparrow_R(X\mathrel{\sqsubseteq}Y)
+    &= X\mathrel{\sqsubseteq}(Y+1).
+\end{aligned}
+\]
+
+Thus right-only lifting uses `⇑ᴿᵢ Φ`, with no invented fresh assumption.
+The checked theorem `⊑-target-lift-rightᵢ` states
+
+\[
+  \Phi;\Delta_L;\Delta_R\vdash A\sqsubseteq B
+  \Longrightarrow
+  \Uparrow_R\Phi;\Delta_L;\Delta_R+1
+    \vdash A\sqsubseteq\uparrow B.
+\]
+
+The former rule used `(0 ˣ⊑★) ∷ ⇑ᴸᵢ Φ`: it incremented the target context,
+shifted the source assumptions, and introduced an unrelated fresh assumption.
+
+## Checked operational lemmas
+
+The following allocation lemmas are checked in
+`proof.NuImprecisionSimulation`:
+
+- `matched-ν↑-allocation`;
+- `left-ν↑-allocation`;
+- `matched-νcast-allocation`;
+- `left-νcast-allocation`.
+
+The first two handle reveal conversions. The last two restore the `ν ★`
+path produced by `β-inst`. The matched `ν ★` proof applies the target
+widening first and the source widening second. It derives the intermediate
+bridge
+
+\[
+  \widehat\Phi;\Delta_L+1;\Delta_R+1
+    \vdash C \sqsubseteq \uparrow B'.
+\]
+
+internally by embedding the target widening into indexed type imprecision and
+composing it on the right of the body relation. Thus callers do not supply the
+bridge, and no generic paired-widening rule is needed. The left-only proof
+needs no bridge: its body derivation and lifted result relation are exactly the
+input and output indices of the source widening rule.
+
+`post-allocation-β-Λ•` checks
+
+\[
+  ((\uparrow(\Lambda X.V))\;\bullet)\langle s\rangle
+    \longrightarrow V\langle s\rangle.
+\]
+
+Its proof uses `open0-ext-suc-cancelᵐ`. The module also checks
+`post-β-inst`, `post-β-gen•`, `post-β-∀-reveal`, and
+`post-β-∀-conceal`.
+
+The `β-∀•` lemmas are significant. If
+
+\[
+  c : \mathsf{RevealConversion}
+    (\mathsf{ext}\,\mu,\alpha+1,\uparrow C,A,B),
+\]
+
+then
+
+\[
+  c[\alpha] :
+  \mathsf{RevealConversion}(\mu,\alpha,C,A[\alpha],B[\alpha]),
+\]
+
+and similarly for conceal. This is a provenance theorem, not an equation
+claiming that `c[α]` is a freshly recomputed `reveal`.
+
+The indexed opening theorem `⊑-open∀ᵢ` states
+
+\[
+  \frac{
+    (\alpha\sqsubseteq\beta)\in\Phi
+    \qquad
+    (0\sqsubseteq0)::\Uparrow\Phi;
+      \Delta_L+1;\Delta_R+1\vdash A\sqsubseteq B
+  }{
+    \Phi;\Delta_L;\Delta_R
+      \vdash A[\alpha]\sqsubseteq B[\beta]
+  }.
+\]
+
+`paired-β-∀-reveal` and `paired-β-∀-conceal` combine this theorem with
+conversion opening. They check both `β-∀•` steps and reconstruct
+`PairedConversion` for the opened coercions and opened input/output indices.
+
+## Trace evidence
+
+`NuExamplesFresh` records full rule-name traces for the polymorphic identity
+pair.
+
+| Program | Reduction-rule sequence | Result |
+|---|---|---|
+| `polyIdNat-app` | allocation, `β-Λ•`, `β-↦`, term β, seal/unseal | `7` |
+| `polyIdDyn-app` | allocation, `β-Λ•`, `β-seq`, `β-id`, `β-↦`, term β, seal/unseal | tagged `7` |
+| `tag-mismatch` | `β-seq`, `β-id`, failed tag/untag | blame |
+
+The two related executions are not lockstep. Tag-side administrative casts
+add steps before the executions rejoin.
+
+The checked `program-via-D` and `program-via-E` traces in
+`proof.MLBRouteOperationalExperiment` show a stronger difference. One route
+performs `β-inst`, a nested allocation, and then an outer allocation; the
+other performs the outer allocation before `β-inst` and the nested
+allocation. A simulation must tolerate differently ordered allocations under
+casts and `ν`.
+
+`ReductionTrace` is the reusable rule-name view of evaluator traces.
+
+## Simulation-up-to boundary
+
+The checked facts support an administrative up-to closure containing
+`β-Λ•`, `β-∀•`, `β-gen•`, `β-id`, and `β-seq`. These rules expose
+or reassociate compiled casts without term substitution or an observable tag
+decision.
+
+The closure should initially exclude:
+
+- `β-↦` and term β, which need application and substitution invariants;
+- `β-inst` together with `ν ★` allocation, because allocation changes the
+  store and therefore belongs in the separate allocation closure already
+  checked by `matched-νcast-allocation` and `left-νcast-allocation`;
+- tag/untag, which may produce a value or blame;
+- seal/unseal, until store-name coherence is explicit at that proof point.
+
+The closure itself has not been added. Its soundness theorem is the useful
+proof target.
+
+## Next proof boundary
+
+The two earlier focused obligations are discharged. The next boundary is at
+the term-relation level: use `paired-β-∀-reveal` and
+`paired-β-∀-conceal` after exposing the bare relation between `V •` and
+`V′ •`, then include that reconstruction in the administrative up-to
+soundness theorem. The adjacent `β-gen•` case must transport the narrowing
+coercion around this opened paired conversion. This work no longer requires a
+change to reveal/conceal or indexed type-imprecision.

--- a/GTSF/proof/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/NuImprecisionDGGProgress.md
@@ -1,0 +1,1825 @@
+# Nu-imprecision DGG progress
+
+This ledger tracks the checked path from `QuotientedTermImprecision` to the
+dynamic gradual guarantee. A checked item has been accepted by Agda without
+unsolved metas; a statement-only item has its intended interface written down
+but is not counted as proved.
+
+## Current objective
+
+Prove simulation coverage for reductions involving `ν`, `Λ`, `gen`, `inst`,
+and runtime type application `•`, beginning with the definition-sensitive
+cases.
+
+## Coverage ledger
+
+| Obligation | Status | Evidence or next issue |
+|---|---|---|
+| Matched ordinary `ν` allocation | checked | `matched-ν↑-allocation` |
+| Left-only ordinary `ν` allocation | checked | `left-ν↑-allocation` |
+| Right-only ordinary `ν` allocation | checked locally | `right-ν↑-allocation`; uses explicit intermediate index |
+| Matched `ν ★` allocation | checked | `matched-νcast-allocation` |
+| Left-only `ν ★` allocation | checked | `left-νcast-allocation` |
+| Right-only `ν ★` allocation | checked locally | `right-νcast-allocation`; uses explicit intermediate index |
+| Post-allocation `β-Λ•` reduction | checked for matched and left-only `ν` | `matched-ν↑-β-Λ•` and `left-ν↑-β-Λ•` |
+| Paired reveal `β-∀•` | checked through allocation | `matched-post-allocation-β-∀-conversionᵀ` |
+| Paired conceal `β-∀•` | checked through allocation | Same theorem handles both paired conversion forms |
+| One-sided reveal/conceal `β-∀•` | checked | Left/right reveal and conceal lemmas |
+| Generic narrowing/widening `β-∀•` | checked one-step boundary | Both constructor orders and all four combinations return `WeakOneStepResult` |
+| Source-only canonical-`∀` catchup | checked | Terminal, `α/Λ`, reveal, conceal, generic narrowing, and generic widening clauses |
+| `β-gen•` | partial | Matched reconstruction and one-sided administrative clause checked; source-allocation naturality remains |
+| `β-inst` followed by `ν ★` allocation | checked locally | Matched, left-only, and right-only two-step lemmas |
+| Polymorphic value-shape inversion | checked locally | `Λ`, `∀` cast, or `gen`; each forces one administrative step |
+| Quotiented `∀`-index inversion | checked locally | Representatives remain `∀`; ordinary witness is paired `∀` or source-only `ν` |
+| Swapped two-allocation context/store | checked locally | Crossed name assumptions and independent-order store links |
+| Swapped two-allocation relation boundary | checked locally | `allocation-crossedᵀ`; projections equal the two-`bind` traces |
+| Reduction under `ν` and `ν ★` | checked | Matched, source-only, and target-only outer frame lemmas |
+| `blame-ν` | checked outcome | Exceptional outcomes carry a source catchup to blame; source frames lift it with `ν-blame-tail` |
+| Administrative simulation-up-to | partial | Composition and all six `ν`-frame outcome maps are checked |
+| One-step Nu-imprecision simulation | partial | Direct quotient and generic `β-∀•` clauses are checked |
+| Terminal target-trace alignment | checked | Determinism makes every administrative `targetTail` a prefix of an observed trace to a value or blame |
+| Closed `GradualDGG` | checked reduction | `closed-nu-dgg⇒gradual-dgg` reduces it to `ClosedNuDGG`, which now follows from exactly three terminal simulation clauses |
+
+## Definition audit
+
+The right-only `ν` constructors use the target-only context transformation
+
+\[
+  \Uparrow_R(X\sqsubseteq\star)=X\sqsubseteq\star,
+  \qquad
+  \Uparrow_R(X\sqsubseteq Y)=X\sqsubseteq(Y+1).
+\]
+
+This correctly avoids inventing a source seal. It does not by itself provide
+the relation needed immediately after the target allocates:
+
+\[
+  N \sqsubseteq (\uparrow N')\,\bullet.
+\]
+
+The term relation now has a dual `⊑αᵀ` state with an explicit, well-typed
+post-allocation imprecision index. The right-only `ν` and `ν ★` constructors
+carry this index as an invariant, so allocation cannot manufacture a relation
+between the unchanged source type and the opened target body.
+
+The first relational `β-Λ•` proof exposed a second store boundary. A `Λ` body
+is related under the shifted old store, while allocation adds a fresh entry.
+The `allocation-matchedᵀ` and `allocation-leftᵀ` rules cross exactly this
+extension. They require a `LiftStoreⁱ` or `LiftLeftStoreⁱ` witness for the tail
+and explicit refined typings under the extended stores; they do not permit
+arbitrary store replacement.
+
+## Work sequence
+
+1. Add and validate the right-only post-allocation bullet state. — checked
+2. Prove right-only ordinary `ν` and `ν ★` allocation. — checked locally
+3. Prove relational post-allocation `β-Λ•` lemmas. — matched and left-only checked
+4. Prove one-sided and generic-cast `β-∀•` lemmas. — checked locally
+5. Prove relational `β-gen•` transport. — matched body checked locally
+6. Connect `β-inst` to `ν ★` and its allocation step. — checked locally
+7. Prove `ξ-ν`, `blame-ν`, and store-change composition. — checked
+8. Package administrative reductions into a sound simulation-up-to closure.
+9. Prove one-step simulation and lift it to `GradualDGG`.
+
+## Log
+
+### 2026-07-14
+
+- Created this ledger.
+- Began the right-only allocation audit.
+- Confirmed that `⇑ᴿᵢ` and `⊑-target-lift-rightᵢ` cover the final result index,
+  but a separate relation is needed for the bare target bullet before its
+  reveal or widening conversion is applied.
+- Added `⊑αᵀ` and strengthened the right-only `ν` and `ν ★` states with the
+  intermediate post-allocation type-imprecision index.
+- Proved `right-ν↑-allocation` and `right-νcast-allocation`.
+- Added fresh allocation-store extension rules constrained by the existing
+  store-lift witnesses.
+- Proved matched and left-only allocation followed by `β-Λ•`, ending in a
+  related pair after the reveal conversion.
+- Lifted paired and one-sided reveal/conceal `β-∀•` facts to complete
+  term-relation simulation lemmas.
+- Consolidated the binder-opening mode renaming as
+  `single-mode-rename-lower` in `proof.CoercionProperties`.
+- Proved `open-narrowing`, `open-widening`, `open-all-narrowing`, and
+  `open-all-widening`. In nominal form, the latter two establish
+
+  \[
+    c : \forall X.A \mathrel{\trianglerighteq} \forall X.B
+    \Longrightarrow
+    c[\alpha] : A[\alpha/X]
+      \mathrel{\trianglerighteq} B[\alpha/X],
+  \]
+
+  and its widening dual.
+- Proved the four generic one-sided term simulations
+  `left-β-∀-narrowingᵀ`, `left-β-∀-wideningᵀ`,
+  `right-β-∀-narrowingᵀ`, and `right-β-∀-wideningᵀ`.
+- Proved `post-allocation-β-gen•-bare` and its cast-context lifting. The
+  reduction uses
+
+  \[
+    ((\uparrow V)\langle
+       \mathsf{gen}\;(\uparrow A)\;(\uparrow c)\rangle)\,\bullet
+    \longrightarrow
+    (\uparrow V)\langle c\rangle,
+  \]
+
+  where opening the shifted coercion cancels back to `c`.
+- Proved `allocate-gen-narrowing`, which transports the original `gen` body
+  narrowing under the exact fresh store extension.
+- Proved `matched-gen-left-incompatible` and
+  `matched-gen-right-incompatible`. A one-sided `gen` body rule would require
+  `0 ˣ⊑★`, but matched allocation provides only `0 ˣ⊑ˣ 0`.
+- Added the paired `gen-down⊑gen-downᵀ` repair to the quotiented down-cast
+  judgment and proved `matched-post-allocation-β-genᵀ`. The final body casts
+  remain paired and quotiented, so no false one-sided star assumption is
+  introduced.
+- Proved `matched-β-inst-νcast-allocation`,
+  `left-β-inst-νcast-allocation`, and
+  `right-β-inst-νcast-allocation`. These package the complete administrative
+  boundary
+
+  \[
+    V\langle\mathsf{inst}\;B\;s\rangle
+      \longrightarrow \nu\star.V\;s
+      \longrightarrow
+      ((\uparrow V)\,\bullet)\langle s\rangle,
+  \]
+
+  including the `keep` then `bind ★` store-change trace and the appropriate
+  matched, left-only, or right-only post-allocation relation.
+- Added store-extension monotonicity for `RevealConversion` and
+  `ConcealConversion`. This preserves the exact single-seal provenance while
+  permitting allocation to add a fresh store entry.
+- Proved `post-allocation-polymorphic-value-step` and the matched/one-sided
+  relational corollaries. If a closed value has type `∀X.A`, then it has
+  exactly one of the shapes
+
+  \[
+    \Lambda X.V,
+    \qquad V\langle\forall X.c\rangle,
+    \qquad V\langle\mathsf{gen}\;A\;c\rangle,
+  \]
+
+  and its post-allocation runtime bullet takes the corresponding `β-Λ•`,
+  `β-∀•`, or `β-gen•` step. The latter two use shift/open cancellation, so
+  the reduct contains the original body coercion `c`.
+- Proved `open-allocated-paired-all-conversion`. A paired reveal or conceal
+  between outer `∀` coercions opens after allocation to a paired conversion
+  between their bodies. Its matched seal entry is transported to the shifted
+  store tail, while the newly allocated entry remains independent.
+- Proved `matched-post-allocation-β-∀-conversionᵀ`. In nominal form, from a
+  bare relation `V ⊑ V′` and a paired outer conversion, it reconstructs
+
+  \[
+    (\uparrow(V\langle\forall X.c\rangle))\,\bullet
+      \longrightarrow ((\uparrow V)\,\bullet)\langle c\rangle
+      \mathrel{\sqsubseteq}
+      ((\uparrow V')\,\bullet)\langle c'\rangle
+      \longleftarrow
+    (\uparrow(V'\langle\forall X.c'\rangle))\,\bullet.
+  \]
+
+  This single theorem covers both paired reveal and paired conceal.
+- Completed the generic one-sided cast compatibility audit. In addition to
+  `matched-gen-left-incompatible` and `matched-gen-right-incompatible`, proved
+  `matched-inst-left-incompatible` and `matched-inst-right-incompatible`.
+  Hence none of the four generic one-sided reconstruction rules can cross a
+  matched fresh-seal boundary:
+
+  \[
+    X\sqsubseteq X
+      \not\Longrightarrow X\sqsubseteq\star.
+  \]
+
+  Narrowing under a freshly opened `∀` uses `genᵈ`; widening uses `instᵈ`.
+  Both modes permit a star-changing cast at the fresh name, so their generic
+  compatibility predicates demand the unavailable `X ˣ⊑★` assumption.
+  This rules out a mutual structural lifting theorem for the current term
+  relation: at least the generic cast branches cannot be reconstructed with
+  their original one-sided constructors.
+- Proved outer-`∀` shape preservation and reflection for permutation
+  equivalence in `proof.ForallPermutationProperties`:
+
+  \[
+    \forall X.A \approx_{\forall} B
+      \Longrightarrow
+      \exists C.\;B=\forall X.C,
+    \qquad
+    A \approx_{\forall} \forall X.B
+      \Longrightarrow
+      \exists C.\;A=\forall X.C.
+  \]
+
+  Symmetry and transitivity are handled mutually; the adjacent-binder swap
+  case preserves the outer binder explicitly.
+- Proved `⊑ᵖ-all-representatives` and `⊑ᵖ-all-view`. Thus an index
+
+  \[
+    \forall X.A \sqsubseteq^{p} \forall X.B
+  \]
+
+  exposes polymorphic representatives `∀X.C` and `∀X.D`, an ordinary
+  imprecision derivation between them, and the surrounding permutation
+  equivalences. The ordinary derivation has exactly two possible shapes:
+
+  \[
+    \frac{C\sqsubseteq D}
+         {\forall X.C\sqsubseteq\forall X.D}
+    \qquad\text{or}\qquad
+    \frac{C\sqsubseteq\forall X.D}
+         {\forall X.C\sqsubseteq\forall X.D}\;\nu.
+  \]
+
+  The mechanized `AllImprecisionView` records this paired-versus-source-only
+  split without assuming that quotienting makes every outer binder matched.
+- Audited the adjacent-binder swap operationally. Opening only the first
+  binder does not preserve `≈∀`, because the two representatives instantiate
+  different logical binders first. The sound simulation unit for a direct
+  swap is therefore two allocations. If the newest names are `α₀` and `β₀`
+  and the preceding names are `α₁` and `β₁`, the required context is
+
+  \[
+    \alpha_0\sqsubseteq\beta_1,
+    \qquad
+    \alpha_1\sqsubseteq\beta_0,
+  \]
+
+  followed by the old assumptions shifted twice.
+- Added `swapRight∀∀ᵢ` and proved `⊑-swapRight01∀∀ᵢ`. The latter
+  transports an ordinary two-binder imprecision derivation by swapping only
+  the target's two fresh names:
+
+  \[
+    A\sqsubseteq B
+      \Longrightarrow
+    A\sqsubseteq \mathsf{swap}_{01}(B)
+  \]
+
+  under the crossed context above.
+- The existing `StoreImp` list could not represent this crossing: even when a
+  `store-matched` entry mentioned different names, both physical-store
+  projections inherited the same list order. Added correspondence-only
+  `store-link` entries and the `StoreCorresponds` judgment. Physical left and
+  right entries can now be ordered independently, while links record the
+  crossed name relation used by paired reveal/conceal conversions.
+- Added `crossedStoreⁱ`. Its checked projection equations are
+
+  \[
+  \begin{aligned}
+    \mathsf{leftStore}(\rho_{\times})
+      &= (\alpha_0,A_0),(\alpha_1,A_1),\mathsf{leftStore}(\rho),\\
+    \mathsf{rightStore}(\rho_{\times})
+      &= (\beta_0,B_0),(\beta_1,B_1),\mathsf{rightStore}(\rho).
+  \end{aligned}
+  \]
+
+  Meanwhile `crossedStoreⁱ-new-old` and `crossedStoreⁱ-old-new` expose the
+  crossed correspondences. Store links lift through matched, left-only, and
+  right-only allocation, and paired conversions now consume
+  `StoreCorresponds` rather than requiring a physically paired entry.
+- Moved `swapRight∀∀ᵢ` to the shared type-imprecision context API and
+  added `allocation-crossedᵀ` to the quotiented term relation. This rule is
+  deliberately not arbitrary store weakening: it requires two successive
+  `LiftStoreⁱ` witnesses for the old tail, adds exactly two physical entries
+  to each side, and installs only the crossed links
+
+  \[
+    \alpha_{\mathsf{new}}\sqsubseteq\beta_{\mathsf{old}},
+    \qquad
+    \alpha_{\mathsf{old}}\sqsubseteq\beta_{\mathsf{new}}.
+  \]
+
+  Its source- and target-typing projections are checked.
+- Proved `leftStoreⁱ-crossed-two-binds` and
+  `rightStoreⁱ-crossed-two-binds`. If the source allocates `Aold` then
+  `Anew`, while the target allocates `Bold` then `Bnew`, the final stores are
+
+  \[
+  \begin{aligned}
+    \mathsf{leftStore}(\rho_\times)
+      &= \mathsf{applyStores}
+           [\mathsf{bind}\;Aold,\mathsf{bind}\;Anew]
+           (\mathsf{leftStore}(\rho)),\\
+    \mathsf{rightStore}(\rho_\times)
+      &= \mathsf{applyStores}
+           [\mathsf{bind}\;Bold,\mathsf{bind}\;Bnew]
+           (\mathsf{rightStore}(\rho)).
+  \end{aligned}
+  \]
+
+  Thus the crossed state supplies the store equalities required by the
+  public DGG, rather than merely having the right list shape.
+- Proved the two direct-swap administrative traces. In nominal notation, the
+  left route reduces in the order
+
+  \[
+    \beta_{\mathsf{inst}};
+    \mathsf{alloc}\;\alpha_1;
+    \beta_{\forall\bullet};
+    \beta_{\Lambda\bullet};
+    \mathsf{alloc}\;\alpha_0;
+    \beta_{\forall\bullet};
+    \beta_{\mathsf{gen}\bullet},
+  \]
+
+  while the right route reduces in the opposite allocation order
+
+  \[
+    \mathsf{alloc}\;\beta_1;
+    \beta_{\forall\bullet};
+    \beta_{\mathsf{gen}\bullet};
+    \beta_{\mathsf{inst}};
+    \mathsf{alloc}\;\beta_0;
+    \beta_{\forall\bullet};
+    \beta_{\Lambda\bullet}.
+  \]
+
+  Both are seven checked small steps. Their exposed bodies are
+
+  \[
+    \uparrow W
+    \qquad\text{and}\qquad
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)W'.
+  \]
+- Added the exact quotient boundary `swapRight-bodyᵀ` and proved
+  `crossed-bodyᵀ`. From a body relation `W \sqsubseteq W'` below the first
+  `∀`, the latter derives
+
+  \[
+    \uparrow W
+      \sqsubseteq
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)W'
+  \]
+
+  under `swapRight∀∀ᵢ`. This is deliberately narrower than a general lifting
+  theorem: it requires both store-lift witnesses and explicit typing of the
+  renamed endpoints.
+- Proved the two type derivations consumed by the crossed allocation:
+
+  \[
+  \begin{aligned}
+    \uparrow^2 A_{\mathsf{obs}}
+      &\sqsubseteq \uparrow^2 B_{\mathsf{obs}},\\
+    \star &\sqsubseteq \star.
+  \end{aligned}
+  \]
+
+  The first is `⊑-crossed-double-lift∀∀ᵢ`; the second is `id★`.
+  `⊑-crossed-body-lift∀∀ᵢ` supplies the adjacent-binder-permuted body index.
+- Proved `paired-swap-gen-inst-allocationᵀ`. It combines the two traces,
+  feeds the crossed body and the two instantiation-type relations to
+  `allocation-crossedᵀ`, then rebuilds the exposed paired `gen` narrowing,
+  paired `inst` widening, and final paired reveal conversion over the crossed
+  store.
+- Proved `left-swap-reveal-conversion` and
+  `right-swap-reveal-conversion`. They derive the final reveal premises from
+  the original outer `ν` premises. On the left,
+
+  \[
+    s \longmapsto
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)s
+  \]
+
+  and the inner `★` entry is inserted second. On the right,
+
+  \[
+    s' \longmapsto \uparrow s'
+  \]
+
+  and the inner `★` entry is inserted first. The resulting conversions reveal
+  `α₀` and `β₁`, respectively, so `crossedStoreⁱ-new-old` supplies their
+  paired correspondence.
+- Strengthened `paired-swap-gen-inst-allocationᵀ` to accept the original
+  outer reveal conversions at the one-binder stores. It now performs both
+  conversion transports internally before applying `conv⊑convᵀ`.
+- Proved direct inversion lemmas for the paired administrative coercions:
+
+  \[
+  \begin{array}{rcl}
+    \forall X.\mathsf{gen}\;A\;d
+      &: & \forall X.A \;\Rrightarrow\;
+           \forall X.\forall Y.D,\\
+    \mathsf{gen}\;(\forall X.B)\;(\forall Y.d')
+      &: & \forall X.B \;\Rrightarrow\;
+           \forall Y.\forall X.D',\\
+    \mathsf{inst}\;(\forall X.E)\;(\forall Y.u)
+      &: & \forall Y.\forall X.D \;\Rrightarrow\;
+           \forall X.E,\\
+    \forall Y.(\mathsf{inst}\;E'\;u')
+      &: & \forall Y.\forall X.D' \;\Rrightarrow\;
+           \forall Y.E'.
+  \end{array}
+  \]
+
+  Inverting their `cast-all`, `cast-gen`, and `cast-inst` premises derives
+
+  \[
+  \begin{aligned}
+    d  &: \uparrow A \Rrightarrow D,
+      &d' &: \operatorname{rename}(\operatorname{ext}\,\uparrow)B
+              \Rrightarrow D',\\
+    u  &: D \Rrightarrow
+             \operatorname{rename}(\operatorname{ext}\,\uparrow)E,
+      &u' &: D' \Rrightarrow \uparrow E'.
+  \end{aligned}
+  \]
+
+  The derivations are then transported through the two store lifts. The left
+  widening body has mode
+  `extᵈ (instᵈ tag-or-idᵈ)` and uses the star at name `1`; the right
+  body has mode `instᵈ (extᵈ tag-or-idᵈ)` and uses the star at name
+  `0`.
+- Added `crossed-up⊑upᵀ`, the ordinary term-imprecision boundary for that
+  exact pair of widening modes. Its typing projections use
+  `cast-ext (cast-inst cast-tag-or-id)` on the left and
+  `cast-inst (cast-ext cast-tag-or-id)` on the right. This retains the seal
+  permission produced by each `inst` instead of imposing the old,
+  uninhabited `id-onlyᵈ` requirement on the exposed bodies.
+- Strengthened `paired-swap-gen-inst-allocationᵀ` again: its four coercion
+  arguments are now the original paired `∀gen`/`gen∀` narrowing and
+  `inst∀`/`∀inst` widening derivations. It derives the final typings of
+  `d`, `d'`, `u`, and `u'` internally before rebuilding the crossed body
+  relation.
+- Proved the symmetric crossed type transport
+  `⊑-crossed-left-body-lift∀∀ᵢ`. If
+
+  \[
+    E \sqsubseteq E'
+  \]
+
+  below one paired binder, it derives
+
+  \[
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)E
+      \sqsubseteq \uparrow E'
+  \]
+
+  in `swapRight∀∀ᵢ Φ`. This is the left-renaming counterpart of
+  `⊑-crossed-body-lift∀∀ᵢ`, which shifts the left endpoint and renames
+  the right endpoint.
+- Proved `crossed-lift-store`. From the first store lift supplied by the
+  `Λ⊑Λᵀ` inversion, it constructs an existential second store and a
+  `LiftStoreⁱ (swapRight∀∀ᵢ Φ)` witness. Each stored or linked
+  imprecision proof is transported with
+  `⊑-crossed-double-lift∀∀ᵢ`; left-only and right-only entries carry
+  their twice-shifted well-formedness evidence.
+- Proved `direct-swap-gen-inst-caseᵀ`. This is the integrated direct-adjacent
+  simulation case. It consumes the evidence exposed by the pre-reduction
+  constructor inversions:
+
+  \[
+  \begin{aligned}
+    W &\sqsubseteq W',\\
+    D &\sqsubseteq D' &&\text{below two paired binders},\\
+    E &\sqsubseteq E' &&\text{below one paired binder},\\
+    F &\sqsubseteq F',
+  \end{aligned}
+  \]
+
+  together with the observer relation, four full administrative coercion
+  typings, and two outer reveal conversions. It constructs `ρ₂`, the crossed
+  quotient index, the crossed `E` and `F` indices, the source's seven-step
+  trace, and the final Nu-term relation. Thus a caller no longer supplies the
+  hand-built `ρ₂`, `qD×`, `pE×`, or `pF×` setup.
+- Proved `right-swap-allocation-step-tail` and changed the two direct-swap
+  wrappers to expose the target trace in the form needed by forward
+  simulation. In nominal notation the target side is now factored as
+
+  \[
+    M' \longrightarrow_{\operatorname{bind} B_{\mathit{obs}}} N'
+       \longrightarrow^{6} P'.
+  \]
+
+  The first arrow is exactly the target step being simulated. The six-step
+  suffix is administrative closure through `β-∀•`, `β-gen•`, `β-inst`, the
+  inner `ν` allocation, the second `β-∀•`, and `β-Λ•`. The final crossed
+  relation is only required at `P'`, not at the transient state `N'`.
+- Added `nested-Λ-no•` and `nested-Λ-runtime-no•`, then moved
+  `direct-swap-gen-inst-caseᵀ` to the actual one-step premises. It now
+  consumes source `RuntimeOK` for the whole `ν` term and target `No•` for the
+  value allocated by the target `ν` step. It derives `No• W` and `No• W'`
+  internally before building the two administrative traces.
+- Audited constructor inversion for the direct quotient case. Exact term shape
+  does not determine the term-imprecision constructor: generic left- and
+  right-cast constructors overlap the paired `up⊑upᵀ` shape. Consequently,
+  the direct quotient witness must be dispatched while recursing on the
+  imprecision derivation; a standalone inversion function on only the two term
+  indices would be false.
+- Defined `WeakOneStepResult`, the general result of simulating one target
+  store-changing step. Given an observed target change `χ`, it records source
+  changes `χ̄`, target administrative changes `ψ̄`, final terms `N` and
+  `N'`, and a final store-imprecision witness `ρ'` such that
+
+  \[
+  \begin{aligned}
+    M &\longrightarrow^{\bar\chi} N,\\
+    M'_1 &\longrightarrow^{\bar\psi} N',\\
+    \operatorname{leftStore}(\rho')
+      &= \operatorname{applyStores}(\bar\chi,
+           \operatorname{leftStore}(\rho)),\\
+    \operatorname{rightStore}(\rho')
+      &= \operatorname{applyStores}(\bar\psi,
+           \operatorname{applyStore}(\chi,
+             \operatorname{rightStore}(\rho))),\\
+    N &\sqsubseteq N'.
+  \end{aligned}
+  \]
+
+  The final endpoint types carry equations to
+  `applyTys χ̄ A` and `applyTys ψ̄ (applyTy χ B)`. This admits the
+  nominal crossed endpoint
+  `renameᵗ (extᵗ suc) (⇑ᵗ F)` while recording that it equals the
+  two-step store-change action on `F`.
+- Proved `weak-one-step-direct-quotientᵀ`, the direct quotient clause for
+  derivation recursion. It packages `direct-swap-gen-inst-caseᵀ` as a
+  `WeakOneStepResult`, including both store projection equations from
+  `leftStoreⁱ-crossed-two-binds` and `rightStoreⁱ-crossed-two-binds`. Its
+  quotient premise includes an equality to the literal direct constructor
+
+  \[
+    q_D = \mathsf{quotient}^{p}
+      \;\mathsf{refl}
+      \;(\forall^{i}(\forall^{i}p_D))
+      \;\mathsf{swap},
+  \]
+
+  so this clause does not accidentally cover a transitive quotient witness.
+- Added the four generic `β-∀•` base and finishing clauses for weak
+  one-step simulation. The right clauses consume the observed target step
+  and return zero source steps; the left clauses consume the resulting body
+  relation and add the source catch-up step. All store projections are
+  definitional because every step has change `keep`.
+- Proved all four compositions with the left generic cast outermost:
+
+  \[
+    \begin{array}{c|cc}
+      & \text{target narrowing} & \text{target widening} \\
+      \hline
+      \text{source narrowing} & \checkmark & \checkmark \\
+      \text{source widening} & \checkmark & \checkmark
+    \end{array}
+  \]
+
+  These are
+  `weak-one-step-generic-β-∀-left-outer-narrowing-narrowingᵀ`,
+  `weak-one-step-generic-β-∀-left-outer-narrowing-wideningᵀ`,
+  `weak-one-step-generic-β-∀-left-outer-widening-narrowingᵀ`, and
+  `weak-one-step-generic-β-∀-left-outer-widening-wideningᵀ`.
+- Proved the symmetric four compositions with the right generic cast
+  outermost. The helper `weak-one-step-keep-source-catchupᵀ` packages the
+  already-derived source `keep` step after the right constructor reconstructs
+  the final relation. Thus exact term shape no longer leaves an uncovered
+  generic narrowing/widening order at this `β-∀•` boundary.
+- Generalized `WeakOneStepResult` so its final left and right type contexts
+  are explicit, with equations to the corresponding `applyTyCtxs` actions.
+  This matches the existing treatment of endpoint types and avoids dependent
+  transport through `StoreImp` when traces are concatenated.
+- Proved `weak-one-step-composeᵀ`. Given consecutive weak results separated
+  by the next observed target step, it produces one weak result whose traces
+  are
+
+  \[
+    \bar\chi_1 \mathbin{+\!+} \bar\chi_2
+    \qquad\text{and}\qquad
+    \bar\psi_1 \mathbin{+\!+}
+      (\chi_2 :: \bar\psi_2).
+  \]
+
+  Its context, endpoint-type, and store projection equations follow from
+  `applyTyCtxs-++`, `applyTys-++`, and `applyStores-++`. Its source and target
+  traces use `↠-trans`. No postulate or heterogeneous transport is needed.
+- Proved `weak-one-step-relatedᵀ`, the neutral result with zero source and
+  target-tail steps when the post-step terms are already related.
+- Added the symmetric crossed-widening constructor
+  `crossed-left-up⊑upᵀ`. It admits the mode pair forced by the reverse
+  adjacent swap:
+
+  \[
+    \mathsf{inst}(\mathsf{ext}(\mathsf{tag\mbox{-}or\mbox{-}id)) )
+    \quad\text{and}\quad
+    \mathsf{ext}(\mathsf{inst}(\mathsf{tag\mbox{-}or\mbox{-}id)) ).
+  \]
+
+  Its source and target typing projections use the corresponding nested cast
+  modes. This is a genuine relation clause: the existing crossed widening
+  admits only the opposite mode order.
+- Proved the reverse crossed body and administrative transports:
+  `crossed-left-bodyᵀ`, the four mirrored `gen`/`inst` coercion-body lemmas,
+  and the two mirrored reveal-conversion lemmas. The final body and reveal
+  shapes are
+
+  \[
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)W
+      \sqsubseteq \uparrow W',
+    \qquad
+    \uparrow s
+      \quad\text{and}\quad
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)s'.
+  \]
+- Proved `paired-reverse-swap-gen-inst-allocationᵀ`. It derives the opposite
+  allocation traces directly from the paired administrative forms:
+
+  \[
+    \begin{aligned}
+      \text{source:}&\quad A_{\mathit{obs}}\ ;\ \star,\\
+      \text{target:}&\quad \star\ ;\ B_{\mathit{obs}}.
+    \end{aligned}
+  \]
+
+  The target's first observed step is `keep`, exposing the inner `ν ★`; its
+  tail then performs the two allocations. The observer conversion uses the
+  old--new crossed-store correspondence, while the fresh `★` cells use the
+  new--old identity correspondence.
+- Proved `direct-reverse-swap-gen-inst-caseᵀ` for the literal quotient
+  witness
+
+  \[
+    q_D = \mathsf{quotient}^{p}
+      \;(\mathsf{sym}\;\mathsf{swap})
+      \;(\forall^{i}(\forall^{i}p_D))
+      \;\mathsf{refl}.
+  \]
+
+  It derives the crossed inner quotient by swapping the source index and
+  derives both outer crossed endpoints from the original nominal
+  imprecision premises.
+- Proved `weak-one-step-reverse-direct-quotientᵀ`. Its final endpoint is
+
+  \[
+    \uparrow\uparrow F
+      \sqsubseteq
+    \operatorname{rename}(\operatorname{ext}\,\uparrow)(\uparrow F'),
+  \]
+
+  and the right endpoint equation is exactly
+  `renameᵗ-ext-suc-comm suc F′`. Both store projections are discharged by
+  the existing two-bind crossed-store lemmas instantiated in the reverse
+  order.
+- Proved `direct-swap-residualᵖ` and `reverse-swap-residualᵖ`. These remove
+  the former assumption that the permutation remaining after the adjacent
+  swap is reflexive. In the direct orientation, if
+
+  \[
+    D \sqsubseteq E
+    \qquad\text{and}\qquad
+    \mathsf{swap}_{01}(E) \approx_{\forall} T,
+  \]
+
+  then the crossed context contains
+
+  \[
+    D \sqsubseteq^{p} T.
+  \]
+
+  The reverse lemma starts from
+  `S ≈∀ renameᵗ swap01ᵗ D` and derives `S ⊑ᵖ E`. Thus the local
+  operational swap preserves, rather than discards, the residual quotient
+  proof.
+- Added `direct-swap-residual-outerᵖ` and
+  `reverse-swap-residual-outerᵖ`. They construct the exact outer quotient
+  indices produced by the route-permutation proof:
+
+  \[
+    \mathsf{trans}\;\mathsf{swap}
+      \;(\forall(\forall\,r))
+    \qquad\text{or its symmetric orientation}.
+  \]
+
+  These lemmas make explicit that `≈∀-trans` here is proof structure for one
+  adjacent operational swap followed by a residual congruence; it is not an
+  additional runtime step.
+- Generalized `direct-swap-gen-inst-caseᵀ`,
+  `direct-reverse-swap-gen-inst-caseᵀ`, and both weak one-step wrappers to
+  consume these residual equivalences. The resulting inner
+  `gen-down⊑gen-downᵀ` derivation retains an arbitrary quotiented relation,
+  so later simulation recursion can expose the next local permutation only
+  when another reduction reaches it.
+- Packaged the synchronized reveal-allocation lemma as
+  `weak-one-step-matched-ν↑ᵀ`. For an observed target allocation
+  `bind A′`, it records the source allocation `bind A`, the matched fresh
+  store entry, the lifted endpoint relation
+
+  \[
+    \uparrow B \sqsubseteq \uparrow B',
+  \]
+
+  and both store projections as consequences of the supplied store lift.
+- Packaged the right-only reveal allocation as
+  `weak-one-step-right-ν↑ᵀ`. It uses zero source steps and returns the repaired
+  right-lifted context `⇑ᴿᵢ Φ`, a right-only fresh-store entry, and
+  `⊑-target-lift-rightᵢ pB`.
+- Added the analogous `ν ★` clauses
+  `weak-one-step-matched-νcastᵀ` and
+  `weak-one-step-right-νcastᵀ`. These are the allocation-facing recursion
+  interfaces reached after `β-inst`; they preserve the instantiation
+  widening evidence already reconstructed by `matched-νcast-allocation` and
+  `right-νcast-allocation`.
+- Strengthened `WeakOneStepResult` with two world-action laws. For every
+  observer relation (C \sqsubseteq D), `transportType` returns
+
+  \[
+    \operatorname{applyTys}(\bar\chi,C)
+      \sqsubseteq
+    \operatorname{applyTys}
+      (\bar\psi,\operatorname{applyTy}(\chi,D)).
+  \]
+
+  For every body relation under a nominal type binder,
+  `transportAllBody` returns
+
+  \[
+    \operatorname{applyTysUnder}(\bar\chi,C)
+      \sqsubseteq
+    \operatorname{applyTysUnder}
+      (\bar\psi,\operatorname{applyTyUnder}(\chi,D)).
+  \]
+
+  The latter is not derivable merely by inverting the former: a relation
+  whose two endpoints are syntactic `∀` types may be headed by the
+  source-only `ν` rule rather than by `∀ⁱ`.
+- Proved the matched, right-only, crossed-double-allocation, neutral, and
+  compositional instances of both transport laws. The crossed body theorem
+  preserves the static binder at index zero while shifting the two runtime
+  allocations beneath it. The composition proof uses the new general lemma
+  `applyTysUnderTyBinders-++`.
+- Proved `lift-store-result`: every final store-imprecision witness can be
+  lifted under a fresh paired nominal binder. Each stored relation is mapped
+  by `⊑-lift∀ᵢ`; left-only and right-only entries use ordinary
+  well-formed type renaming.
+- Defined `WeakOneStepAllResult`, the recursive result interface for an input
+  relation headed by `∀ⁱ`. Besides the general weak result, it records the
+  canonical final body relation
+
+  \[
+    \operatorname{sourceResult}
+      \sqsubseteq
+    \operatorname{targetResult}
+      :
+    \forall\operatorname{applyTysUnder}(\bar\chi,C)
+      \sqsubseteq
+    \forall\operatorname{applyTysUnder}
+      (\bar\psi,\operatorname{applyTyUnder}(\chi,C'))
+  \]
+
+  with proof index
+  `∀ⁱ (transportAllBody weakResult q)`. The neutral constructor
+  `weak-one-step-all-relatedᵀ` is checked.
+- Proved `weak-one-step-matched-ν-frameᵀ`. Given a recursive
+  `WeakOneStepAllResult`, it lifts both traces through the whole outer term,
+  transports the paired single-seal reveal conversions across all source and
+  target-tail store changes, constructs the final lifted store, and rebuilds
+  the outer `ν⊑νᵀ` derivation.
+- Proved `apply-widen-inst-under-ty-binders` and
+  `weak-one-step-matched-νcast-frameᵀ`. The former iterates the existing
+  one-change `inst` widening preservation theorem, retaining the changing
+  cast mode and seal-store invariant. The latter uses it on both sides and
+  rebuilds the outer `νcast⊑νcastᵀ` derivation. Thus both matched outer
+  frame forms now use the same canonical `∀ⁱ` recursive interface.
+- Validated the focused modules and the aggregate development with
+  `agda --no-allow-unsolved-metas -v0 All.agda`.
+
+### 2026-07-15
+
+- Proved `weak-result-source-all`. A general recursive result whose source
+  endpoint initially has type `∀X.C` can be normalized to the explicit final
+  source type
+
+  \[
+    \forall X.\operatorname{applyUnder}(\bar\chi,C).
+  \]
+
+  This does not invert its term-imprecision derivation or assume that its
+  target endpoint is polymorphic.
+- Proved `lift-left-store-result` and the source-only outer frame lemmas
+  `weak-one-step-source-ν-frameᵀ` and
+  `weak-one-step-source-νcast-frameᵀ`. In nominal form, the ordinary frame
+  transports
+
+  \[
+    s : C \mathrel{\uparrow}
+      (\uparrow B)
+  \]
+
+  through every source allocation, lifts only the source store and context,
+  and reconstructs `ν⊑ᵀ`. The `ν ★` frame transports the corresponding
+  instantiation widening while preserving `CastMode` and `SealModeStore★`,
+  then reconstructs `νcast⊑ᵀ`.
+- Added `applyTy-∀`, which states
+
+  \[
+    \operatorname{applyTy}(\chi,\forall X.C)
+      = \forall X.\operatorname{applyUnder}(\chi,C),
+  \]
+
+  and used it to prove `weak-result-target-all`, the dual endpoint
+  normalization for a recursive result whose target is polymorphic.
+- Strengthened `WeakOneStepResult` with `transportRightBody`. Besides the
+  closed endpoint and paired-binder actions, every result now transports the
+  target-only crossed premise
+
+  \[
+    \Uparrow_R\Phi \mid \Delta_L
+      \vdash B \sqsubseteq C' \dashv \Delta_R,X
+  \]
+
+  to
+
+  \[
+    \Uparrow_R\Phi_f \mid \Delta_{L,f}
+      \vdash
+      \operatorname{applyTys}(\bar\chi,B)
+      \sqsubseteq
+      \operatorname{applyUnder}
+        (\bar\psi,\operatorname{applyUnder}(\chi,C'))
+      \dashv \Delta_{R,f},X.
+  \]
+
+  This premise is not derivable from the closed endpoint relation: it is the
+  separate invariant already required by `⊑νᵀ` and `⊑νcastᵀ`.
+- Proved `lift-right-store-result` and both target-only frame lemmas
+  `weak-one-step-target-ν-frameᵀ` and
+  `weak-one-step-target-νcast-frameᵀ`. They transport only the target reveal
+  or instantiation-widening evidence, lift only the target store and context,
+  and use `transportRightBody` to reconstruct the outer relation.
+- Proved the three allocation actions on the target-only crossed premise:
+  `⊑-lift-under-rightᵢ`, `⊑-target-lift-under-rightᵢ`, and
+  `⊑-crossed-double-lift-under-rightᵢ`. They respectively transport it
+  through a matched allocation, a target-only allocation, and the two
+  allocations whose target order is crossed. In every case the nominal
+  binder remains at index zero, so the target body is renamed by
+  `extᵗ suc`, not by `suc`.
+- Installed `transportRightBody` in every existing `WeakOneStepResult`
+  constructor. Neutral clauses use identity; outer frames forward the
+  recursive action; matched, right-only, and crossed allocations use the
+  three laws above. `weak-one-step-compose-right-body` proves that the action
+  is closed under simulation-up-to composition. The temporary
+  `WeakOneStepRightAllResult` wrapper was deleted after this generalization.
+- Defined `WeakOneStepOutcome`. A target step produces either a related
+  `WeakOneStepResult` or evidence that the more-precise source reduces to
+  `blame`. A target reduction to blame is not by itself a simulation outcome.
+- Proved `ν-blame-tail` and the three outcome maps
+  `weak-outcome-map-source`, `weak-outcome-map-target-ν`, and
+  `weak-all-outcome-map-target-ν`. Their six concrete corollaries cover
+  ordinary and `★` frames in matched, source-only, and target-only
+  orientations. Matched and source-only frames lift source blame through the
+  whole source `ν` term; target-only frames preserve source-blame evidence
+  unchanged.
+- Added `WeakOneStepAllOutcome`, which retains the canonical `∀ⁱ` result in
+  the related branch and shares the source-blame branch with the general
+  outcome.
+- Strictly validated the focused simulation module and the aggregate
+  development with no unsolved metas.
+- Audited the hypotheses needed by the total derivation-recursive dispatcher.
+  An arbitrary `StoreImp` does not imply store uniqueness, so the eventual
+  theorem should take well-formedness of the two projected stores as explicit
+  hypotheses. More importantly, the current matched `ν ★` allocation lemma is
+  not yet a usable leaf: it assumes
+
+  \[
+    \mathsf{RightCastCtxCompatible}
+      (\mathsf{inst}^{d}\,\mu')
+      (\mathsf{suc}\,\Delta_R)
+      ((0\mathbin{\smash{\sqsubseteq}}0)::\Uparrow\Phi),
+  \]
+
+  while `matched-inst-right-incompatible` proves that exact proposition
+  impossible. The analogous right-only `ν ★` leaf also asks for a global
+  compatibility premise that is not carried by `⊑νcastᵀ`. Consequently the
+  total dispatcher cannot obtain either premise by inversion of its input
+  derivation. No term- or type-imprecision definition was changed during this
+  audit.
+- Audited the smaller alternative of loosening the existing one-layer cast
+  rules instead of adding allocation constructors whose conclusions mention
+  both runtime bullet and cast nodes. For the quotiented relation,
+  `⊑cast⊑ᵀ` already takes its final type-imprecision derivation explicitly;
+  its `StoreDetWf` and `RightCastCtxCompatible` premises are therefore not
+  used by either typing projection. Removing those two premises repairs the
+  right-only `ν ★` state. The matched state cannot be obtained by merely
+  nesting the two one-sided rules: after applying either widening first, the
+  required intermediate type relation need not exist. It can instead use the
+  existing one-layer `conv⊑convᵀ` rule if that rule is broadened from paired
+  reveal/conceal evidence to the disjoint alternative of two well-typed
+  widening coercions. This proposal changes no type-imprecision rule and
+  subsumes the two previously proposed multi-node administrative
+  constructors. It was subsequently approved and implemented below.
+
+### 2026-07-16
+
+- Defined the proof-relevant invariant `PairedCast`. It has two cases:
+  `paired-conversion` embeds the existing exact paired reveal/conceal
+  judgment, while `paired-widening` records two `CastMode` witnesses, their
+  seal-store invariants, and the two widening typings. The existing
+  `conv⊑convᵀ` term rule now consumes `PairedCast`. Thus both alternatives
+  still introduce exactly one cast node on each side and share one simulation
+  case at the term-relation level.
+- Loosened the quotiented `⊑cast⊑ᵀ` rule. Before the change it required
+  `StoreDetWf` and `RightCastCtxCompatible` in addition to the target
+  widening and an explicit final type-imprecision derivation. After the
+  change it retains `CastMode`, `SealModeStore★`, the target widening typing,
+  the inner term relation, and the explicit final type relation, but removes
+  the two premises used only by the alternative route that derives that final
+  type relation. The non-quotiented rule in `NuTermImprecision` is unchanged.
+- Reproved `matched-νcast-allocation` using one `paired-widening` above the
+  existing bare-bullet `α⊑αᵀ` relation. There is no intermediate one-sided
+  type relation and no appeal to the impossible matched-inst compatibility
+  predicate.
+- Reproved `right-νcast-allocation` by applying the loosened `⊑cast⊑ᵀ`
+  directly to `⊑αᵀ` and its already-recorded crossed body relation. Removed
+  the false/unavailable compatibility and determinacy hypotheses from both
+  weak one-step allocation interfaces and from the matched and right-only
+  `β-inst` administrative traces.
+- Strictly validated `QuotientedTermImprecision.agda`,
+  `proof/NuImprecisionSimulation.agda`, and the aggregate `All.agda` with no
+  unsolved metas.
+- Factored source catchup into two proof-level invariants, without adding a
+  term-imprecision rule. For a weak result (R), `LeftSilentInvariant R`
+  states
+
+  \[
+    \overline\psi = \epsilon
+    \qquad\text{and}\qquad
+    \operatorname{target}(R) = V'.
+  \]
+
+  `LeftCatchupInvariant R` adds the exhaustive final-source classification
+
+  \[
+    (\operatorname{Value}(W) \land \operatorname{No\bullet}(W))
+      \;\lor\; W = \mathsf{blame}.
+  \]
+
+  The `No•` component is essential: a caught-up value can be supplied
+  directly to the operational `ν-step` rule. `LeftCatchupAllResult` combines
+  the same invariant with `WeakOneStepAllResult`, retaining the canonical
+  body relation for a nominal universal type
+  `∀X.C ⊑ ∀X.C'`.
+- Proved `weak-one-step-prepend-left-silentᵀ`. If a source-only prefix leaves
+  the target unchanged and a second weak result simulates the observed target
+  step, then their composition observes the second target change, concatenates
+  only the source histories, and retains only the second target tail. This is
+  the correct algebra for source catchup before a target step; ordinary weak
+  composition would incorrectly keep the prefix's observed `keep`.
+- Proved result-indexed transport for both allocation interfaces:
+  `weak-result-source-reveal` and `weak-result-target-reveal` transport the
+  two single-seal reveal conversions to the caught-up world, while
+  `weak-result-source-widen-inst` and `weak-result-target-widen-inst` transport
+  the corresponding `inst` widenings together with `CastMode` and
+  `SealModeStore★`.
+- Proved that matched ordinary and `★` frames preserve the silent-prefix
+  invariant. Then proved the value branches
+  `weak-one-step-matched-ν↑-value-catchupᵀ` and
+  `weak-one-step-matched-νcast-value-catchupᵀ`. In nominal form, both have the
+  same proof shape:
+
+  \[
+    N \longrightarrow^{\!*}_{L} W
+      \quad W \sqsubseteq V'
+      \quad \operatorname{Value}(W),\operatorname{No\bullet}(W)
+  \]
+
+  is first lifted through the whole `ν` frame, then followed by the existing
+  synchronized allocation leaf. The two lemmas differ only in whether the
+  transported boundary evidence is a pair of reveals or a pair of
+  instantiation widenings.
+- Proved `weak-one-step-source-blame-right-allocationᵀ`. It handles the
+  common crossed outcome after catchup:
+
+  \[
+    \nu X.\mathsf{blame}
+      \longrightarrow \mathsf{blame}
+    \qquad
+    \nu Y.V'
+      \longrightarrow
+      ((\uparrow V')\,\bullet)\langle s'\rangle.
+  \]
+
+  The proof uses target preservation for the observed allocation and then
+  applies `blame⊑ᵀ` at the right-lifted type relation. Consequently it is
+  independent of the target boundary coercion's reveal/widening shape. The
+  only additional theorem-level premise is the right projected store's
+  `StoreWf`, already identified as necessary for the total dispatcher.
+- Proved both blame branches after canonical-`∀` catchup and packaged the
+  exhaustive splits as `weak-one-step-matched-ν↑-catchupᵀ` and
+  `weak-one-step-matched-νcast-catchupᵀ`. Each dispatcher inspects only the
+  shared final-source invariant:
+
+  \[
+    (\operatorname{Value}(W)\land\operatorname{No\bullet}(W))
+      \lor W=\mathsf{blame}.
+  \]
+
+  Thus matched allocation now contributes one recursive clause per existing
+  outer term-imprecision constructor, not separate value and blame clauses.
+- Strictly validated the focused simulation module and the aggregate
+  `All.agda` development with `--no-allow-unsolved-metas` after adding the
+  catchup algebra and all four matched allocation outcome proofs.
+- Proved the constructor-independent terminal clauses
+  `left-catchup-all-valueᵀ` and `left-catchup-all-blameᵀ`. Thus a source
+  term already at a value or blame closes without inspecting how its
+  imprecision derivation was built. The value clause derives `No•` from
+  `RuntimeOK`, so the terminal invariant is not duplicated across term
+  constructors.
+- Proved `left-catchup-all-keep-stepᵀ` and the recursive algebra
+  `left-catchup-all-prepend-keepᵀ`. In nominal form, if
+
+  \[
+    M \longrightarrow_{\mathsf{keep}} N,
+    \qquad
+    N \sqsubseteq V',
+    \qquad
+    N \longrightarrow_L^{\!*} W \sqsubseteq V',
+  \]
+
+  then the combined catchup is
+
+  \[
+    M \longrightarrow_{\mathsf{keep}}
+      N \longrightarrow_L^{\!*} W \sqsubseteq V'.
+  \]
+
+  The target remains unchanged, and only the source trace is extended.
+  This one lemma is the shared recursion step for `β-Λ•`, `β-∀•`, and
+  `β-gen•`; no term-imprecision constructor is added.
+- Proved the direct `β-Λ•` terminal leaf and the stronger
+  `left-catchup-all-α-Λᵀ` clause. The latter handles the fact that the
+  allocation witness carried by the outer `α⊑ᵀ` state and the lift witness
+  carried by the inner `Λ⊑ᵀ` state may produce different proof-relevant
+  `StoreImp` lists. No equality between those lists is required. Both lifts
+  have the same left and right runtime-store projections, so the weak result
+  chooses the inner lift for the final body relation and discharges the store
+  equations by
+
+  \[
+    \operatorname{leftStore}(\rho_b)
+      = \uparrow\operatorname{leftStore}(\rho)
+      = \operatorname{leftStore}(\rho_a),
+    \qquad
+    \operatorname{rightStore}(\rho_b)
+      = \operatorname{rightStore}(\rho)
+      = \operatorname{rightStore}(\rho_a).
+  \]
+
+  This is the minimal coherence invariant needed at the direct
+  `α/Λ` boundary; strengthening the term relation with equality of lift
+  witnesses would be unnecessary.
+- Audited two attempted direct coverage splits for the active-bullet case.
+  Agda expands the hidden indexed cases for more than a minute even when the
+  source is fixed to `(\uparrow L)\,\bullet`. The probes were removed. The
+  checked proof instead uses explicit clauses for the three canonical
+  polymorphic value shapes and composes them with the shared `keep` algebra.
+- Factored `left-allocated-bulletᵀ`. From a source-only universal relation
+
+  \[
+    V \sqsubseteq V' : \forall X.A \sqsubseteq B'
+  \]
+
+  and the chosen left-allocation lift, it reconstructs
+
+  \[
+    (\uparrow V)\,\bullet \sqsubseteq V' : A \sqsubseteq B'
+  \]
+
+  together with the two endpoint typings under the allocated store. Both
+  one-layer `∀`-cast catchup clauses reuse this fact rather than rebuilding
+  the `α⊑ᵀ` state independently.
+- Proved `open-allocated-left-all-reveal` and
+  `open-allocated-left-all-conceal`. They open exactly one outer universal
+  conversion after source-only allocation, transport the shifted old store
+  through `LiftLeftStoreⁱ`, and weaken it with the fresh stored type. These
+  are the single-sided counterparts of the earlier paired conversion lemma;
+  they preserve the exact reveal/conceal shape.
+- Proved the recursive reveal and conceal clauses
+  `left-catchup-all-α-∀-revealᵀ` and
+  `left-catchup-all-α-∀-concealᵀ`. Both have the same nominal diagram:
+
+      (\uparrow(V⟨∀X.c⟩)) •     ⊑     V'
+                 |
+                 | one source `keep` step
+                 v
+        ((\uparrow V) •)⟨c⟩       ⊑     V'
+                 |
+                 | recursive catchup
+                 v
+                 W                  ⊑     V'
+
+  The first horizontal relation is rebuilt by `left-allocated-bulletᵀ`
+  followed by the existing one-sided conversion rule. The second vertical
+  segment is composed by `left-catchup-all-prepend-keepᵀ`. Thus the two
+  term-relation constructors contribute two expected simulation clauses, but
+  no additional term-relation rule.
+- Proved `allocate-all-narrowing` and `allocate-all-widening`. They expose the
+  body of a generic outer `∀` cast under one fresh source allocation while
+  preserving the extended cast mode. Proved `allocated-left-seal★` once for
+  the corresponding seal-store invariant.
+- Proved `left-catchup-all-α-∀-wideningᵀ`. It reconstructs the bare bullet
+  with `left-allocated-bulletᵀ`, applies the existing `cast⊑⊑ᵀ` rule to the
+  allocated body widening, and uses the shared `keep`-prepend algebra. Thus
+  generic widening needs no new term relation and no store determinacy.
+- Proved the focused impossibility fact
+  `fresh-shifted-var-store-not-det`:
+
+  \[
+    \neg\operatorname{StoreDetWf}
+      \bigl(2,[(0,\alpha_1)]\bigr).
+  \]
+
+  Here `α₁` is the shifted form of the open type variable `α₀`. The
+  `wfOlder` field would require `α₁` to be well formed at type context
+  length zero. Consequently `StoreDetWf` cannot in general be transported
+  through ordinary source-only allocation, even though the allocated store
+  is valid for term typing.
+
+### Approved minimal definition change
+
+The generic narrowing catchup clause reaches the same post-step shape as the
+checked widening clause, but the current quotiented `cast⊒⊑ᵀ` constructor
+requires `StoreDetWf` and `LeftCastCtxCompatible` in order to derive its final
+type-imprecision index internally. The impossibility lemma above rules out
+obtaining the determinacy premise from the allocation invariant in general.
+
+The smallest proposed repair is to make the quotiented narrowing constructor
+parallel to the already-loosened widening constructor. Before:
+
+\[
+\begin{aligned}
+  &\operatorname{CastMode}(\mu),\quad
+    \operatorname{StoreDetWf}(\Sigma_L),\quad
+    \operatorname{SealModeStore}_\star(\mu,\Sigma_L),\\
+  &\operatorname{LeftCastCtxCompatible}(\mu,\Phi),\quad
+    c : A \mathrel{\trianglerighteq} B,\quad
+    M \sqsubseteq M' : A \sqsubseteq B'\\
+  &\hspace{2em}\Longrightarrow
+    M\langle c\rangle \sqsubseteq M'
+      : B \sqsubseteq B'
+      \quad\text{at the internally derived index.}
+\end{aligned}
+\]
+
+After:
+
+\[
+\begin{aligned}
+  &\operatorname{CastMode}(\mu),\quad
+    \operatorname{SealModeStore}_\star(\mu,\Sigma_L),\quad
+    c : A \mathrel{\trianglerighteq} B,\\
+  &M \sqsubseteq M' : A \sqsubseteq B',\quad
+    q : B \sqsubseteq B'\\
+  &\hspace{2em}\Longrightarrow
+    M\langle c\rangle \sqsubseteq M' : B \sqsubseteq B'
+      \quad\text{at }q.
+\end{aligned}
+\]
+
+The quotiented `cast⊒⊑idᵀ` constructor is therefore redundant and has been
+removed, reducing rather than increasing the simulation cases. The
+non-quotiented `NuTermImprecision` definition remains unchanged. The user
+approved this smaller route, and the change above is now implemented.
+
+- Audited the remaining canonical `gen` value shape
+
+  \[
+    (\uparrow(V\langle\mathsf{gen}\;A\;c\rangle))\,\bullet
+      \longrightarrow_{\mathsf{keep}}
+    (\uparrow V)\langle c\rangle.
+  \]
+
+  In the ordinary one-sided term judgment, a single outer `gen` cast can only
+  be introduced by the generic source-narrowing constructor (the quotiented
+  `gen-down⊑gen-downᵀ` rule applies to paired downcasts underneath an
+  additional upcast). Therefore this case reaches exactly the same
+  `StoreDetWf` obstruction as generic outer-`∀` narrowing; it is not a
+  separate reason to add a term rule. Once the pending narrowing constructor
+  is loosened, the `gen` clause can use `allocate-gen-narrowing` and finish at
+  the already-value-shaped reduct.
+- Audited the proof-only allocation wrappers before beginning the total
+  dispatcher. `allocation-matchedᵀ`, `allocation-leftᵀ`, and the crossed
+  wrappers are currently constructed only by the simulation lemmas, not by
+  compilation of initial terms. A later target step may nevertheless receive
+  one of these derivations, so the total theorem still needs naturality of a
+  weak result under the corresponding stored world extension. This is a
+  separate recursive-world obligation; it does not repair or weaken the
+  generic narrowing premise and does not justify another term constructor.
+
+### Next boundary
+
+Both orientations of the adjacent-swap quotient branch and both orders of
+generic `β-∀•` casts now return the same `WeakOneStepResult`. The generic
+overlap has eight checked cases:
+
+\[
+  2\ \text{constructor orders}
+    \times 2\ \text{source directions}
+    \times 2\ \text{target directions} = 8.
+\]
+
+The result algebra for consecutive operational segments is checked, and the
+difficult primitive permutation and its inverse both have residual-preserving
+operational clauses. The earlier plan to interpret `≈∀-trans` itself by
+`weak-one-step-composeᵀ` was too eager. For the compiler-generated route
+proof, the transitive node packages one adjacent swap followed by a residual
+`≈∀-∀` congruence. The adjacent-swap clause now performs the runtime work and
+stores that congruence in the inner quotient index. Composition is needed
+only after a later target reduction actually exposes another local segment.
+
+The allocation leaves needed by a derivation-recursive one-step theorem have
+the common `WeakOneStepResult` interface. The ordinary matched and right-only
+`ν` leaves, the repaired matched and right-only `ν ★` leaves, and both crossed
+adjacent-swap orientations are usable directly. None of the instantiation
+allocation leaves now assumes a cast-compatibility proposition absent from
+its input term-imprecision derivation. Agda requires the eventual recursive
+function to be total, so it cannot be introduced as a one-clause partial
+definition.
+
+All six outer `ξ-ν` frame forms are now checked: ordinary and `★`, each in
+matched, source-only, and target-only orientation. The matched forms consume
+`WeakOneStepAllResult`; target-only forms use the general
+`transportRightBody` action; source-only forms need only explicit source
+endpoint normalization. Their outcome-level corollaries also propagate an
+inner source catchup to blame.
+
+The canonical-`∀` catchup base cases, shared `keep` recursion algebra,
+direct `α/Λ` leaf, single-sided reveal/conceal clauses, and both generic cast
+directions are now checked. The narrowing proof is
+`left-catchup-all-α-∀-narrowingᵀ`; it uses the loosened one-layer
+`cast⊒⊑ᵀ` rule with the explicit final witness `∀ⁱ q`. Thus the first
+remaining canonical value shape is complete:
+
+\[
+  (\uparrow(V\langle\forall X.c\rangle))\,\bullet.
+\]
+
+The administrative half of the `gen` shape is also checked by
+`left-catchup-all-α-gen-narrowingᵀ`:
+
+\[
+  (\uparrow(V\langle\mathsf{gen}\;A\;c\rangle))\,\bullet
+    \longrightarrow_{\mathsf{keep}}
+  (\uparrow V)\langle c\rangle.
+\]
+
+It uses `allocate-gen-narrowing`, the shared `keep`-prepend algebra, and the
+same loosened one-layer narrowing rule. Its only non-administrative premise
+is the transported inner relation
+
+\[
+  \nu\Phi;\Delta_L+1,\Delta_R;\rho^+
+    \vdash \uparrow V\sqsubseteq V'
+    :\uparrow A\sqsubseteq \forall X.C'.
+\]
+
+This isolates the next invariant: term imprecision must be natural under a
+one-sided source allocation. Proving that reusable transport is preferable
+to adding an `α/gen` rule, because it also addresses later recursion through
+proof-only allocation worlds. The β-gen clause itself needs no additional
+term-imprecision constructor.
+
+- Refactored all four β-`∀` overlap theorems containing source narrowing.
+  They now take the needed intermediate or final type-imprecision witness
+  explicitly. None retains `StoreDetWf`, `LeftCastCtxCompatible`, or an
+  internally derived source-cast index.
+- Proved the first reusable source-allocation naturality components:
+  `lifted-left-weakenCast-seal★`, `lifted-left-narrowing`, and
+  `lifted-left-widening` transport the cast evidence through the source type
+  shift. The constructor actions
+  `left-source-lift-cast-narrowingᵀ` and
+  `left-source-lift-cast-wideningᵀ` then rebuild exactly one shifted cast
+  node. `allocated-left-relationᵀ` adds the fresh runtime-store entry without
+  changing the term relation.
+- Strengthened `left-catchup-all-α-gen-narrowingᵀ` to consume its recursive
+  inner relation in the shifted store world `ρ′`; it uses
+  `allocated-left-relationᵀ` internally. Thus the remaining premise is now
+  precisely the output of the desired structural theorem:
+
+  \[
+  \begin{aligned}
+    &\Phi;\Delta_L,\Delta_R;\rho;\Gamma
+      \vdash M\sqsubseteq M' : A\sqsubseteq B\\
+    &\quad\Longrightarrow
+      \nu\Phi;\Delta_L+1,\Delta_R;\uparrow_L\rho;\uparrow_L\Gamma
+      \vdash \uparrow M\sqsubseteq M' : \uparrow A\sqsubseteq B.
+  \end{aligned}
+  \]
+
+  The difficult recursive clause is `Λ`: a source-only `ν` extension must
+  commute past a matched `∀` extension. The required type-index action is
+  already `⊑-∀ν-to-ν∀ᵢ`. The next proof should establish the corresponding
+  term/store/context naturality square and reuse it in the `Λ` clause. This
+  is a structural theorem, not a new term-imprecision constructor.
+- Proved the store half as `left-forall-store-square`. It constructs both
+  allocation orders
+
+  \[
+    \rho\xrightarrow{\nu_L}\rho_\nu
+      \xrightarrow{\forall}\rho_{\nu\forall},
+    \qquad
+    \rho\xrightarrow{\forall}\rho_\forall
+      \xrightarrow{\nu_L}\rho_{\forall\nu},
+  \]
+
+  without identifying their proof-relevant `StoreImp` witnesses, and proves
+
+  \[
+    \operatorname{left}(\rho_{\nu\forall})
+      =\operatorname{left}(\rho_{\forall\nu}),
+    \qquad
+    \operatorname{right}(\rho_{\nu\forall})
+      =\operatorname{right}(\rho_{\forall\nu}).
+  \]
+
+  Thus the remaining `Λ` obligation is the term-relation reindexing between
+  `∀(νΦ)` and `ν(∀Φ)`; no equality of world witnesses is needed.
+- Proved the inverse type-index transport `⊑-ν∀-to-∀νᵢ`:
+
+  \[
+    \nu(\forall\Phi)\vdash A\sqsubseteq B
+      \quad\Longrightarrow\quad
+    \forall(\nu\Phi)\vdash
+      \operatorname{swap}_{01}(A)\sqsubseteq B.
+  \]
+
+  Together with the earlier forward direction, this supplies both
+  orientations needed when source allocation and a matched universal binder
+  occur in opposite orders.
+- Proved the term-context analogue `left-forall-ctx-square`. It constructs
+  both lifting orders and identifies their erased left and right term
+  contexts. As for stores, the two `CtxImp` witnesses remain distinct.
+- Proved `left-source-lift-Λᵀ`. Once the body relation has been transported
+  into the `∀(νΦ)` corner, the existing `Λ⊑Λᵀ` constructor directly rebuilds
+  the shifted outer abstractions:
+
+  \[
+    \forall(\nu\Phi)\vdash
+      \operatorname{rename}(\operatorname{ext}(\mathsf{suc}),V)
+        \sqsubseteq V'
+    \quad\Longrightarrow\quad
+    \nu\Phi\vdash
+      \uparrow(\Lambda V)\sqsubseteq\Lambda V'.
+  \]
+
+  Therefore no new term-imprecision rule is missing at the outer `Λ`
+  boundary; only body naturality remains.
+- Added the general one-sided world-renaming infrastructure
+  `⊑-rename-leftᵢ`, `rename-left-storeⁱ`, and `rename-left-ctxⁱ`, with endpoint
+  equations, term-context lookup transport, and `StoreCorresponds` transport.
+  This captures the repeated non-binder cases once, rather than adding a
+  constructor for each administrative term shape.
+- Audited the attempted commutation of that map through `LiftStoreⁱ` and
+  `LiftCtxⁱ`. The type equation
+
+  \[
+    \operatorname{rename}(\operatorname{ext}(\tau),\uparrow A)
+      = \uparrow\operatorname{rename}(\tau,A)
+  \]
+
+  is propositional, while store and context entries retain their
+  type-imprecision proofs. Consequently erased endpoint equality cannot
+  transport the variable case, and a deterministic raw renaming map cannot
+  be definitionally identified with the normalized lifted world. The next
+  proof object must relate proof-relevant world entries while carrying these
+  endpoint equalities. This is the minimal binder-naturality invariant; it
+  does not require changing the term-imprecision definition.
+- Replaced the first proof-flexible `LeftStoreRenameⁱ` and
+  `LeftCtxRenameⁱ` attempt with a coherent version. Every matched, linked,
+  or term-context entry now contains exactly the canonical
+  `⊑-rename-leftᵢ` image of its input type-imprecision witness, transported
+  only along its recorded source-endpoint equality. Thus repeated uses of one
+  input witness have definitionally the same image.
+- Made `⊑-rename-leftᵢ` structural on type-imprecision derivations. In
+  particular,
+
+  \[
+    \mathsf{ren}_L(p_A\mapsto p_B)
+      = \mathsf{ren}_L(p_A)\mapsto\mathsf{ren}_L(p_B),
+    \qquad
+    \mathsf{ren}_L(\forall^i p)
+      = \forall^i\mathsf{ren}_L(p).
+  \]
+
+  This is the proof-level coherence needed by application and `Λ`; it is not
+  a new term-imprecision rule.
+- Proved coordinated binder actions `left-store-rename-∀`,
+  `left-ctx-rename-∀`, `left-store-rename-ν`, and `left-ctx-rename-ν`.
+  Each action constructs the target lifted world and its coherent body-world
+  relation together. The source endpoint equation at either binder is the
+  single naturality law
+
+  \[
+    \uparrow\mathsf{rename}(\tau,A)
+      = \mathsf{rename}(\mathsf{ext}(\tau),\uparrow A).
+  \]
+
+  No intermediate `ν(∀Φ)` world or adjacent-binder swap is needed when
+  crossing `Λ`; the direct body route is
+
+  \[
+    \forall\Phi \longrightarrow \forall(\nu\Phi)
+  \]
+
+  under `ext suc`.
+- Proved the canonical source-allocation bridges
+  `rename-left-store-source-liftⁱ`,
+  `rename-left-ctx-source-liftⁱ`, and `left-source-rename-worldsⁱ`.
+  These identify the desired outer source allocation with the coherent
+  renaming `suc` without adding an administrative term constructor.
+- Proved coherent erased-world equations for both stores and term contexts.
+  The left erasures are exactly renamed by `τ`, while the right erasures are
+  unchanged. These equations are the boundary needed to transport existing
+  typing and cast premises through the same invariant.
+- Reproved the focused variable and `Λ` actions against the coherent worlds,
+  and added the application action `left-rename-·ᵀ`. Application is rebuilt
+  directly with the existing `·⊑·ᵀ` constructor: the function and argument
+  recursive results now share the exact canonical image of `p_A`. This checks
+  the central reason for discarding the proof-flexible precursor.
+- Proved the erased typing transports `left-typing-renameⁱ` and
+  `right-typing-left-renameⁱ`, then checked the focused `blame` and `ƛ`
+  actions. Source typing uses the existing `CastModeRenamer`; target typing is
+  unchanged after transport across the right-erasure equations.
+- Proved general source-side seal-mode, narrowing, and widening transport as
+  `left-seal★-renameⁱ`, `left-narrowing-renameⁱ`, and
+  `left-widening-renameⁱ`. The focused `cast⊒⊑ᵀ` and `cast⊑⊑ᵀ`
+  actions now rebuild the two source-cast constructors under an arbitrary
+  coherent renaming. For source allocation the renamer is
+  `castModeRenamer-suc`; crossing `Λ` uses `castModeRenamer-ext`.
+- Added the small `LeftInsertion` invariant for the renamings that actually
+  occur in source allocation: `suc`, closed under `ext`. It supplies a mode
+  renaming for every mode environment, including those in reveal/conceal
+  conversions that do not carry a `CastMode` proof, and separately recovers
+  the existing `CastModeRenamer` for ordinary cast rules.
+- Proved coherent matched/link membership and `StoreCorresponds` transport.
+  Using it, proved source and target reveal/conceal transport,
+  `left-paired-conversion-renameⁱ`, `left-paired-cast-renameⁱ`, and the
+  focused `conv⊑convᵀ` action. Propositionally shifted seal names and source
+  types are eliminated at this boundary; no conversion-specific term rule is
+  added.
+- The remaining source-allocation theorem is derivation-recursive. The next
+  difficult clauses are the runtime-bullet allocation forms and the
+  quotiented narrowing layer. This is additional structure on the single
+  naturality theorem, not an expansion of term imprecision.
+- Audited closure of the three quotiented widening constructors under the
+  first source allocation. `up⊑upᵀ` is closed because `id-onlyᵈ` is stable,
+  but the two crossed rules are not. The checked lemmas
+  `no-crossed-up-mode-rename-id`,
+  `no-crossed-up-mode-rename-same`, and
+  `no-crossed-up-mode-rename-opposite` show that
+
+  \[
+    \mathsf{ext}(\mathsf{inst}(\mathsf{tag}))
+  \]
+
+  cannot be renamed by `suc` into any existing left mode. Conversely,
+  `crossed-left-mode-rename-opposite` shows that the other source orientation
+  can rename to the opposite left mode, but its unchanged right mode then
+  makes the pair match neither crossed rule.
+- The minimal repair under consideration is to generalize only the *left*
+  mode premises of `crossed-up⊑upᵀ` and `crossed-left-up⊑upᵀ` from their
+  hard-coded modes to an arbitrary `CastMode μ`, retaining the existing
+  `SealModeStore★ μ` and widening-typing premises. The right mode remains
+  fixed and therefore continues to record the quotient orientation. This
+  changes no AST shape and adds no constructor, but it is a term-imprecision
+  definition change.
+- The user approved that repair. Both constructors now quantify over a left
+  mode `μ` and require
+
+  \[
+    \mathsf{CastMode}(\mu),\qquad
+    \mathsf{SealModeStore}_{\star}(\mu,\Sigma_L),\qquad
+    \mu;\Delta_L;\Sigma_L\vdash u:D\sqsubseteq A.
+  \]
+
+  Their right modes are unchanged. The typing projections and the two existing
+  direct-swap constructions have been updated and checked.
+- Proved quotient-type naturality `⊑ᵖ-rename-leftᵢ`. Its only nonstructural
+  point is that adjacent-universal equivalence commutes with type renaming:
+
+  \[
+    A\approx_{\forall} C
+    \quad\Longrightarrow\quad
+    \operatorname{rename}(\tau,A)
+      \approx_{\forall}
+    \operatorname{rename}(\tau,C).
+  \]
+
+  The swap case uses `renameᵗ-swap01-ext²-commute`; the two outer binders
+  force `ext (ext τ)` to fix the swapped names `0` and `1`.
+- Proved the five quotient-layer constructor actions
+  `left-rename-up⊑upᵀ`, `left-rename-crossed-up⊑upᵀ`,
+  `left-rename-crossed-left-up⊑upᵀ`, `left-rename-down⊑downᵀ`, and
+  `left-rename-gen-down⊑gen-downᵀ`. The crossed actions use the approved
+  arbitrary left mode; the fixed `id-onlyᵈ` and `genᵈ tag-or-idᵈ` modes are
+  stable under every source renaming. Thus the quotient layer needs no new
+  term shape.
+- Refined the source-allocation theorem to the exact fragment needed by
+  `β-gen`: it assumes `No• M`. A source runtime bullet cannot satisfy this
+  premise, so the `α⊑αᵀ` and `α⊑ᵀ` branches are impossible. This is
+  essential: `⊢•` anchors its active seal at store name `0`, so unrestricted
+  source allocation is not a valid typing transformation for an arbitrary
+  bullet term. The right-only `⊑αᵀ` branch remains in scope because its
+  source term contains no bullet.
+- The next administrative boundary is repeated left allocation. If an existing
+  `allocation-leftᵀ` derivation adds `(0,A)` and another source allocation is
+  performed outside it, the transported entry is `(1,↑A)`. The current
+  constructor originally added only name `0`. The user approved replacing that
+  fixed name by an arbitrary source seal name `α`, while retaining its explicit
+  well-formedness and both final typing premises. This is implemented and
+  checked. It remains one proof-only store-extension constructor, not a new
+  term-imprecision shape.
+- Proved the proof-relevant allocation squares
+  `left-right-store-commuteⁱ` and `left-right-ctx-commuteⁱ`. Given source-only
+  and target-only allocations from the same world, they construct a single
+  crossed world reached in either order:
+
+  \[
+  \begin{array}{ccc}
+    (\rho,\Gamma) & \xrightarrow{\nu_L} &
+      (\rho_L,\Gamma_L) \\
+    \mathllap{\nu_R}\downarrow && \downarrow\mathrlap{\nu_R} \\
+    (\rho_R,\Gamma_R) & \xrightarrow{\nu_L} &
+      (\rho_\times,\Gamma_\times).
+  \end{array}
+  \]
+
+  The common target retains the transported type-imprecision witnesses, so
+  this is stronger than equality of erased stores and contexts.
+- Proved `⊑-source-under-rightᵢ`, which transports a body relation already
+  beneath a target-only allocation through a subsequent source allocation:
+
+  \[
+    \mathord{\uparrow_R\Phi};\Delta_L,\Delta_R+1
+      \vdash A\sqsubseteq B
+    \quad\Longrightarrow\quad
+    \mathord{\uparrow_R(\nu_L\Phi)};\Delta_L+1,\Delta_R+1
+      \vdash \uparrow A\sqsubseteq B.
+  \]
+
+  Using the allocation square and this type action,
+  `left-source-lift-⊑αᵀ` rebuilds the right-only runtime-bullet case after a
+  source allocation. This discharges the only bullet constructor compatible
+  with the theorem's `No•` source premise, without adding a term-imprecision
+  rule.
+- Proved `left-rename-Λ⊑ᵀ`, the coherent source-renaming action for the
+  one-sided polymorphic value relation
+
+  \[
+    \Lambda X.\,V \sqsubseteq N'.
+  \]
+
+  It transports the occurrence side condition by
+  `occurs-zero-rename-ext`, constructs the two `ν` body worlds with
+  `left-store-rename-ν` and `left-ctx-rename-ν`, and rebuilds the existing
+  `Λ⊑ᵀ` constructor directly. The matched and one-sided `Λ` boundaries are
+  therefore both closed under coherent source renaming.
+- Closed the three target-cast wrappers under coherent source renaming with
+  `left-rename-⊑cast⊒ᵀ`, `left-rename-⊑cast⊑ᵀ`, and
+  `left-rename-⊑cast⊑idᵀ`. Their right coercions are unchanged because the
+  right projected store is propositionally preserved. The `id-only` branch
+  uses `right-store-det-left-renameⁱ` to transport its `StoreDetWf` premise
+  across that same equation.
+- Closed all four one-sided reveal/conceal wrappers with
+  `left-rename-conv↑⊑ᵀ`, `left-rename-conv↓⊑ᵀ`,
+  `left-rename-⊑conv↑ᵀ`, and `left-rename-⊑conv↓ᵀ`. Source conversions use the
+  single `LeftInsertion` invariant; target conversions again transport across
+  the unchanged right store. These proofs rebuild existing constructors and
+  introduce no new imprecision cases.
+- The remaining ordinary nullary and congruence forms are direct. The next
+  binder-sensitive cluster is `ν⊑νᵀ`, `ν⊑ᵀ`, `⊑νᵀ`, and their three
+  `ν ★` analogues. Their term bodies use the structural recursive result, but
+  their source boundary conversion must also commute with the freshly
+  allocated concrete store. This conversion/store naturality is the next
+  proof boundary independent of the still-unapproved repeated-allocation
+  repair.
+- Proved the allocated ordinary-reveal transports
+  `left-reveal-ν-renameⁱ` and `right-reveal-ν-left-renameⁱ`. The source lemma
+  normalizes
+
+  \[
+    \operatorname{rename}(\operatorname{ext}\tau,
+      (0,\uparrow A)::\uparrow\Sigma_L)
+    =
+    (0,\uparrow\operatorname{rename}(\tau,A))::
+      \uparrow\operatorname{rename}(\tau,\Sigma_L),
+  \]
+
+  while the target lemma transports across the unchanged right projection.
+  Using these lemmas, `left-rename-νᵀ` and `left-rename-ν⊑ᵀ` close the matched
+  and left-only ordinary `ν` constructors.
+- Proved `rename-assm²-⇑ᴿᵢ` and the proof-relevant commuting actions
+  `left-store-rename-⇑ᴿ` and `left-ctx-rename-⇑ᴿ`. For an arbitrary coherent
+  source insertion, they construct a shared world obtained by applying that
+  insertion and a target-only allocation in either order. Unlike the earlier
+  erased square, the resulting matched, linked, and context entries contain
+  the exact structural images of their original type-imprecision witnesses.
+  `left-rename-⊑νᵀ` uses this square to close the right-only ordinary `ν`
+  constructor, including its body relation under `⇑ᴿᵢ`.
+- Proved the `ν ★` concrete-store normalization
+
+  \[
+    \operatorname{rename}(\operatorname{ext}\tau,
+      (0,\star)::\uparrow\Sigma_L)
+    =
+    (0,\star)::\uparrow\operatorname{rename}(\tau,\Sigma_L),
+  \]
+
+  together with source and target transports for both `SealModeStore★` and
+  the widening boundary coercion. The checked actions
+  `left-rename-νcastᵀ`, `left-rename-νcast⊑ᵀ`, and
+  `left-rename-⊑νcastᵀ` consequently close all three existing `ν ★`
+  constructors. Thus all six `ν`/`ν ★` term constructors are now structurally
+  closed without modifying imprecision.
+- The next step is to assemble these actions into the mutual derivation
+  recursion for the `No•` source fragment. Runtime source-bullet constructors
+  remain impossible, and the right-only bullet uses the already-checked
+  allocation square. The proof-only allocation wrappers are the remaining
+  administrative cases.
+- Proved the inverse proof-relevant allocation actions
+  `left-store-rename-⇑ᴿ-inv` and `left-ctx-rename-⇑ᴿ-inv`. If a coherent
+  source renaming is given *after* a target-only allocation, these lemmas
+  reconstruct a renamed pre-allocation world and a target-allocation witness
+  reaching the supplied final world. This is the direction needed by
+  derivation recursion through an already allocated state; it is not merely
+  an inverse equality on erased stores.
+- Proved `left-rename-⊑αᵀ` for arbitrary `LeftInsertion τ`. It uses the inverse
+  square to recursively transport the pre-allocation relation, then rebuilds
+  the existing right-only runtime-bullet constructor at
+
+  \[
+    \mathord{\uparrow_R\Psi};\Delta_L',\Delta_R+1
+      \vdash
+      \operatorname{rename}(\tau,N)
+      \sqsubseteq
+      (\uparrow L')\,\bullet.
+  \]
+
+  The final source and target typings are transported from the reconstructed
+  base world and the given allocated world, respectively. Hence all runtime
+  bullets are now covered by the `No•` recursion: `α⊑αᵀ` and `α⊑ᵀ` are
+  impossible on the source, while `⊑αᵀ` has a checked generic action.
+- The remaining recursive cases are the matched and crossed/swap proof-only
+  allocation wrappers. The ordinary syntax, quotient, `Λ`, conversion, cast,
+  all `ν` families, and `allocation-leftᵀ` now have constructor actions. The
+  next proof step is therefore the matched-allocation square followed by the
+  mutual recursion.
+- The user approved the minimal `allocation-leftᵀ` generalization. The rule
+  now quantifies an arbitrary seal name `α`; its three former occurrences of
+  `store-left zero A hA` are `store-left α A hA`. Its world, lifting premise,
+  inner relation, typings, and term endpoints are unchanged. Existing uses
+  continue to infer `α = zero`.
+- Proved `left-store-rename-ν-inv` and `left-ctx-rename-ν-inv`. These are the
+  inverse naturality squares for a fixed fresh binder: a coherent
+  `ext τ`-renaming of an already lifted world reconstructs the coherently
+  renamed base world and its left-lift witness.
+- Proved `left-store-rename-suc-liftⁱ`. At the opposite-order boundary, a
+  coherent `suc`-renaming from a world to its fresh left extension is itself a
+  `LiftLeftStoreⁱ` witness. This is deliberately separate from the `ext τ`
+  square because the outer allocation shifts the previously fresh name:
+
+  \[
+    0 \longmapsto 1,
+    \qquad
+    \mathsf{suc}(\alpha) \longmapsto
+      \mathsf{suc}(\mathsf{suc}(\alpha)).
+  \]
+
+- Proved `left-source-lift-allocation-leftᵀ`, the repeated-left-allocation
+  constructor action. It recursively accepts the renamed inner relation,
+  converts the tail renaming to the required lift, transports both final
+  typings, and rebuilds the existing wrapper with
+
+  \[
+    \mathsf{storeLeft}(\alpha,A)
+      \longmapsto
+    \mathsf{storeLeft}(\mathsf{suc}(\alpha),\uparrow A).
+  \]
+
+  This is the first checked use of the approved arbitrary seal name. No new
+  term-imprecision constructor or term shape was added.
+- Rechecked both strict targets after this change:
+  `proof/NuImprecisionSimulation.agda` and `All.agda` pass with
+  `--no-allow-unsolved-metas`.
+
+The target-`∀` inversion was also rechecked. It guarantees that the source
+type is universal, but the bodies of matched `Λ` values may still have any
+type and any term shape. Thus restricting naturality to universal-typed
+bodies would be unsound as a proof strategy.
+
+These pieces feed the total derivation-recursive one-step theorem with
+codomain `WeakOneStepOutcome`. Its ordinary operational leaves return
+`WeakOneStepResult` and can be injected with `outcome-related`. A target-blame
+leaf must first establish a source reduction to blame and then use
+`outcome-source-blame`. When the input type relation is headed by `∀ⁱ`,
+recursion returns `WeakOneStepAllOutcome`, retaining the canonical body
+derivation. The later audit of one-sided `β-gen•` shapes remains separate.
+
+The generic lifting obstruction remains useful: `crossed-bodyᵀ` closes only
+the paired direct-swap quotient boundary and does not reintroduce the false
+unrestricted structural lifting theorem. The one-sided `β-gen•` shapes still
+require their separate audit afterward.
+
+### Blame outcome polarity repair
+
+- Replaced the unsound target-blame alternatives in `WeakOneStepOutcome` and
+  `WeakOneStepAllOutcome` with source-blame alternatives. For a more-precise
+  source `M` and less-precise target `N'`, the exceptional outcome now requires
+
+  \[
+    \exists\,\bar\chi.\; M \longrightarrow^{\bar\chi *} \mathsf{blame}.
+  \]
+
+  A target reduction to `blame` alone cannot discharge the simulation.
+- Replaced `weak-one-step-target-blameᵀ` with
+  `weak-one-step-source-blameᵀ`, which takes the source reduction as an
+  explicit premise.
+- Strengthened source-framing outcome maps with a source-blame preservation
+  premise. The matched and source-only `ν`/`ν ★` corollaries discharge it
+  using `ν-blame-tail`; target-only frames preserve the source reduction
+  unchanged.
+- No term- or type-imprecision clause changed. Both strict checks pass:
+  `proof/NuImprecisionSimulation.agda` and `All.agda` with
+  `--no-allow-unsolved-metas`.
+
+### Top-down DGG proof spine
+
+- Aligned the public runtime observations with `compileᵀ`, the compilation
+  interface used by `compile-preserves-term-imprecision`. Proved
+  `compile-term-agrees`, so this changes no compiled term:
+
+  \[
+    \pi_1(\mathsf{compile}\;M)
+      = \pi_1(\mathsf{compile}^{T}\;M).
+  \]
+
+  The agreement proof also transfers `No•` and `RuntimeOK` to `compileᵀ`.
+- Added `proof/NuDGGSpine.agda`. The theorem
+  `compiled-term-imprecision` checks the exact initial boundary
+
+  \[
+    \varnothing;0;0;\varnothing;\varnothing
+      \vdash N \sqsubseteq N' : A \sqsubseteq B,
+  \]
+
+  where `N` and `N'` are the two public compiled observations.
+- Stated the genuine closed operational theorem `ClosedNuDGG` and proved
+  `closed-nu-dgg⇒gradual-dgg`. Thus the public theorem now has one explicit
+  predecessor rather than an informal gap from compiler monotonicity to the
+  final four observations.
+- Proved `multi-runtime-preservation` and exposed it through `NuMetaTheory`.
+  Together with multi-step typing preservation and progress, it discharges
+  the progress component needed at every reachable source state.
+- Proved that the two divergence clauses are consequences of terminal
+  simulation facts:
+
+  1. target convergence implies source convergence if target values catch up
+     to a source value or source blame, and target blame catches up to source
+     blame;
+  2. source divergence therefore implies target divergence;
+  3. forward simulation of source values plus progress implies that target
+     divergence gives source divergence-or-blame.
+
+  The full operational theorem therefore has three substantive terminal
+  obligations: forward source-value simulation, backward target-value
+  simulation, and backward target-blame simulation. The last obligation is
+  exactly where `outcome-source-blame` is required.
+- Proved `closed-nu-terminal-simulation⇒closed-nu-dgg`. It constructs all four
+  clauses of `ClosedNuDGG` from exactly those three terminal clauses. The two
+  divergence clauses are therefore connected to the public proof spine by
+  checked Agda terms rather than only justified in this ledger.
+- This top-down link exposed and repaired two latent interface problems:
+
+  1. the dynamic-application branch of `compile-term-agrees` left the type
+     context of its two cast plans implicit; both plans now carry the explicit
+     ambient context;
+  2. `QuotientedTermImprecision` projects the refined `TermTyping` judgment,
+     whereas the existing progress theorem consumes the older `NuTerms`
+     judgment. The checked bridge `closed-nu-source-typing` now applies the
+     proved `TermTyping.forget` embedding and explicitly normalizes the empty
+     source store and context.
+- Added `proof/NuReductionDeterminism.agda`. It proves value and blame
+  irreducibility, determinism of pure and store-changing one-step reduction,
+  and the two terminal-prefix properties
+
+  \[
+    M \longrightarrow^{\!*}_{\bar\chi} N,
+    \quad
+    M \longrightarrow^{\!*}_{\bar\psi} V,
+    \quad V\ \mathsf{value}
+    \quad\Longrightarrow\quad
+    \exists\bar\theta.\;
+      N \longrightarrow^{\!*}_{\bar\theta} V
+      \land
+      \bar\psi = \bar\chi\mathbin{+\!+}\bar\theta,
+  \]
+
+  with the analogous statement for `blame`.
+- Added `proof/NuDGGTraceAlignment.agda`. It applies those prefix properties
+  directly to `WeakOneStepResult.targetTail`, and lifts them across
+  `WeakOneStepOutcome`. The lifted result has exactly the sound alternatives
+  needed by the backward DGG clauses: either the related result continues
+  along the remaining target trace, or the source already reduces to blame.
+- The next integration boundary is therefore no longer trace alignment. It is
+  the recursive one-step dispatcher itself: from an arbitrary quotiented term
+  relation and target head step, produce `WeakOneStepOutcome`, then recurse on
+  the aligned remainder while threading the result store, contexts, endpoint
+  types, and related-result derivation.
+- No term- or type-imprecision definition changed. The focused spine and the
+  aggregate development pass with `--no-allow-unsolved-metas`.

--- a/GTSF/proof/NuImprecisionSimulation.agda
+++ b/GTSF/proof/NuImprecisionSimulation.agda
@@ -1,0 +1,10763 @@
+module proof.NuImprecisionSimulation where
+
+-- File Charter:
+--   * Establishes allocation and forall-administrative simulation lemmas for
+--     quotiented Nu-term imprecision.
+--   * Factors bare runtime-bullet instantiation from reveal and widening
+--     conversions for ordinary `ν` and `ν ★`.
+--   * Checks `β-Λ•`, `β-∀•`, `β-gen•`, and `β-inst` boundaries.
+--   * Connects crossed stores to two `bind` traces in opposite logical order.
+--   * Defines the general weak one-step result over transformed stores,
+--     contexts, and endpoint types.
+--   * Packages both orientations of the adjacent-`∀` swap as
+--     constructor-level weak-simulation cases with generated crossed stores
+--     and explicit target administrative tails.
+--   * Packages both generic-cast constructor orders at `β-∀•`, for all
+--     source/target narrowing and widening combinations.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (true)
+open import Data.List using ([]; _∷_; _++_; map)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Empty using (⊥)
+open import Data.Nat using (zero; suc; z<s; s<s)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using
+  (cong; cong₂; subst; sym; trans)
+
+open import Types
+open import Ctx using (⤊ᵗ)
+open import Coercions using
+  ( ModeIncl
+  ; ModeEnv
+  ; Mode
+  ; id-only
+  ; tag-or-id
+  ; seal-or-id
+  ; mode≤
+  ; extᵈ
+  ; gen
+  ; genᵈ
+  ; id-onlyᵈ
+  ; id-only≤tag-or-idᵈ
+  ; inst
+  ; instᵈ
+  ; renameᶜ
+  ; tag-or-idᵈ
+  ; `∀
+  ; ⇑ᶜ
+  ; _[_]ᶜ
+  )
+open import Conversion using
+  ( ConcealConversion
+  ; RevealConversion
+  ; conceal-all
+  ; open-conceal-conversion
+  ; open-reveal-conversion
+  ; reveal-all
+  ; rename-reveal-conversion
+  ; rename-conceal-conversion
+  ; weaken-conceal-conversion
+  ; weaken-reveal-conversion
+  )
+open import ForallPermutation using
+  ( _≈∀_
+  ; quotientᵖ
+  ; swap01ᵗ
+  ; ≈∀-refl
+  ; ≈∀-sym
+  ; ≈∀-trans
+  ; ≈∀-⇒
+  ; ≈∀-∀
+  ; ≈∀-swap
+  ; _∣_⊢_⊑ᵖ_⊣_
+  )
+open import ImprecisionWf
+open import NarrowWiden using
+  ( narrow-mode-relax
+  ; narrow-renameᵗ
+  ; narrow-weaken
+  ; widen-mode-relax
+  ; widen-renameᵗ
+  ; widen-weaken
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+import Coercions as C
+import NarrowWiden as NW
+open import NuReduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyStore
+  ; applyStores
+  ; applyCoercionUnderTyBinder
+  ; applyTy
+  ; applyTyCtx
+  ; applyTyCtxs
+  ; applyTys
+  ; bind
+  ; blame-ν
+  ; keep
+  ; β-gen•
+  ; β-inst
+  ; β-Λ•
+  ; β-∀•
+  ; pure-step
+  ; ν-step
+  ; ξ-⟨⟩
+  ; ξ-ν
+  ; ↠-refl
+  ; ↠-step
+  ; _—→[_]_
+  ; _—↠[_]_
+  )
+open import NuTerms using
+  ( No•
+  ; RuntimeOK
+  ; no•-Λ
+  ; no•-⟨⟩
+  ; ok-no
+  ; ok-ν
+  ; blame
+  ; Term
+  ; Value
+  ; `_
+  ; ƛ_
+  ; _·_
+  ; Λ_
+  ; ν
+  ; renameᵗᵐ
+  ; ⇑ᵗᵐ
+  ; _•
+  ; _⟨_⟩
+  )
+open import NuStore using (StoreWf)
+open import NuTermImprecision using
+  ( StoreImp
+  ; StoreImpEntry
+  ; StoreCorresponds
+  ; correspondence-stored
+  ; correspondence-linked
+  ; CtxImp
+  ; ctx-imp
+  ; LiftStoreⁱ
+  ; lift-store-[]
+  ; lift-store-∷
+  ; lift-store-left
+  ; lift-store-right
+  ; lift-store-link
+  ; LiftLeftStoreⁱ
+  ; lift-left-store-[]
+  ; lift-left-store-∷
+  ; lift-left-store-left
+  ; lift-left-store-right
+  ; lift-left-store-link
+  ; LiftRightStoreⁱ
+  ; lift-right-store-[]
+  ; lift-right-store-∷
+  ; lift-right-store-left
+  ; lift-right-store-right
+  ; lift-right-store-link
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; leftStoreⁱ-lift
+  ; rightStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightStoreⁱ-lift-left
+  ; leftStoreⁱ-lift-right
+  ; rightStoreⁱ-lift-right
+  ; LiftCtxⁱ
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; LiftLeftCtxⁱ
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  ; LiftRightCtxⁱ
+  ; lift-right-ctx-[]
+  ; lift-right-ctx-∷
+  ; leftCtxⁱ
+  ; rightCtxⁱ
+  ; leftCtxⁱ-lift
+  ; rightCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; rightCtxⁱ-lift-left
+  ; leftCtxⁱ-lift-right
+  ; rightCtxⁱ-lift-right
+  ; store-matched
+  ; store-left
+  ; store-right
+  ; store-link
+  ; crossedStoreⁱ
+  ; crossedStoreⁱ-new-old
+  ; crossedStoreⁱ-old-new
+  )
+open import QuotientedTermImprecision
+open import Store using (StoreIncl; StoreIncl-drop)
+open import TermTyping using
+  ( CastMode
+  ; SealModeStore★
+  ; cast-ext
+  ; cast-gen
+  ; cast-inst
+  ; cast-tag-or-id
+  ; cast-weaken
+  ; weakenCastᵈ
+  ; forget
+  ; _∣_∣_⊢_⦂_
+  ; ⊢•
+  ; ⊢⟨⟩↑
+  )
+open import proof.CastImprecision using
+  ( RightCastCtxCompatible
+  ; seal★-ext-shift
+  ; seal★-gen-shift
+  ; widening⇒⊑ᵢ
+  ; ⊑-transʳ-castᵢ
+  )
+open import proof.MaximalLowerBoundsWf using
+  ( ∀ᵢᶜ
+  ; rename-assm²ᵢ
+  ; rename-assm²-∀ᵢ
+  ; rename-assm²-⇑ᵢ
+  ; rename-assm²-⇑ᴸᵢ
+  ; rename-assm²-source-νᵢ
+  ; rename-assm²-swapRight∀∀ᵢ
+  ; rename-assm²-target-rightᵢ
+  ; ⊑-renameᵗ²ᵢ
+  ; ⊑-crossed-body-lift∀∀ᵢ
+  ; ⊑-crossed-left-body-lift∀∀ᵢ
+  ; ⊑-crossed-double-lift∀∀ᵢ
+  ; ⊑-lift∀ᵢ
+  ; ⊑-open∀ᵢ
+  ; ⊑-source-liftνᵢ
+  ; ⊑-ν∀-to-∀νᵢ
+  ; ⊑-swapLeft01∀∀ᵢ
+  ; ⊑-swapRight01∀∀ᵢ
+  ; ⊑-target-lift-rightᵢ
+  ; swap01ᵢ
+  )
+open import proof.MediationProperties using (wfTy-applyTys)
+open import proof.ForallPermutationProperties using
+  ( ≈∀-double-swap
+  ; ≈∀-double-swap-sym
+  ; ⊑→⊑ᵖ
+  )
+open import proof.NarrowWidenProperties using
+  ( StoreDetWf
+  ; allocate-all-narrowing
+  ; allocate-all-widening
+  ; allocate-gen-narrowing
+  ; open-all-narrowing
+  ; open-all-widening
+  )
+open import proof.NuTermProperties using
+  ( modeRename-left-inverse
+  ; open0-ext-suc-cancelᵐ
+  ; renameStoreᵗ-ext-suc-cons-comm
+  ; renameᵗᵐ-preserves-No•
+  ; renameᵗᵐ-preserves-Value
+  )
+open import proof.NuProgress using
+  ( AllView
+  ; av-Λ
+  ; av-∀
+  ; av-gen
+  ; canonical-∀
+  ; runtime-value-no•
+  )
+open import proof.NuPreservation using
+  ( runtime-ν
+  ; runtime-⟨⟩
+  )
+open import proof.ReductionProperties using
+  ( applyCoercionUnderTyBinders
+  ; applyStores-++
+  ; applyTy-∀
+  ; applyTyUnderTyBinder
+  ; applyTyCtxs-++
+  ; applyTysUnderTyBinders
+  ; applyTysUnderTyBinders-++
+  ; applyTys-++
+  ; applyTys-★
+  ; applyTys-∀
+  ; ν-↠
+  ; ↠-trans
+  )
+open import proof.CoercionProperties using
+  ( ModeIncl-ext
+  ; ModeIncl-gen
+  ; ModeIncl-inst
+  ; ModeRename
+  ; open0-ext-suc-cancelᶜ
+  )
+open import proof.TypePreservation using
+  ( applyWidenInstUnderTyBinder-typing
+  ; CastModeRenamer
+  ; castModeRenamer-ext
+  ; castModeRenamer-seal★
+  ; castModeRenamer-suc
+  ; modeRename-suc-weakenCast
+  ; preservation
+  ; term-weaken
+  ; typing-renameᵀ
+  )
+open import proof.StoreProperties using (∈-renameStoreᵗ)
+open import proof.TypeProperties using
+  ( RenameLeftInverse
+  ; RenameLeftInverse-ext
+  ; RenameLeftInverse-ext-suc-pred
+  ; RenameLeftInverse-suc
+  ; TyRenameWf
+  ; TyRenameWf-ext
+  ; TyRenameWf-suc
+  ; predᵗ
+  ; occurs-zero-rename-ext
+  ; rename-cong
+  ; renameᵗ-compose
+  ; renameᵗ-ext-suc-comm
+  ; renameᵗ-id
+  ; renameᵗ-preserves-WfTy
+  ; renameStoreᵗ-ext-suc-comm
+  )
+
+store-incl-insert-second :
+  ∀ {Σ α β A B} →
+  StoreIncl ((α , A) ∷ Σ) ((α , A) ∷ (β , B) ∷ Σ)
+store-incl-insert-second (here refl) = here refl
+store-incl-insert-second (there x∈) = there (there x∈)
+
+apply-reveal-under-ty-binder :
+  ∀ {χ μ Δ Σ Aν B C c} →
+  RevealConversion μ (suc Δ)
+    ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
+    zero (⇑ᵗ Aν) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (applyTyCtx χ Δ))
+      ((zero , ⇑ᵗ (applyTy χ Aν)) ∷ ⟰ᵗ (applyStore χ Σ))
+      zero (⇑ᵗ (applyTy χ Aν))
+      (applyCoercionUnderTyBinder χ c)
+      (applyTyUnderTyBinder χ C) (⇑ᵗ (applyTy χ B))
+apply-reveal-under-ty-binder {χ = keep} {μ = μ} c↑ = μ , c↑
+apply-reveal-under-ty-binder
+    {χ = bind Aχ} {μ = μ} {Δ = Δ} {Σ = Σ}
+    {Aν = Aν} {B = B} {C = C} {c = c} c↑ =
+  (λ Y → μ (predᵗ Y)) ,
+  weaken-reveal-conversion store-incl-insert-second
+    (subst
+      (λ T → RevealConversion (λ Y → μ (predᵗ Y))
+        (suc (suc Δ))
+        ((zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ (⟰ᵗ Σ))
+        zero (⇑ᵗ (⇑ᵗ Aν))
+        (renameᶜ (extᵗ suc) c)
+        (renameᵗ (extᵗ suc) C) T)
+      (renameᵗ-ext-suc-comm suc B)
+      (subst
+        (λ T → RevealConversion (λ Y → μ (predᵗ Y))
+          (suc (suc Δ))
+          ((zero , T) ∷ ⟰ᵗ (⟰ᵗ Σ))
+          zero T (renameᶜ (extᵗ suc) c)
+          (renameᵗ (extᵗ suc) C)
+          (renameᵗ (extᵗ suc) (⇑ᵗ B)))
+        (renameᵗ-ext-suc-comm suc Aν)
+        (subst
+          (λ Σ′ → RevealConversion (λ Y → μ (predᵗ Y))
+            (suc (suc Δ)) Σ′ zero
+            (renameᵗ (extᵗ suc) (⇑ᵗ Aν))
+            (renameᶜ (extᵗ suc) c)
+            (renameᵗ (extᵗ suc) C)
+            (renameᵗ (extᵗ suc) (⇑ᵗ B)))
+          renamed-store
+          (rename-reveal-conversion
+            (TyRenameWf-ext TyRenameWf-suc)
+            (modeRename-left-inverse
+              {ρ = extᵗ suc} {ψ = predᵗ}
+              RenameLeftInverse-ext-suc-pred)
+            c↑))))
+  where
+    renamed-store :
+      renameStoreᵗ (extᵗ suc)
+          ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
+        ≡ (zero , renameᵗ (extᵗ suc) (⇑ᵗ Aν)) ∷
+          ⟰ᵗ (⟰ᵗ Σ)
+    renamed-store =
+      cong₂ _∷_ refl (renameStoreᵗ-ext-suc-comm suc Σ)
+
+apply-reveal-under-ty-binders :
+  ∀ {χs μ Δ Σ Aν B C c} →
+  RevealConversion μ (suc Δ)
+    ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
+    zero (⇑ᵗ Aν) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (applyTyCtxs χs Δ))
+      ((zero , ⇑ᵗ (applyTys χs Aν)) ∷
+        ⟰ᵗ (applyStores χs Σ))
+      zero (⇑ᵗ (applyTys χs Aν))
+      (applyCoercionUnderTyBinders χs c)
+      (applyTysUnderTyBinders χs C) (⇑ᵗ (applyTys χs B))
+apply-reveal-under-ty-binders {χs = []} {μ = μ} c↑ = μ , c↑
+apply-reveal-under-ty-binders {χs = χ ∷ χs} c↑
+    with apply-reveal-under-ty-binder {χ = χ} c↑
+apply-reveal-under-ty-binders {χs = χ ∷ χs} c↑
+    | μ′ , c′↑ =
+  apply-reveal-under-ty-binders {χs = χs} c′↑
+
+apply-widen-inst-under-ty-binders :
+  ∀ {χs μ Δ Σ c B C} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ) ((zero , ★) ∷ ⟰ᵗ Σ) →
+  instᵈ μ ∣ suc Δ ∣ (zero , ★) ∷ ⟰ᵗ Σ
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ (instᵈ μ′)
+      ((zero , ★) ∷ ⟰ᵗ (applyStores χs Σ)) ×
+    (instᵈ μ′ ∣ suc (applyTyCtxs χs Δ)
+      ∣ (zero , ★) ∷ ⟰ᵗ (applyStores χs Σ)
+      ⊢ applyCoercionUnderTyBinders χs c
+        ∶ applyTysUnderTyBinders χs C ⊑
+          ⇑ᵗ (applyTys χs B))
+apply-widen-inst-under-ty-binders {χs = []} {μ = μ}
+    mode seal★ c⊑ =
+  μ , mode , seal★ , c⊑
+apply-widen-inst-under-ty-binders {χs = keep ∷ χs}
+    mode seal★ c⊑
+    with applyWidenInstUnderTyBinder-typing
+      {χ = keep} mode seal★ c⊑
+apply-widen-inst-under-ty-binders {χs = keep ∷ χs}
+    mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  apply-widen-inst-under-ty-binders
+    {χs = χs} mode′ seal★′ c′⊑
+apply-widen-inst-under-ty-binders {χs = bind A ∷ χs}
+    mode seal★ c⊑
+    with applyWidenInstUnderTyBinder-typing
+      {χ = bind A} mode seal★ c⊑
+apply-widen-inst-under-ty-binders {χs = bind A ∷ χs}
+    mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  apply-widen-inst-under-ty-binders
+    {χs = χs} mode′ seal★′ c′⊑
+
+------------------------------------------------------------------------
+-- General weak one-step simulation result
+------------------------------------------------------------------------
+
+record WeakOneStepResult
+    {Φ Δᴸ Δᴿ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (M N′ : Term)
+    (A B : Ty)
+    (χ : StoreChange) : Set₁ where
+  constructor weak-step-result
+  field
+    sourceChanges : StoreChanges
+    targetTailChanges : StoreChanges
+    sourceResult : Term
+    targetResult : Term
+    resultCtx : ImpCtx
+    resultLeftCtx : TyCtx
+    resultRightCtx : TyCtx
+    sourceCtxResult :
+      resultLeftCtx ≡ applyTyCtxs sourceChanges Δᴸ
+    targetCtxResult :
+      resultRightCtx
+        ≡ applyTyCtxs targetTailChanges (applyTyCtx χ Δᴿ)
+    resultStore :
+      StoreImp resultCtx resultLeftCtx resultRightCtx
+    resultSourceType : Ty
+    resultTargetType : Ty
+    sourceTypeResult :
+      resultSourceType ≡ applyTys sourceChanges A
+    targetTypeResult :
+      resultTargetType ≡ applyTys targetTailChanges (applyTy χ B)
+    transportType :
+      ∀ {C D} →
+      Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
+      resultCtx ∣ resultLeftCtx
+        ⊢ applyTys sourceChanges C
+          ⊑ applyTys targetTailChanges (applyTy χ D)
+        ⊣ resultRightCtx
+    transportAllBody :
+      ∀ {C D} →
+      ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+      ∀ᵢᶜ resultCtx ∣ suc resultLeftCtx
+        ⊢ applyTysUnderTyBinders sourceChanges C
+          ⊑ applyTysUnderTyBinders targetTailChanges
+              (applyTyUnderTyBinder χ D)
+        ⊣ suc resultRightCtx
+    transportRightBody :
+      ∀ {C D} →
+      ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+      ⇑ᴿᵢ resultCtx ∣ resultLeftCtx
+        ⊢ applyTys sourceChanges C
+          ⊑ applyTysUnderTyBinders targetTailChanges
+              (applyTyUnderTyBinder χ D)
+        ⊣ suc resultRightCtx
+    resultType :
+      resultCtx ∣ resultLeftCtx
+        ⊢ resultSourceType ⊑ resultTargetType
+        ⊣ resultRightCtx
+    sourceCatchup : M —↠[ sourceChanges ] sourceResult
+    targetTail : N′ —↠[ targetTailChanges ] targetResult
+    sourceStoreResult :
+      leftStoreⁱ resultStore
+        ≡ applyStores sourceChanges (leftStoreⁱ ρ)
+    targetStoreResult :
+      rightStoreⁱ resultStore
+        ≡ applyStores targetTailChanges
+            (applyStore χ (rightStoreⁱ ρ))
+    relatedResults :
+      resultCtx
+        ∣ resultLeftCtx
+        ∣ resultRightCtx
+        ∣ resultStore ∣ []
+        ⊢ᴺ sourceResult ⊑ targetResult
+        ⦂ resultSourceType ⊑ resultTargetType
+        ∶ resultType
+
+open WeakOneStepResult
+
+data WeakOneStepOutcome
+    {Φ Δᴸ Δᴿ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (M N′ : Term)
+    (A B : Ty)
+    (χ : StoreChange) : Set₁ where
+  outcome-related :
+    WeakOneStepResult ρ M N′ A B χ →
+    WeakOneStepOutcome ρ M N′ A B χ
+
+  outcome-source-blame : ∀ {χs} →
+    M —↠[ χs ] blame →
+    WeakOneStepOutcome ρ M N′ A B χ
+
+record WeakOneStepAllResult
+    {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  constructor weak-all-result
+  field
+    weakResult : WeakOneStepResult ρ N N₁′ (`∀ C) (`∀ C′) χ
+    canonicalAllResults :
+      resultCtx weakResult
+        ∣ resultLeftCtx weakResult
+        ∣ resultRightCtx weakResult
+        ∣ resultStore weakResult ∣ []
+        ⊢ᴺ sourceResult weakResult ⊑ targetResult weakResult
+        ⦂ `∀
+            (applyTysUnderTyBinders (sourceChanges weakResult) C)
+          ⊑ `∀
+              (applyTysUnderTyBinders (targetTailChanges weakResult)
+                (applyTyUnderTyBinder χ C′))
+        ∶ ∀ⁱ (transportAllBody weakResult q)
+
+open WeakOneStepAllResult
+
+data WeakOneStepAllOutcome
+    {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  all-outcome-related :
+    WeakOneStepAllResult {N = N} {N₁′ = N₁′} {χ = χ} {ρ = ρ} q →
+    WeakOneStepAllOutcome q
+
+  all-outcome-source-blame : ∀ {χs} →
+    N —↠[ χs ] blame →
+    WeakOneStepAllOutcome q
+
+record LeftSilentInvariant
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M V′ A B keep) : Set₁ where
+  constructor left-silent-invariant
+  field
+    targetTailIsEmpty : targetTailChanges result ≡ []
+    targetIsUnchanged : targetResult result ≡ V′
+
+open LeftSilentInvariant
+
+weak-result-right-wf-silent :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : WeakOneStepResult ρ M V′ A B keep) →
+  LeftSilentInvariant result →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  StoreWf (resultRightCtx result) (rightStoreⁱ (resultStore result))
+weak-result-right-wf-silent result
+    (left-silent-invariant refl target-eq) wfΣ′ =
+  subst
+    (λ Δ → StoreWf Δ (rightStoreⁱ (resultStore result)))
+    (sym (targetCtxResult result))
+    (subst
+      (StoreWf _)
+      (sym (targetStoreResult result)) wfΣ′)
+
+record LeftCatchupInvariant
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M V′ A B keep) : Set₁ where
+  constructor left-catchup-invariant
+  field
+    silentInvariant : LeftSilentInvariant result
+    sourceIsValueOrBlame :
+      (Value (sourceResult result) × No• (sourceResult result)) ⊎
+      sourceResult result ≡ blame
+
+open LeftCatchupInvariant
+
+record LeftSilentResult
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} : Set₁ where
+  constructor left-silent
+  field
+    silentResult : WeakOneStepResult ρ M V′ A B keep
+    resultIsLeftSilent : LeftSilentInvariant silentResult
+
+open LeftSilentResult
+
+record LeftCatchupResult
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} : Set₁ where
+  constructor left-catchup
+  field
+    catchupResult : WeakOneStepResult ρ M V′ A B keep
+    catchupInvariant : LeftCatchupInvariant catchupResult
+
+open LeftCatchupResult
+
+forget-left-catchup :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  LeftCatchupResult
+    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ} →
+  LeftSilentResult
+    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ}
+forget-left-catchup
+    (left-catchup result (left-catchup-invariant silent final)) =
+  left-silent result silent
+
+record LeftCatchupAllResult
+    {Φ Δᴸ Δᴿ N V′ C C′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  constructor left-all-catchup
+  field
+    catchupAllResult :
+      WeakOneStepAllResult
+        {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q
+    catchupAllInvariant :
+      LeftCatchupInvariant (weakResult catchupAllResult)
+
+open LeftCatchupAllResult
+
+forget-left-all-catchup :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q →
+  LeftCatchupResult {M = N} {V′ = V′} {ρ = ρ}
+forget-left-all-catchup (left-all-catchup result invariant) =
+  left-catchup (weakResult result) invariant
+
+weak-result-source-all :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ C B′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  ∃[ q′ ]
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ `∀ (applyTysUnderTyBinders (sourceChanges inner) C)
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ q′)
+weak-result-source-all {C = C} inner =
+  subst
+    (λ T → ∃[ q′ ]
+      (resultCtx inner
+        ∣ resultLeftCtx inner
+        ∣ resultRightCtx inner
+        ∣ resultStore inner ∣ []
+        ⊢ᴺ sourceResult inner ⊑ targetResult inner
+        ⦂ `∀ (applyTysUnderTyBinders (sourceChanges inner) C)
+          ⊑ T ∶ q′))
+    (targetTypeResult inner)
+    (subst
+      (λ S → ∃[ q′ ]
+        (resultCtx inner
+          ∣ resultLeftCtx inner
+          ∣ resultRightCtx inner
+          ∣ resultStore inner ∣ []
+          ⊢ᴺ sourceResult inner ⊑ targetResult inner
+          ⦂ S ⊑ resultTargetType inner ∶ q′))
+      (trans (sourceTypeResult inner)
+        (applyTys-∀ (sourceChanges inner) C))
+      (resultType inner , relatedResults inner))
+
+weak-result-target-all :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ B C′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  ∃[ q′ ]
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) B
+        ⊑ `∀
+            (applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C′))
+      ∶ q′)
+weak-result-target-all {C′ = C′} {χ = χ} inner =
+  subst
+    (λ T → ∃[ q′ ]
+      (resultCtx inner
+        ∣ resultLeftCtx inner
+        ∣ resultRightCtx inner
+        ∣ resultStore inner ∣ []
+        ⊢ᴺ sourceResult inner ⊑ targetResult inner
+        ⦂ applyTys (sourceChanges inner) _ ⊑ T ∶ q′))
+    (trans (targetTypeResult inner)
+      (trans
+        (cong (applyTys (targetTailChanges inner))
+          (applyTy-∀ χ C′))
+        (applyTys-∀ (targetTailChanges inner)
+          (applyTyUnderTyBinder χ C′))))
+    (subst
+      (λ S → ∃[ q′ ]
+        (resultCtx inner
+          ∣ resultLeftCtx inner
+          ∣ resultRightCtx inner
+          ∣ resultStore inner ∣ []
+          ⊢ᴺ sourceResult inner ⊑ targetResult inner
+          ⦂ S ⊑ resultTargetType inner ∶ q′))
+      (sourceTypeResult inner)
+      (resultType inner , relatedResults inner))
+
+weak-result-source-reveal :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y χ A B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (resultLeftCtx inner))
+      ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+        ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+      zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+      (applyCoercionUnderTyBinders (sourceChanges inner) c)
+      (applyTysUnderTyBinders (sourceChanges inner) C)
+      (⇑ᵗ (applyTys (sourceChanges inner) B))
+weak-result-source-reveal {A = A} {B = B} {C = C} {c = c} inner c↑
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} c↑
+weak-result-source-reveal {A = A} {B = B} {C = C} {c = c} inner c↑
+    | μ′ , c′↑ =
+  μ′ ,
+  subst
+    (λ Δ → RevealConversion μ′ (suc Δ)
+      ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+        ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+      zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+      (applyCoercionUnderTyBinders (sourceChanges inner) c)
+      (applyTysUnderTyBinders (sourceChanges inner) C)
+      (⇑ᵗ (applyTys (sourceChanges inner) B)))
+    (sym (sourceCtxResult inner))
+    (subst
+      (λ Σ → RevealConversion μ′
+        (suc (applyTyCtxs (sourceChanges inner) _))
+        ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷ ⟰ᵗ Σ)
+        zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+        (applyCoercionUnderTyBinders (sourceChanges inner) c)
+        (applyTysUnderTyBinders (sourceChanges inner) C)
+        (⇑ᵗ (applyTys (sourceChanges inner) B)))
+      (sym (sourceStoreResult inner)) c′↑)
+
+weak-result-target-reveal :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y A B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (χ : StoreChange) →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (resultRightCtx inner))
+      ((zero ,
+        ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+        ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+      zero
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
+      (applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder χ c))
+      (applyTysUnderTyBinders (targetTailChanges inner)
+        (applyTyUnderTyBinder χ C))
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
+weak-result-target-reveal
+    {A = A} {B = B} {C = C} {c = c} χ inner c↑
+    with apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} c↑
+weak-result-target-reveal
+    {A = A} {B = B} {C = C} {c = c} χ inner c↑
+    | μ′ , c′↑ =
+  μ′ ,
+  subst
+    (λ Δ → RevealConversion μ′ (suc Δ)
+      ((zero ,
+        ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+        ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+      zero
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
+      (applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder χ c))
+      (applyTysUnderTyBinders (targetTailChanges inner)
+        (applyTyUnderTyBinder χ C))
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B))))
+    (sym (targetCtxResult inner))
+    (subst
+      (λ Σ → RevealConversion μ′
+        (suc (applyTyCtxs (targetTailChanges inner)
+          (applyTyCtx χ _)))
+        ((zero ,
+          ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+          ⟰ᵗ Σ)
+        zero
+        (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
+        (applyCoercionUnderTyBinders (targetTailChanges inner)
+          (applyCoercionUnderTyBinder χ c))
+        (applyTysUnderTyBinders (targetTailChanges inner)
+          (applyTyUnderTyBinder χ C))
+        (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B))))
+      (sym (targetStoreResult inner)) c′↑)
+
+weak-result-source-widen-inst :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y χ B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ (instᵈ μ′)
+      ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))) ×
+    (instᵈ μ′ ∣ suc (resultLeftCtx inner)
+      ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
+        ∶ applyTysUnderTyBinders (sourceChanges inner) C
+          ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+weak-result-source-widen-inst
+    {B = B} {C = C} {c = c} inner mode seal★ c⊑
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ c⊑
+weak-result-source-widen-inst
+    {B = B} {C = C} {c = c} inner mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  μ′ , mode′ ,
+  subst
+    (λ Σ → SealModeStore★ (instᵈ μ′) ((zero , ★) ∷ ⟰ᵗ Σ))
+    (sym (sourceStoreResult inner)) seal★′ ,
+  subst
+    (λ Δ → instᵈ μ′ ∣ suc Δ
+      ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
+        ∶ applyTysUnderTyBinders (sourceChanges inner) C
+          ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+    (sym (sourceCtxResult inner))
+    (subst
+      (λ Σ → instᵈ μ′
+        ∣ suc (applyTyCtxs (sourceChanges inner) _)
+        ∣ (zero , ★) ∷ ⟰ᵗ Σ
+        ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
+          ∶ applyTysUnderTyBinders (sourceChanges inner) C
+            ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+      (sym (sourceStoreResult inner)) c′⊑)
+
+weak-result-target-widen-inst :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (χ : StoreChange) →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ (instᵈ μ′)
+      ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))) ×
+    (instᵈ μ′ ∣ suc (resultRightCtx inner)
+      ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+          (applyCoercionUnderTyBinder χ c)
+        ∶ applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C)
+          ⊑ ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
+weak-result-target-widen-inst
+    {B = B} {C = C} {c = c} χ inner mode seal★ c⊑
+    with apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode seal★ c⊑
+weak-result-target-widen-inst
+    {B = B} {C = C} {c = c} χ inner mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  μ′ , mode′ ,
+  subst
+    (λ Σ → SealModeStore★ (instᵈ μ′) ((zero , ★) ∷ ⟰ᵗ Σ))
+    (sym (targetStoreResult inner)) seal★′ ,
+  subst
+    (λ Δ → instᵈ μ′ ∣ suc Δ
+      ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+          (applyCoercionUnderTyBinder χ c)
+        ∶ applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C)
+          ⊑ ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
+    (sym (targetCtxResult inner))
+    (subst
+      (λ Σ → instᵈ μ′
+        ∣ suc (applyTyCtxs (targetTailChanges inner)
+          (applyTyCtx χ _))
+        ∣ (zero , ★) ∷ ⟰ᵗ Σ
+        ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ c)
+          ∶ applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C)
+            ⊑ ⇑ᵗ
+                (applyTys (targetTailChanges inner) (applyTy χ B)))
+      (sym (targetStoreResult inner)) c′⊑)
+
+lift-store-result :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρ′ ] LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ′
+lift-store-result [] = [] , lift-store-[]
+lift-store-result (store-matched α A β B p ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-matched α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-matched (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+    (⊑-lift∀ᵢ p) ∷ ρ′ ,
+  lift-store-∷ liftρ
+lift-store-result (store-left α A hA ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-left α A hA ∷ ρ)
+    | ρ′ , liftρ =
+  store-left (suc α) (⇑ᵗ A)
+    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ′ ,
+  lift-store-left liftρ
+lift-store-result (store-right β B hB ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-right β B hB ∷ ρ)
+    | ρ′ , liftρ =
+  store-right (suc β) (⇑ᵗ B)
+    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ′ ,
+  lift-store-right liftρ
+lift-store-result (store-link α A β B p ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-link α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-link (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+    (⊑-lift∀ᵢ p) ∷ ρ′ ,
+  lift-store-link liftρ
+
+lift-left-store-result :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρ′ ] LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
+lift-left-store-result [] = [] , lift-left-store-[]
+lift-left-store-result (store-matched α A β B p ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-matched α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-matched (suc α) (⇑ᵗ A) β B
+    (⊑-source-liftνᵢ p) ∷ ρ′ ,
+  lift-left-store-∷ liftρ
+lift-left-store-result (store-left α A hA ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-left α A hA ∷ ρ)
+    | ρ′ , liftρ =
+  store-left (suc α) (⇑ᵗ A)
+    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ′ ,
+  lift-left-store-left liftρ
+lift-left-store-result (store-right β B hB ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-right β B hB ∷ ρ)
+    | ρ′ , liftρ =
+  store-right β B hB ∷ ρ′ ,
+  lift-left-store-right liftρ
+lift-left-store-result (store-link α A β B p ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-link α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-link (suc α) (⇑ᵗ A) β B
+    (⊑-source-liftνᵢ p) ∷ ρ′ ,
+  lift-left-store-link liftρ
+
+lift-right-store-result :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρ′ ] LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′
+lift-right-store-result [] = [] , lift-right-store-[]
+lift-right-store-result (store-matched α A β B p ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-matched α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-matched α A (suc β) (⇑ᵗ B)
+    (⊑-target-lift-rightᵢ p) ∷ ρ′ ,
+  lift-right-store-∷ liftρ
+lift-right-store-result (store-left α A hA ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-left α A hA ∷ ρ)
+    | ρ′ , liftρ =
+  store-left α A hA ∷ ρ′ ,
+  lift-right-store-left liftρ
+lift-right-store-result (store-right β B hB ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-right β B hB ∷ ρ)
+    | ρ′ , liftρ =
+  store-right (suc β) (⇑ᵗ B)
+    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ′ ,
+  lift-right-store-right liftρ
+lift-right-store-result (store-link α A β B p ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-link α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-link α A (suc β) (⇑ᵗ B)
+    (⊑-target-lift-rightᵢ p) ∷ ρ′ ,
+  lift-right-store-link liftρ
+
+left-right-store-commuteⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ× ]
+    LiftRightStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴸ ρ× ×
+    LiftLeftStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴿ ρ×
+left-right-store-commuteⁱ lift-left-store-[] lift-right-store-[] =
+  [] , lift-right-store-[] , lift-left-store-[]
+left-right-store-commuteⁱ
+    (lift-left-store-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-store-∷ liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-store-∷ liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-matched _ _ _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ ρ× ,
+  lift-right-store-∷ rightᴸ ,
+  lift-left-store-∷ leftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-left liftᴸ)
+    (lift-right-store-left liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-left {hA′ = hAᴸ} liftᴸ)
+    (lift-right-store-left liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-left _ _ hAᴸ ∷ ρ× ,
+  lift-right-store-left rightᴸ ,
+  lift-left-store-left leftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-right liftᴸ)
+    (lift-right-store-right liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-right liftᴸ)
+    (lift-right-store-right {hB′ = hBᴿ} liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-right _ _ hBᴿ ∷ ρ× ,
+  lift-right-store-right rightᴸ ,
+  lift-left-store-right leftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-link {p′ = pᴸ} liftᴸ)
+    (lift-right-store-link liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-link {p′ = pᴸ} liftᴸ)
+    (lift-right-store-link liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-link _ _ _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ ρ× ,
+  lift-right-store-link rightᴸ ,
+  lift-left-store-link leftᴿ
+
+left-right-ctx-commuteⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ γ× ]
+    LiftRightCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴸ γ× ×
+    LiftLeftCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴿ γ×
+left-right-ctx-commuteⁱ lift-left-ctx-[] lift-right-ctx-[] =
+  [] , lift-right-ctx-[] , lift-left-ctx-[]
+left-right-ctx-commuteⁱ
+    (lift-left-ctx-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-ctx-∷ liftᴿ)
+    with left-right-ctx-commuteⁱ liftᴸ liftᴿ
+left-right-ctx-commuteⁱ
+    (lift-left-ctx-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-ctx-∷ liftᴿ)
+    | γ× , rightᴸ , leftᴿ =
+  ctx-imp _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ γ× ,
+  lift-right-ctx-∷ rightᴸ ,
+  lift-left-ctx-∷ leftᴿ
+
+data LeftInsertion : Renameᵗ → Set where
+  left-insertion-suc : LeftInsertion suc
+  left-insertion-ext : ∀ {τ} →
+    LeftInsertion τ → LeftInsertion (extᵗ τ)
+
+left-insertion-mode :
+  ∀ {τ} → LeftInsertion τ → ModeEnv → ModeEnv
+left-insertion-mode left-insertion-suc μ = weakenCastᵈ μ
+left-insertion-mode (left-insertion-ext ins) μ zero = μ zero
+left-insertion-mode (left-insertion-ext ins) μ (suc X) =
+  left-insertion-mode ins (λ Y → μ (suc Y)) X
+
+mode≤-refl : ∀ m → mode≤ m m ≡ true
+mode≤-refl id-only = refl
+mode≤-refl tag-or-id = refl
+mode≤-refl seal-or-id = refl
+
+left-insertion-mode-rename :
+  ∀ {τ} (ins : LeftInsertion τ) (μ : ModeEnv) →
+  ModeRename τ μ (left-insertion-mode ins μ)
+left-insertion-mode-rename left-insertion-suc μ =
+  modeRename-suc-weakenCast
+left-insertion-mode-rename (left-insertion-ext ins) μ zero =
+  mode≤-refl (μ zero)
+left-insertion-mode-rename (left-insertion-ext ins) μ (suc X) =
+  left-insertion-mode-rename ins (λ Y → μ (suc Y)) X
+
+left-insertion-cast-renamer :
+  ∀ {τ} → LeftInsertion τ → CastModeRenamer τ
+left-insertion-cast-renamer left-insertion-suc = castModeRenamer-suc
+left-insertion-cast-renamer (left-insertion-ext ins) =
+  castModeRenamer-ext (left-insertion-cast-renamer ins)
+
+no-crossed-up-mode-rename-id :
+  ModeRename suc
+    (extᵈ (instᵈ tag-or-idᵈ)) id-onlyᵈ → ⊥
+no-crossed-up-mode-rename-id rel with rel (suc zero)
+no-crossed-up-mode-rename-id rel | ()
+
+no-crossed-up-mode-rename-same :
+  ModeRename suc
+    (extᵈ (instᵈ tag-or-idᵈ))
+    (extᵈ (instᵈ tag-or-idᵈ)) → ⊥
+no-crossed-up-mode-rename-same rel with rel (suc zero)
+no-crossed-up-mode-rename-same rel | ()
+
+no-crossed-up-mode-rename-opposite :
+  ModeRename suc
+    (extᵈ (instᵈ tag-or-idᵈ))
+    (instᵈ (extᵈ tag-or-idᵈ)) → ⊥
+no-crossed-up-mode-rename-opposite rel with rel (suc zero)
+no-crossed-up-mode-rename-opposite rel | ()
+
+crossed-left-mode-rename-opposite :
+  ModeRename suc
+    (instᵈ (extᵈ tag-or-idᵈ))
+    (extᵈ (instᵈ tag-or-idᵈ))
+crossed-left-mode-rename-opposite zero = refl
+crossed-left-mode-rename-opposite (suc zero) = refl
+crossed-left-mode-rename-opposite (suc (suc X)) = refl
+
+rename-assm²-target-ext-idᵢ :
+  ∀ {τ a} →
+  rename-assm²ᵢ τ (extᵗ (λ X → X)) a
+    ≡ rename-assm²ᵢ τ (λ X → X) a
+rename-assm²-target-ext-idᵢ {a = X ˣ⊑★} = refl
+rename-assm²-target-ext-idᵢ {a = X ˣ⊑ˣ zero} = refl
+rename-assm²-target-ext-idᵢ {a = X ˣ⊑ˣ suc Y} = refl
+
+rename-assm²-∀-leftᵢ :
+  ∀ {Φ Ψ τ} →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  ∀ {a} → a ∈ ∀ᵢᶜ Φ →
+  rename-assm²ᵢ (extᵗ τ) (λ X → X) a ∈ ∀ᵢᶜ Ψ
+rename-assm²-∀-leftᵢ {Ψ = Ψ} assm {a = a} a∈ =
+  subst
+    (_∈ ∀ᵢᶜ Ψ)
+    rename-assm²-target-ext-idᵢ
+    (rename-assm²-⇑ᵢ assm a∈)
+
+⊑-rename-leftᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A B} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  Ψ ∣ Δᴸ′ ⊢ renameᵗ τ A ⊑ B ⊣ Δᴿ
+⊑-rename-leftᵢ τ assm hτ id★ = id★
+⊑-rename-leftᵢ τ assm hτ (idˣ a∈ X<Δ Y<Δ) =
+  idˣ (assm a∈) (hτ X<Δ) Y<Δ
+⊑-rename-leftᵢ τ assm hτ idι = idι
+⊑-rename-leftᵢ τ assm hτ (p ↦ q) =
+  ⊑-rename-leftᵢ τ assm hτ p ↦
+  ⊑-rename-leftᵢ τ assm hτ q
+⊑-rename-leftᵢ τ assm hτ (∀ⁱ p) =
+  ∀ⁱ (⊑-rename-leftᵢ
+    (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ) p)
+⊑-rename-leftᵢ τ assm hτ (tag ι) = tag ι
+⊑-rename-leftᵢ τ assm hτ (tag p ⇛ q) =
+  tag (⊑-rename-leftᵢ τ assm hτ p) ⇛
+  ⊑-rename-leftᵢ τ assm hτ q
+⊑-rename-leftᵢ τ assm hτ (tagˣ a∈ X<Δ) =
+  tagˣ (assm a∈) (hτ X<Δ)
+⊑-rename-leftᵢ {Φ = Φ} τ assm hτ (ν {A = A} occ p) =
+  ν (trans (occurs-zero-rename-ext τ A) occ)
+    (⊑-rename-leftᵢ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ) p)
+
+⊑-rename-left-atᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A A′ B} (τ : Renameᵗ) →
+  (assm : ∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  (hτ : TyRenameWf Δᴸ Δᴸ′ τ) →
+  A′ ≡ renameᵗ τ A →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  Ψ ∣ Δᴸ′ ⊢ A′ ⊑ B ⊣ Δᴿ
+⊑-rename-left-atᵢ τ assm hτ eqA p =
+  subst (λ T → _ ∣ _ ⊢ T ⊑ _ ⊣ _) (sym eqA)
+    (⊑-rename-leftᵢ τ assm hτ p)
+
+swap01-ext²-commute :
+  ∀ (τ : Renameᵗ) X →
+  swap01ᵗ (extᵗ (extᵗ τ) X) ≡
+    extᵗ (extᵗ τ) (swap01ᵗ X)
+swap01-ext²-commute τ zero = refl
+swap01-ext²-commute τ (suc zero) = refl
+swap01-ext²-commute τ (suc (suc X)) = refl
+
+renameᵗ-swap01-ext²-commute :
+  ∀ (τ : Renameᵗ) A →
+  renameᵗ swap01ᵗ (renameᵗ (extᵗ (extᵗ τ)) A) ≡
+    renameᵗ (extᵗ (extᵗ τ)) (renameᵗ swap01ᵗ A)
+renameᵗ-swap01-ext²-commute τ A =
+  trans
+    (renameᵗ-compose (extᵗ (extᵗ τ)) swap01ᵗ A)
+    (trans
+      (rename-cong (swap01-ext²-commute τ) A)
+      (sym (renameᵗ-compose swap01ᵗ (extᵗ (extᵗ τ)) A)))
+
+≈∀-renameᵗ :
+  ∀ {τ A B} → A ≈∀ B → renameᵗ τ A ≈∀ renameᵗ τ B
+≈∀-renameᵗ ≈∀-refl = ≈∀-refl
+≈∀-renameᵗ (≈∀-sym A≈B) = ≈∀-sym (≈∀-renameᵗ A≈B)
+≈∀-renameᵗ (≈∀-trans A≈B B≈C) =
+  ≈∀-trans (≈∀-renameᵗ A≈B) (≈∀-renameᵗ B≈C)
+≈∀-renameᵗ (≈∀-⇒ A≈A′ B≈B′) =
+  ≈∀-⇒ (≈∀-renameᵗ A≈A′) (≈∀-renameᵗ B≈B′)
+≈∀-renameᵗ (≈∀-∀ A≈B) = ≈∀-∀ (≈∀-renameᵗ A≈B)
+≈∀-renameᵗ {τ = τ} (≈∀-swap {A = A}) =
+  subst
+    (λ T → `∀ (`∀ (renameᵗ (extᵗ (extᵗ τ)) A)) ≈∀
+      `∀ (`∀ T))
+    (renameᵗ-swap01-ext²-commute τ A)
+    ≈∀-swap
+
+⊑ᵖ-rename-leftᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A B} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  Φ ∣ Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ →
+  Ψ ∣ Δᴸ′ ⊢ renameᵗ τ A ⊑ᵖ B ⊣ Δᴿ
+⊑ᵖ-rename-leftᵢ τ assm hτ (quotientᵖ A≈C C⊑D D≈B) =
+  quotientᵖ (≈∀-renameᵗ A≈C)
+    (⊑-rename-leftᵢ τ assm hτ C⊑D) D≈B
+
+⇑ᴿᵢ-membership :
+  ∀ {Φ a} →
+  a ∈ Φ →
+  ⇑ᴿᵢₐ a ∈ ⇑ᴿᵢ Φ
+⇑ᴿᵢ-membership (here refl) = here refl
+⇑ᴿᵢ-membership (there a∈) = there (⇑ᴿᵢ-membership a∈)
+
+rename-assm²-⇑ᴿᵢ :
+  ∀ {Φ Ψ τ} →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  ∀ {a} → a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ τ (λ X → X) a ∈ ⇑ᴿᵢ Ψ
+rename-assm²-⇑ᴿᵢ {Φ = []} assm ()
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (here refl) =
+  ⇑ᴿᵢ-membership (assm (here refl))
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (here refl) =
+  ⇑ᴿᵢ-membership (assm (here refl))
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (there a∈) =
+  rename-assm²-⇑ᴿᵢ (λ b∈ → assm (there b∈)) a∈
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (there a∈) =
+  rename-assm²-⇑ᴿᵢ (λ b∈ → assm (there b∈)) a∈
+
+rename-assm²-source-under-right-tailᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (λ X → X) a ∈ ⇑ᴿᵢ (⇑ᴸᵢ Φ)
+rename-assm²-source-under-right-tailᵢ {Φ = []} ()
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-source-under-right-tailᵢ a∈)
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-source-under-right-tailᵢ a∈)
+
+rename-assm²-source-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (λ X → X) a ∈
+    ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+rename-assm²-source-under-rightᵢ a∈ =
+  there (rename-assm²-source-under-right-tailᵢ a∈)
+
+⊑-source-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ B ⊣ suc Δᴿ
+⊑-source-under-rightᵢ =
+  ⊑-rename-leftᵢ suc rename-assm²-source-under-rightᵢ
+    TyRenameWf-suc
+
+data LeftStoreRenameⁱ
+    {Φ Ψ Δᴸ Δᴸ′ Δᴿ}
+    (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ) :
+    StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ Δᴸ′ Δᴿ → Set where
+  left-store-rename-[] :
+    LeftStoreRenameⁱ τ assm hτ [] []
+
+  left-store-rename-matched :
+    ∀ {ρ ρ′ α α′ A A′ β B p}
+      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-matched α A β B p ∷ ρ)
+      (store-matched α′ A′ β B
+        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′)
+
+  left-store-rename-left :
+    ∀ {ρ ρ′ α α′ A A′ hA hA′}
+      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-left α A hA ∷ ρ)
+      (store-left α′ A′ hA′ ∷ ρ′)
+
+  left-store-rename-right :
+    ∀ {ρ ρ′ β B hB hB′} →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-right β B hB ∷ ρ)
+      (store-right β B hB′ ∷ ρ′)
+
+  left-store-rename-link :
+    ∀ {ρ ρ′ α α′ A A′ β B p}
+      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-link α A β B p ∷ ρ)
+      (store-link α′ A′ β B
+        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′)
+
+data LeftCtxRenameⁱ
+    {Φ Ψ Δᴸ Δᴸ′ Δᴿ}
+    (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ) :
+    CtxImp Φ Δᴸ Δᴿ → CtxImp Ψ Δᴸ′ Δᴿ → Set where
+  left-ctx-rename-[] :
+    LeftCtxRenameⁱ τ assm hτ [] []
+
+  left-ctx-rename-∷ :
+    ∀ {γ γ′ A A′ B p} (eqA : A′ ≡ renameᵗ τ A) →
+    LeftCtxRenameⁱ τ assm hτ γ γ′ →
+    LeftCtxRenameⁱ τ assm hτ
+      (ctx-imp A B p ∷ γ)
+      (ctx-imp A′ B
+        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ γ′)
+
+leftStoreⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  leftStoreⁱ ρ′ ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+leftStoreⁱ-left-rename left-store-rename-[] = refl
+leftStoreⁱ-left-rename
+    (left-store-rename-matched eqα eqA renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-left-rename renameρ)
+leftStoreⁱ-left-rename
+    (left-store-rename-left eqα eqA renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-left-rename renameρ)
+leftStoreⁱ-left-rename (left-store-rename-right renameρ) =
+  leftStoreⁱ-left-rename renameρ
+leftStoreⁱ-left-rename (left-store-rename-link eqα eqA renameρ) =
+  leftStoreⁱ-left-rename renameρ
+
+rightStoreⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  rightStoreⁱ ρ′ ≡ rightStoreⁱ ρ
+rightStoreⁱ-left-rename left-store-rename-[] = refl
+rightStoreⁱ-left-rename
+    (left-store-rename-matched eqα eqA renameρ) =
+  cong (_ ∷_) (rightStoreⁱ-left-rename renameρ)
+rightStoreⁱ-left-rename (left-store-rename-left eqα eqA renameρ) =
+  rightStoreⁱ-left-rename renameρ
+rightStoreⁱ-left-rename (left-store-rename-right renameρ) =
+  cong (_ ∷_) (rightStoreⁱ-left-rename renameρ)
+rightStoreⁱ-left-rename (left-store-rename-link eqα eqA renameρ) =
+  rightStoreⁱ-left-rename renameρ
+
+leftCtxⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  leftCtxⁱ γ′ ≡ map (renameᵗ τ) (leftCtxⁱ γ)
+leftCtxⁱ-left-rename left-ctx-rename-[] = refl
+leftCtxⁱ-left-rename (left-ctx-rename-∷ eqA renameγ) =
+  cong₂ _∷_ eqA (leftCtxⁱ-left-rename renameγ)
+
+rightCtxⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  rightCtxⁱ γ′ ≡ rightCtxⁱ γ
+rightCtxⁱ-left-rename left-ctx-rename-[] = refl
+rightCtxⁱ-left-rename (left-ctx-rename-∷ eqA renameγ) =
+  cong (_ ∷_) (rightCtxⁱ-left-rename renameγ)
+
+left-typing-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ ψ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M A} →
+  RenameLeftInverse τ ψ →
+  CastModeRenamer τ →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  No• M →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ leftCtxⁱ γ′
+    ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A
+left-typing-renameⁱ {Δᴸ′ = Δᴸ′} {τ = τ} {ψ = ψ} {hτ = hτ}
+    {ρ′ = ρ′} {γ = γ} {γ′ = γ′} {M = M} {A = A}
+    invτ modeτ renameρ renameγ noM M⊢ =
+  subst
+    (λ Γ → Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+    (sym (leftCtxⁱ-left-rename renameγ))
+    (subst
+      (λ Σ → Δᴸ′ ∣ Σ ∣ map (renameᵗ τ) (leftCtxⁱ γ)
+        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+      (sym (leftStoreⁱ-left-rename renameρ))
+      (typing-renameᵀ {ρ = τ} {ψ = ψ} hτ invτ modeτ noM M⊢))
+
+right-typing-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Δᴿ ∣ rightStoreⁱ ρ′ ∣ rightCtxⁱ γ′ ⊢ M ⦂ B
+right-typing-left-renameⁱ {Δᴿ = Δᴿ} {ρ′ = ρ′}
+    {γ = γ} {γ′ = γ′} {M = M} {B = B}
+    renameρ renameγ M⊢ =
+  subst
+    (λ Γ → Δᴿ ∣ rightStoreⁱ ρ′ ∣ Γ ⊢ M ⦂ B)
+    (sym (rightCtxⁱ-left-rename renameγ))
+    (subst
+      (λ Σ → Δᴿ ∣ Σ ∣ rightCtxⁱ γ ⊢ M ⦂ B)
+      (sym (rightStoreⁱ-left-rename renameρ)) M⊢)
+
+left-seal★-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {μ} →
+  (modeτ : CastModeRenamer τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ modeτ mode) (leftStoreⁱ ρ′)
+left-seal★-renameⁱ modeτ renameρ mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (castModeRenamer-seal★ modeτ mode seal★)
+
+left-narrowing-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  (modeτ : CastModeRenamer τ) →
+  (mode : CastMode μ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  CastModeRenamer.targetᵈ modeτ mode ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
+left-narrowing-renameⁱ {hτ = hτ} modeτ mode renameρ c⊒ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (narrow-renameᵗ hτ
+      (CastModeRenamer.target-rename modeτ mode) c⊒)
+
+left-widening-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  (modeτ : CastModeRenamer τ) →
+  (mode : CastMode μ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  CastModeRenamer.targetᵈ modeτ mode ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
+left-widening-renameⁱ {hτ = hτ} modeτ mode renameρ c⊑ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (widen-renameᵗ hτ
+      (CastModeRenamer.target-rename modeτ mode) c⊑)
+
+modeRename-id-only :
+  ∀ (τ : Renameᵗ) → ModeRename τ id-onlyᵈ id-onlyᵈ
+modeRename-id-only τ X = refl
+
+modeRename-gen-tag-or-id :
+  ∀ (τ : Renameᵗ) →
+  ModeRename τ (genᵈ tag-or-idᵈ) (genᵈ tag-or-idᵈ)
+modeRename-gen-tag-or-id τ zero with τ zero
+modeRename-gen-tag-or-id τ zero | zero = refl
+modeRename-gen-tag-or-id τ zero | suc Y = refl
+modeRename-gen-tag-or-id τ (suc X) with τ (suc X)
+modeRename-gen-tag-or-id τ (suc X) | zero = refl
+modeRename-gen-tag-or-id τ (suc X) | suc Y = refl
+
+left-narrowing-rename-modeⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ ν c A B} →
+  ModeRename τ μ ν →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ν ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
+left-narrowing-rename-modeⁱ {hτ = hτ} modeτ renameρ c⊒ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (narrow-renameᵗ hτ modeτ c⊒)
+
+left-widening-rename-modeⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ ν c A B} →
+  ModeRename τ μ ν →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ν ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
+left-widening-rename-modeⁱ {hτ = hτ} modeτ renameρ c⊑ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (widen-renameᵗ hτ modeτ c⊑)
+
+left-reveal-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ α X c A B} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  RevealConversion (left-insertion-mode ins μ) Δᴸ′
+    (leftStoreⁱ ρ′) (τ α) (renameᵗ τ X)
+    (renameᶜ τ c) (renameᵗ τ A) (renameᵗ τ B)
+left-reveal-renameⁱ {hτ = hτ} ins renameρ conv =
+  subst
+    (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (rename-reveal-conversion hτ
+      (left-insertion-mode-rename ins _) conv)
+
+left-reveal-ν-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ A B C s} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion
+    (left-insertion-mode (left-insertion-ext ins) μ)
+    (suc Δᴸ′)
+    ((zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+    (renameᵗ (extᵗ τ) C) (⇑ᵗ (renameᵗ τ B))
+left-reveal-ν-renameⁱ
+    {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
+    {μ = μ} {A = A} {B = B} {C = C} {s = s}
+    ins renameρ conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Δᴸ′) target-store
+      zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+      (renameᵗ (extᵗ τ) C) D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Δᴸ′) target-store
+        zero X (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm τ A)
+      store-normalized)
+  where
+  target-mode = left-insertion-mode (left-insertion-ext ins) μ
+
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm τ (leftStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ τ A)) ∷_)
+        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
+
+  renamed :
+    RevealConversion target-mode (suc Δᴸ′)
+      (renameStoreᵗ (extᵗ τ)
+        ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ)))
+      zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+      (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+      (renameᵗ (extᵗ τ) (⇑ᵗ B))
+  renamed =
+    rename-reveal-conversion (TyRenameWf-ext hτ)
+      (left-insertion-mode-rename (left-insertion-ext ins) μ) conv
+
+  store-normalized :
+    RevealConversion target-mode (suc Δᴸ′) target-store
+      zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+      (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+      (renameᵗ (extᵗ τ) (⇑ᵗ B))
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Δᴸ′) Σ
+        zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+        (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      store-eq renamed
+
+right-reveal-ν-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ A B C s} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)
+right-reveal-ν-left-renameⁱ
+    {Δᴿ = Δᴿ} {μ = μ} {A = A} {B = B} {C = C} {s = s}
+    renameρ conv =
+  subst
+    (λ Σ → RevealConversion μ (suc Δᴿ) Σ
+      zero (⇑ᵗ A) s C (⇑ᵗ B))
+    (cong ((zero , ⇑ᵗ A) ∷_)
+      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
+    conv
+
+renameStoreᵗ-ext-★-cons-comm :
+  ∀ (τ : Renameᵗ) (Σ : Store) →
+  renameStoreᵗ (extᵗ τ) ((zero , ★) ∷ ⟰ᵗ Σ) ≡
+    (zero , ★) ∷ ⟰ᵗ (renameStoreᵗ τ Σ)
+renameStoreᵗ-ext-★-cons-comm τ Σ =
+  cong ((zero , ★) ∷_) (renameStoreᵗ-ext-suc-comm τ Σ)
+
+left-seal★-ν★-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  SealModeStore★
+    (instᵈ (CastModeRenamer.targetᵈ
+      (left-insertion-cast-renamer ins) mode))
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
+left-seal★-ν★-renameⁱ {τ = τ} {ρ = ρ} ins renameρ mode seal★ =
+  subst (SealModeStore★ _)
+    store-eq
+    (castModeRenamer-seal★
+      (castModeRenamer-ext (left-insertion-cast-renamer ins))
+      (cast-inst mode) seal★)
+  where
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
+
+right-seal★-ν★-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
+right-seal★-ν★-left-renameⁱ renameρ seal★ =
+  subst (SealModeStore★ _)
+    (cong ((zero , ★) ∷_)
+      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
+    seal★
+
+left-widening-ν★-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c C B} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  instᵈ (CastModeRenamer.targetᵈ
+      (left-insertion-cast-renamer ins) mode)
+    ∣ suc Δᴸ′ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+    ⊢ renameᶜ (extᵗ τ) c
+    ∶ renameᵗ (extᵗ τ) C ⊑ ⇑ᵗ (renameᵗ τ B)
+left-widening-ν★-renameⁱ
+    {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
+    {μ = μ} {c = c} {C = C} {B = B}
+    ins renameρ mode c⊑ =
+  subst
+    (λ D → instᵈ target-mode ∣ suc Δᴸ′ ∣ target-store
+      ⊢ renameᶜ (extᵗ τ) c
+      ∶ renameᵗ (extᵗ τ) C ⊑ D)
+    (renameᵗ-ext-suc-comm τ B)
+    store-normalized
+  where
+  modeτ = left-insertion-cast-renamer ins
+  target-mode = CastModeRenamer.targetᵈ modeτ mode
+  target-store = (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
+
+  renamed :
+    instᵈ target-mode ∣ suc Δᴸ′ ∣
+      renameStoreᵗ (extᵗ τ)
+        ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+      ⊢ renameᶜ (extᵗ τ) c
+      ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B)
+  renamed =
+    widen-renameᵗ (TyRenameWf-ext hτ)
+      (CastModeRenamer.target-rename
+        (castModeRenamer-ext modeτ) (cast-inst mode)) c⊑
+
+  store-normalized :
+    instᵈ target-mode ∣ suc Δᴸ′ ∣ target-store
+      ⊢ renameᶜ (extᵗ τ) c
+      ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B)
+  store-normalized =
+    subst
+      (λ Σ → instᵈ target-mode ∣ suc Δᴸ′ ∣ Σ
+        ⊢ renameᶜ (extᵗ τ) c
+        ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B))
+      store-eq renamed
+
+right-widening-ν★-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c C B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B
+right-widening-ν★-left-renameⁱ
+    {Δᴿ = Δᴿ} {μ = μ} {c = c} {C = C} {B = B}
+    renameρ c⊑ =
+  subst
+    (λ Σ → instᵈ μ ∣ suc Δᴿ ∣ Σ ⊢ c ∶ C ⊑ ⇑ᵗ B)
+    (cong ((zero , ★) ∷_)
+      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
+    c⊑
+
+left-conceal-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ α X c A B} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  ConcealConversion (left-insertion-mode ins μ) Δᴸ′
+    (leftStoreⁱ ρ′) (τ α) (renameᵗ τ X)
+    (renameᶜ τ c) (renameᵗ τ A) (renameᵗ τ B)
+left-conceal-renameⁱ {hτ = hτ} ins renameρ conv =
+  subst
+    (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (rename-conceal-conversion hτ
+      (left-insertion-mode-rename ins _) conv)
+
+right-reveal-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ β X c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ′) β X c A B
+right-reveal-left-renameⁱ renameρ conv =
+  subst
+    (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) conv
+
+right-conceal-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ β X c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ′) β X c A B
+right-conceal-left-renameⁱ renameρ conv =
+  subst
+    (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) conv
+
+right-seal★-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  SealModeStore★ μ (rightStoreⁱ ρ) →
+  SealModeStore★ μ (rightStoreⁱ ρ′)
+right-seal★-left-renameⁱ renameρ seal★ =
+  subst (SealModeStore★ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) seal★
+
+right-widening-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ′ ⊢ c ∶ A ⊑ B
+right-widening-left-renameⁱ renameρ c⊑ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) c⊑
+
+right-narrowing-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ′ ⊢ c ∶ A ⊒ B
+right-narrowing-left-renameⁱ renameρ c⊒ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) c⊒
+
+right-store-det-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  StoreDetWf Δᴿ (rightStoreⁱ ρ) →
+  StoreDetWf Δᴿ (rightStoreⁱ ρ′)
+right-store-det-left-renameⁱ renameρ wfΣ =
+  subst (StoreDetWf _)
+    (sym (rightStoreⁱ-left-rename renameρ)) wfΣ
+
+left-store-rename-∀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  ∃[ ρ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      ρ∀ ρ′∀
+left-store-rename-∀ left-store-rename-[] lift-store-[] =
+  [] , lift-store-[] , left-store-rename-[]
+left-store-rename-∀
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-store-∷ {p′ = p∀} liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-store-∷ {A = A} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-matched (suc α′) (⇑ᵗ A′) (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ ρ′∀ ,
+  lift-store-∷ liftρ′ ,
+  left-store-rename-matched (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-∀
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-store-left liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-store-left {A = A} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-left liftρ′ ,
+  left-store-rename-left (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-∀
+    (left-store-rename-right {hB′ = hB′} renameρ)
+    (lift-store-right liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀
+    (left-store-rename-right {β = β} {B = B} {hB′ = hB′} renameρ)
+    (lift-store-right liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-right (suc β) (⇑ᵗ B)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-right liftρ′ ,
+  left-store-rename-right renameρ∀
+left-store-rename-∀
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-store-link {p′ = p∀} liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-store-link {A = A} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-link (suc α′) (⇑ᵗ A′) (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ ρ′∀ ,
+  lift-store-link liftρ′ ,
+  left-store-rename-link (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-ctx-rename-∀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ γ′∀ ]
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      γ∀ γ′∀
+left-ctx-rename-∀ left-ctx-rename-[] lift-ctx-[] =
+  [] , lift-ctx-[] , left-ctx-rename-[]
+left-ctx-rename-∀
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    (lift-ctx-∷ {p′ = p∀} liftγ)
+    with left-ctx-rename-∀ renameγ liftγ
+left-ctx-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
+    (lift-ctx-∷ {A = A} {p′ = p∀} liftγ)
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ctx-imp (⇑ᵗ A′) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ γ′∀ ,
+  lift-ctx-∷ liftγ′ ,
+  left-ctx-rename-∷ eqA∀ renameγ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-store-rename-ν :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  ∃[ ρ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      ρν ρ′ν
+left-store-rename-ν left-store-rename-[] lift-left-store-[] =
+  [] , lift-left-store-[] , left-store-rename-[]
+left-store-rename-ν
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-left-store-∷ {p′ = pν} liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-left-store-∷ {A = A} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-matched (suc α′) (⇑ᵗ A′) β B
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) eqAν pν) ∷ ρ′ν ,
+  lift-left-store-∷ liftρ′ ,
+  left-store-rename-matched (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-ν
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-left-store-left liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-left-store-left {A = A} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′ν ,
+  lift-left-store-left liftρ′ ,
+  left-store-rename-left (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-ν
+    (left-store-rename-right {hB′ = hB′} renameρ)
+    (lift-left-store-right liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν
+    (left-store-rename-right {β = β} {B = B} {hB′ = hB′} renameρ)
+    (lift-left-store-right liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-right β B hB′ ∷ ρ′ν ,
+  lift-left-store-right liftρ′ ,
+  left-store-rename-right renameρν
+left-store-rename-ν
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-left-store-link {p′ = pν} liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-left-store-link {A = A} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-link (suc α′) (⇑ᵗ A′) β B
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) eqAν pν) ∷ ρ′ν ,
+  lift-left-store-link liftρ′ ,
+  left-store-rename-link (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-ctx-rename-ν :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ γ′ν ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      γν γ′ν
+left-ctx-rename-ν left-ctx-rename-[] lift-left-ctx-[] =
+  [] , lift-left-ctx-[] , left-ctx-rename-[]
+left-ctx-rename-ν
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    (lift-left-ctx-∷ {p′ = pν} liftγ)
+    with left-ctx-rename-ν renameγ liftγ
+left-ctx-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
+    (lift-left-ctx-∷ {A = A} {p′ = pν} liftγ)
+    | γ′ν , liftγ′ , renameγν =
+  ctx-imp (⇑ᵗ A′) B
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) eqAν pν) ∷ γ′ν ,
+  lift-left-ctx-∷ liftγ′ ,
+  left-ctx-rename-∷ eqAν renameγν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-store-rename-ν-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρ′ν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+      (suc Δᴸ′) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LeftStoreRenameⁱ
+    (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+    ρν ρ′ν →
+  ∃[ ρ′ ]
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ ×
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν
+left-store-rename-ν-inv
+    lift-left-store-[] left-store-rename-[] =
+  [] , left-store-rename-[] , lift-left-store-[]
+left-store-rename-ν-inv
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ with eqα
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl | refl =
+  store-matched (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p) ∷ ρ′ ,
+  left-store-rename-matched refl refl renameρ′ ,
+  lift-left-store-∷ liftρ′
+left-store-rename-ν-inv
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv {τ = τ} {hτ = hτ}
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ with eqα
+left-store-rename-ν-inv {τ = τ} {hτ = hτ}
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-store-rename-ν-inv {τ = τ} {hτ = hτ}
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl | refl =
+  store-left (τ α) (renameᵗ τ A)
+      (renameᵗ-preserves-WfTy hA hτ) ∷ ρ′ ,
+  left-store-rename-left refl refl renameρ′ ,
+  lift-left-store-left liftρ′
+left-store-rename-ν-inv
+    {ρ = store-right β B hB ∷ ρ}
+    (lift-left-store-right liftρ)
+    (left-store-rename-right renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv
+    {ρ = store-right β B hB ∷ ρ}
+    (lift-left-store-right liftρ)
+    (left-store-rename-right renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-right β B hB ∷ ρ′ ,
+  left-store-rename-right renameρ′ ,
+  lift-left-store-right liftρ′
+left-store-rename-ν-inv
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ with eqα
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl | refl =
+  store-link (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p) ∷ ρ′ ,
+  left-store-rename-link refl refl renameρ′ ,
+  lift-left-store-link liftρ′
+
+left-ctx-rename-ν-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ′ν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+      (suc Δᴸ′) Δᴿ} →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  LeftCtxRenameⁱ
+    (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+    γν γ′ν →
+  ∃[ γ′ ]
+    LeftCtxRenameⁱ τ assm hτ γ γ′ ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν
+left-ctx-rename-ν-inv lift-left-ctx-[] left-ctx-rename-[] =
+  [] , left-ctx-rename-[] , lift-left-ctx-[]
+left-ctx-rename-ν-inv
+    {γ = ctx-imp A B p ∷ γ}
+    (lift-left-ctx-∷ liftγ)
+    (left-ctx-rename-∷ eqA renameγ)
+    with left-ctx-rename-ν-inv liftγ renameγ
+left-ctx-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {γ = ctx-imp A B p ∷ γ}
+    (lift-left-ctx-∷ liftγ)
+    (left-ctx-rename-∷ eqA renameγ)
+    | γ′ , renameγ′ , liftγ′
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-ctx-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {γ = ctx-imp A B p ∷ γ}
+    (lift-left-ctx-∷ liftγ)
+    (left-ctx-rename-∷ eqA renameγ)
+    | γ′ , renameγ′ , liftγ′ | refl =
+  ctx-imp (renameᵗ τ A) B (⊑-rename-leftᵢ τ assm hτ p) ∷ γ′ ,
+  left-ctx-rename-∷ refl renameγ′ ,
+  lift-left-ctx-∷ liftγ′
+
+left-store-rename-suc-liftⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
+left-store-rename-suc-liftⁱ left-store-rename-[] =
+  lift-left-store-[]
+left-store-rename-suc-liftⁱ
+    {ρ = store-matched α A β B p ∷ ρ}
+    (left-store-rename-matched eqα eqA renameρ)
+    with eqα
+left-store-rename-suc-liftⁱ
+    {ρ = store-matched α A β B p ∷ ρ}
+    (left-store-rename-matched eqα eqA renameρ) | refl
+    with eqA
+left-store-rename-suc-liftⁱ
+    {ρ = store-matched α A β B p ∷ ρ}
+    (left-store-rename-matched eqα eqA renameρ) | refl | refl =
+  lift-left-store-∷ (left-store-rename-suc-liftⁱ renameρ)
+left-store-rename-suc-liftⁱ
+    {ρ = store-left α A hA ∷ ρ}
+    (left-store-rename-left eqα eqA renameρ)
+    with eqα
+left-store-rename-suc-liftⁱ
+    {ρ = store-left α A hA ∷ ρ}
+    (left-store-rename-left eqα eqA renameρ) | refl
+    with eqA
+left-store-rename-suc-liftⁱ
+    {ρ = store-left α A hA ∷ ρ}
+    (left-store-rename-left eqα eqA renameρ) | refl | refl =
+  lift-left-store-left (left-store-rename-suc-liftⁱ renameρ)
+left-store-rename-suc-liftⁱ
+    {ρ = store-right β B hB ∷ ρ}
+    (left-store-rename-right renameρ) =
+  lift-left-store-right (left-store-rename-suc-liftⁱ renameρ)
+left-store-rename-suc-liftⁱ
+    {ρ = store-link α A β B p ∷ ρ}
+    (left-store-rename-link eqα eqA renameρ)
+    with eqα
+left-store-rename-suc-liftⁱ
+    {ρ = store-link α A β B p ∷ ρ}
+    (left-store-rename-link eqα eqA renameρ) | refl
+    with eqA
+left-store-rename-suc-liftⁱ
+    {ρ = store-link α A β B p ∷ ρ}
+    (left-store-rename-link eqα eqA renameρ) | refl | refl =
+  lift-left-store-link (left-store-rename-suc-liftⁱ renameρ)
+
+left-store-rename-⇑ᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ′ᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
+    LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ ρᴿ ρ′ᴿ
+left-store-rename-⇑ᴿ left-store-rename-[] lift-right-store-[] =
+  [] , lift-right-store-[] , left-store-rename-[]
+left-store-rename-⇑ᴿ
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-right-store-∷ {p′ = pᴿ} liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-right-store-∷ {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-matched α′ A′ (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-∷ liftρ′ ,
+  left-store-rename-matched eqα eqA renameρᴿ
+left-store-rename-⇑ᴿ
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-right-store-left liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-right-store-left liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-left α′ A′ hA′ ∷ ρ′ᴿ ,
+  lift-right-store-left liftρ′ ,
+  left-store-rename-left eqα eqA renameρᴿ
+left-store-rename-⇑ᴿ
+    (left-store-rename-right renameρ)
+    (lift-right-store-right liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ
+    (left-store-rename-right {β = β} {B = B} renameρ)
+    (lift-right-store-right {hB′ = hBᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-right (suc β) (⇑ᵗ B) hBᴿ ∷ ρ′ᴿ ,
+  lift-right-store-right liftρ′ ,
+  left-store-rename-right renameρᴿ
+left-store-rename-⇑ᴿ
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-right-store-link {p′ = pᴿ} liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-right-store-link {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-link α′ A′ (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-link liftρ′ ,
+  left-store-rename-link eqα eqA renameρᴿ
+
+left-ctx-rename-⇑ᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ γ′ᴿ ]
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ ×
+    LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ
+left-ctx-rename-⇑ᴿ left-ctx-rename-[] lift-right-ctx-[] =
+  [] , lift-right-ctx-[] , left-ctx-rename-[]
+left-ctx-rename-⇑ᴿ
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
+    with left-ctx-rename-⇑ᴿ renameγ liftγ
+left-ctx-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
+    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ctx-imp A′ (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ γ′ᴿ ,
+  lift-right-ctx-∷ liftγ′ ,
+  left-ctx-rename-∷ eqA renameγᴿ
+
+left-store-rename-⇑ᴿ-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {ρ′ᴿ : StoreImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)} →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ ρᴿ ρ′ᴿ →
+  ∃[ ρ′ ]
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ ×
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ
+left-store-rename-⇑ᴿ-inv
+    lift-right-store-[] left-store-rename-[] =
+  [] , left-store-rename-[] , lift-right-store-[]
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-∷ {p = p} liftρ)
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    (lift-right-store-∷ {p = p} liftρ)
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-matched α′ A′ _ _
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′ ,
+  left-store-rename-matched eqα eqA renameρ′ ,
+  lift-right-store-∷ liftρ′
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-left liftρ)
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-left liftρ)
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-left α′ A′ hA′ ∷ ρ′ ,
+  left-store-rename-left eqα eqA renameρ′ ,
+  lift-right-store-left liftρ′
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-right {hB = hB} liftρ)
+    (left-store-rename-right renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-right {hB = hB} liftρ)
+    (left-store-rename-right renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-right _ _ hB ∷ ρ′ ,
+  left-store-rename-right renameρ′ ,
+  lift-right-store-right liftρ′
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-link {p = p} liftρ)
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    (lift-right-store-link {p = p} liftρ)
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-link α′ A′ _ _
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′ ,
+  left-store-rename-link eqα eqA renameρ′ ,
+  lift-right-store-link liftρ′
+
+left-ctx-rename-⇑ᴿ-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ′ᴿ : CtxImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)} →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ →
+  ∃[ γ′ ]
+    LeftCtxRenameⁱ τ assm hτ γ γ′ ×
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ
+left-ctx-rename-⇑ᴿ-inv lift-right-ctx-[] left-ctx-rename-[] =
+  [] , left-ctx-rename-[] , lift-right-ctx-[]
+left-ctx-rename-⇑ᴿ-inv
+    (lift-right-ctx-∷ {p = p} liftγ)
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    with left-ctx-rename-⇑ᴿ-inv liftγ renameγ
+left-ctx-rename-⇑ᴿ-inv {τ = τ} {assm = assm} {hτ = hτ}
+    (lift-right-ctx-∷ {p = p} liftγ)
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    | γ′ , renameγ′ , liftγ′ =
+  ctx-imp A′ _ (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ γ′ ,
+  left-ctx-rename-∷ eqA renameγ′ ,
+  lift-right-ctx-∷ liftγ′
+
+rename-left-storeⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  StoreImp Φ Δᴸ Δᴿ →
+  StoreImp Ψ Δᴸ′ Δᴿ
+rename-left-storeⁱ τ assm hτ [] = []
+rename-left-storeⁱ τ assm hτ
+    (store-matched α A β B p ∷ ρ) =
+  store-matched (τ α) (renameᵗ τ A) β B
+    (⊑-rename-leftᵢ τ assm hτ p) ∷
+  rename-left-storeⁱ τ assm hτ ρ
+rename-left-storeⁱ τ assm hτ (store-left α A hA ∷ ρ) =
+  store-left (τ α) (renameᵗ τ A)
+    (renameᵗ-preserves-WfTy hA hτ) ∷
+  rename-left-storeⁱ τ assm hτ ρ
+rename-left-storeⁱ τ assm hτ (store-right β B hB ∷ ρ) =
+  store-right β B hB ∷ rename-left-storeⁱ τ assm hτ ρ
+rename-left-storeⁱ τ assm hτ (store-link α A β B p ∷ ρ) =
+  store-link (τ α) (renameᵗ τ A) β B
+    (⊑-rename-leftᵢ τ assm hτ p) ∷
+  rename-left-storeⁱ τ assm hτ ρ
+
+rename-left-store-coherentⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ)
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  LeftStoreRenameⁱ τ assm hτ ρ
+    (rename-left-storeⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ [] =
+  left-store-rename-[]
+rename-left-store-coherentⁱ τ assm hτ
+    (store-matched α A β B p ∷ ρ) =
+  left-store-rename-matched refl refl
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ
+    (store-left α A hA ∷ ρ) =
+  left-store-rename-left refl refl
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ
+    (store-right β B hB ∷ ρ) =
+  left-store-rename-right
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ
+    (store-link α A β B p ∷ ρ) =
+  left-store-rename-link refl refl
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+
+rename-left-store-source-liftⁱ :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ
+    (rename-left-storeⁱ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc ρ)
+rename-left-store-source-liftⁱ [] = lift-left-store-[]
+rename-left-store-source-liftⁱ
+    (store-matched α A β B p ∷ ρ) =
+  lift-left-store-∷ (rename-left-store-source-liftⁱ ρ)
+rename-left-store-source-liftⁱ (store-left α A hA ∷ ρ) =
+  lift-left-store-left (rename-left-store-source-liftⁱ ρ)
+rename-left-store-source-liftⁱ (store-right β B hB ∷ ρ) =
+  lift-left-store-right (rename-left-store-source-liftⁱ ρ)
+rename-left-store-source-liftⁱ (store-link α A β B p ∷ ρ) =
+  lift-left-store-link (rename-left-store-source-liftⁱ ρ)
+
+leftStoreⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  leftStoreⁱ
+      (rename-left-storeⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ ρ)
+    ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+leftStoreⁱ-rename-left [] = refl
+leftStoreⁱ-rename-left (store-matched α A β B p ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (leftStoreⁱ-rename-left ρ)
+leftStoreⁱ-rename-left (store-left α A hA ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (leftStoreⁱ-rename-left ρ)
+leftStoreⁱ-rename-left (store-right β B hB ∷ ρ) =
+  leftStoreⁱ-rename-left ρ
+leftStoreⁱ-rename-left (store-link α A β B p ∷ ρ) =
+  leftStoreⁱ-rename-left ρ
+
+rightStoreⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  rightStoreⁱ
+      (rename-left-storeⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ ρ)
+    ≡ rightStoreⁱ ρ
+rightStoreⁱ-rename-left [] = refl
+rightStoreⁱ-rename-left (store-matched α A β B p ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (rightStoreⁱ-rename-left ρ)
+rightStoreⁱ-rename-left (store-left α A hA ∷ ρ) =
+  rightStoreⁱ-rename-left ρ
+rightStoreⁱ-rename-left (store-right β B hB ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (rightStoreⁱ-rename-left ρ)
+rightStoreⁱ-rename-left (store-link α A β B p ∷ ρ) =
+  rightStoreⁱ-rename-left ρ
+
+rename-left-ctxⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  CtxImp Φ Δᴸ Δᴿ →
+  CtxImp Ψ Δᴸ′ Δᴿ
+rename-left-ctxⁱ τ assm hτ [] = []
+rename-left-ctxⁱ τ assm hτ (ctx-imp A B p ∷ γ) =
+  ctx-imp (renameᵗ τ A) B
+    (⊑-rename-leftᵢ τ assm hτ p) ∷
+  rename-left-ctxⁱ τ assm hτ γ
+
+rename-left-ctx-coherentⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ)
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  LeftCtxRenameⁱ τ assm hτ γ
+    (rename-left-ctxⁱ τ assm hτ γ)
+rename-left-ctx-coherentⁱ τ assm hτ [] =
+  left-ctx-rename-[]
+rename-left-ctx-coherentⁱ τ assm hτ (ctx-imp A B p ∷ γ) =
+  left-ctx-rename-∷ refl
+    (rename-left-ctx-coherentⁱ τ assm hτ γ)
+
+rename-left-ctx-source-liftⁱ :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ
+    (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc γ)
+rename-left-ctx-source-liftⁱ [] = lift-left-ctx-[]
+rename-left-ctx-source-liftⁱ (ctx-imp A B p ∷ γ) =
+  lift-left-ctx-∷ (rename-left-ctx-source-liftⁱ γ)
+
+left-source-rename-worldsⁱ :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ
+      (rename-left-storeⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc ρ) ×
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ
+      (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc γ) ×
+  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc ρ
+      (rename-left-storeⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc ρ) ×
+  LeftCtxRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc γ
+      (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc γ)
+left-source-rename-worldsⁱ ρ γ =
+  rename-left-store-source-liftⁱ ρ ,
+  rename-left-ctx-source-liftⁱ γ ,
+  rename-left-store-coherentⁱ
+    suc rename-assm²-source-νᵢ TyRenameWf-suc ρ ,
+  rename-left-ctx-coherentⁱ
+    suc rename-assm²-source-νᵢ TyRenameWf-suc γ
+
+left-ctx-rename-lookupⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {x A B p} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  γ ∋ x ⦂ ctx-imp A B p →
+  ∃[ A′ ] ∃[ eqA ]
+    γ′ ∋ x ⦂ ctx-imp A′ B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p)
+left-ctx-rename-lookupⁱ
+    (left-ctx-rename-∷ eqA renameγ) Z =
+  _ , eqA , Z
+left-ctx-rename-lookupⁱ
+    (left-ctx-rename-∷ eqA renameγ) (S x∈) =
+  let A′ , eqA′ , x∈′ = left-ctx-rename-lookupⁱ renameγ x∈ in
+  A′ , eqA′ , S x∈′
+
+left-rename-xᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {x A B p}
+    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  γ ∋ x ⦂ ctx-imp A B p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (` x) ⊑ ` x
+    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-xᵀ renameγ x∈ with left-ctx-rename-lookupⁱ renameγ x∈
+left-rename-xᵀ renameγ x∈ | A′ , refl , x∈′ = x⊑xᵀ x∈′
+
+left-rename-blameᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M A B} {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ blame ⊑ M
+    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-blameᵀ renameρ renameγ M⊢ =
+  blame⊑ᵀ (right-typing-left-renameⁱ renameρ renameγ M⊢)
+
+left-rename-ƛᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {N N′ A A′ B B′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣
+      ctx-imp (renameᵗ τ A) A′
+        (⊑-rename-leftᵢ τ assm hτ pA) ∷ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ pB →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ƛ N) ⊑ ƛ N′
+    ⦂ renameᵗ τ (A ⇒ B) ⊑ A′ ⇒ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (pA ↦ pB)
+left-rename-ƛᵀ {hτ = hτ} hA hA′ N⊑N′ =
+  ƛ⊑ƛᵀ (renameᵗ-preserves-WfTy hA hτ) hA′ N⊑N′
+
+left-rename-·ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {L L′ M M′ A A′ B B′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ L ⊑ L′
+    ⦂ renameᵗ τ (A ⇒ B) ⊑ A′ ⇒ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (pA ↦ pB) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′
+    ∶ ⊑-rename-leftᵢ τ assm hτ pA →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (L · M) ⊑ L′ · M′
+    ⦂ renameᵗ τ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ pB
+left-rename-·ᵀ L⊑L′ M⊑M′ = ·⊑·ᵀ L⊑L′ M⊑M′
+
+left-rename-cast⊒⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (modeτ : CastModeRenamer τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-cast⊒⊑ᵀ modeτ renameρ mode seal★ c⊒ M⊑M′ =
+  cast⊒⊑ᵀ (CastModeRenamer.target-mode modeτ mode)
+    (left-seal★-renameⁱ modeτ renameρ mode seal★)
+    (left-narrowing-renameⁱ modeτ mode renameρ c⊒)
+    M⊑M′ _
+
+left-rename-cast⊑⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (modeτ : CastModeRenamer τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-cast⊑⊑ᵀ modeτ renameρ mode seal★ c⊑ M⊑M′ =
+  cast⊑⊑ᵀ (CastModeRenamer.target-mode modeτ mode)
+    (left-seal★-renameⁱ modeτ renameρ mode seal★)
+    (left-widening-renameⁱ modeτ mode renameρ c⊑)
+    M⊑M′ _
+
+left-rename-⊑cast⊒ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑cast⊒ᵀ renameρ mode′ seal★′ c′⊒ M⊑M′ =
+  ⊑cast⊒ᵀ mode′
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-narrowing-left-renameⁱ renameρ c′⊒) M⊑M′ _
+
+left-rename-⊑cast⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑cast⊑ᵀ renameρ mode′ seal★′ c′⊑ M⊑M′ =
+  ⊑cast⊑ᵀ mode′
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ c′⊑) M⊑M′ _
+
+left-rename-⊑cast⊑idᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  StoreDetWf Δᴿ (rightStoreⁱ ρ) →
+  SealModeStore★ id-onlyᵈ (rightStoreⁱ ρ) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑cast⊑idᵀ renameρ wfΣ′ seal★′ c′⊑ M⊑M′ =
+  ⊑cast⊑idᵀ
+    (right-store-det-left-renameⁱ renameρ wfΣ′)
+    (right-seal★-left-renameⁱ {μ = id-onlyᵈ} renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ c′⊑) M⊑M′ _
+
+left-rename-up⊑upᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {N N′ A A′ D D′ u u′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
+left-rename-up⊑upᵀ {τ = τ} renameρ u⊑ u′⊑ N⊑N′ =
+  up⊑upᵀ N⊑N′
+    (left-widening-rename-modeⁱ (modeRename-id-only τ) renameρ u⊑)
+    (right-widening-left-renameⁱ renameρ u′⊑) _
+
+left-rename-crossed-up⊑upᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {N N′ A A′ D D′ u u′ μ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {qD′ : Ψ ∣ Δᴸ′ ⊢ renameᵗ τ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+  SealModeStore★
+    (instᵈ (extᵈ tag-or-idᵈ)) (rightStoreⁱ ρ) →
+  instᵈ (extᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ u′ ∶ D′ ⊑ A′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ qD′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
+left-rename-crossed-up⊑upᵀ ins renameρ mode seal★ u⊑
+    seal★′ u′⊑ N⊑N′ =
+  crossed-up⊑upᵀ N⊑N′ target-mode target-seal target-u⊑
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ u′⊑) _
+  where
+  modeτ = left-insertion-cast-renamer ins
+  target-mode = CastModeRenamer.target-mode modeτ mode
+  target-seal = left-seal★-renameⁱ modeτ renameρ mode seal★
+  target-u⊑ = left-widening-renameⁱ modeτ mode renameρ u⊑
+
+left-rename-crossed-left-up⊑upᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {N N′ A A′ D D′ u u′ μ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {qD′ : Ψ ∣ Δᴸ′ ⊢ renameᵗ τ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+  SealModeStore★
+    (extᵈ (instᵈ tag-or-idᵈ)) (rightStoreⁱ ρ) →
+  extᵈ (instᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ u′ ∶ D′ ⊑ A′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ qD′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
+left-rename-crossed-left-up⊑upᵀ ins renameρ mode seal★ u⊑
+    seal★′ u′⊑ N⊑N′ =
+  crossed-left-up⊑upᵀ N⊑N′ target-mode target-seal target-u⊑
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ u′⊑) _
+  where
+  modeτ = left-insertion-cast-renamer ins
+  target-mode = CastModeRenamer.target-mode modeτ mode
+  target-seal = left-seal★-renameⁱ modeτ renameρ mode seal★
+  target-u⊑ = left-widening-renameⁱ modeτ mode renameρ u⊑
+
+left-rename-down⊑downᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ C C′ D D′ d d′}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ C ⊑ C′ ∶ ⊑-rename-leftᵢ τ assm hτ pC →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩) ⊑ M′ ⟨ d′ ⟩
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD
+left-rename-down⊑downᵀ {τ = τ} renameρ d⊒ d′⊒ M⊑M′ =
+  down⊑downᵀ
+    (left-narrowing-rename-modeⁱ (modeRename-id-only τ) renameρ d⊒)
+    (right-narrowing-left-renameⁱ renameρ d′⊒) M⊑M′ _
+
+left-rename-gen-down⊑gen-downᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ C C′ D D′ d d′}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ C ⊑ C′ ∶ ⊑-rename-leftᵢ τ assm hτ pC →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩) ⊑ M′ ⟨ d′ ⟩
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD
+left-rename-gen-down⊑gen-downᵀ {τ = τ} renameρ d⊒ d′⊒ M⊑M′ =
+  gen-down⊑gen-downᵀ
+    (left-narrowing-rename-modeⁱ
+      (modeRename-gen-tag-or-id τ) renameρ d⊒)
+    (right-narrowing-left-renameⁱ renameρ d′⊒) M⊑M′ _
+
+left-rename-Λᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {V V′ A B} {p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Value V →
+  Value V′ →
+  (∀ {ρ′∀ γ′∀} →
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ →
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ →
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      ρ∀ ρ′∀ →
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      γ∀ γ′∀ →
+    ∀ᵢᶜ Ψ ∣ suc Δᴸ′ ∣ suc Δᴿ ∣ ρ′∀ ∣ γ′∀
+      ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ V′
+      ⦂ renameᵗ (extᵗ τ) A ⊑ B
+      ∶ ⊑-rename-leftᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) p) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ Λ V′
+    ⦂ renameᵗ τ (`∀ A) ⊑ `∀ B
+    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ p)
+left-rename-Λᵀ renameρ renameγ liftρ liftγ vV vV′ body-map
+    with left-store-rename-∀ renameρ liftρ
+left-rename-Λᵀ renameρ renameγ liftρ liftγ vV vV′ body-map
+    | ρ′∀ , liftρ′ , renameρ∀
+    with left-ctx-rename-∀ renameγ liftγ
+left-rename-Λᵀ {τ = τ}
+    renameρ renameγ liftρ liftγ vV vV′ body-map
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  Λ⊑Λᵀ liftρ′ liftγ′
+    (renameᵗᵐ-preserves-Value (extᵗ τ) vV) vV′
+    (body-map liftρ′ liftγ′ renameρ∀ renameγ∀)
+
+left-rename-Λ⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {V N′ A B}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (occ : occurs zero A ≡ true) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Value V →
+  (∀ {ρ′ν γ′ν} →
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν →
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      ρν ρ′ν →
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      γν γ′ν →
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+      ∣ suc Δᴸ′ ∣ Δᴿ ∣ ρ′ν ∣ γ′ν
+      ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ N′
+      ⦂ renameᵗ (extᵗ τ) A ⊑ B
+      ∶ ⊑-rename-leftᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) p) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ N′
+    ⦂ renameᵗ τ (`∀ A) ⊑ B
+    ∶ ⊑-rename-leftᵢ τ assm hτ (ν occ p)
+left-rename-Λ⊑ᵀ renameρ renameγ occ liftρ liftγ vV body-map
+    with left-store-rename-ν renameρ liftρ
+left-rename-Λ⊑ᵀ renameρ renameγ occ liftρ liftγ vV body-map
+    | ρ′ν , liftρ′ , renameρν
+    with left-ctx-rename-ν renameγ liftγ
+left-rename-Λ⊑ᵀ {τ = τ} {A = A}
+    renameρ renameγ occ liftρ liftγ vV body-map
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  Λ⊑ᵀ (trans (occurs-zero-rename-ext τ A) occ)
+    liftρ′ liftγ′ (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
+    (body-map liftρ′ liftγ′ renameρν renameγν)
+
+left-rename-νᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {A A′ B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
+  (A⇑⊑A′⇑ : ∀ᵢᶜ Φ
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ q) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ ν A′ N′ s′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-νᵀ
+    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+    liftρ liftγ N⊑N′
+    with left-store-rename-∀ renameρ liftρ
+left-rename-νᵀ
+    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    with left-ctx-rename-∀ renameγ liftγ
+left-rename-νᵀ {τ = τ} {assm = assm} {hτ = hτ} {A = A}
+    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ν⊑νᵀ
+    (renameᵗ-preserves-WfTy hA hτ) hA′
+    (left-reveal-ν-renameⁱ ins renameρ s↑)
+    (right-reveal-ν-left-renameⁱ renameρ s′↑)
+    (⊑-rename-leftᵢ τ assm hτ A⊑A′)
+    (⊑-rename-left-atᵢ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+      (TyRenameWf-ext hτ)
+      (sym (renameᵗ-ext-suc-comm τ A)) A⇑⊑A′⇑)
+    liftρ′ liftγ′ N⊑N′
+
+left-rename-ν⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {A B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  WfTy Δᴸ A →
+  WfTy (suc Δᴸ) (⇑ᵗ A) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ N′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-ν⊑ᵀ
+    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
+    with left-store-rename-ν renameρ liftρ
+left-rename-ν⊑ᵀ
+    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    with left-ctx-rename-ν renameγ liftγ
+left-rename-ν⊑ᵀ {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {A = A}
+    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  ν⊑ᵀ (renameᵗ-preserves-WfTy hA hτ) h⇑A′
+    (left-reveal-ν-renameⁱ ins renameρ s↑)
+    liftρ′ liftγ′ N⊑N′
+  where
+  h⇑A′ : WfTy (suc Δᴸ′) (⇑ᵗ (renameᵗ τ A))
+  h⇑A′ =
+    subst (WfTy (suc Δᴸ′))
+      (renameᵗ-ext-suc-comm τ A)
+      (renameᵗ-preserves-WfTy h⇑A (TyRenameWf-ext hτ))
+
+left-rename-⊑νᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {A B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  WfTy Δᴿ A →
+  WfTy (suc Δᴿ) (⇑ᵗ A) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ B ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ ν A N′ s
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-⊑νᵀ
+    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-rename-⊑νᵀ
+    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    with left-ctx-rename-⇑ᴿ renameγ liftγ
+left-rename-⊑νᵀ {τ = τ} {assm = assm} {hτ = hτ}
+    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ⊑νᵀ hA h⇑A
+    (right-reveal-ν-left-renameⁱ renameρ s↑)
+    liftρ′ liftγ′
+    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ B⊑C′)
+    N⊑N′
+
+left-rename-νcastᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ q) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ ν ★ N′ s′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-νcastᵀ
+    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
+    liftρ liftγ N⊑N′
+    with left-store-rename-∀ renameρ liftρ
+left-rename-νcastᵀ
+    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    with left-ctx-rename-∀ renameγ liftγ
+left-rename-νcastᵀ
+    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  νcast⊑νcastᵀ
+    (CastModeRenamer.target-mode
+      (left-insertion-cast-renamer ins) mode)
+    (left-seal★-ν★-renameⁱ ins renameρ mode seal★)
+    mode′ (right-seal★-ν★-left-renameⁱ renameρ seal★′)
+    (left-widening-ν★-renameⁱ ins renameρ mode s⊑)
+    (right-widening-ν★-left-renameⁱ renameρ s′⊑)
+    liftρ′ liftγ′ N⊑N′
+
+left-rename-νcast⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ N′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-νcast⊑ᵀ
+    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
+    with left-store-rename-ν renameρ liftρ
+left-rename-νcast⊑ᵀ
+    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    with left-ctx-rename-ν renameγ liftγ
+left-rename-νcast⊑ᵀ
+    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  νcast⊑ᵀ
+    (CastModeRenamer.target-mode
+      (left-insertion-cast-renamer ins) mode)
+    (left-seal★-ν★-renameⁱ ins renameρ mode seal★)
+    (left-widening-ν★-renameⁱ ins renameρ mode s⊑)
+    liftρ′ liftγ′ N⊑N′
+
+left-rename-⊑νcastᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ B ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ ν ★ N′ s
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-⊑νcastᵀ
+    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-rename-⊑νcastᵀ
+    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    with left-ctx-rename-⇑ᴿ renameγ liftγ
+left-rename-⊑νcastᵀ {τ = τ} {assm = assm} {hτ = hτ}
+    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ⊑νcastᵀ mode
+    (right-seal★-ν★-left-renameⁱ renameρ seal★)
+    (right-widening-ν★-left-renameⁱ renameρ s⊑)
+    liftρ′ liftγ′
+    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ B⊑C′)
+    N⊑N′
+
+leftCtxⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  leftCtxⁱ
+      (rename-left-ctxⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ γ)
+    ≡ map (renameᵗ τ) (leftCtxⁱ γ)
+leftCtxⁱ-rename-left [] = refl
+leftCtxⁱ-rename-left (ctx-imp A B p ∷ γ) =
+  cong (renameᵗ _ A ∷_) (leftCtxⁱ-rename-left γ)
+
+rightCtxⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  rightCtxⁱ
+      (rename-left-ctxⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ γ)
+    ≡ rightCtxⁱ γ
+rightCtxⁱ-rename-left [] = refl
+rightCtxⁱ-rename-left (ctx-imp A B p ∷ γ) =
+  cong (B ∷_) (rightCtxⁱ-rename-left γ)
+
+rename-left-ctx-∋ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {γ x A B p} →
+  γ ∋ x ⦂ ctx-imp A B p →
+  rename-left-ctxⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ γ
+    ∋ x ⦂ ctx-imp (renameᵗ τ A) B
+      (⊑-rename-leftᵢ τ assm hτ p)
+rename-left-ctx-∋ Z = Z
+rename-left-ctx-∋ (S x∈) = S (rename-left-ctx-∋ x∈)
+
+rename-left-store-matched∈ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
+  store-matched α A β B p ∈ ρ →
+  store-matched (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p)
+    ∈ rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ ρ
+rename-left-store-matched∈ (here refl) = here refl
+rename-left-store-matched∈
+    {ρ = store-matched α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+rename-left-store-matched∈
+    {ρ = store-left α A hA ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+rename-left-store-matched∈
+    {ρ = store-right β B hB ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+rename-left-store-matched∈
+    {ρ = store-link α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+
+rename-left-store-link∈ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
+  store-link α A β B p ∈ ρ →
+  store-link (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p)
+    ∈ rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ ρ
+rename-left-store-link∈ (here refl) = here refl
+rename-left-store-link∈
+    {ρ = store-matched α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+rename-left-store-link∈
+    {ρ = store-left α A hA ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+rename-left-store-link∈
+    {ρ = store-right β B hB ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+rename-left-store-link∈
+    {ρ = store-link α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+
+rename-left-correspondence :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
+  StoreCorresponds ρ α A β B p →
+  StoreCorresponds
+    (rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ ρ)
+    (τ α) (renameᵗ τ A) β B
+    (⊑-rename-leftᵢ τ assm hτ p)
+rename-left-correspondence (correspondence-stored p∈) =
+  correspondence-stored (rename-left-store-matched∈ p∈)
+rename-left-correspondence (correspondence-linked p∈) =
+  correspondence-linked (rename-left-store-link∈ p∈)
+
+left-store-rename-matched∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {α A β B p} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  store-matched α A β B p ∈ ρ →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+    store-matched α′ A′ β B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∈ ρ′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-matched eqα eqA renameρ) (here refl) =
+  _ , eqα , _ , eqA , here refl
+left-store-rename-matched∈ⁱ
+    (left-store-rename-matched eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-left eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-right renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-link eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+
+left-store-rename-link∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {α A β B p} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  store-link α A β B p ∈ ρ →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+    store-link α′ A′ β B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∈ ρ′
+left-store-rename-link∈ⁱ
+    (left-store-rename-matched eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-link∈ⁱ
+    (left-store-rename-left eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-link∈ⁱ
+    (left-store-rename-right renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-link∈ⁱ
+    (left-store-rename-link eqα eqA renameρ) (here refl) =
+  _ , eqα , _ , eqA , here refl
+left-store-rename-link∈ⁱ
+    (left-store-rename-link eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+
+left-store-rename-correspondenceⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {α A β B p} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  StoreCorresponds ρ α A β B p →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+    StoreCorresponds ρ′ α′ A′ β B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p)
+left-store-rename-correspondenceⁱ renameρ
+    (correspondence-stored p∈) =
+  let α′ , eqα , A′ , eqA , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα , A′ , eqA , correspondence-stored p∈′
+left-store-rename-correspondenceⁱ renameρ
+    (correspondence-linked p∈) =
+  let α′ , eqα , A′ , eqA , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα , A′ , eqA , correspondence-linked p∈′
+
+left-paired-conversion-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {c c′ A A′ B B′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  PairedConversion Φ Δᴸ Δᴿ ρ c c′ p q →
+  PairedConversion Ψ Δᴸ′ Δᴿ ρ′
+    (renameᶜ τ c) c′
+    (⊑-rename-leftᵢ τ assm hτ p)
+    (⊑-rename-leftᵢ τ assm hτ q)
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-reveal corr conv conv′)
+    with left-store-rename-correspondenceⁱ renameρ corr
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-reveal corr conv conv′)
+    | α′ , refl , A′ , refl , corr′ =
+  paired-reveal corr′
+    (left-reveal-renameⁱ ins renameρ conv)
+    (right-reveal-left-renameⁱ renameρ conv′)
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-conceal corr conv conv′)
+    with left-store-rename-correspondenceⁱ renameρ corr
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-conceal corr conv conv′)
+    | α′ , refl , A′ , refl , corr′ =
+  paired-conceal corr′
+    (left-conceal-renameⁱ ins renameρ conv)
+    (right-conceal-left-renameⁱ renameρ conv′)
+
+left-paired-cast-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {c c′ A A′ B B′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+  PairedCast Ψ Δᴸ′ Δᴿ ρ′
+    (renameᶜ τ c) c′
+    (⊑-rename-leftᵢ τ assm hτ p)
+    (⊑-rename-leftᵢ τ assm hτ q)
+left-paired-cast-renameⁱ ins renameρ
+    (paired-conversion conv) =
+  paired-conversion (left-paired-conversion-renameⁱ ins renameρ conv)
+left-paired-cast-renameⁱ ins renameρ
+    (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑) =
+  paired-widening
+    (CastModeRenamer.target-mode modeτ mode)
+    (left-seal★-renameⁱ modeτ renameρ mode seal★)
+    (left-widening-renameⁱ modeτ mode renameρ c⊑)
+    mode′
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ c′⊑)
+  where
+  modeτ = left-insertion-cast-renamer ins
+
+left-rename-conv⊑convᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ c c′ A A′ B B′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-conv⊑convᵀ ins renameρ cast M⊑M′ =
+  conv⊑convᵀ (left-paired-cast-renameⁱ ins renameρ cast) M⊑M′
+
+left-rename-conv↑⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ α X}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-conv↑⊑ᵀ ins renameρ conv M⊑M′ =
+  conv↑⊑ᵀ (left-reveal-renameⁱ ins renameρ conv) M⊑M′ _
+
+left-rename-conv↓⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ α X}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-conv↓⊑ᵀ ins renameρ conv M⊑M′ =
+  conv↓⊑ᵀ (left-conceal-renameⁱ ins renameρ conv) M⊑M′ _
+
+left-rename-⊑conv↑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′ β X′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑conv↑ᵀ renameρ conv M⊑M′ =
+  ⊑conv↑ᵀ (right-reveal-left-renameⁱ renameρ conv) M⊑M′ _
+
+left-rename-⊑conv↓ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′ β X′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑conv↓ᵀ renameρ conv M⊑M′ =
+  ⊑conv↓ᵀ (right-conceal-left-renameⁱ renameρ conv) M⊑M′ _
+
+lift-ctx-result :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γ′ ] LiftCtxⁱ (∀ᵢᶜ Φ) γ γ′
+lift-ctx-result [] = [] , lift-ctx-[]
+lift-ctx-result (ctx-imp A B p ∷ γ) with lift-ctx-result γ
+lift-ctx-result (ctx-imp A B p ∷ γ) | γ′ , liftγ =
+  ctx-imp (⇑ᵗ A) (⇑ᵗ B) (⊑-lift∀ᵢ p) ∷ γ′ ,
+  lift-ctx-∷ liftγ
+
+lift-left-ctx-result :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γ′ ] LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
+lift-left-ctx-result [] = [] , lift-left-ctx-[]
+lift-left-ctx-result (ctx-imp A B p ∷ γ)
+    with lift-left-ctx-result γ
+lift-left-ctx-result (ctx-imp A B p ∷ γ) | γ′ , liftγ =
+  ctx-imp (⇑ᵗ A) B (⊑-source-liftνᵢ p) ∷ γ′ ,
+  lift-left-ctx-∷ liftγ
+
+left-forall-store-square :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρν ] ∃[ ρ∀ ] ∃[ ρν∀ ] ∃[ ρ∀ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν ×
+    LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ ×
+    LiftStoreⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρν ρν∀ ×
+    LiftLeftStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (∀ᵢᶜ Φ)) ρ∀ ρ∀ν ×
+    leftStoreⁱ ρν∀ ≡ leftStoreⁱ ρ∀ν ×
+    rightStoreⁱ ρν∀ ≡ rightStoreⁱ ρ∀ν
+left-forall-store-square ρ with lift-left-store-result ρ
+left-forall-store-square ρ | ρν , liftν
+    with lift-store-result ρ
+left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
+    with lift-store-result ρν
+left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
+    | ρν∀ , liftν∀ with lift-left-store-result ρ∀
+left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
+    | ρν∀ , liftν∀ | ρ∀ν , lift∀ν =
+  ρν , ρ∀ , ρν∀ , ρ∀ν ,
+  liftν , lift∀ , liftν∀ , lift∀ν ,
+  trans
+    (leftStoreⁱ-lift liftν∀)
+    (trans
+      (cong ⟰ᵗ (leftStoreⁱ-lift-left liftν))
+      (sym
+        (trans
+          (leftStoreⁱ-lift-left lift∀ν)
+          (cong ⟰ᵗ (leftStoreⁱ-lift lift∀))))) ,
+  trans
+    (rightStoreⁱ-lift liftν∀)
+    (trans
+      (cong ⟰ᵗ (rightStoreⁱ-lift-left liftν))
+      (sym
+        (trans
+          (rightStoreⁱ-lift-left lift∀ν)
+          (rightStoreⁱ-lift lift∀))))
+
+left-forall-ctx-square :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γν ] ∃[ γ∀ ] ∃[ γν∀ ] ∃[ γ∀ν ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν ×
+    LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ ×
+    LiftCtxⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γν γν∀ ×
+    LiftLeftCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (∀ᵢᶜ Φ)) γ∀ γ∀ν ×
+    leftCtxⁱ γν∀ ≡ leftCtxⁱ γ∀ν ×
+    rightCtxⁱ γν∀ ≡ rightCtxⁱ γ∀ν
+left-forall-ctx-square γ with lift-left-ctx-result γ
+left-forall-ctx-square γ | γν , liftν with lift-ctx-result γ
+left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
+    with lift-ctx-result γν
+left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
+    | γν∀ , liftν∀ with lift-left-ctx-result γ∀
+left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
+    | γν∀ , liftν∀ | γ∀ν , lift∀ν =
+  γν , γ∀ , γν∀ , γ∀ν ,
+  liftν , lift∀ , liftν∀ , lift∀ν ,
+  trans
+    (leftCtxⁱ-lift liftν∀)
+    (trans
+      (cong ⤊ᵗ (leftCtxⁱ-lift-left liftν))
+      (sym
+        (trans
+          (leftCtxⁱ-lift-left lift∀ν)
+          (cong ⤊ᵗ (leftCtxⁱ-lift lift∀))))) ,
+  trans
+    (rightCtxⁱ-lift liftν∀)
+    (trans
+      (cong ⤊ᵗ (rightCtxⁱ-lift-left liftν))
+      (sym
+        (trans
+          (rightCtxⁱ-lift-left lift∀ν)
+          (rightCtxⁱ-lift lift∀))))
+
+left-source-lift-Λᵀ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρν∀ : StoreImp (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) (suc Δᴿ)}
+    {γν∀ : CtxImp (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) (suc Δᴿ)}
+    {V V′ A B q} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  LiftStoreⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρν ρν∀ →
+  LiftCtxⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γν γν∀ →
+  Value V →
+  Value V′ →
+  ∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc (suc Δᴸ) ∣ suc Δᴿ ∣ ρν∀ ∣ γν∀
+    ⊢ᴺ renameᵗᵐ (extᵗ suc) V ⊑ V′
+    ⦂ renameᵗ (extᵗ suc) A ⊑ B ∶ q →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρν ∣ γν
+    ⊢ᴺ ⇑ᵗᵐ (Λ V) ⊑ Λ V′
+    ⦂ ⇑ᵗ (`∀ A) ⊑ `∀ B ∶ ∀ⁱ q
+left-source-lift-Λᵀ
+    liftνρ liftνγ liftν∀ρ liftν∀γ vV vV′ V⊑V′ =
+  Λ⊑Λᵀ liftν∀ρ liftν∀γ
+    (renameᵗᵐ-preserves-Value (extᵗ suc) vV) vV′ V⊑V′
+
+left-source-lift-⊑αᵀ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {N L′ A B C′ q} →
+  Value L′ →
+  No• L′ →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᴸ ∣ γᴸ
+    ⊢ᴺ ⇑ᵗᵐ N ⊑ L′
+    ⦂ ⇑ᵗ B ⊑ `∀ C′ ∶ ⊑-source-liftνᵢ q →
+  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  suc Δᴿ ∣
+    rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ) ∣
+    rightCtxⁱ γᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′ →
+  ∃[ ρ× ] ∃[ γ× ]
+    LiftRightStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴸ ρ× ×
+    LiftLeftStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴿ ρ× ×
+    LiftRightCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴸ γ× ×
+    LiftLeftCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴿ γ× ×
+    (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      ∣ suc Δᴸ ∣ suc Δᴿ ∣
+      store-right zero (⇑ᵗ A) h⇑A ∷ ρ× ∣ γ×
+      ⊢ᴺ ⇑ᵗᵐ N ⊑ (⇑ᵗᵐ L′) •
+      ⦂ ⇑ᵗ B ⊑ C′ ∶ ⊑-source-under-rightᵢ r
+left-source-lift-⊑αᵀ
+    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    N⊑L′ r L′•⊢
+    with left-right-store-commuteⁱ liftᴸρ liftᴿρ
+left-source-lift-⊑αᵀ
+    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    N⊑L′ r L′•⊢
+    | ρ× , rightᴸρ , leftᴿρ
+    with left-right-ctx-commuteⁱ liftᴸγ liftᴿγ
+left-source-lift-⊑αᵀ
+    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    N⊑L′ r L′•⊢
+    | ρ× , rightᴸρ , leftᴿρ
+    | γ× , rightᴸγ , leftᴿγ =
+  ρ× , γ× , rightᴸρ , leftᴿρ , rightᴸγ , leftᴿγ ,
+  ⊑αᵀ vL′ noL′ h⇑A rightᴸρ rightᴸγ N⊑L′
+    (⊑-source-under-rightᵢ r) source-typing target-typing
+  where
+  source-typing =
+    subst
+      (λ Γ → _ ∣ leftStoreⁱ ρ× ∣ Γ ⊢ _ ⦂ _)
+      (sym (leftCtxⁱ-lift-right rightᴸγ))
+      (subst
+        (λ Σ → _ ∣ Σ ∣ leftCtxⁱ _ ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right rightᴸρ))
+        (nu-term-imprecision-source-typing N⊑L′))
+
+  target-typing =
+    subst
+      (λ Γ → _ ∣
+        rightStoreⁱ (store-right zero _ h⇑A ∷ ρ×) ∣ Γ
+        ⊢ _ ⦂ _)
+      (sym (rightCtxⁱ-lift-left leftᴿγ))
+      (subst
+        (λ Σ → _ ∣ (zero , _) ∷ Σ ∣ rightCtxⁱ _
+          ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left leftᴿρ)) L′•⊢)
+
+left-rename-⊑αᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {ρ′ᴿ : StoreImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ′ᴿ : CtxImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)}
+    {N L′ A B C′}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ}
+    {r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ}
+    {h⇑A h⇑A′ : WfTy (suc Δᴿ) (⇑ᵗ A)} →
+  LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ
+    (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ)
+    (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ) →
+  LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ →
+  Value L′ →
+  No• L′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  (∀ {ρ′ γ′} →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftCtxRenameⁱ τ assm hτ γ γ′ →
+    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ N ⊑ L′
+      ⦂ renameᵗ τ B ⊑ `∀ C′
+      ∶ ⊑-rename-leftᵢ τ assm hτ q) →
+  suc Δᴿ
+    ∣ rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ)
+    ∣ rightCtxⁱ γᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′ →
+  (⇑ᴿᵢ Ψ) ∣ Δᴸ′ ∣ suc Δᴿ ∣
+    store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ ∣ γ′ᴿ
+    ⊢ᴺ renameᵗᵐ τ N ⊑ (⇑ᵗᵐ L′) •
+    ⦂ renameᵗ τ B ⊑ C′
+    ∶ ⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ r
+left-rename-⊑αᵀ
+    {Ψ = Ψ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρᴿ = ρᴿ} {ρ′ᴿ = ρ′ᴿ} {γᴿ = γᴿ} {γ′ᴿ = γ′ᴿ}
+    {N = N} {L′ = L′} {A = A} {B = B} {C′ = C′}
+    {q = q} {r = r} {h⇑A = h⇑A} {h⇑A′ = h⇑A′}
+    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
+    liftρ liftγ body-map L′•⊢
+    with left-store-rename-⇑ᴿ-inv liftρ renameρᴿ
+left-rename-⊑αᵀ
+    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
+    liftρ liftγ body-map L′•⊢
+    | ρ′ , renameρ′ , liftρ′
+    with left-ctx-rename-⇑ᴿ-inv liftγ renameγᴿ
+left-rename-⊑αᵀ
+    {Ψ = Ψ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρᴿ = ρᴿ} {ρ′ᴿ = ρ′ᴿ} {γᴿ = γᴿ} {γ′ᴿ = γ′ᴿ}
+    {N = N} {L′ = L′} {A = A} {B = B} {C′ = C′}
+    {q = q} {r = r} {h⇑A = h⇑A} {h⇑A′ = h⇑A′}
+    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
+    liftρ liftγ body-map L′•⊢
+    | ρ′ , renameρ′ , liftρ′
+    | γ′ , renameγ′ , liftγ′ =
+  ⊑αᵀ vL′ noL′ h⇑A′ liftρ′ liftγ′ N⊑L′
+    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ r)
+    source-typing target-typing
+  where
+  N⊑L′ :
+    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ N ⊑ L′
+      ⦂ renameᵗ τ B ⊑ `∀ C′
+      ∶ ⊑-rename-leftᵢ τ assm hτ q
+  N⊑L′ = body-map renameρ′ renameγ′
+
+  source-typing :
+    Δᴸ′ ∣ leftStoreⁱ ρ′ᴿ ∣ leftCtxⁱ γ′ᴿ
+      ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B
+  source-typing =
+    subst
+      (λ Γ → Δᴸ′ ∣ leftStoreⁱ ρ′ᴿ ∣ Γ
+        ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B)
+      (sym (leftCtxⁱ-lift-right liftγ′))
+      (subst
+        (λ Σ → Δᴸ′ ∣ Σ ∣ leftCtxⁱ γ′
+          ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B)
+        (sym (leftStoreⁱ-lift-right liftρ′))
+        (nu-term-imprecision-source-typing N⊑L′))
+
+  target-typing :
+    suc Δᴿ
+      ∣ rightStoreⁱ
+          (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ)
+      ∣ rightCtxⁱ γ′ᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′
+  target-typing =
+    subst
+      (λ Γ → suc Δᴿ
+        ∣ rightStoreⁱ
+            (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ)
+        ∣ Γ ⊢ (⇑ᵗᵐ L′) • ⦂ C′)
+      (sym (rightCtxⁱ-left-rename renameγᴿ))
+      (subst
+        (λ Σ → suc Δᴿ ∣ Σ ∣ rightCtxⁱ γᴿ
+          ⊢ (⇑ᵗᵐ L′) • ⦂ C′)
+        (sym
+          (rightStoreⁱ-left-rename
+            (left-store-rename-right
+              {hB = h⇑A} {hB′ = h⇑A′} renameρᴿ)))
+        L′•⊢)
+
+left-source-lift-allocation-leftᵀ :
+  ∀ {Φ Δᴸ Δᴿ α α′ A A′ B B′ M M′}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρν′ : StoreImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν′ : CtxImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) Δᴿ}
+    {hA : WfTy (suc Δᴸ) A}
+    {hA′ : WfTy (suc (suc Δᴸ)) A′}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  No• M →
+  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc
+    (store-left α A hA ∷ ρν)
+    (store-left α′ A′ hA′ ∷ ρν′) →
+  LeftCtxRenameⁱ suc rename-assm²-source-νᵢ
+    TyRenameWf-suc γν γν′ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+    ∣ suc (suc Δᴸ) ∣ Δᴿ ∣ ρν′ ∣ γν′
+    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc p →
+  suc Δᴸ ∣ leftStoreⁱ (store-left α A hA ∷ ρν)
+    ∣ leftCtxⁱ γν ⊢ M ⦂ B →
+  Δᴿ ∣ rightStoreⁱ (store-left α A hA ∷ ρν)
+    ∣ rightCtxⁱ γν ⊢ M′ ⦂ B′ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+    ∣ suc (suc Δᴸ) ∣ Δᴿ ∣
+    store-left α′ A′ hA′ ∷ ρν′ ∣ γν′
+    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc p
+left-source-lift-allocation-leftᵀ noM
+    (left-store-rename-left eqα eqA renameρν)
+    renameγν M⊑M′ M⊢ M′⊢ with eqα
+left-source-lift-allocation-leftᵀ noM
+    (left-store-rename-left eqα eqA renameρν)
+    renameγν M⊑M′ M⊢ M′⊢ | refl with eqA
+left-source-lift-allocation-leftᵀ
+    {α = α} {A = A} {ρν = ρν} {ρν′ = ρν′}
+    {hA = hA} {hA′ = hA′} noM
+    (left-store-rename-left eqα eqA renameρν)
+    renameγν M⊑M′ M⊢ M′⊢ | refl | refl =
+  allocation-leftᵀ _ (left-store-rename-suc-liftⁱ renameρν)
+    M⊑M′ source-typing target-typing
+  where
+  full-rename :
+    LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc
+      (store-left α A hA ∷ ρν)
+      (store-left (suc α) (⇑ᵗ A) hA′ ∷ ρν′)
+  full-rename = left-store-rename-left refl refl renameρν
+
+  source-typing =
+    left-typing-renameⁱ {ψ = predᵗ}
+      RenameLeftInverse-suc castModeRenamer-suc
+      full-rename renameγν noM M⊢
+
+  target-typing =
+    right-typing-left-renameⁱ full-rename renameγν M′⊢
+
+⊑-lift-under-∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ renameᵗ (extᵗ suc) A ⊑ renameᵗ (extᵗ suc) B
+    ⊣ suc (suc Δᴿ)
+⊑-lift-under-∀ᵢ =
+  ⊑-renameᵗ²ᵢ
+    (rename-assm²-⇑ᵢ rename-assm²-∀ᵢ)
+    (TyRenameWf-ext TyRenameWf-suc)
+    (TyRenameWf-ext TyRenameWf-suc)
+
+renameᵗ-ext-id : ∀ A → renameᵗ (extᵗ (λ X → X)) A ≡ A
+renameᵗ-ext-id A =
+  trans (rename-cong (λ { zero → refl ; (suc X) → refl }) A)
+    (renameᵗ-id A)
+
+⊑-target-lift-right-under-∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (⇑ᴿᵢ Φ) ∣ suc Δᴸ
+    ⊢ A ⊑ renameᵗ (extᵗ suc) B ⊣ suc (suc Δᴿ)
+⊑-target-lift-right-under-∀ᵢ {A = A} p =
+  subst
+    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ (extᵗ suc) _ ⊣ _)
+    (renameᵗ-ext-id A)
+    (⊑-renameᵗ²ᵢ
+      (rename-assm²-⇑ᵢ rename-assm²-target-rightᵢ)
+      (TyRenameWf-ext (λ X<Δ → X<Δ))
+      (TyRenameWf-ext TyRenameWf-suc)
+      p)
+
+rename-assm²-paired-under-right-tailᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (extᵗ suc) a ∈ ⇑ᴿᵢ (⇑ᵢ Φ)
+rename-assm²-paired-under-right-tailᵢ {Φ = []} ()
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-paired-under-right-tailᵢ a∈)
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-paired-under-right-tailᵢ a∈)
+
+rename-assm²-paired-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (extᵗ suc) a ∈ ⇑ᴿᵢ (∀ᵢᶜ Φ)
+rename-assm²-paired-under-rightᵢ a∈ =
+  there (rename-assm²-paired-under-right-tailᵢ a∈)
+
+⊑-lift-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (∀ᵢᶜ Φ) ∣ suc Δᴸ
+    ⊢ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B
+    ⊣ suc (suc Δᴿ)
+⊑-lift-under-rightᵢ =
+  ⊑-renameᵗ²ᵢ
+    rename-assm²-paired-under-rightᵢ
+    TyRenameWf-suc
+    (TyRenameWf-ext TyRenameWf-suc)
+
+rename-assm²-right-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ (λ X → X) (extᵗ suc) a ∈ ⇑ᴿᵢ (⇑ᴿᵢ Φ)
+rename-assm²-right-under-rightᵢ {Φ = []} ()
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-right-under-rightᵢ a∈)
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-right-under-rightᵢ a∈)
+
+⊑-target-lift-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (⇑ᴿᵢ Φ) ∣ Δᴸ
+    ⊢ A ⊑ renameᵗ (extᵗ suc) B
+    ⊣ suc (suc Δᴿ)
+⊑-target-lift-under-rightᵢ {A = A} p =
+  subst
+    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ (extᵗ suc) _ ⊣ _)
+    (renameᵗ-id A)
+    (⊑-renameᵗ²ᵢ
+      rename-assm²-right-under-rightᵢ
+      (λ X<Δ → X<Δ)
+      (TyRenameWf-ext TyRenameWf-suc)
+      p)
+
+rename-assm²-crossed-under-right-tailᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ
+    (λ X → suc (suc X))
+    (extᵗ (λ X → suc (suc X))) a
+    ∈ ⇑ᴿᵢ (⇑ᵢ (⇑ᵢ Φ))
+rename-assm²-crossed-under-right-tailᵢ {Φ = []} ()
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-crossed-under-right-tailᵢ a∈)
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-crossed-under-right-tailᵢ a∈)
+
+rename-assm²-crossed-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ
+    (λ X → suc (suc X))
+    (extᵗ (λ X → suc (suc X))) a
+    ∈ ⇑ᴿᵢ (swapRight∀∀ᵢ Φ)
+rename-assm²-crossed-under-rightᵢ a∈ =
+  there (there (rename-assm²-crossed-under-right-tailᵢ a∈))
+
+renameᵗ-double-lift :
+  ∀ A →
+  ⇑ᵗ (⇑ᵗ A) ≡ renameᵗ (λ X → suc (suc X)) A
+renameᵗ-double-lift A = renameᵗ-compose suc suc A
+
+renameᵗ-double-under-∀ :
+  ∀ A →
+  renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A) ≡
+    renameᵗ (extᵗ (λ X → suc (suc X))) A
+renameᵗ-double-under-∀ A =
+  trans (renameᵗ-compose (extᵗ suc) (extᵗ suc) A)
+    (rename-cong (λ { zero → refl ; (suc X) → refl }) A)
+
+⊑-crossed-double-lift-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (swapRight∀∀ᵢ Φ) ∣ suc (suc Δᴸ)
+    ⊢ ⇑ᵗ (⇑ᵗ A)
+      ⊑ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) B)
+    ⊣ suc (suc (suc Δᴿ))
+⊑-crossed-double-lift-under-rightᵢ {A = A} {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢ ⇑ᵗ (⇑ᵗ A) ⊑ T ⊣ _)
+    (sym (renameᵗ-double-under-∀ B))
+    (subst
+      (λ S → _ ∣ _ ⊢ S ⊑
+        renameᵗ (extᵗ (λ X → suc (suc X))) B ⊣ _)
+      (sym (renameᵗ-double-lift A))
+      (⊑-renameᵗ²ᵢ
+        rename-assm²-crossed-under-rightᵢ
+        (λ X<Δ → s<s (s<s X<Δ))
+        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
+        p))
+
+rename-assm²-crossed-doubleᵢ :
+  ∀ {Φ a} →
+  a ∈ Φ →
+  rename-assm²ᵢ (λ X → suc (suc X)) (λ X → suc (suc X)) a
+    ∈ swapRight∀∀ᵢ Φ
+rename-assm²-crossed-doubleᵢ {a = X ˣ⊑★} a∈ =
+  rename-assm²-swapRight∀∀ᵢ
+    (rename-assm²-∀ᵢ (rename-assm²-∀ᵢ a∈))
+rename-assm²-crossed-doubleᵢ {a = X ˣ⊑ˣ Y} a∈ =
+  rename-assm²-swapRight∀∀ᵢ
+    (rename-assm²-∀ᵢ (rename-assm²-∀ᵢ a∈))
+
+⊑-crossed-double-lift-under-∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (swapRight∀∀ᵢ Φ) ∣ suc (suc (suc Δᴸ))
+    ⊢ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A)
+      ⊑ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) B)
+    ⊣ suc (suc (suc Δᴿ))
+⊑-crossed-double-lift-under-∀ᵢ {A = A} {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢
+      renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A) ⊑ T ⊣ _)
+    (sym (renameᵗ-double-under-∀ B))
+    (subst
+      (λ S → _ ∣ _ ⊢ S ⊑
+        renameᵗ (extᵗ (λ X → suc (suc X))) B ⊣ _)
+      (sym (renameᵗ-double-under-∀ A))
+      (⊑-renameᵗ²ᵢ
+        (rename-assm²-⇑ᵢ rename-assm²-crossed-doubleᵢ)
+        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
+        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
+        p))
+
+weak-one-step-source-blame-right-allocationᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ V′ s s′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  Value V′ →
+  No• V′ →
+  WfTy (suc Δᴿ) (⇑ᵗ A′) →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ ν A′ V′ s′ ⦂ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepResult ρ
+    (ν A blame s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-source-blame-right-allocationᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′}
+    {V′ = V′} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB
+    with lift-right-store-result ρ
+weak-one-step-source-blame-right-allocationᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′}
+    {V′ = V′} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB
+    | ρ′ , liftρ =
+  record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = blame
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = ⇑ᴿᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-right zero (⇑ᵗ A′) h⇑A′ ∷ ρ′
+    ; resultSourceType = _
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-target-lift-rightᵢ
+    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
+    ; transportRightBody = ⊑-target-lift-under-rightᵢ
+    ; resultType = ⊑-target-lift-rightᵢ pB
+    ; sourceCatchup = ↠-step blame-ν ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
+    ; targetStoreResult = target-store-result
+    ; relatedResults = blame⊑ᵀ target-result-typing
+    }
+  where
+    target-store-result =
+      cong ((zero , ⇑ᵗ A′) ∷_)
+        (rightStoreⁱ-lift-right liftρ)
+
+    target-result-typing =
+      subst
+        (λ Σ → suc Δᴿ ∣ Σ ∣ []
+          ⊢ ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩ ⦂ ⇑ᵗ B′)
+        (sym target-store-result)
+        (preservation wfΣ′ (ok-ν (ok-no noV′)) target⊢
+          (ν-step vV′ noV′))
+
+weak-one-step-compose-type :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C D} →
+  Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
+  resultCtx second ∣ resultLeftCtx second
+    ⊢ applyTys (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTys
+        (targetTailChanges first ++
+          χ′ ∷ targetTailChanges second)
+        (applyTy χ D)
+      ⊣ resultRightCtx second
+weak-one-step-compose-type {B = B} {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  subst
+    (λ T → resultCtx second ∣ resultLeftCtx second
+      ⊢ applyTys
+          (sourceChanges first ++ sourceChanges second) C
+        ⊑ T ⊣ resultRightCtx second)
+    (sym (applyTys-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTy χ D)))
+    (subst
+      (λ S → resultCtx second ∣ resultLeftCtx second
+        ⊢ S ⊑ applyTys (targetTailChanges second)
+            (applyTy χ′
+              (applyTys (targetTailChanges first)
+                (applyTy χ D)))
+          ⊣ resultRightCtx second)
+      (sym (applyTys-++
+        (sourceChanges first) (sourceChanges second) C))
+      (transportType second (transportType first p)))
+
+weak-one-step-compose-all-body :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C D} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+  ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
+    ⊢ applyTysUnderTyBinders
+        (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTysUnderTyBinders
+          (targetTailChanges first ++
+            χ′ ∷ targetTailChanges second)
+          (applyTyUnderTyBinder χ D)
+      ⊣ suc (resultRightCtx second)
+weak-one-step-compose-all-body {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  subst
+    (λ T → ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
+      ⊢ applyTysUnderTyBinders
+          (sourceChanges first ++ sourceChanges second) C
+        ⊑ T ⊣ suc (resultRightCtx second))
+    (sym (applyTysUnderTyBinders-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTyUnderTyBinder χ D)))
+    (subst
+      (λ S → ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
+        ⊢ S ⊑ applyTysUnderTyBinders
+            (targetTailChanges second)
+            (applyTyUnderTyBinder χ′
+              (applyTysUnderTyBinders
+                (targetTailChanges first)
+                (applyTyUnderTyBinder χ D)))
+          ⊣ suc (resultRightCtx second))
+      (sym (applyTysUnderTyBinders-++
+        (sourceChanges first) (sourceChanges second) C))
+      (transportAllBody second (transportAllBody first p)))
+
+weak-one-step-compose-right-body :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C D} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
+    ⊢ applyTys
+        (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTysUnderTyBinders
+          (targetTailChanges first ++
+            χ′ ∷ targetTailChanges second)
+          (applyTyUnderTyBinder χ D)
+      ⊣ suc (resultRightCtx second)
+weak-one-step-compose-right-body {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  subst
+    (λ T → ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
+      ⊢ applyTys
+          (sourceChanges first ++ sourceChanges second) C
+        ⊑ T ⊣ suc (resultRightCtx second))
+    (sym (applyTysUnderTyBinders-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTyUnderTyBinder χ D)))
+    (subst
+      (λ S → ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
+        ⊢ S ⊑ applyTysUnderTyBinders
+            (targetTailChanges second)
+            (applyTyUnderTyBinder χ′
+              (applyTysUnderTyBinders
+                (targetTailChanges first)
+                (applyTyUnderTyBinder χ D)))
+          ⊣ suc (resultRightCtx second))
+      (sym (applyTys-++
+        (sourceChanges first) (sourceChanges second) C))
+      (transportRightBody second (transportRightBody first p)))
+
+weak-one-step-composeᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  targetResult first —→[ χ′ ] N′ →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  WeakOneStepResult ρ M M′ A B χ
+weak-one-step-composeᵀ {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B}
+    {χ = χ} {ρ = ρ} first {χ′ = χ′} target→ second =
+  record
+    { sourceChanges = sourceChanges first ++ sourceChanges second
+    ; targetTailChanges =
+        targetTailChanges first ++ χ′ ∷ targetTailChanges second
+    ; sourceResult = sourceResult second
+    ; targetResult = targetResult second
+    ; resultCtx = resultCtx second
+    ; resultLeftCtx = resultLeftCtx second
+    ; resultRightCtx = resultRightCtx second
+    ; sourceCtxResult =
+        trans (sourceCtxResult second)
+          (trans
+            (cong (applyTyCtxs (sourceChanges second))
+              (sourceCtxResult first))
+            (sym (applyTyCtxs-++
+              (sourceChanges first) (sourceChanges second) Δᴸ)))
+    ; targetCtxResult =
+        trans (targetCtxResult second)
+          (trans
+            (cong
+              (λ Δ → applyTyCtxs (targetTailChanges second)
+                (applyTyCtx χ′ Δ))
+              (targetCtxResult first))
+            (sym (applyTyCtxs-++
+              (targetTailChanges first)
+              (χ′ ∷ targetTailChanges second)
+              (applyTyCtx χ Δᴿ))))
+    ; resultStore = resultStore second
+    ; resultSourceType = resultSourceType second
+    ; resultTargetType = resultTargetType second
+    ; sourceTypeResult =
+        trans (sourceTypeResult second)
+          (trans
+            (cong (applyTys (sourceChanges second))
+              (sourceTypeResult first))
+            (sym (applyTys-++
+              (sourceChanges first) (sourceChanges second) A)))
+    ; targetTypeResult =
+        trans (targetTypeResult second)
+          (trans
+            (cong
+              (λ C → applyTys (targetTailChanges second)
+                (applyTy χ′ C))
+              (targetTypeResult first))
+            (sym (applyTys-++
+              (targetTailChanges first)
+              (χ′ ∷ targetTailChanges second)
+              (applyTy χ B))))
+    ; transportType = weak-one-step-compose-type first second
+    ; transportAllBody = weak-one-step-compose-all-body first second
+    ; transportRightBody =
+        weak-one-step-compose-right-body first second
+    ; resultType = resultType second
+    ; sourceCatchup =
+        ↠-trans (sourceCatchup first) (sourceCatchup second)
+    ; targetTail =
+        ↠-trans (targetTail first)
+          (↠-step target→ (targetTail second))
+    ; sourceStoreResult =
+        trans (sourceStoreResult second)
+          (trans
+            (cong (applyStores (sourceChanges second))
+              (sourceStoreResult first))
+            (sym (applyStores-++
+              (sourceChanges first) (sourceChanges second)
+              (leftStoreⁱ ρ))))
+    ; targetStoreResult =
+        trans (targetStoreResult second)
+          (trans
+            (cong
+              (λ Σ → applyStores (targetTailChanges second)
+                (applyStore χ′ Σ))
+              (targetStoreResult first))
+            (sym (applyStores-++
+              (targetTailChanges first)
+              (χ′ ∷ targetTailChanges second)
+              (applyStore χ (rightStoreⁱ ρ)))))
+    ; relatedResults = relatedResults second
+    }
+
+weak-one-step-prepend-left-silentᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (silent : LeftSilentResult {M = M} {V′ = V′} {ρ = ρ}) →
+  let first = silentResult silent in
+  ∀ {χ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ) →
+  WeakOneStepResult ρ M N′ A B χ
+weak-one-step-prepend-left-silentᵀ
+    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B} {ρ = ρ}
+    (left-silent first (left-silent-invariant refl refl))
+    {χ = χ} second =
+  record
+    { sourceChanges = sourceChanges first ++ sourceChanges second
+    ; targetTailChanges = targetTailChanges second
+    ; sourceResult = sourceResult second
+    ; targetResult = targetResult second
+    ; resultCtx = resultCtx second
+    ; resultLeftCtx = resultLeftCtx second
+    ; resultRightCtx = resultRightCtx second
+    ; sourceCtxResult =
+        trans (sourceCtxResult second)
+          (trans
+            (cong (applyTyCtxs (sourceChanges second))
+              (sourceCtxResult first))
+            (sym (applyTyCtxs-++
+              (sourceChanges first) (sourceChanges second) Δᴸ)))
+    ; targetCtxResult =
+        trans (targetCtxResult second)
+          (cong
+            (λ Δ → applyTyCtxs (targetTailChanges second)
+              (applyTyCtx χ Δ))
+            (targetCtxResult first))
+    ; resultStore = resultStore second
+    ; resultSourceType = resultSourceType second
+    ; resultTargetType = resultTargetType second
+    ; sourceTypeResult =
+        trans (sourceTypeResult second)
+          (trans
+            (cong (applyTys (sourceChanges second))
+              (sourceTypeResult first))
+            (sym (applyTys-++
+              (sourceChanges first) (sourceChanges second) A)))
+    ; targetTypeResult =
+        trans (targetTypeResult second)
+          (cong
+            (λ C → applyTys (targetTailChanges second)
+              (applyTy χ C))
+            (targetTypeResult first))
+    ; transportType = weak-one-step-compose-type first second
+    ; transportAllBody = weak-one-step-compose-all-body first second
+    ; transportRightBody =
+        weak-one-step-compose-right-body first second
+    ; resultType = resultType second
+    ; sourceCatchup =
+        ↠-trans (sourceCatchup first) (sourceCatchup second)
+    ; targetTail = targetTail second
+    ; sourceStoreResult =
+        trans (sourceStoreResult second)
+          (trans
+            (cong (applyStores (sourceChanges second))
+              (sourceStoreResult first))
+            (sym (applyStores-++
+              (sourceChanges first) (sourceChanges second)
+              (leftStoreⁱ ρ))))
+    ; targetStoreResult =
+        trans (targetStoreResult second)
+          (cong
+            (λ Σ → applyStores (targetTailChanges second)
+              (applyStore χ Σ))
+            (targetStoreResult first))
+    ; relatedResults = relatedResults second
+    }
+
+weak-one-step-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p →
+  WeakOneStepResult ρ M N A B keep
+weak-one-step-relatedᵀ result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = _
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+left-catchup-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Value M × No• M) ⊎ M ≡ blame →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupResult {M = M} {V′ = V′} {ρ = ρ}
+left-catchup-relatedᵀ final result =
+  left-catchup (weak-one-step-relatedᵀ result)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+weak-one-step-source-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ ρ M N′ A B χ χs} →
+  M —↠[ χs ] blame →
+  WeakOneStepOutcome {Φ} {Δᴸ} {Δᴿ} ρ M N′ A B χ
+weak-one-step-source-blameᵀ = outcome-source-blame
+
+ν-blame-tail :
+  ∀ {N A c χs} →
+  N —↠[ χs ] blame →
+  ν A N c —↠[ χs ++ keep ∷ [] ] blame
+ν-blame-tail N↠blame =
+  ↠-trans (ν-↠ N↠blame)
+    (↠-step blame-ν ↠-refl)
+
+weak-outcome-map-source :
+  ∀ {Φ Δᴸ Δᴿ M M₀ N′ A A₀ B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (WeakOneStepResult ρ M N′ A B χ →
+    WeakOneStepResult ρ M₀ N′ A₀ B χ) →
+  (∀ {χs} → M —↠[ χs ] blame →
+    ∃[ χs′ ] (M₀ —↠[ χs′ ] blame)) →
+  WeakOneStepOutcome ρ M N′ A B χ →
+  WeakOneStepOutcome ρ M₀ N′ A₀ B χ
+weak-outcome-map-source frame blame-frame (outcome-related result) =
+  outcome-related (frame result)
+weak-outcome-map-source frame blame-frame
+    (outcome-source-blame source↠)
+    with blame-frame source↠
+weak-outcome-map-source frame blame-frame
+    (outcome-source-blame source↠) | χs′ , source₀↠ =
+  outcome-source-blame source₀↠
+
+weak-outcome-map-target-ν :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B C D Aν c χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (WeakOneStepResult ρ M N′ A B χ →
+    WeakOneStepResult ρ M (ν Aν N′ c) C D χ) →
+  WeakOneStepOutcome ρ M N′ A B χ →
+  WeakOneStepOutcome ρ M (ν Aν N′ c) C D χ
+weak-outcome-map-target-ν frame (outcome-related result) =
+  outcome-related (frame result)
+weak-outcome-map-target-ν frame (outcome-source-blame source↠) =
+  outcome-source-blame source↠
+
+weak-all-outcome-map-target-ν :
+  ∀ {Φ Δᴸ Δᴿ N M₀ N′ C C′ A B Aν c χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (WeakOneStepAllResult
+      {N = N} {N₁′ = N′} {C = C} {C′ = C′}
+      {χ = χ} {ρ = ρ} q →
+    WeakOneStepResult ρ M₀ (ν Aν N′ c) A B χ) →
+  (∀ {χs} → N —↠[ χs ] blame →
+    ∃[ χs′ ] (M₀ —↠[ χs′ ] blame)) →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ M₀ (ν Aν N′ c) A B χ
+weak-all-outcome-map-target-ν frame blame-frame
+    (all-outcome-related result) =
+  outcome-related (frame result)
+weak-all-outcome-map-target-ν frame blame-frame
+    (all-outcome-source-blame source↠)
+    with blame-frame source↠
+weak-all-outcome-map-target-ν frame blame-frame
+    (all-outcome-source-blame source↠) | χs′ , source₀↠ =
+  outcome-source-blame source₀↠
+
+weak-one-step-all-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N N′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepAllResult {χ = keep} q
+weak-one-step-all-relatedᵀ result =
+  weak-all-result (weak-one-step-relatedᵀ result) result
+
+left-catchup-all-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Value N × No• N) ⊎ N ≡ blame →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q
+left-catchup-all-relatedᵀ final result =
+  left-all-catchup (weak-one-step-all-relatedᵀ result)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+left-catchup-all-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RuntimeOK V →
+  Value V →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = V} {V′ = V′} {ρ = ρ} q
+left-catchup-all-valueᵀ okV vV V⊑V′ =
+  left-catchup-all-relatedᵀ
+    (inj₁ (vV , runtime-value-no• okV vV)) V⊑V′
+
+left-catchup-all-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ blame ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = blame} {V′ = V′} {ρ = ρ} q
+left-catchup-all-blameᵀ blame⊑V′ =
+  left-catchup-all-relatedᵀ (inj₂ refl) blame⊑V′
+
+weak-one-step-all-outcome-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N N′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepAllOutcome {χ = keep} q
+weak-one-step-all-outcome-relatedᵀ result =
+  all-outcome-related (weak-one-step-all-relatedᵀ result)
+
+weak-one-step-matched-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepResult ρ
+    (ν A N s)
+    (ν (applyTy χ A′) N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-ν-frameᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν-frameᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s′↑
+weak-one-step-matched-ν-frameᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν (applyTys (sourceChanges inner) A)
+          (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult =
+        ν (applyTys (targetTailChanges inner) (applyTy χ A′))
+          (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s′))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = ν-↠ (sourceCatchup inner)
+    ; targetTail = ν-↠ (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ν⊑νᵀ
+          (⊑-src-wf (transportType inner pA))
+          (⊑-tgt-wf (transportType inner pA))
+          source-reveal target-reveal
+          (transportType inner pA)
+          (⊑-lift∀ᵢ (transportType inner pA))
+          liftρ lift-ctx-[] innerAll
+    }
+  where
+    source-reveal =
+      subst
+        (λ Δ → RevealConversion μᵣ (suc Δ)
+          ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+            ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+          (applyTysUnderTyBinders (sourceChanges inner) C)
+          (⇑ᵗ (applyTys (sourceChanges inner) B)))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μᵣ
+            (suc (applyTyCtxs (sourceChanges inner) _))
+            ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+            (applyCoercionUnderTyBinders (sourceChanges inner) s)
+            (applyTysUnderTyBinders (sourceChanges inner) C)
+            (⇑ᵗ (applyTys (sourceChanges inner) B)))
+          (sym (sourceStoreResult inner)) source↑)
+
+    target-reveal =
+      subst
+        (λ Δ → RevealConversion μᵗ (suc Δ)
+          ((zero , ⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A′))) ∷
+            ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ A′)))
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s′))
+          (applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C′))
+          (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ B′))))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μᵗ
+            (suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _)))
+            ((zero , ⇑ᵗ
+                (applyTys (targetTailChanges inner) (applyTy χ A′))) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A′)))
+            (applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s′))
+            (applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C′))
+            (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ B′))))
+          (sym (targetStoreResult inner)) target↑)
+
+left-silent-matched-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q) →
+  LeftSilentInvariant (weakResult all) →
+  LeftSilentResult
+    {M = ν A N s} {V′ = ν A′ V′ s′}
+    {A = B} {B = B′} {ρ = ρ}
+left-silent-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    with lift-store-result (resultStore inner)
+left-silent-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+left-silent-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  left-silent
+    (weak-one-step-matched-ν-frameᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll))
+    (left-silent-invariant refl refl)
+
+weak-one-step-matched-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepResult ρ
+    (ν ★ N s)
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν ★ (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult =
+        ν ★ (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s′))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup =
+        subst
+          (λ T → ν ★ N s —↠[ sourceChanges inner ]
+            ν T (sourceResult inner)
+              (applyCoercionUnderTyBinders (sourceChanges inner) s))
+          (applyTys-★ (sourceChanges inner))
+          (ν-↠ (sourceCatchup inner))
+    ; targetTail =
+        subst
+          (λ T → ν ★ N₁′ (applyCoercionUnderTyBinder χ s′)
+            —↠[ targetTailChanges inner ]
+            ν T (targetResult inner)
+              (applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s′)))
+          (applyTys-★ (targetTailChanges inner))
+          (ν-↠ (targetTail inner))
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        νcast⊑νcastᵀ modeᵣ source-seal modeᵗ target-seal
+          source-widen target-widen
+          liftρ lift-ctx-[] innerAll
+    }
+  where
+    source-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μᵣ)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (sourceStoreResult inner)) sealᵣ
+
+    source-widen =
+      subst
+        (λ Δ → instᵈ μᵣ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+            ∶ applyTysUnderTyBinders (sourceChanges inner) C
+              ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μᵣ
+            ∣ suc (applyTyCtxs (sourceChanges inner) _)
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+              ∶ applyTysUnderTyBinders (sourceChanges inner) C
+                ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+          (sym (sourceStoreResult inner)) source⊑)
+
+    target-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μᵗ)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (targetStoreResult inner)) sealᵗ
+
+    target-widen =
+      subst
+        (λ Δ → instᵈ μᵗ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s′)
+            ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                (applyTyUnderTyBinder χ C′)
+              ⊑ ⇑ᵗ
+                  (applyTys (targetTailChanges inner) (applyTy χ B′)))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μᵗ
+            ∣ suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _))
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s′)
+              ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                  (applyTyUnderTyBinder χ C′)
+                ⊑ ⇑ᵗ
+                    (applyTys (targetTailChanges inner) (applyTy χ B′)))
+          (sym (targetStoreResult inner)) target⊑)
+
+left-silent-matched-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q) →
+  LeftSilentInvariant (weakResult all) →
+  LeftSilentResult
+    {M = ν ★ N s} {V′ = ν ★ V′ s′}
+    {A = B} {B = B′} {ρ = ρ}
+left-silent-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    with lift-store-result (resultStore inner)
+left-silent-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+left-silent-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  left-silent
+    (weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll))
+    (left-silent-invariant refl refl)
+
+weak-one-step-source-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴸ A →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepResult ρ (ν A N s) N₁′ B B′ χ
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    with weak-result-source-all inner
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    | q′ , innerResult | ρ′ , liftρ | μ′ , source↑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν (applyTys (sourceChanges inner) A)
+          (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult = targetResult inner
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = ν-↠ (sourceCatchup inner)
+    ; targetTail = targetTail inner
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ν⊑ᵀ final-wf final-shift-wf source-reveal
+          liftρ lift-left-ctx-[] innerResult
+    }
+  where
+    final-wf =
+      subst
+        (λ Δ → WfTy Δ (applyTys (sourceChanges inner) A))
+        (sym (sourceCtxResult inner))
+        (wfTy-applyTys (sourceChanges inner) hA)
+
+    final-shift-wf =
+      renameᵗ-preserves-WfTy final-wf TyRenameWf-suc
+
+    source-reveal =
+      subst
+        (λ Δ → RevealConversion μ′ (suc Δ)
+          ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+            ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+          (applyTysUnderTyBinders (sourceChanges inner) C)
+          (⇑ᵗ (applyTys (sourceChanges inner) B)))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μ′
+            (suc (applyTyCtxs (sourceChanges inner) _))
+            ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+            (applyCoercionUnderTyBinders (sourceChanges inner) s)
+            (applyTysUnderTyBinders (sourceChanges inner) C)
+            (⇑ᵗ (applyTys (sourceChanges inner) B)))
+          (sym (sourceStoreResult inner)) source↑)
+
+weak-one-step-source-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepResult ρ (ν ★ N s) N₁′ B B′ χ
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    with weak-result-source-all inner
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    | q′ , innerResult | ρ′ , liftρ
+    | μ′ , mode′ , seal★′ , source⊑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν ★ (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult = targetResult inner
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup =
+        subst
+          (λ T → ν ★ N s —↠[ sourceChanges inner ]
+            ν T (sourceResult inner)
+              (applyCoercionUnderTyBinders (sourceChanges inner) s))
+          (applyTys-★ (sourceChanges inner))
+          (ν-↠ (sourceCatchup inner))
+    ; targetTail = targetTail inner
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        νcast⊑ᵀ mode′ source-seal source-widen
+          liftρ lift-left-ctx-[] innerResult
+    }
+  where
+    source-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μ′)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (sourceStoreResult inner)) seal★′
+
+    source-widen =
+      subst
+        (λ Δ → instᵈ μ′ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+            ∶ applyTysUnderTyBinders (sourceChanges inner) C
+              ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μ′
+            ∣ suc (applyTyCtxs (sourceChanges inner) _)
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+              ∶ applyTysUnderTyBinders (sourceChanges inner) C
+                ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+          (sym (sourceStoreResult inner)) source⊑)
+
+weak-one-step-target-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴿ A →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepResult ρ N
+    (ν (applyTy χ A) N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s↑
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    | ρ′ , liftρ | μ′ , target↑
+    with weak-result-target-all inner
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    | ρ′ , liftρ | μ′ , target↑ | q′ , innerResult =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult = sourceResult inner
+    ; targetResult =
+        ν (applyTys (targetTailChanges inner) (applyTy χ A))
+          (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = sourceCatchup inner
+    ; targetTail = ν-↠ (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ⊑νᵀ final-wf final-shift-wf target-reveal
+          liftρ lift-right-ctx-[]
+          (transportRightBody inner pC) innerResult
+    }
+  where
+    final-wf =
+      subst
+        (λ Δ → WfTy Δ
+          (applyTys (targetTailChanges inner) (applyTy χ A)))
+        (sym (targetCtxResult inner))
+        (wfTy-applyTys
+          (χ ∷ targetTailChanges inner) hA)
+
+    final-shift-wf =
+      renameᵗ-preserves-WfTy final-wf TyRenameWf-suc
+
+    target-reveal =
+      subst
+        (λ Δ → RevealConversion μ′ (suc Δ)
+          ((zero , ⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+            ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ A)))
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s))
+          (applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C′))
+          (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ B′))))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μ′
+            (suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _)))
+            ((zero , ⇑ᵗ
+                (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A)))
+            (applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s))
+            (applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C′))
+            (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ B′))))
+          (sym (targetStoreResult inner)) target↑)
+
+weak-one-step-target-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepResult ρ N
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode seal★ s⊑
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    with weak-result-target-all inner
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    | q′ , innerResult =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult = sourceResult inner
+    ; targetResult =
+        ν ★ (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = sourceCatchup inner
+    ; targetTail =
+        subst
+          (λ T → ν ★ N₁′ (applyCoercionUnderTyBinder χ s)
+            —↠[ targetTailChanges inner ]
+            ν T (targetResult inner)
+              (applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s)))
+          (applyTys-★ (targetTailChanges inner))
+          (ν-↠ (targetTail inner))
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ⊑νcastᵀ mode′ target-seal target-widen
+          liftρ lift-right-ctx-[]
+          (transportRightBody inner pC) innerResult
+    }
+  where
+    target-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μ′)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (targetStoreResult inner)) seal★′
+
+    target-widen =
+      subst
+        (λ Δ → instᵈ μ′ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s)
+            ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                (applyTyUnderTyBinder χ C′)
+              ⊑ ⇑ᵗ
+                  (applyTys (targetTailChanges inner) (applyTy χ B′)))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μ′
+            ∣ suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _))
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s)
+              ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                  (applyTyUnderTyBinder χ C′)
+                ⊑ ⇑ᵗ
+                    (applyTys (targetTailChanges inner) (applyTy χ B′)))
+          (sym (targetStoreResult inner)) target⊑)
+
+weak-one-step-matched-ν-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ
+    (ν A N s)
+    (ν (applyTy χ A′) N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-ν-frame-outcomeᵀ s↑ s′↑ pA pB =
+  weak-all-outcome-map-target-ν
+    (weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-matched-νcast-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ
+    (ν ★ N s)
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-νcast-frame-outcomeᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB =
+  weak-all-outcome-map-target-ν
+    (weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-source-ν-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴸ A →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ (`∀ C) B′ χ →
+  WeakOneStepOutcome ρ (ν A N s) N₁′ B B′ χ
+weak-one-step-source-ν-frame-outcomeᵀ hA s↑ pB =
+  weak-outcome-map-source
+    (weak-one-step-source-ν-frameᵀ hA s↑ pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-source-νcast-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ (`∀ C) B′ χ →
+  WeakOneStepOutcome ρ (ν ★ N s) N₁′ B B′ χ
+weak-one-step-source-νcast-frame-outcomeᵀ mode seal★ s⊑ pB =
+  weak-outcome-map-source
+    (weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-target-ν-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴿ A →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ B (`∀ C′) χ →
+  WeakOneStepOutcome ρ N
+    (ν (applyTy χ A) N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-ν-frame-outcomeᵀ hA s↑ pB pC =
+  weak-outcome-map-target-ν
+    (weak-one-step-target-ν-frameᵀ hA s↑ pB pC)
+
+weak-one-step-target-νcast-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ B (`∀ C′) χ →
+  WeakOneStepOutcome ρ N
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-νcast-frame-outcomeᵀ
+    mode seal★ s⊑ pB pC =
+  weak-outcome-map-target-ν
+    (weak-one-step-target-νcast-frameᵀ
+      mode seal★ s⊑ pB pC)
+
+∀-imprecision-source-body-wf :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ `∀ A ⊑ B ⊣ Δᴿ →
+  WfTy (suc Δᴸ) A
+∀-imprecision-source-body-wf p with ⊑-src-wf p
+∀-imprecision-source-body-wf p | wf∀ hA = hA
+
+∀-imprecision-target-body-wf :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ A ⊑ `∀ B ⊣ Δᴿ →
+  WfTy (suc Δᴿ) B
+∀-imprecision-target-body-wf p with ⊑-tgt-wf p
+∀-imprecision-target-body-wf p | wf∀ hB = hB
+
+swap01ᵢ-agrees-swap01ᵗ : ∀ X → swap01ᵢ X ≡ swap01ᵗ X
+swap01ᵢ-agrees-swap01ᵗ zero = refl
+swap01ᵢ-agrees-swap01ᵗ (suc zero) = refl
+swap01ᵢ-agrees-swap01ᵗ (suc (suc X)) = refl
+
+renameᵗ-swap01ᵢ-agrees-swap01ᵗ :
+  ∀ A → renameᵗ swap01ᵢ A ≡ renameᵗ swap01ᵗ A
+renameᵗ-swap01ᵢ-agrees-swap01ᵗ A =
+  rename-cong swap01ᵢ-agrees-swap01ᵗ A
+
+direct-swap-residualᵖ :
+  ∀ {Φ Δᴸ Δᴿ D E T} →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  renameᵗ swap01ᵗ E ≈∀ T →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ᵖ T ⊣ suc (suc Δᴿ)
+direct-swap-residualᵖ {E = E} D⊑E Eˢ≈T =
+  quotientᵖ ≈∀-refl crossed Eˢ≈T
+  where
+    crossed =
+      subst
+        (λ T → swapRight∀∀ᵢ _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+        (renameᵗ-swap01ᵢ-agrees-swap01ᵗ E)
+        (⊑-swapRight01∀∀ᵢ D⊑E)
+
+reverse-swap-residualᵖ :
+  ∀ {Φ Δᴸ Δᴿ S D E} →
+  S ≈∀ renameᵗ swap01ᵗ D →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ S ⊑ᵖ E ⊣ suc (suc Δᴿ)
+reverse-swap-residualᵖ {D = D} S≈Dˢ D⊑E =
+  quotientᵖ S≈Dˢ crossed ≈∀-refl
+  where
+    crossed =
+      subst
+        (λ T → swapRight∀∀ᵢ _ ∣ _ ⊢ T ⊑ _ ⊣ _)
+        (renameᵗ-swap01ᵢ-agrees-swap01ᵗ D)
+        (⊑-swapLeft01∀∀ᵢ D⊑E)
+
+direct-swap-residual-outerᵖ :
+  ∀ {Φ Δᴸ Δᴿ D E T} →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  renameᵗ swap01ᵗ E ≈∀ T →
+  Φ ∣ Δᴸ ⊢ `∀ (`∀ D) ⊑ᵖ `∀ (`∀ T) ⊣ Δᴿ
+direct-swap-residual-outerᵖ D⊑E Eˢ≈T =
+  quotientᵖ ≈∀-refl (∀ⁱ (∀ⁱ D⊑E))
+    (≈∀-double-swap Eˢ≈T)
+
+reverse-swap-residual-outerᵖ :
+  ∀ {Φ Δᴸ Δᴿ S D E} →
+  S ≈∀ renameᵗ swap01ᵗ D →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  Φ ∣ Δᴸ ⊢ `∀ (`∀ S) ⊑ᵖ `∀ (`∀ E) ⊣ Δᴿ
+reverse-swap-residual-outerᵖ S≈Dˢ D⊑E =
+  quotientᵖ (≈∀-double-swap-sym S≈Dˢ)
+    (∀ⁱ (∀ⁱ D⊑E)) ≈∀-refl
+
+------------------------------------------------------------------------
+-- Crossed stores realize two allocations in opposite logical orders
+------------------------------------------------------------------------
+
+leftStoreⁱ-crossed-two-binds :
+  ∀ {Φ Δᴸ Δᴿ Aold Anew Bold Bnew}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))}
+    {hAnew : WfTy (suc (suc Δᴸ)) (⇑ᵗ Anew)}
+    {hAold : WfTy (suc (suc Δᴸ)) (⇑ᵗ (⇑ᵗ Aold))}
+    {hBnew : WfTy (suc (suc Δᴿ)) (⇑ᵗ Bnew)}
+    {hBold : WfTy (suc (suc Δᴿ)) (⇑ᵗ (⇑ᵗ Bold))}
+    {pnew-old : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+      ⊢ ⇑ᵗ Anew ⊑ ⇑ᵗ (⇑ᵗ Bold) ⊣ suc (suc Δᴿ)}
+    {pold-new : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+      ⊢ ⇑ᵗ (⇑ᵗ Aold) ⊑ ⇑ᵗ Bnew ⊣ suc (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  leftStoreⁱ
+      (crossedStoreⁱ hAnew hAold hBnew hBold
+        pnew-old pold-new ρ₂)
+    ≡ applyStores (bind Aold ∷ bind Anew ∷ []) (leftStoreⁱ ρ₀)
+leftStoreⁱ-crossed-two-binds liftρ₁ liftρ₂
+    rewrite leftStoreⁱ-lift liftρ₂
+      | leftStoreⁱ-lift liftρ₁ =
+  refl
+
+rightStoreⁱ-crossed-two-binds :
+  ∀ {Φ Δᴸ Δᴿ Aold Anew Bold Bnew}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))}
+    {hAnew : WfTy (suc (suc Δᴸ)) (⇑ᵗ Anew)}
+    {hAold : WfTy (suc (suc Δᴸ)) (⇑ᵗ (⇑ᵗ Aold))}
+    {hBnew : WfTy (suc (suc Δᴿ)) (⇑ᵗ Bnew)}
+    {hBold : WfTy (suc (suc Δᴿ)) (⇑ᵗ (⇑ᵗ Bold))}
+    {pnew-old : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+      ⊢ ⇑ᵗ Anew ⊑ ⇑ᵗ (⇑ᵗ Bold) ⊣ suc (suc Δᴿ)}
+    {pold-new : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+      ⊢ ⇑ᵗ (⇑ᵗ Aold) ⊑ ⇑ᵗ Bnew ⊣ suc (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  rightStoreⁱ
+      (crossedStoreⁱ hAnew hAold hBnew hBold
+        pnew-old pold-new ρ₂)
+    ≡ applyStores (bind Bold ∷ bind Bnew ∷ []) (rightStoreⁱ ρ₀)
+rightStoreⁱ-crossed-two-binds liftρ₁ liftρ₂
+    rewrite rightStoreⁱ-lift liftρ₂
+      | rightStoreⁱ-lift liftρ₁ =
+  refl
+
+rightStoreⁱ-crossed-body :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ (extᵗ suc) (rightStoreⁱ ρ₁) ≡ rightStoreⁱ ρ₂
+rightStoreⁱ-crossed-body {ρ₀ = ρ₀} {ρ₁ = ρ₁} liftρ₁ liftρ₂ =
+  trans
+    (cong (renameStoreᵗ (extᵗ suc)) (rightStoreⁱ-lift liftρ₁))
+    (trans
+      (renameStoreᵗ-ext-suc-comm suc (rightStoreⁱ ρ₀))
+      (trans
+        (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
+        (sym (rightStoreⁱ-lift liftρ₂))))
+
+leftStoreⁱ-crossed-body :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ (extᵗ suc) (leftStoreⁱ ρ₁) ≡ leftStoreⁱ ρ₂
+leftStoreⁱ-crossed-body {ρ₀ = ρ₀} {ρ₁ = ρ₁} liftρ₁ liftρ₂ =
+  trans
+    (cong (renameStoreᵗ (extᵗ suc)) (leftStoreⁱ-lift liftρ₁))
+    (trans
+      (renameStoreᵗ-ext-suc-comm suc (leftStoreⁱ ρ₀))
+      (trans
+        (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
+        (sym (leftStoreⁱ-lift liftρ₂))))
+
+∀gen-body-mode≤gen :
+  ModeIncl
+    (genᵈ (extᵈ (genᵈ tag-or-idᵈ)))
+    (genᵈ tag-or-idᵈ)
+∀gen-body-mode≤gen zero = refl
+∀gen-body-mode≤gen (suc zero) = refl
+∀gen-body-mode≤gen (suc (suc zero)) = refl
+∀gen-body-mode≤gen (suc (suc (suc X))) = refl
+
+gen∀-body-mode≤gen :
+  ModeIncl
+    (extᵈ (genᵈ (genᵈ tag-or-idᵈ)))
+    (genᵈ tag-or-idᵈ)
+gen∀-body-mode≤gen zero = refl
+gen∀-body-mode≤gen (suc zero) = refl
+gen∀-body-mode≤gen (suc (suc zero)) = refl
+gen∀-body-mode≤gen (suc (suc (suc X))) = refl
+
+∀gen-narrowing-body :
+  ∀ {Δ Σ A D d} →
+  genᵈ tag-or-idᵈ ∣ Δ ∣ Σ
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ suc (suc Δ) ∣ ⟰ᵗ (⟰ᵗ Σ)
+    ⊢ d ∶ ⇑ᵗ A ⊒ D
+∀gen-narrowing-body
+    (C.cast-all (C.cast-gen hA occ d⊢) ,
+      NW.cross (NW.`∀ (NW.gen dⁿ))) =
+  narrow-mode-relax ∀gen-body-mode≤gen (d⊢ , dⁿ)
+
+gen∀-narrowing-body :
+  ∀ {Δ Σ B D′ d′} →
+  genᵈ tag-or-idᵈ ∣ Δ ∣ Σ
+    ⊢ gen (`∀ B) (`∀ d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  genᵈ tag-or-idᵈ ∣ suc (suc Δ) ∣ ⟰ᵗ (⟰ᵗ Σ)
+    ⊢ d′ ∶ renameᵗ (extᵗ suc) B ⊒ D′
+gen∀-narrowing-body
+    (C.cast-gen hB occ (C.cast-all d′⊢) ,
+      NW.gen (NW.cross (NW.`∀ d′ⁿ))) =
+  narrow-mode-relax gen∀-body-mode≤gen (d′⊢ , d′ⁿ)
+
+inst∀-widening-body :
+  ∀ {Δ Σ D E u} →
+  id-onlyᵈ ∣ Δ ∣ Σ
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  extᵈ (instᵈ tag-or-idᵈ) ∣ suc (suc Δ) ∣
+    ⟰ᵗ ((zero , ★) ∷ ⟰ᵗ Σ)
+    ⊢ u ∶ D ⊑ renameᵗ (extᵗ suc) E
+inst∀-widening-body
+    (C.cast-inst hE occ (C.cast-all u⊢) ,
+      NW.inst (NW.cross (NW.`∀ uʷ))) =
+  widen-mode-relax
+    (ModeIncl-ext (ModeIncl-inst id-only≤tag-or-idᵈ))
+    (u⊢ , uʷ)
+
+∀inst-widening-body :
+  ∀ {Δ Σ D′ E′ u′} →
+  id-onlyᵈ ∣ Δ ∣ Σ
+    ⊢ `∀ (inst E′ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  instᵈ (extᵈ tag-or-idᵈ) ∣ suc (suc Δ) ∣
+    (zero , ★) ∷ ⟰ᵗ (⟰ᵗ Σ)
+    ⊢ u′ ∶ D′ ⊑ ⇑ᵗ E′
+∀inst-widening-body
+    (C.cast-all (C.cast-inst hE′ occ u′⊢) ,
+      NW.cross (NW.`∀ (NW.inst u′ʷ))) =
+  widen-mode-relax
+    (ModeIncl-inst (ModeIncl-ext id-only≤tag-or-idᵈ))
+    (u′⊢ , u′ʷ)
+
+leftStoreⁱ-double-lift :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  ⟰ᵗ (⟰ᵗ (leftStoreⁱ ρ₀)) ≡ leftStoreⁱ ρ₂
+leftStoreⁱ-double-lift liftρ₁ liftρ₂ =
+  trans
+    (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
+    (sym (leftStoreⁱ-lift liftρ₂))
+
+rightStoreⁱ-double-lift :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  ⟰ᵗ (⟰ᵗ (rightStoreⁱ ρ₀)) ≡ rightStoreⁱ ρ₂
+rightStoreⁱ-double-lift liftρ₁ liftρ₂ =
+  trans
+    (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
+    (sym (rightStoreⁱ-lift liftρ₂))
+
+crossed-lift-store :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  ∃[ ρ₂ ] LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂
+crossed-lift-store lift-store-[] =
+  [] , lift-store-[]
+crossed-lift-store (lift-store-∷ {p = p} liftρ)
+    with crossed-lift-store liftρ
+crossed-lift-store (lift-store-∷ {p = p} liftρ)
+    | ρ₂ , liftρ₂ =
+  _ , lift-store-∷
+    {p′ = ⊑-crossed-double-lift∀∀ᵢ p}
+    liftρ₂
+crossed-lift-store (lift-store-left {hA′ = hA′} liftρ)
+    with crossed-lift-store liftρ
+crossed-lift-store (lift-store-left {hA′ = hA′} liftρ)
+    | ρ₂ , liftρ₂ =
+  _ , lift-store-left
+    {hA′ = renameᵗ-preserves-WfTy hA′ TyRenameWf-suc}
+    liftρ₂
+crossed-lift-store (lift-store-right {hB′ = hB′} liftρ)
+    with crossed-lift-store liftρ
+crossed-lift-store (lift-store-right {hB′ = hB′} liftρ)
+    | ρ₂ , liftρ₂ =
+  _ , lift-store-right
+    {hB′ = renameᵗ-preserves-WfTy hB′ TyRenameWf-suc}
+    liftρ₂
+crossed-lift-store (lift-store-link {p = p} liftρ)
+    with crossed-lift-store liftρ
+crossed-lift-store (lift-store-link {p = p} liftρ)
+    | ρ₂ , liftρ₂ =
+  _ , lift-store-link
+    {p′ = ⊑-crossed-double-lift∀∀ᵢ p}
+    liftρ₂
+
+∀gen-crossed-narrowing-body :
+  ∀ {Φ Δᴸ Δᴿ Aobs A D d}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ suc (suc Δᴸ) ∣
+    (zero , Aobs) ∷ (suc zero , ★) ∷ leftStoreⁱ ρ₂
+    ⊢ d ∶ ⇑ᵗ A ⊒ D
+∀gen-crossed-narrowing-body liftρ₁ liftρ₂ d⊒ =
+  narrow-weaken ≤-refl (λ x∈ → there (there x∈))
+    (subst
+      (λ Σ → genᵈ tag-or-idᵈ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+      (leftStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (∀gen-narrowing-body d⊒))
+
+gen∀-crossed-narrowing-body :
+  ∀ {Φ Δᴸ Δᴿ Bobs B D′ d′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  genᵈ tag-or-idᵈ ∣ suc (suc Δᴿ) ∣
+    (zero , ★) ∷ (suc zero , Bobs) ∷ rightStoreⁱ ρ₂
+    ⊢ d′ ∶ renameᵗ (extᵗ suc) B ⊒ D′
+gen∀-crossed-narrowing-body liftρ₁ liftρ₂ d′⊒ =
+  narrow-weaken ≤-refl (λ x∈ → there (there x∈))
+    (subst
+      (λ Σ → genᵈ tag-or-idᵈ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+      (rightStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (gen∀-narrowing-body d′⊒))
+
+inst∀-crossed-widening-body :
+  ∀ {Φ Δᴸ Δᴿ Aobs D E u}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  extᵈ (instᵈ tag-or-idᵈ) ∣ suc (suc Δᴸ) ∣
+    (zero , Aobs) ∷ (suc zero , ★) ∷ leftStoreⁱ ρ₂
+    ⊢ u ∶ D ⊑ renameᵗ (extᵗ suc) E
+inst∀-crossed-widening-body liftρ₁ liftρ₂ u⊑ =
+  widen-weaken ≤-refl StoreIncl-drop
+    (subst
+      (λ Σ → extᵈ (instᵈ tag-or-idᵈ) ∣ _ ∣
+        (suc zero , ★) ∷ Σ ⊢ _ ∶ _ ⊑ _)
+      (leftStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (inst∀-widening-body u⊑))
+
+∀inst-crossed-widening-body :
+  ∀ {Φ Δᴸ Δᴿ Bobs D′ E′ u′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  instᵈ (extᵈ tag-or-idᵈ) ∣ suc (suc Δᴿ) ∣
+    (zero , ★) ∷ (suc zero , Bobs) ∷ rightStoreⁱ ρ₂
+    ⊢ u′ ∶ D′ ⊑ ⇑ᵗ E′
+∀inst-crossed-widening-body liftρ₁ liftρ₂ u′⊑ =
+  widen-weaken ≤-refl store-incl-insert-second
+    (subst
+      (λ Σ → instᵈ (extᵈ tag-or-idᵈ) ∣ _ ∣
+        (zero , ★) ∷ Σ ⊢ _ ∶ _ ⊑ _)
+      (rightStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (∀inst-widening-body u′⊑))
+
+gen∀-crossed-source-narrowing-body :
+  ∀ {Φ Δᴸ Δᴿ Aobs A D d}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ suc (suc Δᴸ) ∣
+    (zero , ★) ∷ (suc zero , Aobs) ∷ leftStoreⁱ ρ₂
+    ⊢ d ∶ renameᵗ (extᵗ suc) A ⊒ D
+gen∀-crossed-source-narrowing-body liftρ₁ liftρ₂ d⊒ =
+  narrow-weaken ≤-refl (λ x∈ → there (there x∈))
+    (subst
+      (λ Σ → genᵈ tag-or-idᵈ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+      (leftStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (gen∀-narrowing-body d⊒))
+
+∀gen-crossed-target-narrowing-body :
+  ∀ {Φ Δᴸ Δᴿ Bobs B D′ d′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  genᵈ tag-or-idᵈ ∣ suc (suc Δᴿ) ∣
+    (zero , Bobs) ∷ (suc zero , ★) ∷ rightStoreⁱ ρ₂
+    ⊢ d′ ∶ ⇑ᵗ B ⊒ D′
+∀gen-crossed-target-narrowing-body liftρ₁ liftρ₂ d′⊒ =
+  narrow-weaken ≤-refl (λ x∈ → there (there x∈))
+    (subst
+      (λ Σ → genᵈ tag-or-idᵈ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+      (rightStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (∀gen-narrowing-body d′⊒))
+
+∀inst-crossed-source-widening-body :
+  ∀ {Φ Δᴸ Δᴿ Aobs D E u}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  instᵈ (extᵈ tag-or-idᵈ) ∣ suc (suc Δᴸ) ∣
+    (zero , ★) ∷ (suc zero , Aobs) ∷ leftStoreⁱ ρ₂
+    ⊢ u ∶ D ⊑ ⇑ᵗ E
+∀inst-crossed-source-widening-body liftρ₁ liftρ₂ u⊑ =
+  widen-weaken ≤-refl store-incl-insert-second
+    (subst
+      (λ Σ → instᵈ (extᵈ tag-or-idᵈ) ∣ _ ∣
+        (zero , ★) ∷ Σ ⊢ _ ∶ _ ⊑ _)
+      (leftStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (∀inst-widening-body u⊑))
+
+inst∀-crossed-target-widening-body :
+  ∀ {Φ Δᴸ Δᴿ Bobs D′ E′ u′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  extᵈ (instᵈ tag-or-idᵈ) ∣ suc (suc Δᴿ) ∣
+    (zero , Bobs) ∷ (suc zero , ★) ∷ rightStoreⁱ ρ₂
+    ⊢ u′ ∶ D′ ⊑ renameᵗ (extᵗ suc) E′
+inst∀-crossed-target-widening-body liftρ₁ liftρ₂ u′⊑ =
+  widen-weaken ≤-refl StoreIncl-drop
+    (subst
+      (λ Σ → extᵈ (instᵈ tag-or-idᵈ) ∣ _ ∣
+        (suc zero , ★) ∷ Σ ⊢ _ ∶ _ ⊑ _)
+      (rightStoreⁱ-double-lift liftρ₁ liftρ₂)
+      (inst∀-widening-body u′⊑))
+
+seal★-ext-inst-tag-or-id :
+  ∀ {Σ A} →
+  SealModeStore★ (extᵈ (instᵈ tag-or-idᵈ))
+    ((zero , A) ∷ (suc zero , ★) ∷ Σ)
+seal★-ext-inst-tag-or-id zero ()
+seal★-ext-inst-tag-or-id (suc zero) refl =
+  there (here refl)
+seal★-ext-inst-tag-or-id (suc (suc X)) ()
+
+seal★-inst-ext-tag-or-id :
+  ∀ {Σ B} →
+  SealModeStore★ (instᵈ (extᵈ tag-or-idᵈ))
+    ((zero , ★) ∷ (suc zero , B) ∷ Σ)
+seal★-inst-ext-tag-or-id zero refl = here refl
+seal★-inst-ext-tag-or-id (suc zero) ()
+seal★-inst-ext-tag-or-id (suc (suc X)) ()
+
+left-swap-reveal-store :
+  ∀ {Φ Δᴸ Δᴿ Aobs}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ (extᵗ suc)
+      ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    ≡ (zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷ leftStoreⁱ ρ₂
+left-swap-reveal-store {Aobs = Aobs} {ρ₀ = ρ₀} liftρ₁ liftρ₂ =
+  cong₂ _∷_
+    (cong (λ C → zero , C) (renameᵗ-ext-suc-comm suc Aobs))
+    (trans
+      (renameStoreᵗ-ext-suc-comm suc (leftStoreⁱ ρ₀))
+      (trans
+        (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
+        (sym (leftStoreⁱ-lift liftρ₂))))
+
+right-swap-reveal-store :
+  ∀ {Φ Δᴸ Δᴿ Bobs}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ suc
+      ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    ≡ (suc zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷ rightStoreⁱ ρ₂
+right-swap-reveal-store liftρ₁ liftρ₂ =
+  cong₂ _∷_ refl
+    (trans
+      (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
+      (sym (rightStoreⁱ-lift liftρ₂)))
+
+right-swap-source-reveal-store :
+  ∀ {Φ Δᴸ Δᴿ Aobs}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ suc
+      ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    ≡ (suc zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷ leftStoreⁱ ρ₂
+right-swap-source-reveal-store liftρ₁ liftρ₂ =
+  cong₂ _∷_ refl
+    (trans
+      (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
+      (sym (leftStoreⁱ-lift liftρ₂)))
+
+left-swap-target-reveal-store :
+  ∀ {Φ Δᴸ Δᴿ Bobs}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ (extᵗ suc)
+      ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    ≡ (zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷ rightStoreⁱ ρ₂
+left-swap-target-reveal-store {Bobs = Bobs} {ρ₀ = ρ₀}
+    liftρ₁ liftρ₂ =
+  cong₂ _∷_
+    (cong (λ C → zero , C) (renameᵗ-ext-suc-comm suc Bobs))
+    (trans
+      (renameStoreᵗ-ext-suc-comm suc (rightStoreⁱ ρ₀))
+      (trans
+        (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
+        (sym (rightStoreⁱ-lift liftρ₂))))
+
+left-swap-reveal-conversion :
+  ∀ {Φ Δᴸ Δᴿ Aobs E F s μ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E F →
+  RevealConversion (λ Y → μ (predᵗ Y)) (suc (suc Δᴸ))
+    ((zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷
+      (suc zero , ★) ∷ leftStoreⁱ ρ₂)
+    zero (⇑ᵗ (⇑ᵗ Aobs)) (renameᶜ (extᵗ suc) s)
+    (renameᵗ (extᵗ suc) E) (renameᵗ (extᵗ suc) F)
+left-swap-reveal-conversion {Δᴸ = Δᴸ} {Aobs = Aobs}
+    {E = E} {F = F} {s = s} {μ = μ} {ρ₂ = ρ₂}
+    liftρ₁ liftρ₂ s↑ =
+  weaken-reveal-conversion store-incl-insert-second
+    (subst
+      (λ C → RevealConversion (λ Y → μ (predᵗ Y))
+        (suc (suc Δᴸ))
+        ((zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷ leftStoreⁱ ρ₂)
+        zero C (renameᶜ (extᵗ suc) s)
+        (renameᵗ (extᵗ suc) E) (renameᵗ (extᵗ suc) F))
+      (renameᵗ-ext-suc-comm suc Aobs)
+      (subst
+        (λ Σ → RevealConversion (λ Y → μ (predᵗ Y))
+          (suc (suc Δᴸ)) Σ zero
+          (renameᵗ (extᵗ suc) (⇑ᵗ Aobs))
+          (renameᶜ (extᵗ suc) s)
+          (renameᵗ (extᵗ suc) E) (renameᵗ (extᵗ suc) F))
+        (left-swap-reveal-store liftρ₁ liftρ₂)
+        (rename-reveal-conversion
+          (TyRenameWf-ext TyRenameWf-suc)
+          (modeRename-left-inverse
+            {ρ = extᵗ suc} {ψ = predᵗ}
+            RenameLeftInverse-ext-suc-pred)
+          s↑)))
+
+right-swap-reveal-conversion :
+  ∀ {Φ Δᴸ Δᴿ Bobs E′ F′ s′ μ′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ F′ →
+  RevealConversion (λ Y → μ′ (predᵗ Y)) (suc (suc Δᴿ))
+    ((zero , ★) ∷
+      (suc zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷ rightStoreⁱ ρ₂)
+    (suc zero) (⇑ᵗ (⇑ᵗ Bobs)) (⇑ᶜ s′)
+    (⇑ᵗ E′) (⇑ᵗ F′)
+right-swap-reveal-conversion {Δᴿ = Δᴿ} {Bobs = Bobs}
+    {E′ = E′} {F′ = F′} {s′ = s′} {μ′ = μ′}
+    liftρ₁ liftρ₂ s′↑ =
+  weaken-reveal-conversion StoreIncl-drop
+    (subst
+      (λ Σ → RevealConversion (λ Y → μ′ (predᵗ Y))
+        (suc (suc Δᴿ)) Σ (suc zero) (⇑ᵗ (⇑ᵗ Bobs))
+        (⇑ᶜ s′) (⇑ᵗ E′) (⇑ᵗ F′))
+      (right-swap-reveal-store liftρ₁ liftρ₂)
+      (rename-reveal-conversion
+        TyRenameWf-suc
+        (modeRename-left-inverse
+          {ρ = suc} {ψ = predᵗ} RenameLeftInverse-suc)
+        s′↑))
+
+right-swap-source-reveal-conversion :
+  ∀ {Φ Δᴸ Δᴿ Aobs E F s μ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E F →
+  RevealConversion (λ Y → μ (predᵗ Y)) (suc (suc Δᴸ))
+    ((zero , ★) ∷
+      (suc zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷ leftStoreⁱ ρ₂)
+    (suc zero) (⇑ᵗ (⇑ᵗ Aobs)) (⇑ᶜ s)
+    (⇑ᵗ E) (⇑ᵗ F)
+right-swap-source-reveal-conversion {Δᴸ = Δᴸ}
+    {Aobs = Aobs} {E = E} {F = F} {s = s} {μ = μ}
+    liftρ₁ liftρ₂ s↑ =
+  weaken-reveal-conversion StoreIncl-drop
+    (subst
+      (λ Σ → RevealConversion (λ Y → μ (predᵗ Y))
+        (suc (suc Δᴸ)) Σ (suc zero) (⇑ᵗ (⇑ᵗ Aobs))
+        (⇑ᶜ s) (⇑ᵗ E) (⇑ᵗ F))
+      (right-swap-source-reveal-store liftρ₁ liftρ₂)
+      (rename-reveal-conversion
+        TyRenameWf-suc
+        (modeRename-left-inverse
+          {ρ = suc} {ψ = predᵗ} RenameLeftInverse-suc)
+        s↑))
+
+left-swap-target-reveal-conversion :
+  ∀ {Φ Δᴸ Δᴿ Bobs E′ F′ s′ μ′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ F′ →
+  RevealConversion (λ Y → μ′ (predᵗ Y)) (suc (suc Δᴿ))
+    ((zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷
+      (suc zero , ★) ∷ rightStoreⁱ ρ₂)
+    zero (⇑ᵗ (⇑ᵗ Bobs)) (renameᶜ (extᵗ suc) s′)
+    (renameᵗ (extᵗ suc) E′) (renameᵗ (extᵗ suc) F′)
+left-swap-target-reveal-conversion {Δᴿ = Δᴿ}
+    {Bobs = Bobs} {E′ = E′} {F′ = F′} {s′ = s′}
+    {μ′ = μ′} {ρ₂ = ρ₂} liftρ₁ liftρ₂ s′↑ =
+  weaken-reveal-conversion store-incl-insert-second
+    (subst
+      (λ C → RevealConversion (λ Y → μ′ (predᵗ Y))
+        (suc (suc Δᴿ))
+        ((zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷ rightStoreⁱ ρ₂)
+        zero C (renameᶜ (extᵗ suc) s′)
+        (renameᵗ (extᵗ suc) E′)
+        (renameᵗ (extᵗ suc) F′))
+      (renameᵗ-ext-suc-comm suc Bobs)
+      (subst
+        (λ Σ → RevealConversion (λ Y → μ′ (predᵗ Y))
+          (suc (suc Δᴿ)) Σ zero
+          (renameᵗ (extᵗ suc) (⇑ᵗ Bobs))
+          (renameᶜ (extᵗ suc) s′)
+          (renameᵗ (extᵗ suc) E′)
+          (renameᵗ (extᵗ suc) F′))
+        (left-swap-target-reveal-store liftρ₁ liftρ₂)
+        (rename-reveal-conversion
+          (TyRenameWf-ext TyRenameWf-suc)
+          (modeRename-left-inverse
+            {ρ = extᵗ suc} {ψ = predᵗ}
+            RenameLeftInverse-ext-suc-pred)
+          s′↑)))
+
+crossed-source-body-typing :
+  ∀ {Φ Δᴸ Δᴿ A W}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  No• W →
+  suc Δᴸ ∣ leftStoreⁱ ρ₁ ∣ [] ⊢ W ⦂ A →
+  suc (suc Δᴸ) ∣ leftStoreⁱ ρ₂ ∣ []
+    ⊢ renameᵗᵐ suc W ⦂ renameᵗ suc A
+crossed-source-body-typing {Δᴸ = Δᴸ} {A = A} {W = W}
+    {ρ₁ = ρ₁} liftρ₂ noW W⊢ =
+  subst
+    (λ Σ → suc (suc Δᴸ) ∣ Σ ∣ []
+      ⊢ renameᵗᵐ suc W ⦂ renameᵗ suc A)
+    (sym (leftStoreⁱ-lift liftρ₂))
+    (typing-renameᵀ
+      {Δ = suc Δᴸ} {Δ′ = suc (suc Δᴸ)}
+      {Σ = leftStoreⁱ ρ₁} {Γ = []} {M = W} {A = A}
+      {ρ = suc} {ψ = predᵗ}
+      TyRenameWf-suc RenameLeftInverse-suc castModeRenamer-suc
+      noW W⊢)
+
+crossed-target-body-typing :
+  ∀ {Φ Δᴸ Δᴿ B W′}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  No• W′ →
+  suc Δᴿ ∣ rightStoreⁱ ρ₁ ∣ [] ⊢ W′ ⦂ B →
+  suc (suc Δᴿ) ∣ rightStoreⁱ ρ₂ ∣ []
+    ⊢ renameᵗᵐ (extᵗ suc) W′ ⦂ renameᵗ (extᵗ suc) B
+crossed-target-body-typing {Δᴿ = Δᴿ} {B = B} {W′ = W′}
+    {ρ₁ = ρ₁} liftρ₁ liftρ₂ noW′ W′⊢ =
+  subst
+    (λ Σ → suc (suc Δᴿ) ∣ Σ ∣ []
+      ⊢ renameᵗᵐ (extᵗ suc) W′ ⦂ renameᵗ (extᵗ suc) B)
+    (rightStoreⁱ-crossed-body liftρ₁ liftρ₂)
+    (typing-renameᵀ
+      {Δ = suc Δᴿ} {Δ′ = suc (suc Δᴿ)}
+      {Σ = rightStoreⁱ ρ₁} {Γ = []} {M = W′} {A = B}
+      {ρ = extᵗ suc} {ψ = predᵗ}
+      (TyRenameWf-ext TyRenameWf-suc)
+      RenameLeftInverse-ext-suc-pred
+      (castModeRenamer-ext castModeRenamer-suc) noW′ W′⊢)
+
+crossed-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B W W′ p}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  No• W →
+  No• W′ →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ p →
+  swapRight∀∀ᵢ Φ
+    ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣ ρ₂ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ W ⊑ renameᵗᵐ (extᵗ suc) W′
+    ⦂ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B
+    ∶ ⊑-crossed-body-lift∀∀ᵢ p
+crossed-bodyᵀ liftρ₁ liftρ₂ noW noW′ W⊑W′ =
+  swapRight-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl
+    (⊑-crossed-body-lift∀∀ᵢ _)
+    (crossed-source-body-typing liftρ₂ noW
+      (nu-term-imprecision-source-typing W⊑W′))
+    (crossed-target-body-typing liftρ₁ liftρ₂ noW′
+      (nu-term-imprecision-target-typing W⊑W′))
+
+crossed-left-source-body-typing :
+  ∀ {Φ Δᴸ Δᴿ A W}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  No• W →
+  suc Δᴸ ∣ leftStoreⁱ ρ₁ ∣ [] ⊢ W ⦂ A →
+  suc (suc Δᴸ) ∣ leftStoreⁱ ρ₂ ∣ []
+    ⊢ renameᵗᵐ (extᵗ suc) W ⦂ renameᵗ (extᵗ suc) A
+crossed-left-source-body-typing
+    {Δᴸ = Δᴸ} {A = A} {W = W} {ρ₁ = ρ₁}
+    liftρ₁ liftρ₂ noW W⊢ =
+  subst
+    (λ Σ → suc (suc Δᴸ) ∣ Σ ∣ []
+      ⊢ renameᵗᵐ (extᵗ suc) W ⦂ renameᵗ (extᵗ suc) A)
+    (leftStoreⁱ-crossed-body liftρ₁ liftρ₂)
+    (typing-renameᵀ
+      {Δ = suc Δᴸ} {Δ′ = suc (suc Δᴸ)}
+      {Σ = leftStoreⁱ ρ₁} {Γ = []} {M = W} {A = A}
+      {ρ = extᵗ suc} {ψ = predᵗ}
+      (TyRenameWf-ext TyRenameWf-suc)
+      RenameLeftInverse-ext-suc-pred
+      (castModeRenamer-ext castModeRenamer-suc) noW W⊢)
+
+crossed-left-target-body-typing :
+  ∀ {Φ Δᴸ Δᴿ B W′}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  No• W′ →
+  suc Δᴿ ∣ rightStoreⁱ ρ₁ ∣ [] ⊢ W′ ⦂ B →
+  suc (suc Δᴿ) ∣ rightStoreⁱ ρ₂ ∣ []
+    ⊢ renameᵗᵐ suc W′ ⦂ renameᵗ suc B
+crossed-left-target-body-typing
+    {Δᴿ = Δᴿ} {B = B} {W′ = W′} {ρ₁ = ρ₁}
+    liftρ₂ noW′ W′⊢ =
+  subst
+    (λ Σ → suc (suc Δᴿ) ∣ Σ ∣ []
+      ⊢ renameᵗᵐ suc W′ ⦂ renameᵗ suc B)
+    (sym (rightStoreⁱ-lift liftρ₂))
+    (typing-renameᵀ
+      {Δ = suc Δᴿ} {Δ′ = suc (suc Δᴿ)}
+      {Σ = rightStoreⁱ ρ₁} {Γ = []} {M = W′} {A = B}
+      {ρ = suc} {ψ = predᵗ}
+      TyRenameWf-suc RenameLeftInverse-suc castModeRenamer-suc
+      noW′ W′⊢)
+
+crossed-left-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B W W′ p}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  No• W →
+  No• W′ →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ p →
+  swapRight∀∀ᵢ Φ
+    ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣ ρ₂ ∣ []
+    ⊢ᴺ renameᵗᵐ (extᵗ suc) W ⊑ ⇑ᵗᵐ W′
+    ⦂ renameᵗ (extᵗ suc) A ⊑ ⇑ᵗ B
+    ∶ ⊑-crossed-left-body-lift∀∀ᵢ p
+crossed-left-bodyᵀ liftρ₁ liftρ₂ noW noW′ W⊑W′ =
+  swapLeft-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl
+    (⊑-crossed-left-body-lift∀∀ᵢ _)
+    (crossed-left-source-body-typing liftρ₁ liftρ₂ noW
+      (nu-term-imprecision-source-typing W⊑W′))
+    (crossed-left-target-body-typing liftρ₂ noW′
+      (nu-term-imprecision-target-typing W⊑W′))
+
+lift-store-matched-∈ :
+  ∀ {Φ Ψ Δᴸ Δᴿ ρ ρ′ α β A B p} →
+  LiftStoreⁱ {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} Ψ ρ ρ′ →
+  store-matched α A β B p ∈ ρ →
+  ∃[ p′ ]
+    store-matched (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B) p′ ∈ ρ′
+lift-store-matched-∈ lift-store-[] ()
+lift-store-matched-∈ (lift-store-∷ {p′ = p′} liftρ) (here refl) =
+  p′ , here refl
+lift-store-matched-∈ (lift-store-∷ liftρ) (there x∈)
+    with lift-store-matched-∈ liftρ x∈
+lift-store-matched-∈ (lift-store-∷ liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+lift-store-matched-∈ (lift-store-left liftρ) (here ())
+lift-store-matched-∈ (lift-store-left liftρ) (there x∈)
+    with lift-store-matched-∈ liftρ x∈
+lift-store-matched-∈ (lift-store-left liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+lift-store-matched-∈ (lift-store-right liftρ) (here ())
+lift-store-matched-∈ (lift-store-right liftρ) (there x∈)
+    with lift-store-matched-∈ liftρ x∈
+lift-store-matched-∈ (lift-store-right liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+lift-store-matched-∈ (lift-store-link liftρ) (here ())
+lift-store-matched-∈ (lift-store-link liftρ) (there x∈)
+    with lift-store-matched-∈ liftρ x∈
+lift-store-matched-∈ (lift-store-link liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+
+lift-store-link-∈ :
+  ∀ {Φ Ψ Δᴸ Δᴿ ρ ρ′ α β A B p} →
+  LiftStoreⁱ {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} Ψ ρ ρ′ →
+  store-link α A β B p ∈ ρ →
+  ∃[ p′ ]
+    store-link (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B) p′ ∈ ρ′
+lift-store-link-∈ lift-store-[] ()
+lift-store-link-∈ (lift-store-∷ liftρ) (here ())
+lift-store-link-∈ (lift-store-∷ liftρ) (there x∈)
+    with lift-store-link-∈ liftρ x∈
+lift-store-link-∈ (lift-store-∷ liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+lift-store-link-∈ (lift-store-left liftρ) (here ())
+lift-store-link-∈ (lift-store-left liftρ) (there x∈)
+    with lift-store-link-∈ liftρ x∈
+lift-store-link-∈ (lift-store-left liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+lift-store-link-∈ (lift-store-right liftρ) (here ())
+lift-store-link-∈ (lift-store-right liftρ) (there x∈)
+    with lift-store-link-∈ liftρ x∈
+lift-store-link-∈ (lift-store-right liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+lift-store-link-∈ (lift-store-link {p′ = p′} liftρ) (here refl) =
+  p′ , here refl
+lift-store-link-∈ (lift-store-link liftρ) (there x∈)
+    with lift-store-link-∈ liftρ x∈
+lift-store-link-∈ (lift-store-link liftρ) (there x∈)
+    | p′ , shifted∈ =
+  p′ , there shifted∈
+
+lift-store-corresponds :
+  ∀ {Φ Ψ Δᴸ Δᴿ ρ ρ′ α β A B p} →
+  LiftStoreⁱ {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} Ψ ρ ρ′ →
+  StoreCorresponds ρ α A β B p →
+  ∃[ p′ ] StoreCorresponds ρ′
+    (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B) p′
+lift-store-corresponds liftρ (correspondence-stored x∈)
+    with lift-store-matched-∈ liftρ x∈
+lift-store-corresponds liftρ (correspondence-stored x∈)
+    | p′ , shifted∈ =
+  p′ , correspondence-stored shifted∈
+lift-store-corresponds liftρ (correspondence-linked x∈)
+    with lift-store-link-∈ liftρ x∈
+lift-store-corresponds liftρ (correspondence-linked x∈)
+    | p′ , shifted∈ =
+  p′ , correspondence-linked shifted∈
+
+weaken-store-corresponds :
+  ∀ {Φ Δᴸ Δᴿ ρ α β A B p}
+    {entry : StoreImpEntry Φ Δᴸ Δᴿ} →
+  StoreCorresponds ρ α A β B p →
+  StoreCorresponds (entry ∷ ρ) α A β B p
+weaken-store-corresponds (correspondence-stored x∈) =
+  correspondence-stored (there x∈)
+weaken-store-corresponds (correspondence-linked x∈) =
+  correspondence-linked (there x∈)
+
+allocated-left-seal★ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★ (extᵈ μ) ((zero , Aν) ∷ leftStoreⁱ ρ′)
+allocated-left-seal★ liftρ seal★ zero ()
+allocated-left-seal★ {μ = μ} {ρ′ = ρ′} liftρ seal★ (suc α) ok =
+  there (shifted-seal★ (suc α) ok)
+  where
+    shifted-seal★ : SealModeStore★ (extᵈ μ) (leftStoreⁱ ρ′)
+    shifted-seal★ =
+      subst (SealModeStore★ (extᵈ μ))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (seal★-ext-shift seal★)
+
+allocated-left-gen-seal★ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★ (genᵈ μ) ((zero , Aν) ∷ leftStoreⁱ ρ′)
+allocated-left-gen-seal★ liftρ seal★ zero ()
+allocated-left-gen-seal★ {μ = μ} {ρ′ = ρ′}
+    liftρ seal★ (suc α) ok =
+  there (shifted-seal★ (suc α) ok)
+  where
+    shifted-seal★ : SealModeStore★ (genᵈ μ) (leftStoreⁱ ρ′)
+    shifted-seal★ =
+      subst (SealModeStore★ (genᵈ μ))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (seal★-gen-shift seal★)
+
+seal★-weakenCast-shift :
+  ∀ {μ Σ} →
+  SealModeStore★ μ Σ →
+  SealModeStore★ (weakenCastᵈ μ) (⟰ᵗ Σ)
+seal★-weakenCast-shift seal★ zero ()
+seal★-weakenCast-shift seal★ (suc α) ok =
+  ∈-renameStoreᵗ suc (seal★ α ok)
+
+lifted-left-weakenCast-seal★ :
+  ∀ {Φ Δᴸ Δᴿ μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★ (weakenCastᵈ μ) (leftStoreⁱ ρ′)
+lifted-left-weakenCast-seal★ liftρ seal★ =
+  subst (SealModeStore★ _)
+    (sym (leftStoreⁱ-lift-left liftρ))
+    (seal★-weakenCast-shift seal★)
+
+lifted-left-narrowing :
+  ∀ {Φ Δᴸ Δᴿ μ c A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  weakenCastᵈ μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ suc c ∶ ⇑ᵗ A ⊒ ⇑ᵗ B
+lifted-left-narrowing liftρ c⊒ =
+  subst
+    (λ Σ → weakenCastᵈ _ ∣ _ ∣ Σ
+      ⊢ renameᶜ suc _ ∶ ⇑ᵗ _ ⊒ ⇑ᵗ _)
+    (sym (leftStoreⁱ-lift-left liftρ))
+    (narrow-renameᵗ TyRenameWf-suc
+      modeRename-suc-weakenCast c⊒)
+
+lifted-left-widening :
+  ∀ {Φ Δᴸ Δᴿ μ c A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  weakenCastᵈ μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ suc c ∶ ⇑ᵗ A ⊑ ⇑ᵗ B
+lifted-left-widening liftρ c⊑ =
+  subst
+    (λ Σ → weakenCastᵈ _ ∣ _ ∣ Σ
+      ⊢ renameᶜ suc _ ∶ ⇑ᵗ _ ⊑ ⇑ᵗ _)
+    (sym (leftStoreⁱ-lift-left liftρ))
+    (widen-renameᵗ TyRenameWf-suc
+      modeRename-suc-weakenCast c⊑)
+
+left-source-lift-cast-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ c M M′ A B B′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ′ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ A ⊑ B′ ∶ p →
+  (q′ : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ B ⊑ B′ ⊣ Δᴿ) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ ⇑ᵗᵐ (M ⟨ c ⟩) ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′ ∶ q′
+left-source-lift-cast-narrowingᵀ liftρ mode seal★ c⊒ M⊑M′ q′ =
+  cast⊒⊑ᵀ (cast-weaken mode)
+    (lifted-left-weakenCast-seal★ liftρ seal★)
+    (lifted-left-narrowing liftρ c⊒) M⊑M′ q′
+
+left-source-lift-cast-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ c M M′ A B B′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ′ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ A ⊑ B′ ∶ p →
+  (q′ : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ B ⊑ B′ ⊣ Δᴿ) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ ⇑ᵗᵐ (M ⟨ c ⟩) ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′ ∶ q′
+left-source-lift-cast-wideningᵀ liftρ mode seal★ c⊑ M⊑M′ q′ =
+  cast⊑⊑ᵀ (cast-weaken mode)
+    (lifted-left-weakenCast-seal★ liftρ seal★)
+    (lifted-left-widening liftρ c⊑) M⊑M′ q′
+
+allocated-left-relationᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aν M M′ B B′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ′ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  (hAν : WfTy (suc Δᴸ) Aν) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  No• M →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero Aν hAν ∷ ρ′ ∣ γ′
+    ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
+allocated-left-relationᵀ hAν liftρ noM M⊑M′ =
+  allocation-leftᵀ hAν liftρ M⊑M′
+    (term-weaken {Δ′ = _} {Σ′ = _} ≤-refl StoreIncl-drop noM
+      (nu-term-imprecision-source-typing M⊑M′))
+    (nu-term-imprecision-target-typing M⊑M′)
+
+open-allocated-left-all-reveal :
+  ∀ {Φ Δᴸ Δᴿ μ α X Aν c A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    (`∀ c) (`∀ A) (`∀ B) →
+  RevealConversion (extᵈ μ) (suc Δᴸ)
+    ((zero , Aν) ∷ leftStoreⁱ ρ′)
+    (suc α) (⇑ᵗ X) c A B
+open-allocated-left-all-reveal liftρ (reveal-all c↑) =
+  weaken-reveal-conversion StoreIncl-drop
+    (subst
+      (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+      (sym (leftStoreⁱ-lift-left liftρ)) c↑)
+
+open-allocated-left-all-conceal :
+  ∀ {Φ Δᴸ Δᴿ μ α X Aν c A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    (`∀ c) (`∀ A) (`∀ B) →
+  ConcealConversion (extᵈ μ) (suc Δᴸ)
+    ((zero , Aν) ∷ leftStoreⁱ ρ′)
+    (suc α) (⇑ᵗ X) c A B
+open-allocated-left-all-conceal liftρ (conceal-all c↓) =
+  weaken-conceal-conversion StoreIncl-drop
+    (subst
+      (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+      (sym (leftStoreⁱ-lift-left liftρ)) c↓)
+
+open-allocated-paired-all-conversion :
+  ∀ {Φ Δᴸ Δᴿ X X′ pX c c′ A A′ B B′ p q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ′ →
+  PairedConversion Φ Δᴸ Δᴿ ρ
+    (`∀ c) (`∀ c′) {`∀ A} {`∀ A′} {`∀ B} {`∀ B′}
+    (∀ⁱ p) (∀ⁱ q) →
+  PairedConversion (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)
+    (store-matched zero X zero X′ pX ∷ ρ′)
+    c c′ {A} {A′} {B} {B′} p q
+open-allocated-paired-all-conversion liftρ
+    (paired-reveal x~ (reveal-all c↑) (reveal-all c′↑))
+    with lift-store-corresponds liftρ x~
+open-allocated-paired-all-conversion liftρ
+    (paired-reveal x~ (reveal-all c↑) (reveal-all c′↑))
+    | p′ , shifted~ =
+  paired-reveal (weaken-store-corresponds shifted~)
+    (weaken-reveal-conversion StoreIncl-drop left-reveal)
+    (weaken-reveal-conversion StoreIncl-drop right-reveal)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        c↑
+
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        c′↑
+open-allocated-paired-all-conversion liftρ
+    (paired-conceal x~ (conceal-all c↓) (conceal-all c′↓))
+    with lift-store-corresponds liftρ x~
+open-allocated-paired-all-conversion liftρ
+    (paired-conceal x~ (conceal-all c↓) (conceal-all c′↓))
+    | p′ , shifted~ =
+  paired-conceal (weaken-store-corresponds shifted~)
+    (weaken-conceal-conversion StoreIncl-drop left-conceal)
+    (weaken-conceal-conversion StoreIncl-drop right-conceal)
+  where
+    left-conceal =
+      subst
+        (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        c↓
+
+    right-conceal =
+      subst
+        (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        c′↓
+
+------------------------------------------------------------------------
+-- First administrative step after allocation
+------------------------------------------------------------------------
+
+post-allocation-β-Λ•-bare :
+  ∀ {V} →
+  Value V →
+  (⇑ᵗᵐ (Λ V)) • —→[ keep ] V
+post-allocation-β-Λ•-bare {V = V} vV =
+  subst
+    (λ W → (⇑ᵗᵐ (Λ V)) • —→[ keep ] W)
+    (open0-ext-suc-cancelᵐ V)
+    (pure-step
+      (β-Λ• (renameᵗᵐ-preserves-Value (extᵗ suc) vV)))
+
+post-allocation-β-Λ• :
+  ∀ {V s} →
+  Value V →
+  ((⇑ᵗᵐ (Λ V)) •) ⟨ s ⟩ —→[ keep ] V ⟨ s ⟩
+post-allocation-β-Λ• vV =
+  ξ-⟨⟩ (post-allocation-β-Λ•-bare vV)
+
+post-allocation-β-∀•-bare :
+  ∀ {V c} →
+  Value V →
+  (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •
+    —→[ keep ] ((⇑ᵗᵐ V) •) ⟨ c ⟩
+post-allocation-β-∀•-bare {V = V} {c = c} vV =
+  subst
+    (λ d → (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •
+      —→[ keep ] ((⇑ᵗᵐ V) •) ⟨ d ⟩)
+    (open0-ext-suc-cancelᶜ c)
+    (pure-step
+      (β-∀• (renameᵗᵐ-preserves-Value suc vV)))
+
+post-β-inst :
+  ∀ {V B s} →
+  Value V →
+  V ⟨ inst B s ⟩ —→[ keep ] ν ★ V s
+post-β-inst vV = pure-step (β-inst vV)
+
+post-β-gen• :
+  ∀ {V A c} →
+  Value V →
+  ((V ⟨ gen A c ⟩) •) —→[ keep ] (V ⟨ (c [ zero ]ᶜ) ⟩)
+post-β-gen• vV = pure-step (β-gen• vV)
+
+post-allocation-β-gen•-bare :
+  ∀ {V A c} →
+  Value V →
+  (⇑ᵗᵐ (V ⟨ gen A c ⟩)) •
+    —→[ keep ] (⇑ᵗᵐ V) ⟨ c ⟩
+post-allocation-β-gen•-bare {V = V} {c = c} vV =
+  subst
+    (λ d → (⇑ᵗᵐ (V ⟨ gen _ c ⟩)) •
+      —→[ keep ] (⇑ᵗᵐ V) ⟨ d ⟩)
+    (open0-ext-suc-cancelᶜ c)
+    (pure-step
+      (β-gen• (renameᵗᵐ-preserves-Value suc vV)))
+
+post-allocation-β-gen• :
+  ∀ {V A c s} →
+  Value V →
+  ((⇑ᵗᵐ (V ⟨ gen A c ⟩)) •) ⟨ s ⟩
+    —→[ keep ] ((⇑ᵗᵐ V) ⟨ c ⟩) ⟨ s ⟩
+post-allocation-β-gen• {V = V} {c = c} {s = s} vV =
+  ξ-⟨⟩ (post-allocation-β-gen•-bare vV)
+
+nested-Λ-no• :
+  ∀ {W c d} →
+  No• (((Λ W) ⟨ c ⟩) ⟨ d ⟩) →
+  No• W
+nested-Λ-no• (no•-⟨⟩ (no•-⟨⟩ (no•-Λ noW))) = noW
+
+nested-Λ-runtime-no• :
+  ∀ {A W c d s} →
+  RuntimeOK (ν A (((Λ W) ⟨ c ⟩) ⟨ d ⟩) s) →
+  No• W
+nested-Λ-runtime-no• okM
+    with runtime-⟨⟩ (runtime-⟨⟩ (runtime-ν okM))
+nested-Λ-runtime-no• okM | ok-no (no•-Λ noW) = noW
+
+------------------------------------------------------------------------
+-- Direct-swap administrative traces
+------------------------------------------------------------------------
+
+left-swap-allocation-trace :
+  ∀ {Aobs G U W d u s} →
+  Value W →
+  No• W →
+  ν Aobs
+      ((Λ W) ⟨ `∀ (gen G d) ⟩ ⟨ inst U (`∀ u) ⟩)
+      s
+    —↠[
+      keep ∷ bind ★ ∷ keep ∷ keep ∷
+      bind (⇑ᵗ Aobs) ∷ keep ∷ keep ∷ []
+    ]
+      (((⇑ᵗᵐ W) ⟨ d ⟩) ⟨ u ⟩)
+        ⟨ renameᶜ (extᵗ suc) s ⟩
+left-swap-allocation-trace {Aobs = Aobs} {G = G} {U = U}
+    {W = W} {d = d} {u = u} {s = s} vW noW =
+  ↠-step
+    (ξ-ν (post-β-inst ((Λ vW) ⟨ `∀ (gen G d) ⟩)))
+    (↠-step
+      (ξ-ν
+        (ν-step ((Λ vW) ⟨ `∀ (gen G d) ⟩)
+          (no•-⟨⟩ (no•-Λ noW))))
+      (↠-step
+        (ξ-ν
+          (ξ-⟨⟩
+            (post-allocation-β-∀•-bare (Λ vW))))
+        (↠-step
+          (ξ-ν
+            (ξ-⟨⟩
+              (ξ-⟨⟩ (post-allocation-β-Λ•-bare vW))))
+          (↠-step
+            (ν-step
+              (((vW ⟨ gen G d ⟩) ⟨ `∀ u ⟩))
+              (no•-⟨⟩ (no•-⟨⟩ noW)))
+            (↠-step
+              (ξ-⟨⟩
+                (post-allocation-β-∀•-bare
+                  (vW ⟨ gen G d ⟩)))
+              (↠-step
+                (ξ-⟨⟩
+                  (ξ-⟨⟩
+                    (post-allocation-β-gen•-bare vW)))
+                ↠-refl))))))
+
+left-swap-allocation-step-tail :
+  ∀ {Aobs G U W d u s} →
+  Value W →
+  No• W →
+  (ν Aobs
+      ((Λ W) ⟨ `∀ (gen G d) ⟩ ⟨ inst U (`∀ u) ⟩)
+      s
+    —→[ keep ]
+      ν Aobs
+        (ν ★ ((Λ W) ⟨ `∀ (gen G d) ⟩) (`∀ u))
+        s) ×
+  (ν Aobs
+      (ν ★ ((Λ W) ⟨ `∀ (gen G d) ⟩) (`∀ u))
+      s
+    —↠[
+      bind ★ ∷ keep ∷ keep ∷ bind (⇑ᵗ Aobs) ∷
+      keep ∷ keep ∷ []
+    ]
+      (((⇑ᵗᵐ W) ⟨ d ⟩) ⟨ u ⟩)
+        ⟨ renameᶜ (extᵗ suc) s ⟩)
+left-swap-allocation-step-tail {Aobs = Aobs} {G = G} {U = U}
+    {W = W} {d = d} {u = u} {s = s} vW noW =
+  ξ-ν (post-β-inst ((Λ vW) ⟨ `∀ (gen G d) ⟩)) ,
+  ↠-step
+    (ξ-ν
+      (ν-step ((Λ vW) ⟨ `∀ (gen G d) ⟩)
+        (no•-⟨⟩ (no•-Λ noW))))
+    (↠-step
+      (ξ-ν
+        (ξ-⟨⟩
+          (post-allocation-β-∀•-bare (Λ vW))))
+      (↠-step
+        (ξ-ν
+          (ξ-⟨⟩
+            (ξ-⟨⟩ (post-allocation-β-Λ•-bare vW))))
+        (↠-step
+          (ν-step
+            (((vW ⟨ gen G d ⟩) ⟨ `∀ u ⟩))
+            (no•-⟨⟩ (no•-⟨⟩ noW)))
+          (↠-step
+            (ξ-⟨⟩
+              (post-allocation-β-∀•-bare
+                (vW ⟨ gen G d ⟩)))
+            (↠-step
+              (ξ-⟨⟩
+                (ξ-⟨⟩
+                  (post-allocation-β-gen•-bare vW)))
+              ↠-refl)))))
+
+right-swap-allocation-trace :
+  ∀ {Bobs G′ U′ W′ d′ u′ s′} →
+  Value W′ →
+  No• W′ →
+  ν Bobs
+      ((Λ W′) ⟨ gen G′ (`∀ d′) ⟩
+        ⟨ `∀ (inst U′ u′) ⟩)
+      s′
+    —↠[
+      bind Bobs ∷ keep ∷ keep ∷ keep ∷
+      bind ★ ∷ keep ∷ keep ∷ []
+    ]
+      ((renameᵗᵐ (extᵗ suc) W′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+        ⟨ ⇑ᶜ s′ ⟩
+right-swap-allocation-trace {Bobs = Bobs} {G′ = G′} {U′ = U′}
+    {W′ = W′} {d′ = d′} {u′ = u′} {s′ = s′} vW′ noW′ =
+  ↠-step
+    (ν-step
+      (((Λ vW′) ⟨ gen G′ (`∀ d′) ⟩)
+        ⟨ `∀ (inst U′ u′) ⟩)
+      (no•-⟨⟩ (no•-⟨⟩ (no•-Λ noW′))))
+    (↠-step
+      (ξ-⟨⟩
+        (post-allocation-β-∀•-bare
+          ((Λ vW′) ⟨ gen G′ (`∀ d′) ⟩)))
+      (↠-step
+        (ξ-⟨⟩
+          (ξ-⟨⟩
+            (post-allocation-β-gen•-bare (Λ vW′))))
+        (↠-step
+          (ξ-⟨⟩
+            (post-β-inst
+              ((renameᵗᵐ-preserves-Value suc (Λ vW′))
+                ⟨ `∀ d′ ⟩)))
+          (↠-step
+            (ξ-⟨⟩
+              (ν-step
+                ((renameᵗᵐ-preserves-Value suc (Λ vW′))
+                  ⟨ `∀ d′ ⟩)
+                (no•-⟨⟩
+                  (renameᵗᵐ-preserves-No• suc (no•-Λ noW′)))))
+            (↠-step
+              (ξ-⟨⟩
+                (ξ-⟨⟩
+                  (post-allocation-β-∀•-bare
+                    (renameᵗᵐ-preserves-Value suc (Λ vW′)))))
+              (↠-step
+                (ξ-⟨⟩
+                  (ξ-⟨⟩
+                    (ξ-⟨⟩
+                      (post-allocation-β-Λ•-bare
+                        (renameᵗᵐ-preserves-Value
+                          (extᵗ suc) vW′)))))
+                ↠-refl))))))
+
+right-swap-allocation-step-tail :
+  ∀ {Bobs G′ U′ W′ d′ u′ s′} →
+  Value W′ →
+  No• W′ →
+  (ν Bobs
+      ((Λ W′) ⟨ gen G′ (`∀ d′) ⟩
+        ⟨ `∀ (inst U′ u′) ⟩)
+      s′
+    —→[ bind Bobs ]
+      ((⇑ᵗᵐ
+        ((Λ W′) ⟨ gen G′ (`∀ d′) ⟩
+          ⟨ `∀ (inst U′ u′) ⟩)) •) ⟨ s′ ⟩) ×
+  (((⇑ᵗᵐ
+      ((Λ W′) ⟨ gen G′ (`∀ d′) ⟩
+        ⟨ `∀ (inst U′ u′) ⟩)) •) ⟨ s′ ⟩
+    —↠[
+      keep ∷ keep ∷ keep ∷ bind ★ ∷ keep ∷ keep ∷ []
+    ]
+      ((renameᵗᵐ (extᵗ suc) W′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+        ⟨ ⇑ᶜ s′ ⟩)
+right-swap-allocation-step-tail {G′ = G′} {U′ = U′}
+    {d′ = d′} {u′ = u′} vW′ noW′ =
+  ν-step
+    (((Λ vW′) ⟨ gen G′ (`∀ d′) ⟩)
+      ⟨ `∀ (inst U′ u′) ⟩)
+    (no•-⟨⟩ (no•-⟨⟩ (no•-Λ noW′))) ,
+  ↠-step
+    (ξ-⟨⟩
+      (post-allocation-β-∀•-bare
+        ((Λ vW′) ⟨ gen G′ (`∀ d′) ⟩)))
+    (↠-step
+      (ξ-⟨⟩
+        (ξ-⟨⟩
+          (post-allocation-β-gen•-bare (Λ vW′))))
+      (↠-step
+        (ξ-⟨⟩
+          (post-β-inst
+            ((renameᵗᵐ-preserves-Value suc (Λ vW′))
+              ⟨ `∀ d′ ⟩)))
+        (↠-step
+          (ξ-⟨⟩
+            (ν-step
+              ((renameᵗᵐ-preserves-Value suc (Λ vW′))
+                ⟨ `∀ d′ ⟩)
+              (no•-⟨⟩
+                (renameᵗᵐ-preserves-No• suc (no•-Λ noW′)))))
+          (↠-step
+            (ξ-⟨⟩
+              (ξ-⟨⟩
+                (post-allocation-β-∀•-bare
+                  (renameᵗᵐ-preserves-Value suc (Λ vW′)))))
+            (↠-step
+              (ξ-⟨⟩
+                (ξ-⟨⟩
+                  (ξ-⟨⟩
+                    (post-allocation-β-Λ•-bare
+                      (renameᵗᵐ-preserves-Value
+                        (extᵗ suc) vW′)))))
+              ↠-refl)))))
+
+paired-swap-gen-inst-allocationᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  Value W →
+  No• W →
+  Value W′ →
+  No• W′ →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (qD : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ᵖ D′ ⊣ suc (suc Δᴿ)) →
+  (pE : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ renameᵗ (extᵗ suc) E ⊑ ⇑ᵗ E′ ⊣ suc (suc Δᴿ)) →
+  (pF : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ renameᵗ (extᵗ suc) F ⊑ ⇑ᵗ F′ ⊣ suc (suc Δᴿ)) →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E F →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ F′ →
+  (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩ ⟨ inst (`∀ E) (`∀ u) ⟩) s
+    —↠[
+      keep ∷ bind ★ ∷ keep ∷ keep ∷
+      bind (⇑ᵗ Aobs) ∷ keep ∷ keep ∷ []
+    ]
+      (((⇑ᵗᵐ W) ⟨ d ⟩) ⟨ u ⟩)
+        ⟨ renameᶜ (extᵗ suc) s ⟩) ×
+  (ν Bobs
+      ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+        ⟨ `∀ (inst E′ u′) ⟩) s′
+    —→[ bind Bobs ]
+      ((⇑ᵗᵐ
+        ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+          ⟨ `∀ (inst E′ u′) ⟩)) •) ⟨ s′ ⟩) ×
+  (((⇑ᵗᵐ
+      ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+        ⟨ `∀ (inst E′ u′) ⟩)) •) ⟨ s′ ⟩
+    —↠[
+      keep ∷ keep ∷ keep ∷ bind ★ ∷ keep ∷ keep ∷ []
+    ]
+      ((renameᵗᵐ (extᵗ suc) W′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+        ⟨ ⇑ᶜ s′ ⟩) ×
+  (swapRight∀∀ᵢ Φ
+    ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣
+      crossedStoreⁱ
+        (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+        wf★ wf★
+        (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+        (⊑-crossed-double-lift∀∀ᵢ pObs) id★ ρ₂
+    ∣ []
+    ⊢ᴺ (((⇑ᵗᵐ W) ⟨ d ⟩) ⟨ u ⟩)
+        ⟨ renameᶜ (extᵗ suc) s ⟩
+      ⊑ ((renameᵗᵐ (extᵗ suc) W′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+        ⟨ ⇑ᶜ s′ ⟩
+    ⦂ renameᵗ (extᵗ suc) F ⊑ ⇑ᵗ F′ ∶ pF)
+paired-swap-gen-inst-allocationᵀ {Aobs = Aobs} {Bobs = Bobs}
+    liftρ₁ liftρ₂ vW noW vW′ noW′
+    W⊑W′ pObs qD pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑
+    s↑ s′↑
+    with right-swap-allocation-step-tail vW′ noW′
+paired-swap-gen-inst-allocationᵀ {Aobs = Aobs} {Bobs = Bobs}
+    liftρ₁ liftρ₂ vW noW vW′ noW′
+    W⊑W′ pObs qD pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑
+    s↑ s′↑ | right→ , right↠ =
+  let
+    body⊑body′ = crossed-bodyᵀ liftρ₁ liftρ₂ noW noW′ W⊑W′
+    allocated-body =
+      allocation-crossedᵀ
+        (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+        wf★ wf★
+        (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+        liftρ₁ liftρ₂
+        (⊑-crossed-double-lift∀∀ᵢ pObs) id★
+        body⊑body′
+        (term-weaken ≤-refl (λ x∈ → there (there x∈))
+          (renameᵗᵐ-preserves-No• suc noW)
+          (nu-term-imprecision-source-typing body⊑body′))
+        (term-weaken ≤-refl (λ x∈ → there (there x∈))
+          (renameᵗᵐ-preserves-No• (extᵗ suc) noW′)
+          (nu-term-imprecision-target-typing body⊑body′))
+    d⊒ =
+      ∀gen-crossed-narrowing-body
+        {Aobs = ⇑ᵗ (⇑ᵗ Aobs)} liftρ₁ liftρ₂ ∀gen⊒
+    d′⊒ =
+      gen∀-crossed-narrowing-body
+        {Bobs = ⇑ᵗ (⇑ᵗ Bobs)} liftρ₁ liftρ₂ gen∀⊒
+    u⊑ =
+      inst∀-crossed-widening-body
+        {Aobs = ⇑ᵗ (⇑ᵗ Aobs)} liftρ₁ liftρ₂ inst∀⊑
+    u′⊑ =
+      ∀inst-crossed-widening-body
+        {Bobs = ⇑ᵗ (⇑ᵗ Bobs)} liftρ₁ liftρ₂ ∀inst⊑
+    exposed-casts =
+      crossed-up⊑upᵀ
+        (gen-down⊑gen-downᵀ d⊒ d′⊒ allocated-body qD)
+        (cast-ext (cast-inst cast-tag-or-id))
+        seal★-ext-inst-tag-or-id u⊑
+        seal★-inst-ext-tag-or-id u′⊑ pE
+  in
+  left-swap-allocation-trace vW noW ,
+  right→ ,
+  right↠ ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal crossedStoreⁱ-new-old
+        (left-swap-reveal-conversion liftρ₁ liftρ₂ s↑)
+        (right-swap-reveal-conversion liftρ₁ liftρ₂ s′↑)))
+    exposed-casts
+
+paired-reverse-swap-gen-inst-allocationᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  Value W →
+  No• W →
+  Value W′ →
+  No• W′ →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (qD : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ᵖ D′ ⊣ suc (suc Δᴿ)) →
+  (pE : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ ⇑ᵗ E ⊑ renameᵗ (extᵗ suc) E′ ⊣ suc (suc Δᴿ)) →
+  (pF : swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ ⇑ᵗ F ⊑ renameᵗ (extᵗ suc) F′ ⊣ suc (suc Δᴿ)) →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E F →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ F′ →
+  (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s
+    —↠[
+      bind Aobs ∷ keep ∷ keep ∷ keep ∷
+      bind ★ ∷ keep ∷ keep ∷ []
+    ]
+      ((renameᵗᵐ (extᵗ suc) W ⟨ d ⟩) ⟨ u ⟩)
+        ⟨ ⇑ᶜ s ⟩) ×
+  (ν Bobs
+      ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+        ⟨ inst (`∀ E′) (`∀ u′) ⟩) s′
+    —→[ keep ]
+      ν Bobs
+        (ν ★ ((Λ W′) ⟨ `∀ (gen B d′) ⟩) (`∀ u′))
+        s′) ×
+  (ν Bobs
+      (ν ★ ((Λ W′) ⟨ `∀ (gen B d′) ⟩) (`∀ u′))
+      s′
+    —↠[
+      bind ★ ∷ keep ∷ keep ∷ bind (⇑ᵗ Bobs) ∷
+      keep ∷ keep ∷ []
+    ]
+      (((⇑ᵗᵐ W′) ⟨ d′ ⟩) ⟨ u′ ⟩)
+        ⟨ renameᶜ (extᵗ suc) s′ ⟩) ×
+  (swapRight∀∀ᵢ Φ
+    ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣
+      crossedStoreⁱ
+        wf★ (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+        (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs)) wf★
+        id★ (⊑-crossed-double-lift∀∀ᵢ pObs) ρ₂
+    ∣ []
+    ⊢ᴺ ((renameᵗᵐ (extᵗ suc) W ⟨ d ⟩) ⟨ u ⟩)
+        ⟨ ⇑ᶜ s ⟩
+      ⊑ (((⇑ᵗᵐ W′) ⟨ d′ ⟩) ⟨ u′ ⟩)
+        ⟨ renameᶜ (extᵗ suc) s′ ⟩
+    ⦂ ⇑ᵗ F ⊑ renameᵗ (extᵗ suc) F′ ∶ pF)
+paired-reverse-swap-gen-inst-allocationᵀ
+    {Aobs = Aobs} {Bobs = Bobs}
+    liftρ₁ liftρ₂ vW noW vW′ noW′
+    W⊑W′ pObs qD pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑
+    s↑ s′↑
+    with left-swap-allocation-step-tail vW′ noW′
+paired-reverse-swap-gen-inst-allocationᵀ
+    {Aobs = Aobs} {Bobs = Bobs}
+    liftρ₁ liftρ₂ vW noW vW′ noW′
+    W⊑W′ pObs qD pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑
+    s↑ s′↑ | left→ , left↠ =
+  let
+    pObs× = ⊑-crossed-double-lift∀∀ᵢ pObs
+    body⊑body′ = crossed-left-bodyᵀ
+      liftρ₁ liftρ₂ noW noW′ W⊑W′
+    allocated-body =
+      allocation-crossedᵀ
+        wf★ (⊑-src-wf pObs×) (⊑-tgt-wf pObs×) wf★
+        liftρ₁ liftρ₂ id★ pObs× body⊑body′
+        (term-weaken ≤-refl (λ x∈ → there (there x∈))
+          (renameᵗᵐ-preserves-No• (extᵗ suc) noW)
+          (nu-term-imprecision-source-typing body⊑body′))
+        (term-weaken ≤-refl (λ x∈ → there (there x∈))
+          (renameᵗᵐ-preserves-No• suc noW′)
+          (nu-term-imprecision-target-typing body⊑body′))
+    d⊒ = gen∀-crossed-source-narrowing-body
+      {Aobs = ⇑ᵗ (⇑ᵗ Aobs)} liftρ₁ liftρ₂ gen∀⊒
+    d′⊒ = ∀gen-crossed-target-narrowing-body
+      {Bobs = ⇑ᵗ (⇑ᵗ Bobs)} liftρ₁ liftρ₂ ∀gen⊒
+    u⊑ = ∀inst-crossed-source-widening-body
+      {Aobs = ⇑ᵗ (⇑ᵗ Aobs)} liftρ₁ liftρ₂ ∀inst⊑
+    u′⊑ = inst∀-crossed-target-widening-body
+      {Bobs = ⇑ᵗ (⇑ᵗ Bobs)} liftρ₁ liftρ₂ inst∀⊑
+    exposed-casts =
+      crossed-left-up⊑upᵀ
+        (gen-down⊑gen-downᵀ d⊒ d′⊒ allocated-body qD)
+        (cast-inst (cast-ext cast-tag-or-id))
+        seal★-inst-ext-tag-or-id u⊑
+        seal★-ext-inst-tag-or-id u′⊑ pE
+  in
+  right-swap-allocation-trace vW noW ,
+  left→ ,
+  left↠ ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal crossedStoreⁱ-old-new
+        (right-swap-source-reveal-conversion liftρ₁ liftρ₂ s↑)
+        (left-swap-target-reveal-conversion liftρ₁ liftρ₂ s′↑)))
+    exposed-casts
+
+direct-swap-gen-inst-caseᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ T E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  Value W →
+  RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s) →
+  Value W′ →
+  No•
+    ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+      ⟨ `∀ (inst E′ u′) ⟩) →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ D) ⊑ᵖ
+      `∀ (`∀ T) ⊣ Δᴿ) →
+  renameᵗ swap01ᵗ D′ ≈∀ T →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ →
+  Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′)
+      ∶ `∀ B ⊒ `∀ (`∀ T) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′)
+      ∶ `∀ (`∀ T) ⊑ `∀ E′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′) →
+  ∃[ ρ₂ ] ∃[ pF× ]
+    LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ ×
+    (ν Aobs
+        ((Λ W) ⟨ `∀ (gen A d) ⟩
+          ⟨ inst (`∀ E) (`∀ u) ⟩) s
+      —↠[
+        keep ∷ bind ★ ∷ keep ∷ keep ∷
+        bind (⇑ᵗ Aobs) ∷ keep ∷ keep ∷ []
+      ]
+        (((⇑ᵗᵐ W) ⟨ d ⟩) ⟨ u ⟩)
+          ⟨ renameᶜ (extᵗ suc) s ⟩) ×
+    (ν Bobs
+        ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+          ⟨ `∀ (inst E′ u′) ⟩) s′
+      —→[ bind Bobs ]
+        ((⇑ᵗᵐ
+          ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+            ⟨ `∀ (inst E′ u′) ⟩)) •) ⟨ s′ ⟩) ×
+    (((⇑ᵗᵐ
+        ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+          ⟨ `∀ (inst E′ u′) ⟩)) •) ⟨ s′ ⟩
+      —↠[
+        keep ∷ keep ∷ keep ∷ bind ★ ∷ keep ∷ keep ∷ []
+      ]
+        ((renameᵗᵐ (extᵗ suc) W′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+          ⟨ ⇑ᶜ s′ ⟩) ×
+    (swapRight∀∀ᵢ Φ
+      ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣
+        crossedStoreⁱ
+          (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          wf★ wf★
+          (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          (⊑-crossed-double-lift∀∀ᵢ pObs) id★ ρ₂
+      ∣ []
+      ⊢ᴺ (((⇑ᵗᵐ W) ⟨ d ⟩) ⟨ u ⟩)
+          ⟨ renameᶜ (extᵗ suc) s ⟩
+        ⊑ ((renameᵗᵐ (extᵗ suc) W′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+          ⟨ ⇑ᶜ s′ ⟩
+      ⦂ renameᵗ (extᵗ suc) (⇑ᵗ F) ⊑ ⇑ᵗ (⇑ᵗ F′) ∶ pF×)
+direct-swap-gen-inst-caseᵀ {F = F} liftρ₁
+    vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T pE pF
+    ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+    with crossed-lift-store liftρ₁
+direct-swap-gen-inst-caseᵀ {F = F} liftρ₁
+    vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T pE pF
+    ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+    | ρ₂ , liftρ₂ =
+  let
+    noW = nested-Λ-runtime-no• okM
+    noW′ = nested-Λ-no• noM′
+    qD× = direct-swap-residualᵖ pD D′ˢ≈T
+    pE× = ⊑-crossed-left-body-lift∀∀ᵢ pE
+    pF× =
+      subst
+        (λ T → swapRight∀∀ᵢ _ ∣ _
+          ⊢ T ⊑ ⇑ᵗ (⇑ᵗ _) ⊣ _)
+        (sym (renameᵗ-ext-suc-comm suc F))
+        (⊑-crossed-double-lift∀∀ᵢ pF)
+  in
+  ρ₂ , pF× , liftρ₂ ,
+  paired-swap-gen-inst-allocationᵀ
+    liftρ₁ liftρ₂ vW noW vW′ noW′ W⊑W′
+    pObs qD× pE× pF× ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+
+direct-reverse-swap-gen-inst-caseᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B S D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  Value W →
+  RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s) →
+  Value W′ →
+  No•
+    ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+      ⟨ inst (`∀ E′) (`∀ u′) ⟩) →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ S) ⊑ᵖ
+      `∀ (`∀ D′) ⊣ Δᴿ) →
+  S ≈∀ renameᵗ swap01ᵗ D →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ →
+  Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d)
+      ∶ `∀ A ⊒ `∀ (`∀ S) →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u)
+      ∶ `∀ (`∀ S) ⊑ `∀ E →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′) →
+  ∃[ ρ₂ ] ∃[ pF× ]
+    LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ ×
+    (ν Aobs
+        ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+          ⟨ `∀ (inst E u) ⟩) s
+      —↠[
+        bind Aobs ∷ keep ∷ keep ∷ keep ∷
+        bind ★ ∷ keep ∷ keep ∷ []
+      ]
+        ((renameᵗᵐ (extᵗ suc) W ⟨ d ⟩) ⟨ u ⟩)
+          ⟨ ⇑ᶜ s ⟩) ×
+    (ν Bobs
+        ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+          ⟨ inst (`∀ E′) (`∀ u′) ⟩) s′
+      —→[ keep ]
+        ν Bobs
+          (ν ★ ((Λ W′) ⟨ `∀ (gen B d′) ⟩) (`∀ u′))
+          s′) ×
+    (ν Bobs
+        (ν ★ ((Λ W′) ⟨ `∀ (gen B d′) ⟩) (`∀ u′))
+        s′
+      —↠[
+        bind ★ ∷ keep ∷ keep ∷ bind (⇑ᵗ Bobs) ∷
+        keep ∷ keep ∷ []
+      ]
+        (((⇑ᵗᵐ W′) ⟨ d′ ⟩) ⟨ u′ ⟩)
+          ⟨ renameᶜ (extᵗ suc) s′ ⟩) ×
+    (swapRight∀∀ᵢ Φ
+      ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣
+        crossedStoreⁱ
+          wf★ (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs)) wf★
+          id★ (⊑-crossed-double-lift∀∀ᵢ pObs) ρ₂
+      ∣ []
+      ⊢ᴺ ((renameᵗᵐ (extᵗ suc) W ⟨ d ⟩) ⟨ u ⟩)
+          ⟨ ⇑ᶜ s ⟩
+        ⊑ (((⇑ᵗᵐ W′) ⟨ d′ ⟩) ⟨ u′ ⟩)
+          ⟨ renameᶜ (extᵗ suc) s′ ⟩
+      ⦂ ⇑ᵗ (⇑ᵗ F) ⊑ renameᵗ (extᵗ suc) (⇑ᵗ F′)
+      ∶ pF×)
+direct-reverse-swap-gen-inst-caseᵀ {F′ = F′}
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+    gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    with crossed-lift-store liftρ₁
+direct-reverse-swap-gen-inst-caseᵀ {F′ = F′}
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+    gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    | ρ₂ , liftρ₂ =
+  let
+    noW = nested-Λ-runtime-no• okM
+    noW′ = nested-Λ-no• noM′
+    qD× = reverse-swap-residualᵖ S≈Dˢ pD
+    pE× = ⊑-crossed-body-lift∀∀ᵢ pE
+    pF× =
+      subst
+        (λ T → swapRight∀∀ᵢ _ ∣ _
+          ⊢ ⇑ᵗ (⇑ᵗ _) ⊑ T ⊣ _)
+        (sym (renameᵗ-ext-suc-comm suc F′))
+        (⊑-crossed-double-lift∀∀ᵢ pF)
+  in
+  ρ₂ , pF× , liftρ₂ ,
+  paired-reverse-swap-gen-inst-allocationᵀ
+    liftρ₁ liftρ₂ vW noW vW′ noW′ W⊑W′
+    pObs qD× pE× pF× gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+
+-- Direct quotient clause for recursion on the term-imprecision derivation.
+weak-one-step-direct-quotientᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ T E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  Value W →
+  RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s) →
+  Value W′ →
+  No•
+    ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+      ⟨ `∀ (inst E′ u′) ⟩) →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ D) ⊑ᵖ
+      `∀ (`∀ T) ⊣ Δᴿ) →
+  renameᵗ swap01ᵗ D′ ≈∀ T →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ →
+  Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D) →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′)
+      ∶ `∀ B ⊒ `∀ (`∀ T) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′)
+      ∶ `∀ (`∀ T) ⊑ `∀ E′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′) →
+  WeakOneStepResult ρ₀
+    (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s)
+    (((⇑ᵗᵐ
+      ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+        ⟨ `∀ (inst E′ u′) ⟩)) •) ⟨ s′ ⟩)
+    F F′ (bind Bobs)
+weak-one-step-direct-quotientᵀ {Aobs = Aobs} {Bobs = Bobs}
+    {F = F} {F′ = F′} liftρ₁ vW okM vW′ noM′
+    W⊑W′ pObs pD qD D′ˢ≈T pE pF ∀gen⊒ gen∀⊒
+    inst∀⊑ ∀inst⊑ s↑ s′↑
+    with direct-swap-gen-inst-caseᵀ liftρ₁ vW okM vW′ noM′
+      W⊑W′ pObs pD qD D′ˢ≈T pE pF
+      ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+weak-one-step-direct-quotientᵀ {Aobs = Aobs} {Bobs = Bobs}
+    {F = F} {F′ = F′} liftρ₁ vW okM vW′ noM′
+    W⊑W′ pObs pD qD D′ˢ≈T pE pF ∀gen⊒ gen∀⊒
+    inst∀⊑ ∀inst⊑ s↑ s′↑
+    | ρ₂ , pF× , liftρ₂ , left↠ , _ , right↠ , result =
+  record
+    { sourceChanges =
+        keep ∷ bind ★ ∷ keep ∷ keep ∷
+        bind (⇑ᵗ Aobs) ∷ keep ∷ keep ∷ []
+    ; targetTailChanges =
+        keep ∷ keep ∷ keep ∷ bind ★ ∷ keep ∷ keep ∷ []
+    ; sourceResult =
+        (((⇑ᵗᵐ _) ⟨ _ ⟩) ⟨ _ ⟩)
+          ⟨ renameᶜ (extᵗ suc) _ ⟩
+    ; targetResult =
+        ((renameᵗᵐ (extᵗ suc) _ ⟨ _ ⟩) ⟨ _ ⟩)
+          ⟨ ⇑ᶜ _ ⟩
+    ; resultCtx = swapRight∀∀ᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore =
+        crossedStoreⁱ
+          (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          wf★ wf★
+          (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          (⊑-crossed-double-lift∀∀ᵢ pObs) id★ ρ₂
+    ; resultSourceType = renameᵗ (extᵗ suc) (⇑ᵗ F)
+    ; resultTargetType = ⇑ᵗ (⇑ᵗ F′)
+    ; sourceTypeResult = renameᵗ-ext-suc-comm suc F
+    ; targetTypeResult = refl
+    ; transportType = ⊑-crossed-double-lift∀∀ᵢ
+    ; transportAllBody = ⊑-crossed-double-lift-under-∀ᵢ
+    ; transportRightBody = ⊑-crossed-double-lift-under-rightᵢ
+    ; resultType = pF×
+    ; sourceCatchup = left↠
+    ; targetTail = right↠
+    ; sourceStoreResult =
+        leftStoreⁱ-crossed-two-binds
+          {Aold = ★} {Anew = ⇑ᵗ Aobs}
+          {Bold = Bobs} {Bnew = ★}
+          {hAnew =
+            ⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {hAold = wf★} {hBnew = wf★}
+          {hBold =
+            ⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {pnew-old = ⊑-crossed-double-lift∀∀ᵢ pObs}
+          {pold-new = id★}
+          liftρ₁ liftρ₂
+    ; targetStoreResult =
+        rightStoreⁱ-crossed-two-binds
+          {Aold = ★} {Anew = ⇑ᵗ Aobs}
+          {Bold = Bobs} {Bnew = ★}
+          {hAnew =
+            ⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {hAold = wf★} {hBnew = wf★}
+          {hBold =
+            ⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {pnew-old = ⊑-crossed-double-lift∀∀ᵢ pObs}
+          {pold-new = id★}
+          liftρ₁ liftρ₂
+    ; relatedResults = result
+    }
+
+weak-one-step-reverse-direct-quotientᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B S D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  Value W →
+  RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s) →
+  Value W′ →
+  No•
+    ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+      ⟨ inst (`∀ E′) (`∀ u′) ⟩) →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ S) ⊑ᵖ
+      `∀ (`∀ D′) ⊣ Δᴿ) →
+  S ≈∀ renameᵗ swap01ᵗ D →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ →
+  Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d)
+      ∶ `∀ A ⊒ `∀ (`∀ S) →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u)
+      ∶ `∀ (`∀ S) ⊑ `∀ E →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′) →
+  WeakOneStepResult ρ₀
+    (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s)
+    (ν Bobs
+      (ν ★ ((Λ W′) ⟨ `∀ (gen B d′) ⟩) (`∀ u′))
+      s′)
+    F F′ keep
+weak-one-step-reverse-direct-quotientᵀ
+    {Aobs = Aobs} {Bobs = Bobs} {F = F} {F′ = F′}
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+    gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    with direct-reverse-swap-gen-inst-caseᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+      gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+weak-one-step-reverse-direct-quotientᵀ
+    {Aobs = Aobs} {Bobs = Bobs} {F = F} {F′ = F′}
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+    gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    | ρ₂ , pF× , liftρ₂ , right↠ , _ , left↠ , result =
+  record
+    { sourceChanges =
+        bind Aobs ∷ keep ∷ keep ∷ keep ∷
+        bind ★ ∷ keep ∷ keep ∷ []
+    ; targetTailChanges =
+        bind ★ ∷ keep ∷ keep ∷ bind (⇑ᵗ Bobs) ∷
+        keep ∷ keep ∷ []
+    ; sourceResult =
+        ((renameᵗᵐ (extᵗ suc) _ ⟨ _ ⟩) ⟨ _ ⟩)
+          ⟨ ⇑ᶜ _ ⟩
+    ; targetResult =
+        (((⇑ᵗᵐ _) ⟨ _ ⟩) ⟨ _ ⟩)
+          ⟨ renameᶜ (extᵗ suc) _ ⟩
+    ; resultCtx = swapRight∀∀ᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore =
+        crossedStoreⁱ
+          wf★
+          (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
+          wf★ id★ (⊑-crossed-double-lift∀∀ᵢ pObs) ρ₂
+    ; resultSourceType = ⇑ᵗ (⇑ᵗ F)
+    ; resultTargetType = renameᵗ (extᵗ suc) (⇑ᵗ F′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = renameᵗ-ext-suc-comm suc F′
+    ; transportType = ⊑-crossed-double-lift∀∀ᵢ
+    ; transportAllBody = ⊑-crossed-double-lift-under-∀ᵢ
+    ; transportRightBody = ⊑-crossed-double-lift-under-rightᵢ
+    ; resultType = pF×
+    ; sourceCatchup = right↠
+    ; targetTail = left↠
+    ; sourceStoreResult =
+        leftStoreⁱ-crossed-two-binds
+          {Aold = Aobs} {Anew = ★}
+          {Bold = ★} {Bnew = ⇑ᵗ Bobs}
+          {hAnew = wf★}
+          {hAold =
+            ⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {hBnew =
+            ⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {hBold = wf★} {pnew-old = id★}
+          {pold-new = ⊑-crossed-double-lift∀∀ᵢ pObs}
+          liftρ₁ liftρ₂
+    ; targetStoreResult =
+        rightStoreⁱ-crossed-two-binds
+          {Aold = Aobs} {Anew = ★}
+          {Bold = ★} {Bnew = ⇑ᵗ Bobs}
+          {hAnew = wf★}
+          {hAold =
+            ⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {hBnew =
+            ⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs)}
+          {hBold = wf★} {pnew-old = id★}
+          {pold-new = ⊑-crossed-double-lift∀∀ᵢ pObs}
+          liftρ₁ liftρ₂
+    ; relatedResults = result
+    }
+
+Λ-value-body :
+  ∀ {V} →
+  Value (Λ V) →
+  Value V
+Λ-value-body (Λ vV) = vV
+
+post-allocation-polymorphic-value-step :
+  ∀ {Δ : TyCtx} {Σ : Store} {L A} →
+  Value L →
+  Δ ∣ Σ ∣ [] ⊢ L ⦂ `∀ A →
+  ∃[ N ] ((⇑ᵗᵐ L) • —→[ keep ] N)
+post-allocation-polymorphic-value-step
+    {Δ = Δ} {Σ = Σ} {L = L} {A = A} vL L⊢
+    with canonical-∀ {Δ = Δ} {Σ = Σ} {V = L} {A = A}
+      vL (forget L⊢)
+post-allocation-polymorphic-value-step {L = .(Λ V)} vL L⊢
+    | av-Λ {W = V} refl =
+  V , post-allocation-β-Λ•-bare (Λ-value-body vL)
+post-allocation-polymorphic-value-step
+    {L = .(V ⟨ `∀ c ⟩)} vL L⊢ | av-∀ {W = V} {c = c} vV refl =
+  ((⇑ᵗᵐ V) •) ⟨ c ⟩ , post-allocation-β-∀•-bare vV
+post-allocation-polymorphic-value-step
+    {L = .(V ⟨ gen A c ⟩)} vL L⊢
+    | av-gen {W = V} {A = A} {c = c} vV refl =
+  (⇑ᵗᵐ V) ⟨ c ⟩ , post-allocation-β-gen•-bare vV
+
+matched-polymorphic-value-shapeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ A A′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L →
+  Value L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ `∀ A ⊑ `∀ A′ ∶ p →
+  AllView L × AllView L′
+matched-polymorphic-value-shapeᵀ vL vL′ L⊑L′ =
+  canonical-∀ vL
+    (forget (nu-term-imprecision-source-typing L⊑L′)) ,
+  canonical-∀ vL′
+    (forget (nu-term-imprecision-target-typing L⊑L′))
+
+left-polymorphic-value-shapeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L N′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ N′ ⦂ `∀ A ⊑ B ∶ p →
+  AllView L
+left-polymorphic-value-shapeᵀ vL L⊑N′ =
+  canonical-∀ vL
+    (forget (nu-term-imprecision-source-typing L⊑N′))
+
+right-polymorphic-value-shapeᵀ :
+  ∀ {Φ Δᴸ Δᴿ N L′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ L′ ⦂ A ⊑ `∀ B ∶ p →
+  AllView L′
+right-polymorphic-value-shapeᵀ vL′ N⊑L′ =
+  canonical-∀ vL′
+    (forget (nu-term-imprecision-target-typing N⊑L′))
+
+matched-polymorphic-value-stepsᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ A A′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L →
+  Value L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ `∀ A ⊑ `∀ A′ ∶ p →
+  ∃[ N ] ∃[ N′ ]
+    (((⇑ᵗᵐ L) • —→[ keep ] N) ×
+     ((⇑ᵗᵐ L′) • —→[ keep ] N′))
+matched-polymorphic-value-stepsᵀ vL vL′ L⊑L′
+    with post-allocation-polymorphic-value-step vL
+      (nu-term-imprecision-source-typing L⊑L′)
+       | post-allocation-polymorphic-value-step vL′
+      (nu-term-imprecision-target-typing L⊑L′)
+matched-polymorphic-value-stepsᵀ vL vL′ L⊑L′
+    | N , L→N | N′ , L′→N′ =
+  N , N′ , L→N , L′→N′
+
+left-polymorphic-value-stepᵀ :
+  ∀ {Φ Δᴸ Δᴿ L N′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ N′ ⦂ `∀ A ⊑ B ∶ p →
+  ∃[ N ] ((⇑ᵗᵐ L) • —→[ keep ] N)
+left-polymorphic-value-stepᵀ vL L⊑N′ =
+  post-allocation-polymorphic-value-step vL
+    (nu-term-imprecision-source-typing L⊑N′)
+
+right-polymorphic-value-stepᵀ :
+  ∀ {Φ Δᴸ Δᴿ N L′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ L′ ⦂ A ⊑ `∀ B ∶ p →
+  ∃[ N′ ] ((⇑ᵗᵐ L′) • —→[ keep ] N′)
+right-polymorphic-value-stepᵀ vL′ N⊑L′ =
+  post-allocation-polymorphic-value-step vL′
+    (nu-term-imprecision-target-typing N⊑L′)
+
+matched-post-allocation-β-∀-conversionᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aν Aν′ A A′ B B′ V V′ c c′ p q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  (pν : ∀ᵢᶜ Φ
+    ∣ suc Δᴸ ⊢ ⇑ᵗ Aν ⊑ ⇑ᵗ Aν′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ A′ ∶ ∀ⁱ p →
+  PairedConversion Φ Δᴸ Δᴿ ρ
+    (`∀ c) (`∀ c′) {`∀ A} {`∀ A′} {`∀ B} {`∀ B′}
+    (∀ⁱ p) (∀ⁱ q) →
+  ((⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •
+    —→[ keep ] ((⇑ᵗᵐ V) •) ⟨ c ⟩) ×
+  ((⇑ᵗᵐ (V′ ⟨ `∀ c′ ⟩)) •
+    —→[ keep ] ((⇑ᵗᵐ V′) •) ⟨ c′ ⟩) ×
+  (∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero (⇑ᵗ Aν) zero (⇑ᵗ Aν′) pν ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ V) •) ⟨ c ⟩ ⊑ ((⇑ᵗᵐ V′) •) ⟨ c′ ⟩
+    ⦂ B ⊑ B′ ∶ q)
+matched-post-allocation-β-∀-conversionᵀ {p = p} vV noV vV′ noV′
+    pν liftρ V⊑V′ conversion =
+  post-allocation-β-∀•-bare vV ,
+  post-allocation-β-∀•-bare vV′ ,
+  conv⊑convᵀ
+    (paired-conversion
+      (open-allocated-paired-all-conversion liftρ conversion))
+    (α⊑αᵀ vV noV vV′ noV′ pν liftρ lift-ctx-[] V⊑V′
+      left-bullet-typing right-bullet-typing)
+  where
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-src-wf p) vV noV
+          (nu-term-imprecision-source-typing V⊑V′))
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-tgt-wf p) vV′ noV′
+          (nu-term-imprecision-target-typing V⊑V′))
+
+post-β-∀-reveal :
+  ∀ {μ Δ Σ C c A B V} →
+  Value V →
+  RevealConversion μ (suc Δ) Σ zero C
+    (`∀ c) (`∀ A) (`∀ B) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ] (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   RevealConversion μ (suc Δ) Σ zero C
+     (c [ zero ]ᶜ) (A [ zero ]ᴿ) (B [ zero ]ᴿ))
+post-β-∀-reveal vV (reveal-all c↑) =
+  pure-step (β-∀• vV) ,
+  open-reveal-conversion z<s c↑
+
+post-β-∀-conceal :
+  ∀ {μ Δ Σ C c A B V} →
+  Value V →
+  ConcealConversion μ (suc Δ) Σ zero C
+    (`∀ c) (`∀ A) (`∀ B) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ] (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   ConcealConversion μ (suc Δ) Σ zero C
+     (c [ zero ]ᶜ) (A [ zero ]ᴿ) (B [ zero ]ᴿ))
+post-β-∀-conceal vV (conceal-all c↓) =
+  pure-step (β-∀• vV) ,
+  open-conceal-conversion z<s c↓
+
+paired-β-∀-reveal :
+  ∀ {Φ Δᴸ Δᴿ X X′ pX μ μ′ c c′ A A′ B B′ V V′}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  (zero⊑zero : (zero ˣ⊑ˣ zero) ∈ Φ) →
+  store-matched zero X zero X′ pX ∈ ρ →
+  Value V →
+  Value V′ →
+  RevealConversion μ (suc Δᴸ) (leftStoreⁱ ρ) zero X
+    (`∀ c) (`∀ A) (`∀ B) →
+  RevealConversion μ′ (suc Δᴿ) (rightStoreⁱ ρ) zero X′
+    (`∀ c′) (`∀ A′) (`∀ B′) →
+  (p : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ A ⊑ A′ ⊣ suc (suc Δᴿ)) →
+  (q : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ B ⊑ B′ ⊣ suc (suc Δᴿ)) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ] (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   PairedConversion Φ (suc Δᴸ) (suc Δᴿ) ρ
+     (c [ zero ]ᶜ) (c′ [ zero ]ᶜ)
+     (⊑-open∀ᵢ {α = zero} {β = zero} zero⊑zero z<s z<s p)
+     (⊑-open∀ᵢ {α = zero} {β = zero} zero⊑zero z<s z<s q))
+paired-β-∀-reveal zero⊑zero zero-entry vV vV′
+    (reveal-all c↑) (reveal-all c′↑) p q =
+  pure-step (β-∀• vV) ,
+  pure-step (β-∀• vV′) ,
+  paired-reveal (correspondence-stored zero-entry)
+    (open-reveal-conversion z<s c↑)
+    (open-reveal-conversion z<s c′↑)
+
+paired-β-∀-conceal :
+  ∀ {Φ Δᴸ Δᴿ X X′ pX μ μ′ c c′ A A′ B B′ V V′}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  (zero⊑zero : (zero ˣ⊑ˣ zero) ∈ Φ) →
+  store-matched zero X zero X′ pX ∈ ρ →
+  Value V →
+  Value V′ →
+  ConcealConversion μ (suc Δᴸ) (leftStoreⁱ ρ) zero X
+    (`∀ c) (`∀ A) (`∀ B) →
+  ConcealConversion μ′ (suc Δᴿ) (rightStoreⁱ ρ) zero X′
+    (`∀ c′) (`∀ A′) (`∀ B′) →
+  (p : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ A ⊑ A′ ⊣ suc (suc Δᴿ)) →
+  (q : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ B ⊑ B′ ⊣ suc (suc Δᴿ)) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ] (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   PairedConversion Φ (suc Δᴸ) (suc Δᴿ) ρ
+     (c [ zero ]ᶜ) (c′ [ zero ]ᶜ)
+     (⊑-open∀ᵢ {α = zero} {β = zero} zero⊑zero z<s z<s p)
+     (⊑-open∀ᵢ {α = zero} {β = zero} zero⊑zero z<s z<s q))
+paired-β-∀-conceal zero⊑zero zero-entry vV vV′
+    (conceal-all c↓) (conceal-all c′↓) p q =
+  pure-step (β-∀• vV) ,
+  pure-step (β-∀• vV′) ,
+  paired-conceal (correspondence-stored zero-entry)
+    (open-conceal-conversion z<s c↓)
+    (open-conceal-conversion z<s c′↓)
+
+paired-β-∀-revealᵀ :
+  ∀ {Φ Δᴸ Δᴿ X X′ pX μ μ′ c c′ A A′ B B′ V V′}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)}
+    {γ : CtxImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  (zero⊑zero : (zero ˣ⊑ˣ zero) ∈ Φ) →
+  store-matched zero X zero X′ pX ∈ ρ →
+  Value V →
+  Value V′ →
+  RevealConversion μ (suc Δᴸ) (leftStoreⁱ ρ) zero X
+    (`∀ c) (`∀ A) (`∀ B) →
+  RevealConversion μ′ (suc Δᴿ) (rightStoreⁱ ρ) zero X′
+    (`∀ c′) (`∀ A′) (`∀ B′) →
+  (p : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ A ⊑ A′ ⊣ suc (suc Δᴿ)) →
+  (q : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ B ⊑ B′ ⊣ suc (suc Δᴿ)) →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ
+    ∶ ⊑-open∀ᵢ {α = zero} {β = zero} zero⊑zero z<s z<s p →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ]
+      (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   (Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ (V •) ⟨ (c [ zero ]ᶜ) ⟩
+        ⊑ (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩
+      ⦂ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ
+      ∶ ⊑-open∀ᵢ {α = zero} {β = zero}
+          zero⊑zero z<s z<s q))
+paired-β-∀-revealᵀ zero⊑zero zero-entry vV vV′
+    (reveal-all c↑) (reveal-all c′↑) p q V•⊑V′• =
+  pure-step (β-∀• vV) ,
+  pure-step (β-∀• vV′) ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal (correspondence-stored zero-entry)
+        (open-reveal-conversion z<s c↑)
+        (open-reveal-conversion z<s c′↑)))
+    V•⊑V′•
+
+paired-β-∀-concealᵀ :
+  ∀ {Φ Δᴸ Δᴿ X X′ pX μ μ′ c c′ A A′ B B′ V V′}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)}
+    {γ : CtxImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  (zero⊑zero : (zero ˣ⊑ˣ zero) ∈ Φ) →
+  store-matched zero X zero X′ pX ∈ ρ →
+  Value V →
+  Value V′ →
+  ConcealConversion μ (suc Δᴸ) (leftStoreⁱ ρ) zero X
+    (`∀ c) (`∀ A) (`∀ B) →
+  ConcealConversion μ′ (suc Δᴿ) (rightStoreⁱ ρ) zero X′
+    (`∀ c′) (`∀ A′) (`∀ B′) →
+  (p : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ A ⊑ A′ ⊣ suc (suc Δᴿ)) →
+  (q : ∀ᵢᶜ Φ ∣ suc (suc Δᴸ) ⊢ B ⊑ B′ ⊣ suc (suc Δᴿ)) →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ
+    ∶ ⊑-open∀ᵢ {α = zero} {β = zero} zero⊑zero z<s z<s p →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ]
+      (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   (Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ (V •) ⟨ (c [ zero ]ᶜ) ⟩
+        ⊑ (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩
+      ⦂ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ
+      ∶ ⊑-open∀ᵢ {α = zero} {β = zero}
+          zero⊑zero z<s z<s q))
+paired-β-∀-concealᵀ zero⊑zero zero-entry vV vV′
+    (conceal-all c↓) (conceal-all c′↓) p q V•⊑V′• =
+  pure-step (β-∀• vV) ,
+  pure-step (β-∀• vV′) ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-conceal (correspondence-stored zero-entry)
+        (open-conceal-conversion z<s c↓)
+        (open-conceal-conversion z<s c′↓)))
+    V•⊑V′•
+
+left-β-∀-revealᵀ :
+  ∀ {Φ Δᴸ Δᴿ X μ c A B B′ V N′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ (suc Δᴸ) Δᴿ} →
+  Value V →
+  RevealConversion μ (suc Δᴸ) (leftStoreⁱ ρ) zero X
+    (`∀ c) (`∀ A) (`∀ B) →
+  Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ V • ⊑ N′ ⦂ A [ zero ]ᴿ ⊑ B′ ∶ p →
+  (q : Φ ∣ suc Δᴸ ⊢ B [ zero ]ᴿ ⊑ B′ ⊣ Δᴿ) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ]
+      (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   (N′ —↠[ [] ] N′) ×
+   (Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ (V •) ⟨ (c [ zero ]ᶜ) ⟩ ⊑ N′
+      ⦂ B [ zero ]ᴿ ⊑ B′ ∶ q))
+left-β-∀-revealᵀ vV (reveal-all c↑) V•⊑N′ q =
+  pure-step (β-∀• vV) ,
+  ↠-refl ,
+  conv↑⊑ᵀ (open-reveal-conversion z<s c↑) V•⊑N′ q
+
+left-β-∀-concealᵀ :
+  ∀ {Φ Δᴸ Δᴿ X μ c A B B′ V N′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ (suc Δᴸ) Δᴿ} →
+  Value V →
+  ConcealConversion μ (suc Δᴸ) (leftStoreⁱ ρ) zero X
+    (`∀ c) (`∀ A) (`∀ B) →
+  Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ V • ⊑ N′ ⦂ A [ zero ]ᴿ ⊑ B′ ∶ p →
+  (q : Φ ∣ suc Δᴸ ⊢ B [ zero ]ᴿ ⊑ B′ ⊣ Δᴿ) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ]
+      (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   (N′ —↠[ [] ] N′) ×
+   (Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ (V •) ⟨ (c [ zero ]ᶜ) ⟩ ⊑ N′
+      ⦂ B [ zero ]ᴿ ⊑ B′ ∶ q))
+left-β-∀-concealᵀ vV (conceal-all c↓) V•⊑N′ q =
+  pure-step (β-∀• vV) ,
+  ↠-refl ,
+  conv↓⊑ᵀ (open-conceal-conversion z<s c↓) V•⊑N′ q
+
+right-β-∀-revealᵀ :
+  ∀ {Φ Δᴸ Δᴿ X′ μ′ c′ A A′ B′ N V′ p}
+    {ρ : StoreImp Φ Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ (suc Δᴿ)} →
+  Value V′ →
+  RevealConversion μ′ (suc Δᴿ) (rightStoreⁱ ρ) zero X′
+    (`∀ c′) (`∀ A′) (`∀ B′) →
+  Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ N ⊑ V′ • ⦂ A ⊑ A′ [ zero ]ᴿ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  ((N —↠[ [] ] N) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   (Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ N ⊑ (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩
+      ⦂ A ⊑ B′ [ zero ]ᴿ ∶ q))
+right-β-∀-revealᵀ vV′ (reveal-all c′↑) N⊑V′• q =
+  ↠-refl ,
+  pure-step (β-∀• vV′) ,
+  ⊑conv↑ᵀ (open-reveal-conversion z<s c′↑) N⊑V′• q
+
+right-β-∀-concealᵀ :
+  ∀ {Φ Δᴸ Δᴿ X′ μ′ c′ A A′ B′ N V′ p}
+    {ρ : StoreImp Φ Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ (suc Δᴿ)} →
+  Value V′ →
+  ConcealConversion μ′ (suc Δᴿ) (rightStoreⁱ ρ) zero X′
+    (`∀ c′) (`∀ A′) (`∀ B′) →
+  Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ N ⊑ V′ • ⦂ A ⊑ A′ [ zero ]ᴿ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  ((N —↠[ [] ] N) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   (Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ N ⊑ (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩
+      ⦂ A ⊑ B′ [ zero ]ᴿ ∶ q))
+right-β-∀-concealᵀ vV′ (conceal-all c′↓) N⊑V′• q =
+  ↠-refl ,
+  pure-step (β-∀• vV′) ,
+  ⊑conv↓ᵀ (open-conceal-conversion z<s c′↓) N⊑V′• q
+
+------------------------------------------------------------------------
+-- Generic narrowing and widening `β-∀•`
+------------------------------------------------------------------------
+
+left-β-∀-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ c A B B′ V N′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ (suc Δᴸ) Δᴿ} →
+  Value V →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c∀⊒ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ B) →
+  Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ V • ⊑ N′ ⦂ A [ zero ]ᴿ ⊑ B′ ∶ p →
+  (q : Φ ∣ suc Δᴸ ⊢ B [ zero ]ᴿ ⊑ B′ ⊣ Δᴿ) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ]
+      (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   (N′ —↠[ [] ] N′) ×
+   (Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ (V •) ⟨ (c [ zero ]ᶜ) ⟩ ⊑ N′
+      ⦂ B [ zero ]ᴿ ⊑ B′ ∶ q))
+left-β-∀-narrowingᵀ vV mode seal★ c∀⊒ V•⊑N′ q =
+  pure-step (β-∀• vV) ,
+  ↠-refl ,
+  cast⊒⊑ᵀ mode seal★
+    (open-all-narrowing z<s c∀⊒) V•⊑N′ q
+
+left-β-∀-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ c A B B′ V N′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ (suc Δᴸ) Δᴿ} →
+  Value V →
+  CastMode μ →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (c∀⊑ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ B) →
+  Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ V • ⊑ N′ ⦂ A [ zero ]ᴿ ⊑ B′ ∶ p →
+  (q : Φ ∣ suc Δᴸ ⊢ B [ zero ]ᴿ ⊑ B′ ⊣ Δᴿ) →
+  (((V ⟨ `∀ c ⟩) • —→[ keep ]
+      (V •) ⟨ (c [ zero ]ᶜ) ⟩) ×
+   (N′ —↠[ [] ] N′) ×
+   (Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ (V •) ⟨ (c [ zero ]ᶜ) ⟩ ⊑ N′
+      ⦂ B [ zero ]ᴿ ⊑ B′ ∶ q))
+left-β-∀-wideningᵀ vV mode seal★ c∀⊑ V•⊑N′ q =
+  pure-step (β-∀• vV) ,
+  ↠-refl ,
+  cast⊑⊑ᵀ mode seal★
+    (open-all-widening z<s c∀⊑) V•⊑N′ q
+
+right-β-∀-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ′ c′ A A′ B′ N V′ p}
+    {ρ : StoreImp Φ Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ (suc Δᴿ)} →
+  Value V′ →
+  CastMode μ′ →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (c∀⊒ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊒ `∀ B′) →
+  Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ N ⊑ V′ • ⦂ A ⊑ A′ [ zero ]ᴿ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  ((N —↠[ [] ] N) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   (Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ N ⊑ (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩
+      ⦂ A ⊑ B′ [ zero ]ᴿ ∶ q))
+right-β-∀-narrowingᵀ vV′ mode′ seal★′ c∀⊒ N⊑V′• q =
+  ↠-refl ,
+  pure-step (β-∀• vV′) ,
+  ⊑cast⊒ᵀ mode′ seal★′
+    (open-all-narrowing z<s c∀⊒) N⊑V′• q
+
+right-β-∀-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ′ c′ A A′ B′ N V′ p}
+    {ρ : StoreImp Φ Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ (suc Δᴿ)} →
+  Value V′ →
+  CastMode μ′ →
+  (wfΣ′ : StoreDetWf (suc Δᴿ) (rightStoreⁱ ρ)) →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (okΦ′ : RightCastCtxCompatible μ′ (suc Δᴿ) Φ) →
+  (c∀⊑ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊑ `∀ B′) →
+  Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ N ⊑ V′ • ⦂ A ⊑ A′ [ zero ]ᴿ ∶ p →
+  ((N —↠[ [] ] N) ×
+   ((V′ ⟨ `∀ c′ ⟩) • —→[ keep ]
+      (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩) ×
+   (Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ N ⊑ (V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩
+      ⦂ A ⊑ B′ [ zero ]ᴿ
+      ∶ ⊑-transʳ-castᵢ okΦ′ p
+          (widening⇒⊑ᵢ wfΣ′ seal★′
+            (open-all-widening z<s c∀⊑))))
+right-β-∀-wideningᵀ {p = p} vV′ mode′ wfΣ′ seal★′ okΦ′
+    c∀⊑ N⊑V′• =
+  ↠-refl ,
+  pure-step (β-∀• vV′) ,
+  ⊑cast⊑ᵀ mode′ seal★′ (open-all-widening z<s c∀⊑) N⊑V′•
+    (⊑-transʳ-castᵢ okΦ′ p
+      (widening⇒⊑ᵢ wfΣ′ seal★′
+        (open-all-widening z<s c∀⊑)))
+
+-- Base recursion clauses for generic casts on the target of `β-∀•`.
+
+weak-one-step-right-β-∀-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ′ c′ A A′ B′ N V′ p}
+    {ρ : StoreImp Φ Δᴸ (suc Δᴿ)} →
+  Value V′ →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊒ `∀ B′ →
+  Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ • ⦂ A ⊑ A′ [ zero ]ᴿ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ N
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    A (B′ [ zero ]ᴿ) keep
+weak-one-step-right-β-∀-narrowingᵀ vV′ mode′ seal★′ c∀⊒
+    N⊑V′• q
+    with right-β-∀-narrowingᵀ
+      vV′ mode′ seal★′ c∀⊒ N⊑V′• q
+weak-one-step-right-β-∀-narrowingᵀ vV′ mode′ seal★′ c∀⊒
+    N⊑V′• q
+    | _ , _ , result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = q
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+weak-one-step-right-β-∀-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ′ c′ A A′ B′ N V′ p}
+    {ρ : StoreImp Φ Δᴸ (suc Δᴿ)} →
+  Value V′ →
+  CastMode μ′ →
+  (wfΣ′ : StoreDetWf (suc Δᴿ) (rightStoreⁱ ρ)) →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (okΦ′ : RightCastCtxCompatible μ′ (suc Δᴿ) Φ) →
+  (c∀⊑ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊑ `∀ B′) →
+  Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ • ⦂ A ⊑ A′ [ zero ]ᴿ ∶ p →
+  WeakOneStepResult ρ N
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    A (B′ [ zero ]ᴿ) keep
+weak-one-step-right-β-∀-wideningᵀ {p = p} vV′ mode′ wfΣ′
+    seal★′ okΦ′ c∀⊑ N⊑V′•
+    with right-β-∀-wideningᵀ vV′ mode′ wfΣ′ seal★′ okΦ′
+      c∀⊑ N⊑V′•
+weak-one-step-right-β-∀-wideningᵀ {p = p} vV′ mode′ wfΣ′
+    seal★′ okΦ′ c∀⊑ N⊑V′•
+    | _ , _ , result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType =
+        ⊑-transʳ-castᵢ okΦ′ p
+          (widening⇒⊑ᵢ wfΣ′ seal★′
+            (open-all-widening z<s c∀⊑))
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+weak-one-step-left-β-∀-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ c A B B′ V N′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) Δᴿ} →
+  Value V →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c∀⊒ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ B) →
+  Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ N′ ⦂ A [ zero ]ᴿ ⊑ B′ ∶ p →
+  (q : Φ ∣ suc Δᴸ ⊢ B [ zero ]ᴿ ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •) N′
+    (B [ zero ]ᴿ) B′ keep
+weak-one-step-left-β-∀-narrowingᵀ vV mode seal★ c∀⊒
+    V•⊑N′ q
+    with left-β-∀-narrowingᵀ vV mode seal★ c∀⊒ V•⊑N′ q
+weak-one-step-left-β-∀-narrowingᵀ vV mode seal★ c∀⊒
+    V•⊑N′ q
+    | source→ , _ , result =
+  record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = q
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+weak-one-step-left-β-∀-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ c A B B′ V N′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) Δᴿ} →
+  Value V →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  Φ ∣ suc Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ N′ ⦂ A [ zero ]ᴿ ⊑ B′ ∶ p →
+  (q : Φ ∣ suc Δᴸ ⊢ B [ zero ]ᴿ ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •) N′
+    (B [ zero ]ᴿ) B′ keep
+weak-one-step-left-β-∀-wideningᵀ vV mode seal★ c∀⊑
+    V•⊑N′ q
+    with left-β-∀-wideningᵀ vV mode seal★ c∀⊑ V•⊑N′ q
+weak-one-step-left-β-∀-wideningᵀ vV mode seal★ c∀⊑
+    V•⊑N′ q
+    | source→ , _ , result =
+  record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = q
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+-- Overlapping two-sided generic-cast derivations, with the left cast outer.
+
+weak-one-step-generic-β-∀-left-outer-narrowing-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c∀⊒ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ B) →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊒ `∀ B′ →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  (qR : Φ ∣ suc Δᴸ
+    ⊢ A [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  (q : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-left-outer-narrowing-narrowingᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ seal★′ c′∀⊒
+    V•⊑V′• qR q
+    with right-β-∀-narrowingᵀ
+      vV′ mode′ seal★′ c′∀⊒ V•⊑V′• qR
+weak-one-step-generic-β-∀-left-outer-narrowing-narrowingᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ seal★′ c′∀⊒
+    V•⊑V′• qR q
+    | _ , _ , V•⊑V′•c′ =
+  weak-one-step-left-β-∀-narrowingᵀ
+    vV mode seal★ c∀⊒ V•⊑V′•c′ q
+
+weak-one-step-generic-β-∀-left-outer-narrowing-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c∀⊒ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ B) →
+  CastMode μ′ →
+  (wfΣ′ : StoreDetWf (suc Δᴿ) (rightStoreⁱ ρ)) →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (okΦ′ : RightCastCtxCompatible μ′ (suc Δᴿ) Φ) →
+  (c′∀⊑ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊑ `∀ B′) →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  (q : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-left-outer-narrowing-wideningᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ wfΣ′ seal★′
+    okΦ′ c′∀⊑ V•⊑V′• q
+    with right-β-∀-wideningᵀ
+      vV′ mode′ wfΣ′ seal★′ okΦ′ c′∀⊑ V•⊑V′•
+weak-one-step-generic-β-∀-left-outer-narrowing-wideningᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ wfΣ′ seal★′
+    okΦ′ c′∀⊑ V•⊑V′• q
+    | _ , _ , V•⊑V′•c′ =
+  weak-one-step-left-β-∀-narrowingᵀ
+    vV mode seal★ c∀⊒ V•⊑V′•c′ q
+
+weak-one-step-generic-β-∀-left-outer-widening-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊒ `∀ B′ →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  Φ ∣ suc Δᴸ
+    ⊢ A [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ →
+  (q : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-left-outer-widening-narrowingᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ seal★′ c′∀⊒
+    V•⊑V′• qR q
+    with right-β-∀-narrowingᵀ
+      vV′ mode′ seal★′ c′∀⊒ V•⊑V′• qR
+weak-one-step-generic-β-∀-left-outer-widening-narrowingᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ seal★′ c′∀⊒
+    V•⊑V′• qR q
+    | _ , _ , V•⊑V′•c′ =
+  weak-one-step-left-β-∀-wideningᵀ
+    vV mode seal★ c∀⊑ V•⊑V′•c′ q
+
+weak-one-step-generic-β-∀-left-outer-widening-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  CastMode μ′ →
+  (wfΣ′ : StoreDetWf (suc Δᴿ) (rightStoreⁱ ρ)) →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (okΦ′ : RightCastCtxCompatible μ′ (suc Δᴿ) Φ) →
+  (c′∀⊑ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊑ `∀ B′) →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  (q : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-left-outer-widening-wideningᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ wfΣ′ seal★′ okΦ′
+    c′∀⊑ V•⊑V′• q
+    with right-β-∀-wideningᵀ
+      vV′ mode′ wfΣ′ seal★′ okΦ′ c′∀⊑ V•⊑V′•
+weak-one-step-generic-β-∀-left-outer-widening-wideningᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ wfΣ′ seal★′ okΦ′
+    c′∀⊑ V•⊑V′• q
+    | _ , _ , V•⊑V′•c′ =
+  weak-one-step-left-β-∀-wideningᵀ
+    vV mode seal★ c∀⊑ V•⊑V′•c′ q
+
+weak-one-step-keep-source-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —→[ keep ] N →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+  WeakOneStepResult ρ M N′ A B keep
+weak-one-step-keep-source-catchupᵀ source→ result =
+  record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = _
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+left-catchup-all-keep-stepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —→[ keep ] N →
+  (Value N × No• N) ⊎ N ≡ blame →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = M} {V′ = V′} {ρ = ρ} q
+left-catchup-all-keep-stepᵀ source→ final N⊑V′ =
+  let result = weak-one-step-keep-source-catchupᵀ source→ N⊑V′ in
+  left-all-catchup (weak-all-result result N⊑V′)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+left-catchup-all-prepend-keepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —→[ keep ] N →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q →
+  LeftCatchupAllResult {N = M} {V′ = V′} {ρ = ρ} q
+left-catchup-all-prepend-keepᵀ source→ N⊑V′
+    (left-all-catchup second
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)) =
+  let
+    first = weak-one-step-keep-source-catchupᵀ source→ N⊑V′
+    combined = weak-one-step-prepend-left-silentᵀ
+      (left-silent first (left-silent-invariant refl refl))
+      (weakResult second)
+  in
+  left-all-catchup
+    (weak-all-result combined (canonicalAllResults second))
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+left-catchup-all-post-allocation-β-Λ•ᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  No• V →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (Λ V)) •} {V′ = V′} {ρ = ρ} q
+left-catchup-all-post-allocation-β-Λ•ᵀ vV noV V⊑V′ =
+  left-catchup-all-keep-stepᵀ
+    (post-allocation-β-Λ•-bare vV) (inj₁ (vV , noV)) V⊑V′
+
+left-catchup-all-α-Λᵀ :
+  ∀ {Φ Δᴸ Δᴿ A W V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  Value W →
+  No• W →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵃ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵇ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+    ⊢ᴺ W ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (Λ W)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ A) h⇑A ∷ ρᵃ} q
+left-catchup-all-α-Λᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {W = W} {V′ = V′}
+    {C = C} {C′ = C′} {q = q} {ρ = ρ} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ}
+    vW noW h⇑A liftρᵃ liftρᵇ W⊑V′ =
+  left-all-catchup
+    (weak-all-result result allocated-body)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₁ (vW , noW)))
+  where
+    allocated-body =
+      allocation-leftᵀ h⇑A liftρᵇ W⊑V′
+        (term-weaken {Δ = suc _} {Δ′ = suc _}
+          {Σ = leftStoreⁱ ρᵇ}
+          {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
+          {Γ = []} ≤-refl StoreIncl-drop noW
+          (nu-term-imprecision-source-typing W⊑V′))
+        (nu-term-imprecision-target-typing W⊑V′)
+
+    result =
+      record
+        { sourceChanges = keep ∷ []
+        ; targetTailChanges = []
+        ; sourceResult = W
+        ; targetResult = V′
+        ; resultCtx = (zero ˣ⊑★) ∷ ⇑ᴸᵢ _
+        ; resultLeftCtx = _
+        ; resultRightCtx = _
+        ; sourceCtxResult = refl
+        ; targetCtxResult = refl
+        ; resultStore = store-left zero (⇑ᵗ A) h⇑A ∷ ρᵇ
+        ; resultSourceType = `∀ _
+        ; resultTargetType = `∀ _
+        ; sourceTypeResult = refl
+        ; targetTypeResult = refl
+        ; transportType = λ p → p
+        ; transportAllBody = λ p → p
+        ; transportRightBody = λ p → p
+        ; resultType = ∀ⁱ q
+        ; sourceCatchup =
+            ↠-step (post-allocation-β-Λ•-bare vW) ↠-refl
+        ; targetTail = ↠-refl
+        ; sourceStoreResult =
+            cong ((zero , ⇑ᵗ A) ∷_)
+              (trans (leftStoreⁱ-lift-left liftρᵇ)
+                (sym (leftStoreⁱ-lift-left liftρᵃ)))
+        ; targetStoreResult =
+            trans (rightStoreⁱ-lift-left liftρᵇ)
+              (sym (rightStoreⁱ-lift-left liftρᵃ))
+        ; relatedResults = allocated-body
+        }
+
+left-allocated-bulletᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aν A B′ V V′ occ r}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ B′ ∶ ν occ r →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero (⇑ᵗ Aν) hAν ∷ ρ′ ∣ []
+    ⊢ᴺ (⇑ᵗᵐ V) • ⊑ V′ ⦂ A ⊑ B′ ∶ r
+left-allocated-bulletᵀ
+    {Aν = Aν} {V = V} {V′ = V′} {r = r}
+    vV noV hAν liftρ V⊑V′ =
+  α⊑ᵀ vV noV hAν liftρ lift-left-ctx-[] V⊑V′
+    left-bullet-typing right-typing
+  where
+    left-bullet-typing =
+      subst
+        (λ Σ → _ ∣ (zero , ⇑ᵗ Aν) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ V) • ⦂ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (⊢• refl refl (⊑-src-wf r) vV noV
+          (nu-term-imprecision-source-typing V⊑V′))
+
+    right-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ V′ ⦂ _)
+        (sym (rightStoreⁱ-lift-left liftρ))
+        (nu-term-imprecision-target-typing V⊑V′)
+
+left-catchup-all-α-∀-revealᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ α X Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    (`∀ c) (`∀ A) (`∀ (`∀ C)) →
+  (catchup : LeftCatchupAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q) →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-all-α-∀-revealᵀ
+    {Aν = Aν} {V = V} {V′ = V′} {r = r} {q = q} {ρ′ = ρ′}
+    vV noV hAν liftρ V⊑V′ c↑ catchup =
+  left-catchup-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+    bullet-relation =
+      left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+    post-relation =
+      conv↑⊑ᵀ (open-allocated-left-all-reveal liftρ c↑)
+        bullet-relation (∀ⁱ q)
+
+left-catchup-all-α-∀-concealᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ α X Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    (`∀ c) (`∀ A) (`∀ (`∀ C)) →
+  (catchup : LeftCatchupAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q) →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-all-α-∀-concealᵀ
+    {Aν = Aν} {V = V} {V′ = V′} {q = q} {ρ′ = ρ′}
+    vV noV hAν liftρ V⊑V′ c↓ catchup =
+  left-catchup-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+    bullet-relation =
+      left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+    post-relation =
+      conv↓⊑ᵀ (open-allocated-left-all-conceal liftρ c↓)
+        bullet-relation (∀ⁱ q)
+
+left-catchup-all-α-∀-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ (`∀ C) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  (catchup : LeftCatchupAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q) →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-all-α-∀-narrowingᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {μ = μ} {Aν = Aν} {A = A} {C = C}
+    {c = c} {V = V} {V′ = V′} {q = q} {ρ = ρ} {ρ′ = ρ′}
+    vV noV hAν mode seal★ liftρ c∀⊒ V⊑V′ catchup =
+  left-catchup-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+    bullet-relation =
+      left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+    body-narrowing :
+      extᵈ μ ∣ suc Δᴸ ∣
+        (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρ′
+        ⊢ c ∶ A ⊒ `∀ C
+    body-narrowing =
+      subst
+        (λ Σ → extᵈ μ ∣ suc Δᴸ ∣ Σ
+          ⊢ c ∶ A ⊒ `∀ C)
+        (cong ((zero , ⇑ᵗ Aν) ∷_)
+          (sym (leftStoreⁱ-lift-left liftρ)))
+        (allocate-all-narrowing c∀⊒)
+
+    post-relation =
+      cast⊒⊑ᵀ (cast-ext mode)
+        (allocated-left-seal★ liftρ seal★)
+        body-narrowing bullet-relation (∀ⁱ q)
+
+left-catchup-all-α-∀-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ (`∀ C) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  (catchup : LeftCatchupAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q) →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-all-α-∀-wideningᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {μ = μ} {Aν = Aν} {A = A} {C = C}
+    {c = c} {V = V} {V′ = V′} {q = q} {ρ = ρ} {ρ′ = ρ′}
+    vV noV hAν mode seal★ liftρ c∀⊑ V⊑V′ catchup =
+  left-catchup-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+    bullet-relation =
+      left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+    body-widening :
+      extᵈ μ ∣ suc Δᴸ ∣
+        (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρ′
+        ⊢ c ∶ A ⊑ `∀ C
+    body-widening =
+      subst
+        (λ Σ → extᵈ μ ∣ suc Δᴸ ∣ Σ
+          ⊢ c ∶ A ⊑ `∀ C)
+        (cong ((zero , ⇑ᵗ Aν) ∷_)
+          (sym (leftStoreⁱ-lift-left liftρ)))
+        (allocate-all-widening c∀⊑)
+
+    post-relation =
+      cast⊑⊑ᵀ (cast-ext mode)
+        (allocated-left-seal★ liftρ seal★)
+        body-widening bullet-relation (∀ⁱ q)
+
+left-catchup-all-α-gen-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ p q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ gen A c ∶ A ⊒ `∀ (`∀ C) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ V ⊑ V′ ⦂ ⇑ᵗ A ⊑ `∀ C′ ∶ p →
+  (catchup : LeftCatchupAllResult
+    {N = (⇑ᵗᵐ V) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q) →
+  LeftCatchupAllResult
+    {N = (⇑ᵗᵐ (V ⟨ gen A c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-all-α-gen-narrowingᵀ
+    {Δᴸ = Δᴸ} {μ = μ} {Aν = Aν} {A = A} {C = C}
+    {c = c} {q = q} {ρ′ = ρ′}
+    vV noV hAν mode seal★ liftρ cgen⊒ shifted-body catchup =
+  left-catchup-all-prepend-keepᵀ
+    (post-allocation-β-gen•-bare vV) post-relation catchup
+  where
+    body-narrowing :
+      genᵈ μ ∣ suc Δᴸ ∣
+        (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρ′
+        ⊢ c ∶ ⇑ᵗ A ⊒ `∀ C
+    body-narrowing =
+      subst
+        (λ Σ → genᵈ μ ∣ suc Δᴸ ∣ Σ
+          ⊢ c ∶ ⇑ᵗ A ⊒ `∀ C)
+        (cong ((zero , ⇑ᵗ Aν) ∷_)
+          (sym (leftStoreⁱ-lift-left liftρ)))
+        (allocate-gen-narrowing cgen⊒)
+
+    body-relation =
+      allocated-left-relationᵀ hAν liftρ
+        (renameᵗᵐ-preserves-No• suc noV) shifted-body
+
+    post-relation =
+      cast⊒⊑ᵀ (cast-gen mode)
+        (allocated-left-gen-seal★ liftρ seal★)
+        body-narrowing body-relation (∀ⁱ q)
+
+shifted-var-not-wf-at-zero :
+  WfTy zero (＇ (suc zero)) → ⊥
+shifted-var-not-wf-at-zero (wfVar ())
+
+fresh-shifted-var-store-not-det :
+  StoreDetWf (suc (suc zero))
+    ((zero , ＇ (suc zero)) ∷ []) → ⊥
+fresh-shifted-var-store-not-det wfΣ =
+  shifted-var-not-wf-at-zero
+    (StoreDetWf.wfOlder wfΣ (here refl))
+
+-- The same generic overlap with the right cast outermost.
+
+weak-one-step-generic-β-∀-right-outer-narrowing-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c∀⊒ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ B) →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊒ `∀ B′ →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  (qL : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  (q : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-right-outer-narrowing-narrowingᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ seal★′ c′∀⊒
+    V•⊑V′• qL q
+    with left-β-∀-narrowingᵀ
+      vV mode seal★ c∀⊒ V•⊑V′• qL
+weak-one-step-generic-β-∀-right-outer-narrowing-narrowingᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ seal★′ c′∀⊒
+    V•⊑V′• qL q
+    | source→ , _ , V•c⊑V′•
+    with right-β-∀-narrowingᵀ
+      vV′ mode′ seal★′ c′∀⊒ V•c⊑V′• q
+weak-one-step-generic-β-∀-right-outer-narrowing-narrowingᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ seal★′ c′∀⊒
+    V•⊑V′• qL q
+    | source→ , _ , V•c⊑V′•
+    | _ , _ , result =
+  weak-one-step-keep-source-catchupᵀ source→ result
+
+weak-one-step-generic-β-∀-right-outer-narrowing-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c∀⊒ : μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ B) →
+  CastMode μ′ →
+  (wfΣ′ : StoreDetWf (suc Δᴿ) (rightStoreⁱ ρ)) →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (okΦ′ : RightCastCtxCompatible μ′ (suc Δᴿ) Φ) →
+  (c′∀⊑ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊑ `∀ B′) →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  (qL : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-right-outer-narrowing-wideningᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ wfΣ′ seal★′
+    okΦ′ c′∀⊑ V•⊑V′• qL
+    with left-β-∀-narrowingᵀ
+      vV mode seal★ c∀⊒ V•⊑V′• qL
+weak-one-step-generic-β-∀-right-outer-narrowing-wideningᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ wfΣ′ seal★′
+    okΦ′ c′∀⊑ V•⊑V′• qL
+    | source→ , _ , V•c⊑V′•
+    with right-β-∀-wideningᵀ
+      vV′ mode′ wfΣ′ seal★′ okΦ′ c′∀⊑ V•c⊑V′•
+weak-one-step-generic-β-∀-right-outer-narrowing-wideningᵀ
+    vV vV′ mode seal★ c∀⊒ mode′ wfΣ′ seal★′
+    okΦ′ c′∀⊑ V•⊑V′• qL
+    | source→ , _ , V•c⊑V′•
+    | _ , _ , result =
+  weak-one-step-keep-source-catchupᵀ source→ result
+
+weak-one-step-generic-β-∀-right-outer-widening-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊒ `∀ B′ →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ⊣ suc Δᴿ →
+  (q : Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ B′ [ zero ]ᴿ ⊣ suc Δᴿ) →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-right-outer-widening-narrowingᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ seal★′ c′∀⊒
+    V•⊑V′• qL q
+    with left-β-∀-wideningᵀ
+      vV mode seal★ c∀⊑ V•⊑V′• qL
+weak-one-step-generic-β-∀-right-outer-widening-narrowingᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ seal★′ c′∀⊒
+    V•⊑V′• qL q
+    | source→ , _ , V•c⊑V′•
+    with right-β-∀-narrowingᵀ
+      vV′ mode′ seal★′ c′∀⊒ V•c⊑V′• q
+weak-one-step-generic-β-∀-right-outer-widening-narrowingᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ seal★′ c′∀⊒
+    V•⊑V′• qL q
+    | source→ , _ , V•c⊑V′•
+    | _ , _ , result =
+  weak-one-step-keep-source-catchupᵀ source→ result
+
+weak-one-step-generic-β-∀-right-outer-widening-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ μ′ c c′ A A′ B B′ V V′ p}
+    {ρ : StoreImp Φ (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ suc Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ B →
+  CastMode μ′ →
+  (wfΣ′ : StoreDetWf (suc Δᴿ) (rightStoreⁱ ρ)) →
+  (seal★′ : SealModeStore★ μ′ (rightStoreⁱ ρ)) →
+  (okΦ′ : RightCastCtxCompatible μ′ (suc Δᴿ) Φ) →
+  (c′∀⊑ : μ′ ∣ suc Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ `∀ c′ ∶ `∀ A′ ⊑ `∀ B′) →
+  Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V • ⊑ V′ •
+    ⦂ A [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ∶ p →
+  Φ ∣ suc Δᴸ
+    ⊢ B [ zero ]ᴿ ⊑ A′ [ zero ]ᴿ ⊣ suc Δᴿ →
+  WeakOneStepResult ρ
+    ((V ⟨ `∀ c ⟩) •)
+    ((V′ •) ⟨ (c′ [ zero ]ᶜ) ⟩)
+    (B [ zero ]ᴿ) (B′ [ zero ]ᴿ) keep
+weak-one-step-generic-β-∀-right-outer-widening-wideningᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ wfΣ′ seal★′ okΦ′
+    c′∀⊑ V•⊑V′• qL
+    with left-β-∀-wideningᵀ
+      vV mode seal★ c∀⊑ V•⊑V′• qL
+weak-one-step-generic-β-∀-right-outer-widening-wideningᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ wfΣ′ seal★′ okΦ′
+    c′∀⊑ V•⊑V′• qL
+    | source→ , _ , V•c⊑V′•
+    with right-β-∀-wideningᵀ
+      vV′ mode′ wfΣ′ seal★′ okΦ′ c′∀⊑ V•c⊑V′•
+weak-one-step-generic-β-∀-right-outer-widening-wideningᵀ
+    vV vV′ mode seal★ c∀⊑ mode′ wfΣ′ seal★′ okΦ′
+    c′∀⊑ V•⊑V′• qL
+    | source→ , _ , V•c⊑V′•
+    | _ , _ , result =
+  weak-one-step-keep-source-catchupᵀ source→ result
+
+------------------------------------------------------------------------
+-- Synchronized polymorphic allocation
+------------------------------------------------------------------------
+
+matched-ν↑-allocation :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  (ν A N s —→[ bind A ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (ν A′ N′ s′ —→[ bind A′ ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′) A⇑⊑A′⇑ ∷ ρ′
+    ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-ν↑-allocation {q = q} vN noN vN′ noN′ s↑ s′↑ pB
+    A⇑⊑A′⇑ liftρ N⊑N′ =
+  ν-step vN noN ,
+  ν-step vN′ noN′ ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal (correspondence-stored (here refl))
+        left-reveal right-reveal))
+    (α⊑αᵀ vN noN vN′ noN′ A⇑⊑A′⇑ liftρ lift-ctx-[]
+      N⊑N′ left-bullet-typing right-bullet-typing)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift liftρ))
+        s↑
+
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (rightStoreⁱ-lift liftρ))
+        s′↑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-tgt-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-matched-ν↑ᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ N′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑ᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    with matched-ν↑-allocation vN noN vN′ noN′ s↑ s′↑
+      pB A⇑⊑A′⇑ liftρ N⊑N′
+weak-one-step-matched-ν↑ᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    | source→ , _ , result =
+  record
+    { sourceChanges = bind A ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore =
+        store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′)
+          A⇑⊑A′⇑ ∷ ρ′
+    ; resultSourceType = ⇑ᵗ B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-lift∀ᵢ
+    ; transportAllBody = ⊑-lift-under-∀ᵢ
+    ; transportRightBody = ⊑-lift-under-rightᵢ
+    ; resultType = ⊑-lift∀ᵢ pB
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult =
+        cong ((zero , ⇑ᵗ A) ∷_) (leftStoreⁱ-lift liftρ)
+    ; targetStoreResult =
+        cong ((zero , ⇑ᵗ A′) ∷_) (rightStoreⁱ-lift liftρ)
+    ; relatedResults = result
+    }
+
+weak-one-step-matched-ν↑-value-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  Value (sourceResult (weakResult (catchupAllResult catchup))) →
+  No• (sourceResult (weakResult (catchupAllResult catchup))) →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW | ρ′ , liftρ₀ | μᵣ , source↑₀ | μᵗ , target↑₀
+    with weak-result-source-reveal inner s↑
+       | weak-result-target-reveal keep inner s′↑
+weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW | ρ′ , liftρ₀ | μᵣ , source↑₀ | μᵗ , target↑₀
+    | μˢ , source↑ | μᵗ′ , target↑ =
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent
+      (weak-one-step-matched-ν-frameᵀ
+        s↑ s′↑ pA pB (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-ν↑ᵀ
+      vW noW vV′ noV′ source↑ target↑
+      (transportType inner pB)
+      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
+
+weak-one-step-matched-ν↑-blame-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  sourceResult (weakResult (catchupAllResult catchup)) ≡ blame →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl
+    with silent
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    | μᵣ , source↑ | μᵗ , target↑ =
+  let
+    first = weak-one-step-matched-ν-frameᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′
+      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+      target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent first (left-silent-invariant refl refl)) second
+
+weak-one-step-matched-ν↑-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-ν↑-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
+    | inj₁ (vW , noW) =
+  weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′ catchup vW noW
+weak-one-step-matched-ν↑-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
+    | inj₂ eq-blame =
+  weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame
+
+------------------------------------------------------------------------
+-- Synchronized `inst` allocation
+------------------------------------------------------------------------
+
+matched-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  (ν ★ N s —→[ bind ★ ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (ν ★ N′ s′ —→[ bind ★ ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero ★ zero ★ id★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-νcast-allocation {q = q} vN noN vN′ noN′ mode seal★ mode′
+    seal★′ s⊑ s′⊑ pB liftρ N⊑N′ =
+  ν-step vN noN ,
+  ν-step vN′ noN′ ,
+  conv⊑convᵀ
+    (paired-widening
+      (cast-inst mode) left-seal left-widening
+      (cast-inst mode′) right-seal right-widening)
+    (α⊑αᵀ vN noN vN′ noN′ id★ liftρ lift-ctx-[] N⊑N′
+      left-bullet-typing right-bullet-typing)
+  where
+    left-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (leftStoreⁱ-lift liftρ))
+        seal★
+
+    right-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (rightStoreⁱ-lift liftρ))
+        seal★′
+
+    left-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        s⊑
+
+    right-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        s′⊑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-tgt-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-matched-νcastᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ N′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
+    pB liftρ N⊑N′
+    with matched-νcast-allocation
+      vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
+      pB liftρ N⊑N′
+weak-one-step-matched-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
+    pB liftρ N⊑N′
+    | source→ , _ , result =
+  record
+    { sourceChanges = bind ★ ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-matched zero ★ zero ★ id★ ∷ ρ′
+    ; resultSourceType = ⇑ᵗ B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-lift∀ᵢ
+    ; transportAllBody = ⊑-lift-under-∀ᵢ
+    ; transportRightBody = ⊑-lift-under-rightᵢ
+    ; resultType = ⊑-lift∀ᵢ pB
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult =
+        cong ((zero , ★) ∷_) (leftStoreⁱ-lift liftρ)
+    ; targetStoreResult =
+        cong ((zero , ★) ∷_) (rightStoreⁱ-lift liftρ)
+    ; relatedResults = result
+    }
+
+weak-one-step-matched-νcast-value-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  Value (sourceResult (weakResult (catchupAllResult catchup))) →
+  No• (sourceResult (weakResult (catchupAllResult catchup))) →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW | ρ′ , liftρ₀
+    | μᵣ , modeᵣ , sealᵣ , source⊑₀
+    | μᵗ , modeᵗ , sealᵗ , target⊑₀
+    with weak-result-source-widen-inst inner mode seal★ s⊑
+       | weak-result-target-widen-inst
+          keep inner mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW | ρ′ , liftρ₀
+    | μᵣ , modeᵣ , sealᵣ , source⊑₀
+    | μᵗ , modeᵗ , sealᵗ , target⊑₀
+    | μˢ , modeˢ , sealˢ , source⊑
+    | μᵗ′ , modeᵗ′ , sealᵗ′ , target⊑ =
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent
+      (weak-one-step-matched-νcast-frameᵀ
+        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+        (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-νcastᵀ
+      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
+
+weak-one-step-matched-νcast-blame-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  sourceResult (weakResult (catchupAllResult catchup)) ≡ blame →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl
+    with silent
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  let
+    first = weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′ wf★ target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent first (left-silent-invariant refl refl)) second
+
+weak-one-step-matched-νcast-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcast-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-νcast-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup | inj₁ (vW , noW) =
+  weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup vW noW
+weak-one-step-matched-νcast-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup | inj₂ eq-blame =
+  weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup eq-blame
+
+left-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N′ s μ q occ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value N →
+  No• N →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
+  (ν ★ N s —→[ bind ★ ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-νcast-allocation {q = q} vN noN mode seal★ s⊑ pB liftρ
+    N⊑N′ =
+  ν-step vN noN ,
+  ↠-refl ,
+  cast⊑⊑ᵀ (cast-inst mode) left-seal left-widening
+    (α⊑ᵀ vN noN wf★ liftρ lift-left-ctx-[] N⊑N′
+      left-bullet-typing right-term-typing)
+    (⊑-source-liftνᵢ pB)
+  where
+    left-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        seal★
+
+    left-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        s⊑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left liftρ))
+        (nu-term-imprecision-target-typing N⊑N′)
+
+------------------------------------------------------------------------
+-- Left-only polymorphic allocation
+------------------------------------------------------------------------
+
+left-ν↑-allocation :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N′ s μ q occ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value N →
+  No• N →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
+  (ν A N s —→[ bind A ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-ν↑-allocation {q = q} vN noN h⇑A s↑ pB liftρ N⊑N′ =
+  ν-step vN noN ,
+  ↠-refl ,
+  conv↑⊑ᵀ left-reveal
+    (α⊑ᵀ vN noN h⇑A liftρ lift-left-ctx-[] N⊑N′
+      left-bullet-typing right-term-typing)
+    (⊑-source-liftνᵢ pB)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        s↑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left liftρ))
+        (nu-term-imprecision-target-typing N⊑N′)
+
+------------------------------------------------------------------------
+-- Right-only polymorphic allocation
+------------------------------------------------------------------------
+
+right-ν↑-allocation :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  (N —↠[ [] ] N) ×
+  (ν A N′ s —→[ bind A ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
+  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+    store-right zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
+    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
+    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
+right-ν↑-allocation {q = q} vN′ noN′ h⇑A s′↑ pB pC liftρ
+    N⊑N′ =
+  ↠-refl ,
+  ν-step vN′ noN′ ,
+  ⊑conv↑ᵀ right-reveal
+    (⊑αᵀ vN′ noN′ h⇑A liftρ lift-right-ctx-[] N⊑N′ pC
+      left-term-typing right-bullet-typing)
+    (⊑-target-lift-rightᵢ pB)
+  where
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (rightStoreⁱ-lift-right liftρ))
+        s′↑
+
+    left-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right liftρ))
+        (nu-term-imprecision-source-typing N⊑N′)
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift-right liftρ))
+        (⊢• refl refl (∀-imprecision-target-body-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-right-ν↑ᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  WeakOneStepResult ρ N (((⇑ᵗᵐ N′) •) ⟨ s ⟩)
+    B B′ (bind A)
+weak-one-step-right-ν↑ᵀ
+    {A = A} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    with right-ν↑-allocation
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+weak-one-step-right-ν↑ᵀ
+    {A = A} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    | _ , _ , result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = ⇑ᴿᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-right zero (⇑ᵗ A) h⇑A ∷ ρ′
+    ; resultSourceType = B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-target-lift-rightᵢ
+    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
+    ; transportRightBody = ⊑-target-lift-under-rightᵢ
+    ; resultType = ⊑-target-lift-rightᵢ pB
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
+    ; targetStoreResult =
+        cong ((zero , ⇑ᵗ A) ∷_) (rightStoreⁱ-lift-right liftρ)
+    ; relatedResults = result
+    }
+
+------------------------------------------------------------------------
+-- Right-only `inst` allocation
+------------------------------------------------------------------------
+
+right-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  (N —↠[ [] ] N) ×
+  (ν ★ N′ s —→[ bind ★ ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
+  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+    store-right zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
+    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
+right-νcast-allocation {q = q} vN′ noN′ mode seal★ s⊑ pB pC
+    liftρ N⊑N′ =
+  ↠-refl ,
+  ν-step vN′ noN′ ,
+  ⊑cast⊑ᵀ (cast-inst mode) right-seal right-widening
+    (⊑αᵀ vN′ noN′ wf★ liftρ lift-right-ctx-[] N⊑N′ pC
+      left-term-typing right-bullet-typing)
+    (⊑-target-lift-rightᵢ pB)
+  where
+    right-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (rightStoreⁱ-lift-right liftρ))
+        seal★
+
+    right-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (rightStoreⁱ-lift-right liftρ))
+        s⊑
+
+    left-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right liftρ))
+        (nu-term-imprecision-source-typing N⊑N′)
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift-right liftρ))
+        (⊢• refl refl (∀-imprecision-target-body-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-right-νcastᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  WeakOneStepResult ρ N (((⇑ᵗᵐ N′) •) ⟨ s ⟩)
+    B B′ (bind ★)
+weak-one-step-right-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    with right-νcast-allocation
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+weak-one-step-right-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    | _ , _ , result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = ⇑ᴿᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-right zero ★ wf★ ∷ ρ′
+    ; resultSourceType = B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-target-lift-rightᵢ
+    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
+    ; transportRightBody = ⊑-target-lift-under-rightᵢ
+    ; resultType = ⊑-target-lift-rightᵢ pB
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
+    ; targetStoreResult =
+        cong ((zero , ★) ∷_) (rightStoreⁱ-lift-right liftρ)
+    ; relatedResults = result
+    }
+
+------------------------------------------------------------------------
+-- `β-inst` followed by `ν ★` allocation
+------------------------------------------------------------------------
+
+matched-β-inst-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  (N ⟨ inst B s ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ ⟨ inst B′ s′ ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero ★ zero ★ id★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-β-inst-νcast-allocation vN noN vN′ noN′ mode seal★
+    mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
+    with matched-νcast-allocation vN noN vN′ noN′ mode seal★
+      mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
+matched-β-inst-νcast-allocation vN noN vN′ noN′ mode seal★
+    mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
+    | N→ , N′→ , result =
+  ↠-step (post-β-inst vN) (↠-step N→ ↠-refl) ,
+  ↠-step (post-β-inst vN′) (↠-step N′→ ↠-refl) ,
+  result
+
+left-β-inst-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N′ s μ q occ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value N →
+  No• N →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
+  (N ⟨ inst B s ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-β-inst-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
+    with left-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
+left-β-inst-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
+    | N→ , N′→ , result =
+  ↠-step (post-β-inst vN) (↠-step N→ ↠-refl) ,
+  N′→ ,
+  result
+
+right-β-inst-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  (N —↠[ [] ] N) ×
+  (N′ ⟨ inst B′ s ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
+  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+    store-right zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
+    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
+right-β-inst-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC liftρ
+    N⊑N′
+    with right-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC
+      liftρ N⊑N′
+right-β-inst-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC liftρ
+    N⊑N′ | N→ , N′→ , result =
+  N→ ,
+  ↠-step (post-β-inst vN′) (↠-step N′→ ↠-refl) ,
+  result
+
+------------------------------------------------------------------------
+-- Allocation followed by `β-Λ•`
+------------------------------------------------------------------------
+
+matched-ν↑-β-Λ• :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ V V′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ′ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ C ⊑ C′ ∶ q →
+  (ν A (Λ V) s —↠[ bind A ∷ keep ∷ [] ] V ⟨ s ⟩) ×
+  (ν A′ (Λ V′) s′
+    —↠[ bind A′ ∷ keep ∷ [] ] V′ ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′) A⇑⊑A′⇑ ∷ ρ′
+    ∣ []
+    ⊢ᴺ V ⟨ s ⟩ ⊑ V′ ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-ν↑-β-Λ• {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {A′ = A′}
+    {C = C} {C′ = C′} {V = V} {V′ = V′} {ρ′ = ρ′}
+    vV noV vV′ noV′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ
+    V⊑V′ =
+  ↠-step (ν-step (Λ vV) (no•-Λ noV))
+    (↠-step (post-allocation-β-Λ• vV) ↠-refl) ,
+  ↠-step (ν-step (Λ vV′) (no•-Λ noV′))
+    (↠-step (post-allocation-β-Λ• vV′) ↠-refl) ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal (correspondence-stored (here refl))
+        left-reveal right-reveal))
+    (allocation-matchedᵀ A⇑⊑A′⇑ liftρ V⊑V′
+      left-body-typing right-body-typing)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift liftρ))
+        s↑
+
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (rightStoreⁱ-lift liftρ))
+        s′↑
+
+    left-body-typing :
+      suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′ ∣ [] ⊢ V ⦂ C
+    left-body-typing =
+      term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρ′}
+        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′}
+        {Γ = []} {M = V} {A = C} ≤-refl StoreIncl-drop noV
+        (nu-term-imprecision-source-typing V⊑V′)
+
+    right-body-typing :
+      suc Δᴿ ∣ (zero , ⇑ᵗ A′) ∷ rightStoreⁱ ρ′ ∣ []
+        ⊢ V′ ⦂ C′
+    right-body-typing =
+      term-weaken {Δ = suc Δᴿ} {Δ′ = suc Δᴿ}
+        {Σ = rightStoreⁱ ρ′}
+        {Σ′ = (zero , ⇑ᵗ A′) ∷ rightStoreⁱ ρ′}
+        {Γ = []} {M = V′} {A = C′} ≤-refl StoreIncl-drop noV′
+        (nu-term-imprecision-target-typing V⊑V′)
+
+left-ν↑-β-Λ• :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C V N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ []
+    ⊢ᴺ V ⊑ N′ ⦂ C ⊑ B′ ∶ q →
+  (ν A (Λ V) s —↠[ bind A ∷ keep ∷ [] ] V ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
+    ⊢ᴺ V ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-ν↑-β-Λ• {Δᴸ = Δᴸ} {A = A} {C = C} {V = V}
+    {ρ′ = ρ′} vV noV h⇑A s↑ pB liftρ V⊑N′ =
+  ↠-step (ν-step (Λ vV) (no•-Λ noV))
+    (↠-step (post-allocation-β-Λ• vV) ↠-refl) ,
+  ↠-refl ,
+  conv↑⊑ᵀ left-reveal
+    (allocation-leftᵀ h⇑A liftρ V⊑N′
+      source-body-typing
+      (nu-term-imprecision-target-typing V⊑N′))
+    (⊑-source-liftνᵢ pB)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        s↑
+
+    source-body-typing :
+      suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′ ∣ [] ⊢ V ⦂ C
+    source-body-typing =
+      term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρ′}
+        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′}
+        {Γ = []} {M = V} {A = C} ≤-refl StoreIncl-drop noV
+        (nu-term-imprecision-source-typing V⊑N′)
+
+------------------------------------------------------------------------
+-- Matched allocation followed by `β-gen•`
+------------------------------------------------------------------------
+
+matched-post-allocation-β-genᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aν Aν′ A A′ B B′ V V′ c c′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)}
+    {γ′ : CtxImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ gen A c ∶ A ⊒ `∀ B →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ gen A′ c′ ∶ A′ ⊒ `∀ B′ →
+  (pν : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ Aν ⊑ Aν′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ
+    ∣ store-matched zero Aν zero Aν′ pν ∷ ρ′ ∣ γ′
+    ⊢ᴺ ⇑ᵗᵐ V ⊑ ⇑ᵗᵐ V′ ⦂ ⇑ᵗ A ⊑ ⇑ᵗ A′ ∶ p →
+  (q : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ B ⊑ᵖ B′ ⊣ suc Δᴿ) →
+  (((⇑ᵗᵐ (V ⟨ gen A c ⟩)) •
+      —→[ keep ] (⇑ᵗᵐ V) ⟨ c ⟩) ×
+   ((⇑ᵗᵐ (V′ ⟨ gen A′ c′ ⟩)) •
+      —→[ keep ] (⇑ᵗᵐ V′) ⟨ c′ ⟩) ×
+   (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      ∣ suc Δᴸ ∣ suc Δᴿ
+      ∣ store-matched zero Aν zero Aν′ pν ∷ ρ′ ∣ γ′
+      ⊢ᴺᵖ (⇑ᵗᵐ V) ⟨ c ⟩ ⊑ (⇑ᵗᵐ V′) ⟨ c′ ⟩
+      ⦂ B ⊑ᵖ B′ ∶ q))
+matched-post-allocation-β-genᵀ {Aν = Aν} {Aν′ = Aν′} vV vV′
+    c⊒ c′⊒ pν liftρ V⊑V′ q =
+  post-allocation-β-gen•-bare vV ,
+  post-allocation-β-gen•-bare vV′ ,
+  gen-down⊑gen-downᵀ
+    (narrow-mode-relax (ModeIncl-gen id-only≤tag-or-idᵈ) left-body)
+    (narrow-mode-relax (ModeIncl-gen id-only≤tag-or-idᵈ) right-body)
+    V⊑V′ q
+  where
+    left-body =
+      subst
+        (λ Σ → genᵈ id-onlyᵈ ∣ _ ∣ (zero , Aν) ∷ Σ
+          ⊢ _ ∶ _ ⊒ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (allocate-gen-narrowing {Aν = Aν} c⊒)
+
+    right-body =
+      subst
+        (λ Σ → genᵈ id-onlyᵈ ∣ _ ∣ (zero , Aν′) ∷ Σ
+          ⊢ _ ∶ _ ⊒ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (allocate-gen-narrowing {Aν = Aν′} c′⊒)

--- a/GTSF/proof/NuPreservation.agda
+++ b/GTSF/proof/NuPreservation.agda
@@ -893,3 +893,18 @@ multi-preservation wfΣ okM M⊢ (↠-step red reds) =
     (runtime-preservation wfΣ okM M⊢ red)
     (preservation wfΣ okM M⊢ red)
     reds
+
+multi-runtime-preservation :
+  ∀ {Δ Σ M N A χs} →
+  StoreWf Δ Σ →
+  RuntimeOK M →
+  Δ ∣ Σ ∣ [] ⊢ M ⦂ A →
+  M —↠[ χs ] N →
+  RuntimeOK N
+multi-runtime-preservation wfΣ okM M⊢ ↠-refl = okM
+multi-runtime-preservation wfΣ okM M⊢ (↠-step red reds) =
+  multi-runtime-preservation
+    (store-preservation wfΣ M⊢ red)
+    (runtime-preservation wfΣ okM M⊢ red)
+    (preservation wfΣ okM M⊢ red)
+    reds

--- a/GTSF/proof/NuReductionDeterminism.agda
+++ b/GTSF/proof/NuReductionDeterminism.agda
@@ -1,0 +1,238 @@
+module proof.NuReductionDeterminism where
+
+-- File Charter:
+--   * Determinism and terminal-state infrastructure for Nu reduction.
+--   * Proves that values and blame cannot step, that one-step reduction is
+--     deterministic, and that a reduction tail is a prefix of any trace to a
+--     terminal value or blame.
+--   * The prefix lemmas are the trace-alignment boundary needed to iterate the
+--     weak one-step imprecision simulation.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (cong; sym)
+
+open import Coercions
+open import NuTerms
+open import NuReduction
+
+
+pure-value-irreducible :
+  ∀ {V N} →
+  Value V →
+  V —→ N →
+  ⊥
+pure-value-irreducible (ƛ N) ()
+pure-value-irreducible (Λ vV) ()
+pure-value-irreducible ($ κ) ()
+pure-value-irreducible (() ⟨ G ! ⟩) blame-⟨⟩
+pure-value-irreducible (() ⟨ seal A α ⟩) blame-⟨⟩
+pure-value-irreducible (() ⟨ c ↦ d ⟩) blame-⟨⟩
+pure-value-irreducible (() ⟨ `∀ c ⟩) blame-⟨⟩
+pure-value-irreducible (() ⟨ gen A c ⟩) blame-⟨⟩
+
+value-irreducible :
+  ∀ {V χ N} →
+  Value V →
+  V —→[ χ ] N →
+  ⊥
+value-irreducible vV (pure-step V→N) =
+  pure-value-irreducible vV V→N
+value-irreducible (vV ⟨ G ! ⟩) (ξ-⟨⟩ V→N) =
+  value-irreducible vV V→N
+value-irreducible (vV ⟨ seal A α ⟩) (ξ-⟨⟩ V→N) =
+  value-irreducible vV V→N
+value-irreducible (vV ⟨ c ↦ d ⟩) (ξ-⟨⟩ V→N) =
+  value-irreducible vV V→N
+value-irreducible (vV ⟨ `∀ c ⟩) (ξ-⟨⟩ V→N) =
+  value-irreducible vV V→N
+value-irreducible (vV ⟨ gen A c ⟩) (ξ-⟨⟩ V→N) =
+  value-irreducible vV V→N
+
+blame-irreducible :
+  ∀ {χ N} →
+  blame —→[ χ ] N →
+  ⊥
+blame-irreducible (pure-step ())
+
+
+pure-deterministic :
+  ∀ {M N N′} →
+  M —→ N →
+  M —→ N′ →
+  N ≡ N′
+pure-deterministic δ-⊕ δ-⊕ = refl
+pure-deterministic (β vV) (β vV′) = refl
+pure-deterministic (β-Λ• vV) (β-Λ• vV′) = refl
+pure-deterministic (β-∀• vV) (β-∀• vV′) = refl
+pure-deterministic (β-gen• vV) (β-gen• vV′) = refl
+pure-deterministic (β-id vV) (β-id vV′) = refl
+pure-deterministic (β-seq vV) (β-seq vV′) = refl
+pure-deterministic (β-↦ vV vW) (β-↦ vV′ vW′) = refl
+pure-deterministic (β-inst vV) (β-inst vV′) = refl
+pure-deterministic (tag-untag-ok vV) (tag-untag-ok vV′) = refl
+pure-deterministic (tag-untag-ok vV)
+  (tag-untag-bad vV′ G≠G) = ⊥-elim (G≠G refl)
+pure-deterministic (tag-untag-bad vV G≠G)
+  (tag-untag-ok vV′) = ⊥-elim (G≠G refl)
+pure-deterministic (tag-untag-bad vV G≠H)
+  (tag-untag-bad vV′ G≠H′) = refl
+pure-deterministic (seal-unseal vV) (seal-unseal vV′) = refl
+pure-deterministic blame-·₁ blame-·₁ = refl
+pure-deterministic (blame-·₂ vV) (blame-·₂ vV′) = refl
+pure-deterministic blame-• blame-• = refl
+pure-deterministic blame-⟨⟩ blame-⟨⟩ = refl
+pure-deterministic blame-⊕₁ blame-⊕₁ = refl
+pure-deterministic (blame-⊕₂ vV) (blame-⊕₂ vV′) = refl
+
+
+pure-full-deterministic :
+  ∀ {M N N′ χ} →
+  M —→ N →
+  M —→[ χ ] N′ →
+  (χ ≡ keep) × (N ≡ N′)
+pure-full-deterministic M→N (pure-step M→N′) =
+  refl , pure-deterministic M→N M→N′
+pure-full-deterministic δ-⊕ (ξ-⊕₁ L→L′ shift) =
+  ⊥-elim (value-irreducible ($ _) L→L′)
+pure-full-deterministic δ-⊕ (ξ-⊕₂ vL shift M→M′) =
+  ⊥-elim (value-irreducible ($ _) M→M′)
+pure-full-deterministic (β vV) (ξ-·₁ L→L′ shift) =
+  ⊥-elim (value-irreducible (ƛ _) L→L′)
+pure-full-deterministic (β vV) (ξ-·₂ vL shift M→M′) =
+  ⊥-elim (value-irreducible vV M→M′)
+pure-full-deterministic (β-id vV) (ξ-⟨⟩ V→V′) =
+  ⊥-elim (value-irreducible vV V→V′)
+pure-full-deterministic (β-seq vV) (ξ-⟨⟩ V→V′) =
+  ⊥-elim (value-irreducible vV V→V′)
+pure-full-deterministic (β-↦ vV vW) (ξ-·₁ L→L′ shift) =
+  ⊥-elim (value-irreducible (vV ⟨ _ ↦ _ ⟩) L→L′)
+pure-full-deterministic (β-↦ vV vW) (ξ-·₂ vL shift W→W′) =
+  ⊥-elim (value-irreducible vW W→W′)
+pure-full-deterministic (β-inst vV) (ξ-⟨⟩ V→V′) =
+  ⊥-elim (value-irreducible vV V→V′)
+pure-full-deterministic (tag-untag-ok vV) (ξ-⟨⟩ V→V′) =
+  ⊥-elim (value-irreducible (vV ⟨ _ ! ⟩) V→V′)
+pure-full-deterministic (tag-untag-bad vV G≠H) (ξ-⟨⟩ V→V′) =
+  ⊥-elim (value-irreducible (vV ⟨ _ ! ⟩) V→V′)
+pure-full-deterministic (seal-unseal vV) (ξ-⟨⟩ V→V′) =
+  ⊥-elim (value-irreducible (vV ⟨ seal _ _ ⟩) V→V′)
+pure-full-deterministic blame-·₁ (ξ-·₁ L→L′ shift) =
+  ⊥-elim (blame-irreducible L→L′)
+pure-full-deterministic blame-·₁ (ξ-·₂ () shift M→M′)
+pure-full-deterministic (blame-·₂ vV) (ξ-·₁ V→V′ shift) =
+  ⊥-elim (value-irreducible vV V→V′)
+pure-full-deterministic (blame-·₂ vV)
+  (ξ-·₂ vV′ shift blame→N) = ⊥-elim (blame-irreducible blame→N)
+pure-full-deterministic blame-⟨⟩ (ξ-⟨⟩ blame→N) =
+  ⊥-elim (blame-irreducible blame→N)
+pure-full-deterministic blame-⊕₁ (ξ-⊕₁ blame→N shift) =
+  ⊥-elim (blame-irreducible blame→N)
+pure-full-deterministic blame-⊕₁ (ξ-⊕₂ () shift M→M′)
+pure-full-deterministic (blame-⊕₂ vV) (ξ-⊕₁ V→V′ shift) =
+  ⊥-elim (value-irreducible vV V→V′)
+pure-full-deterministic (blame-⊕₂ vV)
+  (ξ-⊕₂ vV′ shift blame→N) = ⊥-elim (blame-irreducible blame→N)
+
+
+step-deterministic :
+  ∀ {M N N′ χ χ′} →
+  M —→[ χ ] N →
+  M —→[ χ′ ] N′ →
+  (χ ≡ χ′) × (N ≡ N′)
+step-deterministic (pure-step M→N) M→N′
+  with pure-full-deterministic M→N M→N′
+step-deterministic (pure-step M→N) M→N′ | refl , refl = refl , refl
+step-deterministic M→N (pure-step M→N′)
+  with pure-full-deterministic M→N′ M→N
+step-deterministic M→N (pure-step M→N′) | refl , refl = refl , refl
+step-deterministic (ν-step vV no•V) (ν-step vV′ no•V′) = refl , refl
+step-deterministic (ν-step vV no•V) (ξ-ν V→V′) =
+  ⊥-elim (value-irreducible vV V→V′)
+step-deterministic (ν-step () no•V) blame-ν
+step-deterministic (ξ-ν V→V′) (ν-step vV no•V) =
+  ⊥-elim (value-irreducible vV V→V′)
+step-deterministic (ξ-ν L→L′) (ξ-ν L→L′′)
+  with step-deterministic L→L′ L→L′′
+step-deterministic (ξ-ν L→L′) (ξ-ν L→L′′) | refl , refl =
+  refl , refl
+step-deterministic (ξ-ν blame→N) blame-ν =
+  ⊥-elim (blame-irreducible blame→N)
+step-deterministic blame-ν (ν-step () no•V)
+step-deterministic blame-ν (ξ-ν blame→N) =
+  ⊥-elim (blame-irreducible blame→N)
+step-deterministic blame-ν blame-ν = refl , refl
+step-deterministic (ξ-·₁ L→L′ shift) (ξ-·₁ L→L′′ shift′)
+  with step-deterministic L→L′ L→L′′
+step-deterministic (ξ-·₁ L→L′ shift) (ξ-·₁ L→L′′ shift′)
+  | refl , refl = refl , refl
+step-deterministic (ξ-·₁ V→V′ shift) (ξ-·₂ vV shift′ M→M′) =
+  ⊥-elim (value-irreducible vV V→V′)
+step-deterministic (ξ-·₂ vV shift M→M′) (ξ-·₁ V→V′ shift′) =
+  ⊥-elim (value-irreducible vV V→V′)
+step-deterministic (ξ-·₂ vV shift M→M′)
+  (ξ-·₂ vV′ shift′ M→M′′)
+  with step-deterministic M→M′ M→M′′
+step-deterministic (ξ-·₂ vV shift M→M′)
+  (ξ-·₂ vV′ shift′ M→M′′) | refl , refl = refl , refl
+step-deterministic (ξ-⟨⟩ M→M′) (ξ-⟨⟩ M→M′′)
+  with step-deterministic M→M′ M→M′′
+step-deterministic (ξ-⟨⟩ M→M′) (ξ-⟨⟩ M→M′′) | refl , refl =
+  refl , refl
+step-deterministic (ξ-⊕₁ L→L′ shift) (ξ-⊕₁ L→L′′ shift′)
+  with step-deterministic L→L′ L→L′′
+step-deterministic (ξ-⊕₁ L→L′ shift) (ξ-⊕₁ L→L′′ shift′)
+  | refl , refl = refl , refl
+step-deterministic (ξ-⊕₁ V→V′ shift) (ξ-⊕₂ vV shift′ M→M′) =
+  ⊥-elim (value-irreducible vV V→V′)
+step-deterministic (ξ-⊕₂ vV shift M→M′) (ξ-⊕₁ V→V′ shift′) =
+  ⊥-elim (value-irreducible vV V→V′)
+step-deterministic (ξ-⊕₂ vV shift M→M′)
+  (ξ-⊕₂ vV′ shift′ M→M′′)
+  with step-deterministic M→M′ M→M′′
+step-deterministic (ξ-⊕₂ vV shift M→M′)
+  (ξ-⊕₂ vV′ shift′ M→M′′) | refl , refl = refl , refl
+
+
+target-tail-prefix-value :
+  ∀ {M N V χs ψs} →
+  M —↠[ χs ] N →
+  M —↠[ ψs ] V →
+  Value V →
+  ∃[ θs ] ((N —↠[ θs ] V) × (ψs ≡ χs ++ θs))
+target-tail-prefix-value {ψs = ψs} ↠-refl M↠V vV =
+  ψs , M↠V , refl
+target-tail-prefix-value (↠-step M→L L↠N) ↠-refl vM =
+  ⊥-elim (value-irreducible vM M→L)
+target-tail-prefix-value (↠-step M→L L↠N)
+  (↠-step M→L′ L′↠V) vV
+  with step-deterministic M→L M→L′
+target-tail-prefix-value (↠-step M→L L↠N)
+  (↠-step M→L′ L′↠V) vV | refl , refl
+  with target-tail-prefix-value L↠N L′↠V vV
+target-tail-prefix-value (↠-step M→L L↠N)
+  (↠-step M→L′ L′↠V) vV | refl , refl
+  | θs , N↠V , ψs≡χs++θs =
+    θs , N↠V , cong (_ ∷_) ψs≡χs++θs
+
+target-tail-prefix-blame :
+  ∀ {M N χs ψs} →
+  M —↠[ χs ] N →
+  M —↠[ ψs ] blame →
+  ∃[ θs ] ((N —↠[ θs ] blame) × (ψs ≡ χs ++ θs))
+target-tail-prefix-blame {ψs = ψs} ↠-refl M↠blame =
+  ψs , M↠blame , refl
+target-tail-prefix-blame (↠-step M→L L↠N) ↠-refl =
+  ⊥-elim (blame-irreducible M→L)
+target-tail-prefix-blame (↠-step M→L L↠N)
+  (↠-step M→L′ L′↠blame)
+  with step-deterministic M→L M→L′
+target-tail-prefix-blame (↠-step M→L L↠N)
+  (↠-step M→L′ L′↠blame) | refl , refl
+  with target-tail-prefix-blame L↠N L′↠blame
+target-tail-prefix-blame (↠-step M→L L↠N)
+  (↠-step M→L′ L′↠blame) | refl , refl
+  | θs , N↠blame , ψs≡χs++θs =
+    θs , N↠blame , cong (_ ∷_) ψs≡χs++θs

--- a/GTSF/proof/NuTermProperties.agda
+++ b/GTSF/proof/NuTermProperties.agda
@@ -99,13 +99,6 @@ renameStoreᵗ-single-suc-cons-cancel α Σ A =
     (cong₂ _,_ refl (renameᵗ-single-suc-cancel α A))
     (renameStoreᵗ-single-suc-cancel α Σ)
 
-singleRenameᵗ-Wf-< :
-  ∀ {Δ α} →
-  α < Δ →
-  TyRenameWf (suc Δ) Δ (singleRenameᵗ α)
-singleRenameᵗ-Wf-< α<Δ {zero} z<s = α<Δ
-singleRenameᵗ-Wf-< α<Δ {suc X} (s<s X<Δ) = X<Δ
-
 rename-[]ᴿ-commute :
   ∀ ρ B α →
   renameᵗ ρ (B [ α ]ᴿ) ≡ renameᵗ (extᵗ ρ) B [ ρ α ]ᴿ

--- a/GTSF/proof/ReductionProperties.agda
+++ b/GTSF/proof/ReductionProperties.agda
@@ -353,6 +353,14 @@ applyTysUnderTyBinders [] A = A
 applyTysUnderTyBinders (χ ∷ χs) A =
   applyTysUnderTyBinders χs (applyTyUnderTyBinder χ A)
 
+applyTysUnderTyBinders-++ :
+  ∀ χs χs′ A →
+  applyTysUnderTyBinders (χs ++ χs′) A ≡
+    applyTysUnderTyBinders χs′ (applyTysUnderTyBinders χs A)
+applyTysUnderTyBinders-++ [] χs′ A = refl
+applyTysUnderTyBinders-++ (χ ∷ χs) χs′ A =
+  applyTysUnderTyBinders-++ χs χs′ (applyTyUnderTyBinder χ A)
+
 applyTysUnderTyBinders-⇑ᵗ :
   ∀ χs A →
   applyTysUnderTyBinders χs (⇑ᵗ A) ≡ ⇑ᵗ (applyTys χs A)
@@ -363,6 +371,12 @@ applyTysUnderTyBinders-⇑ᵗ (bind B ∷ χs) A =
   trans
     (cong (applyTysUnderTyBinders χs) (renameᵗ-ext-suc-comm suc A))
     (applyTysUnderTyBinders-⇑ᵗ χs (⇑ᵗ A))
+
+applyTy-∀ :
+  ∀ χ A →
+  applyTy χ (`∀ A) ≡ `∀ (applyTyUnderTyBinder χ A)
+applyTy-∀ keep A = refl
+applyTy-∀ (bind B) A = refl
 
 applyTys-∀ :
   ∀ χs A →

--- a/GTSF/proof/TypeProperties.agda
+++ b/GTSF/proof/TypeProperties.agda
@@ -291,6 +291,13 @@ singleRenameᵗ-Wf α<sucΔ {zero} z<s = α<sucΔ
 singleRenameᵗ-Wf α<sucΔ {suc X} (s<s X<Δ) =
   m<n⇒m<1+n X<Δ
 
+singleRenameᵗ-Wf-< :
+  ∀ {Δ α} →
+  α < Δ →
+  TyRenameWf (suc Δ) Δ (singleRenameᵗ α)
+singleRenameᵗ-Wf-< α<Δ {zero} z<s = α<Δ
+singleRenameᵗ-Wf-< α<Δ {suc X} (s<s X<Δ) = X<Δ
+
 renameᵗ-ground :
   ∀ ρ {G} →
   Ground G →


### PR DESCRIPTION
## Summary

This pull request captures the current GTSF dynamic gradual guarantee
development based on `NuTermImprecision`, concentrating first on the difficult
interactions among `∀`, `ν`, seals, tags, `gen`, `inst`, and runtime type
application.

It:

- refines reveal/conceal conversion evidence and introduces paired conversion
  evidence for matched seal revelation;
- repairs right-only allocation with an explicit intermediate imprecision
  index;
- extends quotiented term imprecision with the administrative forms needed by
  polymorphic reduction, including crossed two-allocation states;
- proves focused simulation boundaries for `β-Λ•`, `β-∀•`, `β-gen•`, `β-inst`,
  ordinary `ν`, and `ν ★`;
- adds value-shape and quotient inversion results, crossed allocation traces,
  weak one-step result/outcome infrastructure, administrative composition, and
  matched/source-only/target-only `ν` frame lifting;
- uses source-blame outcomes with the DGG-correct polarity;
- adds reduction determinism and terminal trace-prefix alignment for
  administrative target tails;
- connects compiler monotonicity to a closed Nu DGG statement and proves that
  three terminal simulation obligations imply the four public DGG
  observations;
- records the checked coverage and remaining obligations in a progress ledger.

## Why

Earlier partial proofs did not expose enough invariant information at
right-only allocation and crossed polymorphic administrative states. They also
left the relationship between local simulation lemmas and the public DGG
theorem informal.

The revised relations carry the exact store, type, and coercion information
needed at those boundaries. The top-down proof spine now makes the remaining
gap explicit instead of hiding it behind an overly permissive weak-simulation
outcome.

## Current proof boundary

The full DGG is not yet complete. The next central obligation is the general
recursive dispatcher

$$
M \sqsubseteq N', \qquad N' \longrightarrow_{\chi} N'_1
\quad\Longrightarrow\quad
\mathsf{WeakOneStepOutcome}(M,N'_1,\chi),
$$

followed by recursion over the aligned target remainder and the corresponding
terminal catch-up cases.

## Validation

All checks were run from `GTSF/` with unsolved metas disabled:

- `agda --no-allow-unsolved-metas -v0 Compile.agda`
- `agda --no-allow-unsolved-metas -v0 proof/NuImprecisionSimulation.agda`
- `agda --no-allow-unsolved-metas -v0 proof/NuDGGSpine.agda`
- `agda --no-allow-unsolved-metas -v0 proof/NuDGGTraceAlignment.agda`
- `agda --no-allow-unsolved-metas -v0 proof/NuReductionDeterminism.agda`
- `agda --no-allow-unsolved-metas -v0 All.agda`
