### PR TITLE
Experiment with contextual coercion typing for beta-inst

### DIFF
--- a/GTSFImp/experimental/ContextualActivationRegression.agda
+++ b/GTSFImp/experimental/ContextualActivationRegression.agda
@@ -1,0 +1,78 @@
+module experimental.ContextualActivationRegression where
+
+-- File Charter:
+--   * Retains the former nested-generalization counterexample as a positive
+--     regression test for automatic activation.
+--   * Shows that removing raw `gen` and `inst` endpoint annotations lets the
+--     existing `inst` side conditions support the phase change.
+--   * Leaves the live GTSFImp development unchanged.
+
+open import Data.Fin using (zero; suc)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types renaming (`∀ to `∀ᵗ)
+import Consistency as C
+import experimental.ContextualCoercion as CC
+import experimental.ContextualCoercionActivation as CCA
+
+------------------------------------------------------------------------
+-- A pending body satisfying all `inst` side conditions
+------------------------------------------------------------------------
+
+A : Ty 1
+A = ＇ zero ⇒ ★
+
+B-body : Ty 1
+B-body = ★ ⇒ ＇ zero
+
+B : Ty 0
+B = `∀ᵗ B-body
+
+inner : CC.Coercion 2
+inner = CC.inst-in (suc zero) CC.↦ CC.？ CC.id
+
+body : CC.Coercion 1
+body = CC.gen inner
+
+focus-in-pending :
+  CC.flipCtx (CC.genCtx CC.pending0) (suc zero)
+    ≡ CC.inst-in-bound CC.pending
+focus-in-pending = refl
+
+gen-variable-ordinary :
+  CC.genCtx CC.pending0 zero ≡ CC.ordinary C.★∼X
+gen-variable-ordinary = refl
+
+inner-pending :
+  CC.genCtx CC.pending0 CC.⊢ inner
+    ∶ (＇ suc zero ⇒ ★) ⇒ (★ ⇒ ＇ zero)
+inner-pending =
+  CC.⊢↦
+    (CC.⊢inst-in-pending focus-in-pending)
+    (CC.⊢proj
+      (CC.generic-X
+        (CC.ordinary-entry C.★∼X gen-variable-ordinary))
+      (C.★∼Xᵍ refl)
+      (CC.⊢id (＇ zero))
+      nonstar-X)
+
+body-pending :
+  CC.pending0 CC.⊢ body ∶ A ⇒ ⇑ᵗ B
+body-pending =
+  CC.⊢gen nonvar-fun
+    (∈-fun-right ∉-star var-∈)
+    inner-pending
+    (λ ())
+
+inst-side-conditions :
+  CC.ordinaryCtx CC.⊢ CC.inst body ∶ (`∀ᵗ A) ⇒ B
+inst-side-conditions =
+  CC.⊢inst nonvar-fun (∈-fun-left var-∈) body-pending (λ ())
+
+------------------------------------------------------------------------
+-- The unchanged raw body receives the active source type
+------------------------------------------------------------------------
+
+body-active :
+  CC.active0 CC.⊢ body ∶ (★ ⇒ ★) ⇒ ⇑ᵗ B
+body-active = CCA.activate-newest-typing body-pending

--- a/GTSFImp/experimental/ContextualBetaInst.agda
+++ b/GTSFImp/experimental/ContextualBetaInst.agda
@@ -1,0 +1,284 @@
+module experimental.ContextualBetaInst where
+
+-- File Charter:
+--   * Gives the leaf-local contextual-coercion experiment a small term and
+--     reduction layer.
+--   * Records the pending-to-active typing change required by `β-inst` while
+--     keeping the raw body coercion unchanged.
+--   * Lowers active `inst-in` and `inst-out` leaves to raw identity coercions.
+--   * Proves preservation for the experimental `β-inst` rule.
+--   * Leaves the live GTSFImp term and reduction definitions unchanged.
+
+import Data.Fin as Fin
+open import Data.List using ([])
+import Data.Nat as Nat
+open import Data.Product using (Σ-syntax; _×_; _,_; proj₂)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types
+open import TyStore using (store-empty; Z∋)
+open import TermCtx using (Z)
+open import Conversion using (Conv↑; replaceTy; 〖_,_↑_〗; _⊢↑_)
+open import Primitives using (κℕ)
+import CastTerms as Live
+import Reduction as LiveReduction
+import proof.TypeInTermSubst as LiveTypeSubst
+import proof.TypeSafety.Preservation as LivePreservation
+import experimental.ContextualCoercion as CC
+import experimental.ContextualCoercionActivation as CCA
+
+private
+  variable
+    Δ Δ′ : TyCtx
+
+------------------------------------------------------------------------
+-- Experimental terms
+------------------------------------------------------------------------
+
+infixl 7 _⦂∀_[_]
+infixl 7 _↑_
+infixl 7 _⟨_⟩
+
+data Term : (Δ : TyCtx) → Set where
+  live : Live.Term Δ → Term Δ
+
+  _⦂∀_[_] : Term Δ → Ty (Nat.suc Δ) → Ty Δ → Term Δ
+
+  _↑_ : Term Δ → {A B : Ty Δ} → Conv↑ Δ A B → Term Δ
+
+  _⟨_⟩ : Term Δ → CC.Coercion Δ → Term Δ
+
+------------------------------------------------------------------------
+-- Typing for the experimental wrappers
+------------------------------------------------------------------------
+
+infix 4 _⊢_⦂_
+
+data _⊢_⦂_ (Γ : Live.Ctx) : Term (Live.Δᵉ Γ) →
+    Ty (Live.Δᵉ Γ) → Set where
+
+  ⊢live : ∀ {M A}
+    → Γ Live.⊢ M ⦂ A
+    → Γ ⊢ live M ⦂ A
+
+  ⊢• : ∀ {M A B}
+    → Γ ⊢ M ⦂ (`∀ B)
+    → Γ ⊢ M ⦂∀ B [ A ] ⦂ B [ A ]ᵗ
+
+  ⊢reveal : ∀ {M A B} {c : Conv↑ (Live.Δᵉ Γ) A B}
+    → Live.Σᵉ Γ ⊢↑ c
+    → Γ ⊢ M ⦂ A
+    → Γ ⊢ M ↑ c ⦂ B
+
+  ⊢cast : ∀ {M κ c A B}
+    → κ CC.⊢ c ∶ A ⇒ B
+    → Γ ⊢ M ⦂ A
+    → Γ ⊢ M ⟨ c ⟩ ⦂ B
+
+------------------------------------------------------------------------
+-- Values and pure coercion steps
+------------------------------------------------------------------------
+
+data Value {Δ : TyCtx} : Term Δ → Set where
+  live : ∀ {V}
+    → Live.Value V
+    → Value (live V)
+
+infix 2 _—→_
+
+data _—→_ {Δ : TyCtx} : Term Δ → Term Δ → Set where
+
+  id-step : ∀ {V}
+    → Live.Value V
+    → live V ⟨ CC.id ⟩ —→ live V
+
+  inst-out-step : ∀ {V X}
+    → Live.Value V
+    → live V ⟨ CC.inst-out X ⟩ —→ live V ⟨ CC.id ⟩
+
+  inst-in-step : ∀ {V X}
+    → Live.Value V
+    → live V ⟨ CC.inst-in X ⟩ —→ live V ⟨ CC.id ⟩
+
+------------------------------------------------------------------------
+-- Store-changing instantiation
+------------------------------------------------------------------------
+
+infix 2 _—→[_]_
+
+data _—→[_]_ : ∀ {Δ Δ′}
+  → Term Δ
+  → LiveReduction.StoreChange Δ Δ′
+  → Term Δ′
+  → Set where
+
+  β-inst : ∀ {Δ} {V : Live.Term Δ}
+      {A : Ty (Nat.suc Δ)} {B : Ty Δ}
+      {c : CC.Coercion (Nat.suc Δ)}
+    → NonVar A
+    → Fin.zero ∈ᵗ A
+    → CC.instCtx CC.pending (CC.ordinaryCtx {Δ = Δ})
+        CC.⊢ c ∶ A ⇒ ⇑ᵗ B
+    → Live.Value V
+    → B ≢ ★
+    → live V ⟨ CC.inst c ⟩
+        —→[ LiveReduction.bind ★ ]
+      ((live (Live.⇑ᵗᵐ V)
+          ⦂∀ LiveReduction.applyBody (LiveReduction.bind ★) A
+            [ ＇ Fin.zero ])
+        ↑ 〖 Fin.zero , ★ ↑ A 〗)
+        ⟨ c ⟩
+
+------------------------------------------------------------------------
+-- Type preservation for `β-inst`
+------------------------------------------------------------------------
+
+transport-typing : ∀ {Γ : Live.Ctx} {M A B}
+  → A ≡ B
+  → Γ ⊢ M ⦂ A
+  → Γ ⊢ M ⦂ B
+transport-typing refl M⊢ = M⊢
+
+β-inst-redex-typing : ∀ {Γ : Live.Ctx}
+    {V : Live.Term (Live.Δᵉ Γ)}
+    {A : Ty (Nat.suc (Live.Δᵉ Γ))}
+    {B : Ty (Live.Δᵉ Γ)}
+    {c : CC.Coercion (Nat.suc (Live.Δᵉ Γ))}
+  → NonVar A
+  → Fin.zero ∈ᵗ A
+  → CC.instCtx CC.pending
+      (CC.ordinaryCtx {Δ = Live.Δᵉ Γ}) CC.⊢ c ∶ A ⇒ ⇑ᵗ B
+  → (B≢★ : B ≢ ★)
+  → Γ Live.⊢ V ⦂ (`∀ A)
+  → Γ ⊢ live V ⟨ CC.inst c ⟩ ⦂ B
+β-inst-redex-typing nonvar occurs pending-c⊢ B≢★ V⊢ =
+  ⊢cast (CC.⊢inst nonvar occurs pending-c⊢ B≢★) (⊢live V⊢)
+
+β-inst-contractum-typing : ∀ {Γ : Live.Ctx}
+    {V : Live.Term (Live.Δᵉ Γ)}
+    {A : Ty (Nat.suc (Live.Δᵉ Γ))}
+    {B : Ty (Live.Δᵉ Γ)}
+    {c : CC.Coercion (Nat.suc (Live.Δᵉ Γ))}
+  → CC.instCtx CC.pending
+      (CC.ordinaryCtx {Δ = Live.Δᵉ Γ}) CC.⊢ c ∶ A ⇒ ⇑ᵗ B
+  → Γ Live.⊢ V ⦂ (`∀ A)
+  → (Γ Live.,ˢ ★) ⊢
+      ((live (Live.⇑ᵗᵐ V)
+          ⦂∀ LiveReduction.applyBody (LiveReduction.bind ★) A
+            [ ＇ Fin.zero ])
+        ↑ 〖 Fin.zero , ★ ↑ A 〗)
+      ⟨ c ⟩
+      ⦂ ⇑ᵗ B
+β-inst-contractum-typing {A = A} pending-c⊢ V⊢ =
+  ⊢cast active-c⊢ revealed⊢
+  where
+  active-c⊢ = CCA.activate-newest-typing pending-c⊢
+
+  shifted⊢ =
+    ⊢live (LiveTypeSubst.typing-shiftᵗ-bind {C = ★} V⊢)
+
+  applied⊢ = ⊢• shifted⊢
+
+  opened⊢ =
+    transport-typing (LivePreservation.applyBody-open-zero A) applied⊢
+
+  reveal⊢ =
+    LivePreservation.structural-reveal-typing A (Z∋ refl)
+
+  revealed⊢ = ⊢reveal reveal⊢ opened⊢
+
+β-inst-preservation : ∀ {Γ : Live.Ctx}
+    {V : Live.Term (Live.Δᵉ Γ)}
+    {A : Ty (Nat.suc (Live.Δᵉ Γ))}
+    {B : Ty (Live.Δᵉ Γ)}
+    {c : CC.Coercion (Nat.suc (Live.Δᵉ Γ))}
+  → NonVar A
+  → Fin.zero ∈ᵗ A
+  → CC.instCtx CC.pending
+      (CC.ordinaryCtx {Δ = Live.Δᵉ Γ}) CC.⊢ c ∶ A ⇒ ⇑ᵗ B
+  → Live.Value V
+  → B ≢ ★
+  → Γ Live.⊢ V ⦂ (`∀ A)
+  → Σ[ N ∈ Term (Nat.suc (Live.Δᵉ Γ)) ]
+      (live V ⟨ CC.inst c ⟩ —→[ LiveReduction.bind ★ ] N)
+      × ((Γ Live.,ˢ ★) ⊢ N ⦂ ⇑ᵗ B)
+β-inst-preservation nonvar occurs pending-c⊢ vV B≢★ V⊢ =
+  _ , β-inst nonvar occurs pending-c⊢ vV B≢★
+    , β-inst-contractum-typing pending-c⊢ V⊢
+
+------------------------------------------------------------------------
+-- Focused checked examples
+------------------------------------------------------------------------
+
+Dyn⇒Dyn0 : Ty 0
+Dyn⇒Dyn0 = ★ ⇒ ★
+
+identity-inst-coercion : CC.Coercion 0
+identity-inst-coercion = CC.inst CC.identity-body-coercion
+
+identity-inst-typing :
+  CC.ordinaryCtx CC.⊢ identity-inst-coercion
+    ∶ (`∀ CC.X⇒X) ⇒ Dyn⇒Dyn0
+identity-inst-typing =
+  CC.⊢inst nonvar-fun (∈-fun-left var-∈)
+    CC.identity-body-pending (λ ())
+
+poly-id : Live.Term 0
+poly-id = Live.Λ (Live.ƛ (Live.` 0))
+
+poly-id-value : Live.Value poly-id
+poly-id-value = Live.Λ (Live.ƛ (Live.` 0))
+
+identity-inst-redex : Term 0
+identity-inst-redex = live poly-id ⟨ identity-inst-coercion ⟩
+
+identity-inst-contractum : Term 1
+identity-inst-contractum =
+  ((live (Live.⇑ᵗᵐ poly-id)
+      ⦂∀ LiveReduction.applyBody (LiveReduction.bind ★) CC.X⇒X
+        [ ＇ Fin.zero ])
+    ↑ 〖 Fin.zero , ★ ↑ CC.X⇒X 〗)
+    ⟨ CC.identity-body-coercion ⟩
+
+identity-β-inst :
+  identity-inst-redex —→[ LiveReduction.bind ★ ]
+    identity-inst-contractum
+identity-β-inst =
+  β-inst nonvar-fun (∈-fun-left var-∈)
+    CC.identity-body-pending poly-id-value (λ ())
+
+identity-ctx : Live.Ctx
+identity-ctx = Live.⟨ 0 , store-empty , [] ⟩
+
+poly-id-⊢ : identity-ctx Live.⊢ poly-id ⦂ (`∀ CC.X⇒X)
+poly-id-⊢ =
+  Live.⊢Λ (Live.ƛ (Live.` 0)) (Live.⊢ƛ (Live.⊢` Z))
+
+identity-inst-redex-⊢ :
+  identity-ctx ⊢ identity-inst-redex ⦂ Dyn⇒Dyn0
+identity-inst-redex-⊢ =
+  β-inst-redex-typing nonvar-fun (∈-fun-left var-∈)
+    CC.identity-body-pending (λ ()) poly-id-⊢
+
+identity-inst-contractum-⊢ :
+  (identity-ctx Live.,ˢ ★) ⊢ identity-inst-contractum ⦂ ⇑ᵗ Dyn⇒Dyn0
+identity-inst-contractum-⊢ =
+  proj₂ (proj₂ (β-inst-preservation nonvar-fun
+    (∈-fun-left var-∈) CC.identity-body-pending
+    poly-id-value (λ ()) poly-id-⊢))
+
+nat-value : Live.Term 1
+nat-value = Live.$ (κℕ 0)
+
+nat-value-value : Live.Value nat-value
+nat-value-value = Live.$ (κℕ 0)
+
+inst-out-lowers-to-id :
+  live nat-value ⟨ CC.inst-out Fin.zero ⟩ —→
+    live nat-value ⟨ CC.id ⟩
+inst-out-lowers-to-id = inst-out-step nat-value-value
+
+inst-in-lowers-to-id :
+  live nat-value ⟨ CC.inst-in Fin.zero ⟩ —→
+    live nat-value ⟨ CC.id ⟩
+inst-in-lowers-to-id = inst-in-step nat-value-value

--- a/GTSFImp/experimental/ContextualCoercion.agda
+++ b/GTSFImp/experimental/ContextualCoercion.agda
@@ -1,0 +1,757 @@
+module experimental.ContextualCoercion where
+
+-- File Charter:
+--   * Defines raw `Coercion` syntax separately from contextual typing.
+--   * Realizes instantiation-bound variables only at `inst-out` and
+--     `inst-in` leaves; all structural typing rules use ordinary endpoints.
+--   * Prevents generic injection and projection from handling an
+--     instantiation-bound ground variable.
+--   * Relates contextual coercion typing to live consistency.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Fin using (zero; suc)
+open import Data.Nat using (suc)
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; cong; cong₂; subst; sym; trans)
+
+open import Types renaming (`∀ to `∀ᵗ)
+open import FunExt using (funext)
+import Consistency as C
+
+private
+  variable
+    Δ : TyCtx
+    A A′ B B′ : Ty Δ
+
+------------------------------------------------------------------------
+-- Raw coercions
+------------------------------------------------------------------------
+
+infixr 7 _↦_
+infix 8 _! ？_
+
+data Coercion : (Δ : TyCtx) → Set where
+  id : Coercion Δ
+  _↦_ : Coercion Δ → Coercion Δ → Coercion Δ
+  `∀_ : Coercion (suc Δ) → Coercion Δ
+  _! : Coercion Δ → Coercion Δ
+  ？_ : Coercion Δ → Coercion Δ
+  inst-out : TyVar Δ → Coercion Δ
+  inst-in : TyVar Δ → Coercion Δ
+  inst : Coercion (suc Δ) → Coercion Δ
+  gen : Coercion (suc Δ) → Coercion Δ
+  bot-elim : Coercion Δ
+  bot-intro : Coercion Δ
+
+------------------------------------------------------------------------
+-- Cast contexts and consistency environments
+------------------------------------------------------------------------
+
+data Phase : Set where
+  pending active : Phase
+
+data Entry : Set where
+  ordinary : C.Var∼ → Entry
+  inst-out-bound : Phase → Entry
+  inst-in-bound : Phase → Entry
+
+CastCtx : TyCtx → Set
+CastCtx Δ = TyVar Δ → Entry
+
+entryMode : Entry → C.Var∼
+entryMode (ordinary mode) = mode
+entryMode (inst-out-bound phase) = C.X∼★
+entryMode (inst-in-bound phase) = C.★∼X
+
+toEnv∼ : CastCtx Δ → C.Env∼ Δ
+toEnv∼ κ X = entryMode (κ X)
+
+fromEnv∼ : C.Env∼ Δ → CastCtx Δ
+fromEnv∼ μ X = ordinary (μ X)
+
+toEnv∼-fromEnv∼ : ∀ {μ : C.Env∼ Δ}
+  → toEnv∼ (fromEnv∼ μ) ≡ μ
+toEnv∼-fromEnv∼ = refl
+
+ordinaryCtx : ∀ {Δ} → CastCtx Δ
+ordinaryCtx = fromEnv∼ C.idᶜ
+
+flipEntry : Entry → Entry
+flipEntry (ordinary mode) = ordinary (C.flipVar∼ mode)
+flipEntry (inst-out-bound phase) = inst-in-bound phase
+flipEntry (inst-in-bound phase) = inst-out-bound phase
+
+flipCtx : CastCtx Δ → CastCtx Δ
+flipCtx κ X = flipEntry (κ X)
+
+extCtx : CastCtx Δ → CastCtx (suc Δ)
+extCtx κ zero = ordinary C.X∼X
+extCtx κ (suc X) = κ X
+
+instCtx : Phase → CastCtx Δ → CastCtx (suc Δ)
+instCtx phase κ zero = inst-out-bound phase
+instCtx phase κ (suc X) = κ X
+
+genCtx : CastCtx Δ → CastCtx (suc Δ)
+genCtx κ zero = ordinary C.★∼X
+genCtx κ (suc X) = κ X
+
+toEnv∼-flip : ∀ {κ : CastCtx Δ}
+  → toEnv∼ (flipCtx κ) ≡ C.flipᵐ (toEnv∼ κ)
+toEnv∼-flip {κ = κ} = funext λ X → entry-flip (κ X)
+  where
+  entry-flip : ∀ entry
+    → entryMode (flipEntry entry) ≡ C.flipVar∼ (entryMode entry)
+  entry-flip (ordinary C.X∼X) = refl
+  entry-flip (ordinary C.X∼★) = refl
+  entry-flip (ordinary C.★∼X) = refl
+  entry-flip (ordinary C.★∼X∼★) = refl
+  entry-flip (inst-out-bound phase) = refl
+  entry-flip (inst-in-bound phase) = refl
+
+toEnv∼-ext : ∀ {κ : CastCtx Δ}
+  → toEnv∼ (extCtx κ) ≡ C.extᵐ (toEnv∼ κ)
+toEnv∼-ext = funext λ { zero → refl; (suc X) → refl }
+
+toEnv∼-inst : ∀ phase {κ : CastCtx Δ}
+  → toEnv∼ (instCtx phase κ) ≡ C.instᵐ (toEnv∼ κ)
+toEnv∼-inst phase = funext λ { zero → refl; (suc X) → refl }
+
+toEnv∼-gen : ∀ {κ : CastCtx Δ}
+  → toEnv∼ (genCtx κ) ≡ C.genᵐ (toEnv∼ κ)
+toEnv∼-gen = funext λ { zero → refl; (suc X) → refl }
+
+------------------------------------------------------------------------
+-- Leaf-local realization and generic-ground gate
+------------------------------------------------------------------------
+
+phaseType : ∀ {Δ} → Phase → TyVar Δ → Ty Δ
+phaseType pending X = ＇ X
+phaseType active X = ★
+
+data OrdinaryVariable {Δ : TyCtx} (κ : CastCtx Δ)
+    (X : TyVar Δ) : Set where
+  ordinary-entry : ∀ mode
+    → κ X ≡ ordinary mode
+    → OrdinaryVariable κ X
+
+data GenericGround {Δ : TyCtx} (κ : CastCtx Δ) : Ty Δ → Set where
+  generic-⇒ : GenericGround κ (★ ⇒ ★)
+  generic-ι : ∀ {ι} → GenericGround κ (‵ ι)
+  generic-X : ∀ {X}
+    → OrdinaryVariable κ X
+    → GenericGround κ (＇ X)
+  generic-∀ : GenericGround κ (`∀ᵗ ★)
+
+generic-ground : ∀ {κ : CastCtx Δ} {G}
+  → GenericGround κ G
+  → Ground G
+generic-ground generic-⇒ = ★⇒★
+generic-ground generic-ι = ‵ _
+generic-ground (generic-X {X = X} ordinary-X) = ＇ X
+generic-ground generic-∀ = ∀★
+
+------------------------------------------------------------------------
+-- Context-dependent coercion typing
+------------------------------------------------------------------------
+
+infix 4 _⊢_∶_⇒_
+
+data _⊢_∶_⇒_ {Δ : TyCtx} (κ : CastCtx Δ) :
+    Coercion Δ → Ty Δ → Ty Δ → Set where
+
+  ⊢id : ∀ {A}
+    → Atom A
+    → κ ⊢ id ∶ A ⇒ A
+
+  ⊢↦ : ∀ {c d A A′ B B′}
+    → flipCtx κ ⊢ c ∶ A′ ⇒ A
+    → κ ⊢ d ∶ B ⇒ B′
+    → κ ⊢ c ↦ d ∶ (A ⇒ B) ⇒ (A′ ⇒ B′)
+
+  ⊢∀ : ∀ {c A B}
+    → extCtx κ ⊢ c ∶ A ⇒ B
+    → κ ⊢ `∀ c ∶ `∀ᵗ A ⇒ `∀ᵗ B
+
+  ⊢inj : ∀ {c A G}
+    → GenericGround κ G
+    → C._⊢_∼★ (toEnv∼ κ) G
+    → κ ⊢ c ∶ A ⇒ G
+    → NonStar A
+    → κ ⊢ c ! ∶ A ⇒ ★
+
+  ⊢proj : ∀ {c G B}
+    → GenericGround κ G
+    → C._⊢★∼_ (toEnv∼ κ) G
+    → κ ⊢ c ∶ G ⇒ B
+    → NonStar B
+    → κ ⊢ ？ c ∶ ★ ⇒ B
+
+  ⊢inst-out-pending : ∀ {X}
+    → κ X ≡ inst-out-bound pending
+    → κ ⊢ inst-out X ∶ ＇ X ⇒ ★
+
+  ⊢inst-out-active : ∀ {X}
+    → κ X ≡ inst-out-bound active
+    → κ ⊢ inst-out X ∶ ★ ⇒ ★
+
+  ⊢inst-in-pending : ∀ {X}
+    → κ X ≡ inst-in-bound pending
+    → κ ⊢ inst-in X ∶ ★ ⇒ ＇ X
+
+  ⊢inst-in-active : ∀ {X}
+    → κ X ≡ inst-in-bound active
+    → κ ⊢ inst-in X ∶ ★ ⇒ ★
+
+  ⊢inst : ∀ {A B c}
+    → NonVar A
+    → zero ∈ᵗ A
+    → instCtx pending κ ⊢ c ∶ A ⇒ ⇑ᵗ B
+    → B ≢ ★
+    → κ ⊢ inst c ∶ `∀ᵗ A ⇒ B
+
+  ⊢gen : ∀ {A B c}
+    → NonVar B
+    → zero ∈ᵗ B
+    → genCtx κ ⊢ c ∶ ⇑ᵗ A ⇒ B
+    → A ≢ ★
+    → κ ⊢ gen c ∶ A ⇒ `∀ᵗ B
+
+  ⊢bot-elim : κ ⊢ bot-elim ∶ `∀ᵗ (＇ zero) ⇒ `∀ᵗ ★
+
+  ⊢bot-intro : κ ⊢ bot-intro ∶ `∀ᵗ ★ ⇒ `∀ᵗ (＇ zero)
+
+------------------------------------------------------------------------
+-- Forward correspondence with live consistency
+------------------------------------------------------------------------
+
+transport-consistency : ∀ {μ ν : C.Env∼ Δ} {A B}
+  → μ ≡ ν
+  → C._⊢_∼_ μ A B
+  → C._⊢_∼_ ν A B
+transport-consistency refl c = c
+
+inst-out-leaf-consistency : ∀ {κ : CastCtx Δ} {X phase}
+  → κ X ≡ inst-out-bound phase
+  → C._⊢_∼_ (toEnv∼ κ) (phaseType phase X) ★
+inst-out-leaf-consistency {X = X} {phase = pending} eq =
+  C._! ⦃ Gᵍ = ＇ X ⦄
+    ⦃ G∼★ = C.X∼★ᵍ (cong entryMode eq) ⦄
+    (C.id (＇ X)) ⦃ Ans = nonstar-X ⦄
+inst-out-leaf-consistency {phase = active} eq = C.id ★
+
+inst-in-leaf-consistency : ∀ {κ : CastCtx Δ} {X phase}
+  → κ X ≡ inst-in-bound phase
+  → C._⊢_∼_ (toEnv∼ κ) ★ (phaseType phase X)
+inst-in-leaf-consistency {X = X} {phase = pending} eq =
+  C.？_ ⦃ Gᵍ = ＇ X ⦄
+    ⦃ ★∼G = C.★∼Xᵍ (cong entryMode eq) ⦄
+    (C.id (＇ X)) ⦃ Bns = nonstar-X ⦄
+inst-in-leaf-consistency {phase = active} eq = C.id ★
+
+coercion→consistency : ∀ {κ : CastCtx Δ} {c A B}
+  → κ ⊢ c ∶ A ⇒ B
+  → C._⊢_∼_ (toEnv∼ κ) A B
+coercion→consistency (⊢id atom) = C.id atom
+coercion→consistency {κ = κ} (⊢↦ c⊢ d⊢) =
+  C._↦_
+    (transport-consistency (toEnv∼-flip {κ = κ})
+      (coercion→consistency c⊢))
+    (coercion→consistency d⊢)
+coercion→consistency {κ = κ} (⊢∀ c⊢) =
+  C.∀ᶜ (transport-consistency (toEnv∼-ext {κ = κ})
+    (coercion→consistency c⊢))
+coercion→consistency (⊢inj generic G∼★ c⊢ nonstar) =
+  C._! ⦃ Gᵍ = generic-ground generic ⦄ ⦃ G∼★ = G∼★ ⦄
+    (coercion→consistency c⊢) ⦃ Ans = nonstar ⦄
+coercion→consistency (⊢proj generic ★∼G c⊢ nonstar) =
+  C.？_ ⦃ Gᵍ = generic-ground generic ⦄ ⦃ ★∼G = ★∼G ⦄
+    (coercion→consistency c⊢) ⦃ Bns = nonstar ⦄
+coercion→consistency {κ = κ} (⊢inst-out-pending {X = X} eq) =
+  inst-out-leaf-consistency {κ = κ} {X = X} {phase = pending} eq
+coercion→consistency {κ = κ} (⊢inst-out-active {X = X} eq) =
+  inst-out-leaf-consistency {κ = κ} {X = X} {phase = active} eq
+coercion→consistency {κ = κ} (⊢inst-in-pending {X = X} eq) =
+  inst-in-leaf-consistency {κ = κ} {X = X} {phase = pending} eq
+coercion→consistency {κ = κ} (⊢inst-in-active {X = X} eq) =
+  inst-in-leaf-consistency {κ = κ} {X = X} {phase = active} eq
+coercion→consistency {κ = κ}
+    (⊢inst nonvar occurs c⊢ B≢★) =
+  C.inst_ ⦃ Anv = nonvar ⦄ ⦃ z∈A = occurs ⦄
+    (transport-consistency (toEnv∼-inst pending {κ = κ})
+      (coercion→consistency c⊢)) B≢★
+coercion→consistency {κ = κ}
+    (⊢gen nonvar occurs c⊢ A≢★) =
+  C.gen_ ⦃ Bnv = nonvar ⦄ ⦃ z∈B = occurs ⦄
+    (transport-consistency (toEnv∼-gen {κ = κ})
+      (coercion→consistency c⊢)) A≢★
+coercion→consistency ⊢bot-elim = C.bot-elim
+coercion→consistency ⊢bot-intro = C.bot-intro
+
+------------------------------------------------------------------------
+-- Reverse correspondence for pending contexts
+------------------------------------------------------------------------
+
+data PendingEntry {Δ : TyCtx} (κ : CastCtx Δ)
+    (X : TyVar Δ) : Set where
+  pending-ordinary : ∀ mode
+    → κ X ≡ ordinary mode
+    → PendingEntry κ X
+  pending-out :
+      κ X ≡ inst-out-bound pending
+    → PendingEntry κ X
+  pending-in :
+      κ X ≡ inst-in-bound pending
+    → PendingEntry κ X
+
+PendingCtx : ∀ {Δ} → CastCtx Δ → Set
+PendingCtx κ = ∀ X → PendingEntry κ X
+
+fromEnv∼-pending : ∀ {μ : C.Env∼ Δ}
+  → PendingCtx (fromEnv∼ μ)
+fromEnv∼-pending X = pending-ordinary _ refl
+
+flip-pending : ∀ {κ : CastCtx Δ}
+  → PendingCtx κ
+  → PendingCtx (flipCtx κ)
+flip-pending pendingκ X with pendingκ X
+flip-pending pendingκ X | pending-ordinary mode eq =
+  pending-ordinary (C.flipVar∼ mode) (cong flipEntry eq)
+flip-pending pendingκ X | pending-out eq =
+  pending-in (cong flipEntry eq)
+flip-pending pendingκ X | pending-in eq =
+  pending-out (cong flipEntry eq)
+
+ext-pending : ∀ {κ : CastCtx Δ}
+  → PendingCtx κ
+  → PendingCtx (extCtx κ)
+ext-pending pendingκ zero = pending-ordinary C.X∼X refl
+ext-pending pendingκ (suc X) with pendingκ X
+ext-pending pendingκ (suc X) | pending-ordinary mode eq =
+  pending-ordinary mode eq
+ext-pending pendingκ (suc X) | pending-out eq = pending-out eq
+ext-pending pendingκ (suc X) | pending-in eq = pending-in eq
+
+inst-pending : ∀ {κ : CastCtx Δ}
+  → PendingCtx κ
+  → PendingCtx (instCtx pending κ)
+inst-pending pendingκ zero = pending-out refl
+inst-pending pendingκ (suc X) with pendingκ X
+inst-pending pendingκ (suc X) | pending-ordinary mode eq =
+  pending-ordinary mode eq
+inst-pending pendingκ (suc X) | pending-out eq = pending-out eq
+inst-pending pendingκ (suc X) | pending-in eq = pending-in eq
+
+gen-pending : ∀ {κ : CastCtx Δ}
+  → PendingCtx κ
+  → PendingCtx (genCtx κ)
+gen-pending pendingκ zero = pending-ordinary C.★∼X refl
+gen-pending pendingκ (suc X) with pendingκ X
+gen-pending pendingκ (suc X) | pending-ordinary mode eq =
+  pending-ordinary mode eq
+gen-pending pendingκ (suc X) | pending-out eq = pending-out eq
+gen-pending pendingκ (suc X) | pending-in eq = pending-in eq
+
+data ToStarView {Δ : TyCtx} (κ : CastCtx Δ)
+    (X : TyVar Δ) : Set where
+  ordinary-to-star :
+      OrdinaryVariable κ X
+    → ToStarView κ X
+  bound-to-star :
+      κ X ≡ inst-out-bound pending
+    → ToStarView κ X
+
+to-star-view : ∀ {κ : CastCtx Δ} {X}
+  → PendingCtx κ
+  → toEnv∼ κ X ≡ C.X∼★
+  → ToStarView κ X
+to-star-view {X = X} pendingκ mode with pendingκ X
+to-star-view pendingκ mode | pending-ordinary entry eq =
+  ordinary-to-star (ordinary-entry entry eq)
+to-star-view pendingκ mode | pending-out eq = bound-to-star eq
+to-star-view pendingκ mode | pending-in eq
+    with trans (sym (cong entryMode eq)) mode
+to-star-view pendingκ mode | pending-in eq | ()
+
+data FromStarView {Δ : TyCtx} (κ : CastCtx Δ)
+    (X : TyVar Δ) : Set where
+  ordinary-from-star :
+      OrdinaryVariable κ X
+    → FromStarView κ X
+  bound-from-star :
+      κ X ≡ inst-in-bound pending
+    → FromStarView κ X
+
+from-star-view : ∀ {κ : CastCtx Δ} {X}
+  → PendingCtx κ
+  → toEnv∼ κ X ≡ C.★∼X
+  → FromStarView κ X
+from-star-view {X = X} pendingκ mode with pendingκ X
+from-star-view pendingκ mode | pending-ordinary entry eq =
+  ordinary-from-star (ordinary-entry entry eq)
+from-star-view pendingκ mode | pending-out eq
+    with trans (sym (cong entryMode eq)) mode
+from-star-view pendingκ mode | pending-out eq | ()
+from-star-view pendingκ mode | pending-in eq = bound-from-star eq
+
+cross-to-star-ordinary : ∀ {κ : CastCtx Δ} {X}
+  → PendingCtx κ
+  → toEnv∼ κ X ≡ C.★∼X∼★
+  → OrdinaryVariable κ X
+cross-to-star-ordinary {X = X} pendingκ mode with pendingκ X
+cross-to-star-ordinary pendingκ mode | pending-ordinary entry eq =
+  ordinary-entry entry eq
+cross-to-star-ordinary pendingκ mode | pending-out eq
+    with trans (sym (cong entryMode eq)) mode
+cross-to-star-ordinary pendingκ mode | pending-out eq | ()
+cross-to-star-ordinary pendingκ mode | pending-in eq
+    with trans (sym (cong entryMode eq)) mode
+cross-to-star-ordinary pendingκ mode | pending-in eq | ()
+
+cross-from-star-ordinary : ∀ {κ : CastCtx Δ} {X}
+  → PendingCtx κ
+  → toEnv∼ κ X ≡ C.★∼X∼★
+  → OrdinaryVariable κ X
+cross-from-star-ordinary = cross-to-star-ordinary
+
+target-variable-shape : ∀ {μ : C.Env∼ Δ} {A X}
+  → C._⊢_∼_ μ A (＇ X)
+  → (A ≡ ＇ X) ⊎ (A ≡ ★)
+target-variable-shape (C.id (＇ X)) = inj₁ refl
+target-variable-shape (C.？_ c) = inj₂ refl
+target-variable-shape
+    (C.inst_ ⦃ Anv = nonvar ⦄ ⦃ z∈A = occurs ⦄ c B≢★)
+    with target-variable-shape c
+target-variable-shape
+    (C.inst_ ⦃ Anv = () ⦄ ⦃ z∈A = occurs ⦄ c B≢★)
+    | inj₁ refl
+target-variable-shape
+    (C.inst_ ⦃ Anv = nonvar ⦄ ⦃ z∈A = () ⦄ c B≢★)
+    | inj₂ refl
+
+source-variable-shape : ∀ {μ : C.Env∼ Δ} {B X}
+  → C._⊢_∼_ μ (＇ X) B
+  → (B ≡ ＇ X) ⊎ (B ≡ ★)
+source-variable-shape c = target-variable-shape (C.sym∼ c)
+
+nonstar-not-star : ∀ {A : Ty Δ}
+  → NonStar A
+  → A ≡ ★
+  → ⊥
+nonstar-not-star nonstar refl = nonStar≢★ nonstar refl
+
+bound-injection-source : ∀ {μ : C.Env∼ Δ} {A X}
+  → C._⊢_∼_ μ A (＇ X)
+  → NonStar A
+  → A ≡ ＇ X
+bound-injection-source c nonstar with target-variable-shape c
+bound-injection-source c nonstar | inj₁ eq = eq
+bound-injection-source c nonstar | inj₂ eq =
+  ⊥-elim (nonstar-not-star nonstar eq)
+
+bound-projection-target : ∀ {μ : C.Env∼ Δ} {B X}
+  → C._⊢_∼_ μ (＇ X) B
+  → NonStar B
+  → B ≡ ＇ X
+bound-projection-target c nonstar with source-variable-shape c
+bound-projection-target c nonstar | inj₁ eq = eq
+bound-projection-target c nonstar | inj₂ eq =
+  ⊥-elim (nonstar-not-star nonstar eq)
+
+transport-coercion-typing : ∀ {κ : CastCtx Δ} {c A B A′ B′}
+  → A ≡ A′
+  → B ≡ B′
+  → κ ⊢ c ∶ A ⇒ B
+  → κ ⊢ c ∶ A′ ⇒ B′
+transport-coercion-typing refl refl c⊢ = c⊢
+
+EnvAgrees : ∀ {Δ} → C.Env∼ Δ → CastCtx Δ → Set
+EnvAgrees μ κ = ∀ X → μ X ≡ toEnv∼ κ X
+
+flip-agrees : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ}
+  → EnvAgrees μ κ
+  → EnvAgrees (C.flipᵐ μ) (flipCtx κ)
+flip-agrees {κ = κ} agrees X =
+  trans (cong C.flipVar∼ (agrees X))
+    (sym (cong (λ env → env X) (toEnv∼-flip {κ = κ})))
+
+ext-agrees : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ}
+  → EnvAgrees μ κ
+  → EnvAgrees (C.extᵐ μ) (extCtx κ)
+ext-agrees agrees zero = refl
+ext-agrees agrees (suc X) = agrees X
+
+inst-agrees : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ}
+  → EnvAgrees μ κ
+  → EnvAgrees (C.instᵐ μ) (instCtx pending κ)
+inst-agrees agrees zero = refl
+inst-agrees agrees (suc X) = agrees X
+
+gen-agrees : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ}
+  → EnvAgrees μ κ
+  → EnvAgrees (C.genᵐ μ) (genCtx κ)
+gen-agrees agrees zero = refl
+gen-agrees agrees (suc X) = agrees X
+
+transport-∼★ : ∀ {μ ν : C.Env∼ Δ} {G}
+  → μ ≡ ν
+  → C._⊢_∼★ μ G
+  → C._⊢_∼★ ν G
+transport-∼★ refl G∼★ = G∼★
+
+transport-★∼ : ∀ {μ ν : C.Env∼ Δ} {G}
+  → μ ≡ ν
+  → C._⊢★∼_ μ G
+  → C._⊢★∼_ ν G
+transport-★∼ refl ★∼G = ★∼G
+
+aligned-mode : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ} {X mode}
+  → EnvAgrees μ κ
+  → μ X ≡ mode
+  → toEnv∼ κ X ≡ mode
+aligned-mode {X = X} agrees mode = trans (sym (agrees X)) mode
+
+aligned-∼★ : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ} {G}
+  → EnvAgrees μ κ
+  → C._⊢_∼★ μ G
+  → C._⊢_∼★ (toEnv∼ κ) G
+aligned-∼★ {κ = κ} agrees = transport-∼★ (funext agrees)
+
+aligned-★∼ : ∀ {μ : C.Env∼ Δ} {κ : CastCtx Δ} {G}
+  → EnvAgrees μ κ
+  → C._⊢★∼_ μ G
+  → C._⊢★∼_ (toEnv∼ κ) G
+aligned-★∼ {κ = κ} agrees = transport-★∼ (funext agrees)
+
+consistency→coercion-with : ∀ {μ : C.Env∼ Δ}
+    {κ : CastCtx Δ} {A B}
+  → EnvAgrees μ κ
+  → PendingCtx κ
+  → C._⊢_∼_ μ A B
+  → Σ[ c ∈ Coercion Δ ] (κ ⊢ c ∶ A ⇒ B)
+consistency→coercion-with agrees pendingκ (C.id atom) =
+  id , ⊢id atom
+consistency→coercion-with {κ = κ} agrees pendingκ (c C.↦ d)
+    with consistency→coercion-with (flip-agrees {κ = κ} agrees)
+      (flip-pending pendingκ) c
+       | consistency→coercion-with agrees pendingκ d
+consistency→coercion-with agrees pendingκ (c C.↦ d)
+    | c′ , c′⊢ | d′ , d′⊢ =
+  c′ ↦ d′ , ⊢↦ c′⊢ d′⊢
+consistency→coercion-with agrees pendingκ (C.∀ᶜ c)
+    with consistency→coercion-with (ext-agrees agrees)
+      (ext-pending pendingκ) c
+consistency→coercion-with agrees pendingκ (C.∀ᶜ c) | c′ , c′⊢ =
+  `∀ c′ , ⊢∀ c′⊢
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.⇒∼★ ⦄ c ⦃ Ans = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.⇒∼★ ⦄ c ⦃ Ans = nonstar ⦄)
+    | c′ , c′⊢ =
+  c′ ! , ⊢inj generic-⇒
+    (aligned-∼★ {κ = κ} agrees C.⇒∼★) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.ι∼★ ⦄ c ⦃ Ans = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.ι∼★ ⦄ c ⦃ Ans = nonstar ⦄)
+    | c′ , c′⊢ =
+  c′ ! , ⊢inj generic-ι
+    (aligned-∼★ {κ = κ} agrees C.ι∼★) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.X∼★ᵍ {X = X} mode ⦄ c
+      ⦃ Ans = nonstar ⦄)
+    with to-star-view pendingκ (aligned-mode {κ = κ} agrees mode)
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.X∼★ᵍ mode ⦄ c ⦃ Ans = nonstar ⦄)
+    | ordinary-to-star ordinary-X
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.X∼★ᵍ mode ⦄ c ⦃ Ans = nonstar ⦄)
+    | ordinary-to-star ordinary-X | c′ , c′⊢ =
+  c′ ! , ⊢inj (generic-X ordinary-X)
+    (C.X∼★ᵍ (aligned-mode {κ = κ} agrees mode)) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.X∼★ᵍ {X = X} mode ⦄ c
+      ⦃ Ans = nonstar ⦄)
+    | bound-to-star bound-X =
+  inst-out X ,
+    transport-coercion-typing (sym source-eq) refl
+      (⊢inst-out-pending bound-X)
+  where
+  source-eq = bound-injection-source c nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.X∼★ᶜ {X = X} mode ⦄ c
+      ⦃ Ans = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.X∼★ᶜ {X = X} mode ⦄ c
+      ⦃ Ans = nonstar ⦄)
+    | c′ , c′⊢ =
+  c′ ! , ⊢inj
+    (generic-X
+      (cross-to-star-ordinary pendingκ (aligned-mode {κ = κ} agrees mode)))
+    (C.X∼★ᶜ (aligned-mode {κ = κ} agrees mode)) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.∀∼★ ⦄ c ⦃ Ans = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C._! ⦃ G∼★ = C.∀∼★ ⦄ c ⦃ Ans = nonstar ⦄)
+    | c′ , c′⊢ =
+  c′ ! , ⊢inj generic-∀
+    (aligned-∼★ {κ = κ} agrees C.∀∼★) c′⊢ nonstar
+
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼⇒ ⦄ c ⦃ Bns = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼⇒ ⦄ c ⦃ Bns = nonstar ⦄)
+    | c′ , c′⊢ =
+  ？ c′ , ⊢proj generic-⇒
+    (aligned-★∼ {κ = κ} agrees C.★∼⇒) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼ι ⦄ c ⦃ Bns = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼ι ⦄ c ⦃ Bns = nonstar ⦄)
+    | c′ , c′⊢ =
+  ？ c′ , ⊢proj generic-ι
+    (aligned-★∼ {κ = κ} agrees C.★∼ι) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼Xᵍ {X = X} mode ⦄ c
+      ⦃ Bns = nonstar ⦄)
+    with from-star-view pendingκ (aligned-mode {κ = κ} agrees mode)
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼Xᵍ mode ⦄ c ⦃ Bns = nonstar ⦄)
+    | ordinary-from-star ordinary-X
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼Xᵍ mode ⦄ c ⦃ Bns = nonstar ⦄)
+    | ordinary-from-star ordinary-X | c′ , c′⊢ =
+  ？ c′ , ⊢proj (generic-X ordinary-X)
+    (C.★∼Xᵍ (aligned-mode {κ = κ} agrees mode)) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼Xᵍ {X = X} mode ⦄ c
+      ⦃ Bns = nonstar ⦄)
+    | bound-from-star bound-X =
+  inst-in X ,
+    transport-coercion-typing refl (sym target-eq)
+      (⊢inst-in-pending bound-X)
+  where
+  target-eq = bound-projection-target c nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼Xᶜ {X = X} mode ⦄ c
+      ⦃ Bns = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼Xᶜ {X = X} mode ⦄ c
+      ⦃ Bns = nonstar ⦄)
+    | c′ , c′⊢ =
+  ？ c′ , ⊢proj
+    (generic-X
+      (cross-from-star-ordinary pendingκ (aligned-mode {κ = κ} agrees mode)))
+    (C.★∼Xᶜ (aligned-mode {κ = κ} agrees mode)) c′⊢ nonstar
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼∀ ⦄ c ⦃ Bns = nonstar ⦄)
+    with consistency→coercion-with agrees pendingκ c
+consistency→coercion-with {κ = κ} agrees pendingκ
+    (C.？_ ⦃ ★∼G = C.★∼∀ ⦄ c ⦃ Bns = nonstar ⦄)
+    | c′ , c′⊢ =
+  ？ c′ , ⊢proj generic-∀
+    (aligned-★∼ {κ = κ} agrees C.★∼∀) c′⊢ nonstar
+consistency→coercion-with agrees pendingκ
+    (C.inst_ ⦃ Anv = nonvar ⦄ ⦃ z∈A = occurs ⦄ c B≠★)
+    with consistency→coercion-with (inst-agrees agrees)
+      (inst-pending pendingκ) c
+consistency→coercion-with agrees pendingκ
+    (C.inst_ ⦃ Anv = nonvar ⦄ ⦃ z∈A = occurs ⦄ c B≠★)
+    | c′ , c′⊢ =
+  inst c′ , ⊢inst nonvar occurs c′⊢ B≠★
+consistency→coercion-with agrees pendingκ
+    (C.gen_ ⦃ Bnv = nonvar ⦄ ⦃ z∈B = occurs ⦄ c A≠★)
+    with consistency→coercion-with (gen-agrees agrees)
+      (gen-pending pendingκ) c
+consistency→coercion-with agrees pendingκ
+    (C.gen_ ⦃ Bnv = nonvar ⦄ ⦃ z∈B = occurs ⦄ c A≠★)
+    | c′ , c′⊢ =
+  gen c′ , ⊢gen nonvar occurs c′⊢ A≠★
+consistency→coercion-with agrees pendingκ C.bot-elim =
+  bot-elim , ⊢bot-elim
+consistency→coercion-with agrees pendingκ C.bot-intro =
+  bot-intro , ⊢bot-intro
+
+consistency→coercion : ∀ {κ : CastCtx Δ} {A B}
+  → PendingCtx κ
+  → C._⊢_∼_ (toEnv∼ κ) A B
+  → Σ[ c ∈ Coercion Δ ] (κ ⊢ c ∶ A ⇒ B)
+consistency→coercion pendingκ c =
+  consistency→coercion-with (λ X → refl) pendingκ c
+
+consistency→fromEnv∼-coercion : ∀ {μ : C.Env∼ Δ} {A B}
+  → C._⊢_∼_ μ A B
+  → Σ[ c ∈ Coercion Δ ] (fromEnv∼ μ ⊢ c ∶ A ⇒ B)
+consistency→fromEnv∼-coercion c =
+  consistency→coercion-with (λ X → refl) fromEnv∼-pending c
+
+fromEnv∼-coercion→consistency : ∀ {μ : C.Env∼ Δ} {c A B}
+  → fromEnv∼ μ ⊢ c ∶ A ⇒ B
+  → C._⊢_∼_ μ A B
+fromEnv∼-coercion→consistency c⊢ =
+  transport-consistency toEnv∼-fromEnv∼
+    (coercion→consistency c⊢)
+
+------------------------------------------------------------------------
+-- Focused identity-function experiment
+------------------------------------------------------------------------
+
+X : Ty 1
+X = ＇ zero
+
+X⇒X : Ty 1
+X⇒X = X ⇒ X
+
+Dyn⇒Dyn : Ty 1
+Dyn⇒Dyn = ★ ⇒ ★
+
+identity-body-coercion : Coercion 1
+identity-body-coercion = inst-in zero ↦ inst-out zero
+
+pending0 : CastCtx 1
+pending0 = instCtx pending (ordinaryCtx {Δ = 0})
+
+active0 : CastCtx 1
+active0 = instCtx active (ordinaryCtx {Δ = 0})
+
+zero-pending-out : pending0 zero ≡ inst-out-bound pending
+zero-pending-out = refl
+
+zero-pending-in :
+  flipCtx pending0 zero ≡ inst-in-bound pending
+zero-pending-in = refl
+
+identity-body-pending :
+  pending0 ⊢ identity-body-coercion ∶ X⇒X ⇒ Dyn⇒Dyn
+identity-body-pending =
+  ⊢↦ (⊢inst-in-pending zero-pending-in)
+    (⊢inst-out-pending zero-pending-out)
+
+zero-active-out : active0 zero ≡ inst-out-bound active
+zero-active-out = refl
+
+zero-active-in : flipCtx active0 zero ≡ inst-in-bound active
+zero-active-in = refl
+
+identity-body-active :
+  active0 ⊢ identity-body-coercion ∶ Dyn⇒Dyn ⇒ Dyn⇒Dyn
+identity-body-active =
+  ⊢↦ (⊢inst-in-active zero-active-in)
+    (⊢inst-out-active zero-active-out)
+
+identity-body-consistency :
+  C._⊢_∼_ (C.instᵐ (C.idᶜ {Δ = 0})) X⇒X Dyn⇒Dyn
+identity-body-consistency =
+  transport-consistency (toEnv∼-inst pending)
+    (coercion→consistency identity-body-pending)

--- a/GTSFImp/experimental/ContextualCoercionActivation.agda
+++ b/GTSFImp/experimental/ContextualCoercionActivation.agda
@@ -1,0 +1,689 @@
+module experimental.ContextualCoercionActivation where
+
+-- File Charter:
+--   * Proves that an instantiation-bound contextual coercion can switch from
+--     pending to active without changing its raw `Coercion` syntax.
+--   * Uses freshness of the unaffected endpoint to orient the phase switch.
+--   * Reuses the live substitution and occurrence infrastructure for binders.
+--   * Leaves the live GTSFImp development unchanged.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Fin using (zero; suc)
+open import Data.Fin.Properties using (_≟_)
+import Data.Nat as Nat
+open import Data.Product using (_,_)
+open import Data.Sum using (inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; cong; cong₂; subst; sym; trans)
+open import Relation.Nullary using (yes; no)
+
+open import Types renaming (`∀ to `∀ᵗ)
+open import Conversion using (replaceTy)
+open import FunExt using (funext)
+open import proof.ImprecisionConsistency using
+  (shift-not-occurs; zero-absent-shift; subst-zero-occurs-exts)
+import proof.TypeSafety.Preservation as Preservation
+import Consistency as C
+open import experimental.ContextualCoercion
+
+private
+  variable
+    Δ : TyCtx
+
+------------------------------------------------------------------------
+-- A one-entry pending-to-active context change
+------------------------------------------------------------------------
+
+record OutActivation {X : TyVar Δ} (κ κ′ : CastCtx Δ) : Set where
+  constructor out-activation
+  field
+    pending-out-at : κ X ≡ inst-out-bound pending
+    active-out-at : κ′ X ≡ inst-out-bound active
+    same-out-away : ∀ {Y} → X ≢ Y → κ Y ≡ κ′ Y
+
+record InActivation {X : TyVar Δ} (κ κ′ : CastCtx Δ) : Set where
+  constructor in-activation
+  field
+    pending-in-at : κ X ≡ inst-in-bound pending
+    active-in-at : κ′ X ≡ inst-in-bound active
+    same-in-away : ∀ {Y} → X ≢ Y → κ Y ≡ κ′ Y
+
+open OutActivation
+open InActivation
+
+flip-out-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → InActivation {X = X} (flipCtx κ) (flipCtx κ′)
+flip-out-activation (out-activation old new away) =
+  in-activation (cong flipEntry old) (cong flipEntry new)
+    (λ X≠Y → cong flipEntry (away X≠Y))
+
+flip-in-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → OutActivation {X = X} (flipCtx κ) (flipCtx κ′)
+flip-in-activation (in-activation old new away) =
+  out-activation (cong flipEntry old) (cong flipEntry new)
+    (λ X≠Y → cong flipEntry (away X≠Y))
+
+ext-out-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → OutActivation {X = suc X} (extCtx κ) (extCtx κ′)
+ext-out-activation {X = X} (out-activation old new away) =
+  out-activation old new away′
+  where
+  away′ : ∀ {Y} → suc X ≢ Y → extCtx _ Y ≡ extCtx _ Y
+  away′ {zero} sucX≠zero = refl
+  away′ {suc Y} sucX≠sucY =
+    away (λ X≡Y → sucX≠sucY (cong suc X≡Y))
+
+ext-in-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → InActivation {X = suc X} (extCtx κ) (extCtx κ′)
+ext-in-activation {X = X} (in-activation old new away) =
+  in-activation old new away′
+  where
+  away′ : ∀ {Y} → suc X ≢ Y → extCtx _ Y ≡ extCtx _ Y
+  away′ {zero} sucX≠zero = refl
+  away′ {suc Y} sucX≠sucY =
+    away (λ X≡Y → sucX≠sucY (cong suc X≡Y))
+
+inst-out-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → OutActivation {X = suc X}
+      (instCtx pending κ) (instCtx pending κ′)
+inst-out-activation {X = X} (out-activation old new away) =
+  out-activation old new away′
+  where
+  away′ : ∀ {Y} → suc X ≢ Y
+    → instCtx pending _ Y ≡ instCtx pending _ Y
+  away′ {zero} sucX≠zero = refl
+  away′ {suc Y} sucX≠sucY =
+    away (λ X≡Y → sucX≠sucY (cong suc X≡Y))
+
+inst-in-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → InActivation {X = suc X}
+      (instCtx pending κ) (instCtx pending κ′)
+inst-in-activation {X = X} (in-activation old new away) =
+  in-activation old new away′
+  where
+  away′ : ∀ {Y} → suc X ≢ Y
+    → instCtx pending _ Y ≡ instCtx pending _ Y
+  away′ {zero} sucX≠zero = refl
+  away′ {suc Y} sucX≠sucY =
+    away (λ X≡Y → sucX≠sucY (cong suc X≡Y))
+
+gen-out-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → OutActivation {X = suc X} (genCtx κ) (genCtx κ′)
+gen-out-activation {X = X} (out-activation old new away) =
+  out-activation old new away′
+  where
+  away′ : ∀ {Y} → suc X ≢ Y → genCtx _ Y ≡ genCtx _ Y
+  away′ {zero} sucX≠zero = refl
+  away′ {suc Y} sucX≠sucY =
+    away (λ X≡Y → sucX≠sucY (cong suc X≡Y))
+
+gen-in-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → InActivation {X = suc X} (genCtx κ) (genCtx κ′)
+gen-in-activation {X = X} (in-activation old new away) =
+  in-activation old new away′
+  where
+  away′ : ∀ {Y} → suc X ≢ Y → genCtx _ Y ≡ genCtx _ Y
+  away′ {zero} sucX≠zero = refl
+  away′ {suc Y} sucX≠sucY =
+    away (λ X≡Y → sucX≠sucY (cong suc X≡Y))
+
+out-entry-mode-eq : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → ∀ Y → entryMode (κ Y) ≡ entryMode (κ′ Y)
+out-entry-mode-eq {X = X} activation Y with X ≟ Y
+out-entry-mode-eq {X = X} activation .X | yes refl =
+  trans (cong entryMode (pending-out-at activation))
+    (sym (cong entryMode (active-out-at activation)))
+out-entry-mode-eq {X = X} activation Y | no X≠Y =
+  cong entryMode (same-out-away activation X≠Y)
+
+in-entry-mode-eq : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → ∀ Y → entryMode (κ Y) ≡ entryMode (κ′ Y)
+in-entry-mode-eq {X = X} activation Y with X ≟ Y
+in-entry-mode-eq {X = X} activation .X | yes refl =
+  trans (cong entryMode (pending-in-at activation))
+    (sym (cong entryMode (active-in-at activation)))
+in-entry-mode-eq {X = X} activation Y | no X≠Y =
+  cong entryMode (same-in-away activation X≠Y)
+
+toEnv∼-out-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → toEnv∼ κ ≡ toEnv∼ κ′
+toEnv∼-out-activation activation =
+  funext (out-entry-mode-eq activation)
+
+toEnv∼-in-activation : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → toEnv∼ κ ≡ toEnv∼ κ′
+toEnv∼-in-activation activation =
+  funext (in-entry-mode-eq activation)
+
+------------------------------------------------------------------------
+-- Type replacement and generic-ground support
+------------------------------------------------------------------------
+
+replace-not-occurs : ∀ {X : TyVar Δ} {A : Ty Δ}
+  → X ∉ᵗ A
+  → replaceTy X ★ A ≡ A
+replace-not-occurs {X = X} (∉-var {Y = Y} X≠Y) with X ≟ Y
+replace-not-occurs (∉-var X≠X) | yes refl = ⊥-elim (X≠X refl)
+replace-not-occurs (∉-var X≠Y) | no X≠Y′ = refl
+replace-not-occurs ∉-base = refl
+replace-not-occurs ∉-star = refl
+replace-not-occurs (∉-fun X∉A X∉B) =
+  cong₂ _⇒_ (replace-not-occurs X∉A) (replace-not-occurs X∉B)
+replace-not-occurs (∉-all X∉A) =
+  cong `∀ᵗ (replace-not-occurs X∉A)
+
+replace-nonvar : ∀ {X : TyVar Δ} {A : Ty Δ}
+  → NonVar A
+  → NonVar (replaceTy X ★ A)
+replace-nonvar nonvar-base = nonvar-base
+replace-nonvar nonvar-star = nonvar-star
+replace-nonvar nonvar-fun = nonvar-fun
+replace-nonvar nonvar-all = nonvar-all
+
+replace-nonstar : ∀ {X : TyVar Δ} {A : Ty Δ}
+  → NonStar A
+  → A ≢ ＇ X
+  → NonStar (replaceTy X ★ A)
+replace-nonstar {X = X} (nonstar-X {X = Y}) Y≠X with X ≟ Y
+replace-nonstar {X = X} (nonstar-X {X = .X}) Y≠X | yes refl =
+  ⊥-elim (Y≠X refl)
+replace-nonstar {X = X} (nonstar-X {X = Y}) Y≠X | no X≠Y =
+  nonstar-X
+replace-nonstar nonstar-ι A≠X = nonstar-ι
+replace-nonstar nonstar-⇒ A≠X = nonstar-⇒
+replace-nonstar nonstar-∀ A≠X = nonstar-∀
+
+nonstar-from-≢★ : ∀ {A : Ty Δ} → A ≢ ★ → NonStar A
+nonstar-from-≢★ {A = ＇ X} A≠★ = nonstar-X
+nonstar-from-≢★ {A = ‵ ι} A≠★ = nonstar-ι
+nonstar-from-≢★ {A = ★} A≠★ = ⊥-elim (A≠★ refl)
+nonstar-from-≢★ {A = A ⇒ B} A≠★ = nonstar-⇒
+nonstar-from-≢★ {A = `∀ᵗ A} A≠★ = nonstar-∀
+
+replace-nonstar-from-≢ : ∀ {X : TyVar Δ} {A : Ty Δ}
+  → A ≢ ★
+  → A ≢ ＇ X
+  → replaceTy X ★ A ≢ ★
+replace-nonstar-from-≢ A≠★ A≠X =
+  nonStar≢★ (replace-nonstar (nonstar-from-≢★ A≠★) A≠X)
+
+replace-shift : ∀ {X : TyVar Δ} (A : Ty Δ)
+  → replaceTy (suc X) ★ (⇑ᵗ A) ≡ ⇑ᵗ (replaceTy X ★ A)
+replace-shift {X = X} A =
+  trans (Preservation.replaceTy-subst (suc X) ★ (⇑ᵗ A))
+    (trans
+      (substᵗ-cong (⇑ᵗ A) (Preservation.replaceEnv-ext X ★))
+      (trans (substᵗ-shift (Preservation.replaceEnv X ★) A)
+        (cong (λ B → ⇑ᵗ B)
+          (sym (Preservation.replaceTy-subst X ★ A)))))
+
+replace-suc-zero-occurs : ∀ {X : TyVar Δ} {A : Ty (Nat.suc Δ)}
+  → zero ∈ᵗ A
+  → zero ∈ᵗ replaceTy (suc X) ★ A
+replace-suc-zero-occurs {X = X} {A = A} zero∈A =
+  subst (zero ∈ᵗ_)
+    (sym
+      (trans (Preservation.replaceTy-subst (suc X) ★ A)
+        (substᵗ-cong A (Preservation.replaceEnv-ext X ★))))
+    (subst-zero-occurs-exts zero∈A)
+
+ordinary-away-out : ∀ {X Y : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → OrdinaryVariable κ Y
+  → X ≢ Y
+ordinary-away-out activation (ordinary-entry mode ordinary-Y) refl
+    with trans (sym (pending-out-at activation)) ordinary-Y
+ordinary-away-out activation (ordinary-entry mode ordinary-Y) refl | ()
+
+ordinary-away-in : ∀ {X Y : TyVar Δ} {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → OrdinaryVariable κ Y
+  → X ≢ Y
+ordinary-away-in activation (ordinary-entry mode ordinary-Y) refl
+    with trans (sym (pending-in-at activation)) ordinary-Y
+ordinary-away-in activation (ordinary-entry mode ordinary-Y) refl | ()
+
+activate-generic-out : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ} {G}
+  → OutActivation {X = X} κ κ′
+  → GenericGround κ G
+  → GenericGround κ′ G
+activate-generic-out activation generic-⇒ = generic-⇒
+activate-generic-out activation generic-ι = generic-ι
+activate-generic-out activation
+    (generic-X (ordinary-entry mode ordinary-Y)) =
+  generic-X (ordinary-entry mode ordinary-Y′)
+  where
+  X≠Y = ordinary-away-out activation (ordinary-entry mode ordinary-Y)
+  ordinary-Y′ =
+    trans (sym (same-out-away activation X≠Y)) ordinary-Y
+activate-generic-out activation generic-∀ = generic-∀
+
+activate-generic-in : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ} {G}
+  → InActivation {X = X} κ κ′
+  → GenericGround κ G
+  → GenericGround κ′ G
+activate-generic-in activation generic-⇒ = generic-⇒
+activate-generic-in activation generic-ι = generic-ι
+activate-generic-in activation
+    (generic-X (ordinary-entry mode ordinary-Y)) =
+  generic-X (ordinary-entry mode ordinary-Y′)
+  where
+  X≠Y = ordinary-away-in activation (ordinary-entry mode ordinary-Y)
+  ordinary-Y′ =
+    trans (sym (same-in-away activation X≠Y)) ordinary-Y
+activate-generic-in activation generic-∀ = generic-∀
+
+generic-fresh-out : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ} {G}
+  → OutActivation {X = X} κ κ′
+  → GenericGround κ G
+  → X ∉ᵗ G
+generic-fresh-out activation generic-⇒ = ∉-fun ∉-star ∉-star
+generic-fresh-out activation generic-ι = ∉-base
+generic-fresh-out activation (generic-X ordinary-Y) =
+  ∉-var (ordinary-away-out activation ordinary-Y)
+generic-fresh-out activation generic-∀ = ∉-all ∉-star
+
+generic-fresh-in : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ} {G}
+  → InActivation {X = X} κ κ′
+  → GenericGround κ G
+  → X ∉ᵗ G
+generic-fresh-in activation generic-⇒ = ∉-fun ∉-star ∉-star
+generic-fresh-in activation generic-ι = ∉-base
+generic-fresh-in activation (generic-X ordinary-Y) =
+  ∉-var (ordinary-away-in activation ordinary-Y)
+generic-fresh-in activation generic-∀ = ∉-all ∉-star
+
+generic-not-star : ∀ {κ : CastCtx Δ} {G}
+  → GenericGround κ G
+  → G ≢ ★
+generic-not-star generic-⇒ ()
+generic-not-star generic-ι ()
+generic-not-star (generic-X ordinary-X) ()
+generic-not-star generic-∀ ()
+
+absent-present : ∀ {X : TyVar Δ} {A : Ty Δ}
+  → X ∉ᵗ A
+  → X ∈ᵗ A
+  → ⊥
+absent-present (∉-var X≠Y) var-∈ = X≠Y refl
+absent-present ∉-base ()
+absent-present ∉-star ()
+absent-present (∉-fun X∉A X∉B) (∈-fun-left X∈A) =
+  absent-present X∉A X∈A
+absent-present (∉-fun X∉A X∉B)
+    (∈-fun-right X∉A′ X∈B) =
+  absent-present X∉B X∈B
+absent-present (∉-all X∉A) (∈-all X∈A) =
+  absent-present X∉A X∈A
+
+generic-not-focus-out : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {G}
+  → OutActivation {X = X} κ κ′
+  → GenericGround κ G
+  → G ≢ ＇ X
+generic-not-focus-out {X = X} activation generic G≡X =
+  absent-present
+    (subst (X ∉ᵗ_) G≡X (generic-fresh-out activation generic))
+    var-∈
+
+generic-not-focus-in : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {G}
+  → InActivation {X = X} κ κ′
+  → GenericGround κ G
+  → G ≢ ＇ X
+generic-not-focus-in {X = X} activation generic G≡X =
+  absent-present
+    (subst (X ∉ᵗ_) G≡X (generic-fresh-in activation generic))
+    var-∈
+
+activate-to-star-out : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {G}
+  → OutActivation {X = X} κ κ′
+  → C._⊢_∼★ (toEnv∼ κ) G
+  → C._⊢_∼★ (toEnv∼ κ′) G
+activate-to-star-out {G = G} activation =
+  subst (λ μ → C._⊢_∼★ μ G) (toEnv∼-out-activation activation)
+
+activate-to-star-in : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {G}
+  → InActivation {X = X} κ κ′
+  → C._⊢_∼★ (toEnv∼ κ) G
+  → C._⊢_∼★ (toEnv∼ κ′) G
+activate-to-star-in {G = G} activation =
+  subst (λ μ → C._⊢_∼★ μ G) (toEnv∼-in-activation activation)
+
+activate-from-star-out : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {G}
+  → OutActivation {X = X} κ κ′
+  → C._⊢★∼_ (toEnv∼ κ) G
+  → C._⊢★∼_ (toEnv∼ κ′) G
+activate-from-star-out {G = G} activation =
+  subst (λ μ → C._⊢★∼_ μ G) (toEnv∼-out-activation activation)
+
+activate-from-star-in : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {G}
+  → InActivation {X = X} κ κ′
+  → C._⊢★∼_ (toEnv∼ κ) G
+  → C._⊢★∼_ (toEnv∼ κ′) G
+activate-from-star-in {G = G} activation =
+  subst (λ μ → C._⊢★∼_ μ G) (toEnv∼-in-activation activation)
+
+nonvar-variable-impossible : ∀ {X : TyVar Δ} → NonVar (＇ X) → ⊥
+nonvar-variable-impossible ()
+
+occurs-star-impossible : ∀ {X : TyVar Δ} → X ∈ᵗ ★ → ⊥
+occurs-star-impossible ()
+
+tag-source-not-focus : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {c A G}
+  → OutActivation {X = X} κ κ′
+  → GenericGround κ G
+  → κ ⊢ c ∶ A ⇒ G
+  → A ≢ ＇ X
+tag-source-not-focus {κ = κ} {G = G} activation generic c⊢ A≡X
+    with source-variable-shape
+      (subst (λ T → C._⊢_∼_ (toEnv∼ κ) T G)
+        A≡X (coercion→consistency c⊢))
+tag-source-not-focus activation generic c⊢ A≡X | inj₁ G≡X =
+  ⊥-elim (generic-not-focus-out activation generic G≡X)
+tag-source-not-focus activation generic c⊢ A≡X | inj₂ G≡★ =
+  ⊥-elim (generic-not-star generic G≡★)
+
+untag-target-not-focus : ∀ {X : TyVar Δ}
+    {κ κ′ : CastCtx Δ} {c G B}
+  → InActivation {X = X} κ κ′
+  → GenericGround κ G
+  → κ ⊢ c ∶ G ⇒ B
+  → B ≢ ＇ X
+untag-target-not-focus {κ = κ} {G = G} activation generic c⊢ B≡X
+    with target-variable-shape
+      (subst (λ T → C._⊢_∼_ (toEnv∼ κ) G T)
+        B≡X (coercion→consistency c⊢))
+untag-target-not-focus activation generic c⊢ B≡X | inj₁ G≡X =
+  ⊥-elim (generic-not-focus-in activation generic G≡X)
+untag-target-not-focus activation generic c⊢ B≡X | inj₂ G≡★ =
+  ⊥-elim (generic-not-star generic G≡★)
+
+gen-source-not-focus : ∀ {X : TyVar Δ}
+    {κ : CastCtx (Nat.suc Δ)} {c A B}
+  → κ ⊢ c ∶ ⇑ᵗ A ⇒ B
+  → NonVar B
+  → zero ∈ᵗ B
+  → A ≢ ＇ X
+gen-source-not-focus {κ = κ} {B = B} c⊢ nonvar occurs A≡X
+    with source-variable-shape
+      (subst (λ T → C._⊢_∼_ (toEnv∼ κ) T B)
+        (cong (λ T → ⇑ᵗ T) A≡X)
+        (coercion→consistency c⊢))
+gen-source-not-focus c⊢ nonvar occurs A≡X | inj₁ B≡X =
+  ⊥-elim (nonvar-variable-impossible (subst NonVar B≡X nonvar))
+gen-source-not-focus c⊢ nonvar occurs A≡X | inj₂ B≡★ =
+  ⊥-elim
+    (occurs-star-impossible (subst (zero ∈ᵗ_) B≡★ occurs))
+
+inst-target-not-focus : ∀ {X : TyVar Δ}
+    {κ : CastCtx (Nat.suc Δ)} {c A B}
+  → κ ⊢ c ∶ A ⇒ ⇑ᵗ B
+  → NonVar A
+  → zero ∈ᵗ A
+  → B ≢ ＇ X
+inst-target-not-focus {κ = κ} {A = A} c⊢ nonvar occurs B≡X
+    with target-variable-shape
+      (subst (λ T → C._⊢_∼_ (toEnv∼ κ) A T)
+        (cong (λ T → ⇑ᵗ T) B≡X)
+        (coercion→consistency c⊢))
+inst-target-not-focus c⊢ nonvar occurs B≡X | inj₁ A≡X =
+  ⊥-elim (nonvar-variable-impossible (subst NonVar A≡X nonvar))
+inst-target-not-focus c⊢ nonvar occurs B≡X | inj₂ A≡★ =
+  ⊥-elim
+    (occurs-star-impossible (subst (zero ∈ᵗ_) A≡★ occurs))
+
+------------------------------------------------------------------------
+-- Specialized leaves under activation
+------------------------------------------------------------------------
+
+activate-out-out-pending : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → κ Y ≡ inst-out-bound pending
+  → κ′ ⊢ inst-out Y ∶ replaceTy X ★ (＇ Y) ⇒ ★
+activate-out-out-pending {X = X} {Y = Y} activation eq with X ≟ Y
+activate-out-out-pending {X = X} {Y = .X} activation eq | yes refl =
+  ⊢inst-out-active (active-out-at activation)
+activate-out-out-pending {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-out-pending
+    (trans (sym (same-out-away activation X≠Y)) eq)
+
+activate-out-out-active : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → κ Y ≡ inst-out-bound active
+  → κ′ ⊢ inst-out Y ∶ replaceTy X ★ ★ ⇒ ★
+activate-out-out-active {X = X} {Y = Y} activation eq with X ≟ Y
+activate-out-out-active {X = X} {Y = .X} activation eq | yes refl
+    with trans (sym (pending-out-at activation)) eq
+activate-out-out-active {X = X} {Y = .X} activation eq | yes refl | ()
+activate-out-out-active {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-out-active
+    (trans (sym (same-out-away activation X≠Y)) eq)
+
+activate-out-in-pending : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → κ Y ≡ inst-in-bound pending
+  → κ′ ⊢ inst-in Y ∶ replaceTy X ★ ★ ⇒ ＇ Y
+activate-out-in-pending {X = X} {Y = Y} activation eq with X ≟ Y
+activate-out-in-pending {X = X} {Y = .X} activation eq | yes refl
+    with trans (sym (pending-out-at activation)) eq
+activate-out-in-pending {X = X} {Y = .X} activation eq | yes refl | ()
+activate-out-in-pending {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-in-pending
+    (trans (sym (same-out-away activation X≠Y)) eq)
+
+activate-out-in-active : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → OutActivation {X = X} κ κ′
+  → κ Y ≡ inst-in-bound active
+  → κ′ ⊢ inst-in Y ∶ replaceTy X ★ ★ ⇒ ★
+activate-out-in-active {X = X} {Y = Y} activation eq with X ≟ Y
+activate-out-in-active {X = X} {Y = .X} activation eq | yes refl
+    with trans (sym (pending-out-at activation)) eq
+activate-out-in-active {X = X} {Y = .X} activation eq | yes refl | ()
+activate-out-in-active {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-in-active
+    (trans (sym (same-out-away activation X≠Y)) eq)
+
+activate-in-in-pending : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → κ Y ≡ inst-in-bound pending
+  → κ′ ⊢ inst-in Y ∶ ★ ⇒ replaceTy X ★ (＇ Y)
+activate-in-in-pending {X = X} {Y = Y} activation eq with X ≟ Y
+activate-in-in-pending {X = X} {Y = .X} activation eq | yes refl =
+  ⊢inst-in-active (active-in-at activation)
+activate-in-in-pending {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-in-pending
+    (trans (sym (same-in-away activation X≠Y)) eq)
+
+activate-in-in-active : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → κ Y ≡ inst-in-bound active
+  → κ′ ⊢ inst-in Y ∶ ★ ⇒ replaceTy X ★ ★
+activate-in-in-active {X = X} {Y = Y} activation eq with X ≟ Y
+activate-in-in-active {X = X} {Y = .X} activation eq | yes refl
+    with trans (sym (pending-in-at activation)) eq
+activate-in-in-active {X = X} {Y = .X} activation eq | yes refl | ()
+activate-in-in-active {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-in-active
+    (trans (sym (same-in-away activation X≠Y)) eq)
+
+activate-in-out-pending : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → κ Y ≡ inst-out-bound pending
+  → κ′ ⊢ inst-out Y ∶ ＇ Y ⇒ replaceTy X ★ ★
+activate-in-out-pending {X = X} {Y = Y} activation eq with X ≟ Y
+activate-in-out-pending {X = X} {Y = .X} activation eq | yes refl
+    with trans (sym (pending-in-at activation)) eq
+activate-in-out-pending {X = X} {Y = .X} activation eq | yes refl | ()
+activate-in-out-pending {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-out-pending
+    (trans (sym (same-in-away activation X≠Y)) eq)
+
+activate-in-out-active : ∀ {X Y : TyVar Δ}
+    {κ κ′ : CastCtx Δ}
+  → InActivation {X = X} κ κ′
+  → κ Y ≡ inst-out-bound active
+  → κ′ ⊢ inst-out Y ∶ ★ ⇒ replaceTy X ★ ★
+activate-in-out-active {X = X} {Y = Y} activation eq with X ≟ Y
+activate-in-out-active {X = X} {Y = .X} activation eq | yes refl
+    with trans (sym (pending-in-at activation)) eq
+activate-in-out-active {X = X} {Y = .X} activation eq | yes refl | ()
+activate-in-out-active {X = X} {Y = Y} activation eq | no X≠Y =
+  ⊢inst-out-active
+    (trans (sym (same-in-away activation X≠Y)) eq)
+
+------------------------------------------------------------------------
+-- Phase activation preserves the raw coercion
+------------------------------------------------------------------------
+
+mutual
+  activate-out : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+      {c A B}
+    → OutActivation {X = X} κ κ′
+    → X ∉ᵗ B
+    → κ ⊢ c ∶ A ⇒ B
+    → κ′ ⊢ c ∶ replaceTy X ★ A ⇒ B
+  activate-out {κ′ = κ′} {A = A} activation fresh (⊢id atom) =
+    transport-coercion-typing (sym (replace-not-occurs fresh)) refl
+      (⊢id atom)
+  activate-out activation (∉-fun X∉A′ X∉B′) (⊢↦ c⊢ d⊢) =
+    ⊢↦
+      (activate-in (flip-out-activation activation) X∉A′ c⊢)
+      (activate-out activation X∉B′ d⊢)
+  activate-out activation (∉-all X∉B) (⊢∀ c⊢) =
+    ⊢∀ (activate-out (ext-out-activation activation) X∉B c⊢)
+  activate-out activation fresh
+      (⊢inj generic gate c⊢ nonstar) =
+    ⊢inj (activate-generic-out activation generic)
+      (activate-to-star-out activation gate)
+      (activate-out activation (generic-fresh-out activation generic) c⊢)
+      (replace-nonstar nonstar
+        (tag-source-not-focus activation generic c⊢))
+  activate-out activation fresh
+      (⊢proj generic gate c⊢ nonstar) =
+    ⊢proj (activate-generic-out activation generic)
+      (activate-from-star-out activation gate)
+      (transport-coercion-typing
+        (replace-not-occurs (generic-fresh-out activation generic)) refl
+        (activate-out activation fresh c⊢))
+      nonstar
+  activate-out activation fresh (⊢inst-out-pending eq) =
+    activate-out-out-pending activation eq
+  activate-out activation fresh (⊢inst-out-active eq) =
+    activate-out-out-active activation eq
+  activate-out activation fresh (⊢inst-in-pending eq) =
+    activate-out-in-pending activation eq
+  activate-out activation fresh (⊢inst-in-active eq) =
+    activate-out-in-active activation eq
+  activate-out activation fresh
+      (⊢inst nonvar occurs c⊢ B≠★) =
+    ⊢inst (replace-nonvar nonvar) (replace-suc-zero-occurs occurs)
+      (activate-out (inst-out-activation activation)
+        (shift-not-occurs fresh) c⊢)
+      B≠★
+  activate-out {X = X} activation (∉-all X∉B)
+      (⊢gen {A = A} nonvar occurs c⊢ A≠★) =
+    ⊢gen nonvar occurs
+      (transport-coercion-typing (replace-shift A) refl
+        (activate-out (gen-out-activation activation) X∉B c⊢))
+      (replace-nonstar-from-≢ A≠★
+        (gen-source-not-focus c⊢ nonvar occurs))
+  activate-out activation fresh ⊢bot-elim = ⊢bot-elim
+  activate-out activation fresh ⊢bot-intro = ⊢bot-intro
+
+  activate-in : ∀ {X : TyVar Δ} {κ κ′ : CastCtx Δ}
+      {c A B}
+    → InActivation {X = X} κ κ′
+    → X ∉ᵗ A
+    → κ ⊢ c ∶ A ⇒ B
+    → κ′ ⊢ c ∶ A ⇒ replaceTy X ★ B
+  activate-in {κ′ = κ′} {A = A} activation fresh (⊢id atom) =
+    transport-coercion-typing refl (sym (replace-not-occurs fresh))
+      (⊢id atom)
+  activate-in activation (∉-fun X∉A X∉B) (⊢↦ c⊢ d⊢) =
+    ⊢↦
+      (activate-out (flip-in-activation activation) X∉A c⊢)
+      (activate-in activation X∉B d⊢)
+  activate-in activation (∉-all X∉A) (⊢∀ c⊢) =
+    ⊢∀ (activate-in (ext-in-activation activation) X∉A c⊢)
+  activate-in activation fresh
+      (⊢inj generic gate c⊢ nonstar) =
+    ⊢inj (activate-generic-in activation generic)
+      (activate-to-star-in activation gate)
+      (transport-coercion-typing refl
+        (replace-not-occurs (generic-fresh-in activation generic))
+        (activate-in activation fresh c⊢))
+      nonstar
+  activate-in activation fresh
+      (⊢proj generic gate c⊢ nonstar) =
+    ⊢proj (activate-generic-in activation generic)
+      (activate-from-star-in activation gate)
+      (activate-in activation
+        (generic-fresh-in activation generic) c⊢)
+      (replace-nonstar nonstar
+        (untag-target-not-focus activation generic c⊢))
+  activate-in activation fresh (⊢inst-out-pending eq) =
+    activate-in-out-pending activation eq
+  activate-in activation fresh (⊢inst-out-active eq) =
+    activate-in-out-active activation eq
+  activate-in activation fresh (⊢inst-in-pending eq) =
+    activate-in-in-pending activation eq
+  activate-in activation fresh (⊢inst-in-active eq) =
+    activate-in-in-active activation eq
+  activate-in {X = X} activation (∉-all X∉A)
+      (⊢inst {B = B} nonvar occurs c⊢ B≠★) =
+    ⊢inst nonvar occurs
+      (transport-coercion-typing refl (replace-shift B)
+        (activate-in (inst-in-activation activation) X∉A c⊢))
+      (replace-nonstar-from-≢ B≠★
+        (inst-target-not-focus c⊢ nonvar occurs))
+  activate-in activation fresh
+      (⊢gen nonvar occurs c⊢ A≠★) =
+    ⊢gen (replace-nonvar nonvar) (replace-suc-zero-occurs occurs)
+      (activate-in (gen-in-activation activation)
+        (shift-not-occurs fresh) c⊢)
+      A≠★
+  activate-in activation fresh ⊢bot-elim = ⊢bot-elim
+  activate-in activation fresh ⊢bot-intro = ⊢bot-intro
+
+newest-out-activation : ∀ {Δ} {κ : CastCtx Δ}
+  → OutActivation {X = zero}
+      (instCtx pending κ) (instCtx active κ)
+newest-out-activation = out-activation refl refl away
+  where
+  away : ∀ {Δ} {κ : CastCtx Δ} {Y}
+    → zero ≢ Y
+    → instCtx pending κ Y ≡ instCtx active κ Y
+  away {Y = zero} zero≠zero = ⊥-elim (zero≠zero refl)
+  away {Y = suc Y} zero≠sucY = refl
+
+activate-newest-typing : ∀ {Δ} {κ : CastCtx Δ}
+    {c : Coercion (Nat.suc Δ)} {A : Ty (Nat.suc Δ)} {B : Ty Δ}
+  → instCtx pending κ ⊢ c ∶ A ⇒ ⇑ᵗ B
+  → instCtx active κ ⊢ c ∶ replaceTy zero ★ A ⇒ ⇑ᵗ B
+activate-newest-typing {B = B} c⊢ =
+  activate-out newest-out-activation (zero-absent-shift B) c⊢

--- a/GTSFImp/experimental/README.md
+++ b/GTSFImp/experimental/README.md
@@ -1,0 +1,147 @@
+# Leaf-local contextual coercion experiment
+
+This experiment tests the context-switching presentation of `β-inst` without
+changing the live GTSFImp development.
+
+## Raw coercions and leaf-local typing
+
+[`ContextualCoercion.agda`](ContextualCoercion.agda) separates raw `Coercion`
+syntax from its typing judgment. The raw constructors cover the live
+consistency constructors and add two specialized leaves:
+
+- `inst-out X` represents the instantiation-bound cast from `X` to `★`;
+- `inst-in X` represents the instantiation-bound cast from `★` to `X`.
+
+The raw `id`, `inst c`, and `gen c` constructors carry no endpoint types.
+Their endpoint types occur in the typing derivation, not in the raw syntax.
+
+A `CastCtx` entry records the live consistency mode and, for an
+instantiation-bound variable, whether allocation is `pending` or `active`.
+The phase affects only the two specialized typing rules:
+
+```agda
+⊢inst-out-pending : κ X ≡ inst-out-bound pending
+  → κ ⊢ inst-out X ∶ ＇ X ⇒ ★
+
+⊢inst-out-active : κ X ≡ inst-out-bound active
+  → κ ⊢ inst-out X ∶ ★ ⇒ ★
+
+⊢inst-in-pending : κ X ≡ inst-in-bound pending
+  → κ ⊢ inst-in X ∶ ★ ⇒ ＇ X
+
+⊢inst-in-active : κ X ≡ inst-in-bound active
+  → κ ⊢ inst-in X ∶ ★ ⇒ ★
+```
+
+The rules for identity, arrows, universals, injection, projection,
+instantiation, generalization, and the two bottom cases use their ordinary
+endpoint indices; there is no recursive `interpret` operation in the typing
+relation.
+
+The generic injection and projection rules require `GenericGround κ G`.
+For a variable ground `＇ X`, that evidence can be constructed only when
+`κ X` is `ordinary`. Consequently, when `X` is instantiation-bound, the raw
+generic identity injection and projection at `X` are not typable: the boundary
+must be represented by `inst-out X` or `inst-in X`.
+
+## Correspondence with consistency
+
+The phase-forgetting map is
+
+```agda
+toEnv∼ : CastCtx Δ → Env∼ Δ
+```
+
+and it commutes with `flipᵐ`, `extᵐ`, `instᵐ`, and `genᵐ`. Every
+contextual coercion typing derivation erases to live consistency at its
+actual endpoints:
+
+```agda
+coercion→consistency :
+  κ ⊢ c ∶ A ⇒ B
+  → toEnv∼ κ ⊢ A ∼ B
+```
+
+The reverse theorem applies to a `PendingCtx`, whose entries are ordinary or
+instantiation-bound at the pending phase:
+
+```agda
+consistency→coercion :
+  PendingCtx κ
+  → toEnv∼ κ ⊢ A ∼ B
+  → Σ[ c ∈ Coercion Δ ] (κ ⊢ c ∶ A ⇒ B)
+```
+
+In the variable-ground injection and projection cases, the proof inspects the
+corresponding `CastCtx` entry. An ordinary entry produces generic `_!` or `？_`
+syntax; an instantiation-bound entry produces `inst-out` or `inst-in`.
+`consistency→fromEnv∼-coercion` and
+`fromEnv∼-coercion→consistency` state the resulting equivalence for an
+arbitrary live `Env∼` embedded by `fromEnv∼`.
+
+## `β-inst` and phase activation
+
+[`ContextualBetaInst.agda`](ContextualBetaInst.agda) adds experimental term
+wrappers and reduction. Cast contexts occur only in `⊢cast`, not in `Term`.
+The same raw body coercion is used before and after allocation.
+
+[`ContextualCoercionActivation.agda`](ContextualCoercionActivation.agda)
+proves that every well-typed pending instantiation body admits the required
+active typing:
+
+```agda
+activate-newest-typing :
+  pending0 ⊢ c ∶ A ⇒ ⇑ᵗ B
+  → active0 ⊢ c ∶ replaceTy zero ★ A ⇒ ⇑ᵗ B
+```
+
+The proof is by induction on contextual coercion typing. It reuses the live
+occurrence, shifting, and type-replacement lemmas to carry the phase change
+through arrows, universals, nested `inst`, and nested `gen`. The raw coercion
+is unchanged throughout.
+
+The experimental `β-inst` takes the pending body typing as a premise, derives
+the active typing using `activate-newest-typing`, and retains the generated
+reveal conversion
+
+```agda
+↑ 〖 zero , ★ ↑ A 〗
+```
+
+and then applies the actively typed, unchanged raw coercion `c`. The theorem
+`β-inst-preservation` proves preservation across the `bind ★` store change.
+The identity example checks the characteristic phase change:
+
+```agda
+pending0 ⊢ inst-in zero ↦ inst-out zero
+  ∶ (X ⇒ X) ⇒ (★ ⇒ ★)
+
+active0 ⊢ inst-in zero ↦ inst-out zero
+  ∶ (★ ⇒ ★) ⇒ (★ ⇒ ★)
+```
+
+At runtime, either specialized leaf lowers to the unannotated `id`.
+
+## Nested-generalization regression
+
+The [checked regression](ContextualActivationRegression.agda) retains the
+former nested-`gen` counterexample. In named-variable notation, its pending
+body has the following shape, where `X` is bound by the enclosing `inst` and
+`Y` is bound by `gen`:
+
+```agda
+gen (inst-in X ↦ ？ id)
+```
+
+It is typable from `X ⇒ ★` to `∀ Y. ★ ⇒ Y`. Consequently the outer
+`inst` source is non-variable and contains `X`, while its target is non-`★`;
+all existing `inst` side conditions hold. The enclosing variable is also
+forced through `inst-in`, exactly as intended.
+
+After activation, `body-active` checks that the same raw body is typable from
+`★ ⇒ ★` to the same target. This is precisely the case that failed when
+raw `gen` stored its source annotation. Removing the endpoint annotations
+from both `gen` and `inst` eliminates that obstruction.
+
+The experiment does not replace the live consistency relation, evaluator, or
+full type-safety development.


### PR DESCRIPTION
## Summary

Adds a self-contained `GTSFImp/experimental` development exploring contextual coercion typing for `β-inst`, without changing the live GTSFImp language or metatheory.

- separates raw `Coercion` syntax from contextual coercion typing;
- leaves endpoint types out of raw `id`, `inst`, and `gen` constructors;
- interprets instantiation-bound variables only at `inst-out` and `inst-in` leaves, with pending and active phases;
- proves forward and reverse correspondence with the existing consistency relation;
- proves that a pending instantiation body can be retyped under the active context without changing its raw coercion;
- uses that activation theorem to prove preservation for the experimental `β-inst` rule;
- includes identity and nested-generalization regression examples plus design notes.

The experiment retains the generated reveal conversion `↑ 〖 zero , ★ ↑ A 〗`. At runtime, `inst-out` and `inst-in` lower to the unannotated identity coercion.

## Motivation

The design aims to keep the simplifications of GTSFImp—separate casts and conversions, and consistency in place of quotient-based narrowing/widening—while avoiding the explicit coercion substitution `c [ ★/0 ]ᶜ` in `β-inst`. The coercion typing context records when an instantiation-bound variable changes from pending to active, and the activation theorem shows that the unchanged raw coercion receives the required post-allocation typing.

## Validation

From `GTSFImp/`:

- `agda --no-allow-unsolved-metas -v0 experimental/ContextualCoercion.agda`
- `agda --no-allow-unsolved-metas -v0 experimental/ContextualCoercionActivation.agda`
- `agda --no-allow-unsolved-metas -v0 experimental/ContextualBetaInst.agda`
- `agda --no-allow-unsolved-metas -v0 experimental/ContextualActivationRegression.agda`

All four commands pass.