### PR TITLE
Port GTSFImp compilation and indexed imprecision proofs

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -8,10 +8,17 @@ import ConsistencyExamples
 import Conversion
 import Imprecision
 import Primitives
+import GradualTerms
+import GradualTermImprecision
 import CastTerms
+import Compile
 import Reduction
 import Eval
 import Example
 import proof.TypeSafety.Progress
 import proof.TypeSafety.Preservation
 import proof.ImprecisionConsistency
+import proof.Imprecision
+import proof.Consistency
+import proof.DGG.CastTermImprecision
+import proof.DGG.CompilePreservesImprecision

--- a/GTSFImp/Compile.agda
+++ b/GTSFImp/Compile.agda
@@ -1,0 +1,119 @@
+module Compile where
+
+-- File Charter:
+--   * Compiles gradual source terms to the explicit-cast calculus.
+--   * Inserts consistency evidence directly as cast annotations.
+--   * Proves that compilation preserves typing and source values.
+--   * Is parametric in the target type store; type application allocates its
+--     runtime representation later, according to the target semantics.
+
+open import Data.Product using (Σ-syntax; _,_; proj₁)
+
+open import Types
+open import TyStore using (TyStore; store-lift)
+open import TermCtx using (TermCtx)
+open import Consistency
+
+open import GradualTerms
+  using (GTerm)
+  renaming
+    ( `_ to `ᴳ_
+    ; ƛ_⇒_ to ƛᴳ_⇒_
+    ; _·[_]_ to _·ᴳ[_]_
+    ; Λ_ to Λᴳ_
+    ; _`[_] to _`ᴳ[_]
+    ; $ to $ᴳ
+    ; _⊕[_at_]_ to _⊕ᴳ[_at_]_
+    ; Value to Valueᴳ
+    ; _∣_⊢_⦂_ to _∣_⊢ᴳ_⦂_
+    ; ⊢` to ⊢ᴳ`
+    ; ⊢ƛ to ⊢ᴳƛ
+    ; ⊢· to ⊢ᴳ·
+    ; ⊢·★ to ⊢ᴳ·★
+    ; ⊢Λ to ⊢ᴳΛ
+    ; ⊢• to ⊢ᴳ•
+    ; ⊢$ to ⊢ᴳ$
+    ; ⊢⊕ to ⊢ᴳ⊕
+    )
+
+open import CastTerms
+  using (Term; ⟨_,_,_⟩)
+  renaming
+    ( `_ to `ᵀ_
+    ; ƛ_ to ƛᵀ_
+    ; _·_ to _·ᵀ_
+    ; Λ_ to Λᵀ_
+    ; _⦂∀_[_] to _⦂∀ᵀ_[_]
+    ; $ to $ᵀ
+    ; _⊕[_]_ to _⊕ᵀ[_]_
+    ; _⟨_⟩ to _⟨ᵀ_⟩
+    ; Value to Valueᵀ
+    ; _⊢_⦂_ to _⊢ᵀ_⦂_
+    ; ⊢` to ⊢ᵀ`
+    ; ⊢ƛ to ⊢ᵀƛ
+    ; ⊢· to ⊢ᵀ·
+    ; ⊢Λ to ⊢ᵀΛ
+    ; ⊢• to ⊢ᵀ•
+    ; ⊢$ to ⊢ᵀ$
+    ; ⊢⊕ to ⊢ᵀ⊕
+    ; ⊢⟨⟩ to ⊢ᵀ⟨⟩
+    )
+
+------------------------------------------------------------------------
+-- Compilation
+------------------------------------------------------------------------
+
+compile : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ} {M : GTerm Δ}
+    {A : Ty Δ}
+  → Δ ∣ Γ ⊢ᴳ M ⦂ A
+  → Σ[ N ∈ Term Δ ] ⟨ Δ , Σ , Γ ⟩ ⊢ᵀ N ⦂ A
+
+compile-value : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ}
+    {M : GTerm Δ} {A : Ty Δ}
+  → (vM : Valueᴳ M)
+  → (M⊢ : Δ ∣ Γ ⊢ᴳ M ⦂ A)
+  → Valueᵀ (proj₁ (compile {Σ = Σ} M⊢))
+
+compile (⊢ᴳ` x∈) =
+  `ᵀ _ , ⊢ᵀ` x∈
+compile (⊢ᴳƛ M⊢) with compile M⊢
+compile (⊢ᴳƛ M⊢) | N , N⊢ =
+  ƛᵀ N , ⊢ᵀƛ N⊢
+compile (⊢ᴳ· L⊢ M⊢ A∼A′) with compile L⊢ | compile M⊢
+compile (⊢ᴳ· L⊢ M⊢ A∼A′) | L′ , L′⊢ | M′ , M′⊢ =
+  L′ ·ᵀ (M′ ⟨ᵀ symᶜ A∼A′ ⟩) ,
+  ⊢ᵀ· L′⊢ (⊢ᵀ⟨⟩ M′⊢ (symᶜ A∼A′))
+compile (⊢ᴳ·★ L⊢ M⊢ A′∼★) with compile L⊢ | compile M⊢
+compile (⊢ᴳ·★ L⊢ M⊢ A′∼★) | L′ , L′⊢ | M′ , M′⊢ =
+  let c : ★ ∼ (★ ⇒ ★)
+      c = (？ (id ★ ↦ id ★)) in
+  L′ ⟨ᵀ c ⟩ ·ᵀ (M′ ⟨ᵀ A′∼★ ⟩) , ⊢ᵀ· (⊢ᵀ⟨⟩ L′⊢ c) (⊢ᵀ⟨⟩ M′⊢ A′∼★)
+compile {Σ = Σ} (⊢ᴳΛ vM M⊢)
+    with compile {Σ = store-lift Σ} M⊢
+       | compile-value {Σ = store-lift Σ} vM M⊢
+compile {Σ = Σ} (⊢ᴳΛ vM M⊢) | N , N⊢ | vN =
+  Λᵀ N , ⊢ᵀΛ vN N⊢
+compile (⊢ᴳ• {B = B} {A = A} M⊢) with compile M⊢
+compile (⊢ᴳ• {B = B} {A = A} M⊢) | M′ , M′⊢ =
+  M′ ⦂∀ᵀ B [ A ] , ⊢ᵀ• M′⊢
+compile (⊢ᴳ$ κ) =
+  $ᵀ κ , ⊢ᵀ$ κ
+compile (⊢ᴳ⊕ op L⊢ A∼arg M⊢ B∼arg)
+    with compile L⊢ | compile M⊢
+compile (⊢ᴳ⊕ op L⊢ A∼arg M⊢ B∼arg)
+    | L′ , L′⊢ | M′ , M′⊢ =
+  (L′ ⟨ᵀ A∼arg ⟩) ⊕ᵀ[ op ] (M′ ⟨ᵀ B∼arg ⟩) ,
+  ⊢ᵀ⊕ op (⊢ᵀ⟨⟩ L′⊢ A∼arg) (⊢ᵀ⟨⟩ M′⊢ B∼arg)
+
+compile-value {Σ = Σ} (ƛᴳ A ⇒ M) (⊢ᴳƛ M⊢)
+    with compile {Σ = Σ} M⊢
+compile-value {Σ = Σ} (ƛᴳ A ⇒ M) (⊢ᴳƛ M⊢)
+    | N , N⊢ =
+  ƛᵀ N
+compile-value ($ᴳ κ) (⊢ᴳ$ .κ) = $ᵀ κ
+compile-value {Σ = Σ} (Λᴳ M) (⊢ᴳΛ vM M⊢)
+    with compile {Σ = store-lift Σ} M⊢
+       | compile-value {Σ = store-lift Σ} vM M⊢
+compile-value {Σ = Σ} (Λᴳ M) (⊢ᴳΛ vM M⊢)
+    | N , N⊢ | vN =
+  Λᵀ vN

--- a/GTSFImp/Consistency.agda
+++ b/GTSFImp/Consistency.agda
@@ -2,8 +2,7 @@ module Consistency where
 
 -- File Charter:
 --   * Defines environment-indexed type consistency.
---   * Gives `∀ X. ★` a ground representation and bridges the empty
---     universal `∀ X. X` to and from that representation.
+--   * Gives every universal type the ground representation `∀ X. ★`.
 --   * Provides renaming and substitution for consistency evidence.
 --   * Closes instantiation-bound consistency evidence at ★.
 
@@ -68,8 +67,7 @@ data GroundMatch {Δ : TyCtx} {μ : Env∼ Δ} {r : Var∼} :
   match-⇒ : ∀ {A} → GroundMatch g-⇒ A
   match-ι : ∀ {A ι} → GroundMatch (g-ι {ι = ι}) A
   match-X : ∀ {X} {eq : μ X ≡ r} → GroundMatch (g-X eq) (＇ X)
-  match-∀ : GroundMatch g-∀ (`∀ ★)
-  match-⊥ : GroundMatch g-∀ (`∀ (＇ zero))
+  match-∀ : ∀ {A} → GroundMatch g-∀ (`∀ A)
 
 groundMatch-unique : ∀ {Δ} {μ : Env∼ Δ} {r G A}
     {g : Groundʳ μ r G}
@@ -79,7 +77,6 @@ groundMatch-unique match-⇒ match-⇒ = refl
 groundMatch-unique match-ι match-ι = refl
 groundMatch-unique match-X match-X = refl
 groundMatch-unique match-∀ match-∀ = refl
-groundMatch-unique match-⊥ match-⊥ = refl
 
 data NonStar {Δ : TyCtx} : Ty Δ → Set where
   nonstar-X : ∀ {X} → NonStar (＇ X)
@@ -125,13 +122,9 @@ instance
     → GroundMatch (g-X {Δ = Δ} {μ = μ} {r = r} {X = X} eq) (＇ X)
   match-X-instance = match-X
 
-  match-∀-instance : ∀ {Δ μ r}
-    → GroundMatch (g-∀ {Δ = Δ} {μ = μ} {r = r}) (`∀ ★)
+  match-∀-instance : ∀ {Δ μ r A}
+    → GroundMatch (g-∀ {Δ = Δ} {μ = μ} {r = r}) (`∀ A)
   match-∀-instance = match-∀
-
-  match-⊥-instance : ∀ {Δ μ r}
-    → GroundMatch (g-∀ {Δ = Δ} {μ = μ} {r = r}) (`∀ (＇ zero))
-  match-⊥-instance = match-⊥
 
   nonstar-X-instance : ∀ {Δ} {X : TyVar Δ} → NonStar (＇ X)
   nonstar-X-instance = nonstar-X
@@ -276,7 +269,6 @@ flip-GroundMatch match-⇒ = match-⇒
 flip-GroundMatch match-ι = match-ι
 flip-GroundMatch match-X = match-X
 flip-GroundMatch match-∀ = match-∀
-flip-GroundMatch match-⊥ = match-⊥
 
 private
   postulate
@@ -410,7 +402,6 @@ private
   rename-GroundMatch ρ eq match-ι = match-ι
   rename-GroundMatch {μ = μ} {μ′ = μ′} ρ eq match-X = match-X
   rename-GroundMatch ρ eq match-∀ = match-∀
-  rename-GroundMatch ρ eq match-⊥ = match-⊥
 
   rename∼ : ∀ {Δ Δ′} {μ : Env∼ Δ} {μ′ : Env∼ Δ′}
       {A B : Ty Δ}
@@ -705,9 +696,9 @@ private
   factor-inst-star
       (_! ⦃ g-X eq ⦄ c ⦃ Ans ⦄ ⦃ match-X ⦄) () z∈A
   factor-inst-star
-      (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄) Anv (∈-all ())
-  factor-inst-star
-      (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-⊥ ⦄) Anv (∈-all ())
+      (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄) Anv z∈A =
+    _! ⦃ g-∀ ⦄ (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c (λ ()))
+      ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
   factor-inst-star (？_ ⦃ g ⦄ c ⦃ Bns ⦄ ⦃ match ⦄) Anv ()
   factor-inst-star
       (inst_ ⦃ Anv′ ⦄ ⦃ z∈A′ ⦄ c ★≢★) Anv z∈A =
@@ -731,9 +722,9 @@ private
   factor-gen-star
       (？_ ⦃ g-X eq ⦄ c ⦃ Bns ⦄ ⦃ match-X ⦄) () z∈B
   factor-gen-star
-      (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄) Bnv (∈-all ())
-  factor-gen-star
-      (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-⊥ ⦄) Bnv (∈-all ())
+      (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄) Bnv z∈B =
+    ？_ ⦃ g-∀ ⦄ (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c (λ ()))
+      ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
   factor-gen-star (gen_ ⦃ Bnv′ ⦄ ⦃ z∈B′ ⦄ c ★≢★) Bnv z∈B =
     ⊥-elim (★≢★ refl)
 
@@ -761,8 +752,6 @@ subst∼ s (_! ⦃ g-X {X = X} eq ⦄ c ⦃ Ans ⦄ ⦃ match-X ⦄) =
   to-★ s X eq
 subst∼ s (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄) =
   _! ⦃ g-∀ ⦄ (subst∼ s c) ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
-subst∼ s (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-⊥ ⦄) =
-  _! ⦃ g-∀ ⦄ (subst∼ s c) ⦃ nonstar-∀ ⦄ ⦃ match-⊥ ⦄
 subst∼ {σ = σ} s
     (？_ ⦃ g-⇒ ⦄ c ⦃ Bns ⦄ ⦃ match-⇒ ⦄) =
   ？_ ⦃ g-⇒ ⦄ (subst∼ s c)
@@ -777,8 +766,6 @@ subst∼ s (？_ ⦃ g-X {X = X} eq ⦄ c ⦃ Bns ⦄ ⦃ match-X ⦄) =
   from-★ s X eq
 subst∼ s (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄) =
   ？_ ⦃ g-∀ ⦄ (subst∼ s c) ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
-subst∼ s (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-⊥ ⦄) =
-  ？_ ⦃ g-∀ ⦄ (subst∼ s c) ⦃ nonstar-∀ ⦄ ⦃ match-⊥ ⦄
 subst∼ {σ = σ} s
     (inst_ {B = B} ⦃ A-nonvar ⦄ ⦃ zero∈A ⦄ c B≢★)
     with substᵗ σ B ≟Ty ★
@@ -851,6 +838,37 @@ close-instᶜ {B = B} c =
   subst-right-∼ (shift-openᵗ B ★)
     (subst∼
       (subst-env∼ close-inst-self close-inst-to-★ close-inst-from-★)
+      c)
+
+private
+
+  close-gen-self : ∀ {Δ} {μ : Env∼ Δ} (X : TyVar (suc Δ))
+    → μ ⊢ singleSubᵗ ★ X ∼ singleSubᵗ ★ X
+  close-gen-self X = refl∼ (singleSubᵗ ★ X)
+
+  close-gen-to-★ : ∀ {Δ} {μ : Env∼ Δ} (X : TyVar (suc Δ))
+    → genᵐ μ X ≡ X∼★
+    → μ ⊢ singleSubᵗ ★ X ∼ ★
+  close-gen-to-★ zero ()
+  close-gen-to-★ {μ = μ} (suc X) eq =
+    _! ⦃ g-X eq ⦄ (id (＇ X))
+      ⦃ nonstar-X ⦄ ⦃ match-X ⦄
+
+  close-gen-from-★ : ∀ {Δ} {μ : Env∼ Δ} (X : TyVar (suc Δ))
+    → genᵐ μ X ≡ ★∼X
+    → μ ⊢ ★ ∼ singleSubᵗ ★ X
+  close-gen-from-★ zero eq = id ★
+  close-gen-from-★ {μ = μ} (suc X) eq =
+    ？_ ⦃ g-X eq ⦄ (id (＇ X))
+      ⦃ nonstar-X ⦄ ⦃ match-X ⦄
+
+close-genᶜ : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ} {B : Ty (suc Δ)}
+  → genᵐ μ ⊢ ⇑ᵗ A ∼ B
+  → μ ⊢ A ∼ B [ ★ ]ᵗ
+close-genᶜ {A = A} c =
+  subst-left-∼ (shift-openᵗ A ★)
+    (subst∼
+      (subst-env∼ close-gen-self close-gen-to-★ close-gen-from-★)
       c)
 
 private

--- a/GTSFImp/GradualTermImprecision.agda
+++ b/GTSFImp/GradualTermImprecision.agda
@@ -1,0 +1,305 @@
+module GradualTermImprecision where
+
+-- File Charter:
+--   * Defines typed source-term imprecision for GTSFImp.
+--   * Relates intrinsically scoped gradual terms and records type-imprecision
+--     evidence for every related term and context entry.
+--   * Provides source and target typing projections for related terms.
+--   * Depends on GradualTerms, Imprecision, and Consistency.
+
+open import Data.List using (List; []; _∷_; map)
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; cong₂; subst)
+
+open import Types
+open import TermCtx using (TermCtx; ⇑ᶜ)
+import TermCtx as T
+open import Consistency using (_∼_)
+open import GradualTerms
+open import Imprecision
+open import Primitives
+  using (Const; Prim; κℕ; κ𝔹; addℕ; and𝔹; constTy; primArgTy;
+         primResultTy)
+
+constTy-⊑ : ∀ {Δ} (μ : ImpEnv Δ) (κ : Const)
+  → μ ⊢ constTy κ ⊑ constTy κ
+constTy-⊑ μ (κℕ n) = ι⊑ι
+constTy-⊑ μ (κ𝔹 b) = ι⊑ι
+
+primResultTy-⊑ : ∀ {Δ} (μ : ImpEnv Δ) (op : Prim)
+  → μ ⊢ primResultTy op ⊑ primResultTy op
+primResultTy-⊑ μ addℕ = ι⊑ι
+primResultTy-⊑ μ and𝔹 = ι⊑ι
+
+------------------------------------------------------------------------
+-- Term-context imprecision
+------------------------------------------------------------------------
+
+record CtxImpEntry {Δ : TyCtx} (μ : ImpEnv Δ) : Set where
+  constructor ctx-imp
+  field
+    srcTyⁱ : Ty Δ
+    tgtTyⁱ : Ty Δ
+    impTyⁱ : μ ⊢ srcTyⁱ ⊑ tgtTyⁱ
+
+open CtxImpEntry public
+
+CtxImp : ∀ {Δ} → ImpEnv Δ → Set
+CtxImp μ = List (CtxImpEntry μ)
+
+srcCtxⁱ : ∀ {Δ} {μ : ImpEnv Δ} → CtxImp μ → TermCtx Δ
+srcCtxⁱ = map srcTyⁱ
+
+tgtCtxⁱ : ∀ {Δ} {μ : ImpEnv Δ} → CtxImp μ → TermCtx Δ
+tgtCtxⁱ = map tgtTyⁱ
+
+infix 4 _∋ⁱ_⦂_
+
+data _∋ⁱ_⦂_ {Δ} {μ : ImpEnv Δ} :
+    CtxImp μ → Nat.ℕ → CtxImpEntry μ → Set where
+  Zⁱ : ∀ {γ A B p}
+      -------------------------------------------
+    → (ctx-imp A B p ∷ γ) ∋ⁱ Nat.zero ⦂ ctx-imp A B p
+
+  Sⁱ : ∀ {γ e e′ x}
+    → γ ∋ⁱ x ⦂ e
+      ---------------------------
+    → (e′ ∷ γ) ∋ⁱ Nat.suc x ⦂ e
+
+data LiftCtxⁱ {Δ} {μ : ImpEnv Δ} (ν : ImpEnv (Nat.suc Δ)) :
+    CtxImp μ → CtxImp ν → Set where
+  lift-[] : LiftCtxⁱ ν [] []
+
+  lift-∷ : ∀ {γ γ′ A B p p′}
+    → LiftCtxⁱ ν γ γ′
+      -------------------------------------------------------------
+    → LiftCtxⁱ ν (ctx-imp A B p ∷ γ)
+        (ctx-imp (⇑ᵗ A) (⇑ᵗ B) p′ ∷ γ′)
+
+srcCtxⁱ-lift : ∀ {Δ} {μ : ImpEnv Δ}
+    {ν : ImpEnv (Nat.suc Δ)} {γ : CtxImp μ} {γ′ : CtxImp ν}
+  → LiftCtxⁱ ν γ γ′
+  → srcCtxⁱ γ′ ≡ ⇑ᶜ (srcCtxⁱ γ)
+srcCtxⁱ-lift lift-[] = refl
+srcCtxⁱ-lift (lift-∷ liftγ) =
+  cong₂ _∷_ refl (srcCtxⁱ-lift liftγ)
+
+tgtCtxⁱ-lift : ∀ {Δ} {μ : ImpEnv Δ}
+    {ν : ImpEnv (Nat.suc Δ)} {γ : CtxImp μ} {γ′ : CtxImp ν}
+  → LiftCtxⁱ ν γ γ′
+  → tgtCtxⁱ γ′ ≡ ⇑ᶜ (tgtCtxⁱ γ)
+tgtCtxⁱ-lift lift-[] = refl
+tgtCtxⁱ-lift (lift-∷ liftγ) =
+  cong₂ _∷_ refl (tgtCtxⁱ-lift liftγ)
+
+------------------------------------------------------------------------
+-- Typed gradual-term imprecision
+------------------------------------------------------------------------
+
+infix 4 _∣_⊢ᴳ_⊑_⦂_⊑_∶_
+
+data _∣_⊢ᴳ_⊑_⦂_⊑_∶_ {Δ} (μ : ImpEnv Δ) (γ : CtxImp μ) :
+    GTerm Δ → GTerm Δ → (A B : Ty Δ) → μ ⊢ A ⊑ B → Set where
+
+  x⊑xᴳ : ∀ {x A B p}
+    → γ ∋ⁱ x ⦂ ctx-imp A B p
+      ---------------------------------------------
+    → μ ∣ γ ⊢ᴳ ` x ⊑ ` x ⦂ A ⊑ B ∶ p
+
+  ƛ⊑ƛᴳ : ∀ {N N′ A A′ B B′ pA pB}
+    → μ ∣ ctx-imp A A′ pA ∷ γ ⊢ᴳ N ⊑ N′ ⦂ B ⊑ B′ ∶ pB
+      ----------------------------------------------------------
+    → μ ∣ γ ⊢ᴳ ƛ A ⇒ N ⊑ ƛ A′ ⇒ N′
+        ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ ⇒⊑⇒ pA pB
+
+  ·⊑·ᴳ : ∀ {L L′ M M′ A A′ B B′ C C′ ℓ pA pB pC}
+    → μ ∣ γ ⊢ᴳ L ⊑ L′
+        ⦂ A ⇒ B ⊑ A′ ⇒ B′ ∶ ⇒⊑⇒ pA pB
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ C ⊑ C′ ∶ pC
+    → A ∼ C
+    → A′ ∼ C′
+      ---------------------------------------------------------
+    → μ ∣ γ ⊢ᴳ L ·[ ℓ ] M ⊑ L′ ·[ ℓ ] M′
+        ⦂ B ⊑ B′ ∶ pB
+
+  ·⊑·★ᴳ : ∀ {L L′ M M′ A B C C′ ℓ pA pB pC}
+    → μ ∣ γ ⊢ᴳ L ⊑ L′ ⦂ A ⇒ B ⊑ ★ ∶ ⇒⊑★ pA pB
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ C ⊑ C′ ∶ pC
+    → A ∼ C
+    → C′ ∼ ★
+      -----------------------------------------------------
+    → μ ∣ γ ⊢ᴳ L ·[ ℓ ] M ⊑ L′ ·[ ℓ ] M′
+        ⦂ B ⊑ ★ ∶ pB
+
+  ·★⊑·★ᴳ : ∀ {L L′ M M′ C C′ ℓ pC}
+    → μ ∣ γ ⊢ᴳ L ⊑ L′ ⦂ ★ ⊑ ★ ∶ ★⊑★
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ C ⊑ C′ ∶ pC
+    → C ∼ ★
+    → C′ ∼ ★
+      -----------------------------------------------------
+    → μ ∣ γ ⊢ᴳ L ·[ ℓ ] M ⊑ L′ ·[ ℓ ] M′
+        ⦂ ★ ⊑ ★ ∶ ★⊑★
+
+  Λ⊑Λᴳ : ∀ {γ′ V V′ A B p}
+    → LiftCtxⁱ (extᵐ μ) γ γ′
+    → Value V
+    → Value V′
+    → Fin.zero ∈ᵗ A
+    → Fin.zero ∈ᵗ B
+    → extᵐ μ ∣ γ′ ⊢ᴳ V ⊑ V′ ⦂ A ⊑ B ∶ p
+      ----------------------------------------------------
+    → μ ∣ γ ⊢ᴳ Λ V ⊑ Λ V′
+        ⦂ `∀ A ⊑ `∀ B ∶ ∀⊑∀ p
+
+  Λ⊑ᴳ : ∀ {γ′ V N′ A B p}
+    → (Anv : NonVar A)
+    → (zero∈A : Fin.zero ∈ᵗ A)
+    → LiftCtxⁱ (instᵐ μ) γ γ′
+    → Value V
+    → Δ ∣ tgtCtxⁱ γ ⊢ N′ ⦂ B
+    → instᵐ μ ∣ γ′ ⊢ᴳ V ⊑ ⇑ᵗᴳ N′
+        ⦂ A ⊑ ⇑ᵗ B ∶ p
+      --------------------------------------------------
+    → μ ∣ γ ⊢ᴳ Λ V ⊑ N′
+        ⦂ `∀ A ⊑ B ∶ ∀⊑ Anv zero∈A p
+
+  []⊑[]ᴳ : ∀ {M M′ T T′ A B p}
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ `∀ A ⊑ `∀ B ∶ ∀⊑∀ p
+    → (q : μ ⊢ T ⊑ T′)
+    → (r : μ ⊢ A [ T ]ᵗ ⊑ B [ T′ ]ᵗ)
+      ---------------------------------------------------------
+    → μ ∣ γ ⊢ᴳ M `[ T ] ⊑ M′ `[ T′ ]
+        ⦂ A [ T ]ᵗ ⊑ B [ T′ ]ᵗ ∶ r
+
+  []⊑ᴳ : ∀ {M M′ T A B p Anv zero∈A}
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ `∀ A ⊑ B ∶ ∀⊑ Anv zero∈A p
+    → (q : μ ⊢ T ⊑ ★)
+    → (r : μ ⊢ A [ T ]ᵗ ⊑ B)
+      -------------------------------------------------
+    → μ ∣ γ ⊢ᴳ M `[ T ] ⊑ M′ ⦂ A [ T ]ᵗ ⊑ B ∶ r
+
+  κ⊑κᴳ : ∀ (κ : Const)
+      ------------------------------------------------------
+    → μ ∣ γ ⊢ᴳ $ κ ⊑ $ κ
+        ⦂ constTy κ ⊑ constTy κ ∶ constTy-⊑ μ κ
+
+  ⊕⊑⊕ᴳ : ∀ {L L′ M M′ A A′ B B′ pA pB ℓ}
+    → (op : Prim)
+    → μ ∣ γ ⊢ᴳ L ⊑ L′ ⦂ A ⊑ A′ ∶ pA
+    → A ∼ primArgTy op
+    → A′ ∼ primArgTy op
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ B ⊑ B′ ∶ pB
+    → B ∼ primArgTy op
+    → B′ ∼ primArgTy op
+      ----------------------------------------------------------
+    → μ ∣ γ ⊢ᴳ L ⊕[ op at ℓ ] M ⊑ L′ ⊕[ op at ℓ ] M′
+        ⦂ primResultTy op ⊑ primResultTy op ∶ primResultTy-⊑ μ op
+
+------------------------------------------------------------------------
+-- Typing projections
+------------------------------------------------------------------------
+
+lookup-srcⁱ : ∀ {Δ} {μ : ImpEnv Δ} {γ : CtxImp μ} {x A B p}
+  → γ ∋ⁱ x ⦂ ctx-imp A B p
+  → srcCtxⁱ γ T.∋ x ⦂ A
+lookup-srcⁱ Zⁱ = T.Z
+lookup-srcⁱ (Sⁱ x∈) = T.S (lookup-srcⁱ x∈)
+
+lookup-tgtⁱ : ∀ {Δ} {μ : ImpEnv Δ} {γ : CtxImp μ} {x A B p}
+  → γ ∋ⁱ x ⦂ ctx-imp A B p
+  → tgtCtxⁱ γ T.∋ x ⦂ B
+lookup-tgtⁱ Zⁱ = T.Z
+lookup-tgtⁱ (Sⁱ x∈) = T.S (lookup-tgtⁱ x∈)
+
+mutual
+  gradual-term-imprecision-source-typing : ∀ {Δ} {μ : ImpEnv Δ}
+      {γ : CtxImp μ} {M M′ A B p}
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p
+    → Δ ∣ srcCtxⁱ γ ⊢ M ⦂ A
+
+  gradual-term-imprecision-target-typing : ∀ {Δ} {μ : ImpEnv Δ}
+      {γ : CtxImp μ} {M M′ A B p}
+    → μ ∣ γ ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p
+    → Δ ∣ tgtCtxⁱ γ ⊢ M′ ⦂ B
+
+  gradual-term-imprecision-source-typing (x⊑xᴳ x∈) =
+    ⊢` (lookup-srcⁱ x∈)
+  gradual-term-imprecision-source-typing (ƛ⊑ƛᴳ N⊑N′) =
+    ⊢ƛ (gradual-term-imprecision-source-typing N⊑N′)
+  gradual-term-imprecision-source-typing
+      (·⊑·ᴳ L⊑L′ M⊑M′ A∼C A′∼C′) =
+    ⊢· (gradual-term-imprecision-source-typing L⊑L′)
+       (gradual-term-imprecision-source-typing M⊑M′)
+       A∼C
+  gradual-term-imprecision-source-typing
+      (·⊑·★ᴳ L⊑L′ M⊑M′ A∼C C′∼★) =
+    ⊢· (gradual-term-imprecision-source-typing L⊑L′)
+       (gradual-term-imprecision-source-typing M⊑M′)
+       A∼C
+  gradual-term-imprecision-source-typing
+      (·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★) =
+    ⊢·★ (gradual-term-imprecision-source-typing L⊑L′)
+        (gradual-term-imprecision-source-typing M⊑M′)
+        C∼★
+  gradual-term-imprecision-source-typing
+      (Λ⊑Λᴳ liftγ vV vV′ zero∈A zero∈B V⊑V′) =
+    ⊢Λ {zero∈A = zero∈A} vV
+      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (srcCtxⁱ-lift liftγ)
+        (gradual-term-imprecision-source-typing V⊑V′))
+  gradual-term-imprecision-source-typing
+      (Λ⊑ᴳ Anv zero∈A liftγ vV N′⊢ V⊑N′) =
+    ⊢Λ {zero∈A = zero∈A} vV
+      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (srcCtxⁱ-lift liftγ)
+        (gradual-term-imprecision-source-typing V⊑N′))
+  gradual-term-imprecision-source-typing ([]⊑[]ᴳ M⊑M′ q r) =
+    ⊢• (gradual-term-imprecision-source-typing M⊑M′)
+  gradual-term-imprecision-source-typing ([]⊑ᴳ M⊑M′ q r) =
+    ⊢• (gradual-term-imprecision-source-typing M⊑M′)
+  gradual-term-imprecision-source-typing (κ⊑κᴳ κ) =
+    ⊢$ κ
+  gradual-term-imprecision-source-typing
+      (⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
+        B∼arg B′∼arg) =
+    ⊢⊕ op (gradual-term-imprecision-source-typing L⊑L′) A∼arg
+      (gradual-term-imprecision-source-typing M⊑M′) B∼arg
+
+  gradual-term-imprecision-target-typing (x⊑xᴳ x∈) =
+    ⊢` (lookup-tgtⁱ x∈)
+  gradual-term-imprecision-target-typing (ƛ⊑ƛᴳ N⊑N′) =
+    ⊢ƛ (gradual-term-imprecision-target-typing N⊑N′)
+  gradual-term-imprecision-target-typing
+      (·⊑·ᴳ L⊑L′ M⊑M′ A∼C A′∼C′) =
+    ⊢· (gradual-term-imprecision-target-typing L⊑L′)
+       (gradual-term-imprecision-target-typing M⊑M′)
+       A′∼C′
+  gradual-term-imprecision-target-typing
+      (·⊑·★ᴳ L⊑L′ M⊑M′ A∼C C′∼★) =
+    ⊢·★ (gradual-term-imprecision-target-typing L⊑L′)
+        (gradual-term-imprecision-target-typing M⊑M′)
+        C′∼★
+  gradual-term-imprecision-target-typing
+      (·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★) =
+    ⊢·★ (gradual-term-imprecision-target-typing L⊑L′)
+        (gradual-term-imprecision-target-typing M⊑M′)
+        C′∼★
+  gradual-term-imprecision-target-typing
+      (Λ⊑Λᴳ liftγ vV vV′ zero∈A zero∈B V⊑V′) =
+    ⊢Λ {zero∈A = zero∈B} vV′
+      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (tgtCtxⁱ-lift liftγ)
+        (gradual-term-imprecision-target-typing V⊑V′))
+  gradual-term-imprecision-target-typing
+      (Λ⊑ᴳ Anv zero∈A liftγ vV N′⊢ V⊑N′) =
+    N′⊢
+  gradual-term-imprecision-target-typing ([]⊑[]ᴳ M⊑M′ q r) =
+    ⊢• (gradual-term-imprecision-target-typing M⊑M′)
+  gradual-term-imprecision-target-typing ([]⊑ᴳ M⊑M′ q r) =
+    gradual-term-imprecision-target-typing M⊑M′
+  gradual-term-imprecision-target-typing (κ⊑κᴳ κ) =
+    ⊢$ κ
+  gradual-term-imprecision-target-typing
+      (⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
+        B∼arg B′∼arg) =
+    ⊢⊕ op (gradual-term-imprecision-target-typing L⊑L′) A′∼arg
+      (gradual-term-imprecision-target-typing M⊑M′) B′∼arg

--- a/GTSFImp/GradualTerms.agda
+++ b/GTSFImp/GradualTerms.agda
@@ -1,0 +1,130 @@
+module GradualTerms where
+
+-- File Charter:
+--   * Source-language gradual term syntax and typing for GTSFImp.
+--   * Uses intrinsically scoped types and the consistency relation.
+--   * Contains no casts; well-typed source terms are intended to compile to
+--     the cast calculus in CastTerms.
+--   * Exports type-variable renaming and weakening for gradual terms.
+--   * Application and primitive-operation nodes retain source blame labels.
+
+open import Data.Fin using (zero)
+import Data.Fin as Fin
+open import Data.List using (_∷_)
+open import Data.Nat using (ℕ; suc)
+
+open import Types
+open import TermCtx
+open import Consistency using (_∼_)
+open import Primitives
+  using (Const; Prim; constTy; primArgTy; primResultTy)
+
+------------------------------------------------------------------------
+-- Terms
+------------------------------------------------------------------------
+
+Var : Set
+Var = ℕ
+
+Label : Set
+Label = ℕ
+
+infix  5 ƛ_⇒_
+infix  5 Λ_
+infixl 7 _·[_]_
+infixl 7 _`[_]
+infixl 6 _⊕[_at_]_
+infix  9 `_
+
+data GTerm : TyCtx → Set where
+  `_      : ∀ {Δ} → Var → GTerm Δ
+  ƛ_⇒_    : ∀ {Δ} → Ty Δ → GTerm Δ → GTerm Δ
+  _·[_]_  : ∀ {Δ} → GTerm Δ → Label → GTerm Δ → GTerm Δ
+  Λ_      : ∀ {Δ} → GTerm (suc Δ) → GTerm Δ
+  _`[_]   : ∀ {Δ} → GTerm Δ → Ty Δ → GTerm Δ
+  $       : ∀ {Δ} → Const → GTerm Δ
+  _⊕[_at_]_ : ∀ {Δ}
+    → GTerm Δ → Prim → Label → GTerm Δ → GTerm Δ
+
+------------------------------------------------------------------------
+-- Type-variable renaming
+------------------------------------------------------------------------
+
+renameᵗᴳ : ∀ {Δ Δ′} → Δ ⇒ʳ Δ′ → GTerm Δ → GTerm Δ′
+renameᵗᴳ ρ (` x) = ` x
+renameᵗᴳ ρ (ƛ A ⇒ M) = ƛ renameᵗ ρ A ⇒ renameᵗᴳ ρ M
+renameᵗᴳ ρ (L ·[ ℓ ] M) = renameᵗᴳ ρ L ·[ ℓ ] renameᵗᴳ ρ M
+renameᵗᴳ ρ (Λ M) = Λ (renameᵗᴳ (extᵗ ρ) M)
+renameᵗᴳ ρ (M `[ A ]) = renameᵗᴳ ρ M `[ renameᵗ ρ A ]
+renameᵗᴳ ρ ($ κ) = $ κ
+renameᵗᴳ ρ (L ⊕[ op at ℓ ] M) =
+  renameᵗᴳ ρ L ⊕[ op at ℓ ] renameᵗᴳ ρ M
+
+⇑ᵗᴳ : ∀ {Δ} → GTerm Δ → GTerm (suc Δ)
+⇑ᵗᴳ = renameᵗᴳ Fin.suc
+
+------------------------------------------------------------------------
+-- Values
+------------------------------------------------------------------------
+
+data Value {Δ : TyCtx} : GTerm Δ → Set where
+  ƛ_⇒_ : (A : Ty Δ) (N : GTerm Δ) → Value (ƛ A ⇒ N)
+  $ : (κ : Const) → Value ($ κ)
+  Λ_ : (N : GTerm (suc Δ)) → Value (Λ N)
+
+------------------------------------------------------------------------
+-- Typing
+------------------------------------------------------------------------
+
+infix 4 _∣_⊢_⦂_
+
+data _∣_⊢_⦂_ (Δ : TyCtx) (Γ : TermCtx Δ) :
+    GTerm Δ → Ty Δ → Set where
+
+  ⊢` : ∀ {x A}
+    → Γ ∋ x ⦂ A
+      ----------------------
+    → Δ ∣ Γ ⊢ (` x) ⦂ A
+
+  ⊢ƛ : ∀ {M A B}
+    → Δ ∣ (A ∷ Γ) ⊢ M ⦂ B
+      --------------------------
+    → Δ ∣ Γ ⊢ (ƛ A ⇒ M) ⦂ (A ⇒ B)
+
+  ⊢· : ∀ {L M A A′ B ℓ}
+    → Δ ∣ Γ ⊢ L ⦂ (A ⇒ B)
+    → Δ ∣ Γ ⊢ M ⦂ A′
+    → A ∼ A′
+      -------------------------
+    → Δ ∣ Γ ⊢ L ·[ ℓ ] M ⦂ B
+
+  ⊢·★ : ∀ {L M A′ ℓ}
+    → Δ ∣ Γ ⊢ L ⦂ ★
+    → Δ ∣ Γ ⊢ M ⦂ A′
+    → A′ ∼ ★
+      -------------------------
+    → Δ ∣ Γ ⊢ L ·[ ℓ ] M ⦂ ★
+
+  ⊢Λ : ∀ {M A} {zero∈A : zero ∈ᵗ A}
+    → Value M
+    → (suc Δ) ∣ ⇑ᶜ Γ ⊢ M ⦂ A
+      ------------------------
+    → Δ ∣ Γ ⊢ Λ M ⦂ (`∀ A)
+
+  ⊢• : ∀ {M B A}
+    → Δ ∣ Γ ⊢ M ⦂ (`∀ B)
+      ---------------------------
+    → Δ ∣ Γ ⊢ M `[ A ] ⦂ B [ A ]ᵗ
+
+  ⊢$ : ∀ (κ : Const)
+      ---------------------------
+    → Δ ∣ Γ ⊢ ($ κ) ⦂ constTy κ
+
+  ⊢⊕ : ∀ {L M A B ℓ}
+    → (op : Prim)
+    → Δ ∣ Γ ⊢ L ⦂ A
+    → A ∼ primArgTy op
+    → Δ ∣ Γ ⊢ M ⦂ B
+    → B ∼ primArgTy op
+      -----------------------------------------------
+    → Δ ∣ Γ ⊢ L ⊕[ op at ℓ ] M ⦂ primResultTy op

--- a/GTSFImp/Imprecision.agda
+++ b/GTSFImp/Imprecision.agda
@@ -2,8 +2,8 @@ module Imprecision where
 
 -- File Charter:
 --   * Defines intrinsically scoped type imprecision.
---   * Includes the universal-ground and empty-universal clauses required
---     for consistency to coincide with existence of a common lower bound.
+--   * Includes structural universal-to-dynamic and empty-universal clauses
+--     required for consistency to coincide with a common lower bound.
 
 open import Data.Nat using (zero; suc)
 open import Data.Fin using (zero; suc)
@@ -25,13 +25,15 @@ ImpEnv Δ = TyVar Δ → VarImp
 idᵐ : ∀ {Δ} → ImpEnv Δ
 idᵐ X = X⊑X
 
+extendᵐ : VarImp → ImpEnv Δ → ImpEnv (suc Δ)
+extendᵐ v μ zero = v
+extendᵐ v μ (suc X) = μ X
+
 extᵐ : ImpEnv Δ → ImpEnv (suc Δ)
-extᵐ μ zero = X⊑X
-extᵐ μ (suc X) = μ X
+extᵐ = extendᵐ X⊑X
 
 instᵐ : ImpEnv Δ → ImpEnv (suc Δ)
-instᵐ μ zero = X⊑★
-instᵐ μ (suc X) = μ X
+instᵐ = extendᵐ X⊑★
 
 ----------------------------------------------------------------------
 -- Imprecision
@@ -89,6 +91,11 @@ data _⊢_⊑_ {Δ : TyCtx} (μ : ImpEnv Δ) : Ty Δ → Ty Δ → Set where
   ∀★⊑★ :
       ------------------
     μ ⊢ (`∀ ★) ⊑ ★
+
+  ∀⊑★ : ∀ {A}
+    → extᵐ μ ⊢ A ⊑ ★
+      -----------------
+    → μ ⊢ (`∀ A) ⊑ ★
 
   bot-elim :
       --------------------------------

--- a/GTSFImp/proof/Consistency.agda
+++ b/GTSFImp/proof/Consistency.agda
@@ -1,0 +1,19 @@
+module proof.Consistency where
+
+-- File Charter:
+--   * Proves that every closed type is consistent with the dynamic type.
+--   * Derives the result from closed-type imprecision and the common-lower
+--     characterization of consistency.
+--   * Depends on proof.Imprecision and proof.ImprecisionConsistency.
+
+open import Data.Product using (_,_)
+
+open import Types
+open import Consistency
+open import proof.Imprecision using (imprecise-star)
+open import proof.ImprecisionConsistency
+  using (common-lower-consistent; refl⊑)
+
+consistent-star : ∀ (A : Ty 0) → A ∼ ★
+consistent-star A = common-lower-consistent
+  (A , refl⊑ A , imprecise-star A)

--- a/GTSFImp/proof/DGG/CastTermImprecision.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision.agda
@@ -1,0 +1,480 @@
+module proof.DGG.CastTermImprecision where
+
+-- File Charter:
+--   * Defines the compiler-facing fragment of typed cast-term imprecision.
+--   * Indexes related terms by their exact type-imprecision derivation,
+--     related term context, and relational runtime store.
+--   * The runtime-store relation owns the type-imprecision environment and
+--     classifies every type variable as both, left-only, or right-only.
+--   * Proves reflexivity from cast typing and exports source/target typing
+--     projections.
+--   * Deliberately omits runtime-only rules until the DGG requires them.
+
+open import Data.List using (List; []; _∷_)
+open import Data.Empty using (⊥)
+open import Data.Fin using (zero)
+import Data.Fin as Fin
+open import Data.Nat using (suc)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong; cong₂)
+  renaming (subst to subst≡)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-lift; store-bind)
+open import TermCtx using (TermCtx; ⇑ᶜ)
+import TermCtx as T
+import Consistency as Con
+open Con using (Env∼; _⊢_∼_; _↪ᵗ_; toRenameᵗ)
+open import Conversion using (Conv↑; Conv↓; _⊢↑_; _⊢↓_)
+open import Imprecision
+open import Primitives using (Const; Prim; constTy; primArgTy; primResultTy)
+open import CastTerms
+import GradualTermImprecision as GTI
+open import proof.ImprecisionConsistency using (refl⊑)
+
+------------------------------------------------------------------------
+-- Relational runtime stores
+------------------------------------------------------------------------
+
+data StoreCategories : ∀ {Δ}
+    → ImpEnv Δ → TyStore Δ → TyStore Δ → Set where
+  categories-empty :
+    StoreCategories idᵐ store-empty store-empty
+
+  categories-both-abstract : ∀ {Δ μ}
+      {Σᴸ Σᴿ : TyStore Δ}
+    → (v : VarImp)
+    → StoreCategories μ Σᴸ Σᴿ
+      -----------------------------------------------------------
+    → StoreCategories (extendᵐ v μ)
+        (store-lift Σᴸ) (store-lift Σᴿ)
+
+  categories-both : ∀ {Δ μ} {Σᴸ Σᴿ : TyStore Δ} {A B : Ty Δ}
+    → (v : VarImp)
+    → StoreCategories μ Σᴸ Σᴿ
+    → μ ⊢ A ⊑ B
+      -----------------------------------------------------------
+    → StoreCategories (extendᵐ v μ)
+        (store-bind Σᴸ A) (store-bind Σᴿ B)
+
+  categories-left-only : ∀ {Δ μ}
+      {Σᴸ Σᴿ : TyStore Δ} {A : Ty Δ}
+    → (v : VarImp)
+    → StoreCategories μ Σᴸ Σᴿ
+      -----------------------------------------------------------
+    → StoreCategories (extendᵐ v μ)
+        (store-bind Σᴸ A) (store-lift Σᴿ)
+
+  categories-right-only : ∀ {Δ μ} {Σᴸ Σᴿ : TyStore Δ}
+    → (v : VarImp)
+    → StoreCategories μ Σᴸ Σᴿ
+      -----------------------------------------------------------
+    → StoreCategories (extendᵐ v μ)
+        (store-lift Σᴸ) (store-bind Σᴿ ★)
+
+record StoreImp (Δ : TyCtx) : Set where
+  constructor stores
+  field
+    impEnvⁱ : ImpEnv Δ
+    sourceStoreⁱ : TyStore Δ
+    targetStoreⁱ : TyStore Δ
+    categoriesⁱ :
+      StoreCategories impEnvⁱ sourceStoreⁱ targetStoreⁱ
+
+open StoreImp public
+
+liftStoreImp : ∀ {Δ} → VarImp → StoreImp Δ → StoreImp (suc Δ)
+liftStoreImp v (stores μ Σᴸ Σᴿ categories) =
+  stores (extendᵐ v μ) (store-lift Σᴸ) (store-lift Σᴿ)
+    (categories-both-abstract v categories)
+
+------------------------------------------------------------------------
+-- Typed cast-term imprecision
+------------------------------------------------------------------------
+
+infix 4 _∣_⊢ᶜ_⊑_∶_
+
+data _∣_⊢ᶜ_⊑_∶_ {Δ : TyCtx}
+    (ρ : StoreImp Δ) (γ : GTI.CtxImp (impEnvⁱ ρ)) :
+    Term Δ → Term Δ → {A B : Ty Δ}
+    → impEnvⁱ ρ ⊢ A ⊑ B → Set where
+
+  x⊑xᶜ : ∀ {x A B} {p : impEnvⁱ ρ ⊢ A ⊑ B}
+    → γ GTI.∋ⁱ x ⦂ GTI.ctx-imp A B p
+      ------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ ` x ⊑ ` x ∶ p
+
+  ƛ⊑ƛᶜ : ∀ {M M′ A A′ B B′}
+      {pA : impEnvⁱ ρ ⊢ A ⊑ A′}
+      {pB : impEnvⁱ ρ ⊢ B ⊑ B′}
+    → ρ ∣ GTI.ctx-imp A A′ pA ∷ γ ⊢ᶜ M ⊑ M′ ∶ pB
+      -----------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ ƛ M ⊑ ƛ M′ ∶ ⇒⊑⇒ pA pB
+
+  ·⊑·ᶜ : ∀ {L L′ M M′ A A′ B B′}
+      {pA : impEnvⁱ ρ ⊢ A ⊑ A′}
+      {pB : impEnvⁱ ρ ⊢ B ⊑ B′}
+    → ρ ∣ γ ⊢ᶜ L ⊑ L′ ∶ ⇒⊑⇒ pA pB
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ pA
+      --------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ L · M ⊑ L′ · M′ ∶ pB
+
+  Λ⊑Λᶜ : ∀ {γ′ V V′ A B}
+      {p : extᵐ (impEnvⁱ ρ) ⊢ A ⊑ B}
+    → GTI.LiftCtxⁱ (extᵐ (impEnvⁱ ρ)) γ γ′
+    → Value V
+    → Value V′
+    → liftStoreImp X⊑X ρ ∣ γ′ ⊢ᶜ V ⊑ V′ ∶ p
+      -----------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ Λ V ⊑ Λ V′ ∶ ∀⊑∀ p
+
+  Λ⊑ᶜ : ∀ {γ′ V W M A B}
+      {p : instᵐ (impEnvⁱ ρ) ⊢ A ⊑ ⇑ᵗ B}
+    → (Anv : NonVar A)
+    → (zero∈A : zero ∈ᵗ A)
+    → GTI.LiftCtxⁱ (instᵐ (impEnvⁱ ρ)) γ γ′
+    → Value V
+    → ⟨ Δ , targetStoreⁱ ρ , GTI.tgtCtxⁱ γ ⟩ ⊢ M ⦂ B
+    → liftStoreImp X⊑★ ρ ∣ γ′ ⊢ᶜ V ⊑ W ∶ p
+      --------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ Λ V ⊑ M ∶ ∀⊑ Anv zero∈A p
+
+  •⊑•ᶜ : ∀ {M M′ T T′ A B}
+      {p : extᵐ (impEnvⁱ ρ) ⊢ A ⊑ B}
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ ∀⊑∀ p
+    → (q : impEnvⁱ ρ ⊢ T ⊑ T′)
+    → (r : impEnvⁱ ρ ⊢ A [ T ]ᵗ ⊑ B [ T′ ]ᵗ)
+      ------------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ M ⦂∀ A [ T ] ⊑ M′ ⦂∀ B [ T′ ] ∶ r
+
+  •⊑ᶜ : ∀ {M M′ T A B Anv zero∈A}
+      {p : instᵐ (impEnvⁱ ρ) ⊢ A ⊑ ⇑ᵗ B}
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ ∀⊑ Anv zero∈A p
+    → (q : impEnvⁱ ρ ⊢ T ⊑ ★)
+    → (r : impEnvⁱ ρ ⊢ A [ T ]ᵗ ⊑ B)
+      ----------------------------------------------
+    → ρ ∣ γ ⊢ᶜ M ⦂∀ A [ T ] ⊑ M′ ∶ r
+
+  κ⊑κᶜ : ∀ (κ : Const)
+    → (p : impEnvⁱ ρ ⊢ constTy κ ⊑ constTy κ)
+      ------------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ $ κ ⊑ $ κ ∶ p
+
+  cast⊑castᶜ : ∀ {M M′ C C′ A A′}
+      {p : impEnvⁱ ρ ⊢ C ⊑ C′}
+      {ν ν′ : Env∼ Δ}
+    → (c : ν ⊢ C ∼ A)
+    → (c′ : ν′ ⊢ C′ ∼ A′)
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+    → (q : impEnvⁱ ρ ⊢ A ⊑ A′)
+      ---------------------------------------
+    → ρ ∣ γ ⊢ᶜ M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ∶ q
+
+  ⊑castᶜ : ∀ {M M′ A B B′}
+      {p : impEnvⁱ ρ ⊢ A ⊑ B} {ν : Env∼ Δ}
+    → (c′ : ν ⊢ B ∼ B′)
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+    → (q : impEnvⁱ ρ ⊢ A ⊑ B′)
+      -------------------------------
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ⟨ c′ ⟩ ∶ q
+
+  reveal⊑revealᶜ : ∀ {M M′ A A′ B B′}
+      {p : impEnvⁱ ρ ⊢ A ⊑ A′}
+      {c : Conv↑ Δ A B} {c′ : Conv↑ Δ A′ B′}
+    → sourceStoreⁱ ρ ⊢↑ c
+    → targetStoreⁱ ρ ⊢↑ c′
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+    → (q : impEnvⁱ ρ ⊢ B ⊑ B′)
+      ---------------------------------------
+    → ρ ∣ γ ⊢ᶜ M ↑ c ⊑ M′ ↑ c′ ∶ q
+
+  conceal⊑concealᶜ : ∀ {M M′ A A′ B B′}
+      {p : impEnvⁱ ρ ⊢ A ⊑ A′}
+      {c : Conv↓ Δ A B} {c′ : Conv↓ Δ A′ B′}
+    → sourceStoreⁱ ρ ⊢↓ c
+    → targetStoreⁱ ρ ⊢↓ c′
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+    → (q : impEnvⁱ ρ ⊢ B ⊑ B′)
+      ---------------------------------------
+    → ρ ∣ γ ⊢ᶜ M ↓ c ⊑ M′ ↓ c′ ∶ q
+
+  blame⊑blameᶜ : ∀ {A B} (p : impEnvⁱ ρ ⊢ A ⊑ B)
+      ----------------------------------------
+    → ρ ∣ γ ⊢ᶜ blame ⊑ blame ∶ p
+
+  ⊕⊑⊕ᶜ : (op : Prim)
+    → ∀ {L L′ M M′}
+      {p q : impEnvⁱ ρ ⊢ primArgTy op ⊑ primArgTy op}
+    → ρ ∣ γ ⊢ᶜ L ⊑ L′ ∶ p
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ q
+    → (r : impEnvⁱ ρ ⊢ primResultTy op ⊑ primResultTy op)
+      --------------------------------------------------
+    → ρ ∣ γ ⊢ᶜ L ⊕[ op ] M ⊑ L′ ⊕[ op ] M′ ∶ r
+
+------------------------------------------------------------------------
+-- Cast-term imprecision across different type contexts
+------------------------------------------------------------------------
+
+infix 4 _∣_∣_∣_⊢ᶜ_⊑_∶_
+
+data VarCategory : Set where
+  both left-only right-only : VarCategory
+
+categoryAt : ∀ {Δ μ} {Σᴸ Σᴿ : TyStore Δ}
+  → StoreCategories μ Σᴸ Σᴿ
+  → TyVar Δ
+  → VarCategory
+categoryAt (categories-both-abstract v categories) zero = both
+categoryAt (categories-both v categories p) zero = both
+categoryAt (categories-left-only v categories) zero = left-only
+categoryAt (categories-right-only v categories) zero = right-only
+categoryAt (categories-both-abstract v categories) (Fin.suc X) =
+  categoryAt categories X
+categoryAt (categories-both v categories p) (Fin.suc X) =
+  categoryAt categories X
+categoryAt (categories-left-only v categories) (Fin.suc X) =
+  categoryAt categories X
+categoryAt (categories-right-only v categories) (Fin.suc X) =
+  categoryAt categories X
+
+data InImage {Δ₀ Δ : TyCtx}
+    (η : Δ₀ ↪ᵗ Δ) (X : TyVar Δ) : Set where
+  image : ∀ Y → toRenameᵗ η Y ≡ X → InImage η X
+
+data ImageCategory {Δᴸ Δᴿ Δ : TyCtx}
+    (ηᴸ : Δᴸ ↪ᵗ Δ) (ηᴿ : Δᴿ ↪ᵗ Δ) (X : TyVar Δ) :
+    VarCategory → Set where
+  image-both :
+    InImage ηᴸ X →
+    InImage ηᴿ X →
+    ImageCategory ηᴸ ηᴿ X both
+
+  image-left-only :
+    InImage ηᴸ X →
+    (InImage ηᴿ X → ⊥) →
+    ImageCategory ηᴸ ηᴿ X left-only
+
+  image-right-only :
+    (InImage ηᴸ X → ⊥) →
+    InImage ηᴿ X →
+    ImageCategory ηᴸ ηᴿ X right-only
+
+RenamingsCategorize : ∀ {Δᴸ Δᴿ Δ μ} {Σᴸ Σᴿ : TyStore Δ}
+  → (ηᴸ : Δᴸ ↪ᵗ Δ)
+  → (ηᴿ : Δᴿ ↪ᵗ Δ)
+  → StoreCategories μ Σᴸ Σᴿ
+  → Set
+RenamingsCategorize {Δ = Δ} ηᴸ ηᴿ categories =
+  (X : TyVar Δ) →
+  ImageCategory ηᴸ ηᴿ X (categoryAt categories X)
+
+data _∣_∣_∣_⊢ᶜ_⊑_∶_ {Δᴸ Δᴿ Δ}
+    (ηᴸ : Δᴸ ↪ᵗ Δ) (ηᴿ : Δᴿ ↪ᵗ Δ)
+    (ρ : StoreImp Δ) (γ : GTI.CtxImp (impEnvⁱ ρ))
+    : Term Δᴸ → Term Δᴿ → {A B : Ty Δ}
+    → impEnvⁱ ρ ⊢ A ⊑ B → Set where
+
+  rename⊑renameᶜ : ∀ {M M′ A B}
+      {p : impEnvⁱ ρ ⊢ A ⊑ B}
+    → RenamingsCategorize ηᴸ ηᴿ (categoriesⁱ ρ)
+    → ρ ∣ γ ⊢ᶜ renameᵗᵐ ηᴸ M ⊑ renameᵗᵐ ηᴿ M′ ∶ p
+      ------------------------------------------------------
+    → ηᴸ ∣ ηᴿ ∣ ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+
+------------------------------------------------------------------------
+-- Typing projections
+------------------------------------------------------------------------
+
+mutual
+  cast-term-imprecision-source-typing : ∀ {Δ} {ρ : StoreImp Δ}
+      {γ : GTI.CtxImp (impEnvⁱ ρ)} {M M′ A B}
+      {p : impEnvⁱ ρ ⊢ A ⊑ B}
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+    → ⟨ Δ , sourceStoreⁱ ρ , GTI.srcCtxⁱ γ ⟩ ⊢ M ⦂ A
+
+  cast-term-imprecision-target-typing : ∀ {Δ} {ρ : StoreImp Δ}
+      {γ : GTI.CtxImp (impEnvⁱ ρ)} {M M′ A B}
+      {p : impEnvⁱ ρ ⊢ A ⊑ B}
+    → ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ p
+    → ⟨ Δ , targetStoreⁱ ρ , GTI.tgtCtxⁱ γ ⟩ ⊢ M′ ⦂ B
+
+  cast-term-imprecision-source-typing (x⊑xᶜ x∈) =
+    ⊢` (GTI.lookup-srcⁱ x∈)
+  cast-term-imprecision-source-typing (ƛ⊑ƛᶜ M⊑M′) =
+    ⊢ƛ (cast-term-imprecision-source-typing M⊑M′)
+  cast-term-imprecision-source-typing (·⊑·ᶜ L⊑L′ M⊑M′) =
+    ⊢· (cast-term-imprecision-source-typing L⊑L′)
+      (cast-term-imprecision-source-typing M⊑M′)
+  cast-term-imprecision-source-typing
+      (Λ⊑Λᶜ liftγ vV vV′ V⊑V′) =
+    ⊢Λ vV
+      (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+        (GTI.srcCtxⁱ-lift liftγ)
+        (cast-term-imprecision-source-typing V⊑V′))
+  cast-term-imprecision-source-typing
+      (Λ⊑ᶜ Anv zero∈A liftγ vV M′⊢ V⊑W) =
+    ⊢Λ vV
+      (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+        (GTI.srcCtxⁱ-lift liftγ)
+        (cast-term-imprecision-source-typing V⊑W))
+  cast-term-imprecision-source-typing (•⊑•ᶜ M⊑M′ q r) =
+    ⊢• (cast-term-imprecision-source-typing M⊑M′)
+  cast-term-imprecision-source-typing (•⊑ᶜ M⊑M′ q r) =
+    ⊢• (cast-term-imprecision-source-typing M⊑M′)
+  cast-term-imprecision-source-typing (κ⊑κᶜ κ p) =
+    ⊢$ κ
+  cast-term-imprecision-source-typing
+      (cast⊑castᶜ c c′ M⊑M′ q) =
+    ⊢⟨⟩ (cast-term-imprecision-source-typing M⊑M′) c
+  cast-term-imprecision-source-typing (⊑castᶜ c′ M⊑M′ q) =
+    cast-term-imprecision-source-typing M⊑M′
+  cast-term-imprecision-source-typing
+      (reveal⊑revealᶜ c⊢ c′⊢ M⊑M′ q) =
+    ⊢reveal c⊢ (cast-term-imprecision-source-typing M⊑M′)
+  cast-term-imprecision-source-typing
+      (conceal⊑concealᶜ c⊢ c′⊢ M⊑M′ q) =
+    ⊢conceal c⊢ (cast-term-imprecision-source-typing M⊑M′)
+  cast-term-imprecision-source-typing (blame⊑blameᶜ p) =
+    ⊢blame
+  cast-term-imprecision-source-typing (⊕⊑⊕ᶜ op L⊑L′ M⊑M′ r) =
+    ⊢⊕ op (cast-term-imprecision-source-typing L⊑L′)
+      (cast-term-imprecision-source-typing M⊑M′)
+
+  cast-term-imprecision-target-typing (x⊑xᶜ x∈) =
+    ⊢` (GTI.lookup-tgtⁱ x∈)
+  cast-term-imprecision-target-typing (ƛ⊑ƛᶜ M⊑M′) =
+    ⊢ƛ (cast-term-imprecision-target-typing M⊑M′)
+  cast-term-imprecision-target-typing (·⊑·ᶜ L⊑L′ M⊑M′) =
+    ⊢· (cast-term-imprecision-target-typing L⊑L′)
+      (cast-term-imprecision-target-typing M⊑M′)
+  cast-term-imprecision-target-typing
+      (Λ⊑Λᶜ liftγ vV vV′ V⊑V′) =
+    ⊢Λ vV′
+      (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+        (GTI.tgtCtxⁱ-lift liftγ)
+        (cast-term-imprecision-target-typing V⊑V′))
+  cast-term-imprecision-target-typing
+      (Λ⊑ᶜ Anv zero∈A liftγ vV M′⊢ V⊑W) =
+    M′⊢
+  cast-term-imprecision-target-typing (•⊑•ᶜ M⊑M′ q r) =
+    ⊢• (cast-term-imprecision-target-typing M⊑M′)
+  cast-term-imprecision-target-typing (•⊑ᶜ M⊑M′ q r) =
+    cast-term-imprecision-target-typing M⊑M′
+  cast-term-imprecision-target-typing (κ⊑κᶜ κ p) =
+    ⊢$ κ
+  cast-term-imprecision-target-typing
+      (cast⊑castᶜ c c′ M⊑M′ q) =
+    ⊢⟨⟩ (cast-term-imprecision-target-typing M⊑M′) c′
+  cast-term-imprecision-target-typing (⊑castᶜ c′ M⊑M′ q) =
+    ⊢⟨⟩ (cast-term-imprecision-target-typing M⊑M′) c′
+  cast-term-imprecision-target-typing
+      (reveal⊑revealᶜ c⊢ c′⊢ M⊑M′ q) =
+    ⊢reveal c′⊢ (cast-term-imprecision-target-typing M⊑M′)
+  cast-term-imprecision-target-typing
+      (conceal⊑concealᶜ c⊢ c′⊢ M⊑M′ q) =
+    ⊢conceal c′⊢ (cast-term-imprecision-target-typing M⊑M′)
+  cast-term-imprecision-target-typing (blame⊑blameᶜ p) =
+    ⊢blame
+  cast-term-imprecision-target-typing (⊕⊑⊕ᶜ op L⊑L′ M⊑M′ r) =
+    ⊢⊕ op (cast-term-imprecision-target-typing L⊑L′)
+      (cast-term-imprecision-target-typing M⊑M′)
+
+------------------------------------------------------------------------
+-- Reflexivity
+------------------------------------------------------------------------
+
+reflStoreImp : ∀ {Δ} → TyStore Δ → StoreImp Δ
+reflStoreImp store-empty =
+  stores idᵐ store-empty store-empty categories-empty
+reflStoreImp (store-lift Σ) with reflStoreImp Σ
+reflStoreImp (store-lift Σ) | stores μ Σᴸ Σᴿ categories =
+  stores (extᵐ μ) (store-lift Σᴸ) (store-lift Σᴿ)
+    (categories-both-abstract X⊑X categories)
+reflStoreImp (store-bind Σ A) with reflStoreImp Σ
+reflStoreImp (store-bind Σ A) | stores μ Σᴸ Σᴿ categories =
+  stores (extᵐ μ) (store-bind Σᴸ A) (store-bind Σᴿ A)
+    (categories-both X⊑X categories (refl⊑ A))
+
+reflStoreImp-source : ∀ {Δ} (Σ : TyStore Δ)
+  → sourceStoreⁱ (reflStoreImp Σ) ≡ Σ
+reflStoreImp-source store-empty = refl
+reflStoreImp-source (store-lift Σ)
+    with reflStoreImp Σ | reflStoreImp-source Σ
+reflStoreImp-source (store-lift Σ)
+    | stores μ Σᴸ Σᴿ categories | eq =
+  cong store-lift eq
+reflStoreImp-source (store-bind Σ A)
+    with reflStoreImp Σ | reflStoreImp-source Σ
+reflStoreImp-source (store-bind Σ A)
+    | stores μ Σᴸ Σᴿ categories | eq =
+  cong (λ Σ′ → store-bind Σ′ A) eq
+
+reflStoreImp-target : ∀ {Δ} (Σ : TyStore Δ)
+  → targetStoreⁱ (reflStoreImp Σ) ≡ Σ
+reflStoreImp-target store-empty = refl
+reflStoreImp-target (store-lift Σ)
+    with reflStoreImp Σ | reflStoreImp-target Σ
+reflStoreImp-target (store-lift Σ)
+    | stores μ Σᴸ Σᴿ categories | eq =
+  cong store-lift eq
+reflStoreImp-target (store-bind Σ A)
+    with reflStoreImp Σ | reflStoreImp-target Σ
+reflStoreImp-target (store-bind Σ A)
+    | stores μ Σᴸ Σᴿ categories | eq =
+  cong (λ Σ′ → store-bind Σ′ A) eq
+
+reflCtx : ∀ {Δ} (μ : ImpEnv Δ) → TermCtx Δ → GTI.CtxImp μ
+reflCtx μ [] = []
+reflCtx μ (A ∷ Γ) = GTI.ctx-imp A A (refl⊑ A) ∷ reflCtx μ Γ
+
+reflCtx-lift : ∀ {Δ} (μ : ImpEnv Δ) (Γ : TermCtx Δ)
+  → GTI.LiftCtxⁱ (extᵐ μ) (reflCtx μ Γ)
+      (reflCtx (extᵐ μ) (⇑ᶜ Γ))
+reflCtx-lift μ [] = GTI.lift-[]
+reflCtx-lift μ (A ∷ Γ) = GTI.lift-∷ (reflCtx-lift μ Γ)
+
+reflCtx-lookup : ∀ {Δ} {μ : ImpEnv Δ} {Γ : TermCtx Δ} {x A}
+  → Γ T.∋ x ⦂ A
+  → reflCtx μ Γ GTI.∋ⁱ x ⦂ GTI.ctx-imp A A (refl⊑ A)
+reflCtx-lookup T.Z = GTI.Zⁱ
+reflCtx-lookup (T.S x∈) = GTI.Sⁱ (reflCtx-lookup x∈)
+
+reflᶜ : ∀ {Δ} {Σ : TyStore Δ}
+    {Γ : TermCtx Δ} {M : Term Δ} {A : Ty Δ}
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ⦂ A
+  → reflStoreImp Σ ∣ reflCtx (impEnvⁱ (reflStoreImp Σ)) Γ
+      ⊢ᶜ M ⊑ M ∶ refl⊑ A
+reflᶜ (⊢` x∈) = x⊑xᶜ (reflCtx-lookup x∈)
+reflᶜ (⊢ƛ M⊢) = ƛ⊑ƛᶜ (reflᶜ M⊢)
+reflᶜ (⊢· L⊢ M⊢) = ·⊑·ᶜ (reflᶜ L⊢) (reflᶜ M⊢)
+reflᶜ (⊢Λ vM M⊢) =
+  Λ⊑Λᶜ (reflCtx-lift _ _) vM vM (reflᶜ M⊢)
+reflᶜ (⊢• {C = C} {A = A} M⊢) =
+  •⊑•ᶜ (reflᶜ M⊢) (refl⊑ A) (refl⊑ (C [ A ]ᵗ))
+reflᶜ (⊢$ κ) = κ⊑κᶜ κ (refl⊑ (constTy κ))
+reflᶜ (⊢⊕ op L⊢ M⊢) =
+  ⊕⊑⊕ᶜ op (reflᶜ L⊢) (reflᶜ M⊢)
+    (refl⊑ (primResultTy op))
+reflᶜ (⊢⟨⟩ M⊢ c) =
+  cast⊑castᶜ c c (reflᶜ M⊢) (refl⊑ _)
+reflᶜ {Σ = Σ} (⊢reveal {c = c} c⊢ M⊢) =
+  reveal⊑revealᶜ
+    (subst≡ (λ Σ′ → Σ′ ⊢↑ c) (sym (reflStoreImp-source Σ)) c⊢)
+    (subst≡ (λ Σ′ → Σ′ ⊢↑ c) (sym (reflStoreImp-target Σ)) c⊢)
+    (reflᶜ M⊢) (refl⊑ _)
+reflᶜ {Σ = Σ} (⊢conceal {c = c} c⊢ M⊢) =
+  conceal⊑concealᶜ
+    (subst≡ (λ Σ′ → Σ′ ⊢↓ c) (sym (reflStoreImp-source Σ)) c⊢)
+    (subst≡ (λ Σ′ → Σ′ ⊢↓ c) (sym (reflStoreImp-target Σ)) c⊢)
+    (reflᶜ M⊢) (refl⊑ _)
+reflᶜ ⊢blame = blame⊑blameᶜ (refl⊑ _)
+
+⊑ᶜ-cong : ∀ {Δ} {ρ : StoreImp Δ}
+    {γ : GTI.CtxImp (impEnvⁱ ρ)} {L L′ R R′ : Term Δ} {A B}
+    {p : impEnvⁱ ρ ⊢ A ⊑ B}
+  → L ≡ L′
+  → R ≡ R′
+  → ρ ∣ γ ⊢ᶜ L ⊑ R ∶ p
+  → ρ ∣ γ ⊢ᶜ L′ ⊑ R′ ∶ p
+⊑ᶜ-cong refl refl L⊑R = L⊑R

--- a/GTSFImp/proof/DGG/CompilePreservesImprecision.agda
+++ b/GTSFImp/proof/DGG/CompilePreservesImprecision.agda
@@ -1,0 +1,233 @@
+module proof.DGG.CompilePreservesImprecision where
+
+-- File Charter:
+--   * Proves that compiling related gradual terms produces related cast
+--     terms at the same type-imprecision index.
+--   * Uses the gradual relation's typing projections to invoke the compiler.
+--   * Depends on Compile, GradualTermImprecision, and the typed cast-term
+--     imprecision relation.
+
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Fin using (zero)
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; subst)
+
+open import Types
+open import TyStore using (TyStore; store-lift)
+open import TermCtx using (TermCtx; ⇑ᶜ)
+open import Consistency using (_∼_; id; _↦_; ？_; symᶜ)
+open import Imprecision
+open import GradualTerms using (GTerm; _∣_⊢_⦂_)
+import GradualTerms as G
+open import Primitives using (primArgTy)
+import CastTerms as C
+open C using () renaming (Λ_ to Λᵀ_)
+open import Compile using (compile; compile-value)
+import GradualTermImprecision as GTI
+open import GradualTermImprecision using
+  (CtxImp; _∣_⊢ᴳ_⊑_⦂_⊑_∶_)
+import proof.DGG.CastTermImprecision as CTI
+open CTI using (_∣_⊢ᶜ_⊑_∶_)
+open import proof.ImprecisionConsistency using (refl⊑)
+
+dynamic-function-cast : ∀ {Δ} → _∼_ {Δ} ★ (★ ⇒ ★)
+dynamic-function-cast = ？ (id ★ ↦ id ★)
+
+compile-context-subst : ∀ {Δ} {Σ : TyStore Δ}
+    {Γ Γ′ : TermCtx Δ} {M : GTerm Δ} {A : Ty Δ}
+  → (Γ≡Γ′ : Γ ≡ Γ′)
+  → (M⊢ : Δ ∣ Γ ⊢ M ⦂ A)
+  → proj₁ (compile {Σ = Σ}
+      (subst (λ Γ₀ → Δ ∣ Γ₀ ⊢ M ⦂ A) Γ≡Γ′ M⊢))
+    ≡ proj₁ (compile {Σ = Σ} M⊢)
+compile-context-subst refl M⊢ = refl
+
+compile-Λ-term : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ}
+    {M : GTerm (Nat.suc Δ)} {A : Ty (Nat.suc Δ)}
+    {zero∈A : zero ∈ᵗ A}
+  → (vM : G.Value M)
+  → (M⊢ : Nat.suc Δ ∣ ⇑ᶜ Γ ⊢ M ⦂ A)
+  → proj₁ (compile {Σ = Σ} (G.⊢Λ {zero∈A = zero∈A} vM M⊢))
+    ≡ Λᵀ (proj₁ (compile {Σ = store-lift Σ} M⊢))
+compile-Λ-term {Σ = Σ} vM M⊢
+    with compile {Σ = store-lift Σ} M⊢
+       | compile-value {Σ = store-lift Σ} vM M⊢
+compile-Λ-term {Σ = Σ} vM M⊢ | N , N⊢ | vN = refl
+
+compile-preserves-imprecision : ∀ {Δ} {ρ : CTI.StoreImp Δ}
+    {γ : CtxImp (CTI.impEnvⁱ ρ)} {M M′ A B p}
+  → (M⊑M′ : CTI.impEnvⁱ ρ ∣ γ
+      ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p)
+  → ρ ∣ γ ⊢ᶜ
+      proj₁ (compile {Σ = CTI.sourceStoreⁱ ρ}
+        (GTI.gradual-term-imprecision-source-typing M⊑M′))
+      ⊑ proj₁ (compile {Σ = CTI.targetStoreⁱ ρ}
+        (GTI.gradual-term-imprecision-target-typing M⊑M′))
+      ∶ p
+compile-preserves-imprecision (GTI.x⊑xᴳ x∈) =
+  CTI.x⊑xᶜ x∈
+compile-preserves-imprecision {ρ = ρ} (GTI.ƛ⊑ƛᴳ N⊑N′)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing N⊑N′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing N⊑N′)
+       | compile-preserves-imprecision {ρ = ρ} N⊑N′
+compile-preserves-imprecision {ρ = ρ} (GTI.ƛ⊑ƛᴳ N⊑N′)
+    | N , N⊢ | N′ , N′⊢ | N⊑N′ᶜ =
+  CTI.ƛ⊑ƛᶜ N⊑N′ᶜ
+compile-preserves-imprecision
+    {ρ = ρ}
+    (GTI.·⊑·ᴳ {pA = pA} L⊑L′ M⊑M′ A∼C A′∼C′)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing L⊑L′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+       | compile-preserves-imprecision {ρ = ρ} M⊑M′
+compile-preserves-imprecision
+    {ρ = ρ}
+    (GTI.·⊑·ᴳ {pA = pA} L⊑L′ M⊑M′ A∼C A′∼C′)
+    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
+    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+  CTI.·⊑·ᶜ L⊑L′ᶜ
+    (CTI.cast⊑castᶜ (symᶜ A∼C) (symᶜ A′∼C′) M⊑M′ᶜ pA)
+compile-preserves-imprecision
+    {ρ = ρ}
+    (GTI.·⊑·★ᴳ {pA = pA} {pB = pB}
+      L⊑L′ M⊑M′ A∼C C′∼★)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing L⊑L′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+       | compile-preserves-imprecision {ρ = ρ} M⊑M′
+compile-preserves-imprecision
+    {ρ = ρ}
+    (GTI.·⊑·★ᴳ {pA = pA} {pB = pB}
+      L⊑L′ M⊑M′ A∼C C′∼★)
+    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
+    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+  CTI.·⊑·ᶜ
+    (CTI.⊑castᶜ dynamic-function-cast L⊑L′ᶜ (⇒⊑⇒ pA pB))
+    (CTI.cast⊑castᶜ (symᶜ A∼C) C′∼★ M⊑M′ᶜ pA)
+compile-preserves-imprecision
+    {ρ = ρ} (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing L⊑L′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+       | compile-preserves-imprecision {ρ = ρ} M⊑M′
+compile-preserves-imprecision
+    {ρ = ρ} (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
+    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+  CTI.·⊑·ᶜ
+    (CTI.cast⊑castᶜ dynamic-function-cast dynamic-function-cast
+      L⊑L′ᶜ (⇒⊑⇒ ★⊑★ ★⊑★))
+    (CTI.cast⊑castᶜ C∼★ C′∼★ M⊑M′ᶜ ★⊑★)
+compile-preserves-imprecision
+    {ρ = ρ} {γ = γ}
+    (GTI.Λ⊑Λᴳ liftγ vV vV′ zero∈A zero∈B V⊑V′)
+    rewrite compile-Λ-term {Σ = CTI.sourceStoreⁱ ρ}
+      {Γ = GTI.srcCtxⁱ γ}
+      {zero∈A = zero∈A} vV
+      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (GTI.srcCtxⁱ-lift liftγ)
+        (GTI.gradual-term-imprecision-source-typing V⊑V′))
+      | compile-Λ-term {Σ = CTI.targetStoreⁱ ρ}
+      {Γ = GTI.tgtCtxⁱ γ}
+      {zero∈A = zero∈B} vV′
+      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (GTI.tgtCtxⁱ-lift liftγ)
+        (GTI.gradual-term-imprecision-target-typing V⊑V′))
+      | compile-context-subst
+      {Σ = store-lift (CTI.sourceStoreⁱ ρ)}
+      (GTI.srcCtxⁱ-lift liftγ)
+      (GTI.gradual-term-imprecision-source-typing V⊑V′)
+      | compile-context-subst
+      {Σ = store-lift (CTI.targetStoreⁱ ρ)}
+      (GTI.tgtCtxⁱ-lift liftγ)
+      (GTI.gradual-term-imprecision-target-typing V⊑V′) =
+  CTI.Λ⊑Λᶜ liftγ
+    (compile-value {Σ = store-lift (CTI.sourceStoreⁱ ρ)} vV
+      (GTI.gradual-term-imprecision-source-typing V⊑V′))
+    (compile-value {Σ = store-lift (CTI.targetStoreⁱ ρ)} vV′
+      (GTI.gradual-term-imprecision-target-typing V⊑V′))
+    (compile-preserves-imprecision
+      {ρ = CTI.liftStoreImp X⊑X ρ} V⊑V′)
+compile-preserves-imprecision
+    {ρ = ρ} {γ = γ}
+    (GTI.Λ⊑ᴳ Anv zero∈A liftγ vV N′⊢ V⊑N′)
+    rewrite compile-Λ-term {Σ = CTI.sourceStoreⁱ ρ}
+      {Γ = GTI.srcCtxⁱ γ}
+      {zero∈A = zero∈A} vV
+      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (GTI.srcCtxⁱ-lift liftγ)
+        (GTI.gradual-term-imprecision-source-typing V⊑N′))
+      | compile-context-subst
+      {Σ = store-lift (CTI.sourceStoreⁱ ρ)}
+      (GTI.srcCtxⁱ-lift liftγ)
+      (GTI.gradual-term-imprecision-source-typing V⊑N′) =
+  CTI.Λ⊑ᶜ Anv zero∈A liftγ
+    (compile-value {Σ = store-lift (CTI.sourceStoreⁱ ρ)} vV
+      (GTI.gradual-term-imprecision-source-typing V⊑N′))
+    (proj₂ (compile {Σ = CTI.targetStoreⁱ ρ} N′⊢))
+    (compile-preserves-imprecision
+      {ρ = CTI.liftStoreImp X⊑★ ρ} V⊑N′)
+compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑[]ᴳ M⊑M′ q r)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+       | compile-preserves-imprecision {ρ = ρ} M⊑M′
+compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑[]ᴳ M⊑M′ q r)
+    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+  CTI.•⊑•ᶜ M⊑M′ᶜ q r
+compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑ᴳ M⊑M′ q r)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+       | compile-preserves-imprecision {ρ = ρ} M⊑M′
+compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑ᴳ M⊑M′ q r)
+    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+  CTI.•⊑ᶜ M⊑M′ᶜ q r
+compile-preserves-imprecision {ρ = ρ} (GTI.κ⊑κᴳ κ) =
+  CTI.κ⊑κᶜ κ (GTI.constTy-⊑ (CTI.impEnvⁱ ρ) κ)
+compile-preserves-imprecision
+    {ρ = ρ}
+    (GTI.⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
+      B∼arg B′∼arg)
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing L⊑L′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile {Σ = CTI.targetStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+       | compile-preserves-imprecision {ρ = ρ} M⊑M′
+compile-preserves-imprecision
+    {ρ = ρ}
+    (GTI.⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
+      B∼arg B′∼arg)
+    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
+    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+  CTI.⊕⊑⊕ᶜ op
+    (CTI.cast⊑castᶜ A∼arg A′∼arg L⊑L′ᶜ
+      (refl⊑ (primArgTy op)))
+    (CTI.cast⊑castᶜ B∼arg B′∼arg M⊑M′ᶜ
+      (refl⊑ (primArgTy op)))
+    (GTI.primResultTy-⊑ (CTI.impEnvⁱ ρ) op)

--- a/GTSFImp/proof/Imprecision.agda
+++ b/GTSFImp/proof/Imprecision.agda
@@ -1,0 +1,134 @@
+module proof.Imprecision where
+
+-- File Charter:
+--   * Proves that every closed type is less precise than the dynamic type.
+--   * Uses occurrence information to choose between structural universal
+--     imprecision and instantiation at the dynamic type.
+--   * Depends only on Types and Imprecision.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Fin using (zero; suc)
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types
+import Imprecision as I
+
+private
+
+  not-occurs : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+    → X ∉ᵗ A
+    → X ∈ᵗ A
+    → ⊥
+  not-occurs (∉-var X≠Y) var-∈ = X≠Y refl
+  not-occurs ∉-base ()
+  not-occurs ∉-star ()
+  not-occurs (∉-fun X∉A X∉B) (∈-fun-left X∈A) =
+    not-occurs X∉A X∈A
+  not-occurs (∉-fun X∉A X∉B) (∈-fun-right X∉A′ X∈B) =
+    not-occurs X∉B X∈B
+  not-occurs (∉-all X∉A) (∈-all X∈A) = not-occurs X∉A X∈A
+
+  dynamic-domain : ∀ {Δ} {μ : I.ImpEnv Δ} {A B : Ty Δ}
+    → (∀ X → X ∈ᵗ A ⇒ B → μ X ≡ I.X⊑★)
+    → ∀ X → X ∈ᵗ A → μ X ≡ I.X⊑★
+  dynamic-domain dynamic X X∈A = dynamic X (∈-fun-left X∈A)
+
+  dynamic-codomain : ∀ {Δ} {μ : I.ImpEnv Δ} {A B : Ty Δ}
+    → (∀ X → X ∈ᵗ A ⇒ B → μ X ≡ I.X⊑★)
+    → ∀ X → X ∈ᵗ B → μ X ≡ I.X⊑★
+  dynamic-codomain {A = A} dynamic X X∈B with occurs? X A
+  dynamic-codomain dynamic X X∈B | present X∈A =
+    dynamic X (∈-fun-left X∈A)
+  dynamic-codomain dynamic X X∈B | absent X∉A =
+    dynamic X (∈-fun-right X∉A X∈B)
+
+  dynamic-under-inst : ∀ {Δ} {μ : I.ImpEnv Δ}
+      {A : Ty (Nat.suc Δ)}
+    → (∀ X → X ∈ᵗ `∀ A → μ X ≡ I.X⊑★)
+    → ∀ X → X ∈ᵗ A → I.instᵐ μ X ≡ I.X⊑★
+  dynamic-under-inst dynamic zero X∈A = refl
+  dynamic-under-inst dynamic (suc X) X∈A =
+    dynamic X (∈-all X∈A)
+
+  dynamic-under-ext : ∀ {Δ} {μ : I.ImpEnv Δ}
+      {A : Ty (Nat.suc Δ)}
+    → (∀ X → X ∈ᵗ `∀ A → μ X ≡ I.X⊑★)
+    → zero ∉ᵗ A
+    → ∀ X → X ∈ᵗ A → I.extᵐ μ X ≡ I.X⊑★
+  dynamic-under-ext dynamic zero∉A zero zero∈A =
+    ⊥-elim (not-occurs zero∉A zero∈A)
+  dynamic-under-ext dynamic zero∉A (suc X) X∈A =
+    dynamic X (∈-all X∈A)
+
+  data Shape : ∀ {Δ} → Ty Δ → Set where
+    var-shape : ∀ {Δ} {X : TyVar Δ} → Shape (＇ X)
+    base-shape : ∀ {Δ ι} → Shape (‵_ {Δ} ι)
+    star-shape : ∀ {Δ} → Shape (★ {Δ})
+    fun-shape : ∀ {Δ} {A B : Ty Δ}
+      → Shape A
+      → Shape B
+      → Shape (A ⇒ B)
+    all-shape : ∀ {Δ} {A : Ty (Nat.suc Δ)}
+      → Shape A
+      → Shape (`∀ A)
+
+  shape : ∀ {Δ} (A : Ty Δ) → Shape A
+  shape (＇ X) = var-shape
+  shape (‵ ι) = base-shape
+  shape ★ = star-shape
+  shape (A ⇒ B) = fun-shape (shape A) (shape B)
+  shape (`∀ A) = all-shape (shape A)
+
+  data AllChoice {Δ : TyCtx} : Ty (Nat.suc Δ) → Set where
+    bottom-choice : AllChoice (＇ zero)
+    inst-choice : ∀ {A}
+      → NonVar A
+      → zero ∈ᵗ A
+      → AllChoice A
+    structural-choice : ∀ {A}
+      → zero ∉ᵗ A
+      → AllChoice A
+
+  all-choice : ∀ {Δ} (A : Ty (Nat.suc Δ)) → AllChoice A
+  all-choice (＇ zero) = bottom-choice
+  all-choice (＇ (suc X)) = structural-choice (∉-var (λ ()))
+  all-choice (‵ ι) = structural-choice ∉-base
+  all-choice ★ = structural-choice ∉-star
+  all-choice (A ⇒ B) with occurs? zero (A ⇒ B)
+  all-choice (A ⇒ B) | present zero∈A⇒B =
+    inst-choice nonvar-fun zero∈A⇒B
+  all-choice (A ⇒ B) | absent zero∉A⇒B =
+    structural-choice zero∉A⇒B
+  all-choice (`∀ A) with occurs? zero (`∀ A)
+  all-choice (`∀ A) | present zero∈∀A =
+    inst-choice nonvar-all zero∈∀A
+  all-choice (`∀ A) | absent zero∉∀A = structural-choice zero∉∀A
+
+  imprecise-star-shape : ∀ {Δ} {μ : I.ImpEnv Δ} {A : Ty Δ}
+    → Shape A
+    → (∀ X → X ∈ᵗ A → μ X ≡ I.X⊑★)
+    → I._⊢_⊑_ μ A ★
+  imprecise-star-shape var-shape dynamic =
+    I.X⊑★ (dynamic _ var-∈)
+  imprecise-star-shape base-shape dynamic = I.ι⊑★
+  imprecise-star-shape star-shape dynamic = I.★⊑★
+  imprecise-star-shape (fun-shape shape-A shape-B) dynamic =
+    I.⇒⊑★ (imprecise-star-shape shape-A (dynamic-domain dynamic))
+      (imprecise-star-shape shape-B (dynamic-codomain dynamic))
+  imprecise-star-shape (all-shape {A = A} shape-A) dynamic =
+    decide (all-choice A)
+    where
+    decide : AllChoice A → I._⊢_⊑_ _ (`∀ A) ★
+    decide bottom-choice = I.bot⊑★
+    decide (inst-choice Anv zero∈A) =
+      I.∀⊑ Anv zero∈A
+        (imprecise-star-shape shape-A
+          (dynamic-under-inst dynamic))
+    decide (structural-choice zero∉A) =
+      I.∀⊑★
+        (imprecise-star-shape shape-A
+          (dynamic-under-ext dynamic zero∉A))
+
+imprecise-star : ∀ (A : Ty 0) → I._⊑_ A ★
+imprecise-star A = imprecise-star-shape (shape A) (\ ())

--- a/GTSFImp/proof/ImprecisionConsistency.agda
+++ b/GTSFImp/proof/ImprecisionConsistency.agda
@@ -225,6 +225,7 @@ target-occurs-source (I.X⊑★ eq) ()
 target-occurs-source (I.∀⊑ Anv z∈A p) X∈B =
   ∈-all (target-occurs-source p (shift-occurs X∈B))
 target-occurs-source I.∀★⊑★ ()
+target-occurs-source (I.∀⊑★ p) ()
 target-occurs-source I.bot-elim (∈-all ())
 target-occurs-source I.bot⊑★ ()
 
@@ -245,6 +246,7 @@ source-nonvar-from-target (I.X⊑★ eq) Anv ()
 source-nonvar-from-target (I.∀⊑ Anv z∈A p) Bnv z∈B =
   nonvar-all
 source-nonvar-from-target I.∀★⊑★ Anv ()
+source-nonvar-from-target (I.∀⊑★ p) Anv ()
 source-nonvar-from-target I.bot-elim Anv (∈-all ())
 source-nonvar-from-target I.bot⊑★ Anv ()
 
@@ -310,6 +312,14 @@ var-left-to-star h eq (I.∀⊑ Anv z∈A p) =
   I.∀⊑ Anv z∈A
     (var-left-to-star (instantiate-left-lower-env h) eq p)
 
+universal-right-to-star : ∀ {Δ} {μ : I.ImpEnv Δ} {D}
+  → I._⊢_⊑_ μ D (`∀ ★)
+  → I._⊢_⊑_ μ D ★
+universal-right-to-star (I.∀⊑∀ p) = I.∀⊑★ p
+universal-right-to-star (I.∀⊑ Anv z∈A p) =
+  I.∀⊑ Anv z∈A (universal-right-to-star p)
+universal-right-to-star I.bot-elim = I.bot⊑★
+
 ------------------------------------------------------------------------
 -- Consistency implies a common lower bound
 ------------------------------------------------------------------------
@@ -354,11 +364,12 @@ consistent-common-lowerᵐ h
     | D , D⊑A , D⊑G =
   D , D⊑A , var-right-to-star h eq D⊑G
 consistent-common-lowerᵐ h
-    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄) =
-  `∀ ★ , refl⊑ (`∀ ★) , I.∀★⊑★
+    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄)
+    with consistent-common-lowerᵐ h c
 consistent-common-lowerᵐ h
-    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-⊥ ⦄) =
-  `∀ (＇ zero) , refl⊑ (`∀ (＇ zero)) , I.bot⊑★
+    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄)
+    | D , D⊑A , D⊑G =
+  D , D⊑A , universal-right-to-star D⊑G
 consistent-common-lowerᵐ h
     (？_ ⦃ g-⇒ ⦄ c ⦃ Bns ⦄ ⦃ match-⇒ ⦄)
     with consistent-common-lowerᵐ h c
@@ -381,11 +392,12 @@ consistent-common-lowerᵐ h
     | D , D⊑G , D⊑B =
   D , var-left-to-star h eq D⊑G , D⊑B
 consistent-common-lowerᵐ h
-    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄) =
-  `∀ ★ , I.∀★⊑★ , refl⊑ (`∀ ★)
+    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄)
+    with consistent-common-lowerᵐ h c
 consistent-common-lowerᵐ h
-    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-⊥ ⦄) =
-  `∀ (＇ zero) , I.bot⊑★ , refl⊑ (`∀ (＇ zero))
+    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄)
+    | D , D⊑G , D⊑B =
+  D , universal-right-to-star D⊑G , D⊑B
 consistent-common-lowerᵐ h
     (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★)
     with consistent-common-lowerᵐ
@@ -449,6 +461,7 @@ source-nonvar-target (I.X⊑★ eq) ()
 source-nonvar-target (I.∀⊑ Anv z∈A p) nonvar-all =
   unshift-nonvar (source-nonvar-target p Anv)
 source-nonvar-target I.∀★⊑★ nonvar-all = nonvar-star
+source-nonvar-target (I.∀⊑★ p) nonvar-all = nonvar-star
 source-nonvar-target I.bot-elim nonvar-all = nonvar-all
 source-nonvar-target I.bot⊑★ nonvar-all = nonvar-star
 
@@ -487,6 +500,10 @@ source-occurs-target {X = X} focus (I.∀⊑ Anv z∈A p)
   unshift-occurs
     (source-occurs-target {X = suc X} focus p X∈A)
 source-occurs-target focus I.∀★⊑★ (∈-all ())
+source-occurs-target {X = X} focus (I.∀⊑★ p) (∈-all X∈A)
+    with source-occurs-target {X = suc X} focus p X∈A
+source-occurs-target {X = X} focus (I.∀⊑★ p) (∈-all X∈A)
+    | ()
 source-occurs-target focus I.bot-elim (∈-all ())
 source-occurs-target focus I.bot⊑★ (∈-all ())
 
@@ -573,6 +590,44 @@ avoid-under-all safe (suc X) eqL eqR with safe X eqL eqR
 avoid-under-all safe (suc X) eqL eqR
     | ∉-all X∉A , ∉-all X∉B = X∉A , X∉B
 
+avoid-under-all-star : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {A}
+  → AvoidBoth φ ψ (`∀ A) ★
+  → AvoidBoth (I.extᵐ φ) (I.extᵐ ψ) A ★
+avoid-under-all-star safe zero eqL eqR =
+  ⊥-elim (var-identity-not-star eqL)
+avoid-under-all-star safe (suc X) eqL eqR with safe X eqL eqR
+avoid-under-all-star safe (suc X) eqL eqR
+    | ∉-all X∉A , ∉-star = X∉A , ∉-star
+
+avoid-under-star-all : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {B}
+  → AvoidBoth φ ψ ★ (`∀ B)
+  → AvoidBoth (I.extᵐ φ) (I.extᵐ ψ) ★ B
+avoid-under-star-all safe zero eqL eqR =
+  ⊥-elim (var-identity-not-star eqL)
+avoid-under-star-all safe (suc X) eqL eqR with safe X eqL eqR
+avoid-under-star-all safe (suc X) eqL eqR
+    | ∉-star , ∉-all X∉B = ∉-star , X∉B
+
+avoid-under-inst-star-right : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {B}
+  → AvoidBoth φ ψ ★ B
+  → AvoidBoth (I.extᵐ φ) (I.instᵐ ψ) ★ (⇑ᵗ B)
+avoid-under-inst-star-right safe zero eqL eqR =
+  ⊥-elim (var-identity-not-star eqL)
+avoid-under-inst-star-right safe (suc X) eqL eqR
+    with safe X eqL eqR
+avoid-under-inst-star-right safe (suc X) eqL eqR
+    | ∉-star , X∉B = ∉-star , shift-not-occurs X∉B
+
+avoid-under-inst-star-left : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {A}
+  → AvoidBoth φ ψ A ★
+  → AvoidBoth (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ A) ★
+avoid-under-inst-star-left safe zero eqL eqR =
+  ⊥-elim (var-identity-not-star eqR)
+avoid-under-inst-star-left safe (suc X) eqL eqR
+    with safe X eqL eqR
+avoid-under-inst-star-left safe (suc X) eqL eqR
+    | X∉A , ∉-star = shift-not-occurs X∉A , ∉-star
+
 avoid-under-inst-right : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {A B}
   → AvoidBoth φ ψ (`∀ A) B
   → AvoidBoth (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ B)
@@ -625,12 +680,12 @@ star-to-universal-ground =
 bottom-to-star : ∀ {Δ} {μ : Env∼ Δ}
   → μ ⊢ (`∀ (＇ zero)) ∼ ★
 bottom-to-star =
-  _! ⦃ g-∀ ⦄ bot-elim ⦃ nonstar-∀ ⦄ ⦃ match-⊥ ⦄
+  _! ⦃ g-∀ ⦄ bot-elim ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
 
 star-to-bottom : ∀ {Δ} {μ : Env∼ Δ}
   → μ ⊢ ★ ∼ (`∀ (＇ zero))
 star-to-bottom =
-  ？_ ⦃ g-∀ ⦄ bot-intro ⦃ nonstar-∀ ⦄ ⦃ match-⊥ ⦄
+  ？_ ⦃ g-∀ ⦄ bot-intro ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
 
 factor-inst-star-lower : ∀ {Δ} {μ : Env∼ Δ}
     {A : Ty (Nat.suc Δ)}
@@ -650,9 +705,9 @@ factor-inst-star-lower
 factor-inst-star-lower
     (_! ⦃ g-X eq ⦄ c ⦃ Ans ⦄ ⦃ match-X ⦄) () z∈A
 factor-inst-star-lower
-    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄) Anv (∈-all ())
-factor-inst-star-lower
-    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-⊥ ⦄) Anv (∈-all ())
+    (_! ⦃ g-∀ ⦄ c ⦃ Ans ⦄ ⦃ match-∀ ⦄) Anv z∈A =
+  _! ⦃ g-∀ ⦄ (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c (λ ()))
+    ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
 factor-inst-star-lower
     (？_ ⦃ g ⦄ c ⦃ Bns ⦄ ⦃ match ⦄) Anv ()
 factor-inst-star-lower
@@ -679,9 +734,9 @@ factor-gen-star-lower
 factor-gen-star-lower
     (？_ ⦃ g-X eq ⦄ c ⦃ Bns ⦄ ⦃ match-X ⦄) () z∈B
 factor-gen-star-lower
-    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄) Bnv (∈-all ())
-factor-gen-star-lower
-    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-⊥ ⦄) Bnv (∈-all ())
+    (？_ ⦃ g-∀ ⦄ c ⦃ Bns ⦄ ⦃ match-∀ ⦄) Bnv z∈B =
+  ？_ ⦃ g-∀ ⦄ (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c (λ ()))
+    ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
 factor-gen-star-lower
     (gen_ ⦃ Bnv′ ⦄ ⦃ z∈B′ ⦄ c ★≢★) Bnv z∈B =
   ⊥-elim (★≢★ refl)
@@ -798,6 +853,18 @@ lower-bounds-consistentᵐ h safe
     (I.∀⊑∀ p) (I.∀⊑∀ q) =
   ∀ᶜ (lower-bounds-consistentᵐ (extend-lower-env h)
     (avoid-under-all safe) p q)
+lower-bounds-consistentᵐ h safe
+    (I.∀⊑∀ p) (I.∀⊑★ q) =
+  _! ⦃ g-∀ ⦄
+    (∀ᶜ (lower-bounds-consistentᵐ (extend-lower-env h)
+      (avoid-under-all-star safe) p q))
+    ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
+lower-bounds-consistentᵐ h safe
+    (I.∀⊑★ p) (I.∀⊑∀ q) =
+  ？_ ⦃ g-∀ ⦄
+    (∀ᶜ (lower-bounds-consistentᵐ (extend-lower-env h)
+      (avoid-under-star-all safe) p q))
+    ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
 lower-bounds-consistentᵐ {B = B} h safe
     (I.∀⊑∀ p) (I.∀⊑ Dnv z∈D q) with B ≟Ty ★
 lower-bounds-consistentᵐ {B = B} h safe
@@ -832,6 +899,18 @@ lower-bounds-consistentᵐ {A = .★} h safe
       (avoid-under-inst-left safe) p q)
     (source-nonvar-target q Dnv)
     (source-occurs-target refl q z∈D)
+lower-bounds-consistentᵐ h safe
+    (I.∀⊑ Anv z∈D p) (I.∀⊑★ q) =
+  close-genᶜ
+    (lower-bounds-consistentᵐ
+      (instantiate-left-lower-env h)
+      (avoid-under-inst-star-left safe) p q)
+lower-bounds-consistentᵐ h safe
+    (I.∀⊑★ p) (I.∀⊑ Bnv z∈D q) =
+  close-instᶜ
+    (lower-bounds-consistentᵐ
+      (instantiate-right-lower-env h)
+      (avoid-under-inst-star-right safe) p q)
 lower-bounds-consistentᵐ {A = A} {B = B} h safe
     (I.∀⊑ Anv z∈A p) (I.∀⊑ Bnv z∈B q) =
   close-shifted-consistency
@@ -842,6 +921,12 @@ lower-bounds-consistentᵐ h safe
     (I.∀⊑∀ I.★⊑★) I.∀★⊑★ = universal-ground-to-star
 lower-bounds-consistentᵐ h safe
     I.∀★⊑★ (I.∀⊑∀ I.★⊑★) = star-to-universal-ground
+lower-bounds-consistentᵐ h safe
+    I.∀★⊑★ (I.∀⊑★ q) = id ★
+lower-bounds-consistentᵐ h safe
+    (I.∀⊑★ p) I.∀★⊑★ = id ★
+lower-bounds-consistentᵐ h safe
+    (I.∀⊑★ p) (I.∀⊑★ q) = id ★
 lower-bounds-consistentᵐ h safe I.∀★⊑★ I.∀★⊑★ = id ★
 lower-bounds-consistentᵐ h safe
     (I.∀⊑∀ I.X⊑X) I.bot-elim = bot-elim
@@ -851,12 +936,24 @@ lower-bounds-consistentᵐ h safe
     I.bot-elim (I.∀⊑∀ I.X⊑X) = bot-intro
 lower-bounds-consistentᵐ h safe I.bot-elim I.bot-elim =
   refl∼ (`∀ ★)
+lower-bounds-consistentᵐ h safe I.bot-elim (I.∀⊑★ q)
+    with source-occurs-target refl q var-∈
+lower-bounds-consistentᵐ h safe I.bot-elim (I.∀⊑★ q) | ()
 lower-bounds-consistentᵐ h safe I.bot-elim I.bot⊑★ =
   universal-ground-to-star
 lower-bounds-consistentᵐ h safe
     I.bot⊑★ (I.∀⊑∀ I.X⊑X) = star-to-bottom
 lower-bounds-consistentᵐ h safe I.bot⊑★ I.bot-elim =
   star-to-universal-ground
+lower-bounds-consistentᵐ h safe I.bot⊑★ (I.∀⊑★ q)
+    with source-occurs-target refl q var-∈
+lower-bounds-consistentᵐ h safe I.bot⊑★ (I.∀⊑★ q) | ()
+lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot-elim
+    with source-occurs-target refl p var-∈
+lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot-elim | ()
+lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot⊑★
+    with source-occurs-target refl p var-∈
+lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot⊑★ | ()
 lower-bounds-consistentᵐ h safe I.bot⊑★ I.bot⊑★ = id ★
 
 common-lower-consistent : ∀ {Δ} {A B : Ty Δ}

--- a/GTSFImp/proof/TypeSafety/Progress.agda
+++ b/GTSFImp/proof/TypeSafety/Progress.agda
@@ -357,6 +357,9 @@ data ToGround {Δ : TyCtx} {μ : Env∼ Δ} {G : Ty Δ}
   other : ∀ {A : Ty Δ} {c : μ ⊢ A ∼ G}
     → A ≢ G → ToGround g c
 
+occurs-star-impossible : ∀ {Δ} {X : TyVar Δ} → X ∈ᵗ ★ → ⊥
+occurs-star-impossible ()
+
 to-ground : ∀ {Δ} {μ : Env∼ Δ} {A G : Ty Δ}
   → (g : Groundʳ μ X∼★ G)
   → GroundMatch g A
@@ -382,17 +385,16 @@ to-ground g-⇒ match-⇒ (c ↦ d)
 to-ground g-⇒ match-⇒
     (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) = other (λ ())
 to-ground (g-X eq) match-X (id (＇ X)) = same
-to-ground g-∀ match-∀ (∀ᶜ (id ★)) = same
-to-ground g-∀ match-⊥ (∀ᶜ (_! ⦃ g-⇒ ⦄ ()))
-to-ground g-∀ match-⊥ (∀ᶜ (_! ⦃ g-ι ⦄ ()))
-to-ground g-∀ match-⊥
-    (∀ᶜ (_! ⦃ g-X {X = Fin.zero} () ⦄ c))
-to-ground g-∀ match-⊥ (∀ᶜ (_! ⦃ g-∀ ⦄ c ⦃ match = () ⦄))
+to-ground g-∀ match-∀ (∀ᶜ c) with to-star c
+to-ground g-∀ match-∀ (∀ᶜ (id ★)) | same = same
+to-ground g-∀ match-∀ (∀ᶜ c) | other A≠★ =
+  other (λ { refl → A≠★ refl })
 to-ground g-∀ match-∀
     (gen_ ⦃ Bnv ⦄ ⦃ () ⦄ c A≢★)
-to-ground g-∀ match-⊥
-    (gen_ ⦃ Bnv ⦄ ⦃ () ⦄ c A≢★)
-to-ground g-∀ match-⊥ bot-elim = other (λ ())
+to-ground g-∀ match-∀
+    (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) =
+  other (λ { refl → occurs-star-impossible z∈A })
+to-ground g-∀ match-∀ bot-elim = other (λ ())
 
 data FromGround {Δ : TyCtx} {μ : Env∼ Δ} {G : Ty Δ}
     (g : Groundʳ μ ★∼X G) :
@@ -426,17 +428,16 @@ from-ground g-⇒ match-⇒ (c ↦ d)
 from-ground g-⇒ match-⇒
     (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) = other (λ ())
 from-ground (g-X eq) match-X (id (＇ X)) = same
-from-ground g-∀ match-∀ (∀ᶜ (id ★)) = same
-from-ground g-∀ match-⊥ (∀ᶜ (？_ ⦃ g-⇒ ⦄ ()))
-from-ground g-∀ match-⊥ (∀ᶜ (？_ ⦃ g-ι ⦄ ()))
-from-ground g-∀ match-⊥
-    (∀ᶜ (？_ ⦃ g-X {X = Fin.zero} () ⦄ c))
-from-ground g-∀ match-⊥ (∀ᶜ (？_ ⦃ g-∀ ⦄ c ⦃ match = () ⦄))
+from-ground g-∀ match-∀ (∀ᶜ c) with from-star c
+from-ground g-∀ match-∀ (∀ᶜ (id ★)) | same = same
+from-ground g-∀ match-∀ (∀ᶜ c) | other B≠★ =
+  other (λ { refl → B≠★ refl })
 from-ground g-∀ match-∀
     (inst_ ⦃ Anv ⦄ ⦃ () ⦄ c B≢★)
-from-ground g-∀ match-⊥
-    (inst_ ⦃ Anv ⦄ ⦃ () ⦄ c B≢★)
-from-ground g-∀ match-⊥ bot-intro = other (λ ())
+from-ground g-∀ match-∀
+    (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) =
+  other (λ { refl → occurs-star-impossible z∈B })
+from-ground g-∀ match-∀ bot-intro = other (λ ())
 
 ------------------------------------------------------------------------
 -- Polymorphic cast classification


### PR DESCRIPTION
## Summary

- generalize universal ground matching and type imprecision, and prove every closed type is consistent with and less precise than `★`
- port gradual terms, gradual-term imprecision, and compilation from GTSF to GTSFImp
- define cast-term imprecision indexed by exact type imprecision, a two-store relational world, and source/target typing projections
- add heterogeneous cast-term imprecision across distinct type contexts, with injective renaming overlap determining `both`, `left-only`, and `right-only` store categories
- prove that compilation preserves gradual-term imprecision

## Validation

- `agda --no-allow-unsolved-metas -v0 All.agda` from `GTSFImp/`