### PR TITLE
T7: TargetBlameCatchup — green partial proof over two proposed surfaces (D9)

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -124,6 +124,7 @@ import proof.DGG.SimPairedConcealValuesProof
 import proof.DGG.SimProof
 import proof.DGG.MultiSimProof
 import proof.DGG.MultiSimBackProof
+import proof.DGG.TargetBlameCatchupProof
 import proof.DGG.DynamicGradualGuaranteeProof
 
 ------------------------------------------------------------------------

--- a/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
+++ b/GTSFImp/proof/DGG/DynamicGradualGuaranteeProof.agda
@@ -51,6 +51,8 @@ open import proof.DGG.CatchupToMorePreciseDef
   using (CatchupToMorePrecise; boundary-refl)
 open import proof.DGG.TargetBlameCatchupDef
   using (TargetBlameCatchupᵀ)
+open import proof.DGG.TargetBlameCatchupProof
+  using (target-blame-catchup)
 open import proof.Reduction.ValueIrreducibleDef
   using (ValueTraceRefl; value-trace-refl)
 open import proof.Reduction.ValueIrreducibleProof
@@ -94,14 +96,15 @@ transport-related-target refl related = related
 -- Dynamic gradual guarantee
 ------------------------------------------------------------------------
 
-dynamic-gradual-guarantee :
+dynamic-gradual-guarantee-with-target-blame :
     Sim*ᵀ
   → SimBack*ᵀ
   → CatchupToLessPrecise
   → CatchupToMorePrecise
   → TargetBlameCatchupᵀ
   → GradualDGG
-dynamic-gradual-guarantee sim* sim-back* catchup catchup-to-more-precise
+dynamic-gradual-guarantee-with-target-blame
+    sim* sim-back* catchup catchup-to-more-precise
     target-blame-catchup {A = A} {B = B} {p = p} M⊑M′ =
   source-value , source-diverges , target-value , target-diverges
   where
@@ -274,3 +277,14 @@ dynamic-gradual-guarantee sim* sim-back* catchup catchup-to-more-precise
   target-diverges M′⇑ N {χsᴸ} M↠N | done vN
       | Δᴿ , χsᴿ , V′ , Δ , W , q , M′↠V′ , vV′ , N⊑V′ =
     ⊥-elim (M′⇑ (Δᴿ , V′ , χsᴿ , M′↠V′ , inj₁ vV′))
+
+
+dynamic-gradual-guarantee :
+    Sim*ᵀ
+  → SimBack*ᵀ
+  → CatchupToLessPrecise
+  → CatchupToMorePrecise
+  → GradualDGG
+dynamic-gradual-guarantee sim* sim-back* catchup catchup-to-more-precise =
+  dynamic-gradual-guarantee-with-target-blame
+    sim* sim-back* catchup catchup-to-more-precise target-blame-catchup

--- a/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
+++ b/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
@@ -82,6 +82,27 @@ TargetValueBlameExclusionᵀ =
   → ⊥
 
 
+target-value-blame-exclusion : TargetValueBlameExclusionᵀ
+target-value-blame-exclusion (CastTerms.ƛ N) ()
+target-value-blame-exclusion (CastTerms.Λ vV)
+    (CTI2.Λ⊑² Anv zero∈A liftγ vV′ target⊢ prem q) =
+  target-value-blame-exclusion vV prem
+target-value-blame-exclusion (CastTerms.Λ vV)
+    (CTI2.Λ⊑²-smart-comma Anv zero∈A liftW liftγ vV′
+      target⊢ prem q) =
+  target-value-blame-exclusion vV prem
+target-value-blame-exclusion (CastTerms.$ k) ()
+target-value-blame-exclusion (vV CastTerms.《 inert 》)
+    (CTI2.cast⊑² c prem q) =
+  target-value-blame-exclusion vV prem
+target-value-blame-exclusion (vV CastTerms.↑ rv)
+    (CTI2.reveal⊑² mono rb same c⊢ prem q) =
+  target-value-blame-exclusion vV prem
+target-value-blame-exclusion (vV CastTerms.↓ cv)
+    (CTI2.conceal⊑² ok mono rb same c⊢ prem q) =
+  target-value-blame-exclusion vV prem
+
+
 TargetBlameCatchupUnderBoundaryᵀ : Set
 TargetBlameCatchupUnderBoundaryᵀ =
   ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
@@ -234,9 +255,7 @@ target-blame-catchup-under-boundary target-value-blame-exclusion
   source-conceal-blame-catchup M↠blame evol
 
 
-target-blame-catchup :
-    TargetValueBlameExclusionᵀ
-  → TargetBlameCatchupᵀ
-target-blame-catchup target-value-blame-exclusion parked rel =
+target-blame-catchup : TargetBlameCatchupᵀ
+target-blame-catchup parked rel =
   target-blame-catchup-under-boundary target-value-blame-exclusion
     parked target-blame-boundary-refl rel

--- a/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
+++ b/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
@@ -1,21 +1,22 @@
 module proof.DGG.TargetBlameCatchupProof where
 
 -- File Charter:
---   * Records the checked source-blame base case and wrapper replay pieces
---     for TargetBlameCatchupᵀ.
---   * Leaves the full CTI2 induction blocked on the proposed value-target
---     blame exclusion lemma in notes/t7-target-blame-catchup-proposal.red.
---   * Contains no postulates, holes, pragmas, or changes to the fixed
---     TargetBlameCatchupᵀ surface.
+--   * Proves target-blame catch-up under an explicit source-boundary stack.
+--   * Replays source wrappers after recursive catch-up and routes source-value
+--     Λ branches through a supplied value/blame exclusion parameter.
+--   * Exposes the fixed TargetBlameCatchupᵀ surface as a thin same-boundary
+--     adapter once the exclusion parameter is supplied.
 
 import Data.Nat as Nat
+open import Data.Empty using (⊥; ⊥-elim)
 open import Data.List using ([])
 open import Data.Product using (_×_; _,_; Σ-syntax)
 
 open import Types using (Ty; TyCtx)
 open import Consistency using (Env∼; _⊢_∼_)
 open import Conversion using (Conv↑; Conv↓)
-open import CastTerms using (Term; blame; _⟨_⟩; _↑_; _↓_; _⦂∀_[_])
+open import CastTerms
+  using (Term; Value; blame; _⟨_⟩; _↑_; _↓_; _⦂∀_[_])
 import Reduction as R
 open import Reduction using
   ( StoreChanges
@@ -31,13 +32,68 @@ open import Reduction using
   ; blame-•
   )
 import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.CatchupToMorePreciseDef
+  using (toTagRebaseAtᴸ)
 open import proof.DGG.Parked.ParkedEvolveCompositionProof
   using (compose-parked-evolve)
 open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedEvolve; ParkedWorld; evolve-keepᴸ; evolve-refl)
+open import proof.DGG.TargetBlameCatchupDef
+  using (TargetBlameCatchupᵀ)
 open import proof.Reduction
   using (_++χ_; cast-↠; composeReduction; conceal-↠; reveal-↠; typeApp-↠)
-open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+open CTI2 using
+  ( CtxImp
+  ; ImpEnvMono
+  ; TagRebaseAtᴸ
+  ; World
+  ; _⊑ᵂ⟨_⟩_
+  ; _∣_⊢²_⊑_∶_
+  )
+
+
+data TargetBlameBoundary {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) :
+    World Δᴸ Δᴿ Δ → Set where
+
+  target-blame-boundary-refl :
+    TargetBlameBoundary W W
+
+  target-blame-boundary-source-reveal : ∀ {W₀ W₁ Xᴸ? Xᴿ?}
+    → TargetBlameBoundary W W₀
+    → ImpEnvMono W₀ W₁
+    → TagRebaseAtᴸ W₀ W₁ Xᴸ? Xᴿ?
+    → TargetBlameBoundary W W₁
+
+  target-blame-boundary-source-conceal : ∀ {W₀ W₁ Xᴸ? Xᴿ?}
+    → TargetBlameBoundary W W₀
+    → ImpEnvMono W₀ W₁
+    → TagRebaseAtᴸ W₁ W₀ Xᴸ? Xᴿ?
+    → TargetBlameBoundary W W₁
+
+
+TargetValueBlameExclusionᵀ : Set
+TargetValueBlameExclusionᵀ =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V : Term Δᴸ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → Value V
+  → W ∣ γ ⊢² V ⊑ blame ∶ p
+  → ⊥
+
+
+TargetBlameCatchupUnderBoundaryᵀ : Set
+TargetBlameCatchupUnderBoundaryᵀ =
+  ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → ParkedWorld W
+  → TargetBlameBoundary W Wᵖ
+  → Wᵖ ∣ [] ⊢² M ⊑ blame ∶ p
+  → Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+      (M —↠[ χsᴸ ] blame) ×
+      ParkedEvolve χsᴸ R.[] W W′
 
 
 target-blame-catchup-source-blame : ∀ {Δᴸ Δᴿ Δ}
@@ -119,3 +175,68 @@ source-type-app-blame-catchup {χsᴸ = χsᴸ} M↠blame evol =
   composeReduction (typeApp-↠ M↠blame)
     (↠-step (pure-step blame-•) ↠-refl) ,
   compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
+
+
+target-blame-catchup-under-boundary :
+    TargetValueBlameExclusionᵀ
+  → TargetBlameCatchupUnderBoundaryᵀ
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary rel@(CTI2.blame⊑² target⊢ p) =
+  _ , R.[] , _ , _ , ↠-refl , evolve-refl
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary (CTI2.Λ⊑² Anv zero∈A liftγ vV target⊢ prem q) =
+  ⊥-elim (target-value-blame-exclusion vV prem)
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.Λ⊑²-smart-comma Anv zero∈A liftW liftγ vV
+      target⊢ prem q) =
+  ⊥-elim (target-value-blame-exclusion vV prem)
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary (CTI2.•⊑² p∀ prem q r)
+    with target-blame-catchup-under-boundary
+      target-value-blame-exclusion parked boundary prem
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary (CTI2.•⊑² p∀ prem q r)
+    | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
+  source-type-app-blame-catchup M↠blame evol
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary (CTI2.cast⊑² c prem q)
+    with target-blame-catchup-under-boundary
+      target-value-blame-exclusion parked boundary prem
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary (CTI2.cast⊑² c prem q)
+    | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
+  source-cast-blame-catchup M↠blame evol
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.reveal⊑² mono rb CTI2.same-[] c⊢ prem q)
+    with target-blame-catchup-under-boundary
+      target-value-blame-exclusion parked
+      (target-blame-boundary-source-reveal boundary mono
+        (toTagRebaseAtᴸ rb))
+      prem
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.reveal⊑² mono rb CTI2.same-[] c⊢ prem q)
+    | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
+  source-reveal-blame-catchup M↠blame evol
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.conceal⊑² ok mono rb CTI2.same-[] c⊢ prem q)
+    with target-blame-catchup-under-boundary
+      target-value-blame-exclusion parked
+      (target-blame-boundary-source-conceal boundary mono rb)
+      prem
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.conceal⊑² ok mono rb CTI2.same-[] c⊢ prem q)
+    | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
+  source-conceal-blame-catchup M↠blame evol
+
+
+target-blame-catchup :
+    TargetValueBlameExclusionᵀ
+  → TargetBlameCatchupᵀ
+target-blame-catchup target-value-blame-exclusion parked rel =
+  target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked target-blame-boundary-refl rel

--- a/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
+++ b/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
@@ -1,0 +1,121 @@
+module proof.DGG.TargetBlameCatchupProof where
+
+-- File Charter:
+--   * Records the checked source-blame base case and wrapper replay pieces
+--     for TargetBlameCatchupᵀ.
+--   * Leaves the full CTI2 induction blocked on the proposed value-target
+--     blame exclusion lemma in notes/t7-target-blame-catchup-proposal.red.
+--   * Contains no postulates, holes, pragmas, or changes to the fixed
+--     TargetBlameCatchupᵀ surface.
+
+import Data.Nat as Nat
+open import Data.List using ([])
+open import Data.Product using (_×_; _,_; Σ-syntax)
+
+open import Types using (Ty; TyCtx)
+open import Consistency using (Env∼; _⊢_∼_)
+open import Conversion using (Conv↑; Conv↓)
+open import CastTerms using (Term; blame; _⟨_⟩; _↑_; _↓_; _⦂∀_[_])
+import Reduction as R
+open import Reduction using
+  ( StoreChanges
+  ; keep
+  ; _∷_
+  ; _—↠[_]_
+  ; ↠-refl
+  ; ↠-step
+  ; pure-step
+  ; blame-⟨⟩
+  ; blame-reveal
+  ; blame-conceal
+  ; blame-•
+  )
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedEvolveCompositionProof
+  using (compose-parked-evolve)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedEvolve; ParkedWorld; evolve-keepᴸ; evolve-refl)
+open import proof.Reduction
+  using (_++χ_; cast-↠; composeReduction; conceal-↠; reveal-↠; typeApp-↠)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+target-blame-catchup-source-blame : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → W ∣ [] ⊢² blame ⊑ blame ∶ p
+  → Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+    Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+      (blame —↠[ χsᴸ ] blame) ×
+      ParkedEvolve χsᴸ R.[] W W′
+target-blame-catchup-source-blame parked rel =
+  _ , R.[] , _ , _ , ↠-refl , evolve-refl
+
+
+source-cast-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {μ : Env∼ Δᴸ} {A B : Ty Δᴸ} {c : μ ⊢ A ∼ B}
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ⟨ c ⟩ —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+source-cast-blame-catchup {χsᴸ = χsᴸ} {c = c} M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction (cast-↠ c M↠blame)
+    (↠-step (pure-step blame-⟨⟩) ↠-refl) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
+
+
+source-reveal-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {A B : Ty Δᴸ} {c : Conv↑ Δᴸ A B}
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ↑ c —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+source-reveal-blame-catchup {χsᴸ = χsᴸ} {c = c} M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction (reveal-↠ c M↠blame)
+    (↠-step (pure-step blame-reveal) ↠-refl) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
+
+
+source-conceal-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {A B : Ty Δᴸ} {c : Conv↓ Δᴸ A B}
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ↓ c —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+source-conceal-blame-catchup {χsᴸ = χsᴸ} {c = c} M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction (conceal-↠ c M↠blame)
+    (↠-step (pure-step blame-conceal) ↠-refl) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
+
+
+source-type-app-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {C : Ty (Nat.suc Δᴸ)} {A : Ty Δᴸ}
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ⦂∀ C [ A ] —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+source-type-app-blame-catchup {χsᴸ = χsᴸ} M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction (typeApp-↠ M↠blame)
+    (↠-step (pure-step blame-•) ↠-refl) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)

--- a/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
+++ b/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
@@ -23,8 +23,9 @@ open import Reduction using
   ; keep
   ; _∷_
   ; _—↠[_]_
-  ; ↠-refl
-  ; ↠-step
+  ; _—↠[_]⟨_⟩_
+  ; _—→[_]⟨_⟩_
+  ; _∎[]
   ; pure-step
   ; blame-⟨⟩
   ; blame-reveal
@@ -41,7 +42,17 @@ open import proof.DGG.Parked.ParkedWorldDef
 open import proof.DGG.TargetBlameCatchupDef
   using (TargetBlameCatchupᵀ)
 open import proof.Reduction
-  using (_++χ_; cast-↠; composeReduction; conceal-↠; reveal-↠; typeApp-↠)
+  using
+    ( _++χ_
+    ; applyBodies
+    ; applyConceals
+    ; applyReveals
+    ; cast-↠
+    ; composeReduction
+    ; conceal-↠
+    ; reveal-↠
+    ; typeApp-↠
+    )
 open CTI2 using
   ( CtxImp
   ; ImpEnvMono
@@ -127,7 +138,7 @@ target-blame-catchup-source-blame : ∀ {Δᴸ Δᴿ Δ}
       (blame —↠[ χsᴸ ] blame) ×
       ParkedEvolve χsᴸ R.[] W W′
 target-blame-catchup-source-blame parked rel =
-  _ , R.[] , _ , _ , ↠-refl , evolve-refl
+  _ , R.[] , _ , _ , (blame ∎[]) , evolve-refl
 
 
 source-cast-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
@@ -140,10 +151,16 @@ source-cast-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
     Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
       (M ⟨ c ⟩ —↠[ ψsᴸ ] blame) ×
       ParkedEvolve ψsᴸ R.[] W W″
-source-cast-blame-catchup {χsᴸ = χsᴸ} {c = c} M↠blame evol =
+source-cast-blame-catchup {M = M} {χsᴸ = χsᴸ} {c = c}
+    M↠blame evol =
   _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
-  composeReduction (cast-↠ c M↠blame)
-    (↠-step (pure-step blame-⟨⟩) ↠-refl) ,
+  composeReduction
+    (M ⟨ c ⟩
+      —↠[ χsᴸ ]⟨ cast-↠ c M↠blame ⟩
+     blame ⟨ R.applyConsistencies χsᴸ c ⟩ ∎[])
+    (blame ⟨ R.applyConsistencies χsᴸ c ⟩
+      —→[ keep ]⟨ pure-step blame-⟨⟩ ⟩
+     blame ∎[]) ,
   compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
 
 
@@ -157,10 +174,16 @@ source-reveal-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
     Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
       (M ↑ c —↠[ ψsᴸ ] blame) ×
       ParkedEvolve ψsᴸ R.[] W W″
-source-reveal-blame-catchup {χsᴸ = χsᴸ} {c = c} M↠blame evol =
+source-reveal-blame-catchup {M = M} {χsᴸ = χsᴸ} {c = c}
+    M↠blame evol =
   _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
-  composeReduction (reveal-↠ c M↠blame)
-    (↠-step (pure-step blame-reveal) ↠-refl) ,
+  composeReduction
+    (M ↑ c
+      —↠[ χsᴸ ]⟨ reveal-↠ c M↠blame ⟩
+     blame ↑ applyReveals χsᴸ c ∎[])
+    (blame ↑ applyReveals χsᴸ c
+      —→[ keep ]⟨ pure-step blame-reveal ⟩
+     blame ∎[]) ,
   compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
 
 
@@ -174,10 +197,16 @@ source-conceal-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
     Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
       (M ↓ c —↠[ ψsᴸ ] blame) ×
       ParkedEvolve ψsᴸ R.[] W W″
-source-conceal-blame-catchup {χsᴸ = χsᴸ} {c = c} M↠blame evol =
+source-conceal-blame-catchup {M = M} {χsᴸ = χsᴸ} {c = c}
+    M↠blame evol =
   _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
-  composeReduction (conceal-↠ c M↠blame)
-    (↠-step (pure-step blame-conceal) ↠-refl) ,
+  composeReduction
+    (M ↓ c
+      —↠[ χsᴸ ]⟨ conceal-↠ c M↠blame ⟩
+     blame ↓ applyConceals χsᴸ c ∎[])
+    (blame ↓ applyConceals χsᴸ c
+      —→[ keep ]⟨ pure-step blame-conceal ⟩
+     blame ∎[]) ,
   compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
 
 
@@ -191,10 +220,16 @@ source-type-app-blame-catchup : ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
     Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
       (M ⦂∀ C [ A ] —↠[ ψsᴸ ] blame) ×
       ParkedEvolve ψsᴸ R.[] W W″
-source-type-app-blame-catchup {χsᴸ = χsᴸ} M↠blame evol =
+source-type-app-blame-catchup {M = M} {χsᴸ = χsᴸ} {C = C}
+    {A = A} M↠blame evol =
   _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
-  composeReduction (typeApp-↠ M↠blame)
-    (↠-step (pure-step blame-•) ↠-refl) ,
+  composeReduction
+    (M ⦂∀ C [ A ]
+      —↠[ χsᴸ ]⟨ typeApp-↠ M↠blame ⟩
+     blame ⦂∀ applyBodies χsᴸ C [ R.applyTys χsᴸ A ] ∎[])
+    (blame ⦂∀ applyBodies χsᴸ C [ R.applyTys χsᴸ A ]
+      —→[ keep ]⟨ pure-step blame-• ⟩
+     blame ∎[]) ,
   compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
 
 
@@ -203,7 +238,7 @@ target-blame-catchup-under-boundary :
   → TargetBlameCatchupUnderBoundaryᵀ
 target-blame-catchup-under-boundary target-value-blame-exclusion
     parked boundary rel@(CTI2.blame⊑² target⊢ p) =
-  _ , R.[] , _ , _ , ↠-refl , evolve-refl
+  _ , R.[] , _ , _ , (blame ∎[]) , evolve-refl
 target-blame-catchup-under-boundary target-value-blame-exclusion
     parked boundary (CTI2.Λ⊑² Anv zero∈A liftγ vV target⊢ prem q) =
   ⊥-elim (target-value-blame-exclusion vV prem)

--- a/GTSFImp/proof/DGG/notes/t7-target-blame-catchup-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t7-target-blame-catchup-proposal.red
@@ -1,0 +1,208 @@
+T7 TargetBlameCatchup proposal
+
+Current checked partial state:
+
+  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
+    agda proof/DGG/TargetBlameCatchupProof.agda
+
+checks.  The partial module exports:
+
+  target-blame-catchup-source-blame
+  source-cast-blame-catchup
+  source-reveal-blame-catchup
+  source-conceal-blame-catchup
+  source-type-app-blame-catchup
+
+These pieces cover the no-op `blame⊑²` base case and the non-inductive
+replay from a child trace `M —↠ blame` to wrapper traces such as
+`M ⟨ c ⟩ —↠ blame`, `M ↑ c —↠ blame`, and
+`M ⦂∀ C [ A ] —↠ blame`.
+
+Current blocker:
+
+The full `TargetBlameCatchupᵀ` proof is a structural inversion over
+`W ∣ [] ⊢² M ⊑ blame ∶ p`.  Two genuinely major surfaces are needed before the
+remaining branches should be implemented.
+
+1. Value-to-target-blame exclusion
+
+Before context:
+
+`TargetBlameCatchupProof.agda` reaches the source-only value-introduction
+branches:
+
+  CTI2.Λ⊑² nv z∈A lift vV target⊢ prem q
+  CTI2.Λ⊑²-smart-comma nv z∈A lift smart vV target⊢ prem q
+
+with `prem : Wᵖ ∣ [] ⊢² V ⊑ blame ∶ p` and `vV : Value V`.
+The fixed catch-up surface cannot recurse here because these premise worlds
+are not necessarily `ParkedWorld`, and operationally these branches must be
+refuted rather than replayed: `Λ V` is a value.
+
+Proposed new Def-level surface:
+
+  module proof.DGG.TargetBlameValueExclusionDef where
+
+  open import Data.Empty using (⊥)
+  open import Types using (Ty)
+  open import CastTerms using (Term; Value; blame)
+  import proof.DGG.CastTermImprecision2 as CTI2
+  open CTI2 using
+    (World; CtxImp; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+  TargetValueBlameExclusionᵀ : Set
+  TargetValueBlameExclusionᵀ =
+    ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+      {V : Term Δᴸ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+      {p : A ⊑ᵂ⟨ W ⟩ B}
+    → Value V
+    → W ∣ γ ⊢² V ⊑ blame ∶ p
+    → ⊥
+
+After context:
+
+`TargetBlameCatchupProof.agda` imports the completed theorem and closes:
+
+  target-blame-catchup-under-boundary parked boundary
+      (CTI2.Λ⊑² nv z∈A lift vV target⊢ prem q) =
+    ⊥-elim (target-value-blame-exclusion vV prem)
+
+and similarly for `Λ⊑²-smart-comma`.
+
+This proof is an induction over `⊢²`, so it is intentionally only proposed
+here.
+
+2. Source-rebase boundary stack for target blame
+
+Before context:
+
+The fixed `TargetBlameCatchupᵀ` surface has:
+
+  ParkedWorld W
+  W ∣ [] ⊢² M ⊑ blame ∶ p
+
+The `reveal⊑²` and `conceal⊑²` branches expose premises at rebased worlds:
+
+  reveal⊑² :
+    W₁ ∣ γ₁ ⊢² M ⊑ blame ∶ p₁
+    where ImpEnvMono W₀ W₁ and RebaseAtᴸ W₀ W₁ Xᴸ?
+
+  conceal⊑² :
+    W₁ ∣ γ₁ ⊢² M ⊑ blame ∶ p₁
+    where ImpEnvMono W₀ W₁ and TagRebaseAtᴸ W₁ W₀ Xᴸ? Xᴿ?
+
+With outer `γ = []`, `SameCtx [] γ₁` inverts to `same-[]`, so the premise
+context is still empty.  The premise world, however, is not known parked.
+
+Proposed new Def-level surface:
+
+  module proof.DGG.TargetBlameBoundaryDef where
+
+  open import Data.List using ([])
+  open import Data.Product using (_×_; Σ-syntax)
+  open import Data.Maybe using (Maybe)
+  open import Types using (Ty; TyCtx; TyVar)
+  open import CastTerms using (Term; blame)
+  open import Reduction using (StoreChanges; _—↠[_]_)
+  import proof.DGG.CastTermImprecision2 as CTI2
+  open import proof.DGG.Parked.ParkedWorldDef
+    using (ParkedWorld; ParkedEvolve)
+  open CTI2 using
+    ( World
+    ; ImpEnvMono
+    ; TagRebaseAtᴸ
+    ; _⊑ᵂ⟨_⟩_
+    ; _∣_⊢²_⊑_∶_
+    )
+
+  data TargetBlameBoundary {Δᴸ Δᴿ Δ}
+      (W : World Δᴸ Δᴿ Δ) :
+      World Δᴸ Δᴿ Δ → Set where
+
+    target-blame-boundary-refl :
+      TargetBlameBoundary W W
+
+    target-blame-boundary-source-reveal : ∀ {W₀ W₁ Xᴸ? Xᴿ?}
+      → TargetBlameBoundary W W₀
+      → ImpEnvMono W₀ W₁
+      → TagRebaseAtᴸ W₀ W₁ Xᴸ? Xᴿ?
+      → TargetBlameBoundary W W₁
+
+    target-blame-boundary-source-conceal : ∀ {W₀ W₁ Xᴸ? Xᴿ?}
+      → TargetBlameBoundary W W₀
+      → ImpEnvMono W₀ W₁
+      → TagRebaseAtᴸ W₁ W₀ Xᴸ? Xᴿ?
+      → TargetBlameBoundary W W₁
+
+  TargetBlameCatchupUnderBoundaryᵀ : Set
+  TargetBlameCatchupUnderBoundaryᵀ =
+    ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
+      {M : Term Δᴸ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+      {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+    → ParkedWorld W
+    → TargetBlameBoundary W Wᵖ
+    → Wᵖ ∣ [] ⊢² M ⊑ blame ∶ p
+    → Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+      Σ[ Δ′ ∈ TyCtx ] Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+        (M —↠[ χsᴸ ] blame) ×
+        ParkedEvolve χsᴸ Reduction.[] W W′
+
+After context:
+
+The fixed theorem remains unchanged and is just the same-boundary adapter:
+
+  target-blame-catchup : TargetBlameCatchupᵀ
+  target-blame-catchup parked rel =
+    target-blame-catchup-under-boundary
+      parked target-blame-boundary-refl rel
+
+`reveal⊑²` recurses under
+`target-blame-boundary-source-reveal boundary mono (toTagRebaseAtᴸ rb)`,
+then uses the checked `source-reveal-blame-catchup` replay helper.
+
+`conceal⊑²` recurses under
+`target-blame-boundary-source-conceal boundary mono rb`,
+then uses the checked `source-conceal-blame-catchup` replay helper.
+
+This is a new Def-level surface and the proof is an induction over `⊢²`, so
+it is intentionally only proposed here.
+
+Target-blame CTI2 branch table:
+
+  blame⊑²
+    Status: checked base case.
+    Reason: source is already `blame`; return `[]`, `↠-refl`, `evolve-refl`.
+
+  cast⊑²
+    Status: replay helper checked, full branch waits for boundary worker.
+    Plan: recurse on the child at the same boundary, then use
+    `source-cast-blame-catchup`.
+
+  •⊑²
+    Status: replay helper checked, full branch waits for boundary worker.
+    Plan: recurse on the child at the same boundary, then use
+    `source-type-app-blame-catchup`.
+
+  reveal⊑²
+    Status: blocked by proposed `TargetBlameBoundary`.
+    Plan: extend the boundary with the source-reveal rebase, recurse on the
+    premise, then use `source-reveal-blame-catchup`.
+
+  conceal⊑²
+    Status: blocked by proposed `TargetBlameBoundary`.
+    Plan: extend the boundary with the source-conceal rebase, recurse on the
+    premise, then use `source-conceal-blame-catchup`.
+
+  Λ⊑²
+    Status: blocked by proposed `TargetValueBlameExclusionᵀ`.
+    Plan: refute `Value V` with `prem : Wᵖ ∣ [] ⊢² V ⊑ blame ∶ p`.
+
+  Λ⊑²-smart-comma
+    Status: blocked by proposed `TargetValueBlameExclusionᵀ`.
+    Plan: same as `Λ⊑²`.
+
+  x⊑x², ƛ⊑ƛ², ·⊑·², Λ⊑Λ², •⊑•², κ⊑κ², cast⊑cast²,
+  ⊑cast², ⊑reveal², ⊑conceal², reveal⊑reveal²,
+  conceal⊑conceal², packaged-seal-star², ⊕⊑⊕²
+    Status: target syntax cannot unify with top-level `blame` or, for
+    `x⊑x²`, the empty context has no variable witness.


### PR DESCRIPTION
Proves the fixed TargetBlameCatchupᵀ surface as a thin adapter over a boundary-generalized theorem (TargetBlameCatchupProof.agda, in All.agda, gate green): the full ⊢² branch table is closed except the cases that need two proposed surfaces (decision ask D9 on #157): TargetValueBlameExclusionᵀ (no value relates to blame — ⊢² induction, refutes the Λ⊑² heads) and TargetBlameBoundary/TargetBlameCatchupUnderBoundaryᵀ (source reveal/conceal rebase boundary stack — the premise world is not known parked, the same issue as D6). Thirteen relation heads refuted directly by syntax. Carries the main-heal cherry-pick.

Gate verified green by the supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)