### PR TITLE
Hygiene: declared-WIP allowlist for SimProof.agda (restores green gate)

### DIFF
--- a/GTSFImp/Makefile
+++ b/GTSFImp/Makefile
@@ -28,10 +28,15 @@ postulate-check:
 	@! grep -nE 'postulate|TERMINATING|NON_TERMINATING|NO_POSITIVITY_CHECK|NO_UNIVERSE_CHECK|NON_COVERING' \
 		proof/DGG/SimProof.agda | grep -v '^[0-9]*: *--' | grep . \
 	|| { echo "postulate-check: FAILED (SimProof.agda may carry holes only — no postulates or pragmas)"; exit 1; }
-	@test "$$(grep -c '{!' proof/DGG/SimProof.agda)" -le 22 \
+	@test "$$(grep -o '{!' proof/DGG/SimProof.agda | wc -l)" -le 22 \
 	|| { echo "postulate-check: FAILED (SimProof.agda hole count exceeds the declared-WIP baseline of 22)"; exit 1; }
-	@! grep -nE 'proof\.DGG\.SimProof$$' All.agda | grep . \
-	|| { echo "postulate-check: FAILED (SimProof.agda is declared-WIP and must stay out of All.agda while it has holes)"; exit 1; }
+	@! grep -rnE '\bproof\.DGG\.SimProof\b' --include='*.agda' . \
+		| grep -v '/notes/' \
+		| grep -v '/experimental/' \
+		| grep -v '^\./proof/DGG/SimProof.agda' \
+		| grep -v '^[^:]*:[0-9]*: *--' \
+		| grep . \
+	|| { echo "postulate-check: FAILED (SimProof.agda is declared-WIP: no live module may import it while it has holes)"; exit 1; }
 	@! grep -rn 'NON_COVERING' --include='*.agda' . \
 		| grep -v '/notes/' \
 		| grep -v '/experimental/' \

--- a/GTSFImp/Makefile
+++ b/GTSFImp/Makefile
@@ -12,14 +12,26 @@ agda-legacy:
 
 # Hygiene: postulates, holes, and termination pragmas are never allowed in
 # live code; notes/ and experimental/ hold scratch work and negative records.
+# DECLARED-WIP ALLOWLIST (user decision 2026-08-16): SimProof.agda is the
+# top-down Simᵀ skeleton, deliberately partial and kept OUT of All.agda;
+# its holes are capped at the baseline below — ratchet the cap DOWN as
+# sim square cases close, and remove the entry when the file has no holes.
 postulate-check:
 	@! grep -rnE 'postulate|\{!|TERMINATING|NON_TERMINATING|NO_POSITIVITY_CHECK|NO_UNIVERSE_CHECK' \
 		--include='*.agda' . \
 		| grep -v '/notes/' \
 		| grep -v '/experimental/' \
+		| grep -v 'proof/DGG/SimProof.agda' \
 		| grep -v '^[^:]*:[0-9]*: *--' \
 		| grep . \
 	|| { echo "postulate-check: FAILED (see matches above)"; exit 1; }
+	@! grep -nE 'postulate|TERMINATING|NON_TERMINATING|NO_POSITIVITY_CHECK|NO_UNIVERSE_CHECK|NON_COVERING' \
+		proof/DGG/SimProof.agda | grep -v '^[0-9]*: *--' | grep . \
+	|| { echo "postulate-check: FAILED (SimProof.agda may carry holes only — no postulates or pragmas)"; exit 1; }
+	@test "$$(grep -c '{!' proof/DGG/SimProof.agda)" -le 22 \
+	|| { echo "postulate-check: FAILED (SimProof.agda hole count exceeds the declared-WIP baseline of 22)"; exit 1; }
+	@! grep -nE 'proof\.DGG\.SimProof$$' All.agda | grep . \
+	|| { echo "postulate-check: FAILED (SimProof.agda is declared-WIP and must stay out of All.agda while it has holes)"; exit 1; }
 	@! grep -rn 'NON_COVERING' --include='*.agda' . \
 		| grep -v '/notes/' \
 		| grep -v '/experimental/' \


### PR DESCRIPTION
Main's `make postulate-check` has been red since PR #149: `SimProof.agda` (the deliberately-partial top-down `Simᵀ` skeleton) carries 22 open holes, which the `{!` grep catches. Per the user's decision, this adds a **narrow declared-WIP allowlist entry** rather than relaxing the rule:

- `SimProof.agda` is excluded from the general hole grep, but a dedicated check enforces it may carry **holes only** — postulates and all pragmas (TERMINATING/NON_COVERING/etc.) remain forbidden there (negative-tested);
- its hole count is **capped at the current baseline of 22** — closing holes keeps passing, adding a 23rd fails; ratchet the cap down as sim square cases close and delete the entry at zero;
- a guard enforces the file **stays out of All.agda** while it has holes (exact-module match, so `MultiSimProof` is unaffected).

`make postulate-check` on main+this: green. No Agda code changes; the `agda`/`agda-legacy` targets are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
