### PR TITLE
Advance GTSF ν-imprecision simulation

### DIFF
--- a/GTSF/All.agda
+++ b/GTSF/All.agda
@@ -43,7 +43,10 @@ import proof.EndpointCanonicalMLBSimplePairedSpan
 import proof.EndpointCanonicalMLBSimpleFactorization
 import proof.EndpointCanonicalMLBSimpleFactorCounterexample
 import proof.QuotientedTermImprecisionTest
+import proof.NuImprecisionSimulationCore
 import proof.NuImprecisionSimulation
+import proof.NuImprecisionCatchupScratch
+import proof.NuImprecisionAllocationSimulation
 import proof.NuReductionDeterminism
 import proof.NuDGGTraceAlignment
 import proof.NuDGGSpine

--- a/GTSF/QuotientedTermImprecision.agda
+++ b/GTSF/QuotientedTermImprecision.agda
@@ -15,14 +15,12 @@ module QuotientedTermImprecision where
 --     physical store order need not coincide across permuted allocations.
 --   * Factors runtime-bullet instantiation from single-name reveal/conceal
 --     conversions and paired conversion imprecision.
---   * Includes repaired ordinary and `ν ★` allocation states for matched,
---     left-only, and right-only executions.
+--   * Uses one proof-only prefix-extension rule for matched, one-sided, and
+--     crossed allocation states.
 --   * Records the intermediate index for right-only allocation and permits
 --     body relations to cross the exact fresh-store extension it creates.
---   * Includes an exact two-allocation boundary for adjacent-`∀`
---     permutations, with independently ordered stores and crossed links.
---   * Transports both orientations of that body boundary by renaming one
---     endpoint and shifting the other.
+--   * Leaves adjacent-`∀` crossed-body transport admissible, avoiding
+--     syntax-specific swap constructors in the term relation.
 --   * Relates widening bodies exposed by crossed `inst∀` and `∀inst`
 --     coercions in both exact, differently ordered seal-mode orientations.
 
@@ -71,12 +69,10 @@ open import NuTerms using
   )
 open import Primitives
 open import proof.CastImprecision using
-  ( RightCastCtxCompatible
-  ; ∀ᵢᶜ
+  ( ∀ᵢᶜ
   ; widening⇒⊑ᵢ
   ; ⊑-transʳ-castᵢ
   )
-open import proof.NarrowWidenProperties using (StoreDetWf)
 open import TermTyping using
   ( CastMode
   ; SealModeStore★
@@ -101,6 +97,7 @@ open import TermTyping using
   )
 open import NuTermImprecision using
   ( StoreImp
+  ; StoreImpEntry
   ; StoreCorresponds
   ; CtxImp
   ; ctx-imp
@@ -141,6 +138,19 @@ variable
   Δᴸ Δᴿ : TyCtx
   ρ : StoreImp Φ Δᴸ Δᴿ
   γ : CtxImp Φ Δᴸ Δᴿ
+
+------------------------------------------------------------------------
+-- Store-imprecision prefix extension
+------------------------------------------------------------------------
+
+data StoreImpPrefix {Φ Δᴸ Δᴿ} :
+    StoreImp Φ Δᴸ Δᴿ → StoreImp Φ Δᴸ Δᴿ → Set where
+  prefix-reflⁱ : ∀ {ρ} → StoreImpPrefix ρ ρ
+
+  prefix-∷ⁱ :
+    ∀ {ρ₀ ρ⁺} {entry : StoreImpEntry Φ Δᴸ Δᴿ} →
+    StoreImpPrefix ρ₀ ρ⁺ →
+    StoreImpPrefix ρ₀ (entry ∷ ρ⁺)
 
 ------------------------------------------------------------------------
 -- Paired single-name conversions
@@ -185,6 +195,25 @@ data PairedCast
     SealModeStore★ μ′ (rightStoreⁱ ρ) →
     μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
     PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q
+
+data QuotientWideningPair
+    {Φ : ImpCtx} (Δᴸ Δᴿ : TyCtx) (ρ : StoreImp Φ Δᴸ Δᴿ) :
+    (u u′ : Coercion) → (D D′ A A′ : Ty) → Set₁ where
+  quotient-id-widening :
+    ∀ {u u′ D D′ A A′} →
+    id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+    id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
+    QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′
+
+  quotient-cast-widening :
+    ∀ {μ μ′ u u′ D D′ A A′} →
+    CastMode μ →
+    SealModeStore★ μ (leftStoreⁱ ρ) →
+    μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+    CastMode μ′ →
+    SealModeStore★ μ′ (rightStoreⁱ ρ) →
+    μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
+    QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′
 
 ------------------------------------------------------------------------
 -- Nu-term imprecision with quotiented hidden cast intermediates
@@ -235,40 +264,7 @@ mutual
         ∀ {N N′ A A′ D D′ qD u u′}
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ qD
-      → id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A
-      → id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′
-      → (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
-        ------------------------------------------------------------
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ pA
-
-    crossed-up⊑upᵀ :
-        ∀ {N N′ A A′ D D′ qD u u′ μ}
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ qD
-      → CastMode μ
-      → SealModeStore★ μ (leftStoreⁱ ρ)
-      → μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A
-      → SealModeStore★
-          (instᵈ (extᵈ tag-or-idᵈ)) (rightStoreⁱ ρ)
-      → instᵈ (extᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
-          ⊢ u′ ∶ D′ ⊑ A′
-      → (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
-        ------------------------------------------------------------
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ pA
-
-    crossed-left-up⊑upᵀ :
-        ∀ {N N′ A A′ D D′ qD u u′ μ}
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ qD
-      → CastMode μ
-      → SealModeStore★ μ (leftStoreⁱ ρ)
-      → μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A
-      → SealModeStore★
-          (extᵈ (instᵈ tag-or-idᵈ)) (rightStoreⁱ ρ)
-      → extᵈ (instᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
-          ⊢ u′ ∶ D′ ⊑ A′
+      → QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′
       → (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
         ------------------------------------------------------------
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
@@ -368,136 +364,15 @@ mutual
           store-right zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ γ′
           ⊢ᴺ N ⊑ (⇑ᵗᵐ L′) • ⦂ B ⊑ C′ ∶ r
 
-    allocation-matchedᵀ :
-        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A A′ B B′ M M′ p}
-          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
-          {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-            (suc Δᴸ₀) (suc Δᴿ₀)}
-          {γ′ : CtxImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-            (suc Δᴸ₀) (suc Δᴿ₀)} →
-      (pX : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-        ∣ suc Δᴸ₀ ⊢ A ⊑ A′ ⊣ suc Δᴿ₀) →
-      LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀) ρ₀ ρ′ →
-      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-        ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣ ρ′ ∣ γ′
-        ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p →
-      suc Δᴸ₀
-        ∣ leftStoreⁱ (store-matched zero A zero A′ pX ∷ ρ′)
-        ∣ leftCtxⁱ γ′ ⊢ M ⦂ B →
-      suc Δᴿ₀
-        ∣ rightStoreⁱ (store-matched zero A zero A′ pX ∷ ρ′)
-        ∣ rightCtxⁱ γ′ ⊢ M′ ⦂ B′
+    allocation-prefixᵀ : ∀ {ρ₀ M M′ A B p}
+      → StoreImpPrefix ρ₀ ρ
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+          ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p
+      → Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A
+      → Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B
         ------------------------------------------------------------
-      → ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-          ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣
-          store-matched zero A zero A′ pX ∷ ρ′ ∣ γ′
-          ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
-
-    allocation-crossedᵀ :
-        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A₀ A₁ B₀ B₁ C C′ M M′ p}
-          {p₀₁ p₁₀}
-          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
-          {ρ₁ : StoreImp (∀ᵢᶜ Φ₀) (suc Δᴸ₀) (suc Δᴿ₀)}
-          {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ₀)
-            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))}
-          {γ₂ : CtxImp (swapRight∀∀ᵢ Φ₀)
-            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))} →
-      (hA₀ : WfTy (suc (suc Δᴸ₀)) A₀) →
-      (hA₁ : WfTy (suc (suc Δᴸ₀)) A₁) →
-      (hB₀ : WfTy (suc (suc Δᴿ₀)) B₀) →
-      (hB₁ : WfTy (suc (suc Δᴿ₀)) B₁) →
-      LiftStoreⁱ (∀ᵢᶜ Φ₀) ρ₀ ρ₁ →
-      LiftStoreⁱ (swapRight∀∀ᵢ Φ₀) ρ₁ ρ₂ →
-      swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
-        ⊢ A₀ ⊑ B₁ ⊣ suc (suc Δᴿ₀) →
-      swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
-        ⊢ A₁ ⊑ B₀ ⊣ suc (suc Δᴿ₀) →
-      swapRight∀∀ᵢ Φ₀
-        ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣ ρ₂ ∣ γ₂
-        ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ p →
-      suc (suc Δᴸ₀) ∣
-        (zero , A₀) ∷ (suc zero , A₁) ∷ leftStoreⁱ ρ₂
-        ∣ leftCtxⁱ γ₂ ⊢ M ⦂ C →
-      suc (suc Δᴿ₀) ∣
-        (zero , B₀) ∷ (suc zero , B₁) ∷ rightStoreⁱ ρ₂
-        ∣ rightCtxⁱ γ₂ ⊢ M′ ⦂ C′
-        ------------------------------------------------------------
-      → swapRight∀∀ᵢ Φ₀
-          ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣
-          store-left zero A₀ hA₀ ∷
-          store-left (suc zero) A₁ hA₁ ∷
-          store-right zero B₀ hB₀ ∷
-          store-right (suc zero) B₁ hB₁ ∷
-          store-link zero A₀ (suc zero) B₁ p₀₁ ∷
-          store-link (suc zero) A₁ zero B₀ p₁₀ ∷ ρ₂
-          ∣ γ₂ ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ p
-
-    swapRight-bodyᵀ :
-        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A B C C′ W W′ M M′ p}
-          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
-          {ρ₁ : StoreImp (∀ᵢᶜ Φ₀) (suc Δᴸ₀) (suc Δᴿ₀)}
-          {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ₀)
-            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))} →
-      LiftStoreⁱ (∀ᵢᶜ Φ₀) ρ₀ ρ₁ →
-      LiftStoreⁱ (swapRight∀∀ᵢ Φ₀) ρ₁ ρ₂ →
-      ∀ᵢᶜ Φ₀ ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣ ρ₁ ∣ []
-        ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ p →
-      M ≡ ⇑ᵗᵐ W →
-      M′ ≡ renameᵗᵐ (extᵗ suc) W′ →
-      C ≡ ⇑ᵗ A →
-      C′ ≡ renameᵗ (extᵗ suc) B →
-      (q : swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
-        ⊢ C ⊑ C′ ⊣ suc (suc Δᴿ₀)) →
-      suc (suc Δᴸ₀) ∣ leftStoreⁱ ρ₂ ∣ [] ⊢ M ⦂ C →
-      suc (suc Δᴿ₀) ∣ rightStoreⁱ ρ₂ ∣ [] ⊢ M′ ⦂ C′
-        ------------------------------------------------------------
-      → swapRight∀∀ᵢ Φ₀
-          ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣ ρ₂ ∣ []
-          ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ q
-
-    swapLeft-bodyᵀ :
-        ∀ {Φ₀ Δᴸ₀ Δᴿ₀ A B C C′ W W′ M M′ p}
-          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ₀}
-          {ρ₁ : StoreImp (∀ᵢᶜ Φ₀) (suc Δᴸ₀) (suc Δᴿ₀)}
-          {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ₀)
-            (suc (suc Δᴸ₀)) (suc (suc Δᴿ₀))} →
-      LiftStoreⁱ (∀ᵢᶜ Φ₀) ρ₀ ρ₁ →
-      LiftStoreⁱ (swapRight∀∀ᵢ Φ₀) ρ₁ ρ₂ →
-      ∀ᵢᶜ Φ₀ ∣ suc Δᴸ₀ ∣ suc Δᴿ₀ ∣ ρ₁ ∣ []
-        ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ p →
-      M ≡ renameᵗᵐ (extᵗ suc) W →
-      M′ ≡ ⇑ᵗᵐ W′ →
-      C ≡ renameᵗ (extᵗ suc) A →
-      C′ ≡ ⇑ᵗ B →
-      (q : swapRight∀∀ᵢ Φ₀ ∣ suc (suc Δᴸ₀)
-        ⊢ C ⊑ C′ ⊣ suc (suc Δᴿ₀)) →
-      suc (suc Δᴸ₀) ∣ leftStoreⁱ ρ₂ ∣ [] ⊢ M ⦂ C →
-      suc (suc Δᴿ₀) ∣ rightStoreⁱ ρ₂ ∣ [] ⊢ M′ ⦂ C′
-        ------------------------------------------------------------
-      → swapRight∀∀ᵢ Φ₀
-          ∣ suc (suc Δᴸ₀) ∣ suc (suc Δᴿ₀) ∣ ρ₂ ∣ []
-          ⊢ᴺ M ⊑ M′ ⦂ C ⊑ C′ ∶ q
-
-    allocation-leftᵀ :
-        ∀ {Φ₀ Δᴸ₀ Δᴿ α A B B′ M M′ p}
-          {ρ₀ : StoreImp Φ₀ Δᴸ₀ Δᴿ}
-          {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀)
-            (suc Δᴸ₀) Δᴿ}
-          {γ′ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀)
-            (suc Δᴸ₀) Δᴿ} →
-      (hA : WfTy (suc Δᴸ₀) A) →
-      LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀) ρ₀ ρ′ →
-      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀)
-        ∣ suc Δᴸ₀ ∣ Δᴿ ∣ ρ′ ∣ γ′
-        ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p →
-      suc Δᴸ₀ ∣ leftStoreⁱ (store-left α A hA ∷ ρ′)
-        ∣ leftCtxⁱ γ′ ⊢ M ⦂ B →
-      Δᴿ ∣ rightStoreⁱ (store-left α A hA ∷ ρ′)
-        ∣ rightCtxⁱ γ′ ⊢ M′ ⦂ B′
-        ------------------------------------------------------------
-      → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ₀) ∣ suc Δᴸ₀ ∣ Δᴿ ∣
-          store-left α A hA ∷ ρ′ ∣ γ′
-          ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
+      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+          ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p
 
     ν⊑νᵀ :
         ∀ {ρ′ γ′ A A′ B B′ C C′ N N′ p q s s′ μ μ′}
@@ -665,7 +540,6 @@ mutual
           ⊢ᴺ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
 
     ⊑cast⊑idᵀ : ∀ {M M′ A A′ B′ p c′}
-      → (wfΣ′ : StoreDetWf Δᴿ (rightStoreⁱ ρ))
       → (seal★′ : SealModeStore★ id-onlyᵈ (rightStoreⁱ ρ))
       → (c′⊑ :
           id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′)
@@ -798,17 +672,15 @@ mutual
     ⊢·
       (nu-term-imprecision-source-typing L⊑L′)
       (nu-term-imprecision-source-typing M⊑M′)
-  nu-term-imprecision-source-typing (up⊑upᵀ M⊑M′ u⊑ u′⊑ p) =
+  nu-term-imprecision-source-typing
+      (up⊑upᵀ M⊑M′ (quotient-id-widening u⊑ u′⊑) p) =
     ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
       (widen-mode-relax id-only≤tag-or-idᵈ u⊑)
       (quotiented-nu-term-imprecision-source-typing M⊑M′)
   nu-term-imprecision-source-typing
-      (crossed-up⊑upᵀ M⊑M′ mode seal★ u⊑ seal★′ u′⊑ p) =
-    ⊢⟨⟩⊑ mode seal★ u⊑
-      (quotiented-nu-term-imprecision-source-typing M⊑M′)
-  nu-term-imprecision-source-typing
-      (crossed-left-up⊑upᵀ M⊑M′ mode seal★ u⊑
-        seal★′ u′⊑ p) =
+      (up⊑upᵀ M⊑M′
+        (quotient-cast-widening
+          mode seal★ u⊑ mode′ seal★′ u′⊑) p) =
     ⊢⟨⟩⊑ mode seal★ u⊑
       (quotiented-nu-term-imprecision-source-typing M⊑M′)
   nu-term-imprecision-source-typing
@@ -842,22 +714,7 @@ mutual
       (⊑αᵀ vL′ noL′ h⇑A liftρ liftγ N⊑L′ r N⊢ L′•⊢) =
     N⊢
   nu-term-imprecision-source-typing
-      (allocation-matchedᵀ pX liftρ M⊑M′ M⊢ M′⊢) =
-    M⊢
-  nu-term-imprecision-source-typing
-      (allocation-crossedᵀ hA₀ hA₁ hB₀ hB₁ liftρ₁ liftρ₂
-        p₀₁ p₁₀ M⊑M′ M⊢ M′⊢) =
-    M⊢
-  nu-term-imprecision-source-typing
-      (swapRight-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
-        M⊢ M′⊢) =
-    M⊢
-  nu-term-imprecision-source-typing
-      (swapLeft-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
-        M⊢ M′⊢) =
-    M⊢
-  nu-term-imprecision-source-typing
-      (allocation-leftᵀ hA liftρ M⊑M′ M⊢ M′⊢) =
+      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) =
     M⊢
   nu-term-imprecision-source-typing
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
@@ -901,7 +758,7 @@ mutual
       (⊑cast⊑ᵀ mode′ seal★′ c′⊑ M⊑M′ q) =
     nu-term-imprecision-source-typing M⊑M′
   nu-term-imprecision-source-typing
-      (⊑cast⊑idᵀ wfΣ′ seal★′ c′⊑ M⊑M′ q) =
+      (⊑cast⊑idᵀ seal★′ c′⊑ M⊑M′ q) =
     nu-term-imprecision-source-typing M⊑M′
   nu-term-imprecision-source-typing
       (conv⊑convᵀ
@@ -940,18 +797,16 @@ mutual
     ⊢·
       (nu-term-imprecision-target-typing L⊑L′)
       (nu-term-imprecision-target-typing M⊑M′)
-  nu-term-imprecision-target-typing (up⊑upᵀ M⊑M′ u⊑ u′⊑ p) =
+  nu-term-imprecision-target-typing
+      (up⊑upᵀ M⊑M′ (quotient-id-widening u⊑ u′⊑) p) =
     ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
       (widen-mode-relax id-only≤tag-or-idᵈ u′⊑)
       (quotiented-nu-term-imprecision-target-typing M⊑M′)
   nu-term-imprecision-target-typing
-      (crossed-up⊑upᵀ M⊑M′ mode seal★ u⊑ seal★′ u′⊑ p) =
-    ⊢⟨⟩⊑ (cast-inst (cast-ext cast-tag-or-id)) seal★′ u′⊑
-      (quotiented-nu-term-imprecision-target-typing M⊑M′)
-  nu-term-imprecision-target-typing
-      (crossed-left-up⊑upᵀ M⊑M′ mode seal★ u⊑
-        seal★′ u′⊑ p) =
-    ⊢⟨⟩⊑ (cast-ext (cast-inst cast-tag-or-id)) seal★′ u′⊑
+      (up⊑upᵀ M⊑M′
+        (quotient-cast-widening
+          mode seal★ u⊑ mode′ seal★′ u′⊑) p) =
+    ⊢⟨⟩⊑ mode′ seal★′ u′⊑
       (quotiented-nu-term-imprecision-target-typing M⊑M′)
   nu-term-imprecision-target-typing
       (Λ⊑Λᵀ {ρ = ρ} {γ = γ} liftρ liftγ vV vV′ V⊑V′) =
@@ -983,22 +838,7 @@ mutual
       (⊑αᵀ vL′ noL′ h⇑A liftρ liftγ N⊑L′ r N⊢ L′•⊢) =
     L′•⊢
   nu-term-imprecision-target-typing
-      (allocation-matchedᵀ pX liftρ M⊑M′ M⊢ M′⊢) =
-    M′⊢
-  nu-term-imprecision-target-typing
-      (allocation-crossedᵀ hA₀ hA₁ hB₀ hB₁ liftρ₁ liftρ₂
-        p₀₁ p₁₀ M⊑M′ M⊢ M′⊢) =
-    M′⊢
-  nu-term-imprecision-target-typing
-      (swapRight-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
-        M⊢ M′⊢) =
-    M′⊢
-  nu-term-imprecision-target-typing
-      (swapLeft-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl q
-        M⊢ M′⊢) =
-    M′⊢
-  nu-term-imprecision-target-typing
-      (allocation-leftᵀ hA liftρ M⊑M′ M⊢ M′⊢) =
+      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) =
     M′⊢
   nu-term-imprecision-target-typing
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
@@ -1045,7 +885,7 @@ mutual
     ⊢⟨⟩⊑ mode′ seal★′ c′⊑
       (nu-term-imprecision-target-typing M⊑M′)
   nu-term-imprecision-target-typing
-      (⊑cast⊑idᵀ wfΣ′ seal★′ c′⊑ M⊑M′ q) =
+      (⊑cast⊑idᵀ seal★′ c′⊑ M⊑M′ q) =
     ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
       (widen-mode-relax id-only≤tag-or-idᵈ c′⊑)
       (nu-term-imprecision-target-typing M⊑M′)

--- a/GTSF/proof/CoercionProperties.agda
+++ b/GTSF/proof/CoercionProperties.agda
@@ -19,7 +19,7 @@ open import Data.Nat.Properties
   using (_≟_; ≤-refl; n≤1+n; n<1+n; <-≤-trans; <-irrefl;
          m<n⇒m<1+n; suc-injective)
 open import Data.Product using (_×_; _,_; ∃; ∃-syntax; proj₁; proj₂)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (Dec; yes; no)
 open import Relation.Binary.PropositionalEquality
   using (_≢_; cong; cong₂; subst; sym; trans)
 
@@ -32,6 +32,18 @@ open import proof.StoreProperties
 ------------------------------------------------------------------------
 -- Inert coercions
 ------------------------------------------------------------------------
+
+inert-dec : (c : Coercion) → Dec (Inert c)
+inert-dec (id A) = no (λ ())
+inert-dec (c ︔ d) = no (λ ())
+inert-dec (c ↦ d) = yes (c ↦ d)
+inert-dec (`∀ c) = yes (`∀ c)
+inert-dec (G !) = yes (G !)
+inert-dec (G ？) = no (λ ())
+inert-dec (seal A α) = yes (seal A α)
+inert-dec (unseal α A) = no (λ ())
+inert-dec (gen A c) = yes (gen A c)
+inert-dec (inst B c) = no (λ ())
 
 ∧-trueˡ :
   ∀ {b c} →
@@ -134,6 +146,31 @@ renameᶜ-cong eq (inst B c) =
     (renameᶜ-cong
       (λ { zero → refl ; (suc X) → cong suc (eq X) })
       c)
+
+extᵗ-id :
+  ∀ X →
+  extᵗ (λ Y → Y) X ≡ X
+extᵗ-id zero = refl
+extᵗ-id (suc X) = refl
+
+renameᶜ-id :
+  ∀ c →
+  renameᶜ (λ X → X) c ≡ c
+renameᶜ-id (id A) = cong id (renameᵗ-id A)
+renameᶜ-id (c ︔ d) = cong₂ _︔_ (renameᶜ-id c) (renameᶜ-id d)
+renameᶜ-id (c ↦ d) = cong₂ _↦_ (renameᶜ-id c) (renameᶜ-id d)
+renameᶜ-id (`∀ c) =
+  cong `∀ (trans (renameᶜ-cong extᵗ-id c) (renameᶜ-id c))
+renameᶜ-id (G !) = cong _! (renameᵗ-id G)
+renameᶜ-id (G ？) = cong _？ (renameᵗ-id G)
+renameᶜ-id (seal A α) = cong (λ B → seal B α) (renameᵗ-id A)
+renameᶜ-id (unseal α A) = cong (unseal α) (renameᵗ-id A)
+renameᶜ-id (gen A c) =
+  cong₂ gen (renameᵗ-id A)
+    (trans (renameᶜ-cong extᵗ-id c) (renameᶜ-id c))
+renameᶜ-id (inst B c) =
+  cong₂ inst (renameᵗ-id B)
+    (trans (renameᶜ-cong extᵗ-id c) (renameᶜ-id c))
 
 renameᶜ-compose :
   ∀ ρ τ c →

--- a/GTSF/proof/CompileTermImprecision.agda
+++ b/GTSF/proof/CompileTermImprecision.agda
@@ -430,7 +430,7 @@ compiled-argument-cast-imprecision {pA = pA}
   QTI.up⊑upᵀ
     (QTI.down⊑downᵀ (down⊒ plan) (down⊒ plan′) M⊑M′
       lower⊑lower′)
-    (up⊑ plan) (up⊑ plan′) pA
+    (QTI.quotient-id-widening (up⊑ plan) (up⊑ plan′)) pA
 
 compiled-cast-nat-imprecision :
   ∀ {Φ Δᴸ Δᴿ δ M M′ A A′ p ℓ} →
@@ -484,7 +484,7 @@ compiled-right-dynamic-function-imprecision
         (narrow-mode-relax id-only≤tag-or-idᵈ (down⊒ plan))
         L⊑L′ arrow⊑lower
   in
-  QTI.⊑cast⊑idᵀ storeDetWf-[] seal★-id-only
+  QTI.⊑cast⊑idᵀ seal★-id-only
     (up⊑ plan) L⊑L′↓ (pA IWF.↦ pB)
 
 compiled-dynamic-function-imprecision :

--- a/GTSF/proof/ForallPermutationProperties.agda
+++ b/GTSF/proof/ForallPermutationProperties.agda
@@ -3,6 +3,10 @@ module proof.ForallPermutationProperties where
 -- File Charter:
 --   * Provides structural introduction and congruence lemmas for quotiented
 --     type imprecision.
+--   * Collapses quotiented imprecision to ordinary imprecision when its source
+--     endpoint is ground.
+--   * Exhibits adjacent-binder swapping as a bounded, involutive type-context
+--     permutation.
 --   * Provides ordinary imprecision composition with an `idᵢ` derivation on
 --     the right, as needed when promoting a raw MLB candidate.
 --   * Contains no selector-specific assumptions.
@@ -13,8 +17,9 @@ open import Data.List using (_∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (_<_; zero; suc; z<s; s<s)
 open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality using
-  (_≡_; cong; refl; subst; trans)
+  (_≡_; cong; cong₂; refl; subst; sym; trans)
 
 open import Types
 open import ForallPermutation
@@ -28,7 +33,7 @@ open import proof.CastImprecision using
 open import proof.ImprecisionProperties using
   (idᵢ-no-star; idᵢ-var-identity)
 open import proof.TypeProperties using
-  ( rename-cong; renameᵗ-compose; renameᵗ-id
+  ( TyPermutation; rename-cong; renameᵗ-compose; renameᵗ-id
   ; renameᵗ-preserves-WfTy
   )
 
@@ -114,6 +119,182 @@ mutual
 ≈∀-all-left {B = B} A≈B =
   ≈∀-reflects-all-shape A≈B (B , refl)
 
+mutual
+  ≈∀-arrow-right :
+    ∀ {A B C} →
+    A ⇒ B ≈∀ C →
+    ∃[ A′ ] ∃[ B′ ] C ≡ A′ ⇒ B′
+  ≈∀-arrow-right ≈∀-refl = _ , _ , refl
+  ≈∀-arrow-right (≈∀-sym C≈A⇒B) =
+    ≈∀-arrow-left C≈A⇒B
+  ≈∀-arrow-right (≈∀-trans A⇒B≈C C≈D)
+      with ≈∀-arrow-right A⇒B≈C
+  ≈∀-arrow-right (≈∀-trans A⇒B≈C C≈D)
+      | A′ , B′ , refl =
+    ≈∀-arrow-right C≈D
+  ≈∀-arrow-right
+      (≈∀-⇒ {A′ = A′} {B′ = B′} A≈A′ B≈B′) =
+    A′ , B′ , refl
+
+  ≈∀-arrow-left :
+    ∀ {A B C} →
+    C ≈∀ A ⇒ B →
+    ∃[ A′ ] ∃[ B′ ] C ≡ A′ ⇒ B′
+  ≈∀-arrow-left ≈∀-refl = _ , _ , refl
+  ≈∀-arrow-left (≈∀-sym A⇒B≈C) =
+    ≈∀-arrow-right A⇒B≈C
+  ≈∀-arrow-left (≈∀-trans C≈D D≈A⇒B)
+      with ≈∀-arrow-left D≈A⇒B
+  ≈∀-arrow-left (≈∀-trans C≈D D≈A⇒B)
+      | A′ , B′ , refl =
+    ≈∀-arrow-left C≈D
+  ≈∀-arrow-left
+      (≈∀-⇒ {A = A′} {B = B′} A≈A′ B≈B′) =
+    A′ , B′ , refl
+
+------------------------------------------------------------------------
+-- Ground types are fixed points of forall permutation
+------------------------------------------------------------------------
+
+mutual
+  ≈∀-atom-left-eq :
+    ∀ {A B} →
+    Atom A →
+    A ≈∀ B →
+    A ≡ B
+  ≈∀-atom-left-eq atomA ≈∀-refl = refl
+  ≈∀-atom-left-eq atomA (≈∀-sym B≈A) =
+    sym (≈∀-atom-right-eq atomA B≈A)
+  ≈∀-atom-left-eq atomA (≈∀-trans A≈B B≈C) =
+    trans A≡B (≈∀-atom-left-eq (subst Atom A≡B atomA) B≈C)
+    where
+    A≡B = ≈∀-atom-left-eq atomA A≈B
+  ≈∀-atom-left-eq () (≈∀-⇒ A≈A′ B≈B′)
+  ≈∀-atom-left-eq () (≈∀-∀ A≈B)
+  ≈∀-atom-left-eq () ≈∀-swap
+
+  ≈∀-atom-right-eq :
+    ∀ {A B} →
+    Atom B →
+    A ≈∀ B →
+    A ≡ B
+  ≈∀-atom-right-eq atomB ≈∀-refl = refl
+  ≈∀-atom-right-eq atomB (≈∀-sym B≈A) =
+    sym (≈∀-atom-left-eq atomB B≈A)
+  ≈∀-atom-right-eq atomC (≈∀-trans A≈B B≈C) =
+    trans (≈∀-atom-right-eq atomB A≈B) B≡C
+    where
+    B≡C = ≈∀-atom-right-eq atomC B≈C
+    atomB = subst Atom (sym B≡C) atomC
+  ≈∀-atom-right-eq () (≈∀-⇒ A≈A′ B≈B′)
+  ≈∀-atom-right-eq () (≈∀-∀ A≈B)
+  ≈∀-atom-right-eq () ≈∀-swap
+
+mutual
+  ≈∀-ground-left-eq :
+    ∀ {G H} →
+    Ground G →
+    G ≈∀ H →
+    G ≡ H
+  ≈∀-ground-left-eq gG ≈∀-refl = refl
+  ≈∀-ground-left-eq gG (≈∀-sym H≈G) =
+    sym (≈∀-ground-right-eq gG H≈G)
+  ≈∀-ground-left-eq gG (≈∀-trans G≈H H≈K) =
+    trans G≡H
+      (≈∀-ground-left-eq (subst Ground G≡H gG) H≈K)
+    where
+    G≡H = ≈∀-ground-left-eq gG G≈H
+  ≈∀-ground-left-eq ★⇒★ (≈∀-⇒ A≈A′ B≈B′) =
+    cong₂ _⇒_ (≈∀-atom-left-eq ★ A≈A′)
+      (≈∀-atom-left-eq ★ B≈B′)
+  ≈∀-ground-left-eq () (≈∀-∀ A≈B)
+  ≈∀-ground-left-eq () ≈∀-swap
+
+  ≈∀-ground-right-eq :
+    ∀ {G H} →
+    Ground H →
+    G ≈∀ H →
+    G ≡ H
+  ≈∀-ground-right-eq gH ≈∀-refl = refl
+  ≈∀-ground-right-eq gH (≈∀-sym H≈G) =
+    sym (≈∀-ground-left-eq gH H≈G)
+  ≈∀-ground-right-eq gK (≈∀-trans G≈H H≈K) =
+    trans (≈∀-ground-right-eq gH G≈H) H≡K
+    where
+    H≡K = ≈∀-ground-right-eq gK H≈K
+    gH = subst Ground (sym H≡K) gK
+  ≈∀-ground-right-eq ★⇒★ (≈∀-⇒ A≈A′ B≈B′) =
+    cong₂ _⇒_ (≈∀-atom-right-eq ★ A≈A′)
+      (≈∀-atom-right-eq ★ B≈B′)
+  ≈∀-ground-right-eq () (≈∀-∀ A≈B)
+  ≈∀-ground-right-eq () ≈∀-swap
+
+ground-quotient-target :
+  ∀ {Φ Δᴸ Δᴿ G B′ B} →
+  (gG : Ground G) →
+  (p : Φ ∣ Δᴸ ⊢ G ⊑ B′ ⊣ Δᴿ) →
+  B′ ≈∀ B →
+  Φ ∣ Δᴸ ⊢ G ⊑ B ⊣ Δᴿ
+ground-quotient-target (＇ X) p@(idˣ X⊑Y X<Δᴸ Y<Δᴿ) B′≈B =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+    (≈∀-atom-left-eq (＇ _) B′≈B) p
+ground-quotient-target (＇ X) p@(tagˣ X⊑★ X<Δᴸ) B′≈B =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+    (≈∀-atom-left-eq ★ B′≈B) p
+ground-quotient-target (‵ ι) p@idι B′≈B =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+    (≈∀-atom-left-eq (‵ _) B′≈B) p
+ground-quotient-target (‵ ι) p@(tag ι) B′≈B =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+    (≈∀-atom-left-eq ★ B′≈B) p
+ground-quotient-target ★⇒★ p@(id★ ↦ id★) B′≈B =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+    (≈∀-ground-left-eq ★⇒★ B′≈B) p
+ground-quotient-target ★⇒★ p@(tag id★ ⇛ id★) B′≈B =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+    (≈∀-atom-left-eq ★ B′≈B) p
+
+⊑ᵖ-ground-left :
+  ∀ {Φ Δᴸ Δᴿ G B} →
+  Ground G →
+  Φ ∣ Δᴸ ⊢ G ⊑ᵖ B ⊣ Δᴿ →
+  Φ ∣ Δᴸ ⊢ G ⊑ B ⊣ Δᴿ
+⊑ᵖ-ground-left gG (quotientᵖ G≈G′ G′⊑B′ B′≈B)
+    with ≈∀-ground-left-eq gG G≈G′
+⊑ᵖ-ground-left gG (quotientᵖ G≈G′ G′⊑B′ B′≈B)
+    | refl =
+  ground-quotient-target gG G′⊑B′ B′≈B
+
+⊑ᵖ-star-left-eq :
+  ∀ {Φ Δᴸ Δᴿ B} →
+  Φ ∣ Δᴸ ⊢ ★ ⊑ᵖ B ⊣ Δᴿ →
+  B ≡ ★
+⊑ᵖ-star-left-eq (quotientᵖ ★≈A A⊑B′ B′≈B)
+    with ≈∀-atom-left-eq ★ ★≈A
+⊑ᵖ-star-left-eq (quotientᵖ ★≈A A⊑B′ B′≈B)
+    | refl with A⊑B′
+⊑ᵖ-star-left-eq (quotientᵖ ★≈A A⊑B′ B′≈B)
+    | refl | id★ =
+  sym (≈∀-atom-left-eq ★ B′≈B)
+
+⊑ᵖ-arrow-left-shape :
+  ∀ {Φ Δᴸ Δᴿ A B C} →
+  Φ ∣ Δᴸ ⊢ A ⇒ B ⊑ᵖ C ⊣ Δᴿ →
+  (∃[ A′ ] ∃[ B′ ] C ≡ A′ ⇒ B′) ⊎ C ≡ ★
+⊑ᵖ-arrow-left-shape (quotientᵖ A⇒B≈D D⊑E E≈C)
+    with ≈∀-arrow-right A⇒B≈D
+⊑ᵖ-arrow-left-shape (quotientᵖ A⇒B≈D D⊑E E≈C)
+    | D₁ , D₂ , refl with D⊑E
+⊑ᵖ-arrow-left-shape (quotientᵖ A⇒B≈D D⊑E E≈C)
+    | D₁ , D₂ , refl | p ↦ q
+    with ≈∀-arrow-right E≈C
+⊑ᵖ-arrow-left-shape (quotientᵖ A⇒B≈D D⊑E E≈C)
+    | D₁ , D₂ , refl | p ↦ q | C₁ , C₂ , refl =
+  inj₁ (C₁ , C₂ , refl)
+⊑ᵖ-arrow-left-shape (quotientᵖ A⇒B≈D D⊑E E≈C)
+    | D₁ , D₂ , refl | tag p ⇛ q =
+  inj₂ (sym (≈∀-atom-left-eq ★ E≈C))
+
 ⊑ᵖ-all-representatives :
   ∀ {Φ Δᴸ Δᴿ A B} →
   Φ ∣ Δᴸ ⊢ `∀ A ⊑ᵖ `∀ B ⊣ Δᴿ →
@@ -130,25 +311,42 @@ mutual
   C , D , A≈A′ , A′⊑B′ , B′≈B
 
 data AllImprecisionView
-    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx} {A B : Ty} :
-    (Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ B ⊣ Δᴿ) → Set where
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx} {A : Ty} :
+    ∀ {B} → (Φ ∣ Δᴸ ⊢ `∀ A ⊑ B ⊣ Δᴿ) → Set where
   all-paired :
+    ∀ {C} →
     (p : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ
-      ⊢ A ⊑ B ⊣ suc Δᴿ) →
+      ⊢ A ⊑ C ⊣ suc Δᴿ) →
     AllImprecisionView (∀ⁱ p)
 
   all-source :
+    ∀ {B} →
     (occ : occurs zero A ≡ true) →
     (p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ
-      ⊢ A ⊑ `∀ B ⊣ Δᴿ) →
+      ⊢ A ⊑ B ⊣ Δᴿ) →
     AllImprecisionView (ν occ p)
 
 all-imprecision-view :
   ∀ {Φ Δᴸ Δᴿ A B}
-    (p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ B ⊣ Δᴿ) →
+    (p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ B ⊣ Δᴿ) →
   AllImprecisionView p
 all-imprecision-view (∀ⁱ p) = all-paired p
 all-imprecision-view (ν occ p) = all-source occ p
+
+⊑ᵖ-source-all-view :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ `∀ A ⊑ᵖ B ⊣ Δᴿ →
+  ∃[ C ] ∃[ D ]
+    ((`∀ A ≈∀ `∀ C) ×
+     ∃[ p ] (AllImprecisionView p × (D ≈∀ B)))
+⊑ᵖ-source-all-view
+    (quotientᵖ {B′ = B′} A≈A′ A′⊑B′ B′≈B)
+    with ≈∀-all-right A≈A′
+⊑ᵖ-source-all-view
+    (quotientᵖ {B′ = B′} A≈A′ A′⊑B′ B′≈B)
+    | C , refl =
+  C , B′ , A≈A′ , A′⊑B′ ,
+    all-imprecision-view A′⊑B′ , B′≈B
 
 ⊑ᵖ-all-view :
   ∀ {Φ Δᴸ Δᴿ A B} →
@@ -172,6 +370,18 @@ swap01-pres-< {X = zero} z<s = s<s z<s
 swap01-pres-< {X = suc zero} (s<s z<s) = z<s
 swap01-pres-< {X = suc (suc X)} (s<s (s<s X<Δ)) =
   s<s (s<s X<Δ)
+
+swap01-permutation :
+  ∀ Δ → TyPermutation (suc (suc Δ)) (suc (suc Δ))
+swap01-permutation Δ =
+  record
+    { forward = swap01ᵗ
+    ; backward = swap01ᵗ
+    ; forward-wf = swap01-pres-<
+    ; backward-wf = swap01-pres-<
+    ; backward-forward = swap01-involutive
+    ; forward-backward = swap01-involutive
+    }
 
 swap01-preserves-WfTy :
   ∀ {Δ A} →

--- a/GTSF/proof/MaximalLowerBoundsWf.agda
+++ b/GTSF/proof/MaximalLowerBoundsWf.agda
@@ -1063,6 +1063,50 @@ renameᵗ-swap01-liftᵢ B =
       (λ { zero → refl ; (suc X) → refl })
       B)
 
+swap01ᵢ-after-suc :
+  ∀ X → swap01ᵢ (suc X) ≡ extᵗ suc X
+swap01ᵢ-after-suc zero = refl
+swap01ᵢ-after-suc (suc X) = refl
+
+rename-assm²-congᵢ :
+  ∀ {τ τ′ σ σ′ a} →
+  (∀ X → τ X ≡ τ′ X) →
+  (∀ X → σ X ≡ σ′ X) →
+  rename-assm²ᵢ τ σ a ≡ rename-assm²ᵢ τ′ σ′ a
+rename-assm²-congᵢ {a = X ˣ⊑★} eqτ eqσ =
+  cong (λ Y → Y ˣ⊑★) (eqτ X)
+rename-assm²-congᵢ {a = X ˣ⊑ˣ Y} eqτ eqσ =
+  cong₂ _ˣ⊑ˣ_ (eqτ X) (eqσ Y)
+
+rename-assm²-composeᵢ :
+  ∀ τ σ υ ω a →
+  rename-assm²ᵢ υ ω (rename-assm²ᵢ τ σ a) ≡
+    rename-assm²ᵢ (λ X → υ (τ X)) (λ X → ω (σ X)) a
+rename-assm²-composeᵢ τ σ υ ω (X ˣ⊑★) = refl
+rename-assm²-composeᵢ τ σ υ ω (X ˣ⊑ˣ Y) = refl
+
+rename-assm²-crossed-right∀∀ᵢ :
+  ∀ {Φ a} →
+  a ∈ ∀ᵢᶜ Φ →
+  rename-assm²ᵢ suc (extᵗ suc) a ∈ swapRight∀∀ᵢ Φ
+rename-assm²-crossed-right∀∀ᵢ {a = a} a∈ =
+  subst (_∈ swapRight∀∀ᵢ _)
+    (trans
+      (rename-assm²-composeᵢ suc suc (λ X → X) swap01ᵢ a)
+      (rename-assm²-congᵢ (λ X → refl) swap01ᵢ-after-suc))
+    (rename-assm²-swapRight∀∀ᵢ (rename-assm²-∀ᵢ a∈))
+
+rename-assm²-crossed-left∀∀ᵢ :
+  ∀ {Φ a} →
+  a ∈ ∀ᵢᶜ Φ →
+  rename-assm²ᵢ (extᵗ suc) suc a ∈ swapRight∀∀ᵢ Φ
+rename-assm²-crossed-left∀∀ᵢ {a = a} a∈ =
+  subst (_∈ swapRight∀∀ᵢ _)
+    (trans
+      (rename-assm²-composeᵢ suc suc swap01ᵢ (λ X → X) a)
+      (rename-assm²-congᵢ swap01ᵢ-after-suc (λ X → refl)))
+    (rename-assm²-swapLeft∀∀ᵢ (rename-assm²-∀ᵢ a∈))
+
 renameᵗ-swap01-double-liftᵢ :
   ∀ B →
   renameᵗ swap01ᵢ (⇑ᵗ (⇑ᵗ B)) ≡ ⇑ᵗ (⇑ᵗ B)
@@ -1075,38 +1119,57 @@ renameᵗ-swap01-double-liftᵢ B =
         (rename-cong (λ X → refl) B)
         (sym (renameᵗ-compose suc suc B))))
 
+rename-assm²-crossed-double∀∀ᵢ :
+  ∀ {Φ a} →
+  a ∈ Φ →
+  rename-assm²ᵢ (λ X → suc (suc X)) (λ X → suc (suc X)) a
+    ∈ swapRight∀∀ᵢ Φ
+rename-assm²-crossed-double∀∀ᵢ {a = X ˣ⊑★} a∈ =
+  rename-assm²-swapRight∀∀ᵢ
+    (rename-assm²-∀ᵢ (rename-assm²-∀ᵢ a∈))
+rename-assm²-crossed-double∀∀ᵢ {a = X ˣ⊑ˣ Y} a∈ =
+  rename-assm²-swapRight∀∀ᵢ
+    (rename-assm²-∀ᵢ (rename-assm²-∀ᵢ a∈))
+
 ⊑-crossed-body-lift∀∀ᵢ :
   ∀ {Φ Δᴸ Δᴿ A B} →
   ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
   swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
     ⊢ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B ⊣ suc (suc Δᴿ)
-⊑-crossed-body-lift∀∀ᵢ {B = B} p =
-  subst
-    (λ T → _ ∣ _ ⊢ ⇑ᵗ _ ⊑ T ⊣ _)
-    (renameᵗ-swap01-liftᵢ B)
-    (⊑-swapRight01∀∀ᵢ (⊑-lift∀ᵢ p))
+⊑-crossed-body-lift∀∀ᵢ p =
+  ⊑-renameᵗ²ᵢ
+    rename-assm²-crossed-right∀∀ᵢ
+    (λ X<Δ → s<s X<Δ)
+    (TyRenameWf-ext (λ X<Δ → s<s X<Δ)) p
 
 ⊑-crossed-left-body-lift∀∀ᵢ :
   ∀ {Φ Δᴸ Δᴿ A B} →
   ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
   swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
     ⊢ renameᵗ (extᵗ suc) A ⊑ ⇑ᵗ B ⊣ suc (suc Δᴿ)
-⊑-crossed-left-body-lift∀∀ᵢ {A = A} p =
-  subst
-    (λ T → _ ∣ _ ⊢ T ⊑ ⇑ᵗ _ ⊣ _)
-    (renameᵗ-swap01-liftᵢ A)
-    (⊑-swapLeft01∀∀ᵢ (⊑-lift∀ᵢ p))
+⊑-crossed-left-body-lift∀∀ᵢ p =
+  ⊑-renameᵗ²ᵢ
+    rename-assm²-crossed-left∀∀ᵢ
+    (TyRenameWf-ext (λ X<Δ → s<s X<Δ))
+    (λ X<Δ → s<s X<Δ) p
 
 ⊑-crossed-double-lift∀∀ᵢ :
   ∀ {Φ Δᴸ Δᴿ A B} →
   Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
   swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
     ⊢ ⇑ᵗ (⇑ᵗ A) ⊑ ⇑ᵗ (⇑ᵗ B) ⊣ suc (suc Δᴿ)
-⊑-crossed-double-lift∀∀ᵢ {B = B} p =
+⊑-crossed-double-lift∀∀ᵢ {A = A} {B = B} p =
   subst
-    (λ T → _ ∣ _ ⊢ ⇑ᵗ (⇑ᵗ _) ⊑ T ⊣ _)
-    (renameᵗ-swap01-double-liftᵢ B)
-    (⊑-swapRight01∀∀ᵢ (⊑-lift∀ᵢ (⊑-lift∀ᵢ p)))
+    (λ T → _ ∣ _ ⊢ ⇑ᵗ (⇑ᵗ A) ⊑ T ⊣ _)
+    (sym (renameᵗ-compose suc suc B))
+    (subst
+      (λ S → _ ∣ _ ⊢ S ⊑
+        renameᵗ (λ X → suc (suc X)) B ⊣ _)
+      (sym (renameᵗ-compose suc suc A))
+      (⊑-renameᵗ²ᵢ
+        rename-assm²-crossed-double∀∀ᵢ
+        (λ X<Δ → s<s (s<s X<Δ))
+        (λ X<Δ → s<s (s<s X<Δ)) p))
 
 rename-assm²-swap∀∀ᵢ :
   ∀ {Φ a} →

--- a/GTSF/proof/NuDGGTraceAlignment.agda
+++ b/GTSF/proof/NuDGGTraceAlignment.agda
@@ -14,7 +14,7 @@ open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import NuReduction using (_—↠[_]_)
 open import NuTermImprecision using (StoreImp)
 open import NuTerms using (Term; Value; blame)
-open import proof.NuImprecisionSimulation using
+open import proof.NuImprecisionSimulationCore using
   ( WeakOneStepOutcome
   ; WeakOneStepResult
   ; outcome-related
@@ -61,9 +61,11 @@ weak-outcome-target-value-alignedᵀ :
       ((targetResult result —↠[ θs ] V) ×
         (ψs ≡ targetTailChanges result ++ θs)))
   ⊎ ∃[ χs ] (M —↠[ χs ] blame)
-weak-outcome-target-value-alignedᵀ (outcome-related result) N′↠V vV
+weak-outcome-target-value-alignedᵀ
+    (outcome-related result transport coherence) N′↠V vV
   with weak-result-target-prefix-valueᵀ result N′↠V vV
-weak-outcome-target-value-alignedᵀ (outcome-related result) N′↠V vV
+weak-outcome-target-value-alignedᵀ
+    (outcome-related result transport coherence) N′↠V vV
   | θs , result↠V , trace-eq =
     inj₁ (result , θs , result↠V , trace-eq)
 weak-outcome-target-value-alignedᵀ
@@ -80,9 +82,11 @@ weak-outcome-target-blame-alignedᵀ :
       ((targetResult result —↠[ θs ] blame) ×
         (ψs ≡ targetTailChanges result ++ θs)))
   ⊎ ∃[ χs ] (M —↠[ χs ] blame)
-weak-outcome-target-blame-alignedᵀ (outcome-related result) N′↠blame
+weak-outcome-target-blame-alignedᵀ
+    (outcome-related result transport coherence) N′↠blame
   with weak-result-target-prefix-blameᵀ result N′↠blame
-weak-outcome-target-blame-alignedᵀ (outcome-related result) N′↠blame
+weak-outcome-target-blame-alignedᵀ
+    (outcome-related result transport coherence) N′↠blame
   | θs , result↠blame , trace-eq =
     inj₁ (result , θs , result↠blame , trace-eq)
 weak-outcome-target-blame-alignedᵀ

--- a/GTSF/proof/NuImprecisionAllocationSimulation.agda
+++ b/GTSF/proof/NuImprecisionAllocationSimulation.agda
@@ -1,0 +1,3157 @@
+module proof.NuImprecisionAllocationSimulation where
+
+-- File Charter:
+--   * Collects completed synchronized, left-only, and right-only allocation
+--     simulations after the universal catch-up layer.
+--   * Covers ordinary `ν`, `ν ★`, `inst`, post-allocation `β-Λ•`, and
+--     post-allocation `β-gen•` boundaries.
+--   * Depends on `NuImprecisionSimulationCore` and
+--     `NuImprecisionSimulation`; it is kept separate so these stable cases
+--     can be cached while active catch-up work changes.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (true)
+open import Data.List using ([]; _∷_; _++_; map)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Nat using (zero; suc; z<s; s<s)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using
+  (cong; cong₂; subst; sym; trans)
+import Relation.Binary.HeterogeneousEquality as HE
+
+open import Types
+open import Ctx using (⤊ᵗ)
+open import Coercions using
+  ( Coercion
+  ; ModeIncl
+  ; ModeEnv
+  ; Mode
+  ; id-only
+  ; tag-or-id
+  ; seal-or-id
+  ; mode≤
+  ; extᵈ
+  ; gen
+  ; genᵈ
+  ; id-onlyᵈ
+  ; id-only≤tag-or-idᵈ
+  ; inst
+  ; instᵈ
+  ; renameᶜ
+  ; sealModeAllowed
+  ; tag-or-idᵈ
+  ; `∀
+  ; ⇑ᶜ
+  ; _[_]ᶜ
+  )
+open import Conversion using
+  ( ConcealConversion
+  ; RevealConversion
+  ; conceal-all
+  ; open-conceal-conversion
+  ; open-reveal-conversion
+  ; reveal-all
+  ; rename-reveal-conversion
+  ; rename-conceal-conversion
+  ; weaken-conceal-conversion
+  ; weaken-reveal-conversion
+  )
+open import ForallPermutation using
+  ( _≈∀_
+  ; quotientᵖ
+  ; swap01ᵗ
+  ; ≈∀-refl
+  ; ≈∀-sym
+  ; ≈∀-trans
+  ; ≈∀-⇒
+  ; ≈∀-∀
+  ; ≈∀-swap
+  ; _∣_⊢_⊑ᵖ_⊣_
+  )
+open import ImprecisionWf
+open import NarrowWiden using
+  ( narrow-mode-relax
+  ; narrow-renameᵗ
+  ; narrow-weaken
+  ; widen-mode-relax
+  ; widen-renameᵗ
+  ; widen-weaken
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+import Coercions as C
+import NarrowWiden as NW
+open import NuReduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyCoercion
+  ; applyStore
+  ; applyStores
+  ; applyCoercionUnderTyBinder
+  ; applyTerm
+  ; applyTerms
+  ; applyTy
+  ; applyTyCtx
+  ; applyTyCtxs
+  ; applyTys
+  ; bind
+  ; blame-·₁
+  ; blame-·₂
+  ; blame-⟨⟩
+  ; blame-ν
+  ; keep
+  ; β-gen•
+  ; β-inst
+  ; β-Λ•
+  ; β-∀•
+  ; pure-step
+  ; ν-step
+  ; ξ-⟨⟩
+  ; ξ-ν
+  ; ↠-refl
+  ; ↠-step
+  ; _—→[_]_
+  ; _—↠[_]_
+  )
+open import NuTerms using
+  ( No•
+  ; RuntimeOK
+  ; no•-`
+  ; no•-ƛ
+  ; no•-·
+  ; no•-Λ
+  ; no•-ν
+  ; no•-$
+  ; no•-⊕
+  ; no•-⟨⟩
+  ; no•-blame
+  ; ok-no
+  ; ok-•
+  ; ok-·₁
+  ; ok-·₂
+  ; ok-ν
+  ; ok-⊕₁
+  ; ok-⊕₂
+  ; ok-⟨⟩
+  ; blame
+  ; Term
+  ; Value
+  ; `_
+  ; ƛ_
+  ; _·_
+  ; Λ_
+  ; ν
+  ; renameᵗᵐ
+  ; ⇑ᵗᵐ
+  ; _•
+  ; $
+  ; _⊕[_]_
+  ; _⟨_⟩
+  )
+open import Primitives using (κℕ; addℕ)
+open import NuStore using (StoreWf)
+open import NuTermImprecision using
+  ( StoreImp
+  ; StoreImpEntry
+  ; StoreCorresponds
+  ; correspondence-stored
+  ; correspondence-linked
+  ; CtxImp
+  ; ctx-imp
+  ; LiftStoreⁱ
+  ; lift-store-[]
+  ; lift-store-∷
+  ; lift-store-left
+  ; lift-store-right
+  ; lift-store-link
+  ; LiftLeftStoreⁱ
+  ; lift-left-store-[]
+  ; lift-left-store-∷
+  ; lift-left-store-left
+  ; lift-left-store-right
+  ; lift-left-store-link
+  ; LiftRightStoreⁱ
+  ; lift-right-store-[]
+  ; lift-right-store-∷
+  ; lift-right-store-left
+  ; lift-right-store-right
+  ; lift-right-store-link
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; leftStoreⁱ-lift
+  ; rightStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightStoreⁱ-lift-left
+  ; leftStoreⁱ-lift-right
+  ; rightStoreⁱ-lift-right
+  ; LiftCtxⁱ
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; LiftLeftCtxⁱ
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  ; LiftRightCtxⁱ
+  ; lift-right-ctx-[]
+  ; lift-right-ctx-∷
+  ; leftCtxⁱ
+  ; rightCtxⁱ
+  ; leftCtxⁱ-lift
+  ; rightCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; rightCtxⁱ-lift-left
+  ; leftCtxⁱ-lift-right
+  ; rightCtxⁱ-lift-right
+  ; store-matched
+  ; store-left
+  ; store-right
+  ; store-link
+  ; crossedStoreⁱ
+  ; crossedStoreⁱ-new-old
+  ; crossedStoreⁱ-old-new
+  )
+open import QuotientedTermImprecision
+open import Store using (StoreIncl; StoreIncl-drop; StoreIncl-refl)
+open import TermTyping using
+  ( CastMode
+  ; SealModeStore★
+  ; cast-ext
+  ; cast-gen
+  ; cast-inst
+  ; cast-tag-or-id
+  ; cast-weaken
+  ; weakenCastᵈ
+  ; forget
+  ; _∣_∣_⊢_⦂_
+  ; ⊢•
+  ; ⊢⟨⟩↑
+  )
+open import proof.CastImprecision using
+  ( RightCastCtxCompatible
+  ; seal★-ext-shift
+  ; seal★-gen-shift
+  ; widening⇒⊑ᵢ
+  ; ⊑-transʳ-castᵢ
+  )
+open import proof.MaximalLowerBoundsWf using
+  ( ∀ᵢᶜ
+  ; rename-assm²ᵢ
+  ; rename-assm²-composeᵢ
+  ; rename-assm²-congᵢ
+  ; rename-assm²-∀ᵢ
+  ; rename-assm²-crossed-left∀∀ᵢ
+  ; rename-assm²-crossed-right∀∀ᵢ
+  ; rename-assm²-crossed-double∀∀ᵢ
+  ; rename-assm²-⇑ᵢ
+  ; rename-assm²-⇑ᴸᵢ
+  ; rename-assm²-source-νᵢ
+  ; rename-assm²-swapLeft∀∀ᵢ
+  ; rename-assm²-swapRight∀∀ᵢ
+  ; rename-assm²-target-rightᵢ
+  ; ⊑-renameᵗ²ᵢ
+  ; ⊑-crossed-body-lift∀∀ᵢ
+  ; ⊑-crossed-left-body-lift∀∀ᵢ
+  ; ⊑-crossed-double-lift∀∀ᵢ
+  ; ⊑-lift∀ᵢ
+  ; ⊑-open∀ᵢ
+  ; ⊑-source-liftνᵢ
+  ; ⊑-ν∀-to-∀νᵢ
+  ; ⊑-swapLeft01∀∀ᵢ
+  ; ⊑-swapRight01∀∀ᵢ
+  ; ⊑-target-lift-rightᵢ
+  ; swap01ᵢ
+  ; swap01ᵢ-after-suc
+  )
+open import proof.MediationProperties using (wfTy-applyTys)
+open import proof.ForallPermutationProperties using
+  ( ≈∀-double-swap
+  ; ≈∀-double-swap-sym
+  ; ⊑→⊑ᵖ
+  )
+open import proof.NarrowWidenProperties using
+  ( StoreDetWf
+  ; allocate-all-narrowing
+  ; allocate-all-widening
+  ; allocate-gen-narrowing
+  ; open-all-narrowing
+  ; open-all-widening
+  )
+open import proof.NuTermProperties using
+  ( modeRename-left-inverse
+  ; open0-ext-suc-cancelᵐ
+  ; renameStoreᵗ-ext-suc-cons-comm
+  ; renameᵗᵐ-compose
+  ; renameᵗᵐ-cong
+  ; renameᵗᵐ-ext-suc-comm
+  ; renameᵗᵐ-id
+  ; renameᵗᵐ-preserves-No•
+  ; renameᵗᵐ-preserves-Value
+  )
+open import proof.NuProgress using
+  ( AllView
+  ; av-Λ
+  ; av-∀
+  ; av-gen
+  ; canonical-∀
+  ; runtime-value-no•
+  )
+open import proof.NuPreservation using
+  ( runtime-ν
+  ; runtime-⟨⟩
+  ; value-no-step
+  )
+open import proof.ReductionProperties using
+  ( applyCoercions
+  ; applyCoercions-inst
+  ; applyCoercions-preserves-Inert
+  ; applyCoercionUnderTyBinders
+  ; applyTerm-preserves-No•
+  ; applyTerm-preserves-Value
+  ; applyTerms-++
+  ; applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyStores-++
+  ; applyTy-∀
+  ; applyTyUnderTyBinder
+  ; applyTyCtxs-++
+  ; applyTysUnderTyBinders
+  ; applyTysUnderTyBinders-++
+  ; applyTys-++
+  ; applyTys-★
+  ; applyTys-∀
+  ; cast-↠
+  ; ·₁-↠
+  ; ·₂-↠
+  ; ν-↠
+  ; ↠-trans
+  )
+open import proof.LeftChangeNarrowingSeparated using
+  (applyTys-⇒)
+open import proof.CoercionProperties using
+  ( ModeIncl-ext
+  ; ModeIncl-gen
+  ; ModeIncl-inst
+  ; ModeRename
+  ; open0-ext-suc-cancelᶜ
+  )
+open import proof.TypePreservation using
+  ( applyNarrow-typing
+  ; applyWiden-typing
+  ; applyWidenInstUnderTyBinder-typing
+  ; CastModeRenamer
+  ; castModeRenamer-ext
+  ; castModeRenamer-seal★
+  ; seal★-inst
+  ; seal★-weaken
+  ; castModeRenamer-suc
+  ; modeRename-suc-weakenCast
+  ; preservation
+  ; term-weaken
+  ; typing-renameᵀ
+  )
+open import proof.StoreProperties using
+  (∈-renameStoreᵗ; renameStoreᵗ-incl)
+open import proof.TypeProperties using
+  ( RenameLeftInverse
+  ; RenameLeftInverse-ext
+  ; RenameLeftInverse-ext-suc-pred
+  ; RenameLeftInverse-suc
+  ; TyPermutation
+  ; TyPermutation-ext
+  ; TyRenameWf
+  ; TyRenameWf-ext
+  ; TyRenameWf-suc
+  ; backward
+  ; backward-forward
+  ; forward
+  ; forward-backward
+  ; forward-wf
+  ; predᵗ
+  ; occurs-zero-rename-ext
+  ; rename-cong
+  ; renameᵗ-compose
+  ; renameᵗ-ext-suc-comm
+  ; renameᵗ-id
+  ; renameᵗ-preserves-WfTy
+  ; renameStoreᵗ-compose
+  ; renameStoreᵗ-ext-suc-comm
+  )
+
+open import proof.NuImprecisionSimulationCore
+open import proof.NuImprecisionSimulation
+
+------------------------------------------------------------------------
+-- Synchronized polymorphic allocation
+------------------------------------------------------------------------
+
+matched-ν↑-allocation :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  (ν A N s —→[ bind A ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (ν A′ N′ s′ —→[ bind A′ ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′) A⇑⊑A′⇑ ∷ ρ′
+    ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-ν↑-allocation {q = q} vN noN vN′ noN′ s↑ s′↑ pB
+    A⇑⊑A′⇑ liftρ N⊑N′ =
+  ν-step vN noN ,
+  ν-step vN′ noN′ ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal (correspondence-stored (here refl))
+        left-reveal right-reveal))
+    (α⊑αᵀ vN noN vN′ noN′ A⇑⊑A′⇑ liftρ lift-ctx-[]
+      N⊑N′ left-bullet-typing right-bullet-typing)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift liftρ))
+        s↑
+
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (rightStoreⁱ-lift liftρ))
+        s′↑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-tgt-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-matched-ν↑ᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ N′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑ᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    with matched-ν↑-allocation vN noN vN′ noN′ s↑ s′↑
+      pB A⇑⊑A′⇑ liftρ N⊑N′
+weak-one-step-matched-ν↑ᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    | source→ , _ , result =
+  record
+    { sourceChanges = bind A ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore =
+        store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′)
+          A⇑⊑A′⇑ ∷ ρ′
+    ; resultSourceType = ⇑ᵗ B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-lift∀ᵢ
+    ; transportAllBody = ⊑-lift-under-∀ᵢ
+    ; transportRightBody = ⊑-lift-under-rightᵢ
+    ; resultType = ⊑-lift∀ᵢ pB
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult =
+        cong ((zero , ⇑ᵗ A) ∷_) (leftStoreⁱ-lift liftρ)
+    ; targetStoreResult =
+        cong ((zero , ⇑ᵗ A′) ∷_) (rightStoreⁱ-lift liftρ)
+    ; relatedResults = result
+    }
+
+weak-one-step-matched-ν↑-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  (vN : Value N) →
+  (noN : No• N) →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  (liftρ : LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  WeakOneStepTransport
+    (weak-one-step-matched-ν↑ᵀ
+      vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′)
+weak-one-step-matched-ν↑-transportᵀ
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    with matched-ν↑-allocation
+      vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+weak-one-step-matched-ν↑-transportᵀ
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-transport
+    (matched-lift-prefix-bodyᵀ liftρ (prefix-∷ⁱ prefix-reflⁱ))
+
+weak-one-step-matched-ν↑-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  (vN : Value N) →
+  (noN : No• N) →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  (liftρ : LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-ν↑ᵀ
+      vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′)
+weak-one-step-matched-ν↑-type-coherenceᵀ
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    with matched-ν↑-allocation
+      vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+weak-one-step-matched-ν↑-type-coherenceᵀ
+    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-type-coherence (λ pC pD → refl) (λ q′ → refl)
+
+weak-one-step-matched-ν↑-value-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  Value (sourceResult (weakResult (catchupAllResult catchup))) →
+  No• (sourceResult (weakResult (catchupAllResult catchup))) →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW =
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent
+      (weak-one-step-matched-ν-frameᵀ
+        s↑ s′↑ pA pB (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-ν↑ᵀ
+      vW noW vV′ noV′ source↑ target↑
+      (transportType inner pB)
+      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
+  where
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source↑ = proj₂ (weak-result-source-reveal inner s↑)
+  target↑ = proj₂ (weak-result-target-reveal keep inner s′↑)
+
+weak-one-step-matched-ν↑-value-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (vW : Value
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  (noW : No•
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  WeakOneStepTransport (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTransport
+    (weak-one-step-matched-ν↑-value-catchupᵀ
+      s↑ s′↑ pA pB vV′ noV′ catchup vW noW)
+weak-one-step-matched-ν↑-value-catchup-transportᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW inner-transport =
+  weak-one-step-prepend-left-silent-preserves-transportᵀ
+    (left-silent
+      (weak-one-step-matched-ν-frameᵀ
+        s↑ s′↑ pA pB (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-ν↑ᵀ
+      vW noW vV′ noV′ source↑ target↑
+      (transportType inner pB)
+      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
+    (weak-one-step-matched-ν-frame-preserves-transportᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+      inner-transport)
+    (weak-one-step-matched-ν↑-transportᵀ
+      vW noW vV′ noV′ source↑ target↑
+      (transportType inner pB)
+      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
+  where
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source↑ = proj₂ (weak-result-source-reveal inner s↑)
+  target↑ = proj₂ (weak-result-target-reveal keep inner s′↑)
+
+weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (vW : Value
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  (noW : No•
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  WeakOneStepTypeCoherence (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-ν↑-value-catchupᵀ
+      s↑ s′↑ pA pB vV′ noV′ catchup vW noW)
+weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ
+    s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW inner-coherence =
+  weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+    (left-silent
+      (weak-one-step-matched-ν-frameᵀ
+        s↑ s′↑ pA pB (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-ν↑ᵀ
+      vW noW vV′ noV′ source↑ target↑
+      (transportType inner pB)
+      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
+    (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+      inner-coherence)
+    (weak-one-step-matched-ν↑-type-coherenceᵀ
+      vW noW vV′ noV′ source↑ target↑
+      (transportType inner pB)
+      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
+  where
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source↑ = proj₂ (weak-result-source-reveal inner s↑)
+  target↑ = proj₂ (weak-result-target-reveal keep inner s′↑)
+
+weak-one-step-matched-ν↑-blame-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  sourceResult (weakResult (catchupAllResult catchup)) ≡ blame →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl
+    with silent
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+weak-one-step-matched-ν↑-blame-catchupᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    | μᵣ , source↑ | μᵗ , target↑ =
+  let
+    first = weak-one-step-matched-ν-frameᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      {A = applyTys (sourceChanges inner) A}
+      {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′
+      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+      target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent first (left-silent-invariant refl refl)) second
+
+weak-one-step-matched-ν↑-blame-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (eq-blame :
+    sourceResult (weakResult (catchupAllResult catchup)) ≡ blame) →
+  WeakOneStepTransport (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTransport
+    (weak-one-step-matched-ν↑-blame-catchupᵀ
+      wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame)
+weak-one-step-matched-ν↑-blame-catchup-transportᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport
+    with silent
+weak-one-step-matched-ν↑-blame-catchup-transportᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν↑-blame-catchup-transportᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport | left-silent-invariant refl refl
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+weak-one-step-matched-ν↑-blame-catchup-transportᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport | left-silent-invariant refl refl
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  let
+    first = weak-one-step-matched-ν-frameᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      {A = applyTys (sourceChanges inner) A}
+      {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′
+      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+      target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silent-preserves-transportᵀ
+    (left-silent first (left-silent-invariant refl refl))
+    second
+    (weak-one-step-matched-ν-frame-preserves-transportᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+      inner-transport)
+    (weak-one-step-source-blame-right-allocation-transportᵀ
+      {A = applyTys (sourceChanges inner) A}
+      {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′
+      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+      target⊢ (transportType inner pB))
+
+weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (eq-blame :
+    sourceResult (weakResult (catchupAllResult catchup)) ≡ blame) →
+  WeakOneStepTypeCoherence (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-ν↑-blame-catchupᵀ
+      wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame)
+weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence
+    with silent
+weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence | left-silent-invariant refl refl
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence | left-silent-invariant refl refl
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  let
+    first = weak-one-step-matched-ν-frameᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      {A = applyTys (sourceChanges inner) A}
+      {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′
+      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+      target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+    (left-silent first (left-silent-invariant refl refl))
+    second
+    (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll)
+      inner-coherence)
+    (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+      {A = applyTys (sourceChanges inner) A}
+      {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′
+      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+      target⊢ (transportType inner pB))
+
+weak-one-step-matched-ν↑-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepResult ρ
+    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-matched-ν↑-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-ν↑-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
+    | inj₁ (vW , noW) =
+  weak-one-step-matched-ν↑-value-catchupᵀ
+    s↑ s′↑ pA pB vV′ noV′ catchup vW noW
+weak-one-step-matched-ν↑-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
+    | inj₂ eq-blame =
+  weak-one-step-matched-ν↑-blame-catchupᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame
+
+weak-one-step-matched-ν↑-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepTransport (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTransport
+    (weak-one-step-matched-ν↑-catchupᵀ
+      wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup)
+weak-one-step-matched-ν↑-catchup-transportᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup transport
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-ν↑-catchup-transportᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup transport
+    | inj₁ (vW , noW) =
+  weak-one-step-matched-ν↑-value-catchup-transportᵀ
+    s↑ s′↑ pA pB vV′ noV′ catchup vW noW transport
+weak-one-step-matched-ν↑-catchup-transportᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup transport
+    | inj₂ eq-blame =
+  weak-one-step-matched-ν↑-blame-catchup-transportᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame
+    transport
+
+weak-one-step-matched-ν↑-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepTypeCoherence (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-ν↑-catchupᵀ
+      wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup)
+weak-one-step-matched-ν↑-catchup-type-coherenceᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup coherence
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-ν↑-catchup-type-coherenceᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup coherence
+    | inj₁ (vW , noW) =
+  weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ
+    s↑ s′↑ pA pB vV′ noV′ catchup vW noW coherence
+weak-one-step-matched-ν↑-catchup-type-coherenceᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup coherence
+    | inj₂ eq-blame =
+  weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame
+    coherence
+
+weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup : LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepIndexedOutcome
+    {M = ν A N s}
+    {N′ = ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩}
+    {A = B} {B = B′} {χ = bind A′} {ρ = ρ} pB
+weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    with final
+weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₁ (vW , noW) =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result type-eq)
+    transport coherence
+  where
+  old-catchup = left-all-catchup
+    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+  result =
+    weak-one-step-matched-ν↑-value-catchupᵀ
+      s↑ s′↑ pA pB vV′ noV′ old-catchup vW noW
+
+  inner = weakResult (catchupAllResult old-catchup)
+  innerAll = canonicalAllResults (catchupAllResult old-catchup)
+  first = weak-one-step-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (catchupAllResult old-catchup)
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source↑ = proj₂ (weak-result-source-reveal inner s↑)
+  target↑ = proj₂ (weak-result-target-reveal keep inner s′↑)
+  second = weak-one-step-matched-ν↑ᵀ
+    vW noW vV′ noV′ source↑ target↑
+    (transportType inner pB)
+    (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll
+
+  type-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx result ∣ resultLeftCtx result
+          ⊢ S ⊑ T ⊣ resultRightCtx result}
+        (sourceTypeResult result)
+        (targetTypeResult result)
+        (resultType result))
+      (HE.sym (weak-one-step-compose-type-to-nested≅
+        first second pB)))
+
+  transport =
+    weak-one-step-matched-ν↑-value-catchup-transportᵀ
+      s↑ s′↑ pA pB vV′ noV′ old-catchup vW noW
+      inner-transport
+
+  coherence =
+    weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ
+      s↑ s′↑ pA pB vV′ noV′ old-catchup vW noW
+      inner-coherence
+weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {s = s} {s′ = s′}
+    wfΣ′ s↑ s′↑ pA pB vV′ noV′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₂ refl =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result type-eq)
+    transport coherence
+  where
+  old-catchup = left-all-catchup
+    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+  inner = weakResult (catchupAllResult old-catchup)
+  first = weak-one-step-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (catchupAllResult old-catchup)
+  target⊢ = nu-term-imprecision-target-typing (relatedResults first)
+  second = weak-one-step-source-blame-right-allocationᵀ
+    {A = applyTys (sourceChanges inner) A}
+    {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
+    {B = applyTys (sourceChanges inner) B}
+    {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+    {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+    {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+      (applyCoercionUnderTyBinder keep s′)}
+    {ρ = resultStore inner}
+    (weak-result-right-wf-silent inner
+      (left-silent-invariant refl refl) wfΣ′)
+    vV′ noV′
+    (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+    target⊢ (transportType inner pB)
+
+  result =
+    weak-one-step-prepend-left-silentᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+
+  type-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx result ∣ resultLeftCtx result
+          ⊢ S ⊑ T ⊣ resultRightCtx result}
+        (sourceTypeResult result)
+        (targetTypeResult result)
+        (resultType result))
+      (HE.sym (weak-one-step-compose-type-to-nested≅
+        first second pB)))
+
+  transport =
+    weak-one-step-prepend-left-silent-preserves-transportᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      (weak-one-step-matched-ν-frame-preserves-transportᵀ
+        s↑ s′↑ pA pB (catchupAllResult old-catchup)
+        inner-transport)
+      (weak-one-step-source-blame-right-allocation-transportᵀ
+        {A = applyTys (sourceChanges inner) A}
+        {A′ = applyTys (targetTailChanges inner)
+          (applyTy keep A′)}
+        {B = applyTys (sourceChanges inner) B}
+        {B′ = applyTys (targetTailChanges inner)
+          (applyTy keep B′)}
+        {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+        {s′ = applyCoercionUnderTyBinders
+          (targetTailChanges inner)
+          (applyCoercionUnderTyBinder keep s′)}
+        {ρ = resultStore inner}
+        (weak-result-right-wf-silent inner
+          (left-silent-invariant refl refl) wfΣ′)
+        vV′ noV′
+        (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+        target⊢ (transportType inner pB))
+
+  coherence =
+    weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+        s↑ s′↑ pA pB (catchupAllResult old-catchup)
+        inner-coherence)
+      (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+        {A = applyTys (sourceChanges inner) A}
+        {A′ = applyTys (targetTailChanges inner)
+          (applyTy keep A′)}
+        {B = applyTys (sourceChanges inner) B}
+        {B′ = applyTys (targetTailChanges inner)
+          (applyTy keep B′)}
+        {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+        {s′ = applyCoercionUnderTyBinders
+          (targetTailChanges inner)
+          (applyCoercionUnderTyBinder keep s′)}
+        {ρ = resultStore inner}
+        (weak-result-right-wf-silent inner
+          (left-silent-invariant refl refl) wfΣ′)
+        vV′ noV′
+        (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
+        target⊢ (transportType inner pB))
+
+------------------------------------------------------------------------
+-- Synchronized `inst` allocation
+------------------------------------------------------------------------
+
+matched-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  (ν ★ N s —→[ bind ★ ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (ν ★ N′ s′ —→[ bind ★ ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero ★ zero ★ id★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-νcast-allocation {q = q} vN noN vN′ noN′ mode seal★ mode′
+    seal★′ s⊑ s′⊑ pB liftρ N⊑N′ =
+  ν-step vN noN ,
+  ν-step vN′ noN′ ,
+  conv⊑convᵀ
+    (paired-widening
+      (cast-inst mode) left-seal left-widening
+      (cast-inst mode′) right-seal right-widening)
+    (α⊑αᵀ vN noN vN′ noN′ id★ liftρ lift-ctx-[] N⊑N′
+      left-bullet-typing right-bullet-typing)
+  where
+    left-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (leftStoreⁱ-lift liftρ))
+        seal★
+
+    right-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (rightStoreⁱ-lift liftρ))
+        seal★′
+
+    left-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        s⊑
+
+    right-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        s′⊑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (⊢• refl refl (⊑-tgt-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-matched-νcastᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ N′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
+    pB liftρ N⊑N′
+    with matched-νcast-allocation
+      vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
+      pB liftρ N⊑N′
+weak-one-step-matched-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
+    pB liftρ N⊑N′
+    | source→ , _ , result =
+  record
+    { sourceChanges = bind ★ ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-matched zero ★ zero ★ id★ ∷ ρ′
+    ; resultSourceType = ⇑ᵗ B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-lift∀ᵢ
+    ; transportAllBody = ⊑-lift-under-∀ᵢ
+    ; transportRightBody = ⊑-lift-under-rightᵢ
+    ; resultType = ⊑-lift∀ᵢ pB
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult =
+        cong ((zero , ★) ∷_) (leftStoreⁱ-lift liftρ)
+    ; targetStoreResult =
+        cong ((zero , ★) ∷_) (rightStoreⁱ-lift liftρ)
+    ; relatedResults = result
+    }
+
+weak-one-step-matched-νcast-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  (vN : Value N) →
+  (noN : No• N) →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (liftρ : LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  WeakOneStepTransport
+    (weak-one-step-matched-νcastᵀ
+      vN noN vN′ noN′ mode seal★ mode′ seal★′
+      s⊑ s′⊑ pB liftρ N⊑N′)
+weak-one-step-matched-νcast-transportᵀ
+    vN noN vN′ noN′ mode seal★ mode′ seal★′
+    s⊑ s′⊑ pB liftρ N⊑N′
+    with matched-νcast-allocation
+      vN noN vN′ noN′ mode seal★ mode′ seal★′
+      s⊑ s′⊑ pB liftρ N⊑N′
+weak-one-step-matched-νcast-transportᵀ
+    vN noN vN′ noN′ mode seal★ mode′ seal★′
+    s⊑ s′⊑ pB liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-transport
+    (matched-lift-prefix-bodyᵀ liftρ (prefix-∷ⁱ prefix-reflⁱ))
+
+weak-one-step-matched-νcast-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  (vN : Value N) →
+  (noN : No• N) →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (liftρ : LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-νcastᵀ
+      vN noN vN′ noN′ mode seal★ mode′ seal★′
+      s⊑ s′⊑ pB liftρ N⊑N′)
+weak-one-step-matched-νcast-type-coherenceᵀ
+    vN noN vN′ noN′ mode seal★ mode′ seal★′
+    s⊑ s′⊑ pB liftρ N⊑N′
+    with matched-νcast-allocation
+      vN noN vN′ noN′ mode seal★ mode′ seal★′
+      s⊑ s′⊑ pB liftρ N⊑N′
+weak-one-step-matched-νcast-type-coherenceᵀ
+    vN noN vN′ noN′ mode seal★ mode′ seal★′
+    s⊑ s′⊑ pB liftρ N⊑N′ | source→ , target→ , result =
+  weak-step-type-coherence (λ pC pD → refl) (λ q′ → refl)
+
+weak-one-step-matched-νcast-value-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  Value (sourceResult (weakResult (catchupAllResult catchup))) →
+  No• (sourceResult (weakResult (catchupAllResult catchup))) →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW =
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent
+      (weak-one-step-matched-νcast-frameᵀ
+        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+        (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-νcastᵀ
+      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
+  where
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source = weak-result-source-widen-inst inner mode seal★ s⊑
+  modeˢ = proj₁ (proj₂ source)
+  sealˢ = proj₁ (proj₂ (proj₂ source))
+  source⊑ = proj₂ (proj₂ (proj₂ source))
+  target = weak-result-target-widen-inst
+    keep inner mode′ seal★′ s′⊑
+  modeᵗ′ = proj₁ (proj₂ target)
+  sealᵗ′ = proj₁ (proj₂ (proj₂ target))
+  target⊑ = proj₂ (proj₂ (proj₂ target))
+
+weak-one-step-matched-νcast-value-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (vW : Value
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  (noW : No•
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  WeakOneStepTransport (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTransport
+    (weak-one-step-matched-νcast-value-catchupᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ catchup vW noW)
+weak-one-step-matched-νcast-value-catchup-transportᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW inner-transport =
+  weak-one-step-prepend-left-silent-preserves-transportᵀ
+    (left-silent
+      (weak-one-step-matched-νcast-frameᵀ
+        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+        (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-νcastᵀ
+      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
+    (weak-one-step-matched-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll) inner-transport)
+    (weak-one-step-matched-νcast-transportᵀ
+      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
+  where
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source = weak-result-source-widen-inst inner mode seal★ s⊑
+  modeˢ = proj₁ (proj₂ source)
+  sealˢ = proj₁ (proj₂ (proj₂ source))
+  source⊑ = proj₂ (proj₂ (proj₂ source))
+  target = weak-result-target-widen-inst
+    keep inner mode′ seal★′ s′⊑
+  modeᵗ′ = proj₁ (proj₂ target)
+  sealᵗ′ = proj₁ (proj₂ (proj₂ target))
+  target⊑ = proj₂ (proj₂ (proj₂ target))
+
+weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (vW : Value
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  (noW : No•
+    (sourceResult (weakResult (catchupAllResult catchup)))) →
+  WeakOneStepTypeCoherence (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-νcast-value-catchupᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ catchup vW noW)
+weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final))
+    vW noW inner-coherence =
+  weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+    (left-silent
+      (weak-one-step-matched-νcast-frameᵀ
+        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+        (weak-all-result inner innerAll))
+      (left-silent-invariant refl refl))
+    (weak-one-step-matched-νcastᵀ
+      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
+    (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll) inner-coherence)
+    (weak-one-step-matched-νcast-type-coherenceᵀ
+      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
+  where
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source = weak-result-source-widen-inst inner mode seal★ s⊑
+  modeˢ = proj₁ (proj₂ source)
+  sealˢ = proj₁ (proj₂ (proj₂ source))
+  source⊑ = proj₂ (proj₂ (proj₂ source))
+  target = weak-result-target-widen-inst
+    keep inner mode′ seal★′ s′⊑
+  modeᵗ′ = proj₁ (proj₂ target)
+  sealᵗ′ = proj₁ (proj₂ (proj₂ target))
+  target⊑ = proj₂ (proj₂ (proj₂ target))
+
+weak-one-step-matched-νcast-blame-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  sourceResult (weakResult (catchupAllResult catchup)) ≡ blame →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl
+    with silent
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-blame-catchupᵀ
+    {B = B} {B′ = B′} {s = s} {s′ = s′}
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl | left-silent-invariant refl refl | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  let
+    first = weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      {A = ★} {A′ = ★}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′ wf★ target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silentᵀ
+    (left-silent first (left-silent-invariant refl refl)) second
+
+weak-one-step-matched-νcast-blame-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (eq-blame :
+    sourceResult (weakResult (catchupAllResult catchup)) ≡ blame) →
+  WeakOneStepTransport (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTransport
+    (weak-one-step-matched-νcast-blame-catchupᵀ
+      wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ catchup eq-blame)
+weak-one-step-matched-νcast-blame-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport
+    with silent
+weak-one-step-matched-νcast-blame-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-blame-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport | left-silent-invariant refl refl
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-blame-catchup-transportᵀ
+    {B = B} {B′ = B′} {s = s} {s′ = s′}
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-transport | left-silent-invariant refl refl
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  let
+    first = weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      {A = ★} {A′ = ★}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′ wf★ target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silent-preserves-transportᵀ
+    (left-silent first (left-silent-invariant refl refl))
+    second
+    (weak-one-step-matched-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll) inner-transport)
+    (weak-one-step-source-blame-right-allocation-transportᵀ
+      {A = ★} {A′ = ★}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′ wf★ target⊢ (transportType inner pB))
+
+weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  (eq-blame :
+    sourceResult (weakResult (catchupAllResult catchup)) ≡ blame) →
+  WeakOneStepTypeCoherence (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-νcast-blame-catchupᵀ
+      wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ catchup eq-blame)
+weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence
+    with silent
+weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence | left-silent-invariant refl refl
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence | left-silent-invariant refl refl
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
+    {B = B} {B′ = B′} {s = s} {s′ = s′}
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    (left-all-catchup (weak-all-result inner innerAll)
+      (left-catchup-invariant silent final))
+    refl inner-coherence | left-silent-invariant refl refl
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  let
+    first = weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll)
+
+    target⊢ =
+      nu-term-imprecision-target-typing (relatedResults first)
+
+    second = weak-one-step-source-blame-right-allocationᵀ
+      {A = ★} {A′ = ★}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′ wf★ target⊢ (transportType inner pB)
+  in
+  weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+    (left-silent first (left-silent-invariant refl refl))
+    second
+    (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll) inner-coherence)
+    (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+      {A = ★} {A′ = ★}
+      {B = applyTys (sourceChanges inner) B}
+      {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+      {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+      {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder keep s′)}
+      {ρ = resultStore inner}
+      (weak-result-right-wf-silent inner
+        (left-silent-invariant refl refl) wfΣ′)
+      vV′ noV′ wf★ target⊢ (transportType inner pB))
+
+weak-one-step-matched-νcast-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  Value V′ →
+  No• V′ →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepResult ρ
+    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind ★)
+weak-one-step-matched-νcast-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-νcast-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup | inj₁ (vW , noW) =
+  weak-one-step-matched-νcast-value-catchupᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup vW noW
+weak-one-step-matched-νcast-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup | inj₂ eq-blame =
+  weak-one-step-matched-νcast-blame-catchupᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup eq-blame
+
+weak-one-step-matched-νcast-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepTransport (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTransport
+    (weak-one-step-matched-νcast-catchupᵀ
+      wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ catchup)
+weak-one-step-matched-νcast-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    catchup transport
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-νcast-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    catchup transport | inj₁ (vW , noW) =
+  weak-one-step-matched-νcast-value-catchup-transportᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup vW noW transport
+weak-one-step-matched-νcast-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    catchup transport | inj₂ eq-blame =
+  weak-one-step-matched-νcast-blame-catchup-transportᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup eq-blame transport
+
+weak-one-step-matched-νcast-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup :
+    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepTypeCoherence (weakResult (catchupAllResult catchup)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-νcast-catchupᵀ
+      wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ catchup)
+weak-one-step-matched-νcast-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    catchup coherence
+    with sourceIsValueOrBlame (catchupAllInvariant catchup)
+weak-one-step-matched-νcast-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    catchup coherence | inj₁ (vW , noW) =
+  weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup vW noW coherence
+weak-one-step-matched-νcast-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
+    catchup coherence | inj₂ eq-blame =
+  weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′ catchup eq-blame coherence
+
+weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (catchup : LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q) →
+  WeakOneStepIndexedOutcome
+    {M = ν ★ N s}
+    {N′ = ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩}
+    {A = B} {B = B′} {χ = bind ★} {ρ = ρ} pB
+weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
+    {B = B} {B′ = B′} {s = s} {s′ = s′}
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    with final
+weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
+    {B = B} {B′ = B′} {s = s} {s′ = s′}
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₁ (vW , noW) =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result type-eq)
+    transport coherence
+  where
+  old-catchup = left-all-catchup
+    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+  result =
+    weak-one-step-matched-νcast-value-catchupᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ old-catchup vW noW
+
+  inner = weakResult (catchupAllResult old-catchup)
+  innerAll = canonicalAllResults (catchupAllResult old-catchup)
+  first = weak-one-step-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (catchupAllResult old-catchup)
+  liftρ₀ = proj₂ (lift-store-result (resultStore inner))
+  source = weak-result-source-widen-inst inner mode seal★ s⊑
+  modeˢ = proj₁ (proj₂ source)
+  sealˢ = proj₁ (proj₂ (proj₂ source))
+  source⊑ = proj₂ (proj₂ (proj₂ source))
+  target = weak-result-target-widen-inst
+    keep inner mode′ seal★′ s′⊑
+  modeᵗ′ = proj₁ (proj₂ target)
+  sealᵗ′ = proj₁ (proj₂ (proj₂ target))
+  target⊑ = proj₂ (proj₂ (proj₂ target))
+  second = weak-one-step-matched-νcastᵀ
+    vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
+    source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll
+
+  type-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx result ∣ resultLeftCtx result
+          ⊢ S ⊑ T ⊣ resultRightCtx result}
+        (sourceTypeResult result)
+        (targetTypeResult result)
+        (resultType result))
+      (HE.sym (weak-one-step-compose-type-to-nested≅
+        first second pB)))
+
+  transport =
+    weak-one-step-matched-νcast-value-catchup-transportᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ old-catchup vW noW inner-transport
+
+  coherence =
+    weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      vV′ noV′ old-catchup vW noW inner-coherence
+weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
+    {B = B} {B′ = B′} {s = s} {s′ = s′}
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    vV′ noV′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₂ refl =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result type-eq)
+    transport coherence
+  where
+  old-catchup = left-all-catchup
+    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+  inner = weakResult (catchupAllResult old-catchup)
+  first = weak-one-step-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (catchupAllResult old-catchup)
+  target⊢ = nu-term-imprecision-target-typing (relatedResults first)
+  second = weak-one-step-source-blame-right-allocationᵀ
+    {A = ★} {A′ = ★}
+    {B = applyTys (sourceChanges inner) B}
+    {B′ = applyTys (targetTailChanges inner) (applyTy keep B′)}
+    {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+    {s′ = applyCoercionUnderTyBinders (targetTailChanges inner)
+      (applyCoercionUnderTyBinder keep s′)}
+    {ρ = resultStore inner}
+    (weak-result-right-wf-silent inner
+      (left-silent-invariant refl refl) wfΣ′)
+    vV′ noV′ wf★ target⊢ (transportType inner pB)
+
+  result =
+    weak-one-step-prepend-left-silentᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+
+  type-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx result ∣ resultLeftCtx result
+          ⊢ S ⊑ T ⊣ resultRightCtx result}
+        (sourceTypeResult result)
+        (targetTypeResult result)
+        (resultType result))
+      (HE.sym (weak-one-step-compose-type-to-nested≅
+        first second pB)))
+
+  transport =
+    weak-one-step-prepend-left-silent-preserves-transportᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      (weak-one-step-matched-νcast-frame-preserves-transportᵀ
+        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+        (catchupAllResult old-catchup) inner-transport)
+      (weak-one-step-source-blame-right-allocation-transportᵀ
+        {A = ★} {A′ = ★}
+        {B = applyTys (sourceChanges inner) B}
+        {B′ = applyTys (targetTailChanges inner)
+          (applyTy keep B′)}
+        {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+        {s′ = applyCoercionUnderTyBinders
+          (targetTailChanges inner)
+          (applyCoercionUnderTyBinder keep s′)}
+        {ρ = resultStore inner}
+        (weak-result-right-wf-silent inner
+          (left-silent-invariant refl refl) wfΣ′)
+        vV′ noV′ wf★ target⊢ (transportType inner pB))
+
+  coherence =
+    weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+        (catchupAllResult old-catchup) inner-coherence)
+      (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+        {A = ★} {A′ = ★}
+        {B = applyTys (sourceChanges inner) B}
+        {B′ = applyTys (targetTailChanges inner)
+          (applyTy keep B′)}
+        {s = applyCoercionUnderTyBinders (sourceChanges inner) s}
+        {s′ = applyCoercionUnderTyBinders
+          (targetTailChanges inner)
+          (applyCoercionUnderTyBinder keep s′)}
+        {ρ = resultStore inner}
+        (weak-result-right-wf-silent inner
+          (left-silent-invariant refl refl) wfΣ′)
+        vV′ noV′ wf★ target⊢ (transportType inner pB))
+
+left-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N′ s μ q occ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value N →
+  No• N →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
+  (ν ★ N s —→[ bind ★ ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-νcast-allocation {q = q} vN noN mode seal★ s⊑ pB liftρ
+    N⊑N′ =
+  ν-step vN noN ,
+  ↠-refl ,
+  cast⊑⊑ᵀ (cast-inst mode) left-seal left-widening
+    (α⊑ᵀ vN noN wf★ liftρ lift-left-ctx-[] N⊑N′
+      left-bullet-typing right-term-typing)
+    (⊑-source-liftνᵢ pB)
+  where
+    left-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        seal★
+
+    left-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        s⊑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left liftρ))
+        (nu-term-imprecision-target-typing N⊑N′)
+
+------------------------------------------------------------------------
+-- Left-only polymorphic allocation
+------------------------------------------------------------------------
+
+left-ν↑-allocation :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N′ s μ q occ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value N →
+  No• N →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
+  (ν A N s —→[ bind A ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-ν↑-allocation {q = q} vN noN h⇑A s↑ pB liftρ N⊑N′ =
+  ν-step vN noN ,
+  ↠-refl ,
+  conv↑⊑ᵀ left-reveal
+    (α⊑ᵀ vN noN h⇑A liftρ lift-left-ctx-[] N⊑N′
+      left-bullet-typing right-term-typing)
+    (⊑-source-liftνᵢ pB)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        s↑
+
+    left-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (leftStoreⁱ-lift-left liftρ))
+        (⊢• refl refl (⊑-src-wf q) vN noN
+          (nu-term-imprecision-source-typing N⊑N′))
+
+    right-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left liftρ))
+        (nu-term-imprecision-target-typing N⊑N′)
+
+------------------------------------------------------------------------
+-- Right-only polymorphic allocation
+------------------------------------------------------------------------
+
+right-ν↑-allocation :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  (N —↠[ [] ] N) ×
+  (ν A N′ s —→[ bind A ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
+  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+    store-right zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
+    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
+    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
+right-ν↑-allocation {q = q} vN′ noN′ h⇑A s′↑ pB pC liftρ
+    N⊑N′ =
+  ↠-refl ,
+  ν-step vN′ noN′ ,
+  ⊑conv↑ᵀ right-reveal
+    (⊑αᵀ vN′ noN′ h⇑A liftρ lift-right-ctx-[] N⊑N′ pC
+      left-term-typing right-bullet-typing)
+    (⊑-target-lift-rightᵢ pB)
+  where
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (rightStoreⁱ-lift-right liftρ))
+        s′↑
+
+    left-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right liftρ))
+        (nu-term-imprecision-source-typing N⊑N′)
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift-right liftρ))
+        (⊢• refl refl (∀-imprecision-target-body-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-right-ν↑ᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  WeakOneStepResult ρ N (((⇑ᵗᵐ N′) •) ⟨ s ⟩)
+    B B′ (bind A)
+weak-one-step-right-ν↑ᵀ
+    {A = A} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    with right-ν↑-allocation
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+weak-one-step-right-ν↑ᵀ
+    {A = A} {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    | _ , _ , result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = ⇑ᴿᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-right zero (⇑ᵗ A) h⇑A ∷ ρ′
+    ; resultSourceType = B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-target-lift-rightᵢ
+    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
+    ; transportRightBody = ⊑-target-lift-under-rightᵢ
+    ; resultType = ⊑-target-lift-rightᵢ pB
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
+    ; targetStoreResult =
+        cong ((zero , ⇑ᵗ A) ∷_) (rightStoreⁱ-lift-right liftρ)
+    ; relatedResults = result
+    }
+
+weak-one-step-right-ν↑-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  (s′↑ : RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (liftρ : LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q) →
+  WeakOneStepTransport
+    (weak-one-step-right-ν↑ᵀ
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
+weak-one-step-right-ν↑-transportᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    with right-ν↑-allocation
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+weak-one-step-right-ν↑-transportᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-transport
+    (right-lift-prefix-bodyᵀ liftρ (prefix-∷ⁱ prefix-reflⁱ))
+
+weak-one-step-right-ν↑-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  (s′↑ : RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (liftρ : LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-right-ν↑ᵀ
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
+weak-one-step-right-ν↑-type-coherenceᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    with right-ν↑-allocation
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+weak-one-step-right-ν↑-type-coherenceᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-type-coherence
+    (λ pD pE → HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ oneStep pD pE)
+        (≡-to-≅
+          (⊑-target-lift-right-arrow-coherentᵢ pD pE))))
+    (λ r → HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ oneStep r)
+        (≡-to-≅ (⊑-target-lift-right-all-coherentᵢ r))))
+  where
+  oneStep = weak-one-step-right-ν↑ᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+
+------------------------------------------------------------------------
+-- Right-only `inst` allocation
+------------------------------------------------------------------------
+
+right-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  (N —↠[ [] ] N) ×
+  (ν ★ N′ s —→[ bind ★ ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
+  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+    store-right zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
+    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
+right-νcast-allocation {q = q} vN′ noN′ mode seal★ s⊑ pB pC
+    liftρ N⊑N′ =
+  ↠-refl ,
+  ν-step vN′ noN′ ,
+  ⊑cast⊑ᵀ (cast-inst mode) right-seal right-widening
+    (⊑αᵀ vN′ noN′ wf★ liftρ lift-right-ctx-[] N⊑N′ pC
+      left-term-typing right-bullet-typing)
+    (⊑-target-lift-rightᵢ pB)
+  where
+    right-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
+        (sym (rightStoreⁱ-lift-right liftρ))
+        seal★
+
+    right-widening =
+      subst
+        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
+          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
+        (sym (rightStoreⁱ-lift-right liftρ))
+        s⊑
+
+    left-term-typing =
+      subst
+        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right liftρ))
+        (nu-term-imprecision-source-typing N⊑N′)
+
+    right-bullet-typing =
+      subst
+        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
+          ⊢ (⇑ᵗᵐ _) • ⦂ _)
+        (sym (rightStoreⁱ-lift-right liftρ))
+        (⊢• refl refl (∀-imprecision-target-body-wf q) vN′ noN′
+          (nu-term-imprecision-target-typing N⊑N′))
+
+weak-one-step-right-νcastᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  WeakOneStepResult ρ N (((⇑ᵗᵐ N′) •) ⟨ s ⟩)
+    B B′ (bind ★)
+weak-one-step-right-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    with right-νcast-allocation
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+weak-one-step-right-νcastᵀ
+    {B = B} {B′ = B′} {ρ′ = ρ′}
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    | _ , _ , result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = ⇑ᴿᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-right zero ★ wf★ ∷ ρ′
+    ; resultSourceType = B
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-target-lift-rightᵢ
+    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
+    ; transportRightBody = ⊑-target-lift-under-rightᵢ
+    ; resultType = ⊑-target-lift-rightᵢ pB
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
+    ; targetStoreResult =
+        cong ((zero , ★) ∷_) (rightStoreⁱ-lift-right liftρ)
+    ; relatedResults = result
+    }
+
+weak-one-step-right-νcast-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (liftρ : LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q) →
+  WeakOneStepTransport
+    (weak-one-step-right-νcastᵀ
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
+weak-one-step-right-νcast-transportᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    with right-νcast-allocation
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+weak-one-step-right-νcast-transportᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-transport
+    (right-lift-prefix-bodyᵀ liftρ (prefix-∷ⁱ prefix-reflⁱ))
+
+weak-one-step-right-νcast-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (liftρ : LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-right-νcastᵀ
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
+weak-one-step-right-νcast-type-coherenceᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    with right-νcast-allocation
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+weak-one-step-right-νcast-type-coherenceᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+    | source→ , target→ , result =
+  weak-step-type-coherence
+    (λ pD pE → HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ oneStep pD pE)
+        (≡-to-≅
+          (⊑-target-lift-right-arrow-coherentᵢ pD pE))))
+    (λ r → HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ oneStep r)
+        (≡-to-≅ (⊑-target-lift-right-all-coherentᵢ r))))
+  where
+  oneStep = weak-one-step-right-νcastᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+
+weak-one-step-source-blame-right-allocation-indexed-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ V′ s s′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (h⇑A′ : WfTy (suc Δᴿ) (⇑ᵗ A′)) →
+  (target⊢ : Δᴿ ∣ rightStoreⁱ ρ ∣ []
+    ⊢ ν A′ V′ s′ ⦂ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = ν A blame s}
+    {N′ = ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩}
+    {A = B} {B = B′} {χ = bind A′} {ρ = ρ} pB
+weak-one-step-source-blame-right-allocation-indexed-outcomeᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-source-blame-right-allocation-transportᵀ
+      {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
+    (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+      {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
+  where
+  result = weak-one-step-source-blame-right-allocationᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB
+
+weak-one-step-right-ν↑-indexed-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  (s′↑ : RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (liftρ : LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = ((⇑ᵗᵐ N′) •) ⟨ s ⟩}
+    {A = B} {B = B′} {χ = bind A} {ρ = ρ} pB
+weak-one-step-right-ν↑-indexed-outcomeᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′ =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-right-ν↑-transportᵀ
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
+    (weak-one-step-right-ν↑-type-coherenceᵀ
+      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
+  where
+  result = weak-one-step-right-ν↑ᵀ
+    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
+
+weak-one-step-right-νcast-indexed-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (vN′ : Value N′) →
+  (noN′ : No• N′) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (liftρ : LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′) →
+  (N⊑N′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = ((⇑ᵗᵐ N′) •) ⟨ s ⟩}
+    {A = B} {B = B′} {χ = bind ★} {ρ = ρ} pB
+weak-one-step-right-νcast-indexed-outcomeᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′ =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-right-νcast-transportᵀ
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
+    (weak-one-step-right-νcast-type-coherenceᵀ
+      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
+  where
+  result = weak-one-step-right-νcastᵀ
+    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
+
+------------------------------------------------------------------------
+-- `β-inst` followed by `ν ★` allocation
+------------------------------------------------------------------------
+
+matched-β-inst-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value N →
+  No• N →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  (N ⟨ inst B s ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ ⟨ inst B′ s′ ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero ★ zero ★ id★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-β-inst-νcast-allocation vN noN vN′ noN′ mode seal★
+    mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
+    with matched-νcast-allocation vN noN vN′ noN′ mode seal★
+      mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
+matched-β-inst-νcast-allocation vN noN vN′ noN′ mode seal★
+    mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
+    | N→ , N′→ , result =
+  ↠-step (post-β-inst vN) (↠-step N→ ↠-refl) ,
+  ↠-step (post-β-inst vN′) (↠-step N′→ ↠-refl) ,
+  result
+
+left-β-inst-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N′ s μ q occ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value N →
+  No• N →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
+  (N ⟨ inst B s ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-β-inst-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
+    with left-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
+left-β-inst-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
+    | N→ , N′→ , result =
+  ↠-step (post-β-inst vN) (↠-step N→ ↠-refl) ,
+  N′→ ,
+  result
+
+right-β-inst-νcast-allocation :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  Value N′ →
+  No• N′ →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
+  (N —↠[ [] ] N) ×
+  (N′ ⟨ inst B′ s ⟩
+    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
+  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
+    store-right zero ★ wf★ ∷ ρ′ ∣ []
+    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
+    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
+right-β-inst-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC liftρ
+    N⊑N′
+    with right-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC
+      liftρ N⊑N′
+right-β-inst-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC liftρ
+    N⊑N′ | N→ , N′→ , result =
+  N→ ,
+  ↠-step (post-β-inst vN′) (↠-step N′→ ↠-refl) ,
+  result
+
+------------------------------------------------------------------------
+-- Allocation followed by `β-Λ•`
+------------------------------------------------------------------------
+
+matched-ν↑-β-Λ• :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ V V′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ′ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ C ⊑ C′ ∶ q →
+  (ν A (Λ V) s —↠[ bind A ∷ keep ∷ [] ] V ⟨ s ⟩) ×
+  (ν A′ (Λ V′) s′
+    —↠[ bind A′ ∷ keep ∷ [] ] V′ ⟨ s′ ⟩) ×
+  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′) A⇑⊑A′⇑ ∷ ρ′
+    ∣ []
+    ⊢ᴺ V ⟨ s ⟩ ⊑ V′ ⟨ s′ ⟩
+    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
+matched-ν↑-β-Λ• {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {A′ = A′}
+    {C = C} {C′ = C′} {V = V} {V′ = V′} {ρ′ = ρ′}
+    vV noV vV′ noV′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ
+    V⊑V′ =
+  ↠-step (ν-step (Λ vV) (no•-Λ noV))
+    (↠-step (post-allocation-β-Λ• vV) ↠-refl) ,
+  ↠-step (ν-step (Λ vV′) (no•-Λ noV′))
+    (↠-step (post-allocation-β-Λ• vV′) ↠-refl) ,
+  conv⊑convᵀ
+    (paired-conversion
+      (paired-reveal (correspondence-stored (here refl))
+        left-reveal right-reveal))
+    (allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) V⊑V′
+      left-body-typing right-body-typing)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift liftρ))
+        s↑
+
+    right-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (rightStoreⁱ-lift liftρ))
+        s′↑
+
+    left-body-typing :
+      suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′ ∣ [] ⊢ V ⦂ C
+    left-body-typing =
+      term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρ′}
+        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′}
+        {Γ = []} {M = V} {A = C} ≤-refl StoreIncl-drop noV
+        (nu-term-imprecision-source-typing V⊑V′)
+
+    right-body-typing :
+      suc Δᴿ ∣ (zero , ⇑ᵗ A′) ∷ rightStoreⁱ ρ′ ∣ []
+        ⊢ V′ ⦂ C′
+    right-body-typing =
+      term-weaken {Δ = suc Δᴿ} {Δ′ = suc Δᴿ}
+        {Σ = rightStoreⁱ ρ′}
+        {Σ′ = (zero , ⇑ᵗ A′) ∷ rightStoreⁱ ρ′}
+        {Γ = []} {M = V′} {A = C′} ≤-refl StoreIncl-drop noV′
+        (nu-term-imprecision-target-typing V⊑V′)
+
+left-ν↑-β-Λ• :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C V N′ s μ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ []
+    ⊢ᴺ V ⊑ N′ ⦂ C ⊑ B′ ∶ q →
+  (ν A (Λ V) s —↠[ bind A ∷ keep ∷ [] ] V ⟨ s ⟩) ×
+  (N′ —↠[ [] ] N′) ×
+  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
+    ⊢ᴺ V ⟨ s ⟩ ⊑ N′
+    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
+left-ν↑-β-Λ• {Δᴸ = Δᴸ} {A = A} {C = C} {V = V}
+    {ρ′ = ρ′} vV noV h⇑A s↑ pB liftρ V⊑N′ =
+  ↠-step (ν-step (Λ vV) (no•-Λ noV))
+    (↠-step (post-allocation-β-Λ• vV) ↠-refl) ,
+  ↠-refl ,
+  conv↑⊑ᵀ left-reveal
+    (allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) V⊑N′
+      source-body-typing
+      (nu-term-imprecision-target-typing V⊑N′))
+    (⊑-source-liftνᵢ pB)
+  where
+    left-reveal =
+      subst
+        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
+          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
+        (sym (leftStoreⁱ-lift-left liftρ))
+        s↑
+
+    source-body-typing :
+      suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′ ∣ [] ⊢ V ⦂ C
+    source-body-typing =
+      term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρ′}
+        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′}
+        {Γ = []} {M = V} {A = C} ≤-refl StoreIncl-drop noV
+        (nu-term-imprecision-source-typing V⊑N′)
+
+------------------------------------------------------------------------
+-- Matched allocation followed by `β-gen•`
+------------------------------------------------------------------------
+
+matched-post-allocation-β-genᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aν Aν′ A A′ B B′ V V′ c c′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)}
+    {γ′ : CtxImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  Value V →
+  Value V′ →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ gen A c ∶ A ⊒ `∀ B →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ gen A′ c′ ∶ A′ ⊒ `∀ B′ →
+  (pν : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ Aν ⊑ Aν′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ
+    ∣ store-matched zero Aν zero Aν′ pν ∷ ρ′ ∣ γ′
+    ⊢ᴺ ⇑ᵗᵐ V ⊑ ⇑ᵗᵐ V′ ⦂ ⇑ᵗ A ⊑ ⇑ᵗ A′ ∶ p →
+  (q : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ⊢ B ⊑ᵖ B′ ⊣ suc Δᴿ) →
+  (((⇑ᵗᵐ (V ⟨ gen A c ⟩)) •
+      —→[ keep ] (⇑ᵗᵐ V) ⟨ c ⟩) ×
+   ((⇑ᵗᵐ (V′ ⟨ gen A′ c′ ⟩)) •
+      —→[ keep ] (⇑ᵗᵐ V′) ⟨ c′ ⟩) ×
+   (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      ∣ suc Δᴸ ∣ suc Δᴿ
+      ∣ store-matched zero Aν zero Aν′ pν ∷ ρ′ ∣ γ′
+      ⊢ᴺᵖ (⇑ᵗᵐ V) ⟨ c ⟩ ⊑ (⇑ᵗᵐ V′) ⟨ c′ ⟩
+      ⦂ B ⊑ᵖ B′ ∶ q))
+matched-post-allocation-β-genᵀ {Aν = Aν} {Aν′ = Aν′} vV vV′
+    c⊒ c′⊒ pν liftρ V⊑V′ q =
+  post-allocation-β-gen•-bare vV ,
+  post-allocation-β-gen•-bare vV′ ,
+  gen-down⊑gen-downᵀ
+    (narrow-mode-relax (ModeIncl-gen id-only≤tag-or-idᵈ) left-body)
+    (narrow-mode-relax (ModeIncl-gen id-only≤tag-or-idᵈ) right-body)
+    V⊑V′ q
+  where
+    left-body =
+      subst
+        (λ Σ → genᵈ id-onlyᵈ ∣ _ ∣ (zero , Aν) ∷ Σ
+          ⊢ _ ∶ _ ⊒ _)
+        (sym (leftStoreⁱ-lift liftρ))
+        (allocate-gen-narrowing {Aν = Aν} c⊒)
+
+    right-body =
+      subst
+        (λ Σ → genᵈ id-onlyᵈ ∣ _ ∣ (zero , Aν′) ∷ Σ
+          ⊢ _ ∶ _ ⊒ _)
+        (sym (rightStoreⁱ-lift liftρ))
+        (allocate-gen-narrowing {Aν = Aν′} c′⊒)

--- a/GTSF/proof/NuImprecisionCatchupComposition.agda
+++ b/GTSF/proof/NuImprecisionCatchupComposition.agda
@@ -1,0 +1,178 @@
+module proof.NuImprecisionCatchupComposition where
+
+-- File Charter:
+--   * Composes a checked source `keep` step with a later catch-up result.
+--   * Preserves indexed transport and type-coherence witnesses.
+--   * Exports the indexed catch-up wrapper used by active cast dispatchers.
+--   * Depends only on the stable weak-simulation core.
+
+open import Agda.Builtin.Equality using (refl)
+open import Data.List using ([]; _∷_)
+import Relation.Binary.HeterogeneousEquality as HE
+
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NuReduction using
+  (keep; _—→[_]_; ↠-refl; ↠-step)
+open import NuTermImprecision using (StoreImp)
+open import QuotientedTermImprecision
+open import proof.NuImprecisionSimulationCore
+
+weak-one-step-keep-source-catchupᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —→[ keep ] N →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+  WeakOneStepResult ρ M N′ A B keep
+weak-one-step-keep-source-catchupᵀ source→ result =
+  record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = _
+    ; sourceCatchup = ↠-step source→ ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+weak-one-step-keep-source-catchup-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (source→ : M —→[ keep ] N) →
+  (result : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p) →
+  WeakOneStepTransport
+    (weak-one-step-keep-source-catchupᵀ source→ result)
+weak-one-step-keep-source-catchup-transportᵀ source→ result =
+  weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
+
+weak-one-step-keep-source-catchup-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (source→ : M —→[ keep ] N) →
+  (result : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-keep-source-catchupᵀ source→ result)
+weak-one-step-keep-source-catchup-type-coherenceᵀ source→ result =
+  weak-step-type-coherence
+    (λ pC pD → HE.≅-to-≡
+      (transportArrowType-to-raw≅ oneStep pC pD))
+    (λ q → HE.≅-to-≡
+      (transportAllType-to-raw≅ oneStep q))
+  where
+  oneStep = weak-one-step-keep-source-catchupᵀ source→ result
+
+weak-one-step-prepend-source-keepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —→[ keep ] N →
+  WeakOneStepResult ρ N N′ A B χ →
+  WeakOneStepResult ρ M N′ A B χ
+weak-one-step-prepend-source-keepᵀ source→ second =
+  record
+    { sourceChanges = keep ∷ sourceChanges second
+    ; targetTailChanges = targetTailChanges second
+    ; sourceResult = sourceResult second
+    ; targetResult = targetResult second
+    ; resultCtx = resultCtx second
+    ; resultLeftCtx = resultLeftCtx second
+    ; resultRightCtx = resultRightCtx second
+    ; sourceCtxResult = sourceCtxResult second
+    ; targetCtxResult = targetCtxResult second
+    ; resultStore = resultStore second
+    ; resultSourceType = resultSourceType second
+    ; resultTargetType = resultTargetType second
+    ; sourceTypeResult = sourceTypeResult second
+    ; targetTypeResult = targetTypeResult second
+    ; transportType = transportType second
+    ; transportAllBody = transportAllBody second
+    ; transportRightBody = transportRightBody second
+    ; resultType = resultType second
+    ; sourceCatchup = ↠-step source→ (sourceCatchup second)
+    ; targetTail = targetTail second
+    ; sourceStoreResult = sourceStoreResult second
+    ; targetStoreResult = targetStoreResult second
+    ; relatedResults = relatedResults second
+    }
+
+weak-one-step-prepend-source-keep-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (source→ : M —→[ keep ] N)
+    (second : WeakOneStepResult ρ N N′ A B χ) →
+  WeakOneStepTransport second →
+  WeakOneStepTransport
+    (weak-one-step-prepend-source-keepᵀ source→ second)
+weak-one-step-prepend-source-keep-transportᵀ
+    source→ second transport =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-prepend-source-keep-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (source→ : M —→[ keep ] N)
+    (second : WeakOneStepResult ρ N N′ A B χ) →
+  WeakOneStepTypeCoherence second →
+  WeakOneStepTypeCoherence
+    (weak-one-step-prepend-source-keepᵀ source→ second)
+weak-one-step-prepend-source-keep-type-coherenceᵀ
+    source→ second coherence =
+  weak-step-type-coherence
+    (λ pC pD → HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ combined pC pD)
+        (HE.trans
+          (HE.sym (transportArrowType-to-raw≅ second pC pD))
+          (≡-to-≅ (transportArrowCoherent coherence pC pD)))))
+    (λ q → HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ combined q)
+        (HE.trans
+          (HE.sym (transportAllType-to-raw≅ second q))
+          (≡-to-≅ (transportAllCoherent coherence q)))))
+  where
+  combined = weak-one-step-prepend-source-keepᵀ source→ second
+
+left-catchup-indexed-prepend-keepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (source→ : M —→[ keep ] N) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ A ⊑ B ∶ p) →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ} p →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-prepend-keepᵀ source→ N⊑V′
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      second-transport second-coherence) =
+  left-indexed-catchup
+    (weak-indexed-result combined (canonicalIndexedResults indexed))
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+    (weak-one-step-prepend-source-keep-transportᵀ
+      source→ second second-transport)
+    (weak-one-step-prepend-source-keep-type-coherenceᵀ
+      source→ second second-coherence)
+  where
+  second = weakIndexedResult indexed
+  combined = weak-one-step-prepend-source-keepᵀ source→ second

--- a/GTSF/proof/NuImprecisionCatchupScratch.agda
+++ b/GTSF/proof/NuImprecisionCatchupScratch.agda
@@ -1,0 +1,1467 @@
+{-# OPTIONS --allow-unsolved-metas --allow-incomplete-matches #-}
+
+module proof.NuImprecisionCatchupScratch where
+
+-- File Charter:
+--   * Isolates active proof engineering for recursive universal catch-up.
+--   * States arbitrary-type value catch-up and proves its terminal,
+--     target-frame, and recursive quotient-dispatch clauses.
+--   * Exposes source-∀ catch-up as a specialization of that recursion.
+--   * Keeps the general indexed one-step dispatcher visibly incomplete while
+--     its remaining structural clauses are developed.
+--   * Exposes explicit quotient-instantiation residuals in that dispatcher.
+--   * Depends only on the stable weak-simulation core; move a lemma to its
+--     permanent module once its statement and proof are stable.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_; _++_)
+open import Data.Nat using (suc; zero)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_,_; _×_)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using
+  (cong; subst; sym; trans)
+import Relation.Binary.HeterogeneousEquality as HE
+
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_; ∀ⁱ_)
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Coercions using
+  ( Inert
+  ; genᵈ
+  ; id-onlyᵈ
+  ; instᵈ
+  ; tag-or-idᵈ
+  )
+open import Conversion using
+  ( ConcealConversion
+  ; RevealConversion
+  ; weaken-conceal-conversion
+  ; weaken-reveal-conversion
+  )
+open import NarrowWiden using
+  ( narrow-weaken
+  ; widen-weaken
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+open import NuReduction using
+  ( _—→[_]_
+  ; _—↠[_]_
+  ; applyStores
+  ; applyTy
+  ; applyTyCtxs
+  ; applyTys
+  ; blame-ν
+  ; bind
+  ; keep
+  ; ξ-ν
+  ; ν-step
+  ; ↠-refl
+  ; ↠-step
+  )
+open import NuTerms using
+  ( No•
+  ; RuntimeOK
+  ; Value
+  ; no•-Λ
+  ; no•-⟨⟩
+  ; no•-blame
+  ; ok-no
+  ; ok-⟨⟩
+  ; blame
+  ; ν
+  ; ƛ_
+  ; Λ_
+  ; `_
+  ; _·_
+  ; _•
+  ; $
+  ; _⊕[_]_
+  ; _⟨_⟩
+  ; ⇑ᵗᵐ
+  )
+open import NuTermImprecision using
+  ( StoreImp
+  ; leftStoreⁱ
+  ; lift-left-ctx-[]
+  ; rightStoreⁱ
+  )
+open import QuotientedTermImprecision
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using (★; `∀; ⇑ᵗ; ⟰ᵗ)
+open import NuStore using (StoreWf)
+open import proof.MaximalLowerBoundsWf using (∀ᵢᶜ)
+open import proof.CoercionProperties using (ModeRename)
+open import proof.NuImprecisionAllocationSimulation using
+  ( weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
+  ; weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
+  ; weak-one-step-right-ν↑-indexed-outcomeᵀ
+  ; weak-one-step-right-νcast-indexed-outcomeᵀ
+  )
+open import proof.NuImprecisionSimulationCore
+open import proof.NuImprecisionQuotientValue using
+  (left-catchup-indexed-final-quotientᵀ)
+open import proof.NuImprecisionSimulation using
+  ( left-catchup-indexed-prefix-α-Λᵀ
+  ; weak-one-step-target-cast-frameᵀ
+  ; weak-one-step-target-cast-frame-coherenceᵀ
+  ; weak-one-step-target-cast-frame-transportᵀ
+  )
+open import proof.ReductionProperties using
+  (applyCoercions; applyTy-★; applyTys-++; cast-↠)
+open import proof.NuPreservation using (runtime-ν; runtime-⟨⟩)
+open import proof.NuProgress using (runtime-value-no•)
+open import proof.TypePreservation using
+  (seal★-weaken; term-weaken)
+
+left-catchup-indexed-resume-silentᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (silent : LeftSilentIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  let first = weakIndexedResult (silentIndexedResult silent) in
+  LeftCatchupIndexedResult
+    {N = sourceResult first}
+    {V′ = targetResult first}
+    {ρ = resultStore first}
+    (transportType first p) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-resume-silentᵀ
+    {A = A} {B = B} {p = p}
+    (left-silent-indexed first-indexed
+      (left-silent-invariant refl refl)
+      first-runtime first-transport first-coherence)
+    (left-indexed-catchup second-indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      second-transport second-coherence) =
+  left-indexed-catchup
+    (weak-indexed-result combined canonical)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+    combined-transport combined-coherence
+  where
+  first-raw = weakIndexedResult first-indexed
+
+  first = weak-one-step-reindexᵀ
+    first-raw refl refl (canonicalIndexedResults first-indexed)
+
+  first-transport′ =
+    weak-one-step-reindex-preserves-transportᵀ
+      first-raw refl refl (canonicalIndexedResults first-indexed)
+      first-transport
+
+  first-coherence′ =
+    weak-one-step-reindex-preserves-type-coherenceᵀ
+      first-raw refl refl (canonicalIndexedResults first-indexed)
+      first-coherence
+
+  second = weakIndexedResult second-indexed
+
+  raw-combined =
+    weak-one-step-prepend-left-silentᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+
+  source-eq :
+    applyTys (sourceChanges second) (resultSourceType first) ≡
+      applyTys
+        (sourceChanges first ++ sourceChanges second) A
+  source-eq =
+    trans
+      (cong (applyTys (sourceChanges second))
+        (sourceTypeResult first))
+      (sym (applyTys-++
+        (sourceChanges first) (sourceChanges second) A))
+
+  target-eq :
+    applyTys (targetTailChanges second)
+        (applyTy keep (resultTargetType first)) ≡
+      applyTys (targetTailChanges second) (applyTy keep B)
+  target-eq =
+    cong
+      (λ T → applyTys (targetTailChanges second) (applyTy keep T))
+      (targetTypeResult first)
+
+  index-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx second ∣ resultLeftCtx second
+          ⊢ S ⊑ T ⊣ resultRightCtx second}
+        source-eq target-eq
+        (transportType second (transportType first p)))
+      (HE.sym
+        (weak-one-step-compose-type-to-nested≅ first second p)))
+
+  canonical =
+    nu-term-imprecision-transport-typesᵀ
+      source-eq target-eq index-eq
+      (canonicalIndexedResults second-indexed)
+
+  combined = weak-one-step-reindexᵀ
+    raw-combined refl refl canonical
+
+  raw-transport =
+    weak-one-step-prepend-left-silent-preserves-transportᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      first-transport′ second-transport
+
+  combined-transport =
+    weak-one-step-reindex-preserves-transportᵀ
+      raw-combined refl refl canonical raw-transport
+
+  raw-coherence =
+    weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      first-coherence′ second-coherence
+
+  combined-coherence =
+    weak-one-step-reindex-preserves-type-coherenceᵀ
+      raw-combined refl refl canonical raw-coherence
+
+left-catchup-indexed-target-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ W′ A A′ B B′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  (framed : WeakOneStepIndexedResult
+    {M = M} {N′ = W′} {χ = keep} {ρ = ρ} q) →
+  let inner = weakIndexedResult (catchupIndexedResult catchup)
+      first = weakIndexedResult framed
+  in
+  sourceResult first ≡ sourceResult inner →
+  LeftSilentInvariant first →
+  WeakOneStepTransport first →
+  WeakOneStepTypeCoherence first →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = W′} {ρ = ρ} q
+left-catchup-indexed-target-frameᵀ
+    (left-indexed-catchup indexed
+      (left-catchup-invariant inner-silent final)
+      inner-transport inner-coherence)
+    framed refl first-silent first-transport first-coherence =
+  left-indexed-catchup framed
+    (left-catchup-invariant first-silent final)
+    first-transport first-coherence
+
+left-catchup-indexed-prefix-target-narrow-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  CastMode μ →
+  SealModeStore★ μ (rightStoreⁱ ρ₀) →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ₀ ⊢ c ∶ A′ ⊒ B′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′ ⟨ c ⟩} {ρ = ρ⁺} q
+left-catchup-indexed-prefix-target-narrow-castᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c}
+    prefix mode seal★ c⊒
+    catchup@(left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence) =
+  left-catchup-indexed-target-frameᵀ
+    catchup framed refl (left-silent-invariant refl refl)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  seal★⁺ = seal★-weaken
+    (rightStoreⁱ-prefix-inclusion prefix) seal★
+
+  c⊒⁺ = narrow-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) c⊒
+
+  final-seal =
+    subst (SealModeStore★ _)
+      (sym (targetStoreResult inner)) seal★⁺
+
+  final-cast =
+    subst
+      (λ Δ → _ ∣ Δ ∣ rightStoreⁱ (resultStore inner)
+        ⊢ c ∶ A′ ⊒ B′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → _ ∣ Δᴿ ∣ Σ ⊢ c ∶ A′ ⊒ B′)
+        (sym (targetStoreResult inner)) c⊒⁺)
+
+  final-relation =
+    ⊑cast⊒ᵀ mode final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-target-cast-frameᵀ
+    inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-prefix-target-reveal-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ β X′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ₀)
+    β X′ c A′ B′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′ ⟨ c ⟩} {ρ = ρ⁺} q
+left-catchup-indexed-prefix-target-reveal-castᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c}
+    prefix c↑
+    catchup@(left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence) =
+  left-catchup-indexed-target-frameᵀ
+    catchup framed refl (left-silent-invariant refl refl)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  c↑⁺ = weaken-reveal-conversion
+    (rightStoreⁱ-prefix-inclusion prefix) c↑
+
+  final-conversion =
+    subst
+      (λ Δ → RevealConversion _ Δ
+        (rightStoreⁱ (resultStore inner)) _ _ c A′ B′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → RevealConversion _ Δᴿ Σ _ _ c A′ B′)
+        (sym (targetStoreResult inner)) c↑⁺)
+
+  final-relation =
+    ⊑conv↑ᵀ final-conversion
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-target-cast-frameᵀ
+    inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-prefix-target-conceal-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ β X′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ₀)
+    β X′ c A′ B′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′ ⟨ c ⟩} {ρ = ρ⁺} q
+left-catchup-indexed-prefix-target-conceal-castᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c}
+    prefix c↓
+    catchup@(left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence) =
+  left-catchup-indexed-target-frameᵀ
+    catchup framed refl (left-silent-invariant refl refl)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  c↓⁺ = weaken-conceal-conversion
+    (rightStoreⁱ-prefix-inclusion prefix) c↓
+
+  final-conversion =
+    subst
+      (λ Δ → ConcealConversion _ Δ
+        (rightStoreⁱ (resultStore inner)) _ _ c A′ B′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → ConcealConversion _ Δᴿ Σ _ _ c A′ B′)
+        (sym (targetStoreResult inner)) c↓⁺)
+
+  final-relation =
+    ⊑conv↓ᵀ final-conversion
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-target-cast-frameᵀ
+    inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-prefix-target-widen-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  CastMode μ →
+  SealModeStore★ μ (rightStoreⁱ ρ₀) →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ₀ ⊢ c ∶ A′ ⊑ B′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′ ⟨ c ⟩} {ρ = ρ⁺} q
+left-catchup-indexed-prefix-target-widen-castᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c}
+    prefix mode seal★ c⊑
+    catchup@(left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence) =
+  left-catchup-indexed-target-frameᵀ
+    catchup framed refl (left-silent-invariant refl refl)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  seal★⁺ = seal★-weaken
+    (rightStoreⁱ-prefix-inclusion prefix) seal★
+
+  c⊑⁺ = widen-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) c⊑
+
+  final-seal =
+    subst (SealModeStore★ _)
+      (sym (targetStoreResult inner)) seal★⁺
+
+  final-cast =
+    subst
+      (λ Δ → _ ∣ Δ ∣ rightStoreⁱ (resultStore inner)
+        ⊢ c ∶ A′ ⊑ B′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → _ ∣ Δᴿ ∣ Σ ⊢ c ∶ A′ ⊑ B′)
+        (sym (targetStoreResult inner)) c⊑⁺)
+
+  final-relation =
+    ⊑cast⊑ᵀ mode final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-target-cast-frameᵀ
+    inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-prefix-target-widen-id-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  SealModeStore★ id-onlyᵈ (rightStoreⁱ ρ₀) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ c ∶ A′ ⊑ B′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′ ⟨ c ⟩} {ρ = ρ⁺} q
+left-catchup-indexed-prefix-target-widen-id-castᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c}
+    prefix seal★ c⊑
+    catchup@(left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence) =
+  left-catchup-indexed-target-frameᵀ
+    catchup framed refl (left-silent-invariant refl refl)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  seal★⁺ = seal★-weaken {μ = id-onlyᵈ}
+    (rightStoreⁱ-prefix-inclusion prefix) seal★
+
+  c⊑⁺ = widen-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) c⊑
+
+  final-seal =
+    subst (SealModeStore★ id-onlyᵈ)
+      (sym (targetStoreResult inner)) seal★⁺
+
+  final-cast =
+    subst
+      (λ Δ → id-onlyᵈ ∣ Δ ∣ rightStoreⁱ (resultStore inner)
+        ⊢ c ∶ A′ ⊑ B′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → id-onlyᵈ ∣ Δᴿ ∣ Σ ⊢ c ∶ A′ ⊑ B′)
+        (sym (targetStoreResult inner)) c⊑⁺)
+
+  final-relation =
+    ⊑cast⊑idᵀ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-target-cast-frameᵀ
+    inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+------------------------------------------------------------------------
+-- Active arbitrary-type value catch-up worker
+------------------------------------------------------------------------
+
+left-catchup-indexed-prefix-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ A B}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK V →
+  Value V →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupIndexedResult
+    {N = V} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-prefix-valueᵀ
+    prefix okV vV noV′ V⊑V′ =
+  left-catchup-indexed-prefix-relatedᵀ
+    prefix (inj₁ (vV , runtime-value-no• okV vV))
+    V⊑V′ V⊢ V′⊢
+  where
+  V⊢ = term-weaken ≤-refl
+    (leftStoreⁱ-prefix-inclusion prefix)
+    (runtime-value-no• okV vV)
+    (nu-term-imprecision-source-typing V⊑V′)
+  V′⊢ = term-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) noV′
+    (nu-term-imprecision-target-typing V⊑V′)
+
+left-catchup-indexed-prefix-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ V′ A B}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ blame ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupIndexedResult
+    {N = blame} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-prefix-blameᵀ prefix noV′ blame⊑V′ =
+  left-catchup-indexed-prefix-relatedᵀ
+    prefix (inj₂ refl) blame⊑V′ blame⊢ V′⊢
+  where
+  blame⊢ = term-weaken ≤-refl
+    (leftStoreⁱ-prefix-inclusion prefix) no•-blame
+    (nu-term-imprecision-source-typing blame⊑V′)
+  V′⊢ = term-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) noV′
+    (nu-term-imprecision-target-typing blame⊑V′)
+
+weak-one-step-paired-double-cast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ A A′ d d′ u u′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ M M′ C C′ keep) →
+  LeftSilentInvariant inner →
+  (resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ ((sourceResult inner ⟨
+          applyCoercions (sourceChanges inner) d ⟩) ⟨
+        applyCoercions (sourceChanges inner) u ⟩)
+      ⊑ ((targetResult inner ⟨ d′ ⟩) ⟨ u′ ⟩)
+    ⦂ applyTys (sourceChanges inner) A ⊑
+        applyTys (targetTailChanges inner) (applyTy keep A′)
+    ∶ transportType inner pA) →
+  WeakOneStepResult ρ
+    ((M ⟨ d ⟩) ⟨ u ⟩) ((M′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+    A A′ keep
+weak-one-step-paired-double-cast-frameᵀ
+    {A = A} {A′ = A′}
+    {d = d} {d′ = d′} {u = u} {u′ = u′}
+    inner (left-silent-invariant refl refl) final =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = []
+    ; sourceResult = (sourceResult inner ⟨
+        applyCoercions (sourceChanges inner) d ⟩) ⟨
+          applyCoercions (sourceChanges inner) u ⟩
+    ; targetResult = (targetResult inner ⟨ d′ ⟩) ⟨ u′ ⟩
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) A
+    ; resultTargetType = A′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner _
+    ; sourceCatchup = cast-↠ (cast-↠ (sourceCatchup inner))
+    ; targetTail = cast-↠ (cast-↠ (targetTail inner))
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults = final
+    }
+
+left-catchup-final-runtime :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {result : WeakOneStepResult ρ M V′ A B keep} →
+  LeftCatchupInvariant result →
+  RuntimeOK (sourceResult result)
+left-catchup-final-runtime
+    (left-catchup-invariant silent
+      (inj₁ (vV , noV))) =
+  ok-no noV
+left-catchup-final-runtime
+    (left-catchup-invariant silent (inj₂ refl)) =
+  ok-no no•-blame
+
+weak-one-step-transport-source-fixed-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D μ d}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  ModeRename suc μ μ →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (inner : WeakOneStepResult ρ⁺ M M′ C C′ keep) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ₀ ⊢ d ∶ C ⊒ D →
+  μ ∣ resultLeftCtx inner ∣ leftStoreⁱ (resultStore inner)
+    ⊢ applyCoercions (sourceChanges inner) d
+      ∶ applyTys (sourceChanges inner) C
+      ⊒ applyTys (sourceChanges inner) D
+weak-one-step-transport-source-fixed-narrowingᵀ
+    {Δᴸ = Δᴸ} mode-suc prefix inner d⊒ =
+  subst
+    (λ Δ → _ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner) _
+        ∶ applyTys (sourceChanges inner) _
+        ⊒ applyTys (sourceChanges inner) _)
+    (sym (sourceCtxResult inner))
+    (subst
+      (λ Σ → _ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+        ⊢ applyCoercions (sourceChanges inner) _
+          ∶ applyTys (sourceChanges inner) _
+          ⊒ applyTys (sourceChanges inner) _)
+      (sym (sourceStoreResult inner))
+      (apply-fixed-narrows-typing mode-suc
+        (narrow-weaken ≤-refl
+          (leftStoreⁱ-prefix-inclusion prefix) d⊒)))
+
+weak-one-step-transport-target-narrowing-silentᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D′ μ d′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (inner : WeakOneStepResult ρ⁺ M M′ C C′ keep) →
+  LeftSilentInvariant inner →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ₀ ⊢ d′ ∶ C′ ⊒ D′ →
+  μ ∣ resultRightCtx inner ∣ rightStoreⁱ (resultStore inner)
+    ⊢ d′ ∶ C′ ⊒ D′
+weak-one-step-transport-target-narrowing-silentᵀ
+    {Δᴿ = Δᴿ} prefix inner
+    (left-silent-invariant refl refl) d′⊒ =
+  subst
+    (λ Δ → _ ∣ Δ ∣ rightStoreⁱ (resultStore inner)
+      ⊢ _ ∶ _ ⊒ _)
+    (sym (targetCtxResult inner))
+    (subst
+      (λ Σ → _ ∣ Δᴿ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+      (sym (targetStoreResult inner))
+      (narrow-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion prefix) d′⊒))
+
+weak-one-step-transport-id-downᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D D′ d d′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (indexed : WeakOneStepIndexedResult
+    {M = M} {N′ = M′} {χ = keep} {ρ = ρ⁺} pC) →
+  let inner = weakIndexedResult indexed in
+  LeftSilentInvariant inner →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀ ⊢ d ∶ C ⊒ D →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀ ⊢ d′ ∶ C′ ⊒ D′ →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺᵖ (sourceResult inner ⟨
+        applyCoercions (sourceChanges inner) d ⟩)
+      ⊑ (targetResult inner ⟨ d′ ⟩)
+    ⦂ applyTys (sourceChanges inner) D ⊑ᵖ
+      applyTys (targetTailChanges inner) (applyTy keep D′)
+    ∶ weak-one-step-transport-quotientᵀ inner qD
+weak-one-step-transport-id-downᵀ
+    prefix indexed (left-silent-invariant refl refl) d⊒ d′⊒ =
+  down⊑downᵀ
+    (weak-one-step-transport-source-fixed-narrowingᵀ
+      (modeRename-id-only suc) prefix inner d⊒)
+    (weak-one-step-transport-target-narrowing-silentᵀ
+      prefix inner (left-silent-invariant refl refl) d′⊒)
+    (canonicalIndexedResults indexed)
+    (weak-one-step-transport-quotientᵀ inner _)
+  where
+  inner = weakIndexedResult indexed
+
+weak-one-step-transport-gen-downᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D D′ d d′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (indexed : WeakOneStepIndexedResult
+    {M = M} {N′ = M′} {χ = keep} {ρ = ρ⁺} pC) →
+  let inner = weakIndexedResult indexed in
+  LeftSilentInvariant inner →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ d ∶ C ⊒ D →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ d′ ∶ C′ ⊒ D′ →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺᵖ (sourceResult inner ⟨
+        applyCoercions (sourceChanges inner) d ⟩)
+      ⊑ (targetResult inner ⟨ d′ ⟩)
+    ⦂ applyTys (sourceChanges inner) D ⊑ᵖ
+      applyTys (targetTailChanges inner) (applyTy keep D′)
+    ∶ weak-one-step-transport-quotientᵀ inner qD
+weak-one-step-transport-gen-downᵀ
+    prefix indexed (left-silent-invariant refl refl) d⊒ d′⊒ =
+  gen-down⊑gen-downᵀ
+    (weak-one-step-transport-source-fixed-narrowingᵀ
+      (modeRename-gen-tag-or-id suc) prefix inner d⊒)
+    (weak-one-step-transport-target-narrowing-silentᵀ
+      prefix inner (left-silent-invariant refl refl) d′⊒)
+    (canonicalIndexedResults indexed)
+    (weak-one-step-transport-quotientᵀ inner _)
+  where
+  inner = weakIndexedResult indexed
+
+weak-one-step-transport-quotient-widening-pairᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D D′ A A′ u u′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (inner : WeakOneStepResult ρ⁺ M M′ C C′ keep) →
+  LeftSilentInvariant inner →
+  QuotientWideningPair Δᴸ Δᴿ ρ₀ u u′ D D′ A A′ →
+  QuotientWideningPair
+    (resultLeftCtx inner) (resultRightCtx inner) (resultStore inner)
+    (applyCoercions (sourceChanges inner) u) u′
+    (applyTys (sourceChanges inner) D) D′
+    (applyTys (sourceChanges inner) A) A′
+weak-one-step-transport-quotient-widening-pairᵀ
+    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {D = D} {D′ = D′} {A = A} {A′ = A′}
+    prefix inner (left-silent-invariant refl refl)
+    (quotient-id-widening u⊑ u′⊑) =
+  quotient-id-widening source-u target-u
+  where
+  source-u⁺ = widen-weaken ≤-refl
+    (leftStoreⁱ-prefix-inclusion prefix) u⊑
+
+  source-u⁺⁺ = apply-fixed-widens-typing
+    (modeRename-id-only suc) source-u⁺
+
+  source-u =
+    subst
+      (λ Δ → id-onlyᵈ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) _
+          ∶ applyTys (sourceChanges inner) D
+          ⊑ applyTys (sourceChanges inner) A)
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → id-onlyᵈ ∣ applyTyCtxs (sourceChanges inner) Δᴸ
+          ∣ Σ ⊢ applyCoercions (sourceChanges inner) _
+          ∶ applyTys (sourceChanges inner) D
+          ⊑ applyTys (sourceChanges inner) A)
+        (sym (sourceStoreResult inner)) source-u⁺⁺)
+
+  target-u⁺ = widen-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) u′⊑
+
+  target-u =
+    subst
+      (λ Δ → id-onlyᵈ ∣ Δ ∣ rightStoreⁱ (resultStore inner)
+        ⊢ _ ∶ D′ ⊑ A′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → id-onlyᵈ ∣ Δᴿ ∣ Σ ⊢ _ ∶ D′ ⊑ A′)
+        (sym (targetStoreResult inner)) target-u⁺)
+weak-one-step-transport-quotient-widening-pairᵀ
+    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {D = D} {D′ = D′} {A = A} {A′ = A′}
+    prefix inner (left-silent-invariant refl refl)
+    (quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑)
+    with apply-widens-typing
+      { χs = sourceChanges inner }
+      mode
+      (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+      (widen-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion prefix) u⊑)
+weak-one-step-transport-quotient-widening-pairᵀ
+    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {D = D} {D′ = D′} {A = A} {A′ = A′}
+    prefix inner (left-silent-invariant refl refl)
+    (quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑)
+    | μˢ , modeˢ , seal★ˢ , uˢ⊑ =
+  quotient-cast-widening
+    modeˢ source-seal★ source-u
+    mode′ target-seal★ target-u
+  where
+  source-seal★ =
+    subst (SealModeStore★ μˢ)
+      (sym (sourceStoreResult inner)) seal★ˢ
+
+  source-u =
+    subst
+      (λ Δ → μˢ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) _
+          ∶ applyTys (sourceChanges inner) D
+          ⊑ applyTys (sourceChanges inner) A)
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μˢ ∣ applyTyCtxs (sourceChanges inner) Δᴸ
+          ∣ Σ ⊢ applyCoercions (sourceChanges inner) _
+          ∶ applyTys (sourceChanges inner) D
+          ⊑ applyTys (sourceChanges inner) A)
+        (sym (sourceStoreResult inner)) uˢ⊑)
+
+  target-seal★⁺ = seal★-weaken
+    (rightStoreⁱ-prefix-inclusion prefix) seal★′
+
+  target-seal★ =
+    subst (SealModeStore★ _)
+      (sym (targetStoreResult inner)) target-seal★⁺
+
+  target-u⁺ = widen-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) u′⊑
+
+  target-u =
+    subst
+      (λ Δ → _ ∣ Δ ∣ rightStoreⁱ (resultStore inner)
+        ⊢ _ ∶ D′ ⊑ A′)
+      (sym (targetCtxResult inner))
+      (subst
+        (λ Σ → _ ∣ Δᴿ ∣ Σ ⊢ _ ∶ D′ ⊑ A′)
+        (sym (targetStoreResult inner)) target-u⁺)
+
+left-silent-indexed-prefix-down-up-from-finalᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D D′ A A′ d d′ u u′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  QuotientWideningPair Δᴸ Δᴿ ρ₀ u u′ D D′ A A′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = M′} {ρ = ρ⁺} pC) →
+  let indexed = catchupIndexedResult catchup
+      inner = weakIndexedResult indexed
+  in
+  (resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺᵖ (sourceResult inner ⟨
+        applyCoercions (sourceChanges inner) d ⟩)
+      ⊑ (targetResult inner ⟨ d′ ⟩)
+    ⦂ applyTys (sourceChanges inner) D ⊑ᵖ
+      applyTys (targetTailChanges inner) (applyTy keep D′)
+    ∶ weak-one-step-transport-quotientᵀ inner qD) →
+  LeftSilentIndexedResult
+    {N = (M ⟨ d ⟩) ⟨ u ⟩}
+    {V′ = (M′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+    {ρ = ρ⁺} pA
+left-silent-indexed-prefix-down-up-from-finalᵀ
+    {pA = pA} prefix widening
+    (left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    down =
+  left-silent-indexed
+    (weak-indexed-result framed final-relation)
+    (left-silent-invariant refl refl)
+    (ok-⟨⟩ (ok-⟨⟩ (left-catchup-final-runtime invariant)))
+    (weak-step-transport (transportNo•Terms transport))
+    (weak-step-type-coherence
+      (transportArrowCoherent coherence)
+      (transportAllCoherent coherence))
+  where
+  inner = weakIndexedResult indexed
+
+  final-widening =
+    weak-one-step-transport-quotient-widening-pairᵀ
+      prefix inner silent widening
+
+  final-relation =
+    up⊑upᵀ down final-widening (transportType inner pA)
+
+  framed = weak-one-step-paired-double-cast-frameᵀ
+    inner silent final-relation
+
+left-catchup-indexed-prefix-down-upᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D D′ A A′ d d′ u u′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK ((M ⟨ d ⟩) ⟨ u ⟩) →
+  Value M′ →
+  No• M′ →
+  Inert d′ →
+  Inert u′ →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀ ⊢ d ∶ C ⊒ D →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀ ⊢ d′ ∶ C′ ⊒ D′ →
+  QuotientWideningPair Δᴸ Δᴿ ρ₀ u u′ D D′ A A′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = M′} {ρ = ρ⁺} pC) →
+  LeftCatchupIndexedResult
+    {N = (M ⟨ d ⟩) ⟨ u ⟩}
+    {V′ = (M′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+    {ρ = ρ⁺} pA
+left-catchup-indexed-prefix-down-upᵀ
+    prefix okM vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening
+    catchup@(left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    with left-catchup-indexed-final-quotientᵀ
+      vM′ noM′ inert-d′ inert-u′
+      (weak-one-step-transport-id-downᵀ
+        prefix indexed silent d⊒ d′⊒)
+      (weak-one-step-transport-quotient-widening-pairᵀ
+        prefix (weakIndexedResult indexed) silent widening)
+      (transportType (weakIndexedResult indexed) _)
+      (sourceIsValueOrBlame invariant)
+left-catchup-indexed-prefix-down-upᵀ
+    prefix okM vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening
+    catchup@(left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    | inj₁ second =
+  left-catchup-indexed-resume-silentᵀ
+    (left-silent-indexed-prefix-down-up-from-finalᵀ
+      prefix widening catchup
+      (weak-one-step-transport-id-downᵀ
+        prefix indexed silent d⊒ d′⊒))
+    second
+left-catchup-indexed-prefix-down-upᵀ
+    prefix okM vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening
+    catchup@(left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    | inj₂ (B , s , u≡inst , source↠) =
+  {!!}
+
+left-catchup-indexed-prefix-gen-down-upᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ C C′ D D′ A A′ d d′ u u′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK ((M ⟨ d ⟩) ⟨ u ⟩) →
+  Value M′ →
+  No• M′ →
+  Inert d′ →
+  Inert u′ →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ d ∶ C ⊒ D →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ d′ ∶ C′ ⊒ D′ →
+  QuotientWideningPair Δᴸ Δᴿ ρ₀ u u′ D D′ A A′ →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = M′} {ρ = ρ⁺} pC) →
+  LeftCatchupIndexedResult
+    {N = (M ⟨ d ⟩) ⟨ u ⟩}
+    {V′ = (M′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+    {ρ = ρ⁺} pA
+left-catchup-indexed-prefix-gen-down-upᵀ
+    prefix okM vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening
+    catchup@(left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    with left-catchup-indexed-final-quotientᵀ
+      vM′ noM′ inert-d′ inert-u′
+      (weak-one-step-transport-gen-downᵀ
+        prefix indexed silent d⊒ d′⊒)
+      (weak-one-step-transport-quotient-widening-pairᵀ
+        prefix (weakIndexedResult indexed) silent widening)
+      (transportType (weakIndexedResult indexed) _)
+      (sourceIsValueOrBlame invariant)
+left-catchup-indexed-prefix-gen-down-upᵀ
+    prefix okM vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening
+    catchup@(left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    | inj₁ second =
+  left-catchup-indexed-resume-silentᵀ
+    (left-silent-indexed-prefix-down-up-from-finalᵀ
+      prefix widening catchup
+      (weak-one-step-transport-gen-downᵀ
+        prefix indexed silent d⊒ d′⊒))
+    second
+left-catchup-indexed-prefix-gen-down-upᵀ
+    prefix okM vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening
+    catchup@(left-indexed-catchup indexed
+      invariant@(left-catchup-invariant
+        silent@(left-silent-invariant refl refl) final)
+      transport coherence)
+    | inj₂ (B , s , u≡inst , source↠) =
+  {!!}
+
+left-catchup-indexed-prefixᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ A B}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK N →
+  Value V′ →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′ rel@(blame⊑ᵀ V′⊢) =
+  left-catchup-indexed-prefix-blameᵀ prefix noV′ rel
+left-catchup-indexed-prefixᵀ
+    prefix okN (vM′ ⟨ inert-d′ ⟩ ⟨ inert-u′ ⟩)
+    (no•-⟨⟩ (no•-⟨⟩ noM′))
+    (up⊑upᵀ
+      (down⊑downᵀ d⊒ d′⊒ M⊑M′ qD) widening pA) =
+  left-catchup-indexed-prefix-down-upᵀ
+    prefix okN vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening inner
+  where
+  inner = left-catchup-indexed-prefixᵀ prefix
+    (runtime-⟨⟩ (runtime-⟨⟩ okN)) vM′ noM′ M⊑M′
+left-catchup-indexed-prefixᵀ
+    prefix okN (vM′ ⟨ inert-d′ ⟩ ⟨ inert-u′ ⟩)
+    (no•-⟨⟩ (no•-⟨⟩ noM′))
+    (up⊑upᵀ
+      (gen-down⊑gen-downᵀ d⊒ d′⊒ M⊑M′ qD)
+      widening pA) =
+  left-catchup-indexed-prefix-gen-down-upᵀ
+    prefix okN vM′ noM′ inert-d′ inert-u′
+    d⊒ d′⊒ widening inner
+  where
+  inner = left-catchup-indexed-prefixᵀ prefix
+    (runtime-⟨⟩ (runtime-⟨⟩ okN)) vM′ noM′ M⊑M′
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(allocation-prefixᵀ prefix₀ inner N⊢ V′⊢) =
+  left-catchup-indexed-prefixᵀ
+    (store-imp-prefix-transⁱ prefix₀ prefix)
+    okN vV′ noV′ inner
+left-catchup-indexed-prefixᵀ
+    prefix okN (vV′ ⟨ inert ⟩) (no•-⟨⟩ noV′)
+    (⊑cast⊒ᵀ mode seal★ c⊒ rel q) =
+  left-catchup-indexed-prefix-target-narrow-castᵀ
+    prefix mode seal★ c⊒
+    (left-catchup-indexed-prefixᵀ
+      prefix okN vV′ noV′ rel)
+left-catchup-indexed-prefixᵀ
+    prefix okN (vV′ ⟨ inert ⟩) (no•-⟨⟩ noV′)
+    (⊑cast⊑ᵀ mode seal★ c⊑ rel q) =
+  left-catchup-indexed-prefix-target-widen-castᵀ
+    prefix mode seal★ c⊑
+    (left-catchup-indexed-prefixᵀ
+      prefix okN vV′ noV′ rel)
+left-catchup-indexed-prefixᵀ
+    prefix okN (vV′ ⟨ inert ⟩) (no•-⟨⟩ noV′)
+    (⊑cast⊑idᵀ seal★ c⊑ rel q) =
+  left-catchup-indexed-prefix-target-widen-id-castᵀ
+    prefix seal★ c⊑
+    (left-catchup-indexed-prefixᵀ
+      prefix okN vV′ noV′ rel)
+left-catchup-indexed-prefixᵀ
+    prefix okN (vV′ ⟨ inert ⟩) (no•-⟨⟩ noV′)
+    (⊑conv↑ᵀ c↑ rel q) =
+  left-catchup-indexed-prefix-target-reveal-castᵀ
+    prefix c↑
+    (left-catchup-indexed-prefixᵀ
+      prefix okN vV′ noV′ rel)
+left-catchup-indexed-prefixᵀ
+    prefix okN (vV′ ⟨ inert ⟩) (no•-⟨⟩ noV′)
+    (⊑conv↓ᵀ c↓ rel q) =
+  left-catchup-indexed-prefix-target-conceal-castᵀ
+    prefix c↓
+    (left-catchup-indexed-prefixᵀ
+      prefix okN vV′ noV′ rel)
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′ (x⊑xᵀ x∈)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′ rel@(ƛ⊑ƛᵀ hA hA′ body) =
+  left-catchup-indexed-prefix-valueᵀ
+    prefix okN (ƛ _) noV′ rel
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′ (·⊑·ᵀ L⊑L′ M⊑M′)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(Λ⊑Λᵀ liftρ liftγ vV vW′ body) =
+  left-catchup-indexed-prefix-valueᵀ
+    prefix okN (Λ vV) noV′ rel
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(Λ⊑ᵀ occ liftρ liftγ vV body) =
+  left-catchup-indexed-prefix-valueᵀ
+    prefix okN (Λ vV) noV′ rel
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′
+    (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ
+      L⊑L′ L•⊢ L′•⊢)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    (α⊑ᵀ vΛ (no•-Λ noW) h⇑A liftρᵃ lift-left-ctx-[]
+      (Λ⊑ᵀ occ liftρᵇ lift-left-ctx-[] vW W⊑V′) L•⊢ V′⊢) =
+  left-catchup-indexed-prefix-α-Λᵀ
+    vW noW noV′ h⇑A liftρᵃ liftρᵇ prefix W⊑V′
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑V′ L•⊢ V′⊢) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′
+    (⊑αᵀ vL′ noL′ h⇑A liftρ liftγ N⊑L′ r N⊢ L′•⊢)
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′
+    (ν⊑νᵀ hA hA′ s↑ s′↑ pA pA⇑ liftρ liftγ N⊑N′)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑V′) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′
+    (⊑νᵀ hA h⇑A s↑ liftρ liftγ pC N⊑N′)
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′
+    (νcast⊑νcastᵀ mode seal★ mode′ seal★′
+      s⊑ s′⊑ liftρ liftγ N⊑N′)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(νcast⊑ᵀ mode seal★ s⊑ liftρ liftγ N⊑V′) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′
+    (⊑νcastᵀ mode seal★ s⊑ liftρ liftγ pC N⊑N′)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′ rel@κ⊑κᵀ =
+  left-catchup-indexed-prefix-valueᵀ
+    prefix okN ($ _) noV′ rel
+left-catchup-indexed-prefixᵀ
+    prefix okN () noV′ (⊕⊑⊕ᵀ L⊑L′ M⊑M′)
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(cast⊒⊑ᵀ mode seal★ c⊒ N⊑V′ q) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(cast⊑⊑ᵀ mode seal★ c⊑ N⊑V′ q) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(conv⊑convᵀ conversion N⊑V′) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(conv↑⊑ᵀ c↑ N⊑V′ q) =
+  {!!}
+left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(conv↓⊑ᵀ c↓ N⊑V′ q) =
+  {!!}
+
+left-catchup-indexed-source-all-prefixᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C B}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK N →
+  Value V′ →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ B ∶ p →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-source-all-prefixᵀ
+    prefix okN vV′ noV′ N⊑V′ =
+  left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′ N⊑V′
+
+left-catchup-indexed-source-allᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B ⊣ Δᴿ} →
+  RuntimeOK N →
+  Value V′ →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ B ∶ p →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-source-allᵀ okN vV′ noV′ N⊑V′ =
+  left-catchup-indexed-source-all-prefixᵀ
+    prefix-reflⁱ okN vV′ noV′ N⊑V′
+
+left-catchup-indexed-all-prefixᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK N →
+  Value V′ →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} q
+left-catchup-indexed-all-prefixᵀ
+    prefix okN vV′ noV′ N⊑V′ =
+  specialize-left-indexed-all-catchup
+    (left-catchup-indexed-source-all-prefixᵀ
+      prefix okN vV′ noV′ N⊑V′)
+
+left-catchup-indexed-allᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  RuntimeOK N →
+  Value V′ →
+  No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-allᵀ okN vV′ noV′ N⊑V′ =
+  left-catchup-indexed-all-prefixᵀ
+    prefix-reflⁱ okN vV′ noV′ N⊑V′
+
+------------------------------------------------------------------------
+-- Matched allocation leaves for the one-step dispatcher
+------------------------------------------------------------------------
+
+weak-one-step-matched-ν↑-source-allᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RuntimeOK (ν A N s) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  ν A′ V′ s′ —→[ bind A′ ] ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩ →
+  WeakOneStepIndexedOutcome
+    {M = ν A N s}
+    {N′ = ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩}
+    {A = B} {B = B′} {χ = bind A′} {ρ = ρ} pB
+weak-one-step-matched-ν↑-source-allᵀ
+    wfΣ′ okν s↑ s′↑ N⊑V′ (ν-step vV′ noV′) =
+  weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
+    wfΣ′ s↑ s′↑ _ _ vV′ noV′
+    (left-catchup-indexed-allᵀ
+      (runtime-ν okν) vV′ noV′ N⊑V′)
+
+weak-one-step-matched-νcast-source-allᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RuntimeOK (ν ★ N s) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  ν ★ V′ s′ —→[ bind ★ ] ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩ →
+  WeakOneStepIndexedOutcome
+    {M = ν ★ N s}
+    {N′ = ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩}
+    {A = B} {B = B′} {χ = bind ★} {ρ = ρ} pB
+weak-one-step-matched-νcast-source-allᵀ
+    wfΣ′ okν mode seal★ s⊑ mode′ seal★′ s′⊑
+    N⊑V′ (ν-step vV′ noV′) =
+  weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
+    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ _
+    vV′ noV′
+    (left-catchup-indexed-allᵀ
+      (runtime-ν okν) vV′ noV′ N⊑V′)
+
+------------------------------------------------------------------------
+-- Active indexed one-step dispatcher
+------------------------------------------------------------------------
+
+weak-one-step-indexed-simulationᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ N′ A B χ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  RuntimeOK M →
+  RuntimeOK M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  M′ —→[ χ ] N′ →
+  WeakOneStepIndexedOutcome
+    {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′ (blame⊑ᵀ M′⊢) M′→N′ =
+  indexed-outcome-source-blame ↠-refl
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (ν⊑νᵀ hA hA′ s↑ s′↑ pA pA⇑
+      liftρ liftγ N⊑V′)
+    red@(ν-step vV′ noV′) =
+  weak-one-step-matched-ν↑-source-allᵀ
+    {pA = pA} wfΣ′ okM s↑ s′↑ N⊑V′ red
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (ν⊑νᵀ hA hA′ s↑ s′↑ pA pA⇑
+      liftρ liftγ N⊑N′)
+    (ξ-ν N′→N₁′) =
+  weak-one-step-matched-ν-indexed-frame-outcomeᵀ
+    s↑ s′↑ pA _ inner
+  where
+  inner = weak-one-step-indexed-simulationᵀ
+    wfΣ′ (runtime-ν okM) (runtime-ν okM′) N⊑N′ N′→N₁′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (ν⊑νᵀ hA hA′ s↑ s′↑ pA pA⇑
+      liftρ liftγ (blame⊑ᵀ blame⊢))
+    blame-ν =
+  indexed-outcome-source-blame
+    (↠-step blame-ν ↠-refl)
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (νcast⊑νcastᵀ mode seal★ mode′ seal★′
+      s⊑ s′⊑ liftρ liftγ N⊑V′)
+    red@(ν-step vV′ noV′) =
+  weak-one-step-matched-νcast-source-allᵀ
+    wfΣ′ okM mode seal★ s⊑ mode′ seal★′ s′⊑ N⊑V′ red
+weak-one-step-indexed-simulationᵀ {χ = χ}
+    wfΣ′ okM okM′
+    (νcast⊑νcastᵀ mode seal★ mode′ seal★′
+      s⊑ s′⊑ liftρ liftγ N⊑N′)
+    (ξ-ν N′→N₁′)
+    rewrite applyTy-★ χ =
+  weak-one-step-matched-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ _ inner
+  where
+  inner = weak-one-step-indexed-simulationᵀ
+    wfΣ′ (runtime-ν okM) (runtime-ν okM′) N⊑N′ N′→N₁′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (νcast⊑νcastᵀ mode seal★ mode′ seal★′
+      s⊑ s′⊑ liftρ liftγ (blame⊑ᵀ blame⊢))
+    blame-ν =
+  indexed-outcome-source-blame
+    (↠-step blame-ν ↠-refl)
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑N′)
+    N′→N₁′ =
+  weak-one-step-source-ν-indexed-frame-outcomeᵀ
+    hA s↑ _ inner
+  where
+  inner = weak-one-step-indexed-simulationᵀ
+    wfΣ′ (runtime-ν okM) okM′ N⊑N′ N′→N₁′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (νcast⊑ᵀ mode seal★ s⊑ liftρ liftγ N⊑N′)
+    N′→N₁′ =
+  weak-one-step-source-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ _ inner
+  where
+  inner = weak-one-step-indexed-simulationᵀ
+    wfΣ′ (runtime-ν okM) okM′ N⊑N′ N′→N₁′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (⊑νᵀ hA h⇑A s↑ liftρ liftγ pC N⊑V′)
+    (ν-step vV′ noV′) =
+  weak-one-step-right-ν↑-indexed-outcomeᵀ
+    vV′ noV′ h⇑A s↑ _ pC liftρ N⊑V′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (⊑νᵀ hA h⇑A s↑ liftρ liftγ pC N⊑N′)
+    (ξ-ν N′→N₁′) =
+  weak-one-step-target-ν-indexed-frame-outcomeᵀ
+    hA s↑ _ pC inner
+  where
+  inner = weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM (runtime-ν okM′) N⊑N′ N′→N₁′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (⊑νᵀ hA h⇑A s↑ liftρ liftγ pC
+      (blame⊑ᵀ blame⊢))
+    blame-ν =
+  indexed-outcome-source-blame ↠-refl
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (⊑νcastᵀ mode seal★ s⊑ liftρ liftγ pC N⊑V′)
+    (ν-step vV′ noV′) =
+  weak-one-step-right-νcast-indexed-outcomeᵀ
+    vV′ noV′ mode seal★ s⊑ _ pC liftρ N⊑V′
+weak-one-step-indexed-simulationᵀ {χ = χ}
+    wfΣ′ okM okM′
+    (⊑νcastᵀ mode seal★ s⊑ liftρ liftγ pC N⊑N′)
+    (ξ-ν N′→N₁′)
+    rewrite applyTy-★ χ =
+  weak-one-step-target-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ _ pC inner
+  where
+  inner = weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM (runtime-ν okM′) N⊑N′ N′→N₁′
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (⊑νcastᵀ mode seal★ s⊑ liftρ liftγ pC
+      (blame⊑ᵀ blame⊢))
+    blame-ν =
+  indexed-outcome-source-blame ↠-refl

--- a/GTSF/proof/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/NuImprecisionDGGProgress.md
@@ -26,7 +26,7 @@ cases.
 | Paired conceal `β-∀•` | checked through allocation | Same theorem handles both paired conversion forms |
 | One-sided reveal/conceal `β-∀•` | checked | Left/right reveal and conceal lemmas |
 | Generic narrowing/widening `β-∀•` | checked one-step boundary | Both constructor orders and all four combinations return `WeakOneStepResult` |
-| Source-only canonical-`∀` catchup | checked | Terminal, `α/Λ`, reveal, conceal, generic narrowing, and generic widening clauses |
+| Source-only canonical-`∀` catchup | partial | Now a specialization of arbitrary-type value catchup; terminal values, impossible target shapes, target wrappers, prefix recursion, the direct `α/Λ` leaf, and quotient recursion are checked; ten cast/allocation helper holes remain |
 | `β-gen•` | partial | Matched reconstruction and one-sided administrative clause checked; source-allocation naturality remains |
 | `β-inst` followed by `ν ★` allocation | checked locally | Matched, left-only, and right-only two-step lemmas |
 | Polymorphic value-shape inversion | checked locally | `Λ`, `∀` cast, or `gen`; each forces one administrative step |
@@ -35,8 +35,8 @@ cases.
 | Swapped two-allocation relation boundary | checked locally | `allocation-crossedᵀ`; projections equal the two-`bind` traces |
 | Reduction under `ν` and `ν ★` | checked | Matched, source-only, and target-only outer frame lemmas |
 | `blame-ν` | checked outcome | Exceptional outcomes carry a source catchup to blame; source frames lift it with `ν-blame-tail` |
-| Administrative simulation-up-to | partial | Composition and all six `ν`-frame outcome maps are checked |
-| One-step Nu-imprecision simulation | partial | Direct quotient and generic `β-∀•` clauses are checked |
+| Administrative simulation-up-to | partial | Composition and all six `ν`-frame outcome maps preserve transport-bearing outcomes |
+| One-step Nu-imprecision simulation | partial | Direct quotient, generic `β-∀•`, matched/one-sided `ν`, and arbitrary-type value-catchup recursion are checked; the dispatcher remains intentionally incomplete |
 | Terminal target-trace alignment | checked | Determinism makes every administrative `targetTail` a prefix of an observed trace to a value or blame |
 | Closed `GradualDGG` | checked reduction | `closed-nu-dgg⇒gradual-dgg` reduces it to `ClosedNuDGG`, which now follows from exactly three terminal simulation clauses |
 
@@ -597,9 +597,9 @@ arbitrary store replacement.
   adjacent swap:
 
   \[
-    \mathsf{inst}(\mathsf{ext}(\mathsf{tag\mbox{-}or\mbox{-}id)) )
+    \mathsf{inst}(\mathsf{ext}(\mathsf{tag\text{-}or\text{-}id)) )
     \quad\text{and}\quad
-    \mathsf{ext}(\mathsf{inst}(\mathsf{tag\mbox{-}or\mbox{-}id)) ).
+    \mathsf{ext}(\mathsf{inst}(\mathsf{tag\text{-}or\text{-}id)) ).
   \]
 
   Its source and target typing projections use the corresponding nested cast
@@ -857,8 +857,9 @@ arbitrary store replacement.
   is closed under simulation-up-to composition. The temporary
   `WeakOneStepRightAllResult` wrapper was deleted after this generalization.
 - Defined `WeakOneStepOutcome`. A target step produces either a related
-  `WeakOneStepResult` or evidence that the more-precise source reduces to
-  `blame`. A target reduction to blame is not by itself a simulation outcome.
+  `WeakOneStepResult` together with its `WeakOneStepTransport`, or evidence
+  that the more-precise source reduces to `blame`. A target reduction to
+  blame is not by itself a simulation outcome.
 - Proved `ν-blame-tail` and the three outcome maps
   `weak-outcome-map-source`, `weak-outcome-map-target-ν`, and
   `weak-all-outcome-map-target-ν`. Their six concrete corollaries cover
@@ -1705,11 +1706,12 @@ bodies would be unsound as a proof strategy.
 
 These pieces feed the total derivation-recursive one-step theorem with
 codomain `WeakOneStepOutcome`. Its ordinary operational leaves return
-`WeakOneStepResult` and can be injected with `outcome-related`. A target-blame
-leaf must first establish a source reduction to blame and then use
-`outcome-source-blame`. When the input type relation is headed by `∀ⁱ`,
-recursion returns `WeakOneStepAllOutcome`, retaining the canonical body
-derivation. The later audit of one-sided `β-gen•` shapes remains separate.
+`WeakOneStepResult` and a proof that the result transports every bullet-free
+relation in the original world. A target-blame leaf must first establish a
+source reduction to blame and then use `outcome-source-blame`. When the input
+type relation is headed by `∀ⁱ`, recursion returns `WeakOneStepAllOutcome`,
+retaining both the canonical body derivation and the transport witness. The
+later audit of one-sided `β-gen•` shapes remains separate.
 
 The generic lifting obstruction remains useful: `crossed-bodyᵀ` closes only
 the paired direct-swap quotient boundary and does not reintroduce the false
@@ -1823,3 +1825,3125 @@ require their separate audit afterward.
   types, and related-result derivation.
 - No term- or type-imprecision definition changed. The focused spine and the
   aggregate development pass with `--no-allow-unsolved-metas`.
+
+### First structural dispatcher boundary
+
+- Proved the application-left frame `weak-one-step-·₁-frameᵀ`. Suppose
+
+  \[
+    L \sqsubseteq L',
+    \qquad
+    L' \longrightarrow^{\chi} L_1',
+  \]
+
+  and recursive simulation of the function step produces source changes
+  \(\bar\chi_L\), target-tail changes \(\bar\chi_R\), and related
+  endpoints \(W_L \sqsubseteq W_R\). If the recursive result retains the
+  canonical arrow relation
+
+  \[
+    W_L \sqsubseteq W_R :
+      \operatorname{apply}(\bar\chi_L,A) \to
+      \operatorname{apply}(\bar\chi_L,B)
+      \;\sqsubseteq\;
+      \operatorname{apply}(\bar\chi_R,\chi A') \to
+      \operatorname{apply}(\bar\chi_R,\chi B')
+  \]
+
+  and the untouched arguments are transported to
+
+  \[
+    \operatorname{apply}(\bar\chi_L,M)
+      \sqsubseteq
+    \operatorname{apply}(\bar\chi_R,\chi M'),
+  \]
+
+  then the whole applications are related after the same changes. The source
+  and target traces are the function traces lifted through their application
+  frames.
+- Proved `weak-one-step-·₁-frame-outcomeᵀ`, which lifts both sound
+  outcomes.
+  The related branch uses the frame theorem above. In the source-blame branch,
+  `·₁-blame-tail` gives the whole-term trace
+
+  \[
+    L\,M
+      \longrightarrow^{\bar\chi_L *}
+    \mathsf{blame}\,
+      \operatorname{apply}(\bar\chi_L,M)
+      \longrightarrow
+    \mathsf{blame}.
+  \]
+
+  Thus framing does not reintroduce the rejected alternative in which target
+  blame alone is sufficient.
+- This boundary identifies the next exact dispatcher obligation: construct
+  the two transported relations above from the recursive result and the
+  original `L ⊑ L'` and `M ⊑ M'` derivations. This is the term-naturality
+  recursion already motivated by allocations; it must preserve canonical
+  arrow shape, not merely return an unstructured `WeakOneStepResult`.
+- No term-imprecision or type-imprecision rule changed.
+
+### No-bullet term transport through weak results
+
+- The application frame exposed information not present in
+  `WeakOneStepResult`. Its `transportType` field transports
+  \(A \sqsubseteq A'\), but that alone cannot produce
+
+  \[
+    \operatorname{apply}(\bar\chi_L,M)
+      \sqsubseteq
+    \operatorname{apply}(\bar\chi_R,\chi M').
+  \]
+
+  In particular, equality of the erased source and target stores does not
+  reconstruct the proof-relevant matched, left, right, and linked entries
+  needed by the term judgment.
+- Defined the proof-only invariant `WeakOneStepTransport result`. For every
+  original derivation
+
+  \[
+    M \sqsubseteq M' : A \sqsubseteq A'
+  \]
+
+  whose two terms contain no runtime bullet, it transports the whole
+  derivation through exactly the source changes, observed target change, and
+  target administrative tail recorded by `result`. Its conclusion is
+
+  \[
+    \operatorname{apply}(\bar\chi_L,M)
+      \sqsubseteq
+    \operatorname{apply}(\bar\chi_R,\chi M')
+      :
+    \operatorname{apply}(\bar\chi_L,A)
+      \sqsubseteq
+    \operatorname{apply}(\bar\chi_R,\chi A').
+  \]
+
+- Proved `weak-one-step-related-transportᵀ`: the reflexive weak result
+  preserves every no-bullet term derivation unchanged.
+- Proved `weak-one-step-·₁-frame-transportᵀ`. Given the canonical
+  transported arrow relation for the recursively simulated function, the
+  frame obtains its argument premise by applying `WeakOneStepTransport` to
+  the original derivation \(M \sqsubseteq M'\).
+- Proved `weak-one-step-·₁-frame-preserves-transportᵀ`. Framing changes
+  neither allocation sequence nor world transformation, so the inner
+  transport invariant is also the transport invariant of the whole
+  application result.
+- Proved the corresponding sound outcome theorem
+  `weak-one-step-·₁-frame-transport-outcomeᵀ`. Its exceptional branch still
+  requires a source trace to blame.
+- The next leaf obligation is to construct `WeakOneStepTransport` for the
+  allocation-producing results. Matched, left-only, right-only, and crossed
+  allocations must use their proof-relevant store/context actions; erased
+  store equalities are deliberately insufficient.
+- No term-imprecision or type-imprecision definition changed.
+
+### Allocation transport exposes store-representation sensitivity
+
+- Attempted the structural recursion needed to construct
+  `WeakOneStepTransport` for allocation-producing leaves. Every ordinary
+  term constructor, both quotiented cast constructors, all six `ν` forms,
+  `Λ`, conversions, and casts admits the expected no-bullet action using the
+  existing lemmas. The remaining cases are exactly the proof-only
+  `allocation-matchedᵀ`, `allocation-leftᵀ`, `allocation-crossedᵀ`, and
+  swap wrappers.
+- The obstruction is the exact representation of `StoreImp`, rather than a
+  missing type action. For example, suppose an existing matched wrapper has
+  added
+
+  \[
+    \mathsf{storeMatched}(\alpha,A,\beta,B)
+  \]
+
+  and a later source-only allocation transports it. Its image is
+
+  \[
+    \mathsf{storeMatched}
+      (\alpha+1,\uparrow A,\beta,B).
+  \]
+
+  The resulting world has assumptions
+
+  \[
+    0\sqsubseteq\star,
+    \qquad
+    1\sqsubseteq 0,
+  \]
+
+  so it is neither a fresh matched extension nor a fresh left-only extension.
+  The current specialized wrappers cannot rebuild the relation in that exact
+  store, even though all erased source and target stores have the expected
+  shapes. Repeating this per allocation order would create the open-ended
+  family of special cases that the proof strategy is intended to avoid.
+- The minimal definition-level repair to evaluate next is consolidation, not
+  expansion: replace the three specialized proof-only store-extension
+  wrappers by one prefix-extension wrapper. Its premise should contain an
+  explicit proof that the old `StoreImp` is a suffix of the new one, the inner
+  term relation at the old store, and both endpoint typings at the extended
+  store. This retains the current wrappers' essential restriction against
+  arbitrary store replacement, reduces the number of simulation cases, and
+  makes nested matched, one-sided, and crossed allocations instances of one
+  invariant.
+- This consolidation was approved and is implemented below.
+
+### Allocation prefixes replace the specialized wrappers
+
+- Defined the constructor-form judgment
+
+  \[
+    \mathsf{StoreImpPrefix}(\rho_0,\rho^+),
+  \]
+
+  whose reflexive case says that a store is its own suffix and whose step
+  case adds one `StoreImpEntry` to the front of the extended store. Thus the
+  judgment records exactly that
+
+  \[
+    \rho^+ = e_1 :: \cdots :: e_n :: \rho_0
+  \]
+
+  without putting a list function in an indexed datatype.
+- Replaced `allocation-matchedᵀ`, `allocation-leftᵀ`, and
+  `allocation-crossedᵀ` by the single rule `allocation-prefixᵀ`. If
+
+  \[
+    \mathsf{StoreImpPrefix}(\rho_0,\rho^+),
+    \qquad
+    \Phi;\Delta_L;\Delta_R;\rho_0;\Gamma
+      \vdash M \sqsubseteq M' : A \sqsubseteq B,
+  \]
+
+  and both endpoints have their final typings in the projected stores of
+  \(\rho^+\), then
+
+  \[
+    \Phi;\Delta_L;\Delta_R;\rho^+;\Gamma
+      \vdash M \sqsubseteq M' : A \sqsubseteq B.
+  \]
+
+  The rule therefore changes only the proof-relevant store prefix; it does
+  not relate new term or type shapes.
+- Migrated every construction site. A matched or one-sided allocation uses a
+  one-entry prefix. The opposite-order two-allocation traces use the exact
+  six-entry prefix consisting of two left entries, two right entries, and
+  the two crossed links. The three obsolete constructors were deleted, and
+  the source- and target-typing projections now have one prefix case.
+- Proved `left-store-rename-prefix-invⁱ`. If a left store renaming maps an
+  extended store, this lemma exposes a renamed old suffix and the
+  corresponding renamed prefix proof. Proved the direct structural clause
+  `left-rename-allocation-prefixᵀ`, which recursively transports the inner
+  derivation at that suffix and rebuilds the single prefix rule using the
+  final transported typings.
+- The next transport boundary is now sharply isolated. The general
+  no-runtime-bullet naturality recursion can use this one prefix clause for
+  every allocation prefix. Its only remaining non-structural term-shape
+  cases are `swapRight-bodyᵀ` and `swapLeft-bodyᵀ`; those wrappers are
+  intentionally not folded into prefix extension because they permute terms
+  and types rather than merely extending a store.
+- `QuotientedTermImprecision.agda` and
+  `proof/NuImprecisionSimulation.agda` pass with
+  `--no-allow-unsolved-metas` after the consolidation.
+
+### Dependency-preserving permutation boundary
+
+- Added the reusable endpoint notion
+
+  \[
+    \pi : \Delta \mathrel{\rightsquigarrow} \Theta.
+  \]
+
+  A witness contains renamings \(\pi\) and \(\pi^{-1}\), boundedness proofs
+  in both directions, and both inverse laws. Identity, symmetry, extension
+  under a fresh binder, and the adjacent transposition are proved instances.
+  Thus a permutation is not merely an arbitrary function on de Bruijn
+  indices.
+- Added proof-relevant actions on related stores and term contexts. Given
+  endpoint permutations \(\pi_L\) and \(\pi_R\), the assumption action is
+
+  \[
+    X \sqsubseteq Y
+      \longmapsto
+    \pi_L(X) \sqsubseteq \pi_R(Y),
+    \qquad
+    X \sqsubseteq \star
+      \longmapsto
+    \pi_L(X) \sqsubseteq \star.
+  \]
+
+  `RelStoreRenameⁱ` and `RelCtxRenameⁱ` then require the target related
+  store and context explicitly. This is the mechanized dependency check:
+  a proposed permutation is usable only when the renamed entries, endpoint
+  types, and imprecision assumptions inhabit the proposed target world.
+- Packaged these components as `RelWorldPermutationⁱ`. Besides the two
+  endpoint bijections, it carries the two coercion-mode actions. The latter
+  is essential: permuting names in coercions must also permute the mode
+  environment that controls whether a name may be sealed or tagged.
+- Proved the projection equations
+
+  \[
+  \begin{aligned}
+    \mathsf{leftStore}(\varpi\rho)
+      &= \pi_L\,\mathsf{leftStore}(\rho), \\
+    \mathsf{rightStore}(\varpi\rho)
+      &= \pi_R\,\mathsf{rightStore}(\rho), \\
+    \mathsf{leftCtx}(\varpi\Gamma)
+      &= \pi_L\,\mathsf{leftCtx}(\Gamma), \\
+    \mathsf{rightCtx}(\varpi\Gamma)
+      &= \pi_R\,\mathsf{rightCtx}(\Gamma).
+  \end{aligned}
+  \]
+
+  Consequently, for terms with no runtime bullet, endpoint typing already
+  transports through a related-world permutation:
+
+  \[
+    \Delta_L;\Sigma_L;\Gamma_L \vdash M : A
+    \quad\Longrightarrow\quad
+    \Theta_L;\pi_L\Sigma_L;\pi_L\Gamma_L
+      \vdash \pi_L M : \pi_L A,
+  \]
+
+  and symmetrically on the right.
+- The adjacent-allocation shapes now have the explicit factor equations
+
+  \[
+    \mathsf{swap}_{01}(\uparrow M)
+      = \mathsf{lift}_0(\uparrow)M,
+    \qquad
+    \mathsf{swap}_{01}(\mathsf{lift}_0(\uparrow)M)
+      = \uparrow M.
+  \]
+
+  Therefore each old crossed-body wrapper factors into a paired fresh
+  extension followed by a genuine adjacent permutation on one endpoint.
+- Runtime bullet remains deliberately outside the general theorem. Its
+  canonical typing fixes the active fresh name at index zero. The proved
+  pointed equation is
+
+  \[
+    \operatorname{rename}_{\operatorname{ext}(\pi)}
+      ((\uparrow L)\mathbin{\bullet})
+    =
+      (\uparrow\operatorname{rename}_{\pi}L)\mathbin{\bullet}.
+  \]
+
+  Hence a permutation may cross a bullet only in extended form
+  \(\operatorname{ext}(\pi)\), which fixes zero. An unpointed adjacent swap
+  moves zero and does not preserve the canonical bullet state.
+- The next obligation is the actual admissibility recursion. If
+
+  \[
+    \Phi;\rho;\Gamma \vdash M \sqsubseteq M' : A \sqsubseteq B,
+    \qquad
+    \varpi : (\Phi;\rho;\Gamma)
+      \mathrel{\rightsquigarrow}
+      (\Psi;\delta;\Xi),
+  \]
+
+  and neither endpoint contains runtime bullet, prove
+
+  \[
+    \Psi;\delta;\Xi \vdash
+      \pi_L M \sqsubseteq \pi_R M'
+      : \pi_L A \sqsubseteq \pi_R B.
+  \]
+
+  The ordinary and quotiented judgments must be proved mutually. Once this
+  is available, the two specialized swap-body constructors can be derived
+  and deleted rather than adding a primitive permutation case to simulation.
+- Started that mutual boundary with its structurally direct quotiented case.
+  Quotiented type imprecision is natural under independent endpoint
+  permutations:
+
+  \[
+    A \sqsubseteq^{p} B
+      \quad\Longrightarrow\quad
+    \pi_L A \sqsubseteq^{p} \pi_R B.
+  \]
+
+  The two outer \(\forall\)-permutation equivalences are renamed on their
+  respective endpoints, while the ordinary middle derivation uses the
+  two-sided indexed type-renaming theorem.
+- Proved `rel-world-down-permuteᵀ`, the `down/down` clause that the eventual
+  mutual recursion will call. If the recursively permuted bodies are
+  related, both `id-only` narrowing coercions rename in the projected target
+  stores and `down⊑downᵀ` rebuilds the quotiented relation. This case works
+  for every endpoint permutation because the `id-only` mode environment is
+  invariant under arbitrary renaming.
+- Proved `rel-world-gen-down-permuteᵀ`, the direct
+  `gen-down/gen-down` clause. Its mode is `genᵈ tag-or-idᵈ`, which is
+  pointwise `tag-or-id` and is therefore invariant under arbitrary
+  renaming. The binder-order issue arises instead in nested body modes such
+  as `instᵈ (extᵈ μ)` and `extᵈ (instᵈ μ)`.
+
+### Adjacent permutation acts on coercion modes
+
+- Defined the action of the adjacent transposition on a `CastMode` stack. In
+  nominal form, if the first two entries are
+
+  \[
+    (m_0,m_1,\mu),
+  \]
+
+  then the target mode is
+
+  \[
+    (m_1,m_0,\mu).
+  \]
+
+  The construction covers all five `CastMode` forms. The two constructors
+  that introduce an `id-only` entry, `cast-ext` and `cast-weaken`, have the
+  same pointwise mode action and therefore share the same target shape.
+- Proved `swap-mode-target-agrees`:
+
+  \[
+    \mathsf{swapMode}(\mu)(X)
+      = \mu(\mathsf{swap}_{01}(X)).
+  \]
+
+  Together with involutivity of `swap₀₁`, this gives both required
+  semantic properties:
+
+  \[
+    \mathsf{ModeRename}(\mathsf{swap}_{01},\mu,
+      \mathsf{swapMode}(\mu))
+  \]
+
+  and, whenever the target permits sealing at \(\alpha\), the source permits
+  sealing at \(\mathsf{swap}_{01}(\alpha)\).
+- Packaged the result as
+  `castModeRenamer-swap01 : CastModeRenamer swap01ᵗ`. Also proved the
+  identity renamer needed for the unchanged endpoint of a one-sided world
+  permutation.
+- Defined the canonical action of an arbitrary endpoint permutation on an
+  arbitrary mode environment:
+
+  \[
+    (\pi\mu)(X) = \mu(\pi^{-1}(X)).
+  \]
+
+  Proved both `ModeRename` and seal-preimage evidence for this action. This
+  is the form needed by reveal and conceal conversions, whose modes need not
+  come with a `CastMode` derivation.
+- The target computation exposes the crossed modes definitionally:
+
+  \[
+  \begin{aligned}
+    \mathsf{swapMode}(\mathsf{inst}(\mathsf{ext}(\mu)))
+      &= \mathsf{ext}(\mathsf{inst}(\mu)), \\
+    \mathsf{swapMode}(\mathsf{ext}(\mathsf{inst}(\mu)))
+      &= \mathsf{inst}(\mathsf{ext}(\mu)), \\
+    \mathsf{swapMode}(\mathsf{gen}(\mathsf{ext}(\mu)))
+      &= \mathsf{ext}(\mathsf{gen}(\mu)), \\
+    \mathsf{swapMode}(\mathsf{ext}(\mathsf{gen}(\mu)))
+      &= \mathsf{gen}(\mathsf{ext}(\mu)).
+  \end{aligned}
+  \]
+
+  These are the exact order changes produced by the crossed
+  `\forall`/`gen` and `\forall`/`inst` administrative traces. No new term
+  imprecision rule is required for the mode change.
+
+### Permutation under a fresh matched binder
+
+- Proved `rel-store-rename-lift∀ⁱ` and `rel-ctx-rename-lift∀ⁱ`.
+  Given a related-world permutation and a source lift under a fresh matched
+  pair of names, they construct the target lifted store and context and the
+  extended permutation between the two body worlds. In nominal form, the
+  endpoint action extends as
+
+  \[
+    \pi^+(X) = X,
+    \qquad
+    \pi^+(\alpha) = \pi(\alpha)
+    \quad\text{for old names }\alpha,
+  \]
+
+  while the fresh assumption remains `X \sqsubseteq X` and every old
+  assumption is shifted under it.
+- Packaged the construction as `rel-world-permutation-lift∀ⁱ`. Its two
+  coercion-mode actions are obtained by extending the original mode
+  permutations, so the fresh name stays fixed and the old names retain their
+  permuted permissions.
+- Proved `rel-world-Λ-permuteᵀ`, the direct `Λ/Λ` binder boundary. It
+  returns the constructed target body world and an assembler with the exact
+  recursive premise
+
+  \[
+    \forall X.\Psi;\pi_L^+\rho_L;\pi_R^+\rho_R
+      \vdash \pi_L^+ V \sqsubseteq \pi_R^+ V'
+      : \pi_L^+ A \sqsubseteq \pi_R^+ B.
+  \]
+
+  Supplying that recursive body relation yields
+
+  \[
+    \Psi;\pi_L\rho_L;\pi_R\rho_R
+      \vdash \pi_L(\Lambda X.V) \sqsubseteq
+        \pi_R(\Lambda X.V')
+      : \pi_L(\forall X.A) \sqsubseteq
+        \pi_R(\forall X.B).
+  \]
+
+  Thus the matched polymorphic value case is now connected to the eventual
+  mutual admissibility recursion without a new term-imprecision rule.
+
+### Permutation through `ν`, `ν ★`, and one-sided binders
+
+- Proved the source-only and target-only analogues of the matched lifting
+  square:
+
+  - `rel-world-permutation-lift-leftⁱ` extends only \(\pi_L\) and preserves
+    the fresh assumption `X \sqsubseteq \star`;
+  - `rel-world-permutation-lift-rightⁱ` extends only \(\pi_R\) and shifts
+    the target name of every old matched assumption.
+
+  Both constructions produce the target store, target term context, lift
+  witnesses, and the related-world permutation needed by a recursive call.
+  The generic assumption action for the target-only case is recorded by
+  `rename-assm²-⇑ᴿ²ᵢ`.
+- Proved `rel-world-Λ⊑-permuteᵀ`. In nominal form, a source-only
+  polymorphic value relation
+
+  \[
+    X \sqsubseteq \star;Φ
+      \vdash V \sqsubseteq N'
+      : A \sqsubseteq B
+  \]
+
+  is transported in the constructed one-sided body world and reassembled as
+
+  \[
+    Ψ \vdash
+      \pi_L(\Lambda X.V) \sqsubseteq \pi_R N'
+      : \pi_L(\forall X.A) \sqsubseteq \pi_R B.
+  \]
+
+  The occurrence premise for the `ν` type-imprecision index is preserved by
+  `occurs-zero-rename-ext`.
+- Proved `left-reveal-ν-rel-permute` and
+  `right-reveal-ν-rel-permute`. They rename a reveal conversion through the
+  entire fresh-name store
+
+  \[
+    (X,\uparrow A) :: \uparrow\Sigma,
+  \]
+
+  normalize both shifted endpoint types, and use the canonical permutation
+  action on the reveal mode.
+- Using those conversion lemmas and the three lifting squares, proved all
+  three reveal-based `ν` clauses:
+
+  - `rel-world-ν⊑ν-permuteᵀ`;
+  - `rel-world-ν⊑-permuteᵀ`;
+  - `rel-world-⊑ν-permuteᵀ`.
+
+  The matched clause transports the hidden relation
+  \(\uparrow A \sqsubseteq \uparrow A'\) at the extended permutations. The
+  one-sided clauses instead construct exactly the `X \sqsubseteq \star` or
+  target-lifted world required by their original constructors.
+- Proved `left-ν★-widening-rel-permute` and
+  `right-ν★-widening-rel-permute`. Each transports, as one coherent
+  package, the base `CastMode`, the `inst`-extended seal permission, and the
+  widening coercion in
+
+  \[
+    (X,\star) :: \uparrow\Sigma.
+  \]
+
+  Keeping these three premises together prevents the reconstructed relation
+  from accidentally combining a target mode with seal or coercion evidence
+  produced by a different permutation action.
+- Using those packages, proved all three `ν ★` clauses:
+
+  - `rel-world-νcast⊑νcast-permuteᵀ`;
+  - `rel-world-νcast⊑-permuteᵀ`;
+  - `rel-world-⊑νcast-permuteᵀ`.
+
+  Consequently every ordinary Nu-term-imprecision constructor involving
+  `Λ`, `ν`, or `ν ★` now has a direct arbitrary-permutation boundary,
+  except the runtime-bullet constructors, which remain intentionally outside
+  the no-bullet theorem.
+
+### 2026-07-17
+
+- Strengthened `RelStoreRenameⁱ` and `RelCtxRenameⁱ` so every matched target
+  entry contains the canonical renamed imprecision derivation. In nominal
+  notation, a source entry
+
+  \[
+    A \sqsubseteq_p B
+  \]
+
+  is related only to the target entry
+
+  \[
+    \pi_L A
+      \sqsubseteq_{\pi p}
+    \pi_R B,
+  \]
+
+  modulo the endpoint equalities already carried by the world relation.
+  Previously the target entry could contain an unrelated derivation
+  `p′`. That weaker definition preserved endpoint typing but was
+  insufficient for the indexed variable rule: two derivations of the same
+  type-imprecision proposition need not be definitionally equal.
+- Reproved all three binder-lifting squares with this stronger invariant.
+  Matched `∀`, source-only `ν`, and target-only `ν` lifting now preserve the
+  exact renamed witness in every stored and term-context entry. This changes
+  only proof-side world-permutation evidence; neither term imprecision nor
+  type imprecision gained a rule.
+- Proved `rel-ctx-rename-lookupⁱ`. If
+
+  \[
+    \Gamma(x)=A\sqsubseteq_p B,
+  \]
+
+  then the permuted context contains at the same term-variable position the
+  entry
+
+  \[
+    (\pi\Gamma)(x)
+      = \pi_L A\sqsubseteq_{\pi p}\pi_R B.
+  \]
+
+  Hence `rel-world-x-permuteᵀ` supplies the first complete constructor clause
+  of the general admissibility recursion.
+- Added the exact context-extension square and the direct clauses for
+  `blame`, abstraction, and application. In particular, the abstraction
+  clause recurses under
+
+  \[
+    x : \pi_L A\sqsubseteq_{\pi p_A}\pi_R A'
+  \]
+
+  and reconstructs
+
+  \[
+    \lambda x.N \sqsubseteq \lambda x.N'
+      : \pi_L(A\to B)\sqsubseteq
+        \pi_R(A'\to B').
+  \]
+
+- Proved arbitrary-permutation transport for widening coercions on both
+  endpoints and for the associated seal-store invariant. Together with the
+  existing narrowing transport, this gives one coherent target package
+
+  \[
+    \mathsf{CastMode}(\mu),\quad
+    \mathsf{SealStore}(\mu,\Sigma),\quad
+    \mu;\Sigma\vdash c:A\mathrel{\trianglelefteq}B
+  \]
+
+  at each endpoint. The target mode is selected by the same
+  `CastModeRenamer` that maps the coercion and seal evidence.
+- Used those packages to prove the four generic one-sided cast clauses:
+  `rel-world-cast⊒⊑-permuteᵀ`, `rel-world-cast⊑⊑-permuteᵀ`,
+  `rel-world-⊑cast⊒-permuteᵀ`, and
+  `rel-world-⊑cast⊑-permuteᵀ`. These clauses introduce no new imprecision
+  shapes; they rebuild the existing one-node cast constructors around the
+  recursively permuted term relation.
+- The next boundary is paired reveal/conceal and paired widening in
+  `conv⊑convᵀ`, followed by the four one-sided reveal/conceal clauses. Their
+  main extra obligation is permutation of `StoreCorresponds`, since the
+  conversion must continue to reveal exactly the two renamed seal names.
+- Proved `rel-store-rename-correspondenceⁱ` for both ways that stores record a
+  logical pair:
+
+  \[
+    \operatorname{store\text{-}matched}
+      (\alpha,A,\beta,B,p)
+    \qquad\text{and}\qquad
+    \operatorname{store\text{-}link}
+      (\alpha,A,\beta,B,p).
+  \]
+
+  The result preserves the exact renamed witness
+  \(\pi p\), not merely the four renamed endpoints. Thus crossed stores,
+  whose physical entries are independent and whose logical pairing is a
+  link, are closed under the same world permutation as ordinary matched
+  stores.
+- Proved the four general conversion transports
+  `left-reveal-rel-permute`, `right-reveal-rel-permute`,
+  `left-conceal-rel-permute`, and `right-conceal-rel-permute`. Each uses the
+  canonical action
+
+  \[
+    (\pi\mu)(X)=\mu(\pi^{-1}X)
+  \]
+
+  on the conversion mode and normalizes the renamed physical store to the
+  corresponding projection of the target related world.
+- Proved `rel-world-paired-conversion-permute` and
+  `rel-world-paired-cast-permute`. The latter handles both exact paired
+  reveal/conceal and the paired-widening alternative, keeping the mode,
+  seal-store evidence, and widening typing synchronized on both endpoints.
+  Consequently `rel-world-conv⊑conv-permuteᵀ` closes the paired-cast
+  constructor in the eventual recursion.
+- Proved all four one-sided conversion clauses and the ordinary
+  quotient-to-term clause `rel-world-up⊑up-permuteᵀ`. The remaining
+  coercion boundary is the two crossed quotient-to-term constructors. Their
+  fixed modes are the two adjacent orders
+
+  \[
+    \mathsf{inst}(\mathsf{ext}(\mu))
+    \qquad\text{and}\qquad
+    \mathsf{ext}(\mathsf{inst}(\mu)).
+  \]
+
+  An arbitrary permutation need not leave either fixed order unchanged.
+  The next audit should determine the smallest single premise invariant that
+  subsumes `up⊑upᵀ`, `crossed-up⊑upᵀ`, and
+  `crossed-left-up⊑upᵀ` without adding another syntax-shaped relation rule.
+- Replaced that three-constructor family with one `up⊑upᵀ` rule and the
+  genuine reusable premise `QuotientWideningPair`. It has two cases:
+
+  \[
+    \begin{array}{ll}
+    \text{identity pair:}&
+      \mathsf{id};\Sigma_L\vdash u:D\sqsubseteq A,
+      \quad
+      \mathsf{id};\Sigma_R\vdash u':D'\sqsubseteq A',\\[2mm]
+    \text{cast-mode pair:}&
+      \mathsf{CastMode}(\mu),
+      \ \mathsf{SealStore}(\mu,\Sigma_L),
+      \ \mu;\Sigma_L\vdash u:D\sqsubseteq A,\\
+    & \mathsf{CastMode}(\mu'),
+      \ \mathsf{SealStore}(\mu',\Sigma_R),
+      \ \mu';\Sigma_R\vdash u':D'\sqsubseteq A'.
+    \end{array}
+  \]
+
+  The first case retains the ordinary compiled-cast route. The second
+  subsumes both adjacent `inst`/`ext` orders and is closed under arbitrary
+  independent endpoint permutations. This removes two term-imprecision
+  constructors instead of adding another permutation-specific constructor.
+- Updated the two crossed administrative derivations to use
+  `quotient-cast-widening`, and updated compilation and the quotient
+  regression example to use `quotient-id-widening`. The source and target
+  typing projections now analyze the widening-pair premise while retaining a
+  single outer `up⊑upᵀ` case.
+- Proved `rel-world-quotient-widening-pair-permute`; therefore
+  `rel-world-up⊑up-permuteᵀ` now covers identity, direct crossed, reverse
+  crossed, and all subsequent permutations through one derivation clause.
+- Removed the `StoreDetWf` premise from `⊑cast⊑idᵀ`. The conclusion
+  already carries the final type-imprecision derivation explicitly, and the
+  source- and target-typing projections never used store determinacy. More
+  importantly, arbitrary dependency-preserving permutations need not preserve
+  the age ordering built into `StoreDetWf`, so retaining it would have imposed
+  an unrelated obstruction on permutation admissibility.
+- Proved the target identity-cast clause
+  `rel-world-⊑cast⊑id-permuteᵀ`. In nominal form, if
+
+  \[
+    \mu_{\mathsf{id}};\Sigma_R
+      \vdash c' : A' \mathrel{\trianglelefteq} B'
+  \]
+
+  and the bodies are related after applying \(\pi_L\) and \(\pi_R\), then
+
+  \[
+    \pi_L M
+      \sqsubseteq
+    (\pi_R M')\langle \pi_R c'\rangle
+      : \pi_L A \sqsubseteq \pi_R B'.
+  \]
+
+  The seal-store premise at the target is reconstructed directly: the
+  identity-only mode permits no seal name, so
+  `SealModeStore★ id-onlyᵈ Σ` holds for every store \(\Sigma\).
+- Added the direct constant and arithmetic clauses
+  `rel-world-κ-permuteᵀ` and `rel-world-⊕-permuteᵀ`. Base types,
+  numeric constants, and the addition operator contain no type names, so the
+  permutation action is definitionally inert and only the operand relations
+  recurse.
+- Proved `rel-store-rename-prefix-invⁱ`. If
+
+  \[
+    \rho_0 \preccurlyeq \rho^+,
+    \qquad
+    \varpi : \rho^+ \rightsquigarrow \delta^+,
+  \]
+
+  then there is a suffix \(\delta_0\) such that
+
+  \[
+    \varpi_0 : \rho_0 \rightsquigarrow \delta_0,
+    \qquad
+    \delta_0 \preccurlyeq \delta^+.
+  \]
+
+  The proof follows the prefix and the proof-relevant store renaming in
+  lockstep; therefore matched, left-only, right-only, and linked entries all
+  preserve exactly the same prefix depth.
+- Used that inversion to prove
+  `rel-world-allocation-prefix-permuteᵀ`. The recursive body is transported
+  at the exposed suffix world, endpoint typing is transported at the full
+  world, and the single existing prefix rule reattaches the target prefix.
+  Hence every allocation-producing trace remains covered by one structural
+  invariant rather than separate matched, one-sided, and crossed rules.
+- The ordinary structural helper layer is now complete. The mutual no-bullet
+  recursion has direct clauses for variables, `blame`, abstraction,
+  application, constants, arithmetic, casts, conversions, `Λ`, `ν`, `ν ★`,
+  quotient boundaries, and allocation prefixes. Its remaining definition
+  boundary is confined to `swapRight-bodyᵀ` and `swapLeft-bodyᵀ`: an
+  arbitrary outer permutation destroys their fixed two-lift presentation.
+  The next step is to express their already-proved
+  fresh-extension-then-adjacent-swap factorization in a form closed under
+  composition with the outer permutation, and then assemble the mutual
+  recursion without adding another syntax-specific imprecision rule.
+
+### Crossed bodies as semantic world embeddings
+
+- The fixed two-lift presentation is not itself closed under arbitrary
+  permutation. This is now a checked obstruction, not merely a failed proof
+  attempt. Every target of `LiftStoreⁱ` excludes a projected store entry at
+  index zero on both endpoints:
+
+  \[
+    (0,A) \notin \mathsf{leftStore}(\rho^+),
+    \qquad
+    (0,B) \notin \mathsf{rightStore}(\rho^+).
+  \]
+
+  The lemmas `swap01-lift-left-obstruction` and
+  `swap01-lift-right-obstruction` then show that an adjacent permutation can
+  move an older entry to zero, making it impossible to reconstruct another
+  `LiftStoreⁱ` witness. Consequently the crossed-body proof must preserve the
+  semantic related-store shape needed by the term relation, rather than
+  demand a new syntactic lift decomposition.
+- Introduced `StoreProjectionEmbeddingⁱ`. For endpoint renamings
+  \(\tau_L\) and \(\tau_R\), it records exactly
+
+  \[
+  \begin{aligned}
+    \tau_L\,\mathsf{leftStore}(\rho)
+      &\subseteq \mathsf{leftStore}(\delta),\\
+    \tau_R\,\mathsf{rightStore}(\rho)
+      &\subseteq \mathsf{rightStore}(\delta).
+  \end{aligned}
+  \]
+
+  This projection-only notion was sufficient for endpoint typing but not for
+  the term relation: allocation-prefix inversion and paired reveal/conceal
+  also need the related-store entry shape. The checked world invariant is
+  therefore the stronger `RelStoreEmbeddingⁱ`. It preserves whether each
+  entry is matched, source-only, target-only, or linked, and requires the four
+  endpoint names and types to be the appropriate renamings. Crucially, a
+  target matched/link entry may contain a different proof of its
+  type-imprecision proposition. Thus the invariant retains exactly the
+  structural information used by term imprecision without reviving the
+  proof-relevance obstruction in `LiftStoreⁱ`.
+- `RelWorldEmbeddingⁱ` combines this structural store embedding with
+  well-scoped endpoint renamings, left inverses, coercion-mode renamers, the
+  assumption action, and the renamed term context. The structural invariant
+  implies the exact projection equations
+
+  \[
+  \begin{aligned}
+    \mathsf{leftStore}(\delta)
+      &= \tau_L\,\mathsf{leftStore}(\rho),\\
+    \mathsf{rightStore}(\delta)
+      &= \tau_R\,\mathsf{rightStore}(\rho).
+  \end{aligned}
+  \]
+
+  Hence `rel-world-source-typing-embed` and
+  `rel-world-target-typing-embed` transport endpoint typing directly. An
+  exact `RelWorldPermutationⁱ` induces a world embedding by forgetting only
+  the identity of the stored type-imprecision proofs.
+- Proved that coercion-mode renamers compose. If
+
+  \[
+    \mathsf{ModeRename}(\tau,\mu,\nu),
+    \qquad
+    \mathsf{ModeRename}(\upsilon,\nu,\xi),
+  \]
+
+  then
+
+  \[
+    \mathsf{ModeRename}(\upsilon\circ\tau,\mu,\xi).
+  \]
+
+  The composed `CastModeRenamer` also composes seal preimages: a target seal
+  name is pulled back first through \(\upsilon\), then through \(\tau\).
+- Proved composition for assumption transport, well-formed renamings, left
+  inverses, and structural store embeddings. Also proved
+  `rel-store-embedding-prefix-invⁱ`, so an allocation prefix can be exposed
+  after embedding just as it can after an exact permutation. These components
+  yield
+  `rel-world-embedding-[]-composeⁱ`, the empty-term-context composition
+  theorem required by the crossed wrappers. The restriction to the empty
+  context is exact here: both crossed-body constructors are closed terms.
+- Constructed both primitive crossed embeddings:
+
+  \[
+  \begin{array}{c|cc}
+    & \text{left endpoint} & \text{right endpoint} \\
+    \hline
+    \text{right-crossed}
+      & \mathsf{suc}
+      & \mathsf{ext}(\mathsf{suc}) \\
+    \text{left-crossed}
+      & \mathsf{ext}(\mathsf{suc})
+      & \mathsf{suc}.
+  \end{array}
+  \]
+
+  The opposite endpoint order is expressed only by these two renamings; no
+  new term-imprecision constructor or coercion-specific rule is introduced.
+- Finally proved `crossed-right-then-permutation-embeddingⁱ` and
+  `crossed-left-then-permutation-embeddingⁱ`. For example, composing the
+  right-crossed embedding with arbitrary outer permutations
+  \(\pi_L,\pi_R\) produces the endpoint actions
+
+  \[
+    \alpha \mapsto \pi_L(\mathsf{suc}\,\alpha),
+    \qquad
+    \beta \mapsto
+      \pi_R(\mathsf{ext}(\mathsf{suc})\,\beta),
+  \]
+
+  together with the composed structural store embedding, assumption action,
+  mode action, and inverse maps. Thus the crossed factorization is now stable
+  under every dependency-preserving outer permutation despite the failure of
+  fixed lift reconstruction.
+- Completed the remaining paired-conversion prerequisite. The lemmas
+  `rel-store-embedding-matched∈ⁱ` and
+  `rel-store-embedding-link∈ⁱ` transport the two representations of a
+  logical seal pair through the structural embedding. Their conclusion first
+  exposes all five target witnesses
+
+  \[
+    \alpha', A', \beta', B', p'
+  \]
+
+  and only then states the four endpoint equalities and target membership.
+  This witness-first order matters operationally to Agda: the equivalent
+  interleaved existential statement made dependent constraint solving
+  diverge. The wrapper `rel-store-embedding-correspondenceⁱ` now proves
+
+  \[
+    \mathsf{Corresponds}_{\rho}(\alpha,A,\beta,B,p)
+    \Longrightarrow
+    \exists \alpha',A',\beta',B',p'.
+      \begin{cases}
+        \alpha' = \tau_L\alpha,\\
+        A' = \tau_L A,\\
+        \beta' = \tau_R\beta,\\
+        B' = \tau_R B,\\
+        \mathsf{Corresponds}_{\delta}
+          (\alpha',A',\beta',B',p').
+      \end{cases}
+  \]
+
+  The target proof \(p'\) is intentionally existential rather than the
+  canonical renamed source proof.
+- The next boundary is to state the mutual no-runtime-bullet naturality
+  recursion over `RelWorldEmbeddingⁱ`.
+  Ordinary permutation clauses enter through the canonical
+  permutation-to-embedding map; the two crossed clauses enter through the
+  composed embeddings above. Completing that recursion will derive and then
+  delete the two specialized crossed-body constructors.
+- Began that recursion boundary with the embedding-native structural layer:
+  `rel-world-x-embedᵀ`, `rel-world-embedding-ctx-∷ⁱ`,
+  `rel-world-ƛ-embedᵀ`, and `rel-world-blame-embedᵀ`. The variable clause
+  uses the proof-relevant renamed context, abstraction extends that context
+  by the canonically renamed argument relation, and blame uses the general
+  target-typing transport.
+- Proved `rel-world-allocation-prefix-embedᵀ`. Structural store-embedding
+  inversion exposes a target suffix and prefix; the recursive body is related
+  at that suffix, while the full-world endpoint typings are transported and
+  the one existing `allocation-prefixᵀ` rule reattaches the prefix. Thus the
+  allocation case remains one clause even after replacing exact permutations
+  by the more general crossed embedding.
+- The next constructor family is coercions and conversions. Narrowing,
+  widening, seal-store evidence, and paired reveal/conceal must be restated
+  against the structural projection equations. After those shared transports,
+  the ordinary and quotiented cast clauses can be inserted into the mutual
+  recursion without changing either term-imprecision judgment.
+- Completed the coercion-mode action for a general embedding. If
+
+  \[
+    \psi(\tau\alpha)=\alpha,
+  \]
+
+  define the target mode by pullback,
+
+  \[
+    (\tau_*\mu)(\beta)=\mu(\psi\beta).
+  \]
+
+  Then
+
+  \[
+    \mathsf{ModeRename}(\tau,\mu,\tau_*\mu).
+  \]
+
+  This is enough for reveal and conceal conversions: their distinguished seal
+  name becomes \(\tau\alpha\), their stored type becomes \(\tau A\), and the
+  conversion endpoints and coercion are renamed uniformly. General
+  narrowing, widening, and `SealModeStore★` instead use the embedding's
+  `CastModeRenamer`, which additionally supplies preimages for every target
+  seal permission.
+- Proved embedding transport for paired reveal and conceal. From
+
+  \[
+    \mathsf{Corresponds}_{\rho}(\alpha,A,\beta,B,p)
+  \]
+
+  the structural embedding produces some \(p'\) such that
+
+  \[
+    \mathsf{Corresponds}_{\delta}
+      (\tau_L\alpha,\tau_L A,\tau_R\beta,\tau_R B,p').
+  \]
+
+  Thus the conversion modes on the two endpoints remain independent, while
+  the logical seal pair remains synchronized by the related store. No paired
+  type-instantiation rule is needed.
+- Lifted every ordinary cast and conversion clause to
+  `RelWorldEmbeddingⁱ`: paired casts, one-sided reveal/conceal, source and
+  target narrowing or widening, the target identity-only cast, and quotient
+  widening. In nominal notation, the paired cast clause now has the form
+
+  \[
+  \begin{aligned}
+    &\gamma\vdash M\sqsubseteq M' : A\sqsubseteq A',\\
+    &(c,c') : (A,A')\Longrightarrow(B,B')
+    \\
+    &\qquad\Longrightarrow
+    \delta\vdash
+      \tau_L(M\langle c\rangle)
+      \sqsubseteq
+      \tau_R(M'\langle c'\rangle)
+      : \tau_L B\sqsubseteq\tau_R B'.
+  \end{aligned}
+  \]
+
+  These are derived transports only; the term-imprecision definition is
+  unchanged.
+- Proved that a structural world embedding lifts under a matched fresh
+  universal binder. The store theorem constructs \(\delta^{\forall}\) and
+  establishes
+
+  \[
+    \mathsf{RelStoreEmbedding}
+      (\operatorname{ext}\tau_L,
+       \operatorname{ext}\tau_R,
+       \rho^{\forall},
+       \delta^{\forall}),
+  \]
+
+  while preserving the target `LiftStoreⁱ` witness. Together with context
+  lifting, extended inverse maps, and extended mode renamers, this yields
+  `rel-world-embedding-lift∀ⁱ` and the embedding-native `Λ` clause. Hence the
+  matched polymorphic introduction case is now ready for the mutual
+  no-runtime-bullet recursion.
+- The next sub-boundary is the corresponding one-sided binder lifting used by
+  `Λ` on only the less-precise side and by one-sided `ν` cases. After the left
+  and right variants are available, the mutual recursion can cover all
+  binder-shaped constructors and invoke the already-composed crossed
+  embeddings at the two administrative swap leaves.
+- Completed both one-sided binder lifts. A source-only binder extends only the
+  source embedding and its inverse,
+
+  \[
+    (\tau_L,\tau_R)
+      \longmapsto
+    (\operatorname{ext}\tau_L,\tau_R),
+  \]
+
+  whereas a target-only binder extends only the target side,
+
+  \[
+    (\tau_L,\tau_R)
+      \longmapsto
+    (\tau_L,\operatorname{ext}\tau_R).
+  \]
+
+  The associated store and context lemmas preserve `LiftLeftStoreⁱ` and
+  `LiftRightStoreⁱ` witnesses and construct structural embeddings at the
+  lifted worlds. The source-only `Λ` clause is now also proved over the
+  general embedding.
+- Thus all three recursive world transitions needed by polymorphic terms are
+  available:
+
+  \[
+  \begin{array}{c|c}
+    \text{binder relation} & \text{recursive endpoint action} \\
+    \hline
+    \forall/\forall
+      & (\operatorname{ext}\tau_L,
+         \operatorname{ext}\tau_R) \\
+    \forall/\star
+      & (\operatorname{ext}\tau_L,\tau_R) \\
+    \star/\forall
+      & (\tau_L,\operatorname{ext}\tau_R).
+  \end{array}
+  \]
+
+  The remaining binder work is local to the `ν` constructors: their reveal or
+  widening coercion lives under the freshly extended store and must be
+  normalized against these three world transitions. Once those transports
+  are restated for embeddings, the mutual no-runtime-bullet recursion can be
+  written exhaustively.
+
+### 2026-07-17
+
+- Completed the ordinary `ν` transport under an arbitrary structural world
+  embedding. If the endpoint renamings are `τₗ` and `τᵣ`, the fresh
+  reveal conversions are transported under `ext τₗ` and `ext τᵣ`, and
+  the three term orientations are reconstructed:
+
+  \[
+    \nu X.M \sqsubseteq \nu Y.M',
+    \qquad
+    \nu X.M \sqsubseteq M',
+    \qquad
+    M \sqsubseteq \nu Y.M'.
+  \]
+
+  The endpoint normalization uses
+
+  \[
+    (\operatorname{ext}\tau)(\uparrow A)
+      = \uparrow(\tau A).
+  \]
+
+- Completed the analogous `ν\star` family. Here the seal permission and
+  widening derivation move together:
+
+  \[
+    (\mu,\mathsf{seal},s:C\sqsubseteq\uparrow B)
+      \longmapsto
+    (\tau_*\mu,\mathsf{seal}',
+       \tau s:\tau C\sqsubseteq\uparrow(\tau B)).
+  \]
+
+  This supplies matched, source-only, and target-only `ν\star` clauses
+  without coupling conversion to type instantiation.
+
+- Proved the mutually recursive embedding admissibility theorems
+  `rel-world-embed-no•ᵀ` and `rel-world-embed-no•ᵀᵖ`. In nominal form, the
+  ordinary theorem states that if
+
+  \[
+    E:(\Phi,\Gamma,\rho)
+      \hookrightarrow_{\tau_L,\tau_R}
+      (\Psi,\Gamma',\rho'),
+    \qquad
+    \Phi;\Gamma;\rho\vdash M\sqsubseteq M':A\sqsubseteq B,
+  \]
+
+  and neither endpoint contains a runtime bullet, then
+
+  \[
+    \Psi;\Gamma';\rho'\vdash
+      \tau_L M\sqsubseteq\tau_R M'
+      :\tau_L A\sqsubseteq\tau_R B.
+  \]
+
+  The recursion is exhaustive. It covers variables, abstraction,
+  application, `Λ`, all six ordinary and `★`-allocating `ν` orientations,
+  allocation prefixes, paired and one-sided conversions, narrowing and
+  widening casts, constants, arithmetic, and both quotient constructors.
+  The three runtime-bullet constructors are impossible by `No•`.
+
+- Derived permutation admissibility as the immediate corollaries
+  `rel-world-permute-no•ᵀ` and `rel-world-permute-no•ᵀᵖ`, using the canonical
+  map from a related-world permutation to a structural embedding. Thus an
+  arbitrary well-formed permutation of both worlds now acts uniformly on
+  terms, endpoint types, coercions, stores, contexts, and the proof-relevant
+  imprecision index.
+
+- Removed `swapRight-bodyᵀ` and `swapLeft-bodyᵀ` from
+  `QuotientedTermImprecision`. They were syntax-specific proof rules whose
+  role is now admissible. The crossed lemmas are one-line applications of
+  the general theorem to the two primitive embeddings:
+
+  \[
+  \begin{aligned}
+    (\mathsf{suc},\operatorname{ext}\mathsf{suc}) &:
+      M\sqsubseteq M'
+      \Longrightarrow
+      \uparrow M\sqsubseteq
+        \operatorname{ext}(\mathsf{suc})M',\\
+    (\operatorname{ext}\mathsf{suc},\mathsf{suc}) &:
+      M\sqsubseteq M'
+      \Longrightarrow
+      \operatorname{ext}(\mathsf{suc})M
+        \sqsubseteq\uparrow M'.
+  \end{aligned}
+  \]
+
+  The four bespoke crossed endpoint-typing helpers became dead code and were
+  deleted as well. The next boundary is to use permutation admissibility as
+  the general `transportNo•Terms` implementation inside weak one-step
+  results, then expose the remaining one-step derivation recursion between
+  these checked leaves and the terminal DGG theorem.
+
+- Factored the opposite-order allocation transports through one structural
+  invariant. Two successive store lifts induce the world embedding
+
+  \[
+    (\tau_L,\tau_R)
+      = (\mathsf{suc}\circ\mathsf{suc},
+         \mathsf{suc}\circ\mathsf{suc}),
+  \]
+
+  from the original world to the crossed world. Hence, for terms with no
+  runtime bullet,
+
+  \[
+    M\sqsubseteq M' : A\sqsubseteq B
+    \quad\Longrightarrow\quad
+    \uparrow\uparrow M\sqsubseteq\uparrow\uparrow M'
+      : \uparrow\uparrow A\sqsubseteq\uparrow\uparrow B.
+  \]
+
+  This is `crossed-double-bodyᵀ`; it is an immediate application of general
+  embedding admissibility, not a new term-imprecision rule.
+
+- Proved that a related-store prefix induces ordinary inclusions of both
+  endpoint stores. Combining those inclusions with weakening gives
+  `crossed-double-prefix-bodyᵀ`: the double-shifted relation remains valid
+  after arbitrary administrative store entries are prefixed to the crossed
+  store.
+
+- Constructed `WeakOneStepTransport` for both opposite-order direct quotient
+  leaves. In each case the recorded store-change traces compute
+  definitionally to two shifts, and the six-entry crossed store is handled by
+  the prefix theorem. No equality transport, new syntax-specific precision
+  rule, or coupling between conversion and instantiation is required. The
+  next sub-boundary is to propagate this transport invariant through the
+  matched and one-sided `ν` frames, then make it an explicit component of
+  the general weak one-step derivation recursion.
+
+- Proved transport preservation for all six outer `ν` frames: matched,
+  source-only, and target-only, each for ordinary reveal allocation and
+  `ν\star` widening allocation. These frames retain the inner change lists,
+  endpoint action, and result store, so their universal term transport is
+  inherited exactly from the recursive result after the frame-specific
+  reveal or widening evidence is reconstructed.
+
+- Strengthened both weak outcome types. Their related alternatives now carry
+  the result and its transport proof together:
+
+  \[
+    \mathsf{related}(R,T)
+      : \mathsf{WeakOneStepOutcome}(M,N').
+  \]
+
+  The application and all six `ν` outcome maps now preserve this pair.
+  Consequently the forthcoming dispatcher cannot silently return a result
+  whose change trace lacks the permutation action needed by a later frame.
+  Target-trace alignment was updated to retain the stronger input while using
+  only its operational result. The focused module and `All.agda` both pass
+  with no unsolved metas. The active boundary is now the total weak one-step
+  recursion itself.
+
+- Factored the three primitive one-allocation actions through structural world
+  embeddings. For any bullet-free relation
+
+  \[
+    M \sqsubseteq M' : A \sqsubseteq B,
+  \]
+
+  the matched, source-only, and target-only lifts give, respectively,
+
+  \[
+  \begin{aligned}
+    \uparrow M &\sqsubseteq \uparrow M'
+      : \uparrow A \sqsubseteq \uparrow B,\\
+    \uparrow M &\sqsubseteq M'
+      : \uparrow A \sqsubseteq B,\\
+    M &\sqsubseteq \uparrow M'
+      : A \sqsubseteq \uparrow B.
+  \end{aligned}
+  \]
+
+  Each conclusion remains valid under an arbitrary later related-store prefix.
+  The identity-renaming equations for terms and coercions discharge the
+  unchanged endpoint in the one-sided cases.
+
+- Used these prefix-stable actions to construct exact
+  `WeakOneStepTransport` witnesses for matched and target-only allocation,
+  both for ordinary reveal allocation and `ν\star` widening allocation. The
+  source-blame/target-allocation leaf now has the same target-only witness.
+
+- Proved that weak-result transport is closed under sequential composition.
+  If `R₁` transports the initial relation and `R₂` transports every relation
+  in the world produced by `R₁`, then the composed weak result transports by
+
+  \[
+    T_{R_2 \circ R_1}(P)
+      = T_{R_2}(T_{R_1}(P)).
+  \]
+
+  The theorem normalizes concatenated source and target change lists using
+  the corresponding `applyTerms` and `applyTys` fusion equations. A dedicated
+  silent-prefix corollary handles the common shape where the source catches up
+  while the target is unchanged, followed by the target's distinguished step.
+
+- Connected this composition theorem to the paired polymorphic catch-up
+  proofs. Both ordinary reveal and `inst` widening now preserve transport
+  through their complete value/blame split:
+
+  \[
+    \mathsf{catchup}(N,N')
+      \Longrightarrow
+    \mathsf{transport}
+      \bigl(\mathsf{alloc}(\mathsf{catchup}(N),N')\bigr).
+  \]
+
+  Consequently the total dispatcher may call either paired allocation
+  catch-up theorem without losing the recursive transport invariant. The next
+  boundary is to define the structurally direct clauses of that dispatcher and
+  then connect these checked polymorphic clauses at the canonical allocation
+  cases.
+
+- Audited the first application clause of the total dispatcher. A generic
+  `WeakOneStepOutcome` retains the final relation, but it does not retain the
+  fact that this relation has the canonical transported arrow index. That fact
+  is required to relate the untouched arguments. In nominal form, recursive
+  simulation of the function must return
+
+  \[
+  \begin{aligned}
+    W &\sqsubseteq W' :
+      T_L(A) \to T_L(B)
+      \sqsubseteq
+      T_R(A') \to T_R(B'),\\
+    &\hspace{2.4cm}
+      T(p_A) \mathbin{\mapsto} T(p_B),
+  \end{aligned}
+  \]
+
+  rather than only an existentially indexed relation between equal endpoint
+  types. This is proof-relevant: duplicate context assumptions mean that one
+  cannot repair the lost index using an unrestricted proof-irrelevance
+  argument.
+
+- Added `WeakOneStepArrowResult` and `WeakOneStepArrowOutcome`, parallel to
+  the existing universal-shaped result and outcome. The arrow result retains
+  both the ordinary weak result and the canonical relation displayed above;
+  its exceptional alternative still requires an actual source trace to
+  `blame`.
+
+- Proved the direct arrow-shaped related result and its transport-bearing
+  outcome. Then proved the callback-free application-left outcome map. Given
+
+  \[
+    M \sqsubseteq M' : A \sqsubseteq A'
+  \]
+
+  with bullet-free arguments, it applies the recursive transport witness to
+  obtain `T_L(M) \sqsubseteq T_R(M')` and combines that derivation directly
+  with the retained canonical arrow result. Thus the application clause no
+  longer assumes an external function capable of reconstructing information
+  that the recursive outcome had forgotten.
+
+- The next dispatcher sub-boundary is to propagate this arrow-shaped
+  invariant through the weak-result constructors that can themselves produce
+  arrow-typed results. After that closure theorem, the application-left clause
+  can be placed directly in the mutual ordinary/arrow/universal recursion.
+
+- Added the canonical projections
+  `forget-weak-arrow-outcome` and `forget-weak-all-outcome`. The mutual
+  dispatcher may therefore recurse at an elimination-specific shape, use its
+  retained evidence in the enclosing frame, and then return the ordinary
+  outcome expected by the terminal trace-alignment theorem.
+
+- Proved `weak-one-step-reindexᵀ`. Given a weak result and a new derivation
+  relating the same final terms at definitionally transported endpoint types,
+  it replaces only the exposed result types, result precision witness, and
+  related-term derivation. It preserves source and target traces, the result
+  world, all three type-transport actions, and both store equations.
+  `weak-one-step-reindex-preserves-transportᵀ` shows that its universal
+  term-transport witness is unchanged.
+
+- Used that operation to prove `weak-one-step-arrow-reindexᵀ` and its
+  transport theorem. The endpoint equations are the normalized actions
+
+  \[
+  \begin{aligned}
+    T_L(A \to B) &= T_L(A) \to T_L(B),\\
+    T_R(A' \to B') &= T_R(A') \to T_R(B').
+  \end{aligned}
+  \]
+
+  Thus later arrow-producing frame lemmas need only reconstruct the canonical
+  final term relation; they can reuse the operational and world components of
+  the ordinary weak result.
+
+- The closure audit must still account for nested result shapes. For example,
+  if an application returns another function, retaining only the outer
+  function's domain/codomain split is insufficient unless the transported
+  codomain precision is itself exposed canonically. The next step is therefore
+  to formulate the minimal recursive type-transport coherence invariant shared
+  by arrow and universal outcomes before multiplying shape-specific frame
+  rules.
+
+### Type-action coherence boundary
+
+- Defined the normalized actions `transportArrowType` and
+  `transportAllType`. They expose the endpoint equalities hidden by a weak
+  result's lists of store changes. In nominal notation, if the result induces
+  the type action (T_R), these definitions have the shapes
+
+  \[
+  \begin{aligned}
+    \mathsf{transportArrowType}(R,p_A,p_B)
+      &: T_R(A) \to T_R(B)
+         \sqsubseteq T_R(A') \to T_R(B'),\\
+    \mathsf{transportAllType}(R,q)
+      &: \forall X.\,T_R^X(C)
+         \sqsubseteq \forall X.\,T_R^X(C').
+  \end{aligned}
+  \]
+
+- Defined `WeakOneStepTypeCoherence R`. It records the two equations
+
+  \[
+  \begin{aligned}
+    \mathsf{transportArrowType}(R,p_A,p_B)
+      &= T_R(p_A) \mathbin{\mapsto} T_R(p_B),\\
+    \mathsf{transportAllType}(R,q)
+      &= \forall T_R^X(q).
+  \end{aligned}
+  \]
+
+  This is the minimal recursive invariant needed by application and
+  polymorphic elimination. It retains the actual precision derivations, so it
+  does not assume proof irrelevance; that would be invalid in contexts with
+  duplicate imprecision assumptions.
+
+- Proved coherence for an unchanged related state, reindexing, sequential
+  weak-result composition, a silent source prefix, application-left framing,
+  and all six matched/source-only/target-only `ν` and `ν★` frames. Hence a
+  nested arrow or universal result keeps its canonical precision structure
+  through every structural operation already used by the dispatcher.
+
+- Strengthened `WeakOneStepOutcome`, `WeakOneStepArrowOutcome`, and
+  `WeakOneStepAllOutcome`. Their related alternatives now carry all three
+  components
+
+  \[
+    \mathsf{related}(R,
+      \mathsf{WeakOneStepTransport}(R),
+      \mathsf{WeakOneStepTypeCoherence}(R)).
+  \]
+
+  All outcome maps and forgetful projections preserve the new component.
+
+- Proved primitive coherence for matched reveal allocation, matched `ν★`
+  allocation, right-only reveal allocation, right-only `ν★` allocation, and
+  the source-blame/right-allocation leaf. Each proof reduces to the canonical
+  matched or right-lifting action recorded in the corresponding weak result.
+
+- Proved primitive coherence for both opposite-order direct quotient leaves.
+  Their two-allocation traces normalize to the same crossed double-lifting
+  action on arrows and under `∀`. Thus type-action coherence does not impose an
+  allocation order and does not need a new term-imprecision rule.
+
+- Propagated coherence through the complete paired catch-up constructions for
+  both ordinary reveal allocation and `ν★` allocation. Each construction is
+  exhaustive over the source-value/source-blame split. The value branch
+  composes frame coherence with matched-allocation coherence; the blame branch
+  composes frame coherence with source-blame/right-allocation coherence.
+
+- The active boundary is now the mutually recursive ordinary, arrow-shaped,
+  and universal-shaped weak one-step dispatcher. Its recursive hypotheses can
+  return outcomes that retain term transport and type-action coherence, so the
+  first direct clauses can be added without another strengthening of the
+  result interface. The first clauses should be the unchanged related leaves,
+  application-left via `WeakOneStepArrowOutcome`, and the matched reveal and
+  `ν★` canonical-allocation cases via the checked catch-up theorems.
+
+### Precision-indexed dispatcher interface
+
+- The application-right audit found the general form of the canonical-index
+  requirement. If the recursive argument relation begins at
+
+  \[
+    M \sqsubseteq M' : A \sqsubseteq A' \;[p_A],
+  \]
+
+  the enclosing application needs the final relation specifically at
+  (T_R(p_A)), not at an existential derivation relating the same endpoint
+  types. This is the same requirement previously encountered only for arrows
+  and universals.
+
+- Defined `WeakOneStepIndexedResult p`. It contains a weak result (R) and
+  the canonical final relation
+
+  \[
+    \operatorname{source}(R)
+      \sqsubseteq
+    \operatorname{target}(R)
+      : T_R(A) \sqsubseteq T_R(A')
+      \;[T_R(p)].
+  \]
+
+  `WeakOneStepIndexedOutcome p` pairs this result with term transport and
+  type-action coherence, or supplies an actual source trace to `blame`.
+  `weak-one-step-index-resultᵀ` is the checked bridge from a weak result whose
+  recorded final index is propositionally the transported original index.
+
+- Proved `nu-term-imprecision-transport-typesᵀ`, which simultaneously
+  transports both endpoint types and the dependent precision index of a term
+  relation. This isolates the dependent equality needed when a type action is
+  normalized through `→` or `∀`.
+
+- Proved that an indexed result at (p_A \mapsto p_B) yields the previous
+  arrow-shaped result, and that an indexed result at `∀ⁱ q` yields the previous
+  universal-shaped result. The conversions use exactly the two equations in
+  `WeakOneStepTypeCoherence`; no proof-irrelevance principle is used.
+  Consequently the dispatcher no longer needs three mutually maintained
+  recursions. One recursion returning `WeakOneStepIndexedOutcome p` can derive
+  the arrow or universal view only at an elimination site.
+
+- Added the unchanged indexed related outcome. It has empty source and target
+  tails and retains the input precision derivation definitionally.
+
+- Proved indexed application-left framing. Recursive simulation of the
+  function is viewed as an arrow result, the untouched arguments are
+  transported, and the enclosing application returns an indexed result at the
+  original codomain derivation (p_B).
+
+- Proved indexed application-right framing. Given related bullet-free values
+  (V \sqsubseteq V'), recursive simulation of the arguments produces
+
+  \[
+    T_R(V)\;T_R(M)
+      \sqsubseteq
+    T_R(V')\;T_R(M') : T_R(B) \sqsubseteq T_R(B')
+      \;[T_R(p_B)].
+  \]
+
+  `weak-result-transport-arrow-termsᵀ` normalizes the transported function
+  relation using arrow coherence. The exceptional branch lifts a genuine
+  argument trace to `blame` through the value application frame and then uses
+  application blame.
+
+- Proved indexed contextual framing for all six `ν` families: matched,
+  source-only, and target-only, each for ordinary reveal and `ν★`. Matched
+  framing derives the universal view of the recursive body; one-sided framing
+  uses the indexed body result directly. Source blame is lifted through source
+  frames and remains unchanged for target-only frames.
+
+- The active proof boundary is now a single derivation-recursive theorem with
+  codomain `WeakOneStepIndexedOutcome p`. Its structural clauses for
+  application and all `ξ-ν` reductions are represented by checked maps. The
+  next step is to state the total dispatcher with its two projected `StoreWf`
+  and runtime hypotheses, add the impossible value-head cases and these direct
+  structural clauses, then connect canonical matched/right-only allocation.
+  The remaining allocation-specific gap is not the result interface: it is to
+  package the existing universal source-catchup construction with indexed
+  transport and coherence so the allocation clauses can call it recursively.
+
+### Indexed universal catch-up and paired lift worlds
+
+- Defined `LeftCatchupIndexedAllResult q`. Besides the universal caught-up
+  weak result, it records the source-value-or-blame invariant, term transport,
+  and type-action coherence. Value, blame, one silent `keep` step, silent
+  prefix composition, and the post-allocation `β-Λ•` step now construct this
+  package directly.
+
+- Lifted the universal administrative catch-up steps for reveal, conceal,
+  narrowing, widening, and `gen` narrowing to the indexed package. These
+  theorems only prepend a source `keep` step, so their precision index remains
+  the index supplied by the recursive catch-up result.
+
+- The `α/Λ` leaf exposes two `LiftLeftStoreⁱ` derivations from the same store:
+  one belongs to the enclosing allocation, while the other belongs to the
+  body relation obtained by inverting `Λ`. Their stores have identical names
+  and types but may contain different proof-relevant precision witnesses.
+  Therefore equality of the two stores is neither available nor required.
+
+- Proved `paired-left-lift-rel-embeddingⁱ` and its world and fresh-prefix
+  forms. They give an identity embedding between any two left lifts of the
+  same base store. The construction is structural in the two lift
+  derivations and ignores only the precision witnesses stored in entries;
+  it does not identify precision derivations.
+
+- Defined the identity permutation action `⊑-rename-idᵢ`. It need not equal
+  its input proof object. What the dispatcher needs are the checked shape
+  equations
+
+  \[
+  \begin{aligned}
+    I(p_A \mapsto p_B) &= I(p_A) \mapsto I(p_B),\\
+    I(\forall q) &= \forall I^X(q).
+  \end{aligned}
+  \]
+
+  The first equation is `⊑-rename-id-arrowᵢ`; the second is
+  `⊑-rename-id-allᵢ`. Equality-proof uniqueness is used only to reconcile two
+  proofs of the same type-renaming equality under `∀`; no irrelevance
+  principle is assumed for precision derivations or context membership.
+
+- Proved `left-catchup-indexed-all-α-Λᵀ`. It moves the final body relation
+  across the paired lift embedding and records the identity permutation
+  action as its transport. The theorem assumes `No• V'`, exactly the runtime
+  fact needed by the general no-bullet world-embedding theorem; matched
+  allocation callers already possess this fact for the target value.
+
+- Connected indexed universal catch-up to both matched allocation families:
+  `weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ` and
+  `weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ` now return the general
+  `WeakOneStepIndexedOutcome`. They reuse the existing exhaustive
+  source-value/source-blame constructions and their transport/coherence
+  proofs.
+
+- The next boundary is the total derivation recursion itself. Its matched
+  allocation clauses can now invoke indexed source catch-up without losing
+  the canonical precision index. The immediate task is to state the
+  dispatcher over a term-imprecision derivation, add unchanged and structural
+  clauses, and use these two indexed matched-allocation outcomes at the first
+  canonical `ν` and `ν★` leaves.
+
+### Right extension across a pending source allocation
+
+- The application-left runtime audit isolates one exceptional state. The
+  source function is already a bullet-free value, while its argument may
+  contain the unique pending runtime bullet. If the target function allocates
+  a fresh name, ordinary `No•` transport cannot move that argument relation
+  into the target-extended world.
+
+- Proved that the two context actions commute:
+
+  \[
+    \mathord{\Uparrow}_{L}
+      (\mathord{\Uparrow}_{R}\Phi)
+    =
+    \mathord{\Uparrow}_{R}
+      (\mathord{\Uparrow}_{L}\Phi).
+  \]
+
+  The constructor-facing store and term-context commutation lemmas use the
+  left-allocation name as the outermost related-context entry. This is the
+  shape expected directly by `α⊑ᵀ`.
+
+- Proved the converse factorization lemmas. If a world first performs a
+  source-only allocation and the resulting world is then extended on the
+  target, the square factors through a target extension of the original
+  world:
+
+  \[
+  \begin{array}{ccc}
+    (\rho,\gamma)
+      & \xrightarrow{\;R\;} &
+    (\rho_R,\gamma_R) \\
+    {\scriptstyle L}\downarrow
+      && \downarrow{\scriptstyle L} \\
+    (\rho_L,\gamma_L)
+      & \xrightarrow{\;R\;} &
+    (\rho_{LR},\gamma_{LR}).
+  \end{array}
+  \]
+
+  These are `left-right-store-factorⁱ` and
+  `left-right-ctx-factorⁱ`. They preserve the concrete final store and
+  context rather than replacing proof-relevant precision witnesses by
+  equality.
+
+- Proved `right-store-prefix-factorⁱ`. A right lift of a store carrying an
+  administrative prefix factors into a right lift of the relational suffix
+  and a corresponding prefix over the lifted suffix. This is the exact
+  decomposition needed for an argument relation already wrapped by
+  `allocation-prefixᵀ`; importantly, the lift applies only to the suffix and
+  therefore preserves store length.
+
+- Proved the direct pending-bullet transport
+  `right-target-lift-α⊑ᵀ`. In nominal notation, its central premise and
+  conclusion have the following form. Suppose
+
+  \[
+    L \sqsubseteq \uparrow_R N'
+      : \forall X.\,C \sqsubseteq \uparrow_R B'
+  \]
+
+  in the target-extended base world, and suppose the source-only allocation
+  makes `(\uparrow_L L)\,\bullet` well typed. Then the commuting allocation
+  square derives
+
+  \[
+    (\uparrow_L L)\,\bullet
+      \sqsubseteq \uparrow_R N'
+      : C \sqsubseteq \uparrow_R B'
+  \]
+
+  in the combined world. The statement now gives the pre-extension precision
+  derivation and the occurrence witness explicit types. This prevents Agda
+  from leaving the base related context as an escaped metavariable.
+
+- Proved the canonical index equation
+  `⊑-target-lift-right-ν-shapeᵢ`. For
+
+  \[
+    p : C \sqsubseteq B
+  \]
+
+  in the source-allocation premise world, target lifting a source-only
+  universal derivation has constructor shape
+
+  \[
+    T_R(\nu\,p) = \nu\,(T_R^L(p)).
+  \]
+
+  The occurrence witness on the right is existential because its particular
+  equality proof is irrelevant to constructor selection. The proof uses the
+  general source-transport equation `transport-ν-⊑ᵢ` plus equality-proof
+  uniqueness only for the two proofs that identity renaming preserves the
+  outer universal type. This lets the canonical right-lift index feed the
+  direct `α⊑ᵀ` leaf without postulating precision-proof irrelevance.
+
+- This establishes the difficult leaf but not yet the whole exceptional
+  application argument. The next proof is a structural right-extension
+  theorem for a source term satisfying `RuntimeOK` and a target term
+  satisfying `No•`. Its `ok-no` branch reuses
+  `right-lift-prefix-bodyᵀ`; its unique-bullet leaf uses
+  `right-target-lift-α⊑ᵀ`; application, `ν`, primitive operation, and cast
+  cases merely lift the recursive result through their existing relation
+  constructors. The application-left dispatcher can then replace its
+  residual exceptional alternative by that theorem when the recursive
+  function step is a target-only allocation.
+
+- Proved that structural theorem as the mutually recursive pair
+  `right-target-lift-runtimeᵀ` and `right-target-lift-runtimeᵀᵖ`.  In
+  nominal notation, let
+
+  \[
+    \Omega = (\alpha \sqsubseteq \star) :: \uparrow_L\Phi,
+    \qquad
+    \Omega_{LR}
+      = (\alpha \sqsubseteq \star) ::
+        \uparrow_L(\uparrow_R\Phi).
+  \]
+
+  If
+
+  \[
+    \Omega;\rho \vdash M \sqsubseteq M' : A \sqsubseteq B\;[p],
+    \qquad
+    \mathsf{RuntimeOK}(M),
+    \qquad
+    \mathsf{NoBullet}(M'),
+  \]
+
+  and `ρ` right-extends to `ρ_R` in `Ω_{LR}`, then
+
+  \[
+    \Omega_{LR};\rho_R \vdash
+      M \sqsubseteq \uparrow_R M'
+      : A \sqsubseteq \uparrow_R B\;[\uparrow_R^L p].
+  \]
+
+  The quotiented theorem has the identical shape with
+  `A \sqsubseteq^p B`.  No term-imprecision constructor was added.  The proof
+  factors `allocation-prefixᵀ`, uses the canonical `α⊑ᵀ` square at the
+  unique runtime-bullet leaf, and otherwise follows the existing relation
+  constructors.  It covers applications, primitive operations, ordinary
+  `ν`, `ν★`, paired and one-sided casts, reveal/conceal conversions, and
+  both quotient constructors.
+
+- Added direct ordinary and quotiented normalization bridges between the raw
+  structural embedding action and `↑_R^L`.  Added specialized wrappers for
+  all six ordinary and `ν★` orientations.  Thus seal-mode renaming and
+  reveal/widening transport remain inside the existing generic world-embedding
+  lemmas rather than being repeated in the runtime recursion.
+
+- Proved `weak-one-step-·₁-value-frameᵀ`.  If recursive simulation of the
+  function has
+
+  \[
+    \chi_s = [], \qquad L_s = L,
+  \]
+
+  then the enclosing source application also takes zero steps.  Consequently
+  its argument may satisfy `RuntimeOK`; only the target argument must satisfy
+  `No•` so that the target tail can be lifted through the application frame.
+  Transport and type-action coherence are inherited unchanged from the
+  function result.
+
+- The remaining application-left allocation boundary is now an action
+  alignment, not a term-relation gap.  The existing right-only allocation
+  leaf records the generic action `⊑-target-lift-rightᵢ` in the context
+  `⇑ᴿᵢ Ω`, whereas the crossed structural theorem records the normalized
+  action `⊑-target-under-leftᵢ` in `Ω_{LR}`.  The contexts are identified by
+
+  \[
+    \uparrow_L(\uparrow_R\Phi)
+      = \uparrow_R(\uparrow_L\Phi),
+  \]
+
+  but the dependent precision derivations are not definitionally equal.  A
+  direct equality attempt exposes proof-relevant renaming evidence and would
+  require a separate derivation-recursive coherence proof.
+
+  The smaller next obligation is instead to rebuild the right-only allocation
+  leaf with `⊑-target-under-leftᵢ` as its transport action.  This does not need
+  equality of precision derivations: the final reveal or widening constructor
+  is allowed to choose the normalized conclusion index directly, while the
+  inner target-bullet relation is transported only along the context
+  commutation equality.  The new zero-source-step frame can then consume
+  `right-target-lift-runtimeᵀ` directly for both right-only `ν` and `ν★`
+  allocation leaves.
+
+### 2026-07-18: indexed allocation and mode-permutation boundary
+
+- Replaced the last crossed-action detour by direct assumption-renaming
+  lemmas.  The two one-sided actions now act on a related assumption as
+
+  \[
+  (\mathsf{suc},\operatorname{ext}\mathsf{suc})
+  \qquad\text{and}\qquad
+  (\operatorname{ext}\mathsf{suc},\mathsf{suc}),
+  \]
+
+  and map it directly into the crossed related context.  Their proofs use
+  composition and pointwise congruence of assumption renaming.  Consequently
+  the mode action remains the one supplied by the same structural world
+  embedding; there is no separate mode-specific term-imprecision rule.
+
+- Made the general type-action coherence layer fully explicit.  In
+  particular, transport through arrows and through `∀` now states the source
+  and target substitution equations and the raw relation being transported.
+  The composition theorem therefore records, without inferred holes, that
+
+  \[
+  T_{\chi_2}(T_{\chi_1}(p))
+    \cong T_{\chi_2\circ\chi_1}(p)
+  \]
+
+  and that this action commutes with both arrow formation and the body of a
+  universal type.  The equality is heterogeneous because the two sides can
+  expose definitionally different context and endpoint indices.
+
+- Closed the indexed matched ordinary-`ν` and matched-`ν★` catch-up
+  leaves.  Each proof now makes the operational split required by the DGG:
+
+  \[
+  \begin{array}{ll}
+  \text{source reaches a value}
+    &\Longrightarrow \text{frame the recursive catch-up and use the matched
+       allocation leaf},\\
+  \text{source reaches blame}
+    &\Longrightarrow \text{frame the blame trace and use the right-only
+       allocation leaf}.
+  \end{array}
+  \]
+
+  Thus the less-precise program is not allowed to choose blame merely because
+  the simulation is weak; every blame outcome carries an actual source trace
+  to `blame`.
+
+- Closed the paired-lift `α/Λ` boundary.  Suppose two lifted stores
+  `ρᵃ` and `ρᵇ` arise from the same base store.  The body relation is
+  first extended by the fresh allocation in `ρᵇ`, then transported by the
+  paired identity embedding to the corresponding extension of `ρᵃ`:
+
+  \[
+  (\alpha,\uparrow A)::\rho^b
+    \vdash W\sqsubseteq V'
+  \quad\Longrightarrow\quad
+  (\alpha,\uparrow A)::\rho^a
+    \vdash W\sqsubseteq V'.
+  \]
+
+  The induced term and type actions are identity renamings, but the two
+  proof-relevant store witnesses are not equated.  The indexed theorem
+  `left-catchup-indexed-all-α-Λᵀ` records the corresponding transport and
+  arrow/`∀` coherence evidence.
+
+- Completed the indexed administrative wrappers for universal narrowing,
+  universal widening, and `gen` narrowing.  Their body coercions are now
+  named explicitly and transported through the allocated store; no coercion
+  is coupled to the bullet/type-instantiation rule.
+
+- Strengthened the terminal trace-alignment consumer to retain the third
+  component of `outcome-related`, namely type-action coherence.  Alignment
+  still projects only the operational weak result, but it no longer discards
+  the stronger invariant by matching an obsolete constructor shape.
+
+- Validation completed for
+  `proof/NuImprecisionSimulation.agda`, including
+  `--no-allow-unsolved-metas`, and for
+  `proof/NuDGGTraceAlignment.agda`.
+
+- The next boundary is the total derivation recursion
+
+  \[
+  \Phi;\rho\vdash M\sqsubseteq M' : A\sqsubseteq_p B,
+  \qquad M'\longrightarrow_{\chi}N'
+  \quad\Longrightarrow\quad
+  \mathsf{WeakOneStepIndexedOutcome}(p).
+  \]
+
+  Its unchanged, application-frame, and six `ν`-frame maps are already
+  checked.  The next implementation step is to add the direct clauses for
+  the canonical matched, one-sided, and crossed allocation-producing leaves,
+  invoking the indexed catch-up theorems above, and then expose this recursion
+  to the terminal DGG proof.
+
+### 2026-07-18: direct indexed allocation leaves
+
+- Packaged the three remaining one-sided allocation results at their original
+  precision indices:
+
+
+  \[
+  \begin{array}{rcl}
+  \nu X.\mathsf{blame} &\sqsubseteq& \nu X'.V',\\
+  N &\sqsubseteq& \nu X'.V',\\
+  N &\sqsubseteq& \nu \star.V'.
+  \end{array}
+  \]
+
+  The corresponding theorems are
+  `weak-one-step-source-blame-right-allocation-indexed-outcomeᵀ`,
+  `weak-one-step-right-ν↑-indexed-outcomeᵀ`, and
+  `weak-one-step-right-νcast-indexed-outcomeᵀ`.  Each theorem combines
+  its existing weak result, term transport, and arrow/`∀` type-action
+  coherence.  The first alternative still contains an actual source trace to
+  `blame`; no unrestricted less-precise blame alternative was reintroduced.
+
+- Packaged both crossed adjacent-allocation traces as indexed outcomes:
+
+  \[
+  \begin{array}{c@{\qquad}c}
+  \mathsf{gen}_{\forall};\mathsf{inst}_{\forall}
+    & \mathsf{gen};\forall\mathsf{inst},\\
+  \mathsf{gen};\forall\mathsf{inst}
+    & \mathsf{gen}_{\forall};\mathsf{inst}_{\forall}.
+  \end{array}
+  \]
+
+  Operationally, the two sides allocate the same two names in opposite
+  orders.  Relationally, both conclusions use the existing crossed action
+
+  \[
+    T_{\times\forall\forall}(p)
+      = \mathsf{crossedLift}_{\forall\forall}(p).
+  \]
+
+  The new theorems
+  `weak-one-step-direct-quotient-indexed-outcomeᵀ` and
+  `weak-one-step-reverse-direct-quotient-indexed-outcomeᵀ` expose this
+  action directly at the original body relation
+  `p : F \sqsubseteq F'`.  No permutation or term-imprecision constructor was
+  added.
+
+- Added the general equality lemma `subst-cancel-sym`.  The crossed body
+  witnesses had previously been transported backward along
+
+  \[
+    \operatorname{rename}(\operatorname{ext}\,\mathsf{suc},
+      \uparrow F)
+      = \uparrow\uparrow F
+  \]
+
+  so that their endpoints matched the concrete opposite-order traces.  The
+  indexed wrapper transports the same endpoint forward.  The new lemma proves
+
+  \[
+    \operatorname{subst}_P(e)
+      (\operatorname{subst}_P(e^{-1})(x)) = x,
+  \]
+
+  once on the source endpoint and once on the target endpoint.  This is the
+  complete extra equality needed at the crossed quotient boundary.
+
+- Validated `proof/NuImprecisionSimulation.agda` both normally and with
+  `--no-allow-unsolved-metas`, then rechecked
+  `proof/NuDGGTraceAlignment.agda` and the aggregate `All.agda` module.
+
+- The leaf-level allocation interface is now complete: canonical matched,
+  right-only, source-blame/right-only, and both crossed quotient orientations
+  all return `WeakOneStepIndexedOutcome` at the transported original index.
+  The remaining prerequisite for the total weak one-step dispatcher is not
+  another allocation rule.  It is the total universal source-catch-up
+  recursion
+
+  \[
+  \begin{aligned}
+    &\Phi;\rho \vdash N \sqsubseteq V'
+       : \forall X.C \sqsubseteq \forall X.C'\;[\forall q],\\
+    &\mathsf{RuntimeOK}(N),\quad
+      \mathsf{Value}(V'),\quad \mathsf{NoBullet}(V')\\
+    &\hspace{2em}\Longrightarrow
+      \mathsf{LeftCatchupIndexedAllResult}(q).
+  \end{aligned}
+  \]
+
+  Its terminal value and blame cases, silent-step composition, `β-Λ•`,
+  one-layer reveal/conceal, universal narrowing/widening, and `gen` narrowing
+  clauses are already checked.  The next implementation boundary is to join
+  those clauses into one exhaustive recursion over the quotiented term
+  relation, including transport through `allocation-prefixᵀ`.  Once that
+  theorem is total, the matched ordinary-`ν` and matched-`ν★` dispatcher
+  clauses can call the indexed catch-up outcomes directly.
+
+### 2026-07-18: pending-prefix universal catch-up boundary
+
+- Generalized the universal catch-up infrastructure around a pending store
+  prefix.  The invariant is now stated before recursion: if
+
+  \[
+    \rho_0 \preccurlyeq \rho^+
+    \quad\text{and}\quad
+    \Phi;\rho_0 \vdash N \sqsubseteq V'
+      : \forall X.C \sqsubseteq \forall X.C'\;[\forall q],
+  \]
+
+  then the catch-up result is constructed directly in the outer world
+  `\rho^+`.  This is stronger than lifting a completed result afterward.
+  A source catch-up may allocate new names, and those new names must precede
+  the already-pending prefix entries in the operational store.
+
+- Proved transitivity of `StoreImpPrefix` and the two prefix-aware catch-up
+  combinators:
+
+  \[
+  \begin{aligned}
+    &\mathsf{terminal}_{\rho_0\preccurlyeq\rho^+},\\
+    &\mathsf{prependKeep}_{\rho_0\preccurlyeq\rho^+}.
+  \end{aligned}
+  \]
+
+  The first weakens a terminal value-or-`blame` relation into `\rho^+`.
+  The second prepends one source `keep` step while retaining the relation at
+  `\rho_0` and the catch-up result at `\rho^+`.  Their Agda names are
+  `left-catchup-indexed-all-prefix-relatedᵀ` and
+  `left-catchup-indexed-all-prefix-prepend-keepᵀ`.
+
+- Proved the corresponding prefix-aware `β-Λ•` theorem
+  `left-catchup-indexed-all-prefix-post-allocation-β-Λ•ᵀ`.
+  In nominal notation its operational component is
+
+  \[
+    (\Lambda X.\,W)[\alpha]
+      \longrightarrow W,
+  \]
+
+  while the final value relation is weakened from `\rho_0` to `\rho^+`.
+
+- Factored the identity action on arbitrary relation worlds.  The new
+  `identity-store-rel-embeddingⁱ` and `identity-world-embeddingⁱ` do not
+  identify proof-relevant store witnesses; they embed a world into itself.
+  Consequently `identity-bodyᵀ` proves
+
+  \[
+    \Phi;\rho\vdash L\sqsubseteq L' : A\sqsubseteq B\;[p]
+    \quad\Longrightarrow\quad
+    \Phi;\rho\vdash L\sqsubseteq L' : A\sqsubseteq B\;[I(p)]
+  \]
+
+  for bullet-free terms, where `I = ⊑-rename-idᵢ`.  This is the transport
+  needed when the pending prefix produces an arbitrary outer store.
+
+- Closed the direct prefixed `α/Λ` leaf.  Given two left lifts `\rho^a`
+  and `\rho^b` of the same base world and a pending extension
+
+  \[
+    (\alpha,\uparrow A)::\rho^a \preccurlyeq \rho^+,
+  \]
+
+  `left-catchup-indexed-all-prefix-α-Λᵀ` constructs the one-step trace
+
+  \[
+    (\Lambda X.\,W)[\alpha] \longrightarrow W
+  \]
+
+  and the final relation in `\rho^+`.  The relation first moves from
+  `\rho^b` to `\rho^a` by the paired-lift identity embedding and is then
+  weakened through the pending prefix.  Its transport action is uniformly
+  `I`, independent of the shape of `\rho^+`.
+
+- Audited the total recursion by temporarily exposing its terminal,
+  prefix-composition, and direct `α/Λ` clauses to Agda's exhaustiveness
+  checker.  After these clauses, the remaining top-level constructors are
+
+  \[
+  \begin{gathered}
+    \mathsf{up},\quad \nu_L,\quad \nu_L^\star,\\
+    \mathsf{cast}_L^{\mathord\sqsupseteq},\quad
+    \mathsf{cast}_L^{\mathord\sqsubseteq},\quad
+    \mathsf{cast}_R^{\mathord\sqsupseteq},\quad
+    \mathsf{cast}_R^{\mathord\sqsubseteq},\\
+    \mathsf{conv}_{LR},\quad
+    \mathsf{reveal}_L,\quad \mathsf{conceal}_L,\quad
+    \mathsf{reveal}_R,\quad \mathsf{conceal}_R.
+  \end{gathered}
+  \]
+
+  In the `α` branch, canonical-form inversion reduces the residual cases to
+  target-cast or prefix wrappers around `Λ`, plus the universal-cast and
+  `gen` value forms.  Thus the next proof obligation is a single general
+  cast-framing operation for indexed left catch-up.  It should transport an
+  already-computed catch-up through one existing source or target cast
+  constructor, rather than add another term-imprecision rule.  Once this
+  operation is checked, the remaining `α` cases and the top-level cast cases
+  share the same recursion principle.
+
+### 2026-07-18: arbitrary-index universal cast framing
+
+- Added structural source and target cast frames for weak one-step results.
+  The source frame has the following nominal proof shape:
+
+  \[
+  \begin{array}{c@{\qquad}c}
+    M & V' \\
+    \mathrel{\Downarrow^{\chi_s}} & \mathrel{\Downarrow^0} \\
+    W & V' \\
+    \hline
+    M\langle c\rangle & V' \\
+    \mathrel{\Downarrow^{\chi_s}} & \mathrel{\Downarrow^0} \\
+    W\langle \chi_s(c)\rangle & V'.
+  \end{array}
+  \]
+
+  The frame preserves both `WeakOneStepTransport` and
+  `WeakOneStepTypeCoherence`.  It does not add a term-imprecision
+  constructor; the final cast relation is rebuilt from the transported
+  original evidence.
+
+- Factored the terminal argument shared by inert source casts.  If the inner
+  catch-up ends in a value `W`, inertness gives
+
+  \[
+    \mathsf{Value}(W\langle c\rangle).
+  \]
+
+  If it ends in `blame`, the frame appends the existing reduction
+
+  \[
+    \mathsf{blame}\langle c\rangle \longrightarrow \mathsf{blame}.
+  \]
+
+  Thus the blame branch still contains a concrete source trace; it is not an
+  unrestricted permission for the less-precise term to blame.
+
+- Proved the exact universal coercion classifications
+
+  \[
+  \begin{aligned}
+    c : \forall X.A \mathrel{\sqsupseteq} \forall X.B
+      &\Longrightarrow \mathsf{Inert}(c),\\
+    c : \forall X.A \mathrel{\sqsubseteq} \forall X.B
+      &\Longrightarrow
+        \mathsf{Inert}(c)
+        \;\lor\;
+        \exists s.\;c=\mathsf{inst}(\forall X.B,s).
+  \end{aligned}
+  \]
+
+  Reveal and conceal conversions between two universal types are also inert.
+  These classifications deliberately require both endpoints to be universal:
+  a coercion whose target alone is universal may be an `unseal` from a stored
+  universal type.
+
+- Added iterated preservation for narrowing and widening evidence through an
+  arbitrary sequence of emitted `keep` and `bind` changes.  Added the analogous
+  transport for the single-name reveal and conceal predicates.  The latter
+  transports the distinguished seal name and its associated type as names are
+  allocated.
+
+- Closed the source narrowing, inert source widening, source reveal, and
+  source conceal catch-up clauses.  Each has a prefix-aware form.  If
+
+  \[
+    \rho_0 \preccurlyeq \rho^+,
+  \]
+
+  the original coercion evidence and seal permission are weakened along the
+  induced inclusion of left stores before framing the recursive result in
+  `\rho^+`.
+
+- Corrected an interface error discovered by the cast clauses.  Even when the
+  endpoints of the inner relation are both universal, its proof index need not
+  have the form `\forall q`; it may have the source-only form `\nu q`.  In
+  particular, a source cast rule may hide
+
+  \[
+    \Phi;\rho \vdash M \sqsubseteq V'
+      : \forall X.A \sqsubseteq \forall X.A'\;[p]
+  \]
+
+  for an arbitrary admissible index `p`.  Added the genuinely general package
+  `LeftCatchupIndexedResult p`, together with arbitrary-index terminal and
+  `keep`-prefix composition.  The source cast clauses now consume this general
+  package and return the requested outer `\forall`-indexed result.  The older
+  `LeftCatchupIndexedAllResult q` remains only where a theorem specifically
+  needs the canonical outer index `\forall q`.
+
+- The remaining source-widening boundary is now isolated exactly as
+
+  \[
+    c=\mathsf{inst}(\forall X.B,s).
+  \]
+
+  Its value branch performs `\beta\text{-inst}` and creates a `\nu\,\star`
+  state; its blame branch is already covered by the generic cast-on-blame
+  composition.  The administrative transition and its return to catch-up are
+  now checked in the next boundary.
+
+### 2026-07-18: `\beta`-inst-to-`\nu\,\star` handoff and cached proof layers
+
+- Proved the exceptional source-widening value trace.  If the recursive
+  catch-up produces a value `W`, then the source has the nominal reduction
+  shape
+
+  \[
+  \begin{aligned}
+    M\langle \mathsf{inst}(\forall X.B,s)\rangle
+      &\mathrel{\Downarrow^{\chi_s}}
+        W\langle
+          \mathsf{inst}(\forall X.\chi_s(B),\chi_s(s))
+        \rangle \\
+      &\longrightarrow
+        \nu\,\star\,W\,\chi_s(s).
+  \end{aligned}
+  \]
+
+  The last arrow is the actual `\beta\text{-inst}` reduction.  The final
+  relation is obtained from the existing source `\nu\,\star` frame, so this is
+  a simulation-up-to administrative step rather than a new term-imprecision
+  rule.
+
+- Strengthened `LeftSilentIndexedResult p`.  A silent continuation now carries
+  all four invariants needed by recursion:
+
+  \[
+  \begin{gathered}
+    \text{a canonical indexed result at the transported }p,\\
+    \mathsf{RuntimeOK}(W),\qquad
+    \mathsf{WeakOneStepTransport},\qquad
+    \mathsf{WeakOneStepTypeCoherence}.
+  \end{gathered}
+  \]
+
+  Storing `RuntimeOK` in the package is essential: the trace may be hidden
+  behind a transported coercion derivation, so the consumer should not depend
+  on reducing the proof term definitionally to rediscover that the result is
+  `\nu\,\star\,W\,s`.
+
+- Added the exhaustive source-widening progress boundary.  For
+  `c : \forall X.A \sqsubseteq \forall X.B`, exactly one of the following
+  checked outcomes is returned:
+
+  \[
+  \begin{array}{c|c}
+    \mathsf{Inert}(c),\ W\text{ a value}
+      & \text{terminal catch-up} \\
+    c=\mathsf{inst}(\forall X.B,s),\ W\text{ a value}
+      & \text{silent }\beta\text{-inst-to-}\nu\,\star\text{ continuation} \\
+    W=\mathsf{blame}
+      & \text{terminal catch-up with an explicit blame trace.}
+  \end{array}
+  \]
+
+- Proved `left-catchup-indexed-resume-silentᵀ`.  If a silent prefix transports
+  `p` to `p_1`, and recursive catch-up closes the resulting relation at `p_1`,
+  then their source traces compose and produce catch-up at the original `p`.
+  The proof first canonicalizes the prefix endpoint types, then uses
+  heterogeneous equality only at the composition boundary.  It does not use
+  proof irrelevance.
+
+- Repaired two latent framing interfaces exposed by this composition:
+
+  - a source-only cast changes the left endpoint but leaves the right endpoint
+    fixed, so the indexed frame concludes `B \sqsubseteq A'`, not an unrelated
+    `B \sqsubseteq B'`;
+  - cast frames are normalized through their stored canonical indexed
+    relation before their raw `resultType` is composed.
+
+  The universal narrowing and widening classifications are now exhaustive for
+  `id`, sequence, `\forall`, `gen`, and `inst` coercion shapes.
+
+- Split the former 24,000-line simulation module into cacheable layers:
+
+  - `NuImprecisionSimulationCore` contains 15,003 lines of stable weak-step,
+    transport, world-embedding, and permutation infrastructure;
+  - `NuImprecisionSimulation` contains 7,205 lines of active universal
+    catch-up and generic `\beta\text{-}\forall` reasoning;
+  - `NuImprecisionAllocationSimulation` contains 3,157 lines of completed
+    synchronized and one-sided allocation cases;
+  - `NuImprecisionCatchupScratch` is a 126-line active proof file containing
+    the resume lemma.
+
+  With the core cache warm, the scratch lemma checks in about four seconds.
+  The next proof boundary is to invoke its done/continue interface from the
+  total indexed universal catch-up recursion.
+
+### 2026-07-18: arbitrary-index source-`∀` catch-up boundary
+
+- Refined the recursive catch-up interface after asking Agda for the exact
+  constructor coverage.  The structurally useful worker must preserve
+  an arbitrary derivation
+
+  \[
+    p : \Phi;\Delta_L \vdash \forall X.A \sqsubseteq B;\Delta_R,
+  \]
+
+  rather than assume both endpoints and the index already have the paired
+  shape `\forall q`.  A source cast can hide either a paired `\forall` index
+  or a source-only `\nu` index, and a target cast can hide a non-universal
+  target type.  The public canonical-`\forall` theorem will be the
+  specialization obtained after this general worker returns.
+
+- Added `specialize-left-indexed-all-catchup`, the checked projection
+
+  \[
+    \mathsf{LeftCatchupIndexedResult}(\forall q)
+      \Longrightarrow
+    \mathsf{LeftCatchupIndexedAllResult}(q).
+  \]
+
+  Added the prefix-aware terminal value lemma
+  `left-catchup-indexed-source-all-prefix-valueᵀ`.  It weakens only after the
+  source is known to be a bullet-free value, so a pending allocation prefix
+  is never incorrectly pushed through an active runtime bullet.
+
+- Proved the first fully general value-shaped allocation leaf,
+  `left-catchup-indexed-prefix-α-Λᵀ`.  In nominal notation its operational
+  component is
+
+  \[
+    (\Lambda X.W)[\alpha] \longrightarrow W.
+  \]
+
+  If two lifted worlds `\rho^a` and `\rho^b` arise from the same base world,
+  and
+
+  \[
+    (\alpha,\uparrow A)::\rho^a \preccurlyeq \rho^+,
+    \qquad
+    \rho^b \vdash W \sqsubseteq V' : C \sqsubseteq_p B,
+  \]
+
+  the lemma returns `LeftCatchupIndexedResult p` in `\rho^+`.  It transports
+  `p` by the existing identity permutation action; it does not require
+  `p = \forall q` or require `B` to be universal.
+
+- Kept the unfinished dispatcher out of the checked modules.  Its temporary
+  coverage audit confirmed that, after terminal `blame`, both `Λ` value
+  forms, prefix composition, and the direct `α/Λ` leaf, the remaining
+  boundary consists of quotiented widening, the residual value-shaped
+  `α` forms, source-only `ν` and `ν★`, and source/target cast or conversion
+  wrappers.  These should be discharged by supporting framing lemmas, with
+  the recursive hypothesis computed before it is passed to each helper.
+
+- Moved the stable terminal/projection lemmas to
+  `NuImprecisionSimulationCore` and the stable general `α/Λ` lemma to
+  `NuImprecisionSimulation`.  `NuImprecisionCatchupScratch` is again a
+  149-line checked file containing only the active silent-resumption lemma.
+  All three modules check with `--no-allow-unsolved-metas`.
+
+### 2026-07-18: target frames and the visible one-step dispatcher
+
+- Added a generic target-frame composition lemma and five prefix-aware target
+  wrappers.  They handle target narrowing, target widening in arbitrary and
+  identity-only modes, reveal, and conceal.  In nominal notation, each has
+  the common shape
+
+  \[
+    \frac{
+      \rho_0 \preccurlyeq \rho^+
+      \qquad
+      \rho^+ \vdash N \sqsubseteq V' : A \sqsubseteq_p A'
+    }{
+      \rho^+ \vdash
+        N \sqsubseteq V'\langle c'\rangle
+        : A \sqsubseteq_q B'}.
+  \]
+
+  The coercion or single-name conversion evidence is first weakened from
+  `\rho_0` to `\rho^+`, then transported through the recursive catch-up
+  result.  No term-imprecision constructor was added.
+
+- Exposed `left-catchup-indexed-source-all-prefixᵀ` as the active recursive
+  worker, together with its unprefixed and canonical paired-`∀` corollaries.
+  The implemented recursion obtains its induction hypothesis before passing
+  it to each target-frame helper.  Agda's coverage report isolates the
+  remaining work into nine explicit hole families:
+
+  1. paired quotiented widening;
+  2. residual post-allocation `α` forms;
+  3. source-only `ν` and `ν\,\star` catch-up;
+  4. source narrowing and source widening frames;
+  5. paired, reveal-only, and conceal-only source conversions.
+
+  These holes are intentionally confined to
+  `NuImprecisionCatchupScratch`; the stable core, allocation, and universal
+  support modules remain hole-free.
+
+- Added the visible recursive statement
+  `weak-one-step-indexed-simulationᵀ`:
+
+  \[
+    \begin{gathered}
+      \Phi;\rho \vdash M \sqsubseteq M' : A \sqsubseteq_p B,
+      \qquad
+      M' \longrightarrow^{\chi} N' \\
+      \Longrightarrow
+      \mathsf{WeakOneStepIndexedOutcome}(p).
+    \end{gathered}
+  \]
+
+  Its checked clauses now include immediate source `blame`, matched ordinary
+  `ν`, matched `ν\,\star`, source-only `ν` and `ν\,\star` frames, and
+  target-only `ν` and `ν\,\star` allocation and frame cases.  For every
+  `ξ-ν` clause, recursion is on the body relation and the resulting induction
+  hypothesis is supplied to the corresponding indexed frame theorem.
+  Target `blame-ν` is closed whenever inversion exposes an inner
+  `blame \sqsubseteq blame` leaf.
+
+- The `ν\,\star` frame boundary exposed one harmless syntactic transport:
+
+  \[
+    \mathsf{applyTy}(\chi,\star)=\star.
+  \]
+
+  Both matched and target-only `ξ-ν` clauses rewrite by `applyTy-★` before
+  invoking their frame helper.
+
+- The scratch module checks normally with its explicit construction options.
+  It is not claimed to check with `--no-allow-unsolved-metas`: the nine
+  catch-up families and the rest of the general dispatcher are deliberately
+  still open.  The next focused boundary is paired quotiented widening,
+  because it is the only remaining worker family whose outer source shape is
+  a casted quotiented term rather than an allocation or a single source
+  frame.
+
+### 2026-07-18: arbitrary-type catch-up and quotient recursion
+
+- Generalized the active value-catch-up recursion from a universal source
+  endpoint to an arbitrary source endpoint:
+
+  \[
+    \begin{gathered}
+      \rho_0 \preccurlyeq \rho^+,
+      \qquad
+      \rho_0 \vdash M \sqsubseteq V' : A \sqsubseteq_p B,
+      \\
+      \operatorname{RuntimeOK}(M),
+      \qquad
+      \operatorname{Value}(V'),
+      \qquad
+      \operatorname{NoBullet}(V')
+      \\
+      \Longrightarrow
+      \mathsf{LeftCatchupIndexedResult}_{\rho^+}
+        (M,V',A,B,p).
+    \end{gathered}
+  \]
+
+  The previous source-`\forall` worker is now a direct specialization of this
+  theorem.  This is a proof-interface change only; no term-imprecision rule
+  was added or loosened.
+
+- Proved the general terminal clauses for `blame`, functions, type
+  abstractions, and constants.  Also discharged by inversion every relation
+  constructor whose target syntax cannot be a value: variables,
+  applications, paired runtime bullets, target-only runtime bullets, matched
+  allocations, target-only allocations, and primitive applications.
+
+- Added the direct recursive quotient clauses.  In nominal notation, for the
+  ordinary body premise
+
+  \[
+    M \sqsubseteq M' : C \sqsubseteq_{p_C} C',
+  \]
+
+  the dispatcher first obtains the induction hypothesis
+
+  \[
+    \mathsf{catchup}(M,M',p_C),
+  \]
+
+  and then supplies it to the appropriate cast-spine helper:
+
+  \[
+    \frac{
+      \mathsf{catchup}(M,M',p_C)
+      \qquad
+      M\langle d\rangle
+        \sqsubseteq^p M'\langle d'\rangle
+      \qquad
+      (u,u') : (D,D') \leadsto (A,A')
+    }{
+      M\langle d\rangle\langle u\rangle
+        \mathrel{\mathsf{catchup}}
+      M'\langle d'\rangle\langle u'\rangle
+    }.
+  \]
+
+  There are separate helpers for the two existing quotient constructors,
+  `down\sqsubseteq down` and `gen\text{-}down\sqsubseteq gen\text{-}down`.
+  These are proof helpers, not new syntax-directed relation clauses.
+
+- The target-value inversion is now expressed directly in the dispatcher:
+
+  \[
+    \operatorname{Value}
+      (M'\langle d'\rangle\langle u'\rangle)
+    \Longrightarrow
+    \operatorname{Value}(M')
+      \land \operatorname{Inert}(d')
+      \land \operatorname{Inert}(u').
+  \]
+
+  The source runtime premise is stripped through both casts before the
+  recursive call.  Thus the quotient boundary no longer assumes that its
+  hidden ordinary source type is itself universal.
+
+- Proved and moved to `NuImprecisionSimulationCore` the missing quotient-index
+  transport theorem.  Store changes act on types by renaming, and renaming
+  preserves adjacent-`\forall` permutation equivalence:
+
+  \[
+    C \approx_\forall E
+    \Longrightarrow
+    \mathsf{applyTys}(\bar\chi,C)
+      \approx_\forall
+    \mathsf{applyTys}(\bar\chi,E).
+  \]
+
+  Therefore, if a weak result transports the ordinary middle witness in
+
+  \[
+    C \approx_\forall E
+      \sqsubseteq F
+      \approx_\forall D,
+  \]
+
+  then `weak-one-step-transport-quotientᵀ` reconstructs the corresponding
+  transported quotient witness.  The weak-result record itself does not need
+  another field.
+
+- The generalized recursion and the source-`\forall` corollaries check in
+  the scratch module.  Ten explicit holes remain: two quotient cast-spine
+  helpers, residual source runtime-bullet catch-up, source-only ordinary and
+  `\star` allocation, source narrowing/widening, and three source-side
+  conversion families.
+
+### Next boundary
+
+Analyze each quotient cast-spine helper by the final state returned from its
+body induction hypothesis:
+
+\[
+  M \longrightarrow^* \mathsf{blame}
+  \qquad\text{or}\qquad
+  M \longrightarrow^* V.
+\]
+
+The blame branch should append two cast-blame steps.  The value branch should
+use the narrowing and widening typing premises to classify each source cast
+as inert or administrative, resuming catch-up after every administrative
+step.  This isolates all operational work inside the two helpers and keeps
+the derivation recursion fixed.
+
+### 2026-07-18: transported quotient spines and the shared value boundary
+
+- Proved fixed-mode transport for narrowing and widening coercions.  If
+  renaming by one type-variable step preserves the mode environment, then
+
+  \[
+    \mu;\Delta;\Sigma \vdash c : A \mathrel{\trianglerighteq} B
+    \Longrightarrow
+    \mu;\mathsf{applyCtxs}(\bar\chi,\Delta);
+      \mathsf{applyStores}(\bar\chi,\Sigma)
+      \vdash
+      \mathsf{applyCoercions}(\bar\chi,c)
+      : \mathsf{applyTys}(\bar\chi,A)
+        \mathrel{\trianglerighteq}
+        \mathsf{applyTys}(\bar\chi,B),
+  \]
+
+  and likewise for widening.  The two modes needed by quotient narrowing,
+  `id-only` and `gen(tag-or-id)`, satisfy this invariant.  These lemmas are
+  stable and now live in `NuImprecisionSimulationCore`.
+
+- Proved transport of both quotient narrowing constructors through a body
+  catch-up result.  In nominal notation, the ordinary case reconstructs
+
+  \[
+    N\langle \bar\chi d\rangle
+      \sqsubseteq^p
+    N'\langle d'\rangle
+    : \bar\chi D \sqsubseteq^p D',
+  \]
+
+  while the generalized case has the same conclusion with its narrowing
+  derivations checked in `gen(tag-or-id)` mode.  Source coercion evidence is
+  transported through `\bar\chi`; target evidence only requires prefix
+  weakening because the target catch-up tail is empty.
+
+- Proved transport of `QuotientWideningPair` for both of its existing
+  constructors.  The identity-only constructor uses fixed-mode widening
+  transport.  The arbitrary-cast constructor transports its cast mode,
+  seal-store invariant, and widening derivation together.  Consequently the
+  final quotient relation is rebuilt directly as
+
+  \[
+    \frac{
+      N\langle \bar\chi d\rangle
+        \sqsubseteq^p N'\langle d'\rangle
+      \qquad
+      (\bar\chi u,u') :
+        (\bar\chi D,D') \leadsto (\bar\chi A,A')
+    }{
+      N\langle \bar\chi d\rangle\langle \bar\chi u\rangle
+        \sqsubseteq
+      N'\langle d'\rangle\langle u'\rangle
+      : \bar\chi A \sqsubseteq A'}.
+  \]
+
+  A single double-cast frame lifts the body reduction trace to this relation.
+  The construction preserves the weak-result transport and type-coherence
+  interfaces, so both quotient dispatcher clauses now call the same
+  structural helper.  No term-imprecision rule was added.
+
+- Closed the body-blame operational branch.  Once body catch-up yields
+  `blame`, the source has the trace
+
+  \[
+    \mathsf{blame}\langle d\rangle\langle u\rangle
+      \longrightarrow
+    \mathsf{blame}\langle u\rangle
+      \longrightarrow
+    \mathsf{blame}.
+  \]
+
+  The target takes zero steps, and its typing derivation constructs the
+  existing left-blame relation at the final index.  This branch therefore
+  does not permit new source blame; it merely propagates blame already
+  returned by the recursive body catch-up.
+
+- Factored the remaining quotient work into one shared hole,
+  `left-catchup-indexed-final-double-castᵀ`, rather than one hole per
+  quotient constructor.  Its open clause assumes that body catch-up returned
+  a value.  The two former quotient helper holes are closed, and the scratch
+  module now has nine explicit holes in total: this shared value clause plus
+  the eight previously isolated allocation, cast, and conversion families.
+
+### Next boundary
+
+Classify the transported source narrowing and widening coercions when the
+body result is a value:
+
+\[
+  \operatorname{Value}(V),
+  \qquad
+  V\langle d\rangle\langle u\rangle
+    \sqsubseteq
+  V'\langle d'\rangle\langle u'\rangle,
+  \qquad
+  \operatorname{Inert}(d'),
+  \operatorname{Inert}(u').
+\]
+
+The desired inversion should distinguish inert source casts from the few
+administrative `gen`/`inst` shapes that allocate or expose a type
+instantiation.  Each inert/inert outcome closes immediately as a value;
+each administrative outcome should resume catch-up after its explicit
+reduction trace and reuse the completed allocation-crossed lemmas.  This is
+the only remaining quotient-specific operational boundary.
+
+### 2026-07-18: active quotient spines reduce by one silent step
+
+- Moved the quotient body-value boundary out of
+  `NuImprecisionCatchupScratch` into the small, independently checked module
+  `NuImprecisionQuotientValue`.  The large catch-up dispatcher now
+  imports only the final quotient theorem.  Stable coercion-shape decision is
+  supplied by `inert-dec` in `CoercionProperties`, so changing the active
+  proof does not force Agda to recheck the general coercion metatheory.
+
+- Closed the inert/inert source case directly.  In nominal notation, if
+
+  \[
+    V\langle d\rangle\langle u\rangle
+      \sqsubseteq
+    V'\langle d'\rangle\langle u'\rangle
+  \]
+
+  is the rebuilt quotient relation and both `d` and `u` are inert, then the
+  source already is a value and catch-up takes zero steps.
+
+- Proved the general active-cast progress lemma.  If `V` is a closed
+  bullet-free value, `c : C \Rightarrow D` is a well-typed coercion, and `c`
+  is not inert, then
+
+  \[
+    V\langle c\rangle \longrightarrow_{\mathsf{keep}} L
+  \]
+
+  for some `L`.  The proof uses typed progress and value irreducibility.  A
+  separate inversion proves that every step out of a cast around a value has
+  store change `keep`; hence this fact does not hide an allocation.
+
+- Lifted that result to the complete source quotient spine.  If
+
+  \[
+    \neg\bigl(\operatorname{Inert}(d) \land
+               \operatorname{Inert}(u)\bigr),
+  \]
+
+  then, for some `L`,
+
+  \[
+    V\langle d\rangle\langle u\rangle
+      \longrightarrow_{\mathsf{keep}} L.
+  \]
+
+  When `d` is active, its step is lifted through the outer cast.  When `d` is
+  inert, the whole inner cast is a value and typed progress supplies the step
+  of `u`.
+
+- Expanded the active quotient dispatcher over the two narrowing premises
+  (`down/down` and generalized `gen-down/gen-down`) and the two widening-pair
+  premises (identity-mode and arbitrary cast-mode).  Every one of these four
+  clauses obtains the source step first and feeds it to the same supporting
+  theorem.  Thus the relation recursion gained no constructor and the
+  semantic work did not multiply into four holes.
+
+- The shared supporting theorem now has exactly two explicit unfinished
+  clauses:
+
+  \[
+    \begin{array}{ll}
+    \text{outer step:} &
+      V\langle d\rangle\langle u\rangle
+        \longrightarrow L, \\
+    \text{inner step:} &
+      V\langle d\rangle \longrightarrow K,
+      \quad
+      V\langle d\rangle\langle u\rangle
+        \longrightarrow K\langle u\rangle.
+    \end{array}
+  \]
+
+  This is the next proof boundary.  The outer clause contains the important
+  `inst` case, whose first step exposes `ν ★`; the inner clause contains the
+  administrative narrowing cases.  They should be handled by reduction-shape
+  helpers and then resumed through the existing allocation simulation, rather
+  than by extending term imprecision.
+
+### 2026-07-18: quotient reduction is split into reachable root shapes
+
+- Replaced the two opaque source-step holes by separate outer- and inner-cast
+  dispatchers.  For a bullet-free value `V`, the operational candidates are
+  now visible as the formula-shaped cases
+
+  \[
+    V\langle d\rangle\langle u\rangle \longrightarrow L
+  \]
+
+  and
+
+  \[
+    V\langle d\rangle \longrightarrow K,
+    \qquad
+    V\langle d\rangle\langle u\rangle
+      \longrightarrow K\langle u\rangle.
+  \]
+
+  Each dispatcher explicitly analyzes identity, sequence, instantiation,
+  tag/untag, and seal/unseal roots.  A step below the inner cast is impossible
+  because `V` is a value.
+
+- Proved two coercion-shape inversions from the quotient narrowing premise.
+  If
+
+  \[
+    V\langle d\rangle \sqsubseteq^{p}
+      V'\langle d'\rangle,
+  \]
+
+  then `d` cannot be a tag and cannot be an unseal.  Consequently, an outer
+  tag/untag redex and an inner seal/unseal redex are unreachable.  This is a
+  typing fact, not an added case of term imprecision.
+
+- Closed the reachable failed-tag case.  When the tag occurs inside `V` and
+  the quotient narrowing is an untag, the whole source trace is
+
+  \[
+    W\langle G\mathbin{!}\rangle
+      \langle H\mathbin{?}\rangle\langle u\rangle
+      \longrightarrow
+    \mathsf{blame}\langle u\rangle
+      \longrightarrow
+    \mathsf{blame},
+    \qquad G \ne H.
+  \]
+
+  The final relation is obtained from the existing source-blame rule; the
+  target remains unchanged.
+
+- Proved the two instantiation/allocation traces needed by the remaining hard
+  cases.  Instantiation at the outer widening gives
+
+  \[
+    V\langle d\rangle\langle \mathsf{inst}\ B\ s\rangle
+      \longrightarrow
+    \nu\,\star\;V\langle d\rangle\;s
+      \longrightarrow_{\mathsf{bind}\ \star}
+    \bigl((\uparrow V\langle d\rangle)\,\bullet\bigr)
+      \langle s\rangle.
+  \]
+
+  Instantiation at the inner narrowing, lifted through the outer cast, gives
+
+  \[
+    V\langle \mathsf{inst}\ B\ s\rangle\langle u\rangle
+      \longrightarrow
+    (\nu\,\star\;V\;s)\langle u\rangle
+      \longrightarrow_{\mathsf{bind}\ \star}
+    \bigl((\uparrow V)\,\bullet\bigr)
+      \langle s\rangle\langle \uparrow u\rangle.
+  \]
+
+  These checked traces are already bound in the two unfinished instantiation
+  clauses.  The next relational step is therefore specifically to transport
+  the quotient narrowing/widening evidence across the fresh `\star` entry and
+  connect it to the crossed-allocation lemmas.
+
+- Eight reachable quotient clauses remain: outer identity, sequence,
+  instantiation, and seal/unseal; and inner identity, sequence,
+  instantiation, and matching tag/untag.  The dispatcher skeleton is
+  intentionally incomplete while these supporting lemmas are developed.
+
+- Proved the ground-endpoint quotient-collapse lemma
+  `⊑ᵖ-ground-left`.  In nominal notation, if `G` is ground, then
+
+  \[
+    \Gamma \vdash G \sqsubseteq^{p} B
+    \quad\Longrightarrow\quad
+    \Gamma \vdash G \sqsubseteq B.
+  \]
+
+  The proof first shows that variables, base types, `\star`, and the ground
+  function type `\star \to \star` are fixed points of adjacent-`\forall`
+  permutation.  It then inverts ordinary imprecision from a ground source;
+  every possible target is itself fixed by the permutation equivalence.
+
+  Two checked narrowing inversions feed this lemma into the active quotient
+  clauses.  A seal narrowing has hidden source endpoint `\alpha`, and an
+  untag narrowing has hidden source endpoint `G`.  Hence the remaining
+  seal/unseal and matching tag/untag holes now contain an ordinary hidden
+  index, rather than only the quotiented one.  Their next obligation is term
+  inversion: remove the cancelled source conversion while rebuilding the two
+  inert target casts.
+
+### 2026-07-18: inert-target inversion eliminates the conversion leaves
+
+- Audited the matching tag/untag state against the loosened
+  `paired-widening` premise.  An unrestricted paired widening can indeed
+  forget an intermediate index, so stripping the source tag in isolation is
+  not a valid general lemma.  The complete quotient state carries a stronger
+  invariant, however: its target narrowing and widening are both inert
+  because the target is already a value.
+
+- Proved the coercion inversion used by that invariant.  In nominal form, if
+  `G` is ground, `G \sqsubseteq D`, the mode `\mu` permits no seals, and
+
+  \[
+    c : \star \mathrel{\trianglerighteq}_{\mu} D,
+    \qquad \operatorname{Inert}(c),
+  \]
+
+  then this state is impossible.  The only nontrivial inert coercion out of
+  `\star` is a `gen` coercion, whose target is universal; ordinary
+  imprecision cannot relate a ground source to that universal target.  The
+  two quotient narrowing modes satisfy the no-seal premise:
+
+  \[
+    \mathsf{id\!\text{-}\!only}^{d},
+    \qquad
+    \mathsf{gen}^{d}(\mathsf{tag\!\text{-}\!or\!\text{-}\!id}^{d}).
+  \]
+
+- Proved that ordinary imprecision with source `\star` has target `\star`.
+  Applying this to the body of
+
+  \[
+    W\langle G!\rangle\langle G?\rangle
+      \sqsubseteq
+    V'\langle d'\rangle
+  \]
+
+  transports the target narrowing to one whose source is `\star`.  Ground
+  quotient collapse supplies `G \sqsubseteq D'`, and the inert-target
+  coercion inversion gives a contradiction.  Thus the matching tag/untag
+  dispatcher clause is unreachable; no source-tag stripping rule and no new
+  term-imprecision constructor is needed.
+
+- Strengthened the analogous seal observation.  A quotient narrowing cannot
+  be a seal at all, because neither quotient narrowing mode permits seals.
+  Therefore the outer seal/unseal dispatcher clause is also unreachable.
+  This replaces the earlier weaker fact that only recovered its ground
+  endpoint.
+
+- The active quotient dispatcher now has six holes: outer identity,
+  sequence, and instantiation; and inner identity, sequence, and
+  instantiation.  All tag/untag and seal/unseal roots are closed.  The next
+  boundary is administrative identity/sequence normalization while retaining
+  the original quotient-spine evidence; the crossed `inst` allocation traces
+  remain the subsequent polymorphic boundary.
+
+### 2026-07-18: sequence normalization preserves the quotient spine
+
+- Split both sequence grammars at their canonical endpoints.  A widening
+  sequence has one of the forms
+
+  \[
+    s;G!
+    \qquad\text{or}\qquad
+    \mathsf{unseal}\ \alpha;s,
+  \]
+
+  while a quotient narrowing sequence has one of the forms
+
+  \[
+    G?;g
+    \qquad\text{or}\qquad
+    n;\mathsf{seal}\ \alpha.
+  \]
+
+  The unseal-headed outer alternatives are impossible because they would
+  make the inert quotient narrowing end at a type name in a mode that permits
+  no seals.  The seal-tailed inner alternatives are impossible directly:
+  neither quotient narrowing mode permits their final seal.
+
+- Proved the strict-cross ground-endpoint inversion.  If `s` is a typed
+  strict-cross widening ending at a ground type `G`, or `g` is a typed
+  strict-cross narrowing beginning at `G`, then
+
+  \[
+    G = \star \to \star.
+  \]
+
+  Consequently ordinary imprecision supplies
+
+  \[
+    G \sqsubseteq \star.
+  \]
+
+  The proof is exhaustive: strict-cross function coercions force an arrow
+  endpoint, strict-cross universal coercions force a universal endpoint, and
+  only the ground arrow `\star \to \star` survives.
+
+- Closed both outer sequence clauses.  The source trace is
+
+  \[
+    V\langle d\rangle\langle s;G!\rangle
+      \longrightarrow
+    V\langle d\rangle\langle s\rangle\langle G!\rangle.
+  \]
+
+  At the residual state, `up⊑upᵀ` retains the original quotient narrowing,
+  uses `s` as its source widening, and keeps the original target widening.
+  The ordinary source-cast rule then adds `G!`.  This works for both the
+  identity-mode pair and the arbitrary cast-mode pair, and the residual is a
+  value.  No term-imprecision constructor was added.
+
+- Proved `inner-sequence-residualᵀ`.  For either quotient narrowing mode, if
+
+  \[
+    V\langle G?;g\rangle\langle u\rangle
+      \sqsubseteq
+    V'\langle d'\rangle\langle u'\rangle,
+  \]
+
+  then the result of the administrative sequence step has the checked
+  relation
+
+  \[
+    V\langle G?\rangle\langle g\rangle\langle u\rangle
+      \sqsubseteq
+    V'\langle d'\rangle\langle u'\rangle.
+  \]
+
+  The leading untag is reconstructed by the ordinary source-narrowing rule at
+  `G \sqsubseteq \star`; the strict-cross suffix `g`, target narrowing `d'`,
+  and outer widenings remain in the quotient constructors.
+
+- Six implementation holes remain, but only five semantic families: outer
+  identity and instantiation; inner identity, sequence, and instantiation.
+  The two inner sequence holes now already bind their residual relation.  The
+  next boundary is to pass the recursive ordinary catch-up result into the
+  quotient helper and prepend the checked `keep` step.  This is the required
+  induction hypothesis handoff; duplicating ordinary tag/untag catch-up inside
+  the quotient helper would be the wrong proof structure.
+
+- Moved the stable source-`keep` composition layer out of
+  `NuImprecisionSimulation` into `NuImprecisionCatchupComposition`.  It proves
+  that a source step
+
+  \[
+    M \longrightarrow_{\mathsf{keep}} N
+  \]
+
+  can be prepended to an indexed catch-up result for `N`, while preserving
+  `WeakOneStepTransport` and `WeakOneStepTypeCoherence`.  The large simulation
+  module now imports these cached lemmas instead of defining them locally.
+
+- Wired both inner sequence clauses through that composition theorem.  Their
+  only remaining local hole is now the catch-up result for the already-checked
+  residual relation; the outer result, trace concatenation, transport, and
+  coherence are all derived.  Thus the open goal is no longer “simulate
+  `β-seq`.”  It is exactly “supply the recursive ordinary catch-up result for
+  the residual source-narrowing relation.”
+
+### 2026-07-18: identity spines and inner instantiation are impossible
+
+- Proved the three atomic target inversions needed for a literal identity
+  coercion.  If an inert narrowing ends at a base type or at `\star`, then the
+  state is impossible.  If it ends at a type name, the same conclusion holds
+  whenever the mode permits no seals.  Both quotient narrowing modes satisfy
+  that restriction.
+
+- Proved that quotiented imprecision with source `\star` has target `\star`:
+
+  \[
+    \Phi;\Delta_L \vdash
+      \star \sqsubseteq^{p} B
+    \quad\Longrightarrow\quad
+    B = \star.
+  \]
+
+  Together with ground quotient collapse, this gives the complete target-side
+  inversion for identity coercions.  A source name can only relate to a target
+  name or `\star`; a source base type can only relate to the same base type or
+  `\star`; and a source `\star` can only relate to `\star`.
+
+- Closed both identity dispatcher leaves.  In nominal notation, a widening
+  coercion that is literally `\mathsf{id}_A` can only have one of the forms
+
+  \[
+    \mathsf{id}_{\alpha},
+    \qquad
+    \mathsf{id}_{\iota},
+    \qquad
+    \mathsf{id}_{\star}.
+  \]
+
+  In the outer leaf, the source quotient narrowing is already an inert value
+  ending at that atomic type, which is impossible.  In the inner leaf, the
+  target quotient narrowing is inert and ends at the corresponding name, base
+  type, or `\star`, which is likewise impossible.  No quotient elimination and
+  no new term-imprecision rule are required.
+
+- Closed the inner `\mathsf{inst}` leaf by coercion-grammar inversion.  The
+  inner coercion belongs to the quotient narrowing half, while
+  `\mathsf{inst}` is a widening form.  The only superficially possible
+  narrowing case is a crossed coercion, whose grammar cannot produce an
+  `\mathsf{inst}` node.
+
+- Refined the reachable outer `\mathsf{inst}` skeleton into its two existing
+  widening-pair cases.  Both clauses now expose directly the premises
+
+  \[
+    \mathsf{occurs}(\alpha,A),
+    \qquad
+    \mathsf{inst}(\mu);\Delta,\alpha{:}\star
+      \vdash s : A \mathrel{\sqsubseteq} \uparrow B,
+  \]
+
+  obtained from the original `cast-inst` typing and widening derivation.  The
+  already-checked trace allocates the fresh `\star` name.  The remaining
+  obligation is therefore exactly to relate the allocated bullet body and its
+  residual cast `s` to the inert target quotient spine.
+
+- Generalized `AllImprecisionView` from universal targets to arbitrary target
+  types, without changing the underlying imprecision relation.  The new
+  `\sqsubseteq^{p}` source-universal view states that
+
+  \[
+    \Phi;\Delta_L \vdash \forall\alpha.A
+      \sqsubseteq^{p} B
+  \]
+
+  selects a universal source representative `\forall\beta.C`, an ordinary
+  imprecision derivation from that representative, and a final permutation
+  equivalence to `B`.  The ordinary derivation has exactly the existing two
+  forms: paired `\forall` imprecision or source-only `\nu` imprecision.  Both
+  outer instantiation holes now bind this view, so the remaining allocation
+  proof can branch on this semantic invariant rather than on term syntax.
+
+- Four holes remain in `NuImprecisionQuotientValue`: two outer
+  instantiation clauses (identity mode and general cast mode), and the two
+  ordinary catch-up results for normalized inner sequences.  They represent
+  two semantic boundaries, not four unrelated cases.
+
+### Next boundary
+
+Thread the ordinary catch-up induction hypothesis through the two normalized
+inner-sequence clauses.  Then use the resulting recursion interface at the
+outer instantiation boundary, where the source-only `\star` allocation must be
+combined with the existing permutation/crossed-allocation infrastructure.
+
+### 2026-07-20: quotient value scratch is hole-free
+
+- Closed both normalized inner-sequence leaves by contradiction.  A strict
+  crossed narrowing after a source untag has an arrow target, whereas the
+  underlying source term has type `\star`.  Quotiented imprecision therefore
+  forces the target narrowing to start at `\star`; no inert narrowing from
+  `\star` can end at that arrow (or at `\star` in the alternative quotient
+  shape).  Thus these leaves do not require a recursive catch-up hypothesis.
+
+- Removed the temporary split on the two quotient-narrowing constructors.  It
+  was useful diagnostically, but it duplicated the same allocation boundary
+  and did not expose any additional invariant connecting the quotient
+  representatives to the cast spines.
+
+- Replaced the two outer-instantiation holes with an explicit residual
+  alternative.  In nominal notation, when the source widening is
+
+  \[
+    u = \mathsf{inst}\ B\ s,
+  \]
+
+  the scratch theorem now returns the checked trace
+
+  \[
+    V\langle d\rangle\langle u\rangle
+      \longrightarrow
+    \nu\,\star\,(V\langle d\rangle)\,s
+      \longrightarrow
+    (\uparrow V\langle d\rangle)\,\bullet\langle s\rangle.
+  \]
+
+  All other branches still return `LeftCatchupIndexedResult` directly.  The
+  result is stated inline as a sum, rather than introducing an alias for part
+  of the theorem statement.
+
+- Propagated that residual into the ordinary-down and gen-down clauses of the
+  recursive catch-up dispatcher.  The quotient value scratch contains no
+  holes.  The dispatcher now has two new, explicit holes whose contexts carry
+  the transported quotient narrowing/widening evidence, the source allocation
+  trace, and the already-obtained catch-up induction hypothesis for the
+  underlying terms.
+
+- This refactoring avoids a circular proof.  The quotient endpoint witness
+  alone does not derive the ordinary post-allocation body relation required by
+  `left-β-inst-νcast-allocation`; the representative equivalences are not tied
+  to the narrowing/widening ASTs.  The next proof must use the dispatcher
+  induction hypothesis together with the existing one-sided/crossed allocation
+  and mode-permutation lemmas, or strengthen the quotient-spine invariant.  It
+  must not assume an ordinary body relation inside the value helper.
+
+### Next boundary
+
+Complete the two explicit quotient-instantiation residual clauses in
+`NuImprecisionCatchupScratch`.  First invert the transported narrowing and
+widening spines into the one-sided and adjacent-swap allocation shapes.  Then
+feed the already-bound underlying catch-up result into the corresponding
+allocation/permutation helper and prepend the checked `keep, bind \star`
+trace.

--- a/GTSF/proof/NuImprecisionQuotientValue.agda
+++ b/GTSF/proof/NuImprecisionQuotientValue.agda
@@ -1,0 +1,1420 @@
+{-# OPTIONS --allow-unsolved-metas --allow-incomplete-matches #-}
+
+module proof.NuImprecisionQuotientValue where
+
+-- File Charter:
+--   * Isolates the active value-shaped quotient cast-spine obligation.
+--   * Closes the body-blame and inert/inert source cases.
+--   * Returns outer `inst` allocation traces to the recursive dispatcher.
+--   * Depends only on the stable weak-simulation core and quotient relation.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (false; true)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (zero; suc)
+open import Data.Product using (_,_; _×_; proj₁; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using (subst; sym; trans)
+open import Relation.Nullary using (no; yes)
+
+open import ImprecisionWf using
+  ( _∣_⊢_⊑_⊣_
+  ; id★
+  ; idˣ
+  ; idι
+  ; tag_
+  ; tag_⇛_
+  ; tagˣ
+  )
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Coercions using
+  ( Inert
+  ; gen
+  ; inst
+  ; seal
+  ; unseal
+  ; _︔_
+  ; _!
+  ; _？
+  ; _↦_
+  ; `∀
+  ; ⇑ᶜ
+  ; _∣_∣_⊢_∶_=⇒_
+  )
+import Coercions as C
+import NarrowWiden as NW
+open NW using (_∣_∣_⊢_∶_⊑_)
+open NW using (_∣_∣_⊢_∶_⊒_)
+open import NuReduction using
+  ( β-id
+  ; β-inst
+  ; β-seq
+  ; bind
+  ; blame-⟨⟩
+  ; keep
+  ; pure-step
+  ; seal-unseal
+  ; tag-untag-bad
+  ; tag-untag-ok
+  ; ξ-⟨⟩
+  ; ν-step
+  ; _—→_
+  ; _—→[_]_
+  ; _—↠[_]_
+  ; ↠-refl
+  ; ↠-step
+  )
+open import NuTerms using
+  ( No•
+  ; Value
+  ; blame
+  ; no•-⟨⟩
+  ; ok-no
+  ; _•
+  ; _⟨_⟩
+  )
+import NuTerms as NT
+open import NuTermImprecision using
+  (StoreImp; rightStoreⁱ; seal★-tag-or-id)
+open import QuotientedTermImprecision
+open import TermTyping using (forget; _∣_∣_⊢_⦂_)
+open import Types using (Ground; ★)
+import Types as T
+open import proof.CoercionProperties using (inert-dec)
+open import proof.CastImprecision using
+  ( strictCrossNarrowing⇒crossNarrowing
+  ; strictCrossWidening⇒crossWidening
+  )
+open import proof.ForallPermutationProperties using
+  (⊑ᵖ-arrow-left-shape; ⊑ᵖ-ground-left
+  ; ⊑ᵖ-star-left-eq)
+open import proof.NuImprecisionCatchupComposition using
+  (left-catchup-indexed-prepend-keepᵀ)
+open import proof.NuImprecisionSimulationCore
+open import proof.NuPreservation using (value-no-step)
+open import proof.NuProgress using
+  (Progress; crash; done; progress-cast; step)
+open import TermTyping using (cast-gen; cast-tag-or-id)
+
+false≢true : false ≡ true → ⊥
+false≢true ()
+
+id-only-no-seal : ∀ α → C.sealModeAllowed (C.id-onlyᵈ α) ≡ false
+id-only-no-seal α = refl
+
+gen-tag-or-id-no-seal :
+  ∀ α →
+  C.sealModeAllowed (C.genᵈ C.tag-or-idᵈ α) ≡ false
+gen-tag-or-id-no-seal zero = refl
+gen-tag-or-id-no-seal (suc α) = refl
+
+ground-imprecision-target-all-impossible :
+  ∀ {Φ Δᴸ Δᴿ G B} →
+  Ground G →
+  Φ ∣ Δᴸ ⊢ G ⊑ T.`∀ B ⊣ Δᴿ →
+  ⊥
+ground-imprecision-target-all-impossible (T.＇ α) ()
+ground-imprecision-target-all-impossible (T.‵ ι) ()
+ground-imprecision-target-all-impossible T.★⇒★ ()
+
+ground-star-inert-narrowing-no-seal :
+  ∀ {Φ Δᴸ Δᴿ μ Σ G d D} →
+  (∀ α → C.sealModeAllowed (μ α) ≡ false) →
+  Ground G →
+  Φ ∣ Δᴸ ⊢ G ⊑ D ⊣ Δᴿ →
+  μ ∣ Δᴿ ∣ Σ ⊢ d ∶ ★ ⊒ D →
+  Inert d →
+  ⊥
+ground-star-inert-narrowing-no-seal
+    no-seal gG q (_ , NW.cross ()) (G !)
+ground-star-inert-narrowing-no-seal no-seal gG q
+    (C.cast-seal h★ α∈Σ ok , narrowing) (seal ★ α) =
+  false≢true (trans (sym (no-seal α)) ok)
+ground-star-inert-narrowing-no-seal
+    no-seal gG q (() , narrowing) (c ↦ d)
+ground-star-inert-narrowing-no-seal
+    no-seal gG q (() , narrowing) (`∀ c)
+ground-star-inert-narrowing-no-seal no-seal gG q
+    (C.cast-gen h★ occ c⊢ , NW.gen narrowing) (gen ★ c) =
+  ground-imprecision-target-all-impossible gG q
+
+inert-narrowing-target-var-no-seal :
+  ∀ {μ Δ Σ d C α} →
+  (∀ β → C.sealModeAllowed (μ β) ≡ false) →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ C ⊒ T.＇ α →
+  Inert d →
+  ⊥
+inert-narrowing-target-var-no-seal
+    no-seal (_ , NW.cross ()) (G !)
+inert-narrowing-target-var-no-seal no-seal
+    (C.cast-seal hA α∈Σ ok , narrowing) (seal A α) =
+  false≢true (trans (sym (no-seal α)) ok)
+inert-narrowing-target-var-no-seal
+    no-seal (() , narrowing) (c ↦ d)
+inert-narrowing-target-var-no-seal
+    no-seal (() , narrowing) (`∀ c)
+inert-narrowing-target-var-no-seal
+    no-seal (() , narrowing) (gen A c)
+
+inert-narrowing-target-base :
+  ∀ {μ Δ Σ d C ι} →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ C ⊒ T.‵ ι →
+  Inert d →
+  ⊥
+inert-narrowing-target-base (_ , NW.cross ()) (G !)
+inert-narrowing-target-base (() , narrowing) (seal A α)
+inert-narrowing-target-base (() , narrowing) (c ↦ d)
+inert-narrowing-target-base (() , narrowing) (`∀ c)
+inert-narrowing-target-base (() , narrowing) (gen A c)
+
+inert-narrowing-target-star :
+  ∀ {μ Δ Σ d C} →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ C ⊒ ★ →
+  Inert d →
+  ⊥
+inert-narrowing-target-star (_ , NW.cross ()) (G !)
+inert-narrowing-target-star (() , narrowing) (seal A α)
+inert-narrowing-target-star (() , narrowing) (c ↦ d)
+inert-narrowing-target-star (() , narrowing) (`∀ c)
+inert-narrowing-target-star (() , narrowing) (gen A c)
+
+inert-narrowing-star-to-arrow :
+  ∀ {μ Δ Σ d A B} →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ ★ ⊒ A T.⇒ B →
+  Inert d →
+  ⊥
+inert-narrowing-star-to-arrow (_ , NW.cross ()) (G !)
+inert-narrowing-star-to-arrow (() , narrowing) (seal A α)
+inert-narrowing-star-to-arrow (() , narrowing) (c ↦ d)
+inert-narrowing-star-to-arrow (() , narrowing) (`∀ c)
+inert-narrowing-star-to-arrow (() , narrowing) (gen A c)
+
+cast-value-inert :
+  ∀ {V c} →
+  Value (V ⟨ c ⟩) →
+  Inert c
+cast-value-inert (vV ⟨ inert ⟩) = inert
+
+strict-cross-widening-inert :
+  ∀ {c} →
+  NW.StrictCrossWidening c →
+  Inert c
+strict-cross-widening-inert (NW.cw-funˡ n w) = _ ↦ _
+strict-cross-widening-inert (NW.cw-funʳ n w) = _ ↦ _
+strict-cross-widening-inert (NW.cw-all w) = `∀ _
+
+strict-cross-widening-ground-star :
+  ∀ {Φ Δᴸ Δᴿ μ Σ s D G} →
+  Ground G →
+  NW.StrictCrossWidening s →
+  μ ∣ Δᴸ ∣ Σ ⊢ s ∶ D ⊑ G →
+  Φ ∣ Δᴸ ⊢ G ⊑ ★ ⊣ Δᴿ
+strict-cross-widening-ground-star
+    (T.＇ α) (NW.cw-funˡ n w) ()
+strict-cross-widening-ground-star
+    (T.＇ α) (NW.cw-funʳ n w) ()
+strict-cross-widening-ground-star
+    (T.＇ α) (NW.cw-all w) ()
+strict-cross-widening-ground-star
+    (T.‵ ι) (NW.cw-funˡ n w) ()
+strict-cross-widening-ground-star
+    (T.‵ ι) (NW.cw-funʳ n w) ()
+strict-cross-widening-ground-star
+    (T.‵ ι) (NW.cw-all w) ()
+strict-cross-widening-ground-star
+    T.★⇒★ (NW.cw-funˡ n w) (C.cast-fun s⊢ t⊢ , widening) =
+  tag id★ ⇛ id★
+strict-cross-widening-ground-star
+    T.★⇒★ (NW.cw-funʳ n w) (C.cast-fun s⊢ t⊢ , widening) =
+  tag id★ ⇛ id★
+strict-cross-widening-ground-star
+    T.★⇒★ (NW.cw-all w) ()
+
+strict-cross-narrowing-inert :
+  ∀ {c} →
+  NW.StrictCrossNarrowing c →
+  Inert c
+strict-cross-narrowing-inert (NW.cn-funˡ w n) = _ ↦ _
+strict-cross-narrowing-inert (NW.cn-funʳ w n) = _ ↦ _
+strict-cross-narrowing-inert (NW.cn-all n) = `∀ _
+
+strict-cross-narrowing-ground-star :
+  ∀ {Φ Δᴸ Δᴿ μ Σ g G D} →
+  Ground G →
+  NW.StrictCrossNarrowing g →
+  μ ∣ Δᴸ ∣ Σ ⊢ g ∶ G ⊒ D →
+  Φ ∣ Δᴸ ⊢ G ⊑ ★ ⊣ Δᴿ
+strict-cross-narrowing-ground-star
+    (T.＇ α) (NW.cn-funˡ w n) ()
+strict-cross-narrowing-ground-star
+    (T.＇ α) (NW.cn-funʳ w n) ()
+strict-cross-narrowing-ground-star
+    (T.＇ α) (NW.cn-all n) ()
+strict-cross-narrowing-ground-star
+    (T.‵ ι) (NW.cn-funˡ w n) ()
+strict-cross-narrowing-ground-star
+    (T.‵ ι) (NW.cn-funʳ w n) ()
+strict-cross-narrowing-ground-star
+    (T.‵ ι) (NW.cn-all n) ()
+strict-cross-narrowing-ground-star
+    T.★⇒★ (NW.cn-funˡ w n) (C.cast-fun s⊢ t⊢ , narrowing) =
+  tag id★ ⇛ id★
+strict-cross-narrowing-ground-star
+    T.★⇒★ (NW.cn-funʳ w n) (C.cast-fun s⊢ t⊢ , narrowing) =
+  tag id★ ⇛ id★
+strict-cross-narrowing-ground-star
+    T.★⇒★ (NW.cn-all n) ()
+
+strict-cross-narrowing-ground-target-arrow :
+  ∀ {Δ Σ μ g G D} →
+  Ground G →
+  NW.StrictCrossNarrowing g →
+  μ ∣ Δ ∣ Σ ⊢ g ∶ G ⊒ D →
+  ∃[ A ] ∃[ B ] D ≡ A T.⇒ B
+strict-cross-narrowing-ground-target-arrow
+    (T.＇ α) (NW.cn-funˡ w n) ()
+strict-cross-narrowing-ground-target-arrow
+    (T.＇ α) (NW.cn-funʳ w n) ()
+strict-cross-narrowing-ground-target-arrow
+    (T.＇ α) (NW.cn-all n) ()
+strict-cross-narrowing-ground-target-arrow
+    (T.‵ ι) (NW.cn-funˡ w n) ()
+strict-cross-narrowing-ground-target-arrow
+    (T.‵ ι) (NW.cn-funʳ w n) ()
+strict-cross-narrowing-ground-target-arrow
+    (T.‵ ι) (NW.cn-all n) ()
+strict-cross-narrowing-ground-target-arrow
+    T.★⇒★ (NW.cn-funˡ w n) (C.cast-fun s⊢ t⊢ , narrowing) =
+  _ , _ , refl
+strict-cross-narrowing-ground-target-arrow
+    T.★⇒★ (NW.cn-funʳ w n) (C.cast-fun s⊢ t⊢ , narrowing) =
+  _ , _ , refl
+strict-cross-narrowing-ground-target-arrow
+    T.★⇒★ (NW.cn-all n) ()
+
+star-imprecision-target :
+  ∀ {Φ Δᴸ Δᴿ B} →
+  Φ ∣ Δᴸ ⊢ ★ ⊑ B ⊣ Δᴿ →
+  B ≡ ★
+star-imprecision-target id★ = refl
+
+star-term-imprecision-target :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ B}
+  {p : Φ ∣ Δᴸ ⊢ ★ ⊑ B ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ ★ ⊑ B ∶ p →
+  B ≡ ★
+star-term-imprecision-target {p = p} M⊑M′ =
+  star-imprecision-target p
+
+cast-value-step-change :
+  ∀ {χ V c N} →
+  Value V →
+  (V ⟨ c ⟩) —→[ χ ] N →
+  χ ≡ keep
+cast-value-step-change vV (pure-step red) = refl
+cast-value-step-change vV (ξ-⟨⟩ V→N) =
+  ⊥-elim (value-no-step vV V→N)
+
+active-value-cast-step :
+  ∀ {μ Δ Σ V c A B} →
+  Value V →
+  No• V →
+  NT._∣_∣_⊢_⦂_ Δ Σ [] V A →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A =⇒ B →
+  (Inert c → ⊥) →
+  ∃[ N ] ((V ⟨ c ⟩) —→[ keep ] N)
+active-value-cast-step {V = V} {c = c} vV noV V⊢ c⊢ not-inert
+    with progress-cast (ok-no noV) c⊢ V⊢
+active-value-cast-step {V = V} {c = c} vV noV V⊢ c⊢ not-inert
+    | done (vW ⟨ inert ⟩) =
+  ⊥-elim (not-inert inert)
+active-value-cast-step {V = V} {c = c} vV noV V⊢ c⊢ not-inert
+    | step {χ = χ} {N = N} cast→ =
+  N , subst
+    (λ χ′ → (V ⟨ c ⟩) —→[ χ′ ] N)
+    (cast-value-step-change vV cast→) cast→
+active-value-cast-step {V = V} {c = c} vV noV V⊢ c⊢ not-inert
+    | crash ()
+
+active-double-cast-step :
+  ∀ {μ ν Δ Σ V d u C D A} →
+  Value V →
+  No• V →
+  NT._∣_∣_⊢_⦂_ Δ Σ [] V C →
+  μ ∣ Δ ∣ Σ ⊢ d ∶ C =⇒ D →
+  ν ∣ Δ ∣ Σ ⊢ u ∶ D =⇒ A →
+  (Inert d × Inert u → ⊥) →
+  ∃[ N ] (((V ⟨ d ⟩) ⟨ u ⟩) —→[ keep ] N)
+active-double-cast-step vV noV V⊢ d⊢ u⊢ source-active
+    with inert-dec _
+active-double-cast-step vV noV V⊢ d⊢ u⊢ source-active
+    | no not-inert-d
+    with active-value-cast-step vV noV V⊢ d⊢ not-inert-d
+active-double-cast-step vV noV V⊢ d⊢ u⊢ source-active
+    | no not-inert-d | N , source→ =
+  N ⟨ _ ⟩ , ξ-⟨⟩ source→
+active-double-cast-step vV noV V⊢ d⊢ u⊢ source-active
+    | yes inert-d
+    with active-value-cast-step
+      (vV ⟨ inert-d ⟩) (no•-⟨⟩ noV)
+      (NT.⊢⟨⟩ d⊢ V⊢) u⊢
+      (λ inert-u → source-active (inert-d , inert-u))
+active-double-cast-step vV noV V⊢ d⊢ u⊢ source-active
+    | yes inert-d | N , source→ =
+  N , source→
+
+outer-inst-allocation-trace :
+  ∀ {V d B s} →
+  No• V →
+  Value (V ⟨ d ⟩) →
+  ((V ⟨ d ⟩) ⟨ inst B s ⟩)
+    —↠[ keep ∷ bind ★ ∷ [] ]
+      ((NT.⇑ᵗᵐ (V ⟨ d ⟩)) •) ⟨ s ⟩
+outer-inst-allocation-trace noV vW =
+  ↠-step (pure-step (β-inst vW))
+    (↠-step (ν-step vW (no•-⟨⟩ noV)) ↠-refl)
+
+inner-inst-allocation-trace :
+  ∀ {V B s u} →
+  Value V →
+  No• V →
+  ((V ⟨ inst B s ⟩) ⟨ u ⟩)
+    —↠[ keep ∷ bind ★ ∷ [] ]
+      (((NT.⇑ᵗᵐ V) •) ⟨ s ⟩) ⟨ ⇑ᶜ u ⟩
+inner-inst-allocation-trace vV noV =
+  ↠-step (ξ-⟨⟩ (pure-step (β-inst vV)))
+    (↠-step (ξ-⟨⟩ (ν-step vV noV)) ↠-refl)
+
+left-catchup-indexed-one-keep-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —→[ keep ] N →
+  Value N →
+  No• N →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupIndexedResult {N = M} {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-one-keep-valueᵀ M→N vN noN N⊑V′ =
+  left-indexed-catchup
+    (weak-indexed-result result N⊑V′)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₁ (vN , noN)))
+    (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
+    (weak-step-type-coherence
+      (λ pC pD → refl) (λ q → refl))
+  where
+  result = record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ q → q
+    ; transportAllBody = λ q → q
+    ; transportRightBody = λ q → q
+    ; resultType = _
+    ; sourceCatchup = ↠-step M→N ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = N⊑V′
+    }
+
+left-catchup-indexed-double-cast-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ V′ A B p d u}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ V′ ⦂ B →
+  LeftCatchupIndexedResult
+    {N = (blame ⟨ d ⟩) ⟨ u ⟩}
+    {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-double-cast-blameᵀ V′⊢ =
+  left-indexed-catchup
+    (weak-indexed-result result blame-relation)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₂ refl))
+    (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
+    (weak-step-type-coherence
+      (λ pC pD → refl) (λ q → refl))
+  where
+  blame-relation = blame⊑ᵀ V′⊢
+
+  result = record
+    { sourceChanges = keep ∷ keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = blame
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ q → q
+    ; transportAllBody = λ q → q
+    ; transportRightBody = λ q → q
+    ; resultType = _
+    ; sourceCatchup =
+        ↠-step (ξ-⟨⟩ (pure-step blame-⟨⟩))
+          (↠-step (pure-step blame-⟨⟩) ↠-refl)
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = blame-relation
+    }
+
+left-catchup-indexed-two-keep-to-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  M —↠[ keep ∷ keep ∷ [] ] blame →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ V′ ⦂ B →
+  LeftCatchupIndexedResult {N = M} {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-two-keep-to-blameᵀ M↠blame V′⊢ =
+  left-indexed-catchup
+    (weak-indexed-result result blame-relation)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₂ refl))
+    (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
+    (weak-step-type-coherence
+      (λ pC pD → refl) (λ q → refl))
+  where
+  blame-relation = blame⊑ᵀ V′⊢
+
+  result = record
+    { sourceChanges = keep ∷ keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = blame
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ q → q
+    ; transportAllBody = λ q → q
+    ; transportRightBody = λ q → q
+    ; resultType = _
+    ; sourceCatchup = M↠blame
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = blame-relation
+    }
+
+left-catchup-indexed-final-quotient-inertᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ A A′ pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  No• V →
+  Inert d →
+  Inert u →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ (V ⟨ d ⟩) ⟨ u ⟩
+      ⊑ (V′ ⟨ d′ ⟩) ⟨ u′ ⟩
+    ⦂ A ⊑ A′ ∶ pA) →
+  LeftCatchupIndexedResult
+    {N = (V ⟨ d ⟩) ⟨ u ⟩}
+    {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+    {ρ = ρ} pA
+left-catchup-indexed-final-quotient-inertᵀ
+    vV noV inert-d inert-u relation =
+  left-catchup-indexed-relatedᵀ
+    (inj₁
+      (vV ⟨ inert-d ⟩ ⟨ inert-u ⟩ ,
+       no•-⟨⟩ (no•-⟨⟩ noV)))
+    relation
+
+source-quotient-down-tag-impossible :
+  ∀ {Φ Δᴸ Δᴿ W W′ G d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (W ⟨ G ! ⟩) ⊑ (W′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-quotient-down-tag-impossible
+    (down⊑downᵀ (_ , NW.cross ()) d′⊒ W⊑W′ qD)
+source-quotient-down-tag-impossible
+    (gen-down⊑gen-downᵀ (_ , NW.cross ()) d′⊒ W⊑W′ qD)
+
+source-quotient-down-unseal-impossible :
+  ∀ {Φ Δᴸ Δᴿ W W′ α X d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (W ⟨ unseal α X ⟩) ⊑ (W′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-quotient-down-unseal-impossible
+    (down⊑downᵀ (_ , NW.cross ()) d′⊒ W⊑W′ qD)
+source-quotient-down-unseal-impossible
+    (gen-down⊑gen-downᵀ (_ , NW.cross ()) d′⊒ W⊑W′ qD)
+
+source-quotient-down-seal-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ X α d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ seal X α ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-quotient-down-seal-impossible
+    (down⊑downᵀ
+      (C.cast-seal hX α∈Σ ok , NW.sealⁿ X α)
+      d′⊒ V⊑V′ qD) =
+  false≢true (trans (sym (id-only-no-seal α)) ok)
+source-quotient-down-seal-impossible
+    (gen-down⊑gen-downᵀ
+      (C.cast-seal hX α∈Σ ok , NW.sealⁿ X α)
+      d′⊒ V⊑V′ qD) =
+  false≢true (trans (sym (gen-tag-or-id-no-seal α)) ok)
+
+source-quotient-down-seal-tail-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ n X α d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ (n ︔ seal X α) ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-quotient-down-seal-tail-impossible
+    (down⊑downᵀ
+      (C.cast-seq n⊢ (C.cast-seal hX α∈Σ ok) ,
+        nⁿ NW.︔seal α)
+      d′⋒ V⊑V′ qD) =
+  false≢true (trans (sym (id-only-no-seal α)) ok)
+source-quotient-down-seal-tail-impossible
+    (gen-down⊑gen-downᵀ
+      (C.cast-seq n⊢ (C.cast-seal hX α∈Σ ok) ,
+        nⁿ NW.︔seal α)
+      d′⋒ V⊑V′ qD) =
+  false≢true (trans (sym (gen-tag-or-id-no-seal α)) ok)
+
+source-quotient-down-untag-index-ground :
+  ∀ {Φ Δᴸ Δᴿ W V′ G d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ ((W ⟨ G ! ⟩) ⟨ G ？ ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  Ground D
+source-quotient-down-untag-index-ground
+    (down⊑downᵀ
+      (C.cast-untag hG gG ok , NW.untag gG′)
+      d′⊒ V⊑V′ qD) =
+  gG
+source-quotient-down-untag-index-ground
+    (gen-down⊑gen-downᵀ
+      (C.cast-untag hG gG ok , NW.untag gG′)
+      d′⊒ V⊑V′ qD) =
+  gG
+
+source-inert-quotient-down-var-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ d d′ α D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value (V ⟨ d ⟩) →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ d ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ T.＇ α ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-inert-quotient-down-var-impossible vW
+    (down⊑downᵀ d⊒ d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-var-no-seal
+    id-only-no-seal d⊒ (cast-value-inert vW)
+source-inert-quotient-down-var-impossible vW
+    (gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-var-no-seal
+    gen-tag-or-id-no-seal d⊒ (cast-value-inert vW)
+
+source-inert-quotient-down-base-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ d d′ ι D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value (V ⟨ d ⟩) →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ d ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ T.‵ ι ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-inert-quotient-down-base-impossible vW
+    (down⊑downᵀ d⊒ d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-base d⊒ (cast-value-inert vW)
+source-inert-quotient-down-base-impossible vW
+    (gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-base d⊒ (cast-value-inert vW)
+
+source-inert-quotient-down-star-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ d d′ D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value (V ⟨ d ⟩) →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ d ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ ★ ⊑ᵖ D′ ∶ qD) →
+  ⊥
+source-inert-quotient-down-star-impossible vW
+    (down⊑downᵀ d⊒ d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-star d⊒ (cast-value-inert vW)
+source-inert-quotient-down-star-impossible vW
+    (gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-star d⊒ (cast-value-inert vW)
+
+source-inert-quotient-down-before-id-widening-impossible :
+  ∀ {Φ Δᴸ Δᴿ μ V V′ d d′ X A D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value (V ⟨ d ⟩) →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ d ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  μ ∣ Δᴸ ∣ NuTermImprecision.leftStoreⁱ ρ
+    ⊢ C.id X ∶ D ⊑ A →
+  ⊥
+source-inert-quotient-down-before-id-widening-impossible
+    vW down (C.cast-id hA ok , NW.cross (NW.id-＇ α)) =
+  source-inert-quotient-down-var-impossible vW down
+source-inert-quotient-down-before-id-widening-impossible
+    vW down (C.cast-id hA ok , NW.cross (NW.id-‵ ι)) =
+  source-inert-quotient-down-base-impossible vW down
+source-inert-quotient-down-before-id-widening-impossible
+    vW down (C.cast-id hA ok , NW.id★) =
+  source-inert-quotient-down-star-impossible vW down
+
+target-inert-after-var-imprecision-no-seal :
+  ∀ {Φ Δᴸ Δᴿ μ Σ d C α D′} →
+  (∀ β → C.sealModeAllowed (μ β) ≡ false) →
+  Φ ∣ Δᴸ ⊢ T.＇ α ⊑ D′ ⊣ Δᴿ →
+  μ ∣ Δᴿ ∣ Σ ⊢ d ∶ C ⊒ D′ →
+  Inert d →
+  ⊥
+target-inert-after-var-imprecision-no-seal no-seal
+    (idˣ X⊑Y X<Δᴸ Y<Δᴿ) d⊒ inert-d =
+  inert-narrowing-target-var-no-seal no-seal d⊒ inert-d
+target-inert-after-var-imprecision-no-seal no-seal
+    (tagˣ X⊑★ X<Δᴸ) d⊒ inert-d =
+  inert-narrowing-target-star d⊒ inert-d
+
+target-inert-after-base-imprecision :
+  ∀ {Φ Δᴸ Δᴿ μ Σ d C ι D′} →
+  Φ ∣ Δᴸ ⊢ T.‵ ι ⊑ D′ ⊣ Δᴿ →
+  μ ∣ Δᴿ ∣ Σ ⊢ d ∶ C ⊒ D′ →
+  Inert d →
+  ⊥
+target-inert-after-base-imprecision idι d⊒ inert-d =
+  inert-narrowing-target-base d⊒ inert-d
+target-inert-after-base-imprecision (tag ι) d⊒ inert-d =
+  inert-narrowing-target-star d⊒ inert-d
+
+target-inert-quotient-down-after-source-id-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ X d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Inert d′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ C.id X ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+target-inert-quotient-down-after-source-id-impossible inert-d′
+    (down⊑downᵀ
+      (C.cast-id hX ok , NW.cross (NW.id-＇ α))
+      d′⊒ V⊑V′ qD) =
+  target-inert-after-var-imprecision-no-seal id-only-no-seal
+    (⊑ᵖ-ground-left (T.＇ α) qD) d′⊒ inert-d′
+target-inert-quotient-down-after-source-id-impossible inert-d′
+    (down⊑downᵀ
+      (C.cast-id hX ok , NW.cross (NW.id-‵ ι))
+      d′⊒ V⊑V′ qD) =
+  target-inert-after-base-imprecision
+    (⊑ᵖ-ground-left (T.‵ ι) qD) d′⊒ inert-d′
+target-inert-quotient-down-after-source-id-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (down⊑downᵀ
+      (C.cast-id hX ok , NW.id★) d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-star star-d′⊒ inert-d′
+  where
+  star-d′⊒ =
+    subst
+      (λ Y → C.id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ _ ⊒ Y)
+      (⊑ᵖ-star-left-eq qD) d′⊒
+target-inert-quotient-down-after-source-id-impossible inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-id hX ok , NW.cross (NW.id-＇ α))
+      d′⊒ V⊑V′ qD) =
+  target-inert-after-var-imprecision-no-seal gen-tag-or-id-no-seal
+    (⊑ᵖ-ground-left (T.＇ α) qD) d′⊒ inert-d′
+target-inert-quotient-down-after-source-id-impossible inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-id hX ok , NW.cross (NW.id-‵ ι))
+      d′⊒ V⊑V′ qD) =
+  target-inert-after-base-imprecision
+    (⊑ᵖ-ground-left (T.‵ ι) qD) d′⊒ inert-d′
+target-inert-quotient-down-after-source-id-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-id hX ok , NW.id★) d′⊒ V⊑V′ qD) =
+  inert-narrowing-target-star star-d′⊒ inert-d′
+  where
+  star-d′⊒ =
+    subst
+      (λ Y → C.genᵈ C.tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ _ ⊒ Y)
+      (⊑ᵖ-star-left-eq qD) d′⊒
+
+target-inert-after-source-untag-impossible :
+  ∀ {Φ Δᴸ Δᴿ W V′ G d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Inert d′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ ((W ⟨ G ! ⟩) ⟨ G ？ ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+target-inert-after-source-untag-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (down⊑downᵀ
+      (C.cast-untag hG gG ok , NW.untag gG′)
+      d′⊒ W⊑V′ qD) =
+  ground-star-inert-narrowing-no-seal
+    id-only-no-seal gG ordinary-qD star-d′⊒ inert-d′
+  where
+  ordinary-qD = ⊑ᵖ-ground-left gG qD
+  star-d′⊒ =
+    subst
+      (λ C′ → C.id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ C′ ⊒ _)
+      (star-term-imprecision-target W⊑V′) d′⊒
+target-inert-after-source-untag-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-untag hG gG ok , NW.untag gG′)
+      d′⊒ W⊑V′ qD) =
+  ground-star-inert-narrowing-no-seal
+    gen-tag-or-id-no-seal gG ordinary-qD star-d′⊒ inert-d′
+  where
+  ordinary-qD = ⊑ᵖ-ground-left gG qD
+  star-d′⊒ =
+    subst
+      (λ C′ → C.genᵈ C.tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ C′ ⊒ _)
+      (star-term-imprecision-target W⊑V′) d′⊒
+
+target-inert-after-source-untag-sequence-impossible :
+  ∀ {Φ Δᴸ Δᴿ V V′ G g d′ D D′ qD}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Inert d′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ (G ？) ︔ g ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  ⊥
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (down⊑downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    with strict-cross-narrowing-ground-target-arrow
+      gG gⁿ (g⊢ , NW.cross
+        (strictCrossNarrowing⇒crossNarrowing gⁿ))
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (down⊑downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    | A , B , refl with ⊑ᵖ-arrow-left-shape qD
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (down⊑downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    | A , B , refl | inj₁ (A′ , B′ , refl) =
+  inert-narrowing-star-to-arrow star-d′⊒ inert-d′
+  where
+  star-d′⊒ =
+    subst
+      (λ X → C.id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ X ⊒ _)
+      (star-term-imprecision-target V⊑V′) d′⊒
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (down⊑downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    | A , B , refl | inj₂ refl =
+  inert-narrowing-target-star star-d′⊒ inert-d′
+  where
+  star-d′⊒ =
+    subst
+      (λ X → C.id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ X ⊒ ★)
+      (star-term-imprecision-target V⊑V′) d′⊒
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    with strict-cross-narrowing-ground-target-arrow
+      gG gⁿ (g⊢ , NW.cross
+        (strictCrossNarrowing⇒crossNarrowing gⁿ))
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    | A , B , refl with ⊑ᵖ-arrow-left-shape qD
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    | A , B , refl | inj₁ (A′ , B′ , refl) =
+  inert-narrowing-star-to-arrow star-d′⊒ inert-d′
+  where
+  star-d′⊒ =
+    subst
+      (λ X → C.genᵈ C.tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ X ⊒ _)
+      (star-term-imprecision-target V⊑V′) d′⊒
+target-inert-after-source-untag-sequence-impossible
+    {Δᴿ = Δᴿ} {ρ = ρ} inert-d′
+    (gen-down⊑gen-downᵀ
+      (C.cast-seq (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    | A , B , refl | inj₂ refl =
+  inert-narrowing-target-star star-d′⊒ inert-d′
+  where
+  star-d′⊒ =
+    subst
+      (λ X → C.genᵈ C.tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+        ⊢ _ ∶ X ⊒ ★)
+      (star-term-imprecision-target V⊑V′) d′⊒
+
+inner-sequence-residualᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ G g d′ u u′ D D′ A A′ qD pA}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ ((G ？) ︔ g) ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ ((V ⟨ G ？ ⟩) ⟨ g ⟩) ⟨ u ⟩
+      ⊑ (V′ ⟨ d′ ⟩) ⟨ u′ ⟩
+    ⦂ A ⊑ A′ ∶ pA
+inner-sequence-residualᵀ
+    (down⊑downᵀ
+      (C.cast-seq
+        (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    widening pA =
+  up⊑upᵀ split-down widening pA
+  where
+  g⊒ =
+    g⊢ , NW.cross (strictCrossNarrowing⇒crossNarrowing gⁿ)
+  G⊑★ = strict-cross-narrowing-ground-star gG gⁿ g⊒
+  G⊑C′ =
+    subst (λ X → _ ∣ _ ⊢ _ ⊑ X ⊣ _)
+      (sym (star-term-imprecision-target V⊑V′)) G⊑★
+  untag⊒ =
+    NW.narrow-mode-relax C.id-only≤tag-or-idᵈ
+      (C.cast-untag hG gG⊢ ok , NW.untag gG)
+  untag-relation =
+    cast⊒⊑ᵀ cast-tag-or-id seal★-tag-or-id untag⊒
+      V⊑V′ G⊑C′
+  split-down = down⊑downᵀ g⊒ d′⊒ untag-relation qD
+inner-sequence-residualᵀ
+    (gen-down⊑gen-downᵀ
+      (C.cast-seq
+        (C.cast-untag hG gG⊢ ok) g⊢ ,
+        gG NW.？︔ gⁿ)
+      d′⊒ V⊑V′ qD)
+    widening pA =
+  up⊑upᵀ split-down widening pA
+  where
+  g⊒ =
+    g⊢ , NW.cross (strictCrossNarrowing⇒crossNarrowing gⁿ)
+  G⊑★ = strict-cross-narrowing-ground-star gG gⁿ g⊒
+  G⊑C′ =
+    subst (λ X → _ ∣ _ ⊢ _ ⊑ X ⊣ _)
+      (sym (star-term-imprecision-target V⊑V′)) G⊑★
+  untag⊒ = C.cast-untag hG gG⊢ ok , NW.untag gG
+  untag-relation =
+    cast⊒⊑ᵀ (cast-gen cast-tag-or-id)
+      seal★-gen-tag-or-id untag⊒ V⊑V′ G⊑C′
+  split-down =
+    gen-down⊑gen-downᵀ g⊒ d′⊒ untag-relation qD
+
+left-catchup-indexed-final-quotient-outer-pureᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ L D D′ A A′ qD pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  ((V ⟨ d ⟩) ⟨ u ⟩) —→ L →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  Inert d′ →
+  Inert u′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ d ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  LeftCatchupIndexedResult
+      {N = (V ⟨ d ⟩) ⟨ u ⟩}
+      {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+      {ρ = ρ} pA
+  ⊎ ∃[ B ] ∃[ s ]
+      (u ≡ inst B s) ×
+      (((V ⟨ d ⟩) ⟨ u ⟩)
+        —↠[ keep ∷ bind ★ ∷ [] ]
+          ((NT.⇑ᵗᵐ (V ⟨ d ⟩)) •) ⟨ s ⟩)
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-id vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down (quotient-id-widening u⊑ u′⊑) pA =
+  inj₁ (⊥-elim
+    (source-inert-quotient-down-before-id-widening-impossible
+      vW down u⊑))
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-id vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-cast-widening mode seal★ u⊑ mode′ seal★′ u′⊑)
+    pA =
+  inj₁ (⊥-elim
+    (source-inert-quotient-down-before-id-widening-impossible
+      vW down u⊑))
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-seq vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-id-widening
+      (C.cast-seq s⊢ (C.cast-tag hG gG⊢ ok) ,
+        sʷ NW.︔ gG !) u′⊑)
+    pA =
+  inj₁ (left-catchup-indexed-one-keep-valueᵀ
+    (pure-step (β-seq vW))
+    (vW ⟨ strict-cross-widening-inert sʷ ⟩ ⟨ _ ! ⟩)
+    (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noV))) final-relation)
+  where
+  s⊑ =
+    s⊢ , NW.cross (strictCrossWidening⇒crossWidening sʷ)
+  G⊑★ = strict-cross-widening-ground-star gG sʷ s⊑
+  G⊑A′ =
+    subst (λ X → _ ∣ _ ⊢ _ ⊑ X ⊣ _)
+      (sym (star-imprecision-target pA)) G⊑★
+  split-relation =
+    up⊑upᵀ down (quotient-id-widening s⊑ u′⊑) G⊑A′
+  tag⊑ =
+    NW.widen-mode-relax C.id-only≤tag-or-idᵈ
+      (C.cast-tag hG gG⊢ ok , NW.tag gG)
+  final-relation =
+    cast⊑⊑ᵀ cast-tag-or-id seal★-tag-or-id tag⊑
+      split-relation pA
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-seq vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-id-widening
+      (C.cast-seq (C.cast-unseal hA α∈Σ ok) t⊢ ,
+        NW.unseal︔_ α tʷ)
+      u′⊑)
+    pA =
+  inj₁ (⊥-elim
+    (source-inert-quotient-down-var-impossible vW down))
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-seq vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-cast-widening
+      mode seal★
+      (C.cast-seq s⊢ (C.cast-tag hG gG⊢ ok) ,
+        sʷ NW.︔ gG !)
+      mode′ seal★′ u′⊑)
+    pA =
+  inj₁ (left-catchup-indexed-one-keep-valueᵀ
+    (pure-step (β-seq vW))
+    (vW ⟨ strict-cross-widening-inert sʷ ⟩ ⟨ _ ! ⟩)
+    (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noV))) final-relation)
+  where
+  s⊑ =
+    s⊢ , NW.cross (strictCrossWidening⇒crossWidening sʷ)
+  G⊑★ = strict-cross-widening-ground-star gG sʷ s⊑
+  G⊑A′ =
+    subst (λ X → _ ∣ _ ⊢ _ ⊑ X ⊣ _)
+      (sym (star-imprecision-target pA)) G⊑★
+  split-relation =
+    up⊑upᵀ down
+      (quotient-cast-widening
+        mode seal★ s⊑ mode′ seal★′ u′⊑)
+      G⊑A′
+  tag⊑ = C.cast-tag hG gG⊢ ok , NW.tag gG
+  final-relation =
+    cast⊑⊑ᵀ mode seal★ tag⊑ split-relation pA
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-seq vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-cast-widening
+      mode seal★
+      (C.cast-seq (C.cast-unseal hA α∈Σ ok) t⊢ ,
+        NW.unseal︔_ α tʷ)
+      mode′ seal★′ u′⊑)
+    pA =
+  inj₁ (⊥-elim
+    (source-inert-quotient-down-var-impossible vW down))
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-inst vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-id-widening
+      (C.cast-inst hB occ s⊢ , NW.inst sʷ) u′⊑)
+    pA =
+  inj₂ (_ , _ , refl , outer-inst-allocation-trace noV vW)
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (β-inst vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down
+    (quotient-cast-widening mode seal★
+      (C.cast-inst hB occ s⊢ , NW.inst sʷ)
+      mode′ seal★′ u′⊑)
+    pA =
+  inj₂ (_ , _ , refl , outer-inst-allocation-trace noV vW)
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (tag-untag-ok vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA =
+  inj₁ (⊥-elim (source-quotient-down-tag-impossible down))
+left-catchup-indexed-final-quotient-outer-pureᵀ
+    (tag-untag-bad vW G≢H) vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA =
+  inj₁ (⊥-elim (source-quotient-down-tag-impossible down))
+left-catchup-indexed-final-quotient-outer-pureᵀ {qD = qD}
+    (seal-unseal vW) vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA =
+  inj₁ (⊥-elim (source-quotient-down-seal-impossible down))
+
+left-catchup-indexed-final-quotient-inner-stepᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ L D D′ A A′ qD pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (V ⟨ d ⟩) —→[ keep ] L →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  Inert d′ →
+  Inert u′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ (V ⟨ d ⟩) ⊑ (V′ ⟨ d′ ⟩)
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  LeftCatchupIndexedResult
+    {N = (V ⟨ d ⟩) ⟨ u ⟩}
+    {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+    {ρ = ρ} pA
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-id vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA =
+  ⊥-elim
+    (target-inert-quotient-down-after-source-id-impossible
+      inert-d′ down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-seq vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    down@(down⊑downᵀ
+      (C.cast-seq s⊢ t⊢ , gG NW.？︔ gⁿ)
+      d′⋒ V⊑V′ qD)
+    widening pA =
+  ⊥-elim
+    (target-inert-after-source-untag-sequence-impossible
+      inert-d′ down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-seq vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    down@(down⊑downᵀ
+      (C.cast-seq s⊢ (C.cast-seal hX α∈Σ ok) ,
+        nⁿ NW.︔seal α)
+      d′⋒ V⊑V′ qD)
+    widening pA =
+  ⊥-elim (source-quotient-down-seal-tail-impossible down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-seq vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    down@(gen-down⊑gen-downᵀ
+      (C.cast-seq s⊢ t⊢ , gG NW.？︔ gⁿ)
+      d′⋒ V⊑V′ qD)
+    widening pA =
+  ⊥-elim
+    (target-inert-after-source-untag-sequence-impossible
+      inert-d′ down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-seq vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    down@(gen-down⊑gen-downᵀ
+      (C.cast-seq s⊢ (C.cast-seal hX α∈Σ ok) ,
+        nⁿ NW.︔seal α)
+      d′⋒ V⊑V′ qD)
+    widening pA =
+  ⊥-elim (source-quotient-down-seal-tail-impossible down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-inst vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    (down⊑downᵀ (d⊢ , NW.cross ()) d′⊒ V⊑V′ qD)
+    widening pA
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (β-inst vW)) vV noV vV′ noV′ inert-d′ inert-u′
+    (gen-down⊑gen-downᵀ (d⊢ , NW.cross ()) d′⊒ V⊑V′ qD)
+    widening pA
+left-catchup-indexed-final-quotient-inner-stepᵀ {qD = qD}
+    (pure-step (tag-untag-ok vW)) vV noV vV′ noV′
+    inert-d′ inert-u′ down widening pA =
+  ⊥-elim (target-inert-after-source-untag-impossible inert-d′ down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (tag-untag-bad vW G≢H)) vV noV vV′ noV′
+    inert-d′ inert-u′ down widening pA =
+  left-catchup-indexed-two-keep-to-blameᵀ
+    (↠-step (ξ-⟨⟩ (pure-step (tag-untag-bad vW G≢H)))
+      (↠-step (pure-step blame-⟨⟩) ↠-refl))
+    (nu-term-imprecision-target-typing
+      (up⊑upᵀ down widening pA))
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step (seal-unseal vW)) vV noV vV′ noV′
+    inert-d′ inert-u′ down widening pA =
+  ⊥-elim (source-quotient-down-unseal-impossible down)
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (pure-step blame-⟨⟩) () noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+left-catchup-indexed-final-quotient-inner-stepᵀ
+    (ξ-⟨⟩ V→) vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA =
+  ⊥-elim (value-no-step vV V→)
+
+left-catchup-indexed-final-quotient-after-source-stepᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ L D D′ A A′ qD pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  Inert d′ →
+  Inert u′ →
+  ((V ⟨ d ⟩) ⟨ u ⟩) —→[ keep ] L →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ V ⟨ d ⟩ ⊑ V′ ⟨ d′ ⟩
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  LeftCatchupIndexedResult
+      {N = (V ⟨ d ⟩) ⟨ u ⟩}
+      {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+      {ρ = ρ} pA
+  ⊎ ∃[ B ] ∃[ s ]
+      (u ≡ inst B s) ×
+      (((V ⟨ d ⟩) ⟨ u ⟩)
+        —↠[ keep ∷ bind ★ ∷ [] ]
+          ((NT.⇑ᵗᵐ (V ⟨ d ⟩)) •) ⟨ s ⟩)
+left-catchup-indexed-final-quotient-after-source-stepᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    (pure-step source→) down widening pA =
+  left-catchup-indexed-final-quotient-outer-pureᵀ
+    source→ vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+left-catchup-indexed-final-quotient-after-source-stepᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    (ξ-⟨⟩ source→) down widening pA =
+  inj₁ (left-catchup-indexed-final-quotient-inner-stepᵀ
+    source→ vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA)
+
+left-catchup-indexed-final-quotient-activeᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ D D′ A A′ qD pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  Inert d′ →
+  Inert u′ →
+  (Inert d × Inert u → ⊥) →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ V ⟨ d ⟩ ⊑ V′ ⟨ d′ ⟩
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  LeftCatchupIndexedResult
+      {N = (V ⟨ d ⟩) ⟨ u ⟩}
+      {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+      {ρ = ρ} pA
+  ⊎ ∃[ B ] ∃[ s ]
+      (u ≡ inst B s) ×
+      (((V ⟨ d ⟩) ⟨ u ⟩)
+        —↠[ keep ∷ bind ★ ∷ [] ]
+          ((NT.⇑ᵗᵐ (V ⟨ d ⟩)) •) ⟨ s ⟩)
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(down⊑downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-id-widening u⊑ u′⊑) pA
+    with active-double-cast-step vV noV
+      (forget (nu-term-imprecision-source-typing V⊑V′))
+      (proj₁ d⊒) (proj₁ u⊑) source-active
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(down⊑downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-id-widening u⊑ u′⊑) pA
+    | L , source→ =
+  left-catchup-indexed-final-quotient-after-source-stepᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source→ down widening pA
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(down⊑downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑) pA
+    with active-double-cast-step vV noV
+      (forget (nu-term-imprecision-source-typing V⊑V′))
+      (proj₁ d⊒) (proj₁ u⊑) source-active
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(down⊑downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑) pA
+    | L , source→ =
+  left-catchup-indexed-final-quotient-after-source-stepᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source→ down widening pA
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-id-widening u⊑ u′⊑) pA
+    with active-double-cast-step vV noV
+      (forget (nu-term-imprecision-source-typing V⊑V′))
+      (proj₁ d⊒) (proj₁ u⊑) source-active
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-id-widening u⊑ u′⊑) pA
+    | L , source→ =
+  left-catchup-indexed-final-quotient-after-source-stepᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source→ down widening pA
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑) pA
+    with active-double-cast-step vV noV
+      (forget (nu-term-imprecision-source-typing V⊑V′))
+      (proj₁ d⊒) (proj₁ u⊑) source-active
+left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source-active
+    down@(gen-down⊑gen-downᵀ d⊒ d′⊒ V⊑V′ qD)
+    widening@(quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑) pA
+    | L , source→ =
+  left-catchup-indexed-final-quotient-after-source-stepᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    source→ down widening pA
+
+left-catchup-indexed-final-quotient-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ D D′ A A′ qD pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  No• V →
+  Value V′ →
+  No• V′ →
+  Inert d′ →
+  Inert u′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ V ⟨ d ⟩ ⊑ V′ ⟨ d′ ⟩
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  LeftCatchupIndexedResult
+      {N = (V ⟨ d ⟩) ⟨ u ⟩}
+      {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+      {ρ = ρ} pA
+  ⊎ ∃[ B ] ∃[ s ]
+      (u ≡ inst B s) ×
+      (((V ⟨ d ⟩) ⟨ u ⟩)
+        —↠[ keep ∷ bind ★ ∷ [] ]
+          ((NT.⇑ᵗᵐ (V ⟨ d ⟩)) •) ⟨ s ⟩)
+left-catchup-indexed-final-quotient-valueᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+    with inert-dec _ | inert-dec _
+left-catchup-indexed-final-quotient-valueᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+    | yes inert-d | yes inert-u =
+  inj₁ (left-catchup-indexed-final-quotient-inertᵀ
+    vV noV inert-d inert-u (up⊑upᵀ down widening pA))
+left-catchup-indexed-final-quotient-valueᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+    | yes inert-d | no not-inert-u =
+  left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    (λ { (source-d , source-u) → not-inert-u source-u })
+    down widening pA
+left-catchup-indexed-final-quotient-valueᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+    | no not-inert-d | yes inert-u =
+  left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    (λ { (source-d , source-u) → not-inert-d source-d })
+    down widening pA
+left-catchup-indexed-final-quotient-valueᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+    | no not-inert-d | no not-inert-u =
+  left-catchup-indexed-final-quotient-activeᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    (λ { (source-d , source-u) → not-inert-d source-d })
+    down widening pA
+
+left-catchup-indexed-final-quotientᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ D D′ A A′ qD pA d d′ u u′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V′ →
+  No• V′ →
+  Inert d′ →
+  Inert u′ →
+  (Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺᵖ V ⟨ d ⟩ ⊑ V′ ⟨ d′ ⟩
+    ⦂ D ⊑ᵖ D′ ∶ qD) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  ((Value V × No• V) ⊎ V ≡ blame) →
+  LeftCatchupIndexedResult
+      {N = (V ⟨ d ⟩) ⟨ u ⟩}
+      {V′ = (V′ ⟨ d′ ⟩) ⟨ u′ ⟩}
+      {ρ = ρ} pA
+  ⊎ ∃[ B ] ∃[ s ]
+      (u ≡ inst B s) ×
+      (((V ⟨ d ⟩) ⟨ u ⟩)
+        —↠[ keep ∷ bind ★ ∷ [] ]
+          ((NT.⇑ᵗᵐ (V ⟨ d ⟩)) •) ⟨ s ⟩)
+left-catchup-indexed-final-quotientᵀ
+    vV′ noV′ inert-d′ inert-u′
+    down widening pA (inj₁ (vV , noV)) =
+  left-catchup-indexed-final-quotient-valueᵀ
+    vV noV vV′ noV′ inert-d′ inert-u′
+    down widening pA
+left-catchup-indexed-final-quotientᵀ
+    vV′ noV′ inert-d′ inert-u′
+    down widening pA (inj₂ refl) =
+  inj₁ (left-catchup-indexed-double-cast-blameᵀ
+    (nu-term-imprecision-target-typing
+      (up⊑upᵀ down widening pA)))

--- a/GTSF/proof/NuImprecisionSimulation.agda
+++ b/GTSF/proof/NuImprecisionSimulation.agda
@@ -1,37 +1,36 @@
 module proof.NuImprecisionSimulation where
 
 -- File Charter:
---   * Establishes allocation and forall-administrative simulation lemmas for
---     quotiented Nu-term imprecision.
+--   * Develops universal catch-up and generic `β-∀•` simulation lemmas on
+--     top of the stable weak-simulation core.
 --   * Factors bare runtime-bullet instantiation from reveal and widening
 --     conversions for ordinary `ν` and `ν ★`.
 --   * Checks `β-Λ•`, `β-∀•`, `β-gen•`, and `β-inst` boundaries.
 --   * Connects crossed stores to two `bind` traces in opposite logical order.
---   * Defines the general weak one-step result over transformed stores,
---     contexts, and endpoint types.
---   * Packages both orientations of the adjacent-`∀` swap as
---     constructor-level weak-simulation cases with generated crossed stores
---     and explicit target administrative tails.
 --   * Packages both generic-cast constructor orders at `β-∀•`, for all
 --     source/target narrowing and widening combinations.
+--   * Depends on `NuImprecisionSimulationCore`; completed synchronized and
+--     one-sided allocation cases live in `NuImprecisionAllocationSimulation`.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (true)
 open import Data.List using ([]; _∷_; _++_; map)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here; there)
-open import Data.Empty using (⊥)
+open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Nat using (zero; suc; z<s; s<s)
 open import Data.Nat.Properties using (≤-refl)
-open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
 open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality using
   (cong; cong₂; subst; sym; trans)
+import Relation.Binary.HeterogeneousEquality as HE
 
 open import Types
 open import Ctx using (⤊ᵗ)
 open import Coercions using
-  ( ModeIncl
+  ( Coercion
+  ; ModeIncl
   ; ModeEnv
   ; Mode
   ; id-only
@@ -46,6 +45,7 @@ open import Coercions using
   ; inst
   ; instᵈ
   ; renameᶜ
+  ; sealModeAllowed
   ; tag-or-idᵈ
   ; `∀
   ; ⇑ᶜ
@@ -91,14 +91,20 @@ import NarrowWiden as NW
 open import NuReduction using
   ( StoreChange
   ; StoreChanges
+  ; applyCoercion
   ; applyStore
   ; applyStores
   ; applyCoercionUnderTyBinder
+  ; applyTerm
+  ; applyTerms
   ; applyTy
   ; applyTyCtx
   ; applyTyCtxs
   ; applyTys
   ; bind
+  ; blame-·₁
+  ; blame-·₂
+  ; blame-⟨⟩
   ; blame-ν
   ; keep
   ; β-gen•
@@ -117,10 +123,23 @@ open import NuReduction using
 open import NuTerms using
   ( No•
   ; RuntimeOK
+  ; no•-`
+  ; no•-ƛ
+  ; no•-·
   ; no•-Λ
+  ; no•-ν
+  ; no•-$
+  ; no•-⊕
   ; no•-⟨⟩
+  ; no•-blame
   ; ok-no
+  ; ok-•
+  ; ok-·₁
+  ; ok-·₂
   ; ok-ν
+  ; ok-⊕₁
+  ; ok-⊕₂
+  ; ok-⟨⟩
   ; blame
   ; Term
   ; Value
@@ -132,8 +151,11 @@ open import NuTerms using
   ; renameᵗᵐ
   ; ⇑ᵗᵐ
   ; _•
+  ; $
+  ; _⊕[_]_
   ; _⟨_⟩
   )
+open import Primitives using (κℕ; addℕ)
 open import NuStore using (StoreWf)
 open import NuTermImprecision using
   ( StoreImp
@@ -195,7 +217,7 @@ open import NuTermImprecision using
   ; crossedStoreⁱ-old-new
   )
 open import QuotientedTermImprecision
-open import Store using (StoreIncl; StoreIncl-drop)
+open import Store using (StoreIncl; StoreIncl-drop; StoreIncl-refl)
 open import TermTyping using
   ( CastMode
   ; SealModeStore★
@@ -220,10 +242,16 @@ open import proof.CastImprecision using
 open import proof.MaximalLowerBoundsWf using
   ( ∀ᵢᶜ
   ; rename-assm²ᵢ
+  ; rename-assm²-composeᵢ
+  ; rename-assm²-congᵢ
   ; rename-assm²-∀ᵢ
+  ; rename-assm²-crossed-left∀∀ᵢ
+  ; rename-assm²-crossed-right∀∀ᵢ
+  ; rename-assm²-crossed-double∀∀ᵢ
   ; rename-assm²-⇑ᵢ
   ; rename-assm²-⇑ᴸᵢ
   ; rename-assm²-source-νᵢ
+  ; rename-assm²-swapLeft∀∀ᵢ
   ; rename-assm²-swapRight∀∀ᵢ
   ; rename-assm²-target-rightᵢ
   ; ⊑-renameᵗ²ᵢ
@@ -238,6 +266,7 @@ open import proof.MaximalLowerBoundsWf using
   ; ⊑-swapRight01∀∀ᵢ
   ; ⊑-target-lift-rightᵢ
   ; swap01ᵢ
+  ; swap01ᵢ-after-suc
   )
 open import proof.MediationProperties using (wfTy-applyTys)
 open import proof.ForallPermutationProperties using
@@ -257,6 +286,10 @@ open import proof.NuTermProperties using
   ( modeRename-left-inverse
   ; open0-ext-suc-cancelᵐ
   ; renameStoreᵗ-ext-suc-cons-comm
+  ; renameᵗᵐ-compose
+  ; renameᵗᵐ-cong
+  ; renameᵗᵐ-ext-suc-comm
+  ; renameᵗᵐ-id
   ; renameᵗᵐ-preserves-No•
   ; renameᵗᵐ-preserves-Value
   )
@@ -271,9 +304,18 @@ open import proof.NuProgress using
 open import proof.NuPreservation using
   ( runtime-ν
   ; runtime-⟨⟩
+  ; value-no-step
   )
 open import proof.ReductionProperties using
-  ( applyCoercionUnderTyBinders
+  ( applyCoercions
+  ; applyCoercions-inst
+  ; applyCoercions-preserves-Inert
+  ; applyCoercionUnderTyBinders
+  ; applyTerm-preserves-No•
+  ; applyTerm-preserves-Value
+  ; applyTerms-++
+  ; applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
   ; applyStores-++
   ; applyTy-∀
   ; applyTyUnderTyBinder
@@ -283,9 +325,14 @@ open import proof.ReductionProperties using
   ; applyTys-++
   ; applyTys-★
   ; applyTys-∀
+  ; cast-↠
+  ; ·₁-↠
+  ; ·₂-↠
   ; ν-↠
   ; ↠-trans
   )
+open import proof.LeftChangeNarrowingSeparated using
+  (applyTys-⇒)
 open import proof.CoercionProperties using
   ( ModeIncl-ext
   ; ModeIncl-gen
@@ -294,25 +341,37 @@ open import proof.CoercionProperties using
   ; open0-ext-suc-cancelᶜ
   )
 open import proof.TypePreservation using
-  ( applyWidenInstUnderTyBinder-typing
+  ( applyNarrow-typing
+  ; applyWiden-typing
+  ; applyWidenInstUnderTyBinder-typing
   ; CastModeRenamer
   ; castModeRenamer-ext
   ; castModeRenamer-seal★
+  ; seal★-inst
+  ; seal★-weaken
   ; castModeRenamer-suc
   ; modeRename-suc-weakenCast
   ; preservation
   ; term-weaken
   ; typing-renameᵀ
   )
-open import proof.StoreProperties using (∈-renameStoreᵗ)
+open import proof.StoreProperties using
+  (∈-renameStoreᵗ; renameStoreᵗ-incl)
 open import proof.TypeProperties using
   ( RenameLeftInverse
   ; RenameLeftInverse-ext
   ; RenameLeftInverse-ext-suc-pred
   ; RenameLeftInverse-suc
+  ; TyPermutation
+  ; TyPermutation-ext
   ; TyRenameWf
   ; TyRenameWf-ext
   ; TyRenameWf-suc
+  ; backward
+  ; backward-forward
+  ; forward
+  ; forward-backward
+  ; forward-wf
   ; predᵗ
   ; occurs-zero-rename-ext
   ; rename-cong
@@ -320,5678 +379,303 @@ open import proof.TypeProperties using
   ; renameᵗ-ext-suc-comm
   ; renameᵗ-id
   ; renameᵗ-preserves-WfTy
+  ; renameStoreᵗ-compose
   ; renameStoreᵗ-ext-suc-comm
   )
 
-store-incl-insert-second :
-  ∀ {Σ α β A B} →
-  StoreIncl ((α , A) ∷ Σ) ((α , A) ∷ (β , B) ∷ Σ)
-store-incl-insert-second (here refl) = here refl
-store-incl-insert-second (there x∈) = there (there x∈)
-
-apply-reveal-under-ty-binder :
-  ∀ {χ μ Δ Σ Aν B C c} →
-  RevealConversion μ (suc Δ)
-    ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
-    zero (⇑ᵗ Aν) c C (⇑ᵗ B) →
-  ∃[ μ′ ]
-    RevealConversion μ′ (suc (applyTyCtx χ Δ))
-      ((zero , ⇑ᵗ (applyTy χ Aν)) ∷ ⟰ᵗ (applyStore χ Σ))
-      zero (⇑ᵗ (applyTy χ Aν))
-      (applyCoercionUnderTyBinder χ c)
-      (applyTyUnderTyBinder χ C) (⇑ᵗ (applyTy χ B))
-apply-reveal-under-ty-binder {χ = keep} {μ = μ} c↑ = μ , c↑
-apply-reveal-under-ty-binder
-    {χ = bind Aχ} {μ = μ} {Δ = Δ} {Σ = Σ}
-    {Aν = Aν} {B = B} {C = C} {c = c} c↑ =
-  (λ Y → μ (predᵗ Y)) ,
-  weaken-reveal-conversion store-incl-insert-second
-    (subst
-      (λ T → RevealConversion (λ Y → μ (predᵗ Y))
-        (suc (suc Δ))
-        ((zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ (⟰ᵗ Σ))
-        zero (⇑ᵗ (⇑ᵗ Aν))
-        (renameᶜ (extᵗ suc) c)
-        (renameᵗ (extᵗ suc) C) T)
-      (renameᵗ-ext-suc-comm suc B)
-      (subst
-        (λ T → RevealConversion (λ Y → μ (predᵗ Y))
-          (suc (suc Δ))
-          ((zero , T) ∷ ⟰ᵗ (⟰ᵗ Σ))
-          zero T (renameᶜ (extᵗ suc) c)
-          (renameᵗ (extᵗ suc) C)
-          (renameᵗ (extᵗ suc) (⇑ᵗ B)))
-        (renameᵗ-ext-suc-comm suc Aν)
-        (subst
-          (λ Σ′ → RevealConversion (λ Y → μ (predᵗ Y))
-            (suc (suc Δ)) Σ′ zero
-            (renameᵗ (extᵗ suc) (⇑ᵗ Aν))
-            (renameᶜ (extᵗ suc) c)
-            (renameᵗ (extᵗ suc) C)
-            (renameᵗ (extᵗ suc) (⇑ᵗ B)))
-          renamed-store
-          (rename-reveal-conversion
-            (TyRenameWf-ext TyRenameWf-suc)
-            (modeRename-left-inverse
-              {ρ = extᵗ suc} {ψ = predᵗ}
-              RenameLeftInverse-ext-suc-pred)
-            c↑))))
-  where
-    renamed-store :
-      renameStoreᵗ (extᵗ suc)
-          ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
-        ≡ (zero , renameᵗ (extᵗ suc) (⇑ᵗ Aν)) ∷
-          ⟰ᵗ (⟰ᵗ Σ)
-    renamed-store =
-      cong₂ _∷_ refl (renameStoreᵗ-ext-suc-comm suc Σ)
-
-apply-reveal-under-ty-binders :
-  ∀ {χs μ Δ Σ Aν B C c} →
-  RevealConversion μ (suc Δ)
-    ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
-    zero (⇑ᵗ Aν) c C (⇑ᵗ B) →
-  ∃[ μ′ ]
-    RevealConversion μ′ (suc (applyTyCtxs χs Δ))
-      ((zero , ⇑ᵗ (applyTys χs Aν)) ∷
-        ⟰ᵗ (applyStores χs Σ))
-      zero (⇑ᵗ (applyTys χs Aν))
-      (applyCoercionUnderTyBinders χs c)
-      (applyTysUnderTyBinders χs C) (⇑ᵗ (applyTys χs B))
-apply-reveal-under-ty-binders {χs = []} {μ = μ} c↑ = μ , c↑
-apply-reveal-under-ty-binders {χs = χ ∷ χs} c↑
-    with apply-reveal-under-ty-binder {χ = χ} c↑
-apply-reveal-under-ty-binders {χs = χ ∷ χs} c↑
-    | μ′ , c′↑ =
-  apply-reveal-under-ty-binders {χs = χs} c′↑
-
-apply-widen-inst-under-ty-binders :
-  ∀ {χs μ Δ Σ c B C} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ) ((zero , ★) ∷ ⟰ᵗ Σ) →
-  instᵈ μ ∣ suc Δ ∣ (zero , ★) ∷ ⟰ᵗ Σ
-    ⊢ c ∶ C ⊑ ⇑ᵗ B →
-  ∃[ μ′ ]
-    CastMode μ′ ×
-    SealModeStore★ (instᵈ μ′)
-      ((zero , ★) ∷ ⟰ᵗ (applyStores χs Σ)) ×
-    (instᵈ μ′ ∣ suc (applyTyCtxs χs Δ)
-      ∣ (zero , ★) ∷ ⟰ᵗ (applyStores χs Σ)
-      ⊢ applyCoercionUnderTyBinders χs c
-        ∶ applyTysUnderTyBinders χs C ⊑
-          ⇑ᵗ (applyTys χs B))
-apply-widen-inst-under-ty-binders {χs = []} {μ = μ}
-    mode seal★ c⊑ =
-  μ , mode , seal★ , c⊑
-apply-widen-inst-under-ty-binders {χs = keep ∷ χs}
-    mode seal★ c⊑
-    with applyWidenInstUnderTyBinder-typing
-      {χ = keep} mode seal★ c⊑
-apply-widen-inst-under-ty-binders {χs = keep ∷ χs}
-    mode seal★ c⊑
-    | μ′ , mode′ , seal★′ , c′⊑ =
-  apply-widen-inst-under-ty-binders
-    {χs = χs} mode′ seal★′ c′⊑
-apply-widen-inst-under-ty-binders {χs = bind A ∷ χs}
-    mode seal★ c⊑
-    with applyWidenInstUnderTyBinder-typing
-      {χ = bind A} mode seal★ c⊑
-apply-widen-inst-under-ty-binders {χs = bind A ∷ χs}
-    mode seal★ c⊑
-    | μ′ , mode′ , seal★′ , c′⊑ =
-  apply-widen-inst-under-ty-binders
-    {χs = χs} mode′ seal★′ c′⊑
-
-------------------------------------------------------------------------
--- General weak one-step simulation result
-------------------------------------------------------------------------
-
-record WeakOneStepResult
-    {Φ Δᴸ Δᴿ}
-    (ρ : StoreImp Φ Δᴸ Δᴿ)
-    (M N′ : Term)
-    (A B : Ty)
-    (χ : StoreChange) : Set₁ where
-  constructor weak-step-result
-  field
-    sourceChanges : StoreChanges
-    targetTailChanges : StoreChanges
-    sourceResult : Term
-    targetResult : Term
-    resultCtx : ImpCtx
-    resultLeftCtx : TyCtx
-    resultRightCtx : TyCtx
-    sourceCtxResult :
-      resultLeftCtx ≡ applyTyCtxs sourceChanges Δᴸ
-    targetCtxResult :
-      resultRightCtx
-        ≡ applyTyCtxs targetTailChanges (applyTyCtx χ Δᴿ)
-    resultStore :
-      StoreImp resultCtx resultLeftCtx resultRightCtx
-    resultSourceType : Ty
-    resultTargetType : Ty
-    sourceTypeResult :
-      resultSourceType ≡ applyTys sourceChanges A
-    targetTypeResult :
-      resultTargetType ≡ applyTys targetTailChanges (applyTy χ B)
-    transportType :
-      ∀ {C D} →
-      Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
-      resultCtx ∣ resultLeftCtx
-        ⊢ applyTys sourceChanges C
-          ⊑ applyTys targetTailChanges (applyTy χ D)
-        ⊣ resultRightCtx
-    transportAllBody :
-      ∀ {C D} →
-      ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
-      ∀ᵢᶜ resultCtx ∣ suc resultLeftCtx
-        ⊢ applyTysUnderTyBinders sourceChanges C
-          ⊑ applyTysUnderTyBinders targetTailChanges
-              (applyTyUnderTyBinder χ D)
-        ⊣ suc resultRightCtx
-    transportRightBody :
-      ∀ {C D} →
-      ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
-      ⇑ᴿᵢ resultCtx ∣ resultLeftCtx
-        ⊢ applyTys sourceChanges C
-          ⊑ applyTysUnderTyBinders targetTailChanges
-              (applyTyUnderTyBinder χ D)
-        ⊣ suc resultRightCtx
-    resultType :
-      resultCtx ∣ resultLeftCtx
-        ⊢ resultSourceType ⊑ resultTargetType
-        ⊣ resultRightCtx
-    sourceCatchup : M —↠[ sourceChanges ] sourceResult
-    targetTail : N′ —↠[ targetTailChanges ] targetResult
-    sourceStoreResult :
-      leftStoreⁱ resultStore
-        ≡ applyStores sourceChanges (leftStoreⁱ ρ)
-    targetStoreResult :
-      rightStoreⁱ resultStore
-        ≡ applyStores targetTailChanges
-            (applyStore χ (rightStoreⁱ ρ))
-    relatedResults :
-      resultCtx
-        ∣ resultLeftCtx
-        ∣ resultRightCtx
-        ∣ resultStore ∣ []
-        ⊢ᴺ sourceResult ⊑ targetResult
-        ⦂ resultSourceType ⊑ resultTargetType
-        ∶ resultType
-
-open WeakOneStepResult
-
-data WeakOneStepOutcome
-    {Φ Δᴸ Δᴿ}
-    (ρ : StoreImp Φ Δᴸ Δᴿ)
-    (M N′ : Term)
-    (A B : Ty)
-    (χ : StoreChange) : Set₁ where
-  outcome-related :
-    WeakOneStepResult ρ M N′ A B χ →
-    WeakOneStepOutcome ρ M N′ A B χ
-
-  outcome-source-blame : ∀ {χs} →
-    M —↠[ χs ] blame →
-    WeakOneStepOutcome ρ M N′ A B χ
-
-record WeakOneStepAllResult
-    {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
-  constructor weak-all-result
-  field
-    weakResult : WeakOneStepResult ρ N N₁′ (`∀ C) (`∀ C′) χ
-    canonicalAllResults :
-      resultCtx weakResult
-        ∣ resultLeftCtx weakResult
-        ∣ resultRightCtx weakResult
-        ∣ resultStore weakResult ∣ []
-        ⊢ᴺ sourceResult weakResult ⊑ targetResult weakResult
-        ⦂ `∀
-            (applyTysUnderTyBinders (sourceChanges weakResult) C)
-          ⊑ `∀
-              (applyTysUnderTyBinders (targetTailChanges weakResult)
-                (applyTyUnderTyBinder χ C′))
-        ∶ ∀ⁱ (transportAllBody weakResult q)
-
-open WeakOneStepAllResult
-
-data WeakOneStepAllOutcome
-    {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
-  all-outcome-related :
-    WeakOneStepAllResult {N = N} {N₁′ = N₁′} {χ = χ} {ρ = ρ} q →
-    WeakOneStepAllOutcome q
-
-  all-outcome-source-blame : ∀ {χs} →
-    N —↠[ χs ] blame →
-    WeakOneStepAllOutcome q
-
-record LeftSilentInvariant
-    {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    (result : WeakOneStepResult ρ M V′ A B keep) : Set₁ where
-  constructor left-silent-invariant
-  field
-    targetTailIsEmpty : targetTailChanges result ≡ []
-    targetIsUnchanged : targetResult result ≡ V′
-
-open LeftSilentInvariant
-
-weak-result-right-wf-silent :
-  ∀ {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (result : WeakOneStepResult ρ M V′ A B keep) →
-  LeftSilentInvariant result →
-  StoreWf Δᴿ (rightStoreⁱ ρ) →
-  StoreWf (resultRightCtx result) (rightStoreⁱ (resultStore result))
-weak-result-right-wf-silent result
-    (left-silent-invariant refl target-eq) wfΣ′ =
-  subst
-    (λ Δ → StoreWf Δ (rightStoreⁱ (resultStore result)))
-    (sym (targetCtxResult result))
-    (subst
-      (StoreWf _)
-      (sym (targetStoreResult result)) wfΣ′)
-
-record LeftCatchupInvariant
-    {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    (result : WeakOneStepResult ρ M V′ A B keep) : Set₁ where
-  constructor left-catchup-invariant
-  field
-    silentInvariant : LeftSilentInvariant result
-    sourceIsValueOrBlame :
-      (Value (sourceResult result) × No• (sourceResult result)) ⊎
-      sourceResult result ≡ blame
-
-open LeftCatchupInvariant
-
-record LeftSilentResult
-    {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} : Set₁ where
-  constructor left-silent
-  field
-    silentResult : WeakOneStepResult ρ M V′ A B keep
-    resultIsLeftSilent : LeftSilentInvariant silentResult
-
-open LeftSilentResult
-
-record LeftCatchupResult
-    {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} : Set₁ where
-  constructor left-catchup
-  field
-    catchupResult : WeakOneStepResult ρ M V′ A B keep
-    catchupInvariant : LeftCatchupInvariant catchupResult
-
-open LeftCatchupResult
-
-forget-left-catchup :
-  ∀ {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  LeftCatchupResult
-    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ} →
-  LeftSilentResult
-    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ}
-forget-left-catchup
-    (left-catchup result (left-catchup-invariant silent final)) =
-  left-silent result silent
-
-record LeftCatchupAllResult
-    {Φ Δᴸ Δᴿ N V′ C C′}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
-  constructor left-all-catchup
-  field
-    catchupAllResult :
-      WeakOneStepAllResult
-        {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q
-    catchupAllInvariant :
-      LeftCatchupInvariant (weakResult catchupAllResult)
-
-open LeftCatchupAllResult
-
-forget-left-all-catchup :
-  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q →
-  LeftCatchupResult {M = N} {V′ = V′} {ρ = ρ}
-forget-left-all-catchup (left-all-catchup result invariant) =
-  left-catchup (weakResult result) invariant
-
-weak-result-source-all :
-  ∀ {Φ Δᴸ Δᴿ N N₁′ C B′ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
-  ∃[ q′ ]
-    (resultCtx inner
-      ∣ resultLeftCtx inner
-      ∣ resultRightCtx inner
-      ∣ resultStore inner ∣ []
-      ⊢ᴺ sourceResult inner ⊑ targetResult inner
-      ⦂ `∀ (applyTysUnderTyBinders (sourceChanges inner) C)
-        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
-      ∶ q′)
-weak-result-source-all {C = C} inner =
-  subst
-    (λ T → ∃[ q′ ]
-      (resultCtx inner
-        ∣ resultLeftCtx inner
-        ∣ resultRightCtx inner
-        ∣ resultStore inner ∣ []
-        ⊢ᴺ sourceResult inner ⊑ targetResult inner
-        ⦂ `∀ (applyTysUnderTyBinders (sourceChanges inner) C)
-          ⊑ T ∶ q′))
-    (targetTypeResult inner)
-    (subst
-      (λ S → ∃[ q′ ]
-        (resultCtx inner
-          ∣ resultLeftCtx inner
-          ∣ resultRightCtx inner
-          ∣ resultStore inner ∣ []
-          ⊢ᴺ sourceResult inner ⊑ targetResult inner
-          ⦂ S ⊑ resultTargetType inner ∶ q′))
-      (trans (sourceTypeResult inner)
-        (applyTys-∀ (sourceChanges inner) C))
-      (resultType inner , relatedResults inner))
-
-weak-result-target-all :
-  ∀ {Φ Δᴸ Δᴿ N N₁′ B C′ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
-  ∃[ q′ ]
-    (resultCtx inner
-      ∣ resultLeftCtx inner
-      ∣ resultRightCtx inner
-      ∣ resultStore inner ∣ []
-      ⊢ᴺ sourceResult inner ⊑ targetResult inner
-      ⦂ applyTys (sourceChanges inner) B
-        ⊑ `∀
-            (applyTysUnderTyBinders (targetTailChanges inner)
-              (applyTyUnderTyBinder χ C′))
-      ∶ q′)
-weak-result-target-all {C′ = C′} {χ = χ} inner =
-  subst
-    (λ T → ∃[ q′ ]
-      (resultCtx inner
-        ∣ resultLeftCtx inner
-        ∣ resultRightCtx inner
-        ∣ resultStore inner ∣ []
-        ⊢ᴺ sourceResult inner ⊑ targetResult inner
-        ⦂ applyTys (sourceChanges inner) _ ⊑ T ∶ q′))
-    (trans (targetTypeResult inner)
-      (trans
-        (cong (applyTys (targetTailChanges inner))
-          (applyTy-∀ χ C′))
-        (applyTys-∀ (targetTailChanges inner)
-          (applyTyUnderTyBinder χ C′))))
-    (subst
-      (λ S → ∃[ q′ ]
-        (resultCtx inner
-          ∣ resultLeftCtx inner
-          ∣ resultRightCtx inner
-          ∣ resultStore inner ∣ []
-          ⊢ᴺ sourceResult inner ⊑ targetResult inner
-          ⦂ S ⊑ resultTargetType inner ∶ q′))
-      (sourceTypeResult inner)
-      (resultType inner , relatedResults inner))
-
-weak-result-source-reveal :
-  ∀ {Φ Δᴸ Δᴿ N N′ X Y χ A B C c μ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (inner : WeakOneStepResult ρ N N′ X Y χ) →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) c C (⇑ᵗ B) →
-  ∃[ μ′ ]
-    RevealConversion μ′ (suc (resultLeftCtx inner))
-      ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
-        ⟰ᵗ (leftStoreⁱ (resultStore inner)))
-      zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-      (applyCoercionUnderTyBinders (sourceChanges inner) c)
-      (applyTysUnderTyBinders (sourceChanges inner) C)
-      (⇑ᵗ (applyTys (sourceChanges inner) B))
-weak-result-source-reveal {A = A} {B = B} {C = C} {c = c} inner c↑
-    with apply-reveal-under-ty-binders
-      {χs = sourceChanges inner} c↑
-weak-result-source-reveal {A = A} {B = B} {C = C} {c = c} inner c↑
-    | μ′ , c′↑ =
-  μ′ ,
-  subst
-    (λ Δ → RevealConversion μ′ (suc Δ)
-      ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
-        ⟰ᵗ (leftStoreⁱ (resultStore inner)))
-      zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-      (applyCoercionUnderTyBinders (sourceChanges inner) c)
-      (applyTysUnderTyBinders (sourceChanges inner) C)
-      (⇑ᵗ (applyTys (sourceChanges inner) B)))
-    (sym (sourceCtxResult inner))
-    (subst
-      (λ Σ → RevealConversion μ′
-        (suc (applyTyCtxs (sourceChanges inner) _))
-        ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷ ⟰ᵗ Σ)
-        zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-        (applyCoercionUnderTyBinders (sourceChanges inner) c)
-        (applyTysUnderTyBinders (sourceChanges inner) C)
-        (⇑ᵗ (applyTys (sourceChanges inner) B)))
-      (sym (sourceStoreResult inner)) c′↑)
-
-weak-result-target-reveal :
-  ∀ {Φ Δᴸ Δᴿ N N′ X Y A B C c μ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (χ : StoreChange) →
-  (inner : WeakOneStepResult ρ N N′ X Y χ) →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) c C (⇑ᵗ B) →
-  ∃[ μ′ ]
-    RevealConversion μ′ (suc (resultRightCtx inner))
-      ((zero ,
-        ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
-        ⟰ᵗ (rightStoreⁱ (resultStore inner)))
-      zero
-      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
-      (applyCoercionUnderTyBinders (targetTailChanges inner)
-        (applyCoercionUnderTyBinder χ c))
-      (applyTysUnderTyBinders (targetTailChanges inner)
-        (applyTyUnderTyBinder χ C))
-      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
-weak-result-target-reveal
-    {A = A} {B = B} {C = C} {c = c} χ inner c↑
-    with apply-reveal-under-ty-binders
-      {χs = χ ∷ targetTailChanges inner} c↑
-weak-result-target-reveal
-    {A = A} {B = B} {C = C} {c = c} χ inner c↑
-    | μ′ , c′↑ =
-  μ′ ,
-  subst
-    (λ Δ → RevealConversion μ′ (suc Δ)
-      ((zero ,
-        ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
-        ⟰ᵗ (rightStoreⁱ (resultStore inner)))
-      zero
-      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
-      (applyCoercionUnderTyBinders (targetTailChanges inner)
-        (applyCoercionUnderTyBinder χ c))
-      (applyTysUnderTyBinders (targetTailChanges inner)
-        (applyTyUnderTyBinder χ C))
-      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B))))
-    (sym (targetCtxResult inner))
-    (subst
-      (λ Σ → RevealConversion μ′
-        (suc (applyTyCtxs (targetTailChanges inner)
-          (applyTyCtx χ _)))
-        ((zero ,
-          ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
-          ⟰ᵗ Σ)
-        zero
-        (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
-        (applyCoercionUnderTyBinders (targetTailChanges inner)
-          (applyCoercionUnderTyBinder χ c))
-        (applyTysUnderTyBinders (targetTailChanges inner)
-          (applyTyUnderTyBinder χ C))
-        (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B))))
-      (sym (targetStoreResult inner)) c′↑)
-
-weak-result-source-widen-inst :
-  ∀ {Φ Δᴸ Δᴿ N N′ X Y χ B C c μ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (inner : WeakOneStepResult ρ N N′ X Y χ) →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ c ∶ C ⊑ ⇑ᵗ B →
-  ∃[ μ′ ]
-    CastMode μ′ ×
-    SealModeStore★ (instᵈ μ′)
-      ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))) ×
-    (instᵈ μ′ ∣ suc (resultLeftCtx inner)
-      ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
-      ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
-        ∶ applyTysUnderTyBinders (sourceChanges inner) C
-          ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-weak-result-source-widen-inst
-    {B = B} {C = C} {c = c} inner mode seal★ c⊑
-    with apply-widen-inst-under-ty-binders
-      {χs = sourceChanges inner} mode seal★ c⊑
-weak-result-source-widen-inst
-    {B = B} {C = C} {c = c} inner mode seal★ c⊑
-    | μ′ , mode′ , seal★′ , c′⊑ =
-  μ′ , mode′ ,
-  subst
-    (λ Σ → SealModeStore★ (instᵈ μ′) ((zero , ★) ∷ ⟰ᵗ Σ))
-    (sym (sourceStoreResult inner)) seal★′ ,
-  subst
-    (λ Δ → instᵈ μ′ ∣ suc Δ
-      ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
-      ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
-        ∶ applyTysUnderTyBinders (sourceChanges inner) C
-          ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-    (sym (sourceCtxResult inner))
-    (subst
-      (λ Σ → instᵈ μ′
-        ∣ suc (applyTyCtxs (sourceChanges inner) _)
-        ∣ (zero , ★) ∷ ⟰ᵗ Σ
-        ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
-          ∶ applyTysUnderTyBinders (sourceChanges inner) C
-            ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-      (sym (sourceStoreResult inner)) c′⊑)
-
-weak-result-target-widen-inst :
-  ∀ {Φ Δᴸ Δᴿ N N′ X Y B C c μ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (χ : StoreChange) →
-  (inner : WeakOneStepResult ρ N N′ X Y χ) →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ c ∶ C ⊑ ⇑ᵗ B →
-  ∃[ μ′ ]
-    CastMode μ′ ×
-    SealModeStore★ (instᵈ μ′)
-      ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))) ×
-    (instᵈ μ′ ∣ suc (resultRightCtx inner)
-      ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
-      ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-          (applyCoercionUnderTyBinder χ c)
-        ∶ applyTysUnderTyBinders (targetTailChanges inner)
-            (applyTyUnderTyBinder χ C)
-          ⊑ ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
-weak-result-target-widen-inst
-    {B = B} {C = C} {c = c} χ inner mode seal★ c⊑
-    with apply-widen-inst-under-ty-binders
-      {χs = χ ∷ targetTailChanges inner} mode seal★ c⊑
-weak-result-target-widen-inst
-    {B = B} {C = C} {c = c} χ inner mode seal★ c⊑
-    | μ′ , mode′ , seal★′ , c′⊑ =
-  μ′ , mode′ ,
-  subst
-    (λ Σ → SealModeStore★ (instᵈ μ′) ((zero , ★) ∷ ⟰ᵗ Σ))
-    (sym (targetStoreResult inner)) seal★′ ,
-  subst
-    (λ Δ → instᵈ μ′ ∣ suc Δ
-      ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
-      ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-          (applyCoercionUnderTyBinder χ c)
-        ∶ applyTysUnderTyBinders (targetTailChanges inner)
-            (applyTyUnderTyBinder χ C)
-          ⊑ ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
-    (sym (targetCtxResult inner))
-    (subst
-      (λ Σ → instᵈ μ′
-        ∣ suc (applyTyCtxs (targetTailChanges inner)
-          (applyTyCtx χ _))
-        ∣ (zero , ★) ∷ ⟰ᵗ Σ
-        ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ c)
-          ∶ applyTysUnderTyBinders (targetTailChanges inner)
-              (applyTyUnderTyBinder χ C)
-            ⊑ ⇑ᵗ
-                (applyTys (targetTailChanges inner) (applyTy χ B)))
-      (sym (targetStoreResult inner)) c′⊑)
-
-lift-store-result :
-  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  ∃[ ρ′ ] LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ′
-lift-store-result [] = [] , lift-store-[]
-lift-store-result (store-matched α A β B p ∷ ρ)
-    with lift-store-result ρ
-lift-store-result (store-matched α A β B p ∷ ρ)
-    | ρ′ , liftρ =
-  store-matched (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
-    (⊑-lift∀ᵢ p) ∷ ρ′ ,
-  lift-store-∷ liftρ
-lift-store-result (store-left α A hA ∷ ρ)
-    with lift-store-result ρ
-lift-store-result (store-left α A hA ∷ ρ)
-    | ρ′ , liftρ =
-  store-left (suc α) (⇑ᵗ A)
-    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ′ ,
-  lift-store-left liftρ
-lift-store-result (store-right β B hB ∷ ρ)
-    with lift-store-result ρ
-lift-store-result (store-right β B hB ∷ ρ)
-    | ρ′ , liftρ =
-  store-right (suc β) (⇑ᵗ B)
-    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ′ ,
-  lift-store-right liftρ
-lift-store-result (store-link α A β B p ∷ ρ)
-    with lift-store-result ρ
-lift-store-result (store-link α A β B p ∷ ρ)
-    | ρ′ , liftρ =
-  store-link (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
-    (⊑-lift∀ᵢ p) ∷ ρ′ ,
-  lift-store-link liftρ
-
-lift-left-store-result :
-  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  ∃[ ρ′ ] LiftLeftStoreⁱ
-    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
-lift-left-store-result [] = [] , lift-left-store-[]
-lift-left-store-result (store-matched α A β B p ∷ ρ)
-    with lift-left-store-result ρ
-lift-left-store-result (store-matched α A β B p ∷ ρ)
-    | ρ′ , liftρ =
-  store-matched (suc α) (⇑ᵗ A) β B
-    (⊑-source-liftνᵢ p) ∷ ρ′ ,
-  lift-left-store-∷ liftρ
-lift-left-store-result (store-left α A hA ∷ ρ)
-    with lift-left-store-result ρ
-lift-left-store-result (store-left α A hA ∷ ρ)
-    | ρ′ , liftρ =
-  store-left (suc α) (⇑ᵗ A)
-    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ′ ,
-  lift-left-store-left liftρ
-lift-left-store-result (store-right β B hB ∷ ρ)
-    with lift-left-store-result ρ
-lift-left-store-result (store-right β B hB ∷ ρ)
-    | ρ′ , liftρ =
-  store-right β B hB ∷ ρ′ ,
-  lift-left-store-right liftρ
-lift-left-store-result (store-link α A β B p ∷ ρ)
-    with lift-left-store-result ρ
-lift-left-store-result (store-link α A β B p ∷ ρ)
-    | ρ′ , liftρ =
-  store-link (suc α) (⇑ᵗ A) β B
-    (⊑-source-liftνᵢ p) ∷ ρ′ ,
-  lift-left-store-link liftρ
-
-lift-right-store-result :
-  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  ∃[ ρ′ ] LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′
-lift-right-store-result [] = [] , lift-right-store-[]
-lift-right-store-result (store-matched α A β B p ∷ ρ)
-    with lift-right-store-result ρ
-lift-right-store-result (store-matched α A β B p ∷ ρ)
-    | ρ′ , liftρ =
-  store-matched α A (suc β) (⇑ᵗ B)
-    (⊑-target-lift-rightᵢ p) ∷ ρ′ ,
-  lift-right-store-∷ liftρ
-lift-right-store-result (store-left α A hA ∷ ρ)
-    with lift-right-store-result ρ
-lift-right-store-result (store-left α A hA ∷ ρ)
-    | ρ′ , liftρ =
-  store-left α A hA ∷ ρ′ ,
-  lift-right-store-left liftρ
-lift-right-store-result (store-right β B hB ∷ ρ)
-    with lift-right-store-result ρ
-lift-right-store-result (store-right β B hB ∷ ρ)
-    | ρ′ , liftρ =
-  store-right (suc β) (⇑ᵗ B)
-    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ′ ,
-  lift-right-store-right liftρ
-lift-right-store-result (store-link α A β B p ∷ ρ)
-    with lift-right-store-result ρ
-lift-right-store-result (store-link α A β B p ∷ ρ)
-    | ρ′ , liftρ =
-  store-link α A (suc β) (⇑ᵗ B)
-    (⊑-target-lift-rightᵢ p) ∷ ρ′ ,
-  lift-right-store-link liftρ
-
-left-right-store-commuteⁱ :
-  ∀ {Φ Δᴸ Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  ∃[ ρ× ]
-    LiftRightStoreⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴸ ρ× ×
-    LiftLeftStoreⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴿ ρ×
-left-right-store-commuteⁱ lift-left-store-[] lift-right-store-[] =
-  [] , lift-right-store-[] , lift-left-store-[]
-left-right-store-commuteⁱ
-    (lift-left-store-∷ {p′ = pᴸ} liftᴸ)
-    (lift-right-store-∷ liftᴿ)
-    with left-right-store-commuteⁱ liftᴸ liftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-∷ {p′ = pᴸ} liftᴸ)
-    (lift-right-store-∷ liftᴿ)
-    | ρ× , rightᴸ , leftᴿ =
-  store-matched _ _ _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ ρ× ,
-  lift-right-store-∷ rightᴸ ,
-  lift-left-store-∷ leftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-left liftᴸ)
-    (lift-right-store-left liftᴿ)
-    with left-right-store-commuteⁱ liftᴸ liftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-left {hA′ = hAᴸ} liftᴸ)
-    (lift-right-store-left liftᴿ)
-    | ρ× , rightᴸ , leftᴿ =
-  store-left _ _ hAᴸ ∷ ρ× ,
-  lift-right-store-left rightᴸ ,
-  lift-left-store-left leftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-right liftᴸ)
-    (lift-right-store-right liftᴿ)
-    with left-right-store-commuteⁱ liftᴸ liftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-right liftᴸ)
-    (lift-right-store-right {hB′ = hBᴿ} liftᴿ)
-    | ρ× , rightᴸ , leftᴿ =
-  store-right _ _ hBᴿ ∷ ρ× ,
-  lift-right-store-right rightᴸ ,
-  lift-left-store-right leftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-link {p′ = pᴸ} liftᴸ)
-    (lift-right-store-link liftᴿ)
-    with left-right-store-commuteⁱ liftᴸ liftᴿ
-left-right-store-commuteⁱ
-    (lift-left-store-link {p′ = pᴸ} liftᴸ)
-    (lift-right-store-link liftᴿ)
-    | ρ× , rightᴸ , leftᴿ =
-  store-link _ _ _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ ρ× ,
-  lift-right-store-link rightᴸ ,
-  lift-left-store-link leftᴿ
-
-left-right-ctx-commuteⁱ :
-  ∀ {Φ Δᴸ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ}
-    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  ∃[ γ× ]
-    LiftRightCtxⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴸ γ× ×
-    LiftLeftCtxⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴿ γ×
-left-right-ctx-commuteⁱ lift-left-ctx-[] lift-right-ctx-[] =
-  [] , lift-right-ctx-[] , lift-left-ctx-[]
-left-right-ctx-commuteⁱ
-    (lift-left-ctx-∷ {p′ = pᴸ} liftᴸ)
-    (lift-right-ctx-∷ liftᴿ)
-    with left-right-ctx-commuteⁱ liftᴸ liftᴿ
-left-right-ctx-commuteⁱ
-    (lift-left-ctx-∷ {p′ = pᴸ} liftᴸ)
-    (lift-right-ctx-∷ liftᴿ)
-    | γ× , rightᴸ , leftᴿ =
-  ctx-imp _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ γ× ,
-  lift-right-ctx-∷ rightᴸ ,
-  lift-left-ctx-∷ leftᴿ
-
-data LeftInsertion : Renameᵗ → Set where
-  left-insertion-suc : LeftInsertion suc
-  left-insertion-ext : ∀ {τ} →
-    LeftInsertion τ → LeftInsertion (extᵗ τ)
-
-left-insertion-mode :
-  ∀ {τ} → LeftInsertion τ → ModeEnv → ModeEnv
-left-insertion-mode left-insertion-suc μ = weakenCastᵈ μ
-left-insertion-mode (left-insertion-ext ins) μ zero = μ zero
-left-insertion-mode (left-insertion-ext ins) μ (suc X) =
-  left-insertion-mode ins (λ Y → μ (suc Y)) X
-
-mode≤-refl : ∀ m → mode≤ m m ≡ true
-mode≤-refl id-only = refl
-mode≤-refl tag-or-id = refl
-mode≤-refl seal-or-id = refl
-
-left-insertion-mode-rename :
-  ∀ {τ} (ins : LeftInsertion τ) (μ : ModeEnv) →
-  ModeRename τ μ (left-insertion-mode ins μ)
-left-insertion-mode-rename left-insertion-suc μ =
-  modeRename-suc-weakenCast
-left-insertion-mode-rename (left-insertion-ext ins) μ zero =
-  mode≤-refl (μ zero)
-left-insertion-mode-rename (left-insertion-ext ins) μ (suc X) =
-  left-insertion-mode-rename ins (λ Y → μ (suc Y)) X
-
-left-insertion-cast-renamer :
-  ∀ {τ} → LeftInsertion τ → CastModeRenamer τ
-left-insertion-cast-renamer left-insertion-suc = castModeRenamer-suc
-left-insertion-cast-renamer (left-insertion-ext ins) =
-  castModeRenamer-ext (left-insertion-cast-renamer ins)
-
-no-crossed-up-mode-rename-id :
-  ModeRename suc
-    (extᵈ (instᵈ tag-or-idᵈ)) id-onlyᵈ → ⊥
-no-crossed-up-mode-rename-id rel with rel (suc zero)
-no-crossed-up-mode-rename-id rel | ()
-
-no-crossed-up-mode-rename-same :
-  ModeRename suc
-    (extᵈ (instᵈ tag-or-idᵈ))
-    (extᵈ (instᵈ tag-or-idᵈ)) → ⊥
-no-crossed-up-mode-rename-same rel with rel (suc zero)
-no-crossed-up-mode-rename-same rel | ()
-
-no-crossed-up-mode-rename-opposite :
-  ModeRename suc
-    (extᵈ (instᵈ tag-or-idᵈ))
-    (instᵈ (extᵈ tag-or-idᵈ)) → ⊥
-no-crossed-up-mode-rename-opposite rel with rel (suc zero)
-no-crossed-up-mode-rename-opposite rel | ()
-
-crossed-left-mode-rename-opposite :
-  ModeRename suc
-    (instᵈ (extᵈ tag-or-idᵈ))
-    (extᵈ (instᵈ tag-or-idᵈ))
-crossed-left-mode-rename-opposite zero = refl
-crossed-left-mode-rename-opposite (suc zero) = refl
-crossed-left-mode-rename-opposite (suc (suc X)) = refl
-
-rename-assm²-target-ext-idᵢ :
-  ∀ {τ a} →
-  rename-assm²ᵢ τ (extᵗ (λ X → X)) a
-    ≡ rename-assm²ᵢ τ (λ X → X) a
-rename-assm²-target-ext-idᵢ {a = X ˣ⊑★} = refl
-rename-assm²-target-ext-idᵢ {a = X ˣ⊑ˣ zero} = refl
-rename-assm²-target-ext-idᵢ {a = X ˣ⊑ˣ suc Y} = refl
-
-rename-assm²-∀-leftᵢ :
-  ∀ {Φ Ψ τ} →
-  (∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  ∀ {a} → a ∈ ∀ᵢᶜ Φ →
-  rename-assm²ᵢ (extᵗ τ) (λ X → X) a ∈ ∀ᵢᶜ Ψ
-rename-assm²-∀-leftᵢ {Ψ = Ψ} assm {a = a} a∈ =
-  subst
-    (_∈ ∀ᵢᶜ Ψ)
-    rename-assm²-target-ext-idᵢ
-    (rename-assm²-⇑ᵢ assm a∈)
-
-⊑-rename-leftᵢ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A B} (τ : Renameᵗ) →
-  (∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  TyRenameWf Δᴸ Δᴸ′ τ →
-  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
-  Ψ ∣ Δᴸ′ ⊢ renameᵗ τ A ⊑ B ⊣ Δᴿ
-⊑-rename-leftᵢ τ assm hτ id★ = id★
-⊑-rename-leftᵢ τ assm hτ (idˣ a∈ X<Δ Y<Δ) =
-  idˣ (assm a∈) (hτ X<Δ) Y<Δ
-⊑-rename-leftᵢ τ assm hτ idι = idι
-⊑-rename-leftᵢ τ assm hτ (p ↦ q) =
-  ⊑-rename-leftᵢ τ assm hτ p ↦
-  ⊑-rename-leftᵢ τ assm hτ q
-⊑-rename-leftᵢ τ assm hτ (∀ⁱ p) =
-  ∀ⁱ (⊑-rename-leftᵢ
-    (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ) p)
-⊑-rename-leftᵢ τ assm hτ (tag ι) = tag ι
-⊑-rename-leftᵢ τ assm hτ (tag p ⇛ q) =
-  tag (⊑-rename-leftᵢ τ assm hτ p) ⇛
-  ⊑-rename-leftᵢ τ assm hτ q
-⊑-rename-leftᵢ τ assm hτ (tagˣ a∈ X<Δ) =
-  tagˣ (assm a∈) (hτ X<Δ)
-⊑-rename-leftᵢ {Φ = Φ} τ assm hτ (ν {A = A} occ p) =
-  ν (trans (occurs-zero-rename-ext τ A) occ)
-    (⊑-rename-leftᵢ
-      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ) p)
-
-⊑-rename-left-atᵢ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A A′ B} (τ : Renameᵗ) →
-  (assm : ∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  (hτ : TyRenameWf Δᴸ Δᴸ′ τ) →
-  A′ ≡ renameᵗ τ A →
-  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
-  Ψ ∣ Δᴸ′ ⊢ A′ ⊑ B ⊣ Δᴿ
-⊑-rename-left-atᵢ τ assm hτ eqA p =
-  subst (λ T → _ ∣ _ ⊢ T ⊑ _ ⊣ _) (sym eqA)
-    (⊑-rename-leftᵢ τ assm hτ p)
-
-swap01-ext²-commute :
-  ∀ (τ : Renameᵗ) X →
-  swap01ᵗ (extᵗ (extᵗ τ) X) ≡
-    extᵗ (extᵗ τ) (swap01ᵗ X)
-swap01-ext²-commute τ zero = refl
-swap01-ext²-commute τ (suc zero) = refl
-swap01-ext²-commute τ (suc (suc X)) = refl
-
-renameᵗ-swap01-ext²-commute :
-  ∀ (τ : Renameᵗ) A →
-  renameᵗ swap01ᵗ (renameᵗ (extᵗ (extᵗ τ)) A) ≡
-    renameᵗ (extᵗ (extᵗ τ)) (renameᵗ swap01ᵗ A)
-renameᵗ-swap01-ext²-commute τ A =
-  trans
-    (renameᵗ-compose (extᵗ (extᵗ τ)) swap01ᵗ A)
-    (trans
-      (rename-cong (swap01-ext²-commute τ) A)
-      (sym (renameᵗ-compose swap01ᵗ (extᵗ (extᵗ τ)) A)))
-
-≈∀-renameᵗ :
-  ∀ {τ A B} → A ≈∀ B → renameᵗ τ A ≈∀ renameᵗ τ B
-≈∀-renameᵗ ≈∀-refl = ≈∀-refl
-≈∀-renameᵗ (≈∀-sym A≈B) = ≈∀-sym (≈∀-renameᵗ A≈B)
-≈∀-renameᵗ (≈∀-trans A≈B B≈C) =
-  ≈∀-trans (≈∀-renameᵗ A≈B) (≈∀-renameᵗ B≈C)
-≈∀-renameᵗ (≈∀-⇒ A≈A′ B≈B′) =
-  ≈∀-⇒ (≈∀-renameᵗ A≈A′) (≈∀-renameᵗ B≈B′)
-≈∀-renameᵗ (≈∀-∀ A≈B) = ≈∀-∀ (≈∀-renameᵗ A≈B)
-≈∀-renameᵗ {τ = τ} (≈∀-swap {A = A}) =
-  subst
-    (λ T → `∀ (`∀ (renameᵗ (extᵗ (extᵗ τ)) A)) ≈∀
-      `∀ (`∀ T))
-    (renameᵗ-swap01-ext²-commute τ A)
-    ≈∀-swap
-
-⊑ᵖ-rename-leftᵢ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A B} (τ : Renameᵗ) →
-  (∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  TyRenameWf Δᴸ Δᴸ′ τ →
-  Φ ∣ Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ →
-  Ψ ∣ Δᴸ′ ⊢ renameᵗ τ A ⊑ᵖ B ⊣ Δᴿ
-⊑ᵖ-rename-leftᵢ τ assm hτ (quotientᵖ A≈C C⊑D D≈B) =
-  quotientᵖ (≈∀-renameᵗ A≈C)
-    (⊑-rename-leftᵢ τ assm hτ C⊑D) D≈B
-
-⇑ᴿᵢ-membership :
-  ∀ {Φ a} →
-  a ∈ Φ →
-  ⇑ᴿᵢₐ a ∈ ⇑ᴿᵢ Φ
-⇑ᴿᵢ-membership (here refl) = here refl
-⇑ᴿᵢ-membership (there a∈) = there (⇑ᴿᵢ-membership a∈)
-
-rename-assm²-⇑ᴿᵢ :
-  ∀ {Φ Ψ τ} →
-  (∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  ∀ {a} → a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ τ (λ X → X) a ∈ ⇑ᴿᵢ Ψ
-rename-assm²-⇑ᴿᵢ {Φ = []} assm ()
-rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (here refl) =
-  ⇑ᴿᵢ-membership (assm (here refl))
-rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (here refl) =
-  ⇑ᴿᵢ-membership (assm (here refl))
-rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (there a∈) =
-  rename-assm²-⇑ᴿᵢ (λ b∈ → assm (there b∈)) a∈
-rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (there a∈) =
-  rename-assm²-⇑ᴿᵢ (λ b∈ → assm (there b∈)) a∈
-
-rename-assm²-source-under-right-tailᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ suc (λ X → X) a ∈ ⇑ᴿᵢ (⇑ᴸᵢ Φ)
-rename-assm²-source-under-right-tailᵢ {Φ = []} ()
-rename-assm²-source-under-right-tailᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-source-under-right-tailᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-source-under-right-tailᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
-  there (rename-assm²-source-under-right-tailᵢ a∈)
-rename-assm²-source-under-right-tailᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
-  there (rename-assm²-source-under-right-tailᵢ a∈)
-
-rename-assm²-source-under-rightᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ suc (λ X → X) a ∈
-    ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
-rename-assm²-source-under-rightᵢ a∈ =
-  there (rename-assm²-source-under-right-tailᵢ a∈)
-
-⊑-source-under-rightᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
-    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ B ⊣ suc Δᴿ
-⊑-source-under-rightᵢ =
-  ⊑-rename-leftᵢ suc rename-assm²-source-under-rightᵢ
-    TyRenameWf-suc
-
-data LeftStoreRenameⁱ
-    {Φ Ψ Δᴸ Δᴸ′ Δᴿ}
-    (τ : Renameᵗ)
-    (assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
-    (hτ : TyRenameWf Δᴸ Δᴸ′ τ) :
-    StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ Δᴸ′ Δᴿ → Set where
-  left-store-rename-[] :
-    LeftStoreRenameⁱ τ assm hτ [] []
-
-  left-store-rename-matched :
-    ∀ {ρ ρ′ α α′ A A′ β B p}
-      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-    LeftStoreRenameⁱ τ assm hτ
-      (store-matched α A β B p ∷ ρ)
-      (store-matched α′ A′ β B
-        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′)
-
-  left-store-rename-left :
-    ∀ {ρ ρ′ α α′ A A′ hA hA′}
-      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-    LeftStoreRenameⁱ τ assm hτ
-      (store-left α A hA ∷ ρ)
-      (store-left α′ A′ hA′ ∷ ρ′)
-
-  left-store-rename-right :
-    ∀ {ρ ρ′ β B hB hB′} →
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-    LeftStoreRenameⁱ τ assm hτ
-      (store-right β B hB ∷ ρ)
-      (store-right β B hB′ ∷ ρ′)
-
-  left-store-rename-link :
-    ∀ {ρ ρ′ α α′ A A′ β B p}
-      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-    LeftStoreRenameⁱ τ assm hτ
-      (store-link α A β B p ∷ ρ)
-      (store-link α′ A′ β B
-        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′)
-
-data LeftCtxRenameⁱ
-    {Φ Ψ Δᴸ Δᴸ′ Δᴿ}
-    (τ : Renameᵗ)
-    (assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
-    (hτ : TyRenameWf Δᴸ Δᴸ′ τ) :
-    CtxImp Φ Δᴸ Δᴿ → CtxImp Ψ Δᴸ′ Δᴿ → Set where
-  left-ctx-rename-[] :
-    LeftCtxRenameⁱ τ assm hτ [] []
-
-  left-ctx-rename-∷ :
-    ∀ {γ γ′ A A′ B p} (eqA : A′ ≡ renameᵗ τ A) →
-    LeftCtxRenameⁱ τ assm hτ γ γ′ →
-    LeftCtxRenameⁱ τ assm hτ
-      (ctx-imp A B p ∷ γ)
-      (ctx-imp A′ B
-        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ γ′)
-
-leftStoreⁱ-left-rename :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  leftStoreⁱ ρ′ ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
-leftStoreⁱ-left-rename left-store-rename-[] = refl
-leftStoreⁱ-left-rename
-    (left-store-rename-matched eqα eqA renameρ) =
-  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-left-rename renameρ)
-leftStoreⁱ-left-rename
-    (left-store-rename-left eqα eqA renameρ) =
-  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-left-rename renameρ)
-leftStoreⁱ-left-rename (left-store-rename-right renameρ) =
-  leftStoreⁱ-left-rename renameρ
-leftStoreⁱ-left-rename (left-store-rename-link eqα eqA renameρ) =
-  leftStoreⁱ-left-rename renameρ
-
-rightStoreⁱ-left-rename :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  rightStoreⁱ ρ′ ≡ rightStoreⁱ ρ
-rightStoreⁱ-left-rename left-store-rename-[] = refl
-rightStoreⁱ-left-rename
-    (left-store-rename-matched eqα eqA renameρ) =
-  cong (_ ∷_) (rightStoreⁱ-left-rename renameρ)
-rightStoreⁱ-left-rename (left-store-rename-left eqα eqA renameρ) =
-  rightStoreⁱ-left-rename renameρ
-rightStoreⁱ-left-rename (left-store-rename-right renameρ) =
-  cong (_ ∷_) (rightStoreⁱ-left-rename renameρ)
-rightStoreⁱ-left-rename (left-store-rename-link eqα eqA renameρ) =
-  rightStoreⁱ-left-rename renameρ
-
-leftCtxⁱ-left-rename :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  leftCtxⁱ γ′ ≡ map (renameᵗ τ) (leftCtxⁱ γ)
-leftCtxⁱ-left-rename left-ctx-rename-[] = refl
-leftCtxⁱ-left-rename (left-ctx-rename-∷ eqA renameγ) =
-  cong₂ _∷_ eqA (leftCtxⁱ-left-rename renameγ)
-
-rightCtxⁱ-left-rename :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  rightCtxⁱ γ′ ≡ rightCtxⁱ γ
-rightCtxⁱ-left-rename left-ctx-rename-[] = refl
-rightCtxⁱ-left-rename (left-ctx-rename-∷ eqA renameγ) =
-  cong (_ ∷_) (rightCtxⁱ-left-rename renameγ)
-
-left-typing-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ ψ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M A} →
-  RenameLeftInverse τ ψ →
-  CastModeRenamer τ →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  No• M →
-  Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
-  Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ leftCtxⁱ γ′
-    ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A
-left-typing-renameⁱ {Δᴸ′ = Δᴸ′} {τ = τ} {ψ = ψ} {hτ = hτ}
-    {ρ′ = ρ′} {γ = γ} {γ′ = γ′} {M = M} {A = A}
-    invτ modeτ renameρ renameγ noM M⊢ =
-  subst
-    (λ Γ → Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ Γ
-      ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
-    (sym (leftCtxⁱ-left-rename renameγ))
-    (subst
-      (λ Σ → Δᴸ′ ∣ Σ ∣ map (renameᵗ τ) (leftCtxⁱ γ)
-        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
-      (sym (leftStoreⁱ-left-rename renameρ))
-      (typing-renameᵀ {ρ = τ} {ψ = ψ} hτ invτ modeτ noM M⊢))
-
-right-typing-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M B} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
-  Δᴿ ∣ rightStoreⁱ ρ′ ∣ rightCtxⁱ γ′ ⊢ M ⦂ B
-right-typing-left-renameⁱ {Δᴿ = Δᴿ} {ρ′ = ρ′}
-    {γ = γ} {γ′ = γ′} {M = M} {B = B}
-    renameρ renameγ M⊢ =
-  subst
-    (λ Γ → Δᴿ ∣ rightStoreⁱ ρ′ ∣ Γ ⊢ M ⦂ B)
-    (sym (rightCtxⁱ-left-rename renameγ))
-    (subst
-      (λ Σ → Δᴿ ∣ Σ ∣ rightCtxⁱ γ ⊢ M ⦂ B)
-      (sym (rightStoreⁱ-left-rename renameρ)) M⊢)
-
-left-seal★-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {μ} →
-  (modeτ : CastModeRenamer τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ μ (leftStoreⁱ ρ) →
-  SealModeStore★
-    (CastModeRenamer.targetᵈ modeτ mode) (leftStoreⁱ ρ′)
-left-seal★-renameⁱ modeτ renameρ mode seal★ =
-  subst (SealModeStore★ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (castModeRenamer-seal★ modeτ mode seal★)
-
-left-narrowing-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ c A B} →
-  (modeτ : CastModeRenamer τ) →
-  (mode : CastMode μ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
-  CastModeRenamer.targetᵈ modeτ mode ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
-    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
-left-narrowing-renameⁱ {hτ = hτ} modeτ mode renameρ c⊒ =
-  subst
-    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (narrow-renameᵗ hτ
-      (CastModeRenamer.target-rename modeτ mode) c⊒)
-
-left-widening-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ c A B} →
-  (modeτ : CastModeRenamer τ) →
-  (mode : CastMode μ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
-  CastModeRenamer.targetᵈ modeτ mode ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
-    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
-left-widening-renameⁱ {hτ = hτ} modeτ mode renameρ c⊑ =
-  subst
-    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (widen-renameᵗ hτ
-      (CastModeRenamer.target-rename modeτ mode) c⊑)
-
-modeRename-id-only :
-  ∀ (τ : Renameᵗ) → ModeRename τ id-onlyᵈ id-onlyᵈ
-modeRename-id-only τ X = refl
-
-modeRename-gen-tag-or-id :
-  ∀ (τ : Renameᵗ) →
-  ModeRename τ (genᵈ tag-or-idᵈ) (genᵈ tag-or-idᵈ)
-modeRename-gen-tag-or-id τ zero with τ zero
-modeRename-gen-tag-or-id τ zero | zero = refl
-modeRename-gen-tag-or-id τ zero | suc Y = refl
-modeRename-gen-tag-or-id τ (suc X) with τ (suc X)
-modeRename-gen-tag-or-id τ (suc X) | zero = refl
-modeRename-gen-tag-or-id τ (suc X) | suc Y = refl
-
-left-narrowing-rename-modeⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ ν c A B} →
-  ModeRename τ μ ν →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
-  ν ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
-    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
-left-narrowing-rename-modeⁱ {hτ = hτ} modeτ renameρ c⊒ =
-  subst
-    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (narrow-renameᵗ hτ modeτ c⊒)
-
-left-widening-rename-modeⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ ν c A B} →
-  ModeRename τ μ ν →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
-  ν ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
-    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
-left-widening-rename-modeⁱ {hτ = hτ} modeτ renameρ c⊑ =
-  subst
-    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (widen-renameᵗ hτ modeτ c⊑)
-
-left-reveal-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ α X c A B} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
-  RevealConversion (left-insertion-mode ins μ) Δᴸ′
-    (leftStoreⁱ ρ′) (τ α) (renameᵗ τ X)
-    (renameᶜ τ c) (renameᵗ τ A) (renameᵗ τ B)
-left-reveal-renameⁱ {hτ = hτ} ins renameρ conv =
-  subst
-    (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (rename-reveal-conversion hτ
-      (left-insertion-mode-rename ins _) conv)
-
-left-reveal-ν-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ A B C s} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion
-    (left-insertion-mode (left-insertion-ext ins) μ)
-    (suc Δᴸ′)
-    ((zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
-    zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
-    (renameᵗ (extᵗ τ) C) (⇑ᵗ (renameᵗ τ B))
-left-reveal-ν-renameⁱ
-    {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
-    {μ = μ} {A = A} {B = B} {C = C} {s = s}
-    ins renameρ conv =
-  subst
-    (λ D → RevealConversion target-mode (suc Δᴸ′) target-store
-      zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
-      (renameᵗ (extᵗ τ) C) D)
-    (renameᵗ-ext-suc-comm τ B)
-    (subst
-      (λ X → RevealConversion target-mode (suc Δᴸ′) target-store
-        zero X (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
-        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
-      (renameᵗ-ext-suc-comm τ A)
-      store-normalized)
-  where
-  target-mode = left-insertion-mode (left-insertion-ext ins) μ
-
-  target-store =
-    (zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
-
-  store-eq =
-    trans
-      (renameStoreᵗ-ext-suc-cons-comm τ (leftStoreⁱ ρ) A)
-      (cong ((zero , ⇑ᵗ (renameᵗ τ A)) ∷_)
-        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
-
-  renamed :
-    RevealConversion target-mode (suc Δᴸ′)
-      (renameStoreᵗ (extᵗ τ)
-        ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ)))
-      zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
-      (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
-      (renameᵗ (extᵗ τ) (⇑ᵗ B))
-  renamed =
-    rename-reveal-conversion (TyRenameWf-ext hτ)
-      (left-insertion-mode-rename (left-insertion-ext ins) μ) conv
-
-  store-normalized :
-    RevealConversion target-mode (suc Δᴸ′) target-store
-      zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
-      (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
-      (renameᵗ (extᵗ τ) (⇑ᵗ B))
-  store-normalized =
-    subst
-      (λ Σ → RevealConversion target-mode (suc Δᴸ′) Σ
-        zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
-        (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
-        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
-      store-eq renamed
-
-right-reveal-ν-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ A B C s} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
-    zero (⇑ᵗ A) s C (⇑ᵗ B)
-right-reveal-ν-left-renameⁱ
-    {Δᴿ = Δᴿ} {μ = μ} {A = A} {B = B} {C = C} {s = s}
-    renameρ conv =
-  subst
-    (λ Σ → RevealConversion μ (suc Δᴿ) Σ
-      zero (⇑ᵗ A) s C (⇑ᵗ B))
-    (cong ((zero , ⇑ᵗ A) ∷_)
-      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
-    conv
-
-renameStoreᵗ-ext-★-cons-comm :
-  ∀ (τ : Renameᵗ) (Σ : Store) →
-  renameStoreᵗ (extᵗ τ) ((zero , ★) ∷ ⟰ᵗ Σ) ≡
-    (zero , ★) ∷ ⟰ᵗ (renameStoreᵗ τ Σ)
-renameStoreᵗ-ext-★-cons-comm τ Σ =
-  cong ((zero , ★) ∷_) (renameStoreᵗ-ext-suc-comm τ Σ)
-
-left-seal★-ν★-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  SealModeStore★
-    (instᵈ (CastModeRenamer.targetᵈ
-      (left-insertion-cast-renamer ins) mode))
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
-left-seal★-ν★-renameⁱ {τ = τ} {ρ = ρ} ins renameρ mode seal★ =
-  subst (SealModeStore★ _)
-    store-eq
-    (castModeRenamer-seal★
-      (castModeRenamer-ext (left-insertion-cast-renamer ins))
-      (cast-inst mode) seal★)
-  where
-  store-eq =
-    trans
-      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
-      (cong ((zero , ★) ∷_)
-        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
-
-right-seal★-ν★-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
-right-seal★-ν★-left-renameⁱ renameρ seal★ =
-  subst (SealModeStore★ _)
-    (cong ((zero , ★) ∷_)
-      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
-    seal★
-
-left-widening-ν★-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ c C B} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  (mode : CastMode μ) →
-  instᵈ μ ∣ suc Δᴸ
-    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ c ∶ C ⊑ ⇑ᵗ B →
-  instᵈ (CastModeRenamer.targetᵈ
-      (left-insertion-cast-renamer ins) mode)
-    ∣ suc Δᴸ′ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
-    ⊢ renameᶜ (extᵗ τ) c
-    ∶ renameᵗ (extᵗ τ) C ⊑ ⇑ᵗ (renameᵗ τ B)
-left-widening-ν★-renameⁱ
-    {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
-    {μ = μ} {c = c} {C = C} {B = B}
-    ins renameρ mode c⊑ =
-  subst
-    (λ D → instᵈ target-mode ∣ suc Δᴸ′ ∣ target-store
-      ⊢ renameᶜ (extᵗ τ) c
-      ∶ renameᵗ (extᵗ τ) C ⊑ D)
-    (renameᵗ-ext-suc-comm τ B)
-    store-normalized
-  where
-  modeτ = left-insertion-cast-renamer ins
-  target-mode = CastModeRenamer.targetᵈ modeτ mode
-  target-store = (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
-
-  store-eq =
-    trans
-      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
-      (cong ((zero , ★) ∷_)
-        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
-
-  renamed :
-    instᵈ target-mode ∣ suc Δᴸ′ ∣
-      renameStoreᵗ (extᵗ τ)
-        ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-      ⊢ renameᶜ (extᵗ τ) c
-      ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B)
-  renamed =
-    widen-renameᵗ (TyRenameWf-ext hτ)
-      (CastModeRenamer.target-rename
-        (castModeRenamer-ext modeτ) (cast-inst mode)) c⊑
-
-  store-normalized :
-    instᵈ target-mode ∣ suc Δᴸ′ ∣ target-store
-      ⊢ renameᶜ (extᵗ τ) c
-      ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B)
-  store-normalized =
-    subst
-      (λ Σ → instᵈ target-mode ∣ suc Δᴸ′ ∣ Σ
-        ⊢ renameᶜ (extᵗ τ) c
-        ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B))
-      store-eq renamed
-
-right-widening-ν★-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ c C B} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  instᵈ μ ∣ suc Δᴿ
-    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ c ∶ C ⊑ ⇑ᵗ B →
-  instᵈ μ ∣ suc Δᴿ
-    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
-    ⊢ c ∶ C ⊑ ⇑ᵗ B
-right-widening-ν★-left-renameⁱ
-    {Δᴿ = Δᴿ} {μ = μ} {c = c} {C = C} {B = B}
-    renameρ c⊑ =
-  subst
-    (λ Σ → instᵈ μ ∣ suc Δᴿ ∣ Σ ⊢ c ∶ C ⊑ ⇑ᵗ B)
-    (cong ((zero , ★) ∷_)
-      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
-    c⊑
-
-left-conceal-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ α X c A B} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
-  ConcealConversion (left-insertion-mode ins μ) Δᴸ′
-    (leftStoreⁱ ρ′) (τ α) (renameᵗ τ X)
-    (renameᶜ τ c) (renameᵗ τ A) (renameᵗ τ B)
-left-conceal-renameⁱ {hτ = hτ} ins renameρ conv =
-  subst
-    (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
-    (sym (leftStoreⁱ-left-rename renameρ))
-    (rename-conceal-conversion hτ
-      (left-insertion-mode-rename ins _) conv)
-
-right-reveal-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ β X c A B} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  RevealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
-  RevealConversion μ Δᴿ (rightStoreⁱ ρ′) β X c A B
-right-reveal-left-renameⁱ renameρ conv =
-  subst
-    (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
-    (sym (rightStoreⁱ-left-rename renameρ)) conv
-
-right-conceal-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ β X c A B} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  ConcealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
-  ConcealConversion μ Δᴿ (rightStoreⁱ ρ′) β X c A B
-right-conceal-left-renameⁱ renameρ conv =
-  subst
-    (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
-    (sym (rightStoreⁱ-left-rename renameρ)) conv
-
-right-seal★-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  SealModeStore★ μ (rightStoreⁱ ρ) →
-  SealModeStore★ μ (rightStoreⁱ ρ′)
-right-seal★-left-renameⁱ renameρ seal★ =
-  subst (SealModeStore★ _)
-    (sym (rightStoreⁱ-left-rename renameρ)) seal★
-
-right-widening-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ c A B} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊑ B →
-  μ ∣ Δᴿ ∣ rightStoreⁱ ρ′ ⊢ c ∶ A ⊑ B
-right-widening-left-renameⁱ renameρ c⊑ =
-  subst
-    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
-    (sym (rightStoreⁱ-left-rename renameρ)) c⊑
-
-right-narrowing-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {μ c A B} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
-  μ ∣ Δᴿ ∣ rightStoreⁱ ρ′ ⊢ c ∶ A ⊒ B
-right-narrowing-left-renameⁱ renameρ c⊒ =
-  subst
-    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
-    (sym (rightStoreⁱ-left-rename renameρ)) c⊒
-
-right-store-det-left-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  StoreDetWf Δᴿ (rightStoreⁱ ρ) →
-  StoreDetWf Δᴿ (rightStoreⁱ ρ′)
-right-store-det-left-renameⁱ renameρ wfΣ =
-  subst (StoreDetWf _)
-    (sym (rightStoreⁱ-left-rename renameρ)) wfΣ
-
-left-store-rename-∀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
-  ∃[ ρ′∀ ]
-    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
-    LeftStoreRenameⁱ
-      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
-      ρ∀ ρ′∀
-left-store-rename-∀ left-store-rename-[] lift-store-[] =
-  [] , lift-store-[] , left-store-rename-[]
-left-store-rename-∀
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    (lift-store-∷ {p′ = p∀} liftρ)
-    with left-store-rename-∀ renameρ liftρ
-left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      {β = β} {B = B} eqα eqA renameρ)
-    (lift-store-∷ {A = A} {p′ = p∀} liftρ)
-    | ρ′∀ , liftρ′ , renameρ∀ =
-  store-matched (suc α′) (⇑ᵗ A′) (suc β) (⇑ᵗ B)
-      (⊑-rename-left-atᵢ
-        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
-        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ ρ′∀ ,
-  lift-store-∷ liftρ′ ,
-  left-store-rename-matched (cong suc eqα) eqA∀ renameρ∀
-  where
-  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-left-store-rename-∀
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    (lift-store-left liftρ)
-    with left-store-rename-∀ renameρ liftρ
-left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    (lift-store-left {A = A} liftρ)
-    | ρ′∀ , liftρ′ , renameρ∀ =
-  store-left (suc α′) (⇑ᵗ A′)
-      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′∀ ,
-  lift-store-left liftρ′ ,
-  left-store-rename-left (cong suc eqα) eqA∀ renameρ∀
-  where
-  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-left-store-rename-∀
-    (left-store-rename-right {hB′ = hB′} renameρ)
-    (lift-store-right liftρ)
-    with left-store-rename-∀ renameρ liftρ
-left-store-rename-∀
-    (left-store-rename-right {β = β} {B = B} {hB′ = hB′} renameρ)
-    (lift-store-right liftρ)
-    | ρ′∀ , liftρ′ , renameρ∀ =
-  store-right (suc β) (⇑ᵗ B)
-      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′∀ ,
-  lift-store-right liftρ′ ,
-  left-store-rename-right renameρ∀
-left-store-rename-∀
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    (lift-store-link {p′ = p∀} liftρ)
-    with left-store-rename-∀ renameρ liftρ
-left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      {β = β} {B = B} eqα eqA renameρ)
-    (lift-store-link {A = A} {p′ = p∀} liftρ)
-    | ρ′∀ , liftρ′ , renameρ∀ =
-  store-link (suc α′) (⇑ᵗ A′) (suc β) (⇑ᵗ B)
-      (⊑-rename-left-atᵢ
-        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
-        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ ρ′∀ ,
-  lift-store-link liftρ′ ,
-  left-store-rename-link (cong suc eqα) eqA∀ renameρ∀
-  where
-  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-
-left-ctx-rename-∀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
-  ∃[ γ′∀ ]
-    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
-    LeftCtxRenameⁱ
-      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
-      γ∀ γ′∀
-left-ctx-rename-∀ left-ctx-rename-[] lift-ctx-[] =
-  [] , lift-ctx-[] , left-ctx-rename-[]
-left-ctx-rename-∀
-    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
-    (lift-ctx-∷ {p′ = p∀} liftγ)
-    with left-ctx-rename-∀ renameγ liftγ
-left-ctx-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
-    (lift-ctx-∷ {A = A} {p′ = p∀} liftγ)
-    | γ′∀ , liftγ′ , renameγ∀ =
-  ctx-imp (⇑ᵗ A′) (⇑ᵗ B)
-      (⊑-rename-left-atᵢ
-        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
-        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ γ′∀ ,
-  lift-ctx-∷ liftγ′ ,
-  left-ctx-rename-∷ eqA∀ renameγ∀
-  where
-  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-
-left-store-rename-ν :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
-  ∃[ ρ′ν ]
-    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
-    LeftStoreRenameⁱ
-      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
-      ρν ρ′ν
-left-store-rename-ν left-store-rename-[] lift-left-store-[] =
-  [] , lift-left-store-[] , left-store-rename-[]
-left-store-rename-ν
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    (lift-left-store-∷ {p′ = pν} liftρ)
-    with left-store-rename-ν renameρ liftρ
-left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      {β = β} {B = B} eqα eqA renameρ)
-    (lift-left-store-∷ {A = A} {p′ = pν} liftρ)
-    | ρ′ν , liftρ′ , renameρν =
-  store-matched (suc α′) (⇑ᵗ A′) β B
-      (⊑-rename-left-atᵢ
-        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
-        (TyRenameWf-ext hτ) eqAν pν) ∷ ρ′ν ,
-  lift-left-store-∷ liftρ′ ,
-  left-store-rename-matched (cong suc eqα) eqAν renameρν
-  where
-  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-left-store-rename-ν
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    (lift-left-store-left liftρ)
-    with left-store-rename-ν renameρ liftρ
-left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    (lift-left-store-left {A = A} liftρ)
-    | ρ′ν , liftρ′ , renameρν =
-  store-left (suc α′) (⇑ᵗ A′)
-      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′ν ,
-  lift-left-store-left liftρ′ ,
-  left-store-rename-left (cong suc eqα) eqAν renameρν
-  where
-  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-left-store-rename-ν
-    (left-store-rename-right {hB′ = hB′} renameρ)
-    (lift-left-store-right liftρ)
-    with left-store-rename-ν renameρ liftρ
-left-store-rename-ν
-    (left-store-rename-right {β = β} {B = B} {hB′ = hB′} renameρ)
-    (lift-left-store-right liftρ)
-    | ρ′ν , liftρ′ , renameρν =
-  store-right β B hB′ ∷ ρ′ν ,
-  lift-left-store-right liftρ′ ,
-  left-store-rename-right renameρν
-left-store-rename-ν
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    (lift-left-store-link {p′ = pν} liftρ)
-    with left-store-rename-ν renameρ liftρ
-left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      {β = β} {B = B} eqα eqA renameρ)
-    (lift-left-store-link {A = A} {p′ = pν} liftρ)
-    | ρ′ν , liftρ′ , renameρν =
-  store-link (suc α′) (⇑ᵗ A′) β B
-      (⊑-rename-left-atᵢ
-        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
-        (TyRenameWf-ext hτ) eqAν pν) ∷ ρ′ν ,
-  lift-left-store-link liftρ′ ,
-  left-store-rename-link (cong suc eqα) eqAν renameρν
-  where
-  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-
-left-ctx-rename-ν :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
-  ∃[ γ′ν ]
-    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
-    LeftCtxRenameⁱ
-      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
-      γν γ′ν
-left-ctx-rename-ν left-ctx-rename-[] lift-left-ctx-[] =
-  [] , lift-left-ctx-[] , left-ctx-rename-[]
-left-ctx-rename-ν
-    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
-    (lift-left-ctx-∷ {p′ = pν} liftγ)
-    with left-ctx-rename-ν renameγ liftγ
-left-ctx-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
-    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
-    (lift-left-ctx-∷ {A = A} {p′ = pν} liftγ)
-    | γ′ν , liftγ′ , renameγν =
-  ctx-imp (⇑ᵗ A′) B
-      (⊑-rename-left-atᵢ
-        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
-        (TyRenameWf-ext hτ) eqAν pν) ∷ γ′ν ,
-  lift-left-ctx-∷ liftγ′ ,
-  left-ctx-rename-∷ eqAν renameγν
-  where
-  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
-  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
-
-left-store-rename-ν-inv :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {ρ′ν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
-      (suc Δᴸ′) Δᴿ} →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
-  LeftStoreRenameⁱ
-    (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
-    ρν ρ′ν →
-  ∃[ ρ′ ]
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ ×
-    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν
-left-store-rename-ν-inv
-    lift-left-store-[] left-store-rename-[] =
-  [] , left-store-rename-[] , lift-left-store-[]
-left-store-rename-ν-inv
-    {ρ = store-matched α A β B p ∷ ρ}
-    (lift-left-store-∷ liftρ)
-    (left-store-rename-matched eqα eqA renameρ)
-    with left-store-rename-ν-inv liftρ renameρ
-left-store-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρ = store-matched α A β B p ∷ ρ}
-    (lift-left-store-∷ liftρ)
-    (left-store-rename-matched eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ with eqα
-left-store-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρ = store-matched α A β B p ∷ ρ}
-    (lift-left-store-∷ liftρ)
-    (left-store-rename-matched eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ | refl
-    with trans eqA (renameᵗ-ext-suc-comm τ A)
-left-store-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρ = store-matched α A β B p ∷ ρ}
-    (lift-left-store-∷ liftρ)
-    (left-store-rename-matched eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ | refl | refl =
-  store-matched (τ α) (renameᵗ τ A) β B
-      (⊑-rename-leftᵢ τ assm hτ p) ∷ ρ′ ,
-  left-store-rename-matched refl refl renameρ′ ,
-  lift-left-store-∷ liftρ′
-left-store-rename-ν-inv
-    {ρ = store-left α A hA ∷ ρ}
-    (lift-left-store-left liftρ)
-    (left-store-rename-left eqα eqA renameρ)
-    with left-store-rename-ν-inv liftρ renameρ
-left-store-rename-ν-inv {τ = τ} {hτ = hτ}
-    {ρ = store-left α A hA ∷ ρ}
-    (lift-left-store-left liftρ)
-    (left-store-rename-left eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ with eqα
-left-store-rename-ν-inv {τ = τ} {hτ = hτ}
-    {ρ = store-left α A hA ∷ ρ}
-    (lift-left-store-left liftρ)
-    (left-store-rename-left eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ | refl
-    with trans eqA (renameᵗ-ext-suc-comm τ A)
-left-store-rename-ν-inv {τ = τ} {hτ = hτ}
-    {ρ = store-left α A hA ∷ ρ}
-    (lift-left-store-left liftρ)
-    (left-store-rename-left eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ | refl | refl =
-  store-left (τ α) (renameᵗ τ A)
-      (renameᵗ-preserves-WfTy hA hτ) ∷ ρ′ ,
-  left-store-rename-left refl refl renameρ′ ,
-  lift-left-store-left liftρ′
-left-store-rename-ν-inv
-    {ρ = store-right β B hB ∷ ρ}
-    (lift-left-store-right liftρ)
-    (left-store-rename-right renameρ)
-    with left-store-rename-ν-inv liftρ renameρ
-left-store-rename-ν-inv
-    {ρ = store-right β B hB ∷ ρ}
-    (lift-left-store-right liftρ)
-    (left-store-rename-right renameρ)
-    | ρ′ , renameρ′ , liftρ′ =
-  store-right β B hB ∷ ρ′ ,
-  left-store-rename-right renameρ′ ,
-  lift-left-store-right liftρ′
-left-store-rename-ν-inv
-    {ρ = store-link α A β B p ∷ ρ}
-    (lift-left-store-link liftρ)
-    (left-store-rename-link eqα eqA renameρ)
-    with left-store-rename-ν-inv liftρ renameρ
-left-store-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρ = store-link α A β B p ∷ ρ}
-    (lift-left-store-link liftρ)
-    (left-store-rename-link eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ with eqα
-left-store-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρ = store-link α A β B p ∷ ρ}
-    (lift-left-store-link liftρ)
-    (left-store-rename-link eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ | refl
-    with trans eqA (renameᵗ-ext-suc-comm τ A)
-left-store-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρ = store-link α A β B p ∷ ρ}
-    (lift-left-store-link liftρ)
-    (left-store-rename-link eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ | refl | refl =
-  store-link (τ α) (renameᵗ τ A) β B
-      (⊑-rename-leftᵢ τ assm hτ p) ∷ ρ′ ,
-  left-store-rename-link refl refl renameρ′ ,
-  lift-left-store-link liftρ′
-
-left-ctx-rename-ν-inv :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γ′ν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
-      (suc Δᴸ′) Δᴿ} →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
-  LeftCtxRenameⁱ
-    (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
-    γν γ′ν →
-  ∃[ γ′ ]
-    LeftCtxRenameⁱ τ assm hτ γ γ′ ×
-    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν
-left-ctx-rename-ν-inv lift-left-ctx-[] left-ctx-rename-[] =
-  [] , left-ctx-rename-[] , lift-left-ctx-[]
-left-ctx-rename-ν-inv
-    {γ = ctx-imp A B p ∷ γ}
-    (lift-left-ctx-∷ liftγ)
-    (left-ctx-rename-∷ eqA renameγ)
-    with left-ctx-rename-ν-inv liftγ renameγ
-left-ctx-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {γ = ctx-imp A B p ∷ γ}
-    (lift-left-ctx-∷ liftγ)
-    (left-ctx-rename-∷ eqA renameγ)
-    | γ′ , renameγ′ , liftγ′
-    with trans eqA (renameᵗ-ext-suc-comm τ A)
-left-ctx-rename-ν-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {γ = ctx-imp A B p ∷ γ}
-    (lift-left-ctx-∷ liftγ)
-    (left-ctx-rename-∷ eqA renameγ)
-    | γ′ , renameγ′ , liftγ′ | refl =
-  ctx-imp (renameᵗ τ A) B (⊑-rename-leftᵢ τ assm hτ p) ∷ γ′ ,
-  left-ctx-rename-∷ refl renameγ′ ,
-  lift-left-ctx-∷ liftγ′
-
-left-store-rename-suc-liftⁱ :
-  ∀ {Φ Δᴸ Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc ρ ρ′ →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
-left-store-rename-suc-liftⁱ left-store-rename-[] =
-  lift-left-store-[]
-left-store-rename-suc-liftⁱ
-    {ρ = store-matched α A β B p ∷ ρ}
-    (left-store-rename-matched eqα eqA renameρ)
-    with eqα
-left-store-rename-suc-liftⁱ
-    {ρ = store-matched α A β B p ∷ ρ}
-    (left-store-rename-matched eqα eqA renameρ) | refl
-    with eqA
-left-store-rename-suc-liftⁱ
-    {ρ = store-matched α A β B p ∷ ρ}
-    (left-store-rename-matched eqα eqA renameρ) | refl | refl =
-  lift-left-store-∷ (left-store-rename-suc-liftⁱ renameρ)
-left-store-rename-suc-liftⁱ
-    {ρ = store-left α A hA ∷ ρ}
-    (left-store-rename-left eqα eqA renameρ)
-    with eqα
-left-store-rename-suc-liftⁱ
-    {ρ = store-left α A hA ∷ ρ}
-    (left-store-rename-left eqα eqA renameρ) | refl
-    with eqA
-left-store-rename-suc-liftⁱ
-    {ρ = store-left α A hA ∷ ρ}
-    (left-store-rename-left eqα eqA renameρ) | refl | refl =
-  lift-left-store-left (left-store-rename-suc-liftⁱ renameρ)
-left-store-rename-suc-liftⁱ
-    {ρ = store-right β B hB ∷ ρ}
-    (left-store-rename-right renameρ) =
-  lift-left-store-right (left-store-rename-suc-liftⁱ renameρ)
-left-store-rename-suc-liftⁱ
-    {ρ = store-link α A β B p ∷ ρ}
-    (left-store-rename-link eqα eqA renameρ)
-    with eqα
-left-store-rename-suc-liftⁱ
-    {ρ = store-link α A β B p ∷ ρ}
-    (left-store-rename-link eqα eqA renameρ) | refl
-    with eqA
-left-store-rename-suc-liftⁱ
-    {ρ = store-link α A β B p ∷ ρ}
-    (left-store-rename-link eqα eqA renameρ) | refl | refl =
-  lift-left-store-link (left-store-rename-suc-liftⁱ renameρ)
-
-left-store-rename-⇑ᴿ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  ∃[ ρ′ᴿ ]
-    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
-    LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ ρᴿ ρ′ᴿ
-left-store-rename-⇑ᴿ left-store-rename-[] lift-right-store-[] =
-  [] , lift-right-store-[] , left-store-rename-[]
-left-store-rename-⇑ᴿ
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    (lift-right-store-∷ {p′ = pᴿ} liftρ)
-    with left-store-rename-⇑ᴿ renameρ liftρ
-left-store-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      {β = β} {B = B} eqα eqA renameρ)
-    (lift-right-store-∷ {p′ = pᴿ} liftρ)
-    | ρ′ᴿ , liftρ′ , renameρᴿ =
-  store-matched α′ A′ (suc β) (⇑ᵗ B)
-      (⊑-rename-left-atᵢ
-        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ ρ′ᴿ ,
-  lift-right-store-∷ liftρ′ ,
-  left-store-rename-matched eqα eqA renameρᴿ
-left-store-rename-⇑ᴿ
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    (lift-right-store-left liftρ)
-    with left-store-rename-⇑ᴿ renameρ liftρ
-left-store-rename-⇑ᴿ
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    (lift-right-store-left liftρ)
-    | ρ′ᴿ , liftρ′ , renameρᴿ =
-  store-left α′ A′ hA′ ∷ ρ′ᴿ ,
-  lift-right-store-left liftρ′ ,
-  left-store-rename-left eqα eqA renameρᴿ
-left-store-rename-⇑ᴿ
-    (left-store-rename-right renameρ)
-    (lift-right-store-right liftρ)
-    with left-store-rename-⇑ᴿ renameρ liftρ
-left-store-rename-⇑ᴿ
-    (left-store-rename-right {β = β} {B = B} renameρ)
-    (lift-right-store-right {hB′ = hBᴿ} liftρ)
-    | ρ′ᴿ , liftρ′ , renameρᴿ =
-  store-right (suc β) (⇑ᵗ B) hBᴿ ∷ ρ′ᴿ ,
-  lift-right-store-right liftρ′ ,
-  left-store-rename-right renameρᴿ
-left-store-rename-⇑ᴿ
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    (lift-right-store-link {p′ = pᴿ} liftρ)
-    with left-store-rename-⇑ᴿ renameρ liftρ
-left-store-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      {β = β} {B = B} eqα eqA renameρ)
-    (lift-right-store-link {p′ = pᴿ} liftρ)
-    | ρ′ᴿ , liftρ′ , renameρᴿ =
-  store-link α′ A′ (suc β) (⇑ᵗ B)
-      (⊑-rename-left-atᵢ
-        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ ρ′ᴿ ,
-  lift-right-store-link liftρ′ ,
-  left-store-rename-link eqα eqA renameρᴿ
-
-left-ctx-rename-⇑ᴿ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  ∃[ γ′ᴿ ]
-    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ ×
-    LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ
-left-ctx-rename-⇑ᴿ left-ctx-rename-[] lift-right-ctx-[] =
-  [] , lift-right-ctx-[] , left-ctx-rename-[]
-left-ctx-rename-⇑ᴿ
-    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
-    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
-    with left-ctx-rename-⇑ᴿ renameγ liftγ
-left-ctx-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
-    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
-    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
-    | γ′ᴿ , liftγ′ , renameγᴿ =
-  ctx-imp A′ (⇑ᵗ B)
-      (⊑-rename-left-atᵢ
-        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ γ′ᴿ ,
-  lift-right-ctx-∷ liftγ′ ,
-  left-ctx-rename-∷ eqA renameγᴿ
-
-left-store-rename-⇑ᴿ-inv :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {ρ′ᴿ : StoreImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)} →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ ρᴿ ρ′ᴿ →
-  ∃[ ρ′ ]
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ ×
-    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ
-left-store-rename-⇑ᴿ-inv
-    lift-right-store-[] left-store-rename-[] =
-  [] , left-store-rename-[] , lift-right-store-[]
-left-store-rename-⇑ᴿ-inv
-    (lift-right-store-∷ {p = p} liftρ)
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    with left-store-rename-⇑ᴿ-inv liftρ renameρ
-left-store-rename-⇑ᴿ-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    (lift-right-store-∷ {p = p} liftρ)
-    (left-store-rename-matched {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ =
-  store-matched α′ A′ _ _
-      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′ ,
-  left-store-rename-matched eqα eqA renameρ′ ,
-  lift-right-store-∷ liftρ′
-left-store-rename-⇑ᴿ-inv
-    (lift-right-store-left liftρ)
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    with left-store-rename-⇑ᴿ-inv liftρ renameρ
-left-store-rename-⇑ᴿ-inv
-    (lift-right-store-left liftρ)
-    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
-      eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ =
-  store-left α′ A′ hA′ ∷ ρ′ ,
-  left-store-rename-left eqα eqA renameρ′ ,
-  lift-right-store-left liftρ′
-left-store-rename-⇑ᴿ-inv
-    (lift-right-store-right {hB = hB} liftρ)
-    (left-store-rename-right renameρ)
-    with left-store-rename-⇑ᴿ-inv liftρ renameρ
-left-store-rename-⇑ᴿ-inv
-    (lift-right-store-right {hB = hB} liftρ)
-    (left-store-rename-right renameρ)
-    | ρ′ , renameρ′ , liftρ′ =
-  store-right _ _ hB ∷ ρ′ ,
-  left-store-rename-right renameρ′ ,
-  lift-right-store-right liftρ′
-left-store-rename-⇑ᴿ-inv
-    (lift-right-store-link {p = p} liftρ)
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    with left-store-rename-⇑ᴿ-inv liftρ renameρ
-left-store-rename-⇑ᴿ-inv
-    {τ = τ} {assm = assm} {hτ = hτ}
-    (lift-right-store-link {p = p} liftρ)
-    (left-store-rename-link {α′ = α′} {A′ = A′}
-      eqα eqA renameρ)
-    | ρ′ , renameρ′ , liftρ′ =
-  store-link α′ A′ _ _
-      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′ ,
-  left-store-rename-link eqα eqA renameρ′ ,
-  lift-right-store-link liftρ′
-
-left-ctx-rename-⇑ᴿ-inv :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {γ′ᴿ : CtxImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)} →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ →
-  ∃[ γ′ ]
-    LeftCtxRenameⁱ τ assm hτ γ γ′ ×
-    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ
-left-ctx-rename-⇑ᴿ-inv lift-right-ctx-[] left-ctx-rename-[] =
-  [] , left-ctx-rename-[] , lift-right-ctx-[]
-left-ctx-rename-⇑ᴿ-inv
-    (lift-right-ctx-∷ {p = p} liftγ)
-    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
-    with left-ctx-rename-⇑ᴿ-inv liftγ renameγ
-left-ctx-rename-⇑ᴿ-inv {τ = τ} {assm = assm} {hτ = hτ}
-    (lift-right-ctx-∷ {p = p} liftγ)
-    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
-    | γ′ , renameγ′ , liftγ′ =
-  ctx-imp A′ _ (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ γ′ ,
-  left-ctx-rename-∷ eqA renameγ′ ,
-  lift-right-ctx-∷ liftγ′
-
-rename-left-storeⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ) →
-  (∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  TyRenameWf Δᴸ Δᴸ′ τ →
-  StoreImp Φ Δᴸ Δᴿ →
-  StoreImp Ψ Δᴸ′ Δᴿ
-rename-left-storeⁱ τ assm hτ [] = []
-rename-left-storeⁱ τ assm hτ
-    (store-matched α A β B p ∷ ρ) =
-  store-matched (τ α) (renameᵗ τ A) β B
-    (⊑-rename-leftᵢ τ assm hτ p) ∷
-  rename-left-storeⁱ τ assm hτ ρ
-rename-left-storeⁱ τ assm hτ (store-left α A hA ∷ ρ) =
-  store-left (τ α) (renameᵗ τ A)
-    (renameᵗ-preserves-WfTy hA hτ) ∷
-  rename-left-storeⁱ τ assm hτ ρ
-rename-left-storeⁱ τ assm hτ (store-right β B hB ∷ ρ) =
-  store-right β B hB ∷ rename-left-storeⁱ τ assm hτ ρ
-rename-left-storeⁱ τ assm hτ (store-link α A β B p ∷ ρ) =
-  store-link (τ α) (renameᵗ τ A) β B
-    (⊑-rename-leftᵢ τ assm hτ p) ∷
-  rename-left-storeⁱ τ assm hτ ρ
-
-rename-left-store-coherentⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ)
-    (assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
-    (hτ : TyRenameWf Δᴸ Δᴸ′ τ)
-    (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  LeftStoreRenameⁱ τ assm hτ ρ
-    (rename-left-storeⁱ τ assm hτ ρ)
-rename-left-store-coherentⁱ τ assm hτ [] =
-  left-store-rename-[]
-rename-left-store-coherentⁱ τ assm hτ
-    (store-matched α A β B p ∷ ρ) =
-  left-store-rename-matched refl refl
-    (rename-left-store-coherentⁱ τ assm hτ ρ)
-rename-left-store-coherentⁱ τ assm hτ
-    (store-left α A hA ∷ ρ) =
-  left-store-rename-left refl refl
-    (rename-left-store-coherentⁱ τ assm hτ ρ)
-rename-left-store-coherentⁱ τ assm hτ
-    (store-right β B hB ∷ ρ) =
-  left-store-rename-right
-    (rename-left-store-coherentⁱ τ assm hτ ρ)
-rename-left-store-coherentⁱ τ assm hτ
-    (store-link α A β B p ∷ ρ) =
-  left-store-rename-link refl refl
-    (rename-left-store-coherentⁱ τ assm hτ ρ)
-
-rename-left-store-source-liftⁱ :
-  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ
-    (rename-left-storeⁱ suc rename-assm²-source-νᵢ
-      TyRenameWf-suc ρ)
-rename-left-store-source-liftⁱ [] = lift-left-store-[]
-rename-left-store-source-liftⁱ
-    (store-matched α A β B p ∷ ρ) =
-  lift-left-store-∷ (rename-left-store-source-liftⁱ ρ)
-rename-left-store-source-liftⁱ (store-left α A hA ∷ ρ) =
-  lift-left-store-left (rename-left-store-source-liftⁱ ρ)
-rename-left-store-source-liftⁱ (store-right β B hB ∷ ρ) =
-  lift-left-store-right (rename-left-store-source-liftⁱ ρ)
-rename-left-store-source-liftⁱ (store-link α A β B p ∷ ρ) =
-  lift-left-store-link (rename-left-store-source-liftⁱ ρ)
-
-leftStoreⁱ-rename-left :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  leftStoreⁱ
-      (rename-left-storeⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ ρ)
-    ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
-leftStoreⁱ-rename-left [] = refl
-leftStoreⁱ-rename-left (store-matched α A β B p ∷ ρ) =
-  cong ((_,_ _ _) ∷_) (leftStoreⁱ-rename-left ρ)
-leftStoreⁱ-rename-left (store-left α A hA ∷ ρ) =
-  cong ((_,_ _ _) ∷_) (leftStoreⁱ-rename-left ρ)
-leftStoreⁱ-rename-left (store-right β B hB ∷ ρ) =
-  leftStoreⁱ-rename-left ρ
-leftStoreⁱ-rename-left (store-link α A β B p ∷ ρ) =
-  leftStoreⁱ-rename-left ρ
-
-rightStoreⁱ-rename-left :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  rightStoreⁱ
-      (rename-left-storeⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ ρ)
-    ≡ rightStoreⁱ ρ
-rightStoreⁱ-rename-left [] = refl
-rightStoreⁱ-rename-left (store-matched α A β B p ∷ ρ) =
-  cong ((_,_ _ _) ∷_) (rightStoreⁱ-rename-left ρ)
-rightStoreⁱ-rename-left (store-left α A hA ∷ ρ) =
-  rightStoreⁱ-rename-left ρ
-rightStoreⁱ-rename-left (store-right β B hB ∷ ρ) =
-  cong ((_,_ _ _) ∷_) (rightStoreⁱ-rename-left ρ)
-rightStoreⁱ-rename-left (store-link α A β B p ∷ ρ) =
-  rightStoreⁱ-rename-left ρ
-
-rename-left-ctxⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ) →
-  (∀ {a} → a ∈ Φ →
-    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
-  TyRenameWf Δᴸ Δᴸ′ τ →
-  CtxImp Φ Δᴸ Δᴿ →
-  CtxImp Ψ Δᴸ′ Δᴿ
-rename-left-ctxⁱ τ assm hτ [] = []
-rename-left-ctxⁱ τ assm hτ (ctx-imp A B p ∷ γ) =
-  ctx-imp (renameᵗ τ A) B
-    (⊑-rename-leftᵢ τ assm hτ p) ∷
-  rename-left-ctxⁱ τ assm hτ γ
-
-rename-left-ctx-coherentⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ)
-    (assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
-    (hτ : TyRenameWf Δᴸ Δᴸ′ τ)
-    (γ : CtxImp Φ Δᴸ Δᴿ) →
-  LeftCtxRenameⁱ τ assm hτ γ
-    (rename-left-ctxⁱ τ assm hτ γ)
-rename-left-ctx-coherentⁱ τ assm hτ [] =
-  left-ctx-rename-[]
-rename-left-ctx-coherentⁱ τ assm hτ (ctx-imp A B p ∷ γ) =
-  left-ctx-rename-∷ refl
-    (rename-left-ctx-coherentⁱ τ assm hτ γ)
-
-rename-left-ctx-source-liftⁱ :
-  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ
-    (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
-      TyRenameWf-suc γ)
-rename-left-ctx-source-liftⁱ [] = lift-left-ctx-[]
-rename-left-ctx-source-liftⁱ (ctx-imp A B p ∷ γ) =
-  lift-left-ctx-∷ (rename-left-ctx-source-liftⁱ γ)
-
-left-source-rename-worldsⁱ :
-  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ)
-    (γ : CtxImp Φ Δᴸ Δᴿ) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ
-      (rename-left-storeⁱ suc rename-assm²-source-νᵢ
-        TyRenameWf-suc ρ) ×
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ
-      (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
-        TyRenameWf-suc γ) ×
-  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc ρ
-      (rename-left-storeⁱ suc rename-assm²-source-νᵢ
-        TyRenameWf-suc ρ) ×
-  LeftCtxRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc γ
-      (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
-        TyRenameWf-suc γ)
-left-source-rename-worldsⁱ ρ γ =
-  rename-left-store-source-liftⁱ ρ ,
-  rename-left-ctx-source-liftⁱ γ ,
-  rename-left-store-coherentⁱ
-    suc rename-assm²-source-νᵢ TyRenameWf-suc ρ ,
-  rename-left-ctx-coherentⁱ
-    suc rename-assm²-source-νᵢ TyRenameWf-suc γ
-
-left-ctx-rename-lookupⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {x A B p} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  γ ∋ x ⦂ ctx-imp A B p →
-  ∃[ A′ ] ∃[ eqA ]
-    γ′ ∋ x ⦂ ctx-imp A′ B
-      (⊑-rename-left-atᵢ τ assm hτ eqA p)
-left-ctx-rename-lookupⁱ
-    (left-ctx-rename-∷ eqA renameγ) Z =
-  _ , eqA , Z
-left-ctx-rename-lookupⁱ
-    (left-ctx-rename-∷ eqA renameγ) (S x∈) =
-  let A′ , eqA′ , x∈′ = left-ctx-rename-lookupⁱ renameγ x∈ in
-  A′ , eqA′ , S x∈′
-
-left-rename-xᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {x A B p}
-    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  γ ∋ x ⦂ ctx-imp A B p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (` x) ⊑ ` x
-    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-xᵀ renameγ x∈ with left-ctx-rename-lookupⁱ renameγ x∈
-left-rename-xᵀ renameγ x∈ | A′ , refl , x∈′ = x⊑xᵀ x∈′
-
-left-rename-blameᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M A B} {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ blame ⊑ M
-    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-blameᵀ renameρ renameγ M⊢ =
-  blame⊑ᵀ (right-typing-left-renameⁱ renameρ renameγ M⊢)
-
-left-rename-ƛᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {N N′ A A′ B B′}
-    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  WfTy Δᴸ A →
-  WfTy Δᴿ A′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣
-      ctx-imp (renameᵗ τ A) A′
-        (⊑-rename-leftᵢ τ assm hτ pA) ∷ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ B ⊑ B′
-    ∶ ⊑-rename-leftᵢ τ assm hτ pB →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (ƛ N) ⊑ ƛ N′
-    ⦂ renameᵗ τ (A ⇒ B) ⊑ A′ ⇒ B′
-    ∶ ⊑-rename-leftᵢ τ assm hτ (pA ↦ pB)
-left-rename-ƛᵀ {hτ = hτ} hA hA′ N⊑N′ =
-  ƛ⊑ƛᵀ (renameᵗ-preserves-WfTy hA hτ) hA′ N⊑N′
-
-left-rename-·ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {L L′ M M′ A A′ B B′}
-    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ L ⊑ L′
-    ⦂ renameᵗ τ (A ⇒ B) ⊑ A′ ⇒ B′
-    ∶ ⊑-rename-leftᵢ τ assm hτ (pA ↦ pB) →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′
-    ∶ ⊑-rename-leftᵢ τ assm hτ pA →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (L · M) ⊑ L′ · M′
-    ⦂ renameᵗ τ B ⊑ B′
-    ∶ ⊑-rename-leftᵢ τ assm hτ pB
-left-rename-·ᵀ L⊑L′ M⊑M′ = ·⊑·ᵀ L⊑L′ M⊑M′
-
-left-rename-cast⊒⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A B B′ c μ}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (modeτ : CastModeRenamer τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ μ (leftStoreⁱ ρ) →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-cast⊒⊑ᵀ modeτ renameρ mode seal★ c⊒ M⊑M′ =
-  cast⊒⊑ᵀ (CastModeRenamer.target-mode modeτ mode)
-    (left-seal★-renameⁱ modeτ renameρ mode seal★)
-    (left-narrowing-renameⁱ modeτ mode renameρ c⊒)
-    M⊑M′ _
-
-left-rename-cast⊑⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A B B′ c μ}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (modeτ : CastModeRenamer τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ μ (leftStoreⁱ ρ) →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-cast⊑⊑ᵀ modeτ renameρ mode seal★ c⊑ M⊑M′ =
-  cast⊑⊑ᵀ (CastModeRenamer.target-mode modeτ mode)
-    (left-seal★-renameⁱ modeτ renameρ mode seal★)
-    (left-widening-renameⁱ modeτ mode renameρ c⊑)
-    M⊑M′ _
-
-left-rename-⊑cast⊒ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A A′ B′ c′ μ′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  CastMode μ′ →
-  SealModeStore★ μ′ (rightStoreⁱ ρ) →
-  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-⊑cast⊒ᵀ renameρ mode′ seal★′ c′⊒ M⊑M′ =
-  ⊑cast⊒ᵀ mode′
-    (right-seal★-left-renameⁱ renameρ seal★′)
-    (right-narrowing-left-renameⁱ renameρ c′⊒) M⊑M′ _
-
-left-rename-⊑cast⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A A′ B′ c′ μ′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  CastMode μ′ →
-  SealModeStore★ μ′ (rightStoreⁱ ρ) →
-  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-⊑cast⊑ᵀ renameρ mode′ seal★′ c′⊑ M⊑M′ =
-  ⊑cast⊑ᵀ mode′
-    (right-seal★-left-renameⁱ renameρ seal★′)
-    (right-widening-left-renameⁱ renameρ c′⊑) M⊑M′ _
-
-left-rename-⊑cast⊑idᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A A′ B′ c′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  StoreDetWf Δᴿ (rightStoreⁱ ρ) →
-  SealModeStore★ id-onlyᵈ (rightStoreⁱ ρ) →
-  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-⊑cast⊑idᵀ renameρ wfΣ′ seal★′ c′⊑ M⊑M′ =
-  ⊑cast⊑idᵀ
-    (right-store-det-left-renameⁱ renameρ wfΣ′)
-    (right-seal★-left-renameⁱ {μ = id-onlyᵈ} renameρ seal★′)
-    (right-widening-left-renameⁱ renameρ c′⊑) M⊑M′ _
-
-left-rename-up⊑upᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {N N′ A A′ D D′ u u′}
-    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
-  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
-  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
-  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
-left-rename-up⊑upᵀ {τ = τ} renameρ u⊑ u′⊑ N⊑N′ =
-  up⊑upᵀ N⊑N′
-    (left-widening-rename-modeⁱ (modeRename-id-only τ) renameρ u⊑)
-    (right-widening-left-renameⁱ renameρ u′⊑) _
-
-left-rename-crossed-up⊑upᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {N N′ A A′ D D′ u u′ μ}
-    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {qD′ : Ψ ∣ Δᴸ′ ⊢ renameᵗ τ D ⊑ᵖ D′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
-  CastMode μ →
-  SealModeStore★ μ (leftStoreⁱ ρ) →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
-  SealModeStore★
-    (instᵈ (extᵈ tag-or-idᵈ)) (rightStoreⁱ ρ) →
-  instᵈ (extᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
-    ⊢ u′ ∶ D′ ⊑ A′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ qD′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
-left-rename-crossed-up⊑upᵀ ins renameρ mode seal★ u⊑
-    seal★′ u′⊑ N⊑N′ =
-  crossed-up⊑upᵀ N⊑N′ target-mode target-seal target-u⊑
-    (right-seal★-left-renameⁱ renameρ seal★′)
-    (right-widening-left-renameⁱ renameρ u′⊑) _
-  where
-  modeτ = left-insertion-cast-renamer ins
-  target-mode = CastModeRenamer.target-mode modeτ mode
-  target-seal = left-seal★-renameⁱ modeτ renameρ mode seal★
-  target-u⊑ = left-widening-renameⁱ modeτ mode renameρ u⊑
-
-left-rename-crossed-left-up⊑upᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {N N′ A A′ D D′ u u′ μ}
-    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {qD′ : Ψ ∣ Δᴸ′ ⊢ renameᵗ τ D ⊑ᵖ D′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
-  CastMode μ →
-  SealModeStore★ μ (leftStoreⁱ ρ) →
-  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
-  SealModeStore★
-    (extᵈ (instᵈ tag-or-idᵈ)) (rightStoreⁱ ρ) →
-  extᵈ (instᵈ tag-or-idᵈ) ∣ Δᴿ ∣ rightStoreⁱ ρ
-    ⊢ u′ ∶ D′ ⊑ A′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ qD′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
-left-rename-crossed-left-up⊑upᵀ ins renameρ mode seal★ u⊑
-    seal★′ u′⊑ N⊑N′ =
-  crossed-left-up⊑upᵀ N⊑N′ target-mode target-seal target-u⊑
-    (right-seal★-left-renameⁱ renameρ seal★′)
-    (right-widening-left-renameⁱ renameρ u′⊑) _
-  where
-  modeτ = left-insertion-cast-renamer ins
-  target-mode = CastModeRenamer.target-mode modeτ mode
-  target-seal = left-seal★-renameⁱ modeτ renameρ mode seal★
-  target-u⊑ = left-widening-renameⁱ modeτ mode renameρ u⊑
-
-left-rename-down⊑downᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ C C′ D D′ d d′}
-    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
-    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
-  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
-  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
-  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ C′ ⊒ D′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ C ⊑ C′ ∶ ⊑-rename-leftᵢ τ assm hτ pC →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩) ⊑ M′ ⟨ d′ ⟩
-    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD
-left-rename-down⊑downᵀ {τ = τ} renameρ d⊒ d′⊒ M⊑M′ =
-  down⊑downᵀ
-    (left-narrowing-rename-modeⁱ (modeRename-id-only τ) renameρ d⊒)
-    (right-narrowing-left-renameⁱ renameρ d′⊒) M⊑M′ _
-
-left-rename-gen-down⊑gen-downᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ C C′ D D′ d d′}
-    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
-    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
-  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
-  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
-  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
-    ⊢ d′ ∶ C′ ⊒ D′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ C ⊑ C′ ∶ ⊑-rename-leftᵢ τ assm hτ pC →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩) ⊑ M′ ⟨ d′ ⟩
-    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD
-left-rename-gen-down⊑gen-downᵀ {τ = τ} renameρ d⊒ d′⊒ M⊑M′ =
-  gen-down⊑gen-downᵀ
-    (left-narrowing-rename-modeⁱ
-      (modeRename-gen-tag-or-id τ) renameρ d⊒)
-    (right-narrowing-left-renameⁱ renameρ d′⊒) M⊑M′ _
-
-left-rename-Λᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {V V′ A B} {p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
-  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
-  Value V →
-  Value V′ →
-  (∀ {ρ′∀ γ′∀} →
-    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ →
-    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ →
-    LeftStoreRenameⁱ
-      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
-      ρ∀ ρ′∀ →
-    LeftCtxRenameⁱ
-      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
-      γ∀ γ′∀ →
-    ∀ᵢᶜ Ψ ∣ suc Δᴸ′ ∣ suc Δᴿ ∣ ρ′∀ ∣ γ′∀
-      ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ V′
-      ⦂ renameᵗ (extᵗ τ) A ⊑ B
-      ∶ ⊑-rename-leftᵢ
-        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
-        (TyRenameWf-ext hτ) p) →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ Λ V′
-    ⦂ renameᵗ τ (`∀ A) ⊑ `∀ B
-    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ p)
-left-rename-Λᵀ renameρ renameγ liftρ liftγ vV vV′ body-map
-    with left-store-rename-∀ renameρ liftρ
-left-rename-Λᵀ renameρ renameγ liftρ liftγ vV vV′ body-map
-    | ρ′∀ , liftρ′ , renameρ∀
-    with left-ctx-rename-∀ renameγ liftγ
-left-rename-Λᵀ {τ = τ}
-    renameρ renameγ liftρ liftγ vV vV′ body-map
-    | ρ′∀ , liftρ′ , renameρ∀
-    | γ′∀ , liftγ′ , renameγ∀ =
-  Λ⊑Λᵀ liftρ′ liftγ′
-    (renameᵗᵐ-preserves-Value (extᵗ τ) vV) vV′
-    (body-map liftρ′ liftγ′ renameρ∀ renameγ∀)
-
-left-rename-Λ⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {V N′ A B}
-    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
-      ∣ suc Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  (occ : occurs zero A ≡ true) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
-  Value V →
-  (∀ {ρ′ν γ′ν} →
-    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν →
-    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν →
-    LeftStoreRenameⁱ
-      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
-      ρν ρ′ν →
-    LeftCtxRenameⁱ
-      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
-      γν γ′ν →
-    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
-      ∣ suc Δᴸ′ ∣ Δᴿ ∣ ρ′ν ∣ γ′ν
-      ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ N′
-      ⦂ renameᵗ (extᵗ τ) A ⊑ B
-      ∶ ⊑-rename-leftᵢ
-        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
-        (TyRenameWf-ext hτ) p) →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ N′
-    ⦂ renameᵗ τ (`∀ A) ⊑ B
-    ∶ ⊑-rename-leftᵢ τ assm hτ (ν occ p)
-left-rename-Λ⊑ᵀ renameρ renameγ occ liftρ liftγ vV body-map
-    with left-store-rename-ν renameρ liftρ
-left-rename-Λ⊑ᵀ renameρ renameγ occ liftρ liftγ vV body-map
-    | ρ′ν , liftρ′ , renameρν
-    with left-ctx-rename-ν renameγ liftγ
-left-rename-Λ⊑ᵀ {τ = τ} {A = A}
-    renameρ renameγ occ liftρ liftγ vV body-map
-    | ρ′ν , liftρ′ , renameρν
-    | γ′ν , liftγ′ , renameγν =
-  Λ⊑ᵀ (trans (occurs-zero-rename-ext τ A) occ)
-    liftρ′ liftγ′ (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
-    (body-map liftρ′ liftγ′ renameρν renameγν)
-
-left-rename-νᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {A A′ B B′ C C′ N N′ s s′ μ μ′}
-    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  WfTy Δᴸ A →
-  WfTy Δᴿ A′ →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
-  (A⇑⊑A′⇑ : ∀ᵢᶜ Φ
-    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
-  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ (`∀ C) ⊑ `∀ C′
-    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ q) →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ ν A′ N′ s′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-νᵀ
-    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
-    liftρ liftγ N⊑N′
-    with left-store-rename-∀ renameρ liftρ
-left-rename-νᵀ
-    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
-    liftρ liftγ N⊑N′
-    | ρ′∀ , liftρ′ , renameρ∀
-    with left-ctx-rename-∀ renameγ liftγ
-left-rename-νᵀ {τ = τ} {assm = assm} {hτ = hτ} {A = A}
-    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
-    liftρ liftγ N⊑N′
-    | ρ′∀ , liftρ′ , renameρ∀
-    | γ′∀ , liftγ′ , renameγ∀ =
-  ν⊑νᵀ
-    (renameᵗ-preserves-WfTy hA hτ) hA′
-    (left-reveal-ν-renameⁱ ins renameρ s↑)
-    (right-reveal-ν-left-renameⁱ renameρ s′↑)
-    (⊑-rename-leftᵢ τ assm hτ A⊑A′)
-    (⊑-rename-left-atᵢ
-      (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
-      (TyRenameWf-ext hτ)
-      (sym (renameᵗ-ext-suc-comm τ A)) A⇑⊑A′⇑)
-    liftρ′ liftγ′ N⊑N′
-
-left-rename-ν⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {A B B′ C N N′ s μ}
-    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  WfTy Δᴸ A →
-  WfTy (suc Δᴸ) (⇑ᵗ A) →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ (`∀ C) ⊑ B′
-    ∶ ⊑-rename-leftᵢ τ assm hτ q →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ N′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-ν⊑ᵀ
-    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
-    with left-store-rename-ν renameρ liftρ
-left-rename-ν⊑ᵀ
-    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
-    | ρ′ν , liftρ′ , renameρν
-    with left-ctx-rename-ν renameγ liftγ
-left-rename-ν⊑ᵀ {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {A = A}
-    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
-    | ρ′ν , liftρ′ , renameρν
-    | γ′ν , liftγ′ , renameγν =
-  ν⊑ᵀ (renameᵗ-preserves-WfTy hA hτ) h⇑A′
-    (left-reveal-ν-renameⁱ ins renameρ s↑)
-    liftρ′ liftγ′ N⊑N′
-  where
-  h⇑A′ : WfTy (suc Δᴸ′) (⇑ᵗ (renameᵗ τ A))
-  h⇑A′ =
-    subst (WfTy (suc Δᴸ′))
-      (renameᵗ-ext-suc-comm τ A)
-      (renameᵗ-preserves-WfTy h⇑A (TyRenameWf-ext hτ))
-
-left-rename-⊑νᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {A B B′ C′ N N′ s μ}
-    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  WfTy Δᴿ A →
-  WfTy (suc Δᴿ) (⇑ᵗ A) →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ B ⊑ `∀ C′
-    ∶ ⊑-rename-leftᵢ τ assm hτ q →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ ν A N′ s
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-⊑νᵀ
-    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
-    with left-store-rename-⇑ᴿ renameρ liftρ
-left-rename-⊑νᵀ
-    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
-    | ρ′ᴿ , liftρ′ , renameρᴿ
-    with left-ctx-rename-⇑ᴿ renameγ liftγ
-left-rename-⊑νᵀ {τ = τ} {assm = assm} {hτ = hτ}
-    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
-    | ρ′ᴿ , liftρ′ , renameρᴿ
-    | γ′ᴿ , liftγ′ , renameγᴿ =
-  ⊑νᵀ hA h⇑A
-    (right-reveal-ν-left-renameⁱ renameρ s↑)
-    liftρ′ liftγ′
-    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ B⊑C′)
-    N⊑N′
-
-left-rename-νcastᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {B B′ C C′ N N′ s s′ μ μ′}
-    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  (mode′ : CastMode μ′) →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
-  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ (`∀ C) ⊑ `∀ C′
-    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ q) →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ ν ★ N′ s′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-νcastᵀ
-    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
-    liftρ liftγ N⊑N′
-    with left-store-rename-∀ renameρ liftρ
-left-rename-νcastᵀ
-    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
-    liftρ liftγ N⊑N′
-    | ρ′∀ , liftρ′ , renameρ∀
-    with left-ctx-rename-∀ renameγ liftγ
-left-rename-νcastᵀ
-    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
-    liftρ liftγ N⊑N′
-    | ρ′∀ , liftρ′ , renameρ∀
-    | γ′∀ , liftγ′ , renameγ∀ =
-  νcast⊑νcastᵀ
-    (CastModeRenamer.target-mode
-      (left-insertion-cast-renamer ins) mode)
-    (left-seal★-ν★-renameⁱ ins renameρ mode seal★)
-    mode′ (right-seal★-ν★-left-renameⁱ renameρ seal★′)
-    (left-widening-ν★-renameⁱ ins renameρ mode s⊑)
-    (right-widening-ν★-left-renameⁱ renameρ s′⊑)
-    liftρ′ liftγ′ N⊑N′
-
-left-rename-νcast⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {B B′ C N N′ s μ}
-    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ (`∀ C) ⊑ B′
-    ∶ ⊑-rename-leftᵢ τ assm hτ q →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ N′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-νcast⊑ᵀ
-    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
-    with left-store-rename-ν renameρ liftρ
-left-rename-νcast⊑ᵀ
-    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
-    | ρ′ν , liftρ′ , renameρν
-    with left-ctx-rename-ν renameγ liftγ
-left-rename-νcast⊑ᵀ
-    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
-    | ρ′ν , liftρ′ , renameρν
-    | γ′ν , liftγ′ , renameγν =
-  νcast⊑ᵀ
-    (CastModeRenamer.target-mode
-      (left-insertion-cast-renamer ins) mode)
-    (left-seal★-ν★-renameⁱ ins renameρ mode seal★)
-    (left-widening-ν★-renameⁱ ins renameρ mode s⊑)
-    liftρ′ liftγ′ N⊑N′
-
-left-rename-⊑νcastᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {B B′ C′ N N′ s μ}
-    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  LeftCtxRenameⁱ τ assm hτ γ γ′ →
-  (mode : CastMode μ) →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
-    ⦂ renameᵗ τ B ⊑ `∀ C′
-    ∶ ⊑-rename-leftᵢ τ assm hτ q →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ N ⊑ ν ★ N′ s
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-⊑νcastᵀ
-    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
-    with left-store-rename-⇑ᴿ renameρ liftρ
-left-rename-⊑νcastᵀ
-    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
-    | ρ′ᴿ , liftρ′ , renameρᴿ
-    with left-ctx-rename-⇑ᴿ renameγ liftγ
-left-rename-⊑νcastᵀ {τ = τ} {assm = assm} {hτ = hτ}
-    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
-    | ρ′ᴿ , liftρ′ , renameρᴿ
-    | γ′ᴿ , liftγ′ , renameγᴿ =
-  ⊑νcastᵀ mode
-    (right-seal★-ν★-left-renameⁱ renameρ seal★)
-    (right-widening-ν★-left-renameⁱ renameρ s⊑)
-    liftρ′ liftγ′
-    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ B⊑C′)
-    N⊑N′
-
-leftCtxⁱ-rename-left :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    (γ : CtxImp Φ Δᴸ Δᴿ) →
-  leftCtxⁱ
-      (rename-left-ctxⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ γ)
-    ≡ map (renameᵗ τ) (leftCtxⁱ γ)
-leftCtxⁱ-rename-left [] = refl
-leftCtxⁱ-rename-left (ctx-imp A B p ∷ γ) =
-  cong (renameᵗ _ A ∷_) (leftCtxⁱ-rename-left γ)
-
-rightCtxⁱ-rename-left :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    (γ : CtxImp Φ Δᴸ Δᴿ) →
-  rightCtxⁱ
-      (rename-left-ctxⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ γ)
-    ≡ rightCtxⁱ γ
-rightCtxⁱ-rename-left [] = refl
-rightCtxⁱ-rename-left (ctx-imp A B p ∷ γ) =
-  cong (B ∷_) (rightCtxⁱ-rename-left γ)
-
-rename-left-ctx-∋ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {γ x A B p} →
-  γ ∋ x ⦂ ctx-imp A B p →
-  rename-left-ctxⁱ {Φ = Φ} {Ψ = Ψ}
-      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
-      τ assm hτ γ
-    ∋ x ⦂ ctx-imp (renameᵗ τ A) B
-      (⊑-rename-leftᵢ τ assm hτ p)
-rename-left-ctx-∋ Z = Z
-rename-left-ctx-∋ (S x∈) = S (rename-left-ctx-∋ x∈)
-
-rename-left-store-matched∈ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
-  store-matched α A β B p ∈ ρ →
-  store-matched (τ α) (renameᵗ τ A) β B
-      (⊑-rename-leftᵢ τ assm hτ p)
-    ∈ rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
-      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
-      τ assm hτ ρ
-rename-left-store-matched∈ (here refl) = here refl
-rename-left-store-matched∈
-    {ρ = store-matched α A β B p ∷ ρ} (there p∈) =
-  there (rename-left-store-matched∈ p∈)
-rename-left-store-matched∈
-    {ρ = store-left α A hA ∷ ρ} (there p∈) =
-  there (rename-left-store-matched∈ p∈)
-rename-left-store-matched∈
-    {ρ = store-right β B hB ∷ ρ} (there p∈) =
-  there (rename-left-store-matched∈ p∈)
-rename-left-store-matched∈
-    {ρ = store-link α A β B p ∷ ρ} (there p∈) =
-  there (rename-left-store-matched∈ p∈)
-
-rename-left-store-link∈ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
-  store-link α A β B p ∈ ρ →
-  store-link (τ α) (renameᵗ τ A) β B
-      (⊑-rename-leftᵢ τ assm hτ p)
-    ∈ rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
-      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
-      τ assm hτ ρ
-rename-left-store-link∈ (here refl) = here refl
-rename-left-store-link∈
-    {ρ = store-matched α A β B p ∷ ρ} (there p∈) =
-  there (rename-left-store-link∈ p∈)
-rename-left-store-link∈
-    {ρ = store-left α A hA ∷ ρ} (there p∈) =
-  there (rename-left-store-link∈ p∈)
-rename-left-store-link∈
-    {ρ = store-right β B hB ∷ ρ} (there p∈) =
-  there (rename-left-store-link∈ p∈)
-rename-left-store-link∈
-    {ρ = store-link α A β B p ∷ ρ} (there p∈) =
-  there (rename-left-store-link∈ p∈)
-
-rename-left-correspondence :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
-  StoreCorresponds ρ α A β B p →
-  StoreCorresponds
-    (rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
-      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
-      τ assm hτ ρ)
-    (τ α) (renameᵗ τ A) β B
-    (⊑-rename-leftᵢ τ assm hτ p)
-rename-left-correspondence (correspondence-stored p∈) =
-  correspondence-stored (rename-left-store-matched∈ p∈)
-rename-left-correspondence (correspondence-linked p∈) =
-  correspondence-linked (rename-left-store-link∈ p∈)
-
-left-store-rename-matched∈ⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {α A β B p} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  store-matched α A β B p ∈ ρ →
-  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
-    store-matched α′ A′ β B
-      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∈ ρ′
-left-store-rename-matched∈ⁱ
-    (left-store-rename-matched eqα eqA renameρ) (here refl) =
-  _ , eqα , _ , eqA , here refl
-left-store-rename-matched∈ⁱ
-    (left-store-rename-matched eqα eqA renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-matched∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-left-store-rename-matched∈ⁱ
-    (left-store-rename-left eqα eqA renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-matched∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-left-store-rename-matched∈ⁱ
-    (left-store-rename-right renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-matched∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-left-store-rename-matched∈ⁱ
-    (left-store-rename-link eqα eqA renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-matched∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-
-left-store-rename-link∈ⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {α A β B p} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  store-link α A β B p ∈ ρ →
-  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
-    store-link α′ A′ β B
-      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∈ ρ′
-left-store-rename-link∈ⁱ
-    (left-store-rename-matched eqα eqA renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-link∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-left-store-rename-link∈ⁱ
-    (left-store-rename-left eqα eqA renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-link∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-left-store-rename-link∈ⁱ
-    (left-store-rename-right renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-link∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-left-store-rename-link∈ⁱ
-    (left-store-rename-link eqα eqA renameρ) (here refl) =
-  _ , eqα , _ , eqA , here refl
-left-store-rename-link∈ⁱ
-    (left-store-rename-link eqα eqA renameρ) (there p∈) =
-  let α′ , eqα′ , A′ , eqA′ , p∈′ =
-        left-store-rename-link∈ⁱ renameρ p∈ in
-  α′ , eqα′ , A′ , eqA′ , there p∈′
-
-left-store-rename-correspondenceⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {α A β B p} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  StoreCorresponds ρ α A β B p →
-  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
-    StoreCorresponds ρ′ α′ A′ β B
-      (⊑-rename-left-atᵢ τ assm hτ eqA p)
-left-store-rename-correspondenceⁱ renameρ
-    (correspondence-stored p∈) =
-  let α′ , eqα , A′ , eqA , p∈′ =
-        left-store-rename-matched∈ⁱ renameρ p∈ in
-  α′ , eqα , A′ , eqA , correspondence-stored p∈′
-left-store-rename-correspondenceⁱ renameρ
-    (correspondence-linked p∈) =
-  let α′ , eqα , A′ , eqA , p∈′ =
-        left-store-rename-link∈ⁱ renameρ p∈ in
-  α′ , eqα , A′ , eqA , correspondence-linked p∈′
-
-left-paired-conversion-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {c c′ A A′ B B′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  PairedConversion Φ Δᴸ Δᴿ ρ c c′ p q →
-  PairedConversion Ψ Δᴸ′ Δᴿ ρ′
-    (renameᶜ τ c) c′
-    (⊑-rename-leftᵢ τ assm hτ p)
-    (⊑-rename-leftᵢ τ assm hτ q)
-left-paired-conversion-renameⁱ ins renameρ
-    (paired-reveal corr conv conv′)
-    with left-store-rename-correspondenceⁱ renameρ corr
-left-paired-conversion-renameⁱ ins renameρ
-    (paired-reveal corr conv conv′)
-    | α′ , refl , A′ , refl , corr′ =
-  paired-reveal corr′
-    (left-reveal-renameⁱ ins renameρ conv)
-    (right-reveal-left-renameⁱ renameρ conv′)
-left-paired-conversion-renameⁱ ins renameρ
-    (paired-conceal corr conv conv′)
-    with left-store-rename-correspondenceⁱ renameρ corr
-left-paired-conversion-renameⁱ ins renameρ
-    (paired-conceal corr conv conv′)
-    | α′ , refl , A′ , refl , corr′ =
-  paired-conceal corr′
-    (left-conceal-renameⁱ ins renameρ conv)
-    (right-conceal-left-renameⁱ renameρ conv′)
-
-left-paired-cast-renameⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {c c′ A A′ B B′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
-  PairedCast Ψ Δᴸ′ Δᴿ ρ′
-    (renameᶜ τ c) c′
-    (⊑-rename-leftᵢ τ assm hτ p)
-    (⊑-rename-leftᵢ τ assm hτ q)
-left-paired-cast-renameⁱ ins renameρ
-    (paired-conversion conv) =
-  paired-conversion (left-paired-conversion-renameⁱ ins renameρ conv)
-left-paired-cast-renameⁱ ins renameρ
-    (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑) =
-  paired-widening
-    (CastModeRenamer.target-mode modeτ mode)
-    (left-seal★-renameⁱ modeτ renameρ mode seal★)
-    (left-widening-renameⁱ modeτ mode renameρ c⊑)
-    mode′
-    (right-seal★-left-renameⁱ renameρ seal★′)
-    (right-widening-left-renameⁱ renameρ c′⊑)
-  where
-  modeτ = left-insertion-cast-renamer ins
-
-left-rename-conv⊑convᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ c c′ A A′ B B′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′ ⟨ c′ ⟩
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-conv⊑convᵀ ins renameρ cast M⊑M′ =
-  conv⊑convᵀ (left-paired-cast-renameⁱ ins renameρ cast) M⊑M′
-
-left-rename-conv↑⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A B B′ c μ α X}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-conv↑⊑ᵀ ins renameρ conv M⊑M′ =
-  conv↑⊑ᵀ (left-reveal-renameⁱ ins renameρ conv) M⊑M′ _
-
-left-rename-conv↓⊑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A B B′ c μ α X}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  (ins : LeftInsertion τ) →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
-    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-conv↓⊑ᵀ ins renameρ conv M⊑M′ =
-  conv↓⊑ᵀ (left-conceal-renameⁱ ins renameρ conv) M⊑M′ _
-
-left-rename-⊑conv↑ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A A′ B′ c′ μ′ β X′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-⊑conv↑ᵀ renameρ conv M⊑M′ =
-  ⊑conv↑ᵀ (right-reveal-left-renameⁱ renameρ conv) M⊑M′ _
-
-left-rename-⊑conv↓ᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
-    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
-    {M M′ A A′ B′ c′ μ′ β X′}
-    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
-    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
-  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-  ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
-    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
-  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
-    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
-left-rename-⊑conv↓ᵀ renameρ conv M⊑M′ =
-  ⊑conv↓ᵀ (right-conceal-left-renameⁱ renameρ conv) M⊑M′ _
-
-lift-ctx-result :
-  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
-  ∃[ γ′ ] LiftCtxⁱ (∀ᵢᶜ Φ) γ γ′
-lift-ctx-result [] = [] , lift-ctx-[]
-lift-ctx-result (ctx-imp A B p ∷ γ) with lift-ctx-result γ
-lift-ctx-result (ctx-imp A B p ∷ γ) | γ′ , liftγ =
-  ctx-imp (⇑ᵗ A) (⇑ᵗ B) (⊑-lift∀ᵢ p) ∷ γ′ ,
-  lift-ctx-∷ liftγ
-
-lift-left-ctx-result :
-  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
-  ∃[ γ′ ] LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
-lift-left-ctx-result [] = [] , lift-left-ctx-[]
-lift-left-ctx-result (ctx-imp A B p ∷ γ)
-    with lift-left-ctx-result γ
-lift-left-ctx-result (ctx-imp A B p ∷ γ) | γ′ , liftγ =
-  ctx-imp (⇑ᵗ A) B (⊑-source-liftνᵢ p) ∷ γ′ ,
-  lift-left-ctx-∷ liftγ
-
-left-forall-store-square :
-  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
-  ∃[ ρν ] ∃[ ρ∀ ] ∃[ ρν∀ ] ∃[ ρ∀ν ]
-    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν ×
-    LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ ×
-    LiftStoreⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρν ρν∀ ×
-    LiftLeftStoreⁱ
-      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (∀ᵢᶜ Φ)) ρ∀ ρ∀ν ×
-    leftStoreⁱ ρν∀ ≡ leftStoreⁱ ρ∀ν ×
-    rightStoreⁱ ρν∀ ≡ rightStoreⁱ ρ∀ν
-left-forall-store-square ρ with lift-left-store-result ρ
-left-forall-store-square ρ | ρν , liftν
-    with lift-store-result ρ
-left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
-    with lift-store-result ρν
-left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
-    | ρν∀ , liftν∀ with lift-left-store-result ρ∀
-left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
-    | ρν∀ , liftν∀ | ρ∀ν , lift∀ν =
-  ρν , ρ∀ , ρν∀ , ρ∀ν ,
-  liftν , lift∀ , liftν∀ , lift∀ν ,
-  trans
-    (leftStoreⁱ-lift liftν∀)
-    (trans
-      (cong ⟰ᵗ (leftStoreⁱ-lift-left liftν))
-      (sym
-        (trans
-          (leftStoreⁱ-lift-left lift∀ν)
-          (cong ⟰ᵗ (leftStoreⁱ-lift lift∀))))) ,
-  trans
-    (rightStoreⁱ-lift liftν∀)
-    (trans
-      (cong ⟰ᵗ (rightStoreⁱ-lift-left liftν))
-      (sym
-        (trans
-          (rightStoreⁱ-lift-left lift∀ν)
-          (rightStoreⁱ-lift lift∀))))
-
-left-forall-ctx-square :
-  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
-  ∃[ γν ] ∃[ γ∀ ] ∃[ γν∀ ] ∃[ γ∀ν ]
-    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν ×
-    LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ ×
-    LiftCtxⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γν γν∀ ×
-    LiftLeftCtxⁱ
-      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (∀ᵢᶜ Φ)) γ∀ γ∀ν ×
-    leftCtxⁱ γν∀ ≡ leftCtxⁱ γ∀ν ×
-    rightCtxⁱ γν∀ ≡ rightCtxⁱ γ∀ν
-left-forall-ctx-square γ with lift-left-ctx-result γ
-left-forall-ctx-square γ | γν , liftν with lift-ctx-result γ
-left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
-    with lift-ctx-result γν
-left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
-    | γν∀ , liftν∀ with lift-left-ctx-result γ∀
-left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
-    | γν∀ , liftν∀ | γ∀ν , lift∀ν =
-  γν , γ∀ , γν∀ , γ∀ν ,
-  liftν , lift∀ , liftν∀ , lift∀ν ,
-  trans
-    (leftCtxⁱ-lift liftν∀)
-    (trans
-      (cong ⤊ᵗ (leftCtxⁱ-lift-left liftν))
-      (sym
-        (trans
-          (leftCtxⁱ-lift-left lift∀ν)
-          (cong ⤊ᵗ (leftCtxⁱ-lift lift∀))))) ,
-  trans
-    (rightCtxⁱ-lift liftν∀)
-    (trans
-      (cong ⤊ᵗ (rightCtxⁱ-lift-left liftν))
-      (sym
-        (trans
-          (rightCtxⁱ-lift-left lift∀ν)
-          (rightCtxⁱ-lift lift∀))))
-
-left-source-lift-Λᵀ :
-  ∀ {Φ Δᴸ Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γ : CtxImp Φ Δᴸ Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {ρν∀ : StoreImp (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-      (suc (suc Δᴸ)) (suc Δᴿ)}
-    {γν∀ : CtxImp (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-      (suc (suc Δᴸ)) (suc Δᴿ)}
-    {V V′ A B q} →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
-  LiftStoreⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρν ρν∀ →
-  LiftCtxⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γν γν∀ →
-  Value V →
-  Value V′ →
-  ∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
-    ∣ suc (suc Δᴸ) ∣ suc Δᴿ ∣ ρν∀ ∣ γν∀
-    ⊢ᴺ renameᵗᵐ (extᵗ suc) V ⊑ V′
-    ⦂ renameᵗ (extᵗ suc) A ⊑ B ∶ q →
-  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρν ∣ γν
-    ⊢ᴺ ⇑ᵗᵐ (Λ V) ⊑ Λ V′
-    ⦂ ⇑ᵗ (`∀ A) ⊑ `∀ B ∶ ∀ⁱ q
-left-source-lift-Λᵀ
-    liftνρ liftνγ liftν∀ρ liftν∀γ vV vV′ V⊑V′ =
-  Λ⊑Λᵀ liftν∀ρ liftν∀γ
-    (renameᵗᵐ-preserves-Value (extᵗ suc) vV) vV′ V⊑V′
-
-left-source-lift-⊑αᵀ :
-  ∀ {Φ Δᴸ Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {γ : CtxImp Φ Δᴸ Δᴿ}
-    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {N L′ A B C′ q} →
-  Value L′ →
-  No• L′ →
-  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
-  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᴸ ∣ γᴸ
-    ⊢ᴺ ⇑ᵗᵐ N ⊑ L′
-    ⦂ ⇑ᵗ B ⊑ `∀ C′ ∶ ⊑-source-liftνᵢ q →
-  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  suc Δᴿ ∣
-    rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ) ∣
-    rightCtxⁱ γᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′ →
-  ∃[ ρ× ] ∃[ γ× ]
-    LiftRightStoreⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴸ ρ× ×
-    LiftLeftStoreⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴿ ρ× ×
-    LiftRightCtxⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴸ γ× ×
-    LiftLeftCtxⁱ
-      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴿ γ× ×
-    (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-      ∣ suc Δᴸ ∣ suc Δᴿ ∣
-      store-right zero (⇑ᵗ A) h⇑A ∷ ρ× ∣ γ×
-      ⊢ᴺ ⇑ᵗᵐ N ⊑ (⇑ᵗᵐ L′) •
-      ⦂ ⇑ᵗ B ⊑ C′ ∶ ⊑-source-under-rightᵢ r
-left-source-lift-⊑αᵀ
-    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
-    N⊑L′ r L′•⊢
-    with left-right-store-commuteⁱ liftᴸρ liftᴿρ
-left-source-lift-⊑αᵀ
-    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
-    N⊑L′ r L′•⊢
-    | ρ× , rightᴸρ , leftᴿρ
-    with left-right-ctx-commuteⁱ liftᴸγ liftᴿγ
-left-source-lift-⊑αᵀ
-    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
-    N⊑L′ r L′•⊢
-    | ρ× , rightᴸρ , leftᴿρ
-    | γ× , rightᴸγ , leftᴿγ =
-  ρ× , γ× , rightᴸρ , leftᴿρ , rightᴸγ , leftᴿγ ,
-  ⊑αᵀ vL′ noL′ h⇑A rightᴸρ rightᴸγ N⊑L′
-    (⊑-source-under-rightᵢ r) source-typing target-typing
-  where
-  source-typing =
-    subst
-      (λ Γ → _ ∣ leftStoreⁱ ρ× ∣ Γ ⊢ _ ⦂ _)
-      (sym (leftCtxⁱ-lift-right rightᴸγ))
-      (subst
-        (λ Σ → _ ∣ Σ ∣ leftCtxⁱ _ ⊢ _ ⦂ _)
-        (sym (leftStoreⁱ-lift-right rightᴸρ))
-        (nu-term-imprecision-source-typing N⊑L′))
-
-  target-typing =
-    subst
-      (λ Γ → _ ∣
-        rightStoreⁱ (store-right zero _ h⇑A ∷ ρ×) ∣ Γ
-        ⊢ _ ⦂ _)
-      (sym (rightCtxⁱ-lift-left leftᴿγ))
-      (subst
-        (λ Σ → _ ∣ (zero , _) ∷ Σ ∣ rightCtxⁱ _
-          ⊢ _ ⦂ _)
-        (sym (rightStoreⁱ-lift-left leftᴿρ)) L′•⊢)
-
-left-rename-⊑αᵀ :
-  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
-    {assm : ∀ {a} → a ∈ Φ →
-      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
-    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {ρ′ᴿ : StoreImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)}
-    {γ : CtxImp Φ Δᴸ Δᴿ}
-    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
-    {γ′ᴿ : CtxImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)}
-    {N L′ A B C′}
-    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ}
-    {r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ}
-    {h⇑A h⇑A′ : WfTy (suc Δᴿ) (⇑ᵗ A)} →
-  LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ
-    (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ)
-    (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ) →
-  LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ →
-  Value L′ →
-  No• L′ →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
-  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
-  (∀ {ρ′ γ′} →
-    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
-    LeftCtxRenameⁱ τ assm hτ γ γ′ →
-    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-      ⊢ᴺ renameᵗᵐ τ N ⊑ L′
-      ⦂ renameᵗ τ B ⊑ `∀ C′
-      ∶ ⊑-rename-leftᵢ τ assm hτ q) →
-  suc Δᴿ
-    ∣ rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ)
-    ∣ rightCtxⁱ γᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′ →
-  (⇑ᴿᵢ Ψ) ∣ Δᴸ′ ∣ suc Δᴿ ∣
-    store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ ∣ γ′ᴿ
-    ⊢ᴺ renameᵗᵐ τ N ⊑ (⇑ᵗᵐ L′) •
-    ⦂ renameᵗ τ B ⊑ C′
-    ∶ ⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ r
-left-rename-⊑αᵀ
-    {Ψ = Ψ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρᴿ = ρᴿ} {ρ′ᴿ = ρ′ᴿ} {γᴿ = γᴿ} {γ′ᴿ = γ′ᴿ}
-    {N = N} {L′ = L′} {A = A} {B = B} {C′ = C′}
-    {q = q} {r = r} {h⇑A = h⇑A} {h⇑A′ = h⇑A′}
-    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
-    liftρ liftγ body-map L′•⊢
-    with left-store-rename-⇑ᴿ-inv liftρ renameρᴿ
-left-rename-⊑αᵀ
-    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
-    liftρ liftγ body-map L′•⊢
-    | ρ′ , renameρ′ , liftρ′
-    with left-ctx-rename-⇑ᴿ-inv liftγ renameγᴿ
-left-rename-⊑αᵀ
-    {Ψ = Ψ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
-    {τ = τ} {assm = assm} {hτ = hτ}
-    {ρᴿ = ρᴿ} {ρ′ᴿ = ρ′ᴿ} {γᴿ = γᴿ} {γ′ᴿ = γ′ᴿ}
-    {N = N} {L′ = L′} {A = A} {B = B} {C′ = C′}
-    {q = q} {r = r} {h⇑A = h⇑A} {h⇑A′ = h⇑A′}
-    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
-    liftρ liftγ body-map L′•⊢
-    | ρ′ , renameρ′ , liftρ′
-    | γ′ , renameγ′ , liftγ′ =
-  ⊑αᵀ vL′ noL′ h⇑A′ liftρ′ liftγ′ N⊑L′
-    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ r)
-    source-typing target-typing
-  where
-  N⊑L′ :
-    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
-      ⊢ᴺ renameᵗᵐ τ N ⊑ L′
-      ⦂ renameᵗ τ B ⊑ `∀ C′
-      ∶ ⊑-rename-leftᵢ τ assm hτ q
-  N⊑L′ = body-map renameρ′ renameγ′
-
-  source-typing :
-    Δᴸ′ ∣ leftStoreⁱ ρ′ᴿ ∣ leftCtxⁱ γ′ᴿ
-      ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B
-  source-typing =
-    subst
-      (λ Γ → Δᴸ′ ∣ leftStoreⁱ ρ′ᴿ ∣ Γ
-        ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B)
-      (sym (leftCtxⁱ-lift-right liftγ′))
-      (subst
-        (λ Σ → Δᴸ′ ∣ Σ ∣ leftCtxⁱ γ′
-          ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B)
-        (sym (leftStoreⁱ-lift-right liftρ′))
-        (nu-term-imprecision-source-typing N⊑L′))
-
-  target-typing :
-    suc Δᴿ
-      ∣ rightStoreⁱ
-          (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ)
-      ∣ rightCtxⁱ γ′ᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′
-  target-typing =
-    subst
-      (λ Γ → suc Δᴿ
-        ∣ rightStoreⁱ
-            (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ)
-        ∣ Γ ⊢ (⇑ᵗᵐ L′) • ⦂ C′)
-      (sym (rightCtxⁱ-left-rename renameγᴿ))
-      (subst
-        (λ Σ → suc Δᴿ ∣ Σ ∣ rightCtxⁱ γᴿ
-          ⊢ (⇑ᵗᵐ L′) • ⦂ C′)
-        (sym
-          (rightStoreⁱ-left-rename
-            (left-store-rename-right
-              {hB = h⇑A} {hB′ = h⇑A′} renameρᴿ)))
-        L′•⊢)
-
-left-source-lift-allocation-leftᵀ :
-  ∀ {Φ Δᴸ Δᴿ α α′ A A′ B B′ M M′}
-    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {ρν′ : StoreImp
-      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-      (suc (suc Δᴸ)) Δᴿ}
-    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
-    {γν′ : CtxImp
-      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-      (suc (suc Δᴸ)) Δᴿ}
-    {hA : WfTy (suc Δᴸ) A}
-    {hA′ : WfTy (suc (suc Δᴸ)) A′}
-    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
-      ∣ suc Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
-  No• M →
-  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc
-    (store-left α A hA ∷ ρν)
-    (store-left α′ A′ hA′ ∷ ρν′) →
-  LeftCtxRenameⁱ suc rename-assm²-source-νᵢ
-    TyRenameWf-suc γν γν′ →
-  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-    ∣ suc (suc Δᴸ) ∣ Δᴿ ∣ ρν′ ∣ γν′
-    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′
-    ∶ ⊑-rename-leftᵢ suc rename-assm²-source-νᵢ
-      TyRenameWf-suc p →
-  suc Δᴸ ∣ leftStoreⁱ (store-left α A hA ∷ ρν)
-    ∣ leftCtxⁱ γν ⊢ M ⦂ B →
-  Δᴿ ∣ rightStoreⁱ (store-left α A hA ∷ ρν)
-    ∣ rightCtxⁱ γν ⊢ M′ ⦂ B′ →
-  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
-    ∣ suc (suc Δᴸ) ∣ Δᴿ ∣
-    store-left α′ A′ hA′ ∷ ρν′ ∣ γν′
-    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′
-    ∶ ⊑-rename-leftᵢ suc rename-assm²-source-νᵢ
-      TyRenameWf-suc p
-left-source-lift-allocation-leftᵀ noM
-    (left-store-rename-left eqα eqA renameρν)
-    renameγν M⊑M′ M⊢ M′⊢ with eqα
-left-source-lift-allocation-leftᵀ noM
-    (left-store-rename-left eqα eqA renameρν)
-    renameγν M⊑M′ M⊢ M′⊢ | refl with eqA
-left-source-lift-allocation-leftᵀ
-    {α = α} {A = A} {ρν = ρν} {ρν′ = ρν′}
-    {hA = hA} {hA′ = hA′} noM
-    (left-store-rename-left eqα eqA renameρν)
-    renameγν M⊑M′ M⊢ M′⊢ | refl | refl =
-  allocation-leftᵀ _ (left-store-rename-suc-liftⁱ renameρν)
-    M⊑M′ source-typing target-typing
-  where
-  full-rename :
-    LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc
-      (store-left α A hA ∷ ρν)
-      (store-left (suc α) (⇑ᵗ A) hA′ ∷ ρν′)
-  full-rename = left-store-rename-left refl refl renameρν
-
-  source-typing =
-    left-typing-renameⁱ {ψ = predᵗ}
-      RenameLeftInverse-suc castModeRenamer-suc
-      full-rename renameγν noM M⊢
-
-  target-typing =
-    right-typing-left-renameⁱ full-rename renameγν M′⊢
-
-⊑-lift-under-∀ᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
-    ⊢ renameᵗ (extᵗ suc) A ⊑ renameᵗ (extᵗ suc) B
-    ⊣ suc (suc Δᴿ)
-⊑-lift-under-∀ᵢ =
-  ⊑-renameᵗ²ᵢ
-    (rename-assm²-⇑ᵢ rename-assm²-∀ᵢ)
-    (TyRenameWf-ext TyRenameWf-suc)
-    (TyRenameWf-ext TyRenameWf-suc)
-
-renameᵗ-ext-id : ∀ A → renameᵗ (extᵗ (λ X → X)) A ≡ A
-renameᵗ-ext-id A =
-  trans (rename-cong (λ { zero → refl ; (suc X) → refl }) A)
-    (renameᵗ-id A)
-
-⊑-target-lift-right-under-∀ᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ∀ᵢᶜ (⇑ᴿᵢ Φ) ∣ suc Δᴸ
-    ⊢ A ⊑ renameᵗ (extᵗ suc) B ⊣ suc (suc Δᴿ)
-⊑-target-lift-right-under-∀ᵢ {A = A} p =
-  subst
-    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ (extᵗ suc) _ ⊣ _)
-    (renameᵗ-ext-id A)
-    (⊑-renameᵗ²ᵢ
-      (rename-assm²-⇑ᵢ rename-assm²-target-rightᵢ)
-      (TyRenameWf-ext (λ X<Δ → X<Δ))
-      (TyRenameWf-ext TyRenameWf-suc)
-      p)
-
-rename-assm²-paired-under-right-tailᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ suc (extᵗ suc) a ∈ ⇑ᴿᵢ (⇑ᵢ Φ)
-rename-assm²-paired-under-right-tailᵢ {Φ = []} ()
-rename-assm²-paired-under-right-tailᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-paired-under-right-tailᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
-  there (rename-assm²-paired-under-right-tailᵢ a∈)
-rename-assm²-paired-under-right-tailᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-paired-under-right-tailᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
-  there (rename-assm²-paired-under-right-tailᵢ a∈)
-
-rename-assm²-paired-under-rightᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ suc (extᵗ suc) a ∈ ⇑ᴿᵢ (∀ᵢᶜ Φ)
-rename-assm²-paired-under-rightᵢ a∈ =
-  there (rename-assm²-paired-under-right-tailᵢ a∈)
-
-⊑-lift-under-rightᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ⇑ᴿᵢ (∀ᵢᶜ Φ) ∣ suc Δᴸ
-    ⊢ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B
-    ⊣ suc (suc Δᴿ)
-⊑-lift-under-rightᵢ =
-  ⊑-renameᵗ²ᵢ
-    rename-assm²-paired-under-rightᵢ
-    TyRenameWf-suc
-    (TyRenameWf-ext TyRenameWf-suc)
-
-rename-assm²-right-under-rightᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ (λ X → X) (extᵗ suc) a ∈ ⇑ᴿᵢ (⇑ᴿᵢ Φ)
-rename-assm²-right-under-rightᵢ {Φ = []} ()
-rename-assm²-right-under-rightᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-right-under-rightᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
-  there (rename-assm²-right-under-rightᵢ a∈)
-rename-assm²-right-under-rightᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-right-under-rightᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
-  there (rename-assm²-right-under-rightᵢ a∈)
-
-⊑-target-lift-under-rightᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ⇑ᴿᵢ (⇑ᴿᵢ Φ) ∣ Δᴸ
-    ⊢ A ⊑ renameᵗ (extᵗ suc) B
-    ⊣ suc (suc Δᴿ)
-⊑-target-lift-under-rightᵢ {A = A} p =
-  subst
-    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ (extᵗ suc) _ ⊣ _)
-    (renameᵗ-id A)
-    (⊑-renameᵗ²ᵢ
-      rename-assm²-right-under-rightᵢ
-      (λ X<Δ → X<Δ)
-      (TyRenameWf-ext TyRenameWf-suc)
-      p)
-
-rename-assm²-crossed-under-right-tailᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ
-    (λ X → suc (suc X))
-    (extᵗ (λ X → suc (suc X))) a
-    ∈ ⇑ᴿᵢ (⇑ᵢ (⇑ᵢ Φ))
-rename-assm²-crossed-under-right-tailᵢ {Φ = []} ()
-rename-assm²-crossed-under-right-tailᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-crossed-under-right-tailᵢ
-    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
-  there (rename-assm²-crossed-under-right-tailᵢ a∈)
-rename-assm²-crossed-under-right-tailᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
-  here refl
-rename-assm²-crossed-under-right-tailᵢ
-    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
-  there (rename-assm²-crossed-under-right-tailᵢ a∈)
-
-rename-assm²-crossed-under-rightᵢ :
-  ∀ {Φ a} →
-  a ∈ ⇑ᴿᵢ Φ →
-  rename-assm²ᵢ
-    (λ X → suc (suc X))
-    (extᵗ (λ X → suc (suc X))) a
-    ∈ ⇑ᴿᵢ (swapRight∀∀ᵢ Φ)
-rename-assm²-crossed-under-rightᵢ a∈ =
-  there (there (rename-assm²-crossed-under-right-tailᵢ a∈))
-
-renameᵗ-double-lift :
-  ∀ A →
-  ⇑ᵗ (⇑ᵗ A) ≡ renameᵗ (λ X → suc (suc X)) A
-renameᵗ-double-lift A = renameᵗ-compose suc suc A
-
-renameᵗ-double-under-∀ :
-  ∀ A →
-  renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A) ≡
-    renameᵗ (extᵗ (λ X → suc (suc X))) A
-renameᵗ-double-under-∀ A =
-  trans (renameᵗ-compose (extᵗ suc) (extᵗ suc) A)
-    (rename-cong (λ { zero → refl ; (suc X) → refl }) A)
-
-⊑-crossed-double-lift-under-rightᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ⇑ᴿᵢ (swapRight∀∀ᵢ Φ) ∣ suc (suc Δᴸ)
-    ⊢ ⇑ᵗ (⇑ᵗ A)
-      ⊑ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) B)
-    ⊣ suc (suc (suc Δᴿ))
-⊑-crossed-double-lift-under-rightᵢ {A = A} {B = B} p =
-  subst
-    (λ T → _ ∣ _ ⊢ ⇑ᵗ (⇑ᵗ A) ⊑ T ⊣ _)
-    (sym (renameᵗ-double-under-∀ B))
-    (subst
-      (λ S → _ ∣ _ ⊢ S ⊑
-        renameᵗ (extᵗ (λ X → suc (suc X))) B ⊣ _)
-      (sym (renameᵗ-double-lift A))
-      (⊑-renameᵗ²ᵢ
-        rename-assm²-crossed-under-rightᵢ
-        (λ X<Δ → s<s (s<s X<Δ))
-        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
-        p))
-
-rename-assm²-crossed-doubleᵢ :
-  ∀ {Φ a} →
-  a ∈ Φ →
-  rename-assm²ᵢ (λ X → suc (suc X)) (λ X → suc (suc X)) a
-    ∈ swapRight∀∀ᵢ Φ
-rename-assm²-crossed-doubleᵢ {a = X ˣ⊑★} a∈ =
-  rename-assm²-swapRight∀∀ᵢ
-    (rename-assm²-∀ᵢ (rename-assm²-∀ᵢ a∈))
-rename-assm²-crossed-doubleᵢ {a = X ˣ⊑ˣ Y} a∈ =
-  rename-assm²-swapRight∀∀ᵢ
-    (rename-assm²-∀ᵢ (rename-assm²-∀ᵢ a∈))
-
-⊑-crossed-double-lift-under-∀ᵢ :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
-  ∀ᵢᶜ (swapRight∀∀ᵢ Φ) ∣ suc (suc (suc Δᴸ))
-    ⊢ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A)
-      ⊑ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) B)
-    ⊣ suc (suc (suc Δᴿ))
-⊑-crossed-double-lift-under-∀ᵢ {A = A} {B = B} p =
-  subst
-    (λ T → _ ∣ _ ⊢
-      renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A) ⊑ T ⊣ _)
-    (sym (renameᵗ-double-under-∀ B))
-    (subst
-      (λ S → _ ∣ _ ⊢ S ⊑
-        renameᵗ (extᵗ (λ X → suc (suc X))) B ⊣ _)
-      (sym (renameᵗ-double-under-∀ A))
-      (⊑-renameᵗ²ᵢ
-        (rename-assm²-⇑ᵢ rename-assm²-crossed-doubleᵢ)
-        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
-        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
-        p))
-
-weak-one-step-source-blame-right-allocationᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ V′ s s′}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  StoreWf Δᴿ (rightStoreⁱ ρ) →
-  Value V′ →
-  No• V′ →
-  WfTy (suc Δᴿ) (⇑ᵗ A′) →
-  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ ν A′ V′ s′ ⦂ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepResult ρ
-    (ν A blame s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind A′)
-weak-one-step-source-blame-right-allocationᵀ
-    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′}
-    {V′ = V′} {s′ = s′} {ρ = ρ}
-    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB
-    with lift-right-store-result ρ
-weak-one-step-source-blame-right-allocationᵀ
-    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′}
-    {V′ = V′} {s′ = s′} {ρ = ρ}
-    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB
-    | ρ′ , liftρ =
-  record
-    { sourceChanges = keep ∷ []
-    ; targetTailChanges = []
-    ; sourceResult = blame
-    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; resultCtx = ⇑ᴿᵢ _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore = store-right zero (⇑ᵗ A′) h⇑A′ ∷ ρ′
-    ; resultSourceType = _
-    ; resultTargetType = ⇑ᵗ B′
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = ⊑-target-lift-rightᵢ
-    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
-    ; transportRightBody = ⊑-target-lift-under-rightᵢ
-    ; resultType = ⊑-target-lift-rightᵢ pB
-    ; sourceCatchup = ↠-step blame-ν ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
-    ; targetStoreResult = target-store-result
-    ; relatedResults = blame⊑ᵀ target-result-typing
-    }
-  where
-    target-store-result =
-      cong ((zero , ⇑ᵗ A′) ∷_)
-        (rightStoreⁱ-lift-right liftρ)
-
-    target-result-typing =
-      subst
-        (λ Σ → suc Δᴿ ∣ Σ ∣ []
-          ⊢ ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩ ⦂ ⇑ᵗ B′)
-        (sym target-store-result)
-        (preservation wfΣ′ (ok-ν (ok-no noV′)) target⊢
-          (ν-step vV′ noV′))
-
-weak-one-step-compose-type :
-  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (first : WeakOneStepResult ρ M M′ A B χ) →
-  ∀ {χ′ N′} →
-  (second : WeakOneStepResult (resultStore first)
-    (sourceResult first) N′
-    (resultSourceType first) (resultTargetType first) χ′) →
-  ∀ {C D} →
-  Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
-  resultCtx second ∣ resultLeftCtx second
-    ⊢ applyTys (sourceChanges first ++ sourceChanges second) C
-      ⊑ applyTys
-        (targetTailChanges first ++
-          χ′ ∷ targetTailChanges second)
-        (applyTy χ D)
-      ⊣ resultRightCtx second
-weak-one-step-compose-type {B = B} {χ = χ} first
-    {χ′ = χ′} second {C = C} {D = D} p =
-  subst
-    (λ T → resultCtx second ∣ resultLeftCtx second
-      ⊢ applyTys
-          (sourceChanges first ++ sourceChanges second) C
-        ⊑ T ⊣ resultRightCtx second)
-    (sym (applyTys-++
-      (targetTailChanges first)
-      (χ′ ∷ targetTailChanges second)
-      (applyTy χ D)))
-    (subst
-      (λ S → resultCtx second ∣ resultLeftCtx second
-        ⊢ S ⊑ applyTys (targetTailChanges second)
-            (applyTy χ′
-              (applyTys (targetTailChanges first)
-                (applyTy χ D)))
-          ⊣ resultRightCtx second)
-      (sym (applyTys-++
-        (sourceChanges first) (sourceChanges second) C))
-      (transportType second (transportType first p)))
-
-weak-one-step-compose-all-body :
-  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (first : WeakOneStepResult ρ M M′ A B χ) →
-  ∀ {χ′ N′} →
-  (second : WeakOneStepResult (resultStore first)
-    (sourceResult first) N′
-    (resultSourceType first) (resultTargetType first) χ′) →
-  ∀ {C D} →
-  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
-  ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
-    ⊢ applyTysUnderTyBinders
-        (sourceChanges first ++ sourceChanges second) C
-      ⊑ applyTysUnderTyBinders
-          (targetTailChanges first ++
-            χ′ ∷ targetTailChanges second)
-          (applyTyUnderTyBinder χ D)
-      ⊣ suc (resultRightCtx second)
-weak-one-step-compose-all-body {χ = χ} first
-    {χ′ = χ′} second {C = C} {D = D} p =
-  subst
-    (λ T → ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
-      ⊢ applyTysUnderTyBinders
-          (sourceChanges first ++ sourceChanges second) C
-        ⊑ T ⊣ suc (resultRightCtx second))
-    (sym (applyTysUnderTyBinders-++
-      (targetTailChanges first)
-      (χ′ ∷ targetTailChanges second)
-      (applyTyUnderTyBinder χ D)))
-    (subst
-      (λ S → ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
-        ⊢ S ⊑ applyTysUnderTyBinders
-            (targetTailChanges second)
-            (applyTyUnderTyBinder χ′
-              (applyTysUnderTyBinders
-                (targetTailChanges first)
-                (applyTyUnderTyBinder χ D)))
-          ⊣ suc (resultRightCtx second))
-      (sym (applyTysUnderTyBinders-++
-        (sourceChanges first) (sourceChanges second) C))
-      (transportAllBody second (transportAllBody first p)))
-
-weak-one-step-compose-right-body :
-  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (first : WeakOneStepResult ρ M M′ A B χ) →
-  ∀ {χ′ N′} →
-  (second : WeakOneStepResult (resultStore first)
-    (sourceResult first) N′
-    (resultSourceType first) (resultTargetType first) χ′) →
-  ∀ {C D} →
-  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
-  ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
-    ⊢ applyTys
-        (sourceChanges first ++ sourceChanges second) C
-      ⊑ applyTysUnderTyBinders
-          (targetTailChanges first ++
-            χ′ ∷ targetTailChanges second)
-          (applyTyUnderTyBinder χ D)
-      ⊣ suc (resultRightCtx second)
-weak-one-step-compose-right-body {χ = χ} first
-    {χ′ = χ′} second {C = C} {D = D} p =
-  subst
-    (λ T → ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
-      ⊢ applyTys
-          (sourceChanges first ++ sourceChanges second) C
-        ⊑ T ⊣ suc (resultRightCtx second))
-    (sym (applyTysUnderTyBinders-++
-      (targetTailChanges first)
-      (χ′ ∷ targetTailChanges second)
-      (applyTyUnderTyBinder χ D)))
-    (subst
-      (λ S → ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
-        ⊢ S ⊑ applyTysUnderTyBinders
-            (targetTailChanges second)
-            (applyTyUnderTyBinder χ′
-              (applyTysUnderTyBinders
-                (targetTailChanges first)
-                (applyTyUnderTyBinder χ D)))
-          ⊣ suc (resultRightCtx second))
-      (sym (applyTys-++
-        (sourceChanges first) (sourceChanges second) C))
-      (transportRightBody second (transportRightBody first p)))
-
-weak-one-step-composeᵀ :
-  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (first : WeakOneStepResult ρ M M′ A B χ) →
-  ∀ {χ′ N′} →
-  targetResult first —→[ χ′ ] N′ →
-  (second : WeakOneStepResult (resultStore first)
-    (sourceResult first) N′
-    (resultSourceType first) (resultTargetType first) χ′) →
-  WeakOneStepResult ρ M M′ A B χ
-weak-one-step-composeᵀ {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B}
-    {χ = χ} {ρ = ρ} first {χ′ = χ′} target→ second =
-  record
-    { sourceChanges = sourceChanges first ++ sourceChanges second
-    ; targetTailChanges =
-        targetTailChanges first ++ χ′ ∷ targetTailChanges second
-    ; sourceResult = sourceResult second
-    ; targetResult = targetResult second
-    ; resultCtx = resultCtx second
-    ; resultLeftCtx = resultLeftCtx second
-    ; resultRightCtx = resultRightCtx second
-    ; sourceCtxResult =
-        trans (sourceCtxResult second)
-          (trans
-            (cong (applyTyCtxs (sourceChanges second))
-              (sourceCtxResult first))
-            (sym (applyTyCtxs-++
-              (sourceChanges first) (sourceChanges second) Δᴸ)))
-    ; targetCtxResult =
-        trans (targetCtxResult second)
-          (trans
-            (cong
-              (λ Δ → applyTyCtxs (targetTailChanges second)
-                (applyTyCtx χ′ Δ))
-              (targetCtxResult first))
-            (sym (applyTyCtxs-++
-              (targetTailChanges first)
-              (χ′ ∷ targetTailChanges second)
-              (applyTyCtx χ Δᴿ))))
-    ; resultStore = resultStore second
-    ; resultSourceType = resultSourceType second
-    ; resultTargetType = resultTargetType second
-    ; sourceTypeResult =
-        trans (sourceTypeResult second)
-          (trans
-            (cong (applyTys (sourceChanges second))
-              (sourceTypeResult first))
-            (sym (applyTys-++
-              (sourceChanges first) (sourceChanges second) A)))
-    ; targetTypeResult =
-        trans (targetTypeResult second)
-          (trans
-            (cong
-              (λ C → applyTys (targetTailChanges second)
-                (applyTy χ′ C))
-              (targetTypeResult first))
-            (sym (applyTys-++
-              (targetTailChanges first)
-              (χ′ ∷ targetTailChanges second)
-              (applyTy χ B))))
-    ; transportType = weak-one-step-compose-type first second
-    ; transportAllBody = weak-one-step-compose-all-body first second
-    ; transportRightBody =
-        weak-one-step-compose-right-body first second
-    ; resultType = resultType second
-    ; sourceCatchup =
-        ↠-trans (sourceCatchup first) (sourceCatchup second)
-    ; targetTail =
-        ↠-trans (targetTail first)
-          (↠-step target→ (targetTail second))
-    ; sourceStoreResult =
-        trans (sourceStoreResult second)
-          (trans
-            (cong (applyStores (sourceChanges second))
-              (sourceStoreResult first))
-            (sym (applyStores-++
-              (sourceChanges first) (sourceChanges second)
-              (leftStoreⁱ ρ))))
-    ; targetStoreResult =
-        trans (targetStoreResult second)
-          (trans
-            (cong
-              (λ Σ → applyStores (targetTailChanges second)
-                (applyStore χ′ Σ))
-              (targetStoreResult first))
-            (sym (applyStores-++
-              (targetTailChanges first)
-              (χ′ ∷ targetTailChanges second)
-              (applyStore χ (rightStoreⁱ ρ)))))
-    ; relatedResults = relatedResults second
-    }
-
-weak-one-step-prepend-left-silentᵀ :
-  ∀ {Φ Δᴸ Δᴿ M V′ A B}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (silent : LeftSilentResult {M = M} {V′ = V′} {ρ = ρ}) →
-  let first = silentResult silent in
-  ∀ {χ N′} →
-  (second : WeakOneStepResult (resultStore first)
-    (sourceResult first) N′
-    (resultSourceType first) (resultTargetType first) χ) →
-  WeakOneStepResult ρ M N′ A B χ
-weak-one-step-prepend-left-silentᵀ
-    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B} {ρ = ρ}
-    (left-silent first (left-silent-invariant refl refl))
-    {χ = χ} second =
-  record
-    { sourceChanges = sourceChanges first ++ sourceChanges second
-    ; targetTailChanges = targetTailChanges second
-    ; sourceResult = sourceResult second
-    ; targetResult = targetResult second
-    ; resultCtx = resultCtx second
-    ; resultLeftCtx = resultLeftCtx second
-    ; resultRightCtx = resultRightCtx second
-    ; sourceCtxResult =
-        trans (sourceCtxResult second)
-          (trans
-            (cong (applyTyCtxs (sourceChanges second))
-              (sourceCtxResult first))
-            (sym (applyTyCtxs-++
-              (sourceChanges first) (sourceChanges second) Δᴸ)))
-    ; targetCtxResult =
-        trans (targetCtxResult second)
-          (cong
-            (λ Δ → applyTyCtxs (targetTailChanges second)
-              (applyTyCtx χ Δ))
-            (targetCtxResult first))
-    ; resultStore = resultStore second
-    ; resultSourceType = resultSourceType second
-    ; resultTargetType = resultTargetType second
-    ; sourceTypeResult =
-        trans (sourceTypeResult second)
-          (trans
-            (cong (applyTys (sourceChanges second))
-              (sourceTypeResult first))
-            (sym (applyTys-++
-              (sourceChanges first) (sourceChanges second) A)))
-    ; targetTypeResult =
-        trans (targetTypeResult second)
-          (cong
-            (λ C → applyTys (targetTailChanges second)
-              (applyTy χ C))
-            (targetTypeResult first))
-    ; transportType = weak-one-step-compose-type first second
-    ; transportAllBody = weak-one-step-compose-all-body first second
-    ; transportRightBody =
-        weak-one-step-compose-right-body first second
-    ; resultType = resultType second
-    ; sourceCatchup =
-        ↠-trans (sourceCatchup first) (sourceCatchup second)
-    ; targetTail = targetTail second
-    ; sourceStoreResult =
-        trans (sourceStoreResult second)
-          (trans
-            (cong (applyStores (sourceChanges second))
-              (sourceStoreResult first))
-            (sym (applyStores-++
-              (sourceChanges first) (sourceChanges second)
-              (leftStoreⁱ ρ))))
-    ; targetStoreResult =
-        trans (targetStoreResult second)
-          (cong
-            (λ Σ → applyStores (targetTailChanges second)
-              (applyStore χ Σ))
-            (targetStoreResult first))
-    ; relatedResults = relatedResults second
-    }
-
-weak-one-step-relatedᵀ :
-  ∀ {Φ Δᴸ Δᴿ M N A B p}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p →
-  WeakOneStepResult ρ M N A B keep
-weak-one-step-relatedᵀ result =
-  record
-    { sourceChanges = []
-    ; targetTailChanges = []
-    ; sourceResult = _
-    ; targetResult = _
-    ; resultCtx = _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore = _
-    ; resultSourceType = _
-    ; resultTargetType = _
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = λ p → p
-    ; transportAllBody = λ p → p
-    ; transportRightBody = λ p → p
-    ; resultType = _
-    ; sourceCatchup = ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult = refl
-    ; targetStoreResult = refl
-    ; relatedResults = result
-    }
-
-left-catchup-relatedᵀ :
-  ∀ {Φ Δᴸ Δᴿ M V′ A B p}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (Value M × No• M) ⊎ M ≡ blame →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ M ⊑ V′ ⦂ A ⊑ B ∶ p →
-  LeftCatchupResult {M = M} {V′ = V′} {ρ = ρ}
-left-catchup-relatedᵀ final result =
-  left-catchup (weak-one-step-relatedᵀ result)
-    (left-catchup-invariant
-      (left-silent-invariant refl refl) final)
-
-weak-one-step-source-blameᵀ :
-  ∀ {Φ Δᴸ Δᴿ ρ M N′ A B χ χs} →
-  M —↠[ χs ] blame →
-  WeakOneStepOutcome {Φ} {Δᴸ} {Δᴿ} ρ M N′ A B χ
-weak-one-step-source-blameᵀ = outcome-source-blame
-
-ν-blame-tail :
-  ∀ {N A c χs} →
-  N —↠[ χs ] blame →
-  ν A N c —↠[ χs ++ keep ∷ [] ] blame
-ν-blame-tail N↠blame =
-  ↠-trans (ν-↠ N↠blame)
-    (↠-step blame-ν ↠-refl)
-
-weak-outcome-map-source :
-  ∀ {Φ Δᴸ Δᴿ M M₀ N′ A A₀ B χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (WeakOneStepResult ρ M N′ A B χ →
-    WeakOneStepResult ρ M₀ N′ A₀ B χ) →
-  (∀ {χs} → M —↠[ χs ] blame →
-    ∃[ χs′ ] (M₀ —↠[ χs′ ] blame)) →
-  WeakOneStepOutcome ρ M N′ A B χ →
-  WeakOneStepOutcome ρ M₀ N′ A₀ B χ
-weak-outcome-map-source frame blame-frame (outcome-related result) =
-  outcome-related (frame result)
-weak-outcome-map-source frame blame-frame
-    (outcome-source-blame source↠)
-    with blame-frame source↠
-weak-outcome-map-source frame blame-frame
-    (outcome-source-blame source↠) | χs′ , source₀↠ =
-  outcome-source-blame source₀↠
-
-weak-outcome-map-target-ν :
-  ∀ {Φ Δᴸ Δᴿ M N′ A B C D Aν c χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (WeakOneStepResult ρ M N′ A B χ →
-    WeakOneStepResult ρ M (ν Aν N′ c) C D χ) →
-  WeakOneStepOutcome ρ M N′ A B χ →
-  WeakOneStepOutcome ρ M (ν Aν N′ c) C D χ
-weak-outcome-map-target-ν frame (outcome-related result) =
-  outcome-related (frame result)
-weak-outcome-map-target-ν frame (outcome-source-blame source↠) =
-  outcome-source-blame source↠
-
-weak-all-outcome-map-target-ν :
-  ∀ {Φ Δᴸ Δᴿ N M₀ N′ C C′ A B Aν c χ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (WeakOneStepAllResult
-      {N = N} {N₁′ = N′} {C = C} {C′ = C′}
-      {χ = χ} {ρ = ρ} q →
-    WeakOneStepResult ρ M₀ (ν Aν N′ c) A B χ) →
-  (∀ {χs} → N —↠[ χs ] blame →
-    ∃[ χs′ ] (M₀ —↠[ χs′ ] blame)) →
-  WeakOneStepAllOutcome
-    {N = N} {N₁′ = N′} {C = C} {C′ = C′}
-    {χ = χ} {ρ = ρ} q →
-  WeakOneStepOutcome ρ M₀ (ν Aν N′ c) A B χ
-weak-all-outcome-map-target-ν frame blame-frame
-    (all-outcome-related result) =
-  outcome-related (frame result)
-weak-all-outcome-map-target-ν frame blame-frame
-    (all-outcome-source-blame source↠)
-    with blame-frame source↠
-weak-all-outcome-map-target-ν frame blame-frame
-    (all-outcome-source-blame source↠) | χs′ , source₀↠ =
-  outcome-source-blame source₀↠
-
-weak-one-step-all-relatedᵀ :
-  ∀ {Φ Δᴸ Δᴿ N N′ C C′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  WeakOneStepAllResult {χ = keep} q
-weak-one-step-all-relatedᵀ result =
-  weak-all-result (weak-one-step-relatedᵀ result) result
-
-left-catchup-all-relatedᵀ :
-  ∀ {Φ Δᴸ Δᴿ N V′ C C′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  (Value N × No• N) ⊎ N ≡ blame →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q
-left-catchup-all-relatedᵀ final result =
-  left-all-catchup (weak-one-step-all-relatedᵀ result)
-    (left-catchup-invariant
-      (left-silent-invariant refl refl) final)
-
-left-catchup-all-valueᵀ :
-  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  RuntimeOK V →
-  Value V →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  LeftCatchupAllResult {N = V} {V′ = V′} {ρ = ρ} q
-left-catchup-all-valueᵀ okV vV V⊑V′ =
-  left-catchup-all-relatedᵀ
-    (inj₁ (vV , runtime-value-no• okV vV)) V⊑V′
-
-left-catchup-all-blameᵀ :
-  ∀ {Φ Δᴸ Δᴿ V′ C C′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ blame ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  LeftCatchupAllResult {N = blame} {V′ = V′} {ρ = ρ} q
-left-catchup-all-blameᵀ blame⊑V′ =
-  left-catchup-all-relatedᵀ (inj₂ refl) blame⊑V′
-
-weak-one-step-all-outcome-relatedᵀ :
-  ∀ {Φ Δᴸ Δᴿ N N′ C C′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  WeakOneStepAllOutcome {χ = keep} q
-weak-one-step-all-outcome-relatedᵀ result =
-  all-outcome-related (weak-one-step-all-relatedᵀ result)
-
-weak-one-step-matched-ν-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepAllResult
-    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
-    {χ = χ} {ρ = ρ} q →
-  WeakOneStepResult ρ
-    (ν A N s)
-    (ν (applyTy χ A′) N₁′ (applyCoercionUnderTyBinder χ s′))
-    B B′ χ
-weak-one-step-matched-ν-frameᵀ
-    {A = A} {A′ = A′} {B = B} {B′ = B′}
-    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
-    s↑ s′↑ pA pB (weak-all-result inner innerAll)
-    with lift-store-result (resultStore inner)
-weak-one-step-matched-ν-frameᵀ
-    {A = A} {A′ = A′} {B = B} {B′ = B′}
-    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
-    s↑ s′↑ pA pB (weak-all-result inner innerAll)
-    | ρ′ , liftρ
-    with apply-reveal-under-ty-binders
-      {χs = sourceChanges inner} s↑
-       | apply-reveal-under-ty-binders
-      {χs = χ ∷ targetTailChanges inner} s′↑
-weak-one-step-matched-ν-frameᵀ
-    {A = A} {A′ = A′} {B = B} {B′ = B′}
-    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
-    s↑ s′↑ pA pB (weak-all-result inner innerAll)
-    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
-  record
-    { sourceChanges = sourceChanges inner
-    ; targetTailChanges = targetTailChanges inner
-    ; sourceResult =
-        ν (applyTys (sourceChanges inner) A)
-          (sourceResult inner)
-          (applyCoercionUnderTyBinders (sourceChanges inner) s)
-    ; targetResult =
-        ν (applyTys (targetTailChanges inner) (applyTy χ A′))
-          (targetResult inner)
-          (applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ s′))
-    ; resultCtx = resultCtx inner
-    ; resultLeftCtx = resultLeftCtx inner
-    ; resultRightCtx = resultRightCtx inner
-    ; sourceCtxResult = sourceCtxResult inner
-    ; targetCtxResult = targetCtxResult inner
-    ; resultStore = resultStore inner
-    ; resultSourceType = applyTys (sourceChanges inner) B
-    ; resultTargetType =
-        applyTys (targetTailChanges inner) (applyTy χ B′)
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = transportType inner
-    ; transportAllBody = transportAllBody inner
-    ; transportRightBody = transportRightBody inner
-    ; resultType = transportType inner pB
-    ; sourceCatchup = ν-↠ (sourceCatchup inner)
-    ; targetTail = ν-↠ (targetTail inner)
-    ; sourceStoreResult = sourceStoreResult inner
-    ; targetStoreResult = targetStoreResult inner
-    ; relatedResults =
-        ν⊑νᵀ
-          (⊑-src-wf (transportType inner pA))
-          (⊑-tgt-wf (transportType inner pA))
-          source-reveal target-reveal
-          (transportType inner pA)
-          (⊑-lift∀ᵢ (transportType inner pA))
-          liftρ lift-ctx-[] innerAll
-    }
-  where
-    source-reveal =
-      subst
-        (λ Δ → RevealConversion μᵣ (suc Δ)
-          ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
-            ⟰ᵗ (leftStoreⁱ (resultStore inner)))
-          zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-          (applyCoercionUnderTyBinders (sourceChanges inner) s)
-          (applyTysUnderTyBinders (sourceChanges inner) C)
-          (⇑ᵗ (applyTys (sourceChanges inner) B)))
-        (sym (sourceCtxResult inner))
-        (subst
-          (λ Σ → RevealConversion μᵣ
-            (suc (applyTyCtxs (sourceChanges inner) _))
-            ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
-              ⟰ᵗ Σ)
-            zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-            (applyCoercionUnderTyBinders (sourceChanges inner) s)
-            (applyTysUnderTyBinders (sourceChanges inner) C)
-            (⇑ᵗ (applyTys (sourceChanges inner) B)))
-          (sym (sourceStoreResult inner)) source↑)
-
-    target-reveal =
-      subst
-        (λ Δ → RevealConversion μᵗ (suc Δ)
-          ((zero , ⇑ᵗ
-              (applyTys (targetTailChanges inner) (applyTy χ A′))) ∷
-            ⟰ᵗ (rightStoreⁱ (resultStore inner)))
-          zero (⇑ᵗ
-            (applyTys (targetTailChanges inner) (applyTy χ A′)))
-          (applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ s′))
-          (applyTysUnderTyBinders (targetTailChanges inner)
-            (applyTyUnderTyBinder χ C′))
-          (⇑ᵗ
-            (applyTys (targetTailChanges inner) (applyTy χ B′))))
-        (sym (targetCtxResult inner))
-        (subst
-          (λ Σ → RevealConversion μᵗ
-            (suc (applyTyCtxs (targetTailChanges inner)
-              (applyTyCtx χ _)))
-            ((zero , ⇑ᵗ
-                (applyTys (targetTailChanges inner) (applyTy χ A′))) ∷
-              ⟰ᵗ Σ)
-            zero (⇑ᵗ
-              (applyTys (targetTailChanges inner) (applyTy χ A′)))
-            (applyCoercionUnderTyBinders (targetTailChanges inner)
-              (applyCoercionUnderTyBinder χ s′))
-            (applyTysUnderTyBinders (targetTailChanges inner)
-              (applyTyUnderTyBinder χ C′))
-            (⇑ᵗ
-              (applyTys (targetTailChanges inner) (applyTy χ B′))))
-          (sym (targetStoreResult inner)) target↑)
-
-left-silent-matched-ν-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (all : WeakOneStepAllResult
-    {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q) →
-  LeftSilentInvariant (weakResult all) →
-  LeftSilentResult
-    {M = ν A N s} {V′ = ν A′ V′ s′}
-    {A = B} {B = B′} {ρ = ρ}
-left-silent-matched-ν-frameᵀ
-    s↑ s′↑ pA pB (weak-all-result inner innerAll)
-    (left-silent-invariant refl refl)
-    with lift-store-result (resultStore inner)
-left-silent-matched-ν-frameᵀ
-    s↑ s′↑ pA pB (weak-all-result inner innerAll)
-    (left-silent-invariant refl refl)
-    | ρ′ , liftρ
-    with apply-reveal-under-ty-binders
-      {χs = sourceChanges inner} s↑
-       | apply-reveal-under-ty-binders
-      {χs = keep ∷ []} s′↑
-left-silent-matched-ν-frameᵀ
-    s↑ s′↑ pA pB (weak-all-result inner innerAll)
-    (left-silent-invariant refl refl)
-    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
-  left-silent
-    (weak-one-step-matched-ν-frameᵀ
-      s↑ s′↑ pA pB (weak-all-result inner innerAll))
-    (left-silent-invariant refl refl)
-
-weak-one-step-matched-νcast-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepAllResult
-    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
-    {χ = χ} {ρ = ρ} q →
-  WeakOneStepResult ρ
-    (ν ★ N s)
-    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s′))
-    B B′ χ
-weak-one-step-matched-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    (weak-all-result inner innerAll)
-    with lift-store-result (resultStore inner)
-weak-one-step-matched-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    (weak-all-result inner innerAll)
-    | ρ′ , liftρ
-    with apply-widen-inst-under-ty-binders
-      {χs = sourceChanges inner} mode seal★ s⊑
-       | apply-widen-inst-under-ty-binders
-      {χs = χ ∷ targetTailChanges inner} mode′ seal★′ s′⊑
-weak-one-step-matched-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    (weak-all-result inner innerAll)
-    | ρ′ , liftρ
-    | μᵣ , modeᵣ , sealᵣ , source⊑
-    | μᵗ , modeᵗ , sealᵗ , target⊑ =
-  record
-    { sourceChanges = sourceChanges inner
-    ; targetTailChanges = targetTailChanges inner
-    ; sourceResult =
-        ν ★ (sourceResult inner)
-          (applyCoercionUnderTyBinders (sourceChanges inner) s)
-    ; targetResult =
-        ν ★ (targetResult inner)
-          (applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ s′))
-    ; resultCtx = resultCtx inner
-    ; resultLeftCtx = resultLeftCtx inner
-    ; resultRightCtx = resultRightCtx inner
-    ; sourceCtxResult = sourceCtxResult inner
-    ; targetCtxResult = targetCtxResult inner
-    ; resultStore = resultStore inner
-    ; resultSourceType = applyTys (sourceChanges inner) B
-    ; resultTargetType =
-        applyTys (targetTailChanges inner) (applyTy χ B′)
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = transportType inner
-    ; transportAllBody = transportAllBody inner
-    ; transportRightBody = transportRightBody inner
-    ; resultType = transportType inner pB
-    ; sourceCatchup =
-        subst
-          (λ T → ν ★ N s —↠[ sourceChanges inner ]
-            ν T (sourceResult inner)
-              (applyCoercionUnderTyBinders (sourceChanges inner) s))
-          (applyTys-★ (sourceChanges inner))
-          (ν-↠ (sourceCatchup inner))
-    ; targetTail =
-        subst
-          (λ T → ν ★ N₁′ (applyCoercionUnderTyBinder χ s′)
-            —↠[ targetTailChanges inner ]
-            ν T (targetResult inner)
-              (applyCoercionUnderTyBinders (targetTailChanges inner)
-                (applyCoercionUnderTyBinder χ s′)))
-          (applyTys-★ (targetTailChanges inner))
-          (ν-↠ (targetTail inner))
-    ; sourceStoreResult = sourceStoreResult inner
-    ; targetStoreResult = targetStoreResult inner
-    ; relatedResults =
-        νcast⊑νcastᵀ modeᵣ source-seal modeᵗ target-seal
-          source-widen target-widen
-          liftρ lift-ctx-[] innerAll
-    }
-  where
-    source-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ μᵣ)
-          ((zero , ★) ∷ ⟰ᵗ Σ))
-        (sym (sourceStoreResult inner)) sealᵣ
-
-    source-widen =
-      subst
-        (λ Δ → instᵈ μᵣ ∣ suc Δ
-          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
-          ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
-            ∶ applyTysUnderTyBinders (sourceChanges inner) C
-              ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-        (sym (sourceCtxResult inner))
-        (subst
-          (λ Σ → instᵈ μᵣ
-            ∣ suc (applyTyCtxs (sourceChanges inner) _)
-            ∣ (zero , ★) ∷ ⟰ᵗ Σ
-            ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
-              ∶ applyTysUnderTyBinders (sourceChanges inner) C
-                ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-          (sym (sourceStoreResult inner)) source⊑)
-
-    target-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ μᵗ)
-          ((zero , ★) ∷ ⟰ᵗ Σ))
-        (sym (targetStoreResult inner)) sealᵗ
-
-    target-widen =
-      subst
-        (λ Δ → instᵈ μᵗ ∣ suc Δ
-          ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
-          ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-              (applyCoercionUnderTyBinder χ s′)
-            ∶ applyTysUnderTyBinders (targetTailChanges inner)
-                (applyTyUnderTyBinder χ C′)
-              ⊑ ⇑ᵗ
-                  (applyTys (targetTailChanges inner) (applyTy χ B′)))
-        (sym (targetCtxResult inner))
-        (subst
-          (λ Σ → instᵈ μᵗ
-            ∣ suc (applyTyCtxs (targetTailChanges inner)
-              (applyTyCtx χ _))
-            ∣ (zero , ★) ∷ ⟰ᵗ Σ
-            ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-                (applyCoercionUnderTyBinder χ s′)
-              ∶ applyTysUnderTyBinders (targetTailChanges inner)
-                  (applyTyUnderTyBinder χ C′)
-                ⊑ ⇑ᵗ
-                    (applyTys (targetTailChanges inner) (applyTy χ B′)))
-          (sym (targetStoreResult inner)) target⊑)
-
-left-silent-matched-νcast-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (all : WeakOneStepAllResult
-    {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q) →
-  LeftSilentInvariant (weakResult all) →
-  LeftSilentResult
-    {M = ν ★ N s} {V′ = ν ★ V′ s′}
-    {A = B} {B = B′} {ρ = ρ}
-left-silent-matched-νcast-frameᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    (weak-all-result inner innerAll)
-    (left-silent-invariant refl refl)
-    with lift-store-result (resultStore inner)
-left-silent-matched-νcast-frameᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    (weak-all-result inner innerAll)
-    (left-silent-invariant refl refl)
-    | ρ′ , liftρ
-    with apply-widen-inst-under-ty-binders
-      {χs = sourceChanges inner} mode seal★ s⊑
-       | apply-widen-inst-under-ty-binders
-      {χs = keep ∷ []} mode′ seal★′ s′⊑
-left-silent-matched-νcast-frameᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    (weak-all-result inner innerAll)
-    (left-silent-invariant refl refl)
-    | ρ′ , liftρ
-    | μᵣ , modeᵣ , sealᵣ , source⊑
-    | μᵗ , modeᵗ , sealᵗ , target⊑ =
-  left-silent
-    (weak-one-step-matched-νcast-frameᵀ
-      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-      (weak-all-result inner innerAll))
-    (left-silent-invariant refl refl)
-
-weak-one-step-source-ν-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  WfTy Δᴸ A →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
-  WeakOneStepResult ρ (ν A N s) N₁′ B B′ χ
-weak-one-step-source-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    hA s↑ pB inner
-    with weak-result-source-all inner
-weak-one-step-source-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    hA s↑ pB inner
-    | q′ , innerResult
-    with lift-left-store-result (resultStore inner)
-weak-one-step-source-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    hA s↑ pB inner
-    | q′ , innerResult | ρ′ , liftρ
-    with apply-reveal-under-ty-binders
-      {χs = sourceChanges inner} s↑
-weak-one-step-source-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    hA s↑ pB inner
-    | q′ , innerResult | ρ′ , liftρ | μ′ , source↑ =
-  record
-    { sourceChanges = sourceChanges inner
-    ; targetTailChanges = targetTailChanges inner
-    ; sourceResult =
-        ν (applyTys (sourceChanges inner) A)
-          (sourceResult inner)
-          (applyCoercionUnderTyBinders (sourceChanges inner) s)
-    ; targetResult = targetResult inner
-    ; resultCtx = resultCtx inner
-    ; resultLeftCtx = resultLeftCtx inner
-    ; resultRightCtx = resultRightCtx inner
-    ; sourceCtxResult = sourceCtxResult inner
-    ; targetCtxResult = targetCtxResult inner
-    ; resultStore = resultStore inner
-    ; resultSourceType = applyTys (sourceChanges inner) B
-    ; resultTargetType =
-        applyTys (targetTailChanges inner) (applyTy χ B′)
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = transportType inner
-    ; transportAllBody = transportAllBody inner
-    ; transportRightBody = transportRightBody inner
-    ; resultType = transportType inner pB
-    ; sourceCatchup = ν-↠ (sourceCatchup inner)
-    ; targetTail = targetTail inner
-    ; sourceStoreResult = sourceStoreResult inner
-    ; targetStoreResult = targetStoreResult inner
-    ; relatedResults =
-        ν⊑ᵀ final-wf final-shift-wf source-reveal
-          liftρ lift-left-ctx-[] innerResult
-    }
-  where
-    final-wf =
-      subst
-        (λ Δ → WfTy Δ (applyTys (sourceChanges inner) A))
-        (sym (sourceCtxResult inner))
-        (wfTy-applyTys (sourceChanges inner) hA)
-
-    final-shift-wf =
-      renameᵗ-preserves-WfTy final-wf TyRenameWf-suc
-
-    source-reveal =
-      subst
-        (λ Δ → RevealConversion μ′ (suc Δ)
-          ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
-            ⟰ᵗ (leftStoreⁱ (resultStore inner)))
-          zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-          (applyCoercionUnderTyBinders (sourceChanges inner) s)
-          (applyTysUnderTyBinders (sourceChanges inner) C)
-          (⇑ᵗ (applyTys (sourceChanges inner) B)))
-        (sym (sourceCtxResult inner))
-        (subst
-          (λ Σ → RevealConversion μ′
-            (suc (applyTyCtxs (sourceChanges inner) _))
-            ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
-              ⟰ᵗ Σ)
-            zero (⇑ᵗ (applyTys (sourceChanges inner) A))
-            (applyCoercionUnderTyBinders (sourceChanges inner) s)
-            (applyTysUnderTyBinders (sourceChanges inner) C)
-            (⇑ᵗ (applyTys (sourceChanges inner) B)))
-          (sym (sourceStoreResult inner)) source↑)
-
-weak-one-step-source-νcast-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ
-    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
-  WeakOneStepResult ρ (ν ★ N s) N₁′ B B′ χ
-weak-one-step-source-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    mode seal★ s⊑ pB inner
-    with weak-result-source-all inner
-weak-one-step-source-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    mode seal★ s⊑ pB inner
-    | q′ , innerResult
-    with lift-left-store-result (resultStore inner)
-weak-one-step-source-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    mode seal★ s⊑ pB inner
-    | q′ , innerResult | ρ′ , liftρ
-    with apply-widen-inst-under-ty-binders
-      {χs = sourceChanges inner} mode seal★ s⊑
-weak-one-step-source-νcast-frameᵀ
-    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
-    mode seal★ s⊑ pB inner
-    | q′ , innerResult | ρ′ , liftρ
-    | μ′ , mode′ , seal★′ , source⊑ =
-  record
-    { sourceChanges = sourceChanges inner
-    ; targetTailChanges = targetTailChanges inner
-    ; sourceResult =
-        ν ★ (sourceResult inner)
-          (applyCoercionUnderTyBinders (sourceChanges inner) s)
-    ; targetResult = targetResult inner
-    ; resultCtx = resultCtx inner
-    ; resultLeftCtx = resultLeftCtx inner
-    ; resultRightCtx = resultRightCtx inner
-    ; sourceCtxResult = sourceCtxResult inner
-    ; targetCtxResult = targetCtxResult inner
-    ; resultStore = resultStore inner
-    ; resultSourceType = applyTys (sourceChanges inner) B
-    ; resultTargetType =
-        applyTys (targetTailChanges inner) (applyTy χ B′)
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = transportType inner
-    ; transportAllBody = transportAllBody inner
-    ; transportRightBody = transportRightBody inner
-    ; resultType = transportType inner pB
-    ; sourceCatchup =
-        subst
-          (λ T → ν ★ N s —↠[ sourceChanges inner ]
-            ν T (sourceResult inner)
-              (applyCoercionUnderTyBinders (sourceChanges inner) s))
-          (applyTys-★ (sourceChanges inner))
-          (ν-↠ (sourceCatchup inner))
-    ; targetTail = targetTail inner
-    ; sourceStoreResult = sourceStoreResult inner
-    ; targetStoreResult = targetStoreResult inner
-    ; relatedResults =
-        νcast⊑ᵀ mode′ source-seal source-widen
-          liftρ lift-left-ctx-[] innerResult
-    }
-  where
-    source-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ μ′)
-          ((zero , ★) ∷ ⟰ᵗ Σ))
-        (sym (sourceStoreResult inner)) seal★′
-
-    source-widen =
-      subst
-        (λ Δ → instᵈ μ′ ∣ suc Δ
-          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
-          ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
-            ∶ applyTysUnderTyBinders (sourceChanges inner) C
-              ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-        (sym (sourceCtxResult inner))
-        (subst
-          (λ Σ → instᵈ μ′
-            ∣ suc (applyTyCtxs (sourceChanges inner) _)
-            ∣ (zero , ★) ∷ ⟰ᵗ Σ
-            ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
-              ∶ applyTysUnderTyBinders (sourceChanges inner) C
-                ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
-          (sym (sourceStoreResult inner)) source⊑)
-
-weak-one-step-target-ν-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  WfTy Δᴿ A →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
-  WeakOneStepResult ρ N
-    (ν (applyTy χ A) N₁′ (applyCoercionUnderTyBinder χ s))
-    B B′ χ
-weak-one-step-target-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    hA s↑ pB pC inner
-    with lift-right-store-result (resultStore inner)
-weak-one-step-target-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    hA s↑ pB pC inner
-    | ρ′ , liftρ
-    with apply-reveal-under-ty-binders
-      {χs = χ ∷ targetTailChanges inner} s↑
-weak-one-step-target-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    hA s↑ pB pC inner
-    | ρ′ , liftρ | μ′ , target↑
-    with weak-result-target-all inner
-weak-one-step-target-ν-frameᵀ
-    {A = A} {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    hA s↑ pB pC inner
-    | ρ′ , liftρ | μ′ , target↑ | q′ , innerResult =
-  record
-    { sourceChanges = sourceChanges inner
-    ; targetTailChanges = targetTailChanges inner
-    ; sourceResult = sourceResult inner
-    ; targetResult =
-        ν (applyTys (targetTailChanges inner) (applyTy χ A))
-          (targetResult inner)
-          (applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ s))
-    ; resultCtx = resultCtx inner
-    ; resultLeftCtx = resultLeftCtx inner
-    ; resultRightCtx = resultRightCtx inner
-    ; sourceCtxResult = sourceCtxResult inner
-    ; targetCtxResult = targetCtxResult inner
-    ; resultStore = resultStore inner
-    ; resultSourceType = applyTys (sourceChanges inner) B
-    ; resultTargetType =
-        applyTys (targetTailChanges inner) (applyTy χ B′)
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = transportType inner
-    ; transportAllBody = transportAllBody inner
-    ; transportRightBody = transportRightBody inner
-    ; resultType = transportType inner pB
-    ; sourceCatchup = sourceCatchup inner
-    ; targetTail = ν-↠ (targetTail inner)
-    ; sourceStoreResult = sourceStoreResult inner
-    ; targetStoreResult = targetStoreResult inner
-    ; relatedResults =
-        ⊑νᵀ final-wf final-shift-wf target-reveal
-          liftρ lift-right-ctx-[]
-          (transportRightBody inner pC) innerResult
-    }
-  where
-    final-wf =
-      subst
-        (λ Δ → WfTy Δ
-          (applyTys (targetTailChanges inner) (applyTy χ A)))
-        (sym (targetCtxResult inner))
-        (wfTy-applyTys
-          (χ ∷ targetTailChanges inner) hA)
-
-    final-shift-wf =
-      renameᵗ-preserves-WfTy final-wf TyRenameWf-suc
-
-    target-reveal =
-      subst
-        (λ Δ → RevealConversion μ′ (suc Δ)
-          ((zero , ⇑ᵗ
-              (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
-            ⟰ᵗ (rightStoreⁱ (resultStore inner)))
-          zero (⇑ᵗ
-            (applyTys (targetTailChanges inner) (applyTy χ A)))
-          (applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ s))
-          (applyTysUnderTyBinders (targetTailChanges inner)
-            (applyTyUnderTyBinder χ C′))
-          (⇑ᵗ
-            (applyTys (targetTailChanges inner) (applyTy χ B′))))
-        (sym (targetCtxResult inner))
-        (subst
-          (λ Σ → RevealConversion μ′
-            (suc (applyTyCtxs (targetTailChanges inner)
-              (applyTyCtx χ _)))
-            ((zero , ⇑ᵗ
-                (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
-              ⟰ᵗ Σ)
-            zero (⇑ᵗ
-              (applyTys (targetTailChanges inner) (applyTy χ A)))
-            (applyCoercionUnderTyBinders (targetTailChanges inner)
-              (applyCoercionUnderTyBinder χ s))
-            (applyTysUnderTyBinders (targetTailChanges inner)
-              (applyTyUnderTyBinder χ C′))
-            (⇑ᵗ
-              (applyTys (targetTailChanges inner) (applyTy χ B′))))
-          (sym (targetStoreResult inner)) target↑)
-
-weak-one-step-target-νcast-frameᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ
-    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
-  WeakOneStepResult ρ N
-    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s))
-    B B′ χ
-weak-one-step-target-νcast-frameᵀ
-    {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    mode seal★ s⊑ pB pC inner
-    with lift-right-store-result (resultStore inner)
-weak-one-step-target-νcast-frameᵀ
-    {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    mode seal★ s⊑ pB pC inner
-    | ρ′ , liftρ
-    with apply-widen-inst-under-ty-binders
-      {χs = χ ∷ targetTailChanges inner} mode seal★ s⊑
-weak-one-step-target-νcast-frameᵀ
-    {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    mode seal★ s⊑ pB pC inner
-    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
-    with weak-result-target-all inner
-weak-one-step-target-νcast-frameᵀ
-    {B = B} {B′ = B′} {C′ = C′}
-    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
-    mode seal★ s⊑ pB pC inner
-    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
-    | q′ , innerResult =
-  record
-    { sourceChanges = sourceChanges inner
-    ; targetTailChanges = targetTailChanges inner
-    ; sourceResult = sourceResult inner
-    ; targetResult =
-        ν ★ (targetResult inner)
-          (applyCoercionUnderTyBinders (targetTailChanges inner)
-            (applyCoercionUnderTyBinder χ s))
-    ; resultCtx = resultCtx inner
-    ; resultLeftCtx = resultLeftCtx inner
-    ; resultRightCtx = resultRightCtx inner
-    ; sourceCtxResult = sourceCtxResult inner
-    ; targetCtxResult = targetCtxResult inner
-    ; resultStore = resultStore inner
-    ; resultSourceType = applyTys (sourceChanges inner) B
-    ; resultTargetType =
-        applyTys (targetTailChanges inner) (applyTy χ B′)
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = transportType inner
-    ; transportAllBody = transportAllBody inner
-    ; transportRightBody = transportRightBody inner
-    ; resultType = transportType inner pB
-    ; sourceCatchup = sourceCatchup inner
-    ; targetTail =
-        subst
-          (λ T → ν ★ N₁′ (applyCoercionUnderTyBinder χ s)
-            —↠[ targetTailChanges inner ]
-            ν T (targetResult inner)
-              (applyCoercionUnderTyBinders (targetTailChanges inner)
-                (applyCoercionUnderTyBinder χ s)))
-          (applyTys-★ (targetTailChanges inner))
-          (ν-↠ (targetTail inner))
-    ; sourceStoreResult = sourceStoreResult inner
-    ; targetStoreResult = targetStoreResult inner
-    ; relatedResults =
-        ⊑νcastᵀ mode′ target-seal target-widen
-          liftρ lift-right-ctx-[]
-          (transportRightBody inner pC) innerResult
-    }
-  where
-    target-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ μ′)
-          ((zero , ★) ∷ ⟰ᵗ Σ))
-        (sym (targetStoreResult inner)) seal★′
-
-    target-widen =
-      subst
-        (λ Δ → instᵈ μ′ ∣ suc Δ
-          ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
-          ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-              (applyCoercionUnderTyBinder χ s)
-            ∶ applyTysUnderTyBinders (targetTailChanges inner)
-                (applyTyUnderTyBinder χ C′)
-              ⊑ ⇑ᵗ
-                  (applyTys (targetTailChanges inner) (applyTy χ B′)))
-        (sym (targetCtxResult inner))
-        (subst
-          (λ Σ → instᵈ μ′
-            ∣ suc (applyTyCtxs (targetTailChanges inner)
-              (applyTyCtx χ _))
-            ∣ (zero , ★) ∷ ⟰ᵗ Σ
-            ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
-                (applyCoercionUnderTyBinder χ s)
-              ∶ applyTysUnderTyBinders (targetTailChanges inner)
-                  (applyTyUnderTyBinder χ C′)
-                ⊑ ⇑ᵗ
-                    (applyTys (targetTailChanges inner) (applyTy χ B′)))
-          (sym (targetStoreResult inner)) target⊑)
-
-weak-one-step-matched-ν-frame-outcomeᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepAllOutcome
-    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
-    {χ = χ} {ρ = ρ} q →
-  WeakOneStepOutcome ρ
-    (ν A N s)
-    (ν (applyTy χ A′) N₁′ (applyCoercionUnderTyBinder χ s′))
-    B B′ χ
-weak-one-step-matched-ν-frame-outcomeᵀ s↑ s′↑ pA pB =
-  weak-all-outcome-map-target-ν
-    (weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB)
-    (λ N↠ → _ , ν-blame-tail N↠)
-
-weak-one-step-matched-νcast-frame-outcomeᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepAllOutcome
-    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
-    {χ = χ} {ρ = ρ} q →
-  WeakOneStepOutcome ρ
-    (ν ★ N s)
-    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s′))
-    B B′ χ
-weak-one-step-matched-νcast-frame-outcomeᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB =
-  weak-all-outcome-map-target-ν
-    (weak-one-step-matched-νcast-frameᵀ
-      mode seal★ s⊑ mode′ seal★′ s′⊑ pB)
-    (λ N↠ → _ , ν-blame-tail N↠)
-
-weak-one-step-source-ν-frame-outcomeᵀ :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  WfTy Δᴸ A →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepOutcome ρ N N₁′ (`∀ C) B′ χ →
-  WeakOneStepOutcome ρ (ν A N s) N₁′ B B′ χ
-weak-one-step-source-ν-frame-outcomeᵀ hA s↑ pB =
-  weak-outcome-map-source
-    (weak-one-step-source-ν-frameᵀ hA s↑ pB)
-    (λ N↠ → _ , ν-blame-tail N↠)
-
-weak-one-step-source-νcast-frame-outcomeᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ
-    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  WeakOneStepOutcome ρ N N₁′ (`∀ C) B′ χ →
-  WeakOneStepOutcome ρ (ν ★ N s) N₁′ B B′ χ
-weak-one-step-source-νcast-frame-outcomeᵀ mode seal★ s⊑ pB =
-  weak-outcome-map-source
-    (weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB)
-    (λ N↠ → _ , ν-blame-tail N↠)
-
-weak-one-step-target-ν-frame-outcomeᵀ :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  WfTy Δᴿ A →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  WeakOneStepOutcome ρ N N₁′ B (`∀ C′) χ →
-  WeakOneStepOutcome ρ N
-    (ν (applyTy χ A) N₁′ (applyCoercionUnderTyBinder χ s))
-    B B′ χ
-weak-one-step-target-ν-frame-outcomeᵀ hA s↑ pB pC =
-  weak-outcome-map-target-ν
-    (weak-one-step-target-ν-frameᵀ hA s↑ pB pC)
-
-weak-one-step-target-νcast-frame-outcomeᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ
-    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  WeakOneStepOutcome ρ N N₁′ B (`∀ C′) χ →
-  WeakOneStepOutcome ρ N
-    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s))
-    B B′ χ
-weak-one-step-target-νcast-frame-outcomeᵀ
-    mode seal★ s⊑ pB pC =
-  weak-outcome-map-target-ν
-    (weak-one-step-target-νcast-frameᵀ
-      mode seal★ s⊑ pB pC)
-
-∀-imprecision-source-body-wf :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  Φ ∣ Δᴸ ⊢ `∀ A ⊑ B ⊣ Δᴿ →
-  WfTy (suc Δᴸ) A
-∀-imprecision-source-body-wf p with ⊑-src-wf p
-∀-imprecision-source-body-wf p | wf∀ hA = hA
-
-∀-imprecision-target-body-wf :
-  ∀ {Φ Δᴸ Δᴿ A B} →
-  Φ ∣ Δᴸ ⊢ A ⊑ `∀ B ⊣ Δᴿ →
-  WfTy (suc Δᴿ) B
-∀-imprecision-target-body-wf p with ⊑-tgt-wf p
-∀-imprecision-target-body-wf p | wf∀ hB = hB
-
-swap01ᵢ-agrees-swap01ᵗ : ∀ X → swap01ᵢ X ≡ swap01ᵗ X
-swap01ᵢ-agrees-swap01ᵗ zero = refl
-swap01ᵢ-agrees-swap01ᵗ (suc zero) = refl
-swap01ᵢ-agrees-swap01ᵗ (suc (suc X)) = refl
-
-renameᵗ-swap01ᵢ-agrees-swap01ᵗ :
-  ∀ A → renameᵗ swap01ᵢ A ≡ renameᵗ swap01ᵗ A
-renameᵗ-swap01ᵢ-agrees-swap01ᵗ A =
-  rename-cong swap01ᵢ-agrees-swap01ᵗ A
-
-direct-swap-residualᵖ :
-  ∀ {Φ Δᴸ Δᴿ D E T} →
-  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
-    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
-  renameᵗ swap01ᵗ E ≈∀ T →
-  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
-    ⊢ D ⊑ᵖ T ⊣ suc (suc Δᴿ)
-direct-swap-residualᵖ {E = E} D⊑E Eˢ≈T =
-  quotientᵖ ≈∀-refl crossed Eˢ≈T
-  where
-    crossed =
-      subst
-        (λ T → swapRight∀∀ᵢ _ ∣ _ ⊢ _ ⊑ T ⊣ _)
-        (renameᵗ-swap01ᵢ-agrees-swap01ᵗ E)
-        (⊑-swapRight01∀∀ᵢ D⊑E)
-
-reverse-swap-residualᵖ :
-  ∀ {Φ Δᴸ Δᴿ S D E} →
-  S ≈∀ renameᵗ swap01ᵗ D →
-  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
-    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
-  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
-    ⊢ S ⊑ᵖ E ⊣ suc (suc Δᴿ)
-reverse-swap-residualᵖ {D = D} S≈Dˢ D⊑E =
-  quotientᵖ S≈Dˢ crossed ≈∀-refl
-  where
-    crossed =
-      subst
-        (λ T → swapRight∀∀ᵢ _ ∣ _ ⊢ T ⊑ _ ⊣ _)
-        (renameᵗ-swap01ᵢ-agrees-swap01ᵗ D)
-        (⊑-swapLeft01∀∀ᵢ D⊑E)
-
-direct-swap-residual-outerᵖ :
-  ∀ {Φ Δᴸ Δᴿ D E T} →
-  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
-    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
-  renameᵗ swap01ᵗ E ≈∀ T →
-  Φ ∣ Δᴸ ⊢ `∀ (`∀ D) ⊑ᵖ `∀ (`∀ T) ⊣ Δᴿ
-direct-swap-residual-outerᵖ D⊑E Eˢ≈T =
-  quotientᵖ ≈∀-refl (∀ⁱ (∀ⁱ D⊑E))
-    (≈∀-double-swap Eˢ≈T)
-
-reverse-swap-residual-outerᵖ :
-  ∀ {Φ Δᴸ Δᴿ S D E} →
-  S ≈∀ renameᵗ swap01ᵗ D →
-  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
-    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
-  Φ ∣ Δᴸ ⊢ `∀ (`∀ S) ⊑ᵖ `∀ (`∀ E) ⊣ Δᴿ
-reverse-swap-residual-outerᵖ S≈Dˢ D⊑E =
-  quotientᵖ (≈∀-double-swap-sym S≈Dˢ)
-    (∀ⁱ (∀ⁱ D⊑E)) ≈∀-refl
+open import proof.NuImprecisionSimulationCore
+open import proof.NuImprecisionCatchupComposition
 
 ------------------------------------------------------------------------
 -- Crossed stores realize two allocations in opposite logical orders
 ------------------------------------------------------------------------
+
+lift-store-rel-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp Ψ (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ Ψ ρ ρ′ →
+  RelStoreEmbeddingⁱ suc suc ρ ρ′
+lift-store-rel-embeddingⁱ lift-store-[] =
+  rel-store-embedding-[]
+lift-store-rel-embeddingⁱ (lift-store-∷ liftρ) =
+  rel-store-embedding-matched refl refl refl refl
+    (lift-store-rel-embeddingⁱ liftρ)
+lift-store-rel-embeddingⁱ (lift-store-left liftρ) =
+  rel-store-embedding-left refl refl
+    (lift-store-rel-embeddingⁱ liftρ)
+lift-store-rel-embeddingⁱ (lift-store-right liftρ) =
+  rel-store-embedding-right refl refl
+    (lift-store-rel-embeddingⁱ liftρ)
+lift-store-rel-embeddingⁱ (lift-store-link liftρ) =
+  rel-store-embedding-link refl refl refl refl
+    (lift-store-rel-embeddingⁱ liftρ)
+
+lift-left-store-rel-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp Ψ (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ Ψ ρ ρ′ →
+  RelStoreEmbeddingⁱ suc (λ X → X) ρ ρ′
+lift-left-store-rel-embeddingⁱ lift-left-store-[] =
+  rel-store-embedding-[]
+lift-left-store-rel-embeddingⁱ (lift-left-store-∷ liftρ) =
+  rel-store-embedding-matched refl refl refl
+    (sym (renameᵗ-id _)) (lift-left-store-rel-embeddingⁱ liftρ)
+lift-left-store-rel-embeddingⁱ (lift-left-store-left liftρ) =
+  rel-store-embedding-left refl refl
+    (lift-left-store-rel-embeddingⁱ liftρ)
+lift-left-store-rel-embeddingⁱ (lift-left-store-right liftρ) =
+  rel-store-embedding-right refl (sym (renameᵗ-id _))
+    (lift-left-store-rel-embeddingⁱ liftρ)
+lift-left-store-rel-embeddingⁱ (lift-left-store-link liftρ) =
+  rel-store-embedding-link refl refl refl
+    (sym (renameᵗ-id _)) (lift-left-store-rel-embeddingⁱ liftρ)
+
+identity-store-rel-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RelStoreEmbeddingⁱ (λ X → X) (λ X → X) ρ ρ
+identity-store-rel-embeddingⁱ {ρ = []} =
+  rel-store-embedding-[]
+identity-store-rel-embeddingⁱ
+    {ρ = store-matched α A β B p ∷ ρ} =
+  rel-store-embedding-matched refl (sym (renameᵗ-id A))
+    refl (sym (renameᵗ-id B)) identity-store-rel-embeddingⁱ
+identity-store-rel-embeddingⁱ
+    {ρ = store-left α A hA ∷ ρ} =
+  rel-store-embedding-left refl (sym (renameᵗ-id A))
+    identity-store-rel-embeddingⁱ
+identity-store-rel-embeddingⁱ
+    {ρ = store-right β B hB ∷ ρ} =
+  rel-store-embedding-right refl (sym (renameᵗ-id B))
+    identity-store-rel-embeddingⁱ
+identity-store-rel-embeddingⁱ
+    {ρ = store-link α A β B p ∷ ρ} =
+  rel-store-embedding-link refl (sym (renameᵗ-id A))
+    refl (sym (renameᵗ-id B)) identity-store-rel-embeddingⁱ
+
+identity-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RelWorldEmbeddingⁱ
+    (λ X → X) (λ X → X) (λ X → X) (λ X → X)
+    rename-assm²-idᵢ (λ X<Δ → X<Δ) (λ X<Δ → X<Δ)
+    {ρ = ρ} {ρ′ = ρ} {γ = []} {γ′ = []}
+identity-world-embeddingⁱ =
+  rel-world-embedding (λ X → refl) (λ X → refl)
+    castModeRenamer-id castModeRenamer-id
+    identity-store-rel-embeddingⁱ rel-ctx-rename-[]
+
+paired-left-lift-rel-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp Ψ (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ Ψ ρ ρᵃ →
+  LiftLeftStoreⁱ Ψ ρ ρᵇ →
+  RelStoreEmbeddingⁱ (λ X → X) (λ X → X) ρᵃ ρᵇ
+paired-left-lift-rel-embeddingⁱ
+    lift-left-store-[] lift-left-store-[] =
+  rel-store-embedding-[]
+paired-left-lift-rel-embeddingⁱ
+    (lift-left-store-∷ liftρᵃ) (lift-left-store-∷ liftρᵇ) =
+  rel-store-embedding-matched refl (sym (renameᵗ-id _))
+    refl (sym (renameᵗ-id _))
+    (paired-left-lift-rel-embeddingⁱ liftρᵃ liftρᵇ)
+paired-left-lift-rel-embeddingⁱ
+    (lift-left-store-left liftρᵃ)
+    (lift-left-store-left liftρᵇ) =
+  rel-store-embedding-left refl (sym (renameᵗ-id _))
+    (paired-left-lift-rel-embeddingⁱ liftρᵃ liftρᵇ)
+paired-left-lift-rel-embeddingⁱ
+    (lift-left-store-right liftρᵃ)
+    (lift-left-store-right liftρᵇ) =
+  rel-store-embedding-right refl (sym (renameᵗ-id _))
+    (paired-left-lift-rel-embeddingⁱ liftρᵃ liftρᵇ)
+paired-left-lift-rel-embeddingⁱ
+    (lift-left-store-link liftρᵃ)
+    (lift-left-store-link liftρᵇ) =
+  rel-store-embedding-link refl (sym (renameᵗ-id _))
+    refl (sym (renameᵗ-id _))
+    (paired-left-lift-rel-embeddingⁱ liftρᵃ liftρᵇ)
+
+paired-left-lift-world-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp Ψ (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ Ψ ρ ρᵃ →
+  LiftLeftStoreⁱ Ψ ρ ρᵇ →
+  RelWorldEmbeddingⁱ
+    (λ X → X) (λ X → X) (λ X → X) (λ X → X)
+    rename-assm²-idᵢ (λ X<Δ → X<Δ) (λ X<Δ → X<Δ)
+    {ρ = ρᵃ} {ρ′ = ρᵇ} {γ = []} {γ′ = []}
+paired-left-lift-world-embeddingⁱ liftρᵃ liftρᵇ =
+  rel-world-embedding (λ X → refl) (λ X → refl)
+    castModeRenamer-id castModeRenamer-id
+    (paired-left-lift-rel-embeddingⁱ liftρᵃ liftρᵇ)
+    rel-ctx-rename-[]
+
+paired-left-lift-prefix-world-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ A}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp Ψ (suc Δᴸ) Δᴿ}
+    {hA : WfTy (suc Δᴸ) A} →
+  LiftLeftStoreⁱ Ψ ρ ρᵃ →
+  LiftLeftStoreⁱ Ψ ρ ρᵇ →
+  RelWorldEmbeddingⁱ
+    (λ X → X) (λ X → X) (λ X → X) (λ X → X)
+    rename-assm²-idᵢ (λ X<Δ → X<Δ) (λ X<Δ → X<Δ)
+    {ρ = store-left zero A hA ∷ ρᵃ}
+    {ρ′ = store-left zero A hA ∷ ρᵇ}
+    {γ = []} {γ′ = []}
+paired-left-lift-prefix-world-embeddingⁱ liftρᵃ liftρᵇ =
+  rel-world-embedding (λ X → refl) (λ X → refl)
+    castModeRenamer-id castModeRenamer-id
+    (rel-store-embedding-left refl (sym (renameᵗ-id _))
+      (paired-left-lift-rel-embeddingⁱ liftρᵃ liftρᵇ))
+    rel-ctx-rename-[]
+
+lift-right-store-rel-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp Ψ Δᴸ (suc Δᴿ)} →
+  LiftRightStoreⁱ Ψ ρ ρ′ →
+  RelStoreEmbeddingⁱ (λ X → X) suc ρ ρ′
+lift-right-store-rel-embeddingⁱ lift-right-store-[] =
+  rel-store-embedding-[]
+lift-right-store-rel-embeddingⁱ (lift-right-store-∷ liftρ) =
+  rel-store-embedding-matched refl (sym (renameᵗ-id _))
+    refl refl (lift-right-store-rel-embeddingⁱ liftρ)
+lift-right-store-rel-embeddingⁱ (lift-right-store-left liftρ) =
+  rel-store-embedding-left refl (sym (renameᵗ-id _))
+    (lift-right-store-rel-embeddingⁱ liftρ)
+lift-right-store-rel-embeddingⁱ (lift-right-store-right liftρ) =
+  rel-store-embedding-right refl refl
+    (lift-right-store-rel-embeddingⁱ liftρ)
+lift-right-store-rel-embeddingⁱ (lift-right-store-link liftρ) =
+  rel-store-embedding-link refl (sym (renameᵗ-id _))
+    refl refl (lift-right-store-rel-embeddingⁱ liftρ)
+
+matched-lift-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ′ →
+  RelWorldEmbeddingⁱ suc suc predᵗ predᵗ
+    rename-assm²-∀ᵢ TyRenameWf-suc TyRenameWf-suc
+    {ρ = ρ} {ρ′ = ρ′} {γ = []} {γ′ = []}
+matched-lift-world-embeddingⁱ liftρ =
+  rel-world-embedding RenameLeftInverse-suc RenameLeftInverse-suc
+    castModeRenamer-suc castModeRenamer-suc
+    (lift-store-rel-embeddingⁱ liftρ) rel-ctx-rename-[]
+
+left-lift-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+  RelWorldEmbeddingⁱ suc (λ X → X) predᵗ (λ X → X)
+    rename-assm²-source-νᵢ TyRenameWf-suc (λ X<Δ → X<Δ)
+    {ρ = ρ} {ρ′ = ρ′} {γ = []} {γ′ = []}
+left-lift-world-embeddingⁱ liftρ =
+  rel-world-embedding RenameLeftInverse-suc (λ X → refl)
+    castModeRenamer-suc castModeRenamer-id
+    (lift-left-store-rel-embeddingⁱ liftρ) rel-ctx-rename-[]
+
+right-lift-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
+  RelWorldEmbeddingⁱ (λ X → X) suc (λ X → X) predᵗ
+    rename-assm²-target-rightᵢ (λ X<Δ → X<Δ) TyRenameWf-suc
+    {ρ = ρ} {ρ′ = ρ′} {γ = []} {γ′ = []}
+right-lift-world-embeddingⁱ liftρ =
+  rel-world-embedding (λ X → refl) RenameLeftInverse-suc
+    castModeRenamer-id castModeRenamer-suc
+    (lift-right-store-rel-embeddingⁱ liftρ) rel-ctx-rename-[]
+
+right-lift-under-left-store-rel-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      (suc Δᴸ) (suc Δᴿ)} →
+  LiftRightStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρ ρᴿ →
+  RelStoreEmbeddingⁱ (extᵗ (λ X → X)) suc ρ ρᴿ
+right-lift-under-left-store-rel-embeddingⁱ
+    lift-right-store-[] =
+  rel-store-embedding-[]
+right-lift-under-left-store-rel-embeddingⁱ
+    (lift-right-store-∷ {A = A} liftρ) =
+  rel-store-embedding-matched
+    (sym (ext-id-pointwise _)) (sym (renameᵗ-ext-id A))
+    refl refl (right-lift-under-left-store-rel-embeddingⁱ liftρ)
+right-lift-under-left-store-rel-embeddingⁱ
+    (lift-right-store-left {A = A} liftρ) =
+  rel-store-embedding-left
+    (sym (ext-id-pointwise _)) (sym (renameᵗ-ext-id A))
+    (right-lift-under-left-store-rel-embeddingⁱ liftρ)
+right-lift-under-left-store-rel-embeddingⁱ
+    (lift-right-store-right liftρ) =
+  rel-store-embedding-right refl refl
+    (right-lift-under-left-store-rel-embeddingⁱ liftρ)
+right-lift-under-left-store-rel-embeddingⁱ
+    (lift-right-store-link {A = A} liftρ) =
+  rel-store-embedding-link
+    (sym (ext-id-pointwise _)) (sym (renameᵗ-ext-id A))
+    refl refl (right-lift-under-left-store-rel-embeddingⁱ liftρ)
+
+right-lift-under-left-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      (suc Δᴸ) (suc Δᴿ)} →
+  LiftRightStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρ ρᴿ →
+  RelWorldEmbeddingⁱ
+    (extᵗ (λ X → X)) suc (extᵗ (λ X → X)) predᵗ
+    (rename-assm²-⇑ᴸᵢ rename-assm²-target-rightᵢ)
+    (TyRenameWf-ext (λ X<Δ → X<Δ)) TyRenameWf-suc
+    {ρ = ρ} {ρ′ = ρᴿ} {γ = []} {γ′ = []}
+right-lift-under-left-world-embeddingⁱ liftρ =
+  rel-world-embedding
+    (RenameLeftInverse-ext (λ X → refl))
+    RenameLeftInverse-suc
+    (castModeRenamer-ext castModeRenamer-id)
+    castModeRenamer-suc
+    (right-lift-under-left-store-rel-embeddingⁱ liftρ)
+    rel-ctx-rename-[]
+
+crossed-double-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelWorldEmbeddingⁱ
+    (λ X → suc (suc X)) (λ X → suc (suc X))
+    (λ X → predᵗ (predᵗ X)) (λ X → predᵗ (predᵗ X))
+    rename-assm²-crossed-double∀∀ᵢ
+    (λ X<Δ → s<s (s<s X<Δ)) (λ X<Δ → s<s (s<s X<Δ))
+    {ρ = ρ₀} {ρ′ = ρ₂} {γ = []} {γ′ = []}
+crossed-double-world-embeddingⁱ liftρ₁ liftρ₂ =
+  rel-world-embedding
+    (renameLeftInverse-compose
+      {τ = suc} {υ = suc} {ψ = predᵗ} {ξ = predᵗ}
+      RenameLeftInverse-suc RenameLeftInverse-suc)
+    (renameLeftInverse-compose
+      {τ = suc} {υ = suc} {ψ = predᵗ} {ξ = predᵗ}
+      RenameLeftInverse-suc RenameLeftInverse-suc)
+    (castModeRenamer-compose
+      {τ = suc} {σ = suc} castModeRenamer-suc castModeRenamer-suc)
+    (castModeRenamer-compose
+      {τ = suc} {σ = suc} castModeRenamer-suc castModeRenamer-suc)
+    (rel-store-embedding-composeⁱ
+      {τ = suc} {σ = suc} {υ = suc} {ω = suc}
+      (lift-store-rel-embeddingⁱ liftρ₁)
+      (lift-store-rel-embeddingⁱ liftρ₂))
+    rel-ctx-rename-[]
 
 leftStoreⁱ-crossed-two-binds :
   ∀ {Φ Δᴸ Δᴿ Aold Anew Bold Bnew}
@@ -6078,6 +762,449 @@ leftStoreⁱ-crossed-body {ρ₀ = ρ₀} {ρ₁ = ρ₁} liftρ₁ liftρ₂ =
       (trans
         (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
         (sym (leftStoreⁱ-lift liftρ₂))))
+
+crossed-right-store-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  StoreProjectionEmbeddingⁱ suc (extᵗ suc) ρ₁ ρ₂
+crossed-right-store-embeddingⁱ liftρ₁ liftρ₂ =
+  store-projection-embedding
+    (store-eq-inclusion (leftStoreⁱ-lift liftρ₂))
+    (store-eq-inclusion
+      (sym (rightStoreⁱ-crossed-body liftρ₁ liftρ₂)))
+
+crossed-left-store-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  StoreProjectionEmbeddingⁱ (extᵗ suc) suc ρ₁ ρ₂
+crossed-left-store-embeddingⁱ liftρ₁ liftρ₂ =
+  store-projection-embedding
+    (store-eq-inclusion
+      (sym (leftStoreⁱ-crossed-body liftρ₁ liftρ₂)))
+    (store-eq-inclusion (rightStoreⁱ-lift liftρ₂))
+
+crossed-right-rel-store-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelStoreEmbeddingⁱ suc (extᵗ suc) ρ₁ ρ₂
+crossed-right-rel-store-embeddingⁱ
+    lift-store-[] lift-store-[] =
+  rel-store-embedding-[]
+crossed-right-rel-store-embeddingⁱ
+    (lift-store-∷ {B = B} liftρ₁) (lift-store-∷ liftρ₂) =
+  rel-store-embedding-matched refl refl refl
+    (sym (renameᵗ-ext-suc-comm suc B))
+    (crossed-right-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+crossed-right-rel-store-embeddingⁱ
+    (lift-store-left liftρ₁) (lift-store-left liftρ₂) =
+  rel-store-embedding-left refl refl
+    (crossed-right-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+crossed-right-rel-store-embeddingⁱ
+    (lift-store-right {B = B} liftρ₁)
+    (lift-store-right liftρ₂) =
+  rel-store-embedding-right refl
+    (sym (renameᵗ-ext-suc-comm suc B))
+    (crossed-right-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+crossed-right-rel-store-embeddingⁱ
+    (lift-store-link {B = B} liftρ₁)
+    (lift-store-link liftρ₂) =
+  rel-store-embedding-link refl refl refl
+    (sym (renameᵗ-ext-suc-comm suc B))
+    (crossed-right-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+
+crossed-left-rel-store-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelStoreEmbeddingⁱ (extᵗ suc) suc ρ₁ ρ₂
+crossed-left-rel-store-embeddingⁱ
+    lift-store-[] lift-store-[] =
+  rel-store-embedding-[]
+crossed-left-rel-store-embeddingⁱ
+    (lift-store-∷ {A = A} liftρ₁) (lift-store-∷ liftρ₂) =
+  rel-store-embedding-matched refl
+    (sym (renameᵗ-ext-suc-comm suc A)) refl refl
+    (crossed-left-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+crossed-left-rel-store-embeddingⁱ
+    (lift-store-left {A = A} liftρ₁)
+    (lift-store-left liftρ₂) =
+  rel-store-embedding-left refl
+    (sym (renameᵗ-ext-suc-comm suc A))
+    (crossed-left-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+crossed-left-rel-store-embeddingⁱ
+    (lift-store-right liftρ₁) (lift-store-right liftρ₂) =
+  rel-store-embedding-right refl refl
+    (crossed-left-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+crossed-left-rel-store-embeddingⁱ
+    (lift-store-link {A = A} liftρ₁)
+    (lift-store-link liftρ₂) =
+  rel-store-embedding-link refl
+    (sym (renameᵗ-ext-suc-comm suc A)) refl refl
+    (crossed-left-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+
+crossed-right-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelWorldEmbeddingⁱ suc (extᵗ suc) predᵗ predᵗ
+    rename-assm²-crossed-right∀∀ᵢ
+    TyRenameWf-suc (TyRenameWf-ext TyRenameWf-suc)
+    {ρ = ρ₁} {ρ′ = ρ₂} {γ = []} {γ′ = []}
+crossed-right-world-embeddingⁱ liftρ₁ liftρ₂ =
+  rel-world-embedding
+    RenameLeftInverse-suc RenameLeftInverse-ext-suc-pred
+    castModeRenamer-suc (castModeRenamer-ext castModeRenamer-suc)
+    (crossed-right-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+    rel-ctx-rename-[]
+
+crossed-left-world-embeddingⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelWorldEmbeddingⁱ (extᵗ suc) suc predᵗ predᵗ
+    rename-assm²-crossed-left∀∀ᵢ
+    (TyRenameWf-ext TyRenameWf-suc) TyRenameWf-suc
+    {ρ = ρ₁} {ρ′ = ρ₂} {γ = []} {γ′ = []}
+crossed-left-world-embeddingⁱ liftρ₁ liftρ₂ =
+  rel-world-embedding
+    RenameLeftInverse-ext-suc-pred RenameLeftInverse-suc
+    (castModeRenamer-ext castModeRenamer-suc) castModeRenamer-suc
+    (crossed-left-rel-store-embeddingⁱ liftρ₁ liftρ₂)
+    rel-ctx-rename-[]
+
+crossed-right-then-permutation-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation (suc (suc Δᴸ)) Θᴸ}
+    {πᴿ : TyPermutation (suc (suc Δᴿ)) Θᴿ}
+    {assm : ∀ {a} → a ∈ swapRight∀∀ᵢ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))}
+    {ρ₃ : StoreImp Ψ Θᴸ Θᴿ} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ₂} {ρ′ = ρ₃} {γ = []} {γ′ = []} →
+  RelWorldEmbeddingⁱ
+    (λ X → forward πᴸ (suc X))
+    (λ X → forward πᴿ (extᵗ suc X))
+    (λ X → predᵗ (backward πᴸ X))
+    (λ X → predᵗ (backward πᴿ X))
+    (rename-assm²-membership-composeᵢ
+      rename-assm²-crossed-right∀∀ᵢ assm)
+    (TyRenameWf-compose TyRenameWf-suc (forward-wf πᴸ))
+    (TyRenameWf-compose
+      (TyRenameWf-ext TyRenameWf-suc) (forward-wf πᴿ))
+    {ρ = ρ₁} {ρ′ = ρ₃} {γ = []} {γ′ = []}
+crossed-right-then-permutation-embeddingⁱ liftρ₁ liftρ₂ perm =
+  rel-world-embedding-[]-composeⁱ
+    (crossed-right-world-embeddingⁱ liftρ₁ liftρ₂)
+    (rel-world-permutation-embeddingⁱ perm)
+
+crossed-left-then-permutation-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation (suc (suc Δᴸ)) Θᴸ}
+    {πᴿ : TyPermutation (suc (suc Δᴿ)) Θᴿ}
+    {assm : ∀ {a} → a ∈ swapRight∀∀ᵢ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))}
+    {ρ₃ : StoreImp Ψ Θᴸ Θᴿ} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ₂} {ρ′ = ρ₃} {γ = []} {γ′ = []} →
+  RelWorldEmbeddingⁱ
+    (λ X → forward πᴸ (extᵗ suc X))
+    (λ X → forward πᴿ (suc X))
+    (λ X → predᵗ (backward πᴸ X))
+    (λ X → predᵗ (backward πᴿ X))
+    (rename-assm²-membership-composeᵢ
+      rename-assm²-crossed-left∀∀ᵢ assm)
+    (TyRenameWf-compose
+      (TyRenameWf-ext TyRenameWf-suc) (forward-wf πᴸ))
+    (TyRenameWf-compose TyRenameWf-suc (forward-wf πᴿ))
+    {ρ = ρ₁} {ρ′ = ρ₃} {γ = []} {γ′ = []}
+crossed-left-then-permutation-embeddingⁱ liftρ₁ liftρ₂ perm =
+  rel-world-embedding-[]-composeⁱ
+    (crossed-left-world-embeddingⁱ liftρ₁ liftρ₂)
+    (rel-world-permutation-embeddingⁱ perm)
+
+------------------------------------------------------------------------
+-- General no-runtime-bullet transport through world embeddings
+------------------------------------------------------------------------
+
+mutual
+  rel-world-embed-no•ᵀ :
+    ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+      {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+      {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+      {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+      {M M′ A B} {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+      {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    No• M → No• M′ →
+    Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+      ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+      ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+
+  rel-world-embed-no•ᵀᵖ :
+    ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+      {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+      {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+      {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+      {M M′ D D′} {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+      {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    No• M → No• M′ →
+    Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴺᵖ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+      ⦂ renameᵗ τ D ⊑ᵖ renameᵗ σ D′
+      ∶ ⊑ᵖ-rename²ᵢ assm hτ hσ q
+
+  rel-world-embed-no•ᵀ emb (blame⊑ᵀ M′⊢)
+      no•-blame noM′ =
+    rel-world-blame-embedᵀ emb noM′ M′⊢
+  rel-world-embed-no•ᵀ emb (x⊑xᵀ x∈) no•-` no•-` =
+    rel-world-x-embedᵀ emb x∈
+  rel-world-embed-no•ᵀ emb (ƛ⊑ƛᵀ hA hA′ N⊑N′)
+      (no•-ƛ noN) (no•-ƛ noN′) =
+    rel-world-ƛ-embedᵀ emb hA hA′
+      (rel-world-embed-no•ᵀ
+        (rel-world-embedding-ctx-∷ⁱ emb) N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb (·⊑·ᵀ L⊑L′ M⊑M′)
+      (no•-· noL noM) (no•-· noL′ noM′) =
+    ·⊑·ᵀ
+      (rel-world-embed-no•ᵀ emb L⊑L′ noL noL′)
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb (up⊑upᵀ N⊑N′ widening pA)
+      (no•-⟨⟩ noN) (no•-⟨⟩ noN′) =
+    rel-world-up⊑up-embedᵀ emb widening
+      (rel-world-embed-no•ᵀᵖ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb
+      (Λ⊑Λᵀ liftρ liftγ vV vV′ V⊑V′)
+      (no•-Λ noV) (no•-Λ noV′)
+      with rel-world-Λ-embedᵀ emb liftρ liftγ vV vV′
+  rel-world-embed-no•ᵀ emb
+      (Λ⊑Λᵀ liftρ liftγ vV vV′ V⊑V′)
+      (no•-Λ noV) (no•-Λ noV′)
+      | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb , finish =
+    finish (rel-world-embed-no•ᵀ body-emb V⊑V′ noV noV′)
+  rel-world-embed-no•ᵀ emb (Λ⊑ᵀ occ liftρ liftγ vV V⊑N′)
+      (no•-Λ noV) noN′
+      with rel-world-Λ⊑-embedᵀ emb occ liftρ liftγ vV
+  rel-world-embed-no•ᵀ emb (Λ⊑ᵀ occ liftρ liftγ vV V⊑N′)
+      (no•-Λ noV) noN′
+      | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb , finish =
+    finish (rel-world-embed-no•ᵀ body-emb V⊑N′ noV noN′)
+  rel-world-embed-no•ᵀ emb
+      (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ L⊑L′ L⊢ L′⊢)
+      () noM′
+  rel-world-embed-no•ᵀ emb
+      (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ L⊢ N′⊢) () noN′
+  rel-world-embed-no•ᵀ emb
+      (⊑αᵀ vL′ noL′ hA liftρ liftγ N⊑L′ r N⊢ L′⊢) noN ()
+  rel-world-embed-no•ᵀ emb
+      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) noM noM′ =
+    rel-world-allocation-prefix-embedᵀ emb prefix
+      (λ emb₀ → rel-world-embed-no•ᵀ emb₀ M⊑M′ noM noM′)
+      noM noM′ M⊢ M′⊢
+  rel-world-embed-no•ᵀ emb
+      (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′)
+      (no•-ν noN) (no•-ν noN′) =
+    rel-world-ν⊑ν-embedᵀ emb hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+      liftρ liftγ (rel-world-embed-no•ᵀ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb
+      (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑N′)
+      (no•-ν noN) noN′ =
+    rel-world-ν⊑-embedᵀ emb hA h⇑A s↑ liftρ liftγ
+      (rel-world-embed-no•ᵀ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb
+      (⊑νᵀ hA h⇑A s↑ liftρ liftγ r N⊑N′)
+      noN (no•-ν noN′) =
+    rel-world-⊑ν-embedᵀ emb hA h⇑A s↑ liftρ liftγ r
+      (rel-world-embed-no•ᵀ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb
+      (νcast⊑νcastᵀ mode seal mode′ seal′ s⊑ s′⊑
+        liftρ liftγ N⊑N′)
+      (no•-ν noN) (no•-ν noN′) =
+    rel-world-νcast⊑νcast-embedᵀ emb mode seal mode′ seal′
+      s⊑ s′⊑ liftρ liftγ
+      (rel-world-embed-no•ᵀ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb
+      (νcast⊑ᵀ mode seal s⊑ liftρ liftγ N⊑N′)
+      (no•-ν noN) noN′ =
+    rel-world-νcast⊑-embedᵀ emb mode seal s⊑ liftρ liftγ
+      (rel-world-embed-no•ᵀ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb
+      (⊑νcastᵀ mode seal s⊑ liftρ liftγ r N⊑N′)
+      noN (no•-ν noN′) =
+    rel-world-⊑νcast-embedᵀ emb mode seal s⊑ liftρ liftγ r
+      (rel-world-embed-no•ᵀ emb N⊑N′ noN noN′)
+  rel-world-embed-no•ᵀ emb κ⊑κᵀ no•-$ no•-$ = κ⊑κᵀ
+  rel-world-embed-no•ᵀ emb (⊕⊑⊕ᵀ L⊑L′ M⊑M′)
+      (no•-⊕ noL noM) (no•-⊕ noL′ noM′) =
+    ⊕⊑⊕ᵀ
+      (rel-world-embed-no•ᵀ emb L⊑L′ noL noL′)
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb
+      (cast⊒⊑ᵀ mode seal c⊒ M⊑M′ q)
+      (no•-⟨⟩ noM) noM′ =
+    rel-world-cast⊒⊑-embedᵀ emb mode seal c⊒
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb
+      (cast⊑⊑ᵀ mode seal c⊑ M⊑M′ q)
+      (no•-⟨⟩ noM) noM′ =
+    rel-world-cast⊑⊑-embedᵀ emb mode seal c⊑
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb
+      (⊑cast⊒ᵀ mode seal c⊒ M⊑M′ q)
+      noM (no•-⟨⟩ noM′) =
+    rel-world-⊑cast⊒-embedᵀ emb mode seal c⊒
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb
+      (⊑cast⊑ᵀ mode seal c⊑ M⊑M′ q)
+      noM (no•-⟨⟩ noM′) =
+    rel-world-⊑cast⊑-embedᵀ emb mode seal c⊑
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb
+      (⊑cast⊑idᵀ seal c⊑ M⊑M′ q)
+      noM (no•-⟨⟩ noM′) =
+    rel-world-⊑cast⊑id-embedᵀ emb c⊑
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb
+      (conv⊑convᵀ cast M⊑M′)
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+    rel-world-conv⊑conv-embedᵀ emb cast
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb (conv↑⊑ᵀ conv M⊑M′ q)
+      (no•-⟨⟩ noM) noM′ =
+    rel-world-conv↑⊑-embedᵀ emb conv
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb (conv↓⊑ᵀ conv M⊑M′ q)
+      (no•-⟨⟩ noM) noM′ =
+    rel-world-conv↓⊑-embedᵀ emb conv
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb (⊑conv↑ᵀ conv M⊑M′ q)
+      noM (no•-⟨⟩ noM′) =
+    rel-world-⊑conv↑-embedᵀ emb conv
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+  rel-world-embed-no•ᵀ emb (⊑conv↓ᵀ conv M⊑M′ q)
+      noM (no•-⟨⟩ noM′) =
+    rel-world-⊑conv↓-embedᵀ emb conv
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′)
+
+  rel-world-embed-no•ᵀᵖ emb
+      (down⊑downᵀ d⊒ d′⊒ M⊑M′ q)
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+    rel-world-down-embedᵀ emb d⊒ d′⊒
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′) q
+  rel-world-embed-no•ᵀᵖ emb
+      (gen-down⊑gen-downᵀ d⊒ d′⊒ M⊑M′ q)
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+    rel-world-gen-down-embedᵀ emb d⊒ d′⊒
+      (rel-world-embed-no•ᵀ emb M⊑M′ noM noM′) q
+
+identity-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B L L′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• L →
+  No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ ⊑-rename-idᵢ p
+identity-bodyᵀ {A = A} {B = B} {L = L} {L′ = L′}
+    noL noL′ L⊑L′ =
+  nu-term-imprecision-transport-termsᵀ
+    (renameᵗᵐ-id L) (renameᵗᵐ-id L′)
+    (nu-term-imprecision-transport-typesᵀ
+      (renameᵗ-id A) (renameᵗ-id B) refl
+      (rel-world-embed-no•ᵀ
+        identity-world-embeddingⁱ L⊑L′ noL noL′))
+
+rel-world-permute-no•ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B} {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  No• M → No• M′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-permute-no•ᵀ perm M⊑M′ noM noM′ =
+  rel-world-embed-no•ᵀ
+    (rel-world-permutation-embeddingⁱ perm) M⊑M′ noM noM′
+
+rel-world-permute-no•ᵀᵖ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ D D′} {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+  No• M → No• M′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) D ⊑ᵖ renameᵗ (forward πᴿ) D′
+    ∶ ⊑ᵖ-rename²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-permute-no•ᵀᵖ perm M⊑M′ noM noM′ =
+  rel-world-embed-no•ᵀᵖ
+    (rel-world-permutation-embeddingⁱ perm) M⊑M′ noM noM′
 
 ∀gen-body-mode≤gen :
   ModeIncl
@@ -6413,6 +1540,86 @@ left-swap-reveal-store {Aobs = Aobs} {ρ₀ = ρ₀} liftρ₁ liftρ₂ =
         (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
         (sym (leftStoreⁱ-lift liftρ₂))))
 
+matched-lift-prefix-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B L L′ p}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ ρ⁺ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  StoreImpPrefix ρ₁ ρ⁺ →
+  No• L → No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ⁺ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ L ⊑ ⇑ᵗᵐ L′ ⦂ ⇑ᵗ A ⊑ ⇑ᵗ B
+      ∶ ⊑-lift∀ᵢ p
+matched-lift-prefix-bodyᵀ liftρ prefix noL noL′ L⊑L′ =
+  allocation-prefixᵀ prefix body
+    (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
+      noL↑ (nu-term-imprecision-source-typing body))
+    (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
+      noL′↑ (nu-term-imprecision-target-typing body))
+  where
+  body = rel-world-embed-no•ᵀ
+    (matched-lift-world-embeddingⁱ liftρ) L⊑L′ noL noL′
+  noL↑ = renameᵗᵐ-preserves-No• suc noL
+  noL′↑ = renameᵗᵐ-preserves-No• suc noL′
+
+left-lift-prefix-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B L L′ p}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ ρ⁺ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ₀ ρ₁ →
+  StoreImpPrefix ρ₁ ρ⁺ →
+  No• L → No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ L ⊑ L′ ⦂ ⇑ᵗ A ⊑ B ∶ ⊑-source-liftνᵢ p
+left-lift-prefix-bodyᵀ {B = B} {L′ = L′}
+    liftρ prefix noL noL′ L⊑L′ =
+  allocation-prefixᵀ prefix body
+    (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
+      noL↑ (nu-term-imprecision-source-typing body))
+    (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
+      noL′ (nu-term-imprecision-target-typing body))
+  where
+  body =
+    nu-term-imprecision-transport-termsᵀ refl (renameᵗᵐ-id L′)
+      (nu-term-imprecision-transport-typesᵀ
+        refl (renameᵗ-id B) refl
+        (rel-world-embed-no•ᵀ
+          (left-lift-world-embeddingⁱ liftρ) L⊑L′ noL noL′))
+  noL↑ = renameᵗᵐ-preserves-No• suc noL
+
+right-lift-prefix-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B L L′ p}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ ρ⁺ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ₀ ρ₁ →
+  StoreImpPrefix ρ₁ ρ⁺ →
+  No• L → No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρ⁺ ∣ []
+    ⊢ᴺ L ⊑ ⇑ᵗᵐ L′ ⦂ A ⊑ ⇑ᵗ B
+      ∶ ⊑-target-lift-rightᵢ p
+right-lift-prefix-bodyᵀ {A = A} {L = L}
+    liftρ prefix noL noL′ L⊑L′ =
+  allocation-prefixᵀ prefix body
+    (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
+      noL (nu-term-imprecision-source-typing body))
+    (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
+      noL′↑ (nu-term-imprecision-target-typing body))
+  where
+  body =
+    nu-term-imprecision-transport-termsᵀ (renameᵗᵐ-id L) refl
+      (nu-term-imprecision-transport-typesᵀ
+        (renameᵗ-id A) refl refl
+        (rel-world-embed-no•ᵀ
+          (right-lift-world-embeddingⁱ liftρ) L⊑L′ noL noL′))
+  noL′↑ = renameᵗᵐ-preserves-No• suc noL′
+
 right-swap-reveal-store :
   ∀ {Φ Δᴸ Δᴿ Bobs}
     {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
@@ -6429,44 +1636,6 @@ right-swap-reveal-store liftρ₁ liftρ₂ =
     (trans
       (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
       (sym (rightStoreⁱ-lift liftρ₂)))
-
-right-swap-source-reveal-store :
-  ∀ {Φ Δᴸ Δᴿ Aobs}
-    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
-      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
-  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
-  renameStoreᵗ suc
-      ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
-    ≡ (suc zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷ leftStoreⁱ ρ₂
-right-swap-source-reveal-store liftρ₁ liftρ₂ =
-  cong₂ _∷_ refl
-    (trans
-      (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
-      (sym (leftStoreⁱ-lift liftρ₂)))
-
-left-swap-target-reveal-store :
-  ∀ {Φ Δᴸ Δᴿ Bobs}
-    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
-      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
-  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
-  renameStoreᵗ (extᵗ suc)
-      ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
-    ≡ (zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷ rightStoreⁱ ρ₂
-left-swap-target-reveal-store {Bobs = Bobs} {ρ₀ = ρ₀}
-    liftρ₁ liftρ₂ =
-  cong₂ _∷_
-    (cong (λ C → zero , C) (renameᵗ-ext-suc-comm suc Bobs))
-    (trans
-      (renameStoreᵗ-ext-suc-comm suc (rightStoreⁱ ρ₀))
-      (trans
-        (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
-        (sym (rightStoreⁱ-lift liftρ₂))))
 
 left-swap-reveal-conversion :
   ∀ {Φ Δᴸ Δᴿ Aobs E F s μ}
@@ -6539,6 +1708,44 @@ right-swap-reveal-conversion {Δᴿ = Δᴿ} {Bobs = Bobs}
         (modeRename-left-inverse
           {ρ = suc} {ψ = predᵗ} RenameLeftInverse-suc)
         s′↑))
+
+right-swap-source-reveal-store :
+  ∀ {Φ Δᴸ Δᴿ Aobs}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ suc
+      ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    ≡ (suc zero , ⇑ᵗ (⇑ᵗ Aobs)) ∷ leftStoreⁱ ρ₂
+right-swap-source-reveal-store liftρ₁ liftρ₂ =
+  cong₂ _∷_ refl
+    (trans
+      (cong ⟰ᵗ (sym (leftStoreⁱ-lift liftρ₁)))
+      (sym (leftStoreⁱ-lift liftρ₂)))
+
+left-swap-target-reveal-store :
+  ∀ {Φ Δᴸ Δᴿ Bobs}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  renameStoreᵗ (extᵗ suc)
+      ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    ≡ (zero , ⇑ᵗ (⇑ᵗ Bobs)) ∷ rightStoreⁱ ρ₂
+left-swap-target-reveal-store {Bobs = Bobs} {ρ₀ = ρ₀}
+    liftρ₁ liftρ₂ =
+  cong₂ _∷_
+    (cong (λ C → zero , C) (renameᵗ-ext-suc-comm suc Bobs))
+    (trans
+      (renameStoreᵗ-ext-suc-comm suc (rightStoreⁱ ρ₀))
+      (trans
+        (cong ⟰ᵗ (sym (rightStoreⁱ-lift liftρ₁)))
+        (sym (rightStoreⁱ-lift liftρ₂))))
 
 right-swap-source-reveal-conversion :
   ∀ {Φ Δᴸ Δᴿ Aobs E F s μ}
@@ -6614,54 +1821,309 @@ left-swap-target-reveal-conversion {Δᴿ = Δᴿ}
             RenameLeftInverse-ext-suc-pred)
           s′↑)))
 
-crossed-source-body-typing :
-  ∀ {Φ Δᴸ Δᴿ A W}
-    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
-      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
-  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
-  No• W →
-  suc Δᴸ ∣ leftStoreⁱ ρ₁ ∣ [] ⊢ W ⦂ A →
-  suc (suc Δᴸ) ∣ leftStoreⁱ ρ₂ ∣ []
-    ⊢ renameᵗᵐ suc W ⦂ renameᵗ suc A
-crossed-source-body-typing {Δᴸ = Δᴸ} {A = A} {W = W}
-    {ρ₁ = ρ₁} liftρ₂ noW W⊢ =
-  subst
-    (λ Σ → suc (suc Δᴸ) ∣ Σ ∣ []
-      ⊢ renameᵗᵐ suc W ⦂ renameᵗ suc A)
-    (sym (leftStoreⁱ-lift liftρ₂))
-    (typing-renameᵀ
-      {Δ = suc Δᴸ} {Δ′ = suc (suc Δᴸ)}
-      {Σ = leftStoreⁱ ρ₁} {Γ = []} {M = W} {A = A}
-      {ρ = suc} {ψ = predᵗ}
-      TyRenameWf-suc RenameLeftInverse-suc castModeRenamer-suc
-      noW W⊢)
-
-crossed-target-body-typing :
-  ∀ {Φ Δᴸ Δᴿ B W′}
+crossed-double-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B L L′ p}
     {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
     {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
     {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
       (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
   LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
   LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
-  No• W′ →
-  suc Δᴿ ∣ rightStoreⁱ ρ₁ ∣ [] ⊢ W′ ⦂ B →
-  suc (suc Δᴿ) ∣ rightStoreⁱ ρ₂ ∣ []
-    ⊢ renameᵗᵐ (extᵗ suc) W′ ⦂ renameᵗ (extᵗ suc) B
-crossed-target-body-typing {Δᴿ = Δᴿ} {B = B} {W′ = W′}
-    {ρ₁ = ρ₁} liftρ₁ liftρ₂ noW′ W′⊢ =
-  subst
-    (λ Σ → suc (suc Δᴿ) ∣ Σ ∣ []
-      ⊢ renameᵗᵐ (extᵗ suc) W′ ⦂ renameᵗ (extᵗ suc) B)
-    (rightStoreⁱ-crossed-body liftρ₁ liftρ₂)
-    (typing-renameᵀ
-      {Δ = suc Δᴿ} {Δ′ = suc (suc Δᴿ)}
-      {Σ = rightStoreⁱ ρ₁} {Γ = []} {M = W′} {A = B}
-      {ρ = extᵗ suc} {ψ = predᵗ}
-      (TyRenameWf-ext TyRenameWf-suc)
-      RenameLeftInverse-ext-suc-pred
-      (castModeRenamer-ext castModeRenamer-suc) noW′ W′⊢)
+  No• L → No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  swapRight∀∀ᵢ Φ
+    ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣ ρ₂ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ (⇑ᵗᵐ L) ⊑ ⇑ᵗᵐ (⇑ᵗᵐ L′)
+    ⦂ ⇑ᵗ (⇑ᵗ A) ⊑ ⇑ᵗ (⇑ᵗ B)
+    ∶ ⊑-crossed-double-lift∀∀ᵢ p
+crossed-double-bodyᵀ {A = A} {B = B} {L = L} {L′ = L′}
+    liftρ₁ liftρ₂ noL noL′ L⊑L′ =
+  nu-term-imprecision-transport-termsᵀ
+    (sym (renameᵗᵐ-compose suc suc L))
+    (sym (renameᵗᵐ-compose suc suc L′))
+    (nu-term-imprecision-transport-typesᵀ
+      (sym (renameᵗ-compose suc suc A))
+      (sym (renameᵗ-compose suc suc B))
+      refl
+      (rel-world-embed-no•ᵀ
+        (crossed-double-world-embeddingⁱ liftρ₁ liftρ₂)
+        L⊑L′ noL noL′))
+
+crossed-double-prefix-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B L L′ p}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {ρ₂ ρ⁺ : StoreImp (swapRight∀∀ᵢ Φ)
+      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
+  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
+  StoreImpPrefix ρ₂ ρ⁺ →
+  No• L → No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  swapRight∀∀ᵢ Φ
+    ∣ suc (suc Δᴸ) ∣ suc (suc Δᴿ) ∣ ρ⁺ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ (⇑ᵗᵐ L) ⊑ ⇑ᵗᵐ (⇑ᵗᵐ L′)
+    ⦂ ⇑ᵗ (⇑ᵗ A) ⊑ ⇑ᵗ (⇑ᵗ B)
+    ∶ ⊑-crossed-double-lift∀∀ᵢ p
+crossed-double-prefix-bodyᵀ liftρ₁ liftρ₂ prefix noL noL′ L⊑L′ =
+  allocation-prefixᵀ prefix body
+    (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
+      noLL (nu-term-imprecision-source-typing body))
+    (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
+      noLL′ (nu-term-imprecision-target-typing body))
+  where
+  body = crossed-double-bodyᵀ liftρ₁ liftρ₂ noL noL′ L⊑L′
+  noLL = renameᵗᵐ-preserves-No• suc
+    (renameᵗᵐ-preserves-No• suc noL)
+  noLL′ = renameᵗᵐ-preserves-No• suc
+    (renameᵗᵐ-preserves-No• suc noL′)
+
+paired-left-lift-prefix-bodyᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ A B C L L′ p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp Ψ (suc Δᴸ) Δᴿ}
+    {hC : WfTy (suc Δᴸ) C} →
+  LiftLeftStoreⁱ Ψ ρ ρᵃ →
+  LiftLeftStoreⁱ Ψ ρ ρᵇ →
+  No• L → No• L′ →
+  Ψ ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero C hC ∷ ρᵇ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ p →
+  Ψ ∣ suc Δᴸ ∣ Δᴿ ∣
+    store-left zero C hC ∷ ρᵃ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ A ⊑ B ∶ ⊑-rename-idᵢ p
+paired-left-lift-prefix-bodyᵀ
+    {A = A} {B = B} {L = L} {L′ = L′}
+    liftρᵃ liftρᵇ noL noL′ L⊑L′ =
+  nu-term-imprecision-transport-termsᵀ
+    (renameᵗᵐ-id L) (renameᵗᵐ-id L′)
+    (nu-term-imprecision-transport-typesᵀ
+      (renameᵗ-id A) (renameᵗ-id B) refl
+      (rel-world-embed-no•ᵀ
+        (paired-left-lift-prefix-world-embeddingⁱ liftρᵇ liftρᵃ)
+        L⊑L′ noL noL′))
+
+weak-one-step-·₁-value-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ L L₁′
+      (A ⇒ B) (A′ ⇒ B′) χ) →
+  sourceChanges inner ≡ [] →
+  sourceResult inner ≡ L →
+  No• M′ →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ L ⊑ targetResult inner
+    ⦂ applyTys (sourceChanges inner) A ⇒
+        applyTys (sourceChanges inner) B
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ∶ transportType inner pA ↦ transportType inner pB →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ M ⊑
+      applyTerms (targetTailChanges inner) (applyTerm χ M′)
+    ⦂ applyTys (sourceChanges inner) A
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+    ∶ transportType inner pA →
+  WeakOneStepResult ρ
+    (L · M) (L₁′ · applyTerm χ M′) B B′ χ
+weak-one-step-·₁-value-frameᵀ
+    {L = L} {M = M} {M′ = M′} {B = B} {B′ = B′} {χ = χ}
+    {pB = pB}
+    inner refl refl noM′ L⊑L′ M⊑M′ =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult = L · M
+    ; targetResult =
+        targetResult inner ·
+          applyTerms (targetTailChanges inner) (applyTerm χ M′)
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = ↠-refl
+    ; targetTail =
+        ·₁-↠ (applyTerm-preserves-No• χ noM′)
+          (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults = ·⊑·ᵀ L⊑L′ M⊑M′
+    }
+
+weak-one-step-·₁-value-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ L L₁′
+      (A ⇒ B) (A′ ⇒ B′) χ)
+    (changes-eq : sourceChanges inner ≡ [])
+    (result-eq : sourceResult inner ≡ L)
+    (noM′ : No• M′)
+    (L⊑L′ : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ L ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) A ⇒
+          applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+          applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner pA ↦ transportType inner pB)
+    (M⊑M′ : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ M ⊑
+        applyTerms (targetTailChanges inner) (applyTerm χ M′)
+      ⦂ applyTys (sourceChanges inner) A
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+      ∶ transportType inner pA) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-·₁-value-frameᵀ
+      inner changes-eq result-eq noM′ L⊑L′ M⊑M′)
+weak-one-step-·₁-value-frame-preserves-transportᵀ
+    inner refl refl noM′ L⊑L′ M⊑M′ transport =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-·₁-value-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ L L₁′
+      (A ⇒ B) (A′ ⇒ B′) χ)
+    (changes-eq : sourceChanges inner ≡ [])
+    (result-eq : sourceResult inner ≡ L)
+    (noM′ : No• M′)
+    (L⊑L′ : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ L ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) A ⇒
+          applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+          applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner pA ↦ transportType inner pB)
+    (M⊑M′ : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ M ⊑
+        applyTerms (targetTailChanges inner) (applyTerm χ M′)
+      ⦂ applyTys (sourceChanges inner) A
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+      ∶ transportType inner pA) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-·₁-value-frameᵀ
+      inner changes-eq result-eq noM′ L⊑L′ M⊑M′)
+weak-one-step-·₁-value-frame-preserves-type-coherenceᵀ
+    inner refl refl noM′ L⊑L′ M⊑M′ coherence =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-source-blame-right-allocation-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ V′ s s′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (h⇑A′ : WfTy (suc Δᴿ) (⇑ᵗ A′)) →
+  (target⊢ : Δᴿ ∣ rightStoreⁱ ρ ∣ []
+    ⊢ ν A′ V′ s′ ⦂ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepTransport
+    (weak-one-step-source-blame-right-allocationᵀ
+      {A = A} {A′ = A′} {B = B} {B′ = B′}
+      {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
+      wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
+weak-one-step-source-blame-right-allocation-transportᵀ
+    {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB =
+  weak-step-transport
+    (right-lift-prefix-bodyᵀ
+      (proj₂ (lift-right-store-result ρ))
+      (prefix-∷ⁱ prefix-reflⁱ))
+
+⊑-target-lift-right-arrow-coherentᵢ :
+  ∀ {Φ Δᴸ Δᴿ C C′ D D′}
+    (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+    (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+  ⊑-target-lift-rightᵢ (pC ↦ pD) ≡
+    (⊑-target-lift-rightᵢ pC ↦ ⊑-target-lift-rightᵢ pD)
+⊑-target-lift-right-arrow-coherentᵢ
+    {C = C} {D = D} pC pD =
+  transport-arrow-⊑ᵢ
+    (renameᵗ-id C) refl (renameᵗ-id D) refl
+
+⊑-target-lift-right-all-coherentᵢ :
+  ∀ {Φ Δᴸ Δᴿ C C′}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+  ⊑-target-lift-rightᵢ (∀ⁱ q) ≡
+    (∀ⁱ (⊑-target-lift-right-under-∀ᵢ q))
+⊑-target-lift-right-all-coherentᵢ {C = C} q
+    rewrite equality-proof-unique
+      (renameᵗ-id (`∀ C)) (cong `∀ (renameᵗ-ext-id C)) =
+  transport-all-⊑ᵢ (renameᵗ-ext-id C) refl
+
+weak-one-step-source-blame-right-allocation-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ V′ s s′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (wfΣ′ : StoreWf Δᴿ (rightStoreⁱ ρ)) →
+  (vV′ : Value V′) →
+  (noV′ : No• V′) →
+  (h⇑A′ : WfTy (suc Δᴿ) (⇑ᵗ A′)) →
+  (target⊢ : Δᴿ ∣ rightStoreⁱ ρ ∣ []
+    ⊢ ν A′ V′ s′ ⦂ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-source-blame-right-allocationᵀ
+      {A = A} {A′ = A′} {B = B} {B′ = B′}
+      {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
+      wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
+weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB =
+  weak-step-type-coherence
+    (λ pC pD → HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ result pC pD)
+        (≡-to-≅
+          (⊑-target-lift-right-arrow-coherentᵢ pC pD))))
+    (λ q → HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ result q)
+        (≡-to-≅ (⊑-target-lift-right-all-coherentᵢ q))))
+  where
+  result = weak-one-step-source-blame-right-allocationᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB
 
 crossed-bodyᵀ :
   ∀ {Φ Δᴸ Δᴿ A B W W′ p}
@@ -6681,63 +2143,9 @@ crossed-bodyᵀ :
     ⦂ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B
     ∶ ⊑-crossed-body-lift∀∀ᵢ p
 crossed-bodyᵀ liftρ₁ liftρ₂ noW noW′ W⊑W′ =
-  swapRight-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl
-    (⊑-crossed-body-lift∀∀ᵢ _)
-    (crossed-source-body-typing liftρ₂ noW
-      (nu-term-imprecision-source-typing W⊑W′))
-    (crossed-target-body-typing liftρ₁ liftρ₂ noW′
-      (nu-term-imprecision-target-typing W⊑W′))
-
-crossed-left-source-body-typing :
-  ∀ {Φ Δᴸ Δᴿ A W}
-    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
-      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
-  LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁ →
-  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
-  No• W →
-  suc Δᴸ ∣ leftStoreⁱ ρ₁ ∣ [] ⊢ W ⦂ A →
-  suc (suc Δᴸ) ∣ leftStoreⁱ ρ₂ ∣ []
-    ⊢ renameᵗᵐ (extᵗ suc) W ⦂ renameᵗ (extᵗ suc) A
-crossed-left-source-body-typing
-    {Δᴸ = Δᴸ} {A = A} {W = W} {ρ₁ = ρ₁}
-    liftρ₁ liftρ₂ noW W⊢ =
-  subst
-    (λ Σ → suc (suc Δᴸ) ∣ Σ ∣ []
-      ⊢ renameᵗᵐ (extᵗ suc) W ⦂ renameᵗ (extᵗ suc) A)
-    (leftStoreⁱ-crossed-body liftρ₁ liftρ₂)
-    (typing-renameᵀ
-      {Δ = suc Δᴸ} {Δ′ = suc (suc Δᴸ)}
-      {Σ = leftStoreⁱ ρ₁} {Γ = []} {M = W} {A = A}
-      {ρ = extᵗ suc} {ψ = predᵗ}
-      (TyRenameWf-ext TyRenameWf-suc)
-      RenameLeftInverse-ext-suc-pred
-      (castModeRenamer-ext castModeRenamer-suc) noW W⊢)
-
-crossed-left-target-body-typing :
-  ∀ {Φ Δᴸ Δᴿ B W′}
-    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
-    {ρ₂ : StoreImp (swapRight∀∀ᵢ Φ)
-      (suc (suc Δᴸ)) (suc (suc Δᴿ))} →
-  LiftStoreⁱ (swapRight∀∀ᵢ Φ) ρ₁ ρ₂ →
-  No• W′ →
-  suc Δᴿ ∣ rightStoreⁱ ρ₁ ∣ [] ⊢ W′ ⦂ B →
-  suc (suc Δᴿ) ∣ rightStoreⁱ ρ₂ ∣ []
-    ⊢ renameᵗᵐ suc W′ ⦂ renameᵗ suc B
-crossed-left-target-body-typing
-    {Δᴿ = Δᴿ} {B = B} {W′ = W′} {ρ₁ = ρ₁}
-    liftρ₂ noW′ W′⊢ =
-  subst
-    (λ Σ → suc (suc Δᴿ) ∣ Σ ∣ []
-      ⊢ renameᵗᵐ suc W′ ⦂ renameᵗ suc B)
-    (sym (rightStoreⁱ-lift liftρ₂))
-    (typing-renameᵀ
-      {Δ = suc Δᴿ} {Δ′ = suc (suc Δᴿ)}
-      {Σ = rightStoreⁱ ρ₁} {Γ = []} {M = W′} {A = B}
-      {ρ = suc} {ψ = predᵗ}
-      TyRenameWf-suc RenameLeftInverse-suc castModeRenamer-suc
-      noW′ W′⊢)
+  rel-world-embed-no•ᵀ
+    (crossed-right-world-embeddingⁱ liftρ₁ liftρ₂)
+    W⊑W′ noW noW′
 
 crossed-left-bodyᵀ :
   ∀ {Φ Δᴸ Δᴿ A B W W′ p}
@@ -6757,12 +2165,9 @@ crossed-left-bodyᵀ :
     ⦂ renameᵗ (extᵗ suc) A ⊑ ⇑ᵗ B
     ∶ ⊑-crossed-left-body-lift∀∀ᵢ p
 crossed-left-bodyᵀ liftρ₁ liftρ₂ noW noW′ W⊑W′ =
-  swapLeft-bodyᵀ liftρ₁ liftρ₂ W⊑W′ refl refl refl refl
-    (⊑-crossed-left-body-lift∀∀ᵢ _)
-    (crossed-left-source-body-typing liftρ₁ liftρ₂ noW
-      (nu-term-imprecision-source-typing W⊑W′))
-    (crossed-left-target-body-typing liftρ₂ noW′
-      (nu-term-imprecision-target-typing W⊑W′))
+  rel-world-embed-no•ᵀ
+    (crossed-left-world-embeddingⁱ liftρ₁ liftρ₂)
+    W⊑W′ noW noW′
 
 lift-store-matched-∈ :
   ∀ {Φ Ψ Δᴸ Δᴿ ρ ρ′ α β A B p} →
@@ -6998,7 +2403,7 @@ allocated-left-relationᵀ :
     store-left zero Aν hAν ∷ ρ′ ∣ γ′
     ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
 allocated-left-relationᵀ hAν liftρ noM M⊑M′ =
-  allocation-leftᵀ hAν liftρ M⊑M′
+  allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) M⊑M′
     (term-weaken {Δ′ = _} {Σ′ = _} ≤-refl StoreIncl-drop noM
       (nu-term-imprecision-source-typing M⊑M′))
     (nu-term-imprecision-target-typing M⊑M′)
@@ -7129,6 +2534,16 @@ post-β-inst :
   Value V →
   V ⟨ inst B s ⟩ —→[ keep ] ν ★ V s
 post-β-inst vV = pure-step (β-inst vV)
+
+post-catchup-β-inst :
+  ∀ χs {V B s} →
+  Value V →
+  V ⟨ applyCoercions χs (inst B s) ⟩
+    —→[ keep ]
+      ν ★ V (applyCoercionUnderTyBinders χs s)
+post-catchup-β-inst χs {B = B} {s = s} vV
+    rewrite applyCoercions-inst χs B s =
+  pure-step (β-inst vV)
 
 post-β-gen• :
   ∀ {V A c} →
@@ -7466,12 +2881,10 @@ paired-swap-gen-inst-allocationᵀ {Aobs = Aobs} {Bobs = Bobs}
   let
     body⊑body′ = crossed-bodyᵀ liftρ₁ liftρ₂ noW noW′ W⊑W′
     allocated-body =
-      allocation-crossedᵀ
-        (⊑-src-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
-        wf★ wf★
-        (⊑-tgt-wf (⊑-crossed-double-lift∀∀ᵢ pObs))
-        liftρ₁ liftρ₂
-        (⊑-crossed-double-lift∀∀ᵢ pObs) id★
+      allocation-prefixᵀ
+        (prefix-∷ⁱ (prefix-∷ⁱ (prefix-∷ⁱ
+          (prefix-∷ⁱ (prefix-∷ⁱ
+            (prefix-∷ⁱ prefix-reflⁱ))))))
         body⊑body′
         (term-weaken ≤-refl (λ x∈ → there (there x∈))
           (renameᵗᵐ-preserves-No• suc noW)
@@ -7492,11 +2905,13 @@ paired-swap-gen-inst-allocationᵀ {Aobs = Aobs} {Bobs = Bobs}
       ∀inst-crossed-widening-body
         {Bobs = ⇑ᵗ (⇑ᵗ Bobs)} liftρ₁ liftρ₂ ∀inst⊑
     exposed-casts =
-      crossed-up⊑upᵀ
+      up⊑upᵀ
         (gen-down⊑gen-downᵀ d⊒ d′⊒ allocated-body qD)
-        (cast-ext (cast-inst cast-tag-or-id))
-        seal★-ext-inst-tag-or-id u⊑
-        seal★-inst-ext-tag-or-id u′⊑ pE
+        (quotient-cast-widening
+          (cast-ext (cast-inst cast-tag-or-id))
+          seal★-ext-inst-tag-or-id u⊑
+          (cast-inst (cast-ext cast-tag-or-id))
+          seal★-inst-ext-tag-or-id u′⊑) pE
   in
   left-swap-allocation-trace vW noW ,
   right→ ,
@@ -7597,9 +3012,11 @@ paired-reverse-swap-gen-inst-allocationᵀ
     body⊑body′ = crossed-left-bodyᵀ
       liftρ₁ liftρ₂ noW noW′ W⊑W′
     allocated-body =
-      allocation-crossedᵀ
-        wf★ (⊑-src-wf pObs×) (⊑-tgt-wf pObs×) wf★
-        liftρ₁ liftρ₂ id★ pObs× body⊑body′
+      allocation-prefixᵀ
+        (prefix-∷ⁱ (prefix-∷ⁱ (prefix-∷ⁱ
+          (prefix-∷ⁱ (prefix-∷ⁱ
+            (prefix-∷ⁱ prefix-reflⁱ))))))
+        body⊑body′
         (term-weaken ≤-refl (λ x∈ → there (there x∈))
           (renameᵗᵐ-preserves-No• (extᵗ suc) noW)
           (nu-term-imprecision-source-typing body⊑body′))
@@ -7615,11 +3032,13 @@ paired-reverse-swap-gen-inst-allocationᵀ
     u′⊑ = inst∀-crossed-target-widening-body
       {Bobs = ⇑ᵗ (⇑ᵗ Bobs)} liftρ₁ liftρ₂ inst∀⊑
     exposed-casts =
-      crossed-left-up⊑upᵀ
+      up⊑upᵀ
         (gen-down⊑gen-downᵀ d⊒ d′⊒ allocated-body qD)
-        (cast-inst (cast-ext cast-tag-or-id))
-        seal★-inst-ext-tag-or-id u⊑
-        seal★-ext-inst-tag-or-id u′⊑ pE
+        (quotient-cast-widening
+          (cast-inst (cast-ext cast-tag-or-id))
+          seal★-inst-ext-tag-or-id u⊑
+          (cast-ext (cast-inst cast-tag-or-id))
+          seal★-ext-inst-tag-or-id u′⊑) pE
   in
   right-swap-allocation-trace vW noW ,
   left→ ,
@@ -7967,6 +3386,132 @@ weak-one-step-direct-quotientᵀ {Aobs = Aobs} {Bobs = Bobs}
     ; relatedResults = result
     }
 
+weak-one-step-direct-quotient-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ T E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (liftρ₁ : LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁) →
+  (vW : Value W) →
+  (okM : RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s)) →
+  (vW′ : Value W′) →
+  (noM′ : No•
+    ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+      ⟨ `∀ (inst E′ u′) ⟩)) →
+  (W⊑W′ : ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA) →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ D) ⊑ᵖ `∀ (`∀ T) ⊣ Δᴿ) →
+  (D′ˢ≈T : renameᵗ swap01ᵗ D′ ≈∀ T) →
+  (pE : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ) →
+  (pF : Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ) →
+  (∀gen⊒ : genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D)) →
+  (gen∀⊒ : genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′) ∶ `∀ B ⊒ `∀ (`∀ T)) →
+  (inst∀⊑ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E) →
+  (∀inst⊑ : id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′) ∶ `∀ (`∀ T) ⊑ `∀ E′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′)) →
+  WeakOneStepTransport
+    (weak-one-step-direct-quotientᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑)
+weak-one-step-direct-quotient-transportᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+    with direct-swap-gen-inst-caseᵀ liftρ₁ vW okM vW′ noM′
+      W⊑W′ pObs pD qD D′ˢ≈T pE pF
+      ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+weak-one-step-direct-quotient-transportᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+    | ρ₂ , pF× , liftρ₂ , left↞ , step , right↞ , result =
+  weak-step-transport
+    (crossed-double-prefix-bodyᵀ liftρ₁ liftρ₂
+      (prefix-∷ⁱ (prefix-∷ⁱ (prefix-∷ⁱ
+        (prefix-∷ⁱ (prefix-∷ⁱ
+          (prefix-∷ⁱ prefix-reflⁱ)))))))
+
+weak-one-step-direct-quotient-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ T E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (liftρ₁ : LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁) →
+  (vW : Value W) →
+  (okM : RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s)) →
+  (vW′ : Value W′) →
+  (noM′ : No•
+    ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+      ⟨ `∀ (inst E′ u′) ⟩)) →
+  (W⊑W′ : ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA) →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ D) ⊑ᵖ `∀ (`∀ T) ⊣ Δᴿ) →
+  (D′ˢ≈T : renameᵗ swap01ᵗ D′ ≈∀ T) →
+  (pE : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ) →
+  (pF : Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ) →
+  (∀gen⊒ : genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D)) →
+  (gen∀⊒ : genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′) ∶ `∀ B ⊒ `∀ (`∀ T)) →
+  (inst∀⊑ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E) →
+  (∀inst⊑ : id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′) ∶ `∀ (`∀ T) ⊑ `∀ E′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-direct-quotientᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑)
+weak-one-step-direct-quotient-type-coherenceᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+    with direct-swap-gen-inst-caseᵀ liftρ₁ vW okM vW′ noM′
+      W⊑W′ pObs pD qD D′ˢ≈T pE pF
+      ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+weak-one-step-direct-quotient-type-coherenceᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+    | ρ₂ , pF× , liftρ₂ , left↞ , step , right↞ , result =
+  weak-step-type-coherence
+    (λ pC pD′ → HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ oneStep pC pD′)
+        (≡-to-≅ (⊑-crossed-double-lift-arrowᵢ pC pD′))))
+    (λ q → HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ oneStep q)
+        (≡-to-≅ (⊑-crossed-double-lift-allᵢ q))))
+  where
+  oneStep = weak-one-step-direct-quotientᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+
 weak-one-step-reverse-direct-quotientᵀ :
   ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B S D D′ E E′ F F′}
     {W W′ d d′ u u′ s s′ μ μ′ pA}
@@ -8089,6 +3634,268 @@ weak-one-step-reverse-direct-quotientᵀ
           liftρ₁ liftρ₂
     ; relatedResults = result
     }
+
+weak-one-step-reverse-direct-quotient-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B S D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (liftρ₁ : LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁) →
+  (vW : Value W) →
+  (okM : RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s)) →
+  (vW′ : Value W′) →
+  (noM′ : No•
+    ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+      ⟨ inst (`∀ E′) (`∀ u′) ⟩)) →
+  (W⊑W′ : ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA) →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ S) ⊑ᵖ `∀ (`∀ D′) ⊣ Δᴿ) →
+  (S≈Dˢ : S ≈∀ renameᵗ swap01ᵗ D) →
+  (pE : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ) →
+  (pF : Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ) →
+  (gen∀⊒ : genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d) ∶ `∀ A ⊒ `∀ (`∀ S)) →
+  (∀gen⊒ : genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′)) →
+  (∀inst⊑ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u) ∶ `∀ (`∀ S) ⊑ `∀ E) →
+  (inst∀⊑ : id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′)) →
+  WeakOneStepTransport
+    (weak-one-step-reverse-direct-quotientᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑)
+weak-one-step-reverse-direct-quotient-transportᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    with direct-reverse-swap-gen-inst-caseᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+      gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+weak-one-step-reverse-direct-quotient-transportᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    | ρ₂ , pF× , liftρ₂ , right↞ , step , left↞ , result =
+  weak-step-transport
+    (crossed-double-prefix-bodyᵀ liftρ₁ liftρ₂
+      (prefix-∷ⁱ (prefix-∷ⁱ (prefix-∷ⁱ
+        (prefix-∷ⁱ (prefix-∷ⁱ
+          (prefix-∷ⁱ prefix-reflⁱ)))))))
+
+weak-one-step-reverse-direct-quotient-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B S D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (liftρ₁ : LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁) →
+  (vW : Value W) →
+  (okM : RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s)) →
+  (vW′ : Value W′) →
+  (noM′ : No•
+    ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+      ⟨ inst (`∀ E′) (`∀ u′) ⟩)) →
+  (W⊑W′ : ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA) →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ S) ⊑ᵖ `∀ (`∀ D′) ⊣ Δᴿ) →
+  (S≈Dˢ : S ≈∀ renameᵗ swap01ᵗ D) →
+  (pE : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ) →
+  (pF : Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ) →
+  (gen∀⊒ : genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d) ∶ `∀ A ⊒ `∀ (`∀ S)) →
+  (∀gen⊒ : genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′)) →
+  (∀inst⊑ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u) ∶ `∀ (`∀ S) ⊑ `∀ E) →
+  (inst∀⊑ : id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′)) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-reverse-direct-quotientᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑)
+weak-one-step-reverse-direct-quotient-type-coherenceᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    with direct-reverse-swap-gen-inst-caseᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ pE pF
+      gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+weak-one-step-reverse-direct-quotient-type-coherenceᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+    | ρ₂ , pF× , liftρ₂ , right↞ , step , left↞ , result =
+  weak-step-type-coherence
+    (λ pC pD′ → HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ oneStep pC pD′)
+        (≡-to-≅ (⊑-crossed-double-lift-arrowᵢ pC pD′))))
+    (λ q → HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ oneStep q)
+        (≡-to-≅ (⊑-crossed-double-lift-allᵢ q))))
+  where
+  oneStep = weak-one-step-reverse-direct-quotientᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+
+weak-one-step-direct-quotient-indexed-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B D D′ T E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (liftρ₁ : LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁) →
+  (vW : Value W) →
+  (okM : RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s)) →
+  (vW′ : Value W′) →
+  (noM′ : No•
+    ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+      ⟨ `∀ (inst E′ u′) ⟩)) →
+  (W⊑W′ : ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA) →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ D) ⊑ᵖ `∀ (`∀ T) ⊣ Δᴿ) →
+  (D′ˢ≈T : renameᵗ swap01ᵗ D′ ≈∀ T) →
+  (pE : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ) →
+  (pF : Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ) →
+  (∀gen⊒ : genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (gen A d) ∶ `∀ A ⊒ `∀ (`∀ D)) →
+  (gen∀⊒ : genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ gen (`∀ B) (`∀ d′) ∶ `∀ B ⊒ `∀ (`∀ T)) →
+  (inst∀⊑ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ E) (`∀ u) ∶ `∀ (`∀ D) ⊑ `∀ E) →
+  (∀inst⊑ : id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (inst E′ u′) ∶ `∀ (`∀ T) ⊑ `∀ E′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′)) →
+  WeakOneStepIndexedOutcome
+    {M = ν Aobs
+      ((Λ W) ⟨ `∀ (gen A d) ⟩
+        ⟨ inst (`∀ E) (`∀ u) ⟩) s}
+    {N′ = ((⇑ᵗᵐ
+      ((Λ W′) ⟨ gen (`∀ B) (`∀ d′) ⟩
+        ⟨ `∀ (inst E′ u′) ⟩)) •) ⟨ s′ ⟩}
+    {A = F} {B = F′} {χ = bind Bobs} {ρ = ρ₀} pF
+weak-one-step-direct-quotient-indexed-outcomeᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑ =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result type-eq)
+    (weak-one-step-direct-quotient-transportᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑)
+    (weak-one-step-direct-quotient-type-coherenceᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑)
+  where
+  result = weak-one-step-direct-quotientᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+    pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+  type-eq = subst-cancel-sym
+    (λ S → resultCtx result ∣ resultLeftCtx result
+      ⊢ S ⊑ resultTargetType result ⊣ resultRightCtx result)
+    (sourceTypeResult result)
+    (transportType result pF)
+
+weak-one-step-reverse-direct-quotient-indexed-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aobs Bobs A B S D D′ E E′ F F′}
+    {W W′ d d′ u u′ s s′ μ μ′ pA}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (liftρ₁ : LiftStoreⁱ (∀ᵢᶜ Φ) ρ₀ ρ₁) →
+  (vW : Value W) →
+  (okM : RuntimeOK
+    (ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s)) →
+  (vW′ : Value W′) →
+  (noM′ : No•
+    ((Λ W′) ⟨ `∀ (gen B d′) ⟩
+      ⟨ inst (`∀ E′) (`∀ u′) ⟩)) →
+  (W⊑W′ : ∀ᵢᶜ Φ ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ₁ ∣ []
+    ⊢ᴺ W ⊑ W′ ⦂ A ⊑ B ∶ pA) →
+  (pObs : Φ ∣ Δᴸ ⊢ Aobs ⊑ Bobs ⊣ Δᴿ) →
+  (pD : ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ D′ ⊣ suc (suc Δᴿ)) →
+  (qD : Φ ∣ Δᴸ
+    ⊢ `∀ (`∀ S) ⊑ᵖ `∀ (`∀ D′) ⊣ Δᴿ) →
+  (S≈Dˢ : S ≈∀ renameᵗ swap01ᵗ D) →
+  (pE : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ E ⊑ E′ ⊣ suc Δᴿ) →
+  (pF : Φ ∣ Δᴸ ⊢ F ⊑ F′ ⊣ Δᴿ) →
+  (gen∀⊒ : genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ gen (`∀ A) (`∀ d) ∶ `∀ A ⊒ `∀ (`∀ S)) →
+  (∀gen⊒ : genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ `∀ (gen B d′) ∶ `∀ B ⊒ `∀ (`∀ D′)) →
+  (∀inst⊑ : id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ `∀ (inst E u) ∶ `∀ (`∀ S) ⊑ `∀ E) →
+  (inst∀⊑ : id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst (`∀ E′) (`∀ u′) ∶ `∀ (`∀ D′) ⊑ `∀ E′) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ Aobs) ∷ ⟰ᵗ (leftStoreⁱ ρ₀))
+    zero (⇑ᵗ Aobs) s E (⇑ᵗ F)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ Bobs) ∷ ⟰ᵗ (rightStoreⁱ ρ₀))
+    zero (⇑ᵗ Bobs) s′ E′ (⇑ᵗ F′)) →
+  WeakOneStepIndexedOutcome
+    {M = ν Aobs
+      ((Λ W) ⟨ gen (`∀ A) (`∀ d) ⟩
+        ⟨ `∀ (inst E u) ⟩) s}
+    {N′ = ν Bobs
+      (ν ★ ((Λ W′) ⟨ `∀ (gen B d′) ⟩) (`∀ u′))
+      s′}
+    {A = F} {B = F′} {χ = keep} {ρ = ρ₀} pF
+weak-one-step-reverse-direct-quotient-indexed-outcomeᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑ =
+  indexed-outcome-related
+    (weak-one-step-index-resultᵀ result type-eq)
+    (weak-one-step-reverse-direct-quotient-transportᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑)
+    (weak-one-step-reverse-direct-quotient-type-coherenceᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑)
+  where
+  result = weak-one-step-reverse-direct-quotientᵀ
+    liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+    pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+  type-eq = subst-cancel-sym
+    (λ T → resultCtx result ∣ resultLeftCtx result
+      ⊢ resultSourceType result ⊑ T ⊣ resultRightCtx result)
+    (targetTypeResult result)
+    (transportType result pF)
 
 Λ-value-body :
   ∀ {V} →
@@ -8930,40 +4737,6 @@ weak-one-step-generic-β-∀-left-outer-widening-wideningᵀ
   weak-one-step-left-β-∀-wideningᵀ
     vV mode seal★ c∀⊑ V•⊑V′•c′ q
 
-weak-one-step-keep-source-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ M N N′ A B p}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  M —→[ keep ] N →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p →
-  WeakOneStepResult ρ M N′ A B keep
-weak-one-step-keep-source-catchupᵀ source→ result =
-  record
-    { sourceChanges = keep ∷ []
-    ; targetTailChanges = []
-    ; sourceResult = _
-    ; targetResult = _
-    ; resultCtx = _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore = _
-    ; resultSourceType = _
-    ; resultTargetType = _
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = λ p → p
-    ; transportAllBody = λ p → p
-    ; transportRightBody = λ p → p
-    ; resultType = _
-    ; sourceCatchup = ↠-step source→ ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult = refl
-    ; targetStoreResult = refl
-    ; relatedResults = result
-    }
-
 left-catchup-all-keep-stepᵀ :
   ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
     {ρ : StoreImp Φ Δᴸ Δᴿ} →
@@ -9001,6 +4774,1373 @@ left-catchup-all-prepend-keepᵀ source→ N⊑V′
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
 
+left-catchup-indexed-all-keep-stepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (source→ : M —→[ keep ] N) →
+  (final : (Value N × No• N) ⊎ N ≡ blame) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = M} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-all-keep-stepᵀ source→ final N⊑V′ =
+  left-indexed-all-catchup
+    (weak-one-step-index-resultᵀ result refl)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+    (weak-one-step-keep-source-catchup-transportᵀ
+      source→ N⊑V′)
+    (weak-one-step-keep-source-catchup-type-coherenceᵀ
+      source→ N⊑V′)
+  where
+  result = weak-one-step-keep-source-catchupᵀ source→ N⊑V′
+
+left-catchup-indexed-prefix-prepend-keepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ A B p}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (source→ : M —→[ keep ] N) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ A ⊑ B ∶ p) →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ [] ⊢ N ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ [] ⊢ V′ ⦂ B →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} p →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-prefix-prepend-keepᵀ
+    prefix source→ N⊑V′ N⊢ V′⊢ catchup =
+  left-catchup-indexed-prepend-keepᵀ source→
+    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢) catchup
+
+
+left-catchup-indexed-all-prepend-keepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (source→ : M —→[ keep ] N) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q →
+  LeftCatchupIndexedAllResult
+    {N = M} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-all-prepend-keepᵀ source→ N⊑V′
+    (left-indexed-all-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      second-transport second-coherence) =
+  left-indexed-all-catchup
+    (weak-indexed-result combined (canonicalIndexedResults indexed))
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+    (weak-one-step-prepend-source-keep-transportᵀ
+      source→ second second-transport)
+    (weak-one-step-prepend-source-keep-type-coherenceᵀ
+      source→ second second-coherence)
+  where
+  second = weakIndexedResult indexed
+  combined = weak-one-step-prepend-source-keepᵀ source→ second
+
+left-catchup-indexed-all-prefix-prepend-keepᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (source→ : M —→[ keep ] N) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ [] ⊢ N ⦂ `∀ C →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ [] ⊢ V′ ⦂ `∀ C′ →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} q →
+  LeftCatchupIndexedAllResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} q
+left-catchup-indexed-all-prefix-prepend-keepᵀ
+    prefix source→ N⊑V′ N⊢ V′⊢ catchup =
+  left-catchup-indexed-all-prepend-keepᵀ source→
+    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢) catchup
+
+------------------------------------------------------------------------
+-- Universal cast shapes used by source catch-up
+------------------------------------------------------------------------
+
+weak-one-step-source-cast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B B′ c χ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ M N′ A A′ χ) →
+  (resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ (sourceResult inner ⟨ applyCoercions (sourceChanges inner) c ⟩)
+      ⊑ targetResult inner
+    ⦂ applyTys (sourceChanges inner) B
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+    ∶ transportType inner q) →
+  WeakOneStepResult ρ (M ⟨ c ⟩) N′ B B′ χ
+weak-one-step-source-cast-frameᵀ
+    {B = B} {B′ = B′} {c = c} {χ = χ} inner result =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        sourceResult inner ⟨ applyCoercions (sourceChanges inner) c ⟩
+    ; targetResult = targetResult inner
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner _
+    ; sourceCatchup = cast-↠ (sourceCatchup inner)
+    ; targetTail = targetTail inner
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults = result
+    }
+
+weak-one-step-source-cast-frame-silentᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B B′ c}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M N′ A A′ keep)
+    (result : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ (sourceResult inner ⟨
+          applyCoercions (sourceChanges inner) c ⟩)
+        ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy keep B′)
+      ∶ transportType inner q) →
+  LeftSilentInvariant inner →
+  LeftSilentInvariant
+    (weak-one-step-source-cast-frameᵀ inner result)
+weak-one-step-source-cast-frame-silentᵀ
+    inner result (left-silent-invariant refl refl) =
+  left-silent-invariant refl refl
+
+weak-one-step-source-cast-frame-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B B′ c χ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M N′ A A′ χ)
+    (result : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ (sourceResult inner ⟨ applyCoercions (sourceChanges inner) c ⟩)
+        ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner q) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-source-cast-frameᵀ inner result)
+weak-one-step-source-cast-frame-transportᵀ
+    inner result transport =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-source-cast-frame-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B B′ c χ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M N′ A A′ χ)
+    (result : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ (sourceResult inner ⟨ applyCoercions (sourceChanges inner) c ⟩)
+        ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner q) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-source-cast-frameᵀ inner result)
+weak-one-step-source-cast-frame-coherenceᵀ
+    inner result coherence =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-target-cast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B′ c χ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ M N′ A A′ χ) →
+  (resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ sourceResult inner ⊑
+      (targetResult inner ⟨
+        applyCoercions (targetTailChanges inner)
+          (applyCoercion χ c) ⟩)
+    ⦂ applyTys (sourceChanges inner) A
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+    ∶ transportType inner q) →
+  WeakOneStepResult ρ M (N′ ⟨ applyCoercion χ c ⟩) A B′ χ
+weak-one-step-target-cast-frameᵀ
+    {A = A} {B′ = B′} {c = c} {χ = χ} inner result =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult = sourceResult inner
+    ; targetResult =
+        targetResult inner ⟨
+          applyCoercions (targetTailChanges inner)
+            (applyCoercion χ c) ⟩
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) A
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner _
+    ; sourceCatchup = sourceCatchup inner
+    ; targetTail = cast-↠ (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults = result
+    }
+
+weak-one-step-target-cast-frame-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B′ c χ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M N′ A A′ χ)
+    (result : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑
+        (targetResult inner ⟨
+          applyCoercions (targetTailChanges inner)
+            (applyCoercion χ c) ⟩)
+      ⦂ applyTys (sourceChanges inner) A
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner q) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-target-cast-frameᵀ inner result)
+weak-one-step-target-cast-frame-transportᵀ
+    inner result transport =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-target-cast-frame-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B′ c χ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M N′ A A′ χ)
+    (result : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑
+        (targetResult inner ⟨
+          applyCoercions (targetTailChanges inner)
+            (applyCoercion χ c) ⟩)
+      ⦂ applyTys (sourceChanges inner) A
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner q) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-target-cast-frameᵀ inner result)
+weak-one-step-target-cast-frame-coherenceᵀ
+    inner result coherence =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-source-narrow-cast-indexed-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B c μ χ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ A′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  (indexed : WeakOneStepIndexedResult
+    {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p) →
+  WeakOneStepIndexedResult
+    {M = M ⟨ c ⟩} {N′ = N′} {χ = χ} {ρ = ρ} q
+weak-one-step-source-narrow-cast-indexed-frameᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒ indexed
+    with apply-narrows-typing
+      { χs = sourceChanges (weakIndexedResult indexed) }
+      mode seal★ c⊒
+weak-one-step-source-narrow-cast-indexed-frameᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒ indexed
+    | μ′ , mode′ , seal★′ , c′⊒ =
+  weak-indexed-result framed (relatedResults framed)
+  where
+  inner = weakIndexedResult indexed
+
+  final-seal :
+    SealModeStore★ μ′ (leftStoreⁱ (resultStore inner))
+  final-seal =
+    subst (SealModeStore★ μ′)
+      (sym (sourceStoreResult inner)) seal★′
+
+  final-cast :
+    μ′ ∣ resultLeftCtx inner
+      ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner) c
+        ∶ applyTys (sourceChanges inner) _
+          ⊒ applyTys (sourceChanges inner) B
+  final-cast =
+    subst
+      (λ Δ → μ′ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) c
+          ∶ applyTys (sourceChanges inner) _
+            ⊒ applyTys (sourceChanges inner) B)
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μ′ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+          ⊢ applyCoercions (sourceChanges inner) c
+            ∶ applyTys (sourceChanges inner) _
+              ⊒ applyTys (sourceChanges inner) B)
+        (sym (sourceStoreResult inner)) c′⊒)
+
+  final-relation =
+    cast⊒⊑ᵀ mode′ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  framed = weak-one-step-source-cast-frameᵀ inner final-relation
+
+weak-one-step-source-widen-cast-indexed-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B c μ χ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ A′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  (indexed : WeakOneStepIndexedResult
+    {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p) →
+  WeakOneStepIndexedResult
+    {M = M ⟨ c ⟩} {N′ = N′} {χ = χ} {ρ = ρ} q
+weak-one-step-source-widen-cast-indexed-frameᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ indexed
+    with apply-widens-typing
+      { χs = sourceChanges (weakIndexedResult indexed) }
+      mode seal★ c⊑
+weak-one-step-source-widen-cast-indexed-frameᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ indexed
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  weak-indexed-result framed (relatedResults framed)
+  where
+  inner = weakIndexedResult indexed
+
+  final-seal :
+    SealModeStore★ μ′ (leftStoreⁱ (resultStore inner))
+  final-seal =
+    subst (SealModeStore★ μ′)
+      (sym (sourceStoreResult inner)) seal★′
+
+  final-cast :
+    μ′ ∣ resultLeftCtx inner
+      ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner) c
+        ∶ applyTys (sourceChanges inner) _
+          ⊑ applyTys (sourceChanges inner) B
+  final-cast =
+    subst
+      (λ Δ → μ′ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) c
+          ∶ applyTys (sourceChanges inner) _
+            ⊑ applyTys (sourceChanges inner) B)
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μ′ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+          ⊢ applyCoercions (sourceChanges inner) c
+            ∶ applyTys (sourceChanges inner) _
+              ⊑ applyTys (sourceChanges inner) B)
+        (sym (sourceStoreResult inner)) c′⊑)
+
+  final-relation =
+    cast⊑⊑ᵀ mode′ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  framed = weak-one-step-source-cast-frameᵀ inner final-relation
+
+narrow-all-to-all-inert :
+  ∀ {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ `∀ A ⊒ `∀ B →
+  C.Inert c
+narrow-all-to-all-inert
+    (C.cast-id hA ok , NW.cross ())
+narrow-all-to-all-inert
+    (C.cast-seq () t⊢ , G NW.？︔ gⁿ)
+narrow-all-to-all-inert
+    (C.cast-seq s⊢ () , n NW.︔seal α)
+narrow-all-to-all-inert
+    (C.cast-all c⊢ , NW.cross (NW.`∀ cⁿ)) =
+  C.`∀ _
+narrow-all-to-all-inert
+    (C.cast-inst hB occ c⊢ , NW.cross ())
+narrow-all-to-all-inert
+    (C.cast-gen hA occ c⊢ , NW.gen cⁿ) =
+  C.gen _ _
+
+widen-all-to-all-shape :
+  ∀ {μ Δ Σ c A B} →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ `∀ A ⊑ `∀ B →
+  C.Inert c ⊎ ∃[ s ] c ≡ inst (`∀ B) s
+widen-all-to-all-shape
+    (C.cast-id hA ok , NW.cross ())
+widen-all-to-all-shape
+    (C.cast-seq s⊢ () , gʷ NW.︔ G !)
+widen-all-to-all-shape
+    (C.cast-seq () t⊢ , NW.unseal︔_ α w)
+widen-all-to-all-shape
+    (C.cast-all c⊢ , NW.cross (NW.`∀ cʷ)) =
+  inj₁ (C.`∀ _)
+widen-all-to-all-shape
+    (C.cast-inst hB occ c⊢ , NW.inst cʷ) =
+  inj₂ (_ , refl)
+widen-all-to-all-shape
+    (C.cast-gen hA occ c⊢ , NW.cross ())
+
+reveal-all-to-all-inert :
+  ∀ {μ Δ Σ α X c A B} →
+  RevealConversion μ Δ Σ α X c (`∀ A) (`∀ B) →
+  C.Inert c
+reveal-all-to-all-inert (reveal-all c↑) = C.`∀ _
+
+conceal-all-to-all-inert :
+  ∀ {μ Δ Σ α X c A B} →
+  ConcealConversion μ Δ Σ α X c (`∀ A) (`∀ B) →
+  C.Inert c
+conceal-all-to-all-inert (conceal-all c↓) = C.`∀ _
+
+left-catchup-indexed-all-source-cast-blame-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M L V′ A A′ C C′ ρ d}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  (framed : WeakOneStepIndexedResult
+    {M = L} {N′ = V′} {χ = keep} {ρ = ρ} (∀ⁱ r)) →
+  let inner = weakIndexedResult (catchupIndexedResult catchup)
+      first = weakIndexedResult framed
+  in
+  sourceResult first ≡ sourceResult inner ⟨ d ⟩ →
+  LeftSilentInvariant first →
+  WeakOneStepTransport first →
+  WeakOneStepTypeCoherence first →
+  sourceResult inner ≡ blame →
+  LeftCatchupIndexedAllResult
+    {N = L} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-cast-blame-frameᵀ
+    {r = r}
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    framed refl (left-silent-invariant refl refl)
+    first-transport first-coherence refl =
+  left-indexed-all-catchup
+    (weak-one-step-index-resultᵀ combined type-eq)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₂ refl))
+    combined-transport combined-coherence
+  where
+  first-raw = weakIndexedResult framed
+
+  first = weak-one-step-reindexᵀ
+    first-raw refl refl (canonicalIndexedResults framed)
+
+  first-transport′ =
+    weak-one-step-reindex-preserves-transportᵀ
+      first-raw refl refl (canonicalIndexedResults framed)
+      first-transport
+
+  first-coherence′ =
+    weak-one-step-reindex-preserves-type-coherenceᵀ
+      first-raw refl refl (canonicalIndexedResults framed)
+      first-coherence
+
+  target⊢ =
+    nu-term-imprecision-target-typing (relatedResults first)
+
+  second-relation :
+    resultCtx first
+      ∣ resultLeftCtx first
+      ∣ resultRightCtx first
+      ∣ resultStore first ∣ []
+      ⊢ᴺ blame ⊑ targetResult first
+      ⦂ resultSourceType first ⊑ resultTargetType first
+      ∶ resultType first
+  second-relation = blame⊑ᵀ target⊢
+
+  second = weak-one-step-keep-source-catchupᵀ
+    {Φ = resultCtx first}
+    {Δᴸ = resultLeftCtx first}
+    {Δᴿ = resultRightCtx first}
+    {A = resultSourceType first}
+    {B = resultTargetType first}
+    {p = resultType first}
+    {ρ = resultStore first}
+    (pure-step blame-⟨⟩) second-relation
+
+  combined = weak-one-step-prepend-left-silentᵀ
+    (left-silent first (left-silent-invariant refl refl)) second
+
+  type-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx combined ∣ resultLeftCtx combined
+          ⊢ S ⊑ T ⊣ resultRightCtx combined}
+        (sourceTypeResult combined)
+        (targetTypeResult combined)
+        (resultType combined))
+      (HE.sym (weak-one-step-compose-type-to-nested≅
+        first second (∀ⁱ r))))
+
+  combined-transport =
+    weak-one-step-prepend-left-silent-preserves-transportᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      first-transport′
+      (weak-one-step-keep-source-catchup-transportᵀ
+        (pure-step blame-⟨⟩) second-relation)
+
+  combined-coherence =
+    weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+      (left-silent first (left-silent-invariant refl refl)) second
+      first-coherence′
+      (weak-one-step-keep-source-catchup-type-coherenceᵀ
+        (pure-step blame-⟨⟩) second-relation)
+
+left-catchup-indexed-all-source-inert-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M L V′ A A′ C C′ ρ d}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  C.Inert d →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  (framed : WeakOneStepIndexedResult
+    {M = L} {N′ = V′} {χ = keep} {ρ = ρ} (∀ⁱ r)) →
+  let inner = weakIndexedResult
+        (catchupIndexedResult catchup)
+      first = weakIndexedResult framed
+  in
+  sourceResult first ≡ sourceResult inner ⟨ d ⟩ →
+  LeftSilentInvariant first →
+  WeakOneStepTransport first →
+  WeakOneStepTypeCoherence first →
+  LeftCatchupIndexedAllResult
+    {N = L} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-inert-frameᵀ
+    inert
+    (left-indexed-catchup indexed
+      (left-catchup-invariant inner-silent final)
+      inner-transport inner-coherence)
+    framed refl first-silent
+    first-transport first-coherence
+    with final
+left-catchup-indexed-all-source-inert-frameᵀ
+    inert
+    (left-indexed-catchup indexed
+      (left-catchup-invariant inner-silent final)
+      inner-transport inner-coherence)
+    framed refl first-silent
+    first-transport first-coherence
+    | inj₁ (vW , noW) =
+  left-indexed-all-catchup framed
+    (left-catchup-invariant first-silent
+      (inj₁ (vW ⟨ inert ⟩ , no•-⟨⟩ noW)))
+    first-transport first-coherence
+left-catchup-indexed-all-source-inert-frameᵀ
+    {r = r}
+    inert
+    (left-indexed-catchup indexed
+      (left-catchup-invariant inner-silent final)
+      inner-transport inner-coherence)
+    framed refl first-silent
+    first-transport first-coherence
+    | inj₂ refl =
+  left-catchup-indexed-all-source-cast-blame-frameᵀ
+    (left-indexed-catchup indexed
+      (left-catchup-invariant inner-silent final)
+      inner-transport inner-coherence)
+    framed refl first-silent
+    first-transport first-coherence refl
+
+left-catchup-indexed-all-source-narrow-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ `∀ A ⊒ `∀ B →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-narrow-castᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    with apply-narrows-typing
+      { χs = sourceChanges (weakIndexedResult indexed) }
+      mode seal★ c⊒
+left-catchup-indexed-all-source-narrow-castᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | μ′ , mode′ , seal★′ , c′⊒ =
+  left-catchup-indexed-all-source-inert-frameᵀ
+    (applyCoercions-preserves-Inert (sourceChanges inner)
+      (narrow-all-to-all-inert c⊒))
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    framed refl
+      (weak-one-step-source-cast-frame-silentᵀ
+        inner final-relation (left-silent-invariant refl refl))
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  final-seal :
+    SealModeStore★ μ′ (leftStoreⁱ (resultStore inner))
+  final-seal =
+    subst (SealModeStore★ μ′)
+      (sym (sourceStoreResult inner)) seal★′
+
+  final-cast :
+    μ′ ∣ resultLeftCtx inner
+      ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner) c
+        ∶ applyTys (sourceChanges inner) (`∀ _)
+          ⊒ applyTys (sourceChanges inner) (`∀ B)
+  final-cast =
+    subst
+      (λ Δ → μ′ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) c
+          ∶ applyTys (sourceChanges inner) (`∀ _)
+            ⊒ applyTys (sourceChanges inner) (`∀ B))
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μ′ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+          ⊢ applyCoercions (sourceChanges inner) c
+            ∶ applyTys (sourceChanges inner) (`∀ _)
+              ⊒ applyTys (sourceChanges inner) (`∀ B))
+        (sym (sourceStoreResult inner)) c′⊒)
+
+  final-relation =
+    cast⊒⊑ᵀ mode′ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-source-cast-frameᵀ inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-all-prefix-source-narrow-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ₀) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ₀ ⊢ c ∶ `∀ A ⊒ `∀ B →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ⁺} r
+left-catchup-indexed-all-prefix-source-narrow-castᵀ
+    prefix mode seal★ c⊒ catchup =
+  left-catchup-indexed-all-source-narrow-castᵀ mode
+    (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+    (narrow-weaken ≤-refl
+      (leftStoreⁱ-prefix-inclusion prefix) c⊒)
+    catchup
+
+left-catchup-indexed-all-source-widen-cast-inertᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ `∀ A ⊑ `∀ B →
+  C.Inert c →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-widen-cast-inertᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ inert
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    with apply-widens-typing
+      { χs = sourceChanges (weakIndexedResult indexed) }
+      mode seal★ c⊑
+left-catchup-indexed-all-source-widen-cast-inertᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ inert
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  left-catchup-indexed-all-source-inert-frameᵀ
+    (applyCoercions-preserves-Inert (sourceChanges inner) inert)
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    framed refl
+      (weak-one-step-source-cast-frame-silentᵀ
+        inner final-relation (silentInvariant invariant))
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  final-seal :
+    SealModeStore★ μ′ (leftStoreⁱ (resultStore inner))
+  final-seal =
+    subst (SealModeStore★ μ′)
+      (sym (sourceStoreResult inner)) seal★′
+
+  final-cast :
+    μ′ ∣ resultLeftCtx inner
+      ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner) c
+        ∶ applyTys (sourceChanges inner) (`∀ _)
+          ⊑ applyTys (sourceChanges inner) (`∀ B)
+  final-cast =
+    subst
+      (λ Δ → μ′ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) c
+          ∶ applyTys (sourceChanges inner) (`∀ _)
+            ⊑ applyTys (sourceChanges inner) (`∀ B))
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μ′ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+          ⊢ applyCoercions (sourceChanges inner) c
+            ∶ applyTys (sourceChanges inner) (`∀ _)
+              ⊑ applyTys (sourceChanges inner) (`∀ B))
+        (sym (sourceStoreResult inner)) c′⊑)
+
+  final-relation =
+    cast⊑⊑ᵀ mode′ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-source-cast-frameᵀ inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-all-source-widen-cast-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ `∀ A ⊑ `∀ B →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  sourceResult (weakIndexedResult (catchupIndexedResult catchup))
+    ≡ blame →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-widen-cast-blameᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    eq-blame
+    with apply-widens-typing
+      { χs = sourceChanges (weakIndexedResult indexed) }
+      mode seal★ c⊑
+left-catchup-indexed-all-source-widen-cast-blameᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    eq-blame
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  left-catchup-indexed-all-source-cast-blame-frameᵀ
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    framed refl
+      (weak-one-step-source-cast-frame-silentᵀ
+        inner final-relation (silentInvariant invariant))
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+    eq-blame
+  where
+  inner = weakIndexedResult indexed
+
+  final-seal :
+    SealModeStore★ μ′ (leftStoreⁱ (resultStore inner))
+  final-seal =
+    subst (SealModeStore★ μ′)
+      (sym (sourceStoreResult inner)) seal★′
+
+  final-cast :
+    μ′ ∣ resultLeftCtx inner
+      ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner) c
+        ∶ applyTys (sourceChanges inner) (`∀ _)
+          ⊑ applyTys (sourceChanges inner) (`∀ B)
+  final-cast =
+    subst
+      (λ Δ → μ′ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner) c
+          ∶ applyTys (sourceChanges inner) (`∀ _)
+            ⊑ applyTys (sourceChanges inner) (`∀ B))
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μ′ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+          ⊢ applyCoercions (sourceChanges inner) c
+            ∶ applyTys (sourceChanges inner) (`∀ _)
+              ⊑ applyTys (sourceChanges inner) (`∀ B))
+        (sym (sourceStoreResult inner)) c′⊑)
+
+  final-relation =
+    cast⊑⊑ᵀ mode′ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-source-cast-frameᵀ inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-all-prefix-source-widen-cast-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ₀) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ₀ ⊢ c ∶ `∀ A ⊑ `∀ B →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  sourceResult (weakIndexedResult (catchupIndexedResult catchup))
+    ≡ blame →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ⁺} r
+left-catchup-indexed-all-prefix-source-widen-cast-blameᵀ
+    prefix mode seal★ c⊑ catchup eq-blame =
+  left-catchup-indexed-all-source-widen-cast-blameᵀ mode
+    (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+    (widen-weaken ≤-refl
+      (leftStoreⁱ-prefix-inclusion prefix) c⊑)
+    catchup eq-blame
+
+left-catchup-indexed-all-source-widen-cast-shapeᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c⊑ : μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ c ∶ `∀ A ⊑ `∀ B) →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  LeftCatchupIndexedAllResult
+      {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
+    ⊎ ∃[ s ] c ≡ inst (`∀ B) s
+left-catchup-indexed-all-source-widen-cast-shapeᵀ
+    mode seal★ c⊑ catchup
+    with widen-all-to-all-shape c⊑
+left-catchup-indexed-all-source-widen-cast-shapeᵀ
+    mode seal★ c⊑ catchup | inj₁ inert =
+  inj₁ (left-catchup-indexed-all-source-widen-cast-inertᵀ
+    mode seal★ c⊑ inert catchup)
+left-catchup-indexed-all-source-widen-cast-shapeᵀ
+    mode seal★ c⊑ catchup | inj₂ shape =
+  inj₂ shape
+
+left-catchup-indexed-all-prefix-source-widen-cast-shapeᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ₀) →
+  (c⊑ : μ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ c ∶ `∀ A ⊑ `∀ B) →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedAllResult
+      {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ⁺} r
+    ⊎ ∃[ s ] c ≡ inst (`∀ B) s
+left-catchup-indexed-all-prefix-source-widen-cast-shapeᵀ
+    prefix mode seal★ c⊑ catchup
+    with widen-all-to-all-shape c⊑
+left-catchup-indexed-all-prefix-source-widen-cast-shapeᵀ
+    prefix mode seal★ c⊑ catchup | inj₁ inert =
+  inj₁ (left-catchup-indexed-all-source-widen-cast-inertᵀ
+    mode
+    (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+    (widen-weaken ≤-refl
+      (leftStoreⁱ-prefix-inclusion prefix) c⊑)
+    inert catchup)
+left-catchup-indexed-all-prefix-source-widen-cast-shapeᵀ
+    prefix mode seal★ c⊑ catchup | inj₂ shape =
+  inj₂ shape
+
+left-silent-indexed-all-source-widen-inst-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ s}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ inst (`∀ B) s ∶ `∀ A ⊑ `∀ B →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  let inner = weakIndexedResult (catchupIndexedResult catchup) in
+  Value (sourceResult inner) →
+  No• (sourceResult inner) →
+  LeftSilentIndexedResult
+    {N = M ⟨ inst (`∀ B) s ⟩} {V′ = V′} {ρ = ρ} (∀ⁱ r)
+left-silent-indexed-all-source-widen-inst-valueᵀ
+    {Δᴸ = Δᴸ} {B = B} {s = s} mode seal★
+    (C.cast-inst hB occ s⊢ , NW.inst sʷ)
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    vW noW
+    with apply-widens-typing
+      { χs = sourceChanges (weakIndexedResult indexed) }
+      mode seal★ (C.cast-inst hB occ s⊢ , NW.inst sʷ)
+left-silent-indexed-all-source-widen-inst-valueᵀ
+    {Δᴸ = Δᴸ} {B = B} {s = s} mode seal★
+    (C.cast-inst hB occ s⊢ , NW.inst sʷ)
+    (left-indexed-catchup indexed
+      (left-catchup-invariant
+        (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    vW noW
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  left-silent-indexed
+    (weak-one-step-index-resultᵀ combined type-eq)
+    (left-silent-invariant refl refl)
+    (ok-ν (ok-no noW))
+    combined-transport combined-coherence
+  where
+  inner = weakIndexedResult indexed
+
+  final-seal :
+    SealModeStore★ μ′ (leftStoreⁱ (resultStore inner))
+  final-seal =
+    subst (SealModeStore★ μ′)
+      (sym (sourceStoreResult inner)) seal★′
+
+  final-cast :
+    μ′ ∣ resultLeftCtx inner
+      ∣ leftStoreⁱ (resultStore inner)
+      ⊢ applyCoercions (sourceChanges inner)
+          (inst (`∀ B) s)
+        ∶ applyTys (sourceChanges inner) (`∀ _)
+          ⊑ applyTys (sourceChanges inner) (`∀ B)
+  final-cast =
+    subst
+      (λ Δ → μ′ ∣ Δ ∣ leftStoreⁱ (resultStore inner)
+        ⊢ applyCoercions (sourceChanges inner)
+            (inst (`∀ B) s)
+          ∶ applyTys (sourceChanges inner) (`∀ _)
+            ⊑ applyTys (sourceChanges inner) (`∀ B))
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → μ′ ∣ applyTyCtxs (sourceChanges inner) Δᴸ ∣ Σ
+          ⊢ applyCoercions (sourceChanges inner)
+              (inst (`∀ B) s)
+            ∶ applyTys (sourceChanges inner) (`∀ _)
+              ⊑ applyTys (sourceChanges inner) (`∀ B))
+        (sym (sourceStoreResult inner)) c′⊑)
+
+  final-relation =
+    cast⊑⊑ᵀ mode′ final-seal final-cast
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-source-cast-frameᵀ inner final-relation
+
+  first-silent = weak-one-step-source-cast-frame-silentᵀ
+    inner final-relation (left-silent-invariant refl refl)
+
+  ν-framed = weak-one-step-source-νcast-frameᵀ
+    mode (seal★-inst seal★) (s⊢ , sʷ) (∀ⁱ _) inner
+
+  second-relation :
+    resultCtx first
+      ∣ resultLeftCtx first
+      ∣ resultRightCtx first
+      ∣ resultStore first ∣ []
+      ⊢ᴺ sourceResult ν-framed ⊑ targetResult first
+      ⦂ resultSourceType first ⊑ resultTargetType first
+      ∶ resultType first
+  second-relation = relatedResults ν-framed
+
+  second = weak-one-step-keep-source-catchupᵀ
+    {Φ = resultCtx first}
+    {Δᴸ = resultLeftCtx first}
+    {Δᴿ = resultRightCtx first}
+    {A = resultSourceType first}
+    {B = resultTargetType first}
+    {p = resultType first}
+    {ρ = resultStore first}
+    (post-catchup-β-inst (sourceChanges inner) vW)
+    second-relation
+
+  combined = weak-one-step-prepend-left-silentᵀ
+    (left-silent first first-silent) second
+
+  type-eq = HE.≅-to-≡
+    (HE.trans
+      (subst²-to-≅
+        {P = λ S T → resultCtx combined ∣ resultLeftCtx combined
+          ⊢ S ⊑ T ⊣ resultRightCtx combined}
+        (sourceTypeResult combined)
+        (targetTypeResult combined)
+        (resultType combined))
+      (HE.sym (weak-one-step-compose-type-to-nested≅
+        first second (∀ⁱ _))))
+
+  first-transport = weak-one-step-source-cast-frame-transportᵀ
+    inner final-relation inner-transport
+
+  first-coherence = weak-one-step-source-cast-frame-coherenceᵀ
+    inner final-relation inner-coherence
+
+  combined-transport =
+    weak-one-step-prepend-left-silent-preserves-transportᵀ
+      (left-silent first first-silent) second
+      first-transport
+      (weak-one-step-keep-source-catchup-transportᵀ
+        (post-catchup-β-inst (sourceChanges inner) vW)
+        second-relation)
+
+  combined-coherence =
+    weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+      (left-silent first first-silent) second
+      first-coherence
+      (weak-one-step-keep-source-catchup-type-coherenceᵀ
+        (post-catchup-β-inst (sourceChanges inner) vW)
+        second-relation)
+
+left-silent-indexed-all-prefix-source-widen-inst-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ s}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ₀) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ inst (`∀ B) s ∶ `∀ A ⊑ `∀ B →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  let inner = weakIndexedResult (catchupIndexedResult catchup) in
+  Value (sourceResult inner) →
+  No• (sourceResult inner) →
+  LeftSilentIndexedResult
+    {N = M ⟨ inst (`∀ B) s ⟩} {V′ = V′} {ρ = ρ⁺} (∀ⁱ r)
+left-silent-indexed-all-prefix-source-widen-inst-valueᵀ
+    prefix mode seal★ c⊑ catchup vW noW =
+  left-silent-indexed-all-source-widen-inst-valueᵀ mode
+    (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+    (widen-weaken ≤-refl
+      (leftStoreⁱ-prefix-inclusion prefix) c⊑)
+    catchup vW noW
+
+left-catchup-indexed-all-source-widen-cast-progressᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  (c⊑ : μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ c ∶ `∀ A ⊑ `∀ B) →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  LeftCatchupIndexedProgress
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} (∀ⁱ r)
+left-catchup-indexed-all-source-widen-cast-progressᵀ
+    mode seal★ c⊑
+    (left-indexed-catchup indexed
+      (left-catchup-invariant (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    with final
+left-catchup-indexed-all-source-widen-cast-progressᵀ
+    mode seal★ c⊑
+    (left-indexed-catchup indexed
+      (left-catchup-invariant (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₁ (vW , noW)
+    with widen-all-to-all-shape c⊑
+left-catchup-indexed-all-source-widen-cast-progressᵀ
+    mode seal★ c⊑
+    (left-indexed-catchup indexed
+      (left-catchup-invariant (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₁ (vW , noW) | inj₁ inert =
+  left-progress-done
+    (generalize-left-indexed-all-catchup
+      (left-catchup-indexed-all-source-widen-cast-inertᵀ
+        mode seal★ c⊑ inert
+        (left-indexed-catchup indexed
+          (left-catchup-invariant (left-silent-invariant refl refl) final)
+          inner-transport inner-coherence)))
+left-catchup-indexed-all-source-widen-cast-progressᵀ
+    mode seal★ c⊑
+    (left-indexed-catchup indexed
+      (left-catchup-invariant (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₁ (vW , noW) | inj₂ (s , refl) =
+  left-progress-continue
+    (left-silent-indexed-all-source-widen-inst-valueᵀ
+      mode seal★ c⊑
+      (left-indexed-catchup indexed
+        (left-catchup-invariant (left-silent-invariant refl refl) final)
+        inner-transport inner-coherence)
+      vW noW)
+left-catchup-indexed-all-source-widen-cast-progressᵀ
+    mode seal★ c⊑
+    (left-indexed-catchup indexed
+      (left-catchup-invariant (left-silent-invariant refl refl) final)
+      inner-transport inner-coherence)
+    | inj₂ eq-blame =
+  left-progress-done
+    (generalize-left-indexed-all-catchup
+      (left-catchup-indexed-all-source-widen-cast-blameᵀ
+        mode seal★ c⊑
+        (left-indexed-catchup indexed
+          (left-catchup-invariant (left-silent-invariant refl refl) final)
+          inner-transport inner-coherence)
+        eq-blame))
+
+left-catchup-indexed-all-prefix-source-widen-cast-progressᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  CastMode μ →
+  SealModeStore★ μ (leftStoreⁱ ρ₀) →
+  (c⊑ : μ ∣ Δᴸ ∣ leftStoreⁱ ρ₀
+    ⊢ c ∶ `∀ A ⊑ `∀ B) →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p) →
+  LeftCatchupIndexedProgress
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ⁺} (∀ⁱ r)
+left-catchup-indexed-all-prefix-source-widen-cast-progressᵀ
+    prefix mode seal★ c⊑ catchup =
+  left-catchup-indexed-all-source-widen-cast-progressᵀ mode
+    (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+    (widen-weaken ≤-refl
+      (leftStoreⁱ-prefix-inclusion prefix) c⊑)
+    catchup
+
+left-catchup-indexed-all-source-reveal-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ α X c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    c (`∀ A) (`∀ B) →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-reveal-castᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} c↑
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    with apply-reveal-conversions
+      { χs = sourceChanges (weakIndexedResult indexed) } c↑
+left-catchup-indexed-all-source-reveal-castᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} c↑
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    | μ′ , α′ , X′ , c′↑ =
+  left-catchup-indexed-all-source-inert-frameᵀ
+    (applyCoercions-preserves-Inert (sourceChanges inner)
+      (reveal-all-to-all-inert c↑))
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    framed refl
+      (weak-one-step-source-cast-frame-silentᵀ
+        inner final-relation (silentInvariant invariant))
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  final-conversion :
+    RevealConversion μ′ (resultLeftCtx inner)
+      (leftStoreⁱ (resultStore inner)) α′ X′
+      (applyCoercions (sourceChanges inner) c)
+      (applyTys (sourceChanges inner) (`∀ _))
+      (applyTys (sourceChanges inner) (`∀ B))
+  final-conversion =
+    subst
+      (λ Δ → RevealConversion μ′ Δ
+        (leftStoreⁱ (resultStore inner)) α′ X′
+        (applyCoercions (sourceChanges inner) c)
+        (applyTys (sourceChanges inner) (`∀ _))
+        (applyTys (sourceChanges inner) (`∀ B)))
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → RevealConversion μ′
+          (applyTyCtxs (sourceChanges inner) Δᴸ) Σ α′ X′
+          (applyCoercions (sourceChanges inner) c)
+          (applyTys (sourceChanges inner) (`∀ _))
+          (applyTys (sourceChanges inner) (`∀ B)))
+        (sym (sourceStoreResult inner)) c′↑)
+
+  final-relation =
+    conv↑⊑ᵀ final-conversion
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-source-cast-frameᵀ inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-all-prefix-source-reveal-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ α X c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ₀) α X
+    c (`∀ A) (`∀ B) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ⁺} r
+left-catchup-indexed-all-prefix-source-reveal-castᵀ
+    prefix c↑ catchup =
+  left-catchup-indexed-all-source-reveal-castᵀ
+    (weaken-reveal-conversion
+      (leftStoreⁱ-prefix-inclusion prefix) c↑)
+    catchup
+
+left-catchup-indexed-all-source-conceal-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ α X c}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    c (`∀ A) (`∀ B) →
+  (catchup : LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ} p) →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
+left-catchup-indexed-all-source-conceal-castᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} c↓
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    with apply-conceal-conversions
+      { χs = sourceChanges (weakIndexedResult indexed) } c↓
+left-catchup-indexed-all-source-conceal-castᵀ
+    {Δᴸ = Δᴸ} {B = B} {c = c} c↓
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    | μ′ , α′ , X′ , c′↓ =
+  left-catchup-indexed-all-source-inert-frameᵀ
+    (applyCoercions-preserves-Inert (sourceChanges inner)
+      (conceal-all-to-all-inert c↓))
+    (left-indexed-catchup indexed invariant
+      inner-transport inner-coherence)
+    framed refl
+      (weak-one-step-source-cast-frame-silentᵀ
+        inner final-relation (silentInvariant invariant))
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation inner-transport)
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation inner-coherence)
+  where
+  inner = weakIndexedResult indexed
+
+  final-conversion :
+    ConcealConversion μ′ (resultLeftCtx inner)
+      (leftStoreⁱ (resultStore inner)) α′ X′
+      (applyCoercions (sourceChanges inner) c)
+      (applyTys (sourceChanges inner) (`∀ _))
+      (applyTys (sourceChanges inner) (`∀ B))
+  final-conversion =
+    subst
+      (λ Δ → ConcealConversion μ′ Δ
+        (leftStoreⁱ (resultStore inner)) α′ X′
+        (applyCoercions (sourceChanges inner) c)
+        (applyTys (sourceChanges inner) (`∀ _))
+        (applyTys (sourceChanges inner) (`∀ B)))
+      (sym (sourceCtxResult inner))
+      (subst
+        (λ Σ → ConcealConversion μ′
+          (applyTyCtxs (sourceChanges inner) Δᴸ) Σ α′ X′
+          (applyCoercions (sourceChanges inner) c)
+          (applyTys (sourceChanges inner) (`∀ _))
+          (applyTys (sourceChanges inner) (`∀ B)))
+        (sym (sourceStoreResult inner)) c′↓)
+
+  final-relation =
+    conv↓⊑ᵀ final-conversion
+      (canonicalIndexedResults indexed) (transportType inner _)
+
+  first = weak-one-step-source-cast-frameᵀ inner final-relation
+
+  framed = weak-indexed-result first (relatedResults first)
+
+left-catchup-indexed-all-prefix-source-conceal-castᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ α X c}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ A ⊑ `∀ A′ ⊣ Δᴿ}
+    {r : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ B ⊑ A′ ⊣ suc Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ₀) α X
+    c (`∀ A) (`∀ B) →
+  LeftCatchupIndexedResult
+    {N = M} {V′ = V′} {ρ = ρ⁺} p →
+  LeftCatchupIndexedAllResult
+    {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ⁺} r
+left-catchup-indexed-all-prefix-source-conceal-castᵀ
+    prefix c↓ catchup =
+  left-catchup-indexed-all-source-conceal-castᵀ
+    (weaken-conceal-conversion
+      (leftStoreⁱ-prefix-inclusion prefix) c↓)
+    catchup
+
 left-catchup-all-post-allocation-β-Λ•ᵀ :
   ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
     {ρ : StoreImp Φ Δᴸ Δᴿ} →
@@ -9013,6 +6153,46 @@ left-catchup-all-post-allocation-β-Λ•ᵀ :
 left-catchup-all-post-allocation-β-Λ•ᵀ vV noV V⊑V′ =
   left-catchup-all-keep-stepᵀ
     (post-allocation-β-Λ•-bare vV) (inj₁ (vV , noV)) V⊑V′
+
+left-catchup-indexed-all-post-allocation-β-Λ•ᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  No• V →
+  (V⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (Λ V)) •} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-all-post-allocation-β-Λ•ᵀ
+    vV noV V⊑V′ =
+  left-catchup-indexed-all-keep-stepᵀ
+    (post-allocation-β-Λ•-bare vV) (inj₁ (vV , noV)) V⊑V′
+
+left-catchup-indexed-all-prefix-post-allocation-β-Λ•ᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (vV : Value V) →
+  (noV : No• V) →
+  (noV′ : No• V′) →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (V⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (Λ V)) •} {V′ = V′} {ρ = ρ⁺} q
+left-catchup-indexed-all-prefix-post-allocation-β-Λ•ᵀ
+    vV noV noV′ prefix V⊑V′ =
+  left-catchup-indexed-all-prefix-prepend-keepᵀ
+    prefix (post-allocation-β-Λ•-bare vV) V⊑V′
+    V⊢ V′⊢
+    (left-catchup-indexed-all-prefix-relatedᵀ
+      prefix (inj₁ (vV , noV)) V⊑V′ V⊢ V′⊢)
+  where
+  V⊢ = term-weaken ≤-refl
+    (leftStoreⁱ-prefix-inclusion prefix) noV
+    (nu-term-imprecision-source-typing V⊑V′)
+  V′⊢ = term-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) noV′
+    (nu-term-imprecision-target-typing V⊑V′)
 
 left-catchup-all-α-Λᵀ :
   ∀ {Φ Δᴸ Δᴿ A W V′ C C′ q}
@@ -9039,7 +6219,7 @@ left-catchup-all-α-Λᵀ
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
   where
     allocated-body =
-      allocation-leftᵀ h⇑A liftρᵇ W⊑V′
+      allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
         (term-weaken {Δ = suc _} {Δ′ = suc _}
           {Σ = leftStoreⁱ ρᵇ}
           {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
@@ -9079,6 +6259,241 @@ left-catchup-all-α-Λᵀ
               (sym (rightStoreⁱ-lift-left liftρᵃ))
         ; relatedResults = allocated-body
         }
+
+left-catchup-indexed-all-α-Λᵀ :
+  ∀ {Φ Δᴸ Δᴿ A W V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  Value W →
+  No• W →
+  No• V′ →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  (liftρᵃ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵃ) →
+  (liftρᵇ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵇ) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+    ⊢ᴺ W ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (Λ W)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ A) h⇑A ∷ ρᵃ} q
+left-catchup-indexed-all-α-Λᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {W = W} {V′ = V′}
+    {C = C} {C′ = C′} {q = q} {ρ = ρ} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ}
+    vW noW noV′ h⇑A liftρᵃ liftρᵇ W⊑V′ =
+  left-indexed-all-catchup
+    (weak-one-step-index-resultᵀ result refl)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₁ (vW , noW)))
+    (weak-step-transport
+      (paired-left-lift-prefix-bodyᵀ
+        liftρᵃ liftρᵃ))
+    (weak-step-type-coherence
+      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
+  where
+  allocated-body =
+    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+      (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρᵇ}
+        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
+        {Γ = []} ≤-refl StoreIncl-drop noW
+        (nu-term-imprecision-source-typing W⊑V′))
+      (nu-term-imprecision-target-typing W⊑V′)
+
+  canonical-body =
+    paired-left-lift-prefix-bodyᵀ
+      liftρᵃ liftρᵇ noW noV′ allocated-body
+
+  result =
+    record
+      { sourceChanges = keep ∷ []
+      ; targetTailChanges = []
+      ; sourceResult = W
+      ; targetResult = V′
+      ; resultCtx = (zero ˣ⊑★) ∷ ⇑ᴸᵢ _
+      ; resultLeftCtx = _
+      ; resultRightCtx = _
+      ; sourceCtxResult = refl
+      ; targetCtxResult = refl
+      ; resultStore = store-left zero (⇑ᵗ A) h⇑A ∷ _
+      ; resultSourceType = `∀ _
+      ; resultTargetType = `∀ _
+      ; sourceTypeResult = refl
+      ; targetTypeResult = refl
+      ; transportType = ⊑-rename-idᵢ
+      ; transportAllBody = ⊑-rename-id-all-bodyᵢ
+      ; transportRightBody = ⊑-rename-idᵢ
+      ; resultType = ⊑-rename-idᵢ (∀ⁱ q)
+      ; sourceCatchup =
+          ↠-step (post-allocation-β-Λ•-bare vW) ↠-refl
+      ; targetTail = ↠-refl
+      ; sourceStoreResult = refl
+      ; targetStoreResult = refl
+      ; relatedResults = canonical-body
+      }
+
+left-catchup-indexed-prefix-α-Λᵀ :
+  ∀ {Φ Δᴸ Δᴿ Aν W V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ}
+    {ρ⁺ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  Value W →
+  No• W →
+  No• V′ →
+  (h⇑Aν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (liftρᵃ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵃ) →
+  (liftρᵇ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵇ) →
+  (prefix : StoreImpPrefix
+    (store-left zero (⇑ᵗ Aν) h⇑Aν ∷ ρᵃ) ρ⁺) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+    ⊢ᴺ W ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupIndexedResult
+    {N = (⇑ᵗᵐ (Λ W)) •} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-prefix-α-Λᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Aν = Aν} {W = W} {V′ = V′}
+    {A = A} {B = B} {p = p} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ} {ρ⁺ = ρ⁺}
+    vW noW noV′ h⇑Aν liftρᵃ liftρᵇ prefix W⊑V′ =
+  left-indexed-catchup
+    (weak-one-step-index-resultᵀ result refl)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₁ (vW , noW)))
+    (weak-step-transport identity-bodyᵀ)
+    (weak-step-type-coherence
+      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
+  where
+  allocated-body =
+    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+      (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρᵇ}
+        {Σ′ = (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρᵇ}
+        {Γ = []} ≤-refl StoreIncl-drop noW
+        (nu-term-imprecision-source-typing W⊑V′))
+      (nu-term-imprecision-target-typing W⊑V′)
+
+  canonical-body =
+    paired-left-lift-prefix-bodyᵀ
+      liftρᵃ liftρᵇ noW noV′ allocated-body
+
+  prefixed-body =
+    allocation-prefixᵀ prefix canonical-body
+      (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
+        noW (nu-term-imprecision-source-typing canonical-body))
+      (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
+        noV′ (nu-term-imprecision-target-typing canonical-body))
+
+  result =
+    record
+      { sourceChanges = keep ∷ []
+      ; targetTailChanges = []
+      ; sourceResult = W
+      ; targetResult = V′
+      ; resultCtx = (zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ
+      ; resultLeftCtx = suc Δᴸ
+      ; resultRightCtx = _
+      ; sourceCtxResult = refl
+      ; targetCtxResult = refl
+      ; resultStore = ρ⁺
+      ; resultSourceType = A
+      ; resultTargetType = B
+      ; sourceTypeResult = refl
+      ; targetTypeResult = refl
+      ; transportType = ⊑-rename-idᵢ
+      ; transportAllBody = ⊑-rename-id-all-bodyᵢ
+      ; transportRightBody = ⊑-rename-idᵢ
+      ; resultType = ⊑-rename-idᵢ p
+      ; sourceCatchup =
+          ↠-step (post-allocation-β-Λ•-bare vW) ↠-refl
+      ; targetTail = ↠-refl
+      ; sourceStoreResult = refl
+      ; targetStoreResult = refl
+      ; relatedResults = prefixed-body
+      }
+
+left-catchup-indexed-all-prefix-α-Λᵀ :
+  ∀ {Φ Δᴸ Δᴿ A W V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᵃ ρᵇ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ}
+    {ρ⁺ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  Value W →
+  No• W →
+  No• V′ →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  (liftρᵃ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵃ) →
+  (liftρᵇ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᵇ) →
+  (prefix : StoreImpPrefix
+    (store-left zero (⇑ᵗ A) h⇑A ∷ ρᵃ) ρ⁺) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+    ⊢ᴺ W ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (Λ W)) •} {V′ = V′} {ρ = ρ⁺} q
+left-catchup-indexed-all-prefix-α-Λᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {A = A} {W = W} {V′ = V′}
+    {q = q} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ} {ρ⁺ = ρ⁺}
+    vW noW noV′ h⇑A liftρᵃ liftρᵇ prefix W⊑V′ =
+  left-indexed-all-catchup
+    (weak-one-step-index-resultᵀ result refl)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) (inj₁ (vW , noW)))
+    (weak-step-transport identity-bodyᵀ)
+    (weak-step-type-coherence
+      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
+  where
+  allocated-body =
+    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+      (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
+        {Σ = leftStoreⁱ ρᵇ}
+        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
+        {Γ = []} ≤-refl StoreIncl-drop noW
+        (nu-term-imprecision-source-typing W⊑V′))
+      (nu-term-imprecision-target-typing W⊑V′)
+
+  canonical-body =
+    paired-left-lift-prefix-bodyᵀ
+      liftρᵃ liftρᵇ noW noV′ allocated-body
+
+  prefixed-body =
+    allocation-prefixᵀ prefix canonical-body
+      (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
+        noW (nu-term-imprecision-source-typing canonical-body))
+      (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
+        noV′ (nu-term-imprecision-target-typing canonical-body))
+
+  result =
+    record
+      { sourceChanges = keep ∷ []
+      ; targetTailChanges = []
+      ; sourceResult = W
+      ; targetResult = V′
+      ; resultCtx = (zero ˣ⊑★) ∷ ⇑ᴸᵢ _
+      ; resultLeftCtx = _
+      ; resultRightCtx = _
+      ; sourceCtxResult = refl
+      ; targetCtxResult = refl
+      ; resultStore = ρ⁺
+      ; resultSourceType = `∀ _
+      ; resultTargetType = `∀ _
+      ; sourceTypeResult = refl
+      ; targetTypeResult = refl
+      ; transportType = ⊑-rename-idᵢ
+      ; transportAllBody = ⊑-rename-id-all-bodyᵢ
+      ; transportRightBody = ⊑-rename-idᵢ
+      ; resultType = ⊑-rename-idᵢ (∀ⁱ q)
+      ; sourceCatchup =
+          ↠-step (post-allocation-β-Λ•-bare vW) ↠-refl
+      ; targetTail = ↠-refl
+      ; sourceStoreResult = refl
+      ; targetStoreResult = refl
+      ; relatedResults = prefixed-body
+      }
 
 left-allocated-bulletᵀ :
   ∀ {Φ Δᴸ Δᴿ Aν A B′ V V′ occ r}
@@ -9175,6 +6590,70 @@ left-catchup-all-α-∀-concealᵀ
     post-relation =
       conv↓⊑ᵀ (open-allocated-left-all-conceal liftρ c↓)
         bullet-relation (∀ⁱ q)
+
+left-catchup-indexed-all-α-∀-revealᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ α X Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    (`∀ c) (`∀ A) (`∀ (`∀ C)) →
+  LeftCatchupIndexedAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-indexed-all-α-∀-revealᵀ
+    {V = V} {q = q}
+    vV noV hAν liftρ V⊑V′ c↑ catchup =
+  left-catchup-indexed-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+  bullet-relation =
+    left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+  post-relation =
+    conv↑⊑ᵀ (open-allocated-left-all-reveal liftρ c↑)
+      bullet-relation (∀ⁱ q)
+
+left-catchup-indexed-all-α-∀-concealᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ α X Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X
+    (`∀ c) (`∀ A) (`∀ (`∀ C)) →
+  LeftCatchupIndexedAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-indexed-all-α-∀-concealᵀ
+    {V = V} {q = q}
+    vV noV hAν liftρ V⊑V′ c↓ catchup =
+  left-catchup-indexed-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+  bullet-relation =
+    left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+  post-relation =
+    conv↓⊑ᵀ (open-allocated-left-all-conceal liftρ c↓)
+      bullet-relation (∀ⁱ q)
 
 left-catchup-all-α-∀-narrowingᵀ :
   ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ occ r q}
@@ -9320,6 +6799,151 @@ left-catchup-all-α-gen-narrowingᵀ
       cast⊒⊑ᵀ (cast-gen mode)
         (allocated-left-gen-seal★ liftρ seal★)
         body-narrowing body-relation (∀ⁱ q)
+
+left-catchup-indexed-all-α-∀-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊒ `∀ (`∀ C) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  LeftCatchupIndexedAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-indexed-all-α-∀-narrowingᵀ
+    {Δᴸ = Δᴸ} {μ = μ} {Aν = Aν} {A = A} {C = C}
+    {c = c} {V = V} {q = q} {ρ′ = ρ′}
+    vV noV hAν mode seal★ liftρ c∀⊒ V⊑V′ catchup =
+  left-catchup-indexed-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+  bullet-relation =
+    left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+  body-narrowing :
+    extᵈ μ ∣ suc Δᴸ ∣
+      (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρ′
+      ⊢ c ∶ A ⊒ `∀ C
+  body-narrowing =
+    subst
+      (λ Σ → extᵈ μ ∣ suc Δᴸ ∣ Σ
+        ⊢ c ∶ A ⊒ `∀ C)
+      (cong ((zero , ⇑ᵗ Aν) ∷_)
+        (sym (leftStoreⁱ-lift-left liftρ)))
+      (allocate-all-narrowing c∀⊒)
+
+  post-relation =
+    cast⊒⊑ᵀ (cast-ext mode)
+      (allocated-left-seal★ liftρ seal★)
+      body-narrowing bullet-relation (∀ⁱ q)
+
+left-catchup-indexed-all-α-∀-wideningᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ occ r q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ `∀ c ∶ `∀ A ⊑ `∀ (`∀ C) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ A ⊑ `∀ C′ ∶ ν occ r →
+  LeftCatchupIndexedAllResult
+    {N = ((⇑ᵗᵐ V) •) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (V ⟨ `∀ c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-indexed-all-α-∀-wideningᵀ
+    {Δᴸ = Δᴸ} {μ = μ} {Aν = Aν} {A = A} {C = C}
+    {c = c} {V = V} {q = q} {ρ′ = ρ′}
+    vV noV hAν mode seal★ liftρ c∀⊑ V⊑V′ catchup =
+  left-catchup-indexed-all-prepend-keepᵀ
+    (post-allocation-β-∀•-bare vV) post-relation catchup
+  where
+  bullet-relation =
+    left-allocated-bulletᵀ vV noV hAν liftρ V⊑V′
+
+  body-widening :
+    extᵈ μ ∣ suc Δᴸ ∣
+      (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρ′
+      ⊢ c ∶ A ⊑ `∀ C
+  body-widening =
+    subst
+      (λ Σ → extᵈ μ ∣ suc Δᴸ ∣ Σ
+        ⊢ c ∶ A ⊑ `∀ C)
+      (cong ((zero , ⇑ᵗ Aν) ∷_)
+        (sym (leftStoreⁱ-lift-left liftρ)))
+      (allocate-all-widening c∀⊑)
+
+  post-relation =
+    cast⊑⊑ᵀ (cast-ext mode)
+      (allocated-left-seal★ liftρ seal★)
+      body-widening bullet-relation (∀ⁱ q)
+
+left-catchup-indexed-all-α-gen-narrowingᵀ :
+  ∀ {Φ Δᴸ Δᴿ μ Aν A C C′ c V V′ p q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  Value V →
+  No• V →
+  (hAν : WfTy (suc Δᴸ) (⇑ᵗ Aν)) →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ μ (leftStoreⁱ ρ)) →
+  (liftρ : LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ
+    ⊢ gen A c ∶ A ⊒ `∀ (`∀ C) →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ []
+    ⊢ᴺ ⇑ᵗᵐ V ⊑ V′ ⦂ ⇑ᵗ A ⊑ `∀ C′ ∶ p →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ V) ⟨ c ⟩} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q →
+  LeftCatchupIndexedAllResult
+    {N = (⇑ᵗᵐ (V ⟨ gen A c ⟩)) •} {V′ = V′}
+    {ρ = store-left zero (⇑ᵗ Aν) hAν ∷ ρ′} q
+left-catchup-indexed-all-α-gen-narrowingᵀ
+    {Δᴸ = Δᴸ} {μ = μ} {Aν = Aν} {A = A} {C = C}
+    {c = c} {V = V} {q = q} {ρ′ = ρ′}
+    vV noV hAν mode seal★ liftρ cgen⊒ shifted-body catchup =
+  left-catchup-indexed-all-prepend-keepᵀ
+    (post-allocation-β-gen•-bare vV) post-relation catchup
+  where
+  body-narrowing :
+    genᵈ μ ∣ suc Δᴸ ∣
+      (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρ′
+      ⊢ c ∶ ⇑ᵗ A ⊒ `∀ C
+  body-narrowing =
+    subst
+      (λ Σ → genᵈ μ ∣ suc Δᴸ ∣ Σ
+        ⊢ c ∶ ⇑ᵗ A ⊒ `∀ C)
+      (cong ((zero , ⇑ᵗ Aν) ∷_)
+        (sym (leftStoreⁱ-lift-left liftρ)))
+      (allocate-gen-narrowing cgen⊒)
+
+  body-relation =
+    allocated-left-relationᵀ hAν liftρ
+      (renameᵗᵐ-preserves-No• suc noV) shifted-body
+
+  post-relation =
+    cast⊒⊑ᵀ (cast-gen mode)
+      (allocated-left-gen-seal★ liftρ seal★)
+      body-narrowing body-relation (∀ⁱ q)
 
 shifted-var-not-wf-at-zero :
   WfTy zero (＇ (suc zero)) → ⊥
@@ -9501,1263 +7125,3 @@ weak-one-step-generic-β-∀-right-outer-widening-wideningᵀ
     | source→ , _ , V•c⊑V′•
     | _ , _ , result =
   weak-one-step-keep-source-catchupᵀ source→ result
-
-------------------------------------------------------------------------
--- Synchronized polymorphic allocation
-------------------------------------------------------------------------
-
-matched-ν↑-allocation :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value N →
-  No• N →
-  Value N′ →
-  No• N′ →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  (ν A N s —→[ bind A ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
-  (ν A′ N′ s′ —→[ bind A′ ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
-  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
-    store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′) A⇑⊑A′⇑ ∷ ρ′
-    ∣ []
-    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
-    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
-matched-ν↑-allocation {q = q} vN noN vN′ noN′ s↑ s′↑ pB
-    A⇑⊑A′⇑ liftρ N⊑N′ =
-  ν-step vN noN ,
-  ν-step vN′ noN′ ,
-  conv⊑convᵀ
-    (paired-conversion
-      (paired-reveal (correspondence-stored (here refl))
-        left-reveal right-reveal))
-    (α⊑αᵀ vN noN vN′ noN′ A⇑⊑A′⇑ liftρ lift-ctx-[]
-      N⊑N′ left-bullet-typing right-bullet-typing)
-  where
-    left-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (leftStoreⁱ-lift liftρ))
-        s↑
-
-    right-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (rightStoreⁱ-lift liftρ))
-        s′↑
-
-    left-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (leftStoreⁱ-lift liftρ))
-        (⊢• refl refl (⊑-src-wf q) vN noN
-          (nu-term-imprecision-source-typing N⊑N′))
-
-    right-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (rightStoreⁱ-lift liftρ))
-        (⊢• refl refl (⊑-tgt-wf q) vN′ noN′
-          (nu-term-imprecision-target-typing N⊑N′))
-
-weak-one-step-matched-ν↑ᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value N →
-  No• N →
-  Value N′ →
-  No• N′ →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  WeakOneStepResult ρ
-    (ν A N s) (((⇑ᵗᵐ N′) •) ⟨ s′ ⟩)
-    B B′ (bind A′)
-weak-one-step-matched-ν↑ᵀ
-    {A = A} {A′ = A′} {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
-    with matched-ν↑-allocation vN noN vN′ noN′ s↑ s′↑
-      pB A⇑⊑A′⇑ liftρ N⊑N′
-weak-one-step-matched-ν↑ᵀ
-    {A = A} {A′ = A′} {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN noN vN′ noN′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ N⊑N′
-    | source→ , _ , result =
-  record
-    { sourceChanges = bind A ∷ []
-    ; targetTailChanges = []
-    ; sourceResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore =
-        store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′)
-          A⇑⊑A′⇑ ∷ ρ′
-    ; resultSourceType = ⇑ᵗ B
-    ; resultTargetType = ⇑ᵗ B′
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = ⊑-lift∀ᵢ
-    ; transportAllBody = ⊑-lift-under-∀ᵢ
-    ; transportRightBody = ⊑-lift-under-rightᵢ
-    ; resultType = ⊑-lift∀ᵢ pB
-    ; sourceCatchup = ↠-step source→ ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult =
-        cong ((zero , ⇑ᵗ A) ∷_) (leftStoreⁱ-lift liftρ)
-    ; targetStoreResult =
-        cong ((zero , ⇑ᵗ A′) ∷_) (rightStoreⁱ-lift liftρ)
-    ; relatedResults = result
-    }
-
-weak-one-step-matched-ν↑-value-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  Value V′ →
-  No• V′ →
-  (catchup :
-    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
-  Value (sourceResult (weakResult (catchupAllResult catchup))) →
-  No• (sourceResult (weakResult (catchupAllResult catchup))) →
-  WeakOneStepResult ρ
-    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind A′)
-weak-one-step-matched-ν↑-value-catchupᵀ
-    s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW
-    with lift-store-result (resultStore inner)
-weak-one-step-matched-ν↑-value-catchupᵀ
-    s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW | ρ′ , liftρ
-    with apply-reveal-under-ty-binders
-      {χs = sourceChanges inner} s↑
-       | apply-reveal-under-ty-binders
-      {χs = keep ∷ []} s′↑
-weak-one-step-matched-ν↑-value-catchupᵀ
-    s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW | ρ′ , liftρ₀ | μᵣ , source↑₀ | μᵗ , target↑₀
-    with weak-result-source-reveal inner s↑
-       | weak-result-target-reveal keep inner s′↑
-weak-one-step-matched-ν↑-value-catchupᵀ
-    s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW | ρ′ , liftρ₀ | μᵣ , source↑₀ | μᵗ , target↑₀
-    | μˢ , source↑ | μᵗ′ , target↑ =
-  weak-one-step-prepend-left-silentᵀ
-    (left-silent
-      (weak-one-step-matched-ν-frameᵀ
-        s↑ s′↑ pA pB (weak-all-result inner innerAll))
-      (left-silent-invariant refl refl))
-    (weak-one-step-matched-ν↑ᵀ
-      vW noW vV′ noV′ source↑ target↑
-      (transportType inner pB)
-      (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
-
-weak-one-step-matched-ν↑-blame-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  StoreWf Δᴿ (rightStoreⁱ ρ) →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  Value V′ →
-  No• V′ →
-  (catchup :
-    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
-  sourceResult (weakResult (catchupAllResult catchup)) ≡ blame →
-  WeakOneStepResult ρ
-    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind A′)
-weak-one-step-matched-ν↑-blame-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl
-    with silent
-weak-one-step-matched-ν↑-blame-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl | left-silent-invariant refl refl
-    with lift-store-result (resultStore inner)
-weak-one-step-matched-ν↑-blame-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl | left-silent-invariant refl refl | ρ′ , liftρ
-    with apply-reveal-under-ty-binders
-      {χs = sourceChanges inner} s↑
-       | apply-reveal-under-ty-binders
-      {χs = keep ∷ []} s′↑
-weak-one-step-matched-ν↑-blame-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl | left-silent-invariant refl refl | ρ′ , liftρ
-    | μᵣ , source↑ | μᵗ , target↑ =
-  let
-    first = weak-one-step-matched-ν-frameᵀ
-      s↑ s′↑ pA pB (weak-all-result inner innerAll)
-
-    target⊢ =
-      nu-term-imprecision-target-typing (relatedResults first)
-
-    second = weak-one-step-source-blame-right-allocationᵀ
-      (weak-result-right-wf-silent inner
-        (left-silent-invariant refl refl) wfΣ′)
-      vV′ noV′
-      (⊑-tgt-wf (⊑-lift∀ᵢ (transportType inner pA)))
-      target⊢ (transportType inner pB)
-  in
-  weak-one-step-prepend-left-silentᵀ
-    (left-silent first (left-silent-invariant refl refl)) second
-
-weak-one-step-matched-ν↑-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  StoreWf Δᴿ (rightStoreⁱ ρ) →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  Value V′ →
-  No• V′ →
-  (catchup :
-    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
-  WeakOneStepResult ρ
-    (ν A N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind A′)
-weak-one-step-matched-ν↑-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
-    with sourceIsValueOrBlame (catchupAllInvariant catchup)
-weak-one-step-matched-ν↑-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
-    | inj₁ (vW , noW) =
-  weak-one-step-matched-ν↑-value-catchupᵀ
-    s↑ s′↑ pA pB vV′ noV′ catchup vW noW
-weak-one-step-matched-ν↑-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup
-    | inj₂ eq-blame =
-  weak-one-step-matched-ν↑-blame-catchupᵀ
-    wfΣ′ s↑ s′↑ pA pB vV′ noV′ catchup eq-blame
-
-------------------------------------------------------------------------
--- Synchronized `inst` allocation
-------------------------------------------------------------------------
-
-matched-νcast-allocation :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value N →
-  No• N →
-  Value N′ →
-  No• N′ →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  (ν ★ N s —→[ bind ★ ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
-  (ν ★ N′ s′ —→[ bind ★ ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
-  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
-    store-matched zero ★ zero ★ id★ ∷ ρ′ ∣ []
-    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
-    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
-matched-νcast-allocation {q = q} vN noN vN′ noN′ mode seal★ mode′
-    seal★′ s⊑ s′⊑ pB liftρ N⊑N′ =
-  ν-step vN noN ,
-  ν-step vN′ noN′ ,
-  conv⊑convᵀ
-    (paired-widening
-      (cast-inst mode) left-seal left-widening
-      (cast-inst mode′) right-seal right-widening)
-    (α⊑αᵀ vN noN vN′ noN′ id★ liftρ lift-ctx-[] N⊑N′
-      left-bullet-typing right-bullet-typing)
-  where
-    left-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
-        (sym (leftStoreⁱ-lift liftρ))
-        seal★
-
-    right-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
-        (sym (rightStoreⁱ-lift liftρ))
-        seal★′
-
-    left-widening =
-      subst
-        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
-          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
-        (sym (leftStoreⁱ-lift liftρ))
-        s⊑
-
-    right-widening =
-      subst
-        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
-          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
-        (sym (rightStoreⁱ-lift liftρ))
-        s′⊑
-
-    left-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (leftStoreⁱ-lift liftρ))
-        (⊢• refl refl (⊑-src-wf q) vN noN
-          (nu-term-imprecision-source-typing N⊑N′))
-
-    right-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (rightStoreⁱ-lift liftρ))
-        (⊢• refl refl (⊑-tgt-wf q) vN′ noN′
-          (nu-term-imprecision-target-typing N⊑N′))
-
-weak-one-step-matched-νcastᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value N →
-  No• N →
-  Value N′ →
-  No• N′ →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  WeakOneStepResult ρ
-    (ν ★ N s) (((⇑ᵗᵐ N′) •) ⟨ s′ ⟩)
-    B B′ (bind ★)
-weak-one-step-matched-νcastᵀ
-    {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
-    pB liftρ N⊑N′
-    with matched-νcast-allocation
-      vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
-      pB liftρ N⊑N′
-weak-one-step-matched-νcastᵀ
-    {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN noN vN′ noN′ mode seal★ mode′ seal★′ s⊑ s′⊑
-    pB liftρ N⊑N′
-    | source→ , _ , result =
-  record
-    { sourceChanges = bind ★ ∷ []
-    ; targetTailChanges = []
-    ; sourceResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ ⇑ᵢ _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore = store-matched zero ★ zero ★ id★ ∷ ρ′
-    ; resultSourceType = ⇑ᵗ B
-    ; resultTargetType = ⇑ᵗ B′
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = ⊑-lift∀ᵢ
-    ; transportAllBody = ⊑-lift-under-∀ᵢ
-    ; transportRightBody = ⊑-lift-under-rightᵢ
-    ; resultType = ⊑-lift∀ᵢ pB
-    ; sourceCatchup = ↠-step source→ ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult =
-        cong ((zero , ★) ∷_) (leftStoreⁱ-lift liftρ)
-    ; targetStoreResult =
-        cong ((zero , ★) ∷_) (rightStoreⁱ-lift liftρ)
-    ; relatedResults = result
-    }
-
-weak-one-step-matched-νcast-value-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  Value V′ →
-  No• V′ →
-  (catchup :
-    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
-  Value (sourceResult (weakResult (catchupAllResult catchup))) →
-  No• (sourceResult (weakResult (catchupAllResult catchup))) →
-  WeakOneStepResult ρ
-    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind ★)
-weak-one-step-matched-νcast-value-catchupᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW
-    with lift-store-result (resultStore inner)
-weak-one-step-matched-νcast-value-catchupᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW | ρ′ , liftρ
-    with apply-widen-inst-under-ty-binders
-      {χs = sourceChanges inner} mode seal★ s⊑
-       | apply-widen-inst-under-ty-binders
-      {χs = keep ∷ []} mode′ seal★′ s′⊑
-weak-one-step-matched-νcast-value-catchupᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW | ρ′ , liftρ₀
-    | μᵣ , modeᵣ , sealᵣ , source⊑₀
-    | μᵗ , modeᵗ , sealᵗ , target⊑₀
-    with weak-result-source-widen-inst inner mode seal★ s⊑
-       | weak-result-target-widen-inst
-          keep inner mode′ seal★′ s′⊑
-weak-one-step-matched-νcast-value-catchupᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final))
-    vW noW | ρ′ , liftρ₀
-    | μᵣ , modeᵣ , sealᵣ , source⊑₀
-    | μᵗ , modeᵗ , sealᵗ , target⊑₀
-    | μˢ , modeˢ , sealˢ , source⊑
-    | μᵗ′ , modeᵗ′ , sealᵗ′ , target⊑ =
-  weak-one-step-prepend-left-silentᵀ
-    (left-silent
-      (weak-one-step-matched-νcast-frameᵀ
-        mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-        (weak-all-result inner innerAll))
-      (left-silent-invariant refl refl))
-    (weak-one-step-matched-νcastᵀ
-      vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
-      source⊑ target⊑ (transportType inner pB) liftρ₀ innerAll)
-
-weak-one-step-matched-νcast-blame-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  StoreWf Δᴿ (rightStoreⁱ ρ) →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  Value V′ →
-  No• V′ →
-  (catchup :
-    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
-  sourceResult (weakResult (catchupAllResult catchup)) ≡ blame →
-  WeakOneStepResult ρ
-    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind ★)
-weak-one-step-matched-νcast-blame-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl
-    with silent
-weak-one-step-matched-νcast-blame-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl | left-silent-invariant refl refl
-    with lift-store-result (resultStore inner)
-weak-one-step-matched-νcast-blame-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl | left-silent-invariant refl refl | ρ′ , liftρ
-    with apply-widen-inst-under-ty-binders
-      {χs = sourceChanges inner} mode seal★ s⊑
-       | apply-widen-inst-under-ty-binders
-      {χs = keep ∷ []} mode′ seal★′ s′⊑
-weak-one-step-matched-νcast-blame-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB vV′ noV′
-    (left-all-catchup (weak-all-result inner innerAll)
-      (left-catchup-invariant silent final))
-    refl | left-silent-invariant refl refl | ρ′ , liftρ
-    | μᵣ , modeᵣ , sealᵣ , source⊑
-    | μᵗ , modeᵗ , sealᵗ , target⊑ =
-  let
-    first = weak-one-step-matched-νcast-frameᵀ
-      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-      (weak-all-result inner innerAll)
-
-    target⊢ =
-      nu-term-imprecision-target-typing (relatedResults first)
-
-    second = weak-one-step-source-blame-right-allocationᵀ
-      (weak-result-right-wf-silent inner
-        (left-silent-invariant refl refl) wfΣ′)
-      vV′ noV′ wf★ target⊢ (transportType inner pB)
-  in
-  weak-one-step-prepend-left-silentᵀ
-    (left-silent first (left-silent-invariant refl refl)) second
-
-weak-one-step-matched-νcast-catchupᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′}
-    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ} →
-  StoreWf Δᴿ (rightStoreⁱ ρ) →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  Value V′ →
-  No• V′ →
-  (catchup :
-    LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q) →
-  WeakOneStepResult ρ
-    (ν ★ N s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
-    B B′ (bind ★)
-weak-one-step-matched-νcast-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    vV′ noV′ catchup
-    with sourceIsValueOrBlame (catchupAllInvariant catchup)
-weak-one-step-matched-νcast-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    vV′ noV′ catchup | inj₁ (vW , noW) =
-  weak-one-step-matched-νcast-value-catchupᵀ
-    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    vV′ noV′ catchup vW noW
-weak-one-step-matched-νcast-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    vV′ noV′ catchup | inj₂ eq-blame =
-  weak-one-step-matched-νcast-blame-catchupᵀ
-    wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ pB
-    vV′ noV′ catchup eq-blame
-
-left-νcast-allocation :
-  ∀ {Φ Δᴸ Δᴿ B B′ C N N′ s μ q occ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  Value N →
-  No• N →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
-  (ν ★ N s —→[ bind ★ ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
-  (N′ —↠[ [] ] N′) ×
-  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
-    store-left zero ★ wf★ ∷ ρ′ ∣ []
-    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
-    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
-left-νcast-allocation {q = q} vN noN mode seal★ s⊑ pB liftρ
-    N⊑N′ =
-  ν-step vN noN ,
-  ↠-refl ,
-  cast⊑⊑ᵀ (cast-inst mode) left-seal left-widening
-    (α⊑ᵀ vN noN wf★ liftρ lift-left-ctx-[] N⊑N′
-      left-bullet-typing right-term-typing)
-    (⊑-source-liftνᵢ pB)
-  where
-    left-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
-        (sym (leftStoreⁱ-lift-left liftρ))
-        seal★
-
-    left-widening =
-      subst
-        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
-          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
-        (sym (leftStoreⁱ-lift-left liftρ))
-        s⊑
-
-    left-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (leftStoreⁱ-lift-left liftρ))
-        (⊢• refl refl (⊑-src-wf q) vN noN
-          (nu-term-imprecision-source-typing N⊑N′))
-
-    right-term-typing =
-      subst
-        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
-        (sym (rightStoreⁱ-lift-left liftρ))
-        (nu-term-imprecision-target-typing N⊑N′)
-
-------------------------------------------------------------------------
--- Left-only polymorphic allocation
-------------------------------------------------------------------------
-
-left-ν↑-allocation :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C N N′ s μ q occ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  Value N →
-  No• N →
-  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
-  (ν A N s —→[ bind A ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
-  (N′ —↠[ [] ] N′) ×
-  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
-    store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
-    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
-    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
-left-ν↑-allocation {q = q} vN noN h⇑A s↑ pB liftρ N⊑N′ =
-  ν-step vN noN ,
-  ↠-refl ,
-  conv↑⊑ᵀ left-reveal
-    (α⊑ᵀ vN noN h⇑A liftρ lift-left-ctx-[] N⊑N′
-      left-bullet-typing right-term-typing)
-    (⊑-source-liftνᵢ pB)
-  where
-    left-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (leftStoreⁱ-lift-left liftρ))
-        s↑
-
-    left-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (leftStoreⁱ-lift-left liftρ))
-        (⊢• refl refl (⊑-src-wf q) vN noN
-          (nu-term-imprecision-source-typing N⊑N′))
-
-    right-term-typing =
-      subst
-        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
-        (sym (rightStoreⁱ-lift-left liftρ))
-        (nu-term-imprecision-target-typing N⊑N′)
-
-------------------------------------------------------------------------
--- Right-only polymorphic allocation
-------------------------------------------------------------------------
-
-right-ν↑-allocation :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  Value N′ →
-  No• N′ →
-  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
-  (N —↠[ [] ] N) ×
-  (ν A N′ s —→[ bind A ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
-  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
-    store-right zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
-    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
-    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
-right-ν↑-allocation {q = q} vN′ noN′ h⇑A s′↑ pB pC liftρ
-    N⊑N′ =
-  ↠-refl ,
-  ν-step vN′ noN′ ,
-  ⊑conv↑ᵀ right-reveal
-    (⊑αᵀ vN′ noN′ h⇑A liftρ lift-right-ctx-[] N⊑N′ pC
-      left-term-typing right-bullet-typing)
-    (⊑-target-lift-rightᵢ pB)
-  where
-    right-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (rightStoreⁱ-lift-right liftρ))
-        s′↑
-
-    left-term-typing =
-      subst
-        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
-        (sym (leftStoreⁱ-lift-right liftρ))
-        (nu-term-imprecision-source-typing N⊑N′)
-
-    right-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ⇑ᵗ _) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (rightStoreⁱ-lift-right liftρ))
-        (⊢• refl refl (∀-imprecision-target-body-wf q) vN′ noN′
-          (nu-term-imprecision-target-typing N⊑N′))
-
-weak-one-step-right-ν↑ᵀ :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N′ s μ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  Value N′ →
-  No• N′ →
-  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
-  RevealConversion μ (suc Δᴿ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
-  WeakOneStepResult ρ N (((⇑ᵗᵐ N′) •) ⟨ s ⟩)
-    B B′ (bind A)
-weak-one-step-right-ν↑ᵀ
-    {A = A} {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
-    with right-ν↑-allocation
-      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
-weak-one-step-right-ν↑ᵀ
-    {A = A} {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
-    | _ , _ , result =
-  record
-    { sourceChanges = []
-    ; targetTailChanges = []
-    ; sourceResult = _
-    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; resultCtx = ⇑ᴿᵢ _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore = store-right zero (⇑ᵗ A) h⇑A ∷ ρ′
-    ; resultSourceType = B
-    ; resultTargetType = ⇑ᵗ B′
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = ⊑-target-lift-rightᵢ
-    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
-    ; transportRightBody = ⊑-target-lift-under-rightᵢ
-    ; resultType = ⊑-target-lift-rightᵢ pB
-    ; sourceCatchup = ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
-    ; targetStoreResult =
-        cong ((zero , ⇑ᵗ A) ∷_) (rightStoreⁱ-lift-right liftρ)
-    ; relatedResults = result
-    }
-
-------------------------------------------------------------------------
--- Right-only `inst` allocation
-------------------------------------------------------------------------
-
-right-νcast-allocation :
-  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  Value N′ →
-  No• N′ →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
-  (N —↠[ [] ] N) ×
-  (ν ★ N′ s —→[ bind ★ ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
-  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
-    store-right zero ★ wf★ ∷ ρ′ ∣ []
-    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
-    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
-right-νcast-allocation {q = q} vN′ noN′ mode seal★ s⊑ pB pC
-    liftρ N⊑N′ =
-  ↠-refl ,
-  ν-step vN′ noN′ ,
-  ⊑cast⊑ᵀ (cast-inst mode) right-seal right-widening
-    (⊑αᵀ vN′ noN′ wf★ liftρ lift-right-ctx-[] N⊑N′ pC
-      left-term-typing right-bullet-typing)
-    (⊑-target-lift-rightᵢ pB)
-  where
-    right-seal =
-      subst
-        (λ Σ → SealModeStore★ (instᵈ _) ((zero , ★) ∷ Σ))
-        (sym (rightStoreⁱ-lift-right liftρ))
-        seal★
-
-    right-widening =
-      subst
-        (λ Σ → instᵈ _ ∣ suc _ ∣ (zero , ★) ∷ Σ
-          ⊢ _ ∶ _ ⊑ ⇑ᵗ _)
-        (sym (rightStoreⁱ-lift-right liftρ))
-        s⊑
-
-    left-term-typing =
-      subst
-        (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
-        (sym (leftStoreⁱ-lift-right liftρ))
-        (nu-term-imprecision-source-typing N⊑N′)
-
-    right-bullet-typing =
-      subst
-        (λ Σ → suc _ ∣ (zero , ★) ∷ Σ ∣ []
-          ⊢ (⇑ᵗᵐ _) • ⦂ _)
-        (sym (rightStoreⁱ-lift-right liftρ))
-        (⊢• refl refl (∀-imprecision-target-body-wf q) vN′ noN′
-          (nu-term-imprecision-target-typing N⊑N′))
-
-weak-one-step-right-νcastᵀ :
-  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  Value N′ →
-  No• N′ →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
-  WeakOneStepResult ρ N (((⇑ᵗᵐ N′) •) ⟨ s ⟩)
-    B B′ (bind ★)
-weak-one-step-right-νcastᵀ
-    {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
-    with right-νcast-allocation
-      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
-weak-one-step-right-νcastᵀ
-    {B = B} {B′ = B′} {ρ′ = ρ′}
-    vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′
-    | _ , _ , result =
-  record
-    { sourceChanges = []
-    ; targetTailChanges = []
-    ; sourceResult = _
-    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
-    ; resultCtx = ⇑ᴿᵢ _
-    ; resultLeftCtx = _
-    ; resultRightCtx = _
-    ; sourceCtxResult = refl
-    ; targetCtxResult = refl
-    ; resultStore = store-right zero ★ wf★ ∷ ρ′
-    ; resultSourceType = B
-    ; resultTargetType = ⇑ᵗ B′
-    ; sourceTypeResult = refl
-    ; targetTypeResult = refl
-    ; transportType = ⊑-target-lift-rightᵢ
-    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
-    ; transportRightBody = ⊑-target-lift-under-rightᵢ
-    ; resultType = ⊑-target-lift-rightᵢ pB
-    ; sourceCatchup = ↠-refl
-    ; targetTail = ↠-refl
-    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
-    ; targetStoreResult =
-        cong ((zero , ★) ∷_) (rightStoreⁱ-lift-right liftρ)
-    ; relatedResults = result
-    }
-
-------------------------------------------------------------------------
--- `β-inst` followed by `ν ★` allocation
-------------------------------------------------------------------------
-
-matched-β-inst-νcast-allocation :
-  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value N →
-  No• N →
-  Value N′ →
-  No• N′ →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  CastMode μ′ →
-  SealModeStore★ (instᵈ μ′)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
-  (N ⟨ inst B s ⟩
-    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
-  (N′ ⟨ inst B′ s′ ⟩
-    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩) ×
-  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
-    store-matched zero ★ zero ★ id★ ∷ ρ′ ∣ []
-    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ ((⇑ᵗᵐ N′) •) ⟨ s′ ⟩
-    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
-matched-β-inst-νcast-allocation vN noN vN′ noN′ mode seal★
-    mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
-    with matched-νcast-allocation vN noN vN′ noN′ mode seal★
-      mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
-matched-β-inst-νcast-allocation vN noN vN′ noN′ mode seal★
-    mode′ seal★′ s⊑ s′⊑ pB liftρ N⊑N′
-    | N→ , N′→ , result =
-  ↠-step (post-β-inst vN) (↠-step N→ ↠-refl) ,
-  ↠-step (post-β-inst vN′) (↠-step N′→ ↠-refl) ,
-  result
-
-left-β-inst-νcast-allocation :
-  ∀ {Φ Δᴸ Δᴿ B B′ C N N′ s μ q occ}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  Value N →
-  No• N →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
-    ⊢ s ∶ C ⊑ ⇑ᵗ B →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν occ q →
-  (N ⟨ inst B s ⟩
-    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N) •) ⟨ s ⟩) ×
-  (N′ —↠[ [] ] N′) ×
-  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
-    store-left zero ★ wf★ ∷ ρ′ ∣ []
-    ⊢ᴺ ((⇑ᵗᵐ N) •) ⟨ s ⟩ ⊑ N′
-    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
-left-β-inst-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
-    with left-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
-left-β-inst-νcast-allocation vN noN mode seal★ s⊑ pB liftρ N⊑N′
-    | N→ , N′→ , result =
-  ↠-step (post-β-inst vN) (↠-step N→ ↠-refl) ,
-  N′→ ,
-  result
-
-right-β-inst-νcast-allocation :
-  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N′ s μ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
-  Value N′ →
-  No• N′ →
-  CastMode μ →
-  SealModeStore★ (instᵈ μ)
-    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
-  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
-    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
-  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′ →
-  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ `∀ C′ ∶ q →
-  (N —↠[ [] ] N) ×
-  (N′ ⟨ inst B′ s ⟩
-    —↠[ keep ∷ bind ★ ∷ [] ] ((⇑ᵗᵐ N′) •) ⟨ s ⟩) ×
-  (⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣
-    store-right zero ★ wf★ ∷ ρ′ ∣ []
-    ⊢ᴺ N ⊑ ((⇑ᵗᵐ N′) •) ⟨ s ⟩
-    ⦂ B ⊑ ⇑ᵗ B′ ∶ ⊑-target-lift-rightᵢ pB)
-right-β-inst-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC liftρ
-    N⊑N′
-    with right-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC
-      liftρ N⊑N′
-right-β-inst-νcast-allocation vN′ noN′ mode seal★ s⊑ pB pC liftρ
-    N⊑N′ | N→ , N′→ , result =
-  N→ ,
-  ↠-step (post-β-inst vN′) (↠-step N′→ ↠-refl) ,
-  result
-
-------------------------------------------------------------------------
--- Allocation followed by `β-Λ•`
-------------------------------------------------------------------------
-
-matched-ν↑-β-Λ• :
-  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ V V′ s s′ μ μ′ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value V →
-  No• V →
-  Value V′ →
-  No• V′ →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  RevealConversion μ′ (suc Δᴿ)
-    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
-    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  (A⇑⊑A′⇑ : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ′ ∣ []
-    ⊢ᴺ V ⊑ V′ ⦂ C ⊑ C′ ∶ q →
-  (ν A (Λ V) s —↠[ bind A ∷ keep ∷ [] ] V ⟨ s ⟩) ×
-  (ν A′ (Λ V′) s′
-    —↠[ bind A′ ∷ keep ∷ [] ] V′ ⟨ s′ ⟩) ×
-  (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
-    store-matched zero (⇑ᵗ A) zero (⇑ᵗ A′) A⇑⊑A′⇑ ∷ ρ′
-    ∣ []
-    ⊢ᴺ V ⟨ s ⟩ ⊑ V′ ⟨ s′ ⟩
-    ⦂ ⇑ᵗ B ⊑ ⇑ᵗ B′ ∶ ⊑-lift∀ᵢ pB)
-matched-ν↑-β-Λ• {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {A′ = A′}
-    {C = C} {C′ = C′} {V = V} {V′ = V′} {ρ′ = ρ′}
-    vV noV vV′ noV′ s↑ s′↑ pB A⇑⊑A′⇑ liftρ
-    V⊑V′ =
-  ↠-step (ν-step (Λ vV) (no•-Λ noV))
-    (↠-step (post-allocation-β-Λ• vV) ↠-refl) ,
-  ↠-step (ν-step (Λ vV′) (no•-Λ noV′))
-    (↠-step (post-allocation-β-Λ• vV′) ↠-refl) ,
-  conv⊑convᵀ
-    (paired-conversion
-      (paired-reveal (correspondence-stored (here refl))
-        left-reveal right-reveal))
-    (allocation-matchedᵀ A⇑⊑A′⇑ liftρ V⊑V′
-      left-body-typing right-body-typing)
-  where
-    left-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (leftStoreⁱ-lift liftρ))
-        s↑
-
-    right-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (rightStoreⁱ-lift liftρ))
-        s′↑
-
-    left-body-typing :
-      suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′ ∣ [] ⊢ V ⦂ C
-    left-body-typing =
-      term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
-        {Σ = leftStoreⁱ ρ′}
-        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′}
-        {Γ = []} {M = V} {A = C} ≤-refl StoreIncl-drop noV
-        (nu-term-imprecision-source-typing V⊑V′)
-
-    right-body-typing :
-      suc Δᴿ ∣ (zero , ⇑ᵗ A′) ∷ rightStoreⁱ ρ′ ∣ []
-        ⊢ V′ ⦂ C′
-    right-body-typing =
-      term-weaken {Δ = suc Δᴿ} {Δ′ = suc Δᴿ}
-        {Σ = rightStoreⁱ ρ′}
-        {Σ′ = (zero , ⇑ᵗ A′) ∷ rightStoreⁱ ρ′}
-        {Γ = []} {M = V′} {A = C′} ≤-refl StoreIncl-drop noV′
-        (nu-term-imprecision-target-typing V⊑V′)
-
-left-ν↑-β-Λ• :
-  ∀ {Φ Δᴸ Δᴿ A B B′ C V N′ s μ q}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
-  Value V →
-  No• V →
-  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
-  RevealConversion μ (suc Δᴸ)
-    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
-    zero (⇑ᵗ A) s C (⇑ᵗ B) →
-  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
-  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
-  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ []
-    ⊢ᴺ V ⊑ N′ ⦂ C ⊑ B′ ∶ q →
-  (ν A (Λ V) s —↠[ bind A ∷ keep ∷ [] ] V ⟨ s ⟩) ×
-  (N′ —↠[ [] ] N′) ×
-  (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
-    store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ []
-    ⊢ᴺ V ⟨ s ⟩ ⊑ N′
-    ⦂ ⇑ᵗ B ⊑ B′ ∶ ⊑-source-liftνᵢ pB)
-left-ν↑-β-Λ• {Δᴸ = Δᴸ} {A = A} {C = C} {V = V}
-    {ρ′ = ρ′} vV noV h⇑A s↑ pB liftρ V⊑N′ =
-  ↠-step (ν-step (Λ vV) (no•-Λ noV))
-    (↠-step (post-allocation-β-Λ• vV) ↠-refl) ,
-  ↠-refl ,
-  conv↑⊑ᵀ left-reveal
-    (allocation-leftᵀ h⇑A liftρ V⊑N′
-      source-body-typing
-      (nu-term-imprecision-target-typing V⊑N′))
-    (⊑-source-liftνᵢ pB)
-  where
-    left-reveal =
-      subst
-        (λ Σ → RevealConversion _ (suc _) ((zero , ⇑ᵗ _) ∷ Σ)
-          zero (⇑ᵗ _) _ _ (⇑ᵗ _))
-        (sym (leftStoreⁱ-lift-left liftρ))
-        s↑
-
-    source-body-typing :
-      suc Δᴸ ∣ (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′ ∣ [] ⊢ V ⦂ C
-    source-body-typing =
-      term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
-        {Σ = leftStoreⁱ ρ′}
-        {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρ′}
-        {Γ = []} {M = V} {A = C} ≤-refl StoreIncl-drop noV
-        (nu-term-imprecision-source-typing V⊑N′)
-
-------------------------------------------------------------------------
--- Matched allocation followed by `β-gen•`
-------------------------------------------------------------------------
-
-matched-post-allocation-β-genᵀ :
-  ∀ {Φ Δᴸ Δᴿ Aν Aν′ A A′ B B′ V V′ c c′ p}
-    {ρ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)}
-    {γ′ : CtxImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      (suc Δᴸ) (suc Δᴿ)} →
-  Value V →
-  Value V′ →
-  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ
-    ⊢ gen A c ∶ A ⊒ `∀ B →
-  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
-    ⊢ gen A′ c′ ∶ A′ ⊒ `∀ B′ →
-  (pν : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ⊢ Aν ⊑ Aν′ ⊣ suc Δᴿ) →
-  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
-  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ∣ suc Δᴿ
-    ∣ store-matched zero Aν zero Aν′ pν ∷ ρ′ ∣ γ′
-    ⊢ᴺ ⇑ᵗᵐ V ⊑ ⇑ᵗᵐ V′ ⦂ ⇑ᵗ A ⊑ ⇑ᵗ A′ ∶ p →
-  (q : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-    ∣ suc Δᴸ ⊢ B ⊑ᵖ B′ ⊣ suc Δᴿ) →
-  (((⇑ᵗᵐ (V ⟨ gen A c ⟩)) •
-      —→[ keep ] (⇑ᵗᵐ V) ⟨ c ⟩) ×
-   ((⇑ᵗᵐ (V′ ⟨ gen A′ c′ ⟩)) •
-      —→[ keep ] (⇑ᵗᵐ V′) ⟨ c′ ⟩) ×
-   (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-      ∣ suc Δᴸ ∣ suc Δᴿ
-      ∣ store-matched zero Aν zero Aν′ pν ∷ ρ′ ∣ γ′
-      ⊢ᴺᵖ (⇑ᵗᵐ V) ⟨ c ⟩ ⊑ (⇑ᵗᵐ V′) ⟨ c′ ⟩
-      ⦂ B ⊑ᵖ B′ ∶ q))
-matched-post-allocation-β-genᵀ {Aν = Aν} {Aν′ = Aν′} vV vV′
-    c⊒ c′⊒ pν liftρ V⊑V′ q =
-  post-allocation-β-gen•-bare vV ,
-  post-allocation-β-gen•-bare vV′ ,
-  gen-down⊑gen-downᵀ
-    (narrow-mode-relax (ModeIncl-gen id-only≤tag-or-idᵈ) left-body)
-    (narrow-mode-relax (ModeIncl-gen id-only≤tag-or-idᵈ) right-body)
-    V⊑V′ q
-  where
-    left-body =
-      subst
-        (λ Σ → genᵈ id-onlyᵈ ∣ _ ∣ (zero , Aν) ∷ Σ
-          ⊢ _ ∶ _ ⊒ _)
-        (sym (leftStoreⁱ-lift liftρ))
-        (allocate-gen-narrowing {Aν = Aν} c⊒)
-
-    right-body =
-      subst
-        (λ Σ → genᵈ id-onlyᵈ ∣ _ ∣ (zero , Aν′) ∷ Σ
-          ⊢ _ ∶ _ ⊒ _)
-        (sym (rightStoreⁱ-lift liftρ))
-        (allocate-gen-narrowing {Aν = Aν′} c′⊒)

--- a/GTSF/proof/NuImprecisionSimulationCore.agda
+++ b/GTSF/proof/NuImprecisionSimulationCore.agda
@@ -1,0 +1,15107 @@
+module proof.NuImprecisionSimulationCore where
+
+-- File Charter:
+--   * Defines the stable weak one-step result, its indexed forms, and the
+--     transport and type-coherence interfaces used by simulation proofs.
+--   * Proves composition, framing, allocation-prefix, and terminal helpers.
+--   * Defines the general weak one-step result over transformed stores,
+--     contexts, and endpoint types.
+--   * Defines structural world embeddings and proves their exhaustive mutual
+--     action on ordinary and quotiented no-runtime-bullet imprecision.
+--   * Lifts weak-result type transport through the `∀`-permutation
+--     quotient used by paired narrowing/widening casts.
+--   * Proves that adjacent type-name swapping permutes arbitrary coercion-mode
+--     stacks, including seal permissions and crossed `gen`/`inst` orders.
+--   * Derives both orientations of the adjacent-`∀` crossed-body relation
+--     from structural embeddings, with no syntax-specific imprecision rule.
+--   * Ends at the direct-swap residual lemmas; allocation and active
+--     universal catch-up cases live in the downstream simulation modules.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Bool using (true)
+open import Data.List using ([]; _∷_; _++_; map)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Nat using (zero; suc; z<s; s<s)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using
+  (cong; cong₂; subst; sym; trans)
+import Relation.Binary.HeterogeneousEquality as HE
+
+open import Types
+open import Ctx using (⤊ᵗ)
+open import Coercions using
+  ( Coercion
+  ; ModeIncl
+  ; ModeEnv
+  ; Mode
+  ; id-only
+  ; tag-or-id
+  ; seal-or-id
+  ; mode≤
+  ; extᵈ
+  ; gen
+  ; genᵈ
+  ; id-onlyᵈ
+  ; id-only≤tag-or-idᵈ
+  ; inst
+  ; instᵈ
+  ; renameᶜ
+  ; sealModeAllowed
+  ; tag-or-idᵈ
+  ; `∀
+  ; ⇑ᶜ
+  ; _[_]ᶜ
+  )
+open import Conversion using
+  ( ConcealConversion
+  ; RevealConversion
+  ; conceal-all
+  ; open-conceal-conversion
+  ; open-reveal-conversion
+  ; reveal-all
+  ; rename-reveal-conversion
+  ; rename-conceal-conversion
+  ; weaken-conceal-conversion
+  ; weaken-reveal-conversion
+  )
+open import ForallPermutation using
+  ( _≈∀_
+  ; quotientᵖ
+  ; swap01ᵗ
+  ; ≈∀-refl
+  ; ≈∀-sym
+  ; ≈∀-trans
+  ; ≈∀-⇒
+  ; ≈∀-∀
+  ; ≈∀-swap
+  ; _∣_⊢_⊑ᵖ_⊣_
+  )
+open import ImprecisionWf
+open import NarrowWiden using
+  ( narrow-mode-relax
+  ; narrow-renameᵗ
+  ; narrow-weaken
+  ; widen-mode-relax
+  ; widen-renameᵗ
+  ; widen-weaken
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+import Coercions as C
+import NarrowWiden as NW
+open import NuReduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyCoercion
+  ; applyStore
+  ; applyStores
+  ; applyCoercionUnderTyBinder
+  ; applyTerm
+  ; applyTerms
+  ; applyTy
+  ; applyTyCtx
+  ; applyTyCtxs
+  ; applyTys
+  ; bind
+  ; blame-·₁
+  ; blame-·₂
+  ; blame-⟨⟩
+  ; blame-ν
+  ; keep
+  ; β-gen•
+  ; β-inst
+  ; β-Λ•
+  ; β-∀•
+  ; pure-step
+  ; ν-step
+  ; ξ-⟨⟩
+  ; ξ-ν
+  ; ↠-refl
+  ; ↠-step
+  ; _—→[_]_
+  ; _—↠[_]_
+  )
+open import NuTerms using
+  ( No•
+  ; RuntimeOK
+  ; no•-`
+  ; no•-ƛ
+  ; no•-·
+  ; no•-Λ
+  ; no•-ν
+  ; no•-$
+  ; no•-⊕
+  ; no•-⟨⟩
+  ; no•-blame
+  ; ok-no
+  ; ok-•
+  ; ok-·₁
+  ; ok-·₂
+  ; ok-ν
+  ; ok-⊕₁
+  ; ok-⊕₂
+  ; ok-⟨⟩
+  ; blame
+  ; Term
+  ; Value
+  ; `_
+  ; ƛ_
+  ; _·_
+  ; Λ_
+  ; ν
+  ; renameᵗᵐ
+  ; ⇑ᵗᵐ
+  ; _•
+  ; $
+  ; _⊕[_]_
+  ; _⟨_⟩
+  )
+open import Primitives using (κℕ; addℕ)
+open import NuStore using (StoreWf)
+open import NuTermImprecision using
+  ( StoreImp
+  ; StoreImpEntry
+  ; StoreCorresponds
+  ; correspondence-stored
+  ; correspondence-linked
+  ; CtxImp
+  ; ctx-imp
+  ; LiftStoreⁱ
+  ; lift-store-[]
+  ; lift-store-∷
+  ; lift-store-left
+  ; lift-store-right
+  ; lift-store-link
+  ; LiftLeftStoreⁱ
+  ; lift-left-store-[]
+  ; lift-left-store-∷
+  ; lift-left-store-left
+  ; lift-left-store-right
+  ; lift-left-store-link
+  ; LiftRightStoreⁱ
+  ; lift-right-store-[]
+  ; lift-right-store-∷
+  ; lift-right-store-left
+  ; lift-right-store-right
+  ; lift-right-store-link
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; leftStoreⁱ-lift
+  ; rightStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightStoreⁱ-lift-left
+  ; leftStoreⁱ-lift-right
+  ; rightStoreⁱ-lift-right
+  ; LiftCtxⁱ
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; LiftLeftCtxⁱ
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  ; LiftRightCtxⁱ
+  ; lift-right-ctx-[]
+  ; lift-right-ctx-∷
+  ; leftCtxⁱ
+  ; rightCtxⁱ
+  ; leftCtxⁱ-lift
+  ; rightCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; rightCtxⁱ-lift-left
+  ; leftCtxⁱ-lift-right
+  ; rightCtxⁱ-lift-right
+  ; store-matched
+  ; store-left
+  ; store-right
+  ; store-link
+  ; crossedStoreⁱ
+  ; crossedStoreⁱ-new-old
+  ; crossedStoreⁱ-old-new
+  )
+open import QuotientedTermImprecision
+open import Store using (StoreIncl; StoreIncl-drop; StoreIncl-refl)
+open import TermTyping using
+  ( CastMode
+  ; SealModeStore★
+  ; cast-ext
+  ; cast-gen
+  ; cast-inst
+  ; cast-tag-or-id
+  ; cast-weaken
+  ; weakenCastᵈ
+  ; forget
+  ; _∣_∣_⊢_⦂_
+  ; ⊢•
+  ; ⊢⟨⟩↑
+  )
+open import proof.CastImprecision using
+  ( RightCastCtxCompatible
+  ; seal★-ext-shift
+  ; seal★-gen-shift
+  ; widening⇒⊑ᵢ
+  ; ⊑-transʳ-castᵢ
+  )
+open import proof.MaximalLowerBoundsWf using
+  ( ∀ᵢᶜ
+  ; rename-assm²ᵢ
+  ; rename-assm²-composeᵢ
+  ; rename-assm²-congᵢ
+  ; rename-assm²-∀ᵢ
+  ; rename-assm²-crossed-left∀∀ᵢ
+  ; rename-assm²-crossed-right∀∀ᵢ
+  ; rename-assm²-crossed-double∀∀ᵢ
+  ; rename-assm²-⇑ᵢ
+  ; rename-assm²-⇑ᴸᵢ
+  ; rename-assm²-source-νᵢ
+  ; rename-assm²-swapLeft∀∀ᵢ
+  ; rename-assm²-swapRight∀∀ᵢ
+  ; rename-assm²-target-rightᵢ
+  ; ⊑-renameᵗ²ᵢ
+  ; ⊑-crossed-body-lift∀∀ᵢ
+  ; ⊑-crossed-left-body-lift∀∀ᵢ
+  ; ⊑-crossed-double-lift∀∀ᵢ
+  ; ⊑-lift∀ᵢ
+  ; ⊑-open∀ᵢ
+  ; ⊑-source-liftνᵢ
+  ; ⊑-ν∀-to-∀νᵢ
+  ; ⊑-swapLeft01∀∀ᵢ
+  ; ⊑-swapRight01∀∀ᵢ
+  ; ⊑-target-lift-rightᵢ
+  ; swap01ᵢ
+  ; swap01ᵢ-after-suc
+  )
+open import proof.MediationProperties using (wfTy-applyTys)
+open import proof.ForallPermutationProperties using
+  ( ≈∀-double-swap
+  ; ≈∀-double-swap-sym
+  ; ⊑→⊑ᵖ
+  )
+open import proof.NarrowWidenProperties using
+  ( StoreDetWf
+  ; allocate-all-narrowing
+  ; allocate-all-widening
+  ; allocate-gen-narrowing
+  ; open-all-narrowing
+  ; open-all-widening
+  )
+open import proof.NuTermProperties using
+  ( modeRename-left-inverse
+  ; open0-ext-suc-cancelᵐ
+  ; renameStoreᵗ-ext-suc-cons-comm
+  ; renameᵗᵐ-compose
+  ; renameᵗᵐ-cong
+  ; renameᵗᵐ-ext-suc-comm
+  ; renameᵗᵐ-id
+  ; renameᵗᵐ-preserves-No•
+  ; renameᵗᵐ-preserves-Value
+  )
+open import proof.NuProgress using
+  ( AllView
+  ; av-Λ
+  ; av-∀
+  ; av-gen
+  ; canonical-∀
+  ; runtime-value-no•
+  )
+open import proof.NuPreservation using
+  ( runtime-ν
+  ; runtime-⟨⟩
+  ; value-no-step
+  )
+open import proof.ReductionProperties using
+  ( applyCoercions
+  ; applyCoercions-inst
+  ; applyCoercions-preserves-Inert
+  ; applyCoercionUnderTyBinders
+  ; applyTerm-preserves-No•
+  ; applyTerm-preserves-Value
+  ; applyTerms-++
+  ; applyTerms-preserves-No•
+  ; applyTerms-preserves-Value
+  ; applyStores-++
+  ; applyTy-∀
+  ; applyTyUnderTyBinder
+  ; applyTyCtxs-++
+  ; applyTysUnderTyBinders
+  ; applyTysUnderTyBinders-++
+  ; applyTys-++
+  ; applyTys-★
+  ; applyTys-∀
+  ; cast-↠
+  ; ·₁-↠
+  ; ·₂-↠
+  ; ν-↠
+  ; ↠-trans
+  )
+open import proof.LeftChangeNarrowingSeparated using
+  (applyTys-⇒)
+open import proof.CoercionProperties using
+  ( ModeIncl-ext
+  ; ModeIncl-gen
+  ; ModeIncl-inst
+  ; ModeRename
+  ; open0-ext-suc-cancelᶜ
+  )
+open import proof.TypePreservation using
+  ( applyNarrow-typing
+  ; applyWiden-typing
+  ; applyWidenInstUnderTyBinder-typing
+  ; CastModeRenamer
+  ; castModeRenamer-ext
+  ; castModeRenamer-seal★
+  ; seal★-inst
+  ; seal★-weaken
+  ; castModeRenamer-suc
+  ; modeRename-suc-weakenCast
+  ; preservation
+  ; term-weaken
+  ; typing-renameᵀ
+  )
+open import proof.StoreProperties using
+  (∈-renameStoreᵗ; renameStoreᵗ-incl)
+open import proof.TypeProperties using
+  ( RenameLeftInverse
+  ; RenameLeftInverse-ext
+  ; RenameLeftInverse-ext-suc-pred
+  ; RenameLeftInverse-suc
+  ; TyPermutation
+  ; TyPermutation-ext
+  ; TyRenameWf
+  ; TyRenameWf-ext
+  ; TyRenameWf-suc
+  ; backward
+  ; backward-forward
+  ; forward
+  ; forward-backward
+  ; forward-wf
+  ; predᵗ
+  ; occurs-zero-rename-ext
+  ; rename-cong
+  ; renameᵗ-compose
+  ; renameᵗ-ext-suc-comm
+  ; renameᵗ-id
+  ; renameᵗ-preserves-WfTy
+  ; renameStoreᵗ-compose
+  ; renameStoreᵗ-ext-suc-comm
+  )
+
+store-incl-insert-second :
+  ∀ {Σ α β A B} →
+  StoreIncl ((α , A) ∷ Σ) ((α , A) ∷ (β , B) ∷ Σ)
+store-incl-insert-second (here refl) = here refl
+store-incl-insert-second (there x∈) = there (there x∈)
+
+apply-reveal-under-ty-binder :
+  ∀ {χ μ Δ Σ Aν B C c} →
+  RevealConversion μ (suc Δ)
+    ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
+    zero (⇑ᵗ Aν) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (applyTyCtx χ Δ))
+      ((zero , ⇑ᵗ (applyTy χ Aν)) ∷ ⟰ᵗ (applyStore χ Σ))
+      zero (⇑ᵗ (applyTy χ Aν))
+      (applyCoercionUnderTyBinder χ c)
+      (applyTyUnderTyBinder χ C) (⇑ᵗ (applyTy χ B))
+apply-reveal-under-ty-binder {χ = keep} {μ = μ} c↑ = μ , c↑
+apply-reveal-under-ty-binder
+    {χ = bind Aχ} {μ = μ} {Δ = Δ} {Σ = Σ}
+    {Aν = Aν} {B = B} {C = C} {c = c} c↑ =
+  (λ Y → μ (predᵗ Y)) ,
+  weaken-reveal-conversion store-incl-insert-second
+    (subst
+      (λ T → RevealConversion (λ Y → μ (predᵗ Y))
+        (suc (suc Δ))
+        ((zero , ⇑ᵗ (⇑ᵗ Aν)) ∷ ⟰ᵗ (⟰ᵗ Σ))
+        zero (⇑ᵗ (⇑ᵗ Aν))
+        (renameᶜ (extᵗ suc) c)
+        (renameᵗ (extᵗ suc) C) T)
+      (renameᵗ-ext-suc-comm suc B)
+      (subst
+        (λ T → RevealConversion (λ Y → μ (predᵗ Y))
+          (suc (suc Δ))
+          ((zero , T) ∷ ⟰ᵗ (⟰ᵗ Σ))
+          zero T (renameᶜ (extᵗ suc) c)
+          (renameᵗ (extᵗ suc) C)
+          (renameᵗ (extᵗ suc) (⇑ᵗ B)))
+        (renameᵗ-ext-suc-comm suc Aν)
+        (subst
+          (λ Σ′ → RevealConversion (λ Y → μ (predᵗ Y))
+            (suc (suc Δ)) Σ′ zero
+            (renameᵗ (extᵗ suc) (⇑ᵗ Aν))
+            (renameᶜ (extᵗ suc) c)
+            (renameᵗ (extᵗ suc) C)
+            (renameᵗ (extᵗ suc) (⇑ᵗ B)))
+          renamed-store
+          (rename-reveal-conversion
+            (TyRenameWf-ext TyRenameWf-suc)
+            (modeRename-left-inverse
+              {ρ = extᵗ suc} {ψ = predᵗ}
+              RenameLeftInverse-ext-suc-pred)
+            c↑))))
+  where
+    renamed-store :
+      renameStoreᵗ (extᵗ suc)
+          ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
+        ≡ (zero , renameᵗ (extᵗ suc) (⇑ᵗ Aν)) ∷
+          ⟰ᵗ (⟰ᵗ Σ)
+    renamed-store =
+      cong₂ _∷_ refl (renameStoreᵗ-ext-suc-comm suc Σ)
+
+apply-reveal-under-ty-binders :
+  ∀ {χs μ Δ Σ Aν B C c} →
+  RevealConversion μ (suc Δ)
+    ((zero , ⇑ᵗ Aν) ∷ ⟰ᵗ Σ)
+    zero (⇑ᵗ Aν) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (applyTyCtxs χs Δ))
+      ((zero , ⇑ᵗ (applyTys χs Aν)) ∷
+        ⟰ᵗ (applyStores χs Σ))
+      zero (⇑ᵗ (applyTys χs Aν))
+      (applyCoercionUnderTyBinders χs c)
+      (applyTysUnderTyBinders χs C) (⇑ᵗ (applyTys χs B))
+apply-reveal-under-ty-binders {χs = []} {μ = μ} c↑ = μ , c↑
+apply-reveal-under-ty-binders {χs = χ ∷ χs} c↑
+    with apply-reveal-under-ty-binder {χ = χ} c↑
+apply-reveal-under-ty-binders {χs = χ ∷ χs} c↑
+    | μ′ , c′↑ =
+  apply-reveal-under-ty-binders {χs = χs} c′↑
+
+apply-widen-inst-under-ty-binders :
+  ∀ {χs μ Δ Σ c B C} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ) ((zero , ★) ∷ ⟰ᵗ Σ) →
+  instᵈ μ ∣ suc Δ ∣ (zero , ★) ∷ ⟰ᵗ Σ
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ (instᵈ μ′)
+      ((zero , ★) ∷ ⟰ᵗ (applyStores χs Σ)) ×
+    (instᵈ μ′ ∣ suc (applyTyCtxs χs Δ)
+      ∣ (zero , ★) ∷ ⟰ᵗ (applyStores χs Σ)
+      ⊢ applyCoercionUnderTyBinders χs c
+        ∶ applyTysUnderTyBinders χs C ⊑
+          ⇑ᵗ (applyTys χs B))
+apply-widen-inst-under-ty-binders {χs = []} {μ = μ}
+    mode seal★ c⊑ =
+  μ , mode , seal★ , c⊑
+apply-widen-inst-under-ty-binders {χs = keep ∷ χs}
+    mode seal★ c⊑
+    with applyWidenInstUnderTyBinder-typing
+      {χ = keep} mode seal★ c⊑
+apply-widen-inst-under-ty-binders {χs = keep ∷ χs}
+    mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  apply-widen-inst-under-ty-binders
+    {χs = χs} mode′ seal★′ c′⊑
+apply-widen-inst-under-ty-binders {χs = bind A ∷ χs}
+    mode seal★ c⊑
+    with applyWidenInstUnderTyBinder-typing
+      {χ = bind A} mode seal★ c⊑
+apply-widen-inst-under-ty-binders {χs = bind A ∷ χs}
+    mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  apply-widen-inst-under-ty-binders
+    {χs = χs} mode′ seal★′ c′⊑
+
+apply-narrows-typing :
+  ∀ {χs μ Δ Σ c A B} →
+  CastMode μ →
+  SealModeStore★ μ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ μ′ (applyStores χs Σ) ×
+    (μ′ ∣ applyTyCtxs χs Δ ∣ applyStores χs Σ
+      ⊢ applyCoercions χs c
+        ∶ applyTys χs A ⊒ applyTys χs B)
+apply-narrows-typing {χs = []} {μ = μ} mode seal★ c⊒ =
+  μ , mode , seal★ , c⊒
+apply-narrows-typing {χs = χ ∷ χs} mode seal★ c⊒
+    with applyNarrow-typing {χ = χ} mode seal★ c⊒
+apply-narrows-typing {χs = χ ∷ χs} mode seal★ c⊒
+    | μ′ , mode′ , seal★′ , c′⊒ =
+  apply-narrows-typing {χs = χs} mode′ seal★′ c′⊒
+
+apply-widens-typing :
+  ∀ {χs μ Δ Σ c A B} →
+  CastMode μ →
+  SealModeStore★ μ Σ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊑ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ μ′ (applyStores χs Σ) ×
+    (μ′ ∣ applyTyCtxs χs Δ ∣ applyStores χs Σ
+      ⊢ applyCoercions χs c
+        ∶ applyTys χs A ⊑ applyTys χs B)
+apply-widens-typing {χs = []} {μ = μ} mode seal★ c⊑ =
+  μ , mode , seal★ , c⊑
+apply-widens-typing {χs = χ ∷ χs} mode seal★ c⊑
+    with applyWiden-typing {χ = χ} mode seal★ c⊑
+apply-widens-typing {χs = χ ∷ χs} mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  apply-widens-typing {χs = χs} mode′ seal★′ c′⊑
+
+apply-fixed-narrows-typing :
+  ∀ {χs μ Δ Σ c A B} →
+  ModeRename suc μ μ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊒ B →
+  μ ∣ applyTyCtxs χs Δ ∣ applyStores χs Σ
+    ⊢ applyCoercions χs c
+      ∶ applyTys χs A ⊒ applyTys χs B
+apply-fixed-narrows-typing {χs = []} mode-suc c⊒ = c⊒
+apply-fixed-narrows-typing {χs = keep ∷ χs} mode-suc c⊒ =
+  apply-fixed-narrows-typing {χs = χs} mode-suc c⊒
+apply-fixed-narrows-typing {χs = bind X ∷ χs} mode-suc c⊒ =
+  apply-fixed-narrows-typing {χs = χs} mode-suc
+    (narrow-weaken ≤-refl StoreIncl-drop
+      (narrow-renameᵗ TyRenameWf-suc mode-suc c⊒))
+
+apply-fixed-widens-typing :
+  ∀ {χs μ Δ Σ c A B} →
+  ModeRename suc μ μ →
+  μ ∣ Δ ∣ Σ ⊢ c ∶ A ⊑ B →
+  μ ∣ applyTyCtxs χs Δ ∣ applyStores χs Σ
+    ⊢ applyCoercions χs c
+      ∶ applyTys χs A ⊑ applyTys χs B
+apply-fixed-widens-typing {χs = []} mode-suc c⊑ = c⊑
+apply-fixed-widens-typing {χs = keep ∷ χs} mode-suc c⊑ =
+  apply-fixed-widens-typing {χs = χs} mode-suc c⊑
+apply-fixed-widens-typing {χs = bind X ∷ χs} mode-suc c⊑ =
+  apply-fixed-widens-typing {χs = χs} mode-suc
+    (widen-weaken ≤-refl StoreIncl-drop
+      (widen-renameᵗ TyRenameWf-suc mode-suc c⊑))
+
+apply-reveal-conversion :
+  ∀ {χ μ Δ Σ α X c A B} →
+  RevealConversion μ Δ Σ α X c A B →
+  ∃[ μ′ ] ∃[ α′ ] ∃[ X′ ]
+    RevealConversion μ′ (applyTyCtx χ Δ) (applyStore χ Σ)
+      α′ X′ (applyCoercion χ c) (applyTy χ A) (applyTy χ B)
+apply-reveal-conversion {χ = keep} {μ = μ} {α = α} {X = X} c↑ =
+  μ , α , X , c↑
+apply-reveal-conversion
+    {χ = bind Aχ} {μ = μ} {α = α} {X = X} c↑ =
+  weakenCastᵈ μ , suc α , ⇑ᵗ X ,
+  weaken-reveal-conversion StoreIncl-drop
+    (rename-reveal-conversion TyRenameWf-suc
+      modeRename-suc-weakenCast c↑)
+
+apply-conceal-conversion :
+  ∀ {χ μ Δ Σ α X c A B} →
+  ConcealConversion μ Δ Σ α X c A B →
+  ∃[ μ′ ] ∃[ α′ ] ∃[ X′ ]
+    ConcealConversion μ′ (applyTyCtx χ Δ) (applyStore χ Σ)
+      α′ X′ (applyCoercion χ c) (applyTy χ A) (applyTy χ B)
+apply-conceal-conversion {χ = keep} {μ = μ} {α = α} {X = X} c↓ =
+  μ , α , X , c↓
+apply-conceal-conversion
+    {χ = bind Aχ} {μ = μ} {α = α} {X = X} c↓ =
+  weakenCastᵈ μ , suc α , ⇑ᵗ X ,
+  weaken-conceal-conversion StoreIncl-drop
+    (rename-conceal-conversion TyRenameWf-suc
+      modeRename-suc-weakenCast c↓)
+
+apply-reveal-conversions :
+  ∀ {χs μ Δ Σ α X c A B} →
+  RevealConversion μ Δ Σ α X c A B →
+  ∃[ μ′ ] ∃[ α′ ] ∃[ X′ ]
+    RevealConversion μ′ (applyTyCtxs χs Δ) (applyStores χs Σ)
+      α′ X′ (applyCoercions χs c)
+      (applyTys χs A) (applyTys χs B)
+apply-reveal-conversions {χs = []} {μ = μ} {α = α} {X = X} c↑ =
+  μ , α , X , c↑
+apply-reveal-conversions {χs = χ ∷ χs} c↑
+    with apply-reveal-conversion {χ = χ} c↑
+apply-reveal-conversions {χs = χ ∷ χs} c↑
+    | μ′ , α′ , X′ , c′↑ =
+  apply-reveal-conversions {χs = χs} c′↑
+
+apply-conceal-conversions :
+  ∀ {χs μ Δ Σ α X c A B} →
+  ConcealConversion μ Δ Σ α X c A B →
+  ∃[ μ′ ] ∃[ α′ ] ∃[ X′ ]
+    ConcealConversion μ′ (applyTyCtxs χs Δ) (applyStores χs Σ)
+      α′ X′ (applyCoercions χs c)
+      (applyTys χs A) (applyTys χs B)
+apply-conceal-conversions {χs = []} {μ = μ} {α = α} {X = X} c↓ =
+  μ , α , X , c↓
+apply-conceal-conversions {χs = χ ∷ χs} c↓
+    with apply-conceal-conversion {χ = χ} c↓
+apply-conceal-conversions {χs = χ ∷ χs} c↓
+    | μ′ , α′ , X′ , c′↓ =
+  apply-conceal-conversions {χs = χs} c′↓
+
+------------------------------------------------------------------------
+-- General weak one-step simulation result
+------------------------------------------------------------------------
+
+≡-to-≅ :
+  ∀ {A : Set} {x y : A} →
+  x ≡ y →
+  HE._≅_ x y
+≡-to-≅ refl = HE.refl
+
+subst-to-≅ :
+  ∀ {A : Set} {P : A → Set} {x y : A} →
+  (eq : x ≡ y) →
+  (p : P x) →
+  HE._≅_ (subst P eq p) p
+subst-to-≅ refl p = HE.refl
+
+subst²-to-≅ :
+  ∀ {A B : Set} {P : A → B → Set}
+    {x₀ x₁ : A} {y₀ y₁ : B} →
+  (x₀≡x₁ : x₀ ≡ x₁) →
+  (y₀≡y₁ : y₀ ≡ y₁) →
+  (p : P x₀ y₀) →
+  HE._≅_
+    (subst (P x₁) y₀≡y₁
+      (subst (λ x → P x y₀) x₀≡x₁ p))
+    p
+subst²-to-≅ refl refl p = HE.refl
+
+subst-sym-cancel :
+  ∀ {A : Set} (P : A → Set) {x y : A} →
+  (eq : x ≡ y) →
+  (p : P x) →
+  subst P (sym eq) (subst P eq p) ≡ p
+subst-sym-cancel P refl p = refl
+
+subst-cancel-sym :
+  ∀ {A : Set} (P : A → Set) {x y : A} →
+  (eq : x ≡ y) →
+  (p : P y) →
+  subst P eq (subst P (sym eq) p) ≡ p
+subst-cancel-sym P refl p = refl
+
+record WeakOneStepResult
+    {Φ Δᴸ Δᴿ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (M N′ : Term)
+    (A B : Ty)
+    (χ : StoreChange) : Set₁ where
+  constructor weak-step-result
+  field
+    sourceChanges : StoreChanges
+    targetTailChanges : StoreChanges
+    sourceResult : Term
+    targetResult : Term
+    resultCtx : ImpCtx
+    resultLeftCtx : TyCtx
+    resultRightCtx : TyCtx
+    sourceCtxResult :
+      resultLeftCtx ≡ applyTyCtxs sourceChanges Δᴸ
+    targetCtxResult :
+      resultRightCtx
+        ≡ applyTyCtxs targetTailChanges (applyTyCtx χ Δᴿ)
+    resultStore :
+      StoreImp resultCtx resultLeftCtx resultRightCtx
+    resultSourceType : Ty
+    resultTargetType : Ty
+    sourceTypeResult :
+      resultSourceType ≡ applyTys sourceChanges A
+    targetTypeResult :
+      resultTargetType ≡ applyTys targetTailChanges (applyTy χ B)
+    transportType :
+      ∀ {C D} →
+      Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
+      resultCtx ∣ resultLeftCtx
+        ⊢ applyTys sourceChanges C
+          ⊑ applyTys targetTailChanges (applyTy χ D)
+        ⊣ resultRightCtx
+    transportAllBody :
+      ∀ {C D} →
+      ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+      ∀ᵢᶜ resultCtx ∣ suc resultLeftCtx
+        ⊢ applyTysUnderTyBinders sourceChanges C
+          ⊑ applyTysUnderTyBinders targetTailChanges
+              (applyTyUnderTyBinder χ D)
+        ⊣ suc resultRightCtx
+    transportRightBody :
+      ∀ {C D} →
+      ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+      ⇑ᴿᵢ resultCtx ∣ resultLeftCtx
+        ⊢ applyTys sourceChanges C
+          ⊑ applyTysUnderTyBinders targetTailChanges
+              (applyTyUnderTyBinder χ D)
+        ⊣ suc resultRightCtx
+    resultType :
+      resultCtx ∣ resultLeftCtx
+        ⊢ resultSourceType ⊑ resultTargetType
+        ⊣ resultRightCtx
+    sourceCatchup : M —↠[ sourceChanges ] sourceResult
+    targetTail : N′ —↠[ targetTailChanges ] targetResult
+    sourceStoreResult :
+      leftStoreⁱ resultStore
+        ≡ applyStores sourceChanges (leftStoreⁱ ρ)
+    targetStoreResult :
+      rightStoreⁱ resultStore
+        ≡ applyStores targetTailChanges
+            (applyStore χ (rightStoreⁱ ρ))
+    relatedResults :
+      resultCtx
+        ∣ resultLeftCtx
+        ∣ resultRightCtx
+        ∣ resultStore ∣ []
+        ⊢ᴺ sourceResult ⊑ targetResult
+        ⦂ resultSourceType ⊑ resultTargetType
+        ∶ resultType
+
+open WeakOneStepResult public
+
+record WeakOneStepTransport
+    {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ) : Set₁ where
+  constructor weak-step-transport
+  field
+    transportNo•Terms :
+      ∀ {L L′ C C′ p} →
+      No• L →
+      No• L′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+        ⊢ᴺ L ⊑ L′ ⦂ C ⊑ C′ ∶ p →
+      resultCtx result
+        ∣ resultLeftCtx result
+        ∣ resultRightCtx result
+        ∣ resultStore result ∣ []
+        ⊢ᴺ applyTerms (sourceChanges result) L
+          ⊑ applyTerms (targetTailChanges result) (applyTerm χ L′)
+        ⦂ applyTys (sourceChanges result) C
+          ⊑ applyTys (targetTailChanges result) (applyTy χ C′)
+        ∶ transportType result p
+
+open WeakOneStepTransport public
+
+transportArrowType :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C C′ D D′} →
+  Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ →
+  Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ →
+  resultCtx result ∣ resultLeftCtx result
+    ⊢ applyTys (sourceChanges result) C ⇒
+        applyTys (sourceChanges result) D
+      ⊑ applyTys (targetTailChanges result) (applyTy χ C′) ⇒
+        applyTys (targetTailChanges result) (applyTy χ D′)
+    ⊣ resultRightCtx result
+transportArrowType {χ = χ} result {C′ = C′} {D′ = D′}
+    pC pD =
+  subst
+    (λ T → resultCtx result ∣ resultLeftCtx result
+      ⊢ applyTys (sourceChanges result) _ ⇒
+          applyTys (sourceChanges result) _
+        ⊑ T ⊣ resultRightCtx result)
+    target-eq
+    (subst
+      (λ S → resultCtx result ∣ resultLeftCtx result
+        ⊢ S ⊑ applyTys (targetTailChanges result)
+            (applyTy χ (C′ ⇒ D′))
+          ⊣ resultRightCtx result)
+      (applyTys-⇒ (sourceChanges result) _ _)
+      (transportType result (pC ↦ pD)))
+  where
+  target-eq =
+    trans
+      (cong (applyTys (targetTailChanges result))
+        (applyTys-⇒ (χ ∷ []) C′ D′))
+      (applyTys-⇒ (targetTailChanges result)
+        (applyTy χ C′) (applyTy χ D′))
+
+transportAllType :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C C′} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ →
+  resultCtx result ∣ resultLeftCtx result
+    ⊢ `∀ (applyTysUnderTyBinders
+          (sourceChanges result) C)
+      ⊑ `∀ (applyTysUnderTyBinders
+          (targetTailChanges result)
+          (applyTyUnderTyBinder χ C′))
+    ⊣ resultRightCtx result
+transportAllType {χ = χ} result {C = C} {C′ = C′} q =
+  subst
+    (λ T → resultCtx result ∣ resultLeftCtx result
+      ⊢ `∀ (applyTysUnderTyBinders
+          (sourceChanges result) C)
+        ⊑ T ⊣ resultRightCtx result)
+    target-eq
+    (subst
+      (λ S → resultCtx result ∣ resultLeftCtx result
+        ⊢ S ⊑ applyTys (targetTailChanges result)
+            (applyTy χ (`∀ C′))
+          ⊣ resultRightCtx result)
+      (applyTys-∀ (sourceChanges result) C)
+      (transportType result (∀ⁱ q)))
+  where
+  target-eq =
+    trans
+      (cong (applyTys (targetTailChanges result))
+        (applyTy-∀ χ C′))
+      (applyTys-∀ (targetTailChanges result)
+        (applyTyUnderTyBinder χ C′))
+
+transportType-source-subst-to-raw≅ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C₀ C₁ D} →
+  (eq : C₀ ≡ C₁) →
+  (p : Φ ∣ Δᴸ ⊢ C₀ ⊑ D ⊣ Δᴿ) →
+  HE._≅_
+    (transportType result
+      (subst (λ C → Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ) eq p))
+    (transportType result p)
+transportType-source-subst-to-raw≅ result refl p = HE.refl
+
+transportType-target-subst-to-raw≅ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C D₀ D₁} →
+  (eq : D₀ ≡ D₁) →
+  (p : Φ ∣ Δᴸ ⊢ C ⊑ D₀ ⊣ Δᴿ) →
+  HE._≅_
+    (transportType result
+      (subst (λ D → Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ) eq p))
+    (transportType result p)
+transportType-target-subst-to-raw≅ result refl p = HE.refl
+
+transportArrowType-to-raw≅ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C C′ D D′}
+    (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+    (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+  HE._≅_ (transportArrowType result pC pD)
+    (transportType result (pC ↦ pD))
+transportArrowType-to-raw≅ {χ = χ} result
+    {C = C} {C′ = C′} {D = D} {D′ = D′} pC pD =
+  HE.trans
+    (subst-to-≅
+      {P = λ T → resultCtx result ∣ resultLeftCtx result
+        ⊢ applyTys (sourceChanges result) C ⇒
+            applyTys (sourceChanges result) D
+          ⊑ T ⊣ resultRightCtx result}
+      target-eq source-transport)
+    (subst-to-≅
+      {P = λ S → resultCtx result ∣ resultLeftCtx result
+        ⊢ S ⊑ applyTys (targetTailChanges result)
+            (applyTy χ (C′ ⇒ D′))
+          ⊣ resultRightCtx result}
+      source-eq raw)
+  where
+  raw = transportType result (pC ↦ pD)
+  source-eq = applyTys-⇒ (sourceChanges result) C D
+  source-transport = subst
+    (λ S → resultCtx result ∣ resultLeftCtx result
+      ⊢ S ⊑ applyTys (targetTailChanges result)
+          (applyTy χ (C′ ⇒ D′))
+        ⊣ resultRightCtx result)
+    source-eq raw
+  target-eq = trans
+    (cong (applyTys (targetTailChanges result))
+      (applyTys-⇒ (χ ∷ []) C′ D′))
+    (applyTys-⇒ (targetTailChanges result)
+      (applyTy χ C′) (applyTy χ D′))
+
+transportAllType-to-raw≅ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C C′}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+  HE._≅_ (transportAllType result q)
+    (transportType result (∀ⁱ q))
+transportAllType-to-raw≅ {χ = χ} result
+    {C = C} {C′ = C′} q =
+  HE.trans
+    (subst-to-≅
+      {P = λ T → resultCtx result ∣ resultLeftCtx result
+        ⊢ `∀ (applyTysUnderTyBinders (sourceChanges result) C)
+          ⊑ T ⊣ resultRightCtx result}
+      target-eq source-transport)
+    (subst-to-≅
+      {P = λ S → resultCtx result ∣ resultLeftCtx result
+        ⊢ S ⊑ applyTys (targetTailChanges result)
+            (applyTy χ (`∀ C′))
+          ⊣ resultRightCtx result}
+      source-eq raw)
+  where
+  raw = transportType result (∀ⁱ q)
+  source-eq = applyTys-∀ (sourceChanges result) C
+  source-transport = subst
+    (λ S → resultCtx result ∣ resultLeftCtx result
+      ⊢ S ⊑ applyTys (targetTailChanges result)
+          (applyTy χ (`∀ C′))
+        ⊣ resultRightCtx result)
+    source-eq raw
+  target-eq = trans
+    (cong (applyTys (targetTailChanges result))
+      (applyTy-∀ χ C′))
+    (applyTys-∀ (targetTailChanges result)
+      (applyTyUnderTyBinder χ C′))
+
+transportType-transportArrowType-to-raw≅ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (outer : WeakOneStepResult (resultStore inner)
+      (sourceResult inner) N′
+      (resultSourceType inner) (resultTargetType inner) χ′)
+    {C C′ D D′}
+    (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+    (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+  HE._≅_
+    (transportType outer (transportArrowType inner pC pD))
+    (transportType outer (transportType inner (pC ↦ pD)))
+transportType-transportArrowType-to-raw≅ {χ = χ} inner outer
+    {C = C} {C′ = C′} {D = D} {D′ = D′} pC pD =
+  HE.trans
+    (transportType-target-subst-to-raw≅
+      outer target-eq source-transport)
+    (transportType-source-subst-to-raw≅ outer source-eq raw)
+  where
+  raw = transportType inner (pC ↦ pD)
+  source-eq = applyTys-⇒ (sourceChanges inner) C D
+  source-transport = subst
+    (λ S → resultCtx inner ∣ resultLeftCtx inner
+      ⊢ S ⊑ applyTys (targetTailChanges inner)
+          (applyTy χ (C′ ⇒ D′))
+        ⊣ resultRightCtx inner)
+    source-eq raw
+  target-eq = trans
+    (cong (applyTys (targetTailChanges inner))
+      (applyTys-⇒ (χ ∷ []) C′ D′))
+    (applyTys-⇒ (targetTailChanges inner)
+      (applyTy χ C′) (applyTy χ D′))
+
+transportType-transportAllType-to-raw≅ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (inner : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (outer : WeakOneStepResult (resultStore inner)
+      (sourceResult inner) N′
+      (resultSourceType inner) (resultTargetType inner) χ′)
+    {C C′}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+  HE._≅_
+    (transportType outer (transportAllType inner q))
+    (transportType outer (transportType inner (∀ⁱ q)))
+transportType-transportAllType-to-raw≅ {χ = χ} inner outer
+    {C = C} {C′ = C′} q =
+  HE.trans
+    (transportType-target-subst-to-raw≅
+      outer target-eq source-transport)
+    (transportType-source-subst-to-raw≅ outer source-eq raw)
+  where
+  raw = transportType inner (∀ⁱ q)
+  source-eq = applyTys-∀ (sourceChanges inner) C
+  source-transport = subst
+    (λ S → resultCtx inner ∣ resultLeftCtx inner
+      ⊢ S ⊑ applyTys (targetTailChanges inner)
+          (applyTy χ (`∀ C′))
+        ⊣ resultRightCtx inner)
+    source-eq raw
+  target-eq = trans
+    (cong (applyTys (targetTailChanges inner))
+      (applyTy-∀ χ C′))
+    (applyTys-∀ (targetTailChanges inner)
+      (applyTyUnderTyBinder χ C′))
+
+record WeakOneStepTypeCoherence
+    {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ) : Set₁ where
+  constructor weak-step-type-coherence
+  field
+    transportArrowCoherent :
+      ∀ {C C′ D D′}
+        (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+        (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+      transportArrowType result pC pD ≡
+        transportType result pC ↦ transportType result pD
+    transportAllCoherent :
+      ∀ {C C′}
+        (q : ∀ᵢᶜ Φ ∣ suc Δᴸ
+          ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+      transportAllType result q ≡
+        ∀ⁱ (transportAllBody result q)
+
+open WeakOneStepTypeCoherence public
+
+nu-term-imprecision-transport-typesᵀ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B C D}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ} →
+  (source-eq : A ≡ C) →
+  (target-eq : B ≡ D) →
+  subst (λ T → Φ ∣ Δᴸ ⊢ C ⊑ T ⊣ Δᴿ) target-eq
+    (subst (λ S → Φ ∣ Δᴸ ⊢ S ⊑ B ⊣ Δᴿ) source-eq p)
+    ≡ q →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ C ⊑ D ∶ q
+nu-term-imprecision-transport-typesᵀ
+    refl refl refl M⊑M′ =
+  M⊑M′
+
+nu-term-imprecision-transport-termsᵀ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ N N′ A B p} →
+  M ≡ N →
+  M′ ≡ N′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺ N ⊑ N′ ⦂ A ⊑ B ∶ p
+nu-term-imprecision-transport-termsᵀ refl refl M⊑M′ = M⊑M′
+
+nu-term-imprecisionᵖ-transport-typesᵀ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B C D}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ C ⊑ᵖ D ⊣ Δᴿ} →
+  (source-eq : A ≡ C) →
+  (target-eq : B ≡ D) →
+  subst (λ T → Φ ∣ Δᴸ ⊢ C ⊑ᵖ T ⊣ Δᴿ) target-eq
+    (subst (λ S → Φ ∣ Δᴸ ⊢ S ⊑ᵖ B ⊣ Δᴿ) source-eq p)
+    ≡ q →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᵖ M ⊑ M′ ⦂ A ⊑ᵖ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᵖ M ⊑ M′ ⦂ C ⊑ᵖ D ∶ q
+nu-term-imprecisionᵖ-transport-typesᵀ
+    refl refl refl M⊑M′ =
+  M⊑M′
+
+nu-term-imprecisionᵖ-transport-termsᵀ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ N N′ A B p} →
+  M ≡ N →
+  M′ ≡ N′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᵖ M ⊑ M′ ⦂ A ⊑ᵖ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᵖ N ⊑ N′ ⦂ A ⊑ᵖ B ∶ p
+nu-term-imprecisionᵖ-transport-termsᵀ refl refl M⊑M′ = M⊑M′
+
+rename-assm²-idᵢ :
+  ∀ {Φ a} →
+  a ∈ Φ →
+  rename-assm²ᵢ (λ X → X) (λ X → X) a ∈ Φ
+rename-assm²-idᵢ {a = X ˣ⊑★} a∈ = a∈
+rename-assm²-idᵢ {a = X ˣ⊑ˣ Y} a∈ = a∈
+
+⊑-rename-idᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ
+⊑-rename-idᵢ {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {A = A} {B = B} p =
+  subst
+    (λ T → Φ ∣ Δᴸ ⊢ A ⊑ T ⊣ Δᴿ)
+    (renameᵗ-id B)
+    (subst
+      (λ S → Φ ∣ Δᴸ
+        ⊢ S ⊑ renameᵗ (λ X → X) B ⊣ Δᴿ)
+      (renameᵗ-id A)
+      (⊑-renameᵗ²ᵢ rename-assm²-idᵢ
+        (λ X<Δ → X<Δ) (λ X<Δ → X<Δ) p))
+
+renameᵗ-ext-id :
+  ∀ A →
+  renameᵗ (extᵗ (λ X → X)) A ≡ A
+renameᵗ-ext-id A =
+  trans
+    (rename-cong
+      (λ { zero → refl
+         ; (suc X) → refl })
+      A)
+    (renameᵗ-id A)
+
+ext-id-pointwise : ∀ X → extᵗ (λ Y → Y) X ≡ X
+ext-id-pointwise zero = refl
+ext-id-pointwise (suc X) = refl
+
+renameᵗᵐ-ext-id : ∀ M → renameᵗᵐ (extᵗ (λ X → X)) M ≡ M
+renameᵗᵐ-ext-id M =
+  trans (renameᵗᵐ-cong ext-id-pointwise M) (renameᵗᵐ-id M)
+
+⊑-rename-id-all-bodyᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ
+⊑-rename-id-all-bodyᵢ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {A = A} {B = B} p =
+  subst
+    (λ T → ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ T ⊣ suc Δᴿ)
+    (renameᵗ-ext-id B)
+    (subst
+      (λ S → ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ S ⊑
+        renameᵗ (extᵗ (λ X → X)) B ⊣ suc Δᴿ)
+      (renameᵗ-ext-id A)
+      (⊑-renameᵗ²ᵢ
+        (rename-assm²-⇑ᵢ rename-assm²-idᵢ)
+        (TyRenameWf-ext (λ X<Δ → X<Δ))
+        (TyRenameWf-ext (λ X<Δ → X<Δ)) p))
+
+transport-arrow-⊑ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ A₀′ A₁′ B₀ B₁ B₀′ B₁′}
+    {p : Φ ∣ Δᴸ ⊢ A₀ ⊑ A₀′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B₀ ⊑ B₀′ ⊣ Δᴿ} →
+  (eqA : A₀ ≡ A₁) → (eqA′ : A₀′ ≡ A₁′) →
+  (eqB : B₀ ≡ B₁) → (eqB′ : B₀′ ≡ B₁′) →
+  subst
+    (λ T → Φ ∣ Δᴸ ⊢ A₁ ⇒ B₁ ⊑ T ⊣ Δᴿ)
+    (cong₂ _⇒_ eqA′ eqB′)
+    (subst
+      (λ S → Φ ∣ Δᴸ ⊢ S ⊑ A₀′ ⇒ B₀′ ⊣ Δᴿ)
+      (cong₂ _⇒_ eqA eqB) (p ↦ q))
+    ≡
+  subst (λ T → Φ ∣ Δᴸ ⊢ A₁ ⊑ T ⊣ Δᴿ) eqA′
+      (subst (λ S → Φ ∣ Δᴸ ⊢ S ⊑ A₀′ ⊣ Δᴿ) eqA p)
+    ↦
+  subst (λ T → Φ ∣ Δᴸ ⊢ B₁ ⊑ T ⊣ Δᴿ) eqB′
+      (subst (λ S → Φ ∣ Δᴸ ⊢ S ⊑ B₀′ ⊣ Δᴿ) eqB q)
+transport-arrow-⊑ᵢ refl refl refl refl = refl
+
+⊑-rename-id-arrowᵢ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′}
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+    (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  ⊑-rename-idᵢ (p ↦ q) ≡ ⊑-rename-idᵢ p ↦ ⊑-rename-idᵢ q
+⊑-rename-id-arrowᵢ {A = A} {A′ = A′} {B = B} {B′ = B′} p q =
+  transport-arrow-⊑ᵢ
+    (renameᵗ-id A) (renameᵗ-id A′)
+    (renameᵗ-id B) (renameᵗ-id B′)
+
+transport-all-⊑ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A₀ A₁ B₀ B₁}
+    {p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A₀ ⊑ B₀ ⊣ suc Δᴿ} →
+  (eqA : A₀ ≡ A₁) → (eqB : B₀ ≡ B₁) →
+  subst
+    (λ T → Φ ∣ Δᴸ ⊢ `∀ A₁ ⊑ T ⊣ Δᴿ)
+    (cong `∀ eqB)
+    (subst
+      (λ S → Φ ∣ Δᴸ ⊢ S ⊑ `∀ B₀ ⊣ Δᴿ)
+      (cong `∀ eqA) (∀ⁱ p))
+    ≡ ∀ⁱ
+      (subst (λ T → ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A₁ ⊑ T ⊣ suc Δᴿ)
+        eqB
+        (subst
+          (λ S → ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ S ⊑ B₀ ⊣ suc Δᴿ)
+          eqA p))
+transport-all-⊑ᵢ refl refl = refl
+
+transport-ν-⊑ᵢ :
+  ∀ {Φ Δᴸ Δᴿ C₀ C₁ B}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ C₀ ⊑ B ⊣ Δᴿ} →
+  (eqC : C₀ ≡ C₁) →
+  (occ : occurs zero C₀ ≡ true) →
+  subst
+    (λ S → Φ ∣ Δᴸ ⊢ S ⊑ B ⊣ Δᴿ)
+    (cong `∀ eqC) (ν occ p)
+  ≡ ν
+      (trans (sym (cong (occurs zero) eqC)) occ)
+      (subst
+        (λ S → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+          ∣ suc Δᴸ ⊢ S ⊑ B ⊣ Δᴿ)
+        eqC p)
+transport-ν-⊑ᵢ refl occ = refl
+
+equality-proof-unique :
+  ∀ {A : Set} {x y : A}
+    (p q : x ≡ y) →
+  p ≡ q
+equality-proof-unique refl refl = refl
+
+⊑-rename-id-allᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B}
+    (p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ) →
+  ⊑-rename-idᵢ (∀ⁱ p) ≡ ∀ⁱ (⊑-rename-id-all-bodyᵢ p)
+⊑-rename-id-allᵢ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {A = A} {B = B} p =
+  trans outer-equalities
+    (transport-all-⊑ᵢ (renameᵗ-ext-id A) (renameᵗ-ext-id B))
+  where
+  outer-equalities =
+    cong₂
+      (λ eqA eqB →
+        subst (λ T → Φ ∣ Δᴸ ⊢ `∀ A ⊑ T ⊣ Δᴿ) eqB
+          (subst (λ S → Φ ∣ Δᴸ ⊢ S ⊑
+            renameᵗ (λ X → X) (`∀ B) ⊣ Δᴿ) eqA
+            (⊑-renameᵗ²ᵢ rename-assm²-idᵢ
+              (λ X<Δ → X<Δ) (λ X<Δ → X<Δ) (∀ⁱ p))))
+      (equality-proof-unique
+        (renameᵗ-id (`∀ A)) (cong `∀ (renameᵗ-ext-id A)))
+      (equality-proof-unique
+        (renameᵗ-id (`∀ B)) (cong `∀ (renameᵗ-ext-id B)))
+
+weak-result-transport-arrow-termsᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A A′ B B′ χ L L′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A A′ χ) →
+  WeakOneStepTransport result →
+  WeakOneStepTypeCoherence result →
+  No• L →
+  No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′
+    ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB →
+  resultCtx result
+    ∣ resultLeftCtx result
+    ∣ resultRightCtx result
+    ∣ resultStore result ∣ []
+    ⊢ᴺ applyTerms (sourceChanges result) L
+      ⊑ applyTerms (targetTailChanges result) (applyTerm χ L′)
+    ⦂ applyTys (sourceChanges result) A ⇒
+        applyTys (sourceChanges result) B
+      ⊑ applyTys (targetTailChanges result) (applyTy χ A′) ⇒
+        applyTys (targetTailChanges result) (applyTy χ B′)
+    ∶ transportType result pA ↦ transportType result pB
+weak-result-transport-arrow-termsᵀ
+    {A′ = A′} {B′ = B′} {χ = χ}
+    result transport coherence noL noL′ L⊑L′ =
+  nu-term-imprecision-transport-typesᵀ
+    (applyTys-⇒ (sourceChanges result) _ _)
+    target-eq
+    (transportArrowCoherent coherence _ _)
+    (transportNo•Terms transport noL noL′ L⊑L′)
+  where
+  target-eq =
+    trans
+      (cong (applyTys (targetTailChanges result))
+        (applyTys-⇒ (χ ∷ []) A′ B′))
+      (applyTys-⇒ (targetTailChanges result)
+        (applyTy χ A′) (applyTy χ B′))
+
+weak-one-step-reindexᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C D}
+    {r : resultCtx result ∣ resultLeftCtx result
+      ⊢ C ⊑ D ⊣ resultRightCtx result} →
+  C ≡ applyTys (sourceChanges result) A →
+  D ≡ applyTys (targetTailChanges result) (applyTy χ B) →
+  resultCtx result
+    ∣ resultLeftCtx result
+    ∣ resultRightCtx result
+    ∣ resultStore result ∣ []
+    ⊢ᴺ sourceResult result ⊑ targetResult result
+    ⦂ C ⊑ D ∶ r →
+  WeakOneStepResult ρ M N′ A B χ
+weak-one-step-reindexᵀ result source-eq target-eq related =
+  record
+    { sourceChanges = sourceChanges result
+    ; targetTailChanges = targetTailChanges result
+    ; sourceResult = sourceResult result
+    ; targetResult = targetResult result
+    ; resultCtx = resultCtx result
+    ; resultLeftCtx = resultLeftCtx result
+    ; resultRightCtx = resultRightCtx result
+    ; sourceCtxResult = sourceCtxResult result
+    ; targetCtxResult = targetCtxResult result
+    ; resultStore = resultStore result
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = source-eq
+    ; targetTypeResult = target-eq
+    ; transportType = transportType result
+    ; transportAllBody = transportAllBody result
+    ; transportRightBody = transportRightBody result
+    ; resultType = _
+    ; sourceCatchup = sourceCatchup result
+    ; targetTail = targetTail result
+    ; sourceStoreResult = sourceStoreResult result
+    ; targetStoreResult = targetStoreResult result
+    ; relatedResults = related
+    }
+
+weak-one-step-reindex-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C D}
+    {r : resultCtx result ∣ resultLeftCtx result
+      ⊢ C ⊑ D ⊣ resultRightCtx result}
+    (source-eq : C ≡ applyTys (sourceChanges result) A)
+    (target-eq :
+      D ≡ applyTys (targetTailChanges result) (applyTy χ B))
+    (related : resultCtx result
+      ∣ resultLeftCtx result
+      ∣ resultRightCtx result
+      ∣ resultStore result ∣ []
+      ⊢ᴺ sourceResult result ⊑ targetResult result
+      ⦂ C ⊑ D ∶ r) →
+  WeakOneStepTransport result →
+  WeakOneStepTransport
+    (weak-one-step-reindexᵀ
+      result source-eq target-eq related)
+weak-one-step-reindex-preserves-transportᵀ
+    result source-eq target-eq related transport =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-reindex-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ)
+    {C D}
+    {r : resultCtx result ∣ resultLeftCtx result
+      ⊢ C ⊑ D ⊣ resultRightCtx result}
+    (source-eq : C ≡ applyTys (sourceChanges result) A)
+    (target-eq :
+      D ≡ applyTys (targetTailChanges result) (applyTy χ B))
+    (related : resultCtx result
+      ∣ resultLeftCtx result
+      ∣ resultRightCtx result
+      ∣ resultStore result ∣ []
+      ⊢ᴺ sourceResult result ⊑ targetResult result
+      ⦂ C ⊑ D ∶ r) →
+  WeakOneStepTypeCoherence result →
+  WeakOneStepTypeCoherence
+    (weak-one-step-reindexᵀ
+      result source-eq target-eq related)
+weak-one-step-reindex-preserves-type-coherenceᵀ
+    result source-eq target-eq related coherence =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+data WeakOneStepOutcome
+    {Φ Δᴸ Δᴿ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (M N′ : Term)
+    (A B : Ty)
+    (χ : StoreChange) : Set₁ where
+  outcome-related :
+    (result : WeakOneStepResult ρ M N′ A B χ) →
+    WeakOneStepTransport result →
+    WeakOneStepTypeCoherence result →
+    WeakOneStepOutcome ρ M N′ A B χ
+
+  outcome-source-blame : ∀ {χs} →
+    M —↠[ χs ] blame →
+    WeakOneStepOutcome ρ M N′ A B χ
+
+record WeakOneStepIndexedResult
+    {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) : Set₁ where
+  constructor weak-indexed-result
+  field
+    weakIndexedResult : WeakOneStepResult ρ M N′ A B χ
+    canonicalIndexedResults :
+      resultCtx weakIndexedResult
+        ∣ resultLeftCtx weakIndexedResult
+        ∣ resultRightCtx weakIndexedResult
+        ∣ resultStore weakIndexedResult ∣ []
+        ⊢ᴺ sourceResult weakIndexedResult
+          ⊑ targetResult weakIndexedResult
+        ⦂ applyTys (sourceChanges weakIndexedResult) A
+          ⊑ applyTys (targetTailChanges weakIndexedResult)
+              (applyTy χ B)
+        ∶ transportType weakIndexedResult p
+
+open WeakOneStepIndexedResult public
+
+weak-one-step-index-resultᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M N′ A B χ) →
+  subst
+    (λ T → resultCtx result ∣ resultLeftCtx result
+      ⊢ applyTys (sourceChanges result) A
+        ⊑ T ⊣ resultRightCtx result)
+    (targetTypeResult result)
+    (subst
+      (λ S → resultCtx result ∣ resultLeftCtx result
+        ⊢ S ⊑ resultTargetType result
+        ⊣ resultRightCtx result)
+      (sourceTypeResult result)
+      (resultType result))
+    ≡ transportType result p →
+  WeakOneStepIndexedResult p
+weak-one-step-index-resultᵀ result type-eq =
+  weak-indexed-result result
+    (nu-term-imprecision-transport-typesᵀ
+      (sourceTypeResult result)
+      (targetTypeResult result)
+      type-eq
+      (relatedResults result))
+
+data WeakOneStepIndexedOutcome
+    {Φ Δᴸ Δᴿ M N′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) : Set₁ where
+  indexed-outcome-related :
+    (result : WeakOneStepIndexedResult
+      {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p) →
+    WeakOneStepTransport (weakIndexedResult result) →
+    WeakOneStepTypeCoherence (weakIndexedResult result) →
+    WeakOneStepIndexedOutcome p
+
+  indexed-outcome-source-blame : ∀ {χs} →
+    M —↠[ χs ] blame →
+    WeakOneStepIndexedOutcome p
+
+value-source-multistep-refl :
+  ∀ {χs V N} →
+  Value V →
+  V —↠[ χs ] N →
+  (χs ≡ []) × (N ≡ V)
+value-source-multistep-refl vV ↠-refl = refl , refl
+value-source-multistep-refl vV (↠-step V→L L↠N) =
+  ⊥-elim (value-no-step vV V→L)
+
+source-value-indexed-outcome-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ V N′ A B χ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value V →
+  WeakOneStepIndexedOutcome
+    {M = V} {N′ = N′} {χ = χ} {ρ = ρ} p →
+  ∃[ result ]
+    WeakOneStepTransport (weakIndexedResult result) ×
+    WeakOneStepTypeCoherence (weakIndexedResult result) ×
+    sourceChanges (weakIndexedResult result) ≡ [] ×
+    sourceResult (weakIndexedResult result) ≡ V
+source-value-indexed-outcome-relatedᵀ vV
+    (indexed-outcome-related result transport coherence)
+    with value-source-multistep-refl vV
+      (sourceCatchup (weakIndexedResult result))
+source-value-indexed-outcome-relatedᵀ vV
+    (indexed-outcome-related result transport coherence)
+    | refl , result-eq =
+  result , transport , coherence , refl , result-eq
+source-value-indexed-outcome-relatedᵀ vV
+    (indexed-outcome-source-blame source↠)
+    with value-source-multistep-refl vV source↠
+source-value-indexed-outcome-relatedᵀ vV
+    (indexed-outcome-source-blame source↠)
+    | changes-eq , result-eq =
+  ⊥-elim (value-blame-impossible
+    (subst Value (sym result-eq) vV))
+  where
+  value-blame-impossible : Value blame → ⊥
+  value-blame-impossible ()
+
+record WeakOneStepAllResult
+    {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  constructor weak-all-result
+  field
+    weakResult : WeakOneStepResult ρ N N₁′ (`∀ C) (`∀ C′) χ
+    canonicalAllResults :
+      resultCtx weakResult
+        ∣ resultLeftCtx weakResult
+        ∣ resultRightCtx weakResult
+        ∣ resultStore weakResult ∣ []
+        ⊢ᴺ sourceResult weakResult ⊑ targetResult weakResult
+        ⦂ `∀
+            (applyTysUnderTyBinders (sourceChanges weakResult) C)
+          ⊑ `∀
+              (applyTysUnderTyBinders (targetTailChanges weakResult)
+                (applyTyUnderTyBinder χ C′))
+        ∶ ∀ⁱ (transportAllBody weakResult q)
+
+open WeakOneStepAllResult public
+
+data WeakOneStepAllOutcome
+    {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  all-outcome-related :
+    (result : WeakOneStepAllResult
+      {N = N} {N₁′ = N₁′} {χ = χ} {ρ = ρ} q) →
+    WeakOneStepTransport (weakResult result) →
+    WeakOneStepTypeCoherence (weakResult result) →
+    WeakOneStepAllOutcome q
+
+  all-outcome-source-blame : ∀ {χs} →
+    N —↠[ χs ] blame →
+    WeakOneStepAllOutcome q
+
+record WeakOneStepArrowResult
+    {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+    (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) : Set₁ where
+  constructor weak-arrow-result
+  field
+    weakArrowResult :
+      WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ
+    canonicalArrowResults :
+      resultCtx weakArrowResult
+        ∣ resultLeftCtx weakArrowResult
+        ∣ resultRightCtx weakArrowResult
+        ∣ resultStore weakArrowResult ∣ []
+        ⊢ᴺ sourceResult weakArrowResult
+          ⊑ targetResult weakArrowResult
+        ⦂ applyTys (sourceChanges weakArrowResult) A ⇒
+            applyTys (sourceChanges weakArrowResult) B
+          ⊑ applyTys (targetTailChanges weakArrowResult)
+              (applyTy χ A′) ⇒
+            applyTys (targetTailChanges weakArrowResult)
+              (applyTy χ B′)
+        ∶ transportType weakArrowResult pA ↦
+            transportType weakArrowResult pB
+
+open WeakOneStepArrowResult public
+
+data WeakOneStepArrowOutcome
+    {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+    (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) : Set₁ where
+  arrow-outcome-related :
+    (result : WeakOneStepArrowResult
+      {L = L} {L₁′ = L₁′} {χ = χ} {ρ = ρ} pA pB) →
+    WeakOneStepTransport (weakArrowResult result) →
+    WeakOneStepTypeCoherence (weakArrowResult result) →
+    WeakOneStepArrowOutcome pA pB
+
+  arrow-outcome-source-blame : ∀ {χs} →
+    L —↠[ χs ] blame →
+    WeakOneStepArrowOutcome pA pB
+
+forget-weak-indexed-outcome :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepIndexedOutcome
+    {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p →
+  WeakOneStepOutcome ρ M N′ A B χ
+forget-weak-indexed-outcome
+    (indexed-outcome-related result transport coherence) =
+  outcome-related (weakIndexedResult result) transport coherence
+forget-weak-indexed-outcome
+    (indexed-outcome-source-blame source↠) =
+  outcome-source-blame source↠
+
+forget-weak-all-outcome :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N₁′} {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ N N₁′ (`∀ C) (`∀ C′) χ
+forget-weak-all-outcome
+    (all-outcome-related result transport coherence) =
+  outcome-related (weakResult result) transport coherence
+forget-weak-all-outcome
+    (all-outcome-source-blame source↠) =
+  outcome-source-blame source↠
+
+forget-weak-arrow-outcome :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepArrowOutcome
+    {L = L} {L₁′ = L₁′} {χ = χ} {ρ = ρ} pA pB →
+  WeakOneStepOutcome ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ
+forget-weak-arrow-outcome
+    (arrow-outcome-related result transport coherence) =
+  outcome-related (weakArrowResult result) transport coherence
+forget-weak-arrow-outcome
+    (arrow-outcome-source-blame source↠) =
+  outcome-source-blame source↠
+
+weak-indexed-arrow-resultᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (indexed : WeakOneStepIndexedResult
+    {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} (pA ↦ pB)) →
+  WeakOneStepTypeCoherence (weakIndexedResult indexed) →
+  WeakOneStepArrowResult pA pB
+weak-indexed-arrow-resultᵀ
+    {A′ = A′} {B′ = B′} {χ = χ} indexed coherence =
+  weak-arrow-result base canonical
+  where
+  base = weakIndexedResult indexed
+
+  target-eq =
+    trans
+      (cong (applyTys (targetTailChanges base))
+        (applyTys-⇒ (χ ∷ []) A′ B′))
+      (applyTys-⇒ (targetTailChanges base)
+        (applyTy χ A′) (applyTy χ B′))
+
+  canonical =
+    nu-term-imprecision-transport-typesᵀ
+      (applyTys-⇒ (sourceChanges base) _ _)
+      target-eq
+      (transportArrowCoherent coherence _ _)
+      (canonicalIndexedResults indexed)
+
+weak-indexed-arrow-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepIndexedOutcome
+    {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} (pA ↦ pB) →
+  WeakOneStepArrowOutcome pA pB
+weak-indexed-arrow-outcomeᵀ
+    (indexed-outcome-related indexed transport coherence) =
+  arrow-outcome-related
+    (weak-indexed-arrow-resultᵀ indexed coherence)
+    transport coherence
+weak-indexed-arrow-outcomeᵀ
+    (indexed-outcome-source-blame source↠) =
+  arrow-outcome-source-blame source↠
+
+weak-indexed-all-resultᵀ :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (indexed : WeakOneStepIndexedResult
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} (∀ⁱ q)) →
+  WeakOneStepTypeCoherence (weakIndexedResult indexed) →
+  WeakOneStepAllResult q
+weak-indexed-all-resultᵀ {C′ = C′} {χ = χ} indexed coherence =
+  weak-all-result base canonical
+  where
+  base = weakIndexedResult indexed
+
+  target-eq =
+    trans
+      (cong (applyTys (targetTailChanges base))
+        (applyTy-∀ χ C′))
+      (applyTys-∀ (targetTailChanges base)
+        (applyTyUnderTyBinder χ C′))
+
+  canonical =
+    nu-term-imprecision-transport-typesᵀ
+      (applyTys-∀ (sourceChanges base) _)
+      target-eq
+      (transportAllCoherent coherence _)
+      (canonicalIndexedResults indexed)
+
+weak-indexed-all-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ C C′ χ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} (∀ⁱ q) →
+  WeakOneStepAllOutcome q
+weak-indexed-all-outcomeᵀ
+    (indexed-outcome-related indexed transport coherence) =
+  all-outcome-related
+    (weak-indexed-all-resultᵀ indexed coherence)
+    transport coherence
+weak-indexed-all-outcomeᵀ
+    (indexed-outcome-source-blame source↠) =
+  all-outcome-source-blame source↠
+
+record LeftSilentInvariant
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M V′ A B keep) : Set₁ where
+  constructor left-silent-invariant
+  field
+    targetTailIsEmpty : targetTailChanges result ≡ []
+    targetIsUnchanged : targetResult result ≡ V′
+
+open LeftSilentInvariant public
+
+weak-result-right-wf-silent :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : WeakOneStepResult ρ M V′ A B keep) →
+  LeftSilentInvariant result →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  StoreWf (resultRightCtx result) (rightStoreⁱ (resultStore result))
+weak-result-right-wf-silent result
+    (left-silent-invariant refl target-eq) wfΣ′ =
+  subst
+    (λ Δ → StoreWf Δ (rightStoreⁱ (resultStore result)))
+    (sym (targetCtxResult result))
+    (subst
+      (StoreWf _)
+      (sym (targetStoreResult result)) wfΣ′)
+
+record LeftCatchupInvariant
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result : WeakOneStepResult ρ M V′ A B keep) : Set₁ where
+  constructor left-catchup-invariant
+  field
+    silentInvariant : LeftSilentInvariant result
+    sourceIsValueOrBlame :
+      (Value (sourceResult result) × No• (sourceResult result)) ⊎
+      sourceResult result ≡ blame
+
+open LeftCatchupInvariant public
+
+record LeftSilentResult
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} : Set₁ where
+  constructor left-silent
+  field
+    silentResult : WeakOneStepResult ρ M V′ A B keep
+    resultIsLeftSilent : LeftSilentInvariant silentResult
+
+open LeftSilentResult public
+
+record LeftCatchupResult
+    {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} : Set₁ where
+  constructor left-catchup
+  field
+    catchupResult : WeakOneStepResult ρ M V′ A B keep
+    catchupInvariant : LeftCatchupInvariant catchupResult
+
+open LeftCatchupResult public
+
+forget-left-catchup :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  LeftCatchupResult
+    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ} →
+  LeftSilentResult
+    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ}
+forget-left-catchup
+    (left-catchup result (left-catchup-invariant silent final)) =
+  left-silent result silent
+
+record LeftCatchupAllResult
+    {Φ Δᴸ Δᴿ N V′ C C′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  constructor left-all-catchup
+  field
+    catchupAllResult :
+      WeakOneStepAllResult
+        {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q
+    catchupAllInvariant :
+      LeftCatchupInvariant (weakResult catchupAllResult)
+
+open LeftCatchupAllResult public
+
+record LeftCatchupIndexedResult
+    {Φ Δᴸ Δᴿ N V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) : Set₁ where
+  constructor left-indexed-catchup
+  field
+    catchupIndexedResult :
+      WeakOneStepIndexedResult
+        {M = N} {N′ = V′} {χ = keep} {ρ = ρ} p
+    catchupIndexedInvariant :
+      LeftCatchupInvariant
+        (weakIndexedResult catchupIndexedResult)
+    catchupIndexedTransport :
+      WeakOneStepTransport
+        (weakIndexedResult catchupIndexedResult)
+    catchupIndexedCoherence :
+      WeakOneStepTypeCoherence
+        (weakIndexedResult catchupIndexedResult)
+
+open LeftCatchupIndexedResult public
+
+record LeftSilentIndexedResult
+    {Φ Δᴸ Δᴿ N V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) : Set₁ where
+  constructor left-silent-indexed
+  field
+    silentIndexedResult :
+      WeakOneStepIndexedResult
+        {M = N} {N′ = V′} {χ = keep} {ρ = ρ} p
+    silentIndexedInvariant :
+      LeftSilentInvariant
+        (weakIndexedResult silentIndexedResult)
+    silentIndexedRuntime :
+      RuntimeOK
+        (sourceResult (weakIndexedResult silentIndexedResult))
+    silentIndexedTransport :
+      WeakOneStepTransport
+        (weakIndexedResult silentIndexedResult)
+    silentIndexedCoherence :
+      WeakOneStepTypeCoherence
+        (weakIndexedResult silentIndexedResult)
+
+open LeftSilentIndexedResult public
+
+data LeftCatchupIndexedProgress
+    {Φ Δᴸ Δᴿ N V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) : Set₁ where
+  left-progress-done :
+    LeftCatchupIndexedResult
+      {N = N} {V′ = V′} {ρ = ρ} p →
+    LeftCatchupIndexedProgress p
+
+  left-progress-continue :
+    LeftSilentIndexedResult
+      {N = N} {V′ = V′} {ρ = ρ} p →
+    LeftCatchupIndexedProgress p
+
+record LeftCatchupIndexedAllResult
+    {Φ Δᴸ Δᴿ N V′ C C′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) : Set₁ where
+  constructor left-indexed-all-catchup
+  field
+    catchupIndexedAllResult :
+      WeakOneStepIndexedResult
+        {M = N} {N′ = V′} {χ = keep} {ρ = ρ} (∀ⁱ q)
+    catchupIndexedAllInvariant :
+      LeftCatchupInvariant
+        (weakIndexedResult catchupIndexedAllResult)
+    catchupIndexedAllTransport :
+      WeakOneStepTransport
+        (weakIndexedResult catchupIndexedAllResult)
+    catchupIndexedAllCoherence :
+      WeakOneStepTypeCoherence
+        (weakIndexedResult catchupIndexedAllResult)
+
+open LeftCatchupIndexedAllResult public
+
+generalize-left-indexed-all-catchup :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ} (∀ⁱ q)
+generalize-left-indexed-all-catchup
+    (left-indexed-all-catchup indexed invariant
+      transport coherence) =
+  left-indexed-catchup indexed invariant transport coherence
+
+specialize-left-indexed-all-catchup :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ} (∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q
+specialize-left-indexed-all-catchup
+    (left-indexed-catchup indexed invariant transport coherence) =
+  left-indexed-all-catchup indexed invariant transport coherence
+
+forget-left-indexed-all-catchup :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q →
+  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q
+forget-left-indexed-all-catchup catchup =
+  left-all-catchup
+    (weak-indexed-all-resultᵀ
+      (catchupIndexedAllResult catchup)
+      (catchupIndexedAllCoherence catchup))
+    (catchupIndexedAllInvariant catchup)
+
+forget-left-all-catchup :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q →
+  LeftCatchupResult {M = N} {V′ = V′} {ρ = ρ}
+forget-left-all-catchup (left-all-catchup result invariant) =
+  left-catchup (weakResult result) invariant
+
+weak-result-source-all :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ C B′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  ∃[ q′ ]
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ `∀ (applyTysUnderTyBinders (sourceChanges inner) C)
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ q′)
+weak-result-source-all {C = C} inner =
+  subst
+    (λ T → ∃[ q′ ]
+      (resultCtx inner
+        ∣ resultLeftCtx inner
+        ∣ resultRightCtx inner
+        ∣ resultStore inner ∣ []
+        ⊢ᴺ sourceResult inner ⊑ targetResult inner
+        ⦂ `∀ (applyTysUnderTyBinders (sourceChanges inner) C)
+          ⊑ T ∶ q′))
+    (targetTypeResult inner)
+    (subst
+      (λ S → ∃[ q′ ]
+        (resultCtx inner
+          ∣ resultLeftCtx inner
+          ∣ resultRightCtx inner
+          ∣ resultStore inner ∣ []
+          ⊢ᴺ sourceResult inner ⊑ targetResult inner
+          ⦂ S ⊑ resultTargetType inner ∶ q′))
+      (trans (sourceTypeResult inner)
+        (applyTys-∀ (sourceChanges inner) C))
+      (resultType inner , relatedResults inner))
+
+weak-result-target-all :
+  ∀ {Φ Δᴸ Δᴿ N N₁′ B C′ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  ∃[ q′ ]
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) B
+        ⊑ `∀
+            (applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C′))
+      ∶ q′)
+weak-result-target-all {C′ = C′} {χ = χ} inner =
+  subst
+    (λ T → ∃[ q′ ]
+      (resultCtx inner
+        ∣ resultLeftCtx inner
+        ∣ resultRightCtx inner
+        ∣ resultStore inner ∣ []
+        ⊢ᴺ sourceResult inner ⊑ targetResult inner
+        ⦂ applyTys (sourceChanges inner) _ ⊑ T ∶ q′))
+    (trans (targetTypeResult inner)
+      (trans
+        (cong (applyTys (targetTailChanges inner))
+          (applyTy-∀ χ C′))
+        (applyTys-∀ (targetTailChanges inner)
+          (applyTyUnderTyBinder χ C′))))
+    (subst
+      (λ S → ∃[ q′ ]
+        (resultCtx inner
+          ∣ resultLeftCtx inner
+          ∣ resultRightCtx inner
+          ∣ resultStore inner ∣ []
+          ⊢ᴺ sourceResult inner ⊑ targetResult inner
+          ⦂ S ⊑ resultTargetType inner ∶ q′))
+      (sourceTypeResult inner)
+      (resultType inner , relatedResults inner))
+
+weak-result-source-reveal :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y χ A B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (resultLeftCtx inner))
+      ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+        ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+      zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+      (applyCoercionUnderTyBinders (sourceChanges inner) c)
+      (applyTysUnderTyBinders (sourceChanges inner) C)
+      (⇑ᵗ (applyTys (sourceChanges inner) B))
+weak-result-source-reveal {A = A} {B = B} {C = C} {c = c} inner c↑
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} c↑
+weak-result-source-reveal {A = A} {B = B} {C = C} {c = c} inner c↑
+    | μ′ , c′↑ =
+  μ′ ,
+  subst
+    (λ Δ → RevealConversion μ′ (suc Δ)
+      ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+        ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+      zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+      (applyCoercionUnderTyBinders (sourceChanges inner) c)
+      (applyTysUnderTyBinders (sourceChanges inner) C)
+      (⇑ᵗ (applyTys (sourceChanges inner) B)))
+    (sym (sourceCtxResult inner))
+    (subst
+      (λ Σ → RevealConversion μ′
+        (suc (applyTyCtxs (sourceChanges inner) _))
+        ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷ ⟰ᵗ Σ)
+        zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+        (applyCoercionUnderTyBinders (sourceChanges inner) c)
+        (applyTysUnderTyBinders (sourceChanges inner) C)
+        (⇑ᵗ (applyTys (sourceChanges inner) B)))
+      (sym (sourceStoreResult inner)) c′↑)
+
+weak-result-target-reveal :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y A B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (χ : StoreChange) →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) c C (⇑ᵗ B) →
+  ∃[ μ′ ]
+    RevealConversion μ′ (suc (resultRightCtx inner))
+      ((zero ,
+        ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+        ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+      zero
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
+      (applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder χ c))
+      (applyTysUnderTyBinders (targetTailChanges inner)
+        (applyTyUnderTyBinder χ C))
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
+weak-result-target-reveal
+    {A = A} {B = B} {C = C} {c = c} χ inner c↑
+    with apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} c↑
+weak-result-target-reveal
+    {A = A} {B = B} {C = C} {c = c} χ inner c↑
+    | μ′ , c′↑ =
+  μ′ ,
+  subst
+    (λ Δ → RevealConversion μ′ (suc Δ)
+      ((zero ,
+        ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+        ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+      zero
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
+      (applyCoercionUnderTyBinders (targetTailChanges inner)
+        (applyCoercionUnderTyBinder χ c))
+      (applyTysUnderTyBinders (targetTailChanges inner)
+        (applyTyUnderTyBinder χ C))
+      (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B))))
+    (sym (targetCtxResult inner))
+    (subst
+      (λ Σ → RevealConversion μ′
+        (suc (applyTyCtxs (targetTailChanges inner)
+          (applyTyCtx χ _)))
+        ((zero ,
+          ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+          ⟰ᵗ Σ)
+        zero
+        (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ A)))
+        (applyCoercionUnderTyBinders (targetTailChanges inner)
+          (applyCoercionUnderTyBinder χ c))
+        (applyTysUnderTyBinders (targetTailChanges inner)
+          (applyTyUnderTyBinder χ C))
+        (⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B))))
+      (sym (targetStoreResult inner)) c′↑)
+
+weak-result-source-widen-inst :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y χ B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ (instᵈ μ′)
+      ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))) ×
+    (instᵈ μ′ ∣ suc (resultLeftCtx inner)
+      ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
+        ∶ applyTysUnderTyBinders (sourceChanges inner) C
+          ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+weak-result-source-widen-inst
+    {B = B} {C = C} {c = c} inner mode seal★ c⊑
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ c⊑
+weak-result-source-widen-inst
+    {B = B} {C = C} {c = c} inner mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  μ′ , mode′ ,
+  subst
+    (λ Σ → SealModeStore★ (instᵈ μ′) ((zero , ★) ∷ ⟰ᵗ Σ))
+    (sym (sourceStoreResult inner)) seal★′ ,
+  subst
+    (λ Δ → instᵈ μ′ ∣ suc Δ
+      ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
+        ∶ applyTysUnderTyBinders (sourceChanges inner) C
+          ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+    (sym (sourceCtxResult inner))
+    (subst
+      (λ Σ → instᵈ μ′
+        ∣ suc (applyTyCtxs (sourceChanges inner) _)
+        ∣ (zero , ★) ∷ ⟰ᵗ Σ
+        ⊢ applyCoercionUnderTyBinders (sourceChanges inner) c
+          ∶ applyTysUnderTyBinders (sourceChanges inner) C
+            ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+      (sym (sourceStoreResult inner)) c′⊑)
+
+weak-result-target-widen-inst :
+  ∀ {Φ Δᴸ Δᴿ N N′ X Y B C c μ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (χ : StoreChange) →
+  (inner : WeakOneStepResult ρ N N′ X Y χ) →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  ∃[ μ′ ]
+    CastMode μ′ ×
+    SealModeStore★ (instᵈ μ′)
+      ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))) ×
+    (instᵈ μ′ ∣ suc (resultRightCtx inner)
+      ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+          (applyCoercionUnderTyBinder χ c)
+        ∶ applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C)
+          ⊑ ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
+weak-result-target-widen-inst
+    {B = B} {C = C} {c = c} χ inner mode seal★ c⊑
+    with apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode seal★ c⊑
+weak-result-target-widen-inst
+    {B = B} {C = C} {c = c} χ inner mode seal★ c⊑
+    | μ′ , mode′ , seal★′ , c′⊑ =
+  μ′ , mode′ ,
+  subst
+    (λ Σ → SealModeStore★ (instᵈ μ′) ((zero , ★) ∷ ⟰ᵗ Σ))
+    (sym (targetStoreResult inner)) seal★′ ,
+  subst
+    (λ Δ → instᵈ μ′ ∣ suc Δ
+      ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+      ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+          (applyCoercionUnderTyBinder χ c)
+        ∶ applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C)
+          ⊑ ⇑ᵗ (applyTys (targetTailChanges inner) (applyTy χ B)))
+    (sym (targetCtxResult inner))
+    (subst
+      (λ Σ → instᵈ μ′
+        ∣ suc (applyTyCtxs (targetTailChanges inner)
+          (applyTyCtx χ _))
+        ∣ (zero , ★) ∷ ⟰ᵗ Σ
+        ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ c)
+          ∶ applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C)
+            ⊑ ⇑ᵗ
+                (applyTys (targetTailChanges inner) (applyTy χ B)))
+      (sym (targetStoreResult inner)) c′⊑)
+
+lift-store-result :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρ′ ] LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ′
+lift-store-result [] = [] , lift-store-[]
+lift-store-result (store-matched α A β B p ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-matched α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-matched (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+    (⊑-lift∀ᵢ p) ∷ ρ′ ,
+  lift-store-∷ liftρ
+lift-store-result (store-left α A hA ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-left α A hA ∷ ρ)
+    | ρ′ , liftρ =
+  store-left (suc α) (⇑ᵗ A)
+    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ′ ,
+  lift-store-left liftρ
+lift-store-result (store-right β B hB ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-right β B hB ∷ ρ)
+    | ρ′ , liftρ =
+  store-right (suc β) (⇑ᵗ B)
+    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ′ ,
+  lift-store-right liftρ
+lift-store-result (store-link α A β B p ∷ ρ)
+    with lift-store-result ρ
+lift-store-result (store-link α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-link (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+    (⊑-lift∀ᵢ p) ∷ ρ′ ,
+  lift-store-link liftρ
+
+lift-store-left-zero⊥ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp Ψ (suc Δᴸ) (suc Δᴿ)} {A} →
+  LiftStoreⁱ Ψ ρ ρ′ →
+  (zero , A) ∈ leftStoreⁱ ρ′ → ⊥
+lift-store-left-zero⊥ lift-store-[] ()
+lift-store-left-zero⊥ (lift-store-∷ liftρ) (here ())
+lift-store-left-zero⊥ (lift-store-∷ liftρ) (there x∈) =
+  lift-store-left-zero⊥ liftρ x∈
+lift-store-left-zero⊥ (lift-store-left liftρ) (here ())
+lift-store-left-zero⊥ (lift-store-left liftρ) (there x∈) =
+  lift-store-left-zero⊥ liftρ x∈
+lift-store-left-zero⊥ (lift-store-right liftρ) x∈ =
+  lift-store-left-zero⊥ liftρ x∈
+lift-store-left-zero⊥ (lift-store-link liftρ) x∈ =
+  lift-store-left-zero⊥ liftρ x∈
+
+lift-store-right-zero⊥ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp Ψ (suc Δᴸ) (suc Δᴿ)} {B} →
+  LiftStoreⁱ Ψ ρ ρ′ →
+  (zero , B) ∈ rightStoreⁱ ρ′ → ⊥
+lift-store-right-zero⊥ lift-store-[] ()
+lift-store-right-zero⊥ (lift-store-∷ liftρ) (here ())
+lift-store-right-zero⊥ (lift-store-∷ liftρ) (there x∈) =
+  lift-store-right-zero⊥ liftρ x∈
+lift-store-right-zero⊥ (lift-store-left liftρ) x∈ =
+  lift-store-right-zero⊥ liftρ x∈
+lift-store-right-zero⊥ (lift-store-right liftρ) (here ())
+lift-store-right-zero⊥ (lift-store-right liftρ) (there x∈) =
+  lift-store-right-zero⊥ liftρ x∈
+lift-store-right-zero⊥ (lift-store-link liftρ) x∈ =
+  lift-store-right-zero⊥ liftρ x∈
+
+swap01-lift-left-obstruction :
+  ∀ {Φ Ψ Ω Δᴸ Δᴿ Θᴸ Θᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ′ : StoreImp Ω (suc Θᴸ) (suc Θᴿ)} {A} →
+  (suc zero , A) ∈ leftStoreⁱ ρ →
+  LiftStoreⁱ Ω ρ₀ ρ′ →
+  leftStoreⁱ ρ′ ≡ renameStoreᵗ swap01ᵗ (leftStoreⁱ ρ) →
+  ⊥
+swap01-lift-left-obstruction {A = A} x∈ liftρ eq =
+  lift-store-left-zero⊥ liftρ
+    (subst
+      ((zero , renameᵗ swap01ᵗ A) ∈_)
+      (sym eq) (∈-renameStoreᵗ swap01ᵗ x∈))
+
+swap01-lift-right-obstruction :
+  ∀ {Φ Ψ Ω Δᴸ Δᴿ Θᴸ Θᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₀ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ′ : StoreImp Ω (suc Θᴸ) (suc Θᴿ)} {B} →
+  (suc zero , B) ∈ rightStoreⁱ ρ →
+  LiftStoreⁱ Ω ρ₀ ρ′ →
+  rightStoreⁱ ρ′ ≡ renameStoreᵗ swap01ᵗ (rightStoreⁱ ρ) →
+  ⊥
+swap01-lift-right-obstruction {B = B} x∈ liftρ eq =
+  lift-store-right-zero⊥ liftρ
+    (subst
+      ((zero , renameᵗ swap01ᵗ B) ∈_)
+      (sym eq) (∈-renameStoreᵗ swap01ᵗ x∈))
+
+lift-left-store-result :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρ′ ] LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
+lift-left-store-result [] = [] , lift-left-store-[]
+lift-left-store-result (store-matched α A β B p ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-matched α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-matched (suc α) (⇑ᵗ A) β B
+    (⊑-source-liftνᵢ p) ∷ ρ′ ,
+  lift-left-store-∷ liftρ
+lift-left-store-result (store-left α A hA ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-left α A hA ∷ ρ)
+    | ρ′ , liftρ =
+  store-left (suc α) (⇑ᵗ A)
+    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ′ ,
+  lift-left-store-left liftρ
+lift-left-store-result (store-right β B hB ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-right β B hB ∷ ρ)
+    | ρ′ , liftρ =
+  store-right β B hB ∷ ρ′ ,
+  lift-left-store-right liftρ
+lift-left-store-result (store-link α A β B p ∷ ρ)
+    with lift-left-store-result ρ
+lift-left-store-result (store-link α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-link (suc α) (⇑ᵗ A) β B
+    (⊑-source-liftνᵢ p) ∷ ρ′ ,
+  lift-left-store-link liftρ
+
+lift-right-store-result :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρ′ ] LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρ′
+lift-right-store-result [] = [] , lift-right-store-[]
+lift-right-store-result (store-matched α A β B p ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-matched α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-matched α A (suc β) (⇑ᵗ B)
+    (⊑-target-lift-rightᵢ p) ∷ ρ′ ,
+  lift-right-store-∷ liftρ
+lift-right-store-result (store-left α A hA ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-left α A hA ∷ ρ)
+    | ρ′ , liftρ =
+  store-left α A hA ∷ ρ′ ,
+  lift-right-store-left liftρ
+lift-right-store-result (store-right β B hB ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-right β B hB ∷ ρ)
+    | ρ′ , liftρ =
+  store-right (suc β) (⇑ᵗ B)
+    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ′ ,
+  lift-right-store-right liftρ
+lift-right-store-result (store-link α A β B p ∷ ρ)
+    with lift-right-store-result ρ
+lift-right-store-result (store-link α A β B p ∷ ρ)
+    | ρ′ , liftρ =
+  store-link α A (suc β) (⇑ᵗ B)
+    (⊑-target-lift-rightᵢ p) ∷ ρ′ ,
+  lift-right-store-link liftρ
+
+left-right-store-commuteⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ× ]
+    LiftRightStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴸ ρ× ×
+    LiftLeftStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴿ ρ×
+left-right-store-commuteⁱ lift-left-store-[] lift-right-store-[] =
+  [] , lift-right-store-[] , lift-left-store-[]
+left-right-store-commuteⁱ
+    (lift-left-store-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-store-∷ liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-store-∷ liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-matched _ _ _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ ρ× ,
+  lift-right-store-∷ rightᴸ ,
+  lift-left-store-∷ leftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-left liftᴸ)
+    (lift-right-store-left liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-left {hA′ = hAᴸ} liftᴸ)
+    (lift-right-store-left liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-left _ _ hAᴸ ∷ ρ× ,
+  lift-right-store-left rightᴸ ,
+  lift-left-store-left leftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-right liftᴸ)
+    (lift-right-store-right liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-right liftᴸ)
+    (lift-right-store-right {hB′ = hBᴿ} liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-right _ _ hBᴿ ∷ ρ× ,
+  lift-right-store-right rightᴸ ,
+  lift-left-store-right leftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-link {p′ = pᴸ} liftᴸ)
+    (lift-right-store-link liftᴿ)
+    with left-right-store-commuteⁱ liftᴸ liftᴿ
+left-right-store-commuteⁱ
+    (lift-left-store-link {p′ = pᴸ} liftᴸ)
+    (lift-right-store-link liftᴿ)
+    | ρ× , rightᴸ , leftᴿ =
+  store-link _ _ _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ ρ× ,
+  lift-right-store-link rightᴸ ,
+  lift-left-store-link leftᴿ
+
+left-right-ctx-commuteⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ γ× ]
+    LiftRightCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴸ γ× ×
+    LiftLeftCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴿ γ×
+left-right-ctx-commuteⁱ lift-left-ctx-[] lift-right-ctx-[] =
+  [] , lift-right-ctx-[] , lift-left-ctx-[]
+left-right-ctx-commuteⁱ
+    (lift-left-ctx-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-ctx-∷ liftᴿ)
+    with left-right-ctx-commuteⁱ liftᴸ liftᴿ
+left-right-ctx-commuteⁱ
+    (lift-left-ctx-∷ {p′ = pᴸ} liftᴸ)
+    (lift-right-ctx-∷ liftᴿ)
+    | γ× , rightᴸ , leftᴿ =
+  ctx-imp _ _ (⊑-target-lift-rightᵢ pᴸ) ∷ γ× ,
+  lift-right-ctx-∷ rightᴸ ,
+  lift-left-ctx-∷ leftᴿ
+
+⇑ᴸᵢ-⇑ᴿᵢ-commute :
+  ∀ Φ → ⇑ᴸᵢ (⇑ᴿᵢ Φ) ≡ ⇑ᴿᵢ (⇑ᴸᵢ Φ)
+⇑ᴸᵢ-⇑ᴿᵢ-commute [] = refl
+⇑ᴸᵢ-⇑ᴿᵢ-commute ((X ˣ⊑★) ∷ Φ) =
+  cong ((suc X ˣ⊑★) ∷_) (⇑ᴸᵢ-⇑ᴿᵢ-commute Φ)
+⇑ᴸᵢ-⇑ᴿᵢ-commute ((X ˣ⊑ˣ Y) ∷ Φ) =
+  cong ((suc X ˣ⊑ˣ suc Y) ∷_) (⇑ᴸᵢ-⇑ᴿᵢ-commute Φ)
+
+left-right-store-commute-left-lastⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ× ]
+    LiftRightStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴸ ρ× ×
+    LiftLeftStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴿ ρ×
+left-right-store-commute-left-lastⁱ {Φ = Φ} liftᴸ liftᴿ
+    rewrite ⇑ᴸᵢ-⇑ᴿᵢ-commute Φ =
+  left-right-store-commuteⁱ liftᴸ liftᴿ
+
+left-right-ctx-commute-left-lastⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ γ× ]
+    LiftRightCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) γᴸ γ× ×
+    LiftLeftCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) γᴿ γ×
+left-right-ctx-commute-left-lastⁱ {Φ = Φ} liftᴸ liftᴿ
+    rewrite ⇑ᴸᵢ-⇑ᴿᵢ-commute Φ =
+  left-right-ctx-commuteⁱ liftᴸ liftᴿ
+
+left-right-store-factorⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρ× : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      (suc Δᴸ) (suc Δᴿ)} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftRightStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴸ ρ× →
+  ∃[ ρᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ ×
+    LiftLeftStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴿ ρ×
+left-right-store-factorⁱ
+    lift-left-store-[] lift-right-store-[] =
+  [] , lift-right-store-[] , lift-left-store-[]
+left-right-store-factorⁱ
+    (lift-left-store-∷ {p = p} liftᴸ)
+    (lift-right-store-∷ lift×)
+    with left-right-store-factorⁱ liftᴸ lift×
+left-right-store-factorⁱ
+    (lift-left-store-∷ {p = p} liftᴸ)
+    (lift-right-store-∷ lift×)
+    | ρᴿ , right , left =
+  store-matched _ _ _ _ (⊑-target-lift-rightᵢ p) ∷ ρᴿ ,
+  lift-right-store-∷ right , lift-left-store-∷ left
+left-right-store-factorⁱ
+    (lift-left-store-left {hA = hA} liftᴸ)
+    (lift-right-store-left lift×)
+    with left-right-store-factorⁱ liftᴸ lift×
+left-right-store-factorⁱ
+    (lift-left-store-left {hA = hA} liftᴸ)
+    (lift-right-store-left lift×)
+    | ρᴿ , right , left =
+  store-left _ _ hA ∷ ρᴿ ,
+  lift-right-store-left right , lift-left-store-left left
+left-right-store-factorⁱ
+    (lift-left-store-right liftᴸ)
+    (lift-right-store-right {hB′ = hB×} lift×)
+    with left-right-store-factorⁱ liftᴸ lift×
+left-right-store-factorⁱ
+    (lift-left-store-right liftᴸ)
+    (lift-right-store-right {hB′ = hB×} lift×)
+    | ρᴿ , right , left =
+  store-right _ _ hB× ∷ ρᴿ ,
+  lift-right-store-right right , lift-left-store-right left
+left-right-store-factorⁱ
+    (lift-left-store-link {p = p} liftᴸ)
+    (lift-right-store-link lift×)
+    with left-right-store-factorⁱ liftᴸ lift×
+left-right-store-factorⁱ
+    (lift-left-store-link {p = p} liftᴸ)
+    (lift-right-store-link lift×)
+    | ρᴿ , right , left =
+  store-link _ _ _ _ (⊑-target-lift-rightᵢ p) ∷ ρᴿ ,
+  lift-right-store-link right , lift-left-store-link left
+
+left-right-ctx-factorⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ× : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      (suc Δᴸ) (suc Δᴿ)} →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightCtxⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) γᴸ γ× →
+  ∃[ γᴿ ]
+    LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ ×
+    LiftLeftCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) γᴿ γ×
+left-right-ctx-factorⁱ lift-left-ctx-[] lift-right-ctx-[] =
+  [] , lift-right-ctx-[] , lift-left-ctx-[]
+left-right-ctx-factorⁱ
+    (lift-left-ctx-∷ {p = p} liftᴸ)
+    (lift-right-ctx-∷ lift×)
+    with left-right-ctx-factorⁱ liftᴸ lift×
+left-right-ctx-factorⁱ
+    (lift-left-ctx-∷ {p = p} liftᴸ)
+    (lift-right-ctx-∷ lift×)
+    | γᴿ , right , left =
+  ctx-imp _ _ (⊑-target-lift-rightᵢ p) ∷ γᴿ ,
+  lift-right-ctx-∷ right , lift-left-ctx-∷ left
+
+right-store-prefix-factorⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ⁺ᴿ : StoreImp Ψ Δᴸ (suc Δᴿ)} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  LiftRightStoreⁱ Ψ ρ⁺ ρ⁺ᴿ →
+  ∃[ ρ₀ᴿ ]
+    LiftRightStoreⁱ Ψ ρ₀ ρ₀ᴿ × StoreImpPrefix ρ₀ᴿ ρ⁺ᴿ
+right-store-prefix-factorⁱ prefix-reflⁱ liftρ =
+  _ , liftρ , prefix-reflⁱ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-∷ liftρ)
+    with right-store-prefix-factorⁱ prefix liftρ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-∷ liftρ)
+    | ρ₀ᴿ , lift₀ , prefixᴿ =
+  ρ₀ᴿ , lift₀ , prefix-∷ⁱ prefixᴿ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-left liftρ)
+    with right-store-prefix-factorⁱ prefix liftρ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-left liftρ)
+    | ρ₀ᴿ , lift₀ , prefixᴿ =
+  ρ₀ᴿ , lift₀ , prefix-∷ⁱ prefixᴿ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-right liftρ)
+    with right-store-prefix-factorⁱ prefix liftρ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-right liftρ)
+    | ρ₀ᴿ , lift₀ , prefixᴿ =
+  ρ₀ᴿ , lift₀ , prefix-∷ⁱ prefixᴿ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-link liftρ)
+    with right-store-prefix-factorⁱ prefix liftρ
+right-store-prefix-factorⁱ
+    (prefix-∷ⁱ prefix) (lift-right-store-link liftρ)
+    | ρ₀ᴿ , lift₀ , prefixᴿ =
+  ρ₀ᴿ , lift₀ , prefix-∷ⁱ prefixᴿ
+
+⊑-rename-at²ᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ A A′ B B′} →
+  (assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ) →
+  (hτ : TyRenameWf Δᴸ Θᴸ τ) →
+  (hσ : TyRenameWf Δᴿ Θᴿ σ) →
+  A′ ≡ renameᵗ τ A →
+  B′ ≡ renameᵗ σ B →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  Ψ ∣ Θᴸ ⊢ A′ ⊑ B′ ⊣ Θᴿ
+⊑-rename-at²ᵢ assm hτ hσ eqA eqB p =
+  subst (λ T → _ ∣ _ ⊢ _ ⊑ T ⊣ _) (sym eqB)
+    (subst (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ _ _ ⊣ _)
+      (sym eqA) (⊑-renameᵗ²ᵢ assm hτ hσ p))
+
+data RelStoreRenameⁱ
+    {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    (τ σ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Θᴸ τ)
+    (hσ : TyRenameWf Δᴿ Θᴿ σ) :
+    StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ Θᴸ Θᴿ → Set₁ where
+  rel-store-rename-[] :
+    RelStoreRenameⁱ τ σ assm hτ hσ [] []
+
+  rel-store-rename-matched :
+    ∀ {ρ ρ′ α α′ A A′ β β′ B B′ p} →
+    (eqα : α′ ≡ τ α) → (eqA : A′ ≡ renameᵗ τ A) →
+    (eqβ : β′ ≡ σ β) → (eqB : B′ ≡ renameᵗ σ B) →
+    RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+    RelStoreRenameⁱ τ σ assm hτ hσ
+      (store-matched α A β B p ∷ ρ)
+      (store-matched α′ A′ β′ B′
+        (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p) ∷ ρ′)
+
+  rel-store-rename-left :
+    ∀ {ρ ρ′ α α′ A A′ hA hA′} →
+    α′ ≡ τ α → A′ ≡ renameᵗ τ A →
+    RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+    RelStoreRenameⁱ τ σ assm hτ hσ
+      (store-left α A hA ∷ ρ)
+      (store-left α′ A′ hA′ ∷ ρ′)
+
+  rel-store-rename-right :
+    ∀ {ρ ρ′ β β′ B B′ hB hB′} →
+    β′ ≡ σ β → B′ ≡ renameᵗ σ B →
+    RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+    RelStoreRenameⁱ τ σ assm hτ hσ
+      (store-right β B hB ∷ ρ)
+      (store-right β′ B′ hB′ ∷ ρ′)
+
+  rel-store-rename-link :
+    ∀ {ρ ρ′ α α′ A A′ β β′ B B′ p} →
+    (eqα : α′ ≡ τ α) → (eqA : A′ ≡ renameᵗ τ A) →
+    (eqβ : β′ ≡ σ β) → (eqB : B′ ≡ renameᵗ σ B) →
+    RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+    RelStoreRenameⁱ τ σ assm hτ hσ
+      (store-link α A β B p ∷ ρ)
+      (store-link α′ A′ β′ B′
+        (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p) ∷ ρ′)
+
+data RelStoreEmbeddingⁱ
+    {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    (τ σ : Renameᵗ) :
+    StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ Θᴸ Θᴿ → Set₁ where
+  rel-store-embedding-[] :
+    RelStoreEmbeddingⁱ τ σ [] []
+
+  rel-store-embedding-matched :
+    ∀ {ρ ρ′ α α′ A A′ β β′ B B′ p p′} →
+    α′ ≡ τ α → A′ ≡ renameᵗ τ A →
+    β′ ≡ σ β → B′ ≡ renameᵗ σ B →
+    RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+    RelStoreEmbeddingⁱ τ σ
+      (store-matched α A β B p ∷ ρ)
+      (store-matched α′ A′ β′ B′ p′ ∷ ρ′)
+
+  rel-store-embedding-left :
+    ∀ {ρ ρ′ α α′ A A′ hA hA′} →
+    α′ ≡ τ α → A′ ≡ renameᵗ τ A →
+    RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+    RelStoreEmbeddingⁱ τ σ
+      (store-left α A hA ∷ ρ)
+      (store-left α′ A′ hA′ ∷ ρ′)
+
+  rel-store-embedding-right :
+    ∀ {ρ ρ′ β β′ B B′ hB hB′} →
+    β′ ≡ σ β → B′ ≡ renameᵗ σ B →
+    RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+    RelStoreEmbeddingⁱ τ σ
+      (store-right β B hB ∷ ρ)
+      (store-right β′ B′ hB′ ∷ ρ′)
+
+  rel-store-embedding-link :
+    ∀ {ρ ρ′ α α′ A A′ β β′ B B′ p p′} →
+    α′ ≡ τ α → A′ ≡ renameᵗ τ A →
+    β′ ≡ σ β → B′ ≡ renameᵗ σ B →
+    RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+    RelStoreEmbeddingⁱ τ σ
+      (store-link α A β B p ∷ ρ)
+      (store-link α′ A′ β′ B′ p′ ∷ ρ′)
+
+rel-store-rename-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′
+rel-store-rename-embeddingⁱ rel-store-rename-[] =
+  rel-store-embedding-[]
+rel-store-rename-embeddingⁱ
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ) =
+  rel-store-embedding-matched eqα eqA eqβ eqB
+    (rel-store-rename-embeddingⁱ renameρ)
+rel-store-rename-embeddingⁱ
+    (rel-store-rename-left eqα eqA renameρ) =
+  rel-store-embedding-left eqα eqA
+    (rel-store-rename-embeddingⁱ renameρ)
+rel-store-rename-embeddingⁱ
+    (rel-store-rename-right eqβ eqB renameρ) =
+  rel-store-embedding-right eqβ eqB
+    (rel-store-rename-embeddingⁱ renameρ)
+rel-store-rename-embeddingⁱ
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ) =
+  rel-store-embedding-link eqα eqA eqβ eqB
+    (rel-store-rename-embeddingⁱ renameρ)
+
+leftStoreⁱ-rel-embedding :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  leftStoreⁱ ρ′ ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+leftStoreⁱ-rel-embedding rel-store-embedding-[] = refl
+leftStoreⁱ-rel-embedding
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-rel-embedding emb)
+leftStoreⁱ-rel-embedding
+    (rel-store-embedding-left eqα eqA emb) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-rel-embedding emb)
+leftStoreⁱ-rel-embedding (rel-store-embedding-right eqβ eqB emb) =
+  leftStoreⁱ-rel-embedding emb
+leftStoreⁱ-rel-embedding
+    (rel-store-embedding-link eqα eqA eqβ eqB emb) =
+  leftStoreⁱ-rel-embedding emb
+
+rightStoreⁱ-rel-embedding :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  rightStoreⁱ ρ′ ≡ renameStoreᵗ σ (rightStoreⁱ ρ)
+rightStoreⁱ-rel-embedding rel-store-embedding-[] = refl
+rightStoreⁱ-rel-embedding
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb) =
+  cong₂ _∷_ (cong₂ _,_ eqβ eqB) (rightStoreⁱ-rel-embedding emb)
+rightStoreⁱ-rel-embedding (rel-store-embedding-left eqα eqA emb) =
+  rightStoreⁱ-rel-embedding emb
+rightStoreⁱ-rel-embedding
+    (rel-store-embedding-right eqβ eqB emb) =
+  cong₂ _∷_ (cong₂ _,_ eqβ eqB) (rightStoreⁱ-rel-embedding emb)
+rightStoreⁱ-rel-embedding
+    (rel-store-embedding-link eqα eqA eqβ eqB emb) =
+  rightStoreⁱ-rel-embedding emb
+
+rel-store-embedding-prefix-invⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  RelStoreEmbeddingⁱ τ σ ρ⁺ ρ′⁺ →
+  ∃[ ρ₀′ ]
+    RelStoreEmbeddingⁱ τ σ ρ₀ ρ₀′ ×
+    StoreImpPrefix ρ₀′ ρ′⁺
+rel-store-embedding-prefix-invⁱ prefix-reflⁱ emb =
+  _ , emb , prefix-reflⁱ
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-left eqα eqA emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-left eqα eqA emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-right eqβ eqB emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-right eqβ eqB emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-link eqα eqA eqβ eqB emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-link eqα eqA eqβ eqB emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+
+leftStoreⁱ-prefix-inclusion :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  StoreIncl (leftStoreⁱ ρ₀) (leftStoreⁱ ρ⁺)
+leftStoreⁱ-prefix-inclusion prefix-reflⁱ x∈ = x∈
+leftStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-matched α A β B p} prefix) x∈ =
+  there (leftStoreⁱ-prefix-inclusion prefix x∈)
+leftStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-left α A hA} prefix) x∈ =
+  there (leftStoreⁱ-prefix-inclusion prefix x∈)
+leftStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-right β B hB} prefix) x∈ =
+  leftStoreⁱ-prefix-inclusion prefix x∈
+leftStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-link α A β B p} prefix) x∈ =
+  leftStoreⁱ-prefix-inclusion prefix x∈
+
+rightStoreⁱ-prefix-inclusion :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  StoreIncl (rightStoreⁱ ρ₀) (rightStoreⁱ ρ⁺)
+rightStoreⁱ-prefix-inclusion prefix-reflⁱ x∈ = x∈
+rightStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-matched α A β B p} prefix) x∈ =
+  there (rightStoreⁱ-prefix-inclusion prefix x∈)
+rightStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-left α A hA} prefix) x∈ =
+  rightStoreⁱ-prefix-inclusion prefix x∈
+rightStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-right β B hB} prefix) x∈ =
+  there (rightStoreⁱ-prefix-inclusion prefix x∈)
+rightStoreⁱ-prefix-inclusion
+    (prefix-∷ⁱ {entry = store-link α A β B p} prefix) x∈ =
+  rightStoreⁱ-prefix-inclusion prefix x∈
+
+store-imp-prefix-transⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ ρ₁ ρ₂ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ₁ →
+  StoreImpPrefix ρ₁ ρ₂ →
+  StoreImpPrefix ρ₀ ρ₂
+store-imp-prefix-transⁱ prefix₀₁ prefix-reflⁱ = prefix₀₁
+store-imp-prefix-transⁱ prefix₀₁ (prefix-∷ⁱ prefix₁₂) =
+  prefix-∷ⁱ (store-imp-prefix-transⁱ prefix₀₁ prefix₁₂)
+
+rel-store-rename-prefix-invⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ⁺ ρ′⁺ →
+  ∃[ ρ₀′ ]
+    RelStoreRenameⁱ τ σ assm hτ hσ ρ₀ ρ₀′ ×
+    StoreImpPrefix ρ₀′ ρ′⁺
+rel-store-rename-prefix-invⁱ prefix-reflⁱ renameρ =
+  _ , renameρ , prefix-reflⁱ
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ)
+    with rel-store-rename-prefix-invⁱ prefix renameρ
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-left eqα eqA renameρ)
+    with rel-store-rename-prefix-invⁱ prefix renameρ
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-left eqα eqA renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-right eqβ eqB renameρ)
+    with rel-store-rename-prefix-invⁱ prefix renameρ
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-right eqβ eqB renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ)
+    with rel-store-rename-prefix-invⁱ prefix renameρ
+rel-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+
+rel-store-rename-matched∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {α A β B p} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  store-matched α A β B p ∈ ρ →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+  ∃[ β′ ] β′ ≡ σ β × ∃[ B′ ] ∃[ eqB ]
+    store-matched α′ A′ β′ B′
+      (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p) ∈ ρ′
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ)
+    (here refl) =
+  _ , eqα , _ , eqA , _ , eqβ , _ , eqB , here refl
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ)
+    (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-left eqα eqA renameρ) (here ())
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-left eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-right eqβ eqB renameρ) (here ())
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-right eqβ eqB renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ) (here ())
+rel-store-rename-matched∈ⁱ
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+
+rel-store-rename-link∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {α A β B p} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  store-link α A β B p ∈ ρ →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+  ∃[ β′ ] β′ ≡ σ β × ∃[ B′ ] ∃[ eqB ]
+    store-link α′ A′ β′ B′
+      (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p) ∈ ρ′
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ)
+    (here ())
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ)
+    (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-left eqα eqA renameρ) (here ())
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-left eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-right eqβ eqB renameρ) (here ())
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-right eqβ eqB renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ)
+    (here refl) =
+  _ , eqα , _ , eqA , _ , eqβ , _ , eqB , here refl
+rel-store-rename-link∈ⁱ
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ)
+    (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ ,
+        β′ , eqβ′ , B′ , eqB′ , p∈′ =
+        rel-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ ,
+  β′ , eqβ′ , B′ , eqB′ , there p∈′
+
+rel-store-rename-correspondenceⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {α A β B p} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  StoreCorresponds ρ α A β B p →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+  ∃[ β′ ] β′ ≡ σ β × ∃[ B′ ] ∃[ eqB ]
+    StoreCorresponds ρ′ α′ A′ β′ B′
+      (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p)
+rel-store-rename-correspondenceⁱ renameρ
+    (correspondence-stored p∈) =
+  let α′ , eqα , A′ , eqA , β′ , eqβ , B′ , eqB , p∈′ =
+        rel-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα , A′ , eqA , β′ , eqβ , B′ , eqB ,
+  correspondence-stored p∈′
+rel-store-rename-correspondenceⁱ renameρ
+    (correspondence-linked p∈) =
+  let α′ , eqα , A′ , eqA , β′ , eqβ , B′ , eqB , p∈′ =
+        rel-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα , A′ , eqA , β′ , eqβ , B′ , eqB ,
+  correspondence-linked p∈′
+
+rel-store-embedding-matched∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {α A β B p} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  store-matched α A β B p ∈ ρ →
+  ∃[ α′ ] ∃[ A′ ] ∃[ β′ ] ∃[ B′ ] ∃[ p′ ]
+    (α′ ≡ τ α × A′ ≡ renameᵗ τ A ×
+     β′ ≡ σ β × B′ ≡ renameᵗ σ B ×
+     store-matched α′ A′ β′ B′ p′ ∈ ρ′)
+rel-store-embedding-matched∈ⁱ rel-store-embedding-[] ()
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-matched
+      {p′ = p′} eqα eqA eqβ eqB emb) (here refl) =
+  _ , _ , _ , _ , p′ , eqα , eqA , eqβ , eqB , here refl
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-matched∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-left eqα eqA emb) (here ())
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-left eqα eqA emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-matched∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-right eqβ eqB emb) (here ())
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-right eqβ eqB emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-matched∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-link eqα eqA eqβ eqB emb) (here ())
+rel-store-embedding-matched∈ⁱ
+    (rel-store-embedding-link eqα eqA eqβ eqB emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-matched∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+
+rel-store-embedding-link∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {α A β B p} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  store-link α A β B p ∈ ρ →
+  ∃[ α′ ] ∃[ A′ ] ∃[ β′ ] ∃[ B′ ] ∃[ p′ ]
+    (α′ ≡ τ α × A′ ≡ renameᵗ τ A ×
+     β′ ≡ σ β × B′ ≡ renameᵗ σ B ×
+     store-link α′ A′ β′ B′ p′ ∈ ρ′)
+rel-store-embedding-link∈ⁱ rel-store-embedding-[] ()
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb) (here ())
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-matched eqα eqA eqβ eqB emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-link∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-left eqα eqA emb) (here ())
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-left eqα eqA emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-link∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-right eqβ eqB emb) (here ())
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-right eqβ eqB emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-link∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-link
+      {p′ = p′} eqα eqA eqβ eqB emb) (here refl) =
+  _ , _ , _ , _ , p′ , eqα , eqA , eqβ , eqB , here refl
+rel-store-embedding-link∈ⁱ
+    (rel-store-embedding-link eqα eqA eqβ eqB emb) (there p∈) =
+  let α′ , A′ , β′ , B′ , p′ ,
+        eqα′ , eqA′ , eqβ′ , eqB′ , p∈′ =
+        rel-store-embedding-link∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ ,
+  eqα′ , eqA′ , eqβ′ , eqB′ , there p∈′
+
+rel-store-embedding-correspondenceⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {α A β B p} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  StoreCorresponds ρ α A β B p →
+  ∃[ α′ ] ∃[ A′ ] ∃[ β′ ] ∃[ B′ ] ∃[ p′ ]
+    (α′ ≡ τ α × A′ ≡ renameᵗ τ A ×
+     β′ ≡ σ β × B′ ≡ renameᵗ σ B ×
+     StoreCorresponds ρ′ α′ A′ β′ B′ p′)
+rel-store-embedding-correspondenceⁱ emb
+    (correspondence-stored p∈) =
+  let α′ , A′ , β′ , B′ , p′ , eqα , eqA , eqβ , eqB , p∈′ =
+        rel-store-embedding-matched∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ , eqα , eqA , eqβ , eqB ,
+  correspondence-stored p∈′
+rel-store-embedding-correspondenceⁱ emb
+    (correspondence-linked p∈) =
+  let α′ , A′ , β′ , B′ , p′ , eqα , eqA , eqβ , eqB , p∈′ =
+        rel-store-embedding-link∈ⁱ emb p∈ in
+  α′ , A′ , β′ , B′ , p′ , eqα , eqA , eqβ , eqB ,
+  correspondence-linked p∈′
+
+data RelCtxRenameⁱ
+    {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    (τ σ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Θᴸ τ)
+    (hσ : TyRenameWf Δᴿ Θᴿ σ) :
+    CtxImp Φ Δᴸ Δᴿ → CtxImp Ψ Θᴸ Θᴿ → Set₁ where
+  rel-ctx-rename-[] : RelCtxRenameⁱ τ σ assm hτ hσ [] []
+
+  rel-ctx-rename-∷ :
+    ∀ {γ γ′ A A′ B B′ p} →
+    (eqA : A′ ≡ renameᵗ τ A) →
+    (eqB : B′ ≡ renameᵗ σ B) →
+    RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+    RelCtxRenameⁱ τ σ assm hτ hσ
+      (ctx-imp A B p ∷ γ)
+      (ctx-imp A′ B′
+        (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p) ∷ γ′)
+
+record RelWorldPermutationⁱ
+    {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    (πᴸ : TyPermutation Δᴸ Θᴸ)
+    (πᴿ : TyPermutation Δᴿ Θᴿ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ)
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} : Set₁ where
+  constructor rel-world-permutation
+  field
+    left-cast-renamer : CastModeRenamer (forward πᴸ)
+    right-cast-renamer : CastModeRenamer (forward πᴿ)
+    store-permutation : RelStoreRenameⁱ
+      (forward πᴸ) (forward πᴿ) assm
+      (forward-wf πᴸ) (forward-wf πᴿ) ρ ρ′
+    ctx-permutation : RelCtxRenameⁱ
+      (forward πᴸ) (forward πᴿ) assm
+      (forward-wf πᴸ) (forward-wf πᴿ) γ γ′
+
+open RelWorldPermutationⁱ public
+
+record StoreProjectionEmbeddingⁱ
+    {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    (τ σ : Renameᵗ)
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (ρ′ : StoreImp Ψ Θᴸ Θᴿ) : Set where
+  constructor store-projection-embedding
+  field
+    left-store-inclusion :
+      StoreIncl (renameStoreᵗ τ (leftStoreⁱ ρ)) (leftStoreⁱ ρ′)
+    right-store-inclusion :
+      StoreIncl (renameStoreᵗ σ (rightStoreⁱ ρ)) (rightStoreⁱ ρ′)
+
+open StoreProjectionEmbeddingⁱ public
+
+rel-store-embedding-projectionⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  StoreProjectionEmbeddingⁱ τ σ ρ ρ′
+rel-store-embedding-projectionⁱ emb =
+  store-projection-embedding
+    (λ {x} x∈ → subst (x ∈_)
+      (sym (leftStoreⁱ-rel-embedding emb)) x∈)
+    (λ {x} x∈ → subst (x ∈_)
+      (sym (rightStoreⁱ-rel-embedding emb)) x∈)
+
+record RelWorldEmbeddingⁱ
+    {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    (τ σ ψ φ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Θᴸ τ)
+    (hσ : TyRenameWf Δᴿ Θᴿ σ)
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} : Set₁ where
+  constructor rel-world-embedding
+  field
+    left-embedding-inverse : RenameLeftInverse τ ψ
+    right-embedding-inverse : RenameLeftInverse σ φ
+    left-embedding-cast-renamer : CastModeRenamer τ
+    right-embedding-cast-renamer : CastModeRenamer σ
+    store-embedding : RelStoreEmbeddingⁱ τ σ ρ ρ′
+    embedding-context : RelCtxRenameⁱ τ σ assm hτ hσ γ γ′
+
+open RelWorldEmbeddingⁱ public
+
+rel-ctx-rename-lookupⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {x A B p} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  γ ∋ x ⦂ ctx-imp A B p →
+  ∃[ A′ ] ∃[ B′ ] ∃[ eqA ] ∃[ eqB ]
+    γ′ ∋ x ⦂ ctx-imp A′ B′
+      (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p)
+rel-ctx-rename-lookupⁱ
+    (rel-ctx-rename-∷ eqA eqB renameγ) Z =
+  _ , _ , eqA , eqB , Z
+rel-ctx-rename-lookupⁱ
+    (rel-ctx-rename-∷ eqA eqB renameγ) (S x∈) =
+  let A′ , B′ , eqA′ , eqB′ , x∈′ =
+        rel-ctx-rename-lookupⁱ renameγ x∈ in
+  A′ , B′ , eqA′ , eqB′ , S x∈′
+
+rel-world-x-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {x A B p} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  γ ∋ x ⦂ ctx-imp A B p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (` x)
+      ⊑ renameᵗᵐ (forward πᴿ) (` x)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-x-permuteᵀ perm x∈
+    with rel-ctx-rename-lookupⁱ (ctx-permutation perm) x∈
+rel-world-x-permuteᵀ perm x∈ | A′ , B′ , refl , refl , x∈′ =
+  x⊑xᵀ x∈′
+
+rel-world-permutation-ctx-∷ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {A B p} →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′}
+    {γ = ctx-imp A B p ∷ γ}
+    {γ′ = ctx-imp
+      (renameᵗ (forward πᴸ) A)
+      (renameᵗ (forward πᴿ) B)
+      (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p)
+      ∷ γ′}
+rel-world-permutation-ctx-∷ⁱ perm =
+  rel-world-permutation
+    (left-cast-renamer perm) (right-cast-renamer perm)
+    (store-permutation perm)
+    (rel-ctx-rename-∷ refl refl (ctx-permutation perm))
+
+rel-world-ƛ-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {N N′ A A′ B B′ pA pB} →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣
+      ctx-imp
+        (renameᵗ (forward πᴸ) A)
+        (renameᵗ (forward πᴿ) A′)
+        (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pA)
+        ∷ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pB →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (ƛ N)
+      ⊑ renameᵗᵐ (forward πᴿ) (ƛ N′)
+    ⦂ renameᵗ (forward πᴸ) (A ⇒ B)
+      ⊑ renameᵗ (forward πᴿ) (A′ ⇒ B′)
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+        (pA ↦ pB)
+rel-world-ƛ-permuteᵀ {πᴸ = πᴸ} {πᴿ = πᴿ}
+    perm hA hA′ N⊑N′ =
+  ƛ⊑ƛᵀ
+    (renameᵗ-preserves-WfTy hA (forward-wf πᴸ))
+    (renameᵗ-preserves-WfTy hA′ (forward-wf πᴿ)) N⊑N′
+
+rel-world-·-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {L L′ M M′ A A′ B B′ pA pB} →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) L
+      ⊑ renameᵗᵐ (forward πᴿ) L′
+    ⦂ renameᵗ (forward πᴸ) (A ⇒ B)
+      ⊑ renameᵗ (forward πᴿ) (A′ ⇒ B′)
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+        (pA ↦ pB) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pA →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (L · M)
+      ⊑ renameᵗᵐ (forward πᴿ) (L′ · M′)
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pB
+rel-world-·-permuteᵀ L⊑L′ M⊑M′ = ·⊑·ᵀ L⊑L′ M⊑M′
+
+rel-world-κ-permuteᵀ :
+  ∀ {Ψ Θᴸ Θᴿ} {ρ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Ψ Θᴸ Θᴿ} {n} →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ ∣ γ
+    ⊢ᴺ $ (κℕ n) ⊑ $ (κℕ n) ⦂ ‵ `ℕ ⊑ ‵ `ℕ ∶ idι
+rel-world-κ-permuteᵀ = κ⊑κᵀ
+
+rel-world-⊕-permuteᵀ :
+  ∀ {Ψ Θᴸ Θᴿ} {ρ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Ψ Θᴸ Θᴿ} {L L′ M M′} →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ ∣ γ
+    ⊢ᴺ L ⊑ L′ ⦂ ‵ `ℕ ⊑ ‵ `ℕ ∶ idι →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ ‵ `ℕ ⊑ ‵ `ℕ ∶ idι →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ ∣ γ
+    ⊢ᴺ L ⊕[ addℕ ] M ⊑ L′ ⊕[ addℕ ] M′
+    ⦂ ‵ `ℕ ⊑ ‵ `ℕ ∶ idι
+rel-world-⊕-permuteᵀ L⊑L′ M⊑M′ = ⊕⊑⊕ᵀ L⊑L′ M⊑M′
+
+rel-store-rename-lift∀ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  ∃[ ρ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    RelStoreRenameⁱ
+      (extᵗ τ) (extᵗ σ) (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) ρ∀ ρ′∀
+rel-store-rename-lift∀ⁱ rel-store-rename-[] lift-store-[] =
+  [] , lift-store-[] , rel-store-rename-[]
+rel-store-rename-lift∀ⁱ
+    (rel-store-rename-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-store-∷ {p′ = p∀} liftρ)
+    with rel-store-rename-lift∀ⁱ renameρ liftρ
+rel-store-rename-lift∀ⁱ
+    {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-rename-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-store-∷ {A = A} {B = B} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-matched (suc α′) (⇑ᵗ A′) (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) eqA∀ eqB∀ p∀)
+      ∷ ρ′∀ ,
+  lift-store-∷ liftρ′ ,
+  rel-store-rename-matched
+    (cong suc eqα) eqA∀ (cong suc eqβ) eqB∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-rename-lift∀ⁱ
+    (rel-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-store-left liftρ)
+    with rel-store-rename-lift∀ⁱ renameρ liftρ
+rel-store-rename-lift∀ⁱ {τ = τ}
+    (rel-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-store-left {A = A} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-left liftρ′ ,
+  rel-store-rename-left (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-rename-lift∀ⁱ
+    (rel-store-rename-right {β′ = β′} {B′ = B′} {hB′ = hB′}
+      eqβ eqB renameρ)
+    (lift-store-right liftρ)
+    with rel-store-rename-lift∀ⁱ renameρ liftρ
+rel-store-rename-lift∀ⁱ {σ = σ}
+    (rel-store-rename-right {β′ = β′} {B′ = B′} {hB′ = hB′}
+      eqβ eqB renameρ)
+    (lift-store-right {B = B} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-right (suc β′) (⇑ᵗ B′)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-right liftρ′ ,
+  rel-store-rename-right (cong suc eqβ) eqB∀ renameρ∀
+  where
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-rename-lift∀ⁱ
+    (rel-store-rename-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-store-link {p′ = p∀} liftρ)
+    with rel-store-rename-lift∀ⁱ renameρ liftρ
+rel-store-rename-lift∀ⁱ
+    {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-rename-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-store-link {A = A} {B = B} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-link (suc α′) (⇑ᵗ A′) (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) eqA∀ eqB∀ p∀)
+      ∷ ρ′∀ ,
+  lift-store-link liftρ′ ,
+  rel-store-rename-link
+    (cong suc eqα) eqA∀ (cong suc eqβ) eqB∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+rel-store-embedding-lift∀ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  ∃[ ρ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    RelStoreEmbeddingⁱ (extᵗ τ) (extᵗ σ) ρ∀ ρ′∀
+rel-store-embedding-lift∀ⁱ
+    rel-store-embedding-[] lift-store-[] =
+  [] , lift-store-[] , rel-store-embedding-[]
+rel-store-embedding-lift∀ⁱ {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-store-∷ {p′ = p∀} liftρ)
+    with rel-store-embedding-lift∀ⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift∀ⁱ
+    {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-store-∷ {A = A} {B = B} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-matched (suc α′) (⇑ᵗ A′) (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) eqA∀ eqB∀ p∀)
+      ∷ ρ′∀ ,
+  lift-store-∷ liftρ′ ,
+  rel-store-embedding-matched
+    (cong suc eqα) eqA∀ (cong suc eqβ) eqB∀ emb∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-embedding-lift∀ⁱ {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-store-left liftρ)
+    with rel-store-embedding-lift∀ⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift∀ⁱ {τ = τ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-store-left {A = A} liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-left liftρ′ ,
+  rel-store-embedding-left (cong suc eqα) eqA∀ emb∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-embedding-lift∀ⁱ {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-store-right liftρ)
+    with rel-store-embedding-lift∀ⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift∀ⁱ {σ = σ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-store-right {B = B} liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-right (suc β′) (⇑ᵗ B′)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-right liftρ′ ,
+  rel-store-embedding-right (cong suc eqβ) eqB∀ emb∀
+  where
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-embedding-lift∀ⁱ {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-store-link {p′ = p∀} liftρ)
+    with rel-store-embedding-lift∀ⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift∀ⁱ
+    {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-store-link {A = A} {B = B} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-link (suc α′) (⇑ᵗ A′) (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) eqA∀ eqB∀ p∀)
+      ∷ ρ′∀ ,
+  lift-store-link liftρ′ ,
+  rel-store-embedding-link
+    (cong suc eqα) eqA∀ (cong suc eqβ) eqB∀ emb∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+rel-ctx-rename-lift∀ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ γ′∀ ]
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    RelCtxRenameⁱ
+      (extᵗ τ) (extᵗ σ) (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) γ∀ γ′∀
+rel-ctx-rename-lift∀ⁱ rel-ctx-rename-[] lift-ctx-[] =
+  [] , lift-ctx-[] , rel-ctx-rename-[]
+rel-ctx-rename-lift∀ⁱ
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′}
+      eqA eqB renameγ)
+    (lift-ctx-∷ {p′ = p∀} liftγ)
+    with rel-ctx-rename-lift∀ⁱ renameγ liftγ
+rel-ctx-rename-lift∀ⁱ
+    {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′}
+      eqA eqB renameγ)
+    (lift-ctx-∷ {A = A} {B = B} {p′ = p∀} liftγ)
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ctx-imp (⇑ᵗ A′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) eqA∀ eqB∀ p∀)
+      ∷ γ′∀ ,
+  lift-ctx-∷ liftγ′ ,
+  rel-ctx-rename-∷ eqA∀ eqB∀ renameγ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+rel-world-permutation-lift∀ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ ρ′∀ ] ∃[ γ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    RelWorldPermutationⁱ
+      (TyPermutation-ext πᴸ) (TyPermutation-ext πᴿ)
+      (rename-assm²-⇑ᵢ assm)
+      {ρ = ρ∀} {ρ′ = ρ′∀} {γ = γ∀} {γ′ = γ′∀}
+rel-world-permutation-lift∀ⁱ perm liftρ liftγ
+    with rel-store-rename-lift∀ⁱ (store-permutation perm) liftρ
+       | rel-ctx-rename-lift∀ⁱ (ctx-permutation perm) liftγ
+rel-world-permutation-lift∀ⁱ perm liftρ liftγ
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ρ′∀ , γ′∀ , liftρ′ , liftγ′ ,
+  rel-world-permutation
+    (castModeRenamer-ext (left-cast-renamer perm))
+    (castModeRenamer-ext (right-cast-renamer perm))
+    renameρ∀ renameγ∀
+
+rel-world-embedding-lift∀ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ ρ′∀ ] ∃[ γ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    RelWorldEmbeddingⁱ
+      (extᵗ τ) (extᵗ σ) (extᵗ ψ) (extᵗ φ)
+      (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+      {ρ = ρ∀} {ρ′ = ρ′∀} {γ = γ∀} {γ′ = γ′∀}
+rel-world-embedding-lift∀ⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ liftγ
+    with rel-store-embedding-lift∀ⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      (store-embedding emb) liftρ
+       | rel-ctx-rename-lift∀ⁱ (embedding-context emb) liftγ
+rel-world-embedding-lift∀ⁱ emb liftρ liftγ
+    | ρ′∀ , liftρ′ , embρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ρ′∀ , γ′∀ , liftρ′ , liftγ′ ,
+  rel-world-embedding
+    (RenameLeftInverse-ext (left-embedding-inverse emb))
+    (RenameLeftInverse-ext (right-embedding-inverse emb))
+    (castModeRenamer-ext (left-embedding-cast-renamer emb))
+    (castModeRenamer-ext (right-embedding-cast-renamer emb))
+    embρ∀ renameγ∀
+
+rel-store-rename-lift-leftⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  ∃[ ρ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    RelStoreRenameⁱ
+      (extᵗ τ) σ (rename-assm²-⇑ᴸᵢ assm)
+      (TyRenameWf-ext hτ) hσ ρν ρ′ν
+rel-store-rename-lift-leftⁱ
+    rel-store-rename-[] lift-left-store-[] =
+  [] , lift-left-store-[] , rel-store-rename-[]
+rel-store-rename-lift-leftⁱ
+    (rel-store-rename-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-left-store-∷ {p′ = pν} liftρ)
+    with rel-store-rename-lift-leftⁱ renameρ liftρ
+rel-store-rename-lift-leftⁱ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-rename-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-left-store-∷ {A = A} {B = B} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-matched (suc α′) (⇑ᵗ A′) β′ B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ ρ′ν ,
+  lift-left-store-∷ liftρ′ ,
+  rel-store-rename-matched
+    (cong suc eqα) eqAν eqβ eqB renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-rename-lift-leftⁱ
+    (rel-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-left-store-left liftρ)
+    with rel-store-rename-lift-leftⁱ renameρ liftρ
+rel-store-rename-lift-leftⁱ {τ = τ}
+    (rel-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-left-store-left {A = A} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′ν ,
+  lift-left-store-left liftρ′ ,
+  rel-store-rename-left (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-rename-lift-leftⁱ
+    (rel-store-rename-right {β′ = β′} {B′ = B′} {hB′ = hB′}
+      eqβ eqB renameρ)
+    (lift-left-store-right liftρ)
+    with rel-store-rename-lift-leftⁱ renameρ liftρ
+rel-store-rename-lift-leftⁱ
+    (rel-store-rename-right {β′ = β′} {B′ = B′} {hB′ = hB′}
+      eqβ eqB renameρ)
+    (lift-left-store-right liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-right β′ B′ hB′ ∷ ρ′ν ,
+  lift-left-store-right liftρ′ ,
+  rel-store-rename-right eqβ eqB renameρν
+rel-store-rename-lift-leftⁱ
+    (rel-store-rename-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-left-store-link {p′ = pν} liftρ)
+    with rel-store-rename-lift-leftⁱ renameρ liftρ
+rel-store-rename-lift-leftⁱ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-rename-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-left-store-link {A = A} {B = B} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-link (suc α′) (⇑ᵗ A′) β′ B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ ρ′ν ,
+  lift-left-store-link liftρ′ ,
+  rel-store-rename-link (cong suc eqα) eqAν eqβ eqB renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+rel-store-embedding-lift-leftⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  ∃[ ρ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    RelStoreEmbeddingⁱ (extᵗ τ) σ ρν ρ′ν
+rel-store-embedding-lift-leftⁱ
+    rel-store-embedding-[] lift-left-store-[] =
+  [] , lift-left-store-[] , rel-store-embedding-[]
+rel-store-embedding-lift-leftⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-left-store-∷ {p′ = pν} liftρ)
+    with rel-store-embedding-lift-leftⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-leftⁱ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-left-store-∷ {A = A} {B = B} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-matched (suc α′) (⇑ᵗ A′) β′ B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ ρ′ν ,
+  lift-left-store-∷ liftρ′ ,
+  rel-store-embedding-matched
+    (cong suc eqα) eqAν eqβ eqB embν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-embedding-lift-leftⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-left-store-left liftρ)
+    with rel-store-embedding-lift-leftⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-leftⁱ {τ = τ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-left-store-left {A = A} liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′ν ,
+  lift-left-store-left liftρ′ ,
+  rel-store-embedding-left (cong suc eqα) eqAν embν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-embedding-lift-leftⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-left-store-right liftρ)
+    with rel-store-embedding-lift-leftⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-leftⁱ
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-left-store-right liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-right β′ B′ hB′ ∷ ρ′ν ,
+  lift-left-store-right liftρ′ ,
+  rel-store-embedding-right eqβ eqB embν
+rel-store-embedding-lift-leftⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-left-store-link {p′ = pν} liftρ)
+    with rel-store-embedding-lift-leftⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-leftⁱ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-left-store-link {A = A} {B = B} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-link (suc α′) (⇑ᵗ A′) β′ B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ ρ′ν ,
+  lift-left-store-link liftρ′ ,
+  rel-store-embedding-link (cong suc eqα) eqAν eqβ eqB embν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+rel-ctx-rename-lift-leftⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ γ′ν ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    RelCtxRenameⁱ
+      (extᵗ τ) σ (rename-assm²-⇑ᴸᵢ assm)
+      (TyRenameWf-ext hτ) hσ γν γ′ν
+rel-ctx-rename-lift-leftⁱ rel-ctx-rename-[] lift-left-ctx-[] =
+  [] , lift-left-ctx-[] , rel-ctx-rename-[]
+rel-ctx-rename-lift-leftⁱ
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′}
+      eqA eqB renameγ)
+    (lift-left-ctx-∷ {p′ = pν} liftγ)
+    with rel-ctx-rename-lift-leftⁱ renameγ liftγ
+rel-ctx-rename-lift-leftⁱ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′}
+      eqA eqB renameγ)
+    (lift-left-ctx-∷ {A = A} {B = B} {p′ = pν} liftγ)
+    | γ′ν , liftγ′ , renameγν =
+  ctx-imp (⇑ᵗ A′) B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ γ′ν ,
+  lift-left-ctx-∷ liftγ′ ,
+  rel-ctx-rename-∷ eqAν eqB renameγν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+rel-world-permutation-lift-leftⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ ρ′ν ] ∃[ γ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    RelWorldPermutationⁱ (TyPermutation-ext πᴸ) πᴿ
+      (rename-assm²-⇑ᴸᵢ assm)
+      {ρ = ρν} {ρ′ = ρ′ν} {γ = γν} {γ′ = γ′ν}
+rel-world-permutation-lift-leftⁱ perm liftρ liftγ
+    with rel-store-rename-lift-leftⁱ
+      (store-permutation perm) liftρ
+       | rel-ctx-rename-lift-leftⁱ (ctx-permutation perm) liftγ
+rel-world-permutation-lift-leftⁱ perm liftρ liftγ
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  ρ′ν , γ′ν , liftρ′ , liftγ′ ,
+  rel-world-permutation
+    (castModeRenamer-ext (left-cast-renamer perm))
+    (right-cast-renamer perm) renameρν renameγν
+
+rel-world-embedding-lift-leftⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ ρ′ν ] ∃[ γ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    RelWorldEmbeddingⁱ (extᵗ τ) σ (extᵗ ψ) φ
+      (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ) hσ
+      {ρ = ρν} {ρ′ = ρ′ν} {γ = γν} {γ′ = γ′ν}
+rel-world-embedding-lift-leftⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ liftγ
+    with rel-store-embedding-lift-leftⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      (store-embedding emb) liftρ
+       | rel-ctx-rename-lift-leftⁱ (embedding-context emb) liftγ
+rel-world-embedding-lift-leftⁱ emb liftρ liftγ
+    | ρ′ν , liftρ′ , embρν
+    | γ′ν , liftγ′ , renameγν =
+  ρ′ν , γ′ν , liftρ′ , liftγ′ ,
+  rel-world-embedding
+    (RenameLeftInverse-ext (left-embedding-inverse emb))
+    (right-embedding-inverse emb)
+    (castModeRenamer-ext (left-embedding-cast-renamer emb))
+    (right-embedding-cast-renamer emb) embρν renameγν
+
+rel-world-Λ-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {V V′ A B}
+    {p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Value V →
+  Value V′ →
+  ∃[ ρ′∀ ] ∃[ γ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    RelWorldPermutationⁱ
+      (TyPermutation-ext πᴸ) (TyPermutation-ext πᴿ)
+      (rename-assm²-⇑ᵢ assm)
+      {ρ = ρ∀} {ρ′ = ρ′∀} {γ = γ∀} {γ′ = γ′∀} ×
+    (∀ᵢᶜ Ψ ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ′∀ ∣ γ′∀
+       ⊢ᴺ renameᵗᵐ (extᵗ (forward πᴸ)) V
+         ⊑ renameᵗᵐ (extᵗ (forward πᴿ)) V′
+       ⦂ renameᵗ (extᵗ (forward πᴸ)) A
+         ⊑ renameᵗ (extᵗ (forward πᴿ)) B
+       ∶ ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᵢ assm)
+           (TyRenameWf-ext (forward-wf πᴸ))
+           (TyRenameWf-ext (forward-wf πᴿ)) p →
+     Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+       ⊢ᴺ renameᵗᵐ (forward πᴸ) (Λ V)
+         ⊑ renameᵗᵐ (forward πᴿ) (Λ V′)
+       ⦂ renameᵗ (forward πᴸ) (`∀ A)
+         ⊑ renameᵗ (forward πᴿ) (`∀ B)
+       ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+           (∀ⁱ p))
+rel-world-Λ-permuteᵀ {πᴸ = πᴸ} {πᴿ = πᴿ}
+    perm liftρ liftγ vV vV′
+    with rel-world-permutation-lift∀ⁱ perm liftρ liftγ
+rel-world-Λ-permuteᵀ {πᴸ = πᴸ} {πᴿ = πᴿ}
+    perm liftρ liftγ vV vV′
+    | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-perm =
+  ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-perm ,
+  λ V⊑V′ →
+    Λ⊑Λᵀ liftρ′ liftγ′
+      (renameᵗᵐ-preserves-Value (extᵗ (forward πᴸ)) vV)
+      (renameᵗᵐ-preserves-Value (extᵗ (forward πᴿ)) vV′)
+      V⊑V′
+
+rel-world-Λ-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {V V′ A B}
+    {p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Value V →
+  Value V′ →
+  ∃[ ρ′∀ ] ∃[ γ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    RelWorldEmbeddingⁱ
+      (extᵗ τ) (extᵗ σ) (extᵗ ψ) (extᵗ φ)
+      (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+      {ρ = ρ∀} {ρ′ = ρ′∀} {γ = γ∀} {γ′ = γ′∀} ×
+    (∀ᵢᶜ Ψ ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ′∀ ∣ γ′∀
+       ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ renameᵗᵐ (extᵗ σ) V′
+       ⦂ renameᵗ (extᵗ τ) A ⊑ renameᵗ (extᵗ σ) B
+       ∶ ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᵢ assm)
+           (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) p →
+     Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+       ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ renameᵗᵐ σ (Λ V′)
+       ⦂ renameᵗ τ (`∀ A) ⊑ renameᵗ σ (`∀ B)
+       ∶ ⊑-renameᵗ²ᵢ assm hτ hσ (∀ⁱ p))
+rel-world-Λ-embedᵀ emb liftρ liftγ vV vV′
+    with rel-world-embedding-lift∀ⁱ emb liftρ liftγ
+rel-world-Λ-embedᵀ {τ = τ} {σ = σ}
+    emb liftρ liftγ vV vV′
+    | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb =
+  ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb ,
+  λ V⊑V′ →
+    Λ⊑Λᵀ liftρ′ liftγ′
+      (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
+      (renameᵗᵐ-preserves-Value (extᵗ σ) vV′)
+      V⊑V′
+
+rel-world-Λ⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {V N′ A B}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (occ : occurs zero A ≡ true) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Value V →
+  ∃[ ρ′ν ] ∃[ γ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    RelWorldEmbeddingⁱ (extᵗ τ) σ (extᵗ ψ) φ
+      (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ) hσ
+      {ρ = ρν} {ρ′ = ρ′ν} {γ = γν} {γ′ = γ′ν} ×
+    (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+       ∣ suc Θᴸ ∣ Θᴿ ∣ ρ′ν ∣ γ′ν
+       ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ renameᵗᵐ σ N′
+       ⦂ renameᵗ (extᵗ τ) A ⊑ renameᵗ σ B
+       ∶ ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+           (TyRenameWf-ext hτ) hσ p →
+     Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+       ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ renameᵗᵐ σ N′
+       ⦂ renameᵗ τ (`∀ A) ⊑ renameᵗ σ B
+       ∶ ⊑-renameᵗ²ᵢ assm hτ hσ (ν occ p))
+rel-world-Λ⊑-embedᵀ emb occ liftρ liftγ vV
+    with rel-world-embedding-lift-leftⁱ emb liftρ liftγ
+rel-world-Λ⊑-embedᵀ {τ = τ} {A = A}
+    emb occ liftρ liftγ vV
+    | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb =
+  ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb ,
+  λ V⊑N′ →
+    Λ⊑ᵀ (trans (occurs-zero-rename-ext τ A) occ)
+      liftρ′ liftγ′
+      (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
+      V⊑N′
+
+rel-world-Λ⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {V N′ A B}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (occ : occurs zero A ≡ true) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Value V →
+  ∃[ ρ′ν ] ∃[ γ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    RelWorldPermutationⁱ (TyPermutation-ext πᴸ) πᴿ
+      (rename-assm²-⇑ᴸᵢ assm)
+      {ρ = ρν} {ρ′ = ρ′ν} {γ = γν} {γ′ = γ′ν} ×
+    (((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+       ∣ suc Θᴸ ∣ Θᴿ ∣ ρ′ν ∣ γ′ν
+       ⊢ᴺ renameᵗᵐ (extᵗ (forward πᴸ)) V
+         ⊑ renameᵗᵐ (forward πᴿ) N′
+       ⦂ renameᵗ (extᵗ (forward πᴸ)) A
+         ⊑ renameᵗ (forward πᴿ) B
+       ∶ ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+           (TyRenameWf-ext (forward-wf πᴸ))
+           (forward-wf πᴿ) p →
+     Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+       ⊢ᴺ renameᵗᵐ (forward πᴸ) (Λ V)
+         ⊑ renameᵗᵐ (forward πᴿ) N′
+       ⦂ renameᵗ (forward πᴸ) (`∀ A)
+         ⊑ renameᵗ (forward πᴿ) B
+       ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+           (ν occ p))
+rel-world-Λ⊑-permuteᵀ {πᴸ = πᴸ} {πᴿ = πᴿ} {A = A}
+    perm occ liftρ liftγ vV
+    with rel-world-permutation-lift-leftⁱ perm liftρ liftγ
+rel-world-Λ⊑-permuteᵀ {πᴸ = πᴸ} {πᴿ = πᴿ} {A = A}
+    perm occ liftρ liftγ vV
+    | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-perm =
+  ρ′ν , γ′ν , liftρ′ , liftγ′ , body-perm ,
+  λ V⊑N′ →
+    Λ⊑ᵀ (trans (occurs-zero-rename-ext (forward πᴸ) A) occ)
+      liftρ′ liftγ′
+      (renameᵗᵐ-preserves-Value (extᵗ (forward πᴸ)) vV)
+      V⊑N′
+
+leftStoreⁱ-rel-rename :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  leftStoreⁱ ρ′ ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+leftStoreⁱ-rel-rename rel-store-rename-[] = refl
+leftStoreⁱ-rel-rename
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-rel-rename renameρ)
+leftStoreⁱ-rel-rename
+    (rel-store-rename-left eqα eqA renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-rel-rename renameρ)
+leftStoreⁱ-rel-rename
+    (rel-store-rename-right eqβ eqB renameρ) =
+  leftStoreⁱ-rel-rename renameρ
+leftStoreⁱ-rel-rename
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ) =
+  leftStoreⁱ-rel-rename renameρ
+
+rightStoreⁱ-rel-rename :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  rightStoreⁱ ρ′ ≡ renameStoreᵗ σ (rightStoreⁱ ρ)
+rightStoreⁱ-rel-rename rel-store-rename-[] = refl
+rightStoreⁱ-rel-rename
+    (rel-store-rename-matched eqα eqA eqβ eqB renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqβ eqB) (rightStoreⁱ-rel-rename renameρ)
+rightStoreⁱ-rel-rename
+    (rel-store-rename-left eqα eqA renameρ) =
+  rightStoreⁱ-rel-rename renameρ
+rightStoreⁱ-rel-rename
+    (rel-store-rename-right eqβ eqB renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqβ eqB) (rightStoreⁱ-rel-rename renameρ)
+rightStoreⁱ-rel-rename
+    (rel-store-rename-link eqα eqA eqβ eqB renameρ) =
+  rightStoreⁱ-rel-rename renameρ
+
+leftCtxⁱ-rel-rename :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  leftCtxⁱ γ′ ≡ map (renameᵗ τ) (leftCtxⁱ γ)
+leftCtxⁱ-rel-rename rel-ctx-rename-[] = refl
+leftCtxⁱ-rel-rename (rel-ctx-rename-∷ eqA eqB renameγ) =
+  cong₂ _∷_ eqA (leftCtxⁱ-rel-rename renameγ)
+
+rightCtxⁱ-rel-rename :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  rightCtxⁱ γ′ ≡ map (renameᵗ σ) (rightCtxⁱ γ)
+rightCtxⁱ-rel-rename rel-ctx-rename-[] = refl
+rightCtxⁱ-rel-rename (rel-ctx-rename-∷ eqA eqB renameγ) =
+  cong₂ _∷_ eqB (rightCtxⁱ-rel-rename renameγ)
+
+store-eq-inclusion :
+  ∀ {Σ Σ′} → Σ′ ≡ Σ → StoreIncl Σ Σ′
+store-eq-inclusion eq {x} x∈ = subst (x ∈_) (sym eq) x∈
+
+rel-store-rename-projection-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  (renameρ : RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′) →
+  StoreProjectionEmbeddingⁱ τ σ ρ ρ′
+rel-store-rename-projection-embeddingⁱ renameρ =
+  store-projection-embedding
+    (store-eq-inclusion (leftStoreⁱ-rel-rename renameρ))
+    (store-eq-inclusion (rightStoreⁱ-rel-rename renameρ))
+
+rel-world-permutation-embeddingⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RelWorldEmbeddingⁱ
+    (forward πᴸ) (forward πᴿ) (backward πᴸ) (backward πᴿ)
+    assm (forward-wf πᴸ) (forward-wf πᴿ)
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}
+rel-world-permutation-embeddingⁱ {πᴸ = πᴸ} {πᴿ = πᴿ} perm =
+  rel-world-embedding
+    (backward-forward πᴸ) (backward-forward πᴿ)
+    (left-cast-renamer perm) (right-cast-renamer perm)
+    (rel-store-rename-embeddingⁱ (store-permutation perm))
+    (ctx-permutation perm)
+
+rel-world-source-typing-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M A} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  No• M →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Θᴸ ∣ leftStoreⁱ ρ′ ∣ leftCtxⁱ γ′
+    ⊢ renameᵗᵐ (forward πᴸ) M ⦂ renameᵗ (forward πᴸ) A
+rel-world-source-typing-permute
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {ρ = ρ} {ρ′ = ρ′}
+    {γ = γ} {γ′ = γ′} {M = M} {A = A} perm noM M⊢ =
+  subst
+    (λ Γ → Θᴸ ∣ leftStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ (forward πᴸ) M ⦂ renameᵗ (forward πᴸ) A)
+    (sym (leftCtxⁱ-rel-rename (ctx-permutation perm)))
+    (subst
+      (λ Σ → Θᴸ ∣ Σ ∣ map (renameᵗ (forward πᴸ))
+        (leftCtxⁱ γ) ⊢ renameᵗᵐ (forward πᴸ) M
+        ⦂ renameᵗ (forward πᴸ) A)
+      (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+      (typing-renameᵀ
+        {ρ = forward πᴸ} {ψ = backward πᴸ}
+        (forward-wf πᴸ) (backward-forward πᴸ)
+        (left-cast-renamer perm) noM M⊢))
+
+rel-world-target-typing-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  No• M →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Θᴿ ∣ rightStoreⁱ ρ′ ∣ rightCtxⁱ γ′
+    ⊢ renameᵗᵐ (forward πᴿ) M ⦂ renameᵗ (forward πᴿ) B
+rel-world-target-typing-permute
+    {Θᴿ = Θᴿ} {πᴿ = πᴿ} {ρ = ρ} {ρ′ = ρ′}
+    {γ = γ} {γ′ = γ′} {M = M} {B = B} perm noM M⊢ =
+  subst
+    (λ Γ → Θᴿ ∣ rightStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ (forward πᴿ) M ⦂ renameᵗ (forward πᴿ) B)
+    (sym (rightCtxⁱ-rel-rename (ctx-permutation perm)))
+    (subst
+      (λ Σ → Θᴿ ∣ Σ ∣ map (renameᵗ (forward πᴿ))
+        (rightCtxⁱ γ) ⊢ renameᵗᵐ (forward πᴿ) M
+        ⦂ renameᵗ (forward πᴿ) B)
+      (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+      (typing-renameᵀ
+        {ρ = forward πᴿ} {ψ = backward πᴿ}
+        (forward-wf πᴿ) (backward-forward πᴿ)
+        (right-cast-renamer perm) noM M⊢))
+
+rel-world-source-typing-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M A} →
+  RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  No• M →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Θᴸ ∣ leftStoreⁱ ρ′ ∣ leftCtxⁱ γ′
+    ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A
+rel-world-source-typing-embed
+    {Θᴸ = Θᴸ} {τ = τ} {ψ = ψ} {hτ = hτ}
+    {ρ = ρ} {ρ′ = ρ′}
+    {γ = γ} {γ′ = γ′} {M = M} {A = A} emb noM M⊢ =
+  subst
+    (λ Γ → Θᴸ ∣ leftStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+    (sym (leftCtxⁱ-rel-rename (embedding-context emb)))
+    (subst
+      (λ Σ → Θᴸ ∣ Σ ∣ map (renameᵗ τ) (leftCtxⁱ γ)
+        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+      (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))
+      (typing-renameᵀ {ρ = τ} {ψ = ψ} hτ
+        (left-embedding-inverse emb)
+        (left-embedding-cast-renamer emb) noM M⊢))
+
+rel-world-target-typing-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M B} →
+  RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  No• M →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Θᴿ ∣ rightStoreⁱ ρ′ ∣ rightCtxⁱ γ′
+    ⊢ renameᵗᵐ σ M ⦂ renameᵗ σ B
+rel-world-target-typing-embed
+    {Θᴿ = Θᴿ} {σ = σ} {φ = φ} {hσ = hσ}
+    {ρ = ρ} {ρ′ = ρ′}
+    {γ = γ} {γ′ = γ′} {M = M} {B = B} emb noM M⊢ =
+  subst
+    (λ Γ → Θᴿ ∣ rightStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ σ M ⦂ renameᵗ σ B)
+    (sym (rightCtxⁱ-rel-rename (embedding-context emb)))
+    (subst
+      (λ Σ → Θᴿ ∣ Σ ∣ map (renameᵗ σ) (rightCtxⁱ γ)
+        ⊢ renameᵗᵐ σ M ⦂ renameᵗ σ B)
+      (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))
+      (typing-renameᵀ {ρ = σ} {ψ = φ} hσ
+        (right-embedding-inverse emb)
+        (right-embedding-cast-renamer emb) noM M⊢))
+
+rel-world-x-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {x A B p} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  γ ∋ x ⦂ ctx-imp A B p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (` x) ⊑ renameᵗᵐ σ (` x)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-x-embedᵀ emb x∈
+    with rel-ctx-rename-lookupⁱ (embedding-context emb) x∈
+rel-world-x-embedᵀ emb x∈ | A′ , B′ , refl , refl , x∈′ =
+  x⊑xᵀ x∈′
+
+rel-world-embedding-ctx-∷ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {A B p} →
+  RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′}
+    {γ = ctx-imp A B p ∷ γ}
+    {γ′ = ctx-imp (renameᵗ τ A) (renameᵗ σ B)
+      (⊑-renameᵗ²ᵢ assm hτ hσ p) ∷ γ′}
+rel-world-embedding-ctx-∷ⁱ emb =
+  rel-world-embedding
+    (left-embedding-inverse emb) (right-embedding-inverse emb)
+    (left-embedding-cast-renamer emb)
+    (right-embedding-cast-renamer emb)
+    (store-embedding emb)
+    (rel-ctx-rename-∷ refl refl (embedding-context emb))
+
+rel-world-ƛ-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {N N′ A A′ B B′ pA pB} →
+  RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣
+      ctx-imp (renameᵗ τ A) (renameᵗ σ A′)
+        (⊑-renameᵗ²ᵢ assm hτ hσ pA) ∷ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ pB →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ƛ N) ⊑ renameᵗᵐ σ (ƛ N′)
+    ⦂ renameᵗ τ (A ⇒ B) ⊑ renameᵗ σ (A′ ⇒ B′)
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ (pA ↦ pB)
+rel-world-ƛ-embedᵀ {τ = τ} {σ = σ} {hτ = hτ} {hσ = hσ}
+    emb hA hA′ N⊑N′ =
+  ƛ⊑ƛᵀ
+    (renameᵗ-preserves-WfTy hA hτ)
+    (renameᵗ-preserves-WfTy hA′ hσ) N⊑N′
+
+rel-world-blame-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M A B p} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  No• M →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ blame ⊑ renameᵗᵐ σ M
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-blame-embedᵀ emb noM M⊢ =
+  blame⊑ᵀ (rel-world-target-typing-embed emb noM M⊢)
+
+rel-world-blame-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M A B p} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  No• M →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) blame
+      ⊑ renameᵗᵐ (forward πᴿ) M
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-blame-permuteᵀ perm noM M⊢ =
+  blame⊑ᵀ (rel-world-target-typing-permute perm noM M⊢)
+
+rel-world-allocation-prefix-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B p} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ⁺} {ρ′ = ρ′⁺} {γ = γ} {γ′ = γ′}) →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  (∀ {ρ₀′} → RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ₀} {ρ′ = ρ₀′} {γ = γ} {γ′ = γ′} →
+    Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ₀′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+        ⊑ renameᵗᵐ (forward πᴿ) M′
+      ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B
+      ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p) →
+  No• M → No• M′ →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′⁺ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-allocation-prefix-permuteᵀ
+    perm prefix body-map noM noM′ M⊢ M′⊢
+    with rel-store-rename-prefix-invⁱ
+      prefix (store-permutation perm)
+rel-world-allocation-prefix-permuteᵀ
+    perm prefix body-map noM noM′ M⊢ M′⊢
+    | ρ₀′ , renameρ₀ , prefix′ =
+  allocation-prefixᵀ prefix′ (body-map base-perm)
+    (rel-world-source-typing-permute perm noM M⊢)
+    (rel-world-target-typing-permute perm noM′ M′⊢)
+  where
+  base-perm =
+    rel-world-permutation
+      (left-cast-renamer perm) (right-cast-renamer perm)
+      renameρ₀ (ctx-permutation perm)
+
+rel-world-allocation-prefix-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B p} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ⁺} {ρ′ = ρ′⁺} {γ = γ} {γ′ = γ′}) →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  (∀ {ρ₀′} → RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ₀} {ρ′ = ρ₀′} {γ = γ} {γ′ = γ′} →
+    Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ₀′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+      ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+      ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p) →
+  No• M → No• M′ →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′⁺ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-allocation-prefix-embedᵀ
+    emb prefix body-map noM noM′ M⊢ M′⊢
+    with rel-store-embedding-prefix-invⁱ
+      prefix (store-embedding emb)
+rel-world-allocation-prefix-embedᵀ
+    emb prefix body-map noM noM′ M⊢ M′⊢
+    | ρ₀′ , emb₀ , prefix′ =
+  allocation-prefixᵀ prefix′ (body-map base-emb)
+    (rel-world-source-typing-embed emb noM M⊢)
+    (rel-world-target-typing-embed emb noM′ M′⊢)
+  where
+  base-emb =
+    rel-world-embedding
+      (left-embedding-inverse emb) (right-embedding-inverse emb)
+      (left-embedding-cast-renamer emb)
+      (right-embedding-cast-renamer emb)
+      emb₀ (embedding-context emb)
+
+data LeftInsertion : Renameᵗ → Set where
+  left-insertion-suc : LeftInsertion suc
+  left-insertion-ext : ∀ {τ} →
+    LeftInsertion τ → LeftInsertion (extᵗ τ)
+
+left-insertion-mode :
+  ∀ {τ} → LeftInsertion τ → ModeEnv → ModeEnv
+left-insertion-mode left-insertion-suc μ = weakenCastᵈ μ
+left-insertion-mode (left-insertion-ext ins) μ zero = μ zero
+left-insertion-mode (left-insertion-ext ins) μ (suc X) =
+  left-insertion-mode ins (λ Y → μ (suc Y)) X
+
+mode≤-refl : ∀ m → mode≤ m m ≡ true
+mode≤-refl id-only = refl
+mode≤-refl tag-or-id = refl
+mode≤-refl seal-or-id = refl
+
+left-insertion-mode-rename :
+  ∀ {τ} (ins : LeftInsertion τ) (μ : ModeEnv) →
+  ModeRename τ μ (left-insertion-mode ins μ)
+left-insertion-mode-rename left-insertion-suc μ =
+  modeRename-suc-weakenCast
+left-insertion-mode-rename (left-insertion-ext ins) μ zero =
+  mode≤-refl (μ zero)
+left-insertion-mode-rename (left-insertion-ext ins) μ (suc X) =
+  left-insertion-mode-rename ins (λ Y → μ (suc Y)) X
+
+left-insertion-cast-renamer :
+  ∀ {τ} → LeftInsertion τ → CastModeRenamer τ
+left-insertion-cast-renamer left-insertion-suc = castModeRenamer-suc
+left-insertion-cast-renamer (left-insertion-ext ins) =
+  castModeRenamer-ext (left-insertion-cast-renamer ins)
+
+push-modeᵈ : Mode → ModeEnv → ModeEnv
+push-modeᵈ id-only = extᵈ
+push-modeᵈ tag-or-id = genᵈ
+push-modeᵈ seal-or-id = instᵈ
+
+cast-push-mode :
+  ∀ {m μ} → CastMode μ → CastMode (push-modeᵈ m μ)
+cast-push-mode {m = id-only} mode = cast-ext mode
+cast-push-mode {m = tag-or-id} mode = cast-gen mode
+cast-push-mode {m = seal-or-id} mode = cast-inst mode
+
+swap-head-targetᵈ :
+  ∀ {μ} → Mode → CastMode μ → ModeEnv
+swap-head-targetᵈ m cast-tag-or-id =
+  genᵈ (push-modeᵈ m tag-or-idᵈ)
+swap-head-targetᵈ m (cast-ext {μ = μ} mode) =
+  extᵈ (push-modeᵈ m μ)
+swap-head-targetᵈ m (cast-gen {μ = μ} mode) =
+  genᵈ (push-modeᵈ m μ)
+swap-head-targetᵈ m (cast-inst {μ = μ} mode) =
+  instᵈ (push-modeᵈ m μ)
+swap-head-targetᵈ m (cast-weaken {μ = μ} mode) =
+  extᵈ (push-modeᵈ m μ)
+
+swap-head-target-mode :
+  ∀ {m μ} (mode : CastMode μ) →
+  CastMode (swap-head-targetᵈ m mode)
+swap-head-target-mode {m = m} cast-tag-or-id =
+  cast-gen (cast-push-mode {m = m} cast-tag-or-id)
+swap-head-target-mode {m = m} (cast-ext mode) =
+  cast-ext (cast-push-mode {m = m} mode)
+swap-head-target-mode {m = m} (cast-gen mode) =
+  cast-gen (cast-push-mode {m = m} mode)
+swap-head-target-mode {m = m} (cast-inst mode) =
+  cast-inst (cast-push-mode {m = m} mode)
+swap-head-target-mode {m = m} (cast-weaken mode) =
+  cast-ext (cast-push-mode {m = m} mode)
+
+swap-mode-targetᵈ :
+  ∀ {μ} → CastMode μ → ModeEnv
+swap-mode-targetᵈ cast-tag-or-id = tag-or-idᵈ
+swap-mode-targetᵈ (cast-ext mode) =
+  swap-head-targetᵈ id-only mode
+swap-mode-targetᵈ (cast-gen mode) =
+  swap-head-targetᵈ tag-or-id mode
+swap-mode-targetᵈ (cast-inst mode) =
+  swap-head-targetᵈ seal-or-id mode
+swap-mode-targetᵈ (cast-weaken mode) =
+  swap-head-targetᵈ id-only mode
+
+swap-mode-target-mode :
+  ∀ {μ} (mode : CastMode μ) → CastMode (swap-mode-targetᵈ mode)
+swap-mode-target-mode cast-tag-or-id = cast-tag-or-id
+swap-mode-target-mode (cast-ext mode) =
+  swap-head-target-mode mode
+swap-mode-target-mode (cast-gen mode) =
+  swap-head-target-mode mode
+swap-mode-target-mode (cast-inst mode) =
+  swap-head-target-mode mode
+swap-mode-target-mode (cast-weaken mode) =
+  swap-head-target-mode mode
+
+swap-push-agrees :
+  ∀ m n μ X →
+  push-modeᵈ n (push-modeᵈ m μ) X ≡
+    push-modeᵈ m (push-modeᵈ n μ) (swap01ᵗ X)
+swap-push-agrees id-only id-only μ zero = refl
+swap-push-agrees id-only id-only μ (suc zero) = refl
+swap-push-agrees id-only id-only μ (suc (suc X)) = refl
+swap-push-agrees id-only tag-or-id μ zero = refl
+swap-push-agrees id-only tag-or-id μ (suc zero) = refl
+swap-push-agrees id-only tag-or-id μ (suc (suc X)) = refl
+swap-push-agrees id-only seal-or-id μ zero = refl
+swap-push-agrees id-only seal-or-id μ (suc zero) = refl
+swap-push-agrees id-only seal-or-id μ (suc (suc X)) = refl
+swap-push-agrees tag-or-id id-only μ zero = refl
+swap-push-agrees tag-or-id id-only μ (suc zero) = refl
+swap-push-agrees tag-or-id id-only μ (suc (suc X)) = refl
+swap-push-agrees tag-or-id tag-or-id μ zero = refl
+swap-push-agrees tag-or-id tag-or-id μ (suc zero) = refl
+swap-push-agrees tag-or-id tag-or-id μ (suc (suc X)) = refl
+swap-push-agrees tag-or-id seal-or-id μ zero = refl
+swap-push-agrees tag-or-id seal-or-id μ (suc zero) = refl
+swap-push-agrees tag-or-id seal-or-id μ (suc (suc X)) = refl
+swap-push-agrees seal-or-id id-only μ zero = refl
+swap-push-agrees seal-or-id id-only μ (suc zero) = refl
+swap-push-agrees seal-or-id id-only μ (suc (suc X)) = refl
+swap-push-agrees seal-or-id tag-or-id μ zero = refl
+swap-push-agrees seal-or-id tag-or-id μ (suc zero) = refl
+swap-push-agrees seal-or-id tag-or-id μ (suc (suc X)) = refl
+swap-push-agrees seal-or-id seal-or-id μ zero = refl
+swap-push-agrees seal-or-id seal-or-id μ (suc zero) = refl
+swap-push-agrees seal-or-id seal-or-id μ (suc (suc X)) = refl
+
+swap-head-base-agrees :
+  ∀ m X →
+  genᵈ (push-modeᵈ m tag-or-idᵈ) X ≡
+    push-modeᵈ m tag-or-idᵈ (swap01ᵗ X)
+swap-head-base-agrees id-only zero = refl
+swap-head-base-agrees id-only (suc zero) = refl
+swap-head-base-agrees id-only (suc (suc X)) = refl
+swap-head-base-agrees tag-or-id zero = refl
+swap-head-base-agrees tag-or-id (suc zero) = refl
+swap-head-base-agrees tag-or-id (suc (suc X)) = refl
+swap-head-base-agrees seal-or-id zero = refl
+swap-head-base-agrees seal-or-id (suc zero) = refl
+swap-head-base-agrees seal-or-id (suc (suc X)) = refl
+
+swap-head-weaken-agrees :
+  ∀ m μ X →
+  extᵈ (push-modeᵈ m μ) X ≡
+    push-modeᵈ m (weakenCastᵈ μ) (swap01ᵗ X)
+swap-head-weaken-agrees id-only μ zero = refl
+swap-head-weaken-agrees id-only μ (suc zero) = refl
+swap-head-weaken-agrees id-only μ (suc (suc X)) = refl
+swap-head-weaken-agrees tag-or-id μ zero = refl
+swap-head-weaken-agrees tag-or-id μ (suc zero) = refl
+swap-head-weaken-agrees tag-or-id μ (suc (suc X)) = refl
+swap-head-weaken-agrees seal-or-id μ zero = refl
+swap-head-weaken-agrees seal-or-id μ (suc zero) = refl
+swap-head-weaken-agrees seal-or-id μ (suc (suc X)) = refl
+
+swap-head-target-agrees :
+  ∀ {m μ} (mode : CastMode μ) X →
+  swap-head-targetᵈ m mode X ≡ push-modeᵈ m μ (swap01ᵗ X)
+swap-head-target-agrees {m = m} cast-tag-or-id X =
+  swap-head-base-agrees m X
+swap-head-target-agrees {m = m} (cast-ext {μ = μ} mode) X =
+  swap-push-agrees m id-only μ X
+swap-head-target-agrees {m = m} (cast-gen {μ = μ} mode) X =
+  swap-push-agrees m tag-or-id μ X
+swap-head-target-agrees {m = m} (cast-inst {μ = μ} mode) X =
+  swap-push-agrees m seal-or-id μ X
+swap-head-target-agrees {m = m} (cast-weaken {μ = μ} mode) X =
+  swap-head-weaken-agrees m μ X
+
+swap-mode-target-agrees :
+  ∀ {μ} (mode : CastMode μ) X →
+  swap-mode-targetᵈ mode X ≡ μ (swap01ᵗ X)
+swap-mode-target-agrees cast-tag-or-id X = refl
+swap-mode-target-agrees (cast-ext mode) X =
+  swap-head-target-agrees mode X
+swap-mode-target-agrees (cast-gen mode) X =
+  swap-head-target-agrees mode X
+swap-mode-target-agrees (cast-inst mode) X =
+  swap-head-target-agrees mode X
+swap-mode-target-agrees (cast-weaken mode) zero =
+  swap-head-target-agrees mode zero
+swap-mode-target-agrees (cast-weaken mode) (suc zero) =
+  swap-head-target-agrees mode (suc zero)
+swap-mode-target-agrees (cast-weaken mode) (suc (suc X)) =
+  swap-head-target-agrees mode (suc (suc X))
+
+swap01-involutiveᵐ : ∀ X → swap01ᵗ (swap01ᵗ X) ≡ X
+swap01-involutiveᵐ zero = refl
+swap01-involutiveᵐ (suc zero) = refl
+swap01-involutiveᵐ (suc (suc X)) = refl
+
+swap-mode-target-rename :
+  ∀ {μ} (mode : CastMode μ) →
+  ModeRename swap01ᵗ μ (swap-mode-targetᵈ mode)
+swap-mode-target-rename {μ = μ} mode X =
+  subst
+    (λ m → mode≤ (μ X) m ≡ true)
+    target-eq
+    (mode≤-refl (μ X))
+  where
+  target-eq : μ X ≡ swap-mode-targetᵈ mode (swap01ᵗ X)
+  target-eq =
+    sym
+      (trans
+        (swap-mode-target-agrees mode (swap01ᵗ X))
+        (cong μ (swap01-involutiveᵐ X)))
+
+swap-mode-seal-source :
+  ∀ {μ} (mode : CastMode μ) (α : TyVar) →
+  sealModeAllowed (swap-mode-targetᵈ mode α) ≡ true →
+  ∃[ b ]
+    (sealModeAllowed (μ b) ≡ true × swap01ᵗ b ≡ α)
+swap-mode-seal-source {μ = μ} mode α ok =
+  swap01ᵗ α , source-ok , swap01-involutiveᵐ α
+  where
+  source-ok : sealModeAllowed (μ (swap01ᵗ α)) ≡ true
+  source-ok =
+    subst (λ m → sealModeAllowed m ≡ true)
+      (swap-mode-target-agrees mode α) ok
+
+castModeRenamer-swap01 : CastModeRenamer swap01ᵗ
+castModeRenamer-swap01 =
+  record
+    { targetᵈ = swap-mode-targetᵈ
+    ; target-mode = swap-mode-target-mode
+    ; target-rename = swap-mode-target-rename
+    ; target-seal-source = swap-mode-seal-source
+    }
+
+castModeRenamer-id : CastModeRenamer (λ X → X)
+castModeRenamer-id =
+  record
+    { targetᵈ = λ {μ} mode → μ
+    ; target-mode = λ mode → mode
+    ; target-rename = λ {μ} mode X → mode≤-refl (μ X)
+    ; target-seal-source = λ mode α ok → α , ok , refl
+    }
+
+mode≤-trans :
+  ∀ m n p →
+  mode≤ m n ≡ true →
+  mode≤ n p ≡ true →
+  mode≤ m p ≡ true
+mode≤-trans id-only id-only id-only mn np = refl
+mode≤-trans id-only id-only tag-or-id mn np = refl
+mode≤-trans id-only id-only seal-or-id mn np = refl
+mode≤-trans id-only tag-or-id id-only mn ()
+mode≤-trans id-only tag-or-id tag-or-id mn np = refl
+mode≤-trans id-only tag-or-id seal-or-id mn ()
+mode≤-trans id-only seal-or-id id-only mn ()
+mode≤-trans id-only seal-or-id tag-or-id mn ()
+mode≤-trans id-only seal-or-id seal-or-id mn np = refl
+mode≤-trans tag-or-id id-only id-only () np
+mode≤-trans tag-or-id id-only tag-or-id () np
+mode≤-trans tag-or-id id-only seal-or-id () np
+mode≤-trans tag-or-id tag-or-id id-only mn ()
+mode≤-trans tag-or-id tag-or-id tag-or-id mn np = refl
+mode≤-trans tag-or-id tag-or-id seal-or-id mn ()
+mode≤-trans tag-or-id seal-or-id id-only () np
+mode≤-trans tag-or-id seal-or-id tag-or-id () np
+mode≤-trans tag-or-id seal-or-id seal-or-id () np
+mode≤-trans seal-or-id id-only id-only () np
+mode≤-trans seal-or-id id-only tag-or-id () np
+mode≤-trans seal-or-id id-only seal-or-id () np
+mode≤-trans seal-or-id tag-or-id id-only () np
+mode≤-trans seal-or-id tag-or-id tag-or-id () np
+mode≤-trans seal-or-id tag-or-id seal-or-id () np
+mode≤-trans seal-or-id seal-or-id id-only mn ()
+mode≤-trans seal-or-id seal-or-id tag-or-id mn ()
+mode≤-trans seal-or-id seal-or-id seal-or-id mn np = refl
+
+modeRename-compose :
+  ∀ {τ σ μ ν ξ} →
+  ModeRename τ μ ν →
+  ModeRename σ ν ξ →
+  ModeRename (λ X → σ (τ X)) μ ξ
+modeRename-compose
+    {τ = τ} {σ = σ} {μ = μ} {ν = nu} {ξ = ξ} rel₁ rel₂ X =
+  mode≤-trans (μ X) (nu (τ X)) (ξ (σ (τ X)))
+    (rel₁ X) (rel₂ (τ X))
+
+castModeRenamer-compose :
+  ∀ {τ σ} →
+  CastModeRenamer τ →
+  CastModeRenamer σ →
+  CastModeRenamer (λ X → σ (τ X))
+castModeRenamer-compose {τ = τ} {σ = σ} η θ =
+  record
+    { targetᵈ = target₂
+    ; target-mode = target-mode₂
+    ; target-rename = target-rename₂
+    ; target-seal-source = target-seal-source₂
+    }
+  where
+  target₂ : ∀ {μ} → CastMode μ → ModeEnv
+  target₂ mode =
+    CastModeRenamer.targetᵈ θ (CastModeRenamer.target-mode η mode)
+
+  target-mode₂ :
+    ∀ {μ} (mode : CastMode μ) → CastMode (target₂ mode)
+  target-mode₂ mode =
+    CastModeRenamer.target-mode θ
+      (CastModeRenamer.target-mode η mode)
+
+  target-rename₂ :
+    ∀ {μ} (mode : CastMode μ) →
+    ModeRename (λ X → σ (τ X)) μ (target₂ mode)
+  target-rename₂ {μ = μ} mode =
+    modeRename-compose {τ = τ} {σ = σ} {μ = μ}
+      {ν = CastModeRenamer.targetᵈ η mode}
+      {ξ = target₂ mode}
+      (CastModeRenamer.target-rename η mode)
+      (CastModeRenamer.target-rename θ
+        (CastModeRenamer.target-mode η mode))
+
+  target-seal-source₂ :
+    ∀ {μ} (mode : CastMode μ) (α : TyVar) →
+    sealModeAllowed (target₂ mode α) ≡ true →
+    ∃[ a ]
+      (sealModeAllowed (μ a) ≡ true × σ (τ a) ≡ α)
+  target-seal-source₂ mode α ok =
+    let b , ok-b , eq-b = CastModeRenamer.target-seal-source θ
+          (CastModeRenamer.target-mode η mode) α ok
+        a , ok-a , eq-a =
+          CastModeRenamer.target-seal-source η mode b ok-b in
+    a , ok-a , trans (cong σ eq-a) eq-b
+
+permuted-modeᵈ :
+  ∀ {Δ Θ} → TyPermutation Δ Θ → ModeEnv → ModeEnv
+permuted-modeᵈ π μ X = μ (backward π X)
+
+permuted-mode-rename :
+  ∀ {Δ Θ} (π : TyPermutation Δ Θ) μ →
+  ModeRename (forward π) μ (permuted-modeᵈ π μ)
+permuted-mode-rename π μ X =
+  subst
+    (λ m → mode≤ (μ X) m ≡ true)
+    (sym (cong μ (backward-forward π X)))
+    (mode≤-refl (μ X))
+
+permuted-mode-seal-source :
+  ∀ {Δ Θ} (π : TyPermutation Δ Θ) μ α →
+  sealModeAllowed (permuted-modeᵈ π μ α) ≡ true →
+  ∃[ b ]
+    (sealModeAllowed (μ b) ≡ true × forward π b ≡ α)
+permuted-mode-seal-source π μ α ok =
+  backward π α , ok , forward-backward π α
+
+embedded-modeᵈ : Renameᵗ → ModeEnv → ModeEnv
+embedded-modeᵈ ψ μ X = μ (ψ X)
+
+embedded-mode-rename :
+  ∀ {τ ψ} →
+  RenameLeftInverse τ ψ →
+  ∀ μ → ModeRename τ μ (embedded-modeᵈ ψ μ)
+embedded-mode-rename {τ = τ} {ψ = ψ} inv μ X =
+  subst
+    (λ m → mode≤ (μ X) m ≡ true)
+    (sym (cong μ (inv X)))
+    (mode≤-refl (μ X))
+
+left-reveal-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  RevealConversion (embedded-modeᵈ ψ μ) Θᴸ (leftStoreⁱ ρ′)
+    (τ α) (renameᵗ τ X) (renameᶜ τ c)
+    (renameᵗ τ A) (renameᵗ τ B)
+left-reveal-rel-embed
+    {τ = τ} {ψ = ψ} {hτ = hτ} {μ = μ} emb conv =
+  subst (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))
+    (rename-reveal-conversion hτ
+      (embedded-mode-rename {τ = τ} {ψ = ψ}
+        (left-embedding-inverse emb) μ) conv)
+
+right-reveal-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ β X c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  RevealConversion (embedded-modeᵈ φ μ) Θᴿ (rightStoreⁱ ρ′)
+    (σ β) (renameᵗ σ X) (renameᶜ σ c)
+    (renameᵗ σ A) (renameᵗ σ B)
+right-reveal-rel-embed
+    {σ = σ} {φ = φ} {hσ = hσ} {μ = μ} emb conv =
+  subst (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))
+    (rename-reveal-conversion hσ
+      (embedded-mode-rename {τ = σ} {ψ = φ}
+        (right-embedding-inverse emb) μ) conv)
+
+left-conceal-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  ConcealConversion (embedded-modeᵈ ψ μ) Θᴸ (leftStoreⁱ ρ′)
+    (τ α) (renameᵗ τ X) (renameᶜ τ c)
+    (renameᵗ τ A) (renameᵗ τ B)
+left-conceal-rel-embed
+    {τ = τ} {ψ = ψ} {hτ = hτ} {μ = μ} emb conv =
+  subst (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))
+    (rename-conceal-conversion hτ
+      (embedded-mode-rename {τ = τ} {ψ = ψ}
+        (left-embedding-inverse emb) μ) conv)
+
+right-conceal-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ β X c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  ConcealConversion (embedded-modeᵈ φ μ) Θᴿ (rightStoreⁱ ρ′)
+    (σ β) (renameᵗ σ X) (renameᶜ σ c)
+    (renameᵗ σ A) (renameᵗ σ B)
+right-conceal-rel-embed
+    {σ = σ} {φ = φ} {hσ = hσ} {μ = μ} emb conv =
+  subst (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))
+    (rename-conceal-conversion hσ
+      (embedded-mode-rename {τ = σ} {ψ = φ}
+        (right-embedding-inverse emb) μ) conv)
+
+left-reveal-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  RevealConversion (permuted-modeᵈ πᴸ μ) Θᴸ
+    (leftStoreⁱ ρ′) (forward πᴸ α) (renameᵗ (forward πᴸ) X)
+    (renameᶜ (forward πᴸ) c) (renameᵗ (forward πᴸ) A)
+    (renameᵗ (forward πᴸ) B)
+left-reveal-rel-permute {πᴸ = πᴸ} perm conv =
+  subst (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+    (rename-reveal-conversion (forward-wf πᴸ)
+      (permuted-mode-rename πᴸ _) conv)
+
+right-reveal-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ) α X c A B →
+  RevealConversion (permuted-modeᵈ πᴿ μ) Θᴿ
+    (rightStoreⁱ ρ′) (forward πᴿ α) (renameᵗ (forward πᴿ) X)
+    (renameᶜ (forward πᴿ) c) (renameᵗ (forward πᴿ) A)
+    (renameᵗ (forward πᴿ) B)
+right-reveal-rel-permute {πᴿ = πᴿ} perm conv =
+  subst (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+    (rename-reveal-conversion (forward-wf πᴿ)
+      (permuted-mode-rename πᴿ _) conv)
+
+left-conceal-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  ConcealConversion (permuted-modeᵈ πᴸ μ) Θᴸ
+    (leftStoreⁱ ρ′) (forward πᴸ α) (renameᵗ (forward πᴸ) X)
+    (renameᶜ (forward πᴸ) c) (renameᵗ (forward πᴸ) A)
+    (renameᵗ (forward πᴸ) B)
+left-conceal-rel-permute {πᴸ = πᴸ} perm conv =
+  subst (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+    (rename-conceal-conversion (forward-wf πᴸ)
+      (permuted-mode-rename πᴸ _) conv)
+
+right-conceal-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ) α X c A B →
+  ConcealConversion (permuted-modeᵈ πᴿ μ) Θᴿ
+    (rightStoreⁱ ρ′) (forward πᴿ α) (renameᵗ (forward πᴿ) X)
+    (renameᶜ (forward πᴿ) c) (renameᵗ (forward πᴿ) A)
+    (renameᵗ (forward πᴿ) B)
+right-conceal-rel-permute {πᴿ = πᴿ} perm conv =
+  subst (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+    (rename-conceal-conversion (forward-wf πᴿ)
+      (permuted-mode-rename πᴿ _) conv)
+
+swap-mode-target-inst-ext :
+  ∀ {μ} (mode : CastMode μ) →
+  swap-mode-targetᵈ (cast-inst (cast-ext mode)) ≡
+    extᵈ (instᵈ μ)
+swap-mode-target-inst-ext mode = refl
+
+swap-mode-target-ext-inst :
+  ∀ {μ} (mode : CastMode μ) →
+  swap-mode-targetᵈ (cast-ext (cast-inst mode)) ≡
+    instᵈ (extᵈ μ)
+swap-mode-target-ext-inst mode = refl
+
+swap-mode-target-gen-ext :
+  ∀ {μ} (mode : CastMode μ) →
+  swap-mode-targetᵈ (cast-gen (cast-ext mode)) ≡
+    extᵈ (genᵈ μ)
+swap-mode-target-gen-ext mode = refl
+
+swap-mode-target-ext-gen :
+  ∀ {μ} (mode : CastMode μ) →
+  swap-mode-targetᵈ (cast-ext (cast-gen mode)) ≡
+    genᵈ (extᵈ μ)
+swap-mode-target-ext-gen mode = refl
+
+no-crossed-up-mode-rename-id :
+  ModeRename suc
+    (extᵈ (instᵈ tag-or-idᵈ)) id-onlyᵈ → ⊥
+no-crossed-up-mode-rename-id rel with rel (suc zero)
+no-crossed-up-mode-rename-id rel | ()
+
+no-crossed-up-mode-rename-same :
+  ModeRename suc
+    (extᵈ (instᵈ tag-or-idᵈ))
+    (extᵈ (instᵈ tag-or-idᵈ)) → ⊥
+no-crossed-up-mode-rename-same rel with rel (suc zero)
+no-crossed-up-mode-rename-same rel | ()
+
+no-crossed-up-mode-rename-opposite :
+  ModeRename suc
+    (extᵈ (instᵈ tag-or-idᵈ))
+    (instᵈ (extᵈ tag-or-idᵈ)) → ⊥
+no-crossed-up-mode-rename-opposite rel with rel (suc zero)
+no-crossed-up-mode-rename-opposite rel | ()
+
+crossed-left-mode-rename-opposite :
+  ModeRename suc
+    (instᵈ (extᵈ tag-or-idᵈ))
+    (extᵈ (instᵈ tag-or-idᵈ))
+crossed-left-mode-rename-opposite zero = refl
+crossed-left-mode-rename-opposite (suc zero) = refl
+crossed-left-mode-rename-opposite (suc (suc X)) = refl
+
+swap01-after-suc :
+  ∀ X → swap01ᵗ (suc X) ≡ extᵗ suc X
+swap01-after-suc zero = refl
+swap01-after-suc (suc X) = refl
+
+swap01-after-ext-suc :
+  ∀ X → swap01ᵗ (extᵗ suc X) ≡ suc X
+swap01-after-ext-suc zero = refl
+swap01-after-ext-suc (suc X) = refl
+
+TyRenameWf-compose :
+  ∀ {Δ Θ Ω τ υ} →
+  TyRenameWf Δ Θ τ →
+  TyRenameWf Θ Ω υ →
+  TyRenameWf Δ Ω (λ X → υ (τ X))
+TyRenameWf-compose hτ hυ X<Δ = hυ (hτ X<Δ)
+
+renameLeftInverse-compose :
+  ∀ {τ υ ψ ξ} →
+  RenameLeftInverse τ ψ →
+  RenameLeftInverse υ ξ →
+  RenameLeftInverse (λ X → υ (τ X)) (λ X → ψ (ξ X))
+renameLeftInverse-compose
+    {τ = τ} {ψ = ψ} inv₁ inv₂ X =
+  trans (cong ψ (inv₂ (τ X))) (inv₁ X)
+
+rename-assm²-membership-composeᵢ :
+  ∀ {Φ Ψ Ω τ σ υ ω} →
+  (∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ) →
+  (∀ {a} → a ∈ Ψ → rename-assm²ᵢ υ ω a ∈ Ω) →
+  ∀ {a} → a ∈ Φ →
+  rename-assm²ᵢ (λ X → υ (τ X)) (λ X → ω (σ X)) a ∈ Ω
+rename-assm²-membership-composeᵢ
+    {Ω = Ω} {τ = τ} {σ = σ} {υ = υ} {ω = ω} assm₁ assm₂ {a} a∈ =
+  subst (_∈ Ω) (rename-assm²-composeᵢ τ σ υ ω a)
+    (assm₂ (assm₁ a∈))
+
+store-inclusion-rename-compose :
+  ∀ τ υ {Σ₀ Σ₁ Σ₂} →
+  StoreIncl (renameStoreᵗ τ Σ₀) Σ₁ →
+  StoreIncl (renameStoreᵗ υ Σ₁) Σ₂ →
+  StoreIncl (renameStoreᵗ (λ X → υ (τ X)) Σ₀) Σ₂
+store-inclusion-rename-compose τ υ {Σ₀ = Σ₀} incl₁ incl₂ {x} x∈ =
+  incl₂
+    (renameStoreᵗ-incl υ incl₁
+      (subst (x ∈_) (sym (renameStoreᵗ-compose τ υ Σ₀)) x∈))
+
+store-projection-embedding-composeⁱ :
+  ∀ {Φ Ψ Ω Δᴸ Δᴿ Θᴸ Θᴿ Ξᴸ Ξᴿ τ σ υ ω}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ₂ : StoreImp Ω Ξᴸ Ξᴿ} →
+  StoreProjectionEmbeddingⁱ τ σ ρ₀ ρ₁ →
+  StoreProjectionEmbeddingⁱ υ ω ρ₁ ρ₂ →
+  StoreProjectionEmbeddingⁱ
+    (λ X → υ (τ X)) (λ X → ω (σ X)) ρ₀ ρ₂
+store-projection-embedding-composeⁱ
+    {τ = τ} {σ = σ} {υ = υ} {ω = ω} emb₁ emb₂ =
+  store-projection-embedding
+    (store-inclusion-rename-compose τ υ
+      (left-store-inclusion emb₁) (left-store-inclusion emb₂))
+    (store-inclusion-rename-compose σ ω
+      (right-store-inclusion emb₁) (right-store-inclusion emb₂))
+
+renamed-name-compose :
+  ∀ {τ υ : Renameᵗ} {α α₁ α₂} →
+  α₁ ≡ τ α →
+  α₂ ≡ υ α₁ →
+  α₂ ≡ υ (τ α)
+renamed-name-compose {τ = τ} {υ = υ} eq₁ eq₂ =
+  trans eq₂ (cong υ eq₁)
+
+renamed-type-compose :
+  ∀ (τ υ : Renameᵗ) {A A₁ A₂} →
+  A₁ ≡ renameᵗ τ A →
+  A₂ ≡ renameᵗ υ A₁ →
+  A₂ ≡ renameᵗ (λ X → υ (τ X)) A
+renamed-type-compose τ υ {A = A} eq₁ eq₂ =
+  trans eq₂
+    (trans (cong (renameᵗ υ) eq₁) (renameᵗ-compose τ υ A))
+
+rel-store-embedding-composeⁱ :
+  ∀ {Φ Ψ Ω Δᴸ Δᴿ Θᴸ Θᴿ Ξᴸ Ξᴿ τ σ υ ω}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ₂ : StoreImp Ω Ξᴸ Ξᴿ} →
+  RelStoreEmbeddingⁱ τ σ ρ₀ ρ₁ →
+  RelStoreEmbeddingⁱ υ ω ρ₁ ρ₂ →
+  RelStoreEmbeddingⁱ
+    (λ X → υ (τ X)) (λ X → ω (σ X)) ρ₀ ρ₂
+rel-store-embedding-composeⁱ
+    rel-store-embedding-[] rel-store-embedding-[] =
+  rel-store-embedding-[]
+rel-store-embedding-composeⁱ
+    {τ = τ} {σ = σ} {υ = υ} {ω = ω}
+    (rel-store-embedding-matched
+      {A = A} {B = B} eqα₁ eqA₁ eqβ₁ eqB₁ emb₁)
+    (rel-store-embedding-matched eqα₂ eqA₂ eqβ₂ eqB₂ emb₂) =
+  rel-store-embedding-matched
+    (renamed-name-compose {τ = τ} {υ = υ} eqα₁ eqα₂)
+    (renamed-type-compose τ υ {A = A} eqA₁ eqA₂)
+    (renamed-name-compose {τ = σ} {υ = ω} eqβ₁ eqβ₂)
+    (renamed-type-compose σ ω {A = B} eqB₁ eqB₂)
+    (rel-store-embedding-composeⁱ emb₁ emb₂)
+rel-store-embedding-composeⁱ
+    {τ = τ} {υ = υ}
+    (rel-store-embedding-left {A = A} eqα₁ eqA₁ emb₁)
+    (rel-store-embedding-left eqα₂ eqA₂ emb₂) =
+  rel-store-embedding-left
+    (renamed-name-compose {τ = τ} {υ = υ} eqα₁ eqα₂)
+    (renamed-type-compose τ υ {A = A} eqA₁ eqA₂)
+    (rel-store-embedding-composeⁱ emb₁ emb₂)
+rel-store-embedding-composeⁱ
+    {σ = σ} {ω = ω}
+    (rel-store-embedding-right {B = B} eqβ₁ eqB₁ emb₁)
+    (rel-store-embedding-right eqβ₂ eqB₂ emb₂) =
+  rel-store-embedding-right
+    (renamed-name-compose {τ = σ} {υ = ω} eqβ₁ eqβ₂)
+    (renamed-type-compose σ ω {A = B} eqB₁ eqB₂)
+    (rel-store-embedding-composeⁱ emb₁ emb₂)
+rel-store-embedding-composeⁱ
+    {τ = τ} {σ = σ} {υ = υ} {ω = ω}
+    (rel-store-embedding-link
+      {A = A} {B = B} eqα₁ eqA₁ eqβ₁ eqB₁ emb₁)
+    (rel-store-embedding-link eqα₂ eqA₂ eqβ₂ eqB₂ emb₂) =
+  rel-store-embedding-link
+    (renamed-name-compose {τ = τ} {υ = υ} eqα₁ eqα₂)
+    (renamed-type-compose τ υ {A = A} eqA₁ eqA₂)
+    (renamed-name-compose {τ = σ} {υ = ω} eqβ₁ eqβ₂)
+    (renamed-type-compose σ ω {A = B} eqB₁ eqB₂)
+    (rel-store-embedding-composeⁱ emb₁ emb₂)
+
+rel-world-embedding-[]-composeⁱ :
+  ∀ {Φ Ψ Ω Δᴸ Δᴿ Θᴸ Θᴿ Ξᴸ Ξᴿ}
+    {τ σ ψ φ υ ω ξ ζ}
+    {assm₁ : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {assm₂ : ∀ {a} → a ∈ Ψ → rename-assm²ᵢ υ ω a ∈ Ω}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {hυ : TyRenameWf Θᴸ Ξᴸ υ} {hω : TyRenameWf Θᴿ Ξᴿ ω}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₁ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ₂ : StoreImp Ω Ξᴸ Ξᴿ} →
+  RelWorldEmbeddingⁱ τ σ ψ φ assm₁ hτ hσ
+    {ρ = ρ₀} {ρ′ = ρ₁} {γ = []} {γ′ = []} →
+  RelWorldEmbeddingⁱ υ ω ξ ζ assm₂ hυ hω
+    {ρ = ρ₁} {ρ′ = ρ₂} {γ = []} {γ′ = []} →
+  RelWorldEmbeddingⁱ
+    (λ X → υ (τ X)) (λ X → ω (σ X))
+    (λ X → ψ (ξ X)) (λ X → φ (ζ X))
+    (rename-assm²-membership-composeᵢ assm₁ assm₂)
+    (TyRenameWf-compose hτ hυ) (TyRenameWf-compose hσ hω)
+    {ρ = ρ₀} {ρ′ = ρ₂} {γ = []} {γ′ = []}
+rel-world-embedding-[]-composeⁱ
+    {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
+    {υ = υ} {ω = ω} {ξ = ξ} {ζ = ζ} emb₁ emb₂ =
+  rel-world-embedding
+    (renameLeftInverse-compose {τ = τ} {υ = υ} {ψ = ψ} {ξ = ξ}
+      (left-embedding-inverse emb₁) (left-embedding-inverse emb₂))
+    (renameLeftInverse-compose {τ = σ} {υ = ω} {ψ = φ} {ξ = ζ}
+      (right-embedding-inverse emb₁) (right-embedding-inverse emb₂))
+    (castModeRenamer-compose
+      (left-embedding-cast-renamer emb₁)
+      (left-embedding-cast-renamer emb₂))
+    (castModeRenamer-compose
+      (right-embedding-cast-renamer emb₁)
+      (right-embedding-cast-renamer emb₂))
+    (rel-store-embedding-composeⁱ
+      (store-embedding emb₁) (store-embedding emb₂))
+    rel-ctx-rename-[]
+
+renameᵗ-swap01-after-suc :
+  ∀ A → renameᵗ swap01ᵗ (⇑ᵗ A) ≡ renameᵗ (extᵗ suc) A
+renameᵗ-swap01-after-suc A =
+  trans (renameᵗ-compose suc swap01ᵗ A)
+    (rename-cong swap01-after-suc A)
+
+renameᵗᵐ-swap01-after-suc :
+  ∀ M →
+  renameᵗᵐ swap01ᵗ (⇑ᵗᵐ M) ≡ renameᵗᵐ (extᵗ suc) M
+renameᵗᵐ-swap01-after-suc M =
+  trans (renameᵗᵐ-compose suc swap01ᵗ M)
+    (renameᵗᵐ-cong swap01-after-suc M)
+
+renameᵗ-swap01-after-ext-suc :
+  ∀ A → renameᵗ swap01ᵗ (renameᵗ (extᵗ suc) A) ≡ ⇑ᵗ A
+renameᵗ-swap01-after-ext-suc A =
+  trans (renameᵗ-compose (extᵗ suc) swap01ᵗ A)
+    (rename-cong swap01-after-ext-suc A)
+
+renameᵗᵐ-swap01-after-ext-suc :
+  ∀ M →
+  renameᵗᵐ swap01ᵗ (renameᵗᵐ (extᵗ suc) M) ≡ ⇑ᵗᵐ M
+renameᵗᵐ-swap01-after-ext-suc M =
+  trans (renameᵗᵐ-compose (extᵗ suc) swap01ᵗ M)
+    (renameᵗᵐ-cong swap01-after-ext-suc M)
+
+renameᵗᵐ-pointed-bullet :
+  ∀ τ L →
+  renameᵗᵐ (extᵗ τ) ((⇑ᵗᵐ L) •) ≡
+    (⇑ᵗᵐ (renameᵗᵐ τ L)) •
+renameᵗᵐ-pointed-bullet τ L =
+  cong _• (renameᵗᵐ-ext-suc-comm τ L)
+
+rename-assm²-target-ext-idᵢ :
+  ∀ {τ a} →
+  rename-assm²ᵢ τ (extᵗ (λ X → X)) a
+    ≡ rename-assm²ᵢ τ (λ X → X) a
+rename-assm²-target-ext-idᵢ {a = X ˣ⊑★} = refl
+rename-assm²-target-ext-idᵢ {a = X ˣ⊑ˣ zero} = refl
+rename-assm²-target-ext-idᵢ {a = X ˣ⊑ˣ suc Y} = refl
+
+rename-assm²-∀-leftᵢ :
+  ∀ {Φ Ψ τ} →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  ∀ {a} → a ∈ ∀ᵢᶜ Φ →
+  rename-assm²ᵢ (extᵗ τ) (λ X → X) a ∈ ∀ᵢᶜ Ψ
+rename-assm²-∀-leftᵢ {Ψ = Ψ} assm {a = a} a∈ =
+  subst
+    (_∈ ∀ᵢᶜ Ψ)
+    rename-assm²-target-ext-idᵢ
+    (rename-assm²-⇑ᵢ assm a∈)
+
+⊑-rename-leftᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A B} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  Ψ ∣ Δᴸ′ ⊢ renameᵗ τ A ⊑ B ⊣ Δᴿ
+⊑-rename-leftᵢ τ assm hτ id★ = id★
+⊑-rename-leftᵢ τ assm hτ (idˣ a∈ X<Δ Y<Δ) =
+  idˣ (assm a∈) (hτ X<Δ) Y<Δ
+⊑-rename-leftᵢ τ assm hτ idι = idι
+⊑-rename-leftᵢ τ assm hτ (p ↦ q) =
+  ⊑-rename-leftᵢ τ assm hτ p ↦
+  ⊑-rename-leftᵢ τ assm hτ q
+⊑-rename-leftᵢ τ assm hτ (∀ⁱ p) =
+  ∀ⁱ (⊑-rename-leftᵢ
+    (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ) p)
+⊑-rename-leftᵢ τ assm hτ (tag ι) = tag ι
+⊑-rename-leftᵢ τ assm hτ (tag p ⇛ q) =
+  tag (⊑-rename-leftᵢ τ assm hτ p) ⇛
+  ⊑-rename-leftᵢ τ assm hτ q
+⊑-rename-leftᵢ τ assm hτ (tagˣ a∈ X<Δ) =
+  tagˣ (assm a∈) (hτ X<Δ)
+⊑-rename-leftᵢ {Φ = Φ} τ assm hτ (ν {A = A} occ p) =
+  ν (trans (occurs-zero-rename-ext τ A) occ)
+    (⊑-rename-leftᵢ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ) p)
+
+⊑-rename-left-atᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A A′ B} (τ : Renameᵗ) →
+  (assm : ∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  (hτ : TyRenameWf Δᴸ Δᴸ′ τ) →
+  A′ ≡ renameᵗ τ A →
+  Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  Ψ ∣ Δᴸ′ ⊢ A′ ⊑ B ⊣ Δᴿ
+⊑-rename-left-atᵢ τ assm hτ eqA p =
+  subst (λ T → _ ∣ _ ⊢ T ⊑ _ ⊣ _) (sym eqA)
+    (⊑-rename-leftᵢ τ assm hτ p)
+
+swap01-ext²-commute :
+  ∀ (τ : Renameᵗ) X →
+  swap01ᵗ (extᵗ (extᵗ τ) X) ≡
+    extᵗ (extᵗ τ) (swap01ᵗ X)
+swap01-ext²-commute τ zero = refl
+swap01-ext²-commute τ (suc zero) = refl
+swap01-ext²-commute τ (suc (suc X)) = refl
+
+renameᵗ-swap01-ext²-commute :
+  ∀ (τ : Renameᵗ) A →
+  renameᵗ swap01ᵗ (renameᵗ (extᵗ (extᵗ τ)) A) ≡
+    renameᵗ (extᵗ (extᵗ τ)) (renameᵗ swap01ᵗ A)
+renameᵗ-swap01-ext²-commute τ A =
+  trans
+    (renameᵗ-compose (extᵗ (extᵗ τ)) swap01ᵗ A)
+    (trans
+      (rename-cong (swap01-ext²-commute τ) A)
+      (sym (renameᵗ-compose swap01ᵗ (extᵗ (extᵗ τ)) A)))
+
+≈∀-renameᵗ :
+  ∀ {τ A B} → A ≈∀ B → renameᵗ τ A ≈∀ renameᵗ τ B
+≈∀-renameᵗ ≈∀-refl = ≈∀-refl
+≈∀-renameᵗ (≈∀-sym A≈B) = ≈∀-sym (≈∀-renameᵗ A≈B)
+≈∀-renameᵗ (≈∀-trans A≈B B≈C) =
+  ≈∀-trans (≈∀-renameᵗ A≈B) (≈∀-renameᵗ B≈C)
+≈∀-renameᵗ (≈∀-⇒ A≈A′ B≈B′) =
+  ≈∀-⇒ (≈∀-renameᵗ A≈A′) (≈∀-renameᵗ B≈B′)
+≈∀-renameᵗ (≈∀-∀ A≈B) = ≈∀-∀ (≈∀-renameᵗ A≈B)
+≈∀-renameᵗ {τ = τ} (≈∀-swap {A = A}) =
+  subst
+    (λ T → `∀ (`∀ (renameᵗ (extᵗ (extᵗ τ)) A)) ≈∀
+      `∀ (`∀ T))
+    (renameᵗ-swap01-ext²-commute τ A)
+    ≈∀-swap
+
+applyTy-preserves-≈∀ :
+  ∀ {χ A B} →
+  A ≈∀ B →
+  applyTy χ A ≈∀ applyTy χ B
+applyTy-preserves-≈∀ {χ = keep} A≈B = A≈B
+applyTy-preserves-≈∀ {χ = bind C} A≈B = ≈∀-renameᵗ A≈B
+
+applyTys-preserves-≈∀ :
+  ∀ {χs A B} →
+  A ≈∀ B →
+  applyTys χs A ≈∀ applyTys χs B
+applyTys-preserves-≈∀ {χs = []} A≈B = A≈B
+applyTys-preserves-≈∀ {χs = χ ∷ χs} A≈B =
+  applyTys-preserves-≈∀ {χs = χs}
+    (applyTy-preserves-≈∀ {χ = χ} A≈B)
+
+weak-one-step-transport-quotientᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B χ C D}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : WeakOneStepResult ρ M N′ A B χ) →
+  Φ ∣ Δᴸ ⊢ C ⊑ᵖ D ⊣ Δᴿ →
+  resultCtx result ∣ resultLeftCtx result
+    ⊢ applyTys (sourceChanges result) C
+      ⊑ᵖ applyTys (targetTailChanges result) (applyTy χ D)
+    ⊣ resultRightCtx result
+weak-one-step-transport-quotientᵀ {χ = χ} result
+    (quotientᵖ C≈E E⊑F F≈D) =
+  quotientᵖ
+    (applyTys-preserves-≈∀
+      {χs = sourceChanges result} C≈E)
+    (transportType result E⊑F)
+    (applyTys-preserves-≈∀
+      {χs = targetTailChanges result}
+      (applyTy-preserves-≈∀ {χ = χ} F≈D))
+
+⊑ᵖ-rename-leftᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ A B} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  Φ ∣ Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ →
+  Ψ ∣ Δᴸ′ ⊢ renameᵗ τ A ⊑ᵖ B ⊣ Δᴿ
+⊑ᵖ-rename-leftᵢ τ assm hτ (quotientᵖ A≈C C⊑D D≈B) =
+  quotientᵖ (≈∀-renameᵗ A≈C)
+    (⊑-rename-leftᵢ τ assm hτ C⊑D) D≈B
+
+⊑ᵖ-rename²ᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ A B} →
+  (assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ) →
+  (hτ : TyRenameWf Δᴸ Θᴸ τ) →
+  (hσ : TyRenameWf Δᴿ Θᴿ σ) →
+  Φ ∣ Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ →
+  Ψ ∣ Θᴸ ⊢ renameᵗ τ A ⊑ᵖ renameᵗ σ B ⊣ Θᴿ
+⊑ᵖ-rename²ᵢ assm hτ hσ (quotientᵖ A≈C C⊑D D≈B) =
+  quotientᵖ (≈∀-renameᵗ A≈C)
+    (⊑-renameᵗ²ᵢ assm hτ hσ C⊑D) (≈∀-renameᵗ D≈B)
+
+left-id-narrowing-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  id-onlyᵈ ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ (forward πᴸ) c
+    ∶ renameᵗ (forward πᴸ) A ⊒ renameᵗ (forward πᴸ) B
+left-id-narrowing-rel-permute
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {ρ′ = ρ′} {c = c} {A = A} {B = B}
+    perm c⊒ =
+  subst
+    (λ Σ → id-onlyᵈ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ (forward πᴸ) c
+      ∶ renameᵗ (forward πᴸ) A ⊒ renameᵗ (forward πᴸ) B)
+    (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+    (narrow-renameᵗ (forward-wf πᴸ) (λ X → refl) c⊒)
+
+right-id-narrowing-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  id-onlyᵈ ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ (forward πᴿ) c
+    ∶ renameᵗ (forward πᴿ) A ⊒ renameᵗ (forward πᴿ) B
+right-id-narrowing-rel-permute
+    {Θᴿ = Θᴿ} {πᴿ = πᴿ} {ρ′ = ρ′} {c = c} {A = A} {B = B}
+    perm c⊒ =
+  subst
+    (λ Σ → id-onlyᵈ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ (forward πᴿ) c
+      ∶ renameᵗ (forward πᴿ) A ⊒ renameᵗ (forward πᴿ) B)
+    (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+    (narrow-renameᵗ (forward-wf πᴿ) (λ X → refl) c⊒)
+
+rel-world-down-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ C C′ D D′ pC d d′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) C ⊑ renameᵗ (forward πᴿ) C′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pC →
+  (qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ (forward πᴸ) (M ⟨ d ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ d′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) D ⊑ᵖ renameᵗ (forward πᴿ) D′
+    ∶ ⊑ᵖ-rename²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) qD
+rel-world-down-permuteᵀ perm d⊒ d′⊒ M⊑M′ qD =
+  down⊑downᵀ
+    (left-id-narrowing-rel-permute perm d⊒)
+    (right-id-narrowing-rel-permute perm d′⊒)
+    M⊑M′
+    (⊑ᵖ-rename²ᵢ _ _ _ qD)
+
+⇑ᴿᵢ-membership :
+  ∀ {Φ a} →
+  a ∈ Φ →
+  ⇑ᴿᵢₐ a ∈ ⇑ᴿᵢ Φ
+⇑ᴿᵢ-membership (here refl) = here refl
+⇑ᴿᵢ-membership (there a∈) = there (⇑ᴿᵢ-membership a∈)
+
+rename-assm²-⇑ᴿ²ᵢ :
+  ∀ {Φ Ψ τ σ} →
+  (∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ) →
+  ∀ {a} → a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ τ (extᵗ σ) a ∈ ⇑ᴿᵢ Ψ
+rename-assm²-⇑ᴿ²ᵢ {Φ = []} assm ()
+rename-assm²-⇑ᴿ²ᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (here refl) =
+  ⇑ᴿᵢ-membership (assm (here refl))
+rename-assm²-⇑ᴿ²ᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (here refl) =
+  ⇑ᴿᵢ-membership (assm (here refl))
+rename-assm²-⇑ᴿ²ᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (there a∈) =
+  rename-assm²-⇑ᴿ²ᵢ (λ b∈ → assm (there b∈)) a∈
+rename-assm²-⇑ᴿ²ᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (there a∈) =
+  rename-assm²-⇑ᴿ²ᵢ (λ b∈ → assm (there b∈)) a∈
+
+rename-assm²-⇑ᴿᵢ :
+  ∀ {Φ Ψ τ} →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  ∀ {a} → a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ τ (λ X → X) a ∈ ⇑ᴿᵢ Ψ
+rename-assm²-⇑ᴿᵢ {Φ = []} assm ()
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (here refl) =
+  ⇑ᴿᵢ-membership (assm (here refl))
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (here refl) =
+  ⇑ᴿᵢ-membership (assm (here refl))
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑★) ∷ Φ} assm (there a∈) =
+  rename-assm²-⇑ᴿᵢ (λ b∈ → assm (there b∈)) a∈
+rename-assm²-⇑ᴿᵢ {Φ = (X ˣ⊑ˣ Y) ∷ Φ} assm (there a∈) =
+  rename-assm²-⇑ᴿᵢ (λ b∈ → assm (there b∈)) a∈
+
+rename-assm²-source-under-right-tailᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (λ X → X) a ∈ ⇑ᴿᵢ (⇑ᴸᵢ Φ)
+rename-assm²-source-under-right-tailᵢ {Φ = []} ()
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-source-under-right-tailᵢ a∈)
+rename-assm²-source-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-source-under-right-tailᵢ a∈)
+
+rename-assm²-source-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (λ X → X) a ∈
+    ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+rename-assm²-source-under-rightᵢ a∈ =
+  there (rename-assm²-source-under-right-tailᵢ a∈)
+
+⊑-source-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ B ⊣ suc Δᴿ
+⊑-source-under-rightᵢ =
+  ⊑-rename-leftᵢ suc rename-assm²-source-under-rightᵢ
+    TyRenameWf-suc
+
+⊑-target-under-leftᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ⊢ A ⊑ B ⊣ Δᴿ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+    ∣ suc Δᴸ ⊢ A ⊑ ⇑ᵗ B ⊣ suc Δᴿ
+⊑-target-under-leftᵢ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B} p =
+  subst
+    (λ S → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      ∣ suc Δᴸ ⊢ S ⊑ ⇑ᵗ B ⊣ suc Δᴿ)
+    (renameᵗ-ext-id A)
+    (⊑-renameᵗ²ᵢ
+      (rename-assm²-⇑ᴸᵢ rename-assm²-target-rightᵢ)
+      (TyRenameWf-ext (λ X<Δ → X<Δ))
+      TyRenameWf-suc p)
+
+right-under-left-ctx-eq :
+  ∀ Φ →
+  ⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ≡
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+right-under-left-ctx-eq Φ =
+  cong ((zero ˣ⊑★) ∷_) (sym (⇑ᴸᵢ-⇑ᴿᵢ-commute Φ))
+
+⊑ᵖ-target-under-leftᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+    ∣ suc Δᴸ ⊢ A ⊑ᵖ ⇑ᵗ B ⊣ suc Δᴿ
+⊑ᵖ-target-under-leftᵢ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B} q =
+  subst
+    (λ S → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      ∣ suc Δᴸ ⊢ S ⊑ᵖ ⇑ᵗ B ⊣ suc Δᴿ)
+    (renameᵗ-ext-id A)
+    (⊑ᵖ-rename²ᵢ
+      (rename-assm²-⇑ᴸᵢ rename-assm²-target-rightᵢ)
+      (TyRenameWf-ext (λ X<Δ → X<Δ))
+      TyRenameWf-suc q)
+
+⊑-target-under-left-arrowᵢ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′}
+    (pA : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+    (pB : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  ⊑-target-under-leftᵢ (pA ↦ pB) ≡
+    ⊑-target-under-leftᵢ pA ↦ ⊑-target-under-leftᵢ pB
+⊑-target-under-left-arrowᵢ {A = A} {B = B} pA pB
+    rewrite equality-proof-unique
+      (renameᵗ-ext-id (A ⇒ B))
+      (cong₂ _⇒_ (renameᵗ-ext-id A) (renameᵗ-ext-id B)) =
+  transport-arrow-⊑ᵢ
+    (renameᵗ-ext-id A) refl (renameᵗ-ext-id B) refl
+
+⊑-target-lift-right-ν-shapeᵢ :
+  ∀ {Φ Δᴸ Δᴿ C B}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ C ⊑ B ⊣ Δᴿ}
+    (occ : occurs zero C ≡ true) →
+  ∃[ occ′ ]
+    ⊑-target-lift-rightᵢ (ν occ p) ≡
+      ν occ′ (⊑-target-under-leftᵢ p)
+⊑-target-lift-right-ν-shapeᵢ {C = C} occ
+    rewrite equality-proof-unique
+      (renameᵗ-id (`∀ C)) (cong `∀ (renameᵗ-ext-id C)) =
+  _ ,
+  transport-ν-⊑ᵢ (renameᵗ-ext-id C)
+    (trans (occurs-zero-rename-ext (λ X → X) C) occ)
+
+rel-store-rename-lift-rightⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  RelStoreRenameⁱ τ σ assm hτ hσ ρ ρ′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ′ᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
+    RelStoreRenameⁱ
+      τ (extᵗ σ) (rename-assm²-⇑ᴿ²ᵢ assm)
+      hτ (TyRenameWf-ext hσ) ρᴿ ρ′ᴿ
+rel-store-rename-lift-rightⁱ
+    rel-store-rename-[] lift-right-store-[] =
+  [] , lift-right-store-[] , rel-store-rename-[]
+rel-store-rename-lift-rightⁱ
+    (rel-store-rename-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-right-store-∷ {p′ = pᴿ} liftρ)
+    with rel-store-rename-lift-rightⁱ renameρ liftρ
+rel-store-rename-lift-rightⁱ
+    {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-rename-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-right-store-∷ {A = A} {B = B} {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-matched α′ A′ (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+        hτ (TyRenameWf-ext hσ) eqA eqBᴿ pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-∷ liftρ′ ,
+  rel-store-rename-matched
+    eqα eqA (cong suc eqβ) eqBᴿ renameρᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-rename-lift-rightⁱ
+    (rel-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-right-store-left liftρ)
+    with rel-store-rename-lift-rightⁱ renameρ liftρ
+rel-store-rename-lift-rightⁱ
+    (rel-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-right-store-left liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-left α′ A′ hA′ ∷ ρ′ᴿ ,
+  lift-right-store-left liftρ′ ,
+  rel-store-rename-left eqα eqA renameρᴿ
+rel-store-rename-lift-rightⁱ
+    (rel-store-rename-right {β′ = β′} {B′ = B′} {hB′ = hB′}
+      eqβ eqB renameρ)
+    (lift-right-store-right liftρ)
+    with rel-store-rename-lift-rightⁱ renameρ liftρ
+rel-store-rename-lift-rightⁱ {σ = σ}
+    (rel-store-rename-right {β′ = β′} {B′ = B′} {hB′ = hB′}
+      eqβ eqB renameρ)
+    (lift-right-store-right {B = B} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-right (suc β′) (⇑ᵗ B′)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′ᴿ ,
+  lift-right-store-right liftρ′ ,
+  rel-store-rename-right (cong suc eqβ) eqBᴿ renameρᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-rename-lift-rightⁱ
+    (rel-store-rename-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-right-store-link {p′ = pᴿ} liftρ)
+    with rel-store-rename-lift-rightⁱ renameρ liftρ
+rel-store-rename-lift-rightⁱ
+    {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-rename-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB renameρ)
+    (lift-right-store-link {A = A} {B = B} {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-link α′ A′ (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+        hτ (TyRenameWf-ext hσ) eqA eqBᴿ pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-link liftρ′ ,
+  rel-store-rename-link eqα eqA (cong suc eqβ) eqBᴿ renameρᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+rel-store-embedding-lift-rightⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ′ᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
+    RelStoreEmbeddingⁱ τ (extᵗ σ) ρᴿ ρ′ᴿ
+rel-store-embedding-lift-rightⁱ
+    rel-store-embedding-[] lift-right-store-[] =
+  [] , lift-right-store-[] , rel-store-embedding-[]
+rel-store-embedding-lift-rightⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-right-store-∷ {p′ = pᴿ} liftρ)
+    with rel-store-embedding-lift-rightⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-rightⁱ
+    {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-right-store-∷ {A = A} {B = B} {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , embᴿ =
+  store-matched α′ A′ (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+        hτ (TyRenameWf-ext hσ) eqA eqBᴿ pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-∷ liftρ′ ,
+  rel-store-embedding-matched
+    eqα eqA (cong suc eqβ) eqBᴿ embᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-embedding-lift-rightⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-right-store-left liftρ)
+    with rel-store-embedding-lift-rightⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-rightⁱ
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-right-store-left liftρ)
+    | ρ′ᴿ , liftρ′ , embᴿ =
+  store-left α′ A′ hA′ ∷ ρ′ᴿ ,
+  lift-right-store-left liftρ′ ,
+  rel-store-embedding-left eqα eqA embᴿ
+rel-store-embedding-lift-rightⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-right-store-right liftρ)
+    with rel-store-embedding-lift-rightⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-rightⁱ {σ = σ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-right-store-right {B = B} liftρ)
+    | ρ′ᴿ , liftρ′ , embᴿ =
+  store-right (suc β′) (⇑ᵗ B′)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′ᴿ ,
+  lift-right-store-right liftρ′ ,
+  rel-store-embedding-right (cong suc eqβ) eqBᴿ embᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-embedding-lift-rightⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-right-store-link {p′ = pᴿ} liftρ)
+    with rel-store-embedding-lift-rightⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-lift-rightⁱ
+    {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      eqα eqA eqβ eqB emb)
+    (lift-right-store-link {A = A} {B = B} {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , embᴿ =
+  store-link α′ A′ (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+        hτ (TyRenameWf-ext hσ) eqA eqBᴿ pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-link liftρ′ ,
+  rel-store-embedding-link eqα eqA (cong suc eqβ) eqBᴿ embᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+rel-ctx-rename-lift-rightⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ γ′ᴿ ]
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ ×
+    RelCtxRenameⁱ
+      τ (extᵗ σ) (rename-assm²-⇑ᴿ²ᵢ assm)
+      hτ (TyRenameWf-ext hσ) γᴿ γ′ᴿ
+rel-ctx-rename-lift-rightⁱ rel-ctx-rename-[] lift-right-ctx-[] =
+  [] , lift-right-ctx-[] , rel-ctx-rename-[]
+rel-ctx-rename-lift-rightⁱ
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′}
+      eqA eqB renameγ)
+    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
+    with rel-ctx-rename-lift-rightⁱ renameγ liftγ
+rel-ctx-rename-lift-rightⁱ
+    {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′}
+      eqA eqB renameγ)
+    (lift-right-ctx-∷ {A = A} {B = B} {p′ = pᴿ} liftγ)
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ctx-imp A′ (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+        hτ (TyRenameWf-ext hσ) eqA eqBᴿ pᴿ) ∷ γ′ᴿ ,
+  lift-right-ctx-∷ liftγ′ ,
+  rel-ctx-rename-∷ eqA eqBᴿ renameγᴿ
+  where
+  eqBᴿ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqBᴿ = trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+rel-world-permutation-lift-rightⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ ρ′ᴿ ] ∃[ γ′ᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ ×
+    RelWorldPermutationⁱ πᴸ (TyPermutation-ext πᴿ)
+      (rename-assm²-⇑ᴿ²ᵢ assm)
+      {ρ = ρᴿ} {ρ′ = ρ′ᴿ} {γ = γᴿ} {γ′ = γ′ᴿ}
+rel-world-permutation-lift-rightⁱ perm liftρ liftγ
+    with rel-store-rename-lift-rightⁱ
+      (store-permutation perm) liftρ
+       | rel-ctx-rename-lift-rightⁱ (ctx-permutation perm) liftγ
+rel-world-permutation-lift-rightⁱ perm liftρ liftγ
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ρ′ᴿ , γ′ᴿ , liftρ′ , liftγ′ ,
+  rel-world-permutation
+    (left-cast-renamer perm)
+    (castModeRenamer-ext (right-cast-renamer perm))
+    renameρᴿ renameγᴿ
+
+rel-world-embedding-lift-rightⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ ρ′ᴿ ] ∃[ γ′ᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ ×
+    RelWorldEmbeddingⁱ τ (extᵗ σ) ψ (extᵗ φ)
+      (rename-assm²-⇑ᴿ²ᵢ assm) hτ (TyRenameWf-ext hσ)
+      {ρ = ρᴿ} {ρ′ = ρ′ᴿ} {γ = γᴿ} {γ′ = γ′ᴿ}
+rel-world-embedding-lift-rightⁱ
+    {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ liftγ
+    with rel-store-embedding-lift-rightⁱ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      (store-embedding emb) liftρ
+       | rel-ctx-rename-lift-rightⁱ (embedding-context emb) liftγ
+rel-world-embedding-lift-rightⁱ emb liftρ liftγ
+    | ρ′ᴿ , liftρ′ , embρᴿ
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ρ′ᴿ , γ′ᴿ , liftρ′ , liftγ′ ,
+  rel-world-embedding
+    (left-embedding-inverse emb)
+    (RenameLeftInverse-ext (right-embedding-inverse emb))
+    (left-embedding-cast-renamer emb)
+    (castModeRenamer-ext (right-embedding-cast-renamer emb))
+    embρᴿ renameγᴿ
+
+data LeftStoreRenameⁱ
+    {Φ Ψ Δᴸ Δᴸ′ Δᴿ}
+    (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ) :
+    StoreImp Φ Δᴸ Δᴿ → StoreImp Ψ Δᴸ′ Δᴿ → Set where
+  left-store-rename-[] :
+    LeftStoreRenameⁱ τ assm hτ [] []
+
+  left-store-rename-matched :
+    ∀ {ρ ρ′ α α′ A A′ β B p}
+      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-matched α A β B p ∷ ρ)
+      (store-matched α′ A′ β B
+        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′)
+
+  left-store-rename-left :
+    ∀ {ρ ρ′ α α′ A A′ hA hA′}
+      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-left α A hA ∷ ρ)
+      (store-left α′ A′ hA′ ∷ ρ′)
+
+  left-store-rename-right :
+    ∀ {ρ ρ′ β B hB hB′} →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-right β B hB ∷ ρ)
+      (store-right β B hB′ ∷ ρ′)
+
+  left-store-rename-link :
+    ∀ {ρ ρ′ α α′ A A′ β B p}
+      (eqα : α′ ≡ τ α) (eqA : A′ ≡ renameᵗ τ A) →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftStoreRenameⁱ τ assm hτ
+      (store-link α A β B p ∷ ρ)
+      (store-link α′ A′ β B
+        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′)
+
+data LeftCtxRenameⁱ
+    {Φ Ψ Δᴸ Δᴸ′ Δᴿ}
+    (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ) :
+    CtxImp Φ Δᴸ Δᴿ → CtxImp Ψ Δᴸ′ Δᴿ → Set where
+  left-ctx-rename-[] :
+    LeftCtxRenameⁱ τ assm hτ [] []
+
+  left-ctx-rename-∷ :
+    ∀ {γ γ′ A A′ B p} (eqA : A′ ≡ renameᵗ τ A) →
+    LeftCtxRenameⁱ τ assm hτ γ γ′ →
+    LeftCtxRenameⁱ τ assm hτ
+      (ctx-imp A B p ∷ γ)
+      (ctx-imp A′ B
+        (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ γ′)
+
+left-store-rename-prefix-invⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  LeftStoreRenameⁱ τ assm hτ ρ⁺ ρ′⁺ →
+  ∃[ ρ₀′ ]
+    LeftStoreRenameⁱ τ assm hτ ρ₀ ρ₀′ ×
+    StoreImpPrefix ρ₀′ ρ′⁺
+left-store-rename-prefix-invⁱ prefix-reflⁱ renameρ =
+  _ , renameρ , prefix-reflⁱ
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-matched eqα eqA renameρ)
+    with left-store-rename-prefix-invⁱ prefix renameρ
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-left eqα eqA renameρ)
+    with left-store-rename-prefix-invⁱ prefix renameρ
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-right renameρ)
+    with left-store-rename-prefix-invⁱ prefix renameρ
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-right renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-link eqα eqA renameρ)
+    with left-store-rename-prefix-invⁱ prefix renameρ
+left-store-rename-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ₀′ , renameρ₀ , prefix′ =
+  ρ₀′ , renameρ₀ , prefix-∷ⁱ prefix′
+
+leftStoreⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  leftStoreⁱ ρ′ ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+leftStoreⁱ-left-rename left-store-rename-[] = refl
+leftStoreⁱ-left-rename
+    (left-store-rename-matched eqα eqA renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-left-rename renameρ)
+leftStoreⁱ-left-rename
+    (left-store-rename-left eqα eqA renameρ) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA) (leftStoreⁱ-left-rename renameρ)
+leftStoreⁱ-left-rename (left-store-rename-right renameρ) =
+  leftStoreⁱ-left-rename renameρ
+leftStoreⁱ-left-rename (left-store-rename-link eqα eqA renameρ) =
+  leftStoreⁱ-left-rename renameρ
+
+rightStoreⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  rightStoreⁱ ρ′ ≡ rightStoreⁱ ρ
+rightStoreⁱ-left-rename left-store-rename-[] = refl
+rightStoreⁱ-left-rename
+    (left-store-rename-matched eqα eqA renameρ) =
+  cong (_ ∷_) (rightStoreⁱ-left-rename renameρ)
+rightStoreⁱ-left-rename (left-store-rename-left eqα eqA renameρ) =
+  rightStoreⁱ-left-rename renameρ
+rightStoreⁱ-left-rename (left-store-rename-right renameρ) =
+  cong (_ ∷_) (rightStoreⁱ-left-rename renameρ)
+rightStoreⁱ-left-rename (left-store-rename-link eqα eqA renameρ) =
+  rightStoreⁱ-left-rename renameρ
+
+leftCtxⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  leftCtxⁱ γ′ ≡ map (renameᵗ τ) (leftCtxⁱ γ)
+leftCtxⁱ-left-rename left-ctx-rename-[] = refl
+leftCtxⁱ-left-rename (left-ctx-rename-∷ eqA renameγ) =
+  cong₂ _∷_ eqA (leftCtxⁱ-left-rename renameγ)
+
+rightCtxⁱ-left-rename :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  rightCtxⁱ γ′ ≡ rightCtxⁱ γ
+rightCtxⁱ-left-rename left-ctx-rename-[] = refl
+rightCtxⁱ-left-rename (left-ctx-rename-∷ eqA renameγ) =
+  cong (_ ∷_) (rightCtxⁱ-left-rename renameγ)
+
+left-typing-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ ψ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M A} →
+  RenameLeftInverse τ ψ →
+  CastModeRenamer τ →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  No• M →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ leftCtxⁱ γ′
+    ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A
+left-typing-renameⁱ {Δᴸ′ = Δᴸ′} {τ = τ} {ψ = ψ} {hτ = hτ}
+    {ρ′ = ρ′} {γ = γ} {γ′ = γ′} {M = M} {A = A}
+    invτ modeτ renameρ renameγ noM M⊢ =
+  subst
+    (λ Γ → Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+    (sym (leftCtxⁱ-left-rename renameγ))
+    (subst
+      (λ Σ → Δᴸ′ ∣ Σ ∣ map (renameᵗ τ) (leftCtxⁱ γ)
+        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+      (sym (leftStoreⁱ-left-rename renameρ))
+      (typing-renameᵀ {ρ = τ} {ψ = ψ} hτ invτ modeτ noM M⊢))
+
+right-typing-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Δᴿ ∣ rightStoreⁱ ρ′ ∣ rightCtxⁱ γ′ ⊢ M ⦂ B
+right-typing-left-renameⁱ {Δᴿ = Δᴿ} {ρ′ = ρ′}
+    {γ = γ} {γ′ = γ′} {M = M} {B = B}
+    renameρ renameγ M⊢ =
+  subst
+    (λ Γ → Δᴿ ∣ rightStoreⁱ ρ′ ∣ Γ ⊢ M ⦂ B)
+    (sym (rightCtxⁱ-left-rename renameγ))
+    (subst
+      (λ Σ → Δᴿ ∣ Σ ∣ rightCtxⁱ γ ⊢ M ⦂ B)
+      (sym (rightStoreⁱ-left-rename renameρ)) M⊢)
+
+left-seal★-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {μ} →
+  (modeτ : CastModeRenamer τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ modeτ mode) (leftStoreⁱ ρ′)
+left-seal★-renameⁱ modeτ renameρ mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (castModeRenamer-seal★ modeτ mode seal★)
+
+left-narrowing-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  (modeτ : CastModeRenamer τ) →
+  (mode : CastMode μ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  CastModeRenamer.targetᵈ modeτ mode ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
+left-narrowing-renameⁱ {hτ = hτ} modeτ mode renameρ c⊒ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (narrow-renameᵗ hτ
+      (CastModeRenamer.target-rename modeτ mode) c⊒)
+
+left-widening-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  (modeτ : CastModeRenamer τ) →
+  (mode : CastMode μ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  CastModeRenamer.targetᵈ modeτ mode ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
+left-widening-renameⁱ {hτ = hτ} modeτ mode renameρ c⊑ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (widen-renameᵗ hτ
+      (CastModeRenamer.target-rename modeτ mode) c⊑)
+
+modeRename-id-only :
+  ∀ (τ : Renameᵗ) → ModeRename τ id-onlyᵈ id-onlyᵈ
+modeRename-id-only τ X = refl
+
+seal★-id-only :
+  ∀ {Σ} → SealModeStore★ id-onlyᵈ Σ
+seal★-id-only α ()
+
+modeRename-gen-tag-or-id :
+  ∀ (τ : Renameᵗ) →
+  ModeRename τ (genᵈ tag-or-idᵈ) (genᵈ tag-or-idᵈ)
+modeRename-gen-tag-or-id τ zero with τ zero
+modeRename-gen-tag-or-id τ zero | zero = refl
+modeRename-gen-tag-or-id τ zero | suc Y = refl
+modeRename-gen-tag-or-id τ (suc X) with τ (suc X)
+modeRename-gen-tag-or-id τ (suc X) | zero = refl
+modeRename-gen-tag-or-id τ (suc X) | suc Y = refl
+
+left-narrowing-rename-modeⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ ν c A B} →
+  ModeRename τ μ ν →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ν ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
+left-narrowing-rename-modeⁱ {hτ = hτ} modeτ renameρ c⊒ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (narrow-renameᵗ hτ modeτ c⊒)
+
+left-widening-rename-modeⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ ν c A B} →
+  ModeRename τ μ ν →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ν ∣ Δᴸ′ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
+left-widening-rename-modeⁱ {hτ = hτ} modeτ renameρ c⊑ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (widen-renameᵗ hτ modeτ c⊑)
+
+left-narrowing-rel-permute-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename (forward πᴸ) μ ν →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ν ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ (forward πᴸ) c
+    ∶ renameᵗ (forward πᴸ) A ⊒ renameᵗ (forward πᴸ) B
+left-narrowing-rel-permute-mode
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {ρ′ = ρ′}
+    {c = c} {A = A} {B = B} perm modeπ c⊒ =
+  subst
+    (λ Σ → _ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ (forward πᴸ) c
+      ∶ renameᵗ (forward πᴸ) A ⊒ renameᵗ (forward πᴸ) B)
+    (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+    (narrow-renameᵗ (forward-wf πᴸ) modeπ c⊒)
+
+right-narrowing-rel-permute-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename (forward πᴿ) μ ν →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ν ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ (forward πᴿ) c
+    ∶ renameᵗ (forward πᴿ) A ⊒ renameᵗ (forward πᴿ) B
+right-narrowing-rel-permute-mode
+    {Θᴿ = Θᴿ} {πᴿ = πᴿ} {ρ′ = ρ′}
+    {c = c} {A = A} {B = B} perm modeπ c⊒ =
+  subst
+    (λ Σ → _ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ (forward πᴿ) c
+      ∶ renameᵗ (forward πᴿ) A ⊒ renameᵗ (forward πᴿ) B)
+    (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+    (narrow-renameᵗ (forward-wf πᴿ) modeπ c⊒)
+
+left-widening-rel-permute-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename (forward πᴸ) μ ν →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ν ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ (forward πᴸ) c
+    ∶ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴸ) B
+left-widening-rel-permute-mode
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {ρ′ = ρ′}
+    {c = c} {A = A} {B = B} perm modeπ c⊑ =
+  subst
+    (λ Σ → _ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ (forward πᴸ) c
+      ∶ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴸ) B)
+    (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+    (widen-renameᵗ (forward-wf πᴸ) modeπ c⊑)
+
+right-widening-rel-permute-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename (forward πᴿ) μ ν →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ν ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ (forward πᴿ) c
+    ∶ renameᵗ (forward πᴿ) A ⊑ renameᵗ (forward πᴿ) B
+right-widening-rel-permute-mode
+    {Θᴿ = Θᴿ} {πᴿ = πᴿ} {ρ′ = ρ′}
+    {c = c} {A = A} {B = B} perm modeπ c⊑ =
+  subst
+    (λ Σ → _ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ (forward πᴿ) c
+      ∶ renameᵗ (forward πᴿ) A ⊑ renameᵗ (forward πᴿ) B)
+    (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+    (widen-renameᵗ (forward-wf πᴿ) modeπ c⊑)
+
+left-seal-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ (left-cast-renamer perm) mode)
+    (leftStoreⁱ ρ′)
+left-seal-rel-permute perm mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (leftStoreⁱ-rel-rename (store-permutation perm)))
+    (castModeRenamer-seal★ (left-cast-renamer perm) mode seal★)
+
+right-seal-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (rightStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ (right-cast-renamer perm) mode)
+    (rightStoreⁱ ρ′)
+right-seal-rel-permute perm mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (rightStoreⁱ-rel-rename (store-permutation perm)))
+    (castModeRenamer-seal★ (right-cast-renamer perm) mode seal★)
+
+left-narrowing-rel-embed-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename τ μ ν →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ν ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
+left-narrowing-rel-embed-mode
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb modeτ c⊒ =
+  subst
+    (λ Σ → _ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B)
+    (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))
+    (narrow-renameᵗ hτ modeτ c⊒)
+
+right-narrowing-rel-embed-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename σ μ ν →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  ν ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊒ renameᵗ σ B
+right-narrowing-rel-embed-mode
+    {Θᴿ = Θᴿ} {σ = σ} {hσ = hσ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb modeσ c⊒ =
+  subst
+    (λ Σ → _ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊒ renameᵗ σ B)
+    (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))
+    (narrow-renameᵗ hσ modeσ c⊒)
+
+left-widening-rel-embed-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename τ μ ν →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ν ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
+left-widening-rel-embed-mode
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb modeτ c⊑ =
+  subst
+    (λ Σ → _ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B)
+    (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))
+    (widen-renameᵗ hτ modeτ c⊑)
+
+right-widening-rel-embed-mode :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ ν c A B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename σ μ ν →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  ν ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊑ renameᵗ σ B
+right-widening-rel-embed-mode
+    {Θᴿ = Θᴿ} {σ = σ} {hσ = hσ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb modeσ c⊑ =
+  subst
+    (λ Σ → _ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊑ renameᵗ σ B)
+    (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))
+    (widen-renameᵗ hσ modeσ c⊑)
+
+left-seal-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ (left-embedding-cast-renamer emb) mode)
+    (leftStoreⁱ ρ′)
+left-seal-rel-embed emb mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))
+    (castModeRenamer-seal★
+      (left-embedding-cast-renamer emb) mode seal★)
+
+right-seal-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (rightStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ (right-embedding-cast-renamer emb) mode)
+    (rightStoreⁱ ρ′)
+right-seal-rel-embed emb mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))
+    (castModeRenamer-seal★
+      (right-embedding-cast-renamer emb) mode seal★)
+
+rel-world-paired-conversion-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {c c′ A A′ B B′ p q} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  PairedConversion Φ Δᴸ Δᴿ ρ
+    c c′ {A} {A′} {B} {B′} p q →
+  PairedConversion Ψ Θᴸ Θᴿ ρ′
+    (renameᶜ τ c) (renameᶜ σ c′)
+    (⊑-renameᵗ²ᵢ assm hτ hσ p) (⊑-renameᵗ²ᵢ assm hτ hσ q)
+rel-world-paired-conversion-embed emb
+    (paired-reveal corr conv conv′)
+    with rel-store-embedding-correspondenceⁱ
+      (store-embedding emb) corr
+rel-world-paired-conversion-embed emb
+    (paired-reveal corr conv conv′)
+    | α′ , X , β′ , X′ , p′ ,
+      refl , refl , refl , refl , corr′ =
+  paired-reveal corr′
+    (left-reveal-rel-embed emb conv)
+    (right-reveal-rel-embed emb conv′)
+rel-world-paired-conversion-embed emb
+    (paired-conceal corr conv conv′)
+    with rel-store-embedding-correspondenceⁱ
+      (store-embedding emb) corr
+rel-world-paired-conversion-embed emb
+    (paired-conceal corr conv conv′)
+    | α′ , X , β′ , X′ , p′ ,
+      refl , refl , refl , refl , corr′ =
+  paired-conceal corr′
+    (left-conceal-rel-embed emb conv)
+    (right-conceal-rel-embed emb conv′)
+
+rel-world-paired-cast-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {c c′ A A′ B B′ p q} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q →
+  PairedCast Ψ Θᴸ Θᴿ ρ′ (renameᶜ τ c) (renameᶜ σ c′)
+    (⊑-renameᵗ²ᵢ assm hτ hσ p) (⊑-renameᵗ²ᵢ assm hτ hσ q)
+rel-world-paired-cast-embed emb (paired-conversion conv) =
+  paired-conversion (rel-world-paired-conversion-embed emb conv)
+rel-world-paired-cast-embed emb
+    (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑) =
+  paired-widening
+    (CastModeRenamer.target-mode
+      (left-embedding-cast-renamer emb) mode)
+    (left-seal-rel-embed emb mode seal★)
+    (left-widening-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (left-embedding-cast-renamer emb) mode) c⊑)
+    (CastModeRenamer.target-mode
+      (right-embedding-cast-renamer emb) mode′)
+    (right-seal-rel-embed emb mode′ seal★′)
+    (right-widening-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (right-embedding-cast-renamer emb) mode′) c′⊑)
+
+rel-world-conv⊑conv-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B B′ p q c c′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ renameᵗᵐ σ (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-conv⊑conv-embedᵀ emb cast M⊑M′ =
+  conv⊑convᵀ (rel-world-paired-cast-embed emb cast) M⊑M′
+
+rel-world-conv↑⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ α X} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-conv↑⊑-embedᵀ emb conv M⊑M′ =
+  conv↑⊑ᵀ (left-reveal-rel-embed emb conv) M⊑M′ _
+
+rel-world-conv↓⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ α X} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-conv↓⊑-embedᵀ emb conv M⊑M′ =
+  conv↓⊑ᵀ (left-conceal-rel-embed emb conv) M⊑M′ _
+
+rel-world-⊑conv↑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′ β X′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-⊑conv↑-embedᵀ emb conv M⊑M′ =
+  ⊑conv↑ᵀ (right-reveal-rel-embed emb conv) M⊑M′ _
+
+rel-world-⊑conv↓-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′ β X′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-⊑conv↓-embedᵀ emb conv M⊑M′ =
+  ⊑conv↓ᵀ (right-conceal-rel-embed emb conv) M⊑M′ _
+
+rel-world-quotient-widening-pair-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {u u′ D D′ A A′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  QuotientWideningPair Θᴸ Θᴿ ρ′
+    (renameᶜ τ u) (renameᶜ σ u′)
+    (renameᵗ τ D) (renameᵗ σ D′)
+    (renameᵗ τ A) (renameᵗ σ A′)
+rel-world-quotient-widening-pair-embed
+    {τ = τ} {σ = σ} emb (quotient-id-widening u⊑ u′⊑) =
+  quotient-id-widening
+    (left-widening-rel-embed-mode emb (modeRename-id-only τ) u⊑)
+    (right-widening-rel-embed-mode emb (modeRename-id-only σ) u′⊑)
+rel-world-quotient-widening-pair-embed emb
+    (quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑) =
+  quotient-cast-widening
+    (CastModeRenamer.target-mode
+      (left-embedding-cast-renamer emb) mode)
+    (left-seal-rel-embed emb mode seal★)
+    (left-widening-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (left-embedding-cast-renamer emb) mode) u⊑)
+    (CastModeRenamer.target-mode
+      (right-embedding-cast-renamer emb) mode′)
+    (right-seal-rel-embed emb mode′ seal★′)
+    (right-widening-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (right-embedding-cast-renamer emb) mode′) u′⊑)
+
+rel-world-up⊑up-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {N N′ A A′ D D′ qD u u′ pA} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ D ⊑ᵖ renameᵗ σ D′
+    ∶ ⊑ᵖ-rename²ᵢ assm hτ hσ qD →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ renameᵗᵐ σ (N′ ⟨ u′ ⟩)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ pA
+rel-world-up⊑up-embedᵀ emb widening N⊑N′ =
+  up⊑upᵀ N⊑N′
+    (rel-world-quotient-widening-pair-embed emb widening) _
+
+rel-world-cast⊒⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-cast⊒⊑-embedᵀ emb mode seal★ c⊒ M⊑M′ =
+  cast⊒⊑ᵀ
+    (CastModeRenamer.target-mode
+      (left-embedding-cast-renamer emb) mode)
+    (left-seal-rel-embed emb mode seal★)
+    (left-narrowing-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (left-embedding-cast-renamer emb) mode) c⊒)
+    M⊑M′ _
+
+rel-world-cast⊑⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-cast⊑⊑-embedᵀ emb mode seal★ c⊑ M⊑M′ =
+  cast⊑⊑ᵀ
+    (CastModeRenamer.target-mode
+      (left-embedding-cast-renamer emb) mode)
+    (left-seal-rel-embed emb mode seal★)
+    (left-widening-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (left-embedding-cast-renamer emb) mode) c⊑)
+    M⊑M′ _
+
+rel-world-⊑cast⊒-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-⊑cast⊒-embedᵀ emb mode′ seal★′ c′⊒ M⊑M′ =
+  ⊑cast⊒ᵀ
+    (CastModeRenamer.target-mode
+      (right-embedding-cast-renamer emb) mode′)
+    (right-seal-rel-embed emb mode′ seal★′)
+    (right-narrowing-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (right-embedding-cast-renamer emb) mode′) c′⊒)
+    M⊑M′ _
+
+rel-world-⊑cast⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-⊑cast⊑-embedᵀ emb mode′ seal★′ c′⊑ M⊑M′ =
+  ⊑cast⊑ᵀ
+    (CastModeRenamer.target-mode
+      (right-embedding-cast-renamer emb) mode′)
+    (right-seal-rel-embed emb mode′ seal★′)
+    (right-widening-rel-embed-mode emb
+      (CastModeRenamer.target-rename
+        (right-embedding-cast-renamer emb) mode′) c′⊑)
+    M⊑M′ _
+
+rel-world-⊑cast⊑id-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ A′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ τ A ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q
+rel-world-⊑cast⊑id-embedᵀ {σ = σ} emb c′⊑ M⊑M′ =
+  ⊑cast⊑idᵀ seal★-id-only
+    (right-widening-rel-embed-mode emb
+      (modeRename-id-only σ) c′⊑)
+    M⊑M′ _
+
+rel-world-paired-conversion-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {c c′ A A′ B B′ p q} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  PairedConversion Φ Δᴸ Δᴿ ρ
+    c c′ {A} {A′} {B} {B′} p q →
+  PairedConversion Ψ Θᴸ Θᴿ ρ′
+    (renameᶜ (forward πᴸ) c) (renameᶜ (forward πᴿ) c′)
+    (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p)
+    (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q)
+rel-world-paired-conversion-permute perm
+    (paired-reveal corr conv conv′)
+    with rel-store-rename-correspondenceⁱ
+      (store-permutation perm) corr
+rel-world-paired-conversion-permute perm
+    (paired-reveal corr conv conv′)
+    | α′ , refl , X , refl , β′ , refl , X′ , refl , corr′ =
+  paired-reveal corr′
+    (left-reveal-rel-permute perm conv)
+    (right-reveal-rel-permute perm conv′)
+rel-world-paired-conversion-permute perm
+    (paired-conceal corr conv conv′)
+    with rel-store-rename-correspondenceⁱ
+      (store-permutation perm) corr
+rel-world-paired-conversion-permute perm
+    (paired-conceal corr conv conv′)
+    | α′ , refl , X , refl , β′ , refl , X′ , refl , corr′ =
+  paired-conceal corr′
+    (left-conceal-rel-permute perm conv)
+    (right-conceal-rel-permute perm conv′)
+
+rel-world-paired-cast-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {c c′ A A′ B B′ p q} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q →
+  PairedCast Ψ Θᴸ Θᴿ ρ′
+    (renameᶜ (forward πᴸ) c) (renameᶜ (forward πᴿ) c′)
+    (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p)
+    (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q)
+rel-world-paired-cast-permute perm (paired-conversion conv) =
+  paired-conversion (rel-world-paired-conversion-permute perm conv)
+rel-world-paired-cast-permute perm
+    (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑) =
+  paired-widening
+    (CastModeRenamer.target-mode (left-cast-renamer perm) mode)
+    (left-seal-rel-permute perm mode seal★)
+    (left-widening-rel-permute-mode perm
+      (CastModeRenamer.target-rename (left-cast-renamer perm) mode) c⊑)
+    (CastModeRenamer.target-mode (right-cast-renamer perm) mode′)
+    (right-seal-rel-permute perm mode′ seal★′)
+    (right-widening-rel-permute-mode perm
+      (CastModeRenamer.target-rename (right-cast-renamer perm) mode′)
+      c′⊑)
+
+rel-world-conv⊑conv-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B B′ p q c c′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ {A} {A′} {B} {B′} p q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (M ⟨ c ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-conv⊑conv-permuteᵀ perm cast M⊑M′ =
+  conv⊑convᵀ (rel-world-paired-cast-permute perm cast) M⊑M′
+
+rel-world-conv↑⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ α X} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (M ⟨ c ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-conv↑⊑-permuteᵀ perm conv M⊑M′ =
+  conv↑⊑ᵀ (left-reveal-rel-permute perm conv) M⊑M′ _
+
+rel-world-conv↓⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ α X} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (M ⟨ c ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-conv↓⊑-permuteᵀ perm conv M⊑M′ =
+  conv↓⊑ᵀ (left-conceal-rel-permute perm conv) M⊑M′ _
+
+rel-world-⊑conv↑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′ β X′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-⊑conv↑-permuteᵀ perm conv M⊑M′ =
+  ⊑conv↑ᵀ (right-reveal-rel-permute perm conv) M⊑M′ _
+
+rel-world-⊑conv↓-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′ β X′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-⊑conv↓-permuteᵀ perm conv M⊑M′ =
+  ⊑conv↓ᵀ (right-conceal-rel-permute perm conv) M⊑M′ _
+
+rel-world-quotient-widening-pair-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {u u′ D D′ A A′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  QuotientWideningPair Θᴸ Θᴿ ρ′
+    (renameᶜ (forward πᴸ) u) (renameᶜ (forward πᴿ) u′)
+    (renameᵗ (forward πᴸ) D) (renameᵗ (forward πᴿ) D′)
+    (renameᵗ (forward πᴸ) A) (renameᵗ (forward πᴿ) A′)
+rel-world-quotient-widening-pair-permute
+    {πᴸ = πᴸ} {πᴿ = πᴿ} perm
+    (quotient-id-widening u⊑ u′⊑) =
+  quotient-id-widening
+    (left-widening-rel-permute-mode perm
+      (modeRename-id-only (forward πᴸ)) u⊑)
+    (right-widening-rel-permute-mode perm
+      (modeRename-id-only (forward πᴿ)) u′⊑)
+rel-world-quotient-widening-pair-permute perm
+    (quotient-cast-widening
+      mode seal★ u⊑ mode′ seal★′ u′⊑) =
+  quotient-cast-widening
+    (CastModeRenamer.target-mode (left-cast-renamer perm) mode)
+    (left-seal-rel-permute perm mode seal★)
+    (left-widening-rel-permute-mode perm
+      (CastModeRenamer.target-rename (left-cast-renamer perm) mode) u⊑)
+    (CastModeRenamer.target-mode (right-cast-renamer perm) mode′)
+    (right-seal-rel-permute perm mode′ seal★′)
+    (right-widening-rel-permute-mode perm
+      (CastModeRenamer.target-rename (right-cast-renamer perm) mode′)
+      u′⊑)
+
+rel-world-up⊑up-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {N N′ A A′ D D′ qD u u′ pA} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) D ⊑ᵖ renameᵗ (forward πᴿ) D′
+    ∶ ⊑ᵖ-rename²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) qD →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (N ⟨ u ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) (N′ ⟨ u′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pA
+rel-world-up⊑up-permuteᵀ perm widening N⊑N′ =
+  up⊑upᵀ N⊑N′
+    (rel-world-quotient-widening-pair-permute perm widening) _
+
+rel-world-cast⊒⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (M ⟨ c ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-cast⊒⊑-permuteᵀ perm mode seal★ c⊒ M⊑M′ =
+  cast⊒⊑ᵀ
+    (CastModeRenamer.target-mode (left-cast-renamer perm) mode)
+    (left-seal-rel-permute perm mode seal★)
+    (left-narrowing-rel-permute-mode perm
+      (CastModeRenamer.target-rename (left-cast-renamer perm) mode) c⊒)
+    M⊑M′ _
+
+rel-world-cast⊑⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A B B′ p q c μ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (M ⟨ c ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) B ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-cast⊑⊑-permuteᵀ perm mode seal★ c⊑ M⊑M′ =
+  cast⊑⊑ᵀ
+    (CastModeRenamer.target-mode (left-cast-renamer perm) mode)
+    (left-seal-rel-permute perm mode seal★)
+    (left-widening-rel-permute-mode perm
+      (CastModeRenamer.target-rename (left-cast-renamer perm) mode) c⊑)
+    M⊑M′ _
+
+rel-world-⊑cast⊒-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-⊑cast⊒-permuteᵀ perm mode′ seal★′ c′⊒ M⊑M′ =
+  ⊑cast⊒ᵀ
+    (CastModeRenamer.target-mode (right-cast-renamer perm) mode′)
+    (right-seal-rel-permute perm mode′ seal★′)
+    (right-narrowing-rel-permute-mode perm
+      (CastModeRenamer.target-rename (right-cast-renamer perm) mode′)
+      c′⊒)
+    M⊑M′ _
+
+rel-world-⊑cast⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′ μ′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-⊑cast⊑-permuteᵀ perm mode′ seal★′ c′⊑ M⊑M′ =
+  ⊑cast⊑ᵀ
+    (CastModeRenamer.target-mode (right-cast-renamer perm) mode′)
+    (right-seal-rel-permute perm mode′ seal★′)
+    (right-widening-rel-permute-mode perm
+      (CastModeRenamer.target-rename (right-cast-renamer perm) mode′)
+      c′⊑)
+    M⊑M′ _
+
+rel-world-⊑cast⊑id-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ A A′ B′ p q c′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) A′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ c′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) A ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q
+rel-world-⊑cast⊑id-permuteᵀ {πᴿ = πᴿ} perm c′⊑ M⊑M′ =
+  ⊑cast⊑idᵀ seal★-id-only
+    (right-widening-rel-permute-mode perm
+      (modeRename-id-only (forward πᴿ)) c′⊑)
+    M⊑M′ _
+
+rel-world-gen-down-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ C C′ D D′ pC d d′} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) M ⊑ renameᵗᵐ (forward πᴿ) M′
+    ⦂ renameᵗ (forward πᴸ) C ⊑ renameᵗ (forward πᴿ) C′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) pC →
+  (qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ (forward πᴸ) (M ⟨ d ⟩)
+      ⊑ renameᵗᵐ (forward πᴿ) (M′ ⟨ d′ ⟩)
+    ⦂ renameᵗ (forward πᴸ) D ⊑ᵖ renameᵗ (forward πᴿ) D′
+    ∶ ⊑ᵖ-rename²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) qD
+rel-world-gen-down-permuteᵀ
+    {πᴸ = πᴸ} {πᴿ = πᴿ} perm d⊒ d′⊒ M⊑M′ qD =
+  gen-down⊑gen-downᵀ
+    (left-narrowing-rel-permute-mode perm
+      (modeRename-gen-tag-or-id (forward πᴸ)) d⊒)
+    (right-narrowing-rel-permute-mode perm
+      (modeRename-gen-tag-or-id (forward πᴿ)) d′⊒)
+    M⊑M′
+    (⊑ᵖ-rename²ᵢ _ _ _ qD)
+
+rel-world-down-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ C C′ D D′ pC d d′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ C ⊑ renameᵗ σ C′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ pC →
+  (qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩)
+      ⊑ renameᵗᵐ σ (M′ ⟨ d′ ⟩)
+    ⦂ renameᵗ τ D ⊑ᵖ renameᵗ σ D′
+    ∶ ⊑ᵖ-rename²ᵢ assm hτ hσ qD
+rel-world-down-embedᵀ {τ = τ} {σ = σ} emb d⊒ d′⊒ M⊑M′ qD =
+  down⊑downᵀ
+    (left-narrowing-rel-embed-mode emb (modeRename-id-only τ) d⊒)
+    (right-narrowing-rel-embed-mode emb (modeRename-id-only σ) d′⊒)
+    M⊑M′
+    (⊑ᵖ-rename²ᵢ _ _ _ qD)
+
+rel-world-gen-down-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M M′ C C′ D D′ pC d d′} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+    ⦂ renameᵗ τ C ⊑ renameᵗ σ C′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ pC →
+  (qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩)
+      ⊑ renameᵗᵐ σ (M′ ⟨ d′ ⟩)
+    ⦂ renameᵗ τ D ⊑ᵖ renameᵗ σ D′
+    ∶ ⊑ᵖ-rename²ᵢ assm hτ hσ qD
+rel-world-gen-down-embedᵀ {τ = τ} {σ = σ}
+    emb d⊒ d′⊒ M⊑M′ qD =
+  gen-down⊑gen-downᵀ
+    (left-narrowing-rel-embed-mode emb
+      (modeRename-gen-tag-or-id τ) d⊒)
+    (right-narrowing-rel-embed-mode emb
+      (modeRename-gen-tag-or-id σ) d′⊒)
+    M⊑M′
+    (⊑ᵖ-rename²ᵢ _ _ _ qD)
+
+left-reveal-ν-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ A B C s} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion
+    (permuted-modeᵈ (TyPermutation-ext πᴸ) μ)
+    (suc Θᴸ)
+    ((zero , ⇑ᵗ (renameᵗ (forward πᴸ) A)) ∷
+      ⟰ᵗ (leftStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ (forward πᴸ) A))
+    (renameᶜ (extᵗ (forward πᴸ)) s)
+    (renameᵗ (extᵗ (forward πᴸ)) C)
+    (⇑ᵗ (renameᵗ (forward πᴸ) B))
+left-reveal-ν-rel-permute
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {ρ = ρ} {ρ′ = ρ′}
+    {μ = μ} {A = A} {B = B} {C = C} {s = s} perm conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Θᴸ) target-store
+      zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+      (renameᵗ (extᵗ τ) C) D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Θᴸ) target-store
+        zero X (renameᶜ (extᵗ τ) s)
+        (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm τ A)
+      store-normalized)
+  where
+  τ = forward πᴸ
+  target-mode = permuted-modeᵈ (TyPermutation-ext πᴸ) μ
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm τ (leftStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ τ A)) ∷_)
+        (cong ⟰ᵗ
+          (sym (leftStoreⁱ-rel-rename (store-permutation perm)))))
+
+  renamed =
+    rename-reveal-conversion
+      (TyRenameWf-ext (forward-wf πᴸ))
+      (permuted-mode-rename (TyPermutation-ext πᴸ) μ) conv
+
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Θᴸ) Σ
+        zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+        (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      store-eq renamed
+
+right-reveal-ν-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ A B C s} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion
+    (permuted-modeᵈ (TyPermutation-ext πᴿ) μ)
+    (suc Θᴿ)
+    ((zero , ⇑ᵗ (renameᵗ (forward πᴿ) A)) ∷
+      ⟰ᵗ (rightStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ (forward πᴿ) A))
+    (renameᶜ (extᵗ (forward πᴿ)) s)
+    (renameᵗ (extᵗ (forward πᴿ)) C)
+    (⇑ᵗ (renameᵗ (forward πᴿ) B))
+right-reveal-ν-rel-permute
+    {Θᴿ = Θᴿ} {πᴿ = πᴿ} {ρ = ρ} {ρ′ = ρ′}
+    {μ = μ} {A = A} {B = B} {C = C} {s = s} perm conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Θᴿ) target-store
+      zero (⇑ᵗ (renameᵗ σ A)) (renameᶜ (extᵗ σ) s)
+      (renameᵗ (extᵗ σ) C) D)
+    (renameᵗ-ext-suc-comm σ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Θᴿ) target-store
+        zero X (renameᶜ (extᵗ σ) s)
+        (renameᵗ (extᵗ σ) C)
+        (renameᵗ (extᵗ σ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm σ A)
+      store-normalized)
+  where
+  σ = forward πᴿ
+  target-mode = permuted-modeᵈ (TyPermutation-ext πᴿ) μ
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ σ A)) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm σ (rightStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ σ A)) ∷_)
+        (cong ⟰ᵗ
+          (sym (rightStoreⁱ-rel-rename (store-permutation perm)))))
+
+  renamed =
+    rename-reveal-conversion
+      (TyRenameWf-ext (forward-wf πᴿ))
+      (permuted-mode-rename (TyPermutation-ext πᴿ) μ) conv
+
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Θᴿ) Σ
+        zero (renameᵗ (extᵗ σ) (⇑ᵗ A))
+        (renameᶜ (extᵗ σ) s) (renameᵗ (extᵗ σ) C)
+        (renameᵗ (extᵗ σ) (⇑ᵗ B)))
+      store-eq renamed
+
+left-reveal-ν-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ A B C s} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion (embedded-modeᵈ (extᵗ ψ) μ) (suc Θᴸ)
+    ((zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+    (renameᵗ (extᵗ τ) C) (⇑ᵗ (renameᵗ τ B))
+left-reveal-ν-rel-embed
+    {Θᴸ = Θᴸ} {τ = τ} {ψ = ψ} {hτ = hτ}
+    {ρ = ρ} {ρ′ = ρ′} {μ = μ} {A = A} {B = B} {C = C} {s = s}
+    emb conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Θᴸ) target-store
+      zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+      (renameᵗ (extᵗ τ) C) D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Θᴸ) target-store
+        zero X (renameᶜ (extᵗ τ) s)
+        (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm τ A)
+      store-normalized)
+  where
+  target-mode = embedded-modeᵈ (extᵗ ψ) μ
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm τ (leftStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ τ A)) ∷_)
+        (cong ⟰ᵗ
+          (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))))
+
+  renamed =
+    rename-reveal-conversion (TyRenameWf-ext hτ)
+      (embedded-mode-rename {τ = extᵗ τ} {ψ = extᵗ ψ}
+        (RenameLeftInverse-ext (left-embedding-inverse emb)) μ) conv
+
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Θᴸ) Σ
+        zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+        (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      store-eq renamed
+
+right-reveal-ν-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ A B C s} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion (embedded-modeᵈ (extᵗ φ) μ) (suc Θᴿ)
+    ((zero , ⇑ᵗ (renameᵗ σ A)) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ σ A)) (renameᶜ (extᵗ σ) s)
+    (renameᵗ (extᵗ σ) C) (⇑ᵗ (renameᵗ σ B))
+right-reveal-ν-rel-embed
+    {Θᴿ = Θᴿ} {σ = σ} {φ = φ} {hσ = hσ}
+    {ρ = ρ} {ρ′ = ρ′} {μ = μ} {A = A} {B = B} {C = C} {s = s}
+    emb conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Θᴿ) target-store
+      zero (⇑ᵗ (renameᵗ σ A)) (renameᶜ (extᵗ σ) s)
+      (renameᵗ (extᵗ σ) C) D)
+    (renameᵗ-ext-suc-comm σ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Θᴿ) target-store
+        zero X (renameᶜ (extᵗ σ) s)
+        (renameᵗ (extᵗ σ) C)
+        (renameᵗ (extᵗ σ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm σ A)
+      store-normalized)
+  where
+  target-mode = embedded-modeᵈ (extᵗ φ) μ
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ σ A)) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm σ (rightStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ σ A)) ∷_)
+        (cong ⟰ᵗ
+          (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))))
+
+  renamed =
+    rename-reveal-conversion (TyRenameWf-ext hσ)
+      (embedded-mode-rename {τ = extᵗ σ} {ψ = extᵗ φ}
+        (RenameLeftInverse-ext (right-embedding-inverse emb)) μ) conv
+
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Θᴿ) Σ
+        zero (renameᵗ (extᵗ σ) (⇑ᵗ A))
+        (renameᶜ (extᵗ σ) s) (renameᵗ (extᵗ σ) C)
+        (renameᵗ (extᵗ σ) (⇑ᵗ B)))
+      store-eq renamed
+
+rel-world-ν⊑ν-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {A A′ B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
+  (A⇑⊑A′⇑ : ∀ᵢᶜ Φ
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) (`∀ C)
+      ⊑ renameᵗ (forward πᴿ) (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+        (∀ⁱ q) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (ν A N s)
+      ⊑ renameᵗᵐ (forward πᴿ) (ν A′ N′ s′)
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-ν⊑ν-permuteᵀ
+    {πᴸ = πᴸ} {πᴿ = πᴿ}
+    perm hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ N⊑N′
+    with rel-world-permutation-lift∀ⁱ perm liftρ liftγ
+rel-world-ν⊑ν-permuteᵀ
+    {Ψ = Ψ} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {πᴸ = πᴸ} {πᴿ = πᴿ} {assm = assm}
+    {A = A} {A′ = A′}
+    perm hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ N⊑N′
+    | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-perm =
+  ν⊑νᵀ
+    (renameᵗ-preserves-WfTy hA (forward-wf πᴸ))
+    (renameᵗ-preserves-WfTy hA′ (forward-wf πᴿ))
+    (left-reveal-ν-rel-permute perm s↑)
+    (right-reveal-ν-rel-permute perm s′↑)
+    (⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+      A⊑A′)
+    shifted-A⊑A′
+    liftρ′ liftγ′ N⊑N′
+  where
+  τ = forward πᴸ
+  σ = forward πᴿ
+
+  renamed-A⇑⊑A′⇑ =
+    ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext (forward-wf πᴸ))
+      (TyRenameWf-ext (forward-wf πᴿ)) A⇑⊑A′⇑
+
+  shifted-A⊑A′ =
+    subst
+      (λ T → ∀ᵢᶜ Ψ ∣ suc Θᴸ
+        ⊢ T ⊑ ⇑ᵗ (renameᵗ σ A′) ⊣ suc Θᴿ)
+      (renameᵗ-ext-suc-comm τ A)
+      (subst
+        (λ T → ∀ᵢᶜ Ψ ∣ suc Θᴸ ⊢
+          renameᵗ (extᵗ τ) (⇑ᵗ A) ⊑ T ⊣ suc Θᴿ)
+        (renameᵗ-ext-suc-comm σ A′)
+        renamed-A⇑⊑A′⇑)
+
+rel-world-ν⊑ν-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {A A′ B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
+  (A⇑⊑A′⇑ : ∀ᵢᶜ Φ
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ renameᵗ σ (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ (∀ⁱ q) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ renameᵗᵐ σ (ν A′ N′ s′)
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-ν⊑ν-embedᵀ
+    {τ = τ} {σ = σ}
+    emb hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ N⊑N′
+    with rel-world-embedding-lift∀ⁱ emb liftρ liftγ
+rel-world-ν⊑ν-embedᵀ
+    {Ψ = Ψ} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    {A = A} {A′ = A′}
+    emb hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ N⊑N′
+    | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb =
+  ν⊑νᵀ
+    (renameᵗ-preserves-WfTy hA hτ)
+    (renameᵗ-preserves-WfTy hA′ hσ)
+    (left-reveal-ν-rel-embed emb s↑)
+    (right-reveal-ν-rel-embed emb s′↑)
+    (⊑-renameᵗ²ᵢ assm hτ hσ A⊑A′)
+    shifted-A⊑A′
+    liftρ′ liftγ′ N⊑N′
+  where
+  renamed-A⇑⊑A′⇑ =
+    ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) A⇑⊑A′⇑
+
+  shifted-A⊑A′ =
+    subst
+      (λ T → ∀ᵢᶜ Ψ ∣ suc Θᴸ
+        ⊢ T ⊑ ⇑ᵗ (renameᵗ σ A′) ⊣ suc Θᴿ)
+      (renameᵗ-ext-suc-comm τ A)
+      (subst
+        (λ T → ∀ᵢᶜ Ψ ∣ suc Θᴸ ⊢
+          renameᵗ (extᵗ τ) (⇑ᵗ A) ⊑ T ⊣ suc Θᴿ)
+        (renameᵗ-ext-suc-comm σ A′)
+        renamed-A⇑⊑A′⇑)
+
+rel-world-ν⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {A B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  WfTy Δᴸ A →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) (`∀ C)
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (ν A N s)
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-ν⊑-permuteᵀ
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {A = A}
+    perm hA h⇑A s↑ liftρ liftγ N⊑N′
+    with rel-world-permutation-lift-leftⁱ perm liftρ liftγ
+rel-world-ν⊑-permuteᵀ
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {A = A}
+    perm hA h⇑A s↑ liftρ liftγ N⊑N′
+    | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-perm =
+  ν⊑ᵀ
+    (renameᵗ-preserves-WfTy hA (forward-wf πᴸ))
+    h⇑A′
+    (left-reveal-ν-rel-permute perm s↑)
+    liftρ′ liftγ′ N⊑N′
+  where
+  h⇑A′ : WfTy (suc Θᴸ) (⇑ᵗ (renameᵗ (forward πᴸ) A))
+  h⇑A′ =
+    subst (WfTy (suc Θᴸ))
+      (renameᵗ-ext-suc-comm (forward πᴸ) A)
+      (renameᵗ-preserves-WfTy h⇑A
+        (TyRenameWf-ext (forward-wf πᴸ)))
+
+rel-world-ν⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {A B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  WfTy Δᴸ A →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-ν⊑-embedᵀ
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ} {A = A}
+    emb hA h⇑A s↑ liftρ liftγ N⊑N′
+    with rel-world-embedding-lift-leftⁱ emb liftρ liftγ
+rel-world-ν⊑-embedᵀ
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ} {A = A}
+    emb hA h⇑A s↑ liftρ liftγ N⊑N′
+    | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb =
+  ν⊑ᵀ
+    (renameᵗ-preserves-WfTy hA hτ)
+    h⇑A′
+    (left-reveal-ν-rel-embed emb s↑)
+    liftρ′ liftγ′ N⊑N′
+  where
+  h⇑A′ : WfTy (suc Θᴸ) (⇑ᵗ (renameᵗ τ A))
+  h⇑A′ =
+    subst (WfTy (suc Θᴸ))
+      (renameᵗ-ext-suc-comm τ A)
+      (renameᵗ-preserves-WfTy h⇑A (TyRenameWf-ext hτ))
+
+rel-world-⊑ν-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {A B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  WfTy Δᴿ A →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) (ν A N′ s)
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-⊑ν-permuteᵀ
+    {Θᴿ = Θᴿ} {πᴸ = πᴸ} {πᴿ = πᴿ}
+    {assm = assm} {A = A}
+    perm hA h⇑A s↑ liftρ liftγ r N⊑N′
+    with rel-world-permutation-lift-rightⁱ perm liftρ liftγ
+rel-world-⊑ν-permuteᵀ
+    {Θᴿ = Θᴿ} {πᴸ = πᴸ} {πᴿ = πᴿ}
+    {assm = assm} {A = A}
+    perm hA h⇑A s↑ liftρ liftγ r N⊑N′
+    | ρ′ᴿ , γ′ᴿ , liftρ′ , liftγ′ , body-perm =
+  ⊑νᵀ
+    (renameᵗ-preserves-WfTy hA (forward-wf πᴿ))
+    h⇑A′
+    (right-reveal-ν-rel-permute perm s↑)
+    liftρ′ liftγ′
+    (⊑-renameᵗ²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+      (forward-wf πᴸ) (TyRenameWf-ext (forward-wf πᴿ)) r)
+    N⊑N′
+  where
+  h⇑A′ : WfTy (suc Θᴿ) (⇑ᵗ (renameᵗ (forward πᴿ) A))
+  h⇑A′ =
+    subst (WfTy (suc Θᴿ))
+      (renameᵗ-ext-suc-comm (forward πᴿ) A)
+      (renameᵗ-preserves-WfTy h⇑A
+        (TyRenameWf-ext (forward-wf πᴿ)))
+
+rel-world-⊑ν-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {A B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  WfTy Δᴿ A →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ (ν A N′ s)
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-⊑ν-embedᵀ
+    {Θᴿ = Θᴿ} {σ = σ} {hσ = hσ} {A = A}
+    emb hA h⇑A s↑ liftρ liftγ r N⊑N′
+    with rel-world-embedding-lift-rightⁱ emb liftρ liftγ
+rel-world-⊑ν-embedᵀ
+    {Θᴿ = Θᴿ} {τ = τ} {σ = σ} {assm = assm}
+    {hτ = hτ} {hσ = hσ} {A = A}
+    emb hA h⇑A s↑ liftρ liftγ r N⊑N′
+    | ρ′ᴿ , γ′ᴿ , liftρ′ , liftγ′ , body-emb =
+  ⊑νᵀ
+    (renameᵗ-preserves-WfTy hA hσ)
+    h⇑A′
+    (right-reveal-ν-rel-embed emb s↑)
+    liftρ′ liftγ′
+    (⊑-renameᵗ²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+      hτ (TyRenameWf-ext hσ) r)
+    N⊑N′
+  where
+  h⇑A′ : WfTy (suc Θᴿ) (⇑ᵗ (renameᵗ σ A))
+  h⇑A′ =
+    subst (WfTy (suc Θᴿ))
+      (renameᵗ-ext-suc-comm σ A)
+      (renameᵗ-preserves-WfTy h⇑A (TyRenameWf-ext hσ))
+
+left-reveal-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ α X c A B} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  RevealConversion (left-insertion-mode ins μ) Δᴸ′
+    (leftStoreⁱ ρ′) (τ α) (renameᵗ τ X)
+    (renameᶜ τ c) (renameᵗ τ A) (renameᵗ τ B)
+left-reveal-renameⁱ {hτ = hτ} ins renameρ conv =
+  subst
+    (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (rename-reveal-conversion hτ
+      (left-insertion-mode-rename ins _) conv)
+
+left-reveal-ν-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ A B C s} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion
+    (left-insertion-mode (left-insertion-ext ins) μ)
+    (suc Δᴸ′)
+    ((zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+    (renameᵗ (extᵗ τ) C) (⇑ᵗ (renameᵗ τ B))
+left-reveal-ν-renameⁱ
+    {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
+    {μ = μ} {A = A} {B = B} {C = C} {s = s}
+    ins renameρ conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Δᴸ′) target-store
+      zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+      (renameᵗ (extᵗ τ) C) D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Δᴸ′) target-store
+        zero X (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm τ A)
+      store-normalized)
+  where
+  target-mode = left-insertion-mode (left-insertion-ext ins) μ
+
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm τ (leftStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ τ A)) ∷_)
+        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
+
+  renamed :
+    RevealConversion target-mode (suc Δᴸ′)
+      (renameStoreᵗ (extᵗ τ)
+        ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ)))
+      zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+      (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+      (renameᵗ (extᵗ τ) (⇑ᵗ B))
+  renamed =
+    rename-reveal-conversion (TyRenameWf-ext hτ)
+      (left-insertion-mode-rename (left-insertion-ext ins) μ) conv
+
+  store-normalized :
+    RevealConversion target-mode (suc Δᴸ′) target-store
+      zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+      (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+      (renameᵗ (extᵗ τ) (⇑ᵗ B))
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Δᴸ′) Σ
+        zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+        (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      store-eq renamed
+
+right-reveal-ν-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ A B C s} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)
+right-reveal-ν-left-renameⁱ
+    {Δᴿ = Δᴿ} {μ = μ} {A = A} {B = B} {C = C} {s = s}
+    renameρ conv =
+  subst
+    (λ Σ → RevealConversion μ (suc Δᴿ) Σ
+      zero (⇑ᵗ A) s C (⇑ᵗ B))
+    (cong ((zero , ⇑ᵗ A) ∷_)
+      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
+    conv
+
+renameStoreᵗ-ext-★-cons-comm :
+  ∀ (τ : Renameᵗ) (Σ : Store) →
+  renameStoreᵗ (extᵗ τ) ((zero , ★) ∷ ⟰ᵗ Σ) ≡
+    (zero , ★) ∷ ⟰ᵗ (renameStoreᵗ τ Σ)
+renameStoreᵗ-ext-★-cons-comm τ Σ =
+  cong ((zero , ★) ∷_) (renameStoreᵗ-ext-suc-comm τ Σ)
+
+left-ν★-widening-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ s C B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode (CastModeRenamer.targetᵈ (left-cast-renamer perm) mode) ×
+  SealModeStore★
+    (instᵈ (CastModeRenamer.targetᵈ
+      (left-cast-renamer perm) mode))
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)) ×
+  instᵈ (CastModeRenamer.targetᵈ (left-cast-renamer perm) mode)
+    ∣ suc Θᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+    ⊢ renameᶜ (extᵗ (forward πᴸ)) s
+    ∶ renameᵗ (extᵗ (forward πᴸ)) C
+      ⊑ ⇑ᵗ (renameᵗ (forward πᴸ) B)
+left-ν★-widening-rel-permute
+    {Θᴸ = Θᴸ} {πᴸ = πᴸ} {ρ = ρ} {ρ′ = ρ′}
+    {s = s} {C = C} {B = B} perm mode seal★ s⊑ =
+  CastModeRenamer.target-mode η mode ,
+  subst SealTarget store-eq renamed-seal ,
+  subst
+    (λ D → target-full-mode ∣ suc Θᴸ ∣ target-store
+      ⊢ renameᶜ (extᵗ τ) s
+      ∶ renameᵗ (extᵗ τ) C ⊑ D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ Σ → target-full-mode ∣ suc Θᴸ ∣ Σ
+        ⊢ renameᶜ (extᵗ τ) s
+        ∶ renameᵗ (extᵗ τ) C
+          ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B))
+      store-eq renamed-widening)
+  where
+  τ = forward πᴸ
+  η = left-cast-renamer perm
+  extη = castModeRenamer-ext η
+  target-full-mode = instᵈ (CastModeRenamer.targetᵈ η mode)
+  target-store = (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+  SealTarget = SealModeStore★ target-full-mode
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ
+          (sym (leftStoreⁱ-rel-rename (store-permutation perm)))))
+
+  renamed-seal =
+    castModeRenamer-seal★ extη (cast-inst mode) seal★
+
+  renamed-widening =
+    widen-renameᵗ
+      (TyRenameWf-ext (forward-wf πᴸ))
+      (CastModeRenamer.target-rename extη (cast-inst mode)) s⊑
+
+right-ν★-widening-rel-permute :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ s C B} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode (CastModeRenamer.targetᵈ (right-cast-renamer perm) mode) ×
+  SealModeStore★
+    (instᵈ (CastModeRenamer.targetᵈ
+      (right-cast-renamer perm) mode))
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)) ×
+  instᵈ (CastModeRenamer.targetᵈ (right-cast-renamer perm) mode)
+    ∣ suc Θᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+    ⊢ renameᶜ (extᵗ (forward πᴿ)) s
+    ∶ renameᵗ (extᵗ (forward πᴿ)) C
+      ⊑ ⇑ᵗ (renameᵗ (forward πᴿ) B)
+right-ν★-widening-rel-permute
+    {Θᴿ = Θᴿ} {πᴿ = πᴿ} {ρ = ρ} {ρ′ = ρ′}
+    {s = s} {C = C} {B = B} perm mode seal★ s⊑ =
+  CastModeRenamer.target-mode η mode ,
+  subst SealTarget store-eq renamed-seal ,
+  subst
+    (λ D → target-full-mode ∣ suc Θᴿ ∣ target-store
+      ⊢ renameᶜ (extᵗ σ) s
+      ∶ renameᵗ (extᵗ σ) C ⊑ D)
+    (renameᵗ-ext-suc-comm σ B)
+    (subst
+      (λ Σ → target-full-mode ∣ suc Θᴿ ∣ Σ
+        ⊢ renameᶜ (extᵗ σ) s
+        ∶ renameᵗ (extᵗ σ) C
+          ⊑ renameᵗ (extᵗ σ) (⇑ᵗ B))
+      store-eq renamed-widening)
+  where
+  σ = forward πᴿ
+  η = right-cast-renamer perm
+  extη = castModeRenamer-ext η
+  target-full-mode = instᵈ (CastModeRenamer.targetᵈ η mode)
+  target-store = (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+  SealTarget = SealModeStore★ target-full-mode
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm σ (rightStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ
+          (sym (rightStoreⁱ-rel-rename (store-permutation perm)))))
+
+  renamed-seal =
+    castModeRenamer-seal★ extη (cast-inst mode) seal★
+
+  renamed-widening =
+    widen-renameᵗ
+      (TyRenameWf-ext (forward-wf πᴿ))
+      (CastModeRenamer.target-rename extη (cast-inst mode)) s⊑
+
+left-ν★-widening-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ s C B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode (CastModeRenamer.targetᵈ
+    (left-embedding-cast-renamer emb) mode) ×
+  SealModeStore★
+    (instᵈ (CastModeRenamer.targetᵈ
+      (left-embedding-cast-renamer emb) mode))
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)) ×
+  instᵈ (CastModeRenamer.targetᵈ
+      (left-embedding-cast-renamer emb) mode)
+    ∣ suc Θᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+    ⊢ renameᶜ (extᵗ τ) s
+    ∶ renameᵗ (extᵗ τ) C ⊑ ⇑ᵗ (renameᵗ τ B)
+left-ν★-widening-rel-embed
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
+    {s = s} {C = C} {B = B} emb mode seal★ s⊑ =
+  CastModeRenamer.target-mode η mode ,
+  subst SealTarget store-eq renamed-seal ,
+  subst
+    (λ D → target-full-mode ∣ suc Θᴸ ∣ target-store
+      ⊢ renameᶜ (extᵗ τ) s ∶ renameᵗ (extᵗ τ) C ⊑ D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ Σ → target-full-mode ∣ suc Θᴸ ∣ Σ
+        ⊢ renameᶜ (extᵗ τ) s
+        ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B))
+      store-eq renamed-widening)
+  where
+  η = left-embedding-cast-renamer emb
+  extη = castModeRenamer-ext η
+  target-full-mode = instᵈ (CastModeRenamer.targetᵈ η mode)
+  target-store = (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+  SealTarget = SealModeStore★ target-full-mode
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ
+          (sym (leftStoreⁱ-rel-embedding (store-embedding emb)))))
+
+  renamed-seal =
+    castModeRenamer-seal★ extη (cast-inst mode) seal★
+
+  renamed-widening =
+    widen-renameᵗ (TyRenameWf-ext hτ)
+      (CastModeRenamer.target-rename extη (cast-inst mode)) s⊑
+
+right-ν★-widening-rel-embed :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ s C B} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode (CastModeRenamer.targetᵈ
+    (right-embedding-cast-renamer emb) mode) ×
+  SealModeStore★
+    (instᵈ (CastModeRenamer.targetᵈ
+      (right-embedding-cast-renamer emb) mode))
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)) ×
+  instᵈ (CastModeRenamer.targetᵈ
+      (right-embedding-cast-renamer emb) mode)
+    ∣ suc Θᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+    ⊢ renameᶜ (extᵗ σ) s
+    ∶ renameᵗ (extᵗ σ) C ⊑ ⇑ᵗ (renameᵗ σ B)
+right-ν★-widening-rel-embed
+    {Θᴿ = Θᴿ} {σ = σ} {hσ = hσ} {ρ = ρ} {ρ′ = ρ′}
+    {s = s} {C = C} {B = B} emb mode seal★ s⊑ =
+  CastModeRenamer.target-mode η mode ,
+  subst SealTarget store-eq renamed-seal ,
+  subst
+    (λ D → target-full-mode ∣ suc Θᴿ ∣ target-store
+      ⊢ renameᶜ (extᵗ σ) s ∶ renameᵗ (extᵗ σ) C ⊑ D)
+    (renameᵗ-ext-suc-comm σ B)
+    (subst
+      (λ Σ → target-full-mode ∣ suc Θᴿ ∣ Σ
+        ⊢ renameᶜ (extᵗ σ) s
+        ∶ renameᵗ (extᵗ σ) C ⊑ renameᵗ (extᵗ σ) (⇑ᵗ B))
+      store-eq renamed-widening)
+  where
+  η = right-embedding-cast-renamer emb
+  extη = castModeRenamer-ext η
+  target-full-mode = instᵈ (CastModeRenamer.targetᵈ η mode)
+  target-store = (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+  SealTarget = SealModeStore★ target-full-mode
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm σ (rightStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ
+          (sym (rightStoreⁱ-rel-embedding (store-embedding emb)))))
+
+  renamed-seal =
+    castModeRenamer-seal★ extη (cast-inst mode) seal★
+
+  renamed-widening =
+    widen-renameᵗ (TyRenameWf-ext hσ)
+      (CastModeRenamer.target-rename extη (cast-inst mode)) s⊑
+
+rel-world-νcast⊑νcast-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) (`∀ C)
+      ⊑ renameᵗ (forward πᴿ) (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ)
+        (∀ⁱ q) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (ν ★ N s)
+      ⊑ renameᵗᵐ (forward πᴿ) (ν ★ N′ s′)
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-νcast⊑νcast-permuteᵀ
+    perm mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ liftγ N⊑N′
+    with left-ν★-widening-rel-permute perm mode seal★ s⊑
+       | right-ν★-widening-rel-permute perm mode′ seal★′ s′⊑
+rel-world-νcast⊑νcast-permuteᵀ
+    perm mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | target-mode′ , target-seal′ , target-s′⊑
+    with rel-world-permutation-lift∀ⁱ perm liftρ liftγ
+rel-world-νcast⊑νcast-permuteᵀ
+    perm mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | target-mode′ , target-seal′ , target-s′⊑
+    | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-perm =
+  νcast⊑νcastᵀ target-mode target-seal target-mode′ target-seal′
+    target-s⊑ target-s′⊑ liftρ′ liftγ′ N⊑N′
+
+rel-world-νcast⊑νcast-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ renameᵗ σ (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ (∀ⁱ q) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ renameᵗᵐ σ (ν ★ N′ s′)
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-νcast⊑νcast-embedᵀ
+    emb mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ liftγ N⊑N′
+    with left-ν★-widening-rel-embed emb mode seal★ s⊑
+       | right-ν★-widening-rel-embed emb mode′ seal★′ s′⊑
+rel-world-νcast⊑νcast-embedᵀ
+    emb mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | target-mode′ , target-seal′ , target-s′⊑
+    with rel-world-embedding-lift∀ⁱ emb liftρ liftγ
+rel-world-νcast⊑νcast-embedᵀ
+    emb mode seal★ mode′ seal★′ s⊑ s′⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | target-mode′ , target-seal′ , target-s′⊑
+    | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb =
+  νcast⊑νcastᵀ target-mode target-seal target-mode′ target-seal′
+    target-s⊑ target-s′⊑ liftρ′ liftγ′ N⊑N′
+
+rel-world-νcast⊑-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) (`∀ C)
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) (ν ★ N s)
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-νcast⊑-permuteᵀ
+    perm mode seal★ s⊑ liftρ liftγ N⊑N′
+    with left-ν★-widening-rel-permute perm mode seal★ s⊑
+rel-world-νcast⊑-permuteᵀ
+    perm mode seal★ s⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    with rel-world-permutation-lift-leftⁱ perm liftρ liftγ
+rel-world-νcast⊑-permuteᵀ
+    perm mode seal★ s⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-perm =
+  νcast⊑ᵀ target-mode target-seal target-s⊑
+    liftρ′ liftγ′ N⊑N′
+
+rel-world-νcast⊑-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-νcast⊑-embedᵀ
+    emb mode seal★ s⊑ liftρ liftγ N⊑N′
+    with left-ν★-widening-rel-embed emb mode seal★ s⊑
+rel-world-νcast⊑-embedᵀ
+    emb mode seal★ s⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    with rel-world-embedding-lift-leftⁱ emb liftρ liftγ
+rel-world-νcast⊑-embedᵀ
+    emb mode seal★ s⊑ liftρ liftγ N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb =
+  νcast⊑ᵀ target-mode target-seal target-s⊑
+    liftρ′ liftγ′ N⊑N′
+
+rel-world-⊑νcast-permuteᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ}
+    {πᴸ : TyPermutation Δᴸ Θᴸ}
+    {πᴿ : TyPermutation Δᴿ Θᴿ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ (forward πᴸ) (forward πᴿ) a ∈ Ψ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  (perm : RelWorldPermutationⁱ πᴸ πᴿ assm
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) N′
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ (forward πᴸ) N
+      ⊑ renameᵗᵐ (forward πᴿ) (ν ★ N′ s)
+    ⦂ renameᵗ (forward πᴸ) B
+      ⊑ renameᵗ (forward πᴿ) B′
+    ∶ ⊑-renameᵗ²ᵢ assm (forward-wf πᴸ) (forward-wf πᴿ) p
+rel-world-⊑νcast-permuteᵀ
+    {πᴸ = πᴸ} {πᴿ = πᴿ} {assm = assm}
+    perm mode seal★ s⊑ liftρ liftγ r N⊑N′
+    with right-ν★-widening-rel-permute perm mode seal★ s⊑
+rel-world-⊑νcast-permuteᵀ
+    {πᴸ = πᴸ} {πᴿ = πᴿ} {assm = assm}
+    perm mode seal★ s⊑ liftρ liftγ r N⊑N′
+    | target-mode , target-seal , target-s⊑
+    with rel-world-permutation-lift-rightⁱ perm liftρ liftγ
+rel-world-⊑νcast-permuteᵀ
+    {πᴸ = πᴸ} {πᴿ = πᴿ} {assm = assm}
+    perm mode seal★ s⊑ liftρ liftγ r N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | ρ′ᴿ , γ′ᴿ , liftρ′ , liftγ′ , body-perm =
+  ⊑νcastᵀ target-mode target-seal target-s⊑
+    liftρ′ liftγ′
+    (⊑-renameᵗ²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+      (forward-wf πᴸ) (TyRenameWf-ext (forward-wf πᴿ)) r)
+    N⊑N′
+
+rel-world-⊑νcast-embedᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a} → a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ} {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  (emb : RelWorldEmbeddingⁱ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ N′
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ (`∀ C′)
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ q →
+  Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ renameᵗᵐ σ (ν ★ N′ s)
+    ⦂ renameᵗ τ B ⊑ renameᵗ σ B′
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+rel-world-⊑νcast-embedᵀ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    emb mode seal★ s⊑ liftρ liftγ r N⊑N′
+    with right-ν★-widening-rel-embed emb mode seal★ s⊑
+rel-world-⊑νcast-embedᵀ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    emb mode seal★ s⊑ liftρ liftγ r N⊑N′
+    | target-mode , target-seal , target-s⊑
+    with rel-world-embedding-lift-rightⁱ emb liftρ liftγ
+rel-world-⊑νcast-embedᵀ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    emb mode seal★ s⊑ liftρ liftγ r N⊑N′
+    | target-mode , target-seal , target-s⊑
+    | ρ′ᴿ , γ′ᴿ , liftρ′ , liftγ′ , body-emb =
+  ⊑νcastᵀ target-mode target-seal target-s⊑
+    liftρ′ liftγ′
+    (⊑-renameᵗ²ᵢ (rename-assm²-⇑ᴿ²ᵢ assm)
+      hτ (TyRenameWf-ext hσ) r)
+    N⊑N′
+
+left-seal★-ν★-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  SealModeStore★
+    (instᵈ (CastModeRenamer.targetᵈ
+      (left-insertion-cast-renamer ins) mode))
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
+left-seal★-ν★-renameⁱ {τ = τ} {ρ = ρ} ins renameρ mode seal★ =
+  subst (SealModeStore★ _)
+    store-eq
+    (castModeRenamer-seal★
+      (castModeRenamer-ext (left-insertion-cast-renamer ins))
+      (cast-inst mode) seal★)
+  where
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
+
+right-seal★-ν★-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
+right-seal★-ν★-left-renameⁱ renameρ seal★ =
+  subst (SealModeStore★ _)
+    (cong ((zero , ★) ∷_)
+      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
+    seal★
+
+left-widening-ν★-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c C B} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  instᵈ (CastModeRenamer.targetᵈ
+      (left-insertion-cast-renamer ins) mode)
+    ∣ suc Δᴸ′ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+    ⊢ renameᶜ (extᵗ τ) c
+    ∶ renameᵗ (extᵗ τ) C ⊑ ⇑ᵗ (renameᵗ τ B)
+left-widening-ν★-renameⁱ
+    {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {ρ = ρ} {ρ′ = ρ′}
+    {μ = μ} {c = c} {C = C} {B = B}
+    ins renameρ mode c⊑ =
+  subst
+    (λ D → instᵈ target-mode ∣ suc Δᴸ′ ∣ target-store
+      ⊢ renameᶜ (extᵗ τ) c
+      ∶ renameᵗ (extᵗ τ) C ⊑ D)
+    (renameᵗ-ext-suc-comm τ B)
+    store-normalized
+  where
+  modeτ = left-insertion-cast-renamer ins
+  target-mode = CastModeRenamer.targetᵈ modeτ mode
+  target-store = (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-★-cons-comm τ (leftStoreⁱ ρ))
+      (cong ((zero , ★) ∷_)
+        (cong ⟰ᵗ (sym (leftStoreⁱ-left-rename renameρ))))
+
+  renamed :
+    instᵈ target-mode ∣ suc Δᴸ′ ∣
+      renameStoreᵗ (extᵗ τ)
+        ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+      ⊢ renameᶜ (extᵗ τ) c
+      ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B)
+  renamed =
+    widen-renameᵗ (TyRenameWf-ext hτ)
+      (CastModeRenamer.target-rename
+        (castModeRenamer-ext modeτ) (cast-inst mode)) c⊑
+
+  store-normalized :
+    instᵈ target-mode ∣ suc Δᴸ′ ∣ target-store
+      ⊢ renameᶜ (extᵗ τ) c
+      ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B)
+  store-normalized =
+    subst
+      (λ Σ → instᵈ target-mode ∣ suc Δᴸ′ ∣ Σ
+        ⊢ renameᶜ (extᵗ τ) c
+        ∶ renameᵗ (extᵗ τ) C ⊑ renameᵗ (extᵗ τ) (⇑ᵗ B))
+      store-eq renamed
+
+right-widening-ν★-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c C B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+    ⊢ c ∶ C ⊑ ⇑ᵗ B
+right-widening-ν★-left-renameⁱ
+    {Δᴿ = Δᴿ} {μ = μ} {c = c} {C = C} {B = B}
+    renameρ c⊑ =
+  subst
+    (λ Σ → instᵈ μ ∣ suc Δᴿ ∣ Σ ⊢ c ∶ C ⊑ ⇑ᵗ B)
+    (cong ((zero , ★) ∷_)
+      (cong ⟰ᵗ (sym (rightStoreⁱ-left-rename renameρ))))
+    c⊑
+
+left-conceal-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ α X c A B} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  ConcealConversion (left-insertion-mode ins μ) Δᴸ′
+    (leftStoreⁱ ρ′) (τ α) (renameᵗ τ X)
+    (renameᶜ τ c) (renameᵗ τ A) (renameᵗ τ B)
+left-conceal-renameⁱ {hτ = hτ} ins renameρ conv =
+  subst
+    (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (leftStoreⁱ-left-rename renameρ))
+    (rename-conceal-conversion hτ
+      (left-insertion-mode-rename ins _) conv)
+
+right-reveal-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ β X c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ′) β X c A B
+right-reveal-left-renameⁱ renameρ conv =
+  subst
+    (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) conv
+
+right-conceal-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ β X c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ′) β X c A B
+right-conceal-left-renameⁱ renameρ conv =
+  subst
+    (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) conv
+
+right-seal★-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  SealModeStore★ μ (rightStoreⁱ ρ) →
+  SealModeStore★ μ (rightStoreⁱ ρ′)
+right-seal★-left-renameⁱ renameρ seal★ =
+  subst (SealModeStore★ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) seal★
+
+right-widening-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ′ ⊢ c ∶ A ⊑ B
+right-widening-left-renameⁱ renameρ c⊑ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊑ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) c⊑
+
+right-narrowing-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {μ c A B} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ′ ⊢ c ∶ A ⊒ B
+right-narrowing-left-renameⁱ renameρ c⊒ =
+  subst
+    (λ Σ → _ ∣ _ ∣ Σ ⊢ _ ∶ _ ⊒ _)
+    (sym (rightStoreⁱ-left-rename renameρ)) c⊒
+
+right-store-det-left-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  StoreDetWf Δᴿ (rightStoreⁱ ρ) →
+  StoreDetWf Δᴿ (rightStoreⁱ ρ′)
+right-store-det-left-renameⁱ renameρ wfΣ =
+  subst (StoreDetWf _)
+    (sym (rightStoreⁱ-left-rename renameρ)) wfΣ
+
+left-store-rename-∀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  ∃[ ρ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      ρ∀ ρ′∀
+left-store-rename-∀ left-store-rename-[] lift-store-[] =
+  [] , lift-store-[] , left-store-rename-[]
+left-store-rename-∀
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-store-∷ {p′ = p∀} liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-store-∷ {A = A} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-matched (suc α′) (⇑ᵗ A′) (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ ρ′∀ ,
+  lift-store-∷ liftρ′ ,
+  left-store-rename-matched (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-∀
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-store-left liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-store-left {A = A} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-left liftρ′ ,
+  left-store-rename-left (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-∀
+    (left-store-rename-right {hB′ = hB′} renameρ)
+    (lift-store-right liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀
+    (left-store-rename-right {β = β} {B = B} {hB′ = hB′} renameρ)
+    (lift-store-right liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-right (suc β) (⇑ᵗ B)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-right liftρ′ ,
+  left-store-rename-right renameρ∀
+left-store-rename-∀
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-store-link {p′ = p∀} liftρ)
+    with left-store-rename-∀ renameρ liftρ
+left-store-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-store-link {A = A} {p′ = p∀} liftρ)
+    | ρ′∀ , liftρ′ , renameρ∀ =
+  store-link (suc α′) (⇑ᵗ A′) (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ ρ′∀ ,
+  lift-store-link liftρ′ ,
+  left-store-rename-link (cong suc eqα) eqA∀ renameρ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-ctx-rename-∀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ γ′∀ ]
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      γ∀ γ′∀
+left-ctx-rename-∀ left-ctx-rename-[] lift-ctx-[] =
+  [] , lift-ctx-[] , left-ctx-rename-[]
+left-ctx-rename-∀
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    (lift-ctx-∷ {p′ = p∀} liftγ)
+    with left-ctx-rename-∀ renameγ liftγ
+left-ctx-rename-∀ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
+    (lift-ctx-∷ {A = A} {p′ = p∀} liftγ)
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ctx-imp (⇑ᵗ A′) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) eqA∀ p∀) ∷ γ′∀ ,
+  lift-ctx-∷ liftγ′ ,
+  left-ctx-rename-∷ eqA∀ renameγ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-store-rename-ν :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  ∃[ ρ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      ρν ρ′ν
+left-store-rename-ν left-store-rename-[] lift-left-store-[] =
+  [] , lift-left-store-[] , left-store-rename-[]
+left-store-rename-ν
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-left-store-∷ {p′ = pν} liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-left-store-∷ {A = A} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-matched (suc α′) (⇑ᵗ A′) β B
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) eqAν pν) ∷ ρ′ν ,
+  lift-left-store-∷ liftρ′ ,
+  left-store-rename-matched (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-ν
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-left-store-left liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-left-store-left {A = A} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′ν ,
+  lift-left-store-left liftρ′ ,
+  left-store-rename-left (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+left-store-rename-ν
+    (left-store-rename-right {hB′ = hB′} renameρ)
+    (lift-left-store-right liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν
+    (left-store-rename-right {β = β} {B = B} {hB′ = hB′} renameρ)
+    (lift-left-store-right liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-right β B hB′ ∷ ρ′ν ,
+  lift-left-store-right liftρ′ ,
+  left-store-rename-right renameρν
+left-store-rename-ν
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-left-store-link {p′ = pν} liftρ)
+    with left-store-rename-ν renameρ liftρ
+left-store-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-left-store-link {A = A} {p′ = pν} liftρ)
+    | ρ′ν , liftρ′ , renameρν =
+  store-link (suc α′) (⇑ᵗ A′) β B
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) eqAν pν) ∷ ρ′ν ,
+  lift-left-store-link liftρ′ ,
+  left-store-rename-link (cong suc eqα) eqAν renameρν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-ctx-rename-ν :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ γ′ν ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      γν γ′ν
+left-ctx-rename-ν left-ctx-rename-[] lift-left-ctx-[] =
+  [] , lift-left-ctx-[] , left-ctx-rename-[]
+left-ctx-rename-ν
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    (lift-left-ctx-∷ {p′ = pν} liftγ)
+    with left-ctx-rename-ν renameγ liftγ
+left-ctx-rename-ν {τ = τ} {assm = assm} {hτ = hτ}
+    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
+    (lift-left-ctx-∷ {A = A} {p′ = pν} liftγ)
+    | γ′ν , liftγ′ , renameγν =
+  ctx-imp (⇑ᵗ A′) B
+      (⊑-rename-left-atᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) eqAν pν) ∷ γ′ν ,
+  lift-left-ctx-∷ liftγ′ ,
+  left-ctx-rename-∷ eqAν renameγν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν = trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+left-store-rename-ν-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρ′ν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+      (suc Δᴸ′) Δᴿ} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LeftStoreRenameⁱ
+    (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+    ρν ρ′ν →
+  ∃[ ρ′ ]
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ ×
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν
+left-store-rename-ν-inv
+    lift-left-store-[] left-store-rename-[] =
+  [] , left-store-rename-[] , lift-left-store-[]
+left-store-rename-ν-inv
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ with eqα
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-matched α A β B p ∷ ρ}
+    (lift-left-store-∷ liftρ)
+    (left-store-rename-matched eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl | refl =
+  store-matched (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p) ∷ ρ′ ,
+  left-store-rename-matched refl refl renameρ′ ,
+  lift-left-store-∷ liftρ′
+left-store-rename-ν-inv
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv {τ = τ} {hτ = hτ}
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ with eqα
+left-store-rename-ν-inv {τ = τ} {hτ = hτ}
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-store-rename-ν-inv {τ = τ} {hτ = hτ}
+    {ρ = store-left α A hA ∷ ρ}
+    (lift-left-store-left liftρ)
+    (left-store-rename-left eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl | refl =
+  store-left (τ α) (renameᵗ τ A)
+      (renameᵗ-preserves-WfTy hA hτ) ∷ ρ′ ,
+  left-store-rename-left refl refl renameρ′ ,
+  lift-left-store-left liftρ′
+left-store-rename-ν-inv
+    {ρ = store-right β B hB ∷ ρ}
+    (lift-left-store-right liftρ)
+    (left-store-rename-right renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv
+    {ρ = store-right β B hB ∷ ρ}
+    (lift-left-store-right liftρ)
+    (left-store-rename-right renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-right β B hB ∷ ρ′ ,
+  left-store-rename-right renameρ′ ,
+  lift-left-store-right liftρ′
+left-store-rename-ν-inv
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    with left-store-rename-ν-inv liftρ renameρ
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ with eqα
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-store-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρ = store-link α A β B p ∷ ρ}
+    (lift-left-store-link liftρ)
+    (left-store-rename-link eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ | refl | refl =
+  store-link (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p) ∷ ρ′ ,
+  left-store-rename-link refl refl renameρ′ ,
+  lift-left-store-link liftρ′
+
+left-ctx-rename-ν-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ′ν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+      (suc Δᴸ′) Δᴿ} →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  LeftCtxRenameⁱ
+    (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+    γν γ′ν →
+  ∃[ γ′ ]
+    LeftCtxRenameⁱ τ assm hτ γ γ′ ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν
+left-ctx-rename-ν-inv lift-left-ctx-[] left-ctx-rename-[] =
+  [] , left-ctx-rename-[] , lift-left-ctx-[]
+left-ctx-rename-ν-inv
+    {γ = ctx-imp A B p ∷ γ}
+    (lift-left-ctx-∷ liftγ)
+    (left-ctx-rename-∷ eqA renameγ)
+    with left-ctx-rename-ν-inv liftγ renameγ
+left-ctx-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {γ = ctx-imp A B p ∷ γ}
+    (lift-left-ctx-∷ liftγ)
+    (left-ctx-rename-∷ eqA renameγ)
+    | γ′ , renameγ′ , liftγ′
+    with trans eqA (renameᵗ-ext-suc-comm τ A)
+left-ctx-rename-ν-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {γ = ctx-imp A B p ∷ γ}
+    (lift-left-ctx-∷ liftγ)
+    (left-ctx-rename-∷ eqA renameγ)
+    | γ′ , renameγ′ , liftγ′ | refl =
+  ctx-imp (renameᵗ τ A) B (⊑-rename-leftᵢ τ assm hτ p) ∷ γ′ ,
+  left-ctx-rename-∷ refl renameγ′ ,
+  lift-left-ctx-∷ liftγ′
+
+left-store-rename-suc-liftⁱ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′
+left-store-rename-suc-liftⁱ left-store-rename-[] =
+  lift-left-store-[]
+left-store-rename-suc-liftⁱ
+    {ρ = store-matched α A β B p ∷ ρ}
+    (left-store-rename-matched eqα eqA renameρ)
+    with eqα
+left-store-rename-suc-liftⁱ
+    {ρ = store-matched α A β B p ∷ ρ}
+    (left-store-rename-matched eqα eqA renameρ) | refl
+    with eqA
+left-store-rename-suc-liftⁱ
+    {ρ = store-matched α A β B p ∷ ρ}
+    (left-store-rename-matched eqα eqA renameρ) | refl | refl =
+  lift-left-store-∷ (left-store-rename-suc-liftⁱ renameρ)
+left-store-rename-suc-liftⁱ
+    {ρ = store-left α A hA ∷ ρ}
+    (left-store-rename-left eqα eqA renameρ)
+    with eqα
+left-store-rename-suc-liftⁱ
+    {ρ = store-left α A hA ∷ ρ}
+    (left-store-rename-left eqα eqA renameρ) | refl
+    with eqA
+left-store-rename-suc-liftⁱ
+    {ρ = store-left α A hA ∷ ρ}
+    (left-store-rename-left eqα eqA renameρ) | refl | refl =
+  lift-left-store-left (left-store-rename-suc-liftⁱ renameρ)
+left-store-rename-suc-liftⁱ
+    {ρ = store-right β B hB ∷ ρ}
+    (left-store-rename-right renameρ) =
+  lift-left-store-right (left-store-rename-suc-liftⁱ renameρ)
+left-store-rename-suc-liftⁱ
+    {ρ = store-link α A β B p ∷ ρ}
+    (left-store-rename-link eqα eqA renameρ)
+    with eqα
+left-store-rename-suc-liftⁱ
+    {ρ = store-link α A β B p ∷ ρ}
+    (left-store-rename-link eqα eqA renameρ) | refl
+    with eqA
+left-store-rename-suc-liftⁱ
+    {ρ = store-link α A β B p ∷ ρ}
+    (left-store-rename-link eqα eqA renameρ) | refl | refl =
+  lift-left-store-link (left-store-rename-suc-liftⁱ renameρ)
+
+left-store-rename-⇑ᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  ∃[ ρ′ᴿ ]
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ ×
+    LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ ρᴿ ρ′ᴿ
+left-store-rename-⇑ᴿ left-store-rename-[] lift-right-store-[] =
+  [] , lift-right-store-[] , left-store-rename-[]
+left-store-rename-⇑ᴿ
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-right-store-∷ {p′ = pᴿ} liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-right-store-∷ {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-matched α′ A′ (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-∷ liftρ′ ,
+  left-store-rename-matched eqα eqA renameρᴿ
+left-store-rename-⇑ᴿ
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-right-store-left liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    (lift-right-store-left liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-left α′ A′ hA′ ∷ ρ′ᴿ ,
+  lift-right-store-left liftρ′ ,
+  left-store-rename-left eqα eqA renameρᴿ
+left-store-rename-⇑ᴿ
+    (left-store-rename-right renameρ)
+    (lift-right-store-right liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ
+    (left-store-rename-right {β = β} {B = B} renameρ)
+    (lift-right-store-right {hB′ = hBᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-right (suc β) (⇑ᵗ B) hBᴿ ∷ ρ′ᴿ ,
+  lift-right-store-right liftρ′ ,
+  left-store-rename-right renameρᴿ
+left-store-rename-⇑ᴿ
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    (lift-right-store-link {p′ = pᴿ} liftρ)
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-store-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      {β = β} {B = B} eqα eqA renameρ)
+    (lift-right-store-link {p′ = pᴿ} liftρ)
+    | ρ′ᴿ , liftρ′ , renameρᴿ =
+  store-link α′ A′ (suc β) (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ ρ′ᴿ ,
+  lift-right-store-link liftρ′ ,
+  left-store-rename-link eqα eqA renameρᴿ
+
+left-ctx-rename-⇑ᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ∃[ γ′ᴿ ]
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ ×
+    LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ
+left-ctx-rename-⇑ᴿ left-ctx-rename-[] lift-right-ctx-[] =
+  [] , lift-right-ctx-[] , left-ctx-rename-[]
+left-ctx-rename-⇑ᴿ
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
+    with left-ctx-rename-⇑ᴿ renameγ liftγ
+left-ctx-rename-⇑ᴿ {τ = τ} {assm = assm} {hτ = hτ}
+    (left-ctx-rename-∷ {A′ = A′} {B = B} eqA renameγ)
+    (lift-right-ctx-∷ {p′ = pᴿ} liftγ)
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ctx-imp A′ (⇑ᵗ B)
+      (⊑-rename-left-atᵢ
+        τ (rename-assm²-⇑ᴿᵢ assm) hτ eqA pᴿ) ∷ γ′ᴿ ,
+  lift-right-ctx-∷ liftγ′ ,
+  left-ctx-rename-∷ eqA renameγᴿ
+
+left-store-rename-⇑ᴿ-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {ρ′ᴿ : StoreImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)} →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ ρᴿ ρ′ᴿ →
+  ∃[ ρ′ ]
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ ×
+    LiftRightStoreⁱ (⇑ᴿᵢ Ψ) ρ′ ρ′ᴿ
+left-store-rename-⇑ᴿ-inv
+    lift-right-store-[] left-store-rename-[] =
+  [] , left-store-rename-[] , lift-right-store-[]
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-∷ {p = p} liftρ)
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    (lift-right-store-∷ {p = p} liftρ)
+    (left-store-rename-matched {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-matched α′ A′ _ _
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′ ,
+  left-store-rename-matched eqα eqA renameρ′ ,
+  lift-right-store-∷ liftρ′
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-left liftρ)
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-left liftρ)
+    (left-store-rename-left {α′ = α′} {A′ = A′} {hA′ = hA′}
+      eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-left α′ A′ hA′ ∷ ρ′ ,
+  left-store-rename-left eqα eqA renameρ′ ,
+  lift-right-store-left liftρ′
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-right {hB = hB} liftρ)
+    (left-store-rename-right renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-right {hB = hB} liftρ)
+    (left-store-rename-right renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-right _ _ hB ∷ ρ′ ,
+  left-store-rename-right renameρ′ ,
+  lift-right-store-right liftρ′
+left-store-rename-⇑ᴿ-inv
+    (lift-right-store-link {p = p} liftρ)
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    with left-store-rename-⇑ᴿ-inv liftρ renameρ
+left-store-rename-⇑ᴿ-inv
+    {τ = τ} {assm = assm} {hτ = hτ}
+    (lift-right-store-link {p = p} liftρ)
+    (left-store-rename-link {α′ = α′} {A′ = A′}
+      eqα eqA renameρ)
+    | ρ′ , renameρ′ , liftρ′ =
+  store-link α′ A′ _ _
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ ρ′ ,
+  left-store-rename-link eqα eqA renameρ′ ,
+  lift-right-store-link liftρ′
+
+left-ctx-rename-⇑ᴿ-inv :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ′ᴿ : CtxImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)} →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ →
+  ∃[ γ′ ]
+    LeftCtxRenameⁱ τ assm hτ γ γ′ ×
+    LiftRightCtxⁱ (⇑ᴿᵢ Ψ) γ′ γ′ᴿ
+left-ctx-rename-⇑ᴿ-inv lift-right-ctx-[] left-ctx-rename-[] =
+  [] , left-ctx-rename-[] , lift-right-ctx-[]
+left-ctx-rename-⇑ᴿ-inv
+    (lift-right-ctx-∷ {p = p} liftγ)
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    with left-ctx-rename-⇑ᴿ-inv liftγ renameγ
+left-ctx-rename-⇑ᴿ-inv {τ = τ} {assm = assm} {hτ = hτ}
+    (lift-right-ctx-∷ {p = p} liftγ)
+    (left-ctx-rename-∷ {A′ = A′} eqA renameγ)
+    | γ′ , renameγ′ , liftγ′ =
+  ctx-imp A′ _ (⊑-rename-left-atᵢ τ assm hτ eqA p) ∷ γ′ ,
+  left-ctx-rename-∷ eqA renameγ′ ,
+  lift-right-ctx-∷ liftγ′
+
+rename-left-storeⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  StoreImp Φ Δᴸ Δᴿ →
+  StoreImp Ψ Δᴸ′ Δᴿ
+rename-left-storeⁱ τ assm hτ [] = []
+rename-left-storeⁱ τ assm hτ
+    (store-matched α A β B p ∷ ρ) =
+  store-matched (τ α) (renameᵗ τ A) β B
+    (⊑-rename-leftᵢ τ assm hτ p) ∷
+  rename-left-storeⁱ τ assm hτ ρ
+rename-left-storeⁱ τ assm hτ (store-left α A hA ∷ ρ) =
+  store-left (τ α) (renameᵗ τ A)
+    (renameᵗ-preserves-WfTy hA hτ) ∷
+  rename-left-storeⁱ τ assm hτ ρ
+rename-left-storeⁱ τ assm hτ (store-right β B hB ∷ ρ) =
+  store-right β B hB ∷ rename-left-storeⁱ τ assm hτ ρ
+rename-left-storeⁱ τ assm hτ (store-link α A β B p ∷ ρ) =
+  store-link (τ α) (renameᵗ τ A) β B
+    (⊑-rename-leftᵢ τ assm hτ p) ∷
+  rename-left-storeⁱ τ assm hτ ρ
+
+rename-left-store-coherentⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ)
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  LeftStoreRenameⁱ τ assm hτ ρ
+    (rename-left-storeⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ [] =
+  left-store-rename-[]
+rename-left-store-coherentⁱ τ assm hτ
+    (store-matched α A β B p ∷ ρ) =
+  left-store-rename-matched refl refl
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ
+    (store-left α A hA ∷ ρ) =
+  left-store-rename-left refl refl
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ
+    (store-right β B hB ∷ ρ) =
+  left-store-rename-right
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+rename-left-store-coherentⁱ τ assm hτ
+    (store-link α A β B p ∷ ρ) =
+  left-store-rename-link refl refl
+    (rename-left-store-coherentⁱ τ assm hτ ρ)
+
+rename-left-store-source-liftⁱ :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ
+    (rename-left-storeⁱ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc ρ)
+rename-left-store-source-liftⁱ [] = lift-left-store-[]
+rename-left-store-source-liftⁱ
+    (store-matched α A β B p ∷ ρ) =
+  lift-left-store-∷ (rename-left-store-source-liftⁱ ρ)
+rename-left-store-source-liftⁱ (store-left α A hA ∷ ρ) =
+  lift-left-store-left (rename-left-store-source-liftⁱ ρ)
+rename-left-store-source-liftⁱ (store-right β B hB ∷ ρ) =
+  lift-left-store-right (rename-left-store-source-liftⁱ ρ)
+rename-left-store-source-liftⁱ (store-link α A β B p ∷ ρ) =
+  lift-left-store-link (rename-left-store-source-liftⁱ ρ)
+
+leftStoreⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  leftStoreⁱ
+      (rename-left-storeⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ ρ)
+    ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+leftStoreⁱ-rename-left [] = refl
+leftStoreⁱ-rename-left (store-matched α A β B p ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (leftStoreⁱ-rename-left ρ)
+leftStoreⁱ-rename-left (store-left α A hA ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (leftStoreⁱ-rename-left ρ)
+leftStoreⁱ-rename-left (store-right β B hB ∷ ρ) =
+  leftStoreⁱ-rename-left ρ
+leftStoreⁱ-rename-left (store-link α A β B p ∷ ρ) =
+  leftStoreⁱ-rename-left ρ
+
+rightStoreⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  rightStoreⁱ
+      (rename-left-storeⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ ρ)
+    ≡ rightStoreⁱ ρ
+rightStoreⁱ-rename-left [] = refl
+rightStoreⁱ-rename-left (store-matched α A β B p ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (rightStoreⁱ-rename-left ρ)
+rightStoreⁱ-rename-left (store-left α A hA ∷ ρ) =
+  rightStoreⁱ-rename-left ρ
+rightStoreⁱ-rename-left (store-right β B hB ∷ ρ) =
+  cong ((_,_ _ _) ∷_) (rightStoreⁱ-rename-left ρ)
+rightStoreⁱ-rename-left (store-link α A β B p ∷ ρ) =
+  rightStoreⁱ-rename-left ρ
+
+rename-left-ctxⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ) →
+  (∀ {a} → a ∈ Φ →
+    rename-assm²ᵢ τ (λ X → X) a ∈ Ψ) →
+  TyRenameWf Δᴸ Δᴸ′ τ →
+  CtxImp Φ Δᴸ Δᴿ →
+  CtxImp Ψ Δᴸ′ Δᴿ
+rename-left-ctxⁱ τ assm hτ [] = []
+rename-left-ctxⁱ τ assm hτ (ctx-imp A B p ∷ γ) =
+  ctx-imp (renameᵗ τ A) B
+    (⊑-rename-leftᵢ τ assm hτ p) ∷
+  rename-left-ctxⁱ τ assm hτ γ
+
+rename-left-ctx-coherentⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} (τ : Renameᵗ)
+    (assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Δᴸ′ τ)
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  LeftCtxRenameⁱ τ assm hτ γ
+    (rename-left-ctxⁱ τ assm hτ γ)
+rename-left-ctx-coherentⁱ τ assm hτ [] =
+  left-ctx-rename-[]
+rename-left-ctx-coherentⁱ τ assm hτ (ctx-imp A B p ∷ γ) =
+  left-ctx-rename-∷ refl
+    (rename-left-ctx-coherentⁱ τ assm hτ γ)
+
+rename-left-ctx-source-liftⁱ :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ
+    (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc γ)
+rename-left-ctx-source-liftⁱ [] = lift-left-ctx-[]
+rename-left-ctx-source-liftⁱ (ctx-imp A B p ∷ γ) =
+  lift-left-ctx-∷ (rename-left-ctx-source-liftⁱ γ)
+
+left-source-rename-worldsⁱ :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ)
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ
+      (rename-left-storeⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc ρ) ×
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ
+      (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc γ) ×
+  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc ρ
+      (rename-left-storeⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc ρ) ×
+  LeftCtxRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc γ
+      (rename-left-ctxⁱ suc rename-assm²-source-νᵢ
+        TyRenameWf-suc γ)
+left-source-rename-worldsⁱ ρ γ =
+  rename-left-store-source-liftⁱ ρ ,
+  rename-left-ctx-source-liftⁱ γ ,
+  rename-left-store-coherentⁱ
+    suc rename-assm²-source-νᵢ TyRenameWf-suc ρ ,
+  rename-left-ctx-coherentⁱ
+    suc rename-assm²-source-νᵢ TyRenameWf-suc γ
+
+left-ctx-rename-lookupⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {x A B p} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  γ ∋ x ⦂ ctx-imp A B p →
+  ∃[ A′ ] ∃[ eqA ]
+    γ′ ∋ x ⦂ ctx-imp A′ B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p)
+left-ctx-rename-lookupⁱ
+    (left-ctx-rename-∷ eqA renameγ) Z =
+  _ , eqA , Z
+left-ctx-rename-lookupⁱ
+    (left-ctx-rename-∷ eqA renameγ) (S x∈) =
+  let A′ , eqA′ , x∈′ = left-ctx-rename-lookupⁱ renameγ x∈ in
+  A′ , eqA′ , S x∈′
+
+left-rename-xᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {x A B p}
+    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  γ ∋ x ⦂ ctx-imp A B p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (` x) ⊑ ` x
+    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-xᵀ renameγ x∈ with left-ctx-rename-lookupⁱ renameγ x∈
+left-rename-xᵀ renameγ x∈ | A′ , refl , x∈′ = x⊑xᵀ x∈′
+
+left-rename-blameᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M A B} {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ blame ⊑ M
+    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-blameᵀ renameρ renameγ M⊢ =
+  blame⊑ᵀ (right-typing-left-renameⁱ renameρ renameγ M⊢)
+
+left-rename-ƛᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {N N′ A A′ B B′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣
+      ctx-imp (renameᵗ τ A) A′
+        (⊑-rename-leftᵢ τ assm hτ pA) ∷ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ pB →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ƛ N) ⊑ ƛ N′
+    ⦂ renameᵗ τ (A ⇒ B) ⊑ A′ ⇒ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (pA ↦ pB)
+left-rename-ƛᵀ {hτ = hτ} hA hA′ N⊑N′ =
+  ƛ⊑ƛᵀ (renameᵗ-preserves-WfTy hA hτ) hA′ N⊑N′
+
+left-rename-·ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {L L′ M M′ A A′ B B′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ L ⊑ L′
+    ⦂ renameᵗ τ (A ⇒ B) ⊑ A′ ⇒ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (pA ↦ pB) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′
+    ∶ ⊑-rename-leftᵢ τ assm hτ pA →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (L · M) ⊑ L′ · M′
+    ⦂ renameᵗ τ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ pB
+left-rename-·ᵀ L⊑L′ M⊑M′ = ·⊑·ᵀ L⊑L′ M⊑M′
+
+left-rename-cast⊒⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (modeτ : CastModeRenamer τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-cast⊒⊑ᵀ modeτ renameρ mode seal★ c⊒ M⊑M′ =
+  cast⊒⊑ᵀ (CastModeRenamer.target-mode modeτ mode)
+    (left-seal★-renameⁱ modeτ renameρ mode seal★)
+    (left-narrowing-renameⁱ modeτ mode renameρ c⊒)
+    M⊑M′ _
+
+left-rename-cast⊑⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (modeτ : CastModeRenamer τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-cast⊑⊑ᵀ modeτ renameρ mode seal★ c⊑ M⊑M′ =
+  cast⊑⊑ᵀ (CastModeRenamer.target-mode modeτ mode)
+    (left-seal★-renameⁱ modeτ renameρ mode seal★)
+    (left-widening-renameⁱ modeτ mode renameρ c⊑)
+    M⊑M′ _
+
+left-rename-⊑cast⊒ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑cast⊒ᵀ renameρ mode′ seal★′ c′⊒ M⊑M′ =
+  ⊑cast⊒ᵀ mode′
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-narrowing-left-renameⁱ renameρ c′⊒) M⊑M′ _
+
+left-rename-⊑cast⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  CastMode μ′ →
+  SealModeStore★ μ′ (rightStoreⁱ ρ) →
+  μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑cast⊑ᵀ renameρ mode′ seal★′ c′⊑ M⊑M′ =
+  ⊑cast⊑ᵀ mode′
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ c′⊑) M⊑M′ _
+
+left-rename-⊑cast⊑idᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  SealModeStore★ id-onlyᵈ (rightStoreⁱ ρ) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑cast⊑idᵀ renameρ seal★′ c′⊑ M⊑M′ =
+  ⊑cast⊑idᵀ
+    (right-seal★-left-renameⁱ {μ = id-onlyᵈ} renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ c′⊑) M⊑M′ _
+
+left-rename-up⊑upᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {N N′ A A′ D D′ u u′}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (N ⟨ u ⟩) ⊑ N′ ⟨ u′ ⟩
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ pA
+left-rename-up⊑upᵀ {τ = τ} renameρ u⊑ u′⊑ N⊑N′ =
+  up⊑upᵀ N⊑N′
+    (quotient-id-widening
+      (left-widening-rename-modeⁱ
+        (modeRename-id-only τ) renameρ u⊑)
+      (right-widening-left-renameⁱ renameρ u′⊑)) _
+
+left-rename-down⊑downᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ C C′ D D′ d d′}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ C ⊑ C′ ∶ ⊑-rename-leftᵢ τ assm hτ pC →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩) ⊑ M′ ⟨ d′ ⟩
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD
+left-rename-down⊑downᵀ {τ = τ} renameρ d⊒ d′⊒ M⊑M′ =
+  down⊑downᵀ
+    (left-narrowing-rename-modeⁱ (modeRename-id-only τ) renameρ d⊒)
+    (right-narrowing-left-renameⁱ renameρ d′⊒) M⊑M′ _
+
+left-rename-gen-down⊑gen-downᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ C C′ D D′ d d′}
+    {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+    {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  (renameρ : LeftStoreRenameⁱ τ assm hτ ρ ρ′) →
+  genᵈ tag-or-idᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ C ⊒ D →
+  genᵈ tag-or-idᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ
+    ⊢ d′ ∶ C′ ⊒ D′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ C ⊑ C′ ∶ ⊑-rename-leftᵢ τ assm hτ pC →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺᵖ renameᵗᵐ τ (M ⟨ d ⟩) ⊑ M′ ⟨ d′ ⟩
+    ⦂ renameᵗ τ D ⊑ᵖ D′ ∶ ⊑ᵖ-rename-leftᵢ τ assm hτ qD
+left-rename-gen-down⊑gen-downᵀ {τ = τ} renameρ d⊒ d′⊒ M⊑M′ =
+  gen-down⊑gen-downᵀ
+    (left-narrowing-rename-modeⁱ
+      (modeRename-gen-tag-or-id τ) renameρ d⊒)
+    (right-narrowing-left-renameⁱ renameρ d′⊒) M⊑M′ _
+
+left-rename-Λᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {V V′ A B} {p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Value V →
+  Value V′ →
+  (∀ {ρ′∀ γ′∀} →
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ →
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ →
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      ρ∀ ρ′∀ →
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ)
+      γ∀ γ′∀ →
+    ∀ᵢᶜ Ψ ∣ suc Δᴸ′ ∣ suc Δᴿ ∣ ρ′∀ ∣ γ′∀
+      ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ V′
+      ⦂ renameᵗ (extᵗ τ) A ⊑ B
+      ∶ ⊑-rename-leftᵢ
+        (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+        (TyRenameWf-ext hτ) p) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ Λ V′
+    ⦂ renameᵗ τ (`∀ A) ⊑ `∀ B
+    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ p)
+left-rename-Λᵀ renameρ renameγ liftρ liftγ vV vV′ body-map
+    with left-store-rename-∀ renameρ liftρ
+left-rename-Λᵀ renameρ renameγ liftρ liftγ vV vV′ body-map
+    | ρ′∀ , liftρ′ , renameρ∀
+    with left-ctx-rename-∀ renameγ liftγ
+left-rename-Λᵀ {τ = τ}
+    renameρ renameγ liftρ liftγ vV vV′ body-map
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  Λ⊑Λᵀ liftρ′ liftγ′
+    (renameᵗᵐ-preserves-Value (extᵗ τ) vV) vV′
+    (body-map liftρ′ liftγ′ renameρ∀ renameγ∀)
+
+left-rename-Λ⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {V N′ A B}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (occ : occurs zero A ≡ true) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Value V →
+  (∀ {ρ′ν γ′ν} →
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν →
+    LeftStoreRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      ρν ρ′ν →
+    LeftCtxRenameⁱ
+      (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ)
+      γν γ′ν →
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ)
+      ∣ suc Δᴸ′ ∣ Δᴿ ∣ ρ′ν ∣ γ′ν
+      ⊢ᴺ renameᵗᵐ (extᵗ τ) V ⊑ N′
+      ⦂ renameᵗ (extᵗ τ) A ⊑ B
+      ∶ ⊑-rename-leftᵢ
+        (extᵗ τ) (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) p) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (Λ V) ⊑ N′
+    ⦂ renameᵗ τ (`∀ A) ⊑ B
+    ∶ ⊑-rename-leftᵢ τ assm hτ (ν occ p)
+left-rename-Λ⊑ᵀ renameρ renameγ occ liftρ liftγ vV body-map
+    with left-store-rename-ν renameρ liftρ
+left-rename-Λ⊑ᵀ renameρ renameγ occ liftρ liftγ vV body-map
+    | ρ′ν , liftρ′ , renameρν
+    with left-ctx-rename-ν renameγ liftγ
+left-rename-Λ⊑ᵀ {τ = τ} {A = A}
+    renameρ renameγ occ liftρ liftγ vV body-map
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  Λ⊑ᵀ (trans (occurs-zero-rename-ext τ A) occ)
+    liftρ′ liftγ′ (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
+    (body-map liftρ′ liftγ′ renameρν renameγν)
+
+left-rename-νᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {A A′ B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  WfTy Δᴸ A →
+  WfTy Δᴿ A′ →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
+  (A⇑⊑A′⇑ : ∀ᵢᶜ Φ
+    ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ q) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ ν A′ N′ s′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-νᵀ
+    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+    liftρ liftγ N⊑N′
+    with left-store-rename-∀ renameρ liftρ
+left-rename-νᵀ
+    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    with left-ctx-rename-∀ renameγ liftγ
+left-rename-νᵀ {τ = τ} {assm = assm} {hτ = hτ} {A = A}
+    ins renameρ renameγ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ν⊑νᵀ
+    (renameᵗ-preserves-WfTy hA hτ) hA′
+    (left-reveal-ν-renameⁱ ins renameρ s↑)
+    (right-reveal-ν-left-renameⁱ renameρ s′↑)
+    (⊑-rename-leftᵢ τ assm hτ A⊑A′)
+    (⊑-rename-left-atᵢ
+      (extᵗ τ) (rename-assm²-∀-leftᵢ assm)
+      (TyRenameWf-ext hτ)
+      (sym (renameᵗ-ext-suc-comm τ A)) A⇑⊑A′⇑)
+    liftρ′ liftγ′ N⊑N′
+
+left-rename-ν⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {A B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  WfTy Δᴸ A →
+  WfTy (suc Δᴸ) (⇑ᵗ A) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν A N s) ⊑ N′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-ν⊑ᵀ
+    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
+    with left-store-rename-ν renameρ liftρ
+left-rename-ν⊑ᵀ
+    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    with left-ctx-rename-ν renameγ liftγ
+left-rename-ν⊑ᵀ {Δᴸ′ = Δᴸ′} {τ = τ} {hτ = hτ} {A = A}
+    ins renameρ renameγ hA h⇑A s↑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  ν⊑ᵀ (renameᵗ-preserves-WfTy hA hτ) h⇑A′
+    (left-reveal-ν-renameⁱ ins renameρ s↑)
+    liftρ′ liftγ′ N⊑N′
+  where
+  h⇑A′ : WfTy (suc Δᴸ′) (⇑ᵗ (renameᵗ τ A))
+  h⇑A′ =
+    subst (WfTy (suc Δᴸ′))
+      (renameᵗ-ext-suc-comm τ A)
+      (renameᵗ-preserves-WfTy h⇑A (TyRenameWf-ext hτ))
+
+left-rename-⊑νᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {A B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  WfTy Δᴿ A →
+  WfTy (suc Δᴿ) (⇑ᵗ A) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ B ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ ν A N′ s
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-⊑νᵀ
+    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-rename-⊑νᵀ
+    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    with left-ctx-rename-⇑ᴿ renameγ liftγ
+left-rename-⊑νᵀ {τ = τ} {assm = assm} {hτ = hτ}
+    renameρ renameγ hA h⇑A s↑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ⊑νᵀ hA h⇑A
+    (right-reveal-ν-left-renameⁱ renameρ s↑)
+    liftρ′ liftγ′
+    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ B⊑C′)
+    N⊑N′
+
+left-rename-νcastᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {B B′ C C′ N N′ s s′ μ μ′}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  (mode′ : CastMode μ′) →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ (∀ⁱ q) →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ ν ★ N′ s′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-νcastᵀ
+    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
+    liftρ liftγ N⊑N′
+    with left-store-rename-∀ renameρ liftρ
+left-rename-νcastᵀ
+    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    with left-ctx-rename-∀ renameγ liftγ
+left-rename-νcastᵀ
+    ins renameρ renameγ mode seal★ mode′ seal★′ s⊑ s′⊑
+    liftρ liftγ N⊑N′
+    | ρ′∀ , liftρ′ , renameρ∀
+    | γ′∀ , liftγ′ , renameγ∀ =
+  νcast⊑νcastᵀ
+    (CastModeRenamer.target-mode
+      (left-insertion-cast-renamer ins) mode)
+    (left-seal★-ν★-renameⁱ ins renameρ mode seal★)
+    mode′ (right-seal★-ν★-left-renameⁱ renameρ seal★′)
+    (left-widening-ν★-renameⁱ ins renameρ mode s⊑)
+    (right-widening-ν★-left-renameⁱ renameρ s′⊑)
+    liftρ′ liftγ′ N⊑N′
+
+left-rename-νcast⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {B B′ C N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ (`∀ C) ⊑ B′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (ν ★ N s) ⊑ N′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-νcast⊑ᵀ
+    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
+    with left-store-rename-ν renameρ liftρ
+left-rename-νcast⊑ᵀ
+    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    with left-ctx-rename-ν renameγ liftγ
+left-rename-νcast⊑ᵀ
+    ins renameρ renameγ mode seal★ s⊑ liftρ liftγ N⊑N′
+    | ρ′ν , liftρ′ , renameρν
+    | γ′ν , liftγ′ , renameγν =
+  νcast⊑ᵀ
+    (CastModeRenamer.target-mode
+      (left-insertion-cast-renamer ins) mode)
+    (left-seal★-ν★-renameⁱ ins renameρ mode seal★)
+    (left-widening-ν★-renameⁱ ins renameρ mode s⊑)
+    liftρ′ liftγ′ N⊑N′
+
+left-rename-⊑νcastᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {B B′ C′ N N′ s μ}
+    {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  LeftCtxRenameⁱ τ assm hτ γ γ′ →
+  (mode : CastMode μ) →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ N′
+    ⦂ renameᵗ τ B ⊑ `∀ C′
+    ∶ ⊑-rename-leftᵢ τ assm hτ q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ N ⊑ ν ★ N′ s
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-⊑νcastᵀ
+    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
+    with left-store-rename-⇑ᴿ renameρ liftρ
+left-rename-⊑νcastᵀ
+    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    with left-ctx-rename-⇑ᴿ renameγ liftγ
+left-rename-⊑νcastᵀ {τ = τ} {assm = assm} {hτ = hτ}
+    renameρ renameγ mode seal★ s⊑ liftρ liftγ B⊑C′ N⊑N′
+    | ρ′ᴿ , liftρ′ , renameρᴿ
+    | γ′ᴿ , liftγ′ , renameγᴿ =
+  ⊑νcastᵀ mode
+    (right-seal★-ν★-left-renameⁱ renameρ seal★)
+    (right-widening-ν★-left-renameⁱ renameρ s⊑)
+    liftρ′ liftγ′
+    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ B⊑C′)
+    N⊑N′
+
+leftCtxⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  leftCtxⁱ
+      (rename-left-ctxⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ γ)
+    ≡ map (renameᵗ τ) (leftCtxⁱ γ)
+leftCtxⁱ-rename-left [] = refl
+leftCtxⁱ-rename-left (ctx-imp A B p ∷ γ) =
+  cong (renameᵗ _ A ∷_) (leftCtxⁱ-rename-left γ)
+
+rightCtxⁱ-rename-left :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    (γ : CtxImp Φ Δᴸ Δᴿ) →
+  rightCtxⁱ
+      (rename-left-ctxⁱ {Ψ = Ψ} {Δᴸ′ = Δᴸ′} τ assm hτ γ)
+    ≡ rightCtxⁱ γ
+rightCtxⁱ-rename-left [] = refl
+rightCtxⁱ-rename-left (ctx-imp A B p ∷ γ) =
+  cong (B ∷_) (rightCtxⁱ-rename-left γ)
+
+rename-left-ctx-∋ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {γ x A B p} →
+  γ ∋ x ⦂ ctx-imp A B p →
+  rename-left-ctxⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ γ
+    ∋ x ⦂ ctx-imp (renameᵗ τ A) B
+      (⊑-rename-leftᵢ τ assm hτ p)
+rename-left-ctx-∋ Z = Z
+rename-left-ctx-∋ (S x∈) = S (rename-left-ctx-∋ x∈)
+
+rename-left-store-matched∈ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
+  store-matched α A β B p ∈ ρ →
+  store-matched (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p)
+    ∈ rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ ρ
+rename-left-store-matched∈ (here refl) = here refl
+rename-left-store-matched∈
+    {ρ = store-matched α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+rename-left-store-matched∈
+    {ρ = store-left α A hA ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+rename-left-store-matched∈
+    {ρ = store-right β B hB ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+rename-left-store-matched∈
+    {ρ = store-link α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-matched∈ p∈)
+
+rename-left-store-link∈ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
+  store-link α A β B p ∈ ρ →
+  store-link (τ α) (renameᵗ τ A) β B
+      (⊑-rename-leftᵢ τ assm hτ p)
+    ∈ rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ ρ
+rename-left-store-link∈ (here refl) = here refl
+rename-left-store-link∈
+    {ρ = store-matched α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+rename-left-store-link∈
+    {ρ = store-left α A hA ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+rename-left-store-link∈
+    {ρ = store-right β B hB ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+rename-left-store-link∈
+    {ρ = store-link α A β B p ∷ ρ} (there p∈) =
+  there (rename-left-store-link∈ p∈)
+
+rename-left-correspondence :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ} {τ : Renameᵗ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ} {ρ α A β B p} →
+  StoreCorresponds ρ α A β B p →
+  StoreCorresponds
+    (rename-left-storeⁱ {Φ = Φ} {Ψ = Ψ}
+      {Δᴸ = Δᴸ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+      τ assm hτ ρ)
+    (τ α) (renameᵗ τ A) β B
+    (⊑-rename-leftᵢ τ assm hτ p)
+rename-left-correspondence (correspondence-stored p∈) =
+  correspondence-stored (rename-left-store-matched∈ p∈)
+rename-left-correspondence (correspondence-linked p∈) =
+  correspondence-linked (rename-left-store-link∈ p∈)
+
+left-store-rename-matched∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {α A β B p} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  store-matched α A β B p ∈ ρ →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+    store-matched α′ A′ β B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∈ ρ′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-matched eqα eqA renameρ) (here refl) =
+  _ , eqα , _ , eqA , here refl
+left-store-rename-matched∈ⁱ
+    (left-store-rename-matched eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-left eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-right renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-matched∈ⁱ
+    (left-store-rename-link eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+
+left-store-rename-link∈ⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {α A β B p} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  store-link α A β B p ∈ ρ →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+    store-link α′ A′ β B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p) ∈ ρ′
+left-store-rename-link∈ⁱ
+    (left-store-rename-matched eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-link∈ⁱ
+    (left-store-rename-left eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-link∈ⁱ
+    (left-store-rename-right renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+left-store-rename-link∈ⁱ
+    (left-store-rename-link eqα eqA renameρ) (here refl) =
+  _ , eqα , _ , eqA , here refl
+left-store-rename-link∈ⁱ
+    (left-store-rename-link eqα eqA renameρ) (there p∈) =
+  let α′ , eqα′ , A′ , eqA′ , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα′ , A′ , eqA′ , there p∈′
+
+left-store-rename-correspondenceⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {α A β B p} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  StoreCorresponds ρ α A β B p →
+  ∃[ α′ ] α′ ≡ τ α × ∃[ A′ ] ∃[ eqA ]
+    StoreCorresponds ρ′ α′ A′ β B
+      (⊑-rename-left-atᵢ τ assm hτ eqA p)
+left-store-rename-correspondenceⁱ renameρ
+    (correspondence-stored p∈) =
+  let α′ , eqα , A′ , eqA , p∈′ =
+        left-store-rename-matched∈ⁱ renameρ p∈ in
+  α′ , eqα , A′ , eqA , correspondence-stored p∈′
+left-store-rename-correspondenceⁱ renameρ
+    (correspondence-linked p∈) =
+  let α′ , eqα , A′ , eqA , p∈′ =
+        left-store-rename-link∈ⁱ renameρ p∈ in
+  α′ , eqα , A′ , eqA , correspondence-linked p∈′
+
+left-paired-conversion-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {c c′ A A′ B B′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  PairedConversion Φ Δᴸ Δᴿ ρ c c′ p q →
+  PairedConversion Ψ Δᴸ′ Δᴿ ρ′
+    (renameᶜ τ c) c′
+    (⊑-rename-leftᵢ τ assm hτ p)
+    (⊑-rename-leftᵢ τ assm hτ q)
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-reveal corr conv conv′)
+    with left-store-rename-correspondenceⁱ renameρ corr
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-reveal corr conv conv′)
+    | α′ , refl , A′ , refl , corr′ =
+  paired-reveal corr′
+    (left-reveal-renameⁱ ins renameρ conv)
+    (right-reveal-left-renameⁱ renameρ conv′)
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-conceal corr conv conv′)
+    with left-store-rename-correspondenceⁱ renameρ corr
+left-paired-conversion-renameⁱ ins renameρ
+    (paired-conceal corr conv conv′)
+    | α′ , refl , A′ , refl , corr′ =
+  paired-conceal corr′
+    (left-conceal-renameⁱ ins renameρ conv)
+    (right-conceal-left-renameⁱ renameρ conv′)
+
+left-paired-cast-renameⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {c c′ A A′ B B′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+  PairedCast Ψ Δᴸ′ Δᴿ ρ′
+    (renameᶜ τ c) c′
+    (⊑-rename-leftᵢ τ assm hτ p)
+    (⊑-rename-leftᵢ τ assm hτ q)
+left-paired-cast-renameⁱ ins renameρ
+    (paired-conversion conv) =
+  paired-conversion (left-paired-conversion-renameⁱ ins renameρ conv)
+left-paired-cast-renameⁱ ins renameρ
+    (paired-widening mode seal★ c⊑ mode′ seal★′ c′⊑) =
+  paired-widening
+    (CastModeRenamer.target-mode modeτ mode)
+    (left-seal★-renameⁱ modeτ renameρ mode seal★)
+    (left-widening-renameⁱ modeτ mode renameρ c⊑)
+    mode′
+    (right-seal★-left-renameⁱ renameρ seal★′)
+    (right-widening-left-renameⁱ renameρ c′⊑)
+  where
+  modeτ = left-insertion-cast-renamer ins
+
+left-rename-conv⊑convᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ c c′ A A′ B B′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-conv⊑convᵀ ins renameρ cast M⊑M′ =
+  conv⊑convᵀ (left-paired-cast-renameⁱ ins renameρ cast) M⊑M′
+
+left-rename-conv↑⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ α X}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-conv↑⊑ᵀ ins renameρ conv M⊑M′ =
+  conv↑⊑ᵀ (left-reveal-renameⁱ ins renameρ conv) M⊑M′ _
+
+left-rename-conv↓⊑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B B′ c μ α X}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  (ins : LeftInsertion τ) →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ (M ⟨ c ⟩) ⊑ M′
+    ⦂ renameᵗ τ B ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-conv↓⊑ᵀ ins renameρ conv M⊑M′ =
+  conv↓⊑ᵀ (left-conceal-renameⁱ ins renameρ conv) M⊑M′ _
+
+left-rename-⊑conv↑ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′ β X′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑conv↑ᵀ renameρ conv M⊑M′ =
+  ⊑conv↑ᵀ (right-reveal-left-renameⁱ renameρ conv) M⊑M′ _
+
+left-rename-⊑conv↓ᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A A′ B′ c′ μ′ β X′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ} →
+  LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+  ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ A′ ∶ ⊑-rename-leftᵢ τ assm hτ p →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′ ⟨ c′ ⟩
+    ⦂ renameᵗ τ A ⊑ B′ ∶ ⊑-rename-leftᵢ τ assm hτ q
+left-rename-⊑conv↓ᵀ renameρ conv M⊑M′ =
+  ⊑conv↓ᵀ (right-conceal-left-renameⁱ renameρ conv) M⊑M′ _
+
+lift-ctx-result :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γ′ ] LiftCtxⁱ (∀ᵢᶜ Φ) γ γ′
+lift-ctx-result [] = [] , lift-ctx-[]
+lift-ctx-result (ctx-imp A B p ∷ γ) with lift-ctx-result γ
+lift-ctx-result (ctx-imp A B p ∷ γ) | γ′ , liftγ =
+  ctx-imp (⇑ᵗ A) (⇑ᵗ B) (⊑-lift∀ᵢ p) ∷ γ′ ,
+  lift-ctx-∷ liftγ
+
+lift-left-ctx-result :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γ′ ] LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
+lift-left-ctx-result [] = [] , lift-left-ctx-[]
+lift-left-ctx-result (ctx-imp A B p ∷ γ)
+    with lift-left-ctx-result γ
+lift-left-ctx-result (ctx-imp A B p ∷ γ) | γ′ , liftγ =
+  ctx-imp (⇑ᵗ A) B (⊑-source-liftνᵢ p) ∷ γ′ ,
+  lift-left-ctx-∷ liftγ
+
+left-forall-store-square :
+  ∀ {Φ Δᴸ Δᴿ} (ρ : StoreImp Φ Δᴸ Δᴿ) →
+  ∃[ ρν ] ∃[ ρ∀ ] ∃[ ρν∀ ] ∃[ ρ∀ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν ×
+    LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ ×
+    LiftStoreⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρν ρν∀ ×
+    LiftLeftStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (∀ᵢᶜ Φ)) ρ∀ ρ∀ν ×
+    leftStoreⁱ ρν∀ ≡ leftStoreⁱ ρ∀ν ×
+    rightStoreⁱ ρν∀ ≡ rightStoreⁱ ρ∀ν
+left-forall-store-square ρ with lift-left-store-result ρ
+left-forall-store-square ρ | ρν , liftν
+    with lift-store-result ρ
+left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
+    with lift-store-result ρν
+left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
+    | ρν∀ , liftν∀ with lift-left-store-result ρ∀
+left-forall-store-square ρ | ρν , liftν | ρ∀ , lift∀
+    | ρν∀ , liftν∀ | ρ∀ν , lift∀ν =
+  ρν , ρ∀ , ρν∀ , ρ∀ν ,
+  liftν , lift∀ , liftν∀ , lift∀ν ,
+  trans
+    (leftStoreⁱ-lift liftν∀)
+    (trans
+      (cong ⟰ᵗ (leftStoreⁱ-lift-left liftν))
+      (sym
+        (trans
+          (leftStoreⁱ-lift-left lift∀ν)
+          (cong ⟰ᵗ (leftStoreⁱ-lift lift∀))))) ,
+  trans
+    (rightStoreⁱ-lift liftν∀)
+    (trans
+      (cong ⟰ᵗ (rightStoreⁱ-lift-left liftν))
+      (sym
+        (trans
+          (rightStoreⁱ-lift-left lift∀ν)
+          (rightStoreⁱ-lift lift∀))))
+
+left-forall-ctx-square :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γν ] ∃[ γ∀ ] ∃[ γν∀ ] ∃[ γ∀ν ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν ×
+    LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ ×
+    LiftCtxⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γν γν∀ ×
+    LiftLeftCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (∀ᵢᶜ Φ)) γ∀ γ∀ν ×
+    leftCtxⁱ γν∀ ≡ leftCtxⁱ γ∀ν ×
+    rightCtxⁱ γν∀ ≡ rightCtxⁱ γ∀ν
+left-forall-ctx-square γ with lift-left-ctx-result γ
+left-forall-ctx-square γ | γν , liftν with lift-ctx-result γ
+left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
+    with lift-ctx-result γν
+left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
+    | γν∀ , liftν∀ with lift-left-ctx-result γ∀
+left-forall-ctx-square γ | γν , liftν | γ∀ , lift∀
+    | γν∀ , liftν∀ | γ∀ν , lift∀ν =
+  γν , γ∀ , γν∀ , γ∀ν ,
+  liftν , lift∀ , liftν∀ , lift∀ν ,
+  trans
+    (leftCtxⁱ-lift liftν∀)
+    (trans
+      (cong ⤊ᵗ (leftCtxⁱ-lift-left liftν))
+      (sym
+        (trans
+          (leftCtxⁱ-lift-left lift∀ν)
+          (cong ⤊ᵗ (leftCtxⁱ-lift lift∀))))) ,
+  trans
+    (rightCtxⁱ-lift liftν∀)
+    (trans
+      (cong ⤊ᵗ (rightCtxⁱ-lift-left liftν))
+      (sym
+        (trans
+          (rightCtxⁱ-lift-left lift∀ν)
+          (rightCtxⁱ-lift lift∀))))
+
+left-source-lift-Λᵀ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρν∀ : StoreImp (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) (suc Δᴿ)}
+    {γν∀ : CtxImp (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) (suc Δᴿ)}
+    {V V′ A B q} →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  LiftStoreⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρν ρν∀ →
+  LiftCtxⁱ (∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γν γν∀ →
+  Value V →
+  Value V′ →
+  ∀ᵢᶜ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc (suc Δᴸ) ∣ suc Δᴿ ∣ ρν∀ ∣ γν∀
+    ⊢ᴺ renameᵗᵐ (extᵗ suc) V ⊑ V′
+    ⦂ renameᵗ (extᵗ suc) A ⊑ B ∶ q →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρν ∣ γν
+    ⊢ᴺ ⇑ᵗᵐ (Λ V) ⊑ Λ V′
+    ⦂ ⇑ᵗ (`∀ A) ⊑ `∀ B ∶ ∀ⁱ q
+left-source-lift-Λᵀ
+    liftνρ liftνγ liftν∀ρ liftν∀γ vV vV′ V⊑V′ =
+  Λ⊑Λᵀ liftν∀ρ liftν∀γ
+    (renameᵗᵐ-preserves-Value (extᵗ suc) vV) vV′ V⊑V′
+
+left-source-lift-⊑αᵀ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {N L′ A B C′ q} →
+  Value L′ →
+  No• L′ →
+  (h⇑A : WfTy (suc Δᴿ) (⇑ᵗ A)) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣ ρᴸ ∣ γᴸ
+    ⊢ᴺ ⇑ᵗᵐ N ⊑ L′
+    ⦂ ⇑ᵗ B ⊑ `∀ C′ ∶ ⊑-source-liftνᵢ q →
+  (r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  suc Δᴿ ∣
+    rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ) ∣
+    rightCtxⁱ γᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′ →
+  ∃[ ρ× ] ∃[ γ× ]
+    LiftRightStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴸ ρ× ×
+    LiftLeftStoreⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) ρᴿ ρ× ×
+    LiftRightCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴸ γ× ×
+    LiftLeftCtxⁱ
+      (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)) γᴿ γ× ×
+    (⇑ᴿᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      ∣ suc Δᴸ ∣ suc Δᴿ ∣
+      store-right zero (⇑ᵗ A) h⇑A ∷ ρ× ∣ γ×
+      ⊢ᴺ ⇑ᵗᵐ N ⊑ (⇑ᵗᵐ L′) •
+      ⦂ ⇑ᵗ B ⊑ C′ ∶ ⊑-source-under-rightᵢ r
+left-source-lift-⊑αᵀ
+    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    N⊑L′ r L′•⊢
+    with left-right-store-commuteⁱ liftᴸρ liftᴿρ
+left-source-lift-⊑αᵀ
+    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    N⊑L′ r L′•⊢
+    | ρ× , rightᴸρ , leftᴿρ
+    with left-right-ctx-commuteⁱ liftᴸγ liftᴿγ
+left-source-lift-⊑αᵀ
+    vL′ noL′ h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    N⊑L′ r L′•⊢
+    | ρ× , rightᴸρ , leftᴿρ
+    | γ× , rightᴸγ , leftᴿγ =
+  ρ× , γ× , rightᴸρ , leftᴿρ , rightᴸγ , leftᴿγ ,
+  ⊑αᵀ vL′ noL′ h⇑A rightᴸρ rightᴸγ N⊑L′
+    (⊑-source-under-rightᵢ r) source-typing target-typing
+  where
+  source-typing =
+    subst
+      (λ Γ → _ ∣ leftStoreⁱ ρ× ∣ Γ ⊢ _ ⦂ _)
+      (sym (leftCtxⁱ-lift-right rightᴸγ))
+      (subst
+        (λ Σ → _ ∣ Σ ∣ leftCtxⁱ _ ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right rightᴸρ))
+        (nu-term-imprecision-source-typing N⊑L′))
+
+  target-typing =
+    subst
+      (λ Γ → _ ∣
+        rightStoreⁱ (store-right zero _ h⇑A ∷ ρ×) ∣ Γ
+        ⊢ _ ⦂ _)
+      (sym (rightCtxⁱ-lift-left leftᴿγ))
+      (subst
+        (λ Σ → _ ∣ (zero , _) ∷ Σ ∣ rightCtxⁱ _
+          ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left leftᴿρ)) L′•⊢)
+
+right-target-square-α⊑ᵀ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {ρ× : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      (suc Δᴸ) (suc Δᴿ)}
+    {L N′ A B′ C}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ}
+    {occ : occurs zero C ≡ true} →
+  Value L →
+  No• L →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  LiftRightStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴸ ρ× →
+  LiftLeftStoreⁱ
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴿ ρ× →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρᴿ ∣ []
+    ⊢ᴺ L ⊑ ⇑ᵗᵐ N′
+    ⦂ `∀ C ⊑ ⇑ᵗ B′ ∶ ν occ (⊑-target-under-leftᵢ p) →
+  suc Δᴸ ∣
+    leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρᴸ) ∣ []
+    ⊢ (⇑ᵗᵐ L) • ⦂ C →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣
+    store-left zero (⇑ᵗ A) h⇑A ∷ ρ× ∣ []
+    ⊢ᴺ (⇑ᵗᵐ L) • ⊑ ⇑ᵗᵐ N′
+    ⦂ C ⊑ ⇑ᵗ B′ ∶ ⊑-target-under-leftᵢ p
+right-target-square-α⊑ᵀ
+    vL noL h⇑A rightᴸρ leftᴿρ L⊑N′ L•⊢ =
+  α⊑ᵀ vL noL h⇑A leftᴿρ lift-left-ctx-[] L⊑N′
+    source-typing target-typing
+  where
+  source-typing =
+    subst
+      (λ Σ → _ ∣ (zero , _) ∷ Σ ∣ [] ⊢ _ ⦂ _)
+      (sym (leftStoreⁱ-lift-right rightᴸρ)) L•⊢
+
+  target-typing =
+    subst
+      (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+      (sym (rightStoreⁱ-lift-left leftᴿρ))
+      (nu-term-imprecision-target-typing L⊑N′)
+
+right-target-lift-α⊑ᵀ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴸ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴸ : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {L N′ A B′ C}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ}
+    {occ : occurs zero C ≡ true} →
+  Value L →
+  No• L →
+  (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρᴸ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γᴸ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ∣ suc Δᴿ ∣ ρᴿ ∣ γᴿ
+    ⊢ᴺ L ⊑ ⇑ᵗᵐ N′
+    ⦂ `∀ C ⊑ ⇑ᵗ B′ ∶ ν occ (⊑-target-under-leftᵢ p) →
+  suc Δᴸ ∣
+    leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρᴸ) ∣
+    leftCtxⁱ γᴸ ⊢ (⇑ᵗᵐ L) • ⦂ C →
+  ∃[ ρ× ] ∃[ γ× ]
+    LiftRightStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴸ ρ× ×
+    LiftLeftStoreⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) ρᴿ ρ× ×
+    LiftRightCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) γᴸ γ× ×
+    LiftLeftCtxⁱ
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ)) γᴿ γ× ×
+    ((zero ˣ⊑★) ∷ ⇑ᴸᵢ (⇑ᴿᵢ Φ))
+      ∣ suc Δᴸ ∣ suc Δᴿ ∣
+      store-left zero (⇑ᵗ A) h⇑A ∷ ρ× ∣ γ×
+      ⊢ᴺ (⇑ᵗᵐ L) • ⊑ ⇑ᵗᵐ N′
+      ⦂ C ⊑ ⇑ᵗ B′ ∶ ⊑-target-under-leftᵢ p
+right-target-lift-α⊑ᵀ
+    vL noL h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    L⊑N′ L•⊢
+    with left-right-store-commute-left-lastⁱ liftᴸρ liftᴿρ
+right-target-lift-α⊑ᵀ
+    vL noL h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    L⊑N′ L•⊢
+    | ρ× , rightᴸρ , leftᴿρ
+    with left-right-ctx-commute-left-lastⁱ liftᴸγ liftᴿγ
+right-target-lift-α⊑ᵀ
+    vL noL h⇑A liftᴸρ liftᴸγ liftᴿρ liftᴿγ
+    L⊑N′ L•⊢
+    | ρ× , rightᴸρ , leftᴿρ
+    | γ× , rightᴸγ , leftᴿγ =
+  ρ× , γ× , rightᴸρ , leftᴿρ , rightᴸγ , leftᴿγ ,
+  α⊑ᵀ vL noL h⇑A leftᴿρ leftᴿγ L⊑N′
+    source-typing target-typing
+  where
+  source-typing =
+    subst
+      (λ Γ → _ ∣
+        leftStoreⁱ (store-left zero _ h⇑A ∷ ρ×) ∣ Γ
+        ⊢ _ ⦂ _)
+      (sym (leftCtxⁱ-lift-right rightᴸγ))
+      (subst
+        (λ Σ → _ ∣ (zero , _) ∷ Σ ∣ leftCtxⁱ _
+          ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-right rightᴸρ)) L•⊢)
+
+  target-typing =
+    subst
+      (λ Γ → _ ∣ rightStoreⁱ ρ× ∣ Γ ⊢ _ ⦂ _)
+      (sym (rightCtxⁱ-lift-left leftᴿγ))
+      (subst
+        (λ Σ → _ ∣ Σ ∣ rightCtxⁱ _ ⊢ _ ⦂ _)
+        (sym (rightStoreⁱ-lift-left leftᴿρ))
+        (nu-term-imprecision-target-typing L⊑N′))
+
+left-rename-⊑αᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {ρ′ᴿ : StoreImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γᴿ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {γ′ᴿ : CtxImp (⇑ᴿᵢ Ψ) Δᴸ′ (suc Δᴿ)}
+    {N L′ A B C′}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ `∀ C′ ⊣ Δᴿ}
+    {r : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ}
+    {h⇑A h⇑A′ : WfTy (suc Δᴿ) (⇑ᵗ A)} →
+  LeftStoreRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ
+    (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ)
+    (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ) →
+  LeftCtxRenameⁱ τ (rename-assm²-⇑ᴿᵢ assm) hτ γᴿ γ′ᴿ →
+  Value L′ →
+  No• L′ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ ρᴿ →
+  LiftRightCtxⁱ (⇑ᴿᵢ Φ) γ γᴿ →
+  (∀ {ρ′ γ′} →
+    LeftStoreRenameⁱ τ assm hτ ρ ρ′ →
+    LeftCtxRenameⁱ τ assm hτ γ γ′ →
+    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ N ⊑ L′
+      ⦂ renameᵗ τ B ⊑ `∀ C′
+      ∶ ⊑-rename-leftᵢ τ assm hτ q) →
+  suc Δᴿ
+    ∣ rightStoreⁱ (store-right zero (⇑ᵗ A) h⇑A ∷ ρᴿ)
+    ∣ rightCtxⁱ γᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′ →
+  (⇑ᴿᵢ Ψ) ∣ Δᴸ′ ∣ suc Δᴿ ∣
+    store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ ∣ γ′ᴿ
+    ⊢ᴺ renameᵗᵐ τ N ⊑ (⇑ᵗᵐ L′) •
+    ⦂ renameᵗ τ B ⊑ C′
+    ∶ ⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ r
+left-rename-⊑αᵀ
+    {Ψ = Ψ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρᴿ = ρᴿ} {ρ′ᴿ = ρ′ᴿ} {γᴿ = γᴿ} {γ′ᴿ = γ′ᴿ}
+    {N = N} {L′ = L′} {A = A} {B = B} {C′ = C′}
+    {q = q} {r = r} {h⇑A = h⇑A} {h⇑A′ = h⇑A′}
+    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
+    liftρ liftγ body-map L′•⊢
+    with left-store-rename-⇑ᴿ-inv liftρ renameρᴿ
+left-rename-⊑αᵀ
+    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
+    liftρ liftγ body-map L′•⊢
+    | ρ′ , renameρ′ , liftρ′
+    with left-ctx-rename-⇑ᴿ-inv liftγ renameγᴿ
+left-rename-⊑αᵀ
+    {Ψ = Ψ} {Δᴸ′ = Δᴸ′} {Δᴿ = Δᴿ}
+    {τ = τ} {assm = assm} {hτ = hτ}
+    {ρᴿ = ρᴿ} {ρ′ᴿ = ρ′ᴿ} {γᴿ = γᴿ} {γ′ᴿ = γ′ᴿ}
+    {N = N} {L′ = L′} {A = A} {B = B} {C′ = C′}
+    {q = q} {r = r} {h⇑A = h⇑A} {h⇑A′ = h⇑A′}
+    (left-store-rename-right renameρᴿ) renameγᴿ vL′ noL′
+    liftρ liftγ body-map L′•⊢
+    | ρ′ , renameρ′ , liftρ′
+    | γ′ , renameγ′ , liftγ′ =
+  ⊑αᵀ vL′ noL′ h⇑A′ liftρ′ liftγ′ N⊑L′
+    (⊑-rename-leftᵢ τ (rename-assm²-⇑ᴿᵢ assm) hτ r)
+    source-typing target-typing
+  where
+  N⊑L′ :
+    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ N ⊑ L′
+      ⦂ renameᵗ τ B ⊑ `∀ C′
+      ∶ ⊑-rename-leftᵢ τ assm hτ q
+  N⊑L′ = body-map renameρ′ renameγ′
+
+  source-typing :
+    Δᴸ′ ∣ leftStoreⁱ ρ′ᴿ ∣ leftCtxⁱ γ′ᴿ
+      ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B
+  source-typing =
+    subst
+      (λ Γ → Δᴸ′ ∣ leftStoreⁱ ρ′ᴿ ∣ Γ
+        ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B)
+      (sym (leftCtxⁱ-lift-right liftγ′))
+      (subst
+        (λ Σ → Δᴸ′ ∣ Σ ∣ leftCtxⁱ γ′
+          ⊢ renameᵗᵐ τ N ⦂ renameᵗ τ B)
+        (sym (leftStoreⁱ-lift-right liftρ′))
+        (nu-term-imprecision-source-typing N⊑L′))
+
+  target-typing :
+    suc Δᴿ
+      ∣ rightStoreⁱ
+          (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ)
+      ∣ rightCtxⁱ γ′ᴿ ⊢ (⇑ᵗᵐ L′) • ⦂ C′
+  target-typing =
+    subst
+      (λ Γ → suc Δᴿ
+        ∣ rightStoreⁱ
+            (store-right zero (⇑ᵗ A) h⇑A′ ∷ ρ′ᴿ)
+        ∣ Γ ⊢ (⇑ᵗᵐ L′) • ⦂ C′)
+      (sym (rightCtxⁱ-left-rename renameγᴿ))
+      (subst
+        (λ Σ → suc Δᴿ ∣ Σ ∣ rightCtxⁱ γᴿ
+          ⊢ (⇑ᵗᵐ L′) • ⦂ C′)
+        (sym
+          (rightStoreⁱ-left-rename
+            (left-store-rename-right
+              {hB = h⇑A} {hB′ = h⇑A′} renameρᴿ)))
+        L′•⊢)
+
+left-source-lift-allocation-leftᵀ :
+  ∀ {Φ Δᴸ Δᴿ α α′ A A′ B B′ M M′}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {ρν′ : StoreImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γν′ : CtxImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+      (suc (suc Δᴸ)) Δᴿ}
+    {hA : WfTy (suc Δᴸ) A}
+    {hA′ : WfTy (suc (suc Δᴸ)) A′}
+    {p : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      ∣ suc Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  No• M →
+  LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc
+    (store-left α A hA ∷ ρν)
+    (store-left α′ A′ hA′ ∷ ρν′) →
+  LeftCtxRenameⁱ suc rename-assm²-source-νᵢ
+    TyRenameWf-suc γν γν′ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+    ∣ suc (suc Δᴸ) ∣ Δᴿ ∣ ρν′ ∣ γν′
+    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc p →
+  suc Δᴸ ∣ leftStoreⁱ (store-left α A hA ∷ ρν)
+    ∣ leftCtxⁱ γν ⊢ M ⦂ B →
+  Δᴿ ∣ rightStoreⁱ (store-left α A hA ∷ ρν)
+    ∣ rightCtxⁱ γν ⊢ M′ ⦂ B′ →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ))
+    ∣ suc (suc Δᴸ) ∣ Δᴿ ∣
+    store-left α′ A′ hA′ ∷ ρν′ ∣ γν′
+    ⊢ᴺ ⇑ᵗᵐ M ⊑ M′ ⦂ ⇑ᵗ B ⊑ B′
+    ∶ ⊑-rename-leftᵢ suc rename-assm²-source-νᵢ
+      TyRenameWf-suc p
+left-source-lift-allocation-leftᵀ noM
+    (left-store-rename-left eqα eqA renameρν)
+    renameγν M⊑M′ M⊢ M′⊢ with eqα
+left-source-lift-allocation-leftᵀ noM
+    (left-store-rename-left eqα eqA renameρν)
+    renameγν M⊑M′ M⊢ M′⊢ | refl with eqA
+left-source-lift-allocation-leftᵀ
+    {α = α} {A = A} {ρν = ρν} {ρν′ = ρν′}
+    {hA = hA} {hA′ = hA′} noM
+    (left-store-rename-left eqα eqA renameρν)
+    renameγν M⊑M′ M⊢ M′⊢ | refl | refl =
+  allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ)
+    M⊑M′ source-typing target-typing
+  where
+  full-rename :
+    LeftStoreRenameⁱ suc rename-assm²-source-νᵢ TyRenameWf-suc
+      (store-left α A hA ∷ ρν)
+      (store-left (suc α) (⇑ᵗ A) hA′ ∷ ρν′)
+  full-rename = left-store-rename-left refl refl renameρν
+
+  source-typing =
+    left-typing-renameⁱ {ψ = predᵗ}
+      RenameLeftInverse-suc castModeRenamer-suc
+      full-rename renameγν noM M⊢
+
+  target-typing =
+    right-typing-left-renameⁱ full-rename renameγν M′⊢
+
+left-rename-allocation-prefixᵀ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
+    {assm : ∀ {a} → a ∈ Φ →
+      rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Δᴸ′ τ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Δᴸ′ Δᴿ}
+    {γ′ : CtxImp Ψ Δᴸ′ Δᴿ}
+    {M M′ A B} {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  LeftStoreRenameⁱ τ assm hτ ρ⁺ ρ′⁺ →
+  (∀ {ρ₀′} → LeftStoreRenameⁱ τ assm hτ ρ₀ ρ₀′ →
+    Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ₀′ ∣ γ′
+      ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+      ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p) →
+  Δᴸ′ ∣ leftStoreⁱ ρ′⁺ ∣ leftCtxⁱ γ′
+    ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A →
+  Δᴿ ∣ rightStoreⁱ ρ′⁺ ∣ rightCtxⁱ γ′ ⊢ M′ ⦂ B →
+  Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′⁺ ∣ γ′
+    ⊢ᴺ renameᵗᵐ τ M ⊑ M′
+    ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
+left-rename-allocation-prefixᵀ prefix renameρ body-map M⊢ M′⊢
+    with left-store-rename-prefix-invⁱ prefix renameρ
+left-rename-allocation-prefixᵀ prefix renameρ body-map M⊢ M′⊢
+    | ρ₀′ , renameρ₀ , prefix′ =
+  allocation-prefixᵀ prefix′ (body-map renameρ₀) M⊢ M′⊢
+
+⊑-lift-under-∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ renameᵗ (extᵗ suc) A ⊑ renameᵗ (extᵗ suc) B
+    ⊣ suc (suc Δᴿ)
+⊑-lift-under-∀ᵢ =
+  ⊑-renameᵗ²ᵢ
+    (rename-assm²-⇑ᵢ rename-assm²-∀ᵢ)
+    (TyRenameWf-ext TyRenameWf-suc)
+    (TyRenameWf-ext TyRenameWf-suc)
+
+⊑-target-lift-right-under-∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (⇑ᴿᵢ Φ) ∣ suc Δᴸ
+    ⊢ A ⊑ renameᵗ (extᵗ suc) B ⊣ suc (suc Δᴿ)
+⊑-target-lift-right-under-∀ᵢ {A = A} p =
+  subst
+    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ (extᵗ suc) _ ⊣ _)
+    (renameᵗ-ext-id A)
+    (⊑-renameᵗ²ᵢ
+      (rename-assm²-⇑ᵢ rename-assm²-target-rightᵢ)
+      (TyRenameWf-ext (λ X<Δ → X<Δ))
+      (TyRenameWf-ext TyRenameWf-suc)
+      p)
+
+rename-assm²-paired-under-right-tailᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (extᵗ suc) a ∈ ⇑ᴿᵢ (⇑ᵢ Φ)
+rename-assm²-paired-under-right-tailᵢ {Φ = []} ()
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-paired-under-right-tailᵢ a∈)
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-paired-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-paired-under-right-tailᵢ a∈)
+
+rename-assm²-paired-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ suc (extᵗ suc) a ∈ ⇑ᴿᵢ (∀ᵢᶜ Φ)
+rename-assm²-paired-under-rightᵢ a∈ =
+  there (rename-assm²-paired-under-right-tailᵢ a∈)
+
+⊑-lift-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (∀ᵢᶜ Φ) ∣ suc Δᴸ
+    ⊢ ⇑ᵗ A ⊑ renameᵗ (extᵗ suc) B
+    ⊣ suc (suc Δᴿ)
+⊑-lift-under-rightᵢ =
+  ⊑-renameᵗ²ᵢ
+    rename-assm²-paired-under-rightᵢ
+    TyRenameWf-suc
+    (TyRenameWf-ext TyRenameWf-suc)
+
+rename-assm²-right-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ (λ X → X) (extᵗ suc) a ∈ ⇑ᴿᵢ (⇑ᴿᵢ Φ)
+rename-assm²-right-under-rightᵢ {Φ = []} ()
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-right-under-rightᵢ a∈)
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-right-under-rightᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-right-under-rightᵢ a∈)
+
+⊑-target-lift-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (⇑ᴿᵢ Φ) ∣ Δᴸ
+    ⊢ A ⊑ renameᵗ (extᵗ suc) B
+    ⊣ suc (suc Δᴿ)
+⊑-target-lift-under-rightᵢ {A = A} p =
+  subst
+    (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ (extᵗ suc) _ ⊣ _)
+    (renameᵗ-id A)
+    (⊑-renameᵗ²ᵢ
+      rename-assm²-right-under-rightᵢ
+      (λ X<Δ → X<Δ)
+      (TyRenameWf-ext TyRenameWf-suc)
+      p)
+
+rename-assm²-crossed-under-right-tailᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ
+    (λ X → suc (suc X))
+    (extᵗ (λ X → suc (suc X))) a
+    ∈ ⇑ᴿᵢ (⇑ᵢ (⇑ᵢ Φ))
+rename-assm²-crossed-under-right-tailᵢ {Φ = []} ()
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑★) ∷ Φ} (there a∈) =
+  there (rename-assm²-crossed-under-right-tailᵢ a∈)
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (here refl) =
+  here refl
+rename-assm²-crossed-under-right-tailᵢ
+    {Φ = (X ˣ⊑ˣ Y) ∷ Φ} (there a∈) =
+  there (rename-assm²-crossed-under-right-tailᵢ a∈)
+
+rename-assm²-crossed-under-rightᵢ :
+  ∀ {Φ a} →
+  a ∈ ⇑ᴿᵢ Φ →
+  rename-assm²ᵢ
+    (λ X → suc (suc X))
+    (extᵗ (λ X → suc (suc X))) a
+    ∈ ⇑ᴿᵢ (swapRight∀∀ᵢ Φ)
+rename-assm²-crossed-under-rightᵢ a∈ =
+  there (there (rename-assm²-crossed-under-right-tailᵢ a∈))
+
+renameᵗ-double-lift :
+  ∀ A →
+  ⇑ᵗ (⇑ᵗ A) ≡ renameᵗ (λ X → suc (suc X)) A
+renameᵗ-double-lift A = renameᵗ-compose suc suc A
+
+renameᵗ-double-under-∀ :
+  ∀ A →
+  renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A) ≡
+    renameᵗ (extᵗ (λ X → suc (suc X))) A
+renameᵗ-double-under-∀ A =
+  trans (renameᵗ-compose (extᵗ suc) (extᵗ suc) A)
+    (rename-cong (λ { zero → refl ; (suc X) → refl }) A)
+
+⊑-crossed-double-lift-under-rightᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (swapRight∀∀ᵢ Φ) ∣ suc (suc Δᴸ)
+    ⊢ ⇑ᵗ (⇑ᵗ A)
+      ⊑ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) B)
+    ⊣ suc (suc (suc Δᴿ))
+⊑-crossed-double-lift-under-rightᵢ {A = A} {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢ ⇑ᵗ (⇑ᵗ A) ⊑ T ⊣ _)
+    (sym (renameᵗ-double-under-∀ B))
+    (subst
+      (λ S → _ ∣ _ ⊢ S ⊑
+        renameᵗ (extᵗ (λ X → suc (suc X))) B ⊣ _)
+      (sym (renameᵗ-double-lift A))
+      (⊑-renameᵗ²ᵢ
+        rename-assm²-crossed-under-rightᵢ
+        (λ X<Δ → s<s (s<s X<Δ))
+        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
+        p))
+
+⊑-crossed-double-lift-under-∀ᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ →
+  ∀ᵢᶜ (swapRight∀∀ᵢ Φ) ∣ suc (suc (suc Δᴸ))
+    ⊢ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A)
+      ⊑ renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) B)
+    ⊣ suc (suc (suc Δᴿ))
+⊑-crossed-double-lift-under-∀ᵢ {A = A} {B = B} p =
+  subst
+    (λ T → _ ∣ _ ⊢
+      renameᵗ (extᵗ suc) (renameᵗ (extᵗ suc) A) ⊑ T ⊣ _)
+    (sym (renameᵗ-double-under-∀ B))
+    (subst
+      (λ S → _ ∣ _ ⊢ S ⊑
+        renameᵗ (extᵗ (λ X → suc (suc X))) B ⊣ _)
+      (sym (renameᵗ-double-under-∀ A))
+      (⊑-renameᵗ²ᵢ
+        (rename-assm²-⇑ᵢ rename-assm²-crossed-double∀∀ᵢ)
+        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
+        (TyRenameWf-ext (λ X<Δ → s<s (s<s X<Δ)))
+        p))
+
+⊑-crossed-double-lift-arrowᵢ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′}
+    (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ)
+    (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  ⊑-crossed-double-lift∀∀ᵢ (pA ↦ pB) ≡
+    ⊑-crossed-double-lift∀∀ᵢ pA ↦
+      ⊑-crossed-double-lift∀∀ᵢ pB
+⊑-crossed-double-lift-arrowᵢ
+    {A = A} {A′ = A′} {B = B} {B′ = B′} pA pB
+    rewrite equality-proof-unique
+      (sym (renameᵗ-compose suc suc (A ⇒ B)))
+      (cong₂ _⇒_
+        (sym (renameᵗ-double-lift A))
+        (sym (renameᵗ-double-lift B)))
+          | equality-proof-unique
+      (sym (renameᵗ-compose suc suc (A′ ⇒ B′)))
+      (cong₂ _⇒_
+        (sym (renameᵗ-double-lift A′))
+        (sym (renameᵗ-double-lift B′))) =
+  transport-arrow-⊑ᵢ
+    (sym (renameᵗ-double-lift A))
+    (sym (renameᵗ-double-lift A′))
+    (sym (renameᵗ-double-lift B))
+    (sym (renameᵗ-double-lift B′))
+
+⊑-crossed-double-lift-allᵢ :
+  ∀ {Φ Δᴸ Δᴿ A B}
+    (p : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ A ⊑ B ⊣ suc Δᴿ) →
+  ⊑-crossed-double-lift∀∀ᵢ (∀ⁱ p) ≡
+    ∀ⁱ (⊑-crossed-double-lift-under-∀ᵢ p)
+⊑-crossed-double-lift-allᵢ {A = A} {B = B} p
+    rewrite equality-proof-unique
+      (sym (renameᵗ-compose suc suc (`∀ A)))
+      (cong `∀ (sym (renameᵗ-double-under-∀ A)))
+          | equality-proof-unique
+      (sym (renameᵗ-compose suc suc (`∀ B)))
+      (cong `∀ (sym (renameᵗ-double-under-∀ B))) =
+  transport-all-⊑ᵢ
+    (sym (renameᵗ-double-under-∀ A))
+    (sym (renameᵗ-double-under-∀ B))
+
+weak-one-step-source-blame-right-allocationᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ V′ s s′}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreWf Δᴿ (rightStoreⁱ ρ) →
+  Value V′ →
+  No• V′ →
+  WfTy (suc Δᴿ) (⇑ᵗ A′) →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ ν A′ V′ s′ ⦂ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepResult ρ
+    (ν A blame s) (((⇑ᵗᵐ V′) •) ⟨ s′ ⟩)
+    B B′ (bind A′)
+weak-one-step-source-blame-right-allocationᵀ
+    {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′}
+    {V′ = V′} {s′ = s′} {ρ = ρ}
+    wfΣ′ vV′ noV′ h⇑A′ target⊢ pB =
+  record
+    { sourceChanges = keep ∷ []
+    ; targetTailChanges = []
+    ; sourceResult = blame
+    ; targetResult = ((⇑ᵗᵐ _) •) ⟨ _ ⟩
+    ; resultCtx = ⇑ᴿᵢ _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = store-right zero (⇑ᵗ A′) h⇑A′ ∷ ρ′
+    ; resultSourceType = _
+    ; resultTargetType = ⇑ᵗ B′
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = ⊑-target-lift-rightᵢ
+    ; transportAllBody = ⊑-target-lift-right-under-∀ᵢ
+    ; transportRightBody = ⊑-target-lift-under-rightᵢ
+    ; resultType = ⊑-target-lift-rightᵢ pB
+    ; sourceCatchup = ↠-step blame-ν ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = leftStoreⁱ-lift-right liftρ
+    ; targetStoreResult = target-store-result
+    ; relatedResults = blame⊑ᵀ target-result-typing
+    }
+  where
+    ρ′ = proj₁ (lift-right-store-result ρ)
+    liftρ = proj₂ (lift-right-store-result ρ)
+
+    target-store-result =
+      cong ((zero , ⇑ᵗ A′) ∷_)
+        (rightStoreⁱ-lift-right liftρ)
+
+    target-result-typing =
+      subst
+        (λ Σ → suc Δᴿ ∣ Σ ∣ []
+          ⊢ ((⇑ᵗᵐ V′) •) ⟨ s′ ⟩ ⦂ ⇑ᵗ B′)
+        (sym target-store-result)
+        (preservation wfΣ′ (ok-ν (ok-no noV′)) target⊢
+          (ν-step vV′ noV′))
+
+weak-one-step-compose-type :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C D} →
+  Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
+  resultCtx second ∣ resultLeftCtx second
+    ⊢ applyTys (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTys
+        (targetTailChanges first ++
+          χ′ ∷ targetTailChanges second)
+        (applyTy χ D)
+      ⊣ resultRightCtx second
+weak-one-step-compose-type {B = B} {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  subst
+    (λ T → resultCtx second ∣ resultLeftCtx second
+      ⊢ applyTys
+          (sourceChanges first ++ sourceChanges second) C
+        ⊑ T ⊣ resultRightCtx second)
+    (sym (applyTys-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTy χ D)))
+    (subst
+      (λ S → resultCtx second ∣ resultLeftCtx second
+        ⊢ S ⊑ applyTys (targetTailChanges second)
+            (applyTy χ′
+              (applyTys (targetTailChanges first)
+                (applyTy χ D)))
+          ⊣ resultRightCtx second)
+      (sym (applyTys-++
+        (sourceChanges first) (sourceChanges second) C))
+      (transportType second (transportType first p)))
+
+weak-one-step-compose-type-to-nested≅ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′)
+    {C D}
+    (p : Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ) →
+  HE._≅_ (weak-one-step-compose-type first second p)
+    (transportType second (transportType first p))
+weak-one-step-compose-type-to-nested≅ {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  HE.trans
+    (subst-to-≅
+      {P = λ T → resultCtx second ∣ resultLeftCtx second
+        ⊢ applyTys
+            (sourceChanges first ++ sourceChanges second) C
+          ⊑ T ⊣ resultRightCtx second}
+      target-eq source-transport)
+    (subst-to-≅
+      {P = λ S → resultCtx second ∣ resultLeftCtx second
+        ⊢ S ⊑ applyTys (targetTailChanges second)
+            (applyTy χ′
+              (applyTys (targetTailChanges first) (applyTy χ D)))
+          ⊣ resultRightCtx second}
+      source-eq raw)
+  where
+  raw = transportType second (transportType first p)
+  source-eq = sym (applyTys-++
+    (sourceChanges first) (sourceChanges second) C)
+  source-transport = subst
+    (λ S → resultCtx second ∣ resultLeftCtx second
+      ⊢ S ⊑ applyTys (targetTailChanges second)
+          (applyTy χ′
+            (applyTys (targetTailChanges first) (applyTy χ D)))
+        ⊣ resultRightCtx second)
+    source-eq raw
+  target-eq = sym (applyTys-++
+    (targetTailChanges first)
+    (χ′ ∷ targetTailChanges second) (applyTy χ D))
+
+weak-one-step-nested-arrow-coherent≅ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′) →
+  WeakOneStepTypeCoherence first →
+  WeakOneStepTypeCoherence second →
+  ∀ {C C′ D D′}
+    (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+    (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+  HE._≅_
+    (transportType second (transportType first (pC ↦ pD)))
+    (transportType second (transportType first pC) ↦
+      transportType second (transportType first pD))
+weak-one-step-nested-arrow-coherent≅
+    first second first-coherence second-coherence pC pD =
+  HE.trans
+    (HE.sym
+      (transportType-transportArrowType-to-raw≅
+        first second pC pD))
+    (HE.trans
+      (≡-to-≅
+        (cong (transportType second)
+          (transportArrowCoherent first-coherence pC pD)))
+      (HE.trans
+        (HE.sym
+          (transportArrowType-to-raw≅ second
+            (transportType first pC) (transportType first pD)))
+        (≡-to-≅
+          (transportArrowCoherent second-coherence
+            (transportType first pC) (transportType first pD)))))
+
+weak-one-step-nested-all-coherent≅ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′) →
+  WeakOneStepTypeCoherence first →
+  WeakOneStepTypeCoherence second →
+  ∀ {C C′}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+  HE._≅_
+    (transportType second (transportType first (∀ⁱ q)))
+    (∀ⁱ (transportAllBody second (transportAllBody first q)))
+weak-one-step-nested-all-coherent≅
+    first second first-coherence second-coherence q =
+  HE.trans
+    (HE.sym
+      (transportType-transportAllType-to-raw≅
+        first second q))
+    (HE.trans
+      (≡-to-≅
+        (cong (transportType second)
+          (transportAllCoherent first-coherence q)))
+      (HE.trans
+        (HE.sym
+          (transportAllType-to-raw≅ second
+            (transportAllBody first q)))
+        (≡-to-≅
+          (transportAllCoherent second-coherence
+            (transportAllBody first q)))))
+
+weak-one-step-compose-all-body :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C D} →
+  ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+  ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
+    ⊢ applyTysUnderTyBinders
+        (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTysUnderTyBinders
+          (targetTailChanges first ++
+            χ′ ∷ targetTailChanges second)
+          (applyTyUnderTyBinder χ D)
+      ⊣ suc (resultRightCtx second)
+weak-one-step-compose-all-body {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  subst
+    (λ T → ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
+      ⊢ applyTysUnderTyBinders
+          (sourceChanges first ++ sourceChanges second) C
+        ⊑ T ⊣ suc (resultRightCtx second))
+    (sym (applyTysUnderTyBinders-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTyUnderTyBinder χ D)))
+    (subst
+      (λ S → ∀ᵢᶜ (resultCtx second) ∣ suc (resultLeftCtx second)
+        ⊢ S ⊑ applyTysUnderTyBinders
+            (targetTailChanges second)
+            (applyTyUnderTyBinder χ′
+              (applyTysUnderTyBinders
+                (targetTailChanges first)
+                (applyTyUnderTyBinder χ D)))
+          ⊣ suc (resultRightCtx second))
+      (sym (applyTysUnderTyBinders-++
+        (sourceChanges first) (sourceChanges second) C))
+      (transportAllBody second (transportAllBody first p)))
+
+weak-one-step-compose-right-body :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C D} →
+  ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ suc Δᴿ →
+  ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
+    ⊢ applyTys
+        (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTysUnderTyBinders
+          (targetTailChanges first ++
+            χ′ ∷ targetTailChanges second)
+          (applyTyUnderTyBinder χ D)
+      ⊣ suc (resultRightCtx second)
+weak-one-step-compose-right-body {χ = χ} first
+    {χ′ = χ′} second {C = C} {D = D} p =
+  subst
+    (λ T → ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
+      ⊢ applyTys
+          (sourceChanges first ++ sourceChanges second) C
+        ⊑ T ⊣ suc (resultRightCtx second))
+    (sym (applyTysUnderTyBinders-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTyUnderTyBinder χ D)))
+    (subst
+      (λ S → ⇑ᴿᵢ (resultCtx second) ∣ resultLeftCtx second
+        ⊢ S ⊑ applyTysUnderTyBinders
+            (targetTailChanges second)
+            (applyTyUnderTyBinder χ′
+              (applyTysUnderTyBinders
+                (targetTailChanges first)
+                (applyTyUnderTyBinder χ D)))
+          ⊣ suc (resultRightCtx second))
+      (sym (applyTys-++
+        (sourceChanges first) (sourceChanges second) C))
+      (transportRightBody second (transportRightBody first p)))
+
+weak-one-step-composeᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (first : WeakOneStepResult ρ M M′ A B χ) →
+  ∀ {χ′ N′} →
+  targetResult first —→[ χ′ ] N′ →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ′) →
+  WeakOneStepResult ρ M M′ A B χ
+weak-one-step-composeᵀ {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B}
+    {χ = χ} {ρ = ρ} first {χ′ = χ′} target→ second =
+  record
+    { sourceChanges = sourceChanges first ++ sourceChanges second
+    ; targetTailChanges =
+        targetTailChanges first ++ χ′ ∷ targetTailChanges second
+    ; sourceResult = sourceResult second
+    ; targetResult = targetResult second
+    ; resultCtx = resultCtx second
+    ; resultLeftCtx = resultLeftCtx second
+    ; resultRightCtx = resultRightCtx second
+    ; sourceCtxResult =
+        trans (sourceCtxResult second)
+          (trans
+            (cong (applyTyCtxs (sourceChanges second))
+              (sourceCtxResult first))
+            (sym (applyTyCtxs-++
+              (sourceChanges first) (sourceChanges second) Δᴸ)))
+    ; targetCtxResult =
+        trans (targetCtxResult second)
+          (trans
+            (cong
+              (λ Δ → applyTyCtxs (targetTailChanges second)
+                (applyTyCtx χ′ Δ))
+              (targetCtxResult first))
+            (sym (applyTyCtxs-++
+              (targetTailChanges first)
+              (χ′ ∷ targetTailChanges second)
+              (applyTyCtx χ Δᴿ))))
+    ; resultStore = resultStore second
+    ; resultSourceType = resultSourceType second
+    ; resultTargetType = resultTargetType second
+    ; sourceTypeResult =
+        trans (sourceTypeResult second)
+          (trans
+            (cong (applyTys (sourceChanges second))
+              (sourceTypeResult first))
+            (sym (applyTys-++
+              (sourceChanges first) (sourceChanges second) A)))
+    ; targetTypeResult =
+        trans (targetTypeResult second)
+          (trans
+            (cong
+              (λ C → applyTys (targetTailChanges second)
+                (applyTy χ′ C))
+              (targetTypeResult first))
+            (sym (applyTys-++
+              (targetTailChanges first)
+              (χ′ ∷ targetTailChanges second)
+              (applyTy χ B))))
+    ; transportType = weak-one-step-compose-type first second
+    ; transportAllBody = weak-one-step-compose-all-body first second
+    ; transportRightBody =
+        weak-one-step-compose-right-body first second
+    ; resultType = resultType second
+    ; sourceCatchup =
+        ↠-trans (sourceCatchup first) (sourceCatchup second)
+    ; targetTail =
+        ↠-trans (targetTail first)
+          (↠-step target→ (targetTail second))
+    ; sourceStoreResult =
+        trans (sourceStoreResult second)
+          (trans
+            (cong (applyStores (sourceChanges second))
+              (sourceStoreResult first))
+            (sym (applyStores-++
+              (sourceChanges first) (sourceChanges second)
+              (leftStoreⁱ ρ))))
+    ; targetStoreResult =
+        trans (targetStoreResult second)
+          (trans
+            (cong
+              (λ Σ → applyStores (targetTailChanges second)
+                (applyStore χ′ Σ))
+              (targetStoreResult first))
+            (sym (applyStores-++
+              (targetTailChanges first)
+              (χ′ ∷ targetTailChanges second)
+              (applyStore χ (rightStoreⁱ ρ)))))
+    ; relatedResults = relatedResults second
+    }
+
+weak-one-step-compose-transport-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′) →
+  WeakOneStepTransport first →
+  WeakOneStepTransport second →
+  ∀ {L L′ C C′ p} →
+  No• L →
+  No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ C ⊑ C′ ∶ p →
+  resultCtx second
+    ∣ resultLeftCtx second
+    ∣ resultRightCtx second
+    ∣ resultStore second ∣ [] ⊢ᴺ
+    applyTerms
+      (sourceChanges first ++ sourceChanges second) L
+    ⊑ applyTerms
+        (targetTailChanges first ++ χ′ ∷ targetTailChanges second)
+        (applyTerm χ L′)
+    ⦂ applyTys (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTys
+          (targetTailChanges first ++ χ′ ∷ targetTailChanges second)
+          (applyTy χ C′)
+    ∶ weak-one-step-compose-type first second p
+weak-one-step-compose-transport-bodyᵀ
+    {χ = χ} first {χ′ = χ′} second
+    first-transport second-transport
+    {L = L} {L′ = L′} {C = C} {C′ = C′}
+    noL noL′ L⊑L′
+    rewrite applyTerms-++
+      (sourceChanges first) (sourceChanges second) L
+    | applyTerms-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second) (applyTerm χ L′)
+    | applyTys-++
+      (sourceChanges first) (sourceChanges second) C
+    | applyTys-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second) (applyTy χ C′) =
+  transportNo•Terms second-transport
+    (applyTerms-preserves-No• (sourceChanges first) noL)
+    (applyTerms-preserves-No• (targetTailChanges first)
+      (applyTerm-preserves-No• χ noL′))
+    (transportNo•Terms first-transport noL noL′ L⊑L′)
+
+weak-one-step-compose-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (target→ : targetResult first —→[ χ′ ] N′)
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′) →
+  WeakOneStepTransport first →
+  WeakOneStepTransport second →
+  WeakOneStepTransport
+    (weak-one-step-composeᵀ first target→ second)
+weak-one-step-compose-preserves-transportᵀ
+    first target→ second
+    first-transport second-transport =
+  weak-step-transport
+    (weak-one-step-compose-transport-bodyᵀ
+      first second first-transport second-transport)
+
+weak-one-step-prepend-left-silentᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (silent : LeftSilentResult
+    {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ}) →
+  let first = silentResult silent in
+  ∀ {χ N′} →
+  (second : WeakOneStepResult (resultStore first)
+    (sourceResult first) N′
+    (resultSourceType first) (resultTargetType first) χ) →
+  WeakOneStepResult ρ M N′ A B χ
+weak-one-step-prepend-left-silentᵀ
+    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {A = A} {B = B} {ρ = ρ}
+    (left-silent first (left-silent-invariant refl refl))
+    {χ = χ} second =
+  record
+    { sourceChanges = sourceChanges first ++ sourceChanges second
+    ; targetTailChanges = targetTailChanges second
+    ; sourceResult = sourceResult second
+    ; targetResult = targetResult second
+    ; resultCtx = resultCtx second
+    ; resultLeftCtx = resultLeftCtx second
+    ; resultRightCtx = resultRightCtx second
+    ; sourceCtxResult =
+        trans (sourceCtxResult second)
+          (trans
+            (cong (applyTyCtxs (sourceChanges second))
+              (sourceCtxResult first))
+            (sym (applyTyCtxs-++
+              (sourceChanges first) (sourceChanges second) Δᴸ)))
+    ; targetCtxResult =
+        trans (targetCtxResult second)
+          (cong
+            (λ Δ → applyTyCtxs (targetTailChanges second)
+              (applyTyCtx χ Δ))
+            (targetCtxResult first))
+    ; resultStore = resultStore second
+    ; resultSourceType = resultSourceType second
+    ; resultTargetType = resultTargetType second
+    ; sourceTypeResult =
+        trans (sourceTypeResult second)
+          (trans
+            (cong (applyTys (sourceChanges second))
+              (sourceTypeResult first))
+            (sym (applyTys-++
+              (sourceChanges first) (sourceChanges second) A)))
+    ; targetTypeResult =
+        trans (targetTypeResult second)
+          (cong
+            (λ C → applyTys (targetTailChanges second)
+              (applyTy χ C))
+            (targetTypeResult first))
+    ; transportType = weak-one-step-compose-type first second
+    ; transportAllBody = weak-one-step-compose-all-body first second
+    ; transportRightBody =
+        weak-one-step-compose-right-body first second
+    ; resultType = resultType second
+    ; sourceCatchup =
+        ↠-trans (sourceCatchup first) (sourceCatchup second)
+    ; targetTail = targetTail second
+    ; sourceStoreResult =
+        trans (sourceStoreResult second)
+          (trans
+            (cong (applyStores (sourceChanges second))
+              (sourceStoreResult first))
+            (sym (applyStores-++
+              (sourceChanges first) (sourceChanges second)
+              (leftStoreⁱ ρ))))
+    ; targetStoreResult =
+        trans (targetStoreResult second)
+          (cong
+            (λ Σ → applyStores (targetTailChanges second)
+              (applyStore χ Σ))
+            (targetStoreResult first))
+    ; relatedResults = relatedResults second
+    }
+
+weak-one-step-prepend-left-silent-transport-bodyᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M V′ A B keep)
+    {χ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ) →
+  targetTailChanges first ≡ [] →
+  WeakOneStepTransport first →
+  WeakOneStepTransport second →
+  ∀ {L L′ C C′ p} →
+  No• L →
+  No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′ ⦂ C ⊑ C′ ∶ p →
+  resultCtx second
+    ∣ resultLeftCtx second
+    ∣ resultRightCtx second
+    ∣ resultStore second ∣ [] ⊢ᴺ
+    applyTerms (sourceChanges first ++ sourceChanges second) L
+    ⊑ applyTerms
+        (targetTailChanges first ++ χ ∷ targetTailChanges second)
+        (applyTerm keep L′)
+    ⦂ applyTys (sourceChanges first ++ sourceChanges second) C
+      ⊑ applyTys
+          (targetTailChanges first ++ χ ∷ targetTailChanges second)
+          (applyTy keep C′)
+    ∶ weak-one-step-compose-type first second p
+weak-one-step-prepend-left-silent-transport-bodyᵀ
+    first {χ = χ} second refl first-transport second-transport
+    {L = L} {L′ = L′} {C = C} noL noL′ L⊑L′
+    rewrite applyTerms-++
+      (sourceChanges first) (sourceChanges second) L
+    | applyTys-++
+      (sourceChanges first) (sourceChanges second) C =
+  transportNo•Terms second-transport
+    (applyTerms-preserves-No• (sourceChanges first) noL)
+    noL′
+    (transportNo•Terms first-transport noL noL′ L⊑L′)
+
+weak-one-step-prepend-left-silent-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (silent : LeftSilentResult
+      {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ}) →
+  let first = silentResult silent in
+  ∀ {χ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ) →
+  WeakOneStepTransport first →
+  WeakOneStepTransport second →
+  WeakOneStepTransport
+    (weak-one-step-prepend-left-silentᵀ silent second)
+weak-one-step-prepend-left-silent-preserves-transportᵀ
+    (left-silent first
+      (left-silent-invariant refl refl))
+    {χ = χ} second first-transport second-transport =
+  weak-step-transport
+    (weak-one-step-prepend-left-silent-transport-bodyᵀ
+      first second refl first-transport second-transport)
+
+weak-one-step-compose-arrow-componentsᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C C′ D D′}
+    (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+    (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+  subst
+    (λ T → resultCtx second ∣ resultLeftCtx second
+      ⊢ applyTys
+          (sourceChanges first ++ sourceChanges second) C ⇒
+        applyTys (sourceChanges first ++ sourceChanges second) D
+        ⊑ T
+      ⊣ resultRightCtx second)
+    (cong₂ _⇒_
+      (sym (applyTys-++ (targetTailChanges first)
+        (χ′ ∷ targetTailChanges second) (applyTy χ C′)))
+      (sym (applyTys-++ (targetTailChanges first)
+        (χ′ ∷ targetTailChanges second) (applyTy χ D′))))
+    (subst
+      (λ S → resultCtx second ∣ resultLeftCtx second
+        ⊢ S ⊑
+          applyTys (targetTailChanges second)
+            (applyTy χ′
+              (applyTys (targetTailChanges first) (applyTy χ C′))) ⇒
+          applyTys (targetTailChanges second)
+            (applyTy χ′
+              (applyTys (targetTailChanges first) (applyTy χ D′)))
+        ⊣ resultRightCtx second)
+      (cong₂ _⇒_
+        (sym (applyTys-++
+          (sourceChanges first) (sourceChanges second) C))
+        (sym (applyTys-++
+          (sourceChanges first) (sourceChanges second) D)))
+      (transportType second (transportType first pC) ↦
+        transportType second (transportType first pD)))
+    ≡
+  weak-one-step-compose-type first second pC ↦
+    weak-one-step-compose-type first second pD
+weak-one-step-compose-arrow-componentsᵀ
+    {χ = χ} first {χ′ = χ′} second
+    {C = C} {C′ = C′} {D = D} {D′ = D′} pC pD =
+  transport-arrow-⊑ᵢ
+    (sym (applyTys-++
+      (sourceChanges first) (sourceChanges second) C))
+    (sym (applyTys-++ (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second) (applyTy χ C′)))
+    (sym (applyTys-++
+      (sourceChanges first) (sourceChanges second) D))
+    (sym (applyTys-++ (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second) (applyTy χ D′)))
+
+weak-one-step-compose-all-componentsᵀ :
+  ∀ {Φ Δᴸ Δᴿ M M′ A B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (first : WeakOneStepResult ρ M M′ A B χ)
+    {χ′ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ′) →
+  ∀ {C C′}
+    (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+  subst
+    (λ T → resultCtx second ∣ resultLeftCtx second
+      ⊢ `∀ (applyTysUnderTyBinders
+          (sourceChanges first ++ sourceChanges second) C)
+        ⊑ T ⊣ resultRightCtx second)
+    (cong `∀
+      (sym (applyTysUnderTyBinders-++
+        (targetTailChanges first)
+        (χ′ ∷ targetTailChanges second)
+        (applyTyUnderTyBinder χ C′))))
+    (subst
+      (λ S → resultCtx second ∣ resultLeftCtx second
+        ⊢ S ⊑
+          `∀ (applyTysUnderTyBinders
+            (targetTailChanges second)
+            (applyTyUnderTyBinder χ′
+              (applyTysUnderTyBinders
+                (targetTailChanges first)
+                (applyTyUnderTyBinder χ C′))))
+        ⊣ resultRightCtx second)
+      (cong `∀
+        (sym (applyTysUnderTyBinders-++
+          (sourceChanges first) (sourceChanges second) C)))
+      (∀ⁱ (transportAllBody second (transportAllBody first q))))
+    ≡
+  ∀ⁱ (weak-one-step-compose-all-body first second q)
+weak-one-step-compose-all-componentsᵀ
+    {χ = χ} first {χ′ = χ′} second
+    {C = C} {C′ = C′} q =
+  transport-all-⊑ᵢ
+    (sym (applyTysUnderTyBinders-++
+      (sourceChanges first) (sourceChanges second) C))
+    (sym (applyTysUnderTyBinders-++
+      (targetTailChanges first)
+      (χ′ ∷ targetTailChanges second)
+      (applyTyUnderTyBinder χ C′)))
+
+weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (silent : LeftSilentResult
+      {M = M} {V′ = V′} {A = A} {B = B} {ρ = ρ}) →
+  let first = silentResult silent in
+  ∀ {χ N′}
+    (second : WeakOneStepResult (resultStore first)
+      (sourceResult first) N′
+      (resultSourceType first) (resultTargetType first) χ) →
+  WeakOneStepTypeCoherence first →
+  WeakOneStepTypeCoherence second →
+  WeakOneStepTypeCoherence
+    (weak-one-step-prepend-left-silentᵀ silent second)
+weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    (left-silent first
+      (left-silent-invariant refl refl))
+    {χ = χ} second first-coherence second-coherence =
+  weak-step-type-coherence arrow-coherent all-coherent
+  where
+  arrow-coherent :
+    ∀ {C C′ D D′}
+      (pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ)
+      (pD : Φ ∣ Δᴸ ⊢ D ⊑ D′ ⊣ Δᴿ) →
+    transportArrowType
+      (weak-one-step-prepend-left-silentᵀ
+        (left-silent first
+          (left-silent-invariant refl refl)) second)
+      pC pD ≡
+    weak-one-step-compose-type first second pC ↦
+      weak-one-step-compose-type first second pD
+  arrow-coherent {C = C} {C′ = C′} {D = D} {D′ = D′} pC pD =
+    HE.≅-to-≡
+      (HE.trans
+        (transportArrowType-to-raw≅ combined pC pD)
+        (HE.trans
+          (weak-one-step-compose-type-to-nested≅
+            first second (pC ↦ pD))
+          (HE.trans
+            (weak-one-step-nested-arrow-coherent≅
+              first second first-coherence second-coherence pC pD)
+            (HE.trans
+              (HE.sym
+                (subst²-to-≅
+                  {P = λ S T →
+                    resultCtx second ∣ resultLeftCtx second
+                      ⊢ S ⊑ T ⊣ resultRightCtx second}
+                  (cong₂ _⇒_
+                    (sym (applyTys-++
+                      (sourceChanges first)
+                      (sourceChanges second) C))
+                    (sym (applyTys-++
+                      (sourceChanges first)
+                      (sourceChanges second) D)))
+                  (cong₂ _⇒_
+                    (sym (applyTys-++
+                      (targetTailChanges first)
+                      (χ ∷ targetTailChanges second)
+                      (applyTy keep C′)))
+                    (sym (applyTys-++
+                      (targetTailChanges first)
+                      (χ ∷ targetTailChanges second)
+                      (applyTy keep D′))))
+                  (transportType second (transportType first pC) ↦
+                    transportType second (transportType first pD))))
+              (≡-to-≅
+                (weak-one-step-compose-arrow-componentsᵀ
+                  first second pC pD))))))
+    where
+    combined =
+      weak-one-step-prepend-left-silentᵀ
+        (left-silent first (left-silent-invariant refl refl)) second
+
+  all-coherent :
+    ∀ {C C′}
+      (q : ∀ᵢᶜ Φ ∣ suc Δᴸ ⊢ C ⊑ C′ ⊣ suc Δᴿ) →
+    transportAllType
+      (weak-one-step-prepend-left-silentᵀ
+        (left-silent first
+          (left-silent-invariant refl refl)) second)
+      q ≡
+    ∀ⁱ (weak-one-step-compose-all-body first second q)
+  all-coherent {C = C} {C′ = C′} q =
+    HE.≅-to-≡
+      (HE.trans
+        (transportAllType-to-raw≅ combined q)
+        (HE.trans
+          (weak-one-step-compose-type-to-nested≅
+            first second (∀ⁱ q))
+          (HE.trans
+            (weak-one-step-nested-all-coherent≅
+              first second first-coherence second-coherence q)
+            (HE.trans
+              (HE.sym
+                (subst²-to-≅
+                  {P = λ S T →
+                    resultCtx second ∣ resultLeftCtx second
+                      ⊢ S ⊑ T ⊣ resultRightCtx second}
+                  (cong `∀
+                    (sym (applyTysUnderTyBinders-++
+                      (sourceChanges first)
+                      (sourceChanges second) C)))
+                  (cong `∀
+                    (sym (applyTysUnderTyBinders-++
+                      (targetTailChanges first)
+                      (χ ∷ targetTailChanges second)
+                      (applyTyUnderTyBinder keep C′))))
+                  (∀ⁱ (transportAllBody second
+                    (transportAllBody first q)))))
+              (≡-to-≅
+                (weak-one-step-compose-all-componentsᵀ
+                  first second q))))))
+    where
+    combined =
+      weak-one-step-prepend-left-silentᵀ
+        (left-silent first (left-silent-invariant refl refl)) second
+
+weak-one-step-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p →
+  WeakOneStepResult ρ M N A B keep
+weak-one-step-relatedᵀ result =
+  record
+    { sourceChanges = []
+    ; targetTailChanges = []
+    ; sourceResult = _
+    ; targetResult = _
+    ; resultCtx = _
+    ; resultLeftCtx = _
+    ; resultRightCtx = _
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = _
+    ; resultSourceType = _
+    ; resultTargetType = _
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ p → p
+    ; transportAllBody = λ p → p
+    ; transportRightBody = λ p → p
+    ; resultType = _
+    ; sourceCatchup = ↠-refl
+    ; targetTail = ↠-refl
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; relatedResults = result
+    }
+
+weak-one-step-related-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result :
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+      ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p) →
+  WeakOneStepTransport (weak-one-step-relatedᵀ result)
+weak-one-step-related-transportᵀ result =
+  weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
+
+weak-one-step-related-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p) →
+  WeakOneStepTypeCoherence (weak-one-step-relatedᵀ result)
+weak-one-step-related-type-coherenceᵀ result =
+  weak-step-type-coherence (λ pC pD → refl) (λ q → refl)
+
+weak-one-step-indexed-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p) →
+  WeakOneStepIndexedResult {χ = keep} p
+weak-one-step-indexed-relatedᵀ result =
+  weak-indexed-result (weak-one-step-relatedᵀ result) result
+
+weak-one-step-indexed-outcome-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M N A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p) →
+  WeakOneStepIndexedOutcome {χ = keep} p
+weak-one-step-indexed-outcome-relatedᵀ result =
+  indexed-outcome-related
+    (weak-one-step-indexed-relatedᵀ result)
+    (weak-one-step-related-transportᵀ result)
+    (weak-one-step-related-type-coherenceᵀ result)
+
+weak-one-step-arrow-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ A A′ B B′ pA pB}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′
+    ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB →
+  WeakOneStepArrowResult {χ = keep} pA pB
+weak-one-step-arrow-relatedᵀ result =
+  weak-arrow-result (weak-one-step-relatedᵀ result) result
+
+weak-one-step-arrow-outcome-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ A A′ B B′ pA pB}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (result : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′
+    ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB) →
+  WeakOneStepArrowOutcome {χ = keep} pA pB
+weak-one-step-arrow-outcome-relatedᵀ result =
+  arrow-outcome-related
+    (weak-one-step-arrow-relatedᵀ result)
+    (weak-one-step-related-transportᵀ result)
+    (weak-one-step-related-type-coherenceᵀ result)
+
+weak-one-step-arrow-reindexᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ pA pB}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result :
+      WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ) →
+  resultCtx result
+    ∣ resultLeftCtx result
+    ∣ resultRightCtx result
+    ∣ resultStore result ∣ []
+    ⊢ᴺ sourceResult result ⊑ targetResult result
+    ⦂ applyTys (sourceChanges result) A ⇒
+        applyTys (sourceChanges result) B
+      ⊑ applyTys (targetTailChanges result) (applyTy χ A′) ⇒
+        applyTys (targetTailChanges result) (applyTy χ B′)
+    ∶ transportType result pA ↦ transportType result pB →
+  WeakOneStepArrowResult pA pB
+weak-one-step-arrow-reindexᵀ
+    {A′ = A′} {B′ = B′} {χ = χ} result related =
+  weak-arrow-result reindexed related
+  where
+  source-eq =
+    sym (applyTys-⇒
+      (sourceChanges result) _ _)
+
+  target-eq =
+    sym
+      (trans
+        (cong (applyTys (targetTailChanges result))
+          (applyTys-⇒ (χ ∷ []) A′ B′))
+        (applyTys-⇒ (targetTailChanges result)
+          (applyTy χ A′) (applyTy χ B′)))
+
+  reindexed = weak-one-step-reindexᵀ
+    result source-eq target-eq related
+
+weak-one-step-arrow-reindex-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ A A′ B B′ χ pA pB}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (result :
+      WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ)
+    (related : resultCtx result
+      ∣ resultLeftCtx result
+      ∣ resultRightCtx result
+      ∣ resultStore result ∣ []
+      ⊢ᴺ sourceResult result ⊑ targetResult result
+      ⦂ applyTys (sourceChanges result) A ⇒
+          applyTys (sourceChanges result) B
+        ⊑ applyTys (targetTailChanges result) (applyTy χ A′) ⇒
+          applyTys (targetTailChanges result) (applyTy χ B′)
+      ∶ transportType result pA ↦ transportType result pB) →
+  WeakOneStepTransport result →
+  WeakOneStepTransport
+    (weakArrowResult
+      (weak-one-step-arrow-reindexᵀ result related))
+weak-one-step-arrow-reindex-preserves-transportᵀ
+    {A′ = A′} {B′ = B′} {χ = χ}
+    result related transport =
+  weak-one-step-reindex-preserves-transportᵀ
+    result source-eq target-eq related transport
+  where
+  source-eq =
+    sym (applyTys-⇒
+      (sourceChanges result) _ _)
+
+  target-eq =
+    sym
+      (trans
+        (cong (applyTys (targetTailChanges result))
+          (applyTys-⇒ (χ ∷ []) A′ B′))
+        (applyTys-⇒ (targetTailChanges result)
+          (applyTy χ A′) (applyTy χ B′)))
+
+left-catchup-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ M V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Value M × No• M) ⊎ M ≡ blame →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ V′ ⦂ A ⊑ B ∶ p →
+  LeftCatchupResult {M = M} {V′ = V′} {ρ = ρ}
+left-catchup-relatedᵀ final result =
+  left-catchup (weak-one-step-relatedᵀ result)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+weak-one-step-source-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ ρ M N′ A B χ χs} →
+  M —↠[ χs ] blame →
+  WeakOneStepOutcome {Φ} {Δᴸ} {Δᴿ} ρ M N′ A B χ
+weak-one-step-source-blameᵀ = outcome-source-blame
+
+ν-blame-tail :
+  ∀ {N A c χs} →
+  N —↠[ χs ] blame →
+  ν A N c —↠[ χs ++ keep ∷ [] ] blame
+ν-blame-tail N↠blame =
+  ↠-trans (ν-↠ N↠blame)
+    (↠-step blame-ν ↠-refl)
+
+·₁-blame-tail :
+  ∀ {L M χs} →
+  No• M →
+  L —↠[ χs ] blame →
+  L · M —↠[ χs ++ keep ∷ [] ] blame
+·₁-blame-tail noM L↠blame =
+  ↠-trans (·₁-↠ noM L↠blame)
+    (↠-step (pure-step blame-·₁) ↠-refl)
+
+weak-one-step-·₁-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• M →
+  No• M′ →
+  (inner : WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ) →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ sourceResult inner ⊑ targetResult inner
+    ⦂ applyTys (sourceChanges inner) A ⇒
+        applyTys (sourceChanges inner) B
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ∶ transportType inner pA ↦ transportType inner pB →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ applyTerms (sourceChanges inner) M
+      ⊑ applyTerms (targetTailChanges inner) (applyTerm χ M′)
+    ⦂ applyTys (sourceChanges inner) A
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+    ∶ transportType inner pA →
+  WeakOneStepResult ρ
+    (L · M) (L₁′ · applyTerm χ M′) B B′ χ
+weak-one-step-·₁-frameᵀ
+    {M = M} {M′ = M′} {B = B} {B′ = B′} {χ = χ}
+    noM noM′ inner L⊑L′ M⊑M′ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        sourceResult inner · applyTerms (sourceChanges inner) M
+    ; targetResult =
+        targetResult inner ·
+          applyTerms (targetTailChanges inner) (applyTerm χ M′)
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner _
+    ; sourceCatchup = ·₁-↠ noM (sourceCatchup inner)
+    ; targetTail =
+        ·₁-↠ (applyTerm-preserves-No• χ noM′)
+          (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults = ·⊑·ᵀ L⊑L′ M⊑M′
+    }
+
+weak-one-step-·₁-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• M →
+  No• M′ →
+  (∀ (inner :
+      WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ) →
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) A ⇒
+          applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+          applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner pA ↦ transportType inner pB) ×
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ applyTerms (sourceChanges inner) M
+        ⊑ applyTerms (targetTailChanges inner) (applyTerm χ M′)
+      ⦂ applyTys (sourceChanges inner) A
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+      ∶ transportType inner pA) ×
+    WeakOneStepTransport inner) →
+  WeakOneStepOutcome ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ →
+  WeakOneStepOutcome ρ
+    (L · M) (L₁′ · applyTerm χ M′) B B′ χ
+weak-one-step-·₁-frame-outcomeᵀ
+    noM noM′ frame
+    (outcome-related inner carried-transport carried-coherence)
+    with frame inner
+weak-one-step-·₁-frame-outcomeᵀ
+    noM noM′ frame
+    (outcome-related inner carried-transport carried-coherence)
+    | L⊑L′ , M⊑M′ , transport =
+  outcome-related
+    (weak-one-step-·₁-frameᵀ noM noM′ inner L⊑L′ M⊑M′)
+    (weak-step-transport (transportNo•Terms transport))
+    (weak-step-type-coherence
+      (transportArrowCoherent carried-coherence)
+      (transportAllCoherent carried-coherence))
+weak-one-step-·₁-frame-outcomeᵀ
+    noM noM′ frame (outcome-source-blame source↠) =
+  outcome-source-blame (·₁-blame-tail noM source↠)
+
+weak-one-step-·₁-frame-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• M →
+  No• M′ →
+  (inner : WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ) →
+  resultCtx inner
+    ∣ resultLeftCtx inner
+    ∣ resultRightCtx inner
+    ∣ resultStore inner ∣ []
+    ⊢ᴺ sourceResult inner ⊑ targetResult inner
+    ⦂ applyTys (sourceChanges inner) A ⇒
+        applyTys (sourceChanges inner) B
+      ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ∶ transportType inner pA ↦ transportType inner pB →
+  WeakOneStepTransport inner →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
+  WeakOneStepResult ρ
+    (L · M) (L₁′ · applyTerm χ M′) B B′ χ
+weak-one-step-·₁-frame-transportᵀ
+    noM noM′ inner L⊑L′ transport M⊑M′ =
+  weak-one-step-·₁-frameᵀ noM noM′ inner L⊑L′
+    (transportNo•Terms transport noM noM′ M⊑M′)
+
+weak-one-step-·₁-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (noM : No• M) (noM′ : No• M′)
+    (inner : WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ)
+    (L⊑L′ :
+      resultCtx inner
+        ∣ resultLeftCtx inner
+        ∣ resultRightCtx inner
+        ∣ resultStore inner ∣ []
+        ⊢ᴺ sourceResult inner ⊑ targetResult inner
+        ⦂ applyTys (sourceChanges inner) A ⇒
+            applyTys (sourceChanges inner) B
+          ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+            applyTys (targetTailChanges inner) (applyTy χ B′)
+        ∶ transportType inner pA ↦ transportType inner pB)
+    (M⊑M′ :
+      resultCtx inner
+        ∣ resultLeftCtx inner
+        ∣ resultRightCtx inner
+        ∣ resultStore inner ∣ []
+        ⊢ᴺ applyTerms (sourceChanges inner) M
+          ⊑ applyTerms (targetTailChanges inner) (applyTerm χ M′)
+        ⦂ applyTys (sourceChanges inner) A
+          ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+        ∶ transportType inner pA) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-·₁-frameᵀ noM noM′ inner L⊑L′ M⊑M′)
+weak-one-step-·₁-frame-preserves-transportᵀ
+    noM noM′ inner L⊑L′ M⊑M′ transport =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-·₁-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    (noM : No• M) (noM′ : No• M′)
+    (inner :
+      WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ)
+    (L⊑L′ : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) A ⇒
+          applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+          applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner pA ↦ transportType inner pB)
+    (M⊑M′ : resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ applyTerms (sourceChanges inner) M
+        ⊑ applyTerms (targetTailChanges inner) (applyTerm χ M′)
+      ⦂ applyTys (sourceChanges inner) A
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′)
+      ∶ transportType inner pA) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-·₁-frameᵀ noM noM′ inner L⊑L′ M⊑M′)
+weak-one-step-·₁-frame-preserves-type-coherenceᵀ
+    noM noM′ inner L⊑L′ M⊑M′ coherence =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-·₁-frame-transport-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• M →
+  No• M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
+  (∀ (inner :
+      WeakOneStepResult ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ) →
+    (resultCtx inner
+      ∣ resultLeftCtx inner
+      ∣ resultRightCtx inner
+      ∣ resultStore inner ∣ []
+      ⊢ᴺ sourceResult inner ⊑ targetResult inner
+      ⦂ applyTys (sourceChanges inner) A ⇒
+          applyTys (sourceChanges inner) B
+        ⊑ applyTys (targetTailChanges inner) (applyTy χ A′) ⇒
+          applyTys (targetTailChanges inner) (applyTy χ B′)
+      ∶ transportType inner pA ↦ transportType inner pB) ×
+    WeakOneStepTransport inner) →
+  WeakOneStepOutcome ρ L L₁′ (A ⇒ B) (A′ ⇒ B′) χ →
+  WeakOneStepOutcome ρ
+    (L · M) (L₁′ · applyTerm χ M′) B B′ χ
+weak-one-step-·₁-frame-transport-outcomeᵀ
+    noM noM′ M⊑M′ frame
+    (outcome-related inner carried-transport carried-coherence)
+    with frame inner
+weak-one-step-·₁-frame-transport-outcomeᵀ
+    noM noM′ M⊑M′ frame
+    (outcome-related inner carried-transport carried-coherence)
+    | L⊑L′ , transport =
+  let
+    transported-M =
+      transportNo•Terms transport noM noM′ M⊑M′
+  in
+  outcome-related
+    (weak-one-step-·₁-frameᵀ
+      noM noM′ inner L⊑L′ transported-M)
+    (weak-one-step-·₁-frame-preserves-transportᵀ
+      noM noM′ inner L⊑L′ transported-M transport)
+    (weak-one-step-·₁-frame-preserves-type-coherenceᵀ
+      noM noM′ inner L⊑L′ transported-M carried-coherence)
+weak-one-step-·₁-frame-transport-outcomeᵀ
+    noM noM′ M⊑M′ frame (outcome-source-blame source↠) =
+  outcome-source-blame (·₁-blame-tail noM source↠)
+
+weak-one-step-·₁-frame-arrow-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• M →
+  No• M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
+  WeakOneStepArrowOutcome
+    {L = L} {L₁′ = L₁′} {χ = χ} {ρ = ρ} pA pB →
+  WeakOneStepOutcome ρ
+    (L · M) (L₁′ · applyTerm χ M′) B B′ χ
+weak-one-step-·₁-frame-arrow-outcomeᵀ
+    noM noM′ M⊑M′
+    (arrow-outcome-related arrow transport coherence) =
+  let
+    inner = weakArrowResult arrow
+    L⊑L′ = canonicalArrowResults arrow
+    transported-M =
+      transportNo•Terms transport noM noM′ M⊑M′
+  in
+  outcome-related
+    (weak-one-step-·₁-frameᵀ
+      noM noM′ inner L⊑L′ transported-M)
+    (weak-one-step-·₁-frame-preserves-transportᵀ
+      noM noM′ inner L⊑L′ transported-M transport)
+    (weak-one-step-·₁-frame-preserves-type-coherenceᵀ
+      noM noM′ inner L⊑L′ transported-M coherence)
+weak-one-step-·₁-frame-arrow-outcomeᵀ
+    noM noM′ M⊑M′
+    (arrow-outcome-source-blame source↠) =
+  outcome-source-blame (·₁-blame-tail noM source↠)
+
+runtime-stepping-function-argument-no• :
+  ∀ {L L₁ M χ} →
+  RuntimeOK (L · M) →
+  L —→[ χ ] L₁ →
+  No• M
+runtime-stepping-function-argument-no•
+    (ok-no (no•-· noL noM)) L→ = noM
+runtime-stepping-function-argument-no•
+    (ok-·₁ okL noM) L→ = noM
+runtime-stepping-function-argument-no•
+    (ok-·₂ vL noL okM) L→ =
+  ⊥-elim (value-no-step vL L→)
+
+runtime-application-left-view :
+  ∀ {L L′ L₁′ M M′ χ} →
+  RuntimeOK (L · M) →
+  RuntimeOK (L′ · M′) →
+  L′ —→[ χ ] L₁′ →
+  (No• M × No• M′) ⊎
+  (Value L × No• L × RuntimeOK M × No• M′)
+runtime-application-left-view
+    (ok-no (no•-· noL noM)) okL′M′ L′→ =
+  inj₁ (noM , runtime-stepping-function-argument-no• okL′M′ L′→)
+runtime-application-left-view
+    (ok-·₁ okL noM) okL′M′ L′→ =
+  inj₁ (noM , runtime-stepping-function-argument-no• okL′M′ L′→)
+runtime-application-left-view
+    (ok-·₂ vL noL okM) okL′M′ L′→ =
+  inj₂
+    (vL , noL , okM ,
+      runtime-stepping-function-argument-no• okL′M′ L′→)
+
+weak-one-step-·₁-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  No• M →
+  No• M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
+  WeakOneStepIndexedOutcome
+    {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} (pA ↦ pB) →
+  WeakOneStepIndexedOutcome
+    {M = L · M} {N′ = L₁′ · applyTerm χ M′}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-·₁-indexed-frame-outcomeᵀ
+    noM noM′ M⊑M′ indexed
+    with weak-indexed-arrow-outcomeᵀ indexed
+weak-one-step-·₁-indexed-frame-outcomeᵀ
+    noM noM′ M⊑M′ indexed
+    | arrow-outcome-related arrow transport coherence =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-·₁-frame-preserves-transportᵀ
+      noM noM′ inner L⊑L′ transported-M transport)
+    (weak-one-step-·₁-frame-preserves-type-coherenceᵀ
+      noM noM′ inner L⊑L′ transported-M coherence)
+  where
+  inner = weakArrowResult arrow
+  L⊑L′ = canonicalArrowResults arrow
+  transported-M =
+    transportNo•Terms transport noM noM′ M⊑M′
+  framed =
+    weak-one-step-·₁-frameᵀ
+      noM noM′ inner L⊑L′ transported-M
+weak-one-step-·₁-indexed-frame-outcomeᵀ
+    noM noM′ M⊑M′ indexed
+    | arrow-outcome-source-blame source↠ =
+  indexed-outcome-source-blame (·₁-blame-tail noM source↠)
+
+weak-one-step-·₁-runtime-boundaryᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ L₁′ M M′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RuntimeOK (L · M) →
+  RuntimeOK (L′ · M′) →
+  L′ —→[ χ ] L₁′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
+  WeakOneStepIndexedOutcome
+    {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} (pA ↦ pB) →
+  WeakOneStepIndexedOutcome
+      {M = L · M} {N′ = L₁′ · applyTerm χ M′}
+      {χ = χ} {ρ = ρ} pB
+    ⊎
+  ∃[ result ]
+    WeakOneStepTransport (weakIndexedResult result) ×
+    WeakOneStepTypeCoherence (weakIndexedResult result) ×
+    sourceChanges (weakIndexedResult result) ≡ [] ×
+    sourceResult (weakIndexedResult result) ≡ L ×
+    Value L × No• L × RuntimeOK M × No• M′
+weak-one-step-·₁-runtime-boundaryᵀ
+    okLM okL′M′ L′→ M⊑M′ recursive
+    with runtime-application-left-view okLM okL′M′ L′→
+weak-one-step-·₁-runtime-boundaryᵀ
+    okLM okL′M′ L′→ M⊑M′ recursive
+    | inj₁ (noM , noM′) =
+  inj₁
+    (weak-one-step-·₁-indexed-frame-outcomeᵀ
+      noM noM′ M⊑M′ recursive)
+weak-one-step-·₁-runtime-boundaryᵀ
+    okLM okL′M′ L′→ M⊑M′ recursive
+    | inj₂ (vL , noL , okM , noM′)
+    with source-value-indexed-outcome-relatedᵀ vL recursive
+weak-one-step-·₁-runtime-boundaryᵀ
+    okLM okL′M′ L′→ M⊑M′ recursive
+    | inj₂ (vL , noL , okM , noM′)
+    | result , transport , coherence , changes-eq , result-eq =
+  inj₂
+    (result , transport , coherence , changes-eq , result-eq ,
+      vL , noL , okM , noM′)
+
+·₂-blame-tail :
+  ∀ {L M χs} →
+  Value L →
+  No• L →
+  M —↠[ χs ] blame →
+  L · M —↠[ χs ++ keep ∷ [] ] blame
+·₂-blame-tail {χs = χs} vL noL M↠blame =
+  ↠-trans (·₂-↠ vL noL M↠blame)
+    (↠-step
+      (pure-step
+        (blame-·₂ (applyTerms-preserves-Value χs vL)))
+      ↠-refl)
+
+weak-one-step-·₂-indexed-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ M M₁′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L →
+  No• L →
+  Value L′ →
+  No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′
+    ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB →
+  (inner : WeakOneStepIndexedResult
+    {M = M} {N′ = M₁′} {χ = χ} {ρ = ρ} pA) →
+  (transport : WeakOneStepTransport (weakIndexedResult inner)) →
+  (coherence :
+    WeakOneStepTypeCoherence (weakIndexedResult inner)) →
+  WeakOneStepIndexedResult
+    {M = L · M} {N′ = applyTerm χ L′ · M₁′}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-·₂-indexed-frameᵀ
+    {L = L} {L′ = L′} {B = B} {B′ = B′} {χ = χ}
+    vL noL vL′ noL′ L⊑L′ inner transport coherence =
+  weak-indexed-result framed related
+  where
+  base = weakIndexedResult inner
+
+  function-related =
+    weak-result-transport-arrow-termsᵀ
+      base transport coherence noL noL′ L⊑L′
+
+  related = ·⊑·ᵀ function-related (canonicalIndexedResults inner)
+
+  framed :
+    WeakOneStepResult _ (L · _) (applyTerm χ L′ · _) B B′ χ
+  framed =
+    record
+      { sourceChanges = sourceChanges base
+      ; targetTailChanges = targetTailChanges base
+      ; sourceResult =
+          applyTerms (sourceChanges base) L · sourceResult base
+      ; targetResult =
+          applyTerms (targetTailChanges base) (applyTerm χ L′) ·
+            targetResult base
+      ; resultCtx = resultCtx base
+      ; resultLeftCtx = resultLeftCtx base
+      ; resultRightCtx = resultRightCtx base
+      ; sourceCtxResult = sourceCtxResult base
+      ; targetCtxResult = targetCtxResult base
+      ; resultStore = resultStore base
+      ; resultSourceType = applyTys (sourceChanges base) B
+      ; resultTargetType =
+          applyTys (targetTailChanges base) (applyTy χ B′)
+      ; sourceTypeResult = refl
+      ; targetTypeResult = refl
+      ; transportType = transportType base
+      ; transportAllBody = transportAllBody base
+      ; transportRightBody = transportRightBody base
+      ; resultType = transportType base _
+      ; sourceCatchup = ·₂-↠ vL noL (sourceCatchup base)
+      ; targetTail =
+          ·₂-↠
+            (applyTerm-preserves-Value χ vL′)
+            (applyTerm-preserves-No• χ noL′)
+            (targetTail base)
+      ; sourceStoreResult = sourceStoreResult base
+      ; targetStoreResult = targetStoreResult base
+      ; relatedResults = related
+      }
+
+weak-one-step-·₂-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ L L′ M M₁′ A A′ B B′ χ}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Value L →
+  No• L →
+  Value L′ →
+  No• L′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ L ⊑ L′
+    ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB →
+  WeakOneStepIndexedOutcome
+    {M = M} {N′ = M₁′} {χ = χ} {ρ = ρ} pA →
+  WeakOneStepIndexedOutcome
+    {M = L · M} {N′ = applyTerm χ L′ · M₁′}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-·₂-indexed-frame-outcomeᵀ
+    vL noL vL′ noL′ L⊑L′
+    (indexed-outcome-related inner transport coherence) =
+  indexed-outcome-related
+    (weak-one-step-·₂-indexed-frameᵀ
+      vL noL vL′ noL′ L⊑L′ inner transport coherence)
+    (weak-step-transport (transportNo•Terms transport))
+    (weak-step-type-coherence
+      (transportArrowCoherent coherence)
+      (transportAllCoherent coherence))
+weak-one-step-·₂-indexed-frame-outcomeᵀ
+    vL noL vL′ noL′ L⊑L′
+    (indexed-outcome-source-blame source↠) =
+  indexed-outcome-source-blame (·₂-blame-tail vL noL source↠)
+
+weak-outcome-map-source :
+  ∀ {Φ Δᴸ Δᴿ M M₀ N′ A A₀ B χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (frame : WeakOneStepResult ρ M N′ A B χ →
+    WeakOneStepResult ρ M₀ N′ A₀ B χ) →
+  (∀ (result : WeakOneStepResult ρ M N′ A B χ) →
+    WeakOneStepTransport result →
+    WeakOneStepTransport (frame result)) →
+  (∀ (result : WeakOneStepResult ρ M N′ A B χ) →
+    WeakOneStepTypeCoherence result →
+    WeakOneStepTypeCoherence (frame result)) →
+  (∀ {χs} → M —↠[ χs ] blame →
+    ∃[ χs′ ] (M₀ —↠[ χs′ ] blame)) →
+  WeakOneStepOutcome ρ M N′ A B χ →
+  WeakOneStepOutcome ρ M₀ N′ A₀ B χ
+weak-outcome-map-source
+    frame transport-frame coherence-frame blame-frame
+    (outcome-related result transport coherence) =
+  outcome-related
+    (frame result)
+    (transport-frame result transport)
+    (coherence-frame result coherence)
+weak-outcome-map-source
+    frame transport-frame coherence-frame blame-frame
+    (outcome-source-blame source↠)
+    with blame-frame source↠
+weak-outcome-map-source
+    frame transport-frame coherence-frame blame-frame
+    (outcome-source-blame source↠) | χs′ , source₀↠ =
+  outcome-source-blame source₀↠
+
+weak-outcome-map-target-ν :
+  ∀ {Φ Δᴸ Δᴿ M N′ A B C D Aν c χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (frame : WeakOneStepResult ρ M N′ A B χ →
+    WeakOneStepResult ρ M (ν Aν N′ c) C D χ) →
+  (∀ (result : WeakOneStepResult ρ M N′ A B χ) →
+    WeakOneStepTransport result →
+    WeakOneStepTransport (frame result)) →
+  (∀ (result : WeakOneStepResult ρ M N′ A B χ) →
+    WeakOneStepTypeCoherence result →
+    WeakOneStepTypeCoherence (frame result)) →
+  WeakOneStepOutcome ρ M N′ A B χ →
+  WeakOneStepOutcome ρ M (ν Aν N′ c) C D χ
+weak-outcome-map-target-ν
+    frame transport-frame coherence-frame
+    (outcome-related result transport coherence) =
+  outcome-related
+    (frame result)
+    (transport-frame result transport)
+    (coherence-frame result coherence)
+weak-outcome-map-target-ν
+    frame transport-frame coherence-frame
+    (outcome-source-blame source↠) =
+  outcome-source-blame source↠
+
+weak-all-outcome-map-target-ν :
+  ∀ {Φ Δᴸ Δᴿ N M₀ N′ C C′ A B Aν c χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (frame : WeakOneStepAllResult
+      {N = N} {N₁′ = N′} {C = C} {C′ = C′}
+      {χ = χ} {ρ = ρ} q →
+    WeakOneStepResult ρ M₀ (ν Aν N′ c) A B χ) →
+  (∀ (result : WeakOneStepAllResult
+      {N = N} {N₁′ = N′} {C = C} {C′ = C′}
+      {χ = χ} {ρ = ρ} q) →
+    WeakOneStepTransport (weakResult result) →
+    WeakOneStepTransport (frame result)) →
+  (∀ (result : WeakOneStepAllResult
+      {N = N} {N₁′ = N′} {C = C} {C′ = C′}
+      {χ = χ} {ρ = ρ} q) →
+    WeakOneStepTypeCoherence (weakResult result) →
+    WeakOneStepTypeCoherence (frame result)) →
+  (∀ {χs} → N —↠[ χs ] blame →
+    ∃[ χs′ ] (M₀ —↠[ χs′ ] blame)) →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ M₀ (ν Aν N′ c) A B χ
+weak-all-outcome-map-target-ν
+    frame transport-frame coherence-frame blame-frame
+    (all-outcome-related result transport coherence) =
+  outcome-related
+    (frame result)
+    (transport-frame result transport)
+    (coherence-frame result coherence)
+weak-all-outcome-map-target-ν
+    frame transport-frame coherence-frame blame-frame
+    (all-outcome-source-blame source↠)
+    with blame-frame source↠
+weak-all-outcome-map-target-ν
+    frame transport-frame coherence-frame blame-frame
+    (all-outcome-source-blame source↠) | χs′ , source₀↠ =
+  outcome-source-blame source₀↠
+
+weak-one-step-all-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N N′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepAllResult {χ = keep} q
+weak-one-step-all-relatedᵀ result =
+  weak-all-result (weak-one-step-relatedᵀ result) result
+
+left-catchup-all-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Value N × No• N) ⊎ N ≡ blame →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q
+left-catchup-all-relatedᵀ final result =
+  left-all-catchup (weak-one-step-all-relatedᵀ result)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+
+left-catchup-all-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RuntimeOK V →
+  Value V →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = V} {V′ = V′} {ρ = ρ} q
+left-catchup-all-valueᵀ okV vV V⊑V′ =
+  left-catchup-all-relatedᵀ
+    (inj₁ (vV , runtime-value-no• okV vV)) V⊑V′
+
+left-catchup-all-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ blame ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  LeftCatchupAllResult {N = blame} {V′ = V′} {ρ = ρ} q
+left-catchup-all-blameᵀ blame⊑V′ =
+  left-catchup-all-relatedᵀ (inj₂ refl) blame⊑V′
+
+left-catchup-indexed-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ A B p}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Value N × No• N) ⊎ N ≡ blame →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ A ⊑ B ∶ p) →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ} p
+left-catchup-indexed-relatedᵀ final N⊑V′ =
+  left-indexed-catchup
+    (weak-one-step-indexed-relatedᵀ N⊑V′)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+    (weak-one-step-related-transportᵀ N⊑V′)
+    (weak-one-step-related-type-coherenceᵀ N⊑V′)
+
+left-catchup-indexed-prefix-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ A B p}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (final : (Value N × No• N) ⊎ N ≡ blame) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ A ⊑ B ∶ p) →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ [] ⊢ N ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ [] ⊢ V′ ⦂ B →
+  LeftCatchupIndexedResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-prefix-relatedᵀ
+    prefix final N⊑V′ N⊢ V′⊢ =
+  left-catchup-indexed-relatedᵀ final
+    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢)
+
+left-catchup-indexed-source-all-prefix-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C B}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ `∀ C ⊑ B ⊣ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  RuntimeOK V →
+  Value V →
+  No• V′ →
+  (V⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ B ∶ p) →
+  LeftCatchupIndexedResult
+    {N = V} {V′ = V′} {ρ = ρ⁺} p
+left-catchup-indexed-source-all-prefix-valueᵀ
+    prefix okV vV noV′ V⊑V′ =
+  left-catchup-indexed-prefix-relatedᵀ
+    prefix (inj₁ (vV , noV)) V⊑V′ V⊢ V′⊢
+  where
+  noV = runtime-value-no• okV vV
+  V⊢ = term-weaken ≤-refl
+    (leftStoreⁱ-prefix-inclusion prefix) noV
+    (nu-term-imprecision-source-typing V⊑V′)
+  V′⊢ = term-weaken ≤-refl
+    (rightStoreⁱ-prefix-inclusion prefix) noV′
+    (nu-term-imprecision-target-typing V⊑V′)
+
+left-catchup-indexed-all-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (Value N × No• N) ⊎ N ≡ blame →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-all-relatedᵀ final N⊑V′ =
+  left-indexed-all-catchup
+    (weak-one-step-indexed-relatedᵀ N⊑V′)
+    (left-catchup-invariant
+      (left-silent-invariant refl refl) final)
+    (weak-one-step-related-transportᵀ N⊑V′)
+    (weak-one-step-related-type-coherenceᵀ N⊑V′)
+
+left-catchup-indexed-all-prefix-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N V′ C C′ q}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  (prefix : StoreImpPrefix ρ₀ ρ⁺) →
+  (final : (Value N × No• N) ⊎ N ≡ blame) →
+  (N⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴺ N ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ [] ⊢ N ⦂ `∀ C →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ [] ⊢ V′ ⦂ `∀ C′ →
+  LeftCatchupIndexedAllResult
+    {N = N} {V′ = V′} {ρ = ρ⁺} q
+left-catchup-indexed-all-prefix-relatedᵀ
+    prefix final N⊑V′ N⊢ V′⊢ =
+  left-catchup-indexed-all-relatedᵀ final
+    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢)
+
+left-catchup-indexed-all-valueᵀ :
+  ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RuntimeOK V →
+  Value V →
+  (V⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ V ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = V} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-all-valueᵀ okV vV V⊑V′ =
+  left-catchup-indexed-all-relatedᵀ
+    (inj₁ (vV , runtime-value-no• okV vV)) V⊑V′
+
+left-catchup-indexed-all-blameᵀ :
+  ∀ {Φ Δᴸ Δᴿ V′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (blame⊑V′ : Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ blame ⊑ V′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q) →
+  LeftCatchupIndexedAllResult
+    {N = blame} {V′ = V′} {ρ = ρ} q
+left-catchup-indexed-all-blameᵀ blame⊑V′ =
+  left-catchup-indexed-all-relatedᵀ (inj₂ refl) blame⊑V′
+
+weak-one-step-all-outcome-relatedᵀ :
+  ∀ {Φ Δᴸ Δᴿ N N′ C C′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴺ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+  WeakOneStepAllOutcome {χ = keep} q
+weak-one-step-all-outcome-relatedᵀ result =
+  all-outcome-related (weak-one-step-all-relatedᵀ result)
+    (weak-one-step-related-transportᵀ result)
+    (weak-one-step-related-type-coherenceᵀ result)
+
+weak-one-step-matched-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepResult ρ
+    (ν A N s)
+    (ν (applyTy χ A′) N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-ν-frameᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν-frameᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s′↑
+weak-one-step-matched-ν-frameᵀ
+    {A = A} {A′ = A′} {B = B} {B′ = B′}
+    {C = C} {C′ = C′} {s = s} {s′ = s′} {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν (applyTys (sourceChanges inner) A)
+          (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult =
+        ν (applyTys (targetTailChanges inner) (applyTy χ A′))
+          (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s′))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = ν-↠ (sourceCatchup inner)
+    ; targetTail = ν-↠ (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ν⊑νᵀ
+          (⊑-src-wf (transportType inner pA))
+          (⊑-tgt-wf (transportType inner pA))
+          source-reveal target-reveal
+          (transportType inner pA)
+          (⊑-lift∀ᵢ (transportType inner pA))
+          liftρ lift-ctx-[] innerAll
+    }
+  where
+    source-reveal =
+      subst
+        (λ Δ → RevealConversion μᵣ (suc Δ)
+          ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+            ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+          (applyTysUnderTyBinders (sourceChanges inner) C)
+          (⇑ᵗ (applyTys (sourceChanges inner) B)))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μᵣ
+            (suc (applyTyCtxs (sourceChanges inner) _))
+            ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+            (applyCoercionUnderTyBinders (sourceChanges inner) s)
+            (applyTysUnderTyBinders (sourceChanges inner) C)
+            (⇑ᵗ (applyTys (sourceChanges inner) B)))
+          (sym (sourceStoreResult inner)) source↑)
+
+    target-reveal =
+      subst
+        (λ Δ → RevealConversion μᵗ (suc Δ)
+          ((zero , ⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A′))) ∷
+            ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ A′)))
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s′))
+          (applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C′))
+          (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ B′))))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μᵗ
+            (suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _)))
+            ((zero , ⇑ᵗ
+                (applyTys (targetTailChanges inner) (applyTy χ A′))) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A′)))
+            (applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s′))
+            (applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C′))
+            (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ B′))))
+          (sym (targetStoreResult inner)) target↑)
+
+weak-one-step-matched-ν-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q) →
+  WeakOneStepTransport (weakResult all) →
+  WeakOneStepTransport
+    (weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB all)
+weak-one-step-matched-ν-frame-preserves-transportᵀ
+    {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll) transport
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν-frame-preserves-transportᵀ
+    {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll) transport
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      { χs = sourceChanges inner } s↑
+       | apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s′↑
+weak-one-step-matched-ν-frame-preserves-transportᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll) transport
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (s′↑ : RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′)) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q) →
+  WeakOneStepTypeCoherence (weakResult all) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB all)
+weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll) coherence
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    s↑ s′↑ pA pB (weak-all-result inner innerAll) coherence
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s′↑
+weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll) coherence
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+left-silent-matched-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N V′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q) →
+  LeftSilentInvariant (weakResult all) →
+  LeftSilentResult
+    {M = ν A N s} {V′ = ν A′ V′ s′}
+    {A = B} {B = B′} {ρ = ρ}
+left-silent-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    with lift-store-result (resultStore inner)
+left-silent-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+       | apply-reveal-under-ty-binders
+      {χs = keep ∷ []} s′↑
+left-silent-matched-ν-frameᵀ
+    s↑ s′↑ pA pB (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
+  left-silent
+    (weak-one-step-matched-ν-frameᵀ
+      s↑ s′↑ pA pB (weak-all-result inner innerAll))
+    (left-silent-invariant refl refl)
+
+weak-one-step-matched-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepResult ρ
+    (ν ★ N s)
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {s′ = s′} {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν ★ (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult =
+        ν ★ (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s′))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup =
+        subst
+          (λ T → ν ★ N s —↠[ sourceChanges inner ]
+            ν T (sourceResult inner)
+              (applyCoercionUnderTyBinders (sourceChanges inner) s))
+          (applyTys-★ (sourceChanges inner))
+          (ν-↠ (sourceCatchup inner))
+    ; targetTail =
+        subst
+          (λ T → ν ★ N₁′ (applyCoercionUnderTyBinder χ s′)
+            —↠[ targetTailChanges inner ]
+            ν T (targetResult inner)
+              (applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s′)))
+          (applyTys-★ (targetTailChanges inner))
+          (ν-↠ (targetTail inner))
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        νcast⊑νcastᵀ modeᵣ source-seal modeᵗ target-seal
+          source-widen target-widen
+          liftρ lift-ctx-[] innerAll
+    }
+  where
+    source-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μᵣ)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (sourceStoreResult inner)) sealᵣ
+
+    source-widen =
+      subst
+        (λ Δ → instᵈ μᵣ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+            ∶ applyTysUnderTyBinders (sourceChanges inner) C
+              ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μᵣ
+            ∣ suc (applyTyCtxs (sourceChanges inner) _)
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+              ∶ applyTysUnderTyBinders (sourceChanges inner) C
+                ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+          (sym (sourceStoreResult inner)) source⊑)
+
+    target-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μᵗ)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (targetStoreResult inner)) sealᵗ
+
+    target-widen =
+      subst
+        (λ Δ → instᵈ μᵗ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s′)
+            ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                (applyTyUnderTyBinder χ C′)
+              ⊑ ⇑ᵗ
+                  (applyTys (targetTailChanges inner) (applyTy χ B′)))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μᵗ
+            ∣ suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _))
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s′)
+              ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                  (applyTyUnderTyBinder χ C′)
+                ⊑ ⇑ᵗ
+                    (applyTys (targetTailChanges inner) (applyTy χ B′)))
+          (sym (targetStoreResult inner)) target⊑)
+
+weak-one-step-matched-νcast-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q) →
+  WeakOneStepTransport (weakResult all) →
+  WeakOneStepTransport
+    (weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB all)
+weak-one-step-matched-νcast-frame-preserves-transportᵀ
+    {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll) transport
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-frame-preserves-transportᵀ
+    {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll) transport
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll) transport
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (mode′ : CastMode μ′) →
+  (seal★′ : SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s′⊑ : instᵈ μ′ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q) →
+  WeakOneStepTypeCoherence (weakResult all) →
+  WeakOneStepTypeCoherence
+    (weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB all)
+weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll) coherence
+    with lift-store-result (resultStore inner)
+weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll) coherence
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode′ seal★′ s′⊑
+weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll) coherence
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+left-silent-matched-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N V′ s s′ μ μ′ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (all : WeakOneStepAllResult
+    {N = N} {N₁′ = V′} {χ = keep} {ρ = ρ} q) →
+  LeftSilentInvariant (weakResult all) →
+  LeftSilentResult
+    {M = ν ★ N s} {V′ = ν ★ V′ s′}
+    {A = B} {B = B′} {ρ = ρ}
+left-silent-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    with lift-store-result (resultStore inner)
+left-silent-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+       | apply-widen-inst-under-ty-binders
+      {χs = keep ∷ []} mode′ seal★′ s′⊑
+left-silent-matched-νcast-frameᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+    (weak-all-result inner innerAll)
+    (left-silent-invariant refl refl)
+    | ρ′ , liftρ
+    | μᵣ , modeᵣ , sealᵣ , source⊑
+    | μᵗ , modeᵗ , sealᵗ , target⊑ =
+  left-silent
+    (weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB
+      (weak-all-result inner innerAll))
+    (left-silent-invariant refl refl)
+
+weak-one-step-source-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴸ A →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepResult ρ (ν A N s) N₁′ B B′ χ
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    with weak-result-source-all inner
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+weak-one-step-source-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    hA s↑ pB inner
+    | q′ , innerResult | ρ′ , liftρ | μ′ , source↑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν (applyTys (sourceChanges inner) A)
+          (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult = targetResult inner
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = ν-↠ (sourceCatchup inner)
+    ; targetTail = targetTail inner
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ν⊑ᵀ final-wf final-shift-wf source-reveal
+          liftρ lift-left-ctx-[] innerResult
+    }
+  where
+    final-wf =
+      subst
+        (λ Δ → WfTy Δ (applyTys (sourceChanges inner) A))
+        (sym (sourceCtxResult inner))
+        (wfTy-applyTys (sourceChanges inner) hA)
+
+    final-shift-wf =
+      renameᵗ-preserves-WfTy final-wf TyRenameWf-suc
+
+    source-reveal =
+      subst
+        (λ Δ → RevealConversion μ′ (suc Δ)
+          ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+            ⟰ᵗ (leftStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+          (applyTysUnderTyBinders (sourceChanges inner) C)
+          (⇑ᵗ (applyTys (sourceChanges inner) B)))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μ′
+            (suc (applyTyCtxs (sourceChanges inner) _))
+            ((zero , ⇑ᵗ (applyTys (sourceChanges inner) A)) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ (applyTys (sourceChanges inner) A))
+            (applyCoercionUnderTyBinders (sourceChanges inner) s)
+            (applyTysUnderTyBinders (sourceChanges inner) C)
+            (⇑ᵗ (applyTys (sourceChanges inner) B)))
+          (sym (sourceStoreResult inner)) source↑)
+
+weak-one-step-source-ν-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (hA : WfTy Δᴸ A) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-source-ν-frameᵀ hA s↑ pB inner)
+weak-one-step-source-ν-frame-preserves-transportᵀ
+    hA s↑ pB inner transport
+    with weak-result-source-all inner
+weak-one-step-source-ν-frame-preserves-transportᵀ
+    hA s↑ pB inner transport
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-ν-frame-preserves-transportᵀ
+    hA s↑ pB inner transport
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+weak-one-step-source-ν-frame-preserves-transportᵀ
+    hA s↑ pB inner transport
+    | q′ , innerResult | ρ′ , liftρ | μ′ , source↑ =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-source-ν-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (hA : WfTy Δᴸ A) →
+  (s↑ : RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-source-ν-frameᵀ hA s↑ pB inner)
+weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+    hA s↑ pB inner coherence
+    with weak-result-source-all inner
+weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+    hA s↑ pB inner coherence
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+    hA s↑ pB inner coherence
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = sourceChanges inner} s↑
+weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+    hA s↑ pB inner coherence
+    | q′ , innerResult | ρ′ , liftρ | μ′ , source↑ =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-source-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepResult ρ (ν ★ N s) N₁′ B B′ χ
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    with weak-result-source-all inner
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+weak-one-step-source-νcast-frameᵀ
+    {B = B} {B′ = B′} {C = C} {N = N} {s = s} {χ = χ}
+    mode seal★ s⊑ pB inner
+    | q′ , innerResult | ρ′ , liftρ
+    | μ′ , mode′ , seal★′ , source⊑ =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult =
+        ν ★ (sourceResult inner)
+          (applyCoercionUnderTyBinders (sourceChanges inner) s)
+    ; targetResult = targetResult inner
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup =
+        subst
+          (λ T → ν ★ N s —↠[ sourceChanges inner ]
+            ν T (sourceResult inner)
+              (applyCoercionUnderTyBinders (sourceChanges inner) s))
+          (applyTys-★ (sourceChanges inner))
+          (ν-↠ (sourceCatchup inner))
+    ; targetTail = targetTail inner
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        νcast⊑ᵀ mode′ source-seal source-widen
+          liftρ lift-left-ctx-[] innerResult
+    }
+  where
+    source-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μ′)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (sourceStoreResult inner)) seal★′
+
+    source-widen =
+      subst
+        (λ Δ → instᵈ μ′ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+            ∶ applyTysUnderTyBinders (sourceChanges inner) C
+              ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+        (sym (sourceCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μ′
+            ∣ suc (applyTyCtxs (sourceChanges inner) _)
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (sourceChanges inner) s
+              ∶ applyTysUnderTyBinders (sourceChanges inner) C
+                ⊑ ⇑ᵗ (applyTys (sourceChanges inner) B))
+          (sym (sourceStoreResult inner)) source⊑)
+
+weak-one-step-source-νcast-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB inner)
+weak-one-step-source-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ pB inner transport
+    with weak-result-source-all inner
+weak-one-step-source-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ pB inner transport
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ pB inner transport
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+weak-one-step-source-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ pB inner transport
+    | q′ , innerResult | ρ′ , liftρ
+    | μ′ , mode′ , seal★′ , source⊑ =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ (`∀ C) B′ χ) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB inner)
+weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ pB inner coherence
+    with weak-result-source-all inner
+weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ pB inner coherence
+    | q′ , innerResult
+    with lift-left-store-result (resultStore inner)
+weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ pB inner coherence
+    | q′ , innerResult | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = sourceChanges inner} mode seal★ s⊑
+weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ pB inner coherence
+    | q′ , innerResult | ρ′ , liftρ
+    | μ′ , mode′ , seal★′ , source⊑ =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-target-ν-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴿ A →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepResult ρ N
+    (ν (applyTy χ A) N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s↑
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    | ρ′ , liftρ | μ′ , target↑
+    with weak-result-target-all inner
+weak-one-step-target-ν-frameᵀ
+    {A = A} {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    hA s↑ pB pC inner
+    | ρ′ , liftρ | μ′ , target↑ | q′ , innerResult =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult = sourceResult inner
+    ; targetResult =
+        ν (applyTys (targetTailChanges inner) (applyTy χ A))
+          (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = sourceCatchup inner
+    ; targetTail = ν-↠ (targetTail inner)
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ⊑νᵀ final-wf final-shift-wf target-reveal
+          liftρ lift-right-ctx-[]
+          (transportRightBody inner pC) innerResult
+    }
+  where
+    final-wf =
+      subst
+        (λ Δ → WfTy Δ
+          (applyTys (targetTailChanges inner) (applyTy χ A)))
+        (sym (targetCtxResult inner))
+        (wfTy-applyTys
+          (χ ∷ targetTailChanges inner) hA)
+
+    final-shift-wf =
+      renameᵗ-preserves-WfTy final-wf TyRenameWf-suc
+
+    target-reveal =
+      subst
+        (λ Δ → RevealConversion μ′ (suc Δ)
+          ((zero , ⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+            ⟰ᵗ (rightStoreⁱ (resultStore inner)))
+          zero (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ A)))
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s))
+          (applyTysUnderTyBinders (targetTailChanges inner)
+            (applyTyUnderTyBinder χ C′))
+          (⇑ᵗ
+            (applyTys (targetTailChanges inner) (applyTy χ B′))))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → RevealConversion μ′
+            (suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _)))
+            ((zero , ⇑ᵗ
+                (applyTys (targetTailChanges inner) (applyTy χ A))) ∷
+              ⟰ᵗ Σ)
+            zero (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ A)))
+            (applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s))
+            (applyTysUnderTyBinders (targetTailChanges inner)
+              (applyTyUnderTyBinder χ C′))
+            (⇑ᵗ
+              (applyTys (targetTailChanges inner) (applyTy χ B′))))
+          (sym (targetStoreResult inner)) target↑)
+
+weak-one-step-target-ν-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (hA : WfTy Δᴿ A) →
+  (s↑ : RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-target-ν-frameᵀ hA s↑ pB pC inner)
+weak-one-step-target-ν-frame-preserves-transportᵀ
+    {χ = χ}
+    hA s↑ pB pC inner transport
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-ν-frame-preserves-transportᵀ
+    {χ = χ}
+    hA s↑ pB pC inner transport
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s↑
+weak-one-step-target-ν-frame-preserves-transportᵀ
+    hA s↑ pB pC inner transport
+    | ρ′ , liftρ | μ′ , target↑
+    with weak-result-target-all inner
+weak-one-step-target-ν-frame-preserves-transportᵀ
+    hA s↑ pB pC inner transport
+    | ρ′ , liftρ | μ′ , target↑ | q′ , innerResult =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-target-ν-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (hA : WfTy Δᴿ A) →
+  (s↑ : RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′)) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-target-ν-frameᵀ hA s↑ pB pC inner)
+weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    hA s↑ pB pC inner coherence
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    hA s↑ pB pC inner coherence
+    | ρ′ , liftρ
+    with apply-reveal-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} s↑
+weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+    hA s↑ pB pC inner coherence
+    | ρ′ , liftρ | μ′ , target↑
+    with weak-result-target-all inner
+weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+    hA s↑ pB pC inner coherence
+    | ρ′ , liftρ | μ′ , target↑ | q′ , innerResult =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-target-νcast-frameᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepResult ρ N
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode seal★ s⊑
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    with weak-result-target-all inner
+weak-one-step-target-νcast-frameᵀ
+    {B = B} {B′ = B′} {C′ = C′}
+    {N = N} {N₁′ = N₁′} {s = s} {χ = χ}
+    mode seal★ s⊑ pB pC inner
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    | q′ , innerResult =
+  record
+    { sourceChanges = sourceChanges inner
+    ; targetTailChanges = targetTailChanges inner
+    ; sourceResult = sourceResult inner
+    ; targetResult =
+        ν ★ (targetResult inner)
+          (applyCoercionUnderTyBinders (targetTailChanges inner)
+            (applyCoercionUnderTyBinder χ s))
+    ; resultCtx = resultCtx inner
+    ; resultLeftCtx = resultLeftCtx inner
+    ; resultRightCtx = resultRightCtx inner
+    ; sourceCtxResult = sourceCtxResult inner
+    ; targetCtxResult = targetCtxResult inner
+    ; resultStore = resultStore inner
+    ; resultSourceType = applyTys (sourceChanges inner) B
+    ; resultTargetType =
+        applyTys (targetTailChanges inner) (applyTy χ B′)
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = transportType inner
+    ; transportAllBody = transportAllBody inner
+    ; transportRightBody = transportRightBody inner
+    ; resultType = transportType inner pB
+    ; sourceCatchup = sourceCatchup inner
+    ; targetTail =
+        subst
+          (λ T → ν ★ N₁′ (applyCoercionUnderTyBinder χ s)
+            —↠[ targetTailChanges inner ]
+            ν T (targetResult inner)
+              (applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s)))
+          (applyTys-★ (targetTailChanges inner))
+          (ν-↠ (targetTail inner))
+    ; sourceStoreResult = sourceStoreResult inner
+    ; targetStoreResult = targetStoreResult inner
+    ; relatedResults =
+        ⊑νcastᵀ mode′ target-seal target-widen
+          liftρ lift-right-ctx-[]
+          (transportRightBody inner pC) innerResult
+    }
+  where
+    target-seal =
+      subst
+        (λ Σ → SealModeStore★ (instᵈ μ′)
+          ((zero , ★) ∷ ⟰ᵗ Σ))
+        (sym (targetStoreResult inner)) seal★′
+
+    target-widen =
+      subst
+        (λ Δ → instᵈ μ′ ∣ suc Δ
+          ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ (resultStore inner))
+          ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+              (applyCoercionUnderTyBinder χ s)
+            ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                (applyTyUnderTyBinder χ C′)
+              ⊑ ⇑ᵗ
+                  (applyTys (targetTailChanges inner) (applyTy χ B′)))
+        (sym (targetCtxResult inner))
+        (subst
+          (λ Σ → instᵈ μ′
+            ∣ suc (applyTyCtxs (targetTailChanges inner)
+              (applyTyCtx χ _))
+            ∣ (zero , ★) ∷ ⟰ᵗ Σ
+            ⊢ applyCoercionUnderTyBinders (targetTailChanges inner)
+                (applyCoercionUnderTyBinder χ s)
+              ∶ applyTysUnderTyBinders (targetTailChanges inner)
+                  (applyTyUnderTyBinder χ C′)
+                ⊑ ⇑ᵗ
+                    (applyTys (targetTailChanges inner) (applyTy χ B′)))
+          (sym (targetStoreResult inner)) target⊑)
+
+weak-one-step-target-νcast-frame-preserves-transportᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepTransport inner →
+  WeakOneStepTransport
+    (weak-one-step-target-νcast-frameᵀ mode seal★ s⊑ pB pC inner)
+weak-one-step-target-νcast-frame-preserves-transportᵀ
+    {χ = χ}
+    mode seal★ s⊑ pB pC inner transport
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-νcast-frame-preserves-transportᵀ
+    {χ = χ}
+    mode seal★ s⊑ pB pC inner transport
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode seal★ s⊑
+weak-one-step-target-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ pB pC inner transport
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    with weak-result-target-all inner
+weak-one-step-target-νcast-frame-preserves-transportᵀ
+    mode seal★ s⊑ pB pC inner transport
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    | q′ , innerResult =
+  weak-step-transport (transportNo•Terms transport)
+
+weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  (mode : CastMode μ) →
+  (seal★ : SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ))) →
+  (s⊑ : instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  (inner : WeakOneStepResult ρ N N₁′ B (`∀ C′) χ) →
+  WeakOneStepTypeCoherence inner →
+  WeakOneStepTypeCoherence
+    (weak-one-step-target-νcast-frameᵀ mode seal★ s⊑ pB pC inner)
+weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    mode seal★ s⊑ pB pC inner coherence
+    with lift-right-store-result (resultStore inner)
+weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+    {χ = χ}
+    mode seal★ s⊑ pB pC inner coherence
+    | ρ′ , liftρ
+    with apply-widen-inst-under-ty-binders
+      {χs = χ ∷ targetTailChanges inner} mode seal★ s⊑
+weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ pB pC inner coherence
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    with weak-result-target-all inner
+weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+    mode seal★ s⊑ pB pC inner coherence
+    | ρ′ , liftρ | μ′ , mode′ , seal★′ , target⊑
+    | q′ , innerResult =
+  weak-step-type-coherence
+    (transportArrowCoherent coherence)
+    (transportAllCoherent coherence)
+
+weak-one-step-matched-ν-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ
+    (ν A N s)
+    (ν (applyTy χ A′) N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-ν-frame-outcomeᵀ s↑ s′↑ pA pB =
+  weak-all-outcome-map-target-ν
+    (weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB)
+    (weak-one-step-matched-ν-frame-preserves-transportᵀ
+      s↑ s′↑ pA pB)
+    (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+      s↑ s′↑ pA pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-matched-νcast-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepAllOutcome
+    {N = N} {N₁′ = N₁′} {C = C} {C′ = C′}
+    {χ = χ} {ρ = ρ} q →
+  WeakOneStepOutcome ρ
+    (ν ★ N s)
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s′))
+    B B′ χ
+weak-one-step-matched-νcast-frame-outcomeᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB =
+  weak-all-outcome-map-target-ν
+    (weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB)
+    (weak-one-step-matched-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB)
+    (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-matched-ν-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A A′ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion μ′ (suc Δᴿ)
+    ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+  (pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} (∀ⁱ q) →
+  WeakOneStepIndexedOutcome
+    {M = ν A N s}
+    {N′ = ν (applyTy χ A′) N₁′
+      (applyCoercionUnderTyBinder χ s′)}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-matched-ν-indexed-frame-outcomeᵀ
+    s↑ s′↑ pA pB indexed
+    with weak-indexed-all-outcomeᵀ indexed
+weak-one-step-matched-ν-indexed-frame-outcomeᵀ
+    s↑ s′↑ pA pB indexed
+    | all-outcome-related all transport coherence =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-matched-ν-frame-preserves-transportᵀ
+      s↑ s′↑ pA pB all transport)
+    (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+      s↑ s′↑ pA pB all coherence)
+  where
+  framed = weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB all
+weak-one-step-matched-ν-indexed-frame-outcomeᵀ
+    s↑ s′↑ pA pB indexed
+    | all-outcome-source-blame source↠ =
+  indexed-outcome-source-blame (ν-blame-tail source↠)
+
+weak-one-step-matched-νcast-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C C′ N N₁′ s s′ μ μ′ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  CastMode μ′ →
+  SealModeStore★ (instᵈ μ′)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ′ ∣ suc Δᴿ ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s′ ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} (∀ⁱ q) →
+  WeakOneStepIndexedOutcome
+    {M = ν ★ N s}
+    {N′ = ν ★ N₁′ (applyCoercionUnderTyBinder χ s′)}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-matched-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB indexed
+    with weak-indexed-all-outcomeᵀ indexed
+weak-one-step-matched-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB indexed
+    | all-outcome-related all transport coherence =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-matched-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB all transport)
+    (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB all coherence)
+  where
+  framed =
+    weak-one-step-matched-νcast-frameᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ pB all
+weak-one-step-matched-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ mode′ seal★′ s′⊑ pB indexed
+    | all-outcome-source-blame source↠ =
+  indexed-outcome-source-blame (ν-blame-tail source↠)
+
+weak-one-step-source-ν-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴸ A →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ (`∀ C) B′ χ →
+  WeakOneStepOutcome ρ (ν A N s) N₁′ B B′ χ
+weak-one-step-source-ν-frame-outcomeᵀ hA s↑ pB =
+  weak-outcome-map-source
+    (weak-one-step-source-ν-frameᵀ hA s↑ pB)
+    (weak-one-step-source-ν-frame-preserves-transportᵀ hA s↑ pB)
+    (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+      hA s↑ pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-source-νcast-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ (`∀ C) B′ χ →
+  WeakOneStepOutcome ρ (ν ★ N s) N₁′ B B′ χ
+weak-one-step-source-νcast-frame-outcomeᵀ mode seal★ s⊑ pB =
+  weak-outcome-map-source
+    (weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB)
+    (weak-one-step-source-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ pB)
+    (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ pB)
+    (λ N↠ → _ , ν-blame-tail N↠)
+
+weak-one-step-target-ν-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴿ A →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ B (`∀ C′) χ →
+  WeakOneStepOutcome ρ N
+    (ν (applyTy χ A) N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-ν-frame-outcomeᵀ hA s↑ pB pC =
+  weak-outcome-map-target-ν
+    (weak-one-step-target-ν-frameᵀ hA s↑ pB pC)
+    (weak-one-step-target-ν-frame-preserves-transportᵀ hA s↑ pB pC)
+    (weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+      hA s↑ pB pC)
+
+weak-one-step-target-νcast-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  WeakOneStepOutcome ρ N N₁′ B (`∀ C′) χ →
+  WeakOneStepOutcome ρ N
+    (ν ★ N₁′ (applyCoercionUnderTyBinder χ s))
+    B B′ χ
+weak-one-step-target-νcast-frame-outcomeᵀ
+    mode seal★ s⊑ pB pC =
+  weak-outcome-map-target-ν
+    (weak-one-step-target-νcast-frameᵀ
+      mode seal★ s⊑ pB pC)
+    (weak-one-step-target-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ pB pC)
+    (weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ pB pC)
+
+weak-one-step-source-ν-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C N N₁′ s μ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴸ A →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} q →
+  WeakOneStepIndexedOutcome
+    {M = ν A N s} {N′ = N₁′} {χ = χ} {ρ = ρ} pB
+weak-one-step-source-ν-indexed-frame-outcomeᵀ
+    hA s↑ pB
+    (indexed-outcome-related indexed transport coherence) =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-source-ν-frame-preserves-transportᵀ
+      hA s↑ pB inner transport)
+    (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+      hA s↑ pB inner coherence)
+  where
+  inner = weakIndexedResult indexed
+  framed = weak-one-step-source-ν-frameᵀ hA s↑ pB inner
+weak-one-step-source-ν-indexed-frame-outcomeᵀ
+    hA s↑ pB (indexed-outcome-source-blame source↠) =
+  indexed-outcome-source-blame (ν-blame-tail source↠)
+
+weak-one-step-source-νcast-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C N N₁′ s μ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴸ
+    ∣ (zero , ★) ∷ ⟰ᵗ (leftStoreⁱ ρ)
+    ⊢ s ∶ C ⊑ ⇑ᵗ B →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} q →
+  WeakOneStepIndexedOutcome
+    {M = ν ★ N s} {N′ = N₁′} {χ = χ} {ρ = ρ} pB
+weak-one-step-source-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ pB
+    (indexed-outcome-related indexed transport coherence) =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-source-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ pB inner transport)
+    (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ pB inner coherence)
+  where
+  inner = weakIndexedResult indexed
+  framed =
+    weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB inner
+weak-one-step-source-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ pB
+    (indexed-outcome-source-blame source↠) =
+  indexed-outcome-source-blame (ν-blame-tail source↠)
+
+weak-one-step-target-ν-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ A B B′ C′ N N₁′ s μ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  WfTy Δᴿ A →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C′ (⇑ᵗ B′) →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} q →
+  WeakOneStepIndexedOutcome
+    {M = N}
+    {N′ = ν (applyTy χ A) N₁′
+      (applyCoercionUnderTyBinder χ s)}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-target-ν-indexed-frame-outcomeᵀ
+    hA s↑ pB pC
+    (indexed-outcome-related indexed transport coherence) =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-target-ν-frame-preserves-transportᵀ
+      hA s↑ pB pC inner transport)
+    (weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+      hA s↑ pB pC inner coherence)
+  where
+  inner = weakIndexedResult indexed
+  framed = weak-one-step-target-ν-frameᵀ hA s↑ pB pC inner
+weak-one-step-target-ν-indexed-frame-outcomeᵀ
+    hA s↑ pB pC (indexed-outcome-source-blame source↠) =
+  indexed-outcome-source-blame source↠
+
+weak-one-step-target-νcast-indexed-frame-outcomeᵀ :
+  ∀ {Φ Δᴸ Δᴿ B B′ C′ N N₁′ s μ χ q}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} →
+  CastMode μ →
+  SealModeStore★ (instᵈ μ)
+    ((zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)) →
+  instᵈ μ ∣ suc Δᴿ
+    ∣ (zero , ★) ∷ ⟰ᵗ (rightStoreⁱ ρ)
+    ⊢ s ∶ C′ ⊑ ⇑ᵗ B′ →
+  (pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  (pC : ⇑ᴿᵢ Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ suc Δᴿ) →
+  WeakOneStepIndexedOutcome
+    {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} q →
+  WeakOneStepIndexedOutcome
+    {M = N}
+    {N′ = ν ★ N₁′ (applyCoercionUnderTyBinder χ s)}
+    {χ = χ} {ρ = ρ} pB
+weak-one-step-target-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ pB pC
+    (indexed-outcome-related indexed transport coherence) =
+  indexed-outcome-related
+    (weak-indexed-result framed (relatedResults framed))
+    (weak-one-step-target-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ pB pC inner transport)
+    (weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ pB pC inner coherence)
+  where
+  inner = weakIndexedResult indexed
+  framed =
+    weak-one-step-target-νcast-frameᵀ
+      mode seal★ s⊑ pB pC inner
+weak-one-step-target-νcast-indexed-frame-outcomeᵀ
+    mode seal★ s⊑ pB pC
+    (indexed-outcome-source-blame source↠) =
+  indexed-outcome-source-blame source↠
+
+∀-imprecision-source-body-wf :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ `∀ A ⊑ B ⊣ Δᴿ →
+  WfTy (suc Δᴸ) A
+∀-imprecision-source-body-wf p with ⊑-src-wf p
+∀-imprecision-source-body-wf p | wf∀ hA = hA
+
+∀-imprecision-target-body-wf :
+  ∀ {Φ Δᴸ Δᴿ A B} →
+  Φ ∣ Δᴸ ⊢ A ⊑ `∀ B ⊣ Δᴿ →
+  WfTy (suc Δᴿ) B
+∀-imprecision-target-body-wf p with ⊑-tgt-wf p
+∀-imprecision-target-body-wf p | wf∀ hB = hB
+
+swap01ᵢ-agrees-swap01ᵗ : ∀ X → swap01ᵢ X ≡ swap01ᵗ X
+swap01ᵢ-agrees-swap01ᵗ zero = refl
+swap01ᵢ-agrees-swap01ᵗ (suc zero) = refl
+swap01ᵢ-agrees-swap01ᵗ (suc (suc X)) = refl
+
+renameᵗ-swap01ᵢ-agrees-swap01ᵗ :
+  ∀ A → renameᵗ swap01ᵢ A ≡ renameᵗ swap01ᵗ A
+renameᵗ-swap01ᵢ-agrees-swap01ᵗ A =
+  rename-cong swap01ᵢ-agrees-swap01ᵗ A
+
+direct-swap-residualᵖ :
+  ∀ {Φ Δᴸ Δᴿ D E T} →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  renameᵗ swap01ᵗ E ≈∀ T →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ᵖ T ⊣ suc (suc Δᴿ)
+direct-swap-residualᵖ {E = E} D⊑E Eˢ≈T =
+  quotientᵖ ≈∀-refl crossed Eˢ≈T
+  where
+    crossed =
+      subst
+        (λ T → swapRight∀∀ᵢ _ ∣ _ ⊢ _ ⊑ T ⊣ _)
+        (renameᵗ-swap01ᵢ-agrees-swap01ᵗ E)
+        (⊑-swapRight01∀∀ᵢ D⊑E)
+
+reverse-swap-residualᵖ :
+  ∀ {Φ Δᴸ Δᴿ S D E} →
+  S ≈∀ renameᵗ swap01ᵗ D →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  swapRight∀∀ᵢ Φ ∣ suc (suc Δᴸ)
+    ⊢ S ⊑ᵖ E ⊣ suc (suc Δᴿ)
+reverse-swap-residualᵖ {D = D} S≈Dˢ D⊑E =
+  quotientᵖ S≈Dˢ crossed ≈∀-refl
+  where
+    crossed =
+      subst
+        (λ T → swapRight∀∀ᵢ _ ∣ _ ⊢ T ⊑ _ ⊣ _)
+        (renameᵗ-swap01ᵢ-agrees-swap01ᵗ D)
+        (⊑-swapLeft01∀∀ᵢ D⊑E)
+
+direct-swap-residual-outerᵖ :
+  ∀ {Φ Δᴸ Δᴿ D E T} →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  renameᵗ swap01ᵗ E ≈∀ T →
+  Φ ∣ Δᴸ ⊢ `∀ (`∀ D) ⊑ᵖ `∀ (`∀ T) ⊣ Δᴿ
+direct-swap-residual-outerᵖ D⊑E Eˢ≈T =
+  quotientᵖ ≈∀-refl (∀ⁱ (∀ⁱ D⊑E))
+    (≈∀-double-swap Eˢ≈T)
+
+reverse-swap-residual-outerᵖ :
+  ∀ {Φ Δᴸ Δᴿ S D E} →
+  S ≈∀ renameᵗ swap01ᵗ D →
+  ∀ᵢᶜ (∀ᵢᶜ Φ) ∣ suc (suc Δᴸ)
+    ⊢ D ⊑ E ⊣ suc (suc Δᴿ) →
+  Φ ∣ Δᴸ ⊢ `∀ (`∀ S) ⊑ᵖ `∀ (`∀ E) ⊣ Δᴿ
+reverse-swap-residual-outerᵖ S≈Dˢ D⊑E =
+  quotientᵖ (≈∀-double-swap-sym S≈Dˢ)
+    (∀ⁱ (∀ⁱ D⊑E)) ≈∀-refl

--- a/GTSF/proof/NuTermProperties.agda
+++ b/GTSF/proof/NuTermProperties.agda
@@ -151,6 +151,32 @@ renameᵗᵐ-cong {ρ = ρ} {ρ′ = ρ′} eq (M ⟨ c ⟩) =
     (cong (λ c′ → renameᵗᵐ ρ′ M ⟨ c′ ⟩) (renameᶜ-cong eq c))
 renameᵗᵐ-cong eq blame = refl
 
+renameᵗᵐ-id :
+  ∀ M →
+  renameᵗᵐ (λ X → X) M ≡ M
+renameᵗᵐ-id (` x) = refl
+renameᵗᵐ-id (ƛ M) = cong ƛ_ (renameᵗᵐ-id M)
+renameᵗᵐ-id (L · M) = cong₂ _·_ (renameᵗᵐ-id L) (renameᵗᵐ-id M)
+renameᵗᵐ-id (Λ M) =
+  cong Λ_ (trans (renameᵗᵐ-cong extᵗ-id M) (renameᵗᵐ-id M))
+renameᵗᵐ-id (M •) = cong _• (renameᵗᵐ-id M)
+renameᵗᵐ-id (ν A L c) =
+  trans
+    (cong (λ B → ν B (renameᵗᵐ (λ X → X) L)
+                    (renameᶜ (extᵗ (λ X → X)) c))
+      (renameᵗ-id A))
+    (trans
+      (cong (λ M → ν A M (renameᶜ (extᵗ (λ X → X)) c))
+        (renameᵗᵐ-id L))
+      (cong (ν A L)
+        (trans (renameᶜ-cong extᵗ-id c) (renameᶜ-id c))))
+renameᵗᵐ-id ($ κ) = refl
+renameᵗᵐ-id (L ⊕[ op ] M) =
+  cong₂ _⊕[ op ]_ (renameᵗᵐ-id L) (renameᵗᵐ-id M)
+renameᵗᵐ-id (M ⟨ c ⟩) =
+  cong₂ _⟨_⟩ (renameᵗᵐ-id M) (renameᶜ-id c)
+renameᵗᵐ-id blame = refl
+
 renameᵗᵐ-compose :
   ∀ ρ τ M →
   renameᵗᵐ τ (renameᵗᵐ ρ M) ≡

--- a/GTSF/proof/QuotientedTermImprecisionTest.agda
+++ b/GTSF/proof/QuotientedTermImprecisionTest.agda
@@ -45,4 +45,4 @@ cast-via-D⊑cast-via-E =
   up⊑upᵀ
     (down⊑downᵀ down-D-⊒ down-E-⊒ blame-A⊑blame-A
       glb-lower-XY⊑ᵖYX)
-    up-D-⊑ up-E-⊑ glb-bad-B⊑B
+    (quotient-id-widening up-D-⊑ up-E-⊑) glb-bad-B⊑B

--- a/GTSF/proof/TypeProperties.agda
+++ b/GTSF/proof/TypeProperties.agda
@@ -3,7 +3,8 @@ module proof.TypeProperties where
 -- File Charter:
 --   * Proof-only metatheory for GTSF type operations.
 --   * Well-formedness preservation, occurrence bookkeeping for type binders,
---     and store-renaming equalities used by coercion and term preservation.
+--     type-context permutations, and store-renaming equalities used by
+--     coercion and term preservation.
 --   * No coercion-specific or term-typing lemmas live here.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
@@ -276,6 +277,64 @@ TyRenameWf-suc :
   ∀ {Δ} →
   TyRenameWf Δ (suc Δ) suc
 TyRenameWf-suc X<Δ = s<s X<Δ
+
+record TyPermutation (Δ Δ′ : TyCtx) : Set where
+  constructor ty-permutation
+  field
+    forward : Renameᵗ
+    backward : Renameᵗ
+    forward-wf : TyRenameWf Δ Δ′ forward
+    backward-wf : TyRenameWf Δ′ Δ backward
+    backward-forward : RenameLeftInverse forward backward
+    forward-backward : RenameLeftInverse backward forward
+
+open TyPermutation public
+
+TyPermutation-id : ∀ Δ → TyPermutation Δ Δ
+TyPermutation-id Δ =
+  ty-permutation (λ X → X) (λ X → X)
+    (λ X<Δ → X<Δ) (λ X<Δ → X<Δ) (λ X → refl) (λ X → refl)
+
+TyPermutation-sym :
+  ∀ {Δ Δ′} → TyPermutation Δ Δ′ → TyPermutation Δ′ Δ
+TyPermutation-sym π =
+  ty-permutation (backward π) (forward π)
+    (backward-wf π) (forward-wf π)
+    (forward-backward π) (backward-forward π)
+
+TyPermutation-ext :
+  ∀ {Δ Δ′} → TyPermutation Δ Δ′ →
+  TyPermutation (suc Δ) (suc Δ′)
+TyPermutation-ext π =
+  ty-permutation (extᵗ (forward π)) (extᵗ (backward π))
+    (TyRenameWf-ext (forward-wf π))
+    (TyRenameWf-ext (backward-wf π))
+    (RenameLeftInverse-ext (backward-forward π))
+    (RenameLeftInverse-ext (forward-backward π))
+
+TyPermutation-compose :
+  ∀ {Δ Θ Ω} →
+  TyPermutation Δ Θ → TyPermutation Θ Ω → TyPermutation Δ Ω
+TyPermutation-compose π υ =
+  ty-permutation
+    (λ X → forward υ (forward π X))
+    (λ X → backward π (backward υ X))
+    (λ X<Δ → forward-wf υ (forward-wf π X<Δ))
+    (λ X<Ω → backward-wf π (backward-wf υ X<Ω))
+    backward-forward′
+    forward-backward′
+  where
+  backward-forward′ : ∀ X → _ ≡ X
+  backward-forward′ X =
+    trans
+      (cong (backward π) (backward-forward υ (forward π X)))
+      (backward-forward π X)
+
+  forward-backward′ : ∀ X → _ ≡ X
+  forward-backward′ X =
+    trans
+      (cong (forward υ) (forward-backward π (backward υ X)))
+      (forward-backward υ X)
 
 TyRenameWf-suc-≤ :
   ∀ {Δ Δ′} →


### PR DESCRIPTION
## Summary

- refines quotiented term imprecision and its polymorphic permutation infrastructure;
- splits the large ν-imprecision simulation proof into stable core and allocation-support modules so Agda can cache completed work;
- adds catch-up composition support and a focused active dispatcher scratch module;
- promotes the completed quotient value-shaped proof from scratch into `proof/NuImprecisionQuotientValue.agda`;
- develops matched, one-sided, crossed, and prefix-based allocation transport for `ν`, `Λ`, `gen`/`inst`, and type instantiation;
- updates the DGG progress log with the current proof boundaries and remaining obligations.

## Proof status

`NuImprecisionQuotientValue.agda` is hole-free. The active `NuImprecisionCatchupScratch.agda` intentionally retains ten dispatcher obligations; this is a proof-under-construction PR, so the module permits unsolved metas.

Unrelated pre-existing untracked GTSF papers, interpreter experiments, and `ignore/` files are not included.

## Validation

- `agda -v0 proof/NuImprecisionQuotientValue.agda`
- `agda -v0 All.agda`
- `git diff --cached --check`