### PR TITLE
Prove paired active value synchronization dispatcher

### DIFF
--- a/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda
+++ b/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda
@@ -113,6 +113,12 @@ import
 import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationDef
 import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueRootsDef
+import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationProof
+import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationLemma
+import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationDef
 import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientFrameRecursionDef

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueRootsDef.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueRootsDef.agda
@@ -1,0 +1,180 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueRootsDef
+  where
+
+-- File Charter:
+--   * Defines the smaller target-root cells used to synchronize a paired
+--     active source value cast with one active target cast step.
+--   * Separates the feasible identity, sequence, instantiation, and unseal
+--     target roots while retaining the exact PairedCast evidence.
+--   * Leaves target `tag-untag` and target blame elimination to the
+--     dispatcher proof.
+--   * Contains no implementation, recursive dispatcher, postulate, hole,
+--     permissive option, compatibility alias, or quotient case.
+
+open import Coercions using
+  ( Coercion
+  ; Inert
+  ; id
+  ; inst
+  ; unseal
+  ; _︔_
+  )
+open import Data.Empty using (⊥)
+open import Data.List using ([])
+open import ImprecisionWf using
+  ( ImpCtx
+  ; _∣_⊢_⊑_⊣_
+  )
+open import NuReduction using
+  ( keep
+  ; _—→_
+  )
+open import NuStore using (StoreWf)
+open import NuTermImprecision using
+  ( StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  )
+open import NuTerms using
+  ( No•
+  ; RuntimeOK
+  ; Term
+  ; Value
+  ; _⟨_⟩
+  )
+open import QuotientedTermImprecision using
+  ( PairedCast
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  )
+open import Types using
+  ( Ty
+  ; TyCtx
+  )
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDef
+  using (AssumptionMembershipUnique)
+open import
+  proof.NuCore.Relations.NuImprecisionContextExclusivityDef
+  using (SourceNameExclusive)
+open import
+  proof.WorldCoherent.Core.NuImprecisionWorldCoherenceDef
+  using (WorldCoherent)
+open import
+  proof.WorldCoherent.Core.NuImprecisionWorldCoherentResultDef
+  using (WorldCoherentWeakOneStepIndexedOutcome)
+
+
+record WorldCoherentRightOneStepPairedActiveValueRoots : Set₁ where
+  field
+    rightStepPairedActiveValueIdentityRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρ : StoreImp Φ Δᴸ Δᴿ}
+        {V V′ N′ : Term} {A A′ B B′ I : Ty}
+        {c : Coercion}
+        {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+        {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (V ⟨ c ⟩) →
+      RuntimeOK (V′ ⟨ id I ⟩) →
+      Value V →
+      No• V →
+      Value V′ →
+      No• V′ →
+      (Inert c → ⊥) →
+      PairedCast Φ Δᴸ Δᴿ ρ c (id I) {A} {A′} {B} {B′} p q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+        ⊢ᴺ V ⊑ V′ ⦂ A ⊑ A′ ∶ p →
+      V′ ⟨ id I ⟩ —→ N′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = V ⟨ c ⟩} {N′ = N′}
+        {χ = keep} {ρ = ρ} q
+
+    rightStepPairedActiveValueSequenceRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρ : StoreImp Φ Δᴸ Δᴿ}
+        {V V′ N′ : Term} {A A′ B B′ : Ty}
+        {c s t : Coercion}
+        {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+        {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (V ⟨ c ⟩) →
+      RuntimeOK (V′ ⟨ s ︔ t ⟩) →
+      Value V →
+      No• V →
+      Value V′ →
+      No• V′ →
+      (Inert c → ⊥) →
+      PairedCast Φ Δᴸ Δᴿ ρ c (s ︔ t) {A} {A′} {B} {B′} p q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+        ⊢ᴺ V ⊑ V′ ⦂ A ⊑ A′ ∶ p →
+      V′ ⟨ s ︔ t ⟩ —→ N′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = V ⟨ c ⟩} {N′ = N′}
+        {χ = keep} {ρ = ρ} q
+
+    rightStepPairedActiveValueInstantiationRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρ : StoreImp Φ Δᴸ Δᴿ}
+        {V V′ N′ : Term} {A A′ B B′ C : Ty}
+        {c s : Coercion}
+        {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+        {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (V ⟨ c ⟩) →
+      RuntimeOK (V′ ⟨ inst C s ⟩) →
+      Value V →
+      No• V →
+      Value V′ →
+      No• V′ →
+      (Inert c → ⊥) →
+      PairedCast
+        Φ Δᴸ Δᴿ ρ c (inst C s) {A} {A′} {B} {B′} p q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+        ⊢ᴺ V ⊑ V′ ⦂ A ⊑ A′ ∶ p →
+      V′ ⟨ inst C s ⟩ —→ N′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = V ⟨ c ⟩} {N′ = N′}
+        {χ = keep} {ρ = ρ} q
+
+    rightStepPairedActiveValueUnsealRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρ : StoreImp Φ Δᴸ Δᴿ}
+        {V V′ N′ : Term} {A A′ B B′ C : Ty}
+        {α} {c : Coercion}
+        {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+        {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (V ⟨ c ⟩) →
+      RuntimeOK (V′ ⟨ unseal α C ⟩) →
+      Value V →
+      No• V →
+      Value V′ →
+      No• V′ →
+      (Inert c → ⊥) →
+      PairedCast
+        Φ Δᴸ Δᴿ ρ c (unseal α C) {A} {A′} {B} {B′} p q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+        ⊢ᴺ V ⊑ V′ ⦂ A ⊑ A′ ∶ p →
+      V′ ⟨ unseal α C ⟩ —→ N′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = V ⟨ c ⟩} {N′ = N′}
+        {χ = keep} {ρ = ρ} q
+
+open WorldCoherentRightOneStepPairedActiveValueRoots public

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationLemma.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationLemma.agda
@@ -1,0 +1,28 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationLemma
+  where
+
+-- File Charter:
+--   * Exposes the canonical paired active-value synchronization dispatcher.
+--   * Keeps the smaller target-root record explicit for later
+--     source-administration inhabitants.
+--   * Contains no implementation beyond the Proof-module wrapper, no
+--     postulate, hole, permissive option, recursion, or quotient case.
+
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueRootsDef
+  using (WorldCoherentRightOneStepPairedActiveValueRoots)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationDef
+  using (WorldCoherentRightOneStepPairedActiveValueSynchronizationᵀ)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationProof
+  using
+  (world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ)
+
+
+world-coherent-right-one-step-paired-active-value-synchronizationᵀ :
+  WorldCoherentRightOneStepPairedActiveValueRoots →
+  WorldCoherentRightOneStepPairedActiveValueSynchronizationᵀ
+world-coherent-right-one-step-paired-active-value-synchronizationᵀ =
+  world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationProof.agda
@@ -1,0 +1,116 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationProof
+  where
+
+-- File Charter:
+--   * Proves paired active-value synchronization by exhaustive target-root
+--     dispatch.
+--   * Delegates exactly the feasible identity, sequence, instantiation, and
+--     unseal roots to smaller semantic cells.
+--   * Eliminates target `tag-untag` roots by PairedCast inversion and target
+--     blame because the target cast body is a value.
+--   * Contains no recursive dispatcher, postulate, hole, permissive option,
+--     source-administration worker, or quotient case.
+
+import NarrowWiden as NW
+open import Data.Product using (_,_)
+open import NuReduction using
+  ( β-id
+  ; β-inst
+  ; β-seq
+  ; blame-⟨⟩
+  ; seal-unseal
+  ; tag-untag-bad
+  ; tag-untag-ok
+  )
+open import QuotientedTermImprecision using
+  ( paired-conceal
+  ; paired-conversion
+  ; paired-reveal
+  ; paired-widening
+  )
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueRootsDef
+  using
+  ( WorldCoherentRightOneStepPairedActiveValueRoots
+  ; rightStepPairedActiveValueIdentityRoot
+  ; rightStepPairedActiveValueInstantiationRoot
+  ; rightStepPairedActiveValueSequenceRoot
+  ; rightStepPairedActiveValueUnsealRoot
+  )
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationDef
+  using (WorldCoherentRightOneStepPairedActiveValueSynchronizationᵀ)
+
+
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ :
+  WorldCoherentRightOneStepPairedActiveValueRoots →
+  WorldCoherentRightOneStepPairedActiveValueSynchronizationᵀ
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root@(β-id vBody) =
+  rightStepPairedActiveValueIdentityRoot roots
+    coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root@(β-seq vBody) =
+  rightStepPairedActiveValueSequenceRoot roots
+    coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root@(β-inst vBody) =
+  rightStepPairedActiveValueInstantiationRoot roots
+    coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    (paired-conversion (paired-reveal corr source () replacement))
+    V⊑V′ (tag-untag-ok vBody)
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    (paired-conversion (paired-conceal corr source () replacement))
+    V⊑V′ (tag-untag-ok vBody)
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    (paired-widening mode seal★ c⊑ c-shape mode′ seal★′
+      (c′⊢ , NW.cross ()) c′-shape source-comp target-comp compat)
+    V⊑V′ (tag-untag-ok vBody)
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    (paired-conversion (paired-reveal corr source () replacement))
+    V⊑V′ (tag-untag-bad vBody G≢H)
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    (paired-conversion (paired-conceal corr source () replacement))
+    V⊑V′ (tag-untag-bad vBody G≢H)
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    (paired-widening mode seal★ c⊑ c-shape mode′ seal★′
+      (c′⊢ , NW.cross ()) c′-shape source-comp target-comp compat)
+    V⊑V′ (tag-untag-bad vBody G≢H)
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root@(seal-unseal vBody) =
+  rightStepPairedActiveValueUnsealRoot roots
+    coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV vV′ noV′ noninert
+    paired V⊑V′ root
+world-coherent-right-one-step-paired-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique wfL wfR
+    ok-source ok-target vV noV () noV′ noninert
+    paired V⊑V′ blame-⟨⟩


### PR DESCRIPTION
## Summary

- Add `WorldCoherentRightOneStepPairedActiveValueRoots`, a smaller root-cell record for feasible paired active-value target roots: identity, sequence, instantiation, and unseal.
- Add the dispatcher proof for `WorldCoherentRightOneStepPairedActiveValueSynchronizationᵀ` from those cells.
- Expose the canonical lemma wrapper and import the new modules in the backward strict spine.

## Why

The broad paired active-value synchronization boundary was still only a statement. The new proof follows the existing active-root architecture: dispatch on the observed target reduction, delegate feasible target roots to smaller cells, and eliminate impossible target `tag-untag` and target blame cases without adding a recursive knot.

## Validation

- `make agda FILE=proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationProof.agda`
- `make agda FILE=proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationLemma.agda`
- `agda +RTS -A128M -M18G -RTS --no-allow-unsolved-metas -v0 proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepPairedActiveValueSynchronizationLemma.agda`
- `git diff --check`

The aggregate backward strict spine still stops at the existing unrelated incomplete pattern in `NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda` for `down·up⊑down·upᵀ`.