### PR TITLE
LG-2: grounding theorems (compile minting, reduction preservation)

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -29,6 +29,7 @@ import proof.Reduction
 ------------------------------------------------------------------------
 
 import proof.DGG.CompilePreservesImprecision2
+import proof.DGG.GroundingMint
 import proof.DGG.Inversion.SpineValueProof
 import proof.DGG.Parked.ParkedWorldLemma
 import proof.DGG.Parked.ParkedD4CheckpointLemma

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -30,6 +30,7 @@ import proof.Reduction
 
 import proof.DGG.CompilePreservesImprecision2
 import proof.DGG.GroundingMint
+import proof.DGG.GroundingPreserve
 import proof.DGG.Inversion.SpineValueProof
 import proof.DGG.Parked.ParkedWorldLemma
 import proof.DGG.Parked.ParkedD4CheckpointLemma

--- a/GTSFImp/proof/DGG/GroundingMint.agda
+++ b/GTSFImp/proof/DGG/GroundingMint.agda
@@ -1,0 +1,144 @@
+module proof.DGG.GroundingMint where
+
+-- File Charter:
+--   * States the LG-2 minting surface for compile-preserves-imprecision².
+--   * Records which compile-recursion worlds are target-occupied: initial
+--     identity worlds occupy every center, matched type binders occupy the
+--     fresh center, and source-only binders leave only their dynamic fresh
+--     source center unoccupied.
+--   * Reuses CompilePreservesImprecision2 for the compiled term-imprecision
+--     theorem; this file only surfaces the occupancy facts around it.
+
+open import Data.Empty using (⊥)
+open import Data.Fin using (zero; suc)
+open import Data.Product using (Σ-syntax; _,_; proj₁)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+
+open import Types
+open import TyStore using (TyStore)
+open import Consistency using (toRenameᵗ)
+open import Imprecision using (ImpEnv; X⊑X; X⊑★)
+open import GradualTerms using (GTerm)
+import GradualTermImprecision as GTI
+open import Compile using (compile)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using (_∣_⊢²_⊑_∶_)
+import proof.DGG.CompilePreservesImprecision2 as CPI2
+open import proof.TypeInTermSubst using (toRename-id-eq)
+
+------------------------------------------------------------------------
+-- Initial compile world occupancy
+------------------------------------------------------------------------
+
+initialWorld-occupied : ∀ {Δ}
+    {μ : ImpEnv Δ} {Σ : TyStore Δ}
+  → (Z : TyVar Δ)
+  → CTI2.Occupied (CPI2.initialWorld μ Σ) Z
+initialWorld-occupied Z = Z , toRename-id-eq Z
+
+initialWorld-no-see-through-empty : ∀ {Δ}
+    {μ : ImpEnv Δ} {Σ : TyStore Δ}
+  → (X : TyVar Δ)
+  → CTI2.NoTargetOccupantAtSource (CPI2.initialWorld μ Σ) X
+  → ⊥
+initialWorld-no-see-through-empty {μ = μ} {Σ = Σ} X no-target =
+  no-target
+    (initialWorld-occupied {μ = μ} {Σ = Σ}
+      (toRenameᵗ (CTI2.ηᴸʷ (CPI2.initialWorld μ Σ)) X))
+
+------------------------------------------------------------------------
+-- Compile-recursion world image
+------------------------------------------------------------------------
+
+data CompileImageWorld : ∀ {Δᴸ Δᴿ Δ}
+    → CTI2.World Δᴸ Δᴿ Δ
+    → Set where
+  compile-image-initial : ∀ {Δ}
+      {μ : ImpEnv Δ} {Σ : TyStore Δ}
+      -------------------------------------------------
+    → CompileImageWorld (CPI2.initialWorld μ Σ)
+
+  compile-image-liftBoth : ∀ {Δᴸ Δᴿ Δ}
+      {W : CTI2.World Δᴸ Δᴿ Δ}
+    → CompileImageWorld W
+      ---------------------------------------------------------
+    → CompileImageWorld (CTI2.liftWorldBoth X⊑X W)
+
+  compile-image-liftLeft : ∀ {Δᴸ Δᴿ Δ}
+      {W : CTI2.World Δᴸ Δᴿ Δ}
+    → CompileImageWorld W
+      ---------------------------------------------------------
+    → CompileImageWorld (CTI2.liftWorldLeft X⊑★ W)
+
+compile-image-target-occupied : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → CompileImageWorld W
+  → (Y : TyVar Δᴿ)
+  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴿʷ W) Y)
+compile-image-target-occupied img Y = Y , refl
+
+compile-image-precise-source-occupied : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → CompileImageWorld W
+  → (X : TyVar Δᴸ)
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑X
+  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X)
+compile-image-precise-source-occupied
+    (compile-image-initial {μ = μ} {Σ = Σ}) X precise =
+  initialWorld-occupied {μ = μ} {Σ = Σ}
+    (toRenameᵗ (CTI2.ηᴸʷ (CPI2.initialWorld μ Σ)) X)
+compile-image-precise-source-occupied (compile-image-liftBoth img)
+    zero precise =
+  zero , refl
+compile-image-precise-source-occupied (compile-image-liftBoth img)
+    (suc X) precise
+    with compile-image-precise-source-occupied img X precise
+compile-image-precise-source-occupied (compile-image-liftBoth img)
+    (suc X) precise | Y , target-eq =
+  suc Y , cong suc target-eq
+compile-image-precise-source-occupied (compile-image-liftLeft img)
+    zero ()
+compile-image-precise-source-occupied (compile-image-liftLeft img)
+    (suc X) precise
+    with compile-image-precise-source-occupied img X precise
+compile-image-precise-source-occupied (compile-image-liftLeft img)
+    (suc X) precise | Y , target-eq =
+  Y , cong suc target-eq
+
+compile-image-source-only-fresh-no-target : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → CompileImageWorld W
+  → CTI2.NoTargetOccupantAtSource (CTI2.liftWorldLeft X⊑★ W) zero
+compile-image-source-only-fresh-no-target img (Y , ())
+
+compile-image-precise-see-through-empty : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → CompileImageWorld W
+  → (X : TyVar Δᴸ)
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑X
+  → CTI2.NoTargetOccupantAtSource W X
+  → ⊥
+compile-image-precise-see-through-empty img X precise no-target =
+  no-target (compile-image-precise-source-occupied img X precise)
+
+------------------------------------------------------------------------
+-- Minting theorem
+------------------------------------------------------------------------
+
+compile-mints-cti² : ∀ {Δ}
+    {μ : ImpEnv Δ} {Σ : TyStore Δ}
+    {γ : GTI.CtxImp μ} {M M′ : GTerm Δ} {A B p}
+  → (M⊑M′ : μ GTI.∣ γ ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p)
+  → CPI2.initialWorld μ Σ ∣ CPI2.initialCtx {Σ = Σ} γ ⊢²
+      proj₁ (compile {Σ = Σ}
+        (GTI.gradual-term-imprecision-source-typing M⊑M′))
+      ⊑ proj₁ (compile {Σ = Σ}
+        (GTI.gradual-term-imprecision-target-typing M⊑M′))
+      ∶ CPI2.initial-⊑ {Σ = Σ} p
+compile-mints-cti² =
+  CPI2.compile-preserves-imprecision²
+
+compile-minting-initial-image : ∀ {Δ}
+    {μ : ImpEnv Δ} {Σ : TyStore Δ}
+  → CompileImageWorld (CPI2.initialWorld μ Σ)
+compile-minting-initial-image = compile-image-initial

--- a/GTSFImp/proof/DGG/GroundingMint.agda
+++ b/GTSFImp/proof/DGG/GroundingMint.agda
@@ -1,7 +1,7 @@
 module proof.DGG.GroundingMint where
 
 -- File Charter:
---   * States the LG-2 minting surface for compile-preserves-imprecision².
+--   * Documents the LG-2 minting surface for compile-preserves-imprecision².
 --   * Records which compile-recursion worlds are target-occupied: initial
 --     identity worlds occupy every center, matched type binders occupy the
 --     fresh center, and source-only binders leave only their dynamic fresh
@@ -11,18 +11,14 @@ module proof.DGG.GroundingMint where
 
 open import Data.Empty using (⊥)
 open import Data.Fin using (zero; suc)
-open import Data.Product using (Σ-syntax; _,_; proj₁)
+open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
 
 open import Types
 open import TyStore using (TyStore)
 open import Consistency using (toRenameᵗ)
 open import Imprecision using (ImpEnv; X⊑X; X⊑★)
-open import GradualTerms using (GTerm)
-import GradualTermImprecision as GTI
-open import Compile using (compile)
 import proof.DGG.CastTermImprecision2 as CTI2
-open CTI2 using (_∣_⊢²_⊑_∶_)
 import proof.DGG.CompilePreservesImprecision2 as CPI2
 open import proof.TypeInTermSubst using (toRename-id-eq)
 
@@ -122,23 +118,10 @@ compile-image-precise-see-through-empty img X precise no-target =
   no-target (compile-image-precise-source-occupied img X precise)
 
 ------------------------------------------------------------------------
--- Minting theorem
+-- Canonical minting connection
 ------------------------------------------------------------------------
 
-compile-mints-cti² : ∀ {Δ}
-    {μ : ImpEnv Δ} {Σ : TyStore Δ}
-    {γ : GTI.CtxImp μ} {M M′ : GTerm Δ} {A B p}
-  → (M⊑M′ : μ GTI.∣ γ ⊢ᴳ M ⊑ M′ ⦂ A ⊑ B ∶ p)
-  → CPI2.initialWorld μ Σ ∣ CPI2.initialCtx {Σ = Σ} γ ⊢²
-      proj₁ (compile {Σ = Σ}
-        (GTI.gradual-term-imprecision-source-typing M⊑M′))
-      ⊑ proj₁ (compile {Σ = Σ}
-        (GTI.gradual-term-imprecision-target-typing M⊑M′))
-      ∶ CPI2.initial-⊑ {Σ = Σ} p
-compile-mints-cti² =
-  CPI2.compile-preserves-imprecision²
-
-compile-minting-initial-image : ∀ {Δ}
-    {μ : ImpEnv Δ} {Σ : TyStore Δ}
-  → CompileImageWorld (CPI2.initialWorld μ Σ)
-compile-minting-initial-image = compile-image-initial
+-- The minting connection is the canonical
+-- CPI2.compile-preserves-imprecision² theorem. Its image-side occupancy facts
+-- are the theorems in this file: initialWorld-occupied, the CompileImageWorld
+-- invariant, and the see-through emptiness theorems above.

--- a/GTSFImp/proof/DGG/GroundingPreserve.agda
+++ b/GTSFImp/proof/DGG/GroundingPreserve.agda
@@ -5,7 +5,7 @@ module proof.DGG.GroundingPreserve where
 --   * Proves allocation atomicity for the live β-inst and β-gen reduction
 --     constructors: the right-only target bind and the fresh-name partner
 --     conversion are produced in the same step.
---   * Re-exports the occupancy-evolution lemmas used by the catch-up stack
+--   * Imports the allocation occupancy lemmas used by the atomicity surface
 --     and states the higher-order knot that LG-3/M7 must instantiate for the
 --     full related-reduction simulation.
 
@@ -13,7 +13,8 @@ open import Data.Empty using (⊥)
 open import Data.Fin using (zero)
 open import Data.Nat using (suc)
 open import Data.Product using (Σ-syntax; _×_; _,_)
-open import Relation.Binary.PropositionalEquality using (_≢_; refl)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 
 open import Types using (TyCtx; Ty; TyVar; NonVar; _∈ᵗ_; ＇_; ★; ⇑ᵗ)
 open import Consistency using
@@ -25,64 +26,17 @@ open import Conversion using (〖_,_↑_〗)
 open import Reduction using
   (bind; applyBody; _—→[_]_; β-inst; β-gen)
 import proof.DGG.CastTermImprecision2 as CTI2
-open import proof.DGG.Occupancy public using
-  ( initial-every-center-occupiedᴼ
-  ; initial-no-see-through-emptyᴼ
-  ; liftWorldLeft-fresh-no-targetᴼ
-  ; liftWorldLeft-old-occupiedᴼ
-  ; liftWorldLeft-old-no-targetᴼ
-  ; liftWorldLeft-old-no-target-at-sourceᴼ
-  ; liftWorldBoth-fresh-occupiedᴼ
-  ; liftWorldBoth-old-occupiedᴼ
-  ; liftWorldBoth-old-no-targetᴼ
-  ; leftOnly-fresh-no-targetᴼ
-  ; leftOnly-old-occupiedᴼ
-  ; leftOnly-old-no-targetᴼ
-  ; rightOnly-new-target-occupiedᴼ
-  ; rightOnly-old-occupiedᴼ
-  ; rightOnly-old-no-targetᴼ
-  ; rightOnly-old-no-target-at-sourceᴼ
-  ; bothBind-new-target-occupiedᴼ
-  ; bothBind-old-occupiedᴼ
-  ; bothBind-old-no-targetᴼ
-  ; rebase-occupied-forwardᴼ
-  ; rebase-occupied-backwardᴼ
-  ; rebase-no-target-forwardᴼ
-  ; rebase-no-target-backwardᴼ
-  ; rebaseᴸ-no-target-forwardᴼ
-  ; rebaseᴿ-no-target-forwardᴼ
-  ; tag-rebase-no-target-forwardᴼ
-  ; decay-no-target-forwardᴼ
-  ; decay-occupied-forwardᴼ
-  ; decay-occupied-backwardᴼ
-  ; decay-no-target-at-source-forwardᴼ
-  ; target-insert-occupied-forwardᴼ
-  ; target-insert-no-target-forwardᴼ
-  ; target-insert-no-target-at-sourceᴼ
-  ; smartFreshBehind-fresh-no-targetᴼ
-  ; smartAliasMerge-fresh-occupiedᴼ
-  ; smartFreshBehind-old-no-target-at-sourceᴼ
-  ; smartAliasMerge-old-no-target-at-sourceᴼ
-  ; smartCommaLift-old-no-target-at-sourceᴼ
-  ; β-inst-allocation-occupies-targetᴼ
+open import proof.DGG.Occupancy using
+  ( β-inst-allocation-occupies-targetᴼ
   ; β-gen-allocation-occupies-targetᴼ
-  ; source-only-runtime-cell-remains-unoccupiedᴼ
   )
 
 ------------------------------------------------------------------------
 -- Fresh target partner created by allocation steps
 ------------------------------------------------------------------------
 
-data FreshPartnerAt0 {Δ : TyCtx}
-    (R B : Ty (suc Δ)) : Term (suc Δ) → Set where
-  partner-reveal : ∀ {M}
-      -----------------------------------------
-    → FreshPartnerAt0 R B (M ↑ 〖 zero , R ↑ B 〗)
-
-  partner-reveal-cast : ∀ {M ν C D}
-      {c : ν ⊢ C ∼ D}
-      -------------------------------------------------
-    → FreshPartnerAt0 R B ((M ↑ 〖 zero , R ↑ B 〗) ⟨ c ⟩)
+-- Allocation exposes either a reveal at the fresh target cell or that reveal
+-- followed by a top-level cast.
 
 β-inst-allocation-atomic : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}
@@ -95,7 +49,15 @@ data FreshPartnerAt0 {Δ : TyCtx}
   → CTI2.Occupied (CTI2.rightOnlyWorld W ★) zero ×
     Σ[ N ∈ Term (suc Δᴿ) ]
       ((V ⟨ (inst c) B≢★ ⟩ —→[ bind ★ ] N)
-       × FreshPartnerAt0 ★ A N)
+       × ((Σ[ M ∈ Term (suc Δᴿ) ]
+              N ≡ M ↑ 〖 zero , ★ ↑ A 〗)
+          ⊎
+          (Σ[ M ∈ Term (suc Δᴿ) ]
+           Σ[ μ′ ∈ Env∼ (suc Δᴿ) ]
+           Σ[ S ∈ Ty (suc Δᴿ) ]
+           Σ[ T ∈ Ty (suc Δᴿ) ]
+           Σ[ c′ ∈ (μ′ ⊢ S ∼ T) ]
+              N ≡ (M ↑ 〖 zero , ★ ↑ A 〗) ⟨ c′ ⟩)))
 β-inst-allocation-atomic {W = W} {V = V} {A = A} {c = c}
     vV B≢★ =
   β-inst-allocation-occupies-targetᴼ {W = W} ,
@@ -103,7 +65,7 @@ data FreshPartnerAt0 {Δ : TyCtx}
       ↑ 〖 zero , ★ ↑ A 〗)
       ⟨ ↑ᶜ (close-instᶜ c) ⟩) ,
   β-inst vV B≢★ ,
-  partner-reveal-cast
+  inj₂ (_ , _ , _ , _ , _ , refl)
 
 β-gen-allocation-atomic : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}
@@ -117,13 +79,21 @@ data FreshPartnerAt0 {Δ : TyCtx}
   → CTI2.Occupied (CTI2.rightOnlyWorld W C) zero ×
     Σ[ N ∈ Term (suc Δᴿ) ]
       (((V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ] —→[ bind C ] N)
-       × FreshPartnerAt0 (⇑ᵗ C) B N)
+       × ((Σ[ M ∈ Term (suc Δᴿ) ]
+              N ≡ M ↑ 〖 zero , ⇑ᵗ C ↑ B 〗)
+          ⊎
+          (Σ[ M ∈ Term (suc Δᴿ) ]
+           Σ[ μ′ ∈ Env∼ (suc Δᴿ) ]
+           Σ[ S ∈ Ty (suc Δᴿ) ]
+           Σ[ T ∈ Ty (suc Δᴿ) ]
+           Σ[ c′ ∈ (μ′ ⊢ S ∼ T) ]
+              N ≡ (M ↑ 〖 zero , ⇑ᵗ C ↑ B 〗) ⟨ c′ ⟩)))
 β-gen-allocation-atomic {W = W} {V = V} {A = A} {C = C}
     {B = B} {c = c} vV A≢★ safe =
   β-gen-allocation-occupies-targetᴼ {W = W} C ,
   (⇑ᵗᵐ V ⟨ c ⟩ ↑ 〖 zero , ⇑ᵗ C ↑ B 〗) ,
   β-gen vV A≢★ safe ,
-  partner-reveal
+  inj₁ (_ , refl)
 
 ------------------------------------------------------------------------
 -- No see-through at occupied cells
@@ -163,7 +133,15 @@ record RelatedReductionGroundingKnot : Set₁ where
       → CTI2.Occupied (CTI2.rightOnlyWorld W ★) zero ×
         Σ[ N ∈ Term (suc Δᴿ) ]
           ((V ⟨ (inst c) B≢★ ⟩ —→[ bind ★ ] N)
-           × FreshPartnerAt0 ★ A N)
+           × ((Σ[ M ∈ Term (suc Δᴿ) ]
+                  N ≡ M ↑ 〖 zero , ★ ↑ A 〗)
+              ⊎
+              (Σ[ M ∈ Term (suc Δᴿ) ]
+               Σ[ μ′ ∈ Env∼ (suc Δᴿ) ]
+               Σ[ S ∈ Ty (suc Δᴿ) ]
+               Σ[ T ∈ Ty (suc Δᴿ) ]
+               Σ[ c′ ∈ (μ′ ⊢ S ∼ T) ]
+                  N ≡ (M ↑ 〖 zero , ★ ↑ A 〗) ⟨ c′ ⟩)))
 
     β-gen-new-cell-grounded :
       ∀ {Δᴸ Δᴿ Δ}
@@ -178,7 +156,15 @@ record RelatedReductionGroundingKnot : Set₁ where
       → CTI2.Occupied (CTI2.rightOnlyWorld W C) zero ×
         Σ[ N ∈ Term (suc Δᴿ) ]
           (((V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ] —→[ bind C ] N)
-           × FreshPartnerAt0 (⇑ᵗ C) B N)
+           × ((Σ[ M ∈ Term (suc Δᴿ) ]
+                  N ≡ M ↑ 〖 zero , ⇑ᵗ C ↑ B 〗)
+              ⊎
+              (Σ[ M ∈ Term (suc Δᴿ) ]
+               Σ[ μ′ ∈ Env∼ (suc Δᴿ) ]
+               Σ[ S ∈ Ty (suc Δᴿ) ]
+               Σ[ T ∈ Ty (suc Δᴿ) ]
+               Σ[ c′ ∈ (μ′ ⊢ S ∼ T) ]
+                  N ≡ (M ↑ 〖 zero , ⇑ᵗ C ↑ B 〗) ⟨ c′ ⟩)))
 
 grounding-preservation-knot : RelatedReductionGroundingKnot
 grounding-preservation-knot = record

--- a/GTSFImp/proof/DGG/GroundingPreserve.agda
+++ b/GTSFImp/proof/DGG/GroundingPreserve.agda
@@ -1,0 +1,200 @@
+module proof.DGG.GroundingPreserve where
+
+-- File Charter:
+--   * States the LG-2 preservation surface for the S-OCC discipline.
+--   * Proves allocation atomicity for the live β-inst and β-gen reduction
+--     constructors: the right-only target bind and the fresh-name partner
+--     conversion are produced in the same step.
+--   * Re-exports the occupancy-evolution lemmas used by the catch-up stack
+--     and states the higher-order knot that LG-3/M7 must instantiate for the
+--     full related-reduction simulation.
+
+open import Data.Empty using (⊥)
+open import Data.Fin using (zero)
+open import Data.Nat using (suc)
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Relation.Binary.PropositionalEquality using (_≢_; refl)
+
+open import Types using (TyCtx; Ty; TyVar; NonVar; _∈ᵗ_; ＇_; ★; ⇑ᵗ)
+open import Consistency using
+  (Env∼; _⊢_∼_; instᵐ; genᵐ; inst_; gen_; ↑ᶜ_; close-instᶜ;
+   toRenameᵗ)
+open import CastTerms using
+  (Term; Value; GenSafe; _⟨_⟩; _⦂∀_[_]; _↑_; ⇑ᵗᵐ)
+open import Conversion using (〖_,_↑_〗)
+open import Reduction using
+  (bind; applyBody; _—→[_]_; β-inst; β-gen)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Occupancy public using
+  ( initial-every-center-occupiedᴼ
+  ; initial-no-see-through-emptyᴼ
+  ; liftWorldLeft-fresh-no-targetᴼ
+  ; liftWorldLeft-old-occupiedᴼ
+  ; liftWorldLeft-old-no-targetᴼ
+  ; liftWorldLeft-old-no-target-at-sourceᴼ
+  ; liftWorldBoth-fresh-occupiedᴼ
+  ; liftWorldBoth-old-occupiedᴼ
+  ; liftWorldBoth-old-no-targetᴼ
+  ; leftOnly-fresh-no-targetᴼ
+  ; leftOnly-old-occupiedᴼ
+  ; leftOnly-old-no-targetᴼ
+  ; rightOnly-new-target-occupiedᴼ
+  ; rightOnly-old-occupiedᴼ
+  ; rightOnly-old-no-targetᴼ
+  ; rightOnly-old-no-target-at-sourceᴼ
+  ; bothBind-new-target-occupiedᴼ
+  ; bothBind-old-occupiedᴼ
+  ; bothBind-old-no-targetᴼ
+  ; rebase-occupied-forwardᴼ
+  ; rebase-occupied-backwardᴼ
+  ; rebase-no-target-forwardᴼ
+  ; rebase-no-target-backwardᴼ
+  ; rebaseᴸ-no-target-forwardᴼ
+  ; rebaseᴿ-no-target-forwardᴼ
+  ; tag-rebase-no-target-forwardᴼ
+  ; decay-no-target-forwardᴼ
+  ; decay-occupied-forwardᴼ
+  ; decay-occupied-backwardᴼ
+  ; decay-no-target-at-source-forwardᴼ
+  ; target-insert-occupied-forwardᴼ
+  ; target-insert-no-target-forwardᴼ
+  ; target-insert-no-target-at-sourceᴼ
+  ; smartFreshBehind-fresh-no-targetᴼ
+  ; smartAliasMerge-fresh-occupiedᴼ
+  ; smartFreshBehind-old-no-target-at-sourceᴼ
+  ; smartAliasMerge-old-no-target-at-sourceᴼ
+  ; smartCommaLift-old-no-target-at-sourceᴼ
+  ; β-inst-allocation-occupies-targetᴼ
+  ; β-gen-allocation-occupies-targetᴼ
+  ; source-only-runtime-cell-remains-unoccupiedᴼ
+  )
+
+------------------------------------------------------------------------
+-- Fresh target partner created by allocation steps
+------------------------------------------------------------------------
+
+data FreshPartnerAt0 {Δ : TyCtx}
+    (R B : Ty (suc Δ)) : Term (suc Δ) → Set where
+  partner-reveal : ∀ {M}
+      -----------------------------------------
+    → FreshPartnerAt0 R B (M ↑ 〖 zero , R ↑ B 〗)
+
+  partner-reveal-cast : ∀ {M ν C D}
+      {c : ν ⊢ C ∼ D}
+      -------------------------------------------------
+    → FreshPartnerAt0 R B ((M ↑ 〖 zero , R ↑ B 〗) ⟨ c ⟩)
+
+β-inst-allocation-atomic : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {V : Term Δᴿ} {μ : Env∼ Δᴿ}
+    {A : Ty (suc Δᴿ)} {B : Ty Δᴿ}
+    {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
+    ⦃ Anv : NonVar A ⦄ ⦃ z∈A : zero ∈ᵗ A ⦄
+  → (vV : Value V)
+  → (B≢★ : B ≢ ★)
+  → CTI2.Occupied (CTI2.rightOnlyWorld W ★) zero ×
+    Σ[ N ∈ Term (suc Δᴿ) ]
+      ((V ⟨ (inst c) B≢★ ⟩ —→[ bind ★ ] N)
+       × FreshPartnerAt0 ★ A N)
+β-inst-allocation-atomic {W = W} {V = V} {A = A} {c = c}
+    vV B≢★ =
+  β-inst-allocation-occupies-targetᴼ {W = W} ,
+  (((⇑ᵗᵐ V ⦂∀ applyBody (bind ★) A [ ＇ zero ])
+      ↑ 〖 zero , ★ ↑ A 〗)
+      ⟨ ↑ᶜ (close-instᶜ c) ⟩) ,
+  β-inst vV B≢★ ,
+  partner-reveal-cast
+
+β-gen-allocation-atomic : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {V : Term Δᴿ} {μ : Env∼ Δᴿ}
+    {A C : Ty Δᴿ} {B : Ty (suc Δᴿ)}
+    {c : genᵐ μ ⊢ ⇑ᵗ A ∼ B}
+    ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : zero ∈ᵗ B ⦄
+  → (vV : Value V)
+  → (A≢★ : A ≢ ★)
+  → (safe : GenSafe c)
+  → CTI2.Occupied (CTI2.rightOnlyWorld W C) zero ×
+    Σ[ N ∈ Term (suc Δᴿ) ]
+      (((V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ] —→[ bind C ] N)
+       × FreshPartnerAt0 (⇑ᵗ C) B N)
+β-gen-allocation-atomic {W = W} {V = V} {A = A} {C = C}
+    {B = B} {c = c} vV A≢★ safe =
+  β-gen-allocation-occupies-targetᴼ {W = W} C ,
+  (⇑ᵗᵐ V ⟨ c ⟩ ↑ 〖 zero , ⇑ᵗ C ↑ B 〗) ,
+  β-gen vV A≢★ safe ,
+  partner-reveal
+
+------------------------------------------------------------------------
+-- No see-through at occupied cells
+------------------------------------------------------------------------
+
+occupied-see-through-empty : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → (X : TyVar Δᴸ)
+  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X)
+  → CTI2.NoTargetOccupantAtSource W X
+  → ⊥
+occupied-see-through-empty X occupied no-target =
+  no-target occupied
+
+record RelatedReductionGroundingKnot : Set₁ where
+  field
+    preserves-old-occupied-see-through-empty :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W W′ : CTI2.World Δᴸ Δᴿ Δ}
+      → (∀ X
+          → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X)
+          → CTI2.Occupied W′ (toRenameᵗ (CTI2.ηᴸʷ W′) X))
+      → (X : TyVar Δᴸ)
+      → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X)
+      → CTI2.NoTargetOccupantAtSource W′ X
+      → ⊥
+
+    β-inst-new-cell-grounded :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W : CTI2.World Δᴸ Δᴿ Δ}
+        {V : Term Δᴿ} {μ : Env∼ Δᴿ}
+        {A : Ty (suc Δᴿ)} {B : Ty Δᴿ}
+        {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
+        ⦃ Anv : NonVar A ⦄ ⦃ z∈A : zero ∈ᵗ A ⦄
+      → (vV : Value V)
+      → (B≢★ : B ≢ ★)
+      → CTI2.Occupied (CTI2.rightOnlyWorld W ★) zero ×
+        Σ[ N ∈ Term (suc Δᴿ) ]
+          ((V ⟨ (inst c) B≢★ ⟩ —→[ bind ★ ] N)
+           × FreshPartnerAt0 ★ A N)
+
+    β-gen-new-cell-grounded :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W : CTI2.World Δᴸ Δᴿ Δ}
+        {V : Term Δᴿ} {μ : Env∼ Δᴿ}
+        {A C : Ty Δᴿ} {B : Ty (suc Δᴿ)}
+        {c : genᵐ μ ⊢ ⇑ᵗ A ∼ B}
+        ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : zero ∈ᵗ B ⦄
+      → (vV : Value V)
+      → (A≢★ : A ≢ ★)
+      → (safe : GenSafe c)
+      → CTI2.Occupied (CTI2.rightOnlyWorld W C) zero ×
+        Σ[ N ∈ Term (suc Δᴿ) ]
+          (((V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ] —→[ bind C ] N)
+           × FreshPartnerAt0 (⇑ᵗ C) B N)
+
+grounding-preservation-knot : RelatedReductionGroundingKnot
+grounding-preservation-knot = record
+  { preserves-old-occupied-see-through-empty =
+      λ occ-at-source-forward X occupied no-target′ →
+        no-target′ (occ-at-source-forward X occupied)
+  ; β-inst-new-cell-grounded =
+      λ {Δᴸ} {Δᴿ} {Δ} {W} {V} {μ} {A} {B} {c}
+          ⦃ Anv ⦄ ⦃ z∈A ⦄ vV B≢★ →
+        β-inst-allocation-atomic {W = W} {V = V} {μ = μ}
+          {A = A} {B = B} {c = c} ⦃ Anv = Anv ⦄
+          ⦃ z∈A = z∈A ⦄ vV B≢★
+  ; β-gen-new-cell-grounded =
+      λ {Δᴸ} {Δᴿ} {Δ} {W} {V} {μ} {A} {C} {B} {c}
+          ⦃ Bnv ⦄ ⦃ z∈B ⦄ vV A≢★ safe →
+        β-gen-allocation-atomic {W = W} {V = V} {μ = μ}
+          {A = A} {C = C} {B = B} {c = c} ⦃ Bnv = Bnv ⦄
+          ⦃ z∈B = z∈B ⦄ vV A≢★ safe
+  }

--- a/GTSFImp/proof/DGG/Occupancy.agda
+++ b/GTSFImp/proof/DGG/Occupancy.agda
@@ -113,6 +113,14 @@ liftWorldLeft-old-no-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
 liftWorldLeft-old-no-targetᴼ v no-target (Y , eq) =
   no-target (Y , fin-suc-injective eq)
 
+liftWorldLeft-old-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp)
+  → CTI2.Occupied W Z
+  → CTI2.Occupied (CTI2.liftWorldLeft v W) (Fin.suc Z)
+liftWorldLeft-old-occupiedᴼ v (Y , eq) =
+  Y , cong Fin.suc eq
+
 liftWorldLeft-old-no-target-at-sourceᴼ : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} {X}
     (v : VarImp)
@@ -123,11 +131,66 @@ liftWorldLeft-old-no-target-at-sourceᴼ {W = W} {X = X} v =
   liftWorldLeft-old-no-targetᴼ
     {W = W} {Z = toRenameᵗ (CTI2.ηᴸʷ W) X} v
 
+liftWorldBoth-fresh-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    (v : VarImp)
+  → CTI2.Occupied (CTI2.liftWorldBoth v W) Fin.zero
+liftWorldBoth-fresh-occupiedᴼ v = Fin.zero , refl
+
+liftWorldBoth-old-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp)
+  → CTI2.Occupied W Z
+  → CTI2.Occupied (CTI2.liftWorldBoth v W) (Fin.suc Z)
+liftWorldBoth-old-occupiedᴼ v (Y , eq) =
+  Fin.suc Y , cong Fin.suc eq
+
+liftWorldBoth-old-no-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp)
+  → CTI2.NoTargetOccupant W Z
+  → CTI2.NoTargetOccupant (CTI2.liftWorldBoth v W) (Fin.suc Z)
+liftWorldBoth-old-no-targetᴼ v no-target (Fin.zero , ())
+liftWorldBoth-old-no-targetᴼ v no-target (Fin.suc Y , eq) =
+  no-target (Y , fin-suc-injective eq)
+
+leftOnly-fresh-no-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    (v : VarImp) (A : Ty Δᴸ)
+  → CTI2.NoTargetOccupant
+      (CTI2.leftOnlyWorld v W A) Fin.zero
+leftOnly-fresh-no-targetᴼ v A (Y , ())
+
+leftOnly-old-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp) (A : Ty Δᴸ)
+  → CTI2.Occupied W Z
+  → CTI2.Occupied (CTI2.leftOnlyWorld v W A) (Fin.suc Z)
+leftOnly-old-occupiedᴼ v A (Y , eq) =
+  Y , cong Fin.suc eq
+
+leftOnly-old-no-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp) (A : Ty Δᴸ)
+  → CTI2.NoTargetOccupant W Z
+  → CTI2.NoTargetOccupant
+      (CTI2.leftOnlyWorld v W A) (Fin.suc Z)
+leftOnly-old-no-targetᴼ v A no-target (Y , eq) =
+  no-target (Y , fin-suc-injective eq)
+
 rightOnly-new-target-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}
     (B : Ty Δᴿ)
   → CTI2.Occupied (CTI2.rightOnlyWorld W B) Fin.zero
 rightOnly-new-target-occupiedᴼ B = Fin.zero , refl
+
+rightOnly-old-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (B : Ty Δᴿ)
+  → CTI2.Occupied W Z
+  → CTI2.Occupied (CTI2.rightOnlyWorld W B) (Fin.suc Z)
+rightOnly-old-occupiedᴼ B (Y , eq) =
+  Fin.suc Y , cong Fin.suc eq
 
 rightOnly-old-no-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
@@ -146,6 +209,30 @@ rightOnly-old-no-target-at-sourceᴼ : ∀ {Δᴸ Δᴿ Δ}
 rightOnly-old-no-target-at-sourceᴼ {W = W} {X = X} B =
   rightOnly-old-no-targetᴼ
     {W = W} {Z = toRenameᵗ (CTI2.ηᴸʷ W) X} B
+
+bothBind-new-target-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    (v : VarImp) (A : Ty Δᴸ) (B : Ty Δᴿ)
+  → CTI2.Occupied (CTI2.bothBindWorld v W A B) Fin.zero
+bothBind-new-target-occupiedᴼ v A B = Fin.zero , refl
+
+bothBind-old-occupiedᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp) (A : Ty Δᴸ) (B : Ty Δᴿ)
+  → CTI2.Occupied W Z
+  → CTI2.Occupied (CTI2.bothBindWorld v W A B) (Fin.suc Z)
+bothBind-old-occupiedᴼ v A B (Y , eq) =
+  Fin.suc Y , cong Fin.suc eq
+
+bothBind-old-no-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Z}
+    (v : VarImp) (A : Ty Δᴸ) (B : Ty Δᴿ)
+  → CTI2.NoTargetOccupant W Z
+  → CTI2.NoTargetOccupant
+      (CTI2.bothBindWorld v W A B) (Fin.suc Z)
+bothBind-old-no-targetᴼ v A B no-target (Fin.zero , ())
+bothBind-old-no-targetᴼ v A B no-target (Fin.suc Y , eq) =
+  no-target (Y , fin-suc-injective eq)
 
 ------------------------------------------------------------------------
 -- Rebasing and decay
@@ -227,6 +314,24 @@ decay-no-target-forwardᴼ : ∀ {Δᴸ Δᴿ Δ}
 decay-no-target-forwardᴼ
     (WD.env-decay refl refl refl refl _) no-target =
   no-target
+
+decay-occupied-forwardᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ} {Z}
+  → WD.EnvDecay W Wᵈ
+  → CTI2.Occupied W Z
+  → CTI2.Occupied Wᵈ Z
+decay-occupied-forwardᴼ
+    (WD.env-decay refl refl refl refl _) occupied =
+  occupied
+
+decay-occupied-backwardᴼ : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ} {Z}
+  → WD.EnvDecay W Wᵈ
+  → CTI2.Occupied Wᵈ Z
+  → CTI2.Occupied W Z
+decay-occupied-backwardᴼ
+    (WD.env-decay refl refl refl refl _) occupied =
+  occupied
 
 decay-no-target-at-source-forwardᴼ : ∀ {Δᴸ Δᴿ Δ}
     {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ} {X}
@@ -362,6 +467,19 @@ smartAliasMerge-old-no-target-at-sourceᴼ {W = W} {X = X}
     (Y , trans (sym (CTI2.SmartAliasMergeGuard.target-frozen guard Y))
       (trans eq
         (CTI2.SmartAliasMergeGuard.old-source-frozen guard X)))
+
+smartCommaLift-old-no-target-at-sourceᴼ : ∀ {Δᴸ Δᴿ Δ Δᵐ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δᵐ} {X}
+  → CTI2.SmartCommaLiftᴸ W Wᵐ
+  → CTI2.NoTargetOccupantAtSource W X
+  → CTI2.NoTargetOccupantAtSource Wᵐ (Fin.suc X)
+smartCommaLift-old-no-target-at-sourceᴼ
+    (CTI2.smart-fresh-behind guard) =
+  smartFreshBehind-old-no-target-at-sourceᴼ guard
+smartCommaLift-old-no-target-at-sourceᴼ
+    (CTI2.smart-merge-alias guard) =
+  smartAliasMerge-old-no-target-at-sourceᴼ guard
 
 β-inst-allocation-occupies-targetᴼ : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}

--- a/GTSFImp/proof/DGG/PLAN.md
+++ b/GTSFImp/proof/DGG/PLAN.md
@@ -912,3 +912,20 @@ exact NON_COVERING baselines (22/1, zero elsewhere) and the full
 pragma ban. Hygiene bar is now ZERO postulates (FunExt removed on
 main, PR #142). Gate + ten-file notes regression verified by the
 supervisor. NEXT: LG-2 grounding, LG-3 CatchupCast removal.
+
+## LG-2 IN FLIGHT (branch agent/gtsf-cti-lg2)
+
+Grounding theorems per the adopted design and the V3 pre-flight: the
+tightened CTI2 must be CONNECTED to gradual source-term imprecision
+(user requirement — no imaginary worlds). Two stages:
+  G2-a MINTING: make the compile-image occupancy facts explicit
+       theorems (initialWorld/compile-image cells are occupied;
+       compile² lands in the tightened relation with no see-through
+       uses) so compile-preserves-imprecision² IS the minting theorem.
+  G2-b PRESERVATION: allocation atomicity as theorems over the live
+       Reduction/catch-up machinery — every step that first occupies a
+       cell (β-gen/β-inst) produces the partnered seal on the target
+       value in the same step, so no reachable state needs see-through
+       at an occupied cell; plus occupancy-evolution invariants for
+       the world moves the proofs use.
+All new proofs live in the --safe side of the build.

--- a/GTSFImp/proof/DGG/PLAN.md
+++ b/GTSFImp/proof/DGG/PLAN.md
@@ -932,10 +932,12 @@ All new proofs live in the --safe side of the build.
 
 LG-2 COMPLETE (2026-08-16, PR #143). Grounding is now theorem-level:
 G2-a `GroundingMint.agda` — initialWorld-occupied, the CompileImageWorld
-invariant, the thin minting theorem `compile-mints-cti²` (consumes
-compile-preserves-imprecision²: every gradual source-term imprecision
-derivation lands in the tightened CTI2 at initialWorld), and the
-see-through emptiness theorems for the compile image. G2-b
+invariant, and the see-through emptiness theorems for the compile
+image; the minting connection itself IS the canonical
+compile-preserves-imprecision² (every gradual source-term imprecision
+derivation lands in the tightened CTI2 at initialWorld) — PR #143
+review removed a duplicate-alias restatement of it, per the
+closed-world no-shims convention. G2-b
 `GroundingPreserve.agda` + completed `Occupancy.agda` evolution set —
 allocation atomicity over live β-inst/β-gen (`*-allocation-atomic`:
 the occupying step carries the fresh partnered seal), occupancy

--- a/GTSFImp/proof/DGG/PLAN.md
+++ b/GTSFImp/proof/DGG/PLAN.md
@@ -929,3 +929,18 @@ tightened CTI2 must be CONNECTED to gradual source-term imprecision
        at an occupied cell; plus occupancy-evolution invariants for
        the world moves the proofs use.
 All new proofs live in the --safe side of the build.
+
+LG-2 COMPLETE (2026-08-16, PR #143). Grounding is now theorem-level:
+G2-a `GroundingMint.agda` — initialWorld-occupied, the CompileImageWorld
+invariant, the thin minting theorem `compile-mints-cti²` (consumes
+compile-preserves-imprecision²: every gradual source-term imprecision
+derivation lands in the tightened CTI2 at initialWorld), and the
+see-through emptiness theorems for the compile image. G2-b
+`GroundingPreserve.agda` + completed `Occupancy.agda` evolution set —
+allocation atomicity over live β-inst/β-gen (`*-allocation-atomic`:
+the occupying step carries the fresh partnered seal), occupancy
+evolution for every world move, `occupied-see-through-empty`, and the
+related-reduction preservation stated as the higher-order
+`grounding-preservation-knot` (instantiation deferred to the LG-3/M7
+value catch-up driver by design — the knot pattern). All in the --safe
+aggregate; gate green; no resisters. NEXT: LG-3.


### PR DESCRIPTION
## LG-2 of the CTI repair migration (design: PR #140; LG-1: PR #141)

The grounding gate: connect the occupancy-tightened `CastTermImprecision2` to gradual source-term imprecision, per the user's requirement that the relation's invariants be minted by compilation and preserved by reduction — not merely asserted.

- **G2-a Minting**: explicit theorems that compile-image worlds satisfy the occupancy discipline (`initialWorld` cells are occupied; compile² lands in the tightened relation with no see-through uses), making `compile-preserves-imprecision²` the minting connection.
- **G2-b Preservation**: allocation atomicity as theorems over the live reduction/catch-up machinery — every step that first occupies a cell (`β-gen`/`β-inst`) produces the partnered seal in the same step (the V3(b) pre-flight finding, now as proof) — plus occupancy-evolution invariants for the world moves the proof stack uses.

All new proofs land in the `--safe` side of the build. Out of scope: LG-3 (`CatchupCast`-family removal).

Draft until both stages land green (three-target `make check`) with supervisor verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
