### PR TITLE
Derive GTSF store-prefix weakening outside term imprecision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,20 @@
   structure in the statement itself so the full claim is readable at the use
   site. Add a named definition only when it is a genuine reusable concept, not
   just a shorthand for a proof obligation.
+- Changes to the live term-imprecision relation in
+  `GTSF/QuotientedTermImprecision.agda` require the user's explicit permission
+  before editing that file. The permission request must explain why the
+  relation itself needs to change and include the relevant imprecision and
+  reduction square in LaTeX-style notation, with imprecision horizontal and
+  reduction vertical, for example:
+
+  $$
+  \begin{array}{ccc}
+  M & \sqsubseteq & M' \\
+  \downarrow^{*} & & \downarrow^{*} \\
+  N & \sqsubseteq & N'
+  \end{array}
+  $$
 
 ## Subagent launch notes
 

--- a/GTSF/QuotientedTermImprecision.agda
+++ b/GTSF/QuotientedTermImprecision.agda
@@ -13,8 +13,9 @@ module QuotientedTermImprecision where
 --     physical store order need not coincide across permuted allocations.
 --   * Factors runtime-bullet instantiation from single-name reveal/conceal
 --     conversions and paired conversion imprecision.
---   * Uses one proof-only prefix-extension rule for matched, one-sided, and
---     crossed allocation states.
+--   * Retains canonical allocation-store lineage only in runtime-bullet and
+--     target-instantiation residuals; general store-prefix weakening is
+--     admissible rather than a term-imprecision constructor.
 --   * Relates the terminal result of target-only `inst` allocation through
 --     composable embedded creation evidence with a canonical transported
 --     imprecision index.
@@ -332,7 +333,7 @@ mutual
       Ψ ∣ Δᴸ′ ∣ Δᴿ′ ∣ ρ′ ∣ γ′
         ⊢ᴺ Λ V ⊑ V′ ⟨ c′ ⟩ ⦂ `∀ A ⊑ A′ ∶ p
 
-    α⊑αᵀ : ∀ {ρ′ γ′ L L′ A B C D p}
+    α⊑αᵀ : ∀ {ρ′ ρ⁺ γ′ L L′ A B C D p}
       → Value L
       → No• L
       → Value L′
@@ -344,24 +345,23 @@ mutual
       → LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ L ⊑ L′ ⦂ `∀ C ⊑ `∀ D ∶ ∀ⁱ p
+      → StoreImpPrefix
+          (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
+            A⇑⊑B⇑ ∷ ρ′)
+          ρ⁺
       → suc Δᴸ
-          ∣ leftStoreⁱ
-              (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
-                A⇑⊑B⇑ ∷ ρ′)
+          ∣ leftStoreⁱ ρ⁺
           ∣ leftCtxⁱ γ′ ⊢ (⇑ᵗᵐ L) • ⦂ C
       → suc Δᴿ
-          ∣ rightStoreⁱ
-              (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
-                A⇑⊑B⇑ ∷ ρ′)
+          ∣ rightStoreⁱ ρ⁺
           ∣ rightCtxⁱ γ′ ⊢ (⇑ᵗᵐ L′) • ⦂ D
         ------------------------------------------------------------
-      → ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) ∣ suc Δᴸ ∣ suc Δᴿ ∣
-          store-matched zero (⇑ᵗ A) zero (⇑ᵗ B) A⇑⊑B⇑ ∷ ρ′
-          ∣ γ′
+      → ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
+          ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ⁺ ∣ γ′
           ⊢ᴺ (⇑ᵗᵐ L) • ⊑ (⇑ᵗᵐ L′) • ⦂ C ⊑ D ∶ p
 
     α⊑ᵀ :
-        ∀ {ρ′ γ′ L N′ A B′ C p occ}
+        ∀ {ρ′ ρ⁺ γ′ L N′ A B′ C p occ}
       → {{safe : NonVar C}}
       → Value L
       → No• L
@@ -370,26 +370,19 @@ mutual
       → LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′
       → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
           ⊢ᴺ L ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν safe occ p
+      → StoreImpPrefix
+          (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ρ⁺
       → suc Δᴸ
-          ∣ leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ∣ leftStoreⁱ ρ⁺
           ∣ leftCtxⁱ γ′ ⊢ (⇑ᵗᵐ L) • ⦂ C
       → Δᴿ
-          ∣ rightStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+          ∣ rightStoreⁱ ρ⁺
           ∣ rightCtxⁱ γ′ ⊢ N′ ⦂ B′
         ------------------------------------------------------------
-      → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) ∣ suc Δᴸ ∣ Δᴿ ∣
-          store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ γ′
+      → ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
+          ∣ suc Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ′
           ⊢ᴺ (⇑ᵗᵐ L) • ⊑ N′ ⦂ C ⊑ B′ ∶ p
-
-    allocation-prefixᵀ : ∀ {ρ₀ M M′ A B p}
-      → StoreImpPrefix ρ₀ ρ
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
-          ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p
-      → Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A
-      → Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B
-        ------------------------------------------------------------
-      → Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-          ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p
 
     ν⊑νᵀ :
         ∀ {ρ′ γ′ A A′ B B′ C C′ N N′ p q s s′ μ μ′}

--- a/GTSF/proof/Catchup/Simulation/NuImprecisionKeepCastFrameSupport.agda
+++ b/GTSF/proof/Catchup/Simulation/NuImprecisionKeepCastFrameSupport.agda
@@ -7,6 +7,8 @@ module proof.Catchup.Simulation.NuImprecisionKeepCastFrameSupport where
 --     widening casts.
 --   * Contains no polymorphic reduction case or allocation scheduling.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([])
 open import Data.Product using (_×_; _,_)
@@ -124,7 +126,7 @@ left-catchup-indexed-all-prefix-prepend-keepᵀ :
 left-catchup-indexed-all-prefix-prepend-keepᵀ
     prefix source→ N⊑V′ N⊢ V′⊢ catchup =
   left-catchup-indexed-all-prepend-keepᵀ source→
-    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢) catchup
+    (term-imprecision-store-prefixᵀ prefix N⊑V′ N⊢ V′⊢) catchup
 
 weak-one-step-target-cast-frameᵀ :
   ∀ {Φ Δᴸ Δᴿ M N′ A A′ B′ c χ}

--- a/GTSF/proof/Catchup/Simulation/NuImprecisionSimulation.agda
+++ b/GTSF/proof/Catchup/Simulation/NuImprecisionSimulation.agda
@@ -14,6 +14,8 @@ module proof.Catchup.Simulation.NuImprecisionSimulation where
 --     while target-right prefix lifting lives under
 --     `proof.Right.AllocationRuntime`.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (true)
@@ -1711,7 +1713,7 @@ crossed-double-prefix-bodyᵀ :
     ⦂ ⇑ᵗ (⇑ᵗ A) ⊑ ⇑ᵗ (⇑ᵗ B)
     ∶ ⊑-crossed-double-lift∀∀ᵢ p
 crossed-double-prefix-bodyᵀ liftρ₁ liftρ₂ prefix noL noL′ L⊑L′ =
-  allocation-prefixᵀ prefix body
+  term-imprecision-store-prefixᵀ prefix body
     (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
       noLL (nu-term-imprecision-source-typing body))
     (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
@@ -3028,7 +3030,7 @@ left-catchup-all-α-Λᵀ
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
   where
     allocated-body =
-      allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+      term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
         (term-weaken {Δ = suc _} {Δ′ = suc _}
           {Σ = leftStoreⁱ ρᵇ}
           {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
@@ -3112,7 +3114,7 @@ left-catchup-indexed-all-α-Λᵀ
       replace-right-rename-id-right-bodyᵢ
 
   allocated-body =
-    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+    term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
         {Σ = leftStoreⁱ ρᵇ}
         {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
@@ -3195,7 +3197,7 @@ left-catchup-indexed-prefix-α-Λᵀ
       replace-right-rename-id-right-bodyᵢ
 
   allocated-body =
-    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+    term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
         {Σ = leftStoreⁱ ρᵇ}
         {Σ′ = (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρᵇ}
@@ -3208,7 +3210,7 @@ left-catchup-indexed-prefix-α-Λᵀ
       liftρᵃ liftρᵇ noW noV′ allocated-body
 
   prefixed-body =
-    allocation-prefixᵀ prefix canonical-body
+    term-imprecision-store-prefixᵀ prefix canonical-body
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         noW (nu-term-imprecision-source-typing canonical-body))
       (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
@@ -3285,7 +3287,7 @@ left-catchup-indexed-all-prefix-α-Λᵀ
       replace-right-rename-id-right-bodyᵢ
 
   allocated-body =
-    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+    term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
         {Σ = leftStoreⁱ ρᵇ}
         {Σ′ = (zero , ⇑ᵗ A) ∷ leftStoreⁱ ρᵇ}
@@ -3298,7 +3300,7 @@ left-catchup-indexed-all-prefix-α-Λᵀ
       liftρᵃ liftρᵇ noW noV′ allocated-body
 
   prefixed-body =
-    allocation-prefixᵀ prefix canonical-body
+    term-imprecision-store-prefixᵀ prefix canonical-body
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         noW (nu-term-imprecision-source-typing canonical-body))
       (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
@@ -3352,7 +3354,7 @@ left-allocated-bulletᵀ
     {Aν = Aν} {V = V} {V′ = V′} {r = r}
     vV noV hAν liftρ V⊑V′ =
   α⊑ᵀ vV noV hAν liftρ lift-left-ctx-[] V⊑V′
-    left-bullet-typing right-typing
+    prefix-reflⁱ left-bullet-typing right-typing
   where
     left-bullet-typing =
       subst

--- a/GTSF/proof/Catchup/Simulation/NuImprecisionSimulationCore.agda
+++ b/GTSF/proof/Catchup/Simulation/NuImprecisionSimulationCore.agda
@@ -14,6 +14,8 @@ module proof.Catchup.Simulation.NuImprecisionSimulationCore where
 --   * Ends at the direct-swap residual lemmas; allocation and active
 --     universal catch-up cases live in the downstream simulation modules.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Bool using (true)
@@ -3377,7 +3379,7 @@ rel-world-allocation-prefix-permuteᵀ
 rel-world-allocation-prefix-permuteᵀ
     perm prefix body-map noM noM′ M⊢ M′⊢
     | ρ₀′ , renameρ₀ , prefix′ =
-  allocation-prefixᵀ prefix′ (body-map base-perm)
+  term-imprecision-store-prefixᵀ prefix′ (body-map base-perm)
     (rel-world-source-typing-permute perm noM M⊢)
     (rel-world-target-typing-permute perm noM′ M′⊢)
   where
@@ -3417,7 +3419,7 @@ rel-world-allocation-prefix-embedᵀ
 rel-world-allocation-prefix-embedᵀ
     emb prefix body-map noM noM′ M⊢ M′⊢
     | ρ₀′ , emb₀ , prefix′ =
-  allocation-prefixᵀ prefix′ (body-map base-emb)
+  term-imprecision-store-prefixᵀ prefix′ (body-map base-emb)
     (rel-world-source-typing-embed emb noM M⊢)
     (rel-world-target-typing-embed emb noM′ M′⊢)
   where
@@ -8814,7 +8816,7 @@ right-target-square-α⊑ᵀ :
 right-target-square-α⊑ᵀ
     vL noL h⇑A rightᴸρ leftᴿρ L⊑N′ L•⊢ =
   α⊑ᵀ vL noL h⇑A leftᴿρ lift-left-ctx-[] L⊑N′
-    source-typing target-typing
+    prefix-reflⁱ source-typing target-typing
   where
   source-typing =
     subst
@@ -8883,7 +8885,7 @@ right-target-lift-α⊑ᵀ
     | γ× , rightᴸγ , leftᴿγ =
   ρ× , γ× , rightᴸρ , leftᴿρ , rightᴸγ , leftᴿγ ,
   α⊑ᵀ vL noL h⇑A leftᴿρ leftᴿγ L⊑N′
-    source-typing target-typing
+    prefix-reflⁱ source-typing target-typing
   where
   source-typing =
     subst
@@ -8951,7 +8953,7 @@ left-source-lift-allocation-leftᵀ
     {hA = hA} {hA′ = hA′} noM
     (left-store-rename-left eqα eqA renameρν)
     renameγν M⊑M′ M⊢ M′⊢ | refl | refl =
-  allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ)
+  term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ)
     M⊑M′ source-typing target-typing
   where
   full-rename :
@@ -8968,7 +8970,7 @@ left-source-lift-allocation-leftᵀ
   target-typing =
     right-typing-left-renameⁱ full-rename renameγν M′⊢
 
-left-rename-allocation-prefixᵀ :
+left-rename-term-imprecision-store-prefixᵀ :
   ∀ {Φ Ψ Δᴸ Δᴸ′ Δᴿ τ}
     {assm : ∀ {a} → a ∈ Φ →
       rename-assm²ᵢ τ (λ X → X) a ∈ Ψ}
@@ -8989,11 +8991,11 @@ left-rename-allocation-prefixᵀ :
   Ψ ∣ Δᴸ′ ∣ Δᴿ ∣ ρ′⁺ ∣ γ′
     ⊢ᴺ renameᵗᵐ τ M ⊑ M′
     ⦂ renameᵗ τ A ⊑ B ∶ ⊑-rename-leftᵢ τ assm hτ p
-left-rename-allocation-prefixᵀ prefix renameρ body-map M⊢ M′⊢
+left-rename-term-imprecision-store-prefixᵀ prefix renameρ body-map M⊢ M′⊢
     with left-store-rename-prefix-invⁱ prefix renameρ
-left-rename-allocation-prefixᵀ prefix renameρ body-map M⊢ M′⊢
+left-rename-term-imprecision-store-prefixᵀ prefix renameρ body-map M⊢ M′⊢
     | ρ₀′ , renameρ₀ , prefix′ =
-  allocation-prefixᵀ prefix′ (body-map renameρ₀) M⊢ M′⊢
+  term-imprecision-store-prefixᵀ prefix′ (body-map renameρ₀) M⊢ M′⊢
 
 ⊑-lift-under-∀ᵢ :
   ∀ {Φ Δᴸ Δᴿ A B} →
@@ -12772,7 +12774,7 @@ left-catchup-indexed-prefix-relatedᵀ :
 left-catchup-indexed-prefix-relatedᵀ
     prefix final N⊑V′ N⊢ V′⊢ =
   left-catchup-indexed-relatedᵀ final
-    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢)
+    (term-imprecision-store-prefixᵀ prefix N⊑V′ N⊢ V′⊢)
 
 left-catchup-indexed-source-all-prefix-valueᵀ :
   ∀ {Φ Δᴸ Δᴿ V V′ C B}
@@ -12827,7 +12829,7 @@ left-catchup-indexed-all-prefix-relatedᵀ :
 left-catchup-indexed-all-prefix-relatedᵀ
     prefix final N⊑V′ N⊢ V′⊢ =
   left-catchup-indexed-all-relatedᵀ final
-    (allocation-prefixᵀ prefix N⊑V′ N⊢ V′⊢)
+    (term-imprecision-store-prefixᵀ prefix N⊑V′ N⊢ V′⊢)
 
 left-catchup-indexed-all-valueᵀ :
   ∀ {Φ Δᴸ Δᴿ V V′ C C′ q}

--- a/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionDGGProgress.md
@@ -546,6 +546,7 @@ relation constructor is used.
 | [`NuImprecisionWorldCoherentOneStepDef.agda`](../../WorldCoherent/Core/NuImprecisionWorldCoherentOneStepDef.agda) | **completed `Def`** | World-coherent one-step contract used by the terminal proof |
 | [`QuotientImprecisionCompatibility.agda`](../../../QuotientImprecisionCompatibility.agda) | **canonical support** | Cast-mode and reduction-closed hereditary widening evidence with no dependency on a term-imprecision relation |
 | [`NuImprecisionReductionClosedQuotientDef.agda`](../../Quotient/NuImprecisionReductionClosedQuotientDef.agda) | **completed prototype** | Complete independent ordinary grammar, one embedded-creation case, one paired-narrowing quotient boundary, allocation-aware bilateral closure, and no generic renaming, quotient application, finite spine, or fused down/application/up rule |
+| [`NuImprecisionReductionClosedQuotientStorePrefixExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientStorePrefixExperiment.agda) | **completed metatheory** | Mutual admissible store-prefix weakening for the syntax-directed prototype ordinary and quotient judgments |
 | [`NuImprecisionReductionClosedQuotientExamples.agda`](../../Quotient/NuImprecisionReductionClosedQuotientExamples.agda) | **completed diagnostic** | Reachable two-function-cast top row, two beta steps on each side, and an ordinary-related join without quotient application or a fused rule |
 | [`NuImprecisionReductionClosedQuotientTypingExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientTypingExperiment.agda) | **completed metatheory** | Exhaustive source and target typing projections for the ordinary and quotient judgments |
 | [`NuImprecisionReductionClosedQuotientValueExperiment.agda`](../../Quotient/NuImprecisionReductionClosedQuotientValueExperiment.agda) | **completed metatheory** | Exhaustive source and target value classification, including terminal embedded creation |
@@ -938,6 +939,35 @@ the fused application branches vanished, four quotient application branches
 vanished, and the split identity/gradual downcast cases collapsed to one.
 The frozen direct source-file counts fell from `14/9/9/46/27/26` to
 `8/3/3/39/20/19`; this remains a checkpoint rather than a phase gate.
+
+The fourth Phase 4 checkpoint completed issue #102 on 2026-07-28 while the
+broader #100 migration remained paused. The live and independent prototype
+ordinary judgments no longer contain a generic store-prefix constructor.
+Store monotonicity is proved mutually with the quotient judgment through the
+canonical
+`NuImprecisionTermStorePrefixDef/Proof/Lemma` boundary and the prototype
+`NuImprecisionReductionClosedQuotientStorePrefixExperiment`.
+
+Runtime-bullet rules now retain a prefix from their canonical fresh-allocation
+world to the ambient relation world. Embedded target-instantiation creation
+likewise composes exact post-allocation lineage. Therefore later allocation
+extends the relation by composing residual lineage:
+
+$$
+\begin{array}{ccc}
+M & \mathrel{\sqsubseteq_{\rho_0}} & M' \\
+\downarrow^{0} & & \downarrow^{0} \\
+M & \mathrel{\sqsubseteq_{\rho^+}} & M'
+\end{array}
+\qquad
+\rho_0 \mathrel{\leq_{\mathrm{prefix}}} \rho^+ .
+$$
+
+Focused checks pass for the live and prototype admissibility proofs, source
+and target typing, value and terminal inversion, world embedding, term-context
+shift, parallel substitution, allocation/frame consumers, and the public DGG
+root. Administrative prefix-peeling branches were deleted; inversion now
+reaches the constructor selected by the endpoint syntax.
 
 The next structural check found that the selected prototype support still
 defined a nominally distinct copy of the now-canonical compatibility

--- a/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
+++ b/GTSF/proof/DGG/Design/NuImprecisionReductionClosedQuotientDesign.md
@@ -751,6 +751,46 @@ example. It uses only the independent smaller relation. The former QTI-based
 regression remains as a comparison, but is no longer evidence needed by the
 smaller design.
 
+## Store-prefix weakening is admissible
+
+Relational-store extension is not a term-form rule. For both the ordinary and
+quotient judgments, it is an admissible mutual theorem:
+
+$$
+\rho_0 \mathrel{\leq_{\mathrm{prefix}}} \rho^+
+\quad\land\quad
+\rho_0 \vdash M \mathrel{\sqsubseteq_p} M'
+\quad\land\quad
+\rho^+ \vdash M : A
+\quad\land\quad
+\rho^+ \vdash M' : A'
+\quad\Longrightarrow\quad
+\rho^+ \vdash M \mathrel{\sqsubseteq_p} M'.
+$$
+
+The corresponding imprecision and zero-step reduction square is
+
+$$
+\begin{array}{ccc}
+M & \mathrel{\sqsubseteq_{\rho_0,p}} & M' \\
+\downarrow^{0} & & \downarrow^{0} \\
+M & \mathrel{\sqsubseteq_{\rho^+,p}} & M'.
+\end{array}
+$$
+
+The proof is syntax directed. Ordinary constructors rebuild their premises
+recursively; quotient closing weakens its widening pair; casts weaken their
+typing and seal-mode evidence. A runtime-bullet rule records the prefix from
+its canonical allocation store to its current ambient world. An embedded
+target-instantiation creation residual records the same exact lineage. A
+later prefix step composes those residual prefixes rather than wrapping the
+whole relation in an administrative constructor.
+
+This invariant is strong enough for argument and primitive-operand framing,
+multi-allocation `ν` catch-up, quotient closing, and target-instantiation
+creation. It also makes typing, value classification, world embedding,
+context shift, and substitution inversion strictly syntax directed.
+
 The live-consumer audit found three distinct situations. The direct post-beta
 identity context already fixes its index to the canonical right-lifted index.
 The pure and framed universal-fusion spines previously accepted an arbitrary

--- a/GTSF/proof/Left/AllocationRuntime/NuImprecisionLeftSourceAllocationRuntimeTransportProof.agda
+++ b/GTSF/proof/Left/AllocationRuntime/NuImprecisionLeftSourceAllocationRuntimeTransportProof.agda
@@ -91,7 +91,6 @@ open import QuotientedTermImprecision using
   ; Λ⊑ᵀ
   ; α⊑αᵀ
   ; α⊑ᵀ
-  ; allocation-prefixᵀ
   ; ν⊑νᵀ
   ; ν⊑ᵀ
   ; κ⊑κᵀ
@@ -149,7 +148,6 @@ open import proof.Catchup.Simulation.NuImprecisionSimulationCore using
   ; LeftStoreRenameⁱ
   ; left-ctx-rename-[]
   ; left-ctx-rename-∷
-  ; left-rename-allocation-prefixᵀ
   ; left-rename-blameᵀ
   ; left-rename-cast⊒⊑ᵀ
   ; left-rename-cast⊑⊑ᵀ
@@ -560,25 +558,11 @@ mutual
   left-source-runtimeᵀ-generic rename-no-bullet ins
       renameρ renameγ
       (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
-        L⊑L′ L•⊢ L′•⊢) () runtime
+        L⊑L′ prefix L•⊢ L′•⊢) () runtime
   left-source-runtimeᵀ-generic rename-no-bullet ins
       renameρ renameγ
-      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) () runtime
-  left-source-runtimeᵀ-generic rename-no-bullet ins
-      renameρ renameγ (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢)
-      noM runtime =
-    left-rename-allocation-prefixᵀ prefix renameρ
-      (λ renameρ₀ →
-        left-source-runtimeᵀ-generic rename-no-bullet ins
-          renameρ₀ renameγ M⊑M′ noM runtime)
-      source-typing target-typing
-    where
-    source-typing =
-      left-typing-renameⁱ {ψ = left-insertion-pred ins}
-        (left-insertion-inverse ins)
-        (left-insertion-cast-renamer ins) renameρ renameγ noM M⊢
-
-    target-typing = right-typing-left-renameⁱ renameρ renameγ M′⊢
+      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ prefix L•⊢ N′⊢)
+      () runtime
   left-source-runtimeᵀ-generic rename-no-bullet ins
       renameρ renameγ
       rel@(ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
@@ -856,18 +840,13 @@ private
   left-source-allocation-runtime-rootᵀ rename-no-bullet
       renameρ renameγ
       rel@(α⊑αᵀ vL noL vL′ noL′ p↑ liftρ liftγ
-        L⊑L′ L⊢ L′⊢) noM runtime =
+        L⊑L′ prefix L⊢ L′⊢) noM runtime =
     left-source-runtimeᵀ-generic rename-no-bullet left-insertion-suc
       renameρ renameγ rel noM runtime
   left-source-allocation-runtime-rootᵀ rename-no-bullet
       renameρ renameγ
-      rel@(α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ L⊢ N′⊢)
+      rel@(α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ prefix L⊢ N′⊢)
       noM runtime =
-    left-source-runtimeᵀ-generic rename-no-bullet left-insertion-suc
-      renameρ renameγ rel noM runtime
-  left-source-allocation-runtime-rootᵀ rename-no-bullet
-      renameρ renameγ
-      rel@(allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) noM runtime =
     left-source-runtimeᵀ-generic rename-no-bullet left-insertion-suc
       renameρ renameγ rel noM runtime
   left-source-allocation-runtime-rootᵀ rename-no-bullet

--- a/GTSF/proof/Left/Core/NuImprecisionLeftLiftPrefixBodyProof.agda
+++ b/GTSF/proof/Left/Core/NuImprecisionLeftLiftPrefixBodyProof.agda
@@ -8,6 +8,8 @@ module proof.Left.Core.NuImprecisionLeftLiftPrefixBodyProof where
 --   * Contains only total proof terms, with no permissive options or dispatcher
 --     logic.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (refl)
 open import Data.List using ([]; _∷_)
@@ -25,8 +27,7 @@ open import proof.Store.Core.NuImprecisionRelationalStoreDef using
   )
 open import NuTerms using (renameᵗᵐ)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  )
+  (  )
 open import Relation.Binary.PropositionalEquality using (sym)
 open import Types using (renameᵗ)
 open import proof.Core.Properties.NuImprecisionIndexedRenamingProperties using
@@ -116,7 +117,7 @@ private
 left-lift-prefix-body-proofᵀ : LeftLiftPrefixBodyᵀ
 left-lift-prefix-body-proofᵀ {B = B} {L′ = L′}
     liftρ prefix noL noL′ L⊑L′ =
-  allocation-prefixᵀ prefix body
+  term-imprecision-store-prefixᵀ prefix body
     (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
       noL↑ (nu-term-imprecision-source-typing body))
     (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)

--- a/GTSF/proof/Left/Core/NuImprecisionLeftRenameNoBulletProof.agda
+++ b/GTSF/proof/Left/Core/NuImprecisionLeftRenameNoBulletProof.agda
@@ -46,7 +46,6 @@ open import QuotientedTermImprecision using
   ; Λ⊑ᵀ
   ; α⊑αᵀ
   ; α⊑ᵀ
-  ; allocation-prefixᵀ
   ; ν⊑νᵀ
   ; ν⊑ᵀ
   ; κ⊑κᵀ
@@ -114,7 +113,6 @@ open import proof.Catchup.Simulation.NuImprecisionSimulationCore using
   ; left-rename-·ᵀ
   ; left-rename-ƛᵀ
   ; left-rename-xᵀ
-  ; left-rename-allocation-prefixᵀ
   ; left-seal★-renameⁱ
   ; left-typing-renameⁱ
   ; right-typing-left-renameⁱ
@@ -340,24 +338,10 @@ mutual
         (embedded-creation-target-typingᴱ embedded)
   left-rename-no•ᵀ-proof ins renameρ renameγ ()
       noM′ (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
-        L⊑L′ L•⊢ L′•⊢)
+        L⊑L′ prefix L•⊢ L′•⊢)
   left-rename-no•ᵀ-proof ins renameρ renameγ ()
-      noM′ (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢)
-  left-rename-no•ᵀ-proof ins renameρ renameγ noM noM′
-      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) =
-    left-rename-allocation-prefixᵀ prefix renameρ
-      (λ renameρ₀ →
-        left-rename-no•ᵀ-proof ins renameρ₀ renameγ
-          noM noM′ M⊑M′)
-      source-typing target-typing
-    where
-    source-typing =
-      left-typing-renameⁱ {ψ = left-insertion-pred ins}
-        (left-insertion-inverse ins)
-        (left-insertion-cast-renamer ins) renameρ renameγ noM M⊢
-
-    target-typing =
-      right-typing-left-renameⁱ renameρ renameγ M′⊢
+      noM′
+      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ prefix L•⊢ N′⊢)
   left-rename-no•ᵀ-proof ins renameρ renameγ
       (no•-ν noN) (no•-ν noN′)
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑

--- a/GTSF/proof/NuCore/Misc/NuImprecisionRuntimeBulletStoreStability.agda
+++ b/GTSF/proof/NuCore/Misc/NuImprecisionRuntimeBulletStoreStability.agda
@@ -1,10 +1,12 @@
 module proof.NuCore.Misc.NuImprecisionRuntimeBulletStoreStability where
 
 -- File Charter:
---   * Proves that typing a term with one runtime bullet exposes the canonical
---     zero-headed runtime store shape.
---   * Proves that a relational-store prefix cannot extend the source store
---     while such a term remains typable.
+--   * Classifies terms as bullet-free or containing a runtime bullet and
+--     proves that typing the latter exposes the canonical runtime-store shape.
+--   * Proves that a relational-store prefix cannot extend either projected
+--     store while a bullet-containing term remains typable.
+--   * Aligns an old typing derivation with an enlarged projected store even
+--     when a second typing derivation chooses different hidden types.
 --   * Classifies RuntimeOK terms by the existing AtMostOne• judgment.
 --   * Contains no result carrier, postulate, hole, or permissive option.
 
@@ -14,12 +16,15 @@ open import Data.List using (_∷_; drop)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here)
 open import Data.Nat using (zero; suc)
+open import Data.Nat.Properties using (≤-refl)
 open import Data.Product using (_,_; ∃-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality using (cong; subst; sym)
 
 open import proof.Store.Core.NuImprecisionRelationalStoreDef using
   ( StoreImp
   ; leftStoreⁱ
+  ; rightStoreⁱ
   ; store-link
   ; store-left
   ; store-matched
@@ -30,10 +35,17 @@ open import NuTerms using
   ; No•
   ; One•
   ; RuntimeOK
+  ; Term
+  ; blame
   ; no•-·
+  ; no•-$
+  ; no•-`
   ; no•-⟨⟩
+  ; no•-Λ
   ; no•-ν
   ; no•-⊕
+  ; no•-blame
+  ; no•-ƛ
   ; ok-no
   ; ok-·₁
   ; ok-·₂
@@ -52,6 +64,15 @@ open import NuTerms using
   ; one•-⊕₁
   ; one•-⊕₂
   ; one•-ƛ
+  ; `_
+  ; ƛ_
+  ; _·_
+  ; Λ_
+  ; _•
+  ; ν
+  ; $
+  ; _⊕[_]_
+  ; _⟨_⟩
   ; zero•
   )
 open import QuotientedTermImprecision using
@@ -61,7 +82,10 @@ open import QuotientedTermImprecision using
   )
 open import TermTyping using
   ( _∣_∣_⊢_⦂_
+  ; ⊢`
   ; ⊢·
+  ; ⊢$
+  ; ⊢blame
   ; ⊢⟨⟩↑
   ; ⊢⟨⟩↓
   ; ⊢⟨⟩⊑
@@ -82,9 +106,110 @@ open import Types using
   )
 open import proof.Core.Properties.CoercionProperties using (zero∉-⟰ᵗ)
 open import proof.Store.Prefix.NuImprecisionStorePrefix using
-  (leftStoreⁱ-prefix-inclusion)
+  ( leftStoreⁱ-prefix-inclusion
+  ; rightStoreⁱ-prefix-inclusion
+  )
 open import proof.Core.Properties.NuTermProperties using
   (renameᵗᵐ-preserves-No•)
+open import proof.Core.Properties.TypePreservation using (term-weaken)
+
+
+data Contains• : Term → Set where
+  contains•-here : ∀ {M} → Contains• (M •)
+  contains•-ƛ : ∀ {M} → Contains• M → Contains• (ƛ M)
+  contains•-·₁ : ∀ {L M} → Contains• L → Contains• (L · M)
+  contains•-·₂ : ∀ {L M} → Contains• M → Contains• (L · M)
+  contains•-Λ : ∀ {M} → Contains• M → Contains• (Λ M)
+  contains•-ν : ∀ {A L c} → Contains• L → Contains• (ν A L c)
+  contains•-⊕₁ :
+    ∀ {L op M} → Contains• L → Contains• (L ⊕[ op ] M)
+  contains•-⊕₂ :
+    ∀ {L op M} → Contains• M → Contains• (L ⊕[ op ] M)
+  contains•-⟨⟩ : ∀ {M c} → Contains• M → Contains• (M ⟨ c ⟩)
+
+
+bullet-classification :
+  ∀ M → No• M ⊎ Contains• M
+bullet-classification (` x) = inj₁ no•-`
+bullet-classification (ƛ M) with bullet-classification M
+bullet-classification (ƛ M) | inj₁ noM = inj₁ (no•-ƛ noM)
+bullet-classification (ƛ M) | inj₂ hasM = inj₂ (contains•-ƛ hasM)
+bullet-classification (L · M)
+    with bullet-classification L | bullet-classification M
+bullet-classification (L · M) | inj₁ noL | inj₁ noM =
+  inj₁ (no•-· noL noM)
+bullet-classification (L · M) | inj₁ noL | inj₂ hasM =
+  inj₂ (contains•-·₂ hasM)
+bullet-classification (L · M) | inj₂ hasL | inj₁ noM =
+  inj₂ (contains•-·₁ hasL)
+bullet-classification (L · M) | inj₂ hasL | inj₂ hasM =
+  inj₂ (contains•-·₁ hasL)
+bullet-classification (Λ M) with bullet-classification M
+bullet-classification (Λ M) | inj₁ noM = inj₁ (no•-Λ noM)
+bullet-classification (Λ M) | inj₂ hasM = inj₂ (contains•-Λ hasM)
+bullet-classification (M •) = inj₂ contains•-here
+bullet-classification (ν A L c) with bullet-classification L
+bullet-classification (ν A L c) | inj₁ noL = inj₁ (no•-ν noL)
+bullet-classification (ν A L c) | inj₂ hasL =
+  inj₂ (contains•-ν hasL)
+bullet-classification ($ κ) = inj₁ no•-$
+bullet-classification (L ⊕[ op ] M)
+    with bullet-classification L | bullet-classification M
+bullet-classification (L ⊕[ op ] M) | inj₁ noL | inj₁ noM =
+  inj₁ (no•-⊕ noL noM)
+bullet-classification (L ⊕[ op ] M) | inj₁ noL | inj₂ hasM =
+  inj₂ (contains•-⊕₂ hasM)
+bullet-classification (L ⊕[ op ] M) | inj₂ hasL | inj₁ noM =
+  inj₂ (contains•-⊕₁ hasL)
+bullet-classification (L ⊕[ op ] M) | inj₂ hasL | inj₂ hasM =
+  inj₂ (contains•-⊕₁ hasL)
+bullet-classification (M ⟨ c ⟩) with bullet-classification M
+bullet-classification (M ⟨ c ⟩) | inj₁ noM = inj₁ (no•-⟨⟩ noM)
+bullet-classification (M ⟨ c ⟩) | inj₂ hasM =
+  inj₂ (contains•-⟨⟩ hasM)
+bullet-classification blame = inj₁ no•-blame
+
+
+bullet-typing-store-shape :
+  ∀ {Δ : TyCtx} {Σ : Store} {Γ : Ctx} {M : Term} {A : Ty} →
+  Contains• M →
+  Δ ∣ Σ ∣ Γ ⊢ M ⦂ A →
+  ∃[ X ] ∃[ Σ₀ ] Σ ≡ (zero , X) ∷ ⟰ᵗ Σ₀
+bullet-typing-store-shape contains•-here
+    (⊢• Δ≡ Σ≡ hC vV noV V⊢) =
+  _ , _ , Σ≡
+bullet-typing-store-shape (contains•-ƛ hasM) (⊢ƛ hA M⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape (contains•-·₁ hasL) (⊢· L⊢ M⊢) =
+  bullet-typing-store-shape hasL L⊢
+bullet-typing-store-shape (contains•-·₂ hasM) (⊢· L⊢ M⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape (contains•-Λ hasM) (⊢Λ vM M⊢)
+    with bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape (contains•-Λ hasM) (⊢Λ vM M⊢)
+    | X , Σ₀ , Σ≡ =
+  ⊥-elim
+    (zero∉-⟰ᵗ
+      (subst (λ Σ → (zero , X) ∈ Σ) (sym Σ≡) (here refl)))
+bullet-typing-store-shape (contains•-ν hasM) (⊢ν↑ hA M⊢ c⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape
+    (contains•-ν hasM) (⊢ν⊑ mode seal★ M⊢ c⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape (contains•-⊕₁ hasL) (⊢⊕ L⊢ op M⊢) =
+  bullet-typing-store-shape hasL L⊢
+bullet-typing-store-shape (contains•-⊕₂ hasM) (⊢⊕ L⊢ op M⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape (contains•-⟨⟩ hasM) (⊢⟨⟩↑ c⊢ M⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape (contains•-⟨⟩ hasM) (⊢⟨⟩↓ c⊢ M⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape
+    (contains•-⟨⟩ hasM) (⊢⟨⟩⊒ mode seal★ c⊢ M⊢) =
+  bullet-typing-store-shape hasM M⊢
+bullet-typing-store-shape
+    (contains•-⟨⟩ hasM) (⊢⟨⟩⊑ mode seal★ c⊢ M⊢) =
+  bullet-typing-store-shape hasM M⊢
 
 
 one-bullet-typing-store-shape :
@@ -130,43 +255,122 @@ one-bullet-typing-store-shape
   one-bullet-typing-store-shape oneM M⊢
 
 
-private
-  prefix-left-store-shape-stable :
-    ∀ {Φ Δᴸ Δᴿ}
-      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
-    StoreImpPrefix ρ₀ ρ⁺ →
-    (∃[ X ] ∃[ Σ₀ ]
-      leftStoreⁱ ρ₀ ≡ (zero , X) ∷ ⟰ᵗ Σ₀) →
-    (∃[ Y ] ∃[ Σ⁺ ]
-      leftStoreⁱ ρ⁺ ≡ (zero , Y) ∷ ⟰ᵗ Σ⁺) →
-    leftStoreⁱ ρ₀ ≡ leftStoreⁱ ρ⁺
-  prefix-left-store-shape-stable prefix-reflⁱ old-shape new-shape = refl
-  prefix-left-store-shape-stable
-      (prefix-∷ⁱ {entry = store-matched α A β B p} prefix)
-      (X , Σ₀ , old≡) (Y , Σ⁺ , new≡) =
-    ⊥-elim
-      (zero∉-⟰ᵗ
-        (subst (λ Σ → (zero , X) ∈ Σ) (cong (drop 1) new≡)
-          (leftStoreⁱ-prefix-inclusion prefix
-            (subst (λ Σ → (zero , X) ∈ Σ)
-              (sym old≡) (here refl)))))
-  prefix-left-store-shape-stable
-      (prefix-∷ⁱ {entry = store-left α A hA} prefix)
-      (X , Σ₀ , old≡) (Y , Σ⁺ , new≡) =
-    ⊥-elim
-      (zero∉-⟰ᵗ
-        (subst (λ Σ → (zero , X) ∈ Σ) (cong (drop 1) new≡)
-          (leftStoreⁱ-prefix-inclusion prefix
-            (subst (λ Σ → (zero , X) ∈ Σ)
-              (sym old≡) (here refl)))))
-  prefix-left-store-shape-stable
-      (prefix-∷ⁱ {entry = store-right β B hB} prefix)
-      old-shape new-shape =
-    prefix-left-store-shape-stable prefix old-shape new-shape
-  prefix-left-store-shape-stable
-      (prefix-∷ⁱ {entry = store-link α A β B p} prefix)
-      old-shape new-shape =
-    prefix-left-store-shape-stable prefix old-shape new-shape
+prefix-left-store-shape-stable :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  (∃[ X ] ∃[ Σ₀ ]
+    leftStoreⁱ ρ₀ ≡ (zero , X) ∷ ⟰ᵗ Σ₀) →
+  (∃[ Y ] ∃[ Σ⁺ ]
+    leftStoreⁱ ρ⁺ ≡ (zero , Y) ∷ ⟰ᵗ Σ⁺) →
+  leftStoreⁱ ρ₀ ≡ leftStoreⁱ ρ⁺
+prefix-left-store-shape-stable prefix-reflⁱ old-shape new-shape = refl
+prefix-left-store-shape-stable
+    (prefix-∷ⁱ {entry = store-matched α A β B p} prefix)
+    (X , Σ₀ , old≡) (Y , Σ⁺ , new≡) =
+  ⊥-elim
+    (zero∉-⟰ᵗ
+      (subst (λ Σ → (zero , X) ∈ Σ) (cong (drop 1) new≡)
+        (leftStoreⁱ-prefix-inclusion prefix
+          (subst (λ Σ → (zero , X) ∈ Σ)
+            (sym old≡) (here refl)))))
+prefix-left-store-shape-stable
+    (prefix-∷ⁱ {entry = store-left α A hA} prefix)
+    (X , Σ₀ , old≡) (Y , Σ⁺ , new≡) =
+  ⊥-elim
+    (zero∉-⟰ᵗ
+      (subst (λ Σ → (zero , X) ∈ Σ) (cong (drop 1) new≡)
+        (leftStoreⁱ-prefix-inclusion prefix
+          (subst (λ Σ → (zero , X) ∈ Σ)
+            (sym old≡) (here refl)))))
+prefix-left-store-shape-stable
+    (prefix-∷ⁱ {entry = store-right β B hB} prefix)
+    old-shape new-shape =
+  prefix-left-store-shape-stable prefix old-shape new-shape
+prefix-left-store-shape-stable
+    (prefix-∷ⁱ {entry = store-link α A β B p} prefix)
+    old-shape new-shape =
+  prefix-left-store-shape-stable prefix old-shape new-shape
+
+
+prefix-right-store-shape-stable :
+  ∀ {Φ Δᴸ Δᴿ}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  (∃[ X ] ∃[ Σ₀ ]
+    rightStoreⁱ ρ₀ ≡ (zero , X) ∷ ⟰ᵗ Σ₀) →
+  (∃[ Y ] ∃[ Σ⁺ ]
+    rightStoreⁱ ρ⁺ ≡ (zero , Y) ∷ ⟰ᵗ Σ⁺) →
+  rightStoreⁱ ρ₀ ≡ rightStoreⁱ ρ⁺
+prefix-right-store-shape-stable prefix-reflⁱ old-shape new-shape = refl
+prefix-right-store-shape-stable
+    (prefix-∷ⁱ {entry = store-matched α A β B p} prefix)
+    (X , Σ₀ , old≡) (Y , Σ⁺ , new≡) =
+  ⊥-elim
+    (zero∉-⟰ᵗ
+      (subst (λ Σ → (zero , X) ∈ Σ) (cong (drop 1) new≡)
+        (rightStoreⁱ-prefix-inclusion prefix
+          (subst (λ Σ → (zero , X) ∈ Σ)
+            (sym old≡) (here refl)))))
+prefix-right-store-shape-stable
+    (prefix-∷ⁱ {entry = store-left α A hA} prefix)
+    old-shape new-shape =
+  prefix-right-store-shape-stable prefix old-shape new-shape
+prefix-right-store-shape-stable
+    (prefix-∷ⁱ {entry = store-right β B hB} prefix)
+    (X , Σ₀ , old≡) (Y , Σ⁺ , new≡) =
+  ⊥-elim
+    (zero∉-⟰ᵗ
+      (subst (λ Σ → (zero , X) ∈ Σ) (cong (drop 1) new≡)
+        (rightStoreⁱ-prefix-inclusion prefix
+          (subst (λ Σ → (zero , X) ∈ Σ)
+            (sym old≡) (here refl)))))
+prefix-right-store-shape-stable
+    (prefix-∷ⁱ {entry = store-link α A β B p} prefix)
+    old-shape new-shape =
+  prefix-right-store-shape-stable prefix old-shape new-shape
+
+
+term-typing-prefix-left-align :
+  ∀ {Φ} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {Γ Γ⁺ : Ctx} {M : Term} {A A⁺ : Ty} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  Δᴸ ∣ leftStoreⁱ ρ₀ ∣ Γ ⊢ M ⦂ A →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ A⁺ →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γ ⊢ M ⦂ A
+term-typing-prefix-left-align {M = M} prefix old⊢ new⊢
+    with bullet-classification M
+term-typing-prefix-left-align prefix old⊢ new⊢ | inj₁ noM =
+  term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix) noM old⊢
+term-typing-prefix-left-align prefix old⊢ new⊢ | inj₂ hasM =
+  subst
+    (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+    (prefix-left-store-shape-stable prefix
+      (bullet-typing-store-shape hasM old⊢)
+      (bullet-typing-store-shape hasM new⊢))
+    old⊢
+
+
+term-typing-prefix-right-align :
+  ∀ {Φ} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {Γ Γ⁺ : Ctx} {M : Term} {A A⁺ : Ty} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  Δᴿ ∣ rightStoreⁱ ρ₀ ∣ Γ ⊢ M ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ A⁺ →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ ⊢ M ⦂ A
+term-typing-prefix-right-align {M = M} prefix old⊢ new⊢
+    with bullet-classification M
+term-typing-prefix-right-align prefix old⊢ new⊢ | inj₁ noM =
+  term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix) noM old⊢
+term-typing-prefix-right-align prefix old⊢ new⊢ | inj₂ hasM =
+  subst
+    (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+    (prefix-right-store-shape-stable prefix
+      (bullet-typing-store-shape hasM old⊢)
+      (bullet-typing-store-shape hasM new⊢))
+    old⊢
 
 
 one-bullet-prefix-left-store-stable :

--- a/GTSF/proof/NuCore/Misc/NuImprecisionWorldEmbeddingNoBullet.agda
+++ b/GTSF/proof/NuCore/Misc/NuImprecisionWorldEmbeddingNoBullet.agda
@@ -37,8 +37,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; blame⊑ᵀ
+  ( blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -82,7 +81,6 @@ open import proof.Catchup.Simulation.NuImprecisionSimulationCore using
   ( RelWorldEmbeddingⁱ
   ; embedding-context
   ; left-embedding-inverse
-  ; rel-world-allocation-prefix-embedᵀ
   ; rel-world-blame-embedᵀ
   ; rel-world-cast⊒⊑-embedᵀ
   ; rel-world-cast⊑⊑-embedᵀ
@@ -270,15 +268,12 @@ mutual
         (store-embedding emb)
         rel-ctx-rename-[]
   rel-world-embed-no•ᵀ emb
-      (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ L⊑L′ L⊢ L′⊢)
+      (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ L⊑L′
+        prefix L⊢ L′⊢)
       () noM′
   rel-world-embed-no•ᵀ emb
-      (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ L⊢ N′⊢) () noN′
-  rel-world-embed-no•ᵀ emb
-      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) noM noM′ =
-    rel-world-allocation-prefix-embedᵀ emb prefix
-      (λ emb₀ → rel-world-embed-no•ᵀ emb₀ M⊑M′ noM noM′)
-      noM noM′ M⊢ M′⊢
+      (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ prefix L⊢ N′⊢)
+      () noN′
   rel-world-embed-no•ᵀ emb
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
         liftρ liftγ N⊑N′ replace)

--- a/GTSF/proof/NuCore/Relations/NuImprecisionQuotientedTyping.agda
+++ b/GTSF/proof/NuCore/Relations/NuImprecisionQuotientedTyping.agda
@@ -194,14 +194,11 @@ mutual
       (embedded-creation-source-typingᴱ embedded)
   nu-term-imprecision-source-typing
       (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
-        L•⊢ L′•⊢) =
+        prefix L•⊢ L′•⊢) =
     L•⊢
   nu-term-imprecision-source-typing
-      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ prefix L•⊢ N′⊢) =
     L•⊢
-  nu-term-imprecision-source-typing
-      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) =
-    M⊢
   nu-term-imprecision-source-typing
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
         liftρ liftγ N⊑N′ replace) =
@@ -305,14 +302,11 @@ mutual
       (embedded-creation-target-typingᴱ embedded)
   nu-term-imprecision-target-typing
       (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
-        L•⊢ L′•⊢) =
+        prefix L•⊢ L′•⊢) =
     L′•⊢
   nu-term-imprecision-target-typing
-      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+      (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′ prefix L•⊢ N′⊢) =
     N′⊢
-  nu-term-imprecision-target-typing
-      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) =
-    M′⊢
   nu-term-imprecision-target-typing
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
         liftρ liftγ N⊑N′ replace) =

--- a/GTSF/proof/OneStep/Allocation/NuImprecisionMatchedNuAllocationStepProof.agda
+++ b/GTSF/proof/OneStep/Allocation/NuImprecisionMatchedNuAllocationStepProof.agda
@@ -10,6 +10,8 @@ module
 --   * Contains no dispatcher, postulate, hole, permissive option, or legacy
 --     allocation or broad simulation import.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Conversion using (RevealConversion)
 open import ConversionIndexCompatibility using
@@ -143,7 +145,7 @@ private
       ⊢ᴺ ⇑ᵗᵐ L ⊑ ⇑ᵗᵐ L′ ⦂ ⇑ᵗ A ⊑ ⇑ᵗ B
         ∶ ⊑-lift∀ᵢ p
   matched-lift-prefix-bodyᵀ liftρ prefix noL noL′ L⊑L′ =
-    allocation-prefixᵀ prefix body
+    term-imprecision-store-prefixᵀ prefix body
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         noL↑ (nu-term-imprecision-source-typing body))
       (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
@@ -417,7 +419,7 @@ private
       right-reveal
       replace
       (α⊑αᵀ vN noN vN′ noN′ A⇑⊑A′⇑ liftρ lift-ctx-[]
-        N⊑N′ left-bullet-typing right-bullet-typing)
+        N⊑N′ prefix-reflⁱ left-bullet-typing right-bullet-typing)
     where
     left-reveal =
       subst

--- a/GTSF/proof/OneStep/NuImprecisionAtomicSourceReindex.agda
+++ b/GTSF/proof/OneStep/NuImprecisionAtomicSourceReindex.agda
@@ -24,8 +24,7 @@ open import proof.NuCore.Relations.NuImprecisionTermContextDef using
   (CtxImp)
 open import NuTerms using (Value; _⟨_⟩)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; blame⊑ᵀ
+  ( blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -129,15 +128,10 @@ atomic-source-value-reindexᵀ () vV
     (target-instantiationᵀ embedded) q
 atomic-source-value-reindexᵀ atom ()
     (α⊑αᵀ vL noL vL′ noL′ p↑ liftρ liftγ
-      L⊑L′ L•⊢ L′•⊢) q
+      L⊑L′ prefix L•⊢ L′•⊢) q
 atomic-source-value-reindexᵀ atom ()
     (α⊑ᵀ vL noL hA liftρ liftγ
-      L⊑M′ L•⊢ M′⊢) q
-atomic-source-value-reindexᵀ atom vV
-    (allocation-prefixᵀ prefix V⊑M′ V⊢ M′⊢) q =
-  allocation-prefixᵀ prefix
-    (atomic-source-value-reindexᵀ atom vV V⊑M′ q)
-    V⊢ M′⊢
+      L⊑M′ prefix L•⊢ M′⊢) q
 atomic-source-value-reindexᵀ atom ()
     (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ p↑ liftρ liftγ
       N⊑N′ replacement) q

--- a/GTSF/proof/OneStep/NuImprecisionAtomicTargetReindex.agda
+++ b/GTSF/proof/OneStep/NuImprecisionAtomicTargetReindex.agda
@@ -28,8 +28,7 @@ open import proof.NuCore.Relations.NuImprecisionTermContextDef using
   )
 open import NuTerms using (Value; _⟨_⟩)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; blame⊑ᵀ
+  ( blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -147,19 +146,14 @@ atomic-target-value-reindexᵀ atom vV
       (embedded-creation-target-shapeᴱ embedded) atom)
 atomic-target-value-reindexᵀ atom ()
     (α⊑αᵀ vL noL vL′ noL′ p↑ liftρ liftγ
-      L⊑L′ L•⊢ L′•⊢) q
+      L⊑L′ allocation-prefix L•⊢ L′•⊢) q
 atomic-target-value-reindexᵀ atom vV
     (α⊑ᵀ {occ = occ} {{safe = safe}} vL noL hA liftρ liftγ
-      L⊑V L•⊢ V⊢) q =
+      L⊑V allocation-prefix L•⊢ V⊢) q =
   α⊑ᵀ {{safe = safe}} vL noL hA liftρ liftγ
     (atomic-target-value-reindexᵀ atom vV L⊑V
       (ν safe occ q))
-    L•⊢ V⊢
-atomic-target-value-reindexᵀ atom vV
-    (allocation-prefixᵀ prefix M⊑V M⊢ V⊢) q =
-  allocation-prefixᵀ prefix
-    (atomic-target-value-reindexᵀ atom vV M⊑V q)
-    M⊢ V⊢
+    allocation-prefix L•⊢ V⊢
 atomic-target-value-reindexᵀ atom ()
     (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ p↑ liftρ liftγ N⊑N′
       replacement) q

--- a/GTSF/proof/OneStep/NuImprecisionOneStepPrimitiveLeaves.agda
+++ b/GTSF/proof/OneStep/NuImprecisionOneStepPrimitiveLeaves.agda
@@ -50,7 +50,6 @@ open import NuTerms using
 open import Primitives using (addℕ; κℕ)
 open import QuotientedTermImprecision using
   ( _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
-  ; allocation-prefixᵀ
   ; κ⊑κᵀ
   )
 open import TermTyping using (forget)
@@ -107,9 +106,6 @@ private
     _≡_ {A = Term} ($ (κℕ m)) ($ (κℕ n))
   related-nat-constant-target-constantᵀ
       {m = n} {n = .n} κ⊑κᵀ = refl
-  related-nat-constant-target-constantᵀ
-      (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) =
-    related-nat-constant-target-constantᵀ M⊑M′
 
 
 runtime-⊕₁-viewᵀ :

--- a/GTSF/proof/PairedLambda/Conversions/NuImprecisionPairedLambdaTargetClosingGenLeafNuConversionRotationProof.agda
+++ b/GTSF/proof/PairedLambda/Conversions/NuImprecisionPairedLambdaTargetClosingGenLeafNuConversionRotationProof.agda
@@ -10,6 +10,8 @@ module
 --   * Contains no paired-conversion semantic implementation, postulate, hole,
 --     permissive option, or broad simulation import.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (refl)
 import Coercions as C
@@ -35,8 +37,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; cast⊒⊑ᵀ
+  ( cast⊒⊑ᵀ
   ; conv⊑convᵀ
   ; paired-conversion
   ; α⊑ᵀ
@@ -79,7 +80,7 @@ paired-lambda-target-closing-gen-leaf-ν-conversion-rotation-proofᵀ
       V⊑N′ (ν _ occ-r r)
 
   generic-relation =
-    allocation-prefixᵀ prefix generic-relation₀
+    term-imprecision-store-prefixᵀ prefix generic-relation₀
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         generic-no-bullet
         (nu-term-imprecision-source-typing generic-relation₀))

--- a/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetClosingFrameViewProof.agda
+++ b/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetClosingFrameViewProof.agda
@@ -38,7 +38,6 @@ open import QuotientedTermImprecision using
   ; QuotientWideningPair
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   ; _∣_∣_∣_∣_⊢ᴺᵖ_⊑_⦂_⊑ᵖ_∶_
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
@@ -201,20 +200,11 @@ mutual
       frame-refl
   paired-lambda-target-closing-frame-viewᵀ
       () noW vW′ noW′ allW
-      (α⊑αᵀ vL noL vL′ noL′ p liftρ liftγ L⊑L′ L⊢ L′⊢)
+      (α⊑αᵀ vL noL vL′ noL′ p liftρ liftγ L⊑L′
+        prefix L⊢ L′⊢)
   paired-lambda-target-closing-frame-viewᵀ
       () noW vW′ noW′ allW
-      (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ L⊢ N′⊢)
-  paired-lambda-target-closing-frame-viewᵀ
-      vW noW vW′ noW′ allW
-      (allocation-prefixᵀ prefix rel W⊢ W′⊢)
-      with paired-lambda-target-closing-frame-viewᵀ
-        vW noW vW′ noW′ allW rel
-  paired-lambda-target-closing-frame-viewᵀ
-      vW noW vW′ noW′ allW
-      (allocation-prefixᵀ prefix rel W⊢ W′⊢)
-      | closing-frame-view leaf frames =
-    closing-frame-view leaf (frame-prefix frames prefix W⊢ W′⊢)
+      (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ prefix L⊢ N′⊢)
   paired-lambda-target-closing-frame-viewᵀ
       () noW vW′ noW′ allW
       (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑

--- a/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetClosingFrameViewProperties.agda
+++ b/GTSF/proof/PairedLambda/FrameClosing/Target/NuImprecisionPairedLambdaTargetClosingFrameViewProperties.agda
@@ -11,6 +11,8 @@ module proof.PairedLambda.FrameClosing.Target.NuImprecisionPairedLambdaTargetClo
 --     option.
 
 import Coercions as C
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Coercions using (_!)
 open import Data.List using ([])
 open import Data.Product using (_,_)
@@ -32,7 +34,6 @@ open import QuotientedTermImprecision using
   ( _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   ; Λ⊑Λᵀ
   ; Λ⊑ᵀ
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; conv⊑convᵀ
@@ -138,7 +139,7 @@ paired-lambda-target-closing-frame-view-frames-relation L⊑L′
   L⊑L′
 paired-lambda-target-closing-frame-view-frames-relation L⊑L′
     (frame-prefix frames prefix W⊢ W′⊢) =
-  allocation-prefixᵀ prefix
+  term-imprecision-store-prefixᵀ prefix
     (paired-lambda-target-closing-frame-view-frames-relation L⊑L′ frames)
     W⊢ W′⊢
 paired-lambda-target-closing-frame-view-frames-relation L⊑L′

--- a/GTSF/proof/PairedLambda/LambdaLeaves/Core/NuImprecisionPairedLambdaTargetClosingLambdaLeafClosingProof.agda
+++ b/GTSF/proof/PairedLambda/LambdaLeaves/Core/NuImprecisionPairedLambdaTargetClosingLambdaLeafClosingProof.agda
@@ -13,6 +13,8 @@ module
 --   * Contains no postulate, hole, permissive option, or broad simulation
 --     import.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 import Coercions as C
@@ -44,8 +46,7 @@ open import proof.NuCore.Relations.NuImprecisionTermContextDef using
   )
 open import NuTerms using (No•; Term; Value; Λ_; no•-Λ)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; conv↑⊑ᵀ
+  ( conv↑⊑ᵀ
   ; conv⊑convᵀ
   ; paired-conversion
   ; Λ⊑ᵀ
@@ -95,7 +96,7 @@ paired-lambda-target-closing-lambda-leaf-closing-proofᵀ
   lambda-relation₀ = Λ⊑ᵀ occ liftΛ liftγ vV V⊑N′
 
   lambda-relation =
-    allocation-prefixᵀ prefix lambda-relation₀
+    term-imprecision-store-prefixᵀ prefix lambda-relation₀
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         lambda-no-bullet
         (nu-term-imprecision-source-typing lambda-relation₀))

--- a/GTSF/proof/PairedLambda/LambdaLeaves/Structural/NuImprecisionPairedLambdaTargetClosingLambdaLambdaLeafStructuralConcealClosingFromAllConversionProof.agda
+++ b/GTSF/proof/PairedLambda/LambdaLeaves/Structural/NuImprecisionPairedLambdaTargetClosingLambdaLambdaLeafStructuralConcealClosingFromAllConversionProof.agda
@@ -13,13 +13,14 @@ module
 --   * Contains no canonical assembly, postulate, hole, permissive option,
 --     broad simulation import, or pre-final-reveal intermediate index.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Data.Nat.Properties using (≤-refl)
 open import Conversion using (conceal-all)
 open import NuTerms using (Λ_; no•-Λ)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; paired-conceal
+  ( paired-conceal
   ; Λ⊑Λᵀ
   )
 open import proof.Store.Prefix.NuImprecisionStorePrefix using
@@ -65,7 +66,7 @@ paired-lambda-target-closing-lambda-lambda-leaf-structural-conceal-closing-from-
   lambda-relation₀ = Λ⊑Λᵀ liftΛ liftγ vV vV′ V⊑V′
 
   lambda-relation =
-    allocation-prefixᵀ prefix lambda-relation₀
+    term-imprecision-store-prefixᵀ prefix lambda-relation₀
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         lambda-no-bullet
         (nu-term-imprecision-source-typing lambda-relation₀))

--- a/GTSF/proof/PairedLambda/LambdaLeaves/Structural/NuImprecisionPairedLambdaTargetClosingLambdaLambdaLeafStructuralRevealClosingFromAllConversionProof.agda
+++ b/GTSF/proof/PairedLambda/LambdaLeaves/Structural/NuImprecisionPairedLambdaTargetClosingLambdaLambdaLeafStructuralRevealClosingFromAllConversionProof.agda
@@ -13,13 +13,14 @@ module
 --   * Contains no canonical assembly, postulate, hole, permissive option,
 --     broad simulation import, or pre-final-reveal intermediate index.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Data.Nat.Properties using (≤-refl)
 open import Conversion using (reveal-all)
 open import NuTerms using (Λ_; no•-Λ)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; paired-reveal
+  ( paired-reveal
   ; Λ⊑Λᵀ
   )
 open import proof.Store.Prefix.NuImprecisionStorePrefix using
@@ -64,7 +65,7 @@ paired-lambda-target-closing-lambda-lambda-leaf-structural-reveal-closing-from-a
   lambda-relation₀ = Λ⊑Λᵀ liftΛ liftγ vV vV′ V⊑V′
 
   lambda-relation =
-    allocation-prefixᵀ prefix lambda-relation₀
+    term-imprecision-store-prefixᵀ prefix lambda-relation₀
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         lambda-no-bullet
         (nu-term-imprecision-source-typing lambda-relation₀))

--- a/GTSF/proof/PairedLambda/SourceFrames/SourceAll/NuImprecisionPairedLambdaTargetClosingSourceAllFrameCommutationProof.agda
+++ b/GTSF/proof/PairedLambda/SourceFrames/SourceAll/NuImprecisionPairedLambdaTargetClosingSourceAllFrameCommutationProof.agda
@@ -12,6 +12,8 @@ module
 --   * Contains no canonical assembly, postulate, hole, permissive option, or
 --     broad simulation/core import.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 import Coercions as C
 open import Conversion using (reveal-all)
@@ -20,8 +22,7 @@ open import Data.Product using (_,_)
 open import ImprecisionWf using (ν; ∀ⁱ_)
 open import NuTerms using (no•-⟨⟩; _⟨_⟩)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; conv↑⊑ᵀ
+  ( conv↑⊑ᵀ
   ; conv⊑convᵀ
   ; paired-conversion
   )
@@ -74,7 +75,7 @@ paired-lambda-target-closing-source-all-frame-commutation-proofᵀ
   framed-no-bullet = no•-⟨⟩ noW
 
   ambient-relation =
-    allocation-prefixᵀ prefix framed
+    term-imprecision-store-prefixᵀ prefix framed
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         framed-no-bullet
         (nu-term-imprecision-source-typing framed))

--- a/GTSF/proof/PairedLambda/SourceFrames/UpFrames/NuImprecisionPairedLambdaTargetClosingUpGenLeafClosingProof.agda
+++ b/GTSF/proof/PairedLambda/SourceFrames/UpFrames/NuImprecisionPairedLambdaTargetClosingUpGenLeafClosingProof.agda
@@ -12,6 +12,8 @@ module
 --   * Contains no postulate, hole, permissive option, broad simulation
 --     import, or recursive frame-closing dependency.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (refl)
 import Coercions as C
@@ -56,7 +58,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( QuotientWideningPair
-  ; allocation-prefixᵀ
   ; conv↑⊑ᵀ
   ; conv⊑convᵀ
   ; gen-down⊑gen-downᵀ
@@ -132,7 +133,7 @@ paired-lambda-target-closing-up-gen-leaf-closing-proofᵀ
     up⊑upᵀ quotient-relation widening (ν safe occ-r r)
 
   endpoint-relation =
-    allocation-prefixᵀ prefix endpoint-relation₀
+    term-imprecision-store-prefixᵀ prefix endpoint-relation₀
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         source-no-bullet
         (nu-term-imprecision-source-typing endpoint-relation₀))

--- a/GTSF/proof/PairedLambda/Terminal/NuImprecisionPairedLambdaTargetClosingPendingTargetMaterializationProof.agda
+++ b/GTSF/proof/PairedLambda/Terminal/NuImprecisionPairedLambdaTargetClosingPendingTargetMaterializationProof.agda
@@ -10,11 +10,12 @@ module
 --     target value/no-bullet constructors, and quotiented term-imprecision
 --     frame constructors.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Data.Product using (_,_)
 open import NuTerms using (Value; _⟨_⟩; no•-⟨⟩)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ⊑cast⊒ᵀ
+  ( ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
   ; ⊑cast⊑idᵀ
   ; ⊑conv↑ᵀ
@@ -45,7 +46,7 @@ paired-lambda-target-closing-pending-target-materialization-proofᵀ
 paired-lambda-target-closing-pending-target-materialization-proofᵀ
     vW′ noW′ W⊑W′ (pending-prefix prefix W⊢ W′⊢ pending) =
   paired-lambda-target-closing-pending-target-materialization-proofᵀ
-    vW′ noW′ (allocation-prefixᵀ prefix W⊑W′ W⊢ W′⊢) pending
+    vW′ noW′ (term-imprecision-store-prefixᵀ prefix W⊑W′ W⊢ W′⊢) pending
 paired-lambda-target-closing-pending-target-materialization-proofᵀ
     vW′ noW′ W⊑W′
     (pending-⊑cast⊒ {r = r} inert-c′ mode′ seal★′ c′⊒ pending) =

--- a/GTSF/proof/Quotient/NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda
+++ b/GTSF/proof/Quotient/NuImprecisionEmbeddedTargetInstantiationCreationProperties.agda
@@ -5,8 +5,8 @@ module
 -- File Charter:
 --   * Projects endpoint typing, value, and no-bullet evidence from the
 --     composable embedded target-instantiation creation residual.
---   * Proves each property by structural recursion over exact creation and
---     composed world embeddings.
+--   * Proves each property by structural recursion over exact creation,
+--     composed world embeddings, and allocation-prefix lineage.
 --   * Imports no term-imprecision judgment and contains no postulate, hole,
 --     permissive option, termination bypass, or catch-all clause.
 
@@ -48,6 +48,7 @@ open import
   ; embed-creationᴱ
   ; embed-creation-leftᴱ
   ; exact-creationᴱ
+  ; prefix-creationᴱ
   )
 
 
@@ -75,6 +76,9 @@ embedded-creation-source-typingᴱ
     (embed-creation-leftᴱ embedded assm hτ store-embedding
       source-typing target-typing) =
   source-typing
+embedded-creation-source-typingᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
+  source-typing
 
 
 embedded-creation-target-typingᴱ :
@@ -100,6 +104,9 @@ embedded-creation-target-typingᴱ
 embedded-creation-target-typingᴱ
     (embed-creation-leftᴱ embedded assm hτ store-embedding
       source-typing target-typing) =
+  target-typing
+embedded-creation-target-typingᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
   target-typing
 
 
@@ -129,6 +136,9 @@ embedded-creation-source-valueᴱ
       source-typing target-typing) =
   renameᵗᵐ-preserves-Value _
     (embedded-creation-source-valueᴱ embedded)
+embedded-creation-source-valueᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
+  embedded-creation-source-valueᴱ embedded
 
 
 embedded-creation-target-valueᴱ :
@@ -156,6 +166,9 @@ embedded-creation-target-valueᴱ
 embedded-creation-target-valueᴱ
     (embed-creation-leftᴱ embedded assm hτ store-embedding
       source-typing target-typing) =
+  embedded-creation-target-valueᴱ embedded
+embedded-creation-target-valueᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
   embedded-creation-target-valueᴱ embedded
 
 
@@ -185,6 +198,9 @@ embedded-creation-source-no-bulletᴱ
       source-typing target-typing) =
   renameᵗᵐ-preserves-No• _
     (embedded-creation-source-no-bulletᴱ embedded)
+embedded-creation-source-no-bulletᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
+  embedded-creation-source-no-bulletᴱ embedded
 
 
 embedded-creation-target-no-bulletᴱ :
@@ -211,6 +227,9 @@ embedded-creation-target-no-bulletᴱ
 embedded-creation-target-no-bulletᴱ
     (embed-creation-leftᴱ embedded assm hτ store-embedding
       source-typing target-typing) =
+  embedded-creation-target-no-bulletᴱ embedded
+embedded-creation-target-no-bulletᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
   embedded-creation-target-no-bulletᴱ embedded
 
 
@@ -240,4 +259,7 @@ embedded-creation-target-shapeᴱ
 embedded-creation-target-shapeᴱ
     (embed-creation-leftᴱ embedded assm hτ store-embedding
       source-typing target-typing) =
+  embedded-creation-target-shapeᴱ embedded
+embedded-creation-target-shapeᴱ
+    (prefix-creationᴱ embedded prefix source-typing target-typing) =
   embedded-creation-target-shapeᴱ embedded

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientDef.agda
@@ -9,8 +9,8 @@ module
 --     constructor embeds or converts from another term-imprecision judgment.
 --   * Includes matched and source-only type application and `ν`, with their
 --     allocation-aware store lifts and exact index-substitution equations.
---   * Includes ordinary one-sided and paired reveal/conceal conversions, and
---     proof-only closure under store-prefix extension.
+--   * Includes ordinary one-sided and paired reveal/conceal conversions.
+--     General store-prefix weakening is admissible rather than a constructor.
 --   * Retains the terminal `gen`/ground join, whose value endpoints cannot be
 --     recovered merely by closing the simulation under reduction.
 --   * Keeps quotient indices only across one paired narrowing cast and closes
@@ -234,7 +234,7 @@ mutual
         ⊢ᴿ Λ V ⊑ N′ ⦂ `∀ A ⊑ B ∶ ν safe occ p
 
     α⊑αᴿ :
-      ∀ {ρ′ γ′ L L′ A B C D p} →
+      ∀ {ρ′ ρ⁺ γ′ L L′ A B C D p} →
       Value L →
       No• L →
       Value L′ →
@@ -246,27 +246,24 @@ mutual
       LiftCtxⁱ ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ) γ γ′ →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ L ⊑ L′ ⦂ `∀ C ⊑ `∀ D ∶ ∀ⁱ p →
+      StoreImpPrefixᴿ
+        (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
+          A⇑⊑B⇑ ∷ ρ′)
+        ρ⁺ →
       suc Δᴸ
-        ∣ leftStoreⁱ
-            (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
-              A⇑⊑B⇑ ∷ ρ′)
+        ∣ leftStoreⁱ ρ⁺
         ∣ leftCtxⁱ γ′
         ⊢ (⇑ᵗᵐ L) • ⦂ C →
       suc Δᴿ
-        ∣ rightStoreⁱ
-            (store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
-              A⇑⊑B⇑ ∷ ρ′)
+        ∣ rightStoreⁱ ρ⁺
         ∣ rightCtxⁱ γ′
         ⊢ (⇑ᵗᵐ L′) • ⦂ D →
       ((zero ˣ⊑ˣ zero) ∷ ⇑ᵢ Φ)
-        ∣ suc Δᴸ ∣ suc Δᴿ
-        ∣ store-matched zero (⇑ᵗ A) zero (⇑ᵗ B)
-            A⇑⊑B⇑ ∷ ρ′
-        ∣ γ′
+        ∣ suc Δᴸ ∣ suc Δᴿ ∣ ρ⁺ ∣ γ′
         ⊢ᴿ (⇑ᵗᵐ L) • ⊑ (⇑ᵗᵐ L′) • ⦂ C ⊑ D ∶ p
 
     α⊑ᴿ :
-      ∀ {ρ′ γ′ L N′ A B′ C p occ} →
+      ∀ {ρ′ ρ⁺ γ′ L N′ A B′ C p occ} →
       {{safe : NonVar C}} →
       Value L →
       No• L →
@@ -275,28 +272,20 @@ mutual
       LiftLeftCtxⁱ ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ) γ γ′ →
       Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
         ⊢ᴿ L ⊑ N′ ⦂ `∀ C ⊑ B′ ∶ ν safe occ p →
+      StoreImpPrefixᴿ
+        (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+        ρ⁺ →
       suc Δᴸ
-        ∣ leftStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+        ∣ leftStoreⁱ ρ⁺
         ∣ leftCtxⁱ γ′
         ⊢ (⇑ᵗᵐ L) • ⦂ C →
       Δᴿ
-        ∣ rightStoreⁱ (store-left zero (⇑ᵗ A) h⇑A ∷ ρ′)
+        ∣ rightStoreⁱ ρ⁺
         ∣ rightCtxⁱ γ′
         ⊢ N′ ⦂ B′ →
       ((zero ˣ⊑★) ∷ ⇑ᴸᵢ Φ)
-        ∣ suc Δᴸ ∣ Δᴿ
-        ∣ store-left zero (⇑ᵗ A) h⇑A ∷ ρ′ ∣ γ′
+        ∣ suc Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ′
         ⊢ᴿ (⇑ᵗᵐ L) • ⊑ N′ ⦂ C ⊑ B′ ∶ p
-
-    allocation-prefixᴿ :
-      ∀ {ρ₀ M M′ A B p} →
-      StoreImpPrefixᴿ ρ₀ ρ →
-      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
-        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
-      Δᴸ ∣ leftStoreⁱ ρ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
-      Δᴿ ∣ rightStoreⁱ ρ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B →
-      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ γ
-        ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p
 
     ν⊑νᴿ :
       ∀ {ρ′ γ′ A A′ B B′ C C′ N N′ p q s s′ μ μ′} →

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientStorePrefixExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientStorePrefixExperiment.agda
@@ -1,0 +1,914 @@
+module
+  proof.Quotient.NuImprecisionReductionClosedQuotientStorePrefixExperiment
+  where
+
+-- File Charter:
+--   * Proves admissible relational-store prefix weakening mutually for the
+--     independent ordinary and quotient prototype judgments.
+--   * Keeps the prototype syntax-directed while preserving allocation
+--     lineage in runtime bullets and target-instantiation residuals.
+--   * Reuses the canonical live store-prefix support for projected stores,
+--     evidence, and binder lifts, but does not use the live term relation.
+--   * Contains no postulate, hole, catch-all, or permissive option.
+
+open import Data.List using (_∷_; [])
+open import Data.Nat using (suc; zero)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (refl; subst; sym)
+
+open import Coercions using (cast-tag; tag-or-idᵈ)
+open import Conversion using
+  ( weaken-conceal-conversion
+  ; weaken-reveal-conversion
+  )
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionWf using
+  ( ImpCtx
+  ; _∣_⊢_⊑_⊣_
+  )
+open import NarrowWiden using
+  ( narrow-weaken
+  ; widen-weaken
+  )
+import NarrowWiden
+open import proof.Store.Core.NuImprecisionRelationalStoreDef using
+  ( StoreImp
+  ; leftStoreⁱ
+  ; leftStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightStoreⁱ
+  ; rightStoreⁱ-lift
+  ; rightStoreⁱ-lift-left
+  )
+open import proof.NuCore.Relations.NuImprecisionTermContextDef using
+  ( CtxImp
+  ; leftCtxⁱ
+  ; leftCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; rightCtxⁱ
+  ; rightCtxⁱ-lift
+  ; rightCtxⁱ-lift-left
+  )
+open import NuTerms using (Term; _⟨_⟩; ν)
+open import QuotientImprecisionCompatibility using
+  (SpineCastMode; gradual↓; id-only↓)
+open import QuotientedTermImprecision using
+  ( StoreImpPrefix
+  ; prefix-reflⁱ
+  ; prefix-∷ⁱ
+  )
+open import Store using (StoreIncl-cons)
+open import TermTyping using
+  ( cast-tag-or-id
+  ; forget
+  ; _∣_∣_⊢_⦂_
+  ; ⊢ƛ
+  ; ⊢·
+  ; ⊢Λ
+  ; ⊢ν↑
+  ; ⊢ν⊑
+  ; ⊢⊕
+  ; ⊢⟨⟩↑
+  ; ⊢⟨⟩↓
+  ; ⊢⟨⟩⊒
+  ; ⊢⟨⟩⊑
+  )
+open import proof.Core.Properties.NuTermProperties using
+  (closed-refined-typing-recontextualize; typing-closedᵐ)
+open import proof.Core.Properties.SealModeProperties using
+  (seal★-tag-or-id)
+open import proof.Core.Properties.StoreProperties using
+  (renameStoreᵗ-incl)
+open import proof.Core.Properties.TypePreservation using
+  ( conversion↑-weaken
+  ; conversion↓-weaken
+  ; seal★-weaken
+  )
+open import proof.Store.Prefix.NuImprecisionStorePrefix using
+  ( leftStoreⁱ-prefix-inclusion
+  ; rightStoreⁱ-prefix-inclusion
+  ; store-imp-prefix-transⁱ
+  )
+open import proof.Store.Prefix.NuImprecisionStorePrefixEvidenceProof using
+  (store-corresponds-prefix-proofᵀ)
+open import proof.Store.Prefix.NuImprecisionStorePrefixLiftLemma using
+  ( left-store-prefix-liftᵀ
+  ; paired-store-prefix-liftᵀ
+  )
+open import
+  proof.NuCore.Misc.NuImprecisionRuntimeBulletStoreStability
+  using
+  ( term-typing-prefix-left-align
+  ; term-typing-prefix-right-align
+  )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientDef
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientTypingExperiment
+  using
+  ( smaller-imprecision-source-typingᴿ
+  ; smaller-imprecision-target-typingᴿ
+  ; smaller-quotient-source-typingᴿ
+  ; smaller-quotient-target-typingᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  ( StoreImpPrefixᴿ
+  ; prefix-creationᴱ
+  ; prefix-reflᴿ
+  ; prefix-∷ᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  using
+  ( embedded-creation-source-typingᴱ
+  ; embedded-creation-target-typingᴱ
+  )
+open import Types using (Ctx; Ty; TyCtx)
+
+
+private
+  to-live-prefix :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺} →
+    StoreImpPrefixᴿ {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    StoreImpPrefix ρ₀ ρ⁺
+  to-live-prefix prefix-reflᴿ = prefix-reflⁱ
+  to-live-prefix (prefix-∷ᴿ prefix) =
+    prefix-∷ⁱ (to-live-prefix prefix)
+
+  to-prototype-prefix :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺} →
+    StoreImpPrefix {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    StoreImpPrefixᴿ ρ₀ ρ⁺
+  to-prototype-prefix prefix-reflⁱ = prefix-reflᴿ
+  to-prototype-prefix (prefix-∷ⁱ prefix) =
+    prefix-∷ᴿ (to-prototype-prefix prefix)
+
+  store-imp-prefix-transᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ₁ ρ₂} →
+    StoreImpPrefixᴿ {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ₁ →
+    StoreImpPrefixᴿ ρ₁ ρ₂ →
+    StoreImpPrefixᴿ ρ₀ ρ₂
+  store-imp-prefix-transᴿ prefix₀ prefix₁ =
+    to-prototype-prefix
+      (store-imp-prefix-transⁱ
+        (to-live-prefix prefix₀)
+        (to-live-prefix prefix₁))
+
+  spine-cast-mode-prefixᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ μ} →
+    StoreImpPrefixᴿ {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    SpineCastMode (leftStoreⁱ ρ₀) μ →
+    SpineCastMode (leftStoreⁱ ρ⁺) μ
+  spine-cast-mode-prefixᴿ prefix id-only↓ = id-only↓
+  spine-cast-mode-prefixᴿ prefix (gradual↓ mode seal★) =
+    gradual↓ mode
+      (seal★-weaken
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+
+  target-spine-cast-mode-prefixᴿ :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ μ} →
+    StoreImpPrefixᴿ {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    SpineCastMode (rightStoreⁱ ρ₀) μ →
+    SpineCastMode (rightStoreⁱ ρ⁺) μ
+  target-spine-cast-mode-prefixᴿ prefix id-only↓ = id-only↓
+  target-spine-cast-mode-prefixᴿ prefix (gradual↓ mode seal★) =
+    gradual↓ mode
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+
+  right-cast-typing-prefixᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {Γ Γ⁺ : Ctx} {M : Term} {A⁺ B : Ty} {c} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ₀ ∣ Γ ⊢ M ⟨ c ⟩ ⦂ B →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ A⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ ⊢ M ⟨ c ⟩ ⦂ B
+  right-cast-typing-prefixᴿ prefix (⊢⟨⟩↑ c↑ M⊢) M⊢⁺ =
+    ⊢⟨⟩↑
+      (conversion↑-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix)) c↑)
+      (term-typing-prefix-right-align
+        (to-live-prefix prefix) M⊢ M⊢⁺)
+  right-cast-typing-prefixᴿ prefix (⊢⟨⟩↓ c↓ M⊢) M⊢⁺ =
+    ⊢⟨⟩↓
+      (conversion↓-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix)) c↓)
+      (term-typing-prefix-right-align
+        (to-live-prefix prefix) M⊢ M⊢⁺)
+  right-cast-typing-prefixᴿ prefix
+      (⊢⟨⟩⊒ mode seal★ c⊒ M⊢) M⊢⁺ =
+    ⊢⟨⟩⊒ mode
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (narrow-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c⊒)
+      (term-typing-prefix-right-align
+        (to-live-prefix prefix) M⊢ M⊢⁺)
+  right-cast-typing-prefixᴿ prefix
+      (⊢⟨⟩⊑ mode seal★ c⊑ M⊢) M⊢⁺ =
+    ⊢⟨⟩⊑ mode
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (widen-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c⊑)
+      (term-typing-prefix-right-align
+        (to-live-prefix prefix) M⊢ M⊢⁺)
+
+  cast-body-typingᴿ :
+    ∀ {Δ Σ Γ M B c} →
+    Δ ∣ Σ ∣ Γ ⊢ M ⟨ c ⟩ ⦂ B →
+    ∃[ A ] Δ ∣ Σ ∣ Γ ⊢ M ⦂ A
+  cast-body-typingᴿ (⊢⟨⟩↑ c↑ M⊢) = _ , M⊢
+  cast-body-typingᴿ (⊢⟨⟩↓ c↓ M⊢) = _ , M⊢
+  cast-body-typingᴿ (⊢⟨⟩⊒ mode seal★ c⊒ M⊢) = _ , M⊢
+  cast-body-typingᴿ (⊢⟨⟩⊑ mode seal★ c⊑ M⊢) = _ , M⊢
+
+  nu-body-typingᴿ :
+    ∀ {Δ Σ Γ A L B c} →
+    Δ ∣ Σ ∣ Γ ⊢ ν A L c ⦂ B →
+    ∃[ C ] Δ ∣ Σ ∣ Γ ⊢ L ⦂ C
+  nu-body-typingᴿ (⊢ν↑ hA L⊢ c↑) = _ , L⊢
+  nu-body-typingᴿ (⊢ν⊑ mode seal★ L⊢ c⊑) = _ , L⊢
+
+
+TermImprecisionStorePrefixᴿ : Set₁
+TermImprecisionStorePrefixᴿ =
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A B : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+    ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p
+
+
+QuotientTermImprecisionStorePrefixᴿ : Set₁
+QuotientTermImprecisionStorePrefixᴿ =
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {D D′ : Ty}
+    {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  StoreImpPrefixᴿ ρ₀ ρ⁺ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+    ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ D →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ D′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+    ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q
+
+
+private
+  align-sourceᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {A B A⁺ : Ty} {Γ⁺ : Ctx}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ A⁺ →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ A
+  align-sourceᴿ prefix M⊑M′ M⊢ =
+    term-typing-prefix-left-align (to-live-prefix prefix)
+      (smaller-imprecision-source-typingᴿ M⊑M′) M⊢
+
+  align-targetᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {A B B⁺ : Ty} {Γ⁺ : Ctx}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M′ ⦂ B⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B
+  align-targetᴿ prefix M⊑M′ M′⊢ =
+    term-typing-prefix-right-align (to-live-prefix prefix)
+      (smaller-imprecision-target-typingᴿ M⊑M′) M′⊢
+
+  align-quotient-sourceᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {D D′ D⁺ : Ty} {Γ⁺ : Ctx}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ D⁺ →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ D
+  align-quotient-sourceᴿ prefix M⊑M′ M⊢ =
+    term-typing-prefix-left-align (to-live-prefix prefix)
+      (smaller-quotient-source-typingᴿ M⊑M′) M⊢
+
+  align-quotient-targetᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {D D′ D′⁺ : Ty} {Γ⁺ : Ctx}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M′ ⦂ D′⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ D′
+  align-quotient-targetᴿ prefix M⊑M′ M′⊢ =
+    term-typing-prefix-right-align (to-live-prefix prefix)
+      (smaller-quotient-target-typingᴿ M⊑M′) M′⊢
+
+  quotient-widening-pair-prefixᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {u u′} {D D′ A A′ : Ty} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ₀ u u′ D D′ A A′ →
+    QuotientWideningPairᴿ Δᴸ Δᴿ ρ⁺ u u′ D D′ A A′
+  quotient-widening-pair-prefixᴿ prefix
+      (quotient-id-wideningᴿ source target) =
+    quotient-id-wideningᴿ
+      (widen-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        source)
+      (widen-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        target)
+  quotient-widening-pair-prefixᴿ prefix
+      (quotient-cast-wideningᴿ
+        mode seal★ source mode′ seal★′ target) =
+    quotient-cast-wideningᴿ
+      mode
+      (seal★-weaken
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (widen-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        source)
+      mode′
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★′)
+      (widen-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        target)
+
+
+mutual
+  term-imprecision-store-prefixᴿ :
+    TermImprecisionStorePrefixᴿ
+
+  quotient-term-imprecision-store-prefixᴿ :
+    QuotientTermImprecisionStorePrefixᴿ
+
+  term-imprecision-store-prefix-alignᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {A B A⁺ B⁺ : Ty} {Γᴸ⁺ Γᴿ⁺ : Ctx}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γᴸ⁺ ⊢ M ⦂ A⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γᴿ⁺ ⊢ M′ ⦂ B⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+      ⊢ᴿ M ⊑ M′ ⦂ A ⊑ B ∶ p
+
+  quotient-term-imprecision-store-prefix-alignᴿ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {D D′ D⁺ D′⁺ : Ty} {Γᴸ⁺ Γᴿ⁺ : Ctx}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    StoreImpPrefixᴿ ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γᴸ⁺ ⊢ M ⦂ D⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γᴿ⁺ ⊢ M′ ⦂ D′⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+      ⊢ᴿᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q
+
+  term-imprecision-store-prefix-goᴿ :
+    TermImprecisionStorePrefixᴿ
+
+  quotient-term-imprecision-store-prefix-goᴿ :
+    QuotientTermImprecisionStorePrefixᴿ
+
+  term-imprecision-store-prefixᴿ prefix M⊑M′ M⊢ M′⊢ =
+    term-imprecision-store-prefix-alignᴿ prefix M⊑M′ M⊢ M′⊢
+
+  quotient-term-imprecision-store-prefixᴿ prefix M⊑M′ M⊢ M′⊢ =
+    quotient-term-imprecision-store-prefix-alignᴿ
+      prefix M⊑M′ M⊢ M′⊢
+
+  term-imprecision-store-prefix-alignᴿ prefix M⊑M′ M⊢ M′⊢ =
+    term-imprecision-store-prefix-goᴿ prefix M⊑M′
+      (align-sourceᴿ prefix M⊑M′ M⊢)
+      (align-targetᴿ prefix M⊑M′ M′⊢)
+
+  quotient-term-imprecision-store-prefix-alignᴿ
+      prefix M⊑M′ M⊢ M′⊢ =
+    quotient-term-imprecision-store-prefix-goᴿ prefix M⊑M′
+      (align-quotient-sourceᴿ prefix M⊑M′ M⊢)
+      (align-quotient-targetᴿ prefix M⊑M′ M′⊢)
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (blame⊑ᴿ M′⊢₀) M⊢ M′⊢ =
+    blame⊑ᴿ M′⊢
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (x⊑xᴿ x∈) M⊢ M′⊢ =
+    x⊑xᴿ x∈
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (ƛ⊑ƛᴿ hA hA′ N⊑N′)
+      (⊢ƛ hA⁺ N⊢) (⊢ƛ hA′⁺ N′⊢) =
+    ƛ⊑ƛᴿ hA hA′
+      (term-imprecision-store-prefix-alignᴿ
+        prefix N⊑N′ N⊢ N′⊢)
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (L⊑L′ ·ᴿ M⊑M′)
+      (⊢· L⊢ M⊢) (⊢· L′⊢ M′⊢) =
+    (term-imprecision-store-prefix-alignᴿ
+      prefix L⊑L′ L⊢ L′⊢)
+    ·ᴿ
+    (term-imprecision-store-prefix-alignᴿ
+      prefix M⊑M′ M⊢ M′⊢)
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (Λ⊑Λᴿ liftρ liftγ vV vV′ V⊑V′)
+      (⊢Λ vV⁺ V⊢) (⊢Λ vV′⁺ V′⊢)
+      with paired-store-prefix-liftᵀ
+        (to-live-prefix prefix) liftρ
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (Λ⊑Λᴿ liftρ liftγ vV vV′ V⊑V′)
+      (⊢Λ vV⁺ V⊢) (⊢Λ vV′⁺ V′⊢)
+      | ρ⁺↑ , liftρ⁺ , prefix↑ =
+    Λ⊑Λᴿ liftρ⁺ liftγ vV vV′
+      (term-imprecision-store-prefix-alignᴿ
+        (to-prototype-prefix prefix↑) V⊑V′
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (sym (leftStoreⁱ-lift liftρ⁺))
+          (subst
+            (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+            (sym (leftCtxⁱ-lift liftγ))
+            V⊢))
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (sym (rightStoreⁱ-lift liftρ⁺))
+          (subst
+            (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+            (sym (rightCtxⁱ-lift liftγ))
+            V′⊢)))
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (Λ⊑ᴿ occ liftρ liftγ vV V⊑N′)
+      (⊢Λ vV⁺ V⊢) N′⊢
+      with left-store-prefix-liftᵀ
+        (to-live-prefix prefix) liftρ
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (Λ⊑ᴿ occ liftρ liftγ vV V⊑N′)
+      (⊢Λ vV⁺ V⊢) N′⊢
+      | ρ⁺↑ , liftρ⁺ , prefix↑ =
+    Λ⊑ᴿ occ liftρ⁺ liftγ vV
+      (term-imprecision-store-prefix-alignᴿ
+        (to-prototype-prefix prefix↑) V⊑N′
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (sym (leftStoreⁱ-lift-left liftρ⁺))
+          (subst
+            (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+            (sym (leftCtxⁱ-lift-left liftγ))
+            V⊢))
+        (subst
+          (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+          (sym (rightStoreⁱ-lift-left liftρ⁺))
+          (subst
+            (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+            (sym (rightCtxⁱ-lift-left liftγ))
+            N′⊢)))
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (target-instantiationᴿ embedded) M⊢ M′⊢ =
+    target-instantiationᴿ
+      (prefix-creationᴱ embedded prefix
+        (closed-refined-typing-recontextualize
+          {Γ′ = []}
+          (typing-closedᵐ
+            (forget (embedded-creation-source-typingᴱ embedded)))
+          M⊢)
+        (closed-refined-typing-recontextualize
+          {Γ′ = []}
+          (typing-closedᵐ
+            (forget (embedded-creation-target-typingᴱ embedded)))
+          M′⊢))
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
+        allocation-prefix L•⊢ L′•⊢)
+      L•⊢⁺ L′•⊢⁺ =
+    α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
+      (store-imp-prefix-transᴿ allocation-prefix prefix)
+      L•⊢⁺ L′•⊢⁺
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′
+        allocation-prefix L•⊢ N′⊢)
+      L•⊢⁺ N′⊢⁺ =
+    α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′
+      (store-imp-prefix-transᴿ allocation-prefix prefix)
+      L•⊢⁺ N′⊢⁺
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′ replace)
+      M⊢ M′⊢
+      with nu-body-typingᴿ M⊢ | nu-body-typingᴿ M′⊢
+         | paired-store-prefix-liftᵀ
+             (to-live-prefix prefix) liftρ
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+        liftρ liftγ N⊑N′ replace)
+      M⊢ M′⊢
+      | C⁺ , N⊢ | C′⁺ , N′⊢ | ρ⁺↑ , liftρ⁺ , prefix↑ =
+    ν⊑νᴿ hA hA′
+      (weaken-reveal-conversion
+        (StoreIncl-cons
+          (renameStoreᵗ-incl suc
+            (leftStoreⁱ-prefix-inclusion
+              (to-live-prefix prefix))))
+        s↑)
+      (weaken-reveal-conversion
+        (StoreIncl-cons
+          (renameStoreᵗ-incl suc
+            (rightStoreⁱ-prefix-inclusion
+              (to-live-prefix prefix))))
+        s′↑)
+      A⊑A′ A⇑⊑A′⇑ liftρ⁺ liftγ
+      (term-imprecision-store-prefix-alignᴿ
+        prefix N⊑N′ N⊢ N′⊢)
+      replace
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (ν⊑ᴿ hA h⇑A s↑ liftρ liftγ N⊑N′ replace)
+      M⊢ N′⊢
+      with nu-body-typingᴿ M⊢
+         | left-store-prefix-liftᵀ
+             (to-live-prefix prefix) liftρ
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (ν⊑ᴿ hA h⇑A s↑ liftρ liftγ N⊑N′ replace)
+      M⊢ N′⊢
+      | C⁺ , N⊢ | ρ⁺↑ , liftρ⁺ , prefix↑ =
+    ν⊑ᴿ hA h⇑A
+      (weaken-reveal-conversion
+        (StoreIncl-cons
+          (renameStoreᵗ-incl suc
+            (leftStoreⁱ-prefix-inclusion
+              (to-live-prefix prefix))))
+      s↑)
+      liftρ⁺ liftγ
+      (term-imprecision-store-prefix-alignᴿ
+        prefix N⊑N′ N⊢ N′⊢)
+      replace
+
+  term-imprecision-store-prefix-goᴿ
+      prefix κ⊑κᴿ M⊢ M′⊢ =
+    κ⊑κᴿ
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (L⊑L′ ⊕ᴿ[ op ] M⊑M′)
+      (⊢⊕ L⊢ op⁺ M⊢) (⊢⊕ L′⊢ op′⁺ M′⊢) =
+    (term-imprecision-store-prefix-alignᴿ
+      prefix L⊑L′ L⊢ L′⊢)
+    ⊕ᴿ[ op ]
+    (term-imprecision-store-prefix-alignᴿ
+      prefix M⊑M′ M⊢ M′⊢)
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (gen⊑groundᴿ mode seal★ c⊒ gH vV vW W⊢₀ V⊑Wtag q)
+      M⊢ W⊢
+      with cast-body-typingᴿ M⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (gen⊑groundᴿ mode seal★ c⊒ gH vV vW W⊢₀ V⊑Wtag q)
+      M⊢ W⊢
+      | A⁺ , V⊢ =
+    gen⊑groundᴿ
+      mode
+      (seal★-weaken
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (narrow-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c⊒)
+      gH vV vW W⊢
+      (term-imprecision-store-prefix-alignᴿ
+        prefix V⊑Wtag V⊢
+        (right-cast-typing-prefixᴿ prefix
+          (smaller-imprecision-target-typingᴿ V⊑Wtag)
+          W⊢))
+      q
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q c-shape comp)
+      L⊢ M′⊢
+      with cast-body-typingᴿ L⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (cast⊒⊑ᴿ mode seal★ c⊒ M⊑M′ q c-shape comp)
+      L⊢ M′⊢
+      | A⁺ , M⊢ =
+    cast⊒⊑ᴿ mode
+      (seal★-weaken
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (narrow-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c⊒)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q c-shape comp
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q c-shape comp)
+      L⊢ M′⊢
+      with cast-body-typingᴿ L⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (cast⊑⊑ᴿ mode seal★ c⊑ M⊑M′ q c-shape comp)
+      L⊢ M′⊢
+      | A⁺ , M⊢ =
+    cast⊑⊑ᴿ mode
+      (seal★-weaken
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (widen-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c⊑)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q c-shape comp
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (⊑cast⊒ᴿ mode′ seal★′ c′⊒ M⊑M′ q c-shape comp)
+      M⊢ L′⊢
+      with cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (⊑cast⊒ᴿ mode′ seal★′ c′⊒ M⊑M′ q c-shape comp)
+      M⊢ L′⊢
+      | B′⁺ , M′⊢ =
+    ⊑cast⊒ᴿ mode′
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★′)
+      (narrow-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′⊒)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q c-shape comp
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (⊑cast⊑ᴿ mode′ seal★′ c′⊑ M⊑M′ q c-shape comp)
+      M⊢ L′⊢
+      with cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (⊑cast⊑ᴿ mode′ seal★′ c′⊑ M⊑M′ q c-shape comp)
+      M⊢ L′⊢
+      | B′⁺ , M′⊢ =
+    ⊑cast⊑ᴿ mode′
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★′)
+      (widen-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′⊑)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q c-shape comp
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (conv↑⊑ᴿ c↑ M⊑M′ q replace)
+      L⊢ M′⊢
+      with cast-body-typingᴿ L⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix (conv↑⊑ᴿ c↑ M⊑M′ q replace)
+      L⊢ M′⊢
+      | A⁺ , M⊢ =
+    conv↑⊑ᴿ
+      (weaken-reveal-conversion
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c↑)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q replace
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (conv↓⊑ᴿ c↓ M⊑M′ q replace)
+      L⊢ M′⊢
+      with cast-body-typingᴿ L⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix (conv↓⊑ᴿ c↓ M⊑M′ q replace)
+      L⊢ M′⊢
+      | A⁺ , M⊢ =
+    conv↓⊑ᴿ
+      (weaken-conceal-conversion
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c↓)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q replace
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (⊑conv↑ᴿ c′↑ M⊑M′ q replace)
+      M⊢ L′⊢
+      with cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix (⊑conv↑ᴿ c′↑ M⊑M′ q replace)
+      M⊢ L′⊢
+      | B′⁺ , M′⊢ =
+    ⊑conv↑ᴿ
+      (weaken-reveal-conversion
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′↑)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q replace
+
+  term-imprecision-store-prefix-goᴿ
+      prefix (⊑conv↓ᴿ c′↓ M⊑M′ q replace)
+      M⊢ L′⊢
+      with cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix (⊑conv↓ᴿ c′↓ M⊑M′ q replace)
+      M⊢ L′⊢
+      | B′⁺ , M′⊢ =
+    ⊑conv↓ᴿ
+      (weaken-conceal-conversion
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′↓)
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      q replace
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-revealᴿ corresponds c↑ c′↑ replace M⊑M′)
+      L⊢ L′⊢
+      with cast-body-typingᴿ L⊢ | cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-revealᴿ corresponds c↑ c′↑ replace M⊑M′)
+      L⊢ L′⊢
+      | A⁺ , M⊢ | B′⁺ , M′⊢ =
+    paired-revealᴿ
+      (store-corresponds-prefix-proofᵀ
+        (to-live-prefix prefix) corresponds)
+      (weaken-reveal-conversion
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c↑)
+      (weaken-reveal-conversion
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′↑)
+      replace
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-concealᴿ corresponds c↓ c′↓ replace M⊑M′)
+      L⊢ L′⊢
+      with cast-body-typingᴿ L⊢ | cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-concealᴿ corresponds c↓ c′↓ replace M⊑M′)
+      L⊢ L′⊢
+      | A⁺ , M⊢ | B′⁺ , M′⊢ =
+    paired-concealᴿ
+      (store-corresponds-prefix-proofᵀ
+        (to-live-prefix prefix) corresponds)
+      (weaken-conceal-conversion
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c↓)
+      (weaken-conceal-conversion
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′↓)
+      replace
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (closeᴿ N⊑N′ widening-pair
+        u-shape u′-shape square compatible)
+      M⊢ M′⊢
+      with cast-body-typingᴿ M⊢ | cast-body-typingᴿ M′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (closeᴿ N⊑N′ widening-pair
+        u-shape u′-shape square compatible)
+      M⊢ M′⊢
+      | D⁺ , N⊢ | D′⁺ , N′⊢ =
+    closeᴿ
+      (quotient-term-imprecision-store-prefix-alignᴿ
+        prefix N⊑N′ N⊢ N′⊢)
+      (quotient-widening-pair-prefixᴿ prefix widening-pair)
+      u-shape u′-shape square compatible
+
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-wideningᴿ
+        mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+        left right compatible M⊑M′)
+      L⊢ L′⊢
+      with cast-body-typingᴿ L⊢ | cast-body-typingᴿ L′⊢
+  term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-wideningᴿ
+        mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+        left right compatible M⊑M′)
+      L⊢ L′⊢
+      | A⁺ , M⊢ | B′⁺ , M′⊢ =
+    paired-wideningᴿ
+      mode
+      (seal★-weaken
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★)
+      (widen-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c⊑)
+      c-shape
+      mode′
+      (seal★-weaken
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        seal★′)
+      (widen-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        c′⊑)
+      c′-shape left right compatible
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+
+  quotient-term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-downᴿ
+        M⊑M′ source-mode source source-shape
+        target-mode target target-shape square)
+      L⊢ L′⊢
+      with cast-body-typingᴿ L⊢ | cast-body-typingᴿ L′⊢
+  quotient-term-imprecision-store-prefix-goᴿ
+      prefix
+      (paired-downᴿ
+        M⊑M′ source-mode source source-shape
+        target-mode target target-shape square)
+      L⊢ L′⊢
+      | D⁺ , M⊢ | D′⁺ , M′⊢ =
+    paired-downᴿ
+      (term-imprecision-store-prefix-alignᴿ
+        prefix M⊑M′ M⊢ M′⊢)
+      (spine-cast-mode-prefixᴿ prefix source-mode)
+      (narrow-weaken ≤-refl
+        (leftStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        source)
+      source-shape
+      (target-spine-cast-mode-prefixᴿ prefix target-mode)
+      (narrow-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion (to-live-prefix prefix))
+        target)
+      target-shape square

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientSubstitutionExperiment.agda
@@ -115,7 +115,6 @@ open import
   proof.Quotient.NuImprecisionReductionClosedQuotientDef
   using
   ( QuotientWideningPairᴿ
-  ; allocation-prefixᴿ
   ; blame⊑ᴿ
   ; cast⊑⊑ᴿ
   ; cast⊒⊑ᴿ
@@ -160,6 +159,9 @@ open import
   ( smaller-imprecision-source-typingᴿ
   ; smaller-imprecision-target-typingᴿ
   )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientStorePrefixExperiment
+  using (term-imprecision-store-prefixᴿ)
 open import
   proof.Quotient.NuImprecisionTargetInstantiationCreationDef
   using
@@ -643,18 +645,11 @@ mutual
   smaller-parallel-term-substitution-framedᴿ
       environment frame prefix () noN′
       (α⊑αᴿ vL noL vL′ noL′ p liftρ liftγ
-        body L⊢ L′⊢)
+        body allocation-prefix L⊢ L′⊢)
   smaller-parallel-term-substitution-framedᴿ
       environment frame prefix () noN′
-      (α⊑ᴿ vL noL hA liftρ liftγ body L⊢ N′⊢)
-
-  smaller-parallel-term-substitution-framedᴿ
-      environment frame prefix noN noN′
-      (allocation-prefixᴿ inner-prefix body N⊢ N′⊢) =
-    smaller-parallel-term-substitution-framedᴿ
-      environment frame
-      (store-prefix-transᴿ inner-prefix prefix)
-      noN noN′ body
+      (α⊑ᴿ vL noL hA liftρ liftγ body
+        allocation-prefix L⊢ N′⊢)
 
   smaller-parallel-term-substitution-framedᴿ
       environment frame prefix
@@ -880,7 +875,7 @@ mutual
       (target-instantiationᴿ embedded)
       | eqN | eqN′
       rewrite eqN | eqN′ =
-    allocation-prefixᴿ prefix
+    term-imprecision-store-prefixᴿ prefix
       (target-instantiationᴿ embedded)
       (term-weaken ≤-refl
         (left-store-prefix-inclusionᴿ prefix)

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTermContextShiftExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTermContextShiftExperiment.agda
@@ -236,16 +236,11 @@ private
         (term-ctx-insertᴿ insert↑ body noV noN′)
     term-ctx-insertᴿ insert
         (α⊑αᴿ vL noL vL′ noL′ p liftρ liftγ
-          body L⊢ L′⊢) () noM′
+          body allocation-prefix L⊢ L′⊢) () noM′
     term-ctx-insertᴿ insert
-        (α⊑ᴿ vL noL hA liftρ liftγ body L⊢ N′⊢)
+        (α⊑ᴿ vL noL hA liftρ liftγ body
+          allocation-prefix L⊢ N′⊢)
         () noN′
-    term-ctx-insertᴿ insert
-        (allocation-prefixᴿ prefix body M⊢ M′⊢) noM noM′ =
-      allocation-prefixᴿ prefix
-        (term-ctx-insertᴿ insert body noM noM′)
-        (typing-renameˣ (term-ctx-insert-left-wfᴿ insert) M⊢)
-        (typing-renameˣ (term-ctx-insert-right-wfᴿ insert) M′⊢)
     term-ctx-insertᴿ insert
         (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑
           liftρ liftγ body replace)

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTypingExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientTypingExperiment.agda
@@ -84,7 +84,6 @@ open import
   ; Λ⊑ᴿ
   ; α⊑αᴿ
   ; α⊑ᴿ
-  ; allocation-prefixᴿ
   ; ν⊑νᴿ
   ; ν⊑ᴿ
   ; κ⊑κᴿ
@@ -219,14 +218,12 @@ mutual
           (smaller-imprecision-source-typingᴿ V⊑N′)))
   smaller-imprecision-source-typingᴿ
       (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
-        L⊑L′ L•⊢ L′•⊢) =
+        L⊑L′ allocation-prefix L•⊢ L′•⊢) =
     L•⊢
   smaller-imprecision-source-typingᴿ
-      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′
+        allocation-prefix L•⊢ N′⊢) =
     L•⊢
-  smaller-imprecision-source-typingᴿ
-      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) =
-    M⊢
   smaller-imprecision-source-typingᴿ
       (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
         N⊑N′ replace) =
@@ -330,14 +327,12 @@ mutual
         (smaller-imprecision-target-typingᴿ V⊑N′))
   smaller-imprecision-target-typingᴿ
       (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
-        L⊑L′ L•⊢ L′•⊢) =
+        L⊑L′ allocation-prefix L•⊢ L′•⊢) =
     L′•⊢
   smaller-imprecision-target-typingᴿ
-      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) =
+      (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′
+        allocation-prefix L•⊢ N′⊢) =
     N′⊢
-  smaller-imprecision-target-typingᴿ
-      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) =
-    M′⊢
   smaller-imprecision-target-typingᴿ
       (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
         N⊑N′ replace) =

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientValueExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedQuotientValueExperiment.agda
@@ -43,7 +43,6 @@ open import
   ; Λ⊑ᴿ
   ; α⊑αᴿ
   ; α⊑ᴿ
-  ; allocation-prefixᴿ
   ; ν⊑νᴿ
   ; ν⊑ᴿ
   ; κ⊑κᴿ
@@ -109,12 +108,10 @@ smaller-source-value-classᴿ
   source-universalᴿ
 smaller-source-value-classᴿ
     (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
-      L⊑L′ L•⊢ L′•⊢) ()
+      L⊑L′ allocation-prefix L•⊢ L′•⊢) ()
 smaller-source-value-classᴿ
-    (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) ()
-smaller-source-value-classᴿ
-    (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) vM =
-  smaller-source-value-classᴿ M⊑M′ vM
+    (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′
+      allocation-prefix L•⊢ N′⊢) ()
 smaller-source-value-classᴿ
     (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
       N⊑N′ replace) ()
@@ -198,13 +195,11 @@ smaller-target-value-classᴿ
   smaller-target-value-classᴿ V⊑N′ vN′
 smaller-target-value-classᴿ
     (α⊑αᴿ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ
-      L⊑L′ L•⊢ L′•⊢) ()
+      L⊑L′ allocation-prefix L•⊢ L′•⊢) ()
 smaller-target-value-classᴿ
-    (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′ L•⊢ N′⊢) vN′ =
+    (α⊑ᴿ vL noL h⇑A liftρ liftγ L⊑N′
+      allocation-prefix L•⊢ N′⊢) vN′ =
   smaller-target-value-classᴿ L⊑N′ vN′
-smaller-target-value-classᴿ
-    (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢) vM′ =
-  smaller-target-value-classᴿ M⊑M′ vM′
 smaller-target-value-classᴿ
     (ν⊑νᴿ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑ liftρ liftγ
       N⊑N′ replace) ()

--- a/GTSF/proof/Quotient/NuImprecisionReductionClosedWorldRenameExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionReductionClosedWorldRenameExperiment.agda
@@ -903,27 +903,6 @@ mutual
       (renameᵗᵐ-preserves-Value (extᵗ τ) vV)
       (smaller-world-embed-no•ᴿ body-emb noV noN′ V⊑N′)
   smaller-world-embed-no•ᴿ
-      {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
-      emb noM noM′
-      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢)
-      with rel-store-embedding-prefix-invᴿ
-        prefix (store-embeddingᴿ emb)
-  smaller-world-embed-no•ᴿ
-      {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
-      emb noM noM′
-      (allocation-prefixᴿ prefix M⊑M′ M⊢ M′⊢)
-      | ρ₀′ , store-emb₀ , prefix′ =
-    allocation-prefixᴿ prefix′
-      (smaller-world-embed-no•ᴿ
-        (reduction-closed-world-embeddingᴿ
-          {τ = τ} {σ = σ} {ψ = ψ} {φ = φ}
-          (left-inverseᴿ emb) (right-inverseᴿ emb)
-          (left-cast-renamerᴿ emb) (right-cast-renamerᴿ emb)
-          store-emb₀ (context-embeddingᴿ emb))
-        noM noM′ M⊑M′)
-      (world-embedding-source-typingᴿ emb noM M⊢)
-      (world-embedding-target-typingᴿ emb noM′ M′⊢)
-  smaller-world-embed-no•ᴿ
       {τ = τ} {σ = σ} {assm = assm} {hτ = hτ} {hσ = hσ}
       emb (no•-ν noN) (no•-ν noN′)
       (ν⊑νᴿ {A = A} {A′ = A′}

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationCreationDef.agda
@@ -184,6 +184,32 @@ data EmbeddedTargetInstantiationCreation
       (renameᵗ τ A) (renameᵗ σ A′)
       (⊑-renameᵗ²ᵢ assm hτ hσ p)
 
+  prefix-creationᴱ :
+    ∀ {Ψ Δᴸ Δᴿ}
+      {ρ ρ′ : StoreImp Ψ Δᴸ Δᴿ}
+      {M M′ A A′ p} →
+    EmbeddedTargetInstantiationCreation
+      {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      prefix-evidence body-relation
+      {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      ρ M M′ A A′ p →
+    StoreImpPrefixᴿ ρ ρ′ →
+    Δᴸ ∣ leftStoreⁱ ρ′ ∣ [] ⊢ M ⦂ A →
+    Δᴿ ∣ rightStoreⁱ ρ′ ∣ [] ⊢ M′ ⦂ A′ →
+    EmbeddedTargetInstantiationCreation
+      {Φ₀ = Φ₀} {Θᴸ = Θᴸ} {Θᴿ = Θᴿ}
+      {ρ₀ = ρ₀} {ρ⁺ = ρ⁺} {ρ∀ = ρ∀} {ρᴿ⁺ = ρᴿ⁺}
+      {W = W} {W′ = W′} {B = B} {C = C} {D = D}
+      {s = s} {μ = μ} {r = r} {f = f}
+      {body-shape = body-shape}
+      prefix-evidence body-relation
+      {Ψ = Ψ} {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+      ρ′ M M′ A A′ p
+
   embed-creation-leftᴱ :
     ∀ {Ψ Ω Δᴸ Δᴿ Υᴸ ρ ρ′ M M′ A A′ p τ} →
     EmbeddedTargetInstantiationCreation

--- a/GTSF/proof/Quotient/NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda
+++ b/GTSF/proof/Quotient/NuImprecisionTargetInstantiationFramedConsumerMigrationExperiment.agda
@@ -63,11 +63,13 @@ open import
   ; ⊑conv↓ᴿ
   ; paired-revealᴿ
   ; paired-concealᴿ
-  ; allocation-prefixᴿ
   ; closeᴿ
   ; paired-downᴿ
   ; _∣_∣_∣_∣_⊢ᴿ_⊑_⦂_⊑_∶_
   )
+open import
+  proof.Quotient.NuImprecisionReductionClosedQuotientStorePrefixExperiment
+  using (term-imprecision-store-prefixᴿ)
 open import
   proof.Quotient.NuImprecisionTargetInstantiationConsumerMigrationExperiment
   using
@@ -273,7 +275,7 @@ smaller-closing-frames-foldᴿ relation frame-reflᴿ =
   relation
 smaller-closing-frames-foldᴿ relation
     (frame-prefixᴿ frames prefix M⊢ M′⊢) =
-  allocation-prefixᴿ prefix
+  term-imprecision-store-prefixᴿ prefix
     (smaller-closing-frames-foldᴿ relation frames)
     M⊢ M′⊢
 smaller-closing-frames-foldᴿ relation

--- a/GTSF/proof/Quotient/README.md
+++ b/GTSF/proof/Quotient/README.md
@@ -58,6 +58,7 @@ The selected grammar and its general support are:
 
 The selected metatheory sources are:
 
+- `NuImprecisionReductionClosedQuotientStorePrefixExperiment.agda`;
 - `NuImprecisionReductionClosedQuotientTypingExperiment.agda`;
 - `NuImprecisionReductionClosedQuotientValueExperiment.agda`;
 - `NuImprecisionReductionClosedQuotientTermContextShiftExperiment.agda`;
@@ -86,6 +87,27 @@ must not create a compatibility layer that lets old and selected term
 relations coexist indefinitely. As each result is moved into the live
 relation or a canonical proof module, remove its experimental check root and
 delete the superseded source.
+
+## Store-prefix admissibility
+
+The ordinary live and prototype judgments are now syntax directed: neither
+grammar contains a generic relational-store prefix constructor. The canonical
+live interface is the `NuImprecisionTermStorePrefixDef/Proof/Lemma` family in
+`../Store/Prefix/`; the independent prototype theorem remains in
+`NuImprecisionReductionClosedQuotientStorePrefixExperiment.agda`.
+
+Both proofs are mutual over the ordinary and quotient judgments. They keep
+the terms, endpoint types, term context, and imprecision index fixed while
+moving from `ρ₀` to `ρ⁺`, given endpoint typing in `ρ⁺`. Runtime-bullet
+constructors retain the prefix from their canonical allocation store to their
+ambient store, and embedded target-instantiation creation retains the exact
+post-allocation lineage. Applying general weakening composes that stored
+lineage; it does not add a term-relation wrapper.
+
+Consequently typing, value classification, terminal inversion, world
+embedding, context shift, and substitution reach the constructor selected by
+the endpoint syntax directly. Allocation/frame consumers call the admissible
+theorem only when an unchanged sibling must be rebuilt in an enlarged world.
 
 ## Retiring live surface
 

--- a/GTSF/proof/README.md
+++ b/GTSF/proof/README.md
@@ -23,7 +23,9 @@ Top-level groups:
   During the controlled live-QTI migration, its
   [`README.md`](Quotient/README.md) is the authoritative lifecycle manifest
   for canonical, migration-only, retiring, and obsolete modules.
-- `Store/`: store prefix, correspondence, lineage, and embedding helpers.
+- `Store/`: store prefix, correspondence, lineage, and embedding helpers. The
+  canonical ordinary/quotient term-prefix admissibility boundary is
+  `Store/Prefix/NuImprecisionTermStorePrefixDef/Proof/Lemma`.
 - `Substitution/`: term and parallel substitution helpers.
 - `WorldCoherent/`: world-coherent source, right, quotient, final, and value
   catch-up assemblies.

--- a/GTSF/proof/Right/AllocationRuntime/NuImprecisionRightLiftPrefixBodyProof.agda
+++ b/GTSF/proof/Right/AllocationRuntime/NuImprecisionRightLiftPrefixBodyProof.agda
@@ -10,6 +10,8 @@ module
 --     no-runtime-bullet traversal.
 --   * Contains only total proof terms, with no permissive option or dispatcher.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (refl)
 open import Data.List using ([])
@@ -21,7 +23,6 @@ open import proof.Store.Core.NuImprecisionRelationalStoreDef using
   ; StoreImp
   )
 open import NuTerms using (renameᵗᵐ; ⇑ᵗᵐ)
-open import QuotientedTermImprecision using (allocation-prefixᵀ)
 open import Types using (renameᵗ)
 open import proof.Core.Properties.NuCastModeRenamerProperties using
   (castModeRenamer-id)
@@ -81,7 +82,7 @@ private
 right-lift-prefix-body-proofᵀ : RightLiftPrefixBodyᵀ
 right-lift-prefix-body-proofᵀ {A = A} {L = L}
     liftρ prefix noL noL′ L⊑L′ =
-  allocation-prefixᵀ prefix body
+  term-imprecision-store-prefixᵀ prefix body
     (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
       noL (nu-term-imprecision-source-typing body))
     (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)

--- a/GTSF/proof/Right/AllocationRuntime/NuImprecisionRightTargetAllocationSourceBulletTransportProof.agda
+++ b/GTSF/proof/Right/AllocationRuntime/NuImprecisionRightTargetAllocationSourceBulletTransportProof.agda
@@ -29,6 +29,7 @@ open import ImprecisionWf using
   ( ImpCtx
   ; ⇑ᴿᵢ
   ; _∣_⊢_⊑_⊣_
+  ; ⊑-src-wf
   )
 open import NuReduction using
   ( StoreChanges
@@ -43,6 +44,7 @@ open import proof.Store.Core.NuImprecisionRelationalStoreDef using
   ( LiftRightStoreⁱ
   ; StoreImp
   ; leftStoreⁱ
+  ; leftStoreⁱ-lift-left
   ; rightStoreⁱ
   ; rightStoreⁱ-lift-right
   ; store-right
@@ -64,7 +66,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
@@ -95,7 +96,7 @@ open import QuotientedTermImprecision using
   )
 open import Store using (StoreIncl-drop)
 open import TermTyping using
-  (SealModeStore★; weakenCastᵈ; _∣_∣_⊢_⦂_)
+  (SealModeStore★; weakenCastᵈ; _∣_∣_⊢_⦂_; ⊢•)
 open import Types using
   ( Ty
   ; TyCtx
@@ -111,6 +112,8 @@ open import
   using
   ( replace-right-target-lift-rightᵢ
   )
+open import proof.NuCore.Relations.NuImprecisionQuotientedTyping using
+  (nu-term-imprecision-source-typing)
 open import
   proof.Catchup.Simulation.NuImprecisionWeakOneStepResultTransport
   using
@@ -229,12 +232,6 @@ private
 
   source-bullet-transport
       prefix liftρ unique runtime noM′ M⊢
-      (allocation-prefixᵀ prefix₀ M⊑M′ M⊢₀ M′⊢) eq =
-    source-bullet-transport
-      (store-imp-prefix-transⁱ prefix₀ prefix)
-      liftρ unique runtime noM′ M⊢ M⊑M′ eq
-  source-bullet-transport
-      prefix liftρ unique runtime noM′ M⊢
       (blame⊑ᵀ M′⊢) ()
   source-bullet-transport
       prefix liftρ unique runtime noM′ M⊢
@@ -265,25 +262,33 @@ private
   source-bullet-transport
       prefix liftρ unique runtime noM′ M⊢
       (α⊑αᵀ vV noV vV′ noV′ p liftρ∀ liftγ
-        V⊑V′ V•⊢ V′•⊢)
+        V⊑V′ allocation-prefix V•⊢ V′•⊢)
       eq =
     ⊥-elim (no•-bullet-absurd noM′)
   source-bullet-transport
-      {Δᴸ = Δᴸ} {ρ⁺ = ρ⁺} {L = L} {A = A}
+      {Δᴸ = Δᴸ} {ρ⁺ = ρ⁺} {L = L} {A = A} {q = q}
       prefix liftρ unique runtime noM′ M⊢
       (α⊑ᵀ {L = V} vV noV hA liftρ∀
         lift-left-ctx-[]
-        V⊑M′ V•⊢ M′⊢)
+        V⊑M′ allocation-prefix V•⊢ M′⊢)
       eq =
     nu-term-imprecision-transport-termsᵀ eq refl
       (right-target-allocation-source-only-bullet-transport-proofᵀ
-        prefix liftρ unique noM′ source-typing
-        V⊑M′ vV noV liftρ∀ V•⊢)
+        (store-imp-prefix-transⁱ allocation-prefix prefix)
+        liftρ unique noM′ source-typing
+        V⊑M′ vV noV liftρ∀ canonical-source-typing)
     where
     source-typing =
       subst
         (λ N → Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ [] ⊢ N ⦂ A)
         (sym eq) M⊢
+
+    canonical-source-typing =
+      subst
+        (λ Σ → _ ∣ (zero , _) ∷ Σ ∣ [] ⊢ _ ⦂ _)
+        (sym (leftStoreⁱ-lift-left liftρ∀))
+        (⊢• refl refl (⊑-src-wf q) vV noV
+          (nu-term-imprecision-source-typing V⊑M′))
   source-bullet-transport
       prefix liftρ unique runtime noM′ M⊢
       (ν⊑νᵀ hA hA′ s↑ s′↑ pA pA↑

--- a/GTSF/proof/Right/AllocationRuntime/NuImprecisionRightTargetAllocationSourceOnlyBulletTransportProof.agda
+++ b/GTSF/proof/Right/AllocationRuntime/NuImprecisionRightTargetAllocationSourceOnlyBulletTransportProof.agda
@@ -10,6 +10,8 @@ module proof.Right.AllocationRuntime.NuImprecisionRightTargetAllocationSourceOnl
 --   * Contains no postulate, hole, permissive option, catch-all clause, or
 --     termination bypass.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
@@ -46,7 +48,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; prefix-∷ⁱ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
@@ -229,7 +230,7 @@ right-target-allocation-source-only-bullet-transport-proofᵀ
         prefixᴿ
       | ρᴿ , rightᴸρ , leftᴿρ
       | occ′ , index-eq =
-    allocation-prefixᵀ (prefix-∷ⁱ prefixᴿ) aligned
+    term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefixᴿ) aligned
       source-typing target-typing
     where
     eq = right-under-left-ctx-eq Φ₀

--- a/GTSF/proof/Right/SourceAll/Bodies/NuImprecisionRightSourceAllCastBodyProof.agda
+++ b/GTSF/proof/Right/SourceAll/Bodies/NuImprecisionRightSourceAllCastBodyProof.agda
@@ -20,8 +20,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; cast⊒⊑ᵀ
+  ( cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
   ; conv↑⊑ᵀ
@@ -43,7 +42,6 @@ open import
   proof.Right.SourceAll.ClosingValues.NuImprecisionRightSourceAllClosingCasesDef
   using
   ( WorldCoherentRightSourceAllClosingCases
-  ; sourceAllAllocationPrefixCase
   ; sourceAllResidualCases
   ; sourceAllSourceFramesCase
   ; sourceAllTargetConcealFrameCase
@@ -103,14 +101,6 @@ world-coherent-right-source-all-cast-body-proofᵀ
     (vM ⟨ inert ⟩) (no•-⟨⟩ noM)
     liftρ liftγ paired widening
     source-shape target-shape square compatible
-world-coherent-right-source-all-cast-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okN′ vM noM inert liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner V⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okN′
-    (vM ⟨ inert ⟩) (no•-⟨⟩ noM)
-    liftρ liftγ prefix′ inner
 world-coherent-right-source-all-cast-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     okW vM noM inert liftρ liftγ

--- a/GTSF/proof/Right/SourceAll/Bodies/NuImprecisionRightSourceAllLambdaBodyProof.agda
+++ b/GTSF/proof/Right/SourceAll/Bodies/NuImprecisionRightSourceAllLambdaBodyProof.agda
@@ -32,8 +32,7 @@ open import NuTerms using
   ; $
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ⊑cast⊒ᵀ
+  ( ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
   ; ⊑conv↑ᵀ
   ; ⊑conv↓ᵀ
@@ -42,7 +41,6 @@ open import
   proof.Right.SourceAll.ClosingValues.NuImprecisionRightSourceAllClosingCasesDef
   using
   ( WorldCoherentRightSourceAllClosingCases
-  ; sourceAllAllocationPrefixCase
   ; sourceAllResidualCases
   ; sourceAllTargetConcealFrameCase
   ; sourceAllTargetNarrowFrameCase
@@ -72,13 +70,6 @@ world-coherent-right-source-all-lambda-body-proofᵀ
     (ok-no no•-$) noN liftρ liftγ rel =
   sourceAllTerminalCase cases prefix coherent exclusive unique wfR
     (ƛ _) (no•-ƛ noN) ($ _) no•-$ liftρ liftγ rel
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    ok-cast@(ok-no (no•-⟨⟩ noN′)) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR ok-cast
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-lambda-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     ok-cast@(ok-no (no•-⟨⟩ noN′)) noN liftρ liftγ
@@ -115,86 +106,16 @@ world-coherent-right-source-all-lambda-body-proofᵀ
     (ƛ _) (no•-ƛ noN) liftρ liftγ rel
 world-coherent-right-source-all-lambda-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okVar@(ok-no no•-`) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okVar
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okApp@(ok-no (no•-· noL′ noM′)) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okApp
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okΛ@(ok-no (no•-Λ noN′)) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okΛ
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okPlus@(ok-no (no•-⊕ noL′ noM′)) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okPlus
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okBlame@(ok-no no•-blame) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okBlame
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     ok•@(ok-• vV′ noV′) noN liftρ liftγ rel =
   sourceAllTargetBullet (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR ok•
     (ƛ _) (no•-ƛ noN) liftρ liftγ rel
 world-coherent-right-source-all-lambda-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okApp@(ok-·₁ okL′ noM′) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okApp
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okApp@(ok-·₂ vL′ noL′ okM′) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okApp
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     okν@(ok-ν okN′) noN liftρ liftγ rel =
   sourceAllTargetAllocation (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR okν
     (ƛ _) (no•-ƛ noN) liftρ liftγ rel
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okPlus@(ok-⊕₁ okL′ noM′) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okPlus
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okPlus@(ok-⊕₂ vL′ noL′ okM′) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okPlus
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-lambda-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    ok-cast@(ok-⟨⟩ okN′) noN liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner N⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR ok-cast
-    (ƛ _) (no•-ƛ noN) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-lambda-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     ok-cast@(ok-⟨⟩ okN′) noN liftρ liftγ

--- a/GTSF/proof/Right/SourceAll/Core/NuImprecisionRightSourceAllUniversalBodyProof.agda
+++ b/GTSF/proof/Right/SourceAll/Core/NuImprecisionRightSourceAllUniversalBodyProof.agda
@@ -33,8 +33,7 @@ open import NuTerms using
   ; $
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; Λ⊑Λᵀ
+  ( Λ⊑Λᵀ
   ; Λ⊑ᵀ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
@@ -46,7 +45,6 @@ open import
   proof.Right.SourceAll.ClosingValues.NuImprecisionRightSourceAllClosingCasesDef
   using
   ( WorldCoherentRightSourceAllClosingCases
-  ; sourceAllAllocationPrefixCase
   ; sourceAllResidualCases
   ; sourceAllTargetConcealFrameCase
   ; sourceAllTargetNarrowFrameCase
@@ -111,25 +109,11 @@ world-coherent-right-source-all-universal-body-proofᵀ
     liftρ liftγ liftρ′ liftγ′ body
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okΛ@(ok-no (no•-Λ noU′)) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okΛ
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     ok-cast@(ok-no (no•-⟨⟩ noN′)) vU noU liftρ liftγ
     (Λ⊑ᵀ inner-occ liftρ′ liftγ′ vW body) =
   sourceAllNestedSourceAll (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR ok-cast vW noU
     liftρ liftγ liftρ′ liftγ′ body
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    ok-cast@(ok-no (no•-⟨⟩ noN′)) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR ok-cast
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     ok-cast@(ok-no (no•-⟨⟩ noN′)) vU noU liftρ liftγ
@@ -173,27 +157,12 @@ world-coherent-right-source-all-universal-body-proofᵀ
     liftρ liftγ liftρ′ liftγ′ body
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okVar@(ok-no no•-`) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okVar
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     okApp@(ok-no (no•-· noL′ noM′))
     vU noU liftρ liftγ
     (Λ⊑ᵀ inner-occ liftρ′ liftγ′ vW body) =
   sourceAllNestedSourceAll (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR okApp vW noU
     liftρ liftγ liftρ′ liftγ′ body
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okApp@(ok-no (no•-· noL′ noM′))
-    vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okApp
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     okPlus@(ok-no (no•-⊕ noL′ noM′))
@@ -204,26 +173,11 @@ world-coherent-right-source-all-universal-body-proofᵀ
     liftρ liftγ liftρ′ liftγ′ body
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okPlus@(ok-no (no•-⊕ noL′ noM′))
-    vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okPlus
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     okBlame@(ok-no no•-blame) vU noU liftρ liftγ
     (Λ⊑ᵀ inner-occ liftρ′ liftγ′ vW body) =
   sourceAllNestedSourceAll (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR okBlame vW noU
     liftρ liftγ liftρ′ liftγ′ body
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okBlame@(ok-no no•-blame) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okBlame
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     ok•@(ok-• vV′ noV′) vU noU liftρ liftγ rel =
@@ -239,27 +193,12 @@ world-coherent-right-source-all-universal-body-proofᵀ
     liftρ liftγ liftρ′ liftγ′ body
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okApp@(ok-·₁ okL′ noM′) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okApp
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     okApp@(ok-·₂ vL′ noL′ okM′)
     vU noU liftρ liftγ
     (Λ⊑ᵀ inner-occ liftρ′ liftγ′ vW body) =
   sourceAllNestedSourceAll (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR okApp vW noU
     liftρ liftγ liftρ′ liftγ′ body
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    okApp@(ok-·₂ vL′ noL′ okM′)
-    vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okApp
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     okν@(ok-ν okN′) vU noU liftρ liftγ rel =
@@ -275,13 +214,6 @@ world-coherent-right-source-all-universal-body-proofᵀ
     liftρ liftγ liftρ′ liftγ′ body
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okPlus@(ok-⊕₁ okL′ noM′) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okPlus
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     okPlus@(ok-⊕₂ vL′ noL′ okM′)
     vU noU liftρ liftγ
     (Λ⊑ᵀ inner-occ liftρ′ liftγ′ vW body) =
@@ -290,26 +222,11 @@ world-coherent-right-source-all-universal-body-proofᵀ
     liftρ liftγ liftρ′ liftγ′ body
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
-    okPlus@(ok-⊕₂ vL′ noL′ okM′)
-    vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR okPlus
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
     ok-cast@(ok-⟨⟩ okN′) vU noU liftρ liftγ
     (Λ⊑ᵀ inner-occ liftρ′ liftγ′ vW body) =
   sourceAllNestedSourceAll (sourceAllResidualCases cases)
     prefix coherent exclusive unique wfR ok-cast vW noU
     liftρ liftγ liftρ′ liftγ′ body
-world-coherent-right-source-all-universal-body-proofᵀ
-    cases prefix coherent exclusive unique wfR
-    ok-cast@(ok-⟨⟩ okN′) vU noU liftρ liftγ
-    (allocation-prefixᵀ prefix′ inner U⊢ N′⊢) =
-  sourceAllAllocationPrefixCase cases
-    prefix coherent exclusive unique wfR ok-cast
-    (Λ vU) (no•-Λ noU) liftρ liftγ prefix′ inner
 world-coherent-right-source-all-universal-body-proofᵀ
     cases prefix coherent exclusive unique wfR
     ok-cast@(ok-⟨⟩ okN′) vU noU liftρ liftγ

--- a/GTSF/proof/Source/Allocation/NuImprecisionSourceNuAllocationRelationProof.agda
+++ b/GTSF/proof/Source/Allocation/NuImprecisionSourceNuAllocationRelationProof.agda
@@ -42,6 +42,7 @@ open import QuotientedTermImprecision using
   ( α⊑ᵀ
   ; cast⊑⊑ᵀ
   ; conv↑⊑ᵀ
+  ; prefix-reflⁱ
   )
 open import TermTyping using
   ( SealModeStore★
@@ -59,7 +60,7 @@ source-inst-allocation-relation-proofᵀ
     s-shape-proof comp liftρ N⊑N′ =
   cast⊑⊑ᵀ (cast-inst mode) left-seal left-widening
     (α⊑ᵀ vN noN wf★ liftρ lift-left-ctx-[]
-      N⊑N′ left-bullet-typing right-term-typing)
+      N⊑N′ prefix-reflⁱ left-bullet-typing right-term-typing)
     (⊑-source-liftνᵢ pB) s-shape-proof comp
   where
   left-seal =
@@ -96,7 +97,7 @@ source-reveal-allocation-relation-proofᵀ
     {q = q} vN noN h⇑A s↑ pB replace liftρ N⊑N′ =
   conv↑⊑ᵀ left-reveal
     (α⊑ᵀ vN noN h⇑A liftρ lift-left-ctx-[]
-      N⊑N′ left-bullet-typing right-term-typing)
+      N⊑N′ prefix-reflⁱ left-bullet-typing right-term-typing)
     (⊑-source-liftνᵢ pB) replace
   where
   left-reveal =

--- a/GTSF/proof/Source/Core/NuImprecisionSourceBulletBase.agda
+++ b/GTSF/proof/Source/Core/NuImprecisionSourceBulletBase.agda
@@ -9,6 +9,8 @@ module proof.Source.Core.NuImprecisionSourceBulletBase where
 --   * Keeps local administrative embedding and post-allocation helpers private
 --     and avoids depending on the main simulation or scratch modules.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
@@ -62,7 +64,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; prefix-∷ⁱ
   ; α⊑ᵀ
@@ -349,7 +350,7 @@ left-catchup-indexed-prefix-α-Λᵀ
       (left-silent-invariant refl refl) (inj₁ (vW , noW)))
   where
   allocated-body =
-    allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
+    term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) W⊑V′
       (term-weaken {Δ = suc Δᴸ} {Δ′ = suc Δᴸ}
         {Σ = leftStoreⁱ ρᵇ}
         {Σ′ = (zero , ⇑ᵗ Aν) ∷ leftStoreⁱ ρᵇ}
@@ -362,7 +363,7 @@ left-catchup-indexed-prefix-α-Λᵀ
       liftρᵃ liftρᵇ noW noV′ allocated-body
 
   prefixed-body =
-    allocation-prefixᵀ prefix canonical-body
+    term-imprecision-store-prefixᵀ prefix canonical-body
       (term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix)
         noW (nu-term-imprecision-source-typing canonical-body))
       (term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix)
@@ -416,7 +417,7 @@ left-allocated-bulletᵀ
     {Aν = Aν} {V = V} {V′ = V′} {r = r}
     vV noV hAν liftρ V⊑V′ =
   α⊑ᵀ vV noV hAν liftρ lift-left-ctx-[] V⊑V′
-    left-bullet-typing right-typing
+    prefix-reflⁱ left-bullet-typing right-typing
   where
     left-bullet-typing =
       subst

--- a/GTSF/proof/Source/Core/NuImprecisionSourceLeftAllocationCastTransport.agda
+++ b/GTSF/proof/Source/Core/NuImprecisionSourceLeftAllocationCastTransport.agda
@@ -7,6 +7,8 @@ module proof.Source.Core.NuImprecisionSourceLeftAllocationCastTransport where
 --   * Depends on focused cast, typing-preservation, and term-imprecision
 --     owners; intentionally avoids the broad simulation modules.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Data.List using (_∷_)
 open import Data.List.Relation.Unary.Any using (there)
@@ -38,8 +40,7 @@ open import proof.NuCore.Relations.NuImprecisionTermContextDef using
   )
 open import NuTerms using (No•)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; prefix-reflⁱ
+  ( prefix-reflⁱ
   ; prefix-∷ⁱ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
@@ -100,7 +101,7 @@ allocated-left-relationᵀ :
     store-left zero Aν hAν ∷ ρ′ ∣ γ′
     ⊢ᴺ M ⊑ M′ ⦂ B ⊑ B′ ∶ p
 allocated-left-relationᵀ hAν liftρ noM M⊑M′ =
-  allocation-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) M⊑M′
+  term-imprecision-store-prefixᵀ (prefix-∷ⁱ prefix-reflⁱ) M⊑M′
     (term-weaken {Δ′ = _} {Σ′ = _} ≤-refl StoreIncl-drop noM
       (nu-term-imprecision-source-typing M⊑M′))
     (nu-term-imprecision-target-typing M⊑M′)

--- a/GTSF/proof/Source/OneStep/NuImprecisionSourceOneStepDeltaRootProof.agda
+++ b/GTSF/proof/Source/OneStep/NuImprecisionSourceOneStepDeltaRootProof.agda
@@ -7,6 +7,8 @@ module proof.Source.OneStep.NuImprecisionSourceOneStepDeltaRootProof where
 --   * Uses identity transport, coherence, and reflexive store lineage.
 --   * Contains no postulate, hole, incomplete match, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Agda.Builtin.Equality using (refl)
 open import Data.List using ([]; _∷_)
 open import Data.Nat using (_+_)
@@ -17,8 +19,7 @@ open import NuReduction using
 open import NuTerms using ($; _⊕[_]_)
 open import Primitives using (addℕ; κℕ)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; κ⊑κᵀ
+  ( κ⊑κᵀ
   ; prefix-reflⁱ
   )
 open import TermTyping using (⊢$)
@@ -58,7 +59,7 @@ world-coherent-source-delta-root-proofᵀ
     ⊢$ (κℕ (m + n))
 
   related⁺ =
-    allocation-prefixᵀ prefix κ⊑κᵀ result-typingᴸ result-typingᴿ
+    term-imprecision-store-prefixᵀ prefix κ⊑κᵀ result-typingᴸ result-typingᴿ
 
   δ-step =
     ↠-step (pure-step δ-⊕) ↠-refl

--- a/GTSF/proof/Source/SealTag/NuImprecisionSourceSealCancellationCounterexample.agda
+++ b/GTSF/proof/Source/SealTag/NuImprecisionSourceSealCancellationCounterexample.agda
@@ -43,8 +43,7 @@ open import NuTerms using
   )
 open import Primitives using (κℕ)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; conv⊑convᵀ
+  ( conv⊑convᵀ
   ; κ⊑κᵀ
   ; paired-conceal
   ; paired-conversion
@@ -188,11 +187,6 @@ private
   no-cancellation-conclusion
       (⊑cast⊑idᵀ seal★
         (C.cast-tag hG ground () , widening) inner q)
-  no-cancellation-conclusion
-      (allocation-prefixᵀ prefix inner K⊢ TargetTagged⊢) =
-    no-cancellation-conclusion inner
-
-
 source-seal-cancellation-needs-exclusivity :
   (Φ₀ ∣ suc zero ∣ suc zero ∣ ρ₀ ∣ []
     ⊢ᴺ SourceSealed ⊑ TargetTagged

--- a/GTSF/proof/Source/SealTag/NuImprecisionSourceSealCancellationProof.agda
+++ b/GTSF/proof/Source/SealTag/NuImprecisionSourceSealCancellationProof.agda
@@ -38,7 +38,6 @@ open import NuTerms using
   (No•; Term; Value; no•-⟨⟩; _⟨_⟩)
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -354,23 +353,6 @@ source-seal-cancellation-prefixᵀ
     (source-seal-cancellation-target-replacement
       inner-index q)
 source-seal-cancellation-prefixᵀ
-    {p = idˣ a∈Φ α< β<}
-    prefix coh exclusive wfΣ vV vW noW αX∈Σ
-    (allocation-prefixᵀ prefix₀ inner Vseal⊢ W⊢) q
-    with source-seal-typing⁻¹ Vseal⊢
-source-seal-cancellation-prefixᵀ
-    {p = idˣ a∈Φ α< β<}
-    prefix coh exclusive wfΣ vV vW noW αX∈Σ
-    (allocation-prefixᵀ prefix₀ inner Vseal⊢ W⊢) q
-    | αY∈Σ , V⊢
-    rewrite unique wfΣ
-      (left-prefix-inclusionᵀ prefix αY∈Σ) αX∈Σ =
-  allocation-prefixᵀ prefix₀
-    (source-seal-cancellation-prefixᵀ
-      (prefix-transᵀ prefix₀ prefix) coh exclusive wfΣ
-      vV vW noW αX∈Σ inner q)
-    V⊢ W⊢
-source-seal-cancellation-prefixᵀ
     {p = tagˣ star∈ α<}
     prefix coh exclusive wfΣ vV vW noW αX∈Σ
     (closeᵀ
@@ -476,25 +458,6 @@ source-seal-cancellation-prefixᵀ
     (vM ⟨ inert ⟩) noW αX∈Σ
     (⊑conv↓ᵀ c′↓ Vα⊑M oldq replacement) q =
   ⊥-elim (inert-conceal-target-star-impossibleᵀ c′↓ inert)
-source-seal-cancellation-prefixᵀ
-    {p = tagˣ star∈ α<}
-    prefix coh exclusive wfΣ vV vW noW αX∈Σ
-    (allocation-prefixᵀ prefix₀ inner Vseal⊢ W⊢) q
-    with source-seal-typing⁻¹ Vseal⊢
-source-seal-cancellation-prefixᵀ
-    {p = tagˣ star∈ α<}
-    prefix coh exclusive wfΣ vV vW noW αX∈Σ
-    (allocation-prefixᵀ prefix₀ inner Vseal⊢ W⊢) q
-    | αY∈Σ , V⊢
-    rewrite unique wfΣ
-      (left-prefix-inclusionᵀ prefix αY∈Σ) αX∈Σ =
-  allocation-prefixᵀ prefix₀
-    (source-seal-cancellation-prefixᵀ
-      (prefix-transᵀ prefix₀ prefix) coh exclusive wfΣ
-      vV vW noW αX∈Σ inner q)
-    V⊢ W⊢
-
-
 source-seal-cancellation-proofᵀ : SourceSealCancellationᵀ
 source-seal-cancellation-proofᵀ coh exclusive wfΣ vV vW noW αX∈Σ
     Vseal⊑W q =

--- a/GTSF/proof/Store/Prefix/NuImprecisionStorePrefixNoBulletProof.agda
+++ b/GTSF/proof/Store/Prefix/NuImprecisionStorePrefixNoBulletProof.agda
@@ -4,7 +4,7 @@ module proof.Store.Prefix.NuImprecisionStorePrefixNoBulletProof where
 --   * Proves no-bullet quotiented term imprecision weakening through a
 --     relational-store prefix.
 --   * Uses the typing projections and ordinary store weakening to discharge
---     the ambient typing premises of `allocation-prefixᵀ`.
+--     the ambient typing premises of the canonical admissible prefix rule.
 --   * Contains no postulate, hole, catch-all, or permissive option.
 
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
@@ -16,10 +16,7 @@ open import proof.Store.Core.NuImprecisionRelationalStoreDef using
   ; rightStoreⁱ
   )
 open import NuTerms using (no•-⟨⟩)
-open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; paired-downᵀ
-  )
+open import QuotientedTermImprecision using (paired-downᵀ)
 open import proof.Store.Prefix.NuImprecisionStorePrefix using
   (leftStoreⁱ-prefix-inclusion; rightStoreⁱ-prefix-inclusion)
 open import proof.Store.Prefix.NuImprecisionStorePrefixNoBulletDef using
@@ -30,12 +27,15 @@ open import
   proof.Store.Prefix.NuImprecisionStorePrefixEvidenceProof
   using (spine-cast-mode-prefix-proofᵀ)
 open import proof.Core.Properties.TypePreservation using (term-weaken)
+open import
+  proof.Store.Prefix.NuImprecisionTermStorePrefixLemma
+  using (term-imprecision-store-prefixᵀ)
 
 
 quotiented-store-prefix-no-bullet-proofᵀ :
   QuotientedStorePrefixNoBulletᵀ
 quotiented-store-prefix-no-bullet-proofᵀ prefix noM noM′ M⊑M′ =
-  allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢
+  term-imprecision-store-prefixᵀ prefix M⊑M′ M⊢ M′⊢
   where
   M⊢ =
     term-weaken ≤-refl (leftStoreⁱ-prefix-inclusion prefix) noM

--- a/GTSF/proof/Store/Prefix/NuImprecisionTermStorePrefixDef.agda
+++ b/GTSF/proof/Store/Prefix/NuImprecisionTermStorePrefixDef.agda
@@ -1,0 +1,62 @@
+module proof.Store.Prefix.NuImprecisionTermStorePrefixDef where
+
+-- File Charter:
+--   * States admissible relational-store prefix weakening for the live
+--     ordinary and quotient term-imprecision judgments.
+--   * Keeps endpoint terms, types, contexts, and imprecision indices fixed.
+--   * Requires endpoint typing in the enlarged world so runtime bullets and
+--     target-instantiation residuals retain exact allocation lineage.
+--   * Contains no implementation, postulate, hole, or permissive option.
+
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionWf using (ImpCtx; _∣_⊢_⊑_⊣_)
+open import proof.Store.Core.NuImprecisionRelationalStoreDef using
+  ( StoreImp
+  ; leftStoreⁱ
+  ; rightStoreⁱ
+  )
+open import proof.NuCore.Relations.NuImprecisionTermContextDef using
+  ( CtxImp
+  ; leftCtxⁱ
+  ; rightCtxⁱ
+  )
+open import NuTerms using (Term)
+open import QuotientedTermImprecision using
+  ( StoreImpPrefix
+  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  ; _∣_∣_∣_∣_⊢ᴺᵖ_⊑_⦂_⊑ᵖ_∶_
+  )
+open import TermTyping using (_∣_∣_⊢_⦂_)
+open import Types using (Ty; TyCtx)
+
+
+TermImprecisionStorePrefixᵀ : Set₁
+TermImprecisionStorePrefixᵀ =
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {A B : Ty}
+    {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ A →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+    ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p
+
+
+QuotientTermImprecisionStorePrefixᵀ : Set₁
+QuotientTermImprecisionStorePrefixᵀ =
+  ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+    {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+    {γ : CtxImp Φ Δᴸ Δᴿ}
+    {M M′ : Term} {D D′ : Ty}
+    {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+  StoreImpPrefix ρ₀ ρ⁺ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+    ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+  Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ D →
+  Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ D′ →
+  Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+    ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q

--- a/GTSF/proof/Store/Prefix/NuImprecisionTermStorePrefixLemma.agda
+++ b/GTSF/proof/Store/Prefix/NuImprecisionTermStorePrefixLemma.agda
@@ -1,0 +1,45 @@
+module proof.Store.Prefix.NuImprecisionTermStorePrefixLemma where
+
+-- File Charter:
+--   * Exposes the canonical admissible relational-store prefix rules for the
+--     live ordinary and quotient term-imprecision judgments.
+--   * Instantiates the structural proof with the canonical correspondence,
+--     quotient-widening, and binder-lift transports.
+--   * Contains no constructor, postulate, hole, catch-all, or permissive
+--     option.
+
+open import proof.Store.Prefix.NuImprecisionStorePrefixEvidenceProof using
+  ( quotient-widening-pair-prefix-proofᵀ
+  ; store-corresponds-prefix-proofᵀ
+  )
+open import proof.Store.Prefix.NuImprecisionStorePrefixLiftLemma using
+  ( left-store-prefix-liftᵀ
+  ; paired-store-prefix-liftᵀ
+  )
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixDef using
+  ( QuotientTermImprecisionStorePrefixᵀ
+  ; TermImprecisionStorePrefixᵀ
+  )
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixProof using
+  ( quotient-term-imprecision-store-prefix-proofᵀ
+  ; term-imprecision-store-prefix-proofᵀ
+  )
+
+
+term-imprecision-store-prefixᵀ : TermImprecisionStorePrefixᵀ
+term-imprecision-store-prefixᵀ =
+  term-imprecision-store-prefix-proofᵀ
+    store-corresponds-prefix-proofᵀ
+    quotient-widening-pair-prefix-proofᵀ
+    paired-store-prefix-liftᵀ
+    left-store-prefix-liftᵀ
+
+
+quotient-term-imprecision-store-prefixᵀ :
+  QuotientTermImprecisionStorePrefixᵀ
+quotient-term-imprecision-store-prefixᵀ =
+  quotient-term-imprecision-store-prefix-proofᵀ
+    store-corresponds-prefix-proofᵀ
+    quotient-widening-pair-prefix-proofᵀ
+    paired-store-prefix-liftᵀ
+    left-store-prefix-liftᵀ

--- a/GTSF/proof/Store/Prefix/NuImprecisionTermStorePrefixProof.agda
+++ b/GTSF/proof/Store/Prefix/NuImprecisionTermStorePrefixProof.agda
@@ -1,0 +1,778 @@
+module proof.Store.Prefix.NuImprecisionTermStorePrefixProof where
+
+-- File Charter:
+--   * Proves admissible relational-store prefix weakening mutually for the
+--     live ordinary and quotient term-imprecision judgments.
+--   * Rebuilds syntax-directed constructors after weakening store-indexed
+--     coercions, conversions, correspondence, and binder lifts.
+--   * Composes prefix lineage inside runtime-bullet and target-instantiation
+--     residuals instead of adding an administrative term constructor.
+--   * Contains no postulate, hole, catch-all, or permissive option.
+
+open import Data.List using (_∷_; [])
+open import Data.Nat using (suc; zero)
+open import Data.Nat.Properties using (≤-refl)
+open import Data.Product using (_,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality using (refl; subst; sym)
+
+open import Coercions using
+  ( cast-tag
+  ; tag-or-idᵈ
+  )
+open import Conversion using
+  ( weaken-conceal-conversion
+  ; weaken-reveal-conversion
+  )
+open import ForallPermutation using (_∣_⊢_⊑ᵖ_⊣_)
+open import ImprecisionWf using
+  ( ImpCtx
+  ; _∣_⊢_⊑_⊣_
+  ; ⊑-tgt-wf
+  )
+open import NarrowWiden using
+  ( narrow-weaken
+  ; widen-weaken
+  )
+import NarrowWiden
+open import proof.Store.Core.NuImprecisionRelationalStoreDef using
+  ( StoreImp
+  ; leftStoreⁱ
+  ; leftStoreⁱ-lift
+  ; leftStoreⁱ-lift-left
+  ; rightStoreⁱ
+  ; rightStoreⁱ-lift
+  ; rightStoreⁱ-lift-left
+  )
+open import proof.NuCore.Relations.NuImprecisionTermContextDef using
+  ( CtxImp
+  ; leftCtxⁱ
+  ; leftCtxⁱ-lift
+  ; leftCtxⁱ-lift-left
+  ; rightCtxⁱ
+  ; rightCtxⁱ-lift
+  ; rightCtxⁱ-lift-left
+  )
+open import
+  proof.NuCore.Relations.NuImprecisionQuotientedTyping
+  using
+  ( nu-term-imprecision-source-typing
+  ; nu-term-imprecision-target-typing
+  ; quotiented-nu-term-imprecision-source-typing
+  ; quotiented-nu-term-imprecision-target-typing
+  )
+open import NuTerms using (Term; _⟨_⟩; ν)
+open import QuotientImprecisionCompatibility using
+  ( SpineCastMode
+  ; gradual↓
+  ; id-only↓
+  )
+open import QuotientedTermImprecision
+open import Store using (StoreIncl-cons)
+open import TermTyping using
+  ( cast-tag-or-id
+  ; forget
+  ; _∣_∣_⊢_⦂_
+  ; ⊢ƛ
+  ; ⊢·
+  ; ⊢Λ
+  ; ⊢ν↑
+  ; ⊢ν⊑
+  ; ⊢⊕
+  ; ⊢⟨⟩↑
+  ; ⊢⟨⟩↓
+  ; ⊢⟨⟩⊒
+  ; ⊢⟨⟩⊑
+  )
+open import proof.Core.Properties.NuTermProperties using
+  (closed-refined-typing-recontextualize; typing-closedᵐ)
+open import proof.Core.Properties.SealModeProperties using
+  (seal★-tag-or-id)
+open import proof.Core.Properties.StoreProperties using (renameStoreᵗ-incl)
+open import proof.Core.Properties.TypePreservation using
+  ( conversion↑-weaken
+  ; conversion↓-weaken
+  ; seal★-weaken
+  )
+open import proof.Store.Prefix.NuImprecisionStorePrefix using
+  ( leftStoreⁱ-prefix-inclusion
+  ; rightStoreⁱ-prefix-inclusion
+  ; store-imp-prefix-transⁱ
+  )
+open import proof.Store.Prefix.NuImprecisionStorePrefixEvidenceDef using
+  ( QuotientWideningPairPrefixᵀ
+  ; StoreCorrespondsPrefixᵀ
+  )
+open import proof.Store.Prefix.NuImprecisionStorePrefixLiftDef using
+  ( LeftStorePrefixLiftᵀ
+  ; PairedStorePrefixLiftᵀ
+  )
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixDef using
+  ( QuotientTermImprecisionStorePrefixᵀ
+  ; TermImprecisionStorePrefixᵀ
+  )
+open import
+  proof.NuCore.Misc.NuImprecisionRuntimeBulletStoreStability
+  using
+  ( term-typing-prefix-left-align
+  ; term-typing-prefix-right-align
+  )
+open import
+  proof.Quotient.NuImprecisionTargetInstantiationCreationDef
+  using
+  ( StoreImpPrefixᴿ
+  ; prefix-creationᴱ
+  ; prefix-reflᴿ
+  ; prefix-∷ᴿ
+  )
+open import
+  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
+  using
+  ( embedded-creation-source-typingᴱ
+  ; embedded-creation-target-typingᴱ
+  )
+open import Types using (Ctx; Ty; TyCtx)
+
+
+private
+  to-creation-prefix :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺} →
+    StoreImpPrefix {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    StoreImpPrefixᴿ ρ₀ ρ⁺
+  to-creation-prefix prefix-reflⁱ = prefix-reflᴿ
+  to-creation-prefix (prefix-∷ⁱ prefix) =
+    prefix-∷ᴿ (to-creation-prefix prefix)
+
+  spine-cast-mode-prefix :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ μ} →
+    StoreImpPrefix {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    SpineCastMode (leftStoreⁱ ρ₀) μ →
+    SpineCastMode (leftStoreⁱ ρ⁺) μ
+  spine-cast-mode-prefix prefix id-only↓ = id-only↓
+  spine-cast-mode-prefix prefix (gradual↓ mode seal★) =
+    gradual↓ mode
+      (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+
+  target-spine-cast-mode-prefix :
+    ∀ {Φ Δᴸ Δᴿ ρ₀ ρ⁺ μ} →
+    StoreImpPrefix {Φ} {Δᴸ} {Δᴿ} ρ₀ ρ⁺ →
+    SpineCastMode (rightStoreⁱ ρ₀) μ →
+    SpineCastMode (rightStoreⁱ ρ⁺) μ
+  target-spine-cast-mode-prefix prefix id-only↓ = id-only↓
+  target-spine-cast-mode-prefix prefix (gradual↓ mode seal★) =
+    gradual↓ mode
+      (seal★-weaken (rightStoreⁱ-prefix-inclusion prefix) seal★)
+
+  right-cast-typing-prefix :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {Γ Γ⁺ : Ctx} {M : Term} {A⁺ B : Ty} {c} →
+    StoreImpPrefix ρ₀ ρ⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ₀ ∣ Γ ⊢ M ⟨ c ⟩ ⦂ B →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ A⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ ⊢ M ⟨ c ⟩ ⦂ B
+  right-cast-typing-prefix prefix (⊢⟨⟩↑ c↑ M⊢) M⊢⁺ =
+    ⊢⟨⟩↑
+      (conversion↑-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion prefix) c↑)
+      (term-typing-prefix-right-align prefix M⊢ M⊢⁺)
+  right-cast-typing-prefix prefix (⊢⟨⟩↓ c↓ M⊢) M⊢⁺ =
+    ⊢⟨⟩↓
+      (conversion↓-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion prefix) c↓)
+      (term-typing-prefix-right-align prefix M⊢ M⊢⁺)
+  right-cast-typing-prefix prefix
+      (⊢⟨⟩⊒ mode seal★ c⊒ M⊢) M⊢⁺ =
+    ⊢⟨⟩⊒ mode
+      (seal★-weaken (rightStoreⁱ-prefix-inclusion prefix) seal★)
+      (narrow-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion prefix) c⊒)
+      (term-typing-prefix-right-align prefix M⊢ M⊢⁺)
+  right-cast-typing-prefix prefix
+      (⊢⟨⟩⊑ mode seal★ c⊑ M⊢) M⊢⁺ =
+    ⊢⟨⟩⊑ mode
+      (seal★-weaken (rightStoreⁱ-prefix-inclusion prefix) seal★)
+      (widen-weaken ≤-refl
+        (rightStoreⁱ-prefix-inclusion prefix) c⊑)
+      (term-typing-prefix-right-align prefix M⊢ M⊢⁺)
+
+  cast-body-typing :
+    ∀ {Δ Σ Γ M B c} →
+    Δ ∣ Σ ∣ Γ ⊢ M ⟨ c ⟩ ⦂ B →
+    ∃[ A ] Δ ∣ Σ ∣ Γ ⊢ M ⦂ A
+  cast-body-typing (⊢⟨⟩↑ c↑ M⊢) = _ , M⊢
+  cast-body-typing (⊢⟨⟩↓ c↓ M⊢) = _ , M⊢
+  cast-body-typing (⊢⟨⟩⊒ mode seal★ c⊒ M⊢) = _ , M⊢
+  cast-body-typing (⊢⟨⟩⊑ mode seal★ c⊑ M⊢) = _ , M⊢
+
+  nu-body-typing :
+    ∀ {Δ Σ Γ A L B c} →
+    Δ ∣ Σ ∣ Γ ⊢ ν A L c ⦂ B →
+    ∃[ C ] Δ ∣ Σ ∣ Γ ⊢ L ⦂ C
+  nu-body-typing (⊢ν↑ hA L⊢ c↑) = _ , L⊢
+  nu-body-typing (⊢ν⊑ mode seal★ L⊢ c⊑) = _ , L⊢
+
+
+module _
+    (store-corresponds-prefix : StoreCorrespondsPrefixᵀ)
+    (quotient-widening-pair-prefix : QuotientWideningPairPrefixᵀ)
+    (paired-store-prefix-lift : PairedStorePrefixLiftᵀ)
+    (left-store-prefix-lift : LeftStorePrefixLiftᵀ)
+  where
+
+  align-sourceᵀ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {A B A⁺ : Ty} {Γ⁺ : Ctx}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    StoreImpPrefix ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ A⁺ →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ A
+  align-sourceᵀ prefix M⊑M′ M⊢ =
+    term-typing-prefix-left-align prefix
+      (nu-term-imprecision-source-typing M⊑M′) M⊢
+
+  align-targetᵀ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {A B B⁺ : Ty} {Γ⁺ : Ctx}
+      {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+    StoreImpPrefix ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M′ ⦂ B⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ B
+  align-targetᵀ prefix M⊑M′ M′⊢ =
+    term-typing-prefix-right-align prefix
+      (nu-term-imprecision-target-typing M⊑M′) M′⊢
+
+  align-quotient-sourceᵀ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {D D′ D⁺ : Ty} {Γ⁺ : Ctx}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    StoreImpPrefix ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M ⦂ D⁺ →
+    Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ leftCtxⁱ γ ⊢ M ⦂ D
+  align-quotient-sourceᵀ prefix M⊑M′ M⊢ =
+    term-typing-prefix-left-align prefix
+      (quotiented-nu-term-imprecision-source-typing M⊑M′) M⊢
+
+  align-quotient-targetᵀ :
+    ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+      {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+      {γ : CtxImp Φ Δᴸ Δᴿ}
+      {M M′ : Term} {D D′ D′⁺ : Ty} {Γ⁺ : Ctx}
+      {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+    StoreImpPrefix ρ₀ ρ⁺ →
+    Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+      ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γ⁺ ⊢ M′ ⦂ D′⁺ →
+    Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ rightCtxⁱ γ ⊢ M′ ⦂ D′
+  align-quotient-targetᵀ prefix M⊑M′ M′⊢ =
+    term-typing-prefix-right-align prefix
+      (quotiented-nu-term-imprecision-target-typing M⊑M′) M′⊢
+
+  mutual
+    term-imprecision-store-prefix-proofᵀ :
+      TermImprecisionStorePrefixᵀ
+
+    quotient-term-imprecision-store-prefix-proofᵀ :
+      QuotientTermImprecisionStorePrefixᵀ
+
+    term-imprecision-store-prefix-alignᵀ :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+        {γ : CtxImp Φ Δᴸ Δᴿ}
+        {M M′ : Term} {A B A⁺ B⁺ : Ty} {Γᴸ⁺ Γᴿ⁺ : Ctx}
+        {p : Φ ∣ Δᴸ ⊢ A ⊑ B ⊣ Δᴿ} →
+      StoreImpPrefix ρ₀ ρ⁺ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+        ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p →
+      Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γᴸ⁺ ⊢ M ⦂ A⁺ →
+      Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γᴿ⁺ ⊢ M′ ⦂ B⁺ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+        ⊢ᴺ M ⊑ M′ ⦂ A ⊑ B ∶ p
+
+    quotient-term-imprecision-store-prefix-alignᵀ :
+      ∀ {Φ : ImpCtx} {Δᴸ Δᴿ : TyCtx}
+        {ρ₀ ρ⁺ : StoreImp Φ Δᴸ Δᴿ}
+        {γ : CtxImp Φ Δᴸ Δᴿ}
+        {M M′ : Term} {D D′ D⁺ D′⁺ : Ty} {Γᴸ⁺ Γᴿ⁺ : Ctx}
+        {q : Φ ∣ Δᴸ ⊢ D ⊑ᵖ D′ ⊣ Δᴿ} →
+      StoreImpPrefix ρ₀ ρ⁺ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ₀ ∣ γ
+        ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q →
+      Δᴸ ∣ leftStoreⁱ ρ⁺ ∣ Γᴸ⁺ ⊢ M ⦂ D⁺ →
+      Δᴿ ∣ rightStoreⁱ ρ⁺ ∣ Γᴿ⁺ ⊢ M′ ⦂ D′⁺ →
+      Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ⁺ ∣ γ
+        ⊢ᴺᵖ M ⊑ M′ ⦂ D ⊑ᵖ D′ ∶ q
+
+    term-imprecision-store-prefix-goᵀ :
+      TermImprecisionStorePrefixᵀ
+
+    quotient-term-imprecision-store-prefix-goᵀ :
+      QuotientTermImprecisionStorePrefixᵀ
+
+    term-imprecision-store-prefix-proofᵀ prefix M⊑M′ M⊢ M′⊢ =
+      term-imprecision-store-prefix-alignᵀ prefix M⊑M′ M⊢ M′⊢
+
+    quotient-term-imprecision-store-prefix-proofᵀ prefix M⊑M′ M⊢ M′⊢ =
+      quotient-term-imprecision-store-prefix-alignᵀ
+        prefix M⊑M′ M⊢ M′⊢
+
+    term-imprecision-store-prefix-alignᵀ prefix M⊑M′ M⊢ M′⊢ =
+      term-imprecision-store-prefix-goᵀ prefix M⊑M′
+        (align-sourceᵀ prefix M⊑M′ M⊢)
+        (align-targetᵀ prefix M⊑M′ M′⊢)
+
+    quotient-term-imprecision-store-prefix-alignᵀ
+        prefix M⊑M′ M⊢ M′⊢ =
+      quotient-term-imprecision-store-prefix-goᵀ prefix M⊑M′
+        (align-quotient-sourceᵀ prefix M⊑M′ M⊢)
+        (align-quotient-targetᵀ prefix M⊑M′ M′⊢)
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (blame⊑ᵀ M′⊢₀) M⊢ M′⊢ =
+      blame⊑ᵀ M′⊢
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (x⊑xᵀ x∈) M⊢ M′⊢ =
+      x⊑xᵀ x∈
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (ƛ⊑ƛᵀ hA hA′ N⊑N′)
+        (⊢ƛ hA⁺ N⊢) (⊢ƛ hA′⁺ N′⊢) =
+      ƛ⊑ƛᵀ hA hA′
+        (term-imprecision-store-prefix-alignᵀ
+          prefix N⊑N′ N⊢ N′⊢)
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (·⊑·ᵀ L⊑L′ M⊑M′)
+        (⊢· L⊢ M⊢) (⊢· L′⊢ M′⊢) =
+      ·⊑·ᵀ
+        (term-imprecision-store-prefix-alignᵀ
+          prefix L⊑L′ L⊢ L′⊢)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (closeᵀ N⊑N′ widening-pair p
+          u-shape u′-shape square compatible)
+        M⊢ M′⊢
+        with cast-body-typing M⊢ | cast-body-typing M′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (closeᵀ N⊑N′ widening-pair p
+          u-shape u′-shape square compatible)
+        M⊢ M′⊢
+        | D⁺ , N⊢ | D′⁺ , N′⊢ =
+      closeᵀ
+        (quotient-term-imprecision-store-prefix-alignᵀ
+          prefix N⊑N′ N⊢ N′⊢)
+        (quotient-widening-pair-prefix prefix widening-pair)
+        p u-shape u′-shape square compatible
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (Λ⊑Λᵀ liftρ liftγ vV vV′ V⊑V′)
+        (⊢Λ vV⁺ V⊢) (⊢Λ vV′⁺ V′⊢)
+        with paired-store-prefix-lift prefix liftρ
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (Λ⊑Λᵀ liftρ liftγ vV vV′ V⊑V′)
+        (⊢Λ vV⁺ V⊢) (⊢Λ vV′⁺ V′⊢)
+        | ρ⁺↑ , liftρ⁺ , prefix↑ =
+      Λ⊑Λᵀ liftρ⁺ liftγ vV vV′
+        (term-imprecision-store-prefix-alignᵀ
+          prefix↑ V⊑V′
+          (subst
+            (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+            (sym (leftStoreⁱ-lift liftρ⁺))
+            (subst
+              (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+              (sym (leftCtxⁱ-lift liftγ))
+              V⊢))
+          (subst
+            (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+            (sym (rightStoreⁱ-lift liftρ⁺))
+            (subst
+              (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+              (sym (rightCtxⁱ-lift liftγ))
+              V′⊢)))
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (Λ⊑ᵀ occ liftρ liftγ vV V⊑N′)
+        (⊢Λ vV⁺ V⊢) N′⊢
+        with left-store-prefix-lift prefix liftρ
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (Λ⊑ᵀ occ liftρ liftγ vV V⊑N′)
+        (⊢Λ vV⁺ V⊢) N′⊢
+        | ρ⁺↑ , liftρ⁺ , prefix↑ =
+      Λ⊑ᵀ occ liftρ⁺ liftγ vV
+        (term-imprecision-store-prefix-alignᵀ
+          prefix↑ V⊑N′
+          (subst
+            (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+            (sym (leftStoreⁱ-lift-left liftρ⁺))
+            (subst
+              (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+              (sym (leftCtxⁱ-lift-left liftγ))
+              V⊢))
+          (subst
+            (λ Σ → _ ∣ Σ ∣ _ ⊢ _ ⦂ _)
+            (sym (rightStoreⁱ-lift-left liftρ⁺))
+            (subst
+              (λ Γ → _ ∣ _ ∣ Γ ⊢ _ ⦂ _)
+              (sym (rightCtxⁱ-lift-left liftγ))
+              N′⊢)))
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (target-instantiationᵀ embedded) M⊢ M′⊢ =
+      target-instantiationᵀ
+        (prefix-creationᴱ embedded (to-creation-prefix prefix)
+          (closed-refined-typing-recontextualize
+            {Γ′ = []}
+            (typing-closedᵐ
+              (forget (embedded-creation-source-typingᴱ embedded)))
+            M⊢)
+          (closed-refined-typing-recontextualize
+            {Γ′ = []}
+            (typing-closedᵐ
+              (forget (embedded-creation-target-typingᴱ embedded)))
+            M′⊢))
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
+          allocation-prefix L•⊢ L′•⊢)
+        L•⊢⁺ L′•⊢⁺ =
+      α⊑αᵀ vL noL vL′ noL′ A⇑⊑B⇑ liftρ liftγ L⊑L′
+        (store-imp-prefix-transⁱ allocation-prefix prefix)
+        L•⊢⁺ L′•⊢⁺
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′
+          allocation-prefix L•⊢ N′⊢)
+        L•⊢⁺ N′⊢⁺ =
+      α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑N′
+        (store-imp-prefix-transⁱ allocation-prefix prefix)
+        L•⊢⁺ N′⊢⁺
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+          liftρ liftγ N⊑N′ replace)
+        M⊢ M′⊢
+        with nu-body-typing M⊢ | nu-body-typing M′⊢
+           | paired-store-prefix-lift prefix liftρ
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A⇑⊑A′⇑
+          liftρ liftγ N⊑N′ replace)
+        M⊢ M′⊢
+        | C⁺ , N⊢ | C′⁺ , N′⊢ | ρ⁺↑ , liftρ⁺ , prefix↑ =
+      ν⊑νᵀ hA hA′
+        (weaken-reveal-conversion
+          (StoreIncl-cons
+            (renameStoreᵗ-incl suc
+              (leftStoreⁱ-prefix-inclusion prefix)))
+          s↑)
+        (weaken-reveal-conversion
+          (StoreIncl-cons
+            (renameStoreᵗ-incl suc
+              (rightStoreⁱ-prefix-inclusion prefix)))
+          s′↑)
+        A⊑A′ A⇑⊑A′⇑ liftρ⁺ liftγ
+        (term-imprecision-store-prefix-alignᵀ
+          prefix N⊑N′ N⊢ N′⊢)
+        replace
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑N′ replace)
+        M⊢ N′⊢
+        with nu-body-typing M⊢
+           | left-store-prefix-lift prefix liftρ
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑N′ replace)
+        M⊢ N′⊢
+        | C⁺ , N⊢ | ρ⁺↑ , liftρ⁺ , prefix↑ =
+      ν⊑ᵀ hA h⇑A
+        (weaken-reveal-conversion
+          (StoreIncl-cons
+            (renameStoreᵗ-incl suc
+              (leftStoreⁱ-prefix-inclusion prefix)))
+          s↑)
+        liftρ⁺ liftγ
+        (term-imprecision-store-prefix-alignᵀ
+          prefix N⊑N′ N⊢ N′⊢)
+        replace
+
+    term-imprecision-store-prefix-goᵀ
+        prefix κ⊑κᵀ M⊢ M′⊢ =
+      κ⊑κᵀ
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (⊕⊑⊕ᵀ L⊑L′ M⊑M′)
+        (⊢⊕ L⊢ op M⊢) (⊢⊕ L′⊢ op′ M′⊢) =
+      ⊕⊑⊕ᵀ
+        (term-imprecision-store-prefix-alignᵀ
+          prefix L⊑L′ L⊢ L′⊢)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (gen⊑groundᵀ mode seal★ c⊒ gH vV vW W⊢₀ V⊑Wtag q)
+        M⊢ W⊢
+        with cast-body-typing M⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (gen⊑groundᵀ mode seal★ c⊒ gH vV vW W⊢₀ V⊑Wtag q)
+        M⊢ W⊢
+        | A⁺ , V⊢ =
+      gen⊑groundᵀ
+        mode
+        (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+        (narrow-weaken ≤-refl
+          (leftStoreⁱ-prefix-inclusion prefix) c⊒)
+        gH vV vW W⊢
+        (term-imprecision-store-prefix-alignᵀ
+          prefix V⊑Wtag V⊢
+          (right-cast-typing-prefix prefix
+            (nu-term-imprecision-target-typing V⊑Wtag) W⊢))
+        q
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (cast⊒⊑ᵀ mode seal★ c⊒ M⊑M′ q c-shape comp)
+        L⊢ M′⊢
+        with cast-body-typing L⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (cast⊒⊑ᵀ mode seal★ c⊒ M⊑M′ q c-shape comp)
+        L⊢ M′⊢
+        | A⁺ , M⊢ =
+      cast⊒⊑ᵀ mode
+        (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+        (narrow-weaken ≤-refl
+          (leftStoreⁱ-prefix-inclusion prefix) c⊒)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q c-shape comp
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (cast⊑⊑ᵀ mode seal★ c⊑ M⊑M′ q c-shape comp)
+        L⊢ M′⊢
+        with cast-body-typing L⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (cast⊑⊑ᵀ mode seal★ c⊑ M⊑M′ q c-shape comp)
+        L⊢ M′⊢
+        | A⁺ , M⊢ =
+      cast⊑⊑ᵀ mode
+        (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+        (widen-weaken ≤-refl
+          (leftStoreⁱ-prefix-inclusion prefix) c⊑)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q c-shape comp
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (⊑cast⊒ᵀ mode′ seal★′ c′⊒ M⊑M′ q c-shape comp)
+        M⊢ L′⊢
+        with cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (⊑cast⊒ᵀ mode′ seal★′ c′⊒ M⊑M′ q c-shape comp)
+        M⊢ L′⊢
+        | B′⁺ , M′⊢ =
+      ⊑cast⊒ᵀ mode′
+        (seal★-weaken (rightStoreⁱ-prefix-inclusion prefix) seal★′)
+        (narrow-weaken ≤-refl
+          (rightStoreⁱ-prefix-inclusion prefix) c′⊒)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q c-shape comp
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (⊑cast⊑ᵀ mode′ seal★′ c′⊑ M⊑M′ q c-shape comp)
+        M⊢ L′⊢
+        with cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (⊑cast⊑ᵀ mode′ seal★′ c′⊑ M⊑M′ q c-shape comp)
+        M⊢ L′⊢
+        | B′⁺ , M′⊢ =
+      ⊑cast⊑ᵀ mode′
+        (seal★-weaken (rightStoreⁱ-prefix-inclusion prefix) seal★′)
+        (widen-weaken ≤-refl
+          (rightStoreⁱ-prefix-inclusion prefix) c′⊑)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q c-shape comp
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (conv↑⊑ᵀ c↑ M⊑M′ q replace)
+        L⊢ M′⊢
+        with cast-body-typing L⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix (conv↑⊑ᵀ c↑ M⊑M′ q replace)
+        L⊢ M′⊢
+        | A⁺ , M⊢ =
+      conv↑⊑ᵀ
+        (weaken-reveal-conversion
+          (leftStoreⁱ-prefix-inclusion prefix) c↑)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q replace
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (conv↓⊑ᵀ c↓ M⊑M′ q replace)
+        L⊢ M′⊢
+        with cast-body-typing L⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix (conv↓⊑ᵀ c↓ M⊑M′ q replace)
+        L⊢ M′⊢
+        | A⁺ , M⊢ =
+      conv↓⊑ᵀ
+        (weaken-conceal-conversion
+          (leftStoreⁱ-prefix-inclusion prefix) c↓)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q replace
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (⊑conv↑ᵀ c′↑ M⊑M′ q replace)
+        M⊢ L′⊢
+        with cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix (⊑conv↑ᵀ c′↑ M⊑M′ q replace)
+        M⊢ L′⊢
+        | B′⁺ , M′⊢ =
+      ⊑conv↑ᵀ
+        (weaken-reveal-conversion
+          (rightStoreⁱ-prefix-inclusion prefix) c′↑)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q replace
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (⊑conv↓ᵀ c′↓ M⊑M′ q replace)
+        M⊢ L′⊢
+        with cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix (⊑conv↓ᵀ c′↓ M⊑M′ q replace)
+        M⊢ L′⊢
+        | B′⁺ , M′⊢ =
+      ⊑conv↓ᵀ
+        (weaken-conceal-conversion
+          (rightStoreⁱ-prefix-inclusion prefix) c′↓)
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        q replace
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (paired-revealᵀ corresponds c↑ c′↑ replace M⊑M′)
+        L⊢ L′⊢
+        with cast-body-typing L⊢ | cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix (paired-revealᵀ corresponds c↑ c′↑ replace M⊑M′)
+        L⊢ L′⊢
+        | A⁺ , M⊢ | B′⁺ , M′⊢ =
+      paired-revealᵀ
+        (store-corresponds-prefix prefix corresponds)
+        (weaken-reveal-conversion
+          (leftStoreⁱ-prefix-inclusion prefix) c↑)
+        (weaken-reveal-conversion
+          (rightStoreⁱ-prefix-inclusion prefix) c′↑)
+        replace
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+
+    term-imprecision-store-prefix-goᵀ
+        prefix (paired-concealᵀ corresponds c↓ c′↓ replace M⊑M′)
+        L⊢ L′⊢
+        with cast-body-typing L⊢ | cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix (paired-concealᵀ corresponds c↓ c′↓ replace M⊑M′)
+        L⊢ L′⊢
+        | A⁺ , M⊢ | B′⁺ , M′⊢ =
+      paired-concealᵀ
+        (store-corresponds-prefix prefix corresponds)
+        (weaken-conceal-conversion
+          (leftStoreⁱ-prefix-inclusion prefix) c↓)
+        (weaken-conceal-conversion
+          (rightStoreⁱ-prefix-inclusion prefix) c′↓)
+        replace
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (paired-wideningᵀ
+          mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+          left right compatible M⊑M′)
+        L⊢ L′⊢
+        with cast-body-typing L⊢ | cast-body-typing L′⊢
+    term-imprecision-store-prefix-goᵀ
+        prefix
+        (paired-wideningᵀ
+          mode seal★ c⊑ c-shape mode′ seal★′ c′⊑ c′-shape
+          left right compatible M⊑M′)
+        L⊢ L′⊢
+        | A⁺ , M⊢ | B′⁺ , M′⊢ =
+      paired-wideningᵀ
+        mode
+        (seal★-weaken (leftStoreⁱ-prefix-inclusion prefix) seal★)
+        (widen-weaken ≤-refl
+          (leftStoreⁱ-prefix-inclusion prefix) c⊑)
+        c-shape
+        mode′
+        (seal★-weaken (rightStoreⁱ-prefix-inclusion prefix) seal★′)
+        (widen-weaken ≤-refl
+          (rightStoreⁱ-prefix-inclusion prefix) c′⊑)
+        c′-shape left right compatible
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+
+    quotient-term-imprecision-store-prefix-goᵀ
+        prefix
+        (paired-downᵀ
+          M⊑M′ source-mode source source-shape
+          target-mode target target-shape square elimination)
+        L⊢ L′⊢
+        with cast-body-typing L⊢ | cast-body-typing L′⊢
+    quotient-term-imprecision-store-prefix-goᵀ
+        prefix
+        (paired-downᵀ
+          M⊑M′ source-mode source source-shape
+          target-mode target target-shape square elimination)
+        L⊢ L′⊢
+        | D⁺ , M⊢ | D′⁺ , M′⊢ =
+      paired-downᵀ
+        (term-imprecision-store-prefix-alignᵀ
+          prefix M⊑M′ M⊢ M′⊢)
+        (spine-cast-mode-prefix prefix source-mode)
+        (narrow-weaken ≤-refl
+          (leftStoreⁱ-prefix-inclusion prefix) source)
+        source-shape
+        (target-spine-cast-mode-prefix prefix target-mode)
+        (narrow-weaken ≤-refl
+          (rightStoreⁱ-prefix-inclusion prefix) target)
+        target-shape square elimination

--- a/GTSF/proof/Substitution/Parallel/NuImprecisionParallelTermSubstitutionProof.agda
+++ b/GTSF/proof/Substitution/Parallel/NuImprecisionParallelTermSubstitutionProof.agda
@@ -8,6 +8,8 @@ module proof.Substitution.Parallel.NuImprecisionParallelTermSubstitutionProof wh
 --   * Contains no postulate, hole, catch-all, termination pragma, or
 --     permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Data.List using (_∷_)
 open import Data.Nat using (suc; zero)
 open import Data.Nat.Properties using (≤-refl)
@@ -45,7 +47,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; cast⊑⊑ᵀ
   ; cast⊒⊑ᵀ
@@ -238,7 +239,7 @@ mutual
                   (forget
                     (embedded-creation-target-typingᴱ embedded)))
                 τ′ =
-    allocation-prefixᵀ prefix
+    term-imprecision-store-prefixᵀ prefix
       (target-instantiationᵀ embedded)
       (term-weaken ≤-refl
         (leftStoreⁱ-prefix-inclusion prefix)
@@ -259,17 +260,12 @@ mutual
 
   quotiented-parallel-term-substitution-framed-proofᵀ
       environment frame prefix () noN′
-      (α⊑αᵀ vL noL vL′ noL′ p liftρ liftγ body L⊢ L′⊢)
+      (α⊑αᵀ vL noL vL′ noL′ p liftρ liftγ body
+        allocation-prefix L⊢ L′⊢)
   quotiented-parallel-term-substitution-framed-proofᵀ
       environment frame prefix () noN′
-      (α⊑ᵀ vL noL hA liftρ liftγ body L⊢ N′⊢)
-  quotiented-parallel-term-substitution-framed-proofᵀ
-      environment frame prefix noN noN′
-      (allocation-prefixᵀ inner-prefix body N⊢ N′⊢) =
-    quotiented-parallel-term-substitution-framed-proofᵀ
-      environment frame
-      (store-imp-prefix-transⁱ inner-prefix prefix)
-      noN noN′ body
+      (α⊑ᵀ vL noL hA liftρ liftγ body
+        allocation-prefix L⊢ N′⊢)
 
   quotiented-parallel-term-substitution-framed-proofᵀ
       environment frame prefix (no•-ν noN) (no•-ν noN′)

--- a/GTSF/proof/Substitution/Term/NuImprecisionTermContextShiftProof.agda
+++ b/GTSF/proof/Substitution/Term/NuImprecisionTermContextShiftProof.agda
@@ -288,17 +288,11 @@ private
       target-instantiationᵀ embedded
     term-ctx-insert-no•ᵀ insert
         (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ
-          L⊑L′ L⊢ L′⊢)
+          L⊑L′ prefix L⊢ L′⊢)
         () noM′
     term-ctx-insert-no•ᵀ insert
-        (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ L⊢ N′⊢)
+        (α⊑ᵀ vL noL hA liftρ liftγ L⊑N′ prefix L⊢ N′⊢)
         () noN′
-    term-ctx-insert-no•ᵀ insert
-        (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢) noM noM′ =
-      allocation-prefixᵀ prefix
-        (term-ctx-insert-no•ᵀ insert M⊑M′ noM noM′)
-        (typing-renameˣ (term-ctx-insert-left-wfⁱ insert) M⊢)
-        (typing-renameˣ (term-ctx-insert-right-wfⁱ insert) M′⊢)
     term-ctx-insert-no•ᵀ insert
         (ν⊑νᵀ hA hA′ s↑ s′↑ A⊑A′ A↑⊑A′↑
           liftρ liftγ N⊑N′ replace)

--- a/GTSF/proof/Target/Core/NuImprecisionTargetBlameCatchup.agda
+++ b/GTSF/proof/Target/Core/NuImprecisionTargetBlameCatchup.agda
@@ -33,7 +33,6 @@ open import QuotientedTermImprecision using
   ; blame⊑ᵀ
   ; Λ⊑ᵀ
   ; α⊑ᵀ
-  ; allocation-prefixᵀ
   ; ν⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
@@ -57,9 +56,6 @@ value-not-target-blameᵀ :
 value-not-target-blameᵀ () (blame⊑ᵀ _)
 value-not-target-blameᵀ (Λ vV) (Λ⊑ᵀ occ liftρ liftγ _ V⊑N′) =
   value-not-target-blameᵀ vV V⊑N′
-value-not-target-blameᵀ vV
-    (allocation-prefixᵀ prefix V⊑blame V⊢ blame⊢) =
-  value-not-target-blameᵀ vV V⊑blame
 value-not-target-blameᵀ (vV ⟨ c ⟩)
     (cast⊒⊑ᵀ mode seal★ c⊒ V⊑blame q c-shape comp) =
   value-not-target-blameᵀ vV V⊑blame
@@ -106,11 +102,9 @@ left-catchup-target-blame-generalᵀ okM
     (Λ⊑ᵀ occ liftρ liftγ vV V⊑blame) =
   ⊥-elim (value-not-target-blameᵀ vV V⊑blame)
 left-catchup-target-blame-generalᵀ okM
-    (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑blame L•⊢ blame⊢) =
+    (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑blame
+      prefix L•⊢ blame⊢) =
   ⊥-elim (value-not-target-blameᵀ vL L⊑blame)
-left-catchup-target-blame-generalᵀ okM
-    (allocation-prefixᵀ prefix M⊑blame M⊢ blame⊢) =
-  left-catchup-target-blame-generalᵀ okM M⊑blame
 left-catchup-target-blame-generalᵀ okM
     (ν⊑ᵀ hA h⇑A s↑ liftρ liftγ N⊑blame replace) =
   χs ++ keep ∷ [] , ν-blame-tailᵀ N↠blame

--- a/GTSF/proof/Target/Core/NuImprecisionTargetBulletSourceApplicationExclusionProof.agda
+++ b/GTSF/proof/Target/Core/NuImprecisionTargetBulletSourceApplicationExclusionProof.agda
@@ -1,11 +1,10 @@
 module proof.Target.Core.NuImprecisionTargetBulletSourceApplicationExclusionProof where
 
 -- File Charter:
---   * Exhaustively peels target-bullet allocation prefixes and invokes the
---     canonical application/target-value exclusion at the bullet root.
+--   * Proves directly that a source application cannot be related to a
+--     target runtime bullet by the syntax-directed term relation.
 --   * Contains no catch-all, postulate, hole, or permissive option.
 
-open import QuotientedTermImprecision using (allocation-prefixᵀ)
 open import
   proof.Target.Core.NuImprecisionTargetBulletSourceApplicationExclusionDef
   using (QuotientedTargetBulletExcludesSourceApplicationᵀ)
@@ -17,5 +16,4 @@ open import
 quotiented-target-bullet-excludes-source-application-proofᵀ :
   QuotientedTargetBulletExcludesSourceApplicationᵀ
 quotiented-target-bullet-excludes-source-application-proofᵀ
-    (allocation-prefixᵀ prefix inner source⊢ target⊢) =
-  quotiented-target-bullet-excludes-source-application-proofᵀ inner
+    ()

--- a/GTSF/proof/Target/Core/NuImprecisionTargetBulletSourceValueExclusionProof.agda
+++ b/GTSF/proof/Target/Core/NuImprecisionTargetBulletSourceValueExclusionProof.agda
@@ -3,8 +3,7 @@ module
   where
 
 -- File Charter:
---   * Exhaustively peels source-value and allocation frames above a target
---     runtime bullet.
+--   * Exhaustively peels source-value frames above a target runtime bullet.
 --   * Closes the exposed right-allocation root with its incompatible
 --     pre-allocation and post-allocation type indices.
 --   * Contains no catch-all, postulate, hole, or permissive option.
@@ -13,8 +12,7 @@ open import Data.Empty using (⊥-elim)
 open import NuTerms using
   (Value; Λ_; _⟨_⟩)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; blame⊑ᵀ
+  ( blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; conv↑⊑ᵀ
@@ -22,11 +20,7 @@ open import QuotientedTermImprecision using
   ; Λ⊑ᵀ
   ; α⊑αᵀ
   ; α⊑ᵀ
-  ; target-instantiationᵀ
   )
-open import
-  proof.Quotient.NuImprecisionEmbeddedTargetInstantiationCreationProperties
-  using (embedded-creation-target-valueᴱ)
 open import
   proof.NuCore.Misc.NuImprecisionTargetBulletIndexCycleDef
   using (TargetBulletIndexCycleᵀ)
@@ -45,20 +39,11 @@ quotiented-target-bullet-excludes-source-value-proofᵀ cycle
   quotiented-target-bullet-excludes-source-value-proofᵀ
     cycle vW inner
 quotiented-target-bullet-excludes-source-value-proofᵀ cycle
-    vV (target-instantiationᵀ embedded)
-    with embedded-creation-target-valueᴱ embedded
-quotiented-target-bullet-excludes-source-value-proofᵀ cycle
-    vV (target-instantiationᵀ embedded) | ()
-quotiented-target-bullet-excludes-source-value-proofᵀ cycle
     () (α⊑αᵀ vL noL vL′ noL′ p liftρ liftγ
-      inner source-typing target-typing)
+      inner prefix source-typing target-typing)
 quotiented-target-bullet-excludes-source-value-proofᵀ cycle
     () (α⊑ᵀ vL noL hA liftρ liftγ
-      inner source-typing target-typing)
-quotiented-target-bullet-excludes-source-value-proofᵀ cycle
-    vV (allocation-prefixᵀ prefix inner source-typing target-typing) =
-  quotiented-target-bullet-excludes-source-value-proofᵀ
-    cycle vV inner
+      inner prefix source-typing target-typing)
 quotiented-target-bullet-excludes-source-value-proofᵀ cycle
     (vV ⟨ inert ⟩)
     (cast⊒⊑ᵀ mode seal★ cast inner q shape composition) =

--- a/GTSF/proof/Target/Core/NuImprecisionTargetValueSourceApplicationExclusionProof.agda
+++ b/GTSF/proof/Target/Core/NuImprecisionTargetValueSourceApplicationExclusionProof.agda
@@ -3,13 +3,12 @@ module proof.Target.Core.NuImprecisionTargetValueSourceApplicationExclusionProof
 -- File Charter:
 --   * Exhaustively proves that no QTI derivation relates a source application
 --     to a target value.
---   * Recurses only through allocation prefixes and target cast wrappers.
+--   * Recurses only through target cast wrappers.
 --   * Contains no catch-all, postulate, hole, or permissive option.
 
 open import NuTerms using (Value; _⟨_⟩)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ·⊑·ᵀ
+  ( ·⊑·ᵀ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
   ; ⊑conv↑ᵀ
@@ -23,9 +22,6 @@ quotiented-target-value-excludes-source-application-proofᵀ :
   QuotientedTargetValueExcludesSourceApplicationᵀ
 quotiented-target-value-excludes-source-application-proofᵀ
     (·⊑·ᵀ L⊑L′ M⊑M′) ()
-quotiented-target-value-excludes-source-application-proofᵀ
-    (allocation-prefixᵀ prefix inner source⊢ target⊢) vV =
-  quotiented-target-value-excludes-source-application-proofᵀ inner vV
 quotiented-target-value-excludes-source-application-proofᵀ
     (⊑cast⊒ᵀ mode seal★ c⊒ inner q c-shape comp)
     (vV ⟨ inert ⟩) =

--- a/GTSF/proof/Target/SealTag/NuImprecisionTargetSealCancellationProof.agda
+++ b/GTSF/proof/Target/SealTag/NuImprecisionTargetSealCancellationProof.agda
@@ -34,7 +34,6 @@ open import NuTerms using
   (No•; Term; Value; no•-⟨⟩; _⟨_⟩)
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -278,23 +277,6 @@ target-seal-cancellation-prefixᵀ
       (right-prefix-inclusionᵀ prefix βX∈Σ) βX′∈Σ =
   conv↓⊑ᵀ {μ = μ} (conceal-seal hY αY∈Σ ok)
     M⊑V q (source-variable-left-replacementᵀ q inner-index)
-target-seal-cancellation-prefixᵀ
-    {p = idˣ a∈Φ α< β<} prefix coh wfΣ vW noW vV βX′∈Σ
-    (allocation-prefixᵀ prefix₀ inner W⊢ Vseal⊢) q
-    with target-seal-typing⁻¹ Vseal⊢
-target-seal-cancellation-prefixᵀ
-    {p = idˣ a∈Φ α< β<} prefix coh wfΣ vW noW vV βX′∈Σ
-    (allocation-prefixᵀ prefix₀ inner W⊢ Vseal⊢) q
-    | βX∈Σ , V⊢
-    rewrite unique wfΣ
-      (right-prefix-inclusionᵀ prefix βX∈Σ) βX′∈Σ =
-  allocation-prefixᵀ prefix₀
-    (target-seal-cancellation-prefixᵀ
-      (prefix-transᵀ prefix₀ prefix) coh wfΣ
-      vW noW vV βX′∈Σ inner q)
-    W⊢ V⊢
-
-
 target-seal-cancellation-proofᵀ : TargetSealCancellationᵀ
 target-seal-cancellation-proofᵀ coh wfΣ vW noW vV β∈Σ W⊑V q =
   target-seal-cancellation-prefixᵀ

--- a/GTSF/proof/Target/SealTag/NuImprecisionTargetTagCancellationProof.agda
+++ b/GTSF/proof/Target/SealTag/NuImprecisionTargetTagCancellationProof.agda
@@ -75,8 +75,7 @@ open import QuotientImprecisionCompatibility using
   ; compatible-through-non-function-representativesᴿ
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; cast⊒⊑ᵀ
+  ( cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
   ; conv↑⊑ᵀ
@@ -923,16 +922,6 @@ target-tag-cancellation-proofᵀ exclusive unique gH
   cast⊑⊑ᵀ mode seal★ u⊑ ordinary requested u-shape
     (quotient-function-tag-right-composition
       unique outer-index requested _ ordinary-index square)
-target-tag-cancellation-proofᵀ exclusive unique gH vV noV vW
-    (allocation-prefixᵀ prefix inner V⊢ Wtag⊢) requested
-    with target-tag-cancellation-proofᵀ exclusive unique
-      gH vV noV vW inner requested
-target-tag-cancellation-proofᵀ exclusive unique gH vV noV vW
-    (allocation-prefixᵀ prefix inner V⊢ Wtag⊢) requested
-    | refl , canceled =
-  refl ,
-  allocation-prefixᵀ prefix canceled V⊢
-    (target-tag-typing⁻¹ Wtag⊢)
 target-tag-cancellation-proofᵀ exclusive unique gH vV noV vW
     (⊑cast⊑ᵀ {p = inner-index} mode seal★
       (C.cast-tag hG gG ok , NW.tag gG′) inner old-index

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Cases/NuImprecisionWorldCoherentRightOneStepLeftFrameCasesProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Cases/NuImprecisionWorldCoherentRightOneStepLeftFrameCasesProof.agda
@@ -10,6 +10,8 @@ module
 --   * Contains no recursive dispatcher implementation, result wrapper,
 --     postulate, hole, permissive option, or compatibility alias.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Data.List using ([])
 open import Data.Product using (_,_)
 open import Data.Sum using (inj₁; inj₂)
@@ -40,7 +42,6 @@ open import NuTerms using
 open import Primitives using (addℕ)
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import TermTyping using
@@ -146,7 +147,7 @@ world-coherent-right-one-step-application-left-caseᵀ
     L⊑L′ M⊑M′ L⊢ M⊢ L′⊢ M′⊢ L′→
     | inj₁ (noM , noM′) =
   rightStepApplicationLeftFrame frames noM noM′
-    (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢)
+    (term-imprecision-store-prefixᵀ prefix M⊑M′ M⊢ M′⊢)
     (recursive prefix coherent exclusive unique wfL wfR
       (runtime-·₁ okLM) (runtime-·₁ okL′M′)
       L⊑L′ L⊢ L′⊢ L′→)
@@ -203,7 +204,7 @@ world-coherent-right-one-step-primitive-left-caseᵀ
     L⊑L′ M⊑M′ L⊢ M⊢ L′⊢ M′⊢ L′→
     | inj₁ (noM , noM′) =
   rightStepPrimitiveLeftFrame frames noM noM′
-    (allocation-prefixᵀ prefix M⊑M′ M⊢ M′⊢)
+    (term-imprecision-store-prefixᵀ prefix M⊑M′ M⊢ M′⊢)
     (recursive prefix coherent exclusive unique wfL wfR
       (runtime-⊕₁ okLM) (runtime-⊕₁ okL′M′)
       L⊑L′ L⊢ L′⊢ L′→)

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Cases/NuImprecisionWorldCoherentRightOneStepRightFrameValueCasesProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Cases/NuImprecisionWorldCoherentRightOneStepRightFrameValueCasesProof.agda
@@ -10,6 +10,8 @@ module
 --   * Contains no catch-up, crossed runtime case, result wrapper, postulate,
 --     hole, permissive option, or compatibility alias.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Data.List using ([])
 
 open import ImprecisionWf using
@@ -40,7 +42,6 @@ open import NuTerms using
 open import Primitives using (addℕ)
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import TermTyping using (_∣_∣_⊢_⦂_)
@@ -119,7 +120,7 @@ world-coherent-right-one-step-application-right-value-caseᵀ
     vL noL vL′ noL′ okM okM′ L⊑L′ M⊑M′
     L⊢ M⊢ L′⊢ M′⊢ M′→ =
   rightStepApplicationRightFrame frames vL noL vL′ noL′
-    (allocation-prefixᵀ prefix L⊑L′ L⊢ L′⊢)
+    (term-imprecision-store-prefixᵀ prefix L⊑L′ L⊢ L′⊢)
     (recursive prefix coherent exclusive unique wfL wfR
       okM okM′ M⊑M′ M⊢ M′⊢ M′→)
 
@@ -160,6 +161,6 @@ world-coherent-right-one-step-primitive-right-value-caseᵀ
     vL noL vL′ noL′ okM okM′ L⊑L′ M⊑M′
     L⊢ M⊢ L′⊢ M′⊢ M′→ =
   rightStepPrimitiveRightFrame frames vL noL vL′ noL′
-    (allocation-prefixᵀ prefix L⊑L′ L⊢ L′⊢)
+    (term-imprecision-store-prefixᵀ prefix L⊑L′ L⊢ L′⊢)
     (recursive prefix coherent exclusive unique wfL wfR
       okM okM′ M⊑M′ M⊢ M′⊢ M′→)

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationFunctionCastBetaFunctionCastValuesProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationFunctionCastBetaFunctionCastValuesProof.agda
@@ -58,7 +58,6 @@ open import PairedWideningCompatibility using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -223,13 +222,6 @@ world-coherent-right-one-step-application-function-cast-beta-function-cast-value
       {M = (V ⟨ c C.↦ d ⟩) · M}
       {N′ = (V′ · (W′ ⟨ e ⟩)) ⟨ f ⟩}
       {χ = keep} {ρ = ρ} pB
-  at-prefix relation-prefix coherent exclusive unique wfL okM okM′
-      (allocation-prefixᵀ prefix₀ inner source⊢ target⊢)
-      argument-related vV vM vV′ vW′ rank =
-    at-prefix
-      (store-imp-prefix-transⁱ prefix₀ relation-prefix)
-      coherent exclusive unique wfL okM okM′ inner
-      argument-related vV vM vV′ vW′ rank
   at-prefix
       {pA = pA} {pB = pB}
       relation-prefix coherent exclusive unique wfL okM okM′

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationFunctionCastBetaLambdaValuesProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationFunctionCastBetaLambdaValuesProof.agda
@@ -41,7 +41,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
@@ -150,13 +149,6 @@ world-coherent-right-one-step-application-function-cast-beta-lambda-values-proof
       {M = (ƛ N) · M}
       {N′ = (V′ · (W′ ⟨ e ⟩)) ⟨ f ⟩}
       {χ = keep} {ρ = ρ} pB
-  at-prefix relation-prefix coherent exclusive unique wfL okM okM′
-      (allocation-prefixᵀ prefix₀ inner source⊢ target⊢)
-      argument-related vM vV′ vW′ =
-    at-prefix
-      (store-imp-prefix-transⁱ prefix₀ relation-prefix)
-      coherent exclusive unique wfL okM okM′
-      inner argument-related vM vV′ vW′
   at-prefix
       {pA = pA} {pB = pB}
       relation-prefix coherent exclusive unique wfL okM okM′

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationLambdaBetaFunctionCastValuesProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationLambdaBetaFunctionCastValuesProof.agda
@@ -52,7 +52,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; conv↑⊑ᵀ
@@ -163,13 +162,6 @@ world-coherent-right-one-step-application-lambda-beta-function-cast-values-at-pr
     WorldCoherentWeakOneStepIndexedOutcome
       {M = (V ⟨ c C.↦ d ⟩) · W} {N′ = N′ [ V′ ]}
       {χ = keep} {ρ = ρ} pB
-  at-prefix relation-prefix coherent exclusive unique wfL okM okM′
-      (allocation-prefixᵀ prefix₀ inner source⊢ target⊢)
-      argument-related vV vW vV′ rank =
-    at-prefix
-      (store-imp-prefix-transⁱ prefix₀ relation-prefix)
-      coherent exclusive unique wfL okM okM′
-      inner argument-related vV vW vV′ rank
   at-prefix
       {pA = pA} {pB = pB}
       relation-prefix coherent exclusive unique wfL okM okM′

--- a/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationLambdaBetaValuesProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/OneStep/Roots/NuImprecisionWorldCoherentRightOneStepApplicationLambdaBetaValuesProof.agda
@@ -42,8 +42,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ƛ⊑ƛᵀ
+  ( ƛ⊑ƛᵀ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import TermTyping using
@@ -94,11 +93,6 @@ private
     Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ ctx-imp A A′ pA ∷ []
       ⊢ᴺ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB
   related-lambda-bodiesᵀ (ƛ⊑ƛᵀ hA hA′ body) = body
-  related-lambda-bodiesᵀ
-      (allocation-prefixᵀ prefix inner
-        (⊢ƛ hA body⊢) (⊢ƛ hA′ body′⊢)) =
-    allocation-prefixᵀ prefix (related-lambda-bodiesᵀ inner)
-      body⊢ body′⊢
 
 
 world-coherent-right-one-step-application-lambda-beta-values-at-zero-proofᵀ :

--- a/GTSF/proof/WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetNarrowUntagRootCounterexample.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetNarrowUntagRootCounterexample.agda
@@ -53,8 +53,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; StoreImpPrefix
+  ( StoreImpPrefix
   ; prefix-reflⁱ
   ; x⊑xᵀ
   ; ƛ⊑ƛᵀ
@@ -175,10 +174,6 @@ private
       ⊢ᴺ ` zero ⊑ ` zero ⦂ X ⊑ ★ ∶ a₂ →
     ⊥
   variable-at-a₂-impossible (x⊑xᵀ ())
-  variable-at-a₂-impossible
-      (allocation-prefixᵀ prefix-reflⁱ inner
-        source-typing target-typing) =
-    variable-at-a₂-impossible inner
 
 
 requested-untagged-relation-impossible :
@@ -189,10 +184,6 @@ requested-untagged-relation-impossible :
 requested-untagged-relation-impossible
     (ƛ⊑ƛᵀ source-wf target-wf body) =
   variable-at-a₂-impossible body
-requested-untagged-relation-impossible
-    (allocation-prefixᵀ prefix-reflⁱ inner
-      source-typing target-typing) =
-  requested-untagged-relation-impossible inner
 
 
 duplicate-assumptions-not-unique :

--- a/GTSF/proof/WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetWidenInstantiationPairedLambdaPendingAllocationPrefixLemma.agda
+++ b/GTSF/proof/WorldCoherent/Right/Target/WidenNarrow/NuImprecisionWorldCoherentRightTargetWidenInstantiationPairedLambdaPendingAllocationPrefixLemma.agda
@@ -12,6 +12,8 @@ module
 --   * Contains no additional theorem shape, result/view/outcome type,
 --     postulate, hole, permissive option, or broad DGG import.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import
   proof.Right.AllocationRuntime.NuImprecisionRightTargetAllocationSourceBulletTransportProof
   using (right-target-allocation-source-bullet-transport-proofᵀ)
@@ -35,9 +37,9 @@ open import
   (world-coherent-right-target-widen-instantiation-paired-lambda-post-beta-context-proofᵀ)
 
 
-world-coherent-right-target-widen-instantiation-paired-lambda-pending-allocation-prefixᵀ :
+world-coherent-right-target-widen-instantiation-paired-lambda-pending-term-imprecision-store-prefixᵀ :
   WorldCoherentRightTargetWidenInstantiationPairedLambdaPendingAllocationPrefixᵀ
-world-coherent-right-target-widen-instantiation-paired-lambda-pending-allocation-prefixᵀ =
+world-coherent-right-target-widen-instantiation-paired-lambda-pending-term-imprecision-store-prefixᵀ =
   world-coherent-right-target-widen-instantiation-paired-lambda-pending-allocation-prefix-proofᵀ
     world-coherent-right-target-widen-instantiation-paired-lambda-post-beta-context-proofᵀ
     right-target-allocation-source-bullet-transport-proofᵀ

--- a/GTSF/proof/WorldCoherent/Right/Value/Catchup/NuImprecisionWorldCoherentRightValueCatchupDispatcherProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Value/Catchup/NuImprecisionWorldCoherentRightValueCatchupDispatcherProof.agda
@@ -25,8 +25,7 @@ open import proof.NuCore.Relations.NuImprecisionTermContextDef using
   ; lift-right-ctx-[]
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; blame⊑ᵀ
+  ( blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -170,16 +169,11 @@ world-coherent-right-value-catchup-dispatcher-proofᵀ
 world-coherent-right-value-catchup-dispatcher-proofᵀ
     cases prefix coherent exclusive unique wfR okM′ () noV
     (α⊑αᵀ vL noL vL′ noL′ pA liftρ liftγ
-      L⊑L′ L•⊢ L′•⊢)
+      L⊑L′ allocation-prefix L•⊢ L′•⊢)
 world-coherent-right-value-catchup-dispatcher-proofᵀ
     cases prefix coherent exclusive unique wfR okM′ () noV
-    (α⊑ᵀ vL noL hA liftρ liftγ L⊑M′ L•⊢ M′⊢)
-world-coherent-right-value-catchup-dispatcher-proofᵀ
-    cases prefix coherent exclusive unique wfR okM′ vV noV
-    (allocation-prefixᵀ prefix₀ inner M⊢ M′⊢) =
-  world-coherent-right-value-catchup-dispatcher-proofᵀ
-    cases (store-imp-prefix-transⁱ prefix₀ prefix)
-    coherent exclusive unique wfR okM′ vV noV inner
+    (α⊑ᵀ vL noL hA liftρ liftγ L⊑M′
+      allocation-prefix L•⊢ M′⊢)
 world-coherent-right-value-catchup-dispatcher-proofᵀ
     cases prefix coherent exclusive unique wfR okM′ () noV
     (ν⊑νᵀ

--- a/GTSF/proof/WorldCoherent/Right/Value/Terminal/NuImprecisionWorldCoherentRightValueTerminalProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Value/Terminal/NuImprecisionWorldCoherentRightValueTerminalProof.agda
@@ -7,6 +7,8 @@ module proof.WorldCoherent.Right.Value.Terminal.NuImprecisionWorldCoherentRightV
 --   * Uses only focused prefix, typing, result, and lineage infrastructure.
 --   * Contains no postulate, hole, incomplete match, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (refl)
 open import Data.List using ([])
@@ -15,8 +17,7 @@ open import Data.Nat.Properties using (≤-refl)
 open import NuReduction using (keep; ↠-refl)
 open import NuTerms using (⇑ᵗᵐ; _•)
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; prefix-reflⁱ
+  ( prefix-reflⁱ
   )
 open import proof.Store.RelEmbedding.NuImprecisionRelStoreEmbeddingAlgebra using
   (rel-store-embedding-reflⁱ)
@@ -68,7 +69,7 @@ world-coherent-right-value-terminal-proofᵀ
       noV′ (nu-term-imprecision-target-typing V⊑V′)
 
   related⁺ =
-    allocation-prefixᵀ prefix V⊑V′ source-typing⁺ target-typing⁺
+    term-imprecision-store-prefixᵀ prefix V⊑V′ source-typing⁺ target-typing⁺
 
   result =
     weak-step-result
@@ -108,7 +109,8 @@ world-coherent-right-value-terminal-proofᵀ
     RightValueCatchupSourceBulletTransportᵀ result
   source-bullet-transport {L = L} {M′ = M′} {C = C} {C′ = C′}
       {q = q} prefix′ okL noL′ L⊢ L⊑L′ =
-    allocation-prefixᵀ {ρ = ρ⁺} {M = (⇑ᵗᵐ L) •} {M′ = M′}
+    term-imprecision-store-prefixᵀ
+      {M = (⇑ᵗᵐ L) •} {M′ = M′}
       {A = C} {B = C′} {p = q}
       prefix′ L⊑L′ L⊢ target-typing′
     where

--- a/GTSF/proof/WorldCoherent/Right/Value/Transport/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletPrefixTransportProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Value/Transport/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletPrefixTransportProof.agda
@@ -10,6 +10,8 @@ module
 --   * Contains no term-imprecision case analysis, postulate, hole, or
 --     termination bypass.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Data.List using (_∷_; [])
 open import Data.Nat using (suc)
 open import Data.Nat.Properties using (≤-refl)
@@ -37,7 +39,6 @@ open import proof.Store.Core.NuImprecisionRelationalStoreDef using
 open import NuTerms using (No•; Term)
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import
@@ -171,7 +172,7 @@ no-bullet-prefix-transportᵀ prefix noM noM′ M⊑M′ caught =
       noM′ (nu-term-imprecision-target-typing M⊑M′)
 
   relation⁺ =
-    allocation-prefixᵀ prefix M⊑M′ source-typing⁺ target-typing⁺
+    term-imprecision-store-prefixᵀ prefix M⊑M′ source-typing⁺ target-typing⁺
 
 
 right-catchup-source-fixed-narrowingᵀ :

--- a/GTSF/proof/WorldCoherent/Right/Value/Transport/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletTransportProof.agda
+++ b/GTSF/proof/WorldCoherent/Right/Value/Transport/NuImprecisionWorldCoherentRightValueCatchupRuntimeNoBulletTransportProof.agda
@@ -125,7 +125,6 @@ open import PairedWideningCompatibility using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
@@ -531,16 +530,6 @@ module _
                 (worldRightCatchupResult caught)))
             q
     active-runtime-no-bullet-transportᵀ
-        prefix (allocation-prefixᵀ prefix₀ inner inner-M⊢ inner-M′⊢)
-        okM activeM noM′ store-eq caught =
-      active-runtime-no-bullet-transportᵀ
-        (store-imp-prefix-transⁱ prefix₀ prefix)
-        inner okM activeM noM′ (trans inner-store-eq store-eq) caught
-      where
-      inner-store-eq =
-        active-prefix-left-store-stable prefix₀ okM activeM
-          (nu-term-imprecision-source-typing inner) inner-M⊢
-    active-runtime-no-bullet-transportᵀ
         prefix (blame⊑ᵀ M′⊢) (ok-no noM) activeM
         noM′ store-eq caught =
       ⊥-elim (activeM noM)
@@ -576,7 +565,7 @@ module _
       ⊥-elim
         (activeGen (no•-⟨⟩ (runtime-value-no• okV vV)))
     active-runtime-no-bullet-transportᵀ
-        prefix M⊑M′@(α⊑αᵀ _ _ _ _ _ _ _ _ _ _)
+        prefix M⊑M′@(α⊑αᵀ _ _ _ _ _ _ _ _ _ _ _)
         okM activeM noM′ store-eq caught =
       worldRightCatchupSourceBulletTransport caught
         prefix okM noM′ source-typing⁺ M⊑M′
@@ -587,7 +576,7 @@ module _
           store-eq
           (nu-term-imprecision-source-typing M⊑M′)
     active-runtime-no-bullet-transportᵀ
-        prefix M⊑M′@(α⊑ᵀ _ _ _ _ _ _ _ _)
+        prefix M⊑M′@(α⊑ᵀ _ _ _ _ _ _ _ _ _)
         okM activeM noM′ store-eq caught =
       worldRightCatchupSourceBulletTransport caught
         prefix okM noM′ source-typing⁺ M⊑M′

--- a/GTSF/proof/WorldCoherent/Source/Allocation/NuImprecisionWorldCoherentSourceAllocationStepProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/Allocation/NuImprecisionWorldCoherentSourceAllocationStepProof.agda
@@ -10,6 +10,8 @@ module proof.WorldCoherent.Source.Allocation.NuImprecisionWorldCoherentSourceAll
 --   * Contains no postulate, hole, permissive option, dispatcher, or new
 --     result carrier.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import CastImprecisionShape using (_⊢ᶜ_⦂_; widening)
@@ -88,7 +90,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
-  ; allocation-prefixᵀ
   ; conv↑⊑ᵀ
   ; prefix-reflⁱ
   ; prefix-∷ⁱ
@@ -777,18 +778,6 @@ world-coherent-source-allocation-step-proofᵀ
     prefix coherent exclusive unique
       wfL wfR
     ok-source ok-target source⊢ target⊢
-    (allocation-prefixᵀ prefix₀ inner inner-source⊢ inner-target⊢)
-    vV noV =
-  world-coherent-source-allocation-step-proofᵀ
-    matched-step source-inst source-reveal right-catchup target-bullet
-    (store-imp-prefix-transⁱ prefix₀ prefix)
-    coherent exclusive unique wfL wfR ok-source ok-target source⊢ target⊢
-    inner vV noV
-world-coherent-source-allocation-step-proofᵀ
-    matched-step source-inst source-reveal right-catchup target-bullet
-    prefix coherent exclusive unique
-      wfL wfR
-    ok-source ok-target source⊢ target⊢
     (ν⊑ᵀ {occ = occ} {{safe = safe}}
       hA h⇑A s↑ liftρ lift-left-ctx-[] inner replace)
     vV noV
@@ -810,7 +799,7 @@ world-coherent-source-allocation-step-proofᵀ
             (leftStoreⁱ-prefix-inclusion prefix)))
         s↑)
       _ replace liftρ⁺
-      (allocation-prefixᵀ prefix inner
+      (term-imprecision-store-prefixᵀ prefix inner
         (ν-body-typing-at
           (proj₁ (coercion-src-tgtᵐ
             (conversion↑⇒coercion

--- a/GTSF/proof/WorldCoherent/Source/CastCatchup/NuImprecisionWorldCoherentSourceBulletCatchupProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/CastCatchup/NuImprecisionWorldCoherentSourceBulletCatchupProof.agda
@@ -6,7 +6,7 @@ module proof.WorldCoherent.Source.CastCatchup.NuImprecisionWorldCoherentSourceBu
 --     value catch-up through its whole statement-level contract.
 --   * Contains no recursive dispatcher implementation or permissive holes.
 
-open import QuotientedTermImprecision using (α⊑ᵀ)
+open import QuotientedTermImprecision using (α⊑ᵀ; prefix-reflⁱ)
 open import proof.WorldCoherent.Source.CastCatchup.NuImprecisionWorldCoherentSourceBulletCatchupDef using
   (WorldCoherentSourceBulletCatchupᵀ)
 open import proof.WorldCoherent.Value.NuImprecisionWorldCoherentValueCatchupPrefixDef using
@@ -20,4 +20,5 @@ world-coherent-source-bullet-catchup-proofᵀ
     catchup h⇑A prefix coherent exclusive unique wfL okN
     vV′ noV′ vL noL liftρ liftγ L⊑V′ L•⊢ V′⊢ =
   catchup prefix coherent exclusive unique wfL okN vV′ noV′
-    (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑V′ L•⊢ V′⊢)
+    (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑V′
+      prefix-reflⁱ L•⊢ V′⊢)

--- a/GTSF/proof/WorldCoherent/Source/CastCatchup/NuImprecisionWorldCoherentSourceBulletRuntimeSiblingCatchupProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/CastCatchup/NuImprecisionWorldCoherentSourceBulletRuntimeSiblingCatchupProof.agda
@@ -57,6 +57,7 @@ open import NuTerms using
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
   ; α⊑ᵀ
+  ; prefix-reflⁱ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import TermTyping using (_∣_∣_⊢_⦂_)
@@ -170,5 +171,6 @@ world-coherent-source-bullet-runtime-sibling-catchup-proofᵀ
     noR okR′ sibling =
   value-sibling prefix coherent exclusive unique wfL okL•
     vV′ noV′
-    (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑V′ L•⊢ V′⊢)
+    (α⊑ᵀ vL noL h⇑A liftρ liftγ L⊑V′
+      prefix-reflⁱ L•⊢ V′⊢)
     noR okR′ sibling

--- a/GTSF/proof/WorldCoherent/Source/CastCatchup/NuImprecisionWorldCoherentSourceWidenRuntimeSiblingCatchupProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/CastCatchup/NuImprecisionWorldCoherentSourceWidenRuntimeSiblingCatchupProof.agda
@@ -11,6 +11,8 @@ module
 --     and independent runtime-sibling transport.
 --   * Contains no postulate, hole, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import CastImprecisionShape using
@@ -88,7 +90,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; cast⊑⊑ᵀ
   ; prefix-reflⁱ
@@ -1300,7 +1301,7 @@ world-coherent-source-inst-widen-runtime-sibling-catchupᵀ
   allocation-store-prefix = prefix-∷ⁱ prefix-reflⁱ
 
   allocation-sibling =
-    allocation-prefixᵀ
+    term-imprecision-store-prefixᵀ
       allocation-store-prefix allocation-sibling-tail
       (term-weaken ≤-refl
         (leftStoreⁱ-prefix-inclusion allocation-store-prefix)

--- a/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/Direct/NuImprecisionWorldCoherentSourceFunctionCastBetaDirectProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/Direct/NuImprecisionWorldCoherentSourceFunctionCastBetaDirectProof.agda
@@ -12,6 +12,8 @@ module
 --   * Contains no coercion algebra, target-value implementation, postulate,
 --     hole, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 import Coercions as C
 open import Agda.Builtin.Equality using (refl)
@@ -41,7 +43,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
@@ -306,7 +307,7 @@ catch-source-function-cast-function-then-finishᵀ
       noR
       (nu-term-imprecision-target-typing argument-related)
   argument-related⁺ =
-    allocation-prefixᵀ prefix argument-related
+    term-imprecision-store-prefixᵀ prefix argument-related
       source-argument⊢⁺ target-argument⊢⁺
   target-argument-no = noR
 

--- a/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/Scheduling/NuImprecisionWorldCoherentSourceFunctionCastBetaSchedulingDispatcherProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/Scheduling/NuImprecisionWorldCoherentSourceFunctionCastBetaSchedulingDispatcherProof.agda
@@ -34,8 +34,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ·⊑·ᵀ
+  ( ·⊑·ᵀ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
   ; ⊑conv↑ᵀ
@@ -133,12 +132,6 @@ private
 world-coherent-source-function-cast-beta-scheduling-dispatcher-proofᵀ :
   WorldCoherentSourceFunctionCastBetaSchedulingCases →
   WorldCoherentSourceFunctionCastBetaRootᵀ
-world-coherent-source-function-cast-beta-scheduling-dispatcher-proofᵀ
-    cases prefix coherent exclusive unique wfL wfR okM okM′
-    M⊢ M′⊢ (allocation-prefixᵀ prefix₀ inner M⊢₀ M′⊢₀) vV vW =
-  world-coherent-source-function-cast-beta-scheduling-dispatcher-proofᵀ
-    cases (store-imp-prefix-transⁱ prefix₀ prefix)
-    coherent exclusive unique wfL wfR okM okM′ M⊢ M′⊢ inner vV vW
 world-coherent-source-function-cast-beta-scheduling-dispatcher-proofᵀ
     cases prefix coherent exclusive unique wfL wfR okM okM′
     M⊢ M′⊢ (·⊑·ᵀ L⊑L′ W⊑R′) vV vW =

--- a/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/TargetLeaves/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetFunctionCastValuesProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/TargetLeaves/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetFunctionCastValuesProof.agda
@@ -46,7 +46,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
@@ -167,16 +166,6 @@ target-function-cast-values-suc-at-prefixᵀ :
     {M′ = (L′ ⟨ e C.↦ f ⟩) · R′}
     {L = (V · (W ⟨ c ⟩)) ⟨ d ⟩}
     {χ = keep} {ρ = ρ} pB
-target-function-cast-values-suc-at-prefixᵀ
-    lower paired target-frames prepend
-    relation-prefix coherent exclusive unique wfL wfR okM okM′
-    (allocation-prefixᵀ prefix₀ inner source⊢ target⊢)
-    argument-related vV vW vL′ vR′ outer-rank =
-  target-function-cast-values-suc-at-prefixᵀ
-    lower paired target-frames prepend
-    (store-imp-prefix-transⁱ prefix₀ relation-prefix)
-    coherent exclusive unique wfL wfR okM okM′ inner
-    argument-related vV vW vL′ vR′ outer-rank
 target-function-cast-values-suc-at-prefixᵀ
     lower paired target-frames prepend
     {pA = pA} {pB = pB}

--- a/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/TargetLeaves/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetLambdaValuesProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/TargetLeaves/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetLambdaValuesProof.agda
@@ -39,7 +39,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; conv↑⊑ᵀ
@@ -108,14 +107,6 @@ target-lambda-values-at-prefixᵀ :
     {M′ = (ƛ N′) · R′}
     {L = (V · (W ⟨ c ⟩)) ⟨ d ⟩}
     {A = B} {B = B′} {χ = keep} {ρ = ρ} pB
-target-lambda-values-at-prefixᵀ
-    relation-prefix coherent exclusive unique okM okM′
-    (allocation-prefixᵀ prefix₀ inner source⊢ target⊢)
-    argument-related vV vW vR′ =
-  target-lambda-values-at-prefixᵀ
-    (store-imp-prefix-transⁱ prefix₀ relation-prefix)
-    coherent exclusive unique okM okM′ inner
-    argument-related vV vW vR′
 target-lambda-values-at-prefixᵀ
     {pA = pA} {pB = pB}
     relation-prefix coherent exclusive unique okM okM′

--- a/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/TargetValue/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetValueProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/FunctionCastBeta/TargetValue/NuImprecisionWorldCoherentSourceFunctionCastBetaTargetValueProof.agda
@@ -9,6 +9,8 @@ module
 --   * Contains no coercion algebra, recursive measure, postulate, hole, or
 --     permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
@@ -36,8 +38,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
+  ( _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import proof.NuCore.Relations.NuImprecisionAssumptionMembershipUniquenessLemma using
   (assumption-membership-unique→precision-index-unique)
@@ -226,7 +227,7 @@ world-coherent-source-function-cast-beta-target-value-at-proofᵀ
       (nu-term-imprecision-target-typing function-related)
 
   function-related⁺ =
-    allocation-prefixᵀ prefix function-related
+    term-imprecision-store-prefixᵀ prefix function-related
       source-function⊢⁺ target-function⊢⁺
 
   framed-indexed =

--- a/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaDirectProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaDirectProof.agda
@@ -8,6 +8,8 @@ module
 --     argument, then dispatches to lambda or function-cast terminals.
 --   * Contains no terminal implementation, postulate, hole, or option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (refl)
 open import Data.List using ([])
@@ -36,7 +38,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
@@ -311,7 +312,7 @@ catch-source-lambda-function-then-finishᵀ
     term-weaken ≤-refl (rightStoreⁱ-prefix-inclusion prefix) noR
       (nu-term-imprecision-target-typing argument-related)
   argument-related⁺ =
-    allocation-prefixᵀ prefix argument-related
+    term-imprecision-store-prefixᵀ prefix argument-related
       source-argument⊢⁺ target-argument⊢⁺
   target-argument-no = noR
 

--- a/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaSchedulingDispatcherProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaSchedulingDispatcherProof.agda
@@ -31,8 +31,7 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ·⊑·ᵀ
+  ( ·⊑·ᵀ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
   ; ⊑conv↑ᵀ
@@ -127,12 +126,6 @@ private
 world-coherent-source-lambda-beta-scheduling-dispatcher-proofᵀ :
   WorldCoherentSourceLambdaBetaSchedulingCases →
   WorldCoherentSourceLambdaBetaRootᵀ
-world-coherent-source-lambda-beta-scheduling-dispatcher-proofᵀ
-    cases prefix coherent exclusive unique wfL wfR okM okM′
-    M⊢ M′⊢ (allocation-prefixᵀ prefix₀ inner M⊢₀ M′⊢₀) vV =
-  world-coherent-source-lambda-beta-scheduling-dispatcher-proofᵀ
-    cases (store-imp-prefix-transⁱ prefix₀ prefix)
-    coherent exclusive unique wfL wfR okM okM′ M⊢ M′⊢ inner vV
 world-coherent-source-lambda-beta-scheduling-dispatcher-proofᵀ
     cases prefix coherent exclusive unique wfL wfR okM okM′
     M⊢ M′⊢ (·⊑·ᵀ L⊑L′ V⊑R′) vV =

--- a/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaTargetFunctionCastDirectProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaTargetFunctionCastDirectProof.agda
@@ -9,6 +9,8 @@ module
 --   * Contains no function-cast spine recursion, postulate, hole, or
 --     permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 import Coercions as C
@@ -42,8 +44,7 @@ open import NuTerms using
   ; _[_]
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; prefix-reflⁱ
+  ( prefix-reflⁱ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import Types using (_⇒_)
@@ -258,7 +259,7 @@ world-coherent-source-lambda-beta-target-function-cast-direct-at-proofᵀ
       (nu-term-imprecision-target-typing function-related)
 
   function-related⁺ =
-    allocation-prefixᵀ prefix function-related
+    term-imprecision-store-prefixᵀ prefix function-related
       source-function⊢⁺ target-function⊢⁺
 
   framed-indexed =

--- a/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaTargetFunctionCastValueProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaTargetFunctionCastValueProof.agda
@@ -9,6 +9,8 @@ module
 --     their well-founded assembly is deliberately separate.
 --   * Contains no catch-all, postulate, hole, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 import Coercions as C
 import Conversion as CV
@@ -45,7 +47,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
@@ -196,16 +197,6 @@ target-function-cast-value-suc-at-prefixᵀ :
     {L = N [ V ]} {χ = keep} {ρ = ρ⁺} pB
 target-function-cast-value-suc-at-prefixᵀ
     target-lambda target-function-cast target-frames prepend
-    relation-prefix prefix coherent exclusive unique wfR okM okM′
-    (allocation-prefixᵀ prefix₀ inner source⊢ target⊢)
-    argument-related vV vW vV′ outer-rank =
-  target-function-cast-value-suc-at-prefixᵀ
-    target-lambda target-function-cast target-frames prepend
-    (store-imp-prefix-transⁱ prefix₀ relation-prefix)
-    prefix coherent exclusive unique wfR okM okM′ inner
-    argument-related vV vW vV′ outer-rank
-target-function-cast-value-suc-at-prefixᵀ
-    target-lambda target-function-cast target-frames prepend
     {pA = pA} {pB = pB}
     relation-prefix prefix coherent exclusive unique wfR okM okM′
     (⊑cast⊒ᵀ {p = pA₀ ↦ pB₀} mode seal★
@@ -240,7 +231,7 @@ target-function-cast-value-suc-at-prefixᵀ
     term-weaken ≤-refl right-incl target-W-no
       (nu-term-imprecision-target-typing inner)
   inner⁺ =
-    allocation-prefixᵀ relation-prefix inner
+    term-imprecision-store-prefixᵀ relation-prefix inner
       source-inner⊢⁺ target-inner⊢⁺
   inner-result =
     finish-inner-target-function-value-atᵀ
@@ -284,7 +275,7 @@ target-function-cast-value-suc-at-prefixᵀ
     term-weaken ≤-refl right-incl target-W-no
       (nu-term-imprecision-target-typing inner)
   inner⁺ =
-    allocation-prefixᵀ relation-prefix inner
+    term-imprecision-store-prefixᵀ relation-prefix inner
       source-inner⊢⁺ target-inner⊢⁺
   inner-result =
     finish-inner-target-function-value-atᵀ
@@ -324,7 +315,7 @@ target-function-cast-value-suc-at-prefixᵀ
     term-weaken ≤-refl right-incl target-W-no
       (nu-term-imprecision-target-typing inner)
   inner⁺ =
-    allocation-prefixᵀ relation-prefix inner
+    term-imprecision-store-prefixᵀ relation-prefix inner
       source-inner⊢⁺ target-inner⊢⁺
   inner-result =
     finish-inner-target-function-value-atᵀ
@@ -364,7 +355,7 @@ target-function-cast-value-suc-at-prefixᵀ
     term-weaken ≤-refl right-incl target-W-no
       (nu-term-imprecision-target-typing inner)
   inner⁺ =
-    allocation-prefixᵀ relation-prefix inner
+    term-imprecision-store-prefixᵀ relation-prefix inner
       source-inner⊢⁺ target-inner⊢⁺
   inner-result =
     finish-inner-target-function-value-atᵀ

--- a/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaTargetLambdaDirectProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/LambdaBeta/NuImprecisionWorldCoherentSourceLambdaBetaTargetLambdaDirectProof.agda
@@ -8,6 +8,8 @@ module
 --   * Uses precision-index uniqueness only to reindex the composed result.
 --   * Contains no function-cast case, postulate, hole, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
@@ -37,8 +39,7 @@ open import NuTerms using
   ; _[_]
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ƛ⊑ƛᵀ
+  ( ƛ⊑ƛᵀ
   ; _∣_∣_∣_∣_⊢ᴺ_⊑_⦂_⊑_∶_
   )
 open import TermTyping using (⊢ƛ; ⊢·)
@@ -170,11 +171,6 @@ related-lambda-bodiesᵀ :
   Φ ∣ Δᴸ ∣ Δᴿ ∣ ρ ∣ ctx-imp A A′ pA ∷ []
     ⊢ᴺ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB
 related-lambda-bodiesᵀ (ƛ⊑ƛᵀ hA hA′ body) = body
-related-lambda-bodiesᵀ
-    (allocation-prefixᵀ prefix inner
-      (⊢ƛ hA body⊢) (⊢ƛ hA′ body′⊢)) =
-  allocation-prefixᵀ prefix (related-lambda-bodiesᵀ inner)
-    body⊢ body′⊢
 
 
 world-coherent-source-lambda-beta-target-lambda-direct-proofᵀ :
@@ -245,7 +241,7 @@ world-coherent-source-lambda-beta-target-lambda-direct-proofᵀ
       (nu-term-imprecision-target-typing function-related)
 
   function-related⁺ =
-    allocation-prefixᵀ prefix function-related
+    term-imprecision-store-prefixᵀ prefix function-related
       source-function⊢⁺ target-function⊢⁺
 
   framed-indexed =

--- a/GTSF/proof/WorldCoherent/Source/Misc/NuImprecisionWorldCoherentSourceNuFrameStepProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/Misc/NuImprecisionWorldCoherentSourceNuFrameStepProof.agda
@@ -31,8 +31,7 @@ open import NuTerms using
   ; ok-ν
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ν⊑νᵀ
+  ( ν⊑νᵀ
   ; ν⊑ᵀ
   ; ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
@@ -142,15 +141,6 @@ world-coherent-source-ν-frame-step-proofᵀ :
   WorldCoherentSourceOneStepTargetCastFrames →
   WorldCoherentSourceOneStepTargetBulletFrameStepᵀ →
   WorldCoherentSourceNuFrameStepᵀ
-world-coherent-source-ν-frame-step-proofᵀ
-    prefix source-ν-frames target-cast-frames
-    target-bullet-step prefixρ coherent exclusive unique wfL wfR
-    ok-source ok-target source⊢ target⊢
-    (allocation-prefixᵀ prefix₀ inner inner-source⊢ inner-target⊢)
-    N→N′ =
-  prefix (store-imp-prefix-transⁱ prefix₀ prefixρ)
-    coherent exclusive unique wfL wfR ok-source ok-target source⊢ target⊢
-    inner (ξ-ν N→N′)
 world-coherent-source-ν-frame-step-proofᵀ
     prefix source-ν-frames target-cast-frames
     target-bullet-step prefixρ coherent exclusive unique wfL wfR

--- a/GTSF/proof/WorldCoherent/Source/NuCatchup/NuImprecisionWorldCoherentSourceNuRuntimeSiblingCatchupProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/NuCatchup/NuImprecisionWorldCoherentSourceNuRuntimeSiblingCatchupProof.agda
@@ -12,6 +12,8 @@ module
 --   * Contains no opaque allocation recovery, postulate, hole, permissive
 --     option, or record-interface change.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Coercions using (Coercion; ModeEnv)
@@ -82,7 +84,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; conv↑⊑ᵀ
   ; prefix-reflⁱ
@@ -604,7 +605,7 @@ world-coherent-source-ν-runtime-sibling-catchup-proofᵀ
   allocation-store-prefix = prefix-∷ⁱ prefix-reflⁱ
 
   allocation-sibling =
-    allocation-prefixᵀ allocation-store-prefix allocation-sibling-tail
+    term-imprecision-store-prefixᵀ allocation-store-prefix allocation-sibling-tail
       (term-weaken ≤-refl
         (leftStoreⁱ-prefix-inclusion allocation-store-prefix)
         (renameᵗᵐ-preserves-No• suc inner-noR)

--- a/GTSF/proof/WorldCoherent/Source/Primitive/NuImprecisionWorldCoherentSourcePrimitiveDeltaCatchupDispatcherProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/Primitive/NuImprecisionWorldCoherentSourcePrimitiveDeltaCatchupDispatcherProof.agda
@@ -10,8 +10,7 @@ module
 --   * Contains no direct scheduling, catch-all, postulate, hole, or option.
 
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; ⊑cast⊒ᵀ
+  ( ⊑cast⊒ᵀ
   ; ⊑cast⊑ᵀ
   ; ⊑conv↑ᵀ
   ; ⊑conv↓ᵀ
@@ -43,12 +42,6 @@ open import proof.Core.Properties.NuRuntimeProperties using (runtime-⟨⟩)
 world-coherent-source-primitive-delta-catchup-dispatcher-proofᵀ :
   WorldCoherentSourcePrimitiveDeltaCatchupCases →
   WorldCoherentSourcePrimitiveDeltaCatchupᵀ
-world-coherent-source-primitive-delta-catchup-dispatcher-proofᵀ
-    cases prefix coherent exclusive unique wfR okM′
-    (allocation-prefixᵀ prefix₀ inner M⊢ M′⊢) =
-  world-coherent-source-primitive-delta-catchup-dispatcher-proofᵀ
-    cases (store-imp-prefix-transⁱ prefix₀ prefix)
-    coherent exclusive unique wfR okM′ inner
 world-coherent-source-primitive-delta-catchup-dispatcher-proofᵀ
     cases prefix coherent exclusive unique wfR okM′
     (⊕⊑⊕ᵀ L⊑L′ R⊑R′) =

--- a/GTSF/proof/WorldCoherent/Source/Primitive/NuImprecisionWorldCoherentSourcePrimitiveDeltaDirectProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/Primitive/NuImprecisionWorldCoherentSourcePrimitiveDeltaDirectProof.agda
@@ -8,6 +8,8 @@ module
 --     source-silent traces with the synchronized natural-addition delta.
 --   * Contains no dispatcher recursion, postulate, hole, or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import proof.NuCore.Relations.NuImprecisionQuotientedTyping
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.List using ([]; _∷_)
@@ -51,7 +53,6 @@ open import NuTerms using
 open import Primitives using (addℕ; κℕ)
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; prefix-reflⁱ
   ; κ⊑κᵀ
   ; ⊕⊑⊕ᵀ
@@ -199,9 +200,6 @@ private
         ⦂ ‵ `ℕ ⊑ ‵ `ℕ ∶ idι →
     m ≡ n
   related-nat-constant-target-constantᵀ κ⊑κᵀ = refl
-  related-nat-constant-target-constantᵀ
-      (allocation-prefixᵀ prefix relation source⊒ target⊒) =
-    related-nat-constant-target-constantᵀ relation
 
 
 related-nat-source-constant-target-valueᵀ :
@@ -745,7 +743,7 @@ finish-left-then-right-deltaᵀ
       no-right (nu-term-imprecision-target-typing right-relation)
 
   right-relation⁺ =
-    allocation-prefixᵀ prefix right-relation
+    term-imprecision-store-prefixᵀ prefix right-relation
       source-right-typing⁺ target-right-typing⁺
 
   framed-left =

--- a/GTSF/proof/WorldCoherent/Source/RevealConceal/NuImprecisionWorldCoherentSourceConcealCatchup.agda
+++ b/GTSF/proof/WorldCoherent/Source/RevealConceal/NuImprecisionWorldCoherentSourceConcealCatchup.agda
@@ -72,7 +72,6 @@ open import NuTerms using
   )
 open import QuotientedTermImprecision using
   ( StoreImpPrefix
-  ; allocation-prefixᵀ
   ; blame⊑ᵀ
   ; cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ

--- a/GTSF/proof/WorldCoherent/Source/RuntimeSteps/NuImprecisionWorldCoherentSourceCastFrameStepProof.agda
+++ b/GTSF/proof/WorldCoherent/Source/RuntimeSteps/NuImprecisionWorldCoherentSourceCastFrameStepProof.agda
@@ -38,8 +38,7 @@ open import NuTerms using
   ; ok-ν
   )
 open import QuotientedTermImprecision using
-  ( allocation-prefixᵀ
-  ; cast⊒⊑ᵀ
+  ( cast⊒⊑ᵀ
   ; cast⊑⊑ᵀ
   ; closeᵀ
   ; conv↑⊑ᵀ
@@ -167,16 +166,6 @@ world-coherent-source-cast-frame-step-proofᵀ :
   WorldCoherentSourceOneStepPairedCastFrameᵀ →
   WorldCoherentSourceOneStepQuotientDownUpStepᵀ →
   WorldCoherentSourceCastFrameStepᵀ
-world-coherent-source-cast-frame-step-proofᵀ
-    prefix source-frames target-frames paired-frame quotient-step
-    prefixρ coherent
-    exclusive unique wfL wfR
-    ok-source ok-target source⊢ target⊢
-    (allocation-prefixᵀ prefix₀ inner inner-source⊢ inner-target⊢)
-    M→M₁ =
-  prefix (store-imp-prefix-transⁱ prefix₀ prefixρ)
-    coherent exclusive unique wfL wfR ok-source ok-target source⊢ target⊢
-    inner (ξ-⟨⟩ M→M₁)
 world-coherent-source-cast-frame-step-proofᵀ
     prefix source-frames target-frames paired-frame quotient-step
     prefixρ coherent

--- a/GTSF/proof/WorldCoherent/Value/NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda
+++ b/GTSF/proof/WorldCoherent/Value/NuImprecisionWorldCoherentValueCatchupRuntimeSiblingPrefixProof.agda
@@ -11,11 +11,19 @@ module
 --     terminalization to their sibling-aware contracts.
 --   * Contains no opaque-final-result sibling transport or permissive option.
 
+open import proof.Store.Prefix.NuImprecisionTermStorePrefixLemma using
+  (term-imprecision-store-prefixᵀ)
 open import Agda.Builtin.Equality using (refl)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (zero)
 open import Data.Product using (_,_; proj₁; proj₂; Σ-syntax)
+open import Relation.Binary.PropositionalEquality using (subst; sym)
 
+open import ImprecisionWf using (⊑-src-wf)
 import NarrowWiden as NW
 open import NarrowWiden using (genSafe→inert)
+open import proof.Store.Core.NuImprecisionRelationalStoreDef using
+  (leftStoreⁱ-lift-left; rightStoreⁱ-lift-left)
 open import proof.NuCore.Relations.NuImprecisionTermContextDef using
   ( lift-left-ctx-[]
   )
@@ -27,6 +35,11 @@ open import NuTerms using
   ; _⟨_⟩
   )
 open import QuotientedTermImprecision
+open import TermTyping using (_∣_∣_⊢_⦂_; ⊢•)
+open import proof.NuCore.Relations.NuImprecisionQuotientedTyping using
+  ( nu-term-imprecision-source-typing
+  ; nu-term-imprecision-target-typing
+  )
 open import
   proof.Catchup.Simulation.NuImprecisionSimulationResultDef
   using
@@ -133,16 +146,6 @@ world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
   inner = proj₁ inner-with-sibling
 
   inner-sibling = proj₂ inner-with-sibling
-world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
-    source-runtime quotient-catchup
-    prefix coherent exclusive unique wfL okL vL′ noL′
-    (allocation-prefixᵀ prefix₀ inner L⊢ L′⊢)
-    noR okR′ sibling =
-  world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
-    source-runtime quotient-catchup
-    (store-imp-prefix-transⁱ prefix₀ prefix)
-    coherent exclusive unique wfL okL vL′ noL′ inner
-    noR okR′ sibling
 world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
     source-runtime quotient-catchup
     prefix coherent exclusive unique wfL okL
@@ -325,18 +328,33 @@ world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
     source-runtime quotient-catchup
     prefix coherent exclusive unique wfL okL () noL′
     (α⊑αᵀ vL noL vL′ noInnerL′ pA liftρ liftγ
-      L⊑L′ L•⊢ L′•⊢)
+      L⊑L′ allocation-prefix L•⊢ L′•⊢)
     noR okR′ sibling
 world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
     source-runtime quotient-catchup
-    prefix coherent exclusive unique wfL okL vL′ noL′
+    {p = p} prefix coherent exclusive unique wfL okL vL′ noL′
     (α⊑ᵀ vL noL h⇑A liftρ lift-left-ctx-[]
-      L⊑L′ L•⊢ L′•⊢)
+      L⊑L′ allocation-prefix L•⊢ L′•⊢)
     noR okR′ sibling =
   source-bullet-sibling source-runtime
-    h⇑A prefix coherent exclusive unique wfL okL
+    h⇑A (store-imp-prefix-transⁱ allocation-prefix prefix)
+    coherent exclusive unique wfL okL
     vL′ noL′ vL noL liftρ lift-left-ctx-[]
-    L⊑L′ L•⊢ L′•⊢ noR okR′ sibling
+    L⊑L′ canonical-source-typing canonical-target-typing
+    noR okR′ sibling
+  where
+  canonical-source-typing =
+    subst
+      (λ Σ → _ ∣ ((zero , _) ∷ Σ) ∣ [] ⊢ _ ⦂ _)
+      (sym (leftStoreⁱ-lift-left liftρ))
+      (⊢• refl refl (⊑-src-wf p) vL noL
+        (nu-term-imprecision-source-typing L⊑L′))
+
+  canonical-target-typing =
+    subst
+      (λ Σ → _ ∣ Σ ∣ [] ⊢ _ ⦂ _)
+      (sym (rightStoreⁱ-lift-left liftρ))
+      (nu-term-imprecision-target-typing L⊑L′)
 world-coherent-left-value-catchup-runtime-sibling-ambientᵀ
     source-runtime quotient-catchup
     prefix coherent exclusive unique wfL okL () noL′
@@ -552,4 +570,4 @@ world-coherent-left-value-catchup-runtime-sibling-prefix-proofᵀ
     source-runtime quotient-catchup
     prefix coherent exclusive unique wfL
     okL vL′ noL′ primary noR okR′
-    (allocation-prefixᵀ prefix sibling R⊢ R′⊢)
+    (term-imprecision-store-prefixᵀ prefix sibling R⊢ R′⊢)


### PR DESCRIPTION
## Summary

- removes `allocation-prefixᵀ` from the live quotiented term-imprecision
  relation and `allocation-prefixᴿ` from the independent quotient prototype
- generalizes the runtime-allocation constructors to retain their
  `StoreImpPrefix` lineage directly
- derives store-prefix monotonicity as a mutually recursive admissible theorem
  for ordinary and quotiented term imprecision
- migrates allocation, simulation, substitution, typing, value, embedding, and
  DGG consumers to the admissible theorem and deletes obsolete inversion cases
- records the design change in the quotient notes and DGG progress ledger
- adds a repository rule requiring explicit permission, a rationale, and an
  imprecision/reduction square before changing the live relation

## Validation

- `agda -v0 QuotientedTermImprecision.agda`
- `agda -v0 proof/Store/Prefix/NuImprecisionTermStorePrefixLemma.agda`
- `agda -v0 DynamicGradualGuarantee.agda`
- `make audit`
- no remaining `allocation-prefixᵀ` or `allocation-prefixᴿ` references

The direct terminal-forward strict spine remains blocked at the paused #100
migration boundary: it imports the not-yet-migrated
`quotient-down-applicationᵖᵀ`. The public DGG root and strict import audit pass.

Fixes #102
