### PR TITLE
T2: left-side sim value interfaces (conceal pair proven; family in progress)

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -119,6 +119,8 @@ import proof.DGG.Catchup.FuelKnotProof
 ------------------------------------------------------------------------
 
 import proof.DGG.SimPrimitiveValuesProof
+import proof.DGG.SimSourceConcealValuesProof
+import proof.DGG.SimPairedConcealValuesProof
 import proof.DGG.SimProof
 import proof.DGG.MultiSimProof
 import proof.DGG.MultiSimBackProof

--- a/GTSFImp/proof/DGG/SimPairedConcealValuesProof.agda
+++ b/GTSFImp/proof/DGG/SimPairedConcealValuesProof.agda
@@ -1,0 +1,33 @@
+module proof.DGG.SimPairedConcealValuesProof where
+
+-- File Charter:
+--   * Implements the paired conceal value simulation interface.
+--   * Refutes source value steps for pivoted conceal conversions.
+--   * Does not alter the conceal relation or reduction rules.
+
+open import Data.Empty using (⊥-elim)
+
+open import Reduction using (pure-step; blame-conceal; ξ-conceal)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.SimPairedConcealValuesDef
+  using (SimPairedConcealValuesᵀ)
+open import proof.Reduction.ValueIrreducibleProof
+  using (value-no-step)
+
+
+sim-paired-conceal-values : SimPairedConcealValuesᵀ
+sim-paired-conceal-values _ _ _ _ (CTI2.⊢↓-sealˣ _) _ _ _ ()
+    (pure-step blame-conceal) _
+sim-paired-conceal-values _ _ _ _ (CTI2.⊢↓-sealˣ _) _ _ _ vV
+    (ξ-conceal step _) _ =
+  ⊥-elim (value-no-step vV step)
+sim-paired-conceal-values _ _ _ _ (CTI2.⊢↓-⇒ˣ _ _ _) _ _ _ ()
+    (pure-step blame-conceal) _
+sim-paired-conceal-values _ _ _ _ (CTI2.⊢↓-⇒ˣ _ _ _) _ _ _ vV
+    (ξ-conceal step _) _ =
+  ⊥-elim (value-no-step vV step)
+sim-paired-conceal-values _ _ _ _ (CTI2.⊢↓-∀ˣ _) _ _ _ ()
+    (pure-step blame-conceal) _
+sim-paired-conceal-values _ _ _ _ (CTI2.⊢↓-∀ˣ _) _ _ _ vV
+    (ξ-conceal step _) _ =
+  ⊥-elim (value-no-step vV step)

--- a/GTSFImp/proof/DGG/SimPrimitiveValuesProof.agda
+++ b/GTSFImp/proof/DGG/SimPrimitiveValuesProof.agda
@@ -6,6 +6,8 @@ module proof.DGG.SimPrimitiveValuesProof where
 --     target operands with their related source constants.
 --   * Performs the matching target delta step with synchronized keep changes.
 
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (refl)
 open import Primitives using (κℕ; κ𝔹; δ-add; δ-and)
 open import CastTerms using ($; _⊕[_]_)
 open import Reduction
@@ -47,9 +49,9 @@ sim-primitive-values parked L⊑V′ M⊑M′ r vV′ vM′ δ-add
     | nv-const refl | nv-const refl
     | CTI2.κ⊑κ² ._ p | CTI2.κ⊑κ² ._ q =
   _ , keep ∷ˢ []ˢ , _ , _ , _ , r ,
-  $ _ ⊕[ _ ] $ _
+  ($ _ ⊕[ _ ] $ _
     —→[ keep ]⟨ pure-step (δ-⊕ δ-add) ⟩
-  $ _ ∎[] ,
+  $ _ ∎[]) ,
   evolve-keepᴸ (evolve-keepᴿ evolve-refl) ,
   CTI2.κ⊑κ² _ r
 sim-primitive-values parked L⊑V′ M⊑M′ r vV′ vM′ δ-and
@@ -62,8 +64,8 @@ sim-primitive-values parked L⊑V′ M⊑M′ r vV′ vM′ δ-and
     | bv-const refl | bv-const refl
     | CTI2.κ⊑κ² ._ p | CTI2.κ⊑κ² ._ q =
   _ , keep ∷ˢ []ˢ , _ , _ , _ , r ,
-  $ _ ⊕[ _ ] $ _
+  ($ _ ⊕[ _ ] $ _
     —→[ keep ]⟨ pure-step (δ-⊕ δ-and) ⟩
-  $ _ ∎[] ,
+  $ _ ∎[]) ,
   evolve-keepᴸ (evolve-keepᴿ evolve-refl) ,
   CTI2.κ⊑κ² _ r

--- a/GTSFImp/proof/DGG/SimSourceConcealValuesProof.agda
+++ b/GTSFImp/proof/DGG/SimSourceConcealValuesProof.agda
@@ -1,0 +1,33 @@
+module proof.DGG.SimSourceConcealValuesProof where
+
+-- File Charter:
+--   * Implements the source-only conceal value simulation interface.
+--   * Closes the `id↓` root step after the target body catchup result.
+--   * Uses value irreducibility to refute non-root frame steps.
+
+open import Data.Empty using (⊥-elim)
+open import Data.Product using (_,_)
+
+open import Reduction using (pure-step; id-conceal; blame-conceal; ξ-conceal)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.CatchupToMorePreciseDef
+  using (boundary-source-conceal)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (evolve-keepᴸ)
+open import proof.DGG.SimSourceConcealValuesDef
+  using (SimSourceConcealValuesᵀ)
+open import proof.Reduction.ValueIrreducibleProof
+  using (value-no-step)
+
+
+sim-source-conceal-values : SimSourceConcealValuesᵀ
+sim-source-conceal-values _ _ _ CTI2.tag-rebase-idᴸ CTI2.⊢↓-idˣ _ _
+    vV (pure-step (id-conceal _))
+    (Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , .W′ , _ ,
+      boundary-source-conceal _ CTI2.tag-rebase-idᴸ , q′ ,
+      _ , M′↠V′ , _ , evol , _ , _ , rel′) =
+  Δᴿ′ , χsᴿ , V′ , Δ′ , W′ , q′ ,
+  M′↠V′ , evolve-keepᴸ evol , rel′
+sim-source-conceal-values _ _ _ _ _ _ _ () (pure-step blame-conceal) _
+sim-source-conceal-values _ _ _ _ _ _ _ vV (ξ-conceal step _) _ =
+  ⊥-elim (value-no-step vV step)

--- a/GTSFImp/proof/DGG/notes/t2-conversion-frame-premise-parked-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t2-conversion-frame-premise-parked-proposal.red
@@ -1,0 +1,78 @@
+# T2 proposal: parked premise worlds for continuation-shaped conversion frames
+
+Date: 2026-08-17
+
+Status: proposed; no live proof surface changed.
+
+The D1 continuation-shaped `SimConversionFramesᵀ` ruling requires `SimProof`
+to perform the child recursive simulation call before invoking the frame field.
+At every reveal/conceal wrapper constructor, the child relation lives at the
+constructor premise world, not at the outer world whose `ParkedWorld` proof is
+available to `Simᵀ`.
+
+Focused diagnostic
+------------------
+
+A temporary compile experiment in the target-reveal branch tried to call:
+
+```agda
+sim parked M⊑M′ M→N
+```
+
+under:
+
+```agda
+rel@(⊑reveal² mono rebase same c′⊢ M⊑M′ q)
+```
+
+Agda reported:
+
+```text
+W′ != W of type (World Δᴸ Δᴿ Δ)
+when checking that the expression M⊑M′ has type
+W ∣ List.[] ⊢² _M_2332 ⊑ _M′_2333 ∶ _p_2337
+```
+
+The same premise-world mismatch appears in the source reveal/conceal and
+target conceal frame cases.  Passing `parked` to the child call is therefore
+ill-typed, and the current parked toolkit exports no lemma that turns
+`ParkedWorld W` into `ParkedWorld Wᵖ` through these rebase witnesses.
+
+Required new statement
+----------------------
+
+One way to make the D1 shape implementable is to add an explicit parked-premise
+capability for wrapper premise worlds:
+
+```agda
+ParkedConversionPremisesᵀ : Set₁
+ParkedConversionPremisesᵀ =
+  (∀ {Δᴸ Δᴿ Δ} {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ?}
+    → ParkedWorld W
+    → CTI2.RebaseAtᴸ W Wᵖ Xᴸ?
+    → ParkedWorld Wᵖ)
+  ×
+  (∀ {Δᴸ Δᴿ Δ} {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ} {Xᴿ?}
+    → ParkedWorld W
+    → CTI2.RebaseAtᴿ W Wᵖ Xᴿ?
+    → ParkedWorld Wᵖ)
+  ×
+  (∀ {Δᴸ Δᴿ Δ} {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+    → ParkedWorld W
+    → CTI2.TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?
+    → ParkedWorld Wᵖ)
+  ×
+  (∀ {Δᴸ Δᴿ Δ} {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+    → ParkedWorld W
+    → CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
+    → ParkedWorld Wᵖ)
+```
+
+With such a capability, `SimProof` could call the structural child simulation
+at the premise world and then pass the resulting Sigma package to the
+continuation-shaped frame fields.
+
+This is a new major proof surface: it changes how parkedness is propagated
+through wrapper rebasing, and the current `ParkedWorld` constructors do not make
+the statement derivable directly.  Per the T2 standing rule, I did not add this
+surface or reshape the live frame interface past the approved design point.

--- a/GTSFImp/proof/DGG/notes/t2-conversion-frames-blocked.red
+++ b/GTSFImp/proof/DGG/notes/t2-conversion-frames-blocked.red
@@ -1,0 +1,51 @@
+# T2 blocker: `SimConversionFramesᵀ`
+
+Date: 2026-08-17
+
+Status: blocked.
+
+The conversion-frame interface cannot be inhabited from its current statement:
+the four fields are frame-recursion obligations, but the record does not take a
+recursive `Simᵀ` argument or any equivalent child-step simulation result.
+
+Case table
+----------
+
+| field | source step shape at `SimProof` call site | needed response | blocker |
+| --- | --- | --- | --- |
+| `source-reveal-frame` | `ξ-reveal M→N _` under `reveal⊑²` or `reveal⊑reveal²` | simulate `M→N` at the child relation, then replay the source reveal wrapper | no child `sim` result is available |
+| `target-reveal-frame` | arbitrary source step `M→N` under target-only `⊑reveal²` | simulate `M→N`, lift the target trace with `reveal-↠ c′`, rebuild target reveal relation | no child `sim` result is available |
+| `source-conceal-frame` | `ξ-conceal M→N _` under `conceal⊑²` or `conceal⊑conceal²` | simulate `M→N` at the child relation, then replay the source conceal wrapper | no child `sim` result is available |
+| `target-conceal-frame` | arbitrary source step `M→N` under target-only `⊑conceal²` | simulate `M→N`, lift the target trace with `conceal-↠ c′`, rebuild target conceal relation | no child `sim` result is available |
+
+Blocking details
+----------------
+
+For `source-reveal-frame`, inversion of the relation can expose a child
+relation:
+
+```agda
+Wᵖ ∣ [] ⊢² M ⊑ M′ ∶ p
+```
+
+and the source frame step exposes a child reduction:
+
+```agda
+M —→[ χᴸ ] N
+```
+
+The requested result needs a relation for the reduct:
+
+```agda
+W′ ∣ [] ⊢² N ⊑ N′ ∶ r
+```
+
+That is precisely the recursive simulation theorem.  The checked replay
+helpers (`structural-reveal-replay`, `structural-conceal-replay`) only rewrap a
+relation after it already exists; they do not produce the child simulation
+result.  The target-only reveal/conceal fields have the same issue, with the
+additional need to lift the target trace using `reveal-↠` or `conceal-↠`.
+
+Completing this interface requires either threading a recursive `Simᵀ` through
+`SimConversionFramesᵀ`, or adding a separate child-step simulation package with
+the same strength.  I did not change the protected `Sim*Def` statements.

--- a/GTSFImp/proof/DGG/notes/t2-paired-cast-values-blocked.red
+++ b/GTSFImp/proof/DGG/notes/t2-paired-cast-values-blocked.red
@@ -1,0 +1,54 @@
+# T2 blocker: `SimPairedCastValuesᵀ`
+
+Date: 2026-08-17
+
+Status: blocked.
+
+The paired ordinary-cast value interface has the same source-side blockers as
+`SimSourceCastValuesᵀ`, with the additional obligation of preserving the
+target cast wrapper at the endpoint.
+
+Case table
+----------
+
+| source step for `V ⟨ c ⟩` | relation head at call site | intended response | status |
+| --- | --- | --- | --- |
+| `pure-step (β-id vV)` | `cast⊑cast²` | no target steps; endpoint `V′ ⟨ c′ ⟩`; rebuild with `⊑cast² c′` over the transported body relation | direct |
+| `pure-step (ground vV A≢G)` | `cast⊑cast²` | no target steps; rebuild source ground reduct against `V′ ⟨ c′ ⟩` | blocked |
+| `pure-step (expand vV G≢B)` | `cast⊑cast²` | no target steps; rebuild source expand reduct against `V′ ⟨ c′ ⟩` | blocked |
+| `pure-step (tag-untag vV)` | `cast⊑cast²` | no target steps; peel the source tag/project layers, then rewrap the target cast | blocked |
+| `β-inst vV B≢★` | `cast⊑cast²` | source left-bind step; relate the opened/revealed/cast source reduct to a target cast endpoint | blocked |
+| source blame rows | `cast⊑cast²` | handled by `SimProof` before this interface is called | not part of this closing proof |
+| `ξ-⟨⟩` | `cast⊑cast²` | handled recursively by `SimProof`, not by this value interface | not part of this closing proof |
+
+Blocking details
+----------------
+
+The direct `β-id` row is just the paired analogue of the source-only direct
+row:
+
+```agda
+W ∣ [] ⊢² V ⊑ V′ ∶ p
+--------------------------------
+W ∣ [] ⊢² V ⊑ V′ ⟨ c′ ⟩ ∶ q
+```
+
+after transporting the body endpoint and applying `⊑cast² c′`.
+
+The remaining source administration rows require the same source-side
+ground/expand/tag-untag inversions described in
+`t2-source-cast-values-blocked.red`.  The paired endpoint then additionally
+requires rebuilding through the target-side cast wrapper.  No current live
+surface derives the needed source-core relation first, and building the target
+wrapper without that core would synthesize an unearned midpoint.
+
+The `β-inst` row is again the strongest blocker: it requires a source-left
+allocation inversion/replay for
+
+```agda
+V ⟨ inst c B≢★ ⟩ —→[ bind ★ ] ...
+```
+
+and then a target-cast endpoint relation after the left-only world change.
+The checked M5/M6 structural instantiation surfaces operate on target
+allocation/head peeling and do not expose this source-left value-step family.

--- a/GTSFImp/proof/DGG/notes/t2-paired-reveal-values-blocked.red
+++ b/GTSFImp/proof/DGG/notes/t2-paired-reveal-values-blocked.red
@@ -1,0 +1,40 @@
+# T2 blocker: `SimPairedRevealValuesᵀ`
+
+Date: 2026-08-17
+
+Status: blocked.
+
+The paired reveal value interface is blocked on the same source-conceal peel
+as the source-only reveal interface, plus endpoint rebuilding through the target
+reveal wrapper.
+
+Case table
+----------
+
+| source step for `V ↑ c` | conversion/relation shape | intended response | status |
+| --- | --- | --- | --- |
+| `pure-step (id-reveal vV)` | paired source conversion is indexed by `just Xᴸ` | refute: `id↑` only has `⊢↑[ nothing ]` | refutable |
+| `pure-step (conceal-reveal vV)` | `V = V₀ ↓ seal Xᴸ R`, `c = unseal Xᴸ R` | catch target body to `V′`, lift the target trace with `reveal-↠ c′`, peel source conceal, then rebuild the target reveal relation | blocked |
+| `pure-step blame-reveal` | source body would be `blame` | impossible because the interface receives `Value V` | refutable |
+| `ξ-reveal step _` | inner body step | impossible because the interface receives `Value V` | refutable |
+
+Blocking details
+----------------
+
+The caught endpoint for the only live source root has the same problematic
+source shape as in `t2-source-reveal-values-blocked.red`:
+
+```agda
+Wᵖ′ ∣ [] ⊢² (V₀ ↓ seal Xᴸ R) ⊑ V′ ∶ p′
+```
+
+The paired result additionally needs the target endpoint
+
+```agda
+V′ ↑ applyReveals χsᴿ c′
+```
+
+using `reveal-↠ c′` on the caught target trace and a rebuilt
+`reveal⊑reveal²`/target-reveal relation at the evolved world.  The existing
+structural target conversion typing transport can type the evolved `c′`, but
+it does not provide the missing source-conceal peel of the caught relation.

--- a/GTSFImp/proof/DGG/notes/t2-source-cast-values-blocked.red
+++ b/GTSFImp/proof/DGG/notes/t2-source-cast-values-blocked.red
@@ -1,0 +1,69 @@
+# T2 blocker: `SimSourceCastValuesᵀ`
+
+Date: 2026-08-17
+
+Status: blocked.
+
+The direct source-only ordinary-cast value interface cannot be completed from
+the currently exported source-side inversion surfaces.  The easy rows are
+clear, but the interface is total over all source cast administration steps.
+
+Case table
+----------
+
+| source step for `V ⟨ c ⟩` | relation head at call site | intended response | status |
+| --- | --- | --- | --- |
+| `pure-step (β-id vV)` | `cast⊑²` | no target steps; return `V′`; transport the caught relation from `p` to `q` by imprecision uniqueness | direct |
+| `pure-step (ground vV A≢G)` | `cast⊑²` | no target steps; rebuild source reduct `(V ⟨ cG ⟩) ⟨ tag G ⟩` against `V′` | blocked |
+| `pure-step (expand vV G≢B)` | `cast⊑²` | no target steps; rebuild source reduct `(V ⟨ proj G ⟩) ⟨ cB ⟩` against `V′` | blocked |
+| `pure-step (tag-untag vV)` | `cast⊑²` | no target steps; peel the source tag/project layers and return the core relation on `V` | blocked |
+| `β-inst vV B≢★` | `cast⊑²` | source left-bind step; relate the opened/revealed/cast reduct under `leftOnlyWorld X⊑★` | blocked |
+| source blame rows | `cast⊑²` | handled by `SimProof` before this interface is called | not part of this closing proof |
+| `ξ-⟨⟩` | `cast⊑²` | handled recursively by `SimProof`, not by this value interface | not part of this closing proof |
+
+Blocking details
+----------------
+
+The ground/expand rows need a source-side midpoint derived from the given
+relation and the cast shape, not synthesized.  For example, the ground row
+needs the source reduct relation
+
+```agda
+W ∣ [] ⊢² (V ⟨ cG ⟩) ⟨ tag G ⟩ ⊑ V′ ∶ q
+```
+
+from
+
+```agda
+W ∣ [] ⊢² V ⊑ V′ ∶ p
+```
+
+and the source-side `A ∼ G`/`G ∼ ★` cast evidence.  Existing live helpers such
+as `target-ground-cast-witness` and the generated-projection replacement
+lemmas are target-cast inversions; they do not provide this source-side
+rebuild.
+
+The `tag-untag` row must invert relation layers on the source:
+
+```agda
+W ∣ [] ⊢² (V ⟨ tag G ⟩) ⟨ proj G ⟩ ⊑ V′ ∶ q
+```
+
+to recover a relation on `V`.  The available checked inversion peels the
+corresponding target-side projection shape.  Reusing it here would amount to
+inventing a refuted-midpoint witness instead of deriving it from the relation
+layers.
+
+The `β-inst` row is a stronger blocker.  The source step allocates on the left:
+
+```agda
+V ⟨ inst c B≢★ ⟩ —→[ bind ★ ]
+  ⇑ᵗᵐ V ⦂∀ (bind ★ ▷ᵇ A) [ ＇ 0 ] ↑ 〖 0 , ★ ↑ A 〗
+    ⟨ ↑ᶜ (c [ ★/0 ]ᶜ) ⟩
+```
+
+Completing this row needs a source-left instantiation inversion/replay surface
+that transports the original value relation into the left-only allocated world
+and through the generated reveal/cast tail.  The existing structural
+instantiation machinery is for target allocation and target-head peeling, not
+this source-left value step.

--- a/GTSFImp/proof/DGG/notes/t2-source-reveal-values-blocked.red
+++ b/GTSFImp/proof/DGG/notes/t2-source-reveal-values-blocked.red
@@ -1,0 +1,44 @@
+# T2 blocker: `SimSourceRevealValuesᵀ`
+
+Date: 2026-08-17
+
+Status: blocked.
+
+The source-only reveal value interface has one direct row and one missing
+source-conceal peel row.
+
+Case table
+----------
+
+| source step for `V ↑ c` | conversion/relation shape | intended response | status |
+| --- | --- | --- | --- |
+| `pure-step (id-reveal vV)` | `c = id↑ A`, `⊢↑-idˣ`, `rebase-idᴸ` | no target steps beyond the supplied catchup; return the caught relation at the source-reveal boundary | direct |
+| `pure-step (conceal-reveal vV)` | `V = V₀ ↓ seal X R`, `c = unseal X R` | no target steps beyond catchup; peel the source conceal layer and relate `V₀` to the caught target value | blocked |
+| `pure-step blame-reveal` | source body would be `blame` | impossible because the interface receives `Value V` | refutable |
+| `ξ-reveal step _` | inner body step | impossible because the interface receives `Value V` | refutable |
+
+Blocking details
+----------------
+
+After catchup in the `conceal-reveal` row, the available endpoint has the
+shape
+
+```agda
+Wᵖ′ ∣ [] ⊢² (V₀ ↓ seal X R) ⊑ V′ ∶ p′
+```
+
+under a `boundary-source-reveal` endpoint.  The required result is instead
+
+```agda
+W′ ∣ [] ⊢² V₀ ⊑ V′ ∶ q′
+```
+
+for the source reduct.  This must be obtained by inverting the source-side
+`conceal⊑²` layer and reconciling the source reveal boundary with the inner
+source-conceal `TagRebaseAtᴸ` evidence.
+
+I found replay helpers such as `structural-reveal-replay` and
+`structural-conceal-replay`, but those rebuild wrappers once the child
+endpoint relation is already available.  They do not peel
+`V₀ ↓ seal X R` from a caught value relation, and the target-side reveal/conceal
+peels go in the opposite direction.


### PR DESCRIPTION
First green chunk of the left-side sim step family: `SimSourceConcealValuesProof` and `SimPairedConcealValuesProof` proven and wired into the --safe aggregate. The remaining five interfaces are case-tabled with recorded blockers (`notes/t2-*-blocked.red`) pending supervisor/user review of the required left-side lemma statements, per the major-lemma check-in rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)