### PR TITLE
Finish backward target blame theorem

### DIFF
--- a/GTSF/PairedWideningCompatibility.agda
+++ b/GTSF/PairedWideningCompatibility.agda
@@ -12,7 +12,6 @@ module PairedWideningCompatibility where
 open import Agda.Builtin.Equality using (_≡_; refl)
 import Coercions as C
 open import Coercions using (Coercion; Inert)
-open import Data.Empty using (⊥)
 open import Data.List using (_∷_)
 open import Data.Nat using (zero; suc)
 open import Data.Product using (Σ; _×_; _,_)
@@ -83,12 +82,12 @@ data PairedWideningCompatible
       {`∀ A} {`∀ A′} {`∀ B} {`∀ B′}
       (∀ⁱ p) (∀ⁱ q) (∀ˢ c-shape) (∀ˢ c′-shape)
 
-  compatible-target-active :
+  compatible-source-inert :
     ∀ {c c′ : Coercion} {A A′ B B′ : Ty}
       {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
       {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
       {c-shape c′-shape : ImprecisionShape} →
-    (Inert c′ → ⊥) →
+    Inert c →
     PairedWideningCompatible
       Φ Δᴸ Δᴿ c c′ p q c-shape c′-shape
 
@@ -97,10 +96,10 @@ data PairedWideningCompatible
       {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
       {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ}
       {c-shape c′-shape : ImprecisionShape} →
-    Inert c′ →
-    Σ (Φ ∣ Δᴸ ⊢ B ⊑ A′ ⊣ Δᴿ) (λ bridge →
+    (Inert c′ →
+      Σ (Φ ∣ Δᴸ ⊢ B ⊑ A′ ⊣ Δᴿ) (λ bridge →
       (c-shape ； ⌊ bridge ⌋ ≋ ⌊ p ⌋) ×
-      (⌊ bridge ⌋ ； c′-shape ≋ ⌊ q ⌋)) →
+      (⌊ bridge ⌋ ； c′-shape ≋ ⌊ q ⌋))) →
     PairedWideningCompatible
       Φ Δᴸ Δᴿ c c′ p q c-shape c′-shape
 
@@ -138,17 +137,19 @@ paired-widening-compatible-shape-transport
       (∀ˢ-injective q-shape)
       compatible)
 paired-widening-compatible-shape-transport
-    p-shape q-shape (compatible-target-active active) =
-  compatible-target-active active
+    p-shape q-shape (compatible-source-inert inert) =
+  compatible-source-inert inert
 paired-widening-compatible-shape-transport
     p-shape q-shape
-    (compatible-target-inert-bridge inert′
-      (bridge , source-triangle , target-triangle)) =
-  compatible-target-inert-bridge inert′
-    ( bridge
-    , transport-result p-shape source-triangle
-    , transport-result q-shape target-triangle
-    )
+    (compatible-target-inert-bridge bridge-evidence) =
+  compatible-target-inert-bridge λ inert′ →
+    let
+      bridge , source-triangle , target-triangle =
+        bridge-evidence inert′
+    in
+      bridge
+      , transport-result p-shape source-triangle
+      , transport-result q-shape target-triangle
   where
   transport-result :
     ∀ {s t r r′} →

--- a/GTSF/proof/Catchup/Simulation/NuImprecisionSimulationCore.agda
+++ b/GTSF/proof/Catchup/Simulation/NuImprecisionSimulationCore.agda
@@ -227,7 +227,10 @@ open import QuotientedTermImprecision
 open import ConversionIndexCompatibility
 open import PairedWideningCompatibility using
   ( PairedWideningCompatible
+  ; compatible-all
+  ; compatible-function
   ; compatible-source-inert
+  ; compatible-tag
   ; compatible-target-inert-bridge
   )
 open import ImprecisionComposition using
@@ -502,6 +505,19 @@ paired-widening-compatible-rename²ᵢ :
     (⊑-renameᵗ²ᵢ assm hτ hσ p)
     (⊑-renameᵗ²ᵢ assm hτ hσ q)
     c-shape c′-shape
+paired-widening-compatible-rename²ᵢ {τ = τ} hτ hσ
+    (compatible-tag G) =
+  compatible-tag (renameᵗ τ G)
+paired-widening-compatible-rename²ᵢ hτ hσ
+    (compatible-function compatible) =
+  compatible-function
+    (paired-widening-compatible-rename²ᵢ hτ hσ compatible)
+paired-widening-compatible-rename²ᵢ {assm = assm} hτ hσ
+    (compatible-all compatible) =
+  compatible-all
+    (paired-widening-compatible-rename²ᵢ
+      {assm = rename-assm²-⇑ᵢ assm}
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) compatible)
 paired-widening-compatible-rename²ᵢ hτ hσ
     (compatible-source-inert inert) =
   compatible-source-inert (renameᶜ-preserves-Inert _ inert)
@@ -538,6 +554,23 @@ paired-widening-compatible-rename-under-binders²ᵢ :
       (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) q)
     (⊑-lift∀ᵢ (⊑-renameᵗ²ᵢ assm hτ hσ p))
     c-shape c′-shape
+paired-widening-compatible-rename-under-binders²ᵢ {τ = τ} hτ hσ
+    (compatible-tag G) =
+  compatible-tag (renameᵗ (extᵗ τ) G)
+paired-widening-compatible-rename-under-binders²ᵢ
+    {B = B₁ ⇒ B₂} {B′ = B₁′ ⇒ B₂′}
+    {p = p₁ ↦ p₂} {q = q₁ ↦ q₂} hτ hσ
+    (compatible-function compatible) =
+  compatible-function
+    (paired-widening-compatible-rename-under-binders²ᵢ
+      hτ hσ compatible)
+paired-widening-compatible-rename-under-binders²ᵢ
+    {τ = τ} {c = C.`∀ c}
+    {B = `∀ B} {B′ = `∀ B′} {p = ∀ⁱ p} {q = ∀ⁱ q}
+    {assm = assm} hτ hσ
+    (compatible-all compatible) =
+  compatible-source-inert
+    (renameᶜ-preserves-Inert (extᵗ τ) (C.`∀ c))
 paired-widening-compatible-rename-under-binders²ᵢ
     {Ψ = Ψ} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ} {τ = τ} {σ = σ}
     {c = c} {c′ = c′} {B = B} {p = p} {q = q}
@@ -5239,6 +5272,19 @@ paired-widening-compatible-rename-leftᵢ :
     (⊑-rename-leftᵢ τ assm hτ p)
     (⊑-rename-leftᵢ τ assm hτ q)
     c-shape c′-shape
+paired-widening-compatible-rename-leftᵢ {τ = τ} hτ
+    (compatible-tag G) =
+  compatible-tag (renameᵗ τ G)
+paired-widening-compatible-rename-leftᵢ hτ
+    (compatible-function compatible) =
+  compatible-function
+    (paired-widening-compatible-rename-leftᵢ hτ compatible)
+paired-widening-compatible-rename-leftᵢ {assm = assm} hτ
+    (compatible-all compatible) =
+  compatible-all
+    (paired-widening-compatible-rename-leftᵢ
+      {assm = rename-assm²-∀-leftᵢ assm}
+      (TyRenameWf-ext hτ) compatible)
 paired-widening-compatible-rename-leftᵢ hτ
     (compatible-source-inert inert) =
   compatible-source-inert (renameᶜ-preserves-Inert _ inert)
@@ -5273,6 +5319,23 @@ paired-widening-compatible-rename-left-under-bindersᵢ :
       (rename-assm²-∀-leftᵢ assm) (TyRenameWf-ext hτ) q)
     (⊑-lift∀ᵢ (⊑-rename-leftᵢ τ assm hτ p))
     c-shape c′-shape
+paired-widening-compatible-rename-left-under-bindersᵢ {τ = τ} hτ
+    (compatible-tag G) =
+  compatible-tag (renameᵗ (extᵗ τ) G)
+paired-widening-compatible-rename-left-under-bindersᵢ
+    {B = B₁ ⇒ B₂} {B′ = B₁′ ⇒ B₂′}
+    {p = p₁ ↦ p₂} {q = q₁ ↦ q₂} hτ
+    (compatible-function compatible) =
+  compatible-function
+    (paired-widening-compatible-rename-left-under-bindersᵢ
+      hτ compatible)
+paired-widening-compatible-rename-left-under-bindersᵢ
+    {τ = τ} {c = C.`∀ c}
+    {B = `∀ B} {B′ = `∀ B′} {p = ∀ⁱ p} {q = ∀ⁱ q}
+    {assm = assm} hτ
+    (compatible-all compatible) =
+  compatible-source-inert
+    (renameᶜ-preserves-Inert (extᵗ τ) (C.`∀ c))
 paired-widening-compatible-rename-left-under-bindersᵢ
     {τ = τ} {c′ = c′} {B = B} {p = p} {q = q}
     {assm = assm} hτ (compatible-source-inert inert) =
@@ -16569,10 +16632,11 @@ weak-one-step-matched-νcast-frameᵀ
             (transportShapeCoherent coherence (∀ⁱ body))))
 
     transport-compat :
+      (pB₀ : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
       PairedWideningCompatible
         ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
         (suc Δᴸ) (suc Δᴿ) s s′
-        q (⊑-lift∀ᵢ pB) s-shape s′-shape →
+        q (⊑-lift∀ᵢ pB₀) s-shape s′-shape →
       PairedWideningCompatible
         ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ (resultCtx inner))
         (suc (resultLeftCtx inner)) (suc (resultRightCtx inner))
@@ -16580,13 +16644,28 @@ weak-one-step-matched-νcast-frameᵀ
         (applyCoercionUnderTyBinders (targetTailChanges inner)
           (applyCoercionUnderTyBinder χ s′))
         (transportAllBody inner q)
-        (⊑-lift∀ᵢ (transportType inner pB))
+        (⊑-lift∀ᵢ (transportType inner pB₀))
         s-shape s′-shape
-    transport-compat (compatible-source-inert inert) =
+    transport-compat pB₀ (compatible-tag G) =
+      compatible-source-inert
+        (applyCoercionUnderTyBinders-preserves-Inert
+          (sourceChanges inner) (G C.!))
+    transport-compat (p₁ ↦ p₂)
+        (compatible-function {c₁ = c₁} {c₂ = c₂} compatible) =
+      compatible-source-inert
+        (applyCoercionUnderTyBinders-preserves-Inert
+          (sourceChanges inner) (c₁ C.↦ c₂))
+    transport-compat (∀ⁱ p)
+        (compatible-all {c = c} compatible) =
+      compatible-source-inert
+        (applyCoercionUnderTyBinders-preserves-Inert
+          (sourceChanges inner) (C.`∀ c))
+    transport-compat pB₀ (compatible-source-inert inert) =
       compatible-source-inert
         (applyCoercionUnderTyBinders-preserves-Inert
           (sourceChanges inner) inert)
-    transport-compat (compatible-target-inert-bridge bridge-evidence) =
+    transport-compat pB₀
+        (compatible-target-inert-bridge bridge-evidence) =
       compatible-target-inert-bridge λ inert′ →
         let
           bridge , source-triangle , target-triangle =
@@ -16614,13 +16693,13 @@ weak-one-step-matched-νcast-frameᵀ
             source-triangle ,
           imprecision-composition-shape-transport
             bridge-shape refl
-            (trans (shape-lift∀ᵢ (transportType inner pB))
-              (trans (transportShapeCoherent coherence pB)
-                (sym (shape-lift∀ᵢ pB))))
+            (trans (shape-lift∀ᵢ (transportType inner pB₀))
+              (trans (transportShapeCoherent coherence pB₀)
+                (sym (shape-lift∀ᵢ pB₀))))
             target-triangle
 
     result-compat =
-      transport-compat compat
+      transport-compat pB compat
 
     transported-source-comp =
       imprecision-composition-shape-transport

--- a/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardBlame.agda
+++ b/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardBlame.agda
@@ -1,12 +1,10 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 module proof.DGG.TerminalBackward.NuDGGTerminalBackwardBlame where
 
 -- File Charter:
 --   * Owns the exact backward target-blame terminal theorem required by the
 --     closed Nu DGG spine.
---   * The statement is frozen and checked; its proof will combine target-step
---     simulation, target-blame catch-up, alignment, and trace induction.
+--   * The proof is the live assembly of target-step simulation,
+--     target-blame catch-up, alignment, and trace induction.
 
 open import Data.List using ([])
 open import Data.Product using (∃-syntax)
@@ -23,6 +21,8 @@ open import NuTerms using (RuntimeOK; blame)
 open import QuotientedTermImprecision using
   (_∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_)
 open import proof.DGG.Core.NuDGGClosedWorld using (empty-store-wf)
+open import proof.DGG.TerminalBackward.NuDGGTerminalBackwardBlameIntegration
+  using (backward-target-blame-general-integratedᵀ)
 
 
 backward-target-blame-generalᵀ :
@@ -38,7 +38,8 @@ backward-target-blame-generalᵀ :
   ∀ χs′ →
   M′ —↠[ χs′ ] blame →
   ∃[ χs ] (M —↠[ χs ] blame)
-backward-target-blame-generalᵀ = {!!}
+backward-target-blame-generalᵀ =
+  backward-target-blame-general-integratedᵀ
 
 
 backward-target-blameᵀ :

--- a/GTSF/proof/NuCore/Misc/NuImprecisionAllocationSimulation.agda
+++ b/GTSF/proof/NuCore/Misc/NuImprecisionAllocationSimulation.agda
@@ -83,7 +83,10 @@ open import ConversionIndexCompatibility using
 open import ImprecisionWf
 open import PairedWideningCompatibility using
   ( PairedWideningCompatible
+  ; compatible-all
+  ; compatible-function
   ; compatible-source-inert
+  ; compatible-tag
   ; compatible-target-inert-bridge
   )
 open import NarrowWiden using
@@ -2346,6 +2349,26 @@ weak-result-transport-paired-widening-compatible-under-binderᵀ :
     (transportAllBody inner q)
     (⊑-lift∀ᵢ (transportType inner p))
     s s′
+weak-result-transport-paired-widening-compatible-under-binderᵀ
+    inner coherent (compatible-tag G) =
+  compatible-source-inert
+    (applyCoercionUnderTyBinders-preserves-Inert
+      (sourceChanges inner) (G C.!))
+weak-result-transport-paired-widening-compatible-under-binderᵀ
+    {B = B₁ ⇒ B₂} {B′ = B₁′ ⇒ B₂′}
+    {p = p₁ ↦ p₂}
+    inner coherent
+    (compatible-function {c₁ = c₁} {c₂ = c₂} compatible) =
+  compatible-source-inert
+    (applyCoercionUnderTyBinders-preserves-Inert
+      (sourceChanges inner) (c₁ C.↦ c₂))
+weak-result-transport-paired-widening-compatible-under-binderᵀ
+    {B = `∀ B} {B′ = `∀ B′} {p = ∀ⁱ p}
+    inner coherent
+    (compatible-all {c = c} compatible) =
+  compatible-source-inert
+    (applyCoercionUnderTyBinders-preserves-Inert
+      (sourceChanges inner) (C.`∀ c))
 weak-result-transport-paired-widening-compatible-under-binderᵀ
     inner coherent
     (compatible-source-inert inert-c) =

--- a/GTSF/proof/OneStep/NuImprecisionAtomicTargetReindex.agda
+++ b/GTSF/proof/OneStep/NuImprecisionAtomicTargetReindex.agda
@@ -22,7 +22,7 @@ open import ImprecisionWf using
   )
 open import NuTermImprecision using
   (CtxImp; StoreImp)
-open import NuTerms using (Value)
+open import NuTerms using (Value; _⟨_⟩)
 open import QuotientedTermImprecision using
   ( PairedCast
   ; allocation-prefixᵀ
@@ -32,6 +32,7 @@ open import QuotientedTermImprecision using
   ; conv↑⊑ᵀ
   ; conv↓⊑ᵀ
   ; conv⊑convᵀ
+  ; down·up⊑down·upᵀ
   ; gen⊑groundᵀ
   ; up⊑upᵀ
   ; x⊑xᵀ
@@ -133,6 +134,11 @@ atomic-target-value-reindexᵀ atom vV (blame⊑ᵀ V⊢) q =
 atomic-target-value-reindexᵀ atom () (x⊑xᵀ x∈) q
 atomic-target-value-reindexᵀ () vV (ƛ⊑ƛᵀ hA hA′ N⊑N′) q
 atomic-target-value-reindexᵀ atom () (·⊑·ᵀ L⊑L′ M⊑M′) q
+atomic-target-value-reindexᵀ atom (() ⟨ inert-u′ ⟩)
+    (down·up⊑down·upᵀ
+      mode seal★ d⊒ d-shape mode′ seal★′ d′⊒ d′-shape
+      L⊑L′ M⊑M′ down-square widening
+      u-shape u′-shape up-square compatible) q
 atomic-target-value-reindexᵀ atom vV
     (up⊑upᵀ N⊑N′ widening p
       source-shape target-shape square) q =


### PR DESCRIPTION
## Summary

This finishes the packaging of item 11, the backward target blame theorem, through the integrated terminal backward-blame route.

The change removes the permissive local option from `NuDGGTerminalBackwardBlame`, connects `backward-target-blame-generalᵀ` to the integrated theorem, and keeps the closed `backward-target-blameᵀ` as the specialization.

It also restores the intended source-inert branch in paired widening compatibility while preserving the newer hereditary `tag`, `function`, and `all` compatibility structure. The supporting catchup/allocation/reindex modules now include the compatibility transport cases needed by the terminal theorem.

## Root Cause

The terminal theorem file still had the theorem as an incomplete local package. The natural assembly path existed, but its paired-widening compatibility shape had drifted from the ledger-backed source-inert formulation expected by downstream proof consumers.

## Impact

The item 11 theorem file now checks without local unsolved metas or a local permissive option. The proof still relies on the known lower catchup/one-step dispatcher work tracked in the progress ledger, so this should not be read as completing the whole DGG.

## Validation

- `cd GTSF && make agda FILE=proof/DGG/TerminalBackward/NuDGGTerminalBackwardBlame.agda`
- `git diff --cached --check`