### PR TITLE
GTSFImp: FunExt consolidation, contravariant function consistency, All.agda charter

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -1,21 +1,29 @@
 module All where
 
-import Types
-import TyStore
-import TermCtx
-import Consistency
-import Consistency2
-import ConsistencyExamples
-import Conversion
-import Imprecision
-import Primitives
-import GradualTerms
-import GradualTermImprecision
-import CastTerms
-import Compile
-import Reduction
-import Eval
-import Example
+-- File Charter:
+--   * Type-checking this module type-checks the whole development.
+--   * Import policy: list the TOP-LEVEL modules only — the finished
+--     baseline metatheory, the finished major lemmas (their public
+--     Lemma/theorem modules), and the current proof frontier. Helper
+--     modules (Def/Proof internals, Support files, workers) are
+--     checked transitively and are deliberately NOT listed here.
+--   * Leaf gates: files that nothing imports (probes, example suites,
+--     catalogs, counterexample records, and checked-but-unconsumed
+--     libraries) must be listed in the "Leaf gates" section below or
+--     they silently leave the gate.
+--   * FunExt is listed explicitly to keep the development's single
+--     axiom visible.
+
+------------------------------------------------------------------------
+-- Axiom base
+------------------------------------------------------------------------
+
+import FunExt
+
+------------------------------------------------------------------------
+-- Baseline metatheory (finished)
+------------------------------------------------------------------------
+
 import proof.TypeSafety.Progress
 import proof.TypeSafety.Preservation
 import proof.ImprecisionConsistency
@@ -23,36 +31,47 @@ import proof.Imprecision
 import proof.Consistency
 import proof.Consistency2
 import proof.Reduction
-import proof.DGG.OneStep
-import proof.DGG.ExampleTerms
-import proof.DGG.Elab
+
+------------------------------------------------------------------------
+-- Major lemmas (finished)
+------------------------------------------------------------------------
+
 import proof.DGG.CompilePreservesImprecision2
-import proof.DGG.Inversion.SpineValueDef
-import proof.DGG.Inversion.RightInjInversion2Def
-import proof.DGG.Inversion.TargetWalkDef
-import proof.DGG.Inversion.TargetWalkSupport
-import proof.DGG.Inversion.SourceStripDef
-import proof.DGG.Inversion.SourceStripProof
-import proof.DGG.Inversion.SourceStripLemma
-import proof.DGG.Inversion.TargetChainProof
-import proof.DGG.Inversion.TargetChainLemma
-import proof.DGG.Inversion.TargetWalkProof
-import proof.DGG.Inversion.TargetWalkLemma
-import proof.DGG.Inversion.RightInjInversion2Proof
 import proof.DGG.Inversion.RightInjInversion2Lemma
-import proof.DGG.Inversion.TargetDescentDef
-import proof.DGG.Inversion.TargetDescentLemma
+import proof.DGG.Parked.ParkedWorldLemma
+import proof.DGG.Parked.ParkedD4CheckpointLemma
+
+------------------------------------------------------------------------
+-- Current frontier (M4/M5: catch-up lemmas, higher-order)
+------------------------------------------------------------------------
+
+import proof.DGG.Catchup.ExtraCastRightProof
+import proof.DGG.Catchup.InstCatchupRightProof
+
+------------------------------------------------------------------------
+-- Leaf gates: nothing imports these; listed so they stay checked
+------------------------------------------------------------------------
+
+-- Example suites and catalogs
+import Example
+import ConsistencyExamples
+import proof.DGG.ReachabilityCatalog
+import proof.DGG.CompileImageShape
+import proof.DGG.Phase3DeepDives
+import proof.DGG.GroundCastTargetExamples
+
+-- Probes and counterexample records (design decisions, kept checked)
 import proof.DGG.SourceStarProbe
 import proof.DGG.CenterCrossingProbe
 import proof.DGG.TerminusRebuildProbe
 import proof.DGG.StarRepChainProbe
-import proof.DGG.ReachabilityScreen
-import proof.DGG.ReachabilityCatalog
-import proof.DGG.CompileImageShape
-import proof.DGG.Phase3DeepDives
-import proof.DGG.Parked.ParkedWorldDef
-import proof.DGG.Parked.ParkedWorldProof
-import proof.DGG.Parked.ParkedWorldLemma
-import proof.DGG.Parked.ParkedD4CheckpointDef
-import proof.DGG.Parked.ParkedD4CheckpointProof
-import proof.DGG.Parked.ParkedD4CheckpointLemma
+import proof.DGG.SealPeelProbe
+import proof.DGG.LambdaImpProbe
+import proof.DGG.MovedLinkProbe
+import proof.DGG.ChainRideProbe
+import proof.DGG.TagBoundaryProbe
+import proof.DGG.ExtraCastRight2Counterexample
+
+-- Checked libraries currently without consumers (candidates for M7+)
+import proof.DGG.CenterRename
+import proof.DGG.WorldSupport

--- a/GTSFImp/CastTerms.agda
+++ b/GTSFImp/CastTerms.agda
@@ -62,7 +62,7 @@ private
 data GenSafe : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
     → μ ⊢ A ∼ B → Set where
   safe-⇒ : ∀ {Δ μ} {A A′ B B′ : Ty Δ}
-      {c : μ ⊢ A ∼ A′} {d : μ ⊢ B ∼ B′}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
     → GenSafe (c ↦ d)
 
   safe-∀ : ∀ {Δ μ} {A B : Ty (suc Δ)}
@@ -90,7 +90,7 @@ data Inert : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
     → Inert {μ = μ} ((idᵍ {μ = μ} Gᵍ) !)
 
   fun : ∀ {Δ} {μ : Env∼ Δ} {A A′ B B′ : Ty Δ}
-      {c : μ ⊢ A ∼ A′} {d : μ ⊢ B ∼ B′}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
     → Inert (c ↦ d)
 
   all : ∀ {Δ} {μ : Env∼ Δ} {A B : Ty (suc Δ)}

--- a/GTSFImp/Consistency.agda
+++ b/GTSFImp/Consistency.agda
@@ -6,8 +6,6 @@ module Consistency where
 --   * Provides renaming and substitution for consistency evidence.
 --   * Closes instantiation-bound consistency evidence at ★.
 
-open import Axiom.Extensionality.Propositional using (Extensionality)
-open import Level using (0ℓ)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Nat using (zero; suc)
 open import Data.Fin using (zero; suc)
@@ -16,6 +14,7 @@ open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (no; yes)
 
 open import Types
+open import FunExt using (funext)
 
 private
   variable
@@ -30,6 +29,25 @@ flipVar∼ : Var∼ → Var∼
 flipVar∼ X∼X = X∼X
 flipVar∼ X∼★ = ★∼X
 flipVar∼ ★∼X = X∼★
+
+flipVar∼-involutive : ∀ v → flipVar∼ (flipVar∼ v) ≡ v
+flipVar∼-involutive X∼X = refl
+flipVar∼-involutive X∼★ = refl
+flipVar∼-involutive ★∼X = refl
+
+flipVar∼-to-X∼★ : ∀ {v}
+  → flipVar∼ v ≡ X∼★
+  → v ≡ ★∼X
+flipVar∼-to-X∼★ {X∼X} ()
+flipVar∼-to-X∼★ {X∼★} ()
+flipVar∼-to-X∼★ {★∼X} refl = refl
+
+flipVar∼-to-★∼X : ∀ {v}
+  → flipVar∼ v ≡ ★∼X
+  → v ≡ X∼★
+flipVar∼-to-★∼X {X∼X} ()
+flipVar∼-to-★∼X {X∼★} refl = refl
+flipVar∼-to-★∼X {★∼X} ()
 
 Env∼ : TyCtx → Set
 Env∼ Δ = TyVar Δ → Var∼
@@ -51,6 +69,9 @@ genᵐ μ (suc X) = μ X
 
 flipᵐ : Env∼ Δ → Env∼ Δ
 flipᵐ μ X = flipVar∼ (μ X)
+
+flipᵐ-involutive : ∀ {Δ} {μ : Env∼ Δ} → flipᵐ (flipᵐ μ) ≡ μ
+flipᵐ-involutive = funext λ X → flipVar∼-involutive _
 
 ----------------------------------------------------------------------
 -- Consistency
@@ -121,7 +142,7 @@ data _⊢_∼_ {Δ : TyCtx} (μ : Env∼ Δ) :
     → μ ⊢ A ∼ A
 
   _↦_ : ∀ {A A′ B B′}
-    → μ ⊢ A ∼ A′
+    → flipᵐ μ ⊢ A′ ∼ A
     → μ ⊢ B ∼ B′
       ---------------------------
     → μ ⊢ (A ⇒ B) ∼ (A′ ⇒ B′)
@@ -226,9 +247,6 @@ flip-★∼ (★∼Xᵍ eq) = X∼★ᵍ (cong flipVar∼ eq)
 flip-★∼ ★∼∀ = ∀∼★
 
 private
-  postulate
-    funext : Extensionality 0ℓ 0ℓ
-
   flip-extᵐ : ∀ {Δ} {μ : Env∼ Δ}
     → flipᵐ (extᵐ μ) ≡ extᵐ (flipᵐ μ)
   flip-extᵐ = funext λ { zero → refl; (suc X) → refl }
@@ -365,6 +383,12 @@ private
     ★∼Xᵍ (trans (eq X) eq-X)
   rename★∼ ρ eq ★∼∀ = ★∼∀
 
+  flip-rename-env : ∀ {Δ Δ′} {μ : Env∼ Δ} {μ′ : Env∼ Δ′}
+    → (ρ : Δ ⇒ʳ Δ′)
+    → (∀ X → μ′ (ρ X) ≡ μ X)
+    → ∀ X → flipᵐ μ′ (ρ X) ≡ flipᵐ μ X
+  flip-rename-env ρ eq X = cong flipVar∼ (eq X)
+
   rename∼ : ∀ {Δ Δ′} {μ : Env∼ Δ} {μ′ : Env∼ Δ′}
       {A B : Ty Δ}
     → (ρ : Δ ⇒ʳ Δ′)
@@ -374,8 +398,10 @@ private
   rename∼ ρ eq (id ★) = id ★
   rename∼ ρ eq (id (‵ ι)) = id (‵ ι)
   rename∼ ρ eq (id (＇ X)) = id (＇ (ρ X))
-  rename∼ ρ eq (A∼A′ ↦ B∼B′) =
-    rename∼ ρ eq A∼A′ ↦ rename∼ ρ eq B∼B′
+  rename∼ {μ = μ} {μ′ = μ′} ρ eq (A∼A′ ↦ B∼B′) =
+    rename∼ {μ = flipᵐ μ} {μ′ = flipᵐ μ′} ρ
+      (flip-rename-env {μ = μ} {μ′ = μ′} ρ eq) A∼A′ ↦
+    rename∼ {μ = μ} {μ′ = μ′} ρ eq B∼B′
   rename∼ ρ eq (∀ᶜ A∼B) =
     ∀ᶜ (rename∼ (extᵗ ρ) (extᵐ-rename ρ eq) A∼B)
   rename∼ {μ = μ} {μ′ = μ′} ρ eq
@@ -605,6 +631,27 @@ private
       ？_ ⦃ ★∼G = ★∼Xᵍ refl ⦄ (id (＇ zero))
     from-★′ (suc X) eq =
       rename∼ suc (λ Y → refl) (from-★ X eq)
+
+  flip-SubstEnv∼ : ∀ {Δ Δ′} {μ : Env∼ Δ} {ν : Env∼ Δ′}
+      {σ : Δ ⇒ˢ Δ′}
+    → SubstEnv∼ μ ν σ
+    → SubstEnv∼ (flipᵐ μ) (flipᵐ ν) σ
+  flip-SubstEnv∼ {μ = μ} {ν = ν} {σ = σ}
+      (subst-env∼ self to-★ from-★) =
+    subst-env∼ self′ to-★′ from-★′
+    where
+    self′ : ∀ X → flipᵐ ν ⊢ σ X ∼ σ X
+    self′ X = sym∼ (self X)
+
+    to-★′ : ∀ X
+      → flipᵐ μ X ≡ X∼★
+      → flipᵐ ν ⊢ σ X ∼ ★
+    to-★′ X eq = sym∼ (from-★ X (flipVar∼-to-X∼★ eq))
+
+    from-★′ : ∀ X
+      → flipᵐ μ X ≡ ★∼X
+      → flipᵐ ν ⊢ ★ ∼ σ X
+    from-★′ X eq = sym∼ (to-★ X (flipVar∼-to-★∼X eq))
 
   subst-∈ᵗ : ∀ {Δ Δ′} {σ : Δ ⇒ˢ Δ′} {X : TyVar Δ}
       {Y : TyVar Δ′} {A : Ty Δ}
@@ -854,7 +901,7 @@ subst∼ : ∀ {Δ Δ′} {μ : Env∼ Δ} {ν : Env∼ Δ′}
 subst∼ s (id ★) = id ★
 subst∼ s (id (‵ ι)) = id (‵ ι)
 subst∼ s (id (＇ X)) = self s X
-subst∼ s (c ↦ d) = subst∼ s c ↦ subst∼ s d
+subst∼ s (c ↦ d) = subst∼ (flip-SubstEnv∼ s) c ↦ subst∼ s d
 subst∼ s (∀ᶜ c) = ∀ᶜ (subst∼ (ext-SubstEnv∼ s) c)
 subst∼ {σ = σ} s (_! ⦃ Gᵍ = ★⇒★ ⦄ c ⦃ Ans ⦄) =
   _! ⦃ Gᵍ = ★⇒★ ⦄ (subst∼ s c)

--- a/GTSFImp/Consistency2.agda
+++ b/GTSFImp/Consistency2.agda
@@ -16,7 +16,7 @@ import Data.Nat as Nat
 import Data.Nat.Induction as NatInduction
 open import Data.Nat.Properties using
   (+-mono-≤; +-monoʳ-≤; +-suc; m≤m+n; m≤n+m; n<1+n;
-   n≤1+n; ≤-<-trans)
+   n≤1+n; +-comm; ≤-<-trans)
 open import Induction.WellFounded using (Acc; acc)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; inspect; [_])
@@ -206,12 +206,12 @@ nothing orElse y = y
 
 arrow-lower : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
     {A A′ B B′ : Ty Δ}
-  → Maybe (Lower φ ψ A A′)
+  → Maybe (Lower ψ φ A′ A)
   → Maybe (Lower φ ψ B B′)
   → Maybe (Lower φ ψ (A ⇒ B) (A′ ⇒ B′))
 arrow-lower nothing right = nothing
 arrow-lower (just left) nothing = nothing
-arrow-lower (just (lower C C⊑A C⊑A′))
+arrow-lower (just (lower C C⊑A′ C⊑A))
     (just (lower D D⊑B D⊑B′)) =
   just (lower (C ⇒ D) (I.⇒⊑⇒ C⊑A D⊑B)
                          (I.⇒⊑⇒ C⊑A′ D⊑B′))
@@ -305,6 +305,12 @@ arrow-left-size A B A′ B′ =
       (+-monoʳ-≤ (size A + size B)
         (n≤1+n (size A′ + size B′)))
 
+arrow-left-size-swapped : ∀ {Δ} (A B A′ B′ : Ty Δ)
+  → size A′ + size A < size (A ⇒ B) + size (A′ ⇒ B′)
+arrow-left-size-swapped A B A′ B′
+    rewrite +-comm (size A′) (size A) =
+  arrow-left-size A B A′ B′
+
 arrow-right-size : ∀ {Δ} (A B A′ B′ : Ty Δ)
   → size B + size B′ < size (A ⇒ B) + size (A′ ⇒ B′)
 arrow-right-size A B A′ B′ =
@@ -360,7 +366,8 @@ lowerAcc φ ψ (‵ ι) (‵ .ι) access | yes refl =
 lowerAcc φ ψ (‵ ι) (‵ ι′) access | no ι≠ι′ = nothing
 lowerAcc φ ψ (A ⇒ B) (A′ ⇒ B′) (acc smaller) =
   arrow-lower
-    (lowerAcc φ ψ A A′ (smaller (arrow-left-size A B A′ B′)))
+    (lowerAcc ψ φ A′ A
+      (smaller (arrow-left-size-swapped A B A′ B′)))
     (lowerAcc φ ψ B B′ (smaller (arrow-right-size A B A′ B′)))
 lowerAcc φ ψ (`∀ A) (`∀ B) (acc smaller) =
   all-lower

--- a/GTSFImp/ConsistencyExamples.agda
+++ b/GTSFImp/ConsistencyExamples.agda
@@ -4,8 +4,6 @@ module ConsistencyExamples where
 --   * Catalogs derivations of consistency for a closed polymorphic type.
 --   * Makes the constructor choices in each derivation explicit.
 
-open import Axiom.Extensionality.Propositional using (Extensionality)
-open import Level using (0ℓ)
 open import Data.Nat using (zero; suc)
 open import Data.Fin using (zero; suc)
 open import Relation.Binary.PropositionalEquality
@@ -29,44 +27,45 @@ all-all =
   ∀ᶜ (∀ᶜ (id (＇ 1) ↦ id (＇ 0) ↦ id (＇ 1)))
 
 ------------------------------------------------------------------------
--- (∀ X. ∀ Y. X ⇒ Y ⇒ X) ∼ (∀ X. X ⇒ ★ ⇒ X)
+-- (∀ X. ∀ Y. X ⇒ X ⇒ Y) ∼ (∀ X. X ⇒ X ⇒ ★)
 ------------------------------------------------------------------------
 
 -- This is the only constructor-distinct derivation.  The outer X binders
 -- must be paired by ∀ᶜ, after which inst relates the remaining Y to ★.
 instance
-  Y∈X⇒Y⇒X-instance :
-    _∈ᵗ_ {Δ = 2} 0 (＇ 1 ⇒ ＇ 0 ⇒ ＇ 1)
-  Y∈X⇒Y⇒X-instance =
-    ∈-fun-right (∉-var (λ ())) (∈-fun-left var-∈)
+  Y∈X⇒X⇒Y-instance :
+    _∈ᵗ_ {Δ = 2} 0 (＇ 1 ⇒ ＇ 1 ⇒ ＇ 0)
+  Y∈X⇒X⇒Y-instance =
+    ∈-fun-right (∉-var (λ ()))
+      (∈-fun-right (∉-var (λ ())) var-∈)
 
 all-all∼all-star :
   _∼_ {Δ = 0}
-    (`∀ (`∀ (＇ 1 ⇒ ＇ 0 ⇒ ＇ 1)))
-    (`∀ (＇ 0 ⇒ ★ ⇒ ＇ 0))
+    (`∀ (`∀ (＇ 1 ⇒ ＇ 1 ⇒ ＇ 0)))
+    (`∀ (＇ 0 ⇒ ＇ 0 ⇒ ★))
 all-all∼all-star =
   ∀ᶜ
-    ((inst (id (＇ 1) ↦ (id (＇ 0) !) ↦ id (＇ 1))) (λ ()))
+    ((inst (id (＇ 1) ↦ id (＇ 1) ↦ (id (＇ 0) !))) (λ ()))
 
 ------------------------------------------------------------------------
--- (∀ X. X ⇒ X) ∼ ★
+-- (∀ X. ★ ⇒ X) ∼ ★
 ------------------------------------------------------------------------
 
 -- The side conditions on inst and ∈-fun-right leave one derivation: inst
--- targets ★ ⇒ ★ and the occurrence premise selects the domain X.
+-- targets ★ ⇒ ★ and the occurrence premise selects the codomain X.
 
-module XOccursLeft where
+module XOccursRight where
 
   private
     instance
-      X∈X⇒X-left-instance :
-        _∈ᵗ_ {Δ = 1} 0 (＇ 0 ⇒ ＇ 0)
-      X∈X⇒X-left-instance = ∈-fun-left var-∈
+      X∈★⇒X-right-instance :
+        _∈ᵗ_ {Δ = 1} 0 (★ ⇒ ＇ 0)
+      X∈★⇒X-right-instance = ∈-fun-right ∉-star var-∈
 
   tag-after-inst :
-    _∼_ {Δ = 0} (`∀ (＇ 0 ⇒ ＇ 0)) ★
+    _∼_ {Δ = 0} (`∀ (★ ⇒ ＇ 0)) ★
   tag-after-inst =
-    ((inst ((id (＇ 0) !) ↦ (id (＇ 0) !))) (λ ())) !
+    ((inst (id ★ ↦ (id (＇ 0) !))) (λ ())) !
 
 ------------------------------------------------------------------------
 -- (∀ X. X) ∼ ★  and  ★ ∼ (∀ X. X)

--- a/GTSFImp/Eval.agda
+++ b/GTSFImp/Eval.agda
@@ -116,7 +116,7 @@ app-redex? (Λ vL) vM = nothing
 app-redex? ($ κ) vM = nothing
 app-redex? (vL 《 inj 》) vM = nothing
 app-redex? (vL 《 fun 》) vM =
-  just (pure-result (β-⇒ vL vM refl))
+  just (pure-result (β-⇒ vL vM))
 app-redex? (vL 《 all 》) vM = nothing
 app-redex? (vL 《 genᵥ A≠★ safe 》) vM = nothing
 app-redex? (vL ↑ fun) vM =

--- a/GTSFImp/Example.agda
+++ b/GTSFImp/Example.agda
@@ -131,8 +131,11 @@ botFromStarExample-⊢ =
 X! : instᵐ (idᶜ {Δ = 0}) ⊢ ＇ 0 ∼ ★
 X! = id (＇ 0) !
 
+?X-inst-domain : flipᵐ (instᵐ (idᶜ {Δ = 0})) ⊢ ★ ∼ ＇ 0
+?X-inst-domain = ？ (id (＇ 0))
+
 instId : (`∀ X⇒X) ∼ (★ ⇒ ★)
-instId = (inst (X! ↦ X!)) (λ ())
+instId = (inst (?X-inst-domain ↦ X!)) (λ ())
 
 instExample : Term 0
 instExample =
@@ -151,8 +154,11 @@ instExample-⊢ =
 ?X : genᵐ (idᶜ {Δ = 0}) ⊢ ★ ∼ ＇ 0
 ?X = ？ (id (＇ 0))
 
+X!-gen-domain : flipᵐ (genᵐ (idᶜ {Δ = 0})) ⊢ ＇ 0 ∼ ★
+X!-gen-domain = id (＇ 0) !
+
 genId : (★ ⇒ ★) ∼ (`∀ X⇒X)
-genId = (gen (?X ↦ ?X)) (λ ())
+genId = (gen (X!-gen-domain ↦ ?X)) (λ ())
 
 genExample : Term 0
 genExample =
@@ -190,8 +196,15 @@ instance
 ?Y₂ : genᵐ (genᵐ (idᶜ {Δ = 0})) ⊢ ★ ∼ ＇ 0
 ?Y₂ = ？ (id (＇ 0))
 
+X!₂-domain : flipᵐ (genᵐ (genᵐ (idᶜ {Δ = 0}))) ⊢ ＇ 1 ∼ ★
+X!₂-domain = id (＇ 1) !
+
+Y!₂-domain : flipᵐ (genᵐ (genᵐ (idᶜ {Δ = 0}))) ⊢ ＇ 0 ∼ ★
+Y!₂-domain = id (＇ 0) !
+
 genFirst : (★ ⇒ ★ ⇒ ★) ∼ `∀ polyFirstBody
-genFirst = (gen ((gen (?X₂ ↦ ?Y₂ ↦ ?X₂)) (λ ()))) (λ ())
+genFirst =
+  (gen ((gen (X!₂-domain ↦ Y!₂-domain ↦ ?X₂)) (λ ()))) (λ ())
 
 second★ : Term 0
 second★ = ƛ (ƛ (` 0))

--- a/GTSFImp/FunExt.agda
+++ b/GTSFImp/FunExt.agda
@@ -1,0 +1,14 @@
+module FunExt where
+
+-- File Charter:
+--   * Centralizes the sole function-extensionality assumption for GTSFImp.
+--   * Exports `funext` for proof infrastructure that compares environments
+--     and predicates extensionally.
+--   * Depends only on the standard library's propositional extensionality
+--     interface.
+
+open import Axiom.Extensionality.Propositional using (Extensionality)
+open import Level using (0ℓ)
+
+postulate
+  funext : Extensionality 0ℓ 0ℓ

--- a/GTSFImp/Reduction.agda
+++ b/GTSFImp/Reduction.agda
@@ -160,13 +160,12 @@ data _—→_ {Δ : TyCtx} : Term Δ → Term Δ → Set where
     → V ⟨ id {μ = μ} a ⟩ —→ V
 
   β-⇒ : ∀ {V W : Term Δ} {μ : Env∼ Δ}
-      {A A′ B B′ : Ty Δ} {c : μ ⊢ A ∼ A′}
-      {c′ : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
+      {A A′ B B′ : Ty Δ}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
     → Value V
     → Value W
-    → c′ ≡ sym∼ c
       --------------------------------------------
-    → (V ⟨ c ↦ d ⟩) · W —→ (V · (W ⟨ c′ ⟩)) ⟨ d ⟩
+    → (V ⟨ c ↦ d ⟩) · W —→ (V · (W ⟨ c ⟩)) ⟨ d ⟩
 
   β-∀ : ∀ {V : Term Δ} {μ : Env∼ Δ}
       {A B : Ty (Nat.suc Δ)} {C : Ty Δ}

--- a/GTSFImp/proof/Consistency2.agda
+++ b/GTSFImp/proof/Consistency2.agda
@@ -27,7 +27,8 @@ import Imprecision as I
 open import proof.ImprecisionConsistency
   using (LowerEnv; VarLower; both-to-star; common-lower-consistent;
          extend-lower-env; identity-lower-env; instantiate-left-lower-env;
-         instantiate-right-lower-env; source-nonvar-from-target;
+         instantiate-right-lower-env; flip-lower-env;
+         source-nonvar-from-target;
          target-occurs-source; shift-occurs; unshift-occurs; var-from-star;
          var-refl; var-to-star)
 
@@ -74,7 +75,7 @@ four-fourth nothing nothing nothing (just x) is-just = is-just
 
 arrow-lower-success : ∀ {Δ} {φ ψ : I.ImpEnv Δ}
     {A A′ B B′ : Ty Δ}
-    {left : Maybe (Lower φ ψ A A′)}
+    {left : Maybe (Lower ψ φ A′ A)}
     {right : Maybe (Lower φ ψ B B′)}
   → IsJust left
   → IsJust right
@@ -224,42 +225,6 @@ ground-occurs-to-star C.ι∼★ ()
 ground-occurs-to-star (C.X∼★ᵍ eq) var-∈ = eq
 ground-occurs-to-star C.∀∼★ (∈-all ())
 
-source-occurs-target-safe : ∀ {Δ} {μ : C.Env∼ Δ}
-    {X : TyVar Δ} {A B : Ty Δ}
-  → μ X ≢ C.X∼★
-  → C._⊢_∼_ μ A B
-  → X ∈ᵗ A
-  → X ∈ᵗ B
-source-occurs-target-safe not-star (C.id a) X∈A = X∈A
-source-occurs-target-safe not-star (c C.↦ d) (∈-fun-left X∈A) =
-  ∈-fun-left (source-occurs-target-safe not-star c X∈A)
-source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
-    (c C.↦ d) (∈-fun-right X∉A X∈B) with occurs? X A′
-source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
-    (c C.↦ d) (∈-fun-right X∉A X∈B) | present X∈A′ =
-  ∈-fun-left X∈A′
-source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
-    (c C.↦ d) (∈-fun-right X∉A X∈B) | absent X∉A′ =
-  ∈-fun-right X∉A′ (source-occurs-target-safe not-star d X∈B)
-source-occurs-target-safe {X = X} not-star (C.∀ᶜ c)
-    (∈-all X∈A) =
-  ∈-all (source-occurs-target-safe {X = suc X} not-star c X∈A)
-source-occurs-target-safe not-star
-    (C._! ⦃ G∼★ = G∼★ ⦄ c ⦃ Ans ⦄) X∈A =
-  ⊥-elim (not-star (ground-occurs-to-star G∼★
-    (source-occurs-target-safe not-star c X∈A)))
-source-occurs-target-safe not-star (C.？_ c) ()
-source-occurs-target-safe {X = X} not-star
-    (C.inst_ c B≢★) (∈-all X∈A) =
-  unshift-occurs
-    (source-occurs-target-safe {X = suc X} not-star c X∈A)
-source-occurs-target-safe {X = X} not-star
-    (C.gen_ c A≢★) X∈A =
-  ∈-all (source-occurs-target-safe {X = suc X} not-star c
-    (shift-occurs X∈A))
-source-occurs-target-safe not-star C.bot-elim (∈-all ())
-source-occurs-target-safe not-star C.bot-intro (∈-all ())
-
 star-no-occurs : ∀ {Δ} {X : TyVar Δ} → X ∈ᵗ ★ → ⊥
 star-no-occurs ()
 
@@ -274,41 +239,96 @@ ground-occurs-from-star C.★∼ι ()
 ground-occurs-from-star (C.★∼Xᵍ eq) var-∈ = eq
 ground-occurs-from-star C.★∼∀ (∈-all ())
 
-target-occurs-source-safe : ∀ {Δ} {μ : C.Env∼ Δ}
-    {X : TyVar Δ} {A B : Ty Δ}
+flip-not-from-star : ∀ {Δ} {μ : C.Env∼ Δ} {X : TyVar Δ}
+  → μ X ≢ C.X∼★
+  → C.flipᵐ μ X ≢ C.★∼X
+flip-not-from-star not-star eq =
+  not-star (C.flipVar∼-to-★∼X eq)
+
+flip-not-to-star : ∀ {Δ} {μ : C.Env∼ Δ} {X : TyVar Δ}
   → μ X ≢ C.★∼X
-  → C._⊢_∼_ μ A B
-  → X ∈ᵗ B
-  → X ∈ᵗ A
-target-occurs-source-safe not-star (C.id a) X∈B = X∈B
-target-occurs-source-safe not-star (c C.↦ d) (∈-fun-left X∈A) =
-  ∈-fun-left (target-occurs-source-safe not-star c X∈A)
-target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
-    (c C.↦ d) (∈-fun-right X∉A′ X∈B′) with occurs? X A
-target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
-    (c C.↦ d) (∈-fun-right X∉A′ X∈B′) | present X∈A =
-  ∈-fun-left X∈A
-target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
-    (c C.↦ d) (∈-fun-right X∉A′ X∈B′) | absent X∉A =
-  ∈-fun-right X∉A (target-occurs-source-safe not-star d X∈B′)
-target-occurs-source-safe {X = X} not-star (C.∀ᶜ c)
-    (∈-all X∈B) =
-  ∈-all (target-occurs-source-safe {X = suc X} not-star c X∈B)
-target-occurs-source-safe not-star (C._! c) ()
-target-occurs-source-safe not-star
-    (C.？_ ⦃ ★∼G = ★∼G ⦄ c) X∈B =
-  ⊥-elim (not-star (ground-occurs-from-star ★∼G
-    (target-occurs-source-safe not-star c X∈B)))
-target-occurs-source-safe {X = X} not-star
-    (C.inst_ c B≢★) X∈B =
-  ∈-all (target-occurs-source-safe {X = suc X} not-star c
-    (shift-occurs X∈B))
-target-occurs-source-safe {X = X} not-star
-    (C.gen_ c A≢★) (∈-all X∈B) =
-  unshift-occurs
-    (target-occurs-source-safe {X = suc X} not-star c X∈B)
-target-occurs-source-safe not-star C.bot-elim (∈-all ())
-target-occurs-source-safe not-star C.bot-intro (∈-all ())
+  → C.flipᵐ μ X ≢ C.X∼★
+flip-not-to-star not-star eq =
+  not-star (C.flipVar∼-to-X∼★ eq)
+
+mutual
+  source-occurs-target-safe : ∀ {Δ} {μ : C.Env∼ Δ}
+      {X : TyVar Δ} {A B : Ty Δ}
+    → μ X ≢ C.X∼★
+    → C._⊢_∼_ μ A B
+    → X ∈ᵗ A
+    → X ∈ᵗ B
+  source-occurs-target-safe not-star (C.id a) X∈A = X∈A
+  source-occurs-target-safe {μ = μ} {X = X} not-star
+      (c C.↦ d) (∈-fun-left X∈A) =
+    ∈-fun-left
+      (target-occurs-source-safe {μ = C.flipᵐ μ} {X = X}
+        (flip-not-from-star {μ = μ} {X = X} not-star) c X∈A)
+  source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
+      (c C.↦ d) (∈-fun-right X∉A X∈B) with occurs? X A′
+  source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
+      (c C.↦ d) (∈-fun-right X∉A X∈B) | present X∈A′ =
+    ∈-fun-left X∈A′
+  source-occurs-target-safe {X = X} {B = A′ ⇒ B′} not-star
+      (c C.↦ d) (∈-fun-right X∉A X∈B) | absent X∉A′ =
+    ∈-fun-right X∉A′ (source-occurs-target-safe not-star d X∈B)
+  source-occurs-target-safe {X = X} not-star (C.∀ᶜ c)
+      (∈-all X∈A) =
+    ∈-all (source-occurs-target-safe {X = suc X} not-star c X∈A)
+  source-occurs-target-safe not-star
+      (C._! ⦃ G∼★ = G∼★ ⦄ c ⦃ Ans ⦄) X∈A =
+    ⊥-elim (not-star (ground-occurs-to-star G∼★
+      (source-occurs-target-safe not-star c X∈A)))
+  source-occurs-target-safe not-star (C.？_ c) ()
+  source-occurs-target-safe {X = X} not-star
+      (C.inst_ c B≢★) (∈-all X∈A) =
+    unshift-occurs
+      (source-occurs-target-safe {X = suc X} not-star c X∈A)
+  source-occurs-target-safe {X = X} not-star
+      (C.gen_ c A≢★) X∈A =
+    ∈-all (source-occurs-target-safe {X = suc X} not-star c
+      (shift-occurs X∈A))
+  source-occurs-target-safe not-star C.bot-elim (∈-all ())
+  source-occurs-target-safe not-star C.bot-intro (∈-all ())
+
+  target-occurs-source-safe : ∀ {Δ} {μ : C.Env∼ Δ}
+      {X : TyVar Δ} {A B : Ty Δ}
+    → μ X ≢ C.★∼X
+    → C._⊢_∼_ μ A B
+    → X ∈ᵗ B
+    → X ∈ᵗ A
+  target-occurs-source-safe not-star (C.id a) X∈B = X∈B
+  target-occurs-source-safe {μ = μ} {X = X} not-star
+      (c C.↦ d) (∈-fun-left X∈A) =
+    ∈-fun-left
+      (source-occurs-target-safe {μ = C.flipᵐ μ} {X = X}
+        (flip-not-to-star {μ = μ} {X = X} not-star) c X∈A)
+  target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
+      (c C.↦ d) (∈-fun-right X∉A′ X∈B′) with occurs? X A
+  target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
+      (c C.↦ d) (∈-fun-right X∉A′ X∈B′) | present X∈A =
+    ∈-fun-left X∈A
+  target-occurs-source-safe {X = X} {A = A ⇒ B} not-star
+      (c C.↦ d) (∈-fun-right X∉A′ X∈B′) | absent X∉A =
+    ∈-fun-right X∉A (target-occurs-source-safe not-star d X∈B′)
+  target-occurs-source-safe {X = X} not-star (C.∀ᶜ c)
+      (∈-all X∈B) =
+    ∈-all (target-occurs-source-safe {X = suc X} not-star c X∈B)
+  target-occurs-source-safe not-star (C._! c) ()
+  target-occurs-source-safe not-star
+      (C.？_ ⦃ ★∼G = ★∼G ⦄ c) X∈B =
+    ⊥-elim (not-star (ground-occurs-from-star ★∼G
+      (target-occurs-source-safe not-star c X∈B)))
+  target-occurs-source-safe {X = X} not-star
+      (C.inst_ c B≢★) X∈B =
+    ∈-all (target-occurs-source-safe {X = suc X} not-star c
+      (shift-occurs X∈B))
+  target-occurs-source-safe {X = X} not-star
+      (C.gen_ c A≢★) (∈-all X∈B) =
+    unshift-occurs
+      (target-occurs-source-safe {X = suc X} not-star c X∈B)
+  target-occurs-source-safe not-star C.bot-elim (∈-all ())
+  target-occurs-source-safe not-star C.bot-intro (∈-all ())
 
 right-dynamic-at : ∀ {r : C.Var∼} {l u : I.VarImp}
   → VarLower r l u
@@ -437,8 +457,8 @@ lowerAcc-complete h (C.id (＇ X)) access | no X≠X = ⊥-elim (X≠X refl)
 lowerAcc-complete {A = A ⇒ B} {B = A′ ⇒ B′} h
     (c C.↦ d) (acc smaller) =
   arrow-lower-success
-    (lowerAcc-complete h c
-      (smaller (arrow-left-size A B A′ B′)))
+    (lowerAcc-complete (flip-lower-env h) c
+      (smaller (arrow-left-size-swapped A B A′ B′)))
     (lowerAcc-complete h d
       (smaller (arrow-right-size A B A′ B′)))
 lowerAcc-complete {φ = φ} {ψ = ψ} {A = `∀ A} {B = `∀ B} h

--- a/GTSFImp/proof/DGG/Catchup/ExtraCastRightProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/ExtraCastRightProof.agda
@@ -150,7 +150,7 @@ module _
     → W ∣ γ ⊢² M ⊑ M′ ∶ p
     → Value M
     → (vM′ : Value M′)
-    → (c : ν ⊢ B ∼ B′)
+    → (c : C.flipᵐ ν ⊢ B′ ∼ B)
     → (d : ν ⊢ C ∼ C′)
     → (q : A ⊑ᵂ⟨ W ⟩ (B′ ⇒ C′))
     → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χs ∈ StoreChanges Δᴿ Δᴿ′ ]

--- a/GTSFImp/proof/DGG/ExampleTerms.agda
+++ b/GTSFImp/proof/DGG/ExampleTerms.agda
@@ -60,11 +60,17 @@ X! = id (＇ 0) !
 X? : genᵐ (idᶜ {Δ = 0}) ⊢ ★ ∼ ＇ 0
 X? = ？ (id (＇ 0))
 
+X?-inst-domain : flipᵐ (instᵐ (idᶜ {Δ = 0})) ⊢ ★ ∼ ＇ 0
+X?-inst-domain = ？ (id (＇ 0))
+
+X!-gen-domain : flipᵐ (genᵐ (idᶜ {Δ = 0})) ⊢ ＇ 0 ∼ ★
+X!-gen-domain = id (＇ 0) !
+
 ν̅α-α♯→α♭ : (`∀ X⇒X) ∼ (★ ⇒ ★)
-ν̅α-α♯→α♭ = (inst (X! ↦ X!)) (λ ())
+ν̅α-α♯→α♭ = (inst (X?-inst-domain ↦ X!)) (λ ())
 
 να-α!→α? : (★ ⇒ ★) ∼ (`∀ X⇒X)
-να-α!→α? = (gen (X? ↦ X?)) (λ ())
+να-α!→α? = (gen (X!-gen-domain ↦ X?)) (λ ())
 
 ------------------------------------------------------------------------
 -- Cambridge26 Example 12: up and then down
@@ -106,11 +112,10 @@ right₀ : Term 0
 right₀ =
   ((((Λ (ƛ (` 0)))
     ⟨ (inst_ {μ = idᶜ {Δ = 0}} ⦃ z∈A = ∈-fun-left var-∈ ⦄
-        ((id {μ = instᵐ (idᶜ {Δ = 0})} (＇ 0) !) ↦
-         (id {μ = instᵐ (idᶜ {Δ = 0})} (＇ 0) !))
+        (X?-inst-domain ↦ X!)
         (λ ())) ⟩)
     ⟨ (gen_ {μ = idᶜ {Δ = 0}} ⦃ z∈B = ∈-fun-left var-∈ ⦄
-        ((？ (id (＇ 0))) ↦ (？ (id (＇ 0)))) (λ ())) ⟩)
+        (X!-gen-domain ↦ X?) (λ ())) ⟩)
     ⦂∀ (＇ 0 ⇒ ＇ 0) [ ‵ `ℕ ]) · $ (κℕ 7)
 
 right-store₀ : TyStore 0
@@ -124,10 +129,14 @@ right₁ : Term (Δ′ right-step₀)
 right₁ =
   ((((Λ (ƛ (` 0))) ⦂∀ (＇ 0 ⇒ ＇ 0) [ ＇ 0 ])
       ↑ (seal 0 ★ ↦↑ unseal 0 ★)
-      ⟨ id {μ = renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})} ★ ↦ id ★ ⟩
+      ⟨ id {μ = flipᵐ (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))} ★ ↦
+        id {μ = renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})} ★ ⟩
       ⟨ (gen_ {μ = extᵐ (idᶜ {Δ = 0})}
           ⦃ z∈B = ∈-fun-left var-∈ ⦄
-          ((？ (id (＇ 0))) ↦ (？ (id (＇ 0)))) (λ ())) ⟩)
+          ((id {μ = flipᵐ (genᵐ (extᵐ (idᶜ {Δ = 0})))} (＇ 0) !)
+            ↦
+           (？_ {μ = genᵐ (extᵐ (idᶜ {Δ = 0}))} (id (＇ 0))))
+          (λ ())) ⟩)
     ⦂∀ (＇ 0 ⇒ ＇ 0) [ ‵ `ℕ ]) · $ (κℕ 7)
 
 right-store₁ : TyStore (Δ′ right-step₀)
@@ -142,11 +151,17 @@ right₂ =
   (((((ƛ (` 0))
     ↑ (seal 0 (＇ 1) ↦↑ unseal 0 (＇ 1)))
     ↑ (seal 1 ★ ↦↑ unseal 1 ★))
-    ⟨ id {μ = applyEnv (bind (＇ 0))
-        (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))} ★ ↦ id ★ ⟩)
+    ⟨ id {μ = flipᵐ (applyEnv (bind (＇ 0))
+        (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ↦
+      id {μ = applyEnv (bind (＇ 0))
+        (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))} ★ ⟩)
     ⟨ (gen_ {μ = extᵐ (extᵐ (idᶜ {Δ = 0}))}
         ⦃ z∈B = ∈-fun-left var-∈ ⦄
-        ((？ (id (＇ 0))) ↦ (？ (id (＇ 0)))) (λ ())) ⟩
+        ((id {μ = flipᵐ (genᵐ (extᵐ (extᵐ (idᶜ {Δ = 0}))))}
+            (＇ 0) !)
+          ↦
+         (？_ {μ = genᵐ (extᵐ (extᵐ (idᶜ {Δ = 0})))} (id (＇ 0))))
+        (λ ())) ⟩
     ⦂∀ (＇ 0 ⇒ ＇ 0) [ ‵ `ℕ ]) · $ (κℕ 7)
 
 right-store₂ : TyStore (Δ′ right-step₁)
@@ -161,13 +176,16 @@ right₃ =
   ((((((ƛ (` 0))
     ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
     ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    ⟨ id {μ = renameEnv∼ wk↪ᵗ
+    ⟨ id {μ = flipᵐ (renameEnv∼ wk↪ᵗ
         (applyEnv (bind (＇ 0))
-          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ↦ id ★ ⟩)
-    ⟨ (？_ {μ = genᵐ
+          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))))} ★ ↦
+      id {μ = renameEnv∼ wk↪ᵗ
+        (applyEnv (bind (＇ 0))
+          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ⟩)
+    ⟨ (id {μ = flipᵐ (genᵐ
           (applyEnv (bind (＇ 0))
-            (applyEnv (bind ★) (idᶜ {Δ = 0})))}
-        (id (＇ 0)))
+            (applyEnv (bind ★) (idᶜ {Δ = 0}))))}
+        (＇ 0) !)
       ↦ (？_ {μ = genᵐ
           (applyEnv (bind (＇ 0))
             (applyEnv (bind ★) (idᶜ {Δ = 0})))}
@@ -187,13 +205,16 @@ right₄ =
   (((((ƛ (` 0))
     ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
     ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    ⟨ id {μ = renameEnv∼ wk↪ᵗ
+    ⟨ id {μ = flipᵐ (renameEnv∼ wk↪ᵗ
         (applyEnv (bind (＇ 0))
-          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ↦ id ★ ⟩)
-    ⟨ (？_ {μ = genᵐ
+          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))))} ★ ↦
+      id {μ = renameEnv∼ wk↪ᵗ
+        (applyEnv (bind (＇ 0))
+          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ⟩)
+    ⟨ (id {μ = flipᵐ (genᵐ
           (applyEnv (bind (＇ 0))
-            (applyEnv (bind ★) (idᶜ {Δ = 0})))}
-        (id (＇ 0)))
+            (applyEnv (bind ★) (idᶜ {Δ = 0}))))}
+        (＇ 0) !)
       ↦ (？_ {μ = genᵐ
           (applyEnv (bind (＇ 0))
             (applyEnv (bind ★) (idᶜ {Δ = 0})))}
@@ -213,9 +234,12 @@ right₅ =
   (((((ƛ (` 0))
     ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
     ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    ⟨ id {μ = renameEnv∼ wk↪ᵗ
+    ⟨ id {μ = flipᵐ (renameEnv∼ wk↪ᵗ
         (applyEnv (bind (＇ 0))
-          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ↦ id ★ ⟩)
+          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))))} ★ ↦
+      id {μ = renameEnv∼ wk↪ᵗ
+        (applyEnv (bind (＇ 0))
+          (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))} ★ ⟩)
     · (($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
       ⟨ id {μ = flipᵐ (genᵐ
           (applyEnv (bind (＇ 0))
@@ -468,122 +492,37 @@ right-changes =
 
 example12-right-reduction : example12-right —↠[ right-changes ] right-final
 example12-right-reduction =
-  ((((Λ (ƛ (` 0)))
-    ⟨ ((inst ((id (＇ 0) !) ↦ (id (＇ 0) !))) (λ ())) ⟩)
-    ⟨ ((gen ((？ (id (＇ 0))) ↦ (？ (id (＇ 0))))) (λ ())) ⟩)
-    ⦂∀ (＇ 0 ⇒ ＇ 0) [ ‵ `ℕ ]) · $ (κℕ 7)
+  right₀
   —→[ bind ★ ]⟨ reduction right-step₀ ⟩
-  ((((Λ (ƛ (` 0))) ⦂∀ (＇ 0 ⇒ ＇ 0) [ ＇ 0 ])
-      ↑ (seal 0 ★ ↦↑ unseal 0 ★)
-      ⟨ id ★ ↦ id ★ ⟩
-      ⟨ ((gen ((？ (id (＇ 0))) ↦ (？ (id (＇ 0))))) (λ ())) ⟩)
-    ⦂∀ (＇ 0 ⇒ ＇ 0) [ ‵ `ℕ ]) · $ (κℕ 7)
+  right₁
   —→[ bind (＇ 0) ]⟨ reduction right-step₁ ⟩
-  (((((ƛ (` 0))
-    ↑ (seal 0 (＇ 1) ↦↑ unseal 0 (＇ 1)))
-    ↑ (seal 1 ★ ↦↑ unseal 1 ★))
-    ⟨ id ★ ↦ id ★ ⟩)
-    ⟨ ((gen ((？ (id (＇ 0))) ↦ (？ (id (＇ 0))))) (λ ())) ⟩
-    ⦂∀ (＇ 0 ⇒ ＇ 0) [ ‵ `ℕ ]) · $ (κℕ 7)
+  right₂
   —→[ bind (‵ `ℕ) ]⟨ reduction right-step₂ ⟩
-  ((((((ƛ (` 0))
-    ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
-    ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    ⟨ id ★ ↦ id ★ ⟩)
-    ⟨ (？ (id (＇ 0))) ↦ (？ (id (＇ 0))) ⟩)
-    ↑ (seal 0 (‵ `ℕ) ↦↑ unseal 0 (‵ `ℕ)))
-    · $ (κℕ 7)
+  right₃
   —→[ keep ]⟨ reduction right-step₃ ⟩
-  (((((ƛ (` 0))
-    ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
-    ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    ⟨ id ★ ↦ id ★ ⟩)
-    ⟨ (？ (id (＇ 0))) ↦ (？ (id (＇ 0))) ⟩)
-    · ($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-  ↑ unseal 0 (‵ `ℕ)
+  right₄
   —→[ keep ]⟨ reduction right-step₄ ⟩
-  (((((ƛ (` 0))
-    ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
-    ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    ⟨ id ★ ↦ id ★ ⟩)
-    · (($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-      ⟨ id (＇ 0) ! ⟩))
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₅
   —→[ keep ]⟨ reduction right-step₅ ⟩
-  (((((ƛ (` 0))
-    ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
-    ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    · ((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-      ⟨ id (＇ 0) ! ⟩)
-      ⟨ id ★ ⟩))
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₆
   —→[ keep ]⟨ reduction right-step₆ ⟩
-  (((((ƛ (` 0))
-    ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
-    ↑ (seal 2 ★ ↦↑ unseal 2 ★))
-    · (($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-      ⟨ id (＇ 0) ! ⟩))
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₇
   —→[ keep ]⟨ reduction right-step₇ ⟩
-  (((((ƛ (` 0))
-    ↑ (seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)))
-    · ((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-      ⟨ id (＇ 0) ! ⟩)
-      ↓ seal 2 ★))
-    ↑ unseal 2 ★)
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₈
   —→[ keep ]⟨ reduction right-step₈ ⟩
-  (((((ƛ (` 0))
-    · (((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-      ⟨ id (＇ 0) ! ⟩)
-      ↓ seal 2 ★)
-      ↓ seal 1 (＇ 2)))
-    ↑ unseal 1 (＇ 2))
-    ↑ unseal 2 ★)
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₉
   —→[ keep ]⟨ reduction right-step₉ ⟩
-  ((((((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-    ⟨ id (＇ 0) ! ⟩)
-    ↓ seal 2 ★)
-    ↓ seal 1 (＇ 2))
-    ↑ unseal 1 (＇ 2))
-    ↑ unseal 2 ★)
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₁₀
   —→[ keep ]⟨ reduction right-step₁₀ ⟩
-  ((((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-    ⟨ id (＇ 0) ! ⟩)
-    ↓ seal 2 ★)
-    ↑ unseal 2 ★)
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩
-  ↑ unseal 0 (‵ `ℕ)
+  right₁₁
   —→[ keep ]⟨ reduction right-step₁₁ ⟩
-  (((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-    ⟨ id (＇ 0) ! ⟩)
-    ⟨ id ★ ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩)
-  ↑ unseal 0 (‵ `ℕ)
+  right₁₂
   —→[ keep ]⟨ reduction right-step₁₂ ⟩
-  ((($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-    ⟨ id (＇ 0) ! ⟩)
-    ⟨ ？ (id (＇ 0)) ⟩)
-  ↑ unseal 0 (‵ `ℕ)
+  right₁₃
   —→[ keep ]⟨ reduction right-step₁₃ ⟩
-  ($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
-  ↑ unseal 0 (‵ `ℕ)
+  right₁₄
   —→[ keep ]⟨ reduction right-step₁₄ ⟩
-  $ (κℕ 7) ∎[]
+  right-final ∎[]
 
 ------------------------------------------------------------------------
 -- Left program: ordinary polymorphic identity instantiated at ℕ

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -462,7 +462,16 @@ example12-target-X?↦X? :
       (applyEnv (bind ★) (idᶜ {Δ = 0})))
     ⊢ (★ ⇒ ★) ∼ (＇ Fin.zero ⇒ ＇ Fin.zero)
 example12-target-X?↦X? =
-  ？ (id (＇ Fin.zero)) ↦ ？ (id (＇ Fin.zero))
+  (id {μ = C.flipᵐ
+      (genᵐ
+        (applyEnv (bind (＇ Fin.zero))
+          (applyEnv (bind ★) (idᶜ {Δ = 0}))))}
+    (＇ Fin.zero) !) ↦
+  ？_ {μ =
+      genᵐ
+        (applyEnv (bind (＇ Fin.zero))
+          (applyEnv (bind ★) (idᶜ {Δ = 0})))}
+    (id (＇ Fin.zero))
 
 example12-target-X! :
   C.flipᵐ
@@ -1339,7 +1348,7 @@ left-path-id★↦id★₁-source = id ★ ↦ id ★
 left-path-id★↦id★₁-target :
   renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}) ⊢ (★ ⇒ ★) ∼ (★ ⇒ ★)
 left-path-id★↦id★₁-target =
-  C.↑ᶜ C.close-instᶜ (Ex.X! ↦ Ex.X!)
+  C.↑ᶜ C.close-instᶜ (Ex.X?-inst-domain ↦ Ex.X!)
 
 left-path-id★↦id★₂-source :
   applyEnv (bind (＇ Fin.zero)) (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))
@@ -1362,14 +1371,25 @@ left-path-gen₁ :
   C.extᵐ (idᶜ {Δ = 0}) ⊢ (★ ⇒ ★) ∼ `∀ left-path-X⇒X₁
 left-path-gen₁ =
   gen_ ⦃ z∈B = ∈-fun-left var-∈ ⦄
-    ((？ (id (＇ Fin.zero))) ↦ (？ (id (＇ Fin.zero)))) (λ ())
+    ((id {μ = C.flipᵐ (genᵐ (C.extᵐ (idᶜ {Δ = 0})))}
+        (＇ Fin.zero) !)
+      ↦
+     (？_ {μ = genᵐ (C.extᵐ (idᶜ {Δ = 0}))}
+        (id (＇ Fin.zero))))
+    (λ ())
 
 left-path-gen₂ :
   C.extᵐ (C.extᵐ (idᶜ {Δ = 0})) ⊢ (★ ⇒ ★) ∼
     `∀ left-path-X⇒X₂
 left-path-gen₂ =
   gen_ ⦃ z∈B = ∈-fun-left var-∈ ⦄
-    ((？ (id (＇ Fin.zero))) ↦ (？ (id (＇ Fin.zero)))) (λ ())
+    ((id {μ = C.flipᵐ
+        (genᵐ (C.extᵐ (C.extᵐ (idᶜ {Δ = 0}))))}
+        (＇ Fin.zero) !)
+      ↦
+     (？_ {μ = genᵐ (C.extᵐ (C.extᵐ (idᶜ {Δ = 0})))}
+        (id (＇ Fin.zero))))
+    (λ ())
 
 left-path-reveal★₁ : Conv↑ 1 (＇ Fin.zero ⇒ ＇ Fin.zero) (★ ⇒ ★)
 left-path-reveal★₁ = seal Fin.zero ★ ↦↑ unseal Fin.zero ★

--- a/GTSFImp/proof/DGG/GroundCastTargetExamples.agda
+++ b/GTSFImp/proof/DGG/GroundCastTargetExamples.agda
@@ -30,7 +30,7 @@ fun-ground-target =
   IC.ground-cast-target⊑ {Δ = 0} {μ = I.idᵐ} {ν = C.idᶜ}
     {A = ‵ `ℕ ⇒ ‵ `𝔹} {B = ‵ `ℕ ⇒ ‵ `𝔹} {G = ★ ⇒ ★}
     ★⇒★ nonstar-⇒
-    (C._↦_ (C._! (C.id (‵ `ℕ))) (C._! (C.id (‵ `𝔹))))
+    (C._↦_ (C.？ (C.id (‵ `ℕ))) (C._! (C.id (‵ `𝔹))))
     (I.⇒⊑⇒ I.ι⊑ι I.ι⊑ι)
     (I.⇒⊑★ I.ι⊑★ I.ι⊑★)
 
@@ -70,7 +70,7 @@ forall-closed-body-to-universal-ground-target =
   IC.ground-cast-target⊑ {Δ = 0} {μ = I.idᵐ} {ν = C.idᶜ}
     {A = `∀ (‵ `ℕ ⇒ ★)} {B = `∀ (‵ `ℕ ⇒ ★)} {G = `∀ ★}
     ∀★ nonstar-∀
-    (C.∀ᶜ (C._! (C._↦_ (C._! (C.id (‵ `ℕ))) (C.id ★))))
+    (C.∀ᶜ (C._! (C._↦_ (C.？ (C.id (‵ `ℕ))) (C.id ★))))
     (I.∀⊑∀ (I.⇒⊑⇒ I.ι⊑ι I.★⊑★))
     (I.∀⊑★ nonstar-⇒
       (I.⇒⊑★ I.ι⊑★ I.★⊑★))
@@ -95,7 +95,11 @@ inst-consistency-to-fun-ground-target =
     {G = ★ ⇒ ★}
     ★⇒★ nonstar-∀
     (C.inst_ ⦃ Anv = nonvar-fun ⦄ ⦃ z∈A = ∈-fun-left var-∈ ⦄
-      (C._↦_ (C._! (C.id (＇ zero))) (C.id ★)) (λ ()))
+      (C._↦_
+        (C.？_ {μ = C.flipᵐ (C.instᵐ (C.idᶜ {Δ = 0}))}
+          (C.id (＇ zero)))
+        (C.id ★))
+      (λ ()))
     (I.∀⊑∀ (I.⇒⊑⇒ I.X⊑X I.★⊑★))
     (I.∀⊑ nonvar-fun (∈-fun-left var-∈)
       (I.⇒⊑★ (I.X⊑★ refl) I.★⊑★))
@@ -108,7 +112,10 @@ no-star-counterexample-consistency :
   C._⊢_∼_ (C.instᵐ (C.idᶜ {Δ = 0}))
     (＇ zero ⇒ ＇ zero) (★ ⇒ ★)
 no-star-counterexample-consistency =
-  C._↦_ (C._! (C.id (＇ zero))) (C._! (C.id (＇ zero)))
+  C._↦_
+    (C.？_ {μ = C.flipᵐ (C.instᵐ (C.idᶜ {Δ = 0}))}
+      (C.id (＇ zero)))
+    (C._! (C.id (＇ zero)))
 
 no-star-counterexample-imprecision :
   I._⊢_⊑_ (I.idᵐ {Δ = 1})

--- a/GTSFImp/proof/DGG/PLAN.md
+++ b/GTSFImp/proof/DGG/PLAN.md
@@ -70,9 +70,9 @@ New modules live under `proof/DGG/Parked/`.
 |---|-----------|------|--------|--------|
 | M1 | Parked foundation (see PLAN history) | S | **landed** (pe-left amendment queued) | a0897ec |
 | M2 | Asymmetric rebase redesign: `ηᴿ-frozen` replaces `ηᴿ-off-pivot`+`anchorᴿ` (deleted); Repark.agda deleted; left-path checkpoints rebuilt frozen; target-moving probes now negative design records. All gates passed (compile² unchanged; net −1501 lines) | L | **landed** | 1ce5afd |
-| M3 | HANDOFF: four postulates (TargetStrip★/ᴸ, two fold workers) with frozen validated statements, user working on target-strip-at★ interactively (36eefb2); source-tag-seal-core PROVEN; everything else green. Was: New inversion under the frozen relation. Landed so far: statement with NO OpenStrata/WFWorld/ParkedWorld premise + SpineValueDef extraction + **H-multi deleted** (seal-transfer unconditional) (`309d8a3`); **TargetDescent complete** — terminal ★ package via same-pivot composition (replaces H-absorb's moved-split) + variable-payload re-emission continuation (`ebd6f6a`). The tag-peel-first route (incl. the hand-off's original H-walk plan) is REFUTED (right-var-obligation-view vs NonVar); the correct terminus-rebuild construction is validated concretely in TerminusRebuildProbe (`3bed622`, both blocked cases constructible). In flight: generalizing the probe template to close all OpenStrata sites, then delete OpenStrata + old inversion | L | **in progress** (final leg) | 309d8a3, ebd6f6a, 3bed622 |
-| M4 | COMPLETE as higher-order theorem: extra-cast-right² with CatchupCast provenance (q-hunt invariant), original value conclusion, mismatch excluded by construction; stitch Lemma pending the walk inhabitant | M | **landed (higher-order)** | see log |
-| M5 | `InstCatchupRight²` allocating cases (Catchup/InstCatchupRight*; per-view workers over AllValueView; right-only bind extension) | M | **in progress** | — |
+| M3 | **COMPLETE** (2026-08-10, `6d42b15`, merged in PR #124): `right-inj-inversion²` live in Inversion/RightInjInversion2Lemma, zero postulates in the stack, All.agda green. Closed via the tightening migration (premise-world partner predicates, partner-flow inversion, see-through round-trip clause, tied conceal indices — see the "M3 COMPLETE" section below and notes/). | L | **landed** | 6d42b15 |
+| M4 | COMPLETE as higher-order theorem: extra-cast-right² with CatchupCast provenance (q-hunt invariant), original value conclusion, mismatch excluded by construction. Inversion now live (M3) — stitch Lemma instantiation is unblocked and pending | M | **landed (higher-order)** | see log |
+| M5 | `InstCatchupRight²` operational half COMPLETE (Catchup/InstCatchupRight{Def,Proof}); relational continuations remain, sequenced with the M6 driver | M | **half landed** | — |
 | M6 | Value catch-up driver: ties the M4↔M5 MUTUAL knot (M5 continuations call back into ExtraCastRight²) by well-founded recursion on the target cast-column length; both Proofs stay higher-order over each other's Defs | M | not started (knot design fixed by M5 finding) | — |
 | M7 | `sim-right²`: one-step simulation, per-case over the reduction relation, consuming M4–M6 | L | not started | — |
 | M8 | `dgg-simulation` top-level corollary; cleanup: dead-code removal, probe housekeeping (`SpineValue` extraction was pulled forward into M3, `309d8a3`) | M | not started | — |
@@ -87,10 +87,10 @@ M4–M6 Defs and can start its non-cast cases once M1 lands.
 |---|---|
 | `ExtraCastRight²` statement (+ `WorldExtendᴿ`/`transport⊑ᵂ` machinery) | proven / in `ExtraCastRight2.agda` stage 1 |
 | `inert-extra-cast-right²`, `id-extra-cast-right²` | proven |
-| `ExtraCastRight²` consuming cases | not started (M4) |
+| `ExtraCastRight²` consuming cases | **proven** higher-order (M4, Catchup/ExtraCastRightProof) |
 | `InstCatchupRight²` statement | proven (stage 1) |
-| `InstCatchupRight²` allocating cases | not started (M5) |
-| `right-inj-inversion²` (new, frozen setting) | statement proven-consumable (Inversion/RightInjInversion2Def, no extra premises); proof = M3 final leg (head-walk cases) |
+| `InstCatchupRight²` allocating cases | **proven** operational half (M5, Catchup/InstCatchupRightProof); relational continuations pending M6 |
+| `right-inj-inversion²` (new, frozen setting) | **PROVEN AND LIVE** (2026-08-10): Inversion/RightInjInversion2Lemma, zero postulates |
 | `TargetDescent` (new) | **proven** (`ebd6f6a`) — terminal ★ + re-emission continuation |
 | `seal-transfer` | **unconditional** — H-multi deleted, collision refuted by frozen centers (`309d8a3`) |
 | Value catch-up (composed) | not stated (M6) |

--- a/GTSFImp/proof/DGG/ReachabilityCatalog.agda
+++ b/GTSFImp/proof/DGG/ReachabilityCatalog.agda
@@ -96,6 +96,18 @@ gen-★?X =
   ？_ ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ ★∼G = ★∼Xᵍ refl ⦄
     (id (＇ Fin.zero)) ⦃ Bns = nonstar-X ⦄
 
+flip-inst-★?X : ∀ {Δ} {μ : Env∼ Δ}
+  → flipᵐ (instᵐ μ) ⊢ ★ ∼ ＇ Fin.zero
+flip-inst-★?X =
+  ？_ ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ ★∼G = ★∼Xᵍ refl ⦄
+    (id (＇ Fin.zero)) ⦃ Bns = nonstar-X ⦄
+
+flip-gen-X! : ∀ {Δ} {μ : Env∼ Δ}
+  → flipᵐ (genᵐ μ) ⊢ ＇ Fin.zero ∼ ★
+flip-gen-X! =
+  _! ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ G∼★ = X∼★ᵍ refl ⦄
+    (id (＇ Fin.zero)) ⦃ Ans = nonstar-X ⦄
+
 sym-screen : ∀ {Δ} {μ : Env∼ Δ} {A B}
   → μ ⊢ A ∼ B
   → flipᵐ μ ⊢ B ∼ A
@@ -108,16 +120,18 @@ sym-screen (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ c ⦃ Ans ⦄) =
   sym∼ (_! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ c ⦃ Ans ⦄)
 sym-screen (？_ ⦃ Gᵍ ⦄ ⦃ ★∼G ⦄ c ⦃ Bns ⦄) =
   sym∼ (？_ ⦃ Gᵍ ⦄ ⦃ ★∼G ⦄ c ⦃ Bns ⦄)
-sym-screen {A = `∀ ((＇ Fin.zero) ⇒ (＇ Fin.zero))} {B = ★ ⇒ ★}
+sym-screen {μ = μ} {A = `∀ ((＇ Fin.zero) ⇒ (＇ Fin.zero))}
+    {B = ★ ⇒ ★}
     (inst_ c B≢★) =
   gen_ ⦃ Bnv = nonvar-fun ⦄ ⦃ z∈B = ∈-fun-left var-∈ ⦄
-    (gen-★?X ↦ gen-★?X) (λ ())
+    (flip-gen-X! {μ = flipᵐ μ} ↦ gen-★?X {μ = flipᵐ μ}) (λ ())
 sym-screen (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) =
   sym∼ (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★)
-sym-screen {A = ★ ⇒ ★} {B = `∀ ((＇ Fin.zero) ⇒ (＇ Fin.zero))}
+sym-screen {μ = μ} {A = ★ ⇒ ★}
+    {B = `∀ ((＇ Fin.zero) ⇒ (＇ Fin.zero))}
     (gen_ c A≢★) =
   inst_ ⦃ Anv = nonvar-fun ⦄ ⦃ z∈A = ∈-fun-left var-∈ ⦄
-    (inst-X! ↦ inst-X!) (λ ())
+    (flip-inst-★?X {μ = flipᵐ μ} ↦ inst-X! {μ = flipᵐ μ}) (λ ())
 sym-screen (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) =
   sym∼ (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★)
 sym-screen bot-elim = bot-intro
@@ -422,12 +436,12 @@ dynId⊢ = ⊢ƛ (⊢` Z)
 starfun∼∀X⇒X : ∀ {Δ} → ★⇒★ᵗ {Δ} ∼ ∀X⇒X {Δ}
 starfun∼∀X⇒X =
   gen_ ⦃ z∈B = ∈-fun-left var-∈ ⦄
-    (gen-★?X ↦ gen-★?X) (λ ())
+    (flip-gen-X! {μ = idᶜ} ↦ gen-★?X {μ = idᶜ}) (λ ())
 
 ∀X⇒X∼★⇒★ : ∀ {Δ} → ∀X⇒X {Δ} ∼ ★⇒★ᵗ {Δ}
 ∀X⇒X∼★⇒★ =
   inst_ ⦃ z∈A = ∈-fun-left var-∈ ⦄
-    (inst-X! ↦ inst-X!) (λ ())
+    (flip-inst-★?X {μ = idᶜ} ↦ inst-X! {μ = idᶜ}) (λ ())
 
 ★⇒★∼★⇒★ : ∀ {Δ} → ★⇒★ᵗ {Δ} ∼ ★⇒★ᵗ {Δ}
 ★⇒★∼★⇒★ = id ★ ↦ id ★

--- a/GTSFImp/proof/DGG/ReachabilityScreen.agda
+++ b/GTSFImp/proof/DGG/ReachabilityScreen.agda
@@ -268,7 +268,10 @@ tag-inst-var! = id (＇ Fin.zero) !
 tag-inst-body :
   instᵐ (idᶜ {Δ = 0}) ⊢
     (＇ Fin.zero ⇒ ★) ∼ (★ ⇒ ★)
-tag-inst-body = tag-inst-var! ↦ id ★
+tag-inst-body =
+  ？_ {μ = Consistency.flipᵐ (instᵐ (idᶜ {Δ = 0}))}
+    (id (＇ Fin.zero)) ↦
+  id {μ = instᵐ (idᶜ {Δ = 0})} ★
 
 tag-inst-cast : idᶜ {Δ = 0} ⊢ `∀ (＇ Fin.zero ⇒ ★) ∼ (★ ⇒ ★)
 tag-inst-cast =

--- a/GTSFImp/proof/DGG/SealTransfer.agda
+++ b/GTSFImp/proof/DGG/SealTransfer.agda
@@ -1,8 +1,0 @@
-module proof.DGG.SealTransfer where
-
--- File Charter:
---   * Compatibility surface for the target-star seal transfer proof.
---   * Re-exports the implementation owned by SealTransferCore for modules
---     that use the transfer theorem without depending on the proof script.
-
-open import proof.DGG.SealTransferCore public

--- a/GTSFImp/proof/DGG/notes/consistency-cleanup-blocked.red
+++ b/GTSFImp/proof/DGG/notes/consistency-cleanup-blocked.red
@@ -1,0 +1,137 @@
+Consistency cleanup blocked after flipping `_↦_`.
+
+Command:
+
+  env \
+    AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
+abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
+    agda -i GTSFImp -v0 GTSFImp/All.agda
+
+Failure:
+
+  GTSFImp/proof/ImprecisionConsistency.agda:423,17-20
+  A′ != A₁ of type (Ty Δ)
+  when checking that the expression A⊑L has type φ ⊢ A ⊑ A₁
+
+Reason this is not mechanical plumbing:
+
+  `consistent-common-lowerᵐ` currently states:
+
+    LowerEnv μ φ ψ
+    -> μ ⊢ A ∼ B
+    -> ∃[ D ] φ ⊢ D ⊑ A × ψ ⊢ D ⊑ B
+
+  After the requested constructor change, a function consistency proof
+
+    c ↦ d : μ ⊢ (A ⇒ B) ∼ (A′ ⇒ B′)
+
+  contains:
+
+    c : μ ⊢ A′ ∼ A
+    d : μ ⊢ B ∼ B′
+
+  Recursing on `c` with the current theorem gives a domain lower bound in
+  the order:
+
+    φ ⊢ D ⊑ A′
+    ψ ⊢ D ⊑ A
+
+  But the lower bound needed for the whole function type is:
+
+    φ ⊢ D ⊑ A
+    ψ ⊢ D ⊑ A′
+
+  Those are swapped.  This cannot be repaired by changing constructor
+  argument order or by inserting `sym∼`; it requires a polarity-aware
+  redesign of the environment/lower-bound theorem, or a different theorem
+  statement.
+
+Concrete open counterexample to the old env-indexed statement:
+
+  Let Δ = 1, μ zero = X∼★, φ zero = X⊑X, and ψ zero = X⊑★.
+  Then `LowerEnv μ φ ψ` holds by `var-to-star`.
+
+  Let:
+
+    c = id (＇ zero) !
+
+  Then:
+
+    c : μ ⊢ ＇ zero ∼ ★
+    c ↦ id (‵ ι) : μ ⊢ (★ ⇒ ‵ ι) ∼ (＇ zero ⇒ ‵ ι)
+
+  The old theorem would require some `D` with:
+
+    φ ⊢ D ⊑ (★ ⇒ ‵ ι)
+    ψ ⊢ D ⊑ (＇ zero ⇒ ‵ ι)
+
+  Any arrow-shaped common lower would need a domain `E` such that:
+
+    φ ⊢ E ⊑ ★
+    ψ ⊢ E ⊑ ＇ zero
+
+  The second judgment forces `E = ＇ zero`, but the first would then require
+  `φ zero = X⊑★`, contradicting `φ zero = X⊑X`.
+
+Work completed before the blocker:
+
+  * Added `GTSFImp/FunExt.agda` with the centralized `funext` postulate.
+  * Removed the private `funext` postulates from `Consistency.agda` and
+    `proof/Imprecision.agda`.
+  * Added `FunExt` to `All.agda`.
+  * Flipped `_↦_` in `Consistency.agda` to the requested domain orientation.
+  * Simplified `β-⇒` in `Reduction.agda` and updated the direct uses in
+    `Eval.agda`, `proof/TypeSafety/Progress.agda`, and
+    `proof/TypeSafety/Preservation.agda`.
+  * Reoriented the first consistency example sites that became invalid in
+    negative function-domain positions.
+
+Continuation blocker after supervisor's mutual-swap direction:
+
+  The proposed companion has the shape:
+
+    consistent-common-lowerᵐ-swap :
+      LowerEnv μ φ ψ
+      -> μ ⊢ A ∼ B
+      -> ∃[ D ] ψ ⊢ D ⊑ A × φ ⊢ D ⊑ B
+
+  This is enough for the arrow-domain position if it exists: for
+  `c : μ ⊢ A′ ∼ A`, the main arrow case can use the swapped result
+  `ψ ⊢ Dc ⊑ A′` and `φ ⊢ Dc ⊑ A`.
+
+  The companion itself cannot mirror the variable-ground `_!` case.  Let
+  `Δ = 1`, `μ zero = X∼★`, `φ zero = X⊑X`, and `ψ zero = X⊑★`.
+  Then `LowerEnv μ φ ψ` holds by `var-to-star`.
+
+  Let:
+
+    c = id (＇ zero)
+    x-to-star = _! {G = ＇ zero} ⦃ Gᵍ = ＇ zero ⦄
+      ⦃ G∼★ = X∼★ᵍ refl ⦄ c ⦃ nonstar-X ⦄
+
+  Then:
+
+    x-to-star : μ ⊢ ＇ zero ∼ ★
+
+  The swapped companion would require some `D` with:
+
+    ψ ⊢ D ⊑ ＇ zero
+    φ ⊢ D ⊑ ★
+
+  The first judgment forces the source to be exactly `＇ zero` up to the
+  structural universal-instantiation cases, and each such case still needs an
+  inner source that lowers to `＇ zero`.  The direct variable case leaves
+  `D = ＇ zero`, and then the second judgment would require:
+
+    φ zero = X⊑★
+
+  But `LowerEnv μ φ ψ` gives `φ zero = X⊑X` for `μ zero = X∼★`.
+  This is the side-specific helper obstruction: the existing
+  `var-right-to-star` works on the `ψ` side because `var-to-star` gives
+  `ψ zero = X⊑★`; the mirrored `_!` branch would need a `φ`-side
+  helper for the same `X∼★` evidence, which contradicts `var-to-star`.
+
+  I stopped here per the instruction:
+
+    If the swap companion hits a case that genuinely cannot mirror: STOP with
+    the case to a .red.

--- a/GTSFImp/proof/Imprecision.agda
+++ b/GTSFImp/proof/Imprecision.agda
@@ -7,21 +7,17 @@ module proof.Imprecision where
 --   * Proves uniqueness for occurrence and type-imprecision evidence.
 --   * Depends only on Types and Imprecision.
 
-open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Fin using (zero; suc)
 import Data.Nat as Nat
-open import Level using (0ℓ)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; cong; cong₂; sym; trans)
 
 open import Types
+open import FunExt using (funext)
 import Imprecision as I
 
 private
-
-  postulate
-    funext : Extensionality 0ℓ 0ℓ
 
   ¬-unique : ∀ {A : Set} (p q : A → ⊥) → p ≡ q
   ¬-unique p q = funext (λ x → ⊥-elim (p x))

--- a/GTSFImp/proof/ImprecisionConsistency.agda
+++ b/GTSFImp/proof/ImprecisionConsistency.agda
@@ -70,6 +70,19 @@ identity-lower-env : ∀ {Δ}
   → LowerEnv (idᶜ {Δ}) (I.idᵐ {Δ}) (I.idᵐ {Δ})
 identity-lower-env X = var-refl
 
+flip-var-lower : ∀ {r φ ψ}
+  → VarLower r φ ψ
+  → VarLower (flipVar∼ r) ψ φ
+flip-var-lower var-refl = var-refl
+flip-var-lower var-to-star = var-from-star
+flip-var-lower var-from-star = var-to-star
+flip-var-lower both-to-star = both-to-star
+
+flip-lower-env : ∀ {μ : Env∼ Δ} {φ ψ}
+  → LowerEnv μ φ ψ
+  → LowerEnv (flipᵐ μ) ψ φ
+flip-lower-env h X = flip-var-lower (h X)
+
 right-star-from-var-lower : ∀ {r l u}
   → VarLower r l u
   → r ≡ X∼★
@@ -416,10 +429,10 @@ consistent-common-lowerᵐ h (id ★) = ★ , I.★⊑★ , I.★⊑★
 consistent-common-lowerᵐ h (id (‵ ι)) = ‵ ι , I.ι⊑ι , I.ι⊑ι
 consistent-common-lowerᵐ h (id (＇ X)) = ＇ X , I.X⊑X , I.X⊑X
 consistent-common-lowerᵐ h (c ↦ d)
-    with consistent-common-lowerᵐ h c
+    with consistent-common-lowerᵐ (flip-lower-env h) c
        | consistent-common-lowerᵐ h d
 consistent-common-lowerᵐ h (c ↦ d)
-    | A , A⊑L , A⊑R | B , B⊑L , B⊑R =
+    | A , A⊑R , A⊑L | B , B⊑L , B⊑R =
   A ⇒ B , I.⇒⊑⇒ A⊑L B⊑L , I.⇒⊑⇒ A⊑R B⊑R
 consistent-common-lowerᵐ h (∀ᶜ c)
     with consistent-common-lowerᵐ (extend-lower-env h) c
@@ -597,6 +610,19 @@ source-occurs-target focus I.bot⊑★ (∈-all ())
 consistency-var-self-not-star : X∼X ≡ X∼★ → ⊥
 consistency-var-self-not-star ()
 
+consistency-var-self-not-from-star : X∼X ≡ ★∼X → ⊥
+consistency-var-self-not-from-star ()
+
+flip-self-mode : ∀ {Δ : TyCtx} {ν : Env∼ Δ} {X : TyVar Δ}
+  → ν X ≡ X∼X
+  → flipᵐ ν X ≡ X∼X
+flip-self-mode same = cong flipVar∼ same
+
+flip-flip-self-mode : ∀ {Δ : TyCtx} {ν : Env∼ Δ} {X : TyVar Δ}
+  → ν X ≡ X∼X
+  → flipᵐ (flipᵐ ν) X ≡ X∼X
+flip-flip-self-mode same = cong flipVar∼ (cong flipVar∼ same)
+
 ground-self-occurs⊥ : ∀ {Δ : TyCtx} {ν : Env∼ Δ} {X : TyVar Δ}
     {G : Ty Δ}
   → ν X ≡ X∼X
@@ -610,47 +636,112 @@ ground-self-occurs⊥ same (X∼★ᵍ eq) var-∈ =
   consistency-var-self-not-star (trans (sym same) eq)
 ground-self-occurs⊥ same ∀∼★ (∈-all ())
 
-consistency-source-occurs-target : ∀ {Δ : TyCtx} {ν : Env∼ Δ}
-    {X : TyVar Δ} {A B : Ty Δ}
+ground-self-occurs★∼⊥ : ∀ {Δ : TyCtx} {ν : Env∼ Δ} {X : TyVar Δ}
+    {G : Ty Δ}
   → ν X ≡ X∼X
-  → ν ⊢ A ∼ B
-  → X ∈ᵗ A
-  → X ∈ᵗ B
-consistency-source-occurs-target same (id a) X∈A = X∈A
-consistency-source-occurs-target {A = A ⇒ B} {B = A′ ⇒ B′}
-    same (c ↦ d) (∈-fun-left X∈A) =
-  ∈-fun-left (consistency-source-occurs-target same c X∈A)
-consistency-source-occurs-target {X = X} {A = A ⇒ B}
-    {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A X∈B)
-    with occurs? X A′
-consistency-source-occurs-target {X = X} {A = A ⇒ B}
-    {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A X∈B)
-    | present X∈A′ = ∈-fun-left X∈A′
-consistency-source-occurs-target {X = X} {A = A ⇒ B}
-    {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A X∈B)
-    | absent X∉A′ =
-  ∈-fun-right X∉A′ (consistency-source-occurs-target same d X∈B)
-consistency-source-occurs-target {X = X} {A = `∀ A} {B = `∀ B}
-    same (∀ᶜ c) (∈-all X∈A) =
-  ∈-all (consistency-source-occurs-target {X = suc X} same c X∈A)
-consistency-source-occurs-target {B = ★} same
-    (_! ⦃ G∼★ = G∼★ ⦄ c ⦃ Ans ⦄) X∈A =
-  ⊥-elim (ground-self-occurs⊥ same G∼★
-    (consistency-source-occurs-target same c X∈A))
-consistency-source-occurs-target {A = ★} same
-    (？_ ⦃ g ⦄ c ⦃ Bns ⦄) ()
-consistency-source-occurs-target {X = X} {A = `∀ A} same
-    (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) (∈-all X∈A) =
-  unshift-occurs
-    (consistency-source-occurs-target {X = suc X} same c X∈A)
-consistency-source-occurs-target {X = X} {B = `∀ B} same
-    (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) X∈A =
-  ∈-all (consistency-source-occurs-target {X = suc X} same c
-    (shift-occurs X∈A))
-consistency-source-occurs-target {A = `∀ (＇ zero)}
-    same bot-elim (∈-all ())
-consistency-source-occurs-target {A = `∀ ★}
-    same bot-intro (∈-all ())
+  → ν ⊢★∼ G
+  → X ∈ᵗ G
+  → ⊥
+ground-self-occurs★∼⊥ same ★∼⇒ (∈-fun-left ())
+ground-self-occurs★∼⊥ same ★∼⇒ (∈-fun-right X∉A ())
+ground-self-occurs★∼⊥ same ★∼ι ()
+ground-self-occurs★∼⊥ same (★∼Xᵍ eq) var-∈ =
+  consistency-var-self-not-from-star (trans (sym same) eq)
+ground-self-occurs★∼⊥ same ★∼∀ (∈-all ())
+
+mutual
+  consistency-source-occurs-target : ∀ {Δ : TyCtx} {ν : Env∼ Δ}
+      {X : TyVar Δ} {A B : Ty Δ}
+    → ν X ≡ X∼X
+    → ν ⊢ A ∼ B
+    → X ∈ᵗ A
+    → X ∈ᵗ B
+  consistency-source-occurs-target same (id a) X∈A = X∈A
+  consistency-source-occurs-target {ν = ν} {X = X}
+      {A = A ⇒ B} {B = A′ ⇒ B′} same (c ↦ d)
+      (∈-fun-left X∈A) =
+    ∈-fun-left
+      (consistency-target-occurs-source {ν = flipᵐ ν} {X = X}
+        (flip-self-mode {ν = ν} {X = X} same) c X∈A)
+  consistency-source-occurs-target {X = X} {A = A ⇒ B}
+      {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A X∈B)
+      with occurs? X A′
+  consistency-source-occurs-target {X = X} {A = A ⇒ B}
+      {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A X∈B)
+      | present X∈A′ = ∈-fun-left X∈A′
+  consistency-source-occurs-target {X = X} {A = A ⇒ B}
+      {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A X∈B)
+      | absent X∉A′ =
+    ∈-fun-right X∉A′
+      (consistency-source-occurs-target same d X∈B)
+  consistency-source-occurs-target {X = X} {A = `∀ A} {B = `∀ B}
+      same (∀ᶜ c) (∈-all X∈A) =
+    ∈-all (consistency-source-occurs-target {X = suc X} same c X∈A)
+  consistency-source-occurs-target {B = ★} same
+      (_! ⦃ G∼★ = G∼★ ⦄ c ⦃ Ans ⦄) X∈A =
+    ⊥-elim (ground-self-occurs⊥ same G∼★
+      (consistency-source-occurs-target same c X∈A))
+  consistency-source-occurs-target {A = ★} same
+      (？_ ⦃ g ⦄ c ⦃ Bns ⦄) ()
+  consistency-source-occurs-target {X = X} {A = `∀ A} same
+      (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) (∈-all X∈A) =
+    unshift-occurs
+      (consistency-source-occurs-target {X = suc X} same c X∈A)
+  consistency-source-occurs-target {X = X} {B = `∀ B} same
+      (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) X∈A =
+    ∈-all (consistency-source-occurs-target {X = suc X} same c
+      (shift-occurs X∈A))
+  consistency-source-occurs-target {A = `∀ (＇ zero)}
+      same bot-elim (∈-all ())
+  consistency-source-occurs-target {A = `∀ ★}
+      same bot-intro (∈-all ())
+
+  consistency-target-occurs-source : ∀ {Δ : TyCtx} {ν : Env∼ Δ}
+      {X : TyVar Δ} {A B : Ty Δ}
+    → ν X ≡ X∼X
+    → ν ⊢ A ∼ B
+    → X ∈ᵗ B
+    → X ∈ᵗ A
+  consistency-target-occurs-source same (id a) X∈B = X∈B
+  consistency-target-occurs-source {ν = ν} {X = X}
+      {A = A ⇒ B} {B = A′ ⇒ B′} same (c ↦ d)
+      (∈-fun-left X∈A′) =
+    ∈-fun-left
+      (consistency-source-occurs-target {ν = flipᵐ ν} {X = X}
+        (flip-self-mode {ν = ν} {X = X} same) c X∈A′)
+  consistency-target-occurs-source {X = X} {A = A ⇒ B}
+      {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A′ X∈B′)
+      with occurs? X A
+  consistency-target-occurs-source {X = X} {A = A ⇒ B}
+      {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A′ X∈B′)
+      | present X∈A = ∈-fun-left X∈A
+  consistency-target-occurs-source {X = X} {A = A ⇒ B}
+      {B = A′ ⇒ B′} same (c ↦ d) (∈-fun-right X∉A′ X∈B′)
+      | absent X∉A =
+    ∈-fun-right X∉A
+      (consistency-target-occurs-source same d X∈B′)
+  consistency-target-occurs-source {X = X} {A = `∀ A} {B = `∀ B}
+      same (∀ᶜ c) (∈-all X∈B) =
+    ∈-all (consistency-target-occurs-source {X = suc X} same c X∈B)
+  consistency-target-occurs-source {B = ★} same
+      (_! ⦃ G∼★ = G∼★ ⦄ c ⦃ Ans ⦄) ()
+  consistency-target-occurs-source {A = ★} same
+      (？_ ⦃ ★∼G = ★∼G ⦄ c ⦃ Bns ⦄) X∈B =
+    ⊥-elim (ground-self-occurs★∼⊥ same ★∼G
+      (consistency-target-occurs-source same c X∈B))
+  consistency-target-occurs-source {X = X} {A = `∀ A} same
+      (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) X∈B =
+    ∈-all
+      (consistency-target-occurs-source {X = suc X} same c
+        (shift-occurs X∈B))
+  consistency-target-occurs-source {X = X} {B = `∀ B} same
+      (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) (∈-all X∈B) =
+    unshift-occurs
+      (consistency-target-occurs-source {X = suc X} same c X∈B)
+  consistency-target-occurs-source {B = `∀ ★}
+      same bot-elim (∈-all ())
+  consistency-target-occurs-source {B = `∀ (＇ zero)}
+      same bot-intro (∈-all ())
 
 shift-ground : ∀ {Δ G}
   → Ground {Δ} G
@@ -1290,6 +1381,12 @@ identity-avoids-both : ∀ {Δ} {A B : Ty Δ}
 identity-avoids-both X eqL eqR =
   ⊥-elim (var-identity-not-star eqL)
 
+swap-avoid-both : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {A B}
+  → AvoidBoth φ ψ A B
+  → AvoidBoth ψ φ B A
+swap-avoid-both safe X eqL eqR with safe X eqR eqL
+swap-avoid-both safe X eqL eqR | X∉A , X∉B = X∉B , X∉A
+
 avoid-arrow-domain : ∀ {Δ} {φ ψ : I.ImpEnv Δ} {A B C D}
   → AvoidBoth φ ψ (A ⇒ B) (C ⇒ D)
   → AvoidBoth φ ψ A C
@@ -1542,12 +1639,14 @@ lower-bounds-consistentᵐ h safe (I.X⊑★ eqL) (I.X⊑★ eqR) =
   id ★
 lower-bounds-consistentᵐ h safe
     (I.⇒⊑⇒ p₁ p₂) (I.⇒⊑⇒ q₁ q₂) =
-  lower-bounds-consistentᵐ h (avoid-arrow-domain safe) p₁ q₁ ↦
+  lower-bounds-consistentᵐ (flip-lower-env h)
+    (swap-avoid-both (avoid-arrow-domain safe)) q₁ p₁ ↦
   lower-bounds-consistentᵐ h (avoid-arrow-codomain safe) p₂ q₂
 lower-bounds-consistentᵐ h safe
     (I.⇒⊑⇒ p₁ p₂) (I.⇒⊑★ q₁ q₂) =
   _! ⦃ Gᵍ = ★⇒★ ⦄
-    (lower-bounds-consistentᵐ h (avoid-arrow-star-domain safe) p₁ q₁
+    (lower-bounds-consistentᵐ (flip-lower-env h)
+      (swap-avoid-both (avoid-arrow-star-domain safe)) q₁ p₁
       ↦
      lower-bounds-consistentᵐ h
        (avoid-arrow-star-codomain safe) p₂ q₂)
@@ -1555,7 +1654,8 @@ lower-bounds-consistentᵐ h safe
 lower-bounds-consistentᵐ h safe
     (I.⇒⊑★ p₁ p₂) (I.⇒⊑⇒ q₁ q₂) =
   ？_ ⦃ Gᵍ = ★⇒★ ⦄
-    (lower-bounds-consistentᵐ h (avoid-star-arrow-domain safe) p₁ q₁
+    (lower-bounds-consistentᵐ (flip-lower-env h)
+      (swap-avoid-both (avoid-star-arrow-domain safe)) q₁ p₁
       ↦
      lower-bounds-consistentᵐ h
        (avoid-star-arrow-codomain safe) p₂ q₂)

--- a/GTSFImp/proof/TypeSafety/Preservation.agda
+++ b/GTSFImp/proof/TypeSafety/Preservation.agda
@@ -160,8 +160,8 @@ pure-preservation (⊢· (⊢ƛ N⊢) V⊢) (β vV) =
   typing-single-subst N⊢ V⊢
 pure-preservation (⊢⟨⟩ V⊢ (id a)) (β-id vV) = V⊢
 pure-preservation
-    (⊢· (⊢⟨⟩ V⊢ (c ↦ d)) W⊢) (β-⇒ vV vW refl) =
-  ⊢⟨⟩ (⊢· V⊢ (⊢⟨⟩ W⊢ (sym∼ c))) d
+    (⊢· (⊢⟨⟩ V⊢ (c ↦ d)) W⊢) (β-⇒ vV vW) =
+  ⊢⟨⟩ (⊢· V⊢ (⊢⟨⟩ W⊢ c)) d
 pure-preservation (⊢• (⊢⟨⟩ V⊢ (∀ᶜ c))) (β-∀ vV refl) =
   ⊢⟨⟩ (⊢• V⊢) (c [ _ ]ᶜ)
 pure-preservation (⊢⟨⟩ V⊢ (c !)) (ground vV A≠G) =

--- a/GTSFImp/proof/TypeSafety/Progress.agda
+++ b/GTSFImp/proof/TypeSafety/Progress.agda
@@ -38,7 +38,7 @@ data Progress {Δ : TyCtx} {Σ : TyStore Δ} (M : Term Δ) : Set where
 data FunView {Δ : TyCtx} (V : Term Δ) : Set where
   fv-ƛ : ∀ {N} → V ≡ ƛ N → FunView V
   fv-⇒ : ∀ {μ : Env∼ Δ} {W} {A A′ B B′ : Ty Δ}
-      {c : μ ⊢ A ∼ A′} {d : μ ⊢ B ∼ B′}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
     → Value W
     → V ≡ W ⟨ c ↦ d ⟩
     → FunView V
@@ -390,7 +390,7 @@ to-ground (‵ ι) (id (‵ ι)) = same
 to-ground (‵ ι) (？_ ⦃ g ⦄ c ⦃ Bns ⦄) = other (λ ())
 to-ground (‵ ι) (inst_ ⦃ Anv ⦄ ⦃ z∈A ⦄ c B≢★) = other (λ ())
 to-ground ★⇒★ (？_ ⦃ g ⦄ c ⦃ Bns ⦄) = other (λ ())
-to-ground ★⇒★ (c ↦ d) with to-star c | to-star d
+to-ground ★⇒★ (c ↦ d) with from-star c | to-star d
 to-ground ★⇒★ (.(id ★) ↦ .(id ★)) | same | same = same
 to-ground ★⇒★ (c ↦ d) | same | other B≠★ =
   other (λ { refl → B≠★ refl })
@@ -427,7 +427,7 @@ from-ground (‵ ι) (id (‵ ι)) = same
 from-ground (‵ ι) (_! ⦃ g ⦄ c ⦃ Ans ⦄) = other (λ ())
 from-ground (‵ ι) (gen_ ⦃ Bnv ⦄ ⦃ z∈B ⦄ c A≢★) = other (λ ())
 from-ground ★⇒★ (_! ⦃ g ⦄ c ⦃ Ans ⦄) = other (λ ())
-from-ground ★⇒★ (c ↦ d) with from-star c | from-star d
+from-ground ★⇒★ (c ↦ d) with to-star c | from-star d
 from-ground ★⇒★ (.(id ★) ↦ .(id ★)) | same | same = same
 from-ground ★⇒★ (c ↦ d) | same | other B≠★ =
   other (λ { refl → B≠★ refl })
@@ -599,7 +599,7 @@ progress (⊢· L⊢ M⊢) | done vL | done vM | fv-ƛ refl =
   step (pure-step (β vM))
 progress (⊢· L⊢ M⊢) | done vL | done vM
     | fv-⇒ vW refl =
-  step (pure-step (β-⇒ vW vM refl))
+  step (pure-step (β-⇒ vW vM))
 progress (⊢· L⊢ M⊢) | done vL | done vM
     | fv-reveal vW refl =
   step (pure-step (β-reveal-⇒ vW vM))

--- a/InitialPairScratch.agda
+++ b/InitialPairScratch.agda
@@ -83,10 +83,16 @@ X? =
   ？_ ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ ★∼G = ★∼Xᵍ refl ⦄
     (id (＇ Fin.zero)) ⦃ Bns = nonstar-X ⦄
 
+X!-gen-domain : ∀ {Δ} {μ : Env∼ Δ}
+  → flipᵐ (genᵐ μ) ⊢ ＇ Fin.zero ∼ ★
+X!-gen-domain =
+  _! ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ G∼★ = X∼★ᵍ refl ⦄
+    (id (＇ Fin.zero)) ⦃ Ans = nonstar-X ⦄
+
 ★⇒★∼∀X⇒X : ∀ {Δ} → idᶜ {Δ = Δ} ⊢ ★ ⇒ ★ ∼ `∀ X⇒X
 ★⇒★∼∀X⇒X =
   gen_ ⦃ Bnv = nonvar-fun ⦄ ⦃ z∈B = ∈-fun-left var-∈ ⦄
-    (X? ↦ X?) (λ ())
+    (X!-gen-domain ↦ X?) (λ ())
 
 dynIdᶜ : ∀ {Δ} → Term Δ
 dynIdᶜ = ƛ (` 0)


### PR DESCRIPTION
Second cleanup round.

**FunExt consolidation** — `GTSFImp/FunExt.agda` holds the development's single postulate; the private duplicates in `Consistency.agda` and `proof/Imprecision.agda` are removed. Hygiene baseline is now exactly one postulate.

**Contravariant function consistency (design note — please review)** — the rule is now
```
_↦_ : flipᵐ μ ⊢ A′ ∼ A → μ ⊢ B ∼ B′ → μ ⊢ (A ⇒ B) ∼ (A′ ⇒ B′)
```
The domain premise lives in `flipᵐ μ`, not `μ`: the same-`μ` version loses derivability in the moded setting (at mode `X∼★`, `(＇X ⇒ ℕ) ∼ (★ ⇒ ℕ)` needs `★ ∼ ＇X` whose `★∼Xᵍ` gate demands the flipped mode), and it provably breaks `consistent-common-lowerᵐ` (both natural proof repairs are refutable from `LowerEnv`'s asymmetry). With `flipᵐ` the rule is derivability-isomorphic to the old one and `consistent-common-lowerᵐ` closes with one small `flip-lower-env` lemma. In unmoded developments `flipᵐ` is invisible, so this is the standard contravariant rule transcribed to the moded relation. A pleasing consequence: the `gen` cast `★⇒★ ∼ ∀X⇒X` now takes `X! ↦ X?` — domain tags flip from projection to injection, as contravariance dictates.

**β-⇒ simplification** — the `sym∼` use, the `c′` variable, and the `c′ ≡ sym∼ c` premise are gone: `(V ⟨ c ↦ d ⟩) · W —→ (V · (W ⟨ c ⟩)) ⟨ d ⟩`.

**All.agda charter** — imports are now top-level modules only (baseline metatheory, finished major lemmas, current frontier) plus an explicit **leaf gates** section for files nothing imports (example suites, probes, counterexample records, and two checked-but-unconsumed libraries: `CenterRename`, `WorldSupport` — flagged as M7 candidates or deletion candidates). Several leaf gates that had silently left the gate (`ExtraCastRightProof`, `InstCatchupRightProof`, five probes, `GroundCastTargetExamples`) are back in. Verified by clean-rebuild audit: zero unreached modules. Also deleted the dead `SealTransfer.agda` shim.

**PLAN.md** — M3 marked landed (PR #124); M4/M5 and the key-lemma table brought current.

Verified: clean-rebuild `All.agda` green; hygiene = 1 postulate (`FunExt.agda`), no holes; root `InitialPairScratch.agda` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)