### PR TITLE
[codex] Prove GTSFImp multi-step simulations

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -115,6 +115,8 @@ import proof.DGG.Catchup.FuelKnotProof
 -- Current frontier (M8: higher-order DGG assembly)
 ------------------------------------------------------------------------
 
+import proof.DGG.MultiSimProof
+import proof.DGG.MultiSimBackProof
 import proof.DGG.DynamicGradualGuaranteeProof
 
 ------------------------------------------------------------------------

--- a/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
+++ b/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
@@ -42,8 +42,8 @@ open import proof.DGG.DynamicGradualGuaranteeDef
     ; compiled-left
     ; compiled-right
     )
-open import proof.DGG.SimDef using (Sim*ᵀ)
-open import proof.DGG.SimBackDef using (SimBack*ᵀ)
+open import proof.DGG.MultiSimDef using (Sim*ᵀ)
+open import proof.DGG.MultiSimBackDef using (SimBack*ᵀ)
 open import proof.DGG.CatchupToLessPreciseDef
   using (CatchupToLessPrecise)
 open import proof.DGG.CatchupToMorePreciseDef

--- a/GTSFImp/proof/DGG/MultiSimBackDef.agda
+++ b/GTSFImp/proof/DGG/MultiSimBackDef.agda
@@ -1,0 +1,42 @@
+module proof.DGG.MultiSimBackDef where
+
+-- File Charter:
+--   * States closed multi-step backward simulation when the less precise
+--     right term reduces.
+--   * Allows a residual right trace and records the accumulated parked-world
+--     evolution needed by later proof layers.
+--   * Contains no simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx)
+open import CastTerms using (Term)
+open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open import proof.DGG.Catchup.ValueCatchupRightDef using (_++χ_)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimBack*ᵀ : Set
+SimBack*ᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δᴿ′} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ} {N′ : Term Δᴿ′}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
+    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+  → ParkedWorld W
+  → W ∣ [] ⊢² M ⊑ M′ ∶ p
+  → M′ —↠[ χsᴿ ] N′
+  → Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+    Σ[ N ∈ Term Δᴸ′ ] Σ[ Δᴿ″ ∈ TyCtx ]
+    Σ[ ψsᴿ ∈ StoreChanges Δᴿ′ Δᴿ″ ]
+    Σ[ N₂′ ∈ Term Δᴿ″ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ′ Δᴿ″ Δ′ ]
+    Σ[ q ∈ applyTys χsᴸ A
+        ⊑ᵂ⟨ W′ ⟩ applyTys ψsᴿ (applyTys χsᴿ B) ]
+      (M —↠[ χsᴸ ] N) ×
+      (N′ —↠[ ψsᴿ ] N₂′) ×
+      ParkedEvolve χsᴸ (χsᴿ ++χ ψsᴿ) W W′ ×
+      (W′ ∣ [] ⊢² N ⊑ N₂′ ∶ q)

--- a/GTSFImp/proof/DGG/MultiSimBackProof.agda
+++ b/GTSFImp/proof/DGG/MultiSimBackProof.agda
@@ -1,0 +1,76 @@
+module proof.DGG.MultiSimBackProof where
+
+-- File Charter:
+--   * Proves multi-step backward simulation from one-step backward
+--     simulation.
+--   * Preserves the residual right trace and composes parked-world evolution.
+--   * Recurses only over the given right multi-step reduction.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([])
+open import Data.Product using (_,_; Σ-syntax)
+
+open import Types using (Ty)
+open import CastTerms using (Term)
+open import Reduction using (_—↠[_]_; ↠-refl; ↠-step)
+  renaming ([] to []ˢ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.SimBackDef using (SimBackᵀ)
+open import proof.DGG.MultiSimBackDef using (SimBack*ᵀ)
+open import proof.DGG.Parked.ParkedWorldDef using (evolve-refl)
+open import proof.DGG.Parked.ParkedWorldLemma
+  using (parked-world-closed)
+open import proof.DGG.Parked.ParkedEvolveCompositionProof
+  using (compose-parked-evolve)
+open import proof.DGG.Catchup.ValueCatchupRightDef using (_++χ_)
+open import proof.DGG.Catchup.ColumnSupportProof
+  using (applyTys-++; composeReduction)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+------------------------------------------------------------------------
+-- Equality transport for related terms
+------------------------------------------------------------------------
+
+transport-related-source : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+  → A ≡ A′
+  → (Σ[ p ∈ A ⊑ᵂ⟨ W ⟩ B ] (W ∣ [] ⊢² M ⊑ M′ ∶ p))
+  → Σ[ q ∈ A′ ⊑ᵂ⟨ W ⟩ B ] (W ∣ [] ⊢² M ⊑ M′ ∶ q)
+transport-related-source refl related = related
+
+------------------------------------------------------------------------
+-- Multi-step backward simulation
+------------------------------------------------------------------------
+
+sim-back* : SimBackᵀ → SimBack*ᵀ
+sim-back* sim-back {W = W} {M = M} {M′ = M′} {p = p}
+    parked related ↠-refl =
+  _ , []ˢ , M , _ , []ˢ , M′ , _ , W , p ,
+  ↠-refl , ↠-refl , evolve-refl , related
+sim-back* sim-back parked related (↠-step M′→N′ N′↠P′)
+    with sim-back parked related M′→N′
+sim-back* sim-back parked related (↠-step M′→N′ N′↠P′)
+    | Δᴸ₁ , χsᴸ₁ , N , Δ₁ , W₁ , q₁ ,
+      M↠N , evol₁ , N⊑N′
+    with sim-back* sim-back (parked-world-closed parked evol₁)
+      N⊑N′ N′↠P′
+sim-back* sim-back parked related (↠-step M′→N′ N′↠P′)
+    | Δᴸ₁ , χsᴸ₁ , N , Δ₁ , W₁ , q₁ ,
+      M↠N , evol₁ , N⊑N′
+    | Δᴸ₂ , χsᴸ₂ , P , Δᴿ₂ , ψsᴿ , P₂′ , Δ₂ , W₂ ,
+      q₂ ,
+      N↠P , P′↠P₂′ , evol₂ , P⊑P₂′
+    with transport-related-source
+      (applyTys-++ χsᴸ₁ χsᴸ₂ _) (q₂ , P⊑P₂′)
+sim-back* sim-back parked related (↠-step M′→N′ N′↠P′)
+    | Δᴸ₁ , χsᴸ₁ , N , Δ₁ , W₁ , q₁ ,
+      M↠N , evol₁ , N⊑N′
+    | Δᴸ₂ , χsᴸ₂ , P , Δᴿ₂ , ψsᴿ , P₂′ , Δ₂ , W₂ ,
+      q₂ ,
+      N↠P , P′↠P₂′ , evol₂ , P⊑P₂′
+    | q , P⊑P₂′′ =
+  Δᴸ₂ , (χsᴸ₁ ++χ χsᴸ₂) , P , Δᴿ₂ , ψsᴿ , P₂′ ,
+  Δ₂ , W₂ , q ,
+  composeReduction M↠N N↠P , P′↠P₂′ ,
+  compose-parked-evolve evol₁ evol₂ , P⊑P₂′′

--- a/GTSFImp/proof/DGG/MultiSimDef.agda
+++ b/GTSFImp/proof/DGG/MultiSimDef.agda
@@ -1,10 +1,10 @@
-module proof.DGG.SimDef where
+module proof.DGG.MultiSimDef where
 
 -- File Charter:
---   * States closed one-step simulation when the more precise left term
+--   * States closed multi-step simulation when the more precise left term
 --     reduces.
---   * Allows the less precise right term to take a store-changing trace and
---     records the resulting parked-world evolution.
+--   * Exposes the target catch-up trace, final related terms, and parked-world
+--     evolution needed by later proof layers.
 --   * Contains no simulation proof.
 
 open import Data.List using ([])
@@ -12,33 +12,26 @@ open import Data.Product using (_×_; Σ-syntax)
 
 open import Types using (Ty; TyCtx)
 open import CastTerms using (Term)
-open import Reduction using
-  ( StoreChange
-  ; StoreChanges
-  ; applyTy
-  ; applyTys
-  ; _—→[_]_
-  ; _—↠[_]_
-  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
 import proof.DGG.CastTermImprecision2 as CTI2
 open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedWorld; ParkedEvolve)
 open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
 
 
-Simᵀ : Set
-Simᵀ =
+Sim*ᵀ : Set
+Sim*ᵀ =
   ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W : World Δᴸ Δᴿ Δ}
     {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
     {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
-    {χᴸ : StoreChange Δᴸ Δᴸ′}
+    {χsᴸ : StoreChanges Δᴸ Δᴸ′}
   → ParkedWorld W
   → W ∣ [] ⊢² M ⊑ M′ ∶ p
-  → M —→[ χᴸ ] N
+  → M —↠[ χsᴸ ] N
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
     Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
     Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
-    Σ[ q ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+    Σ[ q ∈ applyTys χsᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
       (M′ —↠[ χsᴿ ] N′) ×
-      ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+      ParkedEvolve χsᴸ χsᴿ W W′ ×
       (W′ ∣ [] ⊢² N ⊑ N′ ∶ q)

--- a/GTSFImp/proof/DGG/MultiSimProof.agda
+++ b/GTSFImp/proof/DGG/MultiSimProof.agda
@@ -1,0 +1,65 @@
+module proof.DGG.MultiSimProof where
+
+-- File Charter:
+--   * Lifts closed one-step forward simulation to store-changing traces.
+--   * Is parameterized by the one-step simulation interface.
+--   * Uses completed reduction, type-transport, and parked-evolution
+--     composition proofs directly.
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Data.List using ([])
+open import Data.Product using (_×_; _,_; Σ-syntax)
+
+open import Types using (Ty)
+open import CastTerms using (Term)
+open import Reduction using
+  ( applyTys
+  ; _—↠[_]_
+  ; []
+  ; _∷_
+  ; ↠-refl
+  ; ↠-step
+  )
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.SimDef using (Simᵀ)
+open import proof.DGG.MultiSimDef using (Sim*ᵀ)
+open import proof.DGG.Parked.ParkedWorldDef using (evolve-refl)
+open import proof.DGG.Parked.ParkedWorldLemma
+  using (parked-world-closed)
+open import proof.DGG.Parked.ParkedEvolveCompositionProof
+  using (compose-parked-evolve)
+open import proof.DGG.Catchup.ValueCatchupRightDef using (_++χ_)
+open import proof.DGG.Catchup.ColumnSupportProof
+  using (applyTys-++; composeReduction)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+transport-related-target : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+  → B ≡ B′
+  → (Σ[ p ∈ A ⊑ᵂ⟨ W ⟩ B ] (W ∣ [] ⊢² M ⊑ M′ ∶ p))
+  → Σ[ q ∈ A ⊑ᵂ⟨ W ⟩ B′ ] (W ∣ [] ⊢² M ⊑ M′ ∶ q)
+transport-related-target refl related = related
+
+
+sim* : Simᵀ → Sim*ᵀ
+sim* sim parked related ↠-refl =
+  _ , [] , _ , _ , _ , _ , ↠-refl , evolve-refl , related
+sim* sim parked related (↠-step M→N N↠P)
+    with sim parked related M→N
+sim* sim parked related (↠-step M→N N↠P)
+  | _ , χsᴿ , N′ , _ , W′ , _ , M′↠N′ , evol₁ , N⊑N′
+    with sim* sim (parked-world-closed parked evol₁) N⊑N′ N↠P
+sim* sim parked related (↠-step M→N N↠P)
+  | _ , χsᴿ , N′ , _ , W′ , _ , M′↠N′ , evol₁ , N⊑N′
+  | _ , ψsᴿ , P′ , _ , W″ , q , N′↠P′ , evol₂ , P⊑P′
+    with transport-related-target
+      (applyTys-++ χsᴿ ψsᴿ _) (q , P⊑P′)
+sim* sim parked related (↠-step M→N N↠P)
+  | _ , χsᴿ , N′ , _ , W′ , _ , M′↠N′ , evol₁ , N⊑N′
+  | _ , ψsᴿ , P′ , _ , W″ , q , N′↠P′ , evol₂ , P⊑P′
+  | q′ , P⊑P′′ =
+    _ , (χsᴿ ++χ ψsᴿ) , P′ , _ , W″ , q′ ,
+    composeReduction M′↠N′ N′↠P′ ,
+    compose-parked-evolve evol₁ evol₂ , P⊑P′′

--- a/GTSFImp/proof/DGG/Parked/ParkedEvolveCompositionDef.agda
+++ b/GTSFImp/proof/DGG/Parked/ParkedEvolveCompositionDef.agda
@@ -1,0 +1,29 @@
+module proof.DGG.Parked.ParkedEvolveCompositionDef where
+
+-- File Charter:
+--   * States transitive composition for two-sided parked-world evolution.
+--   * Uses the canonical store-change append operation shared by DGG traces.
+--   * Contains no composition proof.
+
+open import Types using (TyCtx)
+open import Reduction using (StoreChanges)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef using (ParkedEvolve)
+open import proof.DGG.Catchup.ValueCatchupRightDef using (_++χ_)
+open CTI2 using (World)
+
+
+ComposeParkedEvolveᵀ : Set
+ComposeParkedEvolveᵀ =
+  ∀ {Δᴸ₀ Δᴸ₁ Δᴸ₂ Δᴿ₀ Δᴿ₁ Δᴿ₂ : TyCtx}
+    {Δ₀ Δ₁ Δ₂ : TyCtx}
+    {χsᴸ : StoreChanges Δᴸ₀ Δᴸ₁}
+    {ψsᴸ : StoreChanges Δᴸ₁ Δᴸ₂}
+    {χsᴿ : StoreChanges Δᴿ₀ Δᴿ₁}
+    {ψsᴿ : StoreChanges Δᴿ₁ Δᴿ₂}
+    {W₀ : World Δᴸ₀ Δᴿ₀ Δ₀}
+    {W₁ : World Δᴸ₁ Δᴿ₁ Δ₁}
+    {W₂ : World Δᴸ₂ Δᴿ₂ Δ₂}
+  → ParkedEvolve χsᴸ χsᴿ W₀ W₁
+  → ParkedEvolve ψsᴸ ψsᴿ W₁ W₂
+  → ParkedEvolve (χsᴸ ++χ ψsᴸ) (χsᴿ ++χ ψsᴿ) W₀ W₂

--- a/GTSFImp/proof/DGG/Parked/ParkedEvolveCompositionProof.agda
+++ b/GTSFImp/proof/DGG/Parked/ParkedEvolveCompositionProof.agda
@@ -1,0 +1,31 @@
+module proof.DGG.Parked.ParkedEvolveCompositionProof where
+
+-- File Charter:
+--   * Proves transitive composition for parked-world evolution.
+--   * Recurses only over the first evolution witness.
+--   * Exports the completed composition lemma used by multi-step simulation.
+
+open import proof.DGG.Parked.ParkedWorldDef using
+  ( evolve-both-bind
+  ; evolve-keepᴸ
+  ; evolve-keepᴿ
+  ; evolve-left-bind
+  ; evolve-refl
+  ; evolve-right-bind
+  )
+open import proof.DGG.Parked.ParkedEvolveCompositionDef
+  using (ComposeParkedEvolveᵀ)
+
+
+compose-parked-evolve : ComposeParkedEvolveᵀ
+compose-parked-evolve evolve-refl evol₂ = evol₂
+compose-parked-evolve (evolve-keepᴸ evol₁) evol₂ =
+  evolve-keepᴸ (compose-parked-evolve evol₁ evol₂)
+compose-parked-evolve (evolve-keepᴿ evol₁) evol₂ =
+  evolve-keepᴿ (compose-parked-evolve evol₁ evol₂)
+compose-parked-evolve (evolve-both-bind evol₁) evol₂ =
+  evolve-both-bind (compose-parked-evolve evol₁ evol₂)
+compose-parked-evolve (evolve-left-bind evol₁) evol₂ =
+  evolve-left-bind (compose-parked-evolve evol₁ evol₂)
+compose-parked-evolve (evolve-right-bind evol₁) evol₂ =
+  evolve-right-bind (compose-parked-evolve evol₁ evol₂)

--- a/GTSFImp/proof/DGG/SimBackDef.agda
+++ b/GTSFImp/proof/DGG/SimBackDef.agda
@@ -1,10 +1,10 @@
 module proof.DGG.SimBackDef where
 
 -- File Charter:
---   * States closed multi-step backward simulation when the less precise
---     right term reduces.
---   * Allows a residual right trace and records the accumulated parked-world
---     evolution needed by later proof layers.
+--   * States closed one-step backward simulation when the less precise right
+--     term reduces.
+--   * Allows the more precise left term to take a store-changing trace and
+--     records the resulting parked-world evolution.
 --   * Contains no simulation proof.
 
 open import Data.List using ([])
@@ -12,31 +12,33 @@ open import Data.Product using (_×_; Σ-syntax)
 
 open import Types using (Ty; TyCtx)
 open import CastTerms using (Term)
-open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
+open import Reduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyTy
+  ; applyTys
+  ; _—→[_]_
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
 import proof.DGG.CastTermImprecision2 as CTI2
 open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedWorld; ParkedEvolve)
-open import proof.DGG.Catchup.ValueCatchupRightDef using (_++χ_)
 open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
 
 
-SimBack*ᵀ : Set
-SimBack*ᵀ =
+SimBackᵀ : Set
+SimBackᵀ =
   ∀ {Δᴸ Δᴿ Δ Δᴿ′} {W : World Δᴸ Δᴿ Δ}
     {M : Term Δᴸ} {M′ : Term Δᴿ} {N′ : Term Δᴿ′}
     {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
-    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+    {χᴿ : StoreChange Δᴿ Δᴿ′}
   → ParkedWorld W
   → W ∣ [] ⊢² M ⊑ M′ ∶ p
-  → M′ —↠[ χsᴿ ] N′
+  → M′ —→[ χᴿ ] N′
   → Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
-    Σ[ N ∈ Term Δᴸ′ ] Σ[ Δᴿ″ ∈ TyCtx ]
-    Σ[ ψsᴿ ∈ StoreChanges Δᴿ′ Δᴿ″ ]
-    Σ[ N₂′ ∈ Term Δᴿ″ ]
-    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ′ Δᴿ″ Δ′ ]
-    Σ[ q ∈ applyTys χsᴸ A
-        ⊑ᵂ⟨ W′ ⟩ applyTys ψsᴿ (applyTys χsᴿ B) ]
+    Σ[ N ∈ Term Δᴸ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+    Σ[ q ∈ applyTys χsᴸ A ⊑ᵂ⟨ W′ ⟩ applyTy χᴿ B ]
       (M —↠[ χsᴸ ] N) ×
-      (N′ —↠[ ψsᴿ ] N₂′) ×
-      ParkedEvolve χsᴸ (χsᴿ ++χ ψsᴿ) W W′ ×
-      (W′ ∣ [] ⊢² N ⊑ N₂′ ∶ q)
+      ParkedEvolve χsᴸ (χᴿ ∷ˢ []ˢ) W W′ ×
+      (W′ ∣ [] ⊢² N ⊑ N′ ∶ q)


### PR DESCRIPTION
## Summary

- split the one-step `Simᵀ` and `SimBackᵀ` interfaces from the existing multi-step interfaces
- move `Sim*ᵀ` and `SimBack*ᵀ` into `MultiSimDef.agda` and `MultiSimBackDef.agda`
- prove `sim* : Simᵀ → Sim*ᵀ` and `sim-back* : SimBackᵀ → SimBack*ᵀ` by induction over their respective store-changing reduction traces
- add completed composition support for `ParkedEvolve` witnesses
- update the top-level DGG proof and aggregate build to use and check the new module structure

## Motivation

This advances the top-down GTSFImp DGG development by one layer. The multi-step simulations are now higher-order proofs parameterized over the still-partial one-step simulation interfaces, keeping the induction and trace-composition work separate from the lower-level operational cases.

`MultiSimBackProof` preserves the residual right trace exposed by `SimBack*ᵀ`, while both proofs compose store-change traces, parked-world evolution, and the corresponding type-index transports.

## Validation

- `agda --no-allow-unsolved-metas -v0 proof/DGG/SimDef.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/SimBackDef.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/MultiSimDef.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/MultiSimBackDef.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/Parked/ParkedEvolveCompositionProof.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/MultiSimProof.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/MultiSimBackProof.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/DynamicGradualGuaranteeProof.agda`
- `agda --no-allow-unsolved-metas -v0 All.agda`