### PR TITLE
Prove quotient active value synchronization dispatcher

### DIFF
--- a/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda
+++ b/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda
@@ -121,6 +121,12 @@ import
 import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationDef
 import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueRootsDef
+import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationProof
+import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationLemma
+import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientFrameRecursionDef
 import
   proof.Right.Core.NuImprecisionQuotientWideningTransportProof

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueRootsDef.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueRootsDef.agda
@@ -1,0 +1,181 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueRootsDef
+  where
+
+-- File Charter:
+--   * Defines the smaller target-root cells used to synchronize an
+--     `up⊑upᵀ` quotient-widening value with one active target cast step.
+--   * Separates the feasible identity, sequence, instantiation, and unseal
+--     target roots while retaining the exact QTIP and widening evidence.
+--   * Leaves target `tag-untag` and target blame elimination to the
+--     dispatcher proof.
+--   * Contains no implementation, recursive dispatcher, postulate, hole,
+--     permissive option, compatibility alias, or ordinary paired-cast case.
+
+open import CastImprecisionShape using (_⊢ᶜ_⦂_; widening)
+open import Coercions using
+  ( Coercion
+  ; id
+  ; inst
+  ; unseal
+  ; _︔_
+  )
+open import Data.List using ([])
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionComposition using (_；⌊_⌋≋ᵖ_；_)
+open import ImprecisionWf using
+  ( ImpCtx
+  ; _∣_⊢_⊑_⊣_
+  )
+open import NuReduction using
+  ( keep
+  ; _—→_
+  )
+open import NuStore using (StoreWf)
+open import NuTermImprecision using
+  ( StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  )
+open import NuTerms using
+  ( RuntimeOK
+  ; Term
+  ; Value
+  ; _⟨_⟩
+  )
+open import QuotientedTermImprecision using
+  ( QuotientWideningPair
+  ; StoreImpPrefix
+  ; _∣_∣_∣_∣_⊢ᴺᵖ_⊑_⦂_⊑ᵖ_∶_
+  )
+open import Types using
+  ( Ty
+  ; TyCtx
+  )
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDef
+  using (AssumptionMembershipUnique)
+open import
+  proof.NuCore.Relations.NuImprecisionContextExclusivityDef
+  using (SourceNameExclusive)
+open import
+  proof.WorldCoherent.Core.NuImprecisionWorldCoherenceDef
+  using (WorldCoherent)
+open import
+  proof.WorldCoherent.Core.NuImprecisionWorldCoherentResultDef
+  using (WorldCoherentWeakOneStepIndexedOutcome)
+
+
+record WorldCoherentRightOneStepQuotientActiveValueRoots : Set₁ where
+  field
+    rightStepQuotientActiveValueIdentityRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {N V′ L′ : Term} {D D′ A A′ I : Ty}
+        {u : Coercion} {u-shape u′-shape}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (N ⟨ u ⟩) →
+      RuntimeOK (V′ ⟨ id I ⟩) →
+      Value V′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺᵖ N ⊑ V′ ⦂ D ⊑ᵖ D′ ∶ qD →
+      QuotientWideningPair Δᴸ Δᴿ ρᵇ u (id I) D D′ A A′ →
+      widening ⊢ᶜ u ⦂ u-shape →
+      widening ⊢ᶜ id I ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ id I ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = N ⟨ u ⟩} {N′ = L′}
+        {χ = keep} {ρ = ρ} pA
+
+    rightStepQuotientActiveValueSequenceRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {N V′ L′ : Term} {D D′ A A′ : Ty}
+        {u c d : Coercion} {u-shape u′-shape}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (N ⟨ u ⟩) →
+      RuntimeOK (V′ ⟨ c ︔ d ⟩) →
+      Value V′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺᵖ N ⊑ V′ ⦂ D ⊑ᵖ D′ ∶ qD →
+      QuotientWideningPair Δᴸ Δᴿ ρᵇ u (c ︔ d) D D′ A A′ →
+      widening ⊢ᶜ u ⦂ u-shape →
+      widening ⊢ᶜ c ︔ d ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ c ︔ d ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = N ⟨ u ⟩} {N′ = L′}
+        {χ = keep} {ρ = ρ} pA
+
+    rightStepQuotientActiveValueInstantiationRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {N V′ L′ : Term} {D D′ A A′ B : Ty}
+        {u c : Coercion} {u-shape u′-shape}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (N ⟨ u ⟩) →
+      RuntimeOK (V′ ⟨ inst B c ⟩) →
+      Value V′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺᵖ N ⊑ V′ ⦂ D ⊑ᵖ D′ ∶ qD →
+      QuotientWideningPair
+        Δᴸ Δᴿ ρᵇ u (inst B c) D D′ A A′ →
+      widening ⊢ᶜ u ⦂ u-shape →
+      widening ⊢ᶜ inst B c ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ inst B c ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = N ⟨ u ⟩} {N′ = L′}
+        {χ = keep} {ρ = ρ} pA
+
+    rightStepQuotientActiveValueUnsealRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {N V′ L′ : Term} {D D′ A A′ B : Ty}
+        {α} {u : Coercion} {u-shape u′-shape}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK (N ⟨ u ⟩) →
+      RuntimeOK (V′ ⟨ unseal α B ⟩) →
+      Value V′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺᵖ N ⊑ V′ ⦂ D ⊑ᵖ D′ ∶ qD →
+      QuotientWideningPair
+        Δᴸ Δᴿ ρᵇ u (unseal α B) D D′ A A′ →
+      widening ⊢ᶜ u ⦂ u-shape →
+      widening ⊢ᶜ unseal α B ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ unseal α B ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = N ⟨ u ⟩} {N′ = L′}
+        {χ = keep} {ρ = ρ} pA
+
+open WorldCoherentRightOneStepQuotientActiveValueRoots public

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationLemma.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationLemma.agda
@@ -1,0 +1,30 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationLemma
+  where
+
+-- File Charter:
+--   * Exposes the canonical quotient active-value synchronization
+--     dispatcher.
+--   * Keeps the smaller target-root record explicit for later
+--     source-administration inhabitants.
+--   * Contains no implementation beyond the Proof-module wrapper, no
+--     postulate, hole, permissive option, recursion, or ordinary paired-cast
+--     case.
+
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueRootsDef
+  using (WorldCoherentRightOneStepQuotientActiveValueRoots)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationDef
+  using (WorldCoherentRightOneStepQuotientActiveValueSynchronizationᵀ)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationProof
+  using
+  (world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ)
+
+
+world-coherent-right-one-step-quotient-active-value-synchronizationᵀ :
+  WorldCoherentRightOneStepQuotientActiveValueRoots →
+  WorldCoherentRightOneStepQuotientActiveValueSynchronizationᵀ
+world-coherent-right-one-step-quotient-active-value-synchronizationᵀ =
+  world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationProof.agda
@@ -1,0 +1,105 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationProof
+  where
+
+-- File Charter:
+--   * Proves quotient active-value synchronization by exhaustive target-root
+--     dispatch.
+--   * Delegates exactly the feasible identity, sequence, instantiation, and
+--     unseal roots to smaller semantic cells.
+--   * Eliminates target `tag-untag` roots by quotient-widening inversion and
+--     target blame because the target cast body is a value.
+--   * Contains no recursive dispatcher, postulate, hole, permissive option,
+--     source-administration worker, ordinary paired-cast proof, or QTIP
+--     recursion.
+
+import NarrowWiden as NW
+open import Data.Product using (_,_)
+open import NuReduction using
+  ( β-id
+  ; β-inst
+  ; β-seq
+  ; blame-⟨⟩
+  ; seal-unseal
+  ; tag-untag-bad
+  ; tag-untag-ok
+  )
+open import QuotientedTermImprecision using
+  ( quotient-cast-widening
+  ; quotient-id-widening
+  )
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueRootsDef
+  using
+  ( WorldCoherentRightOneStepQuotientActiveValueRoots
+  ; rightStepQuotientActiveValueIdentityRoot
+  ; rightStepQuotientActiveValueInstantiationRoot
+  ; rightStepQuotientActiveValueSequenceRoot
+  ; rightStepQuotientActiveValueUnsealRoot
+  )
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationDef
+  using (WorldCoherentRightOneStepQuotientActiveValueSynchronizationᵀ)
+
+
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ :
+  WorldCoherentRightOneStepQuotientActiveValueRoots →
+  WorldCoherentRightOneStepQuotientActiveValueSynchronizationᵀ
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root@(β-id vBody) =
+  rightStepQuotientActiveValueIdentityRoot roots
+    coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root@(β-seq vBody) =
+  rightStepQuotientActiveValueSequenceRoot roots
+    coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root@(β-inst vBody) =
+  rightStepQuotientActiveValueInstantiationRoot roots
+    coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′
+    (quotient-id-widening u⊑ (u′⊢ , NW.cross ()))
+    u-shape u′-shape up-square (tag-untag-ok vBody)
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′
+    (quotient-cast-widening mode seal★ u⊑ mode′ seal★′
+      (u′⊢ , NW.cross ()))
+    u-shape u′-shape up-square (tag-untag-ok vBody)
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′
+    (quotient-id-widening u⊑ (u′⊢ , NW.cross ()))
+    u-shape u′-shape up-square (tag-untag-bad vBody G≢H)
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′
+    (quotient-cast-widening mode seal★ u⊑ mode′ seal★′
+      (u′⊢ , NW.cross ()))
+    u-shape u′-shape up-square (tag-untag-bad vBody G≢H)
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root@(seal-unseal vBody) =
+  rightStepQuotientActiveValueUnsealRoot roots
+    coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′ N⊑V′ widening u-shape u′-shape
+    up-square root
+world-coherent-right-one-step-quotient-active-value-synchronization-proofᵀ
+    roots coherent exclusive unique prefix wfL wfR
+    ok-source ok-target () N⊑V′ widening u-shape u′-shape
+    up-square blame-⟨⟩


### PR DESCRIPTION
## Summary

- Add `WorldCoherentRightOneStepQuotientActiveValueRoots`, a smaller root-cell record for feasible quotient active-value target roots: identity, sequence, instantiation, and unseal.
- Add the dispatcher proof for `WorldCoherentRightOneStepQuotientActiveValueSynchronizationᵀ` from those cells.
- Expose the canonical lemma wrapper and import the new modules in the backward strict spine.

## Why

The broad quotient active-value synchronization boundary was still only a statement. The new proof follows the paired active-value pattern: dispatch on the observed target reduction, delegate feasible target roots to smaller cells, eliminate target `tag-untag` by inverting the target widening evidence in `QuotientWideningPair`, and eliminate target blame with the target `Value` premise.

## Validation

- `make agda FILE=proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationProof.agda`
- `make agda FILE=proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationLemma.agda`
- `agda +RTS -A128M -M18G -RTS --no-allow-unsolved-metas -v0 proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientActiveValueSynchronizationLemma.agda`
- `git diff --check`

The aggregate backward strict spine still stops at the existing unrelated incomplete pattern in `NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda` for `down·up⊑down·upᵀ`.