### PR TITLE
Flatten GTSF weak simulation result carriers

### DIFF
--- a/GTSF/proof/NuDGGTerminalBackwardBlameAssembly.agda
+++ b/GTSF/proof/NuDGGTerminalBackwardBlameAssembly.agda
@@ -169,12 +169,12 @@ backward-target-blame-general-from-componentsᵀ
       source-blame-changes , source-blame
   go (suc fuel) wfL wfR okM okM′ M⊑M′
       (χ ∷ ψs) (↠-step target-step target-rest) bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     with weak-result-target-prefix-blameᵀ
       (weakIndexedResult indexed) target-rest
   go (suc fuel) wfL wfR okM okM′ M⊑M′
       (χ ∷ ψs) (↠-step target-step target-rest) bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     | residual-changes , target-result↠blame , trace-eq
     with go fuel
       (weak-result-source-store-wf
@@ -203,7 +203,7 @@ backward-target-blame-general-from-componentsᵀ
           bound))
   go (suc fuel) wfL wfR okM okM′ M⊑M′
       (χ ∷ ψs) (↠-step target-step target-rest) bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     | residual-changes , target-result↠blame , trace-eq
     | result-blame-changes , source-result↠blame =
       sourceChanges (weakIndexedResult indexed) ++ result-blame-changes ,

--- a/GTSF/proof/NuDGGTerminalBackwardValueProof.agda
+++ b/GTSF/proof/NuDGGTerminalBackwardValueProof.agda
@@ -344,12 +344,12 @@ backward-target-value-or-source-blame-proofᵀ
       inj₂ (source-blame-changes , source-blame)
   go (suc fuel) wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     with weak-result-target-prefix-valueᵀ
       (weakIndexedResult indexed) target-rest vV′
   go (suc fuel) wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     | residual-changes , target-result↠V′ , trace-eq
     with go fuel
       (weak-result-source-store-wf
@@ -378,7 +378,7 @@ backward-target-value-or-source-blame-proofᵀ
           bound))
   go (suc fuel) wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     | residual-changes , target-result↠V′ , trace-eq
     | inj₂ (result-blame-changes , source-result↠blame) =
       inj₂
@@ -387,7 +387,7 @@ backward-target-value-or-source-blame-proofᵀ
                  source-result↠blame)
   go (suc fuel) wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
-    | indexed-outcome-related indexed transport coherence
+    | indexed-outcome-related indexed
     | residual-changes , target-result↠V′ , trace-eq
     | inj₁ (V , result-source-changes , Ψ , ρ′ , q ,
         source-result↠V , vV , left-store-eq , right-store-eq , V⊑V′) =

--- a/GTSF/proof/NuDGGTerminalBackwardValueWorldCoherentProof.agda
+++ b/GTSF/proof/NuDGGTerminalBackwardValueWorldCoherentProof.agda
@@ -206,15 +206,13 @@ world-coherent-backward-target-value-or-source-blame-proofᵀ
   go (suc fuel) coherent exclusive wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
     | world-indexed-outcome-related
-        indexed transport type-coherence
-        successor-coherent successor-exclusive
+        indexed successor-coherent successor-exclusive
     with weak-result-target-prefix-valueᵀ
       (weakIndexedResult indexed) target-rest vV′
   go (suc fuel) coherent exclusive wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
     | world-indexed-outcome-related
-        indexed transport type-coherence
-        successor-coherent successor-exclusive
+        indexed successor-coherent successor-exclusive
     | residual-changes , target-result↠V′ , trace-eq
     with go fuel successor-coherent successor-exclusive
       (weak-result-source-store-wf
@@ -244,8 +242,7 @@ world-coherent-backward-target-value-or-source-blame-proofᵀ
   go (suc fuel) coherent exclusive wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
     | world-indexed-outcome-related
-        indexed transport type-coherence
-        successor-coherent successor-exclusive
+        indexed successor-coherent successor-exclusive
     | residual-changes , target-result↠V′ , trace-eq
     | inj₂ (result-blame-changes , source-result↠blame) =
       inj₂
@@ -257,8 +254,7 @@ world-coherent-backward-target-value-or-source-blame-proofᵀ
   go (suc fuel) coherent exclusive wfL wfR okM okM′ M⊑M′ V′
       (χ ∷ ψs) (↠-step target-step target-rest) vV′ bound
     | world-indexed-outcome-related
-        indexed transport type-coherence
-        successor-coherent successor-exclusive
+        indexed successor-coherent successor-exclusive
     | residual-changes , target-result↠V′ , trace-eq
     | inj₁ (V , result-source-changes , Ψ , ρ′ , q ,
         source-result↠V , vV , left-store-eq , right-store-eq , V⊑V′) =

--- a/GTSF/proof/NuImprecisionAllocationSimulation.agda
+++ b/GTSF/proof/NuImprecisionAllocationSimulation.agda
@@ -668,7 +668,7 @@ weak-one-step-matched-ν↑-value-catchup-transportᵀ
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant
         (left-silent-invariant refl refl) final))
-    vW noW inner-transport =
+    vW noW transport =
   weak-one-step-prepend-left-silent-preserves-transportᵀ
     (left-silent
       (weak-one-step-matched-ν-frameᵀ
@@ -680,7 +680,7 @@ weak-one-step-matched-ν↑-value-catchup-transportᵀ
       (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
     (weak-one-step-matched-ν-frame-preserves-transportᵀ
       s↑ s′↑ pA pB (weak-all-result inner innerAll)
-      inner-transport)
+      transport)
     (weak-one-step-matched-ν↑-transportᵀ
       vW noW vV′ noV′ source↑ target↑
       (transportType inner pB)
@@ -719,7 +719,7 @@ weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant
         (left-silent-invariant refl refl) final))
-    vW noW inner-coherence =
+    vW noW coherence =
   weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
     (left-silent
       (weak-one-step-matched-ν-frameᵀ
@@ -731,7 +731,7 @@ weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ
       (⊑-lift∀ᵢ (transportType inner pA)) liftρ₀ innerAll)
     (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
       s↑ s′↑ pA pB (weak-all-result inner innerAll)
-      inner-coherence)
+      coherence)
     (weak-one-step-matched-ν↑-type-coherenceᵀ
       vW noW vV′ noV′ source↑ target↑
       (transportType inner pB)
@@ -849,7 +849,7 @@ weak-one-step-matched-ν↑-blame-catchup-transportᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport
+    refl transport
     with silent
 weak-one-step-matched-ν↑-blame-catchup-transportᵀ
     {A = A} {A′ = A′} {B = B} {B′ = B′}
@@ -857,13 +857,13 @@ weak-one-step-matched-ν↑-blame-catchup-transportᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport | left-silent-invariant refl refl
+    refl transport | left-silent-invariant refl refl
     with lift-store-result (resultStore inner)
 weak-one-step-matched-ν↑-blame-catchup-transportᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport | left-silent-invariant refl refl
+    refl transport | left-silent-invariant refl refl
     | ρ′ , liftρ
     with apply-reveal-under-ty-binders
       {χs = sourceChanges inner} s↑
@@ -875,7 +875,7 @@ weak-one-step-matched-ν↑-blame-catchup-transportᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport | left-silent-invariant refl refl
+    refl transport | left-silent-invariant refl refl
     | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
   let
     first = weak-one-step-matched-ν-frameᵀ
@@ -904,7 +904,7 @@ weak-one-step-matched-ν↑-blame-catchup-transportᵀ
     second
     (weak-one-step-matched-ν-frame-preserves-transportᵀ
       s↑ s′↑ pA pB (weak-all-result inner innerAll)
-      inner-transport)
+      transport)
     (weak-one-step-source-blame-right-allocation-transportᵀ
       {A = applyTys (sourceChanges inner) A}
       {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
@@ -949,7 +949,7 @@ weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence
+    refl coherence
     with silent
 weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
     {A = A} {A′ = A′} {B = B} {B′ = B′}
@@ -957,13 +957,13 @@ weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence | left-silent-invariant refl refl
+    refl coherence | left-silent-invariant refl refl
     with lift-store-result (resultStore inner)
 weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence | left-silent-invariant refl refl
+    refl coherence | left-silent-invariant refl refl
     | ρ′ , liftρ
     with apply-reveal-under-ty-binders
       {χs = sourceChanges inner} s↑
@@ -975,7 +975,7 @@ weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence | left-silent-invariant refl refl
+    refl coherence | left-silent-invariant refl refl
     | ρ′ , liftρ | μᵣ , source↑ | μᵗ , target↑ =
   let
     first = weak-one-step-matched-ν-frameᵀ
@@ -1004,7 +1004,7 @@ weak-one-step-matched-ν↑-blame-catchup-type-coherenceᵀ
     second
     (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
       s↑ s′↑ pA pB (weak-all-result inner innerAll)
-      inner-coherence)
+      coherence)
     (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
       {A = applyTys (sourceChanges inner) A}
       {A′ = applyTys (targetTailChanges inner) (applyTy keep A′)}
@@ -1153,8 +1153,7 @@ weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     with final
 weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
     {A = A} {A′ = A′} {B = B} {B′ = B′}
@@ -1162,15 +1161,13 @@ weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     | inj₁ (vW , noW) =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result type-eq)
-    transport coherence
+    (weak-one-step-index-resultᵀ result type-eq transport coherence)
   where
   old-catchup = left-all-catchup
-    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (weak-indexed-all-resultᵀ indexed)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
 
@@ -1204,27 +1201,25 @@ weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
   transport =
     weak-one-step-matched-ν↑-value-catchup-transportᵀ
       s↑ s′↑ pA pB vV′ noV′ old-catchup vW noW
-      inner-transport
+      (weakIndexedTransport indexed)
 
   coherence =
     weak-one-step-matched-ν↑-value-catchup-type-coherenceᵀ
       s↑ s′↑ pA pB vV′ noV′ old-catchup vW noW
-      inner-coherence
+      (weakIndexedTypeCoherence indexed)
 weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
     {A = A} {A′ = A′} {B = B} {B′ = B′}
     {s = s} {s′ = s′}
     wfΣ′ s↑ s′↑ pA pB vV′ noV′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     | inj₂ refl =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result type-eq)
-    transport coherence
+    (weak-one-step-index-resultᵀ result type-eq transport coherence)
   where
   old-catchup = left-all-catchup
-    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (weak-indexed-all-resultᵀ indexed)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
 
@@ -1267,7 +1262,7 @@ weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
       (left-silent first (left-silent-invariant refl refl)) second
       (weak-one-step-matched-ν-frame-preserves-transportᵀ
         s↑ s′↑ pA pB (catchupAllResult old-catchup)
-        inner-transport)
+        (weakIndexedTransport indexed))
       (weak-one-step-source-blame-right-allocation-transportᵀ
         {A = applyTys (sourceChanges inner) A}
         {A′ = applyTys (targetTailChanges inner)
@@ -1291,7 +1286,7 @@ weak-one-step-matched-ν↑-indexed-catchup-outcomeᵀ
       (left-silent first (left-silent-invariant refl refl)) second
       (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
         s↑ s′↑ pA pB (catchupAllResult old-catchup)
-        inner-coherence)
+        (weakIndexedTypeCoherence indexed))
       (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
         {A = applyTys (sourceChanges inner) A}
         {A′ = applyTys (targetTailChanges inner)
@@ -1688,7 +1683,7 @@ weak-one-step-matched-νcast-value-catchup-transportᵀ
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant
         (left-silent-invariant refl refl) final))
-    vW noW inner-transport =
+    vW noW transport =
   weak-one-step-prepend-left-silent-preserves-transportᵀ
     (left-silent
       (weak-one-step-matched-νcast-frameᵀ
@@ -1701,7 +1696,7 @@ weak-one-step-matched-νcast-value-catchup-transportᵀ
       (transportType inner pB) liftρ₀ innerAll)
     (weak-one-step-matched-νcast-frame-preserves-transportᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-      (weak-all-result inner innerAll) inner-transport)
+      (weak-all-result inner innerAll) transport)
     (weak-one-step-matched-νcast-transportᵀ
       vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
       source⊑ target⊑ transported-compat
@@ -1759,7 +1754,7 @@ weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant
         (left-silent-invariant refl refl) final))
-    vW noW inner-coherence =
+    vW noW coherence =
   weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
     (left-silent
       (weak-one-step-matched-νcast-frameᵀ
@@ -1772,7 +1767,7 @@ weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ
       (transportType inner pB) liftρ₀ innerAll)
     (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-      (weak-all-result inner innerAll) inner-coherence)
+      (weak-all-result inner innerAll) coherence)
     (weak-one-step-matched-νcast-type-coherenceᵀ
       vW noW vV′ noV′ modeˢ sealˢ modeᵗ′ sealᵗ′
       source⊑ target⊑ transported-compat
@@ -1907,19 +1902,19 @@ weak-one-step-matched-νcast-blame-catchup-transportᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport
+    refl transport
     with silent
 weak-one-step-matched-νcast-blame-catchup-transportᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport | left-silent-invariant refl refl
+    refl transport | left-silent-invariant refl refl
     with lift-store-result (resultStore inner)
 weak-one-step-matched-νcast-blame-catchup-transportᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport | left-silent-invariant refl refl
+    refl transport | left-silent-invariant refl refl
     | ρ′ , liftρ
     with apply-widen-inst-under-ty-binders
       {χs = sourceChanges inner} mode seal★ s⊑
@@ -1930,7 +1925,7 @@ weak-one-step-matched-νcast-blame-catchup-transportᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-transport | left-silent-invariant refl refl
+    refl transport | left-silent-invariant refl refl
     | ρ′ , liftρ
     | μᵣ , modeᵣ , sealᵣ , source⊑
     | μᵗ , modeᵗ , sealᵗ , target⊑ =
@@ -1959,7 +1954,7 @@ weak-one-step-matched-νcast-blame-catchup-transportᵀ
     second
     (weak-one-step-matched-νcast-frame-preserves-transportᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-      (weak-all-result inner innerAll) inner-transport)
+      (weak-all-result inner innerAll) transport)
     (weak-one-step-source-blame-right-allocation-transportᵀ
       {A = ★} {A′ = ★}
       {B = applyTys (sourceChanges inner) B}
@@ -2008,19 +2003,19 @@ weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence
+    refl coherence
     with silent
 weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence | left-silent-invariant refl refl
+    refl coherence | left-silent-invariant refl refl
     with lift-store-result (resultStore inner)
 weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence | left-silent-invariant refl refl
+    refl coherence | left-silent-invariant refl refl
     | ρ′ , liftρ
     with apply-widen-inst-under-ty-binders
       {χs = sourceChanges inner} mode seal★ s⊑
@@ -2031,7 +2026,7 @@ weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB vV′ noV′
     (left-all-catchup (weak-all-result inner innerAll)
       (left-catchup-invariant silent final))
-    refl inner-coherence | left-silent-invariant refl refl
+    refl coherence | left-silent-invariant refl refl
     | ρ′ , liftρ
     | μᵣ , modeᵣ , sealᵣ , source⊑
     | μᵗ , modeᵗ , sealᵗ , target⊑ =
@@ -2060,7 +2055,7 @@ weak-one-step-matched-νcast-blame-catchup-type-coherenceᵀ
     second
     (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-      (weak-all-result inner innerAll) inner-coherence)
+      (weak-all-result inner innerAll) coherence)
     (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
       {A = ★} {A′ = ★}
       {B = applyTys (sourceChanges inner) B}
@@ -2245,8 +2240,7 @@ weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
     vV′ noV′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     with final
 weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
     {B = B} {B′ = B′} {s = s} {s′ = s′}
@@ -2254,15 +2248,13 @@ weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
     vV′ noV′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     | inj₁ (vW , noW) =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result type-eq)
-    transport coherence
+    (weak-one-step-index-resultᵀ result type-eq transport coherence)
   where
   old-catchup = left-all-catchup
-    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (weak-indexed-all-resultᵀ indexed)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
 
@@ -2308,27 +2300,25 @@ weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
   transport =
     weak-one-step-matched-νcast-value-catchup-transportᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-      vV′ noV′ old-catchup vW noW inner-transport
+      vV′ noV′ old-catchup vW noW (weakIndexedTransport indexed)
 
   coherence =
     weak-one-step-matched-νcast-value-catchup-type-coherenceᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-      vV′ noV′ old-catchup vW noW inner-coherence
+      vV′ noV′ old-catchup vW noW (weakIndexedTypeCoherence indexed)
 weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
     {B = B} {B′ = B′} {s = s} {s′ = s′}
     wfΣ′ mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
     vV′ noV′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     | inj₂ refl =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result type-eq)
-    transport coherence
+    (weak-one-step-index-resultᵀ result type-eq transport coherence)
   where
   old-catchup = left-all-catchup
-    (weak-indexed-all-resultᵀ indexed inner-coherence)
+    (weak-indexed-all-resultᵀ indexed)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
 
@@ -2369,7 +2359,7 @@ weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
       (left-silent first (left-silent-invariant refl refl)) second
       (weak-one-step-matched-νcast-frame-preserves-transportᵀ
         mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-        (catchupAllResult old-catchup) inner-transport)
+        (catchupAllResult old-catchup) (weakIndexedTransport indexed))
       (weak-one-step-source-blame-right-allocation-transportᵀ
         {A = ★} {A′ = ★}
         {B = applyTys (sourceChanges inner) B}
@@ -2389,7 +2379,7 @@ weak-one-step-matched-νcast-indexed-catchup-outcomeᵀ
       (left-silent first (left-silent-invariant refl refl)) second
       (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
         mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB
-        (catchupAllResult old-catchup) inner-coherence)
+        (catchupAllResult old-catchup) (weakIndexedTypeCoherence indexed))
       (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
         {A = ★} {A′ = ★}
         {B = applyTys (sourceChanges inner) B}
@@ -2897,11 +2887,11 @@ weak-one-step-source-blame-right-allocation-indexed-outcomeᵀ
     {V′ = V′} {s = s} {s′ = s′} {ρ = ρ}
     wfΣ′ vV′ noV′ h⇑A′ target⊢ pB =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result refl)
-    (weak-one-step-source-blame-right-allocation-transportᵀ
-      {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
-    (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
-      {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
+    (weak-one-step-index-resultᵀ result refl
+      (weak-one-step-source-blame-right-allocation-transportᵀ
+        {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB)
+      (weak-one-step-source-blame-right-allocation-type-coherenceᵀ
+        {ρ = ρ} wfΣ′ vV′ noV′ h⇑A′ target⊢ pB))
   where
   result = weak-one-step-source-blame-right-allocationᵀ
     {A = A} {A′ = A′} {B = B} {B′ = B′}
@@ -2929,11 +2919,11 @@ weak-one-step-right-ν↑-indexed-outcomeᵀ :
 weak-one-step-right-ν↑-indexed-outcomeᵀ
     vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′ =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result refl)
-    (weak-one-step-right-ν↑-transportᵀ
-      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
-    (weak-one-step-right-ν↑-type-coherenceᵀ
-      vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
+    (weak-one-step-index-resultᵀ result refl
+      (weak-one-step-right-ν↑-transportᵀ
+        vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′)
+      (weak-one-step-right-ν↑-type-coherenceᵀ
+        vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′))
   where
   result = weak-one-step-right-ν↑ᵀ
     vN′ noN′ h⇑A s′↑ pB pC liftρ N⊑N′
@@ -2961,11 +2951,11 @@ weak-one-step-right-νcast-indexed-outcomeᵀ :
 weak-one-step-right-νcast-indexed-outcomeᵀ
     vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′ =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result refl)
-    (weak-one-step-right-νcast-transportᵀ
-      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
-    (weak-one-step-right-νcast-type-coherenceᵀ
-      vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
+    (weak-one-step-index-resultᵀ result refl
+      (weak-one-step-right-νcast-transportᵀ
+        vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′)
+      (weak-one-step-right-νcast-type-coherenceᵀ
+        vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′))
   where
   result = weak-one-step-right-νcastᵀ
     vN′ noN′ mode seal★ s⊑ pB pC liftρ N⊑N′

--- a/GTSF/proof/NuImprecisionCatchupComposition.agda
+++ b/GTSF/proof/NuImprecisionCatchupComposition.agda
@@ -164,16 +164,15 @@ left-catchup-indexed-prepend-keepᵀ :
 left-catchup-indexed-prepend-keepᵀ source→
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      second-transport second-coherence) =
+        (left-silent-invariant refl refl) final)) =
   left-indexed-catchup
-    (weak-indexed-result combined (canonicalIndexedResults indexed))
+    (weak-indexed-result combined (canonicalIndexedResults indexed)
+      (weak-one-step-prepend-source-keep-transportᵀ
+        source→ second (weakIndexedTransport indexed))
+      (weak-one-step-prepend-source-keep-type-coherenceᵀ
+        source→ second (weakIndexedTypeCoherence indexed)))
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
-    (weak-one-step-prepend-source-keep-transportᵀ
-      source→ second second-transport)
-    (weak-one-step-prepend-source-keep-type-coherenceᵀ
-      source→ second second-coherence)
   where
   second = weakIndexedResult indexed
   combined = weak-one-step-prepend-source-keepᵀ source→ second
@@ -191,16 +190,15 @@ left-catchup-indexed-all-prepend-keepᵀ :
 left-catchup-indexed-all-prepend-keepᵀ source→ N⊑V′
     (left-indexed-all-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      second-transport second-coherence) =
+        (left-silent-invariant refl refl) final)) =
   left-indexed-all-catchup
-    (weak-indexed-result combined (canonicalIndexedResults indexed))
+    (weak-indexed-result combined (canonicalIndexedResults indexed)
+      (weak-one-step-prepend-source-keep-transportᵀ
+        source→ second (weakIndexedTransport indexed))
+      (weak-one-step-prepend-source-keep-type-coherenceᵀ
+        source→ second (weakIndexedTypeCoherence indexed)))
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
-    (weak-one-step-prepend-source-keep-transportᵀ
-      source→ second second-transport)
-    (weak-one-step-prepend-source-keep-type-coherenceᵀ
-      source→ second second-coherence)
   where
   second = weakIndexedResult indexed
   combined = weak-one-step-prepend-source-keepᵀ source→ second

--- a/GTSF/proof/NuImprecisionCatchupPrefixSupport.agda
+++ b/GTSF/proof/NuImprecisionCatchupPrefixSupport.agda
@@ -74,16 +74,15 @@ left-catchup-indexed-resume-silentᵀ
     {A = A} {B = B} {p = p}
     (left-silent-indexed first-indexed
       (left-silent-invariant refl refl)
-      first-runtime first-transport first-coherence)
+      first-runtime)
     (left-indexed-catchup second-indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      second-transport second-coherence) =
+        (left-silent-invariant refl refl) final)) =
   left-indexed-catchup
-    (weak-indexed-result combined canonical)
+    (weak-indexed-result combined canonical
+      combined-transport combined-coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
-    combined-transport combined-coherence
   where
   first-raw = weakIndexedResult first-indexed
 
@@ -93,12 +92,12 @@ left-catchup-indexed-resume-silentᵀ
   first-transport′ =
     weak-one-step-reindex-preserves-transportᵀ
       first-raw refl refl (canonicalIndexedResults first-indexed)
-      first-transport
+      (weakIndexedTransport first-indexed)
 
   first-coherence′ =
     weak-one-step-reindex-preserves-type-coherenceᵀ
       first-raw refl refl (canonicalIndexedResults first-indexed)
-      first-coherence
+      (weakIndexedTypeCoherence first-indexed)
 
   second = weakIndexedResult second-indexed
 
@@ -147,7 +146,7 @@ left-catchup-indexed-resume-silentᵀ
   raw-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
       (left-silent first (left-silent-invariant refl refl)) second
-      first-transport′ second-transport
+      first-transport′ (weakIndexedTransport second-indexed)
 
   combined-transport =
     weak-one-step-reindex-preserves-transportᵀ
@@ -156,7 +155,7 @@ left-catchup-indexed-resume-silentᵀ
   raw-coherence =
     weak-one-step-prepend-left-silent-preserves-type-coherenceᵀ
       (left-silent first (left-silent-invariant refl refl)) second
-      first-coherence′ second-coherence
+      first-coherence′ (weakIndexedTypeCoherence second-indexed)
 
   combined-coherence =
     weak-one-step-reindex-preserves-type-coherenceᵀ
@@ -182,12 +181,10 @@ left-catchup-indexed-target-frameᵀ :
     {N = M} {V′ = W′} {ρ = ρ} q
 left-catchup-indexed-target-frameᵀ
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent first-transport first-coherence =
   left-indexed-catchup framed
     (left-catchup-invariant first-silent final)
-    first-transport first-coherence
 
 left-catchup-indexed-prefix-target-narrow-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ}
@@ -208,13 +205,13 @@ left-catchup-indexed-prefix-target-narrow-castᵀ
     catchup@(left-indexed-catchup indexed
       (left-catchup-invariant
         (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence) =
+      ) =
   left-catchup-indexed-target-frameᵀ
     catchup framed refl (left-silent-invariant refl refl)
     (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -245,6 +242,10 @@ left-catchup-indexed-prefix-target-narrow-castᵀ
     inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-prefix-target-reveal-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ β X′}
@@ -264,13 +265,13 @@ left-catchup-indexed-prefix-target-reveal-castᵀ
     catchup@(left-indexed-catchup indexed
       (left-catchup-invariant
         (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence) =
+      ) =
   left-catchup-indexed-target-frameᵀ
     catchup framed refl (left-silent-invariant refl refl)
     (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -294,6 +295,10 @@ left-catchup-indexed-prefix-target-reveal-castᵀ
     inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-prefix-target-conceal-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ β X′}
@@ -313,13 +318,13 @@ left-catchup-indexed-prefix-target-conceal-castᵀ
     catchup@(left-indexed-catchup indexed
       (left-catchup-invariant
         (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence) =
+      ) =
   left-catchup-indexed-target-frameᵀ
     catchup framed refl (left-silent-invariant refl refl)
     (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -343,6 +348,10 @@ left-catchup-indexed-prefix-target-conceal-castᵀ
     inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-prefix-target-widen-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c μ}
@@ -363,13 +372,13 @@ left-catchup-indexed-prefix-target-widen-castᵀ
     catchup@(left-indexed-catchup indexed
       (left-catchup-invariant
         (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence) =
+      ) =
   left-catchup-indexed-target-frameᵀ
     catchup framed refl (left-silent-invariant refl refl)
     (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -400,6 +409,10 @@ left-catchup-indexed-prefix-target-widen-castᵀ
     inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-prefix-target-widen-id-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B′ c}
@@ -420,13 +433,13 @@ left-catchup-indexed-prefix-target-widen-id-castᵀ
     catchup@(left-indexed-catchup indexed
       (left-catchup-invariant
         (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence) =
+      ) =
   left-catchup-indexed-target-frameᵀ
     catchup framed refl (left-silent-invariant refl refl)
     (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -457,6 +470,10 @@ left-catchup-indexed-prefix-target-widen-id-castᵀ
     inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-prefix-valueᵀ :
   ∀ {Φ Δᴸ Δᴿ V V′ A B}

--- a/GTSF/proof/NuImprecisionCatchupQuotientSupport.agda
+++ b/GTSF/proof/NuImprecisionCatchupQuotientSupport.agda
@@ -259,17 +259,17 @@ left-silent-indexed-prefix-down-up-from-finalᵀ
     {pA = pA} prefix widening
     (left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     down =
   left-silent-indexed
-    (weak-indexed-result framed final-relation)
+    (weak-indexed-result framed final-relation
+      (weak-step-transport
+        (transportNo•Terms (weakIndexedTransport indexed)))
+      (weak-step-type-coherence
+        (transportArrowCoherent (weakIndexedTypeCoherence indexed))
+        (transportAllCoherent (weakIndexedTypeCoherence indexed))))
     (left-silent-invariant refl refl)
     (ok-⟨⟩ (ok-⟨⟩ (left-catchup-final-runtime invariant)))
-    (weak-step-transport (transportNo•Terms transport))
-    (weak-step-type-coherence
-      (transportArrowCoherent coherence)
-      (transportAllCoherent coherence))
   where
   inner = weakIndexedResult indexed
 

--- a/GTSF/proof/NuImprecisionCatchupScratch.agda
+++ b/GTSF/proof/NuImprecisionCatchupScratch.agda
@@ -190,8 +190,7 @@ left-catchup-indexed-prefix-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     with left-catchup-indexed-final-quotientᵀ
       vM′ noM′ inert-d′ inert-u′
       (weak-one-step-transport-id-downᵀ
@@ -205,8 +204,7 @@ left-catchup-indexed-prefix-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     | inj₁ second =
   left-catchup-indexed-resume-silentᵀ
     (left-silent-indexed-prefix-down-up-from-finalᵀ
@@ -219,8 +217,7 @@ left-catchup-indexed-prefix-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     | inj₂ (inj₁ (B , s , u≡inst , source↠)) =
   {!!}
 left-catchup-indexed-prefix-down-upᵀ
@@ -228,8 +225,7 @@ left-catchup-indexed-prefix-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     | inj₂ (inj₂ (B , s , u≡inst-tag , source↠)) =
   {!!}
 
@@ -261,8 +257,7 @@ left-catchup-indexed-prefix-gen-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     with left-catchup-indexed-final-quotientᵀ
       vM′ noM′ inert-d′ inert-u′
       (weak-one-step-transport-gen-downᵀ
@@ -276,8 +271,7 @@ left-catchup-indexed-prefix-gen-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     | inj₁ second =
   left-catchup-indexed-resume-silentᵀ
     (left-silent-indexed-prefix-down-up-from-finalᵀ
@@ -290,8 +284,7 @@ left-catchup-indexed-prefix-gen-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     | inj₂ (inj₁ (B , s , u≡inst , source↠)) =
   {!!}
 left-catchup-indexed-prefix-gen-down-upᵀ
@@ -299,8 +292,7 @@ left-catchup-indexed-prefix-gen-down-upᵀ
     d⊒ d′⊒ widening
     catchup@(left-indexed-catchup indexed
       invariant@(left-catchup-invariant
-        silent@(left-silent-invariant refl refl) final)
-      transport coherence)
+        silent@(left-silent-invariant refl refl) final))
     | inj₂ (inj₂ (B , s , u≡inst-tag , source↠)) =
   {!!}
 

--- a/GTSF/proof/NuImprecisionCatchupSourceAllocationTerminal.agda
+++ b/GTSF/proof/NuImprecisionCatchupSourceAllocationTerminal.agda
@@ -48,6 +48,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; sourceResult
   ; relatedResults
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-indexed-result
   ; catchupIndexedResult
   )
@@ -75,17 +77,16 @@ left-silent-indexed-prefix-source-ν-terminal-valueᵀ
     {p = p} prefix hA c↑
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     vW noW =
   left-silent-indexed
-    (weak-indexed-result framed (relatedResults framed))
+    (weak-indexed-result framed (relatedResults framed)
+      (weak-one-step-source-ν-frame-preserves-transportᵀ
+        hA c↑⁺ p inner (weakIndexedTransport indexed))
+      (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+        hA c↑⁺ p inner (weakIndexedTypeCoherence indexed)))
     (left-silent-invariant refl refl)
     (ok-ν (ok-no noW))
-    (weak-one-step-source-ν-frame-preserves-transportᵀ
-      hA c↑⁺ p inner inner-transport)
-    (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
-      hA c↑⁺ p inner inner-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -120,17 +121,16 @@ left-silent-indexed-prefix-source-νcast-terminal-valueᵀ
     {p = p} prefix mode seal★ c⊑
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     vW noW =
   left-silent-indexed
-    (weak-indexed-result framed (relatedResults framed))
+    (weak-indexed-result framed (relatedResults framed)
+      (weak-one-step-source-νcast-frame-preserves-transportᵀ
+        mode seal★⁺ c⊑⁺ p inner (weakIndexedTransport indexed))
+      (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+        mode seal★⁺ c⊑⁺ p inner (weakIndexedTypeCoherence indexed)))
     (left-silent-invariant refl refl)
     (ok-ν (ok-no noW))
-    (weak-one-step-source-νcast-frame-preserves-transportᵀ
-      mode seal★⁺ c⊑⁺ p inner inner-transport)
-    (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
-      mode seal★⁺ c⊑⁺ p inner inner-coherence)
   where
   inner = weakIndexedResult indexed
 

--- a/GTSF/proof/NuImprecisionCatchupSourceCastTerminal.agda
+++ b/GTSF/proof/NuImprecisionCatchupSourceCastTerminal.agda
@@ -50,15 +50,14 @@ left-catchup-indexed-source-cast-blame-frameᵀ
     {q = q}
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     framed refl (left-silent-invariant refl refl)
     first-transport first-coherence refl =
   left-indexed-catchup
-    (weak-one-step-index-resultᵀ combined type-eq)
+    (weak-one-step-index-resultᵀ combined type-eq
+      combined-transport combined-coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₂ refl))
-    combined-transport combined-coherence
   where
   first-raw = weakIndexedResult framed
 
@@ -139,34 +138,29 @@ left-catchup-indexed-source-inert-frameᵀ :
 left-catchup-indexed-source-inert-frameᵀ
     inert
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence
     with final
 left-catchup-indexed-source-inert-frameᵀ
     inert
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence
     | inj₁ (vW , noW) =
   left-indexed-catchup framed
     (left-catchup-invariant first-silent
       (inj₁ (vW ⟨ inert ⟩ , no•-⟨⟩ noW)))
-    first-transport first-coherence
 left-catchup-indexed-source-inert-frameᵀ
     inert
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence
     | inj₂ refl =
   left-catchup-indexed-source-cast-blame-frameᵀ
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence refl

--- a/GTSF/proof/NuImprecisionOneStepPrimitiveFrames.agda
+++ b/GTSF/proof/NuImprecisionOneStepPrimitiveFrames.agda
@@ -70,6 +70,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.ReductionProperties using
   ( applyTerm-preserves-No•
@@ -163,16 +165,18 @@ private
     (inner : WeakOneStepIndexedResult
       {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} idι) →
     WeakOneStepTransport (weakIndexedResult inner) →
+    WeakOneStepTypeCoherence (weakIndexedResult inner) →
     WeakOneStepIndexedResult
       {M = L ⊕[ addℕ ] M}
       {N′ = L₁′ ⊕[ addℕ ] applyTerm χ M′}
       {χ = χ} {ρ = ρ} idι
   weak-one-step-⊕₁-indexed-frameᵀ
       {L = L} {L₁′ = L₁′} {M = M} {M′ = M′} {χ = χ}
-      {ρ = ρ} noM noM′ M⊑M′ inner transport =
+      {ρ = ρ} noM noM′ M⊑M′ inner transport coherence =
     weak-one-step-index-resultᵀ framed
       (transport-idι-from-ℕ
         source-ℕ target-ℕ (transportType base idι))
+      framed-transport framed-coherence
     where
     base = weakIndexedResult inner
 
@@ -186,6 +190,11 @@ private
     right-related =
       transport-term-to-ℕᵀ source-ℕ target-ℕ
         (transportNo•Terms transport noM noM′ M⊑M′)
+    framed-transport = weak-step-transport (transportNo•Terms transport)
+    framed-coherence =
+      weak-step-type-coherence
+        (transportArrowCoherent coherence)
+        (transportAllCoherent coherence)
 
     framed :
       WeakOneStepResult ρ
@@ -237,16 +246,18 @@ private
     (inner : WeakOneStepIndexedResult
       {M = M} {N′ = M₁′} {χ = χ} {ρ = ρ} idι) →
     WeakOneStepTransport (weakIndexedResult inner) →
+    WeakOneStepTypeCoherence (weakIndexedResult inner) →
     WeakOneStepIndexedResult
       {M = L ⊕[ addℕ ] M}
       {N′ = applyTerm χ L′ ⊕[ addℕ ] M₁′}
       {χ = χ} {ρ = ρ} idι
   weak-one-step-⊕₂-indexed-frameᵀ
       {L = L} {L′ = L′} {M = M} {M₁′ = M₁′} {χ = χ}
-      {ρ = ρ} vL noL vL′ noL′ L⊑L′ inner transport =
+      {ρ = ρ} vL noL vL′ noL′ L⊑L′ inner transport coherence =
     weak-one-step-index-resultᵀ framed
       (transport-idι-from-ℕ
         source-ℕ target-ℕ (transportType base idι))
+      framed-transport framed-coherence
     where
     base = weakIndexedResult inner
 
@@ -260,6 +271,11 @@ private
     right-related =
       transport-term-to-ℕᵀ
         source-ℕ target-ℕ (canonicalIndexedResults inner)
+    framed-transport = weak-step-transport (transportNo•Terms transport)
+    framed-coherence =
+      weak-step-type-coherence
+        (transportArrowCoherent coherence)
+        (transportAllCoherent coherence)
 
     framed :
       WeakOneStepResult ρ
@@ -317,14 +333,12 @@ weak-one-step-⊕₁-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} idι
 weak-one-step-⊕₁-indexed-frame-outcomeᵀ
     noM noM′ M⊑M′
-    (indexed-outcome-related inner transport coherence) =
+    (indexed-outcome-related inner) =
   indexed-outcome-related
     (weak-one-step-⊕₁-indexed-frameᵀ
-      noM noM′ M⊑M′ inner transport)
-    (weak-step-transport (transportNo•Terms transport))
-    (weak-step-type-coherence
-      (transportArrowCoherent coherence)
-      (transportAllCoherent coherence))
+      noM noM′ M⊑M′ inner
+      (weakIndexedTransport inner)
+      (weakIndexedTypeCoherence inner))
 weak-one-step-⊕₁-indexed-frame-outcomeᵀ
     noM noM′ M⊑M′
     (indexed-outcome-source-blame source↠) =
@@ -348,14 +362,12 @@ weak-one-step-⊕₂-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} idι
 weak-one-step-⊕₂-indexed-frame-outcomeᵀ
     vL noL vL′ noL′ L⊑L′
-    (indexed-outcome-related inner transport coherence) =
+    (indexed-outcome-related inner) =
   indexed-outcome-related
     (weak-one-step-⊕₂-indexed-frameᵀ
-      vL noL vL′ noL′ L⊑L′ inner transport)
-    (weak-step-transport (transportNo•Terms transport))
-    (weak-step-type-coherence
-      (transportArrowCoherent coherence)
-      (transportAllCoherent coherence))
+      vL noL vL′ noL′ L⊑L′ inner
+      (weakIndexedTransport inner)
+      (weakIndexedTypeCoherence inner))
 weak-one-step-⊕₂-indexed-frame-outcomeᵀ
     vL noL vL′ noL′ L⊑L′
     (indexed-outcome-source-blame source↠) =

--- a/GTSF/proof/NuImprecisionOneStepRelated.agda
+++ b/GTSF/proof/NuImprecisionOneStepRelated.agda
@@ -78,7 +78,11 @@ weak-one-step-indexed-relatedᵀ :
     ⊢ᴺ M ⊑ N ⦂ A ⊑ B ∶ p) →
   WeakOneStepIndexedResult {χ = keep} p
 weak-one-step-indexed-relatedᵀ result =
-  weak-indexed-result (weak-one-step-relatedᵀ result) result
+  weak-indexed-result
+    (weak-one-step-relatedᵀ result)
+    result
+    (weak-one-step-related-transportᵀ result)
+    (weak-one-step-related-type-coherenceᵀ result)
 
 
 weak-one-step-indexed-outcome-relatedᵀ :
@@ -90,5 +94,3 @@ weak-one-step-indexed-outcome-relatedᵀ :
 weak-one-step-indexed-outcome-relatedᵀ result =
   indexed-outcome-related
     (weak-one-step-indexed-relatedᵀ result)
-    (weak-one-step-related-transportᵀ result)
-    (weak-one-step-related-type-coherenceᵀ result)

--- a/GTSF/proof/NuImprecisionOneStepSourceCastFrames.agda
+++ b/GTSF/proof/NuImprecisionOneStepSourceCastFrames.agda
@@ -25,11 +25,6 @@ open import proof.NuImprecisionSimulationResultDef using
   ( WeakOneStepIndexedOutcome
   ; indexed-outcome-related
   ; indexed-outcome-source-blame
-  ; transportAllCoherent
-  ; transportArrowCoherent
-  ; transportNo•Terms
-  ; weak-step-transport
-  ; weak-step-type-coherence
   )
 open import proof.NuImprecisionTargetBlameCatchup using
   (cast-blame-tailᵀ)
@@ -49,14 +44,10 @@ weak-one-step-source-narrow-cast-indexed-frame-outcomeᵀ :
     {M = M ⟨ c ⟩} {N′ = N′} {χ = χ} {ρ = ρ} q
 weak-one-step-source-narrow-cast-indexed-frame-outcomeᵀ
     mode seal★ c⊒
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   indexed-outcome-related
     (weak-one-step-source-narrow-cast-indexed-frameᵀ
       mode seal★ c⊒ indexed)
-    (weak-step-transport (transportNo•Terms transport))
-    (weak-step-type-coherence
-      (transportArrowCoherent coherence)
-      (transportAllCoherent coherence))
 weak-one-step-source-narrow-cast-indexed-frame-outcomeᵀ
     mode seal★ c⊒
     (indexed-outcome-source-blame source↠) =
@@ -77,14 +68,10 @@ weak-one-step-source-widen-cast-indexed-frame-outcomeᵀ :
     {M = M ⟨ c ⟩} {N′ = N′} {χ = χ} {ρ = ρ} q
 weak-one-step-source-widen-cast-indexed-frame-outcomeᵀ
     mode seal★ c⊑
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   indexed-outcome-related
     (weak-one-step-source-widen-cast-indexed-frameᵀ
       mode seal★ c⊑ indexed)
-    (weak-step-transport (transportNo•Terms transport))
-    (weak-step-type-coherence
-      (transportArrowCoherent coherence)
-      (transportAllCoherent coherence))
 weak-one-step-source-widen-cast-indexed-frame-outcomeᵀ
     mode seal★ c⊑
     (indexed-outcome-source-blame source↠) =

--- a/GTSF/proof/NuImprecisionOneStepSourceConversionFrames.agda
+++ b/GTSF/proof/NuImprecisionOneStepSourceConversionFrames.agda
@@ -41,6 +41,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionTargetBlameCatchup using
   (cast-blame-tailᵀ)
@@ -58,19 +60,16 @@ weak-one-step-source-reveal-conversion-indexed-frame-outcomeᵀ :
     {M = M ⟨ c ⟩} {N′ = M′} {χ = χ} {ρ = ρ} q
 weak-one-step-source-reveal-conversion-indexed-frame-outcomeᵀ
     {Δᴸ = Δᴸ} {A = A} {B = B} {c = c} c↑
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     with apply-reveal-conversions
       {χs = sourceChanges (weakIndexedResult indexed)} c↑
 weak-one-step-source-reveal-conversion-indexed-frame-outcomeᵀ
     {Δᴸ = Δᴸ} {A = A} {B = B} {c = c} c↑
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     | μ′ , α′ , X′ , c′↑ =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -101,6 +100,12 @@ weak-one-step-source-reveal-conversion-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-source-reveal-conversion-indexed-frame-outcomeᵀ
     c↑ (indexed-outcome-source-blame source↠) q =
   indexed-outcome-source-blame (cast-blame-tailᵀ source↠)
@@ -118,19 +123,16 @@ weak-one-step-source-conceal-conversion-indexed-frame-outcomeᵀ :
     {M = M ⟨ c ⟩} {N′ = M′} {χ = χ} {ρ = ρ} q
 weak-one-step-source-conceal-conversion-indexed-frame-outcomeᵀ
     {Δᴸ = Δᴸ} {A = A} {B = B} {c = c} c↓
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     with apply-conceal-conversions
       {χs = sourceChanges (weakIndexedResult indexed)} c↓
 weak-one-step-source-conceal-conversion-indexed-frame-outcomeᵀ
     {Δᴸ = Δᴸ} {A = A} {B = B} {c = c} c↓
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     | μ′ , α′ , X′ , c′↓ =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -161,6 +163,12 @@ weak-one-step-source-conceal-conversion-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-source-conceal-conversion-indexed-frame-outcomeᵀ
     c↓ (indexed-outcome-source-blame source↠) q =
   indexed-outcome-source-blame (cast-blame-tailᵀ source↠)

--- a/GTSF/proof/NuImprecisionOneStepTargetCastFrames.agda
+++ b/GTSF/proof/NuImprecisionOneStepTargetCastFrames.agda
@@ -59,6 +59,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.ReductionProperties using (applyCoercions)
 open import proof.NuWideningTransport using
@@ -81,21 +83,18 @@ weak-one-step-target-narrow-cast-indexed-frame-outcomeᵀ :
 weak-one-step-target-narrow-cast-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ}
     mode seal★ c′⊒
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     with apply-narrows-typing
       {χs = χ ∷ targetTailChanges (weakIndexedResult indexed)}
       mode seal★ c′⊒
 weak-one-step-target-narrow-cast-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ}
     mode seal★ c′⊒
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     | μ″ , mode″ , seal★″ , c″⊒ =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -132,6 +131,12 @@ weak-one-step-target-narrow-cast-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-target-narrow-cast-indexed-frame-outcomeᵀ
     mode seal★ c′⊒
     (indexed-outcome-source-blame source↠) q =
@@ -154,21 +159,18 @@ weak-one-step-target-widen-cast-indexed-frame-outcomeᵀ :
 weak-one-step-target-widen-cast-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ}
     mode seal★ c′⊑
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     with apply-widens-typing
       {χs = χ ∷ targetTailChanges (weakIndexedResult indexed)}
       mode seal★ c′⊑
 weak-one-step-target-widen-cast-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ}
     mode seal★ c′⊑
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     | μ″ , mode″ , seal★″ , c″⊑ =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -205,6 +207,12 @@ weak-one-step-target-widen-cast-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-target-widen-cast-indexed-frame-outcomeᵀ
     mode seal★ c′⊑
     (indexed-outcome-source-blame source↠) q =
@@ -226,13 +234,10 @@ weak-one-step-target-widen-id-cast-indexed-frame-outcomeᵀ :
 weak-one-step-target-widen-id-cast-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ}
     seal★ c′⊑
-    (indexed-outcome-related indexed transport coherence) q =
+    (indexed-outcome-related indexed) q =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -268,6 +273,12 @@ weak-one-step-target-widen-id-cast-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-target-widen-id-cast-indexed-frame-outcomeᵀ
     seal★ c′⊑
     (indexed-outcome-source-blame source↠) q =

--- a/GTSF/proof/NuImprecisionOneStepTargetConversionFrames.agda
+++ b/GTSF/proof/NuImprecisionOneStepTargetConversionFrames.agda
@@ -44,6 +44,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 
 
@@ -60,19 +62,16 @@ weak-one-step-target-reveal-conversion-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} q
 weak-one-step-target-reveal-conversion-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ} c′↑
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     with apply-reveal-conversions
       {χs = χ ∷ targetTailChanges (weakIndexedResult indexed)} c′↑
 weak-one-step-target-reveal-conversion-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ} c′↑
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     | μ′ , β′ , X′ , c′↑⁺ =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -104,6 +103,12 @@ weak-one-step-target-reveal-conversion-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-target-reveal-conversion-indexed-frame-outcomeᵀ
     c′↑ (indexed-outcome-source-blame source↠) q =
   indexed-outcome-source-blame source↠
@@ -122,19 +127,16 @@ weak-one-step-target-conceal-conversion-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} q
 weak-one-step-target-conceal-conversion-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ} c′↓
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     with apply-conceal-conversions
       {χs = χ ∷ targetTailChanges (weakIndexedResult indexed)} c′↓
 weak-one-step-target-conceal-conversion-indexed-frame-outcomeᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c′ = c′} {χ = χ} c′↓
-    (indexed-outcome-related indexed transport coherence) q
+    (indexed-outcome-related indexed) q
     | μ′ , β′ , X′ , c′↓⁺ =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation transport)
-    (weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
 
@@ -166,6 +168,12 @@ weak-one-step-target-conceal-conversion-indexed-frame-outcomeᵀ
       (canonicalIndexedResults indexed) (transportType inner q)
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 weak-one-step-target-conceal-conversion-indexed-frame-outcomeᵀ
     c′↓ (indexed-outcome-source-blame source↠) q =
   indexed-outcome-source-blame source↠

--- a/GTSF/proof/NuImprecisionQuotientValue.agda
+++ b/GTSF/proof/NuImprecisionQuotientValue.agda
@@ -431,12 +431,12 @@ left-catchup-indexed-one-keep-valueᵀ :
   LeftCatchupIndexedResult {N = M} {V′ = V′} {ρ = ρ} p
 left-catchup-indexed-one-keep-valueᵀ M→N vN noN N⊑V′ =
   left-indexed-catchup
-    (weak-indexed-result result N⊑V′)
+    (weak-indexed-result result N⊑V′
+      (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
+      (weak-step-type-coherence
+        (λ pC pD → refl) (λ q → refl)))
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₁ (vN , noN)))
-    (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
-    (weak-step-type-coherence
-      (λ pC pD → refl) (λ q → refl))
   where
   result = record
     { sourceChanges = keep ∷ []
@@ -474,12 +474,12 @@ left-catchup-indexed-double-cast-blameᵀ :
     {V′ = V′} {A = A} {B = B} {ρ = ρ} p
 left-catchup-indexed-double-cast-blameᵀ V′⊢ =
   left-indexed-catchup
-    (weak-indexed-result result blame-relation)
+    (weak-indexed-result result blame-relation
+      (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
+      (weak-step-type-coherence
+        (λ pC pD → refl) (λ q → refl)))
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₂ refl))
-    (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
-    (weak-step-type-coherence
-      (λ pC pD → refl) (λ q → refl))
   where
   blame-relation = blame⊑ᵀ V′⊢
 
@@ -521,12 +521,12 @@ left-catchup-indexed-two-keep-to-blameᵀ :
     {ρ = ρ} p
 left-catchup-indexed-two-keep-to-blameᵀ M↠blame V′⊢ =
   left-indexed-catchup
-    (weak-indexed-result result blame-relation)
+    (weak-indexed-result result blame-relation
+      (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
+      (weak-step-type-coherence
+        (λ pC pD → refl) (λ q → refl)))
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₂ refl))
-    (weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′))
-    (weak-step-type-coherence
-      (λ pC pD → refl) (λ q → refl))
   where
   blame-relation = blame⊑ᵀ V′⊢
 

--- a/GTSF/proof/NuImprecisionRightValueCatchupResultDef.agda
+++ b/GTSF/proof/NuImprecisionRightValueCatchupResultDef.agda
@@ -17,8 +17,6 @@ open import Types using (Ty; TyCtx)
 open import proof.NuImprecisionSimulationResultDef using
   ( WeakOneStepIndexedResult
   ; WeakOneStepResult
-  ; WeakOneStepTransport
-  ; WeakOneStepTypeCoherence
   ; sourceChanges
   ; sourceResult
   ; targetResult
@@ -59,13 +57,5 @@ record RightValueCatchupIndexedResult
       No•
         (targetResult
           (weakIndexedResult rightCatchupIndexedResult))
-
-    rightCatchupTransport :
-      WeakOneStepTransport
-        (weakIndexedResult rightCatchupIndexedResult)
-
-    rightCatchupTypeCoherence :
-      WeakOneStepTypeCoherence
-        (weakIndexedResult rightCatchupIndexedResult)
 
 open RightValueCatchupIndexedResult public

--- a/GTSF/proof/NuImprecisionSimulation.agda
+++ b/GTSF/proof/NuImprecisionSimulation.agda
@@ -3492,17 +3492,19 @@ weak-one-step-direct-quotient-indexed-outcomeᵀ
     liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
     pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑ =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result type-eq)
-    (weak-one-step-direct-quotient-transportᵀ
-      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
-      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑)
-    (weak-one-step-direct-quotient-type-coherenceᵀ
-      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
-      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑)
+    (weak-one-step-index-resultᵀ result type-eq transport coherence)
   where
   result = weak-one-step-direct-quotientᵀ
     liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
     pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+  transport =
+    weak-one-step-direct-quotient-transportᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
+  coherence =
+    weak-one-step-direct-quotient-type-coherenceᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD D′ˢ≈T
+      pE pF ∀gen⊒ gen∀⊒ inst∀⊑ ∀inst⊑ s↑ s′↑
   type-eq = subst-cancel-sym
     (λ S → resultCtx result ∣ resultLeftCtx result
       ⊢ S ⊑ resultTargetType result ⊣ resultRightCtx result)
@@ -3560,17 +3562,19 @@ weak-one-step-reverse-direct-quotient-indexed-outcomeᵀ
     liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
     pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑ =
   indexed-outcome-related
-    (weak-one-step-index-resultᵀ result type-eq)
-    (weak-one-step-reverse-direct-quotient-transportᵀ
-      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
-      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑)
-    (weak-one-step-reverse-direct-quotient-type-coherenceᵀ
-      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
-      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑)
+    (weak-one-step-index-resultᵀ result type-eq transport coherence)
   where
   result = weak-one-step-reverse-direct-quotientᵀ
     liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
     pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+  transport =
+    weak-one-step-reverse-direct-quotient-transportᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
+  coherence =
+    weak-one-step-reverse-direct-quotient-type-coherenceᵀ
+      liftρ₁ vW okM vW′ noM′ W⊑W′ pObs pD qD S≈Dˢ
+      pE pF gen∀⊒ ∀gen⊒ ∀inst⊑ inst∀⊑ s↑ s′↑
   type-eq = subst-cancel-sym
     (λ T → resultCtx result ∣ resultLeftCtx result
       ⊢ resultSourceType result ⊑ T ⊣ resultRightCtx result)
@@ -4350,15 +4354,14 @@ left-catchup-indexed-all-keep-stepᵀ :
     {N = M} {V′ = V′} {ρ = ρ} q
 left-catchup-indexed-all-keep-stepᵀ source→ final N⊑V′ =
   left-indexed-all-catchup
-    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-index-resultᵀ result refl transport coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
-    (weak-one-step-keep-source-catchup-transportᵀ
-      source→ N⊑V′)
-    (weak-one-step-keep-source-catchup-type-coherenceᵀ
-      source→ N⊑V′)
   where
   result = weak-one-step-keep-source-catchupᵀ source→ N⊑V′
+  transport = weak-one-step-keep-source-catchup-transportᵀ source→ N⊑V′
+  coherence =
+    weak-one-step-keep-source-catchup-type-coherenceᵀ source→ N⊑V′
 
 left-catchup-indexed-all-prefix-prepend-keepᵀ :
   ∀ {Φ Δᴸ Δᴿ M N V′ C C′ q}
@@ -4611,6 +4614,7 @@ weak-one-step-source-narrow-cast-indexed-frameᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒ indexed
     | μ′ , mode′ , seal★′ , c′⊒ =
   weak-indexed-result framed (relatedResults framed)
+    framed-transport framed-coherence
   where
   inner = weakIndexedResult indexed
 
@@ -4645,6 +4649,12 @@ weak-one-step-source-narrow-cast-indexed-frameᵀ
       (canonicalIndexedResults indexed) (transportType inner _)
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
 weak-one-step-source-widen-cast-indexed-frameᵀ :
   ∀ {Φ Δᴸ Δᴿ M N′ A A′ B c μ χ}
@@ -4667,6 +4677,7 @@ weak-one-step-source-widen-cast-indexed-frameᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ indexed
     | μ′ , mode′ , seal★′ , c′⊑ =
   weak-indexed-result framed (relatedResults framed)
+    framed-transport framed-coherence
   where
   inner = weakIndexedResult indexed
 
@@ -4701,6 +4712,12 @@ weak-one-step-source-widen-cast-indexed-frameᵀ
       (canonicalIndexedResults indexed) (transportType inner _)
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
+  framed-transport =
+    weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
 narrow-all-to-all-inert :
   ∀ {μ Δ Σ c A B} →
@@ -4774,15 +4791,14 @@ left-catchup-indexed-all-source-cast-blame-frameᵀ
     {r = r}
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     framed refl (left-silent-invariant refl refl)
     first-transport first-coherence refl =
   left-indexed-all-catchup
-    (weak-one-step-index-resultᵀ combined type-eq)
+    (weak-one-step-index-resultᵀ combined type-eq
+      combined-transport combined-coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₂ refl))
-    combined-transport combined-coherence
   where
   first-raw = weakIndexedResult framed
 
@@ -4872,36 +4888,31 @@ left-catchup-indexed-all-source-inert-frameᵀ :
 left-catchup-indexed-all-source-inert-frameᵀ
     inert
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence
     with final
 left-catchup-indexed-all-source-inert-frameᵀ
     inert
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence
     | inj₁ (vW , noW) =
   left-indexed-all-catchup framed
     (left-catchup-invariant first-silent
       (inj₁ (vW ⟨ inert ⟩ , no•-⟨⟩ noW)))
-    first-transport first-coherence
 left-catchup-indexed-all-source-inert-frameᵀ
     {r = r}
     inert
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence
     | inj₂ refl =
   left-catchup-indexed-all-source-cast-blame-frameᵀ
     (left-indexed-catchup indexed
-      (left-catchup-invariant inner-silent final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant inner-silent final))
     framed refl first-silent
     first-transport first-coherence refl
 
@@ -4921,8 +4932,7 @@ left-catchup-indexed-all-source-narrow-castᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     with apply-narrows-typing
       { χs = sourceChanges (weakIndexedResult indexed) }
       mode seal★ c⊒
@@ -4930,23 +4940,21 @@ left-catchup-indexed-all-source-narrow-castᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊒
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     | μ′ , mode′ , seal★′ , c′⊒ =
   left-catchup-indexed-all-source-inert-frameᵀ
     (applyCoercions-preserves-Inert (sourceChanges inner)
       (narrow-all-to-all-inert c⊒))
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     framed refl
       (weak-one-step-source-cast-frame-silentᵀ
         inner final-relation (left-silent-invariant refl refl))
     (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -4983,6 +4991,10 @@ left-catchup-indexed-all-source-narrow-castᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-all-prefix-source-narrow-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
@@ -5020,27 +5032,24 @@ left-catchup-indexed-all-source-widen-cast-inertᵀ :
     {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
 left-catchup-indexed-all-source-widen-cast-inertᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ inert
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     with apply-widens-typing
       { χs = sourceChanges (weakIndexedResult indexed) }
       mode seal★ c⊑
 left-catchup-indexed-all-source-widen-cast-inertᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑ inert
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     | μ′ , mode′ , seal★′ , c′⊑ =
   left-catchup-indexed-all-source-inert-frameᵀ
     (applyCoercions-preserves-Inert (sourceChanges inner) inert)
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     framed refl
       (weak-one-step-source-cast-frame-silentᵀ
         inner final-relation (silentInvariant invariant))
     (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -5077,6 +5086,10 @@ left-catchup-indexed-all-source-widen-cast-inertᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-all-source-widen-cast-blameᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
@@ -5094,28 +5107,25 @@ left-catchup-indexed-all-source-widen-cast-blameᵀ :
     {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
 left-catchup-indexed-all-source-widen-cast-blameᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     eq-blame
     with apply-widens-typing
       { χs = sourceChanges (weakIndexedResult indexed) }
       mode seal★ c⊑
 left-catchup-indexed-all-source-widen-cast-blameᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} mode seal★ c⊑
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     eq-blame
     | μ′ , mode′ , seal★′ , c′⊑ =
   left-catchup-indexed-all-source-cast-blame-frameᵀ
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     framed refl
       (weak-one-step-source-cast-frame-silentᵀ
         inner final-relation (silentInvariant invariant))
     (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
     eq-blame
   where
   inner = weakIndexedResult indexed
@@ -5153,6 +5163,10 @@ left-catchup-indexed-all-source-widen-cast-blameᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-all-prefix-source-widen-cast-blameᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ c}
@@ -5253,8 +5267,7 @@ left-silent-indexed-all-source-widen-inst-valueᵀ
     (C.cast-inst hB occ s⊢ , NW.inst sʷ)
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     vW noW
     with apply-widens-typing
       { χs = sourceChanges (weakIndexedResult indexed) }
@@ -5264,15 +5277,14 @@ left-silent-indexed-all-source-widen-inst-valueᵀ
     (C.cast-inst hB occ s⊢ , NW.inst sʷ)
     (left-indexed-catchup indexed
       (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+        (left-silent-invariant refl refl) final))
     vW noW
     | μ′ , mode′ , seal★′ , c′⊑ =
   left-silent-indexed
-    (weak-one-step-index-resultᵀ combined type-eq)
+    (weak-one-step-index-resultᵀ combined type-eq
+      combined-transport combined-coherence)
     (left-silent-invariant refl refl)
     (ok-ν (ok-no noW))
-    combined-transport combined-coherence
   where
   inner = weakIndexedResult indexed
 
@@ -5354,10 +5366,10 @@ left-silent-indexed-all-source-widen-inst-valueᵀ
         first second (∀ⁱ _))))
 
   first-transport = weak-one-step-source-cast-frame-transportᵀ
-    inner final-relation inner-transport
+    inner final-relation (weakIndexedTransport indexed)
 
   first-coherence = weak-one-step-source-cast-frame-coherenceᵀ
-    inner final-relation inner-coherence
+    inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -5416,55 +5428,47 @@ left-catchup-indexed-all-source-widen-cast-progressᵀ :
 left-catchup-indexed-all-source-widen-cast-progressᵀ
     mode seal★ c⊑
     (left-indexed-catchup indexed
-      (left-catchup-invariant (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant (left-silent-invariant refl refl) final))
     with final
 left-catchup-indexed-all-source-widen-cast-progressᵀ
     mode seal★ c⊑
     (left-indexed-catchup indexed
-      (left-catchup-invariant (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant (left-silent-invariant refl refl) final))
     | inj₁ (vW , noW)
     with widen-all-to-all-shape c⊑
 left-catchup-indexed-all-source-widen-cast-progressᵀ
     mode seal★ c⊑
     (left-indexed-catchup indexed
-      (left-catchup-invariant (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant (left-silent-invariant refl refl) final))
     | inj₁ (vW , noW) | inj₁ inert =
   left-progress-done
     (generalize-left-indexed-all-catchup
       (left-catchup-indexed-all-source-widen-cast-inertᵀ
         mode seal★ c⊑ inert
         (left-indexed-catchup indexed
-          (left-catchup-invariant (left-silent-invariant refl refl) final)
-          inner-transport inner-coherence)))
+          (left-catchup-invariant (left-silent-invariant refl refl) final))))
 left-catchup-indexed-all-source-widen-cast-progressᵀ
     mode seal★ c⊑
     (left-indexed-catchup indexed
-      (left-catchup-invariant (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant (left-silent-invariant refl refl) final))
     | inj₁ (vW , noW) | inj₂ (s , refl) =
   left-progress-continue
     (left-silent-indexed-all-source-widen-inst-valueᵀ
       mode seal★ c⊑
       (left-indexed-catchup indexed
-        (left-catchup-invariant (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+        (left-catchup-invariant (left-silent-invariant refl refl) final))
       vW noW)
 left-catchup-indexed-all-source-widen-cast-progressᵀ
     mode seal★ c⊑
     (left-indexed-catchup indexed
-      (left-catchup-invariant (left-silent-invariant refl refl) final)
-      inner-transport inner-coherence)
+      (left-catchup-invariant (left-silent-invariant refl refl) final))
     | inj₂ eq-blame =
   left-progress-done
     (generalize-left-indexed-all-catchup
       (left-catchup-indexed-all-source-widen-cast-blameᵀ
         mode seal★ c⊑
         (left-indexed-catchup indexed
-          (left-catchup-invariant (left-silent-invariant refl refl) final)
-          inner-transport inner-coherence)
+          (left-catchup-invariant (left-silent-invariant refl refl) final))
         eq-blame))
 
 left-catchup-indexed-all-prefix-source-widen-cast-progressᵀ :
@@ -5502,27 +5506,24 @@ left-catchup-indexed-all-source-reveal-castᵀ :
     {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
 left-catchup-indexed-all-source-reveal-castᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} c↑
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     with apply-reveal-conversions
       { χs = sourceChanges (weakIndexedResult indexed) } c↑
 left-catchup-indexed-all-source-reveal-castᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} c↑
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     | μ′ , α′ , X′ , c′↑ =
   left-catchup-indexed-all-source-inert-frameᵀ
     (applyCoercions-preserves-Inert (sourceChanges inner)
       (reveal-all-to-all-inert c↑))
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     framed refl
       (weak-one-step-source-cast-frame-silentᵀ
         inner final-relation (silentInvariant invariant))
     (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -5555,6 +5556,10 @@ left-catchup-indexed-all-source-reveal-castᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-all-prefix-source-reveal-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ α X c}
@@ -5588,27 +5593,24 @@ left-catchup-indexed-all-source-conceal-castᵀ :
     {N = M ⟨ c ⟩} {V′ = V′} {ρ = ρ} r
 left-catchup-indexed-all-source-conceal-castᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} c↓
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     with apply-conceal-conversions
       { χs = sourceChanges (weakIndexedResult indexed) } c↓
 left-catchup-indexed-all-source-conceal-castᵀ
     {Δᴸ = Δᴸ} {B = B} {c = c} c↓
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     | μ′ , α′ , X′ , c′↓ =
   left-catchup-indexed-all-source-inert-frameᵀ
     (applyCoercions-preserves-Inert (sourceChanges inner)
       (conceal-all-to-all-inert c↓))
-    (left-indexed-catchup indexed invariant
-      inner-transport inner-coherence)
+    (left-indexed-catchup indexed invariant)
     framed refl
       (weak-one-step-source-cast-frame-silentᵀ
         inner final-relation (silentInvariant invariant))
     (weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport)
+      inner final-relation (weakIndexedTransport indexed))
     (weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence)
+      inner final-relation (weakIndexedTypeCoherence indexed))
   where
   inner = weakIndexedResult indexed
 
@@ -5641,6 +5643,10 @@ left-catchup-indexed-all-source-conceal-castᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
 left-catchup-indexed-all-prefix-source-conceal-castᵀ :
   ∀ {Φ Δᴸ Δᴿ M V′ A A′ B μ α X c}
@@ -5803,15 +5809,17 @@ left-catchup-indexed-all-α-Λᵀ
     {C = C} {C′ = C′} {q = q} {ρ = ρ} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ}
     vW noW noV′ h⇑A liftρᵃ liftρᵇ W⊑V′ =
   left-indexed-all-catchup
-    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-index-resultᵀ result refl transport coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-    (weak-step-transport
-      (paired-left-lift-prefix-bodyᵀ
-        liftρᵃ liftρᵃ))
-    (weak-step-type-coherence
-      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
   where
+  transport =
+    weak-step-transport
+      (paired-left-lift-prefix-bodyᵀ liftρᵃ liftρᵃ)
+  coherence =
+    weak-step-type-coherence
+      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ
+
   allocated-body =
     allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
@@ -5879,13 +5887,15 @@ left-catchup-indexed-prefix-α-Λᵀ
     {A = A} {B = B} {p = p} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ} {ρ⁺ = ρ⁺}
     vW noW noV′ h⇑Aν liftρᵃ liftρᵇ prefix W⊑V′ =
   left-indexed-catchup
-    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-index-resultᵀ result refl transport coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-    (weak-step-transport identity-bodyᵀ)
-    (weak-step-type-coherence
-      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
   where
+  transport = weak-step-transport identity-bodyᵀ
+  coherence =
+    weak-step-type-coherence
+      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ
+
   allocated-body =
     allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
@@ -5960,13 +5970,15 @@ left-catchup-indexed-all-prefix-α-Λᵀ
     {q = q} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ} {ρ⁺ = ρ⁺}
     vW noW noV′ h⇑A liftρᵃ liftρᵇ prefix W⊑V′ =
   left-indexed-all-catchup
-    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-index-resultᵀ result refl transport coherence)
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-    (weak-step-transport identity-bodyᵀ)
-    (weak-step-type-coherence
-      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
   where
+  transport = weak-step-transport identity-bodyᵀ
+  coherence =
+    weak-step-type-coherence
+      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ
+
   allocated-body =
     allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}

--- a/GTSF/proof/NuImprecisionSimulationCore.agda
+++ b/GTSF/proof/NuImprecisionSimulationCore.agda
@@ -1252,14 +1252,17 @@ weak-one-step-index-resultᵀ :
       (sourceTypeResult result)
       (resultType result))
     ≡ transportType result p →
+  WeakOneStepTransport result →
+  WeakOneStepTypeCoherence result →
   WeakOneStepIndexedResult p
-weak-one-step-index-resultᵀ result type-eq =
+weak-one-step-index-resultᵀ result type-eq transport coherence =
   weak-indexed-result result
     (nu-term-imprecision-transport-typesᵀ
       (sourceTypeResult result)
       (targetTypeResult result)
       type-eq
       (relatedResults result))
+    transport coherence
 
 
 value-source-multistep-refl :
@@ -1279,18 +1282,16 @@ source-value-indexed-outcome-relatedᵀ :
   WeakOneStepIndexedOutcome
     {M = V} {N′ = N′} {χ = χ} {ρ = ρ} p →
   ∃[ result ]
-    WeakOneStepTransport (weakIndexedResult result) ×
-    WeakOneStepTypeCoherence (weakIndexedResult result) ×
     sourceChanges (weakIndexedResult result) ≡ [] ×
     sourceResult (weakIndexedResult result) ≡ V
 source-value-indexed-outcome-relatedᵀ vV
-    (indexed-outcome-related result transport coherence)
+    (indexed-outcome-related result)
     with value-source-multistep-refl vV
       (sourceCatchup (weakIndexedResult result))
 source-value-indexed-outcome-relatedᵀ vV
-    (indexed-outcome-related result transport coherence)
+    (indexed-outcome-related result)
     | refl , result-eq =
-  result , transport , coherence , refl , result-eq
+  result , refl , result-eq
 source-value-indexed-outcome-relatedᵀ vV
     (indexed-outcome-source-blame source↠)
     with value-source-multistep-refl vV source↠
@@ -1312,8 +1313,11 @@ forget-weak-indexed-outcome :
     {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p →
   WeakOneStepOutcome ρ M N′ A B χ
 forget-weak-indexed-outcome
-    (indexed-outcome-related result transport coherence) =
-  outcome-related (weakIndexedResult result) transport coherence
+    (indexed-outcome-related result) =
+  outcome-related
+    (weakIndexedResult result)
+    (weakIndexedTransport result)
+    (weakIndexedTypeCoherence result)
 forget-weak-indexed-outcome
     (indexed-outcome-source-blame source↠) =
   outcome-source-blame source↠
@@ -1354,13 +1358,12 @@ weak-indexed-arrow-resultᵀ :
     {ρ : StoreImp Φ Δᴸ Δᴿ} →
   (indexed : WeakOneStepIndexedResult
     {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} (pA ↦ pB)) →
-  WeakOneStepTypeCoherence (weakIndexedResult indexed) →
   WeakOneStepArrowResult pA pB
-weak-indexed-arrow-resultᵀ
-    {A′ = A′} {B′ = B′} {χ = χ} indexed coherence =
+weak-indexed-arrow-resultᵀ {A′ = A′} {B′ = B′} {χ = χ} indexed =
   weak-arrow-result base canonical
   where
   base = weakIndexedResult indexed
+  coherence = weakIndexedTypeCoherence indexed
 
   target-eq =
     trans
@@ -1385,10 +1388,11 @@ weak-indexed-arrow-outcomeᵀ :
     {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} (pA ↦ pB) →
   WeakOneStepArrowOutcome pA pB
 weak-indexed-arrow-outcomeᵀ
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   arrow-outcome-related
-    (weak-indexed-arrow-resultᵀ indexed coherence)
-    transport coherence
+    (weak-indexed-arrow-resultᵀ indexed)
+    (weakIndexedTransport indexed)
+    (weakIndexedTypeCoherence indexed)
 weak-indexed-arrow-outcomeᵀ
     (indexed-outcome-source-blame source↠) =
   arrow-outcome-source-blame source↠
@@ -1399,12 +1403,12 @@ weak-indexed-all-resultᵀ :
     {ρ : StoreImp Φ Δᴸ Δᴿ} →
   (indexed : WeakOneStepIndexedResult
     {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} (∀ⁱ q)) →
-  WeakOneStepTypeCoherence (weakIndexedResult indexed) →
   WeakOneStepAllResult q
-weak-indexed-all-resultᵀ {C′ = C′} {χ = χ} indexed coherence =
+weak-indexed-all-resultᵀ {C′ = C′} {χ = χ} indexed =
   weak-all-result base canonical
   where
   base = weakIndexedResult indexed
+  coherence = weakIndexedTypeCoherence indexed
 
   target-eq =
     trans
@@ -1428,10 +1432,11 @@ weak-indexed-all-outcomeᵀ :
     {M = N} {N′ = N₁′} {χ = χ} {ρ = ρ} (∀ⁱ q) →
   WeakOneStepAllOutcome q
 weak-indexed-all-outcomeᵀ
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   all-outcome-related
-    (weak-indexed-all-resultᵀ indexed coherence)
-    transport coherence
+    (weak-indexed-all-resultᵀ indexed)
+    (weakIndexedTransport indexed)
+    (weakIndexedTypeCoherence indexed)
 weak-indexed-all-outcomeᵀ
     (indexed-outcome-source-blame source↠) =
   all-outcome-source-blame source↠
@@ -1480,9 +1485,8 @@ generalize-left-indexed-all-catchup :
   LeftCatchupIndexedResult
     {N = N} {V′ = V′} {ρ = ρ} (∀ⁱ q)
 generalize-left-indexed-all-catchup
-    (left-indexed-all-catchup indexed invariant
-      transport coherence) =
-  left-indexed-catchup indexed invariant transport coherence
+    (left-indexed-all-catchup indexed invariant) =
+  left-indexed-catchup indexed invariant
 
 specialize-left-indexed-all-catchup :
   ∀ {Φ Δᴸ Δᴿ N V′ C C′}
@@ -1493,8 +1497,8 @@ specialize-left-indexed-all-catchup :
   LeftCatchupIndexedAllResult
     {N = N} {V′ = V′} {ρ = ρ} q
 specialize-left-indexed-all-catchup
-    (left-indexed-catchup indexed invariant transport coherence) =
-  left-indexed-all-catchup indexed invariant transport coherence
+    (left-indexed-catchup indexed invariant) =
+  left-indexed-all-catchup indexed invariant
 
 forget-left-indexed-all-catchup :
   ∀ {Φ Δᴸ Δᴿ N V′ C C′}
@@ -1505,9 +1509,7 @@ forget-left-indexed-all-catchup :
   LeftCatchupAllResult {N = N} {V′ = V′} {ρ = ρ} q
 forget-left-indexed-all-catchup catchup =
   left-all-catchup
-    (weak-indexed-all-resultᵀ
-      (catchupIndexedAllResult catchup)
-      (catchupIndexedAllCoherence catchup))
+    (weak-indexed-all-resultᵀ (catchupIndexedAllResult catchup))
     (catchupIndexedAllInvariant catchup)
 
 forget-left-all-catchup :
@@ -12157,11 +12159,8 @@ weak-one-step-·₁-indexed-frame-outcomeᵀ
     noM noM′ M⊑M′ indexed
     | arrow-outcome-related arrow transport coherence =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-·₁-frame-preserves-transportᵀ
-      noM noM′ inner L⊑L′ transported-M transport)
-    (weak-one-step-·₁-frame-preserves-type-coherenceᵀ
-      noM noM′ inner L⊑L′ transported-M coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakArrowResult arrow
   L⊑L′ = canonicalArrowResults arrow
@@ -12170,6 +12169,12 @@ weak-one-step-·₁-indexed-frame-outcomeᵀ
   framed =
     weak-one-step-·₁-frameᵀ
       noM noM′ inner L⊑L′ transported-M
+  framed-transport =
+    weak-one-step-·₁-frame-preserves-transportᵀ
+      noM noM′ inner L⊑L′ transported-M transport
+  framed-coherence =
+    weak-one-step-·₁-frame-preserves-type-coherenceᵀ
+      noM noM′ inner L⊑L′ transported-M coherence
 weak-one-step-·₁-indexed-frame-outcomeᵀ
     noM noM′ M⊑M′ indexed
     | arrow-outcome-source-blame source↠ =
@@ -12213,9 +12218,10 @@ weak-one-step-·₁-runtime-boundaryᵀ
 weak-one-step-·₁-runtime-boundaryᵀ
     okLM okL′M′ L′→ M⊑M′ recursive
     | inj₂ (vL , noL , okM , noM′)
-    | result , transport , coherence , changes-eq , result-eq =
+    | result , changes-eq , result-eq =
   inj₂
-    (result , transport , coherence , changes-eq , result-eq ,
+    (result , weakIndexedTransport result ,
+      weakIndexedTypeCoherence result , changes-eq , result-eq ,
       vL , noL , okM , noM′)
 
 ·₂-blame-tail :
@@ -12254,7 +12260,7 @@ weak-one-step-·₂-indexed-frameᵀ :
 weak-one-step-·₂-indexed-frameᵀ
     {L = L} {L′ = L′} {B = B} {B′ = B′} {χ = χ}
     vL noL vL′ noL′ L⊑L′ inner transport coherence =
-  weak-indexed-result framed related
+  weak-indexed-result framed related framed-transport framed-coherence
   where
   base = weakIndexedResult inner
 
@@ -12263,6 +12269,11 @@ weak-one-step-·₂-indexed-frameᵀ
       base transport coherence noL noL′ L⊑L′
 
   related = ·⊑·ᵀ function-related (canonicalIndexedResults inner)
+  framed-transport = weak-step-transport (transportNo•Terms transport)
+  framed-coherence =
+    weak-step-type-coherence
+      (transportArrowCoherent coherence)
+      (transportAllCoherent coherence)
 
   framed :
     WeakOneStepResult _ (L · _) (applyTerm χ L′ · _) B B′ χ
@@ -12320,14 +12331,12 @@ weak-one-step-·₂-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} pB
 weak-one-step-·₂-indexed-frame-outcomeᵀ
     vL noL vL′ noL′ L⊑L′
-    (indexed-outcome-related inner transport coherence) =
+    (indexed-outcome-related inner) =
   indexed-outcome-related
     (weak-one-step-·₂-indexed-frameᵀ
-      vL noL vL′ noL′ L⊑L′ inner transport coherence)
-    (weak-step-transport (transportNo•Terms transport))
-    (weak-step-type-coherence
-      (transportArrowCoherent coherence)
-      (transportAllCoherent coherence))
+      vL noL vL′ noL′ L⊑L′ inner
+      (weakIndexedTransport inner)
+      (weakIndexedTypeCoherence inner))
 weak-one-step-·₂-indexed-frame-outcomeᵀ
     vL noL vL′ noL′ L⊑L′
     (indexed-outcome-source-blame source↠) =
@@ -12483,8 +12492,6 @@ left-catchup-indexed-relatedᵀ final N⊑V′ =
     (weak-one-step-indexed-relatedᵀ N⊑V′)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
-    (weak-one-step-related-transportᵀ N⊑V′)
-    (weak-one-step-related-type-coherenceᵀ N⊑V′)
 
 left-catchup-indexed-prefix-relatedᵀ :
   ∀ {Φ Δᴸ Δᴿ N V′ A B p}
@@ -12540,8 +12547,6 @@ left-catchup-indexed-all-relatedᵀ final N⊑V′ =
     (weak-one-step-indexed-relatedᵀ N⊑V′)
     (left-catchup-invariant
       (left-silent-invariant refl refl) final)
-    (weak-one-step-related-transportᵀ N⊑V′)
-    (weak-one-step-related-type-coherenceᵀ N⊑V′)
 
 left-catchup-indexed-all-prefix-relatedᵀ :
   ∀ {Φ Δᴸ Δᴿ N V′ C C′ q}
@@ -13920,13 +13925,16 @@ weak-one-step-matched-ν-indexed-frame-outcomeᵀ
     s↑ s′↑ pA pB indexed
     | all-outcome-related all transport coherence =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-matched-ν-frame-preserves-transportᵀ
-      s↑ s′↑ pA pB all transport)
-    (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
-      s↑ s′↑ pA pB all coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   framed = weak-one-step-matched-ν-frameᵀ s↑ s′↑ pA pB all
+  framed-transport =
+    weak-one-step-matched-ν-frame-preserves-transportᵀ
+      s↑ s′↑ pA pB all transport
+  framed-coherence =
+    weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+      s↑ s′↑ pA pB all coherence
 weak-one-step-matched-ν-indexed-frame-outcomeᵀ
     s↑ s′↑ pA pB indexed
     | all-outcome-source-blame source↠ =
@@ -13961,15 +13969,18 @@ weak-one-step-matched-νcast-indexed-frame-outcomeᵀ
     mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB indexed
     | all-outcome-related all transport coherence =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-matched-νcast-frame-preserves-transportᵀ
-      mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB all transport)
-    (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
-      mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB all coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   framed =
     weak-one-step-matched-νcast-frameᵀ
       mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB all
+  framed-transport =
+    weak-one-step-matched-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB all transport
+  framed-coherence =
+    weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB all coherence
 weak-one-step-matched-νcast-indexed-frame-outcomeᵀ
     mode seal★ s⊑ mode′ seal★′ s′⊑ compat pB indexed
     | all-outcome-source-blame source↠ =
@@ -14073,16 +14084,19 @@ weak-one-step-source-ν-indexed-frame-outcomeᵀ :
     {M = ν A N s} {N′ = N₁′} {χ = χ} {ρ = ρ} pB
 weak-one-step-source-ν-indexed-frame-outcomeᵀ
     hA s↑ pB
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-source-ν-frame-preserves-transportᵀ
-      hA s↑ pB inner transport)
-    (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
-      hA s↑ pB inner coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
   framed = weak-one-step-source-ν-frameᵀ hA s↑ pB inner
+  framed-transport =
+    weak-one-step-source-ν-frame-preserves-transportᵀ
+      hA s↑ pB inner (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+      hA s↑ pB inner (weakIndexedTypeCoherence indexed)
 weak-one-step-source-ν-indexed-frame-outcomeᵀ
     hA s↑ pB (indexed-outcome-source-blame source↠) =
   indexed-outcome-source-blame (ν-blame-tail source↠)
@@ -14103,17 +14117,20 @@ weak-one-step-source-νcast-indexed-frame-outcomeᵀ :
     {M = ν ★ N s} {N′ = N₁′} {χ = χ} {ρ = ρ} pB
 weak-one-step-source-νcast-indexed-frame-outcomeᵀ
     mode seal★ s⊑ pB
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-source-νcast-frame-preserves-transportᵀ
-      mode seal★ s⊑ pB inner transport)
-    (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
-      mode seal★ s⊑ pB inner coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
   framed =
     weak-one-step-source-νcast-frameᵀ mode seal★ s⊑ pB inner
+  framed-transport =
+    weak-one-step-source-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ pB inner (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ pB inner (weakIndexedTypeCoherence indexed)
 weak-one-step-source-νcast-indexed-frame-outcomeᵀ
     mode seal★ s⊑ pB
     (indexed-outcome-source-blame source↠) =
@@ -14137,16 +14154,19 @@ weak-one-step-target-ν-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} pB
 weak-one-step-target-ν-indexed-frame-outcomeᵀ
     hA s↑ pB pC
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-ν-frame-preserves-transportᵀ
-      hA s↑ pB pC inner transport)
-    (weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
-      hA s↑ pB pC inner coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
   framed = weak-one-step-target-ν-frameᵀ hA s↑ pB pC inner
+  framed-transport =
+    weak-one-step-target-ν-frame-preserves-transportᵀ
+      hA s↑ pB pC inner (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+      hA s↑ pB pC inner (weakIndexedTypeCoherence indexed)
 weak-one-step-target-ν-indexed-frame-outcomeᵀ
     hA s↑ pB pC (indexed-outcome-source-blame source↠) =
   indexed-outcome-source-blame source↠
@@ -14170,18 +14190,21 @@ weak-one-step-target-νcast-indexed-frame-outcomeᵀ :
     {χ = χ} {ρ = ρ} pB
 weak-one-step-target-νcast-indexed-frame-outcomeᵀ
     mode seal★ s⊑ pB pC
-    (indexed-outcome-related indexed transport coherence) =
+    (indexed-outcome-related indexed) =
   indexed-outcome-related
-    (weak-indexed-result framed (relatedResults framed))
-    (weak-one-step-target-νcast-frame-preserves-transportᵀ
-      mode seal★ s⊑ pB pC inner transport)
-    (weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
-      mode seal★ s⊑ pB pC inner coherence)
+    (weak-indexed-result framed (relatedResults framed)
+      framed-transport framed-coherence)
   where
   inner = weakIndexedResult indexed
   framed =
     weak-one-step-target-νcast-frameᵀ
       mode seal★ s⊑ pB pC inner
+  framed-transport =
+    weak-one-step-target-νcast-frame-preserves-transportᵀ
+      mode seal★ s⊑ pB pC inner (weakIndexedTransport indexed)
+  framed-coherence =
+    weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★ s⊑ pB pC inner (weakIndexedTypeCoherence indexed)
 weak-one-step-target-νcast-indexed-frame-outcomeᵀ
     mode seal★ s⊑ pB pC
     (indexed-outcome-source-blame source↠) =

--- a/GTSF/proof/NuImprecisionSimulationResultDef.agda
+++ b/GTSF/proof/NuImprecisionSimulationResultDef.agda
@@ -274,6 +274,10 @@ record WeakOneStepIndexedResult
           ⊑ applyTys (targetTailChanges weakIndexedResult)
               (applyTy χ B)
         ∶ transportType weakIndexedResult p
+    weakIndexedTransport :
+      WeakOneStepTransport weakIndexedResult
+    weakIndexedTypeCoherence :
+      WeakOneStepTypeCoherence weakIndexedResult
 
 open WeakOneStepIndexedResult public
 
@@ -284,8 +288,6 @@ data WeakOneStepIndexedOutcome
   indexed-outcome-related :
     (result : WeakOneStepIndexedResult
       {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p) →
-    WeakOneStepTransport (weakIndexedResult result) →
-    WeakOneStepTypeCoherence (weakIndexedResult result) →
     WeakOneStepIndexedOutcome p
 
   indexed-outcome-source-blame : ∀ {χs} →
@@ -439,12 +441,6 @@ record LeftCatchupIndexedResult
     catchupIndexedInvariant :
       LeftCatchupInvariant
         (weakIndexedResult catchupIndexedResult)
-    catchupIndexedTransport :
-      WeakOneStepTransport
-        (weakIndexedResult catchupIndexedResult)
-    catchupIndexedCoherence :
-      WeakOneStepTypeCoherence
-        (weakIndexedResult catchupIndexedResult)
 
 open LeftCatchupIndexedResult public
 record LeftSilentIndexedResult
@@ -462,12 +458,6 @@ record LeftSilentIndexedResult
     silentIndexedRuntime :
       RuntimeOK
         (sourceResult (weakIndexedResult silentIndexedResult))
-    silentIndexedTransport :
-      WeakOneStepTransport
-        (weakIndexedResult silentIndexedResult)
-    silentIndexedCoherence :
-      WeakOneStepTypeCoherence
-        (weakIndexedResult silentIndexedResult)
 
 open LeftSilentIndexedResult public
 data LeftCatchupIndexedProgress
@@ -495,12 +485,6 @@ record LeftCatchupIndexedAllResult
         {M = N} {N′ = V′} {χ = keep} {ρ = ρ} (∀ⁱ q)
     catchupIndexedAllInvariant :
       LeftCatchupInvariant
-        (weakIndexedResult catchupIndexedAllResult)
-    catchupIndexedAllTransport :
-      WeakOneStepTransport
-        (weakIndexedResult catchupIndexedAllResult)
-    catchupIndexedAllCoherence :
-      WeakOneStepTypeCoherence
         (weakIndexedResult catchupIndexedAllResult)
 
 open LeftCatchupIndexedAllResult public

--- a/GTSF/proof/NuImprecisionSourceBulletBase.agda
+++ b/GTSF/proof/NuImprecisionSourceBulletBase.agda
@@ -309,12 +309,12 @@ left-catchup-indexed-prefix-α-Λᵀ
     {A = A} {B = B} {p = p} {ρᵃ = ρᵃ} {ρᵇ = ρᵇ} {ρ⁺ = ρ⁺}
     vW noW noV′ h⇑Aν liftρᵃ liftρᵇ prefix W⊑V′ =
   left-indexed-catchup
-    (weak-one-step-index-resultᵀ result refl)
+    (weak-one-step-index-resultᵀ result refl
+      (weak-step-transport identity-bodyᵀ)
+      (weak-step-type-coherence
+        ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ))
     (left-catchup-invariant
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-    (weak-step-transport identity-bodyᵀ)
-    (weak-step-type-coherence
-      ⊑-rename-id-arrowᵢ ⊑-rename-id-allᵢ)
   where
   allocated-body =
     allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′

--- a/GTSF/proof/NuImprecisionSourceOneStepBlameRootProof.agda
+++ b/GTSF/proof/NuImprecisionSourceOneStepBlameRootProof.agda
@@ -41,8 +41,7 @@ world-coherent-source-keep-blame-root-proofᵀ
     prefix coherent exclusive unique wfL wfR okM okM′
     M⊢ M′⊢ M⊑M′ M→blame =
   world-coherent-source-one-step-indexed
-    indexed transport type-coherence lineage refl refl coherent exclusive
-    unique
+    indexed lineage refl refl coherent exclusive unique
   where
   blame-relation = blame⊑ᵀ M′⊢
 
@@ -59,14 +58,14 @@ world-coherent-source-keep-blame-root-proofᵀ
       refl
       blame-relation
 
-  indexed =
-    weak-indexed-result result blame-relation
-
   transport =
     weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
 
   type-coherence =
     weak-step-type-coherence (λ pC pD → refl) (λ q → refl)
+
+  indexed =
+    weak-indexed-result result blame-relation transport type-coherence
 
   lineage =
     weak-step-store-lineage ρ⁺ rel-store-embedding-reflⁱ prefix-reflⁱ

--- a/GTSF/proof/NuImprecisionSourceOneStepDeltaRootProof.agda
+++ b/GTSF/proof/NuImprecisionSourceOneStepDeltaRootProof.agda
@@ -48,8 +48,7 @@ world-coherent-source-delta-root-proofᵀ
     {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {m = m} {n = n}
     prefix coherent exclusive unique =
   world-coherent-source-one-step-indexed
-    indexed transport type-coherence lineage refl refl coherent exclusive
-    unique
+    indexed lineage refl refl coherent exclusive unique
   where
   result-typingᴸ =
     ⊢$ (κℕ (m + n))
@@ -78,14 +77,14 @@ world-coherent-source-delta-root-proofᵀ
       refl
       related⁺
 
-  indexed =
-    weak-indexed-result result related⁺
-
   transport =
     weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
 
   type-coherence =
     weak-step-type-coherence (λ pC pD → refl) (λ q → refl)
+
+  indexed =
+    weak-indexed-result result related⁺ transport type-coherence
 
   lineage =
     weak-step-store-lineage ρ⁺ rel-store-embedding-reflⁱ prefix-reflⁱ

--- a/GTSF/proof/NuImprecisionWorldCoherentCatchupComposition.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentCatchupComposition.agda
@@ -55,13 +55,12 @@ world-coherent-left-catchup-indexed-resume-silentᵀ :
 world-coherent-left-catchup-indexed-resume-silentᵀ
     silent@(left-silent-indexed first-indexed
       (left-silent-invariant refl refl)
-      first-runtime first-transport first-coherence)
+      first-runtime)
     first-lineage
     (world-coherent-left-indexed-catchup
       second@(left-indexed-catchup second-indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        second-transport second-coherence)
+          (left-silent-invariant refl refl) final))
       second-lineage coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-catchup-indexed-resume-silentᵀ silent second)

--- a/GTSF/proof/NuImprecisionWorldCoherentCatchupPrefixFrames.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentCatchupPrefixFrames.agda
@@ -41,8 +41,7 @@ world-coherent-left-catchup-prefix-target-narrow-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        transport type-coherence)
+          (left-silent-invariant refl refl) final))
       lineage coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-catchup-indexed-prefix-target-narrow-castᵀ
@@ -70,8 +69,7 @@ world-coherent-left-catchup-prefix-target-reveal-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        transport type-coherence)
+          (left-silent-invariant refl refl) final))
       lineage coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-catchup-indexed-prefix-target-reveal-castᵀ
@@ -99,8 +97,7 @@ world-coherent-left-catchup-prefix-target-conceal-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        transport type-coherence)
+          (left-silent-invariant refl refl) final))
       lineage coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-catchup-indexed-prefix-target-conceal-castᵀ
@@ -129,8 +126,7 @@ world-coherent-left-catchup-prefix-target-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        transport type-coherence)
+          (left-silent-invariant refl refl) final))
       lineage coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-catchup-indexed-prefix-target-widen-castᵀ
@@ -158,8 +154,7 @@ world-coherent-left-catchup-prefix-target-widen-id-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        transport type-coherence)
+          (left-silent-invariant refl refl) final))
       lineage coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-catchup-indexed-prefix-target-widen-id-castᵀ

--- a/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCastCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCastCatchupProof.agda
@@ -24,10 +24,11 @@ world-coherent-final-source-νcast-catchup-proofᵀ :
   WorldCoherentFinalSourceNuCastPairedIndexCatchupᵀ →
   WorldCoherentFinalSourceNuCastCatchupᵀ
 world-coherent-final-source-νcast-catchup-proofᵀ
-    source-only paired {q = νⁱ occ r}
+    source-only paired {q = νⁱ safe occ r}
     coherent exclusive wfL mode seal★ s⊑
     vL noL vV′ noV′ L⊑V′ =
-  source-only coherent exclusive wfL mode seal★ s⊑
+  source-only {{safe = safe}}
+    coherent exclusive wfL mode seal★ s⊑
     vL noL vV′ noV′ L⊑V′
 world-coherent-final-source-νcast-catchup-proofᵀ
     source-only paired {q = ∀ⁱ r}

--- a/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCastSourceOnlyIndexCatchupDef.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCastSourceOnlyIndexCatchupDef.agda
@@ -16,6 +16,7 @@ open import Data.Nat using (suc; zero)
 open import Data.Product using (_,_)
 open import ImprecisionWf using
   ( ImpCtx
+  ; NonVar
   ; _ˣ⊑★
   ; ⇑ᴸᵢ
   ; _∣_⊢_⊑_⊣_
@@ -44,6 +45,7 @@ WorldCoherentFinalSourceNuCastSourceOnlyIndexCatchupᵀ =
     {μ : ModeEnv} {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
     {r : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
       ∣ suc Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ}
+    {{safe : NonVar C}}
     {occ : occurs zero C ≡ true} →
   WorldCoherent ρ →
   SourceNameExclusive Φ →
@@ -59,6 +61,6 @@ WorldCoherentFinalSourceNuCastSourceOnlyIndexCatchupᵀ =
   Value V′ →
   No• V′ →
   Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ L ⊑ V′ ⦂ `∀ C ⊑ B′ ∶ νⁱ occ r →
+    ⊢ᴺ L ⊑ V′ ⦂ `∀ C ⊑ B′ ∶ νⁱ safe occ r →
   WorldCoherentLeftCatchupIndexedResult
     {N = ν ★ L s} {V′ = V′} {ρ = ρ} p

--- a/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCastSourceOnlyIndexCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCastSourceOnlyIndexCatchupProof.agda
@@ -174,7 +174,7 @@ world-coherent-final-source-νcast-source-only-index-catchup-proofᵀ
     {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
     {ρ = ρ} {L = L} {V′ = V′}
     {B = B} {B′ = B′} {C = C} {s = s}
-    {μ = μ} {p = p} {r = r} {occ = occ}
+    {μ = μ} {p = p} {r = r} {{safe = safe}} {occ = occ}
     coherent exclusive wfL mode seal★ s⊑
     vL noL vV′ noV′ L⊑V′
     with lift-left-store-result ρ
@@ -183,7 +183,7 @@ world-coherent-final-source-νcast-source-only-index-catchup-proofᵀ
     {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
     {ρ = ρ} {L = L} {V′ = V′}
     {B = B} {B′ = B′} {C = C} {s = s}
-    {μ = μ} {p = p} {r = r} {occ = occ}
+    {μ = μ} {p = p} {r = r} {{safe = safe}} {occ = occ}
     coherent exclusive wfL mode seal★ s⊑
     vL noL vV′ noV′ L⊑V′
     | ρ′ , liftρ =
@@ -214,7 +214,7 @@ world-coherent-final-source-νcast-source-only-index-catchup-proofᵀ
       (sym allocated-store-eq) s⊑
 
   allocated-bullet =
-    left-allocated-bulletᵀ vL noL wf★ liftρ L⊑V′
+    left-allocated-bulletᵀ {{safe = safe}} vL noL wf★ liftρ L⊑V′
 
   bullet-result =
     bullet-catchup wf★ prefix-reflⁱ
@@ -266,16 +266,16 @@ world-coherent-final-source-νcast-source-only-index-catchup-proofᵀ
     weak-indexed-result allocation-result
       (cast⊑⊑ᵀ (cast-inst mode) allocated-seal
         allocated-cast allocated-bullet (⊑-source-liftνᵢ p))
+      (weak-step-transport
+        (left-lift-prefix-body liftρ
+          (prefix-∷ⁱ prefix-reflⁱ)))
+      (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ)
 
   allocation-silent : LeftSilentIndexedResult p
   allocation-silent =
     left-silent-indexed allocation-indexed
       (left-silent-invariant refl refl)
       (ok-⟨⟩ (ok-• vL noL))
-      (weak-step-transport
-        (left-lift-prefix-body liftρ
-          (prefix-∷ⁱ prefix-reflⁱ)))
-      (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ)
 
   allocation-lineage =
     weak-step-store-lineage ρ′

--- a/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuCatchupProof.agda
@@ -24,10 +24,11 @@ world-coherent-final-source-ν-catchup-proofᵀ :
   WorldCoherentFinalSourceNuPairedIndexCatchupᵀ →
   WorldCoherentFinalSourceNuCatchupᵀ
 world-coherent-final-source-ν-catchup-proofᵀ
-    source-only paired {q = νⁱ occ r}
+    source-only paired {q = νⁱ safe occ r}
     coherent exclusive wfL hA h⇑A s↑ liftρ liftγ
     vL noL vV′ noV′ L⊑V′ =
-  source-only coherent exclusive wfL hA h⇑A s↑ liftρ liftγ
+  source-only {{safe = safe}}
+    coherent exclusive wfL hA h⇑A s↑ liftρ liftγ
     vL noL vV′ noV′ L⊑V′
 world-coherent-final-source-ν-catchup-proofᵀ
     source-only paired {q = ∀ⁱ r}

--- a/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuSourceOnlyIndexCatchupDef.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuSourceOnlyIndexCatchupDef.agda
@@ -18,6 +18,7 @@ open import Data.Nat using (zero; suc)
 open import Data.Product using (_,_)
 open import ImprecisionWf using
   ( ImpCtx
+  ; NonVar
   ; _ˣ⊑★
   ; ⇑ᴸᵢ
   ; _∣_⊢_⊑_⊣_
@@ -51,6 +52,7 @@ WorldCoherentFinalSourceNuSourceOnlyIndexCatchupᵀ =
     {μ : ModeEnv} {p : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
     {r : ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
       ∣ suc Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ}
+    {{safe : NonVar C}}
     {occ : occurs zero C ≡ true} →
   WorldCoherent ρ →
   SourceNameExclusive Φ →
@@ -70,6 +72,6 @@ WorldCoherentFinalSourceNuSourceOnlyIndexCatchupᵀ =
   Value V′ →
   No• V′ →
   Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ L ⊑ V′ ⦂ `∀ C ⊑ B′ ∶ νⁱ occ r →
+    ⊢ᴺ L ⊑ V′ ⦂ `∀ C ⊑ B′ ∶ νⁱ safe occ r →
   WorldCoherentLeftCatchupIndexedResult
     {N = ν A L s} {V′ = V′} {ρ = ρ} p

--- a/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuSourceOnlyIndexCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentFinalSourceNuSourceOnlyIndexCatchupProof.agda
@@ -171,7 +171,7 @@ world-coherent-final-source-ν-source-only-index-catchup-proofᵀ
     {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
     {ρ = ρ} {ρ′ = ρ′} {L = L} {V′ = V′}
     {A = A} {B = B} {B′ = B′} {C = C} {s = s}
-    {μ = μ} {p = p} {r = r} {occ = occ}
+    {μ = μ} {p = p} {r = r} {{safe = safe}} {occ = occ}
     coherent exclusive wfL hA h⇑A s↑ liftρ liftγ
     vL noL vV′ noV′ L⊑V′ =
   world-coherent-left-catchup-indexed-resume-silentᵀ
@@ -199,7 +199,7 @@ world-coherent-final-source-ν-source-only-index-catchup-proofᵀ
       (sym allocated-store-eq) s↑
 
   allocated-bullet =
-    left-allocated-bulletᵀ vL noL h⇑A liftρ L⊑V′
+    left-allocated-bulletᵀ {{safe = safe}} vL noL h⇑A liftρ L⊑V′
 
   bullet-result =
     bullet-catchup h⇑A prefix-reflⁱ
@@ -249,16 +249,16 @@ world-coherent-final-source-ν-source-only-index-catchup-proofᵀ
     weak-indexed-result allocation-result
       (conv↑⊑ᵀ allocated-reveal allocated-bullet
         (⊑-source-liftνᵢ p))
+      (weak-step-transport
+        (left-lift-prefix-body liftρ
+          (prefix-∷ⁱ prefix-reflⁱ)))
+      (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ)
 
   allocation-silent : LeftSilentIndexedResult p
   allocation-silent =
     left-silent-indexed allocation-indexed
       (left-silent-invariant refl refl)
       (ok-⟨⟩ (ok-• vL noL))
-      (weak-step-transport
-        (left-lift-prefix-body liftρ
-          (prefix-∷ⁱ prefix-reflⁱ)))
-      (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ)
 
   allocation-lineage =
     weak-step-store-lineage ρ′

--- a/GTSF/proof/NuImprecisionWorldCoherentLeftCatchupPrependKeepStep.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentLeftCatchupPrependKeepStep.agda
@@ -127,21 +127,19 @@ world-coherent-left-catchup-prepend-keep-step
     source→
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup
-        (weak-indexed-result result canonical)
-        (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        (weak-step-transport transport)
-        (weak-step-type-coherence arrow all))
+        (weak-indexed-result result canonical
+          (weak-step-transport transport)
+          (weak-step-type-coherence arrow all))
+        (left-catchup-invariant (left-silent-invariant refl refl) final))
       (weak-step-store-lineage lineage-store lineage-embedding
         lineage-prefix)
       coherent exclusive wfL) =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-indexed-result prefixed canonical)
-      (left-catchup-invariant
-        (left-silent-invariant refl refl) final)
-      (weak-step-transport transport)
-      (weak-step-type-coherence arrow all))
+      (weak-indexed-result prefixed canonical
+        (weak-step-transport transport)
+        (weak-step-type-coherence arrow all))
+      (left-catchup-invariant (left-silent-invariant refl refl) final))
     (weak-step-store-lineage lineage-store lineage-embedding
       lineage-prefix)
     coherent exclusive wfL

--- a/GTSF/proof/NuImprecisionWorldCoherentResultDef.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentResultDef.agda
@@ -15,8 +15,6 @@ open import NuTerms using (blame)
 open import proof.NuImprecisionSimulationResultDef using
   ( LeftCatchupIndexedResult
   ; WeakOneStepIndexedResult
-  ; WeakOneStepTransport
-  ; WeakOneStepTypeCoherence
   ; catchupIndexedResult
   ; resultCtx
   ; resultLeftCtx
@@ -38,8 +36,6 @@ data WorldCoherentWeakOneStepIndexedOutcome
   world-indexed-outcome-related :
     (result : WeakOneStepIndexedResult
       {M = M} {N′ = N′} {χ = χ} {ρ = ρ} p) →
-    WeakOneStepTransport (weakIndexedResult result) →
-    WeakOneStepTypeCoherence (weakIndexedResult result) →
     WorldCoherent (resultStore (weakIndexedResult result)) →
     SourceNameExclusive (resultCtx (weakIndexedResult result)) →
     WorldCoherentWeakOneStepIndexedOutcome p

--- a/GTSF/proof/NuImprecisionWorldCoherentRightSourceConcealFrameContextProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightSourceConcealFrameContextProof.agda
@@ -36,7 +36,7 @@ world-coherent-right-source-conceal-frame-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix =

--- a/GTSF/proof/NuImprecisionWorldCoherentRightSourceFramesProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightSourceFramesProof.agda
@@ -60,8 +60,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulation using
   ( weak-one-step-source-cast-frame-coherenceᵀ
@@ -85,6 +83,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (leftStoreⁱ-prefix-inclusion)
@@ -149,8 +149,7 @@ right-source-narrow-frameᵀ
     (right-value-indexed-catchup framed refl refl
       (vM ⟨ inert ⟩) (no•-⟨⟩ noM)
       (rightCatchupTargetValue catchup)
-      (rightCatchupTargetNoBullet catchup)
-      framed-transport framed-coherence)
+      (rightCatchupTargetNoBullet catchup))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -167,15 +166,6 @@ right-source-narrow-frameᵀ
   framed =
     weak-one-step-source-narrow-cast-indexed-frameᵀ
       mode seal★⁺ c⊒⁺ (rightCatchupIndexedResult catchup)
-
-  framed-transport =
-    weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
-
-  framed-coherence =
-    weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
 
 
 right-source-widen-frameᵀ :
@@ -221,8 +211,7 @@ right-source-widen-frameᵀ
     (right-value-indexed-catchup framed refl refl
       (vM ⟨ inert ⟩) (no•-⟨⟩ noM)
       (rightCatchupTargetValue catchup)
-      (rightCatchupTargetNoBullet catchup)
-      framed-transport framed-coherence)
+      (rightCatchupTargetNoBullet catchup))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -239,15 +228,6 @@ right-source-widen-frameᵀ
   framed =
     weak-one-step-source-widen-cast-indexed-frameᵀ
       mode seal★⁺ c⊑⁺ (rightCatchupIndexedResult catchup)
-
-  framed-transport =
-    weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
-
-  framed-coherence =
-    weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
 
 
 right-source-reveal-frameᵀ :
@@ -291,8 +271,7 @@ right-source-reveal-frameᵀ
     (right-value-indexed-catchup framed refl refl
       (vM ⟨ inert ⟩) (no•-⟨⟩ noM)
       (rightCatchupTargetValue catchup)
-      (rightCatchupTargetNoBullet catchup)
-      framed-transport framed-coherence)
+      (rightCatchupTargetNoBullet catchup))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -324,14 +303,18 @@ right-source-reveal-frameᵀ
 
   framed =
     weak-indexed-result first (relatedResults first)
+      (weak-one-step-source-cast-frame-transportᵀ
+        inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup)))
+      (weak-one-step-source-cast-frame-coherenceᵀ
+        inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
 
   framed-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
 
 right-source-conceal-frameᵀ :
@@ -375,8 +358,7 @@ right-source-conceal-frameᵀ
     (right-value-indexed-catchup framed refl refl
       (vM ⟨ inert ⟩) (no•-⟨⟩ noM)
       (rightCatchupTargetValue catchup)
-      (rightCatchupTargetNoBullet catchup)
-      framed-transport framed-coherence)
+      (rightCatchupTargetNoBullet catchup))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -408,14 +390,18 @@ right-source-conceal-frameᵀ
 
   framed =
     weak-indexed-result first (relatedResults first)
+      (weak-one-step-source-cast-frame-transportᵀ
+        inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup)))
+      (weak-one-step-source-cast-frame-coherenceᵀ
+        inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
 
   framed-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
 
 world-coherent-right-source-frames-proof :

--- a/GTSF/proof/NuImprecisionWorldCoherentRightSourceNarrowFrameContextProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightSourceNarrowFrameContextProof.agda
@@ -36,7 +36,7 @@ world-coherent-right-source-narrow-frame-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix =

--- a/GTSF/proof/NuImprecisionWorldCoherentRightSourceRevealFrameContextProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightSourceRevealFrameContextProof.agda
@@ -36,7 +36,7 @@ world-coherent-right-source-reveal-frame-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix =

--- a/GTSF/proof/NuImprecisionWorldCoherentRightSourceWidenFrameContextProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightSourceWidenFrameContextProof.agda
@@ -36,7 +36,7 @@ world-coherent-right-source-widen-frame-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix =

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetActiveRootResumeProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetActiveRootResumeProof.agda
@@ -96,8 +96,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import
   proof.NuImprecisionRightValueCatchupSourceBulletTransportDef
@@ -160,6 +158,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (rightStoreⁱ-prefix-inclusion; store-imp-prefix-transⁱ)
@@ -399,15 +399,14 @@ private
       framed-relation =
     world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-one-step-index-resultᵀ combined type-eq)
+        (weak-one-step-index-resultᵀ combined type-eq
+          combined-transport combined-coherence)
         combined-source-empty
         combined-source-unchanged
         (rightCatchupSourceValue catchup)
         (rightCatchupSourceNoBullet catchup)
         (rightCatchupTargetValue catchup)
-        (rightCatchupTargetNoBullet catchup)
-        combined-transport
-        combined-coherence)
+        (rightCatchupTargetNoBullet catchup))
       combined-lineage
       combined-bullet
       final-world
@@ -466,11 +465,11 @@ private
 
     first-transport =
       weak-one-step-target-cast-frame-transportᵀ
-        inner framed-relation (rightCatchupTransport catchup)
+        inner framed-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
     first-coherence =
       weak-one-step-target-cast-frame-coherenceᵀ
-        inner framed-relation (rightCatchupTypeCoherence catchup)
+        inner framed-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
     second-transport =
       weak-one-step-related-transportᵀ second-relation

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetActiveUnsealRootProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetActiveUnsealRootProof.agda
@@ -83,8 +83,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import
   proof.NuImprecisionRightValueCatchupSourceBulletTransportDef
@@ -142,6 +140,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (rightStoreⁱ-prefix-inclusion; store-imp-prefix-transⁱ)
@@ -593,15 +593,14 @@ private
       | sv-seal {W = W} {A = Y} vW refl =
     world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-one-step-index-resultᵀ combined type-eq)
+        (weak-one-step-index-resultᵀ combined type-eq
+          combined-transport combined-coherence)
         combined-source-empty
         combined-source-unchanged
         (rightCatchupSourceValue catchup)
         (rightCatchupSourceNoBullet catchup)
         vW
-        noW
-        combined-transport
-        combined-coherence)
+        noW)
       combined-lineage
       combined-bullet
       final-world
@@ -691,11 +690,11 @@ private
 
     first-transport =
       weak-one-step-target-cast-frame-transportᵀ
-        inner framed-relation (rightCatchupTransport catchup)
+        inner framed-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
     first-coherence =
       weak-one-step-target-cast-frame-coherenceᵀ
-        inner framed-relation (rightCatchupTypeCoherence catchup)
+        inner framed-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
     second-transport =
       weak-one-step-related-transportᵀ canceled

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetCastTerminalizationProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetCastTerminalizationProof.agda
@@ -494,7 +494,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-narrowing₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       with apply-narrow-sequence-components
         { χs = keep ∷ targetTailChanges (weakIndexedResult indexed) }
@@ -506,7 +506,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-narrowing₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊒′ , t⊒′
       with final-narrow-component (weakIndexedResult indexed) s⊒′
@@ -515,7 +515,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-narrowing₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊒′ , t⊒′
       | s⊒@(s⊢ , sⁿ) | t⊒@(t⊢ , tⁿ)
@@ -533,7 +533,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-narrowing₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊒′ , t⊒′
       | s⊒@(s⊢ , sⁿ) | t⊒@(t⊢ , tⁿ) | s-plan
@@ -551,7 +551,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-narrowing₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊒′ , t⊒′
       | s⊒@(s⊢ , sⁿ) | t⊒@(t⊢ , tⁿ)
@@ -600,7 +600,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       with apply-widen-sequence-components
         { χs = keep ∷ targetTailChanges (weakIndexedResult indexed) }
@@ -612,7 +612,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊑′ , t⊑′
       with final-widen-component (weakIndexedResult indexed) s⊑′
@@ -621,7 +621,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊑′ , t⊑′
       | s⊑@(s⊢ , sʷ) | t⊑@(t⊢ , tʷ)
@@ -639,7 +639,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊑′ , t⊑′
       | s⊑@(s⊢ , sʷ) | t⊑@(t⊢ , tʷ) | s-plan
@@ -657,7 +657,7 @@ private
       pending prefix mode seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | μ′ , mode′ , seal★′ , s⊑′ , t⊑′
       | s⊑@(s⊢ , sʷ) | t⊑@(t⊢ , tʷ)
@@ -705,7 +705,7 @@ private
       pending prefix seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       with apply-fixed-widen-sequence-components
         { χs = keep ∷
@@ -717,7 +717,7 @@ private
       pending prefix seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | s⊑′ , t⊑′
       with final-widen-component (weakIndexedResult indexed) s⊑′
@@ -726,7 +726,7 @@ private
       pending prefix seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | s⊑′ , t⊑′
       | s⊑@(s⊢ , sʷ) | t⊑@(t⊢ , tʷ)
@@ -742,7 +742,7 @@ private
       pending prefix seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | s⊑′ , t⊑′
       | s⊑@(s⊢ , sʷ) | t⊑@(t⊢ , tʷ) | s-plan
@@ -758,7 +758,7 @@ private
       pending prefix seal★ s₀⊢ t₀⊢ sequence-widening₀
       caught@(world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          vV noV vW noW transport coherence)
+          vV noV vW noW)
         lineage bullet final-world final-exclusive final-unique final-wfR)
       | s⊑′ , t⊑′
       | s⊑@(s⊢ , sʷ) | t⊑@(t⊢ , tʷ)

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetInertFramingContextProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetInertFramingContextProof.agda
@@ -56,7 +56,7 @@ world-coherent-right-target-inert-framing-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix
@@ -79,7 +79,7 @@ world-coherent-right-target-inert-framing-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix
@@ -102,7 +102,7 @@ world-coherent-right-target-inert-framing-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix
@@ -130,7 +130,7 @@ world-coherent-right-target-inert-framing-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix
@@ -159,7 +159,7 @@ world-coherent-right-target-inert-framing-context-proofᵀ
     inner@(world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
         indexed refl refl source-value source-no-bullet
-        target-value target-no-bullet transport type-coherence)
+        target-value target-no-bullet)
       lineage bullet final-world
       final-exclusive final-unique final-wfR)
     context-eq right-prefix =

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetInertFramingProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetInertFramingProof.agda
@@ -55,8 +55,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulation using
   ( weak-one-step-target-cast-frame-coherenceᵀ
@@ -80,6 +78,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (rightStoreⁱ-prefix-inclusion)
@@ -131,8 +131,7 @@ world-coherent-right-target-inert-framing-proofᵀ
       (rightCatchupSourceValue catchup)
       (rightCatchupSourceNoBullet catchup)
       (rightCatchupTargetValue catchup ⟨ inert⁺ ⟩)
-      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup))
-      framed-transport framed-coherence)
+      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup)))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -174,16 +173,17 @@ world-coherent-right-target-inert-framing-proofᵀ
   first =
     weak-one-step-target-cast-frameᵀ inner final-relation
 
-  framed =
-    weak-indexed-result first (relatedResults first)
-
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
+
+  framed =
+    weak-indexed-result first (relatedResults first)
+      framed-transport framed-coherence
 world-coherent-right-target-inert-framing-proofᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c} {q = q}
     prefix inert (inj₂ (inj₁ (_ , _ , _ , c↓)))
@@ -207,8 +207,7 @@ world-coherent-right-target-inert-framing-proofᵀ
       (rightCatchupSourceValue catchup)
       (rightCatchupSourceNoBullet catchup)
       (rightCatchupTargetValue catchup ⟨ inert⁺ ⟩)
-      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup))
-      framed-transport framed-coherence)
+      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup)))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -250,16 +249,17 @@ world-coherent-right-target-inert-framing-proofᵀ
   first =
     weak-one-step-target-cast-frameᵀ inner final-relation
 
-  framed =
-    weak-indexed-result first (relatedResults first)
-
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
+
+  framed =
+    weak-indexed-result first (relatedResults first)
+      framed-transport framed-coherence
 world-coherent-right-target-inert-framing-proofᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c} {q = q}
     prefix inert (inj₂ (inj₂ (inj₁ (_ , mode , seal★ , c⊒))))
@@ -285,8 +285,7 @@ world-coherent-right-target-inert-framing-proofᵀ
       (rightCatchupSourceValue catchup)
       (rightCatchupSourceNoBullet catchup)
       (rightCatchupTargetValue catchup ⟨ inert⁺ ⟩)
-      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup))
-      framed-transport framed-coherence)
+      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup)))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -331,16 +330,17 @@ world-coherent-right-target-inert-framing-proofᵀ
   first =
     weak-one-step-target-cast-frameᵀ inner final-relation
 
-  framed =
-    weak-indexed-result first (relatedResults first)
-
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
+
+  framed =
+    weak-indexed-result first (relatedResults first)
+      framed-transport framed-coherence
 world-coherent-right-target-inert-framing-proofᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c} {q = q}
     prefix inert
@@ -368,8 +368,7 @@ world-coherent-right-target-inert-framing-proofᵀ
       (rightCatchupSourceValue catchup)
       (rightCatchupSourceNoBullet catchup)
       (rightCatchupTargetValue catchup ⟨ inert⁺ ⟩)
-      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup))
-      framed-transport framed-coherence)
+      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup)))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -414,16 +413,17 @@ world-coherent-right-target-inert-framing-proofᵀ
   first =
     weak-one-step-target-cast-frameᵀ inner final-relation
 
-  framed =
-    weak-indexed-result first (relatedResults first)
-
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
+
+  framed =
+    weak-indexed-result first (relatedResults first)
+      framed-transport framed-coherence
 world-coherent-right-target-inert-framing-proofᵀ
     {Δᴿ = Δᴿ} {A′ = A′} {B′ = B′} {c = c} {q = q}
     prefix inert (inj₂ (inj₂ (inj₂ (inj₂ (seal★ , c⊑)))))
@@ -436,8 +436,7 @@ world-coherent-right-target-inert-framing-proofᵀ
       (rightCatchupSourceValue catchup)
       (rightCatchupSourceNoBullet catchup)
       (rightCatchupTargetValue catchup ⟨ inert⁺ ⟩)
-      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup))
-      framed-transport framed-coherence)
+      (no•-⟨⟩ (rightCatchupTargetNoBullet catchup)))
     (weak-step-store-lineage
       (lineageStore lineage)
       (lineageEmbedding lineage)
@@ -488,13 +487,14 @@ world-coherent-right-target-inert-framing-proofᵀ
   first =
     weak-one-step-target-cast-frameᵀ inner final-relation
 
-  framed =
-    weak-indexed-result first (relatedResults first)
-
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (rightCatchupTransport catchup)
+      inner final-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (rightCatchupTypeCoherence catchup)
+      inner final-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
+
+  framed =
+    weak-indexed-result first (relatedResults first)
+      framed-transport framed-coherence

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetKeepPrependProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetKeepPrependProof.agda
@@ -77,15 +77,15 @@ world-coherent-right-target-keep-prepend-proofᵀ
     target→
     (world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-indexed-result result canonical)
-        source-empty source-unchanged vV noV vV′ noV′
-        transport coherence)
+        (weak-indexed-result result canonical
+          transport coherence)
+        source-empty source-unchanged vV noV vV′ noV′)
       lineage bullet coherent exclusive unique wfR) =
   world-coherent-right-value-indexed-catchup
     (right-value-indexed-catchup
-      (weak-indexed-result prepended canonical)
-      source-empty source-unchanged vV noV vV′ noV′
-      prepended-transport prepended-coherence)
+      (weak-indexed-result prepended canonical
+        prepended-transport prepended-coherence)
+      source-empty source-unchanged vV noV vV′ noV′)
     prepended-lineage prepended-bullet
     coherent exclusive unique wfR
   where

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetNarrowUntagRootProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetNarrowUntagRootProof.agda
@@ -81,8 +81,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import
   proof.NuImprecisionRightValueCatchupSourceBulletTransportDef
@@ -140,6 +138,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (rightStoreⁱ-prefix-inclusion; store-imp-prefix-transⁱ)
@@ -523,15 +523,14 @@ private
       | tag-eq , canceled =
     world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-one-step-index-resultᵀ combined type-eq)
+        (weak-one-step-index-resultᵀ combined type-eq
+          combined-transport combined-coherence)
         combined-source-empty
         combined-source-unchanged
         (rightCatchupSourceValue catchup)
         (rightCatchupSourceNoBullet catchup)
         vW
-        noW
-        combined-transport
-        combined-coherence)
+        noW)
       combined-lineage
       combined-bullet
       final-world
@@ -583,11 +582,11 @@ private
 
     first-transport =
       weak-one-step-target-cast-frame-transportᵀ
-        inner framed-relation (rightCatchupTransport catchup)
+        inner framed-relation (weakIndexedTransport (rightCatchupIndexedResult catchup))
 
     first-coherence =
       weak-one-step-target-cast-frame-coherenceᵀ
-        inner framed-relation (rightCatchupTypeCoherence catchup)
+        inner framed-relation (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
     second-transport =
       weak-one-step-related-transportᵀ canceled

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetSequenceResumeProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetSequenceResumeProof.agda
@@ -63,8 +63,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import
   proof.NuImprecisionRightValueCatchupSourceBulletTransportDef
@@ -777,20 +775,23 @@ world-coherent-right-target-sequence-resume-proofᵀ
     {C = C} {q = q}
     (world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-indexed-result first first-canonical)
-        refl refl vV noV vW noW first-transport first-coherence)
+        (weak-indexed-result first first-canonical
+          first-transport first-coherence)
+        refl refl vV noV vW noW)
       first-lineage first-bullet first-world
       first-exclusive first-unique first-wfR)
     (world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-indexed-result second second-canonical)
-        refl refl vV₂ noV₂ vZ noZ second-transport second-coherence)
+        (weak-indexed-result second second-canonical
+          second-transport second-coherence)
+        refl refl vV₂ noV₂ vZ noZ)
       second-lineage second-bullet second-world
       second-exclusive second-unique second-wfR) =
   world-coherent-right-value-indexed-catchup
     (right-value-indexed-catchup
-      (weak-indexed-result combined combined-canonical)
-      refl refl vV noV vZ noZ combined-transport combined-coherence)
+      (weak-indexed-result combined combined-canonical
+        combined-transport combined-coherence)
+      refl refl vV noV vZ noZ)
     combined-lineage combined-bullet second-world
     second-exclusive second-unique second-wfR
   where

--- a/GTSF/proof/NuImprecisionWorldCoherentRightTargetStepResumeProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightTargetStepResumeProof.agda
@@ -55,8 +55,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import
   proof.NuImprecisionRightValueCatchupSourceBulletTransportDef
@@ -307,13 +305,13 @@ world-coherent-right-target-step-resume-proofᵀ
       second-exclusive second-unique second-wfR) =
   world-coherent-right-value-indexed-catchup
     (right-value-indexed-catchup
-      (weak-indexed-result combined combined-canonical)
+      (weak-indexed-result combined combined-canonical
+        combined-transport combined-coherence)
       source-empty source-unchanged
       (rightCatchupSourceValue first-catchup)
       (rightCatchupSourceNoBullet first-catchup)
       (rightCatchupTargetValue second-catchup)
-      (rightCatchupTargetNoBullet second-catchup)
-      combined-transport combined-coherence)
+      (rightCatchupTargetNoBullet second-catchup))
     combined-lineage combined-bullet second-world
     second-exclusive second-unique second-wfR
   where
@@ -356,21 +354,21 @@ world-coherent-right-target-step-resume-proofᵀ
 
   first-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      first-result framed (rightCatchupTransport first-catchup)
+      first-result framed (weakIndexedTransport (rightCatchupIndexedResult first-catchup))
 
   first-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      first-result framed (rightCatchupTypeCoherence first-catchup)
+      first-result framed (weakIndexedTypeCoherence (rightCatchupIndexedResult first-catchup))
 
   combined-transport =
     weak-one-step-compose-preserves-transportᵀ
       first target-step second-result first-transport
-      (rightCatchupTransport second-catchup)
+      (weakIndexedTransport (rightCatchupIndexedResult second-catchup))
 
   combined-coherence =
     weak-one-step-compose-preserves-type-coherenceᵀ
       first target-step second-result first-coherence
-      (rightCatchupTypeCoherence second-catchup)
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult second-catchup))
 
   framed-lineage : WeakOneStepStoreLineage first
   framed-lineage =
@@ -433,13 +431,13 @@ world-coherent-right-target-step-resume-context-proofᵀ
     | combined-lineage , combined-prefix =
   world-coherent-right-value-indexed-catchup
       (right-value-indexed-catchup
-        (weak-indexed-result combined combined-canonical)
+        (weak-indexed-result combined combined-canonical
+          combined-transport combined-coherence)
         source-empty source-unchanged
         (rightCatchupSourceValue first-catchup)
         (rightCatchupSourceNoBullet first-catchup)
         (rightCatchupTargetValue second-catchup)
-        (rightCatchupTargetNoBullet second-catchup)
-        combined-transport combined-coherence)
+        (rightCatchupTargetNoBullet second-catchup))
       combined-lineage combined-bullet second-world
       second-exclusive second-unique second-wfR ,
   combined-context ,
@@ -486,21 +484,21 @@ world-coherent-right-target-step-resume-context-proofᵀ
 
   first-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      first-result framed (rightCatchupTransport first-catchup)
+      first-result framed (weakIndexedTransport (rightCatchupIndexedResult first-catchup))
 
   first-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      first-result framed (rightCatchupTypeCoherence first-catchup)
+      first-result framed (weakIndexedTypeCoherence (rightCatchupIndexedResult first-catchup))
 
   combined-transport =
     weak-one-step-compose-preserves-transportᵀ
       first target-step second-result first-transport
-      (rightCatchupTransport second-catchup)
+      (weakIndexedTransport (rightCatchupIndexedResult second-catchup))
 
   combined-coherence =
     weak-one-step-compose-preserves-type-coherenceᵀ
       first target-step second-result first-coherence
-      (rightCatchupTypeCoherence second-catchup)
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult second-catchup))
 
   framed-bullet : RightValueCatchupSourceBulletTransportᵀ first
   framed-bullet = first-bullet

--- a/GTSF/proof/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletTransportProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletTransportProof.agda
@@ -130,8 +130,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ( rightCatchupIndexedResult
   ; rightCatchupSourceChangesEmpty
   ; rightCatchupSourceUnchanged
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionRuntimeBulletStoreStability using
   ( one-bullet-prefix-left-store-stable
@@ -180,6 +178,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportNo•Terms
   ; transportType
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   ( leftStoreⁱ-prefix-inclusion
@@ -408,7 +408,7 @@ no-bullet-prefix-transportᵀ :
         q
 no-bullet-prefix-transportᵀ prefix noM noM′ M⊑M′ caught =
   transportNo•Terms
-    (rightCatchupTransport (worldRightCatchupResult caught))
+    (weakIndexedTransport (rightCatchupIndexedResult (worldRightCatchupResult caught)))
     noM noM′ relation⁺
   where
   source-typing⁺ =
@@ -636,7 +636,7 @@ module _
               (applyTys-⇒ (keep ∷ []) _ _))
             (applyTys-⇒ (targetTailChanges result) _ _))
           (transportArrowCoherent
-            (rightCatchupTypeCoherence catchup) _ _)
+            (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)) _ _)
           L⊑L′-final-raw
     
       M⊑M′-final =
@@ -664,7 +664,7 @@ module _
               (applyTys-⇒ (keep ∷ []) _ _))
             (applyTys-⇒ (targetTailChanges result) _ _))
           (transportArrowCoherent
-            (rightCatchupTypeCoherence catchup) _ _)
+            (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)) _ _)
           L⊑L′-final-raw
     
       M⊑M′-final =
@@ -1299,7 +1299,7 @@ module _
               (applyTys-∀ (keep ∷ []) _))
             (applyTys-∀ (targetTailChanges result) _))
           (transportAllCoherent
-            (rightCatchupTypeCoherence catchup) _)
+            (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)) _)
           N⊑N′-final-raw
 
       source-reveal =
@@ -1615,7 +1615,7 @@ module _
             (cong (applyTys (targetTailChanges result))
               (applyTys-∀ (keep ∷ []) _))
             (applyTys-∀ (targetTailChanges result) _))
-          (transportAllCoherent (rightCatchupTypeCoherence catchup) _)
+          (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)) _)
           N⊑N′-final-raw
 
       source-seal =

--- a/GTSF/proof/NuImprecisionWorldCoherentRightValueTerminalProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentRightValueTerminalProof.agda
@@ -56,8 +56,7 @@ world-coherent-right-value-terminal-proofᵀ
     {ρ⁺ = ρ⁺} {p = p}
     prefix coherent exclusive unique wfR vV noV vV′ noV′ V⊑V′ =
   world-coherent-right-value-indexed-catchup
-    (right-value-indexed-catchup indexed refl refl vV noV vV′ noV′
-      transport type-coherence)
+    (right-value-indexed-catchup indexed refl refl vV noV vV′ noV′)
     lineage source-bullet-transport coherent exclusive unique wfR
   where
   source-typing⁺ =
@@ -84,14 +83,14 @@ world-coherent-right-value-terminal-proofᵀ
       refl
       related⁺
 
-  indexed =
-    weak-indexed-result result related⁺
-
   transport =
     weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
 
   type-coherence =
     weak-step-type-coherence (λ pC pD → refl) (λ q → refl)
+
+  indexed =
+    weak-indexed-result result related⁺ transport type-coherence
 
   lineage =
     weak-step-store-lineage ρ⁺ rel-store-embedding-reflⁱ prefix-reflⁱ

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceAllocationStepProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceAllocationStepProof.agda
@@ -210,6 +210,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportAllType
   ; transportArrowType
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-indexed-result
   ; weak-step-transport
   ; weak-step-type-coherence
@@ -243,8 +245,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceValue
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionWorldCoherentSourceAllocationStepDef using
   (WorldCoherentSourceAllocationStepᵀ)
@@ -593,8 +593,9 @@ private
       second-transport second-coherence second-lineage
       changes-exact result-exact final-world final-exclusive final-unique =
     world-coherent-source-one-step-indexed
-      (weak-one-step-index-resultᵀ combined type-eq)
-      combined-transport combined-coherence combined-lineage
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
+      combined-lineage
       changes-exact result-exact final-world final-exclusive final-unique
     where
     first-raw = weakIndexedResult first-indexed
@@ -728,11 +729,11 @@ world-coherent-source-allocation-step-proofᵀ
     vV noV
     | ρ↑ , liftρ⁺ | source-step , target-refl , related =
   world-coherent-source-one-step-indexed
-    (weak-indexed-result result related)
-    (weak-step-transport
-      (left-lift-prefix-body-proofᵀ
-        liftρ⁺ (prefix-∷ⁱ prefix-reflⁱ)))
-    (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ)
+    (weak-indexed-result result related
+      (weak-step-transport
+        (left-lift-prefix-body-proofᵀ
+          liftρ⁺ (prefix-∷ⁱ prefix-reflⁱ)))
+      (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ))
     (weak-step-store-lineage ρ↑
       (lift-left-store-embeddingⁱ liftρ⁺)
       (prefix-∷ⁱ prefix-reflⁱ))
@@ -800,8 +801,7 @@ world-coherent-source-allocation-step-proofᵀ
     vV noV
     | world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          caught-vV caught-noV caught-vV′ caught-noV′
-          inner-transport inner-coherence)
+          caught-vV caught-noV caught-vV′ caught-noV′)
         (weak-step-store-lineage
           lineage-store lineage-embedding lineage-prefix)
         source-bullet-transport final-coherent final-exclusive final-unique
@@ -813,7 +813,7 @@ world-coherent-source-allocation-step-proofᵀ
     second-transport second-coherence second-lineage
     refl refl final-world final-exclusive⁺ final-unique⁺
   where
-  all = weak-indexed-all-resultᵀ indexed inner-coherence
+  all = weak-indexed-all-resultᵀ indexed
   inner-result = weakIndexedResult indexed
 
   source-store-incl =
@@ -831,9 +831,6 @@ world-coherent-source-allocation-step-proofᵀ
 
   framed = weak-one-step-matched-νcast-frameᵀ
     mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
-
-  first-indexed =
-    weak-indexed-result framed (relatedResults framed)
 
   target-step = ν-step caught-vV′ caught-noV′
 
@@ -863,17 +860,15 @@ world-coherent-source-allocation-step-proofᵀ
     source-s⊑⁺ target-s⊑⁺ compat⁺
     (transportType inner-result pB) liftρ⁺ final-inner
 
-  second-indexed = weak-one-step-index-resultᵀ second refl
-
   first-transport =
     weak-one-step-matched-νcast-frame-preserves-transportᵀ
       mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
-      inner-transport
+      (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
       mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
-      inner-coherence
+      (weakIndexedTypeCoherence indexed)
 
   first-lineage =
     weak-step-store-lineage
@@ -890,6 +885,13 @@ world-coherent-source-allocation-step-proofᵀ
     source-mode⁺ source-seal⁺ target-mode⁺ target-seal⁺
     source-s⊑⁺ target-s⊑⁺ compat⁺
     (transportType inner-result pB) liftρ⁺ final-inner
+
+  first-indexed =
+    weak-indexed-result framed (relatedResults framed)
+      first-transport first-coherence
+
+  second-indexed = weak-one-step-index-resultᵀ second refl
+    second-transport second-coherence
 
   second-lineage = weak-step-store-lineage _
     (lift-store-embeddingⁱ liftρ⁺) (prefix-∷ⁱ prefix-reflⁱ)
@@ -919,8 +921,7 @@ world-coherent-source-allocation-step-proofᵀ
     vV noV
     | world-coherent-right-value-indexed-catchup
         (right-value-indexed-catchup indexed refl refl
-          caught-vV caught-noV caught-vV′ caught-noV′
-          inner-transport inner-coherence)
+          caught-vV caught-noV caught-vV′ caught-noV′)
         (weak-step-store-lineage
           lineage-store lineage-embedding lineage-prefix)
         source-bullet-transport final-coherent final-exclusive final-unique
@@ -932,7 +933,7 @@ world-coherent-source-allocation-step-proofᵀ
     second-transport second-coherence second-lineage
     refl refl final-world final-exclusive⁺ final-unique⁺
   where
-  all = weak-indexed-all-resultᵀ indexed inner-coherence
+  all = weak-indexed-all-resultᵀ indexed
 
   source↑ = weaken-reveal-conversion
     (StoreIncl-cons
@@ -948,9 +949,6 @@ world-coherent-source-allocation-step-proofᵀ
 
   framed = weak-one-step-matched-ν-frameᵀ
     source↑ target↑ pA pB all
-
-  first-indexed =
-    weak-indexed-result framed (relatedResults framed)
 
   target-step = ν-step caught-vV′ caught-noV′
 
@@ -972,15 +970,13 @@ world-coherent-source-allocation-step-proofᵀ
     source↑⁺ target↑⁺ (transportType inner-result pB)
     A⇑⊑A′⇑⁺ liftρ⁺ final-inner
 
-  second-indexed = weak-one-step-index-resultᵀ second refl
-
   first-transport =
     weak-one-step-matched-ν-frame-preserves-transportᵀ
-      source↑ target↑ pA pB all inner-transport
+      source↑ target↑ pA pB all (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
-      source↑ target↑ pA pB all inner-coherence
+      source↑ target↑ pA pB all (weakIndexedTypeCoherence indexed)
 
   first-lineage =
     weak-step-store-lineage
@@ -995,6 +991,13 @@ world-coherent-source-allocation-step-proofᵀ
     caught-vV caught-noV caught-vV′ caught-noV′
     source↑⁺ target↑⁺ (transportType inner-result pB)
     A⇑⊑A′⇑⁺ liftρ⁺ final-inner
+
+  first-indexed =
+    weak-indexed-result framed (relatedResults framed)
+      first-transport first-coherence
+
+  second-indexed = weak-one-step-index-resultᵀ second refl
+    second-transport second-coherence
 
   second-lineage = weak-step-store-lineage _
     (lift-store-embeddingⁱ liftρ⁺) (prefix-∷ⁱ prefix-reflⁱ)
@@ -1048,11 +1051,11 @@ world-coherent-source-allocation-step-proofᵀ
     vV noV
     | ρ↑ , liftρ⁺ | source-step , target-refl , related =
   world-coherent-source-one-step-indexed
-    (weak-indexed-result result related)
-    (weak-step-transport
-      (left-lift-prefix-body-proofᵀ
-        liftρ⁺ (prefix-∷ⁱ prefix-reflⁱ)))
-    (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ)
+    (weak-indexed-result result related
+      (weak-step-transport
+        (left-lift-prefix-body-proofᵀ
+          liftρ⁺ (prefix-∷ⁱ prefix-reflⁱ)))
+      (weak-step-type-coherence source-lift-arrowᵢ source-lift-allᵢ))
     (weak-step-store-lineage ρ↑
       (lift-left-store-embeddingⁱ liftρ⁺)
       (prefix-∷ⁱ prefix-reflⁱ))

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceBulletCatchupDef.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceBulletCatchupDef.agda
@@ -74,7 +74,7 @@ WorldCoherentSourceBulletCatchupᵀ =
     ([] {A = CtxImpEntry
       ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}) →
   Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
-    ⊢ᴺ L ⊑ V′ ⦂ `∀ C ⊑ B′ ∶ ν _ occ p →
+    ⊢ᴺ L ⊑ V′ ⦂ `∀ C ⊑ B′ ∶ ν safe occ p →
   suc Δᴸ
     ∣ leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
     ∣ leftCtxⁱ ([] {A = CtxImpEntry

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceConcealCatchup.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceConcealCatchup.agda
@@ -162,10 +162,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; WeakOneStepTransport
   ; WeakOneStepTypeCoherence
   ; canonicalIndexedResults
-  ; catchupIndexedCoherence
   ; catchupIndexedInvariant
   ; catchupIndexedResult
-  ; catchupIndexedTransport
   ; left-catchup-invariant
   ; left-indexed-catchup
   ; left-silent
@@ -189,6 +187,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionRelStoreEmbeddingAlgebra using
   (rel-store-embedding-reflⁱ)
@@ -384,8 +384,7 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -395,8 +394,7 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -407,8 +405,7 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -418,8 +415,7 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
   world-coherent-left-indexed-catchup
     (left-indexed-catchup framed
       (left-catchup-invariant first-silent
-        (inj₁ (vW ⟨ inert′ ⟩ , no•-⟨⟩ noW)))
-      first-transport first-coherence)
+        (inj₁ (vW ⟨ inert′ ⟩ , no•-⟨⟩ noW))))
     (weak-step-store-lineage
       lineage-store lineage-embedding lineage-prefix)
     coherent exclusive wfL
@@ -433,6 +429,10 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   inert′ =
     applyCoercions-preserves-Inert (sourceChanges inner) inert
@@ -443,17 +443,16 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 world-coherent-source-inert-conceal-castᵀ inert c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -462,10 +461,10 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
     | inj₂ refl =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₂ refl))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₂ refl)))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -530,11 +529,11 @@ world-coherent-source-inert-conceal-castᵀ inert c↓
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -565,8 +564,7 @@ world-coherent-source-id-conceal-castᵀ atom c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -576,8 +574,7 @@ world-coherent-source-id-conceal-castᵀ atom c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -588,8 +585,7 @@ world-coherent-source-id-conceal-castᵀ atom c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -598,10 +594,10 @@ world-coherent-source-id-conceal-castᵀ atom c↓
     | inj₁ (vW , noW) =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₁ (vW , noW))))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -669,11 +665,11 @@ world-coherent-source-id-conceal-castᵀ atom c↓
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -694,8 +690,7 @@ world-coherent-source-id-conceal-castᵀ atom c↓
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -704,10 +699,10 @@ world-coherent-source-id-conceal-castᵀ atom c↓
     | inj₂ refl =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₂ refl))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₂ refl)))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -772,11 +767,11 @@ world-coherent-source-id-conceal-castᵀ atom c↓
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceFunctionCastBetaDirectProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceFunctionCastBetaDirectProof.agda
@@ -51,8 +51,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   ( weak-indexed-arrow-resultᵀ
@@ -65,6 +63,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportArrowCoherent
   ; transportNo•Terms
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-step-transport
   ; weak-step-type-coherence
   )
@@ -147,7 +147,6 @@ finish-source-function-cast-function-catchupᵀ
   function-result = weakIndexedResult function-indexed
   function-arrow =
     weak-indexed-arrow-resultᵀ function-indexed
-      (rightCatchupTypeCoherence catchup)
   function-final = canonicalArrowResults function-arrow
   target-function-value = rightCatchupTargetValue catchup
   target-function-no = rightCatchupTargetNoBullet catchup
@@ -155,18 +154,18 @@ finish-source-function-cast-function-catchupᵀ
     applyTerms-preserves-No•
       (targetTailChanges function-result) noR
   argument-final =
-    transportNo•Terms (rightCatchupTransport catchup)
+    transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup))
       noW noR argument-related
   framed =
     weak-one-step-·₁-frameᵀ noW noR function-result
       function-final argument-final
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup)))
   framed-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
+      (transportArrowCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
+      (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
     weak-step-store-lineage

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetValueProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetValueProof.agda
@@ -43,8 +43,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   ( weak-one-step-index-resultᵀ
@@ -73,6 +71,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportNo•Terms
   ; transportType
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-step-transport
   ; weak-step-type-coherence
   )
@@ -131,8 +131,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepResultExact
   ; sourceStepSourceNameExclusive
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -182,7 +180,7 @@ world-coherent-source-function-cast-beta-target-value-at-proofᵀ
     function-related argument-related vV vW vL′ target-rank
     | caught | refl | refl =
   world-coherent-source-one-step-indexed
-    combined-indexed combined-transport combined-coherence
+    combined-indexed
     combined-lineage combined-changes combined-result combined-world
     combined-exclusive combined-unique
   where
@@ -217,19 +215,19 @@ world-coherent-source-function-cast-beta-target-value-at-proofᵀ
     weak-one-step-·₂-indexed-frameᵀ
       source-function-value source-function-no vL′ target-function-no
       function-related⁺ argument-indexed
-      (rightCatchupTransport catchup)
-      (rightCatchupTypeCoherence catchup)
+      (weakIndexedTransport (rightCatchupIndexedResult catchup))
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
   framed = weakIndexedResult framed-indexed
 
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup)))
 
   framed-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
+      (transportArrowCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
+      (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
 
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
@@ -242,8 +240,8 @@ world-coherent-source-function-cast-beta-target-value-at-proofᵀ
 
   function-final =
     weak-result-transport-arrow-termsᵀ
-      argument-result (rightCatchupTransport catchup)
-      (rightCatchupTypeCoherence catchup)
+      argument-result (weakIndexedTransport (rightCatchupIndexedResult catchup))
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
       source-function-no target-function-no function-related⁺
 
   target-function-value-final =
@@ -308,17 +306,18 @@ world-coherent-source-function-cast-beta-target-value-at-proofᵀ
     assumption-membership-unique→precision-index-unique
       combined-unique _ (transportType combined pB)
 
-  combined-indexed : WeakOneStepIndexedResult pB
-  combined-indexed =
-    weak-one-step-index-resultᵀ combined combined-type-eq
-
   combined-transport =
     sourceSilentTransport composition framed refl refl phase-two-result
-      framed-transport (sourceStepTransport phase-two)
+      framed-transport (weakIndexedTransport (sourceStepIndexedResult phase-two))
 
   combined-coherence =
     sourceSilentTypeCoherence composition framed refl refl phase-two-result
-      framed-coherence (sourceStepTypeCoherence phase-two)
+      framed-coherence (weakIndexedTypeCoherence (sourceStepIndexedResult phase-two))
+
+  combined-indexed : WeakOneStepIndexedResult pB
+  combined-indexed =
+    weak-one-step-index-resultᵀ combined combined-type-eq
+      combined-transport combined-coherence
 
   combined-lineage =
     sourceSilentStoreLineage composition framed refl refl phase-two-result

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceKeepRelationProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceKeepRelationProof.agda
@@ -34,8 +34,7 @@ world-coherent-source-keep-relation-proofᵀ
     {M = M} {M′ = M′} {L = L} {A = A} {B = B} {p = p}
     coherent exclusive unique final-relation M→L =
   world-coherent-source-one-step-indexed
-    indexed transport type-coherence lineage refl refl coherent exclusive
-    unique
+    indexed lineage refl refl coherent exclusive unique
   where
   result =
     weak-step-result
@@ -50,14 +49,14 @@ world-coherent-source-keep-relation-proofᵀ
       refl
       final-relation
 
-  indexed =
-    weak-indexed-result result final-relation
-
   transport =
     weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
 
   type-coherence =
     weak-step-type-coherence (λ pC pD → refl) (λ q → refl)
+
+  indexed =
+    weak-indexed-result result final-relation transport type-coherence
 
   lineage =
     weak-step-store-lineage ρ rel-store-embedding-reflⁱ prefix-reflⁱ

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceLambdaBetaDirectProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceLambdaBetaDirectProof.agda
@@ -51,8 +51,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   ( weak-indexed-arrow-resultᵀ
@@ -70,6 +68,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportNo•Terms
   ; weakArrowResult
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-step-transport
   ; weak-step-type-coherence
   )
@@ -162,7 +162,6 @@ finish-source-lambda-function-catchupᵀ
   function-result = weakIndexedResult function-indexed
   function-arrow =
     weak-indexed-arrow-resultᵀ function-indexed
-      (rightCatchupTypeCoherence catchup)
   function-final = canonicalArrowResults function-arrow
   target-function-value = rightCatchupTargetValue catchup
 finish-source-lambda-function-catchupᵀ
@@ -176,7 +175,6 @@ finish-source-lambda-function-catchupᵀ
   function-result = weakIndexedResult function-indexed
   function-arrow =
     weak-indexed-arrow-resultᵀ function-indexed
-      (rightCatchupTypeCoherence catchup)
   function-final = canonicalArrowResults function-arrow
   target-function-value = rightCatchupTargetValue catchup
   target-function-no = rightCatchupTargetNoBullet catchup
@@ -184,18 +182,18 @@ finish-source-lambda-function-catchupᵀ
     applyTerms-preserves-No•
       (targetTailChanges function-result) noR
   argument-final =
-    transportNo•Terms (rightCatchupTransport catchup)
+    transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup))
       noV noR argument-related
   framed =
     weak-one-step-·₁-frameᵀ noV noR function-result
       function-final argument-final
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup)))
   framed-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
+      (transportArrowCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
+      (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
     weak-step-store-lineage
@@ -226,7 +224,6 @@ finish-source-lambda-function-catchupᵀ
   function-result = weakIndexedResult function-indexed
   function-arrow =
     weak-indexed-arrow-resultᵀ function-indexed
-      (rightCatchupTypeCoherence catchup)
   function-final = canonicalArrowResults function-arrow
   target-function-value = rightCatchupTargetValue catchup
   target-function-no = rightCatchupTargetNoBullet catchup
@@ -234,18 +231,18 @@ finish-source-lambda-function-catchupᵀ
     applyTerms-preserves-No•
       (targetTailChanges function-result) noR
   argument-final =
-    transportNo•Terms (rightCatchupTransport catchup)
+    transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup))
       noV noR argument-related
   framed =
     weak-one-step-·₁-frameᵀ noV noR function-result
       function-final argument-final
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup)))
   framed-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
+      (transportArrowCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
+      (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
     weak-step-store-lineage

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceLambdaBetaTargetFunctionCastDirectProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceLambdaBetaTargetFunctionCastDirectProof.agda
@@ -52,8 +52,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   ( weak-one-step-index-resultᵀ
@@ -82,6 +80,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportNo•Terms
   ; transportType
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-step-transport
   ; weak-step-type-coherence
   )
@@ -140,8 +140,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepResultExact
   ; sourceStepSourceNameExclusive
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -218,7 +216,7 @@ world-coherent-source-lambda-beta-target-function-cast-direct-at-proofᵀ
     function-related argument-related vV vW target-rank
     | caught | refl | refl =
   world-coherent-source-one-step-indexed
-    combined-indexed combined-transport combined-coherence
+    combined-indexed
     combined-lineage combined-changes combined-result combined-world
     combined-exclusive combined-unique
   where
@@ -256,19 +254,19 @@ world-coherent-source-lambda-beta-target-function-cast-direct-at-proofᵀ
       (ƛ _) source-function-no
       target-function-value target-function-no
       function-related⁺ argument-indexed
-      (rightCatchupTransport catchup)
-      (rightCatchupTypeCoherence catchup)
+      (weakIndexedTransport (rightCatchupIndexedResult catchup))
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
   framed = weakIndexedResult framed-indexed
 
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup)))
 
   framed-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
+      (transportArrowCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
+      (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
 
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
@@ -281,8 +279,8 @@ world-coherent-source-lambda-beta-target-function-cast-direct-at-proofᵀ
 
   function-final =
     weak-result-transport-arrow-termsᵀ
-      argument-result (rightCatchupTransport catchup)
-      (rightCatchupTypeCoherence catchup)
+      argument-result (weakIndexedTransport (rightCatchupIndexedResult catchup))
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
       source-function-no target-function-no function-related⁺
 
   function-final′ =
@@ -396,18 +394,19 @@ world-coherent-source-lambda-beta-target-function-cast-direct-at-proofᵀ
           (resultType combined)))
       (transportType combined pB)
 
-  combined-indexed : WeakOneStepIndexedResult pB
-  combined-indexed =
-    weak-one-step-index-resultᵀ combined combined-type-eq
-
   combined-transport =
     sourceSilentTransport composition framed refl refl phase-two-result
-      framed-transport (sourceStepTransport phase-two′)
+      framed-transport (weakIndexedTransport (sourceStepIndexedResult phase-two′))
 
   combined-coherence =
     sourceSilentTypeCoherence composition framed refl refl
       phase-two-result framed-coherence
-      (sourceStepTypeCoherence phase-two′)
+      (weakIndexedTypeCoherence (sourceStepIndexedResult phase-two′))
+
+  combined-indexed : WeakOneStepIndexedResult pB
+  combined-indexed =
+    weak-one-step-index-resultᵀ combined combined-type-eq
+      combined-transport combined-coherence
 
   combined-lineage =
     sourceSilentStoreLineage composition framed refl refl

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceLambdaBetaTargetLambdaDirectProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceLambdaBetaTargetLambdaDirectProof.agda
@@ -48,8 +48,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   ( weak-one-step-index-resultᵀ
@@ -78,6 +76,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportNo•Terms
   ; transportType
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-step-transport
   ; weak-step-type-coherence
   )
@@ -122,8 +122,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepResultExact
   ; sourceStepSourceNameExclusive
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -207,7 +205,7 @@ world-coherent-source-lambda-beta-target-lambda-direct-proofᵀ
     function-related argument-related vV
     | caught | refl | refl =
   world-coherent-source-one-step-indexed
-    combined-indexed combined-transport combined-coherence
+    combined-indexed
     combined-lineage combined-changes combined-result combined-world
     combined-exclusive combined-unique
   where
@@ -242,19 +240,19 @@ world-coherent-source-lambda-beta-target-lambda-direct-proofᵀ
     weak-one-step-·₂-indexed-frameᵀ
       (ƛ _) source-function-no (ƛ _) target-function-no
       function-related⁺ argument-indexed
-      (rightCatchupTransport catchup)
-      (rightCatchupTypeCoherence catchup)
+      (weakIndexedTransport (rightCatchupIndexedResult catchup))
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
 
   framed = weakIndexedResult framed-indexed
 
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult catchup)))
 
   framed-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (rightCatchupTypeCoherence catchup))
-      (transportAllCoherent (rightCatchupTypeCoherence catchup))
+      (transportArrowCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
+      (transportAllCoherent (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup)))
 
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
@@ -267,8 +265,8 @@ world-coherent-source-lambda-beta-target-lambda-direct-proofᵀ
 
   function-final =
     weak-result-transport-arrow-termsᵀ
-      argument-result (rightCatchupTransport catchup)
-      (rightCatchupTypeCoherence catchup)
+      argument-result (weakIndexedTransport (rightCatchupIndexedResult catchup))
+      (weakIndexedTypeCoherence (rightCatchupIndexedResult catchup))
       source-function-no target-function-no function-related⁺
 
   function-final′ =
@@ -379,17 +377,18 @@ world-coherent-source-lambda-beta-target-lambda-direct-proofᵀ
           (resultType combined)))
       (transportType combined pB)
 
-  combined-indexed : WeakOneStepIndexedResult pB
-  combined-indexed =
-    weak-one-step-index-resultᵀ combined combined-type-eq
-
   combined-transport =
     sourceSilentTransport composition framed refl refl phase-two-result
-      framed-transport (sourceStepTransport phase-two′)
+      framed-transport (weakIndexedTransport (sourceStepIndexedResult phase-two′))
 
   combined-coherence =
     sourceSilentTypeCoherence composition framed refl refl phase-two-result
-      framed-coherence (sourceStepTypeCoherence phase-two′)
+      framed-coherence (weakIndexedTypeCoherence (sourceStepIndexedResult phase-two′))
+
+  combined-indexed : WeakOneStepIndexedResult pB
+  combined-indexed =
+    weak-one-step-index-resultᵀ combined combined-type-eq
+      combined-transport combined-coherence
 
   combined-lineage =
     sourceSilentStoreLineage composition framed refl refl phase-two-result

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceNarrowCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceNarrowCatchupProof.agda
@@ -42,6 +42,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   (weak-one-step-reindexᵀ)
@@ -76,8 +78,7 @@ world-coherent-source-narrow-catchup-framedᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -88,8 +89,7 @@ world-coherent-source-narrow-catchup-framedᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -98,8 +98,7 @@ world-coherent-source-narrow-catchup-framedᵀ
   world-coherent-left-catchup-indexed-resume-silentᵀ
     (left-silent-indexed framed
       (left-silent-invariant refl refl)
-      (ok-⟨⟩ (ok-no noW))
-      first-transport first-coherence)
+      (ok-⟨⟩ (ok-no noW)))
     (weak-step-store-lineage
       lineage-store lineage-embedding lineage-prefix)
     (value-catchup
@@ -116,21 +115,12 @@ world-coherent-source-narrow-catchup-framedᵀ
   framed =
     weak-one-step-source-narrow-cast-indexed-frameᵀ
       mode seal★⁺ c⊒⁺ indexed
-
-  first-transport =
-    weak-step-transport (transportNo•Terms inner-transport)
-
-  first-coherence =
-    weak-step-type-coherence
-      (transportArrowCoherent inner-coherence)
-      (transportAllCoherent inner-coherence)
 world-coherent-source-narrow-catchup-framedᵀ
     value-catchup prefix mode seal★ c⊒ vV′ noV′
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -189,12 +179,12 @@ world-coherent-source-narrow-catchup-framedᵀ
       terminal-first-lineage terminal-second-lineage
 
   first-transport =
-    weak-step-transport (transportNo•Terms inner-transport)
+    weak-step-transport (transportNo•Terms (weakIndexedTransport indexed))
 
   first-coherence =
     weak-step-type-coherence
-      (transportArrowCoherent inner-coherence)
-      (transportAllCoherent inner-coherence)
+      (transportArrowCoherent (weakIndexedTypeCoherence indexed))
+      (transportAllCoherent (weakIndexedTypeCoherence indexed))
 
 
 world-coherent-source-narrow-catchup-proofᵀ :
@@ -236,6 +226,10 @@ world-coherent-source-narrow-catchup-proofᵀ
     value-catchup prefix mode seal★ (c⊢ , NW.untag gG) =
   world-coherent-source-narrow-catchup-framedᵀ
     value-catchup prefix mode seal★ (c⊢ , NW.untag gG)
+world-coherent-source-narrow-catchup-proofᵀ
+    value-catchup prefix mode seal★ (c⊢ , NW.fun-untag-gen safe) =
+  world-coherent-source-narrow-catchup-framedᵀ
+    value-catchup prefix mode seal★ (c⊢ , NW.fun-untag-gen safe)
 world-coherent-source-narrow-catchup-proofᵀ
     value-catchup prefix mode seal★ (c⊢ , gG NW.？︔ gˢ) =
   world-coherent-source-narrow-catchup-framedᵀ

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceNuCastCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceNuCastCatchupProof.agda
@@ -57,6 +57,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; sourceStoreResult
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (leftStoreⁱ-prefix-inclusion)
@@ -90,8 +92,7 @@ world-coherent-source-νcast-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     with final
 world-coherent-source-νcast-catchup-proofᵀ
@@ -99,8 +100,7 @@ world-coherent-source-νcast-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     with apply-widen-inst-under-ty-binders
@@ -121,8 +121,7 @@ world-coherent-source-νcast-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     | μ′ , mode′ , final-seal₀ , final-cast₀
@@ -132,8 +131,7 @@ world-coherent-source-νcast-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     | μ′ , mode′ , final-seal₀ , final-cast₀
@@ -182,8 +180,7 @@ world-coherent-source-νcast-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₂ refl =
   world-coherent-left-catchup-indexed-resume-silentᵀ
@@ -211,13 +208,13 @@ world-coherent-source-νcast-catchup-proofᵀ
 
   first-silent =
     left-silent-indexed
-      (weak-indexed-result framed (relatedResults framed))
+      (weak-indexed-result framed (relatedResults framed)
+        (weak-one-step-source-νcast-frame-preserves-transportᵀ
+          mode seal★⁺ c⊑⁺ _ inner (weakIndexedTransport indexed))
+        (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+          mode seal★⁺ c⊑⁺ _ inner (weakIndexedTypeCoherence indexed)))
       (left-silent-invariant refl refl)
       (ok-ν (ok-no no•-blame))
-      (weak-one-step-source-νcast-frame-preserves-transportᵀ
-        mode seal★⁺ c⊑⁺ _ inner inner-transport)
-      (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
-        mode seal★⁺ c⊑⁺ _ inner inner-coherence)
 
   target⊒ =
     nu-term-imprecision-target-typing (relatedResults framed)
@@ -230,13 +227,13 @@ world-coherent-source-νcast-catchup-proofᵀ
   terminal =
     world-coherent-left-indexed-catchup
       (left-indexed-catchup
-        (weak-indexed-result second (relatedResults second))
+        (weak-indexed-result second (relatedResults second)
+          (weak-one-step-keep-source-catchup-transportᵀ
+            blame-ν second-relation)
+          (weak-one-step-keep-source-catchup-type-coherenceᵀ
+            blame-ν second-relation))
         (left-catchup-invariant
-          (left-silent-invariant refl refl) (inj₂ refl))
-        (weak-one-step-keep-source-catchup-transportᵀ
-          blame-ν second-relation)
-        (weak-one-step-keep-source-catchup-type-coherenceᵀ
-          blame-ν second-relation))
+          (left-silent-invariant refl refl) (inj₂ refl)))
       (weak-step-store-lineage
         (resultStore framed) rel-store-embedding-reflⁱ prefix-reflⁱ)
       coherent exclusive wfL

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceNuCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceNuCatchupProof.agda
@@ -55,6 +55,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; sourceCtxResult
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStoreLift using
   (lift-left-store-result)
@@ -87,8 +89,7 @@ world-coherent-source-ν-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     with final
 world-coherent-source-ν-catchup-proofᵀ
@@ -96,8 +97,7 @@ world-coherent-source-ν-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     with weak-result-source-reveal
@@ -112,8 +112,7 @@ world-coherent-source-ν-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     | μ′ , final-reveal
@@ -123,8 +122,7 @@ world-coherent-source-ν-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     | μ′ , final-reveal
@@ -135,8 +133,7 @@ world-coherent-source-ν-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₁ (vW , noW)
     | μ′ , final-reveal
@@ -173,8 +170,7 @@ world-coherent-source-ν-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       inner-lineage coherent exclusive wfL)
     | inj₂ refl =
   world-coherent-left-catchup-indexed-resume-silentᵀ
@@ -198,13 +194,13 @@ world-coherent-source-ν-catchup-proofᵀ
 
   first-silent =
     left-silent-indexed
-      (weak-indexed-result framed (relatedResults framed))
+      (weak-indexed-result framed (relatedResults framed)
+        (weak-one-step-source-ν-frame-preserves-transportᵀ
+          hA c↑⁺ _ inner (weakIndexedTransport indexed))
+        (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+          hA c↑⁺ _ inner (weakIndexedTypeCoherence indexed)))
       (left-silent-invariant refl refl)
       (ok-ν (ok-no no•-blame))
-      (weak-one-step-source-ν-frame-preserves-transportᵀ
-        hA c↑⁺ _ inner inner-transport)
-      (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
-        hA c↑⁺ _ inner inner-coherence)
 
   target⊒ =
     nu-term-imprecision-target-typing (relatedResults framed)
@@ -217,13 +213,13 @@ world-coherent-source-ν-catchup-proofᵀ
   terminal =
     world-coherent-left-indexed-catchup
       (left-indexed-catchup
-        (weak-indexed-result second (relatedResults second))
+        (weak-indexed-result second (relatedResults second)
+          (weak-one-step-keep-source-catchup-transportᵀ
+            blame-ν second-relation)
+          (weak-one-step-keep-source-catchup-type-coherenceᵀ
+            blame-ν second-relation))
         (left-catchup-invariant
-          (left-silent-invariant refl refl) (inj₂ refl))
-        (weak-one-step-keep-source-catchup-transportᵀ
-          blame-ν second-relation)
-        (weak-one-step-keep-source-catchup-type-coherenceᵀ
-          blame-ν second-relation))
+          (left-silent-invariant refl refl) (inj₂ refl)))
       (weak-step-store-lineage
         (resultStore framed) rel-store-embedding-reflⁱ prefix-reflⁱ)
       coherent exclusive wfL

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepBinaryFramesProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepBinaryFramesProof.agda
@@ -88,6 +88,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-type-coherence
   ; weakArrowResult
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionWeakOneStepStoreLineageDef using
   ( lineageEmbedding
@@ -112,8 +114,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepSourceNameExclusive
   ; sourceStepAssumptionMembershipUnique
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -185,16 +185,18 @@ private
     (inner : WeakOneStepIndexedResult
       {M = L} {N′ = L₁′} {χ = χ} {ρ = ρ} idι) →
     WeakOneStepTransport (weakIndexedResult inner) →
+    WeakOneStepTypeCoherence (weakIndexedResult inner) →
     WeakOneStepIndexedResult
       {M = L ⊕[ addℕ ] M}
       {N′ = L₁′ ⊕[ addℕ ] applyTerm χ M′}
       {χ = χ} {ρ = ρ} idι
   weak-one-step-⊕₁-indexed-frameᵀ
       {L = L} {L₁′ = L₁′} {M = M} {M′ = M′}
-      {χ = χ} {ρ = ρ} noM noM′ M⊑M′ inner transport =
+      {χ = χ} {ρ = ρ} noM noM′ M⊑M′ inner transport coherence =
     weak-one-step-index-resultᵀ framed
       (transport-idι-from-ℕ
         source-ℕ target-ℕ (transportType base idι))
+      framed-transport framed-coherence
     where
     base = weakIndexedResult inner
 
@@ -208,6 +210,11 @@ private
     right-related =
       transport-term-to-ℕᵀ source-ℕ target-ℕ
         (transportNo•Terms transport noM noM′ M⊑M′)
+    framed-transport = weak-step-transport (transportNo•Terms transport)
+    framed-coherence =
+      weak-step-type-coherence
+        (transportArrowCoherent coherence)
+        (transportAllCoherent coherence)
 
     framed :
       WeakOneStepResult ρ
@@ -259,16 +266,19 @@ private
     (inner : WeakOneStepIndexedResult
       {M = M} {N′ = M₁′} {χ = χ} {ρ = ρ} idι) →
     WeakOneStepTransport (weakIndexedResult inner) →
+    WeakOneStepTypeCoherence (weakIndexedResult inner) →
     WeakOneStepIndexedResult
       {M = L ⊕[ addℕ ] M}
       {N′ = applyTerm χ L′ ⊕[ addℕ ] M₁′}
       {χ = χ} {ρ = ρ} idι
   weak-one-step-⊕₂-indexed-frameᵀ
       {L = L} {L′ = L′} {M = M} {M₁′ = M₁′}
-      {χ = χ} {ρ = ρ} vL noL vL′ noL′ L⊑L′ inner transport =
+      {χ = χ} {ρ = ρ} vL noL vL′ noL′ L⊑L′ inner transport
+      coherence =
     weak-one-step-index-resultᵀ framed
       (transport-idι-from-ℕ
         source-ℕ target-ℕ (transportType base idι))
+      framed-transport framed-coherence
     where
     base = weakIndexedResult inner
 
@@ -282,6 +292,11 @@ private
     right-related =
       transport-term-to-ℕᵀ
         source-ℕ target-ℕ (canonicalIndexedResults inner)
+    framed-transport = weak-step-transport (transportNo•Terms transport)
+    framed-coherence =
+      weak-step-type-coherence
+        (transportArrowCoherent coherence)
+        (transportAllCoherent coherence)
 
     framed :
       WeakOneStepResult ρ
@@ -347,8 +362,6 @@ source-step-application-left-frameᵀ
     {M = M} {χ = χ} noM noM′ M⊑M′ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -362,24 +375,24 @@ source-step-application-left-frameᵀ
   indexed₀ = sourceStepIndexedResult complete
   inner = weakIndexedResult indexed₀
   arrow =
-    weak-indexed-arrow-resultᵀ
-      indexed₀ (sourceStepTypeCoherence complete)
+    weak-indexed-arrow-resultᵀ indexed₀
   L⊑L′ = canonicalArrowResults arrow
   transported-M =
     transportNo•Terms
-      (sourceStepTransport complete) noM noM′ M⊑M′
+      (weakIndexedTransport (sourceStepIndexedResult complete)) noM noM′ M⊑M′
 
   framed =
     weak-one-step-·₁-frameᵀ noM noM′ inner L⊑L′ transported-M
-  framed-indexed = weak-indexed-result framed (relatedResults framed)
   framed-transport =
     weak-one-step-·₁-frame-preserves-transportᵀ
       noM noM′ inner L⊑L′ transported-M
-      (sourceStepTransport complete)
+      (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-·₁-frame-preserves-type-coherenceᵀ
       noM noM′ inner L⊑L′ transported-M
-      (sourceStepTypeCoherence complete)
+      (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
+  framed-indexed = weak-indexed-result framed (relatedResults framed)
+    framed-transport framed-coherence
 
   term-exact :
     applyTerms (sourceChanges inner) M ≡ applyTerm χ M
@@ -415,8 +428,6 @@ source-step-application-right-frameᵀ
     {V = V} {χ = χ} vV noV vV′ noV′ V⊑V′ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -432,15 +443,8 @@ source-step-application-right-frameᵀ
   framed-indexed =
     weak-one-step-·₂-indexed-frameᵀ
       vV noV vV′ noV′ V⊑V′ indexed₀
-      (sourceStepTransport complete)
-      (sourceStepTypeCoherence complete)
-  framed-transport =
-    weak-step-transport
-      (transportNo•Terms (sourceStepTransport complete))
-  framed-coherence =
-    weak-step-type-coherence
-      (transportArrowCoherent (sourceStepTypeCoherence complete))
-      (transportAllCoherent (sourceStepTypeCoherence complete))
+      (weakIndexedTransport (sourceStepIndexedResult complete))
+      (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   term-exact :
     applyTerms (sourceChanges inner) V ≡ applyTerm χ V
@@ -473,8 +477,6 @@ source-step-primitive-left-frameᵀ
     {M = M} {χ = χ} noM noM′ M⊑M′ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -489,14 +491,9 @@ source-step-primitive-left-frameᵀ
   inner = weakIndexedResult indexed₀
   framed-indexed =
     weak-one-step-⊕₁-indexed-frameᵀ
-      noM noM′ M⊑M′ indexed₀ (sourceStepTransport complete)
-  framed-transport =
-    weak-step-transport
-      (transportNo•Terms (sourceStepTransport complete))
-  framed-coherence =
-    weak-step-type-coherence
-      (transportArrowCoherent (sourceStepTypeCoherence complete))
-      (transportAllCoherent (sourceStepTypeCoherence complete))
+      noM noM′ M⊑M′ indexed₀
+      (weakIndexedTransport (sourceStepIndexedResult complete))
+      (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   term-exact :
     applyTerms (sourceChanges inner) M ≡ applyTerm χ M
@@ -534,8 +531,6 @@ source-step-primitive-right-frameᵀ
     {V = V} {χ = χ} vV noV vV′ noV′ V⊑V′ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -551,14 +546,8 @@ source-step-primitive-right-frameᵀ
   framed-indexed =
     weak-one-step-⊕₂-indexed-frameᵀ
       vV noV vV′ noV′ V⊑V′ indexed₀
-      (sourceStepTransport complete)
-  framed-transport =
-    weak-step-transport
-      (transportNo•Terms (sourceStepTransport complete))
-  framed-coherence =
-    weak-step-type-coherence
-      (transportArrowCoherent (sourceStepTypeCoherence complete))
-      (transportAllCoherent (sourceStepTypeCoherence complete))
+      (weakIndexedTransport (sourceStepIndexedResult complete))
+      (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   term-exact :
     applyTerms (sourceChanges inner) V ≡ applyTerm χ V

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepResultDef.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepResultDef.agda
@@ -20,8 +20,6 @@ open import proof.NuImprecisionAssumptionMembershipUniquenessDef using
   (AssumptionMembershipUnique)
 open import proof.NuImprecisionSimulationResultDef using
   ( WeakOneStepIndexedResult
-  ; WeakOneStepTransport
-  ; WeakOneStepTypeCoherence
   ; resultCtx
   ; resultStore
   ; sourceChanges
@@ -44,14 +42,6 @@ record WorldCoherentSourceOneStepIndexedResult
     sourceStepIndexedResult :
       WeakOneStepIndexedResult
         {M = M} {N′ = M′} {χ = keep} {ρ = ρ} p
-
-    sourceStepTransport :
-      WeakOneStepTransport
-        (weakIndexedResult sourceStepIndexedResult)
-
-    sourceStepTypeCoherence :
-      WeakOneStepTypeCoherence
-        (weakIndexedResult sourceStepIndexedResult)
 
     sourceStepStoreLineage :
       WeakOneStepStoreLineage

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepSourceCastFramesProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepSourceCastFramesProof.agda
@@ -68,6 +68,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (leftStoreⁱ-prefix-inclusion)
@@ -85,8 +87,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepSourceNameExclusive
   ; sourceStepAssumptionMembershipUnique
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -137,8 +137,6 @@ source-step-source-narrow-frameᵀ
     | μ′ , mode′ , seal★′ , c′⊒ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -183,12 +181,16 @@ source-step-source-narrow-frameᵀ
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   cast-exact :
     applyCoercions (sourceChanges inner) c ≡ applyCoercion χ c
@@ -235,8 +237,6 @@ source-step-source-widen-frameᵀ
     | μ′ , mode′ , seal★′ , c′⊑ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -281,12 +281,16 @@ source-step-source-widen-frameᵀ
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   cast-exact :
     applyCoercions (sourceChanges inner) c ≡ applyCoercion χ c
@@ -329,8 +333,6 @@ source-step-source-reveal-frameᵀ
     | μ′ , α′ , X′ , c′↑ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -372,12 +374,16 @@ source-step-source-reveal-frameᵀ
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   cast-exact :
     applyCoercions (sourceChanges inner) c ≡ applyCoercion χ c
@@ -420,8 +426,6 @@ source-step-source-conceal-frameᵀ
     | μ′ , α′ , X′ , c′↓ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -463,12 +467,16 @@ source-step-source-conceal-frameᵀ
 
   framed = weak-one-step-source-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   cast-exact :
     applyCoercions (sourceChanges inner) c ≡ applyCoercion χ c

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepSourceNuFramesProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepSourceNuFramesProof.agda
@@ -68,6 +68,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; sourceResult
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (leftStoreⁱ-prefix-inclusion; rightStoreⁱ-prefix-inclusion)
@@ -85,8 +87,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepSourceNameExclusive
   ; sourceStepAssumptionMembershipUnique
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -137,8 +137,6 @@ source-step-matched-ν-frameᵀ
     {pA = pA} {pB = pB} prefix s↑ s′↑ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -157,7 +155,6 @@ source-step-matched-ν-frameᵀ
     {χ = keep} {ρ = ρ⁺} q
   all =
     weak-indexed-all-resultᵀ {q = q} indexed₀
-      (sourceStepTypeCoherence complete)
 
   source-store-incl =
     StoreIncl-cons
@@ -178,14 +175,20 @@ source-step-matched-ν-frameᵀ
     weak-one-step-matched-ν-frameᵀ {χ = keep} {q = q}
       s↑⁺ s′↑⁺ pA pB all
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-matched-ν-frame-preserves-transportᵀ
+      {χ = keep} {q = q}
+      s↑⁺ s′↑⁺ pA pB all (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
+      {χ = keep} {q = q}
+      s↑⁺ s′↑⁺ pA pB all (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-matched-ν-frame-preserves-transportᵀ
       {χ = keep} {q = q}
-      s↑⁺ s′↑⁺ pA pB all (sourceStepTransport complete)
+      s↑⁺ s′↑⁺ pA pB all (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-matched-ν-frame-preserves-type-coherenceᵀ
       {χ = keep} {q = q}
-      s↑⁺ s′↑⁺ pA pB all (sourceStepTypeCoherence complete)
+      s↑⁺ s′↑⁺ pA pB all (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   type-exact :
     applyTys (sourceChanges inner) A ≡ applyTy χ A
@@ -244,8 +247,6 @@ source-step-matched-νcast-frameᵀ {s = s} {χ = χ} {q = q} {pB = pB}
     prefix mode seal★ s⊑ mode′ seal★′ s′⊑ compat complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -260,7 +261,6 @@ source-step-matched-νcast-frameᵀ {s = s} {χ = χ} {q = q} {pB = pB}
   inner = weakIndexedResult indexed₀
   all =
     weak-indexed-all-resultᵀ {q = q} indexed₀
-      (sourceStepTypeCoherence complete)
 
   source-store-incl =
     StoreIncl-cons
@@ -280,16 +280,24 @@ source-step-matched-νcast-frameᵀ {s = s} {χ = χ} {q = q} {pB = pB}
       {χ = keep} {q = q}
       mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-matched-νcast-frame-preserves-transportᵀ
+      {χ = keep} {q = q}
+      mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
+      (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
+      {χ = keep} {q = q}
+      mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
+      (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-matched-νcast-frame-preserves-transportᵀ
       {χ = keep} {q = q}
       mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
-      (sourceStepTransport complete)
+      (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-matched-νcast-frame-preserves-type-coherenceᵀ
       {χ = keep} {q = q}
       mode seal★⁺ s⊑⁺ mode′ seal★′⁺ s′⊑⁺ compat pB all
-      (sourceStepTypeCoherence complete)
+      (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   star-exact : ★ ≡ applyTy χ ★
   star-exact = sym (applyTy-★ χ)
@@ -334,8 +342,6 @@ source-step-source-ν-frameᵀ {A = A} {s = s} {χ = χ} {pB = pB}
     prefix hA s↑ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -357,12 +363,16 @@ source-step-source-ν-frameᵀ {A = A} {s = s} {χ = χ} {pB = pB}
 
   framed = weak-one-step-source-ν-frameᵀ hA s↑⁺ pB inner
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-source-ν-frame-preserves-transportᵀ
+      hA s↑⁺ pB inner (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
+      hA s↑⁺ pB inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-source-ν-frame-preserves-transportᵀ
-      hA s↑⁺ pB inner (sourceStepTransport complete)
+      hA s↑⁺ pB inner (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-source-ν-frame-preserves-type-coherenceᵀ
-      hA s↑⁺ pB inner (sourceStepTypeCoherence complete)
+      hA s↑⁺ pB inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   type-exact :
     applyTys (sourceChanges inner) A ≡ applyTy χ A
@@ -411,8 +421,6 @@ source-step-source-νcast-frameᵀ {s = s} {χ = χ} {pB = pB}
     prefix mode seal★ s⊑ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -435,12 +443,16 @@ source-step-source-νcast-frameᵀ {s = s} {χ = χ} {pB = pB}
 
   framed = weak-one-step-source-νcast-frameᵀ mode seal★⁺ s⊑⁺ pB inner
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-source-νcast-frame-preserves-transportᵀ
+      mode seal★⁺ s⊑⁺ pB inner (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★⁺ s⊑⁺ pB inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-source-νcast-frame-preserves-transportᵀ
-      mode seal★⁺ s⊑⁺ pB inner (sourceStepTransport complete)
+      mode seal★⁺ s⊑⁺ pB inner (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-source-νcast-frame-preserves-type-coherenceᵀ
-      mode seal★⁺ s⊑⁺ pB inner (sourceStepTypeCoherence complete)
+      mode seal★⁺ s⊑⁺ pB inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
   star-exact : ★ ≡ applyTy χ ★
   star-exact = sym (applyTy-★ χ)

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepTargetCastFramesProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepTargetCastFramesProof.agda
@@ -70,6 +70,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (rightStoreⁱ-prefix-inclusion)
@@ -87,8 +89,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepSourceNameExclusive
   ; sourceStepAssumptionMembershipUnique
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -140,8 +140,6 @@ source-step-target-narrow-frameᵀ
     | μ″ , mode″ , seal★″ , c″⊒ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -186,12 +184,16 @@ source-step-target-narrow-frameᵀ
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 source-step-target-widen-frameᵀ :
@@ -227,8 +229,6 @@ source-step-target-widen-frameᵀ
     | μ″ , mode″ , seal★″ , c″⊑ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -273,12 +273,16 @@ source-step-target-widen-frameᵀ
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 source-step-target-id-widen-frameᵀ :
@@ -302,8 +306,6 @@ source-step-target-id-widen-frameᵀ
     prefix seal★ c′⊑ complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -354,12 +356,16 @@ source-step-target-id-widen-frameᵀ
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 source-step-target-reveal-frameᵀ :
@@ -391,8 +397,6 @@ source-step-target-reveal-frameᵀ
     | μ″ , β″ , X″ , c″↑ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -434,12 +438,16 @@ source-step-target-reveal-frameᵀ
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 source-step-target-conceal-frameᵀ :
@@ -471,8 +479,6 @@ source-step-target-conceal-frameᵀ
     | μ″ , β″ , X″ , c″↓ =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -514,12 +520,16 @@ source-step-target-conceal-frameᵀ
 
   framed = weak-one-step-target-cast-frameᵀ inner final-relation
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-cast-frame-transportᵀ
-      inner final-relation (sourceStepTransport complete)
+      inner final-relation (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-cast-frame-coherenceᵀ
-      inner final-relation (sourceStepTypeCoherence complete)
+      inner final-relation (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 world-coherent-source-one-step-target-cast-frames-proofᵀ :

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepTargetNuFramesProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceOneStepTargetNuFramesProof.agda
@@ -40,6 +40,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ( relatedResults
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionStorePrefix using
   (rightStoreⁱ-prefix-inclusion)
@@ -57,8 +59,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepSourceNameExclusive
   ; sourceStepAssumptionMembershipUnique
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -95,8 +95,6 @@ source-step-target-ν-frameᵀ {p = p}
     prefix hA s↑ r complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -118,12 +116,16 @@ source-step-target-ν-frameᵀ {p = p}
 
   framed = weak-one-step-target-ν-frameᵀ hA s↑⁺ p r inner
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-ν-frame-preserves-transportᵀ
+      hA s↑⁺ p r inner (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
+      hA s↑⁺ p r inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-ν-frame-preserves-transportᵀ
-      hA s↑⁺ p r inner (sourceStepTransport complete)
+      hA s↑⁺ p r inner (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-ν-frame-preserves-type-coherenceᵀ
-      hA s↑⁺ p r inner (sourceStepTypeCoherence complete)
+      hA s↑⁺ p r inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 source-step-target-νcast-frameᵀ :
@@ -151,8 +153,6 @@ source-step-target-νcast-frameᵀ {p = p}
     prefix mode seal★ s⊑ r complete =
   world-coherent-source-one-step-indexed
     framed-indexed
-    framed-transport
-    framed-coherence
     (weak-step-store-lineage
       (lineageStore (sourceStepStoreLineage complete))
       (lineageEmbedding (sourceStepStoreLineage complete))
@@ -178,12 +178,16 @@ source-step-target-νcast-frameᵀ {p = p}
     weak-one-step-target-νcast-frameᵀ
       mode seal★⁺ s⊑⁺ p r inner
   framed-indexed = weak-indexed-result framed (relatedResults framed)
+    (weak-one-step-target-νcast-frame-preserves-transportᵀ
+      mode seal★⁺ s⊑⁺ p r inner (weakIndexedTransport (sourceStepIndexedResult complete)))
+    (weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
+      mode seal★⁺ s⊑⁺ p r inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
   framed-transport =
     weak-one-step-target-νcast-frame-preserves-transportᵀ
-      mode seal★⁺ s⊑⁺ p r inner (sourceStepTransport complete)
+      mode seal★⁺ s⊑⁺ p r inner (weakIndexedTransport (sourceStepIndexedResult complete))
   framed-coherence =
     weak-one-step-target-νcast-frame-preserves-type-coherenceᵀ
-      mode seal★⁺ s⊑⁺ p r inner (sourceStepTypeCoherence complete)
+      mode seal★⁺ s⊑⁺ p r inner (weakIndexedTypeCoherence (sourceStepIndexedResult complete))
 
 
 world-coherent-source-one-step-target-nu-frames-proofᵀ :

--- a/GTSF/proof/NuImprecisionWorldCoherentSourcePairedCastCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourcePairedCastCatchupProof.agda
@@ -68,6 +68,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionWeakOneStepStoreLineageDef using
   ( lineageEmbedding
@@ -160,8 +162,7 @@ world-coherent-source-paired-cast-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       lineage coherent exclusive wfL) =
   world-coherent-left-catchup-indexed-resume-silentᵀ
     first-silent first-lineage second
@@ -182,17 +183,17 @@ world-coherent-source-paired-cast-catchup-proofᵀ
     (lineagePrefix lineage)
 
   first-indexed = weak-indexed-result first (relatedResults first)
+    (weak-step-transport
+      (transportNo•Terms (weakIndexedTransport indexed)))
+    (weak-step-type-coherence
+      (transportArrowCoherent (weakIndexedTypeCoherence indexed))
+      (transportAllCoherent (weakIndexedTypeCoherence indexed)))
 
   first-silent =
     left-silent-indexed
       first-indexed
       (left-silent-invariant refl refl)
       (ok-⟨⟩ (terminal-runtime final))
-      (weak-step-transport
-        (transportNo•Terms inner-transport))
-      (weak-step-type-coherence
-        (transportArrowCoherent inner-coherence)
-        (transportAllCoherent inner-coherence))
 
   second =
     final-catchup coherent exclusive wfL final

--- a/GTSF/proof/NuImprecisionWorldCoherentSourcePrimitiveDeltaDirectProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourcePrimitiveDeltaDirectProof.agda
@@ -61,8 +61,6 @@ open import proof.NuImprecisionRightValueCatchupResultDef using
   ; rightCatchupSourceUnchanged
   ; rightCatchupTargetNoBullet
   ; rightCatchupTargetValue
-  ; rightCatchupTransport
-  ; rightCatchupTypeCoherence
   )
 open import proof.NuImprecisionSimulationCore using
   ( nu-term-imprecision-transport-typesᵀ
@@ -104,6 +102,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionSourceOneStepDeltaRootDef using
   (WorldCoherentSourceDeltaRootᵀ)
@@ -149,8 +149,6 @@ open import
   ; sourceStepResultExact
   ; sourceStepSourceNameExclusive
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -513,8 +511,6 @@ finish-right-catchup-deltaᵀ
     | target-right≡ | refl | refl | refl =
   world-coherent-source-one-step-indexed
     combined-indexed
-    combined-transport
-    combined-coherence
     combined-lineage
     combined-changes
     combined-result
@@ -529,24 +525,24 @@ finish-right-catchup-deltaᵀ
   framed =
     delta-⊕₂-frameᵀ
       ($ (κℕ m)) no•-$ ($ (κℕ m)) no•-$ κ⊑κᵀ
-      right-indexed (rightCatchupTransport right-catchup)
+      right-indexed (weakIndexedTransport (rightCatchupIndexedResult right-catchup))
 
   framed-transport =
     weak-step-transport
-      (transportNo•Terms (rightCatchupTransport right-catchup))
+      (transportNo•Terms (weakIndexedTransport (rightCatchupIndexedResult right-catchup)))
 
   framed-coherence =
     weak-step-type-coherence
       (transportArrowCoherent
-        (rightCatchupTypeCoherence right-catchup))
+        (weakIndexedTypeCoherence (rightCatchupIndexedResult right-catchup)))
       (transportAllCoherent
-        (rightCatchupTypeCoherence right-catchup))
+        (weakIndexedTypeCoherence (rightCatchupIndexedResult right-catchup)))
 
   framed-lineage : WeakOneStepStoreLineage framed
   framed-lineage =
     delta-⊕₂-frame-lineageᵀ
       ($ (κℕ m)) no•-$ ($ (κℕ m)) no•-$ κ⊑κᵀ
-      right-indexed (rightCatchupTransport right-catchup)
+      right-indexed (weakIndexedTransport (rightCatchupIndexedResult right-catchup))
       (worldRightCatchupStoreLineage right-world)
 
   delta-world =
@@ -579,18 +575,19 @@ finish-right-catchup-deltaᵀ
 
   combined = sourceSilentResult composition framed refl refl delta-result
 
+  combined-transport =
+    sourceSilentTransport composition framed refl refl delta-result
+      framed-transport (weakIndexedTransport (sourceStepIndexedResult delta-world′))
+
+  combined-coherence =
+    sourceSilentTypeCoherence composition framed refl refl delta-result
+      framed-coherence (weakIndexedTypeCoherence (sourceStepIndexedResult delta-world′))
+
   combined-indexed : WeakOneStepIndexedResult idι
   combined-indexed =
     weak-one-step-index-resultᵀ combined
       (nat-result-type-unique combined)
-
-  combined-transport =
-    sourceSilentTransport composition framed refl refl delta-result
-      framed-transport (sourceStepTransport delta-world′)
-
-  combined-coherence =
-    sourceSilentTypeCoherence composition framed refl refl delta-result
-      framed-coherence (sourceStepTypeCoherence delta-world′)
+      combined-transport combined-coherence
 
   combined-lineage =
     sourceSilentStoreLineage composition framed refl refl delta-result
@@ -677,8 +674,6 @@ finish-left-then-right-deltaᵀ
     | left-world | target-left≡ | refl | refl | refl =
   world-coherent-source-one-step-indexed
     combined-indexed
-    combined-transport
-    combined-coherence
     combined-lineage
     combined-changes
     combined-result
@@ -689,7 +684,7 @@ finish-left-then-right-deltaᵀ
   left-catchup = worldRightCatchupResult left-world
   left-indexed = rightCatchupIndexedResult left-catchup
   left-result = weakIndexedResult left-indexed
-  left-transport = rightCatchupTransport left-catchup
+  left-transport = weakIndexedTransport (rightCatchupIndexedResult left-catchup)
 
   source-right-typing⁺ =
     term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
@@ -713,9 +708,9 @@ finish-left-then-right-deltaᵀ
   framed-left-coherence =
     weak-step-type-coherence
       (transportArrowCoherent
-        (rightCatchupTypeCoherence left-catchup))
+        (weakIndexedTypeCoherence (rightCatchupIndexedResult left-catchup)))
       (transportAllCoherent
-        (rightCatchupTypeCoherence left-catchup))
+        (weakIndexedTypeCoherence (rightCatchupIndexedResult left-catchup)))
 
   framed-left-lineage =
     delta-⊕₁-frame-lineageᵀ
@@ -751,20 +746,21 @@ finish-left-then-right-deltaᵀ
     sourceSilentResult
       composition framed-left refl refl phase-two-result
 
-  combined-indexed : WeakOneStepIndexedResult idι
-  combined-indexed =
-    weak-one-step-index-resultᵀ combined
-      (nat-result-type-unique combined)
-
   combined-transport =
     sourceSilentTransport
       composition framed-left refl refl phase-two-result
-      framed-left-transport (sourceStepTransport phase-two)
+      framed-left-transport (weakIndexedTransport (sourceStepIndexedResult phase-two))
 
   combined-coherence =
     sourceSilentTypeCoherence
       composition framed-left refl refl phase-two-result
-      framed-left-coherence (sourceStepTypeCoherence phase-two)
+      framed-left-coherence (weakIndexedTypeCoherence (sourceStepIndexedResult phase-two))
+
+  combined-indexed : WeakOneStepIndexedResult idι
+  combined-indexed =
+    weak-one-step-index-resultᵀ combined
+      (nat-result-type-unique combined)
+      combined-transport combined-coherence
 
   combined-lineage =
     sourceSilentStoreLineage

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceRevealCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceRevealCatchupProof.agda
@@ -84,6 +84,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionRelStoreEmbeddingAlgebra using
   (rel-store-embedding-reflⁱ)
@@ -174,8 +176,7 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -185,8 +186,7 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -196,8 +196,7 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
   world-coherent-left-indexed-catchup
     (left-indexed-catchup framed
       (left-catchup-invariant first-silent
-        (inj₁ (vW ⟨ inert′ ⟩ , no•-⟨⟩ noW)))
-      first-transport first-coherence)
+        (inj₁ (vW ⟨ inert′ ⟩ , no•-⟨⟩ noW))))
     (weak-step-store-lineage
       lineage-store lineage-embedding lineage-prefix)
     coherent exclusive wfL
@@ -211,6 +210,10 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   inert′ =
     applyCoercions-preserves-Inert (sourceChanges inner) inert
@@ -221,17 +224,16 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 world-coherent-source-inert-reveal-castᵀ inert c↑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -240,10 +242,10 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
     | inj₂ refl =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₂ refl))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₂ refl)))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -255,6 +257,10 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   first-silent =
     weak-one-step-source-cast-frame-silentᵀ
@@ -310,11 +316,11 @@ world-coherent-source-inert-reveal-castᵀ inert c↑
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -346,8 +352,7 @@ world-coherent-source-id-reveal-castᵀ atom c↑
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -357,8 +362,7 @@ world-coherent-source-id-reveal-castᵀ atom c↑
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -367,10 +371,10 @@ world-coherent-source-id-reveal-castᵀ atom c↑
     | inj₁ (vW , noW) =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₁ (vW , noW))))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -438,11 +442,11 @@ world-coherent-source-id-reveal-castᵀ atom c↑
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -463,8 +467,7 @@ world-coherent-source-id-reveal-castᵀ atom c↑
     (world-coherent-left-indexed-catchup
       (left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -473,10 +476,10 @@ world-coherent-source-id-reveal-castᵀ atom c↑
     | inj₂ refl =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₂ refl))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₂ refl)))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -542,11 +545,11 @@ world-coherent-source-id-reveal-castᵀ atom c↑
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceSilentCompositionProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceSilentCompositionProof.agda
@@ -28,6 +28,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; targetTypeResult
   ; transportType
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionSourceSilentCompositionDef using
   ( SourceSilentComposition
@@ -50,8 +52,6 @@ open import
   ; sourceStepResultExact
   ; sourceStepSourceNameExclusive
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -67,7 +67,7 @@ world-coherent-source-silent-composition-proofᵀ
     composition first source-empty source-same first-transport
     first-coherence first-lineage second =
   world-coherent-source-one-step-indexed
-    combined-indexed combined-transport combined-coherence
+    combined-indexed
     combined-lineage combined-changes combined-result combined-world
     combined-exclusive combined-unique
   where
@@ -99,16 +99,17 @@ world-coherent-source-silent-composition-proofᵀ
           (resultType combined)))
       (transportType combined _)
 
-  combined-indexed =
-    weak-one-step-index-resultᵀ combined combined-type-eq
-
   combined-transport =
     sourceSilentTransport composition first source-empty source-same
-      second-result first-transport (sourceStepTransport second)
+      second-result first-transport (weakIndexedTransport (sourceStepIndexedResult second))
 
   combined-coherence =
     sourceSilentTypeCoherence composition first source-empty source-same
-      second-result first-coherence (sourceStepTypeCoherence second)
+      second-result first-coherence (weakIndexedTypeCoherence (sourceStepIndexedResult second))
+
+  combined-indexed =
+    weak-one-step-index-resultᵀ combined combined-type-eq
+      combined-transport combined-coherence
 
   combined-lineage =
     sourceSilentStoreLineage composition first source-empty source-same

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceSynchronizedLambdaBetaProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceSynchronizedLambdaBetaProof.agda
@@ -41,7 +41,7 @@ world-coherent-source-synchronized-lambda-beta-proofᵀ
     substitute coherent exclusive unique vV noV vV′ noV′ noN noN′
     body argument =
   world-coherent-source-one-step-indexed
-    indexed transport type-coherence lineage refl refl coherent exclusive
+    indexed lineage refl refl coherent exclusive
     unique
   where
   post-beta =
@@ -60,12 +60,12 @@ world-coherent-source-synchronized-lambda-beta-proofᵀ
       refl
       post-beta
 
-  indexed = weak-indexed-result result post-beta
-
   transport = weak-step-transport (λ noL noL′ L⊑L′ → L⊑L′)
 
   type-coherence =
     weak-step-type-coherence (λ pC pD → refl) (λ q → refl)
+
+  indexed = weak-indexed-result result post-beta transport type-coherence
 
   lineage =
     weak-step-store-lineage _ rel-store-embedding-reflⁱ prefix-reflⁱ

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceTargetKeepPrependProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceTargetKeepPrependProof.agda
@@ -46,6 +46,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   ; weak-step-transport
   ; weak-step-type-coherence
   ; transportNo•Terms
@@ -66,8 +68,6 @@ open import proof.NuImprecisionWorldCoherentSourceOneStepResultDef using
   ; sourceStepResultExact
   ; sourceStepSourceNameExclusive
   ; sourceStepStoreLineage
-  ; sourceStepTransport
-  ; sourceStepTypeCoherence
   ; sourceStepWorldCoherent
   ; world-coherent-source-one-step-indexed
   )
@@ -115,7 +115,7 @@ world-coherent-source-target-keep-prepend-proofᵀ :
 world-coherent-source-target-keep-prepend-proofᵀ
     {p = p} target→ complete =
   world-coherent-source-one-step-indexed
-    indexed transport coherence lineage
+    indexed lineage
     (sourceStepChangesExact complete)
     (sourceStepResultExact complete)
     (sourceStepWorldCoherent complete)
@@ -126,21 +126,21 @@ world-coherent-source-target-keep-prepend-proofᵀ
   old-result = weakIndexedResult old-indexed
   new-result = prepend-target-keep-result old-result target→
 
-  indexed : WeakOneStepIndexedResult p
-  indexed =
-    weak-indexed-result new-result
-      (canonicalIndexedResults old-indexed)
-
   transport : WeakOneStepTransport new-result
   transport =
     weak-step-transport
-      (transportNo•Terms (sourceStepTransport complete))
+      (transportNo•Terms (weakIndexedTransport (sourceStepIndexedResult complete)))
 
   coherence : WeakOneStepTypeCoherence new-result
   coherence =
     weak-step-type-coherence
-      (transportArrowCoherent (sourceStepTypeCoherence complete))
-      (transportAllCoherent (sourceStepTypeCoherence complete))
+      (transportArrowCoherent (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
+      (transportAllCoherent (weakIndexedTypeCoherence (sourceStepIndexedResult complete)))
+
+  indexed : WeakOneStepIndexedResult p
+  indexed =
+    weak-indexed-result new-result
+      (canonicalIndexedResults old-indexed) transport coherence
 
   lineage : WeakOneStepStoreLineage new-result
   lineage =

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceUnsealCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceUnsealCatchupProof.agda
@@ -105,6 +105,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionSourceSealCancellationDef using
   (SourceSealCancellationᵀ)
@@ -286,8 +288,7 @@ world-coherent-source-unseal-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -302,8 +303,7 @@ world-coherent-source-unseal-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -316,8 +316,7 @@ world-coherent-source-unseal-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -333,8 +332,7 @@ world-coherent-source-unseal-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -345,11 +343,11 @@ world-coherent-source-unseal-catchup-proofᵀ
     | sv-seal {W = W} {A = Y} vW refl =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
         (left-silent-invariant refl refl)
-        (inj₁ (vW , seal-no•⁻¹ noS)))
-      combined-transport combined-coherence)
+        (inj₁ (vW , seal-no•⁻¹ noS))))
     combined-lineage coherent exclusive wfL
   where
   inner = weakIndexedResult indexed
@@ -420,11 +418,11 @@ world-coherent-source-unseal-catchup-proofᵀ
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -444,8 +442,7 @@ world-coherent-source-unseal-catchup-proofᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          (left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          (left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -472,6 +469,10 @@ world-coherent-source-unseal-catchup-proofᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   terminal-first =
     weak-one-step-reindexᵀ first refl refl
@@ -509,8 +510,8 @@ world-coherent-source-unseal-catchup-proofᵀ
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)

--- a/GTSF/proof/NuImprecisionWorldCoherentSourceWidenCatchupProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentSourceWidenCatchupProof.agda
@@ -133,6 +133,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; transportType
   ; weak-indexed-result
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionSourceCastSequenceMidpointDef using
   (SourceCastSequenceMidpointᵀ; widening-midpoint)
@@ -431,8 +433,7 @@ world-coherent-source-inert-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -444,8 +445,7 @@ world-coherent-source-inert-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -458,8 +458,7 @@ world-coherent-source-inert-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -469,8 +468,7 @@ world-coherent-source-inert-widen-castᵀ
     world-coherent-left-indexed-catchup
       (left-indexed-catchup framed
         (left-catchup-invariant first-silent
-          (inj₁ (vW ⟨ inert′ ⟩ , no•-⟨⟩ noW)))
-        first-transport first-coherence)
+          (inj₁ (vW ⟨ inert′ ⟩ , no•-⟨⟩ noW))))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL
@@ -484,6 +482,10 @@ world-coherent-source-inert-widen-castᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   inert′ =
     applyCoercions-preserves-Inert (sourceChanges inner) inert
@@ -494,19 +496,18 @@ world-coherent-source-inert-widen-castᵀ
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 world-coherent-source-inert-widen-castᵀ
     {N = N} {V′ = V′} {c = c} {ρ⁺ = ρ⁺}
     inert prefix mode seal★ c⊑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -529,6 +530,10 @@ world-coherent-source-inert-widen-castᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   first-silent =
     weak-one-step-source-cast-frame-silentᵀ
@@ -536,11 +541,11 @@ world-coherent-source-inert-widen-castᵀ
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   terminal-first =
     weak-one-step-reindexᵀ first refl refl
@@ -590,8 +595,7 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -601,8 +605,7 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -613,8 +616,7 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -623,10 +625,10 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
     | inj₁ (vW , noW) =
   world-coherent-left-indexed-catchup
     (left-indexed-catchup
-      (weak-one-step-index-resultᵀ combined type-eq)
+      (weak-one-step-index-resultᵀ combined type-eq
+        combined-transport combined-coherence)
       (left-catchup-invariant
-        (left-silent-invariant refl refl) (inj₁ (vW , noW)))
-      combined-transport combined-coherence)
+        (left-silent-invariant refl refl) (inj₁ (vW , noW))))
     combined-lineage
     coherent exclusive wfL
   where
@@ -680,11 +682,11 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -705,8 +707,7 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -729,6 +730,10 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   first-silent =
     weak-one-step-source-cast-frame-silentᵀ
@@ -736,11 +741,11 @@ world-coherent-source-id-widen-castᵀ atom prefix mode seal★ c⊑
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   terminal-first =
     weak-one-step-reindexᵀ first refl refl
@@ -819,8 +824,7 @@ world-coherent-source-seq-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -835,8 +839,7 @@ world-coherent-source-seq-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -850,8 +853,7 @@ world-coherent-source-seq-widen-castᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -879,11 +881,11 @@ world-coherent-source-seq-widen-castᵀ
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   source-p =
     indexed-source-precision indexed
@@ -937,8 +939,6 @@ world-coherent-source-seq-widen-castᵀ
       (HE.sym (weak-one-step-compose-type-to-nested≅
         first second q)))
 
-  first-indexed = weak-one-step-index-resultᵀ combined type-eq
-
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
       (left-silent first first-silent) second
@@ -955,21 +955,22 @@ world-coherent-source-seq-widen-castᵀ
         (post-catchup-β-seq (sourceChanges inner) vW)
         second-relation)
 
+  first-indexed = weak-one-step-index-resultᵀ combined type-eq
+    combined-transport combined-coherence
+
   runtime =
     ok-⟨⟩ (ok-⟨⟩ (ok-no noW))
 
   first-silent-result =
     left-silent-indexed first-indexed
       (left-silent-invariant refl refl) runtime
-      combined-transport combined-coherence
 world-coherent-source-seq-widen-castᵀ
     midpoint value-prefix
     prefix mode seal★ s⊑ t⊑ seqʷ vV′ noV′
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -993,6 +994,10 @@ world-coherent-source-seq-widen-castᵀ
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   first-silent =
     weak-one-step-source-cast-frame-silentᵀ
@@ -1000,11 +1005,11 @@ world-coherent-source-seq-widen-castᵀ
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   terminal-first =
     weak-one-step-reindexᵀ first refl refl
@@ -1058,8 +1063,7 @@ world-coherent-source-inst-widen-castᵀ value-prefix
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -1070,8 +1074,7 @@ world-coherent-source-inst-widen-castᵀ value-prefix
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -1084,8 +1087,7 @@ world-coherent-source-inst-widen-castᵀ value-prefix
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -1164,15 +1166,13 @@ world-coherent-source-inst-widen-castᵀ value-prefix
       (HE.sym (weak-one-step-compose-type-to-nested≅
         first second q)))
 
-  first-indexed = weak-one-step-index-resultᵀ combined type-eq
-
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   combined-transport =
     weak-one-step-prepend-left-silent-preserves-transportᵀ
@@ -1190,20 +1190,21 @@ world-coherent-source-inst-widen-castᵀ value-prefix
         (post-catchup-β-inst (sourceChanges inner) vW)
         second-relation)
 
+  first-indexed = weak-one-step-index-resultᵀ combined type-eq
+    combined-transport combined-coherence
+
   runtime =
     ok-ν (ok-no noW)
 
   first-silent-result =
     left-silent-indexed first-indexed
       (left-silent-invariant refl refl) runtime
-      combined-transport combined-coherence
 world-coherent-source-inst-widen-castᵀ value-prefix
     prefix mode seal★ c⊑ vV′ noV′
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         (left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        inner-transport inner-coherence)
+          silent@(left-silent-invariant refl refl) final))
       (weak-step-store-lineage
         lineage-store lineage-embedding lineage-prefix)
       coherent exclusive wfL)
@@ -1226,6 +1227,10 @@ world-coherent-source-inst-widen-castᵀ value-prefix
   first = weak-one-step-source-cast-frameᵀ inner final-relation
 
   framed = weak-indexed-result first (relatedResults first)
+    (weak-one-step-source-cast-frame-transportᵀ
+      inner final-relation (weakIndexedTransport indexed))
+    (weak-one-step-source-cast-frame-coherenceᵀ
+      inner final-relation (weakIndexedTypeCoherence indexed))
 
   first-silent =
     weak-one-step-source-cast-frame-silentᵀ
@@ -1233,11 +1238,11 @@ world-coherent-source-inst-widen-castᵀ value-prefix
 
   first-transport =
     weak-one-step-source-cast-frame-transportᵀ
-      inner final-relation inner-transport
+      inner final-relation (weakIndexedTransport indexed)
 
   first-coherence =
     weak-one-step-source-cast-frame-coherenceᵀ
-      inner final-relation inner-coherence
+      inner final-relation (weakIndexedTypeCoherence indexed)
 
   terminal-first =
     weak-one-step-reindexᵀ first refl refl

--- a/GTSF/proof/NuImprecisionWorldCoherentTargetRevealRootProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentTargetRevealRootProof.agda
@@ -30,10 +30,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; WeakOneStepTransport
   ; WeakOneStepTypeCoherence
   ; canonicalIndexedResults
-  ; catchupIndexedCoherence
   ; catchupIndexedInvariant
   ; catchupIndexedResult
-  ; catchupIndexedTransport
   ; resultCtx
   ; resultLeftCtx
   ; resultRightCtx
@@ -62,6 +60,8 @@ open import proof.NuImprecisionSimulationResultDef using
   ; weak-step-transport
   ; weak-step-type-coherence
   ; weakIndexedResult
+  ; weakIndexedTransport
+  ; weakIndexedTypeCoherence
   )
 open import proof.NuImprecisionTargetSealCancellationDef using
   (TargetSealCancellationᵀ)
@@ -103,9 +103,19 @@ target-reveal-retarget-resultᵀ :
 target-reveal-retarget-resultᵀ
     {M = M} {V = V} {A = A} {X′ = X′} {ρ = ρ}
     q catchup refl refl related =
-  weak-indexed-result result related
+  weak-indexed-result result related transport coherence
   where
   old = weakIndexedResult (catchupIndexedResult catchup)
+  transport =
+    weak-step-transport
+      (transportNo•Terms
+        (weakIndexedTransport (catchupIndexedResult catchup)))
+  coherence =
+    weak-step-type-coherence
+      (transportArrowCoherent
+        (weakIndexedTypeCoherence (catchupIndexedResult catchup)))
+      (transportAllCoherent
+        (weakIndexedTypeCoherence (catchupIndexedResult catchup)))
 
   result : WeakOneStepResult ρ M V A X′ keep
   result =
@@ -160,8 +170,8 @@ target-reveal-retarget-transportᵀ :
       (target-reveal-retarget-resultᵀ
         q catchup tail-empty target-same related))
 target-reveal-retarget-transportᵀ q catchup refl refl related =
-  weak-step-transport
-    (transportNo•Terms (catchupIndexedTransport catchup))
+  weakIndexedTransport
+    (target-reveal-retarget-resultᵀ q catchup refl refl related)
 
 
 target-reveal-retarget-coherenceᵀ :
@@ -189,9 +199,8 @@ target-reveal-retarget-coherenceᵀ :
       (target-reveal-retarget-resultᵀ
         q catchup tail-empty target-same related))
 target-reveal-retarget-coherenceᵀ q catchup refl refl related =
-  weak-step-type-coherence
-    (transportArrowCoherent (catchupIndexedCoherence catchup))
-    (transportAllCoherent (catchupIndexedCoherence catchup))
+  weakIndexedTypeCoherence
+    (target-reveal-retarget-resultᵀ q catchup refl refl related)
 
 
 world-coherent-target-reveal-root-proofᵀ :
@@ -235,8 +244,6 @@ world-coherent-target-reveal-root-proofᵀ
     | inj₁ (vW , noW) | refl | refl =
   world-indexed-outcome-related
     retargeted
-    (target-reveal-retarget-transportᵀ q caught refl refl canceled)
-    (target-reveal-retarget-coherenceᵀ q caught refl refl canceled)
     final-coherent
     final-exclusive
   where

--- a/GTSF/proof/NuImprecisionWorldCoherentValueCatchupPrefixProof.agda
+++ b/GTSF/proof/NuImprecisionWorldCoherentValueCatchupPrefixProof.agda
@@ -95,8 +95,7 @@ world-coherent-left-catchup-prefix-down-upᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         invariant@(left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        transport coherence)
+          silent@(left-silent-invariant refl refl) final))
       lineage coherent final-exclusive final-wfL) =
   world-coherent-left-catchup-indexed-resume-silentᵀ
     (left-silent-indexed-prefix-down-up-from-finalᵀ
@@ -152,8 +151,7 @@ world-coherent-left-catchup-prefix-gen-down-upᵀ
     (world-coherent-left-indexed-catchup
       catchup@(left-indexed-catchup indexed
         invariant@(left-catchup-invariant
-          silent@(left-silent-invariant refl refl) final)
-        transport coherence)
+          silent@(left-silent-invariant refl refl) final))
       lineage coherent final-exclusive final-wfL) =
   world-coherent-left-catchup-indexed-resume-silentᵀ
     (left-silent-indexed-prefix-down-up-from-finalᵀ


### PR DESCRIPTION
## Summary

Fixes #78.

This flattens the GTSF weak-simulation result carriers so the indexed success package carries the core result, canonical transported relation, transport evidence, and type-coherence evidence together. It also migrates the source/right/left catch-up and world-coherent consumers away from parallel transport/coherence arguments and old nested projection chains.

The source-only final `ν` helpers now expose the `NonVar` witness required by the current `ν` precision constructor, and the source-bullet catch-up statement uses that witness explicitly instead of leaving an unresolved meta.

## Validation

Focused Agda checks run on the changed import chain, including:

- `make agda FILE=proof/NuImprecisionSimulationResultDef.agda`
- `make agda FILE=proof/NuImprecisionSimulationCore.agda`
- `make agda FILE=proof/NuImprecisionSimulation.agda`
- `make agda FILE=proof/NuImprecisionAllocationSimulation.agda`
- right-target resume/framing/terminalization modules
- source one-step frame modules
- source catch-up modules for widen/reveal/conceal/unseal/nu/nucast/narrow/allocation/cast
- final source `ν` and `νcast` source-only and dispatcher modules
- lambda/function-cast beta direct modules and primitive delta direct proof
- `git diff --check`

Not run to completion: full `All.agda`, per issue guidance that it is too slow for this pass. `proof/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletTransportProof.agda` still fails on pre-existing incomplete pattern coverage for `gen⊑groundᵀ`/active quotient runtime cases, after the carrier-shape changes scope-check.