### PR TITLE
Post-#128 cleanup: stranded rigid-route refutation notes; PLAN brought current

### DIFF
--- a/GTSFImp/proof/DGG/PLAN.md
+++ b/GTSFImp/proof/DGG/PLAN.md
@@ -298,4 +298,14 @@ in-branch tagged-transfer packaging.
 
 Next: M5 relational continuations + M6 driver (designs validated),
 then M7 sim-right², M8 dgg-simulation. Parked: single-source-pair
-pedigree; TODO.md: consistency-relation rigid-var/★ fix.
+pedigree.
+
+## Source-consistency interlude LANDED (2026-08-11, PR #128)
+
+The consistency-relation rigid-var/★ fix parked above shipped as the
+four-mode split (crossable `★∼X∼★` program binders vs strict `X∼X`
+`∀ᶜ` slots; SRCCONSIST-DOSSIER.md §§8-10). The term-imprecision
+relation was NOT changed, so M5-M8 proceed on unchanged foundations.
+The rigid-gate route it replaced is refuted in
+notes/srcconsist-rigid-{lower-bound,ground-cast-helper}-blocked.red.
+Remaining sibling work (GTSF port) is tracked in TODO.md.

--- a/GTSFImp/proof/DGG/notes/srcconsist-rigid-ground-cast-helper-blocked.red
+++ b/GTSFImp/proof/DGG/notes/srcconsist-rigid-ground-cast-helper-blocked.red
@@ -1,0 +1,88 @@
+Rigid source-consistency ground-cast helper blocker
+
+Command:
+
+  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
+abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
+    agda -i GTSFImp -v0 GTSFImp/proof/ImprecisionConsistency.agda
+
+After restricting `consistent-common-lowerᵐ` and the self-occurrence
+preservation lemmas to `RigidFree`, the next exposed failure is:
+
+  GTSFImp/proof/ImprecisionConsistency.agda:1234,59-65
+  (zero ∈ᵗ A) !=< (RigidFree c)
+  when checking that the expression zero∈B has type RigidFree c
+
+This is not just an omitted argument.  The caller is
+`ground-cast-target⊑`, whose current unrestricted statement is:
+
+  Ground G
+  -> NonStar B
+  -> ν ⊢ B ∼ G
+  -> μ ⊢ A ⊑ B
+  -> μ ⊢ A ⊑ ★
+  -> μ ⊢ A ⊑ G
+
+The old proof used self-mode occurrence preservation in the universal-ground
+case:
+
+  ν ⊢ `∀ B ∼ `∀ ★
+  μ ⊢ `∀ A ⊑ `∀ B
+  μ ⊢ `∀ A ⊑ ★
+  --------------------------------
+  μ ⊢ `∀ A ⊑ `∀ ★
+
+It ruled out the `∀⊑` star proof by transporting `zero ∈ᵗ B` across
+`extᵐ ν ⊢ B ∼ ★`, reaching an impossible occurrence in `★`.  Rigid gates make
+that occurrence loss real.
+
+Concrete rigid shape:
+
+  A = B = ＇ zero ⇒ ★
+  μ = idᵐ
+  ν = idᶜ
+
+  extᵐ ν ⊢ A ∼ ★
+    by first showing
+      extᵐ ν ⊢ A ∼ ★ ⇒ ★
+    where the domain uses the rigid projection
+      flipᵐ (extᵐ ν) ⊢ ★ ∼ ＇ zero
+    and then tagging the arrow ground to `★`.
+
+Then:
+
+  idᵐ ⊢ `∀ A ⊑ `∀ B
+    by `∀⊑∀ (⇒⊑⇒ X⊑X ★⊑★)`
+
+  idᵐ ⊢ `∀ A ⊑ ★
+    by `∀⊑ nonvar-fun (∈-fun-left var-∈)
+         (⇒⊑★ (X⊑★ refl) ★⊑★)`
+
+But the old conclusion would require:
+
+  idᵐ ⊢ `∀ (＇ zero ⇒ ★) ⊑ `∀ ★
+
+There is no imprecision clause for this without a rigid crossing in
+imprecision.  The `∀⊑∀` route would need:
+
+  extᵐ idᵐ ⊢ ＇ zero ⇒ ★ ⊑ ★
+
+which requires `extᵐ idᵐ zero ≡ X⊑★`, false.  The `∀⊑` route to
+target ``∀ ★` would need:
+
+  instᵐ idᵐ ⊢ ＇ zero ⇒ ★ ⊑ `∀ ★
+
+which the function source cannot produce.
+
+So the unrestricted `ground-cast-target⊑` statement is false after rigid
+source-consistency gates.  A repair needs one of these larger statement
+changes:
+
+- add a `RigidFree`/no-rigid premise to `ground-cast-target⊑` and its mirror
+  `ground-cast-source⊑`;
+- or replace the conclusion with a rigid-obstruction disjunct and make callers
+  discharge that disjunct from their own safety premises.
+
+Both routes affect DGG-facing helpers (`ground-cast-source⊑` is imported by
+inversion files), so this is outside the lower-bound-cluster repair unless the
+public helper shape is explicitly approved.

--- a/GTSFImp/proof/DGG/notes/srcconsist-rigid-lower-bound-blocked.red
+++ b/GTSFImp/proof/DGG/notes/srcconsist-rigid-lower-bound-blocked.red
@@ -1,0 +1,50 @@
+Rigid source-consistency lower-bound blocker
+
+Command:
+
+  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
+abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
+    agda -i GTSFImp -v0 GTSFImp/proof/ImprecisionConsistency.agda
+
+Failure after adding the approved rigid gates:
+
+  GTSFImp/proof/ImprecisionConsistency.agda:428,1-520,37
+  Incomplete pattern matching for consistent-common-lowerᵐ. Missing:
+
+    consistent-common-lowerᵐ h
+      (_! {G = ＇ X} {G∼★ = X∼★ʳ eq} c)
+
+This is not a mechanical missing case.  The old statement is:
+
+  LowerEnv μ φ ψ
+  -> μ ⊢ A ∼ B
+  -> ∃[ D ] φ ⊢ D ⊑ A × ψ ⊢ D ⊑ B
+
+For the rigid branch, take:
+
+  μ X = X∼X
+  h X = var-refl
+  c = id (＇ X)
+
+Then the new rigid tag gives:
+
+  μ ⊢ ＇ X ∼ ★
+
+The old theorem would require a `D` such that:
+
+  φ ⊢ D ⊑ ＇ X
+  ψ ⊢ D ⊑ ★
+
+The direct variable lower forces `D = ＇ X`, and the star-side proof then
+needs `ψ X ≡ X⊑★`.  But `h X = var-refl` gives `ψ X = X⊑X`.
+
+The repair route named in the preflight, `both-to-star`, works only if the
+statement selects or requires that lower-env branch for rigid variables.  The
+current theorem quantifies over arbitrary `LowerEnv`, so it also admits
+`var-refl`; under that premise the rigid branch is false.
+
+The same issue appears under `∀ᶜ`: a rigid gate for the bound variable can be
+used inside the body, while `∀⊑∀` lowers bodies under `I.extᵐ`, whose fresh
+variable is precise rather than dynamic.  That requires a larger statement
+change to the lower-bound characterization or a change to the type-imprecision
+relation, neither of which is specified by the live migration preflight.


### PR DESCRIPTION
## Summary

Cleanup after the machine freeze / cross-computer handoff around PR #128.

- **Commit the two stranded `.red` refutation notes.** The landed dossier (SRCCONSIST-DOSSIER.md §8) cites `srcconsist-rigid-lower-bound-blocked.red` as the checked counterexample for the unrestricted rigid case of `consistent-common-lowerᵐ`, but both rigid-route blocker notes were sitting uncommitted on the interrupted machine. They record the two concrete refutations that killed the rigid-gate route (`consistent-common-lowerᵐ` false under `var-refl` lower-envs; `ground-cast-target⊑` false at a ∀ᶜ slot) and motivated the crossable/strict split that PR #128 landed.
- **PLAN.md**: record the source-consistency interlude as landed (PR #128, term-imprecision relation unchanged — M5-M8 proceed on unchanged foundations), and clear the parked TODO pointer (the remaining GTSF sibling port stays in TODO.md).

Also done locally (no diff): pruned six fully-merged local branches; the interrupted session's superseded working-tree draft of the split (the `∼X∼` spelling) is stashed, not deleted.

## Validation

Docs-only diff. Baseline `agda -i GTSFImp -v0 GTSFImp/All.agda` on main running in this session (will confirm before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)