### PR TITLE
Prove GTSFImp imprecision uniqueness

### DIFF
--- a/GTSFImp/Consistency.agda
+++ b/GTSFImp/Consistency.agda
@@ -78,18 +78,6 @@ groundMatch-unique match-ι match-ι = refl
 groundMatch-unique match-X match-X = refl
 groundMatch-unique match-∀ match-∀ = refl
 
-data NonStar {Δ : TyCtx} : Ty Δ → Set where
-  nonstar-X : ∀ {X} → NonStar (＇ X)
-  nonstar-ι : ∀ {ι} → NonStar (‵ ι)
-  nonstar-⇒ : ∀ {A B} → NonStar (A ⇒ B)
-  nonstar-∀ : ∀ {A} → NonStar (`∀ A)
-
-nonStar≢★ : ∀ {Δ} {A : Ty Δ} → NonStar A → A ≢ ★
-nonStar≢★ nonstar-X = λ ()
-nonStar≢★ nonstar-ι = λ ()
-nonStar≢★ nonstar-⇒ = λ ()
-nonStar≢★ nonstar-∀ = λ ()
-
 instance
   refl-instance : ∀ {A : Set} {x : A} → x ≡ x
   refl-instance = refl
@@ -125,18 +113,6 @@ instance
   match-∀-instance : ∀ {Δ μ r A}
     → GroundMatch (g-∀ {Δ = Δ} {μ = μ} {r = r}) (`∀ A)
   match-∀-instance = match-∀
-
-  nonstar-X-instance : ∀ {Δ} {X : TyVar Δ} → NonStar (＇ X)
-  nonstar-X-instance = nonstar-X
-
-  nonstar-ι-instance : ∀ {Δ ι} → NonStar (‵_ {Δ} ι)
-  nonstar-ι-instance = nonstar-ι
-
-  nonstar-⇒-instance : ∀ {Δ} {A B : Ty Δ} → NonStar (A ⇒ B)
-  nonstar-⇒-instance = nonstar-⇒
-
-  nonstar-∀-instance : ∀ {Δ} {A : Ty (suc Δ)} → NonStar (`∀ A)
-  nonstar-∀-instance = nonstar-∀
 
 infix 4 _⊢_∼_
 infixr 7 _↦_
@@ -229,12 +205,6 @@ ground-nonstar g-⇒ = nonstar-⇒
 ground-nonstar g-ι = nonstar-ι
 ground-nonstar (g-X eq) = nonstar-X
 ground-nonstar g-∀ = nonstar-∀
-
-nonStar-unique : ∀ {Δ} {A : Ty Δ} (p q : NonStar A) → p ≡ q
-nonStar-unique nonstar-X nonstar-X = refl
-nonStar-unique nonstar-ι nonstar-ι = refl
-nonStar-unique nonstar-⇒ nonstar-⇒ = refl
-nonStar-unique nonstar-∀ nonstar-∀ = refl
 
 renameNonStar : ∀ {Δ Δ′} {A : Ty Δ}
   → (ρ : Δ ⇒ʳ Δ′)

--- a/GTSFImp/Imprecision.agda
+++ b/GTSFImp/Imprecision.agda
@@ -93,6 +93,7 @@ data _⊢_⊑_ {Δ : TyCtx} (μ : ImpEnv Δ) : Ty Δ → Ty Δ → Set where
     μ ⊢ (`∀ ★) ⊑ ★
 
   ∀⊑★ : ∀ {A}
+    → NonStar A
     → extᵐ μ ⊢ A ⊑ ★
       -----------------
     → μ ⊢ (`∀ A) ⊑ ★

--- a/GTSFImp/Types.agda
+++ b/GTSFImp/Types.agda
@@ -85,6 +85,41 @@ instance
   nonVar-all-instance = nonvar-all
 
 ------------------------------------------------------------------------
+-- Non-dynamic types
+------------------------------------------------------------------------
+
+data NonStar {Δ : TyCtx} : Ty Δ → Set where
+  nonstar-X : ∀ {X} → NonStar (＇ X)
+  nonstar-ι : ∀ {ι} → NonStar (‵ ι)
+  nonstar-⇒ : ∀ {A B} → NonStar (A ⇒ B)
+  nonstar-∀ : ∀ {A} → NonStar (`∀ A)
+
+nonStar≢★ : ∀ {Δ} {A : Ty Δ} → NonStar A → A ≢ ★
+nonStar≢★ nonstar-X = λ ()
+nonStar≢★ nonstar-ι = λ ()
+nonStar≢★ nonstar-⇒ = λ ()
+nonStar≢★ nonstar-∀ = λ ()
+
+nonStar-unique : ∀ {Δ} {A : Ty Δ} (p q : NonStar A) → p ≡ q
+nonStar-unique nonstar-X nonstar-X = refl
+nonStar-unique nonstar-ι nonstar-ι = refl
+nonStar-unique nonstar-⇒ nonstar-⇒ = refl
+nonStar-unique nonstar-∀ nonstar-∀ = refl
+
+instance
+  nonstar-X-instance : ∀ {Δ} {X : TyVar Δ} → NonStar (＇ X)
+  nonstar-X-instance = nonstar-X
+
+  nonstar-ι-instance : ∀ {Δ ι} → NonStar (‵_ {Δ} ι)
+  nonstar-ι-instance = nonstar-ι
+
+  nonstar-⇒-instance : ∀ {Δ} {A B : Ty Δ} → NonStar (A ⇒ B)
+  nonstar-⇒-instance = nonstar-⇒
+
+  nonstar-∀-instance : ∀ {Δ} {A : Ty (suc Δ)} → NonStar (`∀ A)
+  nonstar-∀-instance = nonstar-∀
+
+------------------------------------------------------------------------
 -- _∈ᵗ_, _∉ᵗ_, Tag, Non∀, Atom
 ------------------------------------------------------------------------
 

--- a/GTSFImp/proof/Imprecision.agda
+++ b/GTSFImp/proof/Imprecision.agda
@@ -4,17 +4,27 @@ module proof.Imprecision where
 --   * Proves that every closed type is less precise than the dynamic type.
 --   * Uses occurrence information to choose between structural universal
 --     imprecision and instantiation at the dynamic type.
+--   * Proves uniqueness for occurrence and type-imprecision evidence.
 --   * Depends only on Types and Imprecision.
 
+open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Fin using (zero; suc)
 import Data.Nat as Nat
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Level using (0ℓ)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; cong; cong₂; sym; trans)
 
 open import Types
 import Imprecision as I
 
 private
+
+  postulate
+    funext : Extensionality 0ℓ 0ℓ
+
+  ¬-unique : ∀ {A : Set} (p q : A → ⊥) → p ≡ q
+  ¬-unique p q = funext (λ x → ⊥-elim (p x))
 
   not-occurs : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
     → X ∉ᵗ A
@@ -28,6 +38,389 @@ private
   not-occurs (∉-fun X∉A X∉B) (∈-fun-right X∉A′ X∈B) =
     not-occurs X∉B X∈B
   not-occurs (∉-all X∉A) (∈-all X∈A) = not-occurs X∉A X∈A
+
+  varImp-disjoint : ∀ {v : I.VarImp}
+    → v ≡ I.X⊑X
+    → v ≡ I.X⊑★
+    → ⊥
+  varImp-disjoint refl ()
+
+  occurs-not-star : ∀ {Δ} {μ : I.ImpEnv Δ} {X : TyVar Δ} {A : Ty Δ}
+    → μ X ≡ I.X⊑X
+    → X ∈ᵗ A
+    → I._⊢_⊑_ μ A ★
+    → ⊥
+  occurs-not-star same () I.★⊑★
+  occurs-not-star same () I.ι⊑★
+  occurs-not-star same var-∈ (I.X⊑★ to-star) =
+    varImp-disjoint same to-star
+  occurs-not-star same (∈-fun-left X∈A) (I.⇒⊑★ A⊑★ B⊑★) =
+    occurs-not-star same X∈A A⊑★
+  occurs-not-star same (∈-fun-right X∉A X∈B) (I.⇒⊑★ A⊑★ B⊑★) =
+    occurs-not-star same X∈B B⊑★
+  occurs-not-star same (∈-all X∈A) (I.∀⊑ Anv zero∈A A⊑★) =
+    occurs-not-star same X∈A A⊑★
+  occurs-not-star same (∈-all ()) I.∀★⊑★
+  occurs-not-star same (∈-all X∈A) (I.∀⊑★ Ans A⊑★) =
+    occurs-not-star same X∈A A⊑★
+  occurs-not-star same (∈-all ()) I.bot⊑★
+
+  insertʳ : ∀ {Δ} → TyVar (Nat.suc Δ) → Δ ⇒ʳ Nat.suc Δ
+  insertʳ zero Y = suc Y
+  insertʳ {Nat.suc Δ} (suc X) zero = zero
+  insertʳ {Nat.suc Δ} (suc X) (suc Y) = suc (insertʳ X Y)
+
+  insertʳ-ext : ∀ {Δ} (X : TyVar (Nat.suc Δ))
+    → ∀ Y → extᵗ (insertʳ X) Y ≡ insertʳ (suc X) Y
+  insertʳ-ext X zero = refl
+  insertʳ-ext X (suc Y) = refl
+
+  renameᵗ-id′ : ∀ {Δ} (A : Ty Δ) → renameᵗ (λ X → X) A ≡ A
+  renameᵗ-id′ (＇ X) = refl
+  renameᵗ-id′ (‵ ι) = refl
+  renameᵗ-id′ ★ = refl
+  renameᵗ-id′ (A ⇒ B)
+      rewrite renameᵗ-id′ A | renameᵗ-id′ B =
+    refl
+  renameᵗ-id′ (`∀ A) =
+    cong `∀ (trans (renameᵗ-cong A ext-id) (renameᵗ-id′ A))
+    where
+    ext-id : ∀ X → extᵗ (λ Y → Y) X ≡ X
+    ext-id zero = refl
+    ext-id (suc X) = refl
+
+  suc-injectiveᶠ : ∀ {Δ} {X Y : TyVar Δ}
+    → suc X ≡ suc Y
+    → X ≡ Y
+  suc-injectiveᶠ refl = refl
+
+  ext-injective : ∀ {Δ Δ′} {ρ : Δ ⇒ʳ Δ′} {X Y}
+    → (∀ {Z W} → ρ Z ≡ ρ W → Z ≡ W)
+    → extᵗ ρ X ≡ extᵗ ρ Y
+    → X ≡ Y
+  ext-injective {X = zero} {Y = zero} inj eq = refl
+  ext-injective {X = zero} {Y = suc Y} inj ()
+  ext-injective {X = suc X} {Y = zero} inj ()
+  ext-injective {X = suc X} {Y = suc Y} inj eq =
+    cong suc (inj (suc-injectiveᶠ eq))
+
+  rename-fresh : ∀ {Δ Δ′} {ρ : Δ ⇒ʳ Δ′} {X : TyVar Δ}
+      {A : Ty Δ}
+    → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+    → X ∉ᵗ A
+    → ρ X ∉ᵗ renameᵗ ρ A
+  rename-fresh inj (∉-var X≢Y) =
+    ∉-var (λ eq → X≢Y (inj eq))
+  rename-fresh inj ∉-base = ∉-base
+  rename-fresh inj ∉-star = ∉-star
+  rename-fresh inj (∉-fun X∉A X∉B) =
+    ∉-fun (rename-fresh inj X∉A) (rename-fresh inj X∉B)
+  rename-fresh inj (∉-all X∉A) =
+    ∉-all (rename-fresh (ext-injective inj) X∉A)
+
+  shift-fresh : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+    → X ∉ᵗ A
+    → suc X ∉ᵗ ⇑ᵗ A
+  shift-fresh = rename-fresh suc-injectiveᶠ
+
+  insertʳ-fresh-var : ∀ {Δ} (X : TyVar (Nat.suc Δ))
+    → ∀ Y → X ≢ insertʳ X Y
+  insertʳ-fresh-var zero Y ()
+  insertʳ-fresh-var {Nat.suc Δ} (suc X) zero ()
+  insertʳ-fresh-var {Nat.suc Δ} (suc X) (suc Y) eq =
+    insertʳ-fresh-var X Y (suc-injectiveᶠ eq)
+
+  insert-fresh : ∀ {Δ} (X : TyVar (Nat.suc Δ))
+    → ∀ (A : Ty Δ) → X ∉ᵗ renameᵗ (insertʳ X) A
+  insert-fresh X (＇ Y) = ∉-var (insertʳ-fresh-var X Y)
+  insert-fresh X (‵ ι) = ∉-base
+  insert-fresh X ★ = ∉-star
+  insert-fresh X (A ⇒ B) =
+    ∉-fun (insert-fresh X A) (insert-fresh X B)
+  insert-fresh X (`∀ A)
+      rewrite renameᵗ-cong A (insertʳ-ext X) =
+    ∉-all (insert-fresh (suc X) A)
+
+  data WidenPath : ∀ {Δ} → TyVar Δ → Ty Δ → Ty Δ → Set where
+    wp-var : ∀ {Δ} {X : TyVar Δ}
+      → WidenPath X (＇ X) (＇ X)
+
+    wp-fun-left : ∀ {Δ X A A′ B B′}
+      → WidenPath {Δ} X A A′
+      → WidenPath X (A ⇒ B) (A′ ⇒ B′)
+
+    wp-fun-right : ∀ {Δ X A A′ B B′}
+      → WidenPath {Δ} X B B′
+      → WidenPath X (A ⇒ B) (A′ ⇒ B′)
+
+    wp-all : ∀ {Δ X A B}
+      → WidenPath {Nat.suc Δ} (suc X) A B
+      → WidenPath {Δ} X (`∀ A) (`∀ B)
+
+    wp-inst : ∀ {Δ X A B}
+      → WidenPath {Nat.suc Δ} (suc X) A (⇑ᵗ B)
+      → WidenPath {Δ} X (`∀ A) B
+
+  source-path-same : ∀ {Δ} {μ : I.ImpEnv Δ} {X : TyVar Δ}
+      {A B : Ty Δ}
+    → μ X ≡ I.X⊑X
+    → I._⊢_⊑_ μ A B
+    → X ∈ᵗ A
+    → WidenPath X A B
+  source-path-same same I.★⊑★ ()
+  source-path-same same I.ι⊑ι ()
+  source-path-same same I.X⊑X var-∈ = wp-var
+  source-path-same same (I.⇒⊑⇒ A⊑A′ B⊑B′)
+      (∈-fun-left X∈A) =
+    wp-fun-left (source-path-same same A⊑A′ X∈A)
+  source-path-same same (I.⇒⊑⇒ A⊑A′ B⊑B′)
+      (∈-fun-right X∉A X∈B) =
+    wp-fun-right (source-path-same same B⊑B′ X∈B)
+  source-path-same same (I.∀⊑∀ A⊑B) (∈-all X∈A) =
+    wp-all (source-path-same same A⊑B X∈A)
+  source-path-same same p@(I.⇒⊑★ A⊑★ B⊑★) X∈A =
+    ⊥-elim (occurs-not-star same X∈A p)
+  source-path-same same I.ι⊑★ ()
+  source-path-same same (I.X⊑★ x⊑★) var-∈ =
+    ⊥-elim (varImp-disjoint same x⊑★)
+  source-path-same same (I.∀⊑ Anv zero∈A A⊑B) (∈-all X∈A) =
+    wp-inst (source-path-same same A⊑B X∈A)
+  source-path-same same I.∀★⊑★ (∈-all ())
+  source-path-same same (I.∀⊑★ Ans A⊑★) (∈-all X∈A) =
+    ⊥-elim (occurs-not-star same X∈A A⊑★)
+  source-path-same same I.bot-elim (∈-all ())
+  source-path-same same I.bot⊑★ (∈-all ())
+
+  data EndpointSpine : ∀ {Δᴸ Δᴿ} → Ty Δᴸ → Ty Δᴿ → Set where
+    spine-renamed : ∀ {Δ₀ Δᴸ Δᴿ} {L : Ty Δᴸ} {R : Ty Δᴿ}
+        {T : Ty Δ₀} {ρ : Δ₀ ⇒ʳ Δᴸ} {τ : Δ₀ ⇒ʳ Δᴿ}
+      → L ≡ renameᵗ ρ T
+      → R ≡ renameᵗ τ T
+      → EndpointSpine L R
+
+    spine-left-all : ∀ {Δᴸ Δᴿ} {L : Ty (Nat.suc Δᴸ)} {R : Ty Δᴿ}
+      → EndpointSpine L R
+      → EndpointSpine (`∀ L) R
+
+    spine-right-all : ∀ {Δᴸ Δᴿ} {L : Ty Δᴸ} {R : Ty (Nat.suc Δᴿ)}
+      → EndpointSpine L R
+      → EndpointSpine L (`∀ R)
+
+  spine-map-left : ∀ {Δᴸ Δᴸ′ Δᴿ}
+      (ρ : Δᴸ ⇒ʳ Δᴸ′) {L : Ty Δᴸ} {R : Ty Δᴿ}
+    → EndpointSpine L R
+    → EndpointSpine (renameᵗ ρ L) R
+  spine-map-left ρ
+      (spine-renamed {T = T} {ρ = σ} {τ = τ} refl refl) =
+    spine-renamed
+      (renameᵗ-comp σ ρ T)
+      refl
+  spine-map-left ρ (spine-left-all sp) =
+    spine-left-all (spine-map-left (extᵗ ρ) sp)
+  spine-map-left ρ (spine-right-all sp) =
+    spine-right-all (spine-map-left ρ sp)
+
+  spine-map-right : ∀ {Δᴸ Δᴿ Δᴿ′}
+      (ρ : Δᴿ ⇒ʳ Δᴿ′) {L : Ty Δᴸ} {R : Ty Δᴿ}
+    → EndpointSpine L R
+    → EndpointSpine L (renameᵗ ρ R)
+  spine-map-right ρ
+      (spine-renamed {T = T} {ρ = σ} {τ = τ} refl refl) =
+    spine-renamed
+      refl
+      (renameᵗ-comp τ ρ T)
+  spine-map-right ρ (spine-left-all sp) =
+    spine-left-all (spine-map-right ρ sp)
+  spine-map-right ρ (spine-right-all sp) =
+    spine-right-all (spine-map-right (extᵗ ρ) sp)
+
+  spine-peel-right : ∀ {Δᴸ Δᴸ′ Δᴿ}
+      (ρ : Δᴸ ⇒ʳ Δᴸ′) {L : Ty Δᴸ} {R : Ty (Nat.suc Δᴿ)}
+    → EndpointSpine L (`∀ R)
+    → EndpointSpine (renameᵗ ρ L) R
+  spine-peel-right ρ (spine-renamed {T = ＇ β} eqL ())
+  spine-peel-right ρ (spine-renamed {T = ‵ ι} eqL ())
+  spine-peel-right ρ (spine-renamed {T = ★} eqL ())
+  spine-peel-right ρ (spine-renamed {T = T₁ ⇒ T₂} eqL ())
+  spine-peel-right ρ
+      (spine-renamed {T = `∀ T} {ρ = σ} {τ = τ} refl refl) =
+    spine-left-all
+      (spine-renamed
+        (renameᵗ-comp (extᵗ σ) (extᵗ ρ) T)
+        refl)
+  spine-peel-right ρ (spine-left-all sp) =
+    spine-left-all (spine-peel-right (extᵗ ρ) sp)
+  spine-peel-right ρ (spine-right-all sp) =
+    spine-map-left ρ sp
+
+  spine-peel-left : ∀ {Δᴸ Δᴿ Δᴿ′}
+      (ρ : Δᴿ ⇒ʳ Δᴿ′) {L : Ty (Nat.suc Δᴸ)} {R : Ty Δᴿ}
+    → EndpointSpine (`∀ L) R
+    → EndpointSpine L (renameᵗ ρ R)
+  spine-peel-left ρ (spine-renamed {T = ＇ β} () eqR)
+  spine-peel-left ρ (spine-renamed {T = ‵ ι} () eqR)
+  spine-peel-left ρ (spine-renamed {T = ★} () eqR)
+  spine-peel-left ρ (spine-renamed {T = T₁ ⇒ T₂} () eqR)
+  spine-peel-left ρ
+      (spine-renamed {T = `∀ T} {ρ = σ} {τ = τ} refl refl) =
+    spine-right-all
+      (spine-renamed
+        refl
+        (renameᵗ-comp (extᵗ τ) (extᵗ ρ) T))
+  spine-peel-left ρ (spine-left-all sp) =
+    spine-map-right ρ sp
+  spine-peel-left ρ (spine-right-all sp) =
+    spine-right-all (spine-peel-left (extᵗ ρ) sp)
+
+  spine-peel-right-id : ∀ {Δᴸ Δᴿ} {L : Ty Δᴸ}
+      {R : Ty (Nat.suc Δᴿ)}
+    → EndpointSpine L (`∀ R)
+    → EndpointSpine L R
+  spine-peel-right-id (spine-renamed {T = ＇ β} eqL ())
+  spine-peel-right-id (spine-renamed {T = ‵ ι} eqL ())
+  spine-peel-right-id (spine-renamed {T = ★} eqL ())
+  spine-peel-right-id (spine-renamed {T = T₁ ⇒ T₂} eqL ())
+  spine-peel-right-id
+      (spine-renamed {T = `∀ T} {ρ = ρ} {τ = τ} refl refl) =
+    spine-left-all (spine-renamed refl refl)
+  spine-peel-right-id (spine-left-all sp) =
+    spine-left-all (spine-peel-right-id sp)
+  spine-peel-right-id (spine-right-all sp) = sp
+
+  spine-peel-left-id : ∀ {Δᴸ Δᴿ} {L : Ty (Nat.suc Δᴸ)}
+      {R : Ty Δᴿ}
+    → EndpointSpine (`∀ L) R
+    → EndpointSpine L R
+  spine-peel-left-id (spine-renamed {T = ＇ β} () eqR)
+  spine-peel-left-id (spine-renamed {T = ‵ ι} () eqR)
+  spine-peel-left-id (spine-renamed {T = ★} () eqR)
+  spine-peel-left-id (spine-renamed {T = T₁ ⇒ T₂} () eqR)
+  spine-peel-left-id
+      (spine-renamed {T = `∀ T} {ρ = ρ} {τ = τ} refl refl) =
+    spine-right-all (spine-renamed refl refl)
+  spine-peel-left-id (spine-left-all sp) = sp
+  spine-peel-left-id (spine-right-all sp) =
+    spine-right-all (spine-peel-left-id sp)
+
+  spine-strip-both : ∀ {Δᴸ Δᴿ} {L : Ty (Nat.suc Δᴸ)}
+      {R : Ty (Nat.suc Δᴿ)}
+    → EndpointSpine (`∀ L) (`∀ R)
+    → EndpointSpine L R
+  spine-strip-both (spine-renamed {T = ＇ β} () eqR)
+  spine-strip-both (spine-renamed {T = ‵ ι} () eqR)
+  spine-strip-both (spine-renamed {T = ★} () eqR)
+  spine-strip-both (spine-renamed {T = T₁ ⇒ T₂} () eqR)
+  spine-strip-both
+      (spine-renamed {T = `∀ T} {ρ = ρ} {τ = τ} refl refl) =
+    spine-renamed refl refl
+  spine-strip-both (spine-left-all sp) = spine-peel-right-id sp
+  spine-strip-both (spine-right-all sp) = spine-peel-left-id sp
+
+  insert-spine : ∀ {Δ} (X : TyVar (Nat.suc Δ))
+      {B : Ty (Nat.suc Δ)}
+    → EndpointSpine B (renameᵗ (insertʳ X) (`∀ B))
+  insert-spine X {B = B} =
+    spine-right-all
+      (spine-renamed {T = B} {ρ = λ Y → Y} {τ = extᵗ (insertʳ X)}
+        (sym (renameᵗ-id′ B)) refl)
+
+  widen-path-star-spine⊥ : ∀ {Δ Δ★} {X : TyVar Δ}
+      {A B : Ty Δ}
+    → WidenPath X A B
+    → EndpointSpine B (★ {Δ★})
+    → ⊥
+  widen-path-star-spine⊥ wp-var
+      (spine-renamed {T = ＇ β} refl ())
+  widen-path-star-spine⊥ (wp-fun-left p)
+      (spine-renamed {T = T₁ ⇒ T₂} refl ())
+  widen-path-star-spine⊥ (wp-fun-right p)
+      (spine-renamed {T = T₁ ⇒ T₂} refl ())
+  widen-path-star-spine⊥ (wp-all p) (spine-left-all sp) =
+    widen-path-star-spine⊥ p sp
+  widen-path-star-spine⊥ (wp-all p)
+      (spine-renamed {T = `∀ T} refl ())
+  widen-path-star-spine⊥ (wp-inst p) sp =
+    widen-path-star-spine⊥ p (spine-map-left suc sp)
+
+  widen-spine-overlap⊥ : ∀ {Δ}
+      {ν : I.ImpEnv Δ} {X : TyVar Δ}
+      {A B C : Ty Δ}
+    → ν X ≡ I.X⊑★
+    → WidenPath X A B
+    → EndpointSpine B C
+    → X ∉ᵗ C
+    → I._⊢_⊑_ ν A C
+    → ⊥
+  widen-spine-overlap⊥ to-star wp-var sp fresh I.X⊑X =
+    not-occurs fresh var-∈
+  widen-spine-overlap⊥ to-star wp-var sp fresh (I.X⊑★ x⊑★) =
+    widen-path-star-spine⊥ wp-var sp
+  widen-spine-overlap⊥ to-star (wp-fun-left p)
+      (spine-renamed {T = T₁ ⇒ T₂} refl refl)
+      (∉-fun fresh₁ fresh₂) (I.⇒⊑⇒ q₁ q₂) =
+    widen-spine-overlap⊥ to-star p (spine-renamed refl refl) fresh₁ q₁
+  widen-spine-overlap⊥ to-star (wp-fun-right p)
+      (spine-renamed {T = T₁ ⇒ T₂} refl refl)
+      (∉-fun fresh₁ fresh₂) (I.⇒⊑⇒ q₁ q₂) =
+    widen-spine-overlap⊥ to-star p (spine-renamed refl refl) fresh₂ q₂
+  widen-spine-overlap⊥ {Δ = Δ} to-star path@(wp-fun-left p) sp fresh
+      (I.⇒⊑★ q₁ q₂) =
+    widen-path-star-spine⊥ {Δ = Δ} {Δ★ = Δ} path sp
+  widen-spine-overlap⊥ {Δ = Δ} to-star path@(wp-fun-right p) sp fresh
+      (I.⇒⊑★ q₁ q₂) =
+    widen-path-star-spine⊥ {Δ = Δ} {Δ★ = Δ} path sp
+  widen-spine-overlap⊥ to-star (wp-all p) sp (∉-all fresh)
+      (I.∀⊑∀ q) =
+    widen-spine-overlap⊥ to-star p (spine-strip-both sp) fresh q
+  widen-spine-overlap⊥ to-star (wp-all p) sp fresh
+      (I.∀⊑ Anv zero∈A q) =
+    widen-spine-overlap⊥ to-star p (spine-peel-left suc sp)
+      (shift-fresh fresh) q
+  widen-spine-overlap⊥ to-star (wp-all p) sp fresh I.∀★⊑★ =
+    widen-path-star-spine⊥ (wp-all p) sp
+  widen-spine-overlap⊥ to-star (wp-all p) sp fresh
+      (I.∀⊑★ Ans q) =
+    widen-path-star-spine⊥ (wp-all p) sp
+  widen-spine-overlap⊥ to-star (wp-all ()) sp fresh I.bot-elim
+  widen-spine-overlap⊥ to-star (wp-all p) sp fresh I.bot⊑★ =
+    widen-path-star-spine⊥ (wp-all p) sp
+  widen-spine-overlap⊥ to-star (wp-inst p) sp (∉-all fresh)
+      (I.∀⊑∀ q) =
+    widen-spine-overlap⊥ to-star p (spine-peel-right suc sp) fresh q
+  widen-spine-overlap⊥ to-star (wp-inst p) sp fresh
+      (I.∀⊑ Anv zero∈A q) =
+    widen-spine-overlap⊥ to-star p
+      (spine-map-right suc (spine-map-left suc sp))
+      (shift-fresh fresh) q
+  widen-spine-overlap⊥ to-star (wp-inst p) sp fresh I.∀★⊑★ =
+    widen-path-star-spine⊥ (wp-inst p) sp
+  widen-spine-overlap⊥ to-star (wp-inst p) sp fresh
+      (I.∀⊑★ Ans q) =
+    widen-path-star-spine⊥ (wp-inst p) sp
+  widen-spine-overlap⊥ to-star (wp-inst ()) sp fresh I.bot-elim
+  widen-spine-overlap⊥ to-star (wp-inst p) sp fresh I.bot⊑★ =
+    widen-path-star-spine⊥ (wp-inst p) sp
+
+  insert-disjoint : ∀ {Δ} {μ ν : I.ImpEnv (Nat.suc Δ)}
+      {A B : Ty (Nat.suc Δ)} {X : TyVar (Nat.suc Δ)}
+    → μ X ≡ I.X⊑X
+    → ν X ≡ I.X⊑★
+    → X ∈ᵗ A
+    → I._⊢_⊑_ μ A B
+    → I._⊢_⊑_ ν A (renameᵗ (insertʳ X) (`∀ B))
+    → ⊥
+  insert-disjoint {_} {_} {_} {_} {B} {X} same to-star X∈A p q =
+    widen-spine-overlap⊥ to-star (source-path-same same p X∈A)
+      (insert-spine X) (insert-fresh X (`∀ B)) q
+
+  ∀⊑∀-∀⊑-disjoint : ∀ {Δ} {μ : I.ImpEnv Δ}
+      {A B : Ty (Nat.suc Δ)}
+    → zero ∈ᵗ A
+    → I._⊢_⊑_ (I.extᵐ μ) A B
+    → I._⊢_⊑_ (I.instᵐ μ) A (⇑ᵗ (`∀ B))
+    → ⊥
+  ∀⊑∀-∀⊑-disjoint zero∈A p q =
+    insert-disjoint refl refl zero∈A p q
 
   dynamic-domain : ∀ {Δ} {μ : I.ImpEnv Δ} {A B : Ty Δ}
     → (∀ X → X ∈ᵗ A ⇒ B → μ X ≡ I.X⊑★)
@@ -82,28 +475,31 @@ private
 
   data AllChoice {Δ : TyCtx} : Ty (Nat.suc Δ) → Set where
     bottom-choice : AllChoice (＇ zero)
+    star-choice : AllChoice ★
     inst-choice : ∀ {A}
       → NonVar A
       → zero ∈ᵗ A
       → AllChoice A
     structural-choice : ∀ {A}
+      → NonStar A
       → zero ∉ᵗ A
       → AllChoice A
 
   all-choice : ∀ {Δ} (A : Ty (Nat.suc Δ)) → AllChoice A
   all-choice (＇ zero) = bottom-choice
-  all-choice (＇ (suc X)) = structural-choice (∉-var (λ ()))
-  all-choice (‵ ι) = structural-choice ∉-base
-  all-choice ★ = structural-choice ∉-star
+  all-choice (＇ (suc X)) = structural-choice nonstar-X (∉-var (λ ()))
+  all-choice (‵ ι) = structural-choice nonstar-ι ∉-base
+  all-choice ★ = star-choice
   all-choice (A ⇒ B) with occurs? zero (A ⇒ B)
   all-choice (A ⇒ B) | present zero∈A⇒B =
     inst-choice nonvar-fun zero∈A⇒B
   all-choice (A ⇒ B) | absent zero∉A⇒B =
-    structural-choice zero∉A⇒B
+    structural-choice nonstar-⇒ zero∉A⇒B
   all-choice (`∀ A) with occurs? zero (`∀ A)
   all-choice (`∀ A) | present zero∈∀A =
     inst-choice nonvar-all zero∈∀A
-  all-choice (`∀ A) | absent zero∉∀A = structural-choice zero∉∀A
+  all-choice (`∀ A) | absent zero∉∀A =
+    structural-choice nonstar-∀ zero∉∀A
 
   imprecise-star-shape : ∀ {Δ} {μ : I.ImpEnv Δ} {A : Ty Δ}
     → Shape A
@@ -121,14 +517,112 @@ private
     where
     decide : AllChoice A → I._⊢_⊑_ _ (`∀ A) ★
     decide bottom-choice = I.bot⊑★
+    decide star-choice = I.∀★⊑★
     decide (inst-choice Anv zero∈A) =
       I.∀⊑ Anv zero∈A
-        (imprecise-star-shape shape-A
-          (dynamic-under-inst dynamic))
-    decide (structural-choice zero∉A) =
-      I.∀⊑★
+        (imprecise-star-shape shape-A (dynamic-under-inst dynamic))
+    decide (structural-choice Ans zero∉A) =
+      I.∀⊑★ Ans
         (imprecise-star-shape shape-A
           (dynamic-under-ext dynamic zero∉A))
 
 imprecise-star : ∀ (A : Ty 0) → I._⊑_ A ★
 imprecise-star A = imprecise-star-shape (shape A) (\ ())
+
+------------------------------------------------------------------------
+-- Uniqueness of occurrence evidence
+------------------------------------------------------------------------
+
+∉ᵗ-unique : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → (p q : X ∉ᵗ A)
+  → p ≡ q
+∉ᵗ-unique (∉-var X≢Y) (∉-var X≢Y′) =
+  cong ∉-var (¬-unique X≢Y X≢Y′)
+∉ᵗ-unique ∉-base ∉-base = refl
+∉ᵗ-unique ∉-star ∉-star = refl
+∉ᵗ-unique (∉-fun X∉A X∉B) (∉-fun X∉A′ X∉B′)
+    rewrite ∉ᵗ-unique X∉A X∉A′
+          | ∉ᵗ-unique X∉B X∉B′ =
+  refl
+∉ᵗ-unique (∉-all X∉A) (∉-all X∉A′)
+    rewrite ∉ᵗ-unique X∉A X∉A′ =
+  refl
+
+∈ᵗ-unique : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → (p q : X ∈ᵗ A)
+  → p ≡ q
+∈ᵗ-unique var-∈ var-∈ = refl
+∈ᵗ-unique (∈-fun-left X∈A) (∈-fun-left X∈A′)
+    rewrite ∈ᵗ-unique X∈A X∈A′ =
+  refl
+∈ᵗ-unique (∈-fun-left X∈A) (∈-fun-right X∉A X∈B) =
+  ⊥-elim (not-occurs X∉A X∈A)
+∈ᵗ-unique (∈-fun-right X∉A X∈B) (∈-fun-left X∈A) =
+  ⊥-elim (not-occurs X∉A X∈A)
+∈ᵗ-unique (∈-fun-right X∉A X∈B) (∈-fun-right X∉A′ X∈B′)
+    rewrite ∉ᵗ-unique X∉A X∉A′
+          | ∈ᵗ-unique X∈B X∈B′ =
+  refl
+∈ᵗ-unique (∈-all X∈A) (∈-all X∈A′)
+    rewrite ∈ᵗ-unique X∈A X∈A′ =
+  refl
+
+------------------------------------------------------------------------
+-- Uniqueness of type imprecision
+------------------------------------------------------------------------
+
+varImp-eq-unique : ∀ {v w : I.VarImp}
+  → (p q : v ≡ w)
+  → p ≡ q
+varImp-eq-unique refl refl = refl
+
+⊑-unique : ∀ {Δ} {μ : I.ImpEnv Δ} {A B : Ty Δ}
+  → (p q : I._⊢_⊑_ μ A B)
+  → p ≡ q
+⊑-unique I.★⊑★ I.★⊑★ = refl
+⊑-unique I.ι⊑ι I.ι⊑ι = refl
+⊑-unique I.X⊑X I.X⊑X = refl
+⊑-unique (I.⇒⊑⇒ A⊑A′ B⊑B′) (I.⇒⊑⇒ A⊑A″ B⊑B″)
+    rewrite ⊑-unique A⊑A′ A⊑A″
+          | ⊑-unique B⊑B′ B⊑B″ =
+  refl
+⊑-unique (I.∀⊑∀ A⊑B) (I.∀⊑∀ A⊑B′)
+    rewrite ⊑-unique A⊑B A⊑B′ =
+  refl
+⊑-unique (I.∀⊑∀ A⊑B) (I.∀⊑ Anv zero∈A A⊑B′) =
+  ⊥-elim (∀⊑∀-∀⊑-disjoint zero∈A A⊑B A⊑B′)
+⊑-unique (I.∀⊑∀ A⊑★) I.bot-elim =
+  ⊥-elim (occurs-not-star refl var-∈ A⊑★)
+⊑-unique (I.⇒⊑★ A⊑★ B⊑★) (I.⇒⊑★ A⊑★′ B⊑★′)
+    rewrite ⊑-unique A⊑★ A⊑★′
+          | ⊑-unique B⊑★ B⊑★′ =
+  refl
+⊑-unique I.ι⊑★ I.ι⊑★ = refl
+⊑-unique (I.X⊑★ x⊑★) (I.X⊑★ x⊑★′)
+    rewrite varImp-eq-unique x⊑★ x⊑★′ =
+  refl
+⊑-unique (I.∀⊑ Anv zero∈A A⊑B)
+    (I.∀⊑ Anv′ zero∈A′ A⊑B′)
+    rewrite nonVar-unique Anv Anv′
+          | ∈ᵗ-unique zero∈A zero∈A′
+          | ⊑-unique A⊑B A⊑B′ =
+  refl
+⊑-unique (I.∀⊑ Anv zero∈A A⊑B) (I.∀⊑∀ A⊑B′) =
+  ⊥-elim (∀⊑∀-∀⊑-disjoint zero∈A A⊑B′ A⊑B)
+⊑-unique (I.∀⊑ Anv zero∈A A⊑B) (I.∀⊑★ Ans A⊑★) =
+  ⊥-elim (occurs-not-star refl zero∈A A⊑★)
+⊑-unique I.∀★⊑★ I.∀★⊑★ = refl
+⊑-unique (I.∀⊑★ Ans A⊑★) (I.∀⊑★ Ans′ A⊑★′)
+    rewrite nonStar-unique Ans Ans′
+          | ⊑-unique A⊑★ A⊑★′ =
+  refl
+⊑-unique (I.∀⊑★ Ans A⊑★) (I.∀⊑ Anv zero∈A A⊑B) =
+  ⊥-elim (occurs-not-star refl zero∈A A⊑★)
+⊑-unique (I.∀⊑★ Ans A⊑★) I.bot⊑★ =
+  ⊥-elim (occurs-not-star refl var-∈ A⊑★)
+⊑-unique I.bot-elim I.bot-elim = refl
+⊑-unique I.bot-elim (I.∀⊑∀ A⊑★) =
+  ⊥-elim (occurs-not-star refl var-∈ A⊑★)
+⊑-unique I.bot⊑★ I.bot⊑★ = refl
+⊑-unique I.bot⊑★ (I.∀⊑★ Ans A⊑★) =
+  ⊥-elim (occurs-not-star refl var-∈ A⊑★)

--- a/GTSFImp/proof/ImprecisionConsistency.agda
+++ b/GTSFImp/proof/ImprecisionConsistency.agda
@@ -12,7 +12,7 @@ open import Data.Fin using (zero; suc)
 import Data.Nat as Nat
 open import Data.Product using (_×_; _,_; ∃; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; cong; refl; subst; sym; trans)
+  using (_≡_; _≢_; cong; refl; subst; sym; trans)
 open import Relation.Nullary using (no; yes)
 
 open import Types
@@ -225,7 +225,7 @@ target-occurs-source (I.X⊑★ eq) ()
 target-occurs-source (I.∀⊑ Anv z∈A p) X∈B =
   ∈-all (target-occurs-source p (shift-occurs X∈B))
 target-occurs-source I.∀★⊑★ ()
-target-occurs-source (I.∀⊑★ p) ()
+target-occurs-source (I.∀⊑★ Ans p) ()
 target-occurs-source I.bot-elim (∈-all ())
 target-occurs-source I.bot⊑★ ()
 
@@ -246,7 +246,7 @@ source-nonvar-from-target (I.X⊑★ eq) Anv ()
 source-nonvar-from-target (I.∀⊑ Anv z∈A p) Bnv z∈B =
   nonvar-all
 source-nonvar-from-target I.∀★⊑★ Anv ()
-source-nonvar-from-target (I.∀⊑★ p) Anv ()
+source-nonvar-from-target (I.∀⊑★ Ans p) Anv ()
 source-nonvar-from-target I.bot-elim Anv (∈-all ())
 source-nonvar-from-target I.bot⊑★ Anv ()
 
@@ -312,10 +312,23 @@ var-left-to-star h eq (I.∀⊑ Anv z∈A p) =
   I.∀⊑ Anv z∈A
     (var-left-to-star (instantiate-left-lower-env h) eq p)
 
+nonstar-from-≢★ : ∀ {Δ} {A : Ty Δ}
+  → A ≢ ★
+  → NonStar A
+nonstar-from-≢★ {A = ＇ X} A≢★ = nonstar-X
+nonstar-from-≢★ {A = ‵ ι} A≢★ = nonstar-ι
+nonstar-from-≢★ {A = ★} A≢★ = ⊥-elim (A≢★ refl)
+nonstar-from-≢★ {A = A ⇒ B} A≢★ = nonstar-⇒
+nonstar-from-≢★ {A = `∀ A} A≢★ = nonstar-∀
+
 universal-right-to-star : ∀ {Δ} {μ : I.ImpEnv Δ} {D}
   → I._⊢_⊑_ μ D (`∀ ★)
   → I._⊢_⊑_ μ D ★
-universal-right-to-star (I.∀⊑∀ p) = I.∀⊑★ p
+universal-right-to-star {D = `∀ A} (I.∀⊑∀ p) with A ≟Ty ★
+universal-right-to-star {D = `∀ A} (I.∀⊑∀ p) | yes refl =
+  I.∀★⊑★
+universal-right-to-star {D = `∀ A} (I.∀⊑∀ p) | no A≢★ =
+  I.∀⊑★ (nonstar-from-≢★ A≢★) p
 universal-right-to-star (I.∀⊑ Anv z∈A p) =
   I.∀⊑ Anv z∈A (universal-right-to-star p)
 universal-right-to-star I.bot-elim = I.bot⊑★
@@ -461,7 +474,7 @@ source-nonvar-target (I.X⊑★ eq) ()
 source-nonvar-target (I.∀⊑ Anv z∈A p) nonvar-all =
   unshift-nonvar (source-nonvar-target p Anv)
 source-nonvar-target I.∀★⊑★ nonvar-all = nonvar-star
-source-nonvar-target (I.∀⊑★ p) nonvar-all = nonvar-star
+source-nonvar-target (I.∀⊑★ Ans p) nonvar-all = nonvar-star
 source-nonvar-target I.bot-elim nonvar-all = nonvar-all
 source-nonvar-target I.bot⊑★ nonvar-all = nonvar-star
 
@@ -500,9 +513,9 @@ source-occurs-target {X = X} focus (I.∀⊑ Anv z∈A p)
   unshift-occurs
     (source-occurs-target {X = suc X} focus p X∈A)
 source-occurs-target focus I.∀★⊑★ (∈-all ())
-source-occurs-target {X = X} focus (I.∀⊑★ p) (∈-all X∈A)
+source-occurs-target {X = X} focus (I.∀⊑★ Ans p) (∈-all X∈A)
     with source-occurs-target {X = suc X} focus p X∈A
-source-occurs-target {X = X} focus (I.∀⊑★ p) (∈-all X∈A)
+source-occurs-target {X = X} focus (I.∀⊑★ Ans p) (∈-all X∈A)
     | ()
 source-occurs-target focus I.bot-elim (∈-all ())
 source-occurs-target focus I.bot⊑★ (∈-all ())
@@ -854,13 +867,13 @@ lower-bounds-consistentᵐ h safe
   ∀ᶜ (lower-bounds-consistentᵐ (extend-lower-env h)
     (avoid-under-all safe) p q)
 lower-bounds-consistentᵐ h safe
-    (I.∀⊑∀ p) (I.∀⊑★ q) =
+    (I.∀⊑∀ p) (I.∀⊑★ Bns q) =
   _! ⦃ g-∀ ⦄
     (∀ᶜ (lower-bounds-consistentᵐ (extend-lower-env h)
       (avoid-under-all-star safe) p q))
     ⦃ nonstar-∀ ⦄ ⦃ match-∀ ⦄
 lower-bounds-consistentᵐ h safe
-    (I.∀⊑★ p) (I.∀⊑∀ q) =
+    (I.∀⊑★ Ans p) (I.∀⊑∀ q) =
   ？_ ⦃ g-∀ ⦄
     (∀ᶜ (lower-bounds-consistentᵐ (extend-lower-env h)
       (avoid-under-star-all safe) p q))
@@ -900,13 +913,13 @@ lower-bounds-consistentᵐ {A = .★} h safe
     (source-nonvar-target q Dnv)
     (source-occurs-target refl q z∈D)
 lower-bounds-consistentᵐ h safe
-    (I.∀⊑ Anv z∈D p) (I.∀⊑★ q) =
+    (I.∀⊑ Anv z∈D p) (I.∀⊑★ Bns q) =
   close-genᶜ
     (lower-bounds-consistentᵐ
       (instantiate-left-lower-env h)
       (avoid-under-inst-star-left safe) p q)
 lower-bounds-consistentᵐ h safe
-    (I.∀⊑★ p) (I.∀⊑ Bnv z∈D q) =
+    (I.∀⊑★ Ans p) (I.∀⊑ Bnv z∈D q) =
   close-instᶜ
     (lower-bounds-consistentᵐ
       (instantiate-right-lower-env h)
@@ -922,11 +935,11 @@ lower-bounds-consistentᵐ h safe
 lower-bounds-consistentᵐ h safe
     I.∀★⊑★ (I.∀⊑∀ I.★⊑★) = star-to-universal-ground
 lower-bounds-consistentᵐ h safe
-    I.∀★⊑★ (I.∀⊑★ q) = id ★
+    I.∀★⊑★ (I.∀⊑★ Bns q) = id ★
 lower-bounds-consistentᵐ h safe
-    (I.∀⊑★ p) I.∀★⊑★ = id ★
+    (I.∀⊑★ Ans p) I.∀★⊑★ = id ★
 lower-bounds-consistentᵐ h safe
-    (I.∀⊑★ p) (I.∀⊑★ q) = id ★
+    (I.∀⊑★ Ans p) (I.∀⊑★ Bns q) = id ★
 lower-bounds-consistentᵐ h safe I.∀★⊑★ I.∀★⊑★ = id ★
 lower-bounds-consistentᵐ h safe
     (I.∀⊑∀ I.X⊑X) I.bot-elim = bot-elim
@@ -936,24 +949,24 @@ lower-bounds-consistentᵐ h safe
     I.bot-elim (I.∀⊑∀ I.X⊑X) = bot-intro
 lower-bounds-consistentᵐ h safe I.bot-elim I.bot-elim =
   refl∼ (`∀ ★)
-lower-bounds-consistentᵐ h safe I.bot-elim (I.∀⊑★ q)
+lower-bounds-consistentᵐ h safe I.bot-elim (I.∀⊑★ Bns q)
     with source-occurs-target refl q var-∈
-lower-bounds-consistentᵐ h safe I.bot-elim (I.∀⊑★ q) | ()
+lower-bounds-consistentᵐ h safe I.bot-elim (I.∀⊑★ Bns q) | ()
 lower-bounds-consistentᵐ h safe I.bot-elim I.bot⊑★ =
   universal-ground-to-star
 lower-bounds-consistentᵐ h safe
     I.bot⊑★ (I.∀⊑∀ I.X⊑X) = star-to-bottom
 lower-bounds-consistentᵐ h safe I.bot⊑★ I.bot-elim =
   star-to-universal-ground
-lower-bounds-consistentᵐ h safe I.bot⊑★ (I.∀⊑★ q)
+lower-bounds-consistentᵐ h safe I.bot⊑★ (I.∀⊑★ Bns q)
     with source-occurs-target refl q var-∈
-lower-bounds-consistentᵐ h safe I.bot⊑★ (I.∀⊑★ q) | ()
-lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot-elim
+lower-bounds-consistentᵐ h safe I.bot⊑★ (I.∀⊑★ Bns q) | ()
+lower-bounds-consistentᵐ h safe (I.∀⊑★ Ans p) I.bot-elim
     with source-occurs-target refl p var-∈
-lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot-elim | ()
-lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot⊑★
+lower-bounds-consistentᵐ h safe (I.∀⊑★ Ans p) I.bot-elim | ()
+lower-bounds-consistentᵐ h safe (I.∀⊑★ Ans p) I.bot⊑★
     with source-occurs-target refl p var-∈
-lower-bounds-consistentᵐ h safe (I.∀⊑★ p) I.bot⊑★ | ()
+lower-bounds-consistentᵐ h safe (I.∀⊑★ Ans p) I.bot⊑★ | ()
 lower-bounds-consistentᵐ h safe I.bot⊑★ I.bot⊑★ = id ★
 
 common-lower-consistent : ∀ {Δ} {A B : Ty Δ}


### PR DESCRIPTION
## Summary

- move `NonStar` into `Types` and require it on the `∀⊑★` imprecision rule
- prove uniqueness for occurrence evidence and type imprecision in `GTSFImp/proof/Imprecision.agda`
- adapt imprecision/consistency proofs to the refined `∀⊑★` premise

## Validation

- `agda All.agda` from `GTSFImp/`
- `git diff --cached --check` before commit