### PR TITLE
Make GTPLC narrowing and widening deterministic

### DIFF
--- a/GTPLC/FactoredTypeNarrowing.agda
+++ b/GTPLC/FactoredTypeNarrowing.agda
@@ -214,7 +214,7 @@ narrowing-tgt-star : ∀ {μ Δ Σ c A}
 narrowing-tgt-star (NarrowWiden.idᵃ ★ hA) = refl
 narrowing-tgt-star (NarrowWiden.untag G hG allowed ())
 narrowing-tgt-star
-    (NarrowWiden.untag-seq G hG allowed G꞉A p A≢★) = refl
+    (NarrowWiden.untag-seq G hG allowed G꞉A p nonvar★ A≢★) = refl
 
 relocation-tgt-star : ∀ {Δᴸ Δᴿ A} {Φ : ImpCtx Δᴸ Δᴿ}
   → Φ ⊢ A ≈ ★

--- a/GTPLC/NarrowWiden.agda
+++ b/GTPLC/NarrowWiden.agda
@@ -5,14 +5,16 @@ module NarrowWiden where
 --   * Characterizes a kind of normal form for coercions.
 --   * Indexes both relations by a coercion, type context, type store,
 --     and mode environment.
+--   * Equates bundled narrowings by their coercion components.
 --   * Includes store-indexed seal and unseal rules.
 --   * Provides bundled notation and proofs of ordinary coercion typing.
 
 open import Data.Bool using (true)
+open import Data.Empty using (⊥-elim)
 open import Data.List using (_∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.Nat using (_<_; zero; suc)
-open import Data.Product using (_×_; _,_; ∃-syntax; Σ-syntax)
+open import Data.Product using (_×_; _,_; proj₁; ∃-syntax; Σ-syntax)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl)
 open import Relation.Nullary using (yes; no)
@@ -60,11 +62,13 @@ mutual
         ----------------------------
       → μ ∣ Δ ∣ Σ ⊢ G ! ⦂ A ⊑ ★
 
+    -- See [rationale](Rationale.md#canonical-sequence-association).
     tag-seq : ∀ {c A B} (G : Tag)
       → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
       → WfTag Δ G
       → tagAllowed μ G ≡ true
       → G ꞉ B
+      → NonVar A
       → A ≢ B
         ----------------------------------
       → μ ∣ Δ ∣ Σ ⊢ (c ︔ (G !)) ⦂ A ⊑ ★
@@ -127,11 +131,13 @@ mutual
         ----------------------------
       → μ ∣ Δ ∣ Σ ⊢ G ？ ⦂ ★ ⊒ B
 
+    -- See [rationale](Rationale.md#canonical-sequence-association).
     untag-seq : ∀ {c A B} (G : Tag)
       → WfTag Δ G
       → tagAllowed μ G ≡ true
       → G ꞉ A
       → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+      → NonVar B
       → A ≢ B
         ----------------------------------
       → μ ∣ Δ ∣ Σ ⊢ ((G ？) ︔ c) ⦂ ★ ⊒ B
@@ -199,6 +205,18 @@ _∣_⊢_⊒_ : TyCtx → TyStore → Ty → Ty → Set
   Σ[ c ∈ Coercion ] Δ ∣ Σ ⊢ c ⦂ A ⊒ B
 
 ------------------------------------------------------------------------
+-- Narrowing equivalence
+------------------------------------------------------------------------
+
+infix 4 _≐ⁿ_
+
+_≐ⁿ_ : ∀ {μ Δ Σ A B}
+  → μ ∣ Δ ∣ Σ ⊢ A ⊒ B
+  → μ ∣ Δ ∣ Σ ⊢ A ⊒ B
+  → Set
+p ≐ⁿ q = proj₁ p ≡ proj₁ q
+
+------------------------------------------------------------------------
 -- Endpoint well-formedness
 ------------------------------------------------------------------------
 
@@ -219,7 +237,7 @@ mutual
   ⊑-src-wf (p ↦ q) = wf⇒ (⊒-tgt-wf p) (⊑-src-wf q)
   ⊑-src-wf (∀ʷ p) = wf∀ (⊑-src-wf p)
   ⊑-src-wf (tag G hG _ G꞉A) = tag-type-wf hG G꞉A
-  ⊑-src-wf (tag-seq G p _ _ _ _) = ⊑-src-wf p
+  ⊑-src-wf (tag-seq G p _ _ _ _ _) = ⊑-src-wf p
   ⊑-src-wf (unseal X<Δ _ _ _) = wfVar X<Δ
   ⊑-src-wf (unseal-seq X<Δ _ _ _ _) = wfVar X<Δ
   ⊑-src-wf (inst _ _ _ p _) = wf∀ (⊑-src-wf p)
@@ -231,7 +249,7 @@ mutual
   ⊑-tgt-wf (p ↦ q) = wf⇒ (⊒-src-wf p) (⊑-tgt-wf q)
   ⊑-tgt-wf (∀ʷ p) = wf∀ (⊑-tgt-wf p)
   ⊑-tgt-wf (tag _ _ _ _) = wf★
-  ⊑-tgt-wf (tag-seq _ _ _ _ _ _) = wf★
+  ⊑-tgt-wf (tag-seq _ _ _ _ _ _ _) = wf★
   ⊑-tgt-wf (unseal _ hA _ _) = hA
   ⊑-tgt-wf (unseal-seq _ _ _ p _) = ⊑-tgt-wf p
   ⊑-tgt-wf (inst _ _ hB _ _) = hB
@@ -243,7 +261,7 @@ mutual
   ⊒-src-wf (p ↦ q) = wf⇒ (⊑-tgt-wf p) (⊒-src-wf q)
   ⊒-src-wf (∀ⁿ p) = wf∀ (⊒-src-wf p)
   ⊒-src-wf (untag _ _ _ _) = wf★
-  ⊒-src-wf (untag-seq _ _ _ _ _ _) = wf★
+  ⊒-src-wf (untag-seq _ _ _ _ _ _ _) = wf★
   ⊒-src-wf (seal _ hA _ _) = hA
   ⊒-src-wf (seal-seq p _ _ _ _) = ⊒-src-wf p
   ⊒-src-wf (gen _ _ hB _ _) = hB
@@ -255,7 +273,7 @@ mutual
   ⊒-tgt-wf (p ↦ q) = wf⇒ (⊑-src-wf p) (⊒-tgt-wf q)
   ⊒-tgt-wf (∀ⁿ p) = wf∀ (⊒-tgt-wf p)
   ⊒-tgt-wf (untag G hG _ G꞉B) = tag-type-wf hG G꞉B
-  ⊒-tgt-wf (untag-seq _ _ _ _ p _) = ⊒-tgt-wf p
+  ⊒-tgt-wf (untag-seq _ _ _ _ p _ _) = ⊒-tgt-wf p
   ⊒-tgt-wf (seal X<Δ _ _ _) = wfVar X<Δ
   ⊒-tgt-wf (seal-seq _ X<Δ _ _ _) = wfVar X<Δ
   ⊒-tgt-wf (gen _ _ _ p _) = wf∀ (⊒-tgt-wf p)
@@ -285,7 +303,7 @@ mutual
   widening-typing (∀ʷ p) = cast-all (widening-typing p)
   widening-typing (tag G hG allowed G꞉A) =
     cast-tag hG allowed G꞉A
-  widening-typing (tag-seq G p hG allowed G꞉B _) =
+  widening-typing (tag-seq G p hG allowed G꞉B _ _) =
     cast-seq (widening-typing p) (cast-tag hG allowed G꞉B)
   widening-typing (unseal _ hA X,A∈Σ allowed) =
     cast-unseal hA X,A∈Σ allowed
@@ -305,7 +323,7 @@ mutual
   narrowing-typing (∀ⁿ p) = cast-all (narrowing-typing p)
   narrowing-typing (untag G hG allowed G꞉B) =
     cast-untag hG allowed G꞉B
-  narrowing-typing (untag-seq G hG allowed G꞉A p _) =
+  narrowing-typing (untag-seq G hG allowed G꞉A p _ _) =
     cast-seq
       (cast-untag hG allowed G꞉A)
       (narrowing-typing p)
@@ -321,32 +339,6 @@ mutual
 ------------------------------------------------------------------------
 -- Smart sequence wrappers
 ------------------------------------------------------------------------
-
-wrap-tag : ∀ {μ Δ Σ c A B G}
-  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
-  → WfTag Δ G
-  → tagAllowed μ G ≡ true
-  → G ꞉ B
-  → ∃[ d ] μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊑ ★
-wrap-tag {A = A} {B = B} {G = G} p hG allowed G꞉B
-    with A ≟Ty B
-wrap-tag {B = B} {G = G} p hG allowed G꞉B | yes refl =
-  G ! , tag G hG allowed G꞉B
-wrap-tag {c = c} {G = G} p hG allowed G꞉B | no A≢B =
-  (c ︔ (G !)) , tag-seq G p hG allowed G꞉B A≢B
-
-wrap-untag : ∀ {μ Δ Σ c A B G}
-  → WfTag Δ G
-  → tagAllowed μ G ≡ true
-  → G ꞉ A
-  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
-  → ∃[ d ] μ ∣ Δ ∣ Σ ⊢ d ⦂ ★ ⊒ B
-wrap-untag {A = A} {B = B} {G = G} hG allowed G꞉A p
-    with A ≟Ty B
-wrap-untag {A = A} {G = G} hG allowed G꞉A p | yes refl =
-  G ？ , untag G hG allowed G꞉A
-wrap-untag {c = c} {G = G} hG allowed G꞉A p | no A≢B =
-  ((G ？) ︔ c) , untag-seq G hG allowed G꞉A p A≢B
 
 wrap-unseal : ∀ {μ Δ Σ X c A B}
   → X < Δ
@@ -377,3 +369,87 @@ wrap-seal {X = X} {A = A}
 wrap-seal {X = X} {c = c}
     p X<Δ X,B∈Σ allowed | no A≢B =
   (c ︔ seal X) , seal-seq p X<Δ X,B∈Σ allowed A≢B
+
+wrap-tag-nonvar : ∀ {μ Δ Σ c A B G}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+  → WfTag Δ G
+  → tagAllowed μ G ≡ true
+  → G ꞉ B
+  → NonVar A
+  → ∃[ d ] μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊑ ★
+wrap-tag-nonvar {A = A} {B = B} p hG allowed G꞉B nonvarA
+    with A ≟Ty B
+wrap-tag-nonvar {G = G} p hG allowed G꞉B nonvarA | yes refl =
+  G ! , tag G hG allowed G꞉B
+wrap-tag-nonvar {c = c} {G = G} p hG allowed G꞉B nonvarA
+    | no A≢B =
+  (c ︔ (G !)) , tag-seq G p hG allowed G꞉B nonvarA A≢B
+
+wrap-tag : ∀ {μ Δ Σ c A B G}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+  → WfTag Δ G
+  → tagAllowed μ G ≡ true
+  → G ꞉ B
+  → ∃[ d ] μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊑ ★
+wrap-tag {A = ＇ X} {G = G} (idᵃ (＇ .X) hA) hG allowed G꞉A =
+  G ! , tag G hG allowed G꞉A
+wrap-tag {A = ＇ X} (tag H hH H-ok H꞉A) hG allowed ()
+wrap-tag {A = ＇ X} {G = G} (unseal X<Δ hB X,B∈Σ seal-ok)
+    hG tag-ok G꞉B =
+  wrap-unseal X<Δ X,B∈Σ seal-ok (tag G hG tag-ok G꞉B)
+wrap-tag {A = ＇ X} (unseal-seq X<Δ X,A∈Σ seal-ok p A≢B)
+    hG tag-ok G꞉B with wrap-tag p hG tag-ok G꞉B
+wrap-tag {A = ＇ X} (unseal-seq X<Δ X,A∈Σ seal-ok p A≢B)
+    hG tag-ok G꞉B | d , p′ =
+  wrap-unseal X<Δ X,A∈Σ seal-ok p′
+wrap-tag {A = ‵ ι} p hG allowed G꞉B =
+  wrap-tag-nonvar p hG allowed G꞉B nonvar-base
+wrap-tag {A = ★} p hG allowed G꞉B =
+  wrap-tag-nonvar p hG allowed G꞉B nonvar-star
+wrap-tag {A = A ⇒ B} p hG allowed G꞉C =
+  wrap-tag-nonvar p hG allowed G꞉C nonvar-fun
+wrap-tag {A = `∀ A} p hG allowed G꞉B =
+  wrap-tag-nonvar p hG allowed G꞉B nonvar-all
+
+wrap-untag-nonvar : ∀ {μ Δ Σ c A B G}
+  → WfTag Δ G
+  → tagAllowed μ G ≡ true
+  → G ꞉ A
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+  → NonVar B
+  → ∃[ d ] μ ∣ Δ ∣ Σ ⊢ d ⦂ ★ ⊒ B
+wrap-untag-nonvar {A = A} {B = B} hG allowed G꞉A p nonvarB
+    with A ≟Ty B
+wrap-untag-nonvar {G = G} hG allowed G꞉A p nonvarB | yes refl =
+  G ？ , untag G hG allowed G꞉A
+wrap-untag-nonvar {c = c} {G = G} hG allowed G꞉A p nonvarB
+    | no A≢B =
+  (G ？) ︔ c , untag-seq G hG allowed G꞉A p nonvarB A≢B
+
+wrap-untag : ∀ {μ Δ Σ c A B G}
+  → WfTag Δ G
+  → tagAllowed μ G ≡ true
+  → G ꞉ A
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+  → ∃[ d ] μ ∣ Δ ∣ Σ ⊢ d ⦂ ★ ⊒ B
+wrap-untag {B = ＇ X} {G = G} hG allowed G꞉A
+    (idᵃ (＇ .X) hA) =
+  G ？ , untag G hG allowed G꞉A
+wrap-untag {B = ＇ X} hG allowed () (untag H hH H-ok H꞉B)
+wrap-untag {B = ＇ X} {G = G} hG tag-ok G꞉A
+    (seal X<Δ hA X,A∈Σ seal-ok) =
+  wrap-seal (untag G hG tag-ok G꞉A) X<Δ X,A∈Σ seal-ok
+wrap-untag {B = ＇ X} hG tag-ok G꞉A
+    (seal-seq p X<Δ X,B∈Σ seal-ok A≢B)
+    with wrap-untag hG tag-ok G꞉A p
+wrap-untag {B = ＇ X} hG tag-ok G꞉A
+    (seal-seq p X<Δ X,B∈Σ seal-ok A≢B) | d , p′ =
+  wrap-seal p′ X<Δ X,B∈Σ seal-ok
+wrap-untag {B = ‵ ι} hG allowed G꞉A p =
+  wrap-untag-nonvar hG allowed G꞉A p nonvar-base
+wrap-untag {B = ★} hG allowed G꞉A p =
+  wrap-untag-nonvar hG allowed G꞉A p nonvar-star
+wrap-untag {B = A ⇒ B} hG allowed G꞉C p =
+  wrap-untag-nonvar hG allowed G꞉C p nonvar-fun
+wrap-untag {B = `∀ A} hG allowed G꞉B p =
+  wrap-untag-nonvar hG allowed G꞉B p nonvar-all

--- a/GTPLC/Rationale.md
+++ b/GTPLC/Rationale.md
@@ -7,6 +7,7 @@ that the Agda source can link directly to it.
 ## Contents
 
 - [Keep eager checks outside `gen` and `inst`](#gen-inst-side-conditions)
+- [Use canonical association for seal and unseal sequences](#canonical-sequence-association)
 
 <a id="gen-inst-side-conditions"></a>
 ## Keep eager checks outside `gen` and `inst`
@@ -98,3 +99,98 @@ for a mismatched dynamic tag.
 
 [gtsf-narrow-widen]: ../GTSF/NarrowWiden.agda
 [mismatch-regression]: ../GTSF/proof/Compilation/GenSafeMismatchBlameRegression.agda
+
+<a id="canonical-sequence-association"></a>
+## Use canonical association for seal and unseal sequences
+
+### Decision
+
+Seal chains in narrowing associate to the left, while unseal chains in
+widening associate to the right. Thus the canonical forms are
+
+```agda
+((G ？) ︔ seal X) ︔ seal Y
+unseal X ︔ (unseal Y ︔ (G !))
+```
+
+and not
+
+```agda
+(G ？) ︔ (seal X ︔ seal Y)
+(unseal X ︔ unseal Y) ︔ (G !)
+```
+
+The merged narrowing and widening judgments enforce this distinction with
+endpoint-shape premises. The `untag-seq` constructor requires `NonVar B`, so
+it cannot place an untag outside a sequence whose final target is a sealed
+type variable. Such a sequence must instead be extended by `seal-seq`.
+Dually, `tag-seq` requires `NonVar A`, so it cannot place a tag outside a
+sequence whose initial source is an unsealed type variable. Such a sequence
+must instead be extended by `unseal-seq`.
+
+### Why the restriction is necessary
+
+For a concrete example, take the context, store, and mode environment
+
+```agda
+Δ₂ = suc (suc zero)
+
+Σ₂ =
+  (zero , ＇ (suc zero)) ∷
+  (suc zero , ‵ `ℕ) ∷ []
+
+μ-seal X = seal-or-id
+```
+
+The store is recursively well formed:
+
+```agda
+wfΣ₁ = store-bind store-empty wfBase refl
+wfΣ₂ = store-bind wfΣ₁ (wfVar z<s) refl
+```
+
+Thus `zero` is represented by the older variable `suc zero`, which in turn
+is represented by `ℕ`. Before the endpoint-shape premises were added, the
+following two narrowing judgments both held:
+
+```agda
+μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ (((‵ `ℕ) ？) ︔ seal (suc zero)) ︔ seal zero
+    ⦂ ★ ⊒ ＇ zero
+
+μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ ((‵ `ℕ) ？) ︔ (seal (suc zero) ︔ seal zero)
+    ⦂ ★ ⊒ ＇ zero
+```
+
+The first is canonical. It is built by applying `seal-seq` twice. The second
+would require `untag-seq` with final target `＇ zero`, but its new premise
+would be `NonVar (＇ zero)`, which has no constructor.
+
+The dual ambiguity was
+
+```agda
+μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ unseal zero ︔ (unseal (suc zero) ︔ ((‵ `ℕ) !))
+    ⦂ ＇ zero ⊑ ★
+
+μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ (unseal zero ︔ unseal (suc zero)) ︔ ((‵ `ℕ) !)
+    ⦂ ＇ zero ⊑ ★
+```
+
+Here the first is canonical and is built by applying `unseal-seq` twice. The
+second would require `tag-seq` with initial source `＇ zero`, but its new
+premise would be `NonVar (＇ zero)`.
+
+Because `_︔_` is a syntax constructor rather than an associative operation
+modulo equality, each noncanonical coercion is propositionally unequal to its
+canonical counterpart. Narrowing and widening therefore were not determined
+by their endpoints, mode environment, and well-formed store.
+
+The separate GTSF normal-form grammar prevented this overlap with its strict
+cross-narrowing and strict cross-widening categories. The endpoint-shape
+premises are the corresponding invariant for GTPLC's merged grammar and type
+system. They keep every judgment index in constructor form; normalization by
+the smart wrappers happens in their proof definitions rather than through a
+composition function in a constructor conclusion.

--- a/GTPLC/TermNarrowing.agda
+++ b/GTPLC/TermNarrowing.agda
@@ -24,8 +24,9 @@ open import NarrowWiden using
   ( _∣_∣_⊢_⦂_⊑_
   ; _∣_∣_⊢_⦂_⊒_
   ; _∣_∣_⊢_⊒_
+  ; _≐ⁿ_
   )
-open import ImprecisionTheorems using (dualʷ)
+open import ImprecisionTheorems using (dualʷ; _⨟ⁿ_)
 open import EnvironmentNarrowing
 
 ------------------------------------------------------------------------
@@ -149,34 +150,42 @@ data _⊢ᴺ_⊒_∶_ :
       ----------------------------------------
     → ρ ⊢ᴺ L ⊕[ addℕ ] M ⊒ L′ ⊕[ addℕ ] M′ ∶ p
 
-  castⁿ⊒ : ∀ {p : ρ ⊢ᵀ A ⊒ B′}
-      {q : ρ ⊢ᵀ B ⊒ B′}
+  castⁿ⊒ : ∀ {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {qᴸ : ρ ⊢ᴸⁿ B ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B′}
       {s⦂ : ρ ⊢ᴸⁿ s ⦂ A ⊒ B}
-    → ρ ⊢ᴺ M ⊒ M′ ∶ p
-    → (s , s⦂) ⨟ⁿᶠ q ≐ᶠ p
+    → ρ ⊢ᴺ M ⊒ M′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+    → ((s , s⦂) ⨟ⁿ qᴸ) ≐ⁿ pᴸ
       ---------------------
-    → ρ ⊢ᴺ M ⟨ s ⟩ ⊒ M′ ∶ q
+    → ρ ⊢ᴺ M ⟨ s ⟩ ⊒ M′ ∶ (qᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
 
-  castʷ⊒ : ∀ {p : ρ ⊢ᵀ A ⊒ B′}
-      {q : ρ ⊢ᵀ B ⊒ B′}
+  castʷ⊒ : ∀ {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {qᴸ : ρ ⊢ᴸⁿ B ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B′}
       {s⦂ : ρ ⊢ᴸʷ s ⦂ A ⊑ B}
-    → ρ ⊢ᴺ M ⊒ M′ ∶ p
-    → dualʷ (s , s⦂) ⨟ⁿᶠ p ≐ᶠ q
+    → ρ ⊢ᴺ M ⊒ M′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+    → (dualʷ (s , s⦂) ⨟ⁿ pᴸ) ≐ⁿ qᴸ
       ---------------------
-    → ρ ⊢ᴺ M ⟨ s ⟩ ⊒ M′ ∶ q
+    → ρ ⊢ᴺ M ⟨ s ⟩ ⊒ M′ ∶ (qᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
 
-  ⊒castⁿ : ∀ {p : ρ ⊢ᵀ A ⊒ A′}
-      {q : ρ ⊢ᵀ A ⊒ B′}
+  ⊒castⁿ : ∀ {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ A′}
+      {qᴿ : ρ ⊢ᴿⁿ C′ ⊒ B′}
       {t⦂ : ρ ⊢ᴿⁿ t ⦂ A′ ⊒ B′}
-    → ρ ⊢ᴺ M ⊒ M′ ∶ p
-    → p ⨟ᶠⁿ (t , t⦂) ≐ᶠ q
+    → ρ ⊢ᴺ M ⊒ M′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+    → (pᴿ ⨟ⁿ (t , t⦂)) ≐ⁿ qᴿ
       ---------------------
-    → ρ ⊢ᴺ M ⊒ M′ ⟨ t ⟩ ∶ q
+    → ρ ⊢ᴺ M ⊒ M′ ⟨ t ⟩ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ qᴿ)
 
-  ⊒castʷ : ∀ {p : ρ ⊢ᵀ A ⊒ A′}
-      {q : ρ ⊢ᵀ A ⊒ B′}
+  ⊒castʷ : ∀ {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ A′}
+      {qᴿ : ρ ⊢ᴿⁿ C′ ⊒ B′}
       {t⦂ : ρ ⊢ᴿʷ t ⦂ A′ ⊑ B′}
-    → ρ ⊢ᴺ M ⊒ M′ ∶ p
-    → q ⨟ᶠⁿ dualʷ (t , t⦂) ≐ᶠ p
+    → ρ ⊢ᴺ M ⊒ M′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+    → (qᴿ ⨟ⁿ dualʷ (t , t⦂)) ≐ⁿ pᴿ
       ---------------------
-    → ρ ⊢ᴺ M ⊒ M′ ⟨ t ⟩ ∶ q
+    → ρ ⊢ᴺ M ⊒ M′ ⟨ t ⟩ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ qᴿ)

--- a/GTPLC/TyStore.agda
+++ b/GTPLC/TyStore.agda
@@ -2,8 +2,10 @@ module TyStore where
 
 -- File Charter:
 --   * Type-store representation and well-formedness invariants.
---   * Defines type-variable renaming on stores and the invariants assumed by
---     preservation.
+--   * Defines type-variable renaming on stores and a recursive construction
+--     relation for well-formed stores.
+--   * Makes type-binder lifting and fresh runtime allocation the only ways to
+--     extend a well-formed store.
 
 open import Agda.Builtin.Equality using (_≡_)
 open import Data.List using (List; []; _∷_)
@@ -28,10 +30,19 @@ renameTyStoreᵗ ρ ((α , A) ∷ Σ) =
 -- Store well-formedness
 ------------------------------------------------------------------------
 
-record StoreWf (Δ : TyCtx) (Σ : TyStore) : Set₁ where
-  field
-    bound : ∀ {α A} → (α , A) ∈ Σ → α < Δ
-    wfTy : ∀ {α A} → (α , A) ∈ Σ → WfTy Δ A
-    unique : ∀ {α A B} → (α , A) ∈ Σ → (α , B) ∈ Σ → A ≡ B
+data StoreWf : TyCtx → TyStore → Set₁ where
 
-open StoreWf public
+  store-empty : StoreWf zero []
+
+  store-lift : ∀ {Δ Σ Σ′}
+    → StoreWf Δ Σ
+    → Σ′ ≡ ⟰ᵗ Σ
+      -------------------
+    → StoreWf (suc Δ) Σ′
+
+  store-bind : ∀ {Δ Σ A Σ′}
+    → StoreWf Δ Σ
+    → WfTy Δ A
+    → Σ′ ≡ ((zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ)
+      --------------------------------------
+    → StoreWf (suc Δ) Σ′

--- a/GTPLC/proof/ImprecisionComposition.agda
+++ b/GTPLC/proof/ImprecisionComposition.agda
@@ -5,7 +5,11 @@ module proof.ImprecisionComposition where
 --   * Normalizes composition structurally through every constructor.
 --   * Retains only canonical tag, untag, seal, and unseal sequences.
 --   * Uses well-founded recursion over the total coercion size.
+--   * Localizes function extensionality to accessibility proof irrelevance.
 
+open import Axiom.Extensionality.Propositional using
+  (Extensionality; implicit-extensionality)
+open import Data.Bool using (true)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using (_∷_)
 open import Data.List.Membership.Propositional using (_∈_)
@@ -29,8 +33,10 @@ open import Data.Nat.Properties using
   )
 open import Data.Product using (_×_; _,_; proj₁; proj₂; Σ-syntax)
 open import Induction.WellFounded using (Acc; acc)
+open import Level using (0ℓ)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; cong; cong₂; subst; sym)
+  using (_≡_; _≢_; refl; cong; cong₂; subst; sym)
+open import Relation.Nullary using (yes; no)
 
 open import Types
 open import TyStore
@@ -45,6 +51,18 @@ open import proof.ImprecisionModeWeakening using
 open import proof.ImprecisionRenaming using (⇑ⁿ-gen; ⇑ʷ-inst)
 open import proof.TyStore using (∈-⟰ᵗ-inv; ∈-⟰ᵗ-zero)
 open import proof.TypeInTypeSubst using (rename-preserves-∈ᵗ)
+
+private
+
+  postulate
+    funext : Extensionality 0ℓ 0ℓ
+
+  acc-irrelevant : ∀ {n} (a b : Acc _<_ n) → a ≡ b
+  acc-irrelevant (acc f) (acc g) =
+    cong acc
+      (implicit-extensionality funext
+        (λ {m} → funext λ m<n →
+          acc-irrelevant (f m<n) (g m<n)))
 
 ------------------------------------------------------------------------
 -- Store weakening
@@ -85,8 +103,8 @@ mutual
   weaken-storeʷ incl (∀ʷ p) = ∀ʷ (weaken-storeʷ (shift-incl incl) p)
   weaken-storeʷ incl (tag G hG allowed G꞉A) =
     tag G hG allowed G꞉A
-  weaken-storeʷ incl (tag-seq G p hG allowed G꞉B A≢B) =
-    tag-seq G (weaken-storeʷ incl p) hG allowed G꞉B A≢B
+  weaken-storeʷ incl (tag-seq G p hG allowed G꞉B nonvarA A≢B) =
+    tag-seq G (weaken-storeʷ incl p) hG allowed G꞉B nonvarA A≢B
   weaken-storeʷ incl (unseal X<Δ hA X,A∈Σ allowed) =
     unseal X<Δ hA (incl X,A∈Σ) allowed
   weaken-storeʷ incl (unseal-seq X<Δ X,A∈Σ allowed p A≢B) =
@@ -106,8 +124,9 @@ mutual
   weaken-storeⁿ incl (∀ⁿ p) = ∀ⁿ (weaken-storeⁿ (shift-incl incl) p)
   weaken-storeⁿ incl (untag G hG allowed G꞉B) =
     untag G hG allowed G꞉B
-  weaken-storeⁿ incl (untag-seq G hG allowed G꞉A p A≢B) =
-    untag-seq G hG allowed G꞉A (weaken-storeⁿ incl p) A≢B
+  weaken-storeⁿ incl (untag-seq G hG allowed G꞉A p nonvarB A≢B) =
+    untag-seq G hG allowed G꞉A
+      (weaken-storeⁿ incl p) nonvarB A≢B
   weaken-storeⁿ incl (seal X<Δ hA X,A∈Σ allowed) =
     seal X<Δ hA (incl X,A∈Σ) allowed
   weaken-storeⁿ incl (seal-seq p X<Δ X,B∈Σ allowed A≢B) =
@@ -202,7 +221,8 @@ mutual
   narrowing-member fresh (∀ⁿ p) (∈-all X∈A) =
     ∈-all (narrowing-member (shift-fresh fresh) p X∈A)
   narrowing-member fresh (untag G hG allowed G꞉B) ()
-  narrowing-member fresh (untag-seq G hG allowed G꞉A p A≢B) ()
+  narrowing-member fresh
+    (untag-seq G hG allowed G꞉A p nonvarB A≢B) ()
   narrowing-member fresh (seal X<Δ hA X,A∈Σ allowed) X∈A =
     ⊥-elim (fresh X,A∈Σ X∈A)
   narrowing-member fresh
@@ -227,7 +247,8 @@ mutual
   widening-member fresh (∀ʷ p) (∈-all X∈A) =
     ∈-all (widening-member (shift-fresh fresh) p X∈A)
   widening-member fresh (tag G hG allowed G꞉A) ()
-  widening-member fresh (tag-seq G p hG allowed G꞉B A≢B) ()
+  widening-member fresh
+    (tag-seq G p hG allowed G꞉B nonvarA A≢B) ()
   widening-member fresh (unseal X<Δ hA X,A∈Σ allowed) X∈A =
     ⊥-elim (fresh X,A∈Σ X∈A)
   widening-member fresh
@@ -252,7 +273,7 @@ narrowing-nonvar-member fresh (p ↦ q) nonvar-fun X∈A = nonvar-fun
 narrowing-nonvar-member fresh (∀ⁿ p) nonvar-all X∈A = nonvar-all
 narrowing-nonvar-member fresh (untag G hG allowed G꞉B) nonvar-star ()
 narrowing-nonvar-member fresh
-    (untag-seq G hG allowed G꞉A p A≢B) nonvar-star ()
+    (untag-seq G hG allowed G꞉A p nonvarB A≢B) nonvar-star ()
 narrowing-nonvar-member fresh
     (seal X<Δ hA X,A∈Σ allowed) nonvarA X∈A =
   ⊥-elim (fresh X,A∈Σ X∈A)
@@ -275,7 +296,7 @@ widening-nonvar-member fresh (p ↦ q) nonvar-fun X∈A = nonvar-fun
 widening-nonvar-member fresh (∀ʷ p) nonvar-all X∈A = nonvar-all
 widening-nonvar-member fresh (tag G hG allowed G꞉A) nonvar-star ()
 widening-nonvar-member fresh
-    (tag-seq G p hG allowed G꞉B A≢B) nonvar-star ()
+    (tag-seq G p hG allowed G꞉B nonvarA A≢B) nonvar-star ()
 widening-nonvar-member fresh
     (unseal X<Δ hA X,A∈Σ allowed) nonvarA X∈A =
   ⊥-elim (fresh X,A∈Σ X∈A)
@@ -464,6 +485,15 @@ mutual
     → Acc _<_ (sizeᶜ c + sizeᶜ d)
     → μ ∣ Δ ∣ Σ ⊢ A ⊒ C
   composeⁿ (idᵃ a hA) q access = _ , q
+  composeⁿ (untag G hG allowed G꞉B) q access =
+    wrap-untag hG allowed G꞉B q
+  composeⁿ {c = (G ？) ︔ c} {d = d}
+      (untag-seq G hG allowed G꞉B p nonvarC B≢C) q (acc rec)
+      with composeⁿ p q
+        (rec (left-seq-drop-< (sizeᶜ c) (sizeᶜ (G ？)) (sizeᶜ d)))
+  composeⁿ (untag-seq G hG allowed G꞉B p nonvarC B≢C) q (acc rec)
+      | d , r =
+    wrap-untag hG allowed G꞉B r
   composeⁿ p (idᵃ a hB) access = _ , p
   composeⁿ {c = c ↦ d} {d = e ↦ f}
       (p₁ ↦ p₂) (q₁ ↦ q₂) (acc rec)
@@ -481,15 +511,6 @@ mutual
   composeⁿ (∀ⁿ p) (∀ⁿ q) (acc rec)
       | e , r =
     `∀ e , ∀ⁿ r
-  composeⁿ (untag G hG allowed G꞉B) q access =
-    wrap-untag hG allowed G꞉B q
-  composeⁿ {c = (G ？) ︔ c} {d = d}
-      (untag-seq G hG allowed G꞉B p B≢C) q (acc rec)
-      with composeⁿ p q
-        (rec (left-seq-drop-< (sizeᶜ c) (sizeᶜ (G ？)) (sizeᶜ d)))
-  composeⁿ (untag-seq G hG allowed G꞉B p B≢C) q (acc rec)
-      | d , r =
-    wrap-untag hG allowed G꞉B r
   composeⁿ p (seal X<Δ hB X,B∈Σ allowed) access =
     wrap-seal p X<Δ X,B∈Σ allowed
   composeⁿ {c = c} {d = d ︔ seal X}
@@ -580,10 +601,10 @@ mutual
   composeʷ p (tag G hG allowed G꞉B) access =
     wrap-tag p hG allowed G꞉B
   composeʷ {c = c} {d = d ︔ (G !)}
-      p (tag-seq G q hG allowed G꞉C B≢C) (acc rec)
+      p (tag-seq G q hG allowed G꞉C nonvarB B≢C) (acc rec)
       with composeʷ p q
         (rec (right-seq-< (sizeᶜ c) (sizeᶜ d) (sizeᶜ (G !))))
-  composeʷ p (tag-seq G q hG allowed G꞉C B≢C) (acc rec)
+  composeʷ p (tag-seq G q hG allowed G꞉C nonvarB B≢C) (acc rec)
       | d , r =
     wrap-tag r hG allowed G꞉C
   composeʷ {c = `∀ c} {d = inst d}
@@ -635,6 +656,87 @@ mutual
       (unseal-seq X<Δ X,C∈Σ allowed q C≢D) access =
     ⊥-elim (inst-variable-source-no-zero p zero∈A)
 
+composeⁿ-access-irrelevant : ∀ {μ Δ Σ c d A B C}
+    (p : μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B)
+    (q : μ ∣ Δ ∣ Σ ⊢ d ⦂ B ⊒ C)
+    (a b : Acc _<_ (sizeᶜ c + sizeᶜ d))
+  → composeⁿ p q a ≡ composeⁿ p q b
+composeⁿ-access-irrelevant p q a b
+    rewrite acc-irrelevant a b =
+  refl
+
+composeʷ-access-irrelevant : ∀ {μ Δ Σ c d A B C}
+    (p : μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B)
+    (q : μ ∣ Δ ∣ Σ ⊢ d ⦂ B ⊑ C)
+    (a b : Acc _<_ (sizeᶜ c + sizeᶜ d))
+  → composeʷ p q a ≡ composeʷ p q b
+composeʷ-access-irrelevant p q a b
+    rewrite acc-irrelevant a b =
+  refl
+
+wrap-seal-coercion-evidence : ∀ {μ Δ Σ X c A B}
+    (p q : μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B)
+    (X<Δ : X < Δ)
+    (X,B∈Σ : (X , B) ∈ Σ)
+    (allowed : sealModeAllowed (μ X) ≡ true)
+  → proj₁ (wrap-seal p X<Δ X,B∈Σ allowed) ≡
+    proj₁ (wrap-seal q X<Δ X,B∈Σ allowed)
+wrap-seal-coercion-evidence {A = A} {B = B}
+    p q X<Δ X,B∈Σ allowed with A ≟Ty B
+wrap-seal-coercion-evidence {A = A}
+    p q X<Δ X,B∈Σ allowed | yes refl = refl
+wrap-seal-coercion-evidence {c = c}
+    p q X<Δ X,B∈Σ allowed | no A≢B = refl
+
+seal-prefix-compose-evidence : ∀ {μ Δ Σ X A C}
+    {d : Coercion}
+    (s t : μ ∣ Δ ∣ Σ ⊢ seal X ⦂ A ⊒ ＇ X)
+    (q : μ ∣ Δ ∣ Σ ⊢ d ⦂ ＇ X ⊒ C)
+    (a b : Acc _<_ (sizeᶜ (seal X) + sizeᶜ d))
+  → proj₁ (composeⁿ s q a) ≡ proj₁ (composeⁿ t q b)
+seal-prefix-compose-evidence
+    (seal X<Δ hA X,A∈Σ allowedX)
+    (seal X<Δ′ hA′ X,A′∈Σ allowedX′)
+    (idᵃ (＇ X) hX) a b = refl
+seal-prefix-compose-evidence {μ = μ} {Δ = Δ} {Σ = Σ}
+    {X = X} {A = A}
+    s@(seal X<Δ hA X,A∈Σ allowedX)
+    t@(seal X<Δ′ hA′ X,A′∈Σ allowedX′)
+    (seal {X = Y} Y<Δ hX Y,X∈Σ allowed) a b =
+  wrap-seal-coercion-evidence
+    {μ = μ} {Δ = Δ} {Σ = Σ} {X = Y}
+    {c = seal X} {A = A} {B = ＇ X}
+    s t Y<Δ Y,X∈Σ allowed
+seal-prefix-compose-evidence {X = X}
+    {d = d ︔ seal Y}
+    s@(seal X<Δ hA X,A∈Σ allowedX)
+    t@(seal X<Δ′ hA′ X,A′∈Σ allowedX′)
+    (seal-seq q Y<Δ Y,B∈Σ allowed X≢B)
+    (acc rec₁) (acc rec₂)
+    with composeⁿ s q
+      (rec₁ (right-seq-< (sizeᶜ (seal X)) (sizeᶜ d)
+        (sizeᶜ (seal Y))))
+       | composeⁿ t q
+      (rec₂ (right-seq-< (sizeᶜ (seal X)) (sizeᶜ d)
+        (sizeᶜ (seal Y))))
+       | seal-prefix-compose-evidence s t q
+      (rec₁ (right-seq-< (sizeᶜ (seal X)) (sizeᶜ d)
+        (sizeᶜ (seal Y))))
+      (rec₂ (right-seq-< (sizeᶜ (seal X)) (sizeᶜ d)
+        (sizeᶜ (seal Y))))
+seal-prefix-compose-evidence
+    s@(seal X<Δ hA X,A∈Σ allowedX)
+    t@(seal X<Δ′ hA′ X,A′∈Σ allowedX′)
+    (seal-seq q Y<Δ Y,B∈Σ allowed X≢B)
+    (acc rec₁) (acc rec₂)
+    | e , r | .e , r′ | refl =
+  wrap-seal-coercion-evidence r r′ Y<Δ Y,B∈Σ allowed
+seal-prefix-compose-evidence
+    s@(seal X<Δ hA X,A∈Σ allowedX)
+    t@(seal X<Δ′ hA′ X,A′∈Σ allowedX′)
+    (gen nonvarC zero∈C hX q X≢★) a b =
+  ⊥-elim (shifted-variable-target-no-zero q zero∈C)
+
 _⨟ⁿ_ : ∀ {μ Δ Σ A B C}
   → μ ∣ Δ ∣ Σ ⊢ A ⊒ B
   → μ ∣ Δ ∣ Σ ⊢ B ⊒ C
@@ -646,3 +748,44 @@ _⨟ʷ_ : ∀ {μ Δ Σ A B C}
   → μ ∣ Δ ∣ Σ ⊢ B ⊑ C
   → μ ∣ Δ ∣ Σ ⊢ A ⊑ C
 (c , p) ⨟ʷ (d , q) = composeʷ p q (<-wellFounded (sizeᶜ c + sizeᶜ d))
+
+seal-prefix-composeⁿ-evidence : ∀ {μ Δ Σ X A C}
+    {s t : μ ∣ Δ ∣ Σ ⊢ seal X ⦂ A ⊒ ＇ X}
+    {q : μ ∣ Δ ∣ Σ ⊢ ＇ X ⊒ C}
+  → ((seal X , s) ⨟ⁿ q) ≐ⁿ ((seal X , t) ⨟ⁿ q)
+seal-prefix-composeⁿ-evidence {X = X} {s = s} {t = t} {q = d , q} =
+  seal-prefix-compose-evidence s t q
+    (<-wellFounded (sizeᶜ (seal X) + sizeᶜ d))
+    (<-wellFounded (sizeᶜ (seal X) + sizeᶜ d))
+
+------------------------------------------------------------------------
+-- Canonical sequence reassociation
+------------------------------------------------------------------------
+
+untag-seq-inner-access : ∀ G c d
+  → Acc _<_ (sizeᶜ c + sizeᶜ d)
+untag-seq-inner-access G c d
+    with <-wellFounded (sizeᶜ ((G ？) ︔ c) + sizeᶜ d)
+untag-seq-inner-access G c d | acc rec =
+  rec (left-seq-drop-< (sizeᶜ c) (sizeᶜ (G ？)) (sizeᶜ d))
+
+untag-seq-composeⁿ : ∀ {μ Δ Σ G c d A B C}
+    {hG : WfTag Δ G}
+    {allowed : tagAllowed μ G ≡ true}
+    {G꞉A : G ꞉ A}
+    {p : μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B}
+    {nonvarB : NonVar B}
+    {A≢B : A ≢ B}
+    {q : μ ∣ Δ ∣ Σ ⊢ d ⦂ B ⊒ C}
+  → proj₁
+      (((G ？) ︔ c ,
+          untag-seq G hG allowed G꞉A p nonvarB A≢B)
+        ⨟ⁿ (d , q))
+    ≡ proj₁
+      ((G ？ , untag G hG allowed G꞉A)
+        ⨟ⁿ ((c , p) ⨟ⁿ (d , q)))
+untag-seq-composeⁿ {G = G} {c = c} {d = d} {p = p} {q = q}
+    rewrite composeⁿ-access-irrelevant p q
+      (untag-seq-inner-access G c d)
+      (<-wellFounded (sizeᶜ c + sizeᶜ d)) =
+  refl

--- a/GTPLC/proof/ImprecisionDual.agda
+++ b/GTPLC/proof/ImprecisionDual.agda
@@ -12,15 +12,17 @@ open import Data.List using ([]; _∷_)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.Nat using (_<_; zero; suc; z<s; s<s)
-open import Data.Product using (_×_; _,_; ∃-syntax; Σ-syntax)
+open import Data.Product using
+  (_×_; _,_; proj₁; proj₂; ∃-syntax; Σ-syntax)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; subst; sym)
+  using (_≡_; _≢_; refl; subst; sym)
 
 open import Types
 open import TyStore
 open import Coercions
 open import NarrowWiden
 open import proof.ImprecisionComposition using (_⨟ⁿ_; _⨟ʷ_)
+open import proof.NarrowWidenDeterminism using (narrowing-determined)
 
 ------------------------------------------------------------------------
 -- Mode and store changes performed by duality
@@ -349,10 +351,10 @@ mutual
   narrowing-dualᵐ rel ds (untag G hG allowed G꞉A) =
     dual-untag rel ds hG allowed G꞉A
   narrowing-dualᵐ rel ds
-      (untag-seq G hG allowed G꞉A p A≢B)
+      (untag-seq G hG allowed G꞉A p nonvarB A≢B)
       with narrowing-dualᵐ rel ds p
   narrowing-dualᵐ rel ds
-      (untag-seq G hG allowed G꞉A p A≢B) | d , p′ =
+      (untag-seq G hG allowed G꞉A p nonvarB A≢B) | d , p′ =
     (d , p′) ⨟ʷ dual-untag rel ds hG allowed G꞉A
   narrowing-dualᵐ rel ds (seal X<Δ hA X,A∈Σ allowed) =
     dual-seal rel ds X<Δ hA X,A∈Σ allowed
@@ -387,9 +389,11 @@ mutual
     `∀ c , ∀ⁿ p′
   widening-dualᵐ rel ds (tag G hG allowed G꞉A) =
     dual-tag rel ds hG allowed G꞉A
-  widening-dualᵐ rel ds (tag-seq G p hG allowed G꞉B A≢B)
+  widening-dualᵐ rel ds
+      (tag-seq G p hG allowed G꞉B nonvarA A≢B)
       with widening-dualᵐ rel ds p
-  widening-dualᵐ rel ds (tag-seq G p hG allowed G꞉B A≢B)
+  widening-dualᵐ rel ds
+      (tag-seq G p hG allowed G꞉B nonvarA A≢B)
       | d , p′ =
     dual-tag rel ds hG allowed G꞉B ⨟ⁿ (d , p′)
   widening-dualᵐ rel ds (unseal X<Δ hA X,A∈Σ allowed) =
@@ -421,5 +425,48 @@ narrowing-dual {μ = μ} {Δ = Δ} {Σ = Σ} =
 widening-dual : ∀ {μ Δ Σ c A B}
   → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
   → μ ∣ Δ ∣ Σ ⊢ B ⊒ A
-widening-dual {μ = μ} {Δ = Δ} {Σ = Σ} =
-  widening-dualᵐ normal-action (normal-store Δ μ Σ)
+widening-dual {μ = μ} {Δ = Δ} {Σ = Σ} p@(idᵃ a hA) =
+  widening-dualᵐ normal-action (normal-store Δ μ Σ) p
+widening-dual {μ = μ} {Δ = Δ} {Σ = Σ} p@(_ ↦ _) =
+  widening-dualᵐ normal-action (normal-store Δ μ Σ) p
+widening-dual {μ = μ} {Δ = Δ} {Σ = Σ} p@(∀ʷ q) =
+  widening-dualᵐ normal-action (normal-store Δ μ Σ) p
+widening-dual (tag G hG allowed G꞉A) =
+  G ？ , untag G hG allowed G꞉A
+widening-dual (tag-seq G q hG allowed G꞉B nonvarA A≢B)
+    with widening-dual q
+widening-dual (tag-seq G q hG allowed G꞉B nonvarA A≢B)
+    | d , q′ =
+  (G ？ , untag G hG allowed G꞉B) ⨟ⁿ (d , q′)
+widening-dual (unseal X<Δ hA X,A∈Σ allowed) =
+  seal _ , seal X<Δ hA X,A∈Σ allowed
+widening-dual {μ = μ} {Δ = Δ} {Σ = Σ}
+    p@(unseal-seq X<Δ X,A∈Σ allowed q A≢B) =
+  widening-dualᵐ normal-action (normal-store Δ μ Σ) p
+widening-dual {μ = μ} {Δ = Δ} {Σ = Σ}
+    p@(inst nonvarA zero∈A hB q B≢★) =
+  widening-dualᵐ normal-action (normal-store Δ μ Σ) p
+
+tag-seq-dual-composeⁿ : ∀ {μ Δ Σ G c A B C}
+    {q : μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B}
+    {hG : WfTag Δ G}
+    {allowed : tagAllowed μ G ≡ true}
+    {G꞉B : G ꞉ B}
+    {nonvarA : NonVar A}
+    {A≢B : A ≢ B}
+    {p : μ ∣ Δ ∣ Σ ⊢ A ⊒ C}
+  → StoreWf Δ Σ
+  → proj₁
+      (widening-dual
+        (tag-seq G q hG allowed G꞉B nonvarA A≢B) ⨟ⁿ p)
+    ≡ proj₁
+      ((G ？ , untag G hG allowed G꞉B) ⨟ⁿ
+        (widening-dual q ⨟ⁿ p))
+tag-seq-dual-composeⁿ {μ = μ} {Δ = Δ} {Σ = Σ} {G = G}
+    {A = A} {B = B} {C = C} {q = q} {hG = hG}
+    {allowed = allowed} {G꞉B = G꞉B} {nonvarA = nonvarA}
+    {A≢B = A≢B} {p = p} wfΣ =
+  narrowing-determined {μ = μ} {Δ = Δ} {Σ = Σ} {A = ★} {B = C} wfΣ
+    (widening-dual
+      (tag-seq G q hG allowed G꞉B nonvarA A≢B) ⨟ⁿ p)
+    ((G ？ , untag G hG allowed G꞉B) ⨟ⁿ (widening-dual q ⨟ⁿ p))

--- a/GTPLC/proof/ImprecisionModeWeakening.agda
+++ b/GTPLC/proof/ImprecisionModeWeakening.agda
@@ -160,8 +160,9 @@ mutual
   weakenʷ incl (∀ʷ p) = ∀ʷ (weakenʷ (ext-incl incl) p)
   weakenʷ incl (tag G hG allowed G⍉A) =
     tag G hG (tag-incl incl G allowed) G⍉A
-  weakenʷ incl (tag-seq G p hG allowed G⍉B A≠B) =
-    tag-seq G (weakenʷ incl p) hG (tag-incl incl G allowed) G⍉B A≠B
+  weakenʷ incl (tag-seq G p hG allowed G⍉B nonvarA A≠B) =
+    tag-seq G (weakenʷ incl p) hG (tag-incl incl G allowed)
+      G⍉B nonvarA A≠B
   weakenʷ incl (unseal {X = X} X<Delta hA X,A∈Sigma allowed) =
     unseal X<Delta hA X,A∈Sigma (seal-incl incl X allowed)
   weakenʷ incl (unseal-seq {X = X} X<Delta X,A∈Sigma allowed p A≠B) =
@@ -179,9 +180,9 @@ mutual
   weakenⁿ incl (∀ⁿ p) = ∀ⁿ (weakenⁿ (ext-incl incl) p)
   weakenⁿ incl (untag G hG allowed G⍉B) =
     untag G hG (tag-incl incl G allowed) G⍉B
-  weakenⁿ incl (untag-seq G hG allowed G⍉A p A≠B) =
+  weakenⁿ incl (untag-seq G hG allowed G⍉A p nonvarB A≠B) =
     untag-seq G hG (tag-incl incl G allowed) G⍉A
-      (weakenⁿ incl p) A≠B
+      (weakenⁿ incl p) nonvarB A≠B
   weakenⁿ incl (seal {X = X} X<Delta hA X,A∈Sigma allowed) =
     seal X<Delta hA X,A∈Sigma (seal-incl incl X allowed)
   weakenⁿ incl (seal-seq {X = X} p X<Delta X,B∈Sigma allowed A≠B) =

--- a/GTPLC/proof/ImprecisionRenaming.agda
+++ b/GTPLC/proof/ImprecisionRenaming.agda
@@ -74,12 +74,13 @@ mutual
       (modeRename-tagAllowed {μ = μ} {ν = ν} {G = G} rel allowed)
       (rename-preserves-tagged ρ G꞉A)
   renameʷ ρ ψ {μ = μ} {ν = ν} hρ rel inv
-      (tag-seq G p hG allowed G꞉B A≢B) =
+      (tag-seq G p hG allowed G꞉B nonvarA A≢B) =
     tag-seq (renameᵍ ρ G)
       (renameʷ ρ ψ hρ rel inv p)
       (renameᵍ-preserves-WfTag hG hρ)
       (modeRename-tagAllowed {μ = μ} {ν = ν} {G = G} rel allowed)
       (rename-preserves-tagged ρ G꞉B)
+      (renameNonVar ρ nonvarA)
       (rename-≢ ρ ψ inv A≢B)
   renameʷ ρ ψ {μ = μ} {ν = ν} hρ rel inv
       (unseal {X = X} X<Δ hA X,A∈Σ allowed) =
@@ -164,12 +165,13 @@ mutual
       (modeRename-tagAllowed {μ = μ} {ν = ν} {G = G} rel allowed)
       (rename-preserves-tagged ρ G꞉B)
   renameⁿ ρ ψ {μ = μ} {ν = ν} hρ rel inv
-      (untag-seq G hG allowed G꞉A p A≢B) =
+      (untag-seq G hG allowed G꞉A p nonvarB A≢B) =
     untag-seq (renameᵍ ρ G)
       (renameᵍ-preserves-WfTag hG hρ)
       (modeRename-tagAllowed {μ = μ} {ν = ν} {G = G} rel allowed)
       (rename-preserves-tagged ρ G꞉A)
       (renameⁿ ρ ψ hρ rel inv p)
+      (renameNonVar ρ nonvarB)
       (rename-≢ ρ ψ inv A≢B)
   renameⁿ ρ ψ {μ = μ} {ν = ν} hρ rel inv
       (seal {X = X} X<Δ hA X,A∈Σ allowed) =

--- a/GTPLC/proof/LeftEnvironmentChange.agda
+++ b/GTPLC/proof/LeftEnvironmentChange.agda
@@ -1,0 +1,338 @@
+module proof.LeftEnvironmentChange where
+
+-- File Charter:
+--   * Relates narrowing environments across source-side store changes.
+--   * Proves left-only relocation and type-store shifting locally.
+--   * Records the keep and dynamic-instantiation changes used by casts.
+
+open import Data.List using ([]; _∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (there)
+open import Data.Nat using (suc; zero; z<s; s≤s)
+open import Data.Product using (_,_; proj₁; Σ-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; subst)
+
+open import Types
+open import TyStore
+open import Coercions
+open import Terms using (Term; _⟨_⟩)
+open import Reduction
+open import TypeRelocate
+open import NarrowWiden
+open import EnvironmentNarrowing
+open import proof.ImprecisionRenaming using (renameⁿ; renameʷ)
+open import proof.ImprecisionComposition using
+  (weaken-storeⁿ; weaken-storeʷ)
+open import proof.TypeInCoercionSubst using
+  (ModeRename; renameᶜ-preserves-Inert)
+open import proof.TypeInTypeSubst using
+  ( RenameLeftInverse
+  ; RenameLeftInverse-ext
+  ; RenameLeftInverse-suc
+  ; TyRenameWf
+  ; TyRenameWf-ext
+  ; TyRenameWf-suc
+  ; renameᵗ-id
+  ; renameᵗ-preserves-WfTy
+  ; predᵗ
+  )
+open import proof.TyStore using (∈-renameTyStoreᵗ)
+
+------------------------------------------------------------------------
+-- Left-side store changes
+------------------------------------------------------------------------
+
+leftChangesᵢ : (χs : StoreChanges) → ∀ {Δᴸ Δᴿ}
+  → ImpCtx Δᴸ Δᴿ
+  → ImpCtx (χs ▶ᵈ Δᴸ) Δᴿ
+leftChangesᵢ [] Φ = Φ
+leftChangesᵢ (keep ∷ χs) Φ = leftChangesᵢ χs Φ
+leftChangesᵢ (bind A ∷ χs) Φ = leftChangesᵢ χs (freshᴸ Φ)
+
+syntax leftChangesᵢ χs Φ = χs ▶ᵢ Φ
+
+leftChangesᶜ : StoreChanges → Coercion → Coercion
+leftChangesᶜ [] c = c
+leftChangesᶜ (χ ∷ χs) c = leftChangesᶜ χs (changeᶜ χ c)
+
+syntax leftChangesᶜ χs c = χs ▶ᶜ c
+
+cast-trace : ∀ {M N c χs}
+  → M —↠[ χs ] N
+  → M ⟨ c ⟩ —↠[ χs ] N ⟨ χs ▶ᶜ c ⟩
+cast-trace ↠-refl = ↠-refl
+cast-trace (↠-step M→N N—↠P) =
+  ↠-step (ξ-⟨⟩ M→N) (cast-trace N—↠P)
+
+leftChanges-preserves-Inert : ∀ χs {c}
+  → Inert c
+  → Inert (χs ▶ᶜ c)
+leftChanges-preserves-Inert [] i = i
+leftChanges-preserves-Inert (keep ∷ χs) i =
+  leftChanges-preserves-Inert χs i
+leftChanges-preserves-Inert (bind A ∷ χs) i =
+  leftChanges-preserves-Inert χs (renameᶜ-preserves-Inert suc i)
+
+------------------------------------------------------------------------
+-- Relocation under a left-only shift
+------------------------------------------------------------------------
+
+private
+
+  record RenameRelocation
+      {Δᴸ Δᴿ Δᴸ′ Δᴿ′}
+      (ρᴸ ρᴿ : Renameᵗ)
+      (Φ : ImpCtx Δᴸ Δᴿ)
+      (Ψ : ImpCtx Δᴸ′ Δᴿ′) : Set where
+    constructor rename-relocation
+    field
+      left-wfᵣ : TyRenameWf Δᴸ Δᴸ′ ρᴸ
+      right-wfᵣ : TyRenameWf Δᴿ Δᴿ′ ρᴿ
+      pairedᵣ : ∀ {X Y}
+        → Φ ⊢ X ≈ˣ Y
+        → Ψ ⊢ ρᴸ X ≈ˣ ρᴿ Y
+
+  open RenameRelocation
+
+  bothᵣ : ∀ {Δᴸ Δᴿ Δᴸ′ Δᴿ′ ρᴸ ρᴿ}
+      {Φ : ImpCtx Δᴸ Δᴿ} {Ψ : ImpCtx Δᴸ′ Δᴿ′}
+    → RenameRelocation ρᴸ ρᴿ Φ Ψ
+    → RenameRelocation (extᵗ ρᴸ) (extᵗ ρᴿ)
+        (bothᵢ Φ) (bothᵢ Ψ)
+  bothᵣ (rename-relocation hᴸ hᴿ paired) =
+    rename-relocation (TyRenameWf-ext hᴸ) (TyRenameWf-ext hᴿ)
+      both-paired
+    where
+    both-paired : ∀ {X Y}
+      → bothᵢ _ ⊢ X ≈ˣ Y
+      → bothᵢ _ ⊢ extᵗ _ X ≈ˣ extᵗ _ Y
+    both-paired hereᵢ = hereᵢ
+    both-paired (both-thereᵢ X≈Y) = both-thereᵢ (paired X≈Y)
+
+  rename-relocation-type :
+      ∀ {Δᴸ Δᴿ Δᴸ′ Δᴿ′ ρᴸ ρᴿ A B}
+        {Φ : ImpCtx Δᴸ Δᴿ} {Ψ : ImpCtx Δᴸ′ Δᴿ′}
+    → RenameRelocation ρᴸ ρᴿ Φ Ψ
+    → Φ ⊢ A ≈ B
+    → Ψ ⊢ renameᵗ ρᴸ A ≈ renameᵗ ρᴿ B
+  rename-relocation-type r
+      (idᵃ (＇ X) (＇ Y) hX hY (varᵃ X≈Y)) =
+    idᵃ (＇ _) (＇ _)
+      (renameᵗ-preserves-WfTy hX (left-wfᵣ r))
+      (renameᵗ-preserves-WfTy hY (right-wfᵣ r))
+      (varᵃ (pairedᵣ r X≈Y))
+  rename-relocation-type r (idᵃ (‵ ι) (‵ .ι) hι hι′ baseᵃ) =
+    idᵃ (‵ ι) (‵ ι)
+      (renameᵗ-preserves-WfTy hι (left-wfᵣ r))
+      (renameᵗ-preserves-WfTy hι′ (right-wfᵣ r)) baseᵃ
+  rename-relocation-type r (idᵃ ★ ★ h★ h★′ starᵃ) =
+    idᵃ ★ ★
+      (renameᵗ-preserves-WfTy h★ (left-wfᵣ r))
+      (renameᵗ-preserves-WfTy h★′ (right-wfᵣ r)) starᵃ
+  rename-relocation-type r (p ⇒ʳ q) =
+    rename-relocation-type r p ⇒ʳ rename-relocation-type r q
+  rename-relocation-type r (∀ʳ p) =
+    ∀ʳ (rename-relocation-type (bothᵣ r) p)
+
+  left-shiftᵣ : ∀ {Δᴸ Δᴿ} {Φ : ImpCtx Δᴸ Δᴿ}
+    → RenameRelocation suc (λ X → X) Φ (freshᴸ Φ)
+  left-shiftᵣ =
+    rename-relocation TyRenameWf-suc (λ X<Δ → X<Δ)
+      freshᴸ-thereᵢ
+
+⇑ᴸʳ : ∀ {Δᴸ Δᴿ A B} {Φ : ImpCtx Δᴸ Δᴿ}
+  → Φ ⊢ A ≈ B
+  → freshᴸ Φ ⊢ ⇑ᵗ A ≈ B
+⇑ᴸʳ {A = A} {B = B} {Φ = Φ} p =
+  subst (λ B′ → freshᴸ Φ ⊢ ⇑ᵗ A ≈ B′)
+    (renameᵗ-id B) (rename-relocation-type left-shiftᵣ p)
+
+------------------------------------------------------------------------
+-- Type-store and environment extension on the left
+------------------------------------------------------------------------
+
+⇑ᴸˢ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ} {Φ : ImpCtx Δᴸ Δᴿ}
+  → Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ
+  → freshᴸ Φ ∣ suc Δᴸ ⊢ ⟰ᵗ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ
+⇑ᴸˢ []ˢ = []ˢ
+⇑ᴸˢ (bothˢ X≈Y p σ) =
+  bothˢ (freshᴸ-thereᵢ X≈Y) (⇑ᴸʳ p) (⇑ᴸˢ σ)
+⇑ᴸˢ (leftˢ X<Δ σ) = leftˢ (s≤s X<Δ) (⇑ᴸˢ σ)
+⇑ᴸˢ (rightˢ Yᴿ hB σ) =
+  rightˢ (freshᴸ-thereᴿ Yᴿ) hB (⇑ᴸˢ σ)
+
+bind-leftᵉ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+  → NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}
+  → NarrowingEnv (freshᴸ Φ)
+      {(zero , ★) ∷ ⟰ᵗ Σᴸ} {Σᴿ} {[]} {[]}
+bind-leftᵉ (env μᴸ σ μᴿ []ᵍ) =
+  env (instᵈ μᴸ) (leftˢ z<s (⇑ᴸˢ σ)) μᴿ []ᵍ
+
+------------------------------------------------------------------------
+-- Evidence for a sequence of left environment changes
+------------------------------------------------------------------------
+
+data LeftEnvChange
+    {Δᴸ Δᴿ Σᴸ Σᴿ} {Φ : ImpCtx Δᴸ Δᴿ}
+    (ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}) :
+    (χs : StoreChanges)
+    → NarrowingEnv (χs ▶ᵢ Φ)
+        {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}
+    → Set₁ where
+
+  left-done : LeftEnvChange ρ [] ρ
+
+  left-keep : ∀ {χs ρ′}
+    → LeftEnvChange ρ χs ρ′
+    → LeftEnvChange ρ (keep ∷ χs) ρ′
+
+  left-bind : ∀ {χs ρ′}
+    → LeftEnvChange (bind-leftᵉ ρ) χs ρ′
+    → LeftEnvChange ρ (bind ★ ∷ χs) ρ′
+
+------------------------------------------------------------------------
+-- Narrowing and widening transport through the recorded changes
+------------------------------------------------------------------------
+
+left-shift-modeⁿ : ∀ {μ Δ Σ A B}
+  → μ ∣ Δ ∣ Σ ⊢ A ⊒ B
+  → instᵈ μ ∣ suc Δ ∣ (zero , ★) ∷ ⟰ᵗ Σ
+      ⊢ ⇑ᵗ A ⊒ ⇑ᵗ B
+left-shift-modeⁿ (c , c⊒) =
+  ⇑ᶜ c , weaken-storeⁿ add-head
+    (renameⁿ suc predᵗ TyRenameWf-suc modeRename-suc-inst
+      RenameLeftInverse-suc c⊒)
+  where
+  modeRename-suc-inst : ∀ {μ} → ModeRename suc μ (instᵈ μ)
+  modeRename-suc-inst X = refl
+
+  add-head : ∀ {Σ X A}
+    → (X , A) ∈ Σ
+    → (X , A) ∈ ((zero , ★) ∷ Σ)
+  add-head X,A∈Σ = there X,A∈Σ
+
+left-shift-modeʷ : ∀ {μ Δ Σ A B}
+  → μ ∣ Δ ∣ Σ ⊢ A ⊑ B
+  → instᵈ μ ∣ suc Δ ∣ (zero , ★) ∷ ⟰ᵗ Σ
+      ⊢ ⇑ᵗ A ⊑ ⇑ᵗ B
+left-shift-modeʷ (c , c⊑) =
+  ⇑ᶜ c , weaken-storeʷ add-head
+    (renameʷ suc predᵗ TyRenameWf-suc modeRename-suc-inst
+      RenameLeftInverse-suc c⊑)
+  where
+  modeRename-suc-inst : ∀ {μ} → ModeRename suc μ (instᵈ μ)
+  modeRename-suc-inst X = refl
+
+  add-head : ∀ {Σ X A}
+    → (X , A) ∈ Σ
+    → (X , A) ∈ ((zero , ★) ∷ Σ)
+  add-head X,A∈Σ = there X,A∈Σ
+
+bind-leftⁿ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    (ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]})
+  → ρ ⊢ᴸⁿ A ⊒ B
+  → bind-leftᵉ ρ ⊢ᴸⁿ ⇑ᵗ A ⊒ ⇑ᵗ B
+bind-leftⁿ (env μᴸ σ μᴿ []ᵍ) p = left-shift-modeⁿ p
+
+bind-leftʷ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    (ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]})
+  → Σ[ c ∈ Coercion ] ρ ⊢ᴸʷ c ⦂ A ⊑ B
+  → Σ[ c ∈ Coercion ]
+      bind-leftᵉ ρ ⊢ᴸʷ c ⦂ ⇑ᵗ A ⊑ ⇑ᵗ B
+bind-leftʷ (env μᴸ σ μᴿ []ᵍ) p = left-shift-modeʷ p
+
+bind-left-rightⁿ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    (ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]})
+  → ρ ⊢ᴿⁿ A ⊒ B
+  → bind-leftᵉ ρ ⊢ᴿⁿ A ⊒ B
+bind-left-rightⁿ (env μᴸ σ μᴿ []ᵍ) p = p
+
+left-changeⁿ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B χs}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {ρ′ : NarrowingEnv (χs ▶ᵢ Φ)
+      {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}}
+  → LeftEnvChange ρ χs ρ′
+  → ρ ⊢ᴸⁿ A ⊒ B
+  → ρ′ ⊢ᴸⁿ χs ▶ᵗ A ⊒ χs ▶ᵗ B
+left-changeⁿ left-done p = p
+left-changeⁿ (left-keep changes) p = left-changeⁿ changes p
+left-changeⁿ {ρ = ρ} (left-bind changes) p =
+  left-changeⁿ changes (bind-leftⁿ ρ p)
+
+left-changeʷ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B χs}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {ρ′ : NarrowingEnv (χs ▶ᵢ Φ)
+      {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}}
+  → LeftEnvChange ρ χs ρ′
+  → Σ[ c ∈ Coercion ] ρ ⊢ᴸʷ c ⦂ A ⊑ B
+  → Σ[ c ∈ Coercion ]
+      ρ′ ⊢ᴸʷ c ⦂ χs ▶ᵗ A ⊑ χs ▶ᵗ B
+left-changeʷ left-done p = p
+left-changeʷ (left-keep changes) p = left-changeʷ changes p
+left-changeʷ {ρ = ρ} (left-bind changes) p =
+  left-changeʷ changes (bind-leftʷ ρ p)
+
+left-changeʳ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B χs}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {ρ′ : NarrowingEnv (χs ▶ᵢ Φ)
+      {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}}
+  → LeftEnvChange ρ χs ρ′
+  → Φ ⊢ A ≈ B
+  → (χs ▶ᵢ Φ) ⊢ χs ▶ᵗ A ≈ B
+left-changeʳ left-done p = p
+left-changeʳ (left-keep changes) p = left-changeʳ changes p
+left-changeʳ (left-bind changes) p =
+  left-changeʳ changes (⇑ᴸʳ p)
+
+right-changeⁿ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B χs}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {ρ′ : NarrowingEnv (χs ▶ᵢ Φ)
+      {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}}
+  → LeftEnvChange ρ χs ρ′
+  → ρ ⊢ᴿⁿ A ⊒ B
+  → ρ′ ⊢ᴿⁿ A ⊒ B
+right-changeⁿ left-done p = p
+right-changeⁿ (left-keep changes) p = right-changeⁿ changes p
+right-changeⁿ {ρ = ρ} (left-bind changes) p =
+  right-changeⁿ changes (bind-left-rightⁿ ρ p)
+
+left-changeⁿ-coercion : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B χs}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {ρ′ : NarrowingEnv (χs ▶ᵢ Φ)
+      {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}}
+    (changes : LeftEnvChange ρ χs ρ′)
+    (p : ρ ⊢ᴸⁿ A ⊒ B)
+  → proj₁ (left-changeⁿ changes p) ≡ χs ▶ᶜ proj₁ p
+left-changeⁿ-coercion left-done p = refl
+left-changeⁿ-coercion (left-keep changes) p =
+  left-changeⁿ-coercion changes p
+left-changeⁿ-coercion
+    {ρ = env μᴸ σ μᴿ []ᵍ} (left-bind changes) (c , c⊒) =
+  left-changeⁿ-coercion changes
+    (bind-leftⁿ (env μᴸ σ μᴿ []ᵍ) (c , c⊒))
+
+left-changeʷ-coercion : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ A B χs}
+    {Φ : ImpCtx Δᴸ Δᴿ}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {ρ′ : NarrowingEnv (χs ▶ᵢ Φ)
+      {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]}}
+    (changes : LeftEnvChange ρ χs ρ′)
+    (p : Σ[ c ∈ Coercion ] ρ ⊢ᴸʷ c ⦂ A ⊑ B)
+  → proj₁ (left-changeʷ changes p) ≡ χs ▶ᶜ proj₁ p
+left-changeʷ-coercion left-done p = refl
+left-changeʷ-coercion (left-keep changes) p =
+  left-changeʷ-coercion changes p
+left-changeʷ-coercion
+    {ρ = env μᴸ σ μᴿ []ᵍ} (left-bind changes) (c , c⊑) =
+  left-changeʷ-coercion changes
+    (bind-leftʷ (env μᴸ σ μᴿ []ᵍ) (c , c⊑))

--- a/GTPLC/proof/LeftNarrowWiden.agda
+++ b/GTPLC/proof/LeftNarrowWiden.agda
@@ -4,7 +4,7 @@ module proof.LeftNarrowWiden where
 --   * States the GTPLC Left Narrowing and Left Widening formulas.
 --   * Tracks store changes produced while a cast on the left reduces.
 --   * Requires the resulting value to remain related to the right value.
---   * Uses endpoint matching instead of coercion duality or equations.
+--   * Shares relocation and right narrowing across the left cast square.
 
 open import Data.List using ([]; _∷_)
 open import Data.Product using (_×_; _,_; ∃-syntax; Σ-syntax)
@@ -14,23 +14,13 @@ open import TyStore
 open import Coercions
 open import Terms
 open import Reduction
-open import TypeNarrow
+open import TypeRelocate
 open import NarrowWiden
+open import FactoredTypeNarrowing
 open import EnvironmentNarrowing
+open import ImprecisionTheorems using (dualʷ; _⨟ⁿ_)
 open import TermNarrowing
-
-------------------------------------------------------------------------
--- Left-side store changes
-------------------------------------------------------------------------
-
-leftChangesᵢ : (χs : StoreChanges) → ∀ {Δᴸ Δᴿ}
-  → ImpCtx Δᴸ Δᴿ
-  → ImpCtx (χs ▶ᵈ Δᴸ) Δᴿ
-leftChangesᵢ [] Φ = Φ
-leftChangesᵢ (keep ∷ χs) Φ = leftChangesᵢ χs Φ
-leftChangesᵢ (bind A ∷ χs) Φ = leftChangesᵢ χs (freshᴸ Φ)
-
-syntax leftChangesᵢ χs Φ = χs ▶ᵢ Φ
+open import proof.LeftEnvironmentChange
 
 ------------------------------------------------------------------------
 -- Left Narrowing
@@ -38,24 +28,32 @@ syntax leftChangesᵢ χs Φ = χs ▶ᵢ Φ
 
 LeftNarrowing : Set₁
 LeftNarrowing =
-  ∀ {Δᴸ Δᴿ Σᴸ Σᴿ V V′ A B D d μ}
+  ∀ {Δᴸ Δᴿ Σᴸ Σᴿ V V′ A B C C′ D d}
     {Φ : ImpCtx Δᴸ Δᴿ}
-    {σ : Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ}
-    {r : Φ ⊢ A ⊒ B}
-    {p : Φ ⊢ D ⊒ B}
-    {d⊒ : μ ∣ Δᴸ ∣ Σᴸ ⊢ d ⦂ A ⊒ D}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+    {qᴸ : ρ ⊢ᴸⁿ D ⊒ C}
+    {relocation : Φ ⊢ C ≈ C′}
+    {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B}
+    {d⊒ : ρ ⊢ᴸⁿ d ⦂ A ⊒ D}
+  → StoreWf Δᴸ Σᴸ
+  → StoreWf Δᴿ Σᴿ
   → Value V
   → Value V′
-  → (Φ ∣ σ ∣ []ᵍ) ⊢ᴺ V ⊒ V′ ∶ r
-  → d⊒ ⨟ p ≈ r
+  → ρ ⊢ᴺ V ⊒ V′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → ((d , d⊒) ⨟ⁿ qᴸ) ≐ⁿ pᴸ
   → ∃[ χs ] ∃[ W ]
       (V ⟨ d ⟩ —↠[ χs ] W)
     × Value W
-    × Σ[ σ′ ∈
-        χs ▶ᵢ Φ ∣ χs ▶ᵈ Δᴸ
-          ⊢ χs ▶ˢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ ]
-      Σ[ p′ ∈ χs ▶ᵢ Φ ⊢ χs ▶ᵗ D ⊒ B ]
-        ((χs ▶ᵢ Φ ∣ σ′ ∣ []ᵍ) ⊢ᴺ W ⊒ V′ ∶ p′)
+    × StoreWf (χs ▶ᵈ Δᴸ) (χs ▶ˢ Σᴸ)
+    × Σ[ ρ′ ∈ NarrowingEnv (χs ▶ᵢ Φ)
+        {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]} ]
+      Σ[ changes ∈ LeftEnvChange ρ χs ρ′ ]
+        Σ[ qᴸ′ ∈ ρ′ ⊢ᴸⁿ χs ▶ᵗ D ⊒ χs ▶ᵗ C ]
+          Σ[ relocation′ ∈ (χs ▶ᵢ Φ) ⊢ χs ▶ᵗ C ≈ C′ ]
+            Σ[ pᴿ′ ∈ ρ′ ⊢ᴿⁿ C′ ⊒ B ]
+              ρ′ ⊢ᴺ W ⊒ V′
+                ∶ (qᴸ′ ⨟ᶠ relocation′ ⨟ᶠ pᴿ′)
 
 ------------------------------------------------------------------------
 -- Left Widening
@@ -63,21 +61,29 @@ LeftNarrowing =
 
 LeftWidening : Set₁
 LeftWidening =
-  ∀ {Δᴸ Δᴿ Σᴸ Σᴿ V V′ A B D u μ}
+  ∀ {Δᴸ Δᴿ Σᴸ Σᴿ V V′ A B C C′ D u}
     {Φ : ImpCtx Δᴸ Δᴿ}
-    {σ : Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ}
-    {p : Φ ⊢ A ⊒ B}
-    {r : Φ ⊢ D ⊒ B}
-    {u⊑ : μ ∣ Δᴸ ∣ Σᴸ ⊢ u ⦂ A ⊑ D}
+    {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {[]} {[]}}
+    {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+    {qᴸ : ρ ⊢ᴸⁿ D ⊒ C}
+    {relocation : Φ ⊢ C ≈ C′}
+    {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B}
+    {u⊑ : ρ ⊢ᴸʷ u ⦂ A ⊑ D}
+  → StoreWf Δᴸ Σᴸ
+  → StoreWf Δᴿ Σᴿ
   → Value V
   → Value V′
-  → (Φ ∣ σ ∣ []ᵍ) ⊢ᴺ V ⊒ V′ ∶ p
-  → u⊑ ⨟ p ≈ r
+  → ρ ⊢ᴺ V ⊒ V′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → (dualʷ (u , u⊑) ⨟ⁿ pᴸ) ≐ⁿ qᴸ
   → ∃[ χs ] ∃[ W ]
       (V ⟨ u ⟩ —↠[ χs ] W)
     × Value W
-    × Σ[ σ′ ∈
-        χs ▶ᵢ Φ ∣ χs ▶ᵈ Δᴸ
-          ⊢ χs ▶ˢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ ]
-      Σ[ r′ ∈ χs ▶ᵢ Φ ⊢ χs ▶ᵗ D ⊒ B ]
-        ((χs ▶ᵢ Φ ∣ σ′ ∣ []ᵍ) ⊢ᴺ W ⊒ V′ ∶ r′)
+    × StoreWf (χs ▶ᵈ Δᴸ) (χs ▶ˢ Σᴸ)
+    × Σ[ ρ′ ∈ NarrowingEnv (χs ▶ᵢ Φ)
+        {χs ▶ˢ Σᴸ} {Σᴿ} {[]} {[]} ]
+      Σ[ changes ∈ LeftEnvChange ρ χs ρ′ ]
+        Σ[ qᴸ′ ∈ ρ′ ⊢ᴸⁿ χs ▶ᵗ D ⊒ χs ▶ᵗ C ]
+          Σ[ relocation′ ∈ (χs ▶ᵢ Φ) ⊢ χs ▶ᵗ C ≈ C′ ]
+            Σ[ pᴿ′ ∈ ρ′ ⊢ᴿⁿ C′ ⊒ B ]
+              ρ′ ⊢ᴺ W ⊒ V′
+                ∶ (qᴸ′ ⨟ᶠ relocation′ ⨟ᶠ pᴿ′)

--- a/GTPLC/proof/LeftNarrowWidenProof.agda
+++ b/GTPLC/proof/LeftNarrowWidenProof.agda
@@ -1,65 +1,200 @@
 module proof.LeftNarrowWidenProof where
 
 -- File Charter:
---   * Proves the administrative and inert Left Narrowing/Widening cases.
---   * Uses one-context cast evidence directly.
---   * Uses endpoint matching instead of coercion duality or equations.
---   * Leaves the active tag, seal, and instantiation cases open.
+--   * Proves Left Narrowing and Left Widening for values.
+--   * Uses one-context narrowing equations on the changing left factor.
+--   * Delegates active tag and seal cancellation to inversion lemmas.
 
 open import Data.List using ([]; _∷_)
-open import Data.Product using (_,_)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Relation.Binary.PropositionalEquality
+  using (refl; sym; trans)
 
 open import Coercions
 open import Terms
 open import Reduction
+open import TypeRelocate
 open import NarrowWiden
-open import EnvironmentNarrowing using ([]ᵍ)
+open import FactoredTypeNarrowing
+open import EnvironmentNarrowing
+open import ImprecisionTheorems using (dualʷ; _⨟ⁿ_)
 open import TermNarrowing
 open import proof.LeftNarrowWiden
+open import proof.LeftEnvironmentChange
+open import proof.LeftWideningSealInversion
+open import proof.LeftWideningTagInversion
+open import proof.ImprecisionComposition using (untag-seq-composeⁿ)
+open import proof.NarrowWidenDeterminism using (narrowing-determined)
+open import proof.Progress using
+  ( canonical-★
+  ; canonical-tyvar
+  ; DynValue
+  ; SealValue
+  ; sv-tag
+  ; sv-seal
+  )
+open import proof.TermNarrowingTyping using
+  (term-narrowing-source-typing)
 
 ------------------------------------------------------------------------
 -- Left Narrowing
 ------------------------------------------------------------------------
 
 left-narrowing : LeftNarrowing
-left-narrowing {V = V} {σ = σ} {r = r}
-    {d⊒ = idᵃ a hA} vV vV′ V⊒V′ eq =
+left-narrowing {V = V} {ρ = ρ}
+    {pᴸ = pᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = idᵃ a hA} wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   (keep ∷ []) , V ,
   ↠-step (pure-step (β-id vV)) ↠-refl ,
-  vV , σ , r , V⊒V′
-left-narrowing {V = V} {d = c ↦ d} {σ = σ} {p = p}
-    {d⊒ = c⊑ ↦ d⊒} vV vV′ V⊒V′ eq =
+  vV , wfΣᴸ , ρ , left-keep left-done ,
+  pᴸ , relocation , pᴿ , V⊒V′
+left-narrowing {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = _↦_ {c = c} {d = d} c⊑ d⊒}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ c ↦ d ⟩ , ↠-refl , (vV ⟨ c ↦ d ⟩) ,
-  σ , p ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castⁿ⊒ {s⦂ = c⊑ ↦ d⊒} V⊒V′ eq
-left-narrowing {V = V} {d = `∀ c} {σ = σ} {p = p}
-    {d⊒ = ∀ⁿ c⊒} vV vV′ V⊒V′ eq =
+left-narrowing {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = ∀ⁿ_ {c = c} c⊒} wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ `∀ c ⟩ , ↠-refl , (vV ⟨ `∀ c ⟩) ,
-  σ , p ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castⁿ⊒ {s⦂ = ∀ⁿ c⊒} V⊒V′ eq
 left-narrowing
+    {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
     {d⊒ = untag G hG allowed G꞉B}
-    vV vV′ V⊒V′ eq =
-  {!!}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    with canonical-★ vV (term-narrowing-source-typing V⊒V′)
 left-narrowing
-    {d⊒ = untag-seq G hG allowed G꞉A c⊒ A≢B}
-    vV vV′ V⊒V′ eq =
-  {!!}
-left-narrowing {V = V} {d = seal X} {σ = σ} {p = p}
-    {d⊒ = seal X<Δ hA X,A∈Σ allowed}
-    vV vV′ V⊒V′ eq =
+    {ρ = ρ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = untag G hG allowed G꞉B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-tag {W = W} {G = H} vW refl
+    with left-widening-tag-inversion-match
+      {H = G} {v⊑ = tag G hG allowed G꞉B} {pᴸ = qᴸ}
+      wfΣᴸ vW vV′ V⊒V′ eq
+left-narrowing
+    {ρ = ρ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = untag G hG allowed G꞉B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-tag {W = W} {.G} vW refl
+    | refl , qᴸ′ , qᴸ′≐qᴸ , W⊒V′ =
+  (keep ∷ []) , W ,
+  ↠-step (pure-step (tag-untag-ok vW)) ↠-refl ,
+  vW , wfΣᴸ , ρ , left-keep left-done ,
+  qᴸ′ , relocation , pᴿ , W⊒V′
+left-narrowing
+    {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = untag-seq {c = c} G hG allowed G꞉A c⊒ nonvarB A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    with canonical-★ vV (term-narrowing-source-typing V⊒V′)
+left-narrowing
+    {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = untag-seq {c = c} G hG allowed G꞉A c⊒ nonvarB A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-tag {W = W} {G = H} vW refl
+    with left-widening-tag-inversion-match
+      {H = G} {v⊑ = tag G hG allowed G꞉A}
+      {pᴸ = (c , c⊒) ⨟ⁿ qᴸ} {qᴸ = pᴸ}
+      wfΣᴸ vW vV′ V⊒V′
+      (trans
+        (sym (untag-seq-composeⁿ
+          {G = G} {c = c} {d = proj₁ qᴸ}
+          {hG = hG} {allowed = allowed} {G꞉A = G꞉A}
+          {p = c⊒} {nonvarB = nonvarB}
+          {A≢B = A≢B} {q = proj₂ qᴸ}))
+        eq)
+left-narrowing
+    {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = untag-seq {c = c} G hG allowed G꞉A c⊒ nonvarB A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-tag {W = W} {.G} vW refl
+    | refl , rᴸ , rᴸ≐c⨟qᴸ , W⊒V′
+    with left-narrowing
+      {ρ = ρ} {pᴸ = rᴸ} {qᴸ = qᴸ}
+      {relocation = relocation} {pᴿ = pᴿ} {d⊒ = c⊒}
+      wfΣᴸ wfΣᴿ vW vV′ W⊒V′ (sym rᴸ≐c⨟qᴸ)
+left-narrowing
+    {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = untag-seq {c = c} G hG allowed G꞉A c⊒ nonvarB A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-tag {W = W} {.G} vW refl
+    | refl , rᴸ , rᴸ≐c⨟qᴸ , W⊒V′
+    | χs , Z , Wc—↠Z , vZ , wfΣᴸ′ , ρ′ , changes ,
+      qᴸ′ , relocation′ , pᴿ′ , Z⊒V′ =
+  (keep ∷ keep ∷ χs) , Z ,
+  ↠-step (pure-step (β-seq vV))
+    (↠-step
+      (ξ-⟨⟩ (pure-step (tag-untag-ok vW)))
+      Wc—↠Z) ,
+  vZ , wfΣᴸ′ , ρ′ , left-keep (left-keep changes) ,
+  qᴸ′ , relocation′ , pᴿ′ , Z⊒V′
+left-narrowing {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = seal {X = X} X<Δ hA X,A∈Σ allowed}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ seal X ⟩ , ↠-refl , (vV ⟨ seal X ⟩) ,
-  σ , p ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castⁿ⊒ {s⦂ = seal X<Δ hA X,A∈Σ allowed} V⊒V′ eq
 left-narrowing
-    {d⊒ = seal-seq c⊒ X<Δ X,B∈Σ allowed A≢B}
-    vV vV′ V⊒V′ eq =
-  {!!}
-left-narrowing {V = V} {d = gen c} {σ = σ} {p = p}
-    {d⊒ = gen nonvarA zero∈A hB c⊒ B≢★}
-    vV vV′ V⊒V′ eq =
+    {V = V} {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = seal-seq {X = X} {c = c}
+      c⊒ X<Δ X,B∈Σ allowed A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    with left-narrowing
+      {ρ = ρ} {pᴸ = pᴸ} {qᴸ = seal-bundle ⨟ⁿ qᴸ}
+      {relocation = relocation} {pᴿ = pᴿ} {d⊒ = c⊒}
+      wfΣᴸ wfΣᴿ vV vV′ V⊒V′
+      (narrowing-determined wfΣᴸ
+        ((c , c⊒) ⨟ⁿ (seal-bundle ⨟ⁿ qᴸ)) pᴸ)
+  where
+  seal-bundle = seal X , seal X<Δ (⊒-tgt-wf c⊒) X,B∈Σ allowed
+left-narrowing
+    {V = V} {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = seal-seq {X = X} {c = c}
+      c⊒ X<Δ X,B∈Σ allowed A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | χs , Z , Vc—↠Z , vZ , wfΣᴸ′ , ρ′ , changes ,
+      rᴸ , relocation′ , rᴿ , Z⊒V′ =
+  (keep ∷ χs) ,
+  Z ⟨ proj₁ (left-changeⁿ changes seal-bundle) ⟩ ,
+  ↠-step (pure-step (β-seq vV))
+    (Relation.Binary.PropositionalEquality.subst
+      (λ d → V ⟨ c ⟩ ⟨ seal X ⟩ —↠[ χs ] Z ⟨ d ⟩)
+      (sym (left-changeⁿ-coercion changes seal-bundle))
+      (cast-trace Vc—↠Z)) ,
+  Relation.Binary.PropositionalEquality.subst
+    (λ d → Value (Z ⟨ d ⟩))
+    (sym (left-changeⁿ-coercion changes seal-bundle))
+    (vZ ⟨ leftChanges-preserves-Inert χs (seal X) ⟩) ,
+  wfΣᴸ′ , ρ′ , left-keep changes ,
+  left-changeⁿ changes qᴸ , relocation′ , rᴿ ,
+  castⁿ⊒ {s⦂ = proj₂ (left-changeⁿ changes seal-bundle)} Z⊒V′
+    (narrowing-determined wfΣᴸ′
+      (left-changeⁿ changes seal-bundle ⨟ⁿ left-changeⁿ changes qᴸ)
+      rᴸ)
+  where
+  seal-bundle = seal X , seal X<Δ (⊒-tgt-wf c⊒) X,B∈Σ allowed
+left-narrowing {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {d⊒ = gen {c = c} nonvarA zero∈A hB c⊒ B≢★}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ gen c ⟩ , ↠-refl , (vV ⟨ gen c ⟩) ,
-  σ , p ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castⁿ⊒
     {s⦂ = gen nonvarA zero∈A hB c⊒ B≢★}
     V⊒V′ eq
@@ -69,39 +204,151 @@ left-narrowing {V = V} {d = gen c} {σ = σ} {p = p}
 ------------------------------------------------------------------------
 
 left-widening : LeftWidening
-left-widening {V = V} {σ = σ} {p = p}
-    {u⊑ = idᵃ a hA} vV vV′ V⊒V′ eq =
+left-widening {V = V} {ρ = ρ}
+    {pᴸ = pᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = idᵃ a hA} wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   (keep ∷ []) , V ,
   ↠-step (pure-step (β-id vV)) ↠-refl ,
-  vV , σ , p , V⊒V′
-left-widening {V = V} {u = c ↦ d} {σ = σ} {r = r}
-    {u⊑ = c⊒ ↦ d⊑} vV vV′ V⊒V′ eq =
+  vV , wfΣᴸ , ρ , left-keep left-done ,
+  pᴸ , relocation , pᴿ , V⊒V′
+left-widening {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = _↦_ {c = c} {d = d} c⊒ d⊑}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ c ↦ d ⟩ , ↠-refl , (vV ⟨ c ↦ d ⟩) ,
-  σ , r ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castʷ⊒ {s⦂ = c⊒ ↦ d⊑} V⊒V′ eq
-left-widening {V = V} {u = `∀ c} {σ = σ} {r = r}
-    {u⊑ = ∀ʷ c⊑} vV vV′ V⊒V′ eq =
+left-widening {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = ∀ʷ_ {c = c} c⊑} wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ `∀ c ⟩ , ↠-refl , (vV ⟨ `∀ c ⟩) ,
-  σ , r ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castʷ⊒ {s⦂ = ∀ʷ c⊑} V⊒V′ eq
-left-widening {V = V} {u = G !} {σ = σ} {r = r}
-    {u⊑ = tag G hG allowed G꞉A} vV vV′ V⊒V′ eq =
+left-widening {V = V} {ρ = ρ}
+    {qᴸ = qᴸ} {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = tag G hG allowed G꞉A}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   [] , V ⟨ G ! ⟩ , ↠-refl , (vV ⟨ G ! ⟩) ,
-  σ , r ,
+  wfΣᴸ , ρ , left-done ,
+  qᴸ , relocation , pᴿ ,
   castʷ⊒ {s⦂ = tag G hG allowed G꞉A} V⊒V′ eq
 left-widening
-    {u⊑ = tag-seq G c⊑ hG allowed G꞉B A≢B}
-    vV vV′ V⊒V′ eq =
-  {!!}
+    {V = V} {ρ = ρ} {pᴸ = pᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = tag-seq {c = c} G c⊑ hG allowed G꞉B nonvarA A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    with left-widening
+      {ρ = ρ} {pᴸ = pᴸ}
+      {qᴸ = dualʷ (c , c⊑) ⨟ⁿ pᴸ}
+      {relocation = relocation} {pᴿ = pᴿ} {u⊑ = c⊑}
+      wfΣᴸ wfΣᴿ vV vV′ V⊒V′ refl
 left-widening
+    {V = V} {ρ = ρ} {pᴸ = pᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = tag-seq {c = c} G c⊑ hG allowed G꞉B nonvarA A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | χs , Z , Vc—↠Z , vZ , wfΣᴸ′ , ρ′ , changes ,
+      rᴸ , relocation′ , rᴿ , Z⊒V′
+    =
+  (keep ∷ χs) ,
+  Z ⟨ proj₁ (left-changeʷ changes tag-bundle) ⟩ ,
+  ↠-step (pure-step (β-seq vV))
+    (Relation.Binary.PropositionalEquality.subst
+      (λ d → V ⟨ c ⟩ ⟨ G ! ⟩ —↠[ χs ] Z ⟨ d ⟩)
+      (sym (left-changeʷ-coercion changes tag-bundle))
+      (cast-trace Vc—↠Z)) ,
+  Relation.Binary.PropositionalEquality.subst
+    (λ d → Value (Z ⟨ d ⟩))
+    (sym (left-changeʷ-coercion changes tag-bundle))
+    (vZ ⟨ leftChanges-preserves-Inert χs (G !) ⟩) ,
+  wfΣᴸ′ , ρ′ , left-keep changes ,
+  (dualʷ (left-changeʷ changes tag-bundle) ⨟ⁿ rᴸ) ,
+  relocation′ , rᴿ ,
+  castʷ⊒
+    {s⦂ = proj₂ (left-changeʷ changes tag-bundle)}
+    Z⊒V′ refl
+  where
+  tag-bundle = G ! , tag G hG allowed G꞉B
+left-widening
+    {V = V} {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
     {u⊑ = unseal X<Δ hA X,A∈Σ allowed}
-    vV vV′ V⊒V′ eq =
-  {!!}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    with canonical-tyvar vV (term-narrowing-source-typing V⊒V′)
 left-widening
-    {u⊑ = unseal-seq X<Δ X,A∈Σ allowed c⊑ A≢B}
-    vV vV′ V⊒V′ eq =
-  {!!}
+    {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = unseal X<Δ hA X,A∈Σ allowed}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-seal {W = W} vW refl
+    with left-widening-seal-inversion
+      {u⊑ = unseal X<Δ hA X,A∈Σ allowed}
+      {pᴸ = pᴸ} {qᴸ = qᴸ}
+      wfΣᴸ vW vV′ V⊒V′ eq
+left-widening
+    {ρ = ρ} {pᴸ = pᴸ} {qᴸ = qᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = unseal X<Δ hA X,A∈Σ allowed}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-seal {W = W} vW refl
+    | qᴸ′ , qᴸ′≐qᴸ , W⊒V′ =
+  (keep ∷ []) , W ,
+  ↠-step (pure-step (seal-unseal vW)) ↠-refl ,
+  vW , wfΣᴸ , ρ , left-keep left-done ,
+  qᴸ′ , relocation , pᴿ , W⊒V′
+left-widening
+    {V = V} {ρ = ρ} {pᴸ = pᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = unseal-seq {X = X} {c = c}
+      X<Δ X,A∈Σ allowed c⊑ A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    with canonical-tyvar vV (term-narrowing-source-typing V⊒V′)
+left-widening
+    {ρ = ρ} {pᴸ = pᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = unseal-seq {X = X} {c = c}
+      X<Δ X,A∈Σ allowed c⊑ A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-seal {W = W} vW refl
+    with left-widening-seal-inversion
+      {u⊑ = unseal X<Δ (⊑-src-wf c⊑) X,A∈Σ allowed}
+      {pᴸ = pᴸ}
+      {qᴸ = dualʷ
+        (unseal X , unseal X<Δ (⊑-src-wf c⊑) X,A∈Σ allowed)
+        ⨟ⁿ pᴸ}
+      wfΣᴸ vW vV′ V⊒V′ refl
+left-widening
+    {ρ = ρ} {pᴸ = pᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = unseal-seq {X = X} {c = c}
+      X<Δ X,A∈Σ allowed c⊑ A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-seal {W = W} vW refl
+    | rᴸ , rᴸ≐unseal⨟pᴸ , W⊒V′
+    with left-widening
+      {ρ = ρ} {pᴸ = rᴸ}
+      {qᴸ = dualʷ (c , c⊑) ⨟ⁿ rᴸ}
+      {relocation = relocation} {pᴿ = pᴿ} {u⊑ = c⊑}
+      wfΣᴸ wfΣᴿ vW vV′ W⊒V′ refl
+left-widening
+    {ρ = ρ} {pᴸ = pᴸ}
+    {relocation = relocation} {pᴿ = pᴿ}
+    {u⊑ = unseal-seq {c = c} X<Δ X,A∈Σ allowed c⊑ A≢B}
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq
+    | sv-seal {W = W} vW refl
+    | rᴸ , rᴸ≐unseal⨟pᴸ , W⊒V′
+    | χs , Z , Wc—↠Z , vZ , wfΣᴸ′ , ρ′ , changes ,
+      qᴸ′ , relocation′ , pᴿ′ , Z⊒V′ =
+  (keep ∷ keep ∷ χs) , Z ,
+  ↠-step (pure-step (β-seq vV))
+    (↠-step
+      (ξ-⟨⟩ (pure-step (seal-unseal vW)))
+      Wc—↠Z) ,
+  vZ , wfΣᴸ′ , ρ′ , left-keep (left-keep changes) ,
+  qᴸ′ , relocation′ , pᴿ′ , Z⊒V′
 left-widening
     {u⊑ = inst nonvarA zero∈A hB c⊑ B≢★}
-    vV vV′ V⊒V′ eq =
+    wfΣᴸ wfΣᴿ vV vV′ V⊒V′ eq =
   {!!}

--- a/GTPLC/proof/LeftWideningSealInversion.agda
+++ b/GTPLC/proof/LeftWideningSealInversion.agda
@@ -1,141 +1,168 @@
 module proof.LeftWideningSealInversion where
 
 -- File Charter:
---   * Inverts term narrowing whose left value has a seal coercion.
---   * Uses a supplied seal-prefix composition equation.
---   * Relies on one-sided contexts to preserve the surrounding imprecision.
---   * Supports the unseal case of the Left Widening lemma.
+--   * Inverts factored term narrowing whose left value has a seal coercion.
+--   * Uses store uniqueness to identify the sealed source type.
+--   * Preserves the shared relocation and right narrowing components.
 
 open import Data.Empty using (⊥; ⊥-elim)
-open import Data.Nat using (zero; suc)
-open import Data.Product using (_×_; _,_; Σ-syntax)
+open import Data.Nat using (zero)
+open import Data.Product using (_×_; _,_; proj₂; Σ-syntax)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; sym; trans)
 
 open import Types
+open import TyStore
 open import Coercions
 open import Terms
+open import TypeRelocate
 open import NarrowWiden
+open import FactoredTypeNarrowing
 open import EnvironmentNarrowing
-open import ImprecisionTheorems using
-  ( LeftOneSidedᵢ
-  ; _⨟ˡⁿ[_]_
-  ; _≐ⁿ_
-  )
+open import ImprecisionTheorems using (dualʷ; _⨟ⁿ_)
 open import TermNarrowing
+open import proof.TyStore using (unique)
+open import proof.ImprecisionComposition using
+  ( seal-prefix-composeⁿ-evidence
+  ; shifted-variable-target-no-zero
+  )
 
-special-no-zero-variable : ∀ {Δᴸ Δᴿ X} {Φ : ImpCtx Δᴸ Δᴿ}
-  → freshᴿ Φ ⊢ X ≈ˣ zero
-  → ⊥
-special-no-zero-variable ()
+------------------------------------------------------------------------
+-- A one-context narrowing from a variable still targets a variable
+------------------------------------------------------------------------
 
-variable-target-no-zero : ∀ {Δᴸ Δᴿ X A c}
+variable-narrowing-target : ∀ {μ Δ Σ X A c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊒ A
+  → Σ[ Y ∈ TyVar ] A ≡ ＇ Y
+variable-narrowing-target (idᵃ (＇ X) hX) = X , refl
+variable-narrowing-target
+    (seal {X = Y} Y<Δ hA Y,A∈Σ allowed) =
+  Y , refl
+variable-narrowing-target
+    (seal-seq {X = Y} p Y<Δ Y,A∈Σ allowed B≢A) =
+  Y , refl
+variable-narrowing-target
+    (gen nonvarA zero∈A hX p X≢★) =
+  ⊥-elim (shifted-variable-target-no-zero p zero∈A)
+
+variable-relocation-target : ∀ {Δᴸ Δᴿ X A}
     {Φ : ImpCtx Δᴸ Δᴿ}
-  → freshᴿ Φ ∣ Δᴸ ⊢ c ⦂ ＇ X ⊒ A ⊣ suc Δᴿ
+  → Φ ⊢ ＇ X ≈ A
+  → Σ[ Y ∈ TyVar ] A ≡ ＇ Y
+variable-relocation-target
+    (idᵃ (＇ X) (＇ Y) hX hY (varᵃ X≈Y)) =
+  Y , refl
+
+factor-variable-gen-impossible :
+    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ X C A}
+      {Φ : ImpCtx Δᴸ Δᴿ}
+      {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {Γᴸ} {Γᴿ}}
+  → (r : ρ ⊢ᵀ ＇ X ⊒ C)
+  → (d : ⇑ᴿᵉ ρ ⊢ᴿⁿ ⇑ᵗ C ⊒ A)
   → zero ∈ᵗ A
   → ⊥
-variable-target-no-zero
-    (idᵃ (＇ X) (＇ zero) hA hB X≈zero)
-    var-∈ =
-  special-no-zero-variable X≈zero
-variable-target-no-zero
-    (gen nonvarA zero∈A p B≢★) X∈ =
-  variable-target-no-zero p zero∈A
+factor-variable-gen-impossible
+    (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ) (d , d⊒) zero∈A
+    with variable-narrowing-target (proj₂ pᴸ)
+factor-variable-gen-impossible
+    (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ) (d , d⊒) zero∈A
+    | y , refl with variable-relocation-target relocation
+factor-variable-gen-impossible
+    (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ) (d , d⊒) zero∈A
+    | y , refl | z , refl with variable-narrowing-target (proj₂ pᴿ)
+factor-variable-gen-impossible
+    (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ) (d , d⊒) zero∈A
+    | y , refl | z , refl | w , refl =
+  shifted-variable-target-no-zero d⊒ zero∈A
 
-no-variable-to-star-narrowing :
-    ∀ {Δᴸ Δᴿ X c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ＇ X ⊒ ★ ⊣ Δᴿ
-  → ⊥
-no-variable-to-star-narrowing
-    (idᵃ (＇ X) ★ hA hB ())
-
-no-function-to-variable-narrowing :
-    ∀ {Δᴸ Δᴿ A B Y c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ A ⇒ B ⊒ ＇ Y ⊣ Δᴿ
-  → ⊥
-no-function-to-variable-narrowing
-    (idᵃ () (＇ Y) hA hB a⊒b)
-
-no-inert-right-narrowing-to-variable :
-    ∀ {Δᴸ Δᴿ A X Y c d}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ : ImpCtx Δᴿ Δᴿ}
-  → Inert d
-  → Ψ ∣ Δᴿ ⊢ d ⦂ A ⊒ ＇ Y ⊣ Δᴿ
-  → Φ ∣ Δᴸ ⊢ c ⦂ ＇ X ⊒ A ⊣ Δᴿ
-  → ⊥
-no-inert-right-narrowing-to-variable (G !) () p
-no-inert-right-narrowing-to-variable (seal Y)
-    (seal Y⊑★) p =
-  no-variable-to-star-narrowing p
-no-inert-right-narrowing-to-variable (c ↦ d) () p
-no-inert-right-narrowing-to-variable (`∀ c) () p
-no-inert-right-narrowing-to-variable (gen c) () p
-
-no-inert-right-widening-to-variable :
-    ∀ {Δᴿ A Y u}
-      {Ψ : ImpCtx Δᴿ Δᴿ}
-  → Inert u
-  → Ψ ∣ Δᴿ ⊢ u ⦂ A ⊑ ＇ Y ⊣ Δᴿ
-  → ⊥
-no-inert-right-widening-to-variable (G !) ()
-no-inert-right-widening-to-variable (seal Y) ()
-no-inert-right-widening-to-variable (c ↦ d) ()
-no-inert-right-widening-to-variable (`∀ c) ()
-no-inert-right-widening-to-variable (gen c) ()
+------------------------------------------------------------------------
+-- Left widening seal inversion
+------------------------------------------------------------------------
 
 left-widening-seal-inversion :
-    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ X B}
+    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ X A B C C′}
       {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ : ImpCtx Δᴸ Δᴸ}
-      {σ : Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ}
-      {γ : Φ ∣ Δᴸ ⊢ Γᴸ ⊒ᵍ Γᴿ ⊣ Δᴿ}
-      {left : LeftOneSidedᵢ Φ Ψ}
-      {s⊒ : Ψ ∣ Δᴸ ⊢ seal X ⦂ ★ ⊒ ＇ X ⊣ Δᴸ}
-      {p : Φ ∣ Δᴸ ⊢ ＇ X ⊒ B ⊣ Δᴿ}
-      {r : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
+      {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {Γᴸ} {Γᴿ}}
+      {u⊑ : ρ ⊢ᴸʷ unseal X ⦂ ＇ X ⊑ A}
+      {pᴸ : ρ ⊢ᴸⁿ ＇ X ⊒ C}
+      {qᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B}
+  → StoreWf Δᴸ Σᴸ
   → Value V
   → Value V′
-  → Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-      ⊢ᴺ V ⟨ seal X ⟩ ⊒ V′ ⦂ ＇ X ⊒ B ∶ p
-  → (seal X , s⊒) ⨟ˡⁿ[ left ] p ≐ⁿ r
-  → Σ[ r′ ∈ (Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ) ]
-      (r′ ≐ⁿ r)
-    × (Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-        ⊢ᴺ V ⊒ V′ ⦂ ★ ⊒ B ∶ r′)
-left-widening-seal-inversion vV ()
-    (⊒blame M⊢) eq
-left-widening-seal-inversion vV vV′
-    (⊒Λ {p = _ , p} {z∈A = zero∈A}
-      extension preservation vW′ W⊒W′) eq =
-  ⊥-elim (variable-target-no-zero p zero∈A)
+  → ρ ⊢ᴺ V ⟨ seal X ⟩ ⊒ V′
+      ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → (dualʷ (unseal X , u⊑) ⨟ⁿ pᴸ) ≐ⁿ qᴸ
+  → Σ[ pᴸ′ ∈ ρ ⊢ᴸⁿ A ⊒ C ]
+      (pᴸ′ ≐ⁿ qᴸ)
+    × (ρ ⊢ᴺ V ⊒ V′
+        ∶ (pᴸ′ ⨟ᶠ relocation ⨟ᶠ pᴿ))
+left-widening-seal-inversion wfΣᴸ vV () (⊒blame M⊢) eq₀
 left-widening-seal-inversion
-    {p = _ , gen nonvarB zero∈B p B≢★}
-    vV vV′ V⊒V′ eq =
-  ⊥-elim (variable-target-no-zero p zero∈B)
+    {u⊑ = unseal X<Δ hA X,A∈Σ allowed} {pᴸ = pᴸ}
+    wfΣᴸ vV vV′
+    (castⁿ⊒
+      {pᴸ = qᴸ}
+      {s⦂ = seal X<Δ′ hA′ X,A′∈Σ allowed′}
+      V⊒V′ eq) eq₀
+    with unique wfΣᴸ X,A′∈Σ X,A∈Σ
 left-widening-seal-inversion
-    {s⊒ = seal X⊑★₀}
-    {p = _ , idᵃ (＇ X) (＇ Y) hX hY Y⊑X}
-    {r = r , r⊒}
-    vV vV′
-  (castⁿ⊒
-      {d⊒ = seal X⊑★}
-      {p = r′ , r′⊒}
-      left′ seal⊢ V⊒V′ eq′) eq =
-  (r′ , r′⊒) ,
-  trans (sym eq′) eq ,
+    {u⊑ = unseal X<Δ hA X,A∈Σ allowed} {pᴸ = pᴸ}
+    wfΣᴸ vV vV′
+    (castⁿ⊒
+      {pᴸ = qᴸ}
+      {s⦂ = seal X<Δ′ hA′ X,A′∈Σ allowed′}
+      V⊒V′ eq) eq₀
+    | refl =
+  qᴸ ,
+  trans (sym eq)
+    (trans
+      (seal-prefix-composeⁿ-evidence
+        {s = seal X<Δ′ hA′ X,A′∈Σ allowed′}
+        {t = seal X<Δ hA X,A∈Σ allowed}
+        {q = pᴸ})
+      eq₀) ,
   V⊒V′
+left-widening-seal-inversion {ρ = ρ}
+    {u⊑ = unseal {X = X} X<Δ hA X,A∈Σ allowed}
+    wfΣᴸ vV vV′
+    (⊒Λ {r = rᴸ ⨟ᶠ relocation ⨟ᶠ rᴿ}
+      {d = d} {z∈A = zero∈A}
+      extension vW′ W⊒W′) eq₀ =
+  ⊥-elim
+    (factor-variable-gen-impossible {ρ = ρ}
+      (rᴸ ⨟ᶠ relocation ⨟ᶠ rᴿ) d zero∈A)
+left-widening-seal-inversion {ρ = ρ}
+    {u⊑ = unseal {X = X} X<Δ hA X,A∈Σ allowed}
+    wfΣᴸ vV vV′
+    (⊒⟨ν⟩ {r = rᴸ ⨟ᶠ relocation ⨟ᶠ rᴿ}
+      {d = d} {z∈A = zero∈A}
+      vW′ W′⊢ hC c⊢ W⊒W′) eq₀ =
+  ⊥-elim
+    (factor-variable-gen-impossible {ρ = ρ}
+      (rᴸ ⨟ᶠ relocation ⨟ᶠ rᴿ) d zero∈A)
 left-widening-seal-inversion
-    {p = _ , idᵃ (＇ X) (＇ Y) hX hY Y⊑X}
-    vV (vV′ ⟨ i′ ⟩)
-    (⊒castⁿ {d′⊒ = d′⊒} {p = _ , p}
-      right′ d′⊢ V⊒V′ eq′) eq =
-  ⊥-elim (no-inert-right-narrowing-to-variable i′ d′⊒ p)
+    {u⊑ = u⊑} {pᴸ = pᴸ} {qᴸ = qᴸ} wfΣᴸ
+    vV (vW′ ⟨ i′ ⟩)
+    (⊒castⁿ {t⦂ = t⦂} W⊒W′ eq) eq₀
+    with left-widening-seal-inversion
+      {u⊑ = u⊑} {pᴸ = pᴸ} {qᴸ = qᴸ}
+      wfΣᴸ vV vW′ W⊒W′ eq₀
+left-widening-seal-inversion wfΣᴸ
+    vV (vW′ ⟨ i′ ⟩)
+    (⊒castⁿ {t⦂ = t⦂} W⊒W′ eq) eq₀
+    | qᴸ , qᴸ≐qᴸ , V⊒W′ =
+  qᴸ , qᴸ≐qᴸ , ⊒castⁿ {t⦂ = t⦂} V⊒W′ eq
 left-widening-seal-inversion
-    {p = _ , idᵃ (＇ X) (＇ Y) hX hY Y⊑X}
-    vV (vV′ ⟨ i′ ⟩)
-    (⊒castʷ {u′⊑ = u′⊑}
-      right′ u′⊢ V⊒V′ eq′) eq =
-  ⊥-elim (no-inert-right-widening-to-variable i′ u′⊑)
+    {u⊑ = u⊑} {pᴸ = pᴸ} {qᴸ = qᴸ} wfΣᴸ
+    vV (vW′ ⟨ i′ ⟩)
+    (⊒castʷ {t⦂ = t⦂} W⊒W′ eq) eq₀
+    with left-widening-seal-inversion
+      {u⊑ = u⊑} {pᴸ = pᴸ} {qᴸ = qᴸ}
+      wfΣᴸ vV vW′ W⊒W′ eq₀
+left-widening-seal-inversion wfΣᴸ
+    vV (vW′ ⟨ i′ ⟩)
+    (⊒castʷ {t⦂ = t⦂} W⊒W′ eq) eq₀
+    | qᴸ , qᴸ≐qᴸ , V⊒W′ =
+  qᴸ , qᴸ≐qᴸ , ⊒castʷ {t⦂ = t⦂} V⊒W′ eq

--- a/GTPLC/proof/LeftWideningTagInversion.agda
+++ b/GTPLC/proof/LeftWideningTagInversion.agda
@@ -1,2217 +1,350 @@
 module proof.LeftWideningTagInversion where
 
 -- File Charter:
---   * Inverts term narrowing whose left value has a widening tag.
---   * Uses a candidate untagged index and its composition equation.
---   * Excludes quotient-only counterexamples that have no untagged index.
---   * Depends on typed imprecision composition and term narrowing.
+--   * Inverts factored term narrowing whose left value has a tag coercion.
+--   * Identifies the tag from the normalized left narrowing composition.
+--   * Preserves the shared relocation and right narrowing components.
 
 open import Data.Empty using (⊥; ⊥-elim)
-open import Data.Nat using (zero; suc)
-open import Data.Product using (_×_; _,_; proj₁; proj₂; Σ-syntax)
+open import Data.Bool using (true)
+open import Data.Nat using (_<_)
+open import Data.Product using (_×_; _,_; proj₁; Σ-syntax)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; _≢_; cong; cong₂; refl; sym; trans)
+  using (_≡_; cong; refl; subst; sym; trans)
 open import Relation.Nullary using (yes; no)
 
 open import Types
+open import TyStore
 open import Coercions
-open import Coercions using ()
-  renaming (id to idᶜ; _︔_ to _︔ᶜ_; _↦_ to _↦ᶜ_)
 open import Terms
+open import TypeRelocate
 open import NarrowWiden
+open import FactoredTypeNarrowing
 open import EnvironmentNarrowing
-open import ImprecisionTheorems using
-  ( dualⁿ
-  ; dualʷ
-  ; LeftOneSidedᵢ
-  ; RightOneSidedᵢ
-  ; left-compose
-  ; left-id-one-sidedᵢ
-  ; right-compose
-  ; right-id-one-sidedᵢ
-  ; _⨟ⁿ[_]_
-  ; _⨟ˡⁿ[_]_
-  ; _≐ⁿ_
-  )
+open import ImprecisionTheorems using (dualʷ; _⨟ⁿ_)
 open import TermNarrowing
-open import proof.TermNarrowing using (castⁿ⊒castⁿ)
-open import proof.ImprecisionComposition using
-  ( _⨟ᵢ_⇒_
-  ; both-both
-  ; freshᴿ-both
-  ; keepᴿ
-  ; compose-id-left
-  ; compose-right-star
-  ; composeⁿ
-  ; composeʷ
-  ; fun-idⁿ
-  ; recontext-from-funⁿ
-  ; strip-tag★⇒★
-  ; strip-untag★⇒★
-  )
+open import proof.TypeInTypeSubst using (tagged-unique)
+open import proof.NarrowWidenDeterminism using (narrowing-determined)
 
 ------------------------------------------------------------------------
--- Tag-prefix cancellation
+-- The leading untag of a normalized tag composition
 ------------------------------------------------------------------------
 
-base-target-no-member :
-    ∀ {Δᴸ Δᴿ c ι B X}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ‵ ι ⊒ B ⊣ Δᴿ
-  → X ∈ᵗ B
-  → ⊥
-base-target-no-member
-    (idᵃ (‵ ι) (‵ κ) hA hB refl) ()
-base-target-no-member
-    (gen nonvarA zero∈A p B≢★) (∈-all X∈) =
-  base-target-no-member p X∈
+data UntagPrefix (G : Tag) : Coercion → Set where
+  prefix-only : UntagPrefix G (G ？)
+  prefix-seq : ∀ {c d}
+    → UntagPrefix G c
+    → UntagPrefix G (c ︔ d)
 
-no-star-to-function-widening :
-    ∀ {Δᴸ Δᴿ c A B}
-      {Φ : ImpCtx Δᴿ Δᴸ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ★ ⊑ A ⇒ B ⊣ Δᴿ
-  → ⊥
-no-star-to-function-widening
-    (idᵃ ★ () hA hB a⊑b)
+untag-prefix-unique : ∀ {G H c}
+  → UntagPrefix G c
+  → UntagPrefix H c
+  → G ≡ H
+untag-prefix-unique prefix-only prefix-only = refl
+untag-prefix-unique (prefix-seq p) (prefix-seq q) =
+  untag-prefix-unique p q
 
-no-function-to-star-narrowing :
-    ∀ {Δᴸ Δᴿ c A B}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ A ⇒ B ⊒ ★ ⊣ Δᴿ
+tagged-narrowing-star⊥ : ∀ {μ Δ Σ G A c}
+  → G ꞉ A
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ ★
   → ⊥
-no-function-to-star-narrowing
-    (idᵃ () ★ hA hB a⊒b)
+tagged-narrowing-star⊥ (tag-var X) ()
+tagged-narrowing-star⊥ (tag-base ι) ()
+tagged-narrowing-star⊥ tag-fun ()
 
-no-base-to-star-narrowing :
-    ∀ {Δᴸ Δᴿ c ι}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ‵ ι ⊒ ★ ⊣ Δᴿ
+wrap-untag-prefix : ∀ {μ Δ Σ G A B c}
+    (hG : WfTag Δ G)
+    (allowed : tagAllowed μ G ≡ true)
+    (G꞉A : G ꞉ A)
+    (p : μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B)
+  → UntagPrefix G (proj₁ (wrap-untag hG allowed G꞉A p))
+wrap-untag-prefix hG allowed G꞉A (idᵃ (＇ X) hX) = prefix-only
+wrap-untag-prefix hG allowed (tag-var X)
+    (seal X<Δ hA X,A∈Σ seal-ok) =
+  prefix-seq prefix-only
+wrap-untag-prefix hG allowed (tag-base ι)
+    (seal X<Δ hA X,A∈Σ seal-ok) =
+  prefix-seq prefix-only
+wrap-untag-prefix hG allowed tag-fun
+    (seal X<Δ hA X,A∈Σ seal-ok) =
+  prefix-seq prefix-only
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = ＇ Y} p X<Δ X,B∈Σ seal-ok A≢B)
+    with wrap-untag-prefix hG allowed G꞉A p
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = ＇ Y} p X<Δ X,B∈Σ seal-ok A≢B) | prefix =
+  prefix-seq prefix
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = ‵ ι} p X<Δ X,B∈Σ seal-ok A≢B)
+    with wrap-untag-prefix hG allowed G꞉A p
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = ‵ ι} p X<Δ X,B∈Σ seal-ok A≢B) | prefix =
+  prefix-seq prefix
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = ★} p X<Δ X,B∈Σ seal-ok A≢B) =
+  ⊥-elim (tagged-narrowing-star⊥ G꞉A p)
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = B ⇒ C} p X<Δ X,B∈Σ seal-ok A≢B)
+    with wrap-untag-prefix hG allowed G꞉A p
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = B ⇒ C} p X<Δ X,B∈Σ seal-ok A≢B) | prefix =
+  prefix-seq prefix
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = `∀ B} p X<Δ X,B∈Σ seal-ok A≢B)
+    with wrap-untag-prefix hG allowed G꞉A p
+wrap-untag-prefix hG allowed G꞉A
+    (seal-seq {B = `∀ B} p X<Δ X,B∈Σ seal-ok A≢B) | prefix =
+  prefix-seq prefix
+wrap-untag-prefix {A = A} {B = ‵ ι} hG allowed G꞉A p
+    with A ≟Ty (‵ ι)
+wrap-untag-prefix hG allowed G꞉A p | yes refl = prefix-only
+wrap-untag-prefix hG allowed G꞉A p | no A≢B = prefix-seq prefix-only
+wrap-untag-prefix {A = A} {B = ★} hG allowed G꞉A p =
+  ⊥-elim (tagged-narrowing-star⊥ G꞉A p)
+wrap-untag-prefix {A = A} {B = B ⇒ C} hG allowed G꞉A p
+    with A ≟Ty (B ⇒ C)
+wrap-untag-prefix hG allowed G꞉A p | yes refl = prefix-only
+wrap-untag-prefix hG allowed G꞉A p | no A≢B = prefix-seq prefix-only
+wrap-untag-prefix {A = A} {B = `∀ B} hG allowed G꞉A p
+    with A ≟Ty (`∀ B)
+wrap-untag-prefix hG allowed G꞉A p | yes refl = prefix-only
+wrap-untag-prefix hG allowed G꞉A p | no A≢B = prefix-seq prefix-only
+
+dual-tag-composition-prefix : ∀ {μ Δ Σ G A B}
+    (u⊑ : μ ∣ Δ ∣ Σ ⊢ G ! ⦂ A ⊑ ★)
+    (p : μ ∣ Δ ∣ Σ ⊢ A ⊒ B)
+  → UntagPrefix G (proj₁ (dualʷ (G ! , u⊑) ⨟ⁿ p))
+dual-tag-composition-prefix
+    (tag G hG allowed G꞉A) (c , p) =
+  wrap-untag-prefix hG allowed G꞉A p
+
+dual-tag-composition-tags-equal : ∀ {μ Δ Σ G H A B C}
+    {u⊑ : μ ∣ Δ ∣ Σ ⊢ G ! ⦂ A ⊑ ★}
+    {v⊑ : μ ∣ Δ ∣ Σ ⊢ H ! ⦂ B ⊑ ★}
+    {p : μ ∣ Δ ∣ Σ ⊢ A ⊒ C}
+    {q : μ ∣ Δ ∣ Σ ⊢ B ⊒ C}
+  → proj₁ (dualʷ (G ! , u⊑) ⨟ⁿ p) ≡
+    proj₁ (dualʷ (H ! , v⊑) ⨟ⁿ q)
+  → G ≡ H
+dual-tag-composition-tags-equal {u⊑ = u⊑} {v⊑ = v⊑}
+    {p = p} {q = q} eq =
+  untag-prefix-unique
+    (dual-tag-composition-prefix u⊑ p)
+    (Relation.Binary.PropositionalEquality.subst
+      (UntagPrefix _) (sym eq)
+      (dual-tag-composition-prefix v⊑ q))
+
+------------------------------------------------------------------------
+-- Cancellation of a shared tag prefix
+------------------------------------------------------------------------
+
+tag-seal-modes-exclusive : ∀ {μ X}
+  → tagAllowed μ (＇ X) ≡ true
+  → sealModeAllowed (μ X) ≡ true
   → ⊥
-no-base-to-star-narrowing
-    (idᵃ (‵ ι) ★ hA hB ())
+tag-seal-modes-exclusive {μ} {X} tag-ok seal-ok with μ X
+tag-seal-modes-exclusive tag-ok () | id-only
+tag-seal-modes-exclusive tag-ok () | tag-or-id
+tag-seal-modes-exclusive () seal-ok | seal-or-id
 
-no-base-to-function-narrowing :
-    ∀ {Δᴸ Δᴿ c ι A B}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ‵ ι ⊒ A ⇒ B ⊣ Δᴿ
-  → ⊥
-no-base-to-function-narrowing
-    (idᵃ (‵ ι) () hA hB a⊒b)
+variable-tag-endomorphism : ∀ {μ Δ Σ X c}
+  → tagAllowed μ (＇ X) ≡ true
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊒ ＇ X
+  → c ≡ id
+variable-tag-endomorphism tag-ok (idᵃ (＇ X) hX) = refl
+variable-tag-endomorphism {μ = μ} {X = X} tag-ok
+    (seal X<Δ hX X,X∈Σ seal-ok) =
+  ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+    tag-ok seal-ok)
+variable-tag-endomorphism {μ = μ} {X = X} tag-ok
+    (seal-seq p X<Δ X,A∈Σ seal-ok X≢A) =
+  ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+    tag-ok seal-ok)
 
-no-base-to-all-narrowing :
-    ∀ {Δᴸ Δᴿ c ι A}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ‵ ι ⊒ `∀ A ⊣ Δᴿ
-  → ⊥
-no-base-to-all-narrowing
-    (idᵃ (‵ ι) () hA hB a⊒b)
-no-base-to-all-narrowing
-    (gen nonvarA zero∈A p B≢★) =
-  base-target-no-member p zero∈A
+base-tag-endomorphism : ∀ {μ Δ Σ ι c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ‵ ι ⊒ ‵ ι
+  → c ≡ id
+base-tag-endomorphism (idᵃ (‵ ι) hι) = refl
 
-no-base-to-variable-narrowing :
-    ∀ {Δᴸ Δᴿ c ι X}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ ‵ ι ⊒ ＇ X ⊣ Δᴿ
-  → ⊥
-no-base-to-variable-narrowing
-    (idᵃ (‵ ι) (＇ X) hA hB ())
+star-widening-endomorphism : ∀ {μ Δ Σ c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ★ ⊑ ★
+  → c ≡ id
+star-widening-endomorphism (idᵃ ★ h★) = refl
+star-widening-endomorphism
+    (tag-seq G p hG allowed G꞉B nonvar★ ★≢B) =
+  ⊥-elim (★≢B (sym (star-widening-target p)))
+  where
+  star-widening-target : ∀ {μ Δ Σ c B}
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ ★ ⊑ B
+    → B ≡ ★
+  star-widening-target (idᵃ ★ h★) = refl
+  star-widening-target
+    (tag-seq G q hG allowed G꞉B nonvar★ A≢B) = refl
 
-no-function-to-base-narrowing :
-    ∀ {Δᴸ Δᴿ c A B ι}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ A ⇒ B ⊒ ‵ ι ⊣ Δᴿ
-  → ⊥
-no-function-to-base-narrowing
-    (idᵃ () (‵ ι) hA hB a⊒b)
+star-narrowing-endomorphism : ∀ {μ Δ Σ c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ★ ⊒ ★
+  → c ≡ id
+star-narrowing-endomorphism (idᵃ ★ h★) = refl
+star-narrowing-endomorphism
+    (untag-seq G hG allowed G꞉A p nonvar★ A≢★) =
+  ⊥-elim (A≢★ (narrowing-target-star p))
+  where
+  narrowing-target-star : ∀ {μ Δ Σ c A}
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ ★
+    → A ≡ ★
+  narrowing-target-star (idᵃ ★ h★) = refl
+  narrowing-target-star
+      (untag-seq G hG allowed G꞉A q nonvar★ A≢★) = refl
 
-no-function-to-variable-narrowing :
-    ∀ {Δᴸ Δᴿ c A B X}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ A ⇒ B ⊒ ＇ X ⊣ Δᴿ
-  → ⊥
-no-function-to-variable-narrowing
-    (idᵃ () (＇ X) hA hB a⊒b)
-
-star-function-narrowing-coercion :
-    ∀ {Δᴸ Δᴿ c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → Φ ∣ Δᴸ ⊢ c ⦂ (★ ⇒ ★) ⊒ (★ ⇒ ★) ⊣ Δᴿ
-  → c ≡ idᶜ ↦ᶜ idᶜ
-star-function-narrowing-coercion
-    (idᵃ ★ ★ hA hB a⊒b ↦ idᵃ ★ ★ hA′ hB′ a⊒b′) =
+function-tag-endomorphism : ∀ {μ Δ Σ c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ (★ ⇒ ★) ⊒ (★ ⇒ ★)
+  → c ≡ (id ↦ id)
+function-tag-endomorphism (p ↦ q)
+    rewrite star-widening-endomorphism p
+      | star-narrowing-endomorphism q =
   refl
-star-function-narrowing-coercion
-    ((p ︔tag★⇒★[ A≢★⇒★ ]) ↦ q) =
-  ⊥-elim (no-star-to-function-widening p)
-star-function-narrowing-coercion
-    (p ↦ untag★⇒★︔ q [ ★⇒★≢B ]) =
-  ⊥-elim (no-function-to-star-narrowing q)
 
-sequence-tail-injective : ∀ {a b c}
-  → a ︔ᶜ b ≡ a ︔ᶜ c
-  → b ≡ c
+tag-endomorphism-unique : ∀ {μ Δ Σ G A c d}
+  → tagAllowed μ G ≡ true
+  → G ꞉ A
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ A
+  → μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊒ A
+  → c ≡ d
+tag-endomorphism-unique allowed (tag-var X) p q =
+  trans (variable-tag-endomorphism allowed p)
+    (sym (variable-tag-endomorphism allowed q))
+tag-endomorphism-unique allowed (tag-base ι) p q =
+  trans (base-tag-endomorphism p) (sym (base-tag-endomorphism q))
+tag-endomorphism-unique allowed tag-fun p q =
+  trans (function-tag-endomorphism p)
+    (sym (function-tag-endomorphism q))
+
+sequence-tail-injective : ∀ {c d e}
+  → (c ︔ d) ≡ (c ︔ e)
+  → d ≡ e
 sequence-tail-injective refl = refl
 
-sequence-head-injective : ∀ {a b c}
-  → a ︔ᶜ c ≡ b ︔ᶜ c
-  → a ≡ b
-sequence-head-injective refl = refl
-
-star-left-identity-composition :
-    ∀ {Δᴸ Δᴿ B}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      (i : Φ ∣ Δᴸ ⊢ idᶜ ⦂ ★ ⊒ ★ ⊣ Δᴿ)
-      (q : idᵢ Δᴿ ∣ Δᴿ ⊢ ★ ⊒ B ⊣ Δᴿ)
-  → proj₁ ((idᶜ , i) ⨟ⁿ[ right-id-one-sidedᵢ ] q) ≡ proj₁ q
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , idᵃ ★ ★ hA′ hB′ a⊒b′) =
-  refl
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , untag ι) =
-  refl
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , untag★⇒★) =
-  refl
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , untag★⇒★︔ q [ ★⇒★≢B ]) =
-  refl
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , seal X⊑★) =
-  refl
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , q ︔seal X⊑★ [ ★≢B ]) =
-  refl
-star-left-identity-composition
-    (idᵃ ★ ★ hA hB a⊒b)
-    (_ , gen nonvarA zero∈A q ★≢★) =
-  ⊥-elim (★≢★ refl)
-
-no-member-star : ∀ {X}
-  → X ∈ᵗ ★
-  → ⊥
-no-member-star ()
-
-no-member-star-function : ∀ {X}
-  → X ∈ᵗ (★ ⇒ ★)
-  → ⊥
-no-member-star-function (∈-fun-left X∈) =
-  no-member-star X∈
-no-member-star-function (∈-fun-right X∈) =
-  no-member-star X∈
-
-member-not-star-function : ∀ {A X}
-  → X ∈ᵗ A
-  → (★ ⇒ ★) ≢ A
-member-not-star-function X∈ refl =
-  no-member-star-function X∈
-
-function-tag-stripᶜ :
-    ∀ {Δᴸ Δᴿ A c}
-      {Φᴸ : ImpCtx Δᴸ Δᴿ}
-      {Φᴵ : ImpCtx Δᴸ Δᴸ}
-      {Φᴼ : ImpCtx Δᴸ Δᴿ}
-      (comp : Φᴵ ⨟ᵢ Φᴸ ⇒ Φᴼ)
-      (nonvarA : NonVar A)
-      (zero∈A : zero ∈ᵗ A)
-      (p : Φᴸ ∣ Δᴸ ⊢ c ⦂ (★ ⇒ ★) ⊒ A ⊣ Δᴿ)
-  → proj₁
-      (strip-untag★⇒★ nonvarA zero∈A
-        (proj₂
-          (composeⁿ comp (untag★⇒★ {Φ = Φᴵ}) p)))
-      ≡ c
-function-tag-stripᶜ {A = A ⇒ B} comp
-    nonvar-fun zero∈A (p₁ ↦ p₂)
-    with ★ ≟Ty A | ★ ≟Ty B
-function-tag-stripᶜ comp nonvar-fun zero∈A (p₁ ↦ p₂)
-    | yes refl | yes refl =
-  ⊥-elim (no-member-star-function zero∈A)
-function-tag-stripᶜ comp nonvar-fun zero∈A (p₁ ↦ p₂)
-    | yes ★≡A | no ★≢B =
-  refl
-function-tag-stripᶜ comp nonvar-fun zero∈A (p₁ ↦ p₂)
-    | no ★≢A | yes ★≡B =
-  refl
-function-tag-stripᶜ comp nonvar-fun zero∈A (p₁ ↦ p₂)
-    | no ★≢A | no ★≢B =
-  refl
-function-tag-stripᶜ {Δᴸ = Δᴸ} comp
-    nonvar-all (∈-all zero∈A)
-    (gen nonvarA zero∈A′ p B≢★) =
-  refl
-
-function-tag-strip :
-    ∀ {Δᴸ Δᴿ A c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      (nonvarA : NonVar A)
-      (zero∈A : zero ∈ᵗ A)
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ (★ ⇒ ★) ⊒ A ⊣ Δᴿ)
-  → proj₁
-      (strip-untag★⇒★ nonvarA zero∈A
-        (proj₂
-          (dualʷ (★⇒★ ! , tag★⇒★)
-            ⨟ˡⁿ[ left-id-one-sidedᵢ ]
-            (c , p))))
-      ≡ c
-function-tag-strip = function-tag-stripᶜ compose-id-left
-
-function-tag-gen-composition :
-    ∀ {Δᴸ Δᴿ A c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {nonvarA : NonVar A}
-      {zero∈A : zero ∈ᵗ A}
-      {p : freshᴿ Φ ∣ Δᴸ
-        ⊢ c ⦂ (★ ⇒ ★) ⊒ A ⊣ suc Δᴿ}
-      {B≢★ : (★ ⇒ ★) ≢ ★}
-  → proj₁
-      (dualʷ (★⇒★ ! , tag★⇒★)
-        ⨟ˡⁿ[ left-id-one-sidedᵢ ]
-        (Coercions.gen c ,
-          gen nonvarA zero∈A p {{freshⁿᵢ}} B≢★))
-      ≡ (★⇒★ ？) ︔ᶜ Coercions.gen c
-function-tag-gen-composition
-    {nonvarA = nonvarA} {zero∈A = zero∈A}
-    {p = p₁ ↦ p₂} =
-  refl
-function-tag-gen-composition
-    {nonvarA = nonvar-all} {zero∈A = ∈-all zero∈A}
-    {p = gen nonvarA zero∈A′ p B≢★} =
-  refl
-
-function-tag-gen-compositionᶜ :
-    ∀ {Δᴸ Δᴿ A c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ : ImpCtx Δᴸ Δᴸ}
-      (left : LeftOneSidedᵢ Φ Ψ)
-      {nonvarA : NonVar A}
-      {zero∈A : zero ∈ᵗ A}
-      {p : freshᴿ Φ ∣ Δᴸ
-        ⊢ c ⦂ (★ ⇒ ★) ⊒ A ⊣ suc Δᴿ}
-      {B≢★ : (★ ⇒ ★) ≢ ★}
-  → proj₁
-      ((★⇒★ ？ , untag★⇒★ {Φ = Ψ}) ⨟ˡⁿ[ left ]
-        (Coercions.gen c ,
-          gen nonvarA zero∈A p {{freshⁿᵢ}} B≢★))
-      ≡ (★⇒★ ？) ︔ᶜ Coercions.gen c
-function-tag-gen-compositionᶜ
-    left
-    {nonvarA = nonvarA} {zero∈A = zero∈A}
-    {p = p₁ ↦ p₂} =
-  refl
-function-tag-gen-compositionᶜ
-    left
-    {nonvarA = nonvar-all} {zero∈A = ∈-all zero∈A}
-    {p = gen nonvarA zero∈A′ p B≢★} =
-  refl
-
-function-tag-sequence :
-    ∀ {Δᴸ Δᴿ B c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ (★ ⇒ ★) ⊒ B ⊣ Δᴿ)
-      (★⇒★≢B : (★ ⇒ ★) ≢ B)
-  → proj₁
-      (dualʷ (★⇒★ ! , tag★⇒★)
-        ⨟ˡⁿ[ left-id-one-sidedᵢ ] (c , p))
-      ≡ (★⇒★ ？) ︔ᶜ c
-function-tag-sequence {B = A ⇒ B} (p₁ ↦ p₂) ★⇒★≢B
-    with ★ ≟Ty A | ★ ≟Ty B
-function-tag-sequence (p₁ ↦ p₂) ★⇒★≢B
-    | yes refl | yes refl =
-  ⊥-elim (★⇒★≢B refl)
-function-tag-sequence (p₁ ↦ p₂) ★⇒★≢B
-    | yes ★≡A | no ★≢B =
-  refl
-function-tag-sequence (p₁ ↦ p₂) ★⇒★≢B
-    | no ★≢A | yes ★≡B =
-  refl
-function-tag-sequence (p₁ ↦ p₂) ★⇒★≢B
-    | no ★≢A | no ★≢B =
-  refl
-function-tag-sequence
-    (gen nonvarA zero∈A p B≢★) ★⇒★≢∀A =
-  function-tag-gen-composition
-    {nonvarA = nonvarA} {zero∈A = zero∈A}
-    {p = p} {B≢★ = B≢★}
-
-function-tag-sequenceᶜ :
-    ∀ {Δᴸ Δᴿ B c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ : ImpCtx Δᴸ Δᴸ}
-      (left : LeftOneSidedᵢ Φ Ψ)
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ (★ ⇒ ★) ⊒ B ⊣ Δᴿ)
-      (★⇒★≢B : (★ ⇒ ★) ≢ B)
-  → proj₁
-      ((★⇒★ ？ , untag★⇒★ {Φ = Ψ}) ⨟ˡⁿ[ left ] (c , p))
-      ≡ (★⇒★ ？) ︔ᶜ c
-function-tag-sequenceᶜ {B = A ⇒ B} left
-    (p₁ ↦ p₂) ★⇒★≢B
-    with ★ ≟Ty A | ★ ≟Ty B
-function-tag-sequenceᶜ left (p₁ ↦ p₂) ★⇒★≢B
-    | yes refl | yes refl =
-  ⊥-elim (★⇒★≢B refl)
-function-tag-sequenceᶜ left (p₁ ↦ p₂) ★⇒★≢B
-    | yes ★≡A | no ★≢B =
-  refl
-function-tag-sequenceᶜ left (p₁ ↦ p₂) ★⇒★≢B
-    | no ★≢A | yes ★≡B =
-  refl
-function-tag-sequenceᶜ left (p₁ ↦ p₂) ★⇒★≢B
-    | no ★≢A | no ★≢B =
-  refl
-function-tag-sequenceᶜ left
-    (gen nonvarA zero∈A p B≢★) ★⇒★≢∀A =
-  function-tag-gen-compositionᶜ
-    left
-    {nonvarA = nonvarA} {zero∈A = zero∈A}
-    {p = p} {B≢★ = B≢★}
-
-wrap-untag-cong :
-    ∀ {Δᴸ Δᴿ B c d}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ (★ ⇒ ★) ⊒ B ⊣ Δᴿ)
-      (q : Φ ∣ Δᴸ ⊢ d ⦂ (★ ⇒ ★) ⊒ B ⊣ Δᴿ)
-  → c ≡ d
-  → proj₁ (wrap-untag★⇒★ p) ≡
-      proj₁ (wrap-untag★⇒★ q)
-wrap-untag-cong {B = B} p q eq
-    with (★ ⇒ ★) ≟Ty B
-wrap-untag-cong p q eq | yes refl =
-  refl
-wrap-untag-cong p q eq | no B≢★⇒★ =
-  cong (λ c → (★⇒★ ？) ︔ᶜ c) eq
-
-wrap-tag-cong :
-    ∀ {Δᴸ Δᴿ A c d}
-      {Φ : ImpCtx Δᴿ Δᴸ}
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ A ⊑ (★ ⇒ ★) ⊣ Δᴿ)
-      (q : Φ ∣ Δᴸ ⊢ d ⦂ A ⊑ (★ ⇒ ★) ⊣ Δᴿ)
-  → c ≡ d
-  → proj₁ (wrap-tag★⇒★ p) ≡
-      proj₁ (wrap-tag★⇒★ q)
-wrap-tag-cong {A = A} p q eq
-    with A ≟Ty (★ ⇒ ★)
-wrap-tag-cong p q eq | yes refl =
-  refl
-wrap-tag-cong p q eq | no A≢★⇒★ =
-  cong (λ c → c ︔ᶜ (★⇒★ !)) eq
-
-strip-untag-cong :
-    ∀ {Δᴸ Δᴿ B c d}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      (nonvarB : NonVar B)
-      (zero∈B : zero ∈ᵗ B)
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ ★ ⊒ B ⊣ Δᴿ)
-      (q : Φ ∣ Δᴸ ⊢ d ⦂ ★ ⊒ B ⊣ Δᴿ)
-  → c ≡ d
-  → proj₁ (strip-untag★⇒★ nonvarB zero∈B p) ≡
-      proj₁ (strip-untag★⇒★ nonvarB zero∈B q)
-strip-untag-cong nonvar-fun zero∈B
-    untag★⇒★ untag★⇒★ eq =
-  refl
-strip-untag-cong nonvar-fun zero∈B
-    (untag★⇒★︔ p [ ★⇒★≢B ])
-    (untag★⇒★︔ q [ ★⇒★≢B′ ]) eq =
-  sequence-tail-injective eq
-strip-untag-cong nonvar-all zero∈B
-    (untag★⇒★︔ p [ ★⇒★≢B ])
-    (untag★⇒★︔ q [ ★⇒★≢B′ ]) eq =
-  sequence-tail-injective eq
-strip-untag-cong nonvar-all zero∈B
-    (gen nonvarB zero∈B′ p ★≢★)
-    (gen nonvarB′ zero∈B″ q ★≢★′) eq =
-  ⊥-elim (★≢★ refl)
-
-strip-tag-cong :
-    ∀ {Δᴸ Δᴿ A c d}
-      {Φ : ImpCtx Δᴿ Δᴸ}
-      (nonvarA : NonVar A)
-      (zero∈A : zero ∈ᵗ A)
-      (p : Φ ∣ Δᴸ ⊢ c ⦂ A ⊑ ★ ⊣ Δᴿ)
-      (q : Φ ∣ Δᴸ ⊢ d ⦂ A ⊑ ★ ⊣ Δᴿ)
-  → c ≡ d
-  → proj₁ (strip-tag★⇒★ nonvarA zero∈A p) ≡
-      proj₁ (strip-tag★⇒★ nonvarA zero∈A q)
-strip-tag-cong nonvar-fun zero∈A
-    tag★⇒★ tag★⇒★ eq =
-  refl
-strip-tag-cong nonvar-fun zero∈A
-    (p ︔tag★⇒★[ A≢★⇒★ ])
-    (q ︔tag★⇒★[ A≢★⇒★′ ]) eq =
-  sequence-head-injective eq
-strip-tag-cong nonvar-all zero∈A
-    (p ︔tag★⇒★[ A≢★⇒★ ])
-    (q ︔tag★⇒★[ A≢★⇒★′ ]) eq =
-  sequence-head-injective eq
-strip-tag-cong nonvar-all zero∈A
-    (inst nonvarA zero∈A′ p ★≢★)
-    (inst nonvarA′ zero∈A″ q ★≢★′) eq =
-  ⊥-elim (★≢★ refl)
-
-star-gen-normal-cong :
-    ∀ {Δᴸ Δᴿ A c d}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      (nonvarA : NonVar A)
-      (zero∈A : zero ∈ᵗ A)
-      (p : freshᴿ Φ ∣ Δᴸ ⊢ c ⦂ ★ ⊒ A ⊣ suc Δᴿ)
-      (q : freshᴿ Φ ∣ Δᴸ ⊢ d ⦂ ★ ⊒ A ⊣ suc Δᴿ)
-  → c ≡ d
-  → proj₁
-      (wrap-untag★⇒★
-        (gen nonvarA zero∈A
-          (proj₂ (strip-untag★⇒★ nonvarA zero∈A p))
-          {{freshⁿᵢ}}
-          (λ ())))
-      ≡ proj₁
-        (wrap-untag★⇒★
-          (gen nonvarA zero∈A
-            (proj₂ (strip-untag★⇒★ nonvarA zero∈A q))
-            {{freshⁿᵢ}}
-            (λ ())))
-star-gen-normal-cong nonvarA zero∈A p q eq =
-  wrap-untag-cong
-    (gen nonvarA zero∈A
-      (proj₂ (strip-untag★⇒★ nonvarA zero∈A p))
-      {{freshⁿᵢ}}
-      (λ ()))
-    (gen nonvarA zero∈A
-      (proj₂ (strip-untag★⇒★ nonvarA zero∈A q))
-      {{freshⁿᵢ}}
-      (λ ()))
-    (cong Coercions.gen
-      (strip-untag-cong nonvarA zero∈A p q eq))
-
-star-inst-normal-cong :
-    ∀ {Δᴸ Δᴿ A c d}
-      {Φ : ImpCtx Δᴿ Δᴸ}
-      (nonvarA : NonVar A)
-      (zero∈A : zero ∈ᵗ A)
-      (p : freshᴿ Φ ∣ suc Δᴸ ⊢ c ⦂ A ⊑ ★ ⊣ Δᴿ)
-      (q : freshᴿ Φ ∣ suc Δᴸ ⊢ d ⦂ A ⊑ ★ ⊣ Δᴿ)
-  → c ≡ d
-  → proj₁
-      (wrap-tag★⇒★
-        (inst nonvarA zero∈A
-          (proj₂ (strip-tag★⇒★ nonvarA zero∈A p))
-          {{freshʷᵢ}}
-          (λ ())))
-      ≡ proj₁
-        (wrap-tag★⇒★
-          (inst nonvarA zero∈A
-            (proj₂ (strip-tag★⇒★ nonvarA zero∈A q))
-            {{freshʷᵢ}}
-            (λ ())))
-star-inst-normal-cong nonvarA zero∈A p q eq =
-  wrap-tag-cong
-    (inst nonvarA zero∈A
-      (proj₂ (strip-tag★⇒★ nonvarA zero∈A p))
-      {{freshʷᵢ}}
-      (λ ()))
-    (inst nonvarA zero∈A
-      (proj₂ (strip-tag★⇒★ nonvarA zero∈A q))
-      {{freshʷᵢ}}
-      (λ ()))
-    (cong Coercions.inst
-      (strip-tag-cong nonvarA zero∈A p q eq))
-
-special-no-zero-var : ∀ {Δᴸ Δᴿ X} {Φ : ImpCtx Δᴸ Δᴿ}
-  → freshᴿ Φ ⊢ X ≈ˣ zero
-  → ⊥
-special-no-zero-var ()
-
-variable-target-no-zero :
-    ∀ {Δᴸ Δᴿ X A c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → freshᴿ Φ ∣ Δᴸ ⊢ c ⦂ ＇ X ⊒ A ⊣ suc Δᴿ
-  → zero ∈ᵗ A
-  → ⊥
-variable-target-no-zero
-    (idᵃ (＇ X) (＇ zero) hA hB X≈zero)
-    var-∈ =
-  special-no-zero-var X≈zero
-variable-target-no-zero
-    (gen nonvarA zero∈A p B≢★) X∈ =
-  variable-target-no-zero p zero∈A
-
-widening-variable-target-no-zero :
-    ∀ {Δᴸ Δᴿ X A c}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → freshᴿ Φ ∣ suc Δᴿ ⊢ c ⦂ A ⊑ ＇ X ⊣ Δᴸ
-  → zero ∈ᵗ A
-  → ⊥
-widening-variable-target-no-zero
-    (idᵃ (＇ zero) (＇ X) hA hB X≈zero) var-∈ =
-  special-no-zero-var X≈zero
-widening-variable-target-no-zero
-    (inst nonvarA zero∈A p B≢★) X∈ =
-  widening-variable-target-no-zero p zero∈A
-
-------------------------------------------------------------------------
--- Composition ignores derivation evidence
-------------------------------------------------------------------------
-
-mutual
-
-  star-left-identity-composeᶜ :
-      ∀ {Δ₀ Δ₁ Δ₂ B d}
-        {Φ₀₁ : ImpCtx Δ₀ Δ₁}
-        {Φ₁₂ : ImpCtx Δ₁ Δ₂}
-        {Φ₀₂ : ImpCtx Δ₀ Δ₂}
-        (comp : Φ₀₁ ⨟ᵢ Φ₁₂ ⇒ Φ₀₂)
-        (i : Φ₀₁ ∣ Δ₀ ⊢ idᶜ ⦂ ★ ⊒ ★ ⊣ Δ₁)
-        (q : Φ₁₂ ∣ Δ₁ ⊢ d ⦂ ★ ⊒ B ⊣ Δ₂)
-    → proj₁ (composeⁿ comp i q) ≡ d
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b)
-      (idᵃ ★ ★ hA′ hB′ a⊒b′) =
-    refl
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b) (untag ι) =
-    refl
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b) untag★⇒★ =
-    refl
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b)
-      (untag★⇒★︔ q [ ★⇒★≢B ]) =
-    refl
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b)
-      (seal X⊑★) =
-    refl
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b)
-      (q ︔seal X⊑★ [ ★≢B ]) =
-    refl
-  star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b)
-      (gen nonvarA zero∈A q ★≢★) =
-    ⊥-elim (★≢★ refl)
-
-  star-right-identity-composeʷ :
-      ∀ {Δ₀ Δ₁ Δ₂ A c}
-        {Φ₀₁ : ImpCtx Δ₀ Δ₁}
-        {Φ₁₂ : ImpCtx Δ₁ Δ₂}
-        {Φ₀₂ : ImpCtx Δ₀ Δ₂}
-        (comp : Φ₀₁ ⨟ᵢ Φ₁₂ ⇒ Φ₀₂)
-        (p : Φ₁₂ ∣ Δ₂ ⊢ c ⦂ A ⊑ ★ ⊣ Δ₁)
-        (i : Φ₀₁ ∣ Δ₁ ⊢ idᶜ ⦂ ★ ⊑ ★ ⊣ Δ₀)
-    → proj₁ (composeʷ comp p i) ≡ c
-  star-right-identity-composeʷ comp
-      (idᵃ ★ ★ hA hB a⊑b)
-      (idᵃ ★ ★ hA′ hB′ a⊑b′) =
-    refl
-  star-right-identity-composeʷ comp
-      (tag ι) (idᵃ ★ ★ hA hB a⊑b) =
-    refl
-  star-right-identity-composeʷ comp
-      tag★⇒★ (idᵃ ★ ★ hA hB a⊑b) =
-    refl
-  star-right-identity-composeʷ comp
-      (p ︔tag★⇒★[ A≢★⇒★ ])
-      (idᵃ ★ ★ hA hB a⊑b) =
-    refl
-  star-right-identity-composeʷ comp
-      (unseal X⊑★) (idᵃ ★ ★ hA hB a⊑b) =
-    refl
-  star-right-identity-composeʷ comp
-      (unseal X⊑★ ︔ p [ A≢★ ])
-      (idᵃ ★ ★ hA hB a⊑b) =
-    refl
-  star-right-identity-composeʷ comp
-      (inst nonvarA zero∈A p ★≢★)
-      (idᵃ ★ ★ hA hB a⊑b) =
-    ⊥-elim (★≢★ refl)
-
-  function-left-identity-composeᶜ :
-      ∀ {Δ₀ Δ₁ Δ₂ B d}
-        {Φ₀₁ : ImpCtx Δ₀ Δ₁}
-        {Φ₁₂ : ImpCtx Δ₁ Δ₂}
-        {Φ₀₂ : ImpCtx Δ₀ Δ₂}
-        (comp : Φ₀₁ ⨟ᵢ Φ₁₂ ⇒ Φ₀₂)
-        (i : Φ₀₁ ∣ Δ₀ ⊢ idᶜ ↦ᶜ idᶜ
-          ⦂ (★ ⇒ ★) ⊒ (★ ⇒ ★) ⊣ Δ₁)
-        (q : Φ₁₂ ∣ Δ₁ ⊢ d ⦂ (★ ⇒ ★) ⊒ B ⊣ Δ₂)
-    → proj₁ (composeⁿ comp i q) ≡ d
-  function-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)
-      (q₁ ↦ q₂) =
-    cong₂ _↦ᶜ_
-      (star-right-identity-composeʷ comp q₁
-        (idᵃ ★ ★ hA hB a⊒b))
-      (star-left-identity-composeᶜ comp
-        (idᵃ ★ ★ hA′ hB′ a⊒b′) q₂)
-  function-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)
-      (gen nonvarC zero∈C q B≢★) =
-    cong Coercions.gen
-      (function-left-identity-composeᶜ
-        (keepᴿ comp)
-        (idᵃ ★ ★ hA hB a⊒b ↦
-         idᵃ ★ ★ hA′ hB′ a⊒b′)
-        q)
-
-  composeⁿ-left-evidence :
-      ∀ {Δ₀ Δ₁ Δ₂ A B C c d}
-        {Φ₀₁ : ImpCtx Δ₀ Δ₁}
-        {Φ₁₂ : ImpCtx Δ₁ Δ₂}
-        {Φ₀₂ : ImpCtx Δ₀ Δ₂}
-        (comp : Φ₀₁ ⨟ᵢ Φ₁₂ ⇒ Φ₀₂)
-        (p p′ : Φ₀₁ ∣ Δ₀ ⊢ c ⦂ A ⊒ B ⊣ Δ₁)
-        (q : Φ₁₂ ∣ Δ₁ ⊢ d ⦂ B ⊒ C ⊣ Δ₂)
-    → proj₁ (composeⁿ comp p q) ≡
-        proj₁ (composeⁿ comp p′ q)
-  composeⁿ-left-evidence comp
-      (idᵃ (＇ W) (＇ X) hA hB W≈X)
-      (idᵃ (＇ W′) (＇ .X) hA′ hB′ W′≈X)
-      (idᵃ (＇ .X) (＇ Y) hB″ hC X≈Y) =
-    refl
-  composeⁿ-left-evidence comp
-      (seal X⊑★) (seal X⊑★′)
-      (idᵃ (＇ X) (＇ Y) hB hC X≈Y) =
-    refl
-  composeⁿ-left-evidence comp
-      (p ︔seal X⊑★ [ ★≢B ])
-      (p′ ︔seal X⊑★′ [ ★≢B′ ])
-      (idᵃ (＇ X) (＇ Y) hB hC X≈Y) =
-    refl
-  composeⁿ-left-evidence comp
-      (idᵃ (‵ i) (‵ j) hA hB refl)
-      (idᵃ (‵ k) (‵ l) hA′ hB′ refl)
-      (idᵃ (‵ m) (‵ n) hB″ hC refl) =
-    refl
-  composeⁿ-left-evidence comp
-      (untag ι) (untag .ι)
-      (idᵃ (‵ .ι) (‵ κ) hB hC refl) =
-    refl
-  composeⁿ-left-evidence comp
-      (idᵃ ★ ★ hA hB a⊒b)
-      (idᵃ ★ ★ hA′ hB′ a⊒b′) q =
-    trans (star-left-identity-composeᶜ comp
-      (idᵃ ★ ★ hA hB a⊒b) q)
-      (sym (star-left-identity-composeᶜ comp
-        (idᵃ ★ ★ hA′ hB′ a⊒b′) q))
-  composeⁿ-left-evidence comp untag★⇒★ untag★⇒★ q =
-    refl
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ]) (q₁ ↦ q₂) =
-    wrap-untag-cong
-      (proj₂ (composeⁿ comp p (q₁ ↦ q₂)))
-      (proj₂ (composeⁿ comp p′ (q₁ ↦ q₂)))
-      (composeⁿ-left-evidence comp p p′ (q₁ ↦ q₂))
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ]) (∀ⁿ q) =
-    wrap-untag-cong
-      (proj₂ (composeⁿ comp p (∀ⁿ q)))
-      (proj₂ (composeⁿ comp p′ (∀ⁿ q)))
-      (composeⁿ-left-evidence comp p p′ (∀ⁿ q))
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (gen nonvarC occC q B≢★) =
-    wrap-untag-cong
-      (proj₂
-        (composeⁿ comp p (gen nonvarC occC q B≢★)))
-      (proj₂
-        (composeⁿ comp p′ (gen nonvarC occC q B≢★)))
-      (composeⁿ-left-evidence comp p p′
-        (gen nonvarC occC q B≢★))
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (idᵃ (＇ X) (＇ Y) hB hC X≈Y) =
-    ⊥-elim (no-function-to-variable-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (idᵃ (‵ ι) (‵ κ) hB hC refl) =
-    ⊥-elim (no-function-to-base-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (idᵃ ★ ★ hB hC ★⊒★) =
-    ⊥-elim (no-function-to-star-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (untag ι) =
-    ⊥-elim (no-function-to-star-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      untag★⇒★ =
-    ⊥-elim (no-function-to-star-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (untag★⇒★︔ q [ ★⇒★≢C ]) =
-    ⊥-elim (no-function-to-star-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (seal X⊑★) =
-    ⊥-elim (no-function-to-star-narrowing p)
-  composeⁿ-left-evidence comp
-      (untag★⇒★︔ p [ ★⇒★≢B ])
-      (untag★⇒★︔ p′ [ ★⇒★≢B′ ])
-      (q ︔seal X⊑★ [ ★≢C ]) =
-    ⊥-elim (no-function-to-star-narrowing p)
-  composeⁿ-left-evidence comp
-      (gen nonvarB occB p B≢★)
-      (gen nonvarB′ occB′ p′ B≢★′)
-      (∀ⁿ q) =
-    cong Coercions.gen
-      (composeⁿ-left-evidence
-        (freshᴿ-both comp) p p′ q)
-  composeⁿ-left-evidence comp
-      (idᵃ (＇ X) (＇ Y) hA hB X⊒Y)
-      (idᵃ (＇ X′) (＇ Y′) hA′ hB′ X⊒Y′)
-      (gen nonvarC occC q B≢★) =
-    cong Coercions.gen
-      (composeⁿ-left-evidence (keepᴿ comp)
-        (idᵃ (＇ X) (＇ Y) hA hB X⊒Y)
-        (idᵃ (＇ X′) (＇ Y′) hA′ hB′ X⊒Y′) q)
-  composeⁿ-left-evidence comp
-      (idᵃ (‵ ι) (‵ κ) hA hB a⊒b)
-      (idᵃ (‵ ι′) (‵ κ′) hA′ hB′ a⊒b′)
-      (gen nonvarC occC q B≢★) =
-    ⊥-elim (base-target-no-member q occC)
-  composeⁿ-left-evidence comp
-      (p₁ ↦ p₂) (p₁′ ↦ p₂′)
-      (gen nonvarC occC q B≢★) =
-    cong Coercions.gen
-      (composeⁿ-left-evidence (keepᴿ comp)
-        (p₁ ↦ p₂) (p₁′ ↦ p₂′) q)
-  composeⁿ-left-evidence comp
-      (∀ⁿ p) (∀ⁿ p′)
-      (gen nonvarC occC q B≢★) =
-    cong Coercions.gen
-      (composeⁿ-left-evidence (keepᴿ comp)
-        (∀ⁿ p) (∀ⁿ p′) q)
-  composeⁿ-left-evidence comp
-      (untag ι) (untag .ι)
-      (gen nonvarC occC q B≢★) =
-    ⊥-elim (base-target-no-member q occC)
-  composeⁿ-left-evidence comp
-      (seal X⊑★) (seal X⊑★′)
-      (gen nonvarC occC q B≢★) =
-    ⊥-elim (variable-target-no-zero q occC)
-  composeⁿ-left-evidence comp
-      (p ︔seal X⊑★ [ ★≢B ])
-      (p′ ︔seal X⊑★′ [ ★≢B′ ])
-      (gen nonvarC occC q B≢★) =
-    ⊥-elim (variable-target-no-zero q occC)
-  composeⁿ-left-evidence {A = A} comp
-      (gen nonvarA occA p {{extensionP}} A≢★)
-      (gen nonvarA′ occA′ p′ {{extensionP′}} A≢★′)
-      (gen nonvarC occC q B≢★)
-      with composeⁿ-left-evidence (keepᴿ comp)
-        (gen nonvarA occA p {{extensionP}} A≢★)
-        (gen nonvarA′ occA′ p′ {{extensionP′}} A≢★′)
-        q
-         | A ≟Ty ★
-  composeⁿ-left-evidence {A = .★} comp
-      (gen nonvarA occA p {{extensionP}} ★≢★)
-      (gen nonvarA′ occA′ p′ {{extensionP′}} ★≢★′)
-      (gen nonvarC occC q B≢★)
-      | recEq | yes refl =
-    ⊥-elim (★≢★ refl)
-  composeⁿ-left-evidence {A = A} comp
-      (gen nonvarA occA p {{extensionP}} A≢★)
-      (gen nonvarA′ occA′ p′ {{extensionP′}} A≢★′)
-      (gen nonvarC occC q B≢★)
-      | recEq | no A≢★′′ =
-    cong Coercions.gen recEq
-  composeⁿ-left-evidence comp
-      (p₁ ↦ p₂) (p₁′ ↦ p₂′) (q₁ ↦ q₂) =
-    cong₂ _↦ᶜ_
-      (composeʷ-right-evidence comp q₁ p₁ p₁′)
-      (composeⁿ-left-evidence comp p₂ p₂′ q₂)
-  composeⁿ-left-evidence comp
-      (∀ⁿ p) (∀ⁿ p′) (∀ⁿ q) =
-    cong Coercions.`∀
-      (composeⁿ-left-evidence
-        (both-both comp) p p′ q)
-
-  composeʷ-right-evidence :
-      ∀ {Δ₀ Δ₁ Δ₂ A B C c d}
-        {Φ₀₁ : ImpCtx Δ₀ Δ₁}
-        {Φ₁₂ : ImpCtx Δ₁ Δ₂}
-        {Φ₀₂ : ImpCtx Δ₀ Δ₂}
-        (comp : Φ₀₁ ⨟ᵢ Φ₁₂ ⇒ Φ₀₂)
-        (p : Φ₁₂ ∣ Δ₂ ⊢ c ⦂ A ⊑ B ⊣ Δ₁)
-        (q q′ : Φ₀₁ ∣ Δ₁ ⊢ d ⦂ B ⊑ C ⊣ Δ₀)
-    → proj₁ (composeʷ comp p q) ≡
-        proj₁ (composeʷ comp p q′)
-  composeʷ-right-evidence comp p
-      (idᵃ ★ ★ hB hC a⊑b)
-      (idᵃ ★ ★ hB′ hC′ a⊑b′) =
-    trans
-      (star-right-identity-composeʷ comp p
-        (idᵃ ★ ★ hB hC a⊑b))
-      (sym (star-right-identity-composeʷ comp p
-        (idᵃ ★ ★ hB′ hC′ a⊑b′)))
-  composeʷ-right-evidence comp
-      (idᵃ (‵ ι) (‵ κ) hA hB refl)
-      (idᵃ (‵ .κ) (‵ κ₂) hB′ hC refl)
-      (idᵃ (‵ κ₃) (‵ κ₄) hB″ hC′ refl) =
-    refl
-  composeʷ-right-evidence comp
-      (idᵃ (‵ ι) (‵ κ) hA hB refl)
-      (tag .κ) (tag .κ) =
-    refl
-  composeʷ-right-evidence comp
-      (idᵃ (＇ X) (＇ Y) hA hB X⊑Y)
-      (idᵃ (＇ .Y) (＇ z) hB′ hC Y⊑z)
-      (idᵃ (＇ Y′) (＇ z′) hB″ hC′ Y′⊑z′) =
-    refl
-  composeʷ-right-evidence comp
-      (idᵃ (＇ X) (＇ Y) hA hB X⊑Y)
-      (unseal Y⊑★) (unseal Y⊑★′) =
-    refl
-  composeʷ-right-evidence comp
-      (idᵃ (＇ X) (＇ Y) hA hB X⊑Y)
-      (unseal Y⊑★ ︔ q [ A≢★ ])
-      (unseal Y⊑★′ ︔ q′ [ A≢★′ ]) =
-    refl
-  composeʷ-right-evidence comp
-      (idᵃ (‵ ι) (＇ Y) hA hB ())
-      (unseal Y⊑★ ︔ q [ A≢★ ])
-      (unseal Y⊑★′ ︔ q′ [ A≢★′ ])
-  composeʷ-right-evidence comp
-      (idᵃ ★ (＇ Y) hA hB ())
-      (unseal Y⊑★ ︔ q [ A≢★ ])
-      (unseal Y⊑★′ ︔ q′ [ A≢★′ ])
-  composeʷ-right-evidence {A = A ⇒ B} comp
-      (idᵃ () (＇ Y) hA hB a⊑b)
-      (unseal Y⊑★ ︔ q [ A≢★ ])
-      (unseal Y⊑★′ ︔ q′ [ A≢★′ ])
-  composeʷ-right-evidence {A = `∀ A} comp
-      (idᵃ () (＇ Y) hA hB a⊑b)
-      (unseal Y⊑★ ︔ q [ A≢★ ])
-      (unseal Y⊑★′ ︔ q′ [ A≢★′ ])
-  composeʷ-right-evidence comp
-      (inst nonvarA zero∈A p B≢★)
-      (unseal Y⊑★ ︔ q [ A≢★ ])
-      (unseal Y⊑★′ ︔ q′ [ A≢★′ ]) =
-    ⊥-elim (widening-variable-target-no-zero p zero∈A)
-  composeʷ-right-evidence comp p tag★⇒★ tag★⇒★ =
-    refl
-  composeʷ-right-evidence comp p
-      (q ︔tag★⇒★[ B≢★⇒★ ])
-      (q′ ︔tag★⇒★[ B≢★⇒★′ ])
-      with composeʷ comp p q
-         | composeʷ comp p q′
-         | composeʷ-right-evidence comp p q q′
-  composeʷ-right-evidence comp p
-      (q ︔tag★⇒★[ B≢★⇒★ ])
-      (q′ ︔tag★⇒★[ B≢★⇒★′ ])
-      | r , r⊢ | .r , r⊢′ | refl =
-    wrap-tag-cong r⊢ r⊢′ refl
-  composeʷ-right-evidence comp (∀ʷ p)
-      (inst nonvarB occB q C≢★)
-      (inst nonvarB′ occB′ q′ C≢★′) =
-    cong Coercions.inst
-      (composeʷ-right-evidence
-        (freshᴿ-both comp) p q q′)
-  composeʷ-right-evidence comp
-      (inst nonvarA occA p B≢★)
-      (idᵃ (＇ X) (＇ Y) hB hC X⊑Y)
-      (idᵃ (＇ X′) (＇ Y′) hB′ hC′ X′⊑Y′) =
-    cong Coercions.inst
-      (composeʷ-right-evidence (keepᴿ comp) p
-        (idᵃ (＇ X) (＇ Y) hB hC X⊑Y)
-        (idᵃ (＇ X′) (＇ Y′) hB′ hC′ X′⊑Y′))
-  composeʷ-right-evidence comp
-      (inst nonvarA occA p B≢★)
-      (idᵃ (‵ ι) (‵ κ) hB hC a⊑b)
-      (idᵃ (‵ ι′) (‵ κ′) hB′ hC′ a⊑b′) =
-    cong Coercions.inst
-      (composeʷ-right-evidence (keepᴿ comp) p
-        (idᵃ (‵ ι) (‵ κ) hB hC a⊑b)
-        (idᵃ (‵ ι′) (‵ κ′) hB′ hC′ a⊑b′))
-  composeʷ-right-evidence comp
-      (inst nonvarA occA p B≢★)
-      (tag ι) (tag .ι) =
-    refl
-  composeʷ-right-evidence comp
-      (inst nonvarA occA p B≢★)
-      (unseal X⊑★) (unseal X⊑★′) =
-    star-inst-normal-cong nonvarA occA
-      (proj₂
-        (composeʷ (keepᴿ comp) p (unseal X⊑★)))
-      (proj₂
-        (composeʷ (keepᴿ comp) p (unseal X⊑★′)))
-      (composeʷ-right-evidence (keepᴿ comp)
-        p (unseal X⊑★) (unseal X⊑★′))
-  composeʷ-right-evidence {C = C} comp
-      (inst nonvarA occA p B≢★)
-      (inst nonvarB occB q {{extensionQ}} C≢★)
-      (inst nonvarB′ occB′ q′ {{extensionQ′}} C≢★′)
-      with composeʷ-right-evidence (keepᴿ comp) p
-        (inst nonvarB occB q {{extensionQ}} C≢★)
-        (inst nonvarB′ occB′ q′ {{extensionQ′}} C≢★′)
-         | C ≟Ty ★
-  composeʷ-right-evidence {C = .★} comp
-      (inst nonvarA occA p B≢★)
-      (inst nonvarB occB q {{extensionQ}} ★≢★)
-      (inst nonvarB′ occB′ q′ {{extensionQ′}} ★≢★′)
-      | recEq | yes refl =
-    ⊥-elim (★≢★ refl)
-  composeʷ-right-evidence {C = C} comp
-      (inst nonvarA occA p B≢★)
-      (inst nonvarB occB q {{extensionQ}} C≢★)
-      (inst nonvarB′ occB′ q′ {{extensionQ′}} C≢★′)
-      | recEq | no C≢★′′ =
-    cong Coercions.inst recEq
-  composeʷ-right-evidence comp
-      (inst nonvarA occA p B≢★)
-      (q₁ ↦ q₂) (q₁′ ↦ q₂′) =
-    cong Coercions.inst
-      (composeʷ-right-evidence (keepᴿ comp)
-        p (q₁ ↦ q₂) (q₁′ ↦ q₂′))
-  composeʷ-right-evidence comp
-      (inst nonvarA occA p B≢★)
-      (∀ʷ q) (∀ʷ q′) =
-    cong Coercions.inst
-      (composeʷ-right-evidence (keepᴿ comp)
-        p (∀ʷ q) (∀ʷ q′))
-  composeʷ-right-evidence comp
-      (p₁ ↦ p₂) (q₁ ↦ q₂) (q₁′ ↦ q₂′) =
-    cong₂ _↦ᶜ_
-      (composeⁿ-left-evidence comp q₁ q₁′ p₁)
-      (composeʷ-right-evidence comp p₂ q₂ q₂′)
-  composeʷ-right-evidence comp
-      (∀ʷ p) (∀ʷ q) (∀ʷ q′) =
-    cong Coercions.`∀
-      (composeʷ-right-evidence
-        (both-both comp) p q q′)
-
-tag-prefix-cancel :
-    ∀ {Δᴸ Δᴿ A B G}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {u⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {p q : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ
-      dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] q
+tag-prefix-cancel : ∀ {μ Δ Σ G A C}
+    {u v : μ ∣ Δ ∣ Σ ⊢ G ! ⦂ A ⊑ ★}
+    {p q : μ ∣ Δ ∣ Σ ⊢ A ⊒ C}
+  → StoreWf Δ Σ
+  → (dualʷ (G ! , u) ⨟ⁿ p) ≐ⁿ
+      (dualʷ (G ! , v) ⨟ⁿ q)
   → p ≐ⁿ q
-tag-prefix-cancel {u⊑ = tag ι}
-    {p = _ , idᵃ a b hA hB a⊒b}
-    {q = _ , idᵃ a′ b′ hA′ hB′ a⊒b′} eq =
-  refl
-tag-prefix-cancel {u⊑ = tag ι}
-    {p = _ , gen nonvarA zero∈A p B≢★}
-    {q = _ , gen nonvarA′ zero∈A′ q B≢★′} eq =
-  ⊥-elim (base-target-no-member p zero∈A)
-tag-prefix-cancel {B = B} {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , q₁ ↦ q₂} eq
-    with (★ ⇒ ★) ≟Ty B
-tag-prefix-cancel {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , q₁ ↦ q₂} eq | yes refl =
-  trans (star-function-narrowing-coercion (p₁ ↦ p₂))
-    (sym (star-function-narrowing-coercion (q₁ ↦ q₂)))
-tag-prefix-cancel {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , q₁ ↦ q₂} eq | no B≢★⇒★ =
-  sequence-tail-injective eq
-tag-prefix-cancel {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarA zero∈A p B≢★}
-    {q = _ , gen nonvarA′ zero∈A′ q B≢★′} eq =
-  sequence-tail-injective
-    (trans
-      (sym (function-tag-gen-composition
-        {nonvarA = nonvarA} {zero∈A = zero∈A}
-        {p = p} {B≢★ = B≢★}))
-      (trans eq
-        (function-tag-gen-composition
-          {nonvarA = nonvarA′} {zero∈A = zero∈A′}
-          {p = q} {B≢★ = B≢★′})))
-
-tag-prefix-cancelᶜ :
-    ∀ {Δᴸ Δᴿ A B G}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ Ψ′ : ImpCtx Δᴸ Δᴸ}
-      {left : LeftOneSidedᵢ Φ Ψ}
-      {left′ : LeftOneSidedᵢ Φ Ψ′}
-      {u⊑ : Ψ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {v⊑ : Ψ′ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {p q : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left ] p ≐ⁿ
-      dualʷ (G ! , v⊑) ⨟ˡⁿ[ left′ ] q
-  → p ≐ⁿ q
-tag-prefix-cancelᶜ {u⊑ = tag ι} {v⊑ = tag .ι}
-    {p = _ , idᵃ a b hA hB a⊒b}
-    {q = _ , idᵃ a′ b′ hA′ hB′ a⊒b′} eq =
-  refl
-tag-prefix-cancelᶜ {u⊑ = tag ι} {v⊑ = tag .ι}
-    {p = _ , gen nonvarA zero∈A p B≢★}
-    {q = _ , gen nonvarA′ zero∈A′ q B≢★′} eq =
-  ⊥-elim (base-target-no-member p zero∈A)
-tag-prefix-cancelᶜ {B = B}
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , q₁ ↦ q₂} eq
-    with (★ ⇒ ★) ≟Ty B
-tag-prefix-cancelᶜ
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , q₁ ↦ q₂} eq | yes refl =
-  trans (star-function-narrowing-coercion (p₁ ↦ p₂))
-    (sym (star-function-narrowing-coercion (q₁ ↦ q₂)))
-tag-prefix-cancelᶜ
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , q₁ ↦ q₂} eq | no B≢★⇒★ =
-  sequence-tail-injective eq
-tag-prefix-cancelᶜ
-    {left = left} {left′ = left′}
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★}
-    {p = _ , gen nonvarA zero∈A p B≢★}
-    {q = _ , gen nonvarA′ zero∈A′ q B≢★′} eq =
-  sequence-tail-injective
-    (trans
-      (sym (function-tag-gen-compositionᶜ left
-        {nonvarA = nonvarA} {zero∈A = zero∈A}
-        {p = p} {B≢★ = B≢★}))
-      (trans eq
-        (function-tag-gen-compositionᶜ left′
-          {nonvarA = nonvarA′} {zero∈A = zero∈A′}
-          {p = q} {B≢★ = B≢★′})))
-
-base-common-target :
-    ∀ {Δᴸ Δᴿ ι κ B}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-  → (a : Atom (‵ ι))
-  → (a′ : Atom (‵ κ))
-  → (b : Atom B)
-  → (b′ : Atom B)
-  → Φ ⊢ a ≈ᵃ b
-  → Φ ⊢ a′ ≈ᵃ b′
-  → ι ≡ κ
-base-common-target (‵ ι) (‵ κ) b b′ μ≡ι μ≡κ with b | b′
-base-common-target (‵ ι) (‵ κ) b b′ () μ≡κ | ＇ X | ＇ Y
-base-common-target (‵ ι) (‵ κ) b b′ μ≡ι μ≡κ
-    | ‵ μ | ‵ μ′ =
-  trans μ≡ι (sym μ≡κ)
-base-common-target (‵ ι) (‵ κ) b b′ () μ≡κ | ★ | ★
-
-base-tag : Base → Tag
-base-tag ι = ‵ ι
-
-tag-prefix-match :
-    ∀ {Δᴸ Δᴿ A C B G H}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {u⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {v⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ H ! ⦂ C ⊑ ★ ⊣ Δᴸ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-      {q : Φ ∣ Δᴸ ⊢ C ⊒ B ⊣ Δᴿ}
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ
-      dualʷ (H ! , v⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] q
-  → G ≡ H
-tag-prefix-match
-    {u⊑ = tag ι} {v⊑ = tag κ}
-    {p = _ , idᵃ a b hA hB a⊒b}
-    {q = _ , idᵃ a′ b′ hA′ hB′ a⊒b′} eq =
-  cong base-tag (base-common-target a a′ b b′ a⊒b a⊒b′)
-tag-prefix-match
-    {u⊑ = tag ι} {v⊑ = tag κ}
-    {p = _ , gen nonvarB zero∈B p B≢★}
-    {q = q} eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B p {{freshⁿᵢ}} B≢★))
-tag-prefix-match
-    {u⊑ = tag ι} {v⊑ = tag★⇒★}
-    {p = _ , idᵃ (‵ .ι) (‵ μ) hA hB refl}
-    {q = _ , q} eq =
-  ⊥-elim (no-function-to-base-narrowing q)
-tag-prefix-match
-    {u⊑ = tag ι} {v⊑ = tag★⇒★}
-    {p = _ , gen nonvarB zero∈B p B≢★}
-    {q = q} eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B p {{freshⁿᵢ}} B≢★))
-tag-prefix-match
-    {u⊑ = tag★⇒★} {v⊑ = tag κ}
-    {p = _ , p}
-    {q = _ , idᵃ (‵ .κ) (‵ μ) hA hB refl} eq =
-  ⊥-elim (no-function-to-base-narrowing p)
-tag-prefix-match
-    {u⊑ = tag★⇒★} {v⊑ = tag κ}
-    {p = p}
-    {q = _ , gen nonvarB zero∈B q B≢★} eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B q {{freshⁿᵢ}} B≢★))
-tag-prefix-match
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★} eq =
-  refl
-
-tag-prefix-matchᶜ :
-    ∀ {Δᴸ Δᴿ A C B G H}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ Ψ′ : ImpCtx Δᴸ Δᴸ}
-      {left : LeftOneSidedᵢ Φ Ψ}
-      {left′ : LeftOneSidedᵢ Φ Ψ′}
-      {u⊑ : Ψ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {v⊑ : Ψ′ ∣ Δᴸ ⊢ H ! ⦂ C ⊑ ★ ⊣ Δᴸ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-      {q : Φ ∣ Δᴸ ⊢ C ⊒ B ⊣ Δᴿ}
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left ] p ≐ⁿ
-      dualʷ (H ! , v⊑) ⨟ˡⁿ[ left′ ] q
-  → G ≡ H
-tag-prefix-matchᶜ
-    {u⊑ = tag ι} {v⊑ = tag κ}
-    {p = _ , idᵃ a b hA hB a⊒b}
-    {q = _ , idᵃ a′ b′ hA′ hB′ a⊒b′} eq =
-  cong base-tag (base-common-target a a′ b b′ a⊒b a⊒b′)
-tag-prefix-matchᶜ
-    {u⊑ = tag ι} {v⊑ = tag κ}
-    {p = _ , gen nonvarB zero∈B p B≢★}
-    {q = q} eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B p {{freshⁿᵢ}} B≢★))
-tag-prefix-matchᶜ
-    {u⊑ = tag ι} {v⊑ = tag★⇒★}
-    {p = _ , idᵃ (‵ .ι) (‵ μ) hA hB refl}
-    {q = _ , q} eq =
-  ⊥-elim (no-function-to-base-narrowing q)
-tag-prefix-matchᶜ
-    {u⊑ = tag ι} {v⊑ = tag★⇒★}
-    {p = _ , gen nonvarB zero∈B p B≢★}
-    {q = q} eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B p {{freshⁿᵢ}} B≢★))
-tag-prefix-matchᶜ
-    {u⊑ = tag★⇒★} {v⊑ = tag κ}
-    {p = _ , p}
-    {q = _ , idᵃ (‵ .κ) (‵ μ) hA hB refl} eq =
-  ⊥-elim (no-function-to-base-narrowing p)
-tag-prefix-matchᶜ
-    {u⊑ = tag★⇒★} {v⊑ = tag κ}
-    {p = p}
-    {q = _ , gen nonvarB zero∈B q B≢★} eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B q {{freshⁿᵢ}} B≢★))
-tag-prefix-matchᶜ
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★} eq =
-  refl
-
-------------------------------------------------------------------------
--- Moving a right narrowing beneath a tag prefix
-------------------------------------------------------------------------
-
-tag-prefix-compose-right-narrowing :
-    ∀ {Δᴸ Δᴿ A B C G d}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ′ : ImpCtx Δᴿ Δᴿ}
-      {u⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-      {q : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
-      {d⊒ : Ψ′ ∣ Δᴿ ⊢ d ⦂ B ⊒ C ⊣ Δᴿ}
-  → (right : RightOneSidedᵢ Φ Ψ′)
-  → Inert d
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ q
-  → q ⨟ⁿ[ right ] (d , d⊒) ≐ⁿ
-      dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ]
-        (p ⨟ⁿ[ right ] (d , d⊒))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    {d⊒ = c ↦ d} right (c′ ↦ d′) eq =
-  ⊥-elim (no-base-to-function-narrowing p)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    {d⊒ = ∀ⁿ c} right (`∀ c′) eq =
-  ⊥-elim (no-base-to-all-narrowing p)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    {d⊒ = seal X⊑★} right (seal X) eq =
-  ⊥-elim (no-base-to-star-narrowing p)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag ι}
-    {p = _ , idᵃ (‵ .ι) (‵ κ) hA hB refl}
-    {d⊒ = gen nonvarC zero∈C d B≢★} right (gen d′) eq =
-  ⊥-elim (base-target-no-member d zero∈C)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag ι}
-    {p = _ , gen nonvarB zero∈B p B≢★}
-    {d⊒ = gen nonvarC zero∈C d B′≢★} right (gen d′) eq =
-  ⊥-elim (no-base-to-all-narrowing
-    (gen nonvarB zero∈B p {{freshⁿᵢ}} B≢★))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★} {p = _ , p}
-    {d⊒ = seal X⊑★} right (seal X) eq =
-  ⊥-elim (no-function-to-star-narrowing p)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , idᵃ ★ ★ hA hB a⊒b}
-    {d⊒ = gen nonvarC zero∈C d B≢★} right (gen d′) eq =
-  ⊥-elim (B≢★ refl)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , untag ι}
-    {d⊒ = gen nonvarC zero∈C d B≢★} right (gen d′) eq =
-  ⊥-elim (base-target-no-member d zero∈C)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , ((p ︔tag★⇒★[ A≢★⇒★ ]) ↦ q)}
-    {q = _ , untag★⇒★} right i eq =
-  ⊥-elim (no-star-to-function-widening p)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , (p ↦ untag★⇒★︔ q [ ★⇒★≢B ])}
-    {q = _ , untag★⇒★} right i eq =
-  ⊥-elim (no-function-to-star-narrowing q)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , seal X⊑★}
-    {d⊒ = gen nonvarC zero∈C d B≢★} right (gen d′) eq =
-  ⊥-elim (variable-target-no-zero d zero∈C)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , q ︔seal X⊑★ [ ★≢B ]}
-    {d⊒ = gen nonvarC zero∈C d B′≢★} right (gen d′) eq =
-  ⊥-elim (variable-target-no-zero d zero∈C)
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , gen nonvarB zero∈B q ★≢★}
-    {d⊒ = gen nonvarC zero∈C d B≢★} right (gen d′) eq =
-  ⊥-elim (★≢★ refl)
-tag-prefix-compose-right-narrowing
-    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
-    {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {d⊒ = d₁ ↦ d₂} right (d₁′ ↦ d₂′) eq =
-  wrap-untag-cong
-    (recontext-from-funⁿ
-      (compose-right-star (right-compose right))
-      (d₁ ↦ d₂))
-    (recontext-from-funⁿ (compose-right-star compose-id-left)
-      (proj₂
-        (composeⁿ (right-compose right)
-          (idᵃ ★ ★ hA hB a⊒b ↦
-           idᵃ ★ ★ hA′ hB′ a⊒b′)
-          (d₁ ↦ d₂))))
-    (cong₂ _↦ᶜ_
-      (sym (star-right-identity-composeʷ (right-compose right) d₁
-        (idᵃ ★ ★ hA hB a⊒b)))
-      (sym
-        (star-left-identity-composeᶜ (right-compose right)
-          (idᵃ ★ ★ hA′ hB′ a⊒b′)
-          d₂)))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = d₁ ↦ d₂} right (d₁′ ↦ d₂′) eq
-    with tag-prefix-cancel
-      {u⊑ = tag★⇒★}
-      {p = _ , p₁ ↦ p₂}
-      {q = _ , q}
-      (trans eq
-        (sym (function-tag-sequence q ★⇒★≢B)))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = d₁ ↦ d₂} right (d₁′ ↦ d₂′) eq | refl =
-  wrap-untag-cong
-    (proj₂
-      (composeⁿ (right-compose right)
-        q (d₁ ↦ d₂)))
-    (recontext-from-funⁿ (compose-right-star compose-id-left)
-      (proj₂
-        (composeⁿ (right-compose right)
-          (p₁ ↦ p₂) (d₁ ↦ d₂))))
-    (composeⁿ-left-evidence (right-compose right)
-      q (p₁ ↦ p₂) (d₁ ↦ d₂))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarB zero∈B p
-      {{extensionP}} B≢★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = ∀ⁿ d} right (`∀ d′) eq
-    with tag-prefix-cancel
-      {u⊑ = tag★⇒★}
-      {p = _ , gen nonvarB zero∈B p
-        {{extensionP}} B≢★}
-      {q = _ , q}
-      (trans eq
-        (sym (function-tag-sequence q ★⇒★≢B)))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarB zero∈B p
-      {{extensionP}} B≢★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = ∀ⁿ d} right (`∀ d′) eq | refl =
-  trans
-    (cong (λ c → (★⇒★ ？) ︔ᶜ c)
-      (composeⁿ-left-evidence (right-compose right)
-        q (gen nonvarB zero∈B p {{extensionP}} B≢★) (∀ⁿ d)))
-    (sym
-      (function-tag-sequence
-        (proj₂
-          (composeⁿ (right-compose right)
-            (gen nonvarB zero∈B p {{extensionP}} B≢★) (∀ⁿ d)))
-        (λ ())))
-tag-prefix-compose-right-narrowing
-    {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
-    {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {d⊒ = gen nonvarC zero∈C d B≢★} right (gen d′) eq =
-  cong (λ c → (★⇒★ ？) ︔ᶜ Coercions.gen c)
-    (sym
-      (function-left-identity-composeᶜ
-        (keepᴿ (right-compose right))
-        (idᵃ ★ ★ hA hB a⊒b ↦
-         idᵃ ★ ★ hA′ hB′ a⊒b′)
-        d))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = gen nonvarC zero∈C d B′≢★} right (gen d′) eq
-    with tag-prefix-cancel
-      {u⊑ = tag★⇒★}
-      {p = _ , p₁ ↦ p₂}
-      {q = _ , q}
-      (trans eq
-        (sym (function-tag-sequence q ★⇒★≢B)))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = gen nonvarC zero∈C d B′≢★}
-    right (gen d′) eq | refl =
-  trans
-    (cong (λ c → (★⇒★ ？) ︔ᶜ c)
-      (composeⁿ-left-evidence (right-compose right)
-        q (p₁ ↦ p₂)
-        (gen nonvarC zero∈C d B′≢★)))
-    (sym
-      (function-tag-sequence
-        (proj₂
-          (composeⁿ (right-compose right)
-            (p₁ ↦ p₂)
-            (gen nonvarC zero∈C d {{freshⁿᵢ}} B′≢★)))
-        (λ ())))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarB zero∈B p
-      {{extensionP}} B≢★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = gen nonvarC zero∈C d
-      {{extensionD}} B′≢★} right (gen d′) eq
-    with tag-prefix-cancel
-      {u⊑ = tag★⇒★}
-      {p = _ , gen nonvarB zero∈B p
-        {{extensionP}} B≢★}
-      {q = _ , q}
-      (trans eq
-        (sym (function-tag-sequence q ★⇒★≢B)))
-tag-prefix-compose-right-narrowing
-    {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarB zero∈B p
-      {{extensionP}} B≢★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {d⊒ = gen nonvarC zero∈C d
-      {{extensionD}} B′≢★}
-    right (gen d′) eq | refl =
-  trans
-    (cong (λ c → (★⇒★ ？) ︔ᶜ c)
-      (composeⁿ-left-evidence (right-compose right)
-        q (gen nonvarB zero∈B p {{extensionP}} B≢★)
-        (gen nonvarC zero∈C d {{extensionD}} B′≢★)))
-    (sym
-      (function-tag-sequence
-        (proj₂
-          (composeⁿ (right-compose right)
-            (gen nonvarB zero∈B p {{extensionP}} B≢★)
-            (gen nonvarC zero∈C d {{extensionD}} B′≢★)))
-        (λ ())))
-
-tag-factor-right-narrowing :
-    ∀ {Δᴸ Δᴿ A B C G d}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ′ : ImpCtx Δᴿ Δᴿ}
-      {u⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {q : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
-      {r : Φ ∣ Δᴸ ⊢ ★ ⊒ C ⊣ Δᴿ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ C ⊣ Δᴿ}
-  → (right : RightOneSidedᵢ Φ Ψ′)
-  → (d⊒ : Ψ′ ∣ Δᴿ ⊢ d ⦂ B ⊒ C ⊣ Δᴿ)
-  → Inert d
-  → q ⨟ⁿ[ right ] (d , d⊒) ≐ⁿ r
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ r
-  → Σ[ s ∈ (Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ) ]
-      (dualʷ (G ! , u⊑)
-        ⨟ˡⁿ[ left-id-one-sidedᵢ ] s ≐ⁿ q)
-    × (s ⨟ⁿ[ right ] (d , d⊒) ≐ⁿ p)
-tag-factor-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    right (c ↦ d) (c′ ↦ d′) eq′ eq =
-  ⊥-elim (no-base-to-function-narrowing p)
-tag-factor-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    right (∀ⁿ c) (`∀ c′) eq′ eq =
-  ⊥-elim (no-base-to-all-narrowing p)
-tag-factor-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    right (seal X⊑★) (seal X) eq′ eq =
-  ⊥-elim (no-base-to-variable-narrowing p)
-tag-factor-right-narrowing
-    {u⊑ = tag ι} {p = _ , p}
-    right (gen nonvarC zero∈C d B≢★) (gen d′) eq′ eq =
-  ⊥-elim (no-base-to-all-narrowing p)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , idᵃ ★ ★ hA hB a⊒b}
-    {p = _ , p}
-    right (seal X⊑★) (seal X) eq′ eq =
-  ⊥-elim (no-function-to-variable-narrowing p)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , idᵃ ★ ★ hA hB a⊒b}
-    right (gen nonvarC zero∈C d ★≢★) (gen d′) eq′ eq =
-  ⊥-elim (★≢★ refl)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , untag ι}
-    right (gen nonvarC zero∈C d B≢★) (gen d′) eq′ eq =
-  ⊥-elim (base-target-no-member d zero∈C)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , seal X⊑★}
-    right (gen nonvarC zero∈C d B≢★) (gen d′) eq′ eq =
-  ⊥-elim (variable-target-no-zero d zero∈C)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , q ︔seal X⊑★ [ ★≢B ]}
-    right (gen nonvarC zero∈C d B′≢★) (gen d′) eq′ eq =
-  ⊥-elim (variable-target-no-zero d zero∈C)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , gen nonvarB zero∈B q ★≢★}
-    right d⊒ i eq′ eq =
-  ⊥-elim (★≢★ refl)
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , untag★⇒★}
-    {p = p}
-    right d⊒ i eq′ eq =
-  (_ , fun-idⁿ) , refl ,
-  tag-prefix-cancel
-    {u⊑ = tag★⇒★}
-    {p = (_ , fun-idⁿ) ⨟ⁿ[ right ] (_ , d⊒)}
-    {q = p}
-    (trans
-      (sym
-        (tag-prefix-compose-right-narrowing
-          {u⊑ = tag★⇒★}
-          {p = _ , fun-idⁿ}
-          {q = _ , untag★⇒★}
-          {d⊒ = d⊒} right i refl))
-      (trans eq′ (sym eq)))
-tag-factor-right-narrowing
-    {u⊑ = tag★⇒★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {p = p}
-    right d⊒ i eq′ eq =
-  (_ , q) , function-tag-sequence q ★⇒★≢B ,
-  tag-prefix-cancel
-    {u⊑ = tag★⇒★}
-    {p = (_ , q) ⨟ⁿ[ right ] (_ , d⊒)}
-    {q = p}
-    (trans
-      (sym
-        (tag-prefix-compose-right-narrowing
-          {u⊑ = tag★⇒★}
-          {p = _ , q}
-          {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-          {d⊒ = d⊒} right i
-          (function-tag-sequence q ★⇒★≢B)))
-      (trans eq′ (sym eq)))
-
-------------------------------------------------------------------------
--- Moving a right widening beneath a tag prefix
-------------------------------------------------------------------------
-
-tag-prefix-compose-right-widening :
-    ∀ {Δᴸ Δᴿ A B C G u′}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ′ : ImpCtx Δᴿ Δᴿ}
-      {u⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-      {q : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
-      {u′⊑ : Ψ′ ∣ Δᴿ ⊢ u′ ⦂ C ⊑ B ⊣ Δᴿ}
-  → (comp′ : RightOneSidedᵢ Φ Ψ′)
-  → Inert u′
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ q
-  → q ⨟ⁿ[ comp′ ] dualʷ (u′ , u′⊑) ≐ⁿ
-      dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ]
-        (p ⨟ⁿ[ comp′ ] dualʷ (u′ , u′⊑))
-tag-prefix-compose-right-widening
-    {u⊑ = tag ι} {p = _ , p}
-    {u′⊑ = tag κ} comp′ ((‵ .κ) !) eq =
-  ⊥-elim (no-base-to-star-narrowing p)
-tag-prefix-compose-right-widening
-    {u⊑ = tag ι} {p = _ , p}
-    {u′⊑ = tag★⇒★} comp′ (★⇒★ !) eq =
-  ⊥-elim (no-base-to-star-narrowing p)
-tag-prefix-compose-right-widening
-    {u⊑ = tag ι} {p = _ , p}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq =
-  ⊥-elim (no-base-to-function-narrowing p)
-tag-prefix-compose-right-widening
-    {u⊑ = tag ι} {p = _ , p}
-    {u′⊑ = ∀ʷ c} comp′ (`∀ c′) eq =
-  ⊥-elim (no-base-to-all-narrowing p)
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★} {p = _ , p}
-    {u′⊑ = tag κ} comp′ ((‵ .κ) !) eq =
-  ⊥-elim (no-function-to-star-narrowing p)
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★} {p = _ , p}
-    {u′⊑ = tag★⇒★} comp′ (★⇒★ !) eq =
-  ⊥-elim (no-function-to-star-narrowing p)
-tag-prefix-compose-right-widening
-    {C = A ⇒ B} {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq
-    with ★ ≟Ty A | ★ ≟Ty B
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq
-    | yes refl | yes refl =
-  refl
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq
-    | yes ★≡A | no ★≢B =
-  cong (λ e → (★⇒★ ？) ︔ᶜ e)
-    (cong₂ _↦ᶜ_
-      (sym (star-right-identity-composeʷ (right-compose comp′)
-        (proj₂ (dualⁿ (c′ , c)))
-        (idᵃ ★ ★ hA hB a⊒b)))
-      (sym (star-left-identity-composeᶜ (right-compose comp′)
-        (idᵃ ★ ★ hA′ hB′ a⊒b′)
-        (proj₂ (dualʷ (d′ , d))))))
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq
-    | no ★≢A | yes ★≡B =
-  cong (λ e → (★⇒★ ？) ︔ᶜ e)
-    (cong₂ _↦ᶜ_
-      (sym (star-right-identity-composeʷ (right-compose comp′)
-        (proj₂ (dualⁿ (c′ , c)))
-        (idᵃ ★ ★ hA hB a⊒b)))
-      (sym (star-left-identity-composeᶜ (right-compose comp′)
-        (idᵃ ★ ★ hA′ hB′ a⊒b′)
-        (proj₂ (dualʷ (d′ , d))))))
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ ,
-      (idᵃ ★ ★ hA hB a⊒b ↦
-       idᵃ ★ ★ hA′ hB′ a⊒b′)}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq
-    | no ★≢A | no ★≢B =
-  cong (λ e → (★⇒★ ？) ︔ᶜ e)
-    (cong₂ _↦ᶜ_
-      (sym (star-right-identity-composeʷ (right-compose comp′)
-        (proj₂ (dualⁿ (c′ , c)))
-        (idᵃ ★ ★ hA hB a⊒b)))
-      (sym (star-left-identity-composeᶜ (right-compose comp′)
-        (idᵃ ★ ★ hA′ hB′ a⊒b′)
-        (proj₂ (dualʷ (d′ , d))))))
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ , ((p ︔tag★⇒★[ A≢★⇒★ ]) ↦ q)}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq =
-  ⊥-elim (no-star-to-function-widening p)
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ , (p ↦ untag★⇒★︔ q [ ★⇒★≢B ])}
-    {q = _ , untag★⇒★}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq =
-  ⊥-elim (no-function-to-star-narrowing q)
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq
-    with tag-prefix-cancel
-      {u⊑ = tag★⇒★}
-      {p = _ , p₁ ↦ p₂}
-      {q = _ , q}
-      (trans eq
-        (sym (function-tag-sequence q ★⇒★≢B)))
-tag-prefix-compose-right-widening
-    {Φ = Φ} {u⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {u′⊑ = c ↦ d} comp′ (c′ ↦ d′) eq | refl =
-  wrap-untag-cong
-    (proj₂
-      (composeⁿ (right-compose comp′)
-        q (proj₂ (dualʷ (c′ ↦ᶜ d′ , c ↦ d)))))
-    (recontext-from-funⁿ {Φ = Φ} {Ψ = Φ}
-      (compose-right-star compose-id-left)
-      (proj₂
-        (composeⁿ (right-compose comp′)
-          (p₁ ↦ p₂)
-          (proj₂
-            (dualʷ (c′ ↦ᶜ d′ , c ↦ d))))))
-    (composeⁿ-left-evidence (right-compose comp′)
-      q (p₁ ↦ p₂)
-      (proj₂ (dualʷ (c′ ↦ᶜ d′ , c ↦ d))))
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarA zero∈A p
-      {{extensionP}} B≢★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {u′⊑ = ∀ʷ c} comp′ (`∀ c′) eq
-    with tag-prefix-cancel
-      {u⊑ = tag★⇒★}
-      {p = _ , gen nonvarA zero∈A p
-        {{extensionP}} B≢★}
-      {q = _ , q}
-      (trans eq
-        (sym (function-tag-sequence q ★⇒★≢B)))
-tag-prefix-compose-right-widening
-    {u⊑ = tag★⇒★}
-    {p = _ , gen nonvarA zero∈A p
-      {{extensionP}} B≢★}
-    {q = _ , untag★⇒★︔ q [ ★⇒★≢B ]}
-    {u′⊑ = ∀ʷ c} comp′ (`∀ c′) eq | refl =
-  trans
-    (cong (λ c → (★⇒★ ？) ︔ᶜ c)
-      (composeⁿ-left-evidence (right-compose comp′)
-        q (gen nonvarA zero∈A p {{extensionP}} B≢★)
-        (proj₂ (dualʷ (`∀ c′ , ∀ʷ c)))))
-    (sym
-      (function-tag-sequence
-        (proj₂
-          (composeⁿ (right-compose comp′)
-            (gen nonvarA zero∈A p {{extensionP}} B≢★)
-            (proj₂ (dualʷ (`∀ c′ , ∀ʷ c)))))
-        (λ ())))
+tag-prefix-cancel {p = p} {q = q} wfΣ eq =
+  narrowing-determined wfΣ p q
 
 ------------------------------------------------------------------------
 -- Left widening tag inversion
 ------------------------------------------------------------------------
 
-left-widening-tag-inversion :
-    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ A B G}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {σ : Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ}
-      {γ : Φ ∣ Δᴸ ⊢ Γᴸ ⊒ᵍ Γᴿ ⊣ Δᴿ}
-      {u⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {r : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-  → Value V
-  → Value V′
-  → Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-      ⊢ᴺ V ⟨ G ! ⟩ ⊒ V′ ⦂ ★ ⊒ B ∶ r
-  → dualʷ (G ! , u⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ r
-  → Σ[ p′ ∈ (Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ) ]
-      (p′ ≐ⁿ p)
-    × (Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-        ⊢ᴺ V ⊒ V′ ⦂ A ⊒ B ∶ p′)
-left-widening-tag-inversion vV ()
-  (⊒blame M⊢) eq
-left-widening-tag-inversion {u⊑ = tag ι} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag ι} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq =
-  p , refl ,
-  ⊒castʷ {u′⊑ = u′⊑} {p = q} {q = p}
-    rightU u′⊢
-    (castⁿ⊒castⁿ {left = leftD} {right = rightD}
-      {s⊒ = d⊒} {t⊒ = d′⊒}
-      M⊒M′ d⊢ d′⊢ eqDown)
-    (sym
-      (tag-prefix-cancelᶜ
-        {left = leftU}
-        {left′ = left-id-one-sidedᵢ}
-        {u⊑ = tag ι}
-        {v⊑ = tag ι}
-        {p = q}
-        {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-        (trans eqUp
-          (tag-prefix-compose-right-widening
-            {u⊑ = tag ι} {p = p} {q = r}
-            {u′⊑ = u′⊑} rightU iu′ eq))))
-left-widening-tag-inversion {u⊑ = tag★⇒★} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag★⇒★} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq =
-  p , refl ,
-  ⊒castʷ {u′⊑ = u′⊑} {p = q} {q = p}
-    rightU u′⊢
-    (castⁿ⊒castⁿ {left = leftD} {right = rightD}
-      {s⊒ = d⊒} {t⊒ = d′⊒}
-      M⊒M′ d⊢ d′⊢ eqDown)
-    (sym
-      (tag-prefix-cancelᶜ
-        {left = leftU}
-        {left′ = left-id-one-sidedᵢ}
-        {u⊑ = tag★⇒★}
-        {v⊑ = tag★⇒★}
-        {p = q}
-        {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-        (trans eqUp
-          (tag-prefix-compose-right-widening
-            {u⊑ = tag★⇒★} {p = p} {q = r}
-            {u′⊑ = u′⊑} rightU iu′ eq))))
-left-widening-tag-inversion {u⊑ = tag ι} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag .ι} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq =
-  p′ , tag-prefix-cancelᶜ
-    {left = left′} {left′ = left-id-one-sidedᵢ}
-    {u⊑ = tag ι} {v⊑ = tag ι} {p = p′} {q = p}
-    (trans eq′ (sym eq)) , V⊒V′
-left-widening-tag-inversion {u⊑ = tag★⇒★} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag★⇒★} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq =
-  p′ , tag-prefix-cancelᶜ
-    {left = left′} {left′ = left-id-one-sidedᵢ}
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★} {p = p′} {q = p}
-    (trans eq′ (sym eq)) , V⊒V′
-left-widening-tag-inversion vV vV′
-    (⊒Λ {B≢★ = B≢★}
-      extension preservation vV″ V⊒V″) eq =
-  ⊥-elim (B≢★ refl)
-left-widening-tag-inversion vV vV′
-    (⊒⟨ν⟩ {B≢★ = B≢★}
-      vV″ V″⊢ hC c⊢ V⊒V″) eq =
-  ⊥-elim (B≢★ refl)
-left-widening-tag-inversion {u⊑ = u⊑} {p = p}
-    vV (vV′ ⟨ id′ ⟩)
-    (⊒castⁿ {d′ = d′} {d′⊒ = d′⊒}
-      {p = p₀} {q = r} right′ d′⊢ V⊒V′ eq′) eq
-    with tag-factor-right-narrowing
-      {u⊑ = u⊑} {q = p₀} {r = r} {p = p}
-      right′ d′⊒ id′ eq′ eq
-left-widening-tag-inversion {u⊑ = u⊑} {p = p}
-    vV (vV′ ⟨ id′ ⟩)
-    (⊒castⁿ {d′ = d′} {d′⊒ = d′⊒}
-      {p = p₀} {q = r} right′ d′⊢ V⊒V′ eq′) eq
-    | (s , s⊒) , prefix , suffix
-    with left-widening-tag-inversion
-      {u⊑ = u⊑} {p = s , s⊒}
-      vV vV′ V⊒V′ prefix
-left-widening-tag-inversion {p = p}
-    vV (vV′ ⟨ id′ ⟩)
-    (⊒castⁿ {d′⊒ = d′⊒}
-      right′ d′⊢ V⊒V′ eq′) eq
-    | (s , s⊒) , prefix , suffix
-    | (.s , s′⊒) , refl , V⊒V″ =
-  p , refl ,
-  ⊒castⁿ {d′⊒ = d′⊒} {p = s , s′⊒} {q = p}
-    right′ d′⊢ V⊒V″
-    (trans
-      (composeⁿ-left-evidence (right-compose right′)
-        s′⊒ s⊒ d′⊒)
-      suffix)
-left-widening-tag-inversion {u⊑ = u⊑} {p = p}
-    vV (vV″ ⟨ iu′ ⟩)
-    (⊒castʷ {u′ = u′} {u′⊑ = u′⊑}
-      {p = p₀} {q = r} right′ u′⊢ V⊒V′ eq′) eq
-    with left-widening-tag-inversion
-      {u⊑ = u⊑}
-      {p = p ⨟ⁿ[ right′ ] dualʷ (u′ , u′⊑)}
-      vV vV″ V⊒V′
-      (trans
-        (sym
-          (tag-prefix-compose-right-widening
-            {u⊑ = u⊑} {p = p} {q = r}
-            {u′⊑ = u′⊑} right′ iu′ eq))
-        eq′)
-... | p′ , p′≐p⨟u′ , V⊒V″ =
-  p , refl ,
-  ⊒castʷ {u′⊑ = u′⊑} {p = p′} {q = p}
-    right′ u′⊢ V⊒V″ (sym p′≐p⨟u′)
-
-------------------------------------------------------------------------
--- Left widening tag inversion with a separately supplied tag
-------------------------------------------------------------------------
-
 left-widening-tag-inversion-match :
-    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ C B G H}
+    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ A B C C′ G H}
       {Φ : ImpCtx Δᴸ Δᴿ}
-      {σ : Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ}
-      {γ : Φ ∣ Δᴸ ⊢ Γᴸ ⊒ᵍ Γᴿ ⊣ Δᴿ}
-      {v⊑ : idᵢ Δᴸ ∣ Δᴸ ⊢ H ! ⦂ C ⊑ ★ ⊣ Δᴸ}
-      {r : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
-      {p : Φ ∣ Δᴸ ⊢ C ⊒ B ⊣ Δᴿ}
+      {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {Γᴸ} {Γᴿ}}
+      {v⊑ : ρ ⊢ᴸʷ H ! ⦂ A ⊑ ★}
+      {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {qᴸ : ρ ⊢ᴸⁿ ★ ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B}
+  → StoreWf Δᴸ Σᴸ
   → Value V
   → Value V′
-  → Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-      ⊢ᴺ V ⟨ G ! ⟩ ⊒ V′ ⦂ ★ ⊒ B ∶ r
-  → dualʷ (H ! , v⊑) ⨟ˡⁿ[ left-id-one-sidedᵢ ] p ≐ⁿ r
-  → Σ[ G≡H ∈ G ≡ H ]
-      Σ[ p′ ∈ (Φ ∣ Δᴸ ⊢ C ⊒ B ⊣ Δᴿ) ]
-        (p′ ≐ⁿ p)
-      × (Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-          ⊢ᴺ V ⊒ V′ ⦂ C ⊒ B ∶ p′)
-left-widening-tag-inversion-match vV ()
-    (⊒blame M⊢) eq
-left-widening-tag-inversion-match {v⊑ = tag κ} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag ι} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq
-    with tag-prefix-matchᶜ
-      {left = leftU} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag ι} {v⊑ = tag κ}
-      {p = q}
-      {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-      (trans eqUp
-        (tag-prefix-compose-right-widening
-          {u⊑ = tag κ} {p = p} {q = r}
-          {u′⊑ = u′⊑} rightU iu′ eq))
-left-widening-tag-inversion-match {v⊑ = tag κ} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag ι} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq | refl =
-  refl , p , refl ,
-  ⊒castʷ {u′⊑ = u′⊑} {p = q} {q = p}
-    rightU u′⊢
-    (castⁿ⊒castⁿ {left = leftD} {right = rightD}
-      {s⊒ = d⊒} {t⊒ = d′⊒}
-      M⊒M′ d⊢ d′⊢ eqDown)
-    (sym
-      (tag-prefix-cancelᶜ
-        {left = leftU} {left′ = left-id-one-sidedᵢ}
-        {u⊑ = tag κ}
-        {v⊑ = tag κ}
-        {p = q}
-        {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-        (trans eqUp
-          (tag-prefix-compose-right-widening
-            {u⊑ = tag κ} {p = p} {q = r}
-            {u′⊑ = u′⊑} rightU iu′ eq))))
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag ι} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq
-    with tag-prefix-matchᶜ
-      {left = leftU} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag ι} {v⊑ = tag★⇒★}
-      {p = q}
-      {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-      (trans eqUp
-        (tag-prefix-compose-right-widening
-          {u⊑ = tag★⇒★} {p = p} {q = r}
-          {u′⊑ = u′⊑} rightU iu′ eq))
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag ι} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq | ()
-left-widening-tag-inversion-match {v⊑ = tag ι} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag★⇒★} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq
-    with tag-prefix-matchᶜ
-      {left = leftU} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag★⇒★} {v⊑ = tag ι}
-      {p = q}
-      {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-      (trans eqUp
-        (tag-prefix-compose-right-widening
-          {u⊑ = tag ι} {p = p} {q = r}
-          {u′⊑ = u′⊑} rightU iu′ eq))
-left-widening-tag-inversion-match {v⊑ = tag ι} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag★⇒★} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq | ()
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag★⇒★} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq
-    with tag-prefix-matchᶜ
-      {left = leftU} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag★⇒★} {v⊑ = tag★⇒★}
-      {p = q}
-      {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-      (trans eqUp
-        (tag-prefix-compose-right-widening
-          {u⊑ = tag★⇒★} {p = p} {q = r}
-          {u′⊑ = u′⊑} rightU iu′ eq))
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {r = r} {p = p}
-    vV (vV′ ⟨ iu′ ⟩)
-    (up⊒up {u⊑ = tag★⇒★} {u′⊑ = u′⊑}
-      (down⊒down {p = p₀} {d⊒ = d⊒} {d′⊒ = d′⊒}
-        {q = q} M⊒M′ leftD rightD d⊢ d′⊢ eqDown)
-      leftU rightU u⊢ u′⊢ eqUp) eq | refl =
-  refl , p , refl ,
-  ⊒castʷ {u′⊑ = u′⊑} {p = q} {q = p}
-    rightU u′⊢
-    (castⁿ⊒castⁿ {left = leftD} {right = rightD}
-      {s⊒ = d⊒} {t⊒ = d′⊒}
-      M⊒M′ d⊢ d′⊢ eqDown)
-    (sym
-      (tag-prefix-cancelᶜ
-        {left = leftU} {left′ = left-id-one-sidedᵢ}
-        {u⊑ = tag★⇒★}
-        {v⊑ = tag★⇒★}
-        {p = q}
-        {q = p ⨟ⁿ[ rightU ] dualʷ (_ , u′⊑)}
-        (trans eqUp
-          (tag-prefix-compose-right-widening
-            {u⊑ = tag★⇒★} {p = p} {q = r}
-            {u′⊑ = u′⊑} rightU iu′ eq))))
-left-widening-tag-inversion-match {v⊑ = tag κ} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag ι} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq
-    with tag-prefix-matchᶜ
-      {left = left′} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag ι} {v⊑ = tag κ} {p = p′} {q = p}
+  → ρ ⊢ᴺ V ⟨ G ! ⟩ ⊒ V′
+      ∶ (qᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → (dualʷ (H ! , v⊑) ⨟ⁿ pᴸ) ≐ⁿ qᴸ
+  → (G ≡ H)
+    × Σ[ pᴸ′ ∈ ρ ⊢ᴸⁿ A ⊒ C ]
+        (pᴸ′ ≐ⁿ pᴸ)
+      × (ρ ⊢ᴺ V ⊒ V′
+          ∶ (pᴸ′ ⨟ᶠ relocation ⨟ᶠ pᴿ))
+left-widening-tag-inversion-match wfΣᴸ vV () (⊒blame M⊢) eq
+left-widening-tag-inversion-match
+    {v⊑ = tag H hH allowedH H꞉A}
+    wfΣᴸ vV vV′
+    (castʷ⊒
+      {pᴸ = pᴸ′}
+      {s⦂ = tag G hG allowedG G꞉A′}
+      V⊒V′ eq′) eq
+    with dual-tag-composition-tags-equal
+      {u⊑ = tag G hG allowedG G꞉A′}
+      {v⊑ = tag H hH allowedH H꞉A}
+      {p = pᴸ′} {q = _}
       (trans eq′ (sym eq))
-left-widening-tag-inversion-match {v⊑ = tag κ} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag ι} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq | refl =
-  refl , p′ ,
-  tag-prefix-cancelᶜ
-    {left = left′} {left′ = left-id-one-sidedᵢ}
-    {u⊑ = tag κ} {v⊑ = tag κ} {p = p′} {q = p}
+left-widening-tag-inversion-match
+    {v⊑ = tag .G hH allowedH H꞉A}
+    wfΣᴸ vV vV′
+    (castʷ⊒
+      {pᴸ = pᴸ′}
+      {s⦂ = tag G hG allowedG G꞉A′}
+      V⊒V′ eq′) eq
+    | refl with tagged-unique G꞉A′ H꞉A
+left-widening-tag-inversion-match
+    {v⊑ = tag .G hH allowedH H꞉A}
+    wfΣᴸ vV vV′
+    (castʷ⊒
+      {pᴸ = pᴸ′}
+      {s⦂ = tag G hG allowedG G꞉A′}
+      V⊒V′ eq′) eq
+    | refl | refl =
+  refl , pᴸ′ ,
+  tag-prefix-cancel
+    {u = tag G hG allowedG G꞉A′}
+    {v = tag G hH allowedH H꞉A}
+    {p = pᴸ′}
+    wfΣᴸ
     (trans eq′ (sym eq)) ,
   V⊒V′
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag ι} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq
-    with tag-prefix-matchᶜ
-      {left = left′} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag ι} {v⊑ = tag★⇒★} {p = p′} {q = p}
-      (trans eq′ (sym eq))
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag ι} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq | ()
-left-widening-tag-inversion-match {v⊑ = tag κ} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag★⇒★} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq
-    with tag-prefix-matchᶜ
-      {left = left′} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag★⇒★} {v⊑ = tag κ} {p = p′} {q = p}
-      (trans eq′ (sym eq))
-left-widening-tag-inversion-match {v⊑ = tag κ} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag★⇒★} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq | ()
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag★⇒★} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq
-    with tag-prefix-matchᶜ
-      {left = left′} {left′ = left-id-one-sidedᵢ}
-      {u⊑ = tag★⇒★} {v⊑ = tag★⇒★} {p = p′} {q = p}
-      (trans eq′ (sym eq))
-left-widening-tag-inversion-match {v⊑ = tag★⇒★} {p = p}
-    vV vV′
-    (castʷ⊒ {u⊑ = tag★⇒★} {p = p′}
-      left′ u⊢ V⊒V′ eq′) eq | refl =
-  refl , p′ ,
-  tag-prefix-cancelᶜ
-    {left = left′} {left′ = left-id-one-sidedᵢ}
-    {u⊑ = tag★⇒★} {v⊑ = tag★⇒★} {p = p′} {q = p}
-    (trans eq′ (sym eq)) ,
-  V⊒V′
-left-widening-tag-inversion-match vV vV′
-    (⊒Λ {B≢★ = B≢★}
-      extension preservation vV″ V⊒V″) eq =
+left-widening-tag-inversion-match wfΣᴸ vV vV′
+    (⊒Λ {B≢★ = B≢★} extension vW′ W⊒W′) eq =
   ⊥-elim (B≢★ refl)
-left-widening-tag-inversion-match vV vV′
-    (⊒⟨ν⟩ {B≢★ = B≢★}
-      vV″ V″⊢ hC c⊢ V⊒V″) eq =
+left-widening-tag-inversion-match wfΣᴸ vV vV′
+    (⊒⟨ν⟩ {B≢★ = B≢★} vW′ W′⊢ hC c⊢ W⊒W′) eq =
   ⊥-elim (B≢★ refl)
-left-widening-tag-inversion-match {v⊑ = v⊑} {p = p}
-    vV (vV′ ⟨ id′ ⟩)
-    (⊒castⁿ {d′ = d′} {d′⊒ = d′⊒}
-      {p = p₀} {q = r} right′ d′⊢ V⊒V′ eq′) eq
-    with tag-factor-right-narrowing
-      {u⊑ = v⊑} {q = p₀} {r = r} {p = p}
-      right′ d′⊒ id′ eq′ eq
-left-widening-tag-inversion-match {v⊑ = v⊑} {p = p}
-    vV (vV′ ⟨ id′ ⟩)
-    (⊒castⁿ {d′ = d′} {d′⊒ = d′⊒}
-      {p = p₀} {q = r} right′ d′⊢ V⊒V′ eq′) eq
-    | (s , s⊒) , prefix , suffix
+left-widening-tag-inversion-match {v⊑ = v⊑} {pᴸ = pᴸ}
+    wfΣᴸ vV (vW′ ⟨ i′ ⟩)
+    (⊒castⁿ {t⦂ = t⦂} W⊒W′ eq′) eq
     with left-widening-tag-inversion-match
-      {v⊑ = v⊑} {p = s , s⊒}
-      vV vV′ V⊒V′ prefix
-left-widening-tag-inversion-match {p = p}
-    vV (vV′ ⟨ id′ ⟩)
-    (⊒castⁿ {d′⊒ = d′⊒}
-      right′ d′⊢ V⊒V′ eq′) eq
-    | (s , s⊒) , prefix , suffix
-    | G≡H , (.s , s′⊒) , refl , V⊒V″ =
-  G≡H , p , refl ,
-  ⊒castⁿ {d′⊒ = d′⊒} {p = s , s′⊒} {q = p}
-    right′ d′⊢ V⊒V″
-    (trans
-      (composeⁿ-left-evidence (right-compose right′)
-        s′⊒ s⊒ d′⊒)
-      suffix)
-left-widening-tag-inversion-match {v⊑ = v⊑} {p = p}
-    vV (vV″ ⟨ iu′ ⟩)
-    (⊒castʷ {u′ = u′} {u′⊑ = u′⊑}
-      {p = p₀} {q = r} right′ u′⊢ V⊒V′ eq′) eq
+      {v⊑ = v⊑} {pᴸ = pᴸ} wfΣᴸ vV vW′ W⊒W′ eq
+left-widening-tag-inversion-match wfΣᴸ vV (vW′ ⟨ i′ ⟩)
+    (⊒castⁿ {t⦂ = t⦂} W⊒W′ eq′) eq
+    | G≡H , pᴸ′ , pᴸ′≐pᴸ , V⊒W′ =
+  G≡H , pᴸ′ , pᴸ′≐pᴸ ,
+  ⊒castⁿ {t⦂ = t⦂} V⊒W′ eq′
+left-widening-tag-inversion-match {v⊑ = v⊑} {pᴸ = pᴸ}
+    wfΣᴸ vV (vW′ ⟨ i′ ⟩)
+    (⊒castʷ {t⦂ = t⦂} W⊒W′ eq′) eq
     with left-widening-tag-inversion-match
-      {v⊑ = v⊑}
-      {p = p ⨟ⁿ[ right′ ] dualʷ (u′ , u′⊑)}
-      vV vV″ V⊒V′
-      (trans
-        (sym
-          (tag-prefix-compose-right-widening
-            {u⊑ = v⊑} {p = p} {q = r}
-            {u′⊑ = u′⊑} right′ iu′ eq))
-        eq′)
-left-widening-tag-inversion-match {p = p}
-    vV (vV″ ⟨ iu′ ⟩)
-    (⊒castʷ {u′⊑ = u′⊑}
-      right′ u′⊢ V⊒V′ eq′) eq
-    | G≡H , p′ , p′≐p⨟u′ , V⊒V″ =
-  G≡H , p , refl ,
-  ⊒castʷ {u′⊑ = u′⊑} {p = p′} {q = p}
-    right′ u′⊢ V⊒V″ (sym p′≐p⨟u′)
+      {v⊑ = v⊑} {pᴸ = pᴸ} wfΣᴸ vV vW′ W⊒W′ eq
+left-widening-tag-inversion-match wfΣᴸ vV (vW′ ⟨ i′ ⟩)
+    (⊒castʷ {t⦂ = t⦂} W⊒W′ eq′) eq
+    | G≡H , pᴸ′ , pᴸ′≐pᴸ , V⊒W′ =
+  G≡H , pᴸ′ , pᴸ′≐pᴸ ,
+  ⊒castʷ {t⦂ = t⦂} V⊒W′ eq′
 
-------------------------------------------------------------------------
--- Recontextualized supplied tags
-------------------------------------------------------------------------
-
-tag-under-id :
-    ∀ {Δ A G}
-      {Ψ : ImpCtx Δ Δ}
-  → Ψ ∣ Δ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δ
-  → idᵢ Δ ∣ Δ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δ
-tag-under-id (tag ι) = tag ι
-tag-under-id tag★⇒★ = tag★⇒★
-
-tag-prefix-recontext :
-    ∀ {Δᴸ Δᴿ A B G}
+left-widening-tag-inversion :
+    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ A B C C′ G}
       {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ : ImpCtx Δᴸ Δᴸ}
-      {left : LeftOneSidedᵢ Φ Ψ}
-      {v⊑ : Ψ ∣ Δᴸ ⊢ G ! ⦂ A ⊑ ★ ⊣ Δᴸ}
-      {p : Φ ∣ Δᴸ ⊢ A ⊒ B ⊣ Δᴿ}
-  → proj₁ (dualʷ (G ! , v⊑) ⨟ˡⁿ[ left ] p)
-      ≡ proj₁ (dualʷ (G ! , tag-under-id v⊑)
-        ⨟ˡⁿ[ left-id-one-sidedᵢ ] p)
-tag-prefix-recontext
-    {left = record { left-one-sided = one ; left-compose = comp }}
-    {v⊑ = tag ι}
-    {p = _ , idᵃ (‵ .ι) (‵ κ) hA hB refl} =
-  refl
-tag-prefix-recontext
-    {left = record { left-one-sided = one ; left-compose = comp }}
-    {v⊑ = tag ι}
-    {p = _ , gen nonvarA zero∈A p B≢★} =
-  ⊥-elim (base-target-no-member p zero∈A)
-tag-prefix-recontext {B = B}
-    {left = record { left-one-sided = one ; left-compose = comp }}
-    {v⊑ = tag★⇒★} {p = _ , p}
-    with (★ ⇒ ★) ≟Ty B
-tag-prefix-recontext
-    {left = record { left-one-sided = one ; left-compose = comp }}
-    {v⊑ = tag★⇒★}
-    {p = _ , p₁ ↦ p₂} | yes refl =
-  refl
-tag-prefix-recontext
-    {left = record { left-one-sided = one ; left-compose = comp }}
-    {v⊑ = tag★⇒★} {p = _ , p} | no ★⇒★≢B =
-  refl
-
-left-widening-tag-inversion-match-one-sided :
-    ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ V V′ C B G H}
-      {Φ : ImpCtx Δᴸ Δᴿ}
-      {Ψ : ImpCtx Δᴸ Δᴸ}
-      {σ : Φ ∣ Δᴸ ⊢ Σᴸ ⊒ˢ Σᴿ ⊣ Δᴿ}
-      {γ : Φ ∣ Δᴸ ⊢ Γᴸ ⊒ᵍ Γᴿ ⊣ Δᴿ}
-      {left : LeftOneSidedᵢ Φ Ψ}
-      {v⊑ : Ψ ∣ Δᴸ ⊢ H ! ⦂ C ⊑ ★ ⊣ Δᴸ}
-      {r : Φ ∣ Δᴸ ⊢ ★ ⊒ B ⊣ Δᴿ}
-      {p : Φ ∣ Δᴸ ⊢ C ⊒ B ⊣ Δᴿ}
+      {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {Γᴸ} {Γᴿ}}
+      {u⊑ : ρ ⊢ᴸʷ G ! ⦂ A ⊑ ★}
+      {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+      {qᴸ : ρ ⊢ᴸⁿ ★ ⊒ C}
+      {relocation : Φ ⊢ C ≈ C′}
+      {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ B}
+  → StoreWf Δᴸ Σᴸ
   → Value V
   → Value V′
-  → Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-      ⊢ᴺ V ⟨ G ! ⟩ ⊒ V′ ⦂ ★ ⊒ B ∶ r
-  → dualʷ (H ! , v⊑) ⨟ˡⁿ[ left ] p ≐ⁿ r
-  → Σ[ G≡H ∈ G ≡ H ]
-      Σ[ p′ ∈ (Φ ∣ Δᴸ ⊢ C ⊒ B ⊣ Δᴿ) ]
-        (p′ ≐ⁿ p)
-      × (Φ ∣ Δᴸ ∣ Δᴿ ∣ σ ∣ γ
-          ⊢ᴺ V ⊒ V′ ⦂ C ⊒ B ∶ p′)
-left-widening-tag-inversion-match-one-sided
-    {left = left} {v⊑ = tag ι} {p = p}
-    vV vV′ V⊒V′ eq =
-  left-widening-tag-inversion-match
-    {v⊑ = tag ι} {p = p} vV vV′ V⊒V′
-    (trans
-      (sym (tag-prefix-recontext
-        {left = left} {v⊑ = tag ι} {p = p}))
-      eq)
-left-widening-tag-inversion-match-one-sided
-    {left = left} {v⊑ = tag★⇒★} {p = p}
-    vV vV′ V⊒V′ eq =
-  left-widening-tag-inversion-match
-    {v⊑ = tag★⇒★} {p = p} vV vV′ V⊒V′
-    (trans
-      (sym (tag-prefix-recontext
-        {left = left} {v⊑ = tag★⇒★} {p = p}))
-      eq)
+  → ρ ⊢ᴺ V ⟨ G ! ⟩ ⊒ V′
+      ∶ (qᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → (dualʷ (G ! , u⊑) ⨟ⁿ pᴸ) ≐ⁿ qᴸ
+  → Σ[ pᴸ′ ∈ ρ ⊢ᴸⁿ A ⊒ C ]
+      (pᴸ′ ≐ⁿ pᴸ)
+    × (ρ ⊢ᴺ V ⊒ V′
+        ∶ (pᴸ′ ⨟ᶠ relocation ⨟ᶠ pᴿ))
+left-widening-tag-inversion {G = G} {u⊑ = u⊑}
+    wfΣᴸ vV vV′ taggedV⊒V′ eq
+    with left-widening-tag-inversion-match
+      {H = G} {v⊑ = u⊑} wfΣᴸ vV vV′ taggedV⊒V′ eq
+left-widening-tag-inversion wfΣᴸ vV vV′ taggedV⊒V′ eq
+    | refl , pᴸ′ , pᴸ′≐pᴸ , untaggedV⊒V′ =
+  pᴸ′ , pᴸ′≐pᴸ , untaggedV⊒V′

--- a/GTPLC/proof/NarrowWidenBinderGap.agda
+++ b/GTPLC/proof/NarrowWidenBinderGap.agda
@@ -1,0 +1,873 @@
+module proof.NarrowWidenBinderGap where
+
+-- File Charter:
+--   * Rules out the structural-universal/generalization and
+--     structural-universal/instantiation overlaps used by determinism.
+--   * Tracks a selected type-variable occurrence through narrowing and
+--     widening and compares its endpoints across a binder insertion.
+
+open import Data.Bool using (true)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List using (_∷_)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (suc; zero)
+open import Data.Nat.Properties using (suc-injective)
+open import Data.Product using (_,_; _×_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; cong; cong₂; refl; subst; sym; trans)
+
+open import Types
+open import TyStore
+open import Coercions
+open import NarrowWiden
+open import proof.TyStore using
+  (∈-renameTyStoreᵗ; rename-member-inv; StoreWf-⟰ᵗ;
+   StoreWf-bind; unique)
+open import proof.TypeInTypeSubst using
+  (renameᵗ-compose; renameᵗ-id)
+
+------------------------------------------------------------------------
+-- Occurrence paths selected by an id-only variable
+------------------------------------------------------------------------
+
+mutual
+
+  data NarrowPath (X : TyVar) : Ty → Ty → Set where
+
+    np-var : NarrowPath X (＇ X) (＇ X)
+
+    np-fun₁ : ∀ {A A′ B B′}
+      → WidenPath X A′ A
+      → NarrowPath X (A ⇒ B) (A′ ⇒ B′)
+
+    np-fun₂ : ∀ {A A′ B B′}
+      → NarrowPath X B B′
+      → NarrowPath X (A ⇒ B) (A′ ⇒ B′)
+
+    np-all : ∀ {A B}
+      → NarrowPath (suc X) A B
+      → NarrowPath X (`∀ A) (`∀ B)
+
+    np-gen : ∀ {A B}
+      → NarrowPath (suc X) (⇑ᵗ A) B
+      → NarrowPath X A (`∀ B)
+
+  data WidenPath (X : TyVar) : Ty → Ty → Set where
+
+    wp-var : WidenPath X (＇ X) (＇ X)
+
+    wp-fun₁ : ∀ {A A′ B B′}
+      → NarrowPath X A′ A
+      → WidenPath X (A ⇒ B) (A′ ⇒ B′)
+
+    wp-fun₂ : ∀ {A A′ B B′}
+      → WidenPath X B B′
+      → WidenPath X (A ⇒ B) (A′ ⇒ B′)
+
+    wp-all : ∀ {A B}
+      → WidenPath (suc X) A B
+      → WidenPath X (`∀ A) (`∀ B)
+
+    wp-inst : ∀ {A B}
+      → WidenPath (suc X) A (⇑ᵗ B)
+      → WidenPath X (`∀ A) B
+
+id-tag-exclusive : ∀ {m : Mode}
+  → m ≡ id-only
+  → tagModeAllowed m ≡ true
+  → ⊥
+id-tag-exclusive {m} X-id allowed with m
+id-tag-exclusive X-id () | id-only
+id-tag-exclusive () allowed | tag-or-id
+id-tag-exclusive () allowed | seal-or-id
+
+id-seal-exclusive : ∀ {m : Mode}
+  → m ≡ id-only
+  → sealModeAllowed m ≡ true
+  → ⊥
+id-seal-exclusive {m} X-id allowed with m
+id-seal-exclusive X-id () | id-only
+id-seal-exclusive () allowed | tag-or-id
+id-seal-exclusive () allowed | seal-or-id
+
+tagged-member-id-only⊥ : ∀ {μ X G A}
+  → μ X ≡ id-only
+  → tagAllowed μ G ≡ true
+  → G ꞉ A
+  → X ∈ᵗ A
+  → ⊥
+tagged-member-id-only⊥ {X = X} X-id allowed (tag-var .X) var-∈ =
+  id-tag-exclusive X-id allowed
+tagged-member-id-only⊥ X-id allowed (tag-base ι) ()
+tagged-member-id-only⊥ X-id allowed tag-fun (∈-fun-left ())
+tagged-member-id-only⊥ X-id allowed tag-fun (∈-fun-right ())
+
+shift-member-inv : ∀ {X A}
+  → suc X ∈ᵗ ⇑ᵗ A
+  → X ∈ᵗ A
+shift-member-inv {X = X} {A = A} occ with rename-member-inv suc occ
+shift-member-inv {X = X} {A = A} occ | Y , eq , Y∈A =
+  subst (_∈ᵗ A) (sym (suc-injective eq)) Y∈A
+
+mutual
+
+  narrowing-target-member-id-only : ∀ {μ Δ Σ c A B X}
+    → μ X ≡ id-only
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+    → X ∈ᵗ B
+    → X ∈ᵗ A
+  narrowing-target-member-id-only X-id (idᵃ (＇ X) hX) var-∈ = var-∈
+  narrowing-target-member-id-only X-id (idᵃ (‵ ι) hA) ()
+  narrowing-target-member-id-only X-id (idᵃ ★ hA) ()
+  narrowing-target-member-id-only X-id (p ↦ q) (∈-fun-left occ) =
+    ∈-fun-left (widening-source-member-id-only X-id p occ)
+  narrowing-target-member-id-only X-id (p ↦ q) (∈-fun-right occ) =
+    ∈-fun-right (narrowing-target-member-id-only X-id q occ)
+  narrowing-target-member-id-only {X = X} X-id (∀ⁿ p) (∈-all occ) =
+    ∈-all
+      (narrowing-target-member-id-only {X = suc X} X-id p occ)
+  narrowing-target-member-id-only X-id
+      (untag G hG allowed G꞉B) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉B occ)
+  narrowing-target-member-id-only X-id
+      (untag-seq G hG allowed G꞉A p nonvarB A≢B) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉A
+      (narrowing-target-member-id-only X-id p occ))
+  narrowing-target-member-id-only X-id
+      (seal X<Δ hA X,A∈Σ allowed) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  narrowing-target-member-id-only X-id
+      (seal-seq p X<Δ X,A∈Σ allowed A≢B) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  narrowing-target-member-id-only {X = X} X-id
+      (gen nonvarA zero∈A hB p B≢★) (∈-all occ) =
+    shift-member-inv
+      (narrowing-target-member-id-only {X = suc X} X-id p occ)
+
+  widening-source-member-id-only : ∀ {μ Δ Σ c A B X}
+    → μ X ≡ id-only
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+    → X ∈ᵗ A
+    → X ∈ᵗ B
+  widening-source-member-id-only X-id (idᵃ (＇ X) hX) var-∈ = var-∈
+  widening-source-member-id-only X-id (idᵃ (‵ ι) hA) ()
+  widening-source-member-id-only X-id (idᵃ ★ hA) ()
+  widening-source-member-id-only X-id (p ↦ q) (∈-fun-left occ) =
+    ∈-fun-left (narrowing-target-member-id-only X-id p occ)
+  widening-source-member-id-only X-id (p ↦ q) (∈-fun-right occ) =
+    ∈-fun-right (widening-source-member-id-only X-id q occ)
+  widening-source-member-id-only {X = X} X-id (∀ʷ p) (∈-all occ) =
+    ∈-all (widening-source-member-id-only {X = suc X} X-id p occ)
+  widening-source-member-id-only X-id (tag G hG allowed G꞉A) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉A occ)
+  widening-source-member-id-only X-id
+      (tag-seq G p hG allowed G꞉B nonvarA A≢B) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉B
+      (widening-source-member-id-only X-id p occ))
+  widening-source-member-id-only X-id
+      (unseal X<Δ hA X,A∈Σ allowed) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  widening-source-member-id-only X-id
+      (unseal-seq X<Δ X,A∈Σ allowed p A≢B) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  widening-source-member-id-only {X = X} X-id
+      (inst nonvarA zero∈A hB p B≢★) (∈-all occ) =
+    shift-member-inv
+      (widening-source-member-id-only {X = suc X} X-id p occ)
+
+mutual
+
+  narrowing-target-path-id-only : ∀ {μ Δ Σ c A B X}
+    → μ X ≡ id-only
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+    → X ∈ᵗ B
+    → NarrowPath X A B
+  narrowing-target-path-id-only X-id (idᵃ (＇ X) hX) var-∈ = np-var
+  narrowing-target-path-id-only X-id (idᵃ (‵ ι) hA) ()
+  narrowing-target-path-id-only X-id (idᵃ ★ hA) ()
+  narrowing-target-path-id-only X-id (p ↦ q) (∈-fun-left occ) =
+    np-fun₁ (widening-source-path-id-only X-id p occ)
+  narrowing-target-path-id-only X-id (p ↦ q) (∈-fun-right occ) =
+    np-fun₂ (narrowing-target-path-id-only X-id q occ)
+  narrowing-target-path-id-only {X = X} X-id (∀ⁿ p) (∈-all occ) =
+    np-all (narrowing-target-path-id-only {X = suc X} X-id p occ)
+  narrowing-target-path-id-only X-id
+      (untag G hG allowed G꞉B) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉B occ)
+  narrowing-target-path-id-only X-id
+      (untag-seq G hG allowed G꞉A p nonvarB A≢B) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉A
+      (narrowing-target-member-id-only X-id p occ))
+  narrowing-target-path-id-only X-id
+      (seal X<Δ hA X,A∈Σ allowed) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  narrowing-target-path-id-only X-id
+      (seal-seq p X<Δ X,A∈Σ allowed A≢B) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  narrowing-target-path-id-only {X = X} X-id
+      (gen nonvarA zero∈A hB p B≢★) (∈-all occ) =
+    np-gen (narrowing-target-path-id-only {X = suc X} X-id p occ)
+
+  widening-source-path-id-only : ∀ {μ Δ Σ c A B X}
+    → μ X ≡ id-only
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+    → X ∈ᵗ A
+    → WidenPath X A B
+  widening-source-path-id-only X-id (idᵃ (＇ X) hX) var-∈ = wp-var
+  widening-source-path-id-only X-id (idᵃ (‵ ι) hA) ()
+  widening-source-path-id-only X-id (idᵃ ★ hA) ()
+  widening-source-path-id-only X-id (p ↦ q) (∈-fun-left occ) =
+    wp-fun₁ (narrowing-target-path-id-only X-id p occ)
+  widening-source-path-id-only X-id (p ↦ q) (∈-fun-right occ) =
+    wp-fun₂ (widening-source-path-id-only X-id q occ)
+  widening-source-path-id-only {X = X} X-id (∀ʷ p) (∈-all occ) =
+    wp-all (widening-source-path-id-only {X = suc X} X-id p occ)
+  widening-source-path-id-only X-id (tag G hG allowed G꞉A) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉A occ)
+  widening-source-path-id-only X-id
+      (tag-seq G p hG allowed G꞉B nonvarA A≢B) occ =
+    ⊥-elim (tagged-member-id-only⊥ X-id allowed G꞉B
+      (widening-source-member-id-only X-id p occ))
+  widening-source-path-id-only X-id
+      (unseal X<Δ hA X,A∈Σ allowed) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  widening-source-path-id-only X-id
+      (unseal-seq X<Δ X,A∈Σ allowed p A≢B) var-∈ =
+    ⊥-elim (id-seal-exclusive X-id allowed)
+  widening-source-path-id-only {X = X} X-id
+      (inst nonvarA zero∈A hB p B≢★) (∈-all occ) =
+    wp-inst (widening-source-path-id-only {X = suc X} X-id p occ)
+
+------------------------------------------------------------------------
+-- Endpoint spines and freshness
+------------------------------------------------------------------------
+
+Fresh : TyVar → Ty → Set
+Fresh X A = X ∈ᵗ A → ⊥
+
+data EndpointSpine : Ty → Ty → Set where
+
+  spine-renamed : ∀ {L R T ρ τ}
+    → L ≡ renameᵗ ρ T
+    → R ≡ renameᵗ τ T
+    → EndpointSpine L R
+
+  spine-left-all : ∀ {L R}
+    → EndpointSpine L R
+    → EndpointSpine (`∀ L) R
+
+  spine-right-all : ∀ {L R}
+    → EndpointSpine L R
+    → EndpointSpine L (`∀ R)
+
+spine-map-left : ∀ ρ {L R}
+  → EndpointSpine L R
+  → EndpointSpine (renameᵗ ρ L) R
+spine-map-left ρ (spine-renamed {T = T} {ρ = σ} {τ = τ} refl refl) =
+  spine-renamed {T = T} {ρ = λ X → ρ (σ X)} {τ = τ}
+    (renameᵗ-compose σ ρ T) refl
+spine-map-left ρ (spine-left-all sp) =
+  spine-left-all (spine-map-left (extᵗ ρ) sp)
+spine-map-left ρ (spine-right-all sp) =
+  spine-right-all (spine-map-left ρ sp)
+
+spine-map-right : ∀ ρ {L R}
+  → EndpointSpine L R
+  → EndpointSpine L (renameᵗ ρ R)
+spine-map-right ρ (spine-renamed {T = T} {ρ = σ} {τ = τ} refl refl) =
+  spine-renamed {T = T} {ρ = σ} {τ = λ X → ρ (τ X)}
+    refl (renameᵗ-compose τ ρ T)
+spine-map-right ρ (spine-left-all sp) =
+  spine-left-all (spine-map-right ρ sp)
+spine-map-right ρ (spine-right-all sp) =
+  spine-right-all (spine-map-right (extᵗ ρ) sp)
+
+spine-peel-right : ∀ ρ {L R}
+  → EndpointSpine L (`∀ R)
+  → EndpointSpine (renameᵗ ρ L) R
+spine-peel-right ρ (spine-renamed {T = ＇ X} eqL ())
+spine-peel-right ρ (spine-renamed {T = ‵ ι} eqL ())
+spine-peel-right ρ (spine-renamed {T = ★} eqL ())
+spine-peel-right ρ (spine-renamed {T = A ⇒ B} eqL ())
+spine-peel-right ρ
+    (spine-renamed {T = `∀ T} {ρ = σ} {τ = τ} refl refl) =
+  spine-left-all
+    (spine-renamed {T = T}
+      {ρ = λ X → extᵗ ρ (extᵗ σ X)} {τ = extᵗ τ}
+      (renameᵗ-compose (extᵗ σ) (extᵗ ρ) T) refl)
+spine-peel-right ρ (spine-left-all sp) =
+  spine-left-all (spine-peel-right (extᵗ ρ) sp)
+spine-peel-right ρ (spine-right-all sp) = spine-map-left ρ sp
+
+spine-peel-left : ∀ ρ {L R}
+  → EndpointSpine (`∀ L) R
+  → EndpointSpine L (renameᵗ ρ R)
+spine-peel-left ρ (spine-renamed {T = ＇ X} () eqR)
+spine-peel-left ρ (spine-renamed {T = ‵ ι} () eqR)
+spine-peel-left ρ (spine-renamed {T = ★} () eqR)
+spine-peel-left ρ (spine-renamed {T = A ⇒ B} () eqR)
+spine-peel-left ρ
+    (spine-renamed {T = `∀ T} {ρ = σ} {τ = τ} refl refl) =
+  spine-right-all
+    (spine-renamed {T = T} {ρ = extᵗ σ}
+      {τ = λ X → extᵗ ρ (extᵗ τ X)} refl
+      (renameᵗ-compose (extᵗ τ) (extᵗ ρ) T))
+spine-peel-left ρ (spine-left-all sp) = spine-map-right ρ sp
+spine-peel-left ρ (spine-right-all sp) =
+  spine-right-all (spine-peel-left (extᵗ ρ) sp)
+
+spine-peel-right-id : ∀ {L R}
+  → EndpointSpine L (`∀ R)
+  → EndpointSpine L R
+spine-peel-right-id (spine-renamed {T = ＇ X} eqL ())
+spine-peel-right-id (spine-renamed {T = ‵ ι} eqL ())
+spine-peel-right-id (spine-renamed {T = ★} eqL ())
+spine-peel-right-id (spine-renamed {T = A ⇒ B} eqL ())
+spine-peel-right-id
+    (spine-renamed {T = `∀ T} {ρ = ρ} {τ = τ} refl refl) =
+  spine-left-all
+    (spine-renamed {T = T} {ρ = extᵗ ρ} {τ = extᵗ τ} refl refl)
+spine-peel-right-id (spine-left-all sp) =
+  spine-left-all (spine-peel-right-id sp)
+spine-peel-right-id (spine-right-all sp) = sp
+
+spine-peel-left-id : ∀ {L R}
+  → EndpointSpine (`∀ L) R
+  → EndpointSpine L R
+spine-peel-left-id (spine-renamed {T = ＇ X} () eqR)
+spine-peel-left-id (spine-renamed {T = ‵ ι} () eqR)
+spine-peel-left-id (spine-renamed {T = ★} () eqR)
+spine-peel-left-id (spine-renamed {T = A ⇒ B} () eqR)
+spine-peel-left-id
+    (spine-renamed {T = `∀ T} {ρ = ρ} {τ = τ} refl refl) =
+  spine-right-all
+    (spine-renamed {T = T} {ρ = extᵗ ρ} {τ = extᵗ τ} refl refl)
+spine-peel-left-id (spine-left-all sp) = sp
+spine-peel-left-id (spine-right-all sp) =
+  spine-right-all (spine-peel-left-id sp)
+
+spine-strip-both : ∀ {L R}
+  → EndpointSpine (`∀ L) (`∀ R)
+  → EndpointSpine L R
+spine-strip-both (spine-renamed {T = ＇ X} () eqR)
+spine-strip-both (spine-renamed {T = ‵ ι} () eqR)
+spine-strip-both (spine-renamed {T = ★} () eqR)
+spine-strip-both (spine-renamed {T = A ⇒ B} () eqR)
+spine-strip-both
+    (spine-renamed {T = `∀ T} {ρ = ρ} {τ = τ} refl refl) =
+  spine-renamed {T = T} {ρ = extᵗ ρ} {τ = extᵗ τ} refl refl
+spine-strip-both (spine-left-all sp) = spine-peel-right-id sp
+spine-strip-both (spine-right-all sp) = spine-peel-left-id sp
+
+fresh-fun-left : ∀ {X A B}
+  → Fresh X (A ⇒ B)
+  → Fresh X A
+fresh-fun-left fresh occ = fresh (∈-fun-left occ)
+
+fresh-fun-right : ∀ {X A B}
+  → Fresh X (A ⇒ B)
+  → Fresh X B
+fresh-fun-right fresh occ = fresh (∈-fun-right occ)
+
+fresh-shift : ∀ {X A}
+  → Fresh X A
+  → Fresh (suc X) (⇑ᵗ A)
+fresh-shift fresh occ = fresh (shift-member-inv occ)
+
+------------------------------------------------------------------------
+-- A selected path cannot be related across an inserted binder
+------------------------------------------------------------------------
+
+tag-seal-exclusive : ∀ {m : Mode}
+  → m ≡ tag-or-id
+  → sealModeAllowed m ≡ true
+  → ⊥
+tag-seal-exclusive {m} tag-ok seal-ok with m
+tag-seal-exclusive () seal-ok | id-only
+tag-seal-exclusive tag-ok () | tag-or-id
+tag-seal-exclusive () seal-ok | seal-or-id
+
+narrow-path-star-spine⊥ : ∀ {X A B}
+  → NarrowPath X A B
+  → EndpointSpine A ★
+  → ⊥
+narrow-path-star-spine⊥ np-var
+    (spine-renamed {T = ＇ Y} refl ())
+narrow-path-star-spine⊥ (np-fun₁ p)
+    (spine-renamed {T = A ⇒ B} refl ())
+narrow-path-star-spine⊥ (np-fun₂ p)
+    (spine-renamed {T = A ⇒ B} refl ())
+narrow-path-star-spine⊥ (np-all p) (spine-left-all sp) =
+  narrow-path-star-spine⊥ p sp
+narrow-path-star-spine⊥ (np-all p)
+    (spine-renamed {T = `∀ T} refl ())
+narrow-path-star-spine⊥ (np-gen p) sp =
+  narrow-path-star-spine⊥ p (spine-map-left suc sp)
+
+widen-path-star-spine⊥ : ∀ {X A B}
+  → WidenPath X A B
+  → EndpointSpine B ★
+  → ⊥
+widen-path-star-spine⊥ wp-var
+    (spine-renamed {T = ＇ Y} refl ())
+widen-path-star-spine⊥ (wp-fun₁ p)
+    (spine-renamed {T = A ⇒ B} refl ())
+widen-path-star-spine⊥ (wp-fun₂ p)
+    (spine-renamed {T = A ⇒ B} refl ())
+widen-path-star-spine⊥ (wp-all p) (spine-left-all sp) =
+  widen-path-star-spine⊥ p sp
+widen-path-star-spine⊥ (wp-all p)
+    (spine-renamed {T = `∀ T} refl ())
+widen-path-star-spine⊥ (wp-inst p) sp =
+  widen-path-star-spine⊥ p (spine-map-left suc sp)
+
+narrowing-var-to-var-tag⊥ : ∀ {μ Δ Σ X Y c}
+  → μ X ≡ tag-or-id
+  → Y ≢ X
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ Y ⊒ ＇ X
+  → ⊥
+narrowing-var-to-var-tag⊥ tag-ok Y≢X (idᵃ (＇ X) hX) =
+  Y≢X refl
+narrowing-var-to-var-tag⊥ tag-ok Y≢X
+    (seal X<Δ hA X,A∈Σ allowed) =
+  tag-seal-exclusive tag-ok allowed
+narrowing-var-to-var-tag⊥ tag-ok Y≢X
+    (seal-seq p X<Δ X,A∈Σ allowed A≢B) =
+  tag-seal-exclusive tag-ok allowed
+
+narrowing-all-to-var-tag⊥ : ∀ {μ Δ Σ X A c}
+  → μ X ≡ tag-or-id
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ (`∀ A) ⊒ ＇ X
+  → ⊥
+narrowing-all-to-var-tag⊥ tag-ok
+    (seal X<Δ hA X,A∈Σ allowed) =
+  tag-seal-exclusive tag-ok allowed
+narrowing-all-to-var-tag⊥ tag-ok
+    (seal-seq p X<Δ X,A∈Σ allowed A≢B) =
+  tag-seal-exclusive tag-ok allowed
+
+widening-var-to-var-tag⊥ : ∀ {μ Δ Σ X Y c}
+  → μ X ≡ tag-or-id
+  → Y ≢ X
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ ＇ Y
+  → ⊥
+widening-var-to-var-tag⊥ tag-ok Y≢X (idᵃ (＇ X) hX) =
+  Y≢X refl
+widening-var-to-var-tag⊥ tag-ok Y≢X
+    (unseal X<Δ hA X,A∈Σ allowed) =
+  tag-seal-exclusive tag-ok allowed
+widening-var-to-var-tag⊥ tag-ok Y≢X
+    (unseal-seq X<Δ X,A∈Σ allowed p A≢B) =
+  tag-seal-exclusive tag-ok allowed
+
+widening-var-to-all-tag⊥ : ∀ {μ Δ Σ X A c}
+  → μ X ≡ tag-or-id
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ (`∀ A)
+  → ⊥
+widening-var-to-all-tag⊥ tag-ok
+    (unseal X<Δ hA X,A∈Σ allowed) =
+  tag-seal-exclusive tag-ok allowed
+widening-var-to-all-tag⊥ tag-ok
+    (unseal-seq X<Δ X,A∈Σ allowed p A≢B) =
+  tag-seal-exclusive tag-ok allowed
+
+fresh-variable-neq : ∀ {X Y}
+  → Fresh X (＇ Y)
+  → Y ≢ X
+fresh-variable-neq fresh refl = fresh var-∈
+
+narrowing-tag-var-spine⊥ : ∀ {μ Δ Σ X C c}
+  → μ X ≡ tag-or-id
+  → EndpointSpine (＇ X) C
+  → Fresh X C
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ C ⊒ ＇ X
+  → ⊥
+narrowing-tag-var-spine⊥ tag-ok
+    (spine-renamed {T = ＇ Y} refl refl) fresh p =
+  narrowing-var-to-var-tag⊥ tag-ok (fresh-variable-neq fresh) p
+narrowing-tag-var-spine⊥ tag-ok (spine-right-all sp) fresh p =
+  narrowing-all-to-var-tag⊥ tag-ok p
+
+widening-tag-var-spine⊥ : ∀ {μ Δ Σ X C c}
+  → μ X ≡ tag-or-id
+  → EndpointSpine (＇ X) C
+  → Fresh X C
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ C
+  → ⊥
+widening-tag-var-spine⊥ tag-ok
+    (spine-renamed {T = ＇ Y} refl refl) fresh p =
+  widening-var-to-var-tag⊥ tag-ok (fresh-variable-neq fresh) p
+widening-tag-var-spine⊥ tag-ok (spine-right-all sp) fresh p =
+  widening-var-to-all-tag⊥ tag-ok p
+
+mutual
+
+  narrowing-tag-spine-overlap⊥ : ∀ {μ Δ Σ A B C c X}
+    → μ X ≡ tag-or-id
+    → NarrowPath X A B
+    → EndpointSpine A C
+    → Fresh X C
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ C ⊒ B
+    → ⊥
+  narrowing-tag-spine-overlap⊥ tag-ok np-var sp fresh p =
+    narrowing-tag-var-spine⊥ tag-ok sp fresh p
+  narrowing-tag-spine-overlap⊥ tag-ok (np-fun₁ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    widening-tag-spine-overlap⊥ tag-ok p
+      (spine-renamed {T = A} refl refl) (fresh-fun-left fresh) q
+  narrowing-tag-spine-overlap⊥ tag-ok (np-fun₂ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    narrowing-tag-spine-overlap⊥ tag-ok p
+      (spine-renamed {T = B} refl refl) (fresh-fun-right fresh) r
+  narrowing-tag-spine-overlap⊥ tag-ok (np-fun₁ p)
+      (spine-right-all sp) fresh ()
+  narrowing-tag-spine-overlap⊥ tag-ok (np-fun₂ p)
+      (spine-right-all sp) fresh ()
+  narrowing-tag-spine-overlap⊥ {C = C} {X = X} tag-ok (np-all p)
+      sp fresh (∀ⁿ q) =
+    narrowing-tag-spine-overlap⊥ tag-ok p (spine-strip-both sp)
+      (λ occ → fresh (∈-all occ)) q
+  narrowing-tag-spine-overlap⊥ {C = C} {X = X} tag-ok (np-all p)
+      sp fresh (gen nonvarA zero∈A hC q C≢★) =
+    narrowing-tag-spine-overlap⊥ tag-ok p (spine-peel-left suc sp)
+      (fresh-shift fresh) q
+  narrowing-tag-spine-overlap⊥ tag-ok (np-all p) sp fresh
+      (untag-seq G hG allowed G꞉A q nonvarB A≢B) =
+    narrow-path-star-spine⊥ (np-all p) sp
+  narrowing-tag-spine-overlap⊥ {C = `∀ C} {X = X} tag-ok
+      (np-gen p) sp fresh (∀ⁿ q) =
+    narrowing-tag-spine-overlap⊥ tag-ok p (spine-peel-right suc sp)
+      (λ occ → fresh (∈-all occ)) q
+  narrowing-tag-spine-overlap⊥ {C = C} {X = X} tag-ok (np-gen p)
+      sp fresh (gen nonvarA zero∈A hC q C≢★) =
+    narrowing-tag-spine-overlap⊥ tag-ok p
+      (spine-map-right suc (spine-map-left suc sp))
+      (fresh-shift fresh) q
+  narrowing-tag-spine-overlap⊥ tag-ok (np-gen p) sp fresh
+      (untag-seq G hG allowed G꞉A q nonvarB A≢B) =
+    narrow-path-star-spine⊥ (np-gen p) sp
+
+  widening-tag-spine-overlap⊥ : ∀ {μ Δ Σ A B C c X}
+    → μ X ≡ tag-or-id
+    → WidenPath X A B
+    → EndpointSpine B C
+    → Fresh X C
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ C
+    → ⊥
+  widening-tag-spine-overlap⊥ tag-ok wp-var sp fresh p =
+    widening-tag-var-spine⊥ tag-ok sp fresh p
+  widening-tag-spine-overlap⊥ tag-ok (wp-fun₁ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    narrowing-tag-spine-overlap⊥ tag-ok p
+      (spine-renamed {T = A} refl refl) (fresh-fun-left fresh) q
+  widening-tag-spine-overlap⊥ tag-ok (wp-fun₂ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    widening-tag-spine-overlap⊥ tag-ok p
+      (spine-renamed {T = B} refl refl) (fresh-fun-right fresh) r
+  widening-tag-spine-overlap⊥ tag-ok (wp-fun₁ p)
+      (spine-right-all sp) fresh ()
+  widening-tag-spine-overlap⊥ tag-ok (wp-fun₂ p)
+      (spine-right-all sp) fresh ()
+  widening-tag-spine-overlap⊥ {C = C} {X = X} tag-ok (wp-all p)
+      sp fresh (∀ʷ q) =
+    widening-tag-spine-overlap⊥ tag-ok p (spine-strip-both sp)
+      (λ occ → fresh (∈-all occ)) q
+  widening-tag-spine-overlap⊥ {C = C} {X = X} tag-ok (wp-all p)
+      sp fresh (inst nonvarA zero∈A hC q C≢★) =
+    widening-tag-spine-overlap⊥ tag-ok p (spine-peel-left suc sp)
+      (fresh-shift fresh) q
+  widening-tag-spine-overlap⊥ tag-ok (wp-all p) sp fresh
+      (tag-seq G q hG allowed G꞉B nonvarA A≢B) =
+    widen-path-star-spine⊥ (wp-all p) sp
+  widening-tag-spine-overlap⊥ {C = `∀ C} {X = X} tag-ok
+      (wp-inst p) sp fresh (∀ʷ q) =
+    widening-tag-spine-overlap⊥ tag-ok p (spine-peel-right suc sp)
+      (λ occ → fresh (∈-all occ)) q
+  widening-tag-spine-overlap⊥ {C = C} {X = X} tag-ok (wp-inst p)
+      sp fresh (inst nonvarA zero∈A hC q C≢★) =
+    widening-tag-spine-overlap⊥ tag-ok p
+      (spine-map-right suc (spine-map-left suc sp))
+      (fresh-shift fresh) q
+  widening-tag-spine-overlap⊥ tag-ok (wp-inst p) sp fresh
+      (tag-seq G q hG allowed G꞉B nonvarA A≢B) =
+    widen-path-star-spine⊥ (wp-inst p) sp
+
+narrowing-variable-to-star⊥ : ∀ {μ Δ Σ X c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊒ ★
+  → ⊥
+narrowing-variable-to-star⊥ ()
+
+narrowing-all-to-star⊥ : ∀ {μ Δ Σ A c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ (`∀ A) ⊒ ★
+  → ⊥
+narrowing-all-to-star⊥ ()
+
+widening-star-to-variable⊥ : ∀ {μ Δ Σ X c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ★ ⊑ ＇ X
+  → ⊥
+widening-star-to-variable⊥ ()
+
+widening-star-to-all⊥ : ∀ {μ Δ Σ A c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ★ ⊑ (`∀ A)
+  → ⊥
+widening-star-to-all⊥ ()
+
+narrowing-var-to-var-seal⊥ : ∀ {μ Δ Σ X Y c}
+  → StoreWf Δ Σ
+  → (X , ★) ∈ Σ
+  → μ X ≡ seal-or-id
+  → Y ≢ X
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ Y ⊒ ＇ X
+  → ⊥
+narrowing-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (idᵃ (＇ X) hX) =
+  Y≢X refl
+narrowing-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (seal X<Δ hY X,Y∈Σ allowed) with unique wfΣ X,★∈Σ X,Y∈Σ
+narrowing-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (seal X<Δ hY X,Y∈Σ allowed) | ()
+narrowing-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (seal-seq p X<Δ X,A∈Σ allowed Y≢A)
+    with unique wfΣ X,★∈Σ X,A∈Σ
+narrowing-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (seal-seq p X<Δ X,A∈Σ allowed Y≢A) | refl =
+  narrowing-variable-to-star⊥ p
+
+narrowing-all-to-var-seal⊥ : ∀ {μ Δ Σ X A c}
+  → StoreWf Δ Σ
+  → (X , ★) ∈ Σ
+  → μ X ≡ seal-or-id
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ (`∀ A) ⊒ ＇ X
+  → ⊥
+narrowing-all-to-var-seal⊥ wfΣ X,★∈Σ seal-ok
+    (seal X<Δ hA X,A∈Σ allowed) with unique wfΣ X,★∈Σ X,A∈Σ
+narrowing-all-to-var-seal⊥ wfΣ X,★∈Σ seal-ok
+    (seal X<Δ hA X,A∈Σ allowed) | ()
+narrowing-all-to-var-seal⊥ wfΣ X,★∈Σ seal-ok
+    (seal-seq p X<Δ X,B∈Σ allowed A≢B)
+    with unique wfΣ X,★∈Σ X,B∈Σ
+narrowing-all-to-var-seal⊥ wfΣ X,★∈Σ seal-ok
+    (seal-seq p X<Δ X,B∈Σ allowed A≢B) | refl =
+  narrowing-all-to-star⊥ p
+
+widening-var-to-var-seal⊥ : ∀ {μ Δ Σ X Y c}
+  → StoreWf Δ Σ
+  → (X , ★) ∈ Σ
+  → μ X ≡ seal-or-id
+  → Y ≢ X
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ ＇ Y
+  → ⊥
+widening-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (idᵃ (＇ X) hX) =
+  Y≢X refl
+widening-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (unseal X<Δ hY X,Y∈Σ allowed) with unique wfΣ X,★∈Σ X,Y∈Σ
+widening-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (unseal X<Δ hY X,Y∈Σ allowed) | ()
+widening-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (unseal-seq X<Δ X,A∈Σ allowed p A≢Y)
+    with unique wfΣ X,★∈Σ X,A∈Σ
+widening-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok Y≢X
+    (unseal-seq X<Δ X,A∈Σ allowed p A≢Y) | refl =
+  widening-star-to-variable⊥ p
+
+widening-var-to-all-seal⊥ : ∀ {μ Δ Σ X A c}
+  → StoreWf Δ Σ
+  → (X , ★) ∈ Σ
+  → μ X ≡ seal-or-id
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ (`∀ A)
+  → ⊥
+widening-var-to-all-seal⊥ wfΣ X,★∈Σ seal-ok
+    (unseal X<Δ hA X,A∈Σ allowed) with unique wfΣ X,★∈Σ X,A∈Σ
+widening-var-to-all-seal⊥ wfΣ X,★∈Σ seal-ok
+    (unseal X<Δ hA X,A∈Σ allowed) | ()
+widening-var-to-all-seal⊥ wfΣ X,★∈Σ seal-ok
+    (unseal-seq X<Δ X,B∈Σ allowed p B≢A)
+    with unique wfΣ X,★∈Σ X,B∈Σ
+widening-var-to-all-seal⊥ wfΣ X,★∈Σ seal-ok
+    (unseal-seq X<Δ X,B∈Σ allowed p B≢A) | refl =
+  widening-star-to-all⊥ p
+
+narrowing-seal-var-spine⊥ : ∀ {μ Δ Σ X C c}
+  → StoreWf Δ Σ
+  → (X , ★) ∈ Σ
+  → μ X ≡ seal-or-id
+  → EndpointSpine (＇ X) C
+  → Fresh X C
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ C ⊒ ＇ X
+  → ⊥
+narrowing-seal-var-spine⊥ wfΣ X,★∈Σ seal-ok
+    (spine-renamed {T = ＇ Y} refl refl) fresh p =
+  narrowing-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok
+    (fresh-variable-neq fresh) p
+narrowing-seal-var-spine⊥ wfΣ X,★∈Σ seal-ok
+    (spine-right-all sp) fresh p =
+  narrowing-all-to-var-seal⊥ wfΣ X,★∈Σ seal-ok p
+
+widening-seal-var-spine⊥ : ∀ {μ Δ Σ X C c}
+  → StoreWf Δ Σ
+  → (X , ★) ∈ Σ
+  → μ X ≡ seal-or-id
+  → EndpointSpine (＇ X) C
+  → Fresh X C
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ C
+  → ⊥
+widening-seal-var-spine⊥ wfΣ X,★∈Σ seal-ok
+    (spine-renamed {T = ＇ Y} refl refl) fresh p =
+  widening-var-to-var-seal⊥ wfΣ X,★∈Σ seal-ok
+    (fresh-variable-neq fresh) p
+widening-seal-var-spine⊥ wfΣ X,★∈Σ seal-ok
+    (spine-right-all sp) fresh p =
+  widening-var-to-all-seal⊥ wfΣ X,★∈Σ seal-ok p
+
+mutual
+
+  narrowing-seal-spine-overlap⊥ : ∀ {μ Δ Σ A B C c X}
+    → StoreWf Δ Σ
+    → (X , ★) ∈ Σ
+    → μ X ≡ seal-or-id
+    → NarrowPath X A B
+    → EndpointSpine A C
+    → Fresh X C
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ C ⊒ B
+    → ⊥
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok np-var
+      sp fresh p =
+    narrowing-seal-var-spine⊥ wfΣ X,★∈Σ seal-ok sp fresh p
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (np-fun₁ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok p
+      (spine-renamed {T = A} refl refl) (fresh-fun-left fresh) q
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (np-fun₂ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok p
+      (spine-renamed {T = B} refl refl) (fresh-fun-right fresh) r
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (np-fun₁ p)
+      (spine-right-all sp) fresh ()
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (np-fun₂ p)
+      (spine-right-all sp) fresh ()
+  narrowing-seal-spine-overlap⊥ {C = C} {X = X} wfΣ X,★∈Σ
+      seal-ok (np-all p) sp fresh (∀ⁿ q) =
+    narrowing-seal-spine-overlap⊥ (StoreWf-⟰ᵗ wfΣ)
+      (∈-renameTyStoreᵗ suc X,★∈Σ) seal-ok p (spine-strip-both sp)
+      (λ occ → fresh (∈-all occ)) q
+  narrowing-seal-spine-overlap⊥ {C = C} {X = X} wfΣ X,★∈Σ
+      seal-ok (np-all p) sp fresh
+      (gen nonvarA zero∈A hC q C≢★) =
+    narrowing-seal-spine-overlap⊥ (StoreWf-⟰ᵗ wfΣ)
+      (∈-renameTyStoreᵗ suc X,★∈Σ) seal-ok p
+      (spine-peel-left suc sp) (fresh-shift fresh) q
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (np-all p)
+      sp fresh (untag-seq G hG allowed G꞉A q nonvarB A≢B) =
+    narrow-path-star-spine⊥ (np-all p) sp
+  narrowing-seal-spine-overlap⊥ {C = `∀ C} {X = X} wfΣ X,★∈Σ
+      seal-ok (np-gen p) sp fresh (∀ⁿ q) =
+    narrowing-seal-spine-overlap⊥ (StoreWf-⟰ᵗ wfΣ)
+      (∈-renameTyStoreᵗ suc X,★∈Σ) seal-ok p
+      (spine-peel-right suc sp) (λ occ → fresh (∈-all occ)) q
+  narrowing-seal-spine-overlap⊥ {C = C} {X = X} wfΣ X,★∈Σ
+      seal-ok (np-gen p) sp fresh
+      (gen nonvarA zero∈A hC q C≢★) =
+    narrowing-seal-spine-overlap⊥ (StoreWf-⟰ᵗ wfΣ)
+      (∈-renameTyStoreᵗ suc X,★∈Σ) seal-ok p
+      (spine-map-right suc (spine-map-left suc sp))
+      (fresh-shift fresh) q
+  narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (np-gen p)
+      sp fresh (untag-seq G hG allowed G꞉A q nonvarB A≢B) =
+    narrow-path-star-spine⊥ (np-gen p) sp
+
+  widening-seal-spine-overlap⊥ : ∀ {μ Δ Σ A B C c X}
+    → StoreWf Δ Σ
+    → (X , ★) ∈ Σ
+    → μ X ≡ seal-or-id
+    → WidenPath X A B
+    → EndpointSpine B C
+    → Fresh X C
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ C
+    → ⊥
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok wp-var
+      sp fresh p =
+    widening-seal-var-spine⊥ wfΣ X,★∈Σ seal-ok sp fresh p
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (wp-fun₁ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    narrowing-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok p
+      (spine-renamed {T = A} refl refl) (fresh-fun-left fresh) q
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (wp-fun₂ p)
+      (spine-renamed {T = A ⇒ B} refl refl) fresh (q ↦ r) =
+    widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok p
+      (spine-renamed {T = B} refl refl) (fresh-fun-right fresh) r
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (wp-fun₁ p)
+      (spine-right-all sp) fresh ()
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (wp-fun₂ p)
+      (spine-right-all sp) fresh ()
+  widening-seal-spine-overlap⊥ {C = C} {X = X} wfΣ X,★∈Σ
+      seal-ok (wp-all p) sp fresh (∀ʷ q) =
+    widening-seal-spine-overlap⊥ (StoreWf-⟰ᵗ wfΣ)
+      (∈-renameTyStoreᵗ suc X,★∈Σ) seal-ok p (spine-strip-both sp)
+      (λ occ → fresh (∈-all occ)) q
+  widening-seal-spine-overlap⊥ {C = C} {X = X} wfΣ X,★∈Σ
+      seal-ok (wp-all p) sp fresh
+      (inst nonvarA zero∈A hC q C≢★) =
+    widening-seal-spine-overlap⊥ (StoreWf-bind wfΣ wf★)
+      (there (∈-renameTyStoreᵗ suc X,★∈Σ)) seal-ok p
+      (spine-peel-left suc sp) (fresh-shift fresh) q
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (wp-all p)
+      sp fresh (tag-seq G q hG allowed G꞉B nonvarA A≢B) =
+    widen-path-star-spine⊥ (wp-all p) sp
+  widening-seal-spine-overlap⊥ {C = `∀ C} {X = X} wfΣ X,★∈Σ
+      seal-ok (wp-inst p) sp fresh (∀ʷ q) =
+    widening-seal-spine-overlap⊥ (StoreWf-⟰ᵗ wfΣ)
+      (∈-renameTyStoreᵗ suc X,★∈Σ) seal-ok p
+      (spine-peel-right suc sp) (λ occ → fresh (∈-all occ)) q
+  widening-seal-spine-overlap⊥ {C = C} {X = X} wfΣ X,★∈Σ
+      seal-ok (wp-inst p) sp fresh
+      (inst nonvarA zero∈A hC q C≢★) =
+    widening-seal-spine-overlap⊥ (StoreWf-bind wfΣ wf★)
+      (there (∈-renameTyStoreᵗ suc X,★∈Σ)) seal-ok p
+      (spine-map-right suc (spine-map-left suc sp))
+      (fresh-shift fresh) q
+  widening-seal-spine-overlap⊥ wfΣ X,★∈Σ seal-ok (wp-inst p)
+      sp fresh (tag-seq G q hG allowed G꞉B nonvarA A≢B) =
+    widen-path-star-spine⊥ (wp-inst p) sp
+
+------------------------------------------------------------------------
+-- The two binder overlaps
+------------------------------------------------------------------------
+
+inserted-binder-spine : ∀ A
+  → EndpointSpine A (⇑ᵗ (`∀ A))
+inserted-binder-spine A =
+  spine-right-all
+    (spine-renamed {T = A} {ρ = λ X → X} {τ = extᵗ suc}
+      (sym (renameᵗ-id A)) refl)
+
+inserted-binder-fresh : ∀ A
+  → Fresh zero (⇑ᵗ (`∀ A))
+inserted-binder-fresh A (∈-all occ)
+    with rename-member-inv (extᵗ suc) occ
+inserted-binder-fresh A (∈-all occ) | zero , () , zero∈A
+inserted-binder-fresh A (∈-all occ) | suc X , () , X∈A
+
+narrowing-all-gen-overlap⊥ : ∀ {μ Δ Σ A B c d}
+  → StoreWf Δ Σ
+  → zero ∈ᵗ B
+  → extᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ c ⦂ A ⊒ B
+  → genᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ d ⦂ ⇑ᵗ (`∀ A) ⊒ B
+  → ⊥
+narrowing-all-gen-overlap⊥ {A = A} wfΣ zero∈B p q =
+  narrowing-tag-spine-overlap⊥ refl
+    (narrowing-target-path-id-only refl p zero∈B)
+    (inserted-binder-spine A) (inserted-binder-fresh A) q
+
+widening-all-inst-overlap⊥ : ∀ {μ Δ Σ A B c d}
+  → StoreWf Δ Σ
+  → zero ∈ᵗ A
+  → extᵈ μ ∣ suc Δ ∣ ⟰ᵗ Σ ⊢ c ⦂ A ⊑ B
+  → instᵈ μ ∣ suc Δ ∣ (zero , ★) ∷ ⟰ᵗ Σ
+      ⊢ d ⦂ A ⊑ ⇑ᵗ (`∀ B)
+  → ⊥
+widening-all-inst-overlap⊥ {B = B} wfΣ zero∈A p q =
+  widening-seal-spine-overlap⊥ (StoreWf-bind wfΣ wf★) (here refl) refl
+    (widening-source-path-id-only refl p zero∈A)
+    (inserted-binder-spine B) (inserted-binder-fresh B) q

--- a/GTPLC/proof/NarrowWidenDeterminism.agda
+++ b/GTPLC/proof/NarrowWidenDeterminism.agda
@@ -1,0 +1,521 @@
+module proof.NarrowWidenDeterminism where
+
+-- File Charter:
+--   * Proves that mode-indexed narrowing and widening are determined by
+--     their endpoints and a recursively well-formed type store.
+--   * Supplies the tag and variable-chain uniqueness lemmas needed by the
+--     main mutual proof.
+
+open import Data.Bool using (true)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.List.Membership.Propositional using (_∈_)
+open import Data.Nat using (_<_; suc; zero)
+open import Data.Nat.Properties using (<-irrefl; <-trans)
+open import Data.Product using (_,_; _×_; proj₁; proj₂; Σ-syntax)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; cong; cong₂; refl; subst; sym; trans)
+
+open import Types
+open import TyStore
+open import Coercions
+open import NarrowWiden
+open import proof.TyStore using
+  (older; unique; StoreWf-⟰ᵗ; StoreWf-bind)
+open import proof.TypeInTypeSubst using (rename-preserves-tagged)
+open import proof.TypeInTypeSubst using
+  ( predᵗ
+  ; RenameLeftInverse-suc
+  ; renameᵗ-left-inverse
+  )
+open import proof.ImprecisionComposition using
+  (inst-variable-source-no-zero; shifted-variable-target-no-zero)
+open import proof.NarrowWidenBinderGap using
+  (narrowing-all-gen-overlap⊥; widening-all-inst-overlap⊥)
+
+------------------------------------------------------------------------
+-- Small syntactic and mode exclusions
+------------------------------------------------------------------------
+
+tag-seal-modes-exclusive : ∀ {μ X}
+  → tagAllowed μ (＇ X) ≡ true
+  → sealModeAllowed (μ X) ≡ true
+  → ⊥
+tag-seal-modes-exclusive {μ} {X} tag-ok seal-ok with μ X
+tag-seal-modes-exclusive tag-ok () | id-only
+tag-seal-modes-exclusive tag-ok () | tag-or-id
+tag-seal-modes-exclusive () seal-ok | seal-or-id
+
+tagged-tag-unique : ∀ {G H A}
+  → G ꞉ A
+  → H ꞉ A
+  → G ≡ H
+tagged-tag-unique (tag-var X) (tag-var .X) = refl
+tagged-tag-unique (tag-base ι) (tag-base .ι) = refl
+tagged-tag-unique tag-fun tag-fun = refl
+
+⇑ᵗ-injective : ∀ {A B}
+  → ⇑ᵗ A ≡ ⇑ᵗ B
+  → A ≡ B
+⇑ᵗ-injective {A} {B} eq =
+  trans (sym (renameᵗ-left-inverse RenameLeftInverse-suc A))
+    (trans (cong (renameᵗ predᵗ) eq)
+      (renameᵗ-left-inverse RenameLeftInverse-suc B))
+
+narrowing-target-star : ∀ {μ Δ Σ c A}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ ★
+  → A ≡ ★
+narrowing-target-star (idᵃ ★ hA) = refl
+narrowing-target-star
+    (untag-seq G hG allowed G꞉A p nonvar★ A≢★) = refl
+
+widening-source-star : ∀ {μ Δ Σ c B}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ★ ⊑ B
+  → B ≡ ★
+widening-source-star (idᵃ ★ hA) = refl
+widening-source-star
+    (tag-seq G p hG allowed G꞉B nonvar★ ★≢B) = refl
+
+tagged-narrowing-endpoints-equal : ∀ {μ Δ Σ G H c A B}
+  → G ꞉ A
+  → H ꞉ B
+  → NonVar B
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+  → A ≡ B
+tagged-narrowing-endpoints-equal (tag-base ι) (tag-base .ι)
+    nonvar-base (idᵃ (‵ .ι) hA) = refl
+tagged-narrowing-endpoints-equal tag-fun tag-fun nonvar-fun
+    (p ↦ q) = refl
+
+tagged-widening-endpoints-equal : ∀ {μ Δ Σ G H c A B}
+  → G ꞉ A
+  → H ꞉ B
+  → NonVar A
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+  → A ≡ B
+tagged-widening-endpoints-equal (tag-base ι) (tag-base .ι)
+    nonvar-base (idᵃ (‵ .ι) hA) = refl
+tagged-widening-endpoints-equal tag-fun tag-fun nonvar-fun
+    (p ↦ q) = refl
+
+------------------------------------------------------------------------
+-- Variable chains follow the recursive store order
+------------------------------------------------------------------------
+
+narrowing-variable-target : ∀ {μ Δ Σ X A c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊒ A
+  → Σ[ Y ∈ TyVar ] A ≡ ＇ Y
+narrowing-variable-target (idᵃ (＇ X) hX) = X , refl
+narrowing-variable-target
+    (seal {X = Y} Y<Δ hA Y,A∈Σ allowed) = Y , refl
+narrowing-variable-target
+    (seal-seq {X = Y} p Y<Δ Y,A∈Σ allowed A≢B) = Y , refl
+narrowing-variable-target
+    (gen nonvarA zero∈A hX p X≢★) =
+  ⊥-elim (shifted-variable-target-no-zero p zero∈A)
+
+widening-variable-source : ∀ {μ Δ Σ A Y c}
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ ＇ Y
+  → Σ[ X ∈ TyVar ] A ≡ ＇ X
+widening-variable-source (idᵃ (＇ Y) hY) = Y , refl
+widening-variable-source
+    (unseal {X = X} X<Δ hA X,A∈Σ allowed) = X , refl
+widening-variable-source
+    (unseal-seq {X = X} X<Δ X,A∈Σ allowed p A≢B) = X , refl
+widening-variable-source
+    (inst nonvarA zero∈A hY p Y≢★) =
+  ⊥-elim (inst-variable-source-no-zero p zero∈A)
+
+narrowing-variable-order : ∀ {μ Δ Σ X Y c}
+  → StoreWf Δ Σ
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊒ ＇ Y
+  → X ≡ Y ⊎ Y < X
+narrowing-variable-order wfΣ (idᵃ (＇ X) hX) = inj₁ refl
+narrowing-variable-order wfΣ
+    (seal {X = Y} Y<Δ hX Y,X∈Σ allowed) =
+  inj₂ (older wfΣ Y,X∈Σ var-∈)
+narrowing-variable-order wfΣ
+    (seal-seq {X = Y} p Y<Δ Y,A∈Σ allowed X≢A)
+    with narrowing-variable-target p
+narrowing-variable-order wfΣ
+    (seal-seq {X = Y} p Y<Δ Y,A∈Σ allowed X≢A)
+    | z , refl with narrowing-variable-order wfΣ p
+narrowing-variable-order wfΣ
+    (seal-seq {X = Y} p Y<Δ Y,A∈Σ allowed X≢A)
+    | z , refl | inj₁ refl =
+  inj₂ (older wfΣ Y,A∈Σ var-∈)
+narrowing-variable-order wfΣ
+    (seal-seq {X = Y} p Y<Δ Y,A∈Σ allowed X≢A)
+    | z , refl | inj₂ z<X =
+  inj₂ (<-trans (older wfΣ Y,A∈Σ var-∈) z<X)
+
+widening-variable-order : ∀ {μ Δ Σ X Y c}
+  → StoreWf Δ Σ
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊑ ＇ Y
+  → X ≡ Y ⊎ X < Y
+widening-variable-order wfΣ (idᵃ (＇ X) hX) = inj₁ refl
+widening-variable-order wfΣ
+    (unseal {X = X} X<Δ hY X,Y∈Σ allowed) =
+  inj₂ (older wfΣ X,Y∈Σ var-∈)
+widening-variable-order wfΣ
+    (unseal-seq {X = X} X<Δ X,A∈Σ allowed p A≢Y)
+    with widening-variable-source p
+widening-variable-order wfΣ
+    (unseal-seq {X = X} X<Δ X,A∈Σ allowed p A≢Y)
+    | z , refl with widening-variable-order wfΣ p
+widening-variable-order wfΣ
+    (unseal-seq {X = X} X<Δ X,A∈Σ allowed p A≢Y)
+    | z , refl | inj₁ refl =
+  inj₂ (older wfΣ X,A∈Σ var-∈)
+widening-variable-order wfΣ
+    (unseal-seq {X = X} X<Δ X,A∈Σ allowed p A≢Y)
+    | z , refl | inj₂ z<Y =
+  inj₂ (<-trans (older wfΣ X,A∈Σ var-∈) z<Y)
+
+narrowing-self-seal-seq⊥ : ∀ {μ Δ Σ X A c}
+  → StoreWf Δ Σ
+  → (X , A) ∈ Σ
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ ＇ X ⊒ A
+  → ⊥
+narrowing-self-seal-seq⊥ wfΣ X,A∈Σ p
+    with narrowing-variable-target p
+narrowing-self-seal-seq⊥ wfΣ X,A∈Σ p | y , refl
+    with older wfΣ X,A∈Σ var-∈ | narrowing-variable-order wfΣ p
+narrowing-self-seal-seq⊥ wfΣ X,A∈Σ p
+    | y , refl | X<Y | inj₁ refl =
+  <-irrefl refl X<Y
+narrowing-self-seal-seq⊥ wfΣ X,A∈Σ p
+    | y , refl | X<Y | inj₂ Y<X =
+  <-irrefl refl (<-trans X<Y Y<X)
+
+widening-self-unseal-seq⊥ : ∀ {μ Δ Σ X A c}
+  → StoreWf Δ Σ
+  → (X , A) ∈ Σ
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ ＇ X
+  → ⊥
+widening-self-unseal-seq⊥ wfΣ X,A∈Σ p
+    with widening-variable-source p
+widening-self-unseal-seq⊥ wfΣ X,A∈Σ p | y , refl
+    with older wfΣ X,A∈Σ var-∈ | widening-variable-order wfΣ p
+widening-self-unseal-seq⊥ wfΣ X,A∈Σ p
+    | y , refl | X<Y | inj₁ refl =
+  <-irrefl refl X<Y
+widening-self-unseal-seq⊥ wfΣ X,A∈Σ p
+    | y , refl | X<Y | inj₂ Y<X =
+  <-irrefl refl (<-trans X<Y Y<X)
+
+------------------------------------------------------------------------
+-- Determinism
+------------------------------------------------------------------------
+
+mutual
+
+  narrowing-determinedᵐ : ∀ {μ Δ Σ c d A B}
+    → StoreWf Δ Σ
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+    → μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊒ B
+    → c ≡ d
+  narrowing-determinedᵐ wfΣ (idᵃ a hA) (idᵃ b hB) = refl
+  narrowing-determinedᵐ wfΣ (p ↦ q) (p′ ↦ q′) =
+    cong₂ _↦_ (widening-determinedᵐ wfΣ p p′)
+      (narrowing-determinedᵐ wfΣ q q′)
+  narrowing-determinedᵐ wfΣ (∀ⁿ p) (∀ⁿ q) =
+    cong `∀ (narrowing-determinedᵐ (StoreWf-⟰ᵗ wfΣ) p q)
+  narrowing-determinedᵐ wfΣ (∀ⁿ p)
+      (gen nonvarB zero∈B hA q A≢★) =
+    ⊥-elim (narrowing-all-gen-overlap⊥ wfΣ zero∈B p q)
+  narrowing-determinedᵐ wfΣ
+      (gen nonvarB zero∈B hA p A≢★) (∀ⁿ q) =
+    ⊥-elim (narrowing-all-gen-overlap⊥ wfΣ zero∈B q p)
+  narrowing-determinedᵐ wfΣ (∀ⁿ p) (idᵃ () hA)
+  narrowing-determinedᵐ wfΣ
+      (untag G hG G-ok G꞉B) (untag H hH H-ok H꞉B) =
+    cong _？ (tagged-tag-unique G꞉B H꞉B)
+  narrowing-determinedᵐ wfΣ
+      (untag G hG G-ok G꞉B)
+      (untag-seq H hH H-ok H꞉A q nonvarB A≢B) =
+    ⊥-elim (A≢B
+      (tagged-narrowing-endpoints-equal H꞉A G꞉B nonvarB q))
+  narrowing-determinedᵐ wfΣ
+      (untag-seq G hG G-ok G꞉A p nonvarB A≢B)
+      (untag H hH H-ok H꞉B) =
+    ⊥-elim (A≢B
+      (tagged-narrowing-endpoints-equal G꞉A H꞉B nonvarB p))
+  narrowing-determinedᵐ wfΣ
+      (untag-seq G hG G-ok G꞉A p nonvarB A≢B)
+      (untag-seq H hH H-ok H꞉C q nonvarB′ C≢B)
+      with narrowing-tag-source-determined wfΣ
+        G꞉A H꞉C nonvarB p q
+  narrowing-determinedᵐ wfΣ
+      (untag-seq G hG G-ok G꞉A p nonvarB A≢B)
+      (untag-seq H hH H-ok H꞉C q nonvarB′ C≢B)
+      | refl , eq =
+    cong₂ _︔_ (cong _？ (tagged-tag-unique G꞉A H꞉C)) eq
+  narrowing-determinedᵐ wfΣ
+      (untag-seq G hG G-ok G꞉A p nonvarB A≢B)
+      (gen nonvarC zero∈C h★ q ★≢★) =
+    ⊥-elim (★≢★ refl)
+  narrowing-determinedᵐ {μ = μ} wfΣ
+      (untag (＇ X) hG tag-ok (tag-var .X))
+      (seal X<Δ h★ X,★∈Σ seal-ok) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  narrowing-determinedᵐ {μ = μ} wfΣ
+      (untag (＇ X) hG tag-ok (tag-var .X))
+      (seal-seq p X<Δ X,A∈Σ seal-ok ★≢A) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  narrowing-determinedᵐ {μ = μ} wfΣ
+      (seal X<Δ h★ X,★∈Σ seal-ok)
+      (untag (＇ X) hG tag-ok (tag-var .X)) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  narrowing-determinedᵐ {μ = μ} wfΣ
+      (seal-seq p X<Δ X,A∈Σ seal-ok ★≢A)
+      (untag (＇ X) hG tag-ok (tag-var .X)) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  narrowing-determinedᵐ wfΣ
+      (seal X<Δ hA X,A∈Σ allowed)
+      (seal X<Δ′ hA′ X,A∈Σ′ allowed′) = refl
+  narrowing-determinedᵐ wfΣ
+      (seal X<Δ hA X,A∈Σ allowed)
+      (seal-seq q X<Δ′ X,B∈Σ allowed′ A≢B)
+      with unique wfΣ X,A∈Σ X,B∈Σ
+  narrowing-determinedᵐ wfΣ
+      (seal X<Δ hA X,A∈Σ allowed)
+      (seal-seq q X<Δ′ X,B∈Σ allowed′ A≢B) | refl =
+    ⊥-elim (A≢B refl)
+  narrowing-determinedᵐ wfΣ
+      (seal-seq p X<Δ X,B∈Σ allowed A≢B)
+      (seal X<Δ′ hA X,A∈Σ allowed′)
+      with unique wfΣ X,B∈Σ X,A∈Σ
+  narrowing-determinedᵐ wfΣ
+      (seal-seq p X<Δ X,B∈Σ allowed A≢B)
+      (seal X<Δ′ hA X,A∈Σ allowed′) | refl =
+    ⊥-elim (A≢B refl)
+  narrowing-determinedᵐ wfΣ
+      (seal-seq {X = X} p X<Δ X,B∈Σ allowed A≢B)
+      (seal-seq q X<Δ′ X,C∈Σ allowed′ A≢C)
+      with unique wfΣ X,B∈Σ X,C∈Σ
+  narrowing-determinedᵐ wfΣ
+      (seal-seq {X = X} p X<Δ X,B∈Σ allowed A≢B)
+      (seal-seq q X<Δ′ X,C∈Σ allowed′ A≢C) | refl =
+    cong (λ c → c ︔ seal X) (narrowing-determinedᵐ wfΣ p q)
+  narrowing-determinedᵐ wfΣ (idᵃ (＇ X) hX)
+      (seal X<Δ hX′ X,X∈Σ allowed) =
+    ⊥-elim (<-irrefl refl (older wfΣ X,X∈Σ var-∈))
+  narrowing-determinedᵐ wfΣ
+      (seal X<Δ hX X,X∈Σ allowed) (idᵃ (＇ X) hX′) =
+    ⊥-elim (<-irrefl refl (older wfΣ X,X∈Σ var-∈))
+  narrowing-determinedᵐ wfΣ (idᵃ (＇ X) hX)
+      (seal-seq p X<Δ X,A∈Σ allowed X≢A) =
+    ⊥-elim (narrowing-self-seal-seq⊥ wfΣ X,A∈Σ p)
+  narrowing-determinedᵐ wfΣ
+      (seal-seq p X<Δ X,A∈Σ allowed X≢A) (idᵃ (＇ X) hX) =
+    ⊥-elim (narrowing-self-seal-seq⊥ wfΣ X,A∈Σ p)
+  narrowing-determinedᵐ wfΣ (idᵃ ★ h★)
+      (untag-seq G hG allowed G꞉A p nonvar★ A≢★) =
+    ⊥-elim (A≢★ (narrowing-target-star p))
+  narrowing-determinedᵐ wfΣ
+      (untag-seq G hG allowed G꞉A p nonvar★ A≢★)
+      (idᵃ ★ h★) =
+    ⊥-elim (A≢★ (narrowing-target-star p))
+  narrowing-determinedᵐ wfΣ
+      (gen nonvarA zero∈A hB p B≢★)
+      (gen nonvarA′ zero∈A′ hB′ q B≢★′) =
+    cong gen (narrowing-determinedᵐ (StoreWf-⟰ᵗ wfΣ) p q)
+  narrowing-determinedᵐ wfΣ
+      (gen nonvarA zero∈A hB p B≢★) (idᵃ () hC)
+  narrowing-determinedᵐ wfΣ
+      (gen nonvarA zero∈A h★ p ★≢★)
+      (untag-seq G hG allowed G꞉B q nonvarC B≢C) =
+    ⊥-elim (★≢★ refl)
+  narrowing-determinedᵐ wfΣ
+      (gen nonvarA zero∈A hB p B≢★)
+      (untag G hG allowed ())
+
+  widening-determinedᵐ : ∀ {μ Δ Σ c d A B}
+    → StoreWf Δ Σ
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+    → μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊑ B
+    → c ≡ d
+  widening-determinedᵐ wfΣ (idᵃ a hA) (idᵃ b hB) = refl
+  widening-determinedᵐ wfΣ (p ↦ q) (p′ ↦ q′) =
+    cong₂ _↦_ (narrowing-determinedᵐ wfΣ p p′)
+      (widening-determinedᵐ wfΣ q q′)
+  widening-determinedᵐ wfΣ (∀ʷ p) (∀ʷ q) =
+    cong `∀ (widening-determinedᵐ (StoreWf-⟰ᵗ wfΣ) p q)
+  widening-determinedᵐ wfΣ (∀ʷ p)
+      (inst nonvarA zero∈A hB q B≢★) =
+    ⊥-elim (widening-all-inst-overlap⊥ wfΣ zero∈A p q)
+  widening-determinedᵐ wfΣ
+      (inst nonvarA zero∈A hB p B≢★) (∀ʷ q) =
+    ⊥-elim (widening-all-inst-overlap⊥ wfΣ zero∈A q p)
+  widening-determinedᵐ wfΣ (∀ʷ p) (idᵃ () hA)
+  widening-determinedᵐ wfΣ
+      (tag G hG G-ok G꞉A) (tag H hH H-ok H꞉A) =
+    cong _! (tagged-tag-unique G꞉A H꞉A)
+  widening-determinedᵐ wfΣ
+      (tag G hG G-ok G꞉A)
+      (tag-seq H q hH H-ok H꞉B nonvarA A≢B) =
+    ⊥-elim (A≢B
+      (tagged-widening-endpoints-equal G꞉A H꞉B nonvarA q))
+  widening-determinedᵐ wfΣ
+      (tag-seq G p hG G-ok G꞉B nonvarA A≢B)
+      (tag H hH H-ok H꞉A) =
+    ⊥-elim (A≢B
+      (tagged-widening-endpoints-equal H꞉A G꞉B nonvarA p))
+  widening-determinedᵐ wfΣ
+      (tag-seq G p hG G-ok G꞉B nonvarA A≢B)
+      (tag-seq H q hH H-ok H꞉C nonvarA′ A≢C)
+      with widening-tag-target-determined wfΣ
+        G꞉B H꞉C nonvarA p q
+  widening-determinedᵐ wfΣ
+      (tag-seq G p hG G-ok G꞉B nonvarA A≢B)
+      (tag-seq H q hH H-ok H꞉C nonvarA′ A≢C)
+      | refl , eq =
+    cong₂ _︔_ eq (cong _! (tagged-tag-unique G꞉B H꞉C))
+  widening-determinedᵐ wfΣ
+      (tag-seq G p hG G-ok G꞉B nonvarA A≢B)
+      (inst nonvarC zero∈C h★ q ★≢★) =
+    ⊥-elim (★≢★ refl)
+  widening-determinedᵐ {μ = μ} wfΣ
+      (tag (＇ X) hG tag-ok (tag-var .X))
+      (unseal X<Δ h★ X,★∈Σ seal-ok) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  widening-determinedᵐ {μ = μ} wfΣ
+      (tag (＇ X) hG tag-ok (tag-var .X))
+      (unseal-seq X<Δ X,A∈Σ seal-ok p A≢★) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  widening-determinedᵐ {μ = μ} wfΣ
+      (unseal X<Δ h★ X,★∈Σ seal-ok)
+      (tag (＇ X) hG tag-ok (tag-var .X)) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  widening-determinedᵐ {μ = μ} wfΣ
+      (unseal-seq X<Δ X,A∈Σ seal-ok p A≢★)
+      (tag (＇ X) hG tag-ok (tag-var .X)) =
+    ⊥-elim (tag-seal-modes-exclusive {μ = μ} {X = X}
+      tag-ok seal-ok)
+  widening-determinedᵐ wfΣ
+      (unseal X<Δ hA X,A∈Σ allowed)
+      (unseal X<Δ′ hA′ X,A∈Σ′ allowed′) = refl
+  widening-determinedᵐ wfΣ
+      (unseal X<Δ hA X,A∈Σ allowed)
+      (unseal-seq X<Δ′ X,B∈Σ allowed′ q B≢A)
+      with unique wfΣ X,A∈Σ X,B∈Σ
+  widening-determinedᵐ wfΣ
+      (unseal X<Δ hA X,A∈Σ allowed)
+      (unseal-seq X<Δ′ X,B∈Σ allowed′ q B≢A) | refl =
+    ⊥-elim (B≢A refl)
+  widening-determinedᵐ wfΣ
+      (unseal-seq X<Δ X,B∈Σ allowed p B≢A)
+      (unseal X<Δ′ hA X,A∈Σ allowed′)
+      with unique wfΣ X,B∈Σ X,A∈Σ
+  widening-determinedᵐ wfΣ
+      (unseal-seq X<Δ X,B∈Σ allowed p B≢A)
+      (unseal X<Δ′ hA X,A∈Σ allowed′) | refl =
+    ⊥-elim (B≢A refl)
+  widening-determinedᵐ wfΣ
+      (unseal-seq {X = X} X<Δ X,B∈Σ allowed p B≢A)
+      (unseal-seq X<Δ′ X,C∈Σ allowed′ q C≢A)
+      with unique wfΣ X,B∈Σ X,C∈Σ
+  widening-determinedᵐ wfΣ
+      (unseal-seq {X = X} X<Δ X,B∈Σ allowed p B≢A)
+      (unseal-seq X<Δ′ X,C∈Σ allowed′ q C≢A) | refl =
+    cong (unseal X ︔_) (widening-determinedᵐ wfΣ p q)
+  widening-determinedᵐ wfΣ (idᵃ (＇ X) hX)
+      (unseal X<Δ hX′ X,X∈Σ allowed) =
+    ⊥-elim (<-irrefl refl (older wfΣ X,X∈Σ var-∈))
+  widening-determinedᵐ wfΣ
+      (unseal X<Δ hX X,X∈Σ allowed) (idᵃ (＇ X) hX′) =
+    ⊥-elim (<-irrefl refl (older wfΣ X,X∈Σ var-∈))
+  widening-determinedᵐ wfΣ (idᵃ (＇ X) hX)
+      (unseal-seq X<Δ X,A∈Σ allowed p A≢X) =
+    ⊥-elim (widening-self-unseal-seq⊥ wfΣ X,A∈Σ p)
+  widening-determinedᵐ wfΣ
+      (unseal-seq X<Δ X,A∈Σ allowed p A≢X) (idᵃ (＇ X) hX) =
+    ⊥-elim (widening-self-unseal-seq⊥ wfΣ X,A∈Σ p)
+  widening-determinedᵐ wfΣ (idᵃ ★ h★)
+      (tag-seq G p hG allowed G꞉B nonvar★ ★≢B) =
+    ⊥-elim (★≢B (sym (widening-source-star p)))
+  widening-determinedᵐ wfΣ
+      (tag-seq G p hG allowed G꞉B nonvar★ ★≢B)
+      (idᵃ ★ h★) =
+    ⊥-elim (★≢B (sym (widening-source-star p)))
+  widening-determinedᵐ wfΣ
+      (inst nonvarA zero∈A hB p B≢★)
+      (inst nonvarA′ zero∈A′ hB′ q B≢★′) =
+    cong inst (widening-determinedᵐ (StoreWf-bind wfΣ wf★) p q)
+  widening-determinedᵐ wfΣ
+      (inst nonvarA zero∈A hB p B≢★) (idᵃ () hC)
+  widening-determinedᵐ wfΣ
+      (inst nonvarA zero∈A h★ p ★≢★)
+      (tag-seq G q hG allowed G꞉B nonvarC C≢B) =
+    ⊥-elim (★≢★ refl)
+  widening-determinedᵐ wfΣ
+      (inst nonvarA zero∈A hB p B≢★)
+      (tag G hG allowed ())
+
+  narrowing-tag-source-determined : ∀ {μ Δ Σ G H c d A C B}
+    → StoreWf Δ Σ
+    → G ꞉ A
+    → H ꞉ C
+    → NonVar B
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊒ B
+    → μ ∣ Δ ∣ Σ ⊢ d ⦂ C ⊒ B
+    → A ≡ C × c ≡ d
+  narrowing-tag-source-determined wfΣ (tag-base ι) (tag-base .ι)
+      nonvar-base (idᵃ (‵ .ι) hA) (idᵃ (‵ .ι) hA′) =
+    refl , refl
+  narrowing-tag-source-determined wfΣ tag-fun tag-fun nonvar-fun
+      (p ↦ q) (p′ ↦ q′) =
+    refl , cong₂ _↦_ (widening-determinedᵐ wfΣ p p′)
+      (narrowing-determinedᵐ wfΣ q q′)
+  narrowing-tag-source-determined wfΣ G꞉A H꞉C nonvar-all
+      (gen nonvarB zero∈B hA p A≢★)
+      (gen nonvarB′ zero∈B′ hC q C≢★) =
+    let rec = narrowing-tag-source-determined (StoreWf-⟰ᵗ wfΣ)
+          (rename-preserves-tagged suc G꞉A)
+          (rename-preserves-tagged suc H꞉C) nonvarB p q
+    in ⇑ᵗ-injective (proj₁ rec) , cong gen (proj₂ rec)
+
+  widening-tag-target-determined : ∀ {μ Δ Σ G H c d A B C}
+    → StoreWf Δ Σ
+    → G ꞉ B
+    → H ꞉ C
+    → NonVar A
+    → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+    → μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊑ C
+    → B ≡ C × c ≡ d
+  widening-tag-target-determined wfΣ (tag-base ι) (tag-base .ι)
+      nonvar-base (idᵃ (‵ .ι) hA) (idᵃ (‵ .ι) hA′) =
+    refl , refl
+  widening-tag-target-determined wfΣ tag-fun tag-fun nonvar-fun
+      (p ↦ q) (p′ ↦ q′) =
+    refl , cong₂ _↦_ (narrowing-determinedᵐ wfΣ p p′)
+      (widening-determinedᵐ wfΣ q q′)
+  widening-tag-target-determined wfΣ G꞉B H꞉C nonvar-all
+      (inst nonvarA zero∈A hB p B≢★)
+      (inst nonvarA′ zero∈A′ hC q C≢★) =
+    let rec = widening-tag-target-determined (StoreWf-bind wfΣ wf★)
+          (rename-preserves-tagged suc G꞉B)
+          (rename-preserves-tagged suc H꞉C) nonvarA p q
+    in ⇑ᵗ-injective (proj₁ rec) , cong inst (proj₂ rec)
+
+narrowing-determined : ∀ {μ Δ Σ A B}
+  → StoreWf Δ Σ
+  → (p q : μ ∣ Δ ∣ Σ ⊢ A ⊒ B)
+  → p ≐ⁿ q
+narrowing-determined wfΣ (c , p) (d , q) =
+  narrowing-determinedᵐ wfΣ p q
+
+widening-determined : ∀ {μ Δ Σ c d A B}
+  → StoreWf Δ Σ
+  → μ ∣ Δ ∣ Σ ⊢ c ⦂ A ⊑ B
+  → μ ∣ Δ ∣ Σ ⊢ d ⦂ A ⊑ B
+  → c ≡ d
+widening-determined = widening-determinedᵐ

--- a/GTPLC/proof/NarrowWidenDeterminismCounterexample.agda
+++ b/GTPLC/proof/NarrowWidenDeterminismCounterexample.agda
@@ -1,0 +1,100 @@
+module proof.NarrowWidenDeterminismCounterexample where
+
+-- File Charter:
+--   * Records the concrete store that exposed sequence-association
+--     ambiguity before the normal-form grammar was repaired.
+--   * Checks the surviving canonical narrowing and widening associations.
+
+open import Data.List using ([]; _∷_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.Nat using (suc; zero; z<s; s<s)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (_≢_; refl)
+
+open import Types
+open import TyStore
+open import Coercions
+open import NarrowWiden
+
+private
+
+  Δ₂ : TyCtx
+  Δ₂ = suc (suc zero)
+
+  Σ₂ : TyStore
+  Σ₂ =
+    (zero , ＇ (suc zero)) ∷
+    (suc zero , ‵ `ℕ) ∷ []
+
+  μ-seal : ModeEnv
+  μ-seal X = seal-or-id
+
+  wfΣ₁ : StoreWf (suc zero) ((zero , ‵ `ℕ) ∷ [])
+  wfΣ₁ = store-bind store-empty wfBase refl
+
+wfΣ₂ : StoreWf Δ₂ Σ₂
+wfΣ₂ = store-bind wfΣ₁ (wfVar z<s) refl
+
+------------------------------------------------------------------------
+-- Narrowing: ★ to ＇ zero
+------------------------------------------------------------------------
+
+untag-ℕ : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ ((‵ `ℕ) ？) ⦂ ★ ⊒ ‵ `ℕ
+untag-ℕ = untag (‵ `ℕ) wfTagBase refl (tag-base `ℕ)
+
+seal-one : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ seal (suc zero) ⦂ ‵ `ℕ ⊒ ＇ (suc zero)
+seal-one =
+  seal (s<s z<s) wfBase (there (here refl)) refl
+
+seal-zero : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ seal zero ⦂ ＇ (suc zero) ⊒ ＇ zero
+seal-zero =
+  seal z<s (wfVar (s<s z<s)) (here refl) refl
+
+narrow-left-associated : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ (((‵ `ℕ) ？) ︔ seal (suc zero)) ︔ seal zero
+    ⦂ ★ ⊒ ＇ zero
+narrow-left-associated =
+  seal-seq
+    (seal-seq untag-ℕ (s<s z<s) (there (here refl)) refl
+      (λ ()))
+    z<s (here refl) refl (λ ())
+
+narrow-noncanonical-syntax-differs :
+  (((‵ `ℕ) ？) ︔ seal (suc zero)) ︔ seal zero
+    ≢ ((‵ `ℕ) ？) ︔ (seal (suc zero) ︔ seal zero)
+narrow-noncanonical-syntax-differs ()
+
+------------------------------------------------------------------------
+-- Widening: ＇ zero to ★
+------------------------------------------------------------------------
+
+unseal-zero : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ unseal zero ⦂ ＇ zero ⊑ ＇ (suc zero)
+unseal-zero =
+  unseal z<s (wfVar (s<s z<s)) (here refl) refl
+
+unseal-one : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ unseal (suc zero) ⦂ ＇ (suc zero) ⊑ ‵ `ℕ
+unseal-one =
+  unseal (s<s z<s) wfBase (there (here refl)) refl
+
+tag-ℕ : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ ((‵ `ℕ) !) ⦂ ‵ `ℕ ⊑ ★
+tag-ℕ = tag (‵ `ℕ) wfTagBase refl (tag-base `ℕ)
+
+widen-right-associated : μ-seal ∣ Δ₂ ∣ Σ₂
+  ⊢ unseal zero ︔ (unseal (suc zero) ︔ ((‵ `ℕ) !))
+    ⦂ ＇ zero ⊑ ★
+widen-right-associated =
+  unseal-seq z<s (here refl) refl
+    (unseal-seq (s<s z<s) (there (here refl)) refl tag-ℕ
+      (λ ()))
+    (λ ())
+
+widen-noncanonical-syntax-differs :
+  (unseal zero ︔ unseal (suc zero)) ︔ ((‵ `ℕ) !)
+    ≢ unseal zero ︔ (unseal (suc zero) ︔ ((‵ `ℕ) !))
+widen-noncanonical-syntax-differs ()

--- a/GTPLC/proof/TermNarrowing.agda
+++ b/GTPLC/proof/TermNarrowing.agda
@@ -3,12 +3,10 @@ module proof.TermNarrowing where
 -- File Charter:
 --   * Derives paired narrowing-cast and widening-cast term rules.
 --   * Builds each rule from the one-sided cast constructors.
---   * Uses normalized factored composition as the intermediate narrowing.
---   * Checks paired cast squares by equality of normalized coercions.
+--   * Shares the relocation component across each paired cast square.
+--   * Checks the left and right narrowing equations independently.
 
 open import Data.Product using (_,_)
-open import Relation.Binary.PropositionalEquality using (refl; sym)
-
 open import Types
 open import TyStore
 open import Ctx
@@ -17,7 +15,7 @@ open import Terms
 open import NarrowWiden
 open import TypeRelocate
 open import FactoredTypeNarrowing
-open import ImprecisionTheorems using (dualʷ)
+open import ImprecisionTheorems using (dualʷ; _⨟ⁿ_)
 open import EnvironmentNarrowing
 open import TermNarrowing
 
@@ -26,45 +24,51 @@ open import TermNarrowing
 ------------------------------------------------------------------------
 
 castⁿ⊒castⁿ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ M M′ A A′}
-    {D D′ s t}
+    {C C′ D D′ s t}
     {Φ : ImpCtx Δᴸ Δᴿ}
     {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {Γᴸ} {Γᴿ}}
-    {p : ρ ⊢ᵀ A ⊒ A′}
-    {q : ρ ⊢ᵀ D ⊒ D′}
+    {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+    {qᴸ : ρ ⊢ᴸⁿ D ⊒ C}
+    {relocation : Φ ⊢ C ≈ C′}
+    {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ A′}
+    {qᴿ : ρ ⊢ᴿⁿ C′ ⊒ D′}
     {s⦂ : ρ ⊢ᴸⁿ s ⦂ A ⊒ D}
     {t⦂ : ρ ⊢ᴿⁿ t ⦂ A′ ⊒ D′}
-  → ρ ⊢ᴺ M ⊒ M′ ∶ p
-  → (s , s⦂) ⨟ⁿᶠ q ≐ᶠ p ⨟ᶠⁿ (t , t⦂)
+  → ρ ⊢ᴺ M ⊒ M′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → ((s , s⦂) ⨟ⁿ qᴸ) ≐ⁿ pᴸ
+  → (pᴿ ⨟ⁿ (t , t⦂)) ≐ⁿ qᴿ
     --------------------------------
-  → ρ ⊢ᴺ M ⟨ s ⟩ ⊒ M′ ⟨ t ⟩ ∶ q
-castⁿ⊒castⁿ {p = p} {q = q} {s⦂ = s⦂} {t⦂ = t⦂}
-    M⊒M′ square =
-  castⁿ⊒ {p = p ⨟ᶠⁿ (_ , t⦂)} {q = q} {s⦂ = s⦂}
-    (⊒castⁿ {p = p} {q = p ⨟ᶠⁿ (_ , t⦂)}
-      {t⦂ = t⦂} M⊒M′ (refl , refl))
-    square
+  → ρ ⊢ᴺ M ⟨ s ⟩ ⊒ M′ ⟨ t ⟩
+      ∶ (qᴸ ⨟ᶠ relocation ⨟ᶠ qᴿ)
+castⁿ⊒castⁿ {s⦂ = s⦂} {t⦂ = t⦂}
+    M⊒M′ left-eq right-eq =
+  castⁿ⊒ {s⦂ = s⦂}
+    (⊒castⁿ {t⦂ = t⦂} M⊒M′ right-eq)
+    left-eq
 
 ------------------------------------------------------------------------
 -- Paired widening casts
 ------------------------------------------------------------------------
 
 castʷ⊒castʷ : ∀ {Δᴸ Δᴿ Σᴸ Σᴿ Γᴸ Γᴿ M M′ A A′}
-    {D D′ u u′}
+    {C C′ D D′ u u′}
     {Φ : ImpCtx Δᴸ Δᴿ}
     {ρ : NarrowingEnv Φ {Σᴸ} {Σᴿ} {Γᴸ} {Γᴿ}}
-    {q : ρ ⊢ᵀ A ⊒ A′}
-    {p : ρ ⊢ᵀ D ⊒ D′}
+    {pᴸ : ρ ⊢ᴸⁿ A ⊒ C}
+    {qᴸ : ρ ⊢ᴸⁿ D ⊒ C}
+    {relocation : Φ ⊢ C ≈ C′}
+    {pᴿ : ρ ⊢ᴿⁿ C′ ⊒ A′}
+    {qᴿ : ρ ⊢ᴿⁿ C′ ⊒ D′}
     {u⦂ : ρ ⊢ᴸʷ u ⦂ A ⊑ D}
     {u′⦂ : ρ ⊢ᴿʷ u′ ⦂ A′ ⊑ D′}
-  → ρ ⊢ᴺ M ⊒ M′ ∶ q
-  → dualʷ (u , u⦂) ⨟ⁿᶠ q
-      ≐ᶠ p ⨟ᶠⁿ dualʷ (u′ , u′⦂)
+  → ρ ⊢ᴺ M ⊒ M′ ∶ (pᴸ ⨟ᶠ relocation ⨟ᶠ pᴿ)
+  → (dualʷ (u , u⦂) ⨟ⁿ pᴸ) ≐ⁿ qᴸ
+  → (qᴿ ⨟ⁿ dualʷ (u′ , u′⦂)) ≐ⁿ pᴿ
     --------------------------------
-  → ρ ⊢ᴺ M ⟨ u ⟩ ⊒ M′ ⟨ u′ ⟩ ∶ p
-castʷ⊒castʷ {q = q} {p = p} {u⦂ = u⦂} {u′⦂ = u′⦂}
-    M⊒M′ (left-eq , right-eq) =
-  ⊒castʷ {p = dualʷ (_ , u⦂) ⨟ⁿᶠ q}
-    {q = p} {t⦂ = u′⦂}
-    (castʷ⊒ {p = q} {q = dualʷ (_ , u⦂) ⨟ⁿᶠ q}
-      {s⦂ = u⦂} M⊒M′ (refl , refl))
-    (sym left-eq , sym right-eq)
+  → ρ ⊢ᴺ M ⟨ u ⟩ ⊒ M′ ⟨ u′ ⟩
+      ∶ (qᴸ ⨟ᶠ relocation ⨟ᶠ qᴿ)
+castʷ⊒castʷ {u⦂ = u⦂} {u′⦂ = u′⦂}
+    M⊒M′ left-eq right-eq =
+  ⊒castʷ {t⦂ = u′⦂}
+    (castʷ⊒ {s⦂ = u⦂} M⊒M′ left-eq)
+    right-eq

--- a/GTPLC/proof/TermNarrowingTyping.agda
+++ b/GTPLC/proof/TermNarrowingTyping.agda
@@ -9,15 +9,16 @@ module proof.TermNarrowingTyping where
 open import Types hiding (_∋_⦂_)
 open import Ctx
 open import Terms
-open import TypeNarrow
+open import TypeRelocate
+open import FactoredTypeNarrowing
 open import NarrowWiden
 open import EnvironmentNarrowing
 open import TermNarrowing
 
-lookup-source : ∀ {Δᴸ Δᴿ Γᴸ Γᴿ x A B}
+lookup-source : ∀ {Δᴸ Δᴿ μᴸ μᴿ Σᴸ Σᴿ Γᴸ Γᴿ x A B}
     {Φ : ImpCtx Δᴸ Δᴿ}
-    {γ : Φ ∣ Δᴸ ⊢ Γᴸ ⊒ᵍ Γᴿ ⊣ Δᴿ}
-    {p : Φ ⊢ A ⊒ B}
+    {γ : CtxNarrowing μᴸ Σᴸ Φ μᴿ Σᴿ Γᴸ Γᴿ}
+    {p : μᴸ ∣ Σᴸ ∣ Φ ∣ μᴿ ∣ Σᴿ ⊢ A ⊒ᶠ B}
   → γ ∋ x ⦂ p
   → Γᴸ Types.∋ x ⦂ A
 lookup-source Zⁿ = Z
@@ -48,7 +49,7 @@ term-narrowing-source-typing
   term-narrowing-source-typing N⊒V′
 term-narrowing-source-typing
     (ν⊒ν {s⦂ = s⦂} a L⊒L′ square) =
-  ⊢ν (TypeNarrow.⊒-src-wf a)
+  ⊢ν (factor-src-wf a)
      (term-narrowing-source-typing L⊒L′)
      (narrowing-typing s⦂)
 term-narrowing-source-typing

--- a/GTPLC/proof/TyStore.agda
+++ b/GTPLC/proof/TyStore.agda
@@ -66,21 +66,6 @@ renameTyStoreᵗ-ext-suc-comm ρ ((α , A) ∷ Σ) =
     (cong₂ _,_ refl (renameᵗ-ext-suc-comm ρ A))
     (renameTyStoreᵗ-ext-suc-comm ρ Σ)
 
-------------------------------------------------------------------------
--- Store well-formedness and allocation
-------------------------------------------------------------------------
-
-StoreWf-tail : ∀ {Δ α A Σ}
-  → StoreWf Δ ((α , A) ∷ Σ)
-  → StoreWf Δ Σ
-StoreWf-tail wfΣ =
-  record
-    { bound = λ x∈ → bound wfΣ (there x∈)
-    ; wfTy = λ x∈ → wfTy wfΣ (there x∈)
-    ; unique = λ x∈ y∈ →
-        unique wfΣ (there x∈) (there y∈)
-    }
-
 ∈-⟰ᵗ-inv : ∀ {Σ α B}
   → (suc α , B) ∈ ⟰ᵗ Σ
   → ∃[ A ] (B ≡ ⇑ᵗ A × (α , A) ∈ Σ)
@@ -97,6 +82,89 @@ StoreWf-tail wfΣ =
   → ⊥
 ∈-⟰ᵗ-zero {Σ = (α , B) ∷ Σ} (there h) =
   ∈-⟰ᵗ-zero h
+
+------------------------------------------------------------------------
+-- Pointwise consequences of recursive store well-formedness
+------------------------------------------------------------------------
+
+bound : ∀ {Δ Σ α A}
+  → StoreWf Δ Σ
+  → (α , A) ∈ Σ
+  → α < Δ
+bound store-empty ()
+bound {α = zero} (store-lift wfΣ refl) α,A∈Σ =
+  ⊥-elim (∈-⟰ᵗ-zero α,A∈Σ)
+bound {α = suc α} (store-lift wfΣ refl) α,A∈Σ
+    with ∈-⟰ᵗ-inv α,A∈Σ
+bound {α = suc α} (store-lift wfΣ refl) α,A∈Σ
+    | A , eq , α,A∈Σ′ =
+  s<s (bound wfΣ α,A∈Σ′)
+bound (store-bind wfΣ hA refl) (here refl) = z<s
+bound (store-bind wfΣ hA refl) (there α,A∈Σ) =
+  bound (store-lift wfΣ refl) α,A∈Σ
+
+wfTy : ∀ {Δ Σ α A}
+  → StoreWf Δ Σ
+  → (α , A) ∈ Σ
+  → WfTy Δ A
+wfTy store-empty ()
+wfTy {α = zero} (store-lift wfΣ refl) α,A∈Σ =
+  ⊥-elim (∈-⟰ᵗ-zero α,A∈Σ)
+wfTy {α = suc α} (store-lift wfΣ refl) α,A∈Σ
+    with ∈-⟰ᵗ-inv α,A∈Σ
+wfTy {α = suc α} (store-lift wfΣ refl) α,A∈Σ
+    | A , eq , α,A∈Σ′ =
+  subst (WfTy _) (sym eq)
+    (renameᵗ-preserves-WfTy (wfTy wfΣ α,A∈Σ′) TyRenameWf-suc)
+wfTy (store-bind wfΣ hA refl) (here refl) =
+  renameᵗ-preserves-WfTy hA TyRenameWf-suc
+wfTy (store-bind wfΣ hA refl) (there α,A∈Σ) =
+  wfTy (store-lift wfΣ refl) α,A∈Σ
+
+rename-member-inv : ∀ ρ {X A}
+  → X ∈ᵗ renameᵗ ρ A
+  → ∃[ Y ] (X ≡ ρ Y × Y ∈ᵗ A)
+rename-member-inv ρ {A = ＇ Y} var-∈ = Y , refl , var-∈
+rename-member-inv ρ {A = A ⇒ B} (∈-fun-left X∈A)
+    with rename-member-inv ρ X∈A
+rename-member-inv ρ {A = A ⇒ B} (∈-fun-left X∈A)
+    | Y , eq , Y∈A =
+  Y , eq , ∈-fun-left Y∈A
+rename-member-inv ρ {A = A ⇒ B} (∈-fun-right X∈B)
+    with rename-member-inv ρ X∈B
+rename-member-inv ρ {A = A ⇒ B} (∈-fun-right X∈B)
+    | Y , eq , Y∈B =
+  Y , eq , ∈-fun-right Y∈B
+rename-member-inv ρ {A = `∀ A} (∈-all X∈A)
+    with rename-member-inv (extᵗ ρ) X∈A
+rename-member-inv ρ {A = `∀ A} (∈-all X∈A)
+    | zero , () , Y∈A
+rename-member-inv ρ {A = `∀ A} (∈-all X∈A)
+    | suc Y , refl , Y∈A =
+  Y , refl , ∈-all Y∈A
+
+older : ∀ {Δ Σ X A Y}
+  → StoreWf Δ Σ
+  → (X , A) ∈ Σ
+  → Y ∈ᵗ A
+  → X < Y
+older store-empty () Y∈A
+older {X = zero} (store-lift wfΣ refl) X,A∈Σ Y∈A =
+  ⊥-elim (∈-⟰ᵗ-zero X,A∈Σ)
+older {X = suc X} (store-lift wfΣ refl) X,A∈Σ Y∈A
+    with ∈-⟰ᵗ-inv X,A∈Σ
+older {X = suc X} (store-lift wfΣ refl) X,A∈Σ Y∈A
+    | A , refl , X,A∈Σ′ with rename-member-inv suc Y∈A
+older {X = suc X} (store-lift wfΣ refl) X,A∈Σ Y∈A
+    | A , refl , X,A∈Σ′ | Y , refl , Y∈A′ =
+  s<s (older wfΣ X,A∈Σ′ Y∈A′)
+older (store-bind wfΣ hA refl) (here refl) Y∈A
+    with rename-member-inv suc Y∈A
+older (store-bind wfΣ hA refl) (here refl) Y∈A
+    | Y , refl , Y∈A′ =
+  z<s
+older (store-bind wfΣ hA refl) (there X,A∈Σ) Y∈A =
+  older (store-lift wfΣ refl) X,A∈Σ Y∈A
 
 StoreUnique-⟰ᵗ : ∀ {Σ}
   → (∀ {α A B} → (α , A) ∈ Σ → (α , B) ∈ Σ → A ≡ B)
@@ -126,61 +194,28 @@ StoreUnique-bind uniqueΣ (there h) (here refl) =
 StoreUnique-bind uniqueΣ (there h₁) (there h₂) =
   StoreUnique-⟰ᵗ uniqueΣ h₁ h₂
 
+unique : ∀ {Δ Σ α A B}
+  → StoreWf Δ Σ
+  → (α , A) ∈ Σ
+  → (α , B) ∈ Σ
+  → A ≡ B
+unique store-empty () B∈Σ
+unique (store-lift wfΣ refl) A∈Σ B∈Σ =
+  StoreUnique-⟰ᵗ (unique wfΣ) A∈Σ B∈Σ
+unique (store-bind wfΣ hA refl) A∈Σ B∈Σ =
+  StoreUnique-bind (unique wfΣ) A∈Σ B∈Σ
+
+------------------------------------------------------------------------
+-- Store well-formedness under type binders and allocation
+------------------------------------------------------------------------
+
 StoreWf-⟰ᵗ : ∀ {Δ Σ}
   → StoreWf Δ Σ
   → StoreWf (suc Δ) (⟰ᵗ Σ)
-StoreWf-⟰ᵗ {Δ = Δ} {Σ = Σ} wfΣ =
-  record
-    { bound = shifted-bound
-    ; wfTy = shifted-wfTy
-    ; unique = StoreUnique-⟰ᵗ (unique wfΣ)
-    }
-  where
-    shifted-bound : ∀ {α B}
-      → (α , B) ∈ ⟰ᵗ Σ
-      → α < suc Δ
-    shifted-bound {α = zero} h =
-      ⊥-elim (∈-⟰ᵗ-zero h)
-    shifted-bound {α = suc α} h
-        with ∈-⟰ᵗ-inv h
-    shifted-bound {α = suc α} h | A , eq , A∈Σ =
-      s<s (bound wfΣ A∈Σ)
-
-    shifted-wfTy : ∀ {α B}
-      → (α , B) ∈ ⟰ᵗ Σ
-      → WfTy (suc Δ) B
-    shifted-wfTy {α = zero} h =
-      ⊥-elim (∈-⟰ᵗ-zero h)
-    shifted-wfTy {α = suc α} h
-        with ∈-⟰ᵗ-inv h
-    shifted-wfTy {α = suc α} h | A , eq , A∈Σ =
-      subst (WfTy (suc Δ)) (sym eq)
-        (renameᵗ-preserves-WfTy
-          (wfTy wfΣ A∈Σ) TyRenameWf-suc)
+StoreWf-⟰ᵗ wfΣ = store-lift wfΣ refl
 
 StoreWf-bind : ∀ {Δ Σ A}
   → StoreWf Δ Σ
   → WfTy Δ A
   → StoreWf (suc Δ) ((zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ)
-StoreWf-bind {Δ = Δ} {Σ = Σ} {A = A} wfΣ hA =
-  record
-    { bound = bound′
-    ; wfTy = wfTy′
-    ; unique = StoreUnique-bind (unique wfΣ)
-    }
-  where
-    shifted-wfΣ : StoreWf (suc Δ) (⟰ᵗ Σ)
-    shifted-wfΣ = StoreWf-⟰ᵗ wfΣ
-
-    bound′ : ∀ {α B}
-      → (α , B) ∈ ((zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ)
-      → α < suc Δ
-    bound′ (here refl) = z<s
-    bound′ (there h) = bound shifted-wfΣ h
-
-    wfTy′ : ∀ {α B}
-      → (α , B) ∈ ((zero , ⇑ᵗ A) ∷ ⟰ᵗ Σ)
-      → WfTy (suc Δ) B
-    wfTy′ (here refl) =
-      renameᵗ-preserves-WfTy hA TyRenameWf-suc
-    wfTy′ (there h) = wfTy shifted-wfΣ h
+StoreWf-bind wfΣ hA = store-bind wfΣ hA refl


### PR DESCRIPTION
## Summary

- replace pointwise `StoreWf` with a recursive construction relation so a new
  representation type is well formed in the older store context
- restore canonical association for seal and unseal chains, with concrete
  regression examples and rationale
- define narrowing equivalence by propositional equality of the bundled
  coercions and expose the left and right factored components in term narrowing
- prove narrowing and widening determinism without `TERMINATING`, including the
  binder-overlap lemmas needed for the polymorphic cases
- rebuild tag and seal inversion around determinism and advance the
  `LeftNarrowWiden` proof against the revised definitions

## Why

Merging the narrowing/widening grammar with its typing relation lost the strict
normal-form categories that had fixed sequence association in GTSF. That let
the same endpoints, mode environment, and store admit differently associated
coercions. The old pointwise store invariant also did not express that a
variable's representation must come from the older part of the store.

The canonical endpoint-shape premises and recursive store construction restore
those invariants. Keeping coercion composition out of constructor indices also
lets Agda invert the term relation directly.

## Validation

The following pass with `--no-allow-unsolved-metas`:

- `proof/NarrowWidenDeterminism.agda`
- `proof/NarrowWidenDeterminismCounterexample.agda`
- `proof/LeftWideningTagInversion.agda`
- `proof/LeftWideningSealInversion.agda`
- `proof/ImprecisionComposition.agda`

## Draft status

`proof/LeftNarrowWidenProof.agda` still has one unsolved `inst` case at line
354. Its strict Agda check therefore fails only at that interaction meta. The
PR is draft while that final case is completed.
