### PR TITLE
Add proof-irrelevant alternative consistency relation

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -4,6 +4,7 @@ import Types
 import TyStore
 import TermCtx
 import Consistency
+import Consistency2
 import ConsistencyExamples
 import Conversion
 import Imprecision
@@ -20,6 +21,7 @@ import proof.TypeSafety.Preservation
 import proof.ImprecisionConsistency
 import proof.Imprecision
 import proof.Consistency
+import proof.Consistency2
 import proof.Reduction
 import proof.DGG.CastTermImprecision
 import proof.DGG.CompilePreservesImprecision

--- a/GTSFImp/Consistency2.agda
+++ b/GTSFImp/Consistency2.agda
@@ -1,0 +1,412 @@
+module Consistency2 where
+
+-- File Charter:
+--   * Defines a deterministic common-lower selector for type consistency.
+--   * Defines consistency as successful selection by `lower?`.
+--   * Proves proof irrelevance of the resulting consistency evidence.
+--   * Leaves equivalence with declarative consistency to
+--     `proof.Consistency2`.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Fin using (zero; suc)
+import Data.Fin.Properties as Fin
+open import Data.Maybe using (Maybe; just; nothing; map)
+open import Data.Nat using (ℕ; _+_; _<_; _≤_; s≤s)
+import Data.Nat as Nat
+import Data.Nat.Induction as NatInduction
+open import Data.Nat.Properties using
+  (+-mono-≤; +-monoʳ-≤; +-suc; m≤m+n; m≤n+m; n<1+n;
+   n≤1+n; ≤-<-trans)
+open import Induction.WellFounded using (Acc; acc)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; inspect; [_])
+open import Relation.Nullary using (no; yes)
+
+open import Types
+import Consistency as C
+import Imprecision as I
+
+------------------------------------------------------------------------
+-- The canonical imprecision environments induced by consistency
+------------------------------------------------------------------------
+
+leftᵐ : ∀ {Δ} → C.Env∼ Δ → I.ImpEnv Δ
+leftᵐ μ X with μ X
+leftᵐ μ X | C.X∼X = I.X⊑X
+leftᵐ μ X | C.X∼★ = I.X⊑X
+leftᵐ μ X | C.★∼X = I.X⊑★
+
+rightᵐ : ∀ {Δ} → C.Env∼ Δ → I.ImpEnv Δ
+rightᵐ μ X with μ X
+rightᵐ μ X | C.X∼X = I.X⊑X
+rightᵐ μ X | C.X∼★ = I.X⊑★
+rightᵐ μ X | C.★∼X = I.X⊑X
+
+------------------------------------------------------------------------
+-- Constructing imprecision to the dynamic type
+------------------------------------------------------------------------
+
+AllDynamic : ∀ {Δ} → I.ImpEnv Δ → Ty Δ → Set
+AllDynamic μ A = ∀ X → X ∈ᵗ A → μ X ≡ I.X⊑★
+
+dynamic-domain : ∀ {Δ} {μ : I.ImpEnv Δ} {A B : Ty Δ}
+  → AllDynamic μ (A ⇒ B)
+  → AllDynamic μ A
+dynamic-domain dynamic X X∈A = dynamic X (∈-fun-left X∈A)
+
+dynamic-codomain : ∀ {Δ} {μ : I.ImpEnv Δ} {A B : Ty Δ}
+  → AllDynamic μ (A ⇒ B)
+  → AllDynamic μ B
+dynamic-codomain {A = A} dynamic X X∈B with occurs? X A
+dynamic-codomain dynamic X X∈B | present X∈A =
+  dynamic X (∈-fun-left X∈A)
+dynamic-codomain dynamic X X∈B | absent X∉A =
+  dynamic X (∈-fun-right X∉A X∈B)
+
+dynamic-under-inst : ∀ {Δ} {μ : I.ImpEnv Δ}
+    {A : Ty (Nat.suc Δ)}
+  → AllDynamic μ (`∀ A)
+  → AllDynamic (I.instᵐ μ) A
+dynamic-under-inst dynamic zero X∈A = refl
+dynamic-under-inst dynamic (suc X) X∈A =
+  dynamic X (∈-all X∈A)
+
+dynamic-under-ext : ∀ {Δ} {μ : I.ImpEnv Δ}
+    {A : Ty (Nat.suc Δ)}
+  → AllDynamic μ (`∀ A)
+  → zero ∉ᵗ A
+  → AllDynamic (I.extᵐ μ) A
+dynamic-under-ext dynamic zero∉A zero X∈A =
+  ⊥-elim (not-occurs zero∉A X∈A)
+  where
+  not-occurs : ∀ {Δ} {X : TyVar Δ} {B : Ty Δ}
+    → X ∉ᵗ B
+    → X ∈ᵗ B
+    → ⊥
+  not-occurs (∉-var X≠Y) var-∈ = X≠Y refl
+  not-occurs ∉-base ()
+  not-occurs ∉-star ()
+  not-occurs (∉-fun X∉B X∉C) (∈-fun-left X∈B) =
+    not-occurs X∉B X∈B
+  not-occurs (∉-fun X∉B X∉C) (∈-fun-right X∉B′ X∈C) =
+    not-occurs X∉C X∈C
+  not-occurs (∉-all X∉B) (∈-all X∈B) =
+    not-occurs X∉B X∈B
+dynamic-under-ext dynamic zero∉A (suc X) X∈A =
+  dynamic X (∈-all X∈A)
+
+data AllChoice {Δ : TyCtx} : Ty (Nat.suc Δ) → Set where
+  bottom-choice : AllChoice (＇ zero)
+  star-choice : AllChoice ★
+  inst-choice : ∀ {A}
+    → NonVar A
+    → zero ∈ᵗ A
+    → AllChoice A
+  structural-choice : ∀ {A}
+    → NonStar A
+    → zero ∉ᵗ A
+    → AllChoice A
+
+all-choice : ∀ {Δ} (A : Ty (Nat.suc Δ)) → AllChoice A
+all-choice (＇ zero) = bottom-choice
+all-choice (＇ (suc X)) =
+  structural-choice nonstar-X (∉-var (λ ()))
+all-choice (‵ ι) = structural-choice nonstar-ι ∉-base
+all-choice ★ = star-choice
+all-choice (A ⇒ B) with occurs? zero (A ⇒ B)
+all-choice (A ⇒ B) | present zero∈A⇒B =
+  inst-choice nonvar-fun zero∈A⇒B
+all-choice (A ⇒ B) | absent zero∉A⇒B =
+  structural-choice nonstar-⇒ zero∉A⇒B
+all-choice (`∀ A) with occurs? zero (`∀ A)
+all-choice (`∀ A) | present zero∈∀A =
+  inst-choice nonvar-all zero∈∀A
+all-choice (`∀ A) | absent zero∉∀A =
+  structural-choice nonstar-∀ zero∉∀A
+
+to-star : ∀ {Δ} {μ : I.ImpEnv Δ} (A : Ty Δ)
+  → AllDynamic μ A
+  → I._⊢_⊑_ μ A ★
+to-star (＇ X) dynamic = I.X⊑★ (dynamic X var-∈)
+to-star (‵ ι) dynamic = I.ι⊑★
+to-star ★ dynamic = I.★⊑★
+to-star (A ⇒ B) dynamic =
+  I.⇒⊑★ (to-star A (dynamic-domain dynamic))
+        (to-star B (dynamic-codomain dynamic))
+to-star (`∀ A) dynamic = decide (all-choice A)
+  where
+  decide : AllChoice A → I._⊢_⊑_ _ (`∀ A) ★
+  decide bottom-choice = I.bot⊑★
+  decide star-choice = I.∀★⊑★
+  decide (inst-choice Anv zero∈A) =
+    I.∀⊑ Anv zero∈A (to-star A (dynamic-under-inst dynamic))
+  decide (structural-choice Ans zero∉A) =
+    I.∀⊑★ Ans (to-star A (dynamic-under-ext dynamic zero∉A))
+
+dynamic? : ∀ {Δ} (μ : I.ImpEnv Δ) (A : Ty Δ)
+  → Maybe (AllDynamic μ A)
+dynamic? μ (＇ X) with μ X | inspect μ X
+dynamic? μ (＇ X) | I.X⊑X | [ eq ] = nothing
+dynamic? μ (＇ X) | I.X⊑★ | [ eq ] =
+  just (λ { .X var-∈ → eq })
+dynamic? μ (‵ ι) = just (λ X ())
+dynamic? μ ★ = just (λ X ())
+dynamic? μ (A ⇒ B) with dynamic? μ A
+dynamic? μ (A ⇒ B) | nothing = nothing
+dynamic? μ (A ⇒ B) | just dynamic-A with dynamic? μ B
+dynamic? μ (A ⇒ B) | just dynamic-A | nothing = nothing
+dynamic? μ (A ⇒ B) | just dynamic-A | just dynamic-B =
+  just combine
+  where
+  combine : AllDynamic μ (A ⇒ B)
+  combine X (∈-fun-left X∈A) = dynamic-A X X∈A
+  combine X (∈-fun-right X∉A X∈B) = dynamic-B X X∈B
+dynamic? μ (`∀ A) with dynamic? (I.instᵐ μ) A
+dynamic? μ (`∀ A) | nothing = nothing
+dynamic? μ (`∀ A) | just dynamic-A =
+  just under-all
+  where
+  under-all : AllDynamic μ (`∀ A)
+  under-all X (∈-all X∈A) = dynamic-A (suc X) X∈A
+
+------------------------------------------------------------------------
+-- Proof-carrying search for a common lower bound
+------------------------------------------------------------------------
+
+record Lower {Δ : TyCtx} (φ ψ : I.ImpEnv Δ)
+    (A B : Ty Δ) : Set where
+  constructor lower
+  field
+    lower-type : Ty Δ
+    lower-left : I._⊢_⊑_ φ lower-type A
+    lower-right : I._⊢_⊑_ ψ lower-type B
+
+open Lower public
+
+refl⊑ : ∀ {Δ} (μ : I.ImpEnv Δ) (A : Ty Δ)
+  → I._⊢_⊑_ μ A A
+refl⊑ μ (＇ X) = I.X⊑X
+refl⊑ μ (‵ ι) = I.ι⊑ι
+refl⊑ μ ★ = I.★⊑★
+refl⊑ μ (A ⇒ B) = I.⇒⊑⇒ (refl⊑ μ A) (refl⊑ μ B)
+refl⊑ μ (`∀ A) = I.∀⊑∀ (refl⊑ (I.extᵐ μ) A)
+
+nonVar? : ∀ {Δ} (A : Ty Δ) → Maybe (NonVar A)
+nonVar? (＇ X) = nothing
+nonVar? (‵ ι) = just nonvar-base
+nonVar? ★ = just nonvar-star
+nonVar? (A ⇒ B) = just nonvar-fun
+nonVar? (`∀ A) = just nonvar-all
+
+infixr 3 _orElse_
+
+_orElse_ : ∀ {A : Set} → Maybe A → Maybe A → Maybe A
+just x orElse y = just x
+nothing orElse y = y
+
+arrow-lower : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A A′ B B′ : Ty Δ}
+  → Maybe (Lower φ ψ A A′)
+  → Maybe (Lower φ ψ B B′)
+  → Maybe (Lower φ ψ (A ⇒ B) (A′ ⇒ B′))
+arrow-lower nothing right = nothing
+arrow-lower (just left) nothing = nothing
+arrow-lower (just (lower C C⊑A C⊑A′))
+    (just (lower D D⊑B D⊑B′)) =
+  just (lower (C ⇒ D) (I.⇒⊑⇒ C⊑A D⊑B)
+                         (I.⇒⊑⇒ C⊑A′ D⊑B′))
+
+all-lower : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A B : Ty (Nat.suc Δ)}
+  → Maybe (Lower (I.extᵐ φ) (I.extᵐ ψ) A B)
+  → Maybe (Lower φ ψ (`∀ A) (`∀ B))
+all-lower nothing = nothing
+all-lower (just (lower D D⊑A D⊑B)) =
+  just (lower (`∀ D) (I.∀⊑∀ D⊑A) (I.∀⊑∀ D⊑B))
+
+inst-lower : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A : Ty (Nat.suc Δ)} {B : Ty Δ}
+  → Maybe (Lower (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ B))
+  → Maybe (Lower φ ψ (`∀ A) B)
+inst-lower nothing = nothing
+inst-lower (just (lower D D⊑A D⊑B)) with nonVar? D
+inst-lower (just (lower D D⊑A D⊑B)) | nothing = nothing
+inst-lower (just (lower D D⊑A D⊑B)) | just Dnv
+    with occurs? zero D
+inst-lower (just (lower D D⊑A D⊑B)) | just Dnv
+    | absent zero∉D = nothing
+inst-lower (just (lower D D⊑A D⊑B)) | just Dnv
+    | present zero∈D =
+  just (lower (`∀ D) (I.∀⊑∀ D⊑A)
+                         (I.∀⊑ Dnv zero∈D D⊑B))
+
+gen-lower : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A : Ty Δ} {B : Ty (Nat.suc Δ)}
+  → Maybe (Lower (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ A) B)
+  → Maybe (Lower φ ψ A (`∀ B))
+gen-lower nothing = nothing
+gen-lower (just (lower D D⊑A D⊑B)) with nonVar? D
+gen-lower (just (lower D D⊑A D⊑B)) | nothing = nothing
+gen-lower (just (lower D D⊑A D⊑B)) | just Dnv
+    with occurs? zero D
+gen-lower (just (lower D D⊑A D⊑B)) | just Dnv
+    | absent zero∉D = nothing
+gen-lower (just (lower D D⊑A D⊑B)) | just Dnv
+    | present zero∈D =
+  just (lower (`∀ D) (I.∀⊑ Dnv zero∈D D⊑A)
+                         (I.∀⊑∀ D⊑B))
+
+bot-lower : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+  → (A B : Ty (Nat.suc Δ))
+  → Maybe (Lower φ ψ (`∀ A) (`∀ B))
+bot-lower (＇ zero) ★ =
+  just (lower (`∀ (＇ zero)) (refl⊑ _ _) I.bot-elim)
+bot-lower ★ (＇ zero) =
+  just (lower (`∀ (＇ zero)) I.bot-elim (refl⊑ _ _))
+bot-lower A B = nothing
+
+size : ∀ {Δ} → Ty Δ → ℕ
+size (＇ X) = 1
+size (‵ ι) = 1
+size ★ = 1
+size (A ⇒ B) = 1 + size A + size B
+size (`∀ A) = 1 + size A
+
+size-rename : ∀ {Δ Δ′} (ρ : Δ ⇒ʳ Δ′) (A : Ty Δ)
+  → size (renameᵗ ρ A) ≡ size A
+size-rename ρ (＇ X) = refl
+size-rename ρ (‵ ι) = refl
+size-rename ρ ★ = refl
+size-rename ρ (A ⇒ B)
+    rewrite size-rename ρ A | size-rename ρ B =
+  refl
+size-rename ρ (`∀ A) rewrite size-rename (extᵗ ρ) A = refl
+
+size-shift : ∀ {Δ} (A : Ty Δ) → size (⇑ᵗ A) ≡ size A
+size-shift = size-rename suc
+
+arrow-left-size : ∀ {Δ} (A B A′ B′ : Ty Δ)
+  → size A + size A′ < size (A ⇒ B) + size (A′ ⇒ B′)
+arrow-left-size A B A′ B′ =
+  ≤-<-trans child≤components components<arrows
+  where
+  child≤components :
+      size A + size A′
+      ≤ (size A + size B) + (size A′ + size B′)
+  child≤components =
+    +-mono-≤ (m≤m+n (size A) (size B))
+             (m≤m+n (size A′) (size B′))
+
+  components<arrows :
+      (size A + size B) + (size A′ + size B′)
+      < size (A ⇒ B) + size (A′ ⇒ B′)
+  components<arrows =
+    s≤s
+      (+-monoʳ-≤ (size A + size B)
+        (n≤1+n (size A′ + size B′)))
+
+arrow-right-size : ∀ {Δ} (A B A′ B′ : Ty Δ)
+  → size B + size B′ < size (A ⇒ B) + size (A′ ⇒ B′)
+arrow-right-size A B A′ B′ =
+  ≤-<-trans child≤components components<arrows
+  where
+  child≤components :
+      size B + size B′
+      ≤ (size A + size B) + (size A′ + size B′)
+  child≤components =
+    +-mono-≤ (m≤n+m (size B) (size A))
+             (m≤n+m (size B′) (size A′))
+
+  components<arrows :
+      (size A + size B) + (size A′ + size B′)
+      < size (A ⇒ B) + size (A′ ⇒ B′)
+  components<arrows =
+    s≤s
+      (+-monoʳ-≤ (size A + size B)
+        (n≤1+n (size A′ + size B′)))
+
+all-size-less : ∀ {Δ} (A B : Ty (Nat.suc Δ))
+  → size A + size B < size (`∀ A) + size (`∀ B)
+all-size-less A B =
+  s≤s (+-monoʳ-≤ (size A) (n≤1+n (size B)))
+
+inst-size-less : ∀ {Δ} (A : Ty (Nat.suc Δ)) (B : Ty Δ)
+  → size A + size (⇑ᵗ B) < size (`∀ A) + size B
+inst-size-less A B rewrite size-shift B = n<1+n _
+
+gen-size-less : ∀ {Δ} (A : Ty Δ) (B : Ty (Nat.suc Δ))
+  → size (⇑ᵗ A) + size B < size A + size (`∀ B)
+gen-size-less A B rewrite size-shift A | +-suc (size A) (size B) =
+  n<1+n _
+
+lowerAcc : ∀ {Δ} (φ ψ : I.ImpEnv Δ) (A B : Ty Δ)
+  → Acc _<_ (size A + size B)
+  → Maybe (Lower φ ψ A B)
+lowerAcc φ ψ A ★ access with dynamic? ψ A
+lowerAcc φ ψ A ★ access | nothing = nothing
+lowerAcc φ ψ A ★ access | just dynamic =
+  just (lower A (refl⊑ φ A) (to-star A dynamic))
+lowerAcc φ ψ ★ B access with dynamic? φ B
+lowerAcc φ ψ ★ B access | nothing = nothing
+lowerAcc φ ψ ★ B access | just dynamic =
+  just (lower B (to-star B dynamic) (refl⊑ ψ B))
+lowerAcc φ ψ (＇ X) (＇ Y) access with X Fin.≟ Y
+lowerAcc φ ψ (＇ X) (＇ .X) access | yes refl =
+  just (lower (＇ X) I.X⊑X I.X⊑X)
+lowerAcc φ ψ (＇ X) (＇ Y) access | no X≠Y = nothing
+lowerAcc φ ψ (‵ ι) (‵ ι′) access with ι ≟Base ι′
+lowerAcc φ ψ (‵ ι) (‵ .ι) access | yes refl =
+  just (lower (‵ ι) I.ι⊑ι I.ι⊑ι)
+lowerAcc φ ψ (‵ ι) (‵ ι′) access | no ι≠ι′ = nothing
+lowerAcc φ ψ (A ⇒ B) (A′ ⇒ B′) (acc smaller) =
+  arrow-lower
+    (lowerAcc φ ψ A A′ (smaller (arrow-left-size A B A′ B′)))
+    (lowerAcc φ ψ B B′ (smaller (arrow-right-size A B A′ B′)))
+lowerAcc φ ψ (`∀ A) (`∀ B) (acc smaller) =
+  all-lower
+    (lowerAcc (I.extᵐ φ) (I.extᵐ ψ) A B
+      (smaller (all-size-less A B)))
+  orElse
+  (inst-lower
+    (lowerAcc (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ (`∀ B))
+      (smaller (inst-size-less A (`∀ B)))))
+  orElse
+  gen-lower
+    (lowerAcc (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ (`∀ A)) B
+      (smaller (gen-size-less (`∀ A) B)))
+  orElse
+  bot-lower A B
+lowerAcc φ ψ (`∀ A) B (acc smaller) =
+  inst-lower
+    (lowerAcc (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ B)
+      (smaller (inst-size-less A B)))
+lowerAcc φ ψ A (`∀ B) (acc smaller) =
+  gen-lower
+    (lowerAcc (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ A) B
+      (smaller (gen-size-less A B)))
+lowerAcc φ ψ A B access = nothing
+
+------------------------------------------------------------------------
+-- The unique consistency relation
+------------------------------------------------------------------------
+
+data IsJust {A : Set} : Maybe A → Set where
+  is-just : ∀ {x} → IsJust (just x)
+
+is-just-unique : ∀ {A : Set} {value : Maybe A}
+  → (p q : IsJust value)
+  → p ≡ q
+is-just-unique is-just is-just = refl
+
+lower? : ∀ {Δ} → Ty Δ → Ty Δ → Maybe (Ty Δ)
+lower? A B =
+  map lower-type
+    (lowerAcc I.idᵐ I.idᵐ A B (NatInduction.<-wellFounded _))
+
+infix 4 _∼ᵘ_
+
+_∼ᵘ_ : ∀ {Δ} → Ty Δ → Ty Δ → Set
+A ∼ᵘ B = IsJust (lower? A B)
+
+∼ᵘ-unique : ∀ {Δ} {A B : Ty Δ} (c d : A ∼ᵘ B) → c ≡ d
+∼ᵘ-unique = is-just-unique

--- a/GTSFImp/proof/Consistency2.agda
+++ b/GTSFImp/proof/Consistency2.agda
@@ -1,0 +1,575 @@
+module proof.Consistency2 where
+
+-- File Charter:
+--   * Proves that the unique consistency relation in `Consistency2` is
+--     equivalent to declarative consistency.
+--   * Uses the existing common-lower characterization for soundness.
+--   * Proves completeness by following a declarative derivation through the
+--     deterministic lower-bound search.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Fin using (zero; suc)
+import Data.Fin.Properties as Fin
+open import Data.Maybe using (Maybe; just; nothing; map)
+open import Data.Nat using (_+_; _<_)
+import Data.Nat as Nat
+import Data.Nat.Induction as NatInduction
+open import Data.Product using (_×_; _,_; ∃)
+open import Induction.WellFounded using (Acc; acc)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; inspect; [_]; sym; trans)
+open import Relation.Nullary using (no; yes)
+
+open import Types
+import Consistency as C
+open import Consistency2
+import Imprecision as I
+open import proof.ImprecisionConsistency
+  using (LowerEnv; VarLower; both-to-star; common-lower-consistent;
+         extend-lower-env; identity-lower-env; instantiate-left-lower-env;
+         instantiate-right-lower-env; source-nonvar-from-target;
+         target-occurs-source; shift-occurs; unshift-occurs; var-from-star;
+         var-refl; var-to-star)
+
+------------------------------------------------------------------------
+-- Small facts about successful searches
+------------------------------------------------------------------------
+
+map-success : ∀ {A B : Set} {f : A → B} {value : Maybe A}
+  → IsJust value
+  → IsJust (map f value)
+map-success is-just = is-just
+
+orElse-left : ∀ {A : Set} {left right : Maybe A}
+  → IsJust left
+  → IsJust (left orElse right)
+orElse-left is-just = is-just
+
+orElse-right : ∀ {A : Set} {left right : Maybe A}
+  → IsJust right
+  → IsJust (left orElse right)
+orElse-right {left = just x} success = is-just
+orElse-right {left = nothing} success = success
+
+four-second : ∀ {A : Set} (first second third fourth : Maybe A)
+  → IsJust second
+  → IsJust (first orElse second orElse third orElse fourth)
+four-second (just x) second third fourth success = is-just
+four-second nothing (just x) third fourth is-just = is-just
+
+four-third : ∀ {A : Set} (first second third fourth : Maybe A)
+  → IsJust third
+  → IsJust (first orElse second orElse third orElse fourth)
+four-third (just x) second third fourth success = is-just
+four-third nothing (just x) third fourth success = is-just
+four-third nothing nothing (just x) fourth is-just = is-just
+
+four-fourth : ∀ {A : Set} (first second third fourth : Maybe A)
+  → IsJust fourth
+  → IsJust (first orElse second orElse third orElse fourth)
+four-fourth (just x) second third fourth success = is-just
+four-fourth nothing (just x) third fourth success = is-just
+four-fourth nothing nothing (just x) fourth success = is-just
+four-fourth nothing nothing nothing (just x) is-just = is-just
+
+arrow-lower-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A A′ B B′ : Ty Δ}
+    {left : Maybe (Lower φ ψ A A′)}
+    {right : Maybe (Lower φ ψ B B′)}
+  → IsJust left
+  → IsJust right
+  → IsJust (arrow-lower left right)
+arrow-lower-success is-just is-just = is-just
+
+all-lower-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A B : Ty (Nat.suc Δ)}
+    {result : Maybe (Lower (I.extᵐ φ) (I.extᵐ ψ) A B)}
+  → IsJust result
+  → IsJust (all-lower result)
+all-lower-success is-just = is-just
+
+nonVar-success : ∀ {Δ} {A : Ty Δ}
+  → NonVar A
+  → IsJust (nonVar? A)
+nonVar-success nonvar-base = is-just
+nonVar-success nonvar-star = is-just
+nonVar-success nonvar-fun = is-just
+nonVar-success nonvar-all = is-just
+
+not-occurs : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → X ∉ᵗ A
+  → X ∈ᵗ A
+  → ⊥
+not-occurs (∉-var X≠Y) var-∈ = X≠Y refl
+not-occurs ∉-base ()
+not-occurs ∉-star ()
+not-occurs (∉-fun X∉A X∉B) (∈-fun-left X∈A) =
+  not-occurs X∉A X∈A
+not-occurs (∉-fun X∉A X∉B) (∈-fun-right X∉A′ X∈B) =
+  not-occurs X∉B X∈B
+not-occurs (∉-all X∉A) (∈-all X∈A) =
+  not-occurs X∉A X∈A
+
+occurs-success : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → X ∈ᵗ A
+  → ∃ λ X∈A → occurs? X A ≡ present X∈A
+occurs-success {X = X} {A = A} X∈A with occurs? X A
+occurs-success X∈A | present X∈A′ = X∈A′ , refl
+occurs-success X∈A | absent X∉A = ⊥-elim (not-occurs X∉A X∈A)
+
+inst-lower-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A : Ty (Nat.suc Δ)} {B : Ty Δ}
+    {result : Maybe (Lower (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ B))}
+  → NonVar A
+  → zero ∈ᵗ A
+  → IsJust result
+  → IsJust (inst-lower result)
+inst-lower-success {result = just (lower D D⊑A D⊑B)} Anv zero∈A
+    is-just
+    with nonVar? D | nonVar-success
+      (source-nonvar-from-target D⊑A Anv zero∈A)
+inst-lower-success {result = just (lower D D⊑A D⊑B)} Anv zero∈A
+    is-just | nothing | ()
+inst-lower-success {result = just (lower D D⊑A D⊑B)} Anv zero∈A
+    is-just | just Dnv | is-just
+    with occurs? zero D | occurs-success (target-occurs-source D⊑A zero∈A)
+inst-lower-success {result = just (lower D D⊑A D⊑B)} Anv zero∈A
+    is-just | just Dnv | is-just | absent zero∉D | D∈ , ()
+inst-lower-success {result = just (lower D D⊑A D⊑B)} Anv zero∈A
+    is-just | just Dnv | is-just | present zero∈D | D∈ , refl =
+  is-just
+
+gen-lower-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+    {A : Ty Δ} {B : Ty (Nat.suc Δ)}
+    {result : Maybe (Lower (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ A) B)}
+  → NonVar B
+  → zero ∈ᵗ B
+  → IsJust result
+  → IsJust (gen-lower result)
+gen-lower-success {result = just (lower D D⊑A D⊑B)} Bnv zero∈B
+    is-just
+    with nonVar? D | nonVar-success
+      (source-nonvar-from-target D⊑B Bnv zero∈B)
+gen-lower-success {result = just (lower D D⊑A D⊑B)} Bnv zero∈B
+    is-just | nothing | ()
+gen-lower-success {result = just (lower D D⊑A D⊑B)} Bnv zero∈B
+    is-just | just Dnv | is-just
+    with occurs? zero D | occurs-success (target-occurs-source D⊑B zero∈B)
+gen-lower-success {result = just (lower D D⊑A D⊑B)} Bnv zero∈B
+    is-just | just Dnv | is-just | absent zero∉D | D∈ , ()
+gen-lower-success {result = just (lower D D⊑A D⊑B)} Bnv zero∈B
+    is-just | just Dnv | is-just | present zero∈D | D∈ , refl =
+  is-just
+
+bot-left-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+  → IsJust (bot-lower {φ = φ} {ψ = ψ} (＇ zero) ★)
+bot-left-success = is-just
+
+bot-right-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
+  → IsJust (bot-lower {φ = φ} {ψ = ψ} ★ (＇ zero))
+bot-right-success = is-just
+
+------------------------------------------------------------------------
+-- Dynamic-occurrence tests are complete
+------------------------------------------------------------------------
+
+dynamic-success : ∀ {Δ} {μ : I.ImpEnv Δ} {A : Ty Δ}
+  → AllDynamic μ A
+  → IsJust (dynamic? μ A)
+dynamic-success {μ = μ} {A = ＇ X} dynamic
+    with μ X | inspect μ X
+dynamic-success {μ = μ} {A = ＇ X} dynamic
+    | I.X⊑X | [ eq ] =
+  ⊥-elim (not-star (trans (sym eq) (dynamic X var-∈)))
+  where
+  not-star : I.X⊑X ≢ I.X⊑★
+  not-star ()
+dynamic-success {μ = μ} {A = ＇ X} dynamic
+    | I.X⊑★ | [ eq ] =
+  is-just
+dynamic-success {A = ‵ ι} dynamic = is-just
+dynamic-success {A = ★} dynamic = is-just
+dynamic-success {μ = μ} {A = A ⇒ B} dynamic
+    with dynamic? μ A | dynamic-success (dynamic-domain dynamic)
+dynamic-success {μ = μ} {A = A ⇒ B} dynamic
+    | nothing | ()
+dynamic-success {μ = μ} {A = A ⇒ B} dynamic
+    | just dynamic-A | is-just
+    with dynamic? μ B | dynamic-success (dynamic-codomain dynamic)
+dynamic-success {μ = μ} {A = A ⇒ B} dynamic
+    | just dynamic-A | is-just | nothing | ()
+dynamic-success {μ = μ} {A = A ⇒ B} dynamic
+    | just dynamic-A | is-just | just dynamic-B | is-just =
+  is-just
+dynamic-success {μ = μ} {A = `∀ A} dynamic
+    with dynamic? (I.instᵐ μ) A
+       | dynamic-success (dynamic-under-inst dynamic)
+dynamic-success {μ = μ} {A = `∀ A} dynamic | nothing | ()
+dynamic-success {μ = μ} {A = `∀ A} dynamic
+    | just dynamic-A | is-just =
+  is-just
+
+------------------------------------------------------------------------
+-- Consistency with ★ makes all variables dynamic on the relevant side
+------------------------------------------------------------------------
+
+ground-occurs-to-star : ∀ {Δ} {μ : C.Env∼ Δ}
+    {X : TyVar Δ} {G : Ty Δ}
+  → C._⊢_∼★ μ G
+  → X ∈ᵗ G
+  → μ X ≡ C.X∼★
+ground-occurs-to-star C.⇒∼★ (∈-fun-left ())
+ground-occurs-to-star C.⇒∼★ (∈-fun-right X∉A ())
+ground-occurs-to-star C.ι∼★ ()
+ground-occurs-to-star (C.X∼★ᵍ eq) var-∈ = eq
+ground-occurs-to-star C.∀∼★ (∈-all ())
+
+source-occurs-target-safe : ∀ {Δ} {μ : C.Env∼ Δ}
+    {X : TyVar Δ} {A B : Ty Δ}
+  → μ X ≢ C.X∼★
+  → C._⊢_∼_ μ A B
+  → X ∈ᵗ A
+  → X ∈ᵗ B
+source-occurs-target-safe not-star (C.id a) X∈A = X∈A
+source-occurs-target-safe not-star (c C.↦ d) (∈-fun-left X∈A) =
+  ∈-fun-left (source-occurs-target-safe not-star c X∈A)
+source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
+    (c C.↦ d) (∈-fun-right X∉A X∈B) with occurs? X A′
+source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
+    (c C.↦ d) (∈-fun-right X∉A X∈B) | present X∈A′ =
+  ∈-fun-left X∈A′
+source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
+    (c C.↦ d) (∈-fun-right X∉A X∈B) | absent X∉A′ =
+  ∈-fun-right X∉A′ (source-occurs-target-safe not-star d X∈B)
+source-occurs-target-safe {X = X} not-star (C.∀ᶜ c)
+    (∈-all X∈A) =
+  ∈-all (source-occurs-target-safe {X = suc X} not-star c X∈A)
+source-occurs-target-safe not-star
+    (C._! ⦃ G∼★ = G∼★ ⦄ c ⦃ Ans ⦄) X∈A =
+  ⊥-elim (not-star (ground-occurs-to-star G∼★
+    (source-occurs-target-safe not-star c X∈A)))
+source-occurs-target-safe not-star (C.？_ c) ()
+source-occurs-target-safe {X = X} not-star
+    (C.inst_ c B≢★) (∈-all X∈A) =
+  unshift-occurs
+    (source-occurs-target-safe {X = suc X} not-star c X∈A)
+source-occurs-target-safe {X = X} not-star
+    (C.gen_ c A≢★) X∈A =
+  ∈-all (source-occurs-target-safe {X = suc X} not-star c
+    (shift-occurs X∈A))
+source-occurs-target-safe not-star C.bot-elim (∈-all ())
+source-occurs-target-safe not-star C.bot-intro (∈-all ())
+
+star-no-occurs : ∀ {Δ} {X : TyVar Δ} → X ∈ᵗ ★ → ⊥
+star-no-occurs ()
+
+ground-occurs-from-star : ∀ {Δ} {μ : C.Env∼ Δ}
+    {X : TyVar Δ} {G : Ty Δ}
+  → C._⊢★∼_ μ G
+  → X ∈ᵗ G
+  → μ X ≡ C.★∼X
+ground-occurs-from-star C.★∼⇒ (∈-fun-left ())
+ground-occurs-from-star C.★∼⇒ (∈-fun-right X∉A ())
+ground-occurs-from-star C.★∼ι ()
+ground-occurs-from-star (C.★∼Xᵍ eq) var-∈ = eq
+ground-occurs-from-star C.★∼∀ (∈-all ())
+
+target-occurs-source-safe : ∀ {Δ} {μ : C.Env∼ Δ}
+    {X : TyVar Δ} {A B : Ty Δ}
+  → μ X ≢ C.★∼X
+  → C._⊢_∼_ μ A B
+  → X ∈ᵗ B
+  → X ∈ᵗ A
+target-occurs-source-safe not-star (C.id a) X∈B = X∈B
+target-occurs-source-safe not-star (c C.↦ d) (∈-fun-left X∈A) =
+  ∈-fun-left (target-occurs-source-safe not-star c X∈A)
+target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
+    (c C.↦ d) (∈-fun-right X∉A′ X∈B′) with occurs? X A
+target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
+    (c C.↦ d) (∈-fun-right X∉A′ X∈B′) | present X∈A =
+  ∈-fun-left X∈A
+target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
+    (c C.↦ d) (∈-fun-right X∉A′ X∈B′) | absent X∉A =
+  ∈-fun-right X∉A (target-occurs-source-safe not-star d X∈B′)
+target-occurs-source-safe {X = X} not-star (C.∀ᶜ c)
+    (∈-all X∈B) =
+  ∈-all (target-occurs-source-safe {X = suc X} not-star c X∈B)
+target-occurs-source-safe not-star (C._! c) ()
+target-occurs-source-safe not-star
+    (C.？_ ⦃ ★∼G = ★∼G ⦄ c) X∈B =
+  ⊥-elim (not-star (ground-occurs-from-star ★∼G
+    (target-occurs-source-safe not-star c X∈B)))
+target-occurs-source-safe {X = X} not-star
+    (C.inst_ c B≢★) X∈B =
+  ∈-all (target-occurs-source-safe {X = suc X} not-star c
+    (shift-occurs X∈B))
+target-occurs-source-safe {X = X} not-star
+    (C.gen_ c A≢★) (∈-all X∈B) =
+  unshift-occurs
+    (target-occurs-source-safe {X = suc X} not-star c X∈B)
+target-occurs-source-safe not-star C.bot-elim (∈-all ())
+target-occurs-source-safe not-star C.bot-intro (∈-all ())
+
+right-dynamic-at : ∀ {r : C.Var∼} {l u : I.VarImp}
+  → VarLower r l u
+  → (r ≢ C.X∼★ → ⊥)
+  → u ≡ I.X⊑★
+right-dynamic-at var-refl impossible =
+  ⊥-elim (impossible (λ ()))
+right-dynamic-at var-to-star impossible = refl
+right-dynamic-at var-from-star impossible =
+  ⊥-elim (impossible (λ ()))
+right-dynamic-at both-to-star impossible = refl
+
+left-dynamic-at : ∀ {r : C.Var∼} {l u : I.VarImp}
+  → VarLower r l u
+  → (r ≢ C.★∼X → ⊥)
+  → l ≡ I.X⊑★
+left-dynamic-at var-refl impossible =
+  ⊥-elim (impossible (λ ()))
+left-dynamic-at var-to-star impossible =
+  ⊥-elim (impossible (λ ()))
+left-dynamic-at var-from-star impossible = refl
+left-dynamic-at both-to-star impossible = refl
+
+right-dynamic : ∀ {Δ} {μ : C.Env∼ Δ} {φ ψ}
+    {A : Ty Δ}
+  → LowerEnv μ φ ψ
+  → C._⊢_∼_ μ A ★
+  → AllDynamic ψ A
+right-dynamic h c X X∈A =
+  right-dynamic-at (h X)
+    (λ not-star →
+      star-no-occurs (source-occurs-target-safe not-star c X∈A))
+
+left-dynamic : ∀ {Δ} {μ : C.Env∼ Δ} {φ ψ}
+    {B : Ty Δ}
+  → LowerEnv μ φ ψ
+  → C._⊢_∼_ μ ★ B
+  → AllDynamic φ B
+left-dynamic h c X X∈B =
+  left-dynamic-at (h X)
+    (λ not-star →
+      star-no-occurs (target-occurs-source-safe not-star c X∈B))
+
+no-success : ∀ {A : Set} → IsJust (nothing {A = A}) → ⊥
+no-success ()
+
+right-star-test : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {A : Ty Δ}
+    {access : Acc _<_ (size A + 1)}
+  → IsJust (dynamic? ψ A)
+  → IsJust (lowerAcc φ ψ A ★ access)
+right-star-test {ψ = ψ} {A = A} success with dynamic? ψ A
+right-star-test success | nothing = ⊥-elim (no-success success)
+right-star-test success | just dynamic = is-just
+
+left-star-test : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {B : Ty Δ}
+    {access : Acc _<_ (1 + size B)}
+  → NonStar B
+  → IsJust (dynamic? φ B)
+  → IsJust (lowerAcc φ ψ ★ B access)
+left-star-test {φ = φ} {B = ＇ X} nonstar-X success
+    with dynamic? φ (＇ X)
+left-star-test nonstar-X success | nothing =
+  ⊥-elim (no-success success)
+left-star-test nonstar-X success | just dynamic = is-just
+left-star-test {φ = φ} {B = ‵ ι} nonstar-ι success = is-just
+left-star-test {φ = φ} {B = A ⇒ B} nonstar-⇒ success
+    with dynamic? φ (A ⇒ B)
+left-star-test nonstar-⇒ success | nothing =
+  ⊥-elim (no-success success)
+left-star-test nonstar-⇒ success | just dynamic = is-just
+left-star-test {φ = φ} {B = `∀ B} nonstar-∀ success
+    with dynamic? φ (`∀ B)
+left-star-test nonstar-∀ success | nothing =
+  ⊥-elim (no-success success)
+left-star-test nonstar-∀ success | just dynamic = is-just
+
+right-star-success : ∀ {Δ} {μ : C.Env∼ Δ} {φ ψ}
+    {A : Ty Δ}
+  → LowerEnv μ φ ψ
+  → C._⊢_∼_ μ A ★
+  → (access : Acc _<_ (size A + 1))
+  → IsJust (lowerAcc φ ψ A ★ access)
+right-star-success {φ = φ} {ψ = ψ} {A = A} h c access =
+  right-star-test {φ = φ} {ψ = ψ} {A = A} {access = access}
+    (dynamic-success (right-dynamic h c))
+
+left-star-success : ∀ {Δ} {μ : C.Env∼ Δ} {φ ψ}
+    {B : Ty Δ}
+  → LowerEnv μ φ ψ
+  → C._⊢_∼_ μ ★ B
+  → (access : Acc _<_ (1 + size B))
+  → IsJust (lowerAcc φ ψ ★ B access)
+left-star-success {B = ★} h c access = right-star-success h c access
+left-star-success {φ = φ} {ψ = ψ} {B = ＇ X} h c access =
+  left-star-test {φ = φ} {ψ = ψ} {B = ＇ X} {access = access}
+    nonstar-X (dynamic-success (left-dynamic h c))
+left-star-success {φ = φ} {ψ = ψ} {B = ‵ ι} h c access =
+  left-star-test {φ = φ} {ψ = ψ} {B = ‵ ι} {access = access}
+    nonstar-ι (dynamic-success (left-dynamic h c))
+left-star-success {φ = φ} {ψ = ψ} {B = A ⇒ B} h c access =
+  left-star-test {φ = φ} {ψ = ψ} {B = A ⇒ B} {access = access}
+    nonstar-⇒ (dynamic-success (left-dynamic h c))
+left-star-success {φ = φ} {ψ = ψ} {B = `∀ B} h c access =
+  left-star-test {φ = φ} {ψ = ψ} {B = `∀ B} {access = access}
+    nonstar-∀ (dynamic-success (left-dynamic h c))
+
+------------------------------------------------------------------------
+-- Completeness of lower-bound search
+------------------------------------------------------------------------
+
+lowerAcc-complete : ∀ {Δ} {μ : C.Env∼ Δ} {φ ψ}
+    {A B : Ty Δ}
+  → LowerEnv μ φ ψ
+  → C._⊢_∼_ μ A B
+  → (access : Acc _<_ (size A + size B))
+  → IsJust (lowerAcc φ ψ A B access)
+lowerAcc-complete h c@(C.id ★) access = right-star-success h c access
+lowerAcc-complete h (C.id (‵ ι)) access with ι ≟Base ι
+lowerAcc-complete h (C.id (‵ ι)) access | yes refl = is-just
+lowerAcc-complete h (C.id (‵ ι)) access | no ι≠ι =
+  ⊥-elim (ι≠ι refl)
+lowerAcc-complete h (C.id (＇ X)) access
+    with X Fin.≟ X
+lowerAcc-complete h (C.id (＇ X)) access | yes refl = is-just
+lowerAcc-complete h (C.id (＇ X)) access | no X≠X = ⊥-elim (X≠X refl)
+lowerAcc-complete {A = A ⇒ B} {B = A′ ⇒ B′} h
+    (c C.↦ d) (acc smaller) =
+  arrow-lower-success
+    (lowerAcc-complete h c
+      (smaller (arrow-left-size A B A′ B′)))
+    (lowerAcc-complete h d
+      (smaller (arrow-right-size A B A′ B′)))
+lowerAcc-complete {φ = φ} {ψ = ψ} {A = `∀ A} {B = `∀ B} h
+    (C.∀ᶜ c) (acc smaller) =
+  orElse-left
+    (all-lower-success
+      (lowerAcc-complete (extend-lower-env h) c
+        (smaller (all-size-less A B))))
+lowerAcc-complete h c@(C._! d) access = right-star-success h c access
+lowerAcc-complete h c@(C.？_ d) access = left-star-success h c access
+lowerAcc-complete {A = `∀ A} {B = ＇ X} h
+    (C.inst_ ⦃ Anv ⦄ ⦃ zero∈A ⦄ c B≢★) (acc smaller) =
+  inst-lower-success Anv zero∈A
+    (lowerAcc-complete (instantiate-right-lower-env h) c
+      (smaller (inst-size-less A (＇ X))))
+lowerAcc-complete {A = `∀ A} {B = ‵ ι} h
+    (C.inst_ ⦃ Anv ⦄ ⦃ zero∈A ⦄ c B≢★) (acc smaller) =
+  inst-lower-success Anv zero∈A
+    (lowerAcc-complete (instantiate-right-lower-env h) c
+      (smaller (inst-size-less A (‵ ι))))
+lowerAcc-complete {A = `∀ A} {B = ★} h
+    (C.inst_ c B≢★) (acc smaller) =
+  ⊥-elim (B≢★ refl)
+lowerAcc-complete {A = `∀ A} {B = B₁ ⇒ B₂} h
+    (C.inst_ ⦃ Anv ⦄ ⦃ zero∈A ⦄ c B≢★) (acc smaller) =
+  inst-lower-success Anv zero∈A
+    (lowerAcc-complete (instantiate-right-lower-env h) c
+      (smaller (inst-size-less A (B₁ ⇒ B₂))))
+lowerAcc-complete {φ = φ} {ψ = ψ} {A = `∀ A} {B = `∀ B} h
+    (C.inst_ ⦃ Anv ⦄ ⦃ zero∈A ⦄ c B≢★) (acc smaller) =
+  four-second
+    (all-lower
+      (lowerAcc (I.extᵐ φ) (I.extᵐ ψ) A B
+        (smaller (all-size-less A B))))
+    (inst-lower
+      (lowerAcc (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ (`∀ B))
+        (smaller (inst-size-less A (`∀ B)))))
+    (gen-lower
+      (lowerAcc (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ (`∀ A)) B
+        (smaller (gen-size-less (`∀ A) B))))
+    (bot-lower A B)
+    (inst-lower-success Anv zero∈A
+      (lowerAcc-complete (instantiate-right-lower-env h) c
+        (smaller (inst-size-less A (`∀ B)))))
+lowerAcc-complete {A = ＇ X} {B = `∀ B} h
+    (C.gen_ ⦃ Bnv ⦄ ⦃ zero∈B ⦄ c A≢★) (acc smaller) =
+  gen-lower-success Bnv zero∈B
+    (lowerAcc-complete (instantiate-left-lower-env h) c
+      (smaller (gen-size-less (＇ X) B)))
+lowerAcc-complete {A = ‵ ι} {B = `∀ B} h
+    (C.gen_ ⦃ Bnv ⦄ ⦃ zero∈B ⦄ c A≢★) (acc smaller) =
+  gen-lower-success Bnv zero∈B
+    (lowerAcc-complete (instantiate-left-lower-env h) c
+      (smaller (gen-size-less (‵ ι) B)))
+lowerAcc-complete {A = ★} {B = `∀ B} h
+    (C.gen_ c A≢★) (acc smaller) =
+  ⊥-elim (A≢★ refl)
+lowerAcc-complete {A = A₁ ⇒ A₂} {B = `∀ B} h
+    (C.gen_ ⦃ Bnv ⦄ ⦃ zero∈B ⦄ c A≢★) (acc smaller) =
+  gen-lower-success Bnv zero∈B
+    (lowerAcc-complete (instantiate-left-lower-env h) c
+      (smaller (gen-size-less (A₁ ⇒ A₂) B)))
+lowerAcc-complete {φ = φ} {ψ = ψ} {A = `∀ A} {B = `∀ B} h
+    (C.gen_ ⦃ Bnv ⦄ ⦃ zero∈B ⦄ c A≢★) (acc smaller) =
+  four-third
+    (all-lower
+      (lowerAcc (I.extᵐ φ) (I.extᵐ ψ) A B
+        (smaller (all-size-less A B))))
+    (inst-lower
+      (lowerAcc (I.extᵐ φ) (I.instᵐ ψ) A (⇑ᵗ (`∀ B))
+        (smaller (inst-size-less A (`∀ B)))))
+    (gen-lower
+      (lowerAcc (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ (`∀ A)) B
+        (smaller (gen-size-less (`∀ A) B))))
+    (bot-lower A B)
+    (gen-lower-success Bnv zero∈B
+      (lowerAcc-complete (instantiate-left-lower-env h) c
+        (smaller (gen-size-less (`∀ A) B))))
+lowerAcc-complete {Δ = Δ} {φ = φ} {ψ = ψ} h C.bot-elim
+    (acc smaller) =
+  four-fourth
+    (all-lower
+      (lowerAcc (I.extᵐ φ) (I.extᵐ ψ) (＇ zero) ★
+        (smaller (all-size-less {Δ = Δ} (＇ zero) ★))))
+    (inst-lower
+      (lowerAcc (I.extᵐ φ) (I.instᵐ ψ) (＇ zero) (⇑ᵗ (`∀ ★))
+        (smaller (inst-size-less {Δ = Δ} (＇ zero) (`∀ ★)))))
+    (gen-lower
+      (lowerAcc (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ (`∀ (＇ zero))) ★
+        (smaller (gen-size-less {Δ = Δ} (`∀ (＇ zero)) ★))))
+    (bot-lower (＇ zero) ★)
+    bot-left-success
+lowerAcc-complete {Δ = Δ} {φ = φ} {ψ = ψ} h C.bot-intro
+    (acc smaller) =
+  four-fourth
+    (all-lower
+      (lowerAcc (I.extᵐ φ) (I.extᵐ ψ) ★ (＇ zero)
+        (smaller (all-size-less {Δ = Δ} ★ (＇ zero)))))
+    (inst-lower
+      (lowerAcc (I.extᵐ φ) (I.instᵐ ψ) ★
+        (⇑ᵗ (`∀ (＇ zero)))
+        (smaller (inst-size-less {Δ = Δ} ★ (`∀ (＇ zero))))))
+    (gen-lower
+      (lowerAcc (I.instᵐ φ) (I.extᵐ ψ) (⇑ᵗ (`∀ ★)) (＇ zero)
+        (smaller (gen-size-less {Δ = Δ} (`∀ ★) (＇ zero)))))
+    (bot-lower ★ (＇ zero))
+    bot-right-success
+
+------------------------------------------------------------------------
+-- Equivalence
+------------------------------------------------------------------------
+
+∼→∼ᵘ : ∀ {Δ} {A B : Ty Δ}
+  → C._∼_ A B
+  → A ∼ᵘ B
+∼→∼ᵘ c =
+  map-success
+    (lowerAcc-complete identity-lower-env c
+      (NatInduction.<-wellFounded _))
+
+∼ᵘ→∼ : ∀ {Δ} {A B : Ty Δ}
+  → A ∼ᵘ B
+  → C._∼_ A B
+∼ᵘ→∼ {A = A} {B = B} unique
+    with lowerAcc I.idᵐ I.idᵐ A B
+      (NatInduction.<-wellFounded _)
+∼ᵘ→∼ unique | nothing with unique
+∼ᵘ→∼ unique | nothing | ()
+∼ᵘ→∼ unique | just (lower D D⊑A D⊑B) =
+  common-lower-consistent (D , D⊑A , D⊑B)
+
+consistency↔consistency2 : ∀ {Δ} {A B : Ty Δ}
+  → (C._∼_ A B → A ∼ᵘ B) × (A ∼ᵘ B → C._∼_ A B)
+consistency↔consistency2 = ∼→∼ᵘ , ∼ᵘ→∼


### PR DESCRIPTION
## Summary

- add a deterministic `lower?` search for a common lower bound of two types
- define the proof-carrying alternative consistency relation `_∼ᵘ_`
- prove that `_∼ᵘ_` has unique derivations
- prove `_∼ᵘ_` equivalent to the existing consistency relation
- include both new modules in `GTSFImp/All.agda`

## Motivation

The existing consistency relation is not proof irrelevant: some consistent
type pairs have multiple derivations. This change keeps that relation intact
and provides an equivalent relation whose evidence is canonical because it is
obtained from a deterministic common-lower-bound search.

## Validation

- `agda -v0 Consistency2.agda`
- `agda -v0 proof/Consistency2.agda`
- `agda -v0 All.agda` reaches the new modules, then fails in the unchanged
  `proof/DGG/CompilePreservesImprecision.agda` at lines 186-187
