### PR TITLE
[codex] Restore honest backward-blame proof boundary

### DIFF
--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -14142,6 +14142,48 @@ exact underlying raw result before their composed lineage can be attached.
   confirms the current exhaustive `replace-right-ν∀` compatibility transports
   are present in its strict dependency cone.
 
+### 2026-07-25: audit of merged PRs #91--#95
+
+- **PR #91 is useful except for its terminal theorem facade.**  Retain the
+  source-inert paired-widening compatibility constructor, the conditional
+  exact bridge for an inert target, and their rename, allocation, and atomic
+  reindex transports.  These changes restore the invariant used by the
+  source-inert outer-cast path, and the focused compatibility and atomic
+  reindex modules pass strict checks.
+
+  Do not treat `backward-target-blame-generalᵀ` as complete yet.  The merged
+  implementation merely aliased
+  `backward-target-blame-general-integratedᵀ`, whose one-step component is
+  `weak-one-step-indexed-simulationᵀ` from
+  `NuImprecisionCatchupScratch`.  That scratch module explicitly permits
+  unsolved metas and incomplete matches and still contains the unfinished
+  dispatcher cases.  The alias therefore hid the remaining proof obligation
+  behind an apparently strict theorem module.  The theorem has been restored
+  to its explicit partial state.  Its genuine higher-order proof remains
+  `world-coherent-backward-target-blame-proofᵀ`, conditional on the strict
+  world-coherent one-step simulation.
+
+- **PRs #92--#94 are honest dispatcher progress.**  The paired active-value
+  dispatcher reduces seven target root families to four exact cells:
+  identity, sequence, instantiation, and unseal.  The quotient active-value
+  dispatcher makes the same four cells explicit.  The quotient target-down
+  dispatcher reduces the seven roots to identity, sequence, and untag.  Their
+  other cases close by widening or narrowing inversion and target-value
+  inversion.  All three dispatchers remain conditional on their root records,
+  so they do not claim that the remaining semantic cells are inhabited.
+  Their focused proof and lemma checks pass with
+  `--no-allow-unsolved-metas`.
+
+- **PR #95 is a sound exhaustiveness repair.**  Its two
+  `down·up⊑down·upᵀ` clauses close by value inversion: the relevant side would
+  require an application to be a value beneath the outer inert cast.  Both
+  changed Agda modules pass focused strict checks.
+
+The cold aggregate backward strict spine was stopped after several minutes
+without a diagnostic.  This is not evidence of failure; focused strict checks
+remain the validation unit until the remaining exact root inhabitants and
+allocation transport case make the aggregate cone practical.
+
 ### Revised current plan
 
 1. Finish quotient transport normalization and the crossed binary sibling
@@ -14153,6 +14195,8 @@ exact underlying raw result before their composed lineage can be attached.
    branch are complete.
 3. Assemble the exhaustive prefix-aware world-coherent backward one-step
    dispatcher and restore the green aggregate backward strict spine.
-4. Use the dispatcher in both terminal backward engines, connect the strict
+4. Use only that strict dispatcher in both terminal backward engines.  Remove
+   the explicit partial backward-blame theorem only after its implementation
+   no longer imports `NuImprecisionCatchupScratch`; then connect the strict
    forward and backward terminal engines, construct `GradualDGG`, and run the
    complete strict cone.

--- a/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardBlame.agda
+++ b/GTSF/proof/DGG/TerminalBackward/NuDGGTerminalBackwardBlame.agda
@@ -1,10 +1,12 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
 module proof.DGG.TerminalBackward.NuDGGTerminalBackwardBlame where
 
 -- File Charter:
 --   * Owns the exact backward target-blame terminal theorem required by the
 --     closed Nu DGG spine.
---   * The proof is the live assembly of target-step simulation,
---     target-blame catch-up, alignment, and trace induction.
+--   * The statement is frozen and checked; its proof will combine target-step
+--     simulation, target-blame catch-up, alignment, and trace induction.
 
 open import Data.List using ([])
 open import Data.Product using (∃-syntax)
@@ -21,8 +23,6 @@ open import NuTerms using (RuntimeOK; blame)
 open import QuotientedTermImprecision using
   (_∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_)
 open import proof.DGG.Core.NuDGGClosedWorld using (empty-store-wf)
-open import proof.DGG.TerminalBackward.NuDGGTerminalBackwardBlameIntegration
-  using (backward-target-blame-general-integratedᵀ)
 
 
 backward-target-blame-generalᵀ :
@@ -38,8 +38,7 @@ backward-target-blame-generalᵀ :
   ∀ χs′ →
   M′ —↠[ χs′ ] blame →
   ∃[ χs ] (M —↠[ χs ] blame)
-backward-target-blame-generalᵀ =
-  backward-target-blame-general-integratedᵀ
+backward-target-blame-generalᵀ = {!!}
 
 
 backward-target-blameᵀ :


### PR DESCRIPTION
This PR audits merged PRs #91-#95, retains the useful compatibility, dispatcher, and value-inversion work, and selectively restores NuDGGTerminalBackwardBlame.agda to its explicit partial state. Root cause: the merged unconditional theorem only aliased an integration that still obtains its one-step simulation from the permissive NuImprecisionCatchupScratch dispatcher, hiding unfinished holes and incomplete matches behind an apparently strict module. Impact: the repository presents the backward-blame proof status honestly without removing any completed strict lemma or changing the language, reduction, or imprecision relations. The DGG progress ledger records the detailed per-PR audit and revised next steps. Validation: git diff --check passed; focused strict checks passed for the retained PR #91 compatibility and atomic-reindex work, the PR #92-#94 dispatchers, and both PR #95 value-inversion modules.