### PR TITLE
[codex] Establish GTSFImp Sim proof skeleton

### DIFF
--- a/GTSFImp/proof/DGG/CatchupToMorePreciseDef.agda
+++ b/GTSFImp/proof/DGG/CatchupToMorePreciseDef.agda
@@ -1,9 +1,10 @@
 module proof.DGG.CatchupToMorePreciseDef where
 
 -- File Charter:
---   * States closed target catch-up from a related more precise source value.
---   * The less precise target reaches a related value; unlike source catch-up,
---     this direction has no blame alternative.
+--   * States target catch-up relative to an enclosing parked world.
+--   * The active relation may live at that world or across a source reveal or
+--     conceal boundary; catch-up evolves both worlds and replays the boundary.
+--   * The less precise target reaches a related value, with no blame case.
 --   * Contains no catch-up proof.
 
 open import Data.List using ([])
@@ -15,21 +16,77 @@ open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
 import proof.DGG.CastTermImprecision2 as CTI2
 open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedWorld; ParkedEvolve)
-open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+open import proof.DGG.Catchup.StructuralWorldExtendDef
+  using (StructuralWorldExtendᴿ)
+open CTI2 using
+  ( World
+  ; ImpEnvMono
+  ; RebaseAtᴸ
+  ; RebaseAtᴿ
+  ; TagRebaseAtᴸ
+  ; _⊑ᵂ⟨_⟩_
+  ; _∣_⊢²_⊑_∶_
+  )
 
 
-CatchupToMorePrecise : Set
+data CatchupBoundaryKind : Set where
+  same-boundary : CatchupBoundaryKind
+  source-reveal-boundary : CatchupBoundaryKind
+  source-conceal-boundary : CatchupBoundaryKind
+  target-reveal-boundary : CatchupBoundaryKind
+  target-conceal-boundary : CatchupBoundaryKind
+
+
+data CatchupBoundary {Δᴸ Δᴿ Δ} :
+    CatchupBoundaryKind →
+    World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ → Set where
+
+  boundary-refl : ∀ {W}
+      -------------------------------
+    → CatchupBoundary same-boundary W W
+
+  boundary-source-reveal : ∀ {W Wᵖ Xᴸ?}
+    → ImpEnvMono W Wᵖ
+    → RebaseAtᴸ W Wᵖ Xᴸ?
+      -----------------------------------
+    → CatchupBoundary source-reveal-boundary W Wᵖ
+
+  boundary-source-conceal : ∀ {W Wᵖ Xᴸ? Xᴿ?}
+    → ImpEnvMono W Wᵖ
+    → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
+      ------------------------------------
+    → CatchupBoundary source-conceal-boundary W Wᵖ
+
+  boundary-target-reveal : ∀ {W Wᵖ Xᴿ?}
+    → ImpEnvMono W Wᵖ
+    → RebaseAtᴿ W Wᵖ Xᴿ?
+      -----------------------------------
+    → CatchupBoundary target-reveal-boundary W Wᵖ
+
+  boundary-target-conceal : ∀ {W Wᵖ Xᴿ?}
+    → ImpEnvMono W Wᵖ
+    → RebaseAtᴿ Wᵖ W Xᴿ?
+      -----------------------------------
+    → CatchupBoundary target-conceal-boundary W Wᵖ
+
+
+CatchupToMorePrecise : Set₁
 CatchupToMorePrecise =
-  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+  ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {kind : CatchupBoundaryKind}
     {V : Term Δᴸ} {M′ : Term Δᴿ}
-    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
   → ParkedWorld W
-  → W ∣ [] ⊢² V ⊑ M′ ∶ p
+  → CatchupBoundary kind W Wᵖ
+  → Wᵖ ∣ [] ⊢² V ⊑ M′ ∶ p
   → Value V
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
     Σ[ V′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
     Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
-    Σ[ q ∈ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+    Σ[ Wᵖ′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ boundary′ ∈ CatchupBoundary kind W′ Wᵖ′ ]
+    Σ[ q ∈ A ⊑ᵂ⟨ Wᵖ′ ⟩ applyTys χsᴿ B ]
       (M′ —↠[ χsᴿ ] V′) × Value V′ ×
       ParkedEvolve Reduction.[] χsᴿ W W′ ×
-      (W′ ∣ [] ⊢² V ⊑ V′ ∶ q)
+      StructuralWorldExtendᴿ χsᴿ Wᵖ Wᵖ′ ×
+      (Wᵖ′ ∣ [] ⊢² V ⊑ V′ ∶ q)

--- a/GTSFImp/proof/DGG/CatchupToMorePreciseDef.agda
+++ b/GTSFImp/proof/DGG/CatchupToMorePreciseDef.agda
@@ -4,13 +4,17 @@ module proof.DGG.CatchupToMorePreciseDef where
 --   * States target catch-up relative to an enclosing parked world.
 --   * The active relation may live at that world or across a source reveal or
 --     conceal boundary; catch-up evolves both worlds and replays the boundary.
+--   * Boundary indices preserve the source pivot and map the target pivot
+--     through the target store-change trace.
 --   * The less precise target reaches a related value, with no blame case.
 --   * Contains no catch-up proof.
 
 open import Data.List using ([])
+open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Product using (_×_; Σ-syntax)
+open import Relation.Binary.PropositionalEquality using (_≡_)
 
-open import Types using (Ty; TyCtx)
+open import Types using (Ty; TyCtx; TyVar)
 open import CastTerms using (Term; Value)
 open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
 import proof.DGG.CastTermImprecision2 as CTI2
@@ -18,12 +22,22 @@ open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedWorld; ParkedEvolve)
 open import proof.DGG.Catchup.StructuralWorldExtendDef
   using (StructuralWorldExtendᴿ)
+open import proof.DGG.Catchup.StructuralWorldTagRebaseDef
+  using (mapPivotChanges)
 open CTI2 using
   ( World
   ; ImpEnvMono
   ; RebaseAtᴸ
   ; RebaseAtᴿ
   ; TagRebaseAtᴸ
+  ; rebase-idᴸ
+  ; rebase-varᴸ
+  ; rebase-onlyᴸ
+  ; rebase-idᴿ
+  ; rebase-varᴿ
+  ; tag-rebase-idᴸ
+  ; tag-rebase-varᴸ
+  ; tag-rebase-onlyᴸ
   ; _⊑ᵂ⟨_⟩_
   ; _∣_⊢²_⊑_∶_
   )
@@ -37,55 +51,90 @@ data CatchupBoundaryKind : Set where
   target-conceal-boundary : CatchupBoundaryKind
 
 
+targetPivotᴸ : ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ} {Xᴸ?}
+  → RebaseAtᴸ W Wᵖ Xᴸ?
+  → Maybe (TyVar Δᴿ)
+targetPivotᴸ rebase-idᴸ = nothing
+targetPivotᴸ (rebase-varᴸ {Xᴿ = Xᴿ} rebase) = just Xᴿ
+targetPivotᴸ (rebase-onlyᴸ to-star disaligned represented) = nothing
+
+
+sourcePivotᴿ : ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ} {Xᴿ?}
+  → RebaseAtᴿ W Wᵖ Xᴿ?
+  → Maybe (TyVar Δᴸ)
+sourcePivotᴿ rebase-idᴿ = nothing
+sourcePivotᴿ (rebase-varᴿ {Xᴸ = Xᴸ} rebase) = just Xᴸ
+
+
+toTagRebaseAtᴸ : ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ} {Xᴸ?}
+  → (rebase : RebaseAtᴸ W Wᵖ Xᴸ?)
+  → TagRebaseAtᴸ W Wᵖ Xᴸ? (targetPivotᴸ rebase)
+toTagRebaseAtᴸ rebase-idᴸ = tag-rebase-idᴸ
+toTagRebaseAtᴸ (rebase-varᴸ rebase) = tag-rebase-varᴸ rebase
+toTagRebaseAtᴸ (rebase-onlyᴸ to-star disaligned represented) =
+  tag-rebase-onlyᴸ to-star disaligned represented
+
+
+toTagRebaseAtᴿ : ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ} {Xᴿ?}
+  → (rebase : RebaseAtᴿ W Wᵖ Xᴿ?)
+  → TagRebaseAtᴸ W Wᵖ (sourcePivotᴿ rebase) Xᴿ?
+toTagRebaseAtᴿ rebase-idᴿ = tag-rebase-idᴸ
+toTagRebaseAtᴿ (rebase-varᴿ rebase) = tag-rebase-varᴸ rebase
+
+
 data CatchupBoundary {Δᴸ Δᴿ Δ} :
     CatchupBoundaryKind →
+    Maybe (TyVar Δᴸ) → Maybe (TyVar Δᴿ) →
     World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ → Set where
 
   boundary-refl : ∀ {W}
       -------------------------------
-    → CatchupBoundary same-boundary W W
+    → CatchupBoundary same-boundary nothing nothing W W
 
-  boundary-source-reveal : ∀ {W Wᵖ Xᴸ?}
+  boundary-source-reveal : ∀ {W Wᵖ Xᴸ? Xᴿ?}
     → ImpEnvMono W Wᵖ
-    → RebaseAtᴸ W Wᵖ Xᴸ?
+    → TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?
       -----------------------------------
-    → CatchupBoundary source-reveal-boundary W Wᵖ
+    → CatchupBoundary source-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
 
   boundary-source-conceal : ∀ {W Wᵖ Xᴸ? Xᴿ?}
     → ImpEnvMono W Wᵖ
     → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
       ------------------------------------
-    → CatchupBoundary source-conceal-boundary W Wᵖ
+    → CatchupBoundary source-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
 
-  boundary-target-reveal : ∀ {W Wᵖ Xᴿ?}
+  boundary-target-reveal : ∀ {W Wᵖ Xᴸ? Xᴿ?}
     → ImpEnvMono W Wᵖ
-    → RebaseAtᴿ W Wᵖ Xᴿ?
+    → TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?
       -----------------------------------
-    → CatchupBoundary target-reveal-boundary W Wᵖ
+    → CatchupBoundary target-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
 
-  boundary-target-conceal : ∀ {W Wᵖ Xᴿ?}
+  boundary-target-conceal : ∀ {W Wᵖ Xᴸ? Xᴿ?}
     → ImpEnvMono W Wᵖ
-    → RebaseAtᴿ Wᵖ W Xᴿ?
+    → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
       -----------------------------------
-    → CatchupBoundary target-conceal-boundary W Wᵖ
+    → CatchupBoundary target-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
 
 
 CatchupToMorePrecise : Set₁
 CatchupToMorePrecise =
   ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
     {kind : CatchupBoundaryKind}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
     {V : Term Δᴸ} {M′ : Term Δᴿ}
     {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
   → ParkedWorld W
-  → CatchupBoundary kind W Wᵖ
+  → CatchupBoundary kind Xᴸ? Xᴿ? W Wᵖ
   → Wᵖ ∣ [] ⊢² V ⊑ M′ ∶ p
   → Value V
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
     Σ[ V′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
     Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
     Σ[ Wᵖ′ ∈ World Δᴸ Δᴿ′ Δ′ ]
-    Σ[ boundary′ ∈ CatchupBoundary kind W′ Wᵖ′ ]
+    Σ[ Xᴿ′? ∈ Maybe (TyVar Δᴿ′) ]
+    Σ[ boundary′ ∈ CatchupBoundary kind Xᴸ? Xᴿ′? W′ Wᵖ′ ]
     Σ[ q ∈ A ⊑ᵂ⟨ Wᵖ′ ⟩ applyTys χsᴿ B ]
+      Xᴿ′? ≡ mapPivotChanges χsᴿ Xᴿ? ×
       (M′ —↠[ χsᴿ ] V′) × Value V′ ×
       ParkedEvolve Reduction.[] χsᴿ W W′ ×
       StructuralWorldExtendᴿ χsᴿ Wᵖ Wᵖ′ ×

--- a/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
+++ b/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
@@ -11,6 +11,7 @@ module proof.DGG.DynamicGradualGuaranteeProof where
 open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥-elim)
 open import Data.List using ([])
+open import Data.Maybe using (nothing)
 open import Data.Product using (_×_; _,_; proj₂; Σ-syntax; ∃-syntax)
 open import Data.Sum using (_⊎_; inj₁; inj₂)
 
@@ -138,15 +139,17 @@ dynamic-gradual-guarantee sim* sim-back* catchup catchup-to-more-precise
   source-value {Δᴸ} V χsᴸ M↠V vV
       | Δᴿ₁ , χsᴿ₁ , N′ , Δ₁ , W₁ , q₁ , M′↠N′ ,
         evol₁ , V⊑N′
-      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , .W₂ , boundary-refl , q₂ ,
-        N′↠V′ , vV′ , evol₂ , plan₂ , V⊑V′
+      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , .W₂ , .nothing ,
+        boundary-refl , q₂ , pivot-map , N′↠V′ , vV′ , evol₂ ,
+        plan₂ , V⊑V′
       with transport-related-target
         (applyTys-++ χsᴿ₁ ψsᴿ _) (q₂ , V⊑V′)
   source-value {Δᴸ} V χsᴸ M↠V vV
       | Δᴿ₁ , χsᴿ₁ , N′ , Δ₁ , W₁ , q₁ , M′↠N′ ,
         evol₁ , V⊑N′
-      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , .W₂ , boundary-refl , q₂ ,
-        N′↠V′ , vV′ , evol₂ , plan₂ , V⊑V′
+      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , .W₂ , .nothing ,
+        boundary-refl , q₂ , pivot-map , N′↠V′ , vV′ , evol₂ ,
+        plan₂ , V⊑V′
       | q , V⊑V′′ =
     Δᴿ₂ , (χsᴿ₁ ++χ ψsᴿ) , V′ , Δ₂ , W₂ , q ,
     composeReduction M′↠N′ N′↠V′ , vV′ , V⊑V′′

--- a/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
+++ b/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
@@ -47,7 +47,7 @@ open import proof.DGG.MultiSimBackDef using (SimBack*ᵀ)
 open import proof.DGG.CatchupToLessPreciseDef
   using (CatchupToLessPrecise)
 open import proof.DGG.CatchupToMorePreciseDef
-  using (CatchupToMorePrecise)
+  using (CatchupToMorePrecise; boundary-refl)
 open import proof.DGG.TargetBlameCatchupDef
   using (TargetBlameCatchupᵀ)
 open import proof.Reduction.ValueIrreducibleDef
@@ -133,19 +133,20 @@ dynamic-gradual-guarantee sim* sim-back* catchup catchup-to-more-precise
       | Δᴿ₁ , χsᴿ₁ , N′ , Δ₁ , W₁ , q₁ , M′↠N′ ,
         evol₁ , V⊑N′
       with catchup-to-more-precise
-        (parked-world-closed initial-parked evol₁) V⊑N′ vV
+        (parked-world-closed initial-parked evol₁)
+        boundary-refl V⊑N′ vV
   source-value {Δᴸ} V χsᴸ M↠V vV
       | Δᴿ₁ , χsᴿ₁ , N′ , Δ₁ , W₁ , q₁ , M′↠N′ ,
         evol₁ , V⊑N′
-      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , q₂ , N′↠V′ , vV′ ,
-        evol₂ , V⊑V′
+      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , .W₂ , boundary-refl , q₂ ,
+        N′↠V′ , vV′ , evol₂ , plan₂ , V⊑V′
       with transport-related-target
         (applyTys-++ χsᴿ₁ ψsᴿ _) (q₂ , V⊑V′)
   source-value {Δᴸ} V χsᴸ M↠V vV
       | Δᴿ₁ , χsᴿ₁ , N′ , Δ₁ , W₁ , q₁ , M′↠N′ ,
         evol₁ , V⊑N′
-      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , q₂ , N′↠V′ , vV′ ,
-        evol₂ , V⊑V′
+      | Δᴿ₂ , ψsᴿ , V′ , Δ₂ , W₂ , .W₂ , boundary-refl , q₂ ,
+        N′↠V′ , vV′ , evol₂ , plan₂ , V⊑V′
       | q , V⊑V′′ =
     Δᴿ₂ , (χsᴿ₁ ++χ ψsᴿ) , V′ , Δ₂ , W₂ , q ,
     composeReduction M′↠N′ N′↠V′ , vV′ , V⊑V′′

--- a/GTSFImp/proof/DGG/SimBetaCastDef.agda
+++ b/GTSFImp/proof/DGG/SimBetaCastDef.agda
@@ -1,0 +1,47 @@
+module proof.DGG.SimBetaCastDef where
+
+-- File Charter:
+--   * States simulation of source function-cast beta reduction.
+--   * Packages target catch-up, target reduction, parked-world evolution,
+--     and the final casted application relation behind one interface.
+--   * Contains no beta-cast simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx; _⇒_)
+open import Consistency using (Env∼; flipᵐ; _⊢_∼_; _↦_)
+open import Imprecision using (⇒⊑⇒)
+open import CastTerms using (Term; Value; _·_; _⟨_⟩)
+open import Reduction using
+  ( StoreChanges
+  ; applyTys
+  ; keep
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimBetaCastᵀ : Set
+SimBetaCastᵀ =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {V X : Term Δᴸ} {F′ X′ : Term Δᴿ}
+    {μ : Env∼ Δᴸ} {A A′ B B′ A₀ B₀ : Ty Δᴸ}
+    {C D : Ty Δᴿ}
+    {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
+    {pA : A₀ ⊑ᵂ⟨ W ⟩ C} {pB : B₀ ⊑ᵂ⟨ W ⟩ D}
+  → ParkedWorld W
+  → W ∣ [] ⊢² V ⟨ c ↦ d ⟩ ⊑ F′ ∶ ⇒⊑⇒ pA pB
+  → W ∣ [] ⊢² X ⊑ X′ ∶ pA
+  → Value V
+  → Value X
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ R′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ q ∈ B₀ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ D ]
+      (F′ · X′ —↠[ χsᴿ ] R′) ×
+      ParkedEvolve (keep ∷ˢ []ˢ) χsᴿ W W′ ×
+      (W′ ∣ [] ⊢² (V · (X ⟨ c ⟩)) ⟨ d ⟩ ⊑ R′ ∶ q)

--- a/GTSFImp/proof/DGG/SimBetaCastDef.agda
+++ b/GTSFImp/proof/DGG/SimBetaCastDef.agda
@@ -27,21 +27,22 @@ open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
 
 SimBetaCastᵀ : Set
 SimBetaCastᵀ =
-  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
-    {V X : Term Δᴸ} {F′ X′ : Term Δᴿ}
+  ∀ {Δᴸ Δᴿ Δ} {world : World Δᴸ Δᴿ Δ}
+    {V W : Term Δᴸ} {L′ M′ : Term Δᴿ}
     {μ : Env∼ Δᴸ} {A A′ B B′ A₀ B₀ : Ty Δᴸ}
     {C D : Ty Δᴿ}
     {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
-    {pA : A₀ ⊑ᵂ⟨ W ⟩ C} {pB : B₀ ⊑ᵂ⟨ W ⟩ D}
-  → ParkedWorld W
-  → W ∣ [] ⊢² V ⟨ c ↦ d ⟩ ⊑ F′ ∶ ⇒⊑⇒ pA pB
-  → W ∣ [] ⊢² X ⊑ X′ ∶ pA
+    {pA : A₀ ⊑ᵂ⟨ world ⟩ C}
+    {pB : B₀ ⊑ᵂ⟨ world ⟩ D}
+  → ParkedWorld world
+  → world ∣ [] ⊢² V ⟨ c ↦ d ⟩ ⊑ L′ ∶ ⇒⊑⇒ pA pB
+  → world ∣ [] ⊢² W ⊑ M′ ∶ pA
   → Value V
-  → Value X
+  → Value W
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
-    Σ[ R′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
-    Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
-    Σ[ q ∈ B₀ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ D ]
-      (F′ · X′ —↠[ χsᴿ ] R′) ×
-      ParkedEvolve (keep ∷ˢ []ˢ) χsᴿ W W′ ×
-      (W′ ∣ [] ⊢² (V · (X ⟨ c ⟩)) ⟨ d ⟩ ⊑ R′ ∶ q)
+    Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ world′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ q ∈ B₀ ⊑ᵂ⟨ world′ ⟩ applyTys χsᴿ D ]
+      (L′ · M′ —↠[ χsᴿ ] N′) ×
+      ParkedEvolve (keep ∷ˢ []ˢ) χsᴿ world world′ ×
+      (world′ ∣ [] ⊢² (V · (W ⟨ c ⟩)) ⟨ d ⟩ ⊑ N′ ∶ q)

--- a/GTSFImp/proof/DGG/SimBetaDef.agda
+++ b/GTSFImp/proof/DGG/SimBetaDef.agda
@@ -27,18 +27,18 @@ open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
 
 SimBetaᵀ : Set
 SimBetaᵀ =
-  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
-    {N V : Term Δᴸ} {F′ V′ : Term Δᴿ}
+  ∀ {Δᴸ Δᴿ Δ} {world : World Δᴸ Δᴿ Δ}
+    {M V : Term Δᴸ} {L′ M′ : Term Δᴿ}
     {A B : Ty Δᴸ} {A′ B′ : Ty Δᴿ}
-    {pA : A ⊑ᵂ⟨ W ⟩ A′} {pB : B ⊑ᵂ⟨ W ⟩ B′}
-  → ParkedWorld W
-  → W ∣ [] ⊢² ƛ N ⊑ F′ ∶ ⇒⊑⇒ pA pB
-  → W ∣ [] ⊢² V ⊑ V′ ∶ pA
+    {pA : A ⊑ᵂ⟨ world ⟩ A′} {pB : B ⊑ᵂ⟨ world ⟩ B′}
+  → ParkedWorld world
+  → world ∣ [] ⊢² ƛ M ⊑ L′ ∶ ⇒⊑⇒ pA pB
+  → world ∣ [] ⊢² V ⊑ M′ ∶ pA
   → Value V
   → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
-    Σ[ R′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
-    Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
-    Σ[ q ∈ B ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
-      (F′ · V′ —↠[ χsᴿ ] R′) ×
-      ParkedEvolve (keep ∷ˢ []ˢ) χsᴿ W W′ ×
-      (W′ ∣ [] ⊢² N [ V ] ⊑ R′ ∶ q)
+    Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ world′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ q ∈ B ⊑ᵂ⟨ world′ ⟩ applyTys χsᴿ B′ ]
+      (L′ · M′ —↠[ χsᴿ ] N′) ×
+      ParkedEvolve (keep ∷ˢ []ˢ) χsᴿ world world′ ×
+      (world′ ∣ [] ⊢² M [ V ] ⊑ N′ ∶ q)

--- a/GTSFImp/proof/DGG/SimBetaDef.agda
+++ b/GTSFImp/proof/DGG/SimBetaDef.agda
@@ -1,0 +1,44 @@
+module proof.DGG.SimBetaDef where
+
+-- File Charter:
+--   * States simulation of source beta reduction after a related lambda is
+--     applied to a related source value.
+--   * Packages all target catch-up, parked-world evolution, and the final
+--     substituted term relation behind one higher-order interface.
+--   * Contains no beta-simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx; _⇒_)
+open import Imprecision using (⇒⊑⇒)
+open import CastTerms using (Term; Value; ƛ_; _·_; _[_])
+open import Reduction using
+  ( StoreChanges
+  ; applyTys
+  ; keep
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimBetaᵀ : Set
+SimBetaᵀ =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {N V : Term Δᴸ} {F′ V′ : Term Δᴿ}
+    {A B : Ty Δᴸ} {A′ B′ : Ty Δᴿ}
+    {pA : A ⊑ᵂ⟨ W ⟩ A′} {pB : B ⊑ᵂ⟨ W ⟩ B′}
+  → ParkedWorld W
+  → W ∣ [] ⊢² ƛ N ⊑ F′ ∶ ⇒⊑⇒ pA pB
+  → W ∣ [] ⊢² V ⊑ V′ ∶ pA
+  → Value V
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ R′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ Δᴿ′ Δ′ ]
+    Σ[ q ∈ B ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+      (F′ · V′ —↠[ χsᴿ ] R′) ×
+      ParkedEvolve (keep ∷ˢ []ˢ) χsᴿ W W′ ×
+      (W′ ∣ [] ⊢² N [ V ] ⊑ R′ ∶ q)

--- a/GTSFImp/proof/DGG/SimProof.agda
+++ b/GTSFImp/proof/DGG/SimProof.agda
@@ -20,54 +20,76 @@ open import proof.DGG.Parked.ParkedWorldDef
 open import proof.DGG.SimDef using (Simᵀ)
 open import proof.DGG.SimBetaDef using (SimBetaᵀ)
 open import proof.DGG.SimBetaCastDef using (SimBetaCastᵀ)
+open import proof.DGG.TransportTermImprecisionDef
+  using (TransportTermImprecisionᴾᵀ)
+open import proof.DGG.SimSourceRevealDef using (SimSourceRevealᵀ)
+open import proof.DGG.SimTargetRevealDef using (SimTargetRevealᵀ)
+open import proof.DGG.SimSourceConcealDef using (SimSourceConcealᵀ)
+open import proof.DGG.SimTargetConcealDef using (SimTargetConcealᵀ)
 open import proof.DGG.CatchupToMorePreciseDef
-  using (CatchupToMorePrecise)
+  using
+    ( CatchupToMorePrecise
+    ; boundary-refl
+    ; boundary-source-reveal
+    ; boundary-source-conceal
+    ; toTagRebaseAtᴸ
+    )
 
 ------------------------------------------------------------------------
 -- Direct simulation skeleton
 ------------------------------------------------------------------------
 
-sim : SimBetaᵀ → SimBetaCastᵀ → CatchupToMorePrecise → Simᵀ
+sim : SimBetaᵀ
+  → SimBetaCastᵀ
+  → TransportTermImprecisionᴾᵀ
+  → SimSourceRevealᵀ
+  → SimTargetRevealᵀ
+  → SimSourceConcealᵀ
+  → SimTargetConcealᵀ
+  → CatchupToMorePrecise
+  → Simᵀ
 
 ------------------------------------------------------------------------
 -- Irreducible source forms
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked (x⊑x² x) (pure-step ())
-sim sim-beta sim-beta-cast catchup parked (ƛ⊑ƛ² rel) (pure-step ())
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    (x⊑x² x) (pure-step ())
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    (ƛ⊑ƛ² rel) (pure-step ())
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (Λ⊑Λ² lift vV vV′ rel q) (pure-step ())
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (Λ⊑² Anv z∈A lift vV M′⊢ rel q) (pure-step ())
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (Λ⊑²-smart-comma Anv z∈A smart lift vV M′⊢ rel q)
     (pure-step ())
-sim sim-beta sim-beta-cast catchup parked (κ⊑κ² κ p)
-    (pure-step ())
-sim sim-beta sim-beta-cast catchup parked (blame⊑² M′⊢ p)
-    (pure-step ())
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    (κ⊑κ² κ p) (pure-step ())
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    (blame⊑² M′⊢ p) (pure-step ())
 
 ------------------------------------------------------------------------
 -- Application squares
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ V⊑M′) (pure-step (β vV)) =
   sim-beta parked L⊑L′ V⊑M′ vV
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (pure-step (β-⇒ vV vM)) =
   sim-beta-cast parked L⊑L′ M⊑M′ vV vM
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (pure-step (β-reveal-⇒ vV vM)) =
   {!!}
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (pure-step (β-conceal-⇒ vV vM)) =
   {!!}
 
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} {p = p} parked
     rel@(·⊑·² L⊑L′ M⊑M′) (pure-step blame-·₁) =
   Δᴿ , [] , _ , _ , W , p ,
@@ -75,7 +97,7 @@ sim sim-beta sim-beta-cast catchup
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) p
 
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} {p = p} parked
     rel@(·⊑·² L⊑L′ M⊑M′) (pure-step (blame-·₂ vL)) =
   Δᴿ , [] , _ , _ , W , p ,
@@ -83,18 +105,19 @@ sim sim-beta sim-beta-cast catchup
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) p
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (ξ-·₁ L→N refl)
-    with sim sim-beta sim-beta-cast catchup parked L⊑L′ L→N
-sim sim-beta sim-beta-cast catchup parked
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked L⊑L′ L→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (ξ-·₁ L→N refl)
     | result =
   {!!}
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (ξ-·₂ vL M→N refl)
-    with catchup parked L⊑L′ vL
-sim sim-beta sim-beta-cast catchup parked
+    with catchup parked boundary-refl L⊑L′ vL
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (·⊑·² L⊑L′ M⊑M′) (ξ-·₂ vL M→N refl)
     | caught-up =
   {!!}
@@ -103,62 +126,64 @@ sim sim-beta sim-beta-cast catchup parked
 -- Type-application squares
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (pure-step (β-∀ vM eq)) =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(•⊑•² p∀ M⊑M′ q r) (pure-step blame-•) =
   Δᴿ , [] , _ , _ , W , r ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) r
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (β-Λ vM) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (β-gen vM A≠★ safe) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (β-reveal-∀ vM) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (β-conceal-∀ vM) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
-    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
-sim sim-beta sim-beta-cast catchup parked
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked M⊑M′ M→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑•² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
     | result =
   {!!}
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (pure-step (β-∀ vM eq)) =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(•⊑² p∀ M⊑M′ q r) (pure-step blame-•) =
   Δᴿ , [] , _ , _ , W , r ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) r
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (β-Λ vM) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (β-gen vM A≠★ safe) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (β-reveal-∀ vM) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (β-conceal-∀ vM) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
-    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
-sim sim-beta sim-beta-cast catchup parked
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked M⊑M′ M→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (•⊑² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
     | result =
   {!!}
@@ -167,19 +192,19 @@ sim sim-beta sim-beta-cast catchup parked
 -- Cast squares
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (pure-step (β-id vM)) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (pure-step (ground vM A≠G)) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (pure-step (expand vM G≠B)) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (pure-step (tag-untag vM)) =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(cast⊑cast² c c′ M⊑M′ q)
     (pure-step (tag-untag-bad vM G≠H)) =
@@ -187,71 +212,73 @@ sim sim-beta sim-beta-cast catchup
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(cast⊑cast² c c′ M⊑M′ q) (pure-step (blame-bot-intro vM)) =
   Δᴿ , [] , _ , _ , W , q ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(cast⊑cast² c c′ M⊑M′ q) (pure-step blame-⟨⟩) =
   Δᴿ , [] , _ , _ , W , q ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (β-inst vM B≠★) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (ξ-⟨⟩ M→N refl)
-    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
-sim sim-beta sim-beta-cast catchup parked
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked M⊑M′ M→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑cast² c c′ M⊑M′ q) (ξ-⟨⟩ M→N refl)
     | result =
   {!!}
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (pure-step (β-id vM)) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (pure-step (ground vM A≠G)) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (pure-step (expand vM G≠B)) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (pure-step (tag-untag vM)) =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(cast⊑² c M⊑M′ q) (pure-step (tag-untag-bad vM G≠H)) =
   Δᴿ , [] , _ , _ , W , q ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(cast⊑² c M⊑M′ q) (pure-step (blame-bot-intro vM)) =
   Δᴿ , [] , _ , _ , W , q ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(cast⊑² c M⊑M′ q) (pure-step blame-⟨⟩) =
   Δᴿ , [] , _ , _ , W , q ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (β-inst vM B≠★) =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (ξ-⟨⟩ M→N refl)
-    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
-sim sim-beta sim-beta-cast catchup parked
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked M⊑M′ M→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (cast⊑² c M⊑M′ q) (ξ-⟨⟩ M→N refl)
     | result =
   {!!}
@@ -260,32 +287,55 @@ sim sim-beta sim-beta-cast catchup parked
 -- Target-only wrappers: recurse on the source step
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked (⊑cast² c′ M⊑M′ q) M→N
-    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
-sim sim-beta sim-beta-cast catchup parked (⊑cast² c′ M⊑M′ q) M→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    (⊑cast² c′ M⊑M′ q) M→N
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked M⊑M′ M→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    (⊑cast² c′ M⊑M′ q) M→N
     | result =
   {!!}
 
-sim sim-beta sim-beta-cast catchup parked
-    (⊑reveal² mono rebase same c′⊢ M⊑M′ q) M→N =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(⊑reveal² mono rebase same c′⊢ M⊑M′ q) M→N =
+  tgt↑ parked rel M→N
 
-sim sim-beta sim-beta-cast catchup parked
-    (⊑conceal² mono rebase same c′⊢ M⊑M′ q) M→N =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(⊑conceal² mono rebase same c′⊢ M⊑M′ q) M→N =
+  tgt↓ parked rel M→N
 
 ------------------------------------------------------------------------
 -- Reveal and conceal squares
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked
-    (reveal⊑² mono rebase same c⊢ M⊑M′ q) (pure-step (id-reveal vM)) =
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑² mono rebase same-[] c⊢ M⊑M′ q)
+    (pure-step (id-reveal vM))
+    with catchup parked
+      (boundary-source-reveal mono (toTagRebaseAtᴸ rebase)) M⊑M′ vM
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑² mono rebase same-[] c⊢ M⊑M′ q)
+    (pure-step (id-reveal vM))
+    | Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , Wᵖ′ , Xᴿ′? ,
+      boundary-source-reveal mono′ rebase′ , q′ , pivot-map ,
+      M′↠V′ , vV′ , evol , plan , V⊑V′
+      rewrite pivot-map =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
-    (reveal⊑² mono rebase same c⊢ M⊑M′ q)
-    (pure-step (conceal-reveal vM)) =
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑² mono rebase same-[] c⊢ M⊑M′ q)
+    (pure-step (conceal-reveal vM))
+    with catchup parked
+      (boundary-source-reveal mono (toTagRebaseAtᴸ rebase)) M⊑M′
+      (vM ↓ ConcealValue.seal)
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑² mono rebase same-[] c⊢ M⊑M′ q)
+    (pure-step (conceal-reveal vM))
+    | Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , Wᵖ′ , Xᴿ′? ,
+      boundary-source-reveal mono′ rebase′ , q′ , pivot-map ,
+      M′↠V′ , vV′ , evol , plan , V⊑V′
+      rewrite pivot-map =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(reveal⊑² mono rebase same c⊢ M⊑M′ q)
     (pure-step blame-reveal) =
@@ -293,16 +343,24 @@ sim sim-beta sim-beta-cast catchup
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
-    (reveal⊑² mono rebase same c⊢ M⊑M′ q) (ξ-reveal M→N refl)
-    =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑² mono rebase same c⊢ M⊑M′ q)
+    step@(ξ-reveal M→N refl) =
+  src↑ parked rel step
 
-sim sim-beta sim-beta-cast catchup parked
-    (conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
-    (pure-step (id-conceal vM)) =
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(conceal⊑² partner mono rebase same-[] c⊢ M⊑M′ q)
+    (pure-step (id-conceal vM))
+    with catchup parked (boundary-source-conceal mono rebase) M⊑M′ vM
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(conceal⊑² partner mono rebase same-[] c⊢ M⊑M′ q)
+    (pure-step (id-conceal vM))
+    | Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , Wᵖ′ , Xᴿ′? ,
+      boundary-source-conceal mono′ rebase′ , q′ , pivot-map ,
+      M′↠V′ , vV′ , evol , plan , V⊑V′
+      rewrite pivot-map =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
     (pure-step blame-conceal) =
@@ -310,20 +368,41 @@ sim sim-beta sim-beta-cast catchup
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
-    (conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
-    (ξ-conceal M→N refl) =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
+    step@(ξ-conceal M→N refl) =
+  src↓ parked rel step
 
-sim sim-beta sim-beta-cast catchup parked
-    (reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
-    (pure-step (id-reveal vM)) =
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑reveal² mono rebase same-[] c⊢ c′⊢ M⊑M′ q)
+    (pure-step (id-reveal vM))
+    with catchup parked
+      (boundary-source-reveal mono
+        (toTagRebaseAtᴸ (rebase-varᴸ rebase))) M⊑M′ vM
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑reveal² mono rebase same-[] c⊢ c′⊢ M⊑M′ q)
+    (pure-step (id-reveal vM))
+    | Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , Wᵖ′ , Xᴿ′? ,
+      boundary-source-reveal mono′ rebase′ , q′ , pivot-map ,
+      M′↠V′ , vV′ , evol , plan , V⊑V′
+      rewrite pivot-map =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
-    (reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
-    (pure-step (conceal-reveal vM)) =
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑reveal² mono rebase same-[] c⊢ c′⊢ M⊑M′ q)
+    (pure-step (conceal-reveal vM))
+    with catchup parked
+      (boundary-source-reveal mono
+        (toTagRebaseAtᴸ (rebase-varᴸ rebase))) M⊑M′
+      (vM ↓ ConcealValue.seal)
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑reveal² mono rebase same-[] c⊢ c′⊢ M⊑M′ q)
+    (pure-step (conceal-reveal vM))
+    | Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , Wᵖ′ , Xᴿ′? ,
+      boundary-source-reveal mono′ rebase′ , q′ , pivot-map ,
+      M′↠V′ , vV′ , evol , plan , V⊑V′
+      rewrite pivot-map =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
     (pure-step blame-reveal) =
@@ -331,16 +410,26 @@ sim sim-beta sim-beta-cast catchup
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
-    (reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
-    (ξ-reveal M→N refl) =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
+    step@(ξ-reveal M→N refl) =
+  src↑ parked rel step
 
-sim sim-beta sim-beta-cast catchup parked
-    (conceal⊑conceal² partner mono rebase same c⊢ c′⊢ M⊑M′ q)
-    (pure-step (id-conceal vM)) =
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(conceal⊑conceal² partner mono rebase same-[] c⊢ c′⊢
+      M⊑M′ q) (pure-step (id-conceal vM))
+    with catchup parked
+      (boundary-source-conceal mono (tag-rebase-varᴸ rebase))
+      M⊑M′ vM
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(conceal⊑conceal² partner mono rebase same-[] c⊢ c′⊢
+      M⊑M′ q) (pure-step (id-conceal vM))
+    | Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , Wᵖ′ , Xᴿ′? ,
+      boundary-source-conceal mono′ rebase′ , q′ , pivot-map ,
+      M′↠V′ , vV′ , evol , plan , V⊑V′
+      rewrite pivot-map =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(conceal⊑conceal² partner mono rebase same c⊢ c′⊢ M⊑M′ q)
     (pure-step blame-conceal) =
@@ -348,12 +437,12 @@ sim sim-beta sim-beta-cast catchup
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
-    (conceal⊑conceal² partner mono rebase same c⊢ c′⊢ M⊑M′ q)
-    (ξ-conceal M→N refl) =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(conceal⊑conceal² partner mono rebase same c⊢ c′⊢
+      M⊑M′ q) step@(ξ-conceal M→N refl) =
+  src↓ parked rel step
 
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(packaged-seal-star² partner mono rebase same c⊢ c′⊢
       M⊑M′ sealed q)
@@ -362,44 +451,44 @@ sim sim-beta sim-beta-cast catchup
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) q
-sim sim-beta sim-beta-cast catchup parked
-    (packaged-seal-star² partner mono rebase same c⊢ c′⊢
-      M⊑M′ sealed q)
-    (ξ-conceal M→N refl) =
-  {!!}
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
+    rel@(packaged-seal-star² partner mono rebase same c⊢ c′⊢
+      M⊑M′ sealed q) step@(ξ-conceal M→N refl) =
+  src↓ parked rel step
 
 ------------------------------------------------------------------------
 -- Primitive-operation squares
 ------------------------------------------------------------------------
 
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (⊕⊑⊕² op L⊑L′ M⊑M′ r) (pure-step (δ-⊕ δ)) =
   {!!}
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(⊕⊑⊕² op L⊑L′ M⊑M′ r) (pure-step blame-⊕₁) =
   Δᴿ , [] , _ , _ , W , r ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) r
-sim sim-beta sim-beta-cast catchup
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
     {Δᴿ = Δᴿ} {W = W} parked
     rel@(⊕⊑⊕² op L⊑L′ M⊑M′ r) (pure-step (blame-⊕₂ vL)) =
   Δᴿ , [] , _ , _ , W , r ,
   (_ ∎[]) ,
   evolve-keepᴸ evolve-refl ,
   blame⊑² (CTI2T.target-typing² rel) r
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₁ L→N refl)
-    with sim sim-beta sim-beta-cast catchup parked L⊑L′ L→N
-sim sim-beta sim-beta-cast catchup parked
+    with sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup
+      parked L⊑L′ L→N
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₁ L→N refl)
     | result =
   {!!}
-sim sim-beta sim-beta-cast catchup parked
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₂ vL M→N refl)
-    with catchup parked L⊑L′ vL
-sim sim-beta sim-beta-cast catchup parked
+    with catchup parked boundary-refl L⊑L′ vL
+sim sim-beta sim-beta-cast tr src↑ tgt↑ src↓ tgt↓ catchup parked
     (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₂ vL M→N refl)
     | caught-up =
   {!!}

--- a/GTSFImp/proof/DGG/SimProof.agda
+++ b/GTSFImp/proof/DGG/SimProof.agda
@@ -1,0 +1,405 @@
+module proof.DGG.SimProof where
+
+-- File Charter:
+--   * Gives the direct term-imprecision/reduction case skeleton for Simᵀ.
+--   * Recurses only on immediate term-imprecision premises; any other case
+--     analysis or induction belongs in separately compiled helper lemmas.
+--   * Is currently a partial proof: square-shaped cases are left as holes
+--     until their helper interfaces and transports are fixed.
+
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import CastTerms
+open import Reduction
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CastTermImprecision2Typing as CTI2T
+open CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (evolve-refl; evolve-keepᴸ)
+open import proof.DGG.SimDef using (Simᵀ)
+open import proof.DGG.SimBetaDef using (SimBetaᵀ)
+open import proof.DGG.SimBetaCastDef using (SimBetaCastᵀ)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (CatchupToMorePrecise)
+
+------------------------------------------------------------------------
+-- Direct simulation skeleton
+------------------------------------------------------------------------
+
+sim : SimBetaᵀ → SimBetaCastᵀ → CatchupToMorePrecise → Simᵀ
+
+------------------------------------------------------------------------
+-- Irreducible source forms
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked (x⊑x² x) (pure-step ())
+sim sim-beta sim-beta-cast catchup parked (ƛ⊑ƛ² rel) (pure-step ())
+sim sim-beta sim-beta-cast catchup parked
+    (Λ⊑Λ² lift vV vV′ rel q) (pure-step ())
+sim sim-beta sim-beta-cast catchup parked
+    (Λ⊑² Anv z∈A lift vV M′⊢ rel q) (pure-step ())
+sim sim-beta sim-beta-cast catchup parked
+    (Λ⊑²-smart-comma Anv z∈A smart lift vV M′⊢ rel q)
+    (pure-step ())
+sim sim-beta sim-beta-cast catchup parked (κ⊑κ² κ p)
+    (pure-step ())
+sim sim-beta sim-beta-cast catchup parked (blame⊑² M′⊢ p)
+    (pure-step ())
+
+------------------------------------------------------------------------
+-- Application squares
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ V⊑M′) (pure-step (β vV)) =
+  sim-beta parked L⊑L′ V⊑M′ vV
+
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (pure-step (β-⇒ vV vM)) =
+  sim-beta-cast parked L⊑L′ M⊑M′ vV vM
+
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (pure-step (β-reveal-⇒ vV vM)) =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (pure-step (β-conceal-⇒ vV vM)) =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} {p = p} parked
+    rel@(·⊑·² L⊑L′ M⊑M′) (pure-step blame-·₁) =
+  Δᴿ , [] , _ , _ , W , p ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) p
+
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} {p = p} parked
+    rel@(·⊑·² L⊑L′ M⊑M′) (pure-step (blame-·₂ vL)) =
+  Δᴿ , [] , _ , _ , W , p ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) p
+
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (ξ-·₁ L→N refl)
+    with sim sim-beta sim-beta-cast catchup parked L⊑L′ L→N
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (ξ-·₁ L→N refl)
+    | result =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (ξ-·₂ vL M→N refl)
+    with catchup parked L⊑L′ vL
+sim sim-beta sim-beta-cast catchup parked
+    (·⊑·² L⊑L′ M⊑M′) (ξ-·₂ vL M→N refl)
+    | caught-up =
+  {!!}
+
+------------------------------------------------------------------------
+-- Type-application squares
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (pure-step (β-∀ vM eq)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(•⊑•² p∀ M⊑M′ q r) (pure-step blame-•) =
+  Δᴿ , [] , _ , _ , W , r ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) r
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (β-Λ vM) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (β-gen vM A≠★ safe) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (β-reveal-∀ vM) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (β-conceal-∀ vM) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
+    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑•² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
+    | result =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (pure-step (β-∀ vM eq)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(•⊑² p∀ M⊑M′ q r) (pure-step blame-•) =
+  Δᴿ , [] , _ , _ , W , r ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) r
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (β-Λ vM) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (β-gen vM A≠★ safe) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (β-reveal-∀ vM) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (β-conceal-∀ vM) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
+    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
+sim sim-beta sim-beta-cast catchup parked
+    (•⊑² p∀ M⊑M′ q r) (ξ-• M→N refl refl)
+    | result =
+  {!!}
+
+------------------------------------------------------------------------
+-- Cast squares
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (pure-step (β-id vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (pure-step (ground vM A≠G)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (pure-step (expand vM G≠B)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (pure-step (tag-untag vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(cast⊑cast² c c′ M⊑M′ q)
+    (pure-step (tag-untag-bad vM G≠H)) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(cast⊑cast² c c′ M⊑M′ q) (pure-step (blame-bot-intro vM)) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(cast⊑cast² c c′ M⊑M′ q) (pure-step blame-⟨⟩) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (β-inst vM B≠★) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (ξ-⟨⟩ M→N refl)
+    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑cast² c c′ M⊑M′ q) (ξ-⟨⟩ M→N refl)
+    | result =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (pure-step (β-id vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (pure-step (ground vM A≠G)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (pure-step (expand vM G≠B)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (pure-step (tag-untag vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(cast⊑² c M⊑M′ q) (pure-step (tag-untag-bad vM G≠H)) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(cast⊑² c M⊑M′ q) (pure-step (blame-bot-intro vM)) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(cast⊑² c M⊑M′ q) (pure-step blame-⟨⟩) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (β-inst vM B≠★) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (ξ-⟨⟩ M→N refl)
+    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
+sim sim-beta sim-beta-cast catchup parked
+    (cast⊑² c M⊑M′ q) (ξ-⟨⟩ M→N refl)
+    | result =
+  {!!}
+
+------------------------------------------------------------------------
+-- Target-only wrappers: recurse on the source step
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked (⊑cast² c′ M⊑M′ q) M→N
+    with sim sim-beta sim-beta-cast catchup parked M⊑M′ M→N
+sim sim-beta sim-beta-cast catchup parked (⊑cast² c′ M⊑M′ q) M→N
+    | result =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (⊑reveal² mono rebase same c′⊢ M⊑M′ q) M→N =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (⊑conceal² mono rebase same c′⊢ M⊑M′ q) M→N =
+  {!!}
+
+------------------------------------------------------------------------
+-- Reveal and conceal squares
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked
+    (reveal⊑² mono rebase same c⊢ M⊑M′ q) (pure-step (id-reveal vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (reveal⊑² mono rebase same c⊢ M⊑M′ q)
+    (pure-step (conceal-reveal vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(reveal⊑² mono rebase same c⊢ M⊑M′ q)
+    (pure-step blame-reveal) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (reveal⊑² mono rebase same c⊢ M⊑M′ q) (ξ-reveal M→N refl)
+    =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
+    (pure-step (id-conceal vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
+    (pure-step blame-conceal) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
+    (ξ-conceal M→N refl) =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (pure-step (id-reveal vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (pure-step (conceal-reveal vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (pure-step blame-reveal) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (ξ-reveal M→N refl) =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup parked
+    (conceal⊑conceal² partner mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (pure-step (id-conceal vM)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(conceal⊑conceal² partner mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (pure-step blame-conceal) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (conceal⊑conceal² partner mono rebase same c⊢ c′⊢ M⊑M′ q)
+    (ξ-conceal M→N refl) =
+  {!!}
+
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(packaged-seal-star² partner mono rebase same c⊢ c′⊢
+      M⊑M′ sealed q)
+    (pure-step blame-conceal) =
+  Δᴿ , [] , _ , _ , W , q ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) q
+sim sim-beta sim-beta-cast catchup parked
+    (packaged-seal-star² partner mono rebase same c⊢ c′⊢
+      M⊑M′ sealed q)
+    (ξ-conceal M→N refl) =
+  {!!}
+
+------------------------------------------------------------------------
+-- Primitive-operation squares
+------------------------------------------------------------------------
+
+sim sim-beta sim-beta-cast catchup parked
+    (⊕⊑⊕² op L⊑L′ M⊑M′ r) (pure-step (δ-⊕ δ)) =
+  {!!}
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(⊕⊑⊕² op L⊑L′ M⊑M′ r) (pure-step blame-⊕₁) =
+  Δᴿ , [] , _ , _ , W , r ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) r
+sim sim-beta sim-beta-cast catchup
+    {Δᴿ = Δᴿ} {W = W} parked
+    rel@(⊕⊑⊕² op L⊑L′ M⊑M′ r) (pure-step (blame-⊕₂ vL)) =
+  Δᴿ , [] , _ , _ , W , r ,
+  (_ ∎[]) ,
+  evolve-keepᴸ evolve-refl ,
+  blame⊑² (CTI2T.target-typing² rel) r
+sim sim-beta sim-beta-cast catchup parked
+    (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₁ L→N refl)
+    with sim sim-beta sim-beta-cast catchup parked L⊑L′ L→N
+sim sim-beta sim-beta-cast catchup parked
+    (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₁ L→N refl)
+    | result =
+  {!!}
+sim sim-beta sim-beta-cast catchup parked
+    (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₂ vL M→N refl)
+    with catchup parked L⊑L′ vL
+sim sim-beta sim-beta-cast catchup parked
+    (⊕⊑⊕² op L⊑L′ M⊑M′ r) (ξ-⊕₂ vL M→N refl)
+    | caught-up =
+  {!!}

--- a/GTSFImp/proof/DGG/SimSourceConcealDef.agda
+++ b/GTSFImp/proof/DGG/SimSourceConcealDef.agda
@@ -1,0 +1,45 @@
+module proof.DGG.SimSourceConcealDef where
+
+-- File Charter:
+--   * States simulation for a source conceal wrapper.
+--   * Hides all rebased-premise reasoning and returns the complete Simᵀ
+--     square for the wrapper step.
+--   * Contains no source-conceal simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx)
+open import Conversion using (Conv↓)
+open import CastTerms using (Term; _↓_)
+open import Reduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyTy
+  ; applyTys
+  ; _—→[_]_
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimSourceConcealᵀ : Set
+SimSourceConcealᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {c : Conv↓ Δᴸ A A′} {q : A′ ⊑ᵂ⟨ W ⟩ B}
+    {χᴸ : StoreChange Δᴸ Δᴸ′}
+  → ParkedWorld W
+  → W ∣ [] ⊢² M ↓ c ⊑ M′ ∶ q
+  → M ↓ c —→[ χᴸ ] N
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+    Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+      (M′ —↠[ χsᴿ ] N′) ×
+      ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+      (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)

--- a/GTSFImp/proof/DGG/SimSourceRevealDef.agda
+++ b/GTSFImp/proof/DGG/SimSourceRevealDef.agda
@@ -1,0 +1,45 @@
+module proof.DGG.SimSourceRevealDef where
+
+-- File Charter:
+--   * States simulation for a source reveal wrapper.
+--   * Hides all rebased-premise reasoning and returns the complete Simᵀ
+--     square for the wrapper step.
+--   * Contains no source-reveal simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx)
+open import Conversion using (Conv↑)
+open import CastTerms using (Term; _↑_)
+open import Reduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyTy
+  ; applyTys
+  ; _—→[_]_
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimSourceRevealᵀ : Set
+SimSourceRevealᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {c : Conv↑ Δᴸ A A′} {q : A′ ⊑ᵂ⟨ W ⟩ B}
+    {χᴸ : StoreChange Δᴸ Δᴸ′}
+  → ParkedWorld W
+  → W ∣ [] ⊢² M ↑ c ⊑ M′ ∶ q
+  → M ↑ c —→[ χᴸ ] N
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+    Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+      (M′ —↠[ χsᴿ ] N′) ×
+      ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+      (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)

--- a/GTSFImp/proof/DGG/SimTargetConcealDef.agda
+++ b/GTSFImp/proof/DGG/SimTargetConcealDef.agda
@@ -1,0 +1,45 @@
+module proof.DGG.SimTargetConcealDef where
+
+-- File Charter:
+--   * States simulation beneath a target conceal wrapper.
+--   * Hides all rebased-premise reasoning and returns the complete Simᵀ
+--     square for the source step.
+--   * Contains no target-conceal simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx)
+open import Conversion using (Conv↓)
+open import CastTerms using (Term; _↓_)
+open import Reduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyTy
+  ; applyTys
+  ; _—→[_]_
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimTargetConcealᵀ : Set
+SimTargetConcealᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+    {c′ : Conv↓ Δᴿ B B′} {q : A ⊑ᵂ⟨ W ⟩ B′}
+    {χᴸ : StoreChange Δᴸ Δᴸ′}
+  → ParkedWorld W
+  → W ∣ [] ⊢² M ⊑ M′ ↓ c′ ∶ q
+  → M —→[ χᴸ ] N
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+    Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+      (M′ ↓ c′ —↠[ χsᴿ ] N′) ×
+      ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+      (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)

--- a/GTSFImp/proof/DGG/SimTargetRevealDef.agda
+++ b/GTSFImp/proof/DGG/SimTargetRevealDef.agda
@@ -1,0 +1,45 @@
+module proof.DGG.SimTargetRevealDef where
+
+-- File Charter:
+--   * States simulation beneath a target reveal wrapper.
+--   * Hides all rebased-premise reasoning and returns the complete Simᵀ
+--     square for the source step.
+--   * Contains no target-reveal simulation proof.
+
+open import Data.List using ([])
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx)
+open import Conversion using (Conv↑)
+open import CastTerms using (Term; _↑_)
+open import Reduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyTy
+  ; applyTys
+  ; _—→[_]_
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SimTargetRevealᵀ : Set
+SimTargetRevealᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+    {c′ : Conv↑ Δᴿ B B′} {q : A ⊑ᵂ⟨ W ⟩ B′}
+    {χᴸ : StoreChange Δᴸ Δᴸ′}
+  → ParkedWorld W
+  → W ∣ [] ⊢² M ⊑ M′ ↑ c′ ∶ q
+  → M —→[ χᴸ ] N
+  → Σ[ Δᴿ′ ∈ TyCtx ] Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+    Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+    Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+    Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+      (M′ ↑ c′ —↠[ χsᴿ ] N′) ×
+      ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+      (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)

--- a/GTSFImp/proof/DGG/TransportTermImprecisionDef.agda
+++ b/GTSFImp/proof/DGG/TransportTermImprecisionDef.agda
@@ -1,0 +1,31 @@
+module proof.DGG.TransportTermImprecisionDef where
+
+-- File Charter:
+--   * States transport of closed term imprecision through parked evolution.
+--   * Applies the source and target store-change traces to both terms and
+--     reuses the canonical parked transport of the related result type.
+--   * Contains no term-imprecision transport proof.
+
+open import Data.List using ([])
+
+open import Types using (Ty)
+open import CastTerms using (Term)
+open import Reduction using (StoreChanges; applyTerms)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef using (ParkedEvolve)
+open import proof.DGG.Parked.ParkedWorldLemma using (transport⊑ᴾ)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+TransportTermImprecisionᴾᵀ : Set
+TransportTermImprecisionᴾᵀ =
+  ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
+    {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ′ Δ′}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
+  → (evol : ParkedEvolve χsᴸ χsᴿ W W′)
+  → W ∣ [] ⊢² M ⊑ M′ ∶ p
+  → W′ ∣ [] ⊢² applyTerms χsᴸ M ⊑ applyTerms χsᴿ M′
+      ∶ transport⊑ᴾ evol p


### PR DESCRIPTION
## Summary

- add separately compiled `SimBetaᵀ` and `SimBetaCastᵀ` interfaces
- add an exhaustive higher-order `sim` skeleton that directly matches term imprecision against source reduction
- wire the recursive `sim` and `CatchupToMorePrecise` calls at the corresponding congruence points
- complete ordinary beta, function-cast beta, irreducible-source, and source-to-blame squares
- write zero-step target traces with the local reduction-chain notation

This is intentionally a draft checkpoint. The remaining cases are explicit holes, and `SimProof.agda` is not yet included in `All.agda`.

## Design check-in

The skeleton exposes at least two additional structural dependencies beyond the three initially named:

1. A transport lemma for a closed term-imprecision derivation through `ParkedEvolve`. This is needed to rebuild congruence squares after a recursive simulation or after target-side value catch-up changes the parked world.
2. A rebase-aware simulation bridge for the premises of reveal/conceal imprecision constructors. Their premise relation is indexed by a rebased world, while `Simᵀ` currently requires `ParkedWorld` at that premise world.

Several remaining source redex families (type application, conversion/cast, reveal/conceal, and primitive reduction) may also merit redex-specific helper interfaces once we agree on the structural factoring.

## Validation

- `agda --no-allow-unsolved-metas -v0 proof/DGG/SimBetaDef.agda`
- `agda --no-allow-unsolved-metas -v0 proof/DGG/SimBetaCastDef.agda`
- `agda -v0 All.agda`
- `agda -v0 proof/DGG/SimProof.agda` elaborates the exhaustive skeleton and reports only the intentional holes