### PR TITLE
Complete reduction-closed quotient imprecision prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,8 @@ When writing design notes for a calculus or translation:
   "identity-like case".
 - Put formal terms, judgments, and propositions in backticks in the prose and
   headings so they stand out from the surrounding explanation.
+- In Markdown documents, delimit displayed LaTeX with `$$ ... $$`. Do not use
+  `\[ ... \]`; Obsidian does not render those delimiters reliably.
 - When giving reduction relations in notes, prefer a clean mathematical
   presentation with the notation used consistently throughout the document.
 

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -10,6 +10,8 @@ COMPOSITIONAL_QUOTIENT_EXAMPLES = \
 	proof/Quotient/NuImprecisionCompositionalQuotientExamples.agda
 REDUCTION_CLOSED_QUOTIENT_EXAMPLES = \
 	proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
+CAMBRIDGE26_EXAMPLE14_EXPERIMENT = \
+	proof/Quotient/NuImprecisionCambridge26Example14Experiment.agda
 QUOTIENT_PROOF_DIR = proof/Quotient/
 REDUCTION_CLOSED_QUOTIENT_METATHEORY_MODULES = \
 	NuImprecisionReductionClosedQuotientTypingExperiment.agda \
@@ -81,6 +83,7 @@ dgg-check: audit
 quotient-design-check: audit
 	$(STRICT_AGDA) $(COMPOSITIONAL_QUOTIENT_EXAMPLES)
 	$(STRICT_AGDA) $(REDUCTION_CLOSED_QUOTIENT_EXAMPLES)
+	$(STRICT_AGDA) $(CAMBRIDGE26_EXAMPLE14_EXPERIMENT)
 	$(call strict-check-each,$(REDUCTION_CLOSED_QUOTIENT_METATHEORY))
 	$(call strict-check-each,$(REDUCTION_CLOSED_QUOTIENT_WORLD))
 	$(call strict-check-each,$(REDUCTION_CLOSED_QUOTIENT_AUDITS))

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -2,9 +2,16 @@
 # larger allocation area with a generous heap cap cuts checking time
 # substantially.
 AGDA = agda +RTS -A128M -M18G -RTS -v0
+STRICT_AGDA = agda --no-allow-unsolved-metas -v0
 PYTHON ?= python3
 DGG_STRICT_AGGREGATE = \
 	proof/DGG/Core/NuDGGUnassembledProofsStrictSpine.agda
+COMPOSITIONAL_QUOTIENT_EXAMPLES = \
+	proof/Quotient/NuImprecisionCompositionalQuotientExamples.agda
+REDUCTION_CLOSED_QUOTIENT_EXAMPLES = \
+	proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
+SINGLE_NARROWING_BOUNDARY_EXAMPLES = \
+	proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
 
 # Check a single file with: make agda FILE=NuMetaTheory.agda
 FILE ?= All.agda
@@ -24,6 +31,13 @@ audit:
 dgg-check: audit
 	$(AGDA) $(DGG_STRICT_AGGREGATE)
 
+# Check both quotient-design alternatives and their reduction-shape examples
+# before changing the live DGG relation.
+quotient-design-check: audit
+	$(STRICT_AGDA) $(COMPOSITIONAL_QUOTIENT_EXAMPLES)
+	$(STRICT_AGDA) $(REDUCTION_CLOSED_QUOTIENT_EXAMPLES)
+	$(STRICT_AGDA) $(SINGLE_NARROWING_BOUNDARY_EXAMPLES)
+
 # Per-definition time report; pick the target with FILE=...
 profile:
 	$(AGDA) --profile=definitions $(FILE)
@@ -34,4 +48,5 @@ profile-modules:
 clean:
 	find . -name '*~' -delete
 
-.PHONY: check agda audit dgg-check profile profile-modules clean
+.PHONY: check agda audit dgg-check quotient-design-check profile \
+	profile-modules clean

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -12,6 +12,8 @@ REDUCTION_CLOSED_QUOTIENT_EXAMPLES = \
 	proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
 SINGLE_NARROWING_BOUNDARY_EXAMPLES = \
 	proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
+TARGET_INSTANTIATION_CREATION_EXAMPLES = \
+	proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
 
 # Check a single file with: make agda FILE=NuMetaTheory.agda
 FILE ?= All.agda
@@ -37,6 +39,7 @@ quotient-design-check: audit
 	$(STRICT_AGDA) $(COMPOSITIONAL_QUOTIENT_EXAMPLES)
 	$(STRICT_AGDA) $(REDUCTION_CLOSED_QUOTIENT_EXAMPLES)
 	$(STRICT_AGDA) $(SINGLE_NARROWING_BOUNDARY_EXAMPLES)
+	$(STRICT_AGDA) $(TARGET_INSTANTIATION_CREATION_EXAMPLES)
 
 # Per-definition time report; pick the target with FILE=...
 profile:

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -16,6 +16,8 @@ TARGET_INSTANTIATION_CREATION_EXAMPLES = \
 	proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
 TARGET_INSTANTIATION_TRANSPORT_EXPERIMENT = \
 	proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
+TARGET_INSTANTIATION_TRANSPORT_TERMINAL_EXPERIMENT = \
+	proof/Quotient/NuImprecisionTargetInstantiationTransportTerminalExperiment.agda
 TARGET_INSTANTIATION_TRANSPORT_SPINE_EXPERIMENT = \
 	proof/Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda
 
@@ -45,6 +47,7 @@ quotient-design-check: audit
 	$(STRICT_AGDA) $(SINGLE_NARROWING_BOUNDARY_EXAMPLES)
 	$(STRICT_AGDA) $(TARGET_INSTANTIATION_CREATION_EXAMPLES)
 	$(STRICT_AGDA) $(TARGET_INSTANTIATION_TRANSPORT_EXPERIMENT)
+	$(STRICT_AGDA) $(TARGET_INSTANTIATION_TRANSPORT_TERMINAL_EXPERIMENT)
 	$(STRICT_AGDA) $(TARGET_INSTANTIATION_TRANSPORT_SPINE_EXPERIMENT)
 
 # Per-definition time report; pick the target with FILE=...

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -10,6 +10,37 @@ COMPOSITIONAL_QUOTIENT_EXAMPLES = \
 	proof/Quotient/NuImprecisionCompositionalQuotientExamples.agda
 REDUCTION_CLOSED_QUOTIENT_EXAMPLES = \
 	proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
+QUOTIENT_PROOF_DIR = proof/Quotient/
+REDUCTION_CLOSED_QUOTIENT_METATHEORY_MODULES = \
+	NuImprecisionReductionClosedQuotientTypingExperiment.agda \
+	NuImprecisionReductionClosedQuotientValueExperiment.agda \
+	NuImprecisionReductionClosedQuotientTermContextShiftExperiment.agda \
+	NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda \
+	NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment.agda
+REDUCTION_CLOSED_QUOTIENT_METATHEORY = \
+	$(addprefix $(QUOTIENT_PROOF_DIR), \
+	  $(REDUCTION_CLOSED_QUOTIENT_METATHEORY_MODULES))
+REDUCTION_CLOSED_QUOTIENT_WORLD_MODULES = \
+	NuImprecisionReductionClosedCompatibilityRenameExperiment.agda \
+	NuImprecisionReductionClosedWorldEmbeddingExperiment.agda \
+	NuImprecisionReductionClosedWorldRenameExperiment.agda \
+	NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda
+REDUCTION_CLOSED_QUOTIENT_WORLD = \
+	$(addprefix $(QUOTIENT_PROOF_DIR), \
+	  $(REDUCTION_CLOSED_QUOTIENT_WORLD_MODULES))
+REDUCTION_CLOSED_QUOTIENT_AUDIT_MODULES = \
+	NuImprecisionReductionClosedQuotientIdOnlyCastAudit.agda \
+	NuImprecisionReductionClosedQuotientTransientAudit.agda
+REDUCTION_CLOSED_QUOTIENT_AUDITS = \
+	$(addprefix $(QUOTIENT_PROOF_DIR), \
+	  $(REDUCTION_CLOSED_QUOTIENT_AUDIT_MODULES))
+TARGET_INSTANTIATION_MIGRATION_MODULES = \
+	NuImprecisionTargetInstantiationConsumerMigrationExperiment.agda \
+	NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda \
+	NuImprecisionTargetInstantiationSimulationExperiment.agda
+TARGET_INSTANTIATION_MIGRATIONS = \
+	$(addprefix $(QUOTIENT_PROOF_DIR), \
+	  $(TARGET_INSTANTIATION_MIGRATION_MODULES))
 SINGLE_NARROWING_BOUNDARY_EXAMPLES = \
 	proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
 TARGET_INSTANTIATION_CREATION_EXAMPLES = \
@@ -20,6 +51,12 @@ TARGET_INSTANTIATION_TRANSPORT_TERMINAL_EXPERIMENT = \
 	proof/Quotient/NuImprecisionTargetInstantiationTransportTerminalExperiment.agda
 TARGET_INSTANTIATION_TRANSPORT_SPINE_EXPERIMENT = \
 	proof/Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda
+
+define strict-check-each
+	@for module in $(1); do \
+		$(STRICT_AGDA) $$module || exit $$?; \
+	done
+endef
 
 # Check a single file with: make agda FILE=NuMetaTheory.agda
 FILE ?= All.agda
@@ -44,6 +81,10 @@ dgg-check: audit
 quotient-design-check: audit
 	$(STRICT_AGDA) $(COMPOSITIONAL_QUOTIENT_EXAMPLES)
 	$(STRICT_AGDA) $(REDUCTION_CLOSED_QUOTIENT_EXAMPLES)
+	$(call strict-check-each,$(REDUCTION_CLOSED_QUOTIENT_METATHEORY))
+	$(call strict-check-each,$(REDUCTION_CLOSED_QUOTIENT_WORLD))
+	$(call strict-check-each,$(REDUCTION_CLOSED_QUOTIENT_AUDITS))
+	$(call strict-check-each,$(TARGET_INSTANTIATION_MIGRATIONS))
 	$(STRICT_AGDA) $(SINGLE_NARROWING_BOUNDARY_EXAMPLES)
 	$(STRICT_AGDA) $(TARGET_INSTANTIATION_CREATION_EXAMPLES)
 	$(STRICT_AGDA) $(TARGET_INSTANTIATION_TRANSPORT_EXPERIMENT)

--- a/GTSF/Makefile
+++ b/GTSF/Makefile
@@ -14,6 +14,10 @@ SINGLE_NARROWING_BOUNDARY_EXAMPLES = \
 	proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
 TARGET_INSTANTIATION_CREATION_EXAMPLES = \
 	proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
+TARGET_INSTANTIATION_TRANSPORT_EXPERIMENT = \
+	proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
+TARGET_INSTANTIATION_TRANSPORT_SPINE_EXPERIMENT = \
+	proof/Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda
 
 # Check a single file with: make agda FILE=NuMetaTheory.agda
 FILE ?= All.agda
@@ -40,6 +44,8 @@ quotient-design-check: audit
 	$(STRICT_AGDA) $(REDUCTION_CLOSED_QUOTIENT_EXAMPLES)
 	$(STRICT_AGDA) $(SINGLE_NARROWING_BOUNDARY_EXAMPLES)
 	$(STRICT_AGDA) $(TARGET_INSTANTIATION_CREATION_EXAMPLES)
+	$(STRICT_AGDA) $(TARGET_INSTANTIATION_TRANSPORT_EXPERIMENT)
+	$(STRICT_AGDA) $(TARGET_INSTANTIATION_TRANSPORT_SPINE_EXPERIMENT)
 
 # Per-definition time report; pick the target with FILE=...
 profile:

--- a/GTSF/README.md
+++ b/GTSF/README.md
@@ -13,3 +13,17 @@ in [`scripts/GINGER_AGDA.md`](../scripts/GINGER_AGDA.md).  The wrapper uses the
 repository-local configuration in
 [`scripts/agda-ginger-config/`](../scripts/agda-ginger-config/) and should be
 run from the root of a checkout or worker worktree.
+
+## Local Codex standard-library cache
+
+On the local Mac, Agda stores derived standard-library interfaces under
+`/Users/jsiek/agda-stdlib-2.2/_build`. A sandboxed check can read those
+interfaces but may report `removeLink: permission denied` when Agda needs to
+replace a stale one. This is not a proof failure.
+
+For local Codex checks, authorize writes only to that `_build` directory and
+rerun the focused command. Do not grant access to the standard-library source
+or the rest of the home directory, and do not weaken the strict Agda flags in
+the Makefile. Let an authorized refresh finish: interrupting it can leave a
+partly refreshed cache that makes the next check encounter another stale
+interface.

--- a/GTSF/proof/Catchup/Core/NuImprecisionCatchupScratch.agda
+++ b/GTSF/proof/Catchup/Core/NuImprecisionCatchupScratch.agda
@@ -19,6 +19,7 @@ module proof.Catchup.Core.NuImprecisionCatchupScratch where
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import CastImprecisionShape using
   (_⊢ᶜ_⦂_; narrowing; widening)
+open import Data.Empty using (⊥-elim)
 open import Data.List using ([]; _∷_; _++_)
 open import Data.Nat using (suc; zero)
 open import Data.Nat.Properties using (≤-refl)
@@ -172,7 +173,8 @@ open import proof.Quotient.NuImprecisionQuotientWideningTransport using
   (weak-one-step-transport-quotient-widening-pairᵀ)
 open import proof.Core.Properties.ReductionProperties using
   (applyCoercions; applyTy-★; applyTys-++; cast-↠)
-open import proof.DGG.Core.NuPreservation using (runtime-ν; runtime-⟨⟩)
+open import proof.DGG.Core.NuPreservation using
+  (runtime-ν; runtime-⟨⟩; value-no-step)
 open import proof.DGG.Core.NuProgress using (runtime-value-no•)
 open import proof.Core.Properties.TypePreservation using
   (seal★-weaken; term-weaken)
@@ -458,6 +460,18 @@ left-catchup-indexed-prefixᵀ
   left-catchup-indexed-prefix-valueᵀ
     prefix okN (Λ vV) noV′ rel
 left-catchup-indexed-prefixᵀ
+    prefix okN vV′ noV′
+    rel@(Λ⊑instβᵀ
+      inner-prefix mode seal★ inst⊑ liftρ liftρᴿ
+      vW noW vW′ noW′ inert body f inst-shape creation-square
+      assm hτ hσ store-embedding
+      source-eq target-eq source-type-eq target-type-eq p
+      final-v final-no final-closed
+      final-v′ final-no′ final-closed′
+      source-typing target-typing) =
+  left-catchup-indexed-prefix-valueᵀ
+    prefix okN final-v noV′ rel
+left-catchup-indexed-prefixᵀ
     prefix okN () noV′
     (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ
       L⊑L′ L•⊢ L′•⊢)
@@ -692,6 +706,18 @@ weak-one-step-indexed-simulationᵀ
 weak-one-step-indexed-simulationᵀ
     wfΣ′ okM okM′
     (Λ⊑Λᵀ liftρ liftγ vV vV′ V⊑V′) (pure-step ())
+weak-one-step-indexed-simulationᵀ
+    wfΣ′ okM okM′
+    (Λ⊑instβᵀ
+      inner-prefix mode seal★ inst⊑ liftρ liftρᴿ
+      vW noW vW′ noW′ inert body f inst-shape creation-square
+      assm hτ hσ store-embedding
+      source-eq target-eq source-type-eq target-type-eq p
+      final-v final-no final-closed
+      final-v′ final-no′ final-closed′
+      source-typing target-typing)
+    M′→N′ =
+  ⊥-elim (value-no-step final-v′ M′→N′)
 weak-one-step-indexed-simulationᵀ
     wfΣ′ okM okM′ κ⊑κᵀ (pure-step ())
 weak-one-step-indexed-simulationᵀ

--- a/GTSF/proof/Catchup/Simulation/NuImprecisionSimulationCore.agda
+++ b/GTSF/proof/Catchup/Simulation/NuImprecisionSimulationCore.agda
@@ -289,9 +289,10 @@ open import proof.Core.Properties.ConversionIndexCompatibilityProperties using
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
 open import proof.Store.RelEmbedding.NuImprecisionRelCtxRenameDef
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
-  ( rel-store-embedding-composeⁱ
-  ; rel-store-embedding-prefix-invⁱ
-  )
+  (rel-store-embedding-composeⁱ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingProof using
   (rel-store-embedding-correspondenceⁱ)
 open import proof.Catchup.Simulation.NuImprecisionSimulationResultDef

--- a/GTSF/proof/DGG/Design/NuImprecisionCompositionalQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionCompositionalQuotientDesign.md
@@ -1,0 +1,235 @@
+# Compositional quotient design
+
+This note records the quotient-relation prototype in
+`proof.Quotient.NuImprecisionCompositionalQuotientDef`.  It is deliberately
+separate from the live relation in `QuotientedTermImprecision`: the examples
+should expose an inadequate rule before the DGG proof depends on it.
+
+## Problem with the current presentation
+
+The current quotient relation combines two different ideas:
+
+1. two casts may pass through different but `∀`-permuted intermediate types;
+2. quotient-related terms may occur inside larger terms.
+
+The paired-downcast rules implement the first idea.  The application rules
+partially implement the second, but only when the function is already
+quotient-related and the argument starts from ordinary imprecision before one
+new pair of downcasts.  They cannot directly consume a quotient-related
+argument, so a second function cast exposes the same missing case again:
+
+$$
+\begin{aligned}
+  ((V\langle c_1\mapsto d_1\rangle)
+       \langle c_2\mapsto d_2\rangle)\,W
+  &\longrightarrow
+  ((V\langle c_1\mapsto d_1\rangle)
+       (W\langle c_2\rangle))\langle d_2\rangle\\
+  &\longrightarrow
+  (V((W\langle c_2\rangle)\langle c_1\rangle))
+       \langle d_1\rangle\langle d_2\rangle .
+\end{aligned}
+$$
+
+Adding another rule for exactly two downcasts and two upcasts would merely
+move this boundary to three casts.
+
+## Finite narrowing spines
+
+The prototype first isolates the repeated structure.  A judgment
+
+$$
+  \mathsf{NarrowingSpine}\;\Delta\;\Sigma\;
+  M\;A\;N\;B\;s
+$$
+
+states that `N` is obtained from `M` by one or more narrowing casts, starting
+at `A`, ending at `B`, and having total imprecision shape `s`.
+
+The first cast forms a spine:
+
+$$
+  M : A
+  \quad
+  d : A \mathbin{\trianglerighteq} B
+  \quad
+  \mathsf{shape}(d)=s
+  \quad\Longrightarrow\quad
+  \mathsf{NarrowingSpine}\;M\;A\;(M\langle d\rangle)\;B\;s .
+$$
+
+A cast extends a spine when its shape composes with the accumulated shape:
+
+$$
+  \begin{aligned}
+  &\mathsf{NarrowingSpine}\;M\;A\;N\;B\;s,\\
+  &d : B \mathbin{\trianglerighteq} C,\qquad
+    \mathsf{shape}(d)=t,\qquad t;s \simeq u
+  \end{aligned}
+  \quad\Longrightarrow\quad
+  \mathsf{NarrowingSpine}\;M\;A\;(N\langle d\rangle)\;C\;u .
+$$
+
+Thus one quotient boundary square accounts for the total shapes of both
+spines, independent of their lengths.
+
+## Graded quotient term imprecision
+
+The prototype quotient judgment has a form index:
+
+$$
+  \Phi;\Delta_L;\Delta_R;\rho;\gamma
+  \vdash^{\,c}_{g}
+  M \sqsubseteq M' : A \sqsubseteq^p A' \triangleright q ,
+$$
+
+where
+
+$$
+  g ::= \mathsf{cast\text{-}spine}\mid\mathsf{application}.
+$$
+
+There are three central rules.
+
+Ordinary imprecision embeds at the exact quotient index:
+
+$$
+  M \sqsubseteq M' : A \sqsubseteq A' \triangleright p
+  \quad\Longrightarrow\quad
+  M \sqsubseteq^{p}_{\mathsf{cast\text{-}spine}} M'
+  : A \sqsubseteq^p A'
+  \triangleright
+  [\mathsf{refl},p,\mathsf{refl}] .
+$$
+
+Paired finite narrowing spines introduce a quotient boundary:
+
+$$
+  \begin{aligned}
+  &M \sqsubseteq M' : A \sqsubseteq A' \triangleright p,\\
+  &\mathsf{NarrowingSpine}\;M\;A\;N\;D\;s,\\
+  &\mathsf{NarrowingSpine}\;M'\;A'\;N'\;D'\;s',\\
+  &s;\lfloor p\rfloor \simeq^p q;s'
+  \end{aligned}
+  \quad\Longrightarrow\quad
+  N \sqsubseteq^{p}_{\mathsf{cast\text{-}spine}} N'
+  : D \sqsubseteq^p D' \triangleright q .
+$$
+
+Application is symmetric in its premises:
+
+$$
+  \begin{aligned}
+  &L \sqsubseteq^p L'
+    : C\to B \sqsubseteq^p C'\to B' \triangleright q_C\to q_B,\\
+  &M \sqsubseteq^p M'
+    : C \sqsubseteq^p C' \triangleright q_C
+  \end{aligned}
+  \quad\Longrightarrow\quad
+  L\,M \sqsubseteq^p_{\mathsf{application}} L'\,M'
+  : B \sqsubseteq^p B' \triangleright q_B .
+$$
+
+In particular, the argument may itself be an application derivation or an
+arbitrarily long paired narrowing spine.
+
+The grade prevents this new congruence from silently entering existing
+value-only proofs.  The prototype checks:
+
+$$
+  M \sqsubseteq^p_{\mathsf{application}} M'
+  \quad\Longrightarrow\quad
+  \neg\mathsf{Value}(M)
+  \quad\text{and}\quad
+  \neg\mathsf{Value}(M').
+$$
+
+A cast-spine leaf may still contain an ordinary application, but inversion
+then returns to the existing ordinary relation instead of exposing a new
+quotient application case.
+
+## Closing the quotient
+
+A quotient-closing widening retains two independent facts:
+
+1. its quotient boundary square;
+2. hereditary compatibility after transporting the widening shapes through
+   the chosen quotient representatives.
+
+The second fact is represented by
+`QuotientWideningCompatible`.  It does not pretend that a nontrivial quotient
+index is an ordinary imprecision derivation.  Instead, if
+
+$$
+  q=[D\approx_{\forall}C,\;r,\;C'\approx_{\forall}D'],
+$$
+
+then it transports the two widening shapes to the representatives and stores
+ordinary hereditary compatibility at `r`.
+
+After the first quotient-closing widening, further paired casts use the
+ordinary structured relation.  Consequently the two-function-cast residual
+is derived by four reusable steps:
+
+$$
+\begin{aligned}
+  &(W\langle c_2\rangle)\langle c_1\rangle
+       \sqsubseteq^p
+    (W'\langle c'_2\rangle)\langle c'_1\rangle,\\
+  &V((W\langle c_2\rangle)\langle c_1\rangle)
+       \sqsubseteq^p
+    V'((W'\langle c'_2\rangle)\langle c'_1\rangle),\\
+  &(V((W\langle c_2\rangle)\langle c_1\rangle))
+       \langle d_1\rangle
+       \sqsubseteq
+    (V'((W'\langle c'_2\rangle)\langle c'_1\rangle))
+       \langle d'_1\rangle,\\
+  &((V((W\langle c_2\rangle)\langle c_1\rangle))
+       \langle d_1\rangle)\langle d_2\rangle
+       \sqsubseteq
+    ((V'((W'\langle c'_2\rangle)\langle c'_1\rangle))
+       \langle d'_1\rangle)\langle d'_2\rangle .
+\end{aligned}
+$$
+
+The last derivation is checked by `two-function-cast-residual`.
+
+## Checked examples
+
+`proof.Quotient.NuImprecisionCompositionalQuotientExamples` checks:
+
+- exact ordinary embedding;
+- left-nested application, where an application result is used as a function;
+- right-nested application, where an application result is used as an
+  argument;
+- closing an application-derived quotient term with a widening;
+- one paired downcast through the incomparable `D` and `E` lower bounds;
+- two paired downcasts through the same nontrivial quotient boundary;
+- a quotient-related function consuming that two-cast quotient argument;
+- closing the nontrivial `E ≈∀ D` quotient through transported
+  representative widening shapes;
+- the full residual shape after two successive function-cast reductions.
+
+Run the focused suite with:
+
+```text
+make quotient-design-check
+```
+
+## Remaining design obligation
+
+The finite-spine rule starts from an ordinary term-imprecision leaf.  It
+handles the repeated function-cast family above, but it does not yet place a
+new narrowing spine around an arbitrary quotient application.  Supporting
+that operation requires a quotient-to-quotient cast square with permutation
+transport at both endpoints.
+
+Before replacing the live relation, the next checkpoint is therefore:
+
+1. prove typing projections for both prototype judgments;
+2. restate the terminal/value inversion lemmas using the form index;
+3. decide whether DGG reduction ever needs a narrowing spine around an
+   application-derived quotient term;
+4. if it does, define and test the two-sided quotient cast square;
+5. derive the existing one-cast application rules and
+   `down·up⊑down·upᵀ` from the compositional presentation.

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -6,6 +6,14 @@ public [`GradualDGG`](../../../DynamicGradualGuarantee.agda) statement. It is
 deliberately not an append-only proof-search transcript. Superseded attempts
 are removed from this file and remain available through Git history.
 
+## Obsidian math rendering convention
+
+Use `$$` delimiters for every LaTeX display. For reduction/imprecision
+diagrams, use a plain `aligned` environment with ordinary `&` alignment.
+Avoid `array` environments with custom column specifications such as
+`@{...}`, and write `\leftarrow` instead of `\mapsfrom`. Keep a blank line
+before and after each display.
+
 Here, **completed** means that the owned declaration has passed a focused Agda
 check without holes or permissive options. **Conditional** means that a strict
 higher-order proof is complete but one or more supplied semantic contracts do

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -41,7 +41,11 @@ the audited `Λ⊑instβᵀ` consumers, the reachable two-function-cast
 reduction/imprecision square, and the target instantiation/allocation/type-beta
 square. Its supporting typing, value, terminal, world-embedding, parallel
 substitution, and fully indexed single-variable substitution proofs are
-strict. Exact target-instantiation creation is closed under a composable
+strict. The concrete Cambridge26 Example 14 regression also passes: two
+successive instantiation/generalization round trips reduce through their two
+fresh `★` allocations and the enclosing concrete allocation to the same
+constant as the more precise term. Exact target-instantiation creation is
+closed under a composable
 embedded-creation residual, because a binder renames the allocated target seal
 from `0` to `suc 0`; the term grammar nevertheless has only one creation
 constructor and no generic renaming constructor or separate transported
@@ -440,6 +444,37 @@ that the complete independent relation and the decisive local simulation
 slices are coherent. It does not claim that the general source and target
 simulations, the terminal engines, or `GradualDGG` are complete.
 
+### Cambridge26 Example 14 regression
+
+The concrete repeated-instantiation example succeeds without extending the
+smaller relation. In the paper's less-precise-left notation, its top edge is
+
+$$
+\bigl(\nu\alpha:=\iota.\,(\mathit{id}\langle\bar\nu\alpha.\alpha^\sharp\to\alpha^\flat\rangle\langle\nu\alpha.\alpha^!\to\alpha^?\rangle\langle\bar\nu\alpha.\alpha^\sharp\to\alpha^\flat\rangle\langle\nu\alpha.\alpha^!\to\alpha^?\rangle)\,\alpha\langle\alpha^\sharp\to\alpha^\flat\rangle\bigr)\,c\mathrel{\sqsupseteq}\bigl(\nu\alpha:=\iota.\,\mathit{id}\,\alpha\langle\alpha^\sharp\to\alpha^\flat\rangle\bigr)\,c.
+$$
+
+The Agda relation reverses the displayed orientation: the more precise term is
+the left endpoint of `⊢ᴿ … ⊑ …`. The exact initial derivation alternates the
+ordinary right-widening and right-narrowing cast rules twice, then uses matched
+`ν`, ordinary application, and the constant rule. It uses neither quotient
+imprecision nor creation.
+
+The full bilateral square reduces both programs to the same constant. The
+four-cast endpoint allocates two fresh `★` seals before allocating the outer
+`\iota` seal; the other endpoint allocates only the outer `\iota` seal. The
+final relational store has the concrete entry matched at name `0` and the two
+additional `★` entries on the four-cast side at names `1` and `2`. Its type
+transport is exactly two target-only lifts followed by one matched lift. The
+bottom edge is ordinary constant imprecision.
+
+The strict regression is
+[`NuImprecisionCambridge26Example14Experiment.agda`](../../Quotient/NuImprecisionCambridge26Example14Experiment.agda).
+It contains the exact top edge, both allocation traces, all five exposed
+function-cast beta steps, all five cast-cancellation steps, and the final
+allocation-aware `⊢ᴿ↠` square. No quotient constructor, finite narrowing
+spine, fused application rule, live-QTI embedding, or example-specific
+relation constructor is used.
+
 ## Trusted proof boundaries
 
 | Boundary | Status | Role |
@@ -557,6 +592,10 @@ conversion, and conceal conversion value-catch-up cases.
   instantiation/allocation/type-beta square all succeed without live QTI,
   quotient application, finite spines, or the fused
   `down·up⊑down·upᵀ` rule.
+- Added the strict Cambridge26 Example 14 regression. Its exact top edge and
+  complete bilateral reduction square pass with two target-only `★`
+  allocations, one matched concrete allocation, and an ordinary constant
+  bottom edge.
 - Split live-prefix inversion out of
   `NuImprecisionRelStoreEmbeddingAlgebra`, leaving the generic relational-store
   embedding algebra independent of live term imprecision. Existing live
@@ -803,6 +842,12 @@ does not change the explicitly incomplete terminal-forward status above.
 Focused strict rechecks of the world-renaming and term-context-shift
 experiments passed after their final formatting edits, and `git diff --check`
 passed.
+
+The strict Cambridge26 Example 14 experiment passed on 2026-07-27. The
+subsequent `make quotient-design-check` aggregate also passed with the new
+experiment as a permanent check root. The source file has no lines over 80
+columns, `git diff --check` passes, and the new ledger display uses only the
+required `$$` delimiters.
 
 Do not use `All.agda` as the DGG completion criterion. It includes independent
 and historical development surfaces. The final completion check is the strict

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -15,9 +15,18 @@ holes or incomplete coverage remain.
 ## Current objective
 
 Construct a strict inhabitant of `GradualDGG` by completing the world-coherent
-forward and backward simulations over the repaired QTI grammar. The public
-statement and compiler boundary are checked, but no complete theorem inhabitant
-exists yet.
+forward and backward simulations over a quotient grammar that is stable under
+repeated function casts. The live DGG assembly is paused at a quotient-design
+checkpoint. Both the compositional prototype and the smaller
+up-to-reduction prototype are strict. The smaller prototype now passes the
+relation-level two-function-cast and arbitrary-substitution tests. It now
+permits exactly one paired narrowing cast, not a finite spine. A
+same-polarity stress test separates an unconditionally expressible
+two-narrowing residual from residuals reachable from the live ordinary
+relation; the remaining operational test is the allocation-aware catch-up
+forced by the active `inst` cast on one permutation route. Neither prototype
+has replaced `QuotientedTermImprecision`. The public statement and compiler
+boundary are checked, but no complete theorem inhabitant exists yet.
 
 The current proof uses these invariants:
 
@@ -32,6 +41,156 @@ The current proof uses these invariants:
   membership uniqueness, store well-formedness, and relational-store lineage.
 - no strict spine may transitively import a module enabling
   `--allow-unsolved-metas` or `--allow-incomplete-matches`.
+- in the compositional candidate, quotient application closure is graded so a
+  derivation introduced by the new application rule cannot appear as a source
+  or target value.
+- in the compositional candidate, repeated paired narrowings are represented
+  by a finite cast spine with one total quotient boundary square.
+- in the smaller candidate, a quotient boundary contains exactly one paired
+  narrowing cast. Additional casts must already be related at an ordinary
+  intermediate index or be consumed by bilateral reduction.
+
+## Active up-to-reduction design hypothesis
+
+The compositional quotient prototype is no longer the only candidate for the
+live relation.  The smaller-relation hypothesis is:
+
+> Keep quotient imprecision only at one paired narrowing cast and at the
+> paired widening boundary that closes its quotient. Do not add
+> quotient-indexed application congruence or a fused
+> `down·up⊑down·upᵀ` term rule.  Instead, use the existing bilateral weak
+> simulation result to reduce through function-cast administration until the
+> residuals return to the smaller relation.
+
+The current result algebra already has the required operational shape:
+`sourceCatchup` permits multiple source steps and `targetTail` permits multiple
+target steps after the leading target step.  The paired function-cast proof
+currently chooses a reflexive target tail and relates the immediate
+post-`β-↦` applications, which is what creates pressure for the fused rule.
+The intended replacement follows the `sim-beta-cast` organization from the
+GTLC DGG proof: peel a function cast, catch up the casted argument, recurse on
+the underlying function, and restore the result cast.
+
+This hypothesis is successful only if a quotient-aware beta lemma can cross
+the lambda endpoint.  In particular, after reducing
+
+$$
+((V\langle c_1\mapsto d_1\rangle)
+  \langle c_2\mapsto d_2\rangle)\,W
+$$
+
+through both function casts and the underlying beta-redex, the substituted
+residual must be related using only ordinary imprecision, paired narrowing
+casts, and quotient-closing widenings. If an irreducible quotient can remain
+embedded in an arbitrary lambda body without reaching such a closing
+boundary, reduction alone is insufficient; that is the falsification
+criterion for the smaller relation and evidence that a compatible quotient
+closure is genuinely necessary.
+
+The first test is isolated from `QuotientedTermImprecision`.  It must cover:
+
+1. a nontrivial paired quotient between differently ordered `∀` types;
+2. two successive function casts, not just one;
+3. reduction through the underlying identity lambda, so the quotient argument
+   is actually substituted;
+4. a final derivation in the smaller relation with no quotient-application or
+   fused down/application/up constructor; and
+5. a negative or blocked arbitrary-body test if the identity case succeeds.
+
+Current result: the relation-level portion succeeds more strongly than
+expected. The initial applications, both paired function boundaries, the
+twice-closed identity result, and substitution into an arbitrary related
+lambda body are all derivable without `down·up⊑down·upᵀ` and without either
+quotient-application constructor. After each down/up round trip, the existing
+`up⊑upᵀ` rule returns the argument to ordinary QTI, so the existing strict
+single-substitution theorem applies directly.
+
+The symmetric pure-reduction picture does not hold, however. For the concrete
+`glb-lower-XY`/`glb-lower-YX` routes, the `XY` closing cast is an inert
+universal cast while the `YX` closing cast is an active `inst`. Therefore:
+
+$$
+\begin{aligned}
+((\lambda x.x)\langle\mathit{inner}_{XY}\rangle
+  \langle\mathit{outer}_{XY}\rangle)\,W
+&\longrightarrow^{3}
+W\langle\mathit{down}_{XY}\rangle
+ \langle\mathit{up}_{XY}\rangle
+ \langle\mathit{down}_{XY}\rangle
+ \langle\mathit{up}_{XY}\rangle,\\
+((\lambda x.x)\langle\mathit{inner}_{YX}\rangle
+  \langle\mathit{outer}_{YX}\rangle)\,W'
+&\longrightarrow
+((\lambda x.x)\langle\mathit{inner}_{YX}\rangle)
+  (W'\langle\mathit{down}_{YX}\rangle)
+  \langle\mathit{up}_{YX}\rangle,
+\end{aligned}
+$$
+
+and the second line must allocate before its next function beta. This does not
+falsify the smaller-relation hypothesis: `WeakOneStepResult` already permits
+the required target tail and store changes. It identifies the next proof
+obligation precisely as the existing quotient-`inst` allocation catch-up
+boundary, rather than a missing term-imprecision constructor.
+
+### Single-boundary stress test
+
+The smaller prototype was tightened from a finite narrowing spine to exactly
+one paired narrowing cast. All earlier two-function-cast and substitution
+examples still pass.
+
+A stronger same-polarity example uses two genuine narrowing stages. Reduction
+of the two widening function casts exposes:
+
+$$
+\begin{aligned}
+W\langle d_1\rangle\langle d_2\rangle
+  \langle u_2\rangle\langle u_1\rangle
+\quad\text{and}\quad
+W'\langle d'_1\rangle\langle d'_2\rangle
+  \langle u'_2\rangle\langle u'_1\rangle .
+\end{aligned}
+$$
+
+The checked results are:
+
+1. both applications reduce to these residuals in three pure steps;
+2. the paired prefixes after `d₁,d₂` are related by the compositional
+   length-two `NarrowingSpine`;
+3. those same prefixes cannot be related by the one-paired-narrowing
+   prototype; inversion would require ordinary imprecision between
+   `∀X.∀Y.X→Y` and `∀Y.∀X.X→Y`, which is impossible; and
+4. the adversarial top pair is not generated by the live ordinary relation.
+   Its intermediate function types have exactly the same missing ordinary
+   imprecision. Relating the top would already require a
+   quotient-to-quotient cast rule.
+
+Therefore this test does **not** yet justify finite narrowing spines in the
+simulation invariant. It shows that finite spines add expressiveness, but the
+extra example lies outside the current relation's reachable top squares. For
+a reachable sequence of ordinary paired function casts, every earlier
+narrowing prefix has an ordinary intermediate index and can remain inside the
+ordinary premise of the final single paired narrowing.
+
+The normal-coercion `β-seq` audit also supports one narrowing boundary.
+Arbitrary sequences of function coercions are normalized by coercion
+composition. The surviving quotient-producing narrowing sequences begin with
+an active function untag. The existing strict
+`inner-sequence-residualᵀ` proof factors that untag into an ordinary cast
+relation and reconstructs exactly one quotient-producing tail cast; the
+seal-tail alternative is proved impossible. Thus source sequence expansion
+does not leave a reachable irreducible two-narrowing quotient.
+
+Target ordinary sequence roots likewise rebuild the two casts through
+ordinary imprecision. The still-uninhabited quotient active-value sequence
+root concerns a sequence in the *closing widening*, not repeated narrowing.
+It should use the target tail and the existing sequence-resume midpoint
+machinery; it is not evidence for `NarrowingSpine`.
+
+Conclusion of this checkpoint: retain exactly one paired narrowing cast in the
+smaller prototype. Finite narrowing spines remain only in the alternative
+compositional prototype and are not currently justified for a reachable DGG
+square.
 
 ## Trusted proof boundaries
 
@@ -44,6 +203,12 @@ The current proof uses these invariants:
 | [`NuDGGTerminalBackwardStrictSpine.agda`](../TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda) | **completed strict architecture** | Backward target-trace contracts and completed semantic leaves |
 | [`NuImprecisionOneStepDef.agda`](../../OneStep/NuImprecisionOneStepDef.agda) | **completed `Def`** | Target-oriented indexed one-step simulation contract |
 | [`NuImprecisionWorldCoherentOneStepDef.agda`](../../WorldCoherent/Core/NuImprecisionWorldCoherentOneStepDef.agda) | **completed `Def`** | World-coherent one-step contract used by the terminal proof |
+| [`NuImprecisionCompositionalQuotientDef.agda`](../../Quotient/NuImprecisionCompositionalQuotientDef.agda) | **completed prototype** | Graded quotient relation, finite narrowing spines, symmetric application, and compatible quotient closing |
+| [`NuImprecisionCompositionalQuotientExamples.agda`](../../Quotient/NuImprecisionCompositionalQuotientExamples.agda) | **completed examples** | Exact, nested-application, nontrivial permutation, repeated-cast, quotient-function/argument, and two-function-cast residual checks |
+| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Smaller relation with one paired narrowing boundary, no quotient application, and no fused down/application/up rule |
+| [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Nontrivial two-function-cast relation, identity reduction, arbitrary substitution, and checked active-`inst` allocation boundary |
+| [`NuImprecisionSingleNarrowingBoundaryExamples.agda`](../../Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda) | **completed diagnostic** | Same-polarity three-step reductions, a positive length-two spine, and a checked impossibility result for the single-boundary relation |
+| [`NuImprecisionReductionClosedQuotientDesign.md`](NuImprecisionReductionClosedQuotientDesign.md) | **current design hypothesis** | Complete small-relation sketch: one quotient boundary, ordinary-only congruence and substitution, bilateral reduction closure, reachability criterion, and remaining `sim-beta-cast` obligations |
 | [`NuDGGTerminalForwardIntegrationProof.agda`](../TerminalForward/NuDGGTerminalForwardIntegrationProof.agda) | **partial** | Intended route from forward/backward contracts to `GradualDGG`; currently reaches an uncovered paired-widening compatibility case |
 | [`NuDGGTerminalBackwardValueProof.agda`](../TerminalBackward/NuDGGTerminalBackwardValueProof.agda) | **conditional** | Fuel induction for target-value traces |
 | [`NuDGGTerminalBackwardBlameWorldCoherentProof.agda`](../TerminalBackward/NuDGGTerminalBackwardBlameWorldCoherentProof.agda) | **conditional** | Fuel induction for target-blame traces |
@@ -126,6 +291,60 @@ conversion, and conceal conversion value-catch-up cases.
   distinguished eleven genuinely completed higher-order roots from seven
   stale files that only looked complete to a source scan, and it incorporates
   the independently checked right/source-`∀` strict aggregate.
+- The quotient redesign now has a strict prototype and a focused checked
+  example suite. `NarrowingSpine` handles any positive number of paired
+  downcasts, both application premises use the quotient relation, and the
+  ordinary closing layer retains a quotient boundary square plus hereditary
+  compatibility through the selected representatives.
+- The examples check exact embedding, left- and right-nested applications,
+  quotient closing after application, one and two casts through the
+  incomparable `D`/`E` routes, a quotient-related function consuming the
+  two-cast quotient argument, representative-aware closing of a nontrivial
+  `E ≈∀ D` quotient, and the complete residual shape produced by two
+  successive function-cast reductions.
+- The endpoint-MLB fixture now supplies the explicit `NonVar` witness required
+  by the strengthened `ν` imprecision constructor; this removes a stale-source
+  failure that had been hidden by an older Agda interface.
+- The rationale, formal rules, tested reduction shape, and remaining
+  quotient-to-quotient cast-square question are recorded in
+  [`NuImprecisionCompositionalQuotientDesign.md`](NuImprecisionCompositionalQuotientDesign.md).
+- The smaller quotient prototype has no quotient-indexed application
+  constructor, no fused down/application/up constructor, and now no finite
+  narrowing spine. Its quotient constructor contains exactly one paired
+  narrowing cast. The earlier strict example still constructs the initial
+  two-function-cast application with ordinary application, constructs both
+  function boundaries from paired down/up rules, reduces the identity route
+  through three beta steps, and relates the final twice-closed argument.
+- The same example feeds that twice-closed argument to the canonical strict
+  single-substitution theorem for an arbitrary related lambda body. This
+  discharges the original substitution falsification test: once a quotient is
+  closed, it is ordinary QTI and does not require a compositional quotient
+  premise inside the body.
+- The example also proves that the permuted `YX` closing cast is not inert.
+  Its evaluation must enter the allocation-aware quotient-`inst` catch-up
+  machinery before the second function beta. The operational hypothesis
+  remains open exactly at that already-known semantic boundary.
+- The same-polarity stress test proves that two genuine narrowing prefixes
+  require a finite spine if considered without a reachability premise.
+  It also exposes why this is not yet a counterexample to the smaller
+  simulation relation: the top pair already needs an absent
+  quotient-to-quotient cast rule. The checked negative result therefore
+  rejects that pair as a simulation counterexample.
+- The reachable source `β-seq` case is already handled by the strict
+  `inner-sequence-residualᵀ` factorization: an active untag becomes ordinary
+  imprecision and the remaining tail uses one paired narrowing boundary.
+  The target quotient sequence obligation lies on the closing-widening side
+  and belongs to target-tail resumption, not to finite narrowing spines.
+- The revised whole-design sketch is recorded in
+  [`NuImprecisionReductionClosedQuotientDesign.md`](NuImprecisionReductionClosedQuotientDesign.md).
+  It treats quotient imprecision as a scoped intermediate judgment with one
+  paired narrowing introduction and one compatible paired widening
+  elimination. Application, polymorphism, ordinary casts, and substitution
+  remain in the ordinary relation; the simulation conclusion permits
+  bilateral reduction before requiring its final ordinary horizontal edge.
+  The note also records that the same-polarity two-narrowing stress test lacks
+  an ordinarily related top row and therefore does not refute this smaller
+  design.
 
 ## Counterexample policy and audit
 
@@ -169,32 +388,66 @@ behavior is covered by
 
 ## Current proof plan
 
-1. Restore hereditary `PairedWideningCompatible`: replace the broad
+1. State the allocation-aware quotient `sim-beta-cast` contract directly in
+   terms of the existing world-coherent weak result: the inert route supplies
+   the source catch-up, while the active `inst` route uses the target tail and
+   transports the quotient through the resulting store extension.
+2. Connect that contract to the existing paired-widening target
+   pending-allocation machinery. The immediate leaf is the quotient-`inst`
+   residual already counted among the four ordinary/generated down/up holes in
+   `NuImprecisionCatchupScratch`; do not add a term rule to bypass it.
+3. Complete the two-function-cast operational square and confirm that its
+   related endpoint is the ordinary QTI derivation consumed by
+   `two-round-trips-substitutionᵀ`.
+4. Discharge the target quotient closing-widening `β-seq` root through the
+   existing target-tail sequence-resume midpoint machinery. Do not add a
+   narrowing spine for this widening-side obligation.
+5. If these succeed, derive the live function-cast simulation without
+   `down·up⊑down·upᵀ` or quotient application and begin removing those
+   constructors in a separate migration. If allocation catch-up instead
+   produces an irreducible quotient embedded outside a closing boundary,
+   record that strict counterexample and return to the compositional design.
+6. Prove source and target typing projections for the smaller ordinary and
+   one-boundary quotient judgments. Re-run value, `No•`, and terminal
+   inversion using the fact that the quotient judgment has exactly one
+   constructor.
+7. Test the smaller design on valid ordinary top rows with arbitrary lambda
+   bodies, nested reachable function casts, source and target cast sequences,
+   and active target `inst`. Every test must exhibit its initial ordinary term
+   imprecision derivation before its reduction endpoints are considered.
+8. Keep the compositional quotient prototype as the fallback. Reintroduce
+   quotient application, finite narrowing spines, or a quotient-to-quotient
+   cast square only after a strict counterexample shows a derivable ordinary
+   top row whose reductions cannot reach an ordinary-related join.
+9. Restore hereditary `PairedWideningCompatible`: replace the broad
    `compatible-source-inert` fallback with the target-active case, preserve
    function and universal compatibility recursively, and retain the
    target-inert bridge. Then restore both function-beta consumers and the
    terminal-forward integration check.
-2. Add the missing paired-lambda frame-view
+10. Add the missing paired-lambda frame-view
    `down·up⊑down·upᵀ` case and restore its focused strict-spine check.
-3. Migrate the other six known-incomplete strict proofs to the current
+11. Migrate the other six known-incomplete strict proofs to the current
    uniqueness, binder-transport, compatibility, and `down·up⊑down·upᵀ`
    interfaces.
-4. Finish quotient transport normalization and the crossed binary
+12. Finish quotient transport normalization and the crossed binary
    runtime-sibling catch-up invariant.
-5. Prove the source-down-application `β` and `β-↦` value roots.
-6. Inhabit the remaining exact active-synchronization root records.
-7. Assemble the exhaustive prefix-aware world-coherent backward one-step
+13. Prove the source function-cast `β` and `β-↦` value roots using the
+   up-to-reduction `sim-beta-cast` argument rather than a quotient application
+   or spine-length-specific term rule.
+14. Inhabit the remaining exact active-synchronization root records.
+15. Assemble the exhaustive prefix-aware world-coherent backward one-step
    dispatcher and restore a practical green backward strict-spine check.
-8. Supply that strict dispatcher to both backward terminal engines.
-9. Complete the remaining forward engine contracts, invoke the strict terminal
+16. Supply that strict dispatcher to both backward terminal engines.
+17. Complete the remaining forward engine contracts, invoke the strict terminal
    integration proof, and construct `GradualDGG`.
-10. Promote any still-needed generic scratch clauses through strict
+18. Promote any still-needed generic scratch clauses through strict
    `Def`/`Proof`/`Lemma` boundaries and delete the scratch module.
 
 ## Validation
 
 Routine source audits:
 
+    make quotient-design-check
     make dgg-check
     agda -v0 proof/OneStep/NuImprecisionOneStepDef.agda
     agda -v0 proof/DGG/TerminalBackward/NuDGGTerminalBackwardStrictSpine.agda

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -43,9 +43,11 @@ and its ordinary fragment has explicit constructors. Exact creation is now
 one of those constructors. A focused transport experiment recovers its
 canonical renamed/store-embedded behavior and exposes one missing invariant
 in the old generalized fusion spine: the final index must equal the
-transported creation index rather than be arbitrary. Neither prototype has replaced
-`QuotientedTermImprecision`. The public statement and compiler boundary are
-checked, but no complete theorem inhabitant exists yet.
+transported creation index rather than be arbitrary. The unsafe generic
+renaming closure has been removed and replaced by a creation-specific
+canonical transport edge whose endpoints are proved terminal. Neither
+prototype has replaced `QuotientedTermImprecision`. The public statement and
+compiler boundary are checked, but no complete theorem inhabitant exists yet.
 
 The current proof uses these invariants:
 
@@ -80,10 +82,12 @@ The current proof uses these invariants:
 - endpoint transport of an exact creation edge produces the canonical renamed
   imprecision index. Any client that asks for another proof-relevant index
   must provide an equality to that canonical index.
-- the prototype currently represents closed-endpoint renaming and
-  relational-store embedding with one generic `rename-storeᴿ` constructor.
-  This concentrates, but does not yet discharge, the corresponding simulation
-  obligation.
+- the smaller relation has no generic renaming constructor. Arbitrary
+  well-scoped renamings may identify distinct seal names and change which
+  reduction rule applies.
+- only target-instantiation creation may cross the current canonical transport
+  boundary. Both transported endpoints are values, so its source- and
+  target-leading simulation cases are impossible.
 
 ## Active up-to-reduction design hypothesis
 
@@ -339,6 +343,43 @@ later relation migration. That migration should first introduce the exact
 creation constructor and prove that it supports the generalized live
 consumers before deleting `Λ⊑instβᵀ`.
 
+### Live target-instantiation consumer audit
+
+The direct positive consumers of `Λ⊑instβᵀ` now fall into four groups.
+
+- The direct paired-lambda post-beta context uses identity renaming, the exact
+  allocated store, and the canonical index `⊑-target-lift-rightᵢ f`. It is
+  ready for the first live migration.
+- The pure and paired universal-fusion spine contracts formerly retained an
+  arbitrary final index. Both now require equality with the canonical
+  endpoint-transported creation index, and their strict folds type-check.
+- The paired-lambda closing leaf view still extracts an arbitrary final index
+  from the old fused constructor. Its view, handler, and reconstruction
+  contracts must be strengthened together; the required equality cannot be
+  derived from the old constructor.
+- The unfinished target widening `β-inst` root cases are indirect consumers.
+  Their current contracts retain the outer relation and cast typing but drop
+  the cast-shape composition equation and the matched body/allocation
+  witnesses needed to construct exact creation.
+
+The permissive catch-up scratch concealed two more old-constructor cases.
+`left-catchup-indexed-prefixᵀ` now routes the stored final source value through
+ordinary value catch-up. `weak-one-step-indexed-simulationᵀ` now rejects its
+leading target step using the stored final target value and `value-no-step`.
+The scratch remains permissive because of its twelve previously recorded
+holes and other incomplete constructor coverage, not because these two cases
+are absent.
+
+The generic `rename-storeᴿ` experiment failed its operational audit.
+`TyRenameWf` preserves scope but not injectivity, and `RelStoreEmbeddingⁱ`
+does not provide a renaming inverse. A renaming may identify distinct seals
+and change `tag-untag-bad` into `tag-untag-ok`, so arbitrary reduction
+reflection is false. The constructor has been removed. The replacement
+`target-instantiation-transportᴿ` applies only to exact creation, fixes the
+canonical index, and carries exact endpoint typings. The strict terminal
+experiment proves that both transported endpoints are values and cannot take
+a leading step.
+
 ## Trusted proof boundaries
 
 | Boundary | Status | Role |
@@ -353,7 +394,7 @@ consumers before deleting `Λ⊑instβᵀ`.
 | [`NuImprecisionCompositionalQuotientDef.agda`](../../Quotient/NuImprecisionCompositionalQuotientDef.agda) | **completed prototype** | Graded quotient relation, finite narrowing spines, symmetric application, and compatible quotient closing |
 | [`NuImprecisionCompositionalQuotientExamples.agda`](../../Quotient/NuImprecisionCompositionalQuotientExamples.agda) | **completed examples** | Exact, nested-application, nontrivial permutation, repeated-cast, quotient-function/argument, and two-function-cast residual checks |
 | [`NuImprecisionQuotientBoundarySupport.agda`](../../Quotient/NuImprecisionQuotientBoundarySupport.agda) | **completed support** | Cast-mode and hereditary widening evidence with no dependency on a term-imprecision relation |
-| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Independent smaller ordinary grammar, exact creation, canonical closed-endpoint transport, one paired narrowing boundary, and no quotient application or fused down/application/up rule |
+| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Independent smaller ordinary grammar, exact creation, creation-specific canonical endpoint transport, one paired narrowing boundary, and no generic renaming, quotient application, or fused down/application/up rule |
 | [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Nontrivial two-function-cast relation, identity reduction, arbitrary substitution, and checked active-`inst` allocation boundary |
 | [`NuImprecisionSingleNarrowingBoundaryExamples.agda`](../../Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda) | **completed diagnostic** | Same-polarity three-step reductions, a positive length-two spine, and a checked impossibility result for the single-boundary relation |
 | [`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda) | **completed prototype** | Relation-parametric matched-body, cast-composition, and right-allocation residual |
@@ -437,6 +478,15 @@ conversion, and conceal conversion value-catch-up cases.
 - Proved canonical closed-endpoint renaming/store transport of exact creation.
   Endpoint equations are admissible when the final type-imprecision index is
   explicitly equal to the transported exact index.
+- Removed the generic `rename-storeᴿ` constructor after showing that arbitrary
+  well-scoped renaming need not preserve or reflect reduction. Replaced it
+  with creation-specific canonical transport and proved both transported
+  endpoints irreducible by value inversion.
+- Audited direct and indirect `Λ⊑instβᵀ` consumers. Added its two missing
+  permissive-scratch cases, strengthened the pure and paired fusion-spine
+  contracts with canonical-index equality, and identified the paired-lambda
+  leaf view and target widening `β-inst` roots as the remaining evidence-loss
+  boundaries.
 - Strengthened an independent finite target-instantiation spine with that
   equality and exact post-allocation endpoint typings. Its recursive fold into
   the smaller relation is strict, so nested creation itself introduces no
@@ -566,74 +616,79 @@ behavior is covered by
 
 ## Current proof plan
 
-1. Check whether every live consumer of `Λ⊑instβᵀ` can supply the canonical
-   final-index equality and exact post-allocation endpoint typings used by the
-   completed independent transport-spine fold. For each consumer that cannot,
-   determine whether its endpoint index was genuinely reindexed by a separate
-   theorem or was previously accepted only because the fused constructor left
-   the origin and final indices unrelated.
-2. After every consumer passes, replace `Λ⊑instβᵀ` with exact creation plus
-   canonical transport and remove the fused constructor.
-3. State the allocation-aware quotient `sim-beta-cast` contract directly in
+1. Strengthen the paired-lambda `leaf-instβ` view, all of its handlers, and
+   its reconstruction boundary so they retain exact creation plus the
+   canonical final-index equality. Do not manufacture that equality from the
+   old fused constructor.
+2. Strengthen the unfinished target widening `β-inst` root contracts with the
+   cast-shape composition equation and matched body/allocation witnesses
+   needed by exact creation. Cover both the ordinary cast-mode and
+   identity-mode roots.
+3. Migrate the direct identity post-beta context first, then the strengthened
+   paired-lambda leaf and fusion spines. After every positive consumer passes,
+   replace `Λ⊑instβᵀ` with exact creation plus canonical transport and remove
+   the fused constructor.
+4. Replace the interim creation-specific transport constructor with an
+   admissible syntax-directed no-bullet world-embedding theorem requiring
+   renaming left inverses and cast-mode renamers. Do not reintroduce a generic
+   outer renaming constructor.
+5. State the allocation-aware quotient `sim-beta-cast` contract directly in
    terms of the existing world-coherent weak result: the inert route supplies
    the source catch-up, while the active `inst` route uses the target tail,
    the creation constructor, and the resulting store extension.
-4. Connect that contract to the existing paired-widening target
+6. Connect that contract to the existing paired-widening target
    pending-allocation machinery. The immediate leaf is the quotient-`inst`
    residual already counted among the four ordinary/generated down/up holes in
    `NuImprecisionCatchupScratch`.
-5. Prove the source and target simulation cases for `rename-storeᴿ` by
-   reduction equivariance, or prove the rule admissible and remove it from the
-   inductive relation before the live migration.
-6. Complete the two-function-cast operational square and confirm that its
+7. Complete the two-function-cast operational square and confirm that its
    related endpoint is the ordinary QTI derivation consumed by
    `two-round-trips-substitutionᵀ`.
-7. Discharge the target quotient closing-widening `β-seq` root through the
+8. Discharge the target quotient closing-widening `β-seq` root through the
    existing target-tail sequence-resume midpoint machinery. Do not add a
    narrowing spine for this widening-side obligation.
-8. If these succeed, derive the live function-cast simulation without
+9. If these succeed, derive the live function-cast simulation without
    `down·up⊑down·upᵀ` or quotient application and begin removing those
    constructors in a separate migration. In the same migration, remove the
    uninhabited target-only type-application, `ν`, and casted-`ν` constructors
    and their vacuous semantic roots. If allocation catch-up instead produces
    an irreducible quotient embedded outside a closing boundary, record that
    strict counterexample and return to the compositional design.
-9. Prove source and target typing projections for the smaller ordinary and
+10. Prove source and target typing projections for the smaller ordinary and
    one-boundary quotient judgments. Re-run value, `No•`, and terminal
    inversion using the fact that the quotient judgment has exactly one
    constructor.
-10. Continue testing valid ordinary top rows with arbitrary lambda bodies,
+11. Continue testing valid ordinary top rows with arbitrary lambda bodies,
    nested reachable function casts, source and target cast sequences, and
    active target `inst`. The basic active-target test is complete; its nested
    quotient-closing instance remains. Every test must exhibit its initial
    ordinary term-imprecision derivation before its reduction endpoints are
    considered.
-11. Keep the compositional quotient prototype as the fallback. Reintroduce
+12. Keep the compositional quotient prototype as the fallback. Reintroduce
    quotient application, finite narrowing spines, or a quotient-to-quotient
    cast square only after a strict counterexample shows a derivable ordinary
    top row whose reductions cannot reach an ordinary-related join.
-12. Restore hereditary `PairedWideningCompatible`: replace the broad
+13. Restore hereditary `PairedWideningCompatible`: replace the broad
    `compatible-source-inert` fallback with the target-active case, preserve
    function and universal compatibility recursively, and retain the
    target-inert bridge. Then restore both function-beta consumers and the
    terminal-forward integration check.
-13. Add the missing paired-lambda frame-view
+14. Add the missing paired-lambda frame-view
    `down·up⊑down·upᵀ` case and restore its focused strict-spine check.
-14. Migrate the other six known-incomplete strict proofs to the current
+15. Migrate the other six known-incomplete strict proofs to the current
    uniqueness, binder-transport, compatibility, and `down·up⊑down·upᵀ`
    interfaces.
-15. Finish quotient transport normalization and the crossed binary
+16. Finish quotient transport normalization and the crossed binary
    runtime-sibling catch-up invariant.
-16. Prove the source function-cast `β` and `β-↦` value roots using the
+17. Prove the source function-cast `β` and `β-↦` value roots using the
    up-to-reduction `sim-beta-cast` argument rather than a quotient application
    or spine-length-specific term rule.
-17. Inhabit the remaining exact active-synchronization root records.
-18. Assemble the exhaustive prefix-aware world-coherent backward one-step
+18. Inhabit the remaining exact active-synchronization root records.
+19. Assemble the exhaustive prefix-aware world-coherent backward one-step
    dispatcher and restore a practical green backward strict-spine check.
-19. Supply that strict dispatcher to both backward terminal engines.
-20. Complete the remaining forward engine contracts, invoke the strict terminal
+20. Supply that strict dispatcher to both backward terminal engines.
+21. Complete the remaining forward engine contracts, invoke the strict terminal
    integration proof, and construct `GradualDGG`.
-21. Promote any still-needed generic scratch clauses through strict
+22. Promote any still-needed generic scratch clauses through strict
    `Def`/`Proof`/`Lemma` boundaries and delete the scratch module.
 
 ## Validation
@@ -664,10 +719,15 @@ completion.
 On 2026-07-27, `make quotient-design-check` passed after the authorized
 standard-library interface refresh. It checks the compositional examples, the
 independent reduction-closed examples, the single-boundary diagnostic, the
-target-instantiation creation example, and the canonical transport
-and transport-spine experiments. A subsequent unprivileged strict check of
+target-instantiation creation example, and the canonical transport,
+terminality, and transport-spine experiments. A subsequent unprivileged
+strict check of
 `NuImprecisionTargetInstantiationTransportExperiment.agda` passed in 2.6
 seconds, confirming that the local stdlib cache was coherent.
+The optimized focused check of
+`NuImprecisionCatchupScratch.agda` also passed after the two formerly omitted
+`Λ⊑instβᵀ` clauses were made explicit. Both strengthened fusion-spine folds
+pass strict focused checks.
 
 Do not use `All.agda` as the DGG completion criterion. It includes independent
 and historical development surfaces. The final completion check is the strict

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -344,7 +344,10 @@ conversion, and conceal conversion value-catch-up cases.
   bilateral reduction before requiring its final ordinary horizontal edge.
   The note also records that the same-polarity two-narrowing stress test lacks
   an ordinarily related top row and therefore does not refute this smaller
-  design.
+  design. Its ordinary layer now states the variable, blame, natural-number,
+  addition, one-sided cast, paired conversion, and paired widening rules
+  explicitly, including every relevant index-composition or
+  index-substitution premise.
 
 ## Counterexample policy and audit
 

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -49,6 +49,10 @@ The current proof uses these invariants:
 - in the smaller candidate, a quotient boundary contains exactly one paired
   narrowing cast. Additional casts must already be related at an ordinary
   intermediate index or be consumed by bilateral reduction.
+- the smaller candidate has no target-only type-application or `ν` rule.
+  Their pre-allocation index and independently opened body index are
+  inconsistent; real target-only `inst` allocation is crossed by target
+  reduction before the final ordinary relation is required.
 
 ## Active up-to-reduction design hypothesis
 
@@ -70,6 +74,14 @@ post-`β-↦` applications, which is what creates pressure for the fused rule.
 The intended replacement follows the `sim-beta-cast` organization from the
 GTLC DGG proof: peel a function cast, catch up the casted argument, recurse on
 the underlying function, and restore the result cast.
+
+The implemented smaller prototype currently narrows only the quotient layer:
+its `ordinaryᴿ` constructor embeds the complete live QTI relation.  It
+therefore still admits `Λ⊑instβᵀ` and the uninhabited target-only rules.  The
+design sketch is stricter than this prototype at the ordinary layer.  The
+active target-`inst` test must replace that embedding locally or define the
+candidate ordinary grammar before it can validate removal of those live
+constructors.
 
 This hypothesis is successful only if a quotient-aware beta lemma can cross
 the lambda endpoint.  In particular, after reducing
@@ -191,6 +203,81 @@ Conclusion of this checkpoint: retain exactly one paired narrowing cast in the
 smaller prototype. Finite narrowing spines remain only in the alternative
 compositional prototype and are not currently justified for a reachable DGG
 square.
+
+### Target-only `ν` index audit
+
+The live target-only `ν` constructor records four pieces of evidence:
+
+$$
+\begin{aligned}
+q &: \Phi \mathbin{;} \Delta_L
+  \vdash B \mathrel{\sqsubseteq} \forall C'
+  \dashv \Delta_R,\\
+r &: \mathord{\uparrow_R}\Phi \mathbin{;} \Delta_L
+  \vdash B \mathrel{\sqsubseteq} C'
+  \dashv \operatorname{suc}(\Delta_R),\\
+r[0 \mapsto {\uparrow A}]^R
+  &\doteq \operatorname{lift}^{R}(p),\\
+s &: C' \longrightarrow \mathord{\uparrow}B'.
+\end{aligned}
+$$
+
+Here the last line records only the endpoints of the target reveal
+conversion.  The first two lines already imply contradiction.  The strict
+[`NuImprecisionTargetBulletIndexCycleLemma.agda`](../../NuCore/Misc/NuImprecisionTargetBulletIndexCycleLemma.agda)
+proves the general statement by right-lifting `q`, pairing it with `r`, and
+applying the exhaustive common-target-extension obstruction.  Its focused
+Agda check passes without postulates, holes, or permissive options.
+
+The example audit found no closed positive construction of the target-only
+`ν`, casted-`ν`, or target-only type-application rules.  All apparent uses
+either pattern-match an assumed derivation, transport it conditionally, or
+implement a semantic root whose `q` and `r` hypotheses are themselves
+uninhabited.  The concrete
+[`NuImprecisionRightOpenedInstantiationIndexCounterexample.agda`](../../Right/Core/NuImprecisionRightOpenedInstantiationIndexCounterexample.agda)
+exhibits the smallest failed opening: a matched target universal cannot be
+reopened as an independent target-only binder.
+
+Target-only allocation is nevertheless operationally reachable inside target
+`inst` administration.  The positive
+[`NuImprecisionWorldCoherentRightTargetWidenInstantiationPairedPostBetaCatchupRegression.agda`](../../WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetWidenInstantiationPairedPostBetaCatchupRegression.agda)
+uses the target trace
+
+$$
+\langle\mathsf{inst}\rangle
+\mathbin{;}
+\mathsf{bind}\ \star
+\mathbin{;}
+\beta_{\forall}
+$$
+
+and establishes a live-QTI edge only after that trace.  That final edge uses
+the fused `Λ⊑instβᵀ` constructor, so the regression does not yet validate the
+smaller ordinary relation by itself.
+
+The tighter positive invariant suggested by this example is a
+target-instantiation creation square:
+
+$$
+\left\lfloor \forall^{\,i}q_{\mathrm{body}} \right\rfloor
+\mathbin{;}
+\left\lfloor \mathsf{inst}\ B'\ s \right\rfloor
+\mathrel{\cong}
+\left\lfloor p_{\mathrm{final}} \right\rfloor.
+$$
+
+It retains the matched body relation before allocation, the target
+conversion, the necessarily source-only final index, and the right-allocation
+store lineage.  It contains no independently opened `r`.  The smaller
+up-to-reduction design should omit the three uninhabited term rules and test
+whether this creation evidence can support a separate simulation lemma
+without making the fused post-administration edge primitive.  If not, a
+narrowly scoped creation residual is the candidate new invariant.
+
+The live relation is not changed at this checkpoint.  Deleting the
+uninhabited constructors and their conditional transport cases belongs in the
+later relation migration, after the creation-square test determines whether
+`Λ⊑instβᵀ` can also be removed.
 
 ## Trusted proof boundaries
 
@@ -407,17 +494,23 @@ behavior is covered by
    narrowing spine for this widening-side obligation.
 5. If these succeed, derive the live function-cast simulation without
    `down·up⊑down·upᵀ` or quotient application and begin removing those
-   constructors in a separate migration. If allocation catch-up instead
-   produces an irreducible quotient embedded outside a closing boundary,
-   record that strict counterexample and return to the compositional design.
+   constructors in a separate migration. In the same migration, remove the
+   uninhabited target-only type-application, `ν`, and casted-`ν` constructors
+   and their vacuous semantic roots. If allocation catch-up instead produces
+   an irreducible quotient embedded outside a closing boundary, record that
+   strict counterexample and return to the compositional design.
 6. Prove source and target typing projections for the smaller ordinary and
    one-boundary quotient judgments. Re-run value, `No•`, and terminal
    inversion using the fact that the quotient judgment has exactly one
    constructor.
 7. Test the smaller design on valid ordinary top rows with arbitrary lambda
    bodies, nested reachable function casts, source and target cast sequences,
-   and active target `inst`. Every test must exhibit its initial ordinary term
-   imprecision derivation before its reduction endpoints are considered.
+   and active target `inst`. For the active target-`inst` case, use the matched
+   body relation, creation square, and allocation lineage to derive the final
+   edge without `Λ⊑instβᵀ`; if that is impossible, isolate the smallest
+   creation residual that suffices. Every test must exhibit its initial
+   ordinary term imprecision derivation before its reduction endpoints are
+   considered.
 8. Keep the compositional quotient prototype as the fallback. Reintroduce
    quotient application, finite narrowing spines, or a quotient-to-quotient
    cast square only after a strict counterexample shows a derivable ordinary

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -37,7 +37,13 @@ relation. The allocation-aware target-`inst` test is now complete: the valid
 top row and target trace need no fused final edge, but the final stable values
 cannot be related by ordinary source-only-lambda and target-cast rules. The
 matched body relation, creation equation, and allocation lineage form the
-smallest checked residual. Neither prototype has replaced
+smallest checked residual. The smaller relation is now definitionally
+independent of live QTI: its former `ordinaryᴿ` embedding has been removed,
+and its ordinary fragment has explicit constructors. Exact creation is now
+one of those constructors. A focused transport experiment recovers its
+canonical renamed/store-embedded behavior and exposes one missing invariant
+in the old generalized fusion spine: the final index must equal the
+transported creation index rather than be arbitrary. Neither prototype has replaced
 `QuotientedTermImprecision`. The public statement and compiler boundary are
 checked, but no complete theorem inhabitant exists yet.
 
@@ -71,6 +77,13 @@ The current proof uses these invariants:
   composition equation, and store lineage into the right-extended world.
   Up-to-reduction removes transient allocation edges but not this final
   semantic creation case.
+- endpoint transport of an exact creation edge produces the canonical renamed
+  imprecision index. Any client that asks for another proof-relevant index
+  must provide an equality to that canonical index.
+- the prototype currently represents closed-endpoint renaming and
+  relational-store embedding with one generic `rename-storeᴿ` constructor.
+  This concentrates, but does not yet discharge, the corresponding simulation
+  obligation.
 
 ## Active up-to-reduction design hypothesis
 
@@ -93,14 +106,13 @@ The intended replacement follows the `sim-beta-cast` organization from the
 GTLC DGG proof: peel a function cast, catch up the casted argument, recurse on
 the underlying function, and restore the result cast.
 
-The implemented smaller prototype currently narrows only the quotient layer:
-its `ordinaryᴿ` constructor embeds the complete live QTI relation.  It
-therefore still admits `Λ⊑instβᵀ` and the uninhabited target-only rules.  The
-design sketch is stricter than this prototype at the ordinary layer.  The
-separate target-instantiation test avoids the fused constructor: it constructs
-the valid initial ordinary row, the complete target allocation trace, and the
-creation residual, then proves that the structural final-body factorization is
-impossible.
+The implemented smaller prototype now has its own ordinary grammar.
+`ordinaryᴿ` has been deleted, and neither the smaller definition nor its
+neutral quotient support imports the live term-imprecision relation.  The
+target-instantiation test constructs both its initial and final rows in this
+independent relation.  `TargetInstantiationCreation` is parametric in its
+matched body relation, so the same residual can be checked with either
+relation without importing one into the other.
 
 This hypothesis is successful only if a quotient-aware beta lemma can cross
 the lambda endpoint.  In particular, after reducing
@@ -340,11 +352,14 @@ consumers before deleting `Λ⊑instβᵀ`.
 | [`NuImprecisionWorldCoherentOneStepDef.agda`](../../WorldCoherent/Core/NuImprecisionWorldCoherentOneStepDef.agda) | **completed `Def`** | World-coherent one-step contract used by the terminal proof |
 | [`NuImprecisionCompositionalQuotientDef.agda`](../../Quotient/NuImprecisionCompositionalQuotientDef.agda) | **completed prototype** | Graded quotient relation, finite narrowing spines, symmetric application, and compatible quotient closing |
 | [`NuImprecisionCompositionalQuotientExamples.agda`](../../Quotient/NuImprecisionCompositionalQuotientExamples.agda) | **completed examples** | Exact, nested-application, nontrivial permutation, repeated-cast, quotient-function/argument, and two-function-cast residual checks |
-| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Smaller relation with one paired narrowing boundary, no quotient application, and no fused down/application/up rule |
+| [`NuImprecisionQuotientBoundarySupport.agda`](../../Quotient/NuImprecisionQuotientBoundarySupport.agda) | **completed support** | Cast-mode and hereditary widening evidence with no dependency on a term-imprecision relation |
+| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Independent smaller ordinary grammar, exact creation, canonical closed-endpoint transport, one paired narrowing boundary, and no quotient application or fused down/application/up rule |
 | [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Nontrivial two-function-cast relation, identity reduction, arbitrary substitution, and checked active-`inst` allocation boundary |
 | [`NuImprecisionSingleNarrowingBoundaryExamples.agda`](../../Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda) | **completed diagnostic** | Same-polarity three-step reductions, a positive length-two spine, and a checked impossibility result for the single-boundary relation |
-| [`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda) | **completed prototype** | Exact matched-body, cast-composition, and right-allocation residual with generalized endpoint transport omitted |
-| [`NuImprecisionTargetInstantiationCreationExamples.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationExamples.agda) | **completed diagnostic** | Valid top row, target allocation trace, creation residual, and strict refutation of ordinary final-edge factorization |
+| [`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda) | **completed prototype** | Relation-parametric matched-body, cast-composition, and right-allocation residual |
+| [`NuImprecisionTargetInstantiationCreationExamples.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationExamples.agda) | **completed diagnostic** | Independent smaller initial/final rows, target allocation trace, creation residual, and strict refutation of ordinary final-edge factorization |
+| [`NuImprecisionTargetInstantiationTransportExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda) | **completed diagnostic** | Canonical renaming/store-embedding transport and endpoint replacement with an explicit final-index coherence equality |
+| [`NuImprecisionTargetInstantiationTransportSpineExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda) | **completed diagnostic** | Strict recursive fold for arbitrarily nested exact creation and canonical endpoint transport |
 | [`NuImprecisionReductionClosedQuotientDesign.md`](NuImprecisionReductionClosedQuotientDesign.md) | **current design hypothesis** | Complete small-relation sketch: one quotient boundary, ordinary-only congruence and substitution, bilateral reduction closure, reachability criterion, and remaining `sim-beta-cast` obligations |
 | [`NuDGGTerminalForwardIntegrationProof.agda`](../TerminalForward/NuDGGTerminalForwardIntegrationProof.agda) | **partial** | Intended route from forward/backward contracts to `GradualDGG`; currently reaches an uncovered paired-widening compatibility case |
 | [`NuDGGTerminalBackwardValueProof.agda`](../TerminalBackward/NuDGGTerminalBackwardValueProof.agda) | **conditional** | Fuel induction for target-value traces |
@@ -410,6 +425,22 @@ conversion, and conceal conversion value-catch-up cases.
 
 ## Completed recent work
 
+- Removed `ordinaryᴿ` and changed the smaller relation's worlds, stores, and
+  contexts from fixed parameters to indices. Its variable, abstraction,
+  application, polymorphic, constant, primitive, one-sided cast, paired
+  widening, exact creation, and quotient-boundary cases are now independent
+  constructors.
+- Split `SpineCastMode` and `QuotientWideningCompatible` into
+  `NuImprecisionQuotientBoundarySupport`, which imports no term relation.
+- Made `TargetInstantiationCreation` parametric in the matched body relation
+  and used it as the sole premise of the smaller exact-creation constructor.
+- Proved canonical closed-endpoint renaming/store transport of exact creation.
+  Endpoint equations are admissible when the final type-imprecision index is
+  explicitly equal to the transported exact index.
+- Strengthened an independent finite target-instantiation spine with that
+  equality and exact post-allocation endpoint typings. Its recursive fold into
+  the smaller relation is strict, so nested creation itself introduces no
+  further constructor requirement.
 - The QTI repair added the exact post-`β-inst` relation needed after paired
   target allocation. The positive closed regression is now named
   [`NuImprecisionWorldCoherentRightTargetWidenInstantiationPairedPostBetaCatchupRegression.agda`](../../WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetWidenInstantiationPairedPostBetaCatchupRegression.agda).
@@ -535,15 +566,14 @@ behavior is covered by
 
 ## Current proof plan
 
-1. Prototype an exact target-instantiation creation constructor in the
-   candidate ordinary relation. Its premise should be
-   `TargetInstantiationCreation`; it should not contain arbitrary renaming,
-   store embedding, endpoint equality, closure, or repeated endpoint-typing
-   fields.
-2. Prove renaming, store-embedding, and endpoint-transport admissibility for
-   that exact constructor. Use those lemmas to reconstruct the generalized
-   behavior currently built into `Λ⊑instβᵀ`. Only after this succeeds should
-   the live constructor be replaced.
+1. Check whether every live consumer of `Λ⊑instβᵀ` can supply the canonical
+   final-index equality and exact post-allocation endpoint typings used by the
+   completed independent transport-spine fold. For each consumer that cannot,
+   determine whether its endpoint index was genuinely reindexed by a separate
+   theorem or was previously accepted only because the fused constructor left
+   the origin and final indices unrelated.
+2. After every consumer passes, replace `Λ⊑instβᵀ` with exact creation plus
+   canonical transport and remove the fused constructor.
 3. State the allocation-aware quotient `sim-beta-cast` contract directly in
    terms of the existing world-coherent weak result: the inert route supplies
    the source catch-up, while the active `inst` route uses the target tail,
@@ -552,55 +582,58 @@ behavior is covered by
    pending-allocation machinery. The immediate leaf is the quotient-`inst`
    residual already counted among the four ordinary/generated down/up holes in
    `NuImprecisionCatchupScratch`.
-5. Complete the two-function-cast operational square and confirm that its
+5. Prove the source and target simulation cases for `rename-storeᴿ` by
+   reduction equivariance, or prove the rule admissible and remove it from the
+   inductive relation before the live migration.
+6. Complete the two-function-cast operational square and confirm that its
    related endpoint is the ordinary QTI derivation consumed by
    `two-round-trips-substitutionᵀ`.
-6. Discharge the target quotient closing-widening `β-seq` root through the
+7. Discharge the target quotient closing-widening `β-seq` root through the
    existing target-tail sequence-resume midpoint machinery. Do not add a
    narrowing spine for this widening-side obligation.
-7. If these succeed, derive the live function-cast simulation without
+8. If these succeed, derive the live function-cast simulation without
    `down·up⊑down·upᵀ` or quotient application and begin removing those
    constructors in a separate migration. In the same migration, remove the
    uninhabited target-only type-application, `ν`, and casted-`ν` constructors
    and their vacuous semantic roots. If allocation catch-up instead produces
    an irreducible quotient embedded outside a closing boundary, record that
    strict counterexample and return to the compositional design.
-8. Prove source and target typing projections for the smaller ordinary and
+9. Prove source and target typing projections for the smaller ordinary and
    one-boundary quotient judgments. Re-run value, `No•`, and terminal
    inversion using the fact that the quotient judgment has exactly one
    constructor.
-9. Continue testing valid ordinary top rows with arbitrary lambda bodies,
+10. Continue testing valid ordinary top rows with arbitrary lambda bodies,
    nested reachable function casts, source and target cast sequences, and
    active target `inst`. The basic active-target test is complete; its nested
    quotient-closing instance remains. Every test must exhibit its initial
    ordinary term-imprecision derivation before its reduction endpoints are
    considered.
-10. Keep the compositional quotient prototype as the fallback. Reintroduce
+11. Keep the compositional quotient prototype as the fallback. Reintroduce
    quotient application, finite narrowing spines, or a quotient-to-quotient
    cast square only after a strict counterexample shows a derivable ordinary
    top row whose reductions cannot reach an ordinary-related join.
-11. Restore hereditary `PairedWideningCompatible`: replace the broad
+12. Restore hereditary `PairedWideningCompatible`: replace the broad
    `compatible-source-inert` fallback with the target-active case, preserve
    function and universal compatibility recursively, and retain the
    target-inert bridge. Then restore both function-beta consumers and the
    terminal-forward integration check.
-12. Add the missing paired-lambda frame-view
+13. Add the missing paired-lambda frame-view
    `down·up⊑down·upᵀ` case and restore its focused strict-spine check.
-13. Migrate the other six known-incomplete strict proofs to the current
+14. Migrate the other six known-incomplete strict proofs to the current
    uniqueness, binder-transport, compatibility, and `down·up⊑down·upᵀ`
    interfaces.
-14. Finish quotient transport normalization and the crossed binary
+15. Finish quotient transport normalization and the crossed binary
    runtime-sibling catch-up invariant.
-15. Prove the source function-cast `β` and `β-↦` value roots using the
+16. Prove the source function-cast `β` and `β-↦` value roots using the
    up-to-reduction `sim-beta-cast` argument rather than a quotient application
    or spine-length-specific term rule.
-16. Inhabit the remaining exact active-synchronization root records.
-17. Assemble the exhaustive prefix-aware world-coherent backward one-step
+17. Inhabit the remaining exact active-synchronization root records.
+18. Assemble the exhaustive prefix-aware world-coherent backward one-step
    dispatcher and restore a practical green backward strict-spine check.
-18. Supply that strict dispatcher to both backward terminal engines.
-19. Complete the remaining forward engine contracts, invoke the strict terminal
+19. Supply that strict dispatcher to both backward terminal engines.
+20. Complete the remaining forward engine contracts, invoke the strict terminal
    integration proof, and construct `GradualDGG`.
-20. Promote any still-needed generic scratch clauses through strict
+21. Promote any still-needed generic scratch clauses through strict
    `Def`/`Proof`/`Lemma` boundaries and delete the scratch module.
 
 ## Validation
@@ -627,6 +660,14 @@ transitive canonical `Lemma` consumer, 149 are reachable from an explicit
 strict inventory spine, seven are explicitly known incomplete, and none are
 uninventoried. Focused Agda checks, not these source counts, establish
 completion.
+
+On 2026-07-27, `make quotient-design-check` passed after the authorized
+standard-library interface refresh. It checks the compositional examples, the
+independent reduction-closed examples, the single-boundary diagnostic, the
+target-instantiation creation example, and the canonical transport
+and transport-spine experiments. A subsequent unprivileged strict check of
+`NuImprecisionTargetInstantiationTransportExperiment.agda` passed in 2.6
+seconds, confirming that the local stdlib cache was coherent.
 
 Do not use `All.agda` as the DGG completion criterion. It includes independent
 and historical development surfaces. The final completion check is the strict

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -27,27 +27,32 @@ holes or incomplete coverage remain.
 Construct a strict inhabitant of `GradualDGG` by completing the world-coherent
 forward and backward simulations over a quotient grammar that is stable under
 repeated function casts. The live DGG assembly is paused at a quotient-design
-checkpoint. Both the compositional prototype and the smaller
-up-to-reduction prototype are strict. The smaller prototype now passes the
-relation-level two-function-cast and arbitrary-substitution tests. It now
-permits exactly one paired narrowing cast, not a finite spine. A
-same-polarity stress test separates an unconditionally expressible
-two-narrowing residual from residuals reachable from the live ordinary
-relation. The allocation-aware target-`inst` test is now complete: the valid
-top row and target trace need no fused final edge, but the final stable values
-cannot be related by ordinary source-only-lambda and target-cast rules. The
-matched body relation, creation equation, and allocation lineage form the
-smallest checked residual. The smaller relation is now definitionally
-independent of live QTI: its former `ordinaryᴿ` embedding has been removed,
-and its ordinary fragment has explicit constructors. Exact creation is now
-one of those constructors. A focused transport experiment recovers its
-canonical renamed/store-embedded behavior and exposes one missing invariant
-in the old generalized fusion spine: the final index must equal the
-transported creation index rather than be arbitrary. The unsafe generic
-renaming closure has been removed and replaced by a creation-specific
-canonical transport edge whose endpoints are proved terminal. Neither
-prototype has replaced `QuotientedTermImprecision`. The public statement and
-compiler boundary are checked, but no complete theorem inhabitant exists yet.
+checkpoint. Both the compositional prototype and the smaller up-to-reduction
+prototype are strict, but the smaller prototype is now the selected migration
+candidate. Its grammar is complete and definitionally independent of live
+QTI: variables, blame, abstractions, applications, polymorphism, constants,
+primitive operations, casts, conversions, paired widening, generalization
+against a target ground type, allocation prefixes, and target-instantiation
+creation are all represented directly. Its quotient judgment has exactly one
+paired-narrowing constructor.
+
+The smaller relation now passes all three decisive experiments: migration of
+the audited `Λ⊑instβᵀ` consumers, the reachable two-function-cast
+reduction/imprecision square, and the target instantiation/allocation/type-beta
+square. Its supporting typing, value, terminal, world-embedding, parallel
+substitution, and fully indexed single-variable substitution proofs are
+strict. Exact target-instantiation creation is closed under a composable
+embedded-creation residual, because a binder renames the allocated target seal
+from `0` to `suc 0`; the term grammar nevertheless has only one creation
+constructor and no generic renaming constructor or separate transported
+creation constructor.
+
+The result is ready for a controlled replacement of
+`QuotientedTermImprecision`. It has not yet replaced the live relation, and
+the general source and target function-cast simulations remain to be connected
+to the existing world-coherent operational machinery. The public statement
+and compiler boundary are checked, but no complete `GradualDGG` inhabitant
+exists yet.
 
 The current proof uses these invariants:
 
@@ -79,15 +84,22 @@ The current proof uses these invariants:
   composition equation, and store lineage into the right-extended world.
   Up-to-reduction removes transient allocation edges but not this final
   semantic creation case.
-- endpoint transport of an exact creation edge produces the canonical renamed
-  imprecision index. Any client that asks for another proof-relevant index
-  must provide an equality to that canonical index.
+- exact creation is the base of `EmbeddedTargetInstantiationCreation`.
+  Each typed relational-world embedding computes the canonical renamed
+  imprecision index; no embedding step may choose an unrelated final index.
+- exact creation alone is not stable under an enclosing type binder:
+  `store-right 0` becomes `store-right (suc 0)`. The embedded residual records
+  precisely this necessary closure and composes it without adding another term
+  constructor.
 - the smaller relation has no generic renaming constructor. Arbitrary
   well-scoped renamings may identify distinct seal names and change which
   reduction rule applies.
-- only target-instantiation creation may cross the current canonical transport
-  boundary. Both transported endpoints are values, so its source- and
-  target-leading simulation cases are impossible.
+- only target-instantiation creation may cross the embedded-creation boundary.
+  Every embedded endpoint remains a value, so its source- and target-leading
+  simulation cases are impossible.
+- single-variable substitution requires unique imprecision assumptions and
+  `No•` evidence for both body endpoints and both substituted endpoints. It
+  uses only the smaller relation and its syntax-directed world embeddings.
 
 ## Active up-to-reduction design hypothesis
 
@@ -370,15 +382,63 @@ The scratch remains permissive because of its twelve previously recorded
 holes and other incomplete constructor coverage, not because these two cases
 are absent.
 
+A second audit explicitly included incomplete relation consumers. Exactly
+three permissive modules import the live term-imprecision judgment.
+`NuImprecisionCatchupScratch` is the only one that performs exhaustive
+case analysis on that judgment; both of its analyses contain the old
+`Λ⊑instβᵀ` case and must be migrated to the smaller creation residual.
+`NuImprecisionOneStepTargetCastRoots` and
+`NuImprecisionOneStepTargetConversionRoots` accept a relation premise but
+only pass it to focused helpers; their remaining holes do not hide additional
+term-imprecision constructor cases. No other permissive or postulated module
+both consumes the live relation and contains an incomplete case analysis.
+
 The generic `rename-storeᴿ` experiment failed its operational audit.
 `TyRenameWf` preserves scope but not injectivity, and `RelStoreEmbeddingⁱ`
 does not provide a renaming inverse. A renaming may identify distinct seals
 and change `tag-untag-bad` into `tag-untag-ok`, so arbitrary reduction
-reflection is false. The constructor has been removed. The replacement
-`target-instantiation-transportᴿ` applies only to exact creation, fixes the
-canonical index, and carries exact endpoint typings. The strict terminal
-experiment proves that both transported endpoints are values and cannot take
-a leading step.
+reflection is false. The constructor has been removed. The replacement is
+`EmbeddedTargetInstantiationCreation`: exact creation is its base and each
+embedding step fixes the canonical renamed index and carries exact endpoint
+typings. The term grammar has only `target-instantiationᴿ`; the interim
+transport constructor has been deleted. The strict terminal experiment proves
+that every embedded pair of endpoints consists of values and cannot take a
+leading step.
+
+### Decisive smaller-relation experiments
+
+The three experiments requested before selecting the relation all succeeded.
+
+1. **SUCCESS — `Λ⊑instβᵀ` consumer migration.** The direct identity
+   post-beta context, canonical paired-lambda leaf, unframed and framed fusion
+   spines, ordinary target widening root, and identity-mode target widening
+   root all reconstruct actual smaller-relation derivations. They retain the
+   exact creation evidence and canonical final-index equality; none imports
+   live term imprecision.
+2. **SUCCESS — reachable two-function-cast square.** Both applications take
+   two function-cast beta steps and reach a bottom edge built from ordinary
+   application, two individually closed down/up round trips, and the complete
+   smaller relation. No quotient application, finite narrowing spine, or
+   fused down/application/up constructor is used.
+3. **SUCCESS — target instantiation/allocation/type beta.** The target takes
+   the leading instantiation step, allocates the fresh seal, and completes type
+   beta while the source takes zero steps. The final edge is the canonical
+   embedded-creation case, with transported store, types, and imprecision
+   index. No target-only type-application, target-only `ν`, or live fused
+   constructor is used.
+
+Completing the relation exposed and repaired two additional invariants.
+Creation must be valid under an arbitrary final term-imprecision context
+because its endpoints are closed; otherwise substitution under a lambda
+fails. Exact creation must also be saturated under typed relational-world
+embeddings, because paired or source-only type-binder weakening renames its
+allocated target seal. The resulting grammar still has one creation
+constructor and one quotient constructor.
+
+The selection verdict is **ready for controlled live migration**. This means
+that the complete independent relation and the decisive local simulation
+slices are coherent. It does not claim that the general source and target
+simulations, the terminal engines, or `GradualDGG` are complete.
 
 ## Trusted proof boundaries
 
@@ -394,13 +454,23 @@ a leading step.
 | [`NuImprecisionCompositionalQuotientDef.agda`](../../Quotient/NuImprecisionCompositionalQuotientDef.agda) | **completed prototype** | Graded quotient relation, finite narrowing spines, symmetric application, and compatible quotient closing |
 | [`NuImprecisionCompositionalQuotientExamples.agda`](../../Quotient/NuImprecisionCompositionalQuotientExamples.agda) | **completed examples** | Exact, nested-application, nontrivial permutation, repeated-cast, quotient-function/argument, and two-function-cast residual checks |
 | [`NuImprecisionQuotientBoundarySupport.agda`](../../Quotient/NuImprecisionQuotientBoundarySupport.agda) | **completed support** | Cast-mode and hereditary widening evidence with no dependency on a term-imprecision relation |
-| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Independent smaller ordinary grammar, exact creation, creation-specific canonical endpoint transport, one paired narrowing boundary, and no generic renaming, quotient application, or fused down/application/up rule |
-| [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Nontrivial two-function-cast relation, identity reduction, arbitrary substitution, and checked active-`inst` allocation boundary |
+| [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Complete independent ordinary grammar, one embedded-creation case, one paired-narrowing quotient boundary, allocation-aware bilateral closure, and no generic renaming, quotient application, finite spine, or fused down/application/up rule |
+| [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Reachable two-function-cast top row, two beta steps on each side, and an ordinary-related join without quotient application or a fused rule |
+| [`NuImprecisionReductionClosedQuotientTypingExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientTypingExperiment.agda) | **completed metatheory** | Exhaustive source and target typing projections for the ordinary and quotient judgments |
+| [`NuImprecisionReductionClosedQuotientValueExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientValueExperiment.agda) | **completed metatheory** | Exhaustive source and target value classification, including terminal embedded creation |
+| [`NuImprecisionReductionClosedWorldEmbeddingExperiment.agda`](../../Quotient/NuImprecisionReductionClosedWorldEmbeddingExperiment.agda) | **completed metatheory** | QTI-free relational-world embeddings, paired/source-only binder lifting, prefix inversion, and the strict exact-creation lifting obstruction |
+| [`NuImprecisionReductionClosedWorldRenameExperiment.agda`](../../Quotient/NuImprecisionReductionClosedWorldRenameExperiment.agda) | **completed metatheory** | Exhaustive syntax-directed world embedding for both judgments and canonical paired/source-only binder weakening |
+| [`NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda) | **completed metatheory** | Prefix-aware parallel substitution for every ordinary and quotient constructor |
+| [`NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment.agda) | **completed metatheory** | Fully indexed single-variable substitution using only the smaller relation |
 | [`NuImprecisionSingleNarrowingBoundaryExamples.agda`](../../Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda) | **completed diagnostic** | Same-polarity three-step reductions, a positive length-two spine, and a checked impossibility result for the single-boundary relation |
-| [`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda) | **completed prototype** | Relation-parametric matched-body, cast-composition, and right-allocation residual |
+| [`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda) | **completed prototype** | Relation-parametric exact creation plus its canonical composable embedded residual |
+| [`NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda`](../../Quotient/NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda) | **completed metatheory** | Canonical typing, value, and no-bullet projections for embedded creation |
 | [`NuImprecisionTargetInstantiationCreationExamples.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationExamples.agda) | **completed diagnostic** | Independent smaller initial/final rows, target allocation trace, creation residual, and strict refutation of ordinary final-edge factorization |
 | [`NuImprecisionTargetInstantiationTransportExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda) | **completed diagnostic** | Canonical renaming/store-embedding transport and endpoint replacement with an explicit final-index coherence equality |
 | [`NuImprecisionTargetInstantiationTransportSpineExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda) | **completed diagnostic** | Strict recursive fold for arbitrarily nested exact creation and canonical endpoint transport |
+| [`NuImprecisionTargetInstantiationConsumerMigrationExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationConsumerMigrationExperiment.agda) | **completed diagnostic** | Direct, leaf, and target-widening consumers reconstructed without live QTI |
+| [`NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda) | **completed diagnostic** | Framed leaf and fusion-spine consumers reconstructed without live QTI |
+| [`NuImprecisionTargetInstantiationSimulationExperiment.agda`](../../Quotient/NuImprecisionTargetInstantiationSimulationExperiment.agda) | **completed diagnostic** | Complete target instantiation, allocation, and type-beta square with a zero-step source side |
 | [`NuImprecisionReductionClosedQuotientDesign.md`](NuImprecisionReductionClosedQuotientDesign.md) | **current design hypothesis** | Complete small-relation sketch: one quotient boundary, ordinary-only congruence and substitution, bilateral reduction closure, reachability criterion, and remaining `sim-beta-cast` obligations |
 | [`NuDGGTerminalForwardIntegrationProof.agda`](../TerminalForward/NuDGGTerminalForwardIntegrationProof.agda) | **partial** | Intended route from forward/backward contracts to `GradualDGG`; currently reaches an uncovered paired-widening compatibility case |
 | [`NuDGGTerminalBackwardValueProof.agda`](../TerminalBackward/NuDGGTerminalBackwardValueProof.agda) | **conditional** | Fuel induction for target-value traces |
@@ -466,6 +536,31 @@ conversion, and conceal conversion value-catch-up cases.
 
 ## Completed recent work
 
+- Finished the independent smaller relation rather than testing a partial
+  surrogate. The ordinary grammar now covers every rule in the design,
+  including `gen` against a target ground type, all cast and conversion
+  polarities, matched/source polymorphism, allocation prefixes, and the sole
+  target-instantiation creation case. The quotient grammar still has exactly
+  one paired narrowing constructor.
+- Replaced the separate transported-creation term constructor with
+  `EmbeddedTargetInstantiationCreation`. Exact creation is its canonical base;
+  typed relational-world embeddings compose inside the residual and compute
+  the final index. This is necessary because a type binder renames the
+  allocated target seal from `0` to `suc 0`.
+- Proved exhaustive source/target typing and value projections, embedded
+  creation terminality, term-context shift, paired-widening compatibility
+  transport, QTI-free world embedding, paired/source-only binder weakening,
+  prefix-aware parallel substitution, and fully indexed single-variable
+  substitution for the complete relation.
+- Completed the three decisive experiments. Audited `Λ⊑instβᵀ` consumers,
+  the reachable two-function-cast square, and the target
+  instantiation/allocation/type-beta square all succeed without live QTI,
+  quotient application, finite spines, or the fused
+  `down·up⊑down·upᵀ` rule.
+- Split live-prefix inversion out of
+  `NuImprecisionRelStoreEmbeddingAlgebra`, leaving the generic relational-store
+  embedding algebra independent of live term imprecision. Existing live
+  consumers import the focused prefix proof.
 - Removed `ordinaryᴿ` and changed the smaller relation's worlds, stores, and
   contexts from fixed parameters to indices. Its variable, abstraction,
   application, polymorphic, constant, primitive, one-sided cast, paired
@@ -616,80 +711,48 @@ behavior is covered by
 
 ## Current proof plan
 
-1. Strengthen the paired-lambda `leaf-instβ` view, all of its handlers, and
-   its reconstruction boundary so they retain exact creation plus the
-   canonical final-index equality. Do not manufacture that equality from the
-   old fused constructor.
-2. Strengthen the unfinished target widening `β-inst` root contracts with the
-   cast-shape composition equation and matched body/allocation witnesses
-   needed by exact creation. Cover both the ordinary cast-mode and
-   identity-mode roots.
-3. Migrate the direct identity post-beta context first, then the strengthened
-   paired-lambda leaf and fusion spines. After every positive consumer passes,
-   replace `Λ⊑instβᵀ` with exact creation plus canonical transport and remove
-   the fused constructor.
-4. Replace the interim creation-specific transport constructor with an
-   admissible syntax-directed no-bullet world-embedding theorem requiring
-   renaming left inverses and cast-mode renamers. Do not reintroduce a generic
-   outer renaming constructor.
-5. State the allocation-aware quotient `sim-beta-cast` contract directly in
-   terms of the existing world-coherent weak result: the inert route supplies
-   the source catch-up, while the active `inst` route uses the target tail,
-   the creation constructor, and the resulting store extension.
-6. Connect that contract to the existing paired-widening target
-   pending-allocation machinery. The immediate leaf is the quotient-`inst`
-   residual already counted among the four ordinary/generated down/up holes in
-   `NuImprecisionCatchupScratch`.
-7. Complete the two-function-cast operational square and confirm that its
-   related endpoint is the ordinary QTI derivation consumed by
-   `two-round-trips-substitutionᵀ`.
-8. Discharge the target quotient closing-widening `β-seq` root through the
-   existing target-tail sequence-resume midpoint machinery. Do not add a
-   narrowing spine for this widening-side obligation.
-9. If these succeed, derive the live function-cast simulation without
-   `down·up⊑down·upᵀ` or quotient application and begin removing those
-   constructors in a separate migration. In the same migration, remove the
-   uninhabited target-only type-application, `ν`, and casted-`ν` constructors
-   and their vacuous semantic roots. If allocation catch-up instead produces
-   an irreducible quotient embedded outside a closing boundary, record that
-   strict counterexample and return to the compositional design.
-10. Prove source and target typing projections for the smaller ordinary and
-   one-boundary quotient judgments. Re-run value, `No•`, and terminal
-   inversion using the fact that the quotient judgment has exactly one
-   constructor.
-11. Continue testing valid ordinary top rows with arbitrary lambda bodies,
-   nested reachable function casts, source and target cast sequences, and
-   active target `inst`. The basic active-target test is complete; its nested
-   quotient-closing instance remains. Every test must exhibit its initial
-   ordinary term-imprecision derivation before its reduction endpoints are
-   considered.
-12. Keep the compositional quotient prototype as the fallback. Reintroduce
-   quotient application, finite narrowing spines, or a quotient-to-quotient
-   cast square only after a strict counterexample shows a derivable ordinary
-   top row whose reductions cannot reach an ordinary-related join.
-13. Restore hereditary `PairedWideningCompatible`: replace the broad
-   `compatible-source-inert` fallback with the target-active case, preserve
-   function and universal compatibility recursively, and retain the
-   target-inert bridge. Then restore both function-beta consumers and the
-   terminal-forward integration check.
-14. Add the missing paired-lambda frame-view
-   `down·up⊑down·upᵀ` case and restore its focused strict-spine check.
-15. Migrate the other six known-incomplete strict proofs to the current
-   uniqueness, binder-transport, compatibility, and `down·up⊑down·upᵀ`
-   interfaces.
-16. Finish quotient transport normalization and the crossed binary
-   runtime-sibling catch-up invariant.
-17. Prove the source function-cast `β` and `β-↦` value roots using the
-   up-to-reduction `sim-beta-cast` argument rather than a quotient application
-   or spine-length-specific term rule.
-18. Inhabit the remaining exact active-synchronization root records.
-19. Assemble the exhaustive prefix-aware world-coherent backward one-step
-   dispatcher and restore a practical green backward strict-spine check.
-20. Supply that strict dispatcher to both backward terminal engines.
-21. Complete the remaining forward engine contracts, invoke the strict terminal
-   integration proof, and construct `GradualDGG`.
-22. Promote any still-needed generic scratch clauses through strict
-   `Def`/`Proof`/`Lemma` boundaries and delete the scratch module.
+1. Begin the controlled live migration with the target-instantiation creation
+   family. Strengthen the live paired-lambda leaf and target widening
+   `β-inst` root contracts exactly as demonstrated by the direct and framed
+   consumer experiments.
+2. Replace live `Λ⊑instβᵀ` uses with exact creation plus
+   `EmbeddedTargetInstantiationCreation`, preserving the canonical final-index
+   equality at every leaf and fusion frame. Delete the old constructor only
+   after every strict consumer has moved.
+3. Migrate the two explicit `Λ⊑instβᵀ` branches in
+   `NuImprecisionCatchupScratch`. The other two permissive live-relation
+   consumers do not case-analyze the relation and need only interface
+   migration.
+4. Promote the experimental complete grammar and its typing, value,
+   world-embedding, and substitution theorems to the canonical live modules.
+   Delete obsolete live constructors and compatibility shims rather than
+   re-exporting them.
+5. State and prove the allocation-aware quotient `sim-beta-cast` contract
+   using the existing world-coherent weak result. The inert route supplies
+   source catch-up; the active target-`inst` route uses the target tail,
+   embedded creation, and the transported store.
+6. Connect that contract to paired-widening pending allocation and then to the
+   second function beta. Invoke `smaller-single-term-substitutionᴿ` only after
+   the down/up boundary has closed back to ordinary imprecision.
+7. Discharge the target quotient closing-widening `β-seq` root through the
+   target-tail sequence-resume midpoint machinery. Do not add a narrowing
+   spine for this widening-side obligation.
+8. Remove live quotient application, finite narrowing spines, and
+   `down·up⊑down·upᵀ` as primitive rules once the general function-cast
+   simulations pass. Remove the uninhabited target-only type-application,
+   `ν`, and casted-`ν` cases in the same audited migration.
+9. Keep the compositional quotient prototype only as a fallback. Return to it
+   only if a strict counterexample starts from a derivable ordinary top row
+   and cannot reduce to an ordinary-related join.
+10. Re-run the terminal-forward integration with the stricter hereditary
+    paired-widening compatibility, then migrate the remaining known-incomplete
+    strict proofs to the current uniqueness and binder-transport interfaces.
+11. Finish quotient transport normalization, crossed runtime-sibling catch-up,
+    the remaining exact active-synchronization roots, and the exhaustive
+    prefix-aware world-coherent one-step dispatcher.
+12. Supply the completed dispatcher to both terminal engines, finish the
+    forward contracts, invoke the strict terminal integration proof, construct
+    `GradualDGG`, and delete the remaining scratch module.
 
 ## Validation
 
@@ -710,7 +773,7 @@ explicitly rather than deleted mechanically.
 The aggregate and import audit pass. The terminal-forward strict spine is
 source-safe but its focused Agda check currently fails at the
 `compatible-source-inert` paired-widening function-beta case recorded above.
-The source inventory sees 369 strict-looking `Proof` modules: 156 have no
+The source inventory sees 370 strict-looking `Proof` modules: 156 have no
 transitive canonical `Lemma` consumer, 149 are reachable from an explicit
 strict inventory spine, seven are explicitly known incomplete, and none are
 uninventoried. Focused Agda checks, not these source counts, establish
@@ -728,6 +791,18 @@ The optimized focused check of
 `NuImprecisionCatchupScratch.agda` also passed after the two formerly omitted
 `Λ⊑instβᵀ` clauses were made explicit. Both strengthened fusion-spine folds
 pass strict focused checks.
+
+After completing the independent smaller relation on 2026-07-27,
+`make quotient-design-check` passed with all fourteen new strict roots:
+typing, values, term-context shift, parallel and single substitution, world
+embedding and renaming, compatibility renaming, embedded creation properties,
+the two constructor audits, the two consumer migrations, and the
+target-instantiation simulation. `make dgg-check` also passed after a full
+dependency rebuild; this checks the strict unassembled-proof inventory but
+does not change the explicitly incomplete terminal-forward status above.
+Focused strict rechecks of the world-renaming and term-context-shift
+experiments passed after their final formatting edits, and `git diff --check`
+passed.
 
 Do not use `All.agda` as the DGG completion criterion. It includes independent
 and historical development surfaces. The final completion check is the strict

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -8,11 +8,13 @@ are removed from this file and remain available through Git history.
 
 ## Obsidian math rendering convention
 
-Use `$$` delimiters for every LaTeX display. For reduction/imprecision
-diagrams, use a plain `aligned` environment with ordinary `&` alignment.
-Avoid `array` environments with custom column specifications such as
-`@{...}`, and write `\leftarrow` instead of `\mapsfrom`. Keep a blank line
-before and after each display.
+Use `$$` delimiters for every LaTeX display. Keep each display to one ordinary
+formula: do not use multiline environments such as `aligned`, `array`, or
+`gathered`, because they fail in at least one of Obsidian and the Codex app.
+Present a reduction/imprecision diagram as consecutive single-formula
+displays, with the top relation, each reduction step, and the final relation
+shown separately. Write `\leftarrow` instead of `\mapsfrom`, and keep a blank
+line before and after each display.
 
 Here, **completed** means that the owned declaration has passed a focused Agda
 check without holes or permissive options. **Conditional** means that a strict

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -23,10 +23,13 @@ relation-level two-function-cast and arbitrary-substitution tests. It now
 permits exactly one paired narrowing cast, not a finite spine. A
 same-polarity stress test separates an unconditionally expressible
 two-narrowing residual from residuals reachable from the live ordinary
-relation; the remaining operational test is the allocation-aware catch-up
-forced by the active `inst` cast on one permutation route. Neither prototype
-has replaced `QuotientedTermImprecision`. The public statement and compiler
-boundary are checked, but no complete theorem inhabitant exists yet.
+relation. The allocation-aware target-`inst` test is now complete: the valid
+top row and target trace need no fused final edge, but the final stable values
+cannot be related by ordinary source-only-lambda and target-cast rules. The
+matched body relation, creation equation, and allocation lineage form the
+smallest checked residual. Neither prototype has replaced
+`QuotientedTermImprecision`. The public statement and compiler boundary are
+checked, but no complete theorem inhabitant exists yet.
 
 The current proof uses these invariants:
 
@@ -53,6 +56,11 @@ The current proof uses these invariants:
   Their pre-allocation index and independently opened body index are
   inconsistent; real target-only `inst` allocation is crossed by target
   reduction before the final ordinary relation is required.
+- target-only `inst` catch-up retains a `TargetInstantiationCreation`
+  residual: matched body imprecision, target cast typing, the index
+  composition equation, and store lineage into the right-extended world.
+  Up-to-reduction removes transient allocation edges but not this final
+  semantic creation case.
 
 ## Active up-to-reduction design hypothesis
 
@@ -79,9 +87,10 @@ The implemented smaller prototype currently narrows only the quotient layer:
 its `ordinaryᴿ` constructor embeds the complete live QTI relation.  It
 therefore still admits `Λ⊑instβᵀ` and the uninhabited target-only rules.  The
 design sketch is stricter than this prototype at the ordinary layer.  The
-active target-`inst` test must replace that embedding locally or define the
-candidate ordinary grammar before it can validate removal of those live
-constructors.
+separate target-instantiation test avoids the fused constructor: it constructs
+the valid initial ordinary row, the complete target allocation trace, and the
+creation residual, then proves that the structural final-body factorization is
+impossible.
 
 This hypothesis is successful only if a quotient-aware beta lemma can cross
 the lambda endpoint.  In particular, after reducing
@@ -268,16 +277,45 @@ $$
 
 It retains the matched body relation before allocation, the target
 conversion, the necessarily source-only final index, and the right-allocation
-store lineage.  It contains no independently opened `r`.  The smaller
-up-to-reduction design should omit the three uninhabited term rules and test
-whether this creation evidence can support a separate simulation lemma
-without making the fused post-administration edge primitive.  If not, a
-narrowly scoped creation residual is the candidate new invariant.
+store lineage.  It contains no independently opened `r`.
+
+The strict
+[`NuImprecisionTargetInstantiationCreationExamples.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationExamples.agda)
+now completes this test. It checks the initial ordinary top relation and the
+complete target trace without using the fused final constructor. It also
+proves that factoring the final edge through the ordinary source-only-lambda
+and target-cast rules would require
+
+$$
+((0 \mathrel{\sqsubseteq} \star)::[])
+\mathbin{;} 1
+\vdash
+(\alpha\to\alpha)
+\mathrel{\sqsubseteq}
+(\alpha\to\alpha)
+\dashv 1,
+$$
+
+whose variable premises are impossible. The companion
+[`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda)
+packages exactly the surviving matched-body, cast, composition, and
+allocation-lineage evidence. The focused modules type-check without
+postulates, holes, or permissive options.
+
+Conclusion: up-to-reduction eliminates the transient target-only `ν` and
+runtime-bullet edges, but not the final semantic creation case. Under the
+current `WeakOneStepResult` and public DGG conclusions, the large fused
+constructor should be replaced by a small exact creation constructor fed by
+this residual, with renaming, store embedding, and endpoint transport proved
+separately. Eliminating even the exact constructor would require a
+creation-saturated final relation, which relocates rather than removes the
+same case.
 
 The live relation is not changed at this checkpoint.  Deleting the
 uninhabited constructors and their conditional transport cases belongs in the
-later relation migration, after the creation-square test determines whether
-`Λ⊑instβᵀ` can also be removed.
+later relation migration. That migration should first introduce the exact
+creation constructor and prove that it supports the generalized live
+consumers before deleting `Λ⊑instβᵀ`.
 
 ## Trusted proof boundaries
 
@@ -295,6 +333,8 @@ later relation migration, after the creation-square test determines whether
 | [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Smaller relation with one paired narrowing boundary, no quotient application, and no fused down/application/up rule |
 | [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Nontrivial two-function-cast relation, identity reduction, arbitrary substitution, and checked active-`inst` allocation boundary |
 | [`NuImprecisionSingleNarrowingBoundaryExamples.agda`](../../Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda) | **completed diagnostic** | Same-polarity three-step reductions, a positive length-two spine, and a checked impossibility result for the single-boundary relation |
+| [`NuImprecisionTargetInstantiationCreationDef.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda) | **completed prototype** | Exact matched-body, cast-composition, and right-allocation residual with generalized endpoint transport omitted |
+| [`NuImprecisionTargetInstantiationCreationExamples.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationExamples.agda) | **completed diagnostic** | Valid top row, target allocation trace, creation residual, and strict refutation of ordinary final-edge factorization |
 | [`NuImprecisionReductionClosedQuotientDesign.md`](NuImprecisionReductionClosedQuotientDesign.md) | **current design hypothesis** | Complete small-relation sketch: one quotient boundary, ordinary-only congruence and substitution, bilateral reduction closure, reachability criterion, and remaining `sim-beta-cast` obligations |
 | [`NuDGGTerminalForwardIntegrationProof.agda`](../TerminalForward/NuDGGTerminalForwardIntegrationProof.agda) | **partial** | Intended route from forward/backward contracts to `GradualDGG`; currently reaches an uncovered paired-widening compatibility case |
 | [`NuDGGTerminalBackwardValueProof.agda`](../TerminalBackward/NuDGGTerminalBackwardValueProof.agda) | **conditional** | Fuel induction for target-value traces |
@@ -409,8 +449,9 @@ conversion, and conceal conversion value-catch-up cases.
   premise inside the body.
 - The example also proves that the permuted `YX` closing cast is not inert.
   Its evaluation must enter the allocation-aware quotient-`inst` catch-up
-  machinery before the second function beta. The operational hypothesis
-  remains open exactly at that already-known semantic boundary.
+  machinery before the second function beta. The exact creation invariant at
+  that boundary is now checked; its integration with quotient closing and the
+  second function beta remains open.
 - The same-polarity stress test proves that two genuine narrowing prefixes
   require a finite spine if considered without a reachability premise.
   It also exposes why this is not yet a counterexample to the smaller
@@ -435,6 +476,12 @@ conversion, and conceal conversion value-catch-up cases.
   addition, one-sided cast, paired conversion, and paired widening rules
   explicitly, including every relevant index-composition or
   index-substitution premise.
+- The target-instantiation creation test constructs a valid ordinary top row,
+  takes the target through allocation and type beta, packages the surviving
+  creation evidence, and proves that ordinary source-only-lambda plus
+  target-cast rules cannot relate the final values. This establishes that
+  up-to-reduction can replace transient allocation edges but cannot eliminate
+  the final semantic creation case under the current DGG conclusion.
 
 ## Counterexample policy and audit
 
@@ -478,65 +525,72 @@ behavior is covered by
 
 ## Current proof plan
 
-1. State the allocation-aware quotient `sim-beta-cast` contract directly in
+1. Prototype an exact target-instantiation creation constructor in the
+   candidate ordinary relation. Its premise should be
+   `TargetInstantiationCreation`; it should not contain arbitrary renaming,
+   store embedding, endpoint equality, closure, or repeated endpoint-typing
+   fields.
+2. Prove renaming, store-embedding, and endpoint-transport admissibility for
+   that exact constructor. Use those lemmas to reconstruct the generalized
+   behavior currently built into `Λ⊑instβᵀ`. Only after this succeeds should
+   the live constructor be replaced.
+3. State the allocation-aware quotient `sim-beta-cast` contract directly in
    terms of the existing world-coherent weak result: the inert route supplies
-   the source catch-up, while the active `inst` route uses the target tail and
-   transports the quotient through the resulting store extension.
-2. Connect that contract to the existing paired-widening target
+   the source catch-up, while the active `inst` route uses the target tail,
+   the creation constructor, and the resulting store extension.
+4. Connect that contract to the existing paired-widening target
    pending-allocation machinery. The immediate leaf is the quotient-`inst`
    residual already counted among the four ordinary/generated down/up holes in
-   `NuImprecisionCatchupScratch`; do not add a term rule to bypass it.
-3. Complete the two-function-cast operational square and confirm that its
+   `NuImprecisionCatchupScratch`.
+5. Complete the two-function-cast operational square and confirm that its
    related endpoint is the ordinary QTI derivation consumed by
    `two-round-trips-substitutionᵀ`.
-4. Discharge the target quotient closing-widening `β-seq` root through the
+6. Discharge the target quotient closing-widening `β-seq` root through the
    existing target-tail sequence-resume midpoint machinery. Do not add a
    narrowing spine for this widening-side obligation.
-5. If these succeed, derive the live function-cast simulation without
+7. If these succeed, derive the live function-cast simulation without
    `down·up⊑down·upᵀ` or quotient application and begin removing those
    constructors in a separate migration. In the same migration, remove the
    uninhabited target-only type-application, `ν`, and casted-`ν` constructors
    and their vacuous semantic roots. If allocation catch-up instead produces
    an irreducible quotient embedded outside a closing boundary, record that
    strict counterexample and return to the compositional design.
-6. Prove source and target typing projections for the smaller ordinary and
+8. Prove source and target typing projections for the smaller ordinary and
    one-boundary quotient judgments. Re-run value, `No•`, and terminal
    inversion using the fact that the quotient judgment has exactly one
    constructor.
-7. Test the smaller design on valid ordinary top rows with arbitrary lambda
-   bodies, nested reachable function casts, source and target cast sequences,
-   and active target `inst`. For the active target-`inst` case, use the matched
-   body relation, creation square, and allocation lineage to derive the final
-   edge without `Λ⊑instβᵀ`; if that is impossible, isolate the smallest
-   creation residual that suffices. Every test must exhibit its initial
-   ordinary term imprecision derivation before its reduction endpoints are
+9. Continue testing valid ordinary top rows with arbitrary lambda bodies,
+   nested reachable function casts, source and target cast sequences, and
+   active target `inst`. The basic active-target test is complete; its nested
+   quotient-closing instance remains. Every test must exhibit its initial
+   ordinary term-imprecision derivation before its reduction endpoints are
    considered.
-8. Keep the compositional quotient prototype as the fallback. Reintroduce
+10. Keep the compositional quotient prototype as the fallback. Reintroduce
    quotient application, finite narrowing spines, or a quotient-to-quotient
    cast square only after a strict counterexample shows a derivable ordinary
    top row whose reductions cannot reach an ordinary-related join.
-9. Restore hereditary `PairedWideningCompatible`: replace the broad
+11. Restore hereditary `PairedWideningCompatible`: replace the broad
    `compatible-source-inert` fallback with the target-active case, preserve
    function and universal compatibility recursively, and retain the
    target-inert bridge. Then restore both function-beta consumers and the
    terminal-forward integration check.
-10. Add the missing paired-lambda frame-view
+12. Add the missing paired-lambda frame-view
    `down·up⊑down·upᵀ` case and restore its focused strict-spine check.
-11. Migrate the other six known-incomplete strict proofs to the current
+13. Migrate the other six known-incomplete strict proofs to the current
    uniqueness, binder-transport, compatibility, and `down·up⊑down·upᵀ`
    interfaces.
-12. Finish quotient transport normalization and the crossed binary
+14. Finish quotient transport normalization and the crossed binary
    runtime-sibling catch-up invariant.
-13. Prove the source function-cast `β` and `β-↦` value roots using the
+15. Prove the source function-cast `β` and `β-↦` value roots using the
    up-to-reduction `sim-beta-cast` argument rather than a quotient application
    or spine-length-specific term rule.
-14. Inhabit the remaining exact active-synchronization root records.
-15. Assemble the exhaustive prefix-aware world-coherent backward one-step
+16. Inhabit the remaining exact active-synchronization root records.
+17. Assemble the exhaustive prefix-aware world-coherent backward one-step
    dispatcher and restore a practical green backward strict-spine check.
-16. Supply that strict dispatcher to both backward terminal engines.
-17. Complete the remaining forward engine contracts, invoke the strict terminal
+18. Supply that strict dispatcher to both backward terminal engines.
+19. Complete the remaining forward engine contracts, invoke the strict terminal
    integration proof, and construct `GradualDGG`.
-18. Promote any still-needed generic scratch clauses through strict
+20. Promote any still-needed generic scratch clauses through strict
    `Def`/`Proof`/`Lemma` boundaries and delete the scratch module.
 
 ## Validation

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -524,6 +524,108 @@ Unlike `Λ⊑instβᵀ`, it should not receive arbitrary renamings, an arbitrary
 store embedding, endpoint equalities, closure witnesses, or an arbitrary final
 index. Those operations should be admissibility lemmas over this exact rule.
 
+### Independent prototype and transport test
+
+The checked smaller judgment now has no constructor that embeds the live
+term-imprecision judgment.  In particular, the former `ordinaryᴿ` escape
+hatch has been deleted.  Variables, abstractions, applications, constants,
+primitive operations, ordinary casts, paired boundaries, matched
+abstractions, and source-only abstractions are represented by constructors of
+the smaller judgment itself.
+
+`TargetInstantiationCreation` is now parametric in its matched body relation.
+It therefore records the creation square without depending on either the live
+relation or the smaller relation.  The smaller exact-creation constructor has
+one premise:
+
+$$
+\mathsf{TargetInstantiationCreation}\bigl(W\mathrel{\sqsubseteq_q}W'\bigr).
+$$
+
+Its conclusion is the exact post-allocation edge:
+
+$$
+\Lambda W\mathrel{\sqsubseteq_{\mathord{\uparrow_R}p}}W'\langle s\rangle.
+$$
+
+The first transport experiment shows that this exact rule is not itself
+closed under the generalized store embeddings used by nested universal
+fusion.  A relational store embedding may rename the freshly created target
+seal from `0` to another name.  The exact constructor deliberately creates
+the distinguished right entry at `0`, so it cannot directly reconstruct that
+renamed conclusion.
+
+The smaller relation therefore now has one closed-endpoint transport rule.
+From an ordinary smaller-relation edge,
+
+$$
+M\mathrel{\sqsubseteq_p}M',
+$$
+
+an assumption-preserving pair of renamings and a relational store embedding
+produce
+
+$$
+\mathsf{rename}_{\tau}(M)
+\mathrel{\sqsubseteq_{\mathsf{rename}_{\tau,\sigma}(p)}}
+\mathsf{rename}_{\sigma}(M').
+$$
+
+The endpoint typings are explicit premises of this rule.  This is necessary
+because the general store embedding does not require the renamings to have
+left inverses.
+
+The focused transport proof composes this rule with exact creation.  Its
+result index is not arbitrary; it is exactly
+
+$$
+\mathsf{rename}_{\tau,\sigma}
+\bigl(\mathord{\uparrow_R}p\bigr).
+$$
+
+Endpoint equalities may replace the four renamed terms and types, but the
+client-supplied index must satisfy
+
+$$
+p_{\mathrm{client}}
+\mathrel{=}
+\mathsf{transportEndpoints}
+\left(
+  \mathsf{rename}_{\tau,\sigma}
+  \bigl(\mathord{\uparrow_R}p\bigr)
+\right).
+$$
+
+This equality is the tighter invariant missing from the current generalized
+`fusion-step`: that constructor carries its origin index and an arbitrary
+final index without relating them.  The exact creation plus transport
+decomposition works when this equality is added.
+
+The finite-spine consumer test also succeeds.  Every step retains the exact
+creation premises, the exact post-allocation endpoint typings, the relational
+store embedding, the four endpoint equalities, and the canonical final-index
+equality.  The spine folds recursively into the independent smaller relation:
+the recursive body supplies the relation parameter of
+`TargetInstantiationCreation`, and the endpoint transport theorem supplies
+the outer step.  Thus arbitrarily nested target-instantiation creation does
+not require restoring the large fused constructor.
+
+This result uses one new generic `rename-storeᴿ` constructor in the smaller
+relation.  It replaces the creation-specific renaming and store-embedding
+fields with a relation-wide closed-endpoint transport boundary.  The
+experiment therefore relocates one proof obligation rather than eliminating
+it: simulation must show that reduction is equivariant under this transport
+boundary, or a later proof must make `rename-storeᴿ` admissible and remove it
+as a primitive constructor.  The benefit is that this obligation is stated
+once for every ordinary constructor instead of being hidden inside target
+instantiation creation.
+
+The remaining migration question is empirical: each live
+`Λ⊑instβᵀ` consumer must be audited to see whether it can prove the canonical
+final-index equality.  A consumer that cannot do so is evidence that the old
+constructor accepted an unrelated proof-relevant index, not evidence that
+exact creation or its transport failed.
+
 Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
 can consume only `ν`.  A derivation cannot silently remove on the left a
 universal quantifier that was matched with a universal quantifier on the

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -105,8 +105,64 @@ $$
 }.
 $$
 
-Variables, blame, constants, and primitive operations retain their ordinary
-rules as well.  In particular, application consumes only ordinary premises.
+Variables are related according to the ordinary imprecision index stored in
+the term context:
+
+$$
+\frac{
+  x : A \mathrel{\sqsubseteq_p} A' \in \Gamma
+}{
+  x \mathrel{\sqsubseteq_p} x
+  : A \mathrel{\sqsubseteq} A'
+}.
+$$
+
+Blame on the less precise side is related to every target term at the indexed
+target type:
+
+$$
+\frac{}{
+  \mathsf{blame}
+  \mathrel{\sqsubseteq_p}
+  M'
+  : A \mathrel{\sqsubseteq} A'
+}.
+$$
+
+The suppressed premise checks that `M'` has type `A'`.
+
+Natural-number constants are related only to the same constant:
+
+$$
+\frac{}{
+  \kappa_{\mathbb N}(n)
+  \mathrel{\sqsubseteq_{\mathsf{id}_{\mathbb N}}}
+  \kappa_{\mathbb N}(n)
+  : \mathbb N \mathrel{\sqsubseteq} \mathbb N
+}.
+$$
+
+The primitive addition rule is structural at the identity index:
+
+$$
+\frac{
+  L
+  \mathrel{\sqsubseteq_{\mathsf{id}_{\mathbb N}}}
+  L'
+  \qquad
+  M
+  \mathrel{\sqsubseteq_{\mathsf{id}_{\mathbb N}}}
+  M'
+}{
+  L \mathbin{\oplus} M
+  \mathrel{\sqsubseteq_{\mathsf{id}_{\mathbb N}}}
+  L' \mathbin{\oplus} M'
+  : \mathbb N \mathrel{\sqsubseteq} \mathbb N
+}.
+$$
+
+In particular, application and primitive operations consume only ordinary
+premises.
 
 The polymorphic rules also remain ordinary.  Their essential index changes
 are:
@@ -146,93 +202,390 @@ $$
 }.
 $$
 
-The `ν` term follows the same discipline:
+The `ν` term follows the same discipline.  To display its index equations,
+write `↑A` for the weakening of `A` under the freshly allocated type
+variable, and write `lift` for the corresponding extension of an outer
+imprecision index.  The symbol `≐` below denotes the proof-relevant index
+compatibility judgment implemented in Agda, not propositional equality.
+
+In the matched case, the selected source and target types are themselves
+ordinarily related:
 
 $$
 \frac{
+  A \mathrel{\sqsubseteq_{p_A}} A'
+  \qquad
   N \mathrel{\sqsubseteq_{\forall^{\,i}q}} N'
+  \qquad
+  q[
+    0 \mapsto {\uparrow A}
+    \mathrel{\sqsubseteq_{\operatorname{lift}(p_A)}}
+    {\uparrow A'} \mapsfrom 0
+  ]^P
+  \doteq
+  \operatorname{lift}_{\forall}(p)
 }{
   \nu A\,N\,s
   \mathrel{\sqsubseteq_p}
   \nu A'\,N'\,s'
 }
-\qquad
+.
+$$
+
+In the source-only case, instantiating the source-only index must produce the
+lift of the result index:
+
+$$
 \frac{
   N \mathrel{\sqsubseteq_{\nu q}} N'
+  \qquad
+  q[0 \mapsto {\uparrow A}]^L
+  \doteq
+  \operatorname{lift}_{\nu}^{L}(p)
 }{
   \nu A\,N\,s
   \mathrel{\sqsubseteq_p}
   N'
+}
+.
+$$
+
+The target-only case uses an ordinary bridge from the unchanged source type
+to the body of the target universal:
+
+$$
+\frac{
+  N \mathrel{\sqsubseteq_q} N'
+  : B \mathrel{\sqsubseteq} \forall C'
+  \qquad
+  B \mathrel{\sqsubseteq_r} C'
+  \qquad
+  r[0 \mapsto {\uparrow A}]^R
+  \doteq
+  \operatorname{lift}^{R}(p)
+}{
+  N
+  \mathrel{\sqsubseteq_p}
+  \nu A\,N'\,s
 }.
 $$
 
-The omitted equations apply the selected type instantiations to the inner
-index.  What matters here is that a matched `ν` rule can consume only
-`∀ⁱ`, while a source-only `ν` rule can consume only `ν`.  A derivation cannot
-silently remove on the left a universal quantifier that was matched with a
-universal quantifier on the right.
-
-The existing target-only type-application and `ν` cases remain ordinary too.
-None of the polymorphic rules accepts or produces quotient term imprecision.
+Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
+can consume only `ν`.  A derivation cannot silently remove on the left a
+universal quantifier that was matched with a universal quantifier on the
+right.  All three rules remain in the ordinary judgment; none accepts or
+produces quotient term imprecision.
 
 ## Ordinary cast and conversion rules
 
-One-sided casts remain ordinary whenever their type-imprecision triangle
-commutes.  Schematically, a source cast uses
+Write `⌊p⌋` for the structural shape of an ordinary type-imprecision index
+and `⌊c⌋` for the imprecision shape of a cast.  The judgment
 
 $$
-\begin{array}{ccc}
-A & \mathrel{\sqsubseteq_p} & A'\\
-\downarrow c & & \Vert\\
-B & \mathrel{\sqsubseteq_r} & A'
-\end{array}
-\qquad\Longrightarrow\qquad
-M\langle c\rangle
-\mathrel{\sqsubseteq_r}
-M'.
+s_1 \mathbin{;} s_2 \mathrel{\cong} s_3
 $$
 
-A target cast uses the mirror-image triangle:
+means that the two imprecision shapes on the left compose to the shape on the
+right.  It is a proof-relevant structural composition judgment.
+
+The four one-sided cast rules use different composition equations according
+to the side of the cast and its polarity.
+
+A source narrowing cast has the equation
 
 $$
-\begin{array}{ccc}
-A & \mathrel{\sqsubseteq_p} & A'\\
-\Vert & & \downarrow c'\\
-A & \mathrel{\sqsubseteq_r} & B'
-\end{array}
-\qquad\Longrightarrow\qquad
-M
-\mathrel{\sqsubseteq_r}
-M'\langle c'\rangle.
+\lfloor c\rfloor
+\mathbin{;}\lfloor p\rfloor
+\mathrel{\cong}
+\lfloor q\rfloor:
 $$
-
-These schemas cover both narrowing and widening; the direction of shape
-composition records which side of the triangle is traversed first.
-Reveal and conceal conversions likewise stay ordinary and update the ordinary
-index by the corresponding source or target type substitution.
-
-Paired casts also preserve the ordinary judgment when both the upper and
-lower horizontal edges are ordinary:
 
 $$
 \frac{
   M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
   \qquad
-  \begin{array}{ccc}
-  A & \mathrel{\sqsubseteq_p} & A'\\
-  \downarrow c & & \downarrow c'\\
-  B & \mathrel{\sqsubseteq_r} & B'
-  \end{array}
+  \operatorname{narrow}(c:A\Rightarrow B)
+  \qquad
+  B \mathrel{\sqsubseteq_q} A'
+  \qquad
+  \lfloor c\rfloor
+    \mathbin{;}\lfloor p\rfloor
+    \mathrel{\cong}\lfloor q\rfloor
 }{
   M\langle c\rangle
-  \mathrel{\sqsubseteq_r}
-  M'\langle c'\rangle
+  \mathrel{\sqsubseteq_q}
+  M'
+  : B \mathrel{\sqsubseteq} A'
 }.
 $$
 
-This paired rule includes the reveal, conceal, conversion, and ordinary
-widening cases already required by the live proof.  It does not cover a
-bottom edge that exists only modulo `∀`-permutation.
+A source widening cast has the equation
+
+$$
+\lfloor c\rfloor
+\mathbin{;}\lfloor q\rfloor
+\mathrel{\cong}
+\lfloor p\rfloor:
+$$
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{widen}(c:A\Rightarrow B)
+  \qquad
+  B \mathrel{\sqsubseteq_q} A'
+  \qquad
+  \lfloor c\rfloor
+    \mathbin{;}\lfloor q\rfloor
+    \mathrel{\cong}\lfloor p\rfloor
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_q}
+  M'
+  : B \mathrel{\sqsubseteq} A'
+}.
+$$
+
+A target narrowing cast has the equation
+
+$$
+\lfloor q\rfloor
+\mathbin{;}\lfloor c'\rfloor
+\mathrel{\cong}
+\lfloor p\rfloor:
+$$
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{narrow}(c':A'\Rightarrow B')
+  \qquad
+  A \mathrel{\sqsubseteq_q} B'
+  \qquad
+  \lfloor q\rfloor
+    \mathbin{;}\lfloor c'\rfloor
+    \mathrel{\cong}\lfloor p\rfloor
+}{
+  M
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : A \mathrel{\sqsubseteq} B'
+}.
+$$
+
+A target widening cast has the equation
+
+$$
+\lfloor p\rfloor
+\mathbin{;}\lfloor c'\rfloor
+\mathrel{\cong}
+\lfloor q\rfloor:
+$$
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{widen}(c':A'\Rightarrow B')
+  \qquad
+  A \mathrel{\sqsubseteq_q} B'
+  \qquad
+  \lfloor p\rfloor
+    \mathbin{;}\lfloor c'\rfloor
+    \mathrel{\cong}\lfloor q\rfloor
+}{
+  M
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : A \mathrel{\sqsubseteq} B'
+}.
+$$
+
+Reveal and conceal conversions replace the shape-composition equation by an
+index-substitution equation.  The source reveal and conceal rules are
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{reveal}_L
+    (c:A\Rightarrow B;\alpha\mapsto X)
+  \qquad
+  B \mathrel{\sqsubseteq_q} A'
+  \qquad
+  p[\alpha\mapsto X]^L \doteq q
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_q}
+  M'
+  : B \mathrel{\sqsubseteq} A'
+},
+$$
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{conceal}_L
+    (c:A\Rightarrow B;\alpha\mapsto X)
+  \qquad
+  B \mathrel{\sqsubseteq_q} A'
+  \qquad
+  q[\alpha\mapsto X]^L \doteq p
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_q}
+  M'
+  : B \mathrel{\sqsubseteq} A'
+}.
+$$
+
+The target reveal and conceal rules are
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{reveal}_R
+    (c':A'\Rightarrow B';\beta\mapsto X')
+  \qquad
+  A \mathrel{\sqsubseteq_q} B'
+  \qquad
+  p[\beta\mapsto X']^R \doteq q
+}{
+  M
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : A \mathrel{\sqsubseteq} B'
+},
+$$
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{conceal}_R
+    (c':A'\Rightarrow B';\beta\mapsto X')
+  \qquad
+  A \mathrel{\sqsubseteq_q} B'
+  \qquad
+  q[\beta\mapsto X']^R \doteq p
+}{
+  M
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : A \mathrel{\sqsubseteq} B'
+}.
+$$
+
+Paired reveal uses the ordinary relation between the two selected store
+types as part of one simultaneous index substitution:
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{reveal}_L
+    (c:A\Rightarrow B;\alpha\mapsto X)
+  \qquad
+  \operatorname{reveal}_R
+    (c':A'\Rightarrow B';\beta\mapsto X')
+  \qquad
+  X \mathrel{\sqsubseteq_{p_X}} X'
+  \qquad
+  B \mathrel{\sqsubseteq_q} B'
+  \qquad
+  p[
+    \alpha\mapsto X
+    \mathrel{\sqsubseteq_{p_X}}
+    X'\mapsfrom\beta
+  ]^P
+  \doteq q
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : B \mathrel{\sqsubseteq} B'
+}.
+$$
+
+Paired conceal reverses that index-substitution equation:
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{conceal}_L
+    (c:A\Rightarrow B;\alpha\mapsto X)
+  \qquad
+  \operatorname{conceal}_R
+    (c':A'\Rightarrow B';\beta\mapsto X')
+  \qquad
+  X \mathrel{\sqsubseteq_{p_X}} X'
+  \qquad
+  B \mathrel{\sqsubseteq_q} B'
+  \qquad
+  q[
+    \alpha\mapsto X
+    \mathrel{\sqsubseteq_{p_X}}
+    X'\mapsfrom\beta
+  ]^P
+  \doteq p
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : B \mathrel{\sqsubseteq} B'
+}.
+$$
+
+Finally, an ordinary paired widening requires both paths to have one common
+composite shape, as well as operational compatibility:
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'
+  \qquad
+  \operatorname{widen}(c:A\Rightarrow B)
+  \qquad
+  \operatorname{widen}(c':A'\Rightarrow B')
+  \qquad
+  B \mathrel{\sqsubseteq_q} B'
+  \qquad
+  \lfloor c\rfloor
+    \mathbin{;}\lfloor q\rfloor
+    \mathrel{\cong} t
+  \qquad
+  \lfloor p\rfloor
+    \mathbin{;}\lfloor c'\rfloor
+    \mathrel{\cong} t
+  \qquad
+  \operatorname{compatible}(c,c';p,q)
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_q}
+  M'\langle c'\rangle
+  : B \mathrel{\sqsubseteq} B'
+}.
+$$
+
+All these rules remain ordinary because their conclusions carry ordinary type
+imprecision.  The paired widening rule does not cover a lower horizontal edge
+that exists only modulo `∀`-permutation; that case belongs to quotient
+closing below.
 
 ## The only quotient introduction
 
@@ -250,6 +603,11 @@ $$
   \end{array}
   \qquad
   d,d' \text{ are narrowing}
+  \qquad
+  \lfloor d\rfloor
+    \mathbin{;}\lfloor p\rfloor
+    \mathrel{\cong^\forall_q}
+    \mathbin{;}\lfloor d'\rfloor
 }{
   M\langle d\rangle
   \mathrel{\sqsubseteq^\forall_q}
@@ -257,16 +615,7 @@ $$
 }.
 $$
 
-The square includes the existing composition condition
-
-$$
-\operatorname{shape}(d)
-\mathbin{;}\lfloor p\rfloor
-\mathrel{\cong^\forall_q}
-\mathbin{;}\operatorname{shape}(d').
-$$
-
-That condition says that both paths through the square have the same
+The final premise says that both paths through the square have the same
 imprecision shape after moving to the representatives stored in `q`.
 
 The premise is deliberately ordinary.  Therefore this rule cannot put a
@@ -289,20 +638,16 @@ $$
   u,u' \text{ are widening}
   \qquad
   u,u' \text{ are operationally compatible}
+  \qquad
+  \lfloor u\rfloor
+    \mathbin{;}\lfloor p\rfloor
+    \mathrel{\cong^\forall_q}
+    \mathbin{;}\lfloor u'\rfloor
 }{
   N\langle u\rangle
   \mathrel{\sqsubseteq_p}
   N'\langle u'\rangle
 }.
-$$
-
-The corresponding composition condition is
-
-$$
-\operatorname{shape}(u)
-\mathbin{;}\lfloor p\rfloor
-\mathrel{\cong^\forall_q}
-\mathbin{;}\operatorname{shape}(u').
 $$
 
 Operational compatibility is not merely another typing premise.  It is the

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -342,13 +342,140 @@ B \mathrel{\sqsubseteq_r} C'
 $$
 
 after allocation.  The existing live `Λ⊑instβᵀ` constructor carries most of
-this provenance, but it installs the final post-administration horizontal
-edge directly in term imprecision.  The checked positive regression therefore
-does not yet show that the smaller relation can derive the final edge without
-that fused constructor.  This is the next target-instantiation test for the
-up-to-reduction design: either derive the final ordinary relation from a
-separate creation-square simulation lemma, or retain a narrowly scoped
-creation residual as a genuine invariant.
+this provenance, but it also carries arbitrary endpoint renaming, store
+embedding, endpoint equalities, closure evidence, and the final
+post-administration horizontal edge.
+
+### Checked target-instantiation creation test
+
+The focused test starts from the valid ordinary top row
+
+$$
+\Lambda(\lambda x.x)
+\mathrel{\sqsubseteq}
+\Lambda(\lambda x.x)
+\left\langle
+  \mathsf{inst}\ (\star\to\star)\
+  \bigl(
+    \mathsf{seal}\ \star\ 0
+    \to
+    \mathsf{unseal}\ 0\ \star
+  \bigr)
+\right\rangle
+:
+\forall\alpha.(\alpha\to\alpha)
+\mathrel{\sqsubseteq}
+\star\to\star .
+$$
+
+The source takes zero steps.  The target takes the complete administrative
+trace
+
+$$
+\begin{aligned}
+&\Lambda(\lambda x.x)
+\left\langle
+  \mathsf{inst}\ (\star\to\star)\
+  \bigl(
+    \mathsf{seal}\ \star\ 0
+    \to
+    \mathsf{unseal}\ 0\ \star
+  \bigr)
+\right\rangle
+\\
+&\quad\longrightarrow
+\nu\,\star\,\Lambda(\lambda x.x)\
+  \bigl(
+    \mathsf{seal}\ \star\ 0
+    \to
+    \mathsf{unseal}\ 0\ \star
+  \bigr)
+\\
+&\quad\longrightarrow
+\bigl((\mathord{\uparrow}\Lambda(\lambda x.x))\,\bullet\bigr)
+\left\langle
+  \mathsf{seal}\ \star\ 0
+  \to
+  \mathsf{unseal}\ 0\ \star
+\right\rangle
+\\
+&\quad\longrightarrow
+(\lambda x.x)
+\left\langle
+  \mathsf{seal}\ \star\ 0
+  \to
+  \mathsf{unseal}\ 0\ \star
+\right\rangle .
+\end{aligned}
+$$
+
+Thus up-to-reduction removes every transient target-only `ν` or
+runtime-bullet edge.  It still leaves the final value row
+
+$$
+\Lambda(\lambda x.x)
+\mathrel{\sqsubseteq}
+(\lambda x.x)
+\left\langle
+  \mathsf{seal}\ \star\ 0
+  \to
+  \mathsf{unseal}\ 0\ \star
+\right\rangle .
+$$
+
+The ordinary source-only-lambda rule followed by an ordinary target-cast rule
+cannot derive this row.  That factorization would first require
+
+$$
+(0 \mathrel{\sqsubseteq} \star)\mathbin{;}
+1
+\vdash
+(\alpha\to\alpha)
+\mathrel{\sqsubseteq}
+(\alpha\to\alpha)
+\dashv
+1 .
+$$
+
+The source-only assumption relates the source variable to `★`, not to the
+fresh target seal.  Exhaustive inversion reaches the impossible variable
+judgment
+
+$$
+(0 \mathrel{\sqsubseteq} \star)\mathbin{;}
+1
+\vdash
+\alpha
+\mathrel{\sqsubseteq}
+\alpha
+\dashv
+1 .
+$$
+
+The strict
+[`NuImprecisionTargetInstantiationCreationExamples.agda`](../../Quotient/NuImprecisionTargetInstantiationCreationExamples.agda)
+checks all three parts of this result:
+
+1. the initial ordinary term-imprecision derivation;
+2. the complete target allocation trace; and
+3. the impossibility of the opened structural body index.
+
+The same module constructs
+[`TargetInstantiationCreation`](../../Quotient/NuImprecisionTargetInstantiationCreationDef.agda),
+which contains the matched body relation, target instantiation typing,
+creation equation, and store lifts into the final right-extended world.  It
+does so without constructing the fused final term-imprecision edge.
+
+This determines the limit of up-to-reduction.  The large live constructor can
+be decomposed, but the semantic creation case cannot simply disappear while
+`WeakOneStepResult` and the public DGG theorem still demand ordinary term
+imprecision between the final values.  The smallest conservative replacement
+is an exact creation constructor whose sole premise is the checked creation
+residual.  General renaming, store embedding, and endpoint transport should
+then be proved as separate admissibility lemmas instead of being fields of the
+constructor.  Removing even that exact creation case would require changing
+the simulation conclusion to a creation-saturated relation; that merely moves
+the same semantic case out of ordinary term imprecision.
 
 Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
 can consume only `ν`.  A derivation cannot silently remove on the left a

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -555,34 +555,25 @@ seal from `0` to another name.  The exact constructor deliberately creates
 the distinguished right entry at `0`, so it cannot directly reconstruct that
 renamed conclusion.
 
-The smaller relation therefore now has one closed-endpoint transport rule.
-From an ordinary smaller-relation edge,
+The first experiment used a generic closed-endpoint renaming rule.  That rule
+is too broad.  Its premises require only well-scoped renamings and a
+relational-store embedding.  They do not require either renaming to be
+injective or to have a left inverse.  An arbitrary renaming may identify two
+distinct seal names and thereby change a `tag-untag-bad` reduction into
+`tag-untag-ok`.  Consequently a leading reduction cannot in general be
+reflected through that rule.
 
-$$
-M\mathrel{\sqsubseteq_p}M',
-$$
-
-an assumption-preserving pair of renamings and a relational store embedding
-produce
-
-$$
-\mathsf{rename}_{\tau}(M)
-\mathrel{\sqsubseteq_{\mathsf{rename}_{\tau,\sigma}(p)}}
-\mathsf{rename}_{\sigma}(M').
-$$
-
-The endpoint typings are explicit premises of this rule.  This is necessary
-because the general store embedding does not require the renamings to have
-left inverses.
-
-The focused transport proof composes this rule with exact creation.  Its
-result index is not arbitrary; it is exactly
+The generic `rename-storeᴿ` constructor has therefore been removed.  The
+current prototype permits only an exact target-instantiation creation
+residual to cross the required closed-endpoint renaming and store embedding.
+Its conclusion has the fixed index
 
 $$
 \mathsf{rename}_{\tau,\sigma}
 \bigl(\mathord{\uparrow_R}p\bigr).
 $$
 
+The endpoint typings are explicit premises of this creation-specific rule.
 Endpoint equalities may replace the four renamed terms and types, but the
 client-supplied index must satisfy
 
@@ -601,30 +592,34 @@ This equality is the tighter invariant missing from the current generalized
 final index without relating them.  The exact creation plus transport
 decomposition works when this equality is added.
 
-The finite-spine consumer test also succeeds.  Every step retains the exact
+The finite-spine consumer test also succeeds. Every step retains the exact
 creation premises, the exact post-allocation endpoint typings, the relational
 store embedding, the four endpoint equalities, and the canonical final-index
 equality.  The spine folds recursively into the independent smaller relation:
 the recursive body supplies the relation parameter of
 `TargetInstantiationCreation`, and the endpoint transport theorem supplies
-the outer step.  Thus arbitrarily nested target-instantiation creation does
+the outer step. Thus arbitrarily nested target-instantiation creation does
 not require restoring the large fused constructor.
 
-This result uses one new generic `rename-storeᴿ` constructor in the smaller
-relation.  It replaces the creation-specific renaming and store-embedding
-fields with a relation-wide closed-endpoint transport boundary.  The
-experiment therefore relocates one proof obligation rather than eliminating
-it: simulation must show that reduction is equivariant under this transport
-boundary, or a later proof must make `rename-storeᴿ` admissible and remove it
-as a primitive constructor.  The benefit is that this obligation is stated
-once for every ordinary constructor instead of being hidden inside target
-instantiation creation.
+The creation-specific transported rule introduces no active source or target
+simulation branch.  `TargetInstantiationCreation` retains `Value W`,
+`Value W'`, and an inert target cast.  Type renaming preserves values, so both
+renamed endpoints are values.  The focused terminal experiment proves that a
+leading step from either endpoint is impossible by `value-no-step`.
 
-The remaining migration question is empirical: each live
-`Λ⊑instβᵀ` consumer must be audited to see whether it can prove the canonical
-final-index equality.  A consumer that cannot do so is evidence that the old
-constructor accepted an unrelated proof-relevant index, not evidence that
-exact creation or its transport failed.
+The eventual formulation should derive this transport by a syntax-directed
+no-bullet world-embedding theorem requiring left inverses and cast-mode
+renamers.  The current creation-specific constructor is a safe interim
+boundary: it does not wrap an arbitrary relation, fixes its final index
+canonically, retains exact endpoint typings, and is terminal.
+
+The live-consumer audit found three distinct situations. The direct
+post-beta identity context already fixes its index to the canonical
+right-lifted index. The pure and framed universal-fusion spines previously
+accepted an arbitrary final index; their step contracts now retain the
+canonical equality. The paired-lambda leaf view and the unfinished target
+widening `β-inst` roots still lose required evidence and must be strengthened
+before the old constructor can be removed.
 
 Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
 can consume only `ν`.  A derivation cannot silently remove on the left a

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -250,30 +250,110 @@ $$
 .
 $$
 
-The target-only case uses an ordinary bridge from the unchanged source type
-to the body of the target universal:
+There is no target-only `ν` rule.  The tempting rule would require both a
+pre-allocation index and an independently opened body index:
 
 $$
-\frac{
-  N \mathrel{\sqsubseteq_q} N'
-  : B \mathrel{\sqsubseteq} \forall C'
-  \qquad
-  B \mathrel{\sqsubseteq_r} C'
-  \qquad
-  r[0 \mapsto {\uparrow A}]^R
-  \doteq
-  \operatorname{lift}^{R}(p)
-}{
-  N
-  \mathrel{\sqsubseteq_p}
-  \nu A\,N'\,s
-}.
+\begin{aligned}
+q &: \Phi \mathbin{;} \Delta_L
+  \vdash B \mathrel{\sqsubseteq} \forall C'
+  \dashv \Delta_R,\\
+r &: \mathord{\uparrow_R}\Phi \mathbin{;} \Delta_L
+  \vdash B \mathrel{\sqsubseteq} C'
+  \dashv \operatorname{suc}(\Delta_R).
+\end{aligned}
 $$
+
+These two premises are inconsistent:
+
+$$
+\neg\!\left(
+  \bigl(\Phi \mathbin{;} \Delta_L
+    \vdash B \mathrel{\sqsubseteq} \forall C'
+    \dashv \Delta_R\bigr)
+  \mathbin{\land}
+  \bigl(\mathord{\uparrow_R}\Phi \mathbin{;} \Delta_L
+    \vdash B \mathrel{\sqsubseteq} C'
+    \dashv \operatorname{suc}(\Delta_R)\bigr)
+\right).
+$$
+
+Right-lifting the first index puts the unchanged source type below
+`∀` applied to the uniformly lifted target body.  Pairing that index with the
+second would put one common source below both the target body and an extra
+universal over its uniformly lifted copy.  Exhaustive inversion of type
+imprecision rules this out.  Consequently neither a result-index equation
+
+$$
+r[0 \mapsto {\uparrow A}]^R
+\doteq
+\operatorname{lift}^{R}(p)
+$$
+
+nor a target reveal conversion from `C'` to `↑B'` can make the case
+inhabited: the contradiction already uses only `q` and `r`.
+
+The same obstruction excludes the target-only type-application rule and the
+cast-specialized target-only `ν` rule, because both require the same pair of
+indices.  Actual target-only allocation is instead handled by the
+up-to-reduction conclusion.  The top relation remains at the target
+instantiation, the target takes its whole administrative tail,
+
+$$
+V'\langle\mathsf{inst}\ B\ s\rangle
+\longrightarrow
+\nu\,\star\,V'\,s
+\longrightarrow
+\bigl((\mathord{\uparrow}V')\,\bullet\bigr)\langle s\rangle
+\longrightarrow^{*}
+W',
+$$
+
+and ordinary imprecision is required only between the source catch-up result
+and `W'`.  No horizontal edge is asserted at the transient target `ν` or
+runtime-bullet states.
+
+The evidence retained across this target trace should be a creation square,
+not an independently opened index.  In the directly matched case its
+essential form is
+
+$$
+\begin{aligned}
+W &\mathrel{\sqsubseteq_q} W'
+  : D \mathrel{\sqsubseteq} C',\\
+\Lambda W &\mathrel{\sqsubseteq_{\forall^{\,i}q}} \Lambda W',\\
+\mathsf{inst}\ B'\ s
+  &: \forall C' \longrightarrow B',\\
+\left\lfloor \forall^{\,i}q \right\rfloor
+  \mathbin{;}
+\left\lfloor \mathsf{inst}\ B'\ s \right\rfloor
+  &\mathrel{\cong}
+\left\lfloor p \right\rfloor,
+\end{aligned}
+$$
+
+where `p` is necessarily source-only at its outer universal.  A
+proof-relevant version of this square should retain the matched body
+imprecision, the target conversion, the final source-only index, and the
+right-allocation store lineage.  It should not manufacture
+
+$$
+B \mathrel{\sqsubseteq_r} C'
+$$
+
+after allocation.  The existing live `Λ⊑instβᵀ` constructor carries most of
+this provenance, but it installs the final post-administration horizontal
+edge directly in term imprecision.  The checked positive regression therefore
+does not yet show that the smaller relation can derive the final edge without
+that fused constructor.  This is the next target-instantiation test for the
+up-to-reduction design: either derive the final ordinary relation from a
+separate creation-square simulation lemma, or retain a narrowly scoped
+creation residual as a genuine invariant.
 
 Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
 can consume only `ν`.  A derivation cannot silently remove on the left a
 universal quantifier that was matched with a universal quantifier on the
-right.  All three rules remain in the ordinary judgment; none accepts or
+right.  Both rules remain in the ordinary judgment; neither accepts or
 produces quotient term imprecision.
 
 ## Ordinary cast and conversion rules

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -164,6 +164,47 @@ $$
 In particular, application and primitive operations consume only ordinary
 premises.
 
+The terminal `gen`/ground join also remains ordinary:
+
+$$
+\frac{
+  \mathsf{gen}\ A\ c
+  : A \mathrel{\sqsupseteq} \forall B
+  \qquad
+  \mathsf{Ground}(H)
+  \qquad
+  \mathsf{Value}(V)
+  \qquad
+  \mathsf{Value}(W)
+  \qquad
+  W : H
+  \qquad
+  V
+  \mathrel{\sqsubseteq_p}
+  W\langle H!\rangle
+  : A \mathrel{\sqsubseteq} \star
+  \qquad
+  \forall B \mathrel{\sqsubseteq_q} H
+}{
+  V\langle\mathsf{gen}\ A\ c\rangle
+  \mathrel{\sqsubseteq_q}
+  W
+  : \forall B \mathrel{\sqsubseteq} H
+}.
+$$
+
+The displayed cast premise abbreviates the live coercion-typing premise;
+mode and store evidence are suppressed.  This rule cannot be replaced by
+source narrowing alone, because that route would require
+
+$$
+A \mathrel{\sqsubseteq} H,
+$$
+
+whereas the available inner edge ends at `★`.  Nor can up-to-reduction
+manufacture the missing edge: both `V⟨gen A c⟩` and `W` are values and
+therefore take no reduction steps.
+
 The polymorphic rules also remain ordinary.  Their essential index changes
 are:
 
@@ -312,6 +353,35 @@ $$
 and ordinary imprecision is required only between the source catch-up result
 and `W'`.  No horizontal edge is asserted at the transient target `ν` or
 runtime-bullet states.
+
+The same administrative argument is intended to remove the matched and
+source-only cast-specialized `ν` rules, but only for reachable states.  The
+required reachability invariant on every instantiation residual is
+
+$$
+\mathsf{Value}(V)
+\mathbin{\land}
+\mathsf{No\mathord{\bullet}}(V).
+$$
+
+Under that invariant, the residual has the complete reduction tail
+
+$$
+V\langle\mathsf{inst}\ B\ s\rangle
+\longrightarrow
+\nu\,\star\,V\,s
+\longrightarrow
+\bigl((\mathord{\uparrow}V)\,\bullet\bigr)\langle s\rangle.
+$$
+
+For a matched residual, take this tail on both sides; for a source-only
+residual, take it on the source side.  The resulting edge is rebuilt using
+the ordinary matched or source-only type-application rule, followed by the
+appropriate widening rule.  If the simulation cannot establish
+`Value V × No• V` at every such residual, then the omission is not
+sound for the unrestricted term grammar and a cast-specialized `ν` rule
+must be restored.  This reachability obligation is separate from the
+impossibility of the target-only rule above.
 
 The evidence retained across this target trace should be a creation square,
 not an independently opened index.  In the directly matched case its
@@ -486,7 +556,7 @@ $$
 ((0\mathrel{\sqsubseteq}0)::\mathord{\uparrow}\Phi)\mathbin{;}\operatorname{suc}(\Delta_L)\mathbin{;}\operatorname{suc}(\Delta_R)\mathbin{;}\rho_{\forall}\ \vdash\ W\mathrel{\sqsubseteq_q}W' : D\mathrel{\sqsubseteq}C .
 $$
 
-The target has an inert widening instantiation:
+The target has an active widening instantiation whose body coercion is inert:
 
 $$
 \mathsf{inst}\ B\ s : \forall C\longrightarrow B .
@@ -555,6 +625,28 @@ seal from `0` to another name.  The exact constructor deliberately creates
 the distinguished right entry at `0`, so it cannot directly reconstruct that
 renamed conclusion.
 
+The exact creation edge is nevertheless valid under any term-imprecision
+context in its final world:
+
+$$
+\mathord{\uparrow_R}\Phi
+\mathbin{;}\Delta_L
+\mathbin{;}\operatorname{suc}(\Delta_R)
+\mathbin{;}(\mathsf{right}\ 0\ \star)::\rho_R^+
+\mathbin{;}\gamma
+\ \vdash\
+\Lambda W
+\mathrel{\sqsubseteq_{\mathord{\uparrow_R}p}}
+W'\langle s\rangle.
+$$
+
+This is not a general recontextualization rule.  The creation record proves
+both endpoints typed under the empty term context, hence closed; the typing
+projections recontextualize those particular closed endpoints under `γ`.
+Quantifying `γ` here is required for ordinary substitution beneath lambdas.
+Restricting creation to the empty term context makes the otherwise standard
+parallel substitution theorem fail at exactly this constructor.
+
 The first experiment used a generic closed-endpoint renaming rule.  That rule
 is too broad.  Its premises require only well-scoped renamings and a
 relational-store embedding.  They do not require either renaming to be
@@ -563,19 +655,20 @@ distinct seal names and thereby change a `tag-untag-bad` reduction into
 `tag-untag-ok`.  Consequently a leading reduction cannot in general be
 reflected through that rule.
 
-The generic `rename-storeᴿ` constructor has therefore been removed.  The
-current prototype permits only an exact target-instantiation creation
-residual to cross the required closed-endpoint renaming and store embedding.
-Its conclusion has the fixed index
+The generic `rename-storeᴿ` constructor has therefore been removed. The term
+grammar now has exactly one creation constructor, whose premise is an
+`EmbeddedTargetInstantiationCreation`. The residual begins with exact
+creation and may then compose only the syntax-directed world embeddings
+needed by the proof. Its conclusion has the fixed index
 
 $$
 \mathsf{rename}_{\tau,\sigma}
 \bigl(\mathord{\uparrow_R}p\bigr).
 $$
 
-The endpoint typings are explicit premises of this creation-specific rule.
-Endpoint equalities may replace the four renamed terms and types, but the
-client-supplied index must satisfy
+Each embedding layer retains endpoint typings and the relational store
+embedding. Endpoint equalities may replace the four renamed terms and types,
+but the client-supplied index must satisfy
 
 $$
 p_{\mathrm{client}}
@@ -587,39 +680,93 @@ p_{\mathrm{client}}
 \right).
 $$
 
-This equality is the tighter invariant missing from the current generalized
-`fusion-step`: that constructor carries its origin index and an arbitrary
-final index without relating them.  The exact creation plus transport
-decomposition works when this equality is added.
+This equality is the tighter invariant missing from the old generalized
+`fusion-step`: that constructor carried its origin index and an arbitrary
+final index without relating them. The exact creation plus embedded-residual
+decomposition works when this equality is added. There is no separate
+term-level transport constructor.
 
 The finite-spine consumer test also succeeds. Every step retains the exact
 creation premises, the exact post-allocation endpoint typings, the relational
 store embedding, the four endpoint equalities, and the canonical final-index
-equality.  The spine folds recursively into the independent smaller relation:
+equality. The spine folds recursively into the independent smaller relation:
 the recursive body supplies the relation parameter of
-`TargetInstantiationCreation`, and the endpoint transport theorem supplies
-the outer step. Thus arbitrarily nested target-instantiation creation does
-not require restoring the large fused constructor.
+`TargetInstantiationCreation`, and an embedded residual supplies the outer
+step. Thus arbitrarily nested target-instantiation creation does not require
+restoring the large fused constructor.
 
-The creation-specific transported rule introduces no active source or target
-simulation branch.  `TargetInstantiationCreation` retains `Value W`,
-`Value W'`, and an inert target cast.  Type renaming preserves values, so both
-renamed endpoints are values.  The focused terminal experiment proves that a
+An embedded creation residual introduces no active source or target
+simulation branch. `TargetInstantiationCreation` retains `Value W`,
+`Value W'`, and an inert target cast. Type renaming preserves values, so both
+embedded endpoints are values. The focused terminal experiment proves that a
 leading step from either endpoint is impossible by `value-no-step`.
 
-The eventual formulation should derive this transport by a syntax-directed
-no-bullet world-embedding theorem requiring left inverses and cast-mode
-renamers.  The current creation-specific constructor is a safe interim
-boundary: it does not wrap an arbitrary relation, fixes its final index
-canonically, retains exact endpoint typings, and is terminal.
+The attempted syntax-directed no-bullet world-embedding theorem exposed one
+more invariant. Exact creation by itself is not closed under an enclosing
+paired type binder. The two possible orders of extending the imprecision
+world are different:
 
-The live-consumer audit found three distinct situations. The direct
-post-beta identity context already fixes its index to the canonical
-right-lifted index. The pure and framed universal-fusion spines previously
-accepted an arbitrary final index; their step contracts now retain the
-canonical equality. The paired-lambda leaf view and the unfinished target
-widening `β-inst` roots still lose required evidence and must be strengthened
-before the old constructor can be removed.
+$$
+\forall^{\,i}\bigl(\mathord{\uparrow_R}\Phi\bigr)
+\not=
+\mathord{\uparrow_R}\bigl(\forall^{\,i}\Phi\bigr).
+$$
+
+The left world begins with the matched assumption
+`0 \mathrel{\sqsubseteq} 0`, whereas the right world begins with
+`0 \mathrel{\sqsubseteq} 1`. The final stores exhibit the same obstruction:
+exact creation allocates the distinguished target seal at `0`, while paired
+weakening renames that stored seal to `1`. A store prefix can prepend entries,
+but cannot rename an existing entry.
+
+This is a strict negative result, mechanized by
+`paired-lift-creation-worlds-differᴿ`. Therefore a separate transported term
+constructor cannot simply be deleted while leaving exact creation unchanged.
+The repaired design has exactly one creation case in the term grammar, whose
+premise is an `EmbeddedTargetInstantiationCreation` residual. Exact creation
+is its canonical base. The residual composes syntax-directed world embeddings
+and retains the canonical renamed final index, so paired and source-only
+weakening become admissibility theorems rather than extra term constructors.
+
+The resulting world-embedding traversal is syntax directed over every
+ordinary and quotient constructor. Its paired and source-only one-binder
+corollaries have the canonical conclusions
+
+$$
+\mathsf{weaken}_{\forall}(p)=\mathord{\uparrow_{\forall}}p
+\qquad\text{and}\qquad
+\mathsf{weaken}_{\nu}(p)=\mathord{\uparrow_{\nu}}p.
+$$
+
+These corollaries complete the Kripke environment required by parallel
+substitution beneath both forms of type binder. The fully indexed
+single-variable theorem is therefore admissible for the smaller relation:
+if the body and argument are related without runtime bullets, substituting
+the argument for the newest term variable preserves the same type-imprecision
+index.
+
+The concrete regression `two-round-trips-substitutionᴿ` applies this theorem
+to the twice-closed quotient argument produced by the two-function-cast
+example. It uses only the independent smaller relation. The former QTI-based
+regression remains as a comparison, but is no longer evidence needed by the
+smaller design.
+
+The live-consumer audit found three distinct situations. The direct post-beta
+identity context already fixes its index to the canonical right-lifted index.
+The pure and framed universal-fusion spines previously accepted an arbitrary
+final index; their step contracts now retain the canonical equality. Strict
+shadow migrations also reconstruct the paired-lambda leaf and both target
+widening `β-inst` roots. The corresponding live boundaries still have to be
+strengthened before the old constructor can be removed from live QTI.
+
+An additional audit covered permissive modules because incomplete induction
+could hide an old-constructor branch. Exactly three such modules import the
+live relation. Only `NuImprecisionCatchupScratch` analyzes it by cases, and
+its two analyses both contain an explicit `Λ⊑instβᵀ` branch.
+`NuImprecisionOneStepTargetCastRoots` and
+`NuImprecisionOneStepTargetConversionRoots` merely pass their relation
+premises to focused helpers, so their remaining holes do not conceal another
+constructor consumer.
 
 Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
 can consume only `ν`.  A derivation cannot silently remove on the left a
@@ -1147,7 +1294,8 @@ quotient argument inside application.  The smaller design does not try to
 draw that horizontal edge.  It continues reducing both sides and asks only
 for an ordinary horizontal edge at a later join.
 
-The checked two-function example uses paired casts of opposite polarity:
+The decisive two-function example uses paired casts of opposite polarity.
+Its ordinarily related top row has the form:
 
 $$
 \bigl(
@@ -1155,51 +1303,91 @@ $$
     \langle u\mapsto d\rangle
     \langle d\mapsto u\rangle
 \bigr)\,W
-\longrightarrow^*
-W\langle d\rangle\langle u\rangle
- \langle d\rangle\langle u\rangle.
-$$
-
-The target follows the corresponding primed path:
-
-$$
+\mathrel{\sqsubseteq}
 \bigl(
   (\lambda x.\,x)
     \langle u'\mapsto d'\rangle
     \langle d'\mapsto u'\rangle
-\bigr)\,W'
-\longrightarrow^*
-W'\langle d'\rangle\langle u'\rangle
-  \langle d'\rangle\langle u'\rangle.
+\bigr)\,W'.
 $$
 
-If `W ⊑ W'` is ordinary, the bottom relation is built by opening and closing
-one boundary twice:
+Both sides take exactly the two function-cast beta steps.  The source reaches:
 
 $$
-\begin{aligned}
-W
-&\mathrel{\sqsubseteq} W'\\
+\Bigl(
+  (\lambda x.\,x)
+    \bigl(W\langle d\rangle\langle u\rangle\bigr)
+\Bigr)
+\langle d\rangle\langle u\rangle.
+$$
+
+The target reaches the corresponding primed term:
+
+$$
+\Bigl(
+  (\lambda x.\,x)
+    \bigl(W'\langle d'\rangle\langle u'\rangle\bigr)
+\Bigr)
+\langle d'\rangle\langle u'\rangle.
+$$
+
+If `W ⊑ W'` is ordinary, the bottom edge is constructed in five
+syntax-directed stages.  First open and close the argument boundary:
+
+$$
 W\langle d\rangle
-&\mathrel{\sqsubseteq^\forall}
-W'\langle d'\rangle\\
-W\langle d\rangle\langle u\rangle
-&\mathrel{\sqsubseteq}
-W'\langle d'\rangle\langle u'\rangle\\
-W\langle d\rangle\langle u\rangle\langle d\rangle
-&\mathrel{\sqsubseteq^\forall}
-W'\langle d'\rangle\langle u'\rangle\langle d'\rangle\\
-W\langle d\rangle\langle u\rangle
- \langle d\rangle\langle u\rangle
-&\mathrel{\sqsubseteq}
-W'\langle d'\rangle\langle u'\rangle
- \langle d'\rangle\langle u'\rangle.
-\end{aligned}
+\mathrel{\sqsubseteq^\forall}
+W'\langle d'\rangle.
 $$
 
-Thus additional reachable function casts do not automatically demand longer
-narrowing spines.  In this example each new quotient boundary is opened only
-after the preceding one has closed.
+$$
+W\langle d\rangle\langle u\rangle
+\mathrel{\sqsubseteq}
+W'\langle d'\rangle\langle u'\rangle.
+$$
+
+Then ordinary application relates the two lambda applications:
+
+$$
+(\lambda x.\,x)
+  \bigl(W\langle d\rangle\langle u\rangle\bigr)
+\mathrel{\sqsubseteq}
+(\lambda x.\,x)
+  \bigl(W'\langle d'\rangle\langle u'\rangle\bigr).
+$$
+
+Finally open and close the result boundary:
+
+$$
+\Bigl(
+  (\lambda x.\,x)
+    \bigl(W\langle d\rangle\langle u\rangle\bigr)
+\Bigr)\langle d\rangle
+\mathrel{\sqsubseteq^\forall}
+\Bigl(
+  (\lambda x.\,x)
+    \bigl(W'\langle d'\rangle\langle u'\rangle\bigr)
+\Bigr)\langle d'\rangle.
+$$
+
+$$
+\Bigl(
+  (\lambda x.\,x)
+    \bigl(W\langle d\rangle\langle u\rangle\bigr)
+\Bigr)\langle d\rangle\langle u\rangle
+\mathrel{\sqsubseteq}
+\Bigl(
+  (\lambda x.\,x)
+    \bigl(W'\langle d'\rangle\langle u'\rangle\bigr)
+\Bigr)\langle d'\rangle\langle u'\rangle.
+$$
+
+The square deliberately stops before the ordinary lambda beta step.  The
+primed widening may be active and may allocate, but an up-to-reduction
+simulation needs a related join, not a normal form.  Subsequent simulation
+handles that active argument before substitution.  Thus this reachable
+example uses two separate one-boundary quotient intervals; it needs neither
+quotient application nor a longer narrowing spine.
 
 ## Why the same-polarity stress test is not a simulation square
 
@@ -1279,7 +1467,7 @@ target-tail resumption; it is not evidence for a finite narrowing spine.
 
 ## Substitution boundary
 
-Only the ordinary relation has a substitution theorem:
+The ordinary relation has a strict substitution theorem:
 
 $$
 \frac{
@@ -1300,10 +1488,17 @@ quotient imprecision.  The operational hypothesis must therefore ensure that
 the paired widening closes the quotient before an ordinary substitution
 lemma is needed.
 
+The independent proof derives prefix-aware parallel substitution first and
+then a fully indexed single-variable theorem.  The latter traverses ordinary
+lambdas, paired type binders, and source-only type binders using the
+syntax-directed world-embedding theorem.  It assumes uniqueness of
+imprecision assumptions and `No•` for the body and substituted endpoints; it
+uses no live-QTI premise.
+
 The checked two-function example verifies substitution through an arbitrary
-related body after both down/up round trips have closed.  It does not yet
-prove that every function-cast beta case reaches such a closed argument before
-substitution.  That is the decisive `sim-beta-cast` obligation.
+related body after both down/up round trips have closed.  The general
+function-cast beta simulation must still establish that every reachable
+argument has returned to the ordinary relation before invoking this theorem.
 
 The GTLC proof suggests the right proof shape: peel the function cast, catch up
 the casted argument, recurse on the underlying function application, and
@@ -1361,22 +1556,35 @@ The critical supporting results are:
 
 ## Decision criterion
 
-The current evidence supports the one-boundary hypothesis:
+All three decisive experiments succeed:
 
-- the alternating two-function-cast example is derivable and reaches an
-  ordinary-related endpoint;
-- the endpoint can be substituted into arbitrary ordinarily related bodies;
-- the reachable source cast-sequence case factors to one boundary;
-- the apparent two-narrowing counterexample has no derivable ordinary top
-  row.
+1. Every audited `Λ⊑instβᵀ` consumer can be reconstructed in the independent
+   relation from exact creation, its canonical embedded form, and the retained
+   final-index equality.
+2. The reachable two-function-cast square reduces on both sides to an
+   ordinary-related join.  Its bottom edge uses one paired narrowing boundary
+   at a time, ordinary closing widenings, and ordinary application; it needs
+   neither quotient application nor a fused down/application/up rule.
+3. The target-instantiation square crosses target instantiation, allocation,
+   and type beta with zero source steps and ends at the embedded exact-creation
+   edge.  It needs no target-only type-application or `ν` constructor.
 
-The hypothesis is not proved.  The active target `inst` path and the general
-function-cast beta case remain open.
+The supporting metatheory also succeeds: source and target typing, value and
+terminal inversion, allocation-aware bilateral closure, syntax-directed
+world embedding, parallel substitution, and fully indexed single-variable
+substitution all pass strict checks for the complete independent grammar.
 
-If those proofs succeed, the live quotient application rules and
-`down·up⊑down·upᵀ` should be derived or removed, not retained as primitive
-shortcuts.  If a derivable ordinary top row is found whose reductions can join
-only with quotient imprecision trapped under application or substitution,
-that will be a genuine counterexample.  Only then should the larger
-compositional quotient relation, finite spines, or quotient congruence be
-reconsidered.
+Therefore the smaller relation is ready for a controlled live migration.  It
+should replace live QTI constructor families incrementally, with strict
+consumer checks after each deletion.  This is not yet a proof of the full
+up-to-reduction simulation: the general source and target function-cast beta
+cases still have to connect the existing world-coherent operational machinery
+to this relation.
+
+During that migration, quotient application and
+`down·up⊑down·upᵀ` should be derived or removed rather than retained as
+primitive shortcuts.  If a derivable ordinary top row is later found whose
+reductions can join only with quotient imprecision trapped under application
+or substitution, that will be a genuine counterexample.  Only then should the
+larger compositional quotient relation, finite spines, or quotient congruence
+be reconsidered.

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -1,0 +1,686 @@
+# Smaller term imprecision up to reduction
+
+This note sketches a candidate replacement for the quotient-sensitive part of
+term imprecision.  It is a design hypothesis, not yet a proposed change to the
+live relation.  The main question is whether bilateral catch-up can keep
+quotient imprecision confined between one paired narrowing and its matching
+paired widening.
+
+The presentation suppresses type well-formedness, term typing, value
+conditions, cast modes, store conditions, and routine transport through store
+changes.  Those premises remain necessary in Agda, but they do not determine
+the quotient structure under discussion.
+
+Throughout the diagrams, the less precise term is on the left and the more
+precise term is on the right.
+
+## Type indices
+
+Ordinary type imprecision is written
+
+$$
+A \mathrel{\sqsubseteq_p} A'.
+$$
+
+The index records whether corresponding universal quantifiers are matched or
+whether a universal quantifier occurs only on the less precise side.  The two
+important index forms are
+
+$$
+\forall^{\,i} p
+\qquad\text{and}\qquad
+\nu p.
+$$
+
+Imprecision modulo permutation of adjacent universal quantifiers is written
+
+$$
+D \mathrel{\sqsubseteq^\forall_q} D'.
+$$
+
+It has one definition:
+
+$$
+\frac{
+  D \approx_\forall C
+  \qquad
+  C \mathrel{\sqsubseteq_p} C'
+  \qquad
+  C' \approx_\forall D'
+}{
+  D \mathrel{\sqsubseteq^\forall_{
+    [\,D\approx_\forall C,\;p,\;C'\approx_\forall D'\,]}} D'
+}.
+$$
+
+Thus quotient imprecision does not identify arbitrary types.  It exposes an
+ordinary imprecision derivation between two selected representatives and
+permits only `∀`-permutation on either side of it.
+
+## The two term judgments
+
+The public, ordinary judgment is
+
+$$
+M \mathrel{\sqsubseteq_p} M'
+  : A \mathrel{\sqsubseteq} A'.
+$$
+
+The auxiliary quotient judgment is
+
+$$
+N \mathrel{\sqsubseteq^\forall_q} N'
+  : D \mathrel{\sqsubseteq^\forall} D'.
+$$
+
+The ordinary judgment is used in theorem statements, contexts,
+substitution, and structural congruence.  The quotient judgment is a temporary
+state with exactly one introduction rule.  It is not a second general-purpose
+term relation.
+
+## Ordinary structural rules
+
+The familiar syntax-directed rules remain in the ordinary judgment.  The
+representative function rules are
+
+$$
+\frac{
+  N \mathrel{\sqsubseteq_{p_B}} N'
+  \text{ under }
+  x : A \mathrel{\sqsubseteq_{p_A}} A'
+}{
+  \lambda x.\,N
+  \mathrel{\sqsubseteq_{p_A\to p_B}}
+  \lambda x.\,N'
+}.
+$$
+
+$$
+\frac{
+  L \mathrel{\sqsubseteq_{p_A\to p_B}} L'
+  \qquad
+  M \mathrel{\sqsubseteq_{p_A}} M'
+}{
+  L\,M \mathrel{\sqsubseteq_{p_B}} L'\,M'
+}.
+$$
+
+Variables, blame, constants, and primitive operations retain their ordinary
+rules as well.  In particular, application consumes only ordinary premises.
+
+The polymorphic rules also remain ordinary.  Their essential index changes
+are:
+
+$$
+\frac{
+  V \mathrel{\sqsubseteq_p} V'
+}{
+  \Lambda V
+  \mathrel{\sqsubseteq_{\forall^{\,i}p}}
+  \Lambda V'
+}
+\qquad
+\frac{
+  V \mathrel{\sqsubseteq_p} N'
+}{
+  \Lambda V
+  \mathrel{\sqsubseteq_{\nu p}}
+  N'
+}.
+$$
+
+Matched type application removes a matched index, whereas source-only type
+application removes a source-only index:
+
+$$
+\frac{
+  L \mathrel{\sqsubseteq_{\forall^{\,i}p}} L'
+}{
+  L\,\bullet \mathrel{\sqsubseteq_p} L'\,\bullet
+}
+\qquad
+\frac{
+  L \mathrel{\sqsubseteq_{\nu p}} N'
+}{
+  L\,\bullet \mathrel{\sqsubseteq_p} N'
+}.
+$$
+
+The `ν` term follows the same discipline:
+
+$$
+\frac{
+  N \mathrel{\sqsubseteq_{\forall^{\,i}q}} N'
+}{
+  \nu A\,N\,s
+  \mathrel{\sqsubseteq_p}
+  \nu A'\,N'\,s'
+}
+\qquad
+\frac{
+  N \mathrel{\sqsubseteq_{\nu q}} N'
+}{
+  \nu A\,N\,s
+  \mathrel{\sqsubseteq_p}
+  N'
+}.
+$$
+
+The omitted equations apply the selected type instantiations to the inner
+index.  What matters here is that a matched `ν` rule can consume only
+`∀ⁱ`, while a source-only `ν` rule can consume only `ν`.  A derivation cannot
+silently remove on the left a universal quantifier that was matched with a
+universal quantifier on the right.
+
+The existing target-only type-application and `ν` cases remain ordinary too.
+None of the polymorphic rules accepts or produces quotient term imprecision.
+
+## Ordinary cast and conversion rules
+
+One-sided casts remain ordinary whenever their type-imprecision triangle
+commutes.  Schematically, a source cast uses
+
+$$
+\begin{array}{ccc}
+A & \mathrel{\sqsubseteq_p} & A'\\
+\downarrow c & & \Vert\\
+B & \mathrel{\sqsubseteq_r} & A'
+\end{array}
+\qquad\Longrightarrow\qquad
+M\langle c\rangle
+\mathrel{\sqsubseteq_r}
+M'.
+$$
+
+A target cast uses the mirror-image triangle:
+
+$$
+\begin{array}{ccc}
+A & \mathrel{\sqsubseteq_p} & A'\\
+\Vert & & \downarrow c'\\
+A & \mathrel{\sqsubseteq_r} & B'
+\end{array}
+\qquad\Longrightarrow\qquad
+M
+\mathrel{\sqsubseteq_r}
+M'\langle c'\rangle.
+$$
+
+These schemas cover both narrowing and widening; the direction of shape
+composition records which side of the triangle is traversed first.
+Reveal and conceal conversions likewise stay ordinary and update the ordinary
+index by the corresponding source or target type substitution.
+
+Paired casts also preserve the ordinary judgment when both the upper and
+lower horizontal edges are ordinary:
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  \qquad
+  \begin{array}{ccc}
+  A & \mathrel{\sqsubseteq_p} & A'\\
+  \downarrow c & & \downarrow c'\\
+  B & \mathrel{\sqsubseteq_r} & B'
+  \end{array}
+}{
+  M\langle c\rangle
+  \mathrel{\sqsubseteq_r}
+  M'\langle c'\rangle
+}.
+$$
+
+This paired rule includes the reveal, conceal, conversion, and ordinary
+widening cases already required by the live proof.  It does not cover a
+bottom edge that exists only modulo `∀`-permutation.
+
+## The only quotient introduction
+
+The quotient judgment has exactly one constructor.  It places one narrowing
+cast around each side of an ordinary-related pair:
+
+$$
+\frac{
+  M \mathrel{\sqsubseteq_p} M'
+  \qquad
+  \begin{array}{ccc}
+  A & \mathrel{\sqsubseteq_p} & A'\\
+  \downarrow d & & \downarrow d'\\
+  D & \mathrel{\sqsubseteq^\forall_q} & D'
+  \end{array}
+  \qquad
+  d,d' \text{ are narrowing}
+}{
+  M\langle d\rangle
+  \mathrel{\sqsubseteq^\forall_q}
+  M'\langle d'\rangle
+}.
+$$
+
+The square includes the existing composition condition
+
+$$
+\operatorname{shape}(d)
+\mathbin{;}\lfloor p\rfloor
+\mathrel{\cong^\forall_q}
+\mathbin{;}\operatorname{shape}(d').
+$$
+
+That condition says that both paths through the square have the same
+imprecision shape after moving to the representatives stored in `q`.
+
+The premise is deliberately ordinary.  Therefore this rule cannot put a
+second paired narrowing around an already quotient-related term.
+
+## Closing the quotient
+
+A paired widening returns immediately to the ordinary judgment:
+
+$$
+\frac{
+  N \mathrel{\sqsubseteq^\forall_q} N'
+  \qquad
+  \begin{array}{ccc}
+  D & \mathrel{\sqsubseteq^\forall_q} & D'\\
+  \downarrow u & & \downarrow u'\\
+  A & \mathrel{\sqsubseteq_p} & A'
+  \end{array}
+  \qquad
+  u,u' \text{ are widening}
+  \qquad
+  u,u' \text{ are operationally compatible}
+}{
+  N\langle u\rangle
+  \mathrel{\sqsubseteq_p}
+  N'\langle u'\rangle
+}.
+$$
+
+The corresponding composition condition is
+
+$$
+\operatorname{shape}(u)
+\mathbin{;}\lfloor p\rfloor
+\mathrel{\cong^\forall_q}
+\mathbin{;}\operatorname{shape}(u').
+$$
+
+Operational compatibility is not merely another typing premise.  It is the
+semantic promise that active behavior on either widening can be joined at the
+ordinary representative index.  Function and universal widenings require
+this promise recursively.  An active `inst` may allocate and therefore needs
+the allocation-aware target-tail argument already isolated in the DGG proof.
+
+This compatibility condition must be justified by catch-up lemmas.  It must
+not be weakened merely to make the term rule constructible.
+
+## Rules deliberately absent
+
+There is no quotient rule for application:
+
+$$
+\frac{
+  L \mathrel{\sqsubseteq^\forall} L'
+  \qquad
+  M \mathrel{\sqsubseteq^\forall} M'
+}{
+  L\,M \mathrel{\sqsubseteq^\forall} L'\,M'
+}
+\quad\text{is not a rule.}
+$$
+
+There is likewise no quotient rule for lambda abstraction, type abstraction,
+type application, `ν`, arbitrary paired casts, or substitution.  In
+particular, none of the following is present:
+
+$$
+\begin{aligned}
+&\text{a finite narrowing spine},\\
+&\text{a quotient-to-quotient cast square},\\
+&\text{a fused down/application/up rule},\\
+&\text{a rule specialized to two, three, or more function casts}.
+\end{aligned}
+$$
+
+By inversion, every quotient-related term has exactly the form
+
+$$
+M\langle d\rangle
+\mathrel{\sqsubseteq^\forall_q}
+M'\langle d'\rangle
+$$
+
+for an ordinary derivation `M ⊑ M'` and one paired narrowing.  A quotient
+index is therefore a scoped intermediate state:
+
+$$
+\text{ordinary}
+\;\longrightarrow\;
+\text{one open quotient boundary}
+\;\longrightarrow\;
+\text{ordinary}.
+$$
+
+## Bilateral reduction closure
+
+The smaller relation is intended to be used up to reduction, rather than to
+relate the immediate reduct after every leading step.  Its reduction closure
+is
+
+$$
+M \mathrel{\sqsubseteq^{\twoheadrightarrow}_p} M'
+\quad\text{if}\quad
+\exists N,N'.\;
+M \longrightarrow^* N
+\;\land\;
+M' \longrightarrow^* N'
+\;\land\;
+N \mathrel{\sqsubseteq_p} N'.
+$$
+
+For a source-leading step, the desired simulation conclusion is stated
+directly as
+
+$$
+\begin{aligned}
+M \mathrel{\sqsubseteq_p} M'
+\;\land\;
+M \longrightarrow M_1
+\quad\Longrightarrow\quad
+\exists N,N'.\;&
+M_1 \longrightarrow^* N\\
+&{}\land M' \longrightarrow^* N'\\
+&{}\land N \mathrel{\sqsubseteq_p} N'.
+\end{aligned}
+$$
+
+The square has this shape:
+
+$$
+\begin{array}{ccccc}
+M & \mathrel{\sqsubseteq_p} & M'\\
+\downarrow & & \Big\Downarrow^{*}\\
+M_1 & & N'\\
+\Big\Downarrow^{*} & & \Big\Downarrow^{0}\\
+N & \mathrel{\sqsubseteq_p} & N'
+\end{array}
+$$
+
+For a target-leading step, both the source catch-up and the target tail may be
+nonempty:
+
+$$
+\begin{aligned}
+M \mathrel{\sqsubseteq_p} M'
+\;\land\;
+M' \longrightarrow M'_1
+\quad\Longrightarrow\quad
+\exists N,N'.\;&
+M \longrightarrow^* N\\
+&{}\land M'_1 \longrightarrow^* N'\\
+&{}\land N \mathrel{\sqsubseteq_p} N'.
+\end{aligned}
+$$
+
+$$
+\begin{array}{ccccc}
+M & \mathrel{\sqsubseteq_p} & M'\\
+\Big\Downarrow^{*} & & \downarrow\\
+N & & M'_1\\
+\Big\Downarrow^{0} & & \Big\Downarrow^{*}\\
+N & \mathrel{\sqsubseteq_p} & N'
+\end{array}
+$$
+
+The extra reduction below the leading step is what may eliminate an
+application containing an open quotient boundary before the final horizontal
+relation is required.
+
+## Function-cast beta
+
+The leading reduction for a function cast is
+
+$$
+(V\langle c\mapsto d\rangle)\,W
+\longrightarrow
+(V\,(W\langle c\rangle))\langle d\rangle.
+$$
+
+The live fused rule relates the immediate terms on the right by allowing the
+quotient argument inside application.  The smaller design does not try to
+draw that horizontal edge.  It continues reducing both sides and asks only
+for an ordinary horizontal edge at a later join.
+
+The checked two-function example uses paired casts of opposite polarity:
+
+$$
+\bigl(
+  (\lambda x.\,x)
+    \langle u\mapsto d\rangle
+    \langle d\mapsto u\rangle
+\bigr)\,W
+\longrightarrow^*
+W\langle d\rangle\langle u\rangle
+ \langle d\rangle\langle u\rangle.
+$$
+
+The target follows the corresponding primed path:
+
+$$
+\bigl(
+  (\lambda x.\,x)
+    \langle u'\mapsto d'\rangle
+    \langle d'\mapsto u'\rangle
+\bigr)\,W'
+\longrightarrow^*
+W'\langle d'\rangle\langle u'\rangle
+  \langle d'\rangle\langle u'\rangle.
+$$
+
+If `W ⊑ W'` is ordinary, the bottom relation is built by opening and closing
+one boundary twice:
+
+$$
+\begin{aligned}
+W
+&\mathrel{\sqsubseteq} W'\\
+W\langle d\rangle
+&\mathrel{\sqsubseteq^\forall}
+W'\langle d'\rangle\\
+W\langle d\rangle\langle u\rangle
+&\mathrel{\sqsubseteq}
+W'\langle d'\rangle\langle u'\rangle\\
+W\langle d\rangle\langle u\rangle\langle d\rangle
+&\mathrel{\sqsubseteq^\forall}
+W'\langle d'\rangle\langle u'\rangle\langle d'\rangle\\
+W\langle d\rangle\langle u\rangle
+ \langle d\rangle\langle u\rangle
+&\mathrel{\sqsubseteq}
+W'\langle d'\rangle\langle u'\rangle
+ \langle d'\rangle\langle u'\rangle.
+\end{aligned}
+$$
+
+Thus additional reachable function casts do not automatically demand longer
+narrowing spines.  In this example each new quotient boundary is opened only
+after the preceding one has closed.
+
+## Why the same-polarity stress test is not a simulation square
+
+Two same-polarity function casts can reduce to a prefix with two consecutive
+narrowings:
+
+$$
+W\langle d_2\rangle\langle d_1\rangle.
+$$
+
+A finite-spine relation can describe such a prefix in isolation.  The
+one-boundary relation cannot.  That fact initially looked like a
+counterexample.
+
+However, the chosen source and target intermediate types differed by an
+adjacent `∀` permutation.  In the representative instance,
+
+$$
+\neg\Bigl(
+  \forall X.\,\forall Y.\,X\to Y
+  \mathrel{\sqsubseteq}
+  \forall Y.\,\forall X.\,X\to Y
+\Bigr).
+$$
+
+They are related only by quotient imprecision:
+
+$$
+\forall X.\,\forall Y.\,X\to Y
+\mathrel{\sqsubseteq^\forall}
+\forall Y.\,\forall X.\,X\to Y.
+$$
+
+Consequently, constructing the second same-polarity function cast would
+already require a quotient-to-quotient cast rule at the top of the proposed
+simulation square.  The top terms are not ordinarily related, so their common
+reduction endpoint cannot refute the smaller relation.
+
+The useful lesson is a reachability condition: a stress test counts only when
+its top row is derivable by the proposed public relation.  An isolated
+reduct that needs a larger auxiliary relation is only an expressiveness
+example for that larger relation.
+
+## Cast-sequence reduction
+
+The source sequence rule has the form
+
+$$
+V\langle (G\,?);g\rangle
+\longrightarrow
+V\langle G\,?\rangle\langle g\rangle.
+$$
+
+In the reachable quotient case, the whole sequence need not become a
+two-element narrowing spine.  The active untag prefix is absorbed by an
+ordinary one-sided cast rule, leaving exactly one paired narrowing:
+
+$$
+\begin{aligned}
+V &\mathrel{\sqsubseteq} V'\\
+V\langle G\,?\rangle
+  &\mathrel{\sqsubseteq} V'\\
+V\langle G\,?\rangle\langle g\rangle
+  &\mathrel{\sqsubseteq^\forall}
+    V'\langle g'\rangle\\
+\bigl(V\langle G\,?\rangle\langle g\rangle\bigr)
+  \langle u\rangle
+  &\mathrel{\sqsubseteq}
+    \bigl(V'\langle g'\rangle\bigr)\langle u'\rangle.
+\end{aligned}
+$$
+
+The strict source `β-seq` proof already performs this factorization.  Its
+seal-tail alternative is impossible in the relevant narrowing case.  The
+remaining target sequence root occurs in the closing widening and belongs to
+target-tail resumption; it is not evidence for a finite narrowing spine.
+
+## Substitution boundary
+
+Only the ordinary relation has a substitution theorem:
+
+$$
+\frac{
+  N \mathrel{\sqsubseteq_{p_B}} N'
+  \text{ under }
+  x : A \mathrel{\sqsubseteq_{p_A}} A'
+  \qquad
+  W \mathrel{\sqsubseteq_{p_A}} W'
+}{
+  N[W/x]
+  \mathrel{\sqsubseteq_{p_B}}
+  N'[W'/x]
+}.
+$$
+
+There is intentionally no substitution theorem whose argument premise is
+quotient imprecision.  The operational hypothesis must therefore ensure that
+the paired widening closes the quotient before an ordinary substitution
+lemma is needed.
+
+The checked two-function example verifies substitution through an arbitrary
+related body after both down/up round trips have closed.  It does not yet
+prove that every function-cast beta case reaches such a closed argument before
+substitution.  That is the decisive `sim-beta-cast` obligation.
+
+The GTLC proof suggests the right proof shape: peel the function cast, catch up
+the casted argument, recurse on the underlying function application, and
+restore the result cast.  In GTSF, the recursion must additionally transport
+an active `inst` through any allocation before using the closing widening.
+
+## Proposed proof interface
+
+The design should be accepted only if the following source and target
+simulation statements can be proved using the two term judgments above:
+
+$$
+\begin{aligned}
+M \mathrel{\sqsubseteq_p} M'
+\;\land\;
+M \longrightarrow M_1
+\quad\Longrightarrow\quad
+\exists N,N'.\;&
+M_1 \longrightarrow^* N\\
+&{}\land M' \longrightarrow^* N'\\
+&{}\land N \mathrel{\sqsubseteq_p} N',
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+M \mathrel{\sqsubseteq_p} M'
+\;\land\;
+M' \longrightarrow M'_1
+\quad\Longrightarrow\quad
+\exists N,N'.\;&
+M \longrightarrow^* N\\
+&{}\land M'_1 \longrightarrow^* N'\\
+&{}\land N \mathrel{\sqsubseteq_p} N'.
+\end{aligned}
+$$
+
+The store-changing version replaces the displayed terms, types, and indices
+by their transported forms.  It should not change where quotient imprecision
+may occur.
+
+The critical supporting results are:
+
+1. inversion showing that every quotient term has one ordinary base and one
+   paired narrowing;
+2. source and target typing projections for both judgments;
+3. factorization of narrowing cast sequences into an ordinary prefix and one
+   quotient-producing tail;
+4. allocation-aware catch-up for a quotient closing widening whose target
+   performs `inst`;
+5. function-cast beta simulation following the GTLC peel/catch-up/recurse/
+   restore pattern;
+6. ordinary substitution after the recursive catch-up has closed the
+   quotient.
+
+## Decision criterion
+
+The current evidence supports the one-boundary hypothesis:
+
+- the alternating two-function-cast example is derivable and reaches an
+  ordinary-related endpoint;
+- the endpoint can be substituted into arbitrary ordinarily related bodies;
+- the reachable source cast-sequence case factors to one boundary;
+- the apparent two-narrowing counterexample has no derivable ordinary top
+  row.
+
+The hypothesis is not proved.  The active target `inst` path and the general
+function-cast beta case remain open.
+
+If those proofs succeed, the live quotient application rules and
+`down·up⊑down·upᵀ` should be derived or removed, not retained as primitive
+shortcuts.  If a derivable ordinary top row is found whose reductions can join
+only with quotient imprecision trapped under application or substitution,
+that will be a genuine counterexample.  Only then should the larger
+compositional quotient relation, finite spines, or quotient congruence be
+reconsidered.

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -220,7 +220,7 @@ $$
   q[
     0 \mapsto {\uparrow A}
     \mathrel{\sqsubseteq_{\operatorname{lift}(p_A)}}
-    {\uparrow A'} \mapsfrom 0
+    {\uparrow A'} \leftarrow 0
   ]^P
   \doteq
   \operatorname{lift}_{\forall}(p)
@@ -509,7 +509,7 @@ $$
   p[
     \alpha\mapsto X
     \mathrel{\sqsubseteq_{p_X}}
-    X'\mapsfrom\beta
+    X'\leftarrow\beta
   ]^P
   \doteq q
 }{
@@ -540,7 +540,7 @@ $$
   q[
     \alpha\mapsto X
     \mathrel{\sqsubseteq_{p_X}}
-    X'\mapsfrom\beta
+    X'\leftarrow\beta
   ]^P
   \doteq p
 }{

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -477,6 +477,53 @@ constructor.  Removing even that exact creation case would require changing
 the simulation conclusion to a creation-saturated relation; that merely moves
 the same semantic case out of ordinary term imprecision.
 
+### Candidate exact creation rule
+
+The proposed constructor has the following mathematically relevant premises.
+First, before allocation the bodies are related under a matched binder:
+
+$$
+((0\mathrel{\sqsubseteq}0)::\mathord{\uparrow}\Phi)\mathbin{;}\operatorname{suc}(\Delta_L)\mathbin{;}\operatorname{suc}(\Delta_R)\mathbin{;}\rho_{\forall}\ \vdash\ W\mathrel{\sqsubseteq_q}W' : D\mathrel{\sqsubseteq}C .
+$$
+
+The target has an inert widening instantiation:
+
+$$
+\mathsf{inst}\ B\ s : \forall C\longrightarrow B .
+$$
+
+The matched universal index and the target instantiation shape compose to the
+outer source-only index:
+
+$$
+\left\lfloor\forall^{\,i}q\right\rfloor\mathbin{;}\left\lfloor\mathsf{inst}\ B\ s\right\rfloor\mathrel{\cong}\left\lfloor p\right\rfloor .
+$$
+
+Here the outer index has the required source-only universal:
+
+$$
+p : \Phi\mathbin{;}\Delta_L\ \vdash\ \forall D\mathrel{\sqsubseteq}B\ \dashv\Delta_R .
+$$
+
+The matched body store and final right-only store must arise from the same
+pre-allocation store:
+
+$$
+\rho_0\mathrel{\preccurlyeq}\rho^+,\qquad \rho_0\xrightarrow{\,0\mathrel{\sqsubseteq}0\,}\rho_{\forall},\qquad \rho^+\xrightarrow{\,\mathord{\uparrow_R}\,}\rho_R^+ .
+$$
+
+Then the exact post-allocation conclusion is:
+
+$$
+\mathord{\uparrow_R}\Phi\mathbin{;}\Delta_L\mathbin{;}\operatorname{suc}(\Delta_R)\mathbin{;}(\mathsf{right}\ 0\ \star)::\rho_R^+\ \vdash\ \Lambda W\mathrel{\sqsubseteq_{\mathord{\uparrow_R}p}}W'\langle s\rangle : \forall D\mathrel{\sqsubseteq}\mathord{\uparrow}B .
+$$
+
+The Agda constructor must also receive the routine value, no-bullet, cast-mode,
+and endpoint-typing evidence needed by the intrinsically indexed judgment.
+Unlike `Λ⊑instβᵀ`, it should not receive arbitrary renamings, an arbitrary
+store embedding, endpoint equalities, closure witnesses, or an arbitrary final
+index. Those operations should be admissibility lemmas over this exact rule.
+
 Thus a matched `ν` rule can consume only `∀ⁱ`, while a source-only `ν` rule
 can consume only `ν`.  A derivation cannot silently remove on the left a
 universal quantifier that was matched with a universal quantifier on the

--- a/GTSF/proof/EndpointMLB/Core/MLBGlbExample.agda
+++ b/GTSF/proof/EndpointMLB/Core/MLBGlbExample.agda
@@ -41,7 +41,7 @@ glb-lower-XY⊑A :
   idᵢ zero ∣ zero ⊢ glb-lower-XY ⊑ glb-bad-A ⊣ zero
 glb-lower-XY⊑A =
   ∀ⁱ
-    (ν refl
+    (ν nonvar-fun refl
       ( idˣ (there (here refl)) (s<s z<s) z<s
       ↦ tagˣ (here refl) z<s
       ))
@@ -49,7 +49,7 @@ glb-lower-XY⊑A =
 glb-lower-XY⊑B :
   idᵢ zero ∣ zero ⊢ glb-lower-XY ⊑ glb-bad-B ⊣ zero
 glb-lower-XY⊑B =
-  ν refl
+  ν nonvar-all refl
     (∀ⁱ
       ( tagˣ (there (here refl)) (s<s z<s)
       ↦ idˣ (here refl) z<s z<s
@@ -58,7 +58,7 @@ glb-lower-XY⊑B =
 glb-lower-YX⊑A :
   idᵢ zero ∣ zero ⊢ glb-lower-YX ⊑ glb-bad-A ⊣ zero
 glb-lower-YX⊑A =
-  ν refl
+  ν nonvar-all refl
     (∀ⁱ
       ( idˣ (here refl) z<s z<s
       ↦ tagˣ (there (here refl)) (s<s z<s)
@@ -68,7 +68,7 @@ glb-lower-YX⊑B :
   idᵢ zero ∣ zero ⊢ glb-lower-YX ⊑ glb-bad-B ⊣ zero
 glb-lower-YX⊑B =
   ∀ⁱ
-    (ν refl
+    (ν nonvar-fun refl
       ( tagˣ (here refl) z<s
       ↦ idˣ (there (here refl)) (s<s z<s) z<s
       ))

--- a/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetUniversalFusionSpineDef.agda
+++ b/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetUniversalFusionSpineDef.agda
@@ -8,6 +8,8 @@ module
 --     to paired-lambda frame closing.
 --   * Permits ordinary paired-lambda frames around the pure base and around
 --     every recursively nested target-instantiation fusion step.
+--   * Retains equality between every fused step's ambient final index and
+--     the canonical transported creation index.
 --   * States only the fold back to quotiented term imprecision; extraction
 --     and non-fusion residual routing remain separate boundaries.
 --   * Contains no simulation result, implementation, postulate, hole,
@@ -19,6 +21,7 @@ import Coercions as C
 open import Data.List using ([]; _∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (suc; zero)
+open import Relation.Binary.PropositionalEquality using (sym)
 open import Imprecision using
   ( ImpCtx
   ; _ˣ⊑ˣ_
@@ -59,7 +62,11 @@ open import
   using (TyRenameWf)
 open import
   proof.EndpointMLB.Core.MaximalLowerBoundsWf
-  using (rename-assm²ᵢ)
+  using
+  ( rename-assm²ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-target-lift-rightᵢ
+  )
 open import
   proof.PairedLambda.FrameClosing.Target.NuImprecisionPairedLambdaTargetClosingFrameViewDef
   using (PairedLambdaTargetClosingFrames)
@@ -141,9 +148,12 @@ data PairedLambdaTargetUniversalFusionSpine
       (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ₁ →
     renameᵗᵐ τ (Λ W) ≡ M →
     renameᵗᵐ σ (W′ ⟨ C.`∀ c ⟩) ≡ M′ →
-    renameᵗ τ (`∀ D) ≡ A →
-    renameᵗ σ (⇑ᵗ (`∀ E)) ≡ `∀ H →
+    (source-type-eq : renameᵗ τ (`∀ D) ≡ A) →
+    (target-type-eq : renameᵗ σ (⇑ᵗ (`∀ E)) ≡ `∀ H) →
     (p : Φ ∣ Δᴸ ⊢ A ⊑ `∀ H ⊣ Δᴿ) →
+    ⊑-rename-at²ᵢ assm hτ hσ
+      (sym source-type-eq) (sym target-type-eq)
+      (⊑-target-lift-rightᵢ f) ≡ p →
     Value M →
     No• M →
     Closedᵐ M →

--- a/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetUniversalFusionSpineProof.agda
+++ b/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetUniversalFusionSpineProof.agda
@@ -60,6 +60,7 @@ paired-lambda-target-universal-fusion-spine-relation-proofᵀ
       vW noW vW′ noW′ inert tail f inst-shape creation-square
       assm hτ hσ store-emb
       source-eq target-eq source-type-eq target-type-eq p
+      canonical-index
       final-v final-no final-closed
       final-v′ final-no′ final-closed′
       source-typing target-typing frames) =

--- a/GTSF/proof/Quotient/NuImprecisionCambridge26Example14Experiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionCambridge26Example14Experiment.agda
@@ -1,0 +1,753 @@
+module
+  proof.Quotient.NuImprecisionCambridge26Example14Experiment
+  where
+
+-- File Charter:
+--   * Tests the complete smaller term-imprecision relation on Cambridge26
+--     Example 14: instantiation/generalization repeated twice.
+--   * Constructs the exact initial relation using only ordinary one-sided
+--     cast rules, matched `ν`, application, and constants.
+--   * Tests the allocation-heavy reduction square separately from the top
+--     edge; no example-specific term-imprecision constructor is introduced.
+--   * Imports no live term-imprecision judgment and contains no postulate,
+--     hole, permissive option, termination bypass, or catch-all clause.
+
+open import Agda.Builtin.Equality using (refl)
+open import CastImprecisionShape using
+  ( shape-fun
+  ; shape-gen
+  ; shape-inst
+  ; shape-seal
+  ; shape-tag-var
+  ; shape-unseal
+  ; shape-untag-var
+  )
+import Coercions as C
+open C using (_!; _？)
+open import Conversion using
+  (RevealConversion; conceal-seal; reveal-fun; reveal-unseal)
+open import ConversionIndexCompatibility using
+  ( _[_↦_⊑⟨_⟩_↤_]ᴾ_
+  ; replace-paired-function
+  ; replace-paired-variables
+  )
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here)
+open import Data.Nat using (suc; zero; z<s)
+open import Data.Product using (_,_)
+open import Imprecision using (_ˣ⊑★; _ˣ⊑ˣ_)
+open import ImprecisionComposition using
+  ( comp-idˣ-tagˣ
+  ; comp-↦-↦
+  ; comp-∀-ν
+  )
+open import ImprecisionWf using
+  ( _↦_
+  ; _∣_⊢_⊑_⊣_
+  ; idι
+  ; idˣ
+  ; tagˣ
+  ; ∀ⁱ_
+  ; ν
+  )
+import NarrowWiden as NW
+open import NarrowWiden using
+  (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
+open import NuTermImprecision using
+  ( ctx-imp
+  ; lift-ctx-[]
+  ; lift-store-[]
+  ; StoreImp
+  ; seal★-tag-or-id
+  ; store-matched
+  ; store-right
+  )
+open import NuTerms using
+  ( No•
+  ; Term
+  ; Value
+  ; no•-`
+  ; no•-ƛ
+  ; no•-Λ
+  ; no•-$
+  ; no•-⟨⟩
+  ; `_
+  ; ƛ_
+  ; Λ_
+  ; ν
+  ; _·_
+  ; _⟨_⟩
+  ; $
+  )
+open import NuReduction using
+  ( bind
+  ; keep
+  ; pure-step
+  ; β
+  ; β-gen•
+  ; β-inst
+  ; β-Λ•
+  ; β-↦
+  ; seal-unseal
+  ; tag-untag-ok
+  ; ν-step
+  ; ξ-⟨⟩
+  ; ↠-refl
+  ; ↠-step
+  ; _—↠[_]_
+  )
+open import Primitives using (κℕ)
+open import TermTyping using (cast-tag-or-id)
+open import Types using
+  ( wfBase
+  ; wf★
+  ; wf⇒
+  ; wfVar
+  ; ★
+  ; ‵_
+  ; ＇_
+  ; _⇒_
+  ; `∀
+  )
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using (⊑-lift∀ᵢ; ⊑-target-lift-rightᵢ)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+open import proof.Core.Properties.ReductionProperties using
+  (cast-↠; ν-↠; ·₁-↠; ↠-trans)
+
+
+private
+  I : Term
+  I = ƛ (` zero)
+
+  vI : Value I
+  vI = ƛ (` zero)
+
+  noI : No• I
+  noI = no•-ƛ no•-`
+
+  F = ＇ zero ⇒ ＇ zero
+
+  H = ★ ⇒ ★
+
+  pX :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ⊢ ＇ zero ⊑ ＇ zero ⊣ suc zero
+  pX = idˣ (here refl) z<s z<s
+
+  pF :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ⊢ F ⊑ F ⊣ suc zero
+  pF = pX ↦ pX
+
+  p∀F :
+    [] ∣ zero ⊢ `∀ F ⊑ `∀ F ⊣ zero
+  p∀F = ∀ⁱ pF
+
+  pX★ :
+    ((zero ˣ⊑★) ∷ [])
+      ∣ suc zero ⊢ ＇ zero ⊑ ★ ⊣ zero
+  pX★ = tagˣ (here refl) z<s
+
+  pFH :
+    ((zero ˣ⊑★) ∷ [])
+      ∣ suc zero ⊢ F ⊑ H ⊣ zero
+  pFH = pX★ ↦ pX★
+
+  p∀H :
+    [] ∣ zero ⊢ `∀ F ⊑ H ⊣ zero
+  p∀H = ν Imprecision.nonvar-fun refl pFH
+
+  inst-body-at : Data.Nat.ℕ → C.Coercion
+  inst-body-at α =
+    C.seal ★ α C.↦ C.unseal α ★
+
+  gen-body-at : Data.Nat.ℕ → C.Coercion
+  gen-body-at α =
+    ((＇ α) !) C.↦ ((＇ α) ？)
+
+  inst-body : C.Coercion
+  inst-body = inst-body-at zero
+
+  gen-body : C.Coercion
+  gen-body = gen-body-at zero
+
+  inst-cast : C.Coercion
+  inst-cast =
+    C.inst H inst-body
+
+  gen-cast : C.Coercion
+  gen-cast =
+    C.gen H gen-body
+
+  inst-cast-typing :
+    C.tag-or-idᵈ ∣ zero ∣ []
+      ⊢ inst-cast ∶ `∀ F ⊑ H
+  inst-cast-typing =
+    C.cast-inst (wf⇒ wf★ wf★) refl
+      (C.cast-fun
+        (C.cast-seal wf★ (here refl) refl)
+        (C.cast-unseal wf★ (here refl) refl)) ,
+    NW.inst
+      (NW.safe-fun
+        (NW.sealⁿ ★ zero)
+        (NW.unsealʷ zero ★))
+
+  gen-cast-typing :
+    C.tag-or-idᵈ ∣ zero ∣ []
+      ⊢ gen-cast ∶ H ⊒ `∀ F
+  gen-cast-typing =
+    C.cast-gen (wf⇒ wf★ wf★) refl
+      (C.cast-fun
+        (C.cast-tag (wfVar z<s) (＇ zero) refl)
+        (C.cast-untag (wfVar z<s) (＇ zero) refl)) ,
+    NW.gen
+      (NW.safe-fun
+        (NW.tag (＇ zero))
+        (NW.untag (＇ zero)))
+
+  cast-index-composition =
+    comp-∀-ν
+      (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-tagˣ)
+
+  polymorphic-identityᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ Λ I ⊑ Λ I
+      ⦂ `∀ F ⊑ `∀ F ∶ p∀F
+  polymorphic-identityᴿ =
+    Λ⊑Λᴿ lift-store-[] lift-ctx-[]
+      vI vI
+      (ƛ⊑ƛᴿ (wfVar z<s) (wfVar z<s)
+        (x⊑xᴿ Types.Z))
+
+  one-instᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ Λ I ⊑ (Λ I) ⟨ inst-cast ⟩
+      ⦂ `∀ F ⊑ H ∶ p∀H
+  one-instᴿ =
+    ⊑cast⊑ᴿ cast-tag-or-id seal★-tag-or-id
+      inst-cast-typing polymorphic-identityᴿ p∀H
+      (shape-inst (shape-fun shape-seal shape-unseal))
+      cast-index-composition
+
+  one-round-tripᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ Λ I
+        ⊑ ((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩
+      ⦂ `∀ F ⊑ `∀ F ∶ p∀F
+  one-round-tripᴿ =
+    ⊑cast⊒ᴿ cast-tag-or-id seal★-tag-or-id
+      gen-cast-typing one-instᴿ p∀F
+      (shape-gen (shape-fun shape-tag-var shape-untag-var))
+      cast-index-composition
+
+  two-instᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ Λ I
+        ⊑
+          (((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+            ⟨ inst-cast ⟩
+      ⦂ `∀ F ⊑ H ∶ p∀H
+  two-instᴿ =
+    ⊑cast⊑ᴿ cast-tag-or-id seal★-tag-or-id
+      inst-cast-typing one-round-tripᴿ p∀H
+      (shape-inst (shape-fun shape-seal shape-unseal))
+      cast-index-composition
+
+  two-round-tripsᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ Λ I
+        ⊑
+          ((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+            ⟨ inst-cast ⟩) ⟨ gen-cast ⟩
+      ⦂ `∀ F ⊑ `∀ F ∶ p∀F
+  two-round-tripsᴿ =
+    ⊑cast⊒ᴿ cast-tag-or-id seal★-tag-or-id
+      gen-cast-typing two-instᴿ p∀F
+      (shape-gen (shape-fun shape-tag-var shape-untag-var))
+      cast-index-composition
+
+  one-inst-trace :
+    (Λ I) ⟨ inst-cast ⟩
+      —↠[ keep ∷ bind ★ ∷ keep ∷ [] ]
+    I ⟨ inst-body-at zero ⟩
+  one-inst-trace =
+    ↠-step (pure-step (β-inst (Λ vI)))
+      (↠-step
+        (ν-step (Λ vI) (no•-Λ noI))
+        (↠-step
+          (ξ-⟨⟩ (pure-step (β-Λ• vI)))
+          ↠-refl))
+
+  first-round-value :
+    Value ((I ⟨ inst-body-at zero ⟩) ⟨ gen-cast ⟩)
+  first-round-value =
+    (vI ⟨ C.seal ★ zero C.↦ C.unseal zero ★ ⟩)
+      ⟨ C.gen H gen-body ⟩
+
+  first-round-no-bullet :
+    No• ((I ⟨ inst-body-at zero ⟩) ⟨ gen-cast ⟩)
+  first-round-no-bullet =
+    no•-⟨⟩ (no•-⟨⟩ noI)
+
+  second-inst-trace :
+    (((I ⟨ inst-body-at zero ⟩) ⟨ gen-cast ⟩)
+      ⟨ inst-cast ⟩)
+      —↠[ keep ∷ bind ★ ∷ keep ∷ [] ]
+    ((I ⟨ inst-body-at (suc zero) ⟩)
+      ⟨ gen-body-at zero ⟩) ⟨ inst-body-at zero ⟩
+  second-inst-trace =
+    ↠-step (pure-step (β-inst first-round-value))
+      (↠-step
+        (ν-step first-round-value first-round-no-bullet)
+        (↠-step
+          (ξ-⟨⟩
+            (pure-step
+              (β-gen•
+                (vI
+                  ⟨ C.seal ★ (suc zero)
+                    C.↦ C.unseal (suc zero) ★ ⟩))))
+          ↠-refl))
+
+  two-round-trips-value-trace :
+    ((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+      ⟨ inst-cast ⟩) ⟨ gen-cast ⟩
+      —↠[
+        keep ∷ bind ★ ∷ keep ∷
+        keep ∷ bind ★ ∷ keep ∷ []
+      ]
+    (((I ⟨ inst-body-at (suc zero) ⟩)
+      ⟨ gen-body-at zero ⟩)
+      ⟨ inst-body-at zero ⟩) ⟨ gen-cast ⟩
+  two-round-trips-value-trace =
+    ↠-trans
+      (cast-↠ (cast-↠ (cast-↠ one-inst-trace)))
+      (cast-↠ second-inst-trace)
+
+  pι :
+    [] ∣ zero
+      ⊢ ‵ Types.`ℕ ⊑ ‵ Types.`ℕ ⊣ zero
+  pι =
+    idι {ι = Types.`ℕ}
+
+  pι⇒ι :
+    [] ∣ zero
+      ⊢ (‵ Types.`ℕ ⇒ ‵ Types.`ℕ)
+        ⊑ (‵ Types.`ℕ ⇒ ‵ Types.`ℕ)
+      ⊣ zero
+  pι⇒ι =
+    pι ↦ pι
+
+  reveal-ι : C.Coercion
+  reveal-ι =
+    C.seal (‵ Types.`ℕ) zero
+      C.↦ C.unseal zero (‵ Types.`ℕ)
+
+  reveal-ι-conversion :
+    RevealConversion C.seal-or-idᵈ (suc zero)
+      ((zero , ‵ Types.`ℕ) ∷ [])
+      zero (‵ Types.`ℕ) reveal-ι
+      F (‵ Types.`ℕ ⇒ ‵ Types.`ℕ)
+  reveal-ι-conversion =
+    reveal-fun
+      (conceal-seal wfBase (here refl) refl)
+      (reveal-unseal wfBase (here refl) refl)
+
+  reveal-ι-replacement :
+    pF
+      [ zero ↦ ‵ Types.`ℕ
+      ⊑⟨ ⊑-lift∀ᵢ pι ⟩
+      ‵ Types.`ℕ ↤ zero ]ᴾ
+    ⊑-lift∀ᵢ pι⇒ι
+  reveal-ι-replacement =
+    replace-paired-function
+      (replace-paired-variables refl)
+      (replace-paired-variables refl)
+
+  two-round-trips-value :
+    Value
+      ((((I ⟨ inst-body-at (suc zero) ⟩)
+        ⟨ gen-body-at zero ⟩)
+        ⟨ inst-body-at zero ⟩) ⟨ gen-cast ⟩)
+  two-round-trips-value =
+    (((vI
+      ⟨ C.seal ★ (suc zero)
+        C.↦ C.unseal (suc zero) ★ ⟩)
+      ⟨ ((＇ zero) !) C.↦ ((＇ zero) ？) ⟩)
+      ⟨ C.seal ★ zero C.↦ C.unseal zero ★ ⟩)
+      ⟨ C.gen H gen-body ⟩
+
+  two-round-trips-no-bullet :
+    No•
+      ((((I ⟨ inst-body-at (suc zero) ⟩)
+        ⟨ gen-body-at zero ⟩)
+        ⟨ inst-body-at zero ⟩) ⟨ gen-cast ⟩)
+  two-round-trips-no-bullet =
+    no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noI)))
+
+  simple-ν-function-trace :
+    ν (‵ Types.`ℕ) (Λ I) reveal-ι
+      —↠[ bind (‵ Types.`ℕ) ∷ keep ∷ [] ]
+    I ⟨ reveal-ι ⟩
+  simple-ν-function-trace =
+    ↠-step
+      (ν-step (Λ vI) (no•-Λ noI))
+      (↠-step
+        (ξ-⟨⟩ (pure-step (β-Λ• vI)))
+        ↠-refl)
+
+  complex-ν-function-trace :
+    ν (‵ Types.`ℕ)
+      (((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+        ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+      reveal-ι
+      —↠[
+        keep ∷ bind ★ ∷ keep ∷
+        keep ∷ bind ★ ∷ keep ∷
+        bind (‵ Types.`ℕ) ∷ keep ∷ []
+      ]
+    ((((I ⟨ inst-body-at (suc (suc zero)) ⟩)
+      ⟨ gen-body-at (suc zero) ⟩)
+      ⟨ inst-body-at (suc zero) ⟩)
+      ⟨ gen-body-at zero ⟩) ⟨ reveal-ι ⟩
+  complex-ν-function-trace =
+    ↠-trans
+      (ν-↠ two-round-trips-value-trace)
+      (↠-step
+        (ν-step two-round-trips-value
+          two-round-trips-no-bullet)
+        (↠-step
+          (ξ-⟨⟩
+            (pure-step
+              (β-gen•
+                (((vI
+                  ⟨ C.seal ★ (suc (suc zero))
+                    C.↦ C.unseal (suc (suc zero)) ★ ⟩)
+                  ⟨ ((＇ (suc zero)) !)
+                    C.↦ ((＇ (suc zero)) ？) ⟩)
+                  ⟨ C.seal ★ (suc zero)
+                    C.↦ C.unseal (suc zero) ★ ⟩))))
+          ↠-refl))
+
+  simple-function-application-trace :
+    (I ⟨ reveal-ι ⟩) · $ (κℕ zero)
+      —↠[ keep ∷ keep ∷ keep ∷ [] ]
+    $ (κℕ zero)
+  simple-function-application-trace =
+    ↠-step
+      (pure-step (β-↦ vI ($ (κℕ zero))))
+      (↠-step
+        (ξ-⟨⟩
+          (pure-step
+            (β
+              (($ (κℕ zero))
+                ⟨ C.seal (‵ Types.`ℕ) zero ⟩))))
+        (↠-step
+          (pure-step (seal-unseal ($ (κℕ zero))))
+          ↠-refl))
+
+  complex-function-application-trace :
+    (((((I ⟨ inst-body-at (suc (suc zero)) ⟩)
+      ⟨ gen-body-at (suc zero) ⟩)
+      ⟨ inst-body-at (suc zero) ⟩)
+      ⟨ gen-body-at zero ⟩) ⟨ reveal-ι ⟩)
+      · $ (κℕ zero)
+      —↠[
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ []
+      ]
+    (((((((((($ (κℕ zero))
+      ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+      ⟨ (＇ zero) ! ⟩)
+      ⟨ C.seal ★ (suc zero) ⟩)
+      ⟨ (＇ (suc zero)) ! ⟩)
+      ⟨ C.seal ★ (suc (suc zero)) ⟩)
+      ⟨ C.unseal (suc (suc zero)) ★ ⟩)
+      ⟨ (＇ (suc zero)) ？ ⟩)
+      ⟨ C.unseal (suc zero) ★ ⟩)
+      ⟨ (＇ zero) ？ ⟩)
+      ⟨ C.unseal zero (‵ Types.`ℕ) ⟩
+  complex-function-application-trace =
+    ↠-step
+      (pure-step
+        (β-↦
+          ((((vI
+            ⟨ C.seal ★ (suc (suc zero))
+              C.↦ C.unseal (suc (suc zero)) ★ ⟩)
+            ⟨ ((＇ (suc zero)) !)
+              C.↦ ((＇ (suc zero)) ？) ⟩)
+            ⟨ C.seal ★ (suc zero)
+              C.↦ C.unseal (suc zero) ★ ⟩)
+            ⟨ ((＇ zero) !) C.↦ ((＇ zero) ？) ⟩)
+          ($ (κℕ zero))))
+      (↠-step
+        (ξ-⟨⟩
+          (pure-step
+            (β-↦
+              (((vI
+                ⟨ C.seal ★ (suc (suc zero))
+                  C.↦ C.unseal (suc (suc zero)) ★ ⟩)
+                ⟨ ((＇ (suc zero)) !)
+                  C.↦ ((＇ (suc zero)) ？) ⟩)
+                ⟨ C.seal ★ (suc zero)
+                  C.↦ C.unseal (suc zero) ★ ⟩)
+              (($ (κℕ zero))
+                ⟨ C.seal (‵ Types.`ℕ) zero ⟩))))
+        (↠-step
+          (ξ-⟨⟩
+            (ξ-⟨⟩
+              (pure-step
+                (β-↦
+                  ((vI
+                    ⟨ C.seal ★ (suc (suc zero))
+                      C.↦ C.unseal (suc (suc zero)) ★ ⟩)
+                    ⟨ ((＇ (suc zero)) !)
+                      C.↦ ((＇ (suc zero)) ？) ⟩)
+                  ((($ (κℕ zero))
+                    ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+                    ⟨ (＇ zero) ! ⟩)))))
+          (↠-step
+            (ξ-⟨⟩
+              (ξ-⟨⟩
+                (ξ-⟨⟩
+                  (pure-step
+                    (β-↦
+                      (vI
+                        ⟨ C.seal ★ (suc (suc zero))
+                          C.↦ C.unseal
+                            (suc (suc zero)) ★ ⟩)
+                      (((($ (κℕ zero))
+                        ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+                        ⟨ (＇ zero) ! ⟩)
+                        ⟨ C.seal ★ (suc zero) ⟩))))))
+            (↠-step
+              (ξ-⟨⟩
+                (ξ-⟨⟩
+                  (ξ-⟨⟩
+                    (ξ-⟨⟩
+                      (pure-step
+                        (β-↦ vI
+                          ((((($ (κℕ zero))
+                            ⟨ C.seal
+                              (‵ Types.`ℕ) zero ⟩)
+                            ⟨ (＇ zero) ! ⟩)
+                            ⟨ C.seal ★ (suc zero) ⟩)
+                            ⟨ (＇ (suc zero)) ! ⟩)))))))
+              (↠-step
+                (ξ-⟨⟩
+                  (ξ-⟨⟩
+                    (ξ-⟨⟩
+                      (ξ-⟨⟩
+                        (ξ-⟨⟩
+                          (pure-step
+                            (β
+                              (((((($ (κℕ zero))
+                                ⟨ C.seal
+                                  (‵ Types.`ℕ) zero ⟩)
+                                ⟨ (＇ zero) ! ⟩)
+                                ⟨ C.seal ★ (suc zero) ⟩)
+                                ⟨ (＇ (suc zero)) ! ⟩)
+                                ⟨ C.seal ★
+                                  (suc (suc zero)) ⟩))))))))
+                ↠-refl)))))
+
+  complex-cast-cancellation-trace :
+    (((((((((($ (κℕ zero))
+      ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+      ⟨ (＇ zero) ! ⟩)
+      ⟨ C.seal ★ (suc zero) ⟩)
+      ⟨ (＇ (suc zero)) ! ⟩)
+      ⟨ C.seal ★ (suc (suc zero)) ⟩)
+      ⟨ C.unseal (suc (suc zero)) ★ ⟩)
+      ⟨ (＇ (suc zero)) ？ ⟩)
+      ⟨ C.unseal (suc zero) ★ ⟩)
+      ⟨ (＇ zero) ？ ⟩)
+      ⟨ C.unseal zero (‵ Types.`ℕ) ⟩
+      —↠[ keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ [] ]
+    $ (κℕ zero)
+  complex-cast-cancellation-trace =
+    ↠-step
+      (ξ-⟨⟩
+        (ξ-⟨⟩
+          (ξ-⟨⟩
+            (ξ-⟨⟩
+              (pure-step
+                (seal-unseal
+                  ((((($ (κℕ zero))
+                    ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+                    ⟨ (＇ zero) ! ⟩)
+                    ⟨ C.seal ★ (suc zero) ⟩)
+                    ⟨ (＇ (suc zero)) ! ⟩)))))))
+      (↠-step
+        (ξ-⟨⟩
+          (ξ-⟨⟩
+            (ξ-⟨⟩
+              (pure-step
+                (tag-untag-ok
+                  (((($ (κℕ zero))
+                    ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+                    ⟨ (＇ zero) ! ⟩)
+                    ⟨ C.seal ★ (suc zero) ⟩))))))
+        (↠-step
+          (ξ-⟨⟩
+            (ξ-⟨⟩
+              (pure-step
+                (seal-unseal
+                  ((($ (κℕ zero))
+                    ⟨ C.seal (‵ Types.`ℕ) zero ⟩)
+                    ⟨ (＇ zero) ! ⟩)))))
+          (↠-step
+            (ξ-⟨⟩
+              (pure-step
+                (tag-untag-ok
+                  (($ (κℕ zero))
+                    ⟨ C.seal (‵ Types.`ℕ) zero ⟩))))
+            (↠-step
+              (pure-step (seal-unseal ($ (κℕ zero))))
+              ↠-refl))))
+
+  complex-function-complete-trace :
+    (((((I ⟨ inst-body-at (suc (suc zero)) ⟩)
+      ⟨ gen-body-at (suc zero) ⟩)
+      ⟨ inst-body-at (suc zero) ⟩)
+      ⟨ gen-body-at zero ⟩) ⟨ reveal-ι ⟩)
+      · $ (κℕ zero)
+      —↠[
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ []
+      ]
+    $ (κℕ zero)
+  complex-function-complete-trace =
+    ↠-trans
+      complex-function-application-trace
+      complex-cast-cancellation-trace
+
+  simple-program-trace :
+    (ν (‵ Types.`ℕ) (Λ I) reveal-ι) · $ (κℕ zero)
+      —↠[
+        bind (‵ Types.`ℕ) ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ []
+      ]
+    $ (κℕ zero)
+  simple-program-trace =
+    ↠-trans
+      (·₁-↠ no•-$ simple-ν-function-trace)
+      simple-function-application-trace
+
+  complex-program-trace :
+    (ν (‵ Types.`ℕ)
+      (((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+        ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+      reveal-ι) · $ (κℕ zero)
+      —↠[
+        keep ∷ bind ★ ∷ keep ∷
+        keep ∷ bind ★ ∷ keep ∷
+        bind (‵ Types.`ℕ) ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ []
+      ]
+    $ (κℕ zero)
+  complex-program-trace =
+    ↠-trans
+      (·₁-↠ no•-$ complex-ν-function-trace)
+      complex-function-complete-trace
+
+  result-pι :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero
+      ⊢ ‵ Types.`ℕ ⊑ ‵ Types.`ℕ
+      ⊣ suc (suc (suc zero))
+  result-pι =
+    ⊑-lift∀ᵢ
+      (⊑-target-lift-rightᵢ
+        (⊑-target-lift-rightᵢ pι))
+
+  example14-result-store :
+    StoreImp ((zero ˣ⊑ˣ zero) ∷ [])
+      (suc zero) (suc (suc (suc zero)))
+  example14-result-store =
+    store-matched zero (‵ Types.`ℕ)
+      zero (‵ Types.`ℕ) result-pι ∷
+    store-right (suc zero) ★ wf★ ∷
+    store-right (suc (suc zero)) ★ wf★ ∷
+    []
+
+  example14-functionsᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ ν (‵ Types.`ℕ) (Λ I) reveal-ι
+        ⊑
+          ν (‵ Types.`ℕ)
+            (((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+              ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+            reveal-ι
+      ⦂ (‵ Types.`ℕ ⇒ ‵ Types.`ℕ)
+        ⊑ (‵ Types.`ℕ ⇒ ‵ Types.`ℕ)
+      ∶ pι⇒ι
+  example14-functionsᴿ =
+    ν⊑νᴿ wfBase wfBase
+      reveal-ι-conversion reveal-ι-conversion
+      pι (⊑-lift∀ᵢ pι)
+      lift-store-[] lift-ctx-[]
+      two-round-tripsᴿ
+      reveal-ι-replacement
+
+
+cambridge26-example14-initialᴿ :
+  [] ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ
+      (ν (‵ Types.`ℕ) (Λ I) reveal-ι) · $ (κℕ zero)
+      ⊑
+      (ν (‵ Types.`ℕ)
+        (((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+          ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+        reveal-ι) · $ (κℕ zero)
+    ⦂ ‵ Types.`ℕ ⊑ ‵ Types.`ℕ ∶ pι
+cambridge26-example14-initialᴿ =
+  example14-functionsᴿ ·ᴿ κ⊑κᴿ
+
+
+cambridge26-example14-squareᴿ :
+  [] ∣ zero ∣ zero ∣ []
+    ⊢ᴿ↠
+      (ν (‵ Types.`ℕ) (Λ I) reveal-ι) · $ (κℕ zero)
+      ⊑
+      (ν (‵ Types.`ℕ)
+        (((((Λ I) ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+          ⟨ inst-cast ⟩) ⟨ gen-cast ⟩)
+        reveal-ι) · $ (κℕ zero)
+    ⦂ ‵ Types.`ℕ ⊑ ‵ Types.`ℕ ∶ pι
+cambridge26-example14-squareᴿ =
+  record
+    { sourceChanges =
+        bind (‵ Types.`ℕ) ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ []
+    ; targetChanges =
+        keep ∷ bind ★ ∷ keep ∷
+        keep ∷ bind ★ ∷ keep ∷
+        bind (‵ Types.`ℕ) ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ keep ∷
+        keep ∷ keep ∷ keep ∷ keep ∷ keep ∷ []
+    ; sourceResult = $ (κℕ zero)
+    ; targetResult = $ (κℕ zero)
+    ; resultCtx = (zero ˣ⊑ˣ zero) ∷ []
+    ; resultLeftCtx = suc zero
+    ; resultRightCtx = suc (suc (suc zero))
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = example14-result-store
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; resultSourceType = ‵ Types.`ℕ
+    ; resultTargetType = ‵ Types.`ℕ
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType =
+        λ relation →
+          ⊑-lift∀ᵢ
+            (⊑-target-lift-rightᵢ
+              (⊑-target-lift-rightᵢ relation))
+    ; sourceReduction = simple-program-trace
+    ; targetReduction = complex-program-trace
+    ; resultImprecision = κ⊑κᴿ
+    }

--- a/GTSF/proof/Quotient/NuImprecisionCompositionalQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionCompositionalQuotientDef.agda
@@ -19,7 +19,7 @@ open import CastImprecisionShape using
   ; widening
   ; _⊢ᶜ_⦂_
   )
-open import Coercions using (Coercion; ModeEnv; id-onlyᵈ)
+open import Coercions using (ModeEnv)
 open import ForallPermutation using
   ( _∣_⊢_⊑ᵖ_⊣_
   ; quotientᵖ
@@ -28,12 +28,7 @@ open import ForallPermutation using
   )
 open import Imprecision using (ImpCtx)
 open import ImprecisionComposition using
-  ( ImprecisionShape
-  ; _⊢_≈∀ˢ_
-  ; source-perm-refl
-  ; _；_≋_
-  ; _；⌊_⌋≋ᵖ_；_
-  )
+  (ImprecisionShape; _；_≋_; _；⌊_⌋≋ᵖ_；_)
 open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
 open import NarrowWiden using
   ( _∣_∣_⊢_∶_⊒_
@@ -51,28 +46,15 @@ open import QuotientedTermImprecision using
   ; QuotientWideningPair
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
-open import PairedWideningCompatibility using
-  (PairedWideningCompatible)
-open import TermTyping using
-  ( CastMode
-  ; SealModeStore★
-  )
+open import TermTyping using (_∣_∣_⊢_⦂_)
 open import Types using (Ty; TyCtx; Store; _⇒_)
+open import
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
+  public
 
 ------------------------------------------------------------------------
 -- Finite narrowing cast spines
 ------------------------------------------------------------------------
-
-data SpineCastMode (Σ : Store) : ModeEnv → Set where
-  id-only↓ :
-    SpineCastMode Σ id-onlyᵈ
-
-  gradual↓ :
-    ∀ {μ} →
-    CastMode μ →
-    SealModeStore★ μ Σ →
-    SpineCastMode Σ μ
-
 
 data NarrowingSpine (Δ : TyCtx) (Σ : Store) :
     Term → Ty → Term → Ty → ImprecisionShape → Set₁ where
@@ -113,37 +95,6 @@ data QuotientForm : Set where
 ------------------------------------------------------------------------
 -- Hereditary widening compatibility through quotient representatives
 ------------------------------------------------------------------------
-
-data QuotientWideningCompatible
-    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) :
-    (u u′ : Coercion) → {D D′ A A′ : Ty} →
-    (q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
-    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
-    ImprecisionShape → ImprecisionShape → Set where
-
-  compatible-through-representatives :
-    ∀ {u u′ D D′ A A′ C C′ r p s s′ t t′}
-      {src : D ForallPermutation.≈∀ C}
-      {tgt : C′ ForallPermutation.≈∀ D′} →
-    src ⊢ s ≈∀ˢ t →
-    tgt ⊢ t′ ≈∀ˢ s′ →
-    PairedWideningCompatible Φ Δᴸ Δᴿ u u′
-      {C} {C′} {A} {A′} r p t t′ →
-    QuotientWideningCompatible Φ Δᴸ Δᴿ u u′
-      (quotientᵖ src r tgt) p s s′
-
-
-exact-widening-compatible :
-  ∀ {Φ Δᴸ Δᴿ u u′ D D′ A A′ r p s s′} →
-  PairedWideningCompatible Φ Δᴸ Δᴿ u u′
-    {D} {D′} {A} {A′} r p s s′ →
-  QuotientWideningCompatible Φ Δᴸ Δᴿ u u′
-    (quotientᵖ ≈∀-refl r ≈∀-refl) p s s′
-exact-widening-compatible compatible =
-  compatible-through-representatives
-    {src = ≈∀-refl} {tgt = ≈∀-refl}
-    source-perm-refl source-perm-refl compatible
-
 
 infix 4 _∣_∣_∣_∣_⊢ᴺᶜ[_]_⊑_⦂_⊑ᵖ_∶_
 

--- a/GTSF/proof/Quotient/NuImprecisionCompositionalQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionCompositionalQuotientDef.agda
@@ -1,0 +1,246 @@
+module proof.Quotient.NuImprecisionCompositionalQuotientDef where
+
+-- File Charter:
+--   * Prototypes a compositional presentation of quotiented term imprecision.
+--   * Represents any finite paired narrowing cast spine with one constructor.
+--   * Closes quotient-related terms under application in both positions.
+--   * Separates cast-spine derivations from application derivations so
+--     terminal and value arguments can exclude the latter by inversion.
+--   * Retains quotient-closing widenings and their hereditary compatibility.
+--   * Does not replace the live term-imprecision relation or prove simulation.
+
+open import Agda.Builtin.Equality using (_≡_)
+open import Data.Empty using (⊥)
+open import Data.Nat using (ℕ; zero; suc)
+open import Data.Product using (_×_; _,_)
+
+open import CastImprecisionShape using
+  ( narrowing
+  ; widening
+  ; _⊢ᶜ_⦂_
+  )
+open import Coercions using (Coercion; ModeEnv; id-onlyᵈ)
+open import ForallPermutation using
+  ( _∣_⊢_⊑ᵖ_⊣_
+  ; quotientᵖ
+  ; ≈∀-refl
+  ; ⊑ᵖ-arrow-components
+  )
+open import Imprecision using (ImpCtx)
+open import ImprecisionComposition using
+  ( ImprecisionShape
+  ; _⊢_≈∀ˢ_
+  ; source-perm-refl
+  ; _；_≋_
+  ; _；⌊_⌋≋ᵖ_；_
+  )
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NarrowWiden using
+  ( _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+open import NuTermImprecision using
+  ( StoreImp
+  ; CtxImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  )
+open import NuTerms using (Term; Value; _·_; _⟨_⟩)
+open import QuotientedTermImprecision using
+  ( PairedCast
+  ; QuotientWideningPair
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  )
+open import PairedWideningCompatibility using
+  (PairedWideningCompatible)
+open import TermTyping using
+  ( CastMode
+  ; SealModeStore★
+  )
+open import Types using (Ty; TyCtx; Store; _⇒_)
+
+------------------------------------------------------------------------
+-- Finite narrowing cast spines
+------------------------------------------------------------------------
+
+data SpineCastMode (Σ : Store) : ModeEnv → Set where
+  id-only↓ :
+    SpineCastMode Σ id-onlyᵈ
+
+  gradual↓ :
+    ∀ {μ} →
+    CastMode μ →
+    SealModeStore★ μ Σ →
+    SpineCastMode Σ μ
+
+
+data NarrowingSpine (Δ : TyCtx) (Σ : Store) :
+    Term → Ty → Term → Ty → ImprecisionShape → Set₁ where
+
+  single↓ :
+    ∀ {M A B d μ s} →
+    SpineCastMode Σ μ →
+    μ ∣ Δ ∣ Σ ⊢ d ∶ A ⊒ B →
+    narrowing ⊢ᶜ d ⦂ s →
+    NarrowingSpine Δ Σ M A (M ⟨ d ⟩) B s
+
+  extend↓ :
+    ∀ {M N A B C d μ s t u} →
+    NarrowingSpine Δ Σ M A N B s →
+    SpineCastMode Σ μ →
+    μ ∣ Δ ∣ Σ ⊢ d ∶ B ⊒ C →
+    narrowing ⊢ᶜ d ⦂ t →
+    t ； s ≋ u →
+    NarrowingSpine Δ Σ M A (N ⟨ d ⟩) C u
+
+
+narrowing-spine-length :
+  ∀ {Δ Σ M N A B s} →
+  NarrowingSpine Δ Σ M A N B s →
+  ℕ
+narrowing-spine-length (single↓ mode d⊢ d-shape) = suc zero
+narrowing-spine-length
+    (extend↓ spine mode d⊢ d-shape comp) =
+  suc (narrowing-spine-length spine)
+
+------------------------------------------------------------------------
+-- Graded quotient relation
+------------------------------------------------------------------------
+
+data QuotientForm : Set where
+  cast-spine application : QuotientForm
+
+------------------------------------------------------------------------
+-- Hereditary widening compatibility through quotient representatives
+------------------------------------------------------------------------
+
+data QuotientWideningCompatible
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) :
+    (u u′ : Coercion) → {D D′ A A′ : Ty} →
+    (q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+    ImprecisionShape → ImprecisionShape → Set where
+
+  compatible-through-representatives :
+    ∀ {u u′ D D′ A A′ C C′ r p s s′ t t′}
+      {src : D ForallPermutation.≈∀ C}
+      {tgt : C′ ForallPermutation.≈∀ D′} →
+    src ⊢ s ≈∀ˢ t →
+    tgt ⊢ t′ ≈∀ˢ s′ →
+    PairedWideningCompatible Φ Δᴸ Δᴿ u u′
+      {C} {C′} {A} {A′} r p t t′ →
+    QuotientWideningCompatible Φ Δᴸ Δᴿ u u′
+      (quotientᵖ src r tgt) p s s′
+
+
+exact-widening-compatible :
+  ∀ {Φ Δᴸ Δᴿ u u′ D D′ A A′ r p s s′} →
+  PairedWideningCompatible Φ Δᴸ Δᴿ u u′
+    {D} {D′} {A} {A′} r p s s′ →
+  QuotientWideningCompatible Φ Δᴸ Δᴿ u u′
+    (quotientᵖ ≈∀-refl r ≈∀-refl) p s s′
+exact-widening-compatible compatible =
+  compatible-through-representatives
+    {src = ≈∀-refl} {tgt = ≈∀-refl}
+    source-perm-refl source-perm-refl compatible
+
+
+infix 4 _∣_∣_∣_∣_⊢ᴺᶜ[_]_⊑_⦂_⊑ᵖ_∶_
+
+data _∣_∣_∣_∣_⊢ᴺᶜ[_]_⊑_⦂_⊑ᵖ_∶_
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
+    (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ) :
+    QuotientForm → Term → Term → (A B : Ty) →
+    Φ ∣ Δᴸ ⊢ A ⊑ᵖ B ⊣ Δᴿ → Set₁ where
+
+  ordinaryᶜ :
+    ∀ {M M′ A B p} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ[ cast-spine ] M ⊑ M′
+      ⦂ A ⊑ᵖ B ∶ quotientᵖ ≈∀-refl p ≈∀-refl
+
+  paired-spinesᶜ :
+    ∀ {M M′ N N′ A A′ D D′ p s s′ q} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+    NarrowingSpine Δᴸ (leftStoreⁱ ρ) M A N D s →
+    NarrowingSpine Δᴿ (rightStoreⁱ ρ) M′ A′ N′ D′ s′ →
+    s ；⌊ p ⌋≋ᵖ q ； s′ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ[ cast-spine ] N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ q
+
+  _·ᶜ[_]_ :
+    ∀ {L L′ M M′ A A′ B B′ qF qA qB f g} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ[ f ] L ⊑ L′
+      ⦂ A ⇒ B ⊑ᵖ A′ ⇒ B′ ∶ qF →
+    ⊑ᵖ-arrow-components qF ≡ (qA , qB) →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ[ g ] M ⊑ M′ ⦂ A ⊑ᵖ A′ ∶ qA →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ[ application ] L · M ⊑ L′ · M′
+      ⦂ B ⊑ᵖ B′ ∶ qB
+
+------------------------------------------------------------------------
+-- Returning from the quotient while retaining widening compatibility
+------------------------------------------------------------------------
+
+infix 4 _∣_∣_∣_∣_⊢ᴺᶜ_⊑_⦂_⊑_∶_
+
+data _∣_∣_∣_∣_⊢ᴺᶜ_⊑_⦂_⊑_∶_
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
+    (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ) :
+    Term → Term → (A B : Ty) →
+    Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ → Set₁ where
+
+  ordinary-leafᶜ :
+    ∀ {M M′ A B p} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ M ⊑ M′ ⦂ A ⊑ B ∶ p
+
+  closeᶜ :
+    ∀ {N N′ D D′ A A′ q p u u′ s s′ f} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ[ f ] N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ q →
+    QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+    widening ⊢ᶜ u ⦂ s →
+    widening ⊢ᶜ u′ ⦂ s′ →
+    s ；⌊ p ⌋≋ᵖ q ； s′ →
+    QuotientWideningCompatible Φ Δᴸ Δᴿ u u′ q p s s′ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ p
+
+  paired-castᶜ :
+    ∀ {M M′ A A′ B B′ p q c c′} →
+    PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴺᶜ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ⦂ B ⊑ B′ ∶ q
+
+------------------------------------------------------------------------
+-- The grade keeps application out of value-only inversion
+------------------------------------------------------------------------
+
+application-source-not-value :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B q} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᶜ[ application ] M ⊑ M′ ⦂ A ⊑ᵖ B ∶ q →
+  Value M →
+  ⊥
+application-source-not-value
+    (function ·ᶜ[ components ] argument) ()
+
+
+application-target-not-value :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B q} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᶜ[ application ] M ⊑ M′ ⦂ A ⊑ᵖ B ∶ q →
+  Value M′ →
+  ⊥
+application-target-not-value
+    (function ·ᶜ[ components ] argument) ()

--- a/GTSF/proof/Quotient/NuImprecisionCompositionalQuotientExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionCompositionalQuotientExamples.agda
@@ -1,0 +1,594 @@
+module proof.Quotient.NuImprecisionCompositionalQuotientExamples where
+
+-- File Charter:
+--   * Stress-tests the compositional quotient prototype before it is used by
+--     the dynamic gradual guarantee proof.
+--   * Covers exact embedding, quotient-derived function and argument
+--     positions, left- and right-nested applications, and two paired casts.
+--   * Reuses the incomparable `∀`-permuted lower bounds from the bad-GLB
+--     example for a concrete non-ordinary quotient witness.
+--   * Contains examples only; it does not change the live term relation.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([])
+open import Data.Nat using (zero; suc)
+open import Data.Product using (_,_; proj₁; proj₂)
+
+import Coercions as C
+open import CastImprecisionShape using
+  (narrowing; widening; _⊢ᶜ_⦂_)
+open import Coercions using (Coercion)
+open import ForallPermutation using
+  ( quotientᵖ
+  ; ≈∀-refl
+  ; ≈∀-⇒
+  ; ⊑ᵖ-arrow-components
+  )
+open import Imprecision using (idᵢ)
+open import ImprecisionComposition using
+  ( ⌊_⌋
+  ; _；_≋_
+  ; _；⌊_⌋≋ᵖ_；_
+  ; source-perm-refl
+  ; source-perm-sym
+  ; source-perm-↦
+  ; source-swap-∀ν
+  ; source-swap-ν∀
+  ; quotient-boundary-square
+  ; comp-id★
+  ; comp-idˣ-idˣ
+  ; comp-idˣ-tagˣ
+  ; comp-↦-↦
+  ; comp-∀-∀
+  ; comp-∀-ν
+  ; comp-tagˣ-id★
+  ; comp-ν
+  )
+import ImprecisionWf as IWF
+open import NuTerms using (blame; _·_; _⟨_⟩)
+open import QuotientedTermImprecision using
+  ( blame⊑ᵀ
+  ; PairedCast
+  ; QuotientWideningPair
+  ; quotient-id-widening
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  )
+open import PairedWideningCompatibility using
+  ( compatible-source-inert
+  ; compatible-target-inert-bridge
+  )
+open import TermTyping using (⊢blame)
+open import Types
+open import proof.Compilation.CompileCoercions using
+  ( coerce-downⁿ-shape-idᵢ
+  ; coerce-upʷ-shape-idᵢ
+  )
+open import proof.Core.Permutation.ForallPermutationTest using
+  ( glb-lower-XY≈YX
+  ; glb-lower-XY⊑XY
+  ; glb-lower-YX⊑YX
+  ; glb-lower-XY⊑ᵖYX
+  ; glb-lower-YX⊑ᵖXY
+  )
+open import proof.EndpointMLB.Core.MLBGlbExample using
+  ( glb-bad-A
+  ; glb-bad-A⊑A
+  ; glb-lower-XY
+  ; glb-lower-XY⊑A
+  ; glb-lower-XY⊑B
+  ; glb-lower-YX
+  ; glb-lower-YX⊑A
+  ; glb-lower-YX⊑B
+  ; glb-bad-B
+  ; glb-bad-B⊑B
+  )
+open import proof.Quotient.NuImprecisionCompositionalQuotientDef
+
+------------------------------------------------------------------------
+-- Exact embedding and application closure
+------------------------------------------------------------------------
+
+blame-star⊑blame-star :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ blame ⊑ blame ⦂ ★ ⊑ ★ ∶ IWF.id★
+blame-star⊑blame-star = blame⊑ᵀ (⊢blame wf★)
+
+
+exact-embedding :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ cast-spine ] blame ⊑ blame
+    ⦂ ★ ⊑ᵖ ★ ∶ quotientᵖ ≈∀-refl IWF.id★ ≈∀-refl
+exact-embedding = ordinaryᶜ blame-star⊑blame-star
+
+
+blame-function⊑blame-function :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ blame ⊑ blame
+    ⦂ ★ ⇒ ★ ⊑ ★ ⇒ ★ ∶ IWF.id★ IWF.↦ IWF.id★
+blame-function⊑blame-function =
+  blame⊑ᵀ (⊢blame (wf⇒ wf★ wf★))
+
+
+blame-curried⊑blame-curried :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ blame ⊑ blame
+    ⦂ ★ ⇒ ★ ⇒ ★ ⊑ ★ ⇒ ★ ⇒ ★
+    ∶ IWF.id★ IWF.↦ (IWF.id★ IWF.↦ IWF.id★)
+blame-curried⊑blame-curried =
+  blame⊑ᵀ (⊢blame (wf⇒ wf★ (wf⇒ wf★ wf★)))
+
+
+left-nested-application :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ application ] (blame · blame) · blame
+      ⊑ (blame · blame) · blame
+    ⦂ ★ ⊑ᵖ ★ ∶ quotientᵖ ≈∀-refl IWF.id★ ≈∀-refl
+left-nested-application =
+  (ordinaryᶜ blame-curried⊑blame-curried
+    ·ᶜ[ refl ] ordinaryᶜ blame-star⊑blame-star)
+  ·ᶜ[ refl ] ordinaryᶜ blame-star⊑blame-star
+
+
+right-nested-application :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ application ] blame · (blame · blame)
+      ⊑ blame · (blame · blame)
+    ⦂ ★ ⊑ᵖ ★ ∶ quotientᵖ ≈∀-refl IWF.id★ ≈∀-refl
+right-nested-application =
+  ordinaryᶜ blame-function⊑blame-function
+  ·ᶜ[ refl ]
+  (ordinaryᶜ blame-function⊑blame-function
+    ·ᶜ[ refl ] ordinaryᶜ blame-star⊑blame-star)
+
+------------------------------------------------------------------------
+-- Closing an application-derived quotient term
+------------------------------------------------------------------------
+
+star⊑star :
+  idᵢ zero IWF.∣ zero ⊢ ★ ⊑ ★ ⊣ zero
+star⊑star = IWF.id★
+
+
+up-star-result =
+  coerce-upʷ-shape-idᵢ 80 star⊑star
+
+
+up-star : Coercion
+up-star = proj₁ up-star-result
+
+
+star-quotient-square :
+  ⌊ star⊑star ⌋ ；⌊ star⊑star ⌋≋ᵖ
+    quotientᵖ ≈∀-refl star⊑star ≈∀-refl ； ⌊ star⊑star ⌋
+star-quotient-square =
+  quotient-boundary-square
+    source-perm-refl comp-id★ source-perm-refl comp-id★
+
+
+star-quotient-widening-compatible :
+  QuotientWideningCompatible (idᵢ zero) zero zero
+    up-star up-star
+    (quotientᵖ ≈∀-refl star⊑star ≈∀-refl)
+    star⊑star ⌊ star⊑star ⌋ ⌊ star⊑star ⌋
+star-quotient-widening-compatible =
+  exact-widening-compatible
+    (compatible-target-inert-bridge λ ())
+
+
+closed-right-nested-application :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ (blame · (blame · blame)) ⟨ up-star ⟩
+      ⊑ (blame · (blame · blame)) ⟨ up-star ⟩
+    ⦂ ★ ⊑ ★ ∶ star⊑star
+closed-right-nested-application =
+  closeᶜ right-nested-application
+    (quotient-id-widening
+      (proj₁ (proj₂ up-star-result))
+      (proj₁ (proj₂ up-star-result)))
+    (proj₂ (proj₂ up-star-result))
+    (proj₂ (proj₂ up-star-result))
+    star-quotient-square
+    star-quotient-widening-compatible
+
+------------------------------------------------------------------------
+-- A concrete non-ordinary quotient and a two-cast narrowing spine
+------------------------------------------------------------------------
+
+example-label : Label
+example-label = 81
+
+
+down-D-result =
+  coerce-downⁿ-shape-idᵢ example-label glb-lower-XY⊑A
+
+down-E-result =
+  coerce-downⁿ-shape-idᵢ example-label glb-lower-YX⊑A
+
+identity-D-result =
+  coerce-downⁿ-shape-idᵢ example-label glb-lower-XY⊑XY
+
+identity-E-result =
+  coerce-downⁿ-shape-idᵢ example-label glb-lower-YX⊑YX
+
+
+down-D : Coercion
+down-D = proj₁ down-D-result
+
+down-E : Coercion
+down-E = proj₁ down-E-result
+
+identity-D : Coercion
+identity-D = proj₁ identity-D-result
+
+identity-E : Coercion
+identity-E = proj₁ identity-E-result
+
+
+blame-A⊑blame-A :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ blame ⊑ blame
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+blame-A⊑blame-A =
+  blame⊑ᵀ (⊢blame (IWF.⊑-tgt-wf glb-bad-A⊑A))
+
+
+single-D-spine :
+  NarrowingSpine zero [] blame glb-bad-A
+    (blame ⟨ down-D ⟩) glb-lower-XY ⌊ glb-lower-XY⊑A ⌋
+single-D-spine =
+  single↓ id-only↓ (proj₁ (proj₂ down-D-result))
+    (proj₂ (proj₂ down-D-result))
+
+
+single-E-spine :
+  NarrowingSpine zero [] blame glb-bad-A
+    (blame ⟨ down-E ⟩) glb-lower-YX ⌊ glb-lower-YX⊑A ⌋
+single-E-spine =
+  single↓ id-only↓ (proj₁ (proj₂ down-E-result))
+    (proj₂ (proj₂ down-E-result))
+
+
+identity-D-then-down-D :
+  ⌊ glb-lower-XY⊑XY ⌋ ； ⌊ glb-lower-XY⊑A ⌋
+    ≋ ⌊ glb-lower-XY⊑A ⌋
+identity-D-then-down-D =
+  comp-∀-∀
+    (comp-∀-ν
+      (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ))
+
+
+identity-E-then-down-E :
+  ⌊ glb-lower-YX⊑YX ⌋ ； ⌊ glb-lower-YX⊑A ⌋
+    ≋ ⌊ glb-lower-YX⊑A ⌋
+identity-E-then-down-E =
+  comp-∀-ν
+    (comp-∀-∀
+      (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ))
+
+
+double-D-spine :
+  NarrowingSpine zero [] blame glb-bad-A
+    ((blame ⟨ down-D ⟩) ⟨ identity-D ⟩)
+    glb-lower-XY ⌊ glb-lower-XY⊑A ⌋
+double-D-spine =
+  extend↓ single-D-spine id-only↓
+    (proj₁ (proj₂ identity-D-result))
+    (proj₂ (proj₂ identity-D-result))
+    identity-D-then-down-D
+
+
+double-E-spine :
+  NarrowingSpine zero [] blame glb-bad-A
+    ((blame ⟨ down-E ⟩) ⟨ identity-E ⟩)
+    glb-lower-YX ⌊ glb-lower-YX⊑A ⌋
+double-E-spine =
+  extend↓ single-E-spine id-only↓
+    (proj₁ (proj₂ identity-E-result))
+    (proj₂ (proj₂ identity-E-result))
+    identity-E-then-down-E
+
+
+double-D-length :
+  narrowing-spine-length double-D-spine ≡ suc (suc zero)
+double-D-length = refl
+
+
+double-E-length :
+  narrowing-spine-length double-E-spine ≡ suc (suc zero)
+double-E-length = refl
+
+
+route-quotient-square :
+  ⌊ glb-lower-XY⊑A ⌋ ；⌊ glb-bad-A⊑A ⌋≋ᵖ
+    glb-lower-XY⊑ᵖYX ； ⌊ glb-lower-YX⊑A ⌋
+route-quotient-square =
+  quotient-boundary-square
+    source-perm-refl
+    (comp-∀-∀
+      (comp-ν
+        (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★)))
+    source-swap-∀ν
+    (comp-∀-∀
+      (comp-∀-ν
+        (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ)))
+
+
+single-route-quotient :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ cast-spine ] blame ⟨ down-D ⟩
+      ⊑ blame ⟨ down-E ⟩
+    ⦂ glb-lower-XY ⊑ᵖ glb-lower-YX
+    ∶ glb-lower-XY⊑ᵖYX
+single-route-quotient =
+  paired-spinesᶜ blame-A⊑blame-A
+    single-D-spine single-E-spine route-quotient-square
+
+
+double-route-quotient :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ cast-spine ]
+      ((blame ⟨ down-D ⟩) ⟨ identity-D ⟩)
+      ⊑ ((blame ⟨ down-E ⟩) ⟨ identity-E ⟩)
+    ⦂ glb-lower-XY ⊑ᵖ glb-lower-YX
+    ∶ glb-lower-XY⊑ᵖYX
+double-route-quotient =
+  paired-spinesᶜ blame-A⊑blame-A
+    double-D-spine double-E-spine route-quotient-square
+
+------------------------------------------------------------------------
+-- A quotient-related function consumes the two-cast quotient argument
+------------------------------------------------------------------------
+
+lower-function-D⊑A :
+  idᵢ zero IWF.∣ zero ⊢ (glb-lower-XY ⇒ ★)
+    ⊑ (glb-bad-A ⇒ ★) ⊣ zero
+lower-function-D⊑A =
+  IWF._↦_ glb-lower-XY⊑A IWF.id★
+
+
+lower-function-E⊑A :
+  idᵢ zero IWF.∣ zero ⊢ (glb-lower-YX ⇒ ★)
+    ⊑ (glb-bad-A ⇒ ★) ⊣ zero
+lower-function-E⊑A =
+  IWF._↦_ glb-lower-YX⊑A IWF.id★
+
+
+source-function⊑source-function :
+  idᵢ zero IWF.∣ zero ⊢ (glb-bad-A ⇒ ★)
+    ⊑ (glb-bad-A ⇒ ★) ⊣ zero
+source-function⊑source-function =
+  IWF._↦_ glb-bad-A⊑A IWF.id★
+
+
+lower-function-D⊑D :
+  idᵢ zero IWF.∣ zero ⊢ (glb-lower-XY ⇒ ★)
+    ⊑ (glb-lower-XY ⇒ ★) ⊣ zero
+lower-function-D⊑D =
+  IWF._↦_ glb-lower-XY⊑XY IWF.id★
+
+
+down-function-D-result =
+  coerce-downⁿ-shape-idᵢ example-label
+    lower-function-D⊑A
+
+down-function-E-result =
+  coerce-downⁿ-shape-idᵢ example-label
+    lower-function-E⊑A
+
+
+down-function-D : Coercion
+down-function-D = proj₁ down-function-D-result
+
+down-function-E : Coercion
+down-function-E = proj₁ down-function-E-result
+
+
+blame-A-function⊑blame-A-function :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ blame ⊑ blame
+    ⦂ (glb-bad-A ⇒ ★) ⊑ (glb-bad-A ⇒ ★)
+    ∶ source-function⊑source-function
+blame-A-function⊑blame-A-function =
+  blame⊑ᵀ
+    (⊢blame
+      (wf⇒ (IWF.⊑-tgt-wf glb-bad-A⊑A) wf★))
+
+
+single-function-D-spine :
+  NarrowingSpine zero [] blame (glb-bad-A ⇒ ★)
+    (blame ⟨ down-function-D ⟩)
+    (glb-lower-XY ⇒ ★)
+    ⌊ lower-function-D⊑A ⌋
+single-function-D-spine =
+  single↓ id-only↓
+    (proj₁ (proj₂ down-function-D-result))
+    (proj₂ (proj₂ down-function-D-result))
+
+
+single-function-E-spine :
+  NarrowingSpine zero [] blame (glb-bad-A ⇒ ★)
+    (blame ⟨ down-function-E ⟩)
+    (glb-lower-YX ⇒ ★)
+    ⌊ lower-function-E⊑A ⌋
+single-function-E-spine =
+  single↓ id-only↓
+    (proj₁ (proj₂ down-function-E-result))
+    (proj₂ (proj₂ down-function-E-result))
+
+
+function-route-quotient-square :
+  ⌊ lower-function-D⊑A ⌋
+    ；⌊ source-function⊑source-function ⌋≋ᵖ
+    quotientᵖ ≈∀-refl
+      lower-function-D⊑D
+      (≈∀-⇒ glb-lower-XY≈YX ≈∀-refl)
+    ； ⌊ lower-function-E⊑A ⌋
+function-route-quotient-square =
+  quotient-boundary-square
+    source-perm-refl
+    (comp-↦-↦
+      (comp-∀-∀
+        (comp-ν
+          (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★)))
+      comp-id★)
+    (source-perm-↦ source-swap-∀ν source-perm-refl)
+    (comp-↦-↦
+      (comp-∀-∀
+        (comp-∀-ν
+          (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ)))
+      comp-id★)
+
+
+function-route-quotient :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ cast-spine ] blame ⟨ down-function-D ⟩
+      ⊑ blame ⟨ down-function-E ⟩
+    ⦂ (glb-lower-XY ⇒ ★) ⊑ᵖ (glb-lower-YX ⇒ ★)
+    ∶ quotientᵖ ≈∀-refl
+        lower-function-D⊑D
+        (≈∀-⇒ glb-lower-XY≈YX ≈∀-refl)
+function-route-quotient =
+  paired-spinesᶜ blame-A-function⊑blame-A-function
+    single-function-D-spine single-function-E-spine
+    function-route-quotient-square
+
+
+quotient-function-and-two-cast-argument :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ application ]
+      (blame ⟨ down-function-D ⟩)
+        · ((blame ⟨ down-D ⟩) ⟨ identity-D ⟩)
+      ⊑
+      (blame ⟨ down-function-E ⟩)
+        · ((blame ⟨ down-E ⟩) ⟨ identity-E ⟩)
+    ⦂ ★ ⊑ᵖ ★ ∶ quotientᵖ ≈∀-refl IWF.id★ ≈∀-refl
+quotient-function-and-two-cast-argument =
+  function-route-quotient ·ᶜ[ refl ] double-route-quotient
+
+------------------------------------------------------------------------
+-- Closing a genuinely permuted quotient through its representatives
+------------------------------------------------------------------------
+
+reverse-route-quotient-square :
+  ⌊ glb-lower-YX⊑A ⌋ ；⌊ glb-bad-A⊑A ⌋≋ᵖ
+    glb-lower-YX⊑ᵖXY ； ⌊ glb-lower-XY⊑A ⌋
+reverse-route-quotient-square =
+  quotient-boundary-square
+    source-perm-refl
+    (comp-ν
+      (comp-∀-∀
+        (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★)))
+    (source-perm-sym source-swap-∀ν)
+    (comp-∀-ν
+      (comp-∀-∀
+        (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ)))
+
+
+single-reverse-route-quotient :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ cast-spine ] blame ⟨ down-E ⟩
+      ⊑ blame ⟨ down-D ⟩
+    ⦂ glb-lower-YX ⊑ᵖ glb-lower-XY
+    ∶ glb-lower-YX⊑ᵖXY
+single-reverse-route-quotient =
+  paired-spinesᶜ blame-A⊑blame-A
+    single-E-spine single-D-spine reverse-route-quotient-square
+
+
+up-E-result =
+  coerce-upʷ-shape-idᵢ example-label glb-lower-YX⊑B
+
+up-D-result =
+  coerce-upʷ-shape-idᵢ example-label glb-lower-XY⊑B
+
+
+up-E : Coercion
+up-E = proj₁ up-E-result
+
+up-D : Coercion
+up-D = proj₁ up-D-result
+
+
+up-E-inert : C.Inert up-E
+up-E-inert = C.`∀ _
+
+
+reverse-route-closing-square :
+  ⌊ glb-lower-YX⊑B ⌋ ；⌊ glb-bad-B⊑B ⌋≋ᵖ
+    glb-lower-YX⊑ᵖXY ； ⌊ glb-lower-XY⊑B ⌋
+reverse-route-closing-square =
+  quotient-boundary-square
+    source-perm-refl
+    (comp-∀-∀
+      (comp-ν
+        (comp-↦-↦ comp-tagˣ-id★ comp-idˣ-idˣ)))
+    (source-perm-sym source-swap-ν∀)
+    (comp-∀-∀
+      (comp-∀-ν
+        (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-idˣ)))
+
+
+reverse-route-widening-compatible :
+  QuotientWideningCompatible (idᵢ zero) zero zero
+    up-E up-D glb-lower-YX⊑ᵖXY glb-bad-B⊑B
+    ⌊ glb-lower-YX⊑B ⌋ ⌊ glb-lower-XY⊑B ⌋
+reverse-route-widening-compatible =
+  compatible-through-representatives
+    source-perm-refl
+    (source-perm-sym source-swap-ν∀)
+    (compatible-source-inert up-E-inert)
+
+
+closed-reverse-route-quotient :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ (blame ⟨ down-E ⟩) ⟨ up-E ⟩
+      ⊑ (blame ⟨ down-D ⟩) ⟨ up-D ⟩
+    ⦂ glb-bad-B ⊑ glb-bad-B ∶ glb-bad-B⊑B
+closed-reverse-route-quotient =
+  closeᶜ single-reverse-route-quotient
+    (quotient-id-widening
+      (proj₁ (proj₂ up-E-result))
+      (proj₁ (proj₂ up-D-result)))
+    (proj₂ (proj₂ up-E-result))
+    (proj₂ (proj₂ up-D-result))
+    reverse-route-closing-square
+    reverse-route-widening-compatible
+
+------------------------------------------------------------------------
+-- The residual after two successive function-cast reductions
+------------------------------------------------------------------------
+
+two-function-cast-residual :
+  ∀ {Φ Δᴸ Δᴿ ρ γ L L′ M M′
+      C C′ B B′ E E′ F F′
+      pE pF qF qC qB f g
+      d₂ d₂′ d₁ d₁′ u₁ u₁′ u₂ u₂′ s s′} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᶜ[ f ] L ⊑ L′
+    ⦂ (C ⇒ B) ⊑ᵖ (C′ ⇒ B′) ∶ qF →
+  ⊑ᵖ-arrow-components qF ≡ (qC , qB) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᶜ[ g ] ((M ⟨ d₂ ⟩) ⟨ d₁ ⟩)
+      ⊑ ((M′ ⟨ d₂′ ⟩) ⟨ d₁′ ⟩)
+    ⦂ C ⊑ᵖ C′ ∶ qC →
+  QuotientWideningPair Δᴸ Δᴿ ρ u₁ u₁′ B B′ E E′ →
+  widening ⊢ᶜ u₁ ⦂ s →
+  widening ⊢ᶜ u₁′ ⦂ s′ →
+  s ；⌊ pE ⌋≋ᵖ qB ； s′ →
+  QuotientWideningCompatible Φ Δᴸ Δᴿ
+    u₁ u₁′ qB pE s s′ →
+  PairedCast Φ Δᴸ Δᴿ ρ u₂ u₂′ pE pF →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴺᶜ
+      (((L · ((M ⟨ d₂ ⟩) ⟨ d₁ ⟩)) ⟨ u₁ ⟩) ⟨ u₂ ⟩)
+      ⊑
+      ((L′ · ((M′ ⟨ d₂′ ⟩) ⟨ d₁′ ⟩)) ⟨ u₁′ ⟩)
+        ⟨ u₂′ ⟩
+    ⦂ F ⊑ F′ ∶ pF
+two-function-cast-residual
+    function components argument widening-pair
+    source-shape target-shape square compatible outer-cast =
+  paired-castᶜ outer-cast
+    (closeᶜ
+      (function ·ᶜ[ components ] argument)
+      widening-pair source-shape target-shape square compatible)

--- a/GTSF/proof/Quotient/NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda
+++ b/GTSF/proof/Quotient/NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda
@@ -1,0 +1,170 @@
+module
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  where
+
+-- File Charter:
+--   * Projects endpoint typing, value, and no-bullet evidence from the
+--     composable embedded target-instantiation creation residual.
+--   * Proves each property by structural recursion over exact creation and
+--     composed world embeddings.
+--   * Imports no term-imprecision judgment and contains no postulate, hole,
+--     permissive option, termination bypass, or catch-all clause.
+
+open import Data.List using ([])
+
+open import NuTermImprecision using
+  (StoreImp; leftStoreⁱ; rightStoreⁱ)
+open import NuTerms using
+  ( No•
+  ; Term
+  ; Value
+  ; Λ_
+  ; _⟨_⟩
+  ; no•-Λ
+  ; no•-⟨⟩
+  )
+open import TermTyping using (_∣_∣_⊢_⦂_)
+open import Types using (Ty)
+open import proof.Core.Properties.NuTermProperties using
+  ( renameᵗᵐ-preserves-No•
+  ; renameᵗᵐ-preserves-Value
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  ( EmbeddedTargetInstantiationCreation
+  ; TargetInstantiationCreation
+  ; embed-creationᴱ
+  ; exact-creationᴱ
+  )
+
+
+embedded-creation-source-typingᴱ :
+  ∀ {Φ₀ Θᴸ Θᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f
+      body-shape body-relation Ψ Δᴸ Δᴿ ρ M M′ A A′ p} →
+  EmbeddedTargetInstantiationCreation
+    {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    body-relation
+    {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    ρ M M′ A A′ p →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ [] ⊢ M ⦂ A
+embedded-creation-source-typingᴱ (exact-creationᴱ creation) =
+  TargetInstantiationCreation.source-result-typing creation
+embedded-creation-source-typingᴱ
+    (embed-creationᴱ embedded assm hτ hσ store-embedding
+      source-typing target-typing) =
+  source-typing
+
+
+embedded-creation-target-typingᴱ :
+  ∀ {Φ₀ Θᴸ Θᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f
+      body-shape body-relation Ψ Δᴸ Δᴿ ρ M M′ A A′ p} →
+  EmbeddedTargetInstantiationCreation
+    {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    body-relation
+    {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    ρ M M′ A A′ p →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ M′ ⦂ A′
+embedded-creation-target-typingᴱ (exact-creationᴱ creation) =
+  TargetInstantiationCreation.target-result-typing creation
+embedded-creation-target-typingᴱ
+    (embed-creationᴱ embedded assm hτ hσ store-embedding
+      source-typing target-typing) =
+  target-typing
+
+
+embedded-creation-source-valueᴱ :
+  ∀ {Φ₀ Θᴸ Θᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f
+      body-shape body-relation Ψ Δᴸ Δᴿ ρ M M′ A A′ p} →
+  EmbeddedTargetInstantiationCreation
+    {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    body-relation
+    {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    ρ M M′ A A′ p →
+  Value M
+embedded-creation-source-valueᴱ (exact-creationᴱ creation) =
+  Λ (TargetInstantiationCreation.source-body-value creation)
+embedded-creation-source-valueᴱ
+    (embed-creationᴱ embedded assm hτ hσ store-embedding
+      source-typing target-typing) =
+  renameᵗᵐ-preserves-Value _
+    (embedded-creation-source-valueᴱ embedded)
+
+
+embedded-creation-target-valueᴱ :
+  ∀ {Φ₀ Θᴸ Θᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f
+      body-shape body-relation Ψ Δᴸ Δᴿ ρ M M′ A A′ p} →
+  EmbeddedTargetInstantiationCreation
+    {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    body-relation
+    {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    ρ M M′ A A′ p →
+  Value M′
+embedded-creation-target-valueᴱ (exact-creationᴱ creation) =
+  TargetInstantiationCreation.target-body-value creation
+    ⟨ TargetInstantiationCreation.body-cast-inert creation ⟩
+embedded-creation-target-valueᴱ
+    (embed-creationᴱ embedded assm hτ hσ store-embedding
+      source-typing target-typing) =
+  renameᵗᵐ-preserves-Value _
+    (embedded-creation-target-valueᴱ embedded)
+
+
+embedded-creation-source-no-bulletᴱ :
+  ∀ {Φ₀ Θᴸ Θᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f
+      body-shape body-relation Ψ Δᴸ Δᴿ ρ M M′ A A′ p} →
+  EmbeddedTargetInstantiationCreation
+    {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    body-relation
+    {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    ρ M M′ A A′ p →
+  No• M
+embedded-creation-source-no-bulletᴱ (exact-creationᴱ creation) =
+  no•-Λ (TargetInstantiationCreation.source-body-no-bullet creation)
+embedded-creation-source-no-bulletᴱ
+    (embed-creationᴱ embedded assm hτ hσ store-embedding
+      source-typing target-typing) =
+  renameᵗᵐ-preserves-No• _
+    (embedded-creation-source-no-bulletᴱ embedded)
+
+
+embedded-creation-target-no-bulletᴱ :
+  ∀ {Φ₀ Θᴸ Θᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f
+      body-shape body-relation Ψ Δᴸ Δᴿ ρ M M′ A A′ p} →
+  EmbeddedTargetInstantiationCreation
+    {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    body-relation
+    {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    ρ M M′ A A′ p →
+  No• M′
+embedded-creation-target-no-bulletᴱ (exact-creationᴱ creation) =
+  no•-⟨⟩ (TargetInstantiationCreation.target-body-no-bullet creation)
+embedded-creation-target-no-bulletᴱ
+    (embed-creationᴱ embedded assm hτ hσ store-embedding
+      source-typing target-typing) =
+  renameᵗᵐ-preserves-No• _
+    (embedded-creation-target-no-bulletᴱ embedded)

--- a/GTSF/proof/Quotient/NuImprecisionQuotientBoundarySupport.agda
+++ b/GTSF/proof/Quotient/NuImprecisionQuotientBoundarySupport.agda
@@ -5,24 +5,41 @@ module
 -- File Charter:
 --   * Defines quotient-boundary evidence shared by experimental term
 --     imprecision relations.
---   * Keeps cast-mode and hereditary widening compatibility independent of
---     every term-imprecision judgment.
+--   * Defines the reduction-closed design's hereditary paired-widening
+--     compatibility without changing the live global predicate.
+--   * Requires an inert source paired with an active target, rather than
+--     accepting every target whenever the source is inert.
+--   * Keeps cast-mode and widening compatibility independent of every
+--     term-imprecision judgment.
 --   * Contains no constructor that embeds or converts between term relations.
 
-open import Coercions using (Coercion; ModeEnv; id-onlyᵈ)
+import Coercions as C
+open import Coercions using
+  (Coercion; Inert; ModeEnv; id-onlyᵈ)
+open import Data.Empty using (⊥)
+open import Data.List using (_∷_)
+open import Data.Nat using (suc; zero)
+open import Data.Product using (Σ; _×_)
 open import ForallPermutation using
   (_∣_⊢_⊑ᵖ_⊣_; quotientᵖ; ≈∀-refl)
-open import Imprecision using (ImpCtx)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑ˣ_; ⇑ᵢ)
 open import ImprecisionComposition using
   ( ImprecisionShape
+  ; ⌊_⌋
+  ; _↦ˢ_
+  ; ∀ˢ_
+  ; _；_≋_
   ; _⊢_≈∀ˢ_
   ; source-perm-refl
   )
-open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import ImprecisionWf using
+  (_∣_⊢_⊑_⊣_; _↦_; ∀ⁱ_)
 open import PairedWideningCompatibility using
   (PairedWideningCompatible)
 open import TermTyping using (CastMode; SealModeStore★)
-open import Types using (Store; Ty; TyCtx)
+open import Types using
+  (Store; Ty; TyCtx; _⇒_; `∀)
 
 
 data SpineCastMode (Σ : Store) : ModeEnv → Set where
@@ -34,6 +51,63 @@ data SpineCastMode (Σ : Store) : ModeEnv → Set where
     CastMode μ →
     SealModeStore★ μ Σ →
     SpineCastMode Σ μ
+
+
+data ReductionClosedPairedWideningCompatible
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) :
+    (c c′ : Coercion) → {A A′ B B′ : Ty} →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+    (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+    (c-shape c′-shape : ImprecisionShape) → Set where
+
+  compatible-tagᴿ :
+    ∀ {c′ A A′ B B′ p q c-shape c′-shape} G →
+    ReductionClosedPairedWideningCompatible
+      Φ Δᴸ Δᴿ (G C.!) c′
+      {A} {A′} {B} {B′} p q c-shape c′-shape
+
+  compatible-functionᴿ :
+    ∀ {c₁ c₂ c₁′ c₂′ A₁ A₁′ A₂ A₂′
+      B₁ B₁′ B₂ B₂′
+      p₁ p₂ q₁ q₂ c₁-shape c₂-shape c₁′-shape c₂′-shape} →
+    ReductionClosedPairedWideningCompatible
+      Φ Δᴸ Δᴿ c₂ c₂′ p₂ q₂ c₂-shape c₂′-shape →
+    ReductionClosedPairedWideningCompatible
+      Φ Δᴸ Δᴿ
+      (c₁ C.↦ c₂) (c₁′ C.↦ c₂′)
+      {A₁ ⇒ A₂} {A₁′ ⇒ A₂′}
+      {B₁ ⇒ B₂} {B₁′ ⇒ B₂′}
+      (p₁ ↦ p₂) (q₁ ↦ q₂)
+      (c₁-shape ↦ˢ c₂-shape) (c₁′-shape ↦ˢ c₂′-shape)
+
+  compatible-allᴿ :
+    ∀ {c c′ A A′ B B′ p q c-shape c′-shape} →
+    ReductionClosedPairedWideningCompatible
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) (suc Δᴸ) (suc Δᴿ)
+      c c′ p q c-shape c′-shape →
+    ReductionClosedPairedWideningCompatible
+      Φ Δᴸ Δᴿ
+      (C.`∀ c) (C.`∀ c′)
+      {`∀ A} {`∀ A′} {`∀ B} {`∀ B′}
+      (∀ⁱ p) (∀ⁱ q) (∀ˢ c-shape) (∀ˢ c′-shape)
+
+  compatible-target-activeᴿ :
+    ∀ {c c′ A A′ B B′ p q c-shape c′-shape} →
+    Inert c →
+    (Inert c′ → ⊥) →
+    ReductionClosedPairedWideningCompatible
+      Φ Δᴸ Δᴿ c c′
+      {A} {A′} {B} {B′} p q c-shape c′-shape
+
+  compatible-target-inert-bridgeᴿ :
+    ∀ {c c′ A A′ B B′ p q c-shape c′-shape} →
+    (Inert c′ →
+      Σ (Φ ∣ Δᴸ ⊢ B ⊑ A′ ⊣ Δᴿ) (λ bridge →
+      (c-shape ； ⌊ bridge ⌋ ≋ ⌊ p ⌋) ×
+      (⌊ bridge ⌋ ； c′-shape ≋ ⌊ q ⌋))) →
+    ReductionClosedPairedWideningCompatible
+      Φ Δᴸ Δᴿ c c′
+      {A} {A′} {B} {B′} p q c-shape c′-shape
 
 
 data QuotientWideningCompatible
@@ -63,5 +137,36 @@ exact-widening-compatible :
     (quotientᵖ ≈∀-refl r ≈∀-refl) p s s′
 exact-widening-compatible compatible =
   compatible-through-representatives
+    {src = ≈∀-refl} {tgt = ≈∀-refl}
+    source-perm-refl source-perm-refl compatible
+
+
+data ReductionClosedQuotientWideningCompatible
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) :
+    (u u′ : Coercion) → {D D′ A A′ : Ty} →
+    (q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+    ImprecisionShape → ImprecisionShape → Set where
+
+  compatible-through-representativesᴿ :
+    ∀ {u u′ D D′ A A′ C C′ r p s s′ t t′}
+      {src : D ForallPermutation.≈∀ C}
+      {tgt : C′ ForallPermutation.≈∀ D′} →
+    src ⊢ s ≈∀ˢ t →
+    tgt ⊢ t′ ≈∀ˢ s′ →
+    ReductionClosedPairedWideningCompatible Φ Δᴸ Δᴿ u u′
+      {C} {C′} {A} {A′} r p t t′ →
+    ReductionClosedQuotientWideningCompatible Φ Δᴸ Δᴿ u u′
+      (quotientᵖ src r tgt) p s s′
+
+
+reduction-closed-exact-widening-compatible :
+  ∀ {Φ Δᴸ Δᴿ u u′ D D′ A A′ r p s s′} →
+  ReductionClosedPairedWideningCompatible Φ Δᴸ Δᴿ u u′
+    {D} {D′} {A} {A′} r p s s′ →
+  ReductionClosedQuotientWideningCompatible Φ Δᴸ Δᴿ u u′
+    (quotientᵖ ≈∀-refl r ≈∀-refl) p s s′
+reduction-closed-exact-widening-compatible compatible =
+  compatible-through-representativesᴿ
     {src = ≈∀-refl} {tgt = ≈∀-refl}
     source-perm-refl source-perm-refl compatible

--- a/GTSF/proof/Quotient/NuImprecisionQuotientBoundarySupport.agda
+++ b/GTSF/proof/Quotient/NuImprecisionQuotientBoundarySupport.agda
@@ -1,0 +1,67 @@
+module
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
+  where
+
+-- File Charter:
+--   * Defines quotient-boundary evidence shared by experimental term
+--     imprecision relations.
+--   * Keeps cast-mode and hereditary widening compatibility independent of
+--     every term-imprecision judgment.
+--   * Contains no constructor that embeds or converts between term relations.
+
+open import Coercions using (Coercion; ModeEnv; id-onlyᵈ)
+open import ForallPermutation using
+  (_∣_⊢_⊑ᵖ_⊣_; quotientᵖ; ≈∀-refl)
+open import Imprecision using (ImpCtx)
+open import ImprecisionComposition using
+  ( ImprecisionShape
+  ; _⊢_≈∀ˢ_
+  ; source-perm-refl
+  )
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import PairedWideningCompatibility using
+  (PairedWideningCompatible)
+open import TermTyping using (CastMode; SealModeStore★)
+open import Types using (Store; Ty; TyCtx)
+
+
+data SpineCastMode (Σ : Store) : ModeEnv → Set where
+  id-only↓ :
+    SpineCastMode Σ id-onlyᵈ
+
+  gradual↓ :
+    ∀ {μ} →
+    CastMode μ →
+    SealModeStore★ μ Σ →
+    SpineCastMode Σ μ
+
+
+data QuotientWideningCompatible
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) :
+    (u u′ : Coercion) → {D D′ A A′ : Ty} →
+    (q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) →
+    ImprecisionShape → ImprecisionShape → Set where
+
+  compatible-through-representatives :
+    ∀ {u u′ D D′ A A′ C C′ r p s s′ t t′}
+      {src : D ForallPermutation.≈∀ C}
+      {tgt : C′ ForallPermutation.≈∀ D′} →
+    src ⊢ s ≈∀ˢ t →
+    tgt ⊢ t′ ≈∀ˢ s′ →
+    PairedWideningCompatible Φ Δᴸ Δᴿ u u′
+      {C} {C′} {A} {A′} r p t t′ →
+    QuotientWideningCompatible Φ Δᴸ Δᴿ u u′
+      (quotientᵖ src r tgt) p s s′
+
+
+exact-widening-compatible :
+  ∀ {Φ Δᴸ Δᴿ u u′ D D′ A A′ r p s s′} →
+  PairedWideningCompatible Φ Δᴸ Δᴿ u u′
+    {D} {D′} {A} {A′} r p s s′ →
+  QuotientWideningCompatible Φ Δᴸ Δᴿ u u′
+    (quotientᵖ ≈∀-refl r ≈∀-refl) p s s′
+exact-widening-compatible compatible =
+  compatible-through-representatives
+    {src = ≈∀-refl} {tgt = ≈∀-refl}
+    source-perm-refl source-perm-refl compatible

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedCompatibilityRenameExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedCompatibilityRenameExperiment.agda
@@ -1,0 +1,214 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedCompatibilityRenameExperiment
+  where
+
+-- File Charter:
+--   * Proves two-sided and source-only type-renaming preservation for the
+--     reduction-closed paired- and quotient-widening compatibility evidence.
+--   * Handles the existential target-inert bridge by renaming its ordinary
+--     imprecision witness and transporting its erased composition triangles.
+--   * Supplies the compatibility transport needed by independent paired and
+--     source-only type-world weakening experiments for the smaller relation.
+--   * Depends only on type, coercion, permutation, and compatibility
+--     infrastructure; it imports no term-imprecision judgment or theorem.
+
+open import Coercions using (Coercion; renameᶜ)
+open import Agda.Builtin.Equality using (refl)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Product using (_,_)
+open import ForallPermutation using
+  (_∣_⊢_⊑ᵖ_⊣_; quotientᵖ)
+open import ImprecisionComposition using
+  (ImprecisionShape)
+open import ImprecisionWf using
+  (ImpAssm; ImpCtx; _∣_⊢_⊑_⊣_)
+open import Types using
+  (Renameᵗ; Ty; TyCtx; renameᵗ)
+open import proof.Core.Permutation.ForallPermutationProperties using
+  (≈∀-renameᵗ; ⊑ᵖ-rename-leftᵢ; ⊑ᵖ-rename²ᵢ)
+open import proof.Core.Properties.CoercionProperties using
+  (renameᶜ-preserves-Inert; renameᶜ-reflects-Inert)
+open import
+  proof.Core.Properties.NuCastImprecisionShapeProperties
+  using
+  ( imprecision-composition-shape-transport
+  ; rename-assm²-∀-leftᵢ
+  ; shape-rename
+  ; shape-rename-left
+  ; ⊑-rename-leftᵢ
+  )
+open import
+  proof.Core.Properties.NuImprecisionQuotientBoundaryProperties
+  using (source-perm-shape-rename)
+open import proof.Core.Properties.TypeProperties using
+  (TyRenameWf; TyRenameWf-ext)
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  ( rename-assm²ᵢ
+  ; rename-assm²-⇑ᵢ
+  ; ⊑-renameᵗ²ᵢ
+  )
+open import proof.Quotient.NuImprecisionQuotientBoundarySupport using
+  ( ReductionClosedPairedWideningCompatible
+  ; ReductionClosedQuotientWideningCompatible
+  ; compatible-tagᴿ
+  ; compatible-functionᴿ
+  ; compatible-allᴿ
+  ; compatible-target-activeᴿ
+  ; compatible-target-inert-bridgeᴿ
+  ; compatible-through-representativesᴿ
+  )
+
+
+reduction-closed-paired-compatible-rename²ᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ c c′ A A′ B B′
+      p q c-shape c′-shape}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ} →
+  (hτ : TyRenameWf Δᴸ Θᴸ τ) →
+  (hσ : TyRenameWf Δᴿ Θᴿ σ) →
+  ReductionClosedPairedWideningCompatible
+    Φ Δᴸ Δᴿ c c′ {A} {A′} {B} {B′}
+    p q c-shape c′-shape →
+  ReductionClosedPairedWideningCompatible
+    Ψ Θᴸ Θᴿ (renameᶜ τ c) (renameᶜ σ c′)
+    (⊑-renameᵗ²ᵢ assm hτ hσ p)
+    (⊑-renameᵗ²ᵢ assm hτ hσ q)
+    c-shape c′-shape
+reduction-closed-paired-compatible-rename²ᵢ {τ = τ} hτ hσ
+    (compatible-tagᴿ G) =
+  compatible-tagᴿ (renameᵗ τ G)
+reduction-closed-paired-compatible-rename²ᵢ hτ hσ
+    (compatible-functionᴿ compatible) =
+  compatible-functionᴿ
+    (reduction-closed-paired-compatible-rename²ᵢ
+      hτ hσ compatible)
+reduction-closed-paired-compatible-rename²ᵢ
+    {assm = assm} hτ hσ (compatible-allᴿ compatible) =
+  compatible-allᴿ
+    (reduction-closed-paired-compatible-rename²ᵢ
+      {assm = rename-assm²-⇑ᵢ assm}
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) compatible)
+reduction-closed-paired-compatible-rename²ᵢ
+    {c′ = c′} hτ hσ
+    (compatible-target-activeᴿ inert not-inert′) =
+  compatible-target-activeᴿ
+    (renameᶜ-preserves-Inert _ inert)
+    (λ renamed-inert′ →
+      not-inert′
+        (renameᶜ-reflects-Inert _ c′ renamed-inert′))
+reduction-closed-paired-compatible-rename²ᵢ
+    {c′ = c′} {assm = assm} hτ hσ
+    (compatible-target-inert-bridgeᴿ bridge-evidence) =
+  compatible-target-inert-bridgeᴿ λ renamed-inert′ →
+    let
+      bridge , source-triangle , target-triangle =
+        bridge-evidence
+          (renameᶜ-reflects-Inert _ c′ renamed-inert′)
+    in
+      ⊑-renameᵗ²ᵢ assm hτ hσ bridge ,
+      imprecision-composition-shape-transport
+        refl (shape-rename assm hτ hσ bridge)
+        (shape-rename assm hτ hσ _) source-triangle ,
+      imprecision-composition-shape-transport
+        (shape-rename assm hτ hσ bridge) refl
+        (shape-rename assm hτ hσ _) target-triangle
+
+
+reduction-closed-paired-compatible-rename-leftᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ c c′ A A′ B B′
+      p q c-shape c′-shape}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ (λ X → X) a ∈ Ψ} →
+  (hτ : TyRenameWf Δᴸ Δᴸ′ τ) →
+  ReductionClosedPairedWideningCompatible
+    Φ Δᴸ Δᴿ c c′ {A} {A′} {B} {B′}
+    p q c-shape c′-shape →
+  ReductionClosedPairedWideningCompatible
+    Ψ Δᴸ′ Δᴿ (renameᶜ τ c) c′
+    (⊑-rename-leftᵢ τ assm hτ p)
+    (⊑-rename-leftᵢ τ assm hτ q)
+    c-shape c′-shape
+reduction-closed-paired-compatible-rename-leftᵢ
+    {τ = τ} hτ (compatible-tagᴿ G) =
+  compatible-tagᴿ (renameᵗ τ G)
+reduction-closed-paired-compatible-rename-leftᵢ
+    hτ (compatible-functionᴿ compatible) =
+  compatible-functionᴿ
+    (reduction-closed-paired-compatible-rename-leftᵢ
+      hτ compatible)
+reduction-closed-paired-compatible-rename-leftᵢ
+    {assm = assm} hτ (compatible-allᴿ compatible) =
+  compatible-allᴿ
+    (reduction-closed-paired-compatible-rename-leftᵢ
+      {assm = rename-assm²-∀-leftᵢ assm}
+      (TyRenameWf-ext hτ) compatible)
+reduction-closed-paired-compatible-rename-leftᵢ
+    hτ (compatible-target-activeᴿ inert not-inert′) =
+  compatible-target-activeᴿ
+    (renameᶜ-preserves-Inert _ inert) not-inert′
+reduction-closed-paired-compatible-rename-leftᵢ
+    {assm = assm} hτ
+    (compatible-target-inert-bridgeᴿ bridge-evidence) =
+  compatible-target-inert-bridgeᴿ λ inert′ →
+    let
+      bridge , source-triangle , target-triangle =
+        bridge-evidence inert′
+    in
+      ⊑-rename-leftᵢ _ assm hτ bridge ,
+      imprecision-composition-shape-transport
+        refl (shape-rename-left assm hτ bridge)
+        (shape-rename-left assm hτ _) source-triangle ,
+      imprecision-composition-shape-transport
+        (shape-rename-left assm hτ bridge) refl
+        (shape-rename-left assm hτ _) target-triangle
+
+
+reduction-closed-quotient-compatible-rename²ᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ u u′ D D′ A A′
+      q p u-shape u′-shape}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ} →
+  (hτ : TyRenameWf Δᴸ Θᴸ τ) →
+  (hσ : TyRenameWf Δᴿ Θᴿ σ) →
+  ReductionClosedQuotientWideningCompatible
+    Φ Δᴸ Δᴿ u u′ {D} {D′} {A} {A′}
+    q p u-shape u′-shape →
+  ReductionClosedQuotientWideningCompatible
+    Ψ Θᴸ Θᴿ (renameᶜ τ u) (renameᶜ σ u′)
+    (⊑ᵖ-rename²ᵢ assm hτ hσ q)
+    (⊑-renameᵗ²ᵢ assm hτ hσ p)
+    u-shape u′-shape
+reduction-closed-quotient-compatible-rename²ᵢ
+    {τ = τ} {σ = σ} {assm = assm} hτ hσ
+    (compatible-through-representativesᴿ
+      source-shape target-shape compatible) =
+  compatible-through-representativesᴿ
+    (source-perm-shape-rename {τ = τ} source-shape)
+    (source-perm-shape-rename {τ = σ} target-shape)
+    (reduction-closed-paired-compatible-rename²ᵢ
+      {assm = assm} hτ hσ compatible)
+
+
+reduction-closed-quotient-compatible-rename-leftᵢ :
+  ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ u u′ D D′ A A′
+      q p u-shape u′-shape}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ (λ X → X) a ∈ Ψ} →
+  (hτ : TyRenameWf Δᴸ Δᴸ′ τ) →
+  ReductionClosedQuotientWideningCompatible
+    Φ Δᴸ Δᴿ u u′ {D} {D′} {A} {A′}
+    q p u-shape u′-shape →
+  ReductionClosedQuotientWideningCompatible
+    Ψ Δᴸ′ Δᴿ (renameᶜ τ u) u′
+    (⊑ᵖ-rename-leftᵢ τ assm hτ q)
+    (⊑-rename-leftᵢ τ assm hτ p)
+    u-shape u′-shape
+reduction-closed-quotient-compatible-rename-leftᵢ
+    {τ = τ} {assm = assm} hτ
+    (compatible-through-representativesᴿ
+      source-shape target-shape compatible) =
+  compatible-through-representativesᴿ
+    (source-perm-shape-rename {τ = τ} source-shape)
+    target-shape
+    (reduction-closed-paired-compatible-rename-leftᵢ
+      {assm = assm} hτ compatible)

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
@@ -10,6 +10,8 @@ module
 --   * Keeps quotient indices only across one paired narrowing cast and closes
 --     them with compatible paired widenings.
 --   * Includes the exact residual created by target-only instantiation.
+--   * Permits only that creation residual, not an arbitrary relation, to cross
+--     a canonical closed-endpoint renaming and store embedding.
 --   * Defines pure-reduction closure for focused simulation experiments.
 --   * Does not change or re-export the live term-imprecision relation.
 
@@ -311,29 +313,46 @@ mutual
         ⦂ `∀ D ⊑ ⇑ᵗ B
         ∶ ⊑-target-lift-rightᵢ f
 
-    rename-storeᴿ :
-      ∀ {Φ₀ Ψ Θᴸ Θᴿ Δᴸ′ Δᴿ′}
-        {ρ₀ : StoreImp Φ₀ Θᴸ Θᴿ}
+    target-instantiation-transportᴿ :
+      ∀ {Φ₀ Θᴸ Θᴿ}
+        {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+        {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          (suc Θᴸ) (suc Θᴿ)}
+        {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+        {W W′ : Term} {B C D : Ty} {s : Coercion}
+        {μ : ModeEnv}
+        {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          ∣ suc Θᴸ ⊢ D ⊑ C ⊣ suc Θᴿ}
+        {f : Φ₀ ∣ Θᴸ ⊢ `∀ D ⊑ B ⊣ Θᴿ}
+        {body-shape : ImprecisionShape}
+        {Ψ : ImpCtx} {Δᴸ′ Δᴿ′ : TyCtx}
         {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ′}
-        {τ σ : Renameᵗ}
-        {M M′ : Term} {A B : Ty}
-        {p : Φ₀ ∣ Θᴸ ⊢ A ⊑ B ⊣ Θᴿ} →
+        {τ σ : Renameᵗ} →
+      TargetInstantiationCreation
+        {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+        {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+        {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+        {s = s} {μ = μ} {r = r} {f = f}
+        {body-shape = body-shape}
+        (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
+          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r) →
       (assm :
-        ∀ {a : ImpAssm} → a ∈ Φ₀ →
+        ∀ {a : ImpAssm} → a ∈ ⇑ᴿᵢ Φ₀ →
           rename-assm²ᵢ τ σ a ∈ Ψ) →
       (hτ : TyRenameWf Θᴸ Δᴸ′ τ) →
-      (hσ : TyRenameWf Θᴿ Δᴿ′ σ) →
-      RelStoreEmbeddingⁱ τ σ ρ₀ ρ′ →
-      Φ₀ ∣ Θᴸ ∣ Θᴿ ∣ ρ₀ ∣ []
-        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+      (hσ : TyRenameWf (suc Θᴿ) Δᴿ′ σ) →
+      RelStoreEmbeddingⁱ τ σ
+        (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ′ →
       Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ []
-        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A →
+        ⊢ renameᵗᵐ τ (Λ W) ⦂ renameᵗ τ (`∀ D) →
       Δᴿ′ ∣ rightStoreⁱ ρ′ ∣ []
-        ⊢ renameᵗᵐ σ M′ ⦂ renameᵗ σ B →
+        ⊢ renameᵗᵐ σ (W′ ⟨ s ⟩) ⦂ renameᵗ σ (⇑ᵗ B) →
       Ψ ∣ Δᴸ′ ∣ Δᴿ′ ∣ ρ′ ∣ []
-        ⊢ᴿ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
-        ⦂ renameᵗ τ A ⊑ renameᵗ σ B
-        ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+        ⊢ᴿ renameᵗᵐ τ (Λ W) ⊑ renameᵗᵐ σ (W′ ⟨ s ⟩)
+        ⦂ renameᵗ τ (`∀ D) ⊑ renameᵗ σ (⇑ᵗ B)
+        ∶ ⊑-renameᵗ²ᵢ assm hτ hσ
+            (⊑-target-lift-rightᵢ f)
 
     closeᴿ :
       ∀ {N N′ D D′ A A′ q p u u′ s s′} →

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
@@ -1,0 +1,146 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  where
+
+-- File Charter:
+--   * Defines the smaller quotient-imprecision prototype used to test
+--     simulation up to reduction.
+--   * Keeps quotient indices only across one paired narrowing cast and closes
+--     them with compatible paired widenings.
+--   * Retains ordinary application only after both premises have returned to
+--     an ordinary imprecision index.
+--   * Defines pure-reduction closure for focused function-beta experiments.
+--   * Does not change or re-export the live term-imprecision relation.
+
+open import Data.List using ([]; _∷_)
+
+open import CastImprecisionShape using
+  (narrowing; widening; _⊢ᶜ_⦂_)
+open import Coercions using (ModeEnv)
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Imprecision using (ImpCtx)
+open import ImprecisionComposition using (_；⌊_⌋≋ᵖ_；_)
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NarrowWiden using (_∣_∣_⊢_∶_⊒_)
+open import NuReduction using
+  (StoreChanges; keep; _—↠[_]_)
+open import NuTermImprecision using
+  (CtxImp; StoreImp; leftStoreⁱ; rightStoreⁱ)
+open import NuTerms using (Term; _·_; _⟨_⟩)
+open import QuotientedTermImprecision using
+  (PairedCast; QuotientWideningPair;
+   _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_)
+open import Types using (Ty; TyCtx; _⇒_)
+open import
+  proof.Quotient.NuImprecisionCompositionalQuotientDef
+  using
+  ( SpineCastMode
+  ; QuotientWideningCompatible
+  )
+
+------------------------------------------------------------------------
+-- Store-neutral reduction sequences
+------------------------------------------------------------------------
+
+data AllKeep : StoreChanges → Set where
+  []ᵏ : AllKeep []
+  keep∷ᵏ_ : ∀ {χs} → AllKeep χs → AllKeep (keep ∷ χs)
+
+------------------------------------------------------------------------
+-- Smaller ordinary and quotient relations
+------------------------------------------------------------------------
+
+infix 4 _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+infix 4 _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
+
+mutual
+  data _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+      (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
+      (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ) :
+      Term → Term → (A B : Ty) →
+      Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ → Set₁ where
+
+    ordinaryᴿ :
+      ∀ {M M′ A A′ p} →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+
+    _·ᴿ_ :
+      ∀ {L L′ M M′ A A′ B B′ pA pB} →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ L ⊑ L′
+        ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ImprecisionWf.↦ pB →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ L · M ⊑ L′ · M′ ⦂ B ⊑ B′ ∶ pB
+
+    closeᴿ :
+      ∀ {N N′ D D′ A A′ q p u u′ s s′} →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ q →
+      QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+      widening ⊢ᶜ u ⦂ s →
+      widening ⊢ᶜ u′ ⦂ s′ →
+      s ；⌊ p ⌋≋ᵖ q ； s′ →
+      QuotientWideningCompatible Φ Δᴸ Δᴿ u u′ q p s s′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ p
+
+    paired-castᴿ :
+      ∀ {M M′ A A′ B B′ p q c c′} →
+      PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ⦂ B ⊑ B′ ∶ q
+
+  data _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
+      (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
+      (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ) :
+      Term → Term → (D D′ : Ty) →
+      Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ → Set₁ where
+
+    paired-downᴿ :
+      ∀ {M M′ A A′ D D′ p d d′ s s′ q μ μ′} →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      SpineCastMode (leftStoreⁱ ρ) μ →
+      μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ A ⊒ D →
+      narrowing ⊢ᶜ d ⦂ s →
+      SpineCastMode (rightStoreⁱ ρ) μ′ →
+      μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ A′ ⊒ D′ →
+      narrowing ⊢ᶜ d′ ⦂ s′ →
+      s ；⌊ p ⌋≋ᵖ q ； s′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿᵖ M ⟨ d ⟩ ⊑ M′ ⟨ d′ ⟩
+        ⦂ D ⊑ᵖ D′ ∶ q
+
+------------------------------------------------------------------------
+-- Reduction-saturated use of the smaller ordinary relation
+------------------------------------------------------------------------
+
+infix 4 _∣_∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_
+
+record _∣_∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_
+    (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
+    (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ)
+    (M M′ : Term) (A A′ : Ty)
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) : Set₁ where
+  constructor related-after-pure-reduction
+  field
+    sourceChanges : StoreChanges
+    targetChanges : StoreChanges
+    sourceChangesKeep : AllKeep sourceChanges
+    targetChangesKeep : AllKeep targetChanges
+    sourceResult : Term
+    targetResult : Term
+    sourceReduction : M —↠[ sourceChanges ] sourceResult
+    targetReduction : M′ —↠[ targetChanges ] targetResult
+    resultImprecision :
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ sourceResult ⊑ targetResult ⦂ A ⊑ A′ ∶ p
+
+open _∣_∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_ public

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
@@ -7,24 +7,37 @@ module
 --     simulation up to reduction.
 --   * Gives the ordinary fragment its own syntax-directed constructors; no
 --     constructor embeds or converts from another term-imprecision judgment.
+--   * Includes matched and source-only type application and `ν`, with their
+--     allocation-aware store lifts and exact index-substitution equations.
+--   * Includes ordinary one-sided and paired reveal/conceal conversions, and
+--     proof-only closure under store-prefix extension.
+--   * Retains the terminal `gen`/ground join, whose value endpoints cannot be
+--     recovered merely by closing the simulation under reduction.
 --   * Keeps quotient indices only across one paired narrowing cast and closes
 --     them with compatible paired widenings.
 --   * Includes the exact residual created by target-only instantiation.
---   * Permits only that creation residual, not an arbitrary relation, to cross
---     a canonical closed-endpoint renaming and store embedding.
---   * Defines pure-reduction closure for focused simulation experiments.
+--   * Represents exact and subsequently embedded target-instantiation
+--     residuals with one syntax-directed creation constructor.
+--   * Defines an allocation-aware bilateral reduction closure for closed
+--     terms, with exact context, store, type, and index transport.
 --   * Does not change or re-export the live term-imprecision relation.
 
 open import Agda.Builtin.Bool using (Bool; true)
-open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Equality using (_≡_)
 open import Data.List using ([]; _∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (zero; suc)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (subst; sym)
 
 open import CastImprecisionShape using
   (narrowing; widening; _⊢ᶜ_⦂_)
 open import Coercions using
-  (Coercion; Inert; ModeEnv; id-onlyᵈ; inst)
+  (Coercion; Inert; ModeEnv; id-onlyᵈ; inst; gen; _!)
+open import Conversion using
+  (ConcealConversion; RevealConversion)
+open import ConversionIndexCompatibility using
+  (_[_↦_]ᴸ_; _[_↦_]ᴿ_; _[_↦_⊑⟨_⟩_↤_]ᴾ_)
 open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
 open import Imprecision using
   (ImpCtx; _ˣ⊑ˣ_; _ˣ⊑★; ⇑ᵢ; ⇑ᴸᵢ; ⇑ᴿᵢ)
@@ -35,7 +48,12 @@ open import ImprecisionWf using
 open import NarrowWiden using
   (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
 open import NuReduction using
-  (StoreChanges; keep; _—↠[_]_)
+  ( StoreChanges
+  ; applyStores
+  ; applyTyCtxs
+  ; applyTys
+  ; _—↠[_]_
+  )
 open import NuTermImprecision using
   ( CtxImp
   ; LiftCtxⁱ
@@ -43,10 +61,14 @@ open import NuTermImprecision using
   ; LiftLeftStoreⁱ
   ; LiftStoreⁱ
   ; StoreImp
+  ; StoreCorresponds
   ; ctx-imp
+  ; leftCtxⁱ
   ; leftStoreⁱ
   ; rightCtxⁱ
   ; rightStoreⁱ
+  ; store-left
+  ; store-matched
   ; store-right
   )
 open import NuTerms using
@@ -54,22 +76,24 @@ open import NuTerms using
   ; Term
   ; Value
   ; renameᵗᵐ
+  ; ⇑ᵗᵐ
   ; `_
   ; ƛ_
   ; _·_
   ; Λ_
+  ; _•
+  ; ν
   ; _⟨_⟩
   ; $
   ; _⊕[_]_
   ; blame
   )
-open import PairedWideningCompatibility using
-  (PairedWideningCompatible)
 open import Primitives using (Prim; κℕ)
 open import TermTyping using
   (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
 open import Types using
-  ( Renameᵗ
+  ( Ground
+  ; Renameᵗ
   ; Ty
   ; TyCtx
   ; WfTy
@@ -79,23 +103,29 @@ open import Types using
   ; `∀
   ; renameᵗ
   ; ⇑ᵗ
+  ; ⟰ᵗ
   ; occurs
   )
 open import
   proof.Quotient.NuImprecisionQuotientBoundarySupport
   using
-  ( SpineCastMode
-  ; QuotientWideningCompatible
+  ( ReductionClosedPairedWideningCompatible
+  ; ReductionClosedQuotientWideningCompatible
+  ; SpineCastMode
   )
 open import
   proof.Quotient.NuImprecisionTargetInstantiationCreationDef
   using
-  (TargetInstantiationCreation)
+  ( StoreImpPrefixᴿ
+  ; EmbeddedTargetInstantiationCreation
+  )
 open import
   proof.EndpointMLB.Core.MaximalLowerBoundsWf
   using
   ( rename-assm²ᵢ
   ; ⊑-renameᵗ²ᵢ
+  ; ⊑-lift∀ᵢ
+  ; ⊑-source-liftνᵢ
   ; ⊑-target-lift-rightᵢ
   )
 open import
@@ -111,14 +141,6 @@ variable
   Δᴸ Δᴿ : TyCtx
   ρ : StoreImp Φ Δᴸ Δᴿ
   γ : CtxImp Φ Δᴸ Δᴿ
-
-------------------------------------------------------------------------
--- Store-neutral reduction sequences
-------------------------------------------------------------------------
-
-data AllKeep : StoreChanges → Set where
-  []ᵏ : AllKeep []
-  keep∷ᵏ_ : ∀ {χs} → AllKeep χs → AllKeep (keep ∷ χs)
 
 data QuotientWideningPairᴿ
     {Φ : ImpCtx} (Δᴸ Δᴿ : TyCtx) (ρ : StoreImp Φ Δᴸ Δᴿ) :
@@ -210,6 +232,112 @@ mutual
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ Λ V ⊑ N′ ⦂ `∀ A ⊑ B ∶ ν safe occ p
 
+    α⊑αᴿ :
+      ∀ {ρ′ γ′ L L′ A B C D p} →
+      Value L →
+      No• L →
+      Value L′ →
+      No• L′ →
+      (A⇑⊑B⇑ :
+        ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+          ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ B ⊣ suc Δᴿ) →
+      LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+      LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ L ⊑ L′ ⦂ `∀ C ⊑ `∀ D ∶ ∀ⁱ p →
+      suc Δᴸ
+        ∣ leftStoreⁱ
+            (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
+              A⇑⊑B⇑ ∷ ρ′)
+        ∣ leftCtxⁱ γ′
+        ⊢ (⇑ᵗᵐ L) • ⦂ C →
+      suc Δᴿ
+        ∣ rightStoreⁱ
+            (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
+              A⇑⊑B⇑ ∷ ρ′)
+        ∣ rightCtxⁱ γ′
+        ⊢ (⇑ᵗᵐ L′) • ⦂ D →
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        ∣ suc Δᴸ ∣ suc Δᴿ
+        ∣ store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
+            A⇑⊑B⇑ ∷ ρ′
+        ∣ γ′
+        ⊢ᴿ (⇑ᵗᵐ L) • ⊑ (⇑ᵗᵐ L′) • ⦂ C ⊑ D ∶ p
+
+    α⊑ᴿ :
+      ∀ {ρ′ γ′ L N′ A B′ C p occ} →
+      {{safe : NonVar C}} →
+      Value L →
+      No• L →
+      (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+      LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+      LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ L ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν safe occ p →
+      suc Δᴸ
+        ∣ leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+        ∣ leftCtxⁱ γ′
+        ⊢ (⇑ᵗᵐ L) • ⦂ C →
+      Δᴿ
+        ∣ rightStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+        ∣ rightCtxⁱ γ′
+        ⊢ N′ ⦂ B′ →
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+        ∣ suc Δᴸ ∣ Δᴿ
+        ∣ store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ γ′
+        ⊢ᴿ (⇑ᵗᵐ L) • ⊑ N′ ⦂ C ⊑ B′ ∶ p
+
+    allocation-prefixᴿ :
+      ∀ {ρ₀ M M′ A B p} →
+      StoreImpPrefixᴿ ρ₀ ρ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+      Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+      Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p
+
+    ν⊑νᴿ :
+      ∀ {ρ′ γ′ A A′ B B′ C C′ N N′ p q s s′ μ μ′} →
+      WfTy Δᴸ A →
+      WfTy Δᴿ A′ →
+      RevealConversion μ (suc Δᴸ)
+        ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+        zero (⇑ᵗ A) s C (⇑ᵗ B) →
+      RevealConversion μ′ (suc Δᴿ)
+        ((zero , ⇑ᵗ A′) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+        zero (⇑ᵗ A′) s′ C′ (⇑ᵗ B′) →
+      Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
+      (A⇑⊑A′⇑ :
+        ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+          ∣ suc Δᴸ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ A′ ⊣ suc Δᴿ) →
+      LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+      LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ N ⊑ N′ ⦂ `∀ C ⊑ `∀ C′ ∶ ∀ⁱ q →
+      q [ zero ↦ ⇑ᵗ A
+          ⊑⟨ A⇑⊑A′⇑ ⟩
+          ⇑ᵗ A′ ↤ zero ]ᴾ
+        ⊑-lift∀ᵢ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ ν A N s ⊑ ν A′ N′ s′ ⦂ B ⊑ B′ ∶ p
+
+    ν⊑ᴿ :
+      ∀ {ρ′ γ′ A B B′ C N N′ p q s μ occ} →
+      {{safe : NonVar C}} →
+      WfTy Δᴸ A →
+      (h⇑A : WfTy (suc Δᴸ) (⇑ᵗ A)) →
+      RevealConversion μ (suc Δᴸ)
+        ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+        zero (⇑ᵗ A) s C (⇑ᵗ B) →
+      LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+      LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ N ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν safe occ q →
+      q [ zero ↦ ⇑ᵗ A ]ᴸ ⊑-source-liftνᵢ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ ν A N s ⊑ N′ ⦂ B ⊑ B′ ∶ p
+
     κ⊑κᴿ :
       ∀ {n} →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
@@ -232,6 +360,21 @@ mutual
         ⊢ᴿ L ⊕[ op ] M ⊑ L′ ⊕[ op ] M′
         ⦂ Types.‵ Types.`ℕ ⊑ Types.‵ Types.`ℕ
         ∶ ImprecisionWf.idι
+
+    gen⊑groundᴿ :
+      ∀ {V W A B H p c μ} →
+      CastMode μ →
+      SealModeStore★ μ (leftStoreⁱ ρ) →
+      μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ gen A c ∶ A ⊒ `∀ B →
+      Ground H →
+      Value V →
+      Value W →
+      Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ W ⦂ H →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ V ⊑ W ⟨ H ! ⟩ ⦂ A ⊑ ★ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ `∀ B ⊑ H ⊣ Δᴿ) →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ V ⟨ gen A c ⟩ ⊑ W ⦂ `∀ B ⊑ H ∶ q
 
     cast⊒⊑ᴿ :
       ∀ {M M′ A B B′ p c μ s} →
@@ -285,35 +428,72 @@ mutual
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
 
-    target-instantiationᴿ :
-      ∀ {Φ₀ Θᴸ Θᴿ}
-        {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
-        {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-          (suc Θᴸ) (suc Θᴿ)}
-        {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
-        {W W′ : Term} {B C D : Ty} {s : Coercion}
-        {μ : ModeEnv}
-        {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-          ∣ suc Θᴸ ⊢ D ⊑ C ⊣ suc Θᴿ}
-        {f : Φ₀ ∣ Θᴸ ⊢ `∀ D ⊑ B ⊣ Θᴿ}
-        {body-shape : ImprecisionShape} →
-      TargetInstantiationCreation
-        {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
-        {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
-        {W = W} {W′ = W′} {B = B} {C = C} {D = D}
-        {s = s} {μ = μ} {r = r} {f = f}
-        {body-shape = body-shape}
-        (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
-          ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
-          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r) →
-      ⇑ᴿᵢ Φ₀
-        ∣ Θᴸ ∣ suc Θᴿ
-        ∣ store-right zero ★ wf★ ∷ ρᴿ⁺ ∣ []
-        ⊢ᴿ Λ W ⊑ W′ ⟨ s ⟩
-        ⦂ `∀ D ⊑ ⇑ᵗ B
-        ∶ ⊑-target-lift-rightᵢ f
+    conv↑⊑ᴿ :
+      ∀ {M M′ A B B′ p c μ α X} →
+      RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+      p [ α ↦ X ]ᴸ q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
 
-    target-instantiation-transportᴿ :
+    conv↓⊑ᴿ :
+      ∀ {M M′ A B B′ p c μ α X} →
+      ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+      q [ α ↦ X ]ᴸ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
+
+    ⊑conv↑ᴿ :
+      ∀ {M M′ A A′ B′ p c′ μ′ β X′} →
+      RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ) →
+      p [ β ↦ X′ ]ᴿ q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
+
+    ⊑conv↓ᴿ :
+      ∀ {M M′ A A′ B′ p c′ μ′ β X′} →
+      ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ)
+        β X′ c′ A′ B′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ) →
+      q [ β ↦ X′ ]ᴿ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
+
+    paired-revealᴿ :
+      ∀ {M M′ A A′ B B′ p q c c′
+          α β X X′ pX μ μ′} →
+      StoreCorresponds ρ α X β X′ pX →
+      RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+      RevealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+      p [ α ↦ X ⊑⟨ pX ⟩ X′ ↤ β ]ᴾ q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ⦂ B ⊑ B′ ∶ q
+
+    paired-concealᴿ :
+      ∀ {M M′ A A′ B B′ p q c c′
+          α β X X′ pX μ μ′} →
+      StoreCorresponds ρ α X β X′ pX →
+      ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+      ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ) β X′ c′ A′ B′ →
+      q [ α ↦ X ⊑⟨ pX ⟩ X′ ↤ β ]ᴾ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ⦂ B ⊑ B′ ∶ q
+
+    target-instantiationᴿ :
       ∀ {Φ₀ Θᴸ Θᴿ}
         {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
         {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
@@ -327,32 +507,22 @@ mutual
         {body-shape : ImprecisionShape}
         {Ψ : ImpCtx} {Δᴸ′ Δᴿ′ : TyCtx}
         {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ′}
-        {τ σ : Renameᵗ} →
-      TargetInstantiationCreation
-        {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+        {γ′ : CtxImp Ψ Δᴸ′ Δᴿ′}
+        {M M′ : Term} {A A′ : Ty}
+        {p : Ψ ∣ Δᴸ′ ⊢ A ⊑ A′ ⊣ Δᴿ′} →
+      EmbeddedTargetInstantiationCreation
+        {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
         {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
         {W = W} {W′ = W′} {B = B} {C = C} {D = D}
         {s = s} {μ = μ} {r = r} {f = f}
         {body-shape = body-shape}
         (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
           ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
-          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r) →
-      (assm :
-        ∀ {a : ImpAssm} → a ∈ ⇑ᴿᵢ Φ₀ →
-          rename-assm²ᵢ τ σ a ∈ Ψ) →
-      (hτ : TyRenameWf Θᴸ Δᴸ′ τ) →
-      (hσ : TyRenameWf (suc Θᴿ) Δᴿ′ σ) →
-      RelStoreEmbeddingⁱ τ σ
-        (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ′ →
-      Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ []
-        ⊢ renameᵗᵐ τ (Λ W) ⦂ renameᵗ τ (`∀ D) →
-      Δᴿ′ ∣ rightStoreⁱ ρ′ ∣ []
-        ⊢ renameᵗᵐ σ (W′ ⟨ s ⟩) ⦂ renameᵗ σ (⇑ᵗ B) →
-      Ψ ∣ Δᴸ′ ∣ Δᴿ′ ∣ ρ′ ∣ []
-        ⊢ᴿ renameᵗᵐ τ (Λ W) ⊑ renameᵗᵐ σ (W′ ⟨ s ⟩)
-        ⦂ renameᵗ τ (`∀ D) ⊑ renameᵗ σ (⇑ᵗ B)
-        ∶ ⊑-renameᵗ²ᵢ assm hτ hσ
-            (⊑-target-lift-rightᵢ f)
+          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r)
+        {Ψ = Ψ} {Δᴸ = Δᴸ′} {Δᴿ = Δᴿ′}
+        ρ′ M M′ A A′ p →
+      Ψ ∣ Δᴸ′ ∣ Δᴿ′ ∣ ρ′ ∣ γ′
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
 
     closeᴿ :
       ∀ {N N′ D D′ A A′ q p u u′ s s′} →
@@ -362,7 +532,8 @@ mutual
       widening ⊢ᶜ u ⦂ s →
       widening ⊢ᶜ u′ ⦂ s′ →
       s ；⌊ p ⌋≋ᵖ q ； s′ →
-      QuotientWideningCompatible Φ Δᴸ Δᴿ u u′ q p s s′ →
+      ReductionClosedQuotientWideningCompatible
+        Φ Δᴸ Δᴿ u u′ q p s s′ →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ p
 
@@ -378,7 +549,7 @@ mutual
       widening ⊢ᶜ c′ ⦂ s′ →
       s ； ⌊ q ⌋ ≋ r →
       ⌊ p ⌋ ； s′ ≋ r →
-      PairedWideningCompatible
+      ReductionClosedPairedWideningCompatible
         Φ Δᴸ Δᴿ c c′ p q s s′ →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
@@ -407,28 +578,76 @@ mutual
         ⦂ D ⊑ᵖ D′ ∶ q
 
 ------------------------------------------------------------------------
--- Reduction-saturated use of the smaller ordinary relation
+-- Allocation-aware bilateral reduction closure
 ------------------------------------------------------------------------
 
-infix 4 _∣_∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_
+infix 4 _∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_
 
-record _∣_∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_
+record _∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_
     (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
-    (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ)
+    (ρ : StoreImp Φ Δᴸ Δᴿ)
     (M M′ : Term) (A A′ : Ty)
     (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) : Set₁ where
-  constructor related-after-pure-reduction
+  constructor related-after-bilateral-reduction
   field
     sourceChanges : StoreChanges
     targetChanges : StoreChanges
-    sourceChangesKeep : AllKeep sourceChanges
-    targetChangesKeep : AllKeep targetChanges
     sourceResult : Term
     targetResult : Term
-    sourceReduction : M —↠[ sourceChanges ] sourceResult
-    targetReduction : M′ —↠[ targetChanges ] targetResult
-    resultImprecision :
-      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-        ⊢ᴿ sourceResult ⊑ targetResult ⦂ A ⊑ A′ ∶ p
 
-open _∣_∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_ public
+    resultCtx : ImpCtx
+    resultLeftCtx : TyCtx
+    resultRightCtx : TyCtx
+    sourceCtxResult :
+      resultLeftCtx ≡ applyTyCtxs sourceChanges Δᴸ
+    targetCtxResult :
+      resultRightCtx ≡ applyTyCtxs targetChanges Δᴿ
+
+    resultStore :
+      StoreImp resultCtx resultLeftCtx resultRightCtx
+    sourceStoreResult :
+      leftStoreⁱ resultStore
+        ≡ applyStores sourceChanges (leftStoreⁱ ρ)
+    targetStoreResult :
+      rightStoreⁱ resultStore
+        ≡ applyStores targetChanges (rightStoreⁱ ρ)
+
+    resultSourceType : Ty
+    resultTargetType : Ty
+    sourceTypeResult :
+      resultSourceType ≡ applyTys sourceChanges A
+    targetTypeResult :
+      resultTargetType ≡ applyTys targetChanges A′
+
+    transportType :
+      ∀ {C D} →
+      Φ ∣ Δᴸ ⊢ C ⊑ D ⊣ Δᴿ →
+      resultCtx ∣ resultLeftCtx
+        ⊢ applyTys sourceChanges C
+          ⊑ applyTys targetChanges D
+        ⊣ resultRightCtx
+
+    sourceReduction :
+      M —↠[ sourceChanges ] sourceResult
+    targetReduction :
+      M′ —↠[ targetChanges ] targetResult
+
+    resultImprecision :
+      resultCtx
+        ∣ resultLeftCtx
+        ∣ resultRightCtx
+        ∣ resultStore ∣ []
+        ⊢ᴿ sourceResult ⊑ targetResult
+        ⦂ resultSourceType ⊑ resultTargetType
+        ∶ subst
+            (λ T → resultCtx ∣ resultLeftCtx
+              ⊢ resultSourceType ⊑ T ⊣ resultRightCtx)
+            (sym targetTypeResult)
+            (subst
+              (λ S → resultCtx ∣ resultLeftCtx
+                ⊢ S ⊑ applyTys targetChanges A′
+                ⊣ resultRightCtx)
+              (sym sourceTypeResult)
+              (transportType p))
+
+open _∣_∣_∣_⊢ᴿ↠_⊑_⦂_⊑_∶_ public

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
@@ -5,38 +5,110 @@ module
 -- File Charter:
 --   * Defines the smaller quotient-imprecision prototype used to test
 --     simulation up to reduction.
+--   * Gives the ordinary fragment its own syntax-directed constructors; no
+--     constructor embeds or converts from another term-imprecision judgment.
 --   * Keeps quotient indices only across one paired narrowing cast and closes
 --     them with compatible paired widenings.
---   * Retains ordinary application only after both premises have returned to
---     an ordinary imprecision index.
---   * Defines pure-reduction closure for focused function-beta experiments.
+--   * Includes the exact residual created by target-only instantiation.
+--   * Defines pure-reduction closure for focused simulation experiments.
 --   * Does not change or re-export the live term-imprecision relation.
 
+open import Agda.Builtin.Bool using (Bool; true)
+open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (zero; suc)
 
 open import CastImprecisionShape using
   (narrowing; widening; _⊢ᶜ_⦂_)
-open import Coercions using (ModeEnv)
+open import Coercions using
+  (Coercion; Inert; ModeEnv; id-onlyᵈ; inst)
 open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
-open import Imprecision using (ImpCtx)
-open import ImprecisionComposition using (_；⌊_⌋≋ᵖ_；_)
-open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
-open import NarrowWiden using (_∣_∣_⊢_∶_⊒_)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑ˣ_; _ˣ⊑★; ⇑ᵢ; ⇑ᴸᵢ; ⇑ᴿᵢ)
+open import ImprecisionComposition using
+  (ImprecisionShape; νˢ_; ⌊_⌋; _；_≋_; _；⌊_⌋≋ᵖ_；_)
+open import ImprecisionWf using
+  (ImpAssm; _∣_⊢_⊑_⊣_; NonVar; ∀ⁱ_; ν; _↦_)
+open import NarrowWiden using
+  (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
 open import NuReduction using
   (StoreChanges; keep; _—↠[_]_)
 open import NuTermImprecision using
-  (CtxImp; StoreImp; leftStoreⁱ; rightStoreⁱ)
-open import NuTerms using (Term; _·_; _⟨_⟩)
-open import QuotientedTermImprecision using
-  (PairedCast; QuotientWideningPair;
-   _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_)
-open import Types using (Ty; TyCtx; _⇒_)
+  ( CtxImp
+  ; LiftCtxⁱ
+  ; LiftLeftCtxⁱ
+  ; LiftLeftStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; ctx-imp
+  ; leftStoreⁱ
+  ; rightCtxⁱ
+  ; rightStoreⁱ
+  ; store-right
+  )
+open import NuTerms using
+  ( No•
+  ; Term
+  ; Value
+  ; renameᵗᵐ
+  ; `_
+  ; ƛ_
+  ; _·_
+  ; Λ_
+  ; _⟨_⟩
+  ; $
+  ; _⊕[_]_
+  ; blame
+  )
+open import PairedWideningCompatibility using
+  (PairedWideningCompatible)
+open import Primitives using (Prim; κℕ)
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  ( Renameᵗ
+  ; Ty
+  ; TyCtx
+  ; WfTy
+  ; ★
+  ; wf★
+  ; _⇒_
+  ; `∀
+  ; renameᵗ
+  ; ⇑ᵗ
+  ; occurs
+  )
 open import
-  proof.Quotient.NuImprecisionCompositionalQuotientDef
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
   using
   ( SpineCastMode
   ; QuotientWideningCompatible
   )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  (TargetInstantiationCreation)
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using
+  ( rename-assm²ᵢ
+  ; ⊑-renameᵗ²ᵢ
+  ; ⊑-target-lift-rightᵢ
+  )
+open import
+  proof.Core.Properties.TypeProperties
+  using (TyRenameWf)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+  using (RelStoreEmbeddingⁱ)
+
+
+variable
+  Φ : ImpCtx
+  Δᴸ Δᴿ : TyCtx
+  ρ : StoreImp Φ Δᴸ Δᴿ
+  γ : CtxImp Φ Δᴸ Δᴿ
 
 ------------------------------------------------------------------------
 -- Store-neutral reduction sequences
@@ -46,6 +118,25 @@ data AllKeep : StoreChanges → Set where
   []ᵏ : AllKeep []
   keep∷ᵏ_ : ∀ {χs} → AllKeep χs → AllKeep (keep ∷ χs)
 
+data QuotientWideningPairᴿ
+    {Φ : ImpCtx} (Δᴸ Δᴿ : TyCtx) (ρ : StoreImp Φ Δᴸ Δᴿ) :
+    (u u′ : Coercion) → (D D′ A A′ : Ty) → Set₁ where
+  quotient-id-wideningᴿ :
+    ∀ {u u′ D D′ A A′} →
+    id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+    id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ u u′ D D′ A A′
+
+  quotient-cast-wideningᴿ :
+    ∀ {μ μ′ u u′ D D′ A A′} →
+    CastMode μ →
+    SealModeStore★ μ (leftStoreⁱ ρ) →
+    μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ u ∶ D ⊑ A →
+    CastMode μ′ →
+    SealModeStore★ μ′ (rightStoreⁱ ρ) →
+    μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ u′ ∶ D′ ⊑ A′ →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ u u′ D D′ A A′
+
 ------------------------------------------------------------------------
 -- Smaller ordinary and quotient relations
 ------------------------------------------------------------------------
@@ -54,34 +145,201 @@ infix 4 _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
 infix 4 _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
 
 mutual
-  data _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
-      (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
-      (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ) :
+  data _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_ :
+      (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) →
+      StoreImp Φ Δᴸ Δᴿ → CtxImp Φ Δᴸ Δᴿ →
       Term → Term → (A B : Ty) →
       Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ → Set₁ where
 
-    ordinaryᴿ :
-      ∀ {M M′ A A′ p} →
+    blame⊑ᴿ :
+      ∀ {M A B p} →
+      Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-        ⊢ᴺ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+        ⊢ᴿ blame ⊑ M ⦂ A ⊑ B ∶ p
+
+    x⊑xᴿ :
+      ∀ {x A B p} →
+      γ Types.∋ x ⦂ ctx-imp A B p →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+        ⊢ᴿ ` x ⊑ ` x ⦂ A ⊑ B ∶ p
+
+    ƛ⊑ƛᴿ :
+      ∀ {N N′ A A′ B B′ pA pB} →
+      WfTy Δᴸ A →
+      WfTy Δᴿ A′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ ctx-imp A A′ pA ∷ γ
+        ⊢ᴿ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ ƛ N ⊑ ƛ N′
+        ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB
 
     _·ᴿ_ :
       ∀ {L L′ M M′ A A′ B B′ pA pB} →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ L ⊑ L′
-        ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ImprecisionWf.↦ pB →
+        ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ pA ↦ pB →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ pA →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ L · M ⊑ L′ · M′ ⦂ B ⊑ B′ ∶ pB
 
+    Λ⊑Λᴿ :
+      ∀ {ρ′ γ′ V V′ A B p} →
+      LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ′ →
+      LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′ →
+      Value V →
+      Value V′ →
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ′ ∣ γ′
+        ⊢ᴿ V ⊑ V′ ⦂ A ⊑ B ∶ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ Λ V ⊑ Λ V′ ⦂ `∀ A ⊑ `∀ B ∶ ∀ⁱ p
+
+    Λ⊑ᴿ :
+      ∀ {ρ′ γ′ V N′ A B p} →
+      {{safe : NonVar A}} →
+      (occ : occurs zero A ≡ true) →
+      LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ′ →
+      LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′ →
+      Value V →
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+        ∣ suc Δᴸ ∣ Δᴿ ∣ ρ′ ∣ γ′
+        ⊢ᴿ V ⊑ N′ ⦂ A ⊑ B ∶ p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ Λ V ⊑ N′ ⦂ `∀ A ⊑ B ∶ ν safe occ p
+
+    κ⊑κᴿ :
+      ∀ {n} →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ $ (κℕ n) ⊑ $ (κℕ n)
+        ⦂ Types.‵ Types.`ℕ ⊑ Types.‵ Types.`ℕ
+        ∶ ImprecisionWf.idι
+
+    _⊕ᴿ[_]_ :
+      ∀ {L L′ M M′} →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ L ⊑ L′
+        ⦂ Types.‵ Types.`ℕ ⊑ Types.‵ Types.`ℕ
+        ∶ ImprecisionWf.idι →
+      (op : Prim) →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′
+        ⦂ Types.‵ Types.`ℕ ⊑ Types.‵ Types.`ℕ
+        ∶ ImprecisionWf.idι →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ L ⊕[ op ] M ⊑ L′ ⊕[ op ] M′
+        ⦂ Types.‵ Types.`ℕ ⊑ Types.‵ Types.`ℕ
+        ∶ ImprecisionWf.idι
+
+    cast⊒⊑ᴿ :
+      ∀ {M M′ A B B′ p c μ s} →
+      CastMode μ →
+      SealModeStore★ μ (leftStoreⁱ ρ) →
+      μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+      narrowing ⊢ᶜ c ⦂ s →
+      s ； ⌊ p ⌋ ≋ ⌊ q ⌋ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
+
+    cast⊑⊑ᴿ :
+      ∀ {M M′ A B B′ p c μ s} →
+      CastMode μ →
+      SealModeStore★ μ (leftStoreⁱ ρ) →
+      μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+      widening ⊢ᶜ c ⦂ s →
+      s ； ⌊ q ⌋ ≋ ⌊ p ⌋ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
+
+    ⊑cast⊒ᴿ :
+      ∀ {M M′ A A′ B′ p c′ μ′ s} →
+      CastMode μ′ →
+      SealModeStore★ μ′ (rightStoreⁱ ρ) →
+      μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ) →
+      narrowing ⊢ᶜ c′ ⦂ s →
+      ⌊ q ⌋ ； s ≋ ⌊ p ⌋ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
+
+    ⊑cast⊑ᴿ :
+      ∀ {M M′ A A′ B′ p c′ μ′ s} →
+      CastMode μ′ →
+      SealModeStore★ μ′ (rightStoreⁱ ρ) →
+      μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+      (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ) →
+      widening ⊢ᶜ c′ ⦂ s →
+      ⌊ p ⌋ ； s ≋ ⌊ q ⌋ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
+
+    target-instantiationᴿ :
+      ∀ {Φ₀ Θᴸ Θᴿ}
+        {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+        {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          (suc Θᴸ) (suc Θᴿ)}
+        {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+        {W W′ : Term} {B C D : Ty} {s : Coercion}
+        {μ : ModeEnv}
+        {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          ∣ suc Θᴸ ⊢ D ⊑ C ⊣ suc Θᴿ}
+        {f : Φ₀ ∣ Θᴸ ⊢ `∀ D ⊑ B ⊣ Θᴿ}
+        {body-shape : ImprecisionShape} →
+      TargetInstantiationCreation
+        {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+        {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+        {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+        {s = s} {μ = μ} {r = r} {f = f}
+        {body-shape = body-shape}
+        (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
+          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r) →
+      ⇑ᴿᵢ Φ₀
+        ∣ Θᴸ ∣ suc Θᴿ
+        ∣ store-right zero ★ wf★ ∷ ρᴿ⁺ ∣ []
+        ⊢ᴿ Λ W ⊑ W′ ⟨ s ⟩
+        ⦂ `∀ D ⊑ ⇑ᵗ B
+        ∶ ⊑-target-lift-rightᵢ f
+
+    rename-storeᴿ :
+      ∀ {Φ₀ Ψ Θᴸ Θᴿ Δᴸ′ Δᴿ′}
+        {ρ₀ : StoreImp Φ₀ Θᴸ Θᴿ}
+        {ρ′ : StoreImp Ψ Δᴸ′ Δᴿ′}
+        {τ σ : Renameᵗ}
+        {M M′ : Term} {A B : Ty}
+        {p : Φ₀ ∣ Θᴸ ⊢ A ⊑ B ⊣ Θᴿ} →
+      (assm :
+        ∀ {a : ImpAssm} → a ∈ Φ₀ →
+          rename-assm²ᵢ τ σ a ∈ Ψ) →
+      (hτ : TyRenameWf Θᴸ Δᴸ′ τ) →
+      (hσ : TyRenameWf Θᴿ Δᴿ′ σ) →
+      RelStoreEmbeddingⁱ τ σ ρ₀ ρ′ →
+      Φ₀ ∣ Θᴸ ∣ Θᴿ ∣ ρ₀ ∣ []
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+      Δᴸ′ ∣ leftStoreⁱ ρ′ ∣ []
+        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A →
+      Δᴿ′ ∣ rightStoreⁱ ρ′ ∣ []
+        ⊢ renameᵗᵐ σ M′ ⦂ renameᵗ σ B →
+      Ψ ∣ Δᴸ′ ∣ Δᴿ′ ∣ ρ′ ∣ []
+        ⊢ᴿ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+        ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+        ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+
     closeᴿ :
       ∀ {N N′ D D′ A A′ q p u u′ s s′} →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ q →
-      QuotientWideningPair Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+      QuotientWideningPairᴿ Δᴸ Δᴿ ρ u u′ D D′ A A′ →
       widening ⊢ᶜ u ⦂ s →
       widening ⊢ᶜ u′ ⦂ s′ →
       s ；⌊ p ⌋≋ᵖ q ； s′ →
@@ -89,17 +347,28 @@ mutual
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ N ⟨ u ⟩ ⊑ N′ ⟨ u′ ⟩ ⦂ A ⊑ A′ ∶ p
 
-    paired-castᴿ :
-      ∀ {M M′ A A′ B B′ p q c c′} →
-      PairedCast Φ Δᴸ Δᴿ ρ c c′ p q →
+    paired-wideningᴿ :
+      ∀ {M M′ A A′ B B′ p q c c′ μ μ′ s s′ r} →
+      CastMode μ →
+      SealModeStore★ μ (leftStoreⁱ ρ) →
+      μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+      widening ⊢ᶜ c ⦂ s →
+      CastMode μ′ →
+      SealModeStore★ μ′ (rightStoreⁱ ρ) →
+      μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+      widening ⊢ᶜ c′ ⦂ s′ →
+      s ； ⌊ q ⌋ ≋ r →
+      ⌊ p ⌋ ； s′ ≋ r →
+      PairedWideningCompatible
+        Φ Δᴸ Δᴿ c c′ p q s s′ →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ⦂ B ⊑ B′ ∶ q
 
-  data _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
-      (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx)
-      (ρ : StoreImp Φ Δᴸ Δᴿ) (γ : CtxImp Φ Δᴸ Δᴿ) :
+  data _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_ :
+      (Φ : ImpCtx) (Δᴸ Δᴿ : TyCtx) →
+      StoreImp Φ Δᴸ Δᴿ → CtxImp Φ Δᴸ Δᴿ →
       Term → Term → (D D′ : Ty) →
       Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ → Set₁ where
 

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
@@ -195,7 +195,7 @@ close-routeᴿ :
     ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
 close-routeᴿ relation =
   closeᴿ relation
-    (quotient-id-widening
+    (quotient-id-wideningᴿ
       (proj₁ (proj₂ up-D-result))
       (proj₁ (proj₂ up-E-result)))
     (proj₂ (proj₂ up-D-result))
@@ -430,6 +430,18 @@ identity-A⊑identity-A =
     (IWF.⊑-tgt-wf glb-bad-A⊑A)
     (x⊑xᵀ Types.Z)
 
+identity-A⊑identity-Aᴿ :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ ƛ (` zero) ⊑ ƛ (` zero)
+    ⦂ glb-bad-A ⇒ glb-bad-A
+    ⊑ glb-bad-A ⇒ glb-bad-A
+    ∶ identity-A-function⊑identity-A-function
+identity-A⊑identity-Aᴿ =
+  ƛ⊑ƛᴿ
+    (IWF.⊑-src-wf glb-bad-A⊑A)
+    (IWF.⊑-tgt-wf glb-bad-A⊑A)
+    (x⊑xᴿ Types.Z)
+
 closed-identity-functionsᴿ :
   idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
     ⊢ᴿ ((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩
@@ -440,7 +452,7 @@ closed-identity-functionsᴿ :
 closed-identity-functionsᴿ =
   closeᴿ
     (paired-downᴿ
-      (ordinaryᴿ identity-A⊑identity-A)
+      identity-A⊑identity-Aᴿ
       id-only↓
       inner-D-typing
       (CastShape.shape-fun
@@ -452,7 +464,7 @@ closed-identity-functionsᴿ =
         (proj₂ (proj₂ up-E-result))
         (proj₂ (proj₂ down-E-result)))
       identity-function-quotient-square)
-    (quotient-id-widening outer-D-typing outer-E-typing)
+    (quotient-id-wideningᴿ outer-D-typing outer-E-typing)
     (CastShape.shape-fun
       (proj₂ (proj₂ down-D-result))
       (proj₂ (proj₂ up-D-result)))
@@ -546,7 +558,7 @@ two-function-casts-identity-reduction
 two-round-tripsᴿ :
   ∀ {W W′ : Term} →
   idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
-    ⊢ᴺ W ⊑ W′
+    ⊢ᴿ W ⊑ W′
     ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
   idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
     ⊢ᴿ
@@ -557,7 +569,7 @@ two-round-tripsᴿ :
         ⟨ up-E ⟩)
     ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
 two-round-tripsᴿ W⊑W′ =
-  round-tripᴿ (round-tripᴿ (ordinaryᴿ W⊑W′))
+  round-tripᴿ (round-tripᴿ W⊑W′)
 
 two-round-tripsᵀ :
   ∀ {W W′ : Term} →

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
@@ -11,6 +11,7 @@ module
 --   * Uses no quotient-indexed application or fused down/application/up rule.
 --   * Does not change the live term-imprecision relation.
 
+open import Agda.Builtin.Equality using (refl)
 open import Data.List using ([]; _∷_)
 open import Data.Nat using (zero)
 open import Data.Product using (_,_; proj₁; proj₂)
@@ -64,8 +65,6 @@ open import NuTerms using
   ; _⟨_⟩
   ; _[_]
   )
-open import PairedWideningCompatibility using
-  (compatible-source-inert)
 open import QuotientedTermImprecision using
   ( ƛ⊑ƛᵀ
   ; x⊑xᵀ
@@ -101,8 +100,10 @@ open import
   using
   ( id-only↓
   ; single↓
-  ; QuotientWideningCompatible
-  ; compatible-through-representatives
+  ; compatible-functionᴿ
+  ; compatible-target-activeᴿ
+  ; ReductionClosedQuotientWideningCompatible
+  ; compatible-through-representativesᴿ
   )
 open import
   proof.Quotient.NuImprecisionCompositionalQuotientExamples
@@ -115,6 +116,9 @@ open import
   )
 open import
   proof.Quotient.NuImprecisionReductionClosedQuotientDef
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment
+  using (smaller-single-term-substitutionᴿ)
 open import
   proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessProof
   using (assumption-membership-unique-idᵢ)
@@ -157,13 +161,13 @@ up-E-not-inert : C.Inert up-E → ⊥
 up-E-not-inert ()
 
 route-widening-compatible :
-  QuotientWideningCompatible (idᵢ zero) zero zero
+  ReductionClosedQuotientWideningCompatible (idᵢ zero) zero zero
     up-D up-E glb-lower-XY⊑ᵖYX glb-bad-A⊑A
     ⌊ glb-lower-XY⊑A ⌋ ⌊ glb-lower-YX⊑A ⌋
 route-widening-compatible =
-  compatible-through-representatives
+  compatible-through-representativesᴿ
     source-perm-refl source-swap-∀ν
-    (compatible-source-inert up-D-inert)
+    (compatible-target-activeᴿ up-D-inert up-E-not-inert)
 
 down-routeᴿ :
   ∀ {M M′} →
@@ -407,16 +411,17 @@ identity-function-quotient-square =
           (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ))))
 
 outer-function-compatible :
-  QuotientWideningCompatible (idᵢ zero) zero zero
+  ReductionClosedQuotientWideningCompatible (idᵢ zero) zero zero
     outer-D outer-E identity-function-quotient
     identity-A-function⊑identity-A-function
     (⌊ glb-lower-XY⊑A ⌋ ↦ˢ ⌊ glb-lower-XY⊑A ⌋)
     (⌊ glb-lower-YX⊑A ⌋ ↦ˢ ⌊ glb-lower-YX⊑A ⌋)
 outer-function-compatible =
-  compatible-through-representatives
+  compatible-through-representativesᴿ
     source-perm-refl
     (source-perm-↦ source-swap-∀ν source-swap-∀ν)
-    (compatible-source-inert outer-D-inert)
+    (compatible-functionᴿ
+      (compatible-target-activeᴿ up-D-inert up-E-not-inert))
 
 identity-A⊑identity-A :
   idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
@@ -505,6 +510,20 @@ closed-identity-functionsᵀ =
       (proj₂ (proj₂ up-E-result)))
     identity-function-quotient-square
 
+related-two-function-cast-applicationsᴿ :
+  ∀ {W W′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ
+      (((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩) · W
+      ⊑
+      (((ƛ (` zero)) ⟨ inner-E ⟩) ⟨ outer-E ⟩) · W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+related-two-function-cast-applicationsᴿ W⊑W′ =
+  closed-identity-functionsᴿ ·ᴿ W⊑W′
+
 related-two-function-cast-applicationsᵀ :
   ∀ {W W′} →
   idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
@@ -522,6 +541,31 @@ related-two-function-cast-applicationsᵀ W⊑W′ =
 ------------------------------------------------------------------------
 -- Reducing both successive function casts and the identity beta-redex
 ------------------------------------------------------------------------
+
+two-function-casts-two-beta-reduction :
+  ∀ {W c₁ d₁ c₂ d₂} →
+  Value W →
+  C.Inert c₂ →
+  ((((ƛ (` zero)) ⟨ c₁ C.↦ d₁ ⟩)
+      ⟨ c₂ C.↦ d₂ ⟩) · W)
+    —↠[ keep ∷ keep ∷ [] ]
+  (((ƛ (` zero)) · ((W ⟨ c₂ ⟩) ⟨ c₁ ⟩)) ⟨ d₁ ⟩)
+    ⟨ d₂ ⟩
+two-function-casts-two-beta-reduction
+    {W} {c₁} {d₁} {c₂} {d₂} vW inert-c₂ =
+  ↠-step
+    (pure-step
+      (β-↦
+        ((ƛ (` zero)) ⟨ c₁ C.↦ d₁ ⟩)
+        vW))
+    (↠-step
+      (ξ-⟨⟩
+        (pure-step
+          (β-↦
+            (ƛ (` zero))
+            (vW ⟨ inert-c₂ ⟩))))
+      ↠-refl)
+
 
 two-function-casts-identity-reduction :
   ∀ {W c₁ d₁ c₂ d₂} →
@@ -627,6 +671,40 @@ two-round-trips-substitutionᵀ
     body
     (two-round-tripsᵀ W⊑W′)
 
+two-round-trips-substitutionᴿ :
+  ∀ {N N′ W W′ B B′ pB} →
+  No• N →
+  No• N′ →
+  No• W →
+  No• W′ →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣
+      ctx-imp glb-bad-A glb-bad-A glb-bad-A⊑A ∷ []
+    ⊢ᴿ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ
+      N [
+        ((((W ⟨ down-D ⟩) ⟨ up-D ⟩) ⟨ down-D ⟩)
+          ⟨ up-D ⟩)
+      ]
+      ⊑
+      N′ [
+        ((((W′ ⟨ down-E ⟩) ⟨ up-E ⟩) ⟨ down-E ⟩)
+          ⟨ up-E ⟩)
+      ]
+    ⦂ B ⊑ B′ ∶ pB
+two-round-trips-substitutionᴿ
+    noN noN′ noW noW′ body W⊑W′ =
+  smaller-single-term-substitutionᴿ
+    (assumption-membership-unique-idᵢ zero)
+    noN noN′
+    (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noW))))
+    (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noW′))))
+    body
+    (two-round-tripsᴿ W⊑W′)
+
 ------------------------------------------------------------------------
 -- The inert route takes the expected three beta steps
 ------------------------------------------------------------------------
@@ -668,3 +746,69 @@ target-round-trip-argument-not-value :
 target-round-trip-argument-not-value
     ((vW′ ⟨ down-inert ⟩) ⟨ up-inert ⟩) =
   up-E-not-inert up-inert
+
+------------------------------------------------------------------------
+-- The bilateral square stops after the quotient argument has closed
+------------------------------------------------------------------------
+
+two-function-casts-two-beta-joinᴿ :
+  ∀ {W W′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ
+      (((ƛ (` zero)) · ((W ⟨ down-D ⟩) ⟨ up-D ⟩))
+        ⟨ down-D ⟩) ⟨ up-D ⟩
+      ⊑
+      (((ƛ (` zero)) · ((W′ ⟨ down-E ⟩) ⟨ up-E ⟩))
+        ⟨ down-E ⟩) ⟨ up-E ⟩
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+two-function-casts-two-beta-joinᴿ W⊑W′ =
+  round-tripᴿ
+    (identity-A⊑identity-Aᴿ ·ᴿ round-tripᴿ W⊑W′)
+
+
+two-function-casts-squareᴿ :
+  ∀ {W W′} →
+  Value W →
+  Value W′ →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ []
+    ⊢ᴿ↠
+      ((((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩) · W)
+      ⊑
+      ((((ƛ (` zero)) ⟨ inner-E ⟩) ⟨ outer-E ⟩) · W′)
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+two-function-casts-squareᴿ {W} {W′} vW vW′ W⊑W′ =
+  record
+    { sourceChanges = keep ∷ keep ∷ []
+    ; targetChanges = keep ∷ keep ∷ []
+    ; sourceResult =
+        (((ƛ (` zero)) · ((W ⟨ down-D ⟩) ⟨ up-D ⟩))
+          ⟨ down-D ⟩) ⟨ up-D ⟩
+    ; targetResult =
+        (((ƛ (` zero)) · ((W′ ⟨ down-E ⟩) ⟨ up-E ⟩))
+          ⟨ down-E ⟩) ⟨ up-E ⟩
+    ; resultCtx = idᵢ zero
+    ; resultLeftCtx = zero
+    ; resultRightCtx = zero
+    ; sourceCtxResult = refl
+    ; targetCtxResult = refl
+    ; resultStore = []
+    ; sourceStoreResult = refl
+    ; targetStoreResult = refl
+    ; resultSourceType = glb-bad-A
+    ; resultTargetType = glb-bad-A
+    ; sourceTypeResult = refl
+    ; targetTypeResult = refl
+    ; transportType = λ relation → relation
+    ; sourceReduction =
+        two-function-casts-two-beta-reduction vW down-D-inert
+    ; targetReduction =
+        two-function-casts-two-beta-reduction vW′ down-E-inert
+    ; resultImprecision =
+        two-function-casts-two-beta-joinᴿ W⊑W′
+    }

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientExamples.agda
@@ -1,0 +1,658 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientExamples
+  where
+
+-- File Charter:
+--   * Tests the smaller quotient relation on two successive function casts.
+--   * Uses the incomparable `∀`-permuted lower bounds from the endpoint-MLB
+--     examples, so the quotient index is genuinely non-ordinary.
+--   * Reduces through an identity lambda, forcing the quotient argument to be
+--     substituted before the final smaller-relation derivation.
+--   * Uses no quotient-indexed application or fused down/application/up rule.
+--   * Does not change the live term-imprecision relation.
+
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (zero)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Empty using (⊥)
+
+import CastImprecisionShape as CastShape
+import Coercions as C
+import ImprecisionWf as IWF
+import NarrowWiden as NW
+import Types
+open import NarrowWiden using
+  (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
+open import ForallPermutation using
+  (quotientᵖ; ≈∀-refl; ≈∀-⇒)
+open import Imprecision using (idᵢ)
+open import ImprecisionComposition using
+  ( ⌊_⌋
+  ; _↦ˢ_
+  ; _；⌊_⌋≋ᵖ_；_
+  ; source-perm-refl
+  ; source-perm-↦
+  ; source-swap-∀ν
+  ; quotient-boundary-square
+  ; comp-↦-↦
+  ; comp-∀-∀
+  ; comp-∀-ν
+  ; comp-idˣ-idˣ
+  ; comp-idˣ-tagˣ
+  ; comp-ν
+  ; comp-tagˣ-id★
+  )
+open import NuReduction using
+  ( keep
+  ; pure-step
+  ; ξ-⟨⟩
+  ; β
+  ; β-↦
+  ; ↠-step
+  ; ↠-refl
+  ; _—↠[_]_
+  )
+open import NuTermImprecision using (ctx-imp)
+open import NuTerms using
+  ( Term
+  ; Value
+  ; No•
+  ; no•-⟨⟩
+  ; `_
+  ; ƛ_
+  ; _·_
+  ; _⟨_⟩
+  ; _[_]
+  )
+open import PairedWideningCompatibility using
+  (compatible-source-inert)
+open import QuotientedTermImprecision using
+  ( ƛ⊑ƛᵀ
+  ; x⊑xᵀ
+  ; ·⊑·ᵀ
+  ; down⊑downᵀ
+  ; up⊑upᵀ
+  ; quotient-id-widening
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  ; _∣_∣_∣_∣_⊢ᴺᵖ_⊑_⦂_⊑ᵖ_∶_
+  )
+open import Types using
+  ( Ty
+  ; _⇒_
+  )
+open import proof.Compilation.CompileCoercions using
+  (coerce-upʷ-shape-idᵢ)
+open import proof.Core.Permutation.ForallPermutationTest using
+  ( glb-lower-XY≈YX
+  ; glb-lower-XY⊑XY
+  ; glb-lower-YX⊑YX
+  ; glb-lower-XY⊑ᵖYX
+  )
+open import proof.EndpointMLB.Core.MLBGlbExample using
+  ( glb-bad-A
+  ; glb-bad-A⊑A
+  ; glb-lower-XY
+  ; glb-lower-XY⊑A
+  ; glb-lower-YX
+  ; glb-lower-YX⊑A
+  )
+open import
+  proof.Quotient.NuImprecisionCompositionalQuotientDef
+  using
+  ( id-only↓
+  ; single↓
+  ; QuotientWideningCompatible
+  ; compatible-through-representatives
+  )
+open import
+  proof.Quotient.NuImprecisionCompositionalQuotientExamples
+  using
+  ( down-D
+  ; down-E
+  ; down-D-result
+  ; down-E-result
+  ; route-quotient-square
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessProof
+  using (assumption-membership-unique-idᵢ)
+open import
+  proof.Substitution.Parallel.NuImprecisionParallelTermSubstitutionLemma
+  using (quotiented-parallel-term-substitution-lemmaᵀ)
+open import
+  proof.Substitution.Term.NuImprecisionSingleSubstitutionEnvironmentLemma
+  using (quotiented-single-substitution-environment-lemmaᵀ)
+open import
+  proof.Substitution.Term.NuImprecisionTermSubstitutionProof
+  using (quotiented-term-substitution-proofᵀ)
+
+------------------------------------------------------------------------
+-- One nontrivial down/up round trip
+------------------------------------------------------------------------
+
+up-D-result =
+  coerce-upʷ-shape-idᵢ 82 glb-lower-XY⊑A
+
+up-E-result =
+  coerce-upʷ-shape-idᵢ 82 glb-lower-YX⊑A
+
+up-D : C.Coercion
+up-D = proj₁ up-D-result
+
+up-E : C.Coercion
+up-E = proj₁ up-E-result
+
+down-D-inert : C.Inert down-D
+down-D-inert = C.`∀ _
+
+down-E-inert : C.Inert down-E
+down-E-inert = C.gen _ _
+
+up-D-inert : C.Inert up-D
+up-D-inert = C.`∀ _
+
+up-E-not-inert : C.Inert up-E → ⊥
+up-E-not-inert ()
+
+route-widening-compatible :
+  QuotientWideningCompatible (idᵢ zero) zero zero
+    up-D up-E glb-lower-XY⊑ᵖYX glb-bad-A⊑A
+    ⌊ glb-lower-XY⊑A ⌋ ⌊ glb-lower-YX⊑A ⌋
+route-widening-compatible =
+  compatible-through-representatives
+    source-perm-refl source-swap-∀ν
+    (compatible-source-inert up-D-inert)
+
+down-routeᴿ :
+  ∀ {M M′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ M ⊑ M′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿᵖ M ⟨ down-D ⟩ ⊑ M′ ⟨ down-E ⟩
+    ⦂ glb-lower-XY ⊑ᵖ glb-lower-YX
+    ∶ glb-lower-XY⊑ᵖYX
+down-routeᴿ relation =
+  paired-downᴿ relation
+    id-only↓
+    (proj₁ (proj₂ down-D-result))
+    (proj₂ (proj₂ down-D-result))
+    id-only↓
+    (proj₁ (proj₂ down-E-result))
+    (proj₂ (proj₂ down-E-result))
+    route-quotient-square
+
+close-routeᴿ :
+  ∀ {M M′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿᵖ M ⊑ M′
+    ⦂ glb-lower-XY ⊑ᵖ glb-lower-YX
+    ∶ glb-lower-XY⊑ᵖYX →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ M ⟨ up-D ⟩ ⊑ M′ ⟨ up-E ⟩
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+close-routeᴿ relation =
+  closeᴿ relation
+    (quotient-id-widening
+      (proj₁ (proj₂ up-D-result))
+      (proj₁ (proj₂ up-E-result)))
+    (proj₂ (proj₂ up-D-result))
+    (proj₂ (proj₂ up-E-result))
+    route-quotient-square
+    route-widening-compatible
+
+round-tripᴿ :
+  ∀ {M M′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ M ⊑ M′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ (M ⟨ down-D ⟩) ⟨ up-D ⟩
+      ⊑ (M′ ⟨ down-E ⟩) ⟨ up-E ⟩
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+round-tripᴿ relation = close-routeᴿ (down-routeᴿ relation)
+
+------------------------------------------------------------------------
+-- The same round trip returns to the existing ordinary QTI relation
+------------------------------------------------------------------------
+
+down-routeᵀ :
+  ∀ {M M′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ M ⊑ M′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᵖ M ⟨ down-D ⟩ ⊑ M′ ⟨ down-E ⟩
+    ⦂ glb-lower-XY ⊑ᵖ glb-lower-YX
+    ∶ glb-lower-XY⊑ᵖYX
+down-routeᵀ relation =
+  down⊑downᵀ
+    (proj₁ (proj₂ down-D-result))
+    (proj₂ (proj₂ down-D-result))
+    (proj₁ (proj₂ down-E-result))
+    (proj₂ (proj₂ down-E-result))
+    relation glb-lower-XY⊑ᵖYX route-quotient-square
+
+close-routeᵀ :
+  ∀ {M M′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᵖ M ⊑ M′
+    ⦂ glb-lower-XY ⊑ᵖ glb-lower-YX
+    ∶ glb-lower-XY⊑ᵖYX →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ M ⟨ up-D ⟩ ⊑ M′ ⟨ up-E ⟩
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+close-routeᵀ relation =
+  up⊑upᵀ relation
+    (quotient-id-widening
+      (proj₁ (proj₂ up-D-result))
+      (proj₁ (proj₂ up-E-result)))
+    glb-bad-A⊑A
+    (proj₂ (proj₂ up-D-result))
+    (proj₂ (proj₂ up-E-result))
+    route-quotient-square
+
+round-tripᵀ :
+  ∀ {M M′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ M ⊑ M′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ (M ⟨ down-D ⟩) ⟨ up-D ⟩
+      ⊑ (M′ ⟨ down-E ⟩) ⟨ up-E ⟩
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+round-tripᵀ relation = close-routeᵀ (down-routeᵀ relation)
+
+------------------------------------------------------------------------
+-- The paired inner narrowing and outer widening function casts
+------------------------------------------------------------------------
+
+lower-identity-D⊑A :
+  idᵢ zero IWF.∣ zero
+    ⊢ glb-lower-XY ⇒ glb-lower-XY
+      ⊑ glb-bad-A ⇒ glb-bad-A
+    ⊣ zero
+lower-identity-D⊑A =
+  glb-lower-XY⊑A IWF.↦ glb-lower-XY⊑A
+
+lower-identity-E⊑A :
+  idᵢ zero IWF.∣ zero
+    ⊢ glb-lower-YX ⇒ glb-lower-YX
+      ⊑ glb-bad-A ⇒ glb-bad-A
+    ⊣ zero
+lower-identity-E⊑A =
+  glb-lower-YX⊑A IWF.↦ glb-lower-YX⊑A
+
+identity-A-function⊑identity-A-function :
+  idᵢ zero IWF.∣ zero
+    ⊢ glb-bad-A ⇒ glb-bad-A
+      ⊑ glb-bad-A ⇒ glb-bad-A
+    ⊣ zero
+identity-A-function⊑identity-A-function =
+  glb-bad-A⊑A IWF.↦ glb-bad-A⊑A
+
+identity-D-function⊑identity-D-function :
+  idᵢ zero IWF.∣ zero
+    ⊢ glb-lower-XY ⇒ glb-lower-XY
+      ⊑ glb-lower-XY ⇒ glb-lower-XY
+    ⊣ zero
+identity-D-function⊑identity-D-function =
+  glb-lower-XY⊑XY IWF.↦ glb-lower-XY⊑XY
+
+identity-function-quotient =
+  quotientᵖ ≈∀-refl
+    identity-D-function⊑identity-D-function
+    (≈∀-⇒ glb-lower-XY≈YX glb-lower-XY≈YX)
+
+inner-D : C.Coercion
+inner-D = up-D C.↦ down-D
+
+inner-E : C.Coercion
+inner-E = up-E C.↦ down-E
+
+outer-D : C.Coercion
+outer-D = down-D C.↦ up-D
+
+outer-E : C.Coercion
+outer-E = down-E C.↦ up-E
+
+inner-D-inert : C.Inert inner-D
+inner-D-inert = up-D C.↦ down-D
+
+inner-E-inert : C.Inert inner-E
+inner-E-inert = up-E C.↦ down-E
+
+outer-D-inert : C.Inert outer-D
+outer-D-inert = down-D C.↦ up-D
+
+outer-E-inert : C.Inert outer-E
+outer-E-inert = down-E C.↦ up-E
+
+inner-D-typing :
+  C.id-onlyᵈ ∣ zero ∣ []
+    ⊢ inner-D
+      ∶ glb-bad-A ⇒ glb-bad-A
+      ⊒ glb-lower-XY ⇒ glb-lower-XY
+inner-D-typing =
+  C.cast-fun
+    (proj₁ (proj₁ (proj₂ up-D-result)))
+    (proj₁ (proj₁ (proj₂ down-D-result))) ,
+  NW.cross
+    (proj₂ (proj₁ (proj₂ up-D-result))
+      NW.↦ proj₂ (proj₁ (proj₂ down-D-result)))
+
+inner-E-typing :
+  C.id-onlyᵈ ∣ zero ∣ []
+    ⊢ inner-E
+      ∶ glb-bad-A ⇒ glb-bad-A
+      ⊒ glb-lower-YX ⇒ glb-lower-YX
+inner-E-typing =
+  C.cast-fun
+    (proj₁ (proj₁ (proj₂ up-E-result)))
+    (proj₁ (proj₁ (proj₂ down-E-result))) ,
+  NW.cross
+    (proj₂ (proj₁ (proj₂ up-E-result))
+      NW.↦ proj₂ (proj₁ (proj₂ down-E-result)))
+
+outer-D-typing :
+  C.id-onlyᵈ ∣ zero ∣ []
+    ⊢ outer-D
+      ∶ glb-lower-XY ⇒ glb-lower-XY
+      ⊑ glb-bad-A ⇒ glb-bad-A
+outer-D-typing =
+  C.cast-fun
+    (proj₁ (proj₁ (proj₂ down-D-result)))
+    (proj₁ (proj₁ (proj₂ up-D-result))) ,
+  NW.cross
+    (proj₂ (proj₁ (proj₂ down-D-result))
+      NW.↦ proj₂ (proj₁ (proj₂ up-D-result)))
+
+outer-E-typing :
+  C.id-onlyᵈ ∣ zero ∣ []
+    ⊢ outer-E
+      ∶ glb-lower-YX ⇒ glb-lower-YX
+      ⊑ glb-bad-A ⇒ glb-bad-A
+outer-E-typing =
+  C.cast-fun
+    (proj₁ (proj₁ (proj₂ down-E-result)))
+    (proj₁ (proj₁ (proj₂ up-E-result))) ,
+  NW.cross
+    (proj₂ (proj₁ (proj₂ down-E-result))
+      NW.↦ proj₂ (proj₁ (proj₂ up-E-result)))
+
+identity-function-quotient-square :
+  (⌊ glb-lower-XY⊑A ⌋ ↦ˢ ⌊ glb-lower-XY⊑A ⌋)
+    ；⌊ identity-A-function⊑identity-A-function ⌋≋ᵖ
+      identity-function-quotient ；
+    (⌊ glb-lower-YX⊑A ⌋ ↦ˢ ⌊ glb-lower-YX⊑A ⌋)
+identity-function-quotient-square =
+  quotient-boundary-square
+    source-perm-refl
+    (comp-↦-↦
+      (comp-∀-∀
+        (comp-ν
+          (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★)))
+      (comp-∀-∀
+        (comp-ν
+          (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★))))
+    (source-perm-↦ source-swap-∀ν source-swap-∀ν)
+    (comp-↦-↦
+      (comp-∀-∀
+        (comp-∀-ν
+          (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ)))
+      (comp-∀-∀
+        (comp-∀-ν
+          (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ))))
+
+outer-function-compatible :
+  QuotientWideningCompatible (idᵢ zero) zero zero
+    outer-D outer-E identity-function-quotient
+    identity-A-function⊑identity-A-function
+    (⌊ glb-lower-XY⊑A ⌋ ↦ˢ ⌊ glb-lower-XY⊑A ⌋)
+    (⌊ glb-lower-YX⊑A ⌋ ↦ˢ ⌊ glb-lower-YX⊑A ⌋)
+outer-function-compatible =
+  compatible-through-representatives
+    source-perm-refl
+    (source-perm-↦ source-swap-∀ν source-swap-∀ν)
+    (compatible-source-inert outer-D-inert)
+
+identity-A⊑identity-A :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ ƛ (` zero) ⊑ ƛ (` zero)
+    ⦂ glb-bad-A ⇒ glb-bad-A
+    ⊑ glb-bad-A ⇒ glb-bad-A
+    ∶ identity-A-function⊑identity-A-function
+identity-A⊑identity-A =
+  ƛ⊑ƛᵀ
+    (IWF.⊑-src-wf glb-bad-A⊑A)
+    (IWF.⊑-tgt-wf glb-bad-A⊑A)
+    (x⊑xᵀ Types.Z)
+
+closed-identity-functionsᴿ :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ ((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩
+      ⊑ ((ƛ (` zero)) ⟨ inner-E ⟩) ⟨ outer-E ⟩
+    ⦂ glb-bad-A ⇒ glb-bad-A
+    ⊑ glb-bad-A ⇒ glb-bad-A
+    ∶ identity-A-function⊑identity-A-function
+closed-identity-functionsᴿ =
+  closeᴿ
+    (paired-downᴿ
+      (ordinaryᴿ identity-A⊑identity-A)
+      id-only↓
+      inner-D-typing
+      (CastShape.shape-fun
+        (proj₂ (proj₂ up-D-result))
+        (proj₂ (proj₂ down-D-result)))
+      id-only↓
+      inner-E-typing
+      (CastShape.shape-fun
+        (proj₂ (proj₂ up-E-result))
+        (proj₂ (proj₂ down-E-result)))
+      identity-function-quotient-square)
+    (quotient-id-widening outer-D-typing outer-E-typing)
+    (CastShape.shape-fun
+      (proj₂ (proj₂ down-D-result))
+      (proj₂ (proj₂ up-D-result)))
+    (CastShape.shape-fun
+      (proj₂ (proj₂ down-E-result))
+      (proj₂ (proj₂ up-E-result)))
+    identity-function-quotient-square
+    outer-function-compatible
+
+closed-identity-functionsᵀ :
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ ((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩
+      ⊑ ((ƛ (` zero)) ⟨ inner-E ⟩) ⟨ outer-E ⟩
+    ⦂ glb-bad-A ⇒ glb-bad-A
+    ⊑ glb-bad-A ⇒ glb-bad-A
+    ∶ identity-A-function⊑identity-A-function
+closed-identity-functionsᵀ =
+  up⊑upᵀ
+    (down⊑downᵀ
+      inner-D-typing
+      (CastShape.shape-fun
+        (proj₂ (proj₂ up-D-result))
+        (proj₂ (proj₂ down-D-result)))
+      inner-E-typing
+      (CastShape.shape-fun
+        (proj₂ (proj₂ up-E-result))
+        (proj₂ (proj₂ down-E-result)))
+      identity-A⊑identity-A
+      identity-function-quotient
+      identity-function-quotient-square)
+    (quotient-id-widening outer-D-typing outer-E-typing)
+    identity-A-function⊑identity-A-function
+    (CastShape.shape-fun
+      (proj₂ (proj₂ down-D-result))
+      (proj₂ (proj₂ up-D-result)))
+    (CastShape.shape-fun
+      (proj₂ (proj₂ down-E-result))
+      (proj₂ (proj₂ up-E-result)))
+    identity-function-quotient-square
+
+related-two-function-cast-applicationsᵀ :
+  ∀ {W W′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ
+      (((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩) · W
+      ⊑
+      (((ƛ (` zero)) ⟨ inner-E ⟩) ⟨ outer-E ⟩) · W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+related-two-function-cast-applicationsᵀ W⊑W′ =
+  ·⊑·ᵀ closed-identity-functionsᵀ W⊑W′
+
+------------------------------------------------------------------------
+-- Reducing both successive function casts and the identity beta-redex
+------------------------------------------------------------------------
+
+two-function-casts-identity-reduction :
+  ∀ {W c₁ d₁ c₂ d₂} →
+  Value W →
+  C.Inert c₁ →
+  C.Inert c₂ →
+  ((((ƛ (` zero)) ⟨ c₁ C.↦ d₁ ⟩)
+      ⟨ c₂ C.↦ d₂ ⟩) · W)
+    —↠[ keep ∷ keep ∷ keep ∷ [] ]
+  ((((W ⟨ c₂ ⟩) ⟨ c₁ ⟩) ⟨ d₁ ⟩) ⟨ d₂ ⟩)
+two-function-casts-identity-reduction
+    {W} {c₁} {d₁} {c₂} {d₂} vW inert-c₁ inert-c₂ =
+  ↠-step
+    (pure-step
+      (β-↦
+        ((ƛ (` zero)) ⟨ c₁ C.↦ d₁ ⟩)
+        vW))
+    (↠-step
+      (ξ-⟨⟩
+        (pure-step
+          (β-↦
+            (ƛ (` zero))
+            (vW ⟨ inert-c₂ ⟩))))
+      (↠-step
+        (ξ-⟨⟩
+          (ξ-⟨⟩
+            (pure-step
+              (β ((vW ⟨ inert-c₂ ⟩) ⟨ inert-c₁ ⟩)))))
+        ↠-refl))
+
+-- Relation-level endpoint after both round trips
+------------------------------------------------------------------------
+
+two-round-tripsᴿ :
+  ∀ {W W′ : Term} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ
+      ((((W ⟨ down-D ⟩) ⟨ up-D ⟩) ⟨ down-D ⟩)
+        ⟨ up-D ⟩)
+      ⊑
+      ((((W′ ⟨ down-E ⟩) ⟨ up-E ⟩) ⟨ down-E ⟩)
+        ⟨ up-E ⟩)
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+two-round-tripsᴿ W⊑W′ =
+  round-tripᴿ (round-tripᴿ (ordinaryᴿ W⊑W′))
+
+two-round-tripsᵀ :
+  ∀ {W W′ : Term} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ
+      ((((W ⟨ down-D ⟩) ⟨ up-D ⟩) ⟨ down-D ⟩)
+        ⟨ up-D ⟩)
+      ⊑
+      ((((W′ ⟨ down-E ⟩) ⟨ up-E ⟩) ⟨ down-E ⟩)
+        ⟨ up-E ⟩)
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A
+two-round-tripsᵀ W⊑W′ =
+  round-tripᵀ (round-tripᵀ W⊑W′)
+
+------------------------------------------------------------------------
+-- Arbitrary lambda bodies accept the closed quotient argument
+------------------------------------------------------------------------
+
+two-round-trips-substitutionᵀ :
+  ∀ {N N′ W W′ B B′ pB} →
+  No• N →
+  No• N′ →
+  No• W →
+  No• W′ →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣
+      ctx-imp glb-bad-A glb-bad-A glb-bad-A⊑A ∷ []
+    ⊢ᴺ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ W ⊑ W′
+    ⦂ glb-bad-A ⊑ glb-bad-A ∶ glb-bad-A⊑A →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ
+      N [
+        ((((W ⟨ down-D ⟩) ⟨ up-D ⟩) ⟨ down-D ⟩)
+          ⟨ up-D ⟩)
+      ]
+      ⊑
+      N′ [
+        ((((W′ ⟨ down-E ⟩) ⟨ up-E ⟩) ⟨ down-E ⟩)
+          ⟨ up-E ⟩)
+      ]
+    ⦂ B ⊑ B′ ∶ pB
+two-round-trips-substitutionᵀ
+    noN noN′ noW noW′ body W⊑W′ =
+  quotiented-term-substitution-proofᵀ
+    quotiented-parallel-term-substitution-lemmaᵀ
+    quotiented-single-substitution-environment-lemmaᵀ
+    (assumption-membership-unique-idᵢ zero)
+    noN noN′
+    (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noW))))
+    (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ (no•-⟨⟩ noW′))))
+    body
+    (two-round-tripsᵀ W⊑W′)
+
+------------------------------------------------------------------------
+-- The inert route takes the expected three beta steps
+------------------------------------------------------------------------
+
+source-two-function-casts-identity-reduction :
+  ∀ {W} →
+  Value W →
+  ((((ƛ (` zero)) ⟨ inner-D ⟩) ⟨ outer-D ⟩) · W)
+    —↠[ keep ∷ keep ∷ keep ∷ [] ]
+  ((((W ⟨ down-D ⟩) ⟨ up-D ⟩) ⟨ down-D ⟩)
+    ⟨ up-D ⟩)
+source-two-function-casts-identity-reduction vW =
+  two-function-casts-identity-reduction
+    vW up-D-inert down-D-inert
+
+------------------------------------------------------------------------
+-- The permuted route must allocate before the second function beta
+------------------------------------------------------------------------
+
+target-first-function-cast-reduction :
+  ∀ {W′} →
+  Value W′ →
+  ((((ƛ (` zero)) ⟨ inner-E ⟩) ⟨ outer-E ⟩) · W′)
+    —↠[ keep ∷ [] ]
+  (((ƛ (` zero)) ⟨ inner-E ⟩) · (W′ ⟨ down-E ⟩))
+    ⟨ up-E ⟩
+target-first-function-cast-reduction vW′ =
+  ↠-step
+    (pure-step
+      (β-↦
+        ((ƛ (` zero)) ⟨ inner-E-inert ⟩)
+        vW′))
+    ↠-refl
+
+target-round-trip-argument-not-value :
+  ∀ {W′} →
+  Value ((W′ ⟨ down-E ⟩) ⟨ up-E ⟩) →
+  ⊥
+target-round-trip-argument-not-value
+    ((vW′ ⟨ down-inert ⟩) ⟨ up-inert ⟩) =
+  up-E-not-inert up-inert

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientIdOnlyCastAudit.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientIdOnlyCastAudit.agda
@@ -1,0 +1,122 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientIdOnlyCastAudit
+  where
+
+-- File Charter:
+--   * Proves that all four one-sided id-only cast rules are admissible in the
+--     smaller ordinary relation by relaxing their coercion typing to the
+--     ordinary tag-or-id cast mode.
+--   * Shows that the smaller relation does not need polarity-specific
+--     id-only cast constructors.
+--   * Imports no live term-imprecision judgment and changes no relation.
+
+open import CastImprecisionShape using
+  (narrowing; widening; _⊢ᶜ_⦂_)
+open import Coercions using
+  (Coercion; id-onlyᵈ; id-only≤tag-or-idᵈ)
+open import Imprecision using (ImpCtx)
+open import ImprecisionComposition using
+  (⌊_⌋; _；_≋_)
+open import ImprecisionWf using
+  (_∣_⊢_⊑_⊣_)
+open import NarrowWiden using
+  ( _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  ; narrow-mode-relax
+  ; widen-mode-relax
+  )
+open import NuTermImprecision using
+  ( CtxImp
+  ; StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; seal★-tag-or-id
+  )
+open import NuTerms using
+  (Term; _⟨_⟩)
+open import TermTyping using
+  (cast-tag-or-id)
+open import Types using
+  (Ty; TyCtx)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+
+
+source-id-narrowingᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A B B′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {c : Coercion} {s} →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  narrowing ⊢ᶜ c ⦂ s →
+  s ； ⌊ p ⌋ ≋ ⌊ q ⌋ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
+source-id-narrowingᴿ c⊒ relation q c-shape composition =
+  cast⊒⊑ᴿ cast-tag-or-id seal★-tag-or-id
+    (narrow-mode-relax id-only≤tag-or-idᵈ c⊒)
+    relation q c-shape composition
+
+
+source-id-wideningᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A B B′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {c : Coercion} {s} →
+  id-onlyᵈ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) →
+  widening ⊢ᶜ c ⦂ s →
+  s ； ⌊ q ⌋ ≋ ⌊ p ⌋ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⟨ c ⟩ ⊑ M′ ⦂ B ⊑ B′ ∶ q
+source-id-wideningᴿ c⊑ relation q c-shape composition =
+  cast⊑⊑ᴿ cast-tag-or-id seal★-tag-or-id
+    (widen-mode-relax id-only≤tag-or-idᵈ c⊑)
+    relation q c-shape composition
+
+
+target-id-narrowingᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A A′ B′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {c′ : Coercion} {s} →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊒ B′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ) →
+  narrowing ⊢ᶜ c′ ⦂ s →
+  ⌊ q ⌋ ； s ≋ ⌊ p ⌋ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
+target-id-narrowingᴿ c′⊒ relation q c′-shape composition =
+  ⊑cast⊒ᴿ cast-tag-or-id seal★-tag-or-id
+    (narrow-mode-relax id-only≤tag-or-idᵈ c′⊒)
+    relation q c′-shape composition
+
+
+target-id-wideningᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A A′ B′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {c′ : Coercion} {s} →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ A′ ⊑ B′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+  (q : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ) →
+  widening ⊢ᶜ c′ ⦂ s →
+  ⌊ p ⌋ ； s ≋ ⌊ q ⌋ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⟨ c′ ⟩ ⦂ A ⊑ B′ ∶ q
+target-id-wideningᴿ c′⊑ relation q c′-shape composition =
+  ⊑cast⊑ᴿ cast-tag-or-id seal★-tag-or-id
+    (widen-mode-relax id-only≤tag-or-idᵈ c′⊑)
+    relation q c′-shape composition

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment.agda
@@ -1,0 +1,418 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientSingleSubstitutionExperiment
+  where
+
+-- File Charter:
+--   * Derives fully indexed single-variable substitution for the independent
+--     smaller ordinary relation from its parallel-substitution theorem.
+--   * Builds the complete Kripke substitution environment by recursion on
+--     ordinary lambdas and paired or source-only type binders.
+--   * Uses only the smaller relation's own term-context and type-world
+--     weakening theorems; it imports no live term-imprecision relation.
+--   * Contains no postulate, hole, permissive option, termination bypass, or
+--     catch-all clause.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using (_∷_)
+open import Data.Nat using (suc; zero)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+
+open import Imprecision using
+  (_ˣ⊑★; _ˣ⊑ˣ_; ⇑ᴸᵢ; ⇑ᵢ)
+open import ImprecisionWf using
+  (ImpCtx; _∣_⊢_⊑_⊣_)
+open import NuTermImprecision using
+  ( CtxImp
+  ; LiftCtxⁱ
+  ; LiftLeftCtxⁱ
+  ; LiftLeftStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; ctx-imp
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  )
+open import NuTerms using
+  ( No•
+  ; Substˣ
+  ; Term
+  ; extˢˣ
+  ; no•-`
+  ; renameᵗᵐ
+  ; renameˣᵐ
+  ; singleEnv
+  ; ↑ᵗᵐ
+  ; _[_]
+  )
+open import Types using
+  (S; Ty; TyCtx; Z; renameᵗ; ⇑ᵗ; _∋_⦂_)
+open import proof.Core.Properties.NuTermProperties using
+  ( renameᵗᵐ-preserves-No•
+  ; renameˣᵐ-preserves-No•
+  )
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  (⊑-lift∀ᵢ; ⊑-source-liftνᵢ)
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDef
+  using
+  ( AssumptionMembershipUnique
+  ; PrecisionIndexUnique
+  )
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessLemma
+  using (assumption-membership-unique→precision-index-unique)
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessProof
+  using
+  ( assumption-membership-unique-matched
+  ; assumption-membership-unique-source
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( x⊑xᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientSubstitutionExperiment
+  using
+  ( SmallerSubstitutionEnvironmentFamilyᴿ
+  ; SmallerSubstitutionFrameᴿ
+  ; smaller-parallel-term-substitutionᴿ
+  ; substitution-frame-idᴿ
+  ; substitution-frame-ƛᴿ
+  ; substitution-frame-Λ-leftᴿ
+  ; substitution-frame-Λᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientTermContextShiftExperiment
+  using (smaller-term-context-shiftᴿ)
+open import
+  proof.Quotient.NuImprecisionReductionClosedWorldRenameExperiment
+  using
+  ( smaller-paired-type-world-weakenᴿ
+  ; smaller-source-type-world-weakenᴿ
+  )
+
+
+substitution-frame-preserves-uniqueᴿ :
+  ∀ {Φ₀ : ImpCtx} {Δ₀ᴸ Δ₀ᴿ : TyCtx}
+    {ρ₀ : StoreImp Φ₀ Δ₀ᴸ Δ₀ᴿ}
+    {γ₀ δ₀ : CtxImp Φ₀ Δ₀ᴸ Δ₀ᴿ}
+    {τ₀ τ₀′ : Substˣ}
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {γ δ : CtxImp Φ Δᴸ Δᴿ}
+    {τ τ′ : Substˣ} →
+  SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+    ρ γ δ τ τ′ →
+  AssumptionMembershipUnique Φ₀ →
+  AssumptionMembershipUnique Φ
+substitution-frame-preserves-uniqueᴿ
+    substitution-frame-idᴿ unique =
+  unique
+substitution-frame-preserves-uniqueᴿ
+    (substitution-frame-ƛᴿ frame) unique =
+  substitution-frame-preserves-uniqueᴿ frame unique
+substitution-frame-preserves-uniqueᴿ
+    (substitution-frame-Λᴿ frame liftρ liftγ liftδ) unique =
+  assumption-membership-unique-matched
+    (substitution-frame-preserves-uniqueᴿ frame unique)
+substitution-frame-preserves-uniqueᴿ
+    (substitution-frame-Λ-leftᴿ frame liftρ liftγ liftδ) unique =
+  assumption-membership-unique-source
+    (substitution-frame-preserves-uniqueᴿ frame unique)
+
+
+private
+  paired-unlift-lookupᴿ :
+    ∀ {Φ Ψ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {γ↑ : CtxImp Ψ (suc Δᴸ) (suc Δᴿ)}
+      {x A B p} →
+    LiftCtxⁱ Ψ γ γ↑ →
+    γ↑ ∋ x ⦂ ctx-imp A B p →
+    ∃[ A₀ ] ∃[ B₀ ] ∃[ p₀ ]
+      (γ ∋ x ⦂ ctx-imp A₀ B₀ p₀) ×
+      A ≡ renameᵗ suc A₀ ×
+      B ≡ renameᵗ suc B₀
+  paired-unlift-lookupᴿ lift-ctx-[] ()
+  paired-unlift-lookupᴿ
+      (lift-ctx-∷ {A = A} {B = B} {p = p} shape liftγ) Z =
+    A , B , p , Z , refl , refl
+  paired-unlift-lookupᴿ
+      (lift-ctx-∷ shape liftγ) (S x∈)
+      with paired-unlift-lookupᴿ liftγ x∈
+  paired-unlift-lookupᴿ
+      (lift-ctx-∷ shape liftγ) (S x∈)
+      | A , B , p , x∈₀ , refl , refl =
+    A , B , p , S x∈₀ , refl , refl
+
+
+  source-unlift-lookupᴿ :
+    ∀ {Φ Ψ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {γ↑ : CtxImp Ψ (suc Δᴸ) Δᴿ}
+      {x A B p} →
+    LiftLeftCtxⁱ Ψ γ γ↑ →
+    γ↑ ∋ x ⦂ ctx-imp A B p →
+    ∃[ A₀ ] ∃[ B₀ ] ∃[ p₀ ]
+      (γ ∋ x ⦂ ctx-imp A₀ B₀ p₀) ×
+      A ≡ renameᵗ suc A₀ ×
+      B ≡ B₀
+  source-unlift-lookupᴿ lift-left-ctx-[] ()
+  source-unlift-lookupᴿ
+      (lift-left-ctx-∷
+        {A = A} {B = B} {p = p} shape liftγ) Z =
+    A , B , p , Z , refl , refl
+  source-unlift-lookupᴿ
+      (lift-left-ctx-∷ shape liftγ) (S x∈)
+      with source-unlift-lookupᴿ liftγ x∈
+  source-unlift-lookupᴿ
+      (lift-left-ctx-∷ shape liftγ) (S x∈)
+      | A , B , p , x∈₀ , refl , refl =
+    A , B , p , S x∈₀ , refl , refl
+
+
+  smaller-lambda-substitution-environmentᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ : StoreImp Φ Δᴸ Δᴿ}
+      {γ δ : CtxImp Φ Δᴸ Δᴿ}
+      {τ τ′ : Substˣ} {A B : Ty}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    (∀ {x C D q} →
+      γ ∋ x ⦂ ctx-imp C D q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+        ⊢ᴿ τ x ⊑ τ′ x ⦂ C ⊑ D ∶ q) →
+    (∀ x → No• (τ x)) →
+    (∀ x → No• (τ′ x)) →
+    (∀ {x C D q} →
+      ctx-imp A B p ∷ γ ∋ x ⦂ ctx-imp C D q →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ ctx-imp A B p ∷ δ
+        ⊢ᴿ extˢˣ τ x ⊑ extˢˣ τ′ x
+        ⦂ C ⊑ D ∶ q) ×
+    (∀ x → No• (extˢˣ τ x)) ×
+    (∀ x → No• (extˢˣ τ′ x))
+  smaller-lambda-substitution-environmentᴿ related noτ noτ′ =
+    (λ { Z → x⊑xᴿ Z
+       ; (S x∈) →
+           smaller-term-context-shiftᴿ
+             (noτ _) (noτ′ _) (related x∈)
+       }) ,
+    (λ { zero → no•-`
+       ; (suc x) → renameˣᵐ-preserves-No• suc (noτ x)
+       }) ,
+    λ { zero → no•-`
+      ; (suc x) → renameˣᵐ-preserves-No• suc (noτ′ x)
+      }
+
+
+  smaller-substitution-environment-paired-type-liftᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ : StoreImp Φ Δᴸ Δᴿ}
+      {ρ↑ : StoreImp
+        ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        (suc Δᴸ) (suc Δᴿ)}
+      {γ δ : CtxImp Φ Δᴸ Δᴿ}
+      {γ↑ δ↑ : CtxImp
+        ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        (suc Δᴸ) (suc Δᴿ)}
+      {τ τ′ : Substˣ} →
+    AssumptionMembershipUnique Φ →
+    LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ↑ →
+    LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ↑ →
+    LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) δ δ↑ →
+    (∀ {x A B p} →
+      γ ∋ x ⦂ ctx-imp A B p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+        ⊢ᴿ τ x ⊑ τ′ x ⦂ A ⊑ B ∶ p) →
+    (∀ x → No• (τ x)) →
+    (∀ x → No• (τ′ x)) →
+    (∀ {x A B p} →
+      γ↑ ∋ x ⦂ ctx-imp A B p →
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ↑ ∣ δ↑
+        ⊢ᴿ ↑ᵗᵐ τ x ⊑ ↑ᵗᵐ τ′ x
+        ⦂ A ⊑ B ∶ p) ×
+    (∀ x → No• (↑ᵗᵐ τ x)) ×
+    (∀ x → No• (↑ᵗᵐ τ′ x))
+  smaller-substitution-environment-paired-type-liftᴿ
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ↑ = ρ↑} {γ↑ = γ↑} {δ↑ = δ↑}
+      {τ = τ} {τ′ = τ′}
+      unique liftρ liftγ liftδ
+      related noτ noτ′ =
+    related↑ ,
+    (λ x → renameᵗᵐ-preserves-No• suc (noτ x)) ,
+    λ x → renameᵗᵐ-preserves-No• suc (noτ′ x)
+    where
+    unique↑ =
+      assumption-membership-unique-matched unique
+
+    precision↑ : PrecisionIndexUnique _
+    precision↑ =
+      assumption-membership-unique→precision-index-unique unique↑
+
+    related↑ :
+      ∀ {x A B p} →
+      γ↑ ∋ x ⦂ ctx-imp A B p →
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ↑ ∣ δ↑
+        ⊢ᴿ ↑ᵗᵐ τ x ⊑ ↑ᵗᵐ τ′ x ⦂ A ⊑ B ∶ p
+    related↑ {p = p↑} x∈
+        with paired-unlift-lookupᴿ liftγ x∈
+    related↑ {x = x} {p = p↑} x∈
+        | A , B , p , x∈₀ , refl , refl
+        with precision↑ (⊑-lift∀ᵢ p) p↑
+    related↑ {x = x} {p = p↑} x∈
+        | A , B , p , x∈₀ , refl , refl | refl =
+      smaller-paired-type-world-weakenᴿ
+        unique↑ liftρ liftδ
+        (noτ x) (noτ′ x) (related x∈₀)
+
+
+  smaller-substitution-environment-source-type-liftᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ : StoreImp Φ Δᴸ Δᴿ}
+      {ρ↑ : StoreImp
+        ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+      {γ δ : CtxImp Φ Δᴸ Δᴿ}
+      {γ↑ δ↑ : CtxImp
+        ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+      {τ τ′ : Substˣ} →
+    AssumptionMembershipUnique Φ →
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ↑ →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ↑ →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) δ δ↑ →
+    (∀ {x A B p} →
+      γ ∋ x ⦂ ctx-imp A B p →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+        ⊢ᴿ τ x ⊑ τ′ x ⦂ A ⊑ B ∶ p) →
+    (∀ x → No• (τ x)) →
+    (∀ x → No• (τ′ x)) →
+    (∀ {x A B p} →
+      γ↑ ∋ x ⦂ ctx-imp A B p →
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+        ∣ suc Δᴸ ∣ Δᴿ ∣ ρ↑ ∣ δ↑
+        ⊢ᴿ ↑ᵗᵐ τ x ⊑ τ′ x
+        ⦂ A ⊑ B ∶ p) ×
+    (∀ x → No• (↑ᵗᵐ τ x)) ×
+    (∀ x → No• (τ′ x))
+  smaller-substitution-environment-source-type-liftᴿ
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ↑ = ρ↑} {γ↑ = γ↑} {δ↑ = δ↑}
+      {τ = τ} {τ′ = τ′}
+      unique liftρ liftγ liftδ
+      related noτ noτ′ =
+    related↑ ,
+    (λ x → renameᵗᵐ-preserves-No• suc (noτ x)) ,
+    noτ′
+    where
+    unique↑ =
+      assumption-membership-unique-source unique
+
+    precision↑ : PrecisionIndexUnique _
+    precision↑ =
+      assumption-membership-unique→precision-index-unique unique↑
+
+    related↑ :
+      ∀ {x A B p} →
+      γ↑ ∋ x ⦂ ctx-imp A B p →
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+        ∣ suc Δᴸ ∣ Δᴿ ∣ ρ↑ ∣ δ↑
+        ⊢ᴿ ↑ᵗᵐ τ x ⊑ τ′ x ⦂ A ⊑ B ∶ p
+    related↑ {p = p↑} x∈
+        with source-unlift-lookupᴿ liftγ x∈
+    related↑ {x = x} {p = p↑} x∈
+        | A , B , p , x∈₀ , refl , refl
+        with precision↑ (⊑-source-liftνᵢ p) p↑
+    related↑ {x = x} {p = p↑} x∈
+        | A , B , p , x∈₀ , refl , refl | refl =
+      smaller-source-type-world-weakenᴿ
+        unique↑ liftρ liftδ
+        (noτ x) (noτ′ x) (related x∈₀)
+
+
+smaller-single-substitution-environmentᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {V V′ : Term} {A A′ : Ty}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  AssumptionMembershipUnique Φ →
+  No• V → No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ V ⊑ V′ ⦂ A ⊑ A′ ∶ pA →
+  SmallerSubstitutionEnvironmentFamilyᴿ
+    ρ (ctx-imp A A′ pA ∷ γ) γ
+    (singleEnv V) (singleEnv V′)
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument substitution-frame-idᴿ =
+  (λ { Z → argument
+     ; (S x∈) → x⊑xᴿ x∈
+     }) ,
+  (λ { zero → noV
+     ; (suc x) → no•-`
+     }) ,
+  λ { zero → noV′
+    ; (suc x) → no•-`
+    }
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument
+    (substitution-frame-ƛᴿ frame)
+    with smaller-single-substitution-environmentᴿ
+      unique noV noV′ argument frame
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument
+    (substitution-frame-ƛᴿ frame)
+    | related , noτ , noτ′ =
+  smaller-lambda-substitution-environmentᴿ related noτ noτ′
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument
+    (substitution-frame-Λᴿ frame liftρ liftγ liftδ)
+    with smaller-single-substitution-environmentᴿ
+      unique noV noV′ argument frame
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument
+    (substitution-frame-Λᴿ frame liftρ liftγ liftδ)
+    | related , noτ , noτ′ =
+  smaller-substitution-environment-paired-type-liftᴿ
+    (substitution-frame-preserves-uniqueᴿ frame unique)
+    liftρ liftγ liftδ related noτ noτ′
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument
+    (substitution-frame-Λ-leftᴿ frame liftρ liftγ liftδ)
+    with smaller-single-substitution-environmentᴿ
+      unique noV noV′ argument frame
+smaller-single-substitution-environmentᴿ
+    unique noV noV′ argument
+    (substitution-frame-Λ-leftᴿ frame liftρ liftγ liftδ)
+    | related , noτ , noτ′ =
+  smaller-substitution-environment-source-type-liftᴿ
+    (substitution-frame-preserves-uniqueᴿ frame unique)
+    liftρ liftγ liftδ related noτ noτ′
+
+
+smaller-single-term-substitutionᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {N N′ V V′ : Term} {A A′ B B′ : Ty}
+    {pA : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {pB : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  AssumptionMembershipUnique Φ →
+  No• N → No• N′ → No• V → No• V′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ ctx-imp A A′ pA ∷ γ
+    ⊢ᴿ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ V ⊑ V′ ⦂ A ⊑ A′ ∶ pA →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ N [ V ] ⊑ N′ [ V′ ] ⦂ B ⊑ B′ ∶ pB
+smaller-single-term-substitutionᴿ
+    unique noN noN′ noV noV′ body argument =
+  smaller-parallel-term-substitutionᴿ
+    (smaller-single-substitution-environmentᴿ
+      unique noV noV′ argument)
+    noN noN′ body

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda
@@ -1,0 +1,964 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientSubstitutionExperiment
+  where
+
+-- File Charter:
+--   * Tests parallel and single term substitution for the independent smaller
+--     ordinary and one-boundary quotient-imprecision relations.
+--   * Defines the genuine binder frame and Kripke substitution-environment
+--     family needed by structurally recursive parallel substitution.
+--   * Reconstructs every store-indexed premise after arbitrary proof-only
+--     allocation prefixes.
+--   * Keeps theorem conclusions fully indexed at their use sites.
+--   * Imports neither the live term-imprecision relation nor any theorem that
+--     converts through it.
+--   * Contains no postulate, hole, permissive option, termination bypass, or
+--     catch-all clause.
+
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (there)
+open import Data.Nat using (suc; zero)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using
+  (subst; sym)
+
+open import Conversion using
+  (weaken-conceal-conversion; weaken-reveal-conversion)
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑★; _ˣ⊑ˣ_; ⇑ᴸᵢ; ⇑ᵢ)
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NarrowWiden using (narrow-weaken; widen-weaken)
+open import NuTermImprecision using
+  ( CtxImp
+  ; LiftCtxⁱ
+  ; LiftLeftCtxⁱ
+  ; LiftLeftStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreCorresponds
+  ; StoreImp
+  ; correspondence-linked
+  ; correspondence-stored
+  ; ctx-imp
+  ; leftCtxⁱ
+  ; leftStoreⁱ
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  ; lift-left-store-left
+  ; lift-left-store-link
+  ; lift-left-store-right
+  ; lift-left-store-∷
+  ; lift-store-left
+  ; lift-store-link
+  ; lift-store-right
+  ; lift-store-∷
+  ; rightStoreⁱ
+  ; rightCtxⁱ
+  ; store-left
+  ; store-link
+  ; store-matched
+  ; store-right
+  )
+open import NuTerms using
+  ( Closedᵐ
+  ; No•
+  ; Substˣ
+  ; Term
+  ; Value
+  ; extˢˣ
+  ; no•-$
+  ; no•-ƛ
+  ; no•-Λ
+  ; no•-·
+  ; no•-ν
+  ; no•-⊕
+  ; no•-`
+  ; no•-⟨⟩
+  ; no•-blame
+  ; substˣᵐ
+  ; ↑ᵗᵐ
+  )
+open import Store using (StoreIncl; StoreIncl-cons)
+open import TermTyping using (forget)
+open import Types using
+  (Ty; TyCtx; S; Z; _∋_⦂_; ⇑ᵗ)
+open import proof.Core.Properties.NuCastImprecisionShapeProperties using
+  (shape-lift∀ᵢ; shape-source-liftνᵢ)
+open import proof.Core.Properties.NuTermProperties using
+  ( closed-refined-typing-recontextualize
+  ; subst-closedᵐ
+  ; substˣᵐ-preserves-Value
+  ; typing-closedᵐ
+  )
+open import proof.Core.Properties.StoreProperties using
+  (renameStoreᵗ-incl)
+open import proof.Core.Properties.TypePreservation using
+  ( SubstNo•
+  ; SubstWf
+  ; seal★-weaken
+  ; term-weaken
+  ; typing-substˣ
+  )
+open import proof.Core.Properties.TypeProperties using
+  (TyRenameWf-suc; renameᵗ-preserves-WfTy)
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  (⊑-lift∀ᵢ; ⊑-source-liftνᵢ)
+open import
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
+  using (SpineCastMode; gradual↓; id-only↓)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( QuotientWideningPairᴿ
+  ; allocation-prefixᴿ
+  ; blame⊑ᴿ
+  ; cast⊑⊑ᴿ
+  ; cast⊒⊑ᴿ
+  ; closeᴿ
+  ; conv↑⊑ᴿ
+  ; conv↓⊑ᴿ
+  ; gen⊑groundᴿ
+  ; paired-concealᴿ
+  ; paired-downᴿ
+  ; paired-revealᴿ
+  ; paired-wideningᴿ
+  ; quotient-cast-wideningᴿ
+  ; quotient-id-wideningᴿ
+  ; target-instantiationᴿ
+  ; x⊑xᴿ
+  ; ƛ⊑ƛᴿ
+  ; Λ⊑Λᴿ
+  ; Λ⊑ᴿ
+  ; _·ᴿ_
+  ; α⊑αᴿ
+  ; α⊑ᴿ
+  ; κ⊑κᴿ
+  ; ν⊑νᴿ
+  ; ν⊑ᴿ
+  ; ⊑cast⊑ᴿ
+  ; ⊑cast⊒ᴿ
+  ; ⊑conv↑ᴿ
+  ; ⊑conv↓ᴿ
+  ; _⊕ᴿ[_]_
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  ; _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  using
+  ( embedded-creation-source-typingᴱ
+  ; embedded-creation-target-typingᴱ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientTypingExperiment
+  using
+  ( smaller-imprecision-source-typingᴿ
+  ; smaller-imprecision-target-typingᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  ( StoreImpPrefixᴿ
+  ; prefix-reflᴿ
+  ; prefix-∷ᴿ
+  )
+
+
+------------------------------------------------------------------------
+-- Prefix algebra independent of the live term relation
+------------------------------------------------------------------------
+
+left-store-prefix-inclusionᴿ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  StoreIncl (leftStoreⁱ ρ₀) (leftStoreⁱ ρ⁺)
+left-store-prefix-inclusionᴿ prefix-reflᴿ x∈ = x∈
+left-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-matched α A β B p} prefix) x∈ =
+  there (left-store-prefix-inclusionᴿ prefix x∈)
+left-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-left α A hA} prefix) x∈ =
+  there (left-store-prefix-inclusionᴿ prefix x∈)
+left-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-right β B hB} prefix) x∈ =
+  left-store-prefix-inclusionᴿ prefix x∈
+left-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-link α A β B p} prefix) x∈ =
+  left-store-prefix-inclusionᴿ prefix x∈
+
+
+right-store-prefix-inclusionᴿ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  StoreIncl (rightStoreⁱ ρ₀) (rightStoreⁱ ρ⁺)
+right-store-prefix-inclusionᴿ prefix-reflᴿ x∈ = x∈
+right-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-matched α A β B p} prefix) x∈ =
+  there (right-store-prefix-inclusionᴿ prefix x∈)
+right-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-left α A hA} prefix) x∈ =
+  right-store-prefix-inclusionᴿ prefix x∈
+right-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-right β B hB} prefix) x∈ =
+  there (right-store-prefix-inclusionᴿ prefix x∈)
+right-store-prefix-inclusionᴿ
+    (prefix-∷ᴿ {entry = store-link α A β B p} prefix) x∈ =
+  right-store-prefix-inclusionᴿ prefix x∈
+
+
+store-prefix-transᴿ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ₁ ρ₂ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ₁ →
+  StoreImpPrefixᴿ ρ₁ ρ₂ →
+  StoreImpPrefixᴿ ρ₀ ρ₂
+store-prefix-transᴿ prefix₀₁ prefix-reflᴿ = prefix₀₁
+store-prefix-transᴿ prefix₀₁ (prefix-∷ᴿ prefix₁₂) =
+  prefix-∷ᴿ (store-prefix-transᴿ prefix₀₁ prefix₁₂)
+
+
+paired-store-prefix-liftᴿ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₀↑ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ₀ ρ₀↑ →
+  ∃[ ρ⁺↑ ]
+    LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ⁺ ρ⁺↑ ×
+    StoreImpPrefixᴿ ρ₀↑ ρ⁺↑
+paired-store-prefix-liftᴿ prefix-reflᴿ liftρ =
+  _ , liftρ , prefix-reflᴿ
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-matched α A β B p} prefix) liftρ
+    with paired-store-prefix-liftᴿ prefix liftρ
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-matched α A β B p} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-matched (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+    (⊑-lift∀ᵢ p) ∷ ρ⁺↑ ,
+  lift-store-∷ (shape-lift∀ᵢ p) lift⁺ , prefix-∷ᴿ prefix↑
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-left α A hA} prefix) liftρ
+    with paired-store-prefix-liftᴿ prefix liftρ
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-left α A hA} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-left (suc α) (⇑ᵗ A)
+    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ⁺↑ ,
+  lift-store-left lift⁺ , prefix-∷ᴿ prefix↑
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-right β B hB} prefix) liftρ
+    with paired-store-prefix-liftᴿ prefix liftρ
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-right β B hB} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-right (suc β) (⇑ᵗ B)
+    (renameᵗ-preserves-WfTy hB TyRenameWf-suc) ∷ ρ⁺↑ ,
+  lift-store-right lift⁺ , prefix-∷ᴿ prefix↑
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-link α A β B p} prefix) liftρ
+    with paired-store-prefix-liftᴿ prefix liftρ
+paired-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-link α A β B p} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-link (suc α) (⇑ᵗ A) (suc β) (⇑ᵗ B)
+    (⊑-lift∀ᵢ p) ∷ ρ⁺↑ ,
+  lift-store-link (shape-lift∀ᵢ p) lift⁺ , prefix-∷ᴿ prefix↑
+
+
+left-store-prefix-liftᴿ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ₀↑ : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ₀ ρ₀↑ →
+  ∃[ ρ⁺↑ ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ⁺ ρ⁺↑ ×
+    StoreImpPrefixᴿ ρ₀↑ ρ⁺↑
+left-store-prefix-liftᴿ prefix-reflᴿ liftρ =
+  _ , liftρ , prefix-reflᴿ
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-matched α A β B p} prefix) liftρ
+    with left-store-prefix-liftᴿ prefix liftρ
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-matched α A β B p} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-matched (suc α) (⇑ᵗ A) β B
+    (⊑-source-liftνᵢ p) ∷ ρ⁺↑ ,
+  lift-left-store-∷ (shape-source-liftνᵢ p) lift⁺ ,
+  prefix-∷ᴿ prefix↑
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-left α A hA} prefix) liftρ
+    with left-store-prefix-liftᴿ prefix liftρ
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-left α A hA} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-left (suc α) (⇑ᵗ A)
+    (renameᵗ-preserves-WfTy hA TyRenameWf-suc) ∷ ρ⁺↑ ,
+  lift-left-store-left lift⁺ , prefix-∷ᴿ prefix↑
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-right β B hB} prefix) liftρ
+    with left-store-prefix-liftᴿ prefix liftρ
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-right β B hB} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-right β B hB ∷ ρ⁺↑ ,
+  lift-left-store-right lift⁺ , prefix-∷ᴿ prefix↑
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-link α A β B p} prefix) liftρ
+    with left-store-prefix-liftᴿ prefix liftρ
+left-store-prefix-liftᴿ
+    (prefix-∷ᴿ {entry = store-link α A β B p} prefix) liftρ
+    | ρ⁺↑ , lift⁺ , prefix↑ =
+  store-link (suc α) (⇑ᵗ A) β B
+    (⊑-source-liftνᵢ p) ∷ ρ⁺↑ ,
+  lift-left-store-link (shape-source-liftνᵢ p) lift⁺ ,
+  prefix-∷ᴿ prefix↑
+
+
+paired-ctx-lift-resultᴿ :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γ′ ] LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′
+paired-ctx-lift-resultᴿ [] = [] , lift-ctx-[]
+paired-ctx-lift-resultᴿ (ctx-imp A B p ∷ γ)
+    with paired-ctx-lift-resultᴿ γ
+paired-ctx-lift-resultᴿ (ctx-imp A B p ∷ γ)
+    | γ′ , liftγ =
+  ctx-imp (⇑ᵗ A) (⇑ᵗ B) (⊑-lift∀ᵢ p) ∷ γ′ ,
+  lift-ctx-∷ (shape-lift∀ᵢ p) liftγ
+
+
+left-ctx-lift-resultᴿ :
+  ∀ {Φ Δᴸ Δᴿ} (γ : CtxImp Φ Δᴸ Δᴿ) →
+  ∃[ γ′ ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
+left-ctx-lift-resultᴿ [] = [] , lift-left-ctx-[]
+left-ctx-lift-resultᴿ (ctx-imp A B p ∷ γ)
+    with left-ctx-lift-resultᴿ γ
+left-ctx-lift-resultᴿ (ctx-imp A B p ∷ γ)
+    | γ′ , liftγ =
+  ctx-imp (⇑ᵗ A) B (⊑-source-liftνᵢ p) ∷ γ′ ,
+  lift-left-ctx-∷ (shape-source-liftνᵢ p) liftγ
+
+
+store-corresponds-prefixᴿ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {α X β X′ p} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  StoreCorresponds ρ₀ α X β X′ p →
+  StoreCorresponds ρ⁺ α X β X′ p
+store-corresponds-prefixᴿ prefix-reflᴿ corresponds = corresponds
+store-corresponds-prefixᴿ (prefix-∷ᴿ prefix) corresponds
+    with store-corresponds-prefixᴿ prefix corresponds
+store-corresponds-prefixᴿ (prefix-∷ᴿ prefix)
+    corresponds | correspondence-stored entry∈ =
+  correspondence-stored (there entry∈)
+store-corresponds-prefixᴿ (prefix-∷ᴿ prefix)
+    corresponds | correspondence-linked entry∈ =
+  correspondence-linked (there entry∈)
+
+
+quotient-widening-prefixᴿ :
+  ∀ {Φ Δᴸ Δᴿ} {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {u u′ D D′ A A′} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  QuotientWideningPairᴿ Δᴸ Δᴿ ρ₀ u u′ D D′ A A′ →
+  QuotientWideningPairᴿ Δᴸ Δᴿ ρ⁺ u u′ D D′ A A′
+quotient-widening-prefixᴿ prefix
+    (quotient-id-wideningᴿ source target) =
+  quotient-id-wideningᴿ
+    (widen-weaken ≤-refl
+      (left-store-prefix-inclusionᴿ prefix) source)
+    (widen-weaken ≤-refl
+      (right-store-prefix-inclusionᴿ prefix) target)
+quotient-widening-prefixᴿ prefix
+    (quotient-cast-wideningᴿ
+      mode seal★ source mode′ seal★′ target) =
+  quotient-cast-wideningᴿ
+    mode
+    (seal★-weaken (left-store-prefix-inclusionᴿ prefix) seal★)
+    (widen-weaken ≤-refl
+      (left-store-prefix-inclusionᴿ prefix) source)
+    mode′
+    (seal★-weaken (right-store-prefix-inclusionᴿ prefix) seal★′)
+    (widen-weaken ≤-refl
+      (right-store-prefix-inclusionᴿ prefix) target)
+
+
+spine-mode-prefixᴿ :
+  ∀ {Σ Σ′ μ} →
+  StoreIncl Σ Σ′ →
+  SpineCastMode Σ μ →
+  SpineCastMode Σ′ μ
+spine-mode-prefixᴿ inclusion id-only↓ = id-only↓
+spine-mode-prefixᴿ inclusion (gradual↓ mode seal★) =
+  gradual↓ mode (seal★-weaken inclusion seal★)
+
+
+------------------------------------------------------------------------
+-- Genuine binder frames and environment family
+------------------------------------------------------------------------
+
+data SmallerSubstitutionFrameᴿ
+    {Φ₀ : ImpCtx} {Δ₀ᴸ Δ₀ᴿ : TyCtx}
+    (ρ₀ : StoreImp Φ₀ Δ₀ᴸ Δ₀ᴿ)
+    (γ₀ δ₀ : CtxImp Φ₀ Δ₀ᴸ Δ₀ᴿ)
+    (τ₀ τ₀′ : Substˣ) :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx} →
+    StoreImp Φ Δᴸ Δᴿ →
+    CtxImp Φ Δᴸ Δᴿ →
+    CtxImp Φ Δᴸ Δᴿ →
+    Substˣ → Substˣ → Set₁ where
+  substitution-frame-idᴿ :
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      ρ₀ γ₀ δ₀ τ₀ τ₀′
+
+  substitution-frame-ƛᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ γ δ τ τ′ A A′ pA} →
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      {Φ} {Δᴸ} {Δᴿ} ρ γ δ τ τ′ →
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      ρ
+      (ctx-imp A A′ pA ∷ γ)
+      (ctx-imp A A′ pA ∷ δ)
+      (extˢˣ τ) (extˢˣ τ′)
+
+  substitution-frame-Λᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ ρ↑ γ γ↑ δ δ↑ τ τ′} →
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      {Φ} {Δᴸ} {Δᴿ} ρ γ δ τ τ′ →
+    LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ ρ↑ →
+    LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ↑ →
+    LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) δ δ↑ →
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      ρ↑ γ↑ δ↑ (↑ᵗᵐ τ) (↑ᵗᵐ τ′)
+
+  substitution-frame-Λ-leftᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ ρ↑ γ γ↑ δ δ↑ τ τ′} →
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      {Φ} {Δᴸ} {Δᴿ} ρ γ δ τ τ′ →
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ↑ →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ↑ →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) δ δ↑ →
+    SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+      ρ↑ γ↑ δ↑ (↑ᵗᵐ τ) τ′
+
+
+SmallerSubstitutionEnvironmentFamilyᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx} →
+  StoreImp Φ Δᴸ Δᴿ →
+  CtxImp Φ Δᴸ Δᴿ →
+  CtxImp Φ Δᴸ Δᴿ →
+  Substˣ → Substˣ → Set₁
+SmallerSubstitutionEnvironmentFamilyᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′ =
+  ∀ {Φ Δᴸ Δᴿ ρ γ δ τ τ′} →
+  SmallerSubstitutionFrameᴿ ρ₀ γ₀ δ₀ τ₀ τ₀′
+    {Φ} {Δᴸ} {Δᴿ} ρ γ δ τ τ′ →
+  (∀ {x A B p} →
+    γ ∋ x ⦂ ctx-imp A B p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+      ⊢ᴿ τ x ⊑ τ′ x ⦂ A ⊑ B ∶ p) ×
+  (∀ x → No• (τ x)) ×
+  (∀ x → No• (τ′ x))
+
+
+smaller-substitution-source-wfᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ δ : CtxImp Φ Δᴸ Δᴿ}
+    {τ τ′ : Substˣ} →
+  (∀ {x A B p} →
+    γ ∋ x ⦂ ctx-imp A B p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+      ⊢ᴿ τ x ⊑ τ′ x ⦂ A ⊑ B ∶ p) →
+  SubstWf Δᴸ (leftStoreⁱ ρ) (leftCtxⁱ γ) (leftCtxⁱ δ) τ
+smaller-substitution-source-wfᴿ {γ = []} related ()
+smaller-substitution-source-wfᴿ
+    {γ = ctx-imp A B p ∷ γ} related Z =
+  smaller-imprecision-source-typingᴿ (related Z)
+smaller-substitution-source-wfᴿ
+    {γ = ctx-imp A B p ∷ γ} related (S x∈) =
+  smaller-substitution-source-wfᴿ
+    (λ y∈ → related (S y∈)) x∈
+
+
+smaller-substitution-target-wfᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ δ : CtxImp Φ Δᴸ Δᴿ}
+    {τ τ′ : Substˣ} →
+  (∀ {x A B p} →
+    γ ∋ x ⦂ ctx-imp A B p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+      ⊢ᴿ τ x ⊑ τ′ x ⦂ A ⊑ B ∶ p) →
+  SubstWf Δᴿ (rightStoreⁱ ρ)
+    (rightCtxⁱ γ) (rightCtxⁱ δ) τ′
+smaller-substitution-target-wfᴿ {γ = []} related ()
+smaller-substitution-target-wfᴿ
+    {γ = ctx-imp A B p ∷ γ} related Z =
+  smaller-imprecision-target-typingᴿ (related Z)
+smaller-substitution-target-wfᴿ
+    {γ = ctx-imp A B p ∷ γ} related (S x∈) =
+  smaller-substitution-target-wfᴿ
+    (λ y∈ → related (S y∈)) x∈
+
+
+pointwise-no-bulletᴿ :
+  ∀ {γ τ} →
+  (∀ x → No• (τ x)) →
+  SubstNo• γ τ
+pointwise-no-bulletᴿ noτ {x = x} x∈ = noτ x
+
+
+------------------------------------------------------------------------
+-- Prefix-aware parallel substitution
+------------------------------------------------------------------------
+
+mutual
+  smaller-parallel-term-substitution-framedᴿ :
+    ∀ {Φ₀ : ImpCtx} {Δ₀ᴸ Δ₀ᴿ : TyCtx}
+      {ρ⁺₀ : StoreImp Φ₀ Δ₀ᴸ Δ₀ᴿ}
+      {γ₀ δ₀ : CtxImp Φ₀ Δ₀ᴸ Δ₀ᴿ}
+      {τ₀ τ₀′ : Substˣ} →
+    (environment : SmallerSubstitutionEnvironmentFamilyᴿ
+      ρ⁺₀ γ₀ δ₀ τ₀ τ₀′) →
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ δ : CtxImp Φ Δᴸ Δᴿ}
+      {τ τ′ : Substˣ} {N N′ : Term} {A B : Ty}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    SmallerSubstitutionFrameᴿ ρ⁺₀ γ₀ δ₀ τ₀ τ₀′
+      {Φ} {Δᴸ} {Δᴿ} ρ⁺ γ δ τ τ′ →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    No• N → No• N′ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ δ
+      ⊢ᴿ substˣᵐ τ N ⊑ substˣᵐ τ′ N′
+      ⦂ A ⊑ B ∶ p
+
+  smaller-parallel-quotient-substitution-framedᴿ :
+    ∀ {Φ₀ : ImpCtx} {Δ₀ᴸ Δ₀ᴿ : TyCtx}
+      {ρ⁺₀ : StoreImp Φ₀ Δ₀ᴸ Δ₀ᴿ}
+      {γ₀ δ₀ : CtxImp Φ₀ Δ₀ᴸ Δ₀ᴿ}
+      {τ₀ τ₀′ : Substˣ} →
+    (environment : SmallerSubstitutionEnvironmentFamilyᴿ
+      ρ⁺₀ γ₀ δ₀ τ₀ τ₀′) →
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ δ : CtxImp Φ Δᴸ Δᴿ}
+      {τ τ′ : Substˣ} {N N′ : Term} {D D′ : Ty}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    SmallerSubstitutionFrameᴿ ρ⁺₀ γ₀ δ₀ τ₀ τ₀′
+      {Φ} {Δᴸ} {Δᴿ} ρ⁺ γ δ τ τ′ →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    No• N → No• N′ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿᵖ N ⊑ N′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ δ
+      ⊢ᴿᵖ substˣᵐ τ N ⊑ substˣᵐ τ′ N′
+      ⦂ D ⊑ᵖ D′ ∶ q
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix no•-blame noN′
+      (blame⊑ᴿ N′⊢)
+      with environment frame
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix no•-blame noN′
+      (blame⊑ᴿ N′⊢)
+      | related , noτ , noτ′ =
+    blame⊑ᴿ
+      (typing-substˣ
+        (smaller-substitution-target-wfᴿ related)
+        (pointwise-no-bulletᴿ noτ′)
+        noN′
+        (term-weaken ≤-refl
+          (right-store-prefix-inclusionᴿ prefix) noN′ N′⊢))
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix no•-` no•-` (x⊑xᴿ x∈)
+      with environment frame
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix no•-` no•-` (x⊑xᴿ x∈)
+      | related , noτ , noτ′ =
+    related x∈
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-ƛ noN) (no•-ƛ noN′)
+      (ƛ⊑ƛᴿ hA hA′ body) =
+    ƛ⊑ƛᴿ hA hA′
+      (smaller-parallel-term-substitution-framedᴿ
+        environment (substitution-frame-ƛᴿ frame)
+        prefix noN noN′ body)
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-· noL noM) (no•-· noL′ noM′)
+      (fun ·ᴿ arg) =
+    smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noL noL′ fun
+    ·ᴿ
+    smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noM noM′ arg
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-Λ noV) (no•-Λ noV′)
+      (Λ⊑Λᴿ liftρ liftγ vV vV′ body)
+      with paired-store-prefix-liftᴿ prefix liftρ
+         | paired-ctx-lift-resultᴿ _
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-Λ noV) (no•-Λ noV′)
+      (Λ⊑Λᴿ liftρ liftγ vV vV′ body)
+      | ρ⁺↑ , liftρ⁺ , prefix↑
+      | δ↑ , liftδ =
+    Λ⊑Λᴿ liftρ⁺ liftδ
+      (substˣᵐ-preserves-Value _ vV)
+      (substˣᵐ-preserves-Value _ vV′)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment
+        (substitution-frame-Λᴿ frame liftρ⁺ liftγ liftδ)
+        prefix↑ noV noV′ body)
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-Λ noV) noN′
+      (Λ⊑ᴿ occ liftρ liftγ vV body)
+      with left-store-prefix-liftᴿ prefix liftρ
+         | left-ctx-lift-resultᴿ _
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-Λ noV) noN′
+      (Λ⊑ᴿ occ liftρ liftγ vV body)
+      | ρ⁺↑ , liftρ⁺ , prefix↑
+      | δ↑ , liftδ =
+    Λ⊑ᴿ occ liftρ⁺ liftδ
+      (substˣᵐ-preserves-Value _ vV)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment
+        (substitution-frame-Λ-leftᴿ frame liftρ⁺ liftγ liftδ)
+        prefix↑ noV noN′ body)
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix () noN′
+      (α⊑αᴿ vL noL vL′ noL′ p liftρ liftγ
+        body L⊢ L′⊢)
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix () noN′
+      (α⊑ᴿ vL noL hA liftρ liftγ body L⊢ N′⊢)
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noN noN′
+      (allocation-prefixᴿ inner-prefix body N⊢ N′⊢) =
+    smaller-parallel-term-substitution-framedᴿ
+      environment frame
+      (store-prefix-transᴿ inner-prefix prefix)
+      noN noN′ body
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-ν noN) (no•-ν noN′)
+      (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑
+        liftρ liftγ body replace)
+      with paired-store-prefix-liftᴿ prefix liftρ
+         | paired-ctx-lift-resultᴿ _
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-ν noN) (no•-ν noN′)
+      (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑
+        liftρ liftγ body replace)
+      | ρ⁺↑ , liftρ⁺ , prefix↑
+      | δ↑ , liftδ =
+    ν⊑νᴿ hA hA′
+      (weaken-reveal-conversion
+        (StoreIncl-cons
+          (renameStoreᵗ-incl suc
+            (left-store-prefix-inclusionᴿ prefix)))
+        s↑)
+      (weaken-reveal-conversion
+        (StoreIncl-cons
+          (renameStoreᵗ-incl suc
+            (right-store-prefix-inclusionᴿ prefix)))
+        s′↑)
+      A⊑A′ A↑⊑A′↑ liftρ⁺ liftδ
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noN noN′ body)
+      replace
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-ν noN) noN′
+      (ν⊑ᴿ hA hA↑ s↑ liftρ liftγ body replace)
+      with left-store-prefix-liftᴿ prefix liftρ
+         | left-ctx-lift-resultᴿ _
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-ν noN) noN′
+      (ν⊑ᴿ hA hA↑ s↑ liftρ liftγ body replace)
+      | ρ⁺↑ , liftρ⁺ , prefix↑
+      | δ↑ , liftδ =
+    ν⊑ᴿ hA hA↑
+      (weaken-reveal-conversion
+        (StoreIncl-cons
+          (renameStoreᵗ-incl suc
+            (left-store-prefix-inclusionᴿ prefix)))
+        s↑)
+      liftρ⁺ liftδ
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noN noN′ body)
+      replace
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix no•-$ no•-$ κ⊑κᴿ =
+    κ⊑κᴿ
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-⊕ noL noM) (no•-⊕ noL′ noM′)
+      (left ⊕ᴿ[ op ] right) =
+    smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noL noL′ left
+    ⊕ᴿ[ op ]
+    smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noM noM′ right
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-⟨⟩ noV) noW
+      (gen⊑groundᴿ
+        mode seal★ c⊒ ground vV vW W⊢ body q)
+      with environment frame
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-⟨⟩ noV) noW
+      (gen⊑groundᴿ
+        mode seal★ c⊒ ground vV vW W⊢ body q)
+      | related , noτ , noτ′ =
+    gen⊑groundᴿ mode
+      (seal★-weaken (left-store-prefix-inclusionᴿ prefix) seal★)
+      (narrow-weaken ≤-refl
+        (left-store-prefix-inclusionᴿ prefix) c⊒)
+      ground
+      (substˣᵐ-preserves-Value _ vV)
+      (substˣᵐ-preserves-Value _ vW)
+      (typing-substˣ
+        (smaller-substitution-target-wfᴿ related)
+        (pointwise-no-bulletᴿ noτ′)
+        noW
+        (term-weaken ≤-refl
+          (right-store-prefix-inclusionᴿ prefix)
+          noW W⊢))
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noV (no•-⟨⟩ noW) body)
+      q
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-⟨⟩ noM) noM′
+      (cast⊒⊑ᴿ mode seal★ c⊒ body q shape comp) =
+    cast⊒⊑ᴿ mode
+      (seal★-weaken (left-store-prefix-inclusionᴿ prefix) seal★)
+      (narrow-weaken ≤-refl
+        (left-store-prefix-inclusionᴿ prefix) c⊒)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q shape comp
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-⟨⟩ noM) noM′
+      (cast⊑⊑ᴿ mode seal★ c⊑ body q shape comp) =
+    cast⊑⊑ᴿ mode
+      (seal★-weaken (left-store-prefix-inclusionᴿ prefix) seal★)
+      (widen-weaken ≤-refl
+        (left-store-prefix-inclusionᴿ prefix) c⊑)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q shape comp
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noM (no•-⟨⟩ noM′)
+      (⊑cast⊒ᴿ mode seal★ c⊒ body q shape comp) =
+    ⊑cast⊒ᴿ mode
+      (seal★-weaken (right-store-prefix-inclusionᴿ prefix) seal★)
+      (narrow-weaken ≤-refl
+        (right-store-prefix-inclusionᴿ prefix) c⊒)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q shape comp
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noM (no•-⟨⟩ noM′)
+      (⊑cast⊑ᴿ mode seal★ c⊑ body q shape comp) =
+    ⊑cast⊑ᴿ mode
+      (seal★-weaken (right-store-prefix-inclusionᴿ prefix) seal★)
+      (widen-weaken ≤-refl
+        (right-store-prefix-inclusionᴿ prefix) c⊑)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q shape comp
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-⟨⟩ noM) noM′
+      (conv↑⊑ᴿ conversion body q replace) =
+    conv↑⊑ᴿ
+      (weaken-reveal-conversion
+        (left-store-prefix-inclusionᴿ prefix) conversion)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q replace
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix (no•-⟨⟩ noM) noM′
+      (conv↓⊑ᴿ conversion body q replace) =
+    conv↓⊑ᴿ
+      (weaken-conceal-conversion
+        (left-store-prefix-inclusionᴿ prefix) conversion)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q replace
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noM (no•-⟨⟩ noM′)
+      (⊑conv↑ᴿ conversion body q replace) =
+    ⊑conv↑ᴿ
+      (weaken-reveal-conversion
+        (right-store-prefix-inclusionᴿ prefix) conversion)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q replace
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix noM (no•-⟨⟩ noM′)
+      (⊑conv↓ᴿ conversion body q replace) =
+    ⊑conv↓ᴿ
+      (weaken-conceal-conversion
+        (right-store-prefix-inclusionᴿ prefix) conversion)
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      q replace
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-revealᴿ
+        corresponds source target replace body) =
+    paired-revealᴿ
+      (store-corresponds-prefixᴿ prefix corresponds)
+      (weaken-reveal-conversion
+        (left-store-prefix-inclusionᴿ prefix) source)
+      (weaken-reveal-conversion
+        (right-store-prefix-inclusionᴿ prefix) target)
+      replace
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-concealᴿ
+        corresponds source target replace body) =
+    paired-concealᴿ
+      (store-corresponds-prefixᴿ prefix corresponds)
+      (weaken-conceal-conversion
+        (left-store-prefix-inclusionᴿ prefix) source)
+      (weaken-conceal-conversion
+        (right-store-prefix-inclusionᴿ prefix) target)
+      replace
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment {δ = δ} {τ = ζ} {τ′ = ζ′}
+      frame prefix noN noN′
+      (target-instantiationᴿ embedded)
+      with subst-closedᵐ
+        (typing-closedᵐ
+          (forget (embedded-creation-source-typingᴱ embedded))) ζ
+         | subst-closedᵐ
+            (typing-closedᵐ
+              (forget
+                (embedded-creation-target-typingᴱ embedded))) ζ′
+  smaller-parallel-term-substitution-framedᴿ
+      environment {δ = δ} {τ = ζ} {τ′ = ζ′}
+      frame prefix noN noN′
+      (target-instantiationᴿ embedded)
+      | eqN | eqN′
+      rewrite eqN | eqN′ =
+    allocation-prefixᴿ prefix
+      (target-instantiationᴿ embedded)
+      (term-weaken ≤-refl
+        (left-store-prefix-inclusionᴿ prefix)
+        noN
+        (smaller-imprecision-source-typingᴿ
+          (target-instantiationᴿ embedded)))
+      (term-weaken ≤-refl
+        (right-store-prefix-inclusionᴿ prefix)
+        noN′
+        (smaller-imprecision-target-typingᴿ
+          (target-instantiationᴿ embedded)))
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-⟨⟩ noN) (no•-⟨⟩ noN′)
+      (closeᴿ body widening
+        source-shape target-shape square compatible) =
+    closeᴿ
+      (smaller-parallel-quotient-substitution-framedᴿ
+        environment frame prefix noN noN′ body)
+      (quotient-widening-prefixᴿ prefix widening)
+      source-shape target-shape square compatible
+
+  smaller-parallel-term-substitution-framedᴿ
+      environment frame prefix
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-wideningᴿ
+        mode seal★ source source-shape
+        mode′ seal★′ target target-shape
+        left-square right-square compatible body) =
+    paired-wideningᴿ
+      mode
+      (seal★-weaken (left-store-prefix-inclusionᴿ prefix) seal★)
+      (widen-weaken ≤-refl
+        (left-store-prefix-inclusionᴿ prefix) source)
+      source-shape
+      mode′
+      (seal★-weaken (right-store-prefix-inclusionᴿ prefix) seal★′)
+      (widen-weaken ≤-refl
+        (right-store-prefix-inclusionᴿ prefix) target)
+      target-shape left-square right-square compatible
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+
+  smaller-parallel-quotient-substitution-framedᴿ
+      environment frame prefix
+      (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-downᴿ
+        body source-mode source source-shape
+        target-mode target target-shape square) =
+    paired-downᴿ
+      (smaller-parallel-term-substitution-framedᴿ
+        environment frame prefix noM noM′ body)
+      (spine-mode-prefixᴿ
+        (left-store-prefix-inclusionᴿ prefix) source-mode)
+      (narrow-weaken ≤-refl
+        (left-store-prefix-inclusionᴿ prefix) source)
+      source-shape
+      (spine-mode-prefixᴿ
+        (right-store-prefix-inclusionᴿ prefix) target-mode)
+      (narrow-weaken ≤-refl
+        (right-store-prefix-inclusionᴿ prefix) target)
+      target-shape square
+
+
+smaller-parallel-term-substitutionᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {γ δ : CtxImp Φ Δᴸ Δᴿ}
+    {τ τ′ : Substˣ} {N N′ : Term} {A B : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  SmallerSubstitutionEnvironmentFamilyᴿ ρ γ δ τ τ′ →
+  No• N → No• N′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ N ⊑ N′ ⦂ A ⊑ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+    ⊢ᴿ substˣᵐ τ N ⊑ substˣᵐ τ′ N′
+    ⦂ A ⊑ B ∶ p
+smaller-parallel-term-substitutionᴿ environment noN noN′ N⊑N′ =
+  smaller-parallel-term-substitution-framedᴿ
+    environment substitution-frame-idᴿ prefix-reflᴿ
+    noN noN′ N⊑N′

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTermContextShiftExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTermContextShiftExperiment.agda
@@ -1,0 +1,394 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientTermContextShiftExperiment
+  where
+
+-- File Charter:
+--   * Proves mutual no-bullet term-context insertion for the independent
+--     smaller ordinary and one-boundary quotient-imprecision relations.
+--   * Keeps a fresh variable at the correct depth beneath ordinary lambdas
+--     and transports insertion beneath paired and source-only type binders.
+--   * Recontextualizes the closed target-instantiation residuals directly.
+--   * Imports neither the live term-imprecision relation nor any conversion
+--     from it.
+--   * Contains no postulate, hole, permissive option, termination bypass, or
+--     catch-all clause.
+
+open import Data.List using (_∷_)
+open import Data.Nat using (suc; zero)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑★; _ˣ⊑ˣ_; ⇑ᴸᵢ; ⇑ᵢ)
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NuTermImprecision using
+  ( CtxImp
+  ; LiftCtxⁱ
+  ; LiftLeftCtxⁱ
+  ; StoreImp
+  ; ctx-imp
+  ; leftCtxⁱ
+  ; lift-ctx-∷
+  ; lift-left-ctx-∷
+  ; rightCtxⁱ
+  )
+open import NuTerms using
+  ( No•
+  ; Renameˣ
+  ; Term
+  ; extʳ
+  ; no•-$
+  ; no•-ƛ
+  ; no•-Λ
+  ; no•-·
+  ; no•-ν
+  ; no•-⊕
+  ; no•-`
+  ; no•-⟨⟩
+  ; no•-blame
+  ; renameˣᵐ
+  )
+open import TermTyping using (forget)
+open import Types using
+  (Ty; TyCtx; S; Z; _∋_⦂_; ⇑ᵗ)
+open import proof.Core.Properties.NuCastImprecisionShapeProperties using
+  (shape-lift∀ᵢ; shape-source-liftνᵢ)
+open import proof.Core.Properties.NuTermProperties using
+  ( RenameWf
+  ; rename-closedᵐ
+  ; renameˣᵐ-preserves-Value
+  ; typing-closedᵐ
+  )
+open import proof.Core.Properties.TypePreservation using
+  (typing-renameˣ)
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  (⊑-lift∀ᵢ; ⊑-source-liftνᵢ)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+open import
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  using
+  ( embedded-creation-source-typingᴱ
+  ; embedded-creation-target-typingᴱ
+  )
+
+
+private
+  data TermCtxInsertᴿ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      (C C′ : Ty) (q : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ) :
+      CtxImp Φ Δᴸ Δᴿ →
+      CtxImp Φ Δᴸ Δᴿ → Renameˣ → Set₁ where
+    insert-hereᴿ : ∀ {γ} →
+      TermCtxInsertᴿ C C′ q γ (ctx-imp C C′ q ∷ γ) suc
+
+    insert-underᴿ : ∀ {γ δ η A B p} →
+      TermCtxInsertᴿ C C′ q γ δ η →
+      TermCtxInsertᴿ C C′ q
+        (ctx-imp A B p ∷ γ) (ctx-imp A B p ∷ δ) (extʳ η)
+
+
+  term-ctx-insert-lookupᴿ :
+    ∀ {Φ Δᴸ Δᴿ C C′ q γ δ η x A B p} →
+    TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ} C C′ q γ δ η →
+    γ ∋ x ⦂ ctx-imp A B p →
+    δ ∋ η x ⦂ ctx-imp A B p
+  term-ctx-insert-lookupᴿ insert-hereᴿ x∈ = S x∈
+  term-ctx-insert-lookupᴿ (insert-underᴿ insert) Z = Z
+  term-ctx-insert-lookupᴿ (insert-underᴿ insert) (S x∈) =
+    S (term-ctx-insert-lookupᴿ insert x∈)
+
+
+  term-ctx-insert-left-wfᴿ :
+    ∀ {Φ Δᴸ Δᴿ C C′ q γ δ η} →
+    TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ} C C′ q γ δ η →
+    RenameWf (leftCtxⁱ γ) (leftCtxⁱ δ) η
+  term-ctx-insert-left-wfᴿ insert-hereᴿ x∈ = S x∈
+  term-ctx-insert-left-wfᴿ (insert-underᴿ insert) Z = Z
+  term-ctx-insert-left-wfᴿ (insert-underᴿ insert) (S x∈) =
+    S (term-ctx-insert-left-wfᴿ insert x∈)
+
+
+  term-ctx-insert-right-wfᴿ :
+    ∀ {Φ Δᴸ Δᴿ C C′ q γ δ η} →
+    TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ} C C′ q γ δ η →
+    RenameWf (rightCtxⁱ γ) (rightCtxⁱ δ) η
+  term-ctx-insert-right-wfᴿ insert-hereᴿ x∈ = S x∈
+  term-ctx-insert-right-wfᴿ (insert-underᴿ insert) Z = Z
+  term-ctx-insert-right-wfᴿ (insert-underᴿ insert) (S x∈) =
+    S (term-ctx-insert-right-wfᴿ insert x∈)
+
+
+  term-ctx-insert-paired-liftᴿ :
+    ∀ {Φ Δᴸ Δᴿ C C′ q γ δ η γ↑} →
+    (insert : TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ}
+      C C′ q γ δ η) →
+    LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ↑ →
+    ∃[ δ↑ ]
+      LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) δ δ↑ ×
+      TermCtxInsertᴿ (⇑ᵗ C) (⇑ᵗ C′) (⊑-lift∀ᵢ q)
+        γ↑ δ↑ η
+  term-ctx-insert-paired-liftᴿ {q = q} insert-hereᴿ liftγ =
+    _ ,
+    lift-ctx-∷ {p′ = ⊑-lift∀ᵢ q}
+      (shape-lift∀ᵢ q) liftγ ,
+    insert-hereᴿ
+  term-ctx-insert-paired-liftᴿ
+      (insert-underᴿ insert)
+      (lift-ctx-∷ {p′ = p↑} shape-eq liftγ)
+      with term-ctx-insert-paired-liftᴿ insert liftγ
+  term-ctx-insert-paired-liftᴿ
+      (insert-underᴿ insert)
+      (lift-ctx-∷ {p′ = p↑} shape-eq liftγ)
+      | δ↑ , liftδ , insert↑ =
+    _ , lift-ctx-∷ {p′ = p↑} shape-eq liftδ ,
+    insert-underᴿ insert↑
+
+
+  term-ctx-insert-left-liftᴿ :
+    ∀ {Φ Δᴸ Δᴿ C C′ q γ δ η γ↑} →
+    (insert : TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ}
+      C C′ q γ δ η) →
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ↑ →
+    ∃[ δ↑ ]
+      LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) δ δ↑ ×
+      TermCtxInsertᴿ (⇑ᵗ C) C′ (⊑-source-liftνᵢ q)
+        γ↑ δ↑ η
+  term-ctx-insert-left-liftᴿ {q = q} insert-hereᴿ liftγ =
+    _ ,
+    lift-left-ctx-∷ {p′ = ⊑-source-liftνᵢ q}
+      (shape-source-liftνᵢ q) liftγ ,
+    insert-hereᴿ
+  term-ctx-insert-left-liftᴿ
+      (insert-underᴿ insert)
+      (lift-left-ctx-∷ {p′ = p↑} shape-eq liftγ)
+      with term-ctx-insert-left-liftᴿ insert liftγ
+  term-ctx-insert-left-liftᴿ
+      (insert-underᴿ insert)
+      (lift-left-ctx-∷ {p′ = p↑} shape-eq liftγ)
+      | δ↑ , liftδ , insert↑ =
+    _ , lift-left-ctx-∷ {p′ = p↑} shape-eq liftδ ,
+    insert-underᴿ insert↑
+
+
+  mutual
+    term-ctx-insertᴿ :
+      ∀ {Φ Δᴸ Δᴿ ρ γ δ η C C′ q M M′ A B p} →
+      (insert : TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ}
+        C C′ q γ δ η) →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+      No• M → No• M′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+        ⊢ᴿ renameˣᵐ η M ⊑ renameˣᵐ η M′
+        ⦂ A ⊑ B ∶ p
+
+    quotient-term-ctx-insertᴿ :
+      ∀ {Φ Δᴸ Δᴿ ρ γ δ η C C′ q M M′ D D′ pD} →
+      (insert : TermCtxInsertᴿ {Φ} {Δᴸ} {Δᴿ}
+        C C′ q γ δ η) →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+        ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ pD →
+      No• M → No• M′ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ δ
+        ⊢ᴿᵖ renameˣᵐ η M ⊑ renameˣᵐ η M′
+        ⦂ D ⊑ᵖ D′ ∶ pD
+
+    term-ctx-insertᴿ insert (blame⊑ᴿ M′⊢)
+        no•-blame noM′ =
+      blame⊑ᴿ
+        (typing-renameˣ (term-ctx-insert-right-wfᴿ insert) M′⊢)
+    term-ctx-insertᴿ insert (x⊑xᴿ x∈) no•-` no•-` =
+      x⊑xᴿ (term-ctx-insert-lookupᴿ insert x∈)
+    term-ctx-insertᴿ insert (ƛ⊑ƛᴿ hA hA′ body)
+        (no•-ƛ noN) (no•-ƛ noN′) =
+      ƛ⊑ƛᴿ hA hA′
+        (term-ctx-insertᴿ
+          (insert-underᴿ insert) body noN noN′)
+    term-ctx-insertᴿ insert (fun ·ᴿ arg)
+        (no•-· noL noM) (no•-· noL′ noM′) =
+      term-ctx-insertᴿ insert fun noL noL′
+      ·ᴿ
+      term-ctx-insertᴿ insert arg noM noM′
+    term-ctx-insertᴿ insert
+        (Λ⊑Λᴿ liftρ liftγ vV vV′ body)
+        (no•-Λ noV) (no•-Λ noV′)
+        with term-ctx-insert-paired-liftᴿ insert liftγ
+    term-ctx-insertᴿ insert
+        (Λ⊑Λᴿ liftρ liftγ vV vV′ body)
+        (no•-Λ noV) (no•-Λ noV′)
+        | δ↑ , liftδ , insert↑ =
+      Λ⊑Λᴿ liftρ liftδ
+        (renameˣᵐ-preserves-Value _ vV)
+        (renameˣᵐ-preserves-Value _ vV′)
+        (term-ctx-insertᴿ insert↑ body noV noV′)
+    term-ctx-insertᴿ insert
+        (Λ⊑ᴿ occ liftρ liftγ vV body)
+        (no•-Λ noV) noN′
+        with term-ctx-insert-left-liftᴿ insert liftγ
+    term-ctx-insertᴿ insert
+        (Λ⊑ᴿ occ liftρ liftγ vV body)
+        (no•-Λ noV) noN′
+        | δ↑ , liftδ , insert↑ =
+      Λ⊑ᴿ occ liftρ liftδ
+        (renameˣᵐ-preserves-Value _ vV)
+        (term-ctx-insertᴿ insert↑ body noV noN′)
+    term-ctx-insertᴿ insert
+        (α⊑αᴿ vL noL vL′ noL′ p liftρ liftγ
+          body L⊢ L′⊢) () noM′
+    term-ctx-insertᴿ insert
+        (α⊑ᴿ vL noL hA liftρ liftγ body L⊢ N′⊢)
+        () noN′
+    term-ctx-insertᴿ insert
+        (allocation-prefixᴿ prefix body M⊢ M′⊢) noM noM′ =
+      allocation-prefixᴿ prefix
+        (term-ctx-insertᴿ insert body noM noM′)
+        (typing-renameˣ (term-ctx-insert-left-wfᴿ insert) M⊢)
+        (typing-renameˣ (term-ctx-insert-right-wfᴿ insert) M′⊢)
+    term-ctx-insertᴿ insert
+        (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑
+          liftρ liftγ body replace)
+        (no•-ν noN) (no•-ν noN′)
+        with term-ctx-insert-paired-liftᴿ insert liftγ
+    term-ctx-insertᴿ insert
+        (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑
+          liftρ liftγ body replace)
+        (no•-ν noN) (no•-ν noN′)
+        | δ↑ , liftδ , insert↑ =
+      ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑ liftρ liftδ
+        (term-ctx-insertᴿ insert body noN noN′) replace
+    term-ctx-insertᴿ insert
+        (ν⊑ᴿ hA hA↑ s↑ liftρ liftγ body replace)
+        (no•-ν noN) noN′
+        with term-ctx-insert-left-liftᴿ insert liftγ
+    term-ctx-insertᴿ insert
+        (ν⊑ᴿ hA hA↑ s↑ liftρ liftγ body replace)
+        (no•-ν noN) noN′
+        | δ↑ , liftδ , insert↑ =
+      ν⊑ᴿ hA hA↑ s↑ liftρ liftδ
+        (term-ctx-insertᴿ insert body noN noN′) replace
+    term-ctx-insertᴿ insert κ⊑κᴿ no•-$ no•-$ =
+      κ⊑κᴿ
+    term-ctx-insertᴿ insert (left ⊕ᴿ[ op ] right)
+        (no•-⊕ noL noM) (no•-⊕ noL′ noM′) =
+      term-ctx-insertᴿ insert left noL noL′
+      ⊕ᴿ[ op ]
+      term-ctx-insertᴿ insert right noM noM′
+    term-ctx-insertᴿ insert
+        (gen⊑groundᴿ
+          mode seal c⊒ ground vV vW W⊢ body q)
+        (no•-⟨⟩ noV) noW =
+      gen⊑groundᴿ mode seal c⊒ ground
+        (renameˣᵐ-preserves-Value _ vV)
+        (renameˣᵐ-preserves-Value _ vW)
+        (typing-renameˣ
+          (term-ctx-insert-right-wfᴿ insert) W⊢)
+        (term-ctx-insertᴿ
+          insert body noV (no•-⟨⟩ noW)) q
+    term-ctx-insertᴿ insert
+        (cast⊒⊑ᴿ mode seal c⊒ body q shape comp)
+        (no•-⟨⟩ noM) noM′ =
+      cast⊒⊑ᴿ mode seal c⊒
+        (term-ctx-insertᴿ insert body noM noM′)
+        q shape comp
+    term-ctx-insertᴿ insert
+        (cast⊑⊑ᴿ mode seal c⊑ body q shape comp)
+        (no•-⟨⟩ noM) noM′ =
+      cast⊑⊑ᴿ mode seal c⊑
+        (term-ctx-insertᴿ insert body noM noM′)
+        q shape comp
+    term-ctx-insertᴿ insert
+        (⊑cast⊒ᴿ mode seal c⊒ body q shape comp)
+        noM (no•-⟨⟩ noM′) =
+      ⊑cast⊒ᴿ mode seal c⊒
+        (term-ctx-insertᴿ insert body noM noM′)
+        q shape comp
+    term-ctx-insertᴿ insert
+        (⊑cast⊑ᴿ mode seal c⊑ body q shape comp)
+        noM (no•-⟨⟩ noM′) =
+      ⊑cast⊑ᴿ mode seal c⊑
+        (term-ctx-insertᴿ insert body noM noM′)
+        q shape comp
+    term-ctx-insertᴿ insert
+        (conv↑⊑ᴿ conv body q replace)
+        (no•-⟨⟩ noM) noM′ =
+      conv↑⊑ᴿ conv
+        (term-ctx-insertᴿ insert body noM noM′) q replace
+    term-ctx-insertᴿ insert
+        (conv↓⊑ᴿ conv body q replace)
+        (no•-⟨⟩ noM) noM′ =
+      conv↓⊑ᴿ conv
+        (term-ctx-insertᴿ insert body noM noM′) q replace
+    term-ctx-insertᴿ insert
+        (⊑conv↑ᴿ conv body q replace)
+        noM (no•-⟨⟩ noM′) =
+      ⊑conv↑ᴿ conv
+        (term-ctx-insertᴿ insert body noM noM′) q replace
+    term-ctx-insertᴿ insert
+        (⊑conv↓ᴿ conv body q replace)
+        noM (no•-⟨⟩ noM′) =
+      ⊑conv↓ᴿ conv
+        (term-ctx-insertᴿ insert body noM noM′) q replace
+    term-ctx-insertᴿ insert
+        (paired-revealᴿ corresponds source target replace body)
+        (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+      paired-revealᴿ corresponds source target replace
+        (term-ctx-insertᴿ insert body noM noM′)
+    term-ctx-insertᴿ insert
+        (paired-concealᴿ corresponds source target replace body)
+        (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+      paired-concealᴿ corresponds source target replace
+        (term-ctx-insertᴿ insert body noM noM′)
+    term-ctx-insertᴿ {η = η} insert
+        (target-instantiationᴿ embedded) noM noM′
+        rewrite
+          rename-closedᵐ
+            (typing-closedᵐ
+              (forget (embedded-creation-source-typingᴱ embedded))) η
+        | rename-closedᵐ
+            (typing-closedᵐ
+              (forget (embedded-creation-target-typingᴱ embedded))) η =
+      target-instantiationᴿ embedded
+    term-ctx-insertᴿ insert
+        (closeᴿ body widening
+          source-shape target-shape square compatible)
+        (no•-⟨⟩ noN) (no•-⟨⟩ noN′) =
+      closeᴿ
+        (quotient-term-ctx-insertᴿ insert body noN noN′)
+        widening source-shape target-shape square compatible
+    term-ctx-insertᴿ insert
+        (paired-wideningᴿ
+          mode seal source source-shape
+          mode′ seal′ target target-shape
+          left-square right-square compatible body)
+        (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+      paired-wideningᴿ
+        mode seal source source-shape
+        mode′ seal′ target target-shape
+        left-square right-square compatible
+        (term-ctx-insertᴿ insert body noM noM′)
+
+    quotient-term-ctx-insertᴿ insert
+        (paired-downᴿ
+          body source-mode source source-shape
+          target-mode target target-shape square)
+        (no•-⟨⟩ noM) (no•-⟨⟩ noM′) =
+      paired-downᴿ
+        (term-ctx-insertᴿ insert body noM noM′)
+        source-mode source source-shape
+        target-mode target target-shape square
+
+
+smaller-term-context-shiftᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A B C C′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ} →
+  No• M → No• M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ ctx-imp C C′ q ∷ γ
+    ⊢ᴿ renameˣᵐ suc M ⊑ renameˣᵐ suc M′
+    ⦂ A ⊑ B ∶ p
+smaller-term-context-shiftᴿ noM noM′ M⊑M′ =
+  term-ctx-insertᴿ insert-hereᴿ M⊑M′ noM noM′

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTransientAudit.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTransientAudit.agda
@@ -1,0 +1,70 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientTransientAudit
+  where
+
+-- File Charter:
+--   * Records the operational distinction used by the smaller-relation audit.
+--   * Proves that `gen`-cast and ground endpoints are terminal values, so
+--     up-to-reduction cannot manufacture a missing relation between them.
+--   * Proves that a reachable `ν` carrying an instantiation-body widening is
+--     an administrative transient whenever its body is a no-bullet value.
+--   * Imports no term-imprecision judgment and changes no relation.
+
+import Coercions as C
+open import Coercions using (Coercion)
+open import Data.Empty using (⊥)
+open import NuReduction using
+  ( StoreChange
+  ; bind
+  ; keep
+  ; pure-step
+  ; β-inst
+  ; ν-step
+  ; _—→[_]_
+  )
+open import NuTerms using
+  ( No•
+  ; Term
+  ; Value
+  ; ν
+  ; ⇑ᵗᵐ
+  ; _•
+  ; _⟨_⟩
+  )
+open import Types using
+  (Ty; ★)
+open import proof.DGG.Core.NuPreservation using
+  (value-no-step)
+
+
+gen-cast-value-no-step :
+  ∀ {V N : Term} {A : Ty} {c : Coercion} {χ : StoreChange} →
+  Value V →
+  V ⟨ C.gen A c ⟩ —→[ χ ] N →
+  ⊥
+gen-cast-value-no-step vV reduction =
+  value-no-step (vV ⟨ C.gen _ _ ⟩) reduction
+
+
+ground-value-no-step :
+  ∀ {V N : Term} {χ : StoreChange} →
+  Value V →
+  V —→[ χ ] N →
+  ⊥
+ground-value-no-step = value-no-step
+
+
+instantiation-creates-nu :
+  ∀ {V : Term} {B : Ty} {s : Coercion} →
+  Value V →
+  V ⟨ C.inst B s ⟩ —→[ keep ] ν ★ V s
+instantiation-creates-nu vV =
+  pure-step (β-inst vV)
+
+
+nu-cast-administrative-step :
+  ∀ {V : Term} {s : Coercion} →
+  Value V →
+  No• V →
+  ν ★ V s —→[ bind ★ ] ((⇑ᵗᵐ V) •) ⟨ s ⟩
+nu-cast-administrative-step = ν-step

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTypingExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTypingExperiment.agda
@@ -1,0 +1,420 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientTypingExperiment
+  where
+
+-- File Charter:
+--   * Proves source and target typing projections for the independent smaller
+--     ordinary term-imprecision relation.
+--   * Proves the projections mutually with the one-boundary quotient
+--     judgment, including both narrowing and quotient-closing casts.
+--   * Uses the exact typing evidence retained by the composable embedded
+--     target-instantiation creation residual.
+--   * Contains no legacy term-imprecision judgment, postulate, hole,
+--     permissive option, termination bypass, or catch-all clause.
+
+open import Relation.Binary.PropositionalEquality using (subst)
+
+open import Coercions using (id-only≤tag-or-idᵈ)
+open import Conversion using
+  (conceal-conversion-typing; reveal-conversion-typing)
+open import Data.List using ([])
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionWf using
+  (_∣_⊢_⊑_⊣_; ⊑-src-wf)
+open import NarrowWiden using
+  (narrow-mode-relax; widen-mode-relax)
+open import NuTermImprecision using
+  ( CtxImp
+  ; StoreImp
+  ; leftCtxⁱ
+  ; leftCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; leftCtxⁱ-∋
+  ; leftStoreⁱ
+  ; leftStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightCtxⁱ
+  ; rightCtxⁱ-lift
+  ; rightCtxⁱ-lift-left
+  ; rightCtxⁱ-∋
+  ; rightStoreⁱ
+  ; rightStoreⁱ-lift
+  ; rightStoreⁱ-lift-left
+  ; seal★-tag-or-id
+  )
+open import NuTerms using (Term)
+open import TermTyping using
+  ( cast-tag-or-id
+  ; ⊢blame
+  ; ⊢`
+  ; ⊢ƛ
+  ; ⊢·
+  ; ⊢Λ
+  ; ⊢ν↑
+  ; ⊢$
+  ; ⊢⊕
+  ; ⊢⟨⟩↑
+  ; ⊢⟨⟩↓
+  ; ⊢⟨⟩⊒
+  ; ⊢⟨⟩⊑
+  ; forget
+  ; _∣_∣_⊢_⦂_
+  )
+open import Types using (Ty; TyCtx)
+open import
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  using
+  ( embedded-creation-source-typingᴱ
+  ; embedded-creation-target-typingᴱ
+  )
+open import
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
+  using (SpineCastMode; id-only↓; gradual↓)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( QuotientWideningPairᴿ
+  ; blame⊑ᴿ
+  ; x⊑xᴿ
+  ; ƛ⊑ƛᴿ
+  ; _·ᴿ_
+  ; Λ⊑Λᴿ
+  ; Λ⊑ᴿ
+  ; α⊑αᴿ
+  ; α⊑ᴿ
+  ; allocation-prefixᴿ
+  ; ν⊑νᴿ
+  ; ν⊑ᴿ
+  ; κ⊑κᴿ
+  ; _⊕ᴿ[_]_
+  ; gen⊑groundᴿ
+  ; cast⊒⊑ᴿ
+  ; cast⊑⊑ᴿ
+  ; ⊑cast⊒ᴿ
+  ; ⊑cast⊑ᴿ
+  ; conv↑⊑ᴿ
+  ; conv↓⊑ᴿ
+  ; ⊑conv↑ᴿ
+  ; ⊑conv↓ᴿ
+  ; paired-revealᴿ
+  ; paired-concealᴿ
+  ; target-instantiationᴿ
+  ; closeᴿ
+  ; paired-wideningᴿ
+  ; paired-downᴿ
+  ; quotient-id-wideningᴿ
+  ; quotient-cast-wideningᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  ; _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+open import proof.Core.Properties.NuTermProperties using
+  (closed-refined-typing-recontextualize; typing-closedᵐ)
+
+
+private
+  spine-source-cast-typing :
+    ∀ {Δ Σ Γ M A B d μ} →
+    SpineCastMode Σ μ →
+    μ NarrowWiden.∣ Δ ∣ Σ ⊢ d ∶ A ⊒ B →
+    Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
+    Δ ∣ Σ ∣ Γ ⊢ NuTerms._⟨_⟩ M d ⦂ B
+  spine-source-cast-typing id-only↓ d⊒ M⊢ =
+    ⊢⟨⟩⊒ cast-tag-or-id seal★-tag-or-id
+      (narrow-mode-relax id-only≤tag-or-idᵈ d⊒) M⊢
+  spine-source-cast-typing (gradual↓ mode seal★) d⊒ M⊢ =
+    ⊢⟨⟩⊒ mode seal★ d⊒ M⊢
+
+  quotient-widening-source-typing :
+    ∀ {Φ Δᴸ Δᴿ} {ρ : StoreImp Φ Δᴸ Δᴿ}
+      {Γ N D D′ A A′ u u′} →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ Γ ⊢ N ⦂ D →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ Γ ⊢ NuTerms._⟨_⟩ N u ⦂ A
+  quotient-widening-source-typing
+      (quotient-id-wideningᴿ u⊑ u′⊑) N⊢ =
+    ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
+      (widen-mode-relax id-only≤tag-or-idᵈ u⊑) N⊢
+  quotient-widening-source-typing
+      (quotient-cast-wideningᴿ
+        mode seal★ u⊑ mode′ seal★′ u′⊑) N⊢ =
+    ⊢⟨⟩⊑ mode seal★ u⊑ N⊢
+
+  quotient-widening-target-typing :
+    ∀ {Φ Δᴸ Δᴿ} {ρ : StoreImp Φ Δᴸ Δᴿ}
+      {Γ N′ D D′ A A′ u u′} →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ Γ ⊢ N′ ⦂ D′ →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ Γ ⊢ NuTerms._⟨_⟩ N′ u′ ⦂ A′
+  quotient-widening-target-typing
+      (quotient-id-wideningᴿ u⊑ u′⊑) N′⊢ =
+    ⊢⟨⟩⊑ cast-tag-or-id seal★-tag-or-id
+      (widen-mode-relax id-only≤tag-or-idᵈ u′⊑) N′⊢
+  quotient-widening-target-typing
+      (quotient-cast-wideningᴿ
+        mode seal★ u⊑ mode′ seal★′ u′⊑) N′⊢ =
+    ⊢⟨⟩⊑ mode′ seal★′ u′⊑ N′⊢
+
+
+mutual
+  smaller-imprecision-source-typingᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A
+
+  smaller-imprecision-target-typingᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B
+
+  smaller-quotient-source-typingᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ D D′}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ D
+
+  smaller-quotient-target-typingᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ γ M M′ D D′}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ D′
+
+  smaller-imprecision-source-typingᴿ (blame⊑ᴿ {p = p} M′⊢) =
+    ⊢blame (⊑-src-wf p)
+  smaller-imprecision-source-typingᴿ (x⊑xᴿ x∈) =
+    ⊢` (leftCtxⁱ-∋ x∈)
+  smaller-imprecision-source-typingᴿ (ƛ⊑ƛᴿ hA hA′ N⊑N′) =
+    ⊢ƛ hA (smaller-imprecision-source-typingᴿ N⊑N′)
+  smaller-imprecision-source-typingᴿ (L⊑L′ ·ᴿ M⊑M′) =
+    ⊢· (smaller-imprecision-source-typingᴿ L⊑L′)
+       (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (Λ⊑Λᴿ {ρ = ρ} {γ = γ} liftρ liftγ vV vV′ V⊑V′) =
+    ⊢Λ vV
+      (subst
+        (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+        (leftCtxⁱ-lift liftγ)
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (leftStoreⁱ-lift liftρ)
+          (smaller-imprecision-source-typingᴿ V⊑V′)))
+  smaller-imprecision-source-typingᴿ
+      (Λ⊑ᴿ occ liftρ liftγ vV V⊑N′) =
+    ⊢Λ vV
+      (subst
+        (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+        (leftCtxⁱ-lift-left liftγ)
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (leftStoreⁱ-lift-left liftρ)
+          (smaller-imprecision-source-typingᴿ V⊑N′)))
+  smaller-imprecision-source-typingᴿ
+      (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
+        L⊑L′ L•⊢ L′•⊢) =
+    L•⊢
+  smaller-imprecision-source-typingᴿ
+      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+    L•⊢
+  smaller-imprecision-source-typingᴿ
+      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) =
+    M⊢
+  smaller-imprecision-source-typingᴿ
+      (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
+        N⊑N′ replace) =
+    ⊢ν↑ hA (smaller-imprecision-source-typingᴿ N⊑N′)
+      (reveal-conversion-typing s↑)
+  smaller-imprecision-source-typingᴿ
+      (ν⊑ᴿ hA h⇑A s↑ liftρ liftγ N⊑N′ replace) =
+    ⊢ν↑ hA (smaller-imprecision-source-typingᴿ N⊑N′)
+      (reveal-conversion-typing s↑)
+  smaller-imprecision-source-typingᴿ κ⊑κᴿ =
+    ⊢$ _
+  smaller-imprecision-source-typingᴿ
+      (L⊑L′ ⊕ᴿ[ op ] M⊑M′) =
+    ⊢⊕ (smaller-imprecision-source-typingᴿ L⊑L′) op
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (gen⊑groundᴿ mode seal★ c⊒ ground vV vW W⊢ V⊑Wtag q) =
+    ⊢⟨⟩⊒ mode seal★ c⊒
+      (smaller-imprecision-source-typingᴿ V⊑Wtag)
+  smaller-imprecision-source-typingᴿ
+      (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q shape comp) =
+    ⊢⟨⟩⊒ mode seal★ c⊒
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q shape comp) =
+    ⊢⟨⟩⊑ mode seal★ c⊑
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (⊑cast⊒ᴿ mode′ seal★′ c′⊒ M⊑M′ q shape comp) =
+    smaller-imprecision-source-typingᴿ M⊑M′
+  smaller-imprecision-source-typingᴿ
+      (⊑cast⊑ᴿ mode′ seal★′ c′⊑ M⊑M′ q shape comp) =
+    smaller-imprecision-source-typingᴿ M⊑M′
+  smaller-imprecision-source-typingᴿ
+      (conv↑⊑ᴿ c↑ M⊑M′ q replace) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c↑)
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (conv↓⊑ᴿ c↓ M⊑M′ q replace) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c↓)
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (⊑conv↑ᴿ c′↑ M⊑M′ q replace) =
+    smaller-imprecision-source-typingᴿ M⊑M′
+  smaller-imprecision-source-typingᴿ
+      (⊑conv↓ᴿ c′↓ M⊑M′ q replace) =
+    smaller-imprecision-source-typingᴿ M⊑M′
+  smaller-imprecision-source-typingᴿ
+      (paired-revealᴿ corresponds c↑ c′↑ replace M⊑M′) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c↑)
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (paired-concealᴿ corresponds c↓ c′↓ replace M⊑M′) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c↓)
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (target-instantiationᴿ embedded) =
+    closed-refined-typing-recontextualize
+      (typing-closedᵐ
+        (forget (embedded-creation-source-typingᴱ embedded)))
+      (embedded-creation-source-typingᴱ embedded)
+  smaller-imprecision-source-typingᴿ
+      (closeᴿ M⊑M′ widening-pair
+        u-shape u′-shape square compatible) =
+    quotient-widening-source-typing widening-pair
+      (smaller-quotient-source-typingᴿ M⊑M′)
+  smaller-imprecision-source-typingᴿ
+      (paired-wideningᴿ
+        mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+        left-square right-square compatible M⊑M′) =
+    ⊢⟨⟩⊑ mode seal★ c⊑
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+
+  smaller-imprecision-target-typingᴿ (blame⊑ᴿ M′⊢) =
+    M′⊢
+  smaller-imprecision-target-typingᴿ (x⊑xᴿ x∈) =
+    ⊢` (rightCtxⁱ-∋ x∈)
+  smaller-imprecision-target-typingᴿ (ƛ⊑ƛᴿ hA hA′ N⊑N′) =
+    ⊢ƛ hA′ (smaller-imprecision-target-typingᴿ N⊑N′)
+  smaller-imprecision-target-typingᴿ (L⊑L′ ·ᴿ M⊑M′) =
+    ⊢· (smaller-imprecision-target-typingᴿ L⊑L′)
+       (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (Λ⊑Λᴿ {ρ = ρ} {γ = γ} liftρ liftγ vV vV′ V⊑V′) =
+    ⊢Λ vV′
+      (subst
+        (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+        (rightCtxⁱ-lift liftγ)
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (rightStoreⁱ-lift liftρ)
+          (smaller-imprecision-target-typingᴿ V⊑V′)))
+  smaller-imprecision-target-typingᴿ
+      (Λ⊑ᴿ occ liftρ liftγ vV V⊑N′) =
+    subst
+      (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+      (rightCtxⁱ-lift-left liftγ)
+      (subst
+        (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+        (rightStoreⁱ-lift-left liftρ)
+        (smaller-imprecision-target-typingᴿ V⊑N′))
+  smaller-imprecision-target-typingᴿ
+      (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
+        L⊑L′ L•⊢ L′•⊢) =
+    L′•⊢
+  smaller-imprecision-target-typingᴿ
+      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+    N′⊢
+  smaller-imprecision-target-typingᴿ
+      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) =
+    M′⊢
+  smaller-imprecision-target-typingᴿ
+      (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
+        N⊑N′ replace) =
+    ⊢ν↑ hA′ (smaller-imprecision-target-typingᴿ N⊑N′)
+      (reveal-conversion-typing s′↑)
+  smaller-imprecision-target-typingᴿ
+      (ν⊑ᴿ hA h⇑A s↑ liftρ liftγ N⊑N′ replace) =
+    smaller-imprecision-target-typingᴿ N⊑N′
+  smaller-imprecision-target-typingᴿ κ⊑κᴿ =
+    ⊢$ _
+  smaller-imprecision-target-typingᴿ
+      (L⊑L′ ⊕ᴿ[ op ] M⊑M′) =
+    ⊢⊕ (smaller-imprecision-target-typingᴿ L⊑L′) op
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (gen⊑groundᴿ mode seal★ c⊒ ground vV vW W⊢ V⊑Wtag q) =
+    W⊢
+  smaller-imprecision-target-typingᴿ
+      (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q shape comp) =
+    smaller-imprecision-target-typingᴿ M⊑M′
+  smaller-imprecision-target-typingᴿ
+      (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q shape comp) =
+    smaller-imprecision-target-typingᴿ M⊑M′
+  smaller-imprecision-target-typingᴿ
+      (⊑cast⊒ᴿ mode′ seal★′ c′⊒ M⊑M′ q shape comp) =
+    ⊢⟨⟩⊒ mode′ seal★′ c′⊒
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (⊑cast⊑ᴿ mode′ seal★′ c′⊑ M⊑M′ q shape comp) =
+    ⊢⟨⟩⊑ mode′ seal★′ c′⊑
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (conv↑⊑ᴿ c↑ M⊑M′ q replace) =
+    smaller-imprecision-target-typingᴿ M⊑M′
+  smaller-imprecision-target-typingᴿ
+      (conv↓⊑ᴿ c↓ M⊑M′ q replace) =
+    smaller-imprecision-target-typingᴿ M⊑M′
+  smaller-imprecision-target-typingᴿ
+      (⊑conv↑ᴿ c′↑ M⊑M′ q replace) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c′↑)
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (⊑conv↓ᴿ c′↓ M⊑M′ q replace) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c′↓)
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (paired-revealᴿ corresponds c↑ c′↑ replace M⊑M′) =
+    ⊢⟨⟩↑ (reveal-conversion-typing c′↑)
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (paired-concealᴿ corresponds c↓ c′↓ replace M⊑M′) =
+    ⊢⟨⟩↓ (conceal-conversion-typing c′↓)
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (target-instantiationᴿ embedded) =
+    closed-refined-typing-recontextualize
+      (typing-closedᵐ
+        (forget (embedded-creation-target-typingᴱ embedded)))
+      (embedded-creation-target-typingᴱ embedded)
+  smaller-imprecision-target-typingᴿ
+      (closeᴿ M⊑M′ widening-pair
+        u-shape u′-shape square compatible) =
+    quotient-widening-target-typing widening-pair
+      (smaller-quotient-target-typingᴿ M⊑M′)
+  smaller-imprecision-target-typingᴿ
+      (paired-wideningᴿ
+        mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+        left-square right-square compatible M⊑M′) =
+    ⊢⟨⟩⊑ mode′ seal★′ c′⊑
+      (smaller-imprecision-target-typingᴿ M⊑M′)
+
+  smaller-quotient-source-typingᴿ
+      (paired-downᴿ
+        M⊑M′ mode d⊒ d-shape mode′ d′⊒ d′-shape square) =
+    spine-source-cast-typing mode d⊒
+      (smaller-imprecision-source-typingᴿ M⊑M′)
+
+  smaller-quotient-target-typingᴿ
+      (paired-downᴿ
+        M⊑M′ mode d⊒ d-shape mode′ d′⊒ d′-shape square) =
+    spine-source-cast-typing mode′ d′⊒
+      (smaller-imprecision-target-typingᴿ M⊑M′)

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientValueExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientValueExperiment.agda
@@ -1,0 +1,431 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientValueExperiment
+  where
+
+-- File Charter:
+--   * Classifies source and target Value endpoints of every constructor in the
+--     independent smaller ordinary term-imprecision relation.
+--   * Excludes application, type application, primitive-operation, and `ν`
+--     outer forms by indexed Value inversion.
+--   * Threads Value classification through proof-only allocation prefixes and
+--     one-sided term wrappers, and identifies inert outer casts.
+--   * Classifies the sole embedded target-instantiation creation case and
+--     derives value/no-step facts for exact and composed embeddings.
+--   * Contains no legacy term-imprecision judgment, world-coherent dispatcher,
+--     postulate, hole, permissive option, termination bypass, or catch-all.
+
+open import Data.Empty using (⊥)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NuReduction using (_—→[_]_)
+open import NuTermImprecision using
+  (CtxImp; StoreImp)
+open import NuTerms using
+  (Term; Value; Λ_; _⟨_⟩; renameᵗᵐ)
+open import Types using (Renameᵗ; Ty; TyCtx)
+open import proof.Core.Properties.NuTermProperties using
+  (renameᵗᵐ-preserves-Value)
+open import proof.DGG.Core.NuPreservation using (value-no-step)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( blame⊑ᴿ
+  ; x⊑xᴿ
+  ; ƛ⊑ƛᴿ
+  ; _·ᴿ_
+  ; Λ⊑Λᴿ
+  ; Λ⊑ᴿ
+  ; α⊑αᴿ
+  ; α⊑ᴿ
+  ; allocation-prefixᴿ
+  ; ν⊑νᴿ
+  ; ν⊑ᴿ
+  ; κ⊑κᴿ
+  ; _⊕ᴿ[_]_
+  ; gen⊑groundᴿ
+  ; cast⊒⊑ᴿ
+  ; cast⊑⊑ᴿ
+  ; ⊑cast⊒ᴿ
+  ; ⊑cast⊑ᴿ
+  ; conv↑⊑ᴿ
+  ; conv↓⊑ᴿ
+  ; ⊑conv↑ᴿ
+  ; ⊑conv↓ᴿ
+  ; paired-revealᴿ
+  ; paired-concealᴿ
+  ; target-instantiationᴿ
+  ; closeᴿ
+  ; paired-wideningᴿ
+  ; paired-downᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  ; _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using (TargetInstantiationCreation)
+
+
+data SmallerSourceValueClassᴿ : Set where
+  source-functionᴿ : SmallerSourceValueClassᴿ
+  source-universalᴿ : SmallerSourceValueClassᴿ
+  source-constantᴿ : SmallerSourceValueClassᴿ
+  source-inert-castᴿ : SmallerSourceValueClassᴿ
+  source-creationᴿ : SmallerSourceValueClassᴿ
+
+
+data SmallerTargetValueClassᴿ : Set where
+  target-blame-relatedᴿ : SmallerTargetValueClassᴿ
+  target-functionᴿ : SmallerTargetValueClassᴿ
+  target-universalᴿ : SmallerTargetValueClassᴿ
+  target-constantᴿ : SmallerTargetValueClassᴿ
+  target-groundᴿ : SmallerTargetValueClassᴿ
+  target-inert-castᴿ : SmallerTargetValueClassᴿ
+  target-creationᴿ : SmallerTargetValueClassᴿ
+
+
+smaller-source-value-classᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Value M →
+  SmallerSourceValueClassᴿ
+smaller-source-value-classᴿ (blame⊑ᴿ M′⊢) ()
+smaller-source-value-classᴿ (x⊑xᴿ x∈) ()
+smaller-source-value-classᴿ (ƛ⊑ƛᴿ hA hA′ N⊑N′) vƛ =
+  source-functionᴿ
+smaller-source-value-classᴿ (L⊑L′ ·ᴿ M⊑M′) ()
+smaller-source-value-classᴿ
+    (Λ⊑Λᴿ liftρ liftγ vV vV′ V⊑V′) vΛ =
+  source-universalᴿ
+smaller-source-value-classᴿ
+    (Λ⊑ᴿ occ liftρ liftγ vV V⊑N′) vΛ =
+  source-universalᴿ
+smaller-source-value-classᴿ
+    (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
+      L⊑L′ L•⊢ L′•⊢) ()
+smaller-source-value-classᴿ
+    (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) ()
+smaller-source-value-classᴿ
+    (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) vM =
+  smaller-source-value-classᴿ M⊑M′ vM
+smaller-source-value-classᴿ
+    (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
+      N⊑N′ replace) ()
+smaller-source-value-classᴿ
+    (ν⊑ᴿ hA h⇑A s↑ liftρ liftγ N⊑N′ replace) ()
+smaller-source-value-classᴿ κ⊑κᴿ vκ =
+  source-constantᴿ
+smaller-source-value-classᴿ (L⊑L′ ⊕ᴿ[ op ] M⊑M′) ()
+smaller-source-value-classᴿ
+    (gen⊑groundᴿ mode seal★ c⊒ ground vV vW W⊢ V⊑Wtag q)
+    (vV′ ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q shape comp)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q shape comp)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (⊑cast⊒ᴿ mode′ seal★′ c′⊒ M⊑M′ q shape comp) vM =
+  smaller-source-value-classᴿ M⊑M′ vM
+smaller-source-value-classᴿ
+    (⊑cast⊑ᴿ mode′ seal★′ c′⊑ M⊑M′ q shape comp) vM =
+  smaller-source-value-classᴿ M⊑M′ vM
+smaller-source-value-classᴿ
+    (conv↑⊑ᴿ c↑ M⊑M′ q replace) (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (conv↓⊑ᴿ c↓ M⊑M′ q replace) (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (⊑conv↑ᴿ c′↑ M⊑M′ q replace) vM =
+  smaller-source-value-classᴿ M⊑M′ vM
+smaller-source-value-classᴿ
+    (⊑conv↓ᴿ c′↓ M⊑M′ q replace) vM =
+  smaller-source-value-classᴿ M⊑M′ vM
+smaller-source-value-classᴿ
+    (paired-revealᴿ corresponds c↑ c′↑ replace M⊑M′)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (paired-concealᴿ corresponds c↓ c′↓ replace M⊑M′)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (target-instantiationᴿ embedded) vΛ =
+  source-creationᴿ
+smaller-source-value-classᴿ
+    (closeᴿ M⊑M′ widening-pair
+      u-shape u′-shape square compatible)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+smaller-source-value-classᴿ
+    (paired-wideningᴿ
+      mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+      left-square right-square compatible M⊑M′)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+
+
+smaller-target-value-classᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Value M′ →
+  SmallerTargetValueClassᴿ
+smaller-target-value-classᴿ (blame⊑ᴿ M′⊢) vM′ =
+  target-blame-relatedᴿ
+smaller-target-value-classᴿ (x⊑xᴿ x∈) ()
+smaller-target-value-classᴿ (ƛ⊑ƛᴿ hA hA′ N⊑N′) vƛ =
+  target-functionᴿ
+smaller-target-value-classᴿ (L⊑L′ ·ᴿ M⊑M′) ()
+smaller-target-value-classᴿ
+    (Λ⊑Λᴿ liftρ liftγ vV vV′ V⊑V′) vΛ =
+  target-universalᴿ
+smaller-target-value-classᴿ
+    (Λ⊑ᴿ occ liftρ liftγ vV V⊑N′) vN′ =
+  smaller-target-value-classᴿ V⊑N′ vN′
+smaller-target-value-classᴿ
+    (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
+      L⊑L′ L•⊢ L′•⊢) ()
+smaller-target-value-classᴿ
+    (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) vN′ =
+  smaller-target-value-classᴿ L⊑N′ vN′
+smaller-target-value-classᴿ
+    (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) vM′ =
+  smaller-target-value-classᴿ M⊑M′ vM′
+smaller-target-value-classᴿ
+    (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
+      N⊑N′ replace) ()
+smaller-target-value-classᴿ
+    (ν⊑ᴿ hA h⇑A s↑ liftρ liftγ N⊑N′ replace) vN′ =
+  smaller-target-value-classᴿ N⊑N′ vN′
+smaller-target-value-classᴿ κ⊑κᴿ vκ =
+  target-constantᴿ
+smaller-target-value-classᴿ (L⊑L′ ⊕ᴿ[ op ] M⊑M′) ()
+smaller-target-value-classᴿ
+    (gen⊑groundᴿ mode seal★ c⊒ ground vV vW W⊢ V⊑Wtag q)
+    vW′ =
+  target-groundᴿ
+smaller-target-value-classᴿ
+    (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q shape comp) vM′ =
+  smaller-target-value-classᴿ M⊑M′ vM′
+smaller-target-value-classᴿ
+    (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q shape comp) vM′ =
+  smaller-target-value-classᴿ M⊑M′ vM′
+smaller-target-value-classᴿ
+    (⊑cast⊒ᴿ mode′ seal★′ c′⊒ M⊑M′ q shape comp)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (⊑cast⊑ᴿ mode′ seal★′ c′⊑ M⊑M′ q shape comp)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (conv↑⊑ᴿ c↑ M⊑M′ q replace) vM′ =
+  smaller-target-value-classᴿ M⊑M′ vM′
+smaller-target-value-classᴿ
+    (conv↓⊑ᴿ c↓ M⊑M′ q replace) vM′ =
+  smaller-target-value-classᴿ M⊑M′ vM′
+smaller-target-value-classᴿ
+    (⊑conv↑ᴿ c′↑ M⊑M′ q replace) (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (⊑conv↓ᴿ c′↓ M⊑M′ q replace) (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (paired-revealᴿ corresponds c↑ c′↑ replace M⊑M′)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (paired-concealᴿ corresponds c↓ c′↓ replace M⊑M′)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (target-instantiationᴿ embedded) vM′ =
+  target-creationᴿ
+smaller-target-value-classᴿ
+    (closeᴿ M⊑M′ widening-pair
+      u-shape u′-shape square compatible)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+smaller-target-value-classᴿ
+    (paired-wideningᴿ
+      mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+      left-square right-square compatible M⊑M′)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+
+
+smaller-quotient-source-value-classᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ D D′}
+    {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+  Value M →
+  SmallerSourceValueClassᴿ
+smaller-quotient-source-value-classᴿ
+    (paired-downᴿ
+      M⊑M′ mode d⊒ d-shape mode′ d′⊒ d′-shape square)
+    (vM ⟨ inert ⟩) =
+  source-inert-castᴿ
+
+
+smaller-quotient-target-value-classᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ D D′}
+    {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+  Value M′ →
+  SmallerTargetValueClassᴿ
+smaller-quotient-target-value-classᴿ
+    (paired-downᴿ
+      M⊑M′ mode d⊒ d-shape mode′ d′⊒ d′-shape square)
+    (vM′ ⟨ inert ⟩) =
+  target-inert-castᴿ
+
+
+smaller-source-value-no-stepᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B χ N}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Value M →
+  M —→[ χ ] N →
+  ⊥
+smaller-source-value-no-stepᴿ M⊑M′ vM M→N =
+  value-no-step vM M→N
+
+
+smaller-target-value-no-stepᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B χ N′}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Value M′ →
+  M′ —→[ χ ] N′ →
+  ⊥
+smaller-target-value-no-stepᴿ M⊑M′ vM′ M′→N′ =
+  value-no-step vM′ M′→N′
+
+
+target-instantiation-creation-valuesᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f body-shape}
+    {body-relation : Set₁} →
+  TargetInstantiationCreation
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape} body-relation →
+  Value (Λ W) × Value (W′ ⟨ s ⟩)
+target-instantiation-creation-valuesᴿ creation =
+  Λ (TargetInstantiationCreation.source-body-value creation) ,
+  TargetInstantiationCreation.target-body-value creation
+    ⟨ TargetInstantiationCreation.body-cast-inert creation ⟩
+
+
+target-instantiation-transport-valuesᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f body-shape}
+    {body-relation : Set₁} →
+  (τ σ : Renameᵗ) →
+  TargetInstantiationCreation
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape} body-relation →
+  Value (renameᵗᵐ τ (Λ W)) ×
+  Value (renameᵗᵐ σ (W′ ⟨ s ⟩))
+target-instantiation-transport-valuesᴿ τ σ creation =
+  renameᵗᵐ-preserves-Value τ (proj₁ creation-values) ,
+  renameᵗᵐ-preserves-Value σ (proj₂ creation-values)
+  where
+    creation-values = target-instantiation-creation-valuesᴿ creation
+
+
+target-instantiation-creation-source-no-stepᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f body-shape
+      χ N}
+    {body-relation : Set₁} →
+  (creation :
+    TargetInstantiationCreation
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape} body-relation) →
+  Λ W —→[ χ ] N →
+  ⊥
+target-instantiation-creation-source-no-stepᴿ creation source-step =
+  value-no-step
+    (proj₁ (target-instantiation-creation-valuesᴿ creation))
+    source-step
+
+
+target-instantiation-creation-target-no-stepᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f body-shape
+      χ N′}
+    {body-relation : Set₁} →
+  (creation :
+    TargetInstantiationCreation
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape} body-relation) →
+  W′ ⟨ s ⟩ —→[ χ ] N′ →
+  ⊥
+target-instantiation-creation-target-no-stepᴿ creation target-step =
+  value-no-step
+    (proj₂ (target-instantiation-creation-valuesᴿ creation))
+    target-step
+
+
+target-instantiation-transport-source-no-stepᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f body-shape
+      χ N}
+    {body-relation : Set₁} →
+  (τ σ : Renameᵗ) →
+  (creation :
+    TargetInstantiationCreation
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape} body-relation) →
+  renameᵗᵐ τ (Λ W) —→[ χ ] N →
+  ⊥
+target-instantiation-transport-source-no-stepᴿ
+    τ σ creation source-step =
+  value-no-step
+    (proj₁ (target-instantiation-transport-valuesᴿ τ σ creation))
+    source-step
+
+
+target-instantiation-transport-target-no-stepᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ W W′ B C D s μ r f body-shape
+      χ N′}
+    {body-relation : Set₁} →
+  (τ σ : Renameᵗ) →
+  (creation :
+    TargetInstantiationCreation
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape} body-relation) →
+  renameᵗᵐ σ (W′ ⟨ s ⟩) —→[ χ ] N′ →
+  ⊥
+target-instantiation-transport-target-no-stepᴿ
+    τ σ creation target-step =
+  value-no-step
+    (proj₂ (target-instantiation-transport-valuesᴿ τ σ creation))
+    target-step

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedWorldEmbeddingExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedWorldEmbeddingExperiment.agda
@@ -1,0 +1,855 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedWorldEmbeddingExperiment
+  where
+
+-- File Charter:
+--   * Defines the QTI-free relational-world embedding used by the
+--     reduction-closed smaller-relation experiments.
+--   * Pushes an arbitrary world embedding through term-context extension,
+--     paired type-binder lifting, and source-only type-binder lifting.
+--   * Inverts the experiment's store-prefix evidence through a structural
+--     relational-store embedding.
+--   * Depends only on type, cast-mode, store, context, and experimental
+--     prefix infrastructure; it imports no term-imprecision relation.
+--   * Contains no postulate, hole, catch-all clause, or permissive option.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.Empty using (⊥)
+open import Data.List using ([]; _∷_; map)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (suc; zero)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using
+  (cong; cong₂; subst; sym; trans)
+
+open import ImprecisionComposition using (⌊_⌋)
+open import ImprecisionWf using
+  ( ImpAssm
+  ; ImpCtx
+  ; _ˣ⊑★
+  ; _ˣ⊑ˣ_
+  ; ⇑ᴸᵢ
+  ; ⇑ᵢ
+  ; _∣_⊢_⊑_⊣_
+  )
+open import Imprecision using (⇑ᴿᵢ)
+open import NuTermImprecision using
+  ( CtxImp
+  ; LiftCtxⁱ
+  ; LiftLeftCtxⁱ
+  ; LiftLeftStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; ctx-imp
+  ; leftCtxⁱ
+  ; leftStoreⁱ
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  ; lift-left-store-[]
+  ; lift-left-store-left
+  ; lift-left-store-link
+  ; lift-left-store-right
+  ; lift-left-store-∷
+  ; lift-store-[]
+  ; lift-store-left
+  ; lift-store-link
+  ; lift-store-right
+  ; lift-store-∷
+  ; rightCtxⁱ
+  ; rightStoreⁱ
+  ; store-left
+  ; store-link
+  ; store-matched
+  ; store-right
+  )
+open import NuTerms using (No•; Term; renameᵗᵐ)
+open import TermTyping using (_∣_∣_⊢_⦂_)
+open import Types using
+  (Renameᵗ; Ty; TyCtx; extᵗ; renameᵗ; renameStoreᵗ; ⇑ᵗ)
+open import
+  proof.Core.Properties.NuCastImprecisionShapeProperties
+  using
+  ( shape-rename
+  ; shape-subst-source
+  ; shape-subst-target
+  )
+open import proof.Core.Properties.TypePreservation using
+  (CastModeRenamer; castModeRenamer-ext; typing-renameᵀ)
+open import proof.Core.Properties.TypeProperties using
+  ( RenameLeftInverse
+  ; RenameLeftInverse-ext
+  ; TyRenameWf
+  ; TyRenameWf-ext
+  ; TyRenameWf-suc
+  ; renameᵗ-ext-suc-comm
+  ; renameᵗ-preserves-WfTy
+  )
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  ( ∀ᵢᶜ
+  ; rename-assm²ᵢ
+  ; rename-assm²-⇑ᴸᵢ
+  ; rename-assm²-⇑ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-renameᵗ²ᵢ
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  (StoreImpPrefixᴿ; prefix-reflᴿ; prefix-∷ᴿ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelCtxRenameDef
+  using
+  ( RelCtxRenameⁱ
+  ; rel-ctx-rename-[]
+  ; rel-ctx-rename-∷
+  )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+  using
+  ( RelStoreEmbeddingⁱ
+  ; rel-store-embedding-[]
+  ; rel-store-embedding-left
+  ; rel-store-embedding-link
+  ; rel-store-embedding-matched
+  ; rel-store-embedding-right
+  )
+
+
+record ReductionClosedWorldEmbeddingᴿ
+    {Φ Ψ : ImpCtx} {Δᴸ Δᴿ Θᴸ Θᴿ : TyCtx}
+    (τ σ ψ φ : Renameᵗ)
+    (assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Θᴸ τ)
+    (hσ : TyRenameWf Δᴿ Θᴿ σ)
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} : Set₁ where
+  constructor reduction-closed-world-embeddingᴿ
+  field
+    left-inverseᴿ : RenameLeftInverse τ ψ
+    right-inverseᴿ : RenameLeftInverse σ φ
+    left-cast-renamerᴿ : CastModeRenamer τ
+    right-cast-renamerᴿ : CastModeRenamer σ
+    store-embeddingᴿ : RelStoreEmbeddingⁱ τ σ ρ ρ′
+    context-embeddingᴿ : RelCtxRenameⁱ τ σ assm hτ hσ γ γ′
+
+open ReductionClosedWorldEmbeddingᴿ public
+
+
+left-store-embedding-resultᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  (emb : RelStoreEmbeddingⁱ τ σ ρ ρ′) →
+  leftStoreⁱ ρ′ ≡ renameStoreᵗ τ (leftStoreⁱ ρ)
+left-store-embedding-resultᴿ rel-store-embedding-[] = refl
+left-store-embedding-resultᴿ
+    (rel-store-embedding-matched eqα eqA eqβ eqB shape-eq emb) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA)
+    (left-store-embedding-resultᴿ emb)
+left-store-embedding-resultᴿ
+    (rel-store-embedding-left eqα eqA emb) =
+  cong₂ _∷_ (cong₂ _,_ eqα eqA)
+    (left-store-embedding-resultᴿ emb)
+left-store-embedding-resultᴿ
+    (rel-store-embedding-right eqβ eqB emb) =
+  left-store-embedding-resultᴿ emb
+left-store-embedding-resultᴿ
+    (rel-store-embedding-link eqα eqA eqβ eqB shape-eq emb) =
+  left-store-embedding-resultᴿ emb
+
+
+right-store-embedding-resultᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ} →
+  (emb : RelStoreEmbeddingⁱ τ σ ρ ρ′) →
+  rightStoreⁱ ρ′ ≡ renameStoreᵗ σ (rightStoreⁱ ρ)
+right-store-embedding-resultᴿ rel-store-embedding-[] = refl
+right-store-embedding-resultᴿ
+    (rel-store-embedding-matched eqα eqA eqβ eqB shape-eq emb) =
+  cong₂ _∷_ (cong₂ _,_ eqβ eqB)
+    (right-store-embedding-resultᴿ emb)
+right-store-embedding-resultᴿ
+    (rel-store-embedding-left eqα eqA emb) =
+  right-store-embedding-resultᴿ emb
+right-store-embedding-resultᴿ
+    (rel-store-embedding-right eqβ eqB emb) =
+  cong₂ _∷_ (cong₂ _,_ eqβ eqB)
+    (right-store-embedding-resultᴿ emb)
+right-store-embedding-resultᴿ
+    (rel-store-embedding-link eqα eqA eqβ eqB shape-eq emb) =
+  right-store-embedding-resultᴿ emb
+
+
+left-context-embedding-resultᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  leftCtxⁱ γ′ ≡ map (renameᵗ τ) (leftCtxⁱ γ)
+left-context-embedding-resultᴿ rel-ctx-rename-[] = refl
+left-context-embedding-resultᴿ
+    (rel-ctx-rename-∷ eqA eqB emb) =
+  cong₂ _∷_ eqA (left-context-embedding-resultᴿ emb)
+
+
+right-context-embedding-resultᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  rightCtxⁱ γ′ ≡ map (renameᵗ σ) (rightCtxⁱ γ)
+right-context-embedding-resultᴿ rel-ctx-rename-[] = refl
+right-context-embedding-resultᴿ
+    (rel-ctx-rename-∷ eqA eqB emb) =
+  cong₂ _∷_ eqB (right-context-embedding-resultᴿ emb)
+
+
+world-embedding-source-typingᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M : Term} {A : Ty} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  No• M →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Θᴸ ∣ leftStoreⁱ ρ′ ∣ leftCtxⁱ γ′
+    ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A
+world-embedding-source-typingᴿ
+    {Θᴸ = Θᴸ} {τ = τ} {ψ = ψ} {hτ = hτ}
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}
+    {M = M} {A = A} emb noM M⊢ =
+  subst
+    (λ Γ → Θᴸ ∣ leftStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+    (sym (left-context-embedding-resultᴿ
+      (context-embeddingᴿ emb)))
+    (subst
+      (λ Σ → Θᴸ ∣ Σ ∣ map (renameᵗ τ) (leftCtxⁱ γ)
+        ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A)
+      (sym (left-store-embedding-resultᴿ
+        (store-embeddingᴿ emb)))
+      (typing-renameᵀ {ρ = τ} {ψ = ψ} hτ
+        (left-inverseᴿ emb) (left-cast-renamerᴿ emb)
+        noM M⊢))
+
+
+world-embedding-target-typingᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {M : Term} {B : Ty} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  No• M →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M ⦂ B →
+  Θᴿ ∣ rightStoreⁱ ρ′ ∣ rightCtxⁱ γ′
+    ⊢ renameᵗᵐ σ M ⦂ renameᵗ σ B
+world-embedding-target-typingᴿ
+    {Θᴿ = Θᴿ} {σ = σ} {φ = φ} {hσ = hσ}
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}
+    {M = M} {B = B} emb noM M⊢ =
+  subst
+    (λ Γ → Θᴿ ∣ rightStoreⁱ ρ′ ∣ Γ
+      ⊢ renameᵗᵐ σ M ⦂ renameᵗ σ B)
+    (sym (right-context-embedding-resultᴿ
+      (context-embeddingᴿ emb)))
+    (subst
+      (λ Σ → Θᴿ ∣ Σ ∣ map (renameᵗ σ) (rightCtxⁱ γ)
+        ⊢ renameᵗᵐ σ M ⦂ renameᵗ σ B)
+      (sym (right-store-embedding-resultᴿ
+        (store-embeddingᴿ emb)))
+      (typing-renameᵀ {ρ = σ} {ψ = φ} hσ
+        (right-inverseᴿ emb) (right-cast-renamerᴿ emb)
+        noM M⊢))
+
+
+⊑-rename-at-shapeᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ A A′ B B′}
+    (assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ)
+    (hτ : TyRenameWf Δᴸ Θᴸ τ)
+    (hσ : TyRenameWf Δᴿ Θᴿ σ)
+    (eqA : A′ ≡ renameᵗ τ A)
+    (eqB : B′ ≡ renameᵗ σ B)
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ) →
+  ⌊ ⊑-rename-at²ᵢ assm hτ hσ eqA eqB p ⌋ ≡ ⌊ p ⌋
+⊑-rename-at-shapeᴿ assm hτ hσ eqA eqB p =
+  trans
+    (shape-subst-target (sym eqB)
+      (subst
+        (λ T → _ ∣ _ ⊢ T ⊑ renameᵗ _ _ ⊣ _)
+        (sym eqA)
+        (⊑-renameᵗ²ᵢ assm hτ hσ p)))
+    (trans
+      (shape-subst-source
+        (sym eqA)
+        (⊑-renameᵗ²ᵢ assm hτ hσ p))
+      (shape-rename assm hτ hσ p))
+
+
+world-embedding-context-∷ᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {A B p} →
+  ReductionClosedWorldEmbeddingᴿ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′} →
+  ReductionClosedWorldEmbeddingᴿ τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′}
+    {γ = ctx-imp A B p ∷ γ}
+    {γ′ = ctx-imp (renameᵗ τ A) (renameᵗ σ B)
+      (⊑-renameᵗ²ᵢ assm hτ hσ p) ∷ γ′}
+world-embedding-context-∷ᴿ emb =
+  reduction-closed-world-embeddingᴿ
+    (left-inverseᴿ emb) (right-inverseᴿ emb)
+    (left-cast-renamerᴿ emb) (right-cast-renamerᴿ emb)
+    (store-embeddingᴿ emb)
+    (rel-ctx-rename-∷ refl refl (context-embeddingᴿ emb))
+
+
+rel-store-embedding-paired-liftᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  ∃[ ρ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    RelStoreEmbeddingⁱ (extᵗ τ) (extᵗ σ) ρ∀ ρ′∀
+rel-store-embedding-paired-liftᴿ
+    rel-store-embedding-[] lift-store-[] =
+  [] , lift-store-[] , rel-store-embedding-[]
+rel-store-embedding-paired-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-store-∷ {p′ = p∀} shape∀ liftρ)
+    with rel-store-embedding-paired-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-paired-liftᴿ
+    {τ = τ} {σ = σ} {assm = assm}
+    {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-store-∷
+      {A = A} {B = B} {p′ = p∀} shape∀ liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-matched (suc α′) (⇑ᵗ A′) (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+        eqA∀ eqB∀ p∀) ∷ ρ′∀ ,
+  lift-store-∷
+    (trans
+      (⊑-rename-at-shapeᴿ
+        (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+        eqA∀ eqB∀ p∀)
+      (trans shape∀ (sym shape-emb)))
+    liftρ′ ,
+  rel-store-embedding-matched
+    (cong suc eqα) eqA∀ (cong suc eqβ) eqB∀
+    (⊑-rename-at-shapeᴿ
+      (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+      eqA∀ eqB∀ p∀)
+    emb∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ =
+    trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-embedding-paired-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-store-left liftρ)
+    with rel-store-embedding-paired-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-paired-liftᴿ {τ = τ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-store-left {A = A} liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-left liftρ′ ,
+  rel-store-embedding-left (cong suc eqα) eqA∀ emb∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-embedding-paired-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-store-right liftρ)
+    with rel-store-embedding-paired-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-paired-liftᴿ {σ = σ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-store-right {B = B} liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-right (suc β′) (⇑ᵗ B′)
+      (renameᵗ-preserves-WfTy hB′ TyRenameWf-suc) ∷ ρ′∀ ,
+  lift-store-right liftρ′ ,
+  rel-store-embedding-right (cong suc eqβ) eqB∀ emb∀
+  where
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ =
+    trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+rel-store-embedding-paired-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-store-link {p′ = p∀} shape∀ liftρ)
+    with rel-store-embedding-paired-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-paired-liftᴿ
+    {τ = τ} {σ = σ} {assm = assm}
+    {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-store-link
+      {A = A} {B = B} {p′ = p∀} shape∀ liftρ)
+    | ρ′∀ , liftρ′ , emb∀ =
+  store-link (suc α′) (⇑ᵗ A′) (suc β′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+        eqA∀ eqB∀ p∀) ∷ ρ′∀ ,
+  lift-store-link
+    (trans
+      (⊑-rename-at-shapeᴿ
+        (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+        eqA∀ eqB∀ p∀)
+      (trans shape∀ (sym shape-emb)))
+    liftρ′ ,
+  rel-store-embedding-link
+    (cong suc eqα) eqA∀ (cong suc eqβ) eqB∀
+    (⊑-rename-at-shapeᴿ
+      (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+      eqA∀ eqB∀ p∀)
+    emb∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ =
+    trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+
+rel-context-embedding-paired-liftᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ γ′∀ ]
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    RelCtxRenameⁱ
+      (extᵗ τ) (extᵗ σ) (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) γ∀ γ′∀
+rel-context-embedding-paired-liftᴿ
+    rel-ctx-rename-[] lift-ctx-[] =
+  [] , lift-ctx-[] , rel-ctx-rename-[]
+rel-context-embedding-paired-liftᴿ
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′} {p = p}
+      eqA eqB renameγ)
+    (lift-ctx-∷ {p′ = p∀} shape∀ liftγ)
+    with rel-context-embedding-paired-liftᴿ renameγ liftγ
+rel-context-embedding-paired-liftᴿ
+    {τ = τ} {σ = σ} {assm = assm}
+    {hτ = hτ} {hσ = hσ}
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′} {p = p}
+      eqA eqB renameγ)
+    (lift-ctx-∷
+      {A = A} {B = B} {p′ = p∀} shape∀ liftγ)
+    | γ′∀ , liftγ′ , renameγ∀ =
+  ctx-imp (⇑ᵗ A′) (⇑ᵗ B′)
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+        eqA∀ eqB∀ p∀) ∷ γ′∀ ,
+  lift-ctx-∷
+    (trans
+      (⊑-rename-at-shapeᴿ
+        (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+        eqA∀ eqB∀ p∀)
+      (trans shape∀
+        (sym (⊑-rename-at-shapeᴿ
+          assm hτ hσ eqA eqB p))))
+    liftγ′ ,
+  rel-ctx-rename-∷ eqA∀ eqB∀ renameγ∀
+  where
+  eqA∀ : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqA∀ =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+  eqB∀ : ⇑ᵗ B′ ≡ renameᵗ (extᵗ σ) (⇑ᵗ B)
+  eqB∀ =
+    trans (cong ⇑ᵗ eqB) (sym (renameᵗ-ext-suc-comm σ B))
+
+
+world-embedding-paired-liftᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ∀ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ∀ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ∀ →
+  ∃[ ρ′∀ ] ∃[ γ′∀ ]
+    LiftStoreⁱ (∀ᵢᶜ Ψ) ρ′ ρ′∀ ×
+    LiftCtxⁱ (∀ᵢᶜ Ψ) γ′ γ′∀ ×
+    ReductionClosedWorldEmbeddingᴿ
+      (extᵗ τ) (extᵗ σ) (extᵗ ψ) (extᵗ φ)
+      (rename-assm²-⇑ᵢ assm)
+      (TyRenameWf-ext hτ) (TyRenameWf-ext hσ)
+      {ρ = ρ∀} {ρ′ = ρ′∀} {γ = γ∀} {γ′ = γ′∀}
+world-embedding-paired-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    emb liftρ liftγ
+    with rel-store-embedding-paired-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      (store-embeddingᴿ emb) liftρ
+       | rel-context-embedding-paired-liftᴿ
+          (context-embeddingᴿ emb) liftγ
+world-embedding-paired-liftᴿ emb liftρ liftγ
+    | ρ′∀ , liftρ′ , embρ∀
+    | γ′∀ , liftγ′ , embγ∀ =
+  ρ′∀ , γ′∀ , liftρ′ , liftγ′ ,
+  reduction-closed-world-embeddingᴿ
+    (RenameLeftInverse-ext (left-inverseᴿ emb))
+    (RenameLeftInverse-ext (right-inverseᴿ emb))
+    (castModeRenamer-ext (left-cast-renamerᴿ emb))
+    (castModeRenamer-ext (right-cast-renamerᴿ emb))
+    embρ∀ embγ∀
+
+
+rel-store-embedding-source-liftᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  ∃[ ρ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    RelStoreEmbeddingⁱ (extᵗ τ) σ ρν ρ′ν
+rel-store-embedding-source-liftᴿ
+    rel-store-embedding-[] lift-left-store-[] =
+  [] , lift-left-store-[] , rel-store-embedding-[]
+rel-store-embedding-source-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-left-store-∷ {p′ = pν} shapeν liftρ)
+    with rel-store-embedding-source-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-source-liftᴿ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-matched
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-left-store-∷
+      {A = A} {B = B} {p′ = pν} shapeν liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-matched (suc α′) (⇑ᵗ A′) β′ B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ ρ′ν ,
+  lift-left-store-∷
+    (trans
+      (⊑-rename-at-shapeᴿ
+        (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν)
+      (trans shapeν (sym shape-emb)))
+    liftρ′ ,
+  rel-store-embedding-matched
+    (cong suc eqα) eqAν eqβ eqB
+    (⊑-rename-at-shapeᴿ
+      (rename-assm²-⇑ᴸᵢ assm)
+      (TyRenameWf-ext hτ) hσ eqAν eqB pν)
+    embν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-embedding-source-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-left-store-left liftρ)
+    with rel-store-embedding-source-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-source-liftᴿ {τ = τ}
+    (rel-store-embedding-left
+      {α′ = α′} {A′ = A′} {hA′ = hA′} eqα eqA emb)
+    (lift-left-store-left {A = A} liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-left (suc α′) (⇑ᵗ A′)
+      (renameᵗ-preserves-WfTy hA′ TyRenameWf-suc) ∷ ρ′ν ,
+  lift-left-store-left liftρ′ ,
+  rel-store-embedding-left (cong suc eqα) eqAν embν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+rel-store-embedding-source-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-left-store-right liftρ)
+    with rel-store-embedding-source-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-source-liftᴿ
+    (rel-store-embedding-right
+      {β′ = β′} {B′ = B′} {hB′ = hB′} eqβ eqB emb)
+    (lift-left-store-right liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-right β′ B′ hB′ ∷ ρ′ν ,
+  lift-left-store-right liftρ′ ,
+  rel-store-embedding-right eqβ eqB embν
+rel-store-embedding-source-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-left-store-link {p′ = pν} shapeν liftρ)
+    with rel-store-embedding-source-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ} emb liftρ
+rel-store-embedding-source-liftᴿ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-store-embedding-link
+      {α′ = α′} {A′ = A′} {β′ = β′} {B′ = B′}
+      {p = p} {p′ = p′}
+      eqα eqA eqβ eqB shape-emb emb)
+    (lift-left-store-link
+      {A = A} {B = B} {p′ = pν} shapeν liftρ)
+    | ρ′ν , liftρ′ , embν =
+  store-link (suc α′) (⇑ᵗ A′) β′ B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ ρ′ν ,
+  lift-left-store-link
+    (trans
+      (⊑-rename-at-shapeᴿ
+        (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν)
+      (trans shapeν (sym shape-emb)))
+    liftρ′ ,
+  rel-store-embedding-link
+    (cong suc eqα) eqAν eqβ eqB
+    (⊑-rename-at-shapeᴿ
+      (rename-assm²-⇑ᴸᵢ assm)
+      (TyRenameWf-ext hτ) hσ eqAν eqB pν)
+    embν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+
+rel-context-embedding-source-liftᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ γ′ν ]
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    RelCtxRenameⁱ
+      (extᵗ τ) σ (rename-assm²-⇑ᴸᵢ assm)
+      (TyRenameWf-ext hτ) hσ γν γ′ν
+rel-context-embedding-source-liftᴿ
+    rel-ctx-rename-[] lift-left-ctx-[] =
+  [] , lift-left-ctx-[] , rel-ctx-rename-[]
+rel-context-embedding-source-liftᴿ
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′} {p = p}
+      eqA eqB renameγ)
+    (lift-left-ctx-∷ {p′ = pν} shapeν liftγ)
+    with rel-context-embedding-source-liftᴿ renameγ liftγ
+rel-context-embedding-source-liftᴿ
+    {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+    (rel-ctx-rename-∷ {A′ = A′} {B′ = B′} {p = p}
+      eqA eqB renameγ)
+    (lift-left-ctx-∷
+      {A = A} {B = B} {p′ = pν} shapeν liftγ)
+    | γ′ν , liftγ′ , renameγν =
+  ctx-imp (⇑ᵗ A′) B′
+      (⊑-rename-at²ᵢ (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν) ∷ γ′ν ,
+  lift-left-ctx-∷
+    (trans
+      (⊑-rename-at-shapeᴿ
+        (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ eqAν eqB pν)
+      (trans shapeν
+        (sym (⊑-rename-at-shapeᴿ
+          assm hτ hσ eqA eqB p))))
+    liftγ′ ,
+  rel-ctx-rename-∷ eqAν eqB renameγν
+  where
+  eqAν : ⇑ᵗ A′ ≡ renameᵗ (extᵗ τ) (⇑ᵗ A)
+  eqAν =
+    trans (cong ⇑ᵗ eqA) (sym (renameᵗ-ext-suc-comm τ A))
+
+
+world-embedding-source-liftᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {ρν : StoreImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ}
+    {γν : CtxImp ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+      (suc Δᴸ) Δᴿ} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρν →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γν →
+  ∃[ ρ′ν ] ∃[ γ′ν ]
+    LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) ρ′ ρ′ν ×
+    LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Ψ) γ′ γ′ν ×
+    ReductionClosedWorldEmbeddingᴿ
+      (extᵗ τ) σ (extᵗ ψ) φ
+      (rename-assm²-⇑ᴸᵢ assm) (TyRenameWf-ext hτ) hσ
+      {ρ = ρν} {ρ′ = ρ′ν} {γ = γν} {γ′ = γ′ν}
+world-embedding-source-liftᴿ
+    {assm = assm} {hτ = hτ} {hσ = hσ}
+    emb liftρ liftγ
+    with rel-store-embedding-source-liftᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      (store-embeddingᴿ emb) liftρ
+       | rel-context-embedding-source-liftᴿ
+          (context-embeddingᴿ emb) liftγ
+world-embedding-source-liftᴿ emb liftρ liftγ
+    | ρ′ν , liftρ′ , embρν
+    | γ′ν , liftγ′ , embγν =
+  ρ′ν , γ′ν , liftρ′ , liftγ′ ,
+  reduction-closed-world-embeddingᴿ
+    (RenameLeftInverse-ext (left-inverseᴿ emb))
+    (right-inverseᴿ emb)
+    (castModeRenamer-ext (left-cast-renamerᴿ emb))
+    (right-cast-renamerᴿ emb)
+    embρν embγν
+
+
+rel-store-embedding-prefix-invᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  RelStoreEmbeddingⁱ τ σ ρ⁺ ρ′⁺ →
+  ∃[ ρ₀′ ]
+    RelStoreEmbeddingⁱ τ σ ρ₀ ρ₀′ ×
+    StoreImpPrefixᴿ ρ₀′ ρ′⁺
+rel-store-embedding-prefix-invᴿ prefix-reflᴿ emb =
+  _ , emb , prefix-reflᴿ
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-matched
+      eqα eqA eqβ eqB shape-eq emb)
+    with rel-store-embedding-prefix-invᴿ prefix emb
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-matched
+      eqα eqA eqβ eqB shape-eq emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ᴿ prefix′
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-left eqα eqA emb)
+    with rel-store-embedding-prefix-invᴿ prefix emb
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-left eqα eqA emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ᴿ prefix′
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-right eqβ eqB emb)
+    with rel-store-embedding-prefix-invᴿ prefix emb
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-right eqβ eqB emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ᴿ prefix′
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-link
+      eqα eqA eqβ eqB shape-eq emb)
+    with rel-store-embedding-prefix-invᴿ prefix emb
+rel-store-embedding-prefix-invᴿ (prefix-∷ᴿ prefix)
+    (rel-store-embedding-link
+      eqα eqA eqβ eqB shape-eq emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ᴿ prefix′
+
+
+paired-lift-creation-worlds-differᴿ :
+  ∀ Φ →
+  ∀ᵢᶜ (⇑ᴿᵢ Φ) ≡ ⇑ᴿᵢ (∀ᵢᶜ Φ) →
+  ⊥
+paired-lift-creation-worlds-differᴿ Φ ()

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedWorldRenameExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedWorldRenameExperiment.agda
@@ -1,0 +1,1413 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedWorldRenameExperiment
+  where
+
+-- File Charter:
+--   * Proves that the independent reduction-closed ordinary and quotient
+--     imprecision relations are preserved by structural world embeddings.
+--   * Requires no-runtime-bullet endpoints only where typing transport needs
+--     it, and eliminates the runtime-bullet application constructors.
+--   * Composes an embedding around the single exact target-instantiation
+--     residual instead of adding a transport constructor to the relation.
+--   * Depends on the smaller relation and QTI-free store, context, coercion,
+--     and index infrastructure; it imports no live term-imprecision relation.
+--   * Contains no postulate, hole, catch-all clause, or permissive option.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Bool using (true)
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (zero; suc)
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using
+  (cong; subst; sym; trans)
+
+open import CastImprecisionShape using
+  (narrowing; widening; _⊢ᶜ_⦂_)
+open import Coercions using
+  ( Coercion
+  ; Mode
+  ; ModeEnv
+  ; id-only
+  ; id-onlyᵈ
+  ; mode≤
+  ; renameᶜ
+  ; seal-or-id
+  ; tag-or-id
+  )
+open import Conversion using
+  ( ConcealConversion
+  ; RevealConversion
+  ; rename-conceal-conversion
+  ; rename-reveal-conversion
+  )
+open import ConversionIndexCompatibility using
+  (_[_↦_]ᴸ_; _[_↦_]ᴿ_; _[_↦_⊑⟨_⟩_↤_]ᴾ_)
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Imprecision using
+  (_ˣ⊑★; _ˣ⊑ˣ_; ⇑ᴸᵢ; ⇑ᵢ)
+open import ImprecisionComposition using
+  (⌊_⌋; _；_≋_; _；⌊_⌋≋ᵖ_；_)
+open import ImprecisionWf using
+  ( ImpAssm
+  ; ImpCtx
+  ; NonVar
+  ; _∣_⊢_⊑_⊣_
+  ; _↦_
+  ; ∀ⁱ_
+  ; ν
+  )
+open import NarrowWiden using
+  ( narrow-renameᵗ
+  ; widen-renameᵗ
+  ; _∣_∣_⊢_∶_⊒_
+  ; _∣_∣_⊢_∶_⊑_
+  )
+open import NuTermImprecision using
+  ( CtxImp
+  ; LiftCtxⁱ
+  ; LiftLeftCtxⁱ
+  ; LiftLeftStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; StoreCorresponds
+  ; ctx-imp
+  ; lift-ctx-[]
+  ; lift-ctx-∷
+  ; lift-left-ctx-[]
+  ; lift-left-ctx-∷
+  ; leftCtxⁱ
+  ; leftStoreⁱ
+  ; rightCtxⁱ
+  ; rightStoreⁱ
+  )
+open import NuTerms using
+  ( No•
+  ; Term
+  ; Value
+  ; blame
+  ; no•-$
+  ; no•-·
+  ; no•-Λ
+  ; no•-ν
+  ; no•-⊕
+  ; no•-⟨⟩
+  ; no•-ƛ
+  ; no•-`
+  ; no•-blame
+  ; renameᵗᵐ
+  )
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  ( Renameᵗ
+  ; Ty
+  ; TyCtx
+  ; WfTy
+  ; extᵗ
+  ; occurs
+  ; renameStoreᵗ
+  ; renameᵗ
+  ; ⇑ᵗ
+  ; ⟰ᵗ
+  )
+open import proof.Core.Permutation.ForallPermutationProperties using
+  (⊑ᵖ-rename²ᵢ)
+open import
+  proof.Core.Properties.ConversionIndexCompatibilityProperties
+  using
+  ( replace-left-rename²ᵢ
+  ; replace-left-target-shape
+  ; replace-left-transport-endpoints
+  ; replace-paired-evidence-shape
+  ; replace-paired-rename²ᵢ
+  ; replace-paired-target-shape
+  ; replace-paired-transport-endpoints
+  ; replace-right-rename²ᵢ
+  ; shape-transport-imprecision-endpoints
+  ; transport-imprecision-endpoints
+  )
+open import
+  proof.Core.Properties.NuCastImprecisionShapeProperties
+  using
+  ( cast-shape-rename
+  ; imprecision-composition-shape-transport
+  ; shape-lift∀ᵢ
+  ; shape-rename
+  ; shape-source-liftνᵢ
+  )
+open import
+  proof.Core.Properties.NuImprecisionQuotientBoundaryProperties
+  using (quotient-boundary-square-rename²)
+open import proof.Core.Properties.NuTermProperties using
+  ( modeRename-left-inverse
+  ; renameStoreᵗ-ext-suc-cons-comm
+  ; renameᵗᵐ-id
+  ; renameᵗᵐ-preserves-No•
+  ; renameᵗᵐ-preserves-Value
+  )
+open import proof.Core.Properties.CoercionProperties using
+  (ModeRename; modeRename-id-only)
+open import proof.Core.Properties.TypePreservation using
+  ( CastModeRenamer
+  ; castModeRenamer-seal★
+  ; castModeRenamer-suc
+  )
+open import proof.Core.Properties.TypeProperties using
+  ( RenameLeftInverse
+  ; RenameLeftInverse-ext
+  ; RenameLeftInverse-suc
+  ; TyRenameWf
+  ; TyRenameWf-ext
+  ; TyRenameWf-suc
+  ; occurs-zero-rename-ext
+  ; renameᵗ-ext-suc-comm
+  ; renameᵗ-ground
+  ; renameᵗ-id
+  ; renameᵗ-preserves-WfTy
+  ; predᵗ
+  )
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  ( ∀ᵢᶜ
+  ; rename-assm²-source-νᵢ
+  ; rename-assm²-∀ᵢ
+  ; rename-assm²-⇑ᴸᵢ
+  ; rename-assm²-⇑ᵢ
+  ; rename-assm²ᵢ
+  ; ⊑-lift∀ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-renameᵗ²ᵢ
+  ; ⊑-source-liftνᵢ
+  )
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDef
+  using
+  (AssumptionMembershipUnique; PrecisionIndexUnique)
+open import
+  proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessLemma
+  using (assumption-membership-unique→precision-index-unique)
+open import
+  proof.Quotient.NuImprecisionReductionClosedCompatibilityRenameExperiment
+  using
+  ( reduction-closed-paired-compatible-rename²ᵢ
+  ; reduction-closed-quotient-compatible-rename²ᵢ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+open import
+  proof.Quotient.NuImprecisionReductionClosedWorldEmbeddingExperiment
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using (embed-creationᴱ)
+open import
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  using
+  ( embedded-creation-source-typingᴱ
+  ; embedded-creation-target-typingᴱ
+  )
+open import
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
+  using (SpineCastMode; gradual↓; id-only↓)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelCtxRenameDef
+  using
+  (RelCtxRenameⁱ; rel-ctx-rename-[]; rel-ctx-rename-∷)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingProof
+  using (rel-store-embedding-correspondenceⁱ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra
+  using
+  (lift-left-store-embeddingⁱ; lift-store-embeddingⁱ)
+
+
+embedded-modeᴿ : Renameᵗ → ModeEnv → ModeEnv
+embedded-modeᴿ ψ μ X = μ (ψ X)
+
+
+rel-ctx-rename-lookupᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {x A B p} →
+  RelCtxRenameⁱ τ σ assm hτ hσ γ γ′ →
+  γ Types.∋ x ⦂ ctx-imp A B p →
+  ∃[ A′ ] ∃[ B′ ] ∃[ eqA ] ∃[ eqB ]
+    γ′ Types.∋ x ⦂ ctx-imp A′ B′
+      (⊑-rename-at²ᵢ assm hτ hσ eqA eqB p)
+rel-ctx-rename-lookupᴿ
+    (rel-ctx-rename-∷ eqA eqB renameγ) Types.Z =
+  _ , _ , eqA , eqB , Types.Z
+rel-ctx-rename-lookupᴿ
+    (rel-ctx-rename-∷ eqA eqB renameγ) (Types.S x∈) =
+  let A′ , B′ , eqA′ , eqB′ , x∈′ =
+        rel-ctx-rename-lookupᴿ renameγ x∈
+  in
+  A′ , B′ , eqA′ , eqB′ , Types.S x∈′
+
+
+left-reveal-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  RevealConversion (embedded-modeᴿ ψ μ) Θᴸ (leftStoreⁱ ρ′)
+    (τ α) (renameᵗ τ X) (renameᶜ τ c)
+    (renameᵗ τ A) (renameᵗ τ B)
+left-reveal-world-renameᴿ
+    {τ = τ} {ψ = ψ} {hτ = hτ} {μ = μ} emb conv =
+  subst (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (left-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (rename-reveal-conversion hτ
+      (modeRename-left-inverse {ρ = τ} {ψ = ψ} {μ = μ}
+        (left-inverseᴿ emb)) conv)
+
+
+right-reveal-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ β X c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  RevealConversion (embedded-modeᴿ φ μ) Θᴿ (rightStoreⁱ ρ′)
+    (σ β) (renameᵗ σ X) (renameᶜ σ c)
+    (renameᵗ σ A) (renameᵗ σ B)
+right-reveal-world-renameᴿ
+    {σ = σ} {φ = φ} {hσ = hσ} {μ = μ} emb conv =
+  subst (λ Σ → RevealConversion _ _ Σ _ _ _ _ _)
+    (sym (right-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (rename-reveal-conversion hσ
+      (modeRename-left-inverse {ρ = σ} {ψ = φ} {μ = μ}
+        (right-inverseᴿ emb)) conv)
+
+
+left-conceal-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ α X c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c A B →
+  ConcealConversion (embedded-modeᴿ ψ μ) Θᴸ (leftStoreⁱ ρ′)
+    (τ α) (renameᵗ τ X) (renameᶜ τ c)
+    (renameᵗ τ A) (renameᵗ τ B)
+left-conceal-world-renameᴿ
+    {τ = τ} {ψ = ψ} {hτ = hτ} {μ = μ} emb conv =
+  subst (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (left-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (rename-conceal-conversion hτ
+      (modeRename-left-inverse {ρ = τ} {ψ = ψ} {μ = μ}
+        (left-inverseᴿ emb)) conv)
+
+
+right-conceal-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ β X c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ConcealConversion μ Δᴿ (rightStoreⁱ ρ) β X c A B →
+  ConcealConversion (embedded-modeᴿ φ μ) Θᴿ (rightStoreⁱ ρ′)
+    (σ β) (renameᵗ σ X) (renameᶜ σ c)
+    (renameᵗ σ A) (renameᵗ σ B)
+right-conceal-world-renameᴿ
+    {σ = σ} {φ = φ} {hσ = hσ} {μ = μ} emb conv =
+  subst (λ Σ → ConcealConversion _ _ Σ _ _ _ _ _)
+    (sym (right-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (rename-conceal-conversion hσ
+      (modeRename-left-inverse {ρ = σ} {ψ = φ} {μ = μ}
+        (right-inverseᴿ emb)) conv)
+
+
+left-reveal-ν-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ A B C s} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ (suc Δᴸ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (leftStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion (embedded-modeᴿ (extᵗ ψ) μ) (suc Θᴸ)
+    ((zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+    (renameᵗ (extᵗ τ) C) (⇑ᵗ (renameᵗ τ B))
+left-reveal-ν-world-renameᴿ
+    {Θᴸ = Θᴸ} {τ = τ} {ψ = ψ} {hτ = hτ}
+    {ρ = ρ} {ρ′ = ρ′} {μ = μ}
+    {A = A} {B = B} {C = C} {s = s} emb conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Θᴸ) target-store
+      zero (⇑ᵗ (renameᵗ τ A)) (renameᶜ (extᵗ τ) s)
+      (renameᵗ (extᵗ τ) C) D)
+    (renameᵗ-ext-suc-comm τ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Θᴸ) target-store
+        zero X (renameᶜ (extᵗ τ) s)
+        (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm τ A)
+      store-normalized)
+  where
+  target-mode = embedded-modeᴿ (extᵗ ψ) μ
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ τ A)) ∷ ⟰ᵗ (leftStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm τ (leftStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ τ A)) ∷_)
+        (cong ⟰ᵗ
+          (sym (left-store-embedding-resultᴿ
+            (store-embeddingᴿ emb)))))
+
+  renamed =
+    rename-reveal-conversion (TyRenameWf-ext hτ)
+      (modeRename-left-inverse
+        {ρ = extᵗ τ} {ψ = extᵗ ψ} {μ = μ}
+        (RenameLeftInverse-ext (left-inverseᴿ emb)))
+      conv
+
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Θᴸ) Σ
+        zero (renameᵗ (extᵗ τ) (⇑ᵗ A))
+        (renameᶜ (extᵗ τ) s) (renameᵗ (extᵗ τ) C)
+        (renameᵗ (extᵗ τ) (⇑ᵗ B)))
+      store-eq renamed
+
+
+right-reveal-ν-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ A B C s} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  RevealConversion μ (suc Δᴿ)
+    ((zero , ⇑ᵗ A) ∷ ⟰ᵗ (rightStoreⁱ ρ))
+    zero (⇑ᵗ A) s C (⇑ᵗ B) →
+  RevealConversion (embedded-modeᴿ (extᵗ φ) μ) (suc Θᴿ)
+    ((zero , ⇑ᵗ (renameᵗ σ A)) ∷ ⟰ᵗ (rightStoreⁱ ρ′))
+    zero (⇑ᵗ (renameᵗ σ A)) (renameᶜ (extᵗ σ) s)
+    (renameᵗ (extᵗ σ) C) (⇑ᵗ (renameᵗ σ B))
+right-reveal-ν-world-renameᴿ
+    {Θᴿ = Θᴿ} {σ = σ} {φ = φ} {hσ = hσ}
+    {ρ = ρ} {ρ′ = ρ′} {μ = μ}
+    {A = A} {B = B} {C = C} {s = s} emb conv =
+  subst
+    (λ D → RevealConversion target-mode (suc Θᴿ) target-store
+      zero (⇑ᵗ (renameᵗ σ A)) (renameᶜ (extᵗ σ) s)
+      (renameᵗ (extᵗ σ) C) D)
+    (renameᵗ-ext-suc-comm σ B)
+    (subst
+      (λ X → RevealConversion target-mode (suc Θᴿ) target-store
+        zero X (renameᶜ (extᵗ σ) s)
+        (renameᵗ (extᵗ σ) C)
+        (renameᵗ (extᵗ σ) (⇑ᵗ B)))
+      (renameᵗ-ext-suc-comm σ A)
+      store-normalized)
+  where
+  target-mode = embedded-modeᴿ (extᵗ φ) μ
+  target-store =
+    (zero , ⇑ᵗ (renameᵗ σ A)) ∷ ⟰ᵗ (rightStoreⁱ ρ′)
+
+  store-eq =
+    trans
+      (renameStoreᵗ-ext-suc-cons-comm σ (rightStoreⁱ ρ) A)
+      (cong ((zero , ⇑ᵗ (renameᵗ σ A)) ∷_)
+        (cong ⟰ᵗ
+          (sym (right-store-embedding-resultᴿ
+            (store-embeddingᴿ emb)))))
+
+  renamed =
+    rename-reveal-conversion (TyRenameWf-ext hσ)
+      (modeRename-left-inverse
+        {ρ = extᵗ σ} {ψ = extᵗ φ} {μ = μ}
+        (RenameLeftInverse-ext (right-inverseᴿ emb)))
+      conv
+
+  store-normalized =
+    subst
+      (λ Σ → RevealConversion target-mode (suc Θᴿ) Σ
+        zero (renameᵗ (extᵗ σ) (⇑ᵗ A))
+        (renameᶜ (extᵗ σ) s) (renameᵗ (extᵗ σ) C)
+        (renameᵗ (extᵗ σ) (⇑ᵗ B)))
+      store-eq renamed
+
+
+left-seal-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (leftStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ (left-cast-renamerᴿ emb) mode)
+    (leftStoreⁱ ρ′)
+left-seal-world-renameᴿ emb mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (left-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (castModeRenamer-seal★
+      (left-cast-renamerᴿ emb) mode seal★)
+
+
+right-seal-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  (mode : CastMode μ) →
+  SealModeStore★ μ (rightStoreⁱ ρ) →
+  SealModeStore★
+    (CastModeRenamer.targetᵈ (right-cast-renamerᴿ emb) mode)
+    (rightStoreⁱ ρ′)
+right-seal-world-renameᴿ emb mode seal★ =
+  subst (SealModeStore★ _)
+    (sym (right-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (castModeRenamer-seal★
+      (right-cast-renamerᴿ emb) mode seal★)
+
+
+left-narrow-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ μ′ c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename τ μ μ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  μ′ ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B
+left-narrow-world-renameᴿ
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb mode c⊒ =
+  subst
+    (λ Σ → _ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊒ renameᵗ τ B)
+    (sym (left-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (narrow-renameᵗ hτ mode c⊒)
+
+
+right-narrow-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ μ′ c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename σ μ μ′ →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊒ B →
+  μ′ ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊒ renameᵗ σ B
+right-narrow-world-renameᴿ
+    {Θᴿ = Θᴿ} {σ = σ} {hσ = hσ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb mode c⊒ =
+  subst
+    (λ Σ → _ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊒ renameᵗ σ B)
+    (sym (right-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (narrow-renameᵗ hσ mode c⊒)
+
+
+left-widen-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ μ′ c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename τ μ μ′ →
+  μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  μ′ ∣ Θᴸ ∣ leftStoreⁱ ρ′
+    ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B
+left-widen-world-renameᴿ
+    {Θᴸ = Θᴸ} {τ = τ} {hτ = hτ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb mode c⊑ =
+  subst
+    (λ Σ → _ ∣ Θᴸ ∣ Σ
+      ⊢ renameᶜ τ c ∶ renameᵗ τ A ⊑ renameᵗ τ B)
+    (sym (left-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (widen-renameᵗ hτ mode c⊑)
+
+
+right-widen-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ μ′ c A B} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  ModeRename σ μ μ′ →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c ∶ A ⊑ B →
+  μ′ ∣ Θᴿ ∣ rightStoreⁱ ρ′
+    ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊑ renameᵗ σ B
+right-widen-world-renameᴿ
+    {Θᴿ = Θᴿ} {σ = σ} {hσ = hσ}
+    {ρ′ = ρ′} {c = c} {A = A} {B = B} emb mode c⊑ =
+  subst
+    (λ Σ → _ ∣ Θᴿ ∣ Σ
+      ⊢ renameᶜ σ c ∶ renameᵗ σ A ⊑ renameᵗ σ B)
+    (sym (right-store-embedding-resultᴿ (store-embeddingᴿ emb)))
+    (widen-renameᵗ hσ mode c⊑)
+
+
+spine-mode-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  SpineCastMode (leftStoreⁱ ρ) μ →
+  ∃[ μ′ ]
+    (ModeRename τ μ μ′ × SpineCastMode (leftStoreⁱ ρ′) μ′)
+spine-mode-world-renameᴿ {τ = τ} emb id-only↓ =
+  id-onlyᵈ , modeRename-id-only τ , id-only↓
+spine-mode-world-renameᴿ emb (gradual↓ mode seal★) =
+  CastModeRenamer.targetᵈ (left-cast-renamerᴿ emb) mode ,
+  CastModeRenamer.target-rename (left-cast-renamerᴿ emb) mode ,
+  gradual↓
+    (CastModeRenamer.target-mode (left-cast-renamerᴿ emb) mode)
+    (left-seal-world-renameᴿ emb mode seal★)
+
+
+spine-mode-target-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {μ} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  SpineCastMode (rightStoreⁱ ρ) μ →
+  ∃[ μ′ ]
+    (ModeRename σ μ μ′ × SpineCastMode (rightStoreⁱ ρ′) μ′)
+spine-mode-target-world-renameᴿ {σ = σ} emb id-only↓ =
+  id-onlyᵈ , modeRename-id-only σ , id-only↓
+spine-mode-target-world-renameᴿ emb (gradual↓ mode seal★) =
+  CastModeRenamer.targetᵈ (right-cast-renamerᴿ emb) mode ,
+  CastModeRenamer.target-rename (right-cast-renamerᴿ emb) mode ,
+  gradual↓
+    (CastModeRenamer.target-mode (right-cast-renamerᴿ emb) mode)
+    (right-seal-world-renameᴿ emb mode seal★)
+
+
+quotient-widening-pair-world-renameᴿ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+    {assm : ∀ {a : ImpAssm} →
+      a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+    {hτ : TyRenameWf Δᴸ Θᴸ τ}
+    {hσ : TyRenameWf Δᴿ Θᴿ σ}
+    {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+    {u u′ D D′ A A′} →
+  (emb : ReductionClosedWorldEmbeddingᴿ
+    τ σ ψ φ assm hτ hσ
+    {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+  QuotientWideningPairᴿ Δᴸ Δᴿ ρ u u′ D D′ A A′ →
+  QuotientWideningPairᴿ Θᴸ Θᴿ ρ′
+    (renameᶜ τ u) (renameᶜ σ u′)
+    (renameᵗ τ D) (renameᵗ σ D′)
+    (renameᵗ τ A) (renameᵗ σ A′)
+quotient-widening-pair-world-renameᴿ
+    {τ = τ} {σ = σ} emb
+    (quotient-id-wideningᴿ u⊑ u′⊑) =
+  quotient-id-wideningᴿ
+    (left-widen-world-renameᴿ emb (modeRename-id-only τ) u⊑)
+    (right-widen-world-renameᴿ emb (modeRename-id-only σ) u′⊑)
+quotient-widening-pair-world-renameᴿ emb
+    (quotient-cast-wideningᴿ
+      mode seal★ u⊑ mode′ seal★′ u′⊑) =
+  quotient-cast-wideningᴿ
+    (CastModeRenamer.target-mode (left-cast-renamerᴿ emb) mode)
+    (left-seal-world-renameᴿ emb mode seal★)
+    (left-widen-world-renameᴿ emb
+      (CastModeRenamer.target-rename
+        (left-cast-renamerᴿ emb) mode) u⊑)
+    (CastModeRenamer.target-mode (right-cast-renamerᴿ emb) mode′)
+    (right-seal-world-renameᴿ emb mode′ seal★′)
+    (right-widen-world-renameᴿ emb
+      (CastModeRenamer.target-rename
+        (right-cast-renamerᴿ emb) mode′) u′⊑)
+
+
+mode≤-reflᴿ : ∀ m → mode≤ m m ≡ true
+mode≤-reflᴿ id-only = refl
+mode≤-reflᴿ tag-or-id = refl
+mode≤-reflᴿ seal-or-id = refl
+
+
+castModeRenamer-idᴿ : CastModeRenamer (λ X → X)
+castModeRenamer-idᴿ =
+  record
+    { targetᵈ = λ {μ} mode → μ
+    ; target-mode = λ mode → mode
+    ; target-rename = λ {μ} mode X → mode≤-reflᴿ (μ X)
+    ; target-seal-source = λ mode α ok → α , ok , refl
+    }
+
+
+paired-context-lift-world-renameᴿ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γ↑ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)} →
+  PrecisionIndexUnique (∀ᵢᶜ Φ) →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ↑ →
+  RelCtxRenameⁱ suc suc rename-assm²-∀ᵢ
+    TyRenameWf-suc TyRenameWf-suc γ γ↑
+paired-context-lift-world-renameᴿ unique lift-ctx-[] =
+  rel-ctx-rename-[]
+paired-context-lift-world-renameᴿ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    unique
+    (lift-ctx-∷ {γ = γ} {γ′ = γ↑}
+      {A = A} {B = B} {p = p} {p′ = p↑}
+      shape-eq liftγ) =
+  subst
+    (λ q →
+      RelCtxRenameⁱ suc suc rename-assm²-∀ᵢ
+        TyRenameWf-suc TyRenameWf-suc
+        (ctx-imp A B p ∷ γ)
+        (ctx-imp (⇑ᵗ A) (⇑ᵗ B) q ∷ γ↑))
+    (unique renamed-p p↑)
+    (rel-ctx-rename-∷ refl refl
+      (paired-context-lift-world-renameᴿ unique liftγ))
+  where
+  renamed-p =
+    ⊑-rename-at²ᵢ
+      rename-assm²-∀ᵢ TyRenameWf-suc TyRenameWf-suc
+      refl refl p
+
+
+source-context-lift-world-renameᴿ :
+  ∀ {Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γ↑ : CtxImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ} →
+  PrecisionIndexUnique ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ↑ →
+  RelCtxRenameⁱ suc (λ X → X) rename-assm²-source-νᵢ
+    TyRenameWf-suc (λ X< → X<) γ γ↑
+source-context-lift-world-renameᴿ unique lift-left-ctx-[] =
+  rel-ctx-rename-[]
+source-context-lift-world-renameᴿ
+    {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    unique
+    (lift-left-ctx-∷ {γ = γ} {γ′ = γ↑}
+      {A = A} {B = B} {p = p} {p′ = p↑}
+      shape-eq liftγ) =
+  subst
+    (λ q →
+      RelCtxRenameⁱ suc (λ X → X) rename-assm²-source-νᵢ
+        TyRenameWf-suc (λ X< → X<)
+        (ctx-imp A B p ∷ γ)
+        (ctx-imp (⇑ᵗ A) B q ∷ γ↑))
+    (unique renamed-p p↑)
+    (rel-ctx-rename-∷ refl (sym (renameᵗ-id B))
+      (source-context-lift-world-renameᴿ unique liftγ))
+  where
+  renamed-p =
+    ⊑-rename-at²ᵢ
+      rename-assm²-source-νᵢ
+      TyRenameWf-suc (λ X< → X<)
+      refl (sym (renameᵗ-id B)) p
+
+
+mutual
+  smaller-world-embed-no•ᴿ :
+    ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+      {assm : ∀ {a : ImpAssm} →
+        a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+      {hτ : TyRenameWf Δᴸ Θᴸ τ}
+      {hσ : TyRenameWf Δᴿ Θᴿ σ}
+      {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+      {M M′ : Term} {A B : Ty}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    (emb : ReductionClosedWorldEmbeddingᴿ
+      τ σ ψ φ assm hτ hσ
+      {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+    No• M →
+    No• M′ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴿ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+      ⦂ renameᵗ τ A ⊑ renameᵗ σ B
+      ∶ ⊑-renameᵗ²ᵢ assm hτ hσ p
+
+  smaller-quotient-world-embed-no•ᴿ :
+    ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ ψ φ}
+      {assm : ∀ {a : ImpAssm} →
+        a ∈ Φ → rename-assm²ᵢ τ σ a ∈ Ψ}
+      {hτ : TyRenameWf Δᴸ Θᴸ τ}
+      {hσ : TyRenameWf Δᴿ Θᴿ σ}
+      {ρ : StoreImp Φ Δᴸ Δᴿ} {ρ′ : StoreImp Ψ Θᴸ Θᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ} {γ′ : CtxImp Ψ Θᴸ Θᴿ}
+      {M M′ : Term} {D D′ : Ty}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    (emb : ReductionClosedWorldEmbeddingᴿ
+      τ σ ψ φ assm hτ hσ
+      {ρ = ρ} {ρ′ = ρ′} {γ = γ} {γ′ = γ′}) →
+    No• M →
+    No• M′ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Ψ ∣ Θᴸ ∣ Θᴿ ∣ ρ′ ∣ γ′
+      ⊢ᴿᵖ renameᵗᵐ τ M ⊑ renameᵗᵐ σ M′
+      ⦂ renameᵗ τ D ⊑ᵖ renameᵗ σ D′
+      ∶ ⊑ᵖ-rename²ᵢ assm hτ hσ q
+
+  smaller-world-embed-no•ᴿ emb no•-blame noM′
+      (blame⊑ᴿ M′⊢) =
+    blame⊑ᴿ (world-embedding-target-typingᴿ emb noM′ M′⊢)
+  smaller-world-embed-no•ᴿ emb no•-` no•-`
+      (x⊑xᴿ x∈)
+      with rel-ctx-rename-lookupᴿ
+        (context-embeddingᴿ emb) x∈
+  smaller-world-embed-no•ᴿ emb no•-` no•-`
+      (x⊑xᴿ x∈)
+      | A′ , B′ , refl , refl , x∈′ =
+    x⊑xᴿ x∈′
+  smaller-world-embed-no•ᴿ
+      {hτ = hτ} {hσ = hσ}
+      emb (no•-ƛ noN) (no•-ƛ noN′)
+      (ƛ⊑ƛᴿ hA hA′ N⊑N′) =
+    ƛ⊑ƛᴿ
+      (renameᵗ-preserves-WfTy hA hτ)
+      (renameᵗ-preserves-WfTy hA′ hσ)
+      (smaller-world-embed-no•ᴿ
+        (world-embedding-context-∷ᴿ emb)
+        noN noN′ N⊑N′)
+  smaller-world-embed-no•ᴿ
+      emb (no•-· noL noM) (no•-· noL′ noM′)
+      (L⊑L′ ·ᴿ M⊑M′) =
+    smaller-world-embed-no•ᴿ emb noL noL′ L⊑L′ ·ᴿ
+    smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ}
+      emb (no•-Λ noV) (no•-Λ noV′)
+      (Λ⊑Λᴿ liftρ liftγ vV vV′ V⊑V′)
+      with world-embedding-paired-liftᴿ emb liftρ liftγ
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ}
+      emb (no•-Λ noV) (no•-Λ noV′)
+      (Λ⊑Λᴿ liftρ liftγ vV vV′ V⊑V′)
+      | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb =
+    Λ⊑Λᴿ liftρ′ liftγ′
+      (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
+      (renameᵗᵐ-preserves-Value (extᵗ σ) vV′)
+      (smaller-world-embed-no•ᴿ body-emb noV noV′ V⊑V′)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {A = Types.`∀ A}
+      emb (no•-Λ noV) noN′
+      (Λ⊑ᴿ {{safe}} occ liftρ liftγ vV V⊑N′)
+      with world-embedding-source-liftᴿ emb liftρ liftγ
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {A = Types.`∀ A}
+      emb (no•-Λ noV) noN′
+      (Λ⊑ᴿ {{safe}} occ liftρ liftγ vV V⊑N′)
+      | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb =
+    Λ⊑ᴿ
+      {{ImprecisionWf.renameNonVar (extᵗ τ) safe}}
+      (trans (occurs-zero-rename-ext τ A) occ)
+      liftρ′ liftγ′
+      (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
+      (smaller-world-embed-no•ᴿ body-emb noV noN′ V⊑N′)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
+      emb noM noM′
+      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢)
+      with rel-store-embedding-prefix-invᴿ
+        prefix (store-embeddingᴿ emb)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
+      emb noM noM′
+      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢)
+      | ρ₀′ , store-emb₀ , prefix′ =
+    allocation-prefixᴿ prefix′
+      (smaller-world-embed-no•ᴿ
+        (reduction-closed-world-embeddingᴿ
+          {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
+          (left-inverseᴿ emb) (right-inverseᴿ emb)
+          (left-cast-renamerᴿ emb) (right-cast-renamerᴿ emb)
+          store-emb₀ (context-embeddingᴿ emb))
+        noM noM′ M⊑M′)
+      (world-embedding-source-typingᴿ emb noM M⊢)
+      (world-embedding-target-typingᴿ emb noM′ M′⊢)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-ν noN) (no•-ν noN′)
+      (ν⊑νᴿ {A = A} {A′ = A′}
+        hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′ replace)
+      with world-embedding-paired-liftᴿ emb liftρ liftγ
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-ν noN) (no•-ν noN′)
+      (ν⊑νᴿ {A = A} {A′ = A′}
+        hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′ replace)
+      | ρ′∀ , γ′∀ , liftρ′ , liftγ′ , body-emb =
+    ν⊑νᴿ
+      (renameᵗ-preserves-WfTy hA hτ)
+      (renameᵗ-preserves-WfTy hA′ hσ)
+      (left-reveal-ν-world-renameᴿ emb s↑)
+      (right-reveal-ν-world-renameᴿ emb s′↑)
+      (⊑-renameᵗ²ᵢ assm hτ hσ A⊑A′)
+      shifted-A⊑A′
+      liftρ′ liftγ′
+      (smaller-world-embed-no•ᴿ emb noN noN′ N⊑N′)
+      (replace-paired-target-shape target-shape-eq
+        transported-replace)
+    where
+    renamed-A⇑⊑A′⇑ =
+      ⊑-renameᵗ²ᵢ (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) A⇑⊑A′⇑
+
+    shifted-A⊑A′ =
+      transport-imprecision-endpoints
+        (renameᵗ-ext-suc-comm τ A)
+        (renameᵗ-ext-suc-comm σ A′)
+        renamed-A⇑⊑A′⇑
+
+    renamed-replace =
+      replace-paired-rename²ᵢ
+        {α = zero} {β = zero}
+        (rename-assm²-⇑ᵢ assm)
+        (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) replace
+
+    transported-replace =
+      replace-paired-transport-endpoints
+        refl refl
+        (renameᵗ-ext-suc-comm τ _)
+        (renameᵗ-ext-suc-comm σ _)
+        (renameᵗ-ext-suc-comm τ A)
+        (renameᵗ-ext-suc-comm σ A′)
+        renamed-replace
+
+    target-shape-eq =
+      trans
+        (shape-lift∀ᵢ (⊑-renameᵗ²ᵢ assm hτ hσ _))
+        (trans
+          (shape-rename assm hτ hσ _)
+          (trans
+            (sym (shape-lift∀ᵢ _))
+            (trans
+              (sym
+                (shape-rename
+                  (rename-assm²-⇑ᵢ assm)
+                  (TyRenameWf-ext hτ) (TyRenameWf-ext hσ) _))
+              (sym
+                (shape-transport-imprecision-endpoints
+                  (renameᵗ-ext-suc-comm τ _)
+                  (renameᵗ-ext-suc-comm σ _) _)))))
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-ν noN) noN′
+      (ν⊑ᴿ {A = A} {{safe = safe}}
+        hA h⇑A s↑ liftρ liftγ N⊑N′ replace)
+      with world-embedding-source-liftᴿ emb liftρ liftγ
+  smaller-world-embed-no•ᴿ
+      {Θᴸ = Θᴸ}
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-ν noN) noN′
+      (ν⊑ᴿ {A = A} {{safe = safe}}
+        hA h⇑A s↑ liftρ liftγ N⊑N′ replace)
+      | ρ′ν , γ′ν , liftρ′ , liftγ′ , body-emb =
+    ν⊑ᴿ {{ImprecisionWf.renameNonVar (extᵗ τ) safe}}
+      (renameᵗ-preserves-WfTy hA hτ)
+      h⇑A′
+      (left-reveal-ν-world-renameᴿ emb s↑)
+      liftρ′ liftγ′
+      (smaller-world-embed-no•ᴿ emb noN noN′ N⊑N′)
+      (replace-left-target-shape target-shape-eq
+        transported-replace)
+    where
+    h⇑A′ : WfTy (suc Θᴸ) (⇑ᵗ (renameᵗ τ A))
+    h⇑A′ =
+      subst (WfTy (suc Θᴸ))
+        (renameᵗ-ext-suc-comm τ A)
+        (renameᵗ-preserves-WfTy h⇑A (TyRenameWf-ext hτ))
+
+    renamed-replace =
+      replace-left-rename²ᵢ
+        {α = zero}
+        (rename-assm²-⇑ᴸᵢ assm)
+        (TyRenameWf-ext hτ) hσ replace
+
+    transported-replace =
+      replace-left-transport-endpoints
+        refl refl
+        (renameᵗ-ext-suc-comm τ _)
+        (renameᵗ-ext-suc-comm τ A)
+        renamed-replace
+
+    target-shape-eq =
+      trans
+        (shape-source-liftνᵢ (⊑-renameᵗ²ᵢ assm hτ hσ _))
+        (trans
+          (shape-rename assm hτ hσ _)
+          (trans
+            (sym (shape-source-liftνᵢ _))
+            (trans
+              (sym
+                (shape-rename
+                  (rename-assm²-⇑ᴸᵢ assm)
+                  (TyRenameWf-ext hτ) hσ _))
+              (sym
+                (shape-transport-imprecision-endpoints
+                  (renameᵗ-ext-suc-comm τ _) refl _)))))
+  smaller-world-embed-no•ᴿ emb no•-$ no•-$ κ⊑κᴿ =
+    κ⊑κᴿ
+  smaller-world-embed-no•ᴿ
+      emb (no•-⊕ noL noM) (no•-⊕ noL′ noM′)
+      (L⊑L′ ⊕ᴿ[ op ] M⊑M′) =
+    smaller-world-embed-no•ᴿ emb noL noL′ L⊑L′
+      ⊕ᴿ[ op ]
+    smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ}
+      emb (no•-⟨⟩ noV) noW
+      (gen⊑groundᴿ mode seal★ c⊒ gH vV vW W⊢
+        V⊑Wtag q) =
+    gen⊑groundᴿ
+      (CastModeRenamer.target-mode
+        (left-cast-renamerᴿ emb) mode)
+      (left-seal-world-renameᴿ emb mode seal★)
+      (left-narrow-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (left-cast-renamerᴿ emb) mode) c⊒)
+      (renameᵗ-ground σ gH)
+      (renameᵗᵐ-preserves-Value τ vV)
+      (renameᵗᵐ-preserves-Value σ vW)
+      (world-embedding-target-typingᴿ emb noW W⊢)
+      (smaller-world-embed-no•ᴿ
+        emb noV (no•-⟨⟩ noW) V⊑Wtag)
+      _
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) noM′
+      (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q c-shape comp) =
+    cast⊒⊑ᴿ
+      (CastModeRenamer.target-mode
+        (left-cast-renamerᴿ emb) mode)
+      (left-seal-world-renameᴿ emb mode seal★)
+      (left-narrow-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (left-cast-renamerᴿ emb) mode) c⊒)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _
+      (cast-shape-rename τ c-shape)
+      (imprecision-composition-shape-transport
+        refl (shape-rename assm hτ hσ _)
+        (shape-rename assm hτ hσ _) comp)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) noM′
+      (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q c-shape comp) =
+    cast⊑⊑ᴿ
+      (CastModeRenamer.target-mode
+        (left-cast-renamerᴿ emb) mode)
+      (left-seal-world-renameᴿ emb mode seal★)
+      (left-widen-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (left-cast-renamerᴿ emb) mode) c⊑)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _
+      (cast-shape-rename τ c-shape)
+      (imprecision-composition-shape-transport
+        refl (shape-rename assm hτ hσ _)
+        (shape-rename assm hτ hσ _) comp)
+  smaller-world-embed-no•ᴿ
+      {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb noM (no•-⟨⟩ noM′)
+      (⊑cast⊒ᴿ mode seal★ c⊒ M⊑M′ q c-shape comp) =
+    ⊑cast⊒ᴿ
+      (CastModeRenamer.target-mode
+        (right-cast-renamerᴿ emb) mode)
+      (right-seal-world-renameᴿ emb mode seal★)
+      (right-narrow-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (right-cast-renamerᴿ emb) mode) c⊒)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _
+      (cast-shape-rename σ c-shape)
+      (imprecision-composition-shape-transport
+        (shape-rename assm hτ hσ _) refl
+        (shape-rename assm hτ hσ _) comp)
+  smaller-world-embed-no•ᴿ
+      {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb noM (no•-⟨⟩ noM′)
+      (⊑cast⊑ᴿ mode seal★ c⊑ M⊑M′ q c-shape comp) =
+    ⊑cast⊑ᴿ
+      (CastModeRenamer.target-mode
+        (right-cast-renamerᴿ emb) mode)
+      (right-seal-world-renameᴿ emb mode seal★)
+      (right-widen-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (right-cast-renamerᴿ emb) mode) c⊑)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _
+      (cast-shape-rename σ c-shape)
+      (imprecision-composition-shape-transport
+        (shape-rename assm hτ hσ _) refl
+        (shape-rename assm hτ hσ _) comp)
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) noM′
+      (conv↑⊑ᴿ conv M⊑M′ q replace) =
+    conv↑⊑ᴿ
+      (left-reveal-world-renameᴿ emb conv)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _ (replace-left-rename²ᵢ assm hτ hσ replace)
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) noM′
+      (conv↓⊑ᴿ conv M⊑M′ q replace) =
+    conv↓⊑ᴿ
+      (left-conceal-world-renameᴿ emb conv)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _ (replace-left-rename²ᵢ assm hτ hσ replace)
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb noM (no•-⟨⟩ noM′)
+      (⊑conv↑ᴿ conv M⊑M′ q replace) =
+    ⊑conv↑ᴿ
+      (right-reveal-world-renameᴿ emb conv)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _ (replace-right-rename²ᵢ assm hτ hσ replace)
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb noM (no•-⟨⟩ noM′)
+      (⊑conv↓ᴿ conv M⊑M′ q replace) =
+    ⊑conv↓ᴿ
+      (right-conceal-world-renameᴿ emb conv)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      _ (replace-right-rename²ᵢ assm hτ hσ replace)
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-revealᴿ {pX = pX}
+        corr conv conv′ replace M⊑M′)
+      with rel-store-embedding-correspondenceⁱ
+        (store-embeddingᴿ emb) corr
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-revealᴿ {pX = pX}
+        corr conv conv′ replace M⊑M′)
+      | α′ , X , β′ , X′ , p′ ,
+        refl , refl , refl , refl , shape-eq , corr′ =
+    paired-revealᴿ corr′
+      (left-reveal-world-renameᴿ emb conv)
+      (right-reveal-world-renameᴿ emb conv′)
+      (replace-paired-evidence-shape
+        (trans shape-eq (sym (shape-rename assm hτ hσ pX)))
+        (replace-paired-rename²ᵢ assm hτ hσ replace))
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-concealᴿ {pX = pX}
+        corr conv conv′ replace M⊑M′)
+      with rel-store-embedding-correspondenceⁱ
+        (store-embeddingᴿ emb) corr
+  smaller-world-embed-no•ᴿ
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-concealᴿ {pX = pX}
+        corr conv conv′ replace M⊑M′)
+      | α′ , X , β′ , X′ , p′ ,
+        refl , refl , refl , refl , shape-eq , corr′ =
+    paired-concealᴿ corr′
+      (left-conceal-world-renameᴿ emb conv)
+      (right-conceal-world-renameᴿ emb conv′)
+      (replace-paired-evidence-shape
+        (trans shape-eq (sym (shape-rename assm hτ hσ pX)))
+        (replace-paired-rename²ᵢ assm hτ hσ replace))
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
+      {assm = assm} {hτ = hτ} {hσ = hσ}
+      {ρ = ρ} {ρ′ = ρ′}
+      emb noM noM′ (target-instantiationᴿ creation) =
+    target-instantiationᴿ
+      (embed-creationᴱ creation assm hτ hσ
+        (store-embeddingᴿ emb)
+        (world-embedding-source-typingᴿ
+          empty-emb noM
+          (embedded-creation-source-typingᴱ creation))
+        (world-embedding-target-typingᴿ
+          empty-emb noM′
+          (embedded-creation-target-typingᴱ creation)))
+    where
+    empty-emb :
+      ReductionClosedWorldEmbeddingᴿ
+        τ σ ψ φ assm hτ hσ
+        {ρ = ρ} {ρ′ = ρ′} {γ = []} {γ′ = []}
+    empty-emb =
+      reduction-closed-world-embeddingᴿ
+        {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
+        (left-inverseᴿ emb) (right-inverseᴿ emb)
+        (left-cast-renamerᴿ emb) (right-cast-renamerᴿ emb)
+        (store-embeddingᴿ emb) rel-ctx-rename-[]
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noN) (no•-⟨⟩ noN′)
+      (closeᴿ N⊑N′ widen-pair u-shape u′-shape square compat) =
+    closeᴿ
+      (smaller-quotient-world-embed-no•ᴿ
+        emb noN noN′ N⊑N′)
+      (quotient-widening-pair-world-renameᴿ emb widen-pair)
+      (cast-shape-rename τ u-shape)
+      (cast-shape-rename σ u′-shape)
+      (quotient-boundary-square-rename²
+        {τ = τ} {σ = σ} {assm = assm}
+        {hτ = hτ} {hσ = hσ} square)
+      (reduction-closed-quotient-compatible-rename²ᵢ
+        {assm = assm} hτ hσ compat)
+  smaller-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-wideningᴿ
+        mode seal★ c⊑ c-shape
+        mode′ seal★′ c′⊑ c′-shape
+        left-square right-square compat M⊑M′) =
+    paired-wideningᴿ
+      (CastModeRenamer.target-mode
+        (left-cast-renamerᴿ emb) mode)
+      (left-seal-world-renameᴿ emb mode seal★)
+      (left-widen-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (left-cast-renamerᴿ emb) mode) c⊑)
+      (cast-shape-rename τ c-shape)
+      (CastModeRenamer.target-mode
+        (right-cast-renamerᴿ emb) mode′)
+      (right-seal-world-renameᴿ emb mode′ seal★′)
+      (right-widen-world-renameᴿ emb
+        (CastModeRenamer.target-rename
+          (right-cast-renamerᴿ emb) mode′) c′⊑)
+      (cast-shape-rename σ c′-shape)
+      (imprecision-composition-shape-transport
+        refl (shape-rename assm hτ hσ _)
+        refl left-square)
+      (imprecision-composition-shape-transport
+        (shape-rename assm hτ hσ _)
+        refl refl right-square)
+      (reduction-closed-paired-compatible-rename²ᵢ
+        {assm = assm} hτ hσ compat)
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+
+  smaller-quotient-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-downᴿ
+        M⊑M′ mode d⊒ d-shape
+        mode′ d′⊒ d′-shape square)
+      with spine-mode-world-renameᴿ emb mode
+         | spine-mode-target-world-renameᴿ emb mode′
+  smaller-quotient-world-embed-no•ᴿ
+      {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
+      emb (no•-⟨⟩ noM) (no•-⟨⟩ noM′)
+      (paired-downᴿ
+        M⊑M′ mode d⊒ d-shape
+        mode′ d′⊒ d′-shape square)
+      | μ , mode-rename , modeᴿ
+      | μ′ , mode-rename′ , mode′ᴿ =
+    paired-downᴿ
+      (smaller-world-embed-no•ᴿ emb noM noM′ M⊑M′)
+      modeᴿ
+      (left-narrow-world-renameᴿ emb mode-rename d⊒)
+      (cast-shape-rename τ d-shape)
+      mode′ᴿ
+      (right-narrow-world-renameᴿ emb mode-rename′ d′⊒)
+      (cast-shape-rename σ d′-shape)
+      (quotient-boundary-square-rename²
+        {τ = τ} {σ = σ} {assm = assm}
+        {hτ = hτ} {hσ = hσ} square)
+
+
+smaller-paired-type-world-weakenᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ↑ : StoreImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γ↑ : CtxImp (∀ᵢᶜ Φ) (suc Δᴸ) (suc Δᴿ)}
+    {M M′ : Term} {A B : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  AssumptionMembershipUnique (∀ᵢᶜ Φ) →
+  LiftStoreⁱ (∀ᵢᶜ Φ) ρ ρ↑ →
+  LiftCtxⁱ (∀ᵢᶜ Φ) γ γ↑ →
+  No• M →
+  No• M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  ∀ᵢᶜ Φ
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ↑ ∣ γ↑
+    ⊢ᴿ renameᵗᵐ suc M ⊑ renameᵗᵐ suc M′
+    ⦂ ⇑ᵗ A ⊑ ⇑ᵗ B ∶ ⊑-lift∀ᵢ p
+smaller-paired-type-world-weakenᴿ
+    unique liftρ liftγ noM noM′ M⊑M′ =
+  smaller-world-embed-no•ᴿ
+    (reduction-closed-world-embeddingᴿ
+      {τ = suc} {σ = suc} {ψ = predᵗ} {φ = predᵗ}
+      RenameLeftInverse-suc RenameLeftInverse-suc
+      castModeRenamer-suc castModeRenamer-suc
+      (lift-store-embeddingⁱ liftρ)
+      (paired-context-lift-world-renameᴿ
+        (assumption-membership-unique→precision-index-unique unique)
+        liftγ))
+    noM noM′ M⊑M′
+
+
+smaller-target-type-index-transportᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ A B B′}
+    {p′ : Φ ∣ Δᴸ ⊢ A ⊑ B′ ⊣ Δᴿ}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  (eqB : B′ ≡ B) →
+  subst (λ T → Φ ∣ Δᴸ ⊢ A ⊑ T ⊣ Δᴿ) eqB p′ ≡ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B′ ∶ p′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p
+smaller-target-type-index-transportᴿ refl refl M⊑M′ =
+  M⊑M′
+
+
+smaller-target-term-transportᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ γ M M′ N′ A B p} →
+  M′ ≡ N′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ N′ ⦂ A ⊑ B ∶ p
+smaller-target-term-transportᴿ refl M⊑M′ =
+  M⊑M′
+
+
+smaller-source-type-world-weakenᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ↑ : StoreImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {γ↑ : CtxImp
+      ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) (suc Δᴸ) Δᴿ}
+    {M M′ : Term} {A B : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  AssumptionMembershipUnique ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) →
+  LiftLeftStoreⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ρ ρ↑ →
+  LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ↑ →
+  No• M →
+  No• M′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+    ∣ suc Δᴸ ∣ Δᴿ ∣ ρ↑ ∣ γ↑
+    ⊢ᴿ renameᵗᵐ suc M ⊑ M′
+    ⦂ ⇑ᵗ A ⊑ B ∶ ⊑-source-liftνᵢ p
+smaller-source-type-world-weakenᴿ
+    {M′ = M′} {B = B}
+    unique liftρ liftγ noM noM′ M⊑M′ =
+  smaller-target-term-transportᴿ (renameᵗᵐ-id M′)
+    (smaller-target-type-index-transportᴿ
+      (renameᵗ-id B) refl
+      (smaller-world-embed-no•ᴿ
+        (reduction-closed-world-embeddingᴿ
+          {τ = suc} {σ = λ X → X}
+          {ψ = predᵗ} {φ = λ X → X}
+          RenameLeftInverse-suc (λ X → refl)
+          castModeRenamer-suc castModeRenamer-idᴿ
+          (lift-left-store-embeddingⁱ liftρ)
+          (source-context-lift-world-renameᴿ
+            (assumption-membership-unique→precision-index-unique unique)
+            liftγ))
+        noM noM′ M⊑M′))

--- a/GTSF/proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
@@ -1,0 +1,454 @@
+module
+  proof.Quotient.NuImprecisionSingleNarrowingBoundaryExamples
+  where
+
+-- File Charter:
+--   * Tests whether bilateral reduction makes one paired narrowing boundary
+--     sufficient for quotient term imprecision.
+--   * Uses two same-polarity function widenings whose beta reductions expose
+--     two genuinely quotient-producing narrowing casts around the argument.
+--   * Checks that a finite narrowing spine relates the exposed prefix and that
+--     the one-boundary prototype cannot relate that same prefix.
+--   * Proves the first prefix is quotient-related but not ordinarily related,
+--     so the doubly cast top terms are outside the live relation.
+--   * Records the corresponding four-cast reduction endpoint as an
+--     expressiveness diagnostic, not as a simulation counterexample.
+--   * Does not change or re-export the live term-imprecision relation.
+
+open import Agda.Builtin.Equality using (refl)
+open import Data.Empty using (⊥)
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (zero; suc)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality using (sym; trans)
+
+import Coercions as C
+import ImprecisionWf as IWF
+import CastImprecisionShape as CastShape
+
+open import ForallPermutation using
+  (quotientᵖ; ≈∀-refl; ≈∀-⇒)
+open import Imprecision using (idᵢ; _ˣ⊑ˣ_)
+open import ImprecisionComposition using
+  ( ⌊_⌋
+  ; _↦ˢ_
+  ; _；_≋_
+  ; _；⌊_⌋≋ᵖ_；_
+  ; comp-id★
+  ; comp-idˣ-idˣ
+  ; comp-idˣ-tagˣ
+  ; comp-↦-↦
+  ; comp-∀-∀
+  ; comp-∀-ν
+  ; comp-tagˣ-id★
+  ; comp-ν
+  ; source-perm-refl
+  ; source-perm-↦
+  ; source-swap-∀ν
+  ; quotient-boundary-square
+  )
+open import NuReduction using (keep; _—↠[_]_)
+open import NuTerms using (Term; Value; `_; ƛ_; _·_; _⟨_⟩)
+open import QuotientedTermImprecision using
+  (_∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_)
+open import Types using (Ty; _⇒_)
+open import proof.Compilation.CompileCoercions using
+  (coerce-downⁿ-shape-idᵢ; coerce-upʷ-shape-idᵢ)
+open import proof.Core.Properties.CoercionProperties using
+  (coercion-src-tgtᵐ)
+open import proof.Core.Permutation.ForallPermutationTest using
+  ( glb-lower-XY≈YX
+  ; glb-lower-XY⊑XY
+  ; glb-lower-YX⊑YX
+  )
+open import proof.EndpointMLB.Core.MLBGlbExample using
+  ( glb-bad-A
+  ; glb-bad-A⊑A
+  ; glb-lower-XY
+  ; glb-lower-XY⊑A
+  ; glb-lower-YX
+  ; glb-lower-YX⊑A
+  )
+open import
+  proof.Quotient.NuImprecisionCompositionalQuotientDef
+  using
+  ( cast-spine
+  ; id-only↓
+  ; single↓
+  ; extend↓
+  ; _∣_∣_∣_∣_⊢ᴺᶜ[_]_⊑_⦂_⊑ᵖ_∶_
+  ; paired-spinesᶜ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
+  ; ordinaryᴿ
+  ; paired-downᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientExamples
+  using
+  ( identity-A-function⊑identity-A-function
+  ; identity-function-quotient
+  ; identity-function-quotient-square
+  ; two-function-casts-identity-reduction
+  )
+
+------------------------------------------------------------------------
+-- Two proper narrowing stages between a common type and the quotient
+------------------------------------------------------------------------
+
+first-source-domain : Ty
+first-source-domain = glb-lower-XY ⇒ glb-bad-A
+
+first-target-domain : Ty
+first-target-domain = glb-lower-YX ⇒ glb-bad-A
+
+final-source-domain : Ty
+final-source-domain = glb-lower-XY ⇒ glb-lower-XY
+
+final-target-domain : Ty
+final-target-domain = glb-lower-YX ⇒ glb-lower-YX
+
+first-source-below-common :
+  idᵢ zero IWF.∣ zero ⊢ first-source-domain
+    ⊑ glb-bad-A ⇒ glb-bad-A ⊣ zero
+first-source-below-common =
+  glb-lower-XY⊑A IWF.↦ glb-bad-A⊑A
+
+first-target-below-common :
+  idᵢ zero IWF.∣ zero ⊢ first-target-domain
+    ⊑ glb-bad-A ⇒ glb-bad-A ⊣ zero
+first-target-below-common =
+  glb-lower-YX⊑A IWF.↦ glb-bad-A⊑A
+
+final-source-below-first :
+  idᵢ zero IWF.∣ zero ⊢ final-source-domain
+    ⊑ first-source-domain ⊣ zero
+final-source-below-first =
+  glb-lower-XY⊑XY IWF.↦ glb-lower-XY⊑A
+
+final-target-below-first :
+  idᵢ zero IWF.∣ zero ⊢ final-target-domain
+    ⊑ first-target-domain ⊣ zero
+final-target-below-first =
+  glb-lower-YX⊑YX IWF.↦ glb-lower-YX⊑A
+
+first-source-reflexive :
+  idᵢ zero IWF.∣ zero ⊢ first-source-domain
+    ⊑ first-source-domain ⊣ zero
+first-source-reflexive =
+  glb-lower-XY⊑XY IWF.↦ glb-bad-A⊑A
+
+first-domain-quotient =
+  quotientᵖ ≈∀-refl first-source-reflexive
+    (≈∀-⇒ glb-lower-XY≈YX ≈∀-refl)
+
+first-source-down-result =
+  coerce-downⁿ-shape-idᵢ 83 first-source-below-common
+
+first-target-down-result =
+  coerce-downⁿ-shape-idᵢ 83 first-target-below-common
+
+second-source-down-result =
+  coerce-downⁿ-shape-idᵢ 84 final-source-below-first
+
+second-target-down-result =
+  coerce-downⁿ-shape-idᵢ 84 final-target-below-first
+
+first-source-down : C.Coercion
+first-source-down = proj₁ first-source-down-result
+
+first-target-down : C.Coercion
+first-target-down = proj₁ first-target-down-result
+
+second-source-down : C.Coercion
+second-source-down = proj₁ second-source-down-result
+
+second-target-down : C.Coercion
+second-target-down = proj₁ second-target-down-result
+
+source-self-then-lower :
+  ⌊ glb-lower-XY⊑XY ⌋
+    ； ⌊ glb-lower-XY⊑A ⌋
+    ≋ ⌊ glb-lower-XY⊑A ⌋
+source-self-then-lower =
+  comp-∀-∀
+    (comp-∀-ν
+      (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ))
+
+target-self-then-lower :
+  ⌊ glb-lower-YX⊑YX ⌋
+    ； ⌊ glb-lower-YX⊑A ⌋
+    ≋ ⌊ glb-lower-YX⊑A ⌋
+target-self-then-lower =
+  comp-∀-ν
+    (comp-∀-∀
+      (comp-↦-↦ comp-idˣ-idˣ comp-idˣ-tagˣ))
+
+source-lower-then-common-self :
+  ⌊ glb-lower-XY⊑A ⌋
+    ； ⌊ glb-bad-A⊑A ⌋
+    ≋ ⌊ glb-lower-XY⊑A ⌋
+source-lower-then-common-self =
+  comp-∀-∀
+    (comp-ν
+      (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★))
+
+target-lower-then-common-self :
+  ⌊ glb-lower-YX⊑A ⌋
+    ； ⌊ glb-bad-A⊑A ⌋
+    ≋ ⌊ glb-lower-YX⊑A ⌋
+target-lower-then-common-self =
+  comp-ν
+    (comp-∀-∀
+      (comp-↦-↦ comp-idˣ-idˣ comp-tagˣ-id★))
+
+common-self-compose :
+  ⌊ glb-bad-A⊑A ⌋ ； ⌊ glb-bad-A⊑A ⌋
+    ≋ ⌊ glb-bad-A⊑A ⌋
+common-self-compose =
+  comp-∀-∀
+    (comp-↦-↦ comp-idˣ-idˣ comp-id★)
+
+first-domain-quotient-square :
+  ⌊ first-source-below-common ⌋
+    ；⌊ identity-A-function⊑identity-A-function ⌋≋ᵖ
+    first-domain-quotient ； ⌊ first-target-below-common ⌋
+first-domain-quotient-square =
+  quotient-boundary-square
+    source-perm-refl
+    (comp-↦-↦ source-lower-then-common-self
+      common-self-compose)
+    (source-perm-↦ source-swap-∀ν source-perm-refl)
+    (comp-↦-↦ source-self-then-lower
+      common-self-compose)
+
+source-two-down-shapes :
+  ⌊ final-source-below-first ⌋
+    ； ⌊ first-source-below-common ⌋
+    ≋ ⌊
+      glb-lower-XY⊑A IWF.↦ glb-lower-XY⊑A
+    ⌋
+source-two-down-shapes =
+  comp-↦-↦ source-self-then-lower
+    source-lower-then-common-self
+
+target-two-down-shapes :
+  ⌊ final-target-below-first ⌋
+    ； ⌊ first-target-below-common ⌋
+    ≋ ⌊
+      glb-lower-YX⊑A IWF.↦ glb-lower-YX⊑A
+    ⌋
+target-two-down-shapes =
+  comp-↦-↦ target-self-then-lower
+    target-lower-then-common-self
+
+first-genuine-downᴿ :
+  ∀ {W W′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ W ⊑ W′
+    ⦂ glb-bad-A ⇒ glb-bad-A
+    ⊑ glb-bad-A ⇒ glb-bad-A
+    ∶ identity-A-function⊑identity-A-function →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿᵖ W ⟨ first-source-down ⟩
+      ⊑ W′ ⟨ first-target-down ⟩
+    ⦂ first-source-domain ⊑ᵖ first-target-domain
+    ∶ first-domain-quotient
+first-genuine-downᴿ relation =
+  paired-downᴿ (ordinaryᴿ relation)
+    id-only↓
+    (proj₁ (proj₂ first-source-down-result))
+    (proj₂ (proj₂ first-source-down-result))
+    id-only↓
+    (proj₁ (proj₂ first-target-down-result))
+    (proj₂ (proj₂ first-target-down-result))
+    first-domain-quotient-square
+
+------------------------------------------------------------------------
+-- The finite spine succeeds
+------------------------------------------------------------------------
+
+two-genuine-downsᶜ :
+  ∀ {W W′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ W ⊑ W′
+    ⦂ glb-bad-A ⇒ glb-bad-A
+    ⊑ glb-bad-A ⇒ glb-bad-A
+    ∶ identity-A-function⊑identity-A-function →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺᶜ[ cast-spine ]
+      (W ⟨ first-source-down ⟩) ⟨ second-source-down ⟩
+      ⊑
+      (W′ ⟨ first-target-down ⟩) ⟨ second-target-down ⟩
+    ⦂ final-source-domain ⊑ᵖ final-target-domain
+    ∶ identity-function-quotient
+two-genuine-downsᶜ relation =
+  paired-spinesᶜ relation
+    (extend↓
+      (single↓ id-only↓
+        (proj₁ (proj₂ first-source-down-result))
+        (proj₂ (proj₂ first-source-down-result)))
+      id-only↓
+      (proj₁ (proj₂ second-source-down-result))
+      (proj₂ (proj₂ second-source-down-result))
+      source-two-down-shapes)
+    (extend↓
+      (single↓ id-only↓
+        (proj₁ (proj₂ first-target-down-result))
+        (proj₂ (proj₂ first-target-down-result)))
+      id-only↓
+      (proj₁ (proj₂ second-target-down-result))
+      (proj₂ (proj₂ second-target-down-result))
+      target-two-down-shapes)
+    identity-function-quotient-square
+
+------------------------------------------------------------------------
+-- One paired narrowing cannot consume the already-quotient prefix
+------------------------------------------------------------------------
+
+lower-permuted-types-not-ordinary :
+  idᵢ zero IWF.∣ zero
+    ⊢ glb-lower-XY ⊑ glb-lower-YX ⊣ zero →
+  ⊥
+
+one-not-below-zero :
+  (suc zero ˣ⊑ˣ zero) ∈
+    ((zero ˣ⊑ˣ zero) ∷ (suc zero ˣ⊑ˣ suc zero) ∷ []) →
+  ⊥
+one-not-below-zero (here ())
+one-not-below-zero (there (here ()))
+one-not-below-zero (there (there ()))
+
+lower-permuted-types-not-ordinary
+    (IWF.∀ⁱ
+      (IWF.∀ⁱ
+        (IWF.idˣ assumption _ _ IWF.↦ codomain))) =
+  one-not-below-zero assumption
+lower-permuted-types-not-ordinary
+    (IWF.ν safe occurs (IWF.∀ⁱ ()))
+lower-permuted-types-not-ordinary
+    (IWF.ν safe occurs (IWF.ν safe′ occurs′ ()))
+
+first-domains-not-ordinary :
+  idᵢ zero IWF.∣ zero
+    ⊢ first-source-domain ⊑ first-target-domain ⊣ zero →
+  ⊥
+first-domains-not-ordinary
+    (domain IWF.↦ codomain) =
+  lower-permuted-types-not-ordinary domain
+
+two-genuine-downs-not-single :
+  ∀ {W W′} →
+  idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿᵖ
+      (W ⟨ first-source-down ⟩) ⟨ second-source-down ⟩
+      ⊑
+      (W′ ⟨ first-target-down ⟩) ⟨ second-target-down ⟩
+    ⦂ final-source-domain ⊑ᵖ final-target-domain
+    ∶ identity-function-quotient →
+  ⊥
+two-genuine-downs-not-single
+    (paired-downᴿ {p = p} relation
+      source-mode source-down source-shape
+      target-mode target-down target-shape square)
+    with coercion-src-tgtᵐ (proj₁ source-down)
+       | coercion-src-tgtᵐ
+          (proj₁ (proj₁ (proj₂ second-source-down-result)))
+       | coercion-src-tgtᵐ (proj₁ target-down)
+       | coercion-src-tgtᵐ
+          (proj₁ (proj₁ (proj₂ second-target-down-result)))
+... | source-src , source-tgt
+    | known-source-src , known-source-tgt
+    | target-src , target-tgt
+    | known-target-src , known-target-tgt
+    with trans (sym source-src) known-source-src
+       | trans (sym target-src) known-target-src
+... | refl | refl =
+  first-domains-not-ordinary p
+
+------------------------------------------------------------------------
+-- Unrelated same-polarity tops expose the adversarial prefix
+------------------------------------------------------------------------
+
+-- These reductions are individually valid. Their top terms are not related
+-- by the live relation because the innermost lambdas would already require
+-- ordinary imprecision between the permuted domains.
+
+first-source-up-result =
+  coerce-upʷ-shape-idᵢ 85 first-source-below-common
+
+first-target-up-result =
+  coerce-upʷ-shape-idᵢ 85 first-target-below-common
+
+second-source-up-result =
+  coerce-upʷ-shape-idᵢ 86 final-source-below-first
+
+second-target-up-result =
+  coerce-upʷ-shape-idᵢ 86 final-target-below-first
+
+first-source-up : C.Coercion
+first-source-up = proj₁ first-source-up-result
+
+first-target-up : C.Coercion
+first-target-up = proj₁ first-target-up-result
+
+second-source-up : C.Coercion
+second-source-up = proj₁ second-source-up-result
+
+second-target-up : C.Coercion
+second-target-up = proj₁ second-target-up-result
+
+first-source-down-inert : C.Inert first-source-down
+first-source-down-inert
+    with proj₂ (proj₂ first-source-down-result)
+... | CastShape.shape-fun {c = c} {d = d} domain codomain =
+  c C.↦ d
+
+first-target-down-inert : C.Inert first-target-down
+first-target-down-inert
+    with proj₂ (proj₂ first-target-down-result)
+... | CastShape.shape-fun {c = c} {d = d} domain codomain =
+  c C.↦ d
+
+second-source-down-inert : C.Inert second-source-down
+second-source-down-inert
+    with proj₂ (proj₂ second-source-down-result)
+... | CastShape.shape-fun {c = c} {d = d} domain codomain =
+  c C.↦ d
+
+second-target-down-inert : C.Inert second-target-down
+second-target-down-inert
+    with proj₂ (proj₂ second-target-down-result)
+... | CastShape.shape-fun {c = c} {d = d} domain codomain =
+  c C.↦ d
+
+source-same-polarity-reduction :
+  ∀ {W} →
+  Value W →
+  ((((ƛ (` zero))
+      ⟨ second-source-down C.↦ second-source-up ⟩)
+      ⟨ first-source-down C.↦ first-source-up ⟩) · W)
+    —↠[ keep ∷ keep ∷ keep ∷ [] ]
+  (((((W ⟨ first-source-down ⟩) ⟨ second-source-down ⟩)
+      ⟨ second-source-up ⟩) ⟨ first-source-up ⟩))
+source-same-polarity-reduction vW =
+  two-function-casts-identity-reduction
+    vW second-source-down-inert first-source-down-inert
+
+target-same-polarity-reduction :
+  ∀ {W′} →
+  Value W′ →
+  ((((ƛ (` zero))
+      ⟨ second-target-down C.↦ second-target-up ⟩)
+      ⟨ first-target-down C.↦ first-target-up ⟩) · W′)
+    —↠[ keep ∷ keep ∷ keep ∷ [] ]
+  (((((W′ ⟨ first-target-down ⟩) ⟨ second-target-down ⟩)
+      ⟨ second-target-up ⟩) ⟨ first-target-up ⟩))
+target-same-polarity-reduction vW′ =
+  two-function-casts-identity-reduction
+    vW′ second-target-down-inert first-target-down-inert

--- a/GTSF/proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionSingleNarrowingBoundaryExamples.agda
@@ -84,8 +84,8 @@ open import
 open import
   proof.Quotient.NuImprecisionReductionClosedQuotientDef
   using
-  ( _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
-  ; ordinaryᴿ
+  ( _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  ; _∣_∣_∣_∣_⊢ᴿᵖ_⊑_⦂_⊑ᵖ_∶_
   ; paired-downᴿ
   )
 open import
@@ -250,7 +250,7 @@ target-two-down-shapes =
 first-genuine-downᴿ :
   ∀ {W W′} →
   idᵢ zero ∣ zero ∣ zero ∣ [] ∣ []
-    ⊢ᴺ W ⊑ W′
+    ⊢ᴿ W ⊑ W′
     ⦂ glb-bad-A ⇒ glb-bad-A
     ⊑ glb-bad-A ⇒ glb-bad-A
     ∶ identity-A-function⊑identity-A-function →
@@ -260,7 +260,7 @@ first-genuine-downᴿ :
     ⦂ first-source-domain ⊑ᵖ first-target-domain
     ∶ first-domain-quotient
 first-genuine-downᴿ relation =
-  paired-downᴿ (ordinaryᴿ relation)
+  paired-downᴿ relation
     id-only↓
     (proj₁ (proj₂ first-source-down-result))
     (proj₂ (proj₂ first-source-down-result))

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationConsumerMigrationExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationConsumerMigrationExperiment.agda
@@ -1,0 +1,317 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationConsumerMigrationExperiment
+  where
+
+-- File Charter:
+--   * Shadow-migrates the positive target-instantiation consumers from the
+--     live fused QTI constructor to exact creation and canonical transport.
+--   * Constructs the smaller relation for the direct identity post-beta
+--     context, canonically transported paired-lambda leaf, and ordinary and
+--     identity-mode target-widening beta-instantiation roots.
+--   * Reuses the strict exact-creation transport spine for pure universal
+--     fusion; framed closing is tested in its own companion experiment.
+--   * Does not import the live term-imprecision relation and contains no
+--     postulate, hole, permissive option, termination bypass, or catch-all.
+
+open import Agda.Builtin.Equality using (_≡_)
+open import CastImprecisionShape using
+  (widening; _⊢ᶜ_⦂_)
+open import Coercions using
+  (Coercion; Inert; ModeEnv; id-onlyᵈ; inst)
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (suc; zero)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑ˣ_; ⇑ᵢ; ⇑ᴿᵢ)
+open import ImprecisionComposition using
+  (ImprecisionShape; νˢ_; ⌊_⌋; _；_≋_)
+open import ImprecisionWf using
+  (ImpAssm; _∣_⊢_⊑_⊣_; ∀ⁱ_)
+open import NarrowWiden using (_∣_∣_⊢_∶_⊑_)
+open import NuReduction using
+  ( StoreChanges
+  ; bind
+  ; keep
+  ; _—↠[_]_
+  )
+open import NuTermImprecision using
+  ( CtxImp
+  ; LiftRightStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; store-right
+  )
+open import NuTerms using
+  (No•; Term; Value; Λ_; _⟨_⟩; ν; renameᵗᵐ)
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  (Renameᵗ; Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ; renameᵗ)
+open import Relation.Binary.PropositionalEquality using (sym)
+open import
+  proof.Core.Properties.TypeProperties
+  using (TyRenameWf)
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using
+  ( rename-assm²ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-target-lift-rightᵢ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( target-instantiationᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  ( StoreImpPrefixᴿ
+  ; TargetInstantiationCreation
+  ; exact-creationᴱ
+  ; target-instantiation-creation
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationTransportExperiment
+  using (target-instantiation-endpoint-transportᴿ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+  using (RelStoreEmbeddingⁱ)
+open import
+  proof.Target.Administration.NuImprecisionTargetPendingLambdaAllocationTraceProof
+  using (target-pending-lambda-allocation-trace-proofᵀ)
+
+
+direct-identity-post-beta-contextᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)}
+    {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {W W′ : Term} {B C D : Ty} {s : Coercion} {μ : ModeEnv}
+    {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      ∣ suc Δᴸ ⊢ D ⊑ C ⊣ suc Δᴿ}
+    {f : Φ ∣ Δᴸ ⊢ `∀ D ⊑ B ⊣ Δᴿ}
+    {body-shape : ImprecisionShape}
+    {γ⁺ : CtxImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  CastMode μ →
+  SealModeStore★ μ (rightStoreⁱ ρ₀) →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst B s ∶ `∀ C ⊑ B →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ₀ ρ∀ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ⁺ ρᴿ⁺ →
+  Value W →
+  No• W →
+  Value W′ →
+  No• W′ →
+  Inert s →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+    ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r →
+  widening ⊢ᶜ inst B s ⦂ νˢ body-shape →
+  ⌊ ∀ⁱ r ⌋ ； νˢ body-shape ≋ ⌊ f ⌋ →
+  Δᴸ
+    ∣ leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+    ∣ [] ⊢ Λ W ⦂ `∀ D →
+  suc Δᴿ
+    ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+    ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B →
+  ⇑ᴿᵢ Φ
+    ∣ Δᴸ ∣ suc Δᴿ
+    ∣ store-right zero ★ wf★ ∷ ρᴿ⁺ ∣ γ⁺
+    ⊢ᴿ Λ W ⊑ W′ ⟨ s ⟩
+    ⦂ `∀ D ⊑ ⇑ᵗ B
+    ∶ ⊑-target-lift-rightᵢ f
+direct-identity-post-beta-contextᴿ
+    prefix mode seal★ inst⊑ liftρ liftρᴿ
+    vW noW vW′ noW′ inert body
+    inst-shape creation-square source-typing target-typing =
+  target-instantiationᴿ
+    (exact-creationᴱ
+      (target-instantiation-creation
+        prefix mode seal★ inst⊑ liftρ liftρᴿ
+        vW noW vW′ noW′ inert body
+        inst-shape creation-square source-typing target-typing))
+
+
+data CanonicalTargetInstantiationLeafᴿ
+    {Ψ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    (ρ : StoreImp Ψ Δᴸ Δᴿ) :
+    (M M′ : Term) → (A A′ : Ty) →
+    (p : Ψ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) → Set₁ where
+
+  canonical-instantiation-leafᴿ :
+    ∀ {Φ₀ : ImpCtx} {Θᴸ Θᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+      {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+        (suc Θᴸ) (suc Θᴿ)}
+      {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+      {τ σ : Renameᵗ}
+      {W W′ M M′ : Term} {A A′ B C D : Ty}
+      {s : Coercion} {μ : ModeEnv}
+      {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+        ∣ suc Θᴸ ⊢ D ⊑ C ⊣ suc Θᴿ}
+      {f : Φ₀ ∣ Θᴸ ⊢ `∀ D ⊑ B ⊣ Θᴿ}
+      {p : Ψ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+      {body-shape : ImprecisionShape} →
+    (creation :
+      TargetInstantiationCreation
+        {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+        {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+        {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+        {s = s} {μ = μ} {r = r} {f = f}
+        {body-shape = body-shape}
+        (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+          ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
+          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r)) →
+    (assm :
+      ∀ {a : ImpAssm} → a ∈ ⇑ᴿᵢ Φ₀ →
+        rename-assm²ᵢ τ σ a ∈ Ψ) →
+    (hτ : TyRenameWf Θᴸ Δᴸ τ) →
+    (hσ : TyRenameWf (suc Θᴿ) Δᴿ σ) →
+    RelStoreEmbeddingⁱ τ σ
+      (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ →
+    (source-eq : renameᵗᵐ τ (Λ W) ≡ M) →
+    (target-eq : renameᵗᵐ σ (W′ ⟨ s ⟩) ≡ M′) →
+    (source-type-eq : renameᵗ τ (`∀ D) ≡ A) →
+    (target-type-eq : renameᵗ σ (⇑ᵗ B) ≡ A′) →
+    ⊑-rename-at²ᵢ assm hτ hσ
+      (sym source-type-eq) (sym target-type-eq)
+      (⊑-target-lift-rightᵢ f) ≡ p →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ [] ⊢ M ⦂ A →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ M′ ⦂ A′ →
+    CanonicalTargetInstantiationLeafᴿ ρ M M′ A A′ p
+
+
+canonical-target-instantiation-leaf-reconstructᴿ :
+  ∀ {Ψ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Ψ Δᴸ Δᴿ}
+    {M M′ : Term} {A A′ : Ty}
+    {p : Ψ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  CanonicalTargetInstantiationLeafᴿ ρ M M′ A A′ p →
+  Ψ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+canonical-target-instantiation-leaf-reconstructᴿ
+    (canonical-instantiation-leafᴿ
+      creation assm hτ hσ store-embedding
+      source-eq target-eq source-type-eq target-type-eq
+      index-eq source-typing target-typing) =
+  target-instantiation-endpoint-transportᴿ
+    creation assm hτ hσ store-embedding
+    source-eq target-eq source-type-eq target-type-eq
+    index-eq source-typing target-typing
+
+
+private
+  post-beta-tail : StoreChanges
+  post-beta-tail = bind ★ ∷ keep ∷ []
+
+
+record TargetWideningBetaInstantiationOutcomeᴿ
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {W W′ : Term} {B D : Ty} {s : Coercion}
+    {f : Φ ∣ Δᴸ ⊢ `∀ D ⊑ B ⊣ Δᴿ} : Set₁ where
+  field
+    target-tail :
+      ν ★ (Λ W′) s —↠[ post-beta-tail ] W′ ⟨ s ⟩
+
+    final-relation :
+      ⇑ᴿᵢ Φ
+        ∣ Δᴸ ∣ suc Δᴿ
+        ∣ store-right zero ★ wf★ ∷ ρᴿ⁺ ∣ []
+        ⊢ᴿ Λ W ⊑ W′ ⟨ s ⟩
+        ⦂ `∀ D ⊑ ⇑ᵗ B
+        ∶ ⊑-target-lift-rightᵢ f
+
+open TargetWideningBetaInstantiationOutcomeᴿ public
+
+
+target-widening-beta-instantiation-rootᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ⁺ W W′ B C D s μ r f
+      body-shape} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  CastMode μ →
+  SealModeStore★ μ (rightStoreⁱ ρ₀) →
+  μ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst B s ∶ `∀ C ⊑ B →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ₀ ρ∀ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ⁺ ρᴿ⁺ →
+  Value W →
+  No• W →
+  Value W′ →
+  No• W′ →
+  Inert s →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+    ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r →
+  widening ⊢ᶜ inst B s ⦂ νˢ body-shape →
+  ⌊ ∀ⁱ r ⌋ ； νˢ body-shape ≋ ⌊ f ⌋ →
+  Δᴸ
+    ∣ leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+    ∣ [] ⊢ Λ W ⦂ `∀ D →
+  suc Δᴿ
+    ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+    ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B →
+  TargetWideningBetaInstantiationOutcomeᴿ
+    {ρᴿ⁺ = ρᴿ⁺} {W = W} {W′ = W′}
+    {B = B} {D = D} {s = s} {f = f}
+target-widening-beta-instantiation-rootᴿ
+    prefix mode seal★ inst⊑ liftρ liftρᴿ
+    vW noW vW′ noW′ inert body
+    inst-shape creation-square source-typing target-typing =
+  record
+    { target-tail =
+        target-pending-lambda-allocation-trace-proofᵀ
+          {cs = []} vW′ noW′
+    ; final-relation =
+        target-instantiationᴿ
+          (exact-creationᴱ
+            (target-instantiation-creation
+              prefix mode seal★ inst⊑ liftρ liftρᴿ
+              vW noW vW′ noW′ inert body
+              inst-shape creation-square source-typing target-typing))
+    }
+
+
+target-id-widening-beta-instantiation-rootᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ ρ∀ ρᴿ⁺ W W′ B C D s r f
+      body-shape} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  CastMode id-onlyᵈ →
+  SealModeStore★ id-onlyᵈ (rightStoreⁱ ρ₀) →
+  id-onlyᵈ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+    ⊢ inst B s ∶ `∀ C ⊑ B →
+  LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ₀ ρ∀ →
+  LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ⁺ ρᴿ⁺ →
+  Value W →
+  No• W →
+  Value W′ →
+  No• W′ →
+  Inert s →
+  ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+    ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+    ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r →
+  widening ⊢ᶜ inst B s ⦂ νˢ body-shape →
+  ⌊ ∀ⁱ r ⌋ ； νˢ body-shape ≋ ⌊ f ⌋ →
+  Δᴸ
+    ∣ leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+    ∣ [] ⊢ Λ W ⦂ `∀ D →
+  suc Δᴿ
+    ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+    ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B →
+  TargetWideningBetaInstantiationOutcomeᴿ
+    {ρᴿ⁺ = ρᴿ⁺} {W = W} {W′ = W′}
+    {B = B} {D = D} {s = s} {f = f}
+target-id-widening-beta-instantiation-rootᴿ
+    prefix mode seal★ inst⊑ liftρ liftρᴿ
+    vW noW vW′ noW′ inert body
+    inst-shape creation-square source-typing target-typing =
+  target-widening-beta-instantiation-rootᴿ
+    prefix mode seal★ inst⊑ liftρ liftρᴿ
+    vW noW vW′ noW′ inert body
+    inst-shape creation-square source-typing target-typing

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
@@ -1,0 +1,94 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  where
+
+-- File Charter:
+--   * Defines the exact residual evidence preserved while a target
+--     instantiation allocates a fresh seal and completes its administrative
+--     reduction.
+--   * Retains the matched pre-allocation body relation, the cast/index
+--     creation equation, and the store lineage joining that body world to
+--     the final right-extended world.
+--   * Omits arbitrary endpoint renaming, store embedding, and endpoint
+--     equality transport; those belong in separate admissibility lemmas.
+--   * Does not construct or re-export a term-imprecision edge.
+
+open import CastImprecisionShape using (_⊢ᶜ_⦂_; widening)
+open import Coercions using (Coercion; Inert; ModeEnv; inst)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (suc; zero)
+open import Imprecision using
+  ( ImpCtx
+  ; _ˣ⊑ˣ_
+  ; ⇑ᵢ
+  ; ⇑ᴿᵢ
+  )
+open import ImprecisionComposition using
+  (ImprecisionShape; νˢ_; ⌊_⌋; _；_≋_)
+open import ImprecisionWf using
+  (_∣_⊢_⊑_⊣_; ∀ⁱ_)
+open import NarrowWiden using (_∣_∣_⊢_∶_⊑_)
+open import NuTermImprecision using
+  ( LiftRightStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; store-right
+  )
+open import NuTerms using
+  (No•; Term; Value; Λ_; _⟨_⟩)
+open import QuotientedTermImprecision using
+  ( StoreImpPrefix
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  )
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  (Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ)
+
+
+record TargetInstantiationCreation
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)}
+    {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {W W′ : Term} {B C D : Ty} {s : Coercion} {μ : ModeEnv}
+    {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      ∣ suc Δᴸ ⊢ D ⊑ C ⊣ suc Δᴿ}
+    {f : Φ ∣ Δᴸ ⊢ `∀ D ⊑ B ⊣ Δᴿ}
+    {body-shape : ImprecisionShape} : Set₁ where
+  constructor target-instantiation-creation
+  field
+    store-prefix : StoreImpPrefix ρ₀ ρ⁺
+    cast-mode : CastMode μ
+    seal-mode : SealModeStore★ μ (rightStoreⁱ ρ₀)
+    instantiation-typing :
+      μ ∣ Δᴿ ∣ rightStoreⁱ ρ₀
+        ⊢ inst B s ∶ `∀ C ⊑ B
+    matched-store-lift :
+      LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ρ₀ ρ∀
+    right-store-lift :
+      LiftRightStoreⁱ (⇑ᴿᵢ Φ) ρ⁺ ρᴿ⁺
+    source-body-value : Value W
+    source-body-no-bullet : No• W
+    target-body-value : Value W′
+    target-body-no-bullet : No• W′
+    body-cast-inert : Inert s
+    matched-body-relation :
+      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+        ⊢ᴺ W ⊑ W′ ⦂ D ⊑ C ∶ r
+    instantiation-shape :
+      widening ⊢ᶜ inst B s ⦂ νˢ body-shape
+    index-composition :
+      ⌊ ∀ⁱ r ⌋ ； νˢ body-shape ≋ ⌊ f ⌋
+    source-result-typing :
+      Δᴸ
+        ∣ leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+        ∣ [] ⊢ Λ W ⦂ `∀ D
+    target-result-typing :
+      suc Δᴿ
+        ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+        ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
@@ -9,6 +9,8 @@ module
 --   * Retains the matched pre-allocation body relation, the cast/index
 --     creation equation, and the store lineage joining that body world to
 --     the final right-extended world.
+--   * Accepts the matched body relation as a parameter, so the residual is
+--     independent of every particular term-imprecision judgment.
 --   * Omits arbitrary endpoint renaming, store embedding, and endpoint
 --     equality transport; those belong in separate admissibility lemmas.
 --   * Does not construct or re-export a term-imprecision edge.
@@ -32,20 +34,27 @@ open import NuTermImprecision using
   ( LiftRightStoreⁱ
   ; LiftStoreⁱ
   ; StoreImp
+  ; StoreImpEntry
   ; leftStoreⁱ
   ; rightStoreⁱ
   ; store-right
   )
 open import NuTerms using
   (No•; Term; Value; Λ_; _⟨_⟩)
-open import QuotientedTermImprecision using
-  ( StoreImpPrefix
-  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
-  )
 open import TermTyping using
   (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
 open import Types using
   (Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ)
+
+
+data StoreImpPrefixᴿ {Φ Δᴸ Δᴿ} :
+    StoreImp Φ Δᴸ Δᴿ → StoreImp Φ Δᴸ Δᴿ → Set where
+  prefix-reflᴿ : ∀ {ρ} → StoreImpPrefixᴿ ρ ρ
+
+  prefix-∷ᴿ :
+    ∀ {ρ₀ ρ⁺} {entry : StoreImpEntry Φ Δᴸ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    StoreImpPrefixᴿ ρ₀ (entry ∷ ρ⁺)
 
 
 record TargetInstantiationCreation
@@ -58,10 +67,11 @@ record TargetInstantiationCreation
     {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
       ∣ suc Δᴸ ⊢ D ⊑ C ⊣ suc Δᴿ}
     {f : Φ ∣ Δᴸ ⊢ `∀ D ⊑ B ⊣ Δᴿ}
-    {body-shape : ImprecisionShape} : Set₁ where
+    {body-shape : ImprecisionShape}
+    (body-relation : Set₁) : Set₁ where
   constructor target-instantiation-creation
   field
-    store-prefix : StoreImpPrefix ρ₀ ρ⁺
+    store-prefix : StoreImpPrefixᴿ ρ₀ ρ⁺
     cast-mode : CastMode μ
     seal-mode : SealModeStore★ μ (rightStoreⁱ ρ₀)
     instantiation-typing :
@@ -76,10 +86,7 @@ record TargetInstantiationCreation
     target-body-value : Value W′
     target-body-no-bullet : No• W′
     body-cast-inert : Inert s
-    matched-body-relation :
-      ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
-        ⊢ᴺ W ⊑ W′ ⦂ D ⊑ C ∶ r
+    matched-body-relation : body-relation
     instantiation-shape :
       widening ⊢ᶜ inst B s ⦂ νˢ body-shape
     index-composition :

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
@@ -11,16 +11,18 @@ module
 --     the final right-extended world.
 --   * Accepts the matched body relation as a parameter, so the residual is
 --     independent of every particular term-imprecision judgment.
---   * Omits arbitrary endpoint renaming, store embedding, and endpoint
---     equality transport; those belong in separate admissibility lemmas.
+--   * Defines embedded creation residuals from an exact canonical base and
+--     composable QTI-free world embeddings.
 --   * Does not construct or re-export a term-imprecision edge.
 
 open import CastImprecisionShape using (_⊢ᶜ_⦂_; widening)
 open import Coercions using (Coercion; Inert; ModeEnv; inst)
 open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (suc; zero)
 open import Imprecision using
-  ( ImpCtx
+  ( ImpAssm
+  ; ImpCtx
   ; _ˣ⊑ˣ_
   ; ⇑ᵢ
   ; ⇑ᴿᵢ
@@ -40,11 +42,17 @@ open import NuTermImprecision using
   ; store-right
   )
 open import NuTerms using
-  (No•; Term; Value; Λ_; _⟨_⟩)
+  (No•; Term; Value; renameᵗᵐ; Λ_; _⟨_⟩)
 open import TermTyping using
   (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
 open import Types using
-  (Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ)
+  (Renameᵗ; Ty; TyCtx; ★; wf★; `∀; renameᵗ; ⇑ᵗ)
+open import proof.Core.Properties.TypeProperties using (TyRenameWf)
+open import proof.EndpointMLB.Core.MaximalLowerBoundsWf using
+  (rename-assm²ᵢ; ⊑-renameᵗ²ᵢ; ⊑-target-lift-rightᵢ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+  using (RelStoreEmbeddingⁱ)
 
 
 data StoreImpPrefixᴿ {Φ Δᴸ Δᴿ} :
@@ -99,3 +107,74 @@ record TargetInstantiationCreation
       suc Δᴿ
         ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
         ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B
+
+
+data EmbeddedTargetInstantiationCreation
+    {Φ₀ : ImpCtx} {Θᴸ Θᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+      (suc Θᴸ) (suc Θᴿ)}
+    {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+    {W W′ : Term} {B C D : Ty} {s : Coercion} {μ : ModeEnv}
+    {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+      ∣ suc Θᴸ ⊢ D ⊑ C ⊣ suc Θᴿ}
+    {f : Φ₀ ∣ Θᴸ ⊢ `∀ D ⊑ B ⊣ Θᴿ}
+    {body-shape : ImprecisionShape}
+    (body-relation : Set₁) :
+    ∀ {Ψ : ImpCtx} {Δᴸ Δᴿ : TyCtx} →
+    StoreImp Ψ Δᴸ Δᴿ →
+    (M M′ : Term) → (A A′ : Ty) →
+    Ψ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ →
+    Set₁ where
+
+  exact-creationᴱ :
+    TargetInstantiationCreation
+      {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      body-relation →
+    EmbeddedTargetInstantiationCreation
+      {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      body-relation
+      (store-right zero ★ wf★ ∷ ρᴿ⁺)
+      (Λ W) (W′ ⟨ s ⟩) (`∀ D) (⇑ᵗ B)
+      (⊑-target-lift-rightᵢ f)
+
+  embed-creationᴱ :
+    ∀ {Ψ Ω Δᴸ Δᴿ Υᴸ Υᴿ ρ ρ′ M M′ A A′ p τ σ} →
+    EmbeddedTargetInstantiationCreation
+      {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      body-relation
+      {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      ρ M M′ A A′ p →
+    (assm : ∀ {a : ImpAssm} →
+      a ∈ Ψ → rename-assm²ᵢ τ σ a ∈ Ω) →
+    (hτ : TyRenameWf Δᴸ Υᴸ τ) →
+    (hσ : TyRenameWf Δᴿ Υᴿ σ) →
+    RelStoreEmbeddingⁱ τ σ ρ ρ′ →
+    Υᴸ ∣ leftStoreⁱ ρ′ ∣ []
+      ⊢ renameᵗᵐ τ M ⦂ renameᵗ τ A →
+    Υᴿ ∣ rightStoreⁱ ρ′ ∣ []
+      ⊢ renameᵗᵐ σ M′ ⦂ renameᵗ σ A′ →
+    EmbeddedTargetInstantiationCreation
+      {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      body-relation
+      {Ψ = Ω} {Δᴸ = Υᴸ} {Δᴿ = Υᴿ}
+      ρ′
+      (renameᵗᵐ τ M) (renameᵗᵐ σ M′)
+      (renameᵗ τ A) (renameᵗ σ A′)
+      (⊑-renameᵗ²ᵢ assm hτ hσ p)

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
@@ -50,6 +50,7 @@ open import NuTermImprecision using
   ; lift-right-store-[]
   ; lift-store-[]
   ; seal★-tag-or-id
+  ; store-right
   )
 open import NuTerms using
   ( No•
@@ -64,8 +65,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( prefix-reflⁱ
-  ; ⊑cast⊑ᵀ
+  ( ⊑cast⊑ᵀ
   ; x⊑xᵀ
   ; ƛ⊑ƛᵀ
   ; Λ⊑Λᵀ
@@ -89,12 +89,29 @@ open import Types using
   ; ＇_
   ; _⇒_
   ; `∀
+  ; ⇑ᵗ
+  )
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using (⊑-target-lift-rightᵢ)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( target-instantiationᴿ
+  ; x⊑xᴿ
+  ; ƛ⊑ƛᴿ
+  ; Λ⊑Λᴿ
+  ; ⊑cast⊑ᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
   )
 open import proof.Core.Properties.TypePreservation using (seal★-inst)
 open import
   proof.Quotient.NuImprecisionTargetInstantiationCreationDef
   using
-  (TargetInstantiationCreation; target-instantiation-creation)
+  ( TargetInstantiationCreation
+  ; prefix-reflᴿ
+  ; target-instantiation-creation
+  )
 
 
 private
@@ -156,6 +173,16 @@ private
     ƛ⊑ƛᵀ (Types.wfVar z<s) (Types.wfVar z<s)
       (x⊑xᵀ Types.Z)
 
+  matched-body-relationᴿ :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ∣ suc zero ∣ [] ∣ []
+      ⊢ᴿ I ⊑ I
+      ⦂ (＇ zero ⇒ ＇ zero) ⊑ (＇ zero ⇒ ＇ zero)
+      ∶ matched-body-index
+  matched-body-relationᴿ =
+    ƛ⊑ƛᴿ (Types.wfVar z<s) (Types.wfVar z<s)
+      (x⊑xᴿ Types.Z)
+
   matched-universal-relation :
     [] ∣ zero ∣ zero ∣ [] ∣ []
       ⊢ᴺ Λ I ⊑ Λ I
@@ -165,6 +192,16 @@ private
   matched-universal-relation =
     Λ⊑Λᵀ lift-store-[] lift-ctx-[]
       vI vI matched-body-relation
+
+  matched-universal-relationᴿ :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴿ Λ I ⊑ Λ I
+      ⦂ `∀ (＇ zero ⇒ ＇ zero)
+        ⊑ `∀ (＇ zero ⇒ ＇ zero)
+      ∶ ∀ⁱ matched-body-index
+  matched-universal-relationᴿ =
+    Λ⊑Λᴿ lift-store-[] lift-ctx-[]
+      vI vI matched-body-relationᴿ
 
   body-cast-typing :
     C.instᵈ C.tag-or-idᵈ
@@ -236,9 +273,14 @@ target-instantiation-creation-test :
     {s = body-cast} {μ = C.tag-or-idᵈ}
     {r = matched-body-index} {f = final-index}
     {body-shape = tagˣˢ ↦ˢ tagˣˢ}
+    (((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ∣ suc zero ∣ [] ∣ []
+      ⊢ᴺ I ⊑ I
+      ⦂ (＇ zero ⇒ ＇ zero) ⊑ (＇ zero ⇒ ＇ zero)
+      ∶ matched-body-index)
 target-instantiation-creation-test =
   target-instantiation-creation
-    prefix-reflⁱ
+    prefix-reflᴿ
     cast-tag-or-id
     seal★-tag-or-id
     outer-cast-typing
@@ -269,6 +311,67 @@ initial-target-instantiation-relation =
     (shape-inst (shape-fun shape-seal shape-unseal))
     (comp-∀-ν
       (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-tagˣ))
+
+
+initial-target-instantiation-relationᴿ :
+  [] ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴿ Λ I
+      ⊑ (Λ I) ⟨ C.inst (★ ⇒ ★) body-cast ⟩
+    ⦂ `∀ (＇ zero ⇒ ＇ zero) ⊑ (★ ⇒ ★)
+    ∶ final-index
+initial-target-instantiation-relationᴿ =
+  ⊑cast⊑ᴿ cast-tag-or-id seal★-tag-or-id
+    outer-cast-typing matched-universal-relationᴿ final-index
+    (shape-inst (shape-fun shape-seal shape-unseal))
+    (comp-∀-ν
+      (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-tagˣ))
+
+
+target-instantiation-creation-testᴿ :
+  TargetInstantiationCreation
+    {Φ = []} {Δᴸ = zero} {Δᴿ = zero}
+    {ρ₀ = []} {ρ⁺ = []} {ρ∀ = []} {ρᴿ⁺ = []}
+    {W = I} {W′ = I}
+    {B = ★ ⇒ ★}
+    {C = ＇ zero ⇒ ＇ zero}
+    {D = ＇ zero ⇒ ＇ zero}
+    {s = body-cast} {μ = C.tag-or-idᵈ}
+    {r = matched-body-index} {f = final-index}
+    {body-shape = tagˣˢ ↦ˢ tagˣˢ}
+    (((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ∣ suc zero ∣ [] ∣ []
+      ⊢ᴿ I ⊑ I
+      ⦂ (＇ zero ⇒ ＇ zero) ⊑ (＇ zero ⇒ ＇ zero)
+      ∶ matched-body-index)
+target-instantiation-creation-testᴿ =
+  target-instantiation-creation
+    prefix-reflᴿ
+    cast-tag-or-id
+    seal★-tag-or-id
+    outer-cast-typing
+    lift-store-[]
+    lift-right-store-[]
+    vI
+    noI
+    vI
+    noI
+    (C.seal ★ zero C.↦ C.unseal zero ★)
+    matched-body-relationᴿ
+    (shape-inst (shape-fun shape-seal shape-unseal))
+    (comp-∀-ν
+      (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-tagˣ))
+    source-result-typing
+    target-result-typing
+
+
+created-target-instantiation-relationᴿ :
+  [] ∣ zero ∣ suc zero
+    ∣ store-right zero ★ wf★ ∷ [] ∣ []
+    ⊢ᴿ Λ I ⊑ I ⟨ body-cast ⟩
+    ⦂ `∀ (＇ zero ⇒ ＇ zero) ⊑ ⇑ᵗ (★ ⇒ ★)
+    ∶ ⊑-target-lift-rightᵢ final-index
+created-target-instantiation-relationᴿ =
+  target-instantiationᴿ target-instantiation-creation-testᴿ
 
 
 target-instantiation-administrative-trace :

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
@@ -109,6 +109,7 @@ open import
   proof.Quotient.NuImprecisionTargetInstantiationCreationDef
   using
   ( TargetInstantiationCreation
+  ; exact-creationᴱ
   ; prefix-reflᴿ
   ; target-instantiation-creation
   )
@@ -371,7 +372,8 @@ created-target-instantiation-relationᴿ :
     ⦂ `∀ (＇ zero ⇒ ＇ zero) ⊑ ⇑ᵗ (★ ⇒ ★)
     ∶ ⊑-target-lift-rightᵢ final-index
 created-target-instantiation-relationᴿ =
-  target-instantiationᴿ target-instantiation-creation-testᴿ
+  target-instantiationᴿ
+    (exact-creationᴱ target-instantiation-creation-testᴿ)
 
 
 target-instantiation-administrative-trace :

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationExamples.agda
@@ -1,0 +1,284 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationCreationExamples
+  where
+
+-- File Charter:
+--   * Tests whether target-instantiation allocation can be handled without
+--     constructing the live fused post-administration QTI edge.
+--   * Proves that the ordinary source-only-lambda plus target-cast
+--     factorization fails on the smallest closed example.
+--   * Constructs the exact target-instantiation creation residual and the
+--     complete target reduction trace without using the live fused edge.
+--   * Contains no postulate, hole, permissive option, or termination bypass.
+
+import Coercions as C
+import NarrowWiden as NW
+
+open import Agda.Builtin.Equality using (refl)
+open import CastImprecisionShape using
+  (shape-fun; shape-inst; shape-seal; shape-unseal)
+open import Data.Empty using (⊥)
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (suc; zero; z<s)
+open import Data.Product using (_,_; proj₁)
+open import Imprecision using (_ˣ⊑★; _ˣ⊑ˣ_)
+open import ImprecisionComposition using
+  ( _↦ˢ_
+  ; comp-idˣ-tagˣ
+  ; comp-↦-↦
+  ; comp-∀-ν
+  ; tagˣˢ
+  )
+open import ImprecisionWf using
+  (_↦_; _∣_⊢_⊑_⊣_; idˣ; tagˣ; ∀ⁱ_; ν)
+open import NarrowWiden using (_∣_∣_⊢_∶_⊑_)
+open import NuReduction using
+  ( bind
+  ; keep
+  ; pure-step
+  ; β-inst
+  ; β-Λ•
+  ; ν-step
+  ; ξ-⟨⟩
+  ; ↠-refl
+  ; ↠-step
+  ; _—↠[_]_
+  )
+open import NuTermImprecision using
+  ( lift-ctx-[]
+  ; lift-right-store-[]
+  ; lift-store-[]
+  ; seal★-tag-or-id
+  )
+open import NuTerms using
+  ( No•
+  ; Term
+  ; Value
+  ; no•-`
+  ; no•-ƛ
+  ; no•-Λ
+  ; `_
+  ; ƛ_
+  ; Λ_
+  ; _⟨_⟩
+  )
+open import QuotientedTermImprecision using
+  ( prefix-reflⁱ
+  ; ⊑cast⊑ᵀ
+  ; x⊑xᵀ
+  ; ƛ⊑ƛᵀ
+  ; Λ⊑Λᵀ
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  )
+open import TermTyping using
+  ( cast-inst
+  ; cast-tag-or-id
+  ; ⊢`
+  ; ⊢ƛ
+  ; ⊢Λ
+  ; ⊢⟨⟩⊑
+  ; _∣_∣_⊢_⦂_
+  )
+open import Types using
+  ( Ty
+  ; wf★
+  ; wf⇒
+  ; ★
+  ; Z
+  ; ＇_
+  ; _⇒_
+  ; `∀
+  )
+open import proof.Core.Properties.TypePreservation using (seal★-inst)
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  (TargetInstantiationCreation; target-instantiation-creation)
+
+
+private
+  I : Term
+  I = ƛ (` zero)
+
+  vI : Value I
+  vI = ƛ (` zero)
+
+  noI : No• I
+  noI = no•-ƛ no•-`
+
+  matched-variable-index :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ⊢ ＇ zero ⊑ ＇ zero ⊣ suc zero
+  matched-variable-index =
+    idˣ (here refl) z<s z<s
+
+  matched-body-index :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero
+      ⊢ (＇ zero ⇒ ＇ zero) ⊑ (＇ zero ⇒ ＇ zero)
+      ⊣ suc zero
+  matched-body-index =
+    matched-variable-index ↦ matched-variable-index
+
+  source-only-variable-index :
+    ((zero ˣ⊑★) ∷ [])
+      ∣ suc zero ⊢ ＇ zero ⊑ ★ ⊣ zero
+  source-only-variable-index =
+    tagˣ (here refl) z<s
+
+  source-only-body-index :
+    ((zero ˣ⊑★) ∷ [])
+      ∣ suc zero
+      ⊢ (＇ zero ⇒ ＇ zero) ⊑ (★ ⇒ ★)
+      ⊣ zero
+  source-only-body-index =
+    source-only-variable-index ↦ source-only-variable-index
+
+  final-index :
+    [] ∣ zero
+      ⊢ `∀ (＇ zero ⇒ ＇ zero) ⊑ (★ ⇒ ★)
+      ⊣ zero
+  final-index =
+    ν Imprecision.nonvar-fun refl source-only-body-index
+
+  body-cast : C.Coercion
+  body-cast =
+    C.seal ★ zero C.↦ C.unseal zero ★
+
+  matched-body-relation :
+    ((zero ˣ⊑ˣ zero) ∷ [])
+      ∣ suc zero ∣ suc zero ∣ [] ∣ []
+      ⊢ᴺ I ⊑ I
+      ⦂ (＇ zero ⇒ ＇ zero) ⊑ (＇ zero ⇒ ＇ zero)
+      ∶ matched-body-index
+  matched-body-relation =
+    ƛ⊑ƛᵀ (Types.wfVar z<s) (Types.wfVar z<s)
+      (x⊑xᵀ Types.Z)
+
+  matched-universal-relation :
+    [] ∣ zero ∣ zero ∣ [] ∣ []
+      ⊢ᴺ Λ I ⊑ Λ I
+      ⦂ `∀ (＇ zero ⇒ ＇ zero)
+        ⊑ `∀ (＇ zero ⇒ ＇ zero)
+      ∶ ∀ⁱ matched-body-index
+  matched-universal-relation =
+    Λ⊑Λᵀ lift-store-[] lift-ctx-[]
+      vI vI matched-body-relation
+
+  body-cast-typing :
+    C.instᵈ C.tag-or-idᵈ
+      ∣ suc zero ∣ ((zero , ★) ∷ [])
+      ⊢ body-cast ∶ (＇ zero ⇒ ＇ zero) ⊑ (★ ⇒ ★)
+  body-cast-typing =
+    C.cast-fun
+      (C.cast-seal wf★ (here refl) refl)
+      (C.cast-unseal wf★ (here refl) refl) ,
+    NW.instSafe→widening
+      (NW.safe-fun
+        (NW.sealⁿ ★ zero)
+        (NW.unsealʷ zero ★))
+
+  outer-cast-typing :
+    C.tag-or-idᵈ ∣ zero ∣ []
+      ⊢ C.inst (★ ⇒ ★) body-cast
+        ∶ `∀ (＇ zero ⇒ ＇ zero) ⊑ (★ ⇒ ★)
+  outer-cast-typing =
+    C.cast-inst (wf⇒ wf★ wf★) refl
+      (proj₁ body-cast-typing) ,
+    NW.inst
+      (NW.safe-fun
+        (NW.sealⁿ ★ zero)
+        (NW.unsealʷ zero ★))
+
+  allocated-I-typing :
+    suc zero ∣ ((zero , ★) ∷ []) ∣ []
+      ⊢ I ⦂ (＇ zero ⇒ ＇ zero)
+  allocated-I-typing =
+    ⊢ƛ (Types.wfVar z<s) (⊢` Z)
+
+  source-result-typing :
+    zero ∣ [] ∣ []
+      ⊢ Λ I ⦂ `∀ (＇ zero ⇒ ＇ zero)
+  source-result-typing =
+    ⊢Λ vI (⊢ƛ (Types.wfVar z<s) (⊢` Z))
+
+  target-result-typing :
+    suc zero ∣ ((zero , ★) ∷ []) ∣ []
+      ⊢ I ⟨ body-cast ⟩ ⦂ (★ ⇒ ★)
+  target-result-typing =
+    ⊢⟨⟩⊑ (cast-inst cast-tag-or-id)
+      (seal★-inst seal★-tag-or-id)
+      body-cast-typing allocated-I-typing
+
+
+opened-body-structural-factorization-impossible :
+  ((zero ˣ⊑★) ∷ [])
+    ∣ suc zero
+    ⊢ (＇ zero ⇒ ＇ zero) ⊑ (＇ zero ⇒ ＇ zero)
+    ⊣ suc zero →
+  ⊥
+opened-body-structural-factorization-impossible
+    (domain ↦ codomain)
+    with domain
+... | idˣ (here ()) source-bound target-bound
+... | idˣ (there ()) source-bound target-bound
+
+
+target-instantiation-creation-test :
+  TargetInstantiationCreation
+    {Φ = []} {Δᴸ = zero} {Δᴿ = zero}
+    {ρ₀ = []} {ρ⁺ = []} {ρ∀ = []} {ρᴿ⁺ = []}
+    {W = I} {W′ = I}
+    {B = ★ ⇒ ★}
+    {C = ＇ zero ⇒ ＇ zero}
+    {D = ＇ zero ⇒ ＇ zero}
+    {s = body-cast} {μ = C.tag-or-idᵈ}
+    {r = matched-body-index} {f = final-index}
+    {body-shape = tagˣˢ ↦ˢ tagˣˢ}
+target-instantiation-creation-test =
+  target-instantiation-creation
+    prefix-reflⁱ
+    cast-tag-or-id
+    seal★-tag-or-id
+    outer-cast-typing
+    lift-store-[]
+    lift-right-store-[]
+    vI
+    noI
+    vI
+    noI
+    (C.seal ★ zero C.↦ C.unseal zero ★)
+    matched-body-relation
+    (shape-inst (shape-fun shape-seal shape-unseal))
+    (comp-∀-ν
+      (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-tagˣ))
+    source-result-typing
+    target-result-typing
+
+
+initial-target-instantiation-relation :
+  [] ∣ zero ∣ zero ∣ [] ∣ []
+    ⊢ᴺ Λ I
+      ⊑ (Λ I) ⟨ C.inst (★ ⇒ ★) body-cast ⟩
+    ⦂ `∀ (＇ zero ⇒ ＇ zero) ⊑ (★ ⇒ ★)
+    ∶ final-index
+initial-target-instantiation-relation =
+  ⊑cast⊑ᵀ cast-tag-or-id seal★-tag-or-id
+    outer-cast-typing matched-universal-relation final-index
+    (shape-inst (shape-fun shape-seal shape-unseal))
+    (comp-∀-ν
+      (comp-↦-↦ comp-idˣ-tagˣ comp-idˣ-tagˣ))
+
+
+target-instantiation-administrative-trace :
+  (Λ I) ⟨ C.inst (★ ⇒ ★) body-cast ⟩
+    —↠[ keep ∷ bind ★ ∷ keep ∷ [] ]
+      I ⟨ body-cast ⟩
+target-instantiation-administrative-trace =
+  ↠-step (pure-step (β-inst (Λ vI)))
+    (↠-step
+      (ν-step (Λ vI) (no•-Λ noI))
+      (↠-step
+        (ξ-⟨⟩ (pure-step (β-Λ• vI)))
+        ↠-refl))

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda
@@ -1,0 +1,398 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment
+  where
+
+-- File Charter:
+--   * Shadow-migrates paired-lambda leaf reconstruction and framed universal
+--     fusion to the independent smaller term-imprecision relation.
+--   * Defines a closing-frame spine whose fold constructs every frame with a
+--     smaller ordinary, prefix, conversion, or single-boundary quotient rule.
+--   * Reconstructs exact target-instantiation leaves through canonical
+--     transport before folding any surrounding frames.
+--   * Contains no legacy term-imprecision judgment, postulate, hole,
+--     permissive option, termination bypass, or catch-all clause.
+
+open import CastImprecisionShape using
+  (narrowing; widening; _⊢ᶜ_⦂_)
+open import Coercions using
+  (Coercion; ModeEnv)
+open import Conversion using
+  (ConcealConversion; RevealConversion)
+open import ConversionIndexCompatibility using
+  (_[_↦_]ᴸ_; _[_↦_]ᴿ_; _[_↦_⊑⟨_⟩_↤_]ᴾ_)
+open import Data.List using ([])
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import Imprecision using (ImpCtx)
+open import ImprecisionComposition using
+  (ImprecisionShape; ⌊_⌋; _；_≋_; _；⌊_⌋≋ᵖ_；_)
+open import ImprecisionWf using (_∣_⊢_⊑_⊣_)
+open import NarrowWiden using
+  (_∣_∣_⊢_∶_⊒_; _∣_∣_⊢_∶_⊑_)
+open import NuTermImprecision using
+  ( CtxImp
+  ; StoreCorresponds
+  ; StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  )
+open import NuTerms using
+  (Term; _⟨_⟩)
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  (Ty; TyCtx)
+open import
+  proof.Quotient.NuImprecisionQuotientBoundarySupport
+  using
+  ( ReductionClosedPairedWideningCompatible
+  ; ReductionClosedQuotientWideningCompatible
+  ; SpineCastMode
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( QuotientWideningPairᴿ
+  ; cast⊒⊑ᴿ
+  ; cast⊑⊑ᴿ
+  ; ⊑cast⊒ᴿ
+  ; ⊑cast⊑ᴿ
+  ; conv↑⊑ᴿ
+  ; conv↓⊑ᴿ
+  ; ⊑conv↑ᴿ
+  ; ⊑conv↓ᴿ
+  ; paired-revealᴿ
+  ; paired-concealᴿ
+  ; allocation-prefixᴿ
+  ; closeᴿ
+  ; paired-downᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationConsumerMigrationExperiment
+  using
+  ( CanonicalTargetInstantiationLeafᴿ
+  ; canonical-target-instantiation-leaf-reconstructᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using (StoreImpPrefixᴿ)
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationTransportSpineExperiment
+  using
+  ( TargetInstantiationTransportSpine
+  ; target-instantiation-transport-spine-foldᴿ
+  )
+
+
+data SmallerClosingFramesᴿ
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    (ρ₀ : StoreImp Φ Δᴸ Δᴿ)
+    (L L′ : Term) (A A′ : Ty)
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) :
+    (ρ : StoreImp Φ Δᴸ Δᴿ) →
+    (M M′ : Term) → (B B′ : Ty) →
+    (q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ) → Set₁ where
+
+  frame-reflᴿ :
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ₀ L L′ A A′ p
+
+  frame-prefixᴿ :
+    ∀ {ρ₁ ρ₂ M M′ B B′ q} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ₁ M M′ B B′ q →
+    StoreImpPrefixᴿ ρ₁ ρ₂ →
+    Δᴸ ∣ leftStoreⁱ ρ₂ ∣ [] ⊢ M ⦂ B →
+    Δᴿ ∣ rightStoreⁱ ρ₂ ∣ [] ⊢ M′ ⦂ B′ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ₂ M M′ B B′ q
+
+  frame-source-narrowᴿ :
+    ∀ {ρ M M′ B C B′ q c μ s} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    CastMode μ →
+    SealModeStore★ μ (leftStoreⁱ ρ) →
+    μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ B ⊒ C →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ) →
+    narrowing ⊢ᶜ c ⦂ s →
+    s ； ⌊ q ⌋ ≋ ⌊ r ⌋ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ (M ⟨ c ⟩) M′ C B′ r
+
+  frame-source-widenᴿ :
+    ∀ {ρ M M′ B C B′ q c μ s} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    CastMode μ →
+    SealModeStore★ μ (leftStoreⁱ ρ) →
+    μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ c ∶ B ⊑ C →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ) →
+    widening ⊢ᶜ c ⦂ s →
+    s ； ⌊ r ⌋ ≋ ⌊ q ⌋ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ (M ⟨ c ⟩) M′ C B′ r
+
+  frame-target-narrowᴿ :
+    ∀ {ρ M M′ B B′ C′ q c′ μ′ s′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    CastMode μ′ →
+    SealModeStore★ μ′ (rightStoreⁱ ρ) →
+    μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ B′ ⊒ C′ →
+    (r : Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ Δᴿ) →
+    narrowing ⊢ᶜ c′ ⦂ s′ →
+    ⌊ r ⌋ ； s′ ≋ ⌊ q ⌋ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M (M′ ⟨ c′ ⟩) B C′ r
+
+  frame-target-widenᴿ :
+    ∀ {ρ M M′ B B′ C′ q c′ μ′ s′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    CastMode μ′ →
+    SealModeStore★ μ′ (rightStoreⁱ ρ) →
+    μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ c′ ∶ B′ ⊑ C′ →
+    (r : Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ Δᴿ) →
+    widening ⊢ᶜ c′ ⦂ s′ →
+    ⌊ q ⌋ ； s′ ≋ ⌊ r ⌋ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M (M′ ⟨ c′ ⟩) B C′ r
+
+  frame-source-revealᴿ :
+    ∀ {ρ M M′ B C B′ q c μ α X} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c B C →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ) →
+    q [ α ↦ X ]ᴸ r →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ (M ⟨ c ⟩) M′ C B′ r
+
+  frame-source-concealᴿ :
+    ∀ {ρ M M′ B C B′ q c μ α X} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c B C →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ B′ ⊣ Δᴿ) →
+    r [ α ↦ X ]ᴸ q →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ (M ⟨ c ⟩) M′ C B′ r
+
+  frame-target-revealᴿ :
+    ∀ {ρ M M′ B B′ C′ q c′ μ′ β X′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    RevealConversion μ′ Δᴿ (rightStoreⁱ ρ)
+      β X′ c′ B′ C′ →
+    (r : Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ Δᴿ) →
+    q [ β ↦ X′ ]ᴿ r →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M (M′ ⟨ c′ ⟩) B C′ r
+
+  frame-target-concealᴿ :
+    ∀ {ρ M M′ B B′ C′ q c′ μ′ β X′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ)
+      β X′ c′ B′ C′ →
+    (r : Φ ∣ Δᴸ ⊢ B ⊑ C′ ⊣ Δᴿ) →
+    r [ β ↦ X′ ]ᴿ q →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M (M′ ⟨ c′ ⟩) B C′ r
+
+  frame-paired-revealᴿ :
+    ∀ {ρ M M′ B B′ C C′ q c c′
+        α β X X′ pX μ μ′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    StoreCorresponds ρ α X β X′ pX →
+    RevealConversion μ Δᴸ (leftStoreⁱ ρ) α X c B C →
+    RevealConversion μ′ Δᴿ (rightStoreⁱ ρ)
+      β X′ c′ B′ C′ →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ) →
+    q [ α ↦ X ⊑⟨ pX ⟩ X′ ↤ β ]ᴾ r →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ (M ⟨ c ⟩) (M′ ⟨ c′ ⟩) C C′ r
+
+  frame-paired-concealᴿ :
+    ∀ {ρ M M′ B B′ C C′ q c c′
+        α β X X′ pX μ μ′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    StoreCorresponds ρ α X β X′ pX →
+    ConcealConversion μ Δᴸ (leftStoreⁱ ρ) α X c B C →
+    ConcealConversion μ′ Δᴿ (rightStoreⁱ ρ)
+      β X′ c′ B′ C′ →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ) →
+    r [ α ↦ X ⊑⟨ pX ⟩ X′ ↤ β ]ᴾ q →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ (M ⟨ c ⟩) (M′ ⟨ c′ ⟩) C C′ r
+
+  frame-single-boundaryᴿ :
+    ∀ {ρ M M′ B B′ D D′ C C′ q
+        d d′ u u′ μ μ′ sd sd′ su su′} →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+      ρ M M′ B B′ q →
+    SpineCastMode (leftStoreⁱ ρ) μ →
+    μ ∣ Δᴸ ∣ leftStoreⁱ ρ ⊢ d ∶ B ⊒ D →
+    narrowing ⊢ᶜ d ⦂ sd →
+    SpineCastMode (rightStoreⁱ ρ) μ′ →
+    μ′ ∣ Δᴿ ∣ rightStoreⁱ ρ ⊢ d′ ∶ B′ ⊒ D′ →
+    narrowing ⊢ᶜ d′ ⦂ sd′ →
+    (qD : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ) →
+    sd ；⌊ q ⌋≋ᵖ qD ； sd′ →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ
+      u u′ D D′ C C′ →
+    (r : Φ ∣ Δᴸ ⊢ C ⊑ C′ ⊣ Δᴿ) →
+    widening ⊢ᶜ u ⦂ su →
+    widening ⊢ᶜ u′ ⦂ su′ →
+    su ；⌊ r ⌋≋ᵖ qD ； su′ →
+    ReductionClosedQuotientWideningCompatible
+      Φ Δᴸ Δᴿ u u′ qD r su su′ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A A′ p ρ
+      ((M ⟨ d ⟩) ⟨ u ⟩)
+      ((M′ ⟨ d′ ⟩) ⟨ u′ ⟩)
+      C C′ r
+
+
+smaller-closing-frames-foldᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ : StoreImp Φ Δᴸ Δᴿ}
+    {L L′ M M′ : Term} {A A′ B B′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴿ L ⊑ L′ ⦂ A ⊑ A′ ∶ p →
+  SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+    ρ M M′ B B′ q →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ M ⊑ M′ ⦂ B ⊑ B′ ∶ q
+smaller-closing-frames-foldᴿ relation frame-reflᴿ =
+  relation
+smaller-closing-frames-foldᴿ relation
+    (frame-prefixᴿ frames prefix M⊢ M′⊢) =
+  allocation-prefixᴿ prefix
+    (smaller-closing-frames-foldᴿ relation frames)
+    M⊢ M′⊢
+smaller-closing-frames-foldᴿ relation
+    (frame-source-narrowᴿ
+      frames mode seal★ c⊒ r shape composition) =
+  cast⊒⊑ᴿ mode seal★ c⊒
+    (smaller-closing-frames-foldᴿ relation frames)
+    r shape composition
+smaller-closing-frames-foldᴿ relation
+    (frame-source-widenᴿ
+      frames mode seal★ c⊑ r shape composition) =
+  cast⊑⊑ᴿ mode seal★ c⊑
+    (smaller-closing-frames-foldᴿ relation frames)
+    r shape composition
+smaller-closing-frames-foldᴿ relation
+    (frame-target-narrowᴿ
+      frames mode seal★ c⊒ r shape composition) =
+  ⊑cast⊒ᴿ mode seal★ c⊒
+    (smaller-closing-frames-foldᴿ relation frames)
+    r shape composition
+smaller-closing-frames-foldᴿ relation
+    (frame-target-widenᴿ
+      frames mode seal★ c⊑ r shape composition) =
+  ⊑cast⊑ᴿ mode seal★ c⊑
+    (smaller-closing-frames-foldᴿ relation frames)
+    r shape composition
+smaller-closing-frames-foldᴿ relation
+    (frame-source-revealᴿ frames conversion r replacement) =
+  conv↑⊑ᴿ conversion
+    (smaller-closing-frames-foldᴿ relation frames)
+    r replacement
+smaller-closing-frames-foldᴿ relation
+    (frame-source-concealᴿ frames conversion r replacement) =
+  conv↓⊑ᴿ conversion
+    (smaller-closing-frames-foldᴿ relation frames)
+    r replacement
+smaller-closing-frames-foldᴿ relation
+    (frame-target-revealᴿ frames conversion r replacement) =
+  ⊑conv↑ᴿ conversion
+    (smaller-closing-frames-foldᴿ relation frames)
+    r replacement
+smaller-closing-frames-foldᴿ relation
+    (frame-target-concealᴿ frames conversion r replacement) =
+  ⊑conv↓ᴿ conversion
+    (smaller-closing-frames-foldᴿ relation frames)
+    r replacement
+smaller-closing-frames-foldᴿ relation
+    (frame-paired-revealᴿ
+      frames corresponds source target r replacement) =
+  paired-revealᴿ corresponds source target replacement
+    (smaller-closing-frames-foldᴿ relation frames)
+smaller-closing-frames-foldᴿ relation
+    (frame-paired-concealᴿ
+      frames corresponds source target r replacement) =
+  paired-concealᴿ corresponds source target replacement
+    (smaller-closing-frames-foldᴿ relation frames)
+smaller-closing-frames-foldᴿ relation
+    (frame-single-boundaryᴿ
+      frames source-mode d⊒ d-shape target-mode d′⊒ d′-shape
+      qD down-square widening-pair r u-shape u′-shape
+      up-square compatible) =
+  closeᴿ
+    (paired-downᴿ
+      (smaller-closing-frames-foldᴿ relation frames)
+      source-mode d⊒ d-shape target-mode d′⊒ d′-shape
+      down-square)
+    widening-pair u-shape u′-shape up-square compatible
+
+
+canonical-leaf-with-frames-reconstructᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ : StoreImp Φ Δᴸ Δᴿ}
+    {L L′ M M′ : Term} {A A′ B B′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+    {q : Φ ∣ Δᴸ ⊢ B ⊑ B′ ⊣ Δᴿ} →
+  CanonicalTargetInstantiationLeafᴿ ρ₀ L L′ A A′ p →
+  SmallerClosingFramesᴿ ρ₀ L L′ A A′ p
+    ρ M M′ B B′ q →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ M ⊑ M′ ⦂ B ⊑ B′ ∶ q
+canonical-leaf-with-frames-reconstructᴿ leaf frames =
+  smaller-closing-frames-foldᴿ
+    (canonical-target-instantiation-leaf-reconstructᴿ leaf)
+    frames
+
+
+data FramedTargetUniversalFusionSpineᴿ
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    (ρ : StoreImp Φ Δᴸ Δᴿ) :
+    (M M′ : Term) → (A A′ : Ty) →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) → Set₁ where
+
+  framed-fusion-pureᴿ :
+    ∀ {ρ₀ L L′ A₀ A₀′ p₀ M M′ A A′ p} →
+    TargetInstantiationTransportSpine ρ₀ L L′ A₀ A₀′ p₀ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A₀ A₀′ p₀
+      ρ M M′ A A′ p →
+    FramedTargetUniversalFusionSpineᴿ ρ M M′ A A′ p
+
+  framed-fusion-creationᴿ :
+    ∀ {ρ₀ L L′ A₀ A₀′ p₀ M M′ A A′ p} →
+    CanonicalTargetInstantiationLeafᴿ ρ₀ L L′ A₀ A₀′ p₀ →
+    SmallerClosingFramesᴿ ρ₀ L L′ A₀ A₀′ p₀
+      ρ M M′ A A′ p →
+    FramedTargetUniversalFusionSpineᴿ ρ M M′ A A′ p
+
+
+framed-target-universal-fusion-spine-foldᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A A′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  FramedTargetUniversalFusionSpineᴿ ρ M M′ A A′ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+framed-target-universal-fusion-spine-foldᴿ
+    (framed-fusion-pureᴿ pure frames) =
+  smaller-closing-frames-foldᴿ
+    (target-instantiation-transport-spine-foldᴿ pure)
+    frames
+framed-target-universal-fusion-spine-foldᴿ
+    (framed-fusion-creationᴿ leaf frames) =
+  canonical-leaf-with-frames-reconstructᴿ leaf frames

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationSimulationExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationSimulationExperiment.agda
@@ -1,0 +1,295 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationSimulationExperiment
+  where
+
+-- File Charter:
+--   * Tests one complete target-leading simulation slice for the independent
+--     smaller term-imprecision relation.
+--   * Starts from a target instantiation cast, exposes its leading beta step,
+--     follows allocation and type beta, and constructs the exact final
+--     creation edge in the right-extended relational store.
+--   * Packages the initial and final typing projections, store-change
+--     equations, endpoint values, and value-based terminal inversions.
+--   * Restricts the creation prefix to reflexivity; arbitrary pre-allocation
+--     store growth remains a separate simulation-design question.
+--   * Contains no legacy term-imprecision judgment, postulate, hole,
+--     permissive option, termination bypass, or catch-all clause.
+
+open import Data.Empty using (⊥)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (suc; zero)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+
+open import Coercions using (Coercion; ModeEnv; Inert; inst)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑ˣ_; ⇑ᵢ; ⇑ᴿᵢ)
+open import ImprecisionComposition using
+  (ImprecisionShape; νˢ_; ⌊_⌋; _；_≋_)
+open import ImprecisionWf using
+  (_∣_⊢_⊑_⊣_; ∀ⁱ_)
+open import NuReduction using
+  ( StoreChanges
+  ; applyStores
+  ; applyTyCtxs
+  ; applyTys
+  ; bind
+  ; keep
+  ; pure-step
+  ; β-inst
+  ; ↠-refl
+  ; ↠-step
+  ; _—→[_]_
+  ; _—↠[_]_
+  )
+open import NuTermImprecision using
+  ( LiftRightStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; leftStoreⁱ
+  ; leftStoreⁱ-lift-right
+  ; lift-ctx-[]
+  ; rightStoreⁱ
+  ; rightStoreⁱ-lift-right
+  ; store-right
+  )
+open import NuTerms using
+  (No•; Term; Value; Λ_; _⟨_⟩; ν)
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  (Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ)
+open import
+  proof.Target.Administration.NuImprecisionTargetPendingLambdaAllocationTraceProof
+  using (target-pending-lambda-allocation-trace-proofᵀ)
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using (⊑-target-lift-rightᵢ)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( Λ⊑Λᴿ
+  ; target-instantiationᴿ
+  ; ⊑cast⊑ᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using (TargetInstantiationCreation; exact-creationᴱ)
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientTypingExperiment
+  using
+  ( smaller-imprecision-source-typingᴿ
+  ; smaller-imprecision-target-typingᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientValueExperiment
+  using
+  ( target-instantiation-creation-source-no-stepᴿ
+  ; target-instantiation-creation-target-no-stepᴿ
+  ; target-instantiation-creation-valuesᴿ
+  )
+
+
+private
+  target-instantiation-changes : StoreChanges
+  target-instantiation-changes = keep ∷ bind ★ ∷ keep ∷ []
+
+
+record TargetInstantiationSimulationSliceᴿ
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      (suc Δᴸ) (suc Δᴿ)}
+    {ρᴿ : StoreImp (⇑ᴿᵢ Φ) Δᴸ (suc Δᴿ)}
+    {W W′ : Term} {B C D : Ty} {s : Coercion} {μ : ModeEnv}
+    {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+      ∣ suc Δᴸ ⊢ D ⊑ C ⊣ suc Δᴿ}
+    {f : Φ ∣ Δᴸ ⊢ `∀ D ⊑ B ⊣ Δᴿ}
+    {body-shape : ImprecisionShape}
+    (creation :
+      TargetInstantiationCreation
+        {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+        {ρ₀ = ρ₀} {ρ⁺ = ρ₀} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+        {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+        {s = s} {μ = μ} {r = r} {f = f}
+        {body-shape = body-shape}
+        (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+          ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r)) : Set₁ where
+  field
+    initial-source-typing :
+      Δᴸ ∣ leftStoreⁱ ρ₀ ∣ [] ⊢ Λ W ⦂ `∀ D
+
+    initial-target-typing :
+      Δᴿ ∣ rightStoreⁱ ρ₀ ∣ []
+        ⊢ (Λ W′) ⟨ inst B s ⟩ ⦂ B
+
+    initial-imprecision :
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+        ⊢ᴿ Λ W ⊑ (Λ W′) ⟨ inst B s ⟩
+        ⦂ `∀ D ⊑ B ∶ f
+
+    source-reduction :
+      Λ W —↠[ [] ] Λ W
+
+    leading-target-step :
+      (Λ W′) ⟨ inst B s ⟩ —→[ keep ] ν ★ (Λ W′) s
+
+    target-administrative-tail :
+      ν ★ (Λ W′) s
+        —↠[ bind ★ ∷ keep ∷ [] ]
+        W′ ⟨ s ⟩
+
+    target-reduction :
+      (Λ W′) ⟨ inst B s ⟩
+        —↠[ target-instantiation-changes ]
+        W′ ⟨ s ⟩
+
+    source-store-change :
+      leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ) ≡
+      applyStores [] (leftStoreⁱ ρ₀)
+
+    target-store-change :
+      rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ) ≡
+      applyStores target-instantiation-changes (rightStoreⁱ ρ₀)
+
+    source-context-change :
+      Δᴸ ≡ applyTyCtxs [] Δᴸ
+
+    target-context-change :
+      suc Δᴿ ≡ applyTyCtxs target-instantiation-changes Δᴿ
+
+    source-type-change :
+      `∀ D ≡ applyTys [] (`∀ D)
+
+    target-type-change :
+      ⇑ᵗ B ≡ applyTys target-instantiation-changes B
+
+    final-source-typing :
+      Δᴸ
+        ∣ leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ)
+        ∣ [] ⊢ Λ W ⦂ `∀ D
+
+    final-target-typing :
+      suc Δᴿ
+        ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ)
+        ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B
+
+    final-imprecision :
+      ⇑ᴿᵢ Φ
+        ∣ Δᴸ ∣ suc Δᴿ
+        ∣ store-right zero ★ wf★ ∷ ρᴿ ∣ []
+        ⊢ᴿ Λ W ⊑ W′ ⟨ s ⟩
+        ⦂ `∀ D ⊑ ⇑ᵗ B
+        ∶ ⊑-target-lift-rightᵢ f
+
+    final-source-value : Value (Λ W)
+    final-target-value : Value (W′ ⟨ s ⟩)
+
+    final-source-no-step :
+      ∀ {χ N} → Λ W —→[ χ ] N → ⊥
+
+    final-target-no-step :
+      ∀ {χ N′} → W′ ⟨ s ⟩ —→[ χ ] N′ → ⊥
+
+
+target-instantiation-initial-imprecisionᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ∀ ρᴿ W W′ B C D s μ r f body-shape} →
+  (creation :
+    TargetInstantiationCreation
+      {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ₀} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+        ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r)) →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ []
+    ⊢ᴿ Λ W ⊑ (Λ W′) ⟨ inst B s ⟩
+    ⦂ `∀ D ⊑ B ∶ f
+target-instantiation-initial-imprecisionᴿ creation =
+  ⊑cast⊑ᴿ
+    (TargetInstantiationCreation.cast-mode creation)
+    (TargetInstantiationCreation.seal-mode creation)
+    (TargetInstantiationCreation.instantiation-typing creation)
+    (Λ⊑Λᴿ
+      (TargetInstantiationCreation.matched-store-lift creation)
+      lift-ctx-[]
+      (TargetInstantiationCreation.source-body-value creation)
+      (TargetInstantiationCreation.target-body-value creation)
+      (TargetInstantiationCreation.matched-body-relation creation))
+    _
+    (TargetInstantiationCreation.instantiation-shape creation)
+    (TargetInstantiationCreation.index-composition creation)
+
+
+target-instantiation-simulation-sliceᴿ :
+  ∀ {Φ Δᴸ Δᴿ ρ₀ ρ∀ ρᴿ W W′ B C D s μ r f body-shape}
+    {creation :
+      TargetInstantiationCreation
+        {Φ = Φ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+        {ρ₀ = ρ₀} {ρ⁺ = ρ₀} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ}
+        {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+        {s = s} {μ = μ} {r = r} {f = f}
+        {body-shape = body-shape}
+        (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+          ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ∀ ∣ []
+          ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r)} →
+  TargetInstantiationSimulationSliceᴿ creation
+target-instantiation-simulation-sliceᴿ
+    {creation = creation} =
+  record
+    { initial-source-typing =
+        smaller-imprecision-source-typingᴿ initial-edge
+    ; initial-target-typing =
+        smaller-imprecision-target-typingᴿ initial-edge
+    ; initial-imprecision = initial-edge
+    ; source-reduction = ↠-refl
+    ; leading-target-step =
+        pure-step
+          (β-inst
+            (Λ (TargetInstantiationCreation.target-body-value creation)))
+    ; target-administrative-tail =
+        target-pending-lambda-allocation-trace-proofᵀ
+          {cs = []}
+          (TargetInstantiationCreation.target-body-value creation)
+          (TargetInstantiationCreation.target-body-no-bullet creation)
+    ; target-reduction =
+        ↠-step
+          (pure-step
+            (β-inst
+              (Λ (TargetInstantiationCreation.target-body-value creation))))
+          (target-pending-lambda-allocation-trace-proofᵀ
+            {cs = []}
+            (TargetInstantiationCreation.target-body-value creation)
+            (TargetInstantiationCreation.target-body-no-bullet creation))
+    ; source-store-change =
+        leftStoreⁱ-lift-right
+          (TargetInstantiationCreation.right-store-lift creation)
+    ; target-store-change =
+        cong ((zero , ★) ∷_)
+          (rightStoreⁱ-lift-right
+            (TargetInstantiationCreation.right-store-lift creation))
+    ; source-context-change = refl
+    ; target-context-change = refl
+    ; source-type-change = refl
+    ; target-type-change = refl
+    ; final-source-typing =
+        TargetInstantiationCreation.source-result-typing creation
+    ; final-target-typing =
+        TargetInstantiationCreation.target-result-typing creation
+    ; final-imprecision =
+        target-instantiationᴿ (exact-creationᴱ creation)
+    ; final-source-value =
+        proj₁ (target-instantiation-creation-valuesᴿ creation)
+    ; final-target-value =
+        proj₂ (target-instantiation-creation-valuesᴿ creation)
+    ; final-source-no-step =
+        target-instantiation-creation-source-no-stepᴿ creation
+    ; final-target-no-step =
+        target-instantiation-creation-target-no-stepᴿ creation
+    }
+  where
+    initial-edge = target-instantiation-initial-imprecisionᴿ creation

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
@@ -1,0 +1,147 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationTransportExperiment
+  where
+
+-- File Charter:
+--   * Tests whether exact target-instantiation creation recovers the
+--     generalized renamed/store-embedded behavior needed by fusion clients.
+--   * Proves the canonical transported result from the exact creation
+--     constructor and the relation-wide closed-endpoint transport rule.
+--   * Keeps arbitrary endpoint reindexing out of the experiment: the final
+--     index is the canonical renaming of the exact creation index.
+--   * Imports no legacy term-imprecision judgment and contains no postulate,
+--     hole, permissive option, or termination bypass.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (suc; zero)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑ˣ_; ⇑ᵢ; ⇑ᴿᵢ)
+open import ImprecisionComposition using (ImprecisionShape)
+open import ImprecisionWf using
+  (ImpAssm; _∣_⊢_⊑_⊣_)
+open import NuTermImprecision using
+  (StoreImp; leftStoreⁱ; rightStoreⁱ; store-right)
+open import NuTerms using
+  (Term; Λ_; _⟨_⟩; renameᵗᵐ)
+open import TermTyping using (_∣_∣_⊢_⦂_)
+open import Types using
+  (Renameᵗ; Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ; renameᵗ)
+open import Relation.Binary.PropositionalEquality using (sym)
+open import
+  proof.Core.Properties.TypeProperties
+  using (TyRenameWf)
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using
+  ( rename-assm²ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-renameᵗ²ᵢ
+  ; ⊑-target-lift-rightᵢ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( rename-storeᴿ
+  ; target-instantiationᴿ
+  ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using (TargetInstantiationCreation)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+  using (RelStoreEmbeddingⁱ)
+
+
+target-instantiation-canonical-transportᴿ :
+  ∀ {Φ₀ : ImpCtx} {Θᴸ Θᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+      (suc Θᴸ) (suc Θᴿ)}
+    {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+    {W W′ : Term} {B C D : Ty} {s μ r f}
+    {body-shape : ImprecisionShape}
+    {Ψ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Ψ Δᴸ Δᴿ}
+    {τ σ : Renameᵗ} →
+  TargetInstantiationCreation
+    {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+      ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
+      ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r) →
+  (assm :
+    ∀ {a : ImpAssm} → a ∈ ⇑ᴿᵢ Φ₀ →
+      rename-assm²ᵢ τ σ a ∈ Ψ) →
+  (hτ : TyRenameWf Θᴸ Δᴸ τ) →
+  (hσ : TyRenameWf (suc Θᴿ) Δᴿ σ) →
+  RelStoreEmbeddingⁱ τ σ
+    (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ []
+    ⊢ renameᵗᵐ τ (Λ W) ⦂ renameᵗ τ (`∀ D) →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ []
+    ⊢ renameᵗᵐ σ (W′ ⟨ s ⟩) ⦂ renameᵗ σ (⇑ᵗ B) →
+  Ψ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ renameᵗᵐ τ (Λ W) ⊑ renameᵗᵐ σ (W′ ⟨ s ⟩)
+    ⦂ renameᵗ τ (`∀ D) ⊑ renameᵗ σ (⇑ᵗ B)
+    ∶ ⊑-renameᵗ²ᵢ assm hτ hσ
+        (⊑-target-lift-rightᵢ f)
+target-instantiation-canonical-transportᴿ
+    creation assm hτ hσ store-embedding
+    source-typing target-typing =
+  rename-storeᴿ assm hτ hσ store-embedding
+    (target-instantiationᴿ creation)
+    source-typing target-typing
+
+
+target-instantiation-endpoint-transportᴿ :
+  ∀ {Φ₀ : ImpCtx} {Θᴸ Θᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+    {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+      (suc Θᴸ) (suc Θᴿ)}
+    {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+    {W W′ : Term} {B C D : Ty} {s μ r f}
+    {body-shape : ImprecisionShape}
+    {Ψ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Ψ Δᴸ Δᴿ}
+    {τ σ : Renameᵗ}
+    {M M′ : Term} {A A′ : Ty}
+    {p : Ψ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  TargetInstantiationCreation
+    {Φ = Φ₀} {Δᴸ = Θᴸ} {Δᴿ = Θᴿ}
+    {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+    {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+    {s = s} {μ = μ} {r = r} {f = f}
+    {body-shape = body-shape}
+    (((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+      ∣ suc Θᴸ ∣ suc Θᴿ ∣ ρ∀ ∣ []
+      ⊢ᴿ W ⊑ W′ ⦂ D ⊑ C ∶ r) →
+  (assm :
+    ∀ {a : ImpAssm} → a ∈ ⇑ᴿᵢ Φ₀ →
+      rename-assm²ᵢ τ σ a ∈ Ψ) →
+  (hτ : TyRenameWf Θᴸ Δᴸ τ) →
+  (hσ : TyRenameWf (suc Θᴿ) Δᴿ σ) →
+  RelStoreEmbeddingⁱ τ σ
+    (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ →
+  renameᵗᵐ τ (Λ W) ≡ M →
+  renameᵗᵐ σ (W′ ⟨ s ⟩) ≡ M′ →
+  (source-type-eq : renameᵗ τ (`∀ D) ≡ A) →
+  (target-type-eq : renameᵗ σ (⇑ᵗ B) ≡ A′) →
+  ⊑-rename-at²ᵢ assm hτ hσ
+    (sym source-type-eq) (sym target-type-eq)
+    (⊑-target-lift-rightᵢ f) ≡ p →
+  Δᴸ ∣ leftStoreⁱ ρ ∣ [] ⊢ M ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ M′ ⦂ A′ →
+  Ψ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+target-instantiation-endpoint-transportᴿ
+    creation assm hτ hσ store-embedding
+    refl refl refl refl refl source-typing target-typing =
+  target-instantiation-canonical-transportᴿ
+    creation assm hτ hσ store-embedding
+    source-typing target-typing

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
@@ -5,8 +5,8 @@ module
 -- File Charter:
 --   * Tests whether exact target-instantiation creation recovers the
 --     generalized renamed/store-embedded behavior needed by fusion clients.
---   * Proves the canonical result using the creation-specific transported
---     constructor; the smaller relation has no generic renaming closure.
+--   * Proves the canonical result by composing the sole embedded-creation
+--     residual; the term grammar has no transported creation constructor.
 --   * Keeps arbitrary endpoint reindexing out of the experiment: the final
 --     index is the canonical renaming of the exact creation index.
 --   * Imports no legacy term-imprecision judgment and contains no postulate,
@@ -43,12 +43,16 @@ open import
 open import
   proof.Quotient.NuImprecisionReductionClosedQuotientDef
   using
-  ( target-instantiation-transportᴿ
+  ( target-instantiationᴿ
   ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
   )
 open import
   proof.Quotient.NuImprecisionTargetInstantiationCreationDef
-  using (TargetInstantiationCreation)
+  using
+  ( TargetInstantiationCreation
+  ; embed-creationᴱ
+  ; exact-creationᴱ
+  )
 open import
   proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
   using (RelStoreEmbeddingⁱ)
@@ -93,9 +97,11 @@ target-instantiation-canonical-transportᴿ :
 target-instantiation-canonical-transportᴿ
     creation assm hτ hσ store-embedding
     source-typing target-typing =
-  target-instantiation-transportᴿ
-    creation assm hτ hσ store-embedding
-    source-typing target-typing
+  target-instantiationᴿ
+    (embed-creationᴱ
+      (exact-creationᴱ creation)
+      assm hτ hσ store-embedding
+      source-typing target-typing)
 
 
 target-instantiation-endpoint-transportᴿ :

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportExperiment.agda
@@ -5,8 +5,8 @@ module
 -- File Charter:
 --   * Tests whether exact target-instantiation creation recovers the
 --     generalized renamed/store-embedded behavior needed by fusion clients.
---   * Proves the canonical transported result from the exact creation
---     constructor and the relation-wide closed-endpoint transport rule.
+--   * Proves the canonical result using the creation-specific transported
+--     constructor; the smaller relation has no generic renaming closure.
 --   * Keeps arbitrary endpoint reindexing out of the experiment: the final
 --     index is the canonical renaming of the exact creation index.
 --   * Imports no legacy term-imprecision judgment and contains no postulate,
@@ -43,8 +43,7 @@ open import
 open import
   proof.Quotient.NuImprecisionReductionClosedQuotientDef
   using
-  ( rename-storeᴿ
-  ; target-instantiationᴿ
+  ( target-instantiation-transportᴿ
   ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
   )
 open import
@@ -94,8 +93,8 @@ target-instantiation-canonical-transportᴿ :
 target-instantiation-canonical-transportᴿ
     creation assm hτ hσ store-embedding
     source-typing target-typing =
-  rename-storeᴿ assm hτ hσ store-embedding
-    (target-instantiationᴿ creation)
+  target-instantiation-transportᴿ
+    creation assm hτ hσ store-embedding
     source-typing target-typing
 
 

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportSpineExperiment.agda
@@ -1,0 +1,169 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationTransportSpineExperiment
+  where
+
+-- File Charter:
+--   * Tests finite nesting of exact target-instantiation creation followed by
+--     endpoint renaming and relational-store embedding.
+--   * Strengthens every transported step with equality between its final
+--     imprecision index and the canonical transported creation index.
+--   * Folds the strengthened spine into the independent smaller relation.
+--   * Imports no legacy term-imprecision judgment and contains no postulate,
+--     hole, permissive option, termination bypass, or catch-all clause.
+
+open import Agda.Builtin.Equality using (_≡_)
+open import CastImprecisionShape using (_⊢ᶜ_⦂_; widening)
+open import Coercions using (Coercion; Inert; ModeEnv; inst)
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (suc; zero)
+open import Imprecision using
+  (ImpCtx; _ˣ⊑ˣ_; ⇑ᵢ; ⇑ᴿᵢ)
+open import ImprecisionComposition using
+  (ImprecisionShape; νˢ_; ⌊_⌋; _；_≋_)
+open import ImprecisionWf using
+  (ImpAssm; _∣_⊢_⊑_⊣_; ∀ⁱ_)
+open import NarrowWiden using (_∣_∣_⊢_∶_⊑_)
+open import NuTermImprecision using
+  ( LiftRightStoreⁱ
+  ; LiftStoreⁱ
+  ; StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  ; store-right
+  )
+open import NuTerms using
+  (No•; Term; Value; Λ_; _⟨_⟩; renameᵗᵐ)
+open import TermTyping using
+  (CastMode; SealModeStore★; _∣_∣_⊢_⦂_)
+open import Types using
+  (Renameᵗ; Ty; TyCtx; ★; wf★; `∀; ⇑ᵗ; renameᵗ)
+open import Relation.Binary.PropositionalEquality using (sym)
+open import
+  proof.Core.Properties.TypeProperties
+  using (TyRenameWf)
+open import
+  proof.EndpointMLB.Core.MaximalLowerBoundsWf
+  using
+  ( rename-assm²ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-target-lift-rightᵢ
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+  using
+  ( _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  ( StoreImpPrefixᴿ
+  ; TargetInstantiationCreation
+  ; target-instantiation-creation
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationTransportExperiment
+  using (target-instantiation-endpoint-transportᴿ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+  using (RelStoreEmbeddingⁱ)
+
+
+data TargetInstantiationTransportSpine
+    {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    (ρ : StoreImp Φ Δᴸ Δᴿ) :
+    (M M′ : Term) → (A A′ : Ty) →
+    (p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ) → Set₁ where
+
+  related-base :
+    ∀ {M M′ A A′ p} →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p →
+    TargetInstantiationTransportSpine ρ M M′ A A′ p
+
+  creation-step :
+    ∀ {Φ₀ : ImpCtx} {Θᴸ Θᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ₀ Θᴸ Θᴿ}
+      {ρ∀ : StoreImp ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+        (suc Θᴸ) (suc Θᴿ)}
+      {ρᴿ⁺ : StoreImp (⇑ᴿᵢ Φ₀) Θᴸ (suc Θᴿ)}
+      {τ σ : Renameᵗ}
+      {W W′ M M′ : Term}
+      {A A′ B C D : Ty}
+      {s : Coercion} {μ : ModeEnv}
+      {r : ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀)
+        ∣ suc Θᴸ ⊢ D ⊑ C ⊣ suc Θᴿ}
+      {f : Φ₀ ∣ Θᴸ ⊢ `∀ D ⊑ B ⊣ Θᴿ}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ}
+      {body-shape : ImprecisionShape} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    CastMode μ →
+    SealModeStore★ μ (rightStoreⁱ ρ₀) →
+    μ ∣ Θᴿ ∣ rightStoreⁱ ρ₀
+      ⊢ inst B s ∶ `∀ C ⊑ B →
+    LiftStoreⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ₀) ρ₀ ρ∀ →
+    LiftRightStoreⁱ (⇑ᴿᵢ Φ₀) ρ⁺ ρᴿ⁺ →
+    Value W →
+    No• W →
+    Value W′ →
+    No• W′ →
+    Inert s →
+    TargetInstantiationTransportSpine ρ∀ W W′ D C r →
+    widening ⊢ᶜ inst B s ⦂ νˢ body-shape →
+    ⌊ ∀ⁱ r ⌋ ； νˢ body-shape ≋ ⌊ f ⌋ →
+    Θᴸ
+      ∣ leftStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+      ∣ [] ⊢ Λ W ⦂ `∀ D →
+    suc Θᴿ
+      ∣ rightStoreⁱ (store-right zero ★ wf★ ∷ ρᴿ⁺)
+      ∣ [] ⊢ W′ ⟨ s ⟩ ⦂ ⇑ᵗ B →
+    (assm :
+      ∀ {a : ImpAssm} → a ∈ ⇑ᴿᵢ Φ₀ →
+        rename-assm²ᵢ τ σ a ∈ Φ) →
+    (hτ : TyRenameWf Θᴸ Δᴸ τ) →
+    (hσ : TyRenameWf (suc Θᴿ) Δᴿ σ) →
+    RelStoreEmbeddingⁱ τ σ
+      (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ →
+    (source-eq : renameᵗᵐ τ (Λ W) ≡ M) →
+    (target-eq : renameᵗᵐ σ (W′ ⟨ s ⟩) ≡ M′) →
+    (source-type-eq : renameᵗ τ (`∀ D) ≡ A) →
+    (target-type-eq : renameᵗ σ (⇑ᵗ B) ≡ A′) →
+    ⊑-rename-at²ᵢ assm hτ hσ
+      (sym source-type-eq) (sym target-type-eq)
+      (⊑-target-lift-rightᵢ f) ≡ p →
+    Δᴸ ∣ leftStoreⁱ ρ ∣ [] ⊢ M ⦂ A →
+    Δᴿ ∣ rightStoreⁱ ρ ∣ [] ⊢ M′ ⦂ A′ →
+    TargetInstantiationTransportSpine ρ M M′ A A′ p
+
+
+target-instantiation-transport-spine-foldᴿ :
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ : StoreImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A A′ : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ A′ ⊣ Δᴿ} →
+  TargetInstantiationTransportSpine ρ M M′ A A′ p →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ []
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ A′ ∶ p
+target-instantiation-transport-spine-foldᴿ (related-base relation) =
+  relation
+target-instantiation-transport-spine-foldᴿ
+    (creation-step
+      prefix mode seal-mode inst-typing matched-store-lift
+      right-store-lift source-value source-no-bullet
+      target-value target-no-bullet inert tail
+      inst-shape index-composition
+      canonical-source-typing canonical-target-typing
+      assm hτ hσ store-embedding
+      source-eq target-eq source-type-eq target-type-eq
+      index-eq source-typing target-typing) =
+  target-instantiation-endpoint-transportᴿ
+    (target-instantiation-creation
+      prefix mode seal-mode inst-typing matched-store-lift
+      right-store-lift source-value source-no-bullet
+      target-value target-no-bullet inert
+      (target-instantiation-transport-spine-foldᴿ tail)
+      inst-shape index-composition
+      canonical-source-typing canonical-target-typing)
+    assm hτ hσ store-embedding
+    source-eq target-eq source-type-eq target-type-eq
+    index-eq source-typing target-typing

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportTerminalExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationTransportTerminalExperiment.agda
@@ -1,0 +1,69 @@
+module
+  proof.Quotient.NuImprecisionTargetInstantiationTransportTerminalExperiment
+  where
+
+-- File Charter:
+--   * Proves that exact and canonically transported target-instantiation
+--     creation endpoints are values and therefore cannot take a leading step.
+--   * Discharges the new source- and target-simulation cases introduced by
+--     the creation-specific transported constructor.
+--   * Imports no legacy term-imprecision judgment and contains no postulate,
+--     hole, permissive option, termination bypass, or catch-all clause.
+
+open import Data.Empty using (⊥)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Coercions using (Inert)
+open import NuReduction using (_—→[_]_)
+open import NuTerms using
+  (Term; Value; Λ_; _⟨_⟩; renameᵗᵐ)
+open import Types using (Renameᵗ)
+open import proof.Core.Properties.NuTermProperties using
+  (renameᵗᵐ-preserves-Value)
+open import proof.DGG.Core.NuPreservation using (value-no-step)
+
+
+target-instantiation-transport-valuesᴿ :
+  ∀ {W W′ s} →
+  (τ σ : Renameᵗ) →
+  Value W →
+  Value W′ →
+  Inert s →
+  Value (renameᵗᵐ τ (Λ W)) ×
+  Value (renameᵗᵐ σ (W′ ⟨ s ⟩))
+target-instantiation-transport-valuesᴿ τ σ vW vW′ inert =
+  renameᵗᵐ-preserves-Value τ (Λ vW) ,
+  renameᵗᵐ-preserves-Value σ (vW′ ⟨ inert ⟩)
+
+
+target-instantiation-transport-source-no-stepᴿ :
+  ∀ {W W′ s χ N} →
+  (τ σ : Renameᵗ) →
+  (vW : Value W) →
+  (vW′ : Value W′) →
+  (inert : Inert s) →
+  renameᵗᵐ τ (Λ W) —→[ χ ] N →
+  ⊥
+target-instantiation-transport-source-no-stepᴿ
+    τ σ vW vW′ inert source-step =
+  value-no-step
+    (proj₁
+      (target-instantiation-transport-valuesᴿ
+        τ σ vW vW′ inert))
+    source-step
+
+
+target-instantiation-transport-target-no-stepᴿ :
+  ∀ {W W′ s χ N′} →
+  (τ σ : Renameᵗ) →
+  (vW : Value W) →
+  (vW′ : Value W′) →
+  (inert : Inert s) →
+  renameᵗᵐ σ (W′ ⟨ s ⟩) —→[ χ ] N′ →
+  ⊥
+target-instantiation-transport-target-no-stepᴿ
+    τ σ vW vW′ inert target-step =
+  value-no-step
+    (proj₂
+      (target-instantiation-transport-valuesᴿ
+        τ σ vW vW′ inert))
+    target-step

--- a/GTSF/proof/Source/Core/NuImprecisionSourceSilentCompositionProof.agda
+++ b/GTSF/proof/Source/Core/NuImprecisionSourceSilentCompositionProof.agda
@@ -74,8 +74,10 @@ open import proof.Core.Properties.ConversionIndexCompatibilityProperties using
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.NuCore.Relations.NuImprecisionContextExclusivityDef using
   (SourceNameExclusive)
 open import proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDef using

--- a/GTSF/proof/Store/Lineage/NuImprecisionWeakOneStepStoreLineageProof.agda
+++ b/GTSF/proof/Store/Lineage/NuImprecisionWeakOneStepStoreLineageProof.agda
@@ -20,8 +20,10 @@ open import NuTermImprecision using (StoreImp)
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Catchup.Simulation.NuImprecisionSimulationCore using
   ( weak-one-step-composeᵀ
   ; weak-one-step-prepend-left-silentᵀ

--- a/GTSF/proof/Store/RelEmbedding/NuImprecisionRelStoreEmbeddingAlgebra.agda
+++ b/GTSF/proof/Store/RelEmbedding/NuImprecisionRelStoreEmbeddingAlgebra.agda
@@ -1,9 +1,10 @@
 module proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra where
 
 -- File Charter:
---   * Proves prefix restriction and composition for relational-store
---     embeddings.
---   * Provides the focused algebra needed to compose weak-result lineage.
+--   * Proves reflexivity, congruence, type-binder lifting, and composition for
+--     relational-store embeddings.
+--   * Remains independent of every term-imprecision and store-prefix
+--     judgment; prefix inversion lives in its focused companion module.
 --   * Contains no simulation result, catch-up, or semantic dispatcher proof.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
@@ -36,11 +37,6 @@ open import NuTermImprecision using
   ; store-link
   ; store-matched
   ; store-right
-  )
-open import QuotientedTermImprecision using
-  ( StoreImpPrefix
-  ; prefix-reflⁱ
-  ; prefix-∷ⁱ
   )
 open import Types using (Renameᵗ; renameᵗ)
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
@@ -199,51 +195,6 @@ rel-store-embedding-congⁱ eqτ eqσ
     (trans eqB (rename-cong eqσ _))
     shape-eq
     (rel-store-embedding-congⁱ eqτ eqσ emb)
-
-
-rel-store-embedding-prefix-invⁱ :
-  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
-    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
-    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ} →
-  StoreImpPrefix ρ₀ ρ⁺ →
-  RelStoreEmbeddingⁱ τ σ ρ⁺ ρ′⁺ →
-  ∃[ ρ₀′ ]
-    RelStoreEmbeddingⁱ τ σ ρ₀ ρ₀′ ×
-    StoreImpPrefix ρ₀′ ρ′⁺
-rel-store-embedding-prefix-invⁱ prefix-reflⁱ emb =
-  _ , emb , prefix-reflⁱ
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-matched
-      eqα eqA eqβ eqB shape-eq emb)
-    with rel-store-embedding-prefix-invⁱ prefix emb
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-matched
-      eqα eqA eqβ eqB shape-eq emb)
-    | ρ₀′ , emb₀ , prefix′ =
-  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-left eqα eqA emb)
-    with rel-store-embedding-prefix-invⁱ prefix emb
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-left eqα eqA emb)
-    | ρ₀′ , emb₀ , prefix′ =
-  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-right eqβ eqB emb)
-    with rel-store-embedding-prefix-invⁱ prefix emb
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-right eqβ eqB emb)
-    | ρ₀′ , emb₀ , prefix′ =
-  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-link
-      eqα eqA eqβ eqB shape-eq emb)
-    with rel-store-embedding-prefix-invⁱ prefix emb
-rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
-    (rel-store-embedding-link
-      eqα eqA eqβ eqB shape-eq emb)
-    | ρ₀′ , emb₀ , prefix′ =
-  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
 
 
 private

--- a/GTSF/proof/Store/RelEmbedding/NuImprecisionRelStoreEmbeddingPrefixProof.agda
+++ b/GTSF/proof/Store/RelEmbedding/NuImprecisionRelStoreEmbeddingPrefixProof.agda
@@ -1,0 +1,65 @@
+module
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  where
+
+-- File Charter:
+--   * Proves inversion of a live relational-store prefix through a structural
+--     relational-store embedding.
+--   * Isolates the sole store-prefix dependency from the otherwise
+--     term-relation-independent store-embedding algebra.
+--   * Contains no simulation result, postulate, hole, permissive option,
+--     termination bypass, or catch-all clause.
+
+open import Data.Product using (_×_; _,_; ∃-syntax)
+
+open import NuTermImprecision using (StoreImp)
+open import QuotientedTermImprecision using
+  (StoreImpPrefix; prefix-reflⁱ; prefix-∷ⁱ)
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
+open import Types using (Renameᵗ)
+
+
+rel-store-embedding-prefix-invⁱ :
+  ∀ {Φ Ψ Δᴸ Δᴿ Θᴸ Θᴿ τ σ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {ρ′⁺ : StoreImp Ψ Θᴸ Θᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  RelStoreEmbeddingⁱ τ σ ρ⁺ ρ′⁺ →
+  ∃[ ρ₀′ ]
+    RelStoreEmbeddingⁱ τ σ ρ₀ ρ₀′ ×
+    StoreImpPrefix ρ₀′ ρ′⁺
+rel-store-embedding-prefix-invⁱ prefix-reflⁱ emb =
+  _ , emb , prefix-reflⁱ
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-matched
+      eqα eqA eqβ eqB shape-eq emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-matched
+      eqα eqA eqβ eqB shape-eq emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-left eqα eqA emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-left eqα eqA emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-right eqβ eqB emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-right eqβ eqB emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-link
+      eqα eqA eqβ eqB shape-eq emb)
+    with rel-store-embedding-prefix-invⁱ prefix emb
+rel-store-embedding-prefix-invⁱ (prefix-∷ⁱ prefix)
+    (rel-store-embedding-link
+      eqα eqA eqβ eqB shape-eq emb)
+    | ρ₀′ , emb₀ , prefix′ =
+  ρ₀′ , emb₀ , prefix-∷ⁱ prefix′

--- a/GTSF/proof/Target/Administration/NuImprecisionTargetUniversalFusionSpineDef.agda
+++ b/GTSF/proof/Target/Administration/NuImprecisionTargetUniversalFusionSpineDef.agda
@@ -6,7 +6,7 @@ module
 --   * Defines the constructor-form spine of recursively nested universal
 --     target-instantiation fusion frames.
 --   * Retains one matched-lambda base, every fused frame's generic origin
---     index, and its arbitrary final precision index.
+--     index, and equality with its canonical transported final index.
 --   * States the fold from the spine back to quotiented term imprecision.
 --   * Contains no extraction, normalization, world-coherent result, proof,
 --     postulate, hole, permissive option, or broad DGG import.
@@ -17,6 +17,7 @@ import Coercions as C
 open import Data.List using ([]; _∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (suc; zero)
+open import Relation.Binary.PropositionalEquality using (sym)
 open import Imprecision using
   ( ImpCtx
   ; _ˣ⊑ˣ_
@@ -58,7 +59,11 @@ open import
   using (TyRenameWf)
 open import
   proof.EndpointMLB.Core.MaximalLowerBoundsWf
-  using (rename-assm²ᵢ)
+  using
+  ( rename-assm²ᵢ
+  ; ⊑-rename-at²ᵢ
+  ; ⊑-target-lift-rightᵢ
+  )
 open import
   proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingDef
   using (RelStoreEmbeddingⁱ)
@@ -137,9 +142,12 @@ data TargetUniversalFusionSpine
       (store-right zero ★ wf★ ∷ ρᴿ⁺) ρ →
     renameᵗᵐ τ (Λ W) ≡ M →
     renameᵗᵐ σ (W′ ⟨ C.`∀ c ⟩) ≡ M′ →
-    renameᵗ τ (`∀ D) ≡ A →
-    renameᵗ σ (⇑ᵗ (`∀ E)) ≡ `∀ H →
+    (source-type-eq : renameᵗ τ (`∀ D) ≡ A) →
+    (target-type-eq : renameᵗ σ (⇑ᵗ (`∀ E)) ≡ `∀ H) →
     (p : Φ ∣ Δᴸ ⊢ A ⊑ `∀ H ⊣ Δᴿ) →
+    ⊑-rename-at²ᵢ assm hτ hσ
+      (sym source-type-eq) (sym target-type-eq)
+      (⊑-target-lift-rightᵢ f) ≡ p →
     Value M →
     No• M →
     Closedᵐ M →

--- a/GTSF/proof/Target/Administration/NuImprecisionTargetUniversalFusionSpineProof.agda
+++ b/GTSF/proof/Target/Administration/NuImprecisionTargetUniversalFusionSpineProof.agda
@@ -5,8 +5,8 @@ module
 -- File Charter:
 --   * Folds the constructor-form universal target-instantiation fusion spine
 --     back into quotiented term imprecision.
---   * Rebuilds matched-lambda bases and fused steps without changing either
---     the generic origin index or the arbitrary final precision index.
+--   * Rebuilds matched-lambda bases and fused steps while retaining equality
+--     between each generic origin and canonical transported final index.
 --   * Contains no extraction, normalization, world-coherent result,
 --     postulate, hole, permissive option, termination bypass, catch-all, or
 --     broad DGG import.
@@ -33,6 +33,7 @@ target-universal-fusion-spine-relation-proofᵀ
       vW noW vW′ noW′ inert tail f inst-shape creation-square
       assm hτ hσ store-emb
       source-eq target-eq source-type-eq target-type-eq p
+      canonical-index
       final-v final-no final-closed
       final-v′ final-no′ final-closed′
       source-typing target-typing) =

--- a/GTSF/proof/WorldCoherent/Right/Target/ActiveRoots/NuImprecisionWorldCoherentRightTargetActiveRootResumeProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/ActiveRoots/NuImprecisionWorldCoherentRightTargetActiveRootResumeProof.agda
@@ -94,9 +94,11 @@ open import proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDe
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   ; rel-store-embedding-reflⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Right.ValueCatchup.NuImprecisionRightValueCatchupResultDef using
   ( right-value-indexed-catchup
   ; rightCatchupIndexedResult

--- a/GTSF/proof/WorldCoherent/Right/Target/ActiveRoots/NuImprecisionWorldCoherentRightTargetActiveUnsealRootProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/ActiveRoots/NuImprecisionWorldCoherentRightTargetActiveUnsealRootProof.agda
@@ -75,9 +75,11 @@ open import proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessDe
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   ; rel-store-embedding-reflⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Right.ValueCatchup.NuImprecisionRightValueCatchupResultDef using
   ( right-value-indexed-catchup
   ; rightCatchupIndexedResult

--- a/GTSF/proof/WorldCoherent/Right/Target/Resume/NuImprecisionWorldCoherentRightTargetSequenceResumeProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/Resume/NuImprecisionWorldCoherentRightTargetSequenceResumeProof.agda
@@ -65,8 +65,10 @@ open import proof.Right.StorePrefix.NuImprecisionRightOnlyStorePrefixAlgebra
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Right.ValueCatchup.NuImprecisionRightValueCatchupResultDef using
   ( right-value-indexed-catchup
   ; rightCatchupIndexedResult

--- a/GTSF/proof/WorldCoherent/Right/Target/Resume/NuImprecisionWorldCoherentRightTargetStepResumeProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/Resume/NuImprecisionWorldCoherentRightTargetStepResumeProof.agda
@@ -45,8 +45,10 @@ open import Types using (occurs; ⇑ᵗ; _⇒_; `∀)
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Right.Core.NuImprecisionRightContextAction using
   (applyRightImpCtxChanges; applyRightImpCtxChanges-++)
 open import

--- a/GTSF/proof/WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetNarrowUntagRootProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetNarrowUntagRootProof.agda
@@ -72,9 +72,11 @@ open import proof.NuCore.Relations.NuImprecisionContextExclusivityDef using
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ( rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   ; rel-store-embedding-reflⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Right.ValueCatchup.NuImprecisionRightValueCatchupResultDef using
   ( right-value-indexed-catchup
   ; rightCatchupIndexedResult

--- a/GTSF/proof/WorldCoherent/Source/Allocation/NuImprecisionWorldCoherentSourceAllocationStepProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/Allocation/NuImprecisionWorldCoherentSourceAllocationStepProof.agda
@@ -154,8 +154,10 @@ open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   ; lift-store-embeddingⁱ
   ; rel-store-embedding-composeⁱ
   ; rel-store-embedding-congⁱ
-  ; rel-store-embedding-prefix-invⁱ
   )
+open import
+  proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingPrefixProof
+  using (rel-store-embedding-prefix-invⁱ)
 open import proof.Catchup.Simulation.NuImprecisionSimulationCore using
   ( equality-proof-unique
   ; nu-term-imprecision-transport-typesᵀ


### PR DESCRIPTION
## Summary

- implements the smaller term-imprecision relation as a complete, independent syntax-directed relation;
- includes variables, blame, constants, primitive operations, term and type binders, application, allocation, nu, all cast/conversion polarities, paired reveal/conceal, paired widening, one target-instantiation creation boundary, one paired-down quotient boundary, and bilateral reduction closure;
- deliberately excludes the old-relation embedding, generic rename wrapper, quotient application, finite narrowing spines, fused down/application/up rules, and uninhabited target-only alpha/nu cases;
- proves strict typing, value, term-context shift, prefix-aware parallel substitution, single substitution, world embedding, world renaming, compatibility renaming, and creation properties;
- splits generic relational-store embedding algebra from the live prefix theorem and updates its consumers;
- records the controlled live-migration plan in the DGG ledger.

## Decisive experiments

1. SUCCESS: direct and framed consumers of the old target-instantiation/type-beta constructor migrate to exact creation plus typed embedding.
2. SUCCESS: the reachable two-function-cast square closes using ordinary application and two individually closed down/up round trips, without quotient application or a finite narrowing spine.
3. SUCCESS: the target instantiation, allocation, and type-beta square closes with the canonical embedded creation rule, without a fused target-only constructor.
4. SUCCESS: Cambridge26 example 14 derives its exact ordinary top edge and a complete bilateral square. The repeated instantiation/generalization side allocates two fresh star seals and the outer concrete seal; the other side allocates only the concrete seal; both reduce to the same constant.

## Verdict

The complete smaller relation is ready for controlled migration into the live term-imprecision development. This PR remains a draft because it does not yet replace live QTI or complete the DGG proof.

## Validation

- make quotient-design-check
- make dgg-check
- strict focused world-renaming check
- strict focused term-context-shift check
- strict Cambridge26 example 14 check
- git diff --cached --check