### PR TITLE
T5: heal main's parse error in SimPrimitiveValuesProof + NS-4 stage-2 blocker note

### DIFF
--- a/GTSFImp/proof/DGG/notes/probes/PartnerLiftDraft.agda
+++ b/GTSFImp/proof/DGG/notes/probes/PartnerLiftDraft.agda
@@ -1,0 +1,306 @@
+module proof.DGG.notes.probes.PartnerLiftDraft where
+
+-- File Charter:
+--   * Type-checks D4.4(ii) partner-lift candidate statements.
+--   * Candidate A is checked against the existing target-insert geometry.
+--   * Candidate B is recorded as constructor-type statements only; this
+--     probe does not change the live partner relation.
+
+import Data.Fin as Fin
+open import Data.Maybe using (Maybe; just)
+import Data.Nat as Nat
+
+open import Types using (Ty; TyCtx; TyVar; ★; ＇_)
+open import Consistency using
+  (Env∼; _⊢_∼_; _↪ᵗ_; wk↪ᵗ)
+open import Conversion using (Conv↑; Conv↓; `∀↑_; `∀↓_; seal)
+open import CastTerms using (Term; ⇑ᵗᵐ; _⟨_⟩; _↑_; _↓_)
+open import Reduction using (bind; _∷_; [])
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.TargetExtend as TE
+open import proof.DGG.Catchup.StructuralWorldExtendDef using
+  (mapPivotChanges; StructuralWorldExtendᴿ; structural-bind; structural-[])
+
+
+CandidateA-SealTargetBindᵀ : Set₁
+CandidateA-SealTargetBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SealPartnerOK W X P R Xᴿ? V
+  → CTI2.SealPartnerOK W₁ X P R
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+candidateA-seal-target-bind : CandidateA-SealTargetBindᵀ
+candidateA-seal-target-bind ins =
+  TE.renameSealPartnerOK (TE.align-insert ins)
+    (TE.targetInsertNoTargetAtSource ins)
+
+
+CandidateA-SourceConcealTargetBindᵀ : Set₁
+CandidateA-SourceConcealTargetBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SourceConcealPartnerOK W P c Xᴿ? V
+  → CTI2.SourceConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+candidateA-source-conceal-target-bind :
+  CandidateA-SourceConcealTargetBindᵀ
+candidateA-source-conceal-target-bind ins =
+  TE.renameSourceConcealPartnerOK (TE.align-insert ins)
+    (TE.targetInsertNoTargetAtSource ins)
+
+
+CandidateA-MatchedConcealTargetBindᵀ : Set₁
+CandidateA-MatchedConcealTargetBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.MatchedConcealPartnerOK W P c Xᴿ? V
+  → CTI2.MatchedConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+candidateA-matched-conceal-target-bind :
+  CandidateA-MatchedConcealTargetBindᵀ
+candidateA-matched-conceal-target-bind ins =
+  TE.renameMatchedConcealPartnerOK (TE.align-insert ins)
+
+
+CandidateA-SealStructuralBindᵀ : Set₁
+CandidateA-SealStructuralBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → StructuralWorldExtendᴿ (bind B ∷ []) W W₁
+  → CTI2.SealPartnerOK W X P R Xᴿ? V
+  → CTI2.SealPartnerOK W₁ X P R
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+candidateA-seal-structural-bind : CandidateA-SealStructuralBindᵀ
+candidateA-seal-structural-bind {B = B}
+    (structural-bind ins follows structural-[]) =
+  candidateA-seal-target-bind {B = B} ins
+
+
+CandidateA-SourceConcealStructuralBindᵀ : Set₁
+CandidateA-SourceConcealStructuralBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → StructuralWorldExtendᴿ (bind B ∷ []) W W₁
+  → CTI2.SourceConcealPartnerOK W P c Xᴿ? V
+  → CTI2.SourceConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+candidateA-source-conceal-structural-bind :
+  CandidateA-SourceConcealStructuralBindᵀ
+candidateA-source-conceal-structural-bind {B = B}
+    (structural-bind ins follows structural-[]) =
+  candidateA-source-conceal-target-bind {B = B} ins
+
+
+CandidateA-MatchedConcealStructuralBindᵀ : Set₁
+CandidateA-MatchedConcealStructuralBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → StructuralWorldExtendᴿ (bind B ∷ []) W W₁
+  → CTI2.MatchedConcealPartnerOK W P c Xᴿ? V
+  → CTI2.MatchedConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+candidateA-matched-conceal-structural-bind :
+  CandidateA-MatchedConcealStructuralBindᵀ
+candidateA-matched-conceal-structural-bind {B = B}
+    (structural-bind ins follows structural-[]) =
+  candidateA-matched-conceal-target-bind {B = B} ins
+
+
+candidateA-notTopTag-lift : ∀ {Δ} {V : Term Δ}
+  → CTI2.NotTopTag V
+  → CTI2.NotTopTag (⇑ᵗᵐ V)
+candidateA-notTopTag-lift =
+  TE.notTopTag-rename wk↪ᵗ
+
+
+candidateA-name-protected-shape-target-bind :
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {Y : TyVar Δᴿ} {S : Ty Δᴿ} {V : Term Δᴿ}
+    {μ : Env∼ Δᴿ} {c : μ ⊢ (＇ Y) ∼ ★}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SealPartnerOK W₁ X P R
+      (mapPivotChanges (bind B ∷ []) (just Y))
+      (⇑ᵗᵐ ((V ↓ seal Y S) ⟨ c ⟩))
+candidateA-name-protected-shape-target-bind {B = B} ins =
+  candidateA-seal-target-bind {B = B} ins CTI2.name-protected-target
+
+
+candidateA-source-reveal-wrapper-output :
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B₀ : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′} {d : Conv↑ (Nat.suc Δᴿ) C B}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.SourceConcealPartnerOK W₁ P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?)
+      (⇑ᵗᵐ (V ↑ `∀↑ d))
+candidateA-source-reveal-wrapper-output {B₀ = B₀} =
+  candidateA-source-conceal-target-bind {B = B₀}
+
+
+candidateA-source-conceal-wrapper-output :
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B₀ : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′} {d : Conv↓ (Nat.suc Δᴿ) C B}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.SourceConcealPartnerOK W₁ P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?)
+      (⇑ᵗᵐ (V ↓ `∀↓ d))
+candidateA-source-conceal-wrapper-output {B₀ = B₀} =
+  candidateA-source-conceal-target-bind {B = B₀}
+
+
+CandidateB-SealLiftedRevealConstructorᵀ : Set
+CandidateB-SealLiftedRevealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↑ (Nat.suc Δᴿ) C B}
+  → CTI2.SealPartnerOK W X P R Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.SealPartnerOK (CTI2.rightOnlyWorld W B₀) X P R
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+CandidateB-SealLiftedConcealConstructorᵀ : Set
+CandidateB-SealLiftedConcealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↓ (Nat.suc Δᴿ) C B}
+  → CTI2.SealPartnerOK W X P R Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.SealPartnerOK (CTI2.rightOnlyWorld W B₀) X P R
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+CandidateB-SourceLiftedRevealConstructorᵀ : Set
+CandidateB-SourceLiftedRevealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↑ (Nat.suc Δᴿ) C B}
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.SourceConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+CandidateB-SourceLiftedConcealConstructorᵀ : Set
+CandidateB-SourceLiftedConcealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↓ (Nat.suc Δᴿ) C B}
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.SourceConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+CandidateB-MatchedLiftedRevealConstructorᵀ : Set
+CandidateB-MatchedLiftedRevealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↑ (Nat.suc Δᴿ) C B}
+  → CTI2.MatchedConcealPartnerOK W P cˢ Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.MatchedConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+CandidateB-MatchedLiftedConcealConstructorᵀ : Set
+CandidateB-MatchedLiftedConcealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↓ (Nat.suc Δᴿ) C B}
+  → CTI2.MatchedConcealPartnerOK W P cˢ Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.MatchedConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+
+record CandidateBConstructors : Set where
+  field
+    seal-lifted-reveal-target :
+      CandidateB-SealLiftedRevealConstructorᵀ
+    seal-lifted-conceal-target :
+      CandidateB-SealLiftedConcealConstructorᵀ
+    source-lifted-reveal-target :
+      CandidateB-SourceLiftedRevealConstructorᵀ
+    source-lifted-conceal-target :
+      CandidateB-SourceLiftedConcealConstructorᵀ
+    matched-lifted-reveal-target :
+      CandidateB-MatchedLiftedRevealConstructorᵀ
+    matched-lifted-conceal-target :
+      CandidateB-MatchedLiftedConcealConstructorᵀ

--- a/GTSFImp/proof/DGG/notes/t5-conceal-equal-partner-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t5-conceal-equal-partner-proposal.red
@@ -1,0 +1,110 @@
+T5 NS-4 stage 2 proposal: conceal-equal target partner preservation
+
+Date: 2026-08-17
+
+Status: blocked by the standing major-surface rule.
+
+The fixed stage-2 field is:
+
+```agda
+conceal-equal-ok :
+  StructuralNameConcealEqualOKᵀ
+```
+
+The consumer is the source-conceal equal branch in
+`StructuralNameInstantiationProof.agda`:
+
+```agda
+structural-conceal-replay
+  (StructuralTargetInstantiationPackage.structural-ext target)
+  mono rb sc c⊢
+  (StructuralStrictViewSurfaces.conceal-equal-ok surfaces rb ok
+    spine target)
+  ...
+```
+
+The required transport is:
+
+```agda
+ok :
+  CTI2.SourceConcealPartnerOK Wᵖ U c Xᴿ? V
+
+target :
+  StructuralTargetInstantiationPackage W V
+    (name-type-app-frame B X refl refl ▻ⁱ spine)
+```
+
+to:
+
+```agda
+CTI2.SourceConcealPartnerOK
+  (StructuralTagRebaseAtᴸResult.Wᵖ′
+    (structural-tag-rebase-atᴸ
+      (StructuralTargetInstantiationPackage.structural-ext target) rb))
+  U c
+  (mapPivotChanges
+    (StructuralTargetInstantiationPackage.χs target) Xᴿ?)
+  (StructuralTargetInstantiationPackage.final target)
+```
+
+The structural world part is already checked by
+`structural-tag-rebase-atᴸ`.  The missing part is preserving the
+`SourceConcealPartnerOK` witness across the target package's reduction and
+spine endpoint.
+
+Proposed checked statement
+--------------------------
+
+The direct statement can be the fixed field itself:
+
+```agda
+structural-conceal-equal-ok :
+  StructuralNameConcealEqualOKᵀ
+```
+
+If kept as a reusable helper, the equivalent target-package statement is:
+
+```agda
+structural-target-source-conceal-partner : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {V : Term Δᴿ} {B E : Ty Δᴿ}
+    {spine : InstantiationSpine B E}
+  → (target : StructuralTargetInstantiationPackage W V spine)
+  → ∀ {Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+      {U : Term Δᴸ} {A A′ : Ty Δᴸ}
+      {c : Conv↓ Δᴸ A A′} {Xᴸ? Xᴿ?}
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → CTI2.SourceConcealPartnerOK Wᵖ U c Xᴿ? V
+  → let child = structural-tag-rebase-atᴸ
+          (StructuralTargetInstantiationPackage.structural-ext target) rb
+     in CTI2.SourceConcealPartnerOK
+          (StructuralTagRebaseAtᴸResult.Wᵖ′ child) U c
+          (mapPivotChanges
+            (StructuralTargetInstantiationPackage.χs target) Xᴿ?)
+          (StructuralTargetInstantiationPackage.final target)
+```
+
+Why this is a surface issue
+---------------------------
+
+For `fun`, `∀`, and `id` source conceals, the result is constructor-immediate.
+For source `seal`, however, `SourceConcealPartnerOK` depends on the target
+endpoint shape through `SealPartnerOK`.  The current
+`StructuralTargetInstantiationPackage` records the structural trace,
+reduction, final term, and final value, but it does not carry the endpoint
+partner transport fields that `StructuralCatchupRightResult` carries:
+
+```agda
+source-conceal-endpoint-partner :
+  ...
+  → CTI2.SourceConcealPartnerOK W₀ P c Xᴿ? M″
+  → CTI2.SourceConcealPartnerOK W₀′ P c
+      (mapPivotChanges χs Xᴿ?) N′
+```
+
+Adding that information to the target package would be a Def-level surface
+change, which the task forbids.  Proving it externally would require a new
+target-spine endpoint-partner preservation theorem for seal partners.  Per the
+task rule, this proposal records the statement and does not implement the new
+surface.
+

--- a/GTSFImp/proof/DGG/notes/t5-lambda-strict-one-bind-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t5-lambda-strict-one-bind-proposal.red
@@ -1,0 +1,135 @@
+T5 NS-4 stage 2 proposal: one-bind Lambda strict surface
+
+Date: 2026-08-17
+
+Status: blocked by the standing major-lemma rule.
+
+The fixed stage-2 field is:
+
+```agda
+structural-lambda-strict-surface :
+  StructuralΛStrictSurfaceᵀ
+```
+
+The consumer is the strict `Λ` branch in
+`StructuralNameInstantiationProof.agda`:
+
+```agda
+with StructuralStrictViewSurfaces.Λ-cell surfaces plan chain-plan
+  rel vM vV spine chain typed ins follows child-target
+...
+child-final =
+  structural-value-spine-instantiation-acc surfaces ...
+    (StructuralStrictChild.child-relation child) vM child-value
+    (lambda-child-spine {B = B} {X = X} spine)
+    ...
+```
+
+The required lower edge is the one-bind beta-Lambda strip:
+
+```agda
+rel :
+  W ∣ γ ⊢² M ⊑ Λ V ∶ p
+
+child-relation :
+  W₁ ∣ ECR.mapCtxᴿ
+        (target-insert-bind-world-extendᴿ ins follows) γ
+    ⊢² M ⊑ V ↑ 〖 Fin.zero , ⇑ᵗ (＇ X) ↑ B 〗 ∶
+      ECR.transport⊑ᵂ
+        (target-insert-bind-world-extendᴿ ins follows) q
+```
+
+with the target side reducing vertically and imprecision horizontally:
+
+$$
+\begin{array}{ccc}
+M & \sqsubseteq & \Lambda V \\
+\downarrow^{0} & & \downarrow_{\beta\Lambda} \\
+M & \sqsubseteq & V \uparrow
+  \langle 0,\mathsf{shift}(X)\uparrow B\rangle
+\end{array}
+$$
+
+The live `InstInversionLambdaProof.agda` machinery is close but not the
+same surface.  Its hereditary worker proves a two-insert residual package:
+
+```agda
+Λ-post-prefix-hereditary :
+  ...
+  → ΛPostPrefixPackageAtBase rel (postExtend plan) c′ B′≢★
+```
+
+That conclusion lives at the two-bind post world
+
+```agda
+postExtend plan :
+  ECR.WorldExtendᴿ (bind ★ ∷ bind (＇ Fin.zero) ∷ []) W (W₂ plan)
+```
+
+and its target is `Λ⊑Λ²PostTerm V B`.  The strict surface instead needs the
+caller-supplied single target bind by `＇ X` and target
+`V ↑ 〖 Fin.zero , ⇑ᵗ (＇ X) ↑ B 〗`.  There is no checked theorem that lowers
+the two-insert residual package back to this one-insert child.
+
+Proposed checked statement
+--------------------------
+
+The direct statement can be the fixed field itself:
+
+```agda
+structural-lambda-strict-surface :
+  StructuralΛStrictSurfaceᵀ
+```
+
+Equivalently, the underlying major lemma is:
+
+```agda
+Λ-strict-one-bind-child : ∀ {fuel Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (suc Δᴿ) Δ₁}
+    {γ : CTI2.CtxImp W}
+    {M : Term Δᴸ} {V : Term (suc Δᴿ)}
+    {A : Ty Δᴸ} {B : Ty (suc Δᴿ)} {E : Ty Δᴿ}
+    {X : TyVar Δᴿ} {π : Δ ↪ᵗ Δ₁}
+    {p : A CTI2.⊑ᵂ⟨ W ⟩ `∀ B}
+    {q : A CTI2.⊑ᵂ⟨ W ⟩ E}
+  → (plan : StructuralNamePostPlan W A E q)
+  → StructuralNameChainPlan {fuel = fuel} W γ A E q plan
+  → W CTI2.∣ γ ⊢² M ⊑ Λ V ∶ p
+  → Value M
+  → Value V
+  → (spine : InstantiationSpine (B [ ＇ X ]ᵗ) E)
+  → TargetFrameAbsorptionChain W γ A
+      (name-type-app-frame B X refl refl ▻ⁱ spine) q
+  → SpineTypedʷ {fuel = fuel} W
+      (name-type-app-frame B X refl refl ▻ⁱ spine)
+  → (ins : TE.TargetInsert wk↪ᵗ π W W₁)
+  → (follows : CTI2.targetStoreʷ W₁ ≡
+      applyStores (bind (＇ X) ∷ []) (CTI2.targetStoreʷ W))
+  → (child-target : StructuralTargetInstantiationPackage W₁
+      (V ↑ 〖 Fin.zero , ⇑ᵗ (＇ X) ↑ B 〗)
+      (type-transport-frame (replace-zero-open B (＇ X)) ▻ⁱ
+        mapInstantiationSpine (bind (＇ X)) spine))
+  → let ext₁ = target-insert-bind-world-extendᴿ ins follows
+     in StructuralStrictChild {fuel = fuel} W₁ (ECR.mapCtxᴿ ext₁ γ) M
+          (V ↑ 〖 Fin.zero , ⇑ᵗ (＇ X) ↑ B 〗)
+          A _ (applyTy (bind (＇ X)) E)
+          (type-transport-frame (replace-zero-open B (＇ X)) ▻ⁱ
+            mapInstantiationSpine (bind (＇ X)) spine)
+          (ECR.transport⊑ᵂ ext₁ q)
+```
+
+Why this is major
+-----------------
+
+The proof must recurse over the parent `⊢²` derivation:
+
+- `Λ⊑Λ²` uses the route1 geometry for the beta-Lambda body.
+- `Λ⊑²` and `Λ⊑²-smart-comma` recurse under the source Lambda premise.
+- `cast⊑²`, `reveal⊑²`, and `conceal⊑²` replay the source wrapper around
+  the stripped child relation.
+
+That is a new one-bind hereditary worker, parallel to but distinct from the
+live two-insert `Λ-post-prefix-hereditary`.  Per the task rule, this proposal
+records the statement and does not implement the induction.
+

--- a/GTSFImp/proof/DGG/notes/t5-partner-lift-draft.red
+++ b/GTSFImp/proof/DGG/notes/t5-partner-lift-draft.red
@@ -1,0 +1,306 @@
+T5 D4.4(ii) partner-lift draft
+
+Date: 2026-08-17
+
+Status: statement draft and feasibility probe only.  No live relation or proof
+module was changed.
+
+Probe:
+
+`proof/DGG/notes/probes/PartnerLiftDraft.agda`
+
+Checked standalone with:
+
+`AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home agda --safe -i . -i proof/DGG/notes/probes proof/DGG/notes/probes/PartnerLiftDraft.agda`
+
+
+Candidate A verdict
+-------------------
+
+Candidate A lifts existing partner evidence through the one-bind target
+insertion.  The target term is lifted by `⇑ᵗᵐ`, the optional target pivot is
+lifted by `mapPivotChanges (bind B ∷ [])`, and the world is the strict-cell
+target-insert world.  `NotTopTag` is stable under `⇑ᵗᵐ`; the
+name-protected shape is stable because renaming sends
+`(V ↓ seal Y S) ⟨ c ⟩` to the same outer shape with the renamed seal name and
+renamed consistency evidence.  The `Rep★PartnerOK` occupancy side also lifts
+for existing partner evidence, via `targetInsertNoTargetAtSource`.
+
+The checked target-insert statements are:
+
+```agda
+CandidateA-SealTargetBindᵀ : Set₁
+CandidateA-SealTargetBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SealPartnerOK W X P R Xᴿ? V
+  → CTI2.SealPartnerOK W₁ X P R
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateA-SourceConcealTargetBindᵀ : Set₁
+CandidateA-SourceConcealTargetBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SourceConcealPartnerOK W P c Xᴿ? V
+  → CTI2.SourceConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateA-MatchedConcealTargetBindᵀ : Set₁
+CandidateA-MatchedConcealTargetBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.MatchedConcealPartnerOK W P c Xᴿ? V
+  → CTI2.MatchedConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+```
+
+The checked strict one-bind `StructuralWorldExtendᴿ` versions have the same
+conclusions:
+
+```agda
+CandidateA-SealStructuralBindᵀ : Set₁
+CandidateA-SealStructuralBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → StructuralWorldExtendᴿ (bind B ∷ []) W W₁
+  → CTI2.SealPartnerOK W X P R Xᴿ? V
+  → CTI2.SealPartnerOK W₁ X P R
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateA-SourceConcealStructuralBindᵀ : Set₁
+CandidateA-SourceConcealStructuralBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → StructuralWorldExtendᴿ (bind B ∷ []) W W₁
+  → CTI2.SourceConcealPartnerOK W P c Xᴿ? V
+  → CTI2.SourceConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateA-MatchedConcealStructuralBindᵀ : Set₁
+CandidateA-MatchedConcealStructuralBindᵀ =
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → StructuralWorldExtendᴿ (bind B ∷ []) W W₁
+  → CTI2.MatchedConcealPartnerOK W P c Xᴿ? V
+  → CTI2.MatchedConcealPartnerOK W₁ P c
+      (mapPivotChanges (bind B ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+```
+
+The checked syntactic side statements are:
+
+```agda
+candidateA-notTopTag-lift : ∀ {Δ} {V : Term Δ}
+  → CTI2.NotTopTag V
+  → CTI2.NotTopTag (⇑ᵗᵐ V)
+
+candidateA-name-protected-shape-target-bind :
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B : Ty Δᴿ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {Y : TyVar Δᴿ} {S : Ty Δᴿ} {V : Term Δᴿ}
+    {μ : Env∼ Δᴿ} {c : μ ⊢ (＇ Y) ∼ ★}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SealPartnerOK W₁ X P R
+      (mapPivotChanges (bind B ∷ []) (just Y))
+      (⇑ᵗᵐ ((V ↓ seal Y S) ⟨ c ⟩))
+```
+
+Candidate A does not solve the reveal/conceal strip stop by itself.  Given the
+stopped evidence for a visible target wrapper, A can only produce the lifted
+visible wrapper:
+
+```agda
+candidateA-source-reveal-wrapper-output :
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B₀ : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′} {d : Conv↑ (Nat.suc Δᴿ) C B}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.SourceConcealPartnerOK W₁ P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?)
+      (⇑ᵗᵐ (V ↑ `∀↑ d))
+
+candidateA-source-conceal-wrapper-output :
+  ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {π : Δ ↪ᵗ Δ₁} {B₀ : Ty Δᴿ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′} {d : Conv↓ (Nat.suc Δᴿ) C B}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.SourceConcealPartnerOK W₁ P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?)
+      (⇑ᵗᵐ (V ↓ `∀↓ d))
+```
+
+The required strict child target is `⇑ᵗᵐ V`, not either of these lifted
+wrappers.  The missing step would have to infer a partner for hidden `V` from
+`plain-target not-↑` or `plain-target not-↓`; that evidence records only the
+outer wrapper and says nothing about whether `V` is untagged, name-protected,
+or a valid `Rep★PartnerOK` case.
+
+
+Candidate B statement
+---------------------
+
+Candidate B is the relation-change surface: the partner relation records that a
+target revealed/concealed `∀` wrapper reduced through a right-only allocation,
+so the post-allocation child target `⇑ᵗᵐ V` keeps the wrapper partner
+provenance.  The constructor types checked in the probe are:
+
+```agda
+CandidateB-SealLiftedRevealConstructorᵀ : Set
+CandidateB-SealLiftedRevealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↑ (Nat.suc Δᴿ) C B}
+  → CTI2.SealPartnerOK W X P R Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.SealPartnerOK (CTI2.rightOnlyWorld W B₀) X P R
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateB-SealLiftedConcealConstructorᵀ : Set
+CandidateB-SealLiftedConcealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {X : TyVar Δᴸ} {P : Term Δᴸ} {R : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↓ (Nat.suc Δᴿ) C B}
+  → CTI2.SealPartnerOK W X P R Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.SealPartnerOK (CTI2.rightOnlyWorld W B₀) X P R
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateB-SourceLiftedRevealConstructorᵀ : Set
+CandidateB-SourceLiftedRevealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↑ (Nat.suc Δᴿ) C B}
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.SourceConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateB-SourceLiftedConcealConstructorᵀ : Set
+CandidateB-SourceLiftedConcealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↓ (Nat.suc Δᴿ) C B}
+  → CTI2.SourceConcealPartnerOK W P cˢ Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.SourceConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateB-MatchedLiftedRevealConstructorᵀ : Set
+CandidateB-MatchedLiftedRevealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↑ (Nat.suc Δᴿ) C B}
+  → CTI2.MatchedConcealPartnerOK W P cˢ Xᴿ? (V ↑ `∀↑ d)
+  → CTI2.MatchedConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+
+CandidateB-MatchedLiftedConcealConstructorᵀ : Set
+CandidateB-MatchedLiftedConcealConstructorᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {P : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {B₀ : Ty Δᴿ} {B C : Ty (Nat.suc Δᴿ)}
+    {cˢ : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)} {V : Term Δᴿ}
+    {d : Conv↓ (Nat.suc Δᴿ) C B}
+  → CTI2.MatchedConcealPartnerOK W P cˢ Xᴿ? (V ↓ `∀↓ d)
+  → CTI2.MatchedConcealPartnerOK (CTI2.rightOnlyWorld W B₀) P cˢ
+      (mapPivotChanges (bind B₀ ∷ []) Xᴿ?) (⇑ᵗᵐ V)
+```
+
+The constructor names bundled in the probe are:
+
+```agda
+record CandidateBConstructors : Set where
+  field
+    seal-lifted-reveal-target :
+      CandidateB-SealLiftedRevealConstructorᵀ
+    seal-lifted-conceal-target :
+      CandidateB-SealLiftedConcealConstructorᵀ
+    source-lifted-reveal-target :
+      CandidateB-SourceLiftedRevealConstructorᵀ
+    source-lifted-conceal-target :
+      CandidateB-SourceLiftedConcealConstructorᵀ
+    matched-lifted-reveal-target :
+      CandidateB-MatchedLiftedRevealConstructorᵀ
+    matched-lifted-conceal-target :
+      CandidateB-MatchedLiftedConcealConstructorᵀ
+```
+
+
+D4.3 subsumption answer
+----------------------
+
+The D4.3 package-finalization need is already the
+`StructuralCatchupRightResult.source-conceal-endpoint-partner` invariant:
+it transports a `SourceConcealPartnerOK` premise through
+`mapPivotChanges χs` to the package final target.  Candidate A subsumes only
+the one-bind pure target-lift subcase, where the endpoint target is exactly
+`⇑ᵗᵐ V` and the starting partner was already for `V`.  It does not subsume the
+full package-finalization invariant, because finalization may reduce the target
+to an arbitrary `N′`, not merely rename it.
+
+For the D4.4(ii) reveal/conceal strict cells, Candidate A is insufficient
+unless another strip theorem first gives partner evidence for hidden `V`.
+Candidate B is the candidate that directly discharges that need, because its
+premise is the visible wrapper partner that the stopped case actually has, and
+its conclusion is the post-β child partner for `⇑ᵗᵐ V`.

--- a/GTSFImp/proof/DGG/notes/t5-target-wrapper-strip-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t5-target-wrapper-strip-proposal.red
@@ -81,6 +81,24 @@ handle:
 ⊑conceal² mono rb same c⊢ rel q
 ```
 
+and (per PR review) the PAIRED-wrapper heads, which can produce the same
+target wrappers while the source remains a value carrying its own
+wrapper — the paired case of `target-id-step-inversion` is the model:
+
+```agda
+cast⊑cast² c (∀ᶜ d) rel q        -- paired ∀ᶜ target
+cast⊑cast² c ((gen d) A≢★) rel q -- paired gen target
+reveal⊑reveal² mono rb same c⊢ c′⊢ rel q
+conceal⊑conceal² partner mono rb same c⊢ c′⊢ rel q
+packaged-seal-star² partner mono rb same c⊢ c′⊢ rel pkg-rel q
+```
+
+In the paired rows the strip keeps the source wrapper on the child
+relation (the source side takes zero steps), so the `StructuralStrictChild`
+endpoint is the paired child form rather than the bare source; the
+per-row conclusion shapes must be checked against the fixed
+`StructuralStrictChild` fields when implementing.
+
 and replay source-side heads such as:
 
 ```agda

--- a/GTSFImp/proof/DGG/notes/t5-target-wrapper-strip-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t5-target-wrapper-strip-proposal.red
@@ -1,0 +1,122 @@
+T5 NS-4 stage 2 proposal: target-wrapper strict surfaces
+
+Date: 2026-08-17
+
+Status: blocked by the standing major-lemma rule.
+
+The stage-2 strict cells require a target-wrapper strip theorem.  The fixed
+field types in `StructuralStrictViewSurfaces` are already the right public
+surface; they should not be reshaped.  The missing checked theorems should
+inhabit those fields directly:
+
+```agda
+structural-lambda-strict-surface :
+  StructuralΛStrictSurfaceᵀ
+
+structural-all-cast-strict-surface :
+  StructuralAllCastStrictSurfaceᵀ
+
+structural-gen-strict-surface :
+  StructuralGenStrictSurfaceᵀ
+
+structural-reveal-strict-surface :
+  StructuralRevealStrictSurfaceᵀ
+
+structural-conceal-strict-surface :
+  StructuralConcealStrictSurfaceᵀ
+```
+
+The four non-lambda cells are the new major part.  For example, the
+`∀`-cast cell must turn:
+
+```agda
+rel : W ∣ γ ⊢² M ⊑ V ⟨ ∀ᶜ d ⟩ ∶ p
+```
+
+into the `StructuralStrictChild` whose recursive relation field is:
+
+```agda
+child-relation :
+  W ∣ γ ⊢² M ⊑ V ∶ child-endpoint
+```
+
+where:
+
+```agda
+child-endpoint : Aₛ ⊑ᵂ⟨ W ⟩ `∀ B
+```
+
+and whose chain and typed-spine fields cover:
+
+```agda
+name-type-app-frame B X refl refl ▻ⁱ
+cast-frame (d [ ＇ X ]ᶜ) ▻ⁱ
+mapInstantiationSpine keep spine
+```
+
+The `gen`, `reveal`, and `conceal` cells have the same proof shape after a
+target bind: from a parent relation against the visible target wrapper, produce
+the child relation against `⇑ᵗᵐ V`, plus the target-bind child plan,
+chain plan, frame-absorption chain, and typed spine required by
+`StructuralStrictChild`.
+
+The proof is not a local constructor application.  It must recurse on the
+term-imprecision derivation, just as the live
+`target-id-step-inversion` theorem does for target identity casts:
+
+```agda
+target-id-step-inversion :
+  ...
+  → W ∣ γ ⊢² M ⊑ M′ ⟨ id a ⟩ ∶ q
+  → W ∣ γ ⊢² M ⊑ M′ ∶ q
+```
+
+For the strict target wrappers, the analogous derivation-recursive cells must
+handle:
+
+```agda
+⊑cast² (∀ᶜ d) rel q
+⊑cast² ((gen d) A≢★) rel q
+⊑reveal² mono rb same c⊢ rel q
+⊑conceal² mono rb same c⊢ rel q
+```
+
+and replay source-side heads such as:
+
+```agda
+cast⊑² c rel q
+reveal⊑² mono rb same c⊢ rel q
+conceal⊑² ok mono rb same c⊢ rel q
+Λ⊑² ...
+Λ⊑²-smart-comma ...
+```
+
+The required square for each strict target wrapper is:
+
+$$
+\begin{array}{ccc}
+M & \sqsubseteq & \operatorname{wrap}(V) \\
+\downarrow^{0} & & \downarrow \\
+M & \sqsubseteq & V_{\mathsf{child}}
+\end{array}
+$$
+
+The lower horizontal edge is exactly the `child-relation` field consumed by
+`StructuralNameInstantiationProof.agda`.  The target-only peel modules already
+provide the right vertical edge and finalizer:
+
+```agda
+structural-target-all-peel
+structural-target-gen-peel
+structural-target-reveal-peel
+structural-target-conceal-peel
+```
+
+The live LG-3 repair supplies target-cast step support such as
+`target-id-step-inversion`, exposed ground/expand cast cells, and generated
+projection replacements.  It does not export the polymorphic wrapper strip
+theorems above.  Proving those theorems would be an induction over `⊢²`, so it
+falls under the standing rule for new major lemmas.
+
+No live Agda statement, term-imprecision relation, reduction relation, or
+Catchup knot file was changed for this proposal.

--- a/GTSFImp/proof/DGG/notes/t5-target-wrapper-strip-stop.red
+++ b/GTSFImp/proof/DGG/notes/t5-target-wrapper-strip-stop.red
@@ -1,0 +1,157 @@
+T5 target-wrapper strip stop: fixed child surface lacks the needed evidence
+
+Date: 2026-08-17
+
+Status: stopped before live implementation.
+
+Scope
+-----
+
+This checks the approved D4 target-wrapper strip surfaces against the live
+stage-1 interfaces:
+
+- `StructuralAllCastStrictSurfaceᵀ`
+- `StructuralGenStrictSurfaceᵀ`
+- `StructuralRevealStrictSurfaceᵀ`
+- `StructuralConcealStrictSurfaceᵀ`
+
+No D4.2 or D4.3 work is included here.  The `Λ-cell` and
+`conceal-equal-ok` residuals remain separate.
+
+
+Same-world `∀ᶜ` strip obstruction
+----------------------------------
+
+The top relation case has the intended lower edge:
+
+```agda
+rel : W ∣ γ ⊢² M ⊑ V ⟨ ∀ᶜ d ⟩ ∶ p
+prem : W ∣ γ ⊢² M ⊑ V ∶ child-endpoint
+```
+
+but the fixed `StructuralStrictChild` output also requires a child
+absorption chain for:
+
+```agda
+name-type-app-frame B X refl refl ▻ⁱ
+cast-frame (d [ ＇ X ]ᶜ) ▻ⁱ
+mapInstantiationSpine keep spine
+```
+
+The live parent input gives only:
+
+```agda
+chain : TargetFrameAbsorptionChain W γ Aₛ
+  (name-type-app-frame C X refl refl ▻ⁱ spine) q
+```
+
+Even after inversion of the constructor shape to `tfa-name tail`, the exposed
+tail has type:
+
+```agda
+tail : TargetFrameAbsorptionChain W γ Aₛ spine q
+```
+
+The checked child-chain builder `allv-∀-child-frame-chain` instead needs:
+
+```agda
+qCast : Aₛ ⊑ᵂ⟨ W ⟩ C [ ＇ X ]ᵗ
+tailᵏ : TargetFrameAbsorptionChain W γ Aₛ
+  (mapInstantiationSpine keep spine) q
+```
+
+No live input field, target peel package, or existing helper provides either
+`qCast` or a generic `TargetFrameAbsorptionChain` map-`keep` transport.  The
+typed side has `spine-typed-map-keep`, but the absorption-chain side does not.
+Adding that generic chain transport, or adding generated-frame geometry to the
+strict surface input, is a new surface/infrastructure change rather than a
+local inhabitant of the fixed field.
+
+
+Source-wrapper replay endpoint obstruction
+------------------------------------------
+
+For the four target strips, source-side replay cases such as:
+
+```agda
+cast⊑² c prem q
+Λ⊑² ...
+Λ⊑²-smart-comma ...
+reveal⊑² ...
+conceal⊑² ...
+```
+
+need the child endpoint for the stripped target head at the parent source
+type.  The existing hereditary `StructuralNamePostPlan` supplies source-child
+endpoints for the final target type `E`, which is enough for the checked
+stage-1 worker.  It does not supply the start endpoint of the strict child
+spine, such as:
+
+```agda
+A′ ⊑ᵂ⟨ W ⟩ `∀ B
+A′ ⊑ᵂ⟨ W₁ ⟩ ⇑ᵗ A
+```
+
+after replaying a source cast or source wrapper.  This is the same endpoint
+shape that `target-id-step-inversion` avoids because an identity target cast
+does not change the target endpoint.
+
+
+Reveal/conceal sealed-partner stop
+----------------------------------
+
+The source-conceal replay case for target reveal hits the sealed-material
+warning directly.  A parent partner can be valid only because the visible
+target is a reveal wrapper:
+
+```agda
+ok : SourceConcealPartnerOK Wᵖ U c Xᴿ? (V ↑ `∀↑ d)
+ok = seal-partner-ok (plain-target not-↑)
+```
+
+The desired strip would need a partner for the child endpoint:
+
+```agda
+SourceConcealPartnerOK W₁ᵖ U c Xᴿ? (⇑ᵗᵐ V)
+```
+
+There is no constructor that transforms `plain-target not-↑` into a partner
+for arbitrary `⇑ᵗᵐ V`.
+
+Diagram:
+
+    U ↓ c    ⊑    V ↑ `∀↑ d
+      │0             │ β-reveal-∀
+      │              │
+    U ↓ c    ⊑    ⇑ᵗᵐ V
+
+The target conceal case is analogous:
+
+```agda
+ok : SourceConcealPartnerOK Wᵖ U c Xᴿ? (V ↓ `∀↓ d)
+ok = seal-partner-ok (plain-target not-↓)
+```
+
+The desired child partner would again target arbitrary `⇑ᵗᵐ V`, and the
+visible `not-↓` evidence is lost.
+
+Diagram:
+
+    U ↓ c    ⊑    V ↓ `∀↓ d
+      │0             │ β-conceal-∀
+      │              │
+    U ↓ c    ⊑    ⇑ᵗᵐ V
+
+This is not a request for a stronger premise.  The case is inexpressible with
+the current partner surface, so the reveal/conceal strips were stopped rather
+than forced.
+
+
+Verdict
+-------
+
+The approved D4 relation-recursive idea is still the right shape for the
+exposed target-head cases, but the fixed live strict-child surface lacks
+evidence needed by total source-wrapper replay and by the same-world `∀ᶜ`
+child chain.  No live Agda module, Def file, term-imprecision relation, or
+Catchup knot file was changed for this stop.


### PR DESCRIPTION
**Main is currently RED**: `SimPrimitiveValuesProof.agda` from PR #154 fails `make agda` with a mixfix parse ambiguity ("Could not parse the application ... —→[ keep ]⟨ ... ⟩ ... ∎[]" at lines 49-54) — the gate was evidently not run before merge. This PR's first commit repairs it (disambiguated via an explicit helper `sim-primitive-constant-targets`); supervisor gate-verified green (All + LegacyAll + postulate-check). Recommend merging this promptly to heal main; PR #159 carries an alternative overlapping fix and will rebase.

Second commit: NS-4 stage 2 stopped under the standing major-lemma rule — the four non-Λ strict view cells need derivation-recursive target-wrapper strip theorems over ⊢² (analogous to target-id-step-inversion). Proposal with statements in notes/t5-target-wrapper-strip-proposal.red; posted as decision ask D4 on #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)