### PR TITLE
Format DGG reductions as chains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,11 @@ Put each intermediate term on its own indented line, put the step justification
 on the following `—→⟨ ... ⟩` line, and always end the written chain with `∎`
 so the final term is explicit in the code.
 
+When a proof reuses an existing multi-step reduction segment, use the local
+transitive chain syntax, such as `_—↠⟨_⟩_` or `_—↠[_]⟨_⟩_`, and still finish
+with the relation's reflexive terminator. For store-changing chains in
+GTSFImp, that means writing the final term followed by `∎[]`.
+
 Prefer:
 
     twoᶜ · sucᶜ · `zero
@@ -308,6 +313,14 @@ Prefer:
   —→⟨ β-ƛ (V-suc V-zero) ⟩
     `suc (`suc `zero)
   ∎
+
+For store-changing reductions with a reused tail proof, prefer:
+
+    M
+  —→[ keep ]⟨ step ⟩
+    N
+  —↠[ χs ]⟨ N↠P ⟩
+    P ∎[]
 
 Over nested `—→⟨_⟩_` / `↠-step` constructor applications when proving
 reduction sequences.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,8 @@ When using ASCII diagrams in informal proofs:
 When writing Agda proofs of reduction sequences, use the local chain notation
 for the reduction relation at hand instead of nested constructor applications.
 Put each intermediate term on its own indented line, put the step justification
-on the following `—→⟨ ... ⟩` line, and end the chain with `∎`.
+on the following `—→⟨ ... ⟩` line, and always end the written chain with `∎`
+so the final term is explicit in the code.
 
 Prefer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,29 @@ When using ASCII diagrams in informal proofs:
 
 # Agda Development Notes
 
+## Agda reduction sequence proof style
+
+When writing Agda proofs of reduction sequences, use the local chain notation
+for the reduction relation at hand instead of nested constructor applications.
+Put each intermediate term on its own indented line, put the step justification
+on the following `—→⟨ ... ⟩` line, and end the chain with `∎`.
+
+Prefer:
+
+    twoᶜ · sucᶜ · `zero
+  —→⟨ ξ-·₁ (β-ƛ V-ƛ) ⟩
+    (ƛ "z" ⇒ sucᶜ · (sucᶜ · ` "z")) · `zero
+  —→⟨ β-ƛ V-zero ⟩
+    sucᶜ · (sucᶜ · `zero)
+  —→⟨ ξ-·₂ V-ƛ (β-ƛ V-zero) ⟩
+    sucᶜ · `suc `zero
+  —→⟨ β-ƛ (V-suc V-zero) ⟩
+    `suc (`suc `zero)
+  ∎
+
+Over nested `—→⟨_⟩_` / `↠-step` constructor applications when proving
+reduction sequences.
+
 ## Function extensionality is allowed
 
 It is acceptable to postulate or import function extensionality in Agda proofs

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -20,5 +20,6 @@ import proof.TypeSafety.Preservation
 import proof.ImprecisionConsistency
 import proof.Imprecision
 import proof.Consistency
+import proof.Reduction
 import proof.DGG.CastTermImprecision
 import proof.DGG.CompilePreservesImprecision

--- a/GTSFImp/Eval.agda
+++ b/GTSFImp/Eval.agda
@@ -22,6 +22,7 @@ open import Conversion
 open import Primitives
 open import CastTerms
 open import Reduction
+import proof.Consistency as ConsProof
 import proof.TypeSafety.Progress as Progress
 
 ------------------------------------------------------------------------
@@ -45,7 +46,7 @@ inert? (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ c ⦃ Ans ⦄)
 inert? (？ c) = nothing
 inert? (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) = nothing
 inert? (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) =
-  just (genᵥ A≢★ (Progress.gen-safe c A≢★ Bnv z∈B))
+  just (genᵥ A≢★ (ConsProof.gen-safe c A≢★ Bnv z∈B))
 inert? bot-elim = nothing
 inert? bot-intro = nothing
 

--- a/GTSFImp/Reduction.agda
+++ b/GTSFImp/Reduction.agda
@@ -118,6 +118,24 @@ syntax applyTerms χs M = χs ▶ᵀ M
 applyTerms [] M = M
 applyTerms (χ ∷ χs) M = χs ▶ᵀ (χ ▷ᵀ M)
 
+applyEnvs : ∀ {Δ Δ′}
+  → StoreChanges Δ Δ′
+  → Env∼ Δ
+  → Env∼ Δ′
+syntax applyEnvs χs μ = χs ▶ᵉ μ
+
+applyEnvs [] μ = μ
+applyEnvs (χ ∷ χs) μ = χs ▶ᵉ (χ ▷ᵉ μ)
+
+applyConsistencies : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
+  → (χs : StoreChanges Δ Δ′)
+  → μ ⊢ A ∼ B
+  → χs ▶ᵉ μ ⊢ χs ▶ᵗ A ∼ χs ▶ᵗ B
+syntax applyConsistencies χs c = χs ▶ᶜ c
+
+applyConsistencies [] c = c
+applyConsistencies (χ ∷ χs) c = χs ▶ᶜ (χ ▷ᶜ c)
+
 ------------------------------------------------------------------------
 -- Pure one-step reduction
 ------------------------------------------------------------------------

--- a/GTSFImp/Reduction.agda
+++ b/GTSFImp/Reduction.agda
@@ -435,3 +435,11 @@ pattern _∎[] M = ↠-refl {M = M}
 infixr 2 _—→[_]⟨_⟩_
 pattern _—→[_]⟨_⟩_ L χ L—→M M—↠N =
   ↠-step {M = L} {χ = χ} L—→M M—↠N
+
+infixr 2 _—↠[_]⟨_⟩_
+_—↠[_]⟨_⟩_ : ∀ {Δ Δ′} (M : Term Δ) {N : Term Δ′}
+  → (χs : StoreChanges Δ Δ′)
+  → M —↠[ χs ] N
+  → N —↠[ [] ] N
+  → M —↠[ χs ] N
+M —↠[ χs ]⟨ M↠N ⟩ (_ ∎[]) = M↠N

--- a/GTSFImp/proof/Consistency.agda
+++ b/GTSFImp/proof/Consistency.agda
@@ -4,12 +4,18 @@ module proof.Consistency where
 --   * Proves that every closed type is consistent with the dynamic type.
 --   * Derives the result from closed-type imprecision and the common-lower
 --     characterization of consistency.
+--   * Supplies consistency-side safety facts for polymorphic generated casts.
 --   * Depends on proof.Imprecision and proof.ImprecisionConsistency.
 
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.Nat using (suc)
 open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl; sym)
 
 open import Types
 open import Consistency
+open import CastTerms using (GenSafe; safe-⇒; safe-∀; safe-inst; safe-gen)
 open import proof.Imprecision using (imprecise-star)
 open import proof.ImprecisionConsistency
   using (common-lower-consistent; refl⊑)
@@ -17,3 +23,86 @@ open import proof.ImprecisionConsistency
 consistent-star : ∀ (A : Ty 0) → A ∼ ★
 consistent-star A = common-lower-consistent
   (A , refl⊑ A , imprecise-star A)
+
+------------------------------------------------------------------------
+-- Polymorphic generated cast safety
+------------------------------------------------------------------------
+
+data Preimage {Δ Δ′ : TyCtx} (ρ : Δ ⇒ʳ Δ′) (Y : TyVar Δ′)
+    (A : Ty Δ) : Set where
+  found : (X : TyVar Δ) → ρ X ≡ Y → X ∈ᵗ A → Preimage ρ Y A
+
+rename-preimage : ∀ {Δ Δ′} {ρ : Δ ⇒ʳ Δ′} {Y : TyVar Δ′}
+    {A : Ty Δ}
+  → Y ∈ᵗ renameᵗ ρ A
+  → Preimage ρ Y A
+rename-preimage {A = ＇ X} var-∈ = found X refl var-∈
+rename-preimage {A = ‵ ι} ()
+rename-preimage {A = ★} ()
+rename-preimage {A = A ⇒ B} (∈-fun-left Y∈A)
+    with rename-preimage Y∈A
+rename-preimage {A = A ⇒ B} (∈-fun-left Y∈A)
+    | found X eq X∈A =
+  found X eq (∈-fun-left X∈A)
+rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
+    with rename-preimage Y∈B
+rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
+    | found X eq X∈B with occurs? X A
+rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
+    | found X eq X∈B | present X∈A =
+  found X eq (∈-fun-left X∈A)
+rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
+    | found X eq X∈B | absent X∉A =
+  found X eq (∈-fun-right X∉A X∈B)
+rename-preimage {A = `∀ A} (∈-all Y∈A)
+    with rename-preimage Y∈A
+rename-preimage {A = `∀ A} (∈-all Y∈A)
+    | found Fin.zero () X∈A
+rename-preimage {A = `∀ A} (∈-all Y∈A)
+    | found (Fin.suc X) refl X∈A =
+  found X refl (∈-all X∈A)
+
+zero-not-shift : ∀ {Δ} {A : Ty Δ} → Fin.zero ∈ᵗ ⇑ᵗ A → ⊥
+zero-not-shift z∈ with rename-preimage z∈
+zero-not-shift z∈ | found X () X∈A
+
+shift-star-injective : ∀ {Δ} {A : Ty Δ}
+  → ⇑ᵗ A ≡ ★
+  → A ≡ ★
+shift-star-injective {A = ＇ X} ()
+shift-star-injective {A = ‵ ι} ()
+shift-star-injective {A = ★} refl = refl
+shift-star-injective {A = A ⇒ B} ()
+shift-star-injective {A = `∀ A} ()
+
+gen-safe′ : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ}
+    {C B : Ty (suc Δ)}
+  → (c : genᵐ μ ⊢ C ∼ B)
+  → C ≡ ⇑ᵗ A
+  → A ≢ ★
+  → NonVar B
+  → Fin.zero ∈ᵗ B
+  → GenSafe c
+gen-safe′ (id a) refl A≢★ Bnv z∈B =
+  ⊥-elim (zero-not-shift z∈B)
+gen-safe′ (c ↦ d) eq A≢★ Bnv z∈B = safe-⇒
+gen-safe′ (∀ᶜ c) eq A≢★ Bnv z∈B = safe-∀
+gen-safe′ (_! ⦃ g ⦄ c ⦃ Ans ⦄) eq A≢★ Bnv ()
+gen-safe′ (？_ ⦃ g ⦄ c ⦃ Bns ⦄)
+    eq A≢★ Bnv z∈B =
+  ⊥-elim (A≢★ (shift-star-injective (sym eq)))
+gen-safe′ (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) eq A≢★ Bnv z∈B =
+  safe-inst B≢★
+gen-safe′ (gen_ {A = C} ⦃ Cnv ⦄ ⦃ z∈C ⦄ c C≢★)
+    eq A≢★ Bnv z∈B =
+  safe-gen C≢★ (gen-safe′ c refl C≢★ Cnv z∈C)
+gen-safe′ bot-elim eq A≢★ Bnv (∈-all ())
+gen-safe′ bot-intro eq A≢★ Bnv (∈-all ())
+
+gen-safe : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ} {B : Ty (suc Δ)}
+  → (c : genᵐ μ ⊢ ⇑ᵗ A ∼ B)
+  → A ≢ ★
+  → NonVar B
+  → Fin.zero ∈ᵗ B
+  → GenSafe c
+gen-safe c A≢★ Bnv z∈B = gen-safe′ c refl A≢★ Bnv z∈B

--- a/GTSFImp/proof/DGG/ExtraCastRightProbe.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRightProbe.agda
@@ -20,7 +20,7 @@ import Consistency as C
 open import Conversion using (Conv↑; Conv↓; `∀↑_; `∀↓_; 〖_,_↑_〗)
 open import CastTerms using
   (Term; Value; _⊢_⦂_; ⊢⟨⟩; ⟨_,_,_⟩; ƛ_; Λ_; $; _⦂∀_[_];
-   _⟨_⟩; _↑_; _↓_; GenSafe; Inert; inj; fun; all; seal; genᵥ;
+   _⟨_⟩; _↑_; _↓_; GenSafe; inj; fun; all; seal; genᵥ;
    safe-⇒; safe-∀; safe-inst; safe-gen; _《_》; renameᵗᵐ; ⇑ᵗᵐ)
 open import Imprecision using (_⊢_⊑_)
 import Imprecision as I
@@ -36,88 +36,10 @@ open import proof.ImprecisionConsistency using
    source-occurs-target; toRenameᵗ-injective; unshift-nonvar)
 import proof.Imprecision as PI
 import proof.TypeSafety.Progress as Prog
-open import proof.TypeSafety.Progress using (gen-safe)
+open import proof.Consistency using (gen-safe)
+open import proof.Reduction using (cast-↠; applyConsistencies-Inert)
 open import proof.TypeInTermSubst using
-  (rename-star-injective; rename-occurs; renameᵗ-wk-eq;
-   renameᵗᵐ-preserves-Value; toRename-keep-eq)
-
-applyEnvs : ∀ {Δ Δ′}
-  → StoreChanges Δ Δ′
-  → Env∼ Δ
-  → Env∼ Δ′
-applyEnvs [] μ = μ
-applyEnvs (χ ∷ χs) μ = applyEnvs χs (applyEnv χ μ)
-
-applyConsistencies : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
-  → (χs : StoreChanges Δ Δ′)
-  → μ ⊢ A ∼ B
-  → applyEnvs χs μ ⊢ applyTys χs A ∼ applyTys χs B
-applyConsistencies [] c = c
-applyConsistencies (χ ∷ χs) c =
-  applyConsistencies χs (applyConsistency χ c)
-
-cast-↠ : ∀ {Δ Δ′} {M : Term Δ} {N : Term Δ′}
-    {χs : StoreChanges Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
-  → (c : μ ⊢ A ∼ B)
-  → M —↠[ χs ] N
-  → M ⟨ c ⟩ —↠[ χs ] N ⟨ applyConsistencies χs c ⟩
-cast-↠ {M = M} c (_ ∎[]) = (M ⟨ c ⟩) ∎[]
-cast-↠ {M = M} {N = P} {χs = χ ∷ χs} c
-    (_ —→[ χ ]⟨ M→N ⟩ N↠P) =
-  (M ⟨ c ⟩)
-    —→[ χ ]⟨ ξ-⟨⟩ M→N refl ⟩
-  _
-    —↠[ χs ]⟨ cast-↠ (applyConsistency χ c) N↠P ⟩
-  (P ⟨ applyConsistencies χs (applyConsistency χ c) ⟩) ∎[]
-
-applyStoreChange-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
-    {c : μ ⊢ A ∼ B}
-  → (χ : StoreChange Δ Δ′)
-  → Inert c
-  → Inert (applyConsistency χ c)
-applyStoreChange-Inert keep inert = inert
-applyStoreChange-Inert (bind A)
-    (inj ⦃ Gᵍ = ★⇒★ ⦄ ⦃ G∼★ = C.⇒∼★ ⦄ ⦃ Gns = Gns ⦄) =
-  inj ⦃ Gᵍ = ★⇒★ ⦄ ⦃ G∼★ = C.⇒∼★ ⦄
-    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (bind A)
-    (inj ⦃ Gᵍ = ‵ ι ⦄ ⦃ G∼★ = C.ι∼★ ⦄ ⦃ Gns = Gns ⦄) =
-  inj ⦃ Gᵍ = ‵ ι ⦄ ⦃ G∼★ = C.ι∼★ ⦄
-    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (bind A)
-    (inj {G = ＇ X} ⦃ Gᵍ = ＇ .X ⦄
-      ⦃ G∼★ = C.X∼★ᵍ eq ⦄ ⦃ Gns = Gns ⦄) =
-  inj ⦃ Gᵍ = ＇ Fin.suc X ⦄ ⦃ G∼★ = C.X∼★ᵍ eq ⦄
-    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (bind A)
-    (inj ⦃ Gᵍ = ∀★ ⦄ ⦃ G∼★ = C.∀∼★ ⦄ ⦃ Gns = Gns ⦄) =
-  inj ⦃ Gᵍ = ∀★ ⦄ ⦃ G∼★ = C.∀∼★ ⦄
-    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (bind A) fun = fun
-applyStoreChange-Inert (bind A) all = all
-applyStoreChange-Inert (bind A)
-    (genᵥ {A = A₀} {B = B} {c = c}
-      ⦃ Bnv = Bnv ⦄ ⦃ z∈B = z∈B ⦄ A≢★ safe) =
-  subst≡
-    (λ z → Inert (gen_ ⦃ Bnv = renameNonVar (extᵗ Fin.suc) Bnv ⦄
-      ⦃ z∈B = z ⦄ _ _))
-    (PI.∈ᵗ-unique (rename-occurs (extᵗ Fin.suc) z∈B) _)
-    (genᵥ ⦃ Bnv = renameNonVar (extᵗ Fin.suc) Bnv ⦄
-      ⦃ z∈B = rename-occurs (extᵗ Fin.suc) z∈B ⦄
-      A′≢★
-      (gen-safe _ A′≢★ (renameNonVar (extᵗ Fin.suc) Bnv)
-        (rename-occurs (extᵗ Fin.suc) z∈B)))
-  where
-  A′≢★ = λ eq → A≢★ (rename-star-injective Fin.suc eq)
-
-applyConsistencies-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
-    {c : μ ⊢ A ∼ B}
-  → (χs : StoreChanges Δ Δ′)
-  → Inert c
-  → Inert (applyConsistencies χs c)
-applyConsistencies-Inert [] inert = inert
-applyConsistencies-Inert (χ ∷ χs) inert =
-  applyConsistencies-Inert χs (applyStoreChange-Inert χ inert)
+  (renameᵗ-wk-eq; renameᵗᵐ-preserves-Value; toRename-keep-eq)
 
 gen-safe-source-nonvar : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
     {c : μ ⊢ A ∼ B}
@@ -430,7 +352,7 @@ extra-cast-right : ∀ {Δᴸ Δᴿ Δ}
     Σ[ transport⊑ ∈ (∀ {C : Ty Δᴿ}
       → CTI.impEnvⁱ ρ ⊢ A ⊑ renameᵗ (toRenameᵗ ηᴿ) C
       → CTI.impEnvⁱ ρ′
-          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (applyTys χs C)) ]
+          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (χs ▶ᵗ C)) ]
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
        × (M′ ⟨ c′ ⟩ —↠[ χs ] N′)
@@ -461,7 +383,7 @@ inst-catchup-right : ∀ {Δᴸ Δᴿ Δ}
     Σ[ transport⊑ ∈ (∀ {C : Ty Δᴿ}
       → CTI.impEnvⁱ ρ ⊢ A ⊑ renameᵗ (toRenameᵗ ηᴿ) C
       → CTI.impEnvⁱ ρ′
-          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (applyTys χs C)) ]
+          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (χs ▶ᵗ C)) ]
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
        × (M′ ⟨ (inst c′) B′≢★ ⟩ —↠[ χs ] N′)
@@ -550,7 +472,7 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
   Δᴿ′ , Δ′ , keep ∷ χs , ηᴸ′ , ηᴿ′ , ρ′ , γ′ ,
   A′ , transport⊑ ,
   N′
-    ⟨ applyConsistencies χs
+    ⟨ χs ▶ᶜ
         (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
           ⦃ C.ground-nonstar Gᵍ ⦄) ⟩ ,
   vN′
@@ -571,13 +493,13 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
         M′c↠N′
     ⟩
   (N′
-    ⟨ applyConsistencies χs
+    ⟨ χs ▶ᶜ
         (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
           ⦃ C.ground-nonstar Gᵍ ⦄) ⟩) ∎[]) ,
   CTI.rename⊑renameᶜ categorize′
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ′
-        (applyConsistencies χs
+        (χs ▶ᶜ
           (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
             ⦃ C.ground-nonstar Gᵍ ⦄)))
       M⊑N′ (transport⊑ q))

--- a/GTSFImp/proof/DGG/ExtraCastRightProbe.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRightProbe.agda
@@ -61,10 +61,12 @@ cast-↠ : ∀ {Δ Δ′} {M : Term Δ} {N : Term Δ′}
   → (c : μ ⊢ A ∼ B)
   → M R.—↠[ χs ] N
   → M ⟨ c ⟩ R.—↠[ χs ] N ⟨ applyConsistencies χs c ⟩
-cast-↠ c R.↠-refl = R.↠-refl
-cast-↠ {χs = χ R.∷ χs} c (R.↠-step M→N N↠P) =
-  R.↠-step (R.ξ-⟨⟩ M→N refl)
-    (cast-↠ (R.applyConsistency χ c) N↠P)
+cast-↠ {M = M} c (_ R.∎[]) = (M ⟨ c ⟩) R.∎[]
+cast-↠ {M = M} {χs = χ R.∷ χs} c
+    (_ R.—→[ χ ]⟨ M→N ⟩ N↠P) =
+  (M ⟨ c ⟩)
+    R.—→[ χ ]⟨ R.ξ-⟨⟩ M→N refl ⟩
+  cast-↠ (R.applyConsistency χ c) N↠P
 
 applyStoreChange-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
     {c : μ ⊢ A ∼ B}
@@ -469,7 +471,10 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     {M = M} {M′ = M′} {A = A} {B = B} {p = p}
     M⊑M′ vM vM′ (id a) q =
   Δᴿ , Δ , _ , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
-  vM′ , R.↠-step (R.pure-step (R.β-id vM′)) R.↠-refl ,
+  vM′ ,
+  ((M′ ⟨ id a ⟩)
+    R.—→[ R.keep ]⟨ R.pure-step (R.β-id vM′) ⟩
+  M′ R.∎[]) ,
   subst≡ (λ r → ηᴸ ∣ ηᴿ ∣ ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ r)
     (PI.⊑-unique p q) M⊑M′
 
@@ -479,7 +484,7 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     {M = M} {M′ = M′} {A = A} {B′ = B′}
     (CTI.rename⊑renameᶜ categorize M⊑M′) vM vM′ (c ↦ d) q =
   Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
-  vM′ 《 fun 》 , R.↠-refl ,
+  vM′ 《 fun 》 , ((M′ ⟨ c ↦ d ⟩) R.∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ (renameᵐᶜ ηᴿ (c ↦ d)) M⊑M′ q)
 
@@ -489,7 +494,7 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     {M = M} {M′ = M′} {A = A} {B′ = B′}
     (CTI.rename⊑renameᶜ categorize M⊑M′) vM vM′ (∀ᶜ c) q =
   Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
-  vM′ 《 all 》 , R.↠-refl ,
+  vM′ 《 all 》 , ((M′ ⟨ ∀ᶜ c ⟩) R.∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ (renameᵐᶜ ηᴿ (∀ᶜ c)) M⊑M′ q)
 
@@ -511,7 +516,8 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
   Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
   vM′ 《 inj ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
     ⦃ Gns = C.ground-nonstar Gᵍ ⦄ 》 ,
-  R.↠-refl ,
+  ((M′ ⟨ _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
+    ⦃ C.ground-nonstar Gᵍ ⦄ ⟩) R.∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ
@@ -549,14 +555,16 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     《 applyConsistencies-Inert χs
         (inj ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
           ⦃ Gns = C.ground-nonstar Gᵍ ⦄) 》 ,
-  R.↠-step
-    (R.pure-step
+  ((M′ ⟨ _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ c ⦃ Bns ⦄ ⟩)
+    R.—→[ R.keep ]⟨
+      R.pure-step
       (R.ground ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
-        ⦃ Ans = Bns ⦄ ⦃ Gns = C.ground-nonstar Gᵍ ⦄ vM′ B≢G))
-    (cast-↠
-      (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
-        ⦃ C.ground-nonstar Gᵍ ⦄)
-      M′c↠N′) ,
+        ⦃ Ans = Bns ⦄ ⦃ Gns = C.ground-nonstar Gᵍ ⦄ vM′ B≢G)
+    ⟩
+  cast-↠
+    (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
+      ⦃ C.ground-nonstar Gᵍ ⦄)
+    M′c↠N′) ,
   CTI.rename⊑renameᶜ categorize′
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ′
@@ -600,7 +608,7 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
 -- Subcase: Prog.from-ground g c = same
 extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     {ηᴸ = ηᴸ} {ηᴿ = ηᴿ} {ρ = ρ} {γ = γ}
-    {M = M} {A = A} {B′ = ._}
+    {M = M} {M′ = M′} {A = A} {B′ = ._}
     (CTI.rename⊑renameᶜ categorize M⊑M′ᶜ) vM vM′
     (？_ {B = ._} ⦃ g ⦄ ⦃ ★∼G ⦄ .(C.idᵍ g) ⦃ Bns ⦄) q
     | Prog.sv-tag {W = W} {G = ._} {Gᵍ = h} ⦃ G∼★ = H∼★ ⦄
@@ -610,11 +618,14 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
   Δᴿ , Δ , R.keep R.∷ R.[] , ηᴸ , ηᴿ , ρ , γ , A ,
   (λ r → r) , W ,
   vW ,
-  R.↠-step
-    (R.pure-step
+  ((M′ ⟨ ？_ ⦃ Gᵍ = h ⦄ ⦃ ★∼G = ★∼G ⦄ (C.idᵍ h)
+      ⦃ Bns = Hns ⦄ ⟩)
+    R.—→[ R.keep ]⟨
+      R.pure-step
       (R.tag-untag ⦃ Gᵍ = h ⦄ ⦃ G∼★ = H∼★ ⦄
-        ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = Hns ⦄ vW))
-    R.↠-refl ,
+        ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = Hns ⦄ vW)
+    ⟩
+  W R.∎[]) ,
   RII.right-inj-inversion-indexed vM
     (CTI.rename⊑renameᶜ categorize M⊑M′ᶜ) q
 
@@ -647,21 +658,25 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     | Δᴿ′ , Δ′ , χs , ηᴸ′ , ηᴿ′ , ρ′ , γ′ , A′ ,
       transport⊑ , N′ , vN′ , Wc↠N′ , M⊑N′
     rewrite ground-unique g h
-          | nonStar-unique Hns (C.ground-nonstar h) =
+          | sym (nonStar-unique Hns (C.ground-nonstar h)) =
   Δᴿ′ , Δ′ , R.keep R.∷ R.keep R.∷ χs ,
   ηᴸ′ , ηᴿ′ , ρ′ , γ′ , A′ , transport⊑ , N′ , vN′ ,
-  R.↠-step
-    (R.pure-step
+  (_
+    R.—→[ R.keep ]⟨
+      R.pure-step
       (R.expand ⦃ Gᵍ = h ⦄ ⦃ ★∼G = ★∼G ⦄
-        ⦃ Bns = Bns ⦄ ⦃ Gns = C.ground-nonstar h ⦄
-        vM′ (λ eq → B′≢G (sym eq))))
-    (R.↠-step
+        ⦃ Bns = Bns ⦄ ⦃ Gns = Hns ⦄
+        vM′ (λ eq → B′≢G (sym eq)))
+    ⟩
+  _
+    R.—→[ R.keep ]⟨
       (R.ξ-⟨⟩
         (R.pure-step
           (R.tag-untag ⦃ Gᵍ = h ⦄ ⦃ G∼★ = H∼★ ⦄
-            ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = C.ground-nonstar h ⦄ vW))
+            ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = Hns ⦄ vW))
         refl)
-      Wc↠N′) ,
+    ⟩
+  Wc↠N′) ,
   M⊑N′
 
 -- Subcase: G ≟Ty H = no G≢H
@@ -713,7 +728,7 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     =
   Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
   vM′ 《 genᵥ A≢★ (gen-safe c A≢★ Bnv z∈B) 》 ,
-  R.↠-refl ,
+  ((M′ ⟨ gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★ ⟩) R.∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★))

--- a/GTSFImp/proof/DGG/ExtraCastRightProbe.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRightProbe.agda
@@ -24,7 +24,7 @@ open import CastTerms using
    safe-⇒; safe-∀; safe-inst; safe-gen; _《_》; renameᵗᵐ; ⇑ᵗᵐ)
 open import Imprecision using (_⊢_⊑_)
 import Imprecision as I
-import Reduction as R
+open import Reduction
 import GradualTermImprecision as GTI
 import proof.DGG.CastTermImprecision as CTI
 import proof.DGG.RightInjInversion as RII
@@ -42,58 +42,60 @@ open import proof.TypeInTermSubst using
    renameᵗᵐ-preserves-Value; toRename-keep-eq)
 
 applyEnvs : ∀ {Δ Δ′}
-  → R.StoreChanges Δ Δ′
+  → StoreChanges Δ Δ′
   → Env∼ Δ
   → Env∼ Δ′
-applyEnvs R.[] μ = μ
-applyEnvs (χ R.∷ χs) μ = applyEnvs χs (R.applyEnv χ μ)
+applyEnvs [] μ = μ
+applyEnvs (χ ∷ χs) μ = applyEnvs χs (applyEnv χ μ)
 
 applyConsistencies : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
-  → (χs : R.StoreChanges Δ Δ′)
+  → (χs : StoreChanges Δ Δ′)
   → μ ⊢ A ∼ B
-  → applyEnvs χs μ ⊢ R.applyTys χs A ∼ R.applyTys χs B
-applyConsistencies R.[] c = c
-applyConsistencies (χ R.∷ χs) c =
-  applyConsistencies χs (R.applyConsistency χ c)
+  → applyEnvs χs μ ⊢ applyTys χs A ∼ applyTys χs B
+applyConsistencies [] c = c
+applyConsistencies (χ ∷ χs) c =
+  applyConsistencies χs (applyConsistency χ c)
 
 cast-↠ : ∀ {Δ Δ′} {M : Term Δ} {N : Term Δ′}
-    {χs : R.StoreChanges Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
+    {χs : StoreChanges Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
   → (c : μ ⊢ A ∼ B)
-  → M R.—↠[ χs ] N
-  → M ⟨ c ⟩ R.—↠[ χs ] N ⟨ applyConsistencies χs c ⟩
-cast-↠ {M = M} c (_ R.∎[]) = (M ⟨ c ⟩) R.∎[]
-cast-↠ {M = M} {χs = χ R.∷ χs} c
-    (_ R.—→[ χ ]⟨ M→N ⟩ N↠P) =
+  → M —↠[ χs ] N
+  → M ⟨ c ⟩ —↠[ χs ] N ⟨ applyConsistencies χs c ⟩
+cast-↠ {M = M} c (_ ∎[]) = (M ⟨ c ⟩) ∎[]
+cast-↠ {M = M} {N = P} {χs = χ ∷ χs} c
+    (_ —→[ χ ]⟨ M→N ⟩ N↠P) =
   (M ⟨ c ⟩)
-    R.—→[ χ ]⟨ R.ξ-⟨⟩ M→N refl ⟩
-  cast-↠ (R.applyConsistency χ c) N↠P
+    —→[ χ ]⟨ ξ-⟨⟩ M→N refl ⟩
+  _
+    —↠[ χs ]⟨ cast-↠ (applyConsistency χ c) N↠P ⟩
+  (P ⟨ applyConsistencies χs (applyConsistency χ c) ⟩) ∎[]
 
 applyStoreChange-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
     {c : μ ⊢ A ∼ B}
-  → (χ : R.StoreChange Δ Δ′)
+  → (χ : StoreChange Δ Δ′)
   → Inert c
-  → Inert (R.applyConsistency χ c)
-applyStoreChange-Inert R.keep inert = inert
-applyStoreChange-Inert (R.bind A)
+  → Inert (applyConsistency χ c)
+applyStoreChange-Inert keep inert = inert
+applyStoreChange-Inert (bind A)
     (inj ⦃ Gᵍ = ★⇒★ ⦄ ⦃ G∼★ = C.⇒∼★ ⦄ ⦃ Gns = Gns ⦄) =
   inj ⦃ Gᵍ = ★⇒★ ⦄ ⦃ G∼★ = C.⇒∼★ ⦄
     ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (R.bind A)
+applyStoreChange-Inert (bind A)
     (inj ⦃ Gᵍ = ‵ ι ⦄ ⦃ G∼★ = C.ι∼★ ⦄ ⦃ Gns = Gns ⦄) =
   inj ⦃ Gᵍ = ‵ ι ⦄ ⦃ G∼★ = C.ι∼★ ⦄
     ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (R.bind A)
+applyStoreChange-Inert (bind A)
     (inj {G = ＇ X} ⦃ Gᵍ = ＇ .X ⦄
       ⦃ G∼★ = C.X∼★ᵍ eq ⦄ ⦃ Gns = Gns ⦄) =
   inj ⦃ Gᵍ = ＇ Fin.suc X ⦄ ⦃ G∼★ = C.X∼★ᵍ eq ⦄
     ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (R.bind A)
+applyStoreChange-Inert (bind A)
     (inj ⦃ Gᵍ = ∀★ ⦄ ⦃ G∼★ = C.∀∼★ ⦄ ⦃ Gns = Gns ⦄) =
   inj ⦃ Gᵍ = ∀★ ⦄ ⦃ G∼★ = C.∀∼★ ⦄
     ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
-applyStoreChange-Inert (R.bind A) fun = fun
-applyStoreChange-Inert (R.bind A) all = all
-applyStoreChange-Inert (R.bind A)
+applyStoreChange-Inert (bind A) fun = fun
+applyStoreChange-Inert (bind A) all = all
+applyStoreChange-Inert (bind A)
     (genᵥ {A = A₀} {B = B} {c = c}
       ⦃ Bnv = Bnv ⦄ ⦃ z∈B = z∈B ⦄ A≢★ safe) =
   subst≡
@@ -110,11 +112,11 @@ applyStoreChange-Inert (R.bind A)
 
 applyConsistencies-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
     {c : μ ⊢ A ∼ B}
-  → (χs : R.StoreChanges Δ Δ′)
+  → (χs : StoreChanges Δ Δ′)
   → Inert c
   → Inert (applyConsistencies χs c)
-applyConsistencies-Inert R.[] inert = inert
-applyConsistencies-Inert (χ R.∷ χs) inert =
+applyConsistencies-Inert [] inert = inert
+applyConsistencies-Inert (χ ∷ χs) inert =
   applyConsistencies-Inert χs (applyStoreChange-Inert χ inert)
 
 gen-safe-source-nonvar : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
@@ -420,7 +422,7 @@ extra-cast-right : ∀ {Δᴸ Δᴿ Δ}
   → (c′ : ν ⊢ B ∼ B′)
   → (q : CTI.impEnvⁱ ρ ⊢ A ⊑ renameᵗ (toRenameᵗ ηᴿ) B′)
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ Δ′ ∈ TyCtx ]
-    Σ[ χs ∈ R.StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]
     Σ[ ηᴸ′ ∈ Δᴸ ↪ᵗ Δ′ ] Σ[ ηᴿ′ ∈ Δᴿ′ ↪ᵗ Δ′ ]
     Σ[ ρ′ ∈ CTI.StoreImp Δ′ ]
     Σ[ γ′ ∈ GTI.CtxImp (CTI.impEnvⁱ ρ′) ]
@@ -428,10 +430,10 @@ extra-cast-right : ∀ {Δᴸ Δᴿ Δ}
     Σ[ transport⊑ ∈ (∀ {C : Ty Δᴿ}
       → CTI.impEnvⁱ ρ ⊢ A ⊑ renameᵗ (toRenameᵗ ηᴿ) C
       → CTI.impEnvⁱ ρ′
-          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (R.applyTys χs C)) ]
+          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (applyTys χs C)) ]
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
-       × (M′ ⟨ c′ ⟩ R.—↠[ χs ] N′)
+       × (M′ ⟨ c′ ⟩ —↠[ χs ] N′)
        × (ηᴸ′ ∣ ηᴿ′ ∣ ρ′ ∣ γ′ ⊢ᶜ M ⊑ N′ ∶ transport⊑ q))
 
 inst-catchup-right : ∀ {Δᴸ Δᴿ Δ}
@@ -451,7 +453,7 @@ inst-catchup-right : ∀ {Δᴸ Δᴿ Δ}
   → (B′≢★ : B′ ≢ ★)
   → (q : CTI.impEnvⁱ ρ ⊢ A ⊑ renameᵗ (toRenameᵗ ηᴿ) B′)
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ Δ′ ∈ TyCtx ]
-    Σ[ χs ∈ R.StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]
     Σ[ ηᴸ′ ∈ Δᴸ ↪ᵗ Δ′ ] Σ[ ηᴿ′ ∈ Δᴿ′ ↪ᵗ Δ′ ]
     Σ[ ρ′ ∈ CTI.StoreImp Δ′ ]
     Σ[ γ′ ∈ GTI.CtxImp (CTI.impEnvⁱ ρ′) ]
@@ -459,10 +461,10 @@ inst-catchup-right : ∀ {Δᴸ Δᴿ Δ}
     Σ[ transport⊑ ∈ (∀ {C : Ty Δᴿ}
       → CTI.impEnvⁱ ρ ⊢ A ⊑ renameᵗ (toRenameᵗ ηᴿ) C
       → CTI.impEnvⁱ ρ′
-          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (R.applyTys χs C)) ]
+          ⊢ A′ ⊑ renameᵗ (toRenameᵗ ηᴿ′) (applyTys χs C)) ]
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
-       × (M′ ⟨ (inst c′) B′≢★ ⟩ R.—↠[ χs ] N′)
+       × (M′ ⟨ (inst c′) B′≢★ ⟩ —↠[ χs ] N′)
        × (ηᴸ′ ∣ ηᴿ′ ∣ ρ′ ∣ γ′ ⊢ᶜ M ⊑ N′ ∶ transport⊑ q))
 
 -- Case: c′ = id a
@@ -473,8 +475,8 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
   Δᴿ , Δ , _ , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
   vM′ ,
   ((M′ ⟨ id a ⟩)
-    R.—→[ R.keep ]⟨ R.pure-step (R.β-id vM′) ⟩
-  M′ R.∎[]) ,
+    —→[ keep ]⟨ pure-step (β-id vM′) ⟩
+  M′ ∎[]) ,
   subst≡ (λ r → ηᴸ ∣ ηᴿ ∣ ρ ∣ γ ⊢ᶜ M ⊑ M′ ∶ r)
     (PI.⊑-unique p q) M⊑M′
 
@@ -483,8 +485,8 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     {ηᴸ = ηᴸ} {ηᴿ = ηᴿ} {ρ = ρ} {γ = γ}
     {M = M} {M′ = M′} {A = A} {B′ = B′}
     (CTI.rename⊑renameᶜ categorize M⊑M′) vM vM′ (c ↦ d) q =
-  Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
-  vM′ 《 fun 》 , ((M′ ⟨ c ↦ d ⟩) R.∎[]) ,
+  Δᴿ , Δ , [] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
+  vM′ 《 fun 》 , ((M′ ⟨ c ↦ d ⟩) ∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ (renameᵐᶜ ηᴿ (c ↦ d)) M⊑M′ q)
 
@@ -493,8 +495,8 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     {ηᴸ = ηᴸ} {ηᴿ = ηᴿ} {ρ = ρ} {γ = γ}
     {M = M} {M′ = M′} {A = A} {B′ = B′}
     (CTI.rename⊑renameᶜ categorize M⊑M′) vM vM′ (∀ᶜ c) q =
-  Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
-  vM′ 《 all 》 , ((M′ ⟨ ∀ᶜ c ⟩) R.∎[]) ,
+  Δᴿ , Δ , [] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
+  vM′ 《 all 》 , ((M′ ⟨ ∀ᶜ c ⟩) ∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ (renameᵐᶜ ηᴿ (∀ᶜ c)) M⊑M′ q)
 
@@ -513,11 +515,11 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ .(C.idᵍ Gᵍ) ⦃ Bns ⦄) q
     | Prog.same
     rewrite nonStar-unique Bns (C.ground-nonstar Gᵍ) =
-  Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
+  Δᴿ , Δ , [] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
   vM′ 《 inj ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
     ⦃ Gns = C.ground-nonstar Gᵍ ⦄ 》 ,
   ((M′ ⟨ _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
-    ⦃ C.ground-nonstar Gᵍ ⦄ ⟩) R.∎[]) ,
+    ⦃ C.ground-nonstar Gᵍ ⦄ ⟩) ∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ
@@ -545,7 +547,7 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     | Δᴿ′ , Δ′ , χs , ηᴸ′ , ηᴿ′ , ρ′ , γ′ , A′ ,
       transport⊑ , N′ , vN′ , M′c↠N′ ,
       CTI.rename⊑renameᶜ categorize′ M⊑N′ =
-  Δᴿ′ , Δ′ , R.keep R.∷ χs , ηᴸ′ , ηᴿ′ , ρ′ , γ′ ,
+  Δᴿ′ , Δ′ , keep ∷ χs , ηᴸ′ , ηᴿ′ , ρ′ , γ′ ,
   A′ , transport⊑ ,
   N′
     ⟨ applyConsistencies χs
@@ -556,15 +558,22 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
         (inj ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
           ⦃ Gns = C.ground-nonstar Gᵍ ⦄) 》 ,
   ((M′ ⟨ _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ c ⦃ Bns ⦄ ⟩)
-    R.—→[ R.keep ]⟨
-      R.pure-step
-      (R.ground ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
+    —→[ keep ]⟨
+      pure-step
+      (ground ⦃ Gᵍ = Gᵍ ⦄ ⦃ G∼★ = G∼★ ⦄
         ⦃ Ans = Bns ⦄ ⦃ Gns = C.ground-nonstar Gᵍ ⦄ vM′ B≢G)
     ⟩
-  cast-↠
-    (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
-      ⦃ C.ground-nonstar Gᵍ ⦄)
-    M′c↠N′) ,
+  _
+    —↠[ χs ]⟨
+      cast-↠
+        (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
+          ⦃ C.ground-nonstar Gᵍ ⦄)
+        M′c↠N′
+    ⟩
+  (N′
+    ⟨ applyConsistencies χs
+        (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (C.idᵍ Gᵍ)
+          ⦃ C.ground-nonstar Gᵍ ⦄) ⟩) ∎[]) ,
   CTI.rename⊑renameᶜ categorize′
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ′
@@ -615,17 +624,17 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
         ⦃ Gns = Hns ⦄ vW refl
     | yes refl | Prog.same
     rewrite nonStar-unique Bns Hns | ground-unique g h =
-  Δᴿ , Δ , R.keep R.∷ R.[] , ηᴸ , ηᴿ , ρ , γ , A ,
+  Δᴿ , Δ , keep ∷ [] , ηᴸ , ηᴿ , ρ , γ , A ,
   (λ r → r) , W ,
   vW ,
   ((M′ ⟨ ？_ ⦃ Gᵍ = h ⦄ ⦃ ★∼G = ★∼G ⦄ (C.idᵍ h)
       ⦃ Bns = Hns ⦄ ⟩)
-    R.—→[ R.keep ]⟨
-      R.pure-step
-      (R.tag-untag ⦃ Gᵍ = h ⦄ ⦃ G∼★ = H∼★ ⦄
+    —→[ keep ]⟨
+      pure-step
+      (tag-untag ⦃ Gᵍ = h ⦄ ⦃ G∼★ = H∼★ ⦄
         ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = Hns ⦄ vW)
     ⟩
-  W R.∎[]) ,
+  W ∎[]) ,
   RII.right-inj-inversion-indexed vM
     (CTI.rename⊑renameᶜ categorize M⊑M′ᶜ) q
 
@@ -659,24 +668,26 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
       transport⊑ , N′ , vN′ , Wc↠N′ , M⊑N′
     rewrite ground-unique g h
           | sym (nonStar-unique Hns (C.ground-nonstar h)) =
-  Δᴿ′ , Δ′ , R.keep R.∷ R.keep R.∷ χs ,
+  Δᴿ′ , Δ′ , keep ∷ keep ∷ χs ,
   ηᴸ′ , ηᴿ′ , ρ′ , γ′ , A′ , transport⊑ , N′ , vN′ ,
   (_
-    R.—→[ R.keep ]⟨
-      R.pure-step
-      (R.expand ⦃ Gᵍ = h ⦄ ⦃ ★∼G = ★∼G ⦄
+    —→[ keep ]⟨
+      pure-step
+      (expand ⦃ Gᵍ = h ⦄ ⦃ ★∼G = ★∼G ⦄
         ⦃ Bns = Bns ⦄ ⦃ Gns = Hns ⦄
         vM′ (λ eq → B′≢G (sym eq)))
     ⟩
   _
-    R.—→[ R.keep ]⟨
-      (R.ξ-⟨⟩
-        (R.pure-step
-          (R.tag-untag ⦃ Gᵍ = h ⦄ ⦃ G∼★ = H∼★ ⦄
-            ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = Hns ⦄ vW))
-        refl)
+    —→[ keep ]⟨
+        (ξ-⟨⟩
+          (pure-step
+            (tag-untag ⦃ Gᵍ = h ⦄ ⦃ G∼★ = H∼★ ⦄
+              ⦃ ★∼G = ★∼G ⦄ ⦃ Gns = Hns ⦄ vW))
+          refl)
     ⟩
-  Wc↠N′) ,
+  _
+    —↠[ χs ]⟨ Wc↠N′ ⟩
+  N′ ∎[]) ,
   M⊑N′
 
 -- Subcase: G ≟Ty H = no G≢H
@@ -726,9 +737,9 @@ extra-cast-right {Δᴿ = Δᴿ} {Δ = Δ}
     (CTI.rename⊑renameᶜ categorize M⊑M′) vM vM′
     (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) q
     =
-  Δᴿ , Δ , R.[] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
+  Δᴿ , Δ , [] , ηᴸ , ηᴿ , ρ , γ , A , (λ r → r) , _ ,
   vM′ 《 genᵥ A≢★ (gen-safe c A≢★ Bnv z∈B) 》 ,
-  ((M′ ⟨ gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★ ⟩) R.∎[]) ,
+  ((M′ ⟨ gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★ ⟩) ∎[]) ,
   CTI.rename⊑renameᶜ categorize
     (CTI.⊑castᶜ
       (renameᵐᶜ ηᴿ (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★))

--- a/GTSFImp/proof/Reduction.agda
+++ b/GTSFImp/proof/Reduction.agda
@@ -1,0 +1,85 @@
+module proof.Reduction where
+
+-- File Charter:
+--   * Proof lemmas for the store-changing reduction relation.
+--   * Supplies cast congruence over multi-step reduction and inert
+--     preservation under store-change transport.
+--   * Depends on Reduction for the base relations and proof.Consistency for
+--     generated-cast safety.
+
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality using (refl)
+  renaming (subst to subst≡)
+
+open import Types
+open import Consistency hiding (keep)
+import Consistency as C
+open import CastTerms using (Term; _⟨_⟩; Inert; inj; fun; all; genᵥ)
+open import Reduction
+open import proof.Consistency using (gen-safe)
+import proof.Imprecision as PI
+open import proof.TypeInTermSubst using
+  (rename-star-injective; rename-occurs)
+
+cast-↠ : ∀ {Δ Δ′} {M : Term Δ} {N : Term Δ′}
+    {χs : StoreChanges Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
+  → (c : μ ⊢ A ∼ B)
+  → M —↠[ χs ] N
+  → M ⟨ c ⟩ —↠[ χs ] N ⟨ χs ▶ᶜ c ⟩
+cast-↠ {M = M} c (_ ∎[]) = (M ⟨ c ⟩) ∎[]
+cast-↠ {M = M} {N = P} {χs = χ ∷ χs} c
+    (_ —→[ χ ]⟨ M→N ⟩ N↠P) =
+  (M ⟨ c ⟩)
+    —→[ χ ]⟨ ξ-⟨⟩ M→N refl ⟩
+  _
+    —↠[ χs ]⟨ cast-↠ (χ ▷ᶜ c) N↠P ⟩
+  (P ⟨ χs ▶ᶜ (χ ▷ᶜ c) ⟩) ∎[]
+
+applyStoreChange-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
+    {c : μ ⊢ A ∼ B}
+  → (χ : StoreChange Δ Δ′)
+  → Inert c
+  → Inert (χ ▷ᶜ c)
+applyStoreChange-Inert keep inert = inert
+applyStoreChange-Inert (bind A)
+    (inj ⦃ Gᵍ = ★⇒★ ⦄ ⦃ G∼★ = C.⇒∼★ ⦄ ⦃ Gns = Gns ⦄) =
+  inj ⦃ Gᵍ = ★⇒★ ⦄ ⦃ G∼★ = C.⇒∼★ ⦄
+    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
+applyStoreChange-Inert (bind A)
+    (inj ⦃ Gᵍ = ‵ ι ⦄ ⦃ G∼★ = C.ι∼★ ⦄ ⦃ Gns = Gns ⦄) =
+  inj ⦃ Gᵍ = ‵ ι ⦄ ⦃ G∼★ = C.ι∼★ ⦄
+    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
+applyStoreChange-Inert (bind A)
+    (inj {G = ＇ X} ⦃ Gᵍ = ＇ .X ⦄
+      ⦃ G∼★ = C.X∼★ᵍ eq ⦄ ⦃ Gns = Gns ⦄) =
+  inj ⦃ Gᵍ = ＇ Fin.suc X ⦄ ⦃ G∼★ = C.X∼★ᵍ eq ⦄
+    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
+applyStoreChange-Inert (bind A)
+    (inj ⦃ Gᵍ = ∀★ ⦄ ⦃ G∼★ = C.∀∼★ ⦄ ⦃ Gns = Gns ⦄) =
+  inj ⦃ Gᵍ = ∀★ ⦄ ⦃ G∼★ = C.∀∼★ ⦄
+    ⦃ Gns = C.renameNonStar Fin.suc Gns ⦄
+applyStoreChange-Inert (bind A) fun = fun
+applyStoreChange-Inert (bind A) all = all
+applyStoreChange-Inert (bind A)
+    (genᵥ {A = A₀} {B = B} {c = c}
+      ⦃ Bnv = Bnv ⦄ ⦃ z∈B = z∈B ⦄ A≢★ safe) =
+  subst≡
+    (λ z → Inert (gen_ ⦃ Bnv = renameNonVar (extᵗ Fin.suc) Bnv ⦄
+      ⦃ z∈B = z ⦄ _ _))
+    (PI.∈ᵗ-unique (rename-occurs (extᵗ Fin.suc) z∈B) _)
+    (genᵥ ⦃ Bnv = renameNonVar (extᵗ Fin.suc) Bnv ⦄
+      ⦃ z∈B = rename-occurs (extᵗ Fin.suc) z∈B ⦄
+      A′≢★
+      (gen-safe _ A′≢★ (renameNonVar (extᵗ Fin.suc) Bnv)
+        (rename-occurs (extᵗ Fin.suc) z∈B)))
+  where
+  A′≢★ = λ eq → A≢★ (rename-star-injective Fin.suc eq)
+
+applyConsistencies-Inert : ∀ {Δ Δ′} {μ : Env∼ Δ} {A B : Ty Δ}
+    {c : μ ⊢ A ∼ B}
+  → (χs : StoreChanges Δ Δ′)
+  → Inert c
+  → Inert (χs ▶ᶜ c)
+applyConsistencies-Inert [] inert = inert
+applyConsistencies-Inert (χ ∷ χs) inert =
+  applyConsistencies-Inert χs (applyStoreChange-Inert χ inert)

--- a/GTSFImp/proof/TypeInTermSubst.agda
+++ b/GTSFImp/proof/TypeInTermSubst.agda
@@ -22,7 +22,7 @@ open import Consistency
 open import Conversion
 open import Primitives
 open import CastTerms
-open import proof.TypeSafety.Progress using (gen-safe)
+open import proof.Consistency using (gen-safe)
 
 ------------------------------------------------------------------------
 -- Store lookup transport

--- a/GTSFImp/proof/TypeSafety/Progress.agda
+++ b/GTSFImp/proof/TypeSafety/Progress.agda
@@ -22,6 +22,7 @@ open import Conversion
 open import Primitives
 open import CastTerms
 open import Reduction
+open import proof.Consistency using (gen-safe)
 
 ------------------------------------------------------------------------
 -- Progress and canonical views
@@ -448,48 +449,6 @@ from-ground ∀★ (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) =
   other (λ { refl → occurs-star-impossible z∈B })
 from-ground ∀★ bot-intro = other (λ ())
 
-------------------------------------------------------------------------
--- Polymorphic cast classification
-------------------------------------------------------------------------
-
-data Preimage {Δ Δ′ : TyCtx} (ρ : Δ ⇒ʳ Δ′) (Y : TyVar Δ′)
-    (A : Ty Δ) : Set where
-  found : (X : TyVar Δ) → ρ X ≡ Y → X ∈ᵗ A → Preimage ρ Y A
-
-rename-preimage : ∀ {Δ Δ′} {ρ : Δ ⇒ʳ Δ′} {Y : TyVar Δ′}
-    {A : Ty Δ}
-  → Y ∈ᵗ renameᵗ ρ A
-  → Preimage ρ Y A
-rename-preimage {A = ＇ X} var-∈ = found X refl var-∈
-rename-preimage {A = ‵ ι} ()
-rename-preimage {A = ★} ()
-rename-preimage {A = A ⇒ B} (∈-fun-left Y∈A)
-    with rename-preimage Y∈A
-rename-preimage {A = A ⇒ B} (∈-fun-left Y∈A)
-    | found X eq X∈A =
-  found X eq (∈-fun-left X∈A)
-rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
-    with rename-preimage Y∈B
-rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
-    | found X eq X∈B with occurs? X A
-rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
-    | found X eq X∈B | present X∈A =
-  found X eq (∈-fun-left X∈A)
-rename-preimage {A = A ⇒ B} (∈-fun-right Y∉A Y∈B)
-    | found X eq X∈B | absent X∉A =
-  found X eq (∈-fun-right X∉A X∈B)
-rename-preimage {A = `∀ A} (∈-all Y∈A)
-    with rename-preimage Y∈A
-rename-preimage {A = `∀ A} (∈-all Y∈A)
-    | found Fin.zero () X∈A
-rename-preimage {A = `∀ A} (∈-all Y∈A)
-    | found (Fin.suc X) refl X∈A =
-  found X refl (∈-all X∈A)
-
-zero-not-shift : ∀ {Δ} {A : Ty Δ} → 0 ∈ᵗ ⇑ᵗ A → ⊥
-zero-not-shift z∈ with rename-preimage z∈
-zero-not-shift z∈ | found X () X∈A
-
 no-to-base : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ} {X : TyVar Δ} {ι}
   → μ ⊢ A ∼ ‵ ι
   → X ∈ᵗ A
@@ -515,47 +474,6 @@ occurrence-nonstar var-∈ = nonstar-X
 occurrence-nonstar (∈-fun-left X∈A) = nonstar-⇒
 occurrence-nonstar (∈-fun-right X∉A X∈B) = nonstar-⇒
 occurrence-nonstar (∈-all X∈A) = nonstar-∀
-
-shift-star-injective : ∀ {Δ} {A : Ty Δ}
-  → ⇑ᵗ A ≡ ★
-  → A ≡ ★
-shift-star-injective {A = ＇ X} ()
-shift-star-injective {A = ‵ ι} ()
-shift-star-injective {A = ★} refl = refl
-shift-star-injective {A = A ⇒ B} ()
-shift-star-injective {A = `∀ A} ()
-
-gen-safe′ : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ}
-    {C B : Ty (suc Δ)}
-  → (c : genᵐ μ ⊢ C ∼ B)
-  → C ≡ ⇑ᵗ A
-  → A ≢ ★
-  → NonVar B
-  → 0 ∈ᵗ B
-  → GenSafe c
-gen-safe′ (id a) refl A≠★ Bnv z∈B =
-  ⊥-elim (zero-not-shift z∈B)
-gen-safe′ (c ↦ d) eq A≠★ Bnv z∈B = safe-⇒
-gen-safe′ (∀ᶜ c) eq A≠★ Bnv z∈B = safe-∀
-gen-safe′ (_! ⦃ g ⦄ c ⦃ Ans ⦄) eq A≠★ Bnv ()
-gen-safe′ (？_ ⦃ g ⦄ c ⦃ Bns ⦄)
-    eq A≠★ Bnv z∈B =
-  ⊥-elim (A≠★ (shift-star-injective (sym eq)))
-gen-safe′ (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) eq A≠★ Bnv z∈B =
-  safe-inst B≢★
-gen-safe′ (gen_ {A = C} ⦃ Cnv ⦄ ⦃ z∈C ⦄ c C≢★)
-    eq A≠★ Bnv z∈B =
-  safe-gen C≢★ (gen-safe′ c refl C≢★ Cnv z∈C)
-gen-safe′ bot-elim eq A≠★ Bnv (∈-all ())
-gen-safe′ bot-intro eq A≠★ Bnv (∈-all ())
-
-gen-safe : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ} {B : Ty (suc Δ)}
-  → (c : genᵐ μ ⊢ ⇑ᵗ A ∼ B)
-  → A ≢ ★
-  → NonVar B
-  → 0 ∈ᵗ B
-  → GenSafe c
-gen-safe c A≠★ Bnv z∈B = gen-safe′ c refl A≠★ Bnv z∈B
 
 ------------------------------------------------------------------------
 -- Progress for values under casts and conversions


### PR DESCRIPTION
## Summary

- document that Agda reduction-sequence chains should always end with `∎` so the final term is explicit
- document the transitive reduction chain syntax, including store-changing `_—↠[_]⟨_⟩_`
- add store-changing reduction tail-chain notation and sequence transport syntax `▶ᵉ`/`▶ᶜ` to `GTSFImp/Reduction.agda`
- move shared reduction proof helpers (`cast-↠`, inert preservation under store-change sequences) into `GTSFImp/proof/Reduction.agda`
- move generated-cast safety support into `GTSFImp/proof/Consistency.agda`
- reformat GTSFImp DGG reduction witnesses in `ExtraCastRightProbe.agda` to use `_∎[]`, `_—→[_]⟨_⟩_`, and `_—↠[_]⟨_⟩_`
- keep the existing partial inst catch-up holes unchanged

## Validation

- `git diff --check`
- `agda Reduction.agda`
- `agda proof/Consistency.agda`
- `agda proof/Reduction.agda`
- `agda proof/TypeSafety/Progress.agda`
- `agda Eval.agda`
- `agda proof/DGG/ExtraCastRightProbe.agda` reaches the pre-existing `{!!}` holes in the later inst catch-up section
- `agda All.agda` still reaches the existing `proof.DGG.CompilePreservesImprecision.agda` error