### PR TITLE
T1: LG-3 assembly follow-on (items 1-3 of 9 done)

### DIFF
--- a/GTSFImp/proof/DGG/Catchup/ExtraCastRightAtProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/ExtraCastRightAtProof.agda
@@ -635,10 +635,6 @@ structural-id-extra-cast-right-at : ∀ {fuel Δᴸ Δᴿ Δ}
 structural-id-extra-cast-right-at a c′<fuel rel vM vM′ =
   structural-catchup-keep-step vM′ (pure-step (β-id vM′))
     (target-id-step-inversion a vM vM′ rel)
-    (source-conceal-partner-target-id-core a)
-    (source-conceal-partner-target-id-framed-core a)
-    (matched-conceal-partner-target-id-core a)
-    (matched-conceal-partner-target-id-framed-core a)
 
 
 structural-ground-extra-cast-right-at : ∀ {Δᴸ Δᴿ Δ}
@@ -664,10 +660,6 @@ structural-ground-extra-cast-right-at {W = W} {γ = γ}
   structural-catchup-prepend-keep
     (pure-step (ground ⦃ Gns = ground-nonstar Gᵍ ⦄ vM′ B≢G))
     reduct-rel
-    (source-conceal-partner-ground-step-core c B≢G)
-    (source-conceal-partner-ground-step-framed-core c)
-    (matched-conceal-partner-ground-step-core c B≢G)
-    (matched-conceal-partner-ground-step-framed-core c)
     combined
   where
   tag = _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (idᵍ Gᵍ)
@@ -746,10 +738,6 @@ structural-paired-ground-extra-cast-right-at {W = W} {γ = γ}
     cᴸ cᴿ smaller-extra ground-other-decrease B≢G vM vM′ inertᴸ rel =
   structural-catchup-prepend-keep-stutter
     (pure-step (ground ⦃ Gns = ground-nonstar Gᵍ ⦄ vM′ B≢G))
-    (source-conceal-partner-ground-step-core cᴿ B≢G)
-    (source-conceal-partner-ground-step-framed-core cᴿ)
-    (matched-conceal-partner-ground-step-core cᴿ B≢G)
-    (matched-conceal-partner-ground-step-framed-core cᴿ)
     after-ground
   where
   tag = _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (idᵍ Gᵍ)
@@ -819,10 +807,6 @@ structural-source-injection-ground-extra-cast-right-at
     cᴿ smaller-extra ground-other-decrease B≢G vM vM′ rel =
   structural-catchup-prepend-keep-stutter
     (pure-step (ground ⦃ Gns = ground-nonstar Gᵍ ⦄ vM′ B≢G))
-    (source-conceal-partner-ground-step-core cᴿ B≢G)
-    (source-conceal-partner-ground-step-framed-core cᴿ)
-    (matched-conceal-partner-ground-step-core cᴿ B≢G)
-    (matched-conceal-partner-ground-step-framed-core cᴿ)
     after-ground
   where
   Htag = _! ⦃ Hᵍ ⦄ ⦃ H∼★ ⦄ (idᵍ Hᵍ)
@@ -899,16 +883,6 @@ structural-project-same-extra-cast-right-at {W = W} {γ = γ}
       {A = A} {G = G} {μ = μ} {Gᵍ = Gᵍ}
       {G∼★ = G∼★} {p★ = p★}
       vM vN rel-tag qG)
-    (source-conceal-partner-projection-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-    (source-conceal-partner-projection-framed-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-    (matched-conceal-partner-projection-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-    (matched-conceal-partner-projection-framed-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-  where
-  proj = idᵍ {μ = ν} Gᵍ
 
 
 structural-paired-project-same-extra-cast-right-at : ∀ {Δᴸ Δᴿ Δ}
@@ -944,17 +918,7 @@ structural-paired-project-same-extra-cast-right-at {W = W} {γ = γ}
   structural-catchup-keep-step vN
     (pure-step (tag-untag ⦃ Gns = ground-nonstar Gᵍ ⦄ vN))
     (CTI2.cast⊑² cᴸ core q)
-    (source-conceal-partner-projection-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-    (source-conceal-partner-projection-framed-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-    (matched-conceal-partner-projection-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
-    (matched-conceal-partner-projection-framed-core
-      ⦃ Bns = ground-nonstar Gᵍ ⦄ proj)
   where
-  proj = idᵍ Gᵍ
-
   core : W ∣ γ ⊢² M ⊑ N ∶ qG
   core =
     exposed-project-same-step-inversion-⊑cast²
@@ -997,10 +961,6 @@ structural-project-expand-extra-cast-right-at {W = W} {γ = γ}
     (pure-step (expand ⦃ Gns = ground-nonstar Gᵍ ⦄
       (vN 《 inj ⦃ Gns = ground-nonstar Gᵍ ⦄ 》) G≢B))
     reduct-rel
-    (source-conceal-partner-projection-core c)
-    (source-conceal-partner-projection-framed-core c)
-    (matched-conceal-partner-projection-core c)
-    (matched-conceal-partner-projection-framed-core c)
     combined
   where
   tag = _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (idᵍ {μ = μ} Gᵍ)
@@ -1092,10 +1052,6 @@ structural-paired-project-expand-extra-cast-right-at {W = W} {γ = γ}
   structural-catchup-prepend-keep-stutter
     (pure-step (expand ⦃ Gns = ground-nonstar Gᵍ ⦄
       (vN 《 inj ⦃ Gns = ground-nonstar Gᵍ ⦄ 》) G≢B))
-    (source-conceal-partner-projection-core cᴿ)
-    (source-conceal-partner-projection-framed-core cᴿ)
-    (matched-conceal-partner-projection-core cᴿ)
-    (matched-conceal-partner-projection-framed-core cᴿ)
     after-expand
   where
   tag = _! ⦃ Gᵍ ⦄ ⦃ G∼★ ⦄ (idᵍ {μ = μ} Gᵍ)
@@ -1131,16 +1087,6 @@ structural-paired-project-expand-extra-cast-right-at {W = W} {γ = γ}
         (pure-step
           (tag-untag ⦃ Gns = ground-nonstar Gᵍ ⦄ vN))
         refl)
-      (source-conceal-partner-projection-framed-core
-        ⦃ Bns = ground-nonstar Gᵍ ⦄ proj-core cᴿ)
-      (λ d →
-        source-conceal-partner-projection-double-framed-core
-          ⦃ Bns = ground-nonstar Gᵍ ⦄ proj-core cᴿ d)
-      (matched-conceal-partner-projection-framed-core
-        ⦃ Bns = ground-nonstar Gᵍ ⦄ proj-core cᴿ)
-      (λ d →
-        matched-conceal-partner-projection-double-framed-core
-          ⦃ Bns = ground-nonstar Gᵍ ⦄ proj-core cᴿ d)
       residual
 
 

--- a/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
@@ -86,48 +86,6 @@ record StructuralCatchupRightResult {Δᴸ Δᴿ Δ}
       W′ ∣ ECR.mapCtxᴿ (structural-world-extendᴿ structural-ext) γ
         ⊢² M ⊑ N′ ∶
           ECR.transport⊑ᵂ (structural-world-extendᴿ structural-ext) q
-    source-conceal-endpoint-partner : ∀ {Δ₀ Δ₀′}
-        {W₀ : World Δᴸ Δᴿ Δ₀}
-        {W₀′ : World Δᴸ Δᴿ′ Δ₀′}
-      → StructuralWorldExtendᴿ χs W₀ W₀′
-      → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-          {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.SourceConcealPartnerOK W₀′ P c
-          (mapPivotChanges χs Xᴿ?) N′
-    source-conceal-endpoint-partner-target-cast : ∀ {Δ₀ Δ₀′}
-        {W₀ : World Δᴸ Δᴿ Δ₀}
-        {W₀′ : World Δᴸ Δᴿ′ Δ₀′}
-      → StructuralWorldExtendᴿ χs W₀ W₀′
-      → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-          {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-          {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.SourceConcealPartnerOK W₀′ P c₀
-          (mapPivotChanges χs Xᴿ?)
-          (N′ ⟨ applyConsistencies χs c′ ⟩)
-    matched-conceal-endpoint-partner : ∀ {Δ₀ Δ₀′}
-        {W₀ : World Δᴸ Δᴿ Δ₀}
-        {W₀′ : World Δᴸ Δᴿ′ Δ₀′}
-      → StructuralWorldExtendᴿ χs W₀ W₀′
-      → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-          {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.MatchedConcealPartnerOK W₀′ P c
-          (mapPivotChanges χs Xᴿ?) N′
-    matched-conceal-endpoint-partner-target-cast : ∀ {Δ₀ Δ₀′}
-        {W₀ : World Δᴸ Δᴿ Δ₀}
-        {W₀′ : World Δᴸ Δᴿ′ Δ₀′}
-      → StructuralWorldExtendᴿ χs W₀ W₀′
-      → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-          {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-          {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.MatchedConcealPartnerOK W₀′ P c₀
-          (mapPivotChanges χs Xᴿ?)
-          (N′ ⟨ applyConsistencies χs c′ ⟩)
 
 
 StructuralCatchupRightPayload : ∀ {Δᴸ Δᴿ Δ}
@@ -797,12 +755,6 @@ structural-catchup-refl {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
     ; final-relation =
         subst≡ (λ γ′ → W ∣ γ′ ⊢² M ⊑ N′ ∶ q)
           (sym (ECR.mapCtxᴿ-same γ)) rel
-    ; source-conceal-endpoint-partner = structural-partner-refl
-    ; source-conceal-endpoint-partner-target-cast =
-        structural-partner-target-cast-refl
-    ; matched-conceal-endpoint-partner = structural-matched-partner-refl
-    ; matched-conceal-endpoint-partner-target-cast =
-        structural-matched-partner-target-cast-refl
     }
 
 
@@ -814,35 +766,10 @@ structural-catchup-keep-step : ∀ {Δᴸ Δᴿ Δ}
   → Value N′
   → M″ —→[ keep ] N′
   → W ∣ γ ⊢² M ⊑ N′ ∶ q
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? N′)
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (N′ ⟨ c′ ⟩))
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? N′)
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (N′ ⟨ c′ ⟩))
   → StructuralCatchupRightResult W γ M M″ q
 structural-catchup-keep-step {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
     {M = M} {M″ = M″} {N′ = N′} {q = q}
-    vN′ step rel partner-step partner-step-target-cast
-    matched-step matched-step-target-cast =
+    vN′ step rel =
   record
     { Δᴿ′ = Δᴿ
     ; χs = keep ∷ []
@@ -857,15 +784,6 @@ structural-catchup-keep-step {Δᴿ = Δᴿ} {Δ = Δ} {W = W} {γ = γ}
     ; final-relation =
         subst≡ (λ γ′ → W ∣ γ′ ⊢² M ⊑ N′ ∶ q)
           (sym (ECR.mapCtxᴿ-keep γ)) rel
-    ; source-conceal-endpoint-partner =
-        structural-partner-keep-step partner-step
-    ; source-conceal-endpoint-partner-target-cast =
-        structural-partner-keep-step-target-cast partner-step-target-cast
-    ; matched-conceal-endpoint-partner =
-        structural-matched-partner-keep-step matched-step
-    ; matched-conceal-endpoint-partner-target-cast =
-        structural-matched-partner-keep-step-target-cast
-          matched-step-target-cast
     }
 
 
@@ -875,37 +793,12 @@ structural-catchup-prepend-keep-stutter : ∀ {Δᴸ Δᴿ Δ}
     {A : Ty Δᴸ} {B : Ty Δᴿ}
     {q : A ⊑ᵂ⟨ W ⟩ B}
   → M″ —→[ keep ] M₁
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M₁)
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M₁ ⟨ c′ ⟩))
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M₁)
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M₁ ⟨ c′ ⟩))
   → StructuralCatchupRightResult W γ M M₁ q
   → StructuralCatchupRightResult W γ M M″ q
 structural-catchup-prepend-keep-stutter
     {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {γ = γ}
     {M″ = M″} {M₁ = M₁} {q = q}
-    step partner-step partner-step-target-cast
-    matched-step matched-step-target-cast result =
+    step result =
   record
     { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ result
     ; χs = keep ∷ StructuralCatchupRightResult.χs result
@@ -932,93 +825,11 @@ structural-catchup-prepend-keep-stutter
           (sym (mapCtxᴿ-structural-keep
             (StructuralCatchupRightResult.structural-ext result) γ))
           (StructuralCatchupRightResult.final-relation result)
-    ; source-conceal-endpoint-partner = partner-endpoint
-    ; source-conceal-endpoint-partner-target-cast =
-        partner-endpoint-target-cast
-    ; matched-conceal-endpoint-partner = matched-endpoint
-    ; matched-conceal-endpoint-partner-target-cast =
-        matched-endpoint-target-cast
     }
   where
   χs = StructuralCatchupRightResult.χs result
   tail = StructuralCatchupRightResult.post-reduction result
   N′ = StructuralCatchupRightResult.N′ result
-
-  partner-endpoint : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result) Δ₀′}
-    → StructuralWorldExtendᴿ
-        (keep ∷ StructuralCatchupRightResult.χs result) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M″
-    → CTI2.SourceConcealPartnerOK W₀′ P c
-        (mapPivotChanges
-          (keep ∷ StructuralCatchupRightResult.χs result) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result)
-  partner-endpoint (structural-keep plan) ok =
-    StructuralCatchupRightResult.source-conceal-endpoint-partner
-      result plan (partner-step ok)
-
-  partner-endpoint-target-cast : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result) Δ₀′}
-    → StructuralWorldExtendᴿ
-        (keep ∷ StructuralCatchupRightResult.χs result) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-        {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-    → (c′ : ν ⊢ B₀ ∼ B)
-    → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-    → CTI2.SourceConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges
-          (keep ∷ StructuralCatchupRightResult.χs result) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result
-          ⟨ applyConsistencies
-            (keep ∷ StructuralCatchupRightResult.χs result) c′ ⟩)
-  partner-endpoint-target-cast (structural-keep plan) c′ ok =
-    StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-      result plan c′ (partner-step-target-cast c′ ok)
-
-  matched-endpoint : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result) Δ₀′}
-    → StructuralWorldExtendᴿ
-        (keep ∷ StructuralCatchupRightResult.χs result) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M″
-    → CTI2.MatchedConcealPartnerOK W₀′ P c
-        (mapPivotChanges
-          (keep ∷ StructuralCatchupRightResult.χs result) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result)
-  matched-endpoint (structural-keep plan) ok =
-    StructuralCatchupRightResult.matched-conceal-endpoint-partner
-      result plan (matched-step ok)
-
-  matched-endpoint-target-cast : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result) Δ₀′}
-    → StructuralWorldExtendᴿ
-        (keep ∷ StructuralCatchupRightResult.χs result) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-        {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-    → (c′ : ν ⊢ B₀ ∼ B)
-    → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-    → CTI2.MatchedConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges
-          (keep ∷ StructuralCatchupRightResult.χs result) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result
-          ⟨ applyConsistencies
-            (keep ∷ StructuralCatchupRightResult.χs result) c′ ⟩)
-  matched-endpoint-target-cast (structural-keep plan) c′ ok =
-    StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-      result plan c′ (matched-step-target-cast c′ ok)
 
 
 structural-catchup-prepend-keep : ∀ {Δᴸ Δᴿ Δ}
@@ -1028,30 +839,6 @@ structural-catchup-prepend-keep : ∀ {Δᴸ Δᴿ Δ}
     {q : A ⊑ᵂ⟨ W ⟩ B}
   → M″ —→[ keep ] M₁
   → W ∣ γ ⊢² M ⊑ M₁ ∶ q
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M₁)
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M₁ ⟨ c′ ⟩))
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M″
-      → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M₁)
-  → (∀ {Δ₀} {W₀ : World Δᴸ Δᴿ Δ₀}
-      {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      {B₀ B : Ty Δᴿ} {ν : Env∼ Δᴿ}
-      → (c′ : ν ⊢ B₀ ∼ B)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M₁ ⟨ c′ ⟩))
   → StructuralCatchupRightResult W γ M M₁ q
   → StructuralCatchupRightResult W γ M M″ q
 structural-catchup-prepend-keep step rel₁ =
@@ -1082,16 +869,6 @@ structural-catchup-source-cast {q = q} c result = record
           (structural-world-extendᴿ
             (StructuralCatchupRightResult.structural-ext result))
           q)
-  ; source-conceal-endpoint-partner =
-      StructuralCatchupRightResult.source-conceal-endpoint-partner result
-  ; source-conceal-endpoint-partner-target-cast =
-      StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-        result
-  ; matched-conceal-endpoint-partner =
-      StructuralCatchupRightResult.matched-conceal-endpoint-partner result
-  ; matched-conceal-endpoint-partner-target-cast =
-      StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-        result
   }
 
 
@@ -1103,25 +880,9 @@ structural-catchup-target-inert-cast : ∀ {Δᴸ Δᴿ Δ}
   → (c′ : ν ⊢ B ∼ B′)
   → Inert c′
   → (result : StructuralCatchupRightResult W γ M M″ p)
-  → (∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result) Δ₀′}
-      → StructuralWorldExtendᴿ
-          (StructuralCatchupRightResult.χs result) W₀ W₀′
-      → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-      {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-      → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M″ ⟨ c′ ⟩)
-      → CTI2.SourceConcealPartnerOK
-          W₀′
-          P c₀
-          (mapPivotChanges (StructuralCatchupRightResult.χs result) Xᴿ?)
-          (StructuralCatchupRightResult.N′ result
-            ⟨ applyConsistencies
-              (StructuralCatchupRightResult.χs result) c′ ⟩))
   → StructuralCatchupRightResult W γ M (M″ ⟨ c′ ⟩) q
 structural-catchup-target-inert-cast {q = q}
-    c′ inert result partner-endpoint = record
+    c′ inert result = record
   { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ result
   ; χs = StructuralCatchupRightResult.χs result
   ; Δ′ = StructuralCatchupRightResult.Δ′ result
@@ -1143,17 +904,6 @@ structural-catchup-target-inert-cast {q = q}
           (structural-world-extendᴿ
             (StructuralCatchupRightResult.structural-ext result))
           q)
-  ; source-conceal-endpoint-partner = partner-endpoint
-  ; source-conceal-endpoint-partner-target-cast =
-      λ plan d′ ok →
-        structural-source-partner-nested-target-cast plan c′ d′ ok
-  ; matched-conceal-endpoint-partner =
-      λ plan ok →
-        StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-          result plan c′ ok
-  ; matched-conceal-endpoint-partner-target-cast =
-      λ plan d′ ok →
-        structural-matched-partner-nested-target-cast plan c′ d′ ok
   }
 
 
@@ -1197,16 +947,6 @@ structural-catchup-source-reveal {γ = γ} {q = q}
           (structural-source-reveal plan c⊢)
           (StructuralCatchupRightResult.final-relation child)
           (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
-    ; source-conceal-endpoint-partner =
-        StructuralCatchupRightResult.source-conceal-endpoint-partner child
-    ; source-conceal-endpoint-partner-target-cast =
-        StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-          child
-    ; matched-conceal-endpoint-partner =
-        StructuralCatchupRightResult.matched-conceal-endpoint-partner child
-    ; matched-conceal-endpoint-partner-target-cast =
-        StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-          child
     }
 
 
@@ -1224,14 +964,16 @@ structural-catchup-source-conceal : ∀ {Δᴸ Δᴿ Δ}
   → CTI2.sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c
   → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
   → CTI2.SourceConcealPartnerOK
-      Wᵖ M c Xᴿ? M′
+      (StructuralCatchupRightResult.W′ child) M c
+      (mapPivotChanges (StructuralCatchupRightResult.χs child) Xᴿ?)
+      (StructuralCatchupRightResult.N′ child)
   → StructuralCatchupRightResult W γ (M ↓ c) M′ q
 structural-catchup-source-conceal {γ = γ} {q = q}
-    mono rb sc c⊢ child partner
+    mono rb sc c⊢ child endpoint-partner
     with structural-tag-rebase-atᴸ-pullback
       (StructuralCatchupRightResult.structural-ext child) rb
 structural-catchup-source-conceal {γ = γ} {q = q}
-    mono rb sc c⊢ child partner
+    mono rb sc c⊢ child endpoint-partner
     | record { W′ = W′ ; outer-plan = plan
              ; post-rebase = rb′ ; post-mono = mono′ } =
   record
@@ -1245,9 +987,7 @@ structural-catchup-source-conceal {γ = γ} {q = q}
     ; post-reduction = StructuralCatchupRightResult.post-reduction child
     ; final-relation =
         CTI2.conceal⊑²
-          (StructuralCatchupRightResult.source-conceal-endpoint-partner
-            child (StructuralCatchupRightResult.structural-ext child)
-            partner)
+          endpoint-partner
           (mono′ mono) rb′
           (mapCtxᴿ-sameCtx
             (structural-world-extendᴿ plan)
@@ -1257,16 +997,6 @@ structural-catchup-source-conceal {γ = γ} {q = q}
           (structural-source-conceal plan c⊢)
           (StructuralCatchupRightResult.final-relation child)
           (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
-    ; source-conceal-endpoint-partner =
-        StructuralCatchupRightResult.source-conceal-endpoint-partner child
-    ; source-conceal-endpoint-partner-target-cast =
-        StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-          child
-    ; matched-conceal-endpoint-partner =
-        StructuralCatchupRightResult.matched-conceal-endpoint-partner child
-    ; matched-conceal-endpoint-partner-target-cast =
-        StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-          child
     }
 
 
@@ -1314,12 +1044,6 @@ structural-catchup-compose {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {γ = γ}
               (ECR.transport⊑ᵂ ext₂
                 (ECR.transport⊑ᵂ ext₁ q))
               (StructuralCatchupRightResult.final-relation result₂)))
-    ; source-conceal-endpoint-partner = partner-compose
-    ; source-conceal-endpoint-partner-target-cast =
-        partner-compose-target-cast
-    ; matched-conceal-endpoint-partner = matched-compose
-    ; matched-conceal-endpoint-partner-target-cast =
-        matched-compose-target-cast
     }
   where
   χs₁ = StructuralCatchupRightResult.χs result₁
@@ -1329,130 +1053,6 @@ structural-catchup-compose {Δᴸ = Δᴸ} {Δᴿ = Δᴿ} {γ = γ}
   ext₁ = structural-world-extendᴿ plan₁
   ext₂ = structural-world-extendᴿ plan₂
   ext = structural-world-extendᴿ (composeStructuralWorldExtendᴿ plan₁ plan₂)
-
-  partner-compose : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result₂) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M₀
-    → CTI2.SourceConcealPartnerOK W₀′ P c
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result₂)
-  partner-compose {W₀′ = W₀′} plan
-      {P = P} {c = c} {Xᴿ? = Xᴿ?} ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  partner-compose {W₀′ = W₀′} plan
-      {P = P} {c = c} {Xᴿ? = Xᴿ?} ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.SourceConcealPartnerOK W₀′ P c pivot
-        (StructuralCatchupRightResult.N′ result₂))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (StructuralCatchupRightResult.source-conceal-endpoint-partner
-        result₂ suffix
-        (StructuralCatchupRightResult.source-conceal-endpoint-partner
-          result₁ prefix ok))
-
-  partner-compose-target-cast : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result₂) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-        {C₀ C : Ty Δᴿ} {ν : Env∼ Δᴿ}
-    → (c′ : ν ⊢ C₀ ∼ C)
-    → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M₀ ⟨ c′ ⟩)
-    → CTI2.SourceConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result₂
-          ⟨ applyConsistencies (χs₁ ++χ χs₂) c′ ⟩)
-  partner-compose-target-cast {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} c′ ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  partner-compose-target-cast {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} c′ ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.SourceConcealPartnerOK W₀′ P c₀ pivot
-        (StructuralCatchupRightResult.N′ result₂
-          ⟨ applyConsistencies (χs₁ ++χ χs₂) c′ ⟩))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (subst≡
-        (λ target → CTI2.SourceConcealPartnerOK W₀′ P c₀
-          (mapPivotChanges χs₂ (mapPivotChanges χs₁ Xᴿ?))
-          target)
-        (cast-applyConsistencies-++ χs₁ χs₂ c′
-          (StructuralCatchupRightResult.N′ result₂))
-        (StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-          result₂ suffix (applyConsistencies χs₁ c′)
-          (StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-            result₁ prefix c′ ok)))
-
-  matched-compose : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result₂) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.MatchedConcealPartnerOK W₀ P c Xᴿ? M₀
-    → CTI2.MatchedConcealPartnerOK W₀′ P c
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result₂)
-  matched-compose {W₀′ = W₀′} plan
-      {P = P} {c = c} {Xᴿ? = Xᴿ?} ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  matched-compose {W₀′ = W₀′} plan
-      {P = P} {c = c} {Xᴿ? = Xᴿ?} ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.MatchedConcealPartnerOK W₀′ P c pivot
-        (StructuralCatchupRightResult.N′ result₂))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (StructuralCatchupRightResult.matched-conceal-endpoint-partner
-        result₂ suffix
-        (StructuralCatchupRightResult.matched-conceal-endpoint-partner
-          result₁ prefix ok))
-
-  matched-compose-target-cast : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ result₂) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-        {C₀ C : Ty Δᴿ} {ν : Env∼ Δᴿ}
-    → (c′ : ν ⊢ C₀ ∼ C)
-    → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M₀ ⟨ c′ ⟩)
-    → CTI2.MatchedConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ result₂
-          ⟨ applyConsistencies (χs₁ ++χ χs₂) c′ ⟩)
-  matched-compose-target-cast {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} c′ ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  matched-compose-target-cast {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} c′ ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.MatchedConcealPartnerOK W₀′ P c₀ pivot
-        (StructuralCatchupRightResult.N′ result₂
-          ⟨ applyConsistencies (χs₁ ++χ χs₂) c′ ⟩))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (subst≡
-        (λ target → CTI2.MatchedConcealPartnerOK W₀′ P c₀
-          (mapPivotChanges χs₂ (mapPivotChanges χs₁ Xᴿ?))
-          target)
-        (cast-applyConsistencies-++ χs₁ χs₂ c′
-          (StructuralCatchupRightResult.N′ result₂))
-        (StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-          result₂ suffix (applyConsistencies χs₁ c′)
-          (StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-            result₁ prefix c′ ok)))
 
 
 structural-catchup-compose-target-cast : ∀ {Δᴸ Δᴿ Δ}
@@ -1502,14 +1102,6 @@ structural-catchup-compose-target-cast {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
               (ECR.transport⊑ᵂ ext₂
                 (ECR.transport⊑ᵂ ext₁ q))
               (StructuralCatchupRightResult.final-relation residual)))
-    ; source-conceal-endpoint-partner = partner-endpoint
-    ; source-conceal-endpoint-partner-target-cast =
-        λ plan d′ ok →
-          structural-source-partner-nested-target-cast plan c′ d′ ok
-    ; matched-conceal-endpoint-partner = matched-endpoint
-    ; matched-conceal-endpoint-partner-target-cast =
-        λ plan d′ ok →
-          structural-matched-partner-nested-target-cast plan c′ d′ ok
     }
   where
   χs₁ = StructuralCatchupRightResult.χs child
@@ -1519,58 +1111,6 @@ structural-catchup-compose-target-cast {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
   ext₁ = structural-world-extendᴿ plan₁
   ext₂ = structural-world-extendᴿ plan₂
   ext = structural-world-extendᴿ (composeStructuralWorldExtendᴿ plan₁ plan₂)
-
-  partner-endpoint : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ residual) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M₀ ⟨ c′ ⟩)
-    → CTI2.SourceConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ residual)
-  partner-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  partner-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.SourceConcealPartnerOK W₀′ P c₀ pivot
-        (StructuralCatchupRightResult.N′ residual))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (StructuralCatchupRightResult.source-conceal-endpoint-partner
-        residual suffix
-        (StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-          child prefix c′ ok))
-
-  matched-endpoint : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ residual) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M₀ ⟨ c′ ⟩)
-    → CTI2.MatchedConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ residual)
-  matched-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  matched-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.MatchedConcealPartnerOK W₀′ P c₀ pivot
-        (StructuralCatchupRightResult.N′ residual))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (StructuralCatchupRightResult.matched-conceal-endpoint-partner
-        residual suffix
-        (StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-          child prefix c′ ok))
 
 
 structural-catchup-compose-paired-target-cast : ∀ {Δᴸ Δᴿ Δ}
@@ -1622,14 +1162,6 @@ structural-catchup-compose-paired-target-cast {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
               (ECR.transport⊑ᵂ ext₂
                 (ECR.transport⊑ᵂ ext₁ q))
               (StructuralCatchupRightResult.final-relation residual)))
-    ; source-conceal-endpoint-partner = partner-endpoint
-    ; source-conceal-endpoint-partner-target-cast =
-        λ plan d′ ok →
-          structural-source-partner-nested-target-cast plan c′ d′ ok
-    ; matched-conceal-endpoint-partner = matched-endpoint
-    ; matched-conceal-endpoint-partner-target-cast =
-        λ plan d′ ok →
-          structural-matched-partner-nested-target-cast plan c′ d′ ok
     }
   where
   χs₁ = StructuralCatchupRightResult.χs child
@@ -1639,58 +1171,6 @@ structural-catchup-compose-paired-target-cast {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
   ext₁ = structural-world-extendᴿ plan₁
   ext₂ = structural-world-extendᴿ plan₂
   ext = structural-world-extendᴿ (composeStructuralWorldExtendᴿ plan₁ plan₂)
-
-  partner-endpoint : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ residual) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.SourceConcealPartnerOK W₀ P c₀ Xᴿ? (M₀ ⟨ c′ ⟩)
-    → CTI2.SourceConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ residual)
-  partner-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  partner-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.SourceConcealPartnerOK W₀′ P c₀ pivot
-        (StructuralCatchupRightResult.N′ residual))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (StructuralCatchupRightResult.source-conceal-endpoint-partner
-        residual suffix
-        (StructuralCatchupRightResult.source-conceal-endpoint-partner-target-cast
-          child prefix c′ ok))
-
-  matched-endpoint : ∀ {Δ₀ Δ₀′}
-      {W₀ : World Δᴸ Δᴿ Δ₀}
-      {W₀′ : World Δᴸ
-        (StructuralCatchupRightResult.Δᴿ′ residual) Δ₀′}
-    → StructuralWorldExtendᴿ (χs₁ ++χ χs₂) W₀ W₀′
-    → ∀ {P : Term Δᴸ} {A₀ A₁ : Ty Δᴸ}
-        {c₀ : Conv↓ Δᴸ A₀ A₁} {Xᴿ?}
-    → CTI2.MatchedConcealPartnerOK W₀ P c₀ Xᴿ? (M₀ ⟨ c′ ⟩)
-    → CTI2.MatchedConcealPartnerOK W₀′ P c₀
-        (mapPivotChanges (χs₁ ++χ χs₂) Xᴿ?)
-        (StructuralCatchupRightResult.N′ residual)
-  matched-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      with splitStructuralWorldExtendᴿ χs₁ plan
-  matched-endpoint {W₀′ = W₀′} plan
-      {P = P} {c₀ = c₀} {Xᴿ? = Xᴿ?} ok
-      | record { prefix-plan = prefix ; suffix-plan = suffix } =
-    subst≡
-      (λ pivot → CTI2.MatchedConcealPartnerOK W₀′ P c₀ pivot
-        (StructuralCatchupRightResult.N′ residual))
-      (sym (mapPivotChanges-++ χs₁ χs₂ Xᴿ?))
-      (StructuralCatchupRightResult.matched-conceal-endpoint-partner
-        residual suffix
-        (StructuralCatchupRightResult.matched-conceal-endpoint-partner-target-cast
-          child prefix c′ ok))
 
 
 StructuralValueCatchupRight² : Set₁

--- a/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
@@ -1136,7 +1136,19 @@ structural-catchup-target-reveal : ∀ {Δᴸ Δᴿ Δ}
   → StructuralFrameOutcome
       (StructuralCatchupRightResult.N′ child
         ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
-  → (∀ {N₁}
+  → (∀ {Δᵒ}
+      {Wᵒ : World Δᴸ
+        (StructuralCatchupRightResult.Δᴿ′ child) Δᵒ}
+      {N₁}
+      → (plan : StructuralWorldExtendᴿ
+          (StructuralCatchupRightResult.χs child) W Wᵒ)
+      → Wᵒ ∣
+          ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+          ⊢² M ⊑
+            (StructuralCatchupRightResult.N′ child
+              ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
+            ∶ ECR.transport⊑ᵂ
+                (structural-world-extendᴿ plan) q
       → (StructuralCatchupRightResult.N′ child
            ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
           —→[ keep ] N₁
@@ -1175,9 +1187,26 @@ structural-catchup-target-reveal {γ = γ} {c′ = c′} {q = q}
     }
   where
   χs = StructuralCatchupRightResult.χs child
-structural-catchup-target-reveal
-    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont =
-  keep-cont step finalV
+structural-catchup-target-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont
+    with structural-rebase-atᴿ-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-target-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  keep-cont plan frame-rel step finalV
+  where
+  frame-rel =
+    CTI2.⊑reveal² (mono′ mono) rb′
+      (mapCtxᴿ-sameCtx
+        (structural-world-extendᴿ plan)
+        (structural-world-extendᴿ
+          (StructuralCatchupRightResult.structural-ext child))
+        sc)
+      (structural-target-reveal plan c′⊢)
+      (StructuralCatchupRightResult.final-relation child)
+      (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
 
 
 structural-catchup-target-conceal : ∀ {Δᴸ Δᴿ Δ}
@@ -1195,7 +1224,19 @@ structural-catchup-target-conceal : ∀ {Δᴸ Δᴿ Δ}
   → StructuralFrameOutcome
       (StructuralCatchupRightResult.N′ child
         ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
-  → (∀ {N₁}
+  → (∀ {Δᵒ}
+      {Wᵒ : World Δᴸ
+        (StructuralCatchupRightResult.Δᴿ′ child) Δᵒ}
+      {N₁}
+      → (plan : StructuralWorldExtendᴿ
+          (StructuralCatchupRightResult.χs child) W Wᵒ)
+      → Wᵒ ∣
+          ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+          ⊢² M ⊑
+            (StructuralCatchupRightResult.N′ child
+              ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
+            ∶ ECR.transport⊑ᵂ
+                (structural-world-extendᴿ plan) q
       → (StructuralCatchupRightResult.N′ child
            ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
           —→[ keep ] N₁
@@ -1234,9 +1275,26 @@ structural-catchup-target-conceal {γ = γ} {c′ = c′} {q = q}
     }
   where
   χs = StructuralCatchupRightResult.χs child
-structural-catchup-target-conceal
-    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont =
-  keep-cont step finalV
+structural-catchup-target-conceal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont
+    with structural-reverse-rebase-atᴿ-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-target-conceal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  keep-cont plan frame-rel step finalV
+  where
+  frame-rel =
+    CTI2.⊑conceal² (mono′ mono) rb′
+      (mapCtxᴿ-sameCtx
+        (structural-world-extendᴿ plan)
+        (structural-world-extendᴿ
+          (StructuralCatchupRightResult.structural-ext child))
+        sc)
+      (structural-target-conceal plan c′⊢)
+      (StructuralCatchupRightResult.final-relation child)
+      (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
 
 
 structural-catchup-paired-reveal : ∀ {Δᴸ Δᴿ Δ}
@@ -1257,6 +1315,17 @@ structural-catchup-paired-reveal : ∀ {Δᴸ Δᴿ Δ}
       (StructuralCatchupRightResult.N′ child
         ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
   → (∀ {N₁}
+      → ∀ {Δᵒ}
+      → {Wᵒ : World Δᴸ
+          (StructuralCatchupRightResult.Δᴿ′ child) Δᵒ}
+      → (plan : StructuralWorldExtendᴿ
+          (StructuralCatchupRightResult.χs child) W Wᵒ)
+      → Wᵒ ∣ ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+          ⊢² M ↑ c ⊑
+            (StructuralCatchupRightResult.N′ child
+              ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
+            ∶ ECR.transport⊑ᵂ
+                (structural-world-extendᴿ plan) q
       → (StructuralCatchupRightResult.N′ child
            ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
           —→[ keep ] N₁
@@ -1296,9 +1365,27 @@ structural-catchup-paired-reveal {γ = γ} {c′ = c′} {q = q}
     }
   where
   χs = StructuralCatchupRightResult.χs child
-structural-catchup-paired-reveal
-    mono rb sc c⊢ c′⊢ child (structural-frame-keep step finalV) keep-cont =
-  keep-cont step finalV
+structural-catchup-paired-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c⊢ c′⊢ child (structural-frame-keep step finalV) keep-cont
+    with structural-rebase-at-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-paired-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c⊢ c′⊢ child (structural-frame-keep step finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  keep-cont plan frame-rel step finalV
+  where
+  frame-rel =
+    CTI2.reveal⊑reveal² (mono′ mono) rb′
+      (mapCtxᴿ-sameCtx
+        (structural-world-extendᴿ plan)
+        (structural-world-extendᴿ
+          (StructuralCatchupRightResult.structural-ext child))
+        sc)
+      (structural-source-reveal plan c⊢)
+      (structural-target-reveal-just plan c′⊢)
+      (StructuralCatchupRightResult.final-relation child)
+      (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
 
 
 structural-catchup-paired-conceal : ∀ {Δᴸ Δᴿ Δ}
@@ -1323,6 +1410,17 @@ structural-catchup-paired-conceal : ∀ {Δᴸ Δᴿ Δ}
       (StructuralCatchupRightResult.N′ child
         ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
   → (∀ {N₁}
+      → ∀ {Δᵒ}
+      → {Wᵒ : World Δᴸ
+          (StructuralCatchupRightResult.Δᴿ′ child) Δᵒ}
+      → (plan : StructuralWorldExtendᴿ
+          (StructuralCatchupRightResult.χs child) W Wᵒ)
+      → Wᵒ ∣ ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+          ⊢² M ↓ c ⊑
+            (StructuralCatchupRightResult.N′ child
+              ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
+            ∶ ECR.transport⊑ᵂ
+                (structural-world-extendᴿ plan) q
       → (StructuralCatchupRightResult.N′ child
            ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
           —→[ keep ] N₁
@@ -1364,10 +1462,29 @@ structural-catchup-paired-conceal {γ = γ} {c′ = c′} {q = q}
     }
   where
   χs = StructuralCatchupRightResult.χs child
-structural-catchup-paired-conceal
+structural-catchup-paired-conceal {γ = γ} {c′ = c′} {q = q}
     child endpoint-partner mono rb sc c⊢ c′⊢
-    (structural-frame-keep step finalV) keep-cont =
-  keep-cont step finalV
+    (structural-frame-keep step finalV) keep-cont
+    with structural-reverse-rebase-at-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-paired-conceal {γ = γ} {c′ = c′} {q = q}
+    child endpoint-partner mono rb sc c⊢ c′⊢
+    (structural-frame-keep step finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  keep-cont plan frame-rel step finalV
+  where
+  frame-rel =
+    CTI2.conceal⊑conceal² endpoint-partner (mono′ mono) rb′
+      (mapCtxᴿ-sameCtx
+        (structural-world-extendᴿ plan)
+        (structural-world-extendᴿ
+          (StructuralCatchupRightResult.structural-ext child))
+        sc)
+      (structural-source-conceal plan c⊢)
+      (structural-target-conceal-just plan c′⊢)
+      (StructuralCatchupRightResult.final-relation child)
+      (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
 
 
 structural-catchup-packaged-seal-star : ∀ {Δᴸ Δᴿ Δ}
@@ -1405,6 +1522,20 @@ structural-catchup-packaged-seal-star : ∀ {Δᴸ Δᴿ Δ}
         ↓ seal
             (mapVarChanges (StructuralCatchupRightResult.χs child) Xᴿ) ★)
   → (∀ {N₁}
+      → ∀ {Δᵒ}
+      → {Wᵒ : World Δᴸ
+          (StructuralCatchupRightResult.Δᴿ′ child) Δᵒ}
+      → (plan : StructuralWorldExtendᴿ
+          (StructuralCatchupRightResult.χs child) W Wᵒ)
+      → Wᵒ ∣ ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+          ⊢² M ↓ seal Xᴸ ★ ⊑
+            (StructuralCatchupRightResult.N′ child
+              ↓ seal
+                  (mapVarChanges
+                    (StructuralCatchupRightResult.χs child) Xᴿ)
+                  ★)
+            ∶ ECR.transport⊑ᵂ
+                (structural-world-extendᴿ plan) q
       → (StructuralCatchupRightResult.N′ child
            ↓ seal
                (mapVarChanges (StructuralCatchupRightResult.χs child) Xᴿ)
@@ -1495,9 +1626,72 @@ structural-catchup-packaged-seal-star
       (applyTys-var χs Xᴿ)
       (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
 structural-catchup-packaged-seal-star
-    child endpoint-partner endpoint-source-rel mono rb sc c⊢ c′⊢
-    (structural-frame-keep step finalV) keep-cont =
-  keep-cont step finalV
+    {γ = γ} {γᵖ = γᵖ} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ}
+    {p★ = p★} {qᵖ = qᵖ} {q = q} child endpoint-partner
+    endpoint-source-rel mono rb sc c⊢ c′⊢
+    (structural-frame-keep step finalV) keep-cont
+    with structural-reverse-rebase-at-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-packaged-seal-star
+    {γ = γ} {γᵖ = γᵖ} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ}
+    {p★ = p★} {qᵖ = qᵖ} {q = q} child endpoint-partner
+    endpoint-source-rel mono rb sc c⊢ c′⊢
+    (structural-frame-keep step finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  keep-cont plan frame-rel step finalV
+  where
+  χs = StructuralCatchupRightResult.χs child
+  child-ext =
+    structural-world-extendᴿ
+      (StructuralCatchupRightResult.structural-ext child)
+  p★-packaged : ★ ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ ★
+  p★-packaged =
+    subst≡
+      (λ B → ★ ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ B)
+      (applyTys-★ χs)
+      (ECR.transport⊑ᵂ child-ext p★)
+  qᵖ-packaged :
+    (＇ Xᴸ) ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ ★
+  qᵖ-packaged =
+    subst≡
+      (λ B → (＇ Xᴸ) ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ B)
+      (applyTys-★ χs)
+      (ECR.transport⊑ᵂ child-ext qᵖ)
+  q-packaged :
+    (＇ Xᴸ) ⊑ᵂ⟨ W′ ⟩ (＇ mapVarChanges χs Xᴿ)
+  q-packaged =
+    subst≡
+      (λ B → (＇ Xᴸ) ⊑ᵂ⟨ W′ ⟩ B)
+      (applyTys-var χs Xᴿ)
+      (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+  frame-rel =
+    TBL.⊢²-retarget
+      {q = ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q}
+      (rel-target-transportᴿ
+        (sym (applyTys-var χs Xᴿ))
+        q-packaged
+        (CTI2.packaged-seal-star²
+          {p★ = p★-packaged} {qᵖ = qᵖ-packaged}
+          endpoint-partner (mono′ mono) rb′
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-source-conceal plan c⊢)
+          (structural-target-seal-star plan c′⊢)
+          (TBL.⊢²-retarget {q = p★-packaged}
+            (rel-target-transportᴿ
+              (applyTys-★ χs)
+              (ECR.transport⊑ᵂ child-ext p★)
+              (StructuralCatchupRightResult.final-relation child)))
+          (TBL.⊢²-retarget {q = qᵖ-packaged}
+            (rel-target-transportᴿ
+              (applyTys-★ χs)
+              (ECR.transport⊑ᵂ child-ext qᵖ)
+              endpoint-source-rel))
+          q-packaged))
 
 
 structural-catchup-compose : ∀ {Δᴸ Δᴿ Δ}

--- a/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
@@ -16,20 +16,22 @@ open import Relation.Binary.PropositionalEquality
   renaming (subst to subst≡)
 
 open import Types using
-  (Ty; TyCtx; TyVar; NonVar; _∈ᵗ_; ★; `∀; ⇑ᵗ; renameNonVar)
+  (Ty; TyCtx; TyVar; NonVar; _∈ᵗ_; ★; ＇_; `∀; ⇑ᵗ; renameNonVar)
 open import Consistency using
   (Env∼; _↪ᵗ_; _⊢_∼_; inst_; instᵐ; wk↪ᵗ; toRenameᵗ)
-open import Conversion using (Conv↑; Conv↓)
+open import Conversion using (Conv↑; Conv↓; seal)
 open import Imprecision using (X⊑★)
 open import CastTerms using
   (Term; Value; Inert; ⟨_,_,_⟩; _⊢_⦂_; Λ_; _⟨_⟩; _《_》; _↑_;
    _↓_; renameᵗᵐ)
 open import Reduction using (StoreChanges; []; _∷_; keep; _—→[_]_;
   _—↠[_]_; _—→[_]⟨_⟩_; _—↠[_]⟨_⟩_; _∎[]; bind;
-  applyConsistency; applyConsistencies; applyStores)
+  applyConsistency; applyConsistencies; applyStores; applyTys; ξ-conceal;
+  ↠-step)
 open import proof.Reduction using
   (cast-↠; applyConsistencies-Inert; _++χ_; applyTys-++;
-   cast-applyConsistencies-++; composeReduction)
+   applyTys-★; cast-applyConsistencies-++; composeReduction; reveal-↠;
+   conceal-↠; applyReveals; applyConceals)
 
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.TargetBindLift as TBL
@@ -44,7 +46,9 @@ open import proof.DGG.Catchup.StructuralWorldExtendProof
          structural-world-extendᴿ; composeStructuralWorldExtendᴿ;
          mapCtxᴿ-structural-compose; mapCtxᴿ-structural-keep)
 open import proof.DGG.Catchup.StructuralWorldRebaseProof using
-  (structural-rebase-atᴸ-pullback)
+  (structural-rebase-atᴸ-pullback; structural-rebase-atᴿ-pullback;
+   structural-rebase-at-pullback; structural-reverse-rebase-atᴿ-pullback;
+   structural-reverse-rebase-at-pullback)
 open import proof.DGG.Catchup.StructuralWorldTagRebaseDef
 open import proof.DGG.Catchup.StructuralWorldTagRebaseProof using
   (structural-tag-rebase-atᴸ-pullback)
@@ -52,7 +56,10 @@ open import proof.DGG.Catchup.StructuralWorldEvidenceProof using
   (mapCtxᴿ-sameCtx; mapCtxᴿ-liftCtxᴸ; mapCtxᴿ-smartLiftCtxᴸ;
    liftCtxᴸ-target-ctx; smartCommaLift-target-store;
    smartLiftCtxᴸ-target-ctx; structural-source-reveal;
-   structural-source-conceal)
+   structural-source-conceal; structural-target-reveal;
+   structural-target-conceal)
+open import proof.DGG.Catchup.StructuralFrameOutcomeDef using
+  (StructuralFrameOutcome; structural-frame-value; structural-frame-keep)
 open import proof.DGG.Catchup.StructuralWorldLiftLeftProof using
   (structural-lift-left)
 open import proof.DGG.Catchup.StructuralWorldSmartLiftDef
@@ -66,6 +73,120 @@ open import proof.DGG.Catchup.ValueCatchupRightDef using
 open import proof.TypeInTermSubst using (toRename-wk-eq)
 import proof.DGG.CastTermImprecision2Typing as CTI2T
 open CTI2 using (World; CtxImp; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+mapPivotChanges-just : ∀ {Δ Δ′}
+  → (χs : StoreChanges Δ Δ′)
+  → (X : TyVar Δ)
+  → mapPivotChanges χs (just X) ≡ just (mapVarChanges χs X)
+mapPivotChanges-just [] X = refl
+mapPivotChanges-just (keep ∷ χs) X =
+  mapPivotChanges-just χs X
+mapPivotChanges-just (bind A ∷ χs) X =
+  mapPivotChanges-just χs (toRenameᵗ wk↪ᵗ X)
+
+
+mapVarChanges-cong : ∀ {Δ Δ′}
+  → (χs : StoreChanges Δ Δ′)
+  → {X Y : TyVar Δ}
+  → X ≡ Y
+  → mapVarChanges χs X ≡ mapVarChanges χs Y
+mapVarChanges-cong χs refl = refl
+
+
+applyTys-var : ∀ {Δ Δ′}
+  → (χs : StoreChanges Δ Δ′)
+  → (X : TyVar Δ)
+  → applyTys χs (＇ X) ≡ ＇ mapVarChanges χs X
+applyTys-var [] X = refl
+applyTys-var (keep ∷ χs) X = applyTys-var χs X
+applyTys-var (bind A ∷ χs) X =
+  trans (applyTys-var χs (Fin.suc X))
+    (cong ＇_
+      (mapVarChanges-cong χs (sym (toRename-wk-eq X))))
+
+
+structural-target-reveal-just : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ}
+    {W′ : World Δᴸ Δᴿ′ Δ′}
+    {X : TyVar Δᴿ} {A B : Ty Δᴿ}
+    {c : Conv↑ Δᴿ A B}
+  → StructuralWorldExtendᴿ χs W W′
+  → CTI2.targetStoreʷ W CTI2.⊢↑[ just X ] c
+  → CTI2.targetStoreʷ W′ CTI2.⊢↑[ just (mapVarChanges χs X) ]
+      applyReveals χs c
+structural-target-reveal-just {χs = χs} {W′ = W′} {X = X} {c = c}
+    plan c⊢ =
+  subst≡
+    (λ pivot → CTI2.targetStoreʷ W′ CTI2.⊢↑[ pivot ]
+      applyReveals χs c)
+    (mapPivotChanges-just χs X)
+    (structural-target-reveal plan c⊢)
+
+
+structural-target-conceal-just : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ}
+    {W′ : World Δᴸ Δᴿ′ Δ′}
+    {X : TyVar Δᴿ} {A B : Ty Δᴿ}
+    {c : Conv↓ Δᴿ A B}
+  → StructuralWorldExtendᴿ χs W W′
+  → CTI2.targetStoreʷ W CTI2.⊢↓[ just X ] c
+  → CTI2.targetStoreʷ W′ CTI2.⊢↓[ just (mapVarChanges χs X) ]
+      applyConceals χs c
+structural-target-conceal-just {χs = χs} {W′ = W′} {X = X} {c = c}
+    plan c⊢ =
+  subst≡
+    (λ pivot → CTI2.targetStoreʷ W′ CTI2.⊢↓[ pivot ]
+      applyConceals χs c)
+    (mapPivotChanges-just χs X)
+    (structural-target-conceal plan c⊢)
+
+
+structural-target-seal-star : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ}
+    {W′ : World Δᴸ Δᴿ′ Δ′}
+    {X : TyVar Δᴿ}
+  → StructuralWorldExtendᴿ χs W W′
+  → CTI2.targetStoreʷ W CTI2.⊢↓[ just X ] seal X ★
+  → CTI2.targetStoreʷ W′ CTI2.⊢↓[ just (mapVarChanges χs X) ]
+      seal (mapVarChanges χs X) ★
+structural-target-seal-star structural-[] c⊢ = c⊢
+structural-target-seal-star (structural-keep plan) c⊢ =
+  structural-target-seal-star plan c⊢
+structural-target-seal-star {X = X}
+    (structural-bind {W₁ = W₁} ins follows plan) (CTI2.⊢↓-sealˣ X∈) =
+  structural-target-seal-star plan
+    (CTI2.⊢↓-sealˣ (TE.targetStore-rename ins X∈))
+
+
+conceal-seal-star-↠ : ∀ {Δ Δ′} {M : Term Δ} {N : Term Δ′}
+    {χs : StoreChanges Δ Δ′}
+  → (X : TyVar Δ)
+  → M —↠[ χs ] N
+  → M ↓ seal X ★ —↠[ χs ] N ↓ seal (mapVarChanges χs X) ★
+conceal-seal-star-↠ {M = M} X (_ ∎[]) = M ↓ seal X ★ ∎[]
+conceal-seal-star-↠ {M = M} {N = P} {χs = keep ∷ χs} X
+    (_ —→[ keep ]⟨ M→N ⟩ N↠P) =
+  M ↓ seal X ★
+    —→[ keep ]⟨ ξ-conceal M→N refl ⟩
+  _
+    —↠[ χs ]⟨ conceal-seal-star-↠ X N↠P ⟩
+  P ↓ seal (mapVarChanges χs X) ★ ∎[]
+conceal-seal-star-↠ {M = M} {N = P} {χs = bind A ∷ χs} X
+    (↠-step {N = N} M→N N↠P) =
+  M ↓ seal X ★
+    —→[ bind A ]⟨ ξ-conceal M→N refl ⟩
+  N ↓ seal (Fin.suc X) ★
+    —↠[ χs ]⟨
+      subst≡
+        (λ T → N ↓ seal (Fin.suc X) ★ —↠[ χs ] T)
+        (cong (λ Y → P ↓ seal Y ★)
+          (mapVarChanges-cong χs (sym (toRename-wk-eq X))))
+        (conceal-seal-star-↠ (Fin.suc X) N↠P) ⟩
+  P ↓ seal (mapVarChanges χs (toRenameᵗ wk↪ᵗ X)) ★ ∎[]
 
 
 record StructuralCatchupRightResult {Δᴸ Δᴿ Δ}
@@ -998,6 +1119,385 @@ structural-catchup-source-conceal {γ = γ} {q = q}
           (StructuralCatchupRightResult.final-relation child)
           (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
     }
+
+
+structural-catchup-target-reveal : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {c′ : Conv↑ Δᴿ B B′}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B} {q : A ⊑ᵂ⟨ W ⟩ B′}
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.RebaseAtᴿ W Wᵖ Xᴿ?)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.targetStoreʷ W CTI2.⊢↑[ Xᴿ? ] c′
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
+  → StructuralFrameOutcome
+      (StructuralCatchupRightResult.N′ child
+        ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
+  → (∀ {N₁}
+      → (StructuralCatchupRightResult.N′ child
+           ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
+          —→[ keep ] N₁
+      → Value N₁
+      → StructuralCatchupRightResult W γ M (M′ ↑ c′) q)
+  → StructuralCatchupRightResult W γ M (M′ ↑ c′) q
+structural-catchup-target-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-value finalV) keep-cont
+    with structural-rebase-atᴿ-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-target-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-value finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+        ↑ applyReveals χs c′
+    ; final-value = finalV
+    ; post-reduction =
+        reveal-↠ c′ (StructuralCatchupRightResult.post-reduction child)
+    ; final-relation =
+        CTI2.⊑reveal² (mono′ mono) rb′
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-target-reveal plan c′⊢)
+          (StructuralCatchupRightResult.final-relation child)
+          (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+    }
+  where
+  χs = StructuralCatchupRightResult.χs child
+structural-catchup-target-reveal
+    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont =
+  keep-cont step finalV
+
+
+structural-catchup-target-conceal : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {c′ : Conv↓ Δᴿ B B′}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B} {q : A ⊑ᵂ⟨ W ⟩ B′}
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.RebaseAtᴿ Wᵖ W Xᴿ?)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.targetStoreʷ W CTI2.⊢↓[ Xᴿ? ] c′
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
+  → StructuralFrameOutcome
+      (StructuralCatchupRightResult.N′ child
+        ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
+  → (∀ {N₁}
+      → (StructuralCatchupRightResult.N′ child
+           ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
+          —→[ keep ] N₁
+      → Value N₁
+      → StructuralCatchupRightResult W γ M (M′ ↓ c′) q)
+  → StructuralCatchupRightResult W γ M (M′ ↓ c′) q
+structural-catchup-target-conceal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-value finalV) keep-cont
+    with structural-reverse-rebase-atᴿ-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-target-conceal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c′⊢ child (structural-frame-value finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+        ↓ applyConceals χs c′
+    ; final-value = finalV
+    ; post-reduction =
+        conceal-↠ c′ (StructuralCatchupRightResult.post-reduction child)
+    ; final-relation =
+        CTI2.⊑conceal² (mono′ mono) rb′
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-target-conceal plan c′⊢)
+          (StructuralCatchupRightResult.final-relation child)
+          (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+    }
+  where
+  χs = StructuralCatchupRightResult.χs child
+structural-catchup-target-conceal
+    mono rb sc c′⊢ child (structural-frame-keep step finalV) keep-cont =
+  keep-cont step finalV
+
+
+structural-catchup-paired-reveal : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A A′ B B′ : Ty Δᴸ} {C C′ : Ty Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {c : Conv↑ Δᴸ A B} {c′ : Conv↑ Δᴿ C C′}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ C} {q : B ⊑ᵂ⟨ W ⟩ C′}
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↑[ just Xᴸ ] c
+  → CTI2.targetStoreʷ W CTI2.⊢↑[ just Xᴿ ] c′
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
+  → StructuralFrameOutcome
+      (StructuralCatchupRightResult.N′ child
+        ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
+  → (∀ {N₁}
+      → (StructuralCatchupRightResult.N′ child
+           ↑ applyReveals (StructuralCatchupRightResult.χs child) c′)
+          —→[ keep ] N₁
+      → Value N₁
+      → StructuralCatchupRightResult W γ (M ↑ c) (M′ ↑ c′) q)
+  → StructuralCatchupRightResult W γ (M ↑ c) (M′ ↑ c′) q
+structural-catchup-paired-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c⊢ c′⊢ child (structural-frame-value finalV) keep-cont
+    with structural-rebase-at-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-paired-reveal {γ = γ} {c′ = c′} {q = q}
+    mono rb sc c⊢ c′⊢ child (structural-frame-value finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+        ↑ applyReveals χs c′
+    ; final-value = finalV
+    ; post-reduction =
+        reveal-↠ c′ (StructuralCatchupRightResult.post-reduction child)
+    ; final-relation =
+        CTI2.reveal⊑reveal² (mono′ mono) rb′
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-source-reveal plan c⊢)
+          (structural-target-reveal-just plan c′⊢)
+          (StructuralCatchupRightResult.final-relation child)
+          (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+    }
+  where
+  χs = StructuralCatchupRightResult.χs child
+structural-catchup-paired-reveal
+    mono rb sc c⊢ c′⊢ child (structural-frame-keep step finalV) keep-cont =
+  keep-cont step finalV
+
+
+structural-catchup-paired-conceal : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A A′ B B′ : Ty Δᴸ} {C C′ : Ty Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {c : Conv↓ Δᴸ A B} {c′ : Conv↓ Δᴿ C C′}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ C} {q : B ⊑ᵂ⟨ W ⟩ C′}
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
+  → CTI2.MatchedConcealPartnerOK
+      (StructuralCatchupRightResult.W′ child) M c
+      (just (mapVarChanges (StructuralCatchupRightResult.χs child) Xᴿ))
+      (StructuralCatchupRightResult.N′ child)
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.RebaseAt Wᵖ W Xᴸ Xᴿ)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just Xᴸ ] c
+  → CTI2.targetStoreʷ W CTI2.⊢↓[ just Xᴿ ] c′
+  → StructuralFrameOutcome
+      (StructuralCatchupRightResult.N′ child
+        ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
+  → (∀ {N₁}
+      → (StructuralCatchupRightResult.N′ child
+           ↓ applyConceals (StructuralCatchupRightResult.χs child) c′)
+          —→[ keep ] N₁
+      → Value N₁
+      → StructuralCatchupRightResult W γ (M ↓ c) (M′ ↓ c′) q)
+  → StructuralCatchupRightResult W γ (M ↓ c) (M′ ↓ c′) q
+structural-catchup-paired-conceal {γ = γ} {c′ = c′} {q = q}
+    child endpoint-partner mono rb sc c⊢ c′⊢
+    (structural-frame-value finalV) keep-cont
+    with structural-reverse-rebase-at-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-paired-conceal {γ = γ} {c′ = c′} {q = q}
+    child endpoint-partner mono rb sc c⊢ c′⊢
+    (structural-frame-value finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+        ↓ applyConceals χs c′
+    ; final-value = finalV
+    ; post-reduction =
+        conceal-↠ c′ (StructuralCatchupRightResult.post-reduction child)
+    ; final-relation =
+        CTI2.conceal⊑conceal² endpoint-partner (mono′ mono) rb′
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-source-conceal plan c⊢)
+          (structural-target-conceal-just plan c′⊢)
+          (StructuralCatchupRightResult.final-relation child)
+          (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+    }
+  where
+  χs = StructuralCatchupRightResult.χs child
+structural-catchup-paired-conceal
+    child endpoint-partner mono rb sc c⊢ c′⊢
+    (structural-frame-keep step finalV) keep-cont =
+  keep-cont step finalV
+
+
+structural-catchup-packaged-seal-star : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {p★ : ★ ⊑ᵂ⟨ Wᵖ ⟩ ★}
+    {qᵖ : (＇ Xᴸ) ⊑ᵂ⟨ Wᵖ ⟩ ★}
+    {q : (＇ Xᴸ) ⊑ᵂ⟨ W ⟩ (＇ Xᴿ)}
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p★)
+  → CTI2.MatchedConcealPartnerOK
+      (StructuralCatchupRightResult.W′ child) M (seal Xᴸ ★)
+      (mapPivotChanges (StructuralCatchupRightResult.χs child) Xᴿ?)
+      (StructuralCatchupRightResult.N′ child)
+  → StructuralCatchupRightResult.W′ child ∣
+      ECR.mapCtxᴿ
+        (structural-world-extendᴿ
+          (StructuralCatchupRightResult.structural-ext child))
+        γᵖ
+      ⊢² M ↓ seal Xᴸ ★
+        ⊑ StructuralCatchupRightResult.N′ child ∶
+          ECR.transport⊑ᵂ
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            qᵖ
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.RebaseAt Wᵖ W Xᴸ Xᴿ)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just Xᴸ ] seal Xᴸ ★
+  → CTI2.targetStoreʷ W CTI2.⊢↓[ just Xᴿ ] seal Xᴿ ★
+  → StructuralFrameOutcome
+      (StructuralCatchupRightResult.N′ child
+        ↓ seal
+            (mapVarChanges (StructuralCatchupRightResult.χs child) Xᴿ) ★)
+  → (∀ {N₁}
+      → (StructuralCatchupRightResult.N′ child
+           ↓ seal
+               (mapVarChanges (StructuralCatchupRightResult.χs child) Xᴿ)
+               ★)
+          —→[ keep ] N₁
+      → Value N₁
+      → StructuralCatchupRightResult W γ (M ↓ seal Xᴸ ★)
+          (M′ ↓ seal Xᴿ ★) q)
+  → StructuralCatchupRightResult W γ (M ↓ seal Xᴸ ★)
+      (M′ ↓ seal Xᴿ ★) q
+structural-catchup-packaged-seal-star
+    {γ = γ} {γᵖ = γᵖ} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ}
+    {p★ = p★} {qᵖ = qᵖ} {q = q} child endpoint-partner
+    endpoint-source-rel mono rb sc c⊢ c′⊢
+    (structural-frame-value finalV) keep-cont
+    with structural-reverse-rebase-at-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-packaged-seal-star
+    {γ = γ} {γᵖ = γᵖ} {Xᴸ = Xᴸ} {Xᴿ = Xᴿ}
+    {p★ = p★} {qᵖ = qᵖ} {q = q} child endpoint-partner
+    endpoint-source-rel mono rb sc c⊢ c′⊢
+    (structural-frame-value finalV) keep-cont
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+        ↓ seal (mapVarChanges χs Xᴿ) ★
+    ; final-value = finalV
+    ; post-reduction =
+        conceal-seal-star-↠ Xᴿ
+          (StructuralCatchupRightResult.post-reduction child)
+    ; final-relation =
+        TBL.⊢²-retarget
+          {q = ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q}
+          (rel-target-transportᴿ
+            (sym (applyTys-var χs Xᴿ))
+            q-packaged
+            (CTI2.packaged-seal-star²
+              {p★ = p★-packaged} {qᵖ = qᵖ-packaged}
+              endpoint-partner (mono′ mono) rb′
+              (mapCtxᴿ-sameCtx
+                (structural-world-extendᴿ plan)
+                (structural-world-extendᴿ
+                  (StructuralCatchupRightResult.structural-ext child))
+                sc)
+              (structural-source-conceal plan c⊢)
+              (structural-target-seal-star plan c′⊢)
+              (TBL.⊢²-retarget {q = p★-packaged}
+                (rel-target-transportᴿ
+                  (applyTys-★ χs)
+                  (ECR.transport⊑ᵂ child-ext p★)
+                  (StructuralCatchupRightResult.final-relation child)))
+              (TBL.⊢²-retarget {q = qᵖ-packaged}
+                (rel-target-transportᴿ
+                  (applyTys-★ χs)
+                  (ECR.transport⊑ᵂ child-ext qᵖ)
+                  endpoint-source-rel))
+              q-packaged))
+    }
+  where
+  χs = StructuralCatchupRightResult.χs child
+  child-ext =
+    structural-world-extendᴿ
+      (StructuralCatchupRightResult.structural-ext child)
+  p★-packaged : ★ ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ ★
+  p★-packaged =
+    subst≡
+      (λ B → ★ ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ B)
+      (applyTys-★ χs)
+      (ECR.transport⊑ᵂ child-ext p★)
+  qᵖ-packaged :
+    (＇ Xᴸ) ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ ★
+  qᵖ-packaged =
+    subst≡
+      (λ B → (＇ Xᴸ) ⊑ᵂ⟨ StructuralCatchupRightResult.W′ child ⟩ B)
+      (applyTys-★ χs)
+      (ECR.transport⊑ᵂ child-ext qᵖ)
+  q-packaged :
+    (＇ Xᴸ) ⊑ᵂ⟨ W′ ⟩ (＇ mapVarChanges χs Xᴿ)
+  q-packaged =
+    subst≡
+      (λ B → (＇ Xᴸ) ⊑ᵂ⟨ W′ ⟩ B)
+      (applyTys-var χs Xᴿ)
+      (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+structural-catchup-packaged-seal-star
+    child endpoint-partner endpoint-source-rel mono rb sc c⊢ c′⊢
+    (structural-frame-keep step finalV) keep-cont =
+  keep-cont step finalV
 
 
 structural-catchup-compose : ∀ {Δᴸ Δᴿ Δ}

--- a/GTSFImp/proof/DGG/Catchup/StructuralWorldEvidenceProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralWorldEvidenceProof.agda
@@ -12,15 +12,18 @@ open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym; cong)
   renaming (subst to subst≡)
 
 open import Types using (Ty; TyVar)
+open import TyStore using (TyStore)
 open import Consistency using (wk↪ᵗ; toRenameᵗ)
 open import Conversion using (Conv↑; Conv↓; rename↑; rename↓)
 open import Imprecision using (X⊑★)
 open import Reduction using (StoreChanges)
 open import proof.TypeInTermSubst using
-  (StoreRename-suc-bind; toRename-wk-eq)
+  (StoreRename-id; StoreRename-suc-bind; renameᵗ-pointwise-id;
+   toRename-wk-eq)
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.ExtraCastRight2 as ECR
 import proof.DGG.TargetExtend as TE
+import proof.Reduction as PR
 open import proof.DGG.Catchup.StructuralWorldExtendDef
 
 
@@ -116,6 +119,58 @@ mapPivot-wk-eq nothing = refl
 mapPivot-wk-eq (just X) = cong just (sym (toRename-wk-eq X))
 
 
+mapPivot-id : ∀ {Δ} (X? : Maybe (TyVar Δ))
+  → TE.mapPivot (λ X → X) X? ≡ X?
+mapPivot-id nothing = refl
+mapPivot-id (just X) = refl
+
+
+revealˣ-subst : ∀ {Δ} {Σ : TyStore Δ} {X? : Maybe (TyVar Δ)}
+    {A₀ A₁ B₀ B₁ : Ty Δ}
+  → (eqA : A₀ ≡ A₁)
+  → (eqB : B₀ ≡ B₁)
+  → ∀ {d : Conv↑ Δ A₀ B₀}
+  → Σ CTI2.⊢↑[ X? ] d
+  → Σ CTI2.⊢↑[ X? ]
+      subst≡ (Conv↑ _ A₁) eqB
+        (subst≡ (λ A′ → Conv↑ _ A′ B₀) eqA d)
+revealˣ-subst refl refl d⊢ = d⊢
+
+
+concealˣ-subst : ∀ {Δ} {Σ : TyStore Δ} {X? : Maybe (TyVar Δ)}
+    {A₀ A₁ B₀ B₁ : Ty Δ}
+  → (eqA : A₀ ≡ A₁)
+  → (eqB : B₀ ≡ B₁)
+  → ∀ {d : Conv↓ Δ A₀ B₀}
+  → Σ CTI2.⊢↓[ X? ] d
+  → Σ CTI2.⊢↓[ X? ]
+      subst≡ (Conv↓ _ A₁) eqB
+        (subst≡ (λ A′ → Conv↓ _ A′ B₀) eqA d)
+concealˣ-subst refl refl d⊢ = d⊢
+
+
+normalizeRevealˣ : ∀ {Δ} {Σ : TyStore Δ} {X? : Maybe (TyVar Δ)}
+    {A B : Ty Δ} {c : Conv↑ Δ A B}
+  → Σ CTI2.⊢↑[ X? ] c
+  → Σ CTI2.⊢↑[ X? ] PR.normalizeReveal c
+normalizeRevealˣ {Σ = Σ} {X? = X?} {A = A} {B = B} {c = c} c⊢ =
+  revealˣ-subst (renameᵗ-pointwise-id _ A (λ X → refl))
+    (renameᵗ-pointwise-id _ B (λ X → refl))
+    (subst≡ (λ pivot → Σ CTI2.⊢↑[ pivot ] rename↑ (λ X → X) c)
+      (mapPivot-id X?) (TE.reveal-renameˣ StoreRename-id c⊢))
+
+
+normalizeConcealˣ : ∀ {Δ} {Σ : TyStore Δ} {X? : Maybe (TyVar Δ)}
+    {A B : Ty Δ} {c : Conv↓ Δ A B}
+  → Σ CTI2.⊢↓[ X? ] c
+  → Σ CTI2.⊢↓[ X? ] PR.normalizeConceal c
+normalizeConcealˣ {Σ = Σ} {X? = X?} {A = A} {B = B} {c = c} c⊢ =
+  concealˣ-subst (renameᵗ-pointwise-id _ A (λ X → refl))
+    (renameᵗ-pointwise-id _ B (λ X → refl))
+    (subst≡ (λ pivot → Σ CTI2.⊢↓[ pivot ] rename↓ (λ X → X) c)
+      (mapPivot-id X?) (TE.conceal-renameˣ StoreRename-id c⊢))
+
+
 structural-source-reveal : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {χs : StoreChanges Δᴿ Δᴿ′}
     {W : CTI2.World Δᴸ Δᴿ Δ}
@@ -157,10 +212,10 @@ structural-target-reveal : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → StructuralWorldExtendᴿ χs W W′
   → CTI2.targetStoreʷ W CTI2.⊢↑[ X? ] c
   → CTI2.targetStoreʷ W′ CTI2.⊢↑[ mapPivotChanges χs X? ]
-      mapRevealChanges χs c
+      PR.applyReveals χs c
 structural-target-reveal structural-[] c⊢ = c⊢
 structural-target-reveal (structural-keep plan) c⊢ =
-  structural-target-reveal plan c⊢
+  structural-target-reveal plan (normalizeRevealˣ c⊢)
 structural-target-reveal {X? = X?} {c = c}
     (structural-bind {W₁ = W₁} ins follows plan) c⊢ =
   structural-target-reveal plan
@@ -183,10 +238,10 @@ structural-target-conceal : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → StructuralWorldExtendᴿ χs W W′
   → CTI2.targetStoreʷ W CTI2.⊢↓[ X? ] c
   → CTI2.targetStoreʷ W′ CTI2.⊢↓[ mapPivotChanges χs X? ]
-      mapConcealChanges χs c
+      PR.applyConceals χs c
 structural-target-conceal structural-[] c⊢ = c⊢
 structural-target-conceal (structural-keep plan) c⊢ =
-  structural-target-conceal plan c⊢
+  structural-target-conceal plan (normalizeConcealˣ c⊢)
 structural-target-conceal {X? = X?} {c = c}
     (structural-bind {W₁ = W₁} ins follows plan) c⊢ =
   structural-target-conceal plan

--- a/GTSFImp/proof/DGG/notes/TOPDOWN-BOTTOMUP-FRONTIER.md
+++ b/GTSFImp/proof/DGG/notes/TOPDOWN-BOTTOMUP-FRONTIER.md
@@ -138,3 +138,22 @@ stage 2 (agent/gtsf-ns4-stage2; forbidden from editing
 proof/DGG/Catchup/* to avoid colliding with T1's knot/factory items).
 The former "T4 meet-point closure" is renumbered T6, still staged
 behind T1.
+
+Update 2026-08-17 (evening, supervisor): the ask-generation sweep. All
+bottom-up tracks have reached the ⊢²-induction stratum; the frontier is
+now DECISION-SHAPED. Status of the five assumed surfaces + closings:
+- TargetBlameCatchupᵀ: PROVEN modulo D9's two surfaces (PR #162).
+- SimBackᵀ: green parameterized skeleton, structural rows closed
+  (PR #163); residual architecture = D10.
+- CatchupToLessPrecise: recon complete, four-part left stack proposed
+  (PR #164); = D11.
+- CatchupToMorePrecise: fuel discharge = D8b; embedding + boundary
+  adapters being drafted (T11, Fin.zero probe included).
+- Simᵀ closings: β-closings = D8a-c (PR #161); conversion frames =
+  D1(decided)+D6; left value family = D2a-c; NS-4 strict cells =
+  D4.1-3 (PR #160); Value/Blame irreducibility PROVEN (PR #159).
+Cross-cutting families needing ONE ruling each: wrapper-peel species
+(D2b/D4/D7 + left rows of D11), premise-world parkedness (D6/D9.2 +
+D10's frames). Calibration probes for both in flight (T10).
+Main is RED (PR #154 parse error); heal on PR #160/#159 = D5.
+Decision board: issue #157. Draft PRs: #155/#156/#158-#164.

--- a/GTSFImp/proof/DGG/notes/TOPDOWN-BOTTOMUP-FRONTIER.md
+++ b/GTSFImp/proof/DGG/notes/TOPDOWN-BOTTOMUP-FRONTIER.md
@@ -100,3 +100,28 @@ reduction-theory obligations, likely easy).
    SimProof.agda fail the {! grep. The top-down PRs did not run the
    gate. Needs a user decision: sanction a declared-WIP location the
    hygiene check excludes, or require the gate on top-down PRs.
+
+## Re-map 2026-08-17 (post-#144 merge; supervisor)
+
+The top-down SimProof has ZERO holes; its 13 assumed interfaces are
+the entire frontier. Fit classification:
+1. CatchupToMorePrecise (boundary-kind-indexed, built on the NS-4
+   structural vocabulary) = our ValueCatchupRightAt closed form +
+   three linking lemmas (fuel discharge, WorldExtendᴿ→ParkedEvolve,
+   boundary adapters). Staged behind the assembly residual (T1/T4).
+2. Left-side step family (SimSource/Paired{Cast,Reveal,Conceal}Values,
+   SimConversionFrames; SimPrimitiveValues landing separately by the
+   user) = the right-side rows mirrored; independent (T2).
+3. β-closings (SimPairedFun/AllClosing, SimSourceAllClosing) — the ∀
+   ones touch the M5 Λ machinery; queued.
+4. TransportTermImprecisionᴾ — transport repackaging; queued.
+5. SimBackᵀ, CatchupToLessPrecise, TargetBlameCatchupᵀ — unchanged;
+   queued.
+Confirmed meet-events: the top-down imports StructuralWorldExtendᴿ /
+mapPivotChanges; reveal-↠/conceal-↠ (main, #152/#153) is the likely
+discharge of assembly-residual item 1 (T1 confirms first).
+Parallel tracks live (2026-08-17): T1 assembly follow-on
+(agent/gtsf-lg3-assembly), T2 left-side family
+(agent/gtsf-sim-left-values), T3 legacy NON_COVERING repair
+(agent/gtsf-legacy-noncovering). T4 = meet-point closure, staged
+behind T1.

--- a/GTSFImp/proof/DGG/notes/TOPDOWN-BOTTOMUP-FRONTIER.md
+++ b/GTSFImp/proof/DGG/notes/TOPDOWN-BOTTOMUP-FRONTIER.md
@@ -125,3 +125,16 @@ Parallel tracks live (2026-08-17): T1 assembly follow-on
 (agent/gtsf-sim-left-values), T3 legacy NON_COVERING repair
 (agent/gtsf-legacy-noncovering). T4 = meet-point closure, staged
 behind T1.
+
+Track update (2026-08-17, later): decision asks now live on GitHub
+issue #157 (D1 = SimConversionFrames continuations, D2 = left-side
+lemma family); scheduling aims for ~3 active tracks. Status: T1
+BLOCKED on D1 at the value dispatcher (items 1-3 of 9 done, PR #156
+draft); T2 BLOCKED on D1+D2 (PR #155 draft); T3 DONE-partial (PR #158
+draft, NON_COVERING 22→18, stopped at the wrap-star-cast-nonfinal
+obstruction). Newly launched: T4 = TransportTermImprecisionᴾ +
+Value/BlameIrreducible* (agent/gtsf-transport-irreducible), T5 = NS-4
+stage 2 (agent/gtsf-ns4-stage2; forbidden from editing
+proof/DGG/Catchup/* to avoid colliding with T1's knot/factory items).
+The former "T4 meet-point closure" is renumbered T6, still staged
+behind T1.

--- a/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
@@ -119,6 +119,42 @@ Complete residual enumeration:
 9. Run the required full gate and focused regression, skipping only the
    recorded-stale `TagDisciplineScratch.agda`.
 
-No CTI relation, live term-imprecision relation, `Reduction.agda`, public
-`FuelStepSurface`/`FuelKnot` statement shape, `RightInjInversion2Def`,
-`SpineValueDef`, `PLAN.md`, postulate, pragma, or root scratch file was changed.
+Before this T1 continuation, no CTI relation, live term-imprecision relation,
+`Reduction.agda`, public `FuelStepSurface`/`FuelKnot` statement shape,
+`RightInjInversion2Def`, `SpineValueDef`, `PLAN.md`, postulate, pragma, or root
+scratch file was changed.
+
+ITEM 1 VERDICT (2026-08-17, T1 first act):
+
+Main's shipped `proof.Reduction` support discharges the reveal/conceal
+multi-step congruence blocker on the reduction side.  The checked endpoints are
+the newer normalized maps:
+
+```agda
+reveal-↠ :
+  (c : Conv↑ Δ A B)
+  → M —↠[ χs ] N
+  → M ↑ c —↠[ χs ] N ↑ applyReveals χs c
+
+conceal-↠ :
+  (c : Conv↓ Δ A B)
+  → M —↠[ χs ] N
+  → M ↓ c —↠[ χs ] N ↓ applyConceals χs c
+```
+
+`applyReveals` and `applyConceals` handle the old `keep` mismatch by threading
+`normalizeReveal`/`normalizeConceal`, with the endpoint transports discharged
+by `renamedReveal-term` and `renamedConceal-term`.
+
+The residual note's exact old endpoint shape with `mapRevealChanges` /
+`mapConcealChanges` is no longer the reduction endpoint.  T1 item 1 landed the
+small bridge by exporting `normalizeReveal-⊢↑` / `normalizeConceal-⊢↓` from
+`proof.Reduction` and retargeting
+`proof/DGG/Catchup/StructuralWorldEvidenceProof.agda` to produce indexed target
+conversion evidence for `applyReveals` / `applyConceals`.  No change to the
+reduction relation itself was needed.  Gate:
+
+```text
+AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
+```

--- a/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
@@ -275,3 +275,29 @@ Complete residual enumeration from item 4:
    worker cannot complete its mutual route, the concrete factory pair and
    public knot cannot be specialized, grounding cannot be hooked to the
    concrete knot, and resolved-note/regression cleanup cannot be soundly marked.
+
+ITEM 4 D1 FOLLOW-UP STATUS (2026-08-17):
+
+The D1 ruling was applied to the five structural target-conversion rows in
+`proof/DGG/Catchup/StructuralCatchupRightDef.agda`.  Their keep-outcome
+continuations now receive the checked post-child frame relation before the
+administrative keep step:
+
+```agda
+plan : StructuralWorldExtendᴿ χs W Wᵒ
+frame-rel :
+  Wᵒ ∣ ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+    ⊢² source ⊑ target-frame ∶
+      ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q
+```
+
+This discharges the row-level version of gap 1 without changing CTI, reduction,
+or public fuel surfaces.
+
+The total structural value dispatcher remains stopped before live worker code:
+plain `⊑reveal²` and `⊑conceal²` branches still need a source of reduct
+relations for the direct administrative target keep outcomes.  The required
+major relation-level statements were written to
+`proof/DGG/notes/t1-target-frame-keep-rel-proposal.red` instead of being
+implemented, per the standing rule against new unapproved inductions over
+`⊢²`.

--- a/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
@@ -158,3 +158,19 @@ reduction relation itself was needed.  Gate:
 AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
 postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
 ```
+
+ITEM 2 STATUS (2026-08-17, T1):
+
+The internal structural result surface was iterated to the option-2 supplied
+endpoint shape.  `StructuralCatchupRightResult` no longer carries the four
+false broad endpoint-partner transport fields.  Source-conceal replay now
+consumes the exact endpoint partner evidence it needs at the child endpoint,
+and ordinary keep/prepend/compose/target-cast rows no longer manufacture
+arbitrary source/matched conceal partner transformers as result fields.
+
+Checked chunk:
+
+```text
+AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
+```

--- a/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
@@ -174,3 +174,33 @@ Checked chunk:
 AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
 postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
 ```
+
+ITEM 3 STATUS (2026-08-17, T1):
+
+The five target-conversion structural result transformers landed in
+`proof/DGG/Catchup/StructuralCatchupRightDef.agda`:
+
+```agda
+structural-catchup-target-reveal
+structural-catchup-target-conceal
+structural-catchup-paired-reveal
+structural-catchup-paired-conceal
+structural-catchup-packaged-seal-star
+```
+
+Each transformer uses the relevant F1 structural rebase pullback and the
+structural target/source conversion evidence at the pulled-back endpoint.  The
+target-frame endpoint is split by a supplied `StructuralFrameOutcome`: value
+branches build the result directly with `reveal-↠` / `conceal-↠`, while keep
+branches delegate to the caller-supplied continuation.  The packaged
+seal-star row additionally uses a narrow canonical seal-star replay
+(`conceal-seal-star-↠`) so the CTI constructor sees the mapped endpoint
+`seal (mapVarChanges χs Xᴿ) ★` rather than the normalized generic
+`applyConceals` endpoint.
+
+Checked chunk:
+
+```text
+AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
+```

--- a/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
@@ -204,3 +204,74 @@ Checked chunk:
 AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
 postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
 ```
+
+ITEM 4 STATUS (2026-08-17, T1):
+
+Stopped on the structural value-worker dispatcher before committing any worker
+definition.  The item-3 row transformers check, but the dispatcher cannot call
+the target-conversion rows without additional supplied relation continuations.
+
+The holes-first scratch
+`proof/DGG/notes/LG3T1ValueDispatcherScratch.agda` was created, checked, and
+deleted.  It exposed two focused residual goals:
+
+1. Target-conversion keep continuation.  Even after a recursive child catchup
+   and a `StructuralFrameOutcome`, the new
+   `structural-catchup-target-reveal` / `target-conceal` family requires a
+   caller-supplied continuation of the form:
+
+```agda
+∀ {N₁}
+  → (N′ ↑ applyReveals χs c′) —→[ keep ] N₁
+  → Value N₁
+  → StructuralCatchupRightResult W γ M (M′ ↑ c′) q
+```
+
+and analogously for target conceal, paired reveal, paired conceal, and packaged
+seal-star.  The plain `CTI2.⊑reveal²` / `CTI2.⊑conceal²` derivations do not
+carry a checked relation premise for the reduct `N₁`; the existing
+`TargetFrameAbsorptionChain` keep-rel support is available only in the
+instantiation-spine worker, not in the value dispatcher surface.
+
+2. Source-`Λ` child-result bridge.  A recursive call under
+   `CTI2.liftWorldLeft X⊑★ W` yields:
+
+```agda
+StructuralCatchupRightResult
+  (CTI2.liftWorldLeft X⊑★ W) γᴸ U M′ p
+```
+
+but the dispatcher needs:
+
+```agda
+StructuralCatchupRightResult W γ (Λ U) M′ q
+```
+
+The landed `SourceΛReplayStack` machinery can replay an endpoint relation
+through a caller-supplied outer structural plan, but no checked result-level
+pullback/unlift currently converts an arbitrary completed lifted child result
+into the outer `StructuralCatchupRightResult`.
+
+No worker code, scratch file, postulate, pragma, CTI relation, reduction
+relation, public fuel surface, protected structural definition, or `PLAN.md`
+edit was left in the tree.
+
+Complete residual enumeration from item 4:
+
+1. Add a checked value-dispatcher relation continuation for target reveal and
+   target conceal keep outcomes, or expose a CTI/worker surface that carries
+   the same `keep-rel` information currently present in
+   `TargetFrameAbsorptionChain`.
+2. Specialize that continuation for the paired reveal, paired conceal, and
+   packaged seal-star rows, including the exact matched/source endpoint
+   supplies already required by item 2.
+3. Add a result-level source-`Λ` unlift/pullback that consumes a completed
+   lifted/smart-comma child `StructuralCatchupRightResult` and rebuilds the
+   outer result without requiring a pre-known outer plan.
+4. Only after 1-3, assemble the derivation-recursive
+   `StructuralValueCatchupRightAt` dispatcher over base values, target casts,
+   source wrappers, source-`Λ`, and the five target-conversion rows.
+5. Items 5-9 remain blocked behind the value dispatcher: the extra-cast
+   worker cannot complete its mutual route, the concrete factory pair and
+   public knot cannot be specialized, grounding cannot be hooked to the
+   concrete knot, and resolved-note/regression cleanup cannot be soundly marked.

--- a/GTSFImp/proof/DGG/notes/t1-target-frame-keep-rel-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t1-target-frame-keep-rel-proposal.red
@@ -1,0 +1,46 @@
+T1 target-frame keep relation proposal
+
+Status: proposal only.  Do not implement without approval.
+
+The D1 ruling has been applied to the structural target reveal/conceal row
+surfaces: keep outcomes now receive the checked wrapper relation at the
+post-child world before delegating to the caller.
+
+The structural value dispatcher still cannot be total for the plain
+`⊑reveal²` and `⊑conceal²` branches.  Those CTI constructors carry a child
+relation for the wrapped target term, but not the reduct relation needed after
+an administrative target keep step.  The instantiation-spine route has this as
+`TargetFrameAbsorptionChain.keep-rel`; the standalone value worker has no
+corresponding surface.
+
+Proposed relation-level statements:
+
+```agda
+target-reveal-keep-rel : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {N N₁ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B′} {c′ : Conv↑ Δᴿ B B′}
+  → Value N
+  → W ∣ γ ⊢² M ⊑ N ↑ c′ ∶ q
+  → (N ↑ c′) —→[ keep ] N₁
+  → Value N₁
+  → W ∣ γ ⊢² M ⊑ N₁ ∶ q
+
+target-conceal-keep-rel : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {N N₁ : Term Δᴿ}
+    {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B′} {c′ : Conv↓ Δᴿ B B′}
+  → Value N
+  → W ∣ γ ⊢² M ⊑ N ↓ c′ ∶ q
+  → (N ↓ c′) —→[ keep ] N₁
+  → Value N₁
+  → W ∣ γ ⊢² M ⊑ N₁ ∶ q
+```
+
+These are major lemmas: they require inversion or induction over `⊢²`, because
+the reveal `conceal-reveal` reduct must recover the relation to the concealed
+payload from the relation to the sealed target value.  They should either be
+approved directly, or replaced by an approved continuation-stack surface for
+the value dispatcher that carries the same `keep-rel` information hereditarily.

--- a/GTSFImp/proof/Reduction.agda
+++ b/GTSFImp/proof/Reduction.agda
@@ -19,9 +19,10 @@ open import Relation.Binary.PropositionalEquality using
   renaming (subst to subst≡)
 
 open import Types
+open import TyStore using (TyStore)
 open import Consistency hiding (keep)
 import Consistency as C
-open import Conversion using (Conv↑; Conv↓; rename↑; rename↓)
+open import Conversion using (Conv↑; Conv↓; rename↑; rename↓; _⊢↑_; _⊢↓_)
 open import Primitives using
   (Prim; addℕ; and𝔹; primArgTy; primResultTy)
 open import CastTerms using
@@ -39,6 +40,8 @@ open import proof.TypeInTermSubst using
   ; renameᵗ-pointwise-id
   ; renameᵗᵐ-preserves-Value
   ; rename-openᵗ
+  ; reveal-rename-id
+  ; conceal-rename-id
   )
 
 applyBodies : ∀ {Δ Δ′}
@@ -136,6 +139,40 @@ normalizeConceal {A = A} {B = B} c =
     (subst≡ (λ A′ → Conv↓ _ A′ _)
       (renameᵗ-pointwise-id _ A (λ X → refl))
       (rename↓ (λ X → X) c))
+
+normalizeReveal-⊢↑ : ∀ {Δ} {Σ : TyStore Δ} {A B : Ty Δ}
+    {c : Conv↑ Δ A B}
+  → Σ ⊢↑ c
+  → Σ ⊢↑ normalizeReveal c
+normalizeReveal-⊢↑ {A = A} {B = B} c⊢ =
+  reveal-subst (renameᵗ-pointwise-id _ A (λ X → refl))
+    (renameᵗ-pointwise-id _ B (λ X → refl)) (reveal-rename-id c⊢)
+  where
+  reveal-subst : ∀ {Σ : TyStore _} {A₀ A₁ B₀ B₁ : Ty _}
+    → (eqA : A₀ ≡ A₁)
+    → (eqB : B₀ ≡ B₁)
+    → ∀ {d : Conv↑ _ A₀ B₀}
+    → Σ ⊢↑ d
+    → Σ ⊢↑ subst≡ (Conv↑ _ A₁) eqB
+        (subst≡ (λ A′ → Conv↑ _ A′ B₀) eqA d)
+  reveal-subst refl refl d⊢ = d⊢
+
+normalizeConceal-⊢↓ : ∀ {Δ} {Σ : TyStore Δ} {A B : Ty Δ}
+    {c : Conv↓ Δ A B}
+  → Σ ⊢↓ c
+  → Σ ⊢↓ normalizeConceal c
+normalizeConceal-⊢↓ {A = A} {B = B} c⊢ =
+  conceal-subst (renameᵗ-pointwise-id _ A (λ X → refl))
+    (renameᵗ-pointwise-id _ B (λ X → refl)) (conceal-rename-id c⊢)
+  where
+  conceal-subst : ∀ {Σ : TyStore _} {A₀ A₁ B₀ B₁ : Ty _}
+    → (eqA : A₀ ≡ A₁)
+    → (eqB : B₀ ≡ B₁)
+    → ∀ {d : Conv↓ _ A₀ B₀}
+    → Σ ⊢↓ d
+    → Σ ⊢↓ subst≡ (Conv↓ _ A₁) eqB
+        (subst≡ (λ A′ → Conv↓ _ A′ B₀) eqA d)
+  conceal-subst refl refl d⊢ = d⊢
 
 applyReveals : ∀ {Δ Δ′} (χs : StoreChanges Δ Δ′) {A B : Ty Δ}
   → Conv↑ Δ A B


### PR DESCRIPTION
Assembly follow-on per the nine-item residual (notes/lg3ah-supplied-continuation-assembly-resister.red). Done: the reveal-↠/conceal-↠ bridge (confirming the top-down PRs discharged residual item 1 — a meet-in-the-middle event), the option-2 narrowed endpoint surface, and all five target-conversion transformers. Stopped at the value dispatcher on two recorded gaps pending the supervisor/user check-in. Carries the post-#144 frontier memo re-map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)