### PR TITLE
complete down-up value inversion cases

### DIFF
--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -14116,8 +14116,12 @@ exact underlying raw result before their composed lineage can be attached.
 - **The combined down/application/up QTI invariant is closed under the basic
   structural transports.**  The strengthened `down·up⊑down·upᵀ` case is now
   handled by term-context shift, prefix-aware parallel substitution, left
-  renaming, and relational-world embedding.  Store-prefix weakening already
-  transports ordinary QTI generically through `allocation-prefixᵀ`; its
+  renaming, relational-world embedding, source-conceal atomic source-value
+  reindexing, and value-catchup runtime-sibling prefix.  The two value-based
+  branches are impossible by value inversion: the relevant side would have to
+  be an application value under the outer inert cast.
+  Store-prefix weakening already transports ordinary QTI generically through
+  `allocation-prefixᵀ`; its
   quotiented worker now contains only the four surviving quotient cases.  The
   deleted `ordinary-down-applicationᵖᵀ` and
   `source-down-applicationᵖᵀ` cases and imports have been removed from all five

--- a/GTSF/proof/WorldCoherent/Source/RevealConceal/NuImprecisionWorldCoherentSourceConcealCatchup.agda
+++ b/GTSF/proof/WorldCoherent/Source/RevealConceal/NuImprecisionWorldCoherentSourceConcealCatchup.agda
@@ -87,6 +87,7 @@ open import QuotientedTermImprecision using
   ; conv↓⊑ᵀ
   ; conv↑⊑ᵀ
   ; conv⊑convᵀ
+  ; down·up⊑down·upᵀ
   ; nu-term-imprecision-target-typing
   ; prefix-reflⁱ
   ; up⊑upᵀ
@@ -299,6 +300,12 @@ atomic-source-value-reindexᵀ atom () (blame⊑ᵀ M′⊢) q
 atomic-source-value-reindexᵀ atom () (x⊑xᵀ x∈) q
 atomic-source-value-reindexᵀ () vM (ƛ⊑ƛᵀ hA hA′ N⊑N′) q
 atomic-source-value-reindexᵀ atom () (·⊑·ᵀ L⊑L′ M⊑M′) q
+atomic-source-value-reindexᵀ atom (() ⟨ inert-u ⟩)
+    (down·up⊑down·upᵀ
+      mode seal★ d⊒ d-shape mode′ seal★′ d′⊒ d′-shape
+      L⊑L′ M⊑M′ down-square
+      widening-pair u-shape u′-shape up-square compatible)
+    q
 atomic-source-value-reindexᵀ atom vM
     (up⊑upᵀ M⊑M′ widening p
       source-shape target-shape square) q =

--- a/GTSF/proof/WorldCoherent/Value/NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda
+++ b/GTSF/proof/WorldCoherent/Value/NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda
@@ -185,6 +185,15 @@ world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
   inner-sibling = proj₂ inner-with-sibling
 world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
     source-runtime quotient-catchup
+    prefix coherent exclusive unique wfL okL
+    (() ⟨ inert-u′ ⟩) noL′
+    (down·up⊑down·upᵀ
+      mode seal★ d⊒ d-shape mode′ seal★′ d′⊒ d′-shape
+      L⊑L′ M⊑M′ down-square
+      widening-pair u-shape u′-shape up-square compatible)
+    noR okR′ sibling
+world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
+    source-runtime quotient-catchup
     prefix coherent exclusive unique wfL okL vL′ noL′
     (allocation-prefixᵀ prefix₀ inner L⊢ L′⊢)
     noR okR′ sibling =


### PR DESCRIPTION
## Summary

- Complete the `down·up⊑down·upᵀ` case in `WorldCoherentLeftValueCatchupRuntimeSiblingPrefixProof` by target-value inversion.
- Complete the matching `down·up⊑down·upᵀ` case in source-conceal atomic source-value reindexing by source-value inversion.
- Update the DGG progress ledger to record these strengthened down/application/up transport closures.

## Validation

- `make agda FILE=proof/WorldCoherent/Value/NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda`
- `agda +RTS -A128M -M18G -RTS --no-allow-unsolved-metas -v0 proof/WorldCoherent/Value/NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda`
- `make agda FILE=proof/WorldCoherent/Source/RevealConceal/NuImprecisionWorldCoherentSourceConcealCatchup.agda`
- `agda +RTS -A128M -M18G -RTS --no-allow-unsolved-metas -v0 proof/WorldCoherent/Source/RevealConceal/NuImprecisionWorldCoherentSourceConcealCatchup.agda`
- `git diff --check`

## Note

The backward strict spine now gets past these two modules and stops at the next separate `down·up⊑down·upᵀ` coverage gap: `left-source-allocation-runtime-rootᵀ` in `GTSF/proof/Left/AllocationRuntime/NuImprecisionLeftSourceAllocationRuntimeTransportProof.agda`.