### PR TITLE
T9: CatchupToLessPrecise reconnaissance — left-stack architecture proposals (D11)

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -115,6 +115,7 @@ import proof.DGG.Catchup.ValueCatchupRightProof
 import proof.DGG.Catchup.FuelKnotProof
 import proof.DGG.Catchup.FuelDischargeProof
 import proof.DGG.Catchup.LeftBoundaryCatchupDef
+import proof.DGG.Catchup.LeftValueCatchupDef
 
 ------------------------------------------------------------------------
 -- Current frontier (M8: higher-order DGG assembly)

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -116,6 +116,7 @@ import proof.DGG.Catchup.FuelKnotProof
 import proof.DGG.Catchup.FuelDischargeProof
 import proof.DGG.Catchup.LeftBoundaryCatchupDef
 import proof.DGG.Catchup.LeftValueCatchupDef
+import proof.DGG.Catchup.LeftSourceOperationsDef
 
 ------------------------------------------------------------------------
 -- Current frontier (M8: higher-order DGG assembly)
@@ -129,6 +130,7 @@ import proof.DGG.SimProof
 import proof.DGG.MultiSimProof
 import proof.DGG.MultiSimBackProof
 import proof.DGG.TargetBlameCatchupProof
+import proof.DGG.SimConcealRevealPeel
 import proof.DGG.DynamicGradualGuaranteeProof
 
 ------------------------------------------------------------------------

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -131,6 +131,7 @@ import proof.DGG.MultiSimProof
 import proof.DGG.MultiSimBackProof
 import proof.DGG.TargetBlameCatchupProof
 import proof.DGG.SimConcealRevealPeel
+import proof.DGG.CatchupToLessPreciseProof
 import proof.DGG.DynamicGradualGuaranteeProof
 
 ------------------------------------------------------------------------

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -117,6 +117,7 @@ import proof.DGG.Catchup.FuelDischargeProof
 import proof.DGG.Catchup.LeftBoundaryCatchupDef
 import proof.DGG.Catchup.LeftValueCatchupDef
 import proof.DGG.Catchup.LeftSourceOperationsDef
+import proof.DGG.Catchup.LeftValueCatchupProof
 
 ------------------------------------------------------------------------
 -- Current frontier (M8: higher-order DGG assembly)

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -114,6 +114,7 @@ import proof.DGG.Catchup.ExtraCastRightAtProof
 import proof.DGG.Catchup.ValueCatchupRightProof
 import proof.DGG.Catchup.FuelKnotProof
 import proof.DGG.Catchup.FuelDischargeProof
+import proof.DGG.Catchup.LeftBoundaryCatchupDef
 
 ------------------------------------------------------------------------
 -- Current frontier (M8: higher-order DGG assembly)

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -117,6 +117,7 @@ import proof.DGG.Catchup.FuelDischargeProof
 import proof.DGG.Catchup.LeftBoundaryCatchupDef
 import proof.DGG.Catchup.LeftValueCatchupDef
 import proof.DGG.Catchup.LeftSourceOperationsDef
+import proof.DGG.Catchup.LeftBlameLiftProof
 import proof.DGG.Catchup.LeftValueCatchupProof
 
 ------------------------------------------------------------------------

--- a/GTSFImp/proof/DGG/Catchup/LeftBlameLiftProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftBlameLiftProof.agda
@@ -1,0 +1,84 @@
+module proof.DGG.Catchup.LeftBlameLiftProof where
+
+-- File Charter:
+--   * Proves the source blame-lift workers used by left catch-up packages.
+--   * Lifts source-blame traces through source cast, reveal, and conceal
+--     wrappers and appends the corresponding pure blame step.
+--   * Mirrors the boundary-stack blame propagation pattern without changing
+--     CTI2 or the public catch-up surfaces.
+
+open import Data.Product using (_,_)
+
+open import Consistency using (Env∼; _⊢_∼_)
+open import Conversion using (Conv↑; Conv↓)
+open import CastTerms using (Term; blame; _⟨_⟩; _↑_; _↓_)
+import Reduction as R
+open import Reduction using
+  ( StoreChanges
+  ; keep
+  ; _∷_
+  ; _—↠[_]_
+  ; _—↠[_]⟨_⟩_
+  ; _—→[_]⟨_⟩_
+  ; _∎[]
+  ; pure-step
+  ; blame-⟨⟩
+  ; blame-reveal
+  ; blame-conceal
+  )
+open import Types using (Ty)
+open import proof.DGG.Catchup.LeftSourceOperationsDef
+  using (LeftBlameCastLiftAt; LeftBlameConcealLiftAt; LeftBlameRevealLiftAt)
+open import proof.DGG.Parked.ParkedEvolveCompositionProof
+  using (compose-parked-evolve)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (evolve-keepᴸ; evolve-refl)
+open import proof.Reduction
+  using
+    ( _++χ_
+    ; applyConceals
+    ; applyReveals
+    ; cast-↠
+    ; composeReduction
+    ; conceal-↠
+    ; reveal-↠
+    )
+
+
+left-blame-cast-lift-at : LeftBlameCastLiftAt
+left-blame-cast-lift-at {M = M} {χsᴸ = χsᴸ} c M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction
+    (M ⟨ c ⟩
+      —↠[ χsᴸ ]⟨ cast-↠ c M↠blame ⟩
+     blame ⟨ R.applyConsistencies χsᴸ c ⟩ ∎[])
+    (blame ⟨ R.applyConsistencies χsᴸ c ⟩
+      —→[ keep ]⟨ pure-step blame-⟨⟩ ⟩
+     blame ∎[]) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
+
+
+left-blame-reveal-lift-at : LeftBlameRevealLiftAt
+left-blame-reveal-lift-at {M = M} {χsᴸ = χsᴸ} c M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction
+    (M ↑ c
+      —↠[ χsᴸ ]⟨ reveal-↠ c M↠blame ⟩
+     blame ↑ applyReveals χsᴸ c ∎[])
+    (blame ↑ applyReveals χsᴸ c
+      —→[ keep ]⟨ pure-step blame-reveal ⟩
+     blame ∎[]) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)
+
+
+left-blame-conceal-lift-at : LeftBlameConcealLiftAt
+left-blame-conceal-lift-at {M = M} {χsᴸ = χsᴸ} c M↠blame evol =
+  _ , χsᴸ ++χ (keep ∷ R.[]) , _ , _ ,
+  composeReduction
+    (M ↓ c
+      —↠[ χsᴸ ]⟨ conceal-↠ c M↠blame ⟩
+     blame ↓ applyConceals χsᴸ c ∎[])
+    (blame ↓ applyConceals χsᴸ c
+      —→[ keep ]⟨ pure-step blame-conceal ⟩
+     blame ∎[]) ,
+  compose-parked-evolve evol (evolve-keepᴸ evolve-refl)

--- a/GTSFImp/proof/DGG/Catchup/LeftBoundaryCatchupDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftBoundaryCatchupDef.agda
@@ -1,0 +1,82 @@
+module proof.DGG.Catchup.LeftBoundaryCatchupDef where
+
+-- File Charter:
+--   * States boundary-general source catch-up for the less-precise target
+--     value case.
+--   * The source may reach a related value or blame; target store changes are
+--     empty.
+--   * Carries both enclosing-world and premise-world parked evolution so
+--     source reveal/conceal boundaries can be replayed by proof workers.
+--   * Contains no catch-up proof.
+
+open import Data.List using ([])
+open import Data.Maybe using (Maybe)
+open import Data.Product using (_×_; Σ-syntax)
+open import Data.Sum using (_⊎_)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+
+open import Types using (Ty; TyCtx; TyVar)
+open import CastTerms using (Term; Value; blame)
+open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
+import Reduction as R
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Catchup.StructuralWorldTagRebaseDef
+  using (mapPivotChanges)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (CatchupBoundary; CatchupBoundaryKind)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedEvolve; ParkedWorld)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+LeftCatchupResult : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {kind : CatchupBoundaryKind}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → Set
+LeftCatchupResult {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {W = W} {Wᵖ = Wᵖ}
+    {kind = kind} {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+    {M = M} {V′ = V′} {A = A} {B = B} =
+  (Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+   Σ[ V ∈ Term Δᴸ′ ] Σ[ Δ′ ∈ TyCtx ]
+   Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Wᵖ′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Xᴸ′? ∈ Maybe (TyVar Δᴸ′) ]
+   Σ[ boundary′ ∈ CatchupBoundary kind Xᴸ′? Xᴿ? W′ Wᵖ′ ]
+   Σ[ q ∈ applyTys χsᴸ A ⊑ᵂ⟨ Wᵖ′ ⟩ B ]
+     Xᴸ′? ≡ mapPivotChanges χsᴸ Xᴸ? ×
+     (M —↠[ χsᴸ ] V) × Value V ×
+     ParkedEvolve χsᴸ R.[] W W′ ×
+     ParkedEvolve χsᴸ R.[] Wᵖ Wᵖ′ ×
+     (Wᵖ′ ∣ [] ⊢² V ⊑ V′ ∶ q))
+  ⊎
+  (Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+   Σ[ Δ′ ∈ TyCtx ]
+   Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Wᵖ′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Xᴸ′? ∈ Maybe (TyVar Δᴸ′) ]
+   Σ[ boundary′ ∈ CatchupBoundary kind Xᴸ′? Xᴿ? W′ Wᵖ′ ]
+     Xᴸ′? ≡ mapPivotChanges χsᴸ Xᴸ? ×
+     (M —↠[ χsᴸ ] blame) ×
+     ParkedEvolve χsᴸ R.[] W W′ ×
+     ParkedEvolve χsᴸ R.[] Wᵖ Wᵖ′)
+
+
+CatchupToLessPreciseBoundary : Set
+CatchupToLessPreciseBoundary =
+  ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {kind : CatchupBoundaryKind}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → ParkedWorld W
+  → CatchupBoundary kind Xᴸ? Xᴿ? W Wᵖ
+  → Wᵖ ∣ [] ⊢² M ⊑ V′ ∶ p
+  → Value V′
+  → LeftCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = kind}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {M = M} {V′ = V′} {A = A} {B = B}

--- a/GTSFImp/proof/DGG/Catchup/LeftSourceOperationsDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftSourceOperationsDef.agda
@@ -1,0 +1,238 @@
+module proof.DGG.Catchup.LeftSourceOperationsDef where
+
+-- File Charter:
+--   * States the source operational package surfaces consumed by left
+--     catch-up.
+--   * Packages source casts, source type application, source reveal/conceal,
+--     route-2 packaged seal-star, and blame-lift workers.
+--   * Records the two-sided peel interfaces as explicit parameters rather
+--     than deriving one-sided peels.
+--   * Contains no catch-up proof.
+
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Data.List using ([])
+open import Data.Maybe using (nothing)
+open import Data.Nat using (ℕ; _<_)
+open import Data.Product using (_×_; Σ-syntax)
+open import Relation.Binary.PropositionalEquality using (_≢_)
+
+open import Types
+  using (Ty; TyCtx; TyVar; NonVar; _∈ᵗ_; ★; ＇_; `∀; ⇑ᵗ; _[_]ᵗ)
+open import Consistency using (Env∼; _⊢_∼_; instᵐ; inst_; ↑ᶜ_)
+open import Conversion using (Conv↑; Conv↓; seal)
+open import CastTerms using (Term; Value; blame; _⟨_⟩; _↑_; _↓_; _⦂∀_[_])
+open import Reduction using (StoreChanges; _—↠[_]_)
+import Reduction as R
+open import proof.Consistency using (castSize)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Catchup.LeftBoundaryCatchupDef
+  using (LeftCatchupResult)
+open import proof.DGG.Catchup.LeftValueCatchupDef
+  using (LeftValueCatchupAt; SourceCastBound)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (same-boundary)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedEvolve; ParkedWorld)
+open import proof.DGG.SimConcealRevealPeel
+  using (PairedConcealRevealPeelᵀ; SourceOnlyConcealRevealPeelᵀ)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+LeftExtraCastAt : ℕ → Set
+LeftExtraCastAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {ν : Env∼ Δᴸ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → (c : ν ⊢ A ∼ A′)
+  → castSize c < fuel
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ p)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ⟨ c ⟩} {V′ = V′} {A = A′} {B = B}
+
+
+LeftInstCatchupAt : ℕ → Set
+LeftInstCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {V : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty (Nat.suc Δᴸ)} {A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {ν : Env∼ Δᴸ}
+    {p : `∀ A ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → W ∣ [] ⊢² V ⊑ V′ ∶ p
+  → Value V
+  → Value V′
+  → (c : instᵐ ν ⊢ A ∼ ⇑ᵗ A′)
+  → ⦃ Anv : NonVar A ⦄
+  → ⦃ zero∈A : Fin.zero ∈ᵗ A ⦄
+  → (A′≢★ : A′ ≢ ★)
+  → castSize ((inst c) A′≢★) < fuel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = V ⟨ (inst c) A′≢★ ⟩}
+      {V′ = V′} {A = A′} {B = B}
+
+
+LeftSourceTypeAppCatchupAt : ℕ → Set
+LeftSourceTypeAppCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {C : Ty (Nat.suc Δᴸ)} {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p∀ : `∀ C ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ p∀)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ⦂∀ C [ A ]} {V′ = V′}
+      {A = C [ A ]ᵗ} {B = B}
+
+
+LeftSourceRevealCatchupAt : ℕ → Set
+LeftSourceRevealCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → (c : Conv↑ Δᴸ A A′)
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ p)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ↑ c} {V′ = V′} {A = A′} {B = B}
+
+
+LeftSourceConcealCatchupAt : ℕ → Set
+LeftSourceConcealCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → (c : Conv↓ Δᴸ A A′)
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ p)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ↓ c} {V′ = V′} {A = A′} {B = B}
+
+
+LeftPackagedSealStarRoute2At : ℕ → Set
+LeftPackagedSealStarRoute2At fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ} {Xᴿ?}
+    {p★ : ★ ⊑ᵂ⟨ W ⟩ ★}
+    {qᵖ : (＇ Xᴸ) ⊑ᵂ⟨ W ⟩ ★}
+  → CTI2.MatchedConcealPartnerOK W M (seal Xᴸ ★) Xᴿ? M′
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ M′ ∶ p★)
+  → (pkg-rel : W ∣ [] ⊢² M ↓ seal Xᴸ ★ ⊑ M′ ∶ qᵖ)
+  → Value (M′ ↓ seal Xᴿ ★)
+  → SourceCastBound fuel rel
+  → SourceCastBound fuel pkg-rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ↓ seal Xᴸ ★} {V′ = M′ ↓ seal Xᴿ ★}
+      {A = ＇ Xᴸ} {B = ＇ Xᴿ}
+
+
+LeftBlameCastLiftAt : Set
+LeftBlameCastLiftAt =
+  ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {ν : Env∼ Δᴸ} {A A′ : Ty Δᴸ}
+  → (c : ν ⊢ A ∼ A′)
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ⟨ c ⟩ —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+
+
+LeftBlameRevealLiftAt : Set
+LeftBlameRevealLiftAt =
+  ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {A A′ : Ty Δᴸ}
+  → (c : Conv↑ Δᴸ A A′)
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ↑ c —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+
+
+LeftBlameConcealLiftAt : Set
+LeftBlameConcealLiftAt =
+  ∀ {Δᴸ Δᴸ′ Δᴿ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ′ Δᴿ Δ′}
+    {M : Term Δᴸ} {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {A A′ : Ty Δᴸ}
+  → (c : Conv↓ Δᴸ A A′)
+  → M —↠[ χsᴸ ] blame
+  → ParkedEvolve χsᴸ R.[] W W′
+  → Σ[ Δᴸ″ ∈ TyCtx ] Σ[ ψsᴸ ∈ StoreChanges Δᴸ Δᴸ″ ]
+    Σ[ Δ″ ∈ TyCtx ] Σ[ W″ ∈ World Δᴸ″ Δᴿ Δ″ ]
+      (M ↓ c —↠[ ψsᴸ ] blame) ×
+      ParkedEvolve ψsᴸ R.[] W W″
+
+
+record LeftTwoSidedPeelPackage : Set where
+  field
+    paired-conceal-reveal-peel : PairedConcealRevealPeelᵀ
+    source-only-conceal-reveal-peel : SourceOnlyConcealRevealPeelᵀ
+
+
+record LeftSourceOperationsAt (fuel : ℕ) : Set₁ where
+  field
+    left-extra-cast-at : LeftExtraCastAt fuel
+    left-inst-catchup-at : LeftInstCatchupAt fuel
+    left-source-type-app-catchup-at : LeftSourceTypeAppCatchupAt fuel
+    left-source-reveal-catchup-at : LeftSourceRevealCatchupAt fuel
+    left-source-conceal-catchup-at : LeftSourceConcealCatchupAt fuel
+    left-packaged-seal-star-route2-at : LeftPackagedSealStarRoute2At fuel
+    left-blame-cast-lift-at : LeftBlameCastLiftAt
+    left-blame-reveal-lift-at : LeftBlameRevealLiftAt
+    left-blame-conceal-lift-at : LeftBlameConcealLiftAt
+    left-two-sided-peels : LeftTwoSidedPeelPackage
+
+
+record LeftFuelKnot (fuel : ℕ) : Set₁ where
+  field
+    left-source-operations-at : LeftSourceOperationsAt fuel
+    left-value-catchup-at : LeftValueCatchupAt fuel
+
+
+record LeftFuelStepSurface (fuel : ℕ) : Set₁ where
+  field
+    smaller-left-source-operations :
+      ∀ {m} → m < fuel → LeftSourceOperationsAt m
+    smaller-left-value :
+      ∀ {m} → m < fuel → LeftValueCatchupAt m

--- a/GTSFImp/proof/DGG/Catchup/LeftValueCatchupDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftValueCatchupDef.agda
@@ -1,0 +1,116 @@
+module proof.DGG.Catchup.LeftValueCatchupDef where
+
+-- File Charter:
+--   * Defines the source-cast fuel bound for left catch-up.
+--   * States fuel-indexed source value catch-up, both boundary-general and
+--     closed same-boundary.
+--   * Charges source-side cast heads only; target cast heads are structural
+--     wrappers around the fixed target value.
+--   * Contains no catch-up proof.
+
+open import Data.List using ([])
+open import Data.Maybe using (Maybe; nothing)
+open import Data.Nat using (ℕ; _<_)
+open import Data.Product using (_×_)
+open import Data.Unit using (⊤)
+
+open import Types using (Ty; TyVar)
+open import CastTerms using (Term; Value)
+open import proof.Consistency using (castSize)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Catchup.LeftBoundaryCatchupDef
+  using (LeftCatchupResult)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (CatchupBoundary; CatchupBoundaryKind; same-boundary)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld)
+open CTI2 using (World; CtxImp; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+SourceCastBound : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ℕ
+  → W ∣ γ ⊢² M ⊑ M′ ∶ q
+  → Set
+SourceCastBound fuel (CTI2.x⊑x² x∈) = ⊤
+SourceCastBound fuel (CTI2.ƛ⊑ƛ² rel) = SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.·⊑·² rel₁ rel₂) =
+  SourceCastBound fuel rel₁ × SourceCastBound fuel rel₂
+SourceCastBound fuel (CTI2.Λ⊑Λ² liftγ vV vV′ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.Λ⊑² Anv z∈A liftγ vV M⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.Λ⊑²-smart-comma Anv z∈A liftW liftγ vV M⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.•⊑•² p∀ rel q r) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.•⊑² p∀ rel q r) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.κ⊑κ² κ p) = ⊤
+SourceCastBound fuel (CTI2.cast⊑cast² c c′ rel q) =
+  castSize c < fuel × SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.⊑cast² c′ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.⊑reveal² mono rb sameγ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.⊑conceal² mono rb sameγ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.cast⊑² c rel q) =
+  castSize c < fuel × SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.conceal⊑conceal² partner mono rb sameγ c⊢ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.packaged-seal-star² partner mono rb sameγ c⊢ c′⊢
+      rel pkg-rel q) =
+  SourceCastBound fuel rel × SourceCastBound fuel pkg-rel
+SourceCastBound fuel (CTI2.blame⊑² M′⊢ p) = ⊤
+SourceCastBound fuel (CTI2.⊕⊑⊕² op rel₁ rel₂ r) =
+  SourceCastBound fuel rel₁ × SourceCastBound fuel rel₂
+
+
+LeftValueCatchupBoundaryAt : ℕ → Set
+LeftValueCatchupBoundaryAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {kind : CatchupBoundaryKind}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → ParkedWorld W
+  → CatchupBoundary kind Xᴸ? Xᴿ? W Wᵖ
+  → (rel : Wᵖ ∣ [] ⊢² M ⊑ V′ ∶ q)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = kind}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {M = M} {V′ = V′} {A = A} {B = B}
+
+
+LeftValueCatchupAt : ℕ → Set
+LeftValueCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ q)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M} {V′ = V′} {A = A} {B = B}

--- a/GTSFImp/proof/DGG/Catchup/LeftValueCatchupProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftValueCatchupProof.agda
@@ -8,9 +8,11 @@ module proof.DGG.Catchup.LeftValueCatchupProof where
 
 open import Data.List using ([])
 open import Data.Maybe using (nothing)
-open import Data.Nat using (ℕ)
+open import Data.Nat using (ℕ; _+_; suc; _<_)
+open import Data.Nat.Properties using (m≤m+n; m≤n+m; n<1+n; ≤-<-trans)
 open import Data.Product using (_×_; _,_)
 open import Data.Sum using (inj₁; inj₂)
+open import Data.Unit using (tt)
 open import Relation.Binary.PropositionalEquality using (refl)
 
 open import Types using (Ty; TyVar; ★; ＇_)
@@ -27,11 +29,148 @@ open import proof.DGG.Catchup.LeftBoundaryCatchupDef
 open import proof.DGG.Catchup.LeftValueCatchupDef
   using (LeftValueCatchupAt; SourceCastBound)
 import proof.DGG.Catchup.LeftSourceOperationsDef as LSO
+open import proof.Consistency using (castSize)
 open import proof.DGG.CatchupToMorePreciseDef
   using (boundary-refl; same-boundary)
 open import proof.DGG.Parked.ParkedWorldDef
   using (ParkedWorld; evolve-refl)
 open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+sourceCastBudget : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CTI2.CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ γ ⊢² M ⊑ M′ ∶ q
+  → ℕ
+sourceCastBudget (CTI2.x⊑x² x∈) = 0
+sourceCastBudget (CTI2.ƛ⊑ƛ² rel) = sourceCastBudget rel
+sourceCastBudget (CTI2.·⊑·² rel₁ rel₂) =
+  sourceCastBudget rel₁ + sourceCastBudget rel₂
+sourceCastBudget (CTI2.Λ⊑Λ² liftγ vV vV′ rel q) =
+  sourceCastBudget rel
+sourceCastBudget (CTI2.Λ⊑² Anv zero∈A liftγ vV target⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget
+    (CTI2.Λ⊑²-smart-comma Anv zero∈A liftW liftγ vV target⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget (CTI2.•⊑•² p∀ rel q r) = sourceCastBudget rel
+sourceCastBudget (CTI2.•⊑² p∀ rel q r) = sourceCastBudget rel
+sourceCastBudget (CTI2.κ⊑κ² κ p) = 0
+sourceCastBudget (CTI2.cast⊑cast² c c′ rel q) =
+  castSize c + sourceCastBudget rel
+sourceCastBudget (CTI2.⊑cast² c′ rel q) = sourceCastBudget rel
+sourceCastBudget (CTI2.⊑reveal² mono rb sameγ c′⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget (CTI2.⊑conceal² mono rb sameγ c′⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget (CTI2.cast⊑² c rel q) =
+  castSize c + sourceCastBudget rel
+sourceCastBudget (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget
+    (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget
+    (CTI2.conceal⊑conceal² partner mono rb sameγ c⊢ c′⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget
+    (CTI2.packaged-seal-star² partner mono rb sameγ c⊢ c′⊢
+      rel pkg-rel q) =
+  sourceCastBudget rel + sourceCastBudget pkg-rel
+sourceCastBudget (CTI2.blame⊑² target⊢ p) = 0
+sourceCastBudget (CTI2.⊕⊑⊕² op rel₁ rel₂ r) =
+  sourceCastBudget rel₁ + sourceCastBudget rel₂
+
+
+source-cast-bound< : ∀ {fuel Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CTI2.CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → (rel : W ∣ γ ⊢² M ⊑ M′ ∶ q)
+  → sourceCastBudget rel < fuel
+  → SourceCastBound fuel rel
+source-cast-bound< (CTI2.x⊑x² x∈) budget< = tt
+source-cast-bound< (CTI2.ƛ⊑ƛ² rel) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.·⊑·² rel₁ rel₂) budget< =
+  source-cast-bound< rel₁
+    (≤-<-trans (m≤m+n (sourceCastBudget rel₁) (sourceCastBudget rel₂))
+      budget<) ,
+  source-cast-bound< rel₂
+    (≤-<-trans (m≤n+m (sourceCastBudget rel₂) (sourceCastBudget rel₁))
+      budget<)
+source-cast-bound< (CTI2.Λ⊑Λ² liftγ vV vV′ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.Λ⊑² Anv zero∈A liftγ vV target⊢ rel q)
+    budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.Λ⊑²-smart-comma Anv zero∈A liftW liftγ vV
+    target⊢ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.•⊑•² p∀ rel q r) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.•⊑² p∀ rel q r) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.κ⊑κ² κ p) budget< = tt
+source-cast-bound< (CTI2.cast⊑cast² c c′ rel q) budget< =
+  ≤-<-trans (m≤m+n (castSize c) (sourceCastBudget rel)) budget< ,
+  source-cast-bound< rel
+    (≤-<-trans (m≤n+m (sourceCastBudget rel) (castSize c))
+      budget<)
+source-cast-bound< (CTI2.⊑cast² c′ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.⊑reveal² mono rb sameγ c′⊢ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.⊑conceal² mono rb sameγ c′⊢ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.cast⊑² c rel q) budget< =
+  ≤-<-trans (m≤m+n (castSize c) (sourceCastBudget rel)) budget< ,
+  source-cast-bound< rel
+    (≤-<-trans (m≤n+m (sourceCastBudget rel) (castSize c))
+      budget<)
+source-cast-bound< (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound< (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q)
+    budget< =
+  source-cast-bound< rel budget<
+source-cast-bound<
+    (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound<
+    (CTI2.conceal⊑conceal² partner mono rb sameγ c⊢ c′⊢ rel q) budget< =
+  source-cast-bound< rel budget<
+source-cast-bound<
+    (CTI2.packaged-seal-star² partner mono rb sameγ c⊢ c′⊢
+      rel pkg-rel q) budget< =
+  source-cast-bound< rel
+    (≤-<-trans (m≤m+n (sourceCastBudget rel) (sourceCastBudget pkg-rel))
+      budget<) ,
+  source-cast-bound< pkg-rel
+    (≤-<-trans (m≤n+m (sourceCastBudget pkg-rel) (sourceCastBudget rel))
+      budget<)
+source-cast-bound< (CTI2.blame⊑² target⊢ p) budget< = tt
+source-cast-bound< (CTI2.⊕⊑⊕² op rel₁ rel₂ r) budget< =
+  source-cast-bound< rel₁
+    (≤-<-trans (m≤m+n (sourceCastBudget rel₁) (sourceCastBudget rel₂))
+      budget<) ,
+  source-cast-bound< rel₂
+    (≤-<-trans (m≤n+m (sourceCastBudget rel₂) (sourceCastBudget rel₁))
+      budget<)
+
+
+source-cast-bound : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CTI2.CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → (rel : W ∣ γ ⊢² M ⊑ M′ ∶ q)
+  → SourceCastBound (suc (sourceCastBudget rel)) rel
+source-cast-bound rel = source-cast-bound< rel (n<1+n (sourceCastBudget rel))
 
 
 left-zero-value-result : ∀ {Δᴸ Δᴿ Δ}

--- a/GTSFImp/proof/DGG/Catchup/LeftValueCatchupProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftValueCatchupProof.agda
@@ -1,0 +1,281 @@
+module proof.DGG.Catchup.LeftValueCatchupProof where
+
+-- File Charter:
+--   * Provides the checked source-value catch-up driver shell.
+--   * Closes terminal value/refutation/blame rows directly.
+--   * Routes source-operation, target-wrapper, paired-wrapper, and route-2
+--     package rows through narrow syntactically pinned residual fields.
+
+open import Data.List using ([])
+open import Data.Maybe using (nothing)
+open import Data.Nat using (ℕ)
+open import Data.Product using (_×_; _,_)
+open import Data.Sum using (inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import Types using (Ty; TyVar; ★; ＇_)
+open import Consistency using (Env∼; _⊢_∼_)
+open import Conversion using (Conv↑; Conv↓; seal)
+import CastTerms as CT
+open import CastTerms
+  using (Term; Value; blame; _⟨_⟩; _↑_; _↓_)
+import Reduction as R
+open import Reduction using (_∎[])
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Catchup.LeftBoundaryCatchupDef
+  using (LeftCatchupResult)
+open import proof.DGG.Catchup.LeftValueCatchupDef
+  using (LeftValueCatchupAt; SourceCastBound)
+import proof.DGG.Catchup.LeftSourceOperationsDef as LSO
+open import proof.DGG.CatchupToMorePreciseDef
+  using (boundary-refl; same-boundary)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; evolve-refl)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+
+left-zero-value-result : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {q : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ [] ⊢² M ⊑ V′ ∶ q
+  → Value M
+  → Value V′
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M} {V′ = V′} {A = A} {B = B}
+left-zero-value-result {M = M} rel vM vV′ =
+  inj₁ (_ , R.[] , M , _ , _ , _ , nothing , boundary-refl ,
+    _ , refl , (M ∎[]) , vM , evolve-refl , evolve-refl , rel)
+
+
+left-zero-blame-result : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+    {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {q : A ⊑ᵂ⟨ W ⟩ B}
+  → W ∣ [] ⊢² blame ⊑ V′ ∶ q
+  → Value V′
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = blame} {V′ = V′} {A = A} {B = B}
+left-zero-blame-result rel vV′ =
+  inj₂ (_ , R.[] , _ , _ , _ , nothing , boundary-refl ,
+    refl , (blame ∎[]) , evolve-refl , evolve-refl)
+
+
+record LeftValueCatchupResidualsAt (fuel : ℕ) : Set₁ where
+  field
+    source-operations : LSO.LeftSourceOperationsAt fuel
+
+    paired-cast-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {A A′ : Ty Δᴸ} {B B′ : Ty Δᴿ}
+        {ν : Env∼ Δᴸ} {ν′ : Env∼ Δᴿ}
+        {c : ν ⊢ A ∼ A′} {c′ : ν′ ⊢ B ∼ B′}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B′}
+      → (rel : W ∣ [] ⊢² M ⟨ c ⟩ ⊑ M′ ⟨ c′ ⟩ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ⟨ c′ ⟩)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M ⟨ c ⟩} {V′ = M′ ⟨ c′ ⟩} {A = A′} {B = B′}
+
+    target-cast-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+        {ν′ : Env∼ Δᴿ} {c′ : ν′ ⊢ B ∼ B′}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+      → (rel : W ∣ [] ⊢² M ⊑ M′ ⟨ c′ ⟩ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ⟨ c′ ⟩)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M} {V′ = M′ ⟨ c′ ⟩} {A = A} {B = B′}
+
+    target-reveal-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+        {c′ : Conv↑ Δᴿ B B′}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+      → (rel : W ∣ [] ⊢² M ⊑ M′ ↑ c′ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ↑ c′)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M} {V′ = M′ ↑ c′} {A = A} {B = B′}
+
+    target-conceal-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ}
+        {c′ : Conv↓ Δᴿ B B′}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+      → (rel : W ∣ [] ⊢² M ⊑ M′ ↓ c′ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ↓ c′)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M} {V′ = M′ ↓ c′} {A = A} {B = B′}
+
+    source-reveal-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {V′ : Term Δᴿ}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+        {c : Conv↑ Δᴸ A A′}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+      → (rel : W ∣ [] ⊢² M ↑ c ⊑ V′ ∶ q)
+      → ParkedWorld W
+      → Value V′
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M ↑ c} {V′ = V′} {A = A′} {B = B}
+
+    source-conceal-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {V′ : Term Δᴿ}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+        {c : Conv↓ Δᴸ A A′}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+      → (rel : W ∣ [] ⊢² M ↓ c ⊑ V′ ∶ q)
+      → ParkedWorld W
+      → Value V′
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M ↓ c} {V′ = V′} {A = A′} {B = B}
+
+    paired-reveal-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {A A′ : Ty Δᴸ} {B B′ : Ty Δᴿ}
+        {c : Conv↑ Δᴸ A A′} {c′ : Conv↑ Δᴿ B B′}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B′}
+      → (rel : W ∣ [] ⊢² M ↑ c ⊑ M′ ↑ c′ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ↑ c′)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M ↑ c} {V′ = M′ ↑ c′} {A = A′} {B = B′}
+
+    paired-conceal-row : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {A A′ : Ty Δᴸ} {B B′ : Ty Δᴿ}
+        {c : Conv↓ Δᴸ A A′} {c′ : Conv↓ Δᴿ B B′}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B′}
+      → (rel : W ∣ [] ⊢² M ↓ c ⊑ M′ ↓ c′ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ↓ c′)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M ↓ c} {V′ = M′ ↓ c′} {A = A′} {B = B′}
+
+    packaged-seal-star-route2-row : ∀ {Δᴸ Δᴿ Δ}
+        {W : World Δᴸ Δᴿ Δ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ}
+        {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+        {q : (＇ Xᴸ) ⊑ᵂ⟨ W ⟩ (＇ Xᴿ)}
+      → (rel : W ∣ [] ⊢²
+          M ↓ seal Xᴸ ★ ⊑ M′ ↓ seal Xᴿ ★ ∶ q)
+      → ParkedWorld W
+      → Value (M′ ↓ seal Xᴿ ★)
+      → SourceCastBound fuel rel
+      → LeftCatchupResult
+          {W = W} {Wᵖ = W}
+          {kind = same-boundary}
+          {Xᴸ? = nothing} {Xᴿ? = nothing}
+          {M = M ↓ seal Xᴸ ★} {V′ = M′ ↓ seal Xᴿ ★}
+          {A = ＇ Xᴸ} {B = ＇ Xᴿ}
+
+
+left-value-catchup-with-residuals : ∀ {fuel}
+  → LeftValueCatchupResidualsAt fuel
+  → LeftValueCatchupAt fuel
+left-value-catchup-with-residuals residuals parked (CTI2.x⊑x² ()) vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.ƛ⊑ƛ² prem) vV′ bound =
+  left-zero-value-result rel (CT.ƛ _) vV′
+left-value-catchup-with-residuals residuals parked
+    (CTI2.·⊑·² prem₁ prem₂) () bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.Λ⊑Λ² liftγ vV vV′ prem q) target-value bound =
+  left-zero-value-result rel (CT.Λ vV) target-value
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.Λ⊑² Anv zero∈A liftγ vV target⊢ prem q) vV′ bound =
+  left-zero-value-result rel (CT.Λ vV) vV′
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.Λ⊑²-smart-comma Anv zero∈A liftW liftγ vV
+      target⊢ prem q) vV′ bound =
+  left-zero-value-result rel (CT.Λ vV) vV′
+left-value-catchup-with-residuals residuals parked
+    (CTI2.•⊑•² p∀ prem q r) () bound
+left-value-catchup-with-residuals residuals parked
+    (CTI2.•⊑² p∀ prem q r) vV′ bound =
+  LSO.LeftSourceOperationsAt.left-source-type-app-catchup-at
+    (LeftValueCatchupResidualsAt.source-operations residuals)
+    parked prem vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.κ⊑κ² κ p) vV′ bound =
+  left-zero-value-result rel (CT.$ κ) vV′
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.cast⊑cast² c c′ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.paired-cast-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.⊑cast² c′ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.target-cast-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.⊑reveal² mono rb sameγ c′⊢ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.target-reveal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.⊑conceal² mono rb sameγ c′⊢ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.target-conceal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.cast⊑² c prem q) vV′ (c<fuel , prem-bound) =
+  LSO.LeftSourceOperationsAt.left-extra-cast-at
+    (LeftValueCatchupResidualsAt.source-operations residuals)
+    c c<fuel parked prem vV′ prem-bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.reveal⊑² mono rb sameγ c⊢ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.source-reveal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.conceal⊑² partner mono rb sameγ c⊢ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.source-conceal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.paired-reveal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.conceal⊑conceal² partner mono rb sameγ c⊢ c′⊢ prem q)
+    vV′ bound =
+  LeftValueCatchupResidualsAt.paired-conceal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.packaged-seal-star² partner mono rb sameγ c⊢ c′⊢
+      prem pkg-rel q) vV′ bound =
+  LeftValueCatchupResidualsAt.packaged-seal-star-route2-row
+    residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.blame⊑² target⊢ p) vV′ bound =
+  left-zero-blame-result rel vV′
+left-value-catchup-with-residuals residuals parked
+    (CTI2.⊕⊑⊕² op prem₁ prem₂ r) () bound

--- a/GTSFImp/proof/DGG/CatchupToLessPreciseProof.agda
+++ b/GTSFImp/proof/DGG/CatchupToLessPreciseProof.agda
@@ -7,11 +7,19 @@ module proof.DGG.CatchupToLessPreciseProof where
 --   * Erases boundary-only pivot and premise-world fields from the result.
 
 open import Data.Maybe using (nothing)
+open import Data.Nat using (suc)
 open import Data.Product using (_,_)
 open import Data.Sum using (inj₁; inj₂)
 
 open import proof.DGG.Catchup.LeftBoundaryCatchupDef
   using (CatchupToLessPreciseBoundary)
+open import proof.DGG.Catchup.LeftValueCatchupProof
+  using
+    ( LeftValueCatchupResidualsAt
+    ; left-value-catchup-with-residuals
+    ; source-cast-bound
+    ; sourceCastBudget
+    )
 open import proof.DGG.CatchupToLessPreciseDef
   using (CatchupToLessPrecise)
 open import proof.DGG.CatchupToMorePreciseDef
@@ -32,6 +40,30 @@ left-boundary-catchup→catchup-to-less-precise catchup parked rel vV′
         M↠V , vV , evol , _ , V⊑V′ ) =
   inj₁ (Δᴸ′ , χsᴸ , V , Δ′ , W′ , q , M↠V , vV , evol , V⊑V′)
 left-boundary-catchup→catchup-to-less-precise catchup parked rel vV′
+    | inj₂
+      ( Δᴸ′ , χsᴸ , Δ′ , W′ , .W′ , .nothing ,
+        boundary-refl , _ , M↠blame , evol , _ ) =
+  inj₂ (Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol)
+
+
+LeftCatchupResidualFamily : Set₁
+LeftCatchupResidualFamily =
+  ∀ fuel → LeftValueCatchupResidualsAt fuel
+
+
+left-residuals→catchup-to-less-precise :
+  LeftCatchupResidualFamily → CatchupToLessPrecise
+left-residuals→catchup-to-less-precise residuals parked rel vV′
+    with left-value-catchup-with-residuals
+      (residuals (suc (sourceCastBudget rel)))
+      parked rel vV′ (source-cast-bound rel)
+left-residuals→catchup-to-less-precise residuals parked rel vV′
+    | inj₁
+      ( Δᴸ′ , χsᴸ , V , Δ′ , W′ , .W′ , .nothing ,
+        boundary-refl , q , _ ,
+        M↠V , vV , evol , _ , V⊑V′ ) =
+  inj₁ (Δᴸ′ , χsᴸ , V , Δ′ , W′ , q , M↠V , vV , evol , V⊑V′)
+left-residuals→catchup-to-less-precise residuals parked rel vV′
     | inj₂
       ( Δᴸ′ , χsᴸ , Δ′ , W′ , .W′ , .nothing ,
         boundary-refl , _ , M↠blame , evol , _ ) =

--- a/GTSFImp/proof/DGG/CatchupToLessPreciseProof.agda
+++ b/GTSFImp/proof/DGG/CatchupToLessPreciseProof.agda
@@ -1,0 +1,38 @@
+module proof.DGG.CatchupToLessPreciseProof where
+
+-- File Charter:
+--   * Adapts the boundary-general left catch-up worker to the fixed public
+--     CatchupToLessPrecise surface.
+--   * Instantiates the boundary stack at the closed same-boundary case.
+--   * Erases boundary-only pivot and premise-world fields from the result.
+
+open import Data.Maybe using (nothing)
+open import Data.Product using (_,_)
+open import Data.Sum using (inj₁; inj₂)
+
+open import proof.DGG.Catchup.LeftBoundaryCatchupDef
+  using (CatchupToLessPreciseBoundary)
+open import proof.DGG.CatchupToLessPreciseDef
+  using (CatchupToLessPrecise)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (boundary-refl; same-boundary)
+
+
+left-boundary-catchup→catchup-to-less-precise :
+  CatchupToLessPreciseBoundary → CatchupToLessPrecise
+left-boundary-catchup→catchup-to-less-precise catchup parked rel vV′
+    with catchup
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      parked boundary-refl rel vV′
+left-boundary-catchup→catchup-to-less-precise catchup parked rel vV′
+    | inj₁
+      ( Δᴸ′ , χsᴸ , V , Δ′ , W′ , .W′ , .nothing ,
+        boundary-refl , q , _ ,
+        M↠V , vV , evol , _ , V⊑V′ ) =
+  inj₁ (Δᴸ′ , χsᴸ , V , Δ′ , W′ , q , M↠V , vV , evol , V⊑V′)
+left-boundary-catchup→catchup-to-less-precise catchup parked rel vV′
+    | inj₂
+      ( Δᴸ′ , χsᴸ , Δ′ , W′ , .W′ , .nothing ,
+        boundary-refl , _ , M↠blame , evol , _ ) =
+  inj₂ (Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol)

--- a/GTSFImp/proof/DGG/SimConcealRevealPeel.agda
+++ b/GTSFImp/proof/DGG/SimConcealRevealPeel.agda
@@ -1,0 +1,65 @@
+module proof.DGG.SimConcealRevealPeel where
+
+-- File Charter:
+--   * States the D2b two-sided conceal/reveal peel interfaces.
+--   * Records the source-only variant's required evidence that the target
+--     value was already opened by a target conceal/reveal keep step.
+--   * Does not derive parked evidence or change CTI2.
+
+open import Types using (Ty; TyCtx; TyVar)
+open import Conversion using (seal; unseal)
+open import CastTerms using (Term; Value; _↑_; _↓_)
+open import Reduction using (keep; _—→[_]_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  ( World
+  ; CtxImp
+  ; _⊑ᵂ⟨_⟩_
+  ; _∣_⊢²_⊑_∶_
+  )
+
+
+PairedConcealRevealPeelᵀ : Set
+PairedConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+
+record TargetOpenedByConcealReveal {Δᴿ : TyCtx}
+    (V′ : Term Δᴿ) (R′ : Ty Δᴿ) : Set where
+  field
+    opened-payload : Term Δᴿ
+    opened-pivot : TyVar Δᴿ
+    opened-value : Value opened-payload
+    opened-step :
+      ((opened-payload ↓ seal opened-pivot R′)
+        ↑ unseal opened-pivot R′) —→[ keep ] V′
+
+
+SourceOnlyConcealRevealPeelᵀ : Set
+SourceOnlyConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → TargetOpenedByConcealReveal V₀′ R′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ V₀′ ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q

--- a/GTSFImp/proof/DGG/notes/t9-catchup-to-less-precise-case-table-blocked.red
+++ b/GTSFImp/proof/DGG/notes/t9-catchup-to-less-precise-case-table-blocked.red
@@ -1,0 +1,618 @@
+T9 CatchupToLessPrecise reconnaissance case table
+
+Date: 2026-08-17
+
+Surface under study:
+
+  CatchupToLessPrecise
+
+from `proof/DGG/CatchupToLessPreciseDef.agda`.
+
+Consumption site:
+
+  `DynamicGradualGuaranteeProof.target-value`
+
+After `sim-back*` and target value irreducibility, the live obligation is:
+
+  ParkedWorld W
+  W ∣ [] ⊢² N ⊑ V′ ∶ q
+  Value V′
+
+and the result must either produce a source value related to the fixed target
+value, or produce source blame.  The target store does not move in this
+surface.  The source store may move, and the result must expose
+
+  ParkedEvolve χsᴸ [] W W′.
+
+This is not the right-side catch-up theorem with the sides swapped.  The
+right stack under `proof/DGG/Catchup/` evolves target worlds through
+`StructuralWorldExtendᴿ` and has no blame alternative.  The left theorem
+needs left-store `ParkedEvolve` and an explicit source-blame branch.
+
+Right-side architecture summary
+-------------------------------
+
+`ValueCatchupRightAt fuel` consumes:
+
+  Value M
+  rel : W ∣ γ ⊢² M ⊑ M″ ∶ q
+  TargetCastBound fuel rel
+
+and produces target reduction to a value in a right-extended world.
+
+`TargetCastBound` charges only target cast heads:
+
+  cast⊑cast² c c′ rel q  ->  castSize c′ < fuel
+  ⊑cast² c′ rel q        ->  castSize c′ < fuel
+
+Structural heads recurse into premises.  The internal result
+`StructuralCatchupRightResult` keeps the structural right-extension trace so
+source reveal/conceal wrappers can be replayed after target allocation.  M4 is
+the extra target cast worker, M5 is target instantiation, and
+`FuelKnotProof` ties same-fuel and smaller-fuel calls by accessibility.
+
+The left analogue should charge source cast heads instead:
+
+  cast⊑cast² c c′ rel q  ->  castSize c < fuel
+  cast⊑² c rel q         ->  castSize c < fuel
+
+Target cast heads are wrappers around the fixed target value, not fuel
+drivers.  Source `inst` casts and source `gen` type-application redexes still
+need the same cast-size reasoning, but their store evolution is left-only.
+
+Case table
+----------
+
+Legend:
+
+  routine: can be discharged by constructor inversion or zero-step packaging.
+  mirror: a right-side proof pattern exists, but the result has to be rebuilt
+          for left `ParkedEvolve` and the blame branch.
+  new: no left-side surface currently exposes the needed statement.
+
+### `x⊑x²`
+
+Target value status:
+
+  The head can only arise from a context lookup.  The public theorem has
+  `γ = []`, so this branch is impossible.
+
+Source steps:
+
+  None.
+
+Status:
+
+  routine refutation by empty-context lookup inversion.
+
+### `ƛ⊑ƛ²`
+
+Target value status:
+
+  Target is `ƛ M′`, already a value.
+
+Source status:
+
+  Source is `ƛ M`, already a value.
+
+Source steps:
+
+  None.
+
+Result:
+
+  Value branch with `χsᴸ = []`, `W′ = W`, `q = p`, and the original relation.
+
+Status:
+
+  routine zero-step.
+
+### `·⊑·²`
+
+Target value status:
+
+  Target is an application `L′ · M′`, which has no `Value` constructor.
+
+Source steps:
+
+  Irrelevant after target-value contradiction.
+
+Status:
+
+  routine target-value refutation.
+
+### `Λ⊑Λ²`
+
+Target value status:
+
+  Target is `Λ V′`, with `Value V′`.
+
+Source status:
+
+  Source is `Λ V`, with `Value V`.
+
+Source steps:
+
+  None.
+
+Result:
+
+  Value branch by zero-step and the original relation.
+
+Status:
+
+  routine zero-step.
+
+### `Λ⊑²`
+
+Target value status:
+
+  Target is the arbitrary term `M`, assumed to be a value by the theorem.
+
+Source status:
+
+  Source is `Λ V`, with `Value V`.
+
+Source steps:
+
+  None.
+
+Result:
+
+  Value branch by zero-step and the original relation.  The left-only lifted
+  premise is not opened in terminal catch-up because the source is already a
+  value.
+
+Status:
+
+  routine zero-step.  This confirms that `Λ⊑²` is a source-side head, but not
+  a blocked terminal left catch-up branch.
+
+### `Λ⊑²-smart-comma`
+
+Same terminal behavior as `Λ⊑²`: source is already `Λ V`, so terminal
+catch-up is zero-step.  Smart-comma world geometry is relevant to M5-style
+instantiation, not to this terminal value case.
+
+Status:
+
+  routine zero-step.
+
+### `•⊑•²`
+
+Target value status:
+
+  Target is `M′ ⦂∀ C′ [ A′ ]`, which has no `Value` constructor.
+
+Status:
+
+  routine target-value refutation.
+
+### `•⊑²`
+
+Target value status:
+
+  Target is the arbitrary `M′`, assumed value.
+
+Source status:
+
+  Source is `M ⦂∀ C [ A ]`, never a value.
+
+Source steps:
+
+  1. If `M` steps, lift by `ξ-•`.
+  2. If `M` reaches `blame`, use the lifted trace to
+     `blame ⦂∀ C [ A ]`, then `blame-•`.
+  3. If `M` reaches a polymorphic value, canonical-`∀` analysis gives one of:
+     `Λ`, `∀ᶜ`, `gen`, reveal-`∀`, or conceal-`∀`.
+  4. The value-headed source step is respectively:
+     `β-Λ`, `β-∀`, `β-gen`, `β-reveal-∀`, or `β-conceal-∀`.
+  5. The allocating cases use left `bind` and must update the parked world by
+     `evolve-left-bind`; `β-∀` uses `keep`.
+
+Needed lemmas:
+
+  * a source polymorphic value view suitable for the source term,
+  * source type-application catch-up over a fixed target value,
+  * left-only allocation transport for the post-step relation,
+  * smaller-source-cast recursion for `β-gen` residual casts,
+  * blame lifting through the type-application frame.
+
+Right-side mirror:
+
+  The operational catalog mirrors `InstCatchupRightDef` and
+  `InstCatchupRightProof`, but the relation rewrap and world evolution do not.
+  Right M5 allocates target names and erases to `WorldExtendᴿ`; this branch
+  allocates source names and must return `ParkedEvolve χsᴸ []`.
+
+Status:
+
+  new major branch.  Proposed in
+  `t9-left-source-operations-proposal.red`.
+
+### `κ⊑κ²`
+
+Target value status:
+
+  Target constant is a value.
+
+Source status:
+
+  Source constant is a value.
+
+Source steps:
+
+  None.
+
+Status:
+
+  routine zero-step.
+
+### `cast⊑cast²`
+
+Target value status:
+
+  Target is `M′ ⟨ c′ ⟩`.  `Value (M′ ⟨ c′ ⟩)` inverts to
+  `Value M′` and `Inert c′`.
+
+Source status:
+
+  Source is `M ⟨ c ⟩`.
+
+Source steps:
+
+  1. If `M` steps, lift by `ξ-⟨⟩`.
+  2. If `M` reaches `blame`, lift through the cast frame and then use
+     `blame-⟨⟩`.
+  3. If `M` reaches a value and `c` is inert, the source term is a value.
+  4. If `c` is active, source cast reduction may use:
+     `β-id`, `ground`, `expand`, `tag-untag`, `tag-untag-bad`,
+     `blame-bot-intro`, or `β-inst`.
+
+Needed lemmas:
+
+  * `Value` inversion for target casts,
+  * source extra-cast catch-up over a fixed target value,
+  * source projection/tag inversion.  Unlike the target side, a failed source
+    projection may legitimately select the blame disjunct,
+  * source `β-inst` package with left-only allocation,
+  * endpoint relation rewrapping with the inert target cast.
+
+Right-side mirror:
+
+  M4 has many row proofs for target casts.  Their operational shape is useful,
+  but every result package is right-extension-specific and value-only.
+
+Status:
+
+  new major branch.  Proposed in
+  `t9-left-fuel-stack-proposal.red` and
+  `t9-left-source-operations-proposal.red`.
+
+### `⊑cast²`
+
+Target value status:
+
+  Target is `M′ ⟨ c′ ⟩`, so value inversion gives `Value M′` and `Inert c′`.
+
+Source status:
+
+  Source is just `M`.
+
+Source steps:
+
+  The source steps are exactly the recursive catch-up steps for the premise
+  `W ∣ [] ⊢² M ⊑ M′ ∶ p`.
+
+Result reconstruction:
+
+  If the recursive result is a source value `V`, rebuild the target cast
+  wrapper:
+
+    W′ ∣ [] ⊢² V ⊑ M′χ ⟨ applyConsistencies [] c′ ⟩ ∶ ...
+
+  Since the target does not move in the fixed surface, this is propositionally
+  just `⊑cast² c′ final-rel q` in the same world for zero target changes.
+
+  If the recursive result is source blame, return the blame branch unchanged.
+
+Needed lemmas:
+
+  Mostly wrapper packaging once the boundary-general recursion exists.
+
+Right-side mirror:
+
+  This mirrors a structural target-cast row, but does not consume fuel because
+  the target cast is already inert by the `Value` premise.
+
+Status:
+
+  blocked only on the boundary-general left catch-up worker.
+
+### `⊑reveal²`
+
+Target value status:
+
+  Target is `M′ ↑ c′`.  `Value` inversion gives `Value M′` and
+  `RevealValue c′`; hence `c′` is function-shaped or universal-shaped.
+
+Source status:
+
+  Source is just `M`.
+
+Source steps:
+
+  Recursive catch-up for the premise `W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p`.
+
+Problem:
+
+  The premise relation lives in the rebase world `W′`, but the public result
+  must evolve the enclosing world `W`.  `ParkedEvolve` cannot express a
+  zero-store rebase from `W` to `W′`.  The right catch-up surface solves this
+  with an explicit boundary between `W` and `Wᵖ`; left catch-up needs the same
+  kind of internal boundary result, but source-store-changing.
+
+Status:
+
+  new boundary worker needed.  Proposed in
+  `t9-left-boundary-catchup-proposal.red`.
+
+### `⊑conceal²`
+
+Same shape as `⊑reveal²`, with target `M′ ↓ c′` and
+`ConcealValue c′`.  The premise is in `W′`, while the result must evolve the
+enclosing `W`.  Needs boundary-general left catch-up and target-conceal
+rewrap at the evolved endpoint.
+
+Status:
+
+  new boundary worker needed.
+
+### `cast⊑²`
+
+Target value status:
+
+  Target `M′` is already the fixed value.
+
+Source status:
+
+  Source is `M ⟨ c ⟩`.
+
+Source steps:
+
+  Same source cast inventory as `cast⊑cast²`, but without target cast
+  rewrapping:
+
+  * `ξ-⟨⟩` for an inner source step,
+  * `blame-⟨⟩` after inner source blame,
+  * zero-step if `M` is a value and `c` is inert,
+  * `β-id`, `ground`, `expand`, `tag-untag`, `tag-untag-bad`,
+    `blame-bot-intro`, or `β-inst` when `M` is a value and `c` is active.
+
+Needed lemmas:
+
+  The source extra-cast package is the main missing piece.  The source
+  projection cases must branch to either a related value or source blame.
+
+Right-side mirror:
+
+  M4 target extra-cast rows mirror the cast calculus but not the result shape.
+
+Status:
+
+  new major branch.
+
+### `reveal⊑²`
+
+Target value status:
+
+  Target `M′` is already the fixed value.
+
+Source status:
+
+  Source is `M ↑ c`.
+
+Source steps:
+
+  1. If `M` steps, lift by `ξ-reveal`.
+  2. If `M` reaches `blame`, use `blame-reveal`.
+  3. If `M` is a value and `c` is `id↑`, use `id-reveal`.
+  4. If `M` is `(V ↓ seal X R)` and `c` is `unseal X R`, use
+     `conceal-reveal`.
+  5. If `M` is a value and `c` is function-shaped or universal-shaped, then
+     `M ↑ c` is already a value.
+
+Needed lemmas:
+
+  * boundary-general recursion for the premise world,
+  * source reveal endpoint replay through left `ParkedEvolve`,
+  * source reveal peel/cancel for the `conceal-reveal` redex,
+  * relation transport for `id-reveal`.
+
+Right-side mirror:
+
+  Existing `StructuralTargetRevealPeelProof` and source-wrapper replay code
+  show the kind of geometry needed, but they are target-extension-specific.
+
+Status:
+
+  new major branch.
+
+### `conceal⊑²`
+
+Target value status:
+
+  Target `M′` is already the fixed value.
+
+Source status:
+
+  Source is `M ↓ c`.
+
+Source steps:
+
+  1. If `M` steps, lift by `ξ-conceal`.
+  2. If `M` reaches `blame`, use `blame-conceal`.
+  3. If `M` is a value and `c` is `id↓`, use `id-conceal`.
+  4. If `M` is a value and `c` is `seal`, function-shaped, or
+     universal-shaped, then `M ↓ c` is already a value.
+
+Needed lemmas:
+
+  * boundary-general recursion,
+  * source conceal endpoint partner transport through left `ParkedEvolve`,
+  * relation transport for `id-conceal`.
+
+Right-side mirror:
+
+  `StructuralCatchupRightResult` carries endpoint partner fields exactly
+  because target allocation must preserve source conceal replay.  The left
+  package needs analogous fields for left evolution, not right extension.
+
+Status:
+
+  new major branch.
+
+### `reveal⊑reveal²`
+
+Target value status:
+
+  Target `M′ ↑ c′` must have `Value M′` and `RevealValue c′`.
+
+Source status:
+
+  Source is `M ↑ c`.
+
+Source steps:
+
+  Same source reveal inventory as `reveal⊑²`.
+
+Result reconstruction:
+
+  Rebuild a paired reveal at the evolved endpoint, or use a source reveal peel
+  for the `id-reveal` and `conceal-reveal` redexes.
+
+Status:
+
+  new paired wrapper branch.  It depends on the same boundary and source
+  reveal package as `reveal⊑²`.
+
+### `conceal⊑conceal²`
+
+Target value status:
+
+  Target `M′ ↓ c′` must have `Value M′` and `ConcealValue c′`.
+
+Source status:
+
+  Source is `M ↓ c`.
+
+Source steps:
+
+  Same source conceal inventory as `conceal⊑²`.
+
+Result reconstruction:
+
+  Rebuild paired conceal at the evolved endpoint.  The matched partner
+  side condition has to survive left `ParkedEvolve`.
+
+Status:
+
+  new paired wrapper branch.
+
+### `packaged-seal-star²`
+
+Target value status:
+
+  Target `M′ ↓ seal Xᴿ ★` is a value iff `M′` is a value.
+
+Source status:
+
+  Source `M ↓ seal Xᴸ ★` is a value iff `M` is a value.
+
+Source steps:
+
+  If `M` steps, lift by `ξ-conceal`.  If `M` reaches `blame`, use
+  `blame-conceal`.  If `M` is a value, the source is already a seal value.
+
+Two possible reconstruction routes:
+
+  1. Rebuild `packaged-seal-star²` after recursive catch-up on both the inner
+     premise and the package premise.  This needs synchronized left evolution
+     and endpoint package transport.
+  2. Prefer the package premise catch-up
+     `M ↓ seal Xᴸ ★ ⊑ M′`; if it produces a source value `S`, rewrap the
+     fixed target side with `⊑conceal²` to obtain
+     `S ⊑ M′ ↓ seal Xᴿ ★`.
+
+The second route is likely smaller because it avoids reconstructing the full
+packaged constructor at the endpoint.
+
+Status:
+
+  new branch.  Needs a design choice before implementation.
+
+### `blame⊑²`
+
+Target value status:
+
+  Target `M′` is well typed and assumed value.
+
+Source status:
+
+  Source is exactly `blame`.
+
+Source steps:
+
+  None.
+
+Result:
+
+  Blame branch with `χsᴸ = []`, `W′ = W`, and `evolve-refl`.
+
+Status:
+
+  routine zero-step blame result.
+
+### `⊕⊑⊕²`
+
+Target value status:
+
+  Target is `L′ ⊕[ op ] M′`, which has no `Value` constructor.
+
+Status:
+
+  routine target-value refutation.
+
+Blocked branch summary
+----------------------
+
+The genuinely new work is not a single lemma.
+
+1. A boundary-general left catch-up worker is required before target-only
+   reveal/conceal wrappers or premise-world recursion can be handled.
+2. A left value catch-up driver must recurse over CTI2, target values, and a
+   source-cast fuel bound.
+3. A source extra-cast package must normalize `M ⟨ c ⟩` against a fixed target
+   value and may return blame.
+4. A source type-application package must handle `•⊑²` with source
+   canonical-`∀` views and left allocation.
+5. Source reveal/conceal packages must replay or peel source conversion
+   wrappers, including `conceal-reveal`, `id-reveal`, and `id-conceal`.
+6. `packaged-seal-star²` needs a chosen endpoint reconstruction route.
+
+Routine green candidates
+------------------------
+
+No new checked helper was added in this pass.  The obvious routine helpers
+already exist or are directly pattern-matchable:
+
+  * `no-value-type-app` and `no-value-blame` in
+    `Catchup/StructuralTargetPeelSupportProof.agda`,
+  * `value-no-step` in both reduction irreducibility support and target peel
+    support,
+  * `blame-not-value` in `proof/Reduction/ValueIrreducibleProof.agda`,
+  * target cast/reveal/conceal value inversion is a direct pattern match on
+    the `Value` constructors.
+
+Adding duplicate helpers before the major left surfaces exist would only
+increase API noise.

--- a/GTSFImp/proof/DGG/notes/t9-dgg-left-catchup-adapter-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t9-dgg-left-catchup-adapter-proposal.red
@@ -1,0 +1,119 @@
+T9 proposal: DGG adapter for left catch-up
+
+Date: 2026-08-17
+
+Reason
+------
+
+The top-level DGG statement and the fixed `CatchupToLessPrecise` Def should
+not change.  The new work should live behind an adapter that exports exactly
+the existing surface consumed by `DynamicGradualGuaranteeProof`.
+
+Before context
+--------------
+
+`DynamicGradualGuaranteeProof` currently abstracts over:
+
+```agda
+dynamic-gradual-guarantee :
+    Sim*ᵀ
+  → SimBack*ᵀ
+  → CatchupToLessPrecise
+  → CatchupToMorePrecise
+  → TargetBlameCatchupᵀ
+  → GradualDGG
+```
+
+The `target-value` branch calls:
+
+```agda
+catchup
+  (parked-world-closed initial-parked evol₁) N⊑N₂′ vV′
+```
+
+and handles:
+
+```agda
+inj₁ (... N↠V ... evol₂ ... V⊑V′)
+inj₂ (... N↠blame ... evol₂)
+```
+
+No caller needs to know whether the implementation uses boundary recursion,
+source-cast fuel, source wrapper packages, or a left fuel knot.
+
+After context
+-------------
+
+Add a proof adapter after the proposed left stack exists.  It can live in a
+new module such as:
+
+  `proof/DGG/CatchupToLessPreciseProof.agda`
+
+Proposed statement:
+
+```agda
+module proof.DGG.CatchupToLessPreciseProof where
+
+open import Data.Maybe using (nothing)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import proof.DGG.CatchupToLessPreciseDef
+  using (CatchupToLessPrecise)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (boundary-refl)
+open import proof.DGG.Catchup.LeftBoundaryCatchupDef
+  using (CatchupToLessPreciseBoundary; LeftCatchupResult)
+
+left-boundary-catchup→catchup-to-less-precise :
+  CatchupToLessPreciseBoundary → CatchupToLessPrecise
+```
+
+Adapter behavior:
+
+  1. Instantiate the boundary worker at:
+
+       `kind = same-boundary`
+       `Xᴸ? = nothing`
+       `Xᴿ? = nothing`
+       `Wᵖ = W`
+       `boundary = boundary-refl`
+
+  2. In the value branch, erase `Wᵖ′`, `boundary′`, and the pivot equality.
+     The remaining fields match the fixed value branch:
+
+       Δᴸ′, χsᴸ, V, Δ′, W′, q,
+       source trace, source value, `ParkedEvolve χsᴸ [] W W′`,
+       final CTI2 relation.
+
+  3. In the blame branch, erase the same boundary-only fields and return:
+
+       Δᴸ′, χsᴸ, Δ′, W′,
+       source blame trace,
+       `ParkedEvolve χsᴸ [] W W′`.
+
+No GradualDGG shape change
+--------------------------
+
+`DynamicGradualGuaranteeDef.agda` should remain unchanged.  Its Part 3 already
+allows the exact source-blame alternative needed by left catch-up:
+
+```agda
+(source reaches a related value) ⊎ (source reaches blame)
+```
+
+`DynamicGradualGuaranteeProof.agda` also should not need a shape change.  The
+current catchup call is already at the correct point: after backward
+simulation has reduced the target residual to the same value by
+`value-irreducible*`.
+
+Implementation order after proposals
+------------------------------------
+
+1. Land Def-only left boundary and left fuel surfaces.
+2. Prove routine closed zero/refutation rows in a left proof module.
+3. Land source operation packages one family at a time.
+4. Build the left fuel knot.
+5. Add the adapter above.
+6. Pass the adapter result into `dynamic-gradual-guarantee` without editing
+   the DGG statement.

--- a/GTSFImp/proof/DGG/notes/t9-left-boundary-catchup-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t9-left-boundary-catchup-proposal.red
@@ -1,0 +1,166 @@
+T9 proposal: boundary-general left catch-up surface
+
+Date: 2026-08-17
+
+Reason
+------
+
+`CatchupToLessPrecise` is fixed and must remain the public top-down DGG
+surface.  Its current statement has only one world:
+
+  ParkedWorld W
+  W ∣ [] ⊢² M ⊑ V′ ∶ p
+  Value V′
+
+Target-only reveal/conceal CTI2 heads immediately expose a premise relation in
+a different rebase world:
+
+  ⊑reveal²  : W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p -> W ∣ γ ⊢² M ⊑ M′ ↑ c′ ∶ q
+  ⊑conceal² : W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p -> W ∣ γ ⊢² M ⊑ M′ ↓ c′ ∶ q
+
+`ParkedEvolve` records store changes, not zero-store rebasing.  Therefore a
+recursive call directly at `W′` cannot produce the required evolution from
+the enclosing `W`.  The right-side surface solves this with
+`CatchupBoundary`; the left proof needs the same boundary shape but with
+source-store evolution and a blame branch.
+
+Before context
+--------------
+
+Existing public surface:
+
+```agda
+CatchupToLessPrecise : Set
+CatchupToLessPrecise =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → W ∣ [] ⊢² M ⊑ V′ ∶ p
+  → Value V′
+  → ...
+```
+
+Existing right boundary result:
+
+```agda
+ValueCatchupResult
+  {W = W} {Wᵖ = Wᵖ}
+  {kind = kind} {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+```
+
+It evolves target pivots with:
+
+```agda
+Xᴿ′? ≡ mapPivotChanges χsᴿ Xᴿ?
+```
+
+After context
+-------------
+
+Add a new Def module, for example:
+
+  `proof/DGG/Catchup/LeftBoundaryCatchupDef.agda`
+
+It may import the existing `CatchupBoundary` and `CatchupBoundaryKind` from
+`CatchupToMorePreciseDef.agda`; no public Def file has to change.
+
+Proposed statement
+------------------
+
+```agda
+module proof.DGG.Catchup.LeftBoundaryCatchupDef where
+
+open import Data.List using ([])
+open import Data.Maybe using (Maybe)
+open import Data.Product using (_×_; Σ-syntax)
+open import Data.Sum using (_⊎_)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+
+open import Types using (Ty; TyCtx; TyVar)
+open import CastTerms using (Term; Value; blame)
+open import Reduction using (StoreChanges; applyTys; _—↠[_]_)
+import Reduction as R
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open import proof.DGG.Catchup.StructuralWorldExtendDef
+  using (mapPivotChanges)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (CatchupBoundaryKind; CatchupBoundary)
+open CTI2 using (World; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+LeftCatchupResult : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {kind : CatchupBoundaryKind}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → Set₁
+LeftCatchupResult {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
+    {W = W} {Wᵖ = Wᵖ}
+    {kind = kind} {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+    {M = M} {V′ = V′} {A = A} {B = B} =
+  (Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+   Σ[ V ∈ Term Δᴸ′ ] Σ[ Δ′ ∈ TyCtx ]
+   Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Wᵖ′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Xᴸ′? ∈ Maybe (TyVar Δᴸ′) ]
+   Σ[ boundary′ ∈ CatchupBoundary kind Xᴸ′? Xᴿ? W′ Wᵖ′ ]
+   Σ[ q ∈ applyTys χsᴸ A ⊑ᵂ⟨ Wᵖ′ ⟩ B ]
+     Xᴸ′? ≡ mapPivotChanges χsᴸ Xᴸ? ×
+     (M —↠[ χsᴸ ] V) × Value V ×
+     ParkedEvolve χsᴸ R.[] W W′ ×
+     ParkedEvolve χsᴸ R.[] Wᵖ Wᵖ′ ×
+     (Wᵖ′ ∣ [] ⊢² V ⊑ V′ ∶ q))
+  ⊎
+  (Σ[ Δᴸ′ ∈ TyCtx ] Σ[ χsᴸ ∈ StoreChanges Δᴸ Δᴸ′ ]
+   Σ[ Δ′ ∈ TyCtx ]
+   Σ[ W′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Wᵖ′ ∈ World Δᴸ′ Δᴿ Δ′ ]
+   Σ[ Xᴸ′? ∈ Maybe (TyVar Δᴸ′) ]
+   Σ[ boundary′ ∈ CatchupBoundary kind Xᴸ′? Xᴿ? W′ Wᵖ′ ]
+     Xᴸ′? ≡ mapPivotChanges χsᴸ Xᴸ? ×
+     (M —↠[ χsᴸ ] blame) ×
+     ParkedEvolve χsᴸ R.[] W W′ ×
+     ParkedEvolve χsᴸ R.[] Wᵖ Wᵖ′)
+
+CatchupToLessPreciseBoundary : Set₁
+CatchupToLessPreciseBoundary =
+  ∀ {Δᴸ Δᴿ Δ} {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {kind : CatchupBoundaryKind}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → ParkedWorld W
+  → CatchupBoundary kind Xᴸ? Xᴿ? W Wᵖ
+  → Wᵖ ∣ [] ⊢² M ⊑ V′ ∶ p
+  → Value V′
+  → LeftCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = kind}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {M = M} {V′ = V′} {A = A} {B = B}
+```
+
+Notes
+-----
+
+The result carries `ParkedEvolve` for both the enclosing world and premise
+world.  This is intentionally stronger than the right public result because
+there is no left analogue of `StructuralWorldExtendᴿ` today.
+
+If later a structural left extension is introduced, this result can be
+strengthened internally and erased to the same public `CatchupToLessPrecise`
+surface.
+
+Adapter to the fixed public surface
+-----------------------------------
+
+```agda
+left-boundary-catchup→catchup-to-less-precise :
+  CatchupToLessPreciseBoundary → CatchupToLessPrecise
+```
+
+The adapter instantiates `kind = same-boundary`,
+`Xᴸ? = nothing`, `Xᴿ? = nothing`, `Wᵖ = W`, and
+`boundary = boundary-refl`, then erases `Wᵖ′` and `boundary′`.

--- a/GTSFImp/proof/DGG/notes/t9-left-fuel-stack-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t9-left-fuel-stack-proposal.red
@@ -1,0 +1,207 @@
+T9 proposal: left value catch-up fuel stack
+
+Date: 2026-08-17
+
+Reason
+------
+
+The right M6 stack is organized around target casts embedded in the CTI2
+derivation.  For left catch-up, the reducing side is source, so the fuel
+predicate must track source cast heads instead.  Source casts may produce a
+related value or source blame.  Source `β-inst` allocates on the left and has
+the same cast-size decrease problem as target `β-inst`, but the result must
+return `ParkedEvolve χsᴸ []`.
+
+Before context
+--------------
+
+Live right-side definitions:
+
+```agda
+TargetCastBound : ℕ → W ∣ γ ⊢² M ⊑ M″ ∶ q → Set
+
+ValueCatchupRightAt fuel =
+  Value M
+  → (rel : W ∣ γ ⊢² M ⊑ M″ ∶ q)
+  → TargetCastBound fuel rel
+  → ...
+```
+
+Target casts are charged at:
+
+```agda
+TargetCastBound fuel (cast⊑cast² c c′ rel q) =
+  castSize c′ < fuel × TargetCastBound fuel rel
+
+TargetCastBound fuel (⊑cast² c′ rel q) =
+  castSize c′ < fuel × TargetCastBound fuel rel
+```
+
+After context
+-------------
+
+Add left-side counterparts under `proof/DGG/Catchup/`, without modifying the
+existing right-side modules:
+
+  `LeftValueCatchupDef.agda`
+  `LeftFuelKnotProof.agda`
+
+The public top-down surface remains `CatchupToLessPrecise`.
+
+Proposed statement
+------------------
+
+```agda
+module proof.DGG.Catchup.LeftValueCatchupDef where
+
+open import Data.Nat using (ℕ; _<_)
+open import Data.Maybe using (nothing)
+open import Data.Product using (_×_)
+open import Data.Unit using (⊤)
+
+open import Types using (Ty)
+open import Consistency using (Env∼; _⊢_∼_)
+open import CastTerms using (Term; Value)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Catchup.ValueCatchupRightDef
+  using (castSize)
+open import proof.DGG.Catchup.LeftBoundaryCatchupDef
+  using (LeftCatchupResult)
+open import proof.DGG.CatchupToMorePreciseDef
+  using (CatchupBoundaryKind; same-boundary)
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld)
+open CTI2 using (World; CtxImp; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_)
+
+SourceCastBound : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ℕ
+  → W ∣ γ ⊢² M ⊑ M′ ∶ q
+  → Set
+SourceCastBound fuel (CTI2.x⊑x² x∈) = ⊤
+SourceCastBound fuel (CTI2.ƛ⊑ƛ² rel) = SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.·⊑·² rel₁ rel₂) =
+  SourceCastBound fuel rel₁ × SourceCastBound fuel rel₂
+SourceCastBound fuel (CTI2.Λ⊑Λ² liftγ vV vV′ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.Λ⊑² Anv z∈A liftγ vV M⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.Λ⊑²-smart-comma Anv z∈A liftW liftγ vV M⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.•⊑•² p∀ rel q r) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.•⊑² p∀ rel q r) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.κ⊑κ² κ p) = ⊤
+SourceCastBound fuel (CTI2.cast⊑cast² c c′ rel q) =
+  castSize c < fuel × SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.⊑cast² c′ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.⊑reveal² mono rb sameγ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.⊑conceal² mono rb sameγ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.cast⊑² c rel q) =
+  castSize c < fuel × SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.conceal⊑conceal² partner mono rb sameγ c⊢ c′⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.packaged-seal-star² partner mono rb sameγ c⊢ c′⊢
+      rel pkg-rel q) =
+  SourceCastBound fuel rel × SourceCastBound fuel pkg-rel
+SourceCastBound fuel (CTI2.blame⊑² M′⊢ p) = ⊤
+SourceCastBound fuel (CTI2.⊕⊑⊕² op rel₁ rel₂ r) =
+  SourceCastBound fuel rel₁ × SourceCastBound fuel rel₂
+
+LeftValueCatchupAt : ℕ → Set₁
+LeftValueCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ q)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M} {V′ = V′} {A = A} {B = B}
+```
+
+This is the closed same-boundary specialization.  The actual implementation
+should likely use the boundary-general worker from
+`t9-left-boundary-catchup-proposal.red`:
+
+```agda
+LeftValueCatchupBoundaryAt : ℕ → Set₁
+```
+
+whose arguments include `ParkedWorld W`, `CatchupBoundary ... W Wᵖ`,
+`Wᵖ ∣ [] ⊢² M ⊑ V′ ∶ q`, `Value V′`, and
+`SourceCastBound fuel rel`.
+
+Fuel knot proposal
+------------------
+
+```agda
+LeftExtraCastAt : ℕ → Set₁
+LeftInstCatchupAt : ℕ → Set₁
+
+record LeftFuelKnot (fuel : ℕ) : Set₁ where
+  field
+    left-extra-cast-at : LeftExtraCastAt fuel
+    left-inst-catchup-at : LeftInstCatchupAt fuel
+    left-value-catchup-at : LeftValueCatchupAt fuel
+
+record LeftFuelStepSurface (fuel : ℕ) : Set₁ where
+  field
+    smaller-left-extra :
+      ∀ {m} → m < fuel → LeftExtraCastAt m
+    smaller-left-inst :
+      ∀ {m} → m < fuel → LeftInstCatchupAt m
+    smaller-left-value :
+      ∀ {m} → m < fuel → LeftValueCatchupAt m
+```
+
+Strict-decrease inputs mirror the right stack but apply to source casts:
+
+```agda
+source-ground-other-decreaseᵀ : Set
+source-project-expand-decreaseᵀ : Set
+source-inst-alloc-decreaseᵀ : Set
+```
+
+The existing arithmetic lemmas may be reusable because `castSize` is
+side-independent.  The operational packages and endpoint relation
+reconstruction are not reusable as-is.
+
+Blocked branches covered
+------------------------
+
+This fuel stack is needed by:
+
+  * `cast⊑²`,
+  * `cast⊑cast²`,
+  * source `β-inst`,
+  * source `β-gen` residual casts exposed by `•⊑²`,
+  * recursive source casts under `reveal⊑²`, `conceal⊑²`, and paired wrappers.
+
+Not covered
+-----------
+
+This does not by itself solve boundary replay for source and target
+conversion wrappers.  That is the separate boundary proposal.

--- a/GTSFImp/proof/DGG/notes/t9-left-source-operations-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t9-left-source-operations-proposal.red
@@ -1,0 +1,224 @@
+T9 proposal: source operational packages for left catch-up
+
+Date: 2026-08-17
+
+Reason
+------
+
+The terminal left catch-up proof must construct source reduction traces.  The
+right catch-up stack already has target operational catalogs, but all of its
+result packages are target-extension and value-only.  The left packages need
+to return either a related source value or source blame, with
+`ParkedEvolve χsᴸ []`.
+
+Before context
+--------------
+
+Right operational surfaces include:
+
+```agda
+ExtraCastRightAt fuel
+InstCatchupRightAt fuel
+AllValueViewStepCatalogᵀ
+StructuralCatchupRightResult
+```
+
+They produce target traces such as:
+
+```agda
+M′ ⟨ c′ ⟩ —↠[ χsᴿ ] N′
+M′ ⦂∀ B [ A ] —↠[ χsᴿ ] N′
+```
+
+After context
+-------------
+
+Add left analogues under `proof/DGG/Catchup/`, preferably keeping Def
+surfaces separate from proof modules:
+
+  `LeftExtraCastDef.agda`
+  `LeftInstCatchupDef.agda`
+  `LeftSourceWrapperDef.agda`
+
+The statements below intentionally return `LeftCatchupResult`-shaped
+disjunctions rather than a value-only result.
+
+Source extra cast
+-----------------
+
+```agda
+LeftExtraCastAt : ℕ → Set₁
+LeftExtraCastAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {ν : Env∼ Δᴸ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+    {q : A′ ⊑ᵂ⟨ W ⟩ B}
+  → (c : ν ⊢ A ∼ A′)
+  → castSize c < fuel
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ p)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ⟨ c ⟩} {V′ = V′}
+      {A = A′} {B = B}
+```
+
+Important branches:
+
+  * inert source cast: value branch with zero steps,
+  * `id`: one `β-id` keep step,
+  * ground tag: one `ground` keep step, then smaller source-cast recursion,
+  * projection: `tag-untag` value branch or `tag-untag-bad` blame branch,
+  * `bot-intro`: blame branch by `blame-bot-intro`,
+  * `inst`: delegate to `LeftInstCatchupAt fuel`,
+  * inner source non-value: use the boundary value worker on the premise and
+    lift the trace by `ξ-⟨⟩`,
+  * inner source blame: lift by `ξ-⟨⟩`, then `blame-⟨⟩`.
+
+Source inst cast
+----------------
+
+`β-inst` is the main left allocation point for casts:
+
+```agda
+V ⟨ (inst c) A′≢★ ⟩
+  —→[ bind ★ ]
+⇑ᵗᵐ V ⦂∀ applyBody (bind ★) A [ ＇ zero ] ↑
+  〖 zero , ★ ↑ A 〗 ⟨ ↑ᶜ (c [ ★/0 ]ᶜ) ⟩
+```
+
+Proposed surface:
+
+```agda
+LeftInstCatchupAt : ℕ → Set₁
+LeftInstCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {V : Term Δᴸ} {V′ : Term Δᴿ}
+    {A : Ty (suc Δᴸ)} {A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {ν : Env∼ Δᴸ}
+    {p : `∀ A ⊑ᵂ⟨ W ⟩ B}
+    {q : A′ ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → W ∣ [] ⊢² V ⊑ V′ ∶ p
+  → Value V
+  → Value V′
+  → (c : instᵐ ν ⊢ A ∼ ⇑ᵗ A′)
+  → ⦃ Anv : NonVar A ⦄
+  → ⦃ zero∈A : Fin.zero ∈ᵗ A ⦄
+  → (A′≢★ : A′ ≢ ★)
+  → castSize ((inst c) A′≢★) < fuel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = V ⟨ (inst c) A′≢★ ⟩}
+      {V′ = V′} {A = A′} {B = B}
+```
+
+The proof must:
+
+  1. take the `β-inst` source step with `bind ★`,
+  2. evolve the parked world with `evolve-left-bind`,
+  3. reconstruct the post-step CTI relation under the left-only world,
+  4. use smaller source-cast recursion for the residual
+     `↑ᶜ (c [ ★/0 ]ᶜ)`,
+  5. preserve the fixed target value across the left allocation.
+
+Source type application
+-----------------------
+
+`•⊑²` is the unique CTI2 branch where the source is a type application and the
+target may already be a value.
+
+Proposed surface:
+
+```agda
+LeftSourceTypeAppCatchupAt : ℕ → Set₁
+LeftSourceTypeAppCatchupAt fuel =
+  ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {V′ : Term Δᴿ}
+    {C : Ty (suc Δᴸ)} {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p∀ : `∀ C ⊑ᵂ⟨ W ⟩ B}
+    {q : A ⊑ᵂ⟨ W ⟩ ★}
+    {r : C [ A ]ᵗ ⊑ᵂ⟨ W ⟩ B}
+  → ParkedWorld W
+  → (rel : W ∣ [] ⊢² M ⊑ V′ ∶ p∀)
+  → Value V′
+  → SourceCastBound fuel rel
+  → LeftCatchupResult
+      {W = W} {Wᵖ = W}
+      {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {M = M ⦂∀ C [ A ]} {V′ = V′}
+      {A = C [ A ]ᵗ} {B = B}
+```
+
+Operational branches:
+
+  * inner source steps: lift by `ξ-•`,
+  * inner source blame: lift then use `blame-•`,
+  * `Λ`: `β-Λ` with source `bind A`,
+  * `∀ᶜ`: `β-∀` with `keep`,
+  * `gen`: `β-gen` with source `bind A`, followed by residual source-cast
+    recursion,
+  * reveal-`∀`: `β-reveal-∀` with source `bind A`,
+  * conceal-`∀`: `β-conceal-∀` with source `bind A`.
+
+This is the left analogue of the M5 step catalog, but it is consumed from
+`•⊑²`, not from target extra-cast normalization.
+
+Source reveal/conceal wrappers
+------------------------------
+
+Proposed shared wrapper surfaces:
+
+```agda
+LeftSourceRevealCatchupAt : ℕ → Set₁
+LeftSourceConcealCatchupAt : ℕ → Set₁
+```
+
+They should be boundary-general, because `reveal⊑²`, `conceal⊑²`,
+`reveal⊑reveal²`, and `conceal⊑conceal²` all move through premise worlds.
+
+Source reveal operational branches:
+
+  * `ξ-reveal`,
+  * `blame-reveal`,
+  * `id-reveal`,
+  * `conceal-reveal`,
+  * zero-step value for function and universal reveal conversions.
+
+Source conceal operational branches:
+
+  * `ξ-conceal`,
+  * `blame-conceal`,
+  * `id-conceal`,
+  * zero-step value for seal, function, and universal conceal conversions.
+
+Required endpoint transport fields:
+
+  * source reveal rebase transport through left `ParkedEvolve`,
+  * source conceal `SourceConcealPartnerOK` transport through left
+    `ParkedEvolve`,
+  * matched conceal partner transport through left `ParkedEvolve`,
+  * target-wrapper rewrap for paired wrappers whose target is already a value.
+
+Blocked branches covered
+------------------------
+
+These operation packages cover the non-routine branches in:
+
+  * `cast⊑²`,
+  * `cast⊑cast²`,
+  * `•⊑²`,
+  * `reveal⊑²`,
+  * `conceal⊑²`,
+  * `reveal⊑reveal²`,
+  * `conceal⊑conceal²`,
+  * `packaged-seal-star²`.


### PR DESCRIPTION
Design reconnaissance for the LEFT catch-up surface (no machinery existed). Notes only, gate green (compile surface identical to the verified heal). Deliverables: a complete per-head case table (t9-catchup-to-less-precise-case-table-blocked.red) and four architecture proposals — left boundary worker (t9-left-boundary-catchup-proposal.red), left fuel stack (t9-left-fuel-stack-proposal.red), source-operations packages (t9-left-source-operations-proposal.red), and the thin DGG adapter keeping the fixed Def unchanged (t9-dgg-left-catchup-adapter-proposal.red). Consolidated as decision ask D11 on #157. Carries the main-heal cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)