### PR TITLE
GTSFImp: pivot-local rebasing, mark decay, and the extra-cast-right inversion

### DIFF
--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -228,10 +228,14 @@ reveal⊑reveal²
 conceal⊑conceal²
 ```
 
-All six rules are representation directed: each rule carries a `RebaseAt`
-premise and indexed conversion typing evidence such as `Σ ⊢↑[ X ] c` or
-`Σ ⊢↓[ X ] c`. This records which abstract variable the conversion is
-about and which source/target store representations are being compared.
+All six rules are representation directed: each rule carries a rebasing
+premise and indexed conversion typing evidence such as `Σ ⊢↑[ just X ] c`
+or `Σ ⊢↓[ just X ] c`. This records which abstract variable the
+conversion is about and which source/target store representations are
+being compared. The pivot index is optional: an identity-shaped
+conversion has pivot `nothing`, and the one-sided rules take a
+`RebaseAtᴸ`/`RebaseAtᴿ` premise whose `nothing` case forces the premise
+world to equal the conclusion world.
 
 `RebaseAt W W′ Xᴸ Xᴿ` is deliberately pivot-local. Reduction introduces
 one reveal or conceal wrapper per fresh type variable, so descending
@@ -304,82 +308,51 @@ boundary whose pivot is the moved pair.
 <a id="identity-reveals-v2"></a>
 ## Identity reveals in version-2 cast-term imprecision
 
-The version-2 prototype relation in
-[`proof/DGG/CastTermImprecision2.agda`](proof/DGG/CastTermImprecision2.agda)
-includes a narrow target-only identity-reveal rule:
-
-```agda
-⊑id-reveal²
-```
-
-This rule was added for the `β-reveal-∀` / `β-Λ` example in
-[`proof/DGG/Examples2.agda`](proof/DGG/Examples2.agda). The target starts
-with an administrative universal reveal:
-
-```agda
-Ex.polyId ↑ `∀↑ (id↑ Ex.X⇒X)
-```
-
-Semantically, this reveal is an identity conversion. It should be
-admissible to relate a term to the same target term wrapped by such an
-identity reveal:
-
-```text
-M  ⊑  M′
-        |
-        | add administrative target identity reveal
-        v
-M  ⊑  M′ ↑ id
-```
-
-However, this admissibility is not derivable from the other version-2
-constructors as currently written. The only general target-only reveal rule
-is representation-directed:
-
-```agda
-⊑reveal²
-```
-
-It requires a `RebaseAt W W′ Xᴸ Xᴿ` premise and an indexed conversion
-typing premise for the converted target variable `Xᴿ`. That is appropriate
-for real `seal`/`unseal` boundaries, where the proof must say which
-abstract type variable is being revealed and which store representation is
-being chased.
-
-For an identity reveal at an empty target store, there is no such variable.
-The first nat-chain comparison needs to relate
+The `β-reveal-∀` / `β-Λ` example in
+[`proof/DGG/Examples2.agda`](proof/DGG/Examples2.agda) needs to relate a
+term to the same target term wrapped in an administrative identity
+reveal:
 
 ```agda
 Ex.polyId
   ⊑ Ex.polyId ↑ `∀↑ (id↑ Ex.X⇒X)
 ```
 
-at target type context size `0`. There is no `Xᴿ : TyVar 0`, so the
-`RebaseAt`-based reveal rule cannot even be instantiated. Using a rebase
-premise for this case would also be conceptually misleading: there is no
-store representation path to chase.
+at target type context size `0`. There is no `Xᴿ : TyVar 0`, so a
+reveal rule that demands a pivot variable and a store representation
+cannot even be instantiated here — and semantically there is nothing to
+chase, because the conversion is an identity.
 
-The prototype therefore separates identity reveals from representation
-reveals with a small syntactic predicate:
+An early prototype handled this with a separate primitive rule,
+`⊑id-reveal²`, guarded by an `IdentityReveal` predicate. That design had
+a loophole in the other direction: the indexed conversion typing had
+`Σ ⊢↑[ X ] id↑ A` for **every** `X`, so the rebasing reveal rule could
+be applied to an identity conversion at an arbitrary pivot and change
+the world under a conversion that mentions no variable at all.
+
+The current design closes the loophole and removes the extra rule at
+the same time by making the pivot index optional:
 
 ```agda
-IdentityReveal (id↑ A)
-IdentityReveal c
-  → IdentityReveal (`∀↑ c)
+Σ ⊢↑[ nothing ] id↑ A
+Σ ⊢↑[ just X ] unseal X R
 ```
 
-and the corresponding rule `⊑id-reveal²`. This is intended as an
-admissible closure principle for identity-shaped upward conversions, not as
-a semantic rebase rule. It does not cover arbitrary one-sided reveals and it
-does not introduce any new representation alignment.
+A composite conversion joins the pivots of its halves with `PivotJoin`:
+identity halves contribute `nothing`, variable halves must agree, so a
+conversion has pivot `just X` exactly when some leaf seals or unseals
+`X` and no leaf mentions another variable. An all-identity conversion
+has pivot `nothing` and no other typing.
 
-A cleaner final design would prove this as an admissibility lemma and then
-remove `⊑id-reveal²` as a primitive constructor. That proof would need some
-separate support for identity conversion irrelevance, normalization of
-identity-shaped conversions, or equality of cast terms modulo identity
-reveals. Until that proof infrastructure exists, the explicit rule records
-the intended admissible step locally and keeps real store-dependent reveals
-under the `RebaseAt` machinery.
+The one-sided wrapper rules take a `RebaseAtᴸ` or `RebaseAtᴿ` premise
+indexed by the optional pivot. Its `rebase-var` case wraps an ordinary
+pivot-local `RebaseAt`; its `rebase-id` case is only available at pivot
+`nothing` and forces the premise world to equal the conclusion world.
+Identity reveals are therefore the `nothing` instance of the ordinary
+`⊑reveal²` rule: they never rebase, and rebasing reveals always name
+the variable they reveal. The paired reveal/conceal rules require
+`just` pivots on both sides; a pairing of an identity conversion with a
+variable conversion decomposes into two one-sided steps.
 
 <a id="example12-store-alignment"></a>
 ## Example 12 store alignment and right-only variables

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -233,6 +233,22 @@ premise and indexed conversion typing evidence such as `Σ ⊢↑[ X ] c` or
 `Σ ⊢↓[ X ] c`. This records which abstract variable the conversion is
 about and which source/target store representations are being compared.
 
+`RebaseAt W W′ Xᴸ Xᴿ` is deliberately pivot-local. Reduction introduces
+one reveal or conceal wrapper per fresh type variable, so descending
+through one wrapper is only allowed to change the alignment of the pivot
+pair. Concretely, the record requires that the two runtime stores, the
+center type context, and the imprecision environment are unchanged, that
+`ηᴸ` agrees with the old world at every variable other than `Xᴸ` and
+`ηᴿ` agrees at every variable other than `Xᴿ`, that the pivots are
+aligned in the new world, and that their store representations are
+related there. Store representations are canonical: `resolveVar` follows
+a variable's representation chain to its end (a non-variable type or a
+store-lift variable), instead of letting the derivation stop the chase
+at an arbitrary intermediate type. Chains terminate because a store-bind
+entry mentions only strictly older variables. This keeps rebasing
+deterministic enough for inversion: given the old world and the pivot
+pair, the new world is fixed up to which side of the pivot moved.
+
 Reveal and conceal use opposite `RebaseAt` directions. A reveal checks the
 premise in the pre-reveal world and produces the result in the post-reveal
 world, so its rebasing premise has the same direction as the one-sided
@@ -256,23 +272,34 @@ comparison is
 
 The function premise naturally lives in the `Y/Z` alignment, while the
 inner argument before the outer `Z` seal naturally lives in the `X/Z`
-alignment. Rather than split application, the proof rebases at the `Z`
-conceal boundary:
+alignment. The two alignments differ only in where target `Y` embeds,
+so under pivot-local rebasing the world may change only at a boundary
+whose pivot is the `Y` pair. Rather than split application, the proof
+keeps the whole application node in the `X/Z` alignment — the `Z`
+conceal boundary uses a same-world rebase because `Z/Z′` are already
+aligned there — and performs the `X/Z` to `Y/Z` change at the paired
+`Y` reveal on the function side:
 
 ```text
-((7 ↓ seal X) ⟨ X! ⟩)
+ƛ y. y
   ⊑
-(7 ⟨ ℕ! ⟩)
+ƛ y. y
+  in the Y/Z alignment
 
-↓ conceal Z / Z′ with RebaseAt XZ YZ Z Z′
+↑ reveal Y / Y′ with RebaseAt XZ YZ Y Y′
 
-(((7 ↓ seal X) ⟨ X! ⟩) ↓ seal Z)
+(ƛ y. y) ↑ reveal Y
   ⊑
-((7 ⟨ ℕ! ⟩) ↓ seal Z′)
+(ƛ y. y) ↑ reveal Y′
+  in the X/Z alignment
 ```
 
 After that boundary step, both the function and argument premises are in
-the `Y/Z` alignment and ordinary application imprecision applies.
+the `X/Z` alignment and ordinary application imprecision applies. When
+the argument is later concealed at `Y` (checkpoint 9 of the example),
+the same `RebaseAt XZ YZ Y Y′` witness carries the argument from the
+`X/Z` premise world into the `Y/Z` conclusion world, again at a
+boundary whose pivot is the moved pair.
 
 <a id="identity-reveals-v2"></a>
 ## Identity reveals in version-2 cast-term imprecision
@@ -536,8 +563,8 @@ map it to central `Y` or `Z`. Thus Example 12 shows that the store alignment
 itself can be expressed with the current two-renaming setup, but the
 conversion-wrapper rules need local rebasing. The version-2 rules handle the
 extra right-only conversion layers by rebasing at the reveal/conceal
-boundary for the converted variable and chasing its store representation
-with the `LeadsTo` machinery.
+boundary for the converted variable and comparing the pivots' canonical
+store representations computed by `resolveVar`.
 
 <a id="generalization-tags"></a>
 ## Generalization uses fresh-name tags

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -246,7 +246,10 @@ the target simply does not have, and with only two-sided pivots the
 simulation was provably impossible in every world. The `rebase-onlyᴸ`
 case of `RebaseAtᴸ` covers this: the pivot's center is classified
 `X⊑★`, its canonical source representation sits below `★`, and the
-world stays fixed because there is no alignment to change. There is no
+world stays fixed because there is no alignment to change. A third
+condition records the disalignment directly: no target variable embeds
+at the pivot's center, so a pivot with no target partner is disaligned
+by construction rather than merely unaligned by accident. There is no
 right-only mirror, because type imprecision has no rule with a bare
 variable on the imprecise side: a target variable can only appear in an
 obligation opposite an aligned source variable.

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -237,6 +237,34 @@ conversion has pivot `nothing`, and the one-sided rules take a
 `RebaseAtᴸ`/`RebaseAtᴿ` premise whose `nothing` case forces the premise
 world to equal the conclusion world.
 
+A source pivot does not need an aligned target variable. When the more
+imprecise side never allocates — the probe in
+[`proof/DGG/LambdaImpProbe.agda`](proof/DGG/LambdaImpProbe.agda) pairs
+Example 12's direct program with a monomorphic `(ƛ x) · (7 ⟨ ℕ! ⟩)` —
+the source's `β-Λ` produces reveal and conceal wrappers at a variable
+the target simply does not have, and with only two-sided pivots the
+simulation was provably impossible in every world. The `rebase-onlyᴸ`
+case of `RebaseAtᴸ` covers this: the pivot's center is classified
+`X⊑★`, its canonical source representation sits below `★`, and the
+world stays fixed because there is no alignment to change. There is no
+right-only mirror, because type imprecision has no rule with a bare
+variable on the imprecise side: a target variable can only appear in an
+obligation opposite an aligned source variable.
+
+For the same reason, `Λ⊑²` lifts the world on the left only. Its
+premise compares the type abstraction's body against the target term
+*unweakened*, in `liftWorldLeft X⊑★ W`, which keeps the target context,
+store, and embedding fixed. An earlier version weakened the target with
+`⇑ᵗᵐ` under `liftWorldBoth` — a carryover from the version-1 relation,
+which renamed terms into a shared context. That premise was unusable as
+an induction hypothesis: after `β-Λ` the machine's target store still
+has its old type context, `SameRuntime` pins checkpoint worlds to it,
+and a `liftWorldBoth` world differs from every such world already in
+its `World` indices. With the left-only lift, the premise world differs
+from the post-allocation `leftOnlyWorld` only in binding the fresh
+source variable (`store-lift` versus `store-bind`), which is the
+ordinary world evolution at an allocation step.
+
 `RebaseAt W W′ Xᴸ Xᴿ` is deliberately pivot-local. Reduction introduces
 one reveal or conceal wrapper per fresh type variable, so descending
 through one wrapper is only allowed to change the alignment of the pivot

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -677,3 +677,17 @@ required output is derivable only by rebuilding: the paired
 `conceal⊑conceal²` at `(Xᴸ, Y)` over a premise world that parks `Y` at
 a third center (so the deeper seal's `rebase-onlyᴸ` disalignment
 holds), with the leaf relation reconstructed from scratch.
+
+Two constraints shape the world-support lemma itself.  First,
+embeddings are order-preserving injections built from `keep`/`skip`,
+not pointwise functions, so "move one variable's center" is not a local
+record update: relocating a pivot can collide with the centers of
+variables in the support, and the lemma's agreement hypothesis must
+carry the injectivity bookkeeping explicitly.  Second, terms mention
+store variables without an enclosing wrapper node (a bare `＇X₂` tag
+deep inside a lambda body), so a sub-derivation's support can include
+the very pivot the rebuild wants to move; when no unused center exists
+for re-parking, the peel must extend the center context first, using
+the existing world-extension machinery, and transport along the
+extension.  Parking space is therefore obtained by extension, never
+assumed.

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -320,19 +320,21 @@ Recall what a center is: a world carries a shared center type context
 variable to a variable of `Δ` — its center. A source variable is
 aligned with a target variable exactly when the embeddings send them
 to the same center. In the diagram below the center context has three
-variables `c0, c1, c2`, drawn as columns; each row records where the
-embeddings send the two pivots, so two names in one column mean the
-pivots are aligned there. With the pivots apart in `W` (`Xᴸ` at `c0`,
-`Y` at `c1`), the three possible shapes for `W′` are:
+type variables `X, Y, Z`, drawn as columns; the pivot pair is the
+source variable `Xᴸ` and the target variable `Yᴿ`. Each row records
+where the embeddings send the two pivots, so two names in one column
+mean the pivots are aligned there. With the pivots apart in `W`
+(`Xᴸ` at center `X`, `Yᴿ` at center `Y`), the three possible shapes
+for `W′` are:
 
 ```text
-             c0    c1    c2
-  W    ηᴸ:   Xᴸ
-       ηᴿ:         Y           (pivots apart in W)
+              X      Y      Z
+  W    ηᴸ:    Xᴸ
+       ηᴿ:           Yᴿ           (pivots apart in W)
 
-  W′   (a)   Xᴸ,Y              Y moves to c0, where Xᴸ already sits
-       (b)         Xᴸ,Y        Xᴸ moves to c1, where Y already sits
-       (c)               Xᴸ,Y  both move to c2, previously unoccupied
+  W′   (a)   Xᴸ,Yᴿ                Yᴿ moves to X, where Xᴸ already sits
+       (b)          Xᴸ,Yᴿ         Xᴸ moves to Y, where Yᴿ already sits
+       (c)                 Xᴸ,Yᴿ  both move to Z, previously unoccupied
 ```
 
 Alongside any of these, `ImpEnvMono` lets marks decay `X⊑X → X⊑★` at
@@ -360,7 +362,7 @@ move:
   such moves, one per wrapper.
 - *(b) source joins target* — the mirror, typical when the source side
   allocated its seal later than the target; the boundary at the source
-  seal re-aligns `Xᴸ` onto the already-placed `Y`.
+  seal re-aligns the source pivot onto the already-placed target pivot.
 - *(c) both re-park* — no reduction step needs this, but rebuild
   proofs use the latitude when choosing premise worlds: the seal-peel
   analysis constructs an intermediate world with both pivots at a

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -312,18 +312,27 @@ seal; each wrapper boundary is the one place where that hypothesis may
 be revised, and only for the boundary's own pivot. Since every
 non-pivot embedding is pinned and the record's `pivotAligned` field
 forces the pivots to share a center in `W′`, the degrees of freedom
-reduce to the choice of that shared center. Writing centers as columns
-and world evolution downward, the three possible moves from a common
-starting world are:
+reduce to the choice of that shared center.
+
+Recall what a center is: a world carries a shared center type context
+`Δ` alongside the source and target contexts, and its two embeddings
+`ηᴸ : Δᴸ ↪ᵗ Δ` and `ηᴿ : Δᴿ ↪ᵗ Δ` send every source and target
+variable to a variable of `Δ` — its center. A source variable is
+aligned with a target variable exactly when the embeddings send them
+to the same center. In the diagram below the center context has three
+variables `c0, c1, c2`, drawn as columns; each row records where the
+embeddings send the two pivots, so two names in one column mean the
+pivots are aligned there. With the pivots apart in `W` (`Xᴸ` at `c0`,
+`Y` at `c1`), the three possible shapes for `W′` are:
 
 ```text
              c0    c1    c2
-  W    ηᴸ:   Xᴸ                    (pivots apart in W)
-       ηᴿ:         Y
+  W    ηᴸ:   Xᴸ
+       ηᴿ:         Y           (pivots apart in W)
 
-  W′   (a)   Xᴸ,Y              target pivot joins the source center
-       (b)         Xᴸ,Y        source pivot joins the target center
-       (c)               Xᴸ,Y  both re-park at a third center
+  W′   (a)   Xᴸ,Y              Y moves to c0, where Xᴸ already sits
+       (b)         Xᴸ,Y        Xᴸ moves to c1, where Y already sits
+       (c)               Xᴸ,Y  both move to c2, previously unoccupied
 ```
 
 Alongside any of these, `ImpEnvMono` lets marks decay `X⊑X → X⊑★` at

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -328,6 +328,7 @@ mean the pivots are aligned there. With the pivots apart in `W`
 for `W′` are:
 
 ```text
+              Center Context
               X      Y      Z
   W    ηᴸ:    Xᴸ
        ηᴿ:           Yᴿ           (pivots apart in W)
@@ -761,3 +762,21 @@ for re-parking, the peel must extend the center context first, using
 the existing world-extension machinery, and transport along the
 extension.  Parking space is therefore obtained by extension, never
 assumed.
+
+Re-parking is pure: the transported derivation must not re-align the
+re-parked variable anywhere.  A first design tried to stop at interior
+rebases that capture the variable as their target pivot and transport
+the sub-derivation by plain renaming, but the conceal-direction rules
+refute it: their rebase aligns the pivots in the world being
+re-parked, so vacating the variable contradicts the node's own
+`pivotAligned` field.  Converting such nodes to `rebase-onlyᴸ` fails
+too — the to-star premise would need "the right of an obligation can
+be dynamized to `★`", which is false for universal types
+(`∀(＇0 ⇒ ι) ⊑ ★` is underivable because `extᵐ` pins the bound
+variable's mark precise) — and a capture boundary that also moves its
+source pivot has no expressible counterpart at all once its partner is
+gone.  So `⊢²-repark` requires, as part of its derivation predicate,
+that the re-parked variable is no rebase's target pivot; callers that
+need to move a variable across its own alignment boundaries must
+re-emit those boundary nodes themselves, which is exactly what the
+seal-peel rebuild does.

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -622,3 +622,58 @@ are never compared.
 This distinction is binder directed: `inst` removes its fresh variable from
 consistency and uses conversions, whereas `gen` retains its fresh variable as
 a tag. There are consequently no general `β-tag-X` or `β-untag-X` rules.
+
+## Seal peeling and world support
+
+The last case of the right-injection inversion is the bare seal: from
+
+```
+W ⊢² (V ↓ seal Xᴸ R) ⊑ N ⟨ ＇Y ! ⟩ ∶ ＇Xᴸ ⊑ ★        q : ＇Xᴸ ⊑ᵂ⟨W⟩ ＇Y
+```
+
+produce `W ⊢² V ↓ seal Xᴸ R ⊑ N ∶ q`.  For non-variable tags `q` is
+uninhabited, and `seal-tag-boundary-view²` already forces
+`N ≡ U ↓ seal Y S` with a paired rebase `RebaseAt W′ W Xᴸ Y`.  The
+remaining work is to relate `V` to `U` and reassemble the two seals.
+Analysis of the reassembly produced two structural findings.
+
+**One rebase link per wrapper node.**  A derivation of the input nests
+one premise world per wrapper rule: the source seal contributes
+`W → W′` pivoted at `(Xᴸ, Y)`, a target seal stripped inside contributes
+`W′ → W″` pivoted at some `(X₂, Y)`, and deeper seals in the spine of
+`V` contribute further links.  No single `RebaseAt` can absorb two
+source-side moves, so any rebuild that composes two links into one
+wrapper node fails: pivot-locality is per node, and that is fine,
+because the output term has exactly as many seal nodes as the premise
+tower has links.  Chained representations (`R = ＇X₂` with `X₂` aligned
+to `Y` one world in) are witnessed by a deeper seal in the spine of `V`
+— canonical forms at variable type — and that deeper node carries the
+extra link.  The rebuild is therefore link-by-link, never composing.
+
+**Interior worlds must be renormalized, not transported.**  The input
+derivation may place interior worlds badly: a premise world may move a
+variable that the rebuilt tower needs kept still (concretely, `W₄` may
+park `X₂` and `Y` at a center the output tower cannot reproduce, since
+the output's node pivots are forced by the seal typings).  Such
+derivations are honest — a checked configuration derives one with all
+marks `X⊑★` and `WFWorld` trivially satisfied — so no invariant excludes
+them.  The resolution is that the peel must not transport interior
+sub-derivations between worlds; it must recursively rebuild them at
+worlds of its own choosing, bottoming out at world-agnostic leaves
+(`κ⊑κ²`, `cast⊑cast²`, `x⊑x²` up to `SameCtx`).  The general tool this
+needs is a world-support lemma: a derivation depends only on the
+embeddings and marks of the type variables occurring in its terms,
+types, and store entries, so it can be moved to any world that agrees
+on that support.  The same lemma is what the eventual simulation needs
+to leave a `liftWorldLeft` premise world, so it is shared
+infrastructure, not a detour.
+
+The concrete configuration that forced both findings: source store
+`Xᴸ ⦂ ★, X₂ ⦂ ★`, target store `Y ⦂ ★`, all marks `X⊑★`,
+`V = (V₀₀ ↓ seal X₂ ★) ⟨ ＇X₂ ! ⟩`, `N = (U ↓ seal Y ★) ⟨ ＇Y ! ⟩`,
+with `Y` aligned to `Xᴸ` in `W` and to `X₂` in `W′`.  The input is
+derivable with an interior world moving `X₂` off its `W`-center, and the
+required output is derivable only by rebuilding: the paired
+`conceal⊑conceal²` at `(Xᴸ, Y)` over a premise world that parks `Y` at
+a third center (so the deeper seal's `rebase-onlyᴸ` disalignment
+holds), with the leaf relation reconstructed from scratch.

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -271,18 +271,39 @@ ordinary world evolution at an allocation step.
 `RebaseAt W W′ Xᴸ Xᴿ` is deliberately pivot-local. Reduction introduces
 one reveal or conceal wrapper per fresh type variable, so descending
 through one wrapper is only allowed to change the alignment of the pivot
-pair. Concretely, the record requires that the two runtime stores, the
-center type context, and the imprecision environment are unchanged, that
-`ηᴸ` agrees with the old world at every variable other than `Xᴸ` and
-`ηᴿ` agrees at every variable other than `Xᴿ`, that the pivots are
-aligned in the new world, and that their store representations are
-related there. Store representations are canonical: `resolveVar` follows
-a variable's representation chain to its end (a non-variable type or a
-store-lift variable), instead of letting the derivation stop the chase
-at an arbitrary intermediate type. Chains terminate because a store-bind
+pair. Concretely, the record requires that the two runtime stores and
+the center type context are unchanged, that `ηᴸ` agrees with the old
+world at every variable other than `Xᴸ` and `ηᴿ` agrees at every
+variable other than `Xᴿ`, that the pivots are aligned in the new world,
+and that their store representations are related there. Store
+representations are canonical: `resolveVar` follows a variable's
+representation chain to its end (a non-variable type or a store-lift
+variable), instead of letting the derivation stop the chase at an
+arbitrary intermediate type. Chains terminate because a store-bind
 entry mentions only strictly older variables. This keeps rebasing
 deterministic enough for inversion: given the old world and the pivot
-pair, the new world is fixed up to which side of the pivot moved.
+pair, the new world is fixed up to which side of the pivot moved and up
+to mark decay, described next.
+
+Imprecision marks are not pinned by the rebase. An earlier design
+required the premise and conclusion worlds to agree on every mark, but
+the checked configuration in
+[`proof/DGG/ExtraCastRight2Counterexample.agda`](proof/DGG/ExtraCastRight2Counterexample.agda)
+refuted extra-cast-right under that regime: a rebase that displaces a
+target variable leaves its old partner precise but unaligned, and the
+stale `X⊑X` mark — provably preserved by mark equality — makes the
+relation required after target-tag cancellation empty. Instead, every
+wrapper rule now carries an `ImpEnvMono` premise from its conclusion
+world to its premise world: centers marked `X⊑★` stay `X⊑★`, and
+precise marks may decay to `X⊑★`. Mark decay never removes
+derivability, because no imprecision rule requires a precise mark. The
+companion invariant `WFWorld` says a world is mark-honest: every source
+variable whose center is marked precise has an aligned target variable.
+The counterexample's input world fails it exactly at the displaced
+variable; descending into a dynamized, mark-honest premise world is
+what makes the previously-empty output derivable. There is no mirror
+condition for target variables because type imprecision has no rule
+with a bare variable on the imprecise side.
 
 Reveal and conceal use opposite `RebaseAt` directions. A reveal checks the
 premise in the pre-reveal world and produces the result in the post-reveal

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -305,6 +305,66 @@ what makes the previously-empty output derivable. There is no mirror
 condition for target variables because type imprecision has no rule
 with a bare variable on the imprecise side.
 
+Conversely, what a rebase may change is exactly the placement of its
+pivot pair, plus mark decay. An alignment is the world's hypothesis
+that a source variable and a target variable name the same runtime
+seal; each wrapper boundary is the one place where that hypothesis may
+be revised, and only for the boundary's own pivot. Since every
+non-pivot embedding is pinned and the record's `pivotAligned` field
+forces the pivots to share a center in `W′`, the degrees of freedom
+reduce to the choice of that shared center. Writing centers as columns
+and world evolution downward, the three possible moves from a common
+starting world are:
+
+```text
+             c0    c1    c2
+  W    ηᴸ:   Xᴸ                    (pivots apart in W)
+       ηᴿ:         Y
+
+  W′   (a)   Xᴸ,Y              target pivot joins the source center
+       (b)         Xᴸ,Y        source pivot joins the target center
+       (c)               Xᴸ,Y  both re-park at a third center
+```
+
+Alongside any of these, `ImpEnvMono` lets marks decay `X⊑X → X⊑★` at
+any center, and the pivots' canonical store representations must be
+related in `W′` — the moved hypothesis has to be consistent with what
+the stores actually hold. One practical constraint is not visible in
+the record: embeddings are order-preserving `keep`/`skip` injections,
+so a pivot can only re-park at a center that respects the relative
+order of the untouched variables. When no such center is free, parking
+space comes from extending the center context (see the world-support
+section below).
+
+Representative instances of each move:
+
+The diagram is oriented like the record: `RebaseAt W W′ Xᴸ Xᴿ` aligns
+the pivots in its second index, and the wrapper rules read the same
+record in both directions (reveal descends along it, conceal ascends —
+see the direction paragraph below). Representative instances of each
+move:
+
+- *(a) target joins source* — the outer boundary of
+  [`proof/DGG/SealPeelProbe.agda`](proof/DGG/SealPeelProbe.agda):
+  its record `RebaseAt probe-W′ probe-W Xᴸ Y` starts with the pair
+  apart in `probe-W′` (`Y` sits at `X₂`'s center) and has `Y` joining
+  `Xᴸ`'s center in `probe-W`, revising which source representation the
+  target seal is identified with. Example 12's chains are stacks of
+  such moves, one per wrapper.
+- *(b) source joins target* — the mirror, typical when the source side
+  allocated its seal later than the target; the boundary at the source
+  seal re-aligns `Xᴸ` onto the already-placed `Y`.
+- *(c) both re-park* — no reduction step needs this, but rebuild
+  proofs use the latitude when choosing premise worlds: the seal-peel
+  analysis constructs an intermediate world with both pivots at a
+  center neither occupied before, and the same probe's
+  `probe-Wᵖ` exercises the one-variable version, parking `Y` at a
+  fresh center so that a deeper `rebase-onlyᴸ` disalignment premise
+  holds at the center it vacated.
+- *degenerate* — `rebase-onlyᴸ` and the `nothing`-pivot cases move
+  nothing: `W′ = W`. A pivot with no target partner has no alignment
+  to revise, so the only latitude left is mark decay.
+
 Reveal and conceal use opposite `RebaseAt` directions. A reveal checks the
 premise in the pre-reveal world and produces the result in the post-reveal
 world, so its rebasing premise has the same direction as the one-sided
@@ -444,14 +504,15 @@ Diagram:
       │ one step                       │ three steps
       ▼                                ▼
 
-    ((ƛ x) ↑ (seal Xᴸ ℕ ↦↑ unseal Xᴸ ℕ)) 7
+    ((ƛ x)                                  -- Xᴸ ⇒ Xᴸ
+       ↑ (seal Xᴸ ℕ ↦↑ unseal Xᴸ ℕ)) 7      -- ℕ ⇒ ℕ   then ℕ
       ⊑
-    ((((((ƛ x)
-       ↑ (seal Yᴿ Zᴿ ↦↑ unseal Yᴿ Zᴿ))
-       ↑ (seal Zᴿ ★ ↦↑ unseal Zᴿ ★))
-       ⟨ id ★ ↦ id ★ ⟩)
-       ⟨ (? Xᴿ) ↦ (? Xᴿ) ⟩)
-       ↑ (seal Xᴿ ℕ ↦↑ unseal Xᴿ ℕ)) 7
+    ((((((ƛ x)                              -- Yᴿ ⇒ Yᴿ
+       ↑ (seal Yᴿ Zᴿ ↦↑ unseal Yᴿ Zᴿ))       -- Zᴿ ⇒ Zᴿ
+       ↑ (seal Zᴿ ★ ↦↑ unseal Zᴿ ★))        -- ★ ⇒ ★
+       ⟨ id ★ ↦ id ★ ⟩)                    -- ★ ⇒ ★
+       ⟨ (? Xᴿ) ↦ (? Xᴿ) ⟩)                 -- Xᴿ ⇒ Xᴿ
+       ↑ (seal Xᴿ ℕ ↦↑ unseal Xᴿ ℕ)) 7      -- ℕ ⇒ ℕ  then ℕ
 
 Here `Xᴸ` is the single type variable in the left type context, and `Xᴿ`,
 `Yᴿ`, and `Zᴿ` are the three type variables in the right type context. The

--- a/GTSFImp/Rationale.md
+++ b/GTSFImp/Rationale.md
@@ -336,8 +336,6 @@ order of the untouched variables. When no such center is free, parking
 space comes from extending the center context (see the world-support
 section below).
 
-Representative instances of each move:
-
 The diagram is oriented like the record: `RebaseAt W W′ Xᴸ Xᴿ` aligns
 the pivots in its second index, and the wrapper rules read the same
 record in both directions (reveal descends along it, conceal ascends —

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -7,9 +7,12 @@ module proof.DGG.CastTermImprecision2 where
 --     center context.
 --   * Represents local rebasing explicitly, letting reveal/conceal wrappers
 --     descend with a different alignment.
---   * Rebasing is pivot-local: a RebaseAt keeps the runtime stores, the
---     center context, and the imprecision environment fixed, and moves at
---     most the embeddings of the two pivot variables.
+--   * Rebasing is pivot-local: a RebaseAt keeps the runtime stores and
+--     the center context fixed and moves at most the embeddings of the
+--     two pivot variables.  Imprecision marks are not pinned by the
+--     rebase; instead every wrapper rule carries ImpEnvMono, letting
+--     marks decay toward X⊑★ from conclusion to premise, and WFWorld
+--     names the worlds whose precise marks are honestly aligned.
 --   * Store representations are canonical: a pivot variable is compared
 --     through resolveVar, which follows the store's representation chain
 --     to its end instead of stopping at an arbitrary intermediate type.
@@ -37,6 +40,7 @@ open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_; map)
 open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat as Nat using (ℕ)
+open import Data.Product using (Σ-syntax)
 import Data.Fin as Fin
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 
@@ -159,6 +163,38 @@ record SameRuntime {Δᴸ Δᴿ Δ}
     sourceStore-same : sourceStoreʷ W′ ≡ sourceStoreʷ W
     targetStore-same : targetStoreʷ W′ ≡ targetStoreʷ W
 
+-- Imprecision marks may only decay toward the dynamic type as a rule
+-- descends into its premise: every center the conclusion world marks
+-- X⊑★ stays X⊑★ in the premise world, while precise marks may weaken
+-- to X⊑★.  Equality is too strong: a rebase that displaces a target
+-- variable leaves its old partner precise but unaligned, and the
+-- stale mark blocks tag cancellation (see
+-- proof.DGG.ExtraCastRight2Counterexample).  Each wrapper rule
+-- carries this premise from its conclusion world to its premise
+-- world; the rebase records no longer constrain the marks.
+
+ImpEnvMono : ∀ {Δᴸ Δᴿ Δ}
+  → World Δᴸ Δᴿ Δ
+  → World Δᴸ Δᴿ Δ
+  → Set
+ImpEnvMono W W′ =
+  ∀ Z → impEnvʷ W Z ≡ X⊑★ → impEnvʷ W′ Z ≡ X⊑★
+
+-- A world is mark-honest when every source variable whose center is
+-- marked precise has an aligned target variable.  This is the world
+-- invariant that outlaws stale precise marks: the counterexample's
+-- input world fails it at the displaced source variable, and the
+-- repaired derivation dynamizes into a world that satisfies it.
+-- There is no mirror condition for target variables because type
+-- imprecision has no rule with a bare variable on the imprecise side.
+
+WFWorld : ∀ {Δᴸ Δᴿ Δ} → World Δᴸ Δᴿ Δ → Set
+WFWorld {Δᴸ} {Δᴿ} W =
+  ∀ (Xᴸ : TyVar Δᴸ)
+  → impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ) ≡ X⊑X
+  → Σ[ Xᴿ ∈ TyVar Δᴿ ]
+      toRenameᵗ (ηᴿʷ W) Xᴿ ≡ toRenameᵗ (ηᴸʷ W) Xᴸ
+
 ------------------------------------------------------------------------
 -- Term-context imprecision in local worlds
 ------------------------------------------------------------------------
@@ -277,7 +313,6 @@ record RebaseAt {Δᴸ Δᴿ Δ} (W W′ : World Δᴸ Δᴿ Δ)
       → toRenameᵗ (ηᴸʷ W′) Y ≡ toRenameᵗ (ηᴸʷ W) Y
     ηᴿ-off-pivot : ∀ {Y} → Y ≢ Xᴿ
       → toRenameᵗ (ηᴿʷ W′) Y ≡ toRenameᵗ (ηᴿʷ W) Y
-    sameImpEnv : ∀ Z → impEnvʷ W′ Z ≡ impEnvʷ W Z
     pivotAligned : toRenameᵗ (ηᴸʷ W′) Xᴸ ≡ toRenameᵗ (ηᴿʷ W′) Xᴿ
     storeRepresentations : StoreRepImp W′ Xᴸ Xᴿ
 
@@ -289,7 +324,7 @@ sameWorldRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
   → RebaseAt W W Xᴸ Xᴿ
 sameWorldRebaseAt =
   rebase-at (same-runtime refl refl)
-    (λ _ → refl) (λ _ → refl) (λ _ → refl)
+    (λ _ → refl) (λ _ → refl)
 
 -- One-sided wrappers carry an optional pivot: a conversion with no
 -- pivot (an identity-shaped conversion) keeps the world fixed, and a
@@ -518,6 +553,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
   ⊑reveal² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A B B′ Xᴿ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c′ : Conv↑ Δᴿ B B′}
+    → ImpEnvMono W W′
     → RebaseAtᴿ W W′ Xᴿ?
     → SameCtx γ γ′
     → targetStoreʷ W ⊢↑[ Xᴿ? ] c′
@@ -529,6 +565,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
   ⊑conceal² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A B B′ Xᴿ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c′ : Conv↓ Δᴿ B B′}
+    → ImpEnvMono W W′
     → RebaseAtᴿ W′ W Xᴿ?
     → SameCtx γ γ′
     → targetStoreʷ W ⊢↓[ Xᴿ? ] c′
@@ -548,6 +585,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
   reveal⊑² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↑ Δᴸ A A′}
+    → ImpEnvMono W W′
     → RebaseAtᴸ W W′ Xᴸ?
     → SameCtx γ γ′
     → sourceStoreʷ W ⊢↑[ Xᴸ? ] c
@@ -559,6 +597,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
   conceal⊑² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↓ Δᴸ A A′}
+    → ImpEnvMono W W′
     → RebaseAtᴸ W′ W Xᴸ?
     → SameCtx γ γ′
     → sourceStoreʷ W ⊢↓[ Xᴸ? ] c
@@ -572,6 +611,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       {M M′ A A′ B B′ Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ Wᵖ ⟩ A′}
       {c : Conv↑ Δᴸ A B} {c′ : Conv↑ Δᴿ A′ B′}
+    → ImpEnvMono W Wᵖ
     → RebaseAt W Wᵖ Xᴸ Xᴿ
     → SameCtx γ γᵖ
     → sourceStoreʷ W ⊢↑[ just Xᴸ ] c
@@ -586,6 +626,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       {M M′ A A′ B B′ Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ Wᵖ ⟩ A′}
       {c : Conv↓ Δᴸ A B} {c′ : Conv↓ Δᴿ A′ B′}
+    → ImpEnvMono W Wᵖ
     → RebaseAt Wᵖ W Xᴸ Xᴿ
     → SameCtx γ γᵖ
     → sourceStoreʷ W ⊢↓[ just Xᴸ ] c
@@ -696,14 +737,14 @@ example12-rebase-X-to-Z :
     Fin.zero (Fin.suc (Fin.suc Fin.zero))
 example12-rebase-X-to-Z =
   rebase-at (same-runtime refl refl)
-    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl) (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
     refl example12-Z-representation
 
 example12-rebase-X-to-Y :
   RebaseAt example12-world-X example12-world-Y Fin.zero (Fin.suc Fin.zero)
 example12-rebase-X-to-Y =
   rebase-at (same-runtime refl refl)
-    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl) (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
     refl example12-Y-representation
 
 example12-outer-function :
@@ -831,7 +872,7 @@ example12-nat-chain-rebase-X-to-Y :
     Fin.zero Fin.zero
 example12-nat-chain-rebase-X-to-Y =
   rebase-at (same-runtime refl refl)
-    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl) (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
     refl example12-nat-chain-Y-representation
 
 ------------------------------------------------------------------------
@@ -944,7 +985,7 @@ example12-left-path-rebase-X-to-Z :
     (Fin.suc (Fin.suc Fin.zero)) Fin.zero
 example12-left-path-rebase-X-to-Z =
   rebase-at (same-runtime refl refl)
-    (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
+    (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
     refl example12-left-path-Z-representation
 
 example12-left-path-rebase-X-to-Y :
@@ -952,5 +993,5 @@ example12-left-path-rebase-X-to-Y :
     (Fin.suc Fin.zero) Fin.zero
 example12-left-path-rebase-X-to-Y =
   rebase-at (same-runtime refl refl)
-    (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
+    (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
     refl example12-left-path-Y-representation

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -636,10 +636,14 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -------------------------------------
     → W ∣ γ ⊢² M ↓ c ⊑ M′ ↓ c′ ∶ q
 
-  blame⊑blame² : ∀ {A B}
+  -- Source blame is below any well-typed target term: once the more
+  -- dynamic side has blamed, the imprecision claim places no further
+  -- constraint on the more precise side.
+  blame⊑² : ∀ {M′ A B}
+    → ⟨ Δᴿ , targetStoreʷ W , tgtCtxʷ γ ⟩ ⊢ M′ ⦂ B
     → (p : A ⊑ᵂ⟨ W ⟩ B)
       ------------------------------
-    → W ∣ γ ⊢² blame ⊑ blame ∶ p
+    → W ∣ γ ⊢² blame ⊑ M′ ∶ p
 
   ⊕⊑⊕² : (op : Prim)
     → ∀ {L L′ M M′}

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -311,8 +311,13 @@ data RebaseAtᴸ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ �
   -- must sit below ★; there is no alignment to change, so the world
   -- stays fixed.  Type imprecision has no rule with a bare variable on
   -- the imprecise side, so RebaseAtᴿ needs no mirror constructor.
+  -- The disalignment premise makes "no aligned target variable"
+  -- explicit: no target variable embeds at the pivot's center, which
+  -- lets inversion refute the X⊑X view of a concealed pivot.
   rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
     → impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (ηᴿʷ W) Xᴿ ≢ toRenameᵗ (ηᴸʷ W) Xᴸ)
     → resolveVar (sourceStoreʷ W) Xᴸ ⊑ᵂ⟨ W ⟩ ★
       -------------------------
     → RebaseAtᴸ W W (just Xᴸ)

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -457,8 +457,13 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -------------------------------------------------
     → W ∣ γ ⊢² Λ V ⊑ Λ V′ ∶ q
 
+  -- The NonVar and occurrence premises mirror the ∀⊑ type rule; the
+  -- extra-cast-right inversion needs them to refute the ∀⊑∀ and
+  -- bot-elim views of q.
   Λ⊑² : ∀ {γ′ V M A B}
       {p : A ⊑ᵂ⟨ liftWorldLeft X⊑★ W ⟩ B}
+    → NonVar A
+    → Fin.zero ∈ᵗ A
     → LiftCtxᴸ X⊑★ γ γ′
     → Value V
     → ⟨ Δᴿ , targetStoreʷ W , tgtCtxʷ γ ⟩ ⊢ M ⦂ B

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -636,9 +636,10 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -------------------------------------
     → W ∣ γ ⊢² M ↓ c ⊑ M′ ↓ c′ ∶ q
 
-  -- Source blame is below any well-typed target term: once the more
-  -- dynamic side has blamed, the imprecision claim places no further
-  -- constraint on the more precise side.
+  -- Source blame is below any well-typed target term.  The left side
+  -- is the more static one (A ⊑ ★ for any closed type A, with ★ on
+  -- the right): once the more static side has blamed, imprecision
+  -- places no constraint on the more dynamic side.
   blame⊑² : ∀ {M′ A B}
     → ⟨ Δᴿ , targetStoreʷ W , tgtCtxʷ γ ⟩ ⊢ M′ ⦂ B
     → (p : A ⊑ᵂ⟨ W ⟩ B)

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -17,6 +17,12 @@ module proof.DGG.CastTermImprecision2 where
 --     built only from identity leaves has no pivot and its wrapper rule
 --     keeps the world fixed; only a conversion that seals or unseals an
 --     actual variable can rebase, and only at that variable.
+--   * Source-only structure needs no target counterpart: Λ⊑² lifts the
+--     world on the left only and compares the target term unweakened,
+--     and a rebase-onlyᴸ pivot handles a source variable with no
+--     aligned target variable, justified by the target seeing ★ there.
+--     There is no right-only mirror because type imprecision has no
+--     rule with a bare variable on the imprecise side.
 --   * Records the Example 12 alignments Xᴸ≅Xᴿ, Xᴸ≅Zᴿ, and Xᴸ≅Yᴿ as first-class
 --     store-representation witnesses.
 --   * Records a left-hand analogue of Example 12 where the source store, not
@@ -98,6 +104,20 @@ liftWorldBoth v W =
     (extendᵐ v (impEnvʷ W))
     (store-lift (sourceStoreʷ W))
     (store-lift (targetStoreʷ W))
+
+-- A universal binder on the source side only: the target context, its
+-- store, and its embedding stay fixed, so target terms and types cross
+-- the binder unweakened.
+
+liftWorldLeft : ∀ {Δᴸ Δᴿ Δ}
+  → VarImp
+  → World Δᴸ Δᴿ Δ
+  → World (Nat.suc Δᴸ) Δᴿ (Nat.suc Δ)
+liftWorldLeft v W =
+  world (keep (ηᴸʷ W)) (skip (ηᴿʷ W))
+    (extendᵐ v (impEnvʷ W))
+    (store-lift (sourceStoreʷ W))
+    (targetStoreʷ W)
 
 leftOnlyWorld : ∀ {Δᴸ Δᴿ Δ}
   → VarImp
@@ -198,6 +218,16 @@ data LiftCtx {Δᴸ Δᴿ Δ} (v : VarImp) {W : World Δᴸ Δᴿ Δ} :
     → LiftCtx v (ctx-imp A B p ∷ γ)
         (ctx-imp (⇑ᵗ A) (⇑ᵗ B) p′ ∷ γ′)
 
+data LiftCtxᴸ {Δᴸ Δᴿ Δ} (v : VarImp) {W : World Δᴸ Δᴿ Δ} :
+    CtxImp W → CtxImp (liftWorldLeft v W) → Set where
+  liftᴸ-[] : LiftCtxᴸ v [] []
+
+  liftᴸ-∷ : ∀ {γ γ′ A B p p′}
+    → LiftCtxᴸ v γ γ′
+      -------------------------------------------------------------
+    → LiftCtxᴸ v (ctx-imp A B p ∷ γ)
+        (ctx-imp (⇑ᵗ A) B p′ ∷ γ′)
+
 ------------------------------------------------------------------------
 -- Store representations and local rebasing
 ------------------------------------------------------------------------
@@ -275,6 +305,17 @@ data RebaseAtᴸ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ �
     → RebaseAt W W′ Xᴸ Xᴿ
       ---------------------------
     → RebaseAtᴸ W W′ (just Xᴸ)
+
+  -- A source pivot with no aligned target variable.  The target views
+  -- the pivot's center as dynamic, so its canonical representation
+  -- must sit below ★; there is no alignment to change, so the world
+  -- stays fixed.  Type imprecision has no rule with a bare variable on
+  -- the imprecise side, so RebaseAtᴿ needs no mirror constructor.
+  rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → resolveVar (sourceStoreʷ W) Xᴸ ⊑ᵂ⟨ W ⟩ ★
+      -------------------------
+    → RebaseAtᴸ W W (just Xᴸ)
 
 data RebaseAtᴿ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ
     → Maybe (TyVar Δᴿ) → Set where
@@ -417,11 +458,11 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
     → W ∣ γ ⊢² Λ V ⊑ Λ V′ ∶ q
 
   Λ⊑² : ∀ {γ′ V M A B}
-      {p : A ⊑ᵂ⟨ liftWorldBoth X⊑★ W ⟩ ⇑ᵗ B}
-    → LiftCtx X⊑★ γ γ′
+      {p : A ⊑ᵂ⟨ liftWorldLeft X⊑★ W ⟩ B}
+    → LiftCtxᴸ X⊑★ γ γ′
     → Value V
     → ⟨ Δᴿ , targetStoreʷ W , tgtCtxʷ γ ⟩ ⊢ M ⦂ B
-    → liftWorldBoth X⊑★ W ∣ γ′ ⊢² V ⊑ ⇑ᵗᵐ M ∶ p
+    → liftWorldLeft X⊑★ W ∣ γ′ ⊢² V ⊑ M ∶ p
     → (q : `∀ A ⊑ᵂ⟨ W ⟩ B)
       -------------------------------------------
     → W ∣ γ ⊢² Λ V ⊑ M ∶ q

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -40,7 +40,7 @@ open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_; map)
 open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat as Nat using (ℕ)
-open import Data.Product using (Σ-syntax)
+open import Data.Product using (Σ-syntax; _,_)
 import Data.Fin as Fin
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 
@@ -314,6 +314,16 @@ record RebaseAt {Δᴸ Δᴿ Δ} (W W′ : World Δᴸ Δᴿ Δ)
     ηᴿ-off-pivot : ∀ {Y} → Y ≢ Xᴿ
       → toRenameᵗ (ηᴿʷ W′) Y ≡ toRenameᵗ (ηᴿʷ W) Y
     pivotAligned : toRenameᵗ (ηᴸʷ W′) Xᴸ ≡ toRenameᵗ (ηᴿʷ W′) Xᴿ
+    -- Moved-pivot anchoring: a target pivot that relocates between
+    -- the two worlds must sit aligned with some source variable in
+    -- the first world.  Example 12's chains never move the target
+    -- embedding, so their witnesses discharge the premise; the
+    -- MovedLinkProbe counterexample relocates its target pivot to a
+    -- center no source occupies, which this field outlaws, restoring
+    -- invertibility of the bare-seal boundary.
+    anchorᴿ : toRenameᵗ (ηᴿʷ W) Xᴿ ≢ toRenameᵗ (ηᴿʷ W′) Xᴿ
+      → Σ[ Xₒ ∈ TyVar Δᴸ ]
+          toRenameᵗ (ηᴸʷ W) Xₒ ≡ toRenameᵗ (ηᴿʷ W) Xᴿ
     storeRepresentations : StoreRepImp W′ Xᴸ Xᴿ
 
 sameWorldRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
@@ -322,9 +332,10 @@ sameWorldRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
   → StoreRepImp W Xᴸ Xᴿ
     --------------------
   → RebaseAt W W Xᴸ Xᴿ
-sameWorldRebaseAt =
+sameWorldRebaseAt aligned reps =
   rebase-at (same-runtime refl refl)
-    (λ _ → refl) (λ _ → refl)
+    (λ _ → refl) (λ _ → refl) aligned
+    (λ moved → ⊥-elim (moved refl)) reps
 
 -- One-sided wrappers carry an optional pivot: a conversion with no
 -- pivot (an identity-shaped conversion) keeps the world fixed, and a
@@ -743,14 +754,16 @@ example12-rebase-X-to-Z :
 example12-rebase-X-to-Z =
   rebase-at (same-runtime refl refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
-    refl example12-Z-representation
+    refl (λ moved → ⊥-elim (moved refl))
+    example12-Z-representation
 
 example12-rebase-X-to-Y :
   RebaseAt example12-world-X example12-world-Y Fin.zero (Fin.suc Fin.zero)
 example12-rebase-X-to-Y =
   rebase-at (same-runtime refl refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
-    refl example12-Y-representation
+    refl (λ moved → ⊥-elim (moved refl))
+    example12-Y-representation
 
 example12-outer-function :
   (＇ Fin.zero ⇒ ＇ Fin.zero)
@@ -878,7 +891,8 @@ example12-nat-chain-rebase-X-to-Y :
 example12-nat-chain-rebase-X-to-Y =
   rebase-at (same-runtime refl refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
-    refl example12-nat-chain-Y-representation
+    refl (λ moved → ⊥-elim (moved refl))
+    example12-nat-chain-Y-representation
 
 ------------------------------------------------------------------------
 -- Example 12 variant with the representation path on the left
@@ -991,7 +1005,8 @@ example12-left-path-rebase-X-to-Z :
 example12-left-path-rebase-X-to-Z =
   rebase-at (same-runtime refl refl)
     (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    refl example12-left-path-Z-representation
+    refl (λ _ → Fin.zero , refl)
+    example12-left-path-Z-representation
 
 example12-left-path-rebase-X-to-Y :
   RebaseAt example12-left-path-world-X example12-left-path-world-Y
@@ -999,4 +1014,5 @@ example12-left-path-rebase-X-to-Y :
 example12-left-path-rebase-X-to-Y =
   rebase-at (same-runtime refl refl)
     (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    refl example12-left-path-Y-representation
+    refl (λ _ → Fin.zero , refl)
+    example12-left-path-Y-representation

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -7,6 +7,12 @@ module proof.DGG.CastTermImprecision2 where
 --     center context.
 --   * Represents local rebasing explicitly, letting reveal/conceal wrappers
 --     descend with a different alignment.
+--   * Rebasing is pivot-local: a RebaseAt keeps the runtime stores, the
+--     center context, and the imprecision environment fixed, and moves at
+--     most the embeddings of the two pivot variables.
+--   * Store representations are canonical: a pivot variable is compared
+--     through resolveVar, which follows the store's representation chain
+--     to its end instead of stopping at an arbitrary intermediate type.
 --   * Records the Example 12 alignments Xᴸ≅Xᴿ, Xᴸ≅Zᴿ, and Xᴸ≅Yᴿ as first-class
 --     store-representation witnesses.
 --   * Records a left-hand analogue of Example 12 where the source store, not
@@ -17,10 +23,11 @@ module proof.DGG.CastTermImprecision2 where
 --     So don't add rules unless they are absolutely necessary!
 --     Avoid rules that are not syntax directed.
 
+open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_; map)
 open import Data.Nat as Nat using (ℕ)
 import Data.Fin as Fin
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 
 open import Types
 open import TyStore using
@@ -120,8 +127,8 @@ bothBindWorld v W A B =
     (store-bind (sourceStoreʷ W) A)
     (store-bind (targetStoreʷ W) B)
 
-record SameRuntime {Δᴸ Δᴿ Δ Δ′}
-    (W : World Δᴸ Δᴿ Δ) (W′ : World Δᴸ Δᴿ Δ′) : Set where
+record SameRuntime {Δᴸ Δᴿ Δ}
+    (W W′ : World Δᴸ Δᴿ Δ) : Set where
   constructor same-runtime
   field
     sourceStore-same : sourceStoreʷ W′ ≡ sourceStoreʷ W
@@ -190,42 +197,52 @@ data LiftCtx {Δᴸ Δᴿ Δ} (v : VarImp) {W : World Δᴸ Δᴿ Δ} :
 -- Store representations and local rebasing
 ------------------------------------------------------------------------
 
-data LeadsTo : ∀ {Δ} → TyStore Δ → Ty Δ → Ty Δ → Set where
-  leads-here : ∀ {Δ} {Σ : TyStore Δ} {A : Ty Δ}
-      ------------------
-    → LeadsTo Σ A A
+-- A type variable's canonical store representation: follow the store's
+-- representation chain until it ends at a non-variable type or at a
+-- store-lift (universally bound) variable.  Chains terminate because a
+-- store-bind entry mentions only strictly older variables, so both
+-- functions recurse on the tail of the store.
 
-  leads-var : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ} {A B : Ty Δ}
-    → Σ ∋ X ⦂ A
-    → LeadsTo Σ A B
-      -----------------------
-    → LeadsTo Σ (＇ X) B
+resolveVar : ∀ {Δ} → TyStore Δ → TyVar Δ → Ty Δ
+resolveRep : ∀ {Δ} → TyStore Δ → Ty Δ → Ty Δ
 
-infix 4 _⊢_↝_
+resolveVar (store-lift Σ) Fin.zero = ＇ Fin.zero
+resolveVar (store-lift Σ) (Fin.suc X) = ⇑ᵗ (resolveVar Σ X)
+resolveVar (store-bind Σ A) Fin.zero = ⇑ᵗ (resolveRep Σ A)
+resolveVar (store-bind Σ A) (Fin.suc X) = ⇑ᵗ (resolveVar Σ X)
 
-data _⊢_↝_ {Δ} (Σ : TyStore Δ) : TyVar Δ → Ty Δ → Set where
-  var-leads : ∀ {X A B}
-    → Σ ∋ X ⦂ A
-    → LeadsTo Σ A B
-      ----------------
-    → Σ ⊢ X ↝ B
+resolveRep Σ (＇ X) = resolveVar Σ X
+resolveRep Σ (‵ ι) = ‵ ι
+resolveRep Σ ★ = ★
+resolveRep Σ (A ⇒ B) = A ⇒ B
+resolveRep Σ (`∀ A) = `∀ A
 
 record StoreRepImp {Δᴸ Δᴿ Δ} (W : World Δᴸ Δᴿ Δ)
     (Xᴸ : TyVar Δᴸ) (Xᴿ : TyVar Δᴿ) : Set where
   constructor store-rep-imp
   field
-    sourceRepTy : Ty Δᴸ
-    targetRepTy : Ty Δᴿ
-    sourceRep : sourceStoreʷ W ⊢ Xᴸ ↝ sourceRepTy
-    targetRep : targetStoreʷ W ⊢ Xᴿ ↝ targetRepTy
-    represented : sourceRepTy ⊑ᵂ⟨ W ⟩ targetRepTy
+    represented :
+      resolveVar (sourceStoreʷ W) Xᴸ
+        ⊑ᵂ⟨ W ⟩ resolveVar (targetStoreʷ W) Xᴿ
 
-record RebaseAt {Δᴸ Δᴿ Δ Δ′}
-    (W : World Δᴸ Δᴿ Δ) (W′ : World Δᴸ Δᴿ Δ′)
+-- RebaseAt W W′ Xᴸ Xᴿ is a pivot-local world update.  Reduction only
+-- introduces one reveal or conceal wrapper per fresh type variable, so
+-- descending through one wrapper may change at most the alignment of
+-- the pivot pair: the stores, the center context, and the imprecision
+-- environment stay fixed, both embeddings agree at every non-pivot
+-- variable, the pivots are aligned in W′, and their canonical store
+-- representations are related in W′.
+
+record RebaseAt {Δᴸ Δᴿ Δ} (W W′ : World Δᴸ Δᴿ Δ)
     (Xᴸ : TyVar Δᴸ) (Xᴿ : TyVar Δᴿ) : Set where
   constructor rebase-at
   field
     sameRuntime : SameRuntime W W′
+    ηᴸ-off-pivot : ∀ {Y} → Y ≢ Xᴸ
+      → toRenameᵗ (ηᴸʷ W′) Y ≡ toRenameᵗ (ηᴸʷ W) Y
+    ηᴿ-off-pivot : ∀ {Y} → Y ≢ Xᴿ
+      → toRenameᵗ (ηᴿʷ W′) Y ≡ toRenameᵗ (ηᴿʷ W) Y
+    sameImpEnv : ∀ Z → impEnvʷ W′ Z ≡ impEnvʷ W Z
     pivotAligned : toRenameᵗ (ηᴸʷ W′) Xᴸ ≡ toRenameᵗ (ηᴿʷ W′) Xᴿ
     storeRepresentations : StoreRepImp W′ Xᴸ Xᴿ
 
@@ -235,7 +252,9 @@ sameWorldRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
   → StoreRepImp W Xᴸ Xᴿ
     --------------------
   → RebaseAt W W Xᴸ Xᴿ
-sameWorldRebaseAt = rebase-at (same-runtime refl refl)
+sameWorldRebaseAt =
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl) (λ _ → refl) (λ _ → refl)
 
 ------------------------------------------------------------------------
 -- Conversion typing indexed by the converted variable
@@ -399,7 +418,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -----------------------------
     → W ∣ γ ⊢² M ⊑ M′ ↑ c′ ∶ q
 
-  ⊑reveal² : ∀ {Δ′} {W′ : World Δᴸ Δᴿ Δ′}
+  ⊑reveal² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A B B′ Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c′ : Conv↑ Δᴿ B B′}
     → RebaseAt W W′ Xᴸ Xᴿ
@@ -410,7 +429,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -----------------------------
     → W ∣ γ ⊢² M ⊑ M′ ↑ c′ ∶ q
 
-  ⊑conceal² : ∀ {Δ′} {W′ : World Δᴸ Δᴿ Δ′}
+  ⊑conceal² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A B B′ Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c′ : Conv↓ Δᴿ B B′}
     → RebaseAt W′ W Xᴸ Xᴿ
@@ -429,7 +448,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -----------------------------
     → W ∣ γ ⊢² M ⟨ c ⟩ ⊑ M′ ∶ q
 
-  reveal⊑² : ∀ {Δ′} {W′ : World Δᴸ Δᴿ Δ′}
+  reveal⊑² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↑ Δᴸ A A′}
     → RebaseAt W W′ Xᴸ Xᴿ
@@ -440,7 +459,7 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -----------------------------
     → W ∣ γ ⊢² M ↑ c ⊑ M′ ∶ q
 
-  conceal⊑² : ∀ {Δ′} {W′ : World Δᴸ Δᴿ Δ′}
+  conceal⊑² : ∀ {W′ : World Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↓ Δᴸ A A′}
     → RebaseAt W′ W Xᴸ Xᴿ
@@ -451,8 +470,8 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -----------------------------
     → W ∣ γ ⊢² M ↓ c ⊑ M′ ∶ q
 
-  reveal⊑reveal² : ∀ {Δᵖ}
-      {Wᵖ : World Δᴸ Δᴿ Δᵖ} {γᵖ : CtxImp Wᵖ}
+  reveal⊑reveal² : ∀
+      {Wᵖ : World Δᴸ Δᴿ Δ} {γᵖ : CtxImp Wᵖ}
       {M M′ A A′ B B′ Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ Wᵖ ⟩ A′}
       {c : Conv↑ Δᴸ A B} {c′ : Conv↑ Δᴿ A′ B′}
@@ -465,8 +484,8 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -------------------------------------
     → W ∣ γ ⊢² M ↑ c ⊑ M′ ↑ c′ ∶ q
 
-  conceal⊑conceal² : ∀ {Δᵖ}
-      {Wᵖ : World Δᴸ Δᴿ Δᵖ} {γᵖ : CtxImp Wᵖ}
+  conceal⊑conceal² : ∀
+      {Wᵖ : World Δᴸ Δᴿ Δ} {γᵖ : CtxImp Wᵖ}
       {M M′ A A′ B B′ Xᴸ Xᴿ}
       {p : A ⊑ᵂ⟨ Wᵖ ⟩ A′}
       {c : Conv↓ Δᴸ A B} {c′ : Conv↓ Δᴿ A′ B′}
@@ -564,43 +583,31 @@ example12-target-Z∋ :
   example12-target-store ∋ Fin.suc (Fin.suc Fin.zero) ⦂ ★
 example12-target-Z∋ = S-bind∋ (S-bind∋ (Z∋ refl) refl) refl
 
-example12-Z-leads-star :
-  LeadsTo example12-target-store (＇ (Fin.suc (Fin.suc Fin.zero))) ★
-example12-Z-leads-star = leads-var example12-target-Z∋ leads-here
-
 example12-X-representation : StoreRepImp example12-world-X Fin.zero Fin.zero
-example12-X-representation =
-  store-rep-imp (‵ `ℕ) (‵ `ℕ)
-    (var-leads example12-source-X∋ leads-here)
-    (var-leads example12-target-X∋ leads-here)
-    ι⊑ι
+example12-X-representation = store-rep-imp ι⊑ι
 
 example12-Z-representation :
   StoreRepImp example12-world-Z Fin.zero (Fin.suc (Fin.suc Fin.zero))
-example12-Z-representation =
-  store-rep-imp (‵ `ℕ) ★
-    (var-leads example12-source-X∋ leads-here)
-    (var-leads example12-target-Z∋ leads-here)
-    ι⊑★
+example12-Z-representation = store-rep-imp ι⊑★
 
 example12-Y-representation :
   StoreRepImp example12-world-Y Fin.zero (Fin.suc Fin.zero)
-example12-Y-representation =
-  store-rep-imp (‵ `ℕ) ★
-    (var-leads example12-source-X∋ leads-here)
-    (var-leads example12-target-Y∋ example12-Z-leads-star)
-    ι⊑★
+example12-Y-representation = store-rep-imp ι⊑★
 
 example12-rebase-X-to-Z :
   RebaseAt example12-world-X example12-world-Z
     Fin.zero (Fin.suc (Fin.suc Fin.zero))
 example12-rebase-X-to-Z =
-  rebase-at (same-runtime refl refl) refl example12-Z-representation
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl) (λ _ → refl)
+    refl example12-Z-representation
 
 example12-rebase-X-to-Y :
   RebaseAt example12-world-X example12-world-Y Fin.zero (Fin.suc Fin.zero)
 example12-rebase-X-to-Y =
-  rebase-at (same-runtime refl refl) refl example12-Y-representation
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl) (λ _ → refl)
+    refl example12-Y-representation
 
 example12-outer-function :
   (＇ Fin.zero ⇒ ＇ Fin.zero)
@@ -710,34 +717,21 @@ example12-nat-chain-target-X∋ :
   example12-nat-chain-target-store ∋ Fin.suc Fin.zero ⦂ ‵ `ℕ
 example12-nat-chain-target-X∋ = S-bind∋ (Z∋ refl) refl
 
-example12-nat-chain-target-X⇝ℕ :
-  LeadsTo example12-nat-chain-target-store (＇ (Fin.suc Fin.zero)) (‵ `ℕ)
-example12-nat-chain-target-X⇝ℕ =
-  leads-var example12-nat-chain-target-X∋ leads-here
-
 example12-nat-chain-X-representation :
   StoreRepImp example12-nat-chain-world-X Fin.zero (Fin.suc Fin.zero)
-example12-nat-chain-X-representation =
-  store-rep-imp (‵ `ℕ) (‵ `ℕ)
-    (var-leads example12-nat-chain-source-X∋ leads-here)
-    (var-leads example12-nat-chain-target-X∋ leads-here)
-    ι⊑ι
+example12-nat-chain-X-representation = store-rep-imp ι⊑ι
 
 example12-nat-chain-Y-representation :
   StoreRepImp example12-nat-chain-world-Y Fin.zero Fin.zero
-example12-nat-chain-Y-representation =
-  store-rep-imp (‵ `ℕ) (‵ `ℕ)
-    (var-leads example12-nat-chain-source-X∋ leads-here)
-    (var-leads example12-nat-chain-target-Y∋
-      example12-nat-chain-target-X⇝ℕ)
-    ι⊑ι
+example12-nat-chain-Y-representation = store-rep-imp ι⊑ι
 
 example12-nat-chain-rebase-X-to-Y :
   RebaseAt example12-nat-chain-world-X example12-nat-chain-world-Y
     Fin.zero Fin.zero
 example12-nat-chain-rebase-X-to-Y =
-  rebase-at (same-runtime refl refl) refl
-    example12-nat-chain-Y-representation
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl) (λ _ → refl)
+    refl example12-nat-chain-Y-representation
 
 ------------------------------------------------------------------------
 -- Example 12 variant with the representation path on the left
@@ -831,53 +825,31 @@ example12-left-path-target-U∋ :
   example12-left-path-target-store ∋ Fin.zero ⦂ ★
 example12-left-path-target-U∋ = Z∋ refl
 
-example12-left-path-source-Z⇝★ :
-  LeadsTo example12-left-path-source-store
-    (＇ (Fin.suc (Fin.suc Fin.zero))) ★
-example12-left-path-source-Z⇝★ =
-  leads-var example12-left-path-source-Z∋ leads-here
-
-example12-left-path-source-Y⇝★ :
-  LeadsTo example12-left-path-source-store (＇ (Fin.suc Fin.zero)) ★
-example12-left-path-source-Y⇝★ =
-  leads-var example12-left-path-source-Y∋ example12-left-path-source-Z⇝★
-
 example12-left-path-X-representation :
   StoreRepImp example12-left-path-world-X Fin.zero Fin.zero
-example12-left-path-X-representation =
-  store-rep-imp (‵ `ℕ) ★
-    (var-leads example12-left-path-source-X∋ leads-here)
-    (var-leads example12-left-path-target-U∋ leads-here)
-    ι⊑★
+example12-left-path-X-representation = store-rep-imp ι⊑★
 
 example12-left-path-Z-representation :
   StoreRepImp example12-left-path-world-Z
     (Fin.suc (Fin.suc Fin.zero)) Fin.zero
-example12-left-path-Z-representation =
-  store-rep-imp ★ ★
-    (var-leads example12-left-path-source-Z∋ leads-here)
-    (var-leads example12-left-path-target-U∋ leads-here)
-    ★⊑★
+example12-left-path-Z-representation = store-rep-imp ★⊑★
 
 example12-left-path-Y-representation :
   StoreRepImp example12-left-path-world-Y (Fin.suc Fin.zero) Fin.zero
-example12-left-path-Y-representation =
-  store-rep-imp ★ ★
-    (var-leads example12-left-path-source-Y∋
-      example12-left-path-source-Z⇝★)
-    (var-leads example12-left-path-target-U∋ leads-here)
-    ★⊑★
+example12-left-path-Y-representation = store-rep-imp ★⊑★
 
 example12-left-path-rebase-X-to-Z :
   RebaseAt example12-left-path-world-X example12-left-path-world-Z
     (Fin.suc (Fin.suc Fin.zero)) Fin.zero
 example12-left-path-rebase-X-to-Z =
-  rebase-at (same-runtime refl refl) refl
-    example12-left-path-Z-representation
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
+    refl example12-left-path-Z-representation
 
 example12-left-path-rebase-X-to-Y :
   RebaseAt example12-left-path-world-X example12-left-path-world-Y
     (Fin.suc Fin.zero) Fin.zero
 example12-left-path-rebase-X-to-Y =
-  rebase-at (same-runtime refl refl) refl
-    example12-left-path-Y-representation
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl) (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) }) (λ _ → refl)
+    refl example12-left-path-Y-representation

--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -13,6 +13,10 @@ module proof.DGG.CastTermImprecision2 where
 --   * Store representations are canonical: a pivot variable is compared
 --     through resolveVar, which follows the store's representation chain
 --     to its end instead of stopping at an arbitrary intermediate type.
+--   * Conversion typing is indexed by an optional pivot.  A conversion
+--     built only from identity leaves has no pivot and its wrapper rule
+--     keeps the world fixed; only a conversion that seals or unseals an
+--     actual variable can rebase, and only at that variable.
 --   * Records the Example 12 alignments Xᴸ≅Xᴿ, Xᴸ≅Zᴿ, and Xᴸ≅Yᴿ as first-class
 --     store-representation witnesses.
 --   * Records a left-hand analogue of Example 12 where the source store, not
@@ -25,6 +29,7 @@ module proof.DGG.CastTermImprecision2 where
 
 open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_; map)
+open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat as Nat using (ℕ)
 import Data.Fin as Fin
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
@@ -256,68 +261,119 @@ sameWorldRebaseAt =
   rebase-at (same-runtime refl refl)
     (λ _ → refl) (λ _ → refl) (λ _ → refl)
 
+-- One-sided wrappers carry an optional pivot: a conversion with no
+-- pivot (an identity-shaped conversion) keeps the world fixed, and a
+-- conversion pivoted on a variable may rebase exactly there.
+
+data RebaseAtᴸ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Set where
+  rebase-idᴸ : ∀ {W}
+      ------------------------
+    → RebaseAtᴸ W W nothing
+
+  rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt W W′ Xᴸ Xᴿ
+      ---------------------------
+    → RebaseAtᴸ W W′ (just Xᴸ)
+
+data RebaseAtᴿ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴿ) → Set where
+  rebase-idᴿ : ∀ {W}
+      ------------------------
+    → RebaseAtᴿ W W nothing
+
+  rebase-varᴿ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt W W′ Xᴸ Xᴿ
+      ---------------------------
+    → RebaseAtᴿ W W′ (just Xᴿ)
+
 ------------------------------------------------------------------------
--- Conversion typing indexed by the converted variable
+-- Conversion typing indexed by an optional converted variable
 ------------------------------------------------------------------------
+
+-- The pivot of a composite conversion is the join of the pivots of its
+-- halves: an identity half contributes nothing, and two variable halves
+-- must agree.  An all-identity conversion therefore has pivot nothing
+-- and cannot be retyped at an arbitrary variable.
+
+data PivotJoin {Δ : TyCtx} :
+    Maybe (TyVar Δ) → Maybe (TyVar Δ) → Maybe (TyVar Δ) → Set where
+  join-none :
+      ----------------------------------
+      PivotJoin nothing nothing nothing
+
+  join-left : ∀ {X}
+      ------------------------------------
+    → PivotJoin (just X) nothing (just X)
+
+  join-right : ∀ {X}
+      ------------------------------------
+    → PivotJoin nothing (just X) (just X)
+
+  join-both : ∀ {X}
+      -------------------------------------
+    → PivotJoin (just X) (just X) (just X)
 
 infix 4 _⊢↑[_]_ _⊢↓[_]_
 
 mutual
-  data _⊢↑[_]_ {Δ : TyCtx} (Σ : TyStore Δ) (X : TyVar Δ) :
-      ∀ {A B} → Conv↑ Δ A B → Set where
-    ⊢↑-unsealˣ : ∀ {R}
+  data _⊢↑[_]_ {Δ : TyCtx} (Σ : TyStore Δ) :
+      Maybe (TyVar Δ) → ∀ {A B} → Conv↑ Δ A B → Set where
+    ⊢↑-unsealˣ : ∀ {X R}
       → Σ ∋ X ⦂ R
-        ---------------------
-      → Σ ⊢↑[ X ] unseal X R
+        ----------------------------
+      → Σ ⊢↑[ just X ] unseal X R
 
-    ⊢↑-⇒ˣ : ∀ {A A′ B B′}
+    ⊢↑-⇒ˣ : ∀ {p q r A A′ B B′}
         {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
-      → Σ ⊢↓[ X ] c
-      → Σ ⊢↑[ X ] d
+      → PivotJoin p q r
+      → Σ ⊢↓[ p ] c
+      → Σ ⊢↑[ q ] d
         -----------------
-      → Σ ⊢↑[ X ] c ↦↑ d
+      → Σ ⊢↑[ r ] c ↦↑ d
 
-    ⊢↑-∀ˣ : ∀ {A B} {c : Conv↑ (Nat.suc Δ) A B}
-      → store-lift Σ ⊢↑[ Fin.suc X ] c
-        --------------------
-      → Σ ⊢↑[ X ] `∀↑ c
+    ⊢↑-∀ˣ : ∀ {X A B} {c : Conv↑ (Nat.suc Δ) A B}
+      → store-lift Σ ⊢↑[ just (Fin.suc X) ] c
+        -------------------------
+      → Σ ⊢↑[ just X ] `∀↑ c
+
+    ⊢↑-∀-idˣ : ∀ {A B} {c : Conv↑ (Nat.suc Δ) A B}
+      → store-lift Σ ⊢↑[ nothing ] c
+        -------------------------
+      → Σ ⊢↑[ nothing ] `∀↑ c
 
     ⊢↑-idˣ : ∀ {A}
-        -----------------
-      → Σ ⊢↑[ X ] id↑ A
+        -----------------------
+      → Σ ⊢↑[ nothing ] id↑ A
 
-  data _⊢↓[_]_ {Δ : TyCtx} (Σ : TyStore Δ) (X : TyVar Δ) :
-      ∀ {A B} → Conv↓ Δ A B → Set where
-    ⊢↓-sealˣ : ∀ {R}
+  data _⊢↓[_]_ {Δ : TyCtx} (Σ : TyStore Δ) :
+      Maybe (TyVar Δ) → ∀ {A B} → Conv↓ Δ A B → Set where
+    ⊢↓-sealˣ : ∀ {X R}
       → Σ ∋ X ⦂ R
-        -------------------
-      → Σ ⊢↓[ X ] seal X R
+        --------------------------
+      → Σ ⊢↓[ just X ] seal X R
 
-    ⊢↓-⇒ˣ : ∀ {A A′ B B′}
+    ⊢↓-⇒ˣ : ∀ {p q r A A′ B B′}
         {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
-      → Σ ⊢↑[ X ] c
-      → Σ ⊢↓[ X ] d
+      → PivotJoin p q r
+      → Σ ⊢↑[ p ] c
+      → Σ ⊢↓[ q ] d
         -----------------
-      → Σ ⊢↓[ X ] c ↦↓ d
+      → Σ ⊢↓[ r ] c ↦↓ d
 
-    ⊢↓-∀ˣ : ∀ {A B} {c : Conv↓ (Nat.suc Δ) A B}
-      → store-lift Σ ⊢↓[ Fin.suc X ] c
-        --------------------
-      → Σ ⊢↓[ X ] `∀↓ c
+    ⊢↓-∀ˣ : ∀ {X A B} {c : Conv↓ (Nat.suc Δ) A B}
+      → store-lift Σ ⊢↓[ just (Fin.suc X) ] c
+        -------------------------
+      → Σ ⊢↓[ just X ] `∀↓ c
+
+    ⊢↓-∀-idˣ : ∀ {A B} {c : Conv↓ (Nat.suc Δ) A B}
+      → store-lift Σ ⊢↓[ nothing ] c
+        -------------------------
+      → Σ ⊢↓[ nothing ] `∀↓ c
 
     ⊢↓-idˣ : ∀ {A}
-        -----------------
-      → Σ ⊢↓[ X ] id↓ A
-
-data IdentityReveal {Δ : TyCtx} : ∀ {A B} → Conv↑ Δ A B → Set where
-  identity-reveal-id : ∀ {A}
-      ---------------------------
-    → IdentityReveal (id↑ A)
-
-  identity-reveal-∀ : ∀ {A B} {c : Conv↑ (Nat.suc Δ) A B}
-    → IdentityReveal c
-      -------------------------
-    → IdentityReveal (`∀↑ c)
+        -----------------------
+      → Σ ⊢↓[ nothing ] id↓ A
 
 ------------------------------------------------------------------------
 -- Typed cast-term imprecision with recursive worlds
@@ -408,33 +464,23 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       -----------------------------
     → W ∣ γ ⊢² M ⊑ M′ ⟨ c′ ⟩ ∶ q
 
-  -- TODO: Find a way to remove the below rule
-  ⊑id-reveal² : ∀ {M M′ A B B′}
-      {p : A ⊑ᵂ⟨ W ⟩ B} {c′ : Conv↑ Δᴿ B B′}
-    → IdentityReveal c′
-    → targetStoreʷ W ⊢↑ c′
-    → W ∣ γ ⊢² M ⊑ M′ ∶ p
-    → (q : A ⊑ᵂ⟨ W ⟩ B′)
-      -----------------------------
-    → W ∣ γ ⊢² M ⊑ M′ ↑ c′ ∶ q
-
   ⊑reveal² : ∀ {W′ : World Δᴸ Δᴿ Δ}
-      {γ′ : CtxImp W′} {M M′ A B B′ Xᴸ Xᴿ}
+      {γ′ : CtxImp W′} {M M′ A B B′ Xᴿ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c′ : Conv↑ Δᴿ B B′}
-    → RebaseAt W W′ Xᴸ Xᴿ
+    → RebaseAtᴿ W W′ Xᴿ?
     → SameCtx γ γ′
-    → targetStoreʷ W ⊢↑[ Xᴿ ] c′
+    → targetStoreʷ W ⊢↑[ Xᴿ? ] c′
     → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
     → (q : A ⊑ᵂ⟨ W ⟩ B′)
       -----------------------------
     → W ∣ γ ⊢² M ⊑ M′ ↑ c′ ∶ q
 
   ⊑conceal² : ∀ {W′ : World Δᴸ Δᴿ Δ}
-      {γ′ : CtxImp W′} {M M′ A B B′ Xᴸ Xᴿ}
+      {γ′ : CtxImp W′} {M M′ A B B′ Xᴿ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c′ : Conv↓ Δᴿ B B′}
-    → RebaseAt W′ W Xᴸ Xᴿ
+    → RebaseAtᴿ W′ W Xᴿ?
     → SameCtx γ γ′
-    → targetStoreʷ W ⊢↓[ Xᴿ ] c′
+    → targetStoreʷ W ⊢↓[ Xᴿ? ] c′
     → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
     → (q : A ⊑ᵂ⟨ W ⟩ B′)
       -----------------------------
@@ -449,22 +495,22 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
     → W ∣ γ ⊢² M ⟨ c ⟩ ⊑ M′ ∶ q
 
   reveal⊑² : ∀ {W′ : World Δᴸ Δᴿ Δ}
-      {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ Xᴿ}
+      {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↑ Δᴸ A A′}
-    → RebaseAt W W′ Xᴸ Xᴿ
+    → RebaseAtᴸ W W′ Xᴸ?
     → SameCtx γ γ′
-    → sourceStoreʷ W ⊢↑[ Xᴸ ] c
+    → sourceStoreʷ W ⊢↑[ Xᴸ? ] c
     → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
     → (q : A′ ⊑ᵂ⟨ W ⟩ B)
       -----------------------------
     → W ∣ γ ⊢² M ↑ c ⊑ M′ ∶ q
 
   conceal⊑² : ∀ {W′ : World Δᴸ Δᴿ Δ}
-      {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ Xᴿ}
+      {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↓ Δᴸ A A′}
-    → RebaseAt W′ W Xᴸ Xᴿ
+    → RebaseAtᴸ W′ W Xᴸ?
     → SameCtx γ γ′
-    → sourceStoreʷ W ⊢↓[ Xᴸ ] c
+    → sourceStoreʷ W ⊢↓[ Xᴸ? ] c
     → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
     → (q : A′ ⊑ᵂ⟨ W ⟩ B)
       -----------------------------
@@ -477,8 +523,8 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       {c : Conv↑ Δᴸ A B} {c′ : Conv↑ Δᴿ A′ B′}
     → RebaseAt W Wᵖ Xᴸ Xᴿ
     → SameCtx γ γᵖ
-    → sourceStoreʷ W ⊢↑[ Xᴸ ] c
-    → targetStoreʷ W ⊢↑[ Xᴿ ] c′
+    → sourceStoreʷ W ⊢↑[ just Xᴸ ] c
+    → targetStoreʷ W ⊢↑[ just Xᴿ ] c′
     → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
     → (q : B ⊑ᵂ⟨ W ⟩ B′)
       -------------------------------------
@@ -491,8 +537,8 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       {c : Conv↓ Δᴸ A B} {c′ : Conv↓ Δᴿ A′ B′}
     → RebaseAt Wᵖ W Xᴸ Xᴿ
     → SameCtx γ γᵖ
-    → sourceStoreʷ W ⊢↓[ Xᴸ ] c
-    → targetStoreʷ W ⊢↓[ Xᴿ ] c′
+    → sourceStoreʷ W ⊢↓[ just Xᴸ ] c
+    → targetStoreʷ W ⊢↓[ just Xᴿ ] c′
     → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
     → (q : B ⊑ᵂ⟨ W ⟩ B′)
       -------------------------------------
@@ -659,6 +705,10 @@ example12-nat-chain-reveal = `∀↑ (id↑ Ex.X⇒X)
 example12-nat-chain-reveal-⊢ :
   store-empty ⊢↑ example12-nat-chain-reveal
 example12-nat-chain-reveal-⊢ = ⊢↑-∀ ⊢↑-id
+
+example12-nat-chain-reveal-⊢ˣ :
+  store-empty ⊢↑[ nothing ] example12-nat-chain-reveal
+example12-nat-chain-reveal-⊢ˣ = ⊢↑-∀-idˣ ⊢↑-idˣ
 
 example12-nat-chain-target : Term 0
 example12-nat-chain-target =

--- a/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
@@ -1,0 +1,285 @@
+module proof.DGG.CastTermImprecision2Typing where
+
+-- File Charter:
+--   * Projects source and target typing derivations from the version-2
+--     cast-term imprecision relation.
+--   * Provides the target projection needed by canonical-value inversion in
+--     ExtraCastRight2, transporting typing across SameCtx and pivot-local
+--     rebases whose runtime stores are unchanged.
+--   * Erases optional-pivot conversion typing to ordinary store validity.
+
+open import Data.List using ([]; _∷_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong)
+  renaming (subst to subst≡)
+
+open import Types
+open import TyStore using (TyStore)
+import TermCtx as T
+open import Conversion using
+  (Conv↑; Conv↓; _⊢↑_; _⊢↓_;
+   ⊢↑-unseal; ⊢↑-⇒; ⊢↑-∀; ⊢↑-id;
+   ⊢↓-seal; ⊢↓-⇒; ⊢↓-∀; ⊢↓-id)
+open import CastTerms
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; sourceStoreʷ; targetStoreʷ; CtxImp; ctx-imp; srcTyʷ; tgtTyʷ;
+   srcCtxʷ; tgtCtxʷ; _∋ʷ_⦂_; Zʷ; Sʷ; SameCtx; same-[]; same-∷;
+   LiftCtx; lift-[]; lift-∷; LiftCtxᴸ; liftᴸ-[]; liftᴸ-∷;
+   RebaseAt; RebaseAtᴸ; RebaseAtᴿ; _⊢↑[_]_; _⊢↓[_]_; _∣_⊢²_⊑_∶_)
+
+------------------------------------------------------------------------
+-- Context projections
+------------------------------------------------------------------------
+
+lookup-source : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {x e}
+  → γ ∋ʷ x ⦂ e
+  → srcCtxʷ γ T.∋ x ⦂ srcTyʷ e
+lookup-source Zʷ = T.Z
+lookup-source (Sʷ x∈) = T.S (lookup-source x∈)
+
+lookup-target : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {x e}
+  → γ ∋ʷ x ⦂ e
+  → tgtCtxʷ γ T.∋ x ⦂ tgtTyʷ e
+lookup-target Zʷ = T.Z
+lookup-target (Sʷ x∈) = T.S (lookup-target x∈)
+
+sameCtx-source : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CtxImp W′}
+  → SameCtx γ γ′
+  → srcCtxʷ γ ≡ srcCtxʷ γ′
+sameCtx-source same-[] = refl
+sameCtx-source (same-∷ sc) = cong (_ ∷_) (sameCtx-source sc)
+
+sameCtx-target : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CtxImp W′}
+  → SameCtx γ γ′
+  → tgtCtxʷ γ ≡ tgtCtxʷ γ′
+sameCtx-target same-[] = refl
+sameCtx-target (same-∷ sc) = cong (_ ∷_) (sameCtx-target sc)
+
+liftCtx-source : ∀ {Δᴸ Δᴿ Δ} {v} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γ′ : CtxImp (CTI2.liftWorldBoth v W)}
+  → LiftCtx v γ γ′
+  → srcCtxʷ γ′ ≡ T.⇑ᶜ (srcCtxʷ γ)
+liftCtx-source lift-[] = refl
+liftCtx-source (lift-∷ liftγ) = cong (_ ∷_) (liftCtx-source liftγ)
+
+liftCtx-target : ∀ {Δᴸ Δᴿ Δ} {v} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γ′ : CtxImp (CTI2.liftWorldBoth v W)}
+  → LiftCtx v γ γ′
+  → tgtCtxʷ γ′ ≡ T.⇑ᶜ (tgtCtxʷ γ)
+liftCtx-target lift-[] = refl
+liftCtx-target (lift-∷ liftγ) = cong (_ ∷_) (liftCtx-target liftγ)
+
+liftCtxᴸ-source : ∀ {Δᴸ Δᴿ Δ} {v} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γ′ : CtxImp (CTI2.liftWorldLeft v W)}
+  → LiftCtxᴸ v γ γ′
+  → srcCtxʷ γ′ ≡ T.⇑ᶜ (srcCtxʷ γ)
+liftCtxᴸ-source liftᴸ-[] = refl
+liftCtxᴸ-source (liftᴸ-∷ liftγ) = cong (_ ∷_) (liftCtxᴸ-source liftγ)
+
+------------------------------------------------------------------------
+-- Indexed conversion typing erases to ordinary validity
+------------------------------------------------------------------------
+
+mutual
+  erase-⊢↑ : ∀ {Δ} {Σ : TyStore Δ} {X? A B} {c : Conv↑ Δ A B}
+    → Σ ⊢↑[ X? ] c
+    → Σ ⊢↑ c
+  erase-⊢↑ (CTI2.⊢↑-unsealˣ X∈) = ⊢↑-unseal X∈
+  erase-⊢↑ (CTI2.⊢↑-⇒ˣ join ⊢c ⊢d) =
+    ⊢↑-⇒ (erase-⊢↓ ⊢c) (erase-⊢↑ ⊢d)
+  erase-⊢↑ (CTI2.⊢↑-∀ˣ ⊢c) = ⊢↑-∀ (erase-⊢↑ ⊢c)
+  erase-⊢↑ (CTI2.⊢↑-∀-idˣ ⊢c) = ⊢↑-∀ (erase-⊢↑ ⊢c)
+  erase-⊢↑ CTI2.⊢↑-idˣ = ⊢↑-id
+
+  erase-⊢↓ : ∀ {Δ} {Σ : TyStore Δ} {X? A B} {c : Conv↓ Δ A B}
+    → Σ ⊢↓[ X? ] c
+    → Σ ⊢↓ c
+  erase-⊢↓ (CTI2.⊢↓-sealˣ X∈) = ⊢↓-seal X∈
+  erase-⊢↓ (CTI2.⊢↓-⇒ˣ join ⊢c ⊢d) =
+    ⊢↓-⇒ (erase-⊢↑ ⊢c) (erase-⊢↓ ⊢d)
+  erase-⊢↓ (CTI2.⊢↓-∀ˣ ⊢c) = ⊢↓-∀ (erase-⊢↓ ⊢c)
+  erase-⊢↓ (CTI2.⊢↓-∀-idˣ ⊢c) = ⊢↓-∀ (erase-⊢↓ ⊢c)
+  erase-⊢↓ CTI2.⊢↓-idˣ = ⊢↓-id
+
+------------------------------------------------------------------------
+-- Runtime-store equalities carried by rebasing
+------------------------------------------------------------------------
+
+rebase-source-store : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {Xᴸ Xᴿ}
+  → RebaseAt W W′ Xᴸ Xᴿ
+  → sourceStoreʷ W′ ≡ sourceStoreʷ W
+rebase-source-store rb =
+  CTI2.SameRuntime.sourceStore-same (CTI2.RebaseAt.sameRuntime rb)
+
+rebase-target-store : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {Xᴸ Xᴿ}
+  → RebaseAt W W′ Xᴸ Xᴿ
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+rebase-target-store rb =
+  CTI2.SameRuntime.targetStore-same (CTI2.RebaseAt.sameRuntime rb)
+
+rebaseᴸ-source-store : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {X?}
+  → RebaseAtᴸ W W′ X?
+  → sourceStoreʷ W′ ≡ sourceStoreʷ W
+rebaseᴸ-source-store CTI2.rebase-idᴸ = refl
+rebaseᴸ-source-store (CTI2.rebase-varᴸ rb) = rebase-source-store rb
+rebaseᴸ-source-store (CTI2.rebase-onlyᴸ to-star disaligned represented) = refl
+
+rebaseᴸ-target-store : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {X?}
+  → RebaseAtᴸ W W′ X?
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+rebaseᴸ-target-store CTI2.rebase-idᴸ = refl
+rebaseᴸ-target-store (CTI2.rebase-varᴸ rb) = rebase-target-store rb
+rebaseᴸ-target-store (CTI2.rebase-onlyᴸ to-star disaligned represented) = refl
+
+rebaseᴿ-source-store : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {X?}
+  → RebaseAtᴿ W W′ X?
+  → sourceStoreʷ W′ ≡ sourceStoreʷ W
+rebaseᴿ-source-store CTI2.rebase-idᴿ = refl
+rebaseᴿ-source-store (CTI2.rebase-varᴿ rb) = rebase-source-store rb
+
+rebaseᴿ-target-store : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {X?}
+  → RebaseAtᴿ W W′ X?
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+rebaseᴿ-target-store CTI2.rebase-idᴿ = refl
+rebaseᴿ-target-store (CTI2.rebase-varᴿ rb) = rebase-target-store rb
+
+------------------------------------------------------------------------
+-- Typing transport at a wrapper boundary
+------------------------------------------------------------------------
+
+transport-source : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CtxImp W′} {M A}
+  → sourceStoreʷ W′ ≡ sourceStoreʷ W
+  → SameCtx γ γ′
+  → ⟨ Δᴸ , sourceStoreʷ W′ , srcCtxʷ γ′ ⟩ ⊢ M ⦂ A
+  → ⟨ Δᴸ , sourceStoreʷ W , srcCtxʷ γ ⟩ ⊢ M ⦂ A
+transport-source {Δᴸ = Δᴸ} {W = W} {W′ = W′} {γ = γ} {γ′ = γ′}
+    {M = M} {A = A} store-eq sc M⊢ =
+  subst≡ (λ Σ → ⟨ Δᴸ , Σ , srcCtxʷ γ ⟩ ⊢ M ⦂ A)
+    store-eq
+    (subst≡ (λ Γ → ⟨ Δᴸ , sourceStoreʷ W′ , Γ ⟩ ⊢ M ⦂ A)
+      (sym (sameCtx-source sc)) M⊢)
+
+transport-target : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CtxImp W′} {M A}
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+  → SameCtx γ γ′
+  → ⟨ Δᴿ , targetStoreʷ W′ , tgtCtxʷ γ′ ⟩ ⊢ M ⦂ A
+  → ⟨ Δᴿ , targetStoreʷ W , tgtCtxʷ γ ⟩ ⊢ M ⦂ A
+transport-target {Δᴿ = Δᴿ} {W = W} {W′ = W′} {γ = γ} {γ′ = γ′}
+    {M = M} {A = A} store-eq sc M⊢ =
+  subst≡ (λ Σ → ⟨ Δᴿ , Σ , tgtCtxʷ γ ⟩ ⊢ M ⦂ A)
+    store-eq
+    (subst≡ (λ Γ → ⟨ Δᴿ , targetStoreʷ W′ , Γ ⟩ ⊢ M ⦂ A)
+      (sym (sameCtx-target sc)) M⊢)
+
+------------------------------------------------------------------------
+-- Typing projections
+------------------------------------------------------------------------
+
+mutual
+  source-typing² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+      {γ : CtxImp W} {M M′ A B} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+    → W ∣ γ ⊢² M ⊑ M′ ∶ p
+    → ⟨ Δᴸ , sourceStoreʷ W , srcCtxʷ γ ⟩ ⊢ M ⦂ A
+
+  target-typing² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+      {γ : CtxImp W} {M M′ A B} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+    → W ∣ γ ⊢² M ⊑ M′ ∶ p
+    → ⟨ Δᴿ , targetStoreʷ W , tgtCtxʷ γ ⟩ ⊢ M′ ⦂ B
+
+  source-typing² (CTI2.x⊑x² x∈) = ⊢` (lookup-source x∈)
+  source-typing² (CTI2.ƛ⊑ƛ² M⊑M′) = ⊢ƛ (source-typing² M⊑M′)
+  source-typing² (CTI2.·⊑·² L⊑L′ M⊑M′) =
+    ⊢· (source-typing² L⊑L′) (source-typing² M⊑M′)
+  source-typing² (CTI2.Λ⊑Λ² liftγ vV vV′ V⊑V′ q) =
+    ⊢Λ vV
+      (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+        (liftCtx-source liftγ) (source-typing² V⊑V′))
+  source-typing² (CTI2.Λ⊑² Anv zero∈A liftγ vV M′⊢ V⊑M′ q) =
+    ⊢Λ vV
+      (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+        (liftCtxᴸ-source liftγ) (source-typing² V⊑M′))
+  source-typing² (CTI2.•⊑•² p∀ M⊑M′ q r) = ⊢• (source-typing² M⊑M′)
+  source-typing² (CTI2.•⊑² p∀ M⊑M′ q r) = ⊢• (source-typing² M⊑M′)
+  source-typing² (CTI2.κ⊑κ² κ p) = ⊢$ κ
+  source-typing² (CTI2.cast⊑cast² c c′ M⊑M′ q) =
+    ⊢⟨⟩ (source-typing² M⊑M′) c
+  source-typing² (CTI2.⊑cast² c′ M⊑M′ q) = source-typing² M⊑M′
+  source-typing² (CTI2.⊑reveal² rb sc c′⊢ M⊑M′ q) =
+    transport-source (rebaseᴿ-source-store rb) sc (source-typing² M⊑M′)
+  source-typing² (CTI2.⊑conceal² rb sc c′⊢ M⊑M′ q) =
+    transport-source (sym (rebaseᴿ-source-store rb)) sc
+      (source-typing² M⊑M′)
+  source-typing² (CTI2.cast⊑² c M⊑M′ q) = ⊢⟨⟩ (source-typing² M⊑M′) c
+  source-typing² (CTI2.reveal⊑² rb sc c⊢ M⊑M′ q) =
+    ⊢reveal (erase-⊢↑ c⊢)
+      (transport-source (rebaseᴸ-source-store rb) sc (source-typing² M⊑M′))
+  source-typing² (CTI2.conceal⊑² rb sc c⊢ M⊑M′ q) =
+    ⊢conceal (erase-⊢↓ c⊢)
+      (transport-source (sym (rebaseᴸ-source-store rb)) sc
+        (source-typing² M⊑M′))
+  source-typing² (CTI2.reveal⊑reveal² rb sc c⊢ c′⊢ M⊑M′ q) =
+    ⊢reveal (erase-⊢↑ c⊢)
+      (transport-source (rebase-source-store rb) sc (source-typing² M⊑M′))
+  source-typing² (CTI2.conceal⊑conceal² rb sc c⊢ c′⊢ M⊑M′ q) =
+    ⊢conceal (erase-⊢↓ c⊢)
+      (transport-source (sym (rebase-source-store rb)) sc
+        (source-typing² M⊑M′))
+  source-typing² (CTI2.blame⊑blame² p) = ⊢blame
+  source-typing² (CTI2.⊕⊑⊕² op L⊑L′ M⊑M′ r) =
+    ⊢⊕ op (source-typing² L⊑L′) (source-typing² M⊑M′)
+
+  target-typing² (CTI2.x⊑x² x∈) = ⊢` (lookup-target x∈)
+  target-typing² (CTI2.ƛ⊑ƛ² M⊑M′) = ⊢ƛ (target-typing² M⊑M′)
+  target-typing² (CTI2.·⊑·² L⊑L′ M⊑M′) =
+    ⊢· (target-typing² L⊑L′) (target-typing² M⊑M′)
+  target-typing² (CTI2.Λ⊑Λ² liftγ vV vV′ V⊑V′ q) =
+    ⊢Λ vV′
+      (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+        (liftCtx-target liftγ) (target-typing² V⊑V′))
+  target-typing² (CTI2.Λ⊑² Anv zero∈A liftγ vV M′⊢ V⊑M′ q) = M′⊢
+  target-typing² (CTI2.•⊑•² p∀ M⊑M′ q r) = ⊢• (target-typing² M⊑M′)
+  target-typing² (CTI2.•⊑² p∀ M⊑M′ q r) = target-typing² M⊑M′
+  target-typing² (CTI2.κ⊑κ² κ p) = ⊢$ κ
+  target-typing² (CTI2.cast⊑cast² c c′ M⊑M′ q) =
+    ⊢⟨⟩ (target-typing² M⊑M′) c′
+  target-typing² (CTI2.⊑cast² c′ M⊑M′ q) = ⊢⟨⟩ (target-typing² M⊑M′) c′
+  target-typing² (CTI2.⊑reveal² rb sc c′⊢ M⊑M′ q) =
+    ⊢reveal (erase-⊢↑ c′⊢)
+      (transport-target (rebaseᴿ-target-store rb) sc (target-typing² M⊑M′))
+  target-typing² (CTI2.⊑conceal² rb sc c′⊢ M⊑M′ q) =
+    ⊢conceal (erase-⊢↓ c′⊢)
+      (transport-target (sym (rebaseᴿ-target-store rb)) sc
+        (target-typing² M⊑M′))
+  target-typing² (CTI2.cast⊑² c M⊑M′ q) = target-typing² M⊑M′
+  target-typing² (CTI2.reveal⊑² rb sc c⊢ M⊑M′ q) =
+    transport-target (rebaseᴸ-target-store rb) sc (target-typing² M⊑M′)
+  target-typing² (CTI2.conceal⊑² rb sc c⊢ M⊑M′ q) =
+    transport-target (sym (rebaseᴸ-target-store rb)) sc
+      (target-typing² M⊑M′)
+  target-typing² (CTI2.reveal⊑reveal² rb sc c⊢ c′⊢ M⊑M′ q) =
+    ⊢reveal (erase-⊢↑ c′⊢)
+      (transport-target (rebase-target-store rb) sc (target-typing² M⊑M′))
+  target-typing² (CTI2.conceal⊑conceal² rb sc c⊢ c′⊢ M⊑M′ q) =
+    ⊢conceal (erase-⊢↓ c′⊢)
+      (transport-target (sym (rebase-target-store rb)) sc
+        (target-typing² M⊑M′))
+  target-typing² (CTI2.blame⊑blame² p) = ⊢blame
+  target-typing² (CTI2.⊕⊑⊕² op L⊑L′ M⊑M′ r) =
+    ⊢⊕ op (target-typing² L⊑L′) (target-typing² M⊑M′)

--- a/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
@@ -221,23 +221,23 @@ mutual
   source-typing² (CTI2.cast⊑cast² c c′ M⊑M′ q) =
     ⊢⟨⟩ (source-typing² M⊑M′) c
   source-typing² (CTI2.⊑cast² c′ M⊑M′ q) = source-typing² M⊑M′
-  source-typing² (CTI2.⊑reveal² rb sc c′⊢ M⊑M′ q) =
+  source-typing² (CTI2.⊑reveal² mono rb sc c′⊢ M⊑M′ q) =
     transport-source (rebaseᴿ-source-store rb) sc (source-typing² M⊑M′)
-  source-typing² (CTI2.⊑conceal² rb sc c′⊢ M⊑M′ q) =
+  source-typing² (CTI2.⊑conceal² mono rb sc c′⊢ M⊑M′ q) =
     transport-source (sym (rebaseᴿ-source-store rb)) sc
       (source-typing² M⊑M′)
   source-typing² (CTI2.cast⊑² c M⊑M′ q) = ⊢⟨⟩ (source-typing² M⊑M′) c
-  source-typing² (CTI2.reveal⊑² rb sc c⊢ M⊑M′ q) =
+  source-typing² (CTI2.reveal⊑² mono rb sc c⊢ M⊑M′ q) =
     ⊢reveal (erase-⊢↑ c⊢)
       (transport-source (rebaseᴸ-source-store rb) sc (source-typing² M⊑M′))
-  source-typing² (CTI2.conceal⊑² rb sc c⊢ M⊑M′ q) =
+  source-typing² (CTI2.conceal⊑² mono rb sc c⊢ M⊑M′ q) =
     ⊢conceal (erase-⊢↓ c⊢)
       (transport-source (sym (rebaseᴸ-source-store rb)) sc
         (source-typing² M⊑M′))
-  source-typing² (CTI2.reveal⊑reveal² rb sc c⊢ c′⊢ M⊑M′ q) =
+  source-typing² (CTI2.reveal⊑reveal² mono rb sc c⊢ c′⊢ M⊑M′ q) =
     ⊢reveal (erase-⊢↑ c⊢)
       (transport-source (rebase-source-store rb) sc (source-typing² M⊑M′))
-  source-typing² (CTI2.conceal⊑conceal² rb sc c⊢ c′⊢ M⊑M′ q) =
+  source-typing² (CTI2.conceal⊑conceal² mono rb sc c⊢ c′⊢ M⊑M′ q) =
     ⊢conceal (erase-⊢↓ c⊢)
       (transport-source (sym (rebase-source-store rb)) sc
         (source-typing² M⊑M′))
@@ -260,23 +260,23 @@ mutual
   target-typing² (CTI2.cast⊑cast² c c′ M⊑M′ q) =
     ⊢⟨⟩ (target-typing² M⊑M′) c′
   target-typing² (CTI2.⊑cast² c′ M⊑M′ q) = ⊢⟨⟩ (target-typing² M⊑M′) c′
-  target-typing² (CTI2.⊑reveal² rb sc c′⊢ M⊑M′ q) =
+  target-typing² (CTI2.⊑reveal² mono rb sc c′⊢ M⊑M′ q) =
     ⊢reveal (erase-⊢↑ c′⊢)
       (transport-target (rebaseᴿ-target-store rb) sc (target-typing² M⊑M′))
-  target-typing² (CTI2.⊑conceal² rb sc c′⊢ M⊑M′ q) =
+  target-typing² (CTI2.⊑conceal² mono rb sc c′⊢ M⊑M′ q) =
     ⊢conceal (erase-⊢↓ c′⊢)
       (transport-target (sym (rebaseᴿ-target-store rb)) sc
         (target-typing² M⊑M′))
   target-typing² (CTI2.cast⊑² c M⊑M′ q) = target-typing² M⊑M′
-  target-typing² (CTI2.reveal⊑² rb sc c⊢ M⊑M′ q) =
+  target-typing² (CTI2.reveal⊑² mono rb sc c⊢ M⊑M′ q) =
     transport-target (rebaseᴸ-target-store rb) sc (target-typing² M⊑M′)
-  target-typing² (CTI2.conceal⊑² rb sc c⊢ M⊑M′ q) =
+  target-typing² (CTI2.conceal⊑² mono rb sc c⊢ M⊑M′ q) =
     transport-target (sym (rebaseᴸ-target-store rb)) sc
       (target-typing² M⊑M′)
-  target-typing² (CTI2.reveal⊑reveal² rb sc c⊢ c′⊢ M⊑M′ q) =
+  target-typing² (CTI2.reveal⊑reveal² mono rb sc c⊢ c′⊢ M⊑M′ q) =
     ⊢reveal (erase-⊢↑ c′⊢)
       (transport-target (rebase-target-store rb) sc (target-typing² M⊑M′))
-  target-typing² (CTI2.conceal⊑conceal² rb sc c⊢ c′⊢ M⊑M′ q) =
+  target-typing² (CTI2.conceal⊑conceal² mono rb sc c⊢ c′⊢ M⊑M′ q) =
     ⊢conceal (erase-⊢↓ c′⊢)
       (transport-target (sym (rebase-target-store rb)) sc
         (target-typing² M⊑M′))

--- a/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
@@ -241,7 +241,7 @@ mutual
     ⊢conceal (erase-⊢↓ c⊢)
       (transport-source (sym (rebase-source-store rb)) sc
         (source-typing² M⊑M′))
-  source-typing² (CTI2.blame⊑blame² p) = ⊢blame
+  source-typing² (CTI2.blame⊑² M′⊢ p) = ⊢blame
   source-typing² (CTI2.⊕⊑⊕² op L⊑L′ M⊑M′ r) =
     ⊢⊕ op (source-typing² L⊑L′) (source-typing² M⊑M′)
 
@@ -280,6 +280,6 @@ mutual
     ⊢conceal (erase-⊢↓ c′⊢)
       (transport-target (sym (rebase-target-store rb)) sc
         (target-typing² M⊑M′))
-  target-typing² (CTI2.blame⊑blame² p) = ⊢blame
+  target-typing² (CTI2.blame⊑² M′⊢ p) = M′⊢
   target-typing² (CTI2.⊕⊑⊕² op L⊑L′ M⊑M′ r) =
     ⊢⊕ op (target-typing² L⊑L′) (target-typing² M⊑M′)

--- a/GTSFImp/proof/DGG/CenterRename.agda
+++ b/GTSFImp/proof/DGG/CenterRename.agda
@@ -10,6 +10,7 @@ module proof.DGG.CenterRename where
 
 open import Data.List using ([]; _∷_)
 open import Data.Maybe using (Maybe; just; nothing)
+open import Data.Product using (Σ-syntax; _,_)
 import Data.Fin as Fin
 import Data.Nat as Nat
 open import Relation.Binary.PropositionalEquality
@@ -283,11 +284,24 @@ renameRebaseAt : ∀ {Δᴸ Δᴿ Δ Δ′}
   → (π : Δ ↪ᵗ Δ′)
   → CTI2.RebaseAt W W′ Xᴸ Xᴿ
   → CTI2.RebaseAt (renameWorld π W) (renameWorld π W′) Xᴸ Xᴿ
-renameRebaseAt π (CTI2.rebase-at runtime offL offR aligned reps) =
+renameRebaseAt {Δᴸ = Δᴸ} {W = W} {W′ = W′}
+    {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} π
+    (CTI2.rebase-at runtime offL offR aligned anchor reps) =
   CTI2.rebase-at (renameSameRuntime π runtime)
     (λ Y≢ → rename-embedding-eq π (offL Y≢))
     (λ Y≢ → rename-embedding-eq π (offR Y≢))
-    (rename-embedding-eq π aligned) (renameStoreRep π reps)
+    (rename-embedding-eq π aligned) renamed-anchor
+    (renameStoreRep π reps)
+  where
+  renamed-anchor :
+      toRenameᵗ (CTI2.ηᴿʷ (renameWorld π W)) Xᴿ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ (renameWorld π W′)) Xᴿ
+    → Σ[ Xₒ ∈ TyVar Δᴸ ]
+        toRenameᵗ (CTI2.ηᴸʷ (renameWorld π W)) Xₒ
+          ≡ toRenameᵗ (CTI2.ηᴿʷ (renameWorld π W)) Xᴿ
+  renamed-anchor moved with anchor
+      (λ eq → moved (rename-embedding-eq π eq))
+  renamed-anchor moved | Xₒ , eq = Xₒ , rename-embedding-eq π eq
 
 rename-mark-image : ∀ {Δᴸ Δᴿ Δ Δ′}
     (π : Δ ↪ᵗ Δ′) (W : CTI2.World Δᴸ Δᴿ Δ)

--- a/GTSFImp/proof/DGG/CenterRename.agda
+++ b/GTSFImp/proof/DGG/CenterRename.agda
@@ -479,8 +479,11 @@ renameImpEnvMono π mono = renameEnvMono π mono
     (renameSameCtx {W = W} {W′ = Wᵖ} π sc) c⊢ c′⊢
     (⊢²-rename-center {W = Wᵖ} π M⊑N
       (rename-⊑ᵂ {W = Wᵖ} π p)) p′
-⊢²-rename-center {W = W} π (CTI2.blame⊑blame² p) p′ =
-  CTI2.blame⊑blame² p′
+⊢²-rename-center {W = W} {γ = γ} π (CTI2.blame⊑² M′⊢ p) p′ =
+  CTI2.blame⊑²
+    (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+      (sym (renameCtx-tgt π γ)) M′⊢)
+    p′
 ⊢²-rename-center {W = W} π
     (CTI2.⊕⊑⊕² op {p = p} {q = q} L⊑L′ M⊑M′ r) p′ =
   CTI2.⊕⊑⊕² op

--- a/GTSFImp/proof/DGG/CenterRename.agda
+++ b/GTSFImp/proof/DGG/CenterRename.agda
@@ -1,0 +1,499 @@
+module proof.DGG.CenterRename where
+
+-- File Charter:
+--   * Transports cast-term-imprecision derivations along an
+--     order-preserving injection of their center type context.
+--   * Composes world embeddings, fills fresh centers with X⊑★, and
+--     transports contexts, rebasing evidence, and recursive worlds.
+--   * Exports the general center-renaming theorem and its weakening
+--     specialization.
+
+open import Data.List using ([]; _∷_)
+open import Data.Maybe using (Maybe; just; nothing)
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans; cong)
+  renaming (subst to subst≡)
+
+open import Types
+open import Consistency using
+  (_↪ᵗ_; empty; keep; skip; toRenameᵗ; wk↪ᵗ)
+open import Imprecision
+open import CastTerms using (Term; ⟨_,_,_⟩; _⊢_⦂_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using (_∣_⊢²_⊑_∶_)
+open import proof.ImprecisionConsistency using
+  (rename-⊑; toRenameᵗ-injective)
+import proof.Imprecision as PI
+
+------------------------------------------------------------------------
+-- Embedding composition
+------------------------------------------------------------------------
+
+infixr 9 _∘↪_
+
+_∘↪_ : ∀ {Δ₁ Δ₂ Δ₃}
+  → Δ₂ ↪ᵗ Δ₃
+  → Δ₁ ↪ᵗ Δ₂
+  → Δ₁ ↪ᵗ Δ₃
+π ∘↪ empty = empty
+(skip π) ∘↪ η = skip (π ∘↪ η)
+(keep π) ∘↪ (keep η) = keep (π ∘↪ η)
+(keep π) ∘↪ (skip η) = skip (π ∘↪ η)
+
+toRenameᵗ-∘ : ∀ {Δ₁ Δ₂ Δ₃}
+  → (π : Δ₂ ↪ᵗ Δ₃)
+  → (η : Δ₁ ↪ᵗ Δ₂)
+  → ∀ X
+  → toRenameᵗ (π ∘↪ η) X ≡ toRenameᵗ π (toRenameᵗ η X)
+toRenameᵗ-∘ π empty ()
+toRenameᵗ-∘ (skip π) (keep η) X =
+  cong Fin.suc (toRenameᵗ-∘ π (keep η) X)
+toRenameᵗ-∘ (skip π) (skip η) X =
+  cong Fin.suc (toRenameᵗ-∘ π (skip η) X)
+toRenameᵗ-∘ (keep π) (keep η) Fin.zero = refl
+toRenameᵗ-∘ (keep π) (keep η) (Fin.suc X) =
+  cong Fin.suc (toRenameᵗ-∘ π η X)
+toRenameᵗ-∘ (keep π) (skip η) X =
+  cong Fin.suc (toRenameᵗ-∘ π η X)
+
+------------------------------------------------------------------------
+-- Preimages and imprecision environments
+------------------------------------------------------------------------
+
+sucMaybe : ∀ {Δ} → Maybe (TyVar Δ) → Maybe (TyVar (Nat.suc Δ))
+sucMaybe (just X) = just (Fin.suc X)
+sucMaybe nothing = nothing
+
+sucMaybe-nothing : ∀ {Δ} (m : Maybe (TyVar Δ))
+  → sucMaybe m ≡ nothing
+  → m ≡ nothing
+sucMaybe-nothing (just X) ()
+sucMaybe-nothing nothing eq = refl
+
+preimage? : ∀ {Δ Δ′}
+  → Δ ↪ᵗ Δ′
+  → TyVar Δ′
+  → Maybe (TyVar Δ)
+preimage? empty Z = nothing
+preimage? (keep π) Fin.zero = just Fin.zero
+preimage? (keep π) (Fin.suc Z) = sucMaybe (preimage? π Z)
+preimage? (skip π) Fin.zero = nothing
+preimage? (skip π) (Fin.suc Z) = preimage? π Z
+
+preimage?-image : ∀ {Δ Δ′} (π : Δ ↪ᵗ Δ′) (Z : TyVar Δ)
+  → preimage? π (toRenameᵗ π Z) ≡ just Z
+preimage?-image empty ()
+preimage?-image (keep π) Fin.zero = refl
+preimage?-image (keep π) (Fin.suc Z)
+    rewrite preimage?-image π Z =
+  refl
+preimage?-image (skip π) Z = preimage?-image π Z
+
+renameEnv : ∀ {Δ Δ′} → Δ ↪ᵗ Δ′ → ImpEnv Δ → ImpEnv Δ′
+renameEnv empty μ = λ Z → X⊑★
+renameEnv (keep π) μ =
+  extendᵐ (μ Fin.zero) (renameEnv π (λ X → μ (Fin.suc X)))
+renameEnv (skip π) μ = extendᵐ X⊑★ (renameEnv π μ)
+
+renameEnv-image : ∀ {Δ Δ′} (π : Δ ↪ᵗ Δ′) (μ : ImpEnv Δ)
+  → ∀ Z → renameEnv π μ (toRenameᵗ π Z) ≡ μ Z
+renameEnv-image empty μ ()
+renameEnv-image (keep π) μ Fin.zero = refl
+renameEnv-image (keep π) μ (Fin.suc Z) =
+  renameEnv-image π (λ X → μ (Fin.suc X)) Z
+renameEnv-image (skip π) μ Z = renameEnv-image π μ Z
+
+renameEnv-off : ∀ {Δ Δ′} (π : Δ ↪ᵗ Δ′) (μ : ImpEnv Δ)
+    {Z′ : TyVar Δ′}
+  → preimage? π Z′ ≡ nothing
+  → renameEnv π μ Z′ ≡ X⊑★
+renameEnv-off empty μ eq = refl
+renameEnv-off (keep π) μ {Z′ = Fin.zero} ()
+renameEnv-off (keep π) μ {Z′ = Fin.suc Z} eq =
+  renameEnv-off π (λ X → μ (Fin.suc X))
+    (sucMaybe-nothing (preimage? π Z) eq)
+renameEnv-off (skip π) μ {Z′ = Fin.zero} eq = refl
+renameEnv-off (skip π) μ {Z′ = Fin.suc Z} eq =
+  renameEnv-off π μ eq
+
+------------------------------------------------------------------------
+-- Worlds, obligations, and contexts
+------------------------------------------------------------------------
+
+renameWorld : ∀ {Δᴸ Δᴿ Δ Δ′}
+  → Δ ↪ᵗ Δ′
+  → CTI2.World Δᴸ Δᴿ Δ
+  → CTI2.World Δᴸ Δᴿ Δ′
+renameWorld π W =
+  CTI2.world (π ∘↪ CTI2.ηᴸʷ W) (π ∘↪ CTI2.ηᴿʷ W)
+    (renameEnv π (CTI2.impEnvʷ W))
+    (CTI2.sourceStoreʷ W) (CTI2.targetStoreʷ W)
+
+embedᴸ-rename : ∀ {Δᴸ Δᴿ Δ Δ′}
+    (π : Δ ↪ᵗ Δ′) (W : CTI2.World Δᴸ Δᴿ Δ) (A : Ty Δᴸ)
+  → CTI2.embedᴸ (renameWorld π W) A
+      ≡ renameᵗ (toRenameᵗ π) (CTI2.embedᴸ W A)
+embedᴸ-rename π W A =
+  trans (renameᵗ-cong A (toRenameᵗ-∘ π (CTI2.ηᴸʷ W)))
+    (sym (renameᵗ-comp (toRenameᵗ (CTI2.ηᴸʷ W))
+      (toRenameᵗ π) A))
+
+embedᴿ-rename : ∀ {Δᴸ Δᴿ Δ Δ′}
+    (π : Δ ↪ᵗ Δ′) (W : CTI2.World Δᴸ Δᴿ Δ) (B : Ty Δᴿ)
+  → CTI2.embedᴿ (renameWorld π W) B
+      ≡ renameᵗ (toRenameᵗ π) (CTI2.embedᴿ W B)
+embedᴿ-rename π W B =
+  trans (renameᵗ-cong B (toRenameᵗ-∘ π (CTI2.ηᴿʷ W)))
+    (sym (renameᵗ-comp (toRenameᵗ (CTI2.ηᴿʷ W))
+      (toRenameᵗ π) B))
+
+rename-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ Δ′} {W : CTI2.World Δᴸ Δᴿ Δ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → (π : Δ ↪ᵗ Δ′)
+  → A CTI2.⊑ᵂ⟨ W ⟩ B
+  → A CTI2.⊑ᵂ⟨ renameWorld π W ⟩ B
+rename-⊑ᵂ {W = W} {A = A} {B = B} π p =
+  subst≡
+    (λ L → CTI2.impEnvʷ (renameWorld π W) ⊢
+      L ⊑ CTI2.embedᴿ (renameWorld π W) B)
+    (sym (embedᴸ-rename π W A))
+    (subst≡
+      (λ R → CTI2.impEnvʷ (renameWorld π W) ⊢
+        renameᵗ (toRenameᵗ π) (CTI2.embedᴸ W A) ⊑ R)
+      (sym (embedᴿ-rename π W B))
+      (rename-⊑ (toRenameᵗ π) (toRenameᵗ-injective π)
+        (λ X eq → trans (renameEnv-image π (CTI2.impEnvʷ W) X) eq)
+        p))
+
+renameCtx : ∀ {Δᴸ Δᴿ Δ Δ′} {W : CTI2.World Δᴸ Δᴿ Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.CtxImp W
+  → CTI2.CtxImp (renameWorld π W)
+renameCtx {W = W} π [] = []
+renameCtx {W = W} π (CTI2.ctx-imp A B p ∷ γ) =
+  CTI2.ctx-imp A B (rename-⊑ᵂ {W = W} π p) ∷
+    renameCtx {W = W} π γ
+
+rename-∋ʷ : ∀ {Δᴸ Δᴿ Δ Δ′} {W : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {x A B} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → (π : Δ ↪ᵗ Δ′)
+  → γ CTI2.∋ʷ x ⦂ CTI2.ctx-imp A B p
+  → renameCtx {W = W} π γ CTI2.∋ʷ x ⦂
+      CTI2.ctx-imp A B (rename-⊑ᵂ {W = W} π p)
+rename-∋ʷ {W = W} π CTI2.Zʷ = CTI2.Zʷ
+rename-∋ʷ {W = W} π (CTI2.Sʷ x∈) =
+  CTI2.Sʷ (rename-∋ʷ {W = W} π x∈)
+
+renameSameCtx : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {γ′ : CTI2.CtxImp W′}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.SameCtx γ γ′
+  → CTI2.SameCtx (renameCtx {W = W} π γ)
+      (renameCtx {W = W′} π γ′)
+renameSameCtx π CTI2.same-[] = CTI2.same-[]
+renameSameCtx π (CTI2.same-∷ sc) =
+  CTI2.same-∷ (renameSameCtx π sc)
+
+------------------------------------------------------------------------
+-- Binder commutation
+------------------------------------------------------------------------
+
+renameWorld-liftBoth : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → (v : VarImp)
+  → renameWorld (keep π) (CTI2.liftWorldBoth v W)
+      ≡ CTI2.liftWorldBoth v (renameWorld π W)
+renameWorld-liftBoth π v = refl
+
+renameWorld-liftLeft : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → (v : VarImp)
+  → renameWorld (keep π) (CTI2.liftWorldLeft v W)
+      ≡ CTI2.liftWorldLeft v (renameWorld π W)
+renameWorld-liftLeft π v = refl
+
+renameLiftCtx : ∀ {Δᴸ Δᴿ Δ Δ′} {v}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {γ : CTI2.CtxImp W}
+    {γ′ : CTI2.CtxImp (CTI2.liftWorldBoth v W)}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.LiftCtx v γ γ′
+  → CTI2.LiftCtx v (renameCtx {W = W} π γ)
+      (renameCtx {W = CTI2.liftWorldBoth v W} (keep π) γ′)
+renameLiftCtx π CTI2.lift-[] = CTI2.lift-[]
+renameLiftCtx π (CTI2.lift-∷ liftγ) =
+  CTI2.lift-∷ (renameLiftCtx π liftγ)
+
+renameLiftCtxᴸ : ∀ {Δᴸ Δᴿ Δ Δ′} {v}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {γ : CTI2.CtxImp W}
+    {γ′ : CTI2.CtxImp (CTI2.liftWorldLeft v W)}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.LiftCtxᴸ v γ γ′
+  → CTI2.LiftCtxᴸ v (renameCtx {W = W} π γ)
+      (renameCtx {W = CTI2.liftWorldLeft v W} (keep π) γ′)
+renameLiftCtxᴸ π CTI2.liftᴸ-[] = CTI2.liftᴸ-[]
+renameLiftCtxᴸ π (CTI2.liftᴸ-∷ liftγ) =
+  CTI2.liftᴸ-∷ (renameLiftCtxᴸ π liftγ)
+
+renameCtx-tgt : ∀ {Δᴸ Δᴿ Δ Δ′} {W : CTI2.World Δᴸ Δᴿ Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → (γ : CTI2.CtxImp W)
+  → CTI2.tgtCtxʷ (renameCtx {W = W} π γ) ≡ CTI2.tgtCtxʷ γ
+renameCtx-tgt π [] = refl
+renameCtx-tgt π (CTI2.ctx-imp A B p ∷ γ) =
+  cong (B ∷_) (renameCtx-tgt π γ)
+
+------------------------------------------------------------------------
+-- Runtime and rebasing records
+------------------------------------------------------------------------
+
+renameSameRuntime : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.SameRuntime W W′
+  → CTI2.SameRuntime (renameWorld π W) (renameWorld π W′)
+renameSameRuntime π (CTI2.same-runtime source-eq target-eq) =
+  CTI2.same-runtime source-eq target-eq
+
+renameStoreRep : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.StoreRepImp W Xᴸ Xᴿ
+  → CTI2.StoreRepImp (renameWorld π W) Xᴸ Xᴿ
+renameStoreRep {W = W} π (CTI2.store-rep-imp represented) =
+  CTI2.store-rep-imp (rename-⊑ᵂ {W = W} π represented)
+
+rename-embedding-eq : ∀ {Δ₁ Δ₂ Δ Δ′}
+    (π : Δ ↪ᵗ Δ′) {η₁ : Δ₁ ↪ᵗ Δ} {η₂ : Δ₂ ↪ᵗ Δ}
+    {X₁ : TyVar Δ₁} {X₂ : TyVar Δ₂}
+  → toRenameᵗ η₁ X₁ ≡ toRenameᵗ η₂ X₂
+  → toRenameᵗ (π ∘↪ η₁) X₁ ≡ toRenameᵗ (π ∘↪ η₂) X₂
+rename-embedding-eq π {η₁ = η₁} {η₂ = η₂}
+    {X₁ = X₁} {X₂ = X₂} eq =
+  trans (toRenameᵗ-∘ π η₁ X₁)
+    (trans (cong (toRenameᵗ π) eq)
+      (sym (toRenameᵗ-∘ π η₂ X₂)))
+
+renameRebaseAt : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.RebaseAt W W′ Xᴸ Xᴿ
+  → CTI2.RebaseAt (renameWorld π W) (renameWorld π W′) Xᴸ Xᴿ
+renameRebaseAt π (CTI2.rebase-at runtime offL offR aligned reps) =
+  CTI2.rebase-at (renameSameRuntime π runtime)
+    (λ Y≢ → rename-embedding-eq π (offL Y≢))
+    (λ Y≢ → rename-embedding-eq π (offR Y≢))
+    (rename-embedding-eq π aligned) (renameStoreRep π reps)
+
+rename-mark-image : ∀ {Δᴸ Δᴿ Δ Δ′}
+    (π : Δ ↪ᵗ Δ′) (W : CTI2.World Δᴸ Δᴿ Δ)
+    {Xᴸ : TyVar Δᴸ}
+  → CTI2.impEnvʷ (renameWorld π W)
+      (toRenameᵗ (CTI2.ηᴸʷ (renameWorld π W)) Xᴸ)
+      ≡ CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)
+rename-mark-image π W {Xᴸ} =
+  trans (cong (renameEnv π (CTI2.impEnvʷ W))
+      (toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))
+    (renameEnv-image π (CTI2.impEnvʷ W)
+      (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ))
+
+rename-disaligned : ∀ {Δᴸ Δᴿ Δ Δ′}
+    (π : Δ ↪ᵗ Δ′) (W : CTI2.World Δᴸ Δᴿ Δ)
+    {Xᴸ : TyVar Δᴸ}
+  → (∀ Xᴿ → toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ ≢
+      toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)
+  → ∀ Xᴿ → toRenameᵗ (CTI2.ηᴿʷ (renameWorld π W)) Xᴿ ≢
+      toRenameᵗ (CTI2.ηᴸʷ (renameWorld π W)) Xᴸ
+rename-disaligned π W {Xᴸ} disaligned Xᴿ eq =
+  disaligned Xᴿ (toRenameᵗ-injective π
+    (trans (sym (toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ))
+      (trans eq (toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))))
+
+renameRebaseAtᴸ : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ?}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.RebaseAtᴸ W W′ Xᴸ?
+  → CTI2.RebaseAtᴸ (renameWorld π W) (renameWorld π W′) Xᴸ?
+renameRebaseAtᴸ π CTI2.rebase-idᴸ = CTI2.rebase-idᴸ
+renameRebaseAtᴸ π (CTI2.rebase-varᴸ rb) =
+  CTI2.rebase-varᴸ (renameRebaseAt π rb)
+renameRebaseAtᴸ {W = W} π
+    (CTI2.rebase-onlyᴸ to-star disaligned represented) =
+  CTI2.rebase-onlyᴸ
+    (trans (rename-mark-image π W) to-star)
+    (rename-disaligned π W disaligned)
+    (rename-⊑ᵂ {W = W} π represented)
+
+renameRebaseAtᴿ : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {Xᴿ?}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.RebaseAtᴿ W W′ Xᴿ?
+  → CTI2.RebaseAtᴿ (renameWorld π W) (renameWorld π W′) Xᴿ?
+renameRebaseAtᴿ π CTI2.rebase-idᴿ = CTI2.rebase-idᴿ
+renameRebaseAtᴿ π (CTI2.rebase-varᴿ rb) =
+  CTI2.rebase-varᴿ (renameRebaseAt π rb)
+
+renameEnvMono : ∀ {Δ Δ′} {μ ν : ImpEnv Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → (∀ Z → μ Z ≡ X⊑★ → ν Z ≡ X⊑★)
+  → ∀ Z′ → renameEnv π μ Z′ ≡ X⊑★
+      → renameEnv π ν Z′ ≡ X⊑★
+renameEnvMono empty mono Z eq = refl
+renameEnvMono (keep π) mono Fin.zero eq = mono Fin.zero eq
+renameEnvMono (keep π) mono (Fin.suc Z) eq =
+  renameEnvMono π (λ X → mono (Fin.suc X)) Z eq
+renameEnvMono (skip π) mono Fin.zero eq = refl
+renameEnvMono (skip π) mono (Fin.suc Z) eq =
+  renameEnvMono π mono Z eq
+
+renameImpEnvMono : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.ImpEnvMono W W′
+  → CTI2.ImpEnvMono (renameWorld π W) (renameWorld π W′)
+renameImpEnvMono π mono = renameEnvMono π mono
+
+------------------------------------------------------------------------
+-- Derivation transport
+------------------------------------------------------------------------
+
+⊢²-retarget : ∀ {Δᴸ Δᴿ Δ} {W : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {M : Term Δᴸ} {N : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p q : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ N ∶ p
+  → W ∣ γ ⊢² M ⊑ N ∶ q
+⊢²-retarget {W = W} {γ = γ} {M = M} {N = N} {p = p} {q = q} d =
+  subst≡ (λ r → W ∣ γ ⊢² M ⊑ N ∶ r) (PI.⊑-unique p q) d
+
+⊢²-rename-center : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {M : Term Δᴸ} {N : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → (π : Δ ↪ᵗ Δ′)
+  → W ∣ γ ⊢² M ⊑ N ∶ p
+  → (p′ : A CTI2.⊑ᵂ⟨ renameWorld π W ⟩ B)
+  → renameWorld π W ∣ renameCtx {W = W} π γ ⊢² M ⊑ N ∶ p′
+⊢²-rename-center {W = W} π (CTI2.x⊑x² x∈) p′ =
+  ⊢²-retarget (CTI2.x⊑x² (rename-∋ʷ {W = W} π x∈))
+⊢²-rename-center {W = W} π
+    (CTI2.ƛ⊑ƛ² {pA = pA} {pB = pB} M⊑N) p′ =
+  ⊢²-retarget (CTI2.ƛ⊑ƛ²
+    (⊢²-rename-center {W = W} π M⊑N
+      (rename-⊑ᵂ {W = W} π pB)))
+⊢²-rename-center {W = W} π
+    (CTI2.·⊑·² {pA = pA} {pB = pB} L⊑L′ M⊑M′) p′ =
+  ⊢²-retarget (CTI2.·⊑·²
+    (⊢²-rename-center {W = W} π L⊑L′
+      (⇒⊑⇒ (rename-⊑ᵂ {W = W} π pA)
+        (rename-⊑ᵂ {W = W} π pB)))
+    (⊢²-rename-center {W = W} π M⊑M′
+      (rename-⊑ᵂ {W = W} π pA)))
+⊢²-rename-center {W = W} π
+    (CTI2.Λ⊑Λ² {p = p} liftγ vV vV′ V⊑V′ q) p′ =
+  CTI2.Λ⊑Λ² (renameLiftCtx π liftγ) vV vV′
+    (⊢²-rename-center {W = CTI2.liftWorldBoth X⊑X W}
+      (keep π) V⊑V′
+      (rename-⊑ᵂ {W = CTI2.liftWorldBoth X⊑X W} (keep π) p)) p′
+⊢²-rename-center {W = W} {γ = γ} π
+    (CTI2.Λ⊑² {p = p} Anv zero∈A liftγ vV N⊢ V⊑N q) p′ =
+  CTI2.Λ⊑² Anv zero∈A (renameLiftCtxᴸ π liftγ) vV
+    (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+      (sym (renameCtx-tgt π γ)) N⊢)
+    (⊢²-rename-center {W = CTI2.liftWorldLeft X⊑★ W}
+      (keep π) V⊑N
+      (rename-⊑ᵂ {W = CTI2.liftWorldLeft X⊑★ W} (keep π) p)) p′
+⊢²-rename-center {W = W} π (CTI2.•⊑•² p∀ M⊑N q r) p′ =
+  CTI2.•⊑•² (rename-⊑ᵂ {W = W} π p∀)
+    (⊢²-rename-center {W = W} π M⊑N
+      (rename-⊑ᵂ {W = W} π p∀))
+    (rename-⊑ᵂ {W = W} π q) p′
+⊢²-rename-center {W = W} π (CTI2.•⊑² p∀ M⊑N q r) p′ =
+  CTI2.•⊑² (rename-⊑ᵂ {W = W} π p∀)
+    (⊢²-rename-center {W = W} π M⊑N
+      (rename-⊑ᵂ {W = W} π p∀))
+    (rename-⊑ᵂ {W = W} π q) p′
+⊢²-rename-center {W = W} π (CTI2.κ⊑κ² κ p) p′ =
+  CTI2.κ⊑κ² κ p′
+⊢²-rename-center {W = W} π
+    (CTI2.cast⊑cast² {p = p} c c′ M⊑N q) p′ =
+  CTI2.cast⊑cast² c c′
+    (⊢²-rename-center {W = W} π M⊑N
+      (rename-⊑ᵂ {W = W} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.⊑cast² {p = p} c′ M⊑N q) p′ =
+  CTI2.⊑cast² c′
+    (⊢²-rename-center {W = W} π M⊑N
+      (rename-⊑ᵂ {W = W} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.cast⊑² {p = p} c M⊑N q) p′ =
+  CTI2.cast⊑² c
+    (⊢²-rename-center {W = W} π M⊑N
+      (rename-⊑ᵂ {W = W} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.⊑reveal² {W′ = W′} {p = p} mono rb sc c′⊢ M⊑N q) p′ =
+  CTI2.⊑reveal² (renameImpEnvMono {W = W} {W′ = W′} π mono)
+    (renameRebaseAtᴿ {W = W} {W′ = W′} π rb)
+    (renameSameCtx {W = W} {W′ = W′} π sc) c′⊢
+    (⊢²-rename-center {W = W′} π M⊑N
+      (rename-⊑ᵂ {W = W′} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.⊑conceal² {W′ = W′} {p = p} mono rb sc c′⊢ M⊑N q) p′ =
+  CTI2.⊑conceal² (renameImpEnvMono {W = W} {W′ = W′} π mono)
+    (renameRebaseAtᴿ {W = W′} {W′ = W} π rb)
+    (renameSameCtx {W = W} {W′ = W′} π sc) c′⊢
+    (⊢²-rename-center {W = W′} π M⊑N
+      (rename-⊑ᵂ {W = W′} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.reveal⊑² {W′ = W′} {p = p} mono rb sc c⊢ M⊑N q) p′ =
+  CTI2.reveal⊑² (renameImpEnvMono {W = W} {W′ = W′} π mono)
+    (renameRebaseAtᴸ {W = W} {W′ = W′} π rb)
+    (renameSameCtx {W = W} {W′ = W′} π sc) c⊢
+    (⊢²-rename-center {W = W′} π M⊑N
+      (rename-⊑ᵂ {W = W′} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.conceal⊑² {W′ = W′} {p = p} mono rb sc c⊢ M⊑N q) p′ =
+  CTI2.conceal⊑² (renameImpEnvMono {W = W} {W′ = W′} π mono)
+    (renameRebaseAtᴸ {W = W′} {W′ = W} π rb)
+    (renameSameCtx {W = W} {W′ = W′} π sc) c⊢
+    (⊢²-rename-center {W = W′} π M⊑N
+      (rename-⊑ᵂ {W = W′} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.reveal⊑reveal² {Wᵖ = Wᵖ} {p = p}
+      mono rb sc c⊢ c′⊢ M⊑N q) p′ =
+  CTI2.reveal⊑reveal²
+    (renameImpEnvMono {W = W} {W′ = Wᵖ} π mono)
+    (renameRebaseAt {W = W} {W′ = Wᵖ} π rb)
+    (renameSameCtx {W = W} {W′ = Wᵖ} π sc) c⊢ c′⊢
+    (⊢²-rename-center {W = Wᵖ} π M⊑N
+      (rename-⊑ᵂ {W = Wᵖ} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {p = p}
+      mono rb sc c⊢ c′⊢ M⊑N q) p′ =
+  CTI2.conceal⊑conceal²
+    (renameImpEnvMono {W = W} {W′ = Wᵖ} π mono)
+    (renameRebaseAt {W = Wᵖ} {W′ = W} π rb)
+    (renameSameCtx {W = W} {W′ = Wᵖ} π sc) c⊢ c′⊢
+    (⊢²-rename-center {W = Wᵖ} π M⊑N
+      (rename-⊑ᵂ {W = Wᵖ} π p)) p′
+⊢²-rename-center {W = W} π (CTI2.blame⊑blame² p) p′ =
+  CTI2.blame⊑blame² p′
+⊢²-rename-center {W = W} π
+    (CTI2.⊕⊑⊕² op {p = p} {q = q} L⊑L′ M⊑M′ r) p′ =
+  CTI2.⊕⊑⊕² op
+    (⊢²-rename-center {W = W} π L⊑L′
+      (rename-⊑ᵂ {W = W} π p))
+    (⊢²-rename-center {W = W} π M⊑M′
+      (rename-⊑ᵂ {W = W} π q)) p′
+
+⊢²-extend-center : ∀ {Δᴸ Δᴿ Δ} {W : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {M : Term Δᴸ} {N : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ N ∶ p
+  → (p′ : A CTI2.⊑ᵂ⟨ renameWorld wk↪ᵗ W ⟩ B)
+  → renameWorld wk↪ᵗ W ∣ renameCtx {W = W} wk↪ᵗ γ
+      ⊢² M ⊑ N ∶ p′
+⊢²-extend-center = ⊢²-rename-center wk↪ᵗ

--- a/GTSFImp/proof/DGG/ChainRideProbe.agda
+++ b/GTSFImp/proof/DGG/ChainRideProbe.agda
@@ -1,0 +1,254 @@
+module proof.DGG.ChainRideProbe where
+
+-- File Charter:
+--   * Validates the chain-ride construction for the H-multi stratum.
+--   * The target pivot steps down the chain's centers, with each link
+--     anchored by the next chain variable.
+--   * This shows that the stratum is dischargeable rather than needing an
+--     exclusion.
+--   * The general lemma must still address target-side order preservation
+--     when the target type context has more than one variable.
+
+open import Data.Empty using (⊥-elim)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just)
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-bind; _∋_⦂_; Z∋; S-bind∋)
+open import Consistency using
+  (Env∼; X∼★; _⊢_∼_; _↪ᵗ_; empty; keep; skip; toRenameᵗ; _!; id)
+open import Imprecision
+open import Conversion using (seal)
+open import CastTerms
+open import Primitives using (κℕ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; _⊢↓[_]_; _∣_⊢²_⊑_∶_;
+   RebaseAt; rebase-at; same-runtime; store-rep-imp; ⊢↓-sealˣ)
+
+private
+  Z : TyVar 2
+  Z = Fin.zero
+
+  Z₃ : TyVar 2
+  Z₃ = Fin.suc Fin.zero
+
+  Y : TyVar 1
+  Y = Fin.zero
+
+  a : TyVar 3
+  a = Fin.zero
+
+  b : TyVar 3
+  b = Fin.suc Fin.zero
+
+  c : TyVar 3
+  c = Fin.suc (Fin.suc Fin.zero)
+
+------------------------------------------------------------------------
+-- Stores, embeddings, and worlds
+------------------------------------------------------------------------
+
+sourceStore : TyStore 2
+sourceStore =
+  store-bind (store-bind store-empty ★) (＇ Fin.zero)
+
+targetStore : TyStore 1
+targetStore = store-bind store-empty ★
+
+probe-μ : ImpEnv 3
+probe-μ Fin.zero = X⊑★
+probe-μ (Fin.suc Fin.zero) = X⊑★
+probe-μ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+
+ηᴸ-ab : 2 ↪ᵗ 3
+ηᴸ-ab = keep (keep (skip empty))
+
+ηᴸ-ac : 2 ↪ᵗ 3
+ηᴸ-ac = keep (skip (keep empty))
+
+ηᴿ-a : 1 ↪ᵗ 3
+ηᴿ-a = keep (skip (skip empty))
+
+ηᴿ-b : 1 ↪ᵗ 3
+ηᴿ-b = skip (keep (skip empty))
+
+ηᴿ-c : 1 ↪ᵗ 3
+ηᴿ-c = skip (skip (keep empty))
+
+-- Placement table (a = 0, b = 1, c = 2):
+--
+--       Z   Z₃   Y
+--   W₁   a   b   a
+--   Wₗ   a   b   b
+--   W₂   a   c   c
+
+W₁ : World 2 1 3
+W₁ = world ηᴸ-ab ηᴿ-a probe-μ sourceStore targetStore
+
+Wₗ : World 2 1 3
+Wₗ = world ηᴸ-ab ηᴿ-b probe-μ sourceStore targetStore
+
+W₂ : World 2 1 3
+W₂ = world ηᴸ-ac ηᴿ-c probe-μ sourceStore targetStore
+
+------------------------------------------------------------------------
+-- Store membership and conversion typing
+------------------------------------------------------------------------
+
+probe-Z∋ : sourceStore ∋ Z ⦂ ＇ Z₃
+probe-Z∋ = Z∋ refl
+
+probe-Z₃∋ : sourceStore ∋ Z₃ ⦂ ★
+probe-Z₃∋ = S-bind∋ (Z∋ refl) refl
+
+probe-Z-seal-⊢ : sourceStore ⊢↓[ just Z ] seal Z (＇ Z₃)
+probe-Z-seal-⊢ = ⊢↓-sealˣ probe-Z∋
+
+probe-Z₃-seal-⊢ : sourceStore ⊢↓[ just Z₃ ] seal Z₃ ★
+probe-Z₃-seal-⊢ = ⊢↓-sealˣ probe-Z₃∋
+
+private
+  probe-source-env : Env∼ 2
+  probe-source-env Fin.zero = X∼★
+  probe-source-env (Fin.suc Fin.zero) = X∼★
+
+  probe-target-env : Env∼ 1
+  probe-target-env Fin.zero = X∼★
+
+  probe-ℕ!ᴸ : probe-source-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴸ = id (‵ `ℕ) !
+
+  probe-ℕ!ᴿ : probe-target-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴿ = id (‵ `ℕ) !
+
+------------------------------------------------------------------------
+-- Terms
+------------------------------------------------------------------------
+
+V₀ : Term 2
+V₀ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴸ ⟩
+
+V : Term 2
+V = V₀ ↓ seal Z₃ ★
+
+U : Term 1
+U = ($ (κℕ 0)) ⟨ probe-ℕ!ᴿ ⟩
+
+------------------------------------------------------------------------
+-- Rebase witnesses
+------------------------------------------------------------------------
+
+probe-Z-Y-rep₁ : CTI2.StoreRepImp W₁ Z Y
+probe-Z-Y-rep₁ = store-rep-imp ★⊑★
+
+raₗ : RebaseAt Wₗ W₁ Z Y
+raₗ =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} Z≠ → ⊥-elim (Z≠ refl)
+       ; {Fin.suc Fin.zero} Z₃≠ → refl })
+    (λ { {Fin.zero} Y≠ → ⊥-elim (Y≠ refl) })
+    refl (λ moved → Z₃ , refl) probe-Z-Y-rep₁
+
+probe-Z₃-Y-repₗ : CTI2.StoreRepImp Wₗ Z₃ Y
+probe-Z₃-Y-repₗ = store-rep-imp ★⊑★
+
+link₂ : RebaseAt W₂ Wₗ Z₃ Y
+link₂ =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} Z≠ → refl
+       ; {Fin.suc Fin.zero} Z₃≠ → ⊥-elim (Z₃≠ refl) })
+    (λ { {Fin.zero} Y≠ → ⊥-elim (Y≠ refl) })
+    refl (λ moved → Z₃ , refl) probe-Z₃-Y-repₗ
+
+probe-Z₃-Y-rep₂ : CTI2.StoreRepImp W₂ Z₃ Y
+probe-Z₃-Y-rep₂ = store-rep-imp ★⊑★
+
+probe-premise-rebase : RebaseAt W₂ W₂ Z₃ Y
+probe-premise-rebase =
+  CTI2.sameWorldRebaseAt refl probe-Z₃-Y-rep₂
+
+probe-output-link : RebaseAt W₁ W₁ Z Y
+probe-output-link = CTI2.sameWorldRebaseAt refl probe-Z-Y-rep₁
+
+------------------------------------------------------------------------
+-- Checkpoint 1: the complete H-multi input data
+------------------------------------------------------------------------
+
+p₁ : (＇ Z) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)
+p₁ = X⊑X
+
+probe-moved :
+  toRenameᵗ (CTI2.ηᴸʷ W₂) Z₃ ≢ toRenameᵗ (CTI2.ηᴸʷ W₁) Z₃
+probe-moved ()
+
+probe-mono₁ₗ : CTI2.ImpEnvMono W₁ Wₗ
+probe-mono₁ₗ X eq = eq
+
+probe-monoₗ₂ : CTI2.ImpEnvMono Wₗ W₂
+probe-monoₗ₂ X eq = eq
+
+probe-same₁ₗ : CTI2.SameCtx {W = W₁} {W′ = Wₗ} [] []
+probe-same₁ₗ = CTI2.same-[]
+
+probe-sameₗ₂ : CTI2.SameCtx {W = Wₗ} {W′ = W₂} [] []
+probe-sameₗ₂ = CTI2.same-[]
+
+q₂ : (＇ Z₃) ⊑ᵂ⟨ W₂ ⟩ ★
+q₂ = X⊑★ refl
+
+probe-base² : W₂ ∣ [] ⊢² V₀ ⊑ U ∶ ★⊑★
+probe-base² =
+  CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
+    (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
+
+probe-premise : W₂ ∣ [] ⊢² V ⊑ U ∶ q₂
+probe-premise =
+  CTI2.conceal⊑² (λ X eq → eq)
+    (CTI2.rebase-varᴸ probe-premise-rebase)
+    CTI2.same-[] probe-Z₃-seal-⊢ probe-base² q₂
+
+------------------------------------------------------------------------
+-- Checkpoint 2: the positive chain-ride output
+------------------------------------------------------------------------
+
+qₗ : (＇ Z₃) ⊑ᵂ⟨ Wₗ ⟩ ★
+qₗ = X⊑★ refl
+
+probe-ride-inner : Wₗ ∣ [] ⊢² V ⊑ U ∶ qₗ
+probe-ride-inner =
+  CTI2.conceal⊑² probe-monoₗ₂ (CTI2.rebase-varᴸ link₂)
+    probe-sameₗ₂ probe-Z₃-seal-⊢ probe-base² qₗ
+
+q₃ : (＇ Z) ⊑ᵂ⟨ W₁ ⟩ ★
+q₃ = X⊑★ refl
+
+probe-output :
+  Σ[ q ∈ (＇ Z) ⊑ᵂ⟨ W₁ ⟩ ★ ]
+    (W₁ ∣ [] ⊢² (V ↓ seal Z (＇ Z₃)) ⊑ U ∶ q)
+probe-output =
+  q₃ ,
+  CTI2.conceal⊑² probe-mono₁ₗ (CTI2.rebase-varᴸ raₗ)
+    probe-same₁ₗ probe-Z-seal-⊢ probe-ride-inner q₃
+
+probe-mono₁₁ : CTI2.ImpEnvMono W₁ W₁
+probe-mono₁₁ X eq = eq
+
+probe-same₁₁ : CTI2.SameCtx {W = W₁} {W′ = W₁} [] []
+probe-same₁₁ = CTI2.same-[]
+
+probe-H-multi-output :
+  Σ[ W₃ ∈ World 2 1 3 ] Σ[ γ₃ ∈ CTI2.CtxImp W₃ ]
+    ( RebaseAt W₃ W₁ Z Y
+    × CTI2.ImpEnvMono W₁ W₃
+    × CTI2.SameCtx {W = W₁} [] γ₃
+    × Σ[ q ∈ (＇ Z) ⊑ᵂ⟨ W₃ ⟩ ★ ]
+        (W₃ ∣ γ₃ ⊢² (V ↓ seal Z (＇ Z₃)) ⊑ U ∶ q) )
+probe-H-multi-output =
+  W₁ , [] , probe-output-link , probe-mono₁₁ ,
+  probe-same₁₁ , probe-output

--- a/GTSFImp/proof/DGG/CompilePreservesImprecision.agda
+++ b/GTSFImp/proof/DGG/CompilePreservesImprecision.agda
@@ -7,32 +7,96 @@ module proof.DGG.CompilePreservesImprecision where
 --   * Depends on Compile, GradualTermImprecision, and the typed cast-term
 --     imprecision relation.
 
-open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Product using (_,_; proj₁)
 open import Data.Fin using (zero)
+open import Data.List using (_∷_)
+import Data.Fin as Fin
 import Data.Nat as Nat
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; subst)
+  using (_≡_; refl; sym; trans; cong; cong₂; subst)
 
 open import Types
 open import TyStore using (TyStore; store-lift)
 open import TermCtx using (TermCtx; ⇑ᶜ)
-open import Consistency using (_∼_; id; _↦_; ？_; symᶜ)
+import TermCtx as T
+open import Consistency
+  using (_⊢_∼_; _∼_; id; _↦_; ？_; symᶜ; renameᶜ;
+         _↪ᵗ_; keep; toRenameᵗ; wk↪ᵗ; renameᵐᶜ)
 open import Imprecision
 open import GradualTerms using (GTerm; _∣_⊢_⦂_)
 import GradualTerms as G
-open import Primitives using (primArgTy)
+open import Primitives
+  using (Prim; constTy; primArgTy; primResultTy;
+         constTy-renameᵗ; addℕ; and𝔹)
 import CastTerms as C
-open C using () renaming (Λ_ to Λᵀ_)
+open C using ()
+  renaming (`_ to `ᵀ_; ƛ_ to ƛᵀ_; _·_ to _·ᵀ_; Λ_ to Λᵀ_;
+            _⦂∀_[_] to _⦂∀ᵀ_[_]; $ to $ᵀ;
+            _⊕[_]_ to _⊕ᵀ[_]_; _⟨_⟩ to _⟨ᵀ_⟩)
 open import Compile using (compile; compile-value)
 import GradualTermImprecision as GTI
 open import GradualTermImprecision using
   (CtxImp; _∣_⊢ᴳ_⊑_⦂_⊑_∶_)
 import proof.DGG.CastTermImprecision as CTI
 open CTI using (_∣_⊢ᶜ_⊑_∶_)
-open import proof.ImprecisionConsistency using (refl⊑)
+open import proof.ImprecisionConsistency
+  using (refl⊑; rename-occurs; toRenameᵗ-injective;
+         ty-all-injective)
+open import proof.TypeInTermSubst
+  using (renameCtx-wk-eq; renameᵗ-wk-eq; renameCtx-keep-shift;
+         rename-openᵗ; toRename-keep-eq;
+         toRename-wk-eq; renameᵗᵐ-preserves-Value)
 
 dynamic-function-cast : ∀ {Δ} → _∼_ {Δ} ★ (★ ⇒ ★)
 dynamic-function-cast = ？ (id ★ ↦ id ★)
+
+lookup-uniqueᴳ : ∀ {Δ} {Γ : TermCtx Δ} {x A B}
+  → Γ T.∋ x ⦂ A
+  → Γ T.∋ x ⦂ B
+  → A ≡ B
+lookup-uniqueᴳ T.Z T.Z = refl
+lookup-uniqueᴳ (T.S x∈) (T.S x∈′) =
+  lookup-uniqueᴳ x∈ x∈′
+
+typing-uniqueᴳ : ∀ {Δ} {Γ : TermCtx Δ} {M A B}
+  → Δ ∣ Γ ⊢ M ⦂ A
+  → Δ ∣ Γ ⊢ M ⦂ B
+  → A ≡ B
+typing-uniqueᴳ (G.⊢` x∈) (G.⊢` x∈′) =
+  lookup-uniqueᴳ x∈ x∈′
+typing-uniqueᴳ (G.⊢ƛ M⊢) (G.⊢ƛ M⊢′) =
+  cong (_ ⇒_) (typing-uniqueᴳ M⊢ M⊢′)
+typing-uniqueᴳ (G.⊢· L⊢ M⊢ A∼C)
+    (G.⊢· L⊢′ M⊢′ B∼D)
+    with typing-uniqueᴳ L⊢ L⊢′
+typing-uniqueᴳ (G.⊢· L⊢ M⊢ A∼C)
+    (G.⊢· L⊢′ M⊢′ B∼D)
+    | refl =
+  refl
+typing-uniqueᴳ (G.⊢· L⊢ M⊢ A∼C)
+    (G.⊢·★ L⊢′ M⊢′ B∼★)
+    with typing-uniqueᴳ L⊢ L⊢′
+typing-uniqueᴳ (G.⊢· L⊢ M⊢ A∼C)
+    (G.⊢·★ L⊢′ M⊢′ B∼★)
+    | ()
+typing-uniqueᴳ (G.⊢·★ L⊢ M⊢ A∼★)
+    (G.⊢· L⊢′ M⊢′ B∼D)
+    with typing-uniqueᴳ L⊢ L⊢′
+typing-uniqueᴳ (G.⊢·★ L⊢ M⊢ A∼★)
+    (G.⊢· L⊢′ M⊢′ B∼D)
+    | ()
+typing-uniqueᴳ (G.⊢·★ L⊢ M⊢ A∼★)
+    (G.⊢·★ L⊢′ M⊢′ B∼★) =
+  refl
+typing-uniqueᴳ (G.⊢Λ vM M⊢) (G.⊢Λ vM′ M⊢′) =
+  cong `∀ (typing-uniqueᴳ M⊢ M⊢′)
+typing-uniqueᴳ (G.⊢• {A = A} M⊢) (G.⊢• M⊢′) =
+  cong (λ B → B [ A ]ᵗ)
+    (ty-all-injective (typing-uniqueᴳ M⊢ M⊢′))
+typing-uniqueᴳ (G.⊢$ κ) (G.⊢$ κ′) = refl
+typing-uniqueᴳ (G.⊢⊕ op L⊢ A∼arg M⊢ B∼arg)
+    (G.⊢⊕ op′ L⊢′ A′∼arg M⊢′ B′∼arg) =
+  refl
 
 compile-context-subst : ∀ {Δ} {Σ : TyStore Δ}
     {Γ Γ′ : TermCtx Δ} {M : GTerm Δ} {A : Ty Δ}
@@ -55,121 +119,475 @@ compile-Λ-term {Σ = Σ} vM M⊢
        | compile-value {Σ = store-lift Σ} vM M⊢
 compile-Λ-term {Σ = Σ} vM M⊢ | N , N⊢ | vN = refl
 
-compile-preserves-imprecision : ∀ {Δ} {ρ : CTI.StoreImp Δ}
+-- Embedding-directed renaming follows cast-term renaming under binders.
+Grenameᵐ : ∀ {Δ Δ′} → Δ ↪ᵗ Δ′ → GTerm Δ → GTerm Δ′
+Grenameᵐ η (G.` x) = G.` x
+Grenameᵐ η (G.ƛ A ⇒ M) =
+  G.ƛ renameᵗ (toRenameᵗ η) A ⇒ Grenameᵐ η M
+Grenameᵐ η (L G.·[ ℓ ] M) =
+  Grenameᵐ η L G.·[ ℓ ] Grenameᵐ η M
+Grenameᵐ η (G.Λ M) = G.Λ (Grenameᵐ (keep η) M)
+Grenameᵐ η (M G.`[ A ]) =
+  Grenameᵐ η M G.`[ renameᵗ (toRenameᵗ η) A ]
+Grenameᵐ η (G.$ κ) = G.$ κ
+Grenameᵐ η (L G.⊕[ op at ℓ ] M) =
+  Grenameᵐ η L G.⊕[ op at ℓ ] Grenameᵐ η M
+
+rename-valueᵐᴳ : ∀ {Δ Δ′} (η : Δ ↪ᵗ Δ′) {V}
+  → G.Value V
+  → G.Value (Grenameᵐ η V)
+rename-valueᵐᴳ η (G.ƛ A ⇒ N) =
+  G.ƛ renameᵗ (toRenameᵗ η) A ⇒ Grenameᵐ η N
+rename-valueᵐᴳ η (G.$ κ) = G.$ κ
+rename-valueᵐᴳ η (G.Λ N) =
+  G.Λ (Grenameᵐ (keep η) N)
+
+-- Compilation shape, abstracting over the chosen consistency evidence.
+data Elab {Δ : TyCtx} (Σ : TyStore Δ) (Γ : TermCtx Δ) :
+    GTerm Δ → C.Term Δ → Ty Δ → Set where
+  E-` : ∀ {x A}
+    → Γ T.∋ x ⦂ A
+    → Elab Σ Γ (G.` x) (`ᵀ x) A
+
+  E-ƛ : ∀ {M N A B}
+    → Elab Σ (A ∷ Γ) M N B
+    → Elab Σ Γ (G.ƛ A ⇒ M) (ƛᵀ N) (A ⇒ B)
+
+  E-· : ∀ {L Lᶜ M Mᶜ A B D ν ℓ}
+    → Elab Σ Γ L Lᶜ (A ⇒ B)
+    → Elab Σ Γ M Mᶜ D
+    → A ∼ D
+    → (c : _⊢_∼_ {Δ = Δ} ν D A)
+    → Elab Σ Γ (L G.·[ ℓ ] M)
+        (Lᶜ ·ᵀ (Mᶜ ⟨ᵀ c ⟩)) B
+
+  E-·★ : ∀ {L Lᶜ M Mᶜ A ν ν′ ℓ}
+    → Elab Σ Γ L Lᶜ ★
+    → Elab Σ Γ M Mᶜ A
+    → A ∼ ★
+    → (c : _⊢_∼_ {Δ = Δ} ν ★ (★ ⇒ ★))
+    → (d : _⊢_∼_ {Δ = Δ} ν′ A ★)
+    → Elab Σ Γ (L G.·[ ℓ ] M)
+        ((Lᶜ ⟨ᵀ c ⟩) ·ᵀ (Mᶜ ⟨ᵀ d ⟩)) ★
+
+  E-Λ : ∀ {M N A}
+    → (zero∈A : zero ∈ᵗ A)
+    → G.Value M
+    → C.Value N
+    → Elab (store-lift Σ) (⇑ᶜ Γ) M N A
+    → Elab Σ Γ (G.Λ M) (Λᵀ N) (`∀ A)
+
+  E-[] : ∀ {M N B A C}
+    → Elab Σ Γ M N (`∀ B)
+    → B [ A ]ᵗ ≡ C
+    → Elab Σ Γ (M G.`[ A ])
+        (N ⦂∀ᵀ B [ A ]) C
+
+  E-$ : ∀ κ
+    → Elab Σ Γ (G.$ κ) ($ᵀ κ) (constTy κ)
+
+  E-⊕ : ∀ {L Lᶜ M Mᶜ A B ν ν′ ℓ}
+    → (op : Prim)
+    → Elab Σ Γ L Lᶜ A
+    → A ∼ primArgTy op
+    → (c : _⊢_∼_ {Δ = Δ} ν A (primArgTy op))
+    → Elab Σ Γ M Mᶜ B
+    → B ∼ primArgTy op
+    → (d : _⊢_∼_ {Δ = Δ} ν′ B (primArgTy op))
+    → Elab Σ Γ (L G.⊕[ op at ℓ ] M)
+        ((Lᶜ ⟨ᵀ c ⟩) ⊕ᵀ[ op ] (Mᶜ ⟨ᵀ d ⟩))
+        (primResultTy op)
+
+elab-gradual-typing : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ}
+    {M : GTerm Δ} {N : C.Term Δ} {A : Ty Δ}
+  → Elab Σ Γ M N A
+  → Δ ∣ Γ ⊢ M ⦂ A
+elab-gradual-typing (E-` x∈) = G.⊢` x∈
+elab-gradual-typing (E-ƛ Mᴱ) =
+  G.⊢ƛ (elab-gradual-typing Mᴱ)
+elab-gradual-typing (E-· Lᴱ Mᴱ A∼D c) =
+  G.⊢· (elab-gradual-typing Lᴱ)
+    (elab-gradual-typing Mᴱ) A∼D
+elab-gradual-typing (E-·★ Lᴱ Mᴱ A∼★ c d) =
+  G.⊢·★ (elab-gradual-typing Lᴱ)
+    (elab-gradual-typing Mᴱ) A∼★
+elab-gradual-typing (E-Λ zero∈A vM vN Mᴱ) =
+  G.⊢Λ {zero∈A = zero∈A} vM (elab-gradual-typing Mᴱ)
+elab-gradual-typing (E-[] Mᴱ eq) =
+  subst (λ T → _ ∣ _ ⊢ _ ⦂ T) eq
+    (G.⊢• (elab-gradual-typing Mᴱ))
+elab-gradual-typing (E-$ κ) = G.⊢$ κ
+elab-gradual-typing (E-⊕ op Lᴱ A∼arg c Mᴱ B∼arg d) =
+  G.⊢⊕ op (elab-gradual-typing Lᴱ) A∼arg
+    (elab-gradual-typing Mᴱ) B∼arg
+
+elab-cast-typing : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ}
+    {M : GTerm Δ} {N : C.Term Δ} {A : Ty Δ}
+  → Elab Σ Γ M N A
+  → C.⟨ Δ , Σ , Γ ⟩ C.⊢ N ⦂ A
+elab-cast-typing (E-` x∈) = C.⊢` x∈
+elab-cast-typing (E-ƛ Mᴱ) =
+  C.⊢ƛ (elab-cast-typing Mᴱ)
+elab-cast-typing (E-· Lᴱ Mᴱ A∼D c) =
+  C.⊢· (elab-cast-typing Lᴱ)
+    (C.⊢⟨⟩ (elab-cast-typing Mᴱ) c)
+elab-cast-typing (E-·★ Lᴱ Mᴱ A∼★ c d) =
+  C.⊢· (C.⊢⟨⟩ (elab-cast-typing Lᴱ) c)
+    (C.⊢⟨⟩ (elab-cast-typing Mᴱ) d)
+elab-cast-typing (E-Λ zero∈A vM vN Mᴱ) =
+  C.⊢Λ vN (elab-cast-typing Mᴱ)
+elab-cast-typing (E-[] Mᴱ eq) =
+  subst (λ T → C.⟨ _ , _ , _ ⟩ C.⊢ _ ⦂ T) eq
+    (C.⊢• (elab-cast-typing Mᴱ))
+elab-cast-typing (E-$ κ) = C.⊢$ κ
+elab-cast-typing (E-⊕ op Lᴱ A∼arg c Mᴱ B∼arg d) =
+  C.⊢⊕ op (C.⊢⟨⟩ (elab-cast-typing Lᴱ) c)
+    (C.⊢⟨⟩ (elab-cast-typing Mᴱ) d)
+
+compile-elab : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ}
+    {M : GTerm Δ} {A : Ty Δ}
+  → (M⊢ : Δ ∣ Γ ⊢ M ⦂ A)
+  → Elab Σ Γ M (proj₁ (compile {Σ = Σ} M⊢)) A
+compile-elab (G.⊢` x∈) = E-` x∈
+compile-elab {Σ = Σ} (G.⊢ƛ M⊢)
+    with compile {Σ = Σ} M⊢ | compile-elab {Σ = Σ} M⊢
+compile-elab {Σ = Σ} (G.⊢ƛ M⊢)
+    | N , N⊢ | Nᴱ =
+  E-ƛ Nᴱ
+compile-elab {Σ = Σ} (G.⊢· L⊢ M⊢ A∼D)
+    with compile {Σ = Σ} L⊢ | compile-elab {Σ = Σ} L⊢
+       | compile {Σ = Σ} M⊢ | compile-elab {Σ = Σ} M⊢
+compile-elab {Σ = Σ} (G.⊢· L⊢ M⊢ A∼D)
+    | Lᶜ , Lᶜ⊢ | Lᴱ | Mᶜ , Mᶜ⊢ | Mᴱ =
+  E-· Lᴱ Mᴱ A∼D (symᶜ A∼D)
+compile-elab {Σ = Σ} (G.⊢·★ L⊢ M⊢ A∼★)
+    with compile {Σ = Σ} L⊢ | compile-elab {Σ = Σ} L⊢
+       | compile {Σ = Σ} M⊢ | compile-elab {Σ = Σ} M⊢
+compile-elab {Σ = Σ} (G.⊢·★ L⊢ M⊢ A∼★)
+    | Lᶜ , Lᶜ⊢ | Lᴱ | Mᶜ , Mᶜ⊢ | Mᴱ =
+  E-·★ Lᴱ Mᴱ A∼★ dynamic-function-cast A∼★
+compile-elab {Σ = Σ} (G.⊢Λ {zero∈A = zero∈A} vM M⊢)
+    with compile {Σ = store-lift Σ} M⊢
+       | compile-value {Σ = store-lift Σ} vM M⊢
+       | compile-elab {Σ = store-lift Σ} M⊢
+compile-elab {Σ = Σ} (G.⊢Λ {zero∈A = zero∈A} vM M⊢)
+    | N , N⊢ | vN | Nᴱ =
+  E-Λ zero∈A vM vN Nᴱ
+compile-elab {Σ = Σ} (G.⊢• M⊢)
+    with compile {Σ = Σ} M⊢ | compile-elab {Σ = Σ} M⊢
+compile-elab {Σ = Σ} (G.⊢• M⊢) | N , N⊢ | Nᴱ =
+  E-[] Nᴱ refl
+compile-elab (G.⊢$ κ) = E-$ κ
+compile-elab {Σ = Σ} (G.⊢⊕ op L⊢ A∼arg M⊢ B∼arg)
+    with compile {Σ = Σ} L⊢ | compile-elab {Σ = Σ} L⊢
+       | compile {Σ = Σ} M⊢ | compile-elab {Σ = Σ} M⊢
+compile-elab {Σ = Σ} (G.⊢⊕ op L⊢ A∼arg M⊢ B∼arg)
+    | Lᶜ , Lᶜ⊢ | Lᴱ | Mᶜ , Mᶜ⊢ | Mᴱ =
+  E-⊕ op Lᴱ A∼arg A∼arg Mᴱ B∼arg B∼arg
+
+renameᵗᴳ-cong : ∀ {Δ Δ′} {ρ σ : Δ ⇒ʳ Δ′}
+  → (M : GTerm Δ)
+  → (∀ X → ρ X ≡ σ X)
+  → G.renameᵗᴳ ρ M ≡ G.renameᵗᴳ σ M
+renameᵗᴳ-cong (G.` x) eq = refl
+renameᵗᴳ-cong (G.ƛ A ⇒ M) eq =
+  cong₂ G.ƛ_⇒_ (renameᵗ-cong A eq) (renameᵗᴳ-cong M eq)
+renameᵗᴳ-cong (L G.·[ ℓ ] M) eq =
+  cong₂ (λ L′ M′ → L′ G.·[ ℓ ] M′)
+    (renameᵗᴳ-cong L eq) (renameᵗᴳ-cong M eq)
+renameᵗᴳ-cong (G.Λ M) eq =
+  cong G.Λ_ (renameᵗᴳ-cong M ext-eq)
+  where
+  ext-eq : ∀ X → extᵗ _ X ≡ extᵗ _ X
+  ext-eq Fin.zero = refl
+  ext-eq (Fin.suc X) = cong Fin.suc (eq X)
+renameᵗᴳ-cong (M G.`[ A ]) eq =
+  cong₂ G._`[_] (renameᵗᴳ-cong M eq) (renameᵗ-cong A eq)
+renameᵗᴳ-cong (G.$ κ) eq = refl
+renameᵗᴳ-cong (L G.⊕[ op at ℓ ] M) eq =
+  cong₂ (λ L′ M′ → L′ G.⊕[ op at ℓ ] M′)
+    (renameᵗᴳ-cong L eq) (renameᵗᴳ-cong M eq)
+
+Grenameᵐ-to-rename : ∀ {Δ Δ′} (η : Δ ↪ᵗ Δ′) (M : GTerm Δ)
+  → Grenameᵐ η M ≡ G.renameᵗᴳ (toRenameᵗ η) M
+Grenameᵐ-to-rename η (G.` x) = refl
+Grenameᵐ-to-rename η (G.ƛ A ⇒ M) =
+  cong (G.ƛ renameᵗ (toRenameᵗ η) A ⇒_)
+    (Grenameᵐ-to-rename η M)
+Grenameᵐ-to-rename η (L G.·[ ℓ ] M) =
+  cong₂ (λ L′ M′ → L′ G.·[ ℓ ] M′)
+    (Grenameᵐ-to-rename η L) (Grenameᵐ-to-rename η M)
+Grenameᵐ-to-rename η (G.Λ M) =
+  cong G.Λ_
+    (trans (Grenameᵐ-to-rename (keep η) M)
+      (renameᵗᴳ-cong M (toRename-keep-eq η)))
+Grenameᵐ-to-rename η (M G.`[ A ]) =
+  cong (λ M′ → M′ G.`[ renameᵗ (toRenameᵗ η) A ])
+    (Grenameᵐ-to-rename η M)
+Grenameᵐ-to-rename η (G.$ κ) = refl
+Grenameᵐ-to-rename η (L G.⊕[ op at ℓ ] M) =
+  cong₂ (λ L′ M′ → L′ G.⊕[ op at ℓ ] M′)
+    (Grenameᵐ-to-rename η L) (Grenameᵐ-to-rename η M)
+
+rename-elab : ∀ {Δ Δ′} {Σ : TyStore Δ} {Σ′ : TyStore Δ′}
+    {Γ : TermCtx Δ} {M : GTerm Δ} {N : C.Term Δ} {A : Ty Δ}
+    (η : Δ ↪ᵗ Δ′)
+  → Elab Σ Γ M N A
+  → Elab Σ′ (T.renameCtx (toRenameᵗ η) Γ)
+      (Grenameᵐ η M) (C.renameᵗᵐ η N)
+      (renameᵗ (toRenameᵗ η) A)
+rename-elab η (E-` x∈) =
+  E-` (T.renameᵗ-∋ (toRenameᵗ η) x∈)
+rename-elab η (E-ƛ Mᴱ) =
+  E-ƛ (rename-elab η Mᴱ)
+rename-elab η (E-· Lᴱ Mᴱ A∼D c) =
+  E-· (rename-elab η Lᴱ) (rename-elab η Mᴱ)
+    (renameᶜ (toRenameᵗ η) A∼D) (renameᵐᶜ η c)
+rename-elab η (E-·★ Lᴱ Mᴱ A∼★ c d) =
+  E-·★ (rename-elab η Lᴱ) (rename-elab η Mᴱ)
+    (renameᶜ (toRenameᵗ η) A∼★)
+    (renameᵐᶜ η c) (renameᵐᶜ η d)
+rename-elab {Σ′ = Σ′} {Γ = Γ} η
+    (E-Λ {M = M} {N = N} {A = A} zero∈A vM vN Mᴱ) =
+  subst
+    (λ T′ → Elab Σ′ (T.renameCtx (toRenameᵗ η) Γ)
+      (G.Λ (Grenameᵐ (keep η) M))
+      (Λᵀ (C.renameᵗᵐ (keep η) N)) T′)
+    (cong `∀ (renameᵗ-cong A (toRename-keep-eq η)))
+    (E-Λ
+      (rename-occurs (toRenameᵗ (keep η))
+        (toRenameᵗ-injective (keep η)) zero∈A)
+      (rename-valueᵐᴳ (keep η) vM)
+      (renameᵗᵐ-preserves-Value (keep η) vN)
+      (subst
+        (λ Γ′ → Elab (store-lift Σ′) Γ′
+          (Grenameᵐ (keep η) M)
+          (C.renameᵗᵐ (keep η) N)
+          (renameᵗ (toRenameᵗ (keep η)) A))
+        (renameCtx-keep-shift η Γ)
+        (rename-elab (keep η) Mᴱ)))
+rename-elab {Σ′ = Σ′} {Γ = Γ} η
+    (E-[] {M = M} {N = N} {B = B} {A = A} Mᴱ eq) =
+  subst
+    (λ T′ → Elab Σ′ (T.renameCtx (toRenameᵗ η) Γ)
+      (Grenameᵐ η M G.`[ renameᵗ (toRenameᵗ η) A ])
+      (C.renameᵗᵐ η N
+        ⦂∀ᵀ renameᵗ (toRenameᵗ (keep η)) B
+        [ renameᵗ (toRenameᵗ η) A ])
+      T′)
+    (trans result-eq (cong (renameᵗ (toRenameᵗ η)) eq))
+    (E-[] (subst
+      (λ T′ → Elab Σ′ (T.renameCtx (toRenameᵗ η) Γ)
+        (Grenameᵐ η M) (C.renameᵗᵐ η N) (`∀ T′))
+      (sym body-eq) (rename-elab η Mᴱ)) refl)
+  where
+  body-eq =
+    renameᵗ-cong B (toRename-keep-eq η)
+
+  result-eq =
+    trans (cong (λ T′ →
+        T′ [ renameᵗ (toRenameᵗ η) A ]ᵗ) body-eq)
+      (sym (rename-openᵗ (toRenameᵗ η) B A))
+rename-elab {Σ′ = Σ′} {Γ = Γ} η (E-$ κ) =
+  subst
+    (λ T′ → Elab Σ′ (T.renameCtx (toRenameᵗ η) Γ)
+      (G.$ κ) ($ᵀ κ) T′)
+    (constTy-renameᵗ (toRenameᵗ η) κ) (E-$ κ)
+rename-elab η
+    (E-⊕ addℕ Lᴱ A∼arg c Mᴱ B∼arg d) =
+  E-⊕ addℕ (rename-elab η Lᴱ)
+    (renameᶜ (toRenameᵗ η) A∼arg) (renameᵐᶜ η c)
+    (rename-elab η Mᴱ)
+    (renameᶜ (toRenameᵗ η) B∼arg) (renameᵐᶜ η d)
+rename-elab η
+    (E-⊕ and𝔹 Lᴱ A∼arg c Mᴱ B∼arg d) =
+  E-⊕ and𝔹 (rename-elab η Lᴱ)
+    (renameᶜ (toRenameᵗ η) A∼arg) (renameᵐᶜ η c)
+    (rename-elab η Mᴱ)
+    (renameᶜ (toRenameᵗ η) B∼arg) (renameᵐᶜ η d)
+
+shift-elab : ∀ {Δ} {Σ : TyStore Δ} {Γ : TermCtx Δ}
+    {M : GTerm Δ} {N : C.Term Δ} {A : Ty Δ}
+  → Elab Σ Γ M N A
+  → Elab (store-lift Σ) (⇑ᶜ Γ)
+      (G.⇑ᵗᴳ M) (C.⇑ᵗᵐ N) (⇑ᵗ A)
+shift-elab {Σ = Σ} {Γ = Γ} {M = M} {N = N} {A = A} Mᴱ =
+  subst
+    (λ T′ → Elab (store-lift Σ) (⇑ᶜ Γ)
+      (G.⇑ᵗᴳ M) (C.⇑ᵗᵐ N) T′)
+    (renameᵗ-wk-eq A)
+    (subst
+      (λ M′ → Elab (store-lift Σ) (⇑ᶜ Γ)
+        M′ (C.⇑ᵗᵐ N) (renameᵗ (toRenameᵗ wk↪ᵗ) A))
+      term-eq
+      (subst
+        (λ Γ′ → Elab (store-lift Σ) Γ′
+          (Grenameᵐ wk↪ᵗ M) (C.⇑ᵗᵐ N)
+          (renameᵗ (toRenameᵗ wk↪ᵗ) A))
+        (renameCtx-wk-eq Γ)
+        (rename-elab {Σ′ = store-lift Σ} wk↪ᵗ Mᴱ)))
+  where
+  term-eq =
+    trans (Grenameᵐ-to-rename wk↪ᵗ M)
+      (renameᵗᴳ-cong M toRename-wk-eq)
+
+compile-preserves-elab : ∀ {Δ} {ρ : CTI.StoreImp Δ}
     {γ : CtxImp (CTI.impEnvⁱ ρ)} {M M′ A B p}
+    {N : C.Term Δ}
   → (M⊑M′ : CTI.impEnvⁱ ρ ∣ γ
       ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p)
+  → Elab (CTI.targetStoreⁱ ρ) (GTI.tgtCtxⁱ γ) M′ N B
   → ρ ∣ γ ⊢ᶜ
       proj₁ (compile {Σ = CTI.sourceStoreⁱ ρ}
         (GTI.gradual-term-imprecision-source-typing M⊑M′))
-      ⊑ proj₁ (compile {Σ = CTI.targetStoreⁱ ρ}
-        (GTI.gradual-term-imprecision-target-typing M⊑M′))
-      ∶ p
-compile-preserves-imprecision (GTI.x⊑xᴳ x∈) =
+      ⊑ N ∶ p
+compile-preserves-elab (GTI.x⊑xᴳ x∈) (E-` x∈′) =
   CTI.x⊑xᶜ x∈
-compile-preserves-imprecision {ρ = ρ} (GTI.ƛ⊑ƛᴳ N⊑N′)
+compile-preserves-elab {ρ = ρ} (GTI.ƛ⊑ƛᴳ N⊑N′) (E-ƛ N′ᴱ)
     with compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing N⊑N′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing N⊑N′)
-       | compile-preserves-imprecision {ρ = ρ} N⊑N′
-compile-preserves-imprecision {ρ = ρ} (GTI.ƛ⊑ƛᴳ N⊑N′)
-    | N , N⊢ | N′ , N′⊢ | N⊑N′ᶜ =
+       | compile-preserves-elab {ρ = ρ} N⊑N′ N′ᴱ
+compile-preserves-elab {ρ = ρ} (GTI.ƛ⊑ƛᴳ N⊑N′) (E-ƛ N′ᴱ)
+    | N , N⊢ | N⊑N′ᶜ =
   CTI.ƛ⊑ƛᶜ N⊑N′ᶜ
-compile-preserves-imprecision
+compile-preserves-elab
     {ρ = ρ}
     (GTI.·⊑·ᴳ {pA = pA} L⊑L′ M⊑M′ A∼C A′∼C′)
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    with typing-uniqueᴳ (elab-gradual-typing L′ᴱ)
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+       | typing-uniqueᴳ (elab-gradual-typing M′ᴱ)
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+compile-preserves-elab
+    {ρ = ρ}
+    (GTI.·⊑·ᴳ {pA = pA} L⊑L′ M⊑M′ A∼C A′∼C′)
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    | refl | refl
     with compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing L⊑L′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing L⊑L′)
-       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile-preserves-elab {ρ = ρ} L⊑L′ L′ᴱ
        | compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing M⊑M′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing M⊑M′)
-       | compile-preserves-imprecision {ρ = ρ} M⊑M′
-compile-preserves-imprecision
+       | compile-preserves-elab {ρ = ρ} M⊑M′ M′ᴱ
+compile-preserves-elab
     {ρ = ρ}
     (GTI.·⊑·ᴳ {pA = pA} L⊑L′ M⊑M′ A∼C A′∼C′)
-    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
-    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    | refl | refl
+    | L , L⊢ | L⊑L′ᶜ | M , M⊢ | M⊑M′ᶜ =
   CTI.·⊑·ᶜ L⊑L′ᶜ
-    (CTI.cast⊑castᶜ (symᶜ A∼C) (symᶜ A′∼C′) M⊑M′ᶜ pA)
-compile-preserves-imprecision
+    (CTI.cast⊑castᶜ (symᶜ A∼C) d′ M⊑M′ᶜ pA)
+compile-preserves-elab
+    (GTI.·⊑·ᴳ L⊑L′ M⊑M′ A∼C A′∼C′)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    with typing-uniqueᴳ
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+      (elab-gradual-typing L′ᴱ)
+compile-preserves-elab
+    (GTI.·⊑·ᴳ L⊑L′ M⊑M′ A∼C A′∼C′)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    | ()
+compile-preserves-elab
+    (GTI.·⊑·★ᴳ L⊑L′ M⊑M′ A∼C C′∼★)
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    with typing-uniqueᴳ
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+      (elab-gradual-typing L′ᴱ)
+compile-preserves-elab
+    (GTI.·⊑·★ᴳ L⊑L′ M⊑M′ A∼C C′∼★)
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    | ()
+compile-preserves-elab
     {ρ = ρ}
     (GTI.·⊑·★ᴳ {pA = pA} {pB = pB}
       L⊑L′ M⊑M′ A∼C C′∼★)
-    with compile {Σ = CTI.sourceStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-source-typing L⊑L′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing L⊑L′)
-       | compile-preserves-imprecision {ρ = ρ} L⊑L′
-       | compile {Σ = CTI.sourceStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-source-typing M⊑M′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    with typing-uniqueᴳ (elab-gradual-typing M′ᴱ)
       (GTI.gradual-term-imprecision-target-typing M⊑M′)
-       | compile-preserves-imprecision {ρ = ρ} M⊑M′
-compile-preserves-imprecision
+compile-preserves-elab
     {ρ = ρ}
     (GTI.·⊑·★ᴳ {pA = pA} {pB = pB}
       L⊑L′ M⊑M′ A∼C C′∼★)
-    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
-    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
-  CTI.·⊑·ᶜ
-    (CTI.⊑castᶜ dynamic-function-cast L⊑L′ᶜ (⇒⊑⇒ pA pB))
-    (CTI.cast⊑castᶜ (symᶜ A∼C) C′∼★ M⊑M′ᶜ pA)
-compile-preserves-imprecision
-    {ρ = ρ} (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    | refl
     with compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing L⊑L′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing L⊑L′)
-       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile-preserves-elab {ρ = ρ} L⊑L′ L′ᴱ
        | compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing M⊑M′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing M⊑M′)
-       | compile-preserves-imprecision {ρ = ρ} M⊑M′
-compile-preserves-imprecision
-    {ρ = ρ} (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
-    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
-    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+       | compile-preserves-elab {ρ = ρ} M⊑M′ M′ᴱ
+compile-preserves-elab
+    {ρ = ρ}
+    (GTI.·⊑·★ᴳ {pA = pA} {pB = pB}
+      L⊑L′ M⊑M′ A∼C C′∼★)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    | refl
+    | L , L⊢ | L⊑L′ᶜ | M , M⊢ | M⊑M′ᶜ =
   CTI.·⊑·ᶜ
-    (CTI.cast⊑castᶜ dynamic-function-cast dynamic-function-cast
+    (CTI.⊑castᶜ c′ L⊑L′ᶜ (⇒⊑⇒ pA pB))
+    (CTI.cast⊑castᶜ (symᶜ A∼C) d′ M⊑M′ᶜ pA)
+compile-preserves-elab
+    (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    with typing-uniqueᴳ
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+      (elab-gradual-typing L′ᴱ)
+compile-preserves-elab
+    (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    (E-· L′ᴱ M′ᴱ A′∼D′ d′)
+    | ()
+compile-preserves-elab
+    {ρ = ρ}
+    (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    with typing-uniqueᴳ (elab-gradual-typing M′ᴱ)
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+compile-preserves-elab
+    {ρ = ρ}
+    (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    | refl
+    with compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing L⊑L′)
+       | compile-preserves-elab {ρ = ρ} L⊑L′ L′ᴱ
+       | compile {Σ = CTI.sourceStoreⁱ ρ}
+      (GTI.gradual-term-imprecision-source-typing M⊑M′)
+       | compile-preserves-elab {ρ = ρ} M⊑M′ M′ᴱ
+compile-preserves-elab
+    {ρ = ρ}
+    (GTI.·★⊑·★ᴳ L⊑L′ M⊑M′ C∼★ C′∼★)
+    (E-·★ L′ᴱ M′ᴱ D′∼★ c′ d′)
+    | refl
+    | L , L⊢ | L⊑L′ᶜ | M , M⊢ | M⊑M′ᶜ =
+  CTI.·⊑·ᶜ
+    (CTI.cast⊑castᶜ dynamic-function-cast c′
       L⊑L′ᶜ (⇒⊑⇒ ★⊑★ ★⊑★))
-    (CTI.cast⊑castᶜ C∼★ C′∼★ M⊑M′ᶜ ★⊑★)
-compile-preserves-imprecision
+    (CTI.cast⊑castᶜ C∼★ d′ M⊑M′ᶜ ★⊑★)
+compile-preserves-elab
     {ρ = ρ} {γ = γ}
     (GTI.Λ⊑Λᴳ liftγ vV vV′ zero∈A zero∈B V⊑V′)
+    (E-Λ zero∈B′ vV′′ vN′ V′ᴱ)
     rewrite compile-Λ-term {Σ = CTI.sourceStoreⁱ ρ}
       {Γ = GTI.srcCtxⁱ γ}
       {zero∈A = zero∈A} vV
       (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (GTI.srcCtxⁱ-lift liftγ)
         (GTI.gradual-term-imprecision-source-typing V⊑V′))
-      | compile-Λ-term {Σ = CTI.targetStoreⁱ ρ}
-      {Γ = GTI.tgtCtxⁱ γ}
-      {zero∈A = zero∈B} vV′
-      (subst (λ Γ → _ ∣ Γ ⊢ _ ⦂ _) (GTI.tgtCtxⁱ-lift liftγ)
-        (GTI.gradual-term-imprecision-target-typing V⊑V′))
       | compile-context-subst
       {Σ = store-lift (CTI.sourceStoreⁱ ρ)}
       (GTI.srcCtxⁱ-lift liftγ)
-      (GTI.gradual-term-imprecision-source-typing V⊑V′)
-      | compile-context-subst
-      {Σ = store-lift (CTI.targetStoreⁱ ρ)}
-      (GTI.tgtCtxⁱ-lift liftγ)
-      (GTI.gradual-term-imprecision-target-typing V⊑V′) =
+      (GTI.gradual-term-imprecision-source-typing V⊑V′) =
   CTI.Λ⊑Λᶜ liftγ
     (compile-value {Σ = store-lift (CTI.sourceStoreⁱ ρ)} vV
       (GTI.gradual-term-imprecision-source-typing V⊑V′))
-    (compile-value {Σ = store-lift (CTI.targetStoreⁱ ρ)} vV′
-      (GTI.gradual-term-imprecision-target-typing V⊑V′))
-    (compile-preserves-imprecision
-      {ρ = CTI.liftStoreImp X⊑X ρ} V⊑V′)
-compile-preserves-imprecision
+    vN′
+    (compile-preserves-elab
+      {ρ = CTI.liftStoreImp X⊑X ρ} V⊑V′
+      (subst (λ Γ → Elab
+          (store-lift (CTI.targetStoreⁱ ρ)) Γ _ _ _)
+        (sym (GTI.tgtCtxⁱ-lift liftγ)) V′ᴱ))
+compile-preserves-elab
     {ρ = ρ} {γ = γ}
-    (GTI.Λ⊑ᴳ Anv zero∈A liftγ vV N′⊢ V⊑N′)
+    (GTI.Λ⊑ᴳ Anv zero∈A liftγ vV N′⊢ V⊑N′) N′ᴱ
     rewrite compile-Λ-term {Σ = CTI.sourceStoreⁱ ρ}
       {Γ = GTI.srcCtxⁱ γ}
       {zero∈A = zero∈A} vV
@@ -182,52 +600,87 @@ compile-preserves-imprecision
   CTI.Λ⊑ᶜ Anv zero∈A liftγ
     (compile-value {Σ = store-lift (CTI.sourceStoreⁱ ρ)} vV
       (GTI.gradual-term-imprecision-source-typing V⊑N′))
-    (proj₂ (compile {Σ = CTI.targetStoreⁱ ρ} N′⊢))
-    (compile-preserves-imprecision
-      {ρ = CTI.liftStoreImp X⊑★ ρ} V⊑N′)
-compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑[]ᴳ M⊑M′ q r)
+    (elab-cast-typing N′ᴱ)
+    (compile-preserves-elab
+      {ρ = CTI.liftStoreImp X⊑★ ρ} V⊑N′
+      (subst (λ Γ → Elab
+          (store-lift (CTI.targetStoreⁱ ρ)) Γ _ _ _)
+        (sym (GTI.tgtCtxⁱ-lift liftγ)) (shift-elab N′ᴱ)))
+compile-preserves-elab {ρ = ρ}
+    (GTI.[]⊑[]ᴳ M⊑M′ q r) (E-[] M′ᴱ eq)
+    with typing-uniqueᴳ (elab-gradual-typing M′ᴱ)
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+compile-preserves-elab {ρ = ρ}
+    (GTI.[]⊑[]ᴳ M⊑M′ q r) (E-[] M′ᴱ eq)
+    | refl
+    with eq
+compile-preserves-elab {ρ = ρ}
+    (GTI.[]⊑[]ᴳ M⊑M′ q r) (E-[] M′ᴱ eq)
+    | refl | refl
     with compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing M⊑M′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing M⊑M′)
-       | compile-preserves-imprecision {ρ = ρ} M⊑M′
-compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑[]ᴳ M⊑M′ q r)
-    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+       | compile-preserves-elab {ρ = ρ} M⊑M′ M′ᴱ
+compile-preserves-elab {ρ = ρ}
+    (GTI.[]⊑[]ᴳ M⊑M′ q r) (E-[] M′ᴱ eq)
+    | refl | refl | M , M⊢ | M⊑M′ᶜ =
   CTI.•⊑•ᶜ M⊑M′ᶜ q r
-compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑ᴳ M⊑M′ q r)
+compile-preserves-elab {ρ = ρ}
+    (GTI.[]⊑ᴳ M⊑M′ q r) M′ᴱ
     with compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing M⊑M′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing M⊑M′)
-       | compile-preserves-imprecision {ρ = ρ} M⊑M′
-compile-preserves-imprecision {ρ = ρ} (GTI.[]⊑ᴳ M⊑M′ q r)
-    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+       | compile-preserves-elab {ρ = ρ} M⊑M′ M′ᴱ
+compile-preserves-elab {ρ = ρ}
+    (GTI.[]⊑ᴳ M⊑M′ q r) M′ᴱ
+    | M , M⊢ | M⊑M′ᶜ =
   CTI.•⊑ᶜ M⊑M′ᶜ q r
-compile-preserves-imprecision {ρ = ρ} (GTI.κ⊑κᴳ κ) =
+compile-preserves-elab {ρ = ρ} (GTI.κ⊑κᴳ κ) (E-$ .κ) =
   CTI.κ⊑κᶜ κ (GTI.constTy-⊑ (CTI.impEnvⁱ ρ) κ)
-compile-preserves-imprecision
+compile-preserves-elab
     {ρ = ρ}
     (GTI.⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
       B∼arg B′∼arg)
+    (E-⊕ .op L′ᴱ A′∼arg′ c′ M′ᴱ B′∼arg′ d′)
+    with typing-uniqueᴳ (elab-gradual-typing L′ᴱ)
+      (GTI.gradual-term-imprecision-target-typing L⊑L′)
+       | typing-uniqueᴳ (elab-gradual-typing M′ᴱ)
+      (GTI.gradual-term-imprecision-target-typing M⊑M′)
+compile-preserves-elab
+    {ρ = ρ}
+    (GTI.⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
+      B∼arg B′∼arg)
+    (E-⊕ .op L′ᴱ A′∼arg′ c′ M′ᴱ B′∼arg′ d′)
+    | refl | refl
     with compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing L⊑L′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing L⊑L′)
-       | compile-preserves-imprecision {ρ = ρ} L⊑L′
+       | compile-preserves-elab {ρ = ρ} L⊑L′ L′ᴱ
        | compile {Σ = CTI.sourceStoreⁱ ρ}
       (GTI.gradual-term-imprecision-source-typing M⊑M′)
-       | compile {Σ = CTI.targetStoreⁱ ρ}
-      (GTI.gradual-term-imprecision-target-typing M⊑M′)
-       | compile-preserves-imprecision {ρ = ρ} M⊑M′
-compile-preserves-imprecision
+       | compile-preserves-elab {ρ = ρ} M⊑M′ M′ᴱ
+compile-preserves-elab
     {ρ = ρ}
     (GTI.⊕⊑⊕ᴳ op L⊑L′ A∼arg A′∼arg M⊑M′
       B∼arg B′∼arg)
-    | L , L⊢ | L′ , L′⊢ | L⊑L′ᶜ
-    | M , M⊢ | M′ , M′⊢ | M⊑M′ᶜ =
+    (E-⊕ .op L′ᴱ A′∼arg′ c′ M′ᴱ B′∼arg′ d′)
+    | refl | refl
+    | L , L⊢ | L⊑L′ᶜ | M , M⊢ | M⊑M′ᶜ =
   CTI.⊕⊑⊕ᶜ op
-    (CTI.cast⊑castᶜ A∼arg A′∼arg L⊑L′ᶜ
+    (CTI.cast⊑castᶜ A∼arg c′ L⊑L′ᶜ
       (refl⊑ (primArgTy op)))
-    (CTI.cast⊑castᶜ B∼arg B′∼arg M⊑M′ᶜ
+    (CTI.cast⊑castᶜ B∼arg d′ M⊑M′ᶜ
       (refl⊑ (primArgTy op)))
     (GTI.primResultTy-⊑ (CTI.impEnvⁱ ρ) op)
+
+compile-preserves-imprecision : ∀ {Δ} {ρ : CTI.StoreImp Δ}
+    {γ : CtxImp (CTI.impEnvⁱ ρ)} {M M′ A B p}
+  → (M⊑M′ : CTI.impEnvⁱ ρ ∣ γ
+      ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p)
+  → ρ ∣ γ ⊢ᶜ
+      proj₁ (compile {Σ = CTI.sourceStoreⁱ ρ}
+        (GTI.gradual-term-imprecision-source-typing M⊑M′))
+      ⊑ proj₁ (compile {Σ = CTI.targetStoreⁱ ρ}
+        (GTI.gradual-term-imprecision-target-typing M⊑M′))
+      ∶ p
+compile-preserves-imprecision M⊑M′ =
+  compile-preserves-elab M⊑M′
+    (compile-elab
+      (GTI.gradual-term-imprecision-target-typing M⊑M′))

--- a/GTSFImp/proof/DGG/ConvImp.agda
+++ b/GTSFImp/proof/DGG/ConvImp.agda
@@ -1,0 +1,408 @@
+module proof.DGG.ConvImp where
+
+-- File Charter:
+--   * Occurrence transport along the pivot-indexed conversion typing
+--     _⊢↑[_]_ / _⊢↓[_]_ of proof.DGG.CastTermImprecision2.
+--   * A conversion pivoted at just X only rewrites occurrences of X,
+--     so any other variable Y occurs in one endpoint iff it occurs in
+--     the other, provided Y avoids the store representation of the
+--     pivot.  A conversion with pivot nothing is identity-shaped and
+--     its endpoints are equal outright.
+--   * Transports both the occurrence relation _∈ᵗ_ and its complement
+--     _∉ᵗ_, in both directions, because _∈ᵗ_'s function-range
+--     constructor carries a _∉ᵗ_ witness for the domain and because
+--     the domain component of an arrow conversion flips direction.
+--   * Arrow conversions join their components' pivots with PivotJoin;
+--     a component at pivot nothing transports by its endpoint equality
+--     instead of by recursion.
+--   * Specializes the transport to the ∀-binder, where the pivot is a
+--     shifted variable and the transported variable is zero.
+
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.Maybe using (just; nothing)
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; cong; cong₂)
+
+open import Types
+open import TyStore using (TyStore; store-lift; _∋_⦂_; S-lift∋)
+open import Conversion using
+  (Conv↑; Conv↓; unseal; _↦↑_; `∀↑_; id↑; seal; _↦↓_; `∀↓_; id↓)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (_⊢↑[_]_; _⊢↓[_]_;
+   ⊢↑-unsealˣ; ⊢↑-⇒ˣ; ⊢↑-∀ˣ; ⊢↑-∀-idˣ; ⊢↑-idˣ;
+   ⊢↓-sealˣ; ⊢↓-⇒ˣ; ⊢↓-∀ˣ; ⊢↓-∀-idˣ; ⊢↓-idˣ;
+   PivotJoin; join-none; join-left; join-right; join-both)
+open import proof.ImprecisionConsistency using
+  (fin-suc-injective; shift-not-occurs; zero-absent-shift)
+
+------------------------------------------------------------------------
+-- Occurrence and non-occurrence are contradictory
+------------------------------------------------------------------------
+
+occurs-absent-⊥ : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → X ∈ᵗ A
+  → X ∉ᵗ A
+    ---------
+  → ⊥
+occurs-absent-⊥ var-∈ (∉-var X≢X) = X≢X refl
+occurs-absent-⊥ (∈-fun-left X∈A) (∉-fun X∉A X∉B) =
+  occurs-absent-⊥ X∈A X∉A
+occurs-absent-⊥ (∈-fun-right X∉A′ X∈B) (∉-fun X∉A X∉B) =
+  occurs-absent-⊥ X∈B X∉B
+occurs-absent-⊥ (∈-all X∈A) (∉-all X∉A) =
+  occurs-absent-⊥ X∈A X∉A
+
+occurs-cast : ∀ {Δ} {Y : TyVar Δ} {A B : Ty Δ}
+  → A ≡ B
+  → Y ∈ᵗ A
+    -------
+  → Y ∈ᵗ B
+occurs-cast refl Y∈A = Y∈A
+
+absent-cast : ∀ {Δ} {Y : TyVar Δ} {A B : Ty Δ}
+  → A ≡ B
+  → Y ∉ᵗ A
+    -------
+  → Y ∉ᵗ B
+absent-cast refl Y∉A = Y∉A
+
+------------------------------------------------------------------------
+-- Identity-pivot conversions do not change the type
+------------------------------------------------------------------------
+
+pivot-id-endpoints↑ : ∀ {Δ} {Σ : TyStore Δ} {A B : Ty Δ}
+    {c : Conv↑ Δ A B}
+  → Σ ⊢↑[ nothing ] c
+    ------------------
+  → A ≡ B
+
+pivot-id-endpoints↓ : ∀ {Δ} {Σ : TyStore Δ} {A B : Ty Δ}
+    {c : Conv↓ Δ A B}
+  → Σ ⊢↓[ nothing ] c
+    ------------------
+  → A ≡ B
+
+pivot-id-endpoints↑ (⊢↑-⇒ˣ join-none ⊢c ⊢d) =
+  cong₂ _⇒_ (sym (pivot-id-endpoints↓ ⊢c)) (pivot-id-endpoints↑ ⊢d)
+pivot-id-endpoints↑ (⊢↑-∀-idˣ ⊢c) =
+  cong `∀ (pivot-id-endpoints↑ ⊢c)
+pivot-id-endpoints↑ ⊢↑-idˣ = refl
+
+pivot-id-endpoints↓ (⊢↓-⇒ˣ join-none ⊢c ⊢d) =
+  cong₂ _⇒_ (sym (pivot-id-endpoints↑ ⊢c)) (pivot-id-endpoints↓ ⊢d)
+pivot-id-endpoints↓ (⊢↓-∀-idˣ ⊢c) =
+  cong `∀ (pivot-id-endpoints↓ ⊢c)
+pivot-id-endpoints↓ ⊢↓-idˣ = refl
+
+------------------------------------------------------------------------
+-- Freshness for the pivot's representation, under a type binder
+------------------------------------------------------------------------
+
+-- The freshness side condition of the transport lemmas is
+--   ∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R,
+-- read as: the transported variable Y avoids every representation the
+-- store assigns to the pivot X.  Under a ∀ binder the pivot becomes
+-- suc X and the store becomes store-lift Σ, so the side condition has
+-- to be shifted along with them.
+
+lift-pivot-fresh : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+  → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+  → ∀ {R′} → store-lift Σ ∋ Fin.suc X ⦂ R′
+    -----------------------------------------
+  → Fin.suc Y ∉ᵗ R′
+lift-pivot-fresh fresh (S-lift∋ ∋X refl) = shift-not-occurs (fresh ∋X)
+
+------------------------------------------------------------------------
+-- Occurrence transport along a pivoted conversion
+------------------------------------------------------------------------
+
+mutual
+  conv↑-occurs-pre : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↑ Δ A B}
+    → Σ ⊢↑[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∈ᵗ A
+      -------
+    → Y ∈ᵗ B
+  conv↑-occurs-pre (⊢↑-unsealˣ ∋X) Y≢X fresh var-∈ =
+    ⊥-elim (Y≢X refl)
+  conv↑-occurs-pre (⊢↑-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A) =
+    ∈-fun-left (conv↓-occurs-post ⊢c Y≢X fresh Y∈A)
+  conv↑-occurs-pre (⊢↑-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A Y∈B) =
+    ∈-fun-right (conv↓-absent-post ⊢c Y≢X fresh Y∉A)
+      (conv↑-occurs-pre ⊢d Y≢X fresh Y∈B)
+  conv↑-occurs-pre (⊢↑-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A) =
+    ∈-fun-left (conv↓-occurs-post ⊢c Y≢X fresh Y∈A)
+  conv↑-occurs-pre (⊢↑-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A Y∈B) =
+    ∈-fun-right (conv↓-absent-post ⊢c Y≢X fresh Y∉A)
+      (occurs-cast (pivot-id-endpoints↑ ⊢d) Y∈B)
+  conv↑-occurs-pre (⊢↑-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A) =
+    ∈-fun-left (occurs-cast (sym (pivot-id-endpoints↓ ⊢c)) Y∈A)
+  conv↑-occurs-pre (⊢↑-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A Y∈B) =
+    ∈-fun-right (absent-cast (sym (pivot-id-endpoints↓ ⊢c)) Y∉A)
+      (conv↑-occurs-pre ⊢d Y≢X fresh Y∈B)
+  conv↑-occurs-pre (⊢↑-∀ˣ ⊢c) Y≢X fresh (∈-all Y∈A) =
+    ∈-all (conv↑-occurs-pre ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∈A)
+
+  conv↑-occurs-post : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↑ Δ A B}
+    → Σ ⊢↑[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∈ᵗ B
+      -------
+    → Y ∈ᵗ A
+  conv↑-occurs-post (⊢↑-unsealˣ ∋X) Y≢X fresh Y∈R =
+    ⊥-elim (occurs-absent-⊥ Y∈R (fresh ∋X))
+  conv↑-occurs-post (⊢↑-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A′) =
+    ∈-fun-left (conv↓-occurs-pre ⊢c Y≢X fresh Y∈A′)
+  conv↑-occurs-post (⊢↑-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A′ Y∈B′) =
+    ∈-fun-right (conv↓-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (conv↑-occurs-post ⊢d Y≢X fresh Y∈B′)
+  conv↑-occurs-post (⊢↑-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A′) =
+    ∈-fun-left (conv↓-occurs-pre ⊢c Y≢X fresh Y∈A′)
+  conv↑-occurs-post (⊢↑-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A′ Y∈B′) =
+    ∈-fun-right (conv↓-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (occurs-cast (sym (pivot-id-endpoints↑ ⊢d)) Y∈B′)
+  conv↑-occurs-post (⊢↑-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A′) =
+    ∈-fun-left (occurs-cast (pivot-id-endpoints↓ ⊢c) Y∈A′)
+  conv↑-occurs-post (⊢↑-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A′ Y∈B′) =
+    ∈-fun-right (absent-cast (pivot-id-endpoints↓ ⊢c) Y∉A′)
+      (conv↑-occurs-post ⊢d Y≢X fresh Y∈B′)
+  conv↑-occurs-post (⊢↑-∀ˣ ⊢c) Y≢X fresh (∈-all Y∈B) =
+    ∈-all (conv↑-occurs-post ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∈B)
+
+  conv↓-occurs-pre : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↓ Δ A B}
+    → Σ ⊢↓[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∈ᵗ A
+      -------
+    → Y ∈ᵗ B
+  conv↓-occurs-pre (⊢↓-sealˣ ∋X) Y≢X fresh Y∈R =
+    ⊥-elim (occurs-absent-⊥ Y∈R (fresh ∋X))
+  conv↓-occurs-pre (⊢↓-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A) =
+    ∈-fun-left (conv↑-occurs-post ⊢c Y≢X fresh Y∈A)
+  conv↓-occurs-pre (⊢↓-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A Y∈B) =
+    ∈-fun-right (conv↑-absent-post ⊢c Y≢X fresh Y∉A)
+      (conv↓-occurs-pre ⊢d Y≢X fresh Y∈B)
+  conv↓-occurs-pre (⊢↓-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A) =
+    ∈-fun-left (conv↑-occurs-post ⊢c Y≢X fresh Y∈A)
+  conv↓-occurs-pre (⊢↓-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A Y∈B) =
+    ∈-fun-right (conv↑-absent-post ⊢c Y≢X fresh Y∉A)
+      (occurs-cast (pivot-id-endpoints↓ ⊢d) Y∈B)
+  conv↓-occurs-pre (⊢↓-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A) =
+    ∈-fun-left (occurs-cast (sym (pivot-id-endpoints↑ ⊢c)) Y∈A)
+  conv↓-occurs-pre (⊢↓-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A Y∈B) =
+    ∈-fun-right (absent-cast (sym (pivot-id-endpoints↑ ⊢c)) Y∉A)
+      (conv↓-occurs-pre ⊢d Y≢X fresh Y∈B)
+  conv↓-occurs-pre (⊢↓-∀ˣ ⊢c) Y≢X fresh (∈-all Y∈A) =
+    ∈-all (conv↓-occurs-pre ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∈A)
+
+  conv↓-occurs-post : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↓ Δ A B}
+    → Σ ⊢↓[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∈ᵗ B
+      -------
+    → Y ∈ᵗ A
+  conv↓-occurs-post (⊢↓-sealˣ ∋X) Y≢X fresh var-∈ =
+    ⊥-elim (Y≢X refl)
+  conv↓-occurs-post (⊢↓-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A′) =
+    ∈-fun-left (conv↑-occurs-pre ⊢c Y≢X fresh Y∈A′)
+  conv↓-occurs-post (⊢↓-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A′ Y∈B′) =
+    ∈-fun-right (conv↑-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (conv↓-occurs-post ⊢d Y≢X fresh Y∈B′)
+  conv↓-occurs-post (⊢↓-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A′) =
+    ∈-fun-left (conv↑-occurs-pre ⊢c Y≢X fresh Y∈A′)
+  conv↓-occurs-post (⊢↓-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A′ Y∈B′) =
+    ∈-fun-right (conv↑-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (occurs-cast (sym (pivot-id-endpoints↓ ⊢d)) Y∈B′)
+  conv↓-occurs-post (⊢↓-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-left Y∈A′) =
+    ∈-fun-left (occurs-cast (pivot-id-endpoints↑ ⊢c) Y∈A′)
+  conv↓-occurs-post (⊢↓-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∈-fun-right Y∉A′ Y∈B′) =
+    ∈-fun-right (absent-cast (pivot-id-endpoints↑ ⊢c) Y∉A′)
+      (conv↓-occurs-post ⊢d Y≢X fresh Y∈B′)
+  conv↓-occurs-post (⊢↓-∀ˣ ⊢c) Y≢X fresh (∈-all Y∈B) =
+    ∈-all (conv↓-occurs-post ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∈B)
+
+  conv↑-absent-pre : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↑ Δ A B}
+    → Σ ⊢↑[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∉ᵗ A
+      -------
+    → Y ∉ᵗ B
+  conv↑-absent-pre (⊢↑-unsealˣ ∋X) Y≢X fresh Y∉X = fresh ∋X
+  conv↑-absent-pre (⊢↑-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A Y∉B) =
+    ∉-fun (conv↓-absent-post ⊢c Y≢X fresh Y∉A)
+      (conv↑-absent-pre ⊢d Y≢X fresh Y∉B)
+  conv↑-absent-pre (⊢↑-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A Y∉B) =
+    ∉-fun (conv↓-absent-post ⊢c Y≢X fresh Y∉A)
+      (absent-cast (pivot-id-endpoints↑ ⊢d) Y∉B)
+  conv↑-absent-pre (⊢↑-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A Y∉B) =
+    ∉-fun (absent-cast (sym (pivot-id-endpoints↓ ⊢c)) Y∉A)
+      (conv↑-absent-pre ⊢d Y≢X fresh Y∉B)
+  conv↑-absent-pre (⊢↑-∀ˣ ⊢c) Y≢X fresh (∉-all Y∉A) =
+    ∉-all (conv↑-absent-pre ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∉A)
+
+  conv↑-absent-post : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↑ Δ A B}
+    → Σ ⊢↑[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∉ᵗ B
+      -------
+    → Y ∉ᵗ A
+  conv↑-absent-post (⊢↑-unsealˣ ∋X) Y≢X fresh Y∉R = ∉-var Y≢X
+  conv↑-absent-post (⊢↑-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A′ Y∉B′) =
+    ∉-fun (conv↓-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (conv↑-absent-post ⊢d Y≢X fresh Y∉B′)
+  conv↑-absent-post (⊢↑-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A′ Y∉B′) =
+    ∉-fun (conv↓-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (absent-cast (sym (pivot-id-endpoints↑ ⊢d)) Y∉B′)
+  conv↑-absent-post (⊢↑-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A′ Y∉B′) =
+    ∉-fun (absent-cast (pivot-id-endpoints↓ ⊢c) Y∉A′)
+      (conv↑-absent-post ⊢d Y≢X fresh Y∉B′)
+  conv↑-absent-post (⊢↑-∀ˣ ⊢c) Y≢X fresh (∉-all Y∉B) =
+    ∉-all (conv↑-absent-post ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∉B)
+
+  conv↓-absent-pre : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↓ Δ A B}
+    → Σ ⊢↓[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∉ᵗ A
+      -------
+    → Y ∉ᵗ B
+  conv↓-absent-pre (⊢↓-sealˣ ∋X) Y≢X fresh Y∉R = ∉-var Y≢X
+  conv↓-absent-pre (⊢↓-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A Y∉B) =
+    ∉-fun (conv↑-absent-post ⊢c Y≢X fresh Y∉A)
+      (conv↓-absent-pre ⊢d Y≢X fresh Y∉B)
+  conv↓-absent-pre (⊢↓-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A Y∉B) =
+    ∉-fun (conv↑-absent-post ⊢c Y≢X fresh Y∉A)
+      (absent-cast (pivot-id-endpoints↓ ⊢d) Y∉B)
+  conv↓-absent-pre (⊢↓-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A Y∉B) =
+    ∉-fun (absent-cast (sym (pivot-id-endpoints↑ ⊢c)) Y∉A)
+      (conv↓-absent-pre ⊢d Y≢X fresh Y∉B)
+  conv↓-absent-pre (⊢↓-∀ˣ ⊢c) Y≢X fresh (∉-all Y∉A) =
+    ∉-all (conv↓-absent-pre ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∉A)
+
+  conv↓-absent-post : ∀ {Δ} {Σ : TyStore Δ} {X Y : TyVar Δ}
+      {A B : Ty Δ} {c : Conv↓ Δ A B}
+    → Σ ⊢↓[ just X ] c
+    → Y ≢ X
+    → (∀ {R} → Σ ∋ X ⦂ R → Y ∉ᵗ R)
+    → Y ∉ᵗ B
+      -------
+    → Y ∉ᵗ A
+  conv↓-absent-post (⊢↓-sealˣ ∋X) Y≢X fresh Y∉X = fresh ∋X
+  conv↓-absent-post (⊢↓-⇒ˣ join-both ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A′ Y∉B′) =
+    ∉-fun (conv↑-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (conv↓-absent-post ⊢d Y≢X fresh Y∉B′)
+  conv↓-absent-post (⊢↓-⇒ˣ join-left ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A′ Y∉B′) =
+    ∉-fun (conv↑-absent-pre ⊢c Y≢X fresh Y∉A′)
+      (absent-cast (sym (pivot-id-endpoints↓ ⊢d)) Y∉B′)
+  conv↓-absent-post (⊢↓-⇒ˣ join-right ⊢c ⊢d) Y≢X fresh
+      (∉-fun Y∉A′ Y∉B′) =
+    ∉-fun (absent-cast (pivot-id-endpoints↑ ⊢c) Y∉A′)
+      (conv↓-absent-post ⊢d Y≢X fresh Y∉B′)
+  conv↓-absent-post (⊢↓-∀ˣ ⊢c) Y≢X fresh (∉-all Y∉B) =
+    ∉-all (conv↓-absent-post ⊢c (λ eq → Y≢X (fin-suc-injective eq))
+             (lift-pivot-fresh fresh) Y∉B)
+
+------------------------------------------------------------------------
+-- Corollaries for the ∀-binder
+------------------------------------------------------------------------
+
+-- Under a ∀ binder the pivot is a shifted variable suc X, so the bound
+-- variable zero is neither the pivot nor present in any lifted store
+-- representation.  Hence zero's occurrences survive the conversion.
+
+zero-pivot-fresh : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {R : Ty (Nat.suc Δ)}
+  → store-lift Σ ∋ Fin.suc X ⦂ R
+    -----------------------------
+  → Fin.zero ∉ᵗ R
+zero-pivot-fresh (S-lift∋ ∋X refl) = zero-absent-shift _
+
+conv↑-zero-pre : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↑ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c
+  → Fin.zero ∈ᵗ A
+    --------------
+  → Fin.zero ∈ᵗ B
+conv↑-zero-pre ⊢c = conv↑-occurs-pre ⊢c (λ ()) zero-pivot-fresh
+
+conv↑-zero-post : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↑ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c
+  → Fin.zero ∈ᵗ B
+    --------------
+  → Fin.zero ∈ᵗ A
+conv↑-zero-post ⊢c = conv↑-occurs-post ⊢c (λ ()) zero-pivot-fresh
+
+conv↓-zero-pre : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↓ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c
+  → Fin.zero ∈ᵗ A
+    --------------
+  → Fin.zero ∈ᵗ B
+conv↓-zero-pre ⊢c = conv↓-occurs-pre ⊢c (λ ()) zero-pivot-fresh
+
+conv↓-zero-post : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↓ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c
+  → Fin.zero ∈ᵗ B
+    --------------
+  → Fin.zero ∈ᵗ A
+conv↓-zero-post ⊢c = conv↓-occurs-post ⊢c (λ ()) zero-pivot-fresh

--- a/GTSFImp/proof/DGG/ConvImp.agda
+++ b/GTSFImp/proof/DGG/ConvImp.agda
@@ -406,3 +406,75 @@ conv↓-zero-post : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
     --------------
   → Fin.zero ∈ᵗ A
 conv↓-zero-post ⊢c = conv↓-occurs-post ⊢c (λ ()) zero-pivot-fresh
+
+------------------------------------------------------------------------
+-- Non-variable transport away from the bound variable
+------------------------------------------------------------------------
+
+-- A conversion pivoted at suc X cannot turn a zero-containing non-variable
+-- type into a variable, or conversely.  These small inversion lemmas are the
+-- shape component used alongside the occurrence transport above.
+
+conv↑-nonvar-pre-zero : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↑ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c
+  → NonVar B
+  → Fin.zero ∈ᵗ A
+    ----------------
+  → NonVar A
+conv↑-nonvar-pre-zero (⊢↑-unsealˣ ∋X) Bnv ()
+conv↑-nonvar-pre-zero (⊢↑-⇒ˣ join-both ⊢c ⊢d) Bnv zero∈A =
+  nonvar-fun
+conv↑-nonvar-pre-zero (⊢↑-⇒ˣ join-left ⊢c ⊢d) Bnv zero∈A =
+  nonvar-fun
+conv↑-nonvar-pre-zero (⊢↑-⇒ˣ join-right ⊢c ⊢d) Bnv zero∈A =
+  nonvar-fun
+conv↑-nonvar-pre-zero (⊢↑-∀ˣ ⊢c) Bnv zero∈A = nonvar-all
+
+conv↑-nonvar-post-zero : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↑ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c
+  → NonVar A
+  → Fin.zero ∈ᵗ B
+    ----------------
+  → NonVar B
+conv↑-nonvar-post-zero (⊢↑-unsealˣ ∋X) () zero∈B
+conv↑-nonvar-post-zero (⊢↑-⇒ˣ join-both ⊢c ⊢d) Anv zero∈B =
+  nonvar-fun
+conv↑-nonvar-post-zero (⊢↑-⇒ˣ join-left ⊢c ⊢d) Anv zero∈B =
+  nonvar-fun
+conv↑-nonvar-post-zero (⊢↑-⇒ˣ join-right ⊢c ⊢d) Anv zero∈B =
+  nonvar-fun
+conv↑-nonvar-post-zero (⊢↑-∀ˣ ⊢c) Anv zero∈B = nonvar-all
+
+conv↓-nonvar-pre-zero : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↓ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c
+  → NonVar B
+  → Fin.zero ∈ᵗ A
+    ----------------
+  → NonVar A
+conv↓-nonvar-pre-zero (⊢↓-sealˣ ∋X) () zero∈A
+conv↓-nonvar-pre-zero (⊢↓-⇒ˣ join-both ⊢c ⊢d) Bnv zero∈A =
+  nonvar-fun
+conv↓-nonvar-pre-zero (⊢↓-⇒ˣ join-left ⊢c ⊢d) Bnv zero∈A =
+  nonvar-fun
+conv↓-nonvar-pre-zero (⊢↓-⇒ˣ join-right ⊢c ⊢d) Bnv zero∈A =
+  nonvar-fun
+conv↓-nonvar-pre-zero (⊢↓-∀ˣ ⊢c) Bnv zero∈A = nonvar-all
+
+conv↓-nonvar-post-zero : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {A B : Ty (Nat.suc Δ)} {c : Conv↓ (Nat.suc Δ) A B}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c
+  → NonVar A
+  → Fin.zero ∈ᵗ B
+    ----------------
+  → NonVar B
+conv↓-nonvar-post-zero (⊢↓-sealˣ ∋X) Anv ()
+conv↓-nonvar-post-zero (⊢↓-⇒ˣ join-both ⊢c ⊢d) Anv zero∈B =
+  nonvar-fun
+conv↓-nonvar-post-zero (⊢↓-⇒ˣ join-left ⊢c ⊢d) Anv zero∈B =
+  nonvar-fun
+conv↓-nonvar-post-zero (⊢↓-⇒ˣ join-right ⊢c ⊢d) Anv zero∈B =
+  nonvar-fun
+conv↓-nonvar-post-zero (⊢↓-∀ˣ ⊢c) Anv zero∈B = nonvar-all

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -10,6 +10,7 @@ module proof.DGG.Examples2 where
 
 open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_)
+open import Data.Maybe using (just; nothing)
 open import Data.Nat using (zero; suc)
 import Data.Fin as Fin
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
@@ -273,18 +274,18 @@ example12-target-Z-unseal =
   unseal (Fin.suc (Fin.suc Fin.zero)) ★
 
 example12-target-Y-reveal-⊢ˣ :
-  CTI2.example12-target-store ⊢↑[ Fin.suc Fin.zero ]
+  CTI2.example12-target-store ⊢↑[ just (Fin.suc Fin.zero) ]
     example12-target-Y-reveal
 example12-target-Y-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both
     (CTI2.⊢↓-sealˣ CTI2.example12-target-Y∋)
     (CTI2.⊢↑-unsealˣ CTI2.example12-target-Y∋)
 
 example12-target-Z-reveal-⊢ˣ :
-  CTI2.example12-target-store ⊢↑[ Fin.suc (Fin.suc Fin.zero) ]
+  CTI2.example12-target-store ⊢↑[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-reveal
 example12-target-Z-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both
     (CTI2.⊢↓-sealˣ CTI2.example12-target-Z∋)
     (CTI2.⊢↑-unsealˣ CTI2.example12-target-Z∋)
 
@@ -309,12 +310,12 @@ example12-target-X-seal-⊢ :
 example12-target-X-seal-⊢ = ⊢↓-seal CTI2.example12-target-X∋
 
 example12-source-X-seal-⊢ˣ :
-  CTI2.example12-source-store ⊢↓[ Fin.zero ] example12-source-X-seal
+  CTI2.example12-source-store ⊢↓[ just Fin.zero ] example12-source-X-seal
 example12-source-X-seal-⊢ˣ =
   CTI2.⊢↓-sealˣ CTI2.example12-source-X∋
 
 example12-target-X-seal-⊢ˣ :
-  CTI2.example12-target-store ⊢↓[ Fin.zero ] example12-target-X-seal
+  CTI2.example12-target-store ⊢↓[ just Fin.zero ] example12-target-X-seal
 example12-target-X-seal-⊢ˣ =
   CTI2.⊢↓-sealˣ CTI2.example12-target-X∋
 
@@ -327,47 +328,47 @@ example12-target-X-unseal-⊢ :
 example12-target-X-unseal-⊢ = ⊢↑-unseal CTI2.example12-target-X∋
 
 example12-source-X-unseal-⊢ˣ :
-  CTI2.example12-source-store ⊢↑[ Fin.zero ] example12-source-X-unseal
+  CTI2.example12-source-store ⊢↑[ just Fin.zero ] example12-source-X-unseal
 example12-source-X-unseal-⊢ˣ =
   CTI2.⊢↑-unsealˣ CTI2.example12-source-X∋
 
 example12-target-X-unseal-⊢ˣ :
-  CTI2.example12-target-store ⊢↑[ Fin.zero ] example12-target-X-unseal
+  CTI2.example12-target-store ⊢↑[ just Fin.zero ] example12-target-X-unseal
 example12-target-X-unseal-⊢ˣ =
   CTI2.⊢↑-unsealˣ CTI2.example12-target-X∋
 
 example12-source-X-reveal-⊢ˣ :
-  CTI2.example12-source-store ⊢↑[ Fin.zero ] example12-source-X-reveal
+  CTI2.example12-source-store ⊢↑[ just Fin.zero ] example12-source-X-reveal
 example12-source-X-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ example12-source-X-seal-⊢ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both example12-source-X-seal-⊢ˣ
     example12-source-X-unseal-⊢ˣ
 
 example12-target-X-reveal-⊢ˣ :
-  CTI2.example12-target-store ⊢↑[ Fin.zero ] example12-target-X-reveal
+  CTI2.example12-target-store ⊢↑[ just Fin.zero ] example12-target-X-reveal
 example12-target-X-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ example12-target-X-seal-⊢ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both example12-target-X-seal-⊢ˣ
     example12-target-X-unseal-⊢ˣ
 
 example12-target-Z-seal-⊢ˣ :
-  CTI2.example12-target-store ⊢↓[ Fin.suc (Fin.suc Fin.zero) ]
+  CTI2.example12-target-store ⊢↓[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-seal
 example12-target-Z-seal-⊢ˣ =
   CTI2.⊢↓-sealˣ CTI2.example12-target-Z∋
 
 example12-target-Y-seal-⊢ˣ :
-  CTI2.example12-target-store ⊢↓[ Fin.suc Fin.zero ]
+  CTI2.example12-target-store ⊢↓[ just (Fin.suc Fin.zero) ]
     example12-target-Y-seal
 example12-target-Y-seal-⊢ˣ =
   CTI2.⊢↓-sealˣ CTI2.example12-target-Y∋
 
 example12-target-Y-unseal-⊢ˣ :
-  CTI2.example12-target-store ⊢↑[ Fin.suc Fin.zero ]
+  CTI2.example12-target-store ⊢↑[ just (Fin.suc Fin.zero) ]
     example12-target-Y-unseal
 example12-target-Y-unseal-⊢ˣ =
   CTI2.⊢↑-unsealˣ CTI2.example12-target-Y∋
 
 example12-target-Z-unseal-⊢ˣ :
-  CTI2.example12-target-store ⊢↑[ Fin.suc (Fin.suc Fin.zero) ]
+  CTI2.example12-target-store ⊢↑[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-unseal
 example12-target-Z-unseal-⊢ˣ =
   CTI2.⊢↑-unsealˣ CTI2.example12-target-Z∋
@@ -432,7 +433,7 @@ example12-lambda-Z :
     ⊑ (ƛ (` 0)) ↑ example12-target-Y-reveal ∶
       example12-Z-function-local
 example12-lambda-Z =
-  CTI2.⊑reveal² example12-rebase-Z-to-Y CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
     example12-target-Y-reveal-⊢ˣ example12-lambda-Y
     example12-Z-function-local
 
@@ -442,7 +443,7 @@ example12-lambda-star :
         ↑ example12-target-Z-reveal ∶
       example12-X-function-to-star
 example12-lambda-star =
-  CTI2.⊑reveal² CTI2.example12-rebase-X-to-Z CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
     example12-target-Z-reveal-⊢ˣ example12-lambda-Z
     example12-X-function-to-star
 
@@ -575,7 +576,7 @@ example12-target-Z-seal-checkpoint₃ :
         ↓ example12-target-Z-seal ∶
       example12-Z-var⊑
 example12-target-Z-seal-checkpoint₃ =
-  CTI2.⊑conceal² CTI2.example12-rebase-X-to-Z CTI2.same-[]
+  CTI2.⊑conceal² (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
     example12-target-Z-seal-⊢ˣ example12-target-X!-checkpoint₃
     example12-Z-var⊑
 
@@ -588,7 +589,7 @@ example12-target-Y-seal-checkpoint₃ :
         ↓ example12-target-Y-seal ∶
       example12-Y-var⊑
 example12-target-Y-seal-checkpoint₃ =
-  CTI2.⊑conceal² example12-rebase-Z-to-Y CTI2.same-[]
+  CTI2.⊑conceal² (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
     example12-target-Y-seal-⊢ˣ example12-target-Z-seal-checkpoint₃
     example12-Y-var⊑
 
@@ -602,7 +603,7 @@ example12-target-Y-unseal-checkpoint₃ :
         ↑ example12-target-Y-unseal ∶
       example12-Z-var⊑
 example12-target-Y-unseal-checkpoint₃ =
-  CTI2.⊑reveal² example12-rebase-Z-to-Y CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
     example12-target-Y-unseal-⊢ˣ example12-target-Y-seal-checkpoint₃
     example12-Z-var⊑
 
@@ -617,7 +618,7 @@ example12-target-Z-unseal-checkpoint₃ :
         ↑ example12-target-Z-unseal ∶
       example12-X-var-to-star
 example12-target-Z-unseal-checkpoint₃ =
-  CTI2.⊑reveal² CTI2.example12-rebase-X-to-Z CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
     example12-target-Z-unseal-⊢ˣ example12-target-Y-unseal-checkpoint₃
     example12-X-var-to-star
 
@@ -846,7 +847,7 @@ nat-chain-source-X-seal-⊢ =
   ⊢↓-seal CTI2.example12-nat-chain-source-X∋
 
 nat-chain-source-X-seal-⊢ˣ :
-  CTI2.example12-nat-chain-source-store ⊢↓[ Fin.zero ]
+  CTI2.example12-nat-chain-source-store ⊢↓[ just Fin.zero ]
     nat-chain-source-X-seal
 nat-chain-source-X-seal-⊢ˣ =
   CTI2.⊢↓-sealˣ CTI2.example12-nat-chain-source-X∋
@@ -857,7 +858,7 @@ nat-chain-source-X-unseal-⊢ =
   ⊢↑-unseal CTI2.example12-nat-chain-source-X∋
 
 nat-chain-source-X-unseal-⊢ˣ :
-  CTI2.example12-nat-chain-source-store ⊢↑[ Fin.zero ]
+  CTI2.example12-nat-chain-source-store ⊢↑[ just Fin.zero ]
     nat-chain-source-X-unseal
 nat-chain-source-X-unseal-⊢ˣ =
   CTI2.⊢↑-unsealˣ CTI2.example12-nat-chain-source-X∋
@@ -868,10 +869,10 @@ nat-chain-source-X-reveal-⊢ =
   ⊢↑-⇒ nat-chain-source-X-seal-⊢ nat-chain-source-X-unseal-⊢
 
 nat-chain-source-X-reveal-⊢ˣ :
-  CTI2.example12-nat-chain-source-store ⊢↑[ Fin.zero ]
+  CTI2.example12-nat-chain-source-store ⊢↑[ just Fin.zero ]
     nat-chain-source-X-reveal
 nat-chain-source-X-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ nat-chain-source-X-seal-⊢ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both nat-chain-source-X-seal-⊢ˣ
     nat-chain-source-X-unseal-⊢ˣ
 
 nat-chain-target-X-seal-⊢ :
@@ -880,7 +881,7 @@ nat-chain-target-X-seal-⊢ =
   ⊢↓-seal CTI2.example12-nat-chain-target-X∋
 
 nat-chain-target-X-seal-⊢ˣ :
-  CTI2.example12-nat-chain-target-store ⊢↓[ Fin.suc Fin.zero ]
+  CTI2.example12-nat-chain-target-store ⊢↓[ just (Fin.suc Fin.zero) ]
     nat-chain-target-X-seal
 nat-chain-target-X-seal-⊢ˣ =
   CTI2.⊢↓-sealˣ CTI2.example12-nat-chain-target-X∋
@@ -891,7 +892,7 @@ nat-chain-target-X-unseal-⊢ =
   ⊢↑-unseal CTI2.example12-nat-chain-target-X∋
 
 nat-chain-target-X-unseal-⊢ˣ :
-  CTI2.example12-nat-chain-target-store ⊢↑[ Fin.suc Fin.zero ]
+  CTI2.example12-nat-chain-target-store ⊢↑[ just (Fin.suc Fin.zero) ]
     nat-chain-target-X-unseal
 nat-chain-target-X-unseal-⊢ˣ =
   CTI2.⊢↑-unsealˣ CTI2.example12-nat-chain-target-X∋
@@ -902,24 +903,19 @@ nat-chain-target-X-reveal-⊢ =
   ⊢↑-⇒ nat-chain-target-X-seal-⊢ nat-chain-target-X-unseal-⊢
 
 nat-chain-target-X-reveal-⊢ˣ :
-  CTI2.example12-nat-chain-target-store ⊢↑[ Fin.suc Fin.zero ]
+  CTI2.example12-nat-chain-target-store ⊢↑[ just (Fin.suc Fin.zero) ]
     nat-chain-target-X-reveal
 nat-chain-target-X-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ nat-chain-target-X-seal-⊢ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both nat-chain-target-X-seal-⊢ˣ
     nat-chain-target-X-unseal-⊢ˣ
 
 nat-chain-target-Y-reveal-⊢ˣ :
-  CTI2.example12-nat-chain-target-store ⊢↑[ Fin.zero ]
+  CTI2.example12-nat-chain-target-store ⊢↑[ just Fin.zero ]
     nat-chain-target-Y-reveal
 nat-chain-target-Y-reveal-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ
+  CTI2.⊢↑-⇒ˣ CTI2.join-both
     (CTI2.⊢↓-sealˣ CTI2.example12-nat-chain-target-Y∋)
     (CTI2.⊢↑-unsealˣ CTI2.example12-nat-chain-target-Y∋)
-
-nat-chain-target-id-X-reveal-⊢ :
-  CTI2.example12-nat-chain-target-store ⊢↑
-    nat-chain-target-id-X-reveal
-nat-chain-target-id-X-reveal-⊢ = ⊢↑-id
 
 nat-chain-X-var⊑ :
   ＇ Fin.zero ⊑ᵂ⟨ CTI2.example12-nat-chain-world-X ⟩
@@ -956,9 +952,8 @@ nat-chain-polyId-target-reveal :
     ⊑ Ex.polyId ↑ CTI2.example12-nat-chain-reveal ∶
       example12-∀⊑∀
 nat-chain-polyId-target-reveal =
-  CTI2.⊑id-reveal²
-    (CTI2.identity-reveal-∀ CTI2.identity-reveal-id)
-    CTI2.example12-nat-chain-reveal-⊢ polyId-refl²
+  CTI2.⊑reveal² CTI2.rebase-idᴿ CTI2.same-[]
+    CTI2.example12-nat-chain-reveal-⊢ˣ polyId-refl²
     example12-∀⊑∀
 
 nat-chain-checkpoint₀ :
@@ -985,7 +980,8 @@ nat-chain-lambda-X :
     ⊑ (ƛ (` 0)) ↑ nat-chain-target-Y-reveal ∶
       nat-chain-X-function-local
 nat-chain-lambda-X =
-  CTI2.⊑reveal² CTI2.example12-nat-chain-rebase-X-to-Y
+  CTI2.⊑reveal²
+    (CTI2.rebase-varᴿ CTI2.example12-nat-chain-rebase-X-to-Y)
     CTI2.same-[] nat-chain-target-Y-reveal-⊢ˣ nat-chain-lambda-Y
     nat-chain-X-function-local
 
@@ -995,8 +991,8 @@ nat-chain-lambda-X-id :
         ↑ nat-chain-target-id-X-reveal ∶
       nat-chain-X-function-local
 nat-chain-lambda-X-id =
-  CTI2.⊑id-reveal² CTI2.identity-reveal-id
-    nat-chain-target-id-X-reveal-⊢ nat-chain-lambda-X
+  CTI2.⊑reveal² CTI2.rebase-idᴿ CTI2.same-[]
+    CTI2.⊢↑-idˣ nat-chain-lambda-X
     nat-chain-X-function-local
 
 nat-chain-function-checkpoint₁ :
@@ -1381,15 +1377,15 @@ left-path-reveal★₁-target-⊢ =
     (⊢↑-unseal left-path-target-U∋₁)
 
 left-path-reveal★₁-source-⊢ˣ :
-  Ex.right-store₁ ⊢↑[ Fin.zero ] left-path-reveal★₁
+  Ex.right-store₁ ⊢↑[ just Fin.zero ] left-path-reveal★₁
 left-path-reveal★₁-source-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-U∋₁)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-U∋₁)
     (CTI2.⊢↑-unsealˣ left-path-source-U∋₁)
 
 left-path-reveal★₁-target-⊢ˣ :
-  left-path-target-store₁ ⊢↑[ Fin.zero ] left-path-reveal★₁
+  left-path-target-store₁ ⊢↑[ just Fin.zero ] left-path-reveal★₁
 left-path-reveal★₁-target-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-U∋₁)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-U∋₁)
     (CTI2.⊢↑-unsealˣ left-path-target-U∋₁)
 
 left-path-Y-reveal₂ :
@@ -1464,27 +1460,27 @@ left-path-Z-reveal₂-target-⊢ =
     (⊢↑-unseal left-path-target-Z∋₂)
 
 left-path-Y-reveal₂-source-⊢ˣ :
-  Ex.right-store₂ ⊢↑[ Fin.zero ] left-path-Y-reveal₂
+  Ex.right-store₂ ⊢↑[ just Fin.zero ] left-path-Y-reveal₂
 left-path-Y-reveal₂-source-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-Y∋₂)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-Y∋₂)
     (CTI2.⊢↑-unsealˣ left-path-source-Y∋₂)
 
 left-path-Y-reveal₂-target-⊢ˣ :
-  left-path-target-store₂ ⊢↑[ Fin.zero ] left-path-Y-reveal₂
+  left-path-target-store₂ ⊢↑[ just Fin.zero ] left-path-Y-reveal₂
 left-path-Y-reveal₂-target-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-Y∋₂)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-Y∋₂)
     (CTI2.⊢↑-unsealˣ left-path-target-Y∋₂)
 
 left-path-Z-reveal₂-source-⊢ˣ :
-  Ex.right-store₂ ⊢↑[ Fin.suc Fin.zero ] left-path-Z-reveal₂
+  Ex.right-store₂ ⊢↑[ just (Fin.suc Fin.zero) ] left-path-Z-reveal₂
 left-path-Z-reveal₂-source-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-Z∋₂)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-Z∋₂)
     (CTI2.⊢↑-unsealˣ left-path-source-Z∋₂)
 
 left-path-Z-reveal₂-target-⊢ˣ :
-  left-path-target-store₂ ⊢↑[ Fin.suc Fin.zero ] left-path-Z-reveal₂
+  left-path-target-store₂ ⊢↑[ just (Fin.suc Fin.zero) ] left-path-Z-reveal₂
 left-path-Z-reveal₂-target-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-Z∋₂)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-Z∋₂)
     (CTI2.⊢↑-unsealˣ left-path-target-Z∋₂)
 
 left-path-X⇒X⊑X⇒X₁ :
@@ -1749,34 +1745,34 @@ left-path-target-Y-reveal₃-⊢ =
     (⊢↑-unseal left-path-target-Y∋₃)
 
 left-path-source-Y-reveal₃-⊢ˣ :
-  Ex.right-store₃ ⊢↑[ Fin.suc Fin.zero ] example12-target-Y-reveal
+  Ex.right-store₃ ⊢↑[ just (Fin.suc Fin.zero) ] example12-target-Y-reveal
 left-path-source-Y-reveal₃-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-Y∋₃)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-Y∋₃)
     (CTI2.⊢↑-unsealˣ left-path-source-Y∋₃)
 
 left-path-target-Y-reveal₃-⊢ˣ :
-  left-path-target-store₃ ⊢↑[ Fin.zero ] left-path-Y-reveal₂
+  left-path-target-store₃ ⊢↑[ just Fin.zero ] left-path-Y-reveal₂
 left-path-target-Y-reveal₃-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-Y∋₃)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-Y∋₃)
     (CTI2.⊢↑-unsealˣ left-path-target-Y∋₃)
 
 left-path-source-Z-reveal₃-⊢ˣ :
-  Ex.right-store₃ ⊢↑[ Fin.suc (Fin.suc Fin.zero) ]
+  Ex.right-store₃ ⊢↑[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-reveal
 left-path-source-Z-reveal₃-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-Z∋₃)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-Z∋₃)
     (CTI2.⊢↑-unsealˣ left-path-source-Z∋₃)
 
 left-path-target-Z-reveal₃-⊢ˣ :
-  left-path-target-store₃ ⊢↑[ Fin.suc Fin.zero ] left-path-Z-reveal₂
+  left-path-target-store₃ ⊢↑[ just (Fin.suc Fin.zero) ] left-path-Z-reveal₂
 left-path-target-Z-reveal₃-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-Z∋₃)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-Z∋₃)
     (CTI2.⊢↑-unsealˣ left-path-target-Z∋₃)
 
 left-path-source-X-reveal₃-⊢ˣ :
-  Ex.right-store₃ ⊢↑[ Fin.zero ] example12-target-X-reveal
+  Ex.right-store₃ ⊢↑[ just Fin.zero ] example12-target-X-reveal
 left-path-source-X-reveal₃-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-X∋₃)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-X∋₃)
     (CTI2.⊢↑-unsealˣ left-path-source-X∋₃)
 
 left-path-Y-var⊑YZ₃ :
@@ -1855,7 +1851,7 @@ left-path-target-Z-revealed₃-XZ :
         ↑ left-path-Z-reveal₂ ∶
       left-path-Z⇒Z⊑★⇒★-XZ₃
 left-path-target-Z-revealed₃-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-Z₃ CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₃) CTI2.same-[]
     left-path-target-Z-reveal₃-⊢ˣ left-path-Y-revealed₃
     left-path-Z⇒Z⊑★⇒★-XZ₃
 
@@ -1867,7 +1863,7 @@ left-path-both-Z-revealed₃-XZ :
         ↑ left-path-Z-reveal₂ ∶
       ★⇒★⊑★⇒★² {W = left-path-world₃}
 left-path-both-Z-revealed₃-XZ =
-  CTI2.reveal⊑² left-path-rebase-XZ-Z₃ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₃) CTI2.same-[]
     left-path-source-Z-reveal₃-⊢ˣ left-path-target-Z-revealed₃-XZ
     (★⇒★⊑★⇒★² {W = left-path-world₃})
 
@@ -1908,7 +1904,7 @@ left-path-function₃ :
         ↑ left-path-Z-reveal₂ ∶
       ℕ⇒ℕ⊑★⇒★² {W = left-path-world₃}
 left-path-function₃ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₃ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₃) CTI2.same-[]
     left-path-source-X-reveal₃-⊢ˣ left-path-source-X?₃-XZ
     (ℕ⇒ℕ⊑★⇒★² {W = left-path-world₃})
 
@@ -1966,12 +1962,12 @@ left-path-rebase-XZ-X₄ =
   CTI2.sameWorldRebaseAt refl left-path-source-X-rep₄
 
 left-path-source-X-seal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↓[ Fin.zero ] example12-target-X-seal
+  Ex.right-store₄ ⊢↓[ just Fin.zero ] example12-target-X-seal
 left-path-source-X-seal₄-⊢ˣ =
   CTI2.⊢↓-sealˣ left-path-source-X∋₄
 
 left-path-source-X-unseal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↑[ Fin.zero ] example12-target-X-unseal
+  Ex.right-store₄ ⊢↑[ just Fin.zero ] example12-target-X-unseal
 left-path-source-X-unseal₄-⊢ˣ =
   CTI2.⊢↑-unsealˣ left-path-source-X∋₄
 
@@ -2003,7 +1999,7 @@ left-path-argument₄ :
     ⊑ $ (κℕ 7) ⟨ left-path-ℕ!₂ ⟩ ∶
       left-path-X-var⊑★-XZ₄
 left-path-argument₄ =
-  CTI2.conceal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.conceal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-seal₄-⊢ˣ left-path-argument₄-base
     left-path-X-var⊑★-XZ₄
 
@@ -2028,7 +2024,7 @@ left-path-checkpoint₄ :
   left-path-world₄ ∣ [] ⊢² Ex.right₄
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₄ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-application₄
     left-path-ℕ⊑★₄
 
@@ -2101,7 +2097,7 @@ left-path-checkpoint₅ :
   left-path-world₄ ∣ [] ⊢² Ex.right₅
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₅ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₅
     left-path-ℕ⊑★₄
 
@@ -2192,7 +2188,7 @@ left-path-checkpoint₆ :
   left-path-world₄ ∣ [] ⊢² Ex.right₆
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₆ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₆
     left-path-ℕ⊑★₄
 
@@ -2246,7 +2242,7 @@ left-path-checkpoint₇ :
   left-path-world₄ ∣ [] ⊢² Ex.right₇
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₇ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₇
     left-path-ℕ⊑★₄
 
@@ -2300,28 +2296,28 @@ left-path-target-Y-reveal₄-⊢ =
     (⊢↑-unseal left-path-target-Y∋₄)
 
 left-path-source-Y-reveal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↑[ Fin.suc Fin.zero ] example12-target-Y-reveal
+  Ex.right-store₄ ⊢↑[ just (Fin.suc Fin.zero) ] example12-target-Y-reveal
 left-path-source-Y-reveal₄-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-Y∋₄)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-Y∋₄)
     (CTI2.⊢↑-unsealˣ left-path-source-Y∋₄)
 
 left-path-target-Y-reveal₄-⊢ˣ :
-  left-path-target-store₄ ⊢↑[ Fin.zero ] left-path-Y-reveal₂
+  left-path-target-store₄ ⊢↑[ just Fin.zero ] left-path-Y-reveal₂
 left-path-target-Y-reveal₄-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-Y∋₄)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-Y∋₄)
     (CTI2.⊢↑-unsealˣ left-path-target-Y∋₄)
 
 left-path-source-Z-reveal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↑[ Fin.suc (Fin.suc Fin.zero) ]
+  Ex.right-store₄ ⊢↑[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-reveal
 left-path-source-Z-reveal₄-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-source-Z∋₄)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-source-Z∋₄)
     (CTI2.⊢↑-unsealˣ left-path-source-Z∋₄)
 
 left-path-target-Z-reveal₄-⊢ˣ :
-  left-path-target-store₄ ⊢↑[ Fin.suc Fin.zero ] left-path-Z-reveal₂
+  left-path-target-store₄ ⊢↑[ just (Fin.suc Fin.zero) ] left-path-Z-reveal₂
 left-path-target-Z-reveal₄-⊢ˣ =
-  CTI2.⊢↑-⇒ˣ (CTI2.⊢↓-sealˣ left-path-target-Z∋₄)
+  CTI2.⊢↑-⇒ˣ CTI2.join-both (CTI2.⊢↓-sealˣ left-path-target-Z∋₄)
     (CTI2.⊢↑-unsealˣ left-path-target-Z∋₄)
 
 left-path-target-Z-seal₂ : Conv↓ 2 ★ (＇ (Fin.suc Fin.zero))
@@ -2341,7 +2337,7 @@ left-path-target-Y-unseal₂ =
   unseal Fin.zero (＇ (Fin.suc Fin.zero))
 
 left-path-source-Z-unseal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↑[ Fin.suc (Fin.suc Fin.zero) ]
+  Ex.right-store₄ ⊢↑[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-unseal
 left-path-source-Z-unseal₄-⊢ˣ =
   CTI2.⊢↑-unsealˣ left-path-source-Z∋₄
@@ -2352,7 +2348,7 @@ left-path-source-Z-unseal₄-⊢ =
   ⊢↑-unseal left-path-source-Z∋₄
 
 left-path-target-Z-unseal₄-⊢ˣ :
-  left-path-target-store₄ ⊢↑[ Fin.suc Fin.zero ]
+  left-path-target-store₄ ⊢↑[ just (Fin.suc Fin.zero) ]
     left-path-target-Z-unseal₂
 left-path-target-Z-unseal₄-⊢ˣ =
   CTI2.⊢↑-unsealˣ left-path-target-Z∋₄
@@ -2368,7 +2364,7 @@ left-path-source-Z-seal₄-⊢ =
   ⊢↓-seal left-path-source-Z∋₄
 
 left-path-source-Z-seal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↓[ Fin.suc (Fin.suc Fin.zero) ]
+  Ex.right-store₄ ⊢↓[ just (Fin.suc (Fin.suc Fin.zero)) ]
     example12-target-Z-seal
 left-path-source-Z-seal₄-⊢ˣ =
   CTI2.⊢↓-sealˣ left-path-source-Z∋₄
@@ -2379,7 +2375,7 @@ left-path-target-Z-seal₄-⊢ =
   ⊢↓-seal left-path-target-Z∋₄
 
 left-path-target-Z-seal₄-⊢ˣ :
-  left-path-target-store₄ ⊢↓[ Fin.suc Fin.zero ]
+  left-path-target-store₄ ⊢↓[ just (Fin.suc Fin.zero) ]
     left-path-target-Z-seal₂
 left-path-target-Z-seal₄-⊢ˣ =
   CTI2.⊢↓-sealˣ left-path-target-Z∋₄
@@ -2390,7 +2386,7 @@ left-path-source-Y-seal₄-⊢ =
   ⊢↓-seal left-path-source-Y∋₄
 
 left-path-source-Y-seal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↓[ Fin.suc Fin.zero ] example12-target-Y-seal
+  Ex.right-store₄ ⊢↓[ just (Fin.suc Fin.zero) ] example12-target-Y-seal
 left-path-source-Y-seal₄-⊢ˣ =
   CTI2.⊢↓-sealˣ left-path-source-Y∋₄
 
@@ -2400,7 +2396,7 @@ left-path-target-Y-seal₄-⊢ =
   ⊢↓-seal left-path-target-Y∋₄
 
 left-path-target-Y-seal₄-⊢ˣ :
-  left-path-target-store₄ ⊢↓[ Fin.zero ] left-path-target-Y-seal₂
+  left-path-target-store₄ ⊢↓[ just Fin.zero ] left-path-target-Y-seal₂
 left-path-target-Y-seal₄-⊢ˣ =
   CTI2.⊢↓-sealˣ left-path-target-Y∋₄
 
@@ -2410,7 +2406,7 @@ left-path-source-Y-unseal₄-⊢ =
   ⊢↑-unseal left-path-source-Y∋₄
 
 left-path-source-Y-unseal₄-⊢ˣ :
-  Ex.right-store₄ ⊢↑[ Fin.suc Fin.zero ] example12-target-Y-unseal
+  Ex.right-store₄ ⊢↑[ just (Fin.suc Fin.zero) ] example12-target-Y-unseal
 left-path-source-Y-unseal₄-⊢ˣ =
   CTI2.⊢↑-unsealˣ left-path-source-Y∋₄
 
@@ -2420,7 +2416,7 @@ left-path-target-Y-unseal₄-⊢ =
   ⊢↑-unseal left-path-target-Y∋₄
 
 left-path-target-Y-unseal₄-⊢ˣ :
-  left-path-target-store₄ ⊢↑[ Fin.zero ] left-path-target-Y-unseal₂
+  left-path-target-store₄ ⊢↑[ just Fin.zero ] left-path-target-Y-unseal₂
 left-path-target-Y-unseal₄-⊢ˣ =
   CTI2.⊢↑-unsealˣ left-path-target-Y∋₄
 
@@ -2508,7 +2504,7 @@ left-path-target-Z-revealed₈-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-revealed₈-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-target-Z-unseal₄-⊢ˣ left-path-application₈-XZ
     left-path-Z-var⊑★-XZ₄
 
@@ -2525,7 +2521,7 @@ left-path-both-Z-revealed₈-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       ★⊑★
 left-path-both-Z-revealed₈-XZ =
-  CTI2.reveal⊑² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-revealed₈-XZ
     ★⊑★
 
@@ -2570,7 +2566,7 @@ left-path-checkpoint₈ :
   left-path-world₄ ∣ [] ⊢² Ex.right₈
     ⊑ left-path-target₅ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₈ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₈
     left-path-ℕ⊑★₄
 
@@ -2641,7 +2637,7 @@ left-path-target-Z-unsealed₉-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-unsealed₉-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₉-XZ
     left-path-Z-var⊑★-XZ₄
 
@@ -2662,7 +2658,7 @@ left-path-both-Z-unsealed₉-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       ★⊑★
 left-path-both-Z-unsealed₉-XZ =
-  CTI2.reveal⊑² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-unsealed₉-XZ
     ★⊑★
 
@@ -2715,7 +2711,7 @@ left-path-checkpoint₉ :
   left-path-world₄ ∣ [] ⊢² Ex.right₉
     ⊑ left-path-target₆ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₉ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₉
     left-path-ℕ⊑★₄
 
@@ -2751,7 +2747,7 @@ left-path-target-Z-unsealed₁₀-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-unsealed₁₀-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₁₀-XZ
     left-path-Z-var⊑★-XZ₄
 
@@ -2770,7 +2766,7 @@ left-path-both-Z-unsealed₁₀-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       ★⊑★
 left-path-both-Z-unsealed₁₀-XZ =
-  CTI2.reveal⊑² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-unsealed₁₀-XZ
     ★⊑★
 
@@ -2819,7 +2815,7 @@ left-path-checkpoint₁₀ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₀
     ⊑ left-path-target₇ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₀ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₀
     left-path-ℕ⊑★₄
 
@@ -2875,7 +2871,7 @@ left-path-checkpoint₁₁ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₁
     ⊑ left-path-target₈ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₁ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₁
     left-path-ℕ⊑★₄
 
@@ -2908,7 +2904,7 @@ left-path-checkpoint₁₂ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₂
     ⊑ left-path-target₉ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₂ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₂
     left-path-ℕ⊑★₄
 
@@ -2927,7 +2923,7 @@ left-path-checkpoint₁₃ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₃
     ⊑ left-path-target-final ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₃ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₃
     left-path-ℕ⊑★₄
 
@@ -2935,7 +2931,7 @@ left-path-checkpoint₁₄ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₄
     ⊑ left-path-target-final ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₄ =
-  CTI2.reveal⊑² left-path-rebase-XZ-X₄ CTI2.same-[]
+  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-argument₄
     left-path-ℕ⊑★₄
 

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -8,6 +8,7 @@ module proof.DGG.Examples2 where
 --     simulates each reduction step of the more precise side under the
 --     version-2 cast-term imprecision relation.
 
+open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_)
 open import Data.Nat using (zero; suc)
 import Data.Fin as Fin
@@ -206,7 +207,9 @@ example12-rebase-Z-to-Y :
   CTI2.RebaseAt CTI2.example12-world-Z CTI2.example12-world-Y
     Fin.zero (Fin.suc Fin.zero)
 example12-rebase-Z-to-Y =
-  CTI2.rebase-at (CTI2.same-runtime refl refl) refl
+  CTI2.rebase-at (CTI2.same-runtime refl refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
+    (λ _ → refl) (λ _ → refl) refl
     CTI2.example12-Y-representation
 
 example12-target-Y-reveal :
@@ -1266,7 +1269,7 @@ left-path-world₃-YZ :
   World (Δ′ Ex.right-step₂) (Δ′ left-path-target-step₂)
     (Δ′ Ex.right-step₂)
 left-path-world₃-YZ =
-  world id↪ᵗ left-path-target-ηᴿ-YZ Imprecision.idᵐ
+  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-XZ
     Ex.right-store₃ left-path-target-store₃
 
 left-path-world₄-YZ :
@@ -1359,11 +1362,7 @@ left-path-target-U∋₁ = Z∋ refl
 
 left-path-U-rep₁ :
   CTI2.StoreRepImp left-path-world₁ Fin.zero Fin.zero
-left-path-U-rep₁ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-U∋₁ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-U∋₁ CTI2.leads-here)
-    ★⊑★
+left-path-U-rep₁ = CTI2.store-rep-imp ★⊑★
 
 left-path-rebase-U₁ :
   CTI2.RebaseAt left-path-world₁ left-path-world₁ Fin.zero Fin.zero
@@ -1421,32 +1420,14 @@ left-path-target-Z∋₂ :
   left-path-target-store₂ ∋ Fin.suc Fin.zero ⦂ ★
 left-path-target-Z∋₂ = S-bind∋ (Z∋ refl) refl
 
-left-path-source-Z⇝★₂ :
-  CTI2.LeadsTo Ex.right-store₂ (＇ (Fin.suc Fin.zero)) ★
-left-path-source-Z⇝★₂ =
-  CTI2.leads-var left-path-source-Z∋₂ CTI2.leads-here
-
-left-path-target-Z⇝★₂ :
-  CTI2.LeadsTo left-path-target-store₂ (＇ (Fin.suc Fin.zero)) ★
-left-path-target-Z⇝★₂ =
-  CTI2.leads-var left-path-target-Z∋₂ CTI2.leads-here
-
 left-path-Y-rep₂ :
   CTI2.StoreRepImp left-path-world₂ Fin.zero Fin.zero
-left-path-Y-rep₂ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Y∋₂ left-path-source-Z⇝★₂)
-    (CTI2.var-leads left-path-target-Y∋₂ left-path-target-Z⇝★₂)
-    ★⊑★
+left-path-Y-rep₂ = CTI2.store-rep-imp ★⊑★
 
 left-path-Z-rep₂ :
   CTI2.StoreRepImp left-path-world₂
     (Fin.suc Fin.zero) (Fin.suc Fin.zero)
-left-path-Z-rep₂ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Z∋₂ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Z∋₂ CTI2.leads-here)
-    ★⊑★
+left-path-Z-rep₂ = CTI2.store-rep-imp ★⊑★
 
 left-path-rebase-Y₂ :
   CTI2.RebaseAt left-path-world₂ left-path-world₂
@@ -1716,68 +1697,33 @@ left-path-target-Z∋₃ :
   left-path-target-store₃ ∋ Fin.suc Fin.zero ⦂ ★
 left-path-target-Z∋₃ = S-bind∋ (Z∋ refl) refl
 
-left-path-target-Z⇝★₃ :
-  CTI2.LeadsTo left-path-target-store₃ (＇ (Fin.suc Fin.zero)) ★
-left-path-target-Z⇝★₃ =
-  CTI2.leads-var left-path-target-Z∋₃ CTI2.leads-here
-
-left-path-target-Y⇝★₃ :
-  CTI2.LeadsTo left-path-target-store₃ (＇ Fin.zero) ★
-left-path-target-Y⇝★₃ =
-  CTI2.leads-var left-path-target-Y∋₃ left-path-target-Z⇝★₃
-
-left-path-source-Z⇝★₃ :
-  CTI2.LeadsTo Ex.right-store₃
-    (＇ (Fin.suc (Fin.suc Fin.zero))) ★
-left-path-source-Z⇝★₃ =
-  CTI2.leads-var left-path-source-Z∋₃ CTI2.leads-here
-
 left-path-source-X-rep₃ :
   CTI2.StoreRepImp left-path-world₃ Fin.zero Fin.zero
 left-path-source-X-rep₃ =
-  CTI2.store-rep-imp (‵ `ℕ) ★
-    (CTI2.var-leads left-path-source-X∋₃ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Y∋₃ left-path-target-Z⇝★₃)
-    (ℕ⊑★² {W = left-path-world₃})
+  CTI2.store-rep-imp (ℕ⊑★² {W = left-path-world₃})
 
 left-path-source-Z-rep₃ :
   CTI2.StoreRepImp left-path-world₃
     (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
-left-path-source-Z-rep₃ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Z∋₃ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Z∋₃ CTI2.leads-here)
-    ★⊑★
-
-left-path-source-Z-rep₃-YZ :
-  CTI2.StoreRepImp left-path-world₃-YZ
-    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
-left-path-source-Z-rep₃-YZ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Z∋₃ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Z∋₃ CTI2.leads-here)
-    ★⊑★
+left-path-source-Z-rep₃ = CTI2.store-rep-imp ★⊑★
 
 left-path-source-Y-rep₃-YZ :
   CTI2.StoreRepImp left-path-world₃-YZ (Fin.suc Fin.zero) Fin.zero
-left-path-source-Y-rep₃-YZ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Y∋₃ left-path-source-Z⇝★₃)
-    (CTI2.var-leads left-path-target-Y∋₃ left-path-target-Z⇝★₃)
-    ★⊑★
+left-path-source-Y-rep₃-YZ = CTI2.store-rep-imp ★⊑★
 
-left-path-rebase-XZ-to-YZ-Z₃ :
+-- The XZ and YZ alignments differ only in where target Y embeds, so
+-- the world change is pivot-local at the Y pair.  It happens at the
+-- paired Y reveal boundary rather than at the Z boundaries.
+left-path-rebase-XZ-to-YZ-Y₃ :
   CTI2.RebaseAt left-path-world₃ left-path-world₃-YZ
-    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
-left-path-rebase-XZ-to-YZ-Z₃ =
-  CTI2.rebase-at (CTI2.same-runtime refl refl) refl
-    left-path-source-Z-rep₃-YZ
-
-left-path-rebase-YZ-Y₃ :
-  CTI2.RebaseAt left-path-world₃-YZ left-path-world₃-YZ
     (Fin.suc Fin.zero) Fin.zero
-left-path-rebase-YZ-Y₃ =
-  CTI2.sameWorldRebaseAt refl left-path-source-Y-rep₃-YZ
+left-path-rebase-XZ-to-YZ-Y₃ =
+  CTI2.rebase-at (CTI2.same-runtime refl refl)
+    (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
+       ; {Fin.suc Fin.zero} _ → refl })
+    (λ _ → refl)
+    refl left-path-source-Y-rep₃-YZ
 
 left-path-rebase-XZ-Z₃ :
   CTI2.RebaseAt left-path-world₃ left-path-world₃
@@ -1837,10 +1783,10 @@ left-path-Y-var⊑YZ₃ :
   ＇ (Fin.suc Fin.zero) ⊑ᵂ⟨ left-path-world₃-YZ ⟩ ＇ Fin.zero
 left-path-Y-var⊑YZ₃ = Imprecision.X⊑X {X = Fin.suc Fin.zero}
 
-left-path-Z-var⊑YZ₃ :
-  ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₃-YZ ⟩
+left-path-Z-var⊑XZ₃ :
+  ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₃ ⟩
     ＇ (Fin.suc Fin.zero)
-left-path-Z-var⊑YZ₃ =
+left-path-Z-var⊑XZ₃ =
   Imprecision.X⊑X {X = Fin.suc (Fin.suc Fin.zero)}
 
 left-path-Y⇒Y⊑Y⇒Y-YZ₃ :
@@ -1849,13 +1795,13 @@ left-path-Y⇒Y⊑Y⇒Y-YZ₃ :
 left-path-Y⇒Y⊑Y⇒Y-YZ₃ =
   ⇒⊑⇒ left-path-Y-var⊑YZ₃ left-path-Y-var⊑YZ₃
 
-left-path-Z⇒Z⊑Z⇒Z-YZ₃ :
+left-path-Z⇒Z⊑Z⇒Z-XZ₃ :
   (＇ (Fin.suc (Fin.suc Fin.zero))
     ⇒ ＇ (Fin.suc (Fin.suc Fin.zero)))
-    ⊑ᵂ⟨ left-path-world₃-YZ ⟩
+    ⊑ᵂ⟨ left-path-world₃ ⟩
       (＇ (Fin.suc Fin.zero) ⇒ ＇ (Fin.suc Fin.zero))
-left-path-Z⇒Z⊑Z⇒Z-YZ₃ =
-  ⇒⊑⇒ left-path-Z-var⊑YZ₃ left-path-Z-var⊑YZ₃
+left-path-Z⇒Z⊑Z⇒Z-XZ₃ =
+  ⇒⊑⇒ left-path-Z-var⊑XZ₃ left-path-Z-var⊑XZ₃
 
 left-path-Z-var⊑★-XZ₃ :
   ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₃ ⟩ ★
@@ -1891,16 +1837,16 @@ left-path-lambda₃-YZ =
     {pA = left-path-Y-var⊑YZ₃} {pB = left-path-Y-var⊑YZ₃}
     (x⊑x² {p = left-path-Y-var⊑YZ₃} Zʷ)
 
-left-path-Y-revealed₃-YZ :
-  left-path-world₃-YZ ∣ [] ⊢²
+left-path-Y-revealed₃ :
+  left-path-world₃ ∣ [] ⊢²
     (ƛ (` 0)) ↑ example12-target-Y-reveal
     ⊑ left-path-target-lambda₃ ↑ left-path-Y-reveal₂ ∶
-      left-path-Z⇒Z⊑Z⇒Z-YZ₃
-left-path-Y-revealed₃-YZ =
-  reveal⊑reveal² left-path-rebase-YZ-Y₃ CTI2.same-[]
+      left-path-Z⇒Z⊑Z⇒Z-XZ₃
+left-path-Y-revealed₃ =
+  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₃ CTI2.same-[]
     left-path-source-Y-reveal₃-⊢ˣ left-path-target-Y-reveal₃-⊢ˣ
     left-path-lambda₃-YZ
-    left-path-Z⇒Z⊑Z⇒Z-YZ₃
+    left-path-Z⇒Z⊑Z⇒Z-XZ₃
 
 left-path-target-Z-revealed₃-XZ :
   left-path-world₃ ∣ [] ⊢²
@@ -1909,8 +1855,8 @@ left-path-target-Z-revealed₃-XZ :
         ↑ left-path-Z-reveal₂ ∶
       left-path-Z⇒Z⊑★⇒★-XZ₃
 left-path-target-Z-revealed₃-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-to-YZ-Z₃ CTI2.same-[]
-    left-path-target-Z-reveal₃-⊢ˣ left-path-Y-revealed₃-YZ
+  CTI2.⊑reveal² left-path-rebase-XZ-Z₃ CTI2.same-[]
+    left-path-target-Z-reveal₃-⊢ˣ left-path-Y-revealed₃
     left-path-Z⇒Z⊑★⇒★-XZ₃
 
 left-path-both-Z-revealed₃-XZ :
@@ -2009,18 +1955,10 @@ left-path-target-Z∋₄ :
   left-path-target-store₄ ∋ Fin.suc Fin.zero ⦂ ★
 left-path-target-Z∋₄ = S-bind∋ (Z∋ refl) refl
 
-left-path-target-Z⇝★₄ :
-  CTI2.LeadsTo left-path-target-store₄ (＇ (Fin.suc Fin.zero)) ★
-left-path-target-Z⇝★₄ =
-  CTI2.leads-var left-path-target-Z∋₄ CTI2.leads-here
-
 left-path-source-X-rep₄ :
   CTI2.StoreRepImp left-path-world₄ Fin.zero Fin.zero
 left-path-source-X-rep₄ =
-  CTI2.store-rep-imp (‵ `ℕ) ★
-    (CTI2.var-leads left-path-source-X∋₄ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Y∋₄ left-path-target-Z⇝★₄)
-    (ℕ⊑★² {W = left-path-world₄})
+  CTI2.store-rep-imp (ℕ⊑★² {W = left-path-world₄})
 
 left-path-rebase-XZ-X₄ :
   CTI2.RebaseAt left-path-world₄ left-path-world₄ Fin.zero Fin.zero
@@ -2320,57 +2258,28 @@ left-path-source-Z∋₄ :
   Ex.right-store₄ ∋ Fin.suc (Fin.suc Fin.zero) ⦂ ★
 left-path-source-Z∋₄ = S-bind∋ (S-bind∋ (Z∋ refl) refl) refl
 
-left-path-source-Z⇝★₄ :
-  CTI2.LeadsTo Ex.right-store₄
-    (＇ (Fin.suc (Fin.suc Fin.zero))) ★
-left-path-source-Z⇝★₄ =
-  CTI2.leads-var left-path-source-Z∋₄ CTI2.leads-here
-
 left-path-source-Y-rep₄-YZ :
   CTI2.StoreRepImp left-path-world₄-YZ (Fin.suc Fin.zero) Fin.zero
-left-path-source-Y-rep₄-YZ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Y∋₄ left-path-source-Z⇝★₄)
-    (CTI2.var-leads left-path-target-Y∋₄ left-path-target-Z⇝★₄)
-    ★⊑★
-
-left-path-source-Z-rep₄-YZ :
-  CTI2.StoreRepImp left-path-world₄-YZ
-    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
-left-path-source-Z-rep₄-YZ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Z∋₄ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Z∋₄ CTI2.leads-here)
-    ★⊑★
+left-path-source-Y-rep₄-YZ = CTI2.store-rep-imp ★⊑★
 
 left-path-source-Z-rep₄-XZ :
   CTI2.StoreRepImp left-path-world₄
     (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
-left-path-source-Z-rep₄-XZ =
-  CTI2.store-rep-imp ★ ★
-    (CTI2.var-leads left-path-source-Z∋₄ CTI2.leads-here)
-    (CTI2.var-leads left-path-target-Z∋₄ CTI2.leads-here)
-    ★⊑★
+left-path-source-Z-rep₄-XZ = CTI2.store-rep-imp ★⊑★
 
-left-path-rebase-XZ-to-YZ-Z₄ :
-  CTI2.RebaseAt left-path-world₄ left-path-world₄-YZ
-    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
-left-path-rebase-XZ-to-YZ-Z₄ =
-  CTI2.rebase-at (CTI2.same-runtime refl refl) refl
-    left-path-source-Z-rep₄-YZ
-
+-- As at step 3, the XZ and YZ alignments differ only at target Y, so
+-- the world change happens at the paired Y reveal/conceal boundaries
+-- and the Z boundaries stay in the XZ world.
 left-path-rebase-XZ-to-YZ-Y₄ :
   CTI2.RebaseAt left-path-world₄ left-path-world₄-YZ
     (Fin.suc Fin.zero) Fin.zero
 left-path-rebase-XZ-to-YZ-Y₄ =
-  CTI2.rebase-at (CTI2.same-runtime refl refl) refl
-    left-path-source-Y-rep₄-YZ
-
-left-path-rebase-YZ-Y₄ :
-  CTI2.RebaseAt left-path-world₄-YZ left-path-world₄-YZ
-    (Fin.suc Fin.zero) Fin.zero
-left-path-rebase-YZ-Y₄ =
-  CTI2.sameWorldRebaseAt refl left-path-source-Y-rep₄-YZ
+  CTI2.rebase-at (CTI2.same-runtime refl refl)
+    (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
+       ; {Fin.suc Fin.zero} _ → refl })
+    (λ _ → refl)
+    refl left-path-source-Y-rep₄-YZ
 
 left-path-rebase-XZ-Z₄ :
   CTI2.RebaseAt left-path-world₄ left-path-world₄
@@ -2519,12 +2428,6 @@ left-path-Y-var⊑YZ₄ :
   ＇ (Fin.suc Fin.zero) ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Fin.zero
 left-path-Y-var⊑YZ₄ = Imprecision.X⊑X {X = Fin.suc Fin.zero}
 
-left-path-Z-var⊑YZ₄ :
-  ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₄-YZ ⟩
-    ＇ (Fin.suc Fin.zero)
-left-path-Z-var⊑YZ₄ =
-  Imprecision.X⊑X {X = Fin.suc (Fin.suc Fin.zero)}
-
 left-path-Z-var⊑XZ₄ :
   ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₄ ⟩
     ＇ (Fin.suc Fin.zero)
@@ -2536,13 +2439,13 @@ left-path-Z-var⊑★-XZ₄ :
 left-path-Z-var⊑★-XZ₄ =
   Imprecision.X⊑★ {X = Fin.suc (Fin.suc Fin.zero)} refl
 
-left-path-Z⇒Z⊑Z⇒Z-YZ₄ :
+left-path-Z⇒Z⊑Z⇒Z-XZ₄ :
   (＇ (Fin.suc (Fin.suc Fin.zero))
     ⇒ ＇ (Fin.suc (Fin.suc Fin.zero)))
-    ⊑ᵂ⟨ left-path-world₄-YZ ⟩
+    ⊑ᵂ⟨ left-path-world₄ ⟩
       (＇ (Fin.suc Fin.zero) ⇒ ＇ (Fin.suc Fin.zero))
-left-path-Z⇒Z⊑Z⇒Z-YZ₄ =
-  ⇒⊑⇒ left-path-Z-var⊑YZ₄ left-path-Z-var⊑YZ₄
+left-path-Z⇒Z⊑Z⇒Z-XZ₄ =
+  ⇒⊑⇒ left-path-Z-var⊑XZ₄ left-path-Z-var⊑XZ₄
 
 left-path-lambda₄-YZ :
   left-path-world₄-YZ ∣ [] ⊢² ƛ (` 0) ⊑ left-path-target-lambda₃ ∶
@@ -2554,34 +2457,34 @@ left-path-lambda₄-YZ =
     {pA = left-path-Y-var⊑YZ₄} {pB = left-path-Y-var⊑YZ₄}
     (x⊑x² {p = left-path-Y-var⊑YZ₄} Zʷ)
 
-left-path-Y-revealed₄-YZ :
-  left-path-world₄-YZ ∣ [] ⊢²
+left-path-Y-revealed₄-XZ :
+  left-path-world₄ ∣ [] ⊢²
     (ƛ (` 0)) ↑ example12-target-Y-reveal
     ⊑ left-path-target-lambda₃ ↑ left-path-Y-reveal₂ ∶
-      left-path-Z⇒Z⊑Z⇒Z-YZ₄
-left-path-Y-revealed₄-YZ =
-  reveal⊑reveal² left-path-rebase-YZ-Y₄ CTI2.same-[]
+      left-path-Z⇒Z⊑Z⇒Z-XZ₄
+left-path-Y-revealed₄-XZ =
+  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
     left-path-source-Y-reveal₄-⊢ˣ left-path-target-Y-reveal₄-⊢ˣ
     left-path-lambda₄-YZ
-    left-path-Z⇒Z⊑Z⇒Z-YZ₄
+    left-path-Z⇒Z⊑Z⇒Z-XZ₄
 
-left-path-argument-Z₈-YZ :
-  left-path-world₄-YZ ∣ [] ⊢²
+left-path-argument-Z₈-XZ :
+  left-path-world₄ ∣ [] ⊢²
     ((($ (κℕ 7)) ↓ example12-target-X-seal)
       ⟨ example12-target-X! ⟩)
       ↓ example12-target-Z-seal
     ⊑ ($ (κℕ 7) ⟨ left-path-ℕ!₂ ⟩)
         ↓ left-path-target-Z-seal₂ ∶
-      left-path-Z-var⊑YZ₄
-left-path-argument-Z₈-YZ =
-  CTI2.conceal⊑conceal² left-path-rebase-XZ-to-YZ-Z₄
+      left-path-Z-var⊑XZ₄
+left-path-argument-Z₈-XZ =
+  CTI2.conceal⊑conceal² left-path-rebase-XZ-Z₄
     CTI2.same-[]
     left-path-source-Z-seal₄-⊢ˣ left-path-target-Z-seal₄-⊢ˣ
     left-path-source-X!₄
-    left-path-Z-var⊑YZ₄
+    left-path-Z-var⊑XZ₄
 
-left-path-application₈-preZ :
-  left-path-world₄-YZ ∣ [] ⊢²
+left-path-application₈-XZ :
+  left-path-world₄ ∣ [] ⊢²
     ((ƛ (` 0)) ↑ example12-target-Y-reveal)
       · (((($ (κℕ 7)) ↓ example12-target-X-seal)
           ⟨ example12-target-X! ⟩)
@@ -2589,9 +2492,9 @@ left-path-application₈-preZ :
     ⊑ (left-path-target-lambda₃ ↑ left-path-Y-reveal₂)
         · (($ (κℕ 7) ⟨ left-path-ℕ!₂ ⟩)
             ↓ left-path-target-Z-seal₂) ∶
-      left-path-Z-var⊑YZ₄
-left-path-application₈-preZ =
-  ·⊑·² left-path-Y-revealed₄-YZ left-path-argument-Z₈-YZ
+      left-path-Z-var⊑XZ₄
+left-path-application₈-XZ =
+  ·⊑·² left-path-Y-revealed₄-XZ left-path-argument-Z₈-XZ
 
 left-path-target-Z-revealed₈-XZ :
   left-path-world₄ ∣ [] ⊢²
@@ -2605,8 +2508,8 @@ left-path-target-Z-revealed₈-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-revealed₈-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-to-YZ-Z₄ CTI2.same-[]
-    left-path-target-Z-unseal₄-⊢ˣ left-path-application₈-preZ
+  CTI2.⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+    left-path-target-Z-unseal₄-⊢ˣ left-path-application₈-XZ
     left-path-Z-var⊑★-XZ₄
 
 left-path-both-Z-revealed₈-XZ :
@@ -2682,10 +2585,10 @@ left-path-argument-Y₉-YZ :
         ↓ left-path-target-Y-seal₂) ∶
       left-path-Y-var⊑YZ₄
 left-path-argument-Y₉-YZ =
-  CTI2.conceal⊑conceal² left-path-rebase-YZ-Y₄
+  CTI2.conceal⊑conceal² left-path-rebase-XZ-to-YZ-Y₄
     CTI2.same-[] left-path-source-Y-seal₄-⊢ˣ
     left-path-target-Y-seal₄-⊢ˣ
-    left-path-argument-Z₈-YZ left-path-Y-var⊑YZ₄
+    left-path-argument-Z₈-XZ left-path-Y-var⊑YZ₄
 
 left-path-application₉-YZ :
   left-path-world₄-YZ ∣ [] ⊢²
@@ -2702,8 +2605,8 @@ left-path-application₉-YZ :
 left-path-application₉-YZ =
   ·⊑·² left-path-lambda₄-YZ left-path-argument-Y₉-YZ
 
-left-path-Y-unsealed₉-YZ :
-  left-path-world₄-YZ ∣ [] ⊢²
+left-path-Y-unsealed₉-XZ :
+  left-path-world₄ ∣ [] ⊢²
     ((ƛ (` 0)) ·
       ((((($ (κℕ 7)) ↓ example12-target-X-seal)
         ⟨ example12-target-X! ⟩)
@@ -2715,12 +2618,12 @@ left-path-Y-unsealed₉-YZ :
           ↓ left-path-target-Z-seal₂)
           ↓ left-path-target-Y-seal₂))
         ↑ left-path-target-Y-unseal₂ ∶
-      left-path-Z-var⊑YZ₄
-left-path-Y-unsealed₉-YZ =
-  reveal⊑reveal² left-path-rebase-YZ-Y₄ CTI2.same-[]
+      left-path-Z-var⊑XZ₄
+left-path-Y-unsealed₉-XZ =
+  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
     left-path-source-Y-unseal₄-⊢ˣ left-path-target-Y-unseal₄-⊢ˣ
     left-path-application₉-YZ
-    left-path-Z-var⊑YZ₄
+    left-path-Z-var⊑XZ₄
 
 left-path-target-Z-unsealed₉-XZ :
   left-path-world₄ ∣ [] ⊢²
@@ -2738,8 +2641,8 @@ left-path-target-Z-unsealed₉-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-unsealed₉-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-to-YZ-Z₄ CTI2.same-[]
-    left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₉-YZ
+  CTI2.⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+    left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₉-XZ
     left-path-Z-var⊑★-XZ₄
 
 left-path-both-Z-unsealed₉-XZ :
@@ -2816,8 +2719,8 @@ left-path-checkpoint₉ =
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₉
     left-path-ℕ⊑★₄
 
-left-path-Y-unsealed₁₀-YZ :
-  left-path-world₄-YZ ∣ [] ⊢²
+left-path-Y-unsealed₁₀-XZ :
+  left-path-world₄ ∣ [] ⊢²
     (((((($ (κℕ 7)) ↓ example12-target-X-seal)
       ⟨ example12-target-X! ⟩)
       ↓ example12-target-Z-seal)
@@ -2827,12 +2730,12 @@ left-path-Y-unsealed₁₀-YZ :
         ↓ left-path-target-Z-seal₂)
         ↓ left-path-target-Y-seal₂)
         ↑ left-path-target-Y-unseal₂) ∶
-      left-path-Z-var⊑YZ₄
-left-path-Y-unsealed₁₀-YZ =
-  reveal⊑reveal² left-path-rebase-YZ-Y₄ CTI2.same-[]
+      left-path-Z-var⊑XZ₄
+left-path-Y-unsealed₁₀-XZ =
+  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
     left-path-source-Y-unseal₄-⊢ˣ left-path-target-Y-unseal₄-⊢ˣ
     left-path-argument-Y₉-YZ
-    left-path-Z-var⊑YZ₄
+    left-path-Z-var⊑XZ₄
 
 left-path-target-Z-unsealed₁₀-XZ :
   left-path-world₄ ∣ [] ⊢²
@@ -2848,8 +2751,8 @@ left-path-target-Z-unsealed₁₀-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-unsealed₁₀-XZ =
-  CTI2.⊑reveal² left-path-rebase-XZ-to-YZ-Z₄ CTI2.same-[]
-    left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₁₀-YZ
+  CTI2.⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+    left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₁₀-XZ
     left-path-Z-var⊑★-XZ₄
 
 left-path-both-Z-unsealed₁₀-XZ :
@@ -2931,9 +2834,9 @@ left-path-both-Z-unsealed₁₁-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       ★⊑★
 left-path-both-Z-unsealed₁₁-XZ =
-  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Z₄ CTI2.same-[]
+  reveal⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-unseal₄-⊢ˣ
-    left-path-argument-Z₈-YZ ★⊑★
+    left-path-argument-Z₈-XZ ★⊑★
 
 left-path-source-result-id₁₁ :
   left-path-world₄ ∣ [] ⊢²

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -12,6 +12,7 @@ open import Data.Empty using (⊥-elim)
 open import Data.List using (List; []; _∷_)
 open import Data.Maybe using (just; nothing)
 open import Data.Nat using (zero; suc)
+open import Data.Product using (_,_)
 import Data.Fin as Fin
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 
@@ -211,6 +212,7 @@ example12-rebase-Z-to-Y =
   CTI2.rebase-at (CTI2.same-runtime refl refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
     (λ _ → refl) refl
+    (λ moved → ⊥-elim (moved refl))
     CTI2.example12-Y-representation
 
 example12-target-Y-reveal :
@@ -1718,8 +1720,8 @@ left-path-rebase-XZ-to-YZ-Y₃ =
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
        ; {Fin.suc Fin.zero} _ → refl })
-   
-    refl left-path-source-Y-rep₃-YZ
+    refl (λ _ → Fin.zero , refl)
+    left-path-source-Y-rep₃-YZ
 
 left-path-rebase-XZ-Z₃ :
   CTI2.RebaseAt left-path-world₃ left-path-world₃
@@ -2274,8 +2276,8 @@ left-path-rebase-XZ-to-YZ-Y₄ =
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
        ; {Fin.suc Fin.zero} _ → refl })
-   
-    refl left-path-source-Y-rep₄-YZ
+    refl (λ _ → Fin.zero , refl)
+    left-path-source-Y-rep₄-YZ
 
 left-path-rebase-XZ-Z₄ :
   CTI2.RebaseAt left-path-world₄ left-path-world₄

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -210,7 +210,7 @@ example12-rebase-Z-to-Y :
 example12-rebase-Z-to-Y =
   CTI2.rebase-at (CTI2.same-runtime refl refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    (λ _ → refl) (λ _ → refl) refl
+    (λ _ → refl) refl
     CTI2.example12-Y-representation
 
 example12-target-Y-reveal :
@@ -433,7 +433,7 @@ example12-lambda-Z :
     ⊑ (ƛ (` 0)) ↑ example12-target-Y-reveal ∶
       example12-Z-function-local
 example12-lambda-Z =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
     example12-target-Y-reveal-⊢ˣ example12-lambda-Y
     example12-Z-function-local
 
@@ -443,7 +443,7 @@ example12-lambda-star :
         ↑ example12-target-Z-reveal ∶
       example12-X-function-to-star
 example12-lambda-star =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
     example12-target-Z-reveal-⊢ˣ example12-lambda-Z
     example12-X-function-to-star
 
@@ -515,7 +515,7 @@ example12-function-checkpoint₁ :
         ↑ example12-target-X-reveal ∶
       example12-ℕ⇒ℕ⊑ℕ⇒ℕ-X
 example12-function-checkpoint₁ =
-  reveal⊑reveal² example12-rebase-X-same CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) example12-rebase-X-same CTI2.same-[]
     example12-source-X-reveal-⊢ˣ example12-target-X-reveal-⊢ˣ
     example12-lambda-X
     example12-ℕ⇒ℕ⊑ℕ⇒ℕ-X
@@ -533,7 +533,7 @@ example12-sealed-const :
     ⊑ ($ (κℕ 7)) ↓ example12-target-X-seal ∶
       example12-X-var⊑
 example12-sealed-const =
-  CTI2.conceal⊑conceal² example12-rebase-X-same CTI2.same-[]
+  CTI2.conceal⊑conceal² (λ _ eq → eq) example12-rebase-X-same CTI2.same-[]
     example12-source-X-seal-⊢ˣ example12-target-X-seal-⊢ˣ
     (κ⊑κ² (κℕ 7) example12-ℕ⊑ℕ-X) example12-X-var⊑
 
@@ -553,7 +553,7 @@ example12-checkpoint₂ :
   CTI2.example12-world-X ∣ [] ⊢² Ex.left₂ ⊑ Ex.right₄ ∶
     example12-ℕ⊑ℕ-X
 example12-checkpoint₂ =
-  reveal⊑reveal² example12-rebase-X-same CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) example12-rebase-X-same CTI2.same-[]
     example12-source-X-unseal-⊢ˣ example12-target-X-unseal-⊢ˣ
     example12-application-checkpoint₂
     example12-ℕ⊑ℕ-X
@@ -576,7 +576,7 @@ example12-target-Z-seal-checkpoint₃ :
         ↓ example12-target-Z-seal ∶
       example12-Z-var⊑
 example12-target-Z-seal-checkpoint₃ =
-  CTI2.⊑conceal² (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
+  CTI2.⊑conceal² (λ _ eq → eq) (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
     example12-target-Z-seal-⊢ˣ example12-target-X!-checkpoint₃
     example12-Z-var⊑
 
@@ -589,7 +589,7 @@ example12-target-Y-seal-checkpoint₃ :
         ↓ example12-target-Y-seal ∶
       example12-Y-var⊑
 example12-target-Y-seal-checkpoint₃ =
-  CTI2.⊑conceal² (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
+  CTI2.⊑conceal² (λ _ eq → eq) (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
     example12-target-Y-seal-⊢ˣ example12-target-Z-seal-checkpoint₃
     example12-Y-var⊑
 
@@ -603,7 +603,7 @@ example12-target-Y-unseal-checkpoint₃ :
         ↑ example12-target-Y-unseal ∶
       example12-Z-var⊑
 example12-target-Y-unseal-checkpoint₃ =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ example12-rebase-Z-to-Y) CTI2.same-[]
     example12-target-Y-unseal-⊢ˣ example12-target-Y-seal-checkpoint₃
     example12-Z-var⊑
 
@@ -618,7 +618,7 @@ example12-target-Z-unseal-checkpoint₃ :
         ↑ example12-target-Z-unseal ∶
       example12-X-var-to-star
 example12-target-Z-unseal-checkpoint₃ =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ CTI2.example12-rebase-X-to-Z) CTI2.same-[]
     example12-target-Z-unseal-⊢ˣ example12-target-Y-unseal-checkpoint₃
     example12-X-var-to-star
 
@@ -657,7 +657,7 @@ example12-checkpoint₃ :
   CTI2.example12-world-X ∣ [] ⊢² Ex.left₃ ⊑ Ex.right₁₀ ∶
     example12-ℕ⊑ℕ-X
 example12-checkpoint₃ =
-  reveal⊑reveal² example12-rebase-X-same CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) example12-rebase-X-same CTI2.same-[]
     example12-source-X-unseal-⊢ˣ example12-target-X-unseal-⊢ˣ
     example12-target-★?X-checkpoint₃
     example12-ℕ⊑ℕ-X
@@ -952,7 +952,7 @@ nat-chain-polyId-target-reveal :
     ⊑ Ex.polyId ↑ CTI2.example12-nat-chain-reveal ∶
       example12-∀⊑∀
 nat-chain-polyId-target-reveal =
-  CTI2.⊑reveal² CTI2.rebase-idᴿ CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) CTI2.rebase-idᴿ CTI2.same-[]
     CTI2.example12-nat-chain-reveal-⊢ˣ polyId-refl²
     example12-∀⊑∀
 
@@ -980,7 +980,7 @@ nat-chain-lambda-X :
     ⊑ (ƛ (` 0)) ↑ nat-chain-target-Y-reveal ∶
       nat-chain-X-function-local
 nat-chain-lambda-X =
-  CTI2.⊑reveal²
+  CTI2.⊑reveal² (λ _ eq → eq)
     (CTI2.rebase-varᴿ CTI2.example12-nat-chain-rebase-X-to-Y)
     CTI2.same-[] nat-chain-target-Y-reveal-⊢ˣ nat-chain-lambda-Y
     nat-chain-X-function-local
@@ -991,7 +991,7 @@ nat-chain-lambda-X-id :
         ↑ nat-chain-target-id-X-reveal ∶
       nat-chain-X-function-local
 nat-chain-lambda-X-id =
-  CTI2.⊑reveal² CTI2.rebase-idᴿ CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) CTI2.rebase-idᴿ CTI2.same-[]
     CTI2.⊢↑-idˣ nat-chain-lambda-X
     nat-chain-X-function-local
 
@@ -1003,7 +1003,7 @@ nat-chain-function-checkpoint₁ :
         ↑ nat-chain-target-X-reveal ∶
       nat-chain-ℕ⇒ℕ⊑ℕ⇒ℕ-X
 nat-chain-function-checkpoint₁ =
-  reveal⊑reveal² nat-chain-rebase-X-same CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) nat-chain-rebase-X-same CTI2.same-[]
     nat-chain-source-X-reveal-⊢ˣ nat-chain-target-X-reveal-⊢ˣ
     nat-chain-lambda-X-id
     nat-chain-ℕ⇒ℕ⊑ℕ⇒ℕ-X
@@ -1021,7 +1021,7 @@ nat-chain-sealed-const-X :
     ⊑ ($ (κℕ 7)) ↓ nat-chain-target-X-seal ∶
       nat-chain-X-var⊑
 nat-chain-sealed-const-X =
-  CTI2.conceal⊑conceal² nat-chain-rebase-X-same CTI2.same-[]
+  CTI2.conceal⊑conceal² (λ _ eq → eq) nat-chain-rebase-X-same CTI2.same-[]
     nat-chain-source-X-seal-⊢ˣ nat-chain-target-X-seal-⊢ˣ
     (κ⊑κ² (κℕ 7) nat-chain-ℕ⊑ℕ-X) nat-chain-X-var⊑
 
@@ -1038,7 +1038,7 @@ nat-chain-checkpoint₂ :
   CTI2.example12-nat-chain-world-X ∣ [] ⊢² Ex.left₂
     ⊑ nat-target₄ ∶ nat-chain-ℕ⊑ℕ-X
 nat-chain-checkpoint₂ =
-  reveal⊑reveal² nat-chain-rebase-X-same CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) nat-chain-rebase-X-same CTI2.same-[]
     nat-chain-source-X-unseal-⊢ˣ nat-chain-target-X-unseal-⊢ˣ
     nat-chain-application-checkpoint₂
     nat-chain-ℕ⊑ℕ-X
@@ -1047,7 +1047,7 @@ nat-chain-checkpoint₃ :
   CTI2.example12-nat-chain-world-X ∣ [] ⊢² Ex.left₃
     ⊑ nat-target₇ ∶ nat-chain-ℕ⊑ℕ-X
 nat-chain-checkpoint₃ =
-  reveal⊑reveal² nat-chain-rebase-X-same CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) nat-chain-rebase-X-same CTI2.same-[]
     nat-chain-source-X-unseal-⊢ˣ nat-chain-target-X-unseal-⊢ˣ
     nat-chain-sealed-const-X
     nat-chain-ℕ⊑ℕ-X
@@ -1554,7 +1554,7 @@ left-path-base₁ :
         ★⇒★⊑★⇒★² {W = left-path-world₁}
 left-path-base₁ =
   cast⊑cast² left-path-id★↦id★₁-source left-path-id★↦id★₁-target
-    (reveal⊑reveal² left-path-rebase-U₁ CTI2.same-[]
+    (reveal⊑reveal² (λ _ eq → eq) left-path-rebase-U₁ CTI2.same-[]
       left-path-reveal★₁-source-⊢ˣ left-path-reveal★₁-target-⊢ˣ
       (•⊑•²
         {C = left-path-X⇒X₁} {C′ = left-path-X⇒X₁}
@@ -1617,9 +1617,9 @@ left-path-base₂ :
         ★⇒★⊑★⇒★² {W = left-path-world₂}
 left-path-base₂ =
   cast⊑cast² left-path-id★↦id★₂-source left-path-id★↦id★₂-target
-    (reveal⊑reveal² left-path-rebase-Z₂ CTI2.same-[]
+    (reveal⊑reveal² (λ _ eq → eq) left-path-rebase-Z₂ CTI2.same-[]
       left-path-Z-reveal₂-source-⊢ˣ left-path-Z-reveal₂-target-⊢ˣ
-      (reveal⊑reveal² left-path-rebase-Y₂ CTI2.same-[]
+      (reveal⊑reveal² (λ _ eq → eq) left-path-rebase-Y₂ CTI2.same-[]
         left-path-Y-reveal₂-source-⊢ˣ left-path-Y-reveal₂-target-⊢ˣ
         left-path-lambda₂
         left-path-Z⇒Z⊑Z⇒Z₂)
@@ -1718,7 +1718,7 @@ left-path-rebase-XZ-to-YZ-Y₃ =
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
        ; {Fin.suc Fin.zero} _ → refl })
-    (λ _ → refl)
+   
     refl left-path-source-Y-rep₃-YZ
 
 left-path-rebase-XZ-Z₃ :
@@ -1839,7 +1839,7 @@ left-path-Y-revealed₃ :
     ⊑ left-path-target-lambda₃ ↑ left-path-Y-reveal₂ ∶
       left-path-Z⇒Z⊑Z⇒Z-XZ₃
 left-path-Y-revealed₃ =
-  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₃ CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) left-path-rebase-XZ-to-YZ-Y₃ CTI2.same-[]
     left-path-source-Y-reveal₃-⊢ˣ left-path-target-Y-reveal₃-⊢ˣ
     left-path-lambda₃-YZ
     left-path-Z⇒Z⊑Z⇒Z-XZ₃
@@ -1851,7 +1851,7 @@ left-path-target-Z-revealed₃-XZ :
         ↑ left-path-Z-reveal₂ ∶
       left-path-Z⇒Z⊑★⇒★-XZ₃
 left-path-target-Z-revealed₃-XZ =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₃) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₃) CTI2.same-[]
     left-path-target-Z-reveal₃-⊢ˣ left-path-Y-revealed₃
     left-path-Z⇒Z⊑★⇒★-XZ₃
 
@@ -1863,7 +1863,7 @@ left-path-both-Z-revealed₃-XZ :
         ↑ left-path-Z-reveal₂ ∶
       ★⇒★⊑★⇒★² {W = left-path-world₃}
 left-path-both-Z-revealed₃-XZ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₃) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₃) CTI2.same-[]
     left-path-source-Z-reveal₃-⊢ˣ left-path-target-Z-revealed₃-XZ
     (★⇒★⊑★⇒★² {W = left-path-world₃})
 
@@ -1904,7 +1904,7 @@ left-path-function₃ :
         ↑ left-path-Z-reveal₂ ∶
       ℕ⇒ℕ⊑★⇒★² {W = left-path-world₃}
 left-path-function₃ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₃) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₃) CTI2.same-[]
     left-path-source-X-reveal₃-⊢ˣ left-path-source-X?₃-XZ
     (ℕ⇒ℕ⊑★⇒★² {W = left-path-world₃})
 
@@ -1999,7 +1999,7 @@ left-path-argument₄ :
     ⊑ $ (κℕ 7) ⟨ left-path-ℕ!₂ ⟩ ∶
       left-path-X-var⊑★-XZ₄
 left-path-argument₄ =
-  CTI2.conceal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.conceal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-seal₄-⊢ˣ left-path-argument₄-base
     left-path-X-var⊑★-XZ₄
 
@@ -2024,7 +2024,7 @@ left-path-checkpoint₄ :
   left-path-world₄ ∣ [] ⊢² Ex.right₄
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₄ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-application₄
     left-path-ℕ⊑★₄
 
@@ -2097,7 +2097,7 @@ left-path-checkpoint₅ :
   left-path-world₄ ∣ [] ⊢² Ex.right₅
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₅ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₅
     left-path-ℕ⊑★₄
 
@@ -2188,7 +2188,7 @@ left-path-checkpoint₆ :
   left-path-world₄ ∣ [] ⊢² Ex.right₆
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₆ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₆
     left-path-ℕ⊑★₄
 
@@ -2242,7 +2242,7 @@ left-path-checkpoint₇ :
   left-path-world₄ ∣ [] ⊢² Ex.right₇
     ⊑ left-path-target₄ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₇ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₇
     left-path-ℕ⊑★₄
 
@@ -2274,7 +2274,7 @@ left-path-rebase-XZ-to-YZ-Y₄ =
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
        ; {Fin.suc Fin.zero} _ → refl })
-    (λ _ → refl)
+   
     refl left-path-source-Y-rep₄-YZ
 
 left-path-rebase-XZ-Z₄ :
@@ -2459,7 +2459,7 @@ left-path-Y-revealed₄-XZ :
     ⊑ left-path-target-lambda₃ ↑ left-path-Y-reveal₂ ∶
       left-path-Z⇒Z⊑Z⇒Z-XZ₄
 left-path-Y-revealed₄-XZ =
-  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
     left-path-source-Y-reveal₄-⊢ˣ left-path-target-Y-reveal₄-⊢ˣ
     left-path-lambda₄-YZ
     left-path-Z⇒Z⊑Z⇒Z-XZ₄
@@ -2473,7 +2473,7 @@ left-path-argument-Z₈-XZ :
         ↓ left-path-target-Z-seal₂ ∶
       left-path-Z-var⊑XZ₄
 left-path-argument-Z₈-XZ =
-  CTI2.conceal⊑conceal² left-path-rebase-XZ-Z₄
+  CTI2.conceal⊑conceal² (λ _ eq → eq) left-path-rebase-XZ-Z₄
     CTI2.same-[]
     left-path-source-Z-seal₄-⊢ˣ left-path-target-Z-seal₄-⊢ˣ
     left-path-source-X!₄
@@ -2504,7 +2504,7 @@ left-path-target-Z-revealed₈-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-revealed₈-XZ =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-target-Z-unseal₄-⊢ˣ left-path-application₈-XZ
     left-path-Z-var⊑★-XZ₄
 
@@ -2521,7 +2521,7 @@ left-path-both-Z-revealed₈-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       ★⊑★
 left-path-both-Z-revealed₈-XZ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-revealed₈-XZ
     ★⊑★
 
@@ -2566,7 +2566,7 @@ left-path-checkpoint₈ :
   left-path-world₄ ∣ [] ⊢² Ex.right₈
     ⊑ left-path-target₅ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₈ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₈
     left-path-ℕ⊑★₄
 
@@ -2581,7 +2581,7 @@ left-path-argument-Y₉-YZ :
         ↓ left-path-target-Y-seal₂) ∶
       left-path-Y-var⊑YZ₄
 left-path-argument-Y₉-YZ =
-  CTI2.conceal⊑conceal² left-path-rebase-XZ-to-YZ-Y₄
+  CTI2.conceal⊑conceal² (λ _ eq → eq) left-path-rebase-XZ-to-YZ-Y₄
     CTI2.same-[] left-path-source-Y-seal₄-⊢ˣ
     left-path-target-Y-seal₄-⊢ˣ
     left-path-argument-Z₈-XZ left-path-Y-var⊑YZ₄
@@ -2616,7 +2616,7 @@ left-path-Y-unsealed₉-XZ :
         ↑ left-path-target-Y-unseal₂ ∶
       left-path-Z-var⊑XZ₄
 left-path-Y-unsealed₉-XZ =
-  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
     left-path-source-Y-unseal₄-⊢ˣ left-path-target-Y-unseal₄-⊢ˣ
     left-path-application₉-YZ
     left-path-Z-var⊑XZ₄
@@ -2637,7 +2637,7 @@ left-path-target-Z-unsealed₉-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-unsealed₉-XZ =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₉-XZ
     left-path-Z-var⊑★-XZ₄
 
@@ -2658,7 +2658,7 @@ left-path-both-Z-unsealed₉-XZ :
         ↑ left-path-target-Z-unseal₂ ∶
       ★⊑★
 left-path-both-Z-unsealed₉-XZ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-unsealed₉-XZ
     ★⊑★
 
@@ -2711,7 +2711,7 @@ left-path-checkpoint₉ :
   left-path-world₄ ∣ [] ⊢² Ex.right₉
     ⊑ left-path-target₆ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₉ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₉
     left-path-ℕ⊑★₄
 
@@ -2728,7 +2728,7 @@ left-path-Y-unsealed₁₀-XZ :
         ↑ left-path-target-Y-unseal₂) ∶
       left-path-Z-var⊑XZ₄
 left-path-Y-unsealed₁₀-XZ =
-  reveal⊑reveal² left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) left-path-rebase-XZ-to-YZ-Y₄ CTI2.same-[]
     left-path-source-Y-unseal₄-⊢ˣ left-path-target-Y-unseal₄-⊢ˣ
     left-path-argument-Y₉-YZ
     left-path-Z-var⊑XZ₄
@@ -2747,7 +2747,7 @@ left-path-target-Z-unsealed₁₀-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       left-path-Z-var⊑★-XZ₄
 left-path-target-Z-unsealed₁₀-XZ =
-  CTI2.⊑reveal² (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
+  CTI2.⊑reveal² (λ _ eq → eq) (CTI2.rebase-varᴿ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-target-Z-unseal₄-⊢ˣ left-path-Y-unsealed₁₀-XZ
     left-path-Z-var⊑★-XZ₄
 
@@ -2766,7 +2766,7 @@ left-path-both-Z-unsealed₁₀-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       ★⊑★
 left-path-both-Z-unsealed₁₀-XZ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-Z₄) CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-unsealed₁₀-XZ
     ★⊑★
 
@@ -2815,7 +2815,7 @@ left-path-checkpoint₁₀ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₀
     ⊑ left-path-target₇ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₀ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₀
     left-path-ℕ⊑★₄
 
@@ -2830,7 +2830,7 @@ left-path-both-Z-unsealed₁₁-XZ :
         ↑ left-path-target-Z-unseal₂) ∶
       ★⊑★
 left-path-both-Z-unsealed₁₁-XZ =
-  reveal⊑reveal² left-path-rebase-XZ-Z₄ CTI2.same-[]
+  reveal⊑reveal² (λ _ eq → eq) left-path-rebase-XZ-Z₄ CTI2.same-[]
     left-path-source-Z-unseal₄-⊢ˣ left-path-target-Z-unseal₄-⊢ˣ
     left-path-argument-Z₈-XZ ★⊑★
 
@@ -2871,7 +2871,7 @@ left-path-checkpoint₁₁ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₁
     ⊑ left-path-target₈ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₁ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₁
     left-path-ℕ⊑★₄
 
@@ -2904,7 +2904,7 @@ left-path-checkpoint₁₂ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₂
     ⊑ left-path-target₉ ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₂ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₂
     left-path-ℕ⊑★₄
 
@@ -2923,7 +2923,7 @@ left-path-checkpoint₁₃ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₃
     ⊑ left-path-target-final ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₃ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-source-result-?X₁₃
     left-path-ℕ⊑★₄
 
@@ -2931,7 +2931,7 @@ left-path-checkpoint₁₄ :
   left-path-world₄ ∣ [] ⊢² Ex.right₁₄
     ⊑ left-path-target-final ∶ left-path-ℕ⊑★₄
 left-path-checkpoint₁₄ =
-  CTI2.reveal⊑² (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ left-path-rebase-XZ-X₄) CTI2.same-[]
     left-path-source-X-unseal₄-⊢ˣ left-path-argument₄
     left-path-ℕ⊑★₄
 

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -327,7 +327,8 @@ liftRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
   → CTI2.RebaseAt W W′ Xᴸ Xᴿ
   → CTI2.RebaseAt (CTI2.liftWorldBoth v W)
       (CTI2.liftWorldBoth v W′) (Fin.suc Xᴸ) (Fin.suc Xᴿ)
-liftRebaseAt {W = W} {W′ = W′} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} {v = v} rb =
+liftRebaseAt {Δᴸ = Δᴸ} {W = W} {W′ = W′} {Xᴸ = Xᴸ}
+    {Xᴿ = Xᴿ} {v = v} rb =
   CTI2.rebase-at
     (CTI2.same-runtime
       (cong store-lift
@@ -336,8 +337,20 @@ liftRebaseAt {W = W} {W′ = W′} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} {v = v} rb =
         (CTI2.SameRuntime.targetStore-same (CTI2.RebaseAt.sameRuntime rb))))
     source-off target-off
     (cong Fin.suc (CTI2.RebaseAt.pivotAligned rb))
+    lift-anchor
     (CTI2.store-rep-imp lift-represented)
   where
+  lift-anchor :
+      toRenameᵗ (ηᴿʷ (CTI2.liftWorldBoth v W)) (Fin.suc Xᴿ)
+        ≢ toRenameᵗ (ηᴿʷ (CTI2.liftWorldBoth v W′)) (Fin.suc Xᴿ)
+    → Σ[ Xₒ ∈ TyVar (suc Δᴸ) ]
+        toRenameᵗ (ηᴸʷ (CTI2.liftWorldBoth v W)) Xₒ
+          ≡ toRenameᵗ
+              (ηᴿʷ (CTI2.liftWorldBoth v W)) (Fin.suc Xᴿ)
+  lift-anchor moved with CTI2.RebaseAt.anchorᴿ rb
+      (λ eq → moved (cong Fin.suc eq))
+  lift-anchor moved | Xₒ , eq = Fin.suc Xₒ , cong Fin.suc eq
+
   old-represented =
     CTI2.StoreRepImp.represented
       (CTI2.RebaseAt.storeRepresentations rb)

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -21,11 +21,15 @@ module proof.DGG.ExtraCastRight2 where
 --   * Binder-lifted world/rebase lemmas support the ∀-shaped frontier.
 --     The identity-pivot universal reveal and conceal subcases are complete;
 --     their conversion endpoints are equal and need no rebasing.
---     Bare seal is not reducible to obligation transport alone:
---     ExtraCastRight2Counterexample gives a checked configuration where
---     the input relation exists but every possible output relation after
---     target-tag cancellation is empty.  General bare-seal inversion needs
---     a stronger relation/world invariant or a restricted theorem domain.
+--   * The inversion carries a WFWorld hypothesis and threads it by
+--     decay: var-rebased wrapper cases move their premises into the
+--     honestified premise world (WorldDecay/TermImpDecay) before
+--     recursing, which is the general form of the counterexample
+--     repair recorded in ExtraCastRight2Counterexample.  The next
+--     frontiers are the ∀-shaped wrappers (proof.DGG.TagTransport has
+--     the obligation transports ready) and the bare seal, whose
+--     boundary decomposition is seal-tag-boundary-view² and whose
+--     inner extraction still needs a seal-peeling companion lemma.
 --   * Version-2 pay-offs visible here: no renaming wrapper around the
 --     relation, the Λ⊑² case recurses with the target data unchanged,
 --     and the ground lemmas of proof.ImprecisionConsistency apply
@@ -55,6 +59,8 @@ open import CastTerms
 open import Reduction
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CastTermImprecision2Typing as CTI2T
+import proof.DGG.WorldDecay as WD
+import proof.DGG.TermImpDecay as TD
 open import proof.DGG.ConvImp using
   (pivot-id-endpoints↑; pivot-id-endpoints↓)
 open CTI2 using
@@ -561,8 +567,38 @@ data SpineValue {Δ : TyCtx} : Term Δ → Set where
       {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
     → SpineValue V → SpineValue (V ↓ (c ↦↓ d))
 
+-- Threading mark-honesty and decay through the inversion.  The
+-- inversion's recursion may enter a wrapper's premise world, which
+-- the input derivation does not constrain to be mark-honest; the
+-- var-rebased wrapper cases therefore decay their premises into the
+-- honestified premise world before recursing.
+
+impEnvMono-∘ : ∀ {Δᴸ Δᴿ Δ} {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
+  → CTI2.ImpEnvMono W₁ W₂
+  → CTI2.ImpEnvMono W₂ W₃
+  → CTI2.ImpEnvMono W₁ W₃
+impEnvMono-∘ m₁ m₂ Z eq = m₂ Z (m₁ Z eq)
+
+decaySameCtxʳ : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ W″ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CTI2.CtxImp W′}
+  → (dec : WD.EnvDecay W′ W″)
+  → CTI2.SameCtx γ γ′
+  → CTI2.SameCtx γ (WD.decayCtx dec γ′)
+decaySameCtxʳ dec CTI2.same-[] = CTI2.same-[]
+decaySameCtxʳ dec (CTI2.same-∷ sc) = CTI2.same-∷ (decaySameCtxʳ dec sc)
+
+liftWorldLeft-WF : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+  → CTI2.WFWorld W
+  → CTI2.WFWorld (CTI2.liftWorldLeft X⊑★ W)
+liftWorldLeft-WF wf Fin.zero ()
+liftWorldLeft-WF wf (Fin.suc Xᴸ) eq with wf Xᴸ eq
+liftWorldLeft-WF wf (Fin.suc Xᴸ) eq | Xᴿ , al =
+  Xᴿ , cong Fin.suc al
+
 -- If a spine value is related to a tagged target value, the tag can be
 -- peeled off the target at any obligation for the tag's ground type.
+-- The world is required to be mark-honest; the seal cases depend on it.
 
 right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {γ : CtxImp W}
@@ -571,6 +607,7 @@ right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
     {cH : ν ⊢ H ∼ H}
     {p : A ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.WFWorld W
   → SpineValue M
   → Value N
   → W ∣ γ ⊢² M ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
@@ -578,52 +615,52 @@ right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
   → W ∣ γ ⊢² M ⊑ N ∶ q
 
 -- Target-only cast: the premise already carries the tag obligation.
-right-inj-inversion² sv vN (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
+right-inj-inversion² wf sv vN (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
   subst≡ (λ r → _ ∣ _ ⊢² _ ⊑ _ ∶ r) (PI.⊑-unique p₀ q) prem
 
 -- Paired cast: keep the source cast as a source-only cast.
-right-inj-inversion² sv vN (CTI2.cast⊑cast² c c′ prem q₀) q =
+right-inj-inversion² wf sv vN (CTI2.cast⊑cast² c c′ prem q₀) q =
   CTI2.cast⊑² c prem q
 
 -- Source-only cast around an injection value: no obligation matches.
-right-inj-inversion² {gH = ＇ Y} (sv-cast sv inj)
+right-inj-inversion² {gH = ＇ Y} wf (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ‵ ι} (sv-cast sv inj)
+right-inj-inversion² {gH = ‵ ι} wf (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ★⇒★} (sv-cast sv inj)
+right-inj-inversion² {gH = ★⇒★} wf (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ∀★} (sv-cast sv inj)
+right-inj-inversion² {gH = ∀★} wf (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
 
 -- Source-only function cast: the premise components rebuild the
 -- premise-level tag obligation.
-right-inj-inversion² {gH = ★⇒★} (sv-cast sv fun)
+right-inj-inversion² {gH = ★⇒★} wf (sv-cast sv fun)
     vN (CTI2.cast⊑² {p = ⇒⊑★ pA pB} c prem q₀) (⇒⊑⇒ qA qB) =
   CTI2.cast⊑² c
-    (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ＇ Y} (sv-cast sv fun)
+right-inj-inversion² {gH = ＇ Y} wf (sv-cast sv fun)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ‵ ι} (sv-cast sv fun)
+right-inj-inversion² {gH = ‵ ι} wf (sv-cast sv fun)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ∀★} (sv-cast sv fun)
+right-inj-inversion² {gH = ∀★} wf (sv-cast sv fun)
   vN (CTI2.cast⊑² c prem q₀) ()
 
 -- Source-only universal cast: chase the tag through the cast with the
 -- embedded consistency evidence.
-right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (all {c = c₁}))
+right-inj-inversion² {W = W} {gH = gH} wf (sv-cast sv (all {c = c₁}))
     vN (CTI2.cast⊑² {p = p₀} .(∀ᶜ c₁) prem q₀) q =
   CTI2.cast⊑² (∀ᶜ c₁)
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² wf sv vN prem
       (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH) nonstar-∀
         (C.renameᵐᶜ (ηᴸʷ W) (∀ᶜ c₁)) p₀ q₀ q))
     q
 
 -- Source-only generalization cast: same, with the gen tag's source.
-right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (genᵥ A≢★ safe))
+right-inj-inversion² {W = W} {gH = gH} wf (sv-cast sv (genᵥ A≢★ safe))
     vN (CTI2.cast⊑² {p = p₀} c prem q₀) q =
   CTI2.cast⊑² c
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² wf sv vN prem
       (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH)
         (C.renameNonStar (toRenameᵗ (ηᴸʷ W)) (nonstar-from-≢★ A≢★))
         (C.renameᵐᶜ (ηᴸʷ W) c) p₀ q₀ q))
@@ -631,42 +668,42 @@ right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (genᵥ A≢★ safe))
 
 -- Type abstraction against a non-∀ ground: only the ∀⊑ view is
 -- possible, and its body is exactly a left-only lifted premise.
-right-inj-inversion² {W = W} {gH = ＇ Y} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ＇ Y} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ‵ ι} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ‵ ι} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ★⇒★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ★ ⇒ ★} body))
     (∀⊑ Anv′ z∈A′ body)
 
 -- Type abstraction against the ∀★ ground.  The Λ⊑² occurrence premise
 -- exposes the body's head, which rules out bot-elim, refutes ∀⊑∀ by
 -- occurrence preservation, and leaves the ∀⊑ rebuild.
-right-inj-inversion² {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {gH = ∀★} wf (sv-Λ sv)
   vN (CTI2.Λ⊑² () var-∈ liftγ vV M′⊢ prem q₀) q
-right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-left z∈) liftγ vV
       (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV N⊢
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
@@ -674,15 +711,15 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
            (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
            (∈-fun-left z∈))
 ... | ()
-right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-right z∉ z∈) liftγ vV
       (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV N⊢
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
@@ -690,15 +727,15 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
            (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
            (∈-fun-right z∉ z∈))
 ... | ()
-right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv (∈-all z∈) liftγ vV
       (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV N⊢
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
     vN (CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
@@ -710,35 +747,77 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
 -- Function-shaped reveal: the premise's ⇒⊑★ components rebuild the
 -- premise-level tag obligation, and by ⊑-unique it does not matter
 -- that this inhabitant differs from any other.
-right-inj-inversion² {gH = ★⇒★} (sv-reveal-fun sv)
-    vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} mono rb sc ⊢c prem q₀)
+right-inj-inversion² {gH = ★⇒★} wf (sv-reveal-fun sv)
+    vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} mono CTI2.rebase-idᴸ
+      sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
-  CTI2.reveal⊑² mono rb sc ⊢c
-    (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
+  CTI2.reveal⊑² mono CTI2.rebase-idᴸ sc ⊢c
+    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ＇ Y} (sv-reveal-fun sv)
+right-inj-inversion² {gH = ★⇒★} wf (sv-reveal-fun sv)
+    vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} mono
+      (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c prem q₀)
+    (⇒⊑⇒ qA qB) =
+  CTI2.reveal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c
+    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-fun sv)
+    vN (CTI2.reveal⊑² {W′ = W′} {p = ⇒⊑★ pA pB} mono
+      (CTI2.rebase-varᴸ rb) sc ⊢c prem q₀)
+    (⇒⊑⇒ qA qB) =
+  CTI2.reveal⊑²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt WD.decay-refl (WD.honestify-decay {W = W′}) rb))
+    (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc) ⊢c
+    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+      (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
+      (WD.decay⊑ᵂ (WD.honestify-decay {W = W′}) (⇒⊑⇒ pA pB)))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {gH = ＇ Y} wf (sv-reveal-fun sv)
   vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ‵ ι} (sv-reveal-fun sv)
+right-inj-inversion² {gH = ‵ ι} wf (sv-reveal-fun sv)
   vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ∀★} (sv-reveal-fun sv)
+right-inj-inversion² {gH = ∀★} wf (sv-reveal-fun sv)
   vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
 
 -- Function-shaped conceal: same construction.
-right-inj-inversion² {gH = ★⇒★} (sv-conceal-fun sv)
-    vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} mono rb sc ⊢c prem q₀)
+right-inj-inversion² {gH = ★⇒★} wf (sv-conceal-fun sv)
+    vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} mono CTI2.rebase-idᴸ
+      sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
-  CTI2.conceal⊑² mono rb sc ⊢c
-    (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
+  CTI2.conceal⊑² mono CTI2.rebase-idᴸ sc ⊢c
+    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ＇ Y} (sv-conceal-fun sv)
+right-inj-inversion² {gH = ★⇒★} wf (sv-conceal-fun sv)
+    vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} mono
+      (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c prem q₀)
+    (⇒⊑⇒ qA qB) =
+  CTI2.conceal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c
+    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-fun sv)
+    vN (CTI2.conceal⊑² {W′ = W′} {p = ⇒⊑★ pA pB} mono
+      (CTI2.rebase-varᴸ rb) sc ⊢c prem q₀)
+    (⇒⊑⇒ qA qB) =
+  CTI2.conceal⊑²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt (WD.honestify-decay {W = W′}) WD.decay-refl rb))
+    (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc) ⊢c
+    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+      (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
+      (WD.decay⊑ᵂ (WD.honestify-decay {W = W′}) (⇒⊑⇒ pA pB)))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {gH = ＇ Y} wf (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ‵ ι} (sv-conceal-fun sv)
+right-inj-inversion² {gH = ‵ ι} wf (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ∀★} (sv-conceal-fun sv)
+right-inj-inversion² {gH = ∀★} wf (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
 
 -- Type applications are not spine values.
-right-inj-inversion² () vN (CTI2.•⊑² _ _ _ _) q
+right-inj-inversion² wf () vN (CTI2.•⊑² _ _ _ _) q
 
 ------------------------------------------------------------------------
 -- Identity-pivot universal wrappers
@@ -756,6 +835,7 @@ right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
     {c : Conv↑ (suc Δᴸ) A B}
     {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
     {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.WFWorld W
   → SpineValue V
   → Value N
   → CTI2.SameCtx γ γ′
@@ -765,9 +845,9 @@ right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
   → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
   → W ∣ γ ⊢² V ↑ `∀↑ c ⊑ N ∶ q
 right-inj-reveal-all-id² {W = W} {A = A} {B = B}
-    {H = H} {c = c} sv vN sc c⊢ prem q =
+    {H = H} {c = c} wf sv vN sc c⊢ prem q =
   CTI2.reveal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² wf sv vN prem
       (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
         (sym (cong `∀ (pivot-id-endpoints↑ c⊢))) q))
     q
@@ -779,6 +859,7 @@ right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
     {c : Conv↓ (suc Δᴸ) A B}
     {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
     {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.WFWorld W
   → SpineValue V
   → Value N
   → CTI2.SameCtx γ γ′
@@ -788,9 +869,9 @@ right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
   → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
   → W ∣ γ ⊢² V ↓ `∀↓ c ⊑ N ∶ q
 right-inj-conceal-all-id² {W = W} {A = A} {B = B}
-    {H = H} {c = c} sv vN sc c⊢ prem q =
+    {H = H} {c = c} wf sv vN sc c⊢ prem q =
   CTI2.conceal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
-    (right-inj-inversion² sv vN prem
+    (right-inj-inversion² wf sv vN prem
       (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
         (sym (cong `∀ (pivot-id-endpoints↓ c⊢))) q))
     q

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -13,23 +13,21 @@ module proof.DGG.ExtraCastRight2 where
 --     zero-change and one-keep world extensions.
 --   * Stage 2: the right-injection inversion lemma, proved for spine
 --     values: constants, lambdas, type abstractions, inert casts, and
---     function-shaped reveal/conceal wrappers.  Because obligations
---     are propositions (proof.Imprecision.⊑-unique), the free q of
---     the wrapper rules carries no information beyond its type, and
---     extending to ∀-shaped wrappers is a type-level inhabitation
---     question; see SpineValue for what remains.
+--     function- and ∀-shaped reveal/conceal wrappers.  Because
+--     obligations are propositions (proof.Imprecision.⊑-unique),
+--     the free q of the wrapper rules carries no information beyond
+--     its type; TagTransport supplies the universal-wrapper obligation.
 --   * Binder-lifted world/rebase lemmas support the ∀-shaped frontier.
---     The identity-pivot universal reveal and conceal subcases are complete;
---     their conversion endpoints are equal and need no rebasing.
+--     Identity-pivot universal wrappers have equal conversion endpoints;
+--     indexed pivots use the TagTransport occurrence lemmas.
 --   * The inversion carries a WFWorld hypothesis and threads it by
 --     decay: var-rebased wrapper cases move their premises into the
 --     honestified premise world (WorldDecay/TermImpDecay) before
 --     recursing, which is the general form of the counterexample
---     repair recorded in ExtraCastRight2Counterexample.  The next
---     frontiers are the ∀-shaped wrappers (proof.DGG.TagTransport has
---     the obligation transports ready) and the bare seal, whose
---     boundary decomposition is seal-tag-boundary-view² and whose
---     inner extraction still needs a seal-peeling companion lemma.
+--     repair recorded in ExtraCastRight2Counterexample.  The remaining
+--     frontier is the bare seal, whose boundary decomposition is
+--     seal-tag-boundary-view² and whose inner extraction still needs a
+--     seal-peeling companion lemma.
 --   * Version-2 pay-offs visible here: no renaming wrapper around the
 --     relation, the Λ⊑² case recurses with the target data unchanged,
 --     and the ground lemmas of proof.ImprecisionConsistency apply
@@ -61,6 +59,7 @@ import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CastTermImprecision2Typing as CTI2T
 import proof.DGG.WorldDecay as WD
 import proof.DGG.TermImpDecay as TD
+import proof.DGG.TagTransport as TT
 open import proof.DGG.ConvImp using
   (pivot-id-endpoints↑; pivot-id-endpoints↓)
 open CTI2 using
@@ -537,16 +536,10 @@ seal-tag-boundary-view² rb vN M↓X⊑N! q
 -- Stage 2: right-injection inversion for spine values
 ------------------------------------------------------------------------
 
--- Values whose spine contains no ∀-shaped conversion wrapper and no
--- bare seal.  Function-shaped reveal and conceal wrappers are fine:
--- their pre-conversion tag obligation rebuilds from the ⇒⊑★ view of
--- the premise index, so no transport along the conversion is needed.
--- Since obligations are propositions (proof.Imprecision.⊑-unique),
--- extending to the remaining wrappers is a type-level inhabitation
--- question: an obligation-transport lemma along the pivot-indexed
--- conversion typing.  Its ∀-cases need occurrence transport along
--- conversions.  Until that lemma exists, ∀-shaped wrappers are open.
--- Bare seals are excluded for a stronger reason: the checked
+-- Values whose spine contains no bare seal.  Function-shaped reveal and
+-- conceal wrappers rebuild their pre-conversion tag obligations directly;
+-- ∀-shaped wrappers transport those obligations via TagTransport.
+-- Bare seals remain excluded for a stronger reason: the checked
 -- ExtraCastRight2Counterexample refutes unrestricted relational inversion.
 
 data SpineValue {Δ : TyCtx} : Term Δ → Set where
@@ -566,6 +559,12 @@ data SpineValue {Δ : TyCtx} : Term Δ → Set where
   sv-conceal-fun : ∀ {V} {A A′ B B′ : Ty Δ}
       {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
     → SpineValue V → SpineValue (V ↓ (c ↦↓ d))
+
+  sv-reveal-all : ∀ {V} {A B : Ty (suc Δ)} {c : Conv↑ (suc Δ) A B}
+    → SpineValue V → SpineValue (V ↑ `∀↑ c)
+
+  sv-conceal-all : ∀ {V} {A B : Ty (suc Δ)} {c : Conv↓ (suc Δ) A B}
+    → SpineValue V → SpineValue (V ↓ `∀↓ c)
 
 -- Threading mark-honesty and decay through the inversion.  The
 -- inversion's recursion may enter a wrapper's premise world, which
@@ -599,6 +598,42 @@ liftWorldLeft-WF wf (Fin.suc Xᴸ) eq | Xᴿ , al =
 -- If a spine value is related to a tagged target value, the tag can be
 -- peeled off the target at any obligation for the tag's ground type.
 -- The world is required to be mark-honest; the seal cases depend on it.
+-- The identity-wrapper helpers are declared first so the inversion can
+-- delegate to their proof bodies below.
+
+right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
+    {V : Term Δᴸ} {N : Term Δᴿ}
+    {A B : Ty (suc Δᴸ)} {H : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {c : Conv↑ (suc Δᴸ) A B}
+    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
+    {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.WFWorld W
+  → SpineValue V
+  → Value N
+  → CTI2.SameCtx γ γ′
+  → store-lift (sourceStoreʷ W) CTI2.⊢↑[ nothing ] c
+  → W ∣ γ′ ⊢² V
+      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
+  → W ∣ γ ⊢² V ↑ `∀↑ c ⊑ N ∶ q
+
+right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
+    {V : Term Δᴸ} {N : Term Δᴿ}
+    {A B : Ty (suc Δᴸ)} {H : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {c : Conv↓ (suc Δᴸ) A B}
+    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
+    {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.WFWorld W
+  → SpineValue V
+  → Value N
+  → CTI2.SameCtx γ γ′
+  → store-lift (sourceStoreʷ W) CTI2.⊢↓[ nothing ] c
+  → W ∣ γ′ ⊢² V
+      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
+  → W ∣ γ ⊢² V ↓ `∀↓ c ⊑ N ∶ q
 
 right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {γ : CtxImp W}
@@ -816,6 +851,196 @@ right-inj-inversion² {gH = ‵ ι} wf (sv-conceal-fun sv)
 right-inj-inversion² {gH = ∀★} wf (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
 
+-- Universal reveal: transport the requested tag obligation through the
+-- body conversion.  Variable rebases recurse in the honestified world.
+right-inj-inversion² wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² mono CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
+      prem q₀) q =
+  right-inj-reveal-all-id² wf sv vN sc c⊢ prem q
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  CTI2.reveal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+    (CTI2.⊢↑-∀ˣ c⊢)
+    (right-inj-inversion² wf sv vN prem
+      (TT.transport↑-∀-fun c⊢
+        (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q))
+    q
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  CTI2.reveal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+    (CTI2.⊢↑-∀ˣ c⊢)
+    (right-inj-inversion² wf sv vN prem
+      (TT.transport↑-∀-all c⊢
+        (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q))
+    q
+right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↑-∀-ι-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↑-∀-var-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  CTI2.reveal⊑²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono
+      (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt WD.decay-refl (WD.honestify-decay {W = W′})
+        rb))
+    (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
+    (CTI2.⊢↑-∀ˣ c⊢)
+    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+      (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
+      (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
+        (TT.transport↑-∀-fun c⊢
+          (toRenameᵗ-injective (ηᴸʷ W′))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q)))
+    q
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  CTI2.reveal⊑²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono
+      (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt WD.decay-refl (WD.honestify-decay {W = W′})
+        rb))
+    (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
+    (CTI2.⊢↑-∀ˣ c⊢)
+    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+      (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
+      (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
+        (TT.transport↑-∀-all c⊢
+          (toRenameᵗ-injective (ηᴸʷ W′))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q)))
+    q
+right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↑-∀-ι-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W′))
+      (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-reveal-all sv) vN
+    (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↑-∀-var-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W′))
+      (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+
+-- Universal conceal: the dual transport has the same obligations, while
+-- the variable-rebase decay uses conceal's opposite rebase orientation.
+right-inj-inversion² wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² mono CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
+      prem q₀) q =
+  right-inj-conceal-all-id² wf sv vN sc c⊢ prem q
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  CTI2.conceal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+    (CTI2.⊢↓-∀ˣ c⊢)
+    (right-inj-inversion² wf sv vN prem
+      (TT.transport↓-∀-fun c⊢
+        (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q))
+    q
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  CTI2.conceal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+    (CTI2.⊢↓-∀ˣ c⊢)
+    (right-inj-inversion² wf sv vN prem
+      (TT.transport↓-∀-all c⊢
+        (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q))
+    q
+right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↓-∀-ι-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↓-∀-var-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  CTI2.conceal⊑²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono
+      (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt (WD.honestify-decay {W = W′}) WD.decay-refl
+        rb))
+    (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
+    (CTI2.⊢↓-∀ˣ c⊢)
+    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+      (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
+      (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
+        (TT.transport↓-∀-fun c⊢
+          (toRenameᵗ-injective (ηᴸʷ W′))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q)))
+    q
+right-inj-inversion² {W = W} {gH = ∀★} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  CTI2.conceal⊑²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono
+      (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt (WD.honestify-decay {W = W′}) WD.decay-refl
+        rb))
+    (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
+    (CTI2.⊢↓-∀ˣ c⊢)
+    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+      (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
+      (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
+        (TT.transport↓-∀-all c⊢
+          (toRenameᵗ-injective (ηᴸʷ W′))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q)))
+    q
+right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↓-∀-ι-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W′))
+      (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-conceal-all sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
+      (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+  ⊥-elim
+    (TT.transport↓-∀-var-⊥ c⊢
+      (toRenameᵗ-injective (ηᴸʷ W′))
+      (toRenameᵗ-injective (ηᴸʷ W))
+      p₀ q)
+
 -- Type applications are not spine values.
 right-inj-inversion² wf () vN (CTI2.•⊑² _ _ _ _) q
 
@@ -828,22 +1053,6 @@ right-inj-inversion² wf () vN (CTI2.•⊑² _ _ _ _) q
 -- wrapper world is definitionally unchanged, so ordinary index transport
 -- exposes the recursive injection obligation.
 
-right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
-    {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
-    {V : Term Δᴸ} {N : Term Δᴿ}
-    {A B : Ty (suc Δᴸ)} {H : Ty Δᴿ} {ν : Env∼ Δᴿ}
-    {c : Conv↑ (suc Δᴸ) A B}
-    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
-    {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
-  → CTI2.WFWorld W
-  → SpineValue V
-  → Value N
-  → CTI2.SameCtx γ γ′
-  → store-lift (sourceStoreʷ W) CTI2.⊢↑[ nothing ] c
-  → W ∣ γ′ ⊢² V
-      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
-  → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
-  → W ∣ γ ⊢² V ↑ `∀↑ c ⊑ N ∶ q
 right-inj-reveal-all-id² {W = W} {A = A} {B = B}
     {H = H} {c = c} wf sv vN sc c⊢ prem q =
   CTI2.reveal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
@@ -852,22 +1061,6 @@ right-inj-reveal-all-id² {W = W} {A = A} {B = B}
         (sym (cong `∀ (pivot-id-endpoints↑ c⊢))) q))
     q
 
-right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
-    {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
-    {V : Term Δᴸ} {N : Term Δᴿ}
-    {A B : Ty (suc Δᴸ)} {H : Ty Δᴿ} {ν : Env∼ Δᴿ}
-    {c : Conv↓ (suc Δᴸ) A B}
-    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
-    {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
-  → CTI2.WFWorld W
-  → SpineValue V
-  → Value N
-  → CTI2.SameCtx γ γ′
-  → store-lift (sourceStoreʷ W) CTI2.⊢↓[ nothing ] c
-  → W ∣ γ′ ⊢² V
-      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
-  → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
-  → W ∣ γ ⊢² V ↓ `∀↓ c ⊑ N ∶ q
 right-inj-conceal-all-id² {W = W} {A = A} {B = B}
     {H = H} {c = c} wf sv vN sc c⊢ prem q =
   CTI2.conceal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -10,11 +10,12 @@ module proof.DGG.ExtraCastRight2 where
 --     source type: A : Ty Δᴸ is untouched by target-side allocation,
 --     and only the world and the target types evolve.
 --   * Stage 2: the right-injection inversion lemma, proved for spine
---     values (values built from constants, lambdas, type abstractions,
---     and inert casts).  Reveal- and conceal-wrapped values are the
---     open frontier: inverting through a wrapper must reconstruct the
---     pre-conversion obligation from the post-conversion one, which
---     the free-q wrapper rules do not support locally; see SpineValue.
+--     values: constants, lambdas, type abstractions, inert casts, and
+--     function-shaped reveal/conceal wrappers.  Because obligations
+--     are propositions (proof.Imprecision.⊑-unique), the free q of
+--     the wrapper rules carries no information beyond its type, and
+--     extending to ∀-shaped and seal wrappers is a type-level
+--     inhabitation question; see SpineValue for what remains.
 --   * Version-2 pay-offs visible here: no renaming wrapper around the
 --     relation, the Λ⊑² case recurses with the target data unchanged,
 --     and the ground lemmas of proof.ImprecisionConsistency apply
@@ -34,7 +35,7 @@ open import Consistency using
   (Env∼; _⊢_∼_; _⊢_∼★; _↪ᵗ_; keep; skip; toRenameᵗ;
    _!; ∀ᶜ_; gen_; inst_)
 import Consistency as C
-open import Conversion using (Conv↑; Conv↓; `∀↑_; `∀↓_)
+open import Conversion using (Conv↑; Conv↓; `∀↑_; `∀↓_; _↦↑_; _↦↓_)
 open import Imprecision
 open import Primitives using (Const)
 open import CastTerms
@@ -194,12 +195,17 @@ liftWorldLeft-⊑ᵂ {W = W} {A = A} {B = B} body =
 -- Stage 2: right-injection inversion for spine values
 ------------------------------------------------------------------------
 
--- Values whose spine contains no reveal or conceal wrapper.  Inverting
--- through a wrapper must rebuild the pre-conversion obligation from
--- the post-conversion one; with the free-q wrapper rules that needs
--- representation-substitution coherence the relation does not yet
--- record, so wrapped values are excluded here and left as the open
--- frontier.
+-- Values whose spine contains no ∀-shaped conversion wrapper and no
+-- bare seal.  Function-shaped reveal and conceal wrappers are fine:
+-- their pre-conversion tag obligation rebuilds from the ⇒⊑★ view of
+-- the premise index, so no transport along the conversion is needed.
+-- Since obligations are propositions (proof.Imprecision.⊑-unique),
+-- extending to the remaining wrappers is a type-level inhabitation
+-- question: an obligation-transport lemma along the pivot-indexed
+-- conversion typing.  Its ∀-cases need occurrence transport along
+-- conversions, and its seal case needs rebase-onlyᴸ to record that no
+-- target variable sits at the pivot's center.  Until that lemma
+-- exists, ∀-shaped and seal wrappers are the open frontier.
 
 data SpineValue {Δ : TyCtx} : Term Δ → Set where
   sv-ƛ : (N : Term Δ) → SpineValue (ƛ N)
@@ -210,6 +216,14 @@ data SpineValue {Δ : TyCtx} : Term Δ → Set where
 
   sv-cast : ∀ {V} {μ : Env∼ Δ} {A B : Ty Δ} {c : μ ⊢ A ∼ B}
     → SpineValue V → Inert c → SpineValue (V ⟨ c ⟩)
+
+  sv-reveal-fun : ∀ {V} {A A′ B B′ : Ty Δ}
+      {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
+    → SpineValue V → SpineValue (V ↑ (c ↦↑ d))
+
+  sv-conceal-fun : ∀ {V} {A A′ B B′ : Ty Δ}
+      {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
+    → SpineValue V → SpineValue (V ↓ (c ↦↓ d))
 
 -- If a spine value is related to a tagged target value, the tag can be
 -- peeled off the target at any obligation for the tag's ground type.
@@ -353,7 +367,33 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
            (∈-all z∈))
 ... | ()
 
--- Wrapped values and type applications are not spine values.
-right-inj-inversion² () (CTI2.reveal⊑² _ _ _ _ _) q
-right-inj-inversion² () (CTI2.conceal⊑² _ _ _ _ _) q
+-- Function-shaped reveal: the premise's ⇒⊑★ components rebuild the
+-- premise-level tag obligation, and by ⊑-unique it does not matter
+-- that this inhabitant differs from any other.
+right-inj-inversion² {gH = ★⇒★} (sv-reveal-fun sv)
+    (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀) (⇒⊑⇒ qA qB) =
+  CTI2.reveal⊑² rb sc ⊢c
+    (right-inj-inversion² sv prem (⇒⊑⇒ pA pB))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {gH = ＇ Y} (sv-reveal-fun sv)
+  (CTI2.reveal⊑² _ _ _ _ _) ()
+right-inj-inversion² {gH = ‵ ι} (sv-reveal-fun sv)
+  (CTI2.reveal⊑² _ _ _ _ _) ()
+right-inj-inversion² {gH = ∀★} (sv-reveal-fun sv)
+  (CTI2.reveal⊑² _ _ _ _ _) ()
+
+-- Function-shaped conceal: same construction.
+right-inj-inversion² {gH = ★⇒★} (sv-conceal-fun sv)
+    (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀) (⇒⊑⇒ qA qB) =
+  CTI2.conceal⊑² rb sc ⊢c
+    (right-inj-inversion² sv prem (⇒⊑⇒ pA pB))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {gH = ＇ Y} (sv-conceal-fun sv)
+  (CTI2.conceal⊑² _ _ _ _ _) ()
+right-inj-inversion² {gH = ‵ ι} (sv-conceal-fun sv)
+  (CTI2.conceal⊑² _ _ _ _ _) ()
+right-inj-inversion² {gH = ∀★} (sv-conceal-fun sv)
+  (CTI2.conceal⊑² _ _ _ _ _) ()
+
+-- Type applications are not spine values.
 right-inj-inversion² () (CTI2.•⊑² _ _ _ _) q

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -1,0 +1,359 @@
+module proof.DGG.ExtraCastRight2 where
+
+-- File Charter:
+--   * Ports the extra-cast-on-the-right development to the version-2
+--     cast-term imprecision relation, in stages.
+--   * Stage 1: the statements of extra-cast-right and its inst
+--     catch-up companion as Set-level definitions, together with the
+--     world-extension interface their conclusions need.  Compared with
+--     version 1 the statement carries no transport function for the
+--     source type: A : Ty Δᴸ is untouched by target-side allocation,
+--     and only the world and the target types evolve.
+--   * Stage 2: the right-injection inversion lemma, proved for spine
+--     values (values built from constants, lambdas, type abstractions,
+--     and inert casts).  Reveal- and conceal-wrapped values are the
+--     open frontier: inverting through a wrapper must reconstruct the
+--     pre-conversion obligation from the post-conversion one, which
+--     the free-q wrapper rules do not support locally; see SpineValue.
+--   * Version-2 pay-offs visible here: no renaming wrapper around the
+--     relation, the Λ⊑² case recurses with the target data unchanged,
+--     and the ground lemmas of proof.ImprecisionConsistency apply
+--     directly to world-embedded obligations.
+
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (suc)
+import Data.Fin as Fin
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans)
+  renaming (subst to subst≡)
+
+open import Types
+open import TyStore using (TyStore)
+open import Consistency using
+  (Env∼; _⊢_∼_; _⊢_∼★; _↪ᵗ_; keep; skip; toRenameᵗ;
+   _!; ∀ᶜ_; gen_; inst_)
+import Consistency as C
+open import Conversion using (Conv↑; Conv↓; `∀↑_; `∀↓_)
+open import Imprecision
+open import Primitives using (Const)
+open import CastTerms
+open import Reduction
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; ηᴸʷ; ηᴿʷ; impEnvʷ; sourceStoreʷ; targetStoreʷ; embedᴿ;
+   _⊑ᵂ⟨_⟩_; CtxImp; ctx-imp; _∣_⊢²_⊑_∶_)
+open import proof.ImprecisionConsistency using
+  (ground-cast-source⊑; source-occurs-target; rename-occurs;
+   ext-injective; toRenameᵗ-injective; nonstar-from-≢★)
+import proof.Imprecision as PI
+open import proof.TypeInTermSubst using (toRename-keep-eq)
+
+------------------------------------------------------------------------
+-- Target polymorphic value views (for the inst catch-up statement)
+------------------------------------------------------------------------
+
+data AllValueView {Δ : TyCtx} (V : Term Δ) : Set where
+  allv-Λ : ∀ {W}
+    → Value W
+    → V ≡ Λ W
+    → AllValueView V
+
+  allv-∀ : ∀ {μ : Env∼ Δ} {W} {A B : Ty (suc Δ)}
+      {c : C.extᵐ μ ⊢ A ∼ B}
+    → Value W
+    → V ≡ W ⟨ ∀ᶜ c ⟩
+    → AllValueView V
+
+  allv-gen : ∀ {μ : Env∼ Δ} {W} {A : Ty Δ} {B : Ty (suc Δ)}
+      {c : C.genᵐ μ ⊢ ⇑ᵗ A ∼ B}
+      ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : Fin.zero ∈ᵗ B ⦄
+    → Value W
+    → (A≢★ : A ≢ ★)
+    → GenSafe c
+    → V ≡ W ⟨ (gen c) A≢★ ⟩
+    → AllValueView V
+
+  allv-reveal : ∀ {W} {A B : Ty (suc Δ)} {c : Conv↑ (suc Δ) A B}
+    → Value W
+    → V ≡ W ↑ `∀↑ c
+    → AllValueView V
+
+  allv-conceal : ∀ {W} {A B : Ty (suc Δ)} {c : Conv↓ (suc Δ) A B}
+    → Value W
+    → V ≡ W ↓ `∀↓ c
+    → AllValueView V
+
+------------------------------------------------------------------------
+-- Stage 1: statements
+------------------------------------------------------------------------
+
+-- A right-side world extension: the source store is untouched, the
+-- target store follows the machine's store changes, and every type
+-- obligation transports with the change.
+
+record WorldExtendᴿ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} (χs : StoreChanges Δᴿ Δᴿ′)
+    (W : World Δᴸ Δᴿ Δ) (W′ : World Δᴸ Δᴿ′ Δ′) : Set where
+  field
+    sourceStore-kept : sourceStoreʷ W′ ≡ sourceStoreʷ W
+    targetStore-follows : targetStoreʷ W′ ≡ (χs ▶ˢ targetStoreʷ W)
+    transport⊑ᵂ : ∀ {A : Ty Δᴸ} {C : Ty Δᴿ}
+      → A ⊑ᵂ⟨ W ⟩ C
+      → A ⊑ᵂ⟨ W′ ⟩ (χs ▶ᵗ C)
+
+open WorldExtendᴿ public
+
+mapCtxᴿ : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} {χs : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
+  → WorldExtendᴿ χs W W′
+  → CtxImp W
+  → CtxImp W′
+mapCtxᴿ ext [] = []
+mapCtxᴿ {χs = χs} ext (ctx-imp A B p ∷ γ) =
+  ctx-imp A (χs ▶ᵗ B) (transport⊑ᵂ ext p) ∷ mapCtxᴿ ext γ
+
+-- Extra cast on the right: if related values face an extra target
+-- cast, the target alone reduces to a value in an extended world that
+-- still relates them.
+
+ExtraCastRight² : Set
+ExtraCastRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ M′ ∶ p
+  → Value M
+  → Value M′
+  → (c′ : ν ⊢ B ∼ B′)
+  → (q : A ⊑ᵂ⟨ W ⟩ B′)
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ ext ∈ WorldExtendᴿ χs W W′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ]
+      (Value N′
+        × (M′ ⟨ c′ ⟩ —↠[ χs ] N′)
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+
+-- The inst catch-up companion: instantiating a polymorphic target
+-- value allocates on the right and reduces to a value related in the
+-- extended world.
+
+InstCatchupRight² : Set
+InstCatchupRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty (suc Δᴿ)} {B′ : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ `∀ B}
+  → W ∣ γ ⊢² M ⊑ M′ ∶ p
+  → Value M
+  → Value M′
+  → AllValueView M′
+  → (c′ : C.instᵐ ν ⊢ B ∼ ⇑ᵗ B′)
+  → ⦃ Bnv : NonVar B ⦄
+  → ⦃ zero∈B : Fin.zero ∈ᵗ B ⦄
+  → (B′≢★ : B′ ≢ ★)
+  → (q : A ⊑ᵂ⟨ W ⟩ B′)
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ ext ∈ WorldExtendᴿ χs W W′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ]
+      (Value N′
+        × (M′ ⟨ (inst c′) B′≢★ ⟩ —↠[ χs ] N′)
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+
+------------------------------------------------------------------------
+-- Stage 2: helpers
+------------------------------------------------------------------------
+
+renameᵗ-skip-eq : ∀ {Δᴿ Δ} (η : Δᴿ ↪ᵗ Δ) (B : Ty Δᴿ)
+  → renameᵗ (toRenameᵗ (skip η)) B ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) B)
+renameᵗ-skip-eq η B =
+  trans (renameᵗ-cong B (λ X → refl))
+    (sym (renameᵗ-comp (toRenameᵗ η) Fin.suc B))
+
+-- The ∀⊑ view of a world obligation for `∀ A against B is exactly a
+-- premise for the left-only lifted world: the instᵐ environment is the
+-- lifted world's environment, and B's embedding gains one shift.
+
+liftWorldLeft-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {A : Ty (suc Δᴸ)} {B : Ty Δᴿ}
+  → instᵐ (impEnvʷ W)
+      ⊢ renameᵗ (extᵗ (toRenameᵗ (ηᴸʷ W))) A ⊑ ⇑ᵗ (embedᴿ W B)
+  → A ⊑ᵂ⟨ CTI2.liftWorldLeft X⊑★ W ⟩ B
+liftWorldLeft-⊑ᵂ {W = W} {A = A} {B = B} body =
+  subst≡
+    (λ T → extendᵐ X⊑★ (impEnvʷ W) ⊢
+       T ⊑ renameᵗ (toRenameᵗ (skip (ηᴿʷ W))) B)
+    (sym (renameᵗ-cong A (toRename-keep-eq (ηᴸʷ W))))
+    (subst≡
+      (λ T → extendᵐ X⊑★ (impEnvʷ W) ⊢
+         renameᵗ (extᵗ (toRenameᵗ (ηᴸʷ W))) A ⊑ T)
+      (sym (renameᵗ-skip-eq (ηᴿʷ W) B))
+      body)
+
+------------------------------------------------------------------------
+-- Stage 2: right-injection inversion for spine values
+------------------------------------------------------------------------
+
+-- Values whose spine contains no reveal or conceal wrapper.  Inverting
+-- through a wrapper must rebuild the pre-conversion obligation from
+-- the post-conversion one; with the free-q wrapper rules that needs
+-- representation-substitution coherence the relation does not yet
+-- record, so wrapped values are excluded here and left as the open
+-- frontier.
+
+data SpineValue {Δ : TyCtx} : Term Δ → Set where
+  sv-ƛ : (N : Term Δ) → SpineValue (ƛ N)
+
+  sv-Λ : ∀ {V} → SpineValue V → SpineValue (Λ V)
+
+  sv-$ : (κ : Const) → SpineValue ($ κ)
+
+  sv-cast : ∀ {V} {μ : Env∼ Δ} {A B : Ty Δ} {c : μ ⊢ A ∼ B}
+    → SpineValue V → Inert c → SpineValue (V ⟨ c ⟩)
+
+-- If a spine value is related to a tagged target value, the tag can be
+-- peeled off the target at any obligation for the tag's ground type.
+
+right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W}
+    {M : Term Δᴸ} {N : Term Δᴿ} {A : Ty Δᴸ} {H : Ty Δᴿ}
+    {ν : Env∼ Δᴿ}
+    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
+    {cH : ν ⊢ H ∼ H}
+    {p : A ⊑ᵂ⟨ W ⟩ ★}
+  → SpineValue M
+  → W ∣ γ ⊢² M ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → (q : A ⊑ᵂ⟨ W ⟩ H)
+  → W ∣ γ ⊢² M ⊑ N ∶ q
+
+-- Target-only cast: the premise already carries the tag obligation.
+right-inj-inversion² sv (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
+  subst≡ (λ r → _ ∣ _ ⊢² _ ⊑ _ ∶ r) (PI.⊑-unique p₀ q) prem
+
+-- Paired cast: keep the source cast as a source-only cast.
+right-inj-inversion² sv (CTI2.cast⊑cast² c c′ prem q₀) q =
+  CTI2.cast⊑² c prem q
+
+-- Source-only cast around an injection value: no obligation matches.
+right-inj-inversion² {gH = ＇ Y} (sv-cast sv inj)
+  (CTI2.cast⊑² c prem q₀) ()
+right-inj-inversion² {gH = ‵ ι} (sv-cast sv inj)
+  (CTI2.cast⊑² c prem q₀) ()
+right-inj-inversion² {gH = ★⇒★} (sv-cast sv inj)
+  (CTI2.cast⊑² c prem q₀) ()
+right-inj-inversion² {gH = ∀★} (sv-cast sv inj)
+  (CTI2.cast⊑² c prem q₀) ()
+
+-- Source-only function cast: the premise components rebuild the
+-- premise-level tag obligation.
+right-inj-inversion² {gH = ★⇒★} (sv-cast sv fun)
+    (CTI2.cast⊑² {p = ⇒⊑★ pA pB} c prem q₀) (⇒⊑⇒ qA qB) =
+  CTI2.cast⊑² c
+    (right-inj-inversion² sv prem (⇒⊑⇒ pA pB))
+    (⇒⊑⇒ qA qB)
+right-inj-inversion² {gH = ＇ Y} (sv-cast sv fun)
+  (CTI2.cast⊑² c prem q₀) ()
+right-inj-inversion² {gH = ‵ ι} (sv-cast sv fun)
+  (CTI2.cast⊑² c prem q₀) ()
+right-inj-inversion² {gH = ∀★} (sv-cast sv fun)
+  (CTI2.cast⊑² c prem q₀) ()
+
+-- Source-only universal cast: chase the tag through the cast with the
+-- embedded consistency evidence.
+right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (all {c = c₁}))
+    (CTI2.cast⊑² {p = p₀} .(∀ᶜ c₁) prem q₀) q =
+  CTI2.cast⊑² (∀ᶜ c₁)
+    (right-inj-inversion² sv prem
+      (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH) nonstar-∀
+        (C.renameᵐᶜ (ηᴸʷ W) (∀ᶜ c₁)) p₀ q₀ q))
+    q
+
+-- Source-only generalization cast: same, with the gen tag's source.
+right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (genᵥ A≢★ safe))
+    (CTI2.cast⊑² {p = p₀} c prem q₀) q =
+  CTI2.cast⊑² c
+    (right-inj-inversion² sv prem
+      (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH)
+        (C.renameNonStar (toRenameᵗ (ηᴸʷ W)) (nonstar-from-≢★ A≢★))
+        (C.renameᵐᶜ (ηᴸʷ W) c) p₀ q₀ q))
+    q
+
+-- Type abstraction against a non-∀ ground: only the ∀⊑ view is
+-- possible, and its body is exactly a left-only lifted premise.
+right-inj-inversion² {W = W} {gH = ＇ Y} (sv-Λ sv)
+    (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    (∀⊑ Anv′ z∈A′ body) =
+  CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
+    (right-inj-inversion² sv prem
+      (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ＇ Y} body))
+    (∀⊑ Anv′ z∈A′ body)
+right-inj-inversion² {W = W} {gH = ‵ ι} (sv-Λ sv)
+    (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    (∀⊑ Anv′ z∈A′ body) =
+  CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
+    (right-inj-inversion² sv prem
+      (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ‵ ι} body))
+    (∀⊑ Anv′ z∈A′ body)
+right-inj-inversion² {W = W} {gH = ★⇒★} (sv-Λ sv)
+    (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    (∀⊑ Anv′ z∈A′ body) =
+  CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
+    (right-inj-inversion² sv prem
+      (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ★ ⇒ ★} body))
+    (∀⊑ Anv′ z∈A′ body)
+
+-- Type abstraction against the ∀★ ground.  The Λ⊑² occurrence premise
+-- exposes the body's head, which rules out bot-elim, refutes ∀⊑∀ by
+-- occurrence preservation, and leaves the ∀⊑ rebuild.
+right-inj-inversion² {gH = ∀★} (sv-Λ sv)
+  (CTI2.Λ⊑² () var-∈ liftγ vV M′⊢ prem q₀) q
+right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+    (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-left z∈) liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    (∀⊑ Anv′ z∈A′ body) =
+  CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV N⊢
+    (right-inj-inversion² sv prem
+      (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
+    (∀⊑ Anv′ z∈A′ body)
+right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+    (CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV M′⊢ prem q₀)
+    (∀⊑∀ qbody)
+  with source-occurs-target refl qbody
+         (rename-occurs (extᵗ (toRenameᵗ (ηᴸʷ W)))
+           (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
+           (∈-fun-left z∈))
+... | ()
+right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+    (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-right z∉ z∈) liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    (∀⊑ Anv′ z∈A′ body) =
+  CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV N⊢
+    (right-inj-inversion² sv prem
+      (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
+    (∀⊑ Anv′ z∈A′ body)
+right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+    (CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV M′⊢ prem q₀)
+    (∀⊑∀ qbody)
+  with source-occurs-target refl qbody
+         (rename-occurs (extᵗ (toRenameᵗ (ηᴸʷ W)))
+           (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
+           (∈-fun-right z∉ z∈))
+... | ()
+right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+    (CTI2.Λ⊑² {A = A₀} Anv (∈-all z∈) liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    (∀⊑ Anv′ z∈A′ body) =
+  CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV N⊢
+    (right-inj-inversion² sv prem
+      (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
+    (∀⊑ Anv′ z∈A′ body)
+right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
+    (CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV M′⊢ prem q₀)
+    (∀⊑∀ qbody)
+  with source-occurs-target refl qbody
+         (rename-occurs (extᵗ (toRenameᵗ (ηᴸʷ W)))
+           (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
+           (∈-all z∈))
+... | ()
+
+-- Wrapped values and type applications are not spine values.
+right-inj-inversion² () (CTI2.reveal⊑² _ _ _ _ _) q
+right-inj-inversion² () (CTI2.conceal⊑² _ _ _ _ _) q
+right-inj-inversion² () (CTI2.•⊑² _ _ _ _) q

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -329,7 +329,7 @@ liftRebaseAt {W = W} {W′ = W′} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} {v = v} rb =
         (CTI2.SameRuntime.sourceStore-same (CTI2.RebaseAt.sameRuntime rb)))
       (cong store-lift
         (CTI2.SameRuntime.targetStore-same (CTI2.RebaseAt.sameRuntime rb))))
-    source-off target-off env-same
+    source-off target-off
     (cong Fin.suc (CTI2.RebaseAt.pivotAligned rb))
     (CTI2.store-rep-imp lift-represented)
   where
@@ -387,11 +387,6 @@ liftRebaseAt {W = W} {W′ = W′} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} {v = v} rb =
       (CTI2.RebaseAt.ηᴿ-off-pivot rb
         (λ eq → Y≢ (cong Fin.suc eq)))
 
-  env-same : ∀ Z
-    → impEnvʷ (CTI2.liftWorldBoth v W′) Z
-        ≡ impEnvʷ (CTI2.liftWorldBoth v W) Z
-  env-same Fin.zero = refl
-  env-same (Fin.suc Z) = CTI2.RebaseAt.sameImpEnv rb Z
 
 liftPivot : ∀ {Δ} → Maybe (TyVar Δ) → Maybe (TyVar (suc Δ))
 liftPivot nothing = nothing
@@ -716,31 +711,31 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
 -- premise-level tag obligation, and by ⊑-unique it does not matter
 -- that this inhabitant differs from any other.
 right-inj-inversion² {gH = ★⇒★} (sv-reveal-fun sv)
-    vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀)
+    vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} mono rb sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
-  CTI2.reveal⊑² rb sc ⊢c
+  CTI2.reveal⊑² mono rb sc ⊢c
     (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
 right-inj-inversion² {gH = ＇ Y} (sv-reveal-fun sv)
-  vN (CTI2.reveal⊑² _ _ _ _ _) ()
+  vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
 right-inj-inversion² {gH = ‵ ι} (sv-reveal-fun sv)
-  vN (CTI2.reveal⊑² _ _ _ _ _) ()
+  vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
 right-inj-inversion² {gH = ∀★} (sv-reveal-fun sv)
-  vN (CTI2.reveal⊑² _ _ _ _ _) ()
+  vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
 
 -- Function-shaped conceal: same construction.
 right-inj-inversion² {gH = ★⇒★} (sv-conceal-fun sv)
-    vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀)
+    vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} mono rb sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
-  CTI2.conceal⊑² rb sc ⊢c
+  CTI2.conceal⊑² mono rb sc ⊢c
     (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
 right-inj-inversion² {gH = ＇ Y} (sv-conceal-fun sv)
-  vN (CTI2.conceal⊑² _ _ _ _ _) ()
+  vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
 right-inj-inversion² {gH = ‵ ι} (sv-conceal-fun sv)
-  vN (CTI2.conceal⊑² _ _ _ _ _) ()
+  vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
 right-inj-inversion² {gH = ∀★} (sv-conceal-fun sv)
-  vN (CTI2.conceal⊑² _ _ _ _ _) ()
+  vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
 
 -- Type applications are not spine values.
 right-inj-inversion² () vN (CTI2.•⊑² _ _ _ _) q
@@ -771,7 +766,7 @@ right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
   → W ∣ γ ⊢² V ↑ `∀↑ c ⊑ N ∶ q
 right-inj-reveal-all-id² {W = W} {A = A} {B = B}
     {H = H} {c = c} sv vN sc c⊢ prem q =
-  CTI2.reveal⊑² CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
+  CTI2.reveal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
     (right-inj-inversion² sv vN prem
       (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
         (sym (cong `∀ (pivot-id-endpoints↑ c⊢))) q))
@@ -794,7 +789,7 @@ right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
   → W ∣ γ ⊢² V ↓ `∀↓ c ⊑ N ∶ q
 right-inj-conceal-all-id² {W = W} {A = A} {B = B}
     {H = H} {c = c} sv vN sc c⊢ prem q =
-  CTI2.conceal⊑² CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
+  CTI2.conceal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
     (right-inj-inversion² sv vN prem
       (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
         (sym (cong `∀ (pivot-id-endpoints↓ c⊢))) q))

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -11,9 +11,9 @@ module proof.DGG.ExtraCastRight2 where
 --     and only the world and the target types evolve.
 --     The identity and inert-cast cases are proved directly with reusable
 --     zero-change and one-keep world extensions.
---   * Stage 2: the right-injection inversion lemma, proved for spine
---     values: constants, lambdas, type abstractions, inert casts, and
---     function- and ∀-shaped reveal/conceal wrappers.  Because
+--   * Stage 2: the right-injection inversion lemma, proved for all value
+--     spines: constants, lambdas, type abstractions, inert casts, seals,
+--     and function- and ∀-shaped reveal/conceal wrappers.  Because
 --     obligations are propositions (proof.Imprecision.⊑-unique),
 --     the free q of the wrapper rules carries no information beyond
 --     its type; TagTransport supplies the universal-wrapper obligation.
@@ -24,24 +24,28 @@ module proof.DGG.ExtraCastRight2 where
 --     decay: var-rebased wrapper cases move their premises into the
 --     honestified premise world (WorldDecay/TermImpDecay) before
 --     recursing, which is the general form of the counterexample
---     repair recorded in ExtraCastRight2Counterexample.  The remaining
---     frontier is the bare seal, whose boundary decomposition is
---     seal-tag-boundary-view² and whose inner extraction still needs a
---     seal-peeling companion lemma.
+--     repair recorded in ExtraCastRight2Counterexample.
+--   * Bare-seal inversion is complete modulo OpenStrata: H-walk records
+--     the remaining head walk from the SealPeelProbe analysis, H-absorb
+--     isolates MovedLinkProbe's moved link, and H-Schain isolates
+--     ChainRideProbe's target representation chain.  SealTransfer
+--     supplies the transfer operation modulo its H-multi chain stratum.
 --   * Version-2 pay-offs visible here: no renaming wrapper around the
 --     relation, the Λ⊑² case recurses with the target data unchanged,
 --     and the ground lemmas of proof.ImprecisionConsistency apply
 --     directly to world-embedded obligations.
 
-open import Data.Empty using (⊥-elim)
+open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([]; _∷_)
 open import Data.Nat using (suc)
 import Data.Fin as Fin
 open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; sym; trans; cong)
   renaming (subst to subst≡)
+open import Relation.Nullary using (yes; no)
 
 open import Types
 open import TyStore using (TyStore; store-lift; _∋_⦂_)
@@ -50,7 +54,8 @@ open import Consistency using
    id; _!; ∀ᶜ_; gen_; inst_)
 import Consistency as C
 open import Conversion using
-  (Conv↑; Conv↓; _⊢↓_; `∀↑_; `∀↓_; _↦↑_; _↦↓_; ⊢↓-seal)
+  (Conv↑; Conv↓; _⊢↓_; `∀↑_; `∀↓_; _↦↑_; _↦↓_;
+   ⊢↓-seal)
 open import Imprecision
 open import Primitives using (Const; κℕ; κ𝔹)
 open import CastTerms
@@ -60,6 +65,7 @@ import proof.DGG.CastTermImprecision2Typing as CTI2T
 import proof.DGG.WorldDecay as WD
 import proof.DGG.TermImpDecay as TD
 import proof.DGG.TagTransport as TT
+import proof.DGG.SealPeelToolkit as SPT
 open import proof.DGG.ConvImp using
   (pivot-id-endpoints↑; pivot-id-endpoints↓)
 open CTI2 using
@@ -115,8 +121,9 @@ data AllValueView {Δ : TyCtx} (V : Term Δ) : Set where
 -- target store follows the machine's store changes, and every type
 -- obligation transports with the change.
 
-record WorldExtendᴿ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} (χs : StoreChanges Δᴿ Δᴿ′)
-    (W : World Δᴸ Δᴿ Δ) (W′ : World Δᴸ Δᴿ′ Δ′) : Set where
+record WorldExtendᴿ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    (χs : StoreChanges Δᴿ Δᴿ′) (W : World Δᴸ Δᴿ Δ)
+    (W′ : World Δᴸ Δᴿ′ Δ′) : Set where
   field
     sourceStore-kept : sourceStoreʷ W′ ≡ sourceStoreʷ W
     targetStore-follows : targetStoreʷ W′ ≡ (χs ▶ˢ targetStoreʷ W)
@@ -142,7 +149,8 @@ sameWorldKeepExtendᴿ = record
   ; transport⊑ᵂ = λ p → p
   }
 
-mapCtxᴿ : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} {χs : StoreChanges Δᴿ Δᴿ′}
+mapCtxᴿ : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
     {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
   → WorldExtendᴿ χs W W′
   → CtxImp W
@@ -168,7 +176,8 @@ mapCtxᴿ-keep (ctx-imp A B p ∷ γ) = cong (_ ∷_) (mapCtxᴿ-keep γ)
 -- still relates them.
 
 ExtraCastRight² : Set
-ExtraCastRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+ExtraCastRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W}
     {M : Term Δᴸ} {M′ : Term Δᴿ}
     {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {ν : Env∼ Δᴿ}
     {p : A ⊑ᵂ⟨ W ⟩ B}
@@ -183,14 +192,16 @@ ExtraCastRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp 
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
         × (M′ ⟨ c′ ⟩ —↠[ χs ] N′)
-        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶
+            transport⊑ᵂ ext q))
 
 -- The inst catch-up companion: instantiating a polymorphic target
 -- value allocates on the right and reduces to a value related in the
 -- extended world.
 
 InstCatchupRight² : Set
-InstCatchupRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+InstCatchupRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W}
     {M : Term Δᴸ} {M′ : Term Δᴿ}
     {A : Ty Δᴸ} {B : Ty (suc Δᴿ)} {B′ : Ty Δᴿ} {ν : Env∼ Δᴿ}
     {p : A ⊑ᵂ⟨ W ⟩ `∀ B}
@@ -209,7 +220,8 @@ InstCatchupRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxIm
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
         × (M′ ⟨ (inst c′) B′≢★ ⟩ —↠[ χs ] N′)
-        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶
+            transport⊑ᵂ ext q))
 
 -- Inert target casts are already values, so this direct case of
 -- extra-cast-right neither changes the target store nor the world.
@@ -231,7 +243,8 @@ inert-extra-cast-right² : ∀ {Δᴸ Δᴿ Δ}
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
         × (M′ ⟨ c′ ⟩ —↠[ χs ] N′)
-        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶
+            transport⊑ᵂ ext q))
 inert-extra-cast-right² {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
     {M = M} {M′ = M′}
     M⊑M′ vM vM′ c′ inert q =
@@ -260,7 +273,8 @@ id-extra-cast-right² : ∀ {Δᴸ Δᴿ Δ}
     Σ[ N′ ∈ Term Δᴿ′ ]
       (Value N′
         × (M′ ⟨ id {μ = ν} a ⟩ —↠[ χs ] N′)
-        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶
+            transport⊑ᵂ ext q))
 id-extra-cast-right² {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
     {M = M} {M′ = M′} {p = p} M⊑M′ vM vM′ a q =
   Δᴿ , Reduction.keep ∷ [] , Δ , W , sameWorldKeepExtendᴿ , M′ ,
@@ -270,14 +284,16 @@ id-extra-cast-right² {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
   M′ ∎[]) ,
   subst≡ (λ γ′ → W ∣ γ′ ⊢² M ⊑ M′ ∶ q)
     (sym (mapCtxᴿ-keep γ))
-    (subst≡ (λ r → W ∣ γ ⊢² M ⊑ M′ ∶ r) (PI.⊑-unique p q) M⊑M′)
+    (subst≡ (λ r → W ∣ γ ⊢² M ⊑ M′ ∶ r)
+      (PI.⊑-unique p q) M⊑M′)
 
 ------------------------------------------------------------------------
 -- Stage 2: helpers
 ------------------------------------------------------------------------
 
 renameᵗ-skip-eq : ∀ {Δᴿ Δ} (η : Δᴿ ↪ᵗ Δ) (B : Ty Δᴿ)
-  → renameᵗ (toRenameᵗ (skip η)) B ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) B)
+  → renameᵗ (toRenameᵗ (skip η)) B
+      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) B)
 renameᵗ-skip-eq η B =
   trans (renameᵗ-cong B (λ X → refl))
     (sym (renameᵗ-comp (toRenameᵗ η) Fin.suc B))
@@ -289,7 +305,8 @@ renameᵗ-skip-eq η B =
 liftWorldLeft-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {A : Ty (suc Δᴸ)} {B : Ty Δᴿ}
   → instᵐ (impEnvʷ W)
-      ⊢ renameᵗ (extᵗ (toRenameᵗ (ηᴸʷ W))) A ⊑ ⇑ᵗ (embedᴿ W B)
+      ⊢ renameᵗ (extᵗ (toRenameᵗ (ηᴸʷ W))) A
+        ⊑ ⇑ᵗ (embedᴿ W B)
   → A ⊑ᵂ⟨ CTI2.liftWorldLeft X⊑★ W ⟩ B
 liftWorldLeft-⊑ᵂ {W = W} {A = A} {B = B} body =
   subst≡
@@ -549,11 +566,10 @@ seal-tag-boundary-view² rb vN M↓X⊑N! q
 -- Stage 2: right-injection inversion for spine values
 ------------------------------------------------------------------------
 
--- Values whose spine contains no bare seal.  Function-shaped reveal and
--- conceal wrappers rebuild their pre-conversion tag obligations directly;
--- ∀-shaped wrappers transport those obligations via TagTransport.
--- Bare seals remain excluded for a stronger reason: the checked
--- ExtraCastRight2Counterexample refutes unrestricted relational inversion.
+-- All value spines.  Function-shaped reveal and conceal wrappers rebuild
+-- their pre-conversion tag obligations directly; ∀-shaped wrappers
+-- transport those obligations via TagTransport, and bare seals use the
+-- boundary analysis developed by SealPeelProbe and SealTransfer.
 
 data SpineValue {Δ : TyCtx} : Term Δ → Set where
   sv-ƛ : (N : Term Δ) → SpineValue (ƛ N)
@@ -564,6 +580,9 @@ data SpineValue {Δ : TyCtx} : Term Δ → Set where
 
   sv-cast : ∀ {V} {μ : Env∼ Δ} {A B : Ty Δ} {c : μ ⊢ A ∼ B}
     → SpineValue V → Inert c → SpineValue (V ⟨ c ⟩)
+
+  sv-seal : ∀ {V X R} → SpineValue V
+    → SpineValue (V ↓ Conversion.seal X R)
 
   sv-reveal-fun : ∀ {V} {A A′ B B′ : Ty Δ}
       {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
@@ -600,6 +619,210 @@ decaySameCtxʳ : ∀ {Δᴸ Δᴿ Δ Δ′}
 decaySameCtxʳ dec CTI2.same-[] = CTI2.same-[]
 decaySameCtxʳ dec (CTI2.same-∷ sc) = CTI2.same-∷ (decaySameCtxʳ dec sc)
 
+sameCtx-∘ : ∀ {Δᴸ Δᴿ Δ₁ Δ₂ Δ₃}
+    {W₁ : World Δᴸ Δᴿ Δ₁} {W₂ : World Δᴸ Δᴿ Δ₂}
+    {W₃ : World Δᴸ Δᴿ Δ₃}
+    {γ₁ : CtxImp W₁} {γ₂ : CtxImp W₂} {γ₃ : CtxImp W₃}
+  → CTI2.SameCtx γ₁ γ₂
+  → CTI2.SameCtx γ₂ γ₃
+  → CTI2.SameCtx γ₁ γ₃
+sameCtx-∘ CTI2.same-[] CTI2.same-[] = CTI2.same-[]
+sameCtx-∘ (CTI2.same-∷ sc₁) (CTI2.same-∷ sc₂) =
+  CTI2.same-∷ (sameCtx-∘ sc₁ sc₂)
+
+rebase-target-membership : ∀ {Δᴸ Δᴿ Δ}
+    {W′ W : World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {Y : TyVar Δᴿ} {S : Ty Δᴿ}
+  → CTI2.RebaseAt W′ W X Y
+  → targetStoreʷ W′ ∋ Y ⦂ S
+  → targetStoreʷ W ∋ Y ⦂ S
+rebase-target-membership ra Y∈ =
+  subst≡ (λ Σ → Σ ∋ _ ⦂ _)
+    (sym (CTI2.SameRuntime.targetStore-same
+      (CTI2.RebaseAt.sameRuntime ra))) Y∈
+
+star-source-nonstar-⊥ : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {S : Ty Δᴿ}
+  → ★ ⊑ᵂ⟨ W ⟩ S
+  → NonStar S
+  → ⊥
+star-source-nonstar-⊥ {S = ＇ Y} () nonstar-X
+star-source-nonstar-⊥ {S = ‵ ι} () nonstar-ι
+star-source-nonstar-⊥ {S = A ⇒ B} () nonstar-⇒
+star-source-nonstar-⊥ {S = `∀ A} () nonstar-∀
+
+seal-target-nonstar-⊥ : ∀ {Δᴸ Δᴿ Δ}
+    {W′ W : World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {Y : TyVar Δᴿ} {S : Ty Δᴿ}
+  → sourceStoreʷ W ∋ X ⦂ ★
+  → CTI2.RebaseAt W′ W X Y
+  → targetStoreʷ W ∋ Y ⦂ S
+  → NonVar S
+  → NonStar S
+  → ⊥
+seal-target-nonstar-⊥ {W = W} {X = X} {Y = Y} {S = S}
+    X∈ ra Y∈ Snv Sns =
+  star-source-nonstar-⊥ {W = W} {S = S}
+    (subst≡ (λ T → ★ ⊑ᵂ⟨ W ⟩ T)
+      (SPT.resolveVar-nonvar Y∈ Snv)
+      (subst≡
+        (λ T → T ⊑ᵂ⟨ W ⟩ CTI2.resolveVar (targetStoreʷ W) Y)
+        (SPT.resolveVar-nonvar X∈ nonvar-star)
+        (CTI2.StoreRepImp.represented
+          (CTI2.RebaseAt.storeRepresentations ra))))
+    Sns
+
+-- Compose the outer seal rebase with an inner seal-transfer link when
+-- the inner source pivot did not move.  The anchor reconstruction is
+-- exactly the unmoved branch isolated by MovedLinkProbe.
+composeSealRebase : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ W₂ : World Δᴸ Δᴿ Δ}
+    {Xᴸ X₂ : TyVar Δᴸ} {Y : TyVar Δᴿ}
+  → CTI2.RebaseAt W′ W Xᴸ Y
+  → CTI2.RebaseAt W₂ W′ X₂ Y
+  → toRenameᵗ (ηᴸʷ W₂) X₂ ≡ toRenameᵗ (ηᴸʷ W′) X₂
+  → CTI2.RebaseAt W₂ W Xᴸ Y
+composeSealRebase {Δᴸ = Δᴸ} {W = W} {W′ = W′} {W₂ = W₂}
+    {Xᴸ = Xᴸ} {X₂ = X₂} {Y = Y} ra′ link agrees =
+  CTI2.rebase-at
+    (CTI2.same-runtime
+      (trans (CTI2.SameRuntime.sourceStore-same
+        (CTI2.RebaseAt.sameRuntime ra′))
+        (CTI2.SameRuntime.sourceStore-same
+          (CTI2.RebaseAt.sameRuntime link)))
+      (trans (CTI2.SameRuntime.targetStore-same
+        (CTI2.RebaseAt.sameRuntime ra′))
+        (CTI2.SameRuntime.targetStore-same
+          (CTI2.RebaseAt.sameRuntime link))))
+    source-off target-off (CTI2.RebaseAt.pivotAligned ra′)
+    composite-anchor (CTI2.RebaseAt.storeRepresentations ra′)
+  where
+  source-off : ∀ {Z} → Z ≢ Xᴸ
+    → toRenameᵗ (ηᴸʷ W) Z ≡ toRenameᵗ (ηᴸʷ W₂) Z
+  source-off {Z} Z≠Xᴸ with Fin._≟_ Z X₂
+  source-off {.X₂} X₂≠Xᴸ | yes refl =
+    trans (CTI2.RebaseAt.ηᴸ-off-pivot ra′ X₂≠Xᴸ) (sym agrees)
+  source-off {Z} Z≠Xᴸ | no Z≠X₂ =
+    trans (CTI2.RebaseAt.ηᴸ-off-pivot ra′ Z≠Xᴸ)
+      (CTI2.RebaseAt.ηᴸ-off-pivot link Z≠X₂)
+
+  target-off : ∀ {Z} → Z ≢ Y
+    → toRenameᵗ (ηᴿʷ W) Z ≡ toRenameᵗ (ηᴿʷ W₂) Z
+  target-off Z≠Y =
+    trans (CTI2.RebaseAt.ηᴿ-off-pivot ra′ Z≠Y)
+      (CTI2.RebaseAt.ηᴿ-off-pivot link Z≠Y)
+
+  composite-anchor :
+      toRenameᵗ (ηᴿʷ W₂) Y ≢ toRenameᵗ (ηᴿʷ W) Y
+    → Σ[ Z ∈ TyVar Δᴸ ]
+        toRenameᵗ (ηᴸʷ W₂) Z ≡ toRenameᵗ (ηᴿʷ W₂) Y
+  composite-anchor moved with Fin._≟_
+      (toRenameᵗ (ηᴿʷ W₂) Y) (toRenameᵗ (ηᴿʷ W′) Y)
+  composite-anchor moved | no moved₂ =
+    CTI2.RebaseAt.anchorᴿ link moved₂
+  composite-anchor moved | yes target₂′
+      with CTI2.RebaseAt.anchorᴿ ra′
+        (λ target′W → moved (trans target₂′ target′W))
+  composite-anchor moved | yes target₂′ | Z , anchored
+      with Fin._≟_ Z X₂
+  composite-anchor moved | yes target₂′ | Z , anchored | no Z≠X₂ =
+    Z , trans (sym (CTI2.RebaseAt.ηᴸ-off-pivot link Z≠X₂))
+      (trans anchored (sym target₂′))
+  composite-anchor moved | yes target₂′ | .X₂ , anchored
+      | yes refl =
+    X₂ , trans agrees (trans anchored (sym target₂′))
+
+-- `seal-transfer` is implemented in SealTransfer, which imports this
+-- module for SpineValue.  The inversion receives that proved operation
+-- through OpenStrata to keep the module dependency acyclic.  Its other
+-- fields are precisely the three residual strata from the probe analysis.
+record OpenStrata : Set where
+  field
+    seal-transfer : ∀ {Δᴸ Δᴿ Δ}
+        {W₁ : World Δᴸ Δᴿ Δ} {γ₁ : CtxImp W₁}
+        {V : Term Δᴸ} {U : Term Δᴿ}
+        {Z : TyVar Δᴸ} {Y : TyVar Δᴿ}
+        {p : (＇ Z) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
+      → SpineValue V
+      → Value U
+      → W₁ ∣ γ₁ ⊢² V ⊑ (U ↓ Conversion.seal Y ★) ∶ p
+      → Σ[ W₂ ∈ World Δᴸ Δᴿ Δ ] Σ[ γ₂ ∈ CtxImp W₂ ]
+          ( CTI2.RebaseAt W₂ W₁ Z Y
+          × CTI2.ImpEnvMono W₁ W₂
+          × CTI2.SameCtx γ₁ γ₂
+          × Σ[ q₂ ∈ (＇ Z) ⊑ᵂ⟨ W₂ ⟩ ★ ]
+              (W₂ ∣ γ₂ ⊢² V ⊑ U ∶ q₂) )
+
+    H-walk : ∀ {Δᴸ Δᴿ Δ}
+        {W W′ : World Δᴸ Δᴿ Δ}
+        {γ : CtxImp W} {γ′ : CtxImp W′}
+        {V : Term Δᴸ} {U : Term Δᴿ}
+        {R : Ty Δᴸ} {S : Ty Δᴿ}
+        {Xᴸ : TyVar Δᴸ} {Y : TyVar Δᴿ}
+        {ν : Env∼ Δᴿ} {cY : ν ⊢ (＇ Y) ∼ ★}
+        {p₀ : R ⊑ᵂ⟨ W′ ⟩ ★}
+        {q : (＇ Xᴸ) ⊑ᵂ⟨ W ⟩ (＇ Y)}
+      → SpineValue V
+      → Value U
+      → CTI2.ImpEnvMono W W′
+      → CTI2.RebaseAt W′ W Xᴸ Y
+      → CTI2.SameCtx γ γ′
+      → sourceStoreʷ W ∋ Xᴸ ⦂ R
+      → targetStoreʷ W ∋ Y ⦂ S
+      → W′ ∣ γ′ ⊢² V
+          ⊑ (U ↓ Conversion.seal Y S) ⟨ cY ⟩ ∶ p₀
+      → W ∣ γ ⊢² V ↓ Conversion.seal Xᴸ R
+          ⊑ U ↓ Conversion.seal Y S ∶ q
+
+    H-Schain : ∀ {Δᴸ Δᴿ Δ}
+        {W W′ : World Δᴸ Δᴿ Δ}
+        {γ : CtxImp W} {γ′ : CtxImp W′}
+        {V : Term Δᴸ} {U : Term Δᴿ}
+        {Xᴸ X₂ : TyVar Δᴸ} {Y Y₂ : TyVar Δᴿ}
+        {ν : Env∼ Δᴸ} {c : ν ⊢ (＇ X₂) ∼ ★}
+        {p₂ : (＇ X₂) ⊑ᵂ⟨ W′ ⟩ (＇ Y)}
+        {q : (＇ Xᴸ) ⊑ᵂ⟨ W ⟩ (＇ Y)}
+      → SpineValue V
+      → Inert c
+      → Value U
+      → CTI2.ImpEnvMono W W′
+      → CTI2.RebaseAt W′ W Xᴸ Y
+      → CTI2.SameCtx γ γ′
+      → sourceStoreʷ W ∋ Xᴸ ⦂ ★
+      → targetStoreʷ W ∋ Y ⦂ (＇ Y₂)
+      → W′ ∣ γ′ ⊢² V
+          ⊑ U ↓ Conversion.seal Y (＇ Y₂) ∶ p₂
+      → W ∣ γ ⊢²
+          (V ⟨ c ⟩) ↓ Conversion.seal Xᴸ ★
+          ⊑ U ↓ Conversion.seal Y (＇ Y₂) ∶ q
+
+    H-absorb : ∀ {Δᴸ Δᴿ Δ}
+        {W W′ W₂ : World Δᴸ Δᴿ Δ}
+        {γ : CtxImp W} {γ′ : CtxImp W′} {γ₂ : CtxImp W₂}
+        {V : Term Δᴸ} {U : Term Δᴿ}
+        {Xᴸ X₂ : TyVar Δᴸ} {Y : TyVar Δᴿ}
+        {ν : Env∼ Δᴸ} {c : ν ⊢ (＇ X₂) ∼ ★}
+        {p₂ : (＇ X₂) ⊑ᵂ⟨ W′ ⟩ (＇ Y)}
+        {q : (＇ Xᴸ) ⊑ᵂ⟨ W ⟩ (＇ Y)}
+        {q₂ : (＇ X₂) ⊑ᵂ⟨ W₂ ⟩ ★}
+      → SpineValue V
+      → Inert c
+      → Value U
+      → CTI2.ImpEnvMono W W′
+      → CTI2.RebaseAt W′ W Xᴸ Y
+      → CTI2.SameCtx γ γ′
+      → sourceStoreʷ W ∋ Xᴸ ⦂ ★
+      → targetStoreʷ W ∋ Y ⦂ ★
+      → W′ ∣ γ′ ⊢² V ⊑ U ↓ Conversion.seal Y ★ ∶ p₂
+      → (link : CTI2.RebaseAt W₂ W′ X₂ Y)
+      → CTI2.ImpEnvMono W′ W₂
+      → CTI2.SameCtx γ′ γ₂
+      → W₂ ∣ γ₂ ⊢² V ⊑ U ∶ q₂
+      → toRenameᵗ (ηᴸʷ W₂) X₂ ≢ toRenameᵗ (ηᴸʷ W′) X₂
+      → W ∣ γ ⊢²
+          (V ⟨ c ⟩) ↓ Conversion.seal Xᴸ ★
+          ⊑ U ↓ Conversion.seal Y ★ ∶ q
+
 liftWorldLeft-WF : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
   → CTI2.WFWorld W
   → CTI2.WFWorld (CTI2.liftWorldLeft X⊑★ W)
@@ -622,6 +845,7 @@ right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
     {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
     {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
   → CTI2.WFWorld W
+  → OpenStrata
   → SpineValue V
   → Value N
   → CTI2.SameCtx γ γ′
@@ -639,6 +863,7 @@ right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
     {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
     {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
   → CTI2.WFWorld W
+  → OpenStrata
   → SpineValue V
   → Value N
   → CTI2.SameCtx γ γ′
@@ -656,102 +881,112 @@ right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {cH : ν ⊢ H ∼ H}
     {p : A ⊑ᵂ⟨ W ⟩ ★}
   → CTI2.WFWorld W
+  → OpenStrata
   → SpineValue M
   → Value N
-  → W ∣ γ ⊢² M ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → W ∣ γ ⊢² M
+      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
   → (q : A ⊑ᵂ⟨ W ⟩ H)
   → W ∣ γ ⊢² M ⊑ N ∶ q
 
 -- Target-only cast: the premise already carries the tag obligation.
-right-inj-inversion² wf sv vN (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
+right-inj-inversion² wf open-strata sv vN
+    (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
   subst≡ (λ r → _ ∣ _ ⊢² _ ⊑ _ ∶ r) (PI.⊑-unique p₀ q) prem
 
 -- Paired cast: keep the source cast as a source-only cast.
-right-inj-inversion² wf sv vN (CTI2.cast⊑cast² c c′ prem q₀) q =
+right-inj-inversion² wf open-strata sv vN
+    (CTI2.cast⊑cast² c c′ prem q₀) q =
   CTI2.cast⊑² c prem q
 
 -- Source-only cast around an injection value: no obligation matches.
-right-inj-inversion² {gH = ＇ Y} wf (sv-cast sv inj)
+right-inj-inversion² {gH = ＇ Y} wf open-strata (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ‵ ι} wf (sv-cast sv inj)
+right-inj-inversion² {gH = ‵ ι} wf open-strata (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ★⇒★} wf (sv-cast sv inj)
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ∀★} wf (sv-cast sv inj)
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-cast sv inj)
   vN (CTI2.cast⊑² c prem q₀) ()
 
 -- Source-only function cast: the premise components rebuild the
 -- premise-level tag obligation.
-right-inj-inversion² {gH = ★⇒★} wf (sv-cast sv fun)
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-cast sv fun)
     vN (CTI2.cast⊑² {p = ⇒⊑★ pA pB} c prem q₀) (⇒⊑⇒ qA qB) =
   CTI2.cast⊑² c
-    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² wf open-strata sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ＇ Y} wf (sv-cast sv fun)
+right-inj-inversion² {gH = ＇ Y} wf open-strata (sv-cast sv fun)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ‵ ι} wf (sv-cast sv fun)
+right-inj-inversion² {gH = ‵ ι} wf open-strata (sv-cast sv fun)
   vN (CTI2.cast⊑² c prem q₀) ()
-right-inj-inversion² {gH = ∀★} wf (sv-cast sv fun)
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-cast sv fun)
   vN (CTI2.cast⊑² c prem q₀) ()
 
 -- Source-only universal cast: chase the tag through the cast with the
 -- embedded consistency evidence.
-right-inj-inversion² {W = W} {gH = gH} wf (sv-cast sv (all {c = c₁}))
+right-inj-inversion² {W = W} {gH = gH} wf open-strata
+    (sv-cast sv (all {c = c₁}))
     vN (CTI2.cast⊑² {p = p₀} .(∀ᶜ c₁) prem q₀) q =
   CTI2.cast⊑² (∀ᶜ c₁)
-    (right-inj-inversion² wf sv vN prem
+    (right-inj-inversion² wf open-strata sv vN prem
       (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH) nonstar-∀
         (C.renameᵐᶜ (ηᴸʷ W) (∀ᶜ c₁)) p₀ q₀ q))
     q
 
 -- Source-only generalization cast: same, with the gen tag's source.
-right-inj-inversion² {W = W} {gH = gH} wf (sv-cast sv (genᵥ A≢★ safe))
+right-inj-inversion² {W = W} {gH = gH} wf open-strata
+    (sv-cast sv (genᵥ A≢★ safe))
     vN (CTI2.cast⊑² {p = p₀} c prem q₀) q =
   CTI2.cast⊑² c
-    (right-inj-inversion² wf sv vN prem
+    (right-inj-inversion² wf open-strata sv vN prem
       (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH)
-        (C.renameNonStar (toRenameᵗ (ηᴸʷ W)) (nonstar-from-≢★ A≢★))
+        (C.renameNonStar (toRenameᵗ (ηᴸʷ W))
+          (nonstar-from-≢★ A≢★))
         (C.renameᵐᶜ (ηᴸʷ W) c) p₀ q₀ q))
     q
 
 -- Type abstraction against a non-∀ ground: only the ∀⊑ view is
 -- possible, and its body is exactly a left-only lifted premise.
-right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-Λ sv)
-    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata (sv-Λ sv)
+    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV
+      (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) open-strata sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ＇ Y} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-Λ sv)
-    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+right-inj-inversion² {W = W} {gH = ‵ ι} wf open-strata (sv-Λ sv)
+    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV
+      (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) open-strata sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ‵ ι} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-Λ sv)
-    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata (sv-Λ sv)
+    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV
+      (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) open-strata sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ★ ⇒ ★} body))
     (∀⊑ Anv′ z∈A′ body)
 
 -- Type abstraction against the ∀★ ground.  The Λ⊑² occurrence premise
 -- exposes the body's head, which rules out bot-elim, refutes ∀⊑∀ by
 -- occurrence preservation, and leaves the ∀⊑ rebuild.
-right-inj-inversion² {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-Λ sv)
   vN (CTI2.Λ⊑² () var-∈ liftγ vV M′⊢ prem q₀) q
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-left z∈) liftγ vV
       (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV N⊢
-    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) open-strata sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-Λ sv)
     vN (CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
@@ -759,15 +994,15 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
            (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
            (∈-fun-left z∈))
 ... | ()
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-right z∉ z∈) liftγ vV
       (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV N⊢
-    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) open-strata sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-Λ sv)
     vN (CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
@@ -775,15 +1010,15 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
            (ext-injective (toRenameᵗ-injective (ηᴸʷ W)))
            (∈-fun-right z∉ z∈))
 ... | ()
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-Λ sv)
     vN (CTI2.Λ⊑² {A = A₀} Anv (∈-all z∈) liftγ vV
       (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV N⊢
-    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) sv vN prem
+    (right-inj-inversion² (liftWorldLeft-WF {W = W} wf) open-strata sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-Λ sv)
     vN (CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
@@ -795,116 +1030,121 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-Λ sv)
 -- Function-shaped reveal: the premise's ⇒⊑★ components rebuild the
 -- premise-level tag obligation, and by ⊑-unique it does not matter
 -- that this inhabitant differs from any other.
-right-inj-inversion² {gH = ★⇒★} wf (sv-reveal-fun sv)
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-reveal-fun sv)
     vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} mono CTI2.rebase-idᴸ
       sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
   CTI2.reveal⊑² mono CTI2.rebase-idᴸ sc ⊢c
-    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² wf open-strata sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ★⇒★} wf (sv-reveal-fun sv)
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-reveal-fun sv)
     vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} mono
       (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
   CTI2.reveal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c
-    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² wf open-strata sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-fun sv)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata (sv-reveal-fun sv)
     vN (CTI2.reveal⊑² {W′ = W′} {p = ⇒⊑★ pA pB} mono
       (CTI2.rebase-varᴸ rb) sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
   CTI2.reveal⊑²
-    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′}
+      mono (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
     (CTI2.rebase-varᴸ
       (TD.decayRebaseAt WD.decay-refl (WD.honestify-decay {W = W′}) rb))
     (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc) ⊢c
-    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+    (right-inj-inversion² (WD.honestify-WF W′) open-strata sv vN
       (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
       (WD.decay⊑ᵂ (WD.honestify-decay {W = W′}) (⇒⊑⇒ pA pB)))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ＇ Y} wf (sv-reveal-fun sv)
+right-inj-inversion² {gH = ＇ Y} wf open-strata (sv-reveal-fun sv)
   vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ‵ ι} wf (sv-reveal-fun sv)
+right-inj-inversion² {gH = ‵ ι} wf open-strata (sv-reveal-fun sv)
   vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ∀★} wf (sv-reveal-fun sv)
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-reveal-fun sv)
   vN (CTI2.reveal⊑² _ _ _ _ _ _) ()
 
 -- Function-shaped conceal: same construction.
-right-inj-inversion² {gH = ★⇒★} wf (sv-conceal-fun sv)
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-conceal-fun sv)
     vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} mono CTI2.rebase-idᴸ
       sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
   CTI2.conceal⊑² mono CTI2.rebase-idᴸ sc ⊢c
-    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² wf open-strata sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ★⇒★} wf (sv-conceal-fun sv)
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-conceal-fun sv)
     vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} mono
       (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
   CTI2.conceal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc ⊢c
-    (right-inj-inversion² wf sv vN prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² wf open-strata sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-fun sv)
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata
+    (sv-conceal-fun sv)
     vN (CTI2.conceal⊑² {W′ = W′} {p = ⇒⊑★ pA pB} mono
       (CTI2.rebase-varᴸ rb) sc ⊢c prem q₀)
     (⇒⊑⇒ qA qB) =
   CTI2.conceal⊑²
-    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′} mono (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = WD.honestify W′}
+      mono (WD.EnvDecay.env-mono (WD.honestify-decay {W = W′})))
     (CTI2.rebase-varᴸ
       (TD.decayRebaseAt (WD.honestify-decay {W = W′}) WD.decay-refl rb))
     (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc) ⊢c
-    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+    (right-inj-inversion² (WD.honestify-WF W′) open-strata sv vN
       (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
       (WD.decay⊑ᵂ (WD.honestify-decay {W = W′}) (⇒⊑⇒ pA pB)))
     (⇒⊑⇒ qA qB)
-right-inj-inversion² {gH = ＇ Y} wf (sv-conceal-fun sv)
+right-inj-inversion² {gH = ＇ Y} wf open-strata (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ‵ ι} wf (sv-conceal-fun sv)
+right-inj-inversion² {gH = ‵ ι} wf open-strata (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
-right-inj-inversion² {gH = ∀★} wf (sv-conceal-fun sv)
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-conceal-fun sv)
   vN (CTI2.conceal⊑² _ _ _ _ _ _) ()
 
 -- Universal reveal: transport the requested tag obligation through the
 -- body conversion.  Variable rebases recurse in the honestified world.
-right-inj-inversion² wf (sv-reveal-all sv) vN
+right-inj-inversion² wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² mono CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
       prem q₀) q =
-  right-inj-reveal-all-id² wf sv vN sc c⊢ prem q
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-all sv) vN
+  right-inj-reveal-all-id² wf open-strata sv vN sc c⊢ prem q
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata
+    (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   CTI2.reveal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
     (CTI2.⊢↑-∀ˣ c⊢)
-    (right-inj-inversion² wf sv vN prem
+    (right-inj-inversion² wf open-strata sv vN prem
       (TT.transport↑-∀-fun c⊢
         (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
         p₀ q))
     q
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   CTI2.reveal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
     (CTI2.⊢↑-∀ˣ c⊢)
-    (right-inj-inversion² wf sv vN prem
+    (right-inj-inversion² wf open-strata sv vN prem
       (TT.transport↑-∀-all c⊢
         (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
         p₀ q))
     q
-right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ‵ ι} wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
     (TT.transport↑-∀-ι-⊥ c⊢
       (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
-right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
     (TT.transport↑-∀-var-⊥ c⊢
       (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata
+    (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   CTI2.reveal⊑²
@@ -915,7 +1155,7 @@ right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-all sv) vN
         rb))
     (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
     (CTI2.⊢↑-∀ˣ c⊢)
-    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+    (right-inj-inversion² (WD.honestify-WF W′) open-strata sv vN
       (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
       (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
         (TT.transport↑-∀-fun c⊢
@@ -923,7 +1163,7 @@ right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-reveal-all sv) vN
           (toRenameᵗ-injective (ηᴸʷ W))
           p₀ q)))
     q
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   CTI2.reveal⊑²
@@ -934,7 +1174,7 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-reveal-all sv) vN
         rb))
     (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
     (CTI2.⊢↑-∀ˣ c⊢)
-    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+    (right-inj-inversion² (WD.honestify-WF W′) open-strata sv vN
       (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
       (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
         (TT.transport↑-∀-all c⊢
@@ -942,7 +1182,7 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-reveal-all sv) vN
           (toRenameᵗ-injective (ηᴸʷ W))
           p₀ q)))
     q
-right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ‵ ι} wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
@@ -950,7 +1190,7 @@ right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-reveal-all sv) vN
       (toRenameᵗ-injective (ηᴸʷ W′))
       (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
-right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-reveal-all sv) vN
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata (sv-reveal-all sv) vN
     (CTI2.reveal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↑-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
@@ -961,45 +1201,49 @@ right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-reveal-all sv) vN
 
 -- Universal conceal: the dual transport has the same obligations, while
 -- the variable-rebase decay uses conceal's opposite rebase orientation.
-right-inj-inversion² wf (sv-conceal-all sv) vN
+right-inj-inversion² wf open-strata (sv-conceal-all sv) vN
     (CTI2.conceal⊑² mono CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
       prem q₀) q =
-  right-inj-conceal-all-id² wf sv vN sc c⊢ prem q
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-all sv) vN
+  right-inj-conceal-all-id² wf open-strata sv vN sc c⊢ prem q
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata
+    (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   CTI2.conceal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
     (CTI2.⊢↓-∀ˣ c⊢)
-    (right-inj-inversion² wf sv vN prem
+    (right-inj-inversion² wf open-strata sv vN prem
       (TT.transport↓-∀-fun c⊢
         (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
         p₀ q))
     q
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata
+    (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   CTI2.conceal⊑² mono (CTI2.rebase-onlyᴸ ts dis rep) sc
     (CTI2.⊢↓-∀ˣ c⊢)
-    (right-inj-inversion² wf sv vN prem
+    (right-inj-inversion² wf open-strata sv vN prem
       (TT.transport↓-∀-all c⊢
         (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
         p₀ q))
     q
-right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ‵ ι} wf open-strata
+    (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
     (TT.transport↓-∀-ι-⊥ c⊢
       (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
-right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {p = p₀} mono (CTI2.rebase-onlyᴸ ts dis rep) sc
       (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
     (TT.transport↓-∀-var-⊥ c⊢
       (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
-right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ★⇒★} wf open-strata
+    (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   CTI2.conceal⊑²
@@ -1010,7 +1254,7 @@ right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-all sv) vN
         rb))
     (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
     (CTI2.⊢↓-∀ˣ c⊢)
-    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+    (right-inj-inversion² (WD.honestify-WF W′) open-strata sv vN
       (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
       (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
         (TT.transport↓-∀-fun c⊢
@@ -1018,7 +1262,8 @@ right-inj-inversion² {W = W} {gH = ★⇒★} wf (sv-conceal-all sv) vN
           (toRenameᵗ-injective (ηᴸʷ W))
           p₀ q)))
     q
-right-inj-inversion² {W = W} {gH = ∀★} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ∀★} wf open-strata
+    (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   CTI2.conceal⊑²
@@ -1029,7 +1274,7 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-conceal-all sv) vN
         rb))
     (decaySameCtxʳ (WD.honestify-decay {W = W′}) sc)
     (CTI2.⊢↓-∀ˣ c⊢)
-    (right-inj-inversion² (WD.honestify-WF W′) sv vN
+    (right-inj-inversion² (WD.honestify-WF W′) open-strata sv vN
       (TD.⊢²-decay (WD.honestify-decay {W = W′}) prem)
       (WD.decay⊑ᵂ (WD.honestify-decay {W = W′})
         (TT.transport↓-∀-all c⊢
@@ -1037,7 +1282,8 @@ right-inj-inversion² {W = W} {gH = ∀★} wf (sv-conceal-all sv) vN
           (toRenameᵗ-injective (ηᴸʷ W))
           p₀ q)))
     q
-right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ‵ ι} wf open-strata
+    (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
@@ -1045,7 +1291,7 @@ right-inj-inversion² {W = W} {gH = ‵ ι} wf (sv-conceal-all sv) vN
       (toRenameᵗ-injective (ηᴸʷ W′))
       (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
-right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-conceal-all sv) vN
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata (sv-conceal-all sv) vN
     (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono
       (CTI2.rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
   ⊥-elim
@@ -1054,8 +1300,195 @@ right-inj-inversion² {W = W} {gH = ＇ Y} wf (sv-conceal-all sv) vN
       (toRenameᵗ-injective (ηᴸʷ W))
       p₀ q)
 
+-- Bare source seal.  A variable tag forces the target value to expose
+-- the corresponding seal boundary and turns the one-sided rebase into
+-- a paired link.
+right-inj-inversion² {gH = ‵ ι} wf open-strata (sv-seal sv) vN
+    (CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+    with q
+right-inj-inversion² {gH = ‵ ι} wf open-strata (sv-seal sv) vN
+    (CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+    | ()
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-seal sv) vN
+    (CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+    with q
+right-inj-inversion² {gH = ★⇒★} wf open-strata (sv-seal sv) vN
+    (CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+    | ()
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-seal sv) vN
+    (CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+    with q
+right-inj-inversion² {gH = ∀★} wf open-strata (sv-seal sv) vN
+    (CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+    | ()
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    with seal-rebase-target rb q | right-tag-variable-view vN prem
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    with prem
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.⊑cast² c′ prem₂ .p₀ =
+  CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ Xᴸ∈) prem₂ q
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = `∀ A} (sv-Λ sv₀)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.Λ⊑² Anv z∈A liftγ vV U!⊢ prem₂ .p₀ =
+  OpenStrata.H-walk open-strata (sv-Λ sv₀) vU mono ra′ sc Xᴸ∈
+    (rebase-target-membership ra′ Y∈)
+    (CTI2.Λ⊑² Anv z∈A liftγ vV U!⊢ prem₂ p₀)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.cast⊑² c prem₂ .p₀ =
+  OpenStrata.H-walk open-strata (sv-cast sv₀ inert) vU mono ra′ sc
+    Xᴸ∈ (rebase-target-membership ra′ Y∈)
+    (CTI2.cast⊑² c prem₂ p₀)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.reveal⊑² mono₁ rb₁ sc₁ c⊢ prem₂ .p₀ =
+  OpenStrata.H-walk open-strata sv vU mono ra′ sc Xᴸ∈
+    (rebase-target-membership ra′ Y∈)
+    (CTI2.reveal⊑² mono₁ rb₁ sc₁ c⊢ prem₂ p₀)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} sv) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.conceal⊑² mono₁ rb₁ sc₁ c⊢ prem₂ .p₀ =
+  OpenStrata.H-walk open-strata sv vU mono ra′ sc Xᴸ∈
+    (rebase-target-membership ra′ Y∈)
+    (CTI2.conceal⊑² mono₁ rb₁ sc₁ c⊢ prem₂ p₀)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    with SPT.right-var-obligation-view {W = W′} {Y = Y} p₂
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned
+    with SPT.var-consistency-view c
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₁ refl =
+  CTI2.conceal⊑² mono rb sc (CTI2.⊢↓-sealˣ Xᴸ∈)
+    (CTI2.cast⊑² c prem₂ p₂) q
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} {R = R} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl
+    with S
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | ★
+    with OpenStrata.seal-transfer open-strata sv₀ vU prem₂
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | ★
+    | W₂ , γ₂ , link , mono₂ , sc₂ , q₂ , D₂
+    with Fin._≟_ (toRenameᵗ (ηᴸʷ W₂) X₂)
+      (toRenameᵗ (ηᴸʷ W′) X₂)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | ★
+    | W₂ , γ₂ , link , mono₂ , sc₂ , q₂ , D₂ | yes agrees =
+  CTI2.conceal⊑conceal²
+    (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = W₂} mono mono₂)
+    (composeSealRebase ra′ link agrees)
+    (sameCtx-∘ sc sc₂)
+    (CTI2.⊢↓-sealˣ Xᴸ∈)
+    (CTI2.⊢↓-sealˣ (rebase-target-membership ra′ Y∈))
+    (CTI2.cast⊑² c D₂ ★⊑★) q
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | ★
+    | W₂ , γ₂ , link , mono₂ , sc₂ , q₂ , D₂ | no moved =
+  OpenStrata.H-absorb open-strata sv₀ inert vU mono ra′ sc Xᴸ∈
+    (rebase-target-membership ra′ Y∈) prem₂ link mono₂ sc₂ D₂ moved
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | ＇ Y₂ =
+  OpenStrata.H-Schain open-strata sv₀ inert vU mono ra′ sc Xᴸ∈
+    (rebase-target-membership ra′ Y∈) prem₂
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | ‵ ι =
+  ⊥-elim (seal-target-nonstar-⊥ Xᴸ∈ ra′
+    (rebase-target-membership ra′ Y∈) nonvar-base nonstar-ι)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | A ⇒ B =
+  ⊥-elim (seal-target-nonstar-⊥ Xᴸ∈ ra′
+    (rebase-target-membership ra′ Y∈) nonvar-fun nonstar-⇒)
+right-inj-inversion² {W = W} {gH = ＇ Y} wf open-strata
+    (sv-seal {X = Xᴸ} (sv-cast sv₀ inert)) vN
+    (CTI2.conceal⊑² {W′ = W′} {p = p₀} mono rb sc
+      (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+    | ra′ | varv-seal {W = U} vU Y∈ refl
+    | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
+    | X₂ , refl , aligned | inj₂ refl | `∀ A =
+  ⊥-elim (seal-target-nonstar-⊥ Xᴸ∈ ra′
+    (rebase-target-membership ra′ Y∈) nonvar-all nonstar-∀)
+
 -- Type applications are not spine values.
-right-inj-inversion² wf () vN (CTI2.•⊑² _ _ _ _) q
+right-inj-inversion² wf open-strata () vN (CTI2.•⊑² _ _ _ _) q
 
 ------------------------------------------------------------------------
 -- Identity-pivot universal wrappers
@@ -1067,17 +1500,19 @@ right-inj-inversion² wf () vN (CTI2.•⊑² _ _ _ _) q
 -- exposes the recursive injection obligation.
 
 right-inj-reveal-all-id² {W = W} {A = A} {B = B}
-    {H = H} {c = c} wf sv vN sc c⊢ prem q =
-  CTI2.reveal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
-    (right-inj-inversion² wf sv vN prem
+    {H = H} {c = c} wf open-strata sv vN sc c⊢ prem q =
+  CTI2.reveal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc
+    (CTI2.⊢↑-∀-idˣ c⊢)
+    (right-inj-inversion² wf open-strata sv vN prem
       (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
         (sym (cong `∀ (pivot-id-endpoints↑ c⊢))) q))
     q
 
 right-inj-conceal-all-id² {W = W} {A = A} {B = B}
-    {H = H} {c = c} wf sv vN sc c⊢ prem q =
-  CTI2.conceal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
-    (right-inj-inversion² wf sv vN prem
+    {H = H} {c = c} wf open-strata sv vN sc c⊢ prem q =
+  CTI2.conceal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ sc
+    (CTI2.⊢↓-∀-idˣ c⊢)
+    (right-inj-inversion² wf open-strata sv vN prem
       (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
         (sym (cong `∀ (pivot-id-endpoints↓ c⊢))) q))
     q

--- a/GTSFImp/proof/DGG/ExtraCastRight2.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2.agda
@@ -9,44 +9,61 @@ module proof.DGG.ExtraCastRight2 where
 --     version 1 the statement carries no transport function for the
 --     source type: A : Ty Δᴸ is untouched by target-side allocation,
 --     and only the world and the target types evolve.
+--     The identity and inert-cast cases are proved directly with reusable
+--     zero-change and one-keep world extensions.
 --   * Stage 2: the right-injection inversion lemma, proved for spine
 --     values: constants, lambdas, type abstractions, inert casts, and
 --     function-shaped reveal/conceal wrappers.  Because obligations
 --     are propositions (proof.Imprecision.⊑-unique), the free q of
 --     the wrapper rules carries no information beyond its type, and
---     extending to ∀-shaped and seal wrappers is a type-level
---     inhabitation question; see SpineValue for what remains.
+--     extending to ∀-shaped wrappers is a type-level inhabitation
+--     question; see SpineValue for what remains.
+--   * Binder-lifted world/rebase lemmas support the ∀-shaped frontier.
+--     The identity-pivot universal reveal and conceal subcases are complete;
+--     their conversion endpoints are equal and need no rebasing.
+--     Bare seal is not reducible to obligation transport alone:
+--     ExtraCastRight2Counterexample gives a checked configuration where
+--     the input relation exists but every possible output relation after
+--     target-tag cancellation is empty.  General bare-seal inversion needs
+--     a stronger relation/world invariant or a restricted theorem domain.
 --   * Version-2 pay-offs visible here: no renaming wrapper around the
 --     relation, the Λ⊑² case recurses with the target data unchanged,
 --     and the ground lemmas of proof.ImprecisionConsistency apply
 --     directly to world-embedded obligations.
 
+open import Data.Empty using (⊥-elim)
 open import Data.List using ([]; _∷_)
 open import Data.Nat using (suc)
 import Data.Fin as Fin
+open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; _≢_; refl; sym; trans)
+  using (_≡_; _≢_; refl; sym; trans; cong)
   renaming (subst to subst≡)
 
 open import Types
-open import TyStore using (TyStore)
+open import TyStore using (TyStore; store-lift; _∋_⦂_)
 open import Consistency using
   (Env∼; _⊢_∼_; _⊢_∼★; _↪ᵗ_; keep; skip; toRenameᵗ;
-   _!; ∀ᶜ_; gen_; inst_)
+   id; _!; ∀ᶜ_; gen_; inst_)
 import Consistency as C
-open import Conversion using (Conv↑; Conv↓; `∀↑_; `∀↓_; _↦↑_; _↦↓_)
+open import Conversion using
+  (Conv↑; Conv↓; _⊢↓_; `∀↑_; `∀↓_; _↦↑_; _↦↓_; ⊢↓-seal)
 open import Imprecision
-open import Primitives using (Const)
+open import Primitives using (Const; κℕ; κ𝔹)
 open import CastTerms
 open import Reduction
 import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CastTermImprecision2Typing as CTI2T
+open import proof.DGG.ConvImp using
+  (pivot-id-endpoints↑; pivot-id-endpoints↓)
 open CTI2 using
   (World; ηᴸʷ; ηᴿʷ; impEnvʷ; sourceStoreʷ; targetStoreʷ; embedᴿ;
    _⊑ᵂ⟨_⟩_; CtxImp; ctx-imp; _∣_⊢²_⊑_∶_)
 open import proof.ImprecisionConsistency using
   (ground-cast-source⊑; source-occurs-target; rename-occurs;
-   ext-injective; toRenameᵗ-injective; nonstar-from-≢★)
+   ext-injective; toRenameᵗ-injective; nonstar-from-≢★; rename-⊑;
+   fin-suc-injective)
 import proof.Imprecision as PI
 open import proof.TypeInTermSubst using (toRename-keep-eq)
 
@@ -104,6 +121,22 @@ record WorldExtendᴿ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} (χs : StoreChanges Δᴿ 
 
 open WorldExtendᴿ public
 
+sameWorldExtendᴿ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+  → WorldExtendᴿ [] W W
+sameWorldExtendᴿ = record
+  { sourceStore-kept = refl
+  ; targetStore-follows = refl
+  ; transport⊑ᵂ = λ p → p
+  }
+
+sameWorldKeepExtendᴿ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+  → WorldExtendᴿ (Reduction.keep ∷ []) W W
+sameWorldKeepExtendᴿ = record
+  { sourceStore-kept = refl
+  ; targetStore-follows = refl
+  ; transport⊑ᵂ = λ p → p
+  }
+
 mapCtxᴿ : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} {χs : StoreChanges Δᴿ Δᴿ′}
     {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
   → WorldExtendᴿ χs W W′
@@ -112,6 +145,18 @@ mapCtxᴿ : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′} {χs : StoreChanges Δᴿ Δᴿ�
 mapCtxᴿ ext [] = []
 mapCtxᴿ {χs = χs} ext (ctx-imp A B p ∷ γ) =
   ctx-imp A (χs ▶ᵗ B) (transport⊑ᵂ ext p) ∷ mapCtxᴿ ext γ
+
+mapCtxᴿ-same : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    (γ : CtxImp W)
+  → mapCtxᴿ sameWorldExtendᴿ γ ≡ γ
+mapCtxᴿ-same [] = refl
+mapCtxᴿ-same (ctx-imp A B p ∷ γ) = cong (_ ∷_) (mapCtxᴿ-same γ)
+
+mapCtxᴿ-keep : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    (γ : CtxImp W)
+  → mapCtxᴿ sameWorldKeepExtendᴿ γ ≡ γ
+mapCtxᴿ-keep [] = refl
+mapCtxᴿ-keep (ctx-imp A B p ∷ γ) = cong (_ ∷_) (mapCtxᴿ-keep γ)
 
 -- Extra cast on the right: if related values face an extra target
 -- cast, the target alone reduces to a value in an extended world that
@@ -161,6 +206,67 @@ InstCatchupRight² = ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxIm
         × (M′ ⟨ (inst c′) B′≢★ ⟩ —↠[ χs ] N′)
         × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
 
+-- Inert target casts are already values, so this direct case of
+-- extra-cast-right neither changes the target store nor the world.
+
+inert-extra-cast-right² : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ M′ ∶ p
+  → Value M
+  → (vM′ : Value M′)
+  → (c′ : ν ⊢ B ∼ B′)
+  → Inert c′
+  → (q : A ⊑ᵂ⟨ W ⟩ B′)
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ ext ∈ WorldExtendᴿ χs W W′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ]
+      (Value N′
+        × (M′ ⟨ c′ ⟩ —↠[ χs ] N′)
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+inert-extra-cast-right² {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
+    {M = M} {M′ = M′}
+    M⊑M′ vM vM′ c′ inert q =
+  Δᴿ , [] , Δ , W , sameWorldExtendᴿ , M′ ⟨ c′ ⟩ ,
+  vM′ 《 inert 》 ,
+  (M′ ⟨ c′ ⟩ ∎[]) ,
+  subst≡ (λ γ′ → W ∣ γ′ ⊢² M ⊑ M′ ⟨ c′ ⟩ ∶ q)
+    (sym (mapCtxᴿ-same γ)) (CTI2.⊑cast² c′ M⊑M′ q)
+
+-- An identity cast takes one pure keep step and leaves the original target
+-- value.  The input and requested obligations coincide propositionally.
+
+id-extra-cast-right² : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ M′ ∶ p
+  → Value M
+  → (vM′ : Value M′)
+  → (a : Atom B)
+  → (q : A ⊑ᵂ⟨ W ⟩ B)
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ ext ∈ WorldExtendᴿ χs W W′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ]
+      (Value N′
+        × (M′ ⟨ id {μ = ν} a ⟩ —↠[ χs ] N′)
+        × (W′ ∣ mapCtxᴿ ext γ ⊢² M ⊑ N′ ∶ transport⊑ᵂ ext q))
+id-extra-cast-right² {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
+    {M = M} {M′ = M′} {p = p} M⊑M′ vM vM′ a q =
+  Δᴿ , Reduction.keep ∷ [] , Δ , W , sameWorldKeepExtendᴿ , M′ ,
+  vM′ ,
+  (M′ ⟨ id a ⟩
+    —→[ Reduction.keep ]⟨ pure-step (β-id vM′) ⟩
+  M′ ∎[]) ,
+  subst≡ (λ γ′ → W ∣ γ′ ⊢² M ⊑ M′ ∶ q)
+    (sym (mapCtxᴿ-keep γ))
+    (subst≡ (λ r → W ∣ γ ⊢² M ⊑ M′ ∶ r) (PI.⊑-unique p q) M⊑M′)
+
 ------------------------------------------------------------------------
 -- Stage 2: helpers
 ------------------------------------------------------------------------
@@ -191,6 +297,241 @@ liftWorldLeft-⊑ᵂ {W = W} {A = A} {B = B} body =
       (sym (renameᵗ-skip-eq (ηᴿʷ W) B))
       body)
 
+liftWorldBoth-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {v : VarImp}
+  → A ⊑ᵂ⟨ W ⟩ B
+  → ⇑ᵗ A ⊑ᵂ⟨ CTI2.liftWorldBoth v W ⟩ ⇑ᵗ B
+liftWorldBoth-⊑ᵂ {W = W} {A = A} {B = B} {v = v} p =
+  subst≡
+    (λ L → impEnvʷ (CTI2.liftWorldBoth v W) ⊢ L ⊑
+      embedᴿ (CTI2.liftWorldBoth v W) (⇑ᵗ B))
+    (sym (trans (renameᵗ-cong (⇑ᵗ A) (toRename-keep-eq (ηᴸʷ W)))
+                (renameᵗ-shift (toRenameᵗ (ηᴸʷ W)) A)))
+    (subst≡
+      (λ R → impEnvʷ (CTI2.liftWorldBoth v W) ⊢
+        ⇑ᵗ (CTI2.embedᴸ W A) ⊑ R)
+      (sym (trans (renameᵗ-cong (⇑ᵗ B) (toRename-keep-eq (ηᴿʷ W)))
+                  (renameᵗ-shift (toRenameᵗ (ηᴿʷ W)) B)))
+      (rename-⊑ Fin.suc fin-suc-injective (λ _ eq → eq) p))
+
+-- Rebasing is stable under a binder introduced on both sides.  This is
+-- the world-level counterpart of the shifted-pivot conversion rules.
+
+liftRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ} {v : VarImp}
+  → CTI2.RebaseAt W W′ Xᴸ Xᴿ
+  → CTI2.RebaseAt (CTI2.liftWorldBoth v W)
+      (CTI2.liftWorldBoth v W′) (Fin.suc Xᴸ) (Fin.suc Xᴿ)
+liftRebaseAt {W = W} {W′ = W′} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} {v = v} rb =
+  CTI2.rebase-at
+    (CTI2.same-runtime
+      (cong store-lift
+        (CTI2.SameRuntime.sourceStore-same (CTI2.RebaseAt.sameRuntime rb)))
+      (cong store-lift
+        (CTI2.SameRuntime.targetStore-same (CTI2.RebaseAt.sameRuntime rb))))
+    source-off target-off env-same
+    (cong Fin.suc (CTI2.RebaseAt.pivotAligned rb))
+    (CTI2.store-rep-imp lift-represented)
+  where
+  old-represented =
+    CTI2.StoreRepImp.represented
+      (CTI2.RebaseAt.storeRepresentations rb)
+
+  renamed-represented =
+    rename-⊑ Fin.suc fin-suc-injective (λ _ eq → eq) old-represented
+
+  lift-represented :
+    CTI2.resolveVar
+        (sourceStoreʷ (CTI2.liftWorldBoth v W′)) (Fin.suc Xᴸ)
+      ⊑ᵂ⟨ CTI2.liftWorldBoth v W′ ⟩
+    CTI2.resolveVar
+        (targetStoreʷ (CTI2.liftWorldBoth v W′)) (Fin.suc Xᴿ)
+  lift-represented =
+    subst≡
+      (λ L → impEnvʷ (CTI2.liftWorldBoth v W′) ⊢ L ⊑
+        embedᴿ (CTI2.liftWorldBoth v W′)
+          (⇑ᵗ (CTI2.resolveVar (targetStoreʷ W′) Xᴿ)))
+      (sym (trans
+        (renameᵗ-cong (⇑ᵗ (CTI2.resolveVar (sourceStoreʷ W′) Xᴸ))
+          (toRename-keep-eq (ηᴸʷ W′)))
+        (renameᵗ-shift (toRenameᵗ (ηᴸʷ W′))
+          (CTI2.resolveVar (sourceStoreʷ W′) Xᴸ))))
+      (subst≡
+        (λ R → impEnvʷ (CTI2.liftWorldBoth v W′) ⊢
+          ⇑ᵗ (CTI2.embedᴸ W′
+            (CTI2.resolveVar (sourceStoreʷ W′) Xᴸ)) ⊑ R)
+        (sym (trans
+          (renameᵗ-cong (⇑ᵗ (CTI2.resolveVar (targetStoreʷ W′) Xᴿ))
+            (toRename-keep-eq (ηᴿʷ W′)))
+          (renameᵗ-shift (toRenameᵗ (ηᴿʷ W′))
+            (CTI2.resolveVar (targetStoreʷ W′) Xᴿ))))
+        renamed-represented)
+
+  source-off : ∀ {Y}
+    → Y ≢ Fin.suc Xᴸ
+    → toRenameᵗ (ηᴸʷ (CTI2.liftWorldBoth v W′)) Y
+        ≡ toRenameᵗ (ηᴸʷ (CTI2.liftWorldBoth v W)) Y
+  source-off {Fin.zero} Y≢ = refl
+  source-off {Fin.suc Y} Y≢ =
+    cong Fin.suc
+      (CTI2.RebaseAt.ηᴸ-off-pivot rb
+        (λ eq → Y≢ (cong Fin.suc eq)))
+
+  target-off : ∀ {Y}
+    → Y ≢ Fin.suc Xᴿ
+    → toRenameᵗ (ηᴿʷ (CTI2.liftWorldBoth v W′)) Y
+        ≡ toRenameᵗ (ηᴿʷ (CTI2.liftWorldBoth v W)) Y
+  target-off {Fin.zero} Y≢ = refl
+  target-off {Fin.suc Y} Y≢ =
+    cong Fin.suc
+      (CTI2.RebaseAt.ηᴿ-off-pivot rb
+        (λ eq → Y≢ (cong Fin.suc eq)))
+
+  env-same : ∀ Z
+    → impEnvʷ (CTI2.liftWorldBoth v W′) Z
+        ≡ impEnvʷ (CTI2.liftWorldBoth v W) Z
+  env-same Fin.zero = refl
+  env-same (Fin.suc Z) = CTI2.RebaseAt.sameImpEnv rb Z
+
+liftPivot : ∀ {Δ} → Maybe (TyVar Δ) → Maybe (TyVar (suc Δ))
+liftPivot nothing = nothing
+liftPivot (just X) = just (Fin.suc X)
+
+liftRebaseAtᴸ : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {v : VarImp}
+  → CTI2.RebaseAtᴸ W W′ Xᴸ?
+  → CTI2.RebaseAtᴸ (CTI2.liftWorldBoth v W)
+      (CTI2.liftWorldBoth v W′) (liftPivot Xᴸ?)
+liftRebaseAtᴸ CTI2.rebase-idᴸ = CTI2.rebase-idᴸ
+liftRebaseAtᴸ (CTI2.rebase-varᴸ rb) =
+  CTI2.rebase-varᴸ (liftRebaseAt rb)
+liftRebaseAtᴸ {Δᴿ = Δᴿ} {W = W} {v = v}
+    (CTI2.rebase-onlyᴸ {Xᴸ = Xᴸ} to-star disaligned represented) =
+  CTI2.rebase-onlyᴸ to-star lifted-disaligned
+    (liftWorldBoth-⊑ᵂ
+      {W = W} {A = CTI2.resolveVar (sourceStoreʷ W) Xᴸ}
+      {B = ★} {v = v}
+      represented)
+  where
+  lifted-disaligned : ∀ (Xᴿ : TyVar (suc Δᴿ))
+    → toRenameᵗ (ηᴿʷ (CTI2.liftWorldBoth v W)) Xᴿ
+        ≢ toRenameᵗ (ηᴸʷ (CTI2.liftWorldBoth v W)) (Fin.suc Xᴸ)
+  lifted-disaligned Fin.zero ()
+  lifted-disaligned (Fin.suc Xᴿ) eq =
+    disaligned Xᴿ (fin-suc-injective eq)
+
+------------------------------------------------------------------------
+-- Canonical target values at an abstract variable
+------------------------------------------------------------------------
+
+data VarValueView {Δ : TyCtx} (Σ : TyStore Δ) (V : Term Δ)
+    (X : TyVar Δ) : Set where
+  varv-seal : ∀ {W R}
+    → Value W
+    → Σ ∋ X ⦂ R
+    → V ≡ W ↓ Conversion.seal X R
+    → VarValueView Σ V X
+
+var-value-view : ∀ {Δ} {Σ : TyStore Δ} {Γ} {V : Term Δ} {X}
+  → Value V
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ V ⦂ ＇ X
+  → VarValueView Σ V X
+var-value-view (ƛ N) ()
+var-value-view (Λ vV) ()
+var-value-view ($ (κℕ n)) ()
+var-value-view ($ (κ𝔹 b)) ()
+var-value-view (vV 《 inj 》) ()
+var-value-view (vV 《 fun 》) ()
+var-value-view (vV 《 all 》) ()
+var-value-view (vV 《 genᵥ A≢★ safe 》) ()
+var-value-view (vV ↑ fun) ()
+var-value-view (vV ↑ all) ()
+var-value-view (vV ↓ seal) (⊢conceal (⊢↓-seal X∈) V⊢) =
+  varv-seal vV X∈ refl
+var-value-view (vV ↓ fun) ()
+var-value-view (vV ↓ all) ()
+
+tag-inner-typing : ∀ {Δ} {Σ : TyStore Δ} {Γ} {N : Term Δ}
+    {H : Ty Δ} {ν : Env∼ Δ}
+    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
+    {cH : ν ⊢ H ∼ H}
+  → ⟨ Δ , Σ , Γ ⟩ ⊢
+      N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ⦂ ★
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ N ⦂ H
+tag-inner-typing (⊢⟨⟩ N⊢ cH!) = N⊢
+
+right-tag-variable-view : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {M : Term Δᴸ} {N : Term Δᴿ}
+    {A : Ty Δᴸ} {Y : TyVar Δᴿ} {ν : Env∼ Δᴿ}
+    {H∼★ : ν ⊢ (＇ Y) ∼★} {Hns : NonStar (＇ Y)}
+    {cH : ν ⊢ (＇ Y) ∼ (＇ Y)} {p : A ⊑ᵂ⟨ W ⟩ ★}
+  → Value N
+  → W ∣ γ ⊢² M
+      ⊑ N ⟨ _! ⦃ ＇ Y ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → VarValueView (targetStoreʷ W) N Y
+right-tag-variable-view vN M⊑N! =
+  var-value-view vN (tag-inner-typing (CTI2T.target-typing² M⊑N!))
+
+variable-imprecision-aligns : ∀ {Δ} {μ : ImpEnv Δ} {X Y : TyVar Δ}
+  → μ ⊢ ＇ X ⊑ ＇ Y
+  → X ≡ Y
+variable-imprecision-aligns X⊑X = refl
+
+variable-obligation-aligns : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
+  → ＇ X ⊑ᵂ⟨ W ⟩ ＇ Y
+  → toRenameᵗ (ηᴸʷ W) X ≡ toRenameᵗ (ηᴿʷ W) Y
+variable-obligation-aligns q = variable-imprecision-aligns q
+
+-- If a source seal's result is related to a target variable, a left rebase
+-- cannot be the disaligned rebase-onlyᴸ case.  Its paired pivot is exactly
+-- that target variable.
+
+seal-rebase-target : ∀ {Δᴸ Δᴿ Δ} {Wᵖ W : World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
+  → CTI2.RebaseAtᴸ Wᵖ W (just X)
+  → ＇ X ⊑ᵂ⟨ W ⟩ ＇ Y
+  → CTI2.RebaseAt Wᵖ W X Y
+seal-rebase-target {W = W} {X = X} {Y = Y}
+    (CTI2.rebase-varᴸ {Xᴿ = Xᴿ} rb) q
+    with toRenameᵗ-injective (ηᴿʷ W)
+      (trans (sym (CTI2.RebaseAt.pivotAligned rb))
+        (variable-obligation-aligns {W = W} {X = X} {Y = Y} q))
+seal-rebase-target (CTI2.rebase-varᴸ rb) q | refl = rb
+seal-rebase-target
+    {W = W} {X = X} {Y = Y}
+    (CTI2.rebase-onlyᴸ to-star disaligned represented) q =
+  ⊥-elim
+    (disaligned Y
+      (sym (variable-obligation-aligns {W = W} {X = X} {Y = Y} q)))
+
+-- A source seal related to a variable-tagged target determines both sides
+-- of the matching outer boundary.  The target value must itself be sealed
+-- at that variable, and the source's nominally one-sided rebase is the
+-- corresponding paired rebase.
+
+seal-tag-boundary-view² : ∀ {Δᴸ Δᴿ Δ}
+    {Wᵖ W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {N : Term Δᴿ} {R : Ty Δᴸ}
+    {X : TyVar Δᴸ} {Y : TyVar Δᴿ} {ν : Env∼ Δᴿ}
+    {H∼★ : ν ⊢ (＇ Y) ∼★} {Hns : NonStar (＇ Y)}
+    {cH : ν ⊢ (＇ Y) ∼ (＇ Y)} {p : ＇ X ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.RebaseAtᴸ Wᵖ W (just X)
+  → Value N
+  → W ∣ γ ⊢² M ↓ Conversion.seal X R
+      ⊑ N ⟨ _! ⦃ ＇ Y ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → (q : ＇ X ⊑ᵂ⟨ W ⟩ ＇ Y)
+  → Σ[ U ∈ Term Δᴿ ] Σ[ S ∈ Ty Δᴿ ]
+      (Value U
+        × (targetStoreʷ W ∋ Y ⦂ S)
+        × (N ≡ U ↓ Conversion.seal Y S)
+        × CTI2.RebaseAt Wᵖ W X Y)
+seal-tag-boundary-view² rb vN M↓X⊑N! q
+    with right-tag-variable-view vN M↓X⊑N!
+seal-tag-boundary-view² rb vN M↓X⊑N! q
+    | varv-seal {W = U} {R = S} vU Y∈ refl =
+  U , S , vU , Y∈ , refl , seal-rebase-target rb q
+
 ------------------------------------------------------------------------
 -- Stage 2: right-injection inversion for spine values
 ------------------------------------------------------------------------
@@ -203,9 +544,9 @@ liftWorldLeft-⊑ᵂ {W = W} {A = A} {B = B} body =
 -- extending to the remaining wrappers is a type-level inhabitation
 -- question: an obligation-transport lemma along the pivot-indexed
 -- conversion typing.  Its ∀-cases need occurrence transport along
--- conversions, and its seal case needs rebase-onlyᴸ to record that no
--- target variable sits at the pivot's center.  Until that lemma
--- exists, ∀-shaped and seal wrappers are the open frontier.
+-- conversions.  Until that lemma exists, ∀-shaped wrappers are open.
+-- Bare seals are excluded for a stronger reason: the checked
+-- ExtraCastRight2Counterexample refutes unrestricted relational inversion.
 
 data SpineValue {Δ : TyCtx} : Term Δ → Set where
   sv-ƛ : (N : Term Δ) → SpineValue (ƛ N)
@@ -236,57 +577,58 @@ right-inj-inversion² : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {cH : ν ⊢ H ∼ H}
     {p : A ⊑ᵂ⟨ W ⟩ ★}
   → SpineValue M
+  → Value N
   → W ∣ γ ⊢² M ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
   → (q : A ⊑ᵂ⟨ W ⟩ H)
   → W ∣ γ ⊢² M ⊑ N ∶ q
 
 -- Target-only cast: the premise already carries the tag obligation.
-right-inj-inversion² sv (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
+right-inj-inversion² sv vN (CTI2.⊑cast² {p = p₀} c′ prem q₀) q =
   subst≡ (λ r → _ ∣ _ ⊢² _ ⊑ _ ∶ r) (PI.⊑-unique p₀ q) prem
 
 -- Paired cast: keep the source cast as a source-only cast.
-right-inj-inversion² sv (CTI2.cast⊑cast² c c′ prem q₀) q =
+right-inj-inversion² sv vN (CTI2.cast⊑cast² c c′ prem q₀) q =
   CTI2.cast⊑² c prem q
 
 -- Source-only cast around an injection value: no obligation matches.
 right-inj-inversion² {gH = ＇ Y} (sv-cast sv inj)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 right-inj-inversion² {gH = ‵ ι} (sv-cast sv inj)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 right-inj-inversion² {gH = ★⇒★} (sv-cast sv inj)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 right-inj-inversion² {gH = ∀★} (sv-cast sv inj)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 
 -- Source-only function cast: the premise components rebuild the
 -- premise-level tag obligation.
 right-inj-inversion² {gH = ★⇒★} (sv-cast sv fun)
-    (CTI2.cast⊑² {p = ⇒⊑★ pA pB} c prem q₀) (⇒⊑⇒ qA qB) =
+    vN (CTI2.cast⊑² {p = ⇒⊑★ pA pB} c prem q₀) (⇒⊑⇒ qA qB) =
   CTI2.cast⊑² c
-    (right-inj-inversion² sv prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
 right-inj-inversion² {gH = ＇ Y} (sv-cast sv fun)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 right-inj-inversion² {gH = ‵ ι} (sv-cast sv fun)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 right-inj-inversion² {gH = ∀★} (sv-cast sv fun)
-  (CTI2.cast⊑² c prem q₀) ()
+  vN (CTI2.cast⊑² c prem q₀) ()
 
 -- Source-only universal cast: chase the tag through the cast with the
 -- embedded consistency evidence.
 right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (all {c = c₁}))
-    (CTI2.cast⊑² {p = p₀} .(∀ᶜ c₁) prem q₀) q =
+    vN (CTI2.cast⊑² {p = p₀} .(∀ᶜ c₁) prem q₀) q =
   CTI2.cast⊑² (∀ᶜ c₁)
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH) nonstar-∀
         (C.renameᵐᶜ (ηᴸʷ W) (∀ᶜ c₁)) p₀ q₀ q))
     q
 
 -- Source-only generalization cast: same, with the gen tag's source.
 right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (genᵥ A≢★ safe))
-    (CTI2.cast⊑² {p = p₀} c prem q₀) q =
+    vN (CTI2.cast⊑² {p = p₀} c prem q₀) q =
   CTI2.cast⊑² c
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (ground-cast-source⊑ (C.renameGroundᵐ (ηᴿʷ W) gH)
         (C.renameNonStar (toRenameᵗ (ηᴸʷ W)) (nonstar-from-≢★ A≢★))
         (C.renameᵐᶜ (ηᴸʷ W) c) p₀ q₀ q))
@@ -295,24 +637,24 @@ right-inj-inversion² {W = W} {gH = gH} (sv-cast sv (genᵥ A≢★ safe))
 -- Type abstraction against a non-∀ ground: only the ∀⊑ view is
 -- possible, and its body is exactly a left-only lifted premise.
 right-inj-inversion² {W = W} {gH = ＇ Y} (sv-Λ sv)
-    (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ＇ Y} body))
     (∀⊑ Anv′ z∈A′ body)
 right-inj-inversion² {W = W} {gH = ‵ ι} (sv-Λ sv)
-    (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ‵ ι} body))
     (∀⊑ Anv′ z∈A′ body)
 right-inj-inversion² {W = W} {gH = ★⇒★} (sv-Λ sv)
-    (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    vN (CTI2.Λ⊑² {A = A₀} Anv z∈A liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv z∈A liftγ vV N⊢
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = ★ ⇒ ★} body))
     (∀⊑ Anv′ z∈A′ body)
 
@@ -320,16 +662,17 @@ right-inj-inversion² {W = W} {gH = ★⇒★} (sv-Λ sv)
 -- exposes the body's head, which rules out bot-elim, refutes ∀⊑∀ by
 -- occurrence preservation, and leaves the ∀⊑ rebuild.
 right-inj-inversion² {gH = ∀★} (sv-Λ sv)
-  (CTI2.Λ⊑² () var-∈ liftγ vV M′⊢ prem q₀) q
+  vN (CTI2.Λ⊑² () var-∈ liftγ vV M′⊢ prem q₀) q
 right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
-    (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-left z∈) liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    vN (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-left z∈) liftγ vV
+      (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV N⊢
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
 right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
-    (CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV M′⊢ prem q₀)
+    vN (CTI2.Λ⊑² Anv (∈-fun-left z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
          (rename-occurs (extᵗ (toRenameᵗ (ηᴸʷ W)))
@@ -337,14 +680,15 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
            (∈-fun-left z∈))
 ... | ()
 right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
-    (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-right z∉ z∈) liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    vN (CTI2.Λ⊑² {A = A₀} Anv (∈-fun-right z∉ z∈) liftγ vV
+      (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV N⊢
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
 right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
-    (CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV M′⊢ prem q₀)
+    vN (CTI2.Λ⊑² Anv (∈-fun-right z∉ z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
          (rename-occurs (extᵗ (toRenameᵗ (ηᴸʷ W)))
@@ -352,14 +696,15 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
            (∈-fun-right z∉ z∈))
 ... | ()
 right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
-    (CTI2.Λ⊑² {A = A₀} Anv (∈-all z∈) liftγ vV (⊢⟨⟩ N⊢ _) prem q₀)
+    vN (CTI2.Λ⊑² {A = A₀} Anv (∈-all z∈) liftγ vV
+      (⊢⟨⟩ N⊢ _) prem q₀)
     (∀⊑ Anv′ z∈A′ body) =
   CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV N⊢
-    (right-inj-inversion² sv prem
+    (right-inj-inversion² sv vN prem
       (liftWorldLeft-⊑ᵂ {W = W} {A = A₀} {B = `∀ ★} body))
     (∀⊑ Anv′ z∈A′ body)
 right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
-    (CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV M′⊢ prem q₀)
+    vN (CTI2.Λ⊑² Anv (∈-all z∈) liftγ vV M′⊢ prem q₀)
     (∀⊑∀ qbody)
   with source-occurs-target refl qbody
          (rename-occurs (extᵗ (toRenameᵗ (ηᴸʷ W)))
@@ -371,29 +716,86 @@ right-inj-inversion² {W = W} {gH = ∀★} (sv-Λ sv)
 -- premise-level tag obligation, and by ⊑-unique it does not matter
 -- that this inhabitant differs from any other.
 right-inj-inversion² {gH = ★⇒★} (sv-reveal-fun sv)
-    (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀) (⇒⊑⇒ qA qB) =
+    vN (CTI2.reveal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀)
+    (⇒⊑⇒ qA qB) =
   CTI2.reveal⊑² rb sc ⊢c
-    (right-inj-inversion² sv prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
 right-inj-inversion² {gH = ＇ Y} (sv-reveal-fun sv)
-  (CTI2.reveal⊑² _ _ _ _ _) ()
+  vN (CTI2.reveal⊑² _ _ _ _ _) ()
 right-inj-inversion² {gH = ‵ ι} (sv-reveal-fun sv)
-  (CTI2.reveal⊑² _ _ _ _ _) ()
+  vN (CTI2.reveal⊑² _ _ _ _ _) ()
 right-inj-inversion² {gH = ∀★} (sv-reveal-fun sv)
-  (CTI2.reveal⊑² _ _ _ _ _) ()
+  vN (CTI2.reveal⊑² _ _ _ _ _) ()
 
 -- Function-shaped conceal: same construction.
 right-inj-inversion² {gH = ★⇒★} (sv-conceal-fun sv)
-    (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀) (⇒⊑⇒ qA qB) =
+    vN (CTI2.conceal⊑² {p = ⇒⊑★ pA pB} rb sc ⊢c prem q₀)
+    (⇒⊑⇒ qA qB) =
   CTI2.conceal⊑² rb sc ⊢c
-    (right-inj-inversion² sv prem (⇒⊑⇒ pA pB))
+    (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
     (⇒⊑⇒ qA qB)
 right-inj-inversion² {gH = ＇ Y} (sv-conceal-fun sv)
-  (CTI2.conceal⊑² _ _ _ _ _) ()
+  vN (CTI2.conceal⊑² _ _ _ _ _) ()
 right-inj-inversion² {gH = ‵ ι} (sv-conceal-fun sv)
-  (CTI2.conceal⊑² _ _ _ _ _) ()
+  vN (CTI2.conceal⊑² _ _ _ _ _) ()
 right-inj-inversion² {gH = ∀★} (sv-conceal-fun sv)
-  (CTI2.conceal⊑² _ _ _ _ _) ()
+  vN (CTI2.conceal⊑² _ _ _ _ _) ()
 
 -- Type applications are not spine values.
-right-inj-inversion² () (CTI2.•⊑² _ _ _ _) q
+right-inj-inversion² () vN (CTI2.•⊑² _ _ _ _) q
+
+------------------------------------------------------------------------
+-- Identity-pivot universal wrappers
+------------------------------------------------------------------------
+
+-- These are the complete nothing-pivot subcases of the two universal
+-- wrapper branches.  Their body conversions have equal endpoints and the
+-- wrapper world is definitionally unchanged, so ordinary index transport
+-- exposes the recursive injection obligation.
+
+right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
+    {V : Term Δᴸ} {N : Term Δᴿ}
+    {A B : Ty (suc Δᴸ)} {H : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {c : Conv↑ (suc Δᴸ) A B}
+    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
+    {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
+  → SpineValue V
+  → Value N
+  → CTI2.SameCtx γ γ′
+  → store-lift (sourceStoreʷ W) CTI2.⊢↑[ nothing ] c
+  → W ∣ γ′ ⊢² V
+      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
+  → W ∣ γ ⊢² V ↑ `∀↑ c ⊑ N ∶ q
+right-inj-reveal-all-id² {W = W} {A = A} {B = B}
+    {H = H} {c = c} sv vN sc c⊢ prem q =
+  CTI2.reveal⊑² CTI2.rebase-idᴸ sc (CTI2.⊢↑-∀-idˣ c⊢)
+    (right-inj-inversion² sv vN prem
+      (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
+        (sym (cong `∀ (pivot-id-endpoints↑ c⊢))) q))
+    q
+
+right-inj-conceal-all-id² : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
+    {V : Term Δᴸ} {N : Term Δᴿ}
+    {A B : Ty (suc Δᴸ)} {H : Ty Δᴿ} {ν : Env∼ Δᴿ}
+    {c : Conv↓ (suc Δᴸ) A B}
+    {gH : Ground H} {H∼★ : ν ⊢ H ∼★} {Hns : NonStar H}
+    {cH : ν ⊢ H ∼ H} {p : `∀ A ⊑ᵂ⟨ W ⟩ ★}
+  → SpineValue V
+  → Value N
+  → CTI2.SameCtx γ γ′
+  → store-lift (sourceStoreʷ W) CTI2.⊢↓[ nothing ] c
+  → W ∣ γ′ ⊢² V
+      ⊑ N ⟨ _! ⦃ gH ⦄ ⦃ H∼★ ⦄ cH ⦃ Hns ⦄ ⟩ ∶ p
+  → (q : `∀ B ⊑ᵂ⟨ W ⟩ H)
+  → W ∣ γ ⊢² V ↓ `∀↓ c ⊑ N ∶ q
+right-inj-conceal-all-id² {W = W} {A = A} {B = B}
+    {H = H} {c = c} sv vN sc c⊢ prem q =
+  CTI2.conceal⊑² CTI2.rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
+    (right-inj-inversion² sv vN prem
+      (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
+        (sym (cong `∀ (pivot-id-endpoints↓ c⊢))) q))
+    q

--- a/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
@@ -1,0 +1,319 @@
+module proof.DGG.ExtraCastRight2Counterexample where
+
+-- File Charter:
+--   * Isolates the type-level obstruction in the bare-seal case of
+--     right-injection inversion for CastTermImprecision2.
+--   * Builds a valid pivot-local rebase and source seal for which the
+--     premise-to-star, conclusion-to-star, and conclusion-to-ground
+--     obligations all exist, but the premise-to-ground obligation needed
+--     by recursive inversion does not.
+--   * Realizes that obstruction with a closed term-imprecision derivation and
+--     proves that the relation required after target-tag cancellation is
+--     empty when the displaced source variable has a precise center.
+--   * Depends only on the version-2 world/rebase definitions and the core
+--     type-imprecision relation; it does not change the live relation.
+
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans; cong)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-bind; _∋_⦂_; Z∋; S-bind∋)
+open import Consistency using
+  (Env∼; X∼★; _⊢_∼_; _↪ᵗ_; empty; keep; skip; toRenameᵗ; _!; id)
+open import Imprecision
+open import Conversion using (seal)
+open import CastTerms
+open import Primitives using (κℕ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; _⊢↓[_]_; _∣_⊢²_⊑_∶_;
+   RebaseAt; rebase-at; same-runtime; store-rep-imp; ⊢↓-sealˣ)
+
+private
+  Z : TyVar 2
+  Z = Fin.zero
+
+  U : TyVar 2
+  U = Fin.suc Fin.zero
+
+  Y : TyVar 1
+  Y = Fin.zero
+
+source-store : TyStore 2
+source-store = store-bind (store-bind store-empty (‵ `ℕ)) ★
+
+target-store : TyStore 1
+target-store = store-bind store-empty ★
+
+source-Z∋ : source-store ∋ Z ⦂ ★
+source-Z∋ = Z∋ refl
+
+source-U∋ : source-store ∋ U ⦂ ‵ `ℕ
+source-U∋ = S-bind∋ (Z∋ refl) refl
+
+target-Y∋ : target-store ∋ Y ⦂ ★
+target-Y∋ = Z∋ refl
+
+source-η : 2 ↪ᵗ 2
+source-η = keep (keep empty)
+
+-- Before the outer Z/Y conceal boundary, Y is aligned with U.
+target-η-U : 1 ↪ᵗ 2
+target-η-U = skip (keep empty)
+
+-- After that boundary, Y is aligned with Z.
+target-η-Z : 1 ↪ᵗ 2
+target-η-Z = keep empty
+
+imp-env : ImpEnv 2
+imp-env Fin.zero = X⊑★
+imp-env (Fin.suc Fin.zero) = X⊑X
+
+pre-world : World 2 1 2
+pre-world = world source-η target-η-U imp-env source-store target-store
+
+post-world : World 2 1 2
+post-world = world source-η target-η-Z imp-env source-store target-store
+
+Z-Y-representation : CTI2.StoreRepImp post-world Z Y
+Z-Y-representation = store-rep-imp ★⊑★
+
+Z-Y-rebase : RebaseAt pre-world post-world Z Y
+Z-Y-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
+    (λ _ → refl)
+    refl
+    Z-Y-representation
+
+Z-seal-typed : source-store ⊢↓[ just Z ] seal Z ★
+Z-seal-typed = ⊢↓-sealˣ source-Z∋
+
+-- These are exactly the three type obligations available in the
+-- conceal⊑² branch of right-injection inversion.
+
+premise-to-star : ★ ⊑ᵂ⟨ pre-world ⟩ ★
+premise-to-star = ★⊑★
+
+conclusion-to-star : ＇ Z ⊑ᵂ⟨ post-world ⟩ ★
+conclusion-to-star = X⊑★ refl
+
+conclusion-to-tag : ＇ Z ⊑ᵂ⟨ post-world ⟩ ＇ Y
+conclusion-to-tag = X⊑X
+
+-- Recursive inversion would need this fourth obligation.  It cannot be
+-- built: before the boundary, Y embeds with U, so its target is a variable,
+-- while the source seal representation is dynamic.
+
+no-premise-to-tag : ★ ⊑ᵂ⟨ pre-world ⟩ ＇ Y → ⊥
+no-premise-to-tag ()
+
+-- The missing premise-to-tag obligation is not merely a type-level corner:
+-- paired source/target injections can hide it.  The following closed value
+-- relation realizes all the premises of the problematic source-seal branch.
+
+U-Y-representation : CTI2.StoreRepImp pre-world U Y
+U-Y-representation = store-rep-imp ι⊑★
+
+U-Y-rebase : RebaseAt pre-world pre-world U Y
+U-Y-rebase = CTI2.sameWorldRebaseAt refl U-Y-representation
+
+source-U∈ : source-store ∋ U ⦂ ‵ `ℕ
+source-U∈ = source-U∋
+
+source-U-seal-typed : source-store ⊢↓[ just U ] seal U (‵ `ℕ)
+source-U-seal-typed = ⊢↓-sealˣ source-U∈
+
+target-Y-seal-typed : target-store ⊢↓[ just Y ] seal Y ★
+target-Y-seal-typed = ⊢↓-sealˣ target-Y∋
+
+private
+  source-env : Env∼ 2
+  source-env _ = X∼★
+
+  target-env : Env∼ 1
+  target-env _ = X∼★
+
+  ℕ! : target-env ⊢ (‵ `ℕ) ∼ ★
+  ℕ! = id (‵ `ℕ) !
+
+  U! : source-env ⊢ ＇ U ∼ ★
+  U! = id {μ = source-env} (＇ U) !
+
+  Y! : target-env ⊢ ＇ Y ∼ ★
+  Y! = id {μ = target-env} (＇ Y) !
+
+inner-base² : pre-world ∣ [] ⊢² $ (κℕ 0) ⊑ $ (κℕ 0) ∶ ι⊑ι
+inner-base² = CTI2.κ⊑κ² (κℕ 0) ι⊑ι
+
+inner-target-tag² : pre-world ∣ [] ⊢²
+    $ (κℕ 0) ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ ι⊑★
+inner-target-tag² = CTI2.⊑cast² ℕ! inner-base² ι⊑★
+
+inner-seals² : pre-world ∣ [] ⊢²
+    ($ (κℕ 0)) ↓ seal U (‵ `ℕ)
+    ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ X⊑X
+inner-seals² =
+  CTI2.conceal⊑conceal² U-Y-rebase CTI2.same-[]
+    source-U-seal-typed target-Y-seal-typed inner-target-tag² X⊑X
+
+inner-paired-tags² : pre-world ∣ [] ⊢²
+    (($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩
+    ⊑ (($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★) ⟨ Y! ⟩ ∶ ★⊑★
+inner-paired-tags² =
+  CTI2.cast⊑cast² U! Y! inner-seals² ★⊑★
+
+problematic-seal² : post-world ∣ [] ⊢²
+    ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
+    ⊑ (($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★) ⟨ Y! ⟩ ∶
+      conclusion-to-star
+problematic-seal² =
+  CTI2.conceal⊑² (CTI2.rebase-varᴸ Z-Y-rebase) CTI2.same-[]
+    Z-seal-typed inner-paired-tags² conclusion-to-star
+
+-- Unlike Z's center, U's center is precise.  The natural reassociation
+-- would need the following obligation, which is therefore empty.
+
+no-U-to-star : ＇ U ⊑ᵂ⟨ pre-world ⟩ ★ → ⊥
+no-U-to-star (X⊑★ ())
+
+private
+  U≢Z : U ≢ Z
+  U≢Z ()
+
+  UPrecise : World 2 1 2 → Set
+  UPrecise W =
+    CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) U) ≡ X⊑X
+
+  post-U-precise : UPrecise post-world
+  post-U-precise = refl
+
+  var-identity-not-star : _≡_ {A = VarImp} X⊑X X⊑★ → ⊥
+  var-identity-not-star ()
+
+  U-precise-rebase-back : ∀ {Wᵖ W : World 2 1 2} {Y′}
+    → RebaseAt Wᵖ W Z Y′
+    → UPrecise W
+    → UPrecise Wᵖ
+  U-precise-rebase-back {Wᵖ = Wᵖ} {W = W} rb precise =
+    trans
+      (sym (cong (CTI2.impEnvʷ Wᵖ)
+        (CTI2.RebaseAt.ηᴸ-off-pivot rb U≢Z)))
+      (trans
+        (sym (CTI2.RebaseAt.sameImpEnv rb
+          (toRenameᵗ (CTI2.ηᴸʷ W) U)))
+        precise)
+
+  U-precise-rebaseᴸ-back : ∀ {Wᵖ W : World 2 1 2}
+    → CTI2.RebaseAtᴸ Wᵖ W (just Z)
+    → UPrecise W
+    → UPrecise Wᵖ
+  U-precise-rebaseᴸ-back (CTI2.rebase-varᴸ rb) precise =
+    U-precise-rebase-back rb precise
+  U-precise-rebaseᴸ-back
+      (CTI2.rebase-onlyᴸ to-star disaligned represented) precise =
+    precise
+
+  no-U-to-star-at : ∀ {W : World 2 1 2}
+    → UPrecise W
+    → ＇ U ⊑ᵂ⟨ W ⟩ ★
+    → ⊥
+  no-U-to-star-at precise (X⊑★ eq) =
+    var-identity-not-star (trans (sym precise) eq)
+
+  variable-not-base : ∀ {W : World 2 1 2} {X : TyVar 2}
+    → ＇ X ⊑ᵂ⟨ W ⟩ ‵ `ℕ
+    → ⊥
+  variable-not-base ()
+
+  star-not-base : ∀ {W : World 2 1 2}
+    → ★ ⊑ᵂ⟨ W ⟩ ‵ `ℕ
+    → ⊥
+  star-not-base ()
+
+  star-not-variable : ∀ {W : World 2 1 2}
+    → ★ ⊑ᵂ⟨ W ⟩ ＇ Y
+    → ⊥
+  star-not-variable ()
+
+  no-inner-tags : ∀ {W : World 2 1 2} {γ : CTI2.CtxImp W}
+      {p : ★ ⊑ᵂ⟨ W ⟩ ★}
+    → UPrecise W
+    → W ∣ γ ⊢² (($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩
+        ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ p
+    → ⊥
+  no-inner-tags {W = W} precise
+      (CTI2.cast⊑cast² {p = p} c c′ prem q) =
+    variable-not-base {W = W} {X = U} p
+  no-inner-tags {W = W} precise
+      (CTI2.⊑cast² {p = p} c′ prem q) =
+    star-not-base {W = W} p
+  no-inner-tags {W = W} precise
+      (CTI2.cast⊑² {p = p} c prem q) =
+    no-U-to-star-at {W = W} precise p
+
+  no-outer-vs-tag : ∀ {W : World 2 1 2} {γ : CTI2.CtxImp W}
+      {p : ＇ Z ⊑ᵂ⟨ W ⟩ ★}
+    → UPrecise W
+    → W ∣ γ ⊢²
+        ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
+        ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ p
+    → ⊥
+  no-outer-vs-tag {W = W} precise
+      (CTI2.⊑cast² {p = p} c′ prem q) =
+    variable-not-base {W = W} {X = Z} p
+  no-outer-vs-tag precise
+      (CTI2.conceal⊑² rb sc (CTI2.⊢↓-sealˣ x∋) prem q) =
+    no-inner-tags (U-precise-rebaseᴸ-back rb precise) prem
+
+  target-rebase-source : ∀ {Wᵖ : World 2 1 2}
+    → CTI2.RebaseAtᴿ Wᵖ post-world (just Y)
+    → RebaseAt Wᵖ post-world Z Y
+  target-rebase-source
+      (CTI2.rebase-varᴿ {Xᴸ = Fin.zero} rb) =
+    rb
+  target-rebase-source
+      (CTI2.rebase-varᴿ {Xᴸ = Fin.suc Fin.zero} rb)
+      with CTI2.RebaseAt.pivotAligned rb
+  target-rebase-source
+      (CTI2.rebase-varᴿ {Xᴸ = Fin.suc Fin.zero} rb) | ()
+
+no-problematic-result :
+    post-world ∣ [] ⊢²
+      ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
+      ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ conclusion-to-tag
+    → ⊥
+no-problematic-result
+    (CTI2.⊑conceal² rb sc (CTI2.⊢↓-sealˣ x∋) prem q) =
+  no-outer-vs-tag
+    (U-precise-rebase-back (target-rebase-source rb) post-U-precise)
+    prem
+no-problematic-result
+    (CTI2.conceal⊑² {W′ = W′} {p = p} rb sc c⊢ prem q) =
+  star-not-variable {W = W′} p
+no-problematic-result
+    (CTI2.conceal⊑conceal² rb sc
+      (CTI2.⊢↓-sealˣ x∋) (CTI2.⊢↓-sealˣ y∋) prem q) =
+  no-inner-tags (U-precise-rebase-back rb post-U-precise) prem
+
+-- Thus no bare-seal extension of right-injection inversion can cover this
+-- valid input derivation.  Type-imprecision proof irrelevance cannot repair
+-- the failure: the required conclusion has no inhabitant at all.
+
+no-bare-seal-right-inj² :
+    (post-world ∣ [] ⊢²
+        ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
+        ⊑ (($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★) ⟨ Y! ⟩ ∶
+          conclusion-to-star
+      → post-world ∣ [] ⊢²
+        ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
+        ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ conclusion-to-tag)
+    → ⊥
+no-bare-seal-right-inj² invert =
+  no-problematic-result (invert problematic-seal²)

--- a/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
@@ -1,24 +1,30 @@
 module proof.DGG.ExtraCastRight2Counterexample where
 
 -- File Charter:
---   * Isolates the type-level obstruction in the bare-seal case of
---     right-injection inversion for CastTermImprecision2.
---   * Builds a valid pivot-local rebase and source seal for which the
---     premise-to-star, conclusion-to-star, and conclusion-to-ground
---     obligations all exist, but the premise-to-ground obligation needed
---     by recursive inversion does not.
---   * Realizes that obstruction with a closed term-imprecision derivation and
---     proves that the relation required after target-tag cancellation is
---     empty when the displaced source variable has a precise center.
---   * Depends only on the version-2 world/rebase definitions and the core
---     type-imprecision relation; it does not change the live relation.
+--   * Regression for the bare-seal case of right-injection inversion.
+--   * Under the original design, where rebasing forced the premise and
+--     conclusion worlds to agree on every imprecision mark, this file
+--     proved a counterexample (commit 69fbef83): a valid input
+--     derivation whose required output after target-tag cancellation
+--     was uninhabited.  The culprit was a stale precise mark: the
+--     outer conceal boundary rebases the target variable Y from U to
+--     Z, leaving U precise but unaligned, and mark equality preserved
+--     the staleness all the way down.
+--   * The relation now carries ImpEnvMono instead: marks may decay
+--     toward X⊑★ from conclusion to premise.  This file rebuilds the
+--     same configuration and proves the previously-empty output
+--     derivable, by descending into a dynamized premise world.
+--   * Ties in the WFWorld invariant: the stale input world is not
+--     mark-honest, the dynamized worlds are, and the repair is
+--     exactly the re-marking that honesty demands.
 
 open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
 open import Data.List using ([])
 open import Data.Maybe using (just)
+open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; _≢_; refl; sym; trans; cong)
+  using (_≡_; _≢_; refl)
 
 open import Types
 open import TyStore using
@@ -88,15 +94,14 @@ Z-Y-rebase =
   rebase-at (same-runtime refl refl)
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    (λ _ → refl)
     refl
     Z-Y-representation
 
 Z-seal-typed : source-store ⊢↓[ just Z ] seal Z ★
 Z-seal-typed = ⊢↓-sealˣ source-Z∋
 
--- These are exactly the three type obligations available in the
--- conceal⊑² branch of right-injection inversion.
+-- The three type obligations available at the conceal⊑² boundary of
+-- the stale input.
 
 premise-to-star : ★ ⊑ᵂ⟨ pre-world ⟩ ★
 premise-to-star = ★⊑★
@@ -107,16 +112,32 @@ conclusion-to-star = X⊑★ refl
 conclusion-to-tag : ＇ Z ⊑ᵂ⟨ post-world ⟩ ＇ Y
 conclusion-to-tag = X⊑X
 
--- Recursive inversion would need this fourth obligation.  It cannot be
--- built: before the boundary, Y embeds with U, so its target is a variable,
--- while the source seal representation is dynamic.
+-- In the stale pre-world, Y embeds with U, so the fourth obligation
+-- that recursive inversion would want cannot be built there, and U's
+-- precise mark also blocks the source-tag detour.  These two negative
+-- facts are what made the original counterexample tick; they are
+-- still true of the stale worlds and are kept as documentation.
 
 no-premise-to-tag : ★ ⊑ᵂ⟨ pre-world ⟩ ＇ Y → ⊥
 no-premise-to-tag ()
 
--- The missing premise-to-tag obligation is not merely a type-level corner:
--- paired source/target injections can hide it.  The following closed value
--- relation realizes all the premises of the problematic source-seal branch.
+no-U-to-star : ＇ U ⊑ᵂ⟨ pre-world ⟩ ★ → ⊥
+no-U-to-star (X⊑★ ())
+
+-- The stale input world is not mark-honest: U's center is precise
+-- but no target variable embeds there.
+
+post-world-not-WF : CTI2.WFWorld post-world → ⊥
+post-world-not-WF wf with wf U refl
+post-world-not-WF wf | Fin.zero , ()
+
+pre-world-WF : CTI2.WFWorld pre-world
+pre-world-WF Fin.zero ()
+pre-world-WF (Fin.suc Fin.zero) _ = Fin.zero , refl
+
+------------------------------------------------------------------------
+-- The stale input derivation
+------------------------------------------------------------------------
 
 U-Y-representation : CTI2.StoreRepImp pre-world U Y
 U-Y-representation = store-rep-imp ι⊑★
@@ -124,11 +145,8 @@ U-Y-representation = store-rep-imp ι⊑★
 U-Y-rebase : RebaseAt pre-world pre-world U Y
 U-Y-rebase = CTI2.sameWorldRebaseAt refl U-Y-representation
 
-source-U∈ : source-store ∋ U ⦂ ‵ `ℕ
-source-U∈ = source-U∋
-
 source-U-seal-typed : source-store ⊢↓[ just U ] seal U (‵ `ℕ)
-source-U-seal-typed = ⊢↓-sealˣ source-U∈
+source-U-seal-typed = ⊢↓-sealˣ source-U∋
 
 target-Y-seal-typed : target-store ⊢↓[ just Y ] seal Y ★
 target-Y-seal-typed = ⊢↓-sealˣ target-Y∋
@@ -160,7 +178,7 @@ inner-seals² : pre-world ∣ [] ⊢²
     ($ (κℕ 0)) ↓ seal U (‵ `ℕ)
     ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ X⊑X
 inner-seals² =
-  CTI2.conceal⊑conceal² U-Y-rebase CTI2.same-[]
+  CTI2.conceal⊑conceal² (λ _ eq → eq) U-Y-rebase CTI2.same-[]
     source-U-seal-typed target-Y-seal-typed inner-target-tag² X⊑X
 
 inner-paired-tags² : pre-world ∣ [] ⊢²
@@ -174,146 +192,75 @@ problematic-seal² : post-world ∣ [] ⊢²
     ⊑ (($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★) ⟨ Y! ⟩ ∶
       conclusion-to-star
 problematic-seal² =
-  CTI2.conceal⊑² (CTI2.rebase-varᴸ Z-Y-rebase) CTI2.same-[]
-    Z-seal-typed inner-paired-tags² conclusion-to-star
+  CTI2.conceal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ Z-Y-rebase)
+    CTI2.same-[] Z-seal-typed inner-paired-tags² conclusion-to-star
 
--- Unlike Z's center, U's center is precise.  The natural reassociation
--- would need the following obligation, which is therefore empty.
+------------------------------------------------------------------------
+-- The repair: descend into a mark-honest, dynamized premise world
+------------------------------------------------------------------------
 
-no-U-to-star : ＇ U ⊑ᵂ⟨ pre-world ⟩ ★ → ⊥
-no-U-to-star (X⊑★ ())
+-- Re-marking U's center as dynamic records that below the Z/Y
+-- boundary U has no target partner.  The dynamized worlds are
+-- mark-honest, and ImpEnvMono admits the descent from the stale
+-- conclusion world.
 
-private
-  U≢Z : U ≢ Z
-  U≢Z ()
+imp-env-dyn : ImpEnv 2
+imp-env-dyn Fin.zero = X⊑★
+imp-env-dyn (Fin.suc Fin.zero) = X⊑★
 
-  UPrecise : World 2 1 2 → Set
-  UPrecise W =
-    CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) U) ≡ X⊑X
+pre-worldᵈ : World 2 1 2
+pre-worldᵈ =
+  world source-η target-η-U imp-env-dyn source-store target-store
 
-  post-U-precise : UPrecise post-world
-  post-U-precise = refl
+pre-worldᵈ-WF : CTI2.WFWorld pre-worldᵈ
+pre-worldᵈ-WF Fin.zero ()
+pre-worldᵈ-WF (Fin.suc Fin.zero) ()
 
-  var-identity-not-star : _≡_ {A = VarImp} X⊑X X⊑★ → ⊥
-  var-identity-not-star ()
+dynamize : CTI2.ImpEnvMono post-world pre-worldᵈ
+dynamize Fin.zero _ = refl
+dynamize (Fin.suc Fin.zero) _ = refl
 
-  U-precise-rebase-back : ∀ {Wᵖ W : World 2 1 2} {Y′}
-    → RebaseAt Wᵖ W Z Y′
-    → UPrecise W
-    → UPrecise Wᵖ
-  U-precise-rebase-back {Wᵖ = Wᵖ} {W = W} rb precise =
-    trans
-      (sym (cong (CTI2.impEnvʷ Wᵖ)
-        (CTI2.RebaseAt.ηᴸ-off-pivot rb U≢Z)))
-      (trans
-        (sym (CTI2.RebaseAt.sameImpEnv rb
-          (toRenameᵗ (CTI2.ηᴸʷ W) U)))
-        precise)
+Z-Y-rebaseᵈ : RebaseAt pre-worldᵈ post-world Z Y
+Z-Y-rebaseᵈ =
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
+    refl
+    Z-Y-representation
 
-  U-precise-rebaseᴸ-back : ∀ {Wᵖ W : World 2 1 2}
-    → CTI2.RebaseAtᴸ Wᵖ W (just Z)
-    → UPrecise W
-    → UPrecise Wᵖ
-  U-precise-rebaseᴸ-back (CTI2.rebase-varᴸ rb) precise =
-    U-precise-rebase-back rb precise
-  U-precise-rebaseᴸ-back
-      (CTI2.rebase-onlyᴸ to-star disaligned represented) precise =
-    precise
+U-Y-representationᵈ : CTI2.StoreRepImp pre-worldᵈ U Y
+U-Y-representationᵈ = store-rep-imp ι⊑★
 
-  no-U-to-star-at : ∀ {W : World 2 1 2}
-    → UPrecise W
-    → ＇ U ⊑ᵂ⟨ W ⟩ ★
-    → ⊥
-  no-U-to-star-at precise (X⊑★ eq) =
-    var-identity-not-star (trans (sym precise) eq)
+U-Y-rebaseᵈ : RebaseAt pre-worldᵈ pre-worldᵈ U Y
+U-Y-rebaseᵈ = CTI2.sameWorldRebaseAt refl U-Y-representationᵈ
 
-  variable-not-base : ∀ {W : World 2 1 2} {X : TyVar 2}
-    → ＇ X ⊑ᵂ⟨ W ⟩ ‵ `ℕ
-    → ⊥
-  variable-not-base ()
+-- The obligation that was empty in the stale pre-world is inhabited
+-- in the dynamized one.
 
-  star-not-base : ∀ {W : World 2 1 2}
-    → ★ ⊑ᵂ⟨ W ⟩ ‵ `ℕ
-    → ⊥
-  star-not-base ()
+U-to-starᵈ : ＇ U ⊑ᵂ⟨ pre-worldᵈ ⟩ ★
+U-to-starᵈ = X⊑★ refl
 
-  star-not-variable : ∀ {W : World 2 1 2}
-    → ★ ⊑ᵂ⟨ W ⟩ ＇ Y
-    → ⊥
-  star-not-variable ()
+repaired-base² : pre-worldᵈ ∣ [] ⊢²
+    $ (κℕ 0) ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ ι⊑★
+repaired-base² = CTI2.⊑cast² ℕ! (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ι⊑★
 
-  no-inner-tags : ∀ {W : World 2 1 2} {γ : CTI2.CtxImp W}
-      {p : ★ ⊑ᵂ⟨ W ⟩ ★}
-    → UPrecise W
-    → W ∣ γ ⊢² (($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩
-        ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ p
-    → ⊥
-  no-inner-tags {W = W} precise
-      (CTI2.cast⊑cast² {p = p} c c′ prem q) =
-    variable-not-base {W = W} {X = U} p
-  no-inner-tags {W = W} precise
-      (CTI2.⊑cast² {p = p} c′ prem q) =
-    star-not-base {W = W} p
-  no-inner-tags {W = W} precise
-      (CTI2.cast⊑² {p = p} c prem q) =
-    no-U-to-star-at {W = W} precise p
+repaired-seal² : pre-worldᵈ ∣ [] ⊢²
+    ($ (κℕ 0)) ↓ seal U (‵ `ℕ) ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ U-to-starᵈ
+repaired-seal² =
+  CTI2.conceal⊑² (λ _ eq → eq) (CTI2.rebase-varᴸ U-Y-rebaseᵈ)
+    CTI2.same-[] source-U-seal-typed repaired-base² U-to-starᵈ
 
-  no-outer-vs-tag : ∀ {W : World 2 1 2} {γ : CTI2.CtxImp W}
-      {p : ＇ Z ⊑ᵂ⟨ W ⟩ ★}
-    → UPrecise W
-    → W ∣ γ ⊢²
-        ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
-        ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ p
-    → ⊥
-  no-outer-vs-tag {W = W} precise
-      (CTI2.⊑cast² {p = p} c′ prem q) =
-    variable-not-base {W = W} {X = Z} p
-  no-outer-vs-tag precise
-      (CTI2.conceal⊑² rb sc (CTI2.⊢↓-sealˣ x∋) prem q) =
-    no-inner-tags (U-precise-rebaseᴸ-back rb precise) prem
+repaired-tag² : pre-worldᵈ ∣ [] ⊢²
+    (($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩ ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ ★⊑★
+repaired-tag² = CTI2.cast⊑² U! repaired-seal² ★⊑★
 
-  target-rebase-source : ∀ {Wᵖ : World 2 1 2}
-    → CTI2.RebaseAtᴿ Wᵖ post-world (just Y)
-    → RebaseAt Wᵖ post-world Z Y
-  target-rebase-source
-      (CTI2.rebase-varᴿ {Xᴸ = Fin.zero} rb) =
-    rb
-  target-rebase-source
-      (CTI2.rebase-varᴿ {Xᴸ = Fin.suc Fin.zero} rb)
-      with CTI2.RebaseAt.pivotAligned rb
-  target-rebase-source
-      (CTI2.rebase-varᴿ {Xᴸ = Fin.suc Fin.zero} rb) | ()
+-- The output relation demanded by right-injection inversion after the
+-- target's Y! tag cancels.  Under mark equality this type was proved
+-- empty; under monotone dynamization it is inhabited.
 
-no-problematic-result :
-    post-world ∣ [] ⊢²
-      ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
-      ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ conclusion-to-tag
-    → ⊥
-no-problematic-result
-    (CTI2.⊑conceal² rb sc (CTI2.⊢↓-sealˣ x∋) prem q) =
-  no-outer-vs-tag
-    (U-precise-rebase-back (target-rebase-source rb) post-U-precise)
-    prem
-no-problematic-result
-    (CTI2.conceal⊑² {W′ = W′} {p = p} rb sc c⊢ prem q) =
-  star-not-variable {W = W′} p
-no-problematic-result
-    (CTI2.conceal⊑conceal² rb sc
-      (CTI2.⊢↓-sealˣ x∋) (CTI2.⊢↓-sealˣ y∋) prem q) =
-  no-inner-tags (U-precise-rebase-back rb post-U-precise) prem
-
--- Thus no bare-seal extension of right-injection inversion can cover this
--- valid input derivation.  Type-imprecision proof irrelevance cannot repair
--- the failure: the required conclusion has no inhabitant at all.
-
-no-bare-seal-right-inj² :
-    (post-world ∣ [] ⊢²
-        ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
-        ⊑ (($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★) ⟨ Y! ⟩ ∶
-          conclusion-to-star
-      → post-world ∣ [] ⊢²
-        ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
-        ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ conclusion-to-tag)
-    → ⊥
-no-bare-seal-right-inj² invert =
-  no-problematic-result (invert problematic-seal²)
+repaired-result² : post-world ∣ [] ⊢²
+    ((($ (κℕ 0)) ↓ seal U (‵ `ℕ)) ⟨ U! ⟩) ↓ seal Z ★
+    ⊑ ($ (κℕ 0) ⟨ ℕ! ⟩) ↓ seal Y ★ ∶ conclusion-to-tag
+repaired-result² =
+  CTI2.conceal⊑conceal² dynamize Z-Y-rebaseᵈ CTI2.same-[]
+    Z-seal-typed target-Y-seal-typed repaired-tag² conclusion-to-tag

--- a/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
@@ -95,6 +95,7 @@ Z-Y-rebase =
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
     refl
+    (λ _ → U , refl)
     Z-Y-representation
 
 Z-seal-typed : source-store ⊢↓[ just Z ] seal Z ★
@@ -226,6 +227,7 @@ Z-Y-rebaseᵈ =
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
     refl
+    (λ _ → U , refl)
     Z-Y-representation
 
 U-Y-representationᵈ : CTI2.StoreRepImp pre-worldᵈ U Y

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -120,7 +120,8 @@ probe-Λ-premise =
 probe-Λ⊑ :
   probe-world₀ ∣ [] ⊢² Λ (ƛ (` 0)) ⊑ ƛ (` 0) ∶ probe-∀⊑⇒★
 probe-Λ⊑ =
-  CTI2.Λ⊑² CTI2.liftᴸ-[] (ƛ (` 0)) probe-target-lambda-⊢
+  CTI2.Λ⊑² nonvar-fun (∈-fun-left var-∈)
+    CTI2.liftᴸ-[] (ƛ (` 0)) probe-target-lambda-⊢
     probe-Λ-premise probe-∀⊑⇒★
 
 probe-function₀ :

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -1,0 +1,216 @@
+module proof.DGG.LambdaImpProbe where
+
+-- File Charter:
+--   * Probes the Λ⊑² rule with the smallest ∀ ⊑ non-∀ pair: the source
+--     instantiates a type abstraction at ℕ while the target is a
+--     monomorphic lambda at ★ ⇒ ★ and never allocates a type variable.
+--   * Checkpoint 0 is the first use of Λ⊑² in the development, showing
+--     the rule is derivable where intended.
+--   * After the source's β-Λ step, no checkpoint exists at all: the
+--     one-sided reveal rules demand a target pivot variable, and the
+--     target type context is empty.  This is recorded as negative
+--     theorems that hold for every world, not just one alignment.
+--   * Separately, the Λ⊑² premise cannot serve as the induction
+--     hypothesis for the missing checkpoint even once left-only pivots
+--     exist: it weakens the target term with ⇑ᵗᵐ and lifts the target
+--     store, so it lives at target type context 1 while the machine's
+--     target store stays at context 0, and SameRuntime is homogeneous.
+
+open import Data.Empty using (⊥-elim)
+open import Data.List using ([]; _∷_)
+import Data.Fin as Fin
+open import Data.Maybe using (just; nothing)
+open import Relation.Binary.PropositionalEquality using (refl)
+open import Relation.Nullary using (¬_)
+
+open import Types
+open import TyStore using (TyStore; store-empty; store-bind)
+open import TermCtx using (Z)
+open import Consistency using (_↪ᵗ_; empty; id↪ᵗ)
+open import Imprecision
+open import Primitives using (Const; κℕ)
+open import CastTerms
+open import Reduction
+open import Eval using (step?; value?)
+import proof.DGG.Examples as Ex
+open Ex.OneStep using (Δ′; change; next; reduction)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using (_⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+import proof.DGG.Examples2 as Ex2
+
+------------------------------------------------------------------------
+-- The probe pair
+------------------------------------------------------------------------
+
+-- Source: ((Λ (ƛ x)) ⦂∀ (X ⇒ X) [ ℕ ]) · 7, Example 12's direct
+-- program.  Target: (ƛ x) · (7 ⟨ ℕ! ⟩) at type ★, with the type
+-- abstraction erased entirely, so ∀ X. X ⇒ X ⊑ ★ ⇒ ★ crosses the
+-- ∀ ⊑ non-∀ boundary and the pair needs Λ⊑².
+
+probe-source : Term 0
+probe-source = Ex.example12-left
+
+probe-target : Term 0
+probe-target = (ƛ (` 0)) · (Ex.c ⟨ CTI2.example12-ℕ! ⟩)
+
+probe-target-lambda-⊢ : Ex.∅ ⊢ ƛ (` 0) ⦂ ★ ⇒ ★
+probe-target-lambda-⊢ = ⊢ƛ (⊢` Z)
+
+probe-target-⊢ : Ex.∅ ⊢ probe-target ⦂ ★
+probe-target-⊢ =
+  ⊢· probe-target-lambda-⊢ (⊢⟨⟩ Ex.c-⊢ CTI2.example12-ℕ!)
+
+------------------------------------------------------------------------
+-- Reduction traces
+------------------------------------------------------------------------
+
+-- The source allocates one type variable (β-Λ) and then runs the
+-- revealed function; this is Example 12's left trace, reused.
+
+probe-source-reduction :
+  probe-source —↠[ Ex.left-changes ] Ex.left-final
+probe-source-reduction = Ex.example12-left-reduction
+
+-- The target never allocates: its argument 7 ⟨ ℕ! ⟩ is already a
+-- value, so the only step is the β for the monomorphic lambda.
+
+probe-target-step₀ : Ex.OneStep store-empty probe-target
+probe-target-step₀ =
+  Ex.from-just-step (step? store-empty probe-target) refl
+
+probe-target₁ : Term (Δ′ probe-target-step₀)
+probe-target₁ = next probe-target-step₀
+
+probe-target₁-value : Value probe-target₁
+probe-target₁-value = Ex.from-just-value (value? probe-target₁) refl
+
+probe-target-changes : StoreChanges 0 (Δ′ probe-target-step₀)
+probe-target-changes = change probe-target-step₀ ∷ []
+
+probe-target-reduction :
+  probe-target —↠[ probe-target-changes ] probe-target₁
+probe-target-reduction =
+  probe-target
+  —→[ change probe-target-step₀ ]⟨ reduction probe-target-step₀ ⟩
+  probe-target₁ ∎[]
+
+------------------------------------------------------------------------
+-- Checkpoint 0: the first use of Λ⊑²
+------------------------------------------------------------------------
+
+probe-world₀ : CTI2.World 0 0 0
+probe-world₀ = Ex2.reflWorld store-empty
+
+probe-∀⊑⇒★ : `∀ Ex.X⇒X ⊑ᵂ⟨ probe-world₀ ⟩ (★ ⇒ ★)
+probe-∀⊑⇒★ = Ex2.∀X⇒X⊑★⇒★² {W = probe-world₀}
+
+probe-body⊑ :
+  Ex.X⇒X ⊑ᵂ⟨ CTI2.liftWorldBoth X⊑★ probe-world₀ ⟩ ⇑ᵗ (★ ⇒ ★)
+probe-body⊑ = ⇒⊑⇒ (X⊑★ refl) (X⊑★ refl)
+
+-- The Λ⊑² premise as the rule demands it: the target lambda is
+-- weakened with ⇑ᵗᵐ into the extended target context, and the world
+-- lifts both stores.
+
+probe-Λ-premise :
+  CTI2.liftWorldBoth X⊑★ probe-world₀ ∣ [] ⊢²
+    ƛ (` 0) ⊑ ⇑ᵗᵐ (ƛ (` 0)) ∶ probe-body⊑
+probe-Λ-premise =
+  CTI2.ƛ⊑ƛ²
+    {A = ＇ Fin.zero} {A′ = ★}
+    {pA = X⊑★ refl} {pB = X⊑★ refl}
+    (CTI2.x⊑x² {p = X⊑★ refl} CTI2.Zʷ)
+
+probe-Λ⊑ :
+  probe-world₀ ∣ [] ⊢² Λ (ƛ (` 0)) ⊑ ƛ (` 0) ∶ probe-∀⊑⇒★
+probe-Λ⊑ =
+  CTI2.Λ⊑² CTI2.lift-[] (ƛ (` 0)) probe-target-lambda-⊢
+    probe-Λ-premise probe-∀⊑⇒★
+
+probe-function₀ :
+  probe-world₀ ∣ [] ⊢²
+    (Λ (ƛ (` 0))) ⦂∀ Ex.X⇒X [ Ex.ℕᵗ ] ⊑ ƛ (` 0) ∶
+      Ex2.ℕ⇒ℕ⊑★⇒★² {W = probe-world₀}
+probe-function₀ =
+  CTI2.•⊑²
+    {C = Ex.X⇒X} {A = Ex.ℕᵗ} {B = ★ ⇒ ★}
+    probe-∀⊑⇒★ probe-Λ⊑
+    (Ex2.ℕ⊑★² {W = probe-world₀})
+    (Ex2.ℕ⇒ℕ⊑★⇒★² {W = probe-world₀})
+
+probe-checkpoint₀ :
+  probe-world₀ ∣ [] ⊢² Ex.left₀ ⊑ probe-target ∶
+    Ex2.left-path-ℕ⊑★₀
+probe-checkpoint₀ =
+  CTI2.·⊑·² probe-function₀ Ex2.left-path-argument₀
+
+------------------------------------------------------------------------
+-- After β-Λ there is no checkpoint, in any world
+------------------------------------------------------------------------
+
+-- The source steps to
+--   ((ƛ x) ↑ (seal Xᴸ ℕ ↦↑ unseal Xᴸ ℕ)) · 7
+-- with source store Xᴸ ↦ ℕ, while the target's type context stays
+-- empty.  Peeling the source-only reveal needs reveal⊑², whose
+-- rebasing premise demands a target pivot: rebase-varᴸ wraps a
+-- RebaseAt whose Xᴿ inhabits TyVar 0, and rebase-idᴸ demands the
+-- conversion have no pivot, but seal/unseal pin the pivot to Xᴸ.
+
+no-rebase-empty-target : ∀ {Δᴸ Δ} {W W′ : CTI2.World Δᴸ 0 Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar 0}
+  → ¬ CTI2.RebaseAt W W′ Xᴸ Xᴿ
+no-rebase-empty-target {Xᴿ = ()} _
+
+probe-function₁-unrelatable : ∀ {Δc} {W : CTI2.World 1 0 Δc}
+    {γ : CTI2.CtxImp W} {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ¬ (W ∣ γ ⊢²
+        (ƛ (` 0)) ↑ Ex2.example12-source-X-reveal ⊑ ƛ (` 0) ∶ q)
+probe-function₁-unrelatable
+  (CTI2.reveal⊑² CTI2.rebase-idᴸ _
+    (CTI2.⊢↑-⇒ˣ CTI2.join-none () _) _ _)
+probe-function₁-unrelatable
+  (CTI2.reveal⊑² (CTI2.rebase-varᴸ ra) _ _ _ _) =
+  ⊥-elim (no-rebase-empty-target ra)
+
+-- No relation rule matches an application against a constant, so once
+-- the target has finished reducing there is nothing left to peel.
+
+probe-app⊑const-unrelatable : ∀ {Δᴸ Δc} {W : CTI2.World Δᴸ 0 Δc}
+    {γ : CTI2.CtxImp W} {L M : Term Δᴸ} {κ : Const}
+    {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ¬ (W ∣ γ ⊢² L · M ⊑ $ κ ∶ q)
+probe-app⊑const-unrelatable ()
+
+-- Checkpoint 1 is impossible against the unstepped target...
+
+probe-checkpoint₁-unrelatable : ∀ {Δc} {W : CTI2.World 1 0 Δc}
+    {γ : CTI2.CtxImp W} {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ¬ (W ∣ γ ⊢² Ex.left₁ ⊑ probe-target ∶ q)
+probe-checkpoint₁-unrelatable (CTI2.·⊑·² fn arg) =
+  probe-function₁-unrelatable fn
+
+-- ...and against the target's only other reduct, the final value.
+
+probe-checkpoint₁-stepped-unrelatable : ∀ {Δc} {W : CTI2.World 1 0 Δc}
+    {γ : CTI2.CtxImp W} {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ¬ (W ∣ γ ⊢² Ex.left₁ ⊑ probe-target₁ ∶ q)
+probe-checkpoint₁-stepped-unrelatable (CTI2.⊑cast² _ prem _) =
+  probe-app⊑const-unrelatable prem
+
+-- Every world relating Term 1 to Term 0 has the shape World 1 0 Δc,
+-- because SameRuntime pins the world's stores to the machine's stores
+-- and the target store still has type TyStore 0.  So the two lemmas
+-- above close off every candidate checkpoint for the β-Λ square: the
+-- simulation cannot be completed with the current rules.
+--
+-- Note the Λ⊑² premise proved in probe-Λ-premise is of no help: it
+-- lives in liftWorldBoth X⊑★ probe-world₀ : World 1 1 1, whose target
+-- store is store-lift store-empty : TyStore 1 and whose target term is
+-- the weakened ⇑ᵗᵐ (ƛ (` 0)).  A usable induction hypothesis needs the
+-- unweakened target ƛ (` 0) over target store store-empty : TyStore 0,
+-- which is not even the same World index, so no SameRuntime or
+-- RebaseAt can connect them.  Restating Λ⊑² with a left-only world
+-- lift (keep ηᴸ, skip ηᴿ, store-lift only the source store) and an
+-- unweakened premise V ⊑ M removes both obstacles at this rule, and
+-- the missing left-only pivot form of RebaseAtᴸ is what reveal⊑² and
+-- conceal⊑² additionally need to peel the source-only wrappers.

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -191,7 +191,7 @@ probe-function₁ :
     (ƛ (` 0)) ↑ Ex2.example12-source-X-reveal ⊑ ƛ (` 0) ∶
       Ex2.ℕ⇒ℕ⊑★⇒★² {W = probe-world₁}
 probe-function₁ =
-  CTI2.reveal⊑² probe-rebase-X CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) probe-rebase-X CTI2.same-[]
     Ex2.example12-source-X-reveal-⊢ˣ probe-lambda₁
     (Ex2.ℕ⇒ℕ⊑★⇒★² {W = probe-world₁})
 
@@ -214,7 +214,7 @@ probe-sealed-arg :
     ($ (κℕ 7)) ↓ Ex2.example12-source-X-seal
     ⊑ Ex.c ⟨ CTI2.example12-ℕ! ⟩ ∶ probe-X⊑★₁
 probe-sealed-arg =
-  CTI2.conceal⊑² probe-rebase-X CTI2.same-[]
+  CTI2.conceal⊑² (λ _ eq → eq) probe-rebase-X CTI2.same-[]
     Ex2.example12-source-X-seal-⊢ˣ probe-argument₁ probe-X⊑★₁
 
 probe-app₂ :
@@ -227,7 +227,7 @@ probe-checkpoint₂ :
   probe-world₁ ∣ [] ⊢² Ex.left₂ ⊑ probe-target ∶
     Ex2.ℕ⊑★² {W = probe-world₁}
 probe-checkpoint₂ =
-  CTI2.reveal⊑² probe-rebase-X CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) probe-rebase-X CTI2.same-[]
     Ex2.example12-source-X-unseal-⊢ˣ probe-app₂
     (Ex2.ℕ⊑★² {W = probe-world₁})
 
@@ -238,7 +238,7 @@ probe-checkpoint₃ :
   probe-world₁ ∣ [] ⊢² Ex.left₃ ⊑ probe-target₁ ∶
     Ex2.ℕ⊑★² {W = probe-world₁}
 probe-checkpoint₃ =
-  CTI2.reveal⊑² probe-rebase-X CTI2.same-[]
+  CTI2.reveal⊑² (λ _ eq → eq) probe-rebase-X CTI2.same-[]
     Ex2.example12-source-X-unseal-⊢ˣ probe-sealed-arg
     (Ex2.ℕ⊑★² {W = probe-world₁})
 

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -165,7 +165,7 @@ probe-world₁ = CTI2.leftOnlyWorld X⊑★ probe-world₀ Ex.ℕᵗ
 
 probe-rebase-X : CTI2.RebaseAtᴸ probe-world₁ probe-world₁
     (just Fin.zero)
-probe-rebase-X = CTI2.rebase-onlyᴸ refl ι⊑★
+probe-rebase-X = CTI2.rebase-onlyᴸ refl (λ ()) ι⊑★
 
 probe-X⊑★₁ : (＇ Fin.zero) ⊑ᵂ⟨ probe-world₁ ⟩ ★
 probe-X⊑★₁ = X⊑★ refl

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -4,19 +4,19 @@ module proof.DGG.LambdaImpProbe where
 --   * Probes the Λ⊑² rule with the smallest ∀ ⊑ non-∀ pair: the source
 --     instantiates a type abstraction at ℕ while the target is a
 --     monomorphic lambda at ★ ⇒ ★ and never allocates a type variable.
---   * Checkpoint 0 is the first use of Λ⊑² in the development, showing
---     the rule is derivable where intended.
---   * After the source's β-Λ step, no checkpoint exists at all: the
---     one-sided reveal rules demand a target pivot variable, and the
---     target type context is empty.  This is recorded as negative
---     theorems that hold for every world, not just one alignment.
---   * Separately, the Λ⊑² premise cannot serve as the induction
---     hypothesis for the missing checkpoint even once left-only pivots
---     exist: it weakens the target term with ⇑ᵗᵐ and lifts the target
---     store, so it lives at target type context 1 while the machine's
---     target store stays at context 0, and SameRuntime is homogeneous.
+--   * Checkpoint 0 exercises Λ⊑², whose premise compares the target
+--     term unweakened in a left-only lifted world.
+--   * After the source's β-Λ step the world evolves by leftOnlyWorld
+--     and the source-only reveal, conceal, and sealed argument are
+--     peeled with rebase-onlyᴸ pivots, which need no target variable.
+--     Checkpoints 1-4 complete the weak simulation to the final values.
+--   * An earlier revision of this probe proved the negative results
+--     that forced this design: with the ⇑ᵗᵐ-weakened Λ⊑² premise and
+--     only two-sided pivots, checkpoint 1 was impossible in any world.
+--     The two-sided impossibility is kept below as
+--     no-rebase-empty-target; the rest became derivable and was
+--     replaced by the positive checkpoints.
 
-open import Data.Empty using (⊥-elim)
 open import Data.List using ([]; _∷_)
 import Data.Fin as Fin
 open import Data.Maybe using (just; nothing)
@@ -95,7 +95,7 @@ probe-target-reduction =
   probe-target₁ ∎[]
 
 ------------------------------------------------------------------------
--- Checkpoint 0: the first use of Λ⊑²
+-- Checkpoint 0: Λ⊑² with an unweakened target premise
 ------------------------------------------------------------------------
 
 probe-world₀ : CTI2.World 0 0 0
@@ -105,16 +105,12 @@ probe-∀⊑⇒★ : `∀ Ex.X⇒X ⊑ᵂ⟨ probe-world₀ ⟩ (★ ⇒ ★)
 probe-∀⊑⇒★ = Ex2.∀X⇒X⊑★⇒★² {W = probe-world₀}
 
 probe-body⊑ :
-  Ex.X⇒X ⊑ᵂ⟨ CTI2.liftWorldBoth X⊑★ probe-world₀ ⟩ ⇑ᵗ (★ ⇒ ★)
+  Ex.X⇒X ⊑ᵂ⟨ CTI2.liftWorldLeft X⊑★ probe-world₀ ⟩ (★ ⇒ ★)
 probe-body⊑ = ⇒⊑⇒ (X⊑★ refl) (X⊑★ refl)
 
--- The Λ⊑² premise as the rule demands it: the target lambda is
--- weakened with ⇑ᵗᵐ into the extended target context, and the world
--- lifts both stores.
-
 probe-Λ-premise :
-  CTI2.liftWorldBoth X⊑★ probe-world₀ ∣ [] ⊢²
-    ƛ (` 0) ⊑ ⇑ᵗᵐ (ƛ (` 0)) ∶ probe-body⊑
+  CTI2.liftWorldLeft X⊑★ probe-world₀ ∣ [] ⊢²
+    ƛ (` 0) ⊑ ƛ (` 0) ∶ probe-body⊑
 probe-Λ-premise =
   CTI2.ƛ⊑ƛ²
     {A = ＇ Fin.zero} {A′ = ★}
@@ -124,7 +120,7 @@ probe-Λ-premise =
 probe-Λ⊑ :
   probe-world₀ ∣ [] ⊢² Λ (ƛ (` 0)) ⊑ ƛ (` 0) ∶ probe-∀⊑⇒★
 probe-Λ⊑ =
-  CTI2.Λ⊑² CTI2.lift-[] (ƛ (` 0)) probe-target-lambda-⊢
+  CTI2.Λ⊑² CTI2.liftᴸ-[] (ƛ (` 0)) probe-target-lambda-⊢
     probe-Λ-premise probe-∀⊑⇒★
 
 probe-function₀ :
@@ -145,72 +141,107 @@ probe-checkpoint₀ =
   CTI2.·⊑·² probe-function₀ Ex2.left-path-argument₀
 
 ------------------------------------------------------------------------
--- After β-Λ there is no checkpoint, in any world
+-- Two-sided pivots still need a target variable
 ------------------------------------------------------------------------
 
--- The source steps to
---   ((ƛ x) ↑ (seal Xᴸ ℕ ↦↑ unseal Xᴸ ℕ)) · 7
--- with source store Xᴸ ↦ ℕ, while the target's type context stays
--- empty.  Peeling the source-only reveal needs reveal⊑², whose
--- rebasing premise demands a target pivot: rebase-varᴸ wraps a
--- RebaseAt whose Xᴿ inhabits TyVar 0, and rebase-idᴸ demands the
--- conversion have no pivot, but seal/unseal pin the pivot to Xᴸ.
+-- With an empty target type context there is no pivot pair at all;
+-- this is the impossibility that motivates rebase-onlyᴸ.
 
 no-rebase-empty-target : ∀ {Δᴸ Δ} {W W′ : CTI2.World Δᴸ 0 Δ}
     {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar 0}
   → ¬ CTI2.RebaseAt W W′ Xᴸ Xᴿ
 no-rebase-empty-target {Xᴿ = ()} _
 
-probe-function₁-unrelatable : ∀ {Δc} {W : CTI2.World 1 0 Δc}
-    {γ : CTI2.CtxImp W} {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
-  → ¬ (W ∣ γ ⊢²
-        (ƛ (` 0)) ↑ Ex2.example12-source-X-reveal ⊑ ƛ (` 0) ∶ q)
-probe-function₁-unrelatable
-  (CTI2.reveal⊑² CTI2.rebase-idᴸ _
-    (CTI2.⊢↑-⇒ˣ CTI2.join-none () _) _ _)
-probe-function₁-unrelatable
-  (CTI2.reveal⊑² (CTI2.rebase-varᴸ ra) _ _ _ _) =
-  ⊥-elim (no-rebase-empty-target ra)
+------------------------------------------------------------------------
+-- After β-Λ: the left-only world and its left-only pivot
+------------------------------------------------------------------------
 
--- No relation rule matches an application against a constant, so once
--- the target has finished reducing there is nothing left to peel.
+-- The source allocates Xᴸ ↦ ℕ, so the world evolves by leftOnlyWorld:
+-- the source store binds ℕ while the target side is untouched.
 
-probe-app⊑const-unrelatable : ∀ {Δᴸ Δc} {W : CTI2.World Δᴸ 0 Δc}
-    {γ : CTI2.CtxImp W} {L M : Term Δᴸ} {κ : Const}
-    {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
-  → ¬ (W ∣ γ ⊢² L · M ⊑ $ κ ∶ q)
-probe-app⊑const-unrelatable ()
+probe-world₁ : CTI2.World 1 0 1
+probe-world₁ = CTI2.leftOnlyWorld X⊑★ probe-world₀ Ex.ℕᵗ
 
--- Checkpoint 1 is impossible against the unstepped target...
+probe-rebase-X : CTI2.RebaseAtᴸ probe-world₁ probe-world₁
+    (just Fin.zero)
+probe-rebase-X = CTI2.rebase-onlyᴸ refl ι⊑★
 
-probe-checkpoint₁-unrelatable : ∀ {Δc} {W : CTI2.World 1 0 Δc}
-    {γ : CTI2.CtxImp W} {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
-  → ¬ (W ∣ γ ⊢² Ex.left₁ ⊑ probe-target ∶ q)
-probe-checkpoint₁-unrelatable (CTI2.·⊑·² fn arg) =
-  probe-function₁-unrelatable fn
+probe-X⊑★₁ : (＇ Fin.zero) ⊑ᵂ⟨ probe-world₁ ⟩ ★
+probe-X⊑★₁ = X⊑★ refl
 
--- ...and against the target's only other reduct, the final value.
+probe-fn⊑₁ :
+  (＇ Fin.zero ⇒ ＇ Fin.zero) ⊑ᵂ⟨ probe-world₁ ⟩ (★ ⇒ ★)
+probe-fn⊑₁ = ⇒⊑⇒ probe-X⊑★₁ probe-X⊑★₁
 
-probe-checkpoint₁-stepped-unrelatable : ∀ {Δc} {W : CTI2.World 1 0 Δc}
-    {γ : CTI2.CtxImp W} {A B} {q : A ⊑ᵂ⟨ W ⟩ B}
-  → ¬ (W ∣ γ ⊢² Ex.left₁ ⊑ probe-target₁ ∶ q)
-probe-checkpoint₁-stepped-unrelatable (CTI2.⊑cast² _ prem _) =
-  probe-app⊑const-unrelatable prem
+------------------------------------------------------------------------
+-- Checkpoints 1-4: the simulation completes
+------------------------------------------------------------------------
 
--- Every world relating Term 1 to Term 0 has the shape World 1 0 Δc,
--- because SameRuntime pins the world's stores to the machine's stores
--- and the target store still has type TyStore 0.  So the two lemmas
--- above close off every candidate checkpoint for the β-Λ square: the
--- simulation cannot be completed with the current rules.
---
--- Note the Λ⊑² premise proved in probe-Λ-premise is of no help: it
--- lives in liftWorldBoth X⊑★ probe-world₀ : World 1 1 1, whose target
--- store is store-lift store-empty : TyStore 1 and whose target term is
--- the weakened ⇑ᵗᵐ (ƛ (` 0)).  A usable induction hypothesis needs the
--- unweakened target ƛ (` 0) over target store store-empty : TyStore 0,
--- which is not even the same World index, so no SameRuntime or
--- RebaseAt can connect them.  Restating Λ⊑² with a left-only world
--- lift (keep ηᴸ, skip ηᴿ, store-lift only the source store) and an
--- unweakened premise V ⊑ M removes both obstacles at this rule, and
--- the missing left-only pivot form of RebaseAtᴸ is what reveal⊑² and
--- conceal⊑² additionally need to peel the source-only wrappers.
+probe-lambda₁ :
+  probe-world₁ ∣ [] ⊢² ƛ (` 0) ⊑ ƛ (` 0) ∶ probe-fn⊑₁
+probe-lambda₁ =
+  CTI2.ƛ⊑ƛ²
+    {A = ＇ Fin.zero} {A′ = ★}
+    {pA = probe-X⊑★₁} {pB = probe-X⊑★₁}
+    (CTI2.x⊑x² {p = probe-X⊑★₁} CTI2.Zʷ)
+
+probe-function₁ :
+  probe-world₁ ∣ [] ⊢²
+    (ƛ (` 0)) ↑ Ex2.example12-source-X-reveal ⊑ ƛ (` 0) ∶
+      Ex2.ℕ⇒ℕ⊑★⇒★² {W = probe-world₁}
+probe-function₁ =
+  CTI2.reveal⊑² probe-rebase-X CTI2.same-[]
+    Ex2.example12-source-X-reveal-⊢ˣ probe-lambda₁
+    (Ex2.ℕ⇒ℕ⊑★⇒★² {W = probe-world₁})
+
+probe-argument₁ :
+  probe-world₁ ∣ [] ⊢²
+    $ (κℕ 7) ⊑ Ex.c ⟨ CTI2.example12-ℕ! ⟩ ∶
+      Ex2.ℕ⊑★² {W = probe-world₁}
+probe-argument₁ =
+  CTI2.⊑cast² CTI2.example12-ℕ!
+    (CTI2.κ⊑κ² (κℕ 7) (Ex2.ℕ⊑ℕ² {W = probe-world₁}))
+    (Ex2.ℕ⊑★² {W = probe-world₁})
+
+probe-checkpoint₁ :
+  probe-world₁ ∣ [] ⊢² Ex.left₁ ⊑ probe-target ∶
+    Ex2.ℕ⊑★² {W = probe-world₁}
+probe-checkpoint₁ = CTI2.·⊑·² probe-function₁ probe-argument₁
+
+probe-sealed-arg :
+  probe-world₁ ∣ [] ⊢²
+    ($ (κℕ 7)) ↓ Ex2.example12-source-X-seal
+    ⊑ Ex.c ⟨ CTI2.example12-ℕ! ⟩ ∶ probe-X⊑★₁
+probe-sealed-arg =
+  CTI2.conceal⊑² probe-rebase-X CTI2.same-[]
+    Ex2.example12-source-X-seal-⊢ˣ probe-argument₁ probe-X⊑★₁
+
+probe-app₂ :
+  probe-world₁ ∣ [] ⊢²
+    (ƛ (` 0)) · (($ (κℕ 7)) ↓ Ex2.example12-source-X-seal)
+    ⊑ (ƛ (` 0)) · (Ex.c ⟨ CTI2.example12-ℕ! ⟩) ∶ probe-X⊑★₁
+probe-app₂ = CTI2.·⊑·² probe-lambda₁ probe-sealed-arg
+
+probe-checkpoint₂ :
+  probe-world₁ ∣ [] ⊢² Ex.left₂ ⊑ probe-target ∶
+    Ex2.ℕ⊑★² {W = probe-world₁}
+probe-checkpoint₂ =
+  CTI2.reveal⊑² probe-rebase-X CTI2.same-[]
+    Ex2.example12-source-X-unseal-⊢ˣ probe-app₂
+    (Ex2.ℕ⊑★² {W = probe-world₁})
+
+-- The source's β under the reveal is matched by the target's β, so
+-- checkpoint 3 pairs the source with the stepped target.
+
+probe-checkpoint₃ :
+  probe-world₁ ∣ [] ⊢² Ex.left₃ ⊑ probe-target₁ ∶
+    Ex2.ℕ⊑★² {W = probe-world₁}
+probe-checkpoint₃ =
+  CTI2.reveal⊑² probe-rebase-X CTI2.same-[]
+    Ex2.example12-source-X-unseal-⊢ˣ probe-sealed-arg
+    (Ex2.ℕ⊑★² {W = probe-world₁})
+
+probe-checkpoint₄ :
+  probe-world₁ ∣ [] ⊢² Ex.left-final ⊑ probe-target₁ ∶
+    Ex2.ℕ⊑★² {W = probe-world₁}
+probe-checkpoint₄ = probe-argument₁

--- a/GTSFImp/proof/DGG/MovedLinkProbe.agda
+++ b/GTSFImp/proof/DGG/MovedLinkProbe.agda
@@ -1,19 +1,19 @@
 module proof.DGG.MovedLinkProbe where
 
 -- File Charter:
---   * This probe decides the moved-inner-link stratum of bare-seal
---     inversion.
---   * Checkpoint 1 and checkpoint 2 together show that bare-seal
---     inversion requires an invariant excluding relocation of a
---     re-paired variable.
---   * The concrete worlds record the shape that such an invariant
---     must outlaw.
+--   * This probe records why moved-pivot anchoring is needed for
+--     bare-seal inversion.
+--   * Checkpoint 1 shows that anchoring excludes the ill-formed
+--     moved-inner link; checkpoint 2 records that the corresponding
+--     inversion output is empty without that invariant.
+--   * The concrete worlds exhibit the excluded relocation.
 --   * See Rationale.md, section "Seal peeling and world support".
 
 open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
 open import Data.List using ([])
 open import Data.Maybe using (just)
+open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl)
 open import Relation.Nullary using (¬_)
@@ -178,18 +178,10 @@ probe-outer-target-rebase =
     (λ { {Fin.zero} X≢ → ⊥-elim (X≢ refl) })
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
        ; {Fin.suc Fin.zero} Y′≢ → refl })
-    refl probe-X-Y-rep₁
+    refl (λ moved → ⊥-elim (moved refl)) probe-X-Y-rep₁
 
 probe-X-Y′-rep₄ : CTI2.StoreRepImp probe-W₄ X Y′
 probe-X-Y′-rep₄ = store-rep-imp ★⊑★
-
-probe-inner-target-rebase : RebaseAt probe-W₅ probe-W₄ X Y′
-probe-inner-target-rebase =
-  rebase-at (same-runtime refl refl)
-    (λ { {Fin.zero} X≢ → ⊥-elim (X≢ refl) })
-    (λ { {Fin.zero} Y≢ → refl
-       ; {Fin.suc Fin.zero} Y′≢ → ⊥-elim (Y′≢ refl) })
-    refl probe-X-Y′-rep₄
 
 probe-X-Y-rep₅ : CTI2.StoreRepImp probe-W₅ X Y
 probe-X-Y-rep₅ = store-rep-imp ★⊑★
@@ -199,52 +191,14 @@ probe-inner-source-rebase =
   CTI2.sameWorldRebaseAt refl probe-X-Y-rep₅
 
 ------------------------------------------------------------------------
--- Checkpoint 1: the moved-inner-link input is derivable
+-- Checkpoint 1: moved-pivot anchoring excludes the inner link
 ------------------------------------------------------------------------
 
-pIn : ＇ X ⊑ᵂ⟨ probe-W₁ ⟩ ＇ Y
-pIn = X⊑X
-
-p₄ : ＇ X ⊑ᵂ⟨ probe-W₄ ⟩ ★
-p₄ = X⊑★ refl
-
-p₅ : ＇ X ⊑ᵂ⟨ probe-W₅ ⟩ ★
-p₅ = X⊑★ refl
-
-pPair₄ : ＇ X ⊑ᵂ⟨ probe-W₄ ⟩ ＇ Y′
-pPair₄ = X⊑X
-
-probe-base² :
-  probe-W₆ ∣ [] ⊢² probe-V₀ ⊑ probe-M₅ ∶ ★⊑★
-probe-base² =
-  CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
-    (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
-
-probe-inner-source² :
-  probe-W₅ ∣ [] ⊢² probe-V ⊑ probe-M₅ ∶ p₅
-probe-inner-source² =
-  CTI2.conceal⊑² (λ Z eq → eq)
-    (CTI2.rebase-varᴸ probe-inner-source-rebase)
-    CTI2.same-[] probe-X-seal-⊢ probe-base² p₅
-
-probe-inner-target² :
-  probe-W₄ ∣ [] ⊢² probe-V ⊑ probe-M′ ∶ pPair₄
-probe-inner-target² =
-  CTI2.⊑conceal² (λ Z eq → eq)
-    (CTI2.rebase-varᴿ probe-inner-target-rebase)
-    CTI2.same-[] probe-Y′-seal-⊢ probe-inner-source² pPair₄
-
-probe-inner-tag² :
-  probe-W₄ ∣ [] ⊢² probe-V ⊑ probe-U ∶ p₄
-probe-inner-tag² =
-  CTI2.⊑cast² probe-Y′! probe-inner-target² p₄
-
-probe-input :
-  probe-W₁ ∣ [] ⊢² probe-V ⊑ (probe-U ↓ seal Y ★) ∶ pIn
-probe-input =
-  CTI2.⊑conceal² (λ Z eq → eq)
-    (CTI2.rebase-varᴿ probe-outer-target-rebase)
-    CTI2.same-[] probe-Y-seal-⊢ probe-inner-tag² pIn
+probe-link-ill-formed :
+  ¬ (RebaseAt probe-W₅ probe-W₄ X Y′)
+probe-link-ill-formed rb
+    with CTI2.RebaseAt.anchorᴿ rb (λ ())
+probe-link-ill-formed rb | Fin.zero , ()
 
 ------------------------------------------------------------------------
 -- Checkpoint 2: the corresponding inversion output is empty

--- a/GTSFImp/proof/DGG/MovedLinkProbe.agda
+++ b/GTSFImp/proof/DGG/MovedLinkProbe.agda
@@ -1,0 +1,261 @@
+module proof.DGG.MovedLinkProbe where
+
+-- File Charter:
+--   * This probe decides the moved-inner-link stratum of bare-seal
+--     inversion.
+--   * Checkpoint 1 and checkpoint 2 together show that bare-seal
+--     inversion requires an invariant excluding relocation of a
+--     re-paired variable.
+--   * The concrete worlds record the shape that such an invariant
+--     must outlaw.
+--   * See Rationale.md, section "Seal peeling and world support".
+
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl)
+open import Relation.Nullary using (¬_)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-bind; _∋_⦂_; Z∋; S-bind∋)
+open import Consistency using
+  (Env∼; X∼★; _⊢_∼_; _↪ᵗ_; empty; keep; skip; _!; id)
+open import Imprecision
+open import Conversion using (seal)
+open import CastTerms
+open import Primitives using (κℕ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; _⊢↓[_]_; _∣_⊢²_⊑_∶_;
+   RebaseAt; rebase-at; same-runtime; store-rep-imp; ⊢↓-sealˣ)
+
+private
+  X : TyVar 1
+  X = Fin.zero
+
+  Y : TyVar 2
+  Y = Fin.zero
+
+  Y′ : TyVar 2
+  Y′ = Fin.suc Fin.zero
+
+------------------------------------------------------------------------
+-- Stores, embeddings, and worlds
+------------------------------------------------------------------------
+
+probe-src-store : TyStore 1
+probe-src-store = store-bind store-empty ★
+
+probe-tgt-store : TyStore 2
+probe-tgt-store = store-bind (store-bind store-empty ★) ★
+
+probe-μ : ImpEnv 3
+probe-μ Fin.zero = X⊑★
+probe-μ (Fin.suc Fin.zero) = X⊑★
+probe-μ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+
+η-X-a : 1 ↪ᵗ 3
+η-X-a = keep (skip (skip empty))
+
+η-X-b : 1 ↪ᵗ 3
+η-X-b = skip (keep (skip empty))
+
+η-YY′-ab : 2 ↪ᵗ 3
+η-YY′-ab = keep (keep (skip empty))
+
+η-YY′-ac : 2 ↪ᵗ 3
+η-YY′-ac = keep (skip (keep empty))
+
+-- Final placement table (a = 0, b = 1, c = 2):
+--
+--             X    Y    Y′
+--   probe-W₁   a    a    b
+--   probe-W₄   b    a    b
+--   probe-W₅   a    a    c
+--   probe-W₆   a    a    c
+--
+-- Thus Y < Y′ in every target embedding.  At the inner boundary,
+-- X is re-paired from Y′ at b to Y at a while Y′ moves from b to c.
+
+probe-W₁ : World 1 2 3
+probe-W₁ =
+  world η-X-a η-YY′-ab probe-μ probe-src-store probe-tgt-store
+
+probe-W₄ : World 1 2 3
+probe-W₄ =
+  world η-X-b η-YY′-ab probe-μ probe-src-store probe-tgt-store
+
+probe-W₅ : World 1 2 3
+probe-W₅ =
+  world η-X-a η-YY′-ac probe-μ probe-src-store probe-tgt-store
+
+probe-W₆ : World 1 2 3
+probe-W₆ = probe-W₅
+
+probe-W₁-WF : CTI2.WFWorld probe-W₁
+probe-W₁-WF Fin.zero ()
+
+probe-W₄-WF : CTI2.WFWorld probe-W₄
+probe-W₄-WF Fin.zero ()
+
+probe-W₅-WF : CTI2.WFWorld probe-W₅
+probe-W₅-WF Fin.zero ()
+
+probe-W₆-WF : CTI2.WFWorld probe-W₆
+probe-W₆-WF Fin.zero ()
+
+------------------------------------------------------------------------
+-- Store typing and casts
+------------------------------------------------------------------------
+
+probe-src-X∋ : probe-src-store ∋ X ⦂ ★
+probe-src-X∋ = Z∋ refl
+
+probe-tgt-Y∋ : probe-tgt-store ∋ Y ⦂ ★
+probe-tgt-Y∋ = Z∋ refl
+
+probe-tgt-Y′∋ : probe-tgt-store ∋ Y′ ⦂ ★
+probe-tgt-Y′∋ = S-bind∋ (Z∋ refl) refl
+
+probe-X-seal-⊢ : probe-src-store ⊢↓[ just X ] seal X ★
+probe-X-seal-⊢ = ⊢↓-sealˣ probe-src-X∋
+
+probe-Y-seal-⊢ : probe-tgt-store ⊢↓[ just Y ] seal Y ★
+probe-Y-seal-⊢ = ⊢↓-sealˣ probe-tgt-Y∋
+
+probe-Y′-seal-⊢ : probe-tgt-store ⊢↓[ just Y′ ] seal Y′ ★
+probe-Y′-seal-⊢ = ⊢↓-sealˣ probe-tgt-Y′∋
+
+private
+  probe-src-env : Env∼ 1
+  probe-src-env Fin.zero = X∼★
+
+  probe-tgt-env : Env∼ 2
+  probe-tgt-env Fin.zero = X∼★
+  probe-tgt-env (Fin.suc Fin.zero) = X∼★
+
+  probe-ℕ!ᴸ : probe-src-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴸ = id (‵ `ℕ) !
+
+  probe-ℕ!ᴿ : probe-tgt-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴿ = id (‵ `ℕ) !
+
+  probe-Y′! : probe-tgt-env ⊢ ＇ Y′ ∼ ★
+  probe-Y′! = id { μ = probe-tgt-env } (＇ Y′) !
+
+------------------------------------------------------------------------
+-- Terms
+------------------------------------------------------------------------
+
+probe-V₀ : Term 1
+probe-V₀ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴸ ⟩
+
+probe-V : Term 1
+probe-V = probe-V₀ ↓ seal X ★
+
+probe-M₅ : Term 2
+probe-M₅ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴿ ⟩
+
+probe-M′ : Term 2
+probe-M′ = probe-M₅ ↓ seal Y′ ★
+
+probe-U : Term 2
+probe-U = probe-M′ ⟨ probe-Y′! ⟩
+
+------------------------------------------------------------------------
+-- Rebase witnesses
+------------------------------------------------------------------------
+
+probe-X-Y-rep₁ : CTI2.StoreRepImp probe-W₁ X Y
+probe-X-Y-rep₁ = store-rep-imp ★⊑★
+
+probe-outer-target-rebase : RebaseAt probe-W₄ probe-W₁ X Y
+probe-outer-target-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} X≢ → ⊥-elim (X≢ refl) })
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
+       ; {Fin.suc Fin.zero} Y′≢ → refl })
+    refl probe-X-Y-rep₁
+
+probe-X-Y′-rep₄ : CTI2.StoreRepImp probe-W₄ X Y′
+probe-X-Y′-rep₄ = store-rep-imp ★⊑★
+
+probe-inner-target-rebase : RebaseAt probe-W₅ probe-W₄ X Y′
+probe-inner-target-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} X≢ → ⊥-elim (X≢ refl) })
+    (λ { {Fin.zero} Y≢ → refl
+       ; {Fin.suc Fin.zero} Y′≢ → ⊥-elim (Y′≢ refl) })
+    refl probe-X-Y′-rep₄
+
+probe-X-Y-rep₅ : CTI2.StoreRepImp probe-W₅ X Y
+probe-X-Y-rep₅ = store-rep-imp ★⊑★
+
+probe-inner-source-rebase : RebaseAt probe-W₆ probe-W₅ X Y
+probe-inner-source-rebase =
+  CTI2.sameWorldRebaseAt refl probe-X-Y-rep₅
+
+------------------------------------------------------------------------
+-- Checkpoint 1: the moved-inner-link input is derivable
+------------------------------------------------------------------------
+
+pIn : ＇ X ⊑ᵂ⟨ probe-W₁ ⟩ ＇ Y
+pIn = X⊑X
+
+p₄ : ＇ X ⊑ᵂ⟨ probe-W₄ ⟩ ★
+p₄ = X⊑★ refl
+
+p₅ : ＇ X ⊑ᵂ⟨ probe-W₅ ⟩ ★
+p₅ = X⊑★ refl
+
+pPair₄ : ＇ X ⊑ᵂ⟨ probe-W₄ ⟩ ＇ Y′
+pPair₄ = X⊑X
+
+probe-base² :
+  probe-W₆ ∣ [] ⊢² probe-V₀ ⊑ probe-M₅ ∶ ★⊑★
+probe-base² =
+  CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
+    (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
+
+probe-inner-source² :
+  probe-W₅ ∣ [] ⊢² probe-V ⊑ probe-M₅ ∶ p₅
+probe-inner-source² =
+  CTI2.conceal⊑² (λ Z eq → eq)
+    (CTI2.rebase-varᴸ probe-inner-source-rebase)
+    CTI2.same-[] probe-X-seal-⊢ probe-base² p₅
+
+probe-inner-target² :
+  probe-W₄ ∣ [] ⊢² probe-V ⊑ probe-M′ ∶ pPair₄
+probe-inner-target² =
+  CTI2.⊑conceal² (λ Z eq → eq)
+    (CTI2.rebase-varᴿ probe-inner-target-rebase)
+    CTI2.same-[] probe-Y′-seal-⊢ probe-inner-source² pPair₄
+
+probe-inner-tag² :
+  probe-W₄ ∣ [] ⊢² probe-V ⊑ probe-U ∶ p₄
+probe-inner-tag² =
+  CTI2.⊑cast² probe-Y′! probe-inner-target² p₄
+
+probe-input :
+  probe-W₁ ∣ [] ⊢² probe-V ⊑ (probe-U ↓ seal Y ★) ∶ pIn
+probe-input =
+  CTI2.⊑conceal² (λ Z eq → eq)
+    (CTI2.rebase-varᴿ probe-outer-target-rebase)
+    CTI2.same-[] probe-Y-seal-⊢ probe-inner-tag² pIn
+
+------------------------------------------------------------------------
+-- Checkpoint 2: the corresponding inversion output is empty
+------------------------------------------------------------------------
+
+qOut : ＇ X ⊑ᵂ⟨ probe-W₁ ⟩ ＇ Y
+qOut = X⊑X
+
+probe-no-output :
+  ¬ (probe-W₁ ∣ [] ⊢² probe-V ⊑ probe-U ∶ qOut)
+probe-no-output
+    (CTI2.conceal⊑² {p = p} mono rb sc c⊢ prem q) with p
+probe-no-output
+    (CTI2.conceal⊑² {p = p} mono rb sc c⊢ prem q) | ()

--- a/GTSFImp/proof/DGG/Repark.agda
+++ b/GTSFImp/proof/DGG/Repark.agda
@@ -1,0 +1,243 @@
+module proof.DGG.Repark where
+
+-- File Charter:
+--   * Re-parks one target variable at a hereditarily fresh center by
+--     inserting that center at the variable's old center position.
+--   * Exports the insertion and re-parked embeddings, their pointwise laws,
+--     avoidance predicates, and transport for obligations and contexts.
+--   * Stage 2b-ii builds on exactly these embedding and transport laws for
+--     its derivation induction, stopping capture at rebases pivoted on Yₚ.
+
+open import Data.List using ([]; _∷_)
+open import Data.Empty using (⊥-elim)
+open import Data.Maybe using (nothing)
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans; cong; subst)
+open import Relation.Nullary using (¬_)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-lift; store-bind)
+open import Consistency using
+  (_↪ᵗ_; empty; keep; skip; toRenameᵗ; id↪ᵗ)
+open import Imprecision using (X⊑★; _⊢_⊑_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; ηᴸʷ; ηᴿʷ; impEnvʷ; sourceStoreʷ; targetStoreʷ;
+   _⊑ᵂ⟨_⟩_; CtxImp; ctx-imp; _∋ʷ_⦂_; Zʷ; Sʷ)
+import proof.DGG.CenterRename as CR
+open CR using
+  (_∘↪_; toRenameᵗ-∘; preimage?; renameEnv; renameEnv-image;
+   renameEnv-off; rename-⊑ᵂ)
+open import proof.DGG.WorldSupport using (renameᵗ-support)
+
+------------------------------------------------------------------------
+-- Insertion injections
+------------------------------------------------------------------------
+
+insertᶜ : ∀ {Δ} (k : Fin.Fin (Nat.suc Δ)) → Δ ↪ᵗ Nat.suc Δ
+insertᶜ {Nat.zero} Fin.zero = skip empty
+insertᶜ {Nat.suc Δ} Fin.zero = skip id↪ᵗ
+insertᶜ {Nat.suc Δ} (Fin.suc k) = keep (insertᶜ k)
+
+insertᶜ-misses : ∀ {Δ} (k : Fin.Fin (Nat.suc Δ)) (Z : TyVar Δ)
+  → toRenameᵗ (insertᶜ k) Z ≢ k
+insertᶜ-misses {Nat.zero} Fin.zero ()
+insertᶜ-misses {Nat.suc Δ} Fin.zero Z ()
+insertᶜ-misses {Nat.suc Δ} (Fin.suc k) Fin.zero ()
+insertᶜ-misses {Nat.suc Δ} (Fin.suc k) (Fin.suc Z) eq =
+  insertᶜ-misses k Z (fin-suc-injective eq)
+  where
+  fin-suc-injective : ∀ {n} {X Y : Fin.Fin n}
+    → Fin.suc X ≡ Fin.suc Y
+    → X ≡ Y
+  fin-suc-injective refl = refl
+
+private
+  toRename-id : ∀ {Δ} (X : TyVar Δ) → toRenameᵗ id↪ᵗ X ≡ X
+  toRename-id {Nat.zero} ()
+  toRename-id {Nat.suc Δ} Fin.zero = refl
+  toRename-id {Nat.suc Δ} (Fin.suc X) =
+    cong Fin.suc (toRename-id X)
+
+  insertᶜ-preimage : ∀ {Δ} (k : Fin.Fin (Nat.suc Δ))
+    → preimage? (insertᶜ k) k ≡ nothing
+  insertᶜ-preimage {Nat.zero} Fin.zero = refl
+  insertᶜ-preimage {Nat.suc Δ} Fin.zero = refl
+  insertᶜ-preimage {Nat.suc Δ} (Fin.suc k)
+      rewrite insertᶜ-preimage k =
+    refl
+
+------------------------------------------------------------------------
+-- Re-parked target embedding
+------------------------------------------------------------------------
+
+-- reparkIndex is the constructor-preserving inclusion of ηᴿ(Yₚ) into
+-- Fin (suc Δ).  Thus it has the same de Bruijn number as the old image;
+-- insertion shifts the old center at that number up by one.
+
+reparkIndex : ∀ {Δᴿ Δ}
+  → (ηᴿ : Δᴿ ↪ᵗ Δ)
+  → TyVar Δᴿ
+  → TyVar (Nat.suc Δ)
+reparkIndex empty ()
+reparkIndex (keep ηᴿ) Fin.zero = Fin.zero
+reparkIndex (keep ηᴿ) (Fin.suc Y) = Fin.suc (reparkIndex ηᴿ Y)
+reparkIndex (skip ηᴿ) Y = Fin.suc (reparkIndex ηᴿ Y)
+
+reparkEmbedᴿ : ∀ {Δᴿ Δ}
+  → (ηᴿ : Δᴿ ↪ᵗ Δ)
+  → TyVar Δᴿ
+  → Δᴿ ↪ᵗ Nat.suc Δ
+reparkEmbedᴿ empty ()
+reparkEmbedᴿ (keep ηᴿ) Fin.zero = keep (skip ηᴿ)
+reparkEmbedᴿ (keep ηᴿ) (Fin.suc Y) = keep (reparkEmbedᴿ ηᴿ Y)
+reparkEmbedᴿ (skip ηᴿ) Y = skip (reparkEmbedᴿ ηᴿ Y)
+
+reparkEmbedᴿ-off : ∀ {Δᴿ Δ} (ηᴿ : Δᴿ ↪ᵗ Δ)
+    (Yₚ Y : TyVar Δᴿ)
+  → Y ≢ Yₚ
+  → toRenameᵗ (reparkEmbedᴿ ηᴿ Yₚ) Y
+      ≡ toRenameᵗ (insertᶜ (reparkIndex ηᴿ Yₚ))
+          (toRenameᵗ ηᴿ Y)
+reparkEmbedᴿ-off empty ()
+reparkEmbedᴿ-off (keep ηᴿ) Fin.zero Fin.zero Y≢ =
+  ⊥-elim (Y≢ refl)
+reparkEmbedᴿ-off (keep ηᴿ) Fin.zero (Fin.suc Y) Y≢ =
+  cong Fin.suc (cong Fin.suc (sym (toRename-id (toRenameᵗ ηᴿ Y))))
+reparkEmbedᴿ-off (keep ηᴿ) (Fin.suc Yₚ) Fin.zero Y≢ = refl
+reparkEmbedᴿ-off (keep ηᴿ) (Fin.suc Yₚ) (Fin.suc Y) Y≢ =
+  cong Fin.suc
+    (reparkEmbedᴿ-off ηᴿ Yₚ Y
+      (λ eq → Y≢ (cong Fin.suc eq)))
+reparkEmbedᴿ-off (skip ηᴿ) Yₚ Y Y≢ =
+  cong Fin.suc (reparkEmbedᴿ-off ηᴿ Yₚ Y Y≢)
+
+reparkEmbedᴿ-park : ∀ {Δᴿ Δ} (ηᴿ : Δᴿ ↪ᵗ Δ)
+    (Yₚ : TyVar Δᴿ)
+  → toRenameᵗ (reparkEmbedᴿ ηᴿ Yₚ) Yₚ ≡ reparkIndex ηᴿ Yₚ
+reparkEmbedᴿ-park empty ()
+reparkEmbedᴿ-park (keep ηᴿ) Fin.zero = refl
+reparkEmbedᴿ-park (keep ηᴿ) (Fin.suc Yₚ) =
+  cong Fin.suc (reparkEmbedᴿ-park ηᴿ Yₚ)
+reparkEmbedᴿ-park (skip ηᴿ) Yₚ =
+  cong Fin.suc (reparkEmbedᴿ-park ηᴿ Yₚ)
+
+------------------------------------------------------------------------
+-- Re-parked world and marks
+------------------------------------------------------------------------
+
+reparkWorld : ∀ {Δᴸ Δᴿ Δ}
+  → (W : World Δᴸ Δᴿ Δ)
+  → TyVar Δᴿ
+  → World Δᴸ Δᴿ (Nat.suc Δ)
+reparkWorld W Yₚ =
+  world (insertᶜ k ∘↪ ηᴸʷ W) (reparkEmbedᴿ (ηᴿʷ W) Yₚ)
+    (renameEnv (insertᶜ k) (impEnvʷ W))
+    (sourceStoreʷ W) (targetStoreʷ W)
+  where
+  k = reparkIndex (ηᴿʷ W) Yₚ
+
+repark-mark-image : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) (Yₚ : TyVar Δᴿ) (Z : TyVar Δ)
+  → impEnvʷ (reparkWorld W Yₚ)
+      (toRenameᵗ (insertᶜ (reparkIndex (ηᴿʷ W) Yₚ)) Z)
+      ≡ impEnvʷ W Z
+repark-mark-image W Yₚ Z =
+  renameEnv-image (insertᶜ (reparkIndex (ηᴿʷ W) Yₚ))
+    (impEnvʷ W) Z
+
+repark-mark-inserted : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) (Yₚ : TyVar Δᴿ)
+  → impEnvʷ (reparkWorld W Yₚ) (reparkIndex (ηᴿʷ W) Yₚ)
+      ≡ X⊑★
+repark-mark-inserted W Yₚ =
+  renameEnv-off (insertᶜ k) (impEnvʷ W) (insertᶜ-preimage k)
+  where
+  k = reparkIndex (ηᴿʷ W) Yₚ
+
+------------------------------------------------------------------------
+-- Avoidance predicates
+------------------------------------------------------------------------
+
+data CtxAvoidᴿ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    (Yₚ : TyVar Δᴿ) : CtxImp W → Set where
+  ctx-avoid-[] : CtxAvoidᴿ Yₚ []
+
+  ctx-avoid-∷ : ∀ {γ A B p}
+    → ¬ (Yₚ ∈ᵗ B)
+    → CtxAvoidᴿ Yₚ γ
+    → CtxAvoidᴿ Yₚ (ctx-imp A B p ∷ γ)
+
+data StoreAvoidᴿ : ∀ {Δ} → TyVar Δ → TyStore Δ → Set where
+  store-avoid-lift-zero : ∀ {Δ} {Σ : TyStore Δ}
+    → StoreAvoidᴿ Fin.zero (store-lift Σ)
+
+  store-avoid-lift-suc : ∀ {Δ} {Σ : TyStore Δ} {Y : TyVar Δ}
+    → StoreAvoidᴿ Y Σ
+    → StoreAvoidᴿ (Fin.suc Y) (store-lift Σ)
+
+  store-avoid-bind-zero : ∀ {Δ} {Σ : TyStore Δ} {A : Ty Δ}
+    → StoreAvoidᴿ Fin.zero (store-bind Σ A)
+
+  store-avoid-bind-suc : ∀ {Δ} {Σ : TyStore Δ}
+      {A : Ty Δ} {Y : TyVar Δ}
+    → ¬ (Y ∈ᵗ A)
+    → StoreAvoidᴿ Y Σ
+    → StoreAvoidᴿ (Fin.suc Y) (store-bind Σ A)
+
+------------------------------------------------------------------------
+-- Obligation and context transport
+------------------------------------------------------------------------
+
+repark-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {Yₚ : TyVar Δᴿ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → ¬ (Yₚ ∈ᵗ B)
+  → A ⊑ᵂ⟨ W ⟩ B
+  → A ⊑ᵂ⟨ reparkWorld W Yₚ ⟩ B
+repark-⊑ᵂ {W = W} {Yₚ} {A} {B} Yₚ∉B A⊑B =
+  subst
+    (λ R → impEnvʷ (reparkWorld W Yₚ) ⊢
+      CTI2.embedᴸ (reparkWorld W Yₚ) A ⊑ R)
+    target-eq
+    (rename-⊑ᵂ {W = W} (insertᶜ k) A⊑B)
+  where
+  k = reparkIndex (ηᴿʷ W) Yₚ
+
+  target-eq : CTI2.embedᴿ (CR.renameWorld (insertᶜ k) W) B
+    ≡ CTI2.embedᴿ (reparkWorld W Yₚ) B
+  target-eq = renameᵗ-support B λ Y Y∈B →
+    trans (toRenameᵗ-∘ (insertᶜ k) (ηᴿʷ W) Y)
+      (sym (reparkEmbedᴿ-off (ηᴿʷ W) Yₚ Y
+        (λ eq → Yₚ∉B (subst (λ Z → Z ∈ᵗ B) eq Y∈B))))
+
+ctxAvoid-∋ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {Yₚ : TyVar Δᴿ} {γ : CtxImp W} {x A B p}
+  → (avoid : CtxAvoidᴿ Yₚ γ)
+  → γ ∋ʷ x ⦂ ctx-imp A B p
+  → ¬ (Yₚ ∈ᵗ B)
+ctxAvoid-∋ (ctx-avoid-∷ Yₚ∉B avoid) Zʷ = Yₚ∉B
+ctxAvoid-∋ (ctx-avoid-∷ Yₚ∉B avoid) (Sʷ x∈) =
+  ctxAvoid-∋ avoid x∈
+
+reparkCtx : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {Yₚ : TyVar Δᴿ} {γ : CtxImp W}
+  → CtxAvoidᴿ Yₚ γ
+  → CtxImp (reparkWorld W Yₚ)
+reparkCtx ctx-avoid-[] = []
+reparkCtx {W = W} {Yₚ} (ctx-avoid-∷ {A = A} {B} {p} Yₚ∉B avoid) =
+  ctx-imp A B (repark-⊑ᵂ {W = W} {Yₚ = Yₚ} Yₚ∉B p) ∷
+    reparkCtx avoid
+
+repark-∋ʷ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {Yₚ : TyVar Δᴿ} {γ : CtxImp W} {x A B p}
+  → (avoid : CtxAvoidᴿ Yₚ γ)
+  → (x∈ : γ ∋ʷ x ⦂ ctx-imp A B p)
+  → reparkCtx avoid ∋ʷ x ⦂
+      ctx-imp A B
+        (repark-⊑ᵂ {W = W} {Yₚ = Yₚ} (ctxAvoid-∋ avoid x∈) p)
+repark-∋ʷ (ctx-avoid-∷ Yₚ∉B avoid) Zʷ = Zʷ
+repark-∋ʷ (ctx-avoid-∷ Yₚ∉B avoid) (Sʷ x∈) =
+  Sʷ (repark-∋ʷ avoid x∈)

--- a/GTSFImp/proof/DGG/Repark.agda
+++ b/GTSFImp/proof/DGG/Repark.agda
@@ -5,33 +5,45 @@ module proof.DGG.Repark where
 --     inserting that center at the variable's old center position.
 --   * Exports the insertion and re-parked embeddings, their pointwise laws,
 --     avoidance predicates, and transport for obligations and contexts.
---   * Stage 2b-ii builds on exactly these embedding and transport laws for
---     its derivation induction, stopping capture at rebases pivoted on Yₚ.
+--   * Transports derivations whose target types avoid the parked variable and
+--     whose rebases are never pivoted on that variable.
 
 open import Data.List using ([]; _∷_)
 open import Data.Empty using (⊥-elim)
-open import Data.Maybe using (nothing)
+open import Data.Maybe using (just; nothing)
+open import Data.Unit using (⊤; tt)
 import Data.Fin as Fin
 import Data.Nat as Nat
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; sym; trans; cong; subst)
-open import Relation.Nullary using (¬_)
+open import Relation.Nullary using (¬_; yes; no)
 
 open import Types
 open import TyStore using
-  (TyStore; store-empty; store-lift; store-bind)
+  (TyStore; store-empty; store-lift; store-bind; _∋_⦂_; Z∋; S-lift∋;
+   S-bind∋)
 open import Consistency using
-  (_↪ᵗ_; empty; keep; skip; toRenameᵗ; id↪ᵗ)
-open import Imprecision using (X⊑★; _⊢_⊑_)
+  (Env∼; _⊢_∼_; _↪ᵗ_; empty; keep; skip; toRenameᵗ; id↪ᵗ)
+open import Imprecision using
+  (VarImp; ImpEnv; X⊑X; X⊑★; ⇒⊑⇒; _⊢_⊑_)
+open import Conversion using (Conv↑; Conv↓)
+open import CastTerms using (Term; Value; ⟨_,_,_⟩; _⊢_⦂_)
+open import Primitives using
+  (Const; Prim; constTy; primArgTy; primResultTy)
 import proof.DGG.CastTermImprecision2 as CTI2
 open CTI2 using
   (World; world; ηᴸʷ; ηᴿʷ; impEnvʷ; sourceStoreʷ; targetStoreʷ;
-   _⊑ᵂ⟨_⟩_; CtxImp; ctx-imp; _∋ʷ_⦂_; Zʷ; Sʷ)
+   _⊑ᵂ⟨_⟩_; CtxImp; ctx-imp; _∋ʷ_⦂_; Zʷ; Sʷ;
+   _∣_⊢²_⊑_∶_)
 import proof.DGG.CenterRename as CR
 open CR using
   (_∘↪_; toRenameᵗ-∘; preimage?; renameEnv; renameEnv-image;
    renameEnv-off; rename-⊑ᵂ)
 open import proof.DGG.WorldSupport using (renameᵗ-support)
+open import proof.DGG.ConvImp using (occurs-absent-⊥)
+open import proof.ImprecisionConsistency using
+  (shift-not-occurs; toRenameᵗ-injective; unshift-occurs;
+   zero-not-shift)
 
 ------------------------------------------------------------------------
 -- Insertion injections
@@ -188,6 +200,220 @@ data StoreAvoidᴿ : ∀ {Δ} → TyVar Δ → TyStore Δ → Set where
     → StoreAvoidᴿ Y Σ
     → StoreAvoidᴿ (Fin.suc Y) (store-bind Σ A)
 
+-- A rebase avoids Yₚ exactly when its target pivot, if it has one, is
+-- different from Yₚ.  The one-sided forms make the condition explicit
+-- without splitting each term-imprecision rule into several constructors.
+
+AvoidRebaseᴿ : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ} {Xᴿ?}
+  → TyVar Δᴿ
+  → CTI2.RebaseAtᴿ W W′ Xᴿ?
+  → Set
+AvoidRebaseᴿ Yₚ CTI2.rebase-idᴿ = ⊤
+AvoidRebaseᴿ Yₚ (CTI2.rebase-varᴿ {Xᴿ = Xᴿ} rb) = Xᴿ ≢ Yₚ
+
+AvoidRebaseᴸ : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ?}
+  → TyVar Δᴿ
+  → CTI2.RebaseAtᴸ W W′ Xᴸ?
+  → Set
+AvoidRebaseᴸ Yₚ CTI2.rebase-idᴸ = ⊤
+AvoidRebaseᴸ Yₚ (CTI2.rebase-varᴸ {Xᴿ = Xᴿ} rb) = Xᴿ ≢ Yₚ
+AvoidRebaseᴸ Yₚ (CTI2.rebase-onlyᴸ mark disaligned represented) = ⊤
+
+data AvoidᴿD {Δᴸ Δᴿ Δ} (Yₚ : TyVar Δᴿ) :
+    ∀ {W : World Δᴸ Δᴿ Δ} {γ M N A B} {p : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ N ∶ p → Set where
+  avoid-x⊑x² : ∀ {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+      {x A B} {p : A ⊑ᵂ⟨ W ⟩ B}
+      {x∈ : γ ∋ʷ x ⦂ ctx-imp A B p}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidᴿD Yₚ (CTI2.x⊑x² x∈)
+
+  avoid-ƛ⊑ƛ² : ∀ {W γ M M′ A A′ B B′}
+      {pA : A ⊑ᵂ⟨ W ⟩ A′} {pB : B ⊑ᵂ⟨ W ⟩ B′}
+      {D : W ∣ ctx-imp A A′ pA ∷ γ ⊢² M ⊑ M′ ∶ pB}
+    → ¬ (Yₚ ∈ᵗ A′ ⇒ B′)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.ƛ⊑ƛ² D)
+
+  avoid-·⊑·² : ∀ {W γ L L′ M M′ A A′ B B′}
+      {pA : A ⊑ᵂ⟨ W ⟩ A′} {pB : B ⊑ᵂ⟨ W ⟩ B′}
+      {D₁ : W ∣ γ ⊢² L ⊑ L′ ∶ ⇒⊑⇒ pA pB}
+      {D₂ : W ∣ γ ⊢² M ⊑ M′ ∶ pA}
+    → ¬ (Yₚ ∈ᵗ B′)
+    → AvoidᴿD Yₚ D₁
+    → AvoidᴿD Yₚ D₂
+    → AvoidᴿD Yₚ (CTI2.·⊑·² D₁ D₂)
+
+  avoid-Λ⊑Λ² : ∀ {W γ γ′ V V′ A B}
+      {p : A ⊑ᵂ⟨ CTI2.liftWorldBoth X⊑X W ⟩ B}
+      {liftγ : CTI2.LiftCtx X⊑X γ γ′}
+      {vV : Value V} {vV′ : Value V′}
+      {D : CTI2.liftWorldBoth X⊑X W ∣ γ′ ⊢² V ⊑ V′ ∶ p}
+      {q : `∀ A ⊑ᵂ⟨ W ⟩ `∀ B}
+    → ¬ (Yₚ ∈ᵗ `∀ B)
+    → AvoidᴿD (Fin.suc Yₚ) D
+    → AvoidᴿD Yₚ (CTI2.Λ⊑Λ² liftγ vV vV′ D q)
+
+  avoid-Λ⊑² : ∀ {W γ γ′ V M A B}
+      {p : A ⊑ᵂ⟨ CTI2.liftWorldLeft X⊑★ W ⟩ B}
+      {Anv : NonVar A} {zero∈A : Fin.zero ∈ᵗ A}
+      {liftγ : CTI2.LiftCtxᴸ X⊑★ γ γ′} {vV : Value V}
+      {M⊢ : ⟨ _ , targetStoreʷ W , CTI2.tgtCtxʷ γ ⟩ ⊢ M ⦂ B}
+      {D : CTI2.liftWorldLeft X⊑★ W ∣ γ′ ⊢² V ⊑ M ∶ p}
+      {q : `∀ A ⊑ᵂ⟨ W ⟩ B}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ
+        (CTI2.Λ⊑² Anv zero∈A liftγ vV M⊢ D q)
+
+  avoid-•⊑•² : ∀ {W γ M M′ C C′ A A′}
+      {p∀ : `∀ C ⊑ᵂ⟨ W ⟩ `∀ C′} {q : A ⊑ᵂ⟨ W ⟩ A′}
+      {r : C [ A ]ᵗ ⊑ᵂ⟨ W ⟩ C′ [ A′ ]ᵗ}
+      {D : W ∣ γ ⊢² M ⊑ M′ ∶ p∀}
+    → ¬ (Yₚ ∈ᵗ C′ [ A′ ]ᵗ)
+    → ¬ (Yₚ ∈ᵗ A′)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.•⊑•² p∀ D q r)
+
+  avoid-•⊑² : ∀ {W γ M M′ C A B}
+      {p∀ : `∀ C ⊑ᵂ⟨ W ⟩ B} {q : A ⊑ᵂ⟨ W ⟩ ★}
+      {r : C [ A ]ᵗ ⊑ᵂ⟨ W ⟩ B}
+      {D : W ∣ γ ⊢² M ⊑ M′ ∶ p∀}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.•⊑² p∀ D q r)
+
+  avoid-κ⊑κ² : ∀ {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+      {κ : Const}
+      {p : constTy κ ⊑ᵂ⟨ W ⟩ constTy κ}
+    → ¬ (Yₚ ∈ᵗ constTy κ)
+    → AvoidᴿD Yₚ (CTI2.κ⊑κ² {W = W} {γ = γ} κ p)
+
+  avoid-cast⊑cast² : ∀ {W γ M M′ C C′ A A′ ν ν′}
+      {p : C ⊑ᵂ⟨ W ⟩ C′} {q : A ⊑ᵂ⟨ W ⟩ A′}
+      {c : ν ⊢ C ∼ A} {c′ : ν′ ⊢ C′ ∼ A′}
+      {D : W ∣ γ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ A′)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.cast⊑cast² c c′ D q)
+
+  avoid-⊑cast² : ∀ {W γ M M′ A B B′ ν}
+      {p : A ⊑ᵂ⟨ W ⟩ B} {q : A ⊑ᵂ⟨ W ⟩ B′}
+      {c′ : ν ⊢ B ∼ B′}
+      {D : W ∣ γ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B′)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.⊑cast² c′ D q)
+
+  avoid-⊑reveal² : ∀ {W W′ γ γ′ M M′ A B B′ Xᴿ?}
+      {p : A ⊑ᵂ⟨ W′ ⟩ B} {q : A ⊑ᵂ⟨ W ⟩ B′}
+      {c′ : Conv↑ _ B B′}
+      {mono : CTI2.ImpEnvMono W W′}
+      {rb : CTI2.RebaseAtᴿ W W′ Xᴿ?}
+      {sc : CTI2.SameCtx γ γ′}
+      {c′⊢ : targetStoreʷ W CTI2.⊢↑[ Xᴿ? ] c′}
+      {D : W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B′)
+    → AvoidRebaseᴿ Yₚ rb
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.⊑reveal² mono rb sc c′⊢ D q)
+
+  avoid-⊑conceal² : ∀ {W W′ γ γ′ M M′ A B B′ Xᴿ?}
+      {p : A ⊑ᵂ⟨ W′ ⟩ B} {q : A ⊑ᵂ⟨ W ⟩ B′}
+      {c′ : Conv↓ _ B B′}
+      {mono : CTI2.ImpEnvMono W W′}
+      {rb : CTI2.RebaseAtᴿ W′ W Xᴿ?}
+      {sc : CTI2.SameCtx γ γ′}
+      {c′⊢ : targetStoreʷ W CTI2.⊢↓[ Xᴿ? ] c′}
+      {D : W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B′)
+    → AvoidRebaseᴿ Yₚ rb
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.⊑conceal² mono rb sc c′⊢ D q)
+
+  avoid-cast⊑² : ∀ {W γ M M′ A A′ B ν}
+      {p : A ⊑ᵂ⟨ W ⟩ B} {q : A′ ⊑ᵂ⟨ W ⟩ B}
+      {c : ν ⊢ A ∼ A′}
+      {D : W ∣ γ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.cast⊑² c D q)
+
+  avoid-reveal⊑² : ∀ {W W′ γ γ′ M M′ A A′ B Xᴸ?}
+      {p : A ⊑ᵂ⟨ W′ ⟩ B} {q : A′ ⊑ᵂ⟨ W ⟩ B}
+      {c : Conv↑ _ A A′}
+      {mono : CTI2.ImpEnvMono W W′}
+      {rb : CTI2.RebaseAtᴸ W W′ Xᴸ?}
+      {sc : CTI2.SameCtx γ γ′}
+      {c⊢ : sourceStoreʷ W CTI2.⊢↑[ Xᴸ? ] c}
+      {D : W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidRebaseᴸ Yₚ rb
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.reveal⊑² mono rb sc c⊢ D q)
+
+  avoid-conceal⊑² : ∀ {W W′ γ γ′ M M′ A A′ B Xᴸ?}
+      {p : A ⊑ᵂ⟨ W′ ⟩ B} {q : A′ ⊑ᵂ⟨ W ⟩ B}
+      {c : Conv↓ _ A A′}
+      {mono : CTI2.ImpEnvMono W W′}
+      {rb : CTI2.RebaseAtᴸ W′ W Xᴸ?}
+      {sc : CTI2.SameCtx γ γ′}
+      {c⊢ : sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c}
+      {D : W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidRebaseᴸ Yₚ rb
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ (CTI2.conceal⊑² mono rb sc c⊢ D q)
+
+  avoid-reveal⊑reveal² : ∀
+      {W Wᵖ γ γᵖ M M′ A A′ B B′ Xᴸ Xᴿ}
+      {p : A ⊑ᵂ⟨ Wᵖ ⟩ A′} {q : B ⊑ᵂ⟨ W ⟩ B′}
+      {c : Conv↑ _ A B} {c′ : Conv↑ _ A′ B′}
+      {mono : CTI2.ImpEnvMono W Wᵖ}
+      {rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ}
+      {sc : CTI2.SameCtx γ γᵖ}
+      {c⊢ : sourceStoreʷ W CTI2.⊢↑[ just Xᴸ ] c}
+      {c′⊢ : targetStoreʷ W CTI2.⊢↑[ just Xᴿ ] c′}
+      {D : Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B′)
+    → Xᴿ ≢ Yₚ
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ
+        (CTI2.reveal⊑reveal² mono rb sc c⊢ c′⊢ D q)
+
+  avoid-conceal⊑conceal² : ∀
+      {W Wᵖ γ γᵖ M M′ A A′ B B′ Xᴸ Xᴿ}
+      {p : A ⊑ᵂ⟨ Wᵖ ⟩ A′} {q : B ⊑ᵂ⟨ W ⟩ B′}
+      {c : Conv↓ _ A B} {c′ : Conv↓ _ A′ B′}
+      {mono : CTI2.ImpEnvMono W Wᵖ}
+      {rb : CTI2.RebaseAt Wᵖ W Xᴸ Xᴿ}
+      {sc : CTI2.SameCtx γ γᵖ}
+      {c⊢ : sourceStoreʷ W CTI2.⊢↓[ just Xᴸ ] c}
+      {c′⊢ : targetStoreʷ W CTI2.⊢↓[ just Xᴿ ] c′}
+      {D : Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p}
+    → ¬ (Yₚ ∈ᵗ B′)
+    → Xᴿ ≢ Yₚ
+    → AvoidᴿD Yₚ D
+    → AvoidᴿD Yₚ
+        (CTI2.conceal⊑conceal² mono rb sc c⊢ c′⊢ D q)
+
+  avoid-blame⊑² : ∀ {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+      {M′ A B}
+      {M′⊢ : ⟨ _ , targetStoreʷ W , CTI2.tgtCtxʷ γ ⟩ ⊢ M′ ⦂ B}
+      {p : A ⊑ᵂ⟨ W ⟩ B}
+    → ¬ (Yₚ ∈ᵗ B)
+    → AvoidᴿD Yₚ (CTI2.blame⊑² M′⊢ p)
+
+  avoid-⊕⊑⊕² : ∀ {W γ} {op : Prim} {L L′ M M′}
+      {p q : primArgTy op ⊑ᵂ⟨ W ⟩ primArgTy op}
+      {r : primResultTy op ⊑ᵂ⟨ W ⟩ primResultTy op}
+      {D₁ : W ∣ γ ⊢² L ⊑ L′ ∶ p}
+      {D₂ : W ∣ γ ⊢² M ⊑ M′ ∶ q}
+    → ¬ (Yₚ ∈ᵗ primResultTy op)
+    → AvoidᴿD Yₚ D₁
+    → AvoidᴿD Yₚ D₂
+    → AvoidᴿD Yₚ (CTI2.⊕⊑⊕² op D₁ D₂ r)
+
 ------------------------------------------------------------------------
 -- Obligation and context transport
 ------------------------------------------------------------------------
@@ -241,3 +467,625 @@ repark-∋ʷ : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
 repark-∋ʷ (ctx-avoid-∷ Yₚ∉B avoid) Zʷ = Zʷ
 repark-∋ʷ (ctx-avoid-∷ Yₚ∉B avoid) (Sʷ x∈) =
   Sʷ (repark-∋ʷ avoid x∈)
+
+------------------------------------------------------------------------
+-- Avoidance under binders
+------------------------------------------------------------------------
+
+notOccurs→absent : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → ¬ (X ∈ᵗ A)
+  → X ∉ᵗ A
+notOccurs→absent {X = X} {A} X∉A with occurs? X A
+notOccurs→absent X∉A | present X∈A = ⊥-elim (X∉A X∈A)
+notOccurs→absent X∉A | absent X∉A′ = X∉A′
+
+notOccurs-shift : ∀ {Δ} {X : TyVar Δ} {A : Ty Δ}
+  → ¬ (X ∈ᵗ A)
+  → ¬ (Fin.suc X ∈ᵗ ⇑ᵗ A)
+notOccurs-shift X∉A X∈⇑A =
+  occurs-absent-⊥ X∈⇑A (shift-not-occurs (notOccurs→absent X∉A))
+
+storeAvoid-lift : ∀ {Δ} {Σ : TyStore Δ} {Y : TyVar Δ}
+  → StoreAvoidᴿ Y Σ
+  → StoreAvoidᴿ (Fin.suc Y) (store-lift Σ)
+storeAvoid-lift = store-avoid-lift-suc
+
+storeBound-lift : ∀ {Δ} {Σ : TyStore Δ} {Y : TyVar Δ} {S}
+  → Σ ∋ Y ⦂ S
+  → store-lift Σ ∋ Fin.suc Y ⦂ ⇑ᵗ S
+storeBound-lift Y∈ = S-lift∋ Y∈ refl
+
+ctxAvoid-lift : ∀ {Δᴸ Δᴿ Δ} {v}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {γ′ : CtxImp (CTI2.liftWorldBoth v W)} {Y : TyVar Δᴿ}
+  → CtxAvoidᴿ Y γ
+  → CTI2.LiftCtx v γ γ′
+  → CtxAvoidᴿ (Fin.suc Y) γ′
+ctxAvoid-lift ctx-avoid-[] CTI2.lift-[] = ctx-avoid-[]
+ctxAvoid-lift (ctx-avoid-∷ Y∉B avoid) (CTI2.lift-∷ liftγ) =
+  ctx-avoid-∷ (notOccurs-shift Y∉B) (ctxAvoid-lift avoid liftγ)
+
+ctxAvoid-liftᴸ : ∀ {Δᴸ Δᴿ Δ} {v}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {γ′ : CtxImp (CTI2.liftWorldLeft v W)} {Y : TyVar Δᴿ}
+  → CtxAvoidᴿ Y γ
+  → CTI2.LiftCtxᴸ v γ γ′
+  → CtxAvoidᴿ Y γ′
+ctxAvoid-liftᴸ ctx-avoid-[] CTI2.liftᴸ-[] = ctx-avoid-[]
+ctxAvoid-liftᴸ (ctx-avoid-∷ Y∉B avoid) (CTI2.liftᴸ-∷ liftγ) =
+  ctx-avoid-∷ Y∉B (ctxAvoid-liftᴸ avoid liftγ)
+
+------------------------------------------------------------------------
+-- Binder and context commutations
+------------------------------------------------------------------------
+
+reparkWorld-liftLeft : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+  → (v : VarImp)
+  → (Y : TyVar Δᴿ)
+  → CTI2.liftWorldLeft v (reparkWorld W Y)
+      ≡ reparkWorld (CTI2.liftWorldLeft v W) Y
+reparkWorld-liftLeft v Y = refl
+
+reparkWorld-liftBoth : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+  → (v : VarImp)
+  → (Y : TyVar Δᴿ)
+  → CTI2.liftWorldBoth v (reparkWorld W Y)
+      ≡ reparkWorld (CTI2.liftWorldBoth v W) (Fin.suc Y)
+reparkWorld-liftBoth v Y = refl
+
+reparkLiftCtx : ∀ {Δᴸ Δᴿ Δ} {v}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {γ′ : CtxImp (CTI2.liftWorldBoth v W)} {Y : TyVar Δᴿ}
+  → (avoid : CtxAvoidᴿ Y γ)
+  → (liftγ : CTI2.LiftCtx v γ γ′)
+  → CTI2.LiftCtx v (reparkCtx avoid)
+      (reparkCtx (ctxAvoid-lift avoid liftγ))
+reparkLiftCtx ctx-avoid-[] CTI2.lift-[] = CTI2.lift-[]
+reparkLiftCtx (ctx-avoid-∷ Y∉B avoid) (CTI2.lift-∷ liftγ) =
+  CTI2.lift-∷ (reparkLiftCtx avoid liftγ)
+
+reparkLiftCtxᴸ : ∀ {Δᴸ Δᴿ Δ} {v}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {γ′ : CtxImp (CTI2.liftWorldLeft v W)} {Y : TyVar Δᴿ}
+  → (avoid : CtxAvoidᴿ Y γ)
+  → (liftγ : CTI2.LiftCtxᴸ v γ γ′)
+  → CTI2.LiftCtxᴸ v (reparkCtx avoid)
+      (reparkCtx (ctxAvoid-liftᴸ avoid liftγ))
+reparkLiftCtxᴸ ctx-avoid-[] CTI2.liftᴸ-[] = CTI2.liftᴸ-[]
+reparkLiftCtxᴸ (ctx-avoid-∷ Y∉B avoid) (CTI2.liftᴸ-∷ liftγ) =
+  CTI2.liftᴸ-∷ (reparkLiftCtxᴸ avoid liftγ)
+
+reparkCtx-tgt : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {Y : TyVar Δᴿ} {γ : CtxImp W}
+  → (avoid : CtxAvoidᴿ Y γ)
+  → CTI2.tgtCtxʷ (reparkCtx avoid) ≡ CTI2.tgtCtxʷ γ
+reparkCtx-tgt ctx-avoid-[] = refl
+reparkCtx-tgt (ctx-avoid-∷ {B = B} Y∉B avoid) =
+  cong (B ∷_) (reparkCtx-tgt avoid)
+
+sameCtxAvoid : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CtxImp W′} {Y : TyVar Δᴿ}
+  → CtxAvoidᴿ Y γ
+  → CTI2.SameCtx γ γ′
+  → CtxAvoidᴿ Y γ′
+sameCtxAvoid ctx-avoid-[] CTI2.same-[] = ctx-avoid-[]
+sameCtxAvoid (ctx-avoid-∷ Y∉B avoid) (CTI2.same-∷ sc) =
+  ctx-avoid-∷ Y∉B (sameCtxAvoid avoid sc)
+
+reparkSameCtx : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γ′ : CtxImp W′} {Y : TyVar Δᴿ}
+  → (avoid : CtxAvoidᴿ Y γ)
+  → (sc : CTI2.SameCtx γ γ′)
+  → CTI2.SameCtx (reparkCtx avoid)
+      (reparkCtx (sameCtxAvoid avoid sc))
+reparkSameCtx ctx-avoid-[] CTI2.same-[] = CTI2.same-[]
+reparkSameCtx (ctx-avoid-∷ Y∉B avoid) (CTI2.same-∷ sc) =
+  CTI2.same-∷ (reparkSameCtx avoid sc)
+
+transportStoreBound : ∀ {Δ} {Σ Σ′ : TyStore Δ}
+    {Y : TyVar Δ} {S : Ty Δ}
+  → Σ ≡ Σ′
+  → Σ ∋ Y ⦂ S
+  → Σ′ ∋ Y ⦂ S
+transportStoreBound refl Y∈ = Y∈
+
+transportStoreAvoid : ∀ {Δ} {Σ Σ′ : TyStore Δ}
+    {Y : TyVar Δ}
+  → Σ ≡ Σ′
+  → StoreAvoidᴿ Y Σ
+  → StoreAvoidᴿ Y Σ′
+transportStoreAvoid refl avoid = avoid
+
+------------------------------------------------------------------------
+-- Avoidance of canonical store representations
+------------------------------------------------------------------------
+
+mutual
+  resolveVar-avoid : ∀ {Δ} {Σ : TyStore Δ} {Y X : TyVar Δ} {S₀}
+    → Σ ∋ Y ⦂ S₀
+    → StoreAvoidᴿ Y Σ
+    → X ≢ Y
+    → ¬ (Y ∈ᵗ CTI2.resolveVar Σ X)
+  resolveVar-avoid {X = Fin.zero}
+      (S-lift∋ Y∈ refl) (store-avoid-lift-suc avoid) X≠Y ()
+  resolveVar-avoid {X = Fin.suc X}
+      (S-lift∋ Y∈ refl) (store-avoid-lift-suc avoid) X≠Y Y∈R =
+    resolveVar-avoid Y∈ avoid
+      (λ eq → X≠Y (cong Fin.suc eq)) (unshift-occurs Y∈R)
+  resolveVar-avoid {X = Fin.zero}
+      (Z∋ refl) store-avoid-bind-zero X≠Y Y∈R =
+    ⊥-elim (X≠Y refl)
+  resolveVar-avoid {X = Fin.suc X}
+      (Z∋ refl) store-avoid-bind-zero X≠Y Y∈R =
+    zero-not-shift Y∈R
+  resolveVar-avoid {X = Fin.zero}
+      (S-bind∋ Y∈ refl) (store-avoid-bind-suc Y∉A avoid)
+      X≠Y Y∈R =
+    resolveRep-avoid Y∈ avoid Y∉A (unshift-occurs Y∈R)
+  resolveVar-avoid {X = Fin.suc X}
+      (S-bind∋ Y∈ refl) (store-avoid-bind-suc Y∉A avoid)
+      X≠Y Y∈R =
+    resolveVar-avoid Y∈ avoid
+      (λ eq → X≠Y (cong Fin.suc eq)) (unshift-occurs Y∈R)
+
+  resolveRep-avoid : ∀ {Δ} {Σ : TyStore Δ} {Y : TyVar Δ}
+      {S₀ A}
+    → Σ ∋ Y ⦂ S₀
+    → StoreAvoidᴿ Y Σ
+    → ¬ (Y ∈ᵗ A)
+    → ¬ (Y ∈ᵗ CTI2.resolveRep Σ A)
+  resolveRep-avoid {Y = Y} {A = ＇ X} Y∈ avoid Y∉X Y∈R
+      with Fin._≟_ X Y
+  resolveRep-avoid {Y = Y} {A = ＇ .Y} Y∈ avoid Y∉X Y∈R
+      | yes refl = ⊥-elim (Y∉X var-∈)
+  resolveRep-avoid {Y = Y} {A = ＇ X} Y∈ avoid Y∉X Y∈R
+      | no X≠Y = resolveVar-avoid Y∈ avoid X≠Y Y∈R
+  resolveRep-avoid {A = ‵ ι} Y∈ avoid Y∉A Y∈R = Y∉A Y∈R
+  resolveRep-avoid {A = ★} Y∈ avoid Y∉A Y∈R = Y∉A Y∈R
+  resolveRep-avoid {A = A ⇒ B} Y∈ avoid Y∉AB Y∈R = Y∉AB Y∈R
+  resolveRep-avoid {A = `∀ A} Y∈ avoid Y∉A Y∈R = Y∉A Y∈R
+
+------------------------------------------------------------------------
+-- Rebase transport
+------------------------------------------------------------------------
+
+reparkIndex-toRename : ∀ {Δᴿ Δ} (ηᴿ : Δᴿ ↪ᵗ Δ)
+    (Y : TyVar Δᴿ)
+  → reparkIndex ηᴿ Y ≡ Fin.inject₁ (toRenameᵗ ηᴿ Y)
+reparkIndex-toRename empty ()
+reparkIndex-toRename (keep ηᴿ) Fin.zero = refl
+reparkIndex-toRename (keep ηᴿ) (Fin.suc Y) =
+  cong Fin.suc (reparkIndex-toRename ηᴿ Y)
+reparkIndex-toRename (skip ηᴿ) Y =
+  cong Fin.suc (reparkIndex-toRename ηᴿ Y)
+
+reparkIndex-eq : ∀ {Δᴿ Δ} {η₁ η₂ : Δᴿ ↪ᵗ Δ}
+    {Y : TyVar Δᴿ}
+  → toRenameᵗ η₁ Y ≡ toRenameᵗ η₂ Y
+  → reparkIndex η₁ Y ≡ reparkIndex η₂ Y
+reparkIndex-eq {η₁ = η₁} {η₂} {Y} eq =
+  trans (reparkIndex-toRename η₁ Y)
+    (trans (cong Fin.inject₁ eq) (sym (reparkIndex-toRename η₂ Y)))
+
+insert-map-eq : ∀ {Δ} {k₁ k₂ : TyVar (Nat.suc Δ)}
+    {X₁ X₂ : TyVar Δ}
+  → k₁ ≡ k₂
+  → X₁ ≡ X₂
+  → toRenameᵗ (insertᶜ k₁) X₁ ≡ toRenameᵗ (insertᶜ k₂) X₂
+insert-map-eq refl refl = refl
+
+rebaseIndex-off : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ} {Y : TyVar Δᴿ}
+  → CTI2.RebaseAt W W′ Xᴸ Xᴿ
+  → Xᴿ ≢ Y
+  → reparkIndex (ηᴿʷ W′) Y ≡ reparkIndex (ηᴿʷ W) Y
+rebaseIndex-off rb Xᴿ≠Y =
+  reparkIndex-eq (CTI2.RebaseAt.ηᴿ-off-pivot rb
+    (λ eq → Xᴿ≠Y (sym eq)))
+
+renameEnvMono-insert : ∀ {Δ} {μ ν : ImpEnv Δ}
+    {k₁ k₂ : TyVar (Nat.suc Δ)}
+  → k₁ ≡ k₂
+  → (∀ Z → μ Z ≡ X⊑★ → ν Z ≡ X⊑★)
+  → ∀ Z → renameEnv (insertᶜ k₁) μ Z ≡ X⊑★
+  → renameEnv (insertᶜ k₂) ν Z ≡ X⊑★
+renameEnvMono-insert {k₁ = k} refl mono =
+  CR.renameEnvMono (insertᶜ k) mono
+
+reparkImpEnvMono : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Y : TyVar Δᴿ}
+  → reparkIndex (ηᴿʷ W) Y ≡ reparkIndex (ηᴿʷ W′) Y
+  → CTI2.ImpEnvMono W W′
+  → CTI2.ImpEnvMono (reparkWorld W Y) (reparkWorld W′ Y)
+reparkImpEnvMono {W = W} {W′} {Y} k-eq mono =
+  renameEnvMono-insert k-eq mono
+
+reparkRebaseAt : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ} {Y : TyVar Δᴿ}
+    {S₀ : Ty Δᴿ}
+  → targetStoreʷ W′ ∋ Y ⦂ S₀
+  → StoreAvoidᴿ Y (targetStoreʷ W′)
+  → Xᴿ ≢ Y
+  → CTI2.RebaseAt W W′ Xᴸ Xᴿ
+  → CTI2.RebaseAt (reparkWorld W Y) (reparkWorld W′ Y) Xᴸ Xᴿ
+reparkRebaseAt {W = W} {W′} {Xᴸ} {Xᴿ} {Y} Y∈ avoid Xᴿ≠Y
+    (CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
+      offL offR aligned (CTI2.store-rep-imp represented)) =
+  CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
+    left-off right-off repark-aligned
+    (CTI2.store-rep-imp
+      (repark-⊑ᵂ {W = W′} {Yₚ = Y}
+        (resolveVar-avoid Y∈ avoid Xᴿ≠Y) represented))
+  where
+  k-eq : reparkIndex (ηᴿʷ W′) Y ≡ reparkIndex (ηᴿʷ W) Y
+  k-eq = reparkIndex-eq (offR (λ eq → Xᴿ≠Y (sym eq)))
+
+  left-off : ∀ {Z} → Z ≢ Xᴸ
+    → toRenameᵗ (ηᴸʷ (reparkWorld W′ Y)) Z
+        ≡ toRenameᵗ (ηᴸʷ (reparkWorld W Y)) Z
+  left-off {Z} Z≠Xᴸ =
+    trans (toRenameᵗ-∘ (insertᶜ (reparkIndex (ηᴿʷ W′) Y))
+        (ηᴸʷ W′) Z)
+      (trans (insert-map-eq k-eq (offL Z≠Xᴸ))
+        (sym (toRenameᵗ-∘
+          (insertᶜ (reparkIndex (ηᴿʷ W) Y)) (ηᴸʷ W) Z)))
+
+  right-off : ∀ {Z} → Z ≢ Xᴿ
+    → toRenameᵗ (ηᴿʷ (reparkWorld W′ Y)) Z
+        ≡ toRenameᵗ (ηᴿʷ (reparkWorld W Y)) Z
+  right-off {Z} Z≠Xᴿ with Fin._≟_ Z Y
+  right-off {.Y} Z≠Xᴿ | yes refl =
+    trans (reparkEmbedᴿ-park (ηᴿʷ W′) Y)
+      (trans k-eq (sym (reparkEmbedᴿ-park (ηᴿʷ W) Y)))
+  right-off {Z} Z≠Xᴿ | no Z≠Y =
+    trans (reparkEmbedᴿ-off (ηᴿʷ W′) Y Z Z≠Y)
+      (trans (insert-map-eq k-eq (offR Z≠Xᴿ))
+        (sym (reparkEmbedᴿ-off (ηᴿʷ W) Y Z Z≠Y)))
+
+  repark-aligned :
+    toRenameᵗ (ηᴸʷ (reparkWorld W′ Y)) Xᴸ
+      ≡ toRenameᵗ (ηᴿʷ (reparkWorld W′ Y)) Xᴿ
+  repark-aligned =
+    trans (toRenameᵗ-∘ (insertᶜ (reparkIndex (ηᴿʷ W′) Y))
+        (ηᴸʷ W′) Xᴸ)
+      (trans (cong
+          (toRenameᵗ (insertᶜ (reparkIndex (ηᴿʷ W′) Y)))
+          aligned)
+        (sym (reparkEmbedᴿ-off (ηᴿʷ W′) Y Xᴿ Xᴿ≠Y)))
+
+repark-source-mark : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) (Y : TyVar Δᴿ)
+    (Xᴸ : TyVar Δᴸ)
+  → impEnvʷ (reparkWorld W Y)
+      (toRenameᵗ (ηᴸʷ (reparkWorld W Y)) Xᴸ)
+      ≡ impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ)
+repark-source-mark W Y Xᴸ =
+  trans (cong (impEnvʷ (reparkWorld W Y))
+      (toRenameᵗ-∘ (insertᶜ (reparkIndex (ηᴿʷ W) Y))
+        (ηᴸʷ W) Xᴸ))
+    (repark-mark-image W Y (toRenameᵗ (ηᴸʷ W) Xᴸ))
+
+repark-disaligned : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) (Y : TyVar Δᴿ)
+    {Xᴸ : TyVar Δᴸ}
+  → (∀ Xᴿ → toRenameᵗ (ηᴿʷ W) Xᴿ ≢
+      toRenameᵗ (ηᴸʷ W) Xᴸ)
+  → ∀ Xᴿ → toRenameᵗ (ηᴿʷ (reparkWorld W Y)) Xᴿ ≢
+      toRenameᵗ (ηᴸʷ (reparkWorld W Y)) Xᴸ
+repark-disaligned W Y {Xᴸ} disaligned Xᴿ eq with Fin._≟_ Xᴿ Y
+repark-disaligned W Y {Xᴸ} disaligned .Y eq | yes refl =
+  insertᶜ-misses (reparkIndex (ηᴿʷ W) Y)
+    (toRenameᵗ (ηᴸʷ W) Xᴸ)
+    (trans (sym source-image)
+      (trans (sym eq) (reparkEmbedᴿ-park (ηᴿʷ W) Y)))
+  where
+  source-image :
+    toRenameᵗ (ηᴸʷ (reparkWorld W Y)) Xᴸ ≡
+      toRenameᵗ (insertᶜ (reparkIndex (ηᴿʷ W) Y))
+        (toRenameᵗ (ηᴸʷ W) Xᴸ)
+  source-image =
+    toRenameᵗ-∘ (insertᶜ (reparkIndex (ηᴿʷ W) Y))
+      (ηᴸʷ W) Xᴸ
+repark-disaligned W Y {Xᴸ} disaligned Xᴿ eq | no Xᴿ≠Y =
+  disaligned Xᴿ
+    (toRenameᵗ-injective (insertᶜ (reparkIndex (ηᴿʷ W) Y))
+      (trans (sym (reparkEmbedᴿ-off (ηᴿʷ W) Y Xᴿ Xᴿ≠Y))
+        (trans eq
+          (toRenameᵗ-∘ (insertᶜ (reparkIndex (ηᴿʷ W) Y))
+            (ηᴸʷ W) Xᴸ))))
+
+reparkRebaseAtᴿ : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴿ?} {Y : TyVar Δᴿ}
+    {S₀ : Ty Δᴿ}
+  → targetStoreʷ W′ ∋ Y ⦂ S₀
+  → StoreAvoidᴿ Y (targetStoreʷ W′)
+  → (rb : CTI2.RebaseAtᴿ W W′ Xᴿ?)
+  → AvoidRebaseᴿ Y rb
+  → CTI2.RebaseAtᴿ (reparkWorld W Y) (reparkWorld W′ Y) Xᴿ?
+reparkRebaseAtᴿ Y∈ avoid CTI2.rebase-idᴿ tt = CTI2.rebase-idᴿ
+reparkRebaseAtᴿ Y∈ avoid (CTI2.rebase-varᴿ rb) Xᴿ≠Y =
+  CTI2.rebase-varᴿ (reparkRebaseAt Y∈ avoid Xᴿ≠Y rb)
+
+reparkRebaseAtᴸ : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ?} {Y : TyVar Δᴿ}
+    {S₀ : Ty Δᴿ}
+  → targetStoreʷ W′ ∋ Y ⦂ S₀
+  → StoreAvoidᴿ Y (targetStoreʷ W′)
+  → (rb : CTI2.RebaseAtᴸ W W′ Xᴸ?)
+  → AvoidRebaseᴸ Y rb
+  → CTI2.RebaseAtᴸ (reparkWorld W Y) (reparkWorld W′ Y) Xᴸ?
+reparkRebaseAtᴸ Y∈ avoid CTI2.rebase-idᴸ tt = CTI2.rebase-idᴸ
+reparkRebaseAtᴸ Y∈ avoid (CTI2.rebase-varᴸ rb) Xᴿ≠Y =
+  CTI2.rebase-varᴸ (reparkRebaseAt Y∈ avoid Xᴿ≠Y rb)
+reparkRebaseAtᴸ {W = W} {Y = Y} Y∈ avoid
+    (CTI2.rebase-onlyᴸ {Xᴸ = Xᴸ} mark disaligned represented) tt =
+  CTI2.rebase-onlyᴸ
+    (trans (repark-source-mark W Y Xᴸ) mark)
+    (repark-disaligned W Y disaligned)
+    (repark-⊑ᵂ {W = W} {Yₚ = Y} (λ ()) represented)
+
+rebaseAt-target-eq : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ}
+  → CTI2.RebaseAt W W′ Xᴸ Xᴿ
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+rebaseAt-target-eq rb =
+  CTI2.SameRuntime.targetStore-same (CTI2.RebaseAt.sameRuntime rb)
+
+rebaseAtᴿ-target-eq : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴿ?}
+  → CTI2.RebaseAtᴿ W W′ Xᴿ?
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+rebaseAtᴿ-target-eq CTI2.rebase-idᴿ = refl
+rebaseAtᴿ-target-eq (CTI2.rebase-varᴿ rb) = rebaseAt-target-eq rb
+
+rebaseAtᴸ-target-eq : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ?}
+  → CTI2.RebaseAtᴸ W W′ Xᴸ?
+  → targetStoreʷ W′ ≡ targetStoreʷ W
+rebaseAtᴸ-target-eq CTI2.rebase-idᴸ = refl
+rebaseAtᴸ-target-eq (CTI2.rebase-varᴸ rb) = rebaseAt-target-eq rb
+rebaseAtᴸ-target-eq (CTI2.rebase-onlyᴸ mark disaligned represented) = refl
+
+rebaseIndexᴿ-off : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴿ?} {Y : TyVar Δᴿ}
+  → (rb : CTI2.RebaseAtᴿ W W′ Xᴿ?)
+  → AvoidRebaseᴿ Y rb
+  → reparkIndex (ηᴿʷ W′) Y ≡ reparkIndex (ηᴿʷ W) Y
+rebaseIndexᴿ-off CTI2.rebase-idᴿ tt = refl
+rebaseIndexᴿ-off (CTI2.rebase-varᴿ rb) Xᴿ≠Y =
+  rebaseIndex-off rb Xᴿ≠Y
+
+rebaseIndexᴸ-off : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ?} {Y : TyVar Δᴿ}
+  → (rb : CTI2.RebaseAtᴸ W W′ Xᴸ?)
+  → AvoidRebaseᴸ Y rb
+  → reparkIndex (ηᴿʷ W′) Y ≡ reparkIndex (ηᴿʷ W) Y
+rebaseIndexᴸ-off CTI2.rebase-idᴸ tt = refl
+rebaseIndexᴸ-off (CTI2.rebase-varᴸ rb) Xᴿ≠Y =
+  rebaseIndex-off rb Xᴿ≠Y
+rebaseIndexᴸ-off (CTI2.rebase-onlyᴸ mark disaligned represented) tt =
+  refl
+
+avoid-right : ∀ {Δᴸ Δᴿ Δ} {Y : TyVar Δᴿ}
+    {W : World Δᴸ Δᴿ Δ} {γ M N A B} {p : A ⊑ᵂ⟨ W ⟩ B}
+    {D : W ∣ γ ⊢² M ⊑ N ∶ p}
+  → AvoidᴿD Y D
+  → ¬ (Y ∈ᵗ B)
+avoid-right (avoid-x⊑x² Y∉B) = Y∉B
+avoid-right (avoid-ƛ⊑ƛ² Y∉B avoid) = Y∉B
+avoid-right (avoid-·⊑·² Y∉B avoid₁ avoid₂) = Y∉B
+avoid-right (avoid-Λ⊑Λ² Y∉B avoid) = Y∉B
+avoid-right (avoid-Λ⊑² Y∉B avoid) = Y∉B
+avoid-right (avoid-•⊑•² Y∉B Y∉A′ avoid) = Y∉B
+avoid-right (avoid-•⊑² Y∉B avoid) = Y∉B
+avoid-right (avoid-κ⊑κ² Y∉B) = Y∉B
+avoid-right (avoid-cast⊑cast² Y∉B avoid) = Y∉B
+avoid-right (avoid-⊑cast² Y∉B avoid) = Y∉B
+avoid-right (avoid-⊑reveal² Y∉B rb-avoid avoid) = Y∉B
+avoid-right (avoid-⊑conceal² Y∉B rb-avoid avoid) = Y∉B
+avoid-right (avoid-cast⊑² Y∉B avoid) = Y∉B
+avoid-right (avoid-reveal⊑² Y∉B rb-avoid avoid) = Y∉B
+avoid-right (avoid-conceal⊑² Y∉B rb-avoid avoid) = Y∉B
+avoid-right (avoid-reveal⊑reveal² Y∉B Xᴿ≠Y avoid) = Y∉B
+avoid-right (avoid-conceal⊑conceal² Y∉B Xᴿ≠Y avoid) = Y∉B
+avoid-right (avoid-blame⊑² Y∉B) = Y∉B
+avoid-right (avoid-⊕⊑⊕² Y∉B avoid₁ avoid₂) = Y∉B
+
+notOccurs-fun-left : ∀ {Δ} {Y : TyVar Δ} {A B : Ty Δ}
+  → ¬ (Y ∈ᵗ A ⇒ B)
+  → ¬ (Y ∈ᵗ A)
+notOccurs-fun-left Y∉AB Y∈A = Y∉AB (∈-fun-left Y∈A)
+
+------------------------------------------------------------------------
+-- Derivation transport
+------------------------------------------------------------------------
+
+⊢²-repark : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {Yₚ : TyVar Δᴿ} {S₀ : Ty Δᴿ} {M N A B}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → targetStoreʷ W ∋ Yₚ ⦂ S₀
+  → StoreAvoidᴿ Yₚ (targetStoreʷ W)
+  → (avoid : CtxAvoidᴿ Yₚ γ)
+  → (D : W ∣ γ ⊢² M ⊑ N ∶ p)
+  → AvoidᴿD Yₚ D
+  → (p′ : A ⊑ᵂ⟨ reparkWorld W Yₚ ⟩ B)
+  → reparkWorld W Yₚ ∣ reparkCtx avoid ⊢² M ⊑ N ∶ p′
+⊢²-repark {W = W} Y∈ store-avoid avoid (CTI2.x⊑x² x∈)
+    (avoid-x⊑x² Y∉B) p′ =
+  CR.⊢²-retarget (CTI2.x⊑x² (repark-∋ʷ avoid x∈))
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.ƛ⊑ƛ² {pA = pA} {pB = pB} D)
+    (avoid-ƛ⊑ƛ² Y∉A′⇒B′ avoid-D) p′ =
+  CR.⊢²-retarget (CTI2.ƛ⊑ƛ²
+    (⊢²-repark {W = W} Y∈ store-avoid
+      (ctx-avoid-∷ (notOccurs-fun-left Y∉A′⇒B′) avoid)
+      D avoid-D (repark-⊑ᵂ {W = W} (avoid-right avoid-D) pB)))
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.·⊑·² {pA = pA} {pB = pB} D₁ D₂)
+    (avoid-·⊑·² Y∉B′ avoid₁ avoid₂) p′ =
+  CR.⊢²-retarget (CTI2.·⊑·²
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D₁ avoid₁
+      (⇒⊑⇒ (repark-⊑ᵂ {W = W} (avoid-right avoid₂) pA)
+        (repark-⊑ᵂ {W = W} Y∉B′ pB)))
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D₂ avoid₂
+      (repark-⊑ᵂ {W = W} (avoid-right avoid₂) pA)))
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.Λ⊑Λ² {p = p} liftγ vV vV′ D q)
+    (avoid-Λ⊑Λ² Y∉∀B avoid-D) p′ =
+  CTI2.Λ⊑Λ² (reparkLiftCtx avoid liftγ) vV vV′
+    (⊢²-repark {W = CTI2.liftWorldBoth X⊑X W}
+      (storeBound-lift Y∈) (storeAvoid-lift store-avoid)
+      (ctxAvoid-lift avoid liftγ) D avoid-D
+      (repark-⊑ᵂ {W = CTI2.liftWorldBoth X⊑X W}
+        (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {B = B} Y∈ store-avoid avoid
+    (CTI2.Λ⊑² {p = p} Anv zero∈A liftγ vV M⊢ D q)
+    (avoid-Λ⊑² Y∉B avoid-D) p′ =
+  CTI2.Λ⊑² Anv zero∈A (reparkLiftCtxᴸ avoid liftγ) vV
+    (subst (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ B)
+      (sym (reparkCtx-tgt avoid)) M⊢)
+    (⊢²-repark {W = CTI2.liftWorldLeft X⊑★ W}
+      Y∈ store-avoid (ctxAvoid-liftᴸ avoid liftγ) D avoid-D
+      (repark-⊑ᵂ {W = CTI2.liftWorldLeft X⊑★ W}
+        (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.•⊑•² p∀ D q r)
+    (avoid-•⊑•² Y∉R Y∉A′ avoid-D) p′ =
+  CTI2.•⊑•² (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p∀)
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D avoid-D
+      (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p∀))
+    (repark-⊑ᵂ {W = W} Y∉A′ q) p′
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.•⊑² p∀ D q r) (avoid-•⊑² Y∉B avoid-D) p′ =
+  CTI2.•⊑² (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p∀)
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D avoid-D
+      (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p∀))
+    (repark-⊑ᵂ {W = W} (λ ()) q) p′
+⊢²-repark {W = W} Y∈ store-avoid avoid (CTI2.κ⊑κ² κ p)
+    (avoid-κ⊑κ² Y∉B) p′ =
+  CTI2.κ⊑κ² κ p′
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.cast⊑cast² {p = p} c c′ D q)
+    (avoid-cast⊑cast² Y∉A′ avoid-D) p′ =
+  CTI2.cast⊑cast² c c′
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D avoid-D
+      (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.⊑cast² {p = p} c′ D q)
+    (avoid-⊑cast² Y∉B′ avoid-D) p′ =
+  CTI2.⊑cast² c′
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D avoid-D
+      (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.cast⊑² {p = p} c D q)
+    (avoid-cast⊑² Y∉B avoid-D) p′ =
+  CTI2.cast⊑² c
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D avoid-D
+      (repark-⊑ᵂ {W = W} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {B = B} Y∈ store-avoid avoid
+    (CTI2.blame⊑² M′⊢ p) (avoid-blame⊑² Y∉B) p′ =
+  CTI2.blame⊑²
+    (subst (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ B)
+      (sym (reparkCtx-tgt avoid)) M′⊢)
+    p′
+⊢²-repark {W = W} Y∈ store-avoid avoid
+    (CTI2.⊕⊑⊕² op {p = p} {q = q} D₁ D₂ r)
+    (avoid-⊕⊑⊕² Y∉R avoid₁ avoid₂) p′ =
+  CTI2.⊕⊑⊕² op
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D₁ avoid₁
+      (repark-⊑ᵂ {W = W} (avoid-right avoid₁) p))
+    (⊢²-repark {W = W} Y∈ store-avoid avoid D₂ avoid₂
+      (repark-⊑ᵂ {W = W} (avoid-right avoid₂) q)) p′
+⊢²-repark {W = W} {Yₚ = Y} Y∈ store-avoid avoid
+    (CTI2.⊑reveal² {W′ = W′} {p = p} mono rb sc c′⊢ D q)
+    (avoid-⊑reveal² Y∉B′ rb-avoid avoid-D) p′ =
+  CTI2.⊑reveal²
+    (reparkImpEnvMono {W = W} {W′ = W′} {Y = Y}
+      (sym (rebaseIndexᴿ-off rb rb-avoid)) mono)
+    (reparkRebaseAtᴿ
+      (transportStoreBound (sym (rebaseAtᴿ-target-eq rb)) Y∈)
+      (transportStoreAvoid (sym (rebaseAtᴿ-target-eq rb)) store-avoid)
+      rb rb-avoid)
+    (reparkSameCtx avoid sc) c′⊢
+    (⊢²-repark {W = W′}
+      (transportStoreBound (sym (rebaseAtᴿ-target-eq rb)) Y∈)
+      (transportStoreAvoid (sym (rebaseAtᴿ-target-eq rb)) store-avoid)
+      (sameCtxAvoid avoid sc) D avoid-D
+      (repark-⊑ᵂ {W = W′} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {Yₚ = Y} Y∈ store-avoid avoid
+    (CTI2.⊑conceal² {W′ = W′} {p = p} mono rb sc c′⊢ D q)
+    (avoid-⊑conceal² Y∉B′ rb-avoid avoid-D) p′ =
+  CTI2.⊑conceal²
+    (reparkImpEnvMono {W = W} {W′ = W′} {Y = Y}
+      (rebaseIndexᴿ-off rb rb-avoid) mono)
+    (reparkRebaseAtᴿ Y∈ store-avoid rb rb-avoid)
+    (reparkSameCtx avoid sc) c′⊢
+    (⊢²-repark {W = W′}
+      (transportStoreBound (rebaseAtᴿ-target-eq rb) Y∈)
+      (transportStoreAvoid (rebaseAtᴿ-target-eq rb) store-avoid)
+      (sameCtxAvoid avoid sc) D avoid-D
+      (repark-⊑ᵂ {W = W′} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {Yₚ = Y} Y∈ store-avoid avoid
+    (CTI2.reveal⊑² {W′ = W′} {p = p} mono rb sc c⊢ D q)
+    (avoid-reveal⊑² Y∉B rb-avoid avoid-D) p′ =
+  CTI2.reveal⊑²
+    (reparkImpEnvMono {W = W} {W′ = W′} {Y = Y}
+      (sym (rebaseIndexᴸ-off rb rb-avoid)) mono)
+    (reparkRebaseAtᴸ
+      (transportStoreBound (sym (rebaseAtᴸ-target-eq rb)) Y∈)
+      (transportStoreAvoid (sym (rebaseAtᴸ-target-eq rb)) store-avoid)
+      rb rb-avoid)
+    (reparkSameCtx avoid sc) c⊢
+    (⊢²-repark {W = W′}
+      (transportStoreBound (sym (rebaseAtᴸ-target-eq rb)) Y∈)
+      (transportStoreAvoid (sym (rebaseAtᴸ-target-eq rb)) store-avoid)
+      (sameCtxAvoid avoid sc) D avoid-D
+      (repark-⊑ᵂ {W = W′} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {Yₚ = Y} Y∈ store-avoid avoid
+    (CTI2.conceal⊑² {W′ = W′} {p = p} mono rb sc c⊢ D q)
+    (avoid-conceal⊑² Y∉B rb-avoid avoid-D) p′ =
+  CTI2.conceal⊑²
+    (reparkImpEnvMono {W = W} {W′ = W′} {Y = Y}
+      (rebaseIndexᴸ-off rb rb-avoid) mono)
+    (reparkRebaseAtᴸ Y∈ store-avoid rb rb-avoid)
+    (reparkSameCtx avoid sc) c⊢
+    (⊢²-repark {W = W′}
+      (transportStoreBound (rebaseAtᴸ-target-eq rb) Y∈)
+      (transportStoreAvoid (rebaseAtᴸ-target-eq rb) store-avoid)
+      (sameCtxAvoid avoid sc) D avoid-D
+      (repark-⊑ᵂ {W = W′} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {Yₚ = Y} Y∈ store-avoid avoid
+    (CTI2.reveal⊑reveal² {Wᵖ = Wᵖ} {p = p}
+      mono rb sc c⊢ c′⊢ D q)
+    (avoid-reveal⊑reveal² Y∉B′ Xᴿ≠Y avoid-D) p′ =
+  CTI2.reveal⊑reveal²
+    (reparkImpEnvMono {W = W} {W′ = Wᵖ} {Y = Y}
+      (sym (rebaseIndex-off rb Xᴿ≠Y)) mono)
+    (reparkRebaseAt
+      (transportStoreBound (sym (rebaseAt-target-eq rb)) Y∈)
+      (transportStoreAvoid (sym (rebaseAt-target-eq rb)) store-avoid)
+      Xᴿ≠Y rb)
+    (reparkSameCtx avoid sc) c⊢ c′⊢
+    (⊢²-repark {W = Wᵖ}
+      (transportStoreBound (sym (rebaseAt-target-eq rb)) Y∈)
+      (transportStoreAvoid (sym (rebaseAt-target-eq rb)) store-avoid)
+      (sameCtxAvoid avoid sc) D avoid-D
+      (repark-⊑ᵂ {W = Wᵖ} (avoid-right avoid-D) p)) p′
+⊢²-repark {W = W} {Yₚ = Y} Y∈ store-avoid avoid
+    (CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {p = p}
+      mono rb sc c⊢ c′⊢ D q)
+    (avoid-conceal⊑conceal² Y∉B′ Xᴿ≠Y avoid-D) p′ =
+  CTI2.conceal⊑conceal²
+    (reparkImpEnvMono {W = W} {W′ = Wᵖ} {Y = Y}
+      (rebaseIndex-off rb Xᴿ≠Y) mono)
+    (reparkRebaseAt Y∈ store-avoid Xᴿ≠Y rb)
+    (reparkSameCtx avoid sc) c⊢ c′⊢
+    (⊢²-repark {W = Wᵖ}
+      (transportStoreBound (rebaseAt-target-eq rb) Y∈)
+      (transportStoreAvoid (rebaseAt-target-eq rb) store-avoid)
+      (sameCtxAvoid avoid sc) D avoid-D
+      (repark-⊑ᵂ {W = Wᵖ} (avoid-right avoid-D) p)) p′

--- a/GTSFImp/proof/DGG/Repark.agda
+++ b/GTSFImp/proof/DGG/Repark.agda
@@ -11,6 +11,7 @@ module proof.DGG.Repark where
 open import Data.List using ([]; _∷_)
 open import Data.Empty using (⊥-elim)
 open import Data.Maybe using (just; nothing)
+open import Data.Product using (Σ-syntax; _,_)
 open import Data.Unit using (⊤; tt)
 import Data.Fin as Fin
 import Data.Nat as Nat
@@ -712,11 +713,13 @@ reparkRebaseAt : ∀ {Δᴸ Δᴿ Δ}
   → Xᴿ ≢ Y
   → CTI2.RebaseAt W W′ Xᴸ Xᴿ
   → CTI2.RebaseAt (reparkWorld W Y) (reparkWorld W′ Y) Xᴸ Xᴿ
-reparkRebaseAt {W = W} {W′} {Xᴸ} {Xᴿ} {Y} Y∈ avoid Xᴿ≠Y
+reparkRebaseAt {Δᴸ = Δᴸ} {W = W} {W′} {Xᴸ} {Xᴿ} {Y}
+    Y∈ avoid Xᴿ≠Y
     (CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
-      offL offR aligned (CTI2.store-rep-imp represented)) =
+      offL offR aligned anchor (CTI2.store-rep-imp represented)) =
   CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
     left-off right-off repark-aligned
+    repark-anchor
     (CTI2.store-rep-imp
       (repark-⊑ᵂ {W = W′} {Yₚ = Y}
         (resolveVar-avoid Y∈ avoid Xᴿ≠Y) represented))
@@ -756,6 +759,24 @@ reparkRebaseAt {W = W} {W′} {Xᴸ} {Xᴿ} {Y} Y∈ avoid Xᴿ≠Y
           (toRenameᵗ (insertᶜ (reparkIndex (ηᴿʷ W′) Y)))
           aligned)
         (sym (reparkEmbedᴿ-off (ηᴿʷ W′) Y Xᴿ Xᴿ≠Y)))
+
+  repark-anchor :
+      toRenameᵗ (ηᴿʷ (reparkWorld W Y)) Xᴿ
+        ≢ toRenameᵗ (ηᴿʷ (reparkWorld W′ Y)) Xᴿ
+    → Σ[ Xₒ ∈ TyVar Δᴸ ]
+        toRenameᵗ (ηᴸʷ (reparkWorld W Y)) Xₒ
+          ≡ toRenameᵗ (ηᴿʷ (reparkWorld W Y)) Xᴿ
+  repark-anchor moved with anchor
+      (λ eq → moved
+        (trans (reparkEmbedᴿ-off (ηᴿʷ W) Y Xᴿ Xᴿ≠Y)
+          (trans (insert-map-eq (sym k-eq) eq)
+            (sym (reparkEmbedᴿ-off (ηᴿʷ W′) Y Xᴿ Xᴿ≠Y)))))
+  repark-anchor moved | Xₒ , eq = Xₒ ,
+    trans (toRenameᵗ-∘
+        (insertᶜ (reparkIndex (ηᴿʷ W) Y)) (ηᴸʷ W) Xₒ)
+      (trans (cong
+          (toRenameᵗ (insertᶜ (reparkIndex (ηᴿʷ W) Y))) eq)
+        (sym (reparkEmbedᴿ-off (ηᴿʷ W) Y Xᴿ Xᴿ≠Y)))
 
 repark-source-mark : ∀ {Δᴸ Δᴿ Δ}
     (W : World Δᴸ Δᴿ Δ) (Y : TyVar Δᴿ)

--- a/GTSFImp/proof/DGG/SealPeelProbe.agda
+++ b/GTSFImp/proof/DGG/SealPeelProbe.agda
@@ -1,0 +1,304 @@
+module proof.DGG.SealPeelProbe where
+
+-- File Charter:
+--   * This probe records that inputs whose interior worlds move a
+--     third-party pivot are derivable and mark-honest, so no invariant
+--     excludes them.
+--   * It also records that the right-injection inversion output remains
+--     derivable by rebuilding link-by-link at freshly chosen premise
+--     worlds, rather than by transporting interior derivations.
+--   * Here the rebuild re-parks Y at an unused center so the inner seal's
+--     rebase-onlyᴸ disalignment holds.
+--   * See Rationale.md, section "Seal peeling and world support".
+
+open import Data.Empty using (⊥-elim)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-bind; _∋_⦂_; Z∋; S-bind∋)
+open import Consistency using
+  (Env∼; X∼★; _⊢_∼_; _↪ᵗ_; empty; keep; skip; _!; id)
+open import Imprecision
+open import Conversion using (seal)
+open import CastTerms
+open import Primitives using (κℕ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; _⊢↓[_]_; _∣_⊢²_⊑_∶_;
+   RebaseAt; rebase-at; same-runtime; store-rep-imp; ⊢↓-sealˣ)
+
+private
+  Xᴸ : TyVar 2
+  Xᴸ = Fin.zero
+
+  X₂ : TyVar 2
+  X₂ = Fin.suc Fin.zero
+
+  Y : TyVar 1
+  Y = Fin.zero
+
+  c0 : TyVar 3
+  c0 = Fin.zero
+
+  c1 : TyVar 3
+  c1 = Fin.suc Fin.zero
+
+  c2 : TyVar 3
+  c2 = Fin.suc (Fin.suc Fin.zero)
+
+------------------------------------------------------------------------
+-- Stores, embeddings, and worlds
+------------------------------------------------------------------------
+
+probe-src-store : TyStore 2
+probe-src-store = store-bind (store-bind store-empty ★) ★
+
+probe-tgt-store : TyStore 1
+probe-tgt-store = store-bind store-empty ★
+
+probe-μ : ImpEnv 3
+probe-μ Fin.zero = X⊑★
+probe-μ (Fin.suc Fin.zero) = X⊑★
+probe-μ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+
+ηᴸ-main : 2 ↪ᵗ 3
+ηᴸ-main = keep (keep (skip empty))
+
+ηᴸ-moved : 2 ↪ᵗ 3
+ηᴸ-moved = keep (skip (keep empty))
+
+ηᴿ-c0 : 1 ↪ᵗ 3
+ηᴿ-c0 = keep (skip (skip empty))
+
+ηᴿ-c1 : 1 ↪ᵗ 3
+ηᴿ-c1 = skip (keep (skip empty))
+
+ηᴿ-c2 : 1 ↪ᵗ 3
+ηᴿ-c2 = skip (skip (keep empty))
+
+probe-W : World 2 1 3
+probe-W =
+  world ηᴸ-main ηᴿ-c0 probe-μ probe-src-store probe-tgt-store
+
+probe-W′ : World 2 1 3
+probe-W′ =
+  world ηᴸ-main ηᴿ-c1 probe-μ probe-src-store probe-tgt-store
+
+probe-W₄ : World 2 1 3
+probe-W₄ =
+  world ηᴸ-moved ηᴿ-c2 probe-μ probe-src-store probe-tgt-store
+
+probe-Wᵖ : World 2 1 3
+probe-Wᵖ =
+  world ηᴸ-main ηᴿ-c2 probe-μ probe-src-store probe-tgt-store
+
+probe-W-WF : CTI2.WFWorld probe-W
+probe-W-WF Fin.zero ()
+probe-W-WF (Fin.suc Fin.zero) ()
+
+probe-W′-WF : CTI2.WFWorld probe-W′
+probe-W′-WF Fin.zero ()
+probe-W′-WF (Fin.suc Fin.zero) ()
+
+probe-W₄-WF : CTI2.WFWorld probe-W₄
+probe-W₄-WF Fin.zero ()
+probe-W₄-WF (Fin.suc Fin.zero) ()
+
+probe-Wᵖ-WF : CTI2.WFWorld probe-Wᵖ
+probe-Wᵖ-WF Fin.zero ()
+probe-Wᵖ-WF (Fin.suc Fin.zero) ()
+
+------------------------------------------------------------------------
+-- Store typing and casts
+------------------------------------------------------------------------
+
+probe-src-Xᴸ∋ : probe-src-store ∋ Xᴸ ⦂ ★
+probe-src-Xᴸ∋ = Z∋ refl
+
+probe-src-X₂∋ : probe-src-store ∋ X₂ ⦂ ★
+probe-src-X₂∋ = S-bind∋ (Z∋ refl) refl
+
+probe-tgt-Y∋ : probe-tgt-store ∋ Y ⦂ ★
+probe-tgt-Y∋ = Z∋ refl
+
+probe-Xᴸ-seal-⊢ : probe-src-store ⊢↓[ just Xᴸ ] seal Xᴸ ★
+probe-Xᴸ-seal-⊢ = ⊢↓-sealˣ probe-src-Xᴸ∋
+
+probe-X₂-seal-⊢ : probe-src-store ⊢↓[ just X₂ ] seal X₂ ★
+probe-X₂-seal-⊢ = ⊢↓-sealˣ probe-src-X₂∋
+
+probe-Y-seal-⊢ : probe-tgt-store ⊢↓[ just Y ] seal Y ★
+probe-Y-seal-⊢ = ⊢↓-sealˣ probe-tgt-Y∋
+
+private
+  probe-src-env : Env∼ 2
+  probe-src-env Fin.zero = X∼★
+  probe-src-env (Fin.suc Fin.zero) = X∼★
+
+  probe-tgt-env : Env∼ 1
+  probe-tgt-env Fin.zero = X∼★
+
+  probe-ℕ!ᴸ : probe-src-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴸ = id (‵ `ℕ) !
+
+  probe-ℕ!ᴿ : probe-tgt-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴿ = id (‵ `ℕ) !
+
+  probe-X₂! : probe-src-env ⊢ ＇ X₂ ∼ ★
+  probe-X₂! = id {μ = probe-src-env} (＇ X₂) !
+
+  probe-Y! : probe-tgt-env ⊢ ＇ Y ∼ ★
+  probe-Y! = id {μ = probe-tgt-env} (＇ Y) !
+
+------------------------------------------------------------------------
+-- Terms
+------------------------------------------------------------------------
+
+probe-U₀ : Term 1
+probe-U₀ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴿ ⟩
+
+probe-V₀₀ : Term 2
+probe-V₀₀ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴸ ⟩
+
+probe-V₁ : Term 2
+probe-V₁ = probe-V₀₀ ↓ seal X₂ ★
+
+probe-V : Term 2
+probe-V = probe-V₁ ⟨ probe-X₂! ⟩
+
+probe-M : Term 2
+probe-M = probe-V ↓ seal Xᴸ ★
+
+probe-U₁ : Term 1
+probe-U₁ = probe-U₀ ↓ seal Y ★
+
+probe-N! : Term 1
+probe-N! = probe-U₁ ⟨ probe-Y! ⟩
+
+------------------------------------------------------------------------
+-- Rebase witnesses
+------------------------------------------------------------------------
+
+probe-Xᴸ-Y-rep : CTI2.StoreRepImp probe-W Xᴸ Y
+probe-Xᴸ-Y-rep = store-rep-imp ★⊑★
+
+probe-outer-input-rebase : RebaseAt probe-W′ probe-W Xᴸ Y
+probe-outer-input-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
+    refl probe-Xᴸ-Y-rep
+
+probe-X₂-Y-rep′ : CTI2.StoreRepImp probe-W′ X₂ Y
+probe-X₂-Y-rep′ = store-rep-imp ★⊑★
+
+probe-inner-target-rebase : RebaseAt probe-W₄ probe-W′ X₂ Y
+probe-inner-target-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} _ → refl
+       ; {Fin.suc Fin.zero} X₂≢ → ⊥-elim (X₂≢ refl) })
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
+    refl probe-X₂-Y-rep′
+
+probe-X₂-Y-rep₄ : CTI2.StoreRepImp probe-W₄ X₂ Y
+probe-X₂-Y-rep₄ = store-rep-imp ★⊑★
+
+probe-inner-source-rebase : RebaseAt probe-W₄ probe-W₄ X₂ Y
+probe-inner-source-rebase =
+  CTI2.sameWorldRebaseAt refl probe-X₂-Y-rep₄
+
+probe-outer-output-rebase : RebaseAt probe-Wᵖ probe-W Xᴸ Y
+probe-outer-output-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ _ → refl)
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
+    refl probe-Xᴸ-Y-rep
+
+probe-inner-source-only : CTI2.RebaseAtᴸ probe-Wᵖ probe-Wᵖ
+    (just X₂)
+probe-inner-source-only =
+  CTI2.rebase-onlyᴸ refl (λ { Fin.zero () }) ★⊑★
+
+------------------------------------------------------------------------
+-- Checkpoint 1: the movable-interior input
+------------------------------------------------------------------------
+
+pIn : ＇ Xᴸ ⊑ᵂ⟨ probe-W ⟩ ★
+pIn = X⊑★ refl
+
+pMid : ＇ X₂ ⊑ᵂ⟨ probe-W′ ⟩ ＇ Y
+pMid = X⊑X
+
+p₄ : ＇ X₂ ⊑ᵂ⟨ probe-W₄ ⟩ ★
+p₄ = X⊑★ refl
+
+probe-base² :
+  probe-W₄ ∣ [] ⊢² probe-V₀₀ ⊑ probe-U₀ ∶ ★⊑★
+probe-base² =
+  CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
+    (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
+
+probe-inner-seal² :
+  probe-W₄ ∣ [] ⊢² probe-V₁ ⊑ probe-U₀ ∶ p₄
+probe-inner-seal² =
+  CTI2.conceal⊑² (λ _ eq → eq)
+    (CTI2.rebase-varᴸ probe-inner-source-rebase)
+    CTI2.same-[] probe-X₂-seal-⊢ probe-base² p₄
+
+probe-target-seal² :
+  probe-W′ ∣ [] ⊢² probe-V₁ ⊑ probe-U₁ ∶ pMid
+probe-target-seal² =
+  CTI2.⊑conceal² (λ _ eq → eq)
+    (CTI2.rebase-varᴿ probe-inner-target-rebase)
+    CTI2.same-[] probe-Y-seal-⊢ probe-inner-seal² pMid
+
+probe-paired-tags² :
+  probe-W′ ∣ [] ⊢² probe-V ⊑ probe-N! ∶ ★⊑★
+probe-paired-tags² =
+  CTI2.cast⊑cast² probe-X₂! probe-Y! probe-target-seal² ★⊑★
+
+probe-input :
+  probe-W ∣ [] ⊢² probe-M ⊑ probe-N! ∶ pIn
+probe-input =
+  CTI2.conceal⊑² (λ _ eq → eq)
+    (CTI2.rebase-varᴸ probe-outer-input-rebase)
+    CTI2.same-[] probe-Xᴸ-seal-⊢ probe-paired-tags² pIn
+
+------------------------------------------------------------------------
+-- Checkpoint 2: the link-by-link inversion output
+------------------------------------------------------------------------
+
+qOut : ＇ Xᴸ ⊑ᵂ⟨ probe-W ⟩ ＇ Y
+qOut = X⊑X
+
+pᵛ : ＇ X₂ ⊑ᵂ⟨ probe-Wᵖ ⟩ ★
+pᵛ = X⊑★ refl
+
+probe-output-base² :
+  probe-Wᵖ ∣ [] ⊢² probe-V₀₀ ⊑ probe-U₀ ∶ ★⊑★
+probe-output-base² =
+  CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
+    (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
+
+probe-output-inner-seal² :
+  probe-Wᵖ ∣ [] ⊢² probe-V₁ ⊑ probe-U₀ ∶ pᵛ
+probe-output-inner-seal² =
+  CTI2.conceal⊑² (λ _ eq → eq) probe-inner-source-only
+    CTI2.same-[] probe-X₂-seal-⊢ probe-output-base² pᵛ
+
+probe-output-tag² :
+  probe-Wᵖ ∣ [] ⊢² probe-V ⊑ probe-U₀ ∶ ★⊑★
+probe-output-tag² =
+  CTI2.cast⊑² probe-X₂! probe-output-inner-seal² ★⊑★
+
+probe-output :
+  probe-W ∣ [] ⊢² probe-M ⊑ probe-U₁ ∶ qOut
+probe-output =
+  CTI2.conceal⊑conceal² (λ _ eq → eq)
+    probe-outer-output-rebase CTI2.same-[]
+    probe-Xᴸ-seal-⊢ probe-Y-seal-⊢ probe-output-tag² qOut

--- a/GTSFImp/proof/DGG/SealPeelProbe.agda
+++ b/GTSFImp/proof/DGG/SealPeelProbe.agda
@@ -7,14 +7,15 @@ module proof.DGG.SealPeelProbe where
 --   * It also records that the right-injection inversion output remains
 --     derivable by rebuilding link-by-link at freshly chosen premise
 --     worlds, rather than by transporting interior derivations.
---   * Here the rebuild re-parks Y at an unused center so the inner seal's
---     rebase-onlyᴸ disalignment holds.
+--   * The output rebuild uses the world where X₂ and Y are aligned, so
+--     its inner source seal has a same-world variable rebase.
 --   * See Rationale.md, section "Seal peeling and world support".
 
 open import Data.Empty using (⊥-elim)
 import Data.Fin as Fin
 open import Data.List using ([])
 open import Data.Maybe using (just)
+open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl)
 
@@ -192,7 +193,7 @@ probe-outer-input-rebase =
   rebase-at (same-runtime refl refl)
     (λ _ → refl)
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    refl probe-Xᴸ-Y-rep
+    refl (λ _ → X₂ , refl) probe-Xᴸ-Y-rep
 
 probe-X₂-Y-rep′ : CTI2.StoreRepImp probe-W′ X₂ Y
 probe-X₂-Y-rep′ = store-rep-imp ★⊑★
@@ -203,7 +204,7 @@ probe-inner-target-rebase =
     (λ { {Fin.zero} _ → refl
        ; {Fin.suc Fin.zero} X₂≢ → ⊥-elim (X₂≢ refl) })
     (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    refl probe-X₂-Y-rep′
+    refl (λ _ → X₂ , refl) probe-X₂-Y-rep′
 
 probe-X₂-Y-rep₄ : CTI2.StoreRepImp probe-W₄ X₂ Y
 probe-X₂-Y-rep₄ = store-rep-imp ★⊑★
@@ -212,17 +213,9 @@ probe-inner-source-rebase : RebaseAt probe-W₄ probe-W₄ X₂ Y
 probe-inner-source-rebase =
   CTI2.sameWorldRebaseAt refl probe-X₂-Y-rep₄
 
-probe-outer-output-rebase : RebaseAt probe-Wᵖ probe-W Xᴸ Y
-probe-outer-output-rebase =
-  rebase-at (same-runtime refl refl)
-    (λ _ → refl)
-    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl) })
-    refl probe-Xᴸ-Y-rep
-
-probe-inner-source-only : CTI2.RebaseAtᴸ probe-Wᵖ probe-Wᵖ
-    (just X₂)
-probe-inner-source-only =
-  CTI2.rebase-onlyᴸ refl (λ { Fin.zero () }) ★⊑★
+probe-output-inner-source-rebase : RebaseAt probe-W′ probe-W′ X₂ Y
+probe-output-inner-source-rebase =
+  CTI2.sameWorldRebaseAt refl probe-X₂-Y-rep′
 
 ------------------------------------------------------------------------
 -- Checkpoint 1: the movable-interior input
@@ -276,23 +269,24 @@ probe-input =
 qOut : ＇ Xᴸ ⊑ᵂ⟨ probe-W ⟩ ＇ Y
 qOut = X⊑X
 
-pᵛ : ＇ X₂ ⊑ᵂ⟨ probe-Wᵖ ⟩ ★
+pᵛ : ＇ X₂ ⊑ᵂ⟨ probe-W′ ⟩ ★
 pᵛ = X⊑★ refl
 
 probe-output-base² :
-  probe-Wᵖ ∣ [] ⊢² probe-V₀₀ ⊑ probe-U₀ ∶ ★⊑★
+  probe-W′ ∣ [] ⊢² probe-V₀₀ ⊑ probe-U₀ ∶ ★⊑★
 probe-output-base² =
   CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
     (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
 
 probe-output-inner-seal² :
-  probe-Wᵖ ∣ [] ⊢² probe-V₁ ⊑ probe-U₀ ∶ pᵛ
+  probe-W′ ∣ [] ⊢² probe-V₁ ⊑ probe-U₀ ∶ pᵛ
 probe-output-inner-seal² =
-  CTI2.conceal⊑² (λ _ eq → eq) probe-inner-source-only
+  CTI2.conceal⊑² (λ _ eq → eq)
+    (CTI2.rebase-varᴸ probe-output-inner-source-rebase)
     CTI2.same-[] probe-X₂-seal-⊢ probe-output-base² pᵛ
 
 probe-output-tag² :
-  probe-Wᵖ ∣ [] ⊢² probe-V ⊑ probe-U₀ ∶ ★⊑★
+  probe-W′ ∣ [] ⊢² probe-V ⊑ probe-U₀ ∶ ★⊑★
 probe-output-tag² =
   CTI2.cast⊑² probe-X₂! probe-output-inner-seal² ★⊑★
 
@@ -300,5 +294,5 @@ probe-output :
   probe-W ∣ [] ⊢² probe-M ⊑ probe-U₁ ∶ qOut
 probe-output =
   CTI2.conceal⊑conceal² (λ _ eq → eq)
-    probe-outer-output-rebase CTI2.same-[]
+    probe-outer-input-rebase CTI2.same-[]
     probe-Xᴸ-seal-⊢ probe-Y-seal-⊢ probe-output-tag² qOut

--- a/GTSFImp/proof/DGG/SealPeelToolkit.agda
+++ b/GTSFImp/proof/DGG/SealPeelToolkit.agda
@@ -1,0 +1,209 @@
+module proof.DGG.SealPeelToolkit where
+
+-- File Charter:
+--   * Provides type and world views used by the bare-seal case of seal
+--     peeling in the right-injection inversion.
+--   * Inverts right-variable obligations and source-variable consistency.
+--   * Relates non-variable store entries to their canonical representations.
+--   * Decides target alignment and constructs fully dynamized worlds.
+--   * Depends on CastTermImprecision2's worlds and resolution functions and
+--     on WorldDecay's environment-decay relation.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Fin using (Fin)
+import Data.Fin as Fin
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; cong)
+open import Relation.Nullary using (Dec; yes; no)
+
+open import Types
+open import TyStore using
+  (TyStore; _∋_⦂_; Z∋; S-lift∋; S-bind∋)
+open import Consistency using
+  (Env∼; _⊢_∼_; _↪ᵗ_; empty; keep; skip; toRenameᵗ; id; _!; gen_)
+open import Imprecision
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; ηᴸʷ; ηᴿʷ; impEnvʷ; sourceStoreʷ;
+   targetStoreʷ; resolveVar; resolveRep)
+import proof.DGG.WorldDecay as WD
+
+------------------------------------------------------------------------
+-- Right-variable obligations
+------------------------------------------------------------------------
+
+private
+  imprecision-variable-nonvar-occurs⊥ : ∀ {Δ} {μ : ImpEnv Δ}
+      {A : Ty Δ} {X Y : TyVar Δ}
+    → μ ⊢ A ⊑ ＇ X
+    → NonVar A
+    → Y ∈ᵗ A
+    → ⊥
+  imprecision-variable-nonvar-occurs⊥ X⊑X () var-∈
+  imprecision-variable-nonvar-occurs⊥
+      (∀⊑ Anv zero∈A A⊑X) nonvar-all (∈-all Y∈A) =
+    imprecision-variable-nonvar-occurs⊥ A⊑X Anv zero∈A
+
+  imprecision-right-variable : ∀ {Δ} {μ : ImpEnv Δ}
+      {A : Ty Δ} {X : TyVar Δ}
+    → μ ⊢ A ⊑ ＇ X
+    → A ≡ ＇ X
+  imprecision-right-variable X⊑X = refl
+  imprecision-right-variable (∀⊑ Anv zero∈A A⊑X) =
+    ⊥-elim (imprecision-variable-nonvar-occurs⊥ A⊑X Anv zero∈A)
+
+  ty-var-injective : ∀ {Δ} {X Y : TyVar Δ}
+    → _≡_ {A = Ty Δ} (＇ X) (＇ Y)
+    → X ≡ Y
+  ty-var-injective {X = X} {.X} refl = refl
+
+right-var-obligation-view : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {R : Ty Δᴸ} {Y : TyVar Δᴿ}
+  → R ⊑ᵂ⟨ W ⟩ (＇ Y)
+  → Σ[ X₂ ∈ TyVar Δᴸ ]
+      (R ≡ ＇ X₂
+      × toRenameᵗ (ηᴸʷ W) X₂ ≡ toRenameᵗ (ηᴿʷ W) Y)
+right-var-obligation-view {R = ＇ X₂} p =
+  X₂ , refl , ty-var-injective (imprecision-right-variable p)
+right-var-obligation-view {R = ‵ ι} p
+    with imprecision-right-variable p
+right-var-obligation-view {R = ‵ ι} p | ()
+right-var-obligation-view {R = ★} p
+    with imprecision-right-variable p
+right-var-obligation-view {R = ★} p | ()
+right-var-obligation-view {R = A ⇒ B} p
+    with imprecision-right-variable p
+right-var-obligation-view {R = A ⇒ B} p | ()
+right-var-obligation-view {R = `∀ A} p
+    with imprecision-right-variable p
+right-var-obligation-view {R = `∀ A} p | ()
+
+------------------------------------------------------------------------
+-- Resolution of non-variable store entries
+------------------------------------------------------------------------
+
+private
+  unshift-nonvar : ∀ {Δ} {A : Ty Δ}
+    → NonVar (⇑ᵗ A)
+    → NonVar A
+  unshift-nonvar {A = ＇ X} ()
+  unshift-nonvar {A = ‵ ι} nonvar-base = nonvar-base
+  unshift-nonvar {A = ★} nonvar-star = nonvar-star
+  unshift-nonvar {A = A ⇒ B} nonvar-fun = nonvar-fun
+  unshift-nonvar {A = `∀ A} nonvar-all = nonvar-all
+
+  resolveRep-nonvar : ∀ {Δ} (Σ : TyStore Δ) {R : Ty Δ}
+    → NonVar R
+    → resolveRep Σ R ≡ R
+  resolveRep-nonvar Σ nonvar-base = refl
+  resolveRep-nonvar Σ nonvar-star = refl
+  resolveRep-nonvar Σ nonvar-fun = refl
+  resolveRep-nonvar Σ nonvar-all = refl
+
+resolveVar-nonvar : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ}
+    {R : Ty Δ}
+  → Σ ∋ X ⦂ R
+  → NonVar R
+  → resolveVar Σ X ≡ R
+resolveVar-nonvar (Z∋ {A = A} refl) Rnv =
+  cong ⇑ᵗ (resolveRep-nonvar _ (unshift-nonvar Rnv))
+resolveVar-nonvar (S-lift∋ X∈ refl) Rnv =
+  cong ⇑ᵗ (resolveVar-nonvar X∈ (unshift-nonvar Rnv))
+resolveVar-nonvar (S-bind∋ X∈ refl) Rnv =
+  cong ⇑ᵗ (resolveVar-nonvar X∈ (unshift-nonvar Rnv))
+
+------------------------------------------------------------------------
+-- Alignment at a source center
+------------------------------------------------------------------------
+
+private
+  fin-suc-injective : ∀ {n} {X Y : Fin n}
+    → Fin.suc X ≡ Fin.suc Y
+    → X ≡ Y
+  fin-suc-injective refl = refl
+
+  alignedᴿ? : ∀ {Δᴿ Δ} (ηᴿ : Δᴿ ↪ᵗ Δ) (Z : TyVar Δ)
+    → Dec (Σ[ Zᴿ ∈ TyVar Δᴿ ] toRenameᵗ ηᴿ Zᴿ ≡ Z)
+  alignedᴿ? empty Z = no λ { (() , eq) }
+  alignedᴿ? (keep ηᴿ) Fin.zero = yes (Fin.zero , refl)
+  alignedᴿ? (keep ηᴿ) (Fin.suc Z) with alignedᴿ? ηᴿ Z
+  alignedᴿ? (keep ηᴿ) (Fin.suc Z) | yes (Zᴿ , eq) =
+    yes (Fin.suc Zᴿ , cong Fin.suc eq)
+  alignedᴿ? (keep ηᴿ) (Fin.suc Z) | no unaligned =
+    no λ
+      { (Fin.zero , ())
+      ; (Fin.suc Zᴿ , eq) → unaligned (Zᴿ , fin-suc-injective eq)
+      }
+  alignedᴿ? (skip ηᴿ) Fin.zero = no λ { (Zᴿ , ()) }
+  alignedᴿ? (skip ηᴿ) (Fin.suc Z) with alignedᴿ? ηᴿ Z
+  alignedᴿ? (skip ηᴿ) (Fin.suc Z) | yes (Zᴿ , eq) =
+    yes (Zᴿ , cong Fin.suc eq)
+  alignedᴿ? (skip ηᴿ) (Fin.suc Z) | no unaligned =
+    no λ { (Zᴿ , eq) → unaligned (Zᴿ , fin-suc-injective eq) }
+
+alignedAtᴸ? : ∀ {Δᴸ Δᴿ Δ} (W : World Δᴸ Δᴿ Δ)
+    (Xᴸ : TyVar Δᴸ)
+  → (Σ[ Zᴿ ∈ TyVar Δᴿ ]
+       toRenameᵗ (ηᴿʷ W) Zᴿ ≡ toRenameᵗ (ηᴸʷ W) Xᴸ)
+    ⊎ (∀ Zᴿ →
+       toRenameᵗ (ηᴿʷ W) Zᴿ ≢ toRenameᵗ (ηᴸʷ W) Xᴸ)
+alignedAtᴸ? W Xᴸ
+    with alignedᴿ? (ηᴿʷ W) (toRenameᵗ (ηᴸʷ W) Xᴸ)
+alignedAtᴸ? W Xᴸ | yes aligned = inj₁ aligned
+alignedAtᴸ? W Xᴸ | no unaligned =
+  inj₂ λ Zᴿ eq → unaligned (Zᴿ , eq)
+
+------------------------------------------------------------------------
+-- Fully dynamized worlds
+------------------------------------------------------------------------
+
+dynWorld : ∀ {Δᴸ Δᴿ Δ}
+  → World Δᴸ Δᴿ Δ
+  → World Δᴸ Δᴿ Δ
+dynWorld W =
+  world (ηᴸʷ W) (ηᴿʷ W) (λ Z → X⊑★)
+    (sourceStoreʷ W) (targetStoreʷ W)
+
+dynWorld-decay : ∀ {Δᴸ Δᴿ Δ} (W : World Δᴸ Δᴿ Δ)
+  → WD.EnvDecay W (dynWorld W)
+dynWorld-decay W =
+  WD.env-decay refl refl refl refl (λ Z eq → refl)
+
+dynWorld-WF : ∀ {Δᴸ Δᴿ Δ} (W : World Δᴸ Δᴿ Δ)
+  → CTI2.WFWorld (dynWorld W)
+dynWorld-WF W Xᴸ ()
+
+dynWorld-mark : ∀ {Δᴸ Δᴿ Δ} (W : World Δᴸ Δᴿ Δ)
+    (Z : TyVar Δ)
+  → impEnvʷ (dynWorld W) Z ≡ X⊑★
+dynWorld-mark W Z = refl
+
+------------------------------------------------------------------------
+-- Consistency at a source variable
+------------------------------------------------------------------------
+
+private
+  consistency-variable-nonvar-occurs⊥ : ∀ {Δ} {ν : Env∼ Δ}
+      {Z Y : TyVar Δ} {R : Ty Δ}
+    → ν ⊢ (＇ Z) ∼ R
+    → NonVar R
+    → Y ∈ᵗ R
+    → ⊥
+  consistency-variable-nonvar-occurs⊥ (id (＇ Z)) () var-∈
+  consistency-variable-nonvar-occurs⊥
+      (_! c) nonvar-star ()
+  consistency-variable-nonvar-occurs⊥
+      (gen_ ⦃ Bnv ⦄ ⦃ zero∈B ⦄ c R≢★) nonvar-all (∈-all Y∈B) =
+    consistency-variable-nonvar-occurs⊥ c Bnv zero∈B
+
+var-consistency-view : ∀ {Δ} {ν : Env∼ Δ} {Z : TyVar Δ}
+    {R : Ty Δ}
+  → ν ⊢ (＇ Z) ∼ R
+  → (R ≡ ＇ Z) ⊎ (R ≡ ★)
+var-consistency-view (id (＇ Z)) = inj₁ refl
+var-consistency-view (_! c) = inj₂ refl
+var-consistency-view
+    (gen_ ⦃ Bnv ⦄ ⦃ zero∈B ⦄ c R≢★) =
+  ⊥-elim (consistency-variable-nonvar-occurs⊥ c Bnv zero∈B)

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -2,13 +2,15 @@ module proof.DGG.SealTransfer where
 
 -- File Charter:
 --   * Provides composition for a single moved source-representation pivot.
---   * Extends spine values locally with bare source seals.
+--   * Uses SpineValue's total account of value spines, including seals.
 --   * Transfers a target star-seal boundary to an existential output world.
 --   * Closes single-move interiors, including TagBoundaryProbe's case.
---   * Leaves one hypothesis only for interiors moving more than one pivot.
+--   * Leaves H-multi only for ChainRideProbe's multi-pivot interior.
+--     Together with ExtraCastRight2's OpenStrata fields H-walk
+--     (SealPeelProbe analysis), H-absorb (MovedLinkProbe), and H-Schain
+--     (ChainRideProbe), this completes inversion's named open frontier.
 --   * Depends on SealPeelToolkit, ExtraCastRight2, and term decay.
 
-open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
 open import Data.List using ([]; _∷_)
 open import Data.Maybe using (just)
@@ -35,7 +37,7 @@ open CTI2 using
   (World; CtxImp; RebaseAt; StoreRepImp; _⊑ᵂ⟨_⟩_;
    _∣_⊢²_⊑_∶_;
    same-runtime; rebase-at)
-open ECR using (SpineValue; sv-ƛ; sv-Λ; sv-$; sv-cast;
+open ECR using (SpineValue; sv-ƛ; sv-Λ; sv-$; sv-cast; sv-seal;
   sv-reveal-fun; sv-conceal-fun; sv-reveal-all; sv-conceal-all)
 
 ------------------------------------------------------------------------
@@ -113,41 +115,7 @@ composeSourceRebase {Δᴸ = Δᴸ} {W₁ = W₁} {Wₗ} {W₂}
       (trans (CTI2.RebaseAt.ηᴸ-off-pivot raₗ Z₃≠Z)
         (trans anchored (sym target₂ₗ)))
 
-------------------------------------------------------------------------
--- Seal values
-------------------------------------------------------------------------
-
-data SealValue {Δ : TyCtx} : Term Δ → Set where
-  sv-spine : ∀ {V}
-    → SpineValue V
-    → SealValue V
-
-  sv-sealed : ∀ {V X R}
-    → SealValue V
-    → SealValue (V ↓ Conversion.seal X R)
-
-------------------------------------------------------------------------
--- The present SpineValue interface has no variable-typed inhabitants
-------------------------------------------------------------------------
-
 private
-  spine-variable-⊥ : ∀ {Δ} {Σ} {Γ} {V : Term Δ} {X : TyVar Δ}
-    → SpineValue V
-    → ⟨ Δ , Σ , Γ ⟩ ⊢ V ⦂ ＇ X
-    → ⊥
-  spine-variable-⊥ (sv-ƛ N) ()
-  spine-variable-⊥ (sv-Λ sv) ()
-  spine-variable-⊥ (sv-$ (κℕ n)) ()
-  spine-variable-⊥ (sv-$ (κ𝔹 b)) ()
-  spine-variable-⊥ (sv-cast sv inj) ()
-  spine-variable-⊥ (sv-cast sv fun) ()
-  spine-variable-⊥ (sv-cast sv all) ()
-  spine-variable-⊥ (sv-cast sv (genᵥ A≠★ safe)) ()
-  spine-variable-⊥ (sv-reveal-fun sv) ()
-  spine-variable-⊥ (sv-conceal-fun sv) ()
-  spine-variable-⊥ (sv-reveal-all sv) ()
-  spine-variable-⊥ (sv-conceal-all sv) ()
-
   dyn-var-star : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
       {X : TyVar Δᴸ}
     → (＇ X) ⊑ᵂ⟨ SPT.dynWorld W ⟩ ★
@@ -281,7 +249,7 @@ seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
     {Z : TyVar Δᴸ} {Y : TyVar Δᴿ}
     {p : (＇ Z) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
   → SealTransferAssumption
-  → SealValue V
+  → SpineValue V
   → Value U
   → W₁ ∣ γ₁ ⊢² V ⊑ (U ↓ Conversion.seal Y ★) ∶ p
   → Σ[ W₂ ∈ World Δᴸ Δᴿ Δ ] Σ[ γ₂ ∈ CtxImp W₂ ]
@@ -291,23 +259,80 @@ seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
       × Σ[ q₂ ∈ (＇ Z) ⊑ᵂ⟨ W₂ ⟩ ★ ]
           (W₂ ∣ γ₂ ⊢² V ⊑ U ∶ q₂) )
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-spine sv) vU D =
-  ⊥-elim (spine-variable-⊥ sv (CTI2T.source-typing² D))
-seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-sealed sv) vU D
+    h (sv-ƛ N) vU D
     with CTI2T.source-typing² D
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-sealed sv) vU D
+    h (sv-ƛ N) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-Λ sv) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-Λ sv) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-$ (κℕ n)) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-$ (κℕ n)) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-$ (κ𝔹 b)) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-$ (κ𝔹 b)) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv inj) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv inj) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv fun) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv fun) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv all) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv all) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv (genᵥ A≠★ safe)) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-cast sv (genᵥ A≠★ safe)) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-reveal-fun sv) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-reveal-fun sv) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-conceal-fun sv) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-conceal-fun sv) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-reveal-all sv) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-reveal-all sv) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-conceal-all sv) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-conceal-all sv) vU D | ()
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-seal sv) vU D
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     with D
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-sealed sv) vU D
+    h (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₄ rb₄ sc₄
         (CTI2.⊢↓-sealˣ Y∈) prem .p
     with target-seal-rebase-source rb₄ p
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-sealed sv) vU D
+    h (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₄ rb₄ sc₄
         (CTI2.⊢↓-sealˣ Y∈) prem .p
@@ -322,21 +347,21 @@ seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
   TD.⊢²-decay-at (SPT.dynWorld-decay W₄) prem
     (dyn-var-star {W = W₄} {X = Z})
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-sealed sv) vU D
+    h (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
         monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
     with ECR.seal-rebase-target rbₗ p
        | SPT.right-var-obligation-view {W = Wₗ} {Y = Y} pₗ
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    h@(seal-transfer-assumption h-multi) (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
         monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
     | raₗ | Z₃ , refl , alignedₗ
     with seal-transfer h sv vU prem
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    h@(seal-transfer-assumption h-multi) (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
         monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
@@ -345,7 +370,7 @@ seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
     with Fin._≟_ (toRenameᵗ (CTI2.ηᴸʷ W₂) Z₃)
       (toRenameᵗ (CTI2.ηᴸʷ W₁) Z₃)
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    h@(seal-transfer-assumption h-multi) (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
         monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
@@ -374,7 +399,7 @@ seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
     (TD.⊢²-decay (SPT.dynWorld-decay W₂) V₀⊑U)
     (dyn-var-star {W = W₁} {X = Z})
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    h@(seal-transfer-assumption h-multi) (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
         monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
@@ -384,7 +409,7 @@ seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
   h-multi {p = p} {q₂ = q₂}
     raₗ link₂ moved monoₗ mono₂ scₗ sc₂ Z∈′ V₀⊑U
 seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    h (sv-sealed sv) vU D
+    h (sv-seal sv) vU D
     | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ}
         monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ Z∈′)

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -1,29 +1,28 @@
 module proof.DGG.SealTransfer where
 
 -- File Charter:
---   * Provides composition of same-pivot world rebases.
+--   * Provides composition for a single moved source-representation pivot.
 --   * Extends spine values locally with bare source seals.
---   * Transfers a target star-seal boundary into a dynamized relation.
---   * Closes unequal-target/unmoved rebase chains outright.
---   * Isolates the open H-compose, H-chain, and H-tag strata; see
---     MovedLinkProbe for the moved-link invariant's rationale.
+--   * Transfers a target star-seal boundary to an existential output world.
+--   * Closes single-move interiors, including TagBoundaryProbe's case.
+--   * Leaves one hypothesis only for interiors moving more than one pivot.
 --   * Depends on SealPeelToolkit, ExtraCastRight2, and term decay.
 
 open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
+open import Data.List using ([]; _∷_)
 open import Data.Maybe using (just)
-open import Data.Product using (Σ-syntax; _,_)
+open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; sym; trans)
-  renaming (subst to subst≡)
 open import Relation.Nullary using (yes; no)
 
 open import Types
 open import Imprecision
-open import Conversion
+open import Conversion using (⊢↓-seal)
 open import CastTerms
-open import TyStore using (_∋_⦂_)
-open import Consistency using (Env∼; _⊢_∼_; toRenameᵗ)
+open import TyStore using (_∋_⦂_; Z∋; S-lift∋; S-bind∋)
+open import Consistency using (toRenameᵗ)
 open import Primitives using (κℕ; κ𝔹)
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CastTermImprecision2Typing as CTI2T
@@ -33,143 +32,86 @@ import proof.DGG.TermImpDecay as TD
 import proof.DGG.WorldDecay as WD
 open import proof.ImprecisionConsistency using (toRenameᵗ-injective)
 open CTI2 using
-  (World; CtxImp; RebaseAt; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_;
+  (World; CtxImp; RebaseAt; StoreRepImp; _⊑ᵂ⟨_⟩_;
+   _∣_⊢²_⊑_∶_;
    same-runtime; rebase-at)
 open ECR using (SpineValue; sv-ƛ; sv-Λ; sv-$; sv-cast;
   sv-reveal-fun; sv-conceal-fun; sv-reveal-all; sv-conceal-all)
 
 ------------------------------------------------------------------------
--- Same-pivot rebase composition
+-- Single-move source-representation composition
 ------------------------------------------------------------------------
 
-composeRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
-    {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
-  → RebaseAt W₂ W₁ X Y
-  → RebaseAt W₃ W₂ X Y
-  → (toRenameᵗ (CTI2.ηᴿʷ W₃) Y
-      ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
-    → toRenameᵗ (CTI2.ηᴸʷ W₃) X
-      ≢ toRenameᵗ (CTI2.ηᴸʷ W₂) X
-    → toRenameᵗ (CTI2.ηᴸʷ W₂) X
-      ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
-    → Σ[ Xₒ ∈ TyVar Δᴸ ]
-        toRenameᵗ (CTI2.ηᴸʷ W₃) Xₒ
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W₃) Y)
-  → RebaseAt W₃ W₁ X Y
-composeRebaseAt {Δᴸ = Δᴸ} {W₁ = W₁} {W₂} {W₃} {X} {Y}
-    rb₁ rb₂ compose-corner =
+composeSourceRebase : ∀ {Δᴸ Δᴿ Δ}
+    {W₁ Wₗ W₂ : World Δᴸ Δᴿ Δ}
+    {Z Z₃ : TyVar Δᴸ} {Y : TyVar Δᴿ}
+  → RebaseAt Wₗ W₁ Z Y
+  → RebaseAt W₂ Wₗ Z₃ Y
+  → Z₃ ≢ Z
+  → toRenameᵗ (CTI2.ηᴸʷ W₂) Z₃
+      ≡ toRenameᵗ (CTI2.ηᴸʷ W₁) Z₃
+  → RebaseAt W₂ W₁ Z Y
+composeSourceRebase {Δᴸ = Δᴸ} {W₁ = W₁} {Wₗ} {W₂}
+    {Z} {Z₃} {Y} raₗ link₂ Z₃≠Z agrees =
   rebase-at
     (same-runtime
-      (trans source₁ source₂)
-      (trans target₁ target₂))
-    (λ Y≠X → trans (source-off₁ Y≠X) (source-off₂ Y≠X))
-    (λ Y′≠Y → trans (target-off₁ Y′≠Y) (target-off₂ Y′≠Y))
-    (CTI2.RebaseAt.pivotAligned rb₁)
-    compose-anchor
-    (CTI2.RebaseAt.storeRepresentations rb₁)
+      (trans source₁ₗ sourceₗ₂)
+      (trans target₁ₗ targetₗ₂))
+    source-off target-off
+    (CTI2.RebaseAt.pivotAligned raₗ)
+    composite-anchor
+    (CTI2.RebaseAt.storeRepresentations raₗ)
   where
-  source₁ = CTI2.SameRuntime.sourceStore-same
-    (CTI2.RebaseAt.sameRuntime rb₁)
-  source₂ = CTI2.SameRuntime.sourceStore-same
-    (CTI2.RebaseAt.sameRuntime rb₂)
-  target₁ = CTI2.SameRuntime.targetStore-same
-    (CTI2.RebaseAt.sameRuntime rb₁)
-  target₂ = CTI2.SameRuntime.targetStore-same
-    (CTI2.RebaseAt.sameRuntime rb₂)
-  source-off₁ = CTI2.RebaseAt.ηᴸ-off-pivot rb₁
-  source-off₂ = CTI2.RebaseAt.ηᴸ-off-pivot rb₂
-  target-off₁ = CTI2.RebaseAt.ηᴿ-off-pivot rb₁
-  target-off₂ = CTI2.RebaseAt.ηᴿ-off-pivot rb₂
+  source₁ₗ = CTI2.SameRuntime.sourceStore-same
+    (CTI2.RebaseAt.sameRuntime raₗ)
+  sourceₗ₂ = CTI2.SameRuntime.sourceStore-same
+    (CTI2.RebaseAt.sameRuntime link₂)
+  target₁ₗ = CTI2.SameRuntime.targetStore-same
+    (CTI2.RebaseAt.sameRuntime raₗ)
+  targetₗ₂ = CTI2.SameRuntime.targetStore-same
+    (CTI2.RebaseAt.sameRuntime link₂)
 
-  compose-anchor :
-      toRenameᵗ (CTI2.ηᴿʷ W₃) Y
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W₁) Y
-    → Σ[ Xₒ ∈ TyVar Δᴸ ]
-        toRenameᵗ (CTI2.ηᴸʷ W₃) Xₒ
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W₃) Y
-  compose-anchor moved with Fin._≟_
-      (toRenameᵗ (CTI2.ηᴿʷ W₃) Y)
-      (toRenameᵗ (CTI2.ηᴿʷ W₂) Y)
-  compose-anchor moved | no moved₂ =
-    CTI2.RebaseAt.anchorᴿ rb₂ moved₂
-  compose-anchor moved | yes target₃₂ with CTI2.RebaseAt.anchorᴿ rb₁
-      (λ target₂₁ → moved (trans target₃₂ target₂₁))
-  compose-anchor moved | yes target₃₂ | Xₒ , anchored₂
-      with Fin._≟_ Xₒ X
-  compose-anchor moved | yes target₃₂ | Xₒ , anchored₂ | no Xₒ≠X =
-    Xₒ , trans (sym (source-off₂ Xₒ≠X))
-      (trans anchored₂ (sym target₃₂))
-  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl
-      with Fin._≟_ (toRenameᵗ (CTI2.ηᴸʷ W₃) X)
-        (toRenameᵗ (CTI2.ηᴸʷ W₂) X)
-  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl
-      | yes source₃₂ =
-    X , trans source₃₂ (trans anchored₂ (sym target₃₂))
-  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl
-      | no source-moved =
-    compose-corner target₃₂ source-moved anchored₂
-
--- Composing away from a distinct, unmoved inner target pivot is closed.
-composeRebaseAt-away : ∀ {Δᴸ Δᴿ Δ}
-    {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
-    {X : TyVar Δᴸ} {Y Y″ : TyVar Δᴿ}
-  → RebaseAt W₄ W₁ X Y
-  → RebaseAt W₅ W₄ X Y″
-  → Y″ ≢ Y
-  → toRenameᵗ (CTI2.ηᴿʷ W₅) Y″
-      ≡ toRenameᵗ (CTI2.ηᴿʷ W₄) Y″
-  → RebaseAt W₅ W₁ X Y
-composeRebaseAt-away {Δᴸ = Δᴸ} {W₁ = W₁} {W₄} {W₅}
-    {X} {Y} {Y″} rb₁₄ rb₄₅ Y″≠Y unmoved =
-  rebase-at
-    (same-runtime
-      (trans source₁₄ source₄₅)
-      (trans target₁₄ target₄₅))
-    (λ Z≠X → trans (source-off₁₄ Z≠X) (source-off₄₅ Z≠X))
-    target-off
-    (CTI2.RebaseAt.pivotAligned rb₁₄)
-    away-anchor
-    (CTI2.RebaseAt.storeRepresentations rb₁₄)
-  where
-  source₁₄ = CTI2.SameRuntime.sourceStore-same
-    (CTI2.RebaseAt.sameRuntime rb₁₄)
-  source₄₅ = CTI2.SameRuntime.sourceStore-same
-    (CTI2.RebaseAt.sameRuntime rb₄₅)
-  target₁₄ = CTI2.SameRuntime.targetStore-same
-    (CTI2.RebaseAt.sameRuntime rb₁₄)
-  target₄₅ = CTI2.SameRuntime.targetStore-same
-    (CTI2.RebaseAt.sameRuntime rb₄₅)
-  source-off₁₄ = CTI2.RebaseAt.ηᴸ-off-pivot rb₁₄
-  source-off₄₅ = CTI2.RebaseAt.ηᴸ-off-pivot rb₄₅
-  target-off₁₄ = CTI2.RebaseAt.ηᴿ-off-pivot rb₁₄
-  target-off₄₅ = CTI2.RebaseAt.ηᴿ-off-pivot rb₄₅
-  Y≠Y″ = λ Y≡Y″ → Y″≠Y (sym Y≡Y″)
+  source-off : ∀ {Zₒ} → Zₒ ≢ Z
+    → toRenameᵗ (CTI2.ηᴸʷ W₁) Zₒ
+      ≡ toRenameᵗ (CTI2.ηᴸʷ W₂) Zₒ
+  source-off {Zₒ} Zₒ≠Z with Fin._≟_ Zₒ Z₃
+  source-off {.Z₃} Z₃≠Z | yes refl = sym agrees
+  source-off {Zₒ} Zₒ≠Z | no Zₒ≠Z₃ =
+    trans (CTI2.RebaseAt.ηᴸ-off-pivot raₗ Zₒ≠Z)
+      (CTI2.RebaseAt.ηᴸ-off-pivot link₂ Zₒ≠Z₃)
 
   target-off : ∀ {Yₒ} → Yₒ ≢ Y
     → toRenameᵗ (CTI2.ηᴿʷ W₁) Yₒ
-      ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Yₒ
-  target-off {Yₒ} Yₒ≠Y with Fin._≟_ Yₒ Y″
-  target-off {.Y″} Y″≠Y | yes refl =
-    trans (target-off₁₄ Y″≠Y) (sym unmoved)
-  target-off {Yₒ} Yₒ≠Y | no Yₒ≠Y″ =
-    trans (target-off₁₄ Yₒ≠Y) (target-off₄₅ Yₒ≠Y″)
+      ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Yₒ
+  target-off Yₒ≠Y =
+    trans (CTI2.RebaseAt.ηᴿ-off-pivot raₗ Yₒ≠Y)
+      (CTI2.RebaseAt.ηᴿ-off-pivot link₂ Yₒ≠Y)
 
-  away-anchor :
-      toRenameᵗ (CTI2.ηᴿʷ W₅) Y
+  composite-anchor :
+      toRenameᵗ (CTI2.ηᴿʷ W₂) Y
         ≢ toRenameᵗ (CTI2.ηᴿʷ W₁) Y
-    → Σ[ Xₒ ∈ TyVar Δᴸ ]
-        toRenameᵗ (CTI2.ηᴸʷ W₅) Xₒ
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Y
-  away-anchor moved with CTI2.RebaseAt.anchorᴿ rb₁₄
-      (λ target₄₁ → moved
-        (trans (sym (target-off₄₅ Y≠Y″)) target₄₁))
-  away-anchor moved | Xₒ , anchored₄ with Fin._≟_ Xₒ X
-  away-anchor moved | Xₒ , anchored₄ | no Xₒ≠X =
-    Xₒ , trans (sym (source-off₄₅ Xₒ≠X))
-      (trans anchored₄ (target-off₄₅ Y≠Y″))
-  away-anchor moved | .X , anchored₄ | yes refl =
-    ⊥-elim (Y″≠Y (toRenameᵗ-injective (CTI2.ηᴿʷ W₄)
-      (trans (sym (CTI2.RebaseAt.pivotAligned rb₄₅)) anchored₄)))
+    → Σ[ Zₒ ∈ TyVar Δᴸ ]
+        toRenameᵗ (CTI2.ηᴸʷ W₂) Zₒ
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
+  composite-anchor moved with Fin._≟_
+      (toRenameᵗ (CTI2.ηᴿʷ W₂) Y)
+      (toRenameᵗ (CTI2.ηᴿʷ Wₗ) Y)
+  composite-anchor moved | no moved₂ =
+    CTI2.RebaseAt.anchorᴿ link₂ moved₂
+  composite-anchor moved | yes target₂ₗ
+      with CTI2.RebaseAt.anchorᴿ raₗ
+        (λ targetₗ₁ → moved (trans target₂ₗ targetₗ₁))
+  composite-anchor moved | yes target₂ₗ | Zₒ , anchored
+      with Fin._≟_ Zₒ Z₃
+  composite-anchor moved | yes target₂ₗ | Zₒ , anchored
+      | no Zₒ≠Z₃ =
+    Zₒ , trans (sym (CTI2.RebaseAt.ηᴸ-off-pivot link₂ Zₒ≠Z₃))
+      (trans anchored (sym target₂ₗ))
+  composite-anchor moved | yes target₂ₗ | .Z₃ , anchored
+      | yes refl =
+    Z₃ , trans agrees
+      (trans (CTI2.RebaseAt.ηᴸ-off-pivot raₗ Z₃≠Z)
+        (trans anchored (sym target₂ₗ)))
 
 ------------------------------------------------------------------------
 -- Seal values
@@ -212,26 +154,6 @@ private
   dyn-var-star {W = W} {X = X} =
     X⊑★ (SPT.dynWorld-mark W (toRenameᵗ (CTI2.ηᴸʷ W) X))
 
-  aligned-var : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
-      {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
-    → toRenameᵗ (CTI2.ηᴸʷ W) X ≡ toRenameᵗ (CTI2.ηᴿʷ W) Y
-    → (＇ X) ⊑ᵂ⟨ SPT.dynWorld W ⟩ (＇ Y)
-  aligned-var {W = W} {X = X} eq =
-    subst≡
-      (λ Z → CTI2.impEnvʷ (SPT.dynWorld W) ⊢
-        ＇ toRenameᵗ (CTI2.ηᴸʷ W) X ⊑ ＇ Z)
-      eq X⊑X
-
-  transport-target-member : ∀ {Δᴸ Δᴿ Δ}
-      {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ Z R}
-    → RebaseAt W W′ Xᴸ Xᴿ
-    → CTI2.targetStoreʷ W ∋ Z ⦂ R
-    → CTI2.targetStoreʷ W′ ∋ Z ⦂ R
-  transport-target-member {Z = Z} {R = R} rb Z∈ =
-    subst≡ (λ Σ → Σ ∋ Z ⦂ R)
-      (sym (CTI2.SameRuntime.targetStore-same
-        (CTI2.RebaseAt.sameRuntime rb))) Z∈
-
   dyn-mono : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
     → CTI2.ImpEnvMono (SPT.dynWorld W) (SPT.dynWorld W′)
   dyn-mono Z eq = refl
@@ -261,100 +183,94 @@ private
             {W = W₁} {X = X} {Y = Y} q)))
   target-seal-rebase-source (CTI2.rebase-varᴿ rb) q | refl = rb
 
-  reveal-star-value-⊥ : ∀ {Δ} {V : Term Δ} {A}
-      {c : Conv↑ Δ A ★}
-    → Value (V ↑ c)
-    → ⊥
-  reveal-star-value-⊥ (vV ↑ ())
-
-  conceal-star-value-⊥ : ∀ {Δ} {V : Term Δ} {A}
-      {c : Conv↓ Δ A ★}
-    → Value (V ↓ c)
-    → ⊥
-  conceal-star-value-⊥ (vV ↓ ())
-
-  inert-variable-source : ∀ {Δᴸ Δᴿ Δ}
-      {W : World Δᴸ Δᴿ Δ} {Z : TyVar Δᴸ}
-      {B : Ty Δᴿ} {ν : Env∼ Δᴿ} {c : ν ⊢ B ∼ ★}
-    → Inert c
-    → (＇ Z) ⊑ᵂ⟨ W ⟩ B
-    → Σ[ Y ∈ TyVar Δᴿ ] B ≡ ＇ Y
-  inert-variable-source (inj ⦃ Gᵍ = ＇ Y ⦄) p = Y , refl
-  inert-variable-source (inj ⦃ Gᵍ = ‵ ι ⦄) ()
-  inert-variable-source (inj ⦃ Gᵍ = ★⇒★ ⦄) ()
-  inert-variable-source (inj ⦃ Gᵍ = ∀★ ⦄) ()
-
 ------------------------------------------------------------------------
--- Exceptional configurations
+-- Residual multi-pivot configuration
 ------------------------------------------------------------------------
 
--- These are the three residual strata after deciding target identity and
--- target movement.  MovedLinkProbe explains why moved links need anchors.
+-- The remaining hypothesis covers only a source-seal interior whose
+-- representation pivot moves across the complete stacked rebase.
 record SealTransferAssumption : Set where
   constructor seal-transfer-assumption
   field
-    -- Open: composing (X,Y)-rebases where the inner leg fixes Y but
-    -- relocates X, when Y's anchor at the middle world is X itself.
-    H-compose : ∀ {Δᴸ Δᴿ Δ}
-        {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
-        {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
-      → (rb₁₄ : RebaseAt W₄ W₁ X Y)
-      → (rb₄₅ : RebaseAt W₅ W₄ X Y)
-      → toRenameᵗ (CTI2.ηᴿʷ W₅) Y
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W₄) Y
-      → toRenameᵗ (CTI2.ηᴸʷ W₅) X
-          ≢ toRenameᵗ (CTI2.ηᴸʷ W₄) X
-      → toRenameᵗ (CTI2.ηᴸʷ W₄) X
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W₄) Y
-      → Σ[ Xₒ ∈ TyVar Δᴸ ]
-          toRenameᵗ (CTI2.ηᴸʷ W₅) Xₒ
-            ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Y
+    H-multi : ∀ {Δᴸ Δᴿ Δ}
+        {W₁ Wₗ W₂ : World Δᴸ Δᴿ Δ}
+        {γ₁ : CtxImp W₁} {γₗ : CtxImp Wₗ} {γ₂ : CtxImp W₂}
+        {V : Term Δᴸ} {U : Term Δᴿ}
+        {Z Z₃ : TyVar Δᴸ} {Y : TyVar Δᴿ}
+        {p : (＇ Z) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
+        {q₂ : (＇ Z₃) ⊑ᵂ⟨ W₂ ⟩ ★}
+      → (raₗ : RebaseAt Wₗ W₁ Z Y)
+      → (link₂ : RebaseAt W₂ Wₗ Z₃ Y)
+      → toRenameᵗ (CTI2.ηᴸʷ W₂) Z₃
+          ≢ toRenameᵗ (CTI2.ηᴸʷ W₁) Z₃
+      → CTI2.ImpEnvMono W₁ Wₗ
+      → CTI2.ImpEnvMono Wₗ W₂
+      → CTI2.SameCtx γ₁ γₗ
+      → CTI2.SameCtx γₗ γ₂
+      → CTI2.sourceStoreʷ W₁ ∋ Z ⦂ (＇ Z₃)
+      → W₂ ∣ γ₂ ⊢² V ⊑ U ∶ q₂
+      → Σ[ W₃ ∈ World Δᴸ Δᴿ Δ ] Σ[ γ₃ ∈ CtxImp W₃ ]
+          ( RebaseAt W₃ W₁ Z Y
+          × CTI2.ImpEnvMono W₁ W₃
+          × CTI2.SameCtx γ₁ γ₃
+          × Σ[ q₃ ∈ (＇ Z) ⊑ᵂ⟨ W₃ ⟩ ★ ]
+              (W₃ ∣ γ₃ ⊢²
+                (V ↓ Conversion.seal Z (＇ Z₃)) ⊑ U ∶ q₃) )
 
-    -- Open for the follow-up: a distinct moved target continues at the
-    -- source variable supplied by the inner rebase's anchor.
-    H-chain : ∀ {Δᴸ Δᴿ Δ}
-        {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
-        {γ₁ : CtxImp W₁} {V : Term Δᴸ} {U : Term Δᴿ}
-        {X : TyVar Δᴸ} {Y Y″ : TyVar Δᴿ}
-        {p : (＇ X) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
-      → (rb₁₄ : RebaseAt W₄ W₁ X Y)
-      → (rb₄₅ : RebaseAt W₅ W₄ X Y″)
-      → toRenameᵗ (CTI2.ηᴿʷ W₅) Y″
-          ≢ toRenameᵗ (CTI2.ηᴿʷ W₄) Y″
-      → Y″ ≢ Y
-      → Σ[ Xₒ ∈ TyVar Δᴸ ]
-          toRenameᵗ (CTI2.ηᴸʷ W₅) Xₒ
-            ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Y″
-      → SealValue V
-      → Value U
-      → W₁ ∣ γ₁ ⊢² V ⊑ (U ↓ Conversion.seal Y ★) ∶ p
-      → Σ[ q★ ∈ (＇ X) ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
-          (SPT.dynWorld W₁
-            ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
-            ⊢² V ⊑ U ∶ q★)
+------------------------------------------------------------------------
+-- Package helpers
+------------------------------------------------------------------------
 
-    -- Open: the inner target seal uses a distinct target variable; its
-    -- tag obligation may be unreachable, as MovedLinkProbe motivates.
-    H-tag : ∀ {Δᴸ Δᴿ Δ}
-        {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
-        {γ₁ : CtxImp W₁} {V : Term Δᴸ} {M : Term Δᴿ}
-        {X : TyVar Δᴸ} {Y Y′ : TyVar Δᴿ} {R : Ty Δᴿ}
-        {ν : Env∼ Δᴿ}
-        {p : (＇ X) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
-      → (rb₁₄ : RebaseAt W₄ W₁ X Y)
-      → (rb₄₅ : RebaseAt W₅ W₄ X Y′)
-      → Y′ ≢ Y
-      → (c : ν ⊢ (＇ Y′) ∼ ★)
-      → Inert c
-      → SealValue V
-      → Value (M ↓ Conversion.seal Y′ R)
-      → W₁ ∣ γ₁ ⊢² V ⊑
-          (((M ↓ Conversion.seal Y′ R) ⟨ c ⟩)
-            ↓ Conversion.seal Y ★) ∶ p
-      → Σ[ q★ ∈ (＇ X) ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
-          (SPT.dynWorld W₁
-            ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
-            ⊢² V ⊑ (M ↓ Conversion.seal Y′ R) ⟨ c ⟩ ∶ q★)
+private
+  impEnvMono-∘ : ∀ {Δᴸ Δᴿ Δ}
+      {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
+    → CTI2.ImpEnvMono W₁ W₂
+    → CTI2.ImpEnvMono W₂ W₃
+    → CTI2.ImpEnvMono W₁ W₃
+  impEnvMono-∘ mono₁ mono₂ Z eq = mono₂ Z (mono₁ Z eq)
+
+  dyn-decay-mono : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    → CTI2.ImpEnvMono W (SPT.dynWorld W)
+  dyn-decay-mono Z eq = refl
+
+  sameCtx-refl : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+      {γ : CtxImp W}
+    → CTI2.SameCtx γ γ
+  sameCtx-refl {γ = []} = CTI2.same-[]
+  sameCtx-refl {γ = CTI2.ctx-imp A B p ∷ γ} =
+    CTI2.same-∷ sameCtx-refl
+
+  dynLink : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+      {Z : TyVar Δᴸ} {Y : TyVar Δᴿ}
+    → toRenameᵗ (CTI2.ηᴸʷ W) Z
+        ≡ toRenameᵗ (CTI2.ηᴿʷ W) Y
+    → StoreRepImp W Z Y
+    → RebaseAt (SPT.dynWorld W) W Z Y
+  dynLink {W = W} aligned represented =
+    TD.decayRebaseAt (SPT.dynWorld-decay W)
+      WD.decay-refl (CTI2.sameWorldRebaseAt aligned represented)
+
+  store-variable-distinct : ∀ {Δ} {Σ : TyStore.TyStore Δ}
+      {Z Z₃ : TyVar Δ}
+    → Σ ∋ Z ⦂ (＇ Z₃)
+    → Z₃ ≢ Z
+  store-variable-distinct (Z∋ {A = ＇ X} refl) ()
+  store-variable-distinct (Z∋ {A = ‵ ι} ())
+  store-variable-distinct (Z∋ {A = ★} ())
+  store-variable-distinct (Z∋ {A = A ⇒ B} ())
+  store-variable-distinct (Z∋ {A = `∀ A} ())
+  store-variable-distinct (S-lift∋ {A = ＇ X} X∈ refl) refl =
+    store-variable-distinct X∈ refl
+  store-variable-distinct (S-lift∋ {A = ‵ ι} X∈ ())
+  store-variable-distinct (S-lift∋ {A = ★} X∈ ())
+  store-variable-distinct (S-lift∋ {A = A ⇒ B} X∈ ())
+  store-variable-distinct (S-lift∋ {A = `∀ A} X∈ ())
+  store-variable-distinct (S-bind∋ {A = ＇ X} X∈ refl) refl =
+    store-variable-distinct X∈ refl
+  store-variable-distinct (S-bind∋ {A = ‵ ι} X∈ ())
+  store-variable-distinct (S-bind∋ {A = ★} X∈ ())
+  store-variable-distinct (S-bind∋ {A = A ⇒ B} X∈ ())
+  store-variable-distinct (S-bind∋ {A = `∀ A} X∈ ())
 
 ------------------------------------------------------------------------
 -- Seal transfer
@@ -362,639 +278,133 @@ record SealTransferAssumption : Set where
 
 seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
     {γ₁ : CtxImp W₁} {V : Term Δᴸ} {U : Term Δᴿ}
-    {A : Ty Δᴸ} {Y : TyVar Δᴿ}
-    {p : A ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
+    {Z : TyVar Δᴸ} {Y : TyVar Δᴿ}
+    {p : (＇ Z) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
   → SealTransferAssumption
   → SealValue V
   → Value U
   → W₁ ∣ γ₁ ⊢² V ⊑ (U ↓ Conversion.seal Y ★) ∶ p
-  → Σ[ q★ ∈ A ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
-      (SPT.dynWorld W₁
-        ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
-        ⊢² V ⊑ U ∶ q★)
-seal-transfer {W₁ = W₁} {V = V} {A = A} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag) sv vU D
-    with SPT.right-var-obligation-view {W = W₁} {R = A} {Y = Y} p
-seal-transfer {W₁ = W₁} {V = V} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-spine sv) vU D
-    | X , refl , aligned =
-  ⊥-elim
-    (spine-variable-⊥ sv (CTI2T.source-typing² D))
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
+  → Σ[ W₂ ∈ World Δᴸ Δᴿ Δ ] Σ[ γ₂ ∈ CtxImp W₂ ]
+      ( RebaseAt W₂ W₁ Z Y
+      × CTI2.ImpEnvMono W₁ W₂
+      × CTI2.SameCtx γ₁ γ₂
+      × Σ[ q₂ ∈ (＇ Z) ⊑ᵂ⟨ W₂ ⟩ ★ ]
+          (W₂ ∣ γ₂ ⊢² V ⊑ U ∶ q₂) )
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-spine sv) vU D =
+  ⊥-elim (spine-variable-⊥ sv (CTI2T.source-typing² D))
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-sealed sv) vU D
     with CTI2T.source-typing² D
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
     with D
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    with target-seal-rebase-source rb₂ p
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    with prem₃
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {p = p₄} mono₅
-        (CTI2.rebase-onlyᴸ to-star disaligned represented) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄ =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₄})
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₄ rb₄ sc₄
+        (CTI2.⊢↓-sealˣ Y∈) prem .p
+    with target-seal-rebase-source rb₄ p
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₄ rb₄ sc₄
+        (CTI2.⊢↓-sealˣ Y∈) prem .p
+    | ra₄ =
+  SPT.dynWorld W₄ ,
+  WD.decayCtx (SPT.dynWorld-decay W₄) γ₄ ,
+  TD.decayRebaseAt (SPT.dynWorld-decay W₄) WD.decay-refl ra₄ ,
+  impEnvMono-∘ {W₁ = W₁} {W₂ = W₄}
+    {W₃ = SPT.dynWorld W₄} mono₄ (dyn-decay-mono {W = W₄}) ,
+  ECR.decaySameCtxʳ (SPT.dynWorld-decay W₄) sc₄ ,
+  dyn-var-star {W = W₄} {X = Z} ,
+  TD.⊢²-decay-at (SPT.dynWorld-decay W₄) prem
+    (dyn-var-star {W = W₄} {X = Z})
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
+        monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
+    with ECR.seal-rebase-target rbₗ p
+       | SPT.right-var-obligation-view {W = Wₗ} {Y = Y} pₗ
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
+        monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
+    | raₗ | Z₃ , refl , alignedₗ
+    with seal-transfer h sv vU prem
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
+        monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
+    | raₗ | Z₃ , refl , alignedₗ
+    | W₂ , γ₂ , link₂ , mono₂ , sc₂ , q₂ , V₀⊑U
+    with Fin._≟_ (toRenameᵗ (CTI2.ηᴸʷ W₂) Z₃)
+      (toRenameᵗ (CTI2.ηᴸʷ W₁) Z₃)
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
+        monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
+    | raₗ | Z₃ , refl , alignedₗ
+    | W₂ , γ₂ , link₂ , mono₂ , sc₂ , q₂ , V₀⊑U
+    | yes agrees =
+  SPT.dynWorld W₁ ,
+  WD.decayCtx (SPT.dynWorld-decay W₁) γ₁ ,
+  dynLink {W = W₁} {Z = Z} {Y = Y}
+    (ECR.variable-obligation-aligns {W = W₁} {X = Z} {Y = Y} p)
+    (CTI2.RebaseAt.storeRepresentations raₗ) ,
+  dyn-decay-mono {W = W₁} ,
+  ECR.decaySameCtxʳ (SPT.dynWorld-decay W₁)
+    (sameCtx-refl {γ = γ₁}) ,
+  dyn-var-star {W = W₁} {X = Z} ,
+  CTI2.conceal⊑²
+    (dyn-mono {W = W₁} {W′ = W₂})
     (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = W₄} {W₁ᵈ = SPT.dynWorld W₄}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₄)
-        (SPT.dynWorld-decay W₁) rb₁₄))
-    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay W₄) (composeSameCtx sc₂ sc₅))
-    (CTI2.⊢↓-sealˣ X∈)
-    (TD.⊢²-decay {W = W₄} {Wᵈ = SPT.dynWorld W₄}
-      (SPT.dynWorld-decay W₄) prem₄)
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    with Fin._≟_ Y″ Y
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ {Xᴿ = .Y} rb₄₅) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    | yes refl =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
-    (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₅)
+      (TD.decayRebaseAt (SPT.dynWorld-decay W₂)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅))))
+        (composeSourceRebase raₗ link₂
+          (store-variable-distinct Z∈′) agrees)))
     (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
-    (CTI2.⊢↓-sealˣ X∈)
-    (TD.⊢²-decay {W = W₅} {Wᵈ = SPT.dynWorld W₅}
-      (SPT.dynWorld-decay W₅) prem₄)
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    | no Y″≠Y
-    with Fin._≟_ (toRenameᵗ (CTI2.ηᴿʷ W₅) Y″)
-      (toRenameᵗ (CTI2.ηᴿʷ W₄) Y″)
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    | no Y″≠Y | yes unmoved =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
+      (SPT.dynWorld-decay W₂) (composeSameCtx scₗ sc₂))
+    (CTI2.⊢↓-sealˣ Z∈′)
+    (TD.⊢²-decay (SPT.dynWorld-decay W₂) V₀⊑U)
+    (dyn-var-star {W = W₁} {X = Z})
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h@(seal-transfer-assumption h-multi) (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} {p = pₗ}
+        monoₗ rbₗ scₗ (CTI2.⊢↓-sealˣ Z∈′) prem .p
+    | raₗ | Z₃ , refl , alignedₗ
+    | W₂ , γ₂ , link₂ , mono₂ , sc₂ , q₂ , V₀⊑U
+    | no moved =
+  h-multi {p = p} {q₂ = q₂}
+    raₗ link₂ moved monoₗ mono₂ scₗ sc₂ Z∈′ V₀⊑U
+seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
+    h (sv-sealed sv) vU D
+    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
+    | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ}
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ Z∈′)
+        (CTI2.⊢↓-sealˣ Y∈) prem .p =
+  SPT.dynWorld W₁ ,
+  WD.decayCtx (SPT.dynWorld-decay W₁) γ₁ ,
+  dynLink {W = W₁} {Z = Z} {Y = Y}
+    (ECR.variable-obligation-aligns {W = W₁} {X = Z} {Y = Y} p)
+    (CTI2.RebaseAt.storeRepresentations rbᵖ) ,
+  dyn-decay-mono {W = W₁} ,
+  ECR.decaySameCtxʳ (SPT.dynWorld-decay W₁)
+    (sameCtx-refl {γ = γ₁}) ,
+  dyn-var-star {W = W₁} {X = Z} ,
+  CTI2.conceal⊑²
+    (dyn-mono {W = W₁} {W′ = Wᵖ})
     (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₅)
-        (SPT.dynWorld-decay W₁)
-        (composeRebaseAt-away rb₁₄ rb₄₅ Y″≠Y unmoved)))
+      (TD.decayRebaseAt (SPT.dynWorld-decay Wᵖ)
+        (SPT.dynWorld-decay W₁) rbᵖ))
     (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
-    (CTI2.⊢↓-sealˣ X∈)
-    (TD.⊢²-decay {W = W₅} {Wᵈ = SPT.dynWorld W₅}
-      (SPT.dynWorld-decay W₅) prem₄)
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    | no Y″≠Y | no moved
-    with CTI2.RebaseAt.anchorᴿ rb₄₅ moved
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
-        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    | no Y″≠Y | no moved | Xₒ , anchored₅ =
-  h-chain rb₁₄ rb₄₅ moved Y″≠Y (Xₒ , anchored₅)
-    (sv-sealed sv) vU D
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    with vU
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    with inert-variable-source {W = W₄} {Z = X} inert p₄
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    with ECR.var-value-view vM′ (CTI2T.target-typing² prem₄)
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    with prem₄
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    with SPT.right-var-obligation-view {W = W₅} {Y = Y′} p₅
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    with rb₅
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = .W₄} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-onlyᴸ to-star disaligned represented =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₄})
-    (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = W₄} {W₁ᵈ = SPT.dynWorld W₄}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₄)
-        (SPT.dynWorld-decay W₁) rb₁₄))
-    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay W₄) (composeSameCtx sc₂ sc₅))
-    (CTI2.⊢↓-sealˣ X∈)
-    (CTI2.⊑cast² c
-      (TD.⊢²-decay-at (SPT.dynWorld-decay W₄) prem₅
-        (aligned-var {W = W₄} {X = X₃} {Y = Y′} aligned₅))
-      (dyn-var-star {W = W₄} {X = X₃}))
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
-    with Fin._≟_ Y″ Y
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ {Xᴿ = .Y} rb₄₅
-    | yes refl =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
-    (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₅)
-        (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅))))
-    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
-    (CTI2.⊢↓-sealˣ X∈)
-    (CTI2.⊑cast² c
-      (TD.⊢²-decay-at (SPT.dynWorld-decay W₅) prem₅
-        (aligned-var {W = W₅} {X = X₃} {Y = Y′} aligned₅))
-      (dyn-var-star {W = W₅} {X = X₃}))
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
-    | no Y″≠Y
-    with Fin._≟_ (toRenameᵗ (CTI2.ηᴿʷ W₅) Y″)
-      (toRenameᵗ (CTI2.ηᴿʷ W₄) Y″)
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
-    | no Y″≠Y | yes unmoved =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
-    (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₅)
-        (SPT.dynWorld-decay W₁)
-        (composeRebaseAt-away rb₁₄ rb₄₅ Y″≠Y unmoved)))
-    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
-    (CTI2.⊢↓-sealˣ X∈)
-    (CTI2.⊑cast² c
-      (TD.⊢²-decay-at (SPT.dynWorld-decay W₅) prem₅
-        (aligned-var {W = W₅} {X = X₃} {Y = Y′} aligned₅))
-      (dyn-var-star {W = W₅} {X = X₃}))
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
-    | no Y″≠Y | no moved
-    with CTI2.RebaseAt.anchorᴿ rb₄₅ moved
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
-    | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
-    | no Y″≠Y | no moved | Xₒ , anchored₅ =
-  h-chain rb₁₄ rb₄₅ moved Y″≠Y (Xₒ , anchored₅)
-    (sv-sealed sv) vU D
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
-    with target-seal-rebase-source rb₅ p₄
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
-    | rb₄₅
-    with Fin._≟_ Y′ Y
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y , refl
-    | ECR.varv-seal vM₅ Y∈′ refl
-    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y∈″) prem₅ .p₄
-    | rb₄₅
-    | yes refl =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.⊑cast² c
-    (CTI2.⊑conceal² (dyn-mono {W = W₁} {W′ = W₅})
-      (CTI2.rebase-varᴿ
-        (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
-          {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-          (SPT.dynWorld-decay W₅)
-          (SPT.dynWorld-decay W₁)
-          (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅))))
-      (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-        (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
-      (CTI2.⊢↓-sealˣ (transport-target-member rb₁₄ Y∈″))
-      (TD.⊢²-decay (SPT.dynWorld-decay W₅) prem₅)
-      (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
-        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
-    | rb₄₅
-    | no Y′≠Y =
-  h-tag rb₁₄ rb₄₅ Y′≠Y c inert (sv-sealed sv) vM′ D
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
-        mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
-        (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
-    with Fin._≟_ Y′ Y
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y , refl
-    | ECR.varv-seal vM₅ Y∈′ refl
-    | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
-        mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
-        (CTI2.⊢↓-sealˣ Y∈″) prem₅ .p₄
-    | yes refl =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.⊑cast² c
-    (CTI2.conceal⊑conceal²
-      (dyn-mono {W = W₁} {W′ = W₅})
-      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay W₅)
-        (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅)))
-      (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-        (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
-      (CTI2.⊢↓-sealˣ X∈)
-      (CTI2.⊢↓-sealˣ (transport-target-member rb₁₄ Y∈″))
-      (TD.⊢²-decay (SPT.dynWorld-decay W₅) prem₅)
-      (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
-    | vM′ 《 inert 》
-    | Y′ , refl
-    | ECR.varv-seal vM₅ Y′∈ refl
-    | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
-        mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
-        (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
-    | no Y′≠Y =
-  h-tag rb₁₄ rb₄₅ Y′≠Y c inert (sv-sealed sv) vM′ D
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑reveal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
-  ⊥-elim (reveal-star-value-⊥ vU)
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
-        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
-    | rb₁₄
-    | CTI2.⊑conceal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
-  ⊥-elim (conceal-star-value-⊥ vU)
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} mono rb sc
-        (CTI2.⊢↓-sealˣ X∈′) prem .p
-    with ECR.seal-rebase-target rb p
-       | seal-transfer
-           (seal-transfer-assumption h-compose h-chain h-tag) sv vU prem
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} mono rb sc
-        (CTI2.⊢↓-sealˣ X∈′) prem .p
-    | ra | qᴿ , V₀⊑U =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = Wₗ})
-    (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = Wₗ} {W₁ᵈ = SPT.dynWorld Wₗ}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay Wₗ)
-        (SPT.dynWorld-decay W₁) ra))
-    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay Wₗ) sc)
-    (CTI2.⊢↓-sealˣ X∈) V₀⊑U
-    (dyn-var-star {W = W₁} {X = X})
-seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption h-compose h-chain h-tag)
-      (sv-sealed sv) vU D
-    | X , refl , aligned
-    | ⊢conceal (⊢↓-seal X∈) V₀⊢
-    | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ} mono rb sc
-        (CTI2.⊢↓-sealˣ X∈′) (CTI2.⊢↓-sealˣ Y∈) prem .p =
-  dyn-var-star {W = W₁} {X = X} ,
-  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = Wᵖ})
-    (CTI2.rebase-varᴸ
-      (TD.decayRebaseAt {W₁ = Wᵖ} {W₁ᵈ = SPT.dynWorld Wᵖ}
-        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
-        (SPT.dynWorld-decay Wᵖ)
-        (SPT.dynWorld-decay W₁) rb))
-    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-      (SPT.dynWorld-decay Wᵖ) sc)
-    (CTI2.⊢↓-sealˣ X∈′)
-    (TD.⊢²-decay {W = Wᵖ} {Wᵈ = SPT.dynWorld Wᵖ}
-      (SPT.dynWorld-decay Wᵖ) prem)
-    (dyn-var-star {W = W₁} {X = X})
+      (SPT.dynWorld-decay Wᵖ) scᵖ)
+    (CTI2.⊢↓-sealˣ Z∈′)
+    (TD.⊢²-decay (SPT.dynWorld-decay Wᵖ) prem)
+    (dyn-var-star {W = W₁} {X = Z})

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -4,7 +4,7 @@ module proof.DGG.SealTransfer where
 --   * Provides composition of same-pivot world rebases.
 --   * Extends spine values locally with bare source seals.
 --   * Transfers a target star-seal boundary into a dynamized relation.
---   * Isolates same-target rebasing and inner target chains as hypotheses.
+--   * Isolates same-target rebasing as a hypothesis.
 --   * Depends on SealPeelToolkit, ExtraCastRight2, and term decay.
 
 open import Data.Empty using (⊥; ⊥-elim)
@@ -12,11 +12,13 @@ open import Data.Maybe using (just)
 open import Data.Product using (Σ-syntax; _,_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; sym; trans)
+  renaming (subst to subst≡)
 
 open import Types
 open import Imprecision
 open import Conversion
 open import CastTerms
+open import TyStore using (_∋_⦂_)
 open import Consistency using (Env∼; _⊢_∼_; toRenameᵗ)
 open import Primitives using (κℕ; κ𝔹)
 import proof.DGG.CastTermImprecision2 as CTI2
@@ -105,6 +107,26 @@ private
   dyn-var-star {W = W} {X = X} =
     X⊑★ (SPT.dynWorld-mark W (toRenameᵗ (CTI2.ηᴸʷ W) X))
 
+  aligned-var : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+      {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
+    → toRenameᵗ (CTI2.ηᴸʷ W) X ≡ toRenameᵗ (CTI2.ηᴿʷ W) Y
+    → (＇ X) ⊑ᵂ⟨ SPT.dynWorld W ⟩ (＇ Y)
+  aligned-var {W = W} {X = X} eq =
+    subst≡
+      (λ Z → CTI2.impEnvʷ (SPT.dynWorld W) ⊢
+        ＇ toRenameᵗ (CTI2.ηᴸʷ W) X ⊑ ＇ Z)
+      eq X⊑X
+
+  transport-target-member : ∀ {Δᴸ Δᴿ Δ}
+      {W W′ : World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ Z R}
+    → RebaseAt W W′ Xᴸ Xᴿ
+    → CTI2.targetStoreʷ W ∋ Z ⦂ R
+    → CTI2.targetStoreʷ W′ ∋ Z ⦂ R
+  transport-target-member {Z = Z} {R = R} rb Z∈ =
+    subst≡ (λ Σ → Σ ∋ Z ⦂ R)
+      (sym (CTI2.SameRuntime.targetStore-same
+        (CTI2.RebaseAt.sameRuntime rb))) Z∈
+
   dyn-mono : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
     → CTI2.ImpEnvMono (SPT.dynWorld W) (SPT.dynWorld W′)
   dyn-mono Z eq = refl
@@ -170,33 +192,12 @@ SameTarget = ∀ {Δᴸ Δᴿ Δ}
   → RebaseAt W₅ W₄ Z Y″
   → Y″ ≡ Y
 
--- H2: defer precisely the inner target-seal chain under a variable tag.
-InnerTargetChain : Set
-InnerTargetChain = ∀ {Δᴸ Δᴿ Δ}
-    {W₁ W₄ : World Δᴸ Δᴿ Δ}
-    {γ₁ : CtxImp W₁} {γ₄ : CtxImp W₄}
-    {V₀ : Term Δᴸ} {M′ : Term Δᴿ} {R₂ : Ty Δᴸ}
-    {Z : TyVar Δᴸ} {Y Y′ : TyVar Δᴿ}
-    {ν : Env∼ Δᴿ} {c : ν ⊢ (＇ Y′) ∼ ★}
-    {p₄ : (＇ Z) ⊑ᵂ⟨ W₄ ⟩ (＇ Y′)}
-  → SealValue V₀
-  → Value M′
-  → Inert c
-  → RebaseAt W₄ W₁ Z Y
-  → CTI2.SameCtx γ₁ γ₄
-  → W₄ ∣ γ₄ ⊢² V₀ ↓ Conversion.seal Z R₂ ⊑ M′ ∶ p₄
-  → Σ[ q★ ∈ (＇ Z) ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
-      (SPT.dynWorld W₁
-        ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
-        ⊢² V₀ ↓ Conversion.seal Z R₂ ⊑ M′ ⟨ c ⟩ ∶ q★)
-
--- The landing policy permits one explicit assumption argument.  Its two
--- fields isolate the double-move and inner variable-tag configurations.
+-- The landing policy permits one explicit assumption argument for the
+-- double-move configuration.
 record SealTransferAssumption : Set where
   constructor seal-transfer-assumption
   field
     same-target-assumption : SameTarget
-    inner-target-assumption : InnerTargetChain
 
 ------------------------------------------------------------------------
 -- Seal transfer
@@ -215,27 +216,27 @@ seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
         ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
         ⊢² V ⊑ U ∶ q★)
 seal-transfer {W₁ = W₁} {V = V} {A = A} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target) sv vU D
+    (seal-transfer-assumption same-target) sv vU D
     with SPT.right-var-obligation-view {W = W₁} {R = A} {Y = Y} p
 seal-transfer {W₁ = W₁} {V = V} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-spine sv) vU D
     | X , refl , aligned =
   ⊥-elim
     (spine-variable-⊥ sv (CTI2T.source-typing² D))
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     with CTI2T.source-typing² D
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
     with D
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -243,7 +244,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
     with target-seal-rebase-source rb₂ p
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -252,7 +253,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | rb₁₄
     with prem₃
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -276,7 +277,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (SPT.dynWorld-decay W₄) prem₄)
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -288,7 +289,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
     with same-target rb₁₄ rb₄₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -314,7 +315,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (SPT.dynWorld-decay W₅) prem₄)
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -324,7 +325,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑cast² {p = p₄} c prem₄ q₄
     with vU
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -335,7 +336,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | vM′ 《 inert 》
     with inert-variable-source {W = W₄} {Z = X} inert p₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -344,10 +345,245 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | rb₁₄
     | CTI2.⊑cast² {p = p₄} c prem₄ q₄
     | vM′ 《 inert 》
-    | Y′ , refl =
-  inner-target sv vM′ inert rb₁₄ sc₂ prem₄
+    | Y′ , refl
+    with ECR.var-value-view vM′ (CTI2T.target-typing² prem₄)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    with prem₄
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    with SPT.right-var-obligation-view {W = W₅} {Y = Y′} p₅
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    with rb₅
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = .W₄} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-onlyᴸ to-star disaligned represented =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₄})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = W₄} {W₁ᵈ = SPT.dynWorld W₄}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₄)
+        (SPT.dynWorld-decay W₁) rb₁₄))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay W₄) (composeSameCtx sc₂ sc₅))
+    (CTI2.⊢↓-sealˣ X∈)
+    (CTI2.⊑cast² c
+      (TD.⊢²-decay-at (SPT.dynWorld-decay W₄) prem₅
+        (aligned-var {W = W₄} {X = X₃} {Y = Y′} aligned₅))
+      (dyn-var-star {W = W₄} {X = X₃}))
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-varᴸ rb₄₅
+    with same-target rb₁₄ rb₄₅
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-varᴸ rb₄₅
+    | refl =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₅)
+        (SPT.dynWorld-decay W₁)
+        (composeRebaseAt rb₁₄ rb₄₅)))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
+    (CTI2.⊢↓-sealˣ X∈)
+    (CTI2.⊑cast² c
+      (TD.⊢²-decay-at (SPT.dynWorld-decay W₅) prem₅
+        (aligned-var {W = W₅} {X = X₃} {Y = Y′} aligned₅))
+      (dyn-var-star {W = W₅} {X = X₃}))
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
+    with target-seal-rebase-source rb₅ p₄
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
+    | rb₄₅
+    with same-target rb₁₄ rb₄₅
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y , refl
+    | ECR.varv-seal vM₅ Y∈′ refl
+    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y∈″) prem₅ .p₄
+    | rb₄₅
+    | refl =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.⊑cast² c
+    (CTI2.⊑conceal² (dyn-mono {W = W₁} {W′ = W₅})
+      (CTI2.rebase-varᴿ
+        (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
+          {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+          (SPT.dynWorld-decay W₅)
+          (SPT.dynWorld-decay W₁)
+          (composeRebaseAt rb₁₄ rb₄₅)))
+      (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+        (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
+      (CTI2.⊢↓-sealˣ (transport-target-member rb₁₄ Y∈″))
+      (TD.⊢²-decay (SPT.dynWorld-decay W₅) prem₅)
+      (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
+        mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
+        (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
+    with same-target rb₁₄ rb₄₅
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y , refl
+    | ECR.varv-seal vM₅ Y∈′ refl
+    | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
+        mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
+        (CTI2.⊢↓-sealˣ Y∈″) prem₅ .p₄
+    | refl =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.⊑cast² c
+    (CTI2.conceal⊑conceal²
+      (dyn-mono {W = W₁} {W′ = W₅})
+      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₅)
+        (SPT.dynWorld-decay W₁)
+        (composeRebaseAt rb₁₄ rb₄₅))
+      (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+        (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
+      (CTI2.⊢↓-sealˣ X∈)
+      (CTI2.⊢↓-sealˣ (transport-target-member rb₁₄ Y∈″))
+      (TD.⊢²-decay (SPT.dynWorld-decay W₅) prem₅)
+      (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -357,7 +593,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑reveal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
   ⊥-elim (reveal-star-value-⊥ vU)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -367,7 +603,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑conceal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
   ⊥-elim (conceal-star-value-⊥ vU)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -375,9 +611,9 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ X∈′) prem .p
     with ECR.seal-rebase-target rb p
        | seal-transfer
-           (seal-transfer-assumption same-target inner-target) sv vU prem
+           (seal-transfer-assumption same-target) sv vU prem
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -396,7 +632,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     (CTI2.⊢↓-sealˣ X∈) V₀⊑U
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target inner-target)
+    (seal-transfer-assumption same-target)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -8,11 +8,13 @@ module proof.DGG.SealTransfer where
 --   * Depends on SealPeelToolkit, ExtraCastRight2, and term decay.
 
 open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
 open import Data.Maybe using (just)
 open import Data.Product using (Σ-syntax; _,_)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; sym; trans)
+  using (_≡_; _≢_; refl; sym; trans)
   renaming (subst to subst≡)
+open import Relation.Nullary using (yes; no)
 
 open import Types
 open import Imprecision
@@ -42,8 +44,13 @@ composeRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
     {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
   → RebaseAt W₂ W₁ X Y
   → RebaseAt W₃ W₂ X Y
+  → (toRenameᵗ (CTI2.ηᴿʷ W₃) Y
+      ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
+    → toRenameᵗ (CTI2.ηᴸʷ W₃) X
+      ≡ toRenameᵗ (CTI2.ηᴸʷ W₂) X)
   → RebaseAt W₃ W₁ X Y
-composeRebaseAt rb₁ rb₂ =
+composeRebaseAt {Δᴸ = Δᴸ} {W₁ = W₁} {W₂} {W₃} {X} {Y}
+    rb₁ rb₂ stable =
   rebase-at
     (same-runtime
       (trans source₁ source₂)
@@ -51,6 +58,7 @@ composeRebaseAt rb₁ rb₂ =
     (λ Y≠X → trans (source-off₁ Y≠X) (source-off₂ Y≠X))
     (λ Y′≠Y → trans (target-off₁ Y′≠Y) (target-off₂ Y′≠Y))
     (CTI2.RebaseAt.pivotAligned rb₁)
+    compose-anchor
     (CTI2.RebaseAt.storeRepresentations rb₁)
   where
   source₁ = CTI2.SameRuntime.sourceStore-same
@@ -65,6 +73,28 @@ composeRebaseAt rb₁ rb₂ =
   source-off₂ = CTI2.RebaseAt.ηᴸ-off-pivot rb₂
   target-off₁ = CTI2.RebaseAt.ηᴿ-off-pivot rb₁
   target-off₂ = CTI2.RebaseAt.ηᴿ-off-pivot rb₂
+
+  compose-anchor :
+      toRenameᵗ (CTI2.ηᴿʷ W₃) Y
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W₁) Y
+    → Σ[ Xₒ ∈ TyVar Δᴸ ]
+        toRenameᵗ (CTI2.ηᴸʷ W₃) Xₒ
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₃) Y
+  compose-anchor moved with Fin._≟_
+      (toRenameᵗ (CTI2.ηᴿʷ W₃) Y)
+      (toRenameᵗ (CTI2.ηᴿʷ W₂) Y)
+  compose-anchor moved | no moved₂ =
+    CTI2.RebaseAt.anchorᴿ rb₂ moved₂
+  compose-anchor moved | yes target₃₂ with CTI2.RebaseAt.anchorᴿ rb₁
+      (λ target₂₁ → moved (trans target₃₂ target₂₁))
+  compose-anchor moved | yes target₃₂ | Xₒ , anchored₂
+      with Fin._≟_ Xₒ X
+  compose-anchor moved | yes target₃₂ | Xₒ , anchored₂ | no Xₒ≠X =
+    Xₒ , trans (sym (source-off₂ Xₒ≠X))
+      (trans anchored₂ (sym target₃₂))
+  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl =
+    X , trans (stable target₃₂)
+      (trans (CTI2.RebaseAt.pivotAligned rb₂) (sym target₃₂))
 
 ------------------------------------------------------------------------
 -- Seal values
@@ -192,12 +222,21 @@ SameTarget = ∀ {Δᴸ Δᴿ Δ}
   → RebaseAt W₅ W₄ Z Y″
   → Y″ ≡ Y
 
--- The landing policy permits one explicit assumption argument for the
--- double-move configuration.
+-- The landing policy permits explicit assumptions for the exceptional
+-- stacked-rebase configurations.
 record SealTransferAssumption : Set where
   constructor seal-transfer-assumption
   field
     same-target-assumption : SameTarget
+    compose-pivot-stable-assumption : ∀ {Δᴸ Δᴿ Δ}
+        {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
+        {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
+      → (rb₁ : RebaseAt W₂ W₁ X Y)
+      → (rb₂ : RebaseAt W₃ W₂ X Y)
+      → toRenameᵗ (CTI2.ηᴿʷ W₃) Y
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
+      → toRenameᵗ (CTI2.ηᴸʷ W₃) X
+          ≡ toRenameᵗ (CTI2.ηᴸʷ W₂) X
 
 ------------------------------------------------------------------------
 -- Seal transfer
@@ -216,27 +255,27 @@ seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
         ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
         ⊢² V ⊑ U ∶ q★)
 seal-transfer {W₁ = W₁} {V = V} {A = A} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target) sv vU D
+    (seal-transfer-assumption same-target pivot-stable) sv vU D
     with SPT.right-var-obligation-view {W = W₁} {R = A} {Y = Y} p
 seal-transfer {W₁ = W₁} {V = V} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-spine sv) vU D
     | X , refl , aligned =
   ⊥-elim
     (spine-variable-⊥ sv (CTI2T.source-typing² D))
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     with CTI2T.source-typing² D
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
     with D
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -244,7 +283,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
     with target-seal-rebase-source rb₂ p
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -253,7 +292,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | rb₁₄
     with prem₃
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -277,7 +316,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (SPT.dynWorld-decay W₄) prem₄)
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -289,7 +328,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
     with same-target rb₁₄ rb₄₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -307,7 +346,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
         (SPT.dynWorld-decay W₅)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅)))
+        (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅))))
     (WD.decaySameCtx (SPT.dynWorld-decay W₁)
       (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
     (CTI2.⊢↓-sealˣ X∈)
@@ -315,7 +354,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (SPT.dynWorld-decay W₅) prem₄)
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -325,7 +364,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑cast² {p = p₄} c prem₄ q₄
     with vU
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -336,7 +375,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | vM′ 《 inert 》
     with inert-variable-source {W = W₄} {Z = X} inert p₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -348,7 +387,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | Y′ , refl
     with ECR.var-value-view vM′ (CTI2T.target-typing² prem₄)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -361,7 +400,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | ECR.varv-seal vM₅ Y′∈ refl
     with prem₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -376,7 +415,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
     with SPT.right-var-obligation-view {W = W₅} {Y = Y′} p₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -392,7 +431,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | X₃ , refl , aligned₅
     with rb₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -423,7 +462,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (dyn-var-star {W = W₄} {X = X₃}))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -440,7 +479,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.rebase-varᴸ rb₄₅
     with same-target rb₁₄ rb₄₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -463,7 +502,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
         (SPT.dynWorld-decay W₅)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅)))
+        (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅))))
     (WD.decaySameCtx (SPT.dynWorld-decay W₁)
       (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
     (CTI2.⊢↓-sealˣ X∈)
@@ -473,7 +512,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (dyn-var-star {W = W₅} {X = X₃}))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -488,7 +527,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
     with target-seal-rebase-source rb₅ p₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -504,7 +543,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | rb₄₅
     with same-target rb₁₄ rb₄₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -527,7 +566,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
           {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
           (SPT.dynWorld-decay W₅)
           (SPT.dynWorld-decay W₁)
-          (composeRebaseAt rb₁₄ rb₄₅)))
+          (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅))))
       (WD.decaySameCtx (SPT.dynWorld-decay W₁)
         (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
       (CTI2.⊢↓-sealˣ (transport-target-member rb₁₄ Y∈″))
@@ -535,7 +574,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -551,7 +590,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
     with same-target rb₁₄ rb₄₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -574,7 +613,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
         (SPT.dynWorld-decay W₅)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅))
+        (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅)))
       (WD.decaySameCtx (SPT.dynWorld-decay W₁)
         (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
       (CTI2.⊢↓-sealˣ X∈)
@@ -583,7 +622,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -593,7 +632,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑reveal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
   ⊥-elim (reveal-star-value-⊥ vU)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -603,7 +642,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑conceal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
   ⊥-elim (conceal-star-value-⊥ vU)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -611,9 +650,9 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ X∈′) prem .p
     with ECR.seal-rebase-target rb p
        | seal-transfer
-           (seal-transfer-assumption same-target) sv vU prem
+           (seal-transfer-assumption same-target pivot-stable) sv vU prem
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -632,7 +671,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     (CTI2.⊢↓-sealˣ X∈) V₀⊑U
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target)
+    (seal-transfer-assumption same-target pivot-stable)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -1,0 +1,417 @@
+module proof.DGG.SealTransfer where
+
+-- File Charter:
+--   * Provides composition of same-pivot world rebases.
+--   * Extends spine values locally with bare source seals.
+--   * Transfers a target star-seal boundary into a dynamized relation.
+--   * Isolates same-target rebasing and inner target chains as hypotheses.
+--   * Depends on SealPeelToolkit, ExtraCastRight2, and term decay.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Maybe using (just)
+open import Data.Product using (Σ-syntax; _,_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans)
+
+open import Types
+open import Imprecision
+open import Conversion
+open import CastTerms
+open import Consistency using (Env∼; _⊢_∼_; toRenameᵗ)
+open import Primitives using (κℕ; κ𝔹)
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CastTermImprecision2Typing as CTI2T
+import proof.DGG.ExtraCastRight2 as ECR
+import proof.DGG.SealPeelToolkit as SPT
+import proof.DGG.TermImpDecay as TD
+import proof.DGG.WorldDecay as WD
+open import proof.ImprecisionConsistency using (toRenameᵗ-injective)
+open CTI2 using
+  (World; CtxImp; RebaseAt; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_;
+   same-runtime; rebase-at)
+open ECR using (SpineValue; sv-ƛ; sv-Λ; sv-$; sv-cast;
+  sv-reveal-fun; sv-conceal-fun; sv-reveal-all; sv-conceal-all)
+
+------------------------------------------------------------------------
+-- Same-pivot rebase composition
+------------------------------------------------------------------------
+
+composeRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
+  → RebaseAt W₂ W₁ X Y
+  → RebaseAt W₃ W₂ X Y
+  → RebaseAt W₃ W₁ X Y
+composeRebaseAt rb₁ rb₂ =
+  rebase-at
+    (same-runtime
+      (trans source₁ source₂)
+      (trans target₁ target₂))
+    (λ Y≠X → trans (source-off₁ Y≠X) (source-off₂ Y≠X))
+    (λ Y′≠Y → trans (target-off₁ Y′≠Y) (target-off₂ Y′≠Y))
+    (CTI2.RebaseAt.pivotAligned rb₁)
+    (CTI2.RebaseAt.storeRepresentations rb₁)
+  where
+  source₁ = CTI2.SameRuntime.sourceStore-same
+    (CTI2.RebaseAt.sameRuntime rb₁)
+  source₂ = CTI2.SameRuntime.sourceStore-same
+    (CTI2.RebaseAt.sameRuntime rb₂)
+  target₁ = CTI2.SameRuntime.targetStore-same
+    (CTI2.RebaseAt.sameRuntime rb₁)
+  target₂ = CTI2.SameRuntime.targetStore-same
+    (CTI2.RebaseAt.sameRuntime rb₂)
+  source-off₁ = CTI2.RebaseAt.ηᴸ-off-pivot rb₁
+  source-off₂ = CTI2.RebaseAt.ηᴸ-off-pivot rb₂
+  target-off₁ = CTI2.RebaseAt.ηᴿ-off-pivot rb₁
+  target-off₂ = CTI2.RebaseAt.ηᴿ-off-pivot rb₂
+
+------------------------------------------------------------------------
+-- Seal values
+------------------------------------------------------------------------
+
+data SealValue {Δ : TyCtx} : Term Δ → Set where
+  sv-spine : ∀ {V}
+    → SpineValue V
+    → SealValue V
+
+  sv-sealed : ∀ {V X R}
+    → SealValue V
+    → SealValue (V ↓ Conversion.seal X R)
+
+------------------------------------------------------------------------
+-- The present SpineValue interface has no variable-typed inhabitants
+------------------------------------------------------------------------
+
+private
+  spine-variable-⊥ : ∀ {Δ} {Σ} {Γ} {V : Term Δ} {X : TyVar Δ}
+    → SpineValue V
+    → ⟨ Δ , Σ , Γ ⟩ ⊢ V ⦂ ＇ X
+    → ⊥
+  spine-variable-⊥ (sv-ƛ N) ()
+  spine-variable-⊥ (sv-Λ sv) ()
+  spine-variable-⊥ (sv-$ (κℕ n)) ()
+  spine-variable-⊥ (sv-$ (κ𝔹 b)) ()
+  spine-variable-⊥ (sv-cast sv inj) ()
+  spine-variable-⊥ (sv-cast sv fun) ()
+  spine-variable-⊥ (sv-cast sv all) ()
+  spine-variable-⊥ (sv-cast sv (genᵥ A≠★ safe)) ()
+  spine-variable-⊥ (sv-reveal-fun sv) ()
+  spine-variable-⊥ (sv-conceal-fun sv) ()
+  spine-variable-⊥ (sv-reveal-all sv) ()
+  spine-variable-⊥ (sv-conceal-all sv) ()
+
+  dyn-var-star : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+      {X : TyVar Δᴸ}
+    → (＇ X) ⊑ᵂ⟨ SPT.dynWorld W ⟩ ★
+  dyn-var-star {W = W} {X = X} =
+    X⊑★ (SPT.dynWorld-mark W (toRenameᵗ (CTI2.ηᴸʷ W) X))
+
+  dyn-mono : ∀ {Δᴸ Δᴿ Δ} {W W′ : World Δᴸ Δᴿ Δ}
+    → CTI2.ImpEnvMono (SPT.dynWorld W) (SPT.dynWorld W′)
+  dyn-mono Z eq = refl
+
+  composeSameCtx : ∀ {Δᴸ Δᴿ Δ₁ Δ₂ Δ₃}
+      {W₁ : World Δᴸ Δᴿ Δ₁} {W₂ : World Δᴸ Δᴿ Δ₂}
+      {W₃ : World Δᴸ Δᴿ Δ₃}
+      {γ₁ : CtxImp W₁} {γ₂ : CtxImp W₂} {γ₃ : CtxImp W₃}
+    → CTI2.SameCtx γ₁ γ₂
+    → CTI2.SameCtx γ₂ γ₃
+    → CTI2.SameCtx γ₁ γ₃
+  composeSameCtx CTI2.same-[] CTI2.same-[] = CTI2.same-[]
+  composeSameCtx (CTI2.same-∷ sc₁) (CTI2.same-∷ sc₂) =
+    CTI2.same-∷ (composeSameCtx sc₁ sc₂)
+
+  target-seal-rebase-source : ∀ {Δᴸ Δᴿ Δ}
+      {W₄ W₁ : World Δᴸ Δᴿ Δ}
+      {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
+    → CTI2.RebaseAtᴿ W₄ W₁ (just Y)
+    → (＇ X) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)
+    → RebaseAt W₄ W₁ X Y
+  target-seal-rebase-source {W₁ = W₁} {X = X} {Y = Y}
+      (CTI2.rebase-varᴿ rb) q
+      with toRenameᵗ-injective (CTI2.ηᴸʷ W₁)
+        (trans (CTI2.RebaseAt.pivotAligned rb)
+          (sym (ECR.variable-obligation-aligns
+            {W = W₁} {X = X} {Y = Y} q)))
+  target-seal-rebase-source (CTI2.rebase-varᴿ rb) q | refl = rb
+
+  reveal-star-value-⊥ : ∀ {Δ} {V : Term Δ} {A}
+      {c : Conv↑ Δ A ★}
+    → Value (V ↑ c)
+    → ⊥
+  reveal-star-value-⊥ (vV ↑ ())
+
+  conceal-star-value-⊥ : ∀ {Δ} {V : Term Δ} {A}
+      {c : Conv↓ Δ A ★}
+    → Value (V ↓ c)
+    → ⊥
+  conceal-star-value-⊥ (vV ↓ ())
+
+  inert-variable-source : ∀ {Δᴸ Δᴿ Δ}
+      {W : World Δᴸ Δᴿ Δ} {Z : TyVar Δᴸ}
+      {B : Ty Δᴿ} {ν : Env∼ Δᴿ} {c : ν ⊢ B ∼ ★}
+    → Inert c
+    → (＇ Z) ⊑ᵂ⟨ W ⟩ B
+    → Σ[ Y ∈ TyVar Δᴿ ] B ≡ ＇ Y
+  inert-variable-source (inj ⦃ Gᵍ = ＇ Y ⦄) p = Y , refl
+  inert-variable-source (inj ⦃ Gᵍ = ‵ ι ⦄) ()
+  inert-variable-source (inj ⦃ Gᵍ = ★⇒★ ⦄) ()
+  inert-variable-source (inj ⦃ Gᵍ = ∀★ ⦄) ()
+
+------------------------------------------------------------------------
+-- Exceptional configurations
+------------------------------------------------------------------------
+
+-- H1: stacked rebases at one source pivot choose the same target.
+SameTarget : Set
+SameTarget = ∀ {Δᴸ Δᴿ Δ}
+    {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
+    {Z : TyVar Δᴸ} {Y Y″ : TyVar Δᴿ}
+  → RebaseAt W₄ W₁ Z Y
+  → RebaseAt W₅ W₄ Z Y″
+  → Y″ ≡ Y
+
+-- H2: defer precisely the inner target-seal chain under a variable tag.
+InnerTargetChain : Set
+InnerTargetChain = ∀ {Δᴸ Δᴿ Δ}
+    {W₁ W₄ : World Δᴸ Δᴿ Δ}
+    {γ₁ : CtxImp W₁} {γ₄ : CtxImp W₄}
+    {V₀ : Term Δᴸ} {M′ : Term Δᴿ} {R₂ : Ty Δᴸ}
+    {Z : TyVar Δᴸ} {Y Y′ : TyVar Δᴿ}
+    {ν : Env∼ Δᴿ} {c : ν ⊢ (＇ Y′) ∼ ★}
+    {p₄ : (＇ Z) ⊑ᵂ⟨ W₄ ⟩ (＇ Y′)}
+  → SealValue V₀
+  → Value M′
+  → Inert c
+  → RebaseAt W₄ W₁ Z Y
+  → CTI2.SameCtx γ₁ γ₄
+  → W₄ ∣ γ₄ ⊢² V₀ ↓ Conversion.seal Z R₂ ⊑ M′ ∶ p₄
+  → Σ[ q★ ∈ (＇ Z) ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
+      (SPT.dynWorld W₁
+        ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
+        ⊢² V₀ ↓ Conversion.seal Z R₂ ⊑ M′ ⟨ c ⟩ ∶ q★)
+
+-- The landing policy permits one explicit assumption argument.  Its two
+-- fields isolate the double-move and inner variable-tag configurations.
+record SealTransferAssumption : Set where
+  constructor seal-transfer-assumption
+  field
+    same-target-assumption : SameTarget
+    inner-target-assumption : InnerTargetChain
+
+------------------------------------------------------------------------
+-- Seal transfer
+------------------------------------------------------------------------
+
+seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
+    {γ₁ : CtxImp W₁} {V : Term Δᴸ} {U : Term Δᴿ}
+    {A : Ty Δᴸ} {Y : TyVar Δᴿ}
+    {p : A ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
+  → SealTransferAssumption
+  → SealValue V
+  → Value U
+  → W₁ ∣ γ₁ ⊢² V ⊑ (U ↓ Conversion.seal Y ★) ∶ p
+  → Σ[ q★ ∈ A ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
+      (SPT.dynWorld W₁
+        ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
+        ⊢² V ⊑ U ∶ q★)
+seal-transfer {W₁ = W₁} {V = V} {A = A} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target) sv vU D
+    with SPT.right-var-obligation-view {W = W₁} {R = A} {Y = Y} p
+seal-transfer {W₁ = W₁} {V = V} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-spine sv) vU D
+    | X , refl , aligned =
+  ⊥-elim
+    (spine-variable-⊥ sv (CTI2T.source-typing² D))
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    with CTI2T.source-typing² D
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    with D
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    with target-seal-rebase-source rb₂ p
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    with prem₃
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {p = p₄} mono₅
+        (CTI2.rebase-onlyᴸ to-star disaligned represented) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄ =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₄})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = W₄} {W₁ᵈ = SPT.dynWorld W₄}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₄)
+        (SPT.dynWorld-decay W₁) rb₁₄))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay W₄) (composeSameCtx sc₂ sc₅))
+    (CTI2.⊢↓-sealˣ X∈)
+    (TD.⊢²-decay {W = W₄} {Wᵈ = SPT.dynWorld W₄}
+      (SPT.dynWorld-decay W₄) prem₄)
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
+        mono₅ (CTI2.rebase-varᴸ rb₄₅) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
+    with same-target rb₁₄ rb₄₅
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
+        mono₅ (CTI2.rebase-varᴸ rb₄₅) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
+    | refl =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₅)
+        (SPT.dynWorld-decay W₁)
+        (composeRebaseAt rb₁₄ rb₄₅)))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
+    (CTI2.⊢↓-sealˣ X∈)
+    (TD.⊢²-decay {W = W₅} {Wᵈ = SPT.dynWorld W₅}
+      (SPT.dynWorld-decay W₅) prem₄)
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    with vU
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    with inert-variable-source {W = W₄} {Z = X} inert p₄
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl =
+  inner-target sv vM′ inert rb₁₄ sc₂ prem₄
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑reveal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
+  ⊥-elim (reveal-star-value-⊥ vU)
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑conceal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
+  ⊥-elim (conceal-star-value-⊥ vU)
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} mono rb sc
+        (CTI2.⊢↓-sealˣ X∈′) prem .p
+    with ECR.seal-rebase-target rb p
+       | seal-transfer
+           (seal-transfer-assumption same-target inner-target) sv vU prem
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.conceal⊑² {W′ = Wₗ} {γ′ = γₗ} mono rb sc
+        (CTI2.⊢↓-sealˣ X∈′) prem .p
+    | ra | qᴿ , V₀⊑U =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = Wₗ})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = Wₗ} {W₁ᵈ = SPT.dynWorld Wₗ}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay Wₗ)
+        (SPT.dynWorld-decay W₁) ra))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay Wₗ) sc)
+    (CTI2.⊢↓-sealˣ X∈) V₀⊑U
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption same-target inner-target)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ} mono rb sc
+        (CTI2.⊢↓-sealˣ X∈′) (CTI2.⊢↓-sealˣ Y∈) prem .p =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = Wᵖ})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = Wᵖ} {W₁ᵈ = SPT.dynWorld Wᵖ}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay Wᵖ)
+        (SPT.dynWorld-decay W₁) rb))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay Wᵖ) sc)
+    (CTI2.⊢↓-sealˣ X∈′)
+    (TD.⊢²-decay {W = Wᵖ} {Wᵈ = SPT.dynWorld Wᵖ}
+      (SPT.dynWorld-decay Wᵖ) prem)
+    (dyn-var-star {W = W₁} {X = X})

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -4,7 +4,9 @@ module proof.DGG.SealTransfer where
 --   * Provides composition of same-pivot world rebases.
 --   * Extends spine values locally with bare source seals.
 --   * Transfers a target star-seal boundary into a dynamized relation.
---   * Isolates same-target rebasing as a hypothesis.
+--   * Closes unequal-target/unmoved rebase chains outright.
+--   * Isolates the open H-compose, H-chain, and H-tag strata; see
+--     MovedLinkProbe for the moved-link invariant's rationale.
 --   * Depends on SealPeelToolkit, ExtraCastRight2, and term decay.
 
 open import Data.Empty using (⊥; ⊥-elim)
@@ -47,10 +49,15 @@ composeRebaseAt : ∀ {Δᴸ Δᴿ Δ} {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
   → (toRenameᵗ (CTI2.ηᴿʷ W₃) Y
       ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
     → toRenameᵗ (CTI2.ηᴸʷ W₃) X
-      ≡ toRenameᵗ (CTI2.ηᴸʷ W₂) X)
+      ≢ toRenameᵗ (CTI2.ηᴸʷ W₂) X
+    → toRenameᵗ (CTI2.ηᴸʷ W₂) X
+      ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
+    → Σ[ Xₒ ∈ TyVar Δᴸ ]
+        toRenameᵗ (CTI2.ηᴸʷ W₃) Xₒ
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₃) Y)
   → RebaseAt W₃ W₁ X Y
 composeRebaseAt {Δᴸ = Δᴸ} {W₁ = W₁} {W₂} {W₃} {X} {Y}
-    rb₁ rb₂ stable =
+    rb₁ rb₂ compose-corner =
   rebase-at
     (same-runtime
       (trans source₁ source₂)
@@ -92,9 +99,77 @@ composeRebaseAt {Δᴸ = Δᴸ} {W₁ = W₁} {W₂} {W₃} {X} {Y}
   compose-anchor moved | yes target₃₂ | Xₒ , anchored₂ | no Xₒ≠X =
     Xₒ , trans (sym (source-off₂ Xₒ≠X))
       (trans anchored₂ (sym target₃₂))
-  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl =
-    X , trans (stable target₃₂)
-      (trans (CTI2.RebaseAt.pivotAligned rb₂) (sym target₃₂))
+  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl
+      with Fin._≟_ (toRenameᵗ (CTI2.ηᴸʷ W₃) X)
+        (toRenameᵗ (CTI2.ηᴸʷ W₂) X)
+  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl
+      | yes source₃₂ =
+    X , trans source₃₂ (trans anchored₂ (sym target₃₂))
+  compose-anchor moved | yes target₃₂ | .X , anchored₂ | yes refl
+      | no source-moved =
+    compose-corner target₃₂ source-moved anchored₂
+
+-- Composing away from a distinct, unmoved inner target pivot is closed.
+composeRebaseAt-away : ∀ {Δᴸ Δᴿ Δ}
+    {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {Y Y″ : TyVar Δᴿ}
+  → RebaseAt W₄ W₁ X Y
+  → RebaseAt W₅ W₄ X Y″
+  → Y″ ≢ Y
+  → toRenameᵗ (CTI2.ηᴿʷ W₅) Y″
+      ≡ toRenameᵗ (CTI2.ηᴿʷ W₄) Y″
+  → RebaseAt W₅ W₁ X Y
+composeRebaseAt-away {Δᴸ = Δᴸ} {W₁ = W₁} {W₄} {W₅}
+    {X} {Y} {Y″} rb₁₄ rb₄₅ Y″≠Y unmoved =
+  rebase-at
+    (same-runtime
+      (trans source₁₄ source₄₅)
+      (trans target₁₄ target₄₅))
+    (λ Z≠X → trans (source-off₁₄ Z≠X) (source-off₄₅ Z≠X))
+    target-off
+    (CTI2.RebaseAt.pivotAligned rb₁₄)
+    away-anchor
+    (CTI2.RebaseAt.storeRepresentations rb₁₄)
+  where
+  source₁₄ = CTI2.SameRuntime.sourceStore-same
+    (CTI2.RebaseAt.sameRuntime rb₁₄)
+  source₄₅ = CTI2.SameRuntime.sourceStore-same
+    (CTI2.RebaseAt.sameRuntime rb₄₅)
+  target₁₄ = CTI2.SameRuntime.targetStore-same
+    (CTI2.RebaseAt.sameRuntime rb₁₄)
+  target₄₅ = CTI2.SameRuntime.targetStore-same
+    (CTI2.RebaseAt.sameRuntime rb₄₅)
+  source-off₁₄ = CTI2.RebaseAt.ηᴸ-off-pivot rb₁₄
+  source-off₄₅ = CTI2.RebaseAt.ηᴸ-off-pivot rb₄₅
+  target-off₁₄ = CTI2.RebaseAt.ηᴿ-off-pivot rb₁₄
+  target-off₄₅ = CTI2.RebaseAt.ηᴿ-off-pivot rb₄₅
+  Y≠Y″ = λ Y≡Y″ → Y″≠Y (sym Y≡Y″)
+
+  target-off : ∀ {Yₒ} → Yₒ ≢ Y
+    → toRenameᵗ (CTI2.ηᴿʷ W₁) Yₒ
+      ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Yₒ
+  target-off {Yₒ} Yₒ≠Y with Fin._≟_ Yₒ Y″
+  target-off {.Y″} Y″≠Y | yes refl =
+    trans (target-off₁₄ Y″≠Y) (sym unmoved)
+  target-off {Yₒ} Yₒ≠Y | no Yₒ≠Y″ =
+    trans (target-off₁₄ Yₒ≠Y) (target-off₄₅ Yₒ≠Y″)
+
+  away-anchor :
+      toRenameᵗ (CTI2.ηᴿʷ W₅) Y
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W₁) Y
+    → Σ[ Xₒ ∈ TyVar Δᴸ ]
+        toRenameᵗ (CTI2.ηᴸʷ W₅) Xₒ
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Y
+  away-anchor moved with CTI2.RebaseAt.anchorᴿ rb₁₄
+      (λ target₄₁ → moved
+        (trans (sym (target-off₄₅ Y≠Y″)) target₄₁))
+  away-anchor moved | Xₒ , anchored₄ with Fin._≟_ Xₒ X
+  away-anchor moved | Xₒ , anchored₄ | no Xₒ≠X =
+    Xₒ , trans (sym (source-off₄₅ Xₒ≠X))
+      (trans anchored₄ (target-off₄₅ Y≠Y″))
+  away-anchor moved | .X , anchored₄ | yes refl =
+    ⊥-elim (Y″≠Y (toRenameᵗ-injective (CTI2.ηᴿʷ W₄)
+      (trans (sym (CTI2.RebaseAt.pivotAligned rb₄₅)) anchored₄)))
 
 ------------------------------------------------------------------------
 -- Seal values
@@ -213,30 +288,73 @@ private
 -- Exceptional configurations
 ------------------------------------------------------------------------
 
--- H1: stacked rebases at one source pivot choose the same target.
-SameTarget : Set
-SameTarget = ∀ {Δᴸ Δᴿ Δ}
-    {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
-    {Z : TyVar Δᴸ} {Y Y″ : TyVar Δᴿ}
-  → RebaseAt W₄ W₁ Z Y
-  → RebaseAt W₅ W₄ Z Y″
-  → Y″ ≡ Y
-
--- The landing policy permits explicit assumptions for the exceptional
--- stacked-rebase configurations.
+-- These are the three residual strata after deciding target identity and
+-- target movement.  MovedLinkProbe explains why moved links need anchors.
 record SealTransferAssumption : Set where
   constructor seal-transfer-assumption
   field
-    same-target-assumption : SameTarget
-    compose-pivot-stable-assumption : ∀ {Δᴸ Δᴿ Δ}
-        {W₁ W₂ W₃ : World Δᴸ Δᴿ Δ}
+    -- Open: composing (X,Y)-rebases where the inner leg fixes Y but
+    -- relocates X, when Y's anchor at the middle world is X itself.
+    H-compose : ∀ {Δᴸ Δᴿ Δ}
+        {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
         {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
-      → (rb₁ : RebaseAt W₂ W₁ X Y)
-      → (rb₂ : RebaseAt W₃ W₂ X Y)
-      → toRenameᵗ (CTI2.ηᴿʷ W₃) Y
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W₂) Y
-      → toRenameᵗ (CTI2.ηᴸʷ W₃) X
-          ≡ toRenameᵗ (CTI2.ηᴸʷ W₂) X
+      → (rb₁₄ : RebaseAt W₄ W₁ X Y)
+      → (rb₄₅ : RebaseAt W₅ W₄ X Y)
+      → toRenameᵗ (CTI2.ηᴿʷ W₅) Y
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₄) Y
+      → toRenameᵗ (CTI2.ηᴸʷ W₅) X
+          ≢ toRenameᵗ (CTI2.ηᴸʷ W₄) X
+      → toRenameᵗ (CTI2.ηᴸʷ W₄) X
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W₄) Y
+      → Σ[ Xₒ ∈ TyVar Δᴸ ]
+          toRenameᵗ (CTI2.ηᴸʷ W₅) Xₒ
+            ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Y
+
+    -- Open for the follow-up: a distinct moved target continues at the
+    -- source variable supplied by the inner rebase's anchor.
+    H-chain : ∀ {Δᴸ Δᴿ Δ}
+        {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
+        {γ₁ : CtxImp W₁} {V : Term Δᴸ} {U : Term Δᴿ}
+        {X : TyVar Δᴸ} {Y Y″ : TyVar Δᴿ}
+        {p : (＇ X) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
+      → (rb₁₄ : RebaseAt W₄ W₁ X Y)
+      → (rb₄₅ : RebaseAt W₅ W₄ X Y″)
+      → toRenameᵗ (CTI2.ηᴿʷ W₅) Y″
+          ≢ toRenameᵗ (CTI2.ηᴿʷ W₄) Y″
+      → Y″ ≢ Y
+      → Σ[ Xₒ ∈ TyVar Δᴸ ]
+          toRenameᵗ (CTI2.ηᴸʷ W₅) Xₒ
+            ≡ toRenameᵗ (CTI2.ηᴿʷ W₅) Y″
+      → SealValue V
+      → Value U
+      → W₁ ∣ γ₁ ⊢² V ⊑ (U ↓ Conversion.seal Y ★) ∶ p
+      → Σ[ q★ ∈ (＇ X) ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
+          (SPT.dynWorld W₁
+            ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
+            ⊢² V ⊑ U ∶ q★)
+
+    -- Open: the inner target seal uses a distinct target variable; its
+    -- tag obligation may be unreachable, as MovedLinkProbe motivates.
+    H-tag : ∀ {Δᴸ Δᴿ Δ}
+        {W₁ W₄ W₅ : World Δᴸ Δᴿ Δ}
+        {γ₁ : CtxImp W₁} {V : Term Δᴸ} {M : Term Δᴿ}
+        {X : TyVar Δᴸ} {Y Y′ : TyVar Δᴿ} {R : Ty Δᴿ}
+        {ν : Env∼ Δᴿ}
+        {p : (＇ X) ⊑ᵂ⟨ W₁ ⟩ (＇ Y)}
+      → (rb₁₄ : RebaseAt W₄ W₁ X Y)
+      → (rb₄₅ : RebaseAt W₅ W₄ X Y′)
+      → Y′ ≢ Y
+      → (c : ν ⊢ (＇ Y′) ∼ ★)
+      → Inert c
+      → SealValue V
+      → Value (M ↓ Conversion.seal Y′ R)
+      → W₁ ∣ γ₁ ⊢² V ⊑
+          (((M ↓ Conversion.seal Y′ R) ⟨ c ⟩)
+            ↓ Conversion.seal Y ★) ∶ p
+      → Σ[ q★ ∈ (＇ X) ⊑ᵂ⟨ SPT.dynWorld W₁ ⟩ ★ ]
+          (SPT.dynWorld W₁
+            ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
+            ⊢² V ⊑ (M ↓ Conversion.seal Y′ R) ⟨ c ⟩ ∶ q★)
 
 ------------------------------------------------------------------------
 -- Seal transfer
@@ -255,27 +373,27 @@ seal-transfer : ∀ {Δᴸ Δᴿ Δ} {W₁ : World Δᴸ Δᴿ Δ}
         ∣ WD.decayCtx (SPT.dynWorld-decay W₁) γ₁
         ⊢² V ⊑ U ∶ q★)
 seal-transfer {W₁ = W₁} {V = V} {A = A} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable) sv vU D
+    (seal-transfer-assumption h-compose h-chain h-tag) sv vU D
     with SPT.right-var-obligation-view {W = W₁} {R = A} {Y = Y} p
 seal-transfer {W₁ = W₁} {V = V} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-spine sv) vU D
     | X , refl , aligned =
   ⊥-elim
     (spine-variable-⊥ sv (CTI2T.source-typing² D))
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     with CTI2T.source-typing² D
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
     with D
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -283,7 +401,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
     with target-seal-rebase-source rb₂ p
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -292,7 +410,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | rb₁₄
     with prem₃
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -316,7 +434,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (SPT.dynWorld-decay W₄) prem₄)
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -324,11 +442,11 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
     | rb₁₄
     | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ rb₄₅) sc₅
+        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
         (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    with same-target rb₁₄ rb₄₅
+    with Fin._≟_ Y″ Y
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -336,9 +454,9 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
     | rb₁₄
     | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
-        mono₅ (CTI2.rebase-varᴸ rb₄₅) sc₅
+        mono₅ (CTI2.rebase-varᴸ {Xᴿ = .Y} rb₄₅) sc₅
         (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
-    | refl =
+    | yes refl =
   dyn-var-star {W = W₁} {X = X} ,
   CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
     (CTI2.rebase-varᴸ
@@ -346,7 +464,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
         (SPT.dynWorld-decay W₅)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅))))
+        (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅))))
     (WD.decaySameCtx (SPT.dynWorld-decay W₁)
       (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
     (CTI2.⊢↓-sealˣ X∈)
@@ -354,7 +472,74 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (SPT.dynWorld-decay W₅) prem₄)
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
+        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
+    | no Y″≠Y
+    with Fin._≟_ (toRenameᵗ (CTI2.ηᴿʷ W₅) Y″)
+      (toRenameᵗ (CTI2.ηᴿʷ W₄) Y″)
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
+        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
+    | no Y″≠Y | yes unmoved =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₅)
+        (SPT.dynWorld-decay W₁)
+        (composeRebaseAt-away rb₁₄ rb₄₅ Y″≠Y unmoved)))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
+    (CTI2.⊢↓-sealˣ X∈)
+    (TD.⊢²-decay {W = W₅} {Wᵈ = SPT.dynWorld W₅}
+      (SPT.dynWorld-decay W₅) prem₄)
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
+        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
+    | no Y″≠Y | no moved
+    with CTI2.RebaseAt.anchorᴿ rb₄₅ moved
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₄}
+        mono₅ (CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅) sc₅
+        (CTI2.⊢↓-sealˣ X∈′) prem₄ q₄
+    | no Y″≠Y | no moved | Xₒ , anchored₅ =
+  h-chain rb₁₄ rb₄₅ moved Y″≠Y (Xₒ , anchored₅)
+    (sv-sealed sv) vU D
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -364,7 +549,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑cast² {p = p₄} c prem₄ q₄
     with vU
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -375,7 +560,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | vM′ 《 inert 》
     with inert-variable-source {W = W₄} {Z = X} inert p₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -387,7 +572,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | Y′ , refl
     with ECR.var-value-view vM′ (CTI2T.target-typing² prem₄)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -400,7 +585,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | ECR.varv-seal vM₅ Y′∈ refl
     with prem₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -415,7 +600,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
     with SPT.right-var-obligation-view {W = W₅} {Y = Y′} p₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -431,7 +616,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | X₃ , refl , aligned₅
     with rb₅
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -462,7 +647,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (dyn-var-star {W = W₄} {X = X₃}))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -476,10 +661,10 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
     | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ rb₄₅
-    with same-target rb₁₄ rb₄₅
+    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
+    with Fin._≟_ Y″ Y
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -493,8 +678,8 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
     | X₃ , refl , aligned₅
-    | CTI2.rebase-varᴸ rb₄₅
-    | refl =
+    | CTI2.rebase-varᴸ {Xᴿ = .Y} rb₄₅
+    | yes refl =
   dyn-var-star {W = W₁} {X = X} ,
   CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
     (CTI2.rebase-varᴸ
@@ -502,7 +687,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
         (SPT.dynWorld-decay W₅)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅))))
+        (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅))))
     (WD.decaySameCtx (SPT.dynWorld-decay W₁)
       (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
     (CTI2.⊢↓-sealˣ X∈)
@@ -512,7 +697,96 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (dyn-var-star {W = W₅} {X = X₃}))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
+    | no Y″≠Y
+    with Fin._≟_ (toRenameᵗ (CTI2.ηᴿʷ W₅) Y″)
+      (toRenameᵗ (CTI2.ηᴿʷ W₄) Y″)
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
+    | no Y″≠Y | yes unmoved =
+  dyn-var-star {W = W₁} {X = X} ,
+  CTI2.conceal⊑² (dyn-mono {W = W₁} {W′ = W₅})
+    (CTI2.rebase-varᴸ
+      (TD.decayRebaseAt {W₁ = W₅} {W₁ᵈ = SPT.dynWorld W₅}
+        {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
+        (SPT.dynWorld-decay W₅)
+        (SPT.dynWorld-decay W₁)
+        (composeRebaseAt-away rb₁₄ rb₄₅ Y″≠Y unmoved)))
+    (WD.decaySameCtx (SPT.dynWorld-decay W₁)
+      (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
+    (CTI2.⊢↓-sealˣ X∈)
+    (CTI2.⊑cast² c
+      (TD.⊢²-decay-at (SPT.dynWorld-decay W₅) prem₅
+        (aligned-var {W = W₅} {X = X₃} {Y = Y′} aligned₅))
+      (dyn-var-star {W = W₅} {X = X₃}))
+    (dyn-var-star {W = W₁} {X = X})
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
+    | no Y″≠Y | no moved
+    with CTI2.RebaseAt.anchorᴿ rb₄₅ moved
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ X∈′) prem₅ .p₄
+    | X₃ , refl , aligned₅
+    | CTI2.rebase-varᴸ {Xᴿ = Y″} rb₄₅
+    | no Y″≠Y | no moved | Xₒ , anchored₅ =
+  h-chain rb₁₄ rb₄₅ moved Y″≠Y (Xₒ , anchored₅)
+    (sv-sealed sv) vU D
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -527,7 +801,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
     with target-seal-rebase-source rb₅ p₄
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -541,9 +815,9 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
     | rb₄₅
-    with same-target rb₁₄ rb₄₅
+    with Fin._≟_ Y′ Y
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -557,7 +831,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
         mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y∈″) prem₅ .p₄
     | rb₄₅
-    | refl =
+    | yes refl =
   dyn-var-star {W = W₁} {X = X} ,
   CTI2.⊑cast² c
     (CTI2.⊑conceal² (dyn-mono {W = W₁} {W′ = W₅})
@@ -566,7 +840,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
           {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
           (SPT.dynWorld-decay W₅)
           (SPT.dynWorld-decay W₁)
-          (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅))))
+          (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅))))
       (WD.decaySameCtx (SPT.dynWorld-decay W₁)
         (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
       (CTI2.⊢↓-sealˣ (transport-target-member rb₁₄ Y∈″))
@@ -574,7 +848,24 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.⊑conceal² {W′ = W₅} {γ′ = γ₅} {p = p₅}
+        mono₅ rb₅ sc₅ (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
+    | rb₄₅
+    | no Y′≠Y =
+  h-tag rb₁₄ rb₄₅ Y′≠Y c inert (sv-sealed sv) vM′ D
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -588,9 +879,9 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
         mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
         (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
-    with same-target rb₁₄ rb₄₅
+    with Fin._≟_ Y′ Y
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -604,7 +895,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
         mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
         (CTI2.⊢↓-sealˣ Y∈″) prem₅ .p₄
-    | refl =
+    | yes refl =
   dyn-var-star {W = W₁} {X = X} ,
   CTI2.⊑cast² c
     (CTI2.conceal⊑conceal²
@@ -613,7 +904,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         {W₂ = W₁} {W₂ᵈ = SPT.dynWorld W₁}
         (SPT.dynWorld-decay W₅)
         (SPT.dynWorld-decay W₁)
-        (composeRebaseAt rb₁₄ rb₄₅ (pivot-stable rb₁₄ rb₄₅)))
+        (composeRebaseAt rb₁₄ rb₄₅ (h-compose rb₁₄ rb₄₅)))
       (WD.decaySameCtx (SPT.dynWorld-decay W₁)
         (SPT.dynWorld-decay W₅) (composeSameCtx sc₂ sc₅))
       (CTI2.⊢↓-sealˣ X∈)
@@ -622,7 +913,24 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
       (aligned-var {W = W₁} {X = X} {Y = Y} aligned))
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
+      (sv-sealed sv) vU D
+    | X , refl , aligned
+    | ⊢conceal (⊢↓-seal X∈) V₀⊢
+    | CTI2.⊑conceal² {W′ = W₄} {γ′ = γ₄} mono₂ rb₂ sc₂
+        (CTI2.⊢↓-sealˣ Y∈) prem₃ .p
+    | rb₁₄
+    | CTI2.⊑cast² {p = p₄} c prem₄ q₄
+    | vM′ 《 inert 》
+    | Y′ , refl
+    | ECR.varv-seal vM₅ Y′∈ refl
+    | CTI2.conceal⊑conceal² {Wᵖ = W₅} {γᵖ = γ₅}
+        mono₅ rb₄₅ sc₅ (CTI2.⊢↓-sealˣ X∈′)
+        (CTI2.⊢↓-sealˣ Y′∈′) prem₅ .p₄
+    | no Y′≠Y =
+  h-tag rb₁₄ rb₄₅ Y′≠Y c inert (sv-sealed sv) vM′ D
+seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -632,7 +940,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑reveal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
   ⊥-elim (reveal-star-value-⊥ vU)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -642,7 +950,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     | CTI2.⊑conceal² mono₅ rb₅ sc₅ c′⊢ prem₄ q₄ =
   ⊥-elim (conceal-star-value-⊥ vU)
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -650,9 +958,9 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
         (CTI2.⊢↓-sealˣ X∈′) prem .p
     with ECR.seal-rebase-target rb p
        | seal-transfer
-           (seal-transfer-assumption same-target pivot-stable) sv vU prem
+           (seal-transfer-assumption h-compose h-chain h-tag) sv vU prem
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢
@@ -671,7 +979,7 @@ seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
     (CTI2.⊢↓-sealˣ X∈) V₀⊑U
     (dyn-var-star {W = W₁} {X = X})
 seal-transfer {W₁ = W₁} {A = .(＇ X)} {Y = Y} {p = p}
-    (seal-transfer-assumption same-target pivot-stable)
+    (seal-transfer-assumption h-compose h-chain h-tag)
       (sv-sealed sv) vU D
     | X , refl , aligned
     | ⊢conceal (⊢↓-seal X∈) V₀⊢

--- a/GTSFImp/proof/DGG/TagBoundaryProbe.agda
+++ b/GTSFImp/proof/DGG/TagBoundaryProbe.agda
@@ -1,0 +1,246 @@
+module proof.DGG.TagBoundaryProbe where
+
+-- File Charter:
+--   * This probe decides the tag-boundary stratum (H-tag in
+--     SealTransfer).
+--   * Checkpoint 1 records that a variable-ground tag can be aligned
+--     only in interior worlds even when no target variable moves.
+--   * Checkpoint 2 records that the corresponding inversion output is
+--     empty at the outer world.
+
+open import Data.Empty using (⊥-elim)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality
+  using (_≢_; refl)
+open import Relation.Nullary using (¬_)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-bind; _∋_⦂_; Z∋; S-bind∋)
+open import Consistency using
+  (Env∼; X∼★; _⊢_∼_; _↪ᵗ_; empty; keep; skip; _!; id)
+open import Imprecision
+open import Conversion using (seal)
+open import CastTerms
+open import Primitives using (κℕ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; _⊢↓[_]_; _∣_⊢²_⊑_∶_;
+   RebaseAt; rebase-at; same-runtime; store-rep-imp; ⊢↓-sealˣ)
+
+private
+  X : TyVar 1
+  X = Fin.zero
+
+  Y : TyVar 2
+  Y = Fin.zero
+
+  Y′ : TyVar 2
+  Y′ = Fin.suc Fin.zero
+
+------------------------------------------------------------------------
+-- Stores, embeddings, and worlds
+------------------------------------------------------------------------
+
+probe-src-store : TyStore 1
+probe-src-store = store-bind store-empty ★
+
+probe-tgt-store : TyStore 2
+probe-tgt-store = store-bind (store-bind store-empty ★) ★
+
+probe-μ : ImpEnv 2
+probe-μ Fin.zero = X⊑★
+probe-μ (Fin.suc Fin.zero) = X⊑★
+
+η-X-a : 1 ↪ᵗ 2
+η-X-a = keep (skip empty)
+
+η-X-b : 1 ↪ᵗ 2
+η-X-b = skip (keep empty)
+
+η-YY′-ab : 2 ↪ᵗ 2
+η-YY′-ab = keep (keep empty)
+
+-- Final placement table (a = 0, b = 1):
+--
+--             X    Y    Y′
+--   probe-W₁   a    a    b
+--   probe-W₄   b    a    b
+--   probe-W₅   b    a    b
+--
+-- Only X moves, from a to b.  Both target variables remain fixed.
+
+probe-W₁ : World 1 2 2
+probe-W₁ =
+  world η-X-a η-YY′-ab probe-μ probe-src-store probe-tgt-store
+
+probe-W₄ : World 1 2 2
+probe-W₄ =
+  world η-X-b η-YY′-ab probe-μ probe-src-store probe-tgt-store
+
+probe-W₅ : World 1 2 2
+probe-W₅ =
+  world η-X-b η-YY′-ab probe-μ probe-src-store probe-tgt-store
+
+probe-W₁-WF : CTI2.WFWorld probe-W₁
+probe-W₁-WF Fin.zero ()
+
+probe-W₄-WF : CTI2.WFWorld probe-W₄
+probe-W₄-WF Fin.zero ()
+
+probe-W₅-WF : CTI2.WFWorld probe-W₅
+probe-W₅-WF Fin.zero ()
+
+------------------------------------------------------------------------
+-- Store typing and casts
+------------------------------------------------------------------------
+
+probe-src-X∋ : probe-src-store ∋ X ⦂ ★
+probe-src-X∋ = Z∋ refl
+
+probe-tgt-Y∋ : probe-tgt-store ∋ Y ⦂ ★
+probe-tgt-Y∋ = Z∋ refl
+
+probe-tgt-Y′∋ : probe-tgt-store ∋ Y′ ⦂ ★
+probe-tgt-Y′∋ = S-bind∋ (Z∋ refl) refl
+
+probe-X-seal-⊢ : probe-src-store ⊢↓[ just X ] seal X ★
+probe-X-seal-⊢ = ⊢↓-sealˣ probe-src-X∋
+
+probe-Y-seal-⊢ : probe-tgt-store ⊢↓[ just Y ] seal Y ★
+probe-Y-seal-⊢ = ⊢↓-sealˣ probe-tgt-Y∋
+
+probe-Y′-seal-⊢ : probe-tgt-store ⊢↓[ just Y′ ] seal Y′ ★
+probe-Y′-seal-⊢ = ⊢↓-sealˣ probe-tgt-Y′∋
+
+private
+  probe-src-env : Env∼ 1
+  probe-src-env Fin.zero = X∼★
+
+  probe-tgt-env : Env∼ 2
+  probe-tgt-env Fin.zero = X∼★
+  probe-tgt-env (Fin.suc Fin.zero) = X∼★
+
+  probe-ℕ!ᴸ : probe-src-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴸ = id (‵ `ℕ) !
+
+  probe-ℕ!ᴿ : probe-tgt-env ⊢ (‵ `ℕ) ∼ ★
+  probe-ℕ!ᴿ = id (‵ `ℕ) !
+
+  probe-Y′! : probe-tgt-env ⊢ ＇ Y′ ∼ ★
+  probe-Y′! = id { μ = probe-tgt-env } (＇ Y′) !
+
+------------------------------------------------------------------------
+-- Terms
+------------------------------------------------------------------------
+
+probe-V₀ : Term 1
+probe-V₀ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴸ ⟩
+
+probe-V : Term 1
+probe-V = probe-V₀ ↓ seal X ★
+
+probe-M₅ : Term 2
+probe-M₅ = ($ (κℕ 0)) ⟨ probe-ℕ!ᴿ ⟩
+
+probe-M′ : Term 2
+probe-M′ = probe-M₅ ↓ seal Y′ ★
+
+probe-U : Term 2
+probe-U = probe-M′ ⟨ probe-Y′! ⟩
+
+------------------------------------------------------------------------
+-- Rebase witnesses
+------------------------------------------------------------------------
+
+probe-X-Y-rep₁ : CTI2.StoreRepImp probe-W₁ X Y
+probe-X-Y-rep₁ = store-rep-imp ★⊑★
+
+probe-outer-target-rebase : RebaseAt probe-W₄ probe-W₁ X Y
+probe-outer-target-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} X≢ → ⊥-elim (X≢ refl) })
+    (λ { {Fin.zero} Y≢ → ⊥-elim (Y≢ refl)
+       ; {Fin.suc Fin.zero} Y′≢ → refl })
+    refl (λ moved → ⊥-elim (moved refl)) probe-X-Y-rep₁
+
+probe-X-Y′-rep₄ : CTI2.StoreRepImp probe-W₄ X Y′
+probe-X-Y′-rep₄ = store-rep-imp ★⊑★
+
+probe-inner-target-rebase : RebaseAt probe-W₅ probe-W₄ X Y′
+probe-inner-target-rebase =
+  rebase-at (same-runtime refl refl)
+    (λ { {Fin.zero} X≢ → ⊥-elim (X≢ refl) })
+    (λ { {Fin.zero} Y≢ → refl
+       ; {Fin.suc Fin.zero} Y′≢ → ⊥-elim (Y′≢ refl) })
+    refl (λ moved → ⊥-elim (moved refl)) probe-X-Y′-rep₄
+
+probe-X-Y′-rep₅ : CTI2.StoreRepImp probe-W₅ X Y′
+probe-X-Y′-rep₅ = store-rep-imp ★⊑★
+
+probe-inner-source-rebase : RebaseAt probe-W₅ probe-W₅ X Y′
+probe-inner-source-rebase =
+  CTI2.sameWorldRebaseAt refl probe-X-Y′-rep₅
+
+------------------------------------------------------------------------
+-- Checkpoint 1: the interior tag-boundary input
+------------------------------------------------------------------------
+
+pIn : ＇ X ⊑ᵂ⟨ probe-W₁ ⟩ ＇ Y
+pIn = X⊑X
+
+p₄ : ＇ X ⊑ᵂ⟨ probe-W₄ ⟩ ★
+p₄ = X⊑★ refl
+
+pTag : ＇ X ⊑ᵂ⟨ probe-W₄ ⟩ ＇ Y′
+pTag = X⊑X
+
+p₅ : ＇ X ⊑ᵂ⟨ probe-W₅ ⟩ ★
+p₅ = X⊑★ refl
+
+probe-base² :
+  probe-W₅ ∣ [] ⊢² probe-V₀ ⊑ probe-M₅ ∶ ★⊑★
+probe-base² =
+  CTI2.cast⊑cast² probe-ℕ!ᴸ probe-ℕ!ᴿ
+    (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ★⊑★
+
+probe-source-seal² :
+  probe-W₅ ∣ [] ⊢² probe-V ⊑ probe-M₅ ∶ p₅
+probe-source-seal² =
+  CTI2.conceal⊑² (λ _ eq → eq)
+    (CTI2.rebase-varᴸ probe-inner-source-rebase)
+    CTI2.same-[] probe-X-seal-⊢ probe-base² p₅
+
+probe-inner-seal² :
+  probe-W₄ ∣ [] ⊢² probe-V ⊑ probe-M′ ∶ pTag
+probe-inner-seal² =
+  CTI2.⊑conceal² (λ _ eq → eq)
+    (CTI2.rebase-varᴿ probe-inner-target-rebase)
+    CTI2.same-[] probe-Y′-seal-⊢ probe-source-seal² pTag
+
+probe-tag² :
+  probe-W₄ ∣ [] ⊢² probe-V ⊑ probe-U ∶ p₄
+probe-tag² = CTI2.⊑cast² probe-Y′! probe-inner-seal² p₄
+
+probe-input :
+  probe-W₁ ∣ [] ⊢² probe-V ⊑ (probe-U ↓ seal Y ★) ∶ pIn
+probe-input =
+  CTI2.⊑conceal² (λ _ eq → eq)
+    (CTI2.rebase-varᴿ probe-outer-target-rebase)
+    CTI2.same-[] probe-Y-seal-⊢ probe-tag² pIn
+
+------------------------------------------------------------------------
+-- Checkpoint 2: the outer-world output is empty
+------------------------------------------------------------------------
+
+qOut : ＇ X ⊑ᵂ⟨ probe-W₁ ⟩ ＇ Y
+qOut = X⊑X
+
+probe-no-output :
+  ¬ (probe-W₁ ∣ [] ⊢² probe-V ⊑ probe-U ∶ qOut)
+probe-no-output
+    (CTI2.conceal⊑² {p = p} mono rb sc c⊢ prem q) with p
+probe-no-output
+    (CTI2.conceal⊑² {p = p} mono rb sc c⊢ prem q) | ()

--- a/GTSFImp/proof/DGG/TagTransport.agda
+++ b/GTSFImp/proof/DGG/TagTransport.agda
@@ -1,0 +1,408 @@
+module proof.DGG.TagTransport where
+
+-- File Charter:
+--   * Transports ground-tag imprecision obligations across universal-shaped
+--     pivot-indexed reveal and conceal conversions.
+--   * Refutes base and variable obligations that cannot survive those
+--     conversions.
+--   * Uses binder-occurrence transport and lifted-store freshness to invert
+--     the universal wrappers without changing the imprecision relation.
+
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.Maybe using (just)
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types
+open import TyStore using (TyStore; store-lift; S-lift∋)
+open import Conversion using (Conv↑; Conv↓)
+open import Imprecision
+open import proof.DGG.CastTermImprecision2 using
+  (_⊢↑[_]_; _⊢↓[_]_; ⊢↑-unsealˣ; ⊢↑-⇒ˣ; ⊢↑-∀ˣ;
+   ⊢↓-sealˣ; ⊢↓-⇒ˣ; ⊢↓-∀ˣ)
+open import proof.DGG.ConvImp using
+  (occurs-absent-⊥; conv↑-zero-pre; conv↑-zero-post;
+   conv↓-zero-pre; conv↓-zero-post)
+open import proof.DGG.WorldDecay using (⊑-env-mono)
+open import proof.ImprecisionConsistency using
+  (rename-occurs; unrename-occurs; rename-not-occurs;
+   source-occurs-target; ext-injective; zero-absent-shift)
+
+------------------------------------------------------------------------
+-- Environment and universal-body helpers
+------------------------------------------------------------------------
+
+⊑-extᵐ-instᵐ : ∀ {Δ} {μ : ImpEnv Δ} {A B : Ty (Nat.suc Δ)}
+  → extᵐ μ ⊢ A ⊑ B
+  → instᵐ μ ⊢ A ⊑ B
+⊑-extᵐ-instᵐ p = ⊑-env-mono cond p
+  where
+  cond : ∀ Z → extᵐ _ Z ≡ X⊑★ → instᵐ _ Z ≡ X⊑★
+  cond Fin.zero ()
+  cond (Fin.suc Z) eq = eq
+
+∀⊑★-body-no0 : ∀ {Δ} {μ : ImpEnv Δ} {A : Ty (Nat.suc Δ)}
+  → μ ⊢ `∀ A ⊑ ★
+  → Fin.zero ∉ᵗ A
+  → extᵐ μ ⊢ A ⊑ ★
+∀⊑★-body-no0 (∀⊑ Anv z∈A p) z∉A =
+  ⊥-elim (occurs-absent-⊥ z∈A z∉A)
+∀⊑★-body-no0 ∀★⊑★ z∉A = ★⊑★
+∀⊑★-body-no0 (∀⊑★ Ans p) z∉A = p
+∀⊑★-body-no0 bot⊑★ z∉A =
+  ⊥-elim (occurs-absent-⊥ var-∈ z∉A)
+
+------------------------------------------------------------------------
+-- Reveal transport
+------------------------------------------------------------------------
+
+transport↑-∀-fun : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ} {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↑ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c₁
+  → (∀ {Y Z} → ρ′ Y ≡ ρ′ Z → Y ≡ Z)
+  → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ (★ ⇒ ★)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ (★ ⇒ ★)
+transport↑-∀-fun
+    (⊢↑-unsealˣ (S-lift∋ ∋X refl)) inj′ inj
+    (∀⊑★ Ans pb) (∀⊑ Anv z∈′ qb) =
+  ⊥-elim
+    (occurs-absent-⊥
+      (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)
+      (zero-absent-shift _))
+transport↑-∀-fun
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ (⇒⊑⇒ qA qB)) =
+  ∀⊑ nonvar-fun
+    (rename-occurs (extᵗ _) (ext-injective inj′)
+      (conv↑-zero-post (⊢↑-⇒ˣ pj ⊢a ⊢b)
+        (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+    (⇒⊑⇒ (⊑-extᵐ-instᵐ pA) (⊑-extᵐ-instᵐ pB))
+transport↑-∀-fun
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ (⇒⊑⇒ qA qB)) =
+  ∀⊑ nonvar-fun z∈p (⇒⊑⇒ pA pB)
+transport↑-∀-fun
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb)
+    with source-occurs-target refl pb
+      (rename-occurs (extᵗ _) (ext-injective inj′)
+        (conv↑-zero-post (⊢↑-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+transport↑-∀-fun
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb) | ()
+transport↑-∀-fun
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  ∀⊑ nonvar-all z∈p
+    (transport↑-∀-fun ⊢c₂ (ext-injective inj′)
+      (ext-injective inj) pb qb)
+
+transport↑-∀-all : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ} {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↑ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c₁
+  → (∀ {Y Z} → ρ′ Y ≡ ρ′ Z → Y ≡ Z)
+  → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ `∀ ★
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ `∀ ★
+transport↑-∀-all
+    (⊢↑-unsealˣ (S-lift∋ ∋X refl)) inj′ inj
+    (∀⊑★ Ans pb) q =
+  ∀⊑∀ pb
+transport↑-∀-all
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans pb) q =
+  ∀⊑∀ pb
+transport↑-∀-all
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p pb) (∀⊑∀ qb)
+    with source-occurs-target refl qb
+      (rename-occurs (extᵗ _) (ext-injective inj)
+        (conv↑-zero-pre (⊢↑-⇒ˣ pj ⊢a ⊢b)
+          (unrename-occurs (extᵗ _) (ext-injective inj′) z∈p)))
+transport↑-∀-all
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p pb) (∀⊑∀ qb) | ()
+transport↑-∀-all
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p pb) (∀⊑ Anv z∈′ ())
+transport↑-∀-all
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb) q =
+  ∀⊑∀ pb
+transport↑-∀-all
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑∀ qb)
+    with source-occurs-target refl qb
+      (rename-occurs (extᵗ _) (ext-injective inj)
+        (conv↑-zero-pre (⊢↑-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj′) z∈p)))
+transport↑-∀-all
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑∀ qb) | ()
+transport↑-∀-all
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  ∀⊑ nonvar-all z∈p
+    (transport↑-∀-all ⊢c₂ (ext-injective inj′)
+      (ext-injective inj) pb qb)
+
+transport↑-∀-ι-⊥ : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ}
+    {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↑ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc} {ι : Base}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c₁
+  → (∀ {Y Z} → ρ′ Y ≡ ρ′ Z → Y ≡ Z)
+  → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ ‵ ι
+  → ⊥
+transport↑-∀-ι-⊥
+    (⊢↑-unsealˣ (S-lift∋ ∋X refl)) inj′ inj
+    (∀⊑★ Ans pb) (∀⊑ Anv z∈′ qb) =
+  ⊥-elim
+    (occurs-absent-⊥
+      (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)
+      (zero-absent-shift _))
+transport↑-∀-ι-⊥
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans (⇒⊑★ pA pB)) (∀⊑ Anv z∈′ ())
+transport↑-∀-ι-⊥
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ ())
+transport↑-∀-ι-⊥
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb)
+    with source-occurs-target refl pb
+      (rename-occurs (extᵗ _) (ext-injective inj′)
+        (conv↑-zero-post (⊢↑-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+transport↑-∀-ι-⊥
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb) | ()
+transport↑-∀-ι-⊥
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  transport↑-∀-ι-⊥ ⊢c₂ (ext-injective inj′)
+    (ext-injective inj) pb qb
+
+transport↑-∀-var-⊥ : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ}
+    {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↑ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc}
+    {Z : TyVar Δc}
+  → store-lift Σ ⊢↑[ just (Fin.suc X) ] c₁
+  → (∀ {Y Y′} → ρ′ Y ≡ ρ′ Y′ → Y ≡ Y′)
+  → (∀ {Y Y′} → ρ Y ≡ ρ Y′ → Y ≡ Y′)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ ＇ Z
+  → ⊥
+transport↑-∀-var-⊥
+    (⊢↑-unsealˣ (S-lift∋ ∋X refl)) inj′ inj
+    (∀⊑★ Ans pb) (∀⊑ Anv z∈′ qb) =
+  ⊥-elim
+    (occurs-absent-⊥
+      (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)
+      (zero-absent-shift _))
+transport↑-∀-var-⊥
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans (⇒⊑★ pA pB)) (∀⊑ Anv z∈′ ())
+transport↑-∀-var-⊥
+    (⊢↑-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ ())
+transport↑-∀-var-⊥
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb)
+    with source-occurs-target refl pb
+      (rename-occurs (extᵗ _) (ext-injective inj′)
+        (conv↑-zero-post (⊢↑-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+transport↑-∀-var-⊥
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb) | ()
+transport↑-∀-var-⊥
+    (⊢↑-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  transport↑-∀-var-⊥ ⊢c₂ (ext-injective inj′)
+    (ext-injective inj) pb qb
+
+------------------------------------------------------------------------
+-- Conceal transport
+------------------------------------------------------------------------
+
+transport↓-∀-fun : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ} {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↓ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c₁
+  → (∀ {Y Z} → ρ′ Y ≡ ρ′ Z → Y ≡ Z)
+  → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ (★ ⇒ ★)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ (★ ⇒ ★)
+transport↓-∀-fun
+    (⊢↓-sealˣ (S-lift∋ ∋X refl)) inj′ inj p₀
+    (∀⊑ () z∈′ qb)
+transport↓-∀-fun
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ (⇒⊑⇒ qA qB)) =
+  ∀⊑ nonvar-fun
+    (rename-occurs (extᵗ _) (ext-injective inj′)
+      (conv↓-zero-post (⊢↓-⇒ˣ pj ⊢a ⊢b)
+        (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+    (⇒⊑⇒ (⊑-extᵐ-instᵐ pA) (⊑-extᵐ-instᵐ pB))
+transport↓-∀-fun
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ (⇒⊑⇒ qA qB)) =
+  ∀⊑ nonvar-fun z∈p (⇒⊑⇒ pA pB)
+transport↓-∀-fun
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb)
+    with source-occurs-target refl pb
+      (rename-occurs (extᵗ _) (ext-injective inj′)
+        (conv↓-zero-post (⊢↓-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+transport↓-∀-fun
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb) | ()
+transport↓-∀-fun
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  ∀⊑ nonvar-all z∈p
+    (transport↓-∀-fun ⊢c₂ (ext-injective inj′)
+      (ext-injective inj) pb qb)
+
+transport↓-∀-all : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ} {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↓ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c₁
+  → (∀ {Y Z} → ρ′ Y ≡ ρ′ Z → Y ≡ Z)
+  → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ `∀ ★
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ `∀ ★
+transport↓-∀-all
+    (⊢↓-sealˣ (S-lift∋ ∋X refl)) inj′ inj p₀ (∀⊑∀ qb) =
+  ∀⊑∀
+    (∀⊑★-body-no0 p₀
+      (rename-not-occurs (extᵗ _) (ext-injective inj′)
+        (zero-absent-shift _)))
+transport↓-∀-all
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans pb) q =
+  ∀⊑∀ pb
+transport↓-∀-all
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p pb) (∀⊑∀ qb)
+    with source-occurs-target refl qb
+      (rename-occurs (extᵗ _) (ext-injective inj)
+        (conv↓-zero-pre (⊢↓-⇒ˣ pj ⊢a ⊢b)
+          (unrename-occurs (extᵗ _) (ext-injective inj′) z∈p)))
+transport↓-∀-all
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p pb) (∀⊑∀ qb) | ()
+transport↓-∀-all
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p pb) (∀⊑ Anv z∈′ ())
+transport↓-∀-all
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb) q =
+  ∀⊑∀ pb
+transport↓-∀-all
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑∀ qb)
+    with source-occurs-target refl qb
+      (rename-occurs (extᵗ _) (ext-injective inj)
+        (conv↓-zero-pre (⊢↓-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj′) z∈p)))
+transport↓-∀-all
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑∀ qb) | ()
+transport↓-∀-all
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  ∀⊑ nonvar-all z∈p
+    (transport↓-∀-all ⊢c₂ (ext-injective inj′)
+      (ext-injective inj) pb qb)
+
+transport↓-∀-ι-⊥ : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ}
+    {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↓ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc} {ι : Base}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c₁
+  → (∀ {Y Z} → ρ′ Y ≡ ρ′ Z → Y ≡ Z)
+  → (∀ {Y Z} → ρ Y ≡ ρ Z → Y ≡ Z)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ ‵ ι
+  → ⊥
+transport↓-∀-ι-⊥
+    (⊢↓-sealˣ (S-lift∋ ∋X refl)) inj′ inj p₀
+    (∀⊑ () z∈′ qb)
+transport↓-∀-ι-⊥
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans (⇒⊑★ pA pB)) (∀⊑ Anv z∈′ ())
+transport↓-∀-ι-⊥
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ ())
+transport↓-∀-ι-⊥
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb)
+    with source-occurs-target refl pb
+      (rename-occurs (extᵗ _) (ext-injective inj′)
+        (conv↓-zero-post (⊢↓-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+transport↓-∀-ι-⊥
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb) | ()
+transport↓-∀-ι-⊥
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  transport↓-∀-ι-⊥ ⊢c₂ (ext-injective inj′)
+    (ext-injective inj) pb qb
+
+transport↓-∀-var-⊥ : ∀ {Δᴸ Δc} {Σ : TyStore Δᴸ}
+    {X : TyVar Δᴸ}
+    {A₁ B₁ : Ty (Nat.suc Δᴸ)} {c₁ : Conv↓ (Nat.suc Δᴸ) A₁ B₁}
+    {ρ′ ρ : Δᴸ ⇒ʳ Δc} {μ′ μ : ImpEnv Δc}
+    {Z : TyVar Δc}
+  → store-lift Σ ⊢↓[ just (Fin.suc X) ] c₁
+  → (∀ {Y Y′} → ρ′ Y ≡ ρ′ Y′ → Y ≡ Y′)
+  → (∀ {Y Y′} → ρ Y ≡ ρ Y′ → Y ≡ Y′)
+  → μ′ ⊢ renameᵗ ρ′ (`∀ A₁) ⊑ ★
+  → μ ⊢ renameᵗ ρ (`∀ B₁) ⊑ ＇ Z
+  → ⊥
+transport↓-∀-var-⊥
+    (⊢↓-sealˣ (S-lift∋ ∋X refl)) inj′ inj p₀
+    (∀⊑ () z∈′ qb)
+transport↓-∀-var-⊥
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑★ Ans (⇒⊑★ pA pB)) (∀⊑ Anv z∈′ ())
+transport↓-∀-var-⊥
+    (⊢↓-⇒ˣ pj ⊢a ⊢b) inj′ inj
+    (∀⊑ nonvar-fun z∈p (⇒⊑★ pA pB))
+    (∀⊑ Anv z∈′ ())
+transport↓-∀-var-⊥
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb)
+    with source-occurs-target refl pb
+      (rename-occurs (extᵗ _) (ext-injective inj′)
+        (conv↓-zero-post (⊢↓-∀ˣ ⊢c₂)
+          (unrename-occurs (extᵗ _) (ext-injective inj) z∈′)))
+transport↓-∀-var-⊥
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj (∀⊑★ Ans pb)
+    (∀⊑ Anv z∈′ qb) | ()
+transport↓-∀-var-⊥
+    (⊢↓-∀ˣ ⊢c₂) inj′ inj
+    (∀⊑ nonvar-all z∈p pb) (∀⊑ Anv z∈′ qb) =
+  transport↓-∀-var-⊥ ⊢c₂ (ext-injective inj′)
+    (ext-injective inj) pb qb

--- a/GTSFImp/proof/DGG/TermImpDecay.agda
+++ b/GTSFImp/proof/DGG/TermImpDecay.agda
@@ -1,0 +1,378 @@
+module proof.DGG.TermImpDecay where
+
+-- File Charter:
+--   * Transports version-2 cast-term imprecision across world decay.
+--   * Lifts decay through type binders and term-context lifting.
+--   * Decays pivot-local rebasing and wrapper-rule premise worlds.
+--   * Exports obligation-insensitive transport via proof irrelevance.
+
+open import Data.List using ([]; _∷_)
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong)
+  renaming (subst to subst≡)
+
+open import Types
+open import CastTerms using (Term; ⟨_,_,_⟩; _⊢_⦂_)
+open import Imprecision
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using (_∣_⊢²_⊑_∶_)
+open import proof.DGG.WorldDecay
+import proof.Imprecision as PI
+
+------------------------------------------------------------------------
+-- Decay under type binders
+------------------------------------------------------------------------
+
+liftDecayBoth : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+  → (v : VarImp)
+  → EnvDecay W Wᵈ
+  → EnvDecay (CTI2.liftWorldBoth v W) (CTI2.liftWorldBoth v Wᵈ)
+liftDecayBoth
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′}
+    v
+    (env-decay refl refl refl refl mono) =
+  env-decay refl refl refl refl lift-mono
+  where
+  lift-mono : ∀ Z
+    → extendᵐ v μ Z ≡ X⊑★
+    → extendᵐ v μᵈ Z ≡ X⊑★
+  lift-mono Fin.zero eq = eq
+  lift-mono (Fin.suc Z) eq = mono Z eq
+
+liftDecayLeft : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+  → (v : VarImp)
+  → EnvDecay W Wᵈ
+  → EnvDecay (CTI2.liftWorldLeft v W) (CTI2.liftWorldLeft v Wᵈ)
+liftDecayLeft
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′}
+    v
+    (env-decay refl refl refl refl mono) =
+  env-decay refl refl refl refl lift-mono
+  where
+  lift-mono : ∀ Z
+    → extendᵐ v μ Z ≡ X⊑★
+    → extendᵐ v μᵈ Z ≡ X⊑★
+  lift-mono Fin.zero eq = eq
+  lift-mono (Fin.suc Z) eq = mono Z eq
+
+decayLiftCtx : ∀ {Δᴸ Δᴿ Δ} {v} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W}
+    {γ′ : CTI2.CtxImp (CTI2.liftWorldBoth v W)}
+  → (dec : EnvDecay W Wᵈ)
+  → CTI2.LiftCtx v γ γ′
+  → CTI2.LiftCtx v (decayCtx dec γ)
+      (decayCtx (liftDecayBoth v dec) γ′)
+decayLiftCtx dec CTI2.lift-[] = CTI2.lift-[]
+decayLiftCtx dec (CTI2.lift-∷ liftγ) =
+  CTI2.lift-∷ (decayLiftCtx dec liftγ)
+
+decayLiftCtxᴸ : ∀ {Δᴸ Δᴿ Δ} {v} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W}
+    {γ′ : CTI2.CtxImp (CTI2.liftWorldLeft v W)}
+  → (dec : EnvDecay W Wᵈ)
+  → CTI2.LiftCtxᴸ v γ γ′
+  → CTI2.LiftCtxᴸ v (decayCtx dec γ)
+      (decayCtx (liftDecayLeft v dec) γ′)
+decayLiftCtxᴸ dec CTI2.liftᴸ-[] = CTI2.liftᴸ-[]
+decayLiftCtxᴸ dec (CTI2.liftᴸ-∷ liftγ) =
+  CTI2.liftᴸ-∷ (decayLiftCtxᴸ dec liftγ)
+
+decayCtx-tgt : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+  → (dec : EnvDecay W Wᵈ)
+  → (γ : CTI2.CtxImp W)
+  → CTI2.tgtCtxʷ (decayCtx dec γ) ≡ CTI2.tgtCtxʷ γ
+decayCtx-tgt dec [] = refl
+decayCtx-tgt dec (CTI2.ctx-imp A B p ∷ γ) =
+  cong (_ ∷_) (decayCtx-tgt dec γ)
+
+------------------------------------------------------------------------
+-- Decay of pivot-local rebasing
+------------------------------------------------------------------------
+
+decayRebaseAt : ∀ {Δᴸ Δᴿ Δ}
+    {W₁ W₁ᵈ W₂ W₂ᵈ : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ Xᴿ}
+  → (dec₁ : EnvDecay W₁ W₁ᵈ)
+  → (dec₂ : EnvDecay W₂ W₂ᵈ)
+  → CTI2.RebaseAt W₁ W₂ Xᴸ Xᴿ
+  → CTI2.RebaseAt W₁ᵈ W₂ᵈ Xᴸ Xᴿ
+decayRebaseAt
+    {W₁ = CTI2.world ηL₁ ηR₁ μ₁ ΣL₁ ΣR₁}
+    {W₁ᵈ = CTI2.world ηL₁′ ηR₁′ μ₁ᵈ ΣL₁′ ΣR₁′}
+    {W₂ = CTI2.world ηL₂ ηR₂ μ₂ ΣL₂ ΣR₂}
+    {W₂ᵈ = CTI2.world ηL₂′ ηR₂′ μ₂ᵈ ΣL₂′ ΣR₂′}
+    (env-decay refl refl refl refl mono₁)
+    dec₂@(env-decay refl refl refl refl mono₂)
+    (CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
+      offL offR aligned
+      (CTI2.store-rep-imp represented)) =
+  CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
+    offL offR aligned
+    (CTI2.store-rep-imp (decay⊑ᵂ dec₂ represented))
+
+------------------------------------------------------------------------
+-- Term-imprecision decay
+------------------------------------------------------------------------
+
+⊢²-decay : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → (dec : EnvDecay W Wᵈ)
+  → W ∣ γ ⊢² M ⊑ M′ ∶ p
+  → Wᵈ ∣ decayCtx dec γ ⊢² M ⊑ M′ ∶ decay⊑ᵂ dec p
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.x⊑x² x∈) =
+  CTI2.x⊑x² (decay∋ʷ dec x∈)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.ƛ⊑ƛ² M⊑M′) =
+  CTI2.ƛ⊑ƛ² (⊢²-decay dec M⊑M′)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.·⊑·² L⊑L′ M⊑M′) =
+  CTI2.·⊑·² (⊢²-decay dec L⊑L′) (⊢²-decay dec M⊑M′)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.Λ⊑Λ² liftγ vV vV′ V⊑V′ q) =
+  CTI2.Λ⊑Λ² (decayLiftCtx dec liftγ) vV vV′
+    (⊢²-decay (liftDecayBoth X⊑X dec) V⊑V′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    {γ = γ}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.Λ⊑² Anv zero∈A liftγ vV M′⊢ V⊑M′ q) =
+  CTI2.Λ⊑² Anv zero∈A (decayLiftCtxᴸ dec liftγ) vV
+    (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+      (sym (decayCtx-tgt dec γ)) M′⊢)
+    (⊢²-decay (liftDecayLeft X⊑★ dec) V⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.•⊑•² p∀ M⊑M′ q r) =
+  CTI2.•⊑•² (decay⊑ᵂ dec p∀) (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q) (decay⊑ᵂ dec r)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.•⊑² p∀ M⊑M′ q r) =
+  CTI2.•⊑² (decay⊑ᵂ dec p∀) (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q) (decay⊑ᵂ dec r)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.κ⊑κ² κ p) =
+  CTI2.κ⊑κ² κ (decay⊑ᵂ dec p)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.cast⊑cast² c c′ M⊑M′ q) =
+  CTI2.cast⊑cast² c c′ (⊢²-decay dec M⊑M′) (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.⊑cast² c′ M⊑M′ q) =
+  CTI2.⊑cast² c′ (⊢²-decay dec M⊑M′) (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.cast⊑² c M⊑M′ q) =
+  CTI2.cast⊑² c (⊢²-decay dec M⊑M′) (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.⊑reveal² rule-mono CTI2.rebase-idᴿ sc
+      c′⊢ M⊑M′ q) =
+  CTI2.⊑reveal² (λ _ eq → eq) CTI2.rebase-idᴿ
+    (decaySameCtx dec dec sc) c′⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.⊑reveal² {W′ = W′} rule-mono
+      (CTI2.rebase-varᴿ rb) sc c′⊢ M⊑M′ q) =
+  CTI2.⊑reveal²
+    (blend-mono {W′ = W′} {Wᵈ = Wᵈ})
+    (CTI2.rebase-varᴿ
+      (decayRebaseAt dec
+        (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) rb))
+    (decaySameCtx dec
+      (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) sc)
+    c′⊢
+    (⊢²-decay (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.⊑conceal² rule-mono CTI2.rebase-idᴿ sc
+      c′⊢ M⊑M′ q) =
+  CTI2.⊑conceal² (λ _ eq → eq) CTI2.rebase-idᴿ
+    (decaySameCtx dec dec sc) c′⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.⊑conceal² {W′ = W′} rule-mono
+      (CTI2.rebase-varᴿ rb) sc c′⊢ M⊑M′ q) =
+  CTI2.⊑conceal²
+    (blend-mono {W′ = W′} {Wᵈ = Wᵈ})
+    (CTI2.rebase-varᴿ
+      (decayRebaseAt
+        (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) dec rb))
+    (decaySameCtx dec
+      (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) sc)
+    c′⊢
+    (⊢²-decay (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.reveal⊑² rule-mono CTI2.rebase-idᴸ sc
+      c⊢ M⊑M′ q) =
+  CTI2.reveal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.reveal⊑² {W′ = W′} rule-mono
+      (CTI2.rebase-varᴸ rb) sc c⊢ M⊑M′ q) =
+  CTI2.reveal⊑²
+    (blend-mono {W′ = W′} {Wᵈ = Wᵈ})
+    (CTI2.rebase-varᴸ
+      (decayRebaseAt dec
+        (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) rb))
+    (decaySameCtx dec
+      (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) sc)
+    c⊢
+    (⊢²-decay (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.reveal⊑² rule-mono
+      (CTI2.rebase-onlyᴸ to-star disaligned represented)
+      sc c⊢ M⊑M′ q) =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    (CTI2.rebase-onlyᴸ (mono _ to-star) disaligned
+      (decay⊑ᵂ dec represented))
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑² rule-mono CTI2.rebase-idᴸ sc
+      c⊢ M⊑M′ q) =
+  CTI2.conceal⊑² (λ _ eq → eq) CTI2.rebase-idᴸ
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑² {W′ = W′} rule-mono
+      (CTI2.rebase-varᴸ rb) sc c⊢ M⊑M′ q) =
+  CTI2.conceal⊑²
+    (blend-mono {W′ = W′} {Wᵈ = Wᵈ})
+    (CTI2.rebase-varᴸ
+      (decayRebaseAt
+        (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) dec rb))
+    (decaySameCtx dec
+      (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) sc)
+    c⊢
+    (⊢²-decay (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑² rule-mono
+      (CTI2.rebase-onlyᴸ to-star disaligned represented)
+      sc c⊢ M⊑M′ q) =
+  CTI2.conceal⊑² (λ _ eq → eq)
+    (CTI2.rebase-onlyᴸ (mono _ to-star) disaligned
+      (decay⊑ᵂ dec represented))
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.reveal⊑reveal² {Wᵖ = Wᵖ} rule-mono rb sc
+      c⊢ c′⊢ M⊑M′ q) =
+  CTI2.reveal⊑reveal²
+    (blend-mono {W′ = Wᵖ} {Wᵈ = Wᵈ})
+    (decayRebaseAt dec
+      (blend-decay {W′ = Wᵖ} {Wᵈ = Wᵈ}) rb)
+    (decaySameCtx dec
+      (blend-decay {W′ = Wᵖ} {Wᵈ = Wᵈ}) sc)
+    c⊢ c′⊢
+    (⊢²-decay (blend-decay {W′ = Wᵖ} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} rule-mono rb sc
+      c⊢ c′⊢ M⊑M′ q) =
+  CTI2.conceal⊑conceal²
+    (blend-mono {W′ = Wᵖ} {Wᵈ = Wᵈ})
+    (decayRebaseAt
+      (blend-decay {W′ = Wᵖ} {Wᵈ = Wᵈ}) dec rb)
+    (decaySameCtx dec
+      (blend-decay {W′ = Wᵖ} {Wᵈ = Wᵈ}) sc)
+    c⊢ c′⊢
+    (⊢²-decay (blend-decay {W′ = Wᵖ} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.blame⊑blame² p) =
+  CTI2.blame⊑blame² (decay⊑ᵂ dec p)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.⊕⊑⊕² op L⊑L′ M⊑M′ r) =
+  CTI2.⊕⊑⊕² op (⊢²-decay dec L⊑L′) (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec r)
+
+⊢²-decay-at : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+    {γ : CTI2.CtxImp W} {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → (dec : EnvDecay W Wᵈ)
+  → W ∣ γ ⊢² M ⊑ M′ ∶ p
+  → (pᵈ : A CTI2.⊑ᵂ⟨ Wᵈ ⟩ B)
+  → Wᵈ ∣ decayCtx dec γ ⊢² M ⊑ M′ ∶ pᵈ
+⊢²-decay-at {Wᵈ = Wᵈ} {γ = γ} {M = M} {M′ = M′} {p = p}
+    dec M⊑M′ pᵈ =
+  subst≡ (λ q → Wᵈ ∣ decayCtx dec γ ⊢² M ⊑ M′ ∶ q)
+    (PI.⊑-unique (decay⊑ᵂ dec p) pᵈ) (⊢²-decay dec M⊑M′)

--- a/GTSFImp/proof/DGG/TermImpDecay.agda
+++ b/GTSFImp/proof/DGG/TermImpDecay.agda
@@ -355,8 +355,11 @@ decayRebaseAt
     {W = CTI2.world ηL ηR μ ΣL ΣR}
     {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
     dec@(env-decay refl refl refl refl mono)
-    (CTI2.blame⊑blame² p) =
-  CTI2.blame⊑blame² (decay⊑ᵂ dec p)
+    (CTI2.blame⊑² M′⊢ p) =
+  CTI2.blame⊑²
+    (subst≡ (λ Γ → ⟨ _ , _ , Γ ⟩ ⊢ _ ⦂ _)
+      (sym (decayCtx-tgt dec _)) M′⊢)
+    (decay⊑ᵂ dec p)
 ⊢²-decay
     {W = CTI2.world ηL ηR μ ΣL ΣR}
     {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}

--- a/GTSFImp/proof/DGG/TermImpDecay.agda
+++ b/GTSFImp/proof/DGG/TermImpDecay.agda
@@ -106,10 +106,10 @@ decayRebaseAt
     (env-decay refl refl refl refl mono₁)
     dec₂@(env-decay refl refl refl refl mono₂)
     (CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
-      offL offR aligned
+      offL offR aligned anchor
       (CTI2.store-rep-imp represented)) =
   CTI2.rebase-at (CTI2.same-runtime source-eq target-eq)
-    offL offR aligned
+    offL offR aligned anchor
     (CTI2.store-rep-imp (decay⊑ᵂ dec₂ represented))
 
 ------------------------------------------------------------------------

--- a/GTSFImp/proof/DGG/WorldDecay.agda
+++ b/GTSFImp/proof/DGG/WorldDecay.agda
@@ -1,0 +1,233 @@
+module proof.DGG.WorldDecay where
+
+-- File Charter:
+--   * Defines monotonic decay of local-world imprecision marks toward X⊑★.
+--   * Transports type and context imprecision obligations across decay.
+--   * Blends premise worlds with decayed conclusion-world marks.
+--   * Honestifies worlds by dynamizing centers without a target alignment.
+
+open import Data.Fin using (Fin)
+import Data.Fin as Fin
+open import Data.List using ([]; _∷_)
+open import Data.Product using (Σ-syntax; _,_)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+open import Relation.Nullary using (Dec; yes; no)
+
+open import Types
+open import Consistency using (_↪ᵗ_; empty; keep; skip; toRenameᵗ)
+open import Imprecision
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; _⊑ᵂ⟨_⟩_; CtxImp; ctx-imp; _∋ʷ_⦂_; Zʷ; Sʷ;
+   SameCtx; same-[]; same-∷)
+
+------------------------------------------------------------------------
+-- Type-level environment monotonicity
+------------------------------------------------------------------------
+
+⊑-env-mono : ∀ {Δ} {μ μᵈ : ImpEnv Δ} {A B : Ty Δ}
+  → (∀ Z → μ Z ≡ X⊑★ → μᵈ Z ≡ X⊑★)
+  → μ ⊢ A ⊑ B
+  → μᵈ ⊢ A ⊑ B
+⊑-env-mono cond ★⊑★ = ★⊑★
+⊑-env-mono cond ι⊑ι = ι⊑ι
+⊑-env-mono cond X⊑X = X⊑X
+⊑-env-mono cond (⇒⊑⇒ A⊑A′ B⊑B′) =
+  ⇒⊑⇒ (⊑-env-mono cond A⊑A′) (⊑-env-mono cond B⊑B′)
+⊑-env-mono cond (∀⊑∀ A⊑B) =
+  ∀⊑∀ (⊑-env-mono lift-cond A⊑B)
+  where
+  lift-cond : ∀ Z
+    → extᵐ _ Z ≡ X⊑★
+    → extᵐ _ Z ≡ X⊑★
+  lift-cond Fin.zero eq = eq
+  lift-cond (Fin.suc Z) eq = cond Z eq
+⊑-env-mono cond (⇒⊑★ A⊑★ B⊑★) =
+  ⇒⊑★ (⊑-env-mono cond A⊑★) (⊑-env-mono cond B⊑★)
+⊑-env-mono cond ι⊑★ = ι⊑★
+⊑-env-mono cond (X⊑★ eq) = X⊑★ (cond _ eq)
+⊑-env-mono cond (∀⊑ Anv z∈A A⊑B) =
+  ∀⊑ Anv z∈A (⊑-env-mono lift-cond A⊑B)
+  where
+  lift-cond : ∀ Z
+    → instᵐ _ Z ≡ X⊑★
+    → instᵐ _ Z ≡ X⊑★
+  lift-cond Fin.zero eq = eq
+  lift-cond (Fin.suc Z) eq = cond Z eq
+⊑-env-mono cond ∀★⊑★ = ∀★⊑★
+⊑-env-mono cond (∀⊑★ Ans A⊑★) =
+  ∀⊑★ Ans (⊑-env-mono lift-cond A⊑★)
+  where
+  lift-cond : ∀ Z
+    → extᵐ _ Z ≡ X⊑★
+    → extᵐ _ Z ≡ X⊑★
+  lift-cond Fin.zero eq = eq
+  lift-cond (Fin.suc Z) eq = cond Z eq
+⊑-env-mono cond bot-elim = bot-elim
+⊑-env-mono cond bot⊑★ = bot⊑★
+
+------------------------------------------------------------------------
+-- Environment decay between worlds
+------------------------------------------------------------------------
+
+record EnvDecay {Δᴸ Δᴿ Δ} (W Wᵈ : World Δᴸ Δᴿ Δ) : Set where
+  constructor env-decay
+  field
+    ηᴸ-same : CTI2.ηᴸʷ Wᵈ ≡ CTI2.ηᴸʷ W
+    ηᴿ-same : CTI2.ηᴿʷ Wᵈ ≡ CTI2.ηᴿʷ W
+    sourceStore-same :
+      CTI2.sourceStoreʷ Wᵈ ≡ CTI2.sourceStoreʷ W
+    targetStore-same :
+      CTI2.targetStoreʷ Wᵈ ≡ CTI2.targetStoreʷ W
+    env-mono : CTI2.ImpEnvMono W Wᵈ
+
+open EnvDecay public
+
+decay⊑ᵂ : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : World Δᴸ Δᴿ Δ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → EnvDecay W Wᵈ
+  → A ⊑ᵂ⟨ W ⟩ B
+  → A ⊑ᵂ⟨ Wᵈ ⟩ B
+decay⊑ᵂ
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′}
+    (env-decay refl refl refl refl mono) p =
+  ⊑-env-mono mono p
+
+decay-refl : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+  → EnvDecay W W
+decay-refl = env-decay refl refl refl refl (λ Z eq → eq)
+
+------------------------------------------------------------------------
+-- Context decay
+------------------------------------------------------------------------
+
+decayCtx : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : World Δᴸ Δᴿ Δ}
+  → (dec : EnvDecay W Wᵈ)
+  → CtxImp W
+  → CtxImp Wᵈ
+decayCtx dec [] = []
+decayCtx dec (ctx-imp A B p ∷ γ) =
+  ctx-imp A B (decay⊑ᵂ dec p) ∷ decayCtx dec γ
+
+decay∋ʷ : ∀ {Δᴸ Δᴿ Δ} {W Wᵈ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {x A B} {p : A ⊑ᵂ⟨ W ⟩ B}
+  → (dec : EnvDecay W Wᵈ)
+  → γ ∋ʷ x ⦂ ctx-imp A B p
+  → decayCtx dec γ ∋ʷ x ⦂ ctx-imp A B (decay⊑ᵂ dec p)
+decay∋ʷ dec Zʷ = Zʷ
+decay∋ʷ dec (Sʷ x∈) = Sʷ (decay∋ʷ dec x∈)
+
+decaySameCtx : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W Wᵈ : World Δᴸ Δᴿ Δ}
+    {W′ W′ᵈ : World Δᴸ Δᴿ Δ′}
+    {γ : CtxImp W} {γ′ : CtxImp W′}
+  → (dec : EnvDecay W Wᵈ)
+  → (dec′ : EnvDecay W′ W′ᵈ)
+  → SameCtx γ γ′
+  → SameCtx (decayCtx dec γ) (decayCtx dec′ γ′)
+decaySameCtx dec dec′ same-[] = same-[]
+decaySameCtx dec dec′ (same-∷ same) =
+  same-∷ (decaySameCtx dec dec′ same)
+
+------------------------------------------------------------------------
+-- Blending premise-world marks with a decayed conclusion world
+------------------------------------------------------------------------
+
+blendVar : VarImp → VarImp → VarImp
+blendVar X⊑★ v = X⊑★
+blendVar X⊑X v = v
+
+blendWorld : ∀ {Δᴸ Δᴿ Δ}
+  → World Δᴸ Δᴿ Δ
+  → World Δᴸ Δᴿ Δ
+  → World Δᴸ Δᴿ Δ
+blendWorld W′ Wᵈ =
+  CTI2.world (CTI2.ηᴸʷ W′) (CTI2.ηᴿʷ W′)
+    (λ Z → blendVar (CTI2.impEnvʷ W′ Z) (CTI2.impEnvʷ Wᵈ Z))
+    (CTI2.sourceStoreʷ W′) (CTI2.targetStoreʷ W′)
+
+private
+  blend-left-mono : ∀ {v vᵈ}
+    → v ≡ X⊑★
+    → blendVar v vᵈ ≡ X⊑★
+  blend-left-mono refl = refl
+
+blend-decay : ∀ {Δᴸ Δᴿ Δ}
+    {W′ Wᵈ : World Δᴸ Δᴿ Δ}
+  → EnvDecay W′ (blendWorld W′ Wᵈ)
+blend-decay =
+  env-decay refl refl refl refl (λ Z eq → blend-left-mono eq)
+
+blend-mono : ∀ {Δᴸ Δᴿ Δ}
+    {W′ Wᵈ : World Δᴸ Δᴿ Δ}
+  → CTI2.ImpEnvMono Wᵈ (blendWorld W′ Wᵈ)
+blend-mono {W′ = W′} {Wᵈ = Wᵈ} Z eq
+    with CTI2.impEnvʷ W′ Z
+blend-mono {W′ = W′} {Wᵈ = Wᵈ} Z eq | X⊑★ = refl
+blend-mono {W′ = W′} {Wᵈ = Wᵈ} Z eq | X⊑X = eq
+
+------------------------------------------------------------------------
+-- Honest worlds
+------------------------------------------------------------------------
+
+private
+  fin-suc-injective : ∀ {n} {X Y : Fin n}
+    → Fin.suc X ≡ Fin.suc Y
+    → X ≡ Y
+  fin-suc-injective refl = refl
+
+alignedᴿ? : ∀ {Δᴿ Δ} (ηᴿ : Δᴿ ↪ᵗ Δ) (Z : TyVar Δ)
+  → Dec (Σ[ Xᴿ ∈ TyVar Δᴿ ] toRenameᵗ ηᴿ Xᴿ ≡ Z)
+alignedᴿ? empty Z = no λ { (() , eq) }
+alignedᴿ? (keep ηᴿ) Fin.zero = yes (Fin.zero , refl)
+alignedᴿ? (keep ηᴿ) (Fin.suc Z) with alignedᴿ? ηᴿ Z
+alignedᴿ? (keep ηᴿ) (Fin.suc Z) | yes (Xᴿ , eq) =
+  yes (Fin.suc Xᴿ , cong Fin.suc eq)
+alignedᴿ? (keep ηᴿ) (Fin.suc Z) | no unaligned =
+  no λ
+    { (Fin.zero , ())
+    ; (Fin.suc Xᴿ , eq) → unaligned (Xᴿ , fin-suc-injective eq)
+    }
+alignedᴿ? (skip ηᴿ) Fin.zero = no λ { (Xᴿ , ()) }
+alignedᴿ? (skip ηᴿ) (Fin.suc Z) with alignedᴿ? ηᴿ Z
+alignedᴿ? (skip ηᴿ) (Fin.suc Z) | yes (Xᴿ , eq) =
+  yes (Xᴿ , cong Fin.suc eq)
+alignedᴿ? (skip ηᴿ) (Fin.suc Z) | no unaligned =
+  no λ { (Xᴿ , eq) → unaligned (Xᴿ , fin-suc-injective eq) }
+
+honestEnv : ∀ {Δᴿ Δ} → (Δᴿ ↪ᵗ Δ) → ImpEnv Δ → ImpEnv Δ
+honestEnv ηᴿ μ Z with alignedᴿ? ηᴿ Z
+honestEnv ηᴿ μ Z | yes aligned = μ Z
+honestEnv ηᴿ μ Z | no unaligned = X⊑★
+
+honestify : ∀ {Δᴸ Δᴿ Δ}
+  → World Δᴸ Δᴿ Δ
+  → World Δᴸ Δᴿ Δ
+honestify W =
+  CTI2.world (CTI2.ηᴸʷ W) (CTI2.ηᴿʷ W)
+    (honestEnv (CTI2.ηᴿʷ W) (CTI2.impEnvʷ W))
+    (CTI2.sourceStoreʷ W) (CTI2.targetStoreʷ W)
+
+private
+  honestEnv-mono : ∀ {Δᴿ Δ} (ηᴿ : Δᴿ ↪ᵗ Δ)
+      (μ : ImpEnv Δ) (Z : TyVar Δ)
+    → μ Z ≡ X⊑★
+    → honestEnv ηᴿ μ Z ≡ X⊑★
+  honestEnv-mono ηᴿ μ Z eq with alignedᴿ? ηᴿ Z
+  honestEnv-mono ηᴿ μ Z eq | yes aligned = eq
+  honestEnv-mono ηᴿ μ Z eq | no unaligned = refl
+
+honestify-decay : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+  → EnvDecay W (honestify W)
+honestify-decay {W = W} =
+  env-decay refl refl refl refl
+    (honestEnv-mono (CTI2.ηᴿʷ W) (CTI2.impEnvʷ W))
+
+honestify-WF : ∀ {Δᴸ Δᴿ Δ} (W : World Δᴸ Δᴿ Δ)
+  → CTI2.WFWorld (honestify W)
+honestify-WF W Xᴸ precise
+    with alignedᴿ? (CTI2.ηᴿʷ W)
+           (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)
+honestify-WF W Xᴸ precise | yes (Xᴿ , aligned) = Xᴿ , aligned
+honestify-WF W Xᴸ () | no unaligned

--- a/GTSFImp/proof/DGG/WorldSupport.agda
+++ b/GTSFImp/proof/DGG/WorldSupport.agda
@@ -1,0 +1,210 @@
+module proof.DGG.WorldSupport where
+
+-- File Charter:
+--   * Provides stage 1 of the world-support lemma from Rationale.md.
+--   * Defines syntactic type-variable support for types and cast terms.
+--   * Transports type-imprecision and store-representation obligations.
+--   * Leaves derivation-level world transport to a later stage.
+
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; cong; cong₂; sym; trans; subst)
+
+open import Types
+open import Consistency using (Env∼; _⊢_∼_; toRenameᵗ)
+open import Conversion using (Conv↑; Conv↓)
+open import CastTerms using
+  (Term; `_ ; ƛ_; _·_; Λ_; _⦂∀_[_]; $; _⊕[_]_; _⟨_⟩; _↑_; _↓_;
+   blame)
+open import Imprecision
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; _⊑ᵂ⟨_⟩_; StoreRepImp; store-rep-imp; resolveVar; embedᴸ;
+   embedᴿ)
+open import proof.DGG.WorldDecay using (⊑-env-mono)
+
+------------------------------------------------------------------------
+-- Type support
+------------------------------------------------------------------------
+
+renameᵗ-support : ∀ {Δ Δ′} {ρ₁ ρ₂ : TyVar Δ → TyVar Δ′}
+  → (A : Ty Δ)
+  → (∀ X → X ∈ᵗ A → ρ₁ X ≡ ρ₂ X)
+  → renameᵗ ρ₁ A ≡ renameᵗ ρ₂ A
+renameᵗ-support (＇ X) agree = cong ＇_ (agree X var-∈)
+renameᵗ-support (‵ ι) agree = refl
+renameᵗ-support ★ agree = refl
+renameᵗ-support {ρ₁ = ρ₁} {ρ₂} (A ⇒ B) agree =
+  cong₂ _⇒_ (renameᵗ-support A agree-A) (renameᵗ-support B agree-B)
+  where
+  agree-A : ∀ X → X ∈ᵗ A → ρ₁ X ≡ ρ₂ X
+  agree-A X X∈A = agree X (∈-fun-left X∈A)
+
+  agree-B : ∀ X → X ∈ᵗ B → ρ₁ X ≡ ρ₂ X
+  agree-B X X∈B with occurs? X A
+  agree-B X X∈B | present X∈A = agree X (∈-fun-left X∈A)
+  agree-B X X∈B | absent X∉A =
+    agree X (∈-fun-right X∉A X∈B)
+renameᵗ-support {ρ₁ = ρ₁} {ρ₂} (`∀ A) agree =
+  cong `∀ (renameᵗ-support A agree-ext)
+  where
+  agree-ext : ∀ X → X ∈ᵗ A → extᵗ ρ₁ X ≡ extᵗ ρ₂ X
+  agree-ext Fin.zero X∈A = refl
+  agree-ext (Fin.suc X) X∈A =
+    cong Fin.suc (agree X (∈-all X∈A))
+
+------------------------------------------------------------------------
+-- Cast-term support
+------------------------------------------------------------------------
+
+infix 5 _∈ᵗᵐ_
+
+data _∈ᵗᵐ_ {Δ : TyCtx} : TyVar Δ → Term Δ → Set where
+  ∈ᵗᵐ-ƛ : ∀ {X M}
+    → X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (ƛ M)
+
+  ∈ᵗᵐ-·-left : ∀ {X L M}
+    → X ∈ᵗᵐ L
+    → X ∈ᵗᵐ (L · M)
+
+  ∈ᵗᵐ-·-right : ∀ {X L M}
+    → X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (L · M)
+
+  ∈ᵗᵐ-Λ : ∀ {X M}
+    → Fin.suc X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (Λ M)
+
+  ∈ᵗᵐ-•-term : ∀ {X L C A}
+    → X ∈ᵗᵐ L
+    → X ∈ᵗᵐ (L ⦂∀ C [ A ])
+
+  ∈ᵗᵐ-•-body : ∀ {X L C A}
+    → Fin.suc X ∈ᵗ C
+    → X ∈ᵗᵐ (L ⦂∀ C [ A ])
+
+  ∈ᵗᵐ-•-argument : ∀ {X L C A}
+    → X ∈ᵗ A
+    → X ∈ᵗᵐ (L ⦂∀ C [ A ])
+
+  ∈ᵗᵐ-⊕-left : ∀ {X L op M}
+    → X ∈ᵗᵐ L
+    → X ∈ᵗᵐ (L ⊕[ op ] M)
+
+  ∈ᵗᵐ-⊕-right : ∀ {X L op M}
+    → X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (L ⊕[ op ] M)
+
+  ∈ᵗᵐ-cast-term : ∀ {X M} {μ : Env∼ Δ} {A B}
+      {c : μ ⊢ A ∼ B}
+    → X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (M ⟨ c ⟩)
+
+  ∈ᵗᵐ-cast-source : ∀ {X M} {μ : Env∼ Δ} {A B}
+      {c : μ ⊢ A ∼ B}
+    → X ∈ᵗ A
+    → X ∈ᵗᵐ (M ⟨ c ⟩)
+
+  ∈ᵗᵐ-cast-target : ∀ {X M} {μ : Env∼ Δ} {A B}
+      {c : μ ⊢ A ∼ B}
+    → X ∈ᵗ B
+    → X ∈ᵗᵐ (M ⟨ c ⟩)
+
+  ∈ᵗᵐ-reveal-term : ∀ {X M A B} {c : Conv↑ Δ A B}
+    → X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (M ↑ c)
+
+  ∈ᵗᵐ-reveal-source : ∀ {X M A B} {c : Conv↑ Δ A B}
+    → X ∈ᵗ A
+    → X ∈ᵗᵐ (M ↑ c)
+
+  ∈ᵗᵐ-reveal-target : ∀ {X M A B} {c : Conv↑ Δ A B}
+    → X ∈ᵗ B
+    → X ∈ᵗᵐ (M ↑ c)
+
+  ∈ᵗᵐ-conceal-term : ∀ {X M A B} {c : Conv↓ Δ A B}
+    → X ∈ᵗᵐ M
+    → X ∈ᵗᵐ (M ↓ c)
+
+  ∈ᵗᵐ-conceal-source : ∀ {X M A B} {c : Conv↓ Δ A B}
+    → X ∈ᵗ A
+    → X ∈ᵗᵐ (M ↓ c)
+
+  ∈ᵗᵐ-conceal-target : ∀ {X M A B} {c : Conv↓ Δ A B}
+    → X ∈ᵗ B
+    → X ∈ᵗᵐ (M ↓ c)
+
+------------------------------------------------------------------------
+-- Agreement between worlds on selected supports
+------------------------------------------------------------------------
+
+record WorldAgree {Δᴸ Δᴿ Δ}
+    (P : TyVar Δᴸ → Set) (Q : TyVar Δᴿ → Set)
+    (Wa Wb : World Δᴸ Δᴿ Δ) : Set where
+  constructor world-agree
+  field
+    sameSrcStore : CTI2.sourceStoreʷ Wa ≡ CTI2.sourceStoreʷ Wb
+    sameTgtStore : CTI2.targetStoreʷ Wa ≡ CTI2.targetStoreʷ Wb
+    sameMarks : ∀ Z → CTI2.impEnvʷ Wa Z ≡ CTI2.impEnvʷ Wb Z
+    agreeᴸ : ∀ X → P X
+      → toRenameᵗ (CTI2.ηᴸʷ Wa) X ≡ toRenameᵗ (CTI2.ηᴸʷ Wb) X
+    agreeᴿ : ∀ Y → Q Y
+      → toRenameᵗ (CTI2.ηᴿʷ Wa) Y ≡ toRenameᵗ (CTI2.ηᴿʷ Wb) Y
+
+open WorldAgree public
+
+------------------------------------------------------------------------
+-- Obligation and store-representation transport
+------------------------------------------------------------------------
+
+⊑ᵂ-support : ∀ {Δᴸ Δᴿ Δ} {Wa Wb : World Δᴸ Δᴿ Δ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {P Q}
+  → WorldAgree P Q Wa Wb
+  → (∀ X → X ∈ᵗ A → P X)
+  → (∀ Y → Y ∈ᵗ B → Q Y)
+  → A ⊑ᵂ⟨ Wa ⟩ B
+  → A ⊑ᵂ⟨ Wb ⟩ B
+⊑ᵂ-support {Wa = Wa} {Wb} {A} {B} agree supportᴸ supportᴿ p =
+  subst (λ A′ → CTI2.impEnvʷ Wb ⊢ A′ ⊑ embedᴿ Wb B) left-eq
+    (subst (λ B′ → CTI2.impEnvʷ Wb ⊢ embedᴸ Wa A ⊑ B′) right-eq
+      (⊑-env-mono mark-mono p))
+  where
+  left-eq : embedᴸ Wa A ≡ embedᴸ Wb A
+  left-eq = renameᵗ-support A λ X X∈A →
+    agreeᴸ agree X (supportᴸ X X∈A)
+
+  right-eq : embedᴿ Wa B ≡ embedᴿ Wb B
+  right-eq = renameᵗ-support B λ Y Y∈B →
+    agreeᴿ agree Y (supportᴿ Y Y∈B)
+
+  mark-mono : ∀ Z
+    → CTI2.impEnvʷ Wa Z ≡ X⊑★
+    → CTI2.impEnvʷ Wb Z ≡ X⊑★
+  mark-mono Z eq = trans (sym (sameMarks agree Z)) eq
+
+storeRep-support : ∀ {Δᴸ Δᴿ Δ} {Wa Wb : World Δᴸ Δᴿ Δ}
+    {P : TyVar Δᴸ → Set} {Q : TyVar Δᴿ → Set} {Xᴸ Xᴿ}
+  → WorldAgree P Q Wa Wb
+  → (∀ X → X ∈ᵗ resolveVar (CTI2.sourceStoreʷ Wa) Xᴸ → P X)
+  → (∀ Y → Y ∈ᵗ resolveVar (CTI2.targetStoreʷ Wa) Xᴿ → Q Y)
+  → StoreRepImp Wa Xᴸ Xᴿ
+  → StoreRepImp Wb Xᴸ Xᴿ
+storeRep-support {Wa = Wa} {Wb} {Xᴸ = Xᴸ} {Xᴿ} agree
+    supportᴸ supportᴿ (store-rep-imp represented) =
+  store-rep-imp
+    (subst
+      (λ A → A ⊑ᵂ⟨ Wb ⟩ resolveVar (CTI2.targetStoreʷ Wb) Xᴿ)
+      source-eq
+      (subst (λ B → resolveVar (CTI2.sourceStoreʷ Wa) Xᴸ
+          ⊑ᵂ⟨ Wb ⟩ B)
+        target-eq
+        (⊑ᵂ-support agree supportᴸ supportᴿ represented)))
+  where
+  source-eq : resolveVar (CTI2.sourceStoreʷ Wa) Xᴸ
+    ≡ resolveVar (CTI2.sourceStoreʷ Wb) Xᴸ
+  source-eq = cong (λ Σ → resolveVar Σ Xᴸ) (sameSrcStore agree)
+
+  target-eq : resolveVar (CTI2.targetStoreʷ Wa) Xᴿ
+    ≡ resolveVar (CTI2.targetStoreʷ Wb) Xᴿ
+  target-eq = cong (λ Σ → resolveVar Σ Xᴿ) (sameTgtStore agree)


### PR DESCRIPTION
## Summary

A redesign-and-verify arc for GTSFImp's version-2 cast-term imprecision (the Issue 117 relation) driven by the extra-cast-right lemma:

- **RebaseAt tightening**: pivot-local world rebasing with canonical `resolveVar` store representations, Maybe-indexed conversion pivots, the left-only `Λ⊑²` rule, and — probe-driven — the **moved-pivot anchoring invariant** (`anchorᴿ`: a relocated target pivot must land aligned with a source variable).
- **Mark decay + WFWorld**: rule-level `ImpEnvMono` with the mark-honesty invariant, landed with the checked counterexample-turned-regression.
- **Right-injection inversion** (`ExtraCastRight2`): proved for **all value spines** — constants, lambdas, type abstractions, inert casts, function- and ∀-shaped wrappers (via `TagTransport`), and bare seals (`sv-seal`), threading `WFWorld` by honestified decay.
- **Seal-transfer** (`SealTransfer`): the bare-seal boundary lemma with an existential output world returning a rebase link — the interface change that closed the tag-boundary gap without an invariant.
- **Probe methodology**: each design obstruction was adjudicated by a mechanized probe before any fix — `MovedLinkProbe` (gap → anchoring invariant), `TagBoundaryProbe` (gap → existential interface), `ChainRideProbe` (positive → chain-ride construction), `SealPeelProbe` (link-per-node rebuilds), plus the `Λ⊑²` probe and the original counterexample regression.
- **World-support toolkit**: occurrence/agreement machinery (`WorldSupport`), center functoriality `⊢²-rename-center` (`CenterRename`), pure re-parking `⊢²-repark` (`Repark`).
- **`blame⊑²`**: source blame relates to any well-typed target term (left = more static).
- Repairs the pre-existing `CompilePreservesImprecision` breakage so `All.agda` checks.

## Open items — the honest ledger

**Extra-cast-right itself is NOT yet proven.** `ExtraCastRight²`/`InstCatchupRight²` are stage-1 statements; proven so far are the direct cases (`inert-extra-cast-right²`, `id-extra-cast-right²`) and the hard core, `right-inj-inversion²`, complete over all value spines modulo explicitly-named hypotheses threaded as arguments:

- `OpenStrata` in ExtraCastRight2: **H-walk** (left-spine heads above a seal), **H-absorb** (interior moved the tag variable's source), **H-Schain** (target store chains);
- **H-multi** in SealTransfer (multi-move source chains — `ChainRideProbe` shows its instances dischargeable; the general lemma is staged).

Still to prove on top of the inversion: the consuming cases (tag-untag/projection steps) and the allocating cases (`inst`/`gen` with `WorldExtendᴿ`/`rightOnlyWorld`), plus a module-cycle cleanup (`SpineValue` to its own module).

**Hand-off plan with full detail: #123.**

## Verification

Every `proof/DGG` file and `GTSFImp/All.agda` type-check with `agda -v0` from fresh state; no postulates or holes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)