### PR TITLE
[codex] Investigate CTI projection mismatch reachability

### DIFF
--- a/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
+++ b/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
@@ -17,6 +17,33 @@ $$
 The left side is a value. The right side blames because the projection checks
 the unrelated tag `Y` against `\mathbb{N}`.
 
+The counterexample world also assumes that source `X` and target `Y` occupy
+the same center while that center is marked `X \sqsubseteq \star`. Source
+imprecision does not introduce such a cell at a pair of binders. The checked
+binder cases are
+
+$$
+\begin{array}{c|c|c}
+\text{source form} & \text{target form} & \text{fresh world cell} \\
+\hline
+\Lambda X & \Lambda Y & (X,Y;\;X\sqsubseteq X) \\
+\Lambda X & N'          & (X,-;\;X\sqsubseteq\star).
+\end{array}
+$$
+
+Thus a dynamic cell initially has no target occupant. If a later target-side
+generation is aligned with it, that runtime transition—not a matched
+`\Lambda`—must justify the alignment and preserve the generated cast wrappers.
+More importantly, under the matched-binder environment the judgment
+
+$$
+X \sqsubseteq \star
+$$
+
+is empty, whereas it is immediate under the source-only binder environment.
+So matched source and target type variables can be used only through
+variable-to-variable imprecision in the source derivation.
+
 ## A closed related source pair
 
 `SourceLegScratch.agda` defines the following pair, using named variables
@@ -149,15 +176,29 @@ needed to expose the mismatched projection.
 
 ## Invariant exposed by the failed construction
 
-The experiment supports two connected source invariants.
+The experiment supports three connected source invariants.
 
-1. **Value-flow provenance.** A generated projection `Y?` may inspect only a
+1. **Binder-match provenance.** Matched `\Lambda` binders create an
+   `X\sqsubseteq X` cell. An `X\sqsubseteq\star` cell is created only by a
+   source-only binder and initially has no target variable. The abstract bad
+   world has both an aligned target variable and the dynamic mark, so it
+   already represents a later runtime alignment whose origin has been erased.
+
+   The runtime development can *decay* a matched cell's current world mark from
+   `X\sqsubseteq X` to `X\sqsubseteq\star`. Decay transports the original
+   variable-to-variable derivations; it does not turn a matched source use into
+   a source-level `X\sqsubseteq\star` use. Because the CTI records only the
+   current mark, a later CTI constructor can incorrectly treat that decayed
+   mark as fresh permission to form a star matchup. The relation must retain
+   the pre-decay occurrence/binder provenance as well as the current mark.
+
+2. **Value-flow provenance.** A generated projection `Y?` may inspect only a
    value whose path through the related source terms supplies the matching
    `Y!`, or a residual projection justified after cancellation of such a
    matching pair. An unrelated `\mathbb{N}!` can be returned only by changing
    the target body in a way that breaks source-term imprecision.
 
-2. **Allocation-order provenance.** In the precise execution, the name whose
+3. **Allocation-order provenance.** In the precise execution, the name whose
    store representation is `\star` is the inner, source-only allocation. The
    source name aligned with target `Y` is the outer allocation and has that
    inner name as its representation. Relating the inner source name directly
@@ -179,9 +220,11 @@ the projection with a checked `CatchupCast` witness and both sides return.
 
 This is evidence, not yet a general preservation theorem. The next sound step
 is to prove that source imprecision plus compilation and related reduction
-preserve a provenance-indexed CTI judgment. At every target cast column used by
-catch-up, that judgment should provide `CatchupColumn`; its projection head
-should provide `CatchupCast`, including the matching-injection or recursive
-post-cancellation evidence. Proving that theorem would establish that the
-restriction is semantic provenance inherited from the source, rather than an
-ad hoc premise added only to close `ExtraCastRight`.
+preserve a provenance-indexed CTI judgment. Its world component must remember
+whether a cell came from matched binders or from a one-sided binder followed by
+runtime alignment. At every target cast column used by catch-up, the judgment
+should provide `CatchupColumn`; its projection head should provide
+`CatchupCast`, including the matching-injection or recursive post-cancellation
+evidence. Proving that theorem would establish that the restriction is
+semantic provenance inherited from the source, rather than an ad hoc premise
+added only to close `ExtraCastRight`.

--- a/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
+++ b/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
@@ -234,7 +234,8 @@ following provenance.
   representations.
 - **Cast ancestry:** runtime alignment must record the matching generated
   injection/projection path, or the residual path left after a matching pair
-  has cancelled.
+  has cancelled. This evidence belongs in the constructors of the CTI
+  derivation itself, not in a companion predicate.
 
 The intended state distinctions are therefore
 
@@ -252,8 +253,8 @@ $$
 
 where the first transition is decay and preserves matched-use capability,
 while `\pi` in the second transition is the allocation and cast provenance
-that eventually yields `CatchupCast`. The two states on the right have the
-same current mark but must not support the same CTI constructors.
+used directly by the CTI cast constructors. The two states on the right have
+the same current mark but must not support the same CTI constructors.
 
 This suggests the following rule changes.
 
@@ -269,27 +270,67 @@ This suggests the following rule changes.
    derivations or their cast directions/shapes, not merely their source and
    target types.
 5. `\sqsubseteq\mathrm{cast}^{2}` may add a target projection only from a
-   runtime-aligned witness showing a matching target injection, or from
-   recursive post-cancellation provenance. The symmetric
+   runtime-aligned CTI premise whose target term contains the matching target
+   injection, or from a recursive CTI premise representing the state after a
+   matching pair has cancelled. The symmetric
    `\mathrm{cast}\sqsubseteq^{2}` rule needs the corresponding source-side
-   condition.
-6. A target cast column exposed by inversion must carry `CatchupColumn`; its
-   head projection then yields `CatchupCast` rather than requiring callers to
-   assume it independently.
+   structure.
+6. Separate `GeneratedProjection`, `CatchupCast`, `CatchupCast⁻`,
+   `CatchupColumn`, and `CatchupColumn⁻` judgments should be removed. They
+   duplicate invariants that the strengthened CTI must expose by ordinary
+   inversion.
+
+In particular, the projection clauses should be term-shaped. If the target
+cast is `G?`, the same-tag clause should require the target input to have the
+form `V\langle G!\rangle` and should retain the CTI derivation relating the
+source to that injected value. An expanded projection should retain a
+recursive CTI derivation for the residual cast after the ground pair cancels.
+There should be no CTI constructor capable of deriving
+
+$$
+M \sqsubseteq V\langle H!\rangle\langle G?\rangle
+\qquad\text{when }G\ne H
+$$
+
+solely from endpoint type imprecision. Consequently, the abstract
+`\mathbb{N}!;Y?` counterexample becomes underivable in CTI itself.
+
+The proof interfaces should then consume whole CTI derivations, not a base CTI
+derivation plus an external cast-provenance premise. Schematically,
+`ExtraCastRight` should start from
+
+$$
+W\mid\gamma\vdash M\sqsubseteq M'\langle c'\rangle:q,
+$$
+
+along with the value hypotheses for `M` and `M'`. It should invert that CTI
+derivation to determine whether `c'` is inert, identity, a same-tag projection,
+an expanded projection, or an instantiation. The projection cases obtain the
+matching injection and residual derivation from the corresponding CTI
+constructor.
+
+Likewise, the multi-cast proof should start from a CTI derivation whose target
+is syntactically `M'` under the cast column. Induction may still follow the
+syntactic column, but at each layer it must invert the CTI derivation for that
+already-casted term. No separate proposition should certify the column or its
+head cast.
 
 The required validation theorem has two stages. Compilation should map every
 source-term imprecision derivation to the strengthened CTI and mint all birth
 and use evidence. Related reduction should preserve that evidence while adding
 only justified runtime-alignment and cast-ancestry witnesses. Erasing the
-provenance fields may recover the present CTI, but the catch-up and simulation
-lemmas should consume the strengthened judgment.
+provenance fields may recover the present CTI, but `ExtraCastRight`, the
+multi-cast proof, and the simulation lemmas should consume the strengthened
+judgment directly.
 
 ## Conclusion and next theorem
 
 No source-level counterexample was obtained. The strongest constructed target
 that really blames is well typed but provably not source-related to the
 returning precise program. The strongest genuinely source-related pair reaches
-the projection with a checked `CatchupCast` witness and both sides return.
+the projection with the matching injection structurally present, and both
+sides return. The current mechanization packages that fact as `CatchupCast`;
+the proposed CTI should make the same fact available by inversion.
 
 This is evidence, not yet a general preservation theorem. The next sound step
 is to prove that source imprecision plus compilation and related reduction
@@ -297,5 +338,5 @@ preserve a provenance-indexed CTI judgment. Its world component must remember
 whether a cell came from matched binders or from a one-sided binder followed by
 runtime alignment, while its use evidence remains tied to the source
 derivation. Proving the compilation and reduction preservation stages above
-would establish that `CatchupCast` is semantic provenance inherited from the
-source, rather than an ad hoc premise added only to close `ExtraCastRight`.
+would let `ExtraCastRight` and simulation use semantic provenance directly
+from CTI, with no catch-up provenance relations in the final development.

--- a/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
+++ b/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
@@ -1,0 +1,187 @@
+# Source reachability of the CTI projection mismatch
+
+## Question
+
+Can a related pair of closed gradual source terms compile and reduce to the
+abstract CTI counterexample in `ProjectionMismatchStarRepScratch.agda`?
+
+The bad runtime fragment is
+
+$$
+\left((0\langle \mathbb{N}!\rangle)\mathbin{\downarrow}
+  \operatorname{seal}X\,\star\right)
+\quad\sqsubseteq\quad
+0\langle \mathbb{N}!\rangle\langle Y?\rangle .
+$$
+
+The left side is a value. The right side blames because the projection checks
+the unrelated tag `Y` against `\mathbb{N}`.
+
+## A closed related source pair
+
+`SourceLegScratch.agda` defines the following pair, using named variables
+here instead of the mechanization's de Bruijn indices:
+
+$$
+\begin{aligned}
+P ={}&
+(\lambda g : \forall X.\,X\to X.\;
+   ((\Lambda X.\,\lambda x:X.\,g[X]\,x)[\star])\,0)
+\\[-1mm]&\qquad
+(\Lambda X.\,\lambda x:X.\,x),
+\\[1mm]
+Q ={}&
+(\lambda g : \forall X.\,X\to X.\;
+   (\lambda x:\star.\,g[\star]\,x)\,0)
+\\[-1mm]&\qquad
+(\lambda x:\star.\,x).
+\end{aligned}
+$$
+
+The repaired scratch checks all of the following:
+
+- `P` and `Q` are closed and have result type `\star`.
+- `P \sqsubseteq Q` in gradual source-term imprecision.
+- The proof-erased executable compiler mirrors for `P` and `Q` evaluate to
+  values, and their cast/type skeletons equal those of the ordinary compiler.
+- The target execution reaches a generated-name projection.
+
+Immediately before that projection, the actual target value is not merely
+`0\langle\mathbb{N}!\rangle`. It is
+
+$$
+N_Y =
+\left((0\langle\mathbb{N}!\rangle)
+  \mathbin{\downarrow}\operatorname{seal}Y\,\star\right)
+\langle Y!\rangle .
+$$
+
+The remaining target context applies `Y?` and then unseals `Y`:
+
+$$
+N_Y\langle Y?\rangle
+  \mathbin{\uparrow}\operatorname{unseal}Y\,\star .
+$$
+
+`SourceReachabilityResultScratch.agda` checks the corresponding
+`CatchupCast` witness and this exact reduction:
+
+$$
+\begin{aligned}
+&N_Y\langle Y?\rangle
+  \mathbin{\uparrow}\operatorname{unseal}Y\,\star
+\\
+&\quad\longrightarrow
+\left((0\langle\mathbb{N}!\rangle)
+  \mathbin{\downarrow}\operatorname{seal}Y\,\star\right)
+  \mathbin{\uparrow}\operatorname{unseal}Y\,\star
+\\
+&\quad\longrightarrow 0\langle\mathbb{N}!\rangle .
+\end{aligned}
+$$
+
+Thus this related source pair reaches the critical projection shape, but the
+matching `Y!` provenance is still present and the projection cannot mistake
+the inner `\mathbb{N}!` tag for its input tag.
+
+The executable compiled mirror for `P` contains an additional inert universal
+identity cast, so it is not definitionally the simplified precise checkpoint
+in `InitialPairScratch.agda`. Its complete evaluator trace nevertheless returns
+a value. In the simplified CTI checkpoint, the corresponding nested seals
+cancel in allocation order:
+
+$$
+\begin{aligned}
+&\left(
+  \left((0\langle\mathbb{N}!\rangle)
+    \mathbin{\downarrow}\operatorname{seal}X_1\,\star\right)
+    \mathbin{\downarrow}\operatorname{seal}X_0\,X_1
+  \right)
+  \mathbin{\uparrow}\operatorname{unseal}X_0\,X_1
+  \mathbin{\uparrow}\operatorname{unseal}X_1\,\star
+\\
+&\quad\longrightarrow
+\left((0\langle\mathbb{N}!\rangle)
+  \mathbin{\downarrow}\operatorname{seal}X_1\,\star\right)
+  \mathbin{\uparrow}\operatorname{unseal}X_1\,\star
+\\
+&\quad\longrightarrow 0\langle\mathbb{N}!\rangle .
+\end{aligned}
+$$
+
+## Forcing the target to blame
+
+The target identity can be replaced by a dynamic function that ignores its
+argument and independently manufactures a tagged natural:
+
+$$
+d_{\mathrm{bad}}
+= \lambda x:\star.\;(\lambda z:\star.\,z)\,0.
+$$
+
+Replacing the final `(\lambda x:\star.\,x)` in `Q` by
+`d_{\mathrm{bad}}` produces a closed, well-typed target program. The scratch
+checks that its executable compiled mirror reaches blame and has the same
+cast/type skeleton as the ordinary compiler output. Operationally, the
+generalized function receives a value tagged with `Y!`, discards it, returns a
+value tagged with `\mathbb{N}!`, and then fails the generated `Y?` projection.
+
+This is not a DGG counterexample. The scratch also checks that there is no
+source-imprecision derivation
+
+$$
+\Lambda X.\,\lambda x:X.\,x
+\quad\sqsubseteq\quad
+d_{\mathrm{bad}}.
+$$
+
+Inverting the only possible universal-to-dynamic-function rule leaves the
+impossible body judgment
+
+$$
+x \sqsubseteq (\lambda z:\star.\,z)\,0.
+$$
+
+It then refutes the proposed closed judgment `P \sqsubseteq Q_bad` by
+inverting the outer application and applying that result to its argument
+premise. Source imprecision therefore rejects exactly the value-flow change
+needed to expose the mismatched projection.
+
+## Invariant exposed by the failed construction
+
+The experiment supports two connected source invariants.
+
+1. **Value-flow provenance.** A generated projection `Y?` may inspect only a
+   value whose path through the related source terms supplies the matching
+   `Y!`, or a residual projection justified after cancellation of such a
+   matching pair. An unrelated `\mathbb{N}!` can be returned only by changing
+   the target body in a way that breaks source-term imprecision.
+
+2. **Allocation-order provenance.** In the precise execution, the name whose
+   store representation is `\star` is the inner, source-only allocation. The
+   source name aligned with target `Y` is the outer allocation and has that
+   inner name as its representation. Relating the inner source name directly
+   to `Y` would cross the order-preserving world embeddings. The checked
+   `SourceStarProbe.agda` refutes that crossing in the representative
+   two-allocation world.
+
+The unrestricted CTI rule `\sqsubseteq\mathrm{cast}^{2}` forgets the first
+invariant: it can append `Y?` using only its endpoint type obligations. A
+manually assembled CTI world can also omit the allocation history needed to
+recover the second invariant.
+
+## Conclusion and next theorem
+
+No source-level counterexample was obtained. The strongest constructed target
+that really blames is well typed but provably not source-related to the
+returning precise program. The strongest genuinely source-related pair reaches
+the projection with a checked `CatchupCast` witness and both sides return.
+
+This is evidence, not yet a general preservation theorem. The next sound step
+is to prove that source imprecision plus compilation and related reduction
+preserve a provenance-indexed CTI judgment. At every target cast column used by
+catch-up, that judgment should provide `CatchupColumn`; its projection head
+should provide `CatchupCast`, including the matching-injection or recursive
+post-cancellation evidence. Proving that theorem would establish that the
+restriction is semantic provenance inherited from the source, rather than an
+ad hoc premise added only to close `ExtraCastRight`.

--- a/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
+++ b/GTSFImp/proof/DGG/notes/SOURCE-CTI-REACHABILITY.md
@@ -206,10 +206,83 @@ The experiment supports three connected source invariants.
    `SourceStarProbe.agda` refutes that crossing in the representative
    two-allocation world.
 
-The unrestricted CTI rule `\sqsubseteq\mathrm{cast}^{2}` forgets the first
-invariant: it can append `Y?` using only its endpoint type obligations. A
-manually assembled CTI world can also omit the allocation history needed to
-recover the second invariant.
+The unrestricted CTI rule `\sqsubseteq\mathrm{cast}^{2}` forgets the first two
+invariants: after decay it can treat the current mark as fresh star-use
+permission and append `Y?` using only endpoint type obligations. A manually
+assembled CTI world can also omit the allocation history needed to recover the
+third invariant.
+
+## Proposed strengthening of CTI
+
+The CTI should distinguish a world's current approximation from the evidence
+that authorized each type-variable use. A world cell needs at least the
+following provenance.
+
+- **Birth origin:** either `matched`, introduced by source
+  `\Lambda\sqsubseteq\Lambda`, or `source-only`, introduced by
+  `\Lambda\sqsubseteq N'`.
+- **Current mark:** `X\sqsubseteq X` or `X\sqsubseteq\star`, together with the
+  decay history from the birth mark. This is operational approximation data,
+  not by itself permission to derive a new source `X\sqsubseteq\star` use.
+- **Use capability:** matched birth authorizes variable-to-variable uses even
+  after decay; source-only birth authorizes source-variable-to-star uses. This
+  evidence should be carried by the type and term imprecision derivations
+  rather than reconstructed from the current mark.
+- **Occupancy and allocation ancestry:** a source-only cell initially has no
+  target occupant. Adding or aligning a target variable must record the target
+  allocation, the order-preserving embedding facts, and the related store
+  representations.
+- **Cast ancestry:** runtime alignment must record the matching generated
+  injection/projection path, or the residual path left after a matching pair
+  has cancelled.
+
+The intended state distinctions are therefore
+
+$$
+\begin{aligned}
+&\operatorname{matched}(X,Y;X\sqsubseteq X)
+  \longrightarrow
+  \operatorname{matched}(X,Y;X\sqsubseteq\star),
+\\
+&\operatorname{sourceOnly}(X,-;X\sqsubseteq\star)
+  \longrightarrow
+  \operatorname{runtimeAligned}(X,Y;X\sqsubseteq\star,\pi),
+\end{aligned}
+$$
+
+where the first transition is decay and preserves matched-use capability,
+while `\pi` in the second transition is the allocation and cast provenance
+that eventually yields `CatchupCast`. The two states on the right have the
+same current mark but must not support the same CTI constructors.
+
+This suggests the following rule changes.
+
+1. `\Lambda\sqsubseteq\Lambda` mints matched birth and matched-use evidence;
+   `\Lambda\sqsubseteq N'` mints source-only birth and star-use evidence, with
+   no target occupant.
+2. World decay changes only the current mark. It transports existing use
+   evidence and cannot manufacture star-use evidence for a matched binder.
+3. `RebaseAt` and smart alias merging may turn a source-only cell into a
+   runtime-aligned cell only when they also produce allocation-order,
+   store-representation, and cast-ancestry witnesses.
+4. `\mathrm{cast}\sqsubseteq\mathrm{cast}^{2}` must relate the consistency
+   derivations or their cast directions/shapes, not merely their source and
+   target types.
+5. `\sqsubseteq\mathrm{cast}^{2}` may add a target projection only from a
+   runtime-aligned witness showing a matching target injection, or from
+   recursive post-cancellation provenance. The symmetric
+   `\mathrm{cast}\sqsubseteq^{2}` rule needs the corresponding source-side
+   condition.
+6. A target cast column exposed by inversion must carry `CatchupColumn`; its
+   head projection then yields `CatchupCast` rather than requiring callers to
+   assume it independently.
+
+The required validation theorem has two stages. Compilation should map every
+source-term imprecision derivation to the strengthened CTI and mint all birth
+and use evidence. Related reduction should preserve that evidence while adding
+only justified runtime-alignment and cast-ancestry witnesses. Erasing the
+provenance fields may recover the present CTI, but the catch-up and simulation
+lemmas should consume the strengthened judgment.
 
 ## Conclusion and next theorem
 
@@ -222,9 +295,7 @@ This is evidence, not yet a general preservation theorem. The next sound step
 is to prove that source imprecision plus compilation and related reduction
 preserve a provenance-indexed CTI judgment. Its world component must remember
 whether a cell came from matched binders or from a one-sided binder followed by
-runtime alignment. At every target cast column used by catch-up, the judgment
-should provide `CatchupColumn`; its projection head should provide
-`CatchupCast`, including the matching-injection or recursive post-cancellation
-evidence. Proving that theorem would establish that the restriction is
-semantic provenance inherited from the source, rather than an ad hoc premise
-added only to close `ExtraCastRight`.
+runtime alignment, while its use evidence remains tied to the source
+derivation. Proving the compilation and reduction preservation stages above
+would establish that `CatchupCast` is semantic provenance inherited from the
+source, rather than an ad hoc premise added only to close `ExtraCastRight`.

--- a/GTSFImp/proof/DGG/notes/SourceLegScratch.agda
+++ b/GTSFImp/proof/DGG/notes/SourceLegScratch.agda
@@ -16,7 +16,8 @@ open import Types
 open import TermCtx using (Z; S)
 open import TyStore using (store-empty)
 open import Consistency using
-  (Env∼; idᶜ; instᵐ; genᵐ; _⊢_∼_; _∼_; id; _!; ？_; _↦_;
+  (Env∼; idᶜ; instᵐ; genᵐ; flipᵐ; _⊢_∼_; _∼_; id; _!;
+   ？_; _↦_;
    ∀ᶜ_; inst_; gen_; X∼★ᵍ; ★∼Xᵍ)
 import Imprecision as I
 import GradualTerms as G
@@ -70,11 +71,23 @@ inst-X! =
   _! ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ G∼★ = X∼★ᵍ refl ⦄
     (id (＇ Fin.zero)) ⦃ Ans = nonstar-X ⦄
 
+flip-inst-★?X : ∀ {Δ} {μ : Env∼ Δ}
+  → flipᵐ (instᵐ μ) ⊢ ★ ∼ ＇ Fin.zero
+flip-inst-★?X =
+  ？_ ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ ★∼G = ★∼Xᵍ refl ⦄
+    (id (＇ Fin.zero)) ⦃ Bns = nonstar-X ⦄
+
 gen-★?X : ∀ {Δ} {μ : Env∼ Δ}
   → genᵐ μ ⊢ ★ ∼ ＇ Fin.zero
 gen-★?X =
   ？_ ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ ★∼G = ★∼Xᵍ refl ⦄
     (id (＇ Fin.zero)) ⦃ Bns = nonstar-X ⦄
+
+flip-gen-X! : ∀ {Δ} {μ : Env∼ Δ}
+  → flipᵐ (genᵐ μ) ⊢ ＇ Fin.zero ∼ ★
+flip-gen-X! =
+  _! ⦃ Gᵍ = ＇ Fin.zero ⦄ ⦃ G∼★ = X∼★ᵍ refl ⦄
+    (id (＇ Fin.zero)) ⦃ Ans = nonstar-X ⦄
 
 ∀X⇒X∼∀X⇒X : ∀ {Δ} → ∀X⇒X {Δ} ∼ ∀X⇒X {Δ}
 ∀X⇒X∼∀X⇒X = ∀ᶜ (id (＇ Fin.zero) ↦ id (＇ Fin.zero))
@@ -82,12 +95,12 @@ gen-★?X =
 ∀X⇒X∼★⇒★ : ∀ {Δ} → ∀X⇒X {Δ} ∼ ★⇒★ᵗ {Δ}
 ∀X⇒X∼★⇒★ =
   inst_ ⦃ Anv = nonvar-fun ⦄ ⦃ z∈A = X∈X⇒X ⦄
-    (inst-X! ↦ inst-X!) (λ ())
+    (flip-inst-★?X ↦ inst-X!) (λ ())
 
 ★⇒★∼∀X⇒X : ∀ {Δ} → ★⇒★ᵗ {Δ} ∼ ∀X⇒X {Δ}
 ★⇒★∼∀X⇒X =
   gen_ ⦃ Bnv = nonvar-fun ⦄ ⦃ z∈B = X∈X⇒X ⦄
-    (gen-★?X ↦ gen-★?X) (λ ())
+    (flip-gen-X! ↦ gen-★?X) (λ ())
 
 ------------------------------------------------------------------------
 -- Literal source syntax

--- a/GTSFImp/proof/DGG/notes/SourceReachabilityResultScratch.agda
+++ b/GTSFImp/proof/DGG/notes/SourceReachabilityResultScratch.agda
@@ -1,0 +1,192 @@
+module SourceReachabilityResultScratch where
+
+-- File Charter:
+--   * Connects the target of the closed gradual source pair in
+--     SourceLegScratch to the runtime checkpoints in InitialPairScratch.
+--   * Checks that the target projection reached by compilation carries the
+--     matching generated-name injection required by CatchupCast.
+--   * Records the exact target cancellation route and the companion route
+--     for InitialPairScratch's simplified precise CTI checkpoint.
+
+open import Data.Fin using (zero)
+open import Data.List using ([]; _∷_)
+open import Data.Product using (proj₁)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Nullary using (¬_)
+
+open import Types
+open import Consistency
+open import TermCtx using (Z)
+open import TyStore using (store-empty)
+import Imprecision as I
+import GradualTerms as G
+import GradualTermImprecision as GTI
+open import GradualTerms
+  using ()
+  renaming (_∣_⊢_⦂_ to _∣_⊢ᴳ_⦂_)
+open GTI using (_∣_⊢ᴳ_⊑_⦂_⊑_∶_)
+open import CastTerms
+  using (Term; Value; $; _⟨_⟩; _↑_; _↓_; _《_》; inj; seal)
+open import Reduction
+open import Primitives using (κℕ)
+open import Compile using (compile)
+import Conversion as Conv
+open Conv using (unseal)
+import proof.DGG.ExtraCastRight2 as ECR
+import proof.DGG.StarRepChainProbe as Probe
+import proof.DGG.ReachabilityCatalog as RC
+import proof.DGG.ReachabilityScreen as RS
+import InitialPairScratch as IP
+import SourceLegScratch as Source
+
+------------------------------------------------------------------------
+-- The literal closed source pair reaches InitialPairScratch
+------------------------------------------------------------------------
+
+source-right-entry : Source.Q₁ ≡ IP.Qᶜ
+source-right-entry = refl
+
+source-left-screen-returns :
+  RS.SideSummary.status (RS.runSummary 40 Source.Pᶜ)
+    ≡ RS.returned-value
+source-left-screen-returns = refl
+
+source-right-screen-returns :
+  RS.SideSummary.status (RS.runSummary 40 Source.Qᶜ)
+    ≡ RS.returned-value
+source-right-screen-returns = refl
+
+------------------------------------------------------------------------
+-- Exact target provenance and reduction
+------------------------------------------------------------------------
+
+target-core : Term 1
+target-core = ($ (κℕ 0)) ⟨ IP.Q-shifted-ℕ! ⟩
+
+target-core-value : Value target-core
+target-core-value = $ (κℕ 0) 《 inj 》
+
+target-sealed : Term 1
+target-sealed = target-core ↓ Conv.seal zero ★
+
+target-sealed-value : Value target-sealed
+target-sealed-value = target-core-value ↓ seal
+
+target-input-gate :
+  IP.Q-generated-tagged-input ≡ target-sealed ⟨ IP.Q-Y! ⟩
+target-input-gate = refl
+
+reached-catchup :
+  ECR.CatchupCast {W = Probe.W} {A = ＇ zero}
+    Probe.input-type IP.Q-generated-tagged-input
+    (IP.X? {μ = idᶜ}) Probe.q
+reached-catchup =
+  ECR.catchup-projection
+    (ECR.generated-project-same target-sealed-value)
+
+target-route :
+  IP.Q₆ —↠[ keep ∷ keep ∷ [] ] target-core
+target-route =
+  IP.Q₆
+  —→[ keep ]⟨
+    ξ-reveal (pure-step (tag-untag target-sealed-value)) refl
+  ⟩
+  target-sealed ↑ unseal zero ★
+  —→[ keep ]⟨ pure-step (conceal-reveal target-core-value) ⟩
+  target-core ∎[]
+
+------------------------------------------------------------------------
+-- Companion reduction for the simplified precise CTI checkpoint
+------------------------------------------------------------------------
+
+source-core-value : Value IP.P-two-seal-tagged-zero
+source-core-value = $ (κℕ 0) 《 inj 》
+
+source-inner-sealed-value :
+  Value (IP.P-two-seal-tagged-zero ↓ Conv.seal 1 ★)
+source-inner-sealed-value = source-core-value ↓ seal
+
+source-route :
+  IP.P₇ —↠[ keep ∷ keep ∷ [] ] IP.P-two-seal-tagged-zero
+source-route =
+  IP.P₇
+  —→[ keep ]⟨
+    ξ-reveal
+      (pure-step (conceal-reveal source-inner-sealed-value)) refl
+  ⟩
+  (IP.P-two-seal-tagged-zero ↓ Conv.seal 1 ★) ↑ unseal 1 ★
+  —→[ keep ]⟨ pure-step (conceal-reveal source-core-value) ⟩
+  IP.P-two-seal-tagged-zero ∎[]
+
+------------------------------------------------------------------------
+-- A target that really exposes the bad projection is not source-related
+------------------------------------------------------------------------
+
+bad-bodyᴳ : ∀ {Δ} → G.GTerm Δ
+bad-bodyᴳ =
+  (G.ƛ ★ ⇒ G.` 0) G.·[ 93 ] G.$ (κℕ 0)
+
+★∼ℕ : ∀ {Δ} → Consistency._∼_ {Δ = Δ} ★ (‵ `ℕ)
+★∼ℕ = ？ (id (‵ `ℕ))
+
+bad-body⊢ᴳ : ∀ {Δ Γ} → Δ ∣ Γ ⊢ᴳ bad-bodyᴳ ⦂ ★
+bad-body⊢ᴳ =
+  G.⊢· (G.⊢ƛ (G.⊢` Z)) (G.⊢$ (κℕ 0)) ★∼ℕ
+
+bad-dynᴳ : ∀ {Δ} → G.GTerm Δ
+bad-dynᴳ = G.ƛ ★ ⇒ bad-bodyᴳ
+
+bad-dyn⊢ᴳ : ∀ {Δ Γ}
+  → Δ ∣ Γ ⊢ᴳ bad-dynᴳ ⦂ Source.★⇒★ᵗ
+bad-dyn⊢ᴳ = G.⊢ƛ bad-body⊢ᴳ
+
+bad-targetᴳ : G.GTerm 0
+bad-targetᴳ = Source.Q-funᴳ G.·[ Source.ℓ-outer ] bad-dynᴳ
+
+bad-target⊢ᴳ : 0 ∣ [] ⊢ᴳ bad-targetᴳ ⦂ ★
+bad-target⊢ᴳ =
+  G.⊢· Source.Q-fun⊢ᴳ bad-dyn⊢ᴳ Source.∀X⇒X∼★⇒★
+
+bad-targetᶜ : Term 0
+bad-targetᶜ = RC.compile-screen bad-target⊢ᴳ
+
+bad-target-standardᶜ : Term 0
+bad-target-standardᶜ = proj₁ (compile {Σ = store-empty} bad-target⊢ᴳ)
+
+bad-target-skeleton-gate :
+  RC.skeleton bad-targetᶜ ≡ RC.skeleton bad-target-standardᶜ
+bad-target-skeleton-gate = refl
+
+bad-target-blames :
+  RS.SideSummary.status (RS.runSummary 40 bad-targetᶜ)
+    ≡ RS.returned-blame
+bad-target-blames = refl
+
+no-shifted-bad-body : ∀ {A B : Ty 1}
+    {p : I.instᵐ I.idᵐ I.⊢ A ⊑ B}
+  → ¬ (I.instᵐ I.idᵐ ∣ [] ⊢ᴳ
+      (G.ƛ ＇ zero ⇒ G.` 0) ⊑ G.⇑ᵗᴳ bad-dynᴳ
+      ⦂ A ⊑ B ∶ p)
+no-shifted-bad-body (GTI.ƛ⊑ƛᴳ ())
+
+no-poly-id-imprecision-any : ∀ {A B : Ty 0}
+    {p : I.idᵐ I.⊢ A ⊑ B}
+  → ¬ (I.idᵐ ∣ [] ⊢ᴳ Source.polyIdᴳ ⊑ bad-dynᴳ
+      ⦂ A ⊑ B ∶ p)
+no-poly-id-imprecision-any
+    (GTI.Λ⊑ᴳ _ _ GTI.lift-[] _ _ body) =
+  no-shifted-bad-body body
+
+no-poly-id-imprecision :
+  ¬ (I.idᵐ ∣ [] ⊢ᴳ Source.polyIdᴳ ⊑ bad-dynᴳ
+      ⦂ Source.∀X⇒X ⊑ Source.★⇒★ᵗ
+      ∶ Source.∀X⇒X⊑★⇒★₀)
+no-poly-id-imprecision
+    relation =
+  no-poly-id-imprecision-any relation
+
+no-bad-source-pair :
+  ¬ (I.idᵐ ∣ [] ⊢ᴳ Source.Pᴳ ⊑ bad-targetᴳ
+      ⦂ ★ ⊑ ★ ∶ I.★⊑★)
+no-bad-source-pair (GTI.·⊑·ᴳ _ argument _ _) =
+  no-poly-id-imprecision-any argument

--- a/GTSFImp/proof/DGG/notes/SourceReachabilityResultScratch.agda
+++ b/GTSFImp/proof/DGG/notes/SourceReachabilityResultScratch.agda
@@ -11,7 +11,7 @@ module SourceReachabilityResultScratch where
 open import Data.Fin using (zero)
 open import Data.List using ([]; _∷_)
 open import Data.Product using (proj₁)
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 open import Relation.Nullary using (¬_)
 
 open import Types
@@ -33,11 +33,47 @@ open import Compile using (compile)
 import Conversion as Conv
 open Conv using (unseal)
 import proof.DGG.ExtraCastRight2 as ECR
+import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.StarRepChainProbe as Probe
 import proof.DGG.ReachabilityCatalog as RC
 import proof.DGG.ReachabilityScreen as RS
 import InitialPairScratch as IP
 import SourceLegScratch as Source
+
+------------------------------------------------------------------------
+-- Binder matching fixes the fresh world cell
+------------------------------------------------------------------------
+
+matched-Λ-center : ∀ {Δᴸ Δᴿ Δ} {W : CTI2.World Δᴸ Δᴿ Δ}
+  → toRenameᵗ (CTI2.ηᴸʷ (CTI2.liftWorldBoth I.X⊑X W)) zero
+    ≡ toRenameᵗ (CTI2.ηᴿʷ (CTI2.liftWorldBoth I.X⊑X W)) zero
+matched-Λ-center = refl
+
+matched-Λ-mark : ∀ {Δᴸ Δᴿ Δ} {W : CTI2.World Δᴸ Δᴿ Δ}
+  → CTI2.impEnvʷ (CTI2.liftWorldBoth I.X⊑X W)
+      (toRenameᵗ (CTI2.ηᴸʷ (CTI2.liftWorldBoth I.X⊑X W)) zero)
+    ≡ I.X⊑X
+matched-Λ-mark = refl
+
+matched-Λ-use-not-star : ∀ {Δ} {μ : I.ImpEnv Δ}
+  → ¬ (I.extendᵐ I.X⊑X μ I.⊢ ＇ zero ⊑ ★)
+matched-Λ-use-not-star (I.X⊑★ ())
+
+erased-Λ-mark : ∀ {Δᴸ Δᴿ Δ} {W : CTI2.World Δᴸ Δᴿ Δ}
+  → CTI2.impEnvʷ (CTI2.liftWorldLeft I.X⊑★ W)
+      (toRenameᵗ (CTI2.ηᴸʷ (CTI2.liftWorldLeft I.X⊑★ W)) zero)
+    ≡ I.X⊑★
+erased-Λ-mark = refl
+
+erased-Λ-use-star : ∀ {Δ} {μ : I.ImpEnv Δ}
+  → I.instᵐ μ I.⊢ ＇ zero ⊑ ★
+erased-Λ-use-star = I.X⊑★ refl
+
+erased-Λ-has-no-target : ∀ {Δᴸ Δᴿ Δ} {W : CTI2.World Δᴸ Δᴿ Δ}
+    (Y : TyVar Δᴿ)
+  → toRenameᵗ (CTI2.ηᴿʷ (CTI2.liftWorldLeft I.X⊑★ W)) Y
+    ≢ toRenameᵗ (CTI2.ηᴸʷ (CTI2.liftWorldLeft I.X⊑★ W)) zero
+erased-Λ-has-no-target Y ()
 
 ------------------------------------------------------------------------
 -- The literal closed source pair reaches InitialPairScratch


### PR DESCRIPTION
## Summary

Investigates whether the CTI projection-mismatch counterexample can be reached from related gradual source terms.

- Repairs the source-leg scratch's contravariant consistency witnesses and checks a closed source-related pair.
- Shows that the genuine target path retains a matching generated-name injection and returns.
- Constructs a closely related target that really blames, then proves the proposed full source-imprecision judgment is impossible.
- Isolates the dropped invariants: binder birth/use provenance, world-decay provenance, value-flow/cast ancestry, and allocation order.
- Proposes strengthening CTI itself so cast safety follows by inversion. The proposal removes the separate `GeneratedProjection`, `CatchupCast`, `CatchupCast⁻`, `CatchupColumn`, and `CatchupColumn⁻` predicates from the final design.

## Result

No source-level DGG counterexample was found. The abstract mismatch remains a counterexample to the current unrestricted CTI because CTI records a decayed mark without retaining the source-use and runtime-alignment provenance that authorized it.

The proposed proof interface has `ExtraCastRight` and multi-cast reasoning consume CTI derivations of already-casted terms directly.

## Validation

- `agda -v0 --no-allow-unsolved-metas -i . -i GTSFImp -i GTSFImp/proof/DGG/notes GTSFImp/proof/DGG/notes/SourceLegScratch.agda`
- `agda -v0 --no-allow-unsolved-metas -i . -i GTSFImp -i GTSFImp/proof/DGG/notes GTSFImp/proof/DGG/notes/SourceReachabilityResultScratch.agda`
- From `GTSFImp/`: `agda -v0 --no-allow-unsolved-metas -i . -i proof/DGG/notes proof/DGG/notes/ProjectionMismatchStarRepScratch.agda`
- From `GTSFImp/`: `agda -v0 --no-allow-unsolved-metas proof/DGG/SourceStarProbe.agda`