### PR TITLE
AGENTS.md: reduction-chain proofs use explicit arguments (no underscores)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,12 @@ transitive chain syntax, such as `_—↠⟨_⟩_` or `_—↠[_]⟨_⟩_`, and 
 with the relation's reflexive terminator. For store-changing chains in
 GTSFImp, that means writing the final term followed by `∎[]`.
 
+In reduction-chain proofs, do not use underscores to make the chain's
+arguments implicit: write out the intermediate and final terms (and the
+store-change indices, where the relation carries them) as explicit
+arguments. The point of the chain notation is that a reader can follow
+the terms in the code; an `_` defeats it.
+
 Prefer:
 
     twoᶜ · sucᶜ · `zero


### PR DESCRIPTION
Per Jeremy's guidance: in reduction-chain proofs, intermediate/final terms and store-change indices are written as explicit arguments — an `_` defeats the readability purpose of the chain notation. Added to the existing reduction-sequence style section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)