### PR TITLE
T11: meet-point statements — Fin.zero refuted, parked-family extension proposed (D13)

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -68,6 +68,7 @@ import proof.DGG.Catchup.StructuralSpineTypingDef
 import proof.DGG.Catchup.StructuralStrictViewSurfaceDef
 import proof.DGG.Catchup.StructuralWorldExtendDef
 import proof.DGG.Catchup.StructuralWorldExtendProof
+import proof.DGG.Catchup.StructuralRightParkedEvolveProof
 import proof.DGG.Catchup.StructuralWorldRebaseProof
 import proof.DGG.Catchup.StructuralWorldTagRebaseDef
 import proof.DGG.Catchup.StructuralWorldTagRebaseProof

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -69,6 +69,7 @@ import proof.DGG.Catchup.StructuralStrictViewSurfaceDef
 import proof.DGG.Catchup.StructuralWorldExtendDef
 import proof.DGG.Catchup.StructuralWorldExtendProof
 import proof.DGG.Catchup.StructuralRightParkedEvolveProof
+import proof.DGG.Catchup.BoundaryValueAdaptersProof
 import proof.DGG.Catchup.StructuralWorldRebaseProof
 import proof.DGG.Catchup.StructuralWorldTagRebaseDef
 import proof.DGG.Catchup.StructuralWorldTagRebaseProof

--- a/GTSFImp/proof/DGG/Catchup/BoundaryValueAdaptersProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/BoundaryValueAdaptersProof.agda
@@ -1,0 +1,355 @@
+module proof.DGG.Catchup.BoundaryValueAdaptersProof where
+
+-- File Charter:
+--   * Adapts structural right catch-up results to every public boundary kind.
+--   * Pulls structural target extensions back through forward tag rebases.
+--   * Embeds the resulting enclosing trace into parked evolution.
+
+open import Data.List using ([])
+open import Data.Maybe using (Maybe; nothing)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using
+  (_≡_; refl; sym; trans; cong)
+
+open import Types using (Ty; TyCtx; TyVar)
+open import CastTerms using (Term)
+open import Consistency using (wk↪ᵗ)
+open import Reduction using
+  (StoreChanges; _∷_; keep; bind; applyStore)
+import Reduction as R
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CastTermImprecision2Typing as CTI2T
+import proof.DGG.ExtraCastRight2 as ECR
+import proof.DGG.TargetExtend as TE
+open import proof.DGG.Parked.ParkedWorldDef using (ParkedWorld)
+open import proof.DGG.CatchupToMorePreciseDef
+open import proof.DGG.Catchup.StructuralWorldExtendDef
+open import proof.DGG.Catchup.StructuralWorldExtendProof using
+  (structural-world-extendᴿ)
+open import proof.DGG.Catchup.StructuralWorldTagRebaseDef
+open import proof.DGG.Catchup.StructuralWorldTagRebaseProof using
+  (structural-tag-rebase-atᴸ-pullback)
+open import proof.DGG.Catchup.StructuralRightParkedEvolveProof using
+  (StructuralRightParkedEvolveᵀ)
+open import proof.DGG.Catchup.StructuralCatchupRightDef using
+  (StructuralCatchupRightResult)
+
+
+record StructuralForwardTagRebaseAtᴸPullbackResult
+    {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {Wᵖ′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    (planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′)
+    {W : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+    (rb : CTI2.TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?) : Set₁ where
+  field
+    W′ : CTI2.World Δᴸ Δᴿ′ Δ′
+    outer-plan : StructuralWorldExtendᴿ χs W W′
+    post-rebase : CTI2.TagRebaseAtᴸ W′ Wᵖ′ Xᴸ?
+      (mapPivotChanges χs Xᴿ?)
+    post-mono : CTI2.ImpEnvMono W Wᵖ → CTI2.ImpEnvMono W′ Wᵖ′
+
+
+structural-forward-tag-rebase-atᴸ-pullback :
+    ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+      {χs : StoreChanges Δᴿ Δᴿ′}
+      {Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+      {Wᵖ′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+      {W : CTI2.World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+  → (planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′)
+  → (rb : CTI2.TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?)
+  → StructuralForwardTagRebaseAtᴸPullbackResult planᵖ rb
+structural-forward-tag-rebase-atᴸ-pullback structural-[] rb = record
+  { W′ = _
+  ; outer-plan = structural-[]
+  ; post-rebase = rb
+  ; post-mono = λ mono → mono
+  }
+structural-forward-tag-rebase-atᴸ-pullback (structural-keep planᵖ) rb
+    with structural-forward-tag-rebase-atᴸ-pullback planᵖ rb
+structural-forward-tag-rebase-atᴸ-pullback (structural-keep planᵖ) rb
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { W′ = W′
+    ; outer-plan = structural-keep plan
+    ; post-rebase = rb′
+    ; post-mono = mono′
+    }
+structural-forward-tag-rebase-atᴸ-pullback
+    (structural-bind {B = B} insᵖ followsᵖ planᵖ)
+    CTI2.tag-rebase-idᴸ
+    with structural-forward-tag-rebase-atᴸ-pullback
+      planᵖ CTI2.tag-rebase-idᴸ
+structural-forward-tag-rebase-atᴸ-pullback
+    (structural-bind {B = B} insᵖ followsᵖ planᵖ)
+    CTI2.tag-rebase-idᴸ
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { W′ = W′
+    ; outer-plan = structural-bind insᵖ followsᵖ plan
+    ; post-rebase = rb′
+    ; post-mono = λ mono → mono′ (TE.impEnvMono-insert insᵖ insᵖ mono)
+    }
+structural-forward-tag-rebase-atᴸ-pullback
+    (structural-bind {B = B} insᵖ followsᵖ planᵖ)
+    (CTI2.tag-rebase-varᴸ rb)
+    with structural-forward-tag-rebase-atᴸ-pullback planᵖ
+      (CTI2.tag-rebase-varᴸ (TE.pullbackRebaseAt insᵖ rb))
+structural-forward-tag-rebase-atᴸ-pullback
+    (structural-bind {B = B} insᵖ followsᵖ planᵖ)
+    (CTI2.tag-rebase-varᴸ rb)
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { W′ = W′
+    ; outer-plan = structural-bind ins follows plan
+    ; post-rebase = rb′
+    ; post-mono = λ mono → mono′ (TE.impEnvMono-insert ins insᵖ mono)
+    }
+  where
+  ins = TE.pullbackRebaseTargetInsert insᵖ rb
+
+  follows =
+    trans followsᵖ
+      (cong (applyStore (bind B)) (CTI2T.rebase-target-store rb))
+structural-forward-tag-rebase-atᴸ-pullback
+    (structural-bind {B = B} insᵖ followsᵖ planᵖ)
+    (CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
+    with structural-forward-tag-rebase-atᴸ-pullback planᵖ
+      (CTI2.tag-rebase-onlyᴸ
+        (TE.insert-to-starᴸ insᵖ to-star)
+        (TE.insert-disalignedᴸ insᵖ disaligned)
+        (TE.insert-represented★ᴸ insᵖ represented))
+structural-forward-tag-rebase-atᴸ-pullback
+    (structural-bind {B = B} insᵖ followsᵖ planᵖ)
+    (CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { W′ = W′
+    ; outer-plan = structural-bind insᵖ followsᵖ plan
+    ; post-rebase = rb′
+    ; post-mono = λ mono → mono′ (TE.impEnvMono-insert insᵖ insᵖ mono)
+    }
+
+
+mapPivotChanges-nothing : ∀ {Δ Δ′}
+  → (χs : StoreChanges Δ Δ′)
+  → mapPivotChanges χs nothing ≡ nothing
+mapPivotChanges-nothing R.[] = refl
+mapPivotChanges-nothing (keep ∷ χs) = mapPivotChanges-nothing χs
+mapPivotChanges-nothing (bind B ∷ χs) = mapPivotChanges-nothing χs
+
+
+same-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A CTI2.⊑ᵂ⟨ W ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → StructuralCatchupRightResult W [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = W} {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {V = V} {M′ = M′} {A = A} {B = B}
+same-boundary-value-adapter embed parked child =
+  StructuralCatchupRightResult.Δᴿ′ child ,
+  χs ,
+  StructuralCatchupRightResult.N′ child ,
+  StructuralCatchupRightResult.Δ′ child ,
+  StructuralCatchupRightResult.W′ child ,
+  StructuralCatchupRightResult.W′ child ,
+  nothing ,
+  boundary-refl ,
+  q′ ,
+  sym (mapPivotChanges-nothing χs) ,
+  StructuralCatchupRightResult.post-reduction child ,
+  StructuralCatchupRightResult.final-value child ,
+  embed parked plan ,
+  plan ,
+  plan ,
+  StructuralCatchupRightResult.final-relation child
+  where
+  χs = StructuralCatchupRightResult.χs child
+  plan = StructuralCatchupRightResult.structural-ext child
+  q′ = ECR.transport⊑ᵂ (structural-world-extendᴿ plan) _
+
+
+source-reveal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A CTI2.⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = source-reveal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+source-reveal-boundary-value-adapter embed parked mono rb child
+    with structural-forward-tag-rebase-atᴸ-pullback planᵖ rb
+  where
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+source-reveal-boundary-value-adapter embed parked mono rb child
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  StructuralCatchupRightResult.Δᴿ′ child ,
+  χs ,
+  StructuralCatchupRightResult.N′ child ,
+  StructuralCatchupRightResult.Δ′ child ,
+  W′ ,
+  StructuralCatchupRightResult.W′ child ,
+  mapPivotChanges χs _ ,
+  boundary-source-reveal (mono′ mono) rb′ ,
+  q′ ,
+  refl ,
+  StructuralCatchupRightResult.post-reduction child ,
+  StructuralCatchupRightResult.final-value child ,
+  embed parked plan ,
+  plan ,
+  planᵖ ,
+  StructuralCatchupRightResult.final-relation child
+  where
+  χs = StructuralCatchupRightResult.χs child
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+  q′ = ECR.transport⊑ᵂ (structural-world-extendᴿ planᵖ) _
+
+
+target-reveal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A CTI2.⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = target-reveal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+target-reveal-boundary-value-adapter embed parked mono rb child
+    with structural-forward-tag-rebase-atᴸ-pullback planᵖ rb
+  where
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+target-reveal-boundary-value-adapter embed parked mono rb child
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  StructuralCatchupRightResult.Δᴿ′ child ,
+  χs ,
+  StructuralCatchupRightResult.N′ child ,
+  StructuralCatchupRightResult.Δ′ child ,
+  W′ ,
+  StructuralCatchupRightResult.W′ child ,
+  mapPivotChanges χs _ ,
+  boundary-target-reveal (mono′ mono) rb′ ,
+  q′ ,
+  refl ,
+  StructuralCatchupRightResult.post-reduction child ,
+  StructuralCatchupRightResult.final-value child ,
+  embed parked plan ,
+  plan ,
+  planᵖ ,
+  StructuralCatchupRightResult.final-relation child
+  where
+  χs = StructuralCatchupRightResult.χs child
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+  q′ = ECR.transport⊑ᵂ (structural-world-extendᴿ planᵖ) _
+
+
+source-conceal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A CTI2.⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = source-conceal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+source-conceal-boundary-value-adapter embed parked mono rb child
+    with structural-tag-rebase-atᴸ-pullback planᵖ rb
+  where
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+source-conceal-boundary-value-adapter embed parked mono rb child
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  StructuralCatchupRightResult.Δᴿ′ child ,
+  χs ,
+  StructuralCatchupRightResult.N′ child ,
+  StructuralCatchupRightResult.Δ′ child ,
+  W′ ,
+  StructuralCatchupRightResult.W′ child ,
+  mapPivotChanges χs _ ,
+  boundary-source-conceal (mono′ mono) rb′ ,
+  q′ ,
+  refl ,
+  StructuralCatchupRightResult.post-reduction child ,
+  StructuralCatchupRightResult.final-value child ,
+  embed parked plan ,
+  plan ,
+  planᵖ ,
+  StructuralCatchupRightResult.final-relation child
+  where
+  χs = StructuralCatchupRightResult.χs child
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+  q′ = ECR.transport⊑ᵂ (structural-world-extendᴿ planᵖ) _
+
+
+target-conceal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A CTI2.⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = target-conceal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+target-conceal-boundary-value-adapter embed parked mono rb child
+    with structural-tag-rebase-atᴸ-pullback planᵖ rb
+  where
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+target-conceal-boundary-value-adapter embed parked mono rb child
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  StructuralCatchupRightResult.Δᴿ′ child ,
+  χs ,
+  StructuralCatchupRightResult.N′ child ,
+  StructuralCatchupRightResult.Δ′ child ,
+  W′ ,
+  StructuralCatchupRightResult.W′ child ,
+  mapPivotChanges χs _ ,
+  boundary-target-conceal (mono′ mono) rb′ ,
+  q′ ,
+  refl ,
+  StructuralCatchupRightResult.post-reduction child ,
+  StructuralCatchupRightResult.final-value child ,
+  embed parked plan ,
+  plan ,
+  planᵖ ,
+  StructuralCatchupRightResult.final-relation child
+  where
+  χs = StructuralCatchupRightResult.χs child
+  planᵖ = StructuralCatchupRightResult.structural-ext child
+  q′ = ECR.transport⊑ᵂ (structural-world-extendᴿ planᵖ) _

--- a/GTSFImp/proof/DGG/Catchup/FuelDischargeProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/FuelDischargeProof.agda
@@ -7,11 +7,14 @@ module proof.DGG.Catchup.FuelDischargeProof where
 --     the live CTI2 derivation.
 --   * Composes the builder with a fuel-indexed value-catch-up driver, and
 --     exports the FuelKnot factory-parametric `ValueCatchupRight²` adapter.
+--   * Assembles the structural knot, parked embedding, and boundary adapters
+--     into `CatchupToMorePrecise`, retaining only the structural factories.
 
 open import Data.Nat using (ℕ; suc; _<_; _≤_; _⊔_; z≤n; s≤s)
 open import Data.Nat.Properties using (≤-trans; m≤m⊔n; m≤n⊔m)
 open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Data.Unit using (tt)
+import Data.Nat.Induction as NatInduction
 
 open import Types using (Ty)
 open import CastTerms using (Term; Value)
@@ -22,7 +25,23 @@ open import proof.DGG.Catchup.ValueCatchupRightDef using
    FuelKnot)
 open import proof.DGG.Catchup.FuelKnotProof using
   (ExtraCastFactory; ValueCatchupFactory; InstCatchupFactory;
-   build-fuel-knot)
+   build-fuel-knot; StructuralFuelKnot; StructuralExtraCastFactory;
+   StructuralValueCatchupFactory; StructuralInstCatchupFactory;
+   build-structural-fuel-knot-acc)
+open import proof.DGG.Catchup.StructuralCatchupRightDef using
+  (StructuralValueCatchupRight²; StructuralValueCatchupRightAt)
+open import proof.DGG.Catchup.StructuralRightParkedEvolveProof using
+  (structural-right-parked-evolve)
+open import proof.DGG.Catchup.BoundaryValueAdaptersProof using
+  (same-boundary-value-adapter;
+   source-reveal-boundary-value-adapter;
+   source-conceal-boundary-value-adapter;
+   target-reveal-boundary-value-adapter;
+   target-conceal-boundary-value-adapter)
+open import proof.DGG.CatchupToMorePreciseDef using
+  (CatchupToMorePrecise; boundary-refl; boundary-source-reveal;
+   boundary-source-conceal; boundary-target-reveal;
+   boundary-target-conceal)
 
 
 ≤-step : ∀ {m n} → m ≤ n → m ≤ suc n
@@ -206,3 +225,72 @@ value-catchup-right²-from-fuel-knot-factories
   value-catchup-right²-from-at
     (λ fuel → FuelKnot.value-catchup-at
       (build-fuel-knot extra-factory value-factory inst-factory fuel))
+
+
+structural-value-catchup-right²-from-at :
+    (∀ fuel → StructuralValueCatchupRightAt fuel)
+  → StructuralValueCatchupRight²
+structural-value-catchup-right²-from-at value-at vM rel
+  with ⊢²-target-cast-bound rel
+structural-value-catchup-right²-from-at value-at vM rel
+  | fuel , bound = value-at fuel vM rel bound
+
+
+structural-value-catchup-right²-from-fuel-knot-factories :
+  StructuralExtraCastFactory
+  → StructuralValueCatchupFactory
+  → StructuralInstCatchupFactory
+  → StructuralValueCatchupRight²
+structural-value-catchup-right²-from-fuel-knot-factories
+    extra-factory value-factory inst-factory =
+  structural-value-catchup-right²-from-at
+    (λ fuel → StructuralFuelKnot.structural-value-catchup-at
+      (build-structural-fuel-knot-acc
+        extra-factory value-factory inst-factory fuel
+        (NatInduction.<-wellFounded fuel)))
+
+
+catchup-to-more-precise-from-fuel-knot-factories :
+  StructuralExtraCastFactory
+  → StructuralValueCatchupFactory
+  → StructuralInstCatchupFactory
+  → CatchupToMorePrecise
+catchup-to-more-precise-from-fuel-knot-factories
+    extra-factory value-factory inst-factory parked boundary-refl rel vM =
+  same-boundary-value-adapter structural-right-parked-evolve parked
+    (worker vM rel)
+  where
+  worker = structural-value-catchup-right²-from-fuel-knot-factories
+    extra-factory value-factory inst-factory
+catchup-to-more-precise-from-fuel-knot-factories
+    extra-factory value-factory inst-factory parked
+    (boundary-source-reveal mono rb) rel vM =
+  source-reveal-boundary-value-adapter structural-right-parked-evolve parked
+    mono rb (worker vM rel)
+  where
+  worker = structural-value-catchup-right²-from-fuel-knot-factories
+    extra-factory value-factory inst-factory
+catchup-to-more-precise-from-fuel-knot-factories
+    extra-factory value-factory inst-factory parked
+    (boundary-source-conceal mono rb) rel vM =
+  source-conceal-boundary-value-adapter structural-right-parked-evolve parked
+    mono rb (worker vM rel)
+  where
+  worker = structural-value-catchup-right²-from-fuel-knot-factories
+    extra-factory value-factory inst-factory
+catchup-to-more-precise-from-fuel-knot-factories
+    extra-factory value-factory inst-factory parked
+    (boundary-target-reveal mono rb) rel vM =
+  target-reveal-boundary-value-adapter structural-right-parked-evolve parked
+    mono rb (worker vM rel)
+  where
+  worker = structural-value-catchup-right²-from-fuel-knot-factories
+    extra-factory value-factory inst-factory
+catchup-to-more-precise-from-fuel-knot-factories
+    extra-factory value-factory inst-factory parked
+    (boundary-target-conceal mono rb) rel vM =
+  target-conceal-boundary-value-adapter structural-right-parked-evolve parked
+    mono rb (worker vM rel)
+  where
+  worker = structural-value-catchup-right²-from-fuel-knot-factories
+    extra-factory value-factory inst-factory

--- a/GTSFImp/proof/DGG/Catchup/StructuralRightParkedEvolveProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralRightParkedEvolveProof.agda
@@ -1,0 +1,45 @@
+module proof.DGG.Catchup.StructuralRightParkedEvolveProof where
+
+-- File Charter:
+--   * Embeds structural right-world extension traces into parked evolution.
+--   * Uses the retained target insertion and singleton target-store equation
+--     at every structural bind.
+
+open import Reduction using (StoreChanges; []; _∷_; keep)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.DGG.Parked.ParkedWorldDef using
+  ( ParkedEvolve
+  ; ParkedWorld
+  ; evolve-keepᴿ
+  ; evolve-refl
+  ; evolve-structural-right-bind
+  ; parked-structural-right-insert
+  )
+open import proof.DGG.Catchup.StructuralWorldExtendDef using
+  ( StructuralWorldExtendᴿ
+  ; structural-[]
+  ; structural-bind
+  ; structural-keep
+  )
+
+
+StructuralRightParkedEvolveᵀ : Set₁
+StructuralRightParkedEvolveᵀ =
+  ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+  → ParkedWorld W
+  → StructuralWorldExtendᴿ χsᴿ W W′
+  → ParkedEvolve [] χsᴿ W W′
+
+
+structural-right-parked-evolve : StructuralRightParkedEvolveᵀ
+structural-right-parked-evolve parked structural-[] = evolve-refl
+structural-right-parked-evolve parked (structural-keep plan) =
+  evolve-keepᴿ (structural-right-parked-evolve parked plan)
+structural-right-parked-evolve parked
+    (structural-bind ins follows plan) =
+  evolve-structural-right-bind ins follows
+    (structural-right-parked-evolve
+      (parked-structural-right-insert parked ins follows) plan)

--- a/GTSFImp/proof/DGG/Parked/ParkedBindImprecisionProof.agda
+++ b/GTSFImp/proof/DGG/Parked/ParkedBindImprecisionProof.agda
@@ -1,0 +1,90 @@
+module proof.DGG.Parked.ParkedBindImprecisionProof where
+
+-- File Charter:
+--   * Proves type-imprecision transport across the three canonical parked
+--     bind worlds.
+--   * Sits below both parked evolution and structural target insertion so
+--     those modules can share the bind facts without an import cycle.
+
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym; trans)
+  renaming (subst to subst≡)
+
+open import Types using
+  (Ty; _⇒_; `∀; ★; ⇑ᵗ; renameᵗ; renameᵗ-comp; renameᵗ-cong; renameᵗ-shift)
+open import Consistency using (_↪ᵗ_; toRenameᵗ; keep; skip)
+open import Imprecision using (X⊑X; X⊑★; _⊢_⊑_)
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.ImprecisionConsistency using
+  (fin-suc-injective; rename-⊑)
+open import proof.TypeInTermSubst using (toRename-keep-eq)
+
+open CTI2 using
+  (World; embedᴸ; embedᴿ; impEnvʷ; _⊑ᵂ⟨_⟩_)
+
+
+renameᵗ-skip-eq : ∀ {Δᴿ Δ} (η : Δᴿ ↪ᵗ Δ) (B : Ty Δᴿ)
+  → renameᵗ (toRenameᵗ (skip η)) B
+      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) B)
+renameᵗ-skip-eq η B =
+  trans (renameᵗ-cong B (λ X → refl))
+    (sym (renameᵗ-comp (toRenameᵗ η) Fin.suc B))
+
+
+embed-keep-shift : ∀ {Δ₀ Δ} (η : Δ₀ ↪ᵗ Δ) (A : Ty Δ₀)
+  → renameᵗ (toRenameᵗ (keep η)) (⇑ᵗ A)
+      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) A)
+embed-keep-shift η A =
+  trans (renameᵗ-cong (⇑ᵗ A) (toRename-keep-eq η))
+    (renameᵗ-shift (toRenameᵗ η) A)
+
+
+both-bind-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {C : Ty Δᴸ} {D : Ty Δᴿ}
+  → C ⊑ᵂ⟨ W ⟩ D
+  → ⇑ᵗ C ⊑ᵂ⟨ CTI2.bothBindWorld X⊑X W A B ⟩ ⇑ᵗ D
+both-bind-⊑ᵂ {W = W} {A = A} {B = B} {C = C} {D = D} p =
+  subst≡
+    (λ L → impEnvʷ (CTI2.bothBindWorld X⊑X W A B) ⊢ L ⊑
+      embedᴿ (CTI2.bothBindWorld X⊑X W A B) (⇑ᵗ D))
+    (sym (embed-keep-shift (CTI2.ηᴸʷ W) C))
+    (subst≡
+      (λ R → impEnvʷ (CTI2.bothBindWorld X⊑X W A B) ⊢
+        ⇑ᵗ (embedᴸ W C) ⊑ R)
+      (sym (embed-keep-shift (CTI2.ηᴿʷ W) D))
+      (rename-⊑ Fin.suc fin-suc-injective (λ X eq → eq) p))
+
+
+right-bind-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {B′ : Ty Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → A ⊑ᵂ⟨ W ⟩ B
+  → A ⊑ᵂ⟨ CTI2.rightOnlyWorld W B′ ⟩ ⇑ᵗ B
+right-bind-⊑ᵂ {W = W} {B′ = B′} {A = A} {B = B} p =
+  subst≡
+    (λ L → impEnvʷ (CTI2.rightOnlyWorld W B′) ⊢ L ⊑
+      embedᴿ (CTI2.rightOnlyWorld W B′) (⇑ᵗ B))
+    (sym (renameᵗ-skip-eq (CTI2.ηᴸʷ W) A))
+    (subst≡
+      (λ R → impEnvʷ (CTI2.rightOnlyWorld W B′) ⊢
+        ⇑ᵗ (embedᴸ W A) ⊑ R)
+      (sym (embed-keep-shift (CTI2.ηᴿʷ W) B))
+      (rename-⊑ Fin.suc fin-suc-injective (λ X eq → eq) p))
+
+
+left-bind-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {A′ : Ty Δᴸ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → A ⊑ᵂ⟨ W ⟩ B
+  → ⇑ᵗ A ⊑ᵂ⟨ CTI2.leftOnlyWorld X⊑★ W A′ ⟩ B
+left-bind-⊑ᵂ {W = W} {A′ = A′} {A = A} {B = B} p =
+  subst≡
+    (λ L → impEnvʷ (CTI2.leftOnlyWorld X⊑★ W A′) ⊢ L ⊑
+      embedᴿ (CTI2.leftOnlyWorld X⊑★ W A′) B)
+    (sym (embed-keep-shift (CTI2.ηᴸʷ W) A))
+    (subst≡
+      (λ R → impEnvʷ (CTI2.leftOnlyWorld X⊑★ W A′) ⊢
+        ⇑ᵗ (embedᴸ W A) ⊑ R)
+      (sym (renameᵗ-skip-eq (CTI2.ηᴿʷ W) B))
+      (rename-⊑ Fin.suc fin-suc-injective (λ X eq → eq) p))

--- a/GTSFImp/proof/DGG/Parked/ParkedEvolveCompositionProof.agda
+++ b/GTSFImp/proof/DGG/Parked/ParkedEvolveCompositionProof.agda
@@ -12,6 +12,7 @@ open import proof.DGG.Parked.ParkedWorldDef using
   ; evolve-left-bind
   ; evolve-refl
   ; evolve-right-bind
+  ; evolve-structural-right-bind
   )
 open import proof.DGG.Parked.ParkedEvolveCompositionDef
   using (ComposeParkedEvolveᵀ)
@@ -29,3 +30,7 @@ compose-parked-evolve (evolve-left-bind evol₁) evol₂ =
   evolve-left-bind (compose-parked-evolve evol₁ evol₂)
 compose-parked-evolve (evolve-right-bind evol₁) evol₂ =
   evolve-right-bind (compose-parked-evolve evol₁ evol₂)
+compose-parked-evolve
+    (evolve-structural-right-bind ins follows evol₁) evol₂ =
+  evolve-structural-right-bind ins follows
+    (compose-parked-evolve evol₁ evol₂)

--- a/GTSFImp/proof/DGG/Parked/ParkedWorldDef.agda
+++ b/GTSFImp/proof/DGG/Parked/ParkedWorldDef.agda
@@ -17,13 +17,15 @@ open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
 
 open import Types using (Ty; TyCtx; TyVar)
 open import TyStore using (TyStore)
-open import Consistency using (toRenameᵗ)
+open import Consistency using (_↪ᵗ_; toRenameᵗ; wk↪ᵗ)
 open import Imprecision using (ImpEnv; X⊑X; X⊑★)
-open import Reduction using (StoreChanges; []; _∷_; keep; bind)
+open import Reduction using
+  (StoreChanges; []; _∷_; keep; bind; applyStore)
 import Reduction as R
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CompilePreservesImprecision2 as CPI2
 import proof.DGG.ExtraCastRight2 as ECR
+import proof.DGG.TargetExtend as TE
 
 open CTI2 using (World; CtxImp; _⊑ᵂ⟨_⟩_)
 
@@ -63,6 +65,16 @@ data ParkedWorld : ∀ {Δᴸ Δᴿ Δ}
     → ParkedWorld W
       -----------------------------------------------
     → ParkedWorld (CTI2.rightOnlyWorld W B)
+
+  parked-structural-right-insert : ∀ {Δᴸ Δᴿ Δ Δ₁}
+      {W : World Δᴸ Δᴿ Δ}
+      {W₁ : World Δᴸ (Nat.suc Δᴿ) Δ₁}
+      {B : Ty Δᴿ} {π : Δ ↪ᵗ Δ₁}
+    → ParkedWorld W
+    → TE.TargetInsert wk↪ᵗ π W W₁
+    → CTI2.targetStoreʷ W₁ ≡
+        applyStore (bind B) (CTI2.targetStoreʷ W)
+    → ParkedWorld W₁
 
 
 data ParkedEvolve : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
@@ -123,6 +135,19 @@ data ParkedEvolve : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
       ---------------------------------------------
     → ParkedEvolve χsᴸ (bind B ∷ χsᴿ) W W′
 
+  evolve-structural-right-bind : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ₁ Δ′}
+      {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+      {χsᴿ : StoreChanges (Nat.suc Δᴿ) Δᴿ′}
+      {W : World Δᴸ Δᴿ Δ}
+      {W₁ : World Δᴸ (Nat.suc Δᴿ) Δ₁}
+      {W′ : World Δᴸ′ Δᴿ′ Δ′}
+      {B : Ty Δᴿ} {π : Δ ↪ᵗ Δ₁}
+    → TE.TargetInsert wk↪ᵗ π W W₁
+    → CTI2.targetStoreʷ W₁ ≡
+        applyStore (bind B) (CTI2.targetStoreʷ W)
+    → ParkedEvolve χsᴸ χsᴿ W₁ W′
+    → ParkedEvolve χsᴸ (bind B ∷ χsᴿ) W W′
+
 
 centerVarᴾ : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
     {χsᴸ : StoreChanges Δᴸ Δᴸ′}
@@ -137,6 +162,8 @@ centerVarᴾ (evolve-keepᴿ evol) Z = centerVarᴾ evol Z
 centerVarᴾ (evolve-both-bind evol) Z = centerVarᴾ evol (Fin.suc Z)
 centerVarᴾ (evolve-left-bind evol) Z = centerVarᴾ evol (Fin.suc Z)
 centerVarᴾ (evolve-right-bind evol) Z = centerVarᴾ evol (Fin.suc Z)
+centerVarᴾ (evolve-structural-right-bind {π = π} ins follows evol) Z =
+  centerVarᴾ evol (toRenameᵗ π Z)
 
 
 ParkedWorldClosedᵀ : Set

--- a/GTSFImp/proof/DGG/Parked/ParkedWorldProof.agda
+++ b/GTSFImp/proof/DGG/Parked/ParkedWorldProof.agda
@@ -30,12 +30,16 @@ open import Types using
   ; renameᵗ-cong
   ; renameᵗ-shift
   )
-open import Consistency using (_↪ᵗ_; empty; keep; skip; toRenameᵗ)
+open import Consistency using
+  (_↪ᵗ_; empty; keep; skip; toRenameᵗ; wk↪ᵗ)
 open import Imprecision using (X⊑X; X⊑★; _⊢_⊑_)
 open import Reduction using (StoreChanges)
 import Reduction as R
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.ExtraCastRight2 as ECR
+import proof.DGG.TargetExtend as TE
+open import proof.DGG.Parked.ParkedBindImprecisionProof using
+  (both-bind-⊑ᵂ; left-bind-⊑ᵂ; right-bind-⊑ᵂ)
 open import proof.DGG.Parked.ParkedWorldDef using
   ( MapCtxᴾᵀ
   ; ParkedEvolve
@@ -60,15 +64,17 @@ open import proof.DGG.Parked.ParkedWorldDef using
   ; evolve-left-bind
   ; evolve-refl
   ; evolve-right-bind
+  ; evolve-structural-right-bind
   ; parked-both-bind
   ; parked-initial
   ; parked-left-bind
   ; parked-right-bind
+  ; parked-structural-right-insert
   )
 open import proof.ImprecisionConsistency using
   (fin-suc-injective; rename-⊑)
 open import proof.TypeInTermSubst using
-  (toRename-id-eq; toRename-keep-eq)
+  (renameᵗ-wk-eq; toRename-id-eq; toRename-wk-eq)
 
 open CTI2 using
   ( CtxImp
@@ -81,22 +87,6 @@ open CTI2 using
   ; targetStoreʷ
   ; _⊑ᵂ⟨_⟩_
   )
-
-
-renameᵗ-skip-eq : ∀ {Δᴿ Δ} (η : Δᴿ ↪ᵗ Δ) (B : Ty Δᴿ)
-  → renameᵗ (toRenameᵗ (skip η)) B
-      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) B)
-renameᵗ-skip-eq η B =
-  trans (renameᵗ-cong B (λ X → refl))
-    (sym (renameᵗ-comp (toRenameᵗ η) Fin.suc B))
-
-
-embed-keep-shift : ∀ {Δ₀ Δ} (η : Δ₀ ↪ᵗ Δ) (A : Ty Δ₀)
-  → renameᵗ (toRenameᵗ (keep η)) (⇑ᵗ A)
-      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) A)
-embed-keep-shift η A =
-  trans (renameᵗ-cong (⇑ᵗ A) (toRename-keep-eq η))
-    (renameᵗ-shift (toRenameᵗ η) A)
 
 
 ≤-step : ∀ {m n} → m ≤ n → m ≤ Nat.suc n
@@ -119,55 +109,14 @@ no-suc↪ᵗ : ∀ {Δ} → Nat.suc Δ ↪ᵗ Δ → ⊥
 no-suc↪ᵗ η = no-suc≤ (embed≤ η)
 
 
-both-bind-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ}
-    {W : World Δᴸ Δᴿ Δ} {A : Ty Δᴸ} {B : Ty Δᴿ}
-    {C : Ty Δᴸ} {D : Ty Δᴿ}
-  → C ⊑ᵂ⟨ W ⟩ D
-  → ⇑ᵗ C ⊑ᵂ⟨ CTI2.bothBindWorld X⊑X W A B ⟩ ⇑ᵗ D
-both-bind-⊑ᵂ {W = W} {A = A} {B = B} {C = C} {D = D} p =
-  subst≡
-    (λ L → impEnvʷ (CTI2.bothBindWorld X⊑X W A B) ⊢ L ⊑
-      embedᴿ (CTI2.bothBindWorld X⊑X W A B) (⇑ᵗ D))
-    (sym (embed-keep-shift (CTI2.ηᴸʷ W) C))
-    (subst≡
-      (λ R → impEnvʷ (CTI2.bothBindWorld X⊑X W A B) ⊢
-        ⇑ᵗ (embedᴸ W C) ⊑ R)
-      (sym (embed-keep-shift (CTI2.ηᴿʷ W) D))
-      (rename-⊑ Fin.suc fin-suc-injective (λ X eq → eq) p))
-
-
-right-bind-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ}
-    {W : World Δᴸ Δᴿ Δ} {B′ : Ty Δᴿ}
-    {A : Ty Δᴸ} {B : Ty Δᴿ}
-  → A ⊑ᵂ⟨ W ⟩ B
-  → A ⊑ᵂ⟨ CTI2.rightOnlyWorld W B′ ⟩ ⇑ᵗ B
-right-bind-⊑ᵂ {W = W} {B′ = B′} {A = A} {B = B} p =
-  subst≡
-    (λ L → impEnvʷ (CTI2.rightOnlyWorld W B′) ⊢ L ⊑
-      embedᴿ (CTI2.rightOnlyWorld W B′) (⇑ᵗ B))
-    (sym (renameᵗ-skip-eq (CTI2.ηᴸʷ W) A))
-    (subst≡
-      (λ R → impEnvʷ (CTI2.rightOnlyWorld W B′) ⊢
-        ⇑ᵗ (embedᴸ W A) ⊑ R)
-      (sym (embed-keep-shift (CTI2.ηᴿʷ W) B))
-      (rename-⊑ Fin.suc fin-suc-injective (λ X eq → eq) p))
-
-
-left-bind-⊑ᵂ : ∀ {Δᴸ Δᴿ Δ}
-    {W : World Δᴸ Δᴿ Δ} {A′ : Ty Δᴸ}
-    {A : Ty Δᴸ} {B : Ty Δᴿ}
-  → A ⊑ᵂ⟨ W ⟩ B
-  → ⇑ᵗ A ⊑ᵂ⟨ CTI2.leftOnlyWorld X⊑★ W A′ ⟩ B
-left-bind-⊑ᵂ {W = W} {A′ = A′} {A = A} {B = B} p =
-  subst≡
-    (λ L → impEnvʷ (CTI2.leftOnlyWorld X⊑★ W A′) ⊢ L ⊑
-      embedᴿ (CTI2.leftOnlyWorld X⊑★ W A′) B)
-    (sym (embed-keep-shift (CTI2.ηᴸʷ W) A))
-    (subst≡
-      (λ R → impEnvʷ (CTI2.leftOnlyWorld X⊑★ W A′) ⊢
-        ⇑ᵗ (embedᴸ W A) ⊑ R)
-      (sym (renameᵗ-skip-eq (CTI2.ηᴿʷ W) B))
-      (rename-⊑ Fin.suc fin-suc-injective (λ X eq → eq) p))
+same-size-embedding-id : ∀ {Δ} (η : Δ ↪ᵗ Δ) (X : TyVar Δ)
+  → toRenameᵗ η X ≡ X
+same-size-embedding-id {Nat.zero} empty ()
+same-size-embedding-id {Nat.suc Δ} (keep η) zero = refl
+same-size-embedding-id {Nat.suc Δ} (keep η) (Fin.suc X) =
+  cong Fin.suc (same-size-embedding-id η X)
+same-size-embedding-id {Nat.suc Δ} (skip η) X =
+  ⊥-elim (no-suc↪ᵗ η)
 
 
 transport⊑ᴾ-proofᵀ : Transport⊑ᴾᵀ
@@ -197,6 +146,11 @@ transport⊑ᴾ-proofᵀ {W = W} {W′ = W′} {A = A} {B = B}
     {W = CTI2.rightOnlyWorld W B′} {W′ = W′}
     {A = A} {B = ⇑ᵗ B} evol
     (right-bind-⊑ᵂ {W = W} {B′ = B′} {A = A} {B = B} p)
+transport⊑ᴾ-proofᵀ {A = A} {B = B}
+    (evolve-structural-right-bind {W₁ = W₁} ins follows evol) p =
+  transport⊑ᴾ-proofᵀ evol
+    (subst≡ (λ C → A ⊑ᵂ⟨ W₁ ⟩ C) (renameᵗ-wk-eq B)
+      (TE.transport⊑ᵂ ins p))
 
 
 mapCtxᴾ-proofᵀ : MapCtxᴾᵀ
@@ -219,6 +173,10 @@ parked-world-closed-proofᵀ pw (evolve-left-bind evol) =
   parked-world-closed-proofᵀ (parked-left-bind pw) evol
 parked-world-closed-proofᵀ pw (evolve-right-bind evol) =
   parked-world-closed-proofᵀ (parked-right-bind pw) evol
+parked-world-closed-proofᵀ pw
+    (evolve-structural-right-bind ins follows evol) =
+  parked-world-closed-proofᵀ
+    (parked-structural-right-insert pw ins follows) evol
 
 
 parked-target-stable-proofᵀ : ParkedTargetStableᵀ
@@ -233,6 +191,15 @@ parked-target-stable-proofᵀ (evolve-left-bind evol) Y =
   parked-target-stable-proofᵀ evol Y
 parked-target-stable-proofᵀ (evolve-right-bind evol) Y =
   parked-target-stable-proofᵀ evol (Fin.suc Y)
+parked-target-stable-proofᵀ
+    (evolve-structural-right-bind {χsᴿ = χsᴿ} {W′ = W′} {π = π}
+      ins follows evol) Y =
+  trans
+    (cong
+      (λ Y′ → toRenameᵗ (CTI2.ηᴿʷ W′) (χsᴿ ▶ᵛ Y′))
+      (sym (toRename-wk-eq Y)))
+    (trans (parked-target-stable-proofᵀ evol (toRenameᵗ wk↪ᵗ Y))
+      (cong (centerVarᴾ evol) (TE.target-insert ins Y)))
 
 
 parked-source-stable : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
@@ -254,6 +221,10 @@ parked-source-stable (evolve-left-bind evol) X =
   parked-source-stable evol (Fin.suc X)
 parked-source-stable (evolve-right-bind evol) X =
   parked-source-stable evol X
+parked-source-stable
+    (evolve-structural-right-bind ins follows evol) X =
+  trans (parked-source-stable evol X)
+    (cong (centerVarᴾ evol) (TE.source-insert ins X))
 
 
 parked-target-identity-proofᵀ : ParkedTargetIdentityᵀ
@@ -266,6 +237,9 @@ parked-target-identity-proofᵀ (parked-left-bind {W = W} pw) Y =
 parked-target-identity-proofᵀ (parked-right-bind pw) zero = refl
 parked-target-identity-proofᵀ (parked-right-bind pw) (Fin.suc Y) =
   cong Fin.suc (parked-target-identity-proofᵀ pw Y)
+parked-target-identity-proofᵀ
+    (parked-structural-right-insert {W₁ = W₁} pw ins follows) Y =
+  same-size-embedding-id (CTI2.ηᴿʷ W₁) Y
 
 
 parked-fresh-bothᴸ-proofᵀ : ParkedFreshBothᴸᵀ
@@ -310,6 +284,8 @@ right-source-kept : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
 right-source-kept evolve-refl = refl
 right-source-kept (evolve-keepᴿ evol) = right-source-kept evol
 right-source-kept (evolve-right-bind evol) = right-source-kept evol
+right-source-kept (evolve-structural-right-bind ins follows evol) =
+  trans (right-source-kept evol) (TE.sourceStore-kept ins)
 
 
 right-target-follows : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -321,6 +297,9 @@ right-target-follows evolve-refl = refl
 right-target-follows (evolve-keepᴿ evol) = right-target-follows evol
 right-target-follows (evolve-right-bind evol) =
   right-target-follows evol
+right-target-follows
+    (evolve-structural-right-bind {χsᴿ = χsᴿ} ins follows evol) =
+  trans (right-target-follows evol) (cong (R.applyStores χsᴿ) follows)
 
 
 right-only-parked→world-extendᴿ-proofᵀ :

--- a/GTSFImp/proof/DGG/TargetExtend.agda
+++ b/GTSFImp/proof/DGG/TargetExtend.agda
@@ -44,7 +44,7 @@ open import proof.TypeInTermSubst using
    toRename-keep-eq; toRename-wk-eq; typing-renameᵗ; rename-openᵗ)
 open import proof.ImprecisionConsistency using
   (fin-suc-injective; rename-⊑; subst-⊑; toRenameᵗ-injective)
-open import proof.DGG.Parked.ParkedWorldProof using (right-bind-⊑ᵂ)
+open import proof.DGG.Parked.ParkedBindImprecisionProof using (right-bind-⊑ᵂ)
 open import proof.DGG.CenterRename using
   (_∘↪_; toRenameᵗ-∘; sucMaybe; preimage?; sucMaybe-nothing;
    preimage?-image; EmbeddingPair; pair; embeddingPair; EmbeddingPushout;
@@ -74,7 +74,7 @@ record TargetInsert {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     (ρ : Δᴿ ↪ᵗ Δᴿ′)
     (π : Δ ↪ᵗ Δ′)
     (W : World Δᴸ Δᴿ Δ)
-    (W′ : World Δᴸ Δᴿ′ Δ′) : Set₁ where
+    (W′ : World Δᴸ Δᴿ′ Δ′) : Set where
   field
     sourceStore-kept : CTI2.sourceStoreʷ W′ ≡ CTI2.sourceStoreʷ W
 
@@ -2493,7 +2493,7 @@ pullbackReverseRebaseAt
   reps =
     storeRep-insert ins (CTI2.RebaseAt.storeRepresentations rb)
 
-TargetExtendOPEᵀ : Set₁
+TargetExtendOPEᵀ : Set
 TargetExtendOPEᵀ =
   ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
@@ -2508,7 +2508,7 @@ TargetExtendOPEᵀ =
   → W′ ∣ mapCtxᵀ ins γ
       ⊢² M ⊑ renameᵗᵐ ρ M′ ∶ transport⊑ᵂ ins p
 
-RebaseAtᴿInsertCommuteᵀ : Set₁
+RebaseAtᴿInsertCommuteᵀ : Set
 RebaseAtᴿInsertCommuteᵀ =
   ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
@@ -2522,7 +2522,7 @@ RebaseAtᴿInsertCommuteᵀ =
       CTI2.RebaseAtᴿ W⁺ Wᵖ⁺
         (mapPivot (toRenameᵗ ρ) Xᴿ?)
 
-RebaseAtᴸInsertCommuteᵀ : Set₁
+RebaseAtᴸInsertCommuteᵀ : Set
 RebaseAtᴸInsertCommuteᵀ =
   ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
@@ -2535,7 +2535,7 @@ RebaseAtᴸInsertCommuteᵀ =
       TargetInsert ρ π Wᵖ Wᵖ⁺ ×
       CTI2.RebaseAtᴸ W⁺ Wᵖ⁺ Xᴸ?
 
-TagRebaseAtᴸInsertCommuteᵀ : Set₁
+TagRebaseAtᴸInsertCommuteᵀ : Set
 TagRebaseAtᴸInsertCommuteᵀ =
   ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
@@ -2549,7 +2549,7 @@ TagRebaseAtᴸInsertCommuteᵀ =
       CTI2.TagRebaseAtᴸ W⁺ Wᵖ⁺ Xᴸ?
         (mapPivot (toRenameᵗ ρ) Xᴿ?)
 
-RebaseAtInsertCommuteᵀ : Set₁
+RebaseAtInsertCommuteᵀ : Set
 RebaseAtInsertCommuteᵀ =
   ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
@@ -2562,7 +2562,7 @@ RebaseAtInsertCommuteᵀ =
       TargetInsert ρ π Wᵖ Wᵖ⁺ ×
       CTI2.RebaseAt W⁺ Wᵖ⁺ Xᴸ (toRenameᵗ ρ Xᴿ)
 
-ImpEnvMonoInsertCommuteᵀ : Set₁
+ImpEnvMonoInsertCommuteᵀ : Set
 ImpEnvMonoInsertCommuteᵀ =
   ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}

--- a/GTSFImp/proof/DGG/TransportTermImprecisionProof.agda
+++ b/GTSFImp/proof/DGG/TransportTermImprecisionProof.agda
@@ -10,10 +10,11 @@ module proof.DGG.TransportTermImprecisionProof where
 open import Data.List using ([]; _∷_)
 import Data.Nat as Nat
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; sym; cong)
+  using (_≡_; refl; sym; cong; cong₂)
   renaming (subst to subst≡)
 
 open import CastTerms using (Term)
+import Consistency
 open import Imprecision using (X⊑X; X⊑★)
 import Reduction
 import proof.DGG.CastTermImprecision2 as CTI2
@@ -28,10 +29,13 @@ open import proof.DGG.Parked.ParkedWorldDef
     ; evolve-left-bind
     ; evolve-right-bind
     ; evolve-both-bind
+    ; evolve-structural-right-bind
     )
 open import proof.DGG.Parked.ParkedWorldLemma
   using (mapCtxᴾ; right-only-parked→world-extendᴿ; transport⊑ᴾ)
 open import proof.DGG.TargetExtend using (⊢²-target-extend-bind)
+import proof.DGG.TargetExtend as TE
+open import proof.TypeInTermSubst using (renameᵗ-wk-eq)
 open import proof.DGG.TransportTermImprecisionDef
   using
     ( BothBindTransport²ᵀ
@@ -122,6 +126,31 @@ mapCtxᴾ-right-bind evol (ctx-imp A B p ∷ γ) =
   cong (λ γ′ → ctx-imp _ _ _ ∷ γ′) (mapCtxᴾ-right-bind evol γ)
 
 
+mapCtxᴾ-structural-right-bind : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ₁ Δ′}
+    {χsᴸ : Reduction.StoreChanges Δᴸ Δᴸ′}
+    {χsᴿ : Reduction.StoreChanges (Nat.suc Δᴿ) Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ}
+    {W₁ : World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {W′ : World Δᴸ′ Δᴿ′ Δ′}
+    {B₀} {π}
+  → (ins : TE.TargetInsert Consistency.wk↪ᵗ π W W₁)
+  → (follows : CTI2.targetStoreʷ W₁ ≡
+      Reduction.applyStore (Reduction.bind B₀) (CTI2.targetStoreʷ W))
+  → (evol : ParkedEvolve χsᴸ χsᴿ W₁ W′)
+  → (γ : CtxImp W)
+  → mapCtxᴾ evol (TE.mapCtxᵀ ins γ)
+      ≡ mapCtxᴾ (evolve-structural-right-bind ins follows evol) γ
+mapCtxᴾ-structural-right-bind ins follows evol [] = refl
+mapCtxᴾ-structural-right-bind {χsᴿ = χsᴿ}
+    ins follows evol (ctx-imp A B p ∷ γ) =
+  cong₂ _∷_ entry-eq
+    (mapCtxᴾ-structural-right-bind ins follows evol γ)
+  where
+  entry-eq =
+    TE.ctx-imp-target-eq
+      (cong (Reduction.applyTys χsᴿ) (renameᵗ-wk-eq B))
+
+
 transport-term-imprecision-ctx :
   SourceBindTransport²ᵀ
   → BothBindTransport²ᵀ
@@ -168,6 +197,15 @@ transport-term-imprecision-ctx src both
         (right-only-parked→world-extendᴿ
           (evolve-right-bind {W = W} {B = B₀} evolve-refl))
         M⊑M′))
+transport-term-imprecision-ctx src both
+    {W′ = W′}
+    (evolve-structural-right-bind ins follows evol) M⊑M′ =
+  subst≡
+    (λ γ′ → W′ ∣ γ′ ⊢² _ ⊑ _ ∶ _)
+    (mapCtxᴾ-structural-right-bind ins follows evol _)
+    (transport-term-imprecision-ctx src both evol
+      (TE.⊢²-retargetᴿ (renameᵗ-wk-eq _)
+        (TE.⊢²-target-insert ins M⊑M′)))
 transport-term-imprecision-ctx src both
     (evolve-both-bind {W′ = W′} {A = A₀} {B = B₀} evol) M⊑M′ =
   subst≡

--- a/GTSFImp/proof/DGG/notes/probes/T10Probe1ParkedWorldPreservation.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T10Probe1ParkedWorldPreservation.agda
@@ -10,22 +10,26 @@ module T10Probe1ParkedWorldPreservation where
 open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
 open import Data.Maybe using (just)
-open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl; sym; trans)
 
 open import Types using (TyVar; ★)
 open import TyStore using (store-empty; store-bind)
-open import Consistency using (empty; keep; skip; toRenameᵗ)
+open import Consistency using (empty; keep; toRenameᵗ)
 open import Imprecision using
   (ImpEnv; VarImp; X⊑X; X⊑★; extendᵐ; instᵐ; ★⊑★)
+open import proof.TypeInTermSubst using (toRename-wk-eq)
 
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CompilePreservesImprecision2 as CPI2
+import proof.DGG.TargetExtend as TE
 open import proof.DGG.Parked.ParkedWorldDef using
   ( ParkedWorld
   ; parked-initial
   ; parked-both-bind
   ; parked-left-bind
   ; parked-right-bind
+  ; parked-structural-right-insert
   )
 
 
@@ -43,6 +47,9 @@ W = CTI2.rightOnlyWorld W-paired ★
 
 parked-W : ParkedWorld W
 parked-W = parked-right-bind (parked-both-bind parked-initial)
+
+zero≢suc : ∀ {n} {Y : Fin.Fin n} → Fin.zero ≢ Fin.suc Y
+zero≢suc ()
 
 source-store : TyStore.TyStore 1
 source-store = store-bind store-empty ★
@@ -108,6 +115,17 @@ parked-head00-precise : ∀ {W′ : CTI2.World 1 2 2}
 parked-head00-precise (parked-both-bind pw) src-zero tgt-zero = refl
 parked-head00-precise (parked-left-bind pw) src-zero ()
 parked-head00-precise (parked-right-bind pw) () tgt-zero
+parked-head00-precise
+    (parked-structural-right-insert {W = W} pw ins follows)
+    src-zero tgt-zero
+    with TE.target-center-reflect ins
+      (trans tgt-zero
+        (trans (sym src-zero) (TE.source-insert ins Fin.zero)))
+parked-head00-precise
+    (parked-structural-right-insert {W = W} pw ins follows)
+    src-zero tgt-zero
+    | Y , zero-eq , target-eq =
+  ⊥-elim (zero≢suc (trans zero-eq (toRename-wk-eq Y)))
 
 not-parked-Wᵖ : ParkedWorld Wᵖ → ⊥
 not-parked-Wᵖ pw =

--- a/GTSFImp/proof/DGG/notes/probes/T11TargetInsertPositionProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T11TargetInsertPositionProbe.agda
@@ -1,0 +1,41 @@
+module proof.DGG.notes.probes.T11TargetInsertPositionProbe where
+
+-- File Charter:
+--   * Records the target-center position of the fresh target variable for
+--     direct right binds and for right binds lifted under a source-only binder.
+--   * The checked equalities support the T11 meet-point feasibility note.
+
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types using (Ty)
+open import Consistency using (toRenameᵗ)
+open import Imprecision using (X⊑★)
+import proof.DGG.CastTermImprecision2 as CTI2
+
+
+direct-right-bind-fresh-target-center : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+  → toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) Fin.zero
+      ≡ Fin.zero
+direct-right-bind-fresh-target-center = refl
+
+
+lift-left-around-right-bind-fresh-target-center : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+  → toRenameᵗ
+      (CTI2.ηᴿʷ
+        (CTI2.liftWorldLeft X⊑★ (CTI2.rightOnlyWorld W B)))
+      Fin.zero
+      ≡ Fin.suc Fin.zero
+lift-left-around-right-bind-fresh-target-center = refl
+
+
+parked-right-bind-after-lift-left-fresh-target-center : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+  → toRenameᵗ
+      (CTI2.ηᴿʷ
+        (CTI2.rightOnlyWorld (CTI2.liftWorldLeft X⊑★ W) B))
+      Fin.zero
+      ≡ Fin.zero
+parked-right-bind-after-lift-left-fresh-target-center = refl

--- a/GTSFImp/proof/DGG/notes/t11-meetpoint-boundary-adapters-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t11-meetpoint-boundary-adapters-proposal.red
@@ -1,0 +1,256 @@
+# T11 meet point: boundary-kind adapters
+
+Purpose: draft the adapters from a structural bottom-up
+`StructuralCatchupRightResult` to the boundary-kind-indexed
+`ValueCatchupResult` surface.
+
+## Before context
+
+The fixed top-down surface indexes the result by:
+
+```agda
+data CatchupBoundaryKind : Set where
+  same-boundary : CatchupBoundaryKind
+  source-reveal-boundary : CatchupBoundaryKind
+  source-conceal-boundary : CatchupBoundaryKind
+  target-reveal-boundary : CatchupBoundaryKind
+  target-conceal-boundary : CatchupBoundaryKind
+```
+
+The boundary constructors carry either no rebase, a forward tag rebase,
+or a reverse tag rebase:
+
+```agda
+boundary-refl :
+  CatchupBoundary same-boundary nothing nothing W W
+
+boundary-source-reveal :
+  ImpEnvMono W Wᵖ →
+  TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ? →
+  CatchupBoundary source-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
+
+boundary-source-conceal :
+  ImpEnvMono W Wᵖ →
+  TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ? →
+  CatchupBoundary source-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
+
+boundary-target-reveal :
+  ImpEnvMono W Wᵖ →
+  TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ? →
+  CatchupBoundary target-reveal-boundary Xᴸ? Xᴿ? W Wᵖ
+
+boundary-target-conceal :
+  ImpEnvMono W Wᵖ →
+  TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ? →
+  CatchupBoundary target-conceal-boundary Xᴸ? Xᴿ? W Wᵖ
+```
+
+The adapters below intentionally take the structural bottom-up result,
+because the adapter must reuse both `structural-ext` and the final
+empty-context relation from that result.
+
+## Shared helper statements
+
+Boundary packing needs a structural evolution embedding and two
+boundary transport helpers.
+
+```agda
+StructuralRightParkedEvolveᵀ : Set₁
+StructuralRightParkedEvolveᵀ =
+  ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
+  → ParkedWorld W
+  → StructuralWorldExtendᴿ χsᴿ W W′
+  → ParkedEvolve [] χsᴿ W W′
+```
+
+The existing `structural-tag-rebase-atᴸ-pullback` has the reverse
+orientation needed for conceal boundaries:
+
+```agda
+structural-tag-rebase-atᴸ-pullback :
+  (planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′) →
+  (rb : TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?) →
+  StructuralTagRebaseAtᴸPullbackResult planᵖ rb
+```
+
+Reveal boundaries need the forward orientation.  Candidate statement:
+
+```agda
+record StructuralForwardTagRebaseAtᴸPullbackResult
+    {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {Wᵖ : World Δᴸ Δᴿ Δ}
+    {Wᵖ′ : World Δᴸ Δᴿ′ Δ′}
+    (planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′)
+    {W : World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+    (rb : TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?) : Set₁ where
+  field
+    W′ : World Δᴸ Δᴿ′ Δ′
+    outer-plan : StructuralWorldExtendᴿ χs W W′
+    post-rebase : TagRebaseAtᴸ W′ Wᵖ′ Xᴸ?
+      (mapPivotChanges χs Xᴿ?)
+    post-mono : ImpEnvMono W Wᵖ → ImpEnvMono W′ Wᵖ′
+
+structural-forward-tag-rebase-atᴸ-pullback :
+  ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {Wᵖ : World Δᴸ Δᴿ Δ}
+    {Wᵖ′ : World Δᴸ Δᴿ′ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+  → (planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′)
+  → (rb : TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?)
+  → StructuralForwardTagRebaseAtᴸPullbackResult planᵖ rb
+```
+
+This helper should be assembled by cases on `TagRebaseAtᴸ`, using
+`structural-rebase-atᴸ-pullback` for the `nothing` source-only cases
+and `structural-rebase-at-pullback` for the paired-pivot case.  The
+paired case also needs the small definitional bridge:
+
+```agda
+mapPivotChanges-just : ∀ {Δᴿ Δᴿ′}
+    (χs : StoreChanges Δᴿ Δᴿ′) (Xᴿ : TyVar Δᴿ)
+  → mapPivotChanges χs (just Xᴿ) ≡ just (mapVarChanges χs Xᴿ)
+```
+
+## Kind-specific adapter statements
+
+Same boundary needs no rebase transport.  The outer and premise worlds
+are the same, so both structural extensions are the child
+`structural-ext`.
+
+```agda
+same-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ W ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → StructuralCatchupRightResult W [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = W} {kind = same-boundary}
+      {Xᴸ? = nothing} {Xᴿ? = nothing}
+      {V = V} {M′ = M′} {A = A} {B = B}
+```
+
+Source reveal uses the new forward tag pullback on the child plan:
+`planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′` and
+`rb : TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?` produce `outer-plan` and
+`TagRebaseAtᴸ W′ Wᵖ′ Xᴸ? (mapPivotChanges χs Xᴿ?)`.
+
+```agda
+source-reveal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : ImpEnvMono W Wᵖ)
+  → (rb : TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = source-reveal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+```
+
+Target reveal has the same boundary-level transport as source reveal.
+If the caller starts from a target-specific `RebaseAtᴿ`, first convert
+it with `toTagRebaseAtᴿ`; the adapter itself only sees the generic
+boundary tag rebase.
+
+```agda
+target-reveal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : ImpEnvMono W Wᵖ)
+  → (rb : TagRebaseAtᴸ W Wᵖ Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = target-reveal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+```
+
+Source conceal uses the existing reverse-oriented tag pullback:
+`planᵖ : StructuralWorldExtendᴿ χs Wᵖ Wᵖ′` and
+`rb : TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?` produce `outer-plan` and
+`TagRebaseAtᴸ Wᵖ′ W′ Xᴸ? (mapPivotChanges χs Xᴿ?)`.
+
+```agda
+source-conceal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : ImpEnvMono W Wᵖ)
+  → (rb : TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = source-conceal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+```
+
+Target conceal is identical at the boundary layer.  If the caller
+starts from a target-specific reverse `RebaseAtᴿ`, first convert it
+with `toTagRebaseAtᴿ`; this adapter consumes the generic boundary
+shape.
+
+```agda
+target-conceal-boundary-value-adapter : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {V : Term Δᴸ} {M′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
+  → StructuralRightParkedEvolveᵀ
+  → ParkedWorld W
+  → (mono : ImpEnvMono W Wᵖ)
+  → (rb : TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → StructuralCatchupRightResult Wᵖ [] V M′ p
+  → ValueCatchupResult
+      {W = W} {Wᵖ = Wᵖ} {kind = target-conceal-boundary}
+      {Xᴸ? = Xᴸ?} {Xᴿ? = Xᴿ?}
+      {V = V} {M′ = M′} {A = A} {B = B}
+```
+
+## Transport summary
+
+Same boundary: no rebase transport; use `boundary-refl`, `refl` for
+`nothing ≡ mapPivotChanges χs nothing`, and the child plan twice.
+
+Source reveal and target reveal: use the proposed
+`structural-forward-tag-rebase-atᴸ-pullback`; package the result with
+`boundary-source-reveal (post-mono mono) post-rebase` or
+`boundary-target-reveal (post-mono mono) post-rebase`.
+
+Source conceal and target conceal: use existing
+`structural-tag-rebase-atᴸ-pullback`; package the result with
+`boundary-source-conceal (post-mono mono) post-rebase` or
+`boundary-target-conceal (post-mono mono) post-rebase`.
+
+All five adapters pack:
+
+```agda
+Xᴿ′? = mapPivotChanges χs Xᴿ?
+pivot equality = refl
+post reduction = StructuralCatchupRightResult.post-reduction child
+final value = StructuralCatchupRightResult.final-value child
+parked evolution = structural-right-parked-evolve parked outer-plan
+premise structural plan = StructuralCatchupRightResult.structural-ext child
+final relation = StructuralCatchupRightResult.final-relation child
+```

--- a/GTSFImp/proof/DGG/notes/t11-meetpoint-embedding-proposal.red
+++ b/GTSFImp/proof/DGG/notes/t11-meetpoint-embedding-proposal.red
@@ -1,0 +1,163 @@
+# T11 meet point: structural right extension to parked evolution
+
+Purpose: draft the evolution-conversion side of the
+`CatchupToMorePrecise` meet point.  The bottom-up structural catchup
+result exposes a right structural world-extension trace, while the
+top-down surface requires a parked evolution witness.
+
+## Before context
+
+The top-down result in `CatchupToMorePreciseDef.agda` wants both
+witnesses:
+
+```agda
+ParkedEvolve [] χsᴿ W W′ ×
+StructuralWorldExtendᴿ χsᴿ W W′ ×
+StructuralWorldExtendᴿ χsᴿ Wᵖ Wᵖ′ ×
+(Wᵖ′ ∣ [] ⊢² V ⊑ V′ ∶ q)
+```
+
+The bottom-up structural result already keeps the trace needed for the
+second component:
+
+```agda
+record StructuralCatchupRightResult ... where
+  field
+    χs : StoreChanges Δᴿ Δᴿ′
+    W′ : World Δᴸ Δᴿ′ Δ′
+    structural-ext : StructuralWorldExtendᴿ χs W W′
+```
+
+The public `ValueCatchupRightAt` should not be the adapter input for
+this conversion, because it returns only the erased
+`ECR.WorldExtendᴿ χs W W′`; the structural bind witnesses and rebase
+history are gone.
+
+## Insertion inventory
+
+All structural right binds have a target-store bind at the fresh
+target variable.  This is forced by
+`StructuralWorldExtendᴿ.structural-bind`, whose premise is
+`TE.TargetInsert wk↪ᵗ π W W₁` and whose store side follows
+`applyStores (bind B ∷ [])`.
+
+Direct base target allocations use the zero-centered right-only world:
+
+```agda
+rightBindTargetInsert :
+  TargetInsert wk↪ᵗ wk↪ᵗ W (CTI2.rightOnlyWorld W B)
+
+rightBindTargetWindowInsert = record
+  { windowEmbedding = window-here
+  ; window-zero = refl
+  ; window-old = λ Z → refl
+  }
+```
+
+The direct call sites are the target instantiation, target lambda,
+target generalization, and target reveal/conceal conversion steps.
+They all pass `TE.rightBindTargetInsert` to the shared structural
+target-bind step.
+
+However, the right-catchup stack also transports these plans through
+source-side lambda replay.  The plain source-lambda replay case calls
+`structural-lift-left plan X⊑★`, and that helper rebuilds each bind
+with `TE.liftLeftTargetInsert`.  The target insertion equation for
+that helper is:
+
+```agda
+liftLeft-target-insert ins X =
+  cong Fin.suc (target-insert ins X)
+```
+
+The checked probe records the resulting center positions:
+
+```agda
+direct-right-bind-fresh-target-center : ...
+  → toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) Fin.zero
+      ≡ Fin.zero
+
+lift-left-around-right-bind-fresh-target-center : ...
+  → toRenameᵗ
+      (CTI2.ηᴿʷ
+        (CTI2.liftWorldLeft X⊑★ (CTI2.rightOnlyWorld W B)))
+      Fin.zero
+      ≡ Fin.suc Fin.zero
+
+parked-right-bind-after-lift-left-fresh-target-center : ...
+  → toRenameᵗ
+      (CTI2.ηᴿʷ
+        (CTI2.rightOnlyWorld (CTI2.liftWorldLeft X⊑★ W) B))
+      Fin.zero
+      ≡ Fin.zero
+```
+
+Verdict: not every target insertion used by the structural
+right-catchup stack is at `Fin.zero` in the parked M2 sense.  Direct
+right binds are zero-centered, but a direct right bind transported
+under a source-only lift has the fresh target center at
+`Fin.suc Fin.zero`.  The conversion therefore needs a parked-family
+extension that accepts the structural target insertion evidence, not
+just a discipline argument asserting zero-centered parked steps.
+
+## Candidate after context
+
+The adapter should consume the structural bottom-up result, not the
+erased public result:
+
+```agda
+StructuralRightParkedEvolveᵀ : Set₁
+StructuralRightParkedEvolveᵀ =
+  ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
+  → ParkedWorld W
+  → StructuralWorldExtendᴿ χsᴿ W W′
+  → ParkedEvolve [] χsᴿ W W′
+```
+
+Under the current `ParkedEvolve`, the intended recursive proof fails
+in the `structural-bind` case whenever the intermediate world is not
+definitionally `CTI2.rightOnlyWorld W B`.  The required parked-family
+extension is the following constructor shape, placed with
+`ParkedEvolve`:
+
+```agda
+evolve-structural-right-bind : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ₁ Δ′}
+    {χsᴸ : StoreChanges Δᴸ Δᴸ′}
+    {χsᴿ : StoreChanges (suc Δᴿ) Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ}
+    {W₁ : World Δᴸ (suc Δᴿ) Δ₁}
+    {W′ : World Δᴸ′ Δᴿ′ Δ′}
+    {B : Ty Δᴿ} {π : Δ ↪ᵗ Δ₁}
+  → TE.TargetInsert wk↪ᵗ π W W₁
+  → CTI2.targetStoreʷ W₁ ≡
+      applyStores (bind B ∷ []) (CTI2.targetStoreʷ W)
+  → ParkedEvolve χsᴸ χsᴿ W₁ W′
+  → ParkedEvolve χsᴸ (bind B ∷ χsᴿ) W W′
+```
+
+With that constructor, the embedding is a structural recursion over
+the existing trace:
+
+```agda
+structural-right-parked-evolve :
+  StructuralRightParkedEvolveᵀ
+```
+
+The weaker erased statement is not the right target:
+
+```agda
+WorldExtendᴿ→ParkedEvolveᴿᵀ : Set₁
+WorldExtendᴿ→ParkedEvolveᴿᵀ =
+  ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χsᴿ : StoreChanges Δᴿ Δᴿ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
+  → ParkedWorld W
+  → ECR.WorldExtendᴿ χsᴿ W W′
+  → ParkedEvolve [] χsᴿ W W′
+```
+
+It has too little information to reconstruct non-zero structural
+insertions, and those insertions are genuinely used by source-lambda
+replay in the current right-catchup stack.


### PR DESCRIPTION
Statement drafting + probes for the CatchupToMorePrecise meet point. KEY FINDING (checked probe T11TargetInsertPositionProbe.agda + cited sites): not all right-catchup TargetInserts are at Fin.zero — direct right binds are zero-centered (TargetExtend rightBindTargetWindowInsert), but source-lambda replay via structural-lift-left/liftLeftTargetInsert inserts at suc zero (TargetExtend:677 cong Fin.suc). Hence the naive WorldExtendᴿ→ParkedEvolve embedding is REJECTED (recorded with rationale); the proposal is a parked-family extension: a new ParkedEvolve constructor evolve-structural-right-bind consuming the TargetInsert + store equation, making the embedding (structural-right-parked-evolve) a structural recursion. Also drafts the five CatchupBoundaryKind adapter statements (mapPivotChanges-just, forward tag pullback, shared helpers). Decision ask D13 on #157. Carries the main-heal cherry-pick.

Gate + probe verified green by the supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)