### PR TITLE
[codex] Prove GTSFImp terminal irreducibility

### DIFF
--- a/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
+++ b/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
@@ -4,9 +4,9 @@ module proof.DGG.DynamicGradualGuaranteeProof where
 --   * Proves the closed GTSFImp dynamic gradual guarantee from the
 --     multi-step simulation and terminal catch-up interfaces.
 --   * Uses completed compilation, parked-world, reduction-composition, and
---     type-safety proofs directly.
+--     irreducibility and type-safety proofs directly.
 --   * Contains no induction; operational inductions remain confined to the
---     parameterized simulation, catch-up, and irreducibility lemmas.
+--     parameterized simulation and catch-up lemmas.
 
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥-elim)
@@ -51,9 +51,13 @@ open import proof.DGG.CatchupToMorePreciseDef
 open import proof.DGG.TargetBlameCatchupDef
   using (TargetBlameCatchupᵀ)
 open import proof.Reduction.ValueIrreducibleDef
-  using (ValueTraceRefl; value-trace-refl; ValueIrreducible*ᵀ)
+  using (ValueTraceRefl; value-trace-refl)
+open import proof.Reduction.ValueIrreducibleProof
+  using (value-irreducible*)
 open import proof.Reduction.BlameIrreducibleDef
-  using (BlameTraceRefl; blame-trace-refl; BlameIrreducible*ᵀ)
+  using (BlameTraceRefl; blame-trace-refl)
+open import proof.Reduction.BlameIrreducibleProof
+  using (blame-irreducible*)
 open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedWorld; parked-initial)
 open import proof.DGG.Parked.ParkedWorldLemma
@@ -97,12 +101,9 @@ dynamic-gradual-guarantee :
   → CatchupToLessPrecise
   → CatchupToMorePrecise
   → TargetBlameCatchupᵀ
-  → ValueIrreducible*ᵀ
-  → BlameIrreducible*ᵀ
   → GradualDGG
 dynamic-gradual-guarantee sim* sim-back* catchup catchup-to-more-precise
-    target-blame-catchup value-irreducible* blame-irreducible*
-    {A = A} {B = B} {p = p} M⊑M′ =
+    target-blame-catchup {A = A} {B = B} {p = p} M⊑M′ =
   source-value , source-diverges , target-value , target-diverges
   where
   initial-parked : ParkedWorld

--- a/GTSFImp/proof/Reduction/BlameIrreducibleProof.agda
+++ b/GTSFImp/proof/Reduction/BlameIrreducibleProof.agda
@@ -1,0 +1,30 @@
+module proof.Reduction.BlameIrreducibleProof where
+
+-- File Charter:
+--   * Proves irreducibility of blame for store-changing multi-step
+--     reduction.
+--   * Inverts the first store-changing step locally and exhaustively.
+--   * Exports blame-irreducible* as the implementation of the Def interface.
+
+open import Data.Empty using (⊥; ⊥-elim)
+
+open import Types using (TyCtx)
+open import CastTerms using (Term; blame)
+open import Reduction using
+  (StoreChange; keep; bind; _—→[_]_; pure-step; _—↠[_]_; ↠-refl;
+   ↠-step)
+open import proof.Reduction.BlameIrreducibleDef
+  using (BlameIrreducible*ᵀ; blame-trace-refl)
+
+
+blame-no-step : ∀ {Δ Δ′ : TyCtx} {N : Term Δ′}
+    {χ : StoreChange Δ Δ′}
+  → blame {Δ} —→[ χ ] N
+  → ⊥
+blame-no-step {χ = keep} (pure-step ())
+blame-no-step {χ = bind R} ()
+
+
+blame-irreducible* : BlameIrreducible*ᵀ
+blame-irreducible* ↠-refl = blame-trace-refl
+blame-irreducible* (↠-step step rest) = ⊥-elim (blame-no-step step)

--- a/GTSFImp/proof/Reduction/ValueIrreducibleProof.agda
+++ b/GTSFImp/proof/Reduction/ValueIrreducibleProof.agda
@@ -1,0 +1,81 @@
+module proof.Reduction.ValueIrreducibleProof where
+
+-- File Charter:
+--   * Proves that values cannot take a store-changing reduction step.
+--   * Derives irreducibility for store-changing multi-step reduction.
+--   * Exports value-irreducible* as the implementation of
+--     ValueIrreducible*ᵀ.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import CastTerms
+open import Reduction
+open import proof.Reduction.ValueIrreducibleDef
+
+
+blame-not-value : ∀ {Δ} → Value (blame {Δ}) → ⊥
+blame-not-value ()
+
+
+value-no-pure-step : ∀ {Δ} {V N : Term Δ}
+  → Value V
+  → V —→ N
+  → ⊥
+value-no-pure-step (ƛ M) ()
+value-no-pure-step (Λ vV) ()
+value-no-pure-step ($ k) ()
+value-no-pure-step (vV 《 inj 》) (ground vV′ G≢G) = G≢G refl
+value-no-pure-step (vV 《 inj 》) blame-⟨⟩ = blame-not-value vV
+value-no-pure-step (vV 《 fun 》) blame-⟨⟩ = blame-not-value vV
+value-no-pure-step (vV 《 all 》) blame-⟨⟩ = blame-not-value vV
+value-no-pure-step (vV 《 genᵥ A≠★ safe 》) blame-⟨⟩ =
+  blame-not-value vV
+value-no-pure-step (vV ↑ fun) blame-reveal = blame-not-value vV
+value-no-pure-step (vV ↑ all) blame-reveal = blame-not-value vV
+value-no-pure-step (vV ↓ seal) blame-conceal = blame-not-value vV
+value-no-pure-step (vV ↓ fun) blame-conceal = blame-not-value vV
+value-no-pure-step (vV ↓ all) blame-conceal = blame-not-value vV
+
+
+value-no-step : ∀ {Δ Δ′} {V : Term Δ} {N : Term Δ′}
+    {χ : StoreChange Δ Δ′}
+  → Value V
+  → V —→[ χ ] N
+  → ⊥
+value-no-step (ƛ M) (pure-step step) = value-no-pure-step (ƛ M) step
+value-no-step (Λ vV) (pure-step step) = value-no-pure-step (Λ vV) step
+value-no-step ($ k) (pure-step step) = value-no-pure-step ($ k) step
+value-no-step (vV 《 inj 》) (pure-step (ground vV′ G≢G)) = G≢G refl
+value-no-step (vV 《 inj 》) (ξ-⟨⟩ step refl) = value-no-step vV step
+value-no-step (vV 《 fun 》) (pure-step step) =
+  value-no-pure-step (vV 《 fun 》) step
+value-no-step (vV 《 fun 》) (ξ-⟨⟩ step refl) = value-no-step vV step
+value-no-step (vV 《 all 》) (pure-step step) =
+  value-no-pure-step (vV 《 all 》) step
+value-no-step (vV 《 all 》) (ξ-⟨⟩ step refl) = value-no-step vV step
+value-no-step (vV 《 genᵥ A≠★ safe 》) (pure-step step) =
+  value-no-pure-step (vV 《 genᵥ A≠★ safe 》) step
+value-no-step (vV 《 genᵥ A≠★ safe 》) (ξ-⟨⟩ step refl) =
+  value-no-step vV step
+value-no-step (vV ↑ fun) (pure-step step) =
+  value-no-pure-step (vV ↑ fun) step
+value-no-step (vV ↑ fun) (ξ-reveal step refl) = value-no-step vV step
+value-no-step (vV ↑ all) (pure-step step) =
+  value-no-pure-step (vV ↑ all) step
+value-no-step (vV ↑ all) (ξ-reveal step refl) = value-no-step vV step
+value-no-step (vV ↓ seal) (pure-step step) =
+  value-no-pure-step (vV ↓ seal) step
+value-no-step (vV ↓ seal) (ξ-conceal step refl) = value-no-step vV step
+value-no-step (vV ↓ fun) (pure-step step) =
+  value-no-pure-step (vV ↓ fun) step
+value-no-step (vV ↓ fun) (ξ-conceal step refl) = value-no-step vV step
+value-no-step (vV ↓ all) (pure-step step) =
+  value-no-pure-step (vV ↓ all) step
+value-no-step (vV ↓ all) (ξ-conceal step refl) = value-no-step vV step
+
+
+value-irreducible* : ValueIrreducible*ᵀ
+value-irreducible* vV ↠-refl = value-trace-refl
+value-irreducible* vV (↠-step step rest) =
+  ⊥-elim (value-no-step vV step)


### PR DESCRIPTION
## Summary

- prove `value-irreducible* : ValueIrreducible*ᵀ` by exhaustive inversion of value-shaped store-changing steps
- prove `blame-irreducible* : BlameIrreducible*ᵀ` by exhaustive one-step inversion
- import both completed support proofs directly in `DynamicGradualGuaranteeProof.agda`
- remove value and blame irreducibility from the higher-order DGG proof parameters

## Motivation

The top-level DGG proof previously treated terminal irreducibility as an external parameter so development could continue before those facts were proved. These are small reduction support lemmas rather than major metatheoretic dependencies, so once completed they should be consumed directly instead of receiving a separate `...Lemma` assembly module.

Both proofs retain the constructor-form trace-reflexivity interfaces, allowing downstream code to recover the empty store-change trace and unchanged endpoint by one pattern match.

## Validation

- `agda --no-allow-unsolved-metas -v0 proof/Reduction/ValueIrreducibleProof.agda`
- `agda --no-allow-unsolved-metas -v0 proof/Reduction/BlameIrreducibleProof.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/DynamicGradualGuaranteeProof.agda`
- `agda --no-allow-unsolved-metas -v0 All.agda`