### PR TITLE
T10: calibration probes — D6 refuted, D2b one-sided inexpressible, D7 same-q refuted

### DIFF
--- a/GTSFImp/proof/DGG/notes/TIGHTEN2-BLOCKED.red
+++ b/GTSFImp/proof/DGG/notes/TIGHTEN2-BLOCKED.red
@@ -2,8 +2,7 @@ TIGHTEN2 blocked handoff
 
 Current blocker:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-    agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 reports:
 

--- a/GTSFImp/proof/DGG/notes/consistency-cleanup-blocked.red
+++ b/GTSFImp/proof/DGG/notes/consistency-cleanup-blocked.red
@@ -3,8 +3,6 @@ Consistency cleanup blocked after flipping `_↦_`.
 Command:
 
   env \
-    AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
     agda -i GTSFImp -v0 GTSFImp/All.agda
 
 Failure:

--- a/GTSFImp/proof/DGG/notes/lg1e-target-source-star-reemit-payload-open.red
+++ b/GTSFImp/proof/DGG/notes/lg1e-target-source-star-reemit-payload-open.red
@@ -78,5 +78,5 @@ Regression evidence:
 - `GTSFImp/proof/DGG/Inversion/SourceStripProof.agda`: pass
 - `GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda`: pass
 - `GTSFImp/proof/DGG/Inversion/RightInjInversion2Lemma.agda`: pass
-- full gate `cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check`:
+- full gate `cd GTSFImp && make check`:
   pass, `postulate-check: OK (FunExt-only)`.

--- a/GTSFImp/proof/DGG/notes/lg1h-noncovering-removal-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg1h-noncovering-removal-resister.red
@@ -4,8 +4,7 @@ mismatches.
 Command that exposes the target-strip cases:
 
   cd GTSFImp
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
-    agda -i . -v0 proof/DGG/Inversion/TargetStripProof.agda
+  agda -i . -v0 proof/DGG/Inversion/TargetStripProof.agda
 
 Agda reports the two missing target-strip branches:
 

--- a/GTSFImp/proof/DGG/notes/lg3-target-cast-multistep-worker-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3-target-cast-multistep-worker-resister.red
@@ -198,7 +198,7 @@ Factory status after LG-3h:
 Current gate for this resister record was run with the sanctioned supervisor
 stdlib path:
 
-`cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check`
+`cd GTSFImp && make check`
 
 It passes:
 
@@ -455,7 +455,7 @@ LG-3n STOP postscript, 2026-08-16:
 
 Baseline gate is green:
 
-`cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check`
+`cd GTSFImp && make check`
 
 `postulate-check: OK (no postulates; NON_COVERING at legacy baseline)`
 
@@ -581,7 +581,7 @@ still row-level plus factory adapters:
 
 Gate:
 
-`cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check`
+`cd GTSFImp && make check`
 
 Result:
 
@@ -772,7 +772,7 @@ grounding residual is unchanged and still checked as
 Gate after the landed source-Λ stack support:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -881,7 +881,7 @@ imprecision relation, reduction relation, proof module, protected surface, or
 Gate/regression after the LG-3w note-only chunk:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -980,7 +980,7 @@ remains the checked residual.
 Gate after the paired-row chunk:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -1049,7 +1049,7 @@ Current genuine resisters:
 Gate/regression after the LG-3y checked resister chunk:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:

--- a/GTSFImp/proof/DGG/notes/lg3af-target-conversion-endpoint-partner-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3af-target-conversion-endpoint-partner-resister.red
@@ -6,7 +6,7 @@ Status: STOPPED on the target conversion-frame endpoint-partner discharge for
 Baseline gate before this note:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -228,7 +228,7 @@ protected structural surface, public fuel surface, or `PLAN.md` was changed.
 Gate/regression after the LG-3ag STOP record:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:

--- a/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3ah-supplied-continuation-assembly-resister.red
@@ -5,7 +5,7 @@ Status: STOPPED before live proof edits.
 Baseline/cleanup gate:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 The pre-edit gate was green:
@@ -155,7 +155,7 @@ conversion evidence for `applyReveals` / `applyConceals`.  No change to the
 reduction relation itself was needed.  Gate:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+make check
 postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
 ```
 
@@ -171,7 +171,7 @@ arbitrary source/matched conceal partner transformers as result fields.
 Checked chunk:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+make check
 postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
 ```
 
@@ -201,7 +201,7 @@ seal-star row additionally uses a narrow canonical seal-star replay
 Checked chunk:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+make check
 postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
 ```
 

--- a/GTSFImp/proof/DGG/notes/lg3t-source-lambda-replay-stack-bind-commutation-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3t-source-lambda-replay-stack-bind-commutation-resister.red
@@ -12,7 +12,7 @@ Status:
   `liftCtxᴸ-target-ctx`, `smartCommaLift-target-store`, and
   `smartLiftCtxᴸ-target-ctx`.
 - The required gate passed:
-  `cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check`
+  `cd GTSFImp && make check`
   with `postulate-check: OK (no postulates; NON_COVERING at legacy baseline)`.
 
 ## Remaining missing datum
@@ -205,7 +205,7 @@ factories, and the public `FuelKnot` assembly remain unassembled.
 Gate before and after this note-only stop:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -247,7 +247,7 @@ from frame data at the use site.  The checked gate for the landed support
 chunk was:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:

--- a/GTSFImp/proof/DGG/notes/lg3z-assembly-structural-factory-resister.red
+++ b/GTSFImp/proof/DGG/notes/lg3z-assembly-structural-factory-resister.red
@@ -23,7 +23,7 @@ Checked LG-3z chunk, 2026-08-17:
 Gate:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -163,7 +163,7 @@ Stop-rule status:
 Gate after the LG-3aa residual record:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -244,7 +244,7 @@ Assembly status after LG-3ac:
 Commands run during LG-3ac:
 
 ```text
-cd GTSFImp/proof/DGG/notes && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home agda -i ../../.. -v0 TagDisciplineScratch.agda
+cd GTSFImp/proof/DGG/notes && agda -i ../../.. -v0 TagDisciplineScratch.agda
 ```
 
 Result:
@@ -349,7 +349,7 @@ Checked commits:
 The required gate passed after both checked chunks:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:
@@ -532,7 +532,7 @@ fallback.
 Gate after the LG-3ae fallback note:
 
 ```text
-cd GTSFImp && AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+cd GTSFImp && make check
 ```
 
 Result:

--- a/GTSFImp/proof/DGG/notes/m5-structural-name-instantiation-source-premise-final-blocked.red
+++ b/GTSFImp/proof/DGG/notes/m5-structural-name-instantiation-source-premise-final-blocked.red
@@ -75,8 +75,7 @@ What was tried:
 
      Focused command:
 
-       AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
-         agda -i GTSFImp -v0 \
+       agda -i GTSFImp -v0 \
            GTSFImp/proof/DGG/notes/M5StructuralNameSourceCastCounterexampleScratch.agda
 
      The checked ingredients are:
@@ -136,8 +135,7 @@ RESOLVED-BY-DESIGN postscript, 2026-08-14:
 
   Checked command:
 
-    AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
-      agda -i GTSFImp -v0 \
+    agda -i GTSFImp -v0 \
         GTSFImp/proof/DGG/notes/M5StructuralNamePostPlanScratch.agda
 
   Matrix outcome:

--- a/GTSFImp/proof/DGG/notes/probes/T10Probe1ParkedWorldPreservation.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T10Probe1ParkedWorldPreservation.agda
@@ -1,0 +1,140 @@
+module T10Probe1ParkedWorldPreservation where
+
+-- File Charter:
+--   * Calibration probe for the D6 parked-world preservation questions.
+--   * Builds one finite parked world `W` and one finite non-parked world
+--     `Wᵖ` connected by forward and reversed rebase witnesses.
+--   * The checked `ParkedWorld Wᵖ -> ⊥` refutes all four candidate
+--     preservation statements without changing the live DGG development.
+
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types using (TyVar; ★)
+open import TyStore using (store-empty; store-bind)
+open import Consistency using (empty; keep; skip; toRenameᵗ)
+open import Imprecision using
+  (ImpEnv; VarImp; X⊑X; X⊑★; extendᵐ; instᵐ; ★⊑★)
+
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CompilePreservesImprecision2 as CPI2
+open import proof.DGG.Parked.ParkedWorldDef using
+  ( ParkedWorld
+  ; parked-initial
+  ; parked-both-bind
+  ; parked-left-bind
+  ; parked-right-bind
+  )
+
+
+empty-μ : ImpEnv 0
+empty-μ ()
+
+W₀ : CTI2.World 0 0 0
+W₀ = CPI2.initialWorld empty-μ store-empty
+
+W-paired : CTI2.World 1 1 1
+W-paired = CTI2.bothBindWorld X⊑X W₀ ★ ★
+
+W : CTI2.World 1 2 2
+W = CTI2.rightOnlyWorld W-paired ★
+
+parked-W : ParkedWorld W
+parked-W = parked-right-bind (parked-both-bind parked-initial)
+
+source-store : TyStore.TyStore 1
+source-store = store-bind store-empty ★
+
+target-store : TyStore.TyStore 2
+target-store = store-bind (store-bind store-empty ★) ★
+
+mark-X⊑★ : VarImp
+mark-X⊑★ = X⊑★
+
+mark-X⊑X : VarImp
+mark-X⊑X = X⊑X
+
+mark-X⊑★≢mark-X⊑X : mark-X⊑★ ≢ mark-X⊑X
+mark-X⊑★≢mark-X⊑X ()
+
+μ : ImpEnv 2
+μ = instᵐ (extendᵐ X⊑X empty-μ)
+
+ηᴸ-fresh : 1 Consistency.↪ᵗ 2
+ηᴸ-fresh = keep empty
+
+ηᴿ-id : 2 Consistency.↪ᵗ 2
+ηᴿ-id = keep (keep empty)
+
+Wᵖ : CTI2.World 1 2 2
+Wᵖ = CTI2.world ηᴸ-fresh ηᴿ-id μ source-store target-store
+
+X : TyVar 1
+X = Fin.zero
+
+Y-fresh : TyVar 2
+Y-fresh = Fin.zero
+
+Y-old : TyVar 2
+Y-old = Fin.suc Fin.zero
+
+fresh-representation : CTI2.StoreRepImp Wᵖ X Y-fresh
+fresh-representation = CTI2.store-rep-imp ★⊑★
+
+old-representation : CTI2.StoreRepImp W X Y-old
+old-representation = CTI2.store-rep-imp ★⊑★
+
+forward-rebase : CTI2.RebaseAt W Wᵖ X Y-fresh
+forward-rebase =
+  CTI2.rebase-at (CTI2.same-runtime refl refl)
+    (λ { {Fin.zero} X≢X → ⊥-elim (X≢X refl) })
+    (λ { Fin.zero → refl ; (Fin.suc Fin.zero) → refl })
+    refl fresh-representation
+
+reversed-rebase : CTI2.RebaseAt Wᵖ W X Y-old
+reversed-rebase =
+  CTI2.rebase-at (CTI2.same-runtime refl refl)
+    (λ { {Fin.zero} X≢X → ⊥-elim (X≢X refl) })
+    (λ { Fin.zero → refl ; (Fin.suc Fin.zero) → refl })
+    refl old-representation
+
+parked-head00-precise : ∀ {W′ : CTI2.World 1 2 2}
+  → ParkedWorld W′
+  → toRenameᵗ (CTI2.ηᴸʷ W′) Fin.zero ≡ Fin.zero
+  → toRenameᵗ (CTI2.ηᴿʷ W′) Fin.zero ≡ Fin.zero
+  → CTI2.impEnvʷ W′ Fin.zero ≡ X⊑X
+parked-head00-precise (parked-both-bind pw) src-zero tgt-zero = refl
+parked-head00-precise (parked-left-bind pw) src-zero ()
+parked-head00-precise (parked-right-bind pw) () tgt-zero
+
+not-parked-Wᵖ : ParkedWorld Wᵖ → ⊥
+not-parked-Wᵖ pw =
+  mark-X⊑★≢mark-X⊑X (parked-head00-precise pw refl refl)
+
+claim-a-refuted :
+  (ParkedWorld W → CTI2.RebaseAtᴸ W Wᵖ (just X) → ParkedWorld Wᵖ) → ⊥
+claim-a-refuted claim =
+  not-parked-Wᵖ (claim parked-W (CTI2.rebase-varᴸ forward-rebase))
+
+claim-b-refuted :
+  (ParkedWorld W → CTI2.RebaseAtᴿ W Wᵖ (just Y-fresh)
+    → ParkedWorld Wᵖ)
+  → ⊥
+claim-b-refuted claim =
+  not-parked-Wᵖ (claim parked-W (CTI2.rebase-varᴿ forward-rebase))
+
+claim-c-refuted :
+  (ParkedWorld W → CTI2.TagRebaseAtᴸ W Wᵖ (just X) (just Y-fresh)
+    → ParkedWorld Wᵖ)
+  → ⊥
+claim-c-refuted claim =
+  not-parked-Wᵖ (claim parked-W (CTI2.tag-rebase-varᴸ forward-rebase))
+
+claim-d-refuted :
+  (ParkedWorld W → CTI2.TagRebaseAtᴸ Wᵖ W (just X) (just Y-old)
+    → ParkedWorld Wᵖ)
+  → ⊥
+claim-d-refuted claim =
+  not-parked-Wᵖ (claim parked-W (CTI2.tag-rebase-varᴸ reversed-rebase))

--- a/GTSFImp/proof/DGG/notes/probes/T10Probe2SourceRevealStillSealed.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T10Probe2SourceRevealStillSealed.agda
@@ -1,0 +1,97 @@
+module T10Probe2SourceRevealStillSealed where
+
+-- File Charter:
+--   * Calibration probe for the D2b source conceal-reveal question.
+--   * Sets up a concrete partnered source/target seal with representation
+--     `ℕ`, records the source `conceal-reveal` step, and checks whether
+--     the post-reveal source representation type can still relate to the
+--     sealed target type.
+--   * The checked emptiness lemma shows the one-sided post-reveal shape
+--     `ℕ ⊑ᵂ ＇Y` is not expressible in the current relation.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import Types
+open import TyStore using (TyStore; store-empty; store-bind; _∋_⦂_; Z∋)
+open import Imprecision using (ImpEnv; X⊑X; ι⊑ι)
+open import Conversion using (seal; unseal)
+open import CastTerms using (Term; Value; $; _↓_; _↑_)
+open import Primitives using (κℕ)
+open import Reduction using (_—→_; conceal-reveal)
+
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CompilePreservesImprecision2 as CPI2
+
+
+empty-μ : ImpEnv 0
+empty-μ ()
+
+ℕ₀ : Ty 0
+ℕ₀ = ‵ `ℕ
+
+W₀ : CTI2.World 0 0 0
+W₀ = CPI2.initialWorld empty-μ store-empty
+
+W : CTI2.World 1 1 1
+W = CTI2.bothBindWorld X⊑X W₀ ℕ₀ ℕ₀
+
+X : TyVar 1
+X = Fin.zero
+
+Y : TyVar 1
+Y = Fin.zero
+
+ℕ₁ : Ty 1
+ℕ₁ = ‵ `ℕ
+
+source-store : TyStore 1
+source-store = store-bind store-empty ℕ₀
+
+target-store : TyStore 1
+target-store = store-bind store-empty ℕ₀
+
+source-entry : CTI2.sourceStoreʷ W ∋ X ⦂ ℕ₁
+source-entry = Z∋ refl
+
+target-entry : CTI2.targetStoreʷ W ∋ Y ⦂ ℕ₁
+target-entry = Z∋ refl
+
+source-seal-typed :
+  CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] seal X ℕ₁
+source-seal-typed = CTI2.⊢↓-sealˣ source-entry
+
+source-unseal-typed :
+  CTI2.sourceStoreʷ W CTI2.⊢↑[ just X ] unseal X ℕ₁
+source-unseal-typed = CTI2.⊢↑-unsealˣ source-entry
+
+target-seal-typed :
+  CTI2.targetStoreʷ W CTI2.⊢↓[ just Y ] seal Y ℕ₁
+target-seal-typed = CTI2.⊢↓-sealˣ target-entry
+
+partnered-representation : CTI2.StoreRepImp W X Y
+partnered-representation = CTI2.store-rep-imp ι⊑ι
+
+sealed-before-peel : (＇ X) CTI2.⊑ᵂ⟨ W ⟩ (＇ Y)
+sealed-before-peel = X⊑X
+
+source-value : Term 1
+source-value = $ (κℕ 0)
+
+source-value-value : Value source-value
+source-value-value = $ (κℕ 0)
+
+source-sealed : Term 1
+source-sealed = source-value ↓ seal X ℕ₁
+
+source-revealed : Term 1
+source-revealed = source-sealed ↑ unseal X ℕ₁
+
+source-conceal-reveal-step : source-revealed —→ source-value
+source-conceal-reveal-step = conceal-reveal source-value-value
+
+post-source-reveal-still-sealed-empty :
+  ℕ₁ CTI2.⊑ᵂ⟨ W ⟩ (＇ Y) → ⊥
+post-source-reveal-still-sealed-empty ()

--- a/GTSFImp/proof/DGG/notes/probes/T10Probe3TargetKeepSameQ.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T10Probe3TargetKeepSameQ.agda
@@ -1,0 +1,158 @@
+module T10Probe3TargetKeepSameQ where
+
+-- File Charter:
+--   * Calibration probe for the D7 target keep-step same-`q` question.
+--   * Builds a paired source/target reveal over matching sealed `ℕ` values.
+--   * The relation before the target `conceal-reveal` keep step uses
+--     exactly `q = ℕ ⊑ᵂ ℕ`; the checked counterexample shows that after
+--     only the target step, the same-`q` relation is underivable.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import Types
+open import TyStore using (store-empty; _∋_⦂_; Z∋)
+open import Imprecision using (ImpEnv; X⊑X; ι⊑ι)
+import Conversion as Conv
+import CastTerms as CT
+open import CastTerms using (Term; Value; $; _↓_; _↑_)
+open import Primitives using (κℕ)
+import Reduction as R
+
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CompilePreservesImprecision2 as CPI2
+
+
+empty-μ : ImpEnv 0
+empty-μ ()
+
+ℕ₀ : Ty 0
+ℕ₀ = ‵ `ℕ
+
+W₀ : CTI2.World 0 0 0
+W₀ = CPI2.initialWorld empty-μ store-empty
+
+W : CTI2.World 1 1 1
+W = CTI2.bothBindWorld X⊑X W₀ ℕ₀ ℕ₀
+
+X : TyVar 1
+X = Fin.zero
+
+Y : TyVar 1
+Y = Fin.zero
+
+ℕ₁ : Ty 1
+ℕ₁ = ‵ `ℕ
+
+source-entry : CTI2.sourceStoreʷ W ∋ X ⦂ ℕ₁
+source-entry = Z∋ refl
+
+target-entry : CTI2.targetStoreʷ W ∋ Y ⦂ ℕ₁
+target-entry = Z∋ refl
+
+source-seal-typed :
+  CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] Conv.seal X ℕ₁
+source-seal-typed = CTI2.⊢↓-sealˣ source-entry
+
+target-seal-typed :
+  CTI2.targetStoreʷ W CTI2.⊢↓[ just Y ] Conv.seal Y ℕ₁
+target-seal-typed = CTI2.⊢↓-sealˣ target-entry
+
+source-unseal-typed :
+  CTI2.sourceStoreʷ W CTI2.⊢↑[ just X ] Conv.unseal X ℕ₁
+source-unseal-typed = CTI2.⊢↑-unsealˣ source-entry
+
+target-unseal-typed :
+  CTI2.targetStoreʷ W CTI2.⊢↑[ just Y ] Conv.unseal Y ℕ₁
+target-unseal-typed = CTI2.⊢↑-unsealˣ target-entry
+
+q : ℕ₁ CTI2.⊑ᵂ⟨ W ⟩ ℕ₁
+q = ι⊑ι
+
+sealed-q : (＇ X) CTI2.⊑ᵂ⟨ W ⟩ (＇ Y)
+sealed-q = X⊑X
+
+partnered-representation : CTI2.StoreRepImp W X Y
+partnered-representation = CTI2.store-rep-imp q
+
+same-rebase : CTI2.RebaseAt W W X Y
+same-rebase = CTI2.sameWorldRebaseAt refl partnered-representation
+
+mono-refl : CTI2.ImpEnvMono W W
+mono-refl _ eq = eq
+
+source-value : Term 1
+source-value = $ (κℕ 0)
+
+target-value : Term 1
+target-value = $ (κℕ 0)
+
+source-value-value : Value source-value
+source-value-value = $ (κℕ 0)
+
+target-value-value : Value target-value
+target-value-value = $ (κℕ 0)
+
+source-sealed : Term 1
+source-sealed = source-value ↓ Conv.seal X ℕ₁
+
+target-sealed : Term 1
+target-sealed = target-value ↓ Conv.seal Y ℕ₁
+
+source-sealed-value : Value source-sealed
+source-sealed-value = source-value-value CT.↓ CT.seal
+
+target-sealed-value : Value target-sealed
+target-sealed-value = target-value-value CT.↓ CT.seal
+
+source-revealed : Term 1
+source-revealed = source-sealed ↑ Conv.unseal X ℕ₁
+
+target-revealed : Term 1
+target-revealed = target-sealed ↑ Conv.unseal Y ℕ₁
+
+base-relation : W CTI2.∣ [] ⊢² source-value ⊑ target-value ∶ q
+base-relation = CTI2.κ⊑κ² (κℕ 0) q
+
+matched-conceal-partner :
+  CTI2.MatchedConcealPartnerOK W source-value
+    (Conv.seal X ℕ₁) (just Y) target-value
+matched-conceal-partner = CTI2.matched-seal-nonstar nonstar-ι
+
+sealed-relation :
+  W CTI2.∣ [] ⊢² source-sealed ⊑ target-sealed ∶ sealed-q
+sealed-relation =
+  CTI2.conceal⊑conceal² matched-conceal-partner mono-refl
+    same-rebase CTI2.same-[] source-seal-typed target-seal-typed
+    base-relation sealed-q
+
+before-target-keep :
+  W CTI2.∣ [] ⊢² source-revealed ⊑ target-revealed ∶ q
+before-target-keep =
+  CTI2.reveal⊑reveal² mono-refl same-rebase CTI2.same-[]
+    source-unseal-typed target-unseal-typed sealed-relation q
+
+target-keep-step : target-revealed R.—→[ R.keep ] target-value
+target-keep-step = R.pure-step (R.conceal-reveal target-value-value)
+
+target-keep-value : Value target-value
+target-keep-value = target-value-value
+
+source-sealed-to-representation-empty :
+  ∀ {W′ : CTI2.World 1 1 1}
+  → (＇ X) CTI2.⊑ᵂ⟨ W′ ⟩ ℕ₁
+  → ⊥
+source-sealed-to-representation-empty ()
+
+same-q-after-target-only-empty :
+  W CTI2.∣ [] ⊢² source-revealed ⊑ target-value ∶ q → ⊥
+same-q-after-target-only-empty
+    (CTI2.reveal⊑² {W′ = W′} {p = p} mono rb same c⊢ rel q′) =
+  source-sealed-to-representation-empty {W′ = W′} p
+
+after-both-peel-same-q :
+  W CTI2.∣ [] ⊢² source-value ⊑ target-value ∶ q
+after-both-peel-same-q = base-relation

--- a/GTSFImp/proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda
@@ -1,0 +1,368 @@
+module T12TwoSidedPeelRestatementProbe where
+
+-- File Charter:
+--   * Statement-only scratch probe for the T12 two-sided peel restatements.
+--   * Checks that the proposed replacement surfaces are well-formed Agda
+--     `Set` declarations.
+--   * Provides no implementations, inhabitants, postulates, holes, or imports
+--     from this scratch module into the live DGG development.
+
+open import Data.List using ([])
+open import Data.Maybe using (Maybe; just; nothing)
+open import Data.Product using (_×_; Σ-syntax)
+
+open import Types using (Ty; TyCtx; TyVar)
+open import Conversion using (Conv↑; Conv↓; seal; unseal)
+open import CastTerms using (Term; Value; _↑_; _↓_)
+open import Reduction using
+  ( StoreChange
+  ; StoreChanges
+  ; applyTy
+  ; applyTys
+  ; keep
+  ; _—→[_]_
+  ; _—↠[_]_
+  ) renaming ([] to []ˢ; _∷_ to _∷ˢ_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef
+  using (ParkedWorld; ParkedEvolve)
+open import proof.DGG.CatchupToMorePreciseDef
+  using
+    ( CatchupBoundary
+    ; CatchupBoundaryKind
+    ; source-reveal-boundary
+    ; source-conceal-boundary
+    ; target-reveal-boundary
+    ; target-conceal-boundary
+    )
+open CTI2 using
+  ( World
+  ; CtxImp
+  ; ImpEnvMono
+  ; RebaseAtᴸ
+  ; RebaseAtᴿ
+  ; TagRebaseAtᴸ
+  ; SameCtx
+  ; _⊑ᵂ⟨_⟩_
+  ; _∣_⊢²_⊑_∶_
+  )
+
+
+record TargetOpenedByConcealReveal {Δᴿ : TyCtx}
+    (V′ : Term Δᴿ) (R′ : Ty Δᴿ) : Set where
+  field
+    opened-payload : Term Δᴿ
+    opened-pivot : TyVar Δᴿ
+    opened-value : Value opened-payload
+    opened-step :
+      ((opened-payload ↓ seal opened-pivot R′)
+        ↑ unseal opened-pivot R′) —→[ keep ] V′
+
+
+PairedConcealRevealPeelᵀ : Set
+PairedConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+
+SourceOnlyConcealRevealPeelᵀ : Set
+SourceOnlyConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → TargetOpenedByConcealReveal V₀′ R′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ V₀′ ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+
+record SimConversionFramesSuppliedParkedᵀ : Set₁ where
+  field
+    source-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↑ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴸ W Wᵖ Xᴸ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.sourceStoreʷ W CTI2.⊢↑[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↑ c ⊑ M′ ∶ q
+      → M ↑ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↑ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ W Wᵖ Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.targetStoreʷ W CTI2.⊢↑[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↑ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↑ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    source-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↓ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → CTI2.SourceConcealPartnerOK Wᵖ M c Xᴿ? M′
+      → ImpEnvMono W Wᵖ
+      → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↓ c ⊑ M′ ∶ q
+      → M ↓ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↓ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ Wᵖ W Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.targetStoreʷ W CTI2.⊢↓[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↓ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↓ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+
+record SuppliedBoundaryStack {Δᴸ Δᴿ Δ}
+    (kind : CatchupBoundaryKind)
+    (Xᴸ? : Maybe (TyVar Δᴸ)) (Xᴿ? : Maybe (TyVar Δᴿ))
+    (W Wᵖ : World Δᴸ Δᴿ Δ) : Set₁ where
+  field
+    boundary-outer-parked : ParkedWorld W
+    boundary-premise-parked : ParkedWorld Wᵖ
+    boundary-certificate : CatchupBoundary kind Xᴸ? Xᴿ? W Wᵖ
+
+
+record SimConversionFramesBoundaryStackᵀ : Set₁ where
+  field
+    source-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↑ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack source-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴸ W Wᵖ Xᴸ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.sourceStoreʷ W CTI2.⊢↑[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↑ c ⊑ M′ ∶ q
+      → M ↑ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↑ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack target-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ W Wᵖ Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.targetStoreʷ W CTI2.⊢↑[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↑ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↑ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    source-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↓ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack source-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → CTI2.SourceConcealPartnerOK Wᵖ M c Xᴿ? M′
+      → ImpEnvMono W Wᵖ
+      → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↓ c ⊑ M′ ∶ q
+      → M ↓ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↓ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack target-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ Wᵖ W Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → CTI2.targetStoreʷ W CTI2.⊢↓[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↓ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↓ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+
+record TargetRevealKeepOutcomeContinuationsᵀ : Set₁ where
+  field
+    paired-conceal-reveal :
+      PairedConcealRevealPeelᵀ
+    source-opened-conceal-reveal :
+      SourceOnlyConcealRevealPeelᵀ
+
+
+record TargetConcealKeepOutcomeContinuationsᵀ : Set₁ where
+  field
+    paired-id-conceal :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+        {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B : Ty Δᴿ}
+        {q : A ⊑ᵂ⟨ W ⟩ B}
+      → Value V₀
+      → Value V₀′
+      → W ∣ γ ⊢²
+          (V₀ ↓ Conversion.id↓ A)
+          ⊑ (V₀′ ↓ Conversion.id↓ B) ∶ q
+      → (V₀ ↓ Conversion.id↓ A) —→[ keep ] V₀
+      → (V₀′ ↓ Conversion.id↓ B) —→[ keep ] V₀′
+      → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+    source-opened-id-conceal :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+        {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B : Ty Δᴿ}
+        {q : A ⊑ᵂ⟨ W ⟩ B}
+      → Value V₀
+      → Value V₀′
+      → W ∣ γ ⊢² (V₀ ↓ Conversion.id↓ A) ⊑ V₀′ ∶ q
+      → (V₀ ↓ Conversion.id↓ A) —→[ keep ] V₀
+      → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+
+record RestatedDispatcherKeepOutcomesᵀ : Set₁ where
+  field
+    target-reveal-outcomes : TargetRevealKeepOutcomeContinuationsᵀ
+    target-conceal-outcomes : TargetConcealKeepOutcomeContinuationsᵀ

--- a/GTSFImp/proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda
@@ -49,14 +49,12 @@ open CTI2 using
 
 
 record TargetOpenedByConcealReveal {Δᴿ : TyCtx}
-    (V′ : Term Δᴿ) (R′ : Ty Δᴿ) : Set where
+    (N : Term Δᴿ) (X : TyVar Δᴿ) (R′ : Ty Δᴿ)
+    (V′ : Term Δᴿ) : Set where
   field
-    opened-payload : Term Δᴿ
-    opened-pivot : TyVar Δᴿ
-    opened-value : Value opened-payload
+    opened-value : Value V′
     opened-step :
-      ((opened-payload ↓ seal opened-pivot R′)
-        ↑ unseal opened-pivot R′) —→[ keep ] V′
+      ((N ↓ seal X R′) ↑ unseal X R′) —→[ keep ] V′
 
 
 PairedConcealRevealPeelᵀ : Set
@@ -81,12 +79,12 @@ SourceOnlyConcealRevealPeelᵀ : Set
 SourceOnlyConcealRevealPeelᵀ =
   ∀ {Δᴸ Δᴿ Δ}
     {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
-    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
-    {Xᴸ : TyVar Δᴸ} {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {V₀ : Term Δᴸ} {N′ V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
     {q : R ⊑ᵂ⟨ W ⟩ R′}
   → Value V₀
-  → Value V₀′
-  → TargetOpenedByConcealReveal V₀′ R′
+  → TargetOpenedByConcealReveal N′ Xᴿ R′ V₀′
   → W ∣ γ ⊢²
       ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
       ⊑ V₀′ ∶ q

--- a/GTSFImp/proof/DGG/notes/round10-target-chain-premise-world-mismatch.red
+++ b/GTSFImp/proof/DGG/notes/round10-target-chain-premise-world-mismatch.red
@@ -3,9 +3,7 @@ premise-world mismatch not modeled by the scratch witness.
 
 Command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 \
+agda -i GTSFImp -v0 \
   GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Current live red after removing the temporary probe clause:

--- a/GTSFImp/proof/DGG/notes/round11-target-chain-same-world-source-star.red
+++ b/GTSFImp/proof/DGG/notes/round11-target-chain-same-world-source-star.red
@@ -3,9 +3,7 @@ single-world source-star bridge.
 
 Command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 \
+agda -i GTSFImp -v0 \
   GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Live red:

--- a/GTSFImp/proof/DGG/notes/round12-target-chain-decayed-bridge.red
+++ b/GTSFImp/proof/DGG/notes/round12-target-chain-decayed-bridge.red
@@ -2,9 +2,7 @@ Round 12 stop note: TargetChainProof route A needs one more package
 
 Command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 \
+agda -i GTSFImp -v0 \
   GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Live red remains:

--- a/GTSFImp/proof/DGG/notes/round13-tagged-transfer-same-pivot.red
+++ b/GTSFImp/proof/DGG/notes/round13-tagged-transfer-same-pivot.red
@@ -3,9 +3,7 @@ head.
 
 Command used to confirm the live red before analysis:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 \
+agda -i GTSFImp -v0 \
   GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Live red remains:

--- a/GTSFImp/proof/DGG/notes/round14-target-chain-source-star-package.red
+++ b/GTSFImp/proof/DGG/notes/round14-target-chain-source-star-package.red
@@ -2,9 +2,7 @@ Round 14 stop note: target-chain package needs source-star partner extraction.
 
 Command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 \
+agda -i GTSFImp -v0 \
   GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Current live red remains:

--- a/GTSFImp/proof/DGG/notes/round15-source-star-package-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round15-source-star-package-blocked.red
@@ -2,9 +2,7 @@ Round 15 blocked case: the exact source-star package theorem is too strong.
 
 Checked command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 SourceStarPackageCounterScratch.agda
+agda -i GTSFImp -v0 SourceStarPackageCounterScratch.agda
 
 The scratch file type-checks and instantiates the proposed theorem shape from
 `round14-target-chain-source-star-package.red` with all premises inhabited, but

--- a/GTSFImp/proof/DGG/notes/round16-target-chain-package-source-seal-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round16-target-chain-package-source-seal-blocked.red
@@ -3,15 +3,11 @@ source-star package still lacks a target-pedigree bridge.
 
 Checked commands:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/SealTransferCore.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/SealTransferCore.agda
 
 This is green after backing out the exploratory helper.
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 \
+agda -i GTSFImp -v0 \
   GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Still red at TargetChainProof.agda:88, exactly as before:

--- a/GTSFImp/proof/DGG/notes/round17-premise-package-transfer-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round17-premise-package-transfer-blocked.red
@@ -3,9 +3,7 @@ needing a branch-sensitive transfer package.
 
 Checked context:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Current red:
 

--- a/GTSFImp/proof/DGG/notes/round19-target-chain-package-still-open.red
+++ b/GTSFImp/proof/DGG/notes/round19-target-chain-package-still-open.red
@@ -3,9 +3,7 @@ branch-sensitive source-star package.
 
 Focused command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Current error:
 

--- a/GTSFImp/proof/DGG/notes/round19-target-chain-top-var-tag.red
+++ b/GTSFImp/proof/DGG/notes/round19-target-chain-top-var-tag.red
@@ -2,9 +2,7 @@ Round 19 stop: TargetChainProof top target variable-tag branch.
 
 Focused command:
 
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 
 Current error:
 

--- a/GTSFImp/proof/DGG/notes/round20-source-strip-worker-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round20-source-strip-worker-blocked.red
@@ -2,7 +2,7 @@ Blocked goal: `GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda`
 
 Command:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
 
 Current check result:
 

--- a/GTSFImp/proof/DGG/notes/round21-source-strip-worker-still-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round21-source-strip-worker-still-blocked.red
@@ -2,7 +2,7 @@ Blocked goal: `GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda`
 
 Command:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
 
 Current result:
 

--- a/GTSFImp/proof/DGG/notes/round22-source-strip-worker-spine-dispatch-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round22-source-strip-worker-spine-dispatch-blocked.red
@@ -2,7 +2,7 @@ SourceStripWorkerProof attempt 2 blocked at source-spine dispatch scale.
 
 Command:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
 
 Current state:
 

--- a/GTSFImp/proof/DGG/notes/round23-source-strip-worker-over-seal-still-blocked.red
+++ b/GTSFImp/proof/DGG/notes/round23-source-strip-worker-over-seal-still-blocked.red
@@ -2,7 +2,7 @@ SourceStripWorkerProof performance split attempt 3 blocked at cast-over-seal.
 
 Command used for the target file:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
 
 Current structural state:
 

--- a/GTSFImp/proof/DGG/notes/round25-source-strip-worker-internal-survives-workarounds.red
+++ b/GTSFImp/proof/DGG/notes/round25-source-strip-worker-internal-survives-workarounds.red
@@ -3,9 +3,7 @@ requested workaround classes.
 
 Command shape used throughout:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-    agda -i GTSFImp -v0 <file>
+  agda -i GTSFImp -v0 <file>
 
 Target file:
 

--- a/GTSFImp/proof/DGG/notes/round5-target-chain-partner.red
+++ b/GTSFImp/proof/DGG/notes/round5-target-chain-partner.red
@@ -14,12 +14,12 @@ Landed and checked locally:
 Green checks:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/CastTermImprecision2.agda
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/TermImpDecay.agda
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/SealTransferCore.agda
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetWalkSupport.agda
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetDescentProof.agda
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/CastTermImprecision2.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/TermImpDecay.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/SealTransferCore.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetWalkSupport.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetDescentProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda
 ```
 
 Remaining blocker:

--- a/GTSFImp/proof/DGG/notes/round6-target-chain-partner-false.red
+++ b/GTSFImp/proof/DGG/notes/round6-target-chain-partner-false.red
@@ -20,8 +20,7 @@ This is not derivable under the current live `Rep★PartnerOK` predicate.  I
 checked a temporary scratch module, then deleted it, with:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 TargetChainPartnerCounterScratch.agda
+agda -i GTSFImp -v0 TargetChainPartnerCounterScratch.agda
 ```
 
 The scratch module checked.

--- a/GTSFImp/proof/DGG/notes/round7-target-chain-reemit-partner.red
+++ b/GTSFImp/proof/DGG/notes/round7-target-chain-reemit-partner.red
@@ -3,8 +3,7 @@ Round 7 blocked red: paired-star re-emission now needs a payload partner
 Command:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 ```
 
 Current red:

--- a/GTSFImp/proof/DGG/notes/round8-obligation-map.red
+++ b/GTSFImp/proof/DGG/notes/round8-obligation-map.red
@@ -3,8 +3,7 @@ Round 8 obligation map: seal partner re-emission ring
 Command used for the primary red:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 ```
 
 Primary red:

--- a/GTSFImp/proof/DGG/notes/round9-target-chain-matched-inner-head.red
+++ b/GTSFImp/proof/DGG/notes/round9-target-chain-matched-inner-head.red
@@ -3,9 +3,7 @@ Round 9 stopped red: TargetChainProof source-seal matched-inner head
 Command used for the live check:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-  agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+agda -i GTSFImp -v0 GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
 ```
 
 Live red after removing the temporary probe:

--- a/GTSFImp/proof/DGG/notes/srcconsist-rigid-ground-cast-helper-blocked.red
+++ b/GTSFImp/proof/DGG/notes/srcconsist-rigid-ground-cast-helper-blocked.red
@@ -2,9 +2,7 @@ Rigid source-consistency ground-cast helper blocker
 
 Command:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-    agda -i GTSFImp -v0 GTSFImp/proof/ImprecisionConsistency.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/ImprecisionConsistency.agda
 
 After restricting `consistent-common-lowerᵐ` and the self-occurrence
 preservation lemmas to `RigidFree`, the next exposed failure is:

--- a/GTSFImp/proof/DGG/notes/srcconsist-rigid-lower-bound-blocked.red
+++ b/GTSFImp/proof/DGG/notes/srcconsist-rigid-lower-bound-blocked.red
@@ -2,9 +2,7 @@ Rigid source-consistency lower-bound blocker
 
 Command:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/\
-abaf167a-fb69-4f9e-bdf7-5f069c5047b5/scratchpad/agda-home \
-    agda -i GTSFImp -v0 GTSFImp/proof/ImprecisionConsistency.agda
+  agda -i GTSFImp -v0 GTSFImp/proof/ImprecisionConsistency.agda
 
 Failure after adding the approved rigid gates:
 

--- a/GTSFImp/proof/DGG/notes/t10-probe-verdicts.red
+++ b/GTSFImp/proof/DGG/notes/t10-probe-verdicts.red
@@ -1,0 +1,97 @@
+T10 calibration probe verdicts
+==============================
+
+Status: CHECKED as of 2026-08-17.
+
+No live DGG proof or relation file was changed.  The checked scratch modules
+live under `proof/DGG/notes/probes/` and are not imported by `All.agda`.
+
+
+Probe 1: D6 parked-world preservation
+-------------------------------------
+
+Verdict: REFUTED for all four proposed claims.
+
+Checked file:
+
+`proof/DGG/notes/probes/T10Probe1ParkedWorldPreservation.agda`
+
+The counterexample uses a parked world `W` made from one paired bind followed
+by one target-only bind.  The rebased world `Wᵖ` keeps the stores and target
+embedding but moves the single source pivot onto the target-only center.  That
+center still has the dynamic mark `X⊑★`, so `Wᵖ` is not a parked world.
+
+Checked facts:
+
+- `parked-W : ParkedWorld W`
+- `forward-rebase : RebaseAt W Wᵖ X Y-fresh`
+- `reversed-rebase : RebaseAt Wᵖ W X Y-old`
+- `not-parked-Wᵖ : ParkedWorld Wᵖ -> ⊥`
+- `claim-a-refuted`
+- `claim-b-refuted`
+- `claim-c-refuted`
+- `claim-d-refuted`
+
+The reversed source-conceal direction is refuted by
+`claim-d-refuted`, using `TagRebaseAtᴸ Wᵖ W (just X) (just Y-old)`.
+
+
+Probe 2: D2b source reveal against still-sealed target
+------------------------------------------------------
+
+Verdict: INEXPRESSIBLE for the representative partnered `ℕ` seal.
+
+Checked file:
+
+`proof/DGG/notes/probes/T10Probe2SourceRevealStillSealed.agda`
+
+The partnered sealed shape exists before the source peel:
+
+`sealed-before-peel : ＇X ⊑ᵂ⟨ W ⟩ ＇Y`
+
+The source `conceal-reveal` step is checked:
+
+`source-conceal-reveal-step :
+  ((V ↓ seal X ℕ) ↑ unseal X ℕ) —→ V`
+
+But the one-sided post-source endpoint cannot be expressed:
+
+`post-source-reveal-still-sealed-empty :
+  ℕ ⊑ᵂ⟨ W ⟩ ＇Y -> ⊥`
+
+This supports the two-sided peel route for the concrete non-variable
+representation case.
+
+
+Probe 3: D7 target keep-step same-`q`
+------------------------------------
+
+Verdict: REFUTED for a target-only keep step in the paired
+conceal-reveal case.
+
+Checked file:
+
+`proof/DGG/notes/probes/T10Probe3TargetKeepSameQ.agda`
+
+The pre-step relation is inhabited at the exact endpoint witness:
+
+`q : ℕ ⊑ᵂ⟨ W ⟩ ℕ`
+
+`before-target-keep :
+  W ∣ [] ⊢² source-revealed ⊑ target-revealed ∶ q`
+
+The target takes one keep step to a value:
+
+`target-keep-step : target-revealed —→[ keep ] target-value`
+
+`target-keep-value : Value target-value`
+
+After only the target step, the same-`q` relation is underivable:
+
+`same-q-after-target-only-empty :
+  W ∣ [] ⊢² source-revealed ⊑ target-value ∶ q -> ⊥`
+
+The same `q` is recovered after peeling both sides:
+
+`after-both-peel-same-q :
+  W ∣ [] ⊢² source-value ⊑ target-value ∶ q`

--- a/GTSFImp/proof/DGG/notes/t12-two-sided-peel-restatements.red
+++ b/GTSFImp/proof/DGG/notes/t12-two-sided-peel-restatements.red
@@ -7,11 +7,11 @@ Checked statement probe:
 
 `proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda`
 
-Focused well-formedness command:
+Focused well-formedness command, with the standard-library `AGDA_DIR`
+configured:
 
 ```text
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
-  agda --safe -i GTSFImp -i GTSFImp/proof/DGG/notes/probes -v0 \
+agda --safe -i GTSFImp -i GTSFImp/proof/DGG/notes/probes -v0 \
   GTSFImp/proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda
 ```
 

--- a/GTSFImp/proof/DGG/notes/t12-two-sided-peel-restatements.red
+++ b/GTSFImp/proof/DGG/notes/t12-two-sided-peel-restatements.red
@@ -1,0 +1,455 @@
+T12 two-sided peel restatements
+===============================
+
+Status: statement draft only.  No live DGG module or relation file was edited.
+
+Checked statement probe:
+
+`proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda`
+
+Focused well-formedness command:
+
+```text
+AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
+  agda --safe -i GTSFImp -i GTSFImp/proof/DGG/notes/probes -v0 \
+  GTSFImp/proof/DGG/notes/probes/T12TwoSidedPeelRestatementProbe.agda
+```
+
+Result: pass.
+
+
+Design rule
+-----------
+
+The replacement design is evidence-forced:
+
+- wrapper peels are two-sided synchronized;
+- target keep steps are consumed only by narrow caller-supplied continuations;
+- parked evidence for premise worlds is supplied as input and never derived
+  from a rebase.
+
+
+1. Two-sided synchronized peel family
+------------------------------------
+
+### Paired conceal-reveal peel
+
+Before context:
+
+```agda
+W ∣ γ ⊢²
+  ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+  ⊑ ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) ∶ q
+
+((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) —→[ keep ] V₀′
+```
+
+After context, matching Probe 3's checked `after-both-peel-same-q` shape:
+
+```agda
+W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+Candidate statement:
+
+```agda
+PairedConcealRevealPeelᵀ : Set
+PairedConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+### Source-only variant, target already unsealed
+
+Probe 2 rules out the still-sealed target endpoint for a partnered non-variable
+representation: `R ⊑ᵂ⟨ W ⟩ ＇ Y` is not generally expressible.  The source-only
+variant is therefore sound only when the caller supplies positive evidence that
+the current target payload was already opened by a target conceal-reveal keep
+step.
+
+Before context:
+
+```agda
+TargetOpenedByConcealReveal V₀′ R′
+
+W ∣ γ ⊢²
+  ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+  ⊑ V₀′ ∶ q
+
+((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+```
+
+After context:
+
+```agda
+W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+Candidate statement:
+
+```agda
+record TargetOpenedByConcealReveal {Δᴿ : TyCtx}
+    (V′ : Term Δᴿ) (R′ : Ty Δᴿ) : Set where
+  field
+    opened-payload : Term Δᴿ
+    opened-pivot : TyVar Δᴿ
+    opened-value : Value opened-payload
+    opened-step :
+      ((opened-payload ↓ seal opened-pivot R′)
+        ↑ unseal opened-pivot R′) —→[ keep ] V′
+
+SourceOnlyConcealRevealPeelᵀ : Set
+SourceOnlyConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → TargetOpenedByConcealReveal V₀′ R′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ V₀′ ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+
+2. Supplied parked evidence for conversion frames
+------------------------------------------------
+
+### Variant A: direct supplied `ParkedWorld` input
+
+Each frame case receives both the outer world's parked evidence and the premise
+world's parked evidence.  The rebase is still present as a wrapper-typing
+ingredient, but no frame is allowed to manufacture `ParkedWorld Wᵖ` from
+`ParkedWorld W` and the rebase.
+
+```agda
+record SimConversionFramesSuppliedParkedᵀ : Set₁ where
+  field
+    source-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↑ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴸ W Wᵖ Xᴸ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → sourceStoreʷ W ⊢↑[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↑ c ⊑ M′ ∶ q
+      → M ↑ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↑ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ W Wᵖ Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → targetStoreʷ W ⊢↑[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↑ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↑ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    source-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↓ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → SourceConcealPartnerOK Wᵖ M c Xᴿ? M′
+      → ImpEnvMono W Wᵖ
+      → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → sourceStoreʷ W ⊢↓[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↓ c ⊑ M′ ∶ q
+      → M ↓ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↓ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → ParkedWorld W
+      → ParkedWorld Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ Wᵖ W Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → targetStoreʷ W ⊢↓[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↓ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↓ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+```
+
+### Variant B: boundary-stack input
+
+This variant packages the outer parked evidence, premise parked evidence, and
+the boundary certificate together.  The checked probe uses current
+`CatchupBoundary` as the local analogue of the PR #162-style
+`TargetBlameBoundary` stack.
+
+```agda
+record SuppliedBoundaryStack {Δᴸ Δᴿ Δ}
+    (kind : CatchupBoundaryKind)
+    (Xᴸ? : Maybe (TyVar Δᴸ)) (Xᴿ? : Maybe (TyVar Δᴿ))
+    (W Wᵖ : World Δᴸ Δᴿ Δ) : Set₁ where
+  field
+    boundary-outer-parked : ParkedWorld W
+    boundary-premise-parked : ParkedWorld Wᵖ
+    boundary-certificate : CatchupBoundary kind Xᴸ? Xᴿ? W Wᵖ
+```
+
+Full candidate statement:
+
+```agda
+record SimConversionFramesBoundaryStackᵀ : Set₁ where
+  field
+    source-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↑ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack source-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴸ W Wᵖ Xᴸ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → sourceStoreʷ W ⊢↑[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↑ c ⊑ M′ ∶ q
+      → M ↑ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-reveal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↑ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack target-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ W Wᵖ Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → targetStoreʷ W ⊢↑[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↑ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↑ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    source-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A′ ⊑ᵂ⟨ W ⟩ B}
+        {c : Conv↓ Δᴸ A A′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack source-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → SourceConcealPartnerOK Wᵖ M c Xᴿ? M′
+      → ImpEnvMono W Wᵖ
+      → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → sourceStoreʷ W ⊢↓[ Xᴸ? ] c
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ↓ c ⊑ M′ ∶ q
+      → M ↓ c —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A′ ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B ]
+          (M′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+
+    target-conceal-frame :
+      ∀ {Δᴸ Δᴿ Δ Δᴸ′} {W Wᵖ : World Δᴸ Δᴿ Δ}
+        {γᵖ : CtxImp Wᵖ}
+        {M : Term Δᴸ} {M′ : Term Δᴿ} {N : Term Δᴸ′}
+        {A : Ty Δᴸ} {B B′ : Ty Δᴿ} {Xᴸ? Xᴿ?}
+        {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+        {q : A ⊑ᵂ⟨ W ⟩ B′}
+        {c′ : Conv↓ Δᴿ B B′}
+        {χᴸ : StoreChange Δᴸ Δᴸ′}
+      → SuppliedBoundaryStack target-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
+      → ImpEnvMono W Wᵖ
+      → RebaseAtᴿ Wᵖ W Xᴿ?
+      → SameCtx {W = W} {W′ = Wᵖ} [] γᵖ
+      → targetStoreʷ W ⊢↓[ Xᴿ? ] c′
+      → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+      → W ∣ [] ⊢² M ⊑ M′ ↓ c′ ∶ q
+      → M —→[ χᴸ ] N
+      → Σ[ Δᴿ′ ∈ TyCtx ]
+        Σ[ χsᴿ ∈ StoreChanges Δᴿ Δᴿ′ ]
+        Σ[ N′ ∈ Term Δᴿ′ ] Σ[ Δ′ ∈ TyCtx ]
+        Σ[ W′ ∈ World Δᴸ′ Δᴿ′ Δ′ ]
+        Σ[ r ∈ applyTy χᴸ A ⊑ᵂ⟨ W′ ⟩ applyTys χsᴿ B′ ]
+          (M′ ↓ c′ —↠[ χsᴿ ] N′) ×
+          ParkedEvolve (χᴸ ∷ˢ []ˢ) χsᴿ W W′ ×
+          (W′ ∣ [] ⊢² N ⊑ N′ ∶ r)
+```
+
+Comparison: the direct `ParkedWorld` variant is the smallest repair to the
+current `SimConversionFramesᵀ` surface and makes the D6 fallback explicit.  The
+boundary-stack variant is better if downstream catchup/blame code needs to
+remember why the premise world exists; it centralizes parked evidence and the
+boundary shape in one input, at the cost of an extra certificate value that
+one-step frame replay may not otherwise inspect.
+
+
+3. Restated T1 dispatcher keep-outcome surfaces
+------------------------------------------------
+
+Old surface being replaced:
+
+```agda
+target-reveal/conceal-keep-rel :
+  ∀ {M N N₁}
+  → W ∣ γ ⊢² M ⊑ N ↑/↓ c ∶ qC
+  → (N ↑/↓ c) —→[ keep ] N₁
+  → Value N₁
+  → W ∣ γ ⊢² M ⊑ N₁ ∶ qC
+```
+
+Replacement surface: the dispatcher receives narrow continuation records.  A
+target reveal `conceal-reveal` keep step is discharged only by the paired peel
+or by the source-only peel with `TargetOpenedByConcealReveal` evidence.  Target
+conceal `id-conceal` keep steps get the analogous two-sided/source-opened
+continuations.
+
+```agda
+record TargetRevealKeepOutcomeContinuationsᵀ : Set₁ where
+  field
+    paired-conceal-reveal :
+      PairedConcealRevealPeelᵀ
+    source-opened-conceal-reveal :
+      SourceOnlyConcealRevealPeelᵀ
+
+
+record TargetConcealKeepOutcomeContinuationsᵀ : Set₁ where
+  field
+    paired-id-conceal :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+        {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B : Ty Δᴿ}
+        {q : A ⊑ᵂ⟨ W ⟩ B}
+      → Value V₀
+      → Value V₀′
+      → W ∣ γ ⊢²
+          (V₀ ↓ id↓ A)
+          ⊑ (V₀′ ↓ id↓ B) ∶ q
+      → (V₀ ↓ id↓ A) —→[ keep ] V₀
+      → (V₀′ ↓ id↓ B) —→[ keep ] V₀′
+      → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+    source-opened-id-conceal :
+      ∀ {Δᴸ Δᴿ Δ}
+        {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+        {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+        {A : Ty Δᴸ} {B : Ty Δᴿ}
+        {q : A ⊑ᵂ⟨ W ⟩ B}
+      → Value V₀
+      → Value V₀′
+      → W ∣ γ ⊢² (V₀ ↓ id↓ A) ⊑ V₀′ ∶ q
+      → (V₀ ↓ id↓ A) —→[ keep ] V₀
+      → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+
+record RestatedDispatcherKeepOutcomesᵀ : Set₁ where
+  field
+    target-reveal-outcomes : TargetRevealKeepOutcomeContinuationsᵀ
+    target-conceal-outcomes : TargetConcealKeepOutcomeContinuationsᵀ
+```

--- a/GTSFImp/proof/DGG/notes/t5-partner-lift-draft.red
+++ b/GTSFImp/proof/DGG/notes/t5-partner-lift-draft.red
@@ -11,7 +11,7 @@ Probe:
 
 Checked standalone with:
 
-`AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home agda --safe -i . -i proof/DGG/notes/probes proof/DGG/notes/probes/PartnerLiftDraft.agda`
+`agda --safe -i . -i proof/DGG/notes/probes proof/DGG/notes/probes/PartnerLiftDraft.agda`
 
 
 Candidate A verdict

--- a/GTSFImp/proof/DGG/notes/t7-target-blame-catchup-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t7-target-blame-catchup-proposal.red
@@ -2,8 +2,7 @@ T7 TargetBlameCatchup proposal
 
 Current checked partial state:
 
-  AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
-    agda proof/DGG/TargetBlameCatchupProof.agda
+  agda proof/DGG/TargetBlameCatchupProof.agda
 
 checks.  The partial module exports:
 


### PR DESCRIPTION
Three machine-checked calibration probes (proof/DGG/notes/probes/, standalone --safe, no postulates/holes/pragmas; verdicts in notes/t10-probe-verdicts.red), supervisor-verified:

1. ParkedWorld preservation under RebaseAtᴸ/ᴿ and TagRebaseAtᴸ (both directions): ALL FOUR components REFUTED — the counterexample world's rebase flips a head imprecision entry X⊑X → X⊑★, which parkedness pins. Settles D6 and vindicates D9's boundary-stack formulation.
2. Unsealed source vs still-sealed target: INEXPRESSIBLE (ℕ ⊑ᵂ ＇Y checked empty after source-only reveal, while ＇X ⊑ᵂ ＇Y is inhabited before). Kills D2b candidate (i); the peel must be two-sided.
3. Target-only keep-step same-q: REFUTED (relation at q inhabited before, checked empty after target-only step; same q recovered after peeling BOTH sides). D7's statements as proposed are wrong — the wrapper-peel family must be two-sided and synchronized.

Carries the main-heal cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)