### PR TITLE
[codex] Add GTSFImp gradual source type checker

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -26,6 +26,7 @@ import FunExt
 
 import proof.TypeSafety.Progress
 import proof.TypeSafety.Preservation
+import GradualTypeCheck
 import proof.ImprecisionConsistency
 import proof.Imprecision
 import proof.Consistency
@@ -54,6 +55,7 @@ import proof.DGG.Catchup.InstCatchupRightProof
 
 -- Example suites and catalogs
 import Example
+import GradualTypeCheckExamples
 import ConsistencyExamples
 import SourceConsistencyExamples
 import proof.DGG.ReachabilityCatalog

--- a/GTSFImp/GradualTypeCheck.agda
+++ b/GTSFImp/GradualTypeCheck.agda
@@ -1,0 +1,159 @@
+module GradualTypeCheck where
+
+-- File Charter:
+--   * Maybe-valued type synthesis for the GTSFImp gradual source language.
+--   * Returns a synthesized type together with a `GradualTerms` typing
+--     derivation, plus an expected-type wrapper for examples and clients.
+--   * Uses `Consistency2.lower?` to decide consistency and converts successful
+--     searches to the declarative evidence stored in typing derivations.
+--   * The checker is positive-only: failure returns `nothing` rather than a
+--     proof that no typing derivation exists.
+
+open import Agda.Primitive using (Level)
+import Data.Fin as Fin
+open import Data.List using ([]; _∷_)
+open import Data.Maybe using (Maybe; just; nothing)
+import Data.Nat as Nat
+open import Data.Product using (Σ-syntax; _,_)
+open import Relation.Binary.PropositionalEquality
+  using (inspect; refl; subst; sym; [_])
+open import Relation.Nullary using (no; yes)
+
+open import Types
+open import TermCtx
+open import Consistency using (_∼_)
+import Consistency2 as Unique
+open import GradualTerms
+open import Primitives
+  using (Const; constTy; primArgTy; primResultTy)
+import proof.Consistency2 as UniqueProof
+
+------------------------------------------------------------------------
+-- Result predicates and Maybe witnesses
+------------------------------------------------------------------------
+
+HasSomeType : (Δ : TyCtx) → TermCtx Δ → GTerm Δ → Set
+HasSomeType Δ Γ M = Σ[ A ∈ Ty Δ ] Δ ∣ Γ ⊢ M ⦂ A
+
+WellTyped : GTerm Nat.zero → Set
+WellTyped M = HasSomeType Nat.zero [] M
+
+data IsJust {a : Level} {A : Set a} : Maybe A → Set a where
+  is-just : ∀ {x} → IsJust (just x)
+
+fromJust : ∀ {a : Level} {A : Set a} → (m : Maybe A) → IsJust m → A
+fromJust (just x) is-just = x
+fromJust nothing ()
+
+------------------------------------------------------------------------
+-- Decidable fragments used by the checker
+------------------------------------------------------------------------
+
+lookup? : ∀ {Δ} (Γ : TermCtx Δ) (x : Var)
+  → Maybe (Σ[ A ∈ Ty Δ ] Γ ∋ x ⦂ A)
+lookup? [] x = nothing
+lookup? (A ∷ Γ) Nat.zero = just (A , Z)
+lookup? (A ∷ Γ) (Nat.suc x) with lookup? Γ x
+lookup? (A ∷ Γ) (Nat.suc x) | just (B , x∈) = just (B , S x∈)
+lookup? (A ∷ Γ) (Nat.suc x) | nothing = nothing
+
+value? : ∀ {Δ} (M : GTerm Δ) → Maybe (Value M)
+value? (` x) = nothing
+value? (ƛ A ⇒ M) = just (ƛ A ⇒ M)
+value? (L ·[ ℓ ] M) = nothing
+value? (Λ M) = just (Λ M)
+value? (M `[ A ]) = nothing
+value? ($ κ) = just ($ κ)
+value? (L ⊕[ op at ℓ ] M) = nothing
+
+consistent? : ∀ {Δ} (A B : Ty Δ) → Maybe (A ∼ B)
+consistent? A B
+    with Unique.lower? A B | inspect (Unique.lower? A) B
+consistent? A B | just C | [ eq ] =
+  just (UniqueProof.∼ᵘ→∼
+    (subst Unique.IsJust (sym eq) Unique.is-just))
+consistent? A B | nothing | [ eq ] = nothing
+
+------------------------------------------------------------------------
+-- Type checking
+------------------------------------------------------------------------
+
+type-check-app-from : ∀ {Δ} {Γ : TermCtx Δ} {L M : GTerm Δ}
+  → (ℓ : Label)
+  → (A : Ty Δ)
+  → Δ ∣ Γ ⊢ L ⦂ A
+  → (B : Ty Δ)
+  → Δ ∣ Γ ⊢ M ⦂ B
+  → Maybe (HasSomeType Δ Γ (L ·[ ℓ ] M))
+type-check-app-from ℓ (＇ X) L⊢ B M⊢ = nothing
+type-check-app-from ℓ (‵ ι) L⊢ B M⊢ = nothing
+type-check-app-from ℓ ★ L⊢ B M⊢ with consistent? B ★
+type-check-app-from ℓ ★ L⊢ B M⊢ | just B∼★ =
+  just (★ , ⊢·★ L⊢ M⊢ B∼★)
+type-check-app-from ℓ ★ L⊢ B M⊢ | nothing = nothing
+type-check-app-from ℓ (A ⇒ C) L⊢ B M⊢ with consistent? A B
+type-check-app-from ℓ (A ⇒ C) L⊢ B M⊢ | just A∼B =
+  just (C , ⊢· L⊢ M⊢ A∼B)
+type-check-app-from ℓ (A ⇒ C) L⊢ B M⊢ | nothing = nothing
+type-check-app-from ℓ (`∀ A) L⊢ B M⊢ = nothing
+
+type-check : (Δ : TyCtx) → (Γ : TermCtx Δ) → (M : GTerm Δ)
+  → Maybe (HasSomeType Δ Γ M)
+type-check Δ Γ (` x) with lookup? Γ x
+type-check Δ Γ (` x) | just (A , x∈) = just (A , ⊢` x∈)
+type-check Δ Γ (` x) | nothing = nothing
+type-check Δ Γ (ƛ A ⇒ M) with type-check Δ (A ∷ Γ) M
+type-check Δ Γ (ƛ A ⇒ M) | just (B , M⊢) =
+  just (A ⇒ B , ⊢ƛ M⊢)
+type-check Δ Γ (ƛ A ⇒ M) | nothing = nothing
+type-check Δ Γ (L ·[ ℓ ] M)
+    with type-check Δ Γ L | type-check Δ Γ M
+type-check Δ Γ (L ·[ ℓ ] M)
+    | just (A , L⊢) | just (B , M⊢) =
+  type-check-app-from ℓ A L⊢ B M⊢
+type-check Δ Γ (L ·[ ℓ ] M) | nothing | _ = nothing
+type-check Δ Γ (L ·[ ℓ ] M) | just _ | nothing = nothing
+type-check Δ Γ (Λ M) with value? M
+type-check Δ Γ (Λ M) | nothing = nothing
+type-check Δ Γ (Λ M) | just vM
+    with type-check (Nat.suc Δ) (⇑ᶜ Γ) M
+type-check Δ Γ (Λ M) | just vM | nothing = nothing
+type-check Δ Γ (Λ M) | just vM | just (A , M⊢)
+    with occurs? Fin.zero A
+type-check Δ Γ (Λ M) | just vM | just (A , M⊢)
+    | present zero∈A =
+  just (`∀ A , ⊢Λ {zero∈A = zero∈A} vM M⊢)
+type-check Δ Γ (Λ M) | just vM | just (A , M⊢)
+    | absent zero∉A = nothing
+type-check Δ Γ (M `[ A ]) with type-check Δ Γ M
+type-check Δ Γ (M `[ A ]) | just (＇ X , M⊢) = nothing
+type-check Δ Γ (M `[ A ]) | just (‵ ι , M⊢) = nothing
+type-check Δ Γ (M `[ A ]) | just (★ , M⊢) = nothing
+type-check Δ Γ (M `[ A ]) | just (B ⇒ C , M⊢) = nothing
+type-check Δ Γ (M `[ A ]) | just (`∀ B , M⊢) =
+  just (B [ A ]ᵗ , ⊢• M⊢)
+type-check Δ Γ (M `[ A ]) | nothing = nothing
+type-check Δ Γ ($ κ) = just (constTy κ , ⊢$ κ)
+type-check Δ Γ (L ⊕[ op at ℓ ] M)
+    with type-check Δ Γ L | type-check Δ Γ M
+type-check Δ Γ (L ⊕[ op at ℓ ] M)
+    | just (A , L⊢) | just (B , M⊢)
+    with consistent? A (primArgTy op) | consistent? B (primArgTy op)
+type-check Δ Γ (L ⊕[ op at ℓ ] M)
+    | just (A , L⊢) | just (B , M⊢) | just A∼arg | just B∼arg =
+  just (primResultTy op , ⊢⊕ op L⊢ A∼arg M⊢ B∼arg)
+type-check Δ Γ (L ⊕[ op at ℓ ] M)
+    | just (A , L⊢) | just (B , M⊢) | nothing | _ = nothing
+type-check Δ Γ (L ⊕[ op at ℓ ] M)
+    | just (A , L⊢) | just (B , M⊢) | just _ | nothing = nothing
+type-check Δ Γ (L ⊕[ op at ℓ ] M) | nothing | _ = nothing
+type-check Δ Γ (L ⊕[ op at ℓ ] M) | just _ | nothing = nothing
+
+type-check-expect : (Δ : TyCtx) → (Γ : TermCtx Δ) → (M : GTerm Δ)
+  → (A : Ty Δ)
+  → Maybe (Δ ∣ Γ ⊢ M ⦂ A)
+type-check-expect Δ Γ M A with type-check Δ Γ M
+type-check-expect Δ Γ M A | nothing = nothing
+type-check-expect Δ Γ M A | just (B , M⊢) with B ≟Ty A
+type-check-expect Δ Γ M A | just (B , M⊢) | yes refl = just M⊢
+type-check-expect Δ Γ M A | just (B , M⊢) | no B≢A = nothing

--- a/GTSFImp/GradualTypeCheckExamples.agda
+++ b/GTSFImp/GradualTypeCheckExamples.agda
@@ -4,18 +4,23 @@ module GradualTypeCheckExamples where
 --   * Regression examples for `GradualTypeCheck`.
 --   * Exercises polymorphism, dynamic application, primitive operations, and
 --     rejection of terms whose synthesized operator/argument types disagree.
---   * Each accepted example is checked at its expected source type.
+--   * Each accepted example has a checker-produced typing derivation; closed
+--     data examples are compiled and evaluated to their expected result.
 
 import Data.Fin as Fin
 open import Data.Bool using (true)
 open import Data.List using ([])
-open import Data.Maybe using (nothing)
+open import Data.Maybe using (just; nothing)
+open import Data.Product using (proj₂)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 
 open import Types
 open import GradualTerms
 open import GradualTypeCheck
 open import Primitives
+open import TyStore using (store-empty)
+open import Compile using (compile)
+import Example as Ex
 
 ℕᵗ : Ty 0
 ℕᵗ = ‵ `ℕ
@@ -27,23 +32,59 @@ polyId-check :
   IsJust (type-check-expect 0 [] polyId (`∀ (＇ Fin.zero ⇒ ＇ Fin.zero)))
 polyId-check = is-just
 
+polyId-⊢ : 0 ∣ [] ⊢ polyId ⦂ `∀ (＇ Fin.zero ⇒ ＇ Fin.zero)
+polyId-⊢ =
+  fromJust
+    (type-check-expect 0 [] polyId (`∀ (＇ Fin.zero ⇒ ＇ Fin.zero)))
+    polyId-check
+
 polyIdNat : GTerm 0
 polyIdNat = (polyId `[ ℕᵗ ]) ·[ 0 ] $ (κℕ 42)
 
 polyIdNat-check : IsJust (type-check-expect 0 [] polyIdNat ℕᵗ)
 polyIdNat-check = is-just
 
-dynamicIdNat : GTerm 0
-dynamicIdNat = (ƛ ★ ⇒ ` 0) ·[ 1 ] $ (κℕ 42)
+polyIdNat-⊢ : 0 ∣ [] ⊢ polyIdNat ⦂ ℕᵗ
+polyIdNat-⊢ =
+  fromJust (type-check-expect 0 [] polyIdNat ℕᵗ) polyIdNat-check
 
-dynamicIdNat-check : IsJust (type-check-expect 0 [] dynamicIdNat ★)
+polyIdNat-eval :
+  Ex.evalNat Ex.gas
+    (proj₂ (compile {Σ = store-empty} polyIdNat-⊢)) ≡ just 42
+polyIdNat-eval = refl
+
+dynamicIdNat : GTerm 0
+dynamicIdNat =
+  (ƛ ℕᵗ ⇒ ` 0) ·[ 2 ] ((ƛ ★ ⇒ ` 0) ·[ 1 ] $ (κℕ 42))
+
+dynamicIdNat-check : IsJust (type-check-expect 0 [] dynamicIdNat ℕᵗ)
 dynamicIdNat-check = is-just
+
+dynamicIdNat-⊢ : 0 ∣ [] ⊢ dynamicIdNat ⦂ ℕᵗ
+dynamicIdNat-⊢ =
+  fromJust
+    (type-check-expect 0 [] dynamicIdNat ℕᵗ)
+    dynamicIdNat-check
+
+dynamicIdNat-eval :
+  Ex.evalNat Ex.gas
+    (proj₂ (compile {Σ = store-empty} dynamicIdNat-⊢)) ≡ just 42
+dynamicIdNat-eval = refl
 
 add-example : GTerm 0
 add-example = $ (κℕ 20) ⊕[ addℕ at 2 ] $ (κℕ 22)
 
 add-example-check : IsJust (type-check-expect 0 [] add-example ℕᵗ)
 add-example-check = is-just
+
+add-example-⊢ : 0 ∣ [] ⊢ add-example ⦂ ℕᵗ
+add-example-⊢ =
+  fromJust (type-check-expect 0 [] add-example ℕᵗ) add-example-check
+
+add-example-eval :
+  Ex.evalNat Ex.gas
+    (proj₂ (compile {Σ = store-empty} add-example-⊢)) ≡ just 42
+add-example-eval = refl
 
 bad-application : GTerm 0
 bad-application = $ (κℕ 0) ·[ 3 ] $ (κℕ 1)

--- a/GTSFImp/GradualTypeCheckExamples.agda
+++ b/GTSFImp/GradualTypeCheckExamples.agda
@@ -1,0 +1,58 @@
+module GradualTypeCheckExamples where
+
+-- File Charter:
+--   * Regression examples for `GradualTypeCheck`.
+--   * Exercises polymorphism, dynamic application, primitive operations, and
+--     rejection of terms whose synthesized operator/argument types disagree.
+--   * Each accepted example is checked at its expected source type.
+
+import Data.Fin as Fin
+open import Data.Bool using (true)
+open import Data.List using ([])
+open import Data.Maybe using (nothing)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types
+open import GradualTerms
+open import GradualTypeCheck
+open import Primitives
+
+ℕᵗ : Ty 0
+ℕᵗ = ‵ `ℕ
+
+polyId : GTerm 0
+polyId = Λ (ƛ ＇ Fin.zero ⇒ ` 0)
+
+polyId-check :
+  IsJust (type-check-expect 0 [] polyId (`∀ (＇ Fin.zero ⇒ ＇ Fin.zero)))
+polyId-check = is-just
+
+polyIdNat : GTerm 0
+polyIdNat = (polyId `[ ℕᵗ ]) ·[ 0 ] $ (κℕ 42)
+
+polyIdNat-check : IsJust (type-check-expect 0 [] polyIdNat ℕᵗ)
+polyIdNat-check = is-just
+
+dynamicIdNat : GTerm 0
+dynamicIdNat = (ƛ ★ ⇒ ` 0) ·[ 1 ] $ (κℕ 42)
+
+dynamicIdNat-check : IsJust (type-check-expect 0 [] dynamicIdNat ★)
+dynamicIdNat-check = is-just
+
+add-example : GTerm 0
+add-example = $ (κℕ 20) ⊕[ addℕ at 2 ] $ (κℕ 22)
+
+add-example-check : IsJust (type-check-expect 0 [] add-example ℕᵗ)
+add-example-check = is-just
+
+bad-application : GTerm 0
+bad-application = $ (κℕ 0) ·[ 3 ] $ (κℕ 1)
+
+bad-application-rejected : type-check 0 [] bad-application ≡ nothing
+bad-application-rejected = refl
+
+bad-addition : GTerm 0
+bad-addition = $ (κ𝔹 true) ⊕[ addℕ at 4 ] $ (κℕ 1)
+
+bad-addition-rejected : type-check 0 [] bad-addition ≡ nothing
+bad-addition-rejected = refl

--- a/GTSFImp/proof/DGG/ReachabilityCatalog.agda
+++ b/GTSFImp/proof/DGG/ReachabilityCatalog.agda
@@ -26,6 +26,8 @@ open import Consistency using
    ？_; _↦_; ∀ᶜ_; inst_; gen_; bot-elim; bot-intro; sym∼;
    X∼★ᵍ; ★∼Xᵍ)
 open import GradualTerms
+open import GradualTypeCheck
+  using (fromJust; is-just; type-check-expect)
 open import GradualTermImprecision using
   (CtxImp; ctx-imp; _∣_⊢ᴳ_⊑_⦂_⊑_∶_; _∋ⁱ_⦂_;
    Zⁱ; Sⁱ; LiftCtxⁱ; lift-[]; lift-∷; x⊑xᴳ; ƛ⊑ƛᴳ;
@@ -707,11 +709,9 @@ returnPolyAtX =
 
 returnPolyAtX⊢ : Δ₀ ∣ [] ⊢ returnPolyAtX ⦂ ★⇒★₀
 returnPolyAtX⊢ =
-  ⊢·
-    (⊢• (⊢Λ {zero∈A = X∈X⇒X⇒X}
-      (ƛ X₀ ⇒ polyAtX) (⊢ƛ polyAtX⊢)))
-    (nat⊢ 7)
-    (？ (id (‵ `ℕ)))
+  fromJust
+    (type-check-expect Δ₀ [] returnPolyAtX ★⇒★₀)
+    is-just
 
 badDynBool : GTerm Δ₀
 badDynBool =
@@ -719,11 +719,9 @@ badDynBool =
 
 badDynBool⊢ : Δ₀ ∣ [] ⊢ badDynBool ⦂ ℕ₀
 badDynBool⊢ =
-  ⊢⊕ addℕ
-    (⊢· dynId⊢ (⊢$ (κ𝔹 true)) (？ (id (‵ `𝔹))))
-    (？ (id (‵ `ℕ)))
-    (nat⊢ 1)
-    (id (‵ `ℕ))
+  fromJust
+    (type-check-expect Δ₀ [] badDynBool ℕ₀)
+    is-just
 
 returnPolyFun : GTerm Δ₀
 returnPolyFun = ƛ ℕ₀ ⇒ polyId
@@ -736,10 +734,9 @@ returnPolyUse = ((returnPolyFun ·[ 41 ] nat 0) `[ ℕ₀ ]) ·[ 42 ] nat 2
 
 returnPolyUse⊢ : Δ₀ ∣ [] ⊢ returnPolyUse ⦂ ℕ₀
 returnPolyUse⊢ =
-  ⊢·
-    (⊢• (⊢· returnPolyFun⊢ (nat⊢ 0) (id (‵ `ℕ))))
-    (nat⊢ 2)
-    (id (‵ `ℕ))
+  fromJust
+    (type-check-expect Δ₀ [] returnPolyUse ℕ₀)
+    is-just
 
 usePolyNat : GTerm Δ₀
 usePolyNat = ƛ ∀X⇒X₀ ⇒ (((` 0) `[ ℕ₀ ]) ·[ 43 ] nat 5)
@@ -753,15 +750,18 @@ higherOrderPolyArg = usePolyNat ·[ 44 ] polyId
 
 higherOrderPolyArg⊢ : Δ₀ ∣ [] ⊢ higherOrderPolyArg ⦂ ℕ₀
 higherOrderPolyArg⊢ =
-  ⊢· usePolyNat⊢ (polyId⊢ {Δ = Δ₀})
-    (∀X⇒X∼∀X⇒X {Δ = Δ₀})
+  fromJust
+    (type-check-expect Δ₀ [] higherOrderPolyArg ℕ₀)
+    is-just
 
 higherOrderSharedArg : GTerm Δ₀
 higherOrderSharedArg = usePolyNat ·[ 45 ] polyIdSelf
 
 higherOrderSharedArg⊢ : Δ₀ ∣ [] ⊢ higherOrderSharedArg ⦂ ℕ₀
 higherOrderSharedArg⊢ =
-  ⊢· usePolyNat⊢ polyIdSelf⊢ (∀X⇒X∼∀X⇒X {Δ = Δ₀})
+  fromJust
+    (type-check-expect Δ₀ [] higherOrderSharedArg ℕ₀)
+    is-just
 
 ------------------------------------------------------------------------
 -- Phase-1 catalog entries


### PR DESCRIPTION
## Summary

- adds a Maybe-valued type synthesizer for GTSFImp `GradualTerms` that returns a type together with its typing derivation
- decides consistency through `Consistency2.lower?` and converts successful searches to the declarative evidence expected by the source typing judgment
- checks lambda values, polymorphic occurrence side conditions, applications through both arrow and dynamic types, type application, constants, and typed primitives
- adds accepted and rejected regression examples
- migrates five concrete `ReachabilityCatalog` leaf typings to checker-produced witnesses while preserving its normalization-sensitive compiler and evaluator gates

## Why

GTSFImp had executable checking for related calculi but no checker for its intrinsically scoped gradual source terms. Source programs therefore required manual typing derivations even when their typing was fully syntactic and decidable.

The new checker provides a small canonical API for synthesizing source typings and checking an expected type. It is positive-only: failure returns `nothing` rather than negative typing evidence.

## Validation

- `agda -v0 GradualTypeCheck.agda`
- `agda -v0 GradualTypeCheckExamples.agda`
- `agda -v0 proof/DGG/ReachabilityCatalog.agda`
- `agda -v0 All.agda`
- `git diff --check`