### PR TITLE
prove quotient down active synchronization

### DIFF
--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -13781,7 +13781,11 @@ exact underlying raw result before their composed lineage can be attached.
   exhaustive strict case theorem.  Target body steps use the existing
   quotient down frames, target blame uses the direct roots, and all active
   target downcast roots delegate to one exact two-mode synchronization
-  contract.  The three quotient application constructors remain separate.
+  contract.  That synchronization contract now has a strict dispatcher:
+  target identity, sequence, and untag roots are the only remaining semantic
+  cells; instantiation and unseal roots contradict narrowing, and direct
+  target blame contradicts the target value premise.  The three quotient
+  application constructors remain separate.
   The ordinary-function quotient application constructor now has its own
   exhaustive strict scheduler: it separates function framing, argument
   framing/crossing, β or function-cast β, and direct left blame.  Its three
@@ -14140,8 +14144,9 @@ exact underlying raw result before their composed lineage can be attached.
    catch-up invariant; target-bullet recursion has already been replaced by
    the strict type-index contradiction.
 2. Prove the source-down-application `β`/`β-↦` value root and the remaining
-   exact active synchronization leaves; all current QTIP transport clauses and
-   the paired target-blame branch are complete.
+   exact active synchronization root inhabitants; all current QTIP transport
+   clauses, active synchronization dispatchers, and the paired target-blame
+   branch are complete.
 3. Assemble the exhaustive prefix-aware world-coherent backward one-step
    dispatcher and restore the green aggregate backward strict spine.
 4. Use the dispatcher in both terminal backward engines, connect the strict

--- a/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda
+++ b/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda
@@ -137,6 +137,12 @@ import
 import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationDef
 import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveRootsDef
+import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationProof
+import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationLemma
+import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownCasesProof
 import
   proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepOrdinaryDownApplicationSchedulingDef

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveRootsDef.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveRootsDef.agda
@@ -1,0 +1,161 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveRootsDef
+  where
+
+-- File Charter:
+--   * Defines the feasible target-root cells for exact active target-down
+--     synchronization inside the QTIP down modes.
+--   * Separates identity, sequence, and untag roots while retaining the
+--     enclosing quotient-widening pair and both composition squares.
+--   * Leaves instantiation, unseal, and target blame elimination to the
+--     dispatcher proof.
+--   * Contains no implementation, frame recursion, postulate, hole,
+--     permissive option, compatibility alias, or application case.
+
+import CastImprecisionShape as CastShape
+open import Coercions using (Coercion; id; _︔_; _？)
+open import Data.List using ([])
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionComposition using (_；⌊_⌋≋ᵖ_；_)
+open import ImprecisionWf using (ImpCtx; _∣_⊢_⊑_⊣_)
+open import NarrowWiden using (_∣_∣_⊢_∶_⊒_)
+open import NuReduction using (keep; _—→_)
+open import NuStore using (StoreWf)
+open import NuTermImprecision using
+  (StoreImp; leftStoreⁱ; rightStoreⁱ)
+open import NuTerms using (RuntimeOK; Term; Value; _⟨_⟩)
+open import QuotientedTermImprecision using
+  ( QuotientWideningPair
+  ; StoreImpPrefix
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  )
+open import Types using (Ty; TyCtx)
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDef
+  using (AssumptionMembershipUnique)
+open import
+  proof.NuCore.Relations.NuImprecisionContextExclusivityDef
+  using (SourceNameExclusive)
+open import
+  proof.WorldCoherent.Core.NuImprecisionWorldCoherenceDef
+  using (WorldCoherent)
+open import
+  proof.WorldCoherent.Core.NuImprecisionWorldCoherentResultDef
+  using (WorldCoherentWeakOneStepIndexedOutcome)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationDef
+  using (QuotientDownMode; quotient-down-mode)
+
+
+record WorldCoherentRightOneStepQuotientDownActiveRoots : Set₁ where
+  field
+    rightStepQuotientDownIdentityRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {M V′ L′ : Term} {C C′ D D′ A A′ I : Ty}
+        {d u u′ : Coercion} {d-shape d′-shape u-shape u′-shape}
+        {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      (down-mode : QuotientDownMode) →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK ((M ⟨ d ⟩) ⟨ u ⟩) →
+      RuntimeOK ((V′ ⟨ id I ⟩) ⟨ u′ ⟩) →
+      Value V′ →
+      quotient-down-mode down-mode ∣ Δᴸ ∣ leftStoreⁱ ρᵇ
+        ⊢ d ∶ C ⊒ D →
+      CastShape.narrowing CastShape.⊢ᶜ d ⦂ d-shape →
+      quotient-down-mode down-mode ∣ Δᴿ ∣ rightStoreⁱ ρᵇ
+        ⊢ id I ∶ C′ ⊒ D′ →
+      CastShape.narrowing CastShape.⊢ᶜ id I ⦂ d′-shape →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺ M ⊑ V′ ⦂ C ⊑ C′ ∶ pC →
+      d-shape ；⌊ pC ⌋≋ᵖ qD ； d′-shape →
+      QuotientWideningPair Δᴸ Δᴿ ρᵇ u u′ D D′ A A′ →
+      CastShape.widening CastShape.⊢ᶜ u ⦂ u-shape →
+      CastShape.widening CastShape.⊢ᶜ u′ ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ id I ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = (M ⟨ d ⟩) ⟨ u ⟩}
+        {N′ = L′ ⟨ u′ ⟩} {χ = keep} {ρ = ρ} pA
+
+    rightStepQuotientDownSequenceRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {M V′ L′ : Term} {C C′ D D′ A A′ : Ty}
+        {d s t u u′ : Coercion}
+        {d-shape d′-shape u-shape u′-shape}
+        {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      (down-mode : QuotientDownMode) →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK ((M ⟨ d ⟩) ⟨ u ⟩) →
+      RuntimeOK ((V′ ⟨ s ︔ t ⟩) ⟨ u′ ⟩) →
+      Value V′ →
+      quotient-down-mode down-mode ∣ Δᴸ ∣ leftStoreⁱ ρᵇ
+        ⊢ d ∶ C ⊒ D →
+      CastShape.narrowing CastShape.⊢ᶜ d ⦂ d-shape →
+      quotient-down-mode down-mode ∣ Δᴿ ∣ rightStoreⁱ ρᵇ
+        ⊢ s ︔ t ∶ C′ ⊒ D′ →
+      CastShape.narrowing CastShape.⊢ᶜ s ︔ t ⦂ d′-shape →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺ M ⊑ V′ ⦂ C ⊑ C′ ∶ pC →
+      d-shape ；⌊ pC ⌋≋ᵖ qD ； d′-shape →
+      QuotientWideningPair Δᴸ Δᴿ ρᵇ u u′ D D′ A A′ →
+      CastShape.widening CastShape.⊢ᶜ u ⦂ u-shape →
+      CastShape.widening CastShape.⊢ᶜ u′ ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ s ︔ t ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = (M ⟨ d ⟩) ⟨ u ⟩}
+        {N′ = L′ ⟨ u′ ⟩} {χ = keep} {ρ = ρ} pA
+
+    rightStepQuotientDownUntagRoot :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρᵇ ρ : StoreImp Φ Δᴸ Δᴿ}
+        {M V′ L′ : Term} {C C′ D D′ A A′ H : Ty}
+        {d u u′ : Coercion} {d-shape d′-shape u-shape u′-shape}
+        {pC : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ}
+        {qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ}
+        {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+      (down-mode : QuotientDownMode) →
+      WorldCoherent ρ →
+      SourceNameExclusive Φ →
+      AssumptionMembershipUnique Φ →
+      StoreImpPrefix ρᵇ ρ →
+      StoreWf Δᴸ (leftStoreⁱ ρ) →
+      StoreWf Δᴿ (rightStoreⁱ ρ) →
+      RuntimeOK ((M ⟨ d ⟩) ⟨ u ⟩) →
+      RuntimeOK ((V′ ⟨ H ？ ⟩) ⟨ u′ ⟩) →
+      Value V′ →
+      quotient-down-mode down-mode ∣ Δᴸ ∣ leftStoreⁱ ρᵇ
+        ⊢ d ∶ C ⊒ D →
+      CastShape.narrowing CastShape.⊢ᶜ d ⦂ d-shape →
+      quotient-down-mode down-mode ∣ Δᴿ ∣ rightStoreⁱ ρᵇ
+        ⊢ H ？ ∶ C′ ⊒ D′ →
+      CastShape.narrowing CastShape.⊢ᶜ H ？ ⦂ d′-shape →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρᵇ ∣ []
+        ⊢ᴺ M ⊑ V′ ⦂ C ⊑ C′ ∶ pC →
+      d-shape ；⌊ pC ⌋≋ᵖ qD ； d′-shape →
+      QuotientWideningPair Δᴸ Δᴿ ρᵇ u u′ D D′ A A′ →
+      CastShape.widening CastShape.⊢ᶜ u ⦂ u-shape →
+      CastShape.widening CastShape.⊢ᶜ u′ ⦂ u′-shape →
+      u-shape ；⌊ pA ⌋≋ᵖ qD ； u′-shape →
+      V′ ⟨ H ？ ⟩ —→ L′ →
+      WorldCoherentWeakOneStepIndexedOutcome
+        {M = (M ⟨ d ⟩) ⟨ u ⟩}
+        {N′ = L′ ⟨ u′ ⟩} {χ = keep} {ρ = ρ} pA
+
+open WorldCoherentRightOneStepQuotientDownActiveRoots public

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationLemma.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationLemma.agda
@@ -1,0 +1,29 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationLemma
+  where
+
+-- File Charter:
+--   * Exposes the canonical QTIP target-down active synchronization
+--     dispatcher.
+--   * Keeps the smaller target-root record explicit for later
+--     source-administration inhabitants.
+--   * Contains no implementation beyond the Proof-module wrapper, no
+--     postulate, hole, permissive option, recursion, or application case.
+
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveRootsDef
+  using (WorldCoherentRightOneStepQuotientDownActiveRoots)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationDef
+  using (WorldCoherentRightOneStepQuotientDownActiveSynchronizationᵀ)
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationProof
+  using
+  (world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ)
+
+
+world-coherent-right-one-step-quotient-down-active-synchronizationᵀ :
+  WorldCoherentRightOneStepQuotientDownActiveRoots →
+  WorldCoherentRightOneStepQuotientDownActiveSynchronizationᵀ
+world-coherent-right-one-step-quotient-down-active-synchronizationᵀ =
+  world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationProof.agda
@@ -1,0 +1,95 @@
+module
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationProof
+  where
+
+-- File Charter:
+--   * Proves exact active target-down synchronization inside QTIP by
+--     exhaustive target-root dispatch.
+--   * Delegates exactly the feasible identity, sequence, and untag roots to
+--     smaller semantic cells.
+--   * Eliminates instantiation and unseal roots by narrowing inversion and
+--     eliminates target blame because the cast body is a value.
+--   * Contains no frame recursion, postulate, hole, permissive option,
+--     source-administration worker, or application case.
+
+import NarrowWiden as NW
+open import Data.Product using (_,_)
+open import NuReduction using
+  ( β-id
+  ; β-inst
+  ; β-seq
+  ; blame-⟨⟩
+  ; seal-unseal
+  ; tag-untag-bad
+  ; tag-untag-ok
+  )
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveRootsDef
+  using
+  ( WorldCoherentRightOneStepQuotientDownActiveRoots
+  ; rightStepQuotientDownIdentityRoot
+  ; rightStepQuotientDownSequenceRoot
+  ; rightStepQuotientDownUntagRoot
+  )
+open import
+  proof.WorldCoherent.Right.OneStep.Roots.NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationDef
+  using (WorldCoherentRightOneStepQuotientDownActiveSynchronizationᵀ)
+
+
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ :
+  WorldCoherentRightOneStepQuotientDownActiveRoots →
+  WorldCoherentRightOneStepQuotientDownActiveSynchronizationᵀ
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root@(β-id vBody) =
+  rightStepQuotientDownIdentityRoot roots
+    down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root@(β-seq vBody) =
+  rightStepQuotientDownSequenceRoot roots
+    down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape (d′⊢ , NW.cross ()) d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square (β-inst vBody)
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root@(tag-untag-ok vBody) =
+  rightStepQuotientDownUntagRoot roots
+    down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root@(tag-untag-bad vBody G≢H) =
+  rightStepQuotientDownUntagRoot roots
+    down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape d′⊒ d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square root
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target vV′
+    d⊒ d-shape (d′⊢ , NW.cross ()) d′-shape M⊑V′ down-square
+    widening u-shape u′-shape up-square (seal-unseal vBody)
+world-coherent-right-one-step-quotient-down-active-synchronization-proofᵀ
+    roots down-mode coherent exclusive unique prefix wfL wfR
+    ok-source ok-target () d⊒ d-shape d′⊒ d′-shape M⊑V′
+    down-square widening u-shape u′-shape up-square blame-⟨⟩


### PR DESCRIPTION
## Summary

- Add the QTIP target-down active root bundle for identity, sequence, and untag target roots.
- Add the strict dispatcher for `WorldCoherentRightOneStepQuotientDownActiveSynchronizationᵀ`, eliminating impossible instantiation, unseal, and target-blame cases.
- Wire the completed modules into the backward strict spine and update the DGG progress ledger.

## Validation

- `make agda FILE=proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationProof.agda`
- `make agda FILE=proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationLemma.agda`
- `agda +RTS -A128M -M18G -RTS --no-allow-unsolved-metas -v0 proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepQuotientDownActiveSynchronizationLemma.agda`
- `git diff --check`

## Note

The aggregate backward strict spine still hits the pre-existing unrelated incomplete `down·up⊑down·upᵀ` case in `NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda`.