### PR TITLE
T14: partner-premise redesign reconnaissance (D15)

### DIFF
--- a/GTSFImp/proof/DGG/CastTermImprecision2.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2.agda
@@ -612,6 +612,43 @@ data SourceConcealPartnerOK {Δᴸ Δᴿ Δ}
       ----------------------------------------------------
     → SourceConcealPartnerOK W P (id↓ A) Xᴿ? M′
 
+-- D15 preflight: the source-only `seal X ★` case is a direct
+-- occupancy gate in the term rule below.  This slim classifier covers
+-- only the non-`★` source-seal and non-seal source-conceal cases that
+-- still need endpoint-shape side conditions beside the old rules.
+
+data SourceConcealOK {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) :
+    Term Δᴸ → {A A′ : Ty Δᴸ} → Conv↓ Δᴸ A A′
+    → Maybe (TyVar Δᴿ) → Term Δᴿ → Set where
+  seal-nonstar-plain-ok : ∀ {P X R Xᴿ? M′}
+    → NonStar R
+    → NotTopTag M′
+      ----------------------------------------------------
+    → SourceConcealOK W P (seal X R) Xᴿ? M′
+
+  seal-nonstar-name-protected-ok : ∀ {P X R Y S M μ}
+      {c : μ ⊢ (＇ Y) ∼ ★}
+    → NonStar R
+    → CenterAligned W X Y
+      ----------------------------------------------------
+    → SourceConcealOK W P (seal X R) (just Y)
+        ((M ↓ seal Y S) ⟨ c ⟩)
+
+  fun-conceal-ok : ∀ {P A A′ B B′ Xᴿ? M′}
+      {c : Conv↑ Δᴸ A′ A} {d : Conv↓ Δᴸ B B′}
+      ----------------------------------------------------
+    → SourceConcealOK W P (c ↦↓ d) Xᴿ? M′
+
+  all-conceal-ok : ∀ {P A B Xᴿ? M′}
+      {c : Conv↓ (Nat.suc Δᴸ) A B}
+      ----------------------------------------------------
+    → SourceConcealOK W P (`∀↓ c) Xᴿ? M′
+
+  id-conceal-ok : ∀ {P A Xᴿ? M′}
+      ----------------------------------------------------
+    → SourceConcealOK W P (id↓ A) Xᴿ? M′
+
 data MatchedConcealPartnerOK {Δᴸ Δᴿ Δ}
     (W : World Δᴸ Δᴿ Δ) :
     Term Δᴸ → {A A′ : Ty Δᴸ} → Conv↓ Δᴸ A A′
@@ -930,6 +967,36 @@ data _∣_⊢²_⊑_∶_ {Δᴸ Δᴿ Δ}
       {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ? Xᴿ?}
       {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↓ Δᴸ A A′}
     → SourceConcealPartnerOK W′ M c Xᴿ? M′
+    → ImpEnvMono W W′
+    → TagRebaseAtᴸ W′ W Xᴸ? Xᴿ?
+    → SameCtx γ γ′
+    → sourceStoreʷ W ⊢↓[ Xᴸ? ] c
+    → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
+    → (q : A′ ⊑ᵂ⟨ W ⟩ B)
+      -----------------------------
+    → W ∣ γ ⊢² M ↓ c ⊑ M′ ∶ q
+
+  -- D15 preflight rules: source-only `seal X ★` sees through only under
+  -- `NoTargetOccupantAtSource`; remaining non-`★`/non-seal cases use the
+  -- slim `SourceConcealOK` classifier above.  The old `conceal⊑²` rule is
+  -- deliberately left intact during the preflight.
+  conceal⊑²-seal-star-open : ∀ {W′ : World Δᴸ Δᴿ Δ}
+      {γ′ : CtxImp W′} {M M′ B X}
+      {p : ★ ⊑ᵂ⟨ W′ ⟩ B}
+    → NoTargetOccupantAtSource W′ X
+    → ImpEnvMono W W′
+    → TagRebaseAtᴸ W′ W (just X) nothing
+    → SameCtx γ γ′
+    → sourceStoreʷ W ⊢↓[ just X ] seal X ★
+    → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
+    → (q : (＇ X) ⊑ᵂ⟨ W ⟩ B)
+      -----------------------------
+    → W ∣ γ ⊢² M ↓ seal X ★ ⊑ M′ ∶ q
+
+  conceal⊑²-source-ok : ∀ {W′ : World Δᴸ Δᴿ Δ}
+      {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ? Xᴿ?}
+      {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↓ Δᴸ A A′}
+    → SourceConcealOK W′ M c Xᴿ? M′
     → ImpEnvMono W W′
     → TagRebaseAtᴸ W′ W Xᴸ? Xᴿ?
     → SameCtx γ γ′

--- a/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
+++ b/GTSFImp/proof/DGG/CastTermImprecision2Typing.agda
@@ -264,6 +264,19 @@ mutual
       (transport-source (sym
         (rebaseᴸ-source-store (CTI2.forgetTagRebaseᴸ rb))) sc
         (source-typing² M⊑M′))
+  source-typing²
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc c⊢
+        M⊑M′ q) =
+    ⊢conceal (erase-⊢↓ c⊢)
+      (transport-source (sym
+        (rebaseᴸ-source-store (CTI2.forgetTagRebaseᴸ rb))) sc
+        (source-typing² M⊑M′))
+  source-typing²
+      (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ M⊑M′ q) =
+    ⊢conceal (erase-⊢↓ c⊢)
+      (transport-source (sym
+        (rebaseᴸ-source-store (CTI2.forgetTagRebaseᴸ rb))) sc
+        (source-typing² M⊑M′))
   source-typing² (CTI2.reveal⊑reveal² mono rb sc c⊢ c′⊢ M⊑M′ q) =
     ⊢reveal (erase-⊢↑ c⊢)
       (transport-source (rebase-source-store rb) sc (source-typing² M⊑M′))
@@ -310,6 +323,17 @@ mutual
   target-typing² (CTI2.reveal⊑² mono rb sc c⊢ M⊑M′ q) =
     transport-target (rebaseᴸ-target-store rb) sc (target-typing² M⊑M′)
   target-typing² (CTI2.conceal⊑² ok mono rb sc c⊢ M⊑M′ q) =
+    transport-target (sym
+      (rebaseᴸ-target-store (CTI2.forgetTagRebaseᴸ rb))) sc
+      (target-typing² M⊑M′)
+  target-typing²
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc c⊢
+        M⊑M′ q) =
+    transport-target (sym
+      (rebaseᴸ-target-store (CTI2.forgetTagRebaseᴸ rb))) sc
+      (target-typing² M⊑M′)
+  target-typing²
+      (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ M⊑M′ q) =
     transport-target (sym
       (rebaseᴸ-target-store (CTI2.forgetTagRebaseᴸ rb))) sc
       (target-typing² M⊑M′)

--- a/GTSFImp/proof/DGG/Catchup/FuelDischargeProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/FuelDischargeProof.agda
@@ -107,6 +107,14 @@ target-cast-bound-mono
     fuel≤fuel′ bound =
   target-cast-bound-mono {rel = rel} fuel≤fuel′ bound
 target-cast-bound-mono
+    {rel = CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q}
+    fuel≤fuel′ bound =
+  target-cast-bound-mono {rel = rel} fuel≤fuel′ bound
+target-cast-bound-mono
+    {rel = CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q}
+    fuel≤fuel′ bound =
+  target-cast-bound-mono {rel = rel} fuel≤fuel′ bound
+target-cast-bound-mono
     {rel = CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q}
     fuel≤fuel′ bound =
   target-cast-bound-mono {rel = rel} fuel≤fuel′ bound
@@ -179,6 +187,12 @@ target-cast-bound-mono {rel = CTI2.⊕⊑⊕² op rel₁ rel₂ r}
 ⊢²-target-cast-bound (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
   ⊢²-target-cast-bound rel
 ⊢²-target-cast-bound (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
+  ⊢²-target-cast-bound rel
+⊢²-target-cast-bound
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q) =
+  ⊢²-target-cast-bound rel
+⊢²-target-cast-bound
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q) =
   ⊢²-target-cast-bound rel
 ⊢²-target-cast-bound
     (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =

--- a/GTSFImp/proof/DGG/Catchup/InstInversionLambdaProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/InstInversionLambdaProof.agda
@@ -5309,6 +5309,24 @@ post-source-conceal-partner-ok {c = `∀↓ c} =
 post-source-conceal-partner-ok {c = id↓ A} =
   CTI2.id-conceal-target
 
+post-source-conceal-ok : ∀ {Δᴸ Δᴿ Δ Δ₂}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₂ : CTI2.World Δᴸ (suc (suc Δᴿ)) Δ₂}
+    {M : CT.Term Δᴸ} {V′ : CT.Term (suc Δᴿ)}
+    {A A′ : Ty Δᴸ} {B : Ty (suc Δᴿ)} {Xᴿ? Xᴿ₂?}
+    {c : Conv↓ Δᴸ A A′}
+  → CTI2.SourceConcealOK W M c Xᴿ? (Λ V′)
+  → CTI2.SourceConcealOK W₂ M c Xᴿ₂?
+      (Λ⊑Λ²PostTerm V′ B)
+post-source-conceal-ok (CTI2.seal-nonstar-plain-ok Rns nt) =
+  CTI2.seal-nonstar-plain-ok Rns CTI2.not-↑
+post-source-conceal-ok CTI2.fun-conceal-ok =
+  CTI2.fun-conceal-ok
+post-source-conceal-ok CTI2.all-conceal-ok =
+  CTI2.all-conceal-ok
+post-source-conceal-ok CTI2.id-conceal-ok =
+  CTI2.id-conceal-ok
+
 
 Λ-strip-prefix-p₂ : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}
@@ -6344,6 +6362,56 @@ record ΛTagRebaseChildPostPlan {Δᴸ Δᴿ Δ}
         ΛPostPrefixPackageAtBase.prefix-reduction prefix
     }
 
+Λ-post-prefix-conceal⊑²-source-ok-base : ∀ {Δᴸ Δᴿ Δ Δ₂}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {W₂ : CTI2.World Δᴸ (suc (suc Δᴿ)) Δ₂}
+    {Wᵖ₂ : CTI2.World Δᴸ (suc (suc Δᴿ)) Δ₂}
+    {γ : CTI2.CtxImp W} {γᵖ : CTI2.CtxImp Wᵖ}
+    {M : CT.Term Δᴸ} {V′ : CT.Term (suc Δᴿ)}
+    {A A′ : Ty Δᴸ} {B : Ty (suc Δᴿ)} {B′ : Ty Δᴿ}
+    {ν : Env∼ Δᴿ} {p₀ : A CTI2.⊑ᵂ⟨ Wᵖ ⟩ `∀ B}
+    {p : A′ CTI2.⊑ᵂ⟨ W ⟩ `∀ B}
+    {Xᴸ? Xᴿ?} {Xᴿ₂? : Maybe (Fin.Fin (suc (suc Δᴿ)))}
+    {c : Conv↓ Δᴸ A A′}
+    {ext₂ : ECR.WorldExtendᴿ
+      (bind ★ ∷ bind (＇ Fin.zero) ∷ []) W W₂}
+    {extᵖ₂ : ECR.WorldExtendᴿ
+      (bind ★ ∷ bind (＇ Fin.zero) ∷ []) Wᵖ Wᵖ₂}
+    {c′ : instᵐ ν ⊢ B ∼ ⇑ᵗ B′}
+    {prem : Wᵖ CTI2.∣ γᵖ ⊢² M ⊑ Λ V′ ∶ p₀}
+  → (ok : CTI2.SourceConcealOK Wᵖ M c Xᴿ? (Λ V′))
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → (sc : CTI2.SameCtx γ γᵖ)
+  → (c⊢ : CTI2.sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c)
+  → ⦃ Bnv : NonVar B ⦄
+  → ⦃ zero∈B : Fin.zero ∈ᵗ B ⦄
+  → (B′≢★ : B′ ≢ ★)
+  → CTI2.SourceConcealOK Wᵖ₂ M c Xᴿ₂?
+      (Λ⊑Λ²PostTerm V′ B)
+  → CTI2.ImpEnvMono W₂ Wᵖ₂
+  → CTI2.TagRebaseAtᴸ Wᵖ₂ W₂ Xᴸ? Xᴿ₂?
+  → CTI2.SameCtx (ECR.mapCtxᴿ ext₂ γ) (ECR.mapCtxᴿ extᵖ₂ γᵖ)
+  → CTI2.sourceStoreʷ W₂ CTI2.⊢↓[ Xᴸ? ] c
+  → (top-p₂ : A′ CTI2.⊑ᵂ⟨ W₂ ⟩ ΛResidualSource₂ B)
+  → ΛPostPrefixPackageAtBase prem extᵖ₂ c′ B′≢★
+  → ΛPostPrefixPackageAtBase
+      (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem p)
+      ext₂ c′ B′≢★
+Λ-post-prefix-conceal⊑²-source-ok-base ok mono rb sc c⊢ B′≢★
+    ok₂ mono₂ rb₂ sc₂ c⊢₂ top-p₂ prefix =
+  record
+    { prefix-p₂ = top-p₂
+    ; prefix-relation =
+        CTI2.conceal⊑²-source-ok ok₂ mono₂ rb₂ sc₂ c⊢₂
+          (ΛPostPrefixPackageAtBase.prefix-relation prefix)
+          top-p₂
+    ; prefix-value = ΛPostPrefixPackageAtBase.prefix-value prefix
+    ; prefix-reduction =
+        ΛPostPrefixPackageAtBase.prefix-reduction prefix
+    }
+
 
 Λ-post-prefix-hereditary : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}
@@ -6431,6 +6499,23 @@ record ΛTagRebaseChildPostPlan {Δᴸ Δᴿ Δ}
         ; postMono = post-mono ; postRebase = post-rb } =
   Λ-post-prefix-conceal⊑²-base ok mono rb sc c⊢ B′≢★
     post-source-conceal-partner-ok (post-mono mono) post-rb
+    (mapCtxᴿ-sameCtx (postExtend plan) (postExtend child) sc)
+    (TE.source-conceal-insert (ins₂ plan)
+      (TE.source-conceal-insert (ins₁ plan) c⊢))
+    (Λ-strip-prefix-p₂ plan q)
+    (Λ-post-prefix-hereditary child prem vM target-value c′ B′≢★)
+Λ-post-prefix-hereditary plan
+    rel@(CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem q)
+    (vM ↓ conceal-value) target-value c′ B′≢★
+    with Λ-two-insert-tag-rebase-child plan rb
+Λ-post-prefix-hereditary plan
+    rel@(CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem q)
+    (vM ↓ conceal-value) target-value c′ B′≢★
+    | record
+        { childPlan = child ; sameΔ₂ = refl
+        ; postMono = post-mono ; postRebase = post-rb } =
+  Λ-post-prefix-conceal⊑²-source-ok-base ok mono rb sc c⊢ B′≢★
+    (post-source-conceal-ok ok) (post-mono mono) post-rb
     (mapCtxᴿ-sameCtx (postExtend plan) (postExtend child) sc)
     (TE.source-conceal-insert (ins₂ plan)
       (TE.source-conceal-insert (ins₁ plan) c⊢))

--- a/GTSFImp/proof/DGG/Catchup/LeftValueCatchupDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftValueCatchupDef.agda
@@ -66,6 +66,12 @@ SourceCastBound fuel (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
 SourceCastBound fuel (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
   SourceCastBound fuel rel
 SourceCastBound fuel
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q) =
+  SourceCastBound fuel rel
+SourceCastBound fuel
     (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =
   SourceCastBound fuel rel
 SourceCastBound fuel

--- a/GTSFImp/proof/DGG/Catchup/LeftValueCatchupProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/LeftValueCatchupProof.agda
@@ -72,6 +72,12 @@ sourceCastBudget (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
 sourceCastBudget (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
   sourceCastBudget rel
 sourceCastBudget
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q) =
+  sourceCastBudget rel
+sourceCastBudget
     (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =
   sourceCastBudget rel
 sourceCastBudget
@@ -137,6 +143,13 @@ source-cast-bound< (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) budget< =
   source-cast-bound< rel budget<
 source-cast-bound< (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q)
     budget< =
+  source-cast-bound< rel budget<
+source-cast-bound<
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q)
+    budget< =
+  source-cast-bound< rel budget<
+source-cast-bound<
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q) budget< =
   source-cast-bound< rel budget<
 source-cast-bound<
     (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) budget< =
@@ -400,6 +413,13 @@ left-value-catchup-with-residuals residuals parked
   LeftValueCatchupResidualsAt.source-reveal-row residuals rel parked vV′ bound
 left-value-catchup-with-residuals residuals parked
     rel@(CTI2.conceal⊑² partner mono rb sameγ c⊢ prem q) vV′ bound =
+  LeftValueCatchupResidualsAt.source-conceal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ prem q)
+    vV′ bound =
+  LeftValueCatchupResidualsAt.source-conceal-row residuals rel parked vV′ bound
+left-value-catchup-with-residuals residuals parked
+    rel@(CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ prem q) vV′ bound =
   LeftValueCatchupResidualsAt.source-conceal-row residuals rel parked vV′ bound
 left-value-catchup-with-residuals residuals parked
     rel@(CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ prem q) vV′ bound =

--- a/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralCatchupRightDef.agda
@@ -8,7 +8,7 @@ module proof.DGG.Catchup.StructuralCatchupRightDef where
 --   * Keeps structural traces internal; no public fuel statement is widened.
 
 import Data.Fin as Fin
-open import Data.Maybe using (Maybe; just)
+open import Data.Maybe using (Maybe; just; nothing)
 open import Data.Nat using (ℕ; suc; _<_)
 open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Relation.Binary.PropositionalEquality
@@ -84,6 +84,16 @@ mapPivotChanges-just (keep ∷ χs) X =
   mapPivotChanges-just χs X
 mapPivotChanges-just (bind A ∷ χs) X =
   mapPivotChanges-just χs (toRenameᵗ wk↪ᵗ X)
+
+
+mapPivotChanges-nothing : ∀ {Δ Δ′}
+  → (χs : StoreChanges Δ Δ′)
+  → mapPivotChanges χs nothing ≡ nothing
+mapPivotChanges-nothing [] = refl
+mapPivotChanges-nothing (keep ∷ χs) =
+  mapPivotChanges-nothing χs
+mapPivotChanges-nothing (bind A ∷ χs) =
+  mapPivotChanges-nothing χs
 
 
 mapVarChanges-cong : ∀ {Δ Δ′}
@@ -1109,6 +1119,108 @@ structural-catchup-source-conceal {γ = γ} {q = q}
     ; final-relation =
         CTI2.conceal⊑²
           endpoint-partner
+          (mono′ mono) rb′
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-source-conceal plan c⊢)
+          (StructuralCatchupRightResult.final-relation child)
+          (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+    }
+
+
+structural-catchup-source-conceal-seal-star-open : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {B : Ty Δᴿ} {X : TyVar Δᴸ}
+    {p : ★ ⊑ᵂ⟨ Wᵖ ⟩ B} {q : (＇ X) ⊑ᵂ⟨ W ⟩ B}
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W (just X) nothing)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] seal X ★
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
+  → CTI2.NoTargetOccupantAtSource
+      (StructuralCatchupRightResult.W′ child) X
+  → StructuralCatchupRightResult W γ (M ↓ seal X ★) M′ q
+structural-catchup-source-conceal-seal-star-open
+    {γ = γ} {X = X} {q = q} mono rb sc c⊢ child no-target
+    with structural-tag-rebase-atᴸ-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-source-conceal-seal-star-open
+    {γ = γ} {X = X} {q = q} mono rb sc c⊢ child no-target
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+    ; final-value = StructuralCatchupRightResult.final-value child
+    ; post-reduction = StructuralCatchupRightResult.post-reduction child
+    ; final-relation =
+        CTI2.conceal⊑²-seal-star-open
+          no-target
+          (mono′ mono)
+          (subst≡
+            (λ Xᴿ? → CTI2.TagRebaseAtᴸ
+              (StructuralCatchupRightResult.W′ child) W′ (just X) Xᴿ?)
+            (mapPivotChanges-nothing
+              (StructuralCatchupRightResult.χs child))
+            rb′)
+          (mapCtxᴿ-sameCtx
+            (structural-world-extendᴿ plan)
+            (structural-world-extendᴿ
+              (StructuralCatchupRightResult.structural-ext child))
+            sc)
+          (structural-source-conceal plan c⊢)
+          (StructuralCatchupRightResult.final-relation child)
+          (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q)
+    }
+
+
+structural-catchup-source-conceal-source-ok : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : World Δᴸ Δᴿ Δ}
+    {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
+    {M : Term Δᴸ} {M′ : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ}
+    {Xᴸ? : Maybe (TyVar Δᴸ)} {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {c : Conv↓ Δᴸ A A′}
+    {p : A ⊑ᵂ⟨ Wᵖ ⟩ B} {q : A′ ⊑ᵂ⟨ W ⟩ B}
+  → CTI2.ImpEnvMono W Wᵖ
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c
+  → (child : StructuralCatchupRightResult Wᵖ γᵖ M M′ p)
+  → CTI2.SourceConcealOK
+      (StructuralCatchupRightResult.W′ child) M c
+      (mapPivotChanges (StructuralCatchupRightResult.χs child) Xᴿ?)
+      (StructuralCatchupRightResult.N′ child)
+  → StructuralCatchupRightResult W γ (M ↓ c) M′ q
+structural-catchup-source-conceal-source-ok {γ = γ} {q = q}
+    mono rb sc c⊢ child endpoint-ok
+    with structural-tag-rebase-atᴸ-pullback
+      (StructuralCatchupRightResult.structural-ext child) rb
+structural-catchup-source-conceal-source-ok {γ = γ} {q = q}
+    mono rb sc c⊢ child endpoint-ok
+    | record { W′ = W′ ; outer-plan = plan
+             ; post-rebase = rb′ ; post-mono = mono′ } =
+  record
+    { Δᴿ′ = StructuralCatchupRightResult.Δᴿ′ child
+    ; χs = StructuralCatchupRightResult.χs child
+    ; Δ′ = StructuralCatchupRightResult.Δ′ child
+    ; W′ = W′
+    ; structural-ext = plan
+    ; N′ = StructuralCatchupRightResult.N′ child
+    ; final-value = StructuralCatchupRightResult.final-value child
+    ; post-reduction = StructuralCatchupRightResult.post-reduction child
+    ; final-relation =
+        CTI2.conceal⊑²-source-ok
+          endpoint-ok
           (mono′ mono) rb′
           (mapCtxᴿ-sameCtx
             (structural-world-extendᴿ plan)

--- a/GTSFImp/proof/DGG/Catchup/StructuralNameInstantiationProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralNameInstantiationProof.agda
@@ -180,6 +180,10 @@ derivSize (CTI2.reveal⊑² mono rb sc c⊢ rel q) =
   suc (suc (derivSize rel))
 derivSize (CTI2.conceal⊑² ok mono rb sc c⊢ rel q) =
   suc (suc (derivSize rel))
+derivSize (CTI2.conceal⊑²-seal-star-open no-target mono rb sc c⊢ rel q) =
+  suc (suc (derivSize rel))
+derivSize (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ rel q) =
+  suc (suc (derivSize rel))
 derivSize (CTI2.reveal⊑reveal² mono rb sc c⊢ c⊢′ rel q) =
   suc (suc (derivSize rel))
 derivSize (CTI2.conceal⊑conceal² ok mono rb sc c⊢ c⊢′ rel q) =

--- a/GTSFImp/proof/DGG/Catchup/StructuralNameInstantiationProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralNameInstantiationProof.agda
@@ -1731,6 +1731,59 @@ mutual
           (measure-source< (n<1+n (suc (derivSize prem)))))
         (structural-target-tag-rebase-left rb target))
   structural-name-instantiation-acc surfaces fuel-step residual-cast-builder
+      inst-decrease plan chain-plan
+      (CTI2.conceal⊑²-seal-star-open {X = Xᴸ} no-target mono rb sc
+        c⊢ prem q)
+      (vU CT.↓ cv) vN view spine chain typed (WF.acc smaller) target
+      with StructuralNamePostPlan.conceal-child plan
+             {c = Conv.seal Xᴸ ★} rb
+         | StructuralNameChainPlan.conceal-child chain-plan
+             {c = Conv.seal Xᴸ ★} rb sc chain typed
+  structural-name-instantiation-acc surfaces {B = B} {X = X}
+      fuel-step residual-cast-builder inst-decrease plan chain-plan
+      (CTI2.conceal⊑²-seal-star-open {X = Xᴸ} no-target mono rb sc
+        c⊢ prem q)
+      (vU CT.↓ cv) vN view spine chain typed (WF.acc smaller) target
+      | q₀ , child-plan
+      | child-chain , (child-typed , child-chain-plan) =
+    structural-conceal-seal-star-open-replay
+      (StructuralTargetInstantiationPackage.structural-ext target)
+      mono rb sc c⊢
+      (StructuralStrictViewSurfaces.conceal-equal-no-target surfaces
+        rb no-target spine target)
+      (structural-value-spine-instantiation-acc surfaces fuel-step
+        residual-cast-builder inst-decrease child-plan child-chain-plan
+        prem vU vN (name-type-app-frame B X refl refl ▻ⁱ spine)
+        child-chain child-typed
+        (smaller
+          (measure-source< (n<1+n (suc (derivSize prem)))))
+        (structural-target-tag-rebase-left rb target))
+  structural-name-instantiation-acc surfaces fuel-step residual-cast-builder
+      inst-decrease plan chain-plan
+      (CTI2.conceal⊑²-source-ok {c = c} ok mono rb sc c⊢ prem q)
+      (vU CT.↓ cv) vN view spine chain typed (WF.acc smaller) target
+      with StructuralNamePostPlan.conceal-child plan {c = c} rb
+         | StructuralNameChainPlan.conceal-child chain-plan {c = c} rb sc
+             chain typed
+  structural-name-instantiation-acc surfaces {B = B} {X = X}
+      fuel-step residual-cast-builder inst-decrease plan chain-plan
+      (CTI2.conceal⊑²-source-ok {c = c} ok mono rb sc c⊢ prem q)
+      (vU CT.↓ cv) vN view spine chain typed (WF.acc smaller) target
+      | q₀ , child-plan
+      | child-chain , (child-typed , child-chain-plan) =
+    structural-conceal-source-ok-replay
+      (StructuralTargetInstantiationPackage.structural-ext target)
+      mono rb sc c⊢
+      (StructuralStrictViewSurfaces.conceal-equal-source-ok surfaces rb ok
+        spine target)
+      (structural-value-spine-instantiation-acc surfaces fuel-step
+        residual-cast-builder inst-decrease child-plan child-chain-plan
+        prem vU vN (name-type-app-frame B X refl refl ▻ⁱ spine)
+        child-chain child-typed
+        (smaller
+          (measure-source< (n<1+n (suc (derivSize prem)))))
+        (structural-target-tag-rebase-left rb target))
+  structural-name-instantiation-acc surfaces fuel-step residual-cast-builder
       inst-decrease plan chain-plan rel vM (CT.Λ vV)
       (allv-Λ vV′ refl) spine chain typed (WF.acc smaller) target
       with structural-target-Λ-peel vV spine target

--- a/GTSFImp/proof/DGG/Catchup/StructuralSourceRebaseReplayProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralSourceRebaseReplayProof.agda
@@ -5,6 +5,8 @@ module proof.DGG.Catchup.StructuralSourceRebaseReplayProof where
 --   * Uses transformed rebases, contexts, typing, and monotonicity evidence.
 
 open import Data.Maybe using (Maybe)
+open import Relation.Binary.PropositionalEquality using (sym)
+  renaming (subst to subst≡)
 
 open import Types using (Ty; TyVar)
 open import Conversion using (Conv↑; Conv↓)
@@ -18,6 +20,8 @@ open import proof.DGG.Catchup.StructuralWorldRebaseProof
 open import proof.DGG.Catchup.StructuralWorldTagRebaseDef
 open import proof.DGG.Catchup.StructuralWorldTagRebaseProof
 open import proof.DGG.Catchup.StructuralWorldEvidenceProof
+open import proof.DGG.Catchup.StructuralCatchupRightDef using
+  (mapPivotChanges-nothing)
 
 
 structural-reveal-replay : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -90,6 +94,90 @@ structural-conceal-replay plan mono rb sc c⊢ ok rel
     | record { premise-plan = planᵖ ; post-rebase = rb′
              ; post-mono = mono′ } =
   CTI2.conceal⊑² ok (mono′ mono) rb′
+    (mapCtxᴿ-sameCtx
+      (structural-world-extendᴿ plan)
+      (structural-world-extendᴿ planᵖ) sc)
+    (structural-source-conceal plan c⊢) rel
+    (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) _)
+
+
+structural-conceal-source-ok-replay : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {γ : CTI2.CtxImp W} {γᵖ : CTI2.CtxImp Wᵖ}
+    {M : Term Δᴸ} {F : Term Δᴿ′}
+    {A A′ : Ty Δᴸ} {B : Ty Δᴿ} {Xᴸ? Xᴿ?}
+    {c : Conv↓ Δᴸ A A′}
+    {p : A CTI2.⊑ᵂ⟨ Wᵖ ⟩ B}
+    {q : A′ CTI2.⊑ᵂ⟨ W ⟩ B}
+  → (plan : StructuralWorldExtendᴿ χs W W′)
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ Xᴸ? ] c
+  → let child = structural-tag-rebase-atᴸ plan rb
+        planᵖ = StructuralTagRebaseAtᴸResult.premise-plan child
+     in CTI2.SourceConcealOK
+          (StructuralTagRebaseAtᴸResult.Wᵖ′ child) M c
+          (mapPivotChanges χs Xᴿ?) F
+        → StructuralTagRebaseAtᴸResult.Wᵖ′ child CTI2.∣
+            ECR.mapCtxᴿ (structural-world-extendᴿ planᵖ) γᵖ
+            ⊢² M ⊑ F ∶
+              ECR.transport⊑ᵂ (structural-world-extendᴿ planᵖ) p
+        → W′ CTI2.∣ ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+            ⊢² M ↓ c ⊑ F ∶
+              ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q
+structural-conceal-source-ok-replay plan mono rb sc c⊢ ok rel
+    with structural-tag-rebase-atᴸ plan rb
+structural-conceal-source-ok-replay plan mono rb sc c⊢ ok rel
+    | record { premise-plan = planᵖ ; post-rebase = rb′
+             ; post-mono = mono′ } =
+  CTI2.conceal⊑²-source-ok ok (mono′ mono) rb′
+    (mapCtxᴿ-sameCtx
+      (structural-world-extendᴿ plan)
+      (structural-world-extendᴿ planᵖ) sc)
+    (structural-source-conceal plan c⊢) rel
+    (ECR.transport⊑ᵂ (structural-world-extendᴿ plan) _)
+
+
+structural-conceal-seal-star-open-replay : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {χs : StoreChanges Δᴿ Δᴿ′}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {γ : CTI2.CtxImp W} {γᵖ : CTI2.CtxImp Wᵖ}
+    {M : Term Δᴸ} {F : Term Δᴿ′}
+    {B : Ty Δᴿ} {X : TyVar Δᴸ}
+    {p : Types.★ CTI2.⊑ᵂ⟨ Wᵖ ⟩ B}
+    {q : Types.＇ X CTI2.⊑ᵂ⟨ W ⟩ B}
+  → (plan : StructuralWorldExtendᴿ χs W W′)
+  → (mono : CTI2.ImpEnvMono W Wᵖ)
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W (Data.Maybe.just X) Data.Maybe.nothing)
+  → CTI2.SameCtx γ γᵖ
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ Data.Maybe.just X ]
+      Conversion.seal X Types.★
+  → let child = structural-tag-rebase-atᴸ plan rb
+        planᵖ = StructuralTagRebaseAtᴸResult.premise-plan child
+     in CTI2.NoTargetOccupantAtSource
+          (StructuralTagRebaseAtᴸResult.Wᵖ′ child) X
+        → StructuralTagRebaseAtᴸResult.Wᵖ′ child CTI2.∣
+            ECR.mapCtxᴿ (structural-world-extendᴿ planᵖ) γᵖ
+            ⊢² M ⊑ F ∶
+              ECR.transport⊑ᵂ (structural-world-extendᴿ planᵖ) p
+        → W′ CTI2.∣ ECR.mapCtxᴿ (structural-world-extendᴿ plan) γ
+            ⊢² M ↓ Conversion.seal X Types.★ ⊑ F ∶
+              ECR.transport⊑ᵂ (structural-world-extendᴿ plan) q
+structural-conceal-seal-star-open-replay {χs = χs}
+    plan mono rb sc c⊢ no-target rel
+    with structural-tag-rebase-atᴸ plan rb
+structural-conceal-seal-star-open-replay {χs = χs}
+    plan mono rb sc c⊢ no-target rel
+    | record { premise-plan = planᵖ ; post-rebase = rb′
+             ; post-mono = mono′ } =
+  CTI2.conceal⊑²-seal-star-open no-target (mono′ mono)
+    (subst≡
+      (λ Xᴿ? → CTI2.TagRebaseAtᴸ _ _ (Data.Maybe.just _) Xᴿ?)
+      (mapPivotChanges-nothing χs) rb′)
     (mapCtxᴿ-sameCtx
       (structural-world-extendᴿ plan)
       (structural-world-extendᴿ planᵖ) sc)

--- a/GTSFImp/proof/DGG/Catchup/StructuralStrictViewSurfaceDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralStrictViewSurfaceDef.agda
@@ -8,6 +8,7 @@ module proof.DGG.Catchup.StructuralStrictViewSurfaceDef where
 --     and target-frame absorption chain needed by the structural worker.
 
 import Data.Fin as Fin
+open import Data.Maybe using (just; nothing)
 open import Data.Nat using (ℕ; suc)
 open import Data.Product using (Σ-syntax; _×_)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; _≢_)
@@ -59,6 +60,46 @@ StructuralNameConcealEqualOKᵀ =
           (mapPivotChanges
             (StructuralTargetInstantiationPackage.χs target) Xᴿ?)
           (StructuralTargetInstantiationPackage.final target)
+
+
+StructuralNameConcealEqualSourceOKᵀ : Set₁
+StructuralNameConcealEqualSourceOKᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {U : Term Δᴸ} {V : Term Δᴿ}
+    {A A′ : Ty Δᴸ} {B : Ty (suc Δᴿ)}
+    {E : Ty Δᴿ} {X : TyVar Δᴿ} {Xᴸ? Xᴿ?}
+    {c : Conv↓ Δᴸ A A′}
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?)
+  → CTI2.SourceConcealOK Wᵖ U c Xᴿ? V
+  → (spine : InstantiationSpine (B [ ＇ X ]ᵗ) E)
+  → (target : StructuralTargetInstantiationPackage W V
+      (name-type-app-frame B X refl refl ▻ⁱ spine))
+  → let child = structural-tag-rebase-atᴸ
+          (StructuralTargetInstantiationPackage.structural-ext target) rb
+     in CTI2.SourceConcealOK
+          (StructuralTagRebaseAtᴸResult.Wᵖ′ child) U c
+          (mapPivotChanges
+            (StructuralTargetInstantiationPackage.χs target) Xᴿ?)
+          (StructuralTargetInstantiationPackage.final target)
+
+
+StructuralNameConcealEqualNoTargetᵀ : Set₁
+StructuralNameConcealEqualNoTargetᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {V : Term Δᴿ}
+    {B : Ty (suc Δᴿ)} {E : Ty Δᴿ}
+    {X : TyVar Δᴿ} {Xᴸ : TyVar Δᴸ}
+  → (rb : CTI2.TagRebaseAtᴸ Wᵖ W (just Xᴸ) nothing)
+  → CTI2.NoTargetOccupantAtSource Wᵖ Xᴸ
+  → (spine : InstantiationSpine (B [ ＇ X ]ᵗ) E)
+  → (target : StructuralTargetInstantiationPackage W V
+      (name-type-app-frame B X refl refl ▻ⁱ spine))
+  → let child = structural-tag-rebase-atᴸ
+          (StructuralTargetInstantiationPackage.structural-ext target) rb
+     in CTI2.NoTargetOccupantAtSource
+          (StructuralTagRebaseAtᴸResult.Wᵖ′ child) Xᴸ
 
 
 record StructuralStrictChild {fuel : ℕ} {Δᴸ Δᴿ Δ}
@@ -289,6 +330,8 @@ StructuralConcealStrictSurfaceᵀ =
 record StructuralStrictViewSurfaces : Set₁ where
   field
     conceal-equal-ok : StructuralNameConcealEqualOKᵀ
+    conceal-equal-source-ok : StructuralNameConcealEqualSourceOKᵀ
+    conceal-equal-no-target : StructuralNameConcealEqualNoTargetᵀ
     Λ-cell : StructuralΛStrictSurfaceᵀ
     ∀-cast-cell : StructuralAllCastStrictSurfaceᵀ
     gen-cell : StructuralGenStrictSurfaceᵀ

--- a/GTSFImp/proof/DGG/Catchup/StructuralValueInstantiationViewProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralValueInstantiationViewProof.agda
@@ -41,6 +41,14 @@ value-type-app-source-view
     (CTI2.conceal⊑² ok mono rb sc c⊢ prem q)
     (vV′ CastTerms.↓ cv) =
   type-app-source-conceal vV′ cv
+value-type-app-source-view
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sc c⊢ prem q)
+    (vV′ CastTerms.↓ cv) =
+  type-app-source-conceal vV′ cv
+value-type-app-source-view
+    (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem q)
+    (vV′ CastTerms.↓ cv) =
+  type-app-source-conceal vV′ cv
 
 
 no-value-source-type-app : ∀ {Δᴸ Δᴿ Δ}
@@ -65,5 +73,13 @@ no-value-source-type-app (CTI2.reveal⊑² mono rb sc c⊢ prem q)
   no-value-source-type-app prem vV
 no-value-source-type-app
     (CTI2.conceal⊑² ok mono rb sc c⊢ prem q)
+    (vV CastTerms.↓ cv) =
+  no-value-source-type-app prem vV
+no-value-source-type-app
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sc c⊢ prem q)
+    (vV CastTerms.↓ cv) =
+  no-value-source-type-app prem vV
+no-value-source-type-app
+    (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem q)
     (vV CastTerms.↓ cv) =
   no-value-source-type-app prem vV

--- a/GTSFImp/proof/DGG/Catchup/TagLayerExtractionProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/TagLayerExtractionProof.agda
@@ -240,4 +240,60 @@ extract-tag-layer (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q)
       CTI2.conceal⊑² partner mono rb sameγ c⊢
         (TagLayerExtraction.replay-tag child rel′) q
   }
+extract-tag-layer
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q)
+    (vM ↓ cv) vM′ view
+    with extract-tag-layer rel vM vM′ view
+extract-tag-layer
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q)
+    (vM ↓ cv) vM′ view
+    | child = record
+  { Δᴸ₀ = TagLayerExtraction.Δᴸ₀ child
+  ; Δ₀ = TagLayerExtraction.Δ₀ child
+  ; W₀ = TagLayerExtraction.W₀ child
+  ; γ₀ = TagLayerExtraction.γ₀ child
+  ; M₀ = TagLayerExtraction.M₀ child
+  ; A₀ = TagLayerExtraction.A₀ child
+  ; G = TagLayerExtraction.G child
+  ; μ = TagLayerExtraction.μ child
+  ; Gᵍ = TagLayerExtraction.Gᵍ child
+  ; G∼★ = TagLayerExtraction.G∼★ child
+  ; Gns = TagLayerExtraction.Gns child
+  ; N = TagLayerExtraction.N child
+  ; N-value = TagLayerExtraction.N-value child
+  ; target-eq = TagLayerExtraction.target-eq child
+  ; qG = TagLayerExtraction.qG child
+  ; core-relation = TagLayerExtraction.core-relation child
+  ; replay-tag = λ rel′ →
+      CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢
+        (TagLayerExtraction.replay-tag child rel′) q
+  }
+extract-tag-layer
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q)
+    (vM ↓ cv) vM′ view
+    with extract-tag-layer rel vM vM′ view
+extract-tag-layer
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q)
+    (vM ↓ cv) vM′ view
+    | child = record
+  { Δᴸ₀ = TagLayerExtraction.Δᴸ₀ child
+  ; Δ₀ = TagLayerExtraction.Δ₀ child
+  ; W₀ = TagLayerExtraction.W₀ child
+  ; γ₀ = TagLayerExtraction.γ₀ child
+  ; M₀ = TagLayerExtraction.M₀ child
+  ; A₀ = TagLayerExtraction.A₀ child
+  ; G = TagLayerExtraction.G child
+  ; μ = TagLayerExtraction.μ child
+  ; Gᵍ = TagLayerExtraction.Gᵍ child
+  ; G∼★ = TagLayerExtraction.G∼★ child
+  ; Gns = TagLayerExtraction.Gns child
+  ; N = TagLayerExtraction.N child
+  ; N-value = TagLayerExtraction.N-value child
+  ; target-eq = TagLayerExtraction.target-eq child
+  ; qG = TagLayerExtraction.qG child
+  ; core-relation = TagLayerExtraction.core-relation child
+  ; replay-tag = λ rel′ →
+      CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢
+        (TagLayerExtraction.replay-tag child rel′) q
+  }
 extract-tag-layer (CTI2.blame⊑² M′⊢ p) () vM′ view

--- a/GTSFImp/proof/DGG/Catchup/TargetCastStepInversionProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/TargetCastStepInversionProof.agda
@@ -243,6 +243,25 @@ source-conceal-partner-target-id-core a CTI2.id-conceal-target =
   CTI2.id-conceal-target
 
 
+source-conceal-ok-target-id-core : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {P : Term Δᴸ}
+    {A A′ : Ty Δᴸ} {c : Conv↓ Δᴸ A A′}
+    {Xᴿ? : Maybe (TyVar Δᴿ)}
+    {M′ : Term Δᴿ} {B : Ty Δᴿ} {ν : Env∼ Δᴿ}
+  → (a : Atom B)
+  → CTI2.SourceConcealOK W P c Xᴿ? (M′ ⟨ id {μ = ν} a ⟩)
+  → CTI2.SourceConcealOK W P c Xᴿ? M′
+source-conceal-ok-target-id-core a
+    (CTI2.seal-nonstar-plain-ok Rns nt) =
+  ⊥-elim (not-top-id-cast-impossible a nt)
+source-conceal-ok-target-id-core a CTI2.fun-conceal-ok =
+  CTI2.fun-conceal-ok
+source-conceal-ok-target-id-core a CTI2.all-conceal-ok =
+  CTI2.all-conceal-ok
+source-conceal-ok-target-id-core a CTI2.id-conceal-ok =
+  CTI2.id-conceal-ok
+
+
 rep★-target-id-framed-core : ∀ {Δᴸ Δᴿ Δ}
     {W : World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
     {P : Term Δᴸ} {Xᴿ? : Maybe (TyVar Δᴿ)}
@@ -397,6 +416,18 @@ target-id-step-inversion {M′ = M′} a (vM ↓ cv) vM′
     (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
   CTI2.conceal⊑²
     (source-conceal-partner-target-id-core a partner)
+    mono rb sameγ c⊢
+    (target-id-step-inversion {M′ = M′} a vM vM′ rel) q
+target-id-step-inversion {M′ = M′} a (vM ↓ cv) vM′
+    (CTI2.conceal⊑²-seal-star-open
+      no-target mono rb sameγ c⊢ rel q) =
+  CTI2.conceal⊑²-seal-star-open
+    no-target mono rb sameγ c⊢
+    (target-id-step-inversion {M′ = M′} a vM vM′ rel) q
+target-id-step-inversion {M′ = M′} a (vM ↓ cv) vM′
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q) =
+  CTI2.conceal⊑²-source-ok
+    (source-conceal-ok-target-id-core a ok)
     mono rb sameγ c⊢
     (target-id-step-inversion {M′ = M′} a vM vM′ rel) q
 

--- a/GTSFImp/proof/DGG/Catchup/ValueCatchupRightDef.agda
+++ b/GTSFImp/proof/DGG/Catchup/ValueCatchupRightDef.agda
@@ -76,6 +76,12 @@ TargetCastBound fuel (CTI2.reveal⊑² mono rb sameγ c⊢ rel q) =
 TargetCastBound fuel (CTI2.conceal⊑² partner mono rb sameγ c⊢ rel q) =
   TargetCastBound fuel rel
 TargetCastBound fuel
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb sameγ c⊢ rel q) =
+  TargetCastBound fuel rel
+TargetCastBound fuel
+    (CTI2.conceal⊑²-source-ok ok mono rb sameγ c⊢ rel q) =
+  TargetCastBound fuel rel
+TargetCastBound fuel
     (CTI2.reveal⊑reveal² mono rb sameγ c⊢ c′⊢ rel q) =
   TargetCastBound fuel rel
 TargetCastBound fuel

--- a/GTSFImp/proof/DGG/CenterRename.agda
+++ b/GTSFImp/proof/DGG/CenterRename.agda
@@ -735,6 +735,27 @@ renameSourceConcealPartnerOK π CTI2.all-conceal-target =
 renameSourceConcealPartnerOK π CTI2.id-conceal-target =
   CTI2.id-conceal-target
 
+renameSourceConcealOK : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {M : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′} {Xᴿ? M′}
+  → (π : Δ ↪ᵗ Δ′)
+  → CTI2.SourceConcealOK W M c Xᴿ? M′
+  → CTI2.SourceConcealOK (renameWorld π W) M c Xᴿ? M′
+renameSourceConcealOK π
+    (CTI2.seal-nonstar-plain-ok Rns nt) =
+  CTI2.seal-nonstar-plain-ok Rns nt
+renameSourceConcealOK π
+    (CTI2.seal-nonstar-name-protected-ok Rns aligned) =
+  CTI2.seal-nonstar-name-protected-ok Rns
+    (rename-embedding-eq π aligned)
+renameSourceConcealOK π CTI2.fun-conceal-ok =
+  CTI2.fun-conceal-ok
+renameSourceConcealOK π CTI2.all-conceal-ok =
+  CTI2.all-conceal-ok
+renameSourceConcealOK π CTI2.id-conceal-ok =
+  CTI2.id-conceal-ok
+
 renameMatchedConcealPartnerOK : ∀ {Δᴸ Δᴿ Δ Δ′}
     {W : CTI2.World Δᴸ Δᴿ Δ}
     {M : Term Δᴸ} {A A′ : Ty Δᴸ}
@@ -1110,6 +1131,25 @@ renameSmartFreshBehindGuard {Δᴸ = Δᴸ} {Δᴿ = Δᴿ}
 ⊢²-rename-center {W = W} π
     (CTI2.conceal⊑² {W′ = W′} {p = p} ok mono rb sc c⊢ M⊑N q) p′ =
   CTI2.conceal⊑² (renameSourceConcealPartnerOK π ok)
+    (renameImpEnvMono {W = W} {W′ = W′} π mono)
+    (renameTagRebaseAtᴸ {W = W′} {W′ = W} π rb)
+    (renameSameCtx {W = W} {W′ = W′} π sc) c⊢
+    (⊢²-rename-center {W = W′} π M⊑N
+      (rename-⊑ᵂ {W = W′} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.conceal⊑²-seal-star-open {W′ = W′} {p = p}
+      no-target mono rb sc c⊢ M⊑N q) p′ =
+  CTI2.conceal⊑²-seal-star-open
+    (renameNoTargetOccupantAtSource {W = W′} π no-target)
+    (renameImpEnvMono {W = W} {W′ = W′} π mono)
+    (renameTagRebaseAtᴸ {W = W′} {W′ = W} π rb)
+    (renameSameCtx {W = W} {W′ = W′} π sc) c⊢
+    (⊢²-rename-center {W = W′} π M⊑N
+      (rename-⊑ᵂ {W = W′} π p)) p′
+⊢²-rename-center {W = W} π
+    (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p}
+      ok mono rb sc c⊢ M⊑N q) p′ =
+  CTI2.conceal⊑²-source-ok (renameSourceConcealOK π ok)
     (renameImpEnvMono {W = W} {W′ = W′} π mono)
     (renameTagRebaseAtᴸ {W = W′} {W′ = W} π rb)
     (renameSameCtx {W = W} {W′ = W′} π sc) c⊢

--- a/GTSFImp/proof/DGG/ChainRideProbe.agda
+++ b/GTSFImp/proof/DGG/ChainRideProbe.agda
@@ -201,11 +201,8 @@ probe-base² =
 probe-occupied-Z₃ : CTI2.NoTargetOccupantAtSource W₂ Z₃ → ⊥
 probe-occupied-Z₃ no-target = no-target (Y , refl)
 
-probe-direct-premise-partner-empty :
-  CTI2.SourceConcealPartnerOK W₂ V₀ (seal Z₃ ★) (just Y) U
+probe-direct-premise-source-ok-empty :
+  CTI2.SourceConcealOK W₂ V₀ (seal Z₃ ★) (just Y) U
   → ⊥
-probe-direct-premise-partner-empty
-    (CTI2.seal-partner-ok (CTI2.star-rep-target no-target _)) =
-  probe-occupied-Z₃ no-target
-probe-direct-premise-partner-empty
-    (CTI2.seal-partner-ok (CTI2.plain-target ()))
+probe-direct-premise-source-ok-empty
+    (CTI2.seal-nonstar-plain-ok () _)

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -2099,14 +2099,14 @@ left-path-argument₄-base =
     (κ⊑κ² (κℕ 7) (ℕ⊑ℕ² {W = left-path-world₄-YZ}))
     left-path-ℕ⊑★₄-YZ
 
-left-path-argument₄-old-wrapper-empty : ∀ {P}
+left-path-argument₄-source-ok-empty : ∀ {P}
   →
-  CTI2.SourceConcealPartnerOK left-path-world₄-YZ
+  CTI2.SourceConcealOK left-path-world₄-YZ
     P example12-target-X-seal nothing
     (($ (κℕ 7)) ⟨ left-path-ℕ!₂ ⟩)
   → ⊥
-left-path-argument₄-old-wrapper-empty
-    (CTI2.seal-partner-ok (CTI2.plain-target ()))
+left-path-argument₄-source-ok-empty
+    (CTI2.seal-nonstar-plain-ok _ ())
 
 left-path-argument₄ :
   left-path-world₄-YZ ∣ [] ⊢² $ (κℕ 7)

--- a/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
@@ -236,6 +236,13 @@ repaired-seal-partner-empty : ∀ {Wᵖ : World 2 1 2} {P Xᴿ?}
 repaired-seal-partner-empty
     (CTI2.seal-partner-ok (CTI2.plain-target ()))
 
+repaired-seal-ok-empty : ∀ {Wᵖ : World 2 1 2} {P Xᴿ?}
+  → CTI2.SourceConcealOK Wᵖ P (seal U (‵ `ℕ)) Xᴿ?
+    (($ (κℕ 0)) ⟨ ℕ! ⟩)
+  → ⊥
+repaired-seal-ok-empty
+    (CTI2.seal-nonstar-plain-ok Rns ())
+
 repaired-seal²-empty′ : ∀ {X}
   → (q : ＇ X ⊑ᵂ⟨ pre-worldᵈ ⟩ ★)
   → pre-worldᵈ ∣ [] ⊢²
@@ -248,6 +255,9 @@ repaired-seal²-empty′ (X⊑★ eq)
 repaired-seal²-empty′ q₀
     (CTI2.conceal⊑² ok mono rb sc c⊢ D .q₀) =
   repaired-seal-partner-empty ok
+repaired-seal²-empty′ q₀
+    (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ D .q₀) =
+  repaired-seal-ok-empty ok
 
 repaired-seal²-empty :
   pre-worldᵈ ∣ [] ⊢²

--- a/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
+++ b/GTSFImp/proof/DGG/ExtraCastRight2Counterexample.agda
@@ -229,13 +229,6 @@ repaired-base² : pre-worldᵈ ∣ [] ⊢²
     $ (κℕ 0) ⊑ $ (κℕ 0) ⟨ ℕ! ⟩ ∶ ι⊑★
 repaired-base² = CTI2.⊑cast² ℕ! (CTI2.κ⊑κ² (κℕ 0) ι⊑ι) ι⊑★
 
-repaired-seal-partner-empty : ∀ {Wᵖ : World 2 1 2} {P Xᴿ?}
-  → CTI2.SourceConcealPartnerOK Wᵖ P (seal U (‵ `ℕ)) Xᴿ?
-    (($ (κℕ 0)) ⟨ ℕ! ⟩)
-  → ⊥
-repaired-seal-partner-empty
-    (CTI2.seal-partner-ok (CTI2.plain-target ()))
-
 repaired-seal-ok-empty : ∀ {Wᵖ : World 2 1 2} {P Xᴿ?}
   → CTI2.SourceConcealOK Wᵖ P (seal U (‵ `ℕ)) Xᴿ?
     (($ (κℕ 0)) ⟨ ℕ! ⟩)
@@ -253,8 +246,9 @@ repaired-seal²-empty′ q₀
 repaired-seal²-empty′ (X⊑★ eq)
     (CTI2.⊑cast² {p = p} c′ D .(X⊑★ eq)) | ()
 repaired-seal²-empty′ q₀
-    (CTI2.conceal⊑² ok mono rb sc c⊢ D .q₀) =
-  repaired-seal-partner-empty ok
+    (CTI2.conceal⊑²
+      (CTI2.seal-partner-ok (CTI2.plain-target ()))
+      mono rb sc c⊢ D .q₀)
 repaired-seal²-empty′ q₀
     (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ D .q₀) =
   repaired-seal-ok-empty ok

--- a/GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda
+++ b/GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda
@@ -77,6 +77,15 @@ module _
     (target-source-star-chain : TargetSourceStarChain)
     where
 
+  right-var-obligation-nonstar : ∀ {Δᴸ Δᴿ Δ}
+      {W : World Δᴸ Δᴿ Δ} {R : Ty Δᴸ} {Y : TyVar Δᴿ}
+    → R ⊑ᵂ⟨ W ⟩ (＇ Y)
+    → NonStar R
+  right-var-obligation-nonstar {W = W} {R = R} {Y = Y} p
+      with SPT.right-var-obligation-view {W = W} {R = R} {Y = Y} p
+  right-var-obligation-nonstar p | X₂ , refl , aligned =
+    nonstar-X
+
   right-inj-reveal-all-id² : ∀ {Δᴸ Δᴿ Δ}
       {W : World Δᴸ Δᴿ Δ} {γ γ′ : CtxImp W}
       {V : Term Δᴸ} {N : Term Δᴿ}
@@ -770,9 +779,11 @@ module _
       (CTI2.conceal⊑² {W′ = W′} {p = p₀} ok mono rb sc
         (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
       | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
-      | CTI2.⊑cast² c′ prem₂ .p₀ =
-    CTI2.conceal⊑² (CTI2.seal-partner-ok
-        (CTI2.plain-target CTI2.not-↓))
+      | CTI2.⊑cast² {p = p₂} c′ prem₂ .p₀ =
+    CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-plain-ok
+        (right-var-obligation-nonstar {W = W′} {R = R} {Y = Y} p₂)
+        CTI2.not-↓)
       mono rb sc (CTI2.⊢↓-sealˣ Xᴸ∈) prem₂ q
   right-inj-inversion² {W = W} {gH = ＇ Y}
       (sv-seal {X = Xᴸ} {R = `∀ A} (sv-Λ sv₀)) vN
@@ -863,8 +874,8 @@ module _
       | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
       | CTI2.cast⊑cast² {p = p₂} c c′ prem₂ .p₀
       | X₂ , refl , aligned | inj₁ refl =
-    CTI2.conceal⊑² (CTI2.seal-partner-ok
-        (CTI2.plain-target CTI2.not-↓))
+    CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-plain-ok nonstar-X CTI2.not-↓)
       mono rb sc (CTI2.⊢↓-sealˣ Xᴸ∈)
       (CTI2.cast⊑² c prem₂ p₂) q
   right-inj-inversion² {W = W} {gH = ＇ Y}

--- a/GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda
+++ b/GTSFImp/proof/DGG/Inversion/RightInjInversion2Proof.agda
@@ -391,12 +391,25 @@ module _
     CTI2.conceal⊑² CTI2.fun-conceal-target mono
       (CTI2.tag-rebase-varᴸ rb) sc ⊢c
       (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB)) (⇒⊑⇒ qA qB)
+  right-inj-inversion² {gH = ★⇒★} (sv-conceal-fun sv)
+      vN (CTI2.conceal⊑²-source-ok {p = ⇒⊑★ pA pB} ok mono
+        rb sc ⊢c prem q₀)
+      (⇒⊑⇒ qA qB) =
+    CTI2.conceal⊑²-source-ok CTI2.fun-conceal-ok mono rb sc ⊢c
+      (right-inj-inversion² sv vN prem (⇒⊑⇒ pA pB))
+      (⇒⊑⇒ qA qB)
   right-inj-inversion² {gH = ＇ Y} (sv-conceal-fun sv)
     vN (CTI2.conceal⊑² _ _ _ _ _ _ _) ()
+  right-inj-inversion² {gH = ＇ Y} (sv-conceal-fun sv)
+    vN (CTI2.conceal⊑²-source-ok _ _ _ _ _ _ _) ()
   right-inj-inversion² {gH = ‵ ι} (sv-conceal-fun sv)
     vN (CTI2.conceal⊑² _ _ _ _ _ _ _) ()
+  right-inj-inversion² {gH = ‵ ι} (sv-conceal-fun sv)
+    vN (CTI2.conceal⊑²-source-ok _ _ _ _ _ _ _) ()
   right-inj-inversion² {gH = ∀★} (sv-conceal-fun sv)
     vN (CTI2.conceal⊑² _ _ _ _ _ _ _) ()
+  right-inj-inversion² {gH = ∀★} (sv-conceal-fun sv)
+    vN (CTI2.conceal⊑²-source-ok _ _ _ _ _ _ _) ()
 
   -- Universal reveal: transport the requested tag obligation through the
   -- body conversion.  Variable rebases recurse in the honestified world.
@@ -573,6 +586,103 @@ module _
         (toRenameᵗ-injective (ηᴸʷ W′))
         (toRenameᵗ-injective (ηᴸʷ W))
         p₀ q)
+  right-inj-inversion² {W = W} {H = H} (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono CTI2.tag-rebase-idᴸ sc
+        (CTI2.⊢↓-∀-idˣ c⊢) prem q₀) q =
+    CTI2.conceal⊑²-source-ok CTI2.all-conceal-ok mono
+      CTI2.tag-rebase-idᴸ sc (CTI2.⊢↓-∀-idˣ c⊢)
+      (right-inj-inversion² sv vN prem
+        (subst≡ (λ T → T ⊑ᵂ⟨ W ⟩ H)
+          (sym (cong `∀ (pivot-id-endpoints↓ c⊢))) q))
+      q
+  right-inj-inversion² {W = W} {gH = ★⇒★}
+      (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {p = p₀} ok mono
+        (CTI2.tag-rebase-onlyᴸ ts dis rep) sc
+        (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    CTI2.conceal⊑²-source-ok CTI2.all-conceal-ok mono
+      (CTI2.tag-rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↓-∀ˣ c⊢)
+      (right-inj-inversion² sv vN prem
+        (TT.transport↓-∀-fun c⊢
+          (toRenameᵗ-injective (ηᴸʷ W))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q))
+      q
+  right-inj-inversion² {W = W} {gH = ∀★}
+      (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {p = p₀} ok mono
+        (CTI2.tag-rebase-onlyᴸ ts dis rep) sc
+        (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    CTI2.conceal⊑²-source-ok CTI2.all-conceal-ok mono
+      (CTI2.tag-rebase-onlyᴸ ts dis rep) sc
+      (CTI2.⊢↓-∀ˣ c⊢)
+      (right-inj-inversion² sv vN prem
+        (TT.transport↓-∀-all c⊢
+          (toRenameᵗ-injective (ηᴸʷ W))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q))
+      q
+  right-inj-inversion² {W = W} {gH = ‵ ι}
+      (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {p = p₀} ok mono
+        (CTI2.tag-rebase-onlyᴸ ts dis rep) sc
+        (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    ⊥-elim
+      (TT.transport↓-∀-ι-⊥ c⊢
+        (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q)
+  right-inj-inversion² {W = W} {gH = ＇ Y} (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {p = p₀} ok mono
+        (CTI2.tag-rebase-onlyᴸ ts dis rep) sc
+        (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    ⊥-elim
+      (TT.transport↓-∀-var-⊥ c⊢
+        (toRenameᵗ-injective (ηᴸʷ W)) (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q)
+  right-inj-inversion² {W = W} {gH = ★⇒★}
+      (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p₀} ok mono
+        (CTI2.tag-rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    CTI2.conceal⊑²-source-ok CTI2.all-conceal-ok mono
+      (CTI2.tag-rebase-varᴸ rb) sc
+      (CTI2.⊢↓-∀ˣ c⊢)
+      (right-inj-inversion² sv vN prem
+        (TT.transport↓-∀-fun c⊢
+          (toRenameᵗ-injective (ηᴸʷ W′))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q))
+      q
+  right-inj-inversion² {W = W} {gH = ∀★}
+      (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p₀} ok mono
+        (CTI2.tag-rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    CTI2.conceal⊑²-source-ok CTI2.all-conceal-ok mono
+      (CTI2.tag-rebase-varᴸ rb) sc
+      (CTI2.⊢↓-∀ˣ c⊢)
+      (right-inj-inversion² sv vN prem
+        (TT.transport↓-∀-all c⊢
+          (toRenameᵗ-injective (ηᴸʷ W′))
+          (toRenameᵗ-injective (ηᴸʷ W))
+          p₀ q))
+      q
+  right-inj-inversion² {W = W} {gH = ‵ ι}
+      (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p₀} ok mono
+        (CTI2.tag-rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    ⊥-elim
+      (TT.transport↓-∀-ι-⊥ c⊢
+        (toRenameᵗ-injective (ηᴸʷ W′))
+        (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q)
+  right-inj-inversion² {W = W} {gH = ＇ Y} (sv-conceal-all sv) vN
+      (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p₀} ok mono
+        (CTI2.tag-rebase-varᴸ rb) sc (CTI2.⊢↓-∀ˣ c⊢) prem q₀) q =
+    ⊥-elim
+      (TT.transport↓-∀-var-⊥ c⊢
+        (toRenameᵗ-injective (ηᴸʷ W′))
+        (toRenameᵗ-injective (ηᴸʷ W))
+        p₀ q)
 
   -- Bare source seal.  A variable tag forces the target value to expose
   -- the corresponding seal boundary and turns the one-sided rebase into
@@ -594,6 +704,54 @@ module _
       with q
   right-inj-inversion² {gH = ∀★} (sv-seal sv) vN
       (CTI2.conceal⊑² ok mono rb sc (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      | ()
+  right-inj-inversion² {gH = ‵ ι} (sv-seal sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      with q
+  right-inj-inversion² {gH = ‵ ι} (sv-seal sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      | ()
+  right-inj-inversion² {gH = ★⇒★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      with q
+  right-inj-inversion² {gH = ★⇒★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      | ()
+  right-inj-inversion² {gH = ∀★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      with q
+  right-inj-inversion² {gH = ∀★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      | ()
+  right-inj-inversion² {gH = ‵ ι} (sv-seal sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      with q
+  right-inj-inversion² {gH = ‵ ι} (sv-seal sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      | ()
+  right-inj-inversion² {gH = ★⇒★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      with q
+  right-inj-inversion² {gH = ★⇒★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      | ()
+  right-inj-inversion² {gH = ∀★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
+      with q
+  right-inj-inversion² {gH = ∀★} (sv-seal sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ X∈) prem q₀) q
       | ()
   right-inj-inversion² {W = W} {gH = ＇ Y}
       (sv-seal {X = Xᴸ} {R = R} sv) vN
@@ -663,6 +821,26 @@ module _
     target-tag-seal-walk sv vU mono ra′ sc Xᴸ∈
       (rebase-target-membership ra′ Y∈)
       (CTI2.conceal⊑² ok₁ mono₁ rb₁ sc₁ c⊢ prem₂ p₀)
+  right-inj-inversion² {W = W} {gH = ＇ Y}
+      (sv-seal {X = Xᴸ} {R = R} sv) vN
+      (CTI2.conceal⊑² {W′ = W′} {p = p₀} ok mono rb sc
+        (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+      | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+      | CTI2.conceal⊑²-seal-star-open no-target mono₁ rb₁ sc₁
+          c⊢ prem₂ .p₀ =
+    target-tag-seal-walk sv vU mono ra′ sc Xᴸ∈
+      (rebase-target-membership ra′ Y∈)
+      (CTI2.conceal⊑²-seal-star-open no-target mono₁ rb₁ sc₁
+        c⊢ prem₂ p₀)
+  right-inj-inversion² {W = W} {gH = ＇ Y}
+      (sv-seal {X = Xᴸ} {R = R} sv) vN
+      (CTI2.conceal⊑² {W′ = W′} {p = p₀} ok mono rb sc
+        (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+      | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl
+      | CTI2.conceal⊑²-source-ok ok₁ mono₁ rb₁ sc₁ c⊢ prem₂ .p₀ =
+    target-tag-seal-walk sv vU mono ra′ sc Xᴸ∈
+      (rebase-target-membership ra′ Y∈)
+      (CTI2.conceal⊑²-source-ok ok₁ mono₁ rb₁ sc₁ c⊢ prem₂ p₀)
   right-inj-inversion² {W = W} {gH = ＇ Y}
       (sv-seal {X = Xᴸ} {R = R} (sv-cast sv₀ inert)) vN
       (CTI2.conceal⊑² {W′ = W′} {p = p₀} ok mono rb sc
@@ -808,6 +986,32 @@ module _
       | X₂ , refl , aligned | inj₂ refl | `∀ A =
     ⊥-elim (seal-target-nonstar-⊥ Xᴸ∈ ra′
       (rebase-target-membership ra′ Y∈) nonvar-all nonstar-∀)
+  right-inj-inversion² {W = W} {gH = ＇ Y}
+      (sv-seal {X = Xᴸ} {R = ★} sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+      with seal-rebase-target (CTI2.forgetTagRebaseᴸ rb) q
+         | right-tag-variable-view vN prem
+  right-inj-inversion² {W = W} {gH = ＇ Y}
+      (sv-seal {X = Xᴸ} {R = ★} sv) vN
+      (CTI2.conceal⊑²-seal-star-open no-target mono rb sc
+        (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+      | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl =
+    target-tag-seal-walk sv vU mono ra′ sc Xᴸ∈
+      (rebase-target-membership ra′ Y∈) prem
+  right-inj-inversion² {W = W} {gH = ＇ Y}
+      (sv-seal {X = Xᴸ} {R = R} sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+      with seal-rebase-target (CTI2.forgetTagRebaseᴸ rb) q
+         | right-tag-variable-view vN prem
+  right-inj-inversion² {W = W} {gH = ＇ Y}
+      (sv-seal {X = Xᴸ} {R = R} sv) vN
+      (CTI2.conceal⊑²-source-ok ok mono rb sc
+        (CTI2.⊢↓-sealˣ Xᴸ∈) prem q₀) q
+      | ra′ | varv-seal {W = U} {R = S} vU Y∈ refl =
+    target-tag-seal-walk sv vU mono ra′ sc Xᴸ∈
+      (rebase-target-membership ra′ Y∈) prem
 
   -- Type applications are not spine values.
   right-inj-inversion² () vN (CTI2.•⊑² _ _ _ _) q

--- a/GTSFImp/proof/DGG/Inversion/SourceStripColumnView.agda
+++ b/GTSFImp/proof/DGG/Inversion/SourceStripColumnView.agda
@@ -103,3 +103,10 @@ source-column-seal-D-case
     | CTI2.seal-partner-ok CTI2.name-protected-target
     | CTI2.tag-rebase-varᴸ link =
   column-seal-source-case monoᵢ link scᵢ X∈ prem
+source-column-seal-D-case
+    (CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-name-protected-ok Rns aligned)
+      monoᵢ (CTI2.tag-rebase-varᴸ link) scᵢ
+      (CTI2.⊢↓-sealˣ X∈)
+      (CTI2.⊑cast² {p = pᵤ} cY prem p★) p) =
+  column-seal-source-case monoᵢ link scᵢ X∈ prem

--- a/GTSFImp/proof/DGG/Inversion/SourceStripDef.agda
+++ b/GTSFImp/proof/DGG/Inversion/SourceStripDef.agda
@@ -64,13 +64,7 @@ data SourceTagSealCoreBranch {Δᴸ Δᴿ Δ}
        (W★ ∣ γ★ ⊢² P ⊑ U★ ∶ q★
         × (W★ ∣ γ★ ⊢² P ⊑ U★ ∶ q★
            → Wᵖ ∣ γᵖ ⊢² P
-               ⊑ (U ↓ seal Y S) ⟨ cY ⟩ ∶ pᵖ)
-        × ((qᵒ : (＇ Xᴸ) ⊑ᵂ⟨ Wᵒ ⟩ ★)
-           → (q′ : ★ ⊑ᵂ⟨ Wᵖ ⟩ ★)
-           → Wᵖ ∣ γᵖ ⊢² P
-               ⊑ (U ↓ seal Y S) ⟨ cY ⟩ ∶ q′
-           → Wᵒ ∣ γᵒ ⊢² P ↓ seal Xᴸ ★
-               ⊑ (U ↓ seal Y S) ⟨ cY ⟩ ∶ qᵒ)))))
+               ⊑ (U ↓ seal Y S) ⟨ cY ⟩ ∶ pᵖ)))))
     → SourceTagSealCoreBranch Wᵒ γᵒ P A U Xᴸ Y S cY
         Wᵖ γᵖ pᵖ
 

--- a/GTSFImp/proof/DGG/Inversion/SourceStripProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/SourceStripProof.agda
@@ -69,12 +69,7 @@ private
           target∈★ q★ premise★ reemit =
     core-terminus refl
       (U★ , Y★ , _ , refl , W★ , γ★ , mono★ , same★ ,
-        boundary★ , target∈★ , q★ , premise★ , reemit ,
-        λ qᵒ q′ final →
-          CTI2.conceal⊑²
-            (CTI2.seal-partner-ok CTI2.name-protected-target)
-            mono (CTI2.tag-rebase-varᴸ rb) sc
-            (CTI2.⊢↓-sealˣ source∈) final qᵒ)
+        boundary★ , target∈★ , q★ , premise★ , reemit)
   source-tag-seal-core-tagged {Wᵒ = Wᵒ} {γᵒ = γᵒ}
       (＇ X) sv vU mono rb sc source∈ target∈ D
       with target-strip-at★ sv vU mono rb sc source∈ target∈ D

--- a/GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
@@ -265,6 +265,25 @@ private
       prem q
   source-column-untagged-final {W = W} {W′ = W′} {q = q}
       mono rb sc target∈
+      (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = pᵖ}
+        (CTI2.seal-nonstar-plain-ok Rns nt) monoᵖ rbᵖ scᵖ
+        (CTI2.⊢↓-sealˣ X∈) prem r)
+      with composeTagRebaseTagOuter rb rbᵖ
+  source-column-untagged-final {W = W} {W′ = W′} {q = q}
+      mono rb sc target∈
+      (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = pᵖ}
+        (CTI2.seal-nonstar-plain-ok Rns nt) monoᵖ rbᵖ scᵖ
+        (CTI2.⊢↓-sealˣ X∈) prem r)
+      | Z? , rbᶠ =
+    CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-plain-ok Rns CTI2.not-↓)
+      (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = Wᵖ}
+        mono monoᵖ)
+      rbᶠ (sameCtx-∘ sc scᵖ)
+      (CTI2.⊢↓-sealˣ (rebase-source-membership-back rb X∈))
+      prem q
+  source-column-untagged-final {W = W} {W′ = W′} {q = q}
+      mono rb sc target∈
       (CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {p = pᵖ}
         ok monoᵖ rbᵖ scᵖ
         (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ target∈′)

--- a/GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
@@ -93,6 +93,15 @@ private
       (CTI2.SameRuntime.sourceStore-same
         (CTI2.RebaseAt.sameRuntime rb)) Z∈
 
+  right-var-obligation-nonstar : ∀ {Δᴸ Δᴿ Δ}
+      {W : World Δᴸ Δᴿ Δ} {R : Ty Δᴸ} {Y : TyVar Δᴿ}
+    → R ⊑ᵂ⟨ W ⟩ (＇ Y)
+    → NonStar R
+  right-var-obligation-nonstar {W = W} {R = R} {Y = Y} p
+      with SPT.right-var-obligation-view {W = W} {R = R} {Y = Y} p
+  right-var-obligation-nonstar p | X₂ , refl , aligned =
+    nonstar-X
+
   composeOuterRebase : ∀ {Δᴸ Δᴿ Δ}
       {W W′ W₂ : World Δᴸ Δᴿ Δ}
       {X : TyVar Δᴸ} {Y Y′ : TyVar Δᴿ}
@@ -251,13 +260,16 @@ private
       (CTI2.conceal⊑² {W′ = Wᵖ} {p = pᵖ}
         ok monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈) prem r)
       with composeTagRebaseTagOuter rb rbᵖ
-  source-column-untagged-final {W = W} {W′ = W′} {q = q}
+  source-column-untagged-final {W = W} {W′ = W′} {R = R}
+      {Y = Y} {q = q}
       mono rb sc target∈
       (CTI2.conceal⊑² {W′ = Wᵖ} {p = pᵖ}
         ok monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈) prem r)
       | Z? , rbᶠ =
-    CTI2.conceal⊑²
-      (CTI2.seal-partner-ok (CTI2.plain-target CTI2.not-↓))
+    CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-plain-ok
+        (right-var-obligation-nonstar {W = Wᵖ} {R = R} {Y = Y} pᵖ)
+        CTI2.not-↓)
       (impEnvMono-∘ {W₁ = W} {W₂ = W′} {W₃ = Wᵖ}
         mono monoᵖ)
       rbᶠ (sameCtx-∘ sc scᵖ)
@@ -703,12 +715,16 @@ private
     → Wᵢ ∣ γᵢ ⊢² V ⊑ U ↓ seal Y S ∶ pᵢ
     → W ∣ γ ⊢² (V ↓ seal X Rᵢ) ↓ seal Xᴸ (＇ X)
         ⊑ U ↓ seal Y S ∶ q
-  source-seal-final sv vU mono rb sc source∈ target∈
-      monoᵢ link scᵢ X∈ prem =
+  source-seal-final {Wᵢ = Wᵢ} {Rᵢ = Rᵢ} {Y = Y}
+      {pᵢ = pᵢ} sv vU mono rb sc source∈ target∈ monoᵢ link
+      scᵢ X∈ prem =
     target-source-var-chain (sv-seal sv) vU mono rb sc source∈
       target∈
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok (CTI2.plain-target CTI2.not-↓))
+      (CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok
+          (right-var-obligation-nonstar
+            {W = Wᵢ} {R = Rᵢ} {Y = Y} pᵢ)
+          CTI2.not-↓)
         monoᵢ (CTI2.tag-rebase-varᴸ link) scᵢ
         (CTI2.⊢↓-sealˣ X∈) prem
         (rebase-pivot-obligation link))
@@ -731,11 +747,14 @@ private
     → sourceStoreʷ W′ ∋ X ⦂ R
     → Wᵢ ∣ γᵢ ⊢² V ⊑ U ↓ seal Y S ∶ pᵤ
     → W ∣ γ ⊢² V ↓ seal X R ⊑ U ↓ seal Y S ∶ q
-  source-column-seal-final mono rb sc target∈ monoᵢ link scᵢ
-      X∈ prem =
+  source-column-seal-final {Wᵢ = Wᵢ} {R = R} {Y = Y}
+      {pᵤ = pᵤ} mono rb sc target∈ monoᵢ link scᵢ X∈ prem =
     source-column-untagged-final mono rb sc target∈
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok (CTI2.plain-target CTI2.not-↓))
+      (CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok
+          (right-var-obligation-nonstar
+            {W = Wᵢ} {R = R} {Y = Y} pᵤ)
+          CTI2.not-↓)
         monoᵢ (CTI2.tag-rebase-varᴸ link) scᵢ
         (CTI2.⊢↓-sealˣ X∈) prem
         (rebase-pivot-obligation link))
@@ -1046,11 +1065,13 @@ source-spine-direct-cast : ∀ {Δᴸ Δᴿ Δ}
            Core CoreTy Xᵒ Wᵒ γᵒ qᵒ)
 source-spine-direct-cast {W = W} {W′ = W′} {γ = γ} {γ′ = γ′}
     {V = V} {U = U} {R = R} {S = S} {Xᴸ = Xᴸ} {Y = Y}
-    {q = q} sv vU mono rb sc source∈ target∈
+    {p = p₀} {q = q} sv vU mono rb sc source∈ target∈
     prem =
   self-spine-sealed rb target∈ (sv-seal sv)
-    (CTI2.conceal⊑²
-      (CTI2.seal-partner-ok (CTI2.plain-target CTI2.not-↓))
+    (CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-plain-ok
+        (right-var-obligation-nonstar {W = W′} {R = R} {Y = Y} p₀)
+        CTI2.not-↓)
       mono (CTI2.tag-rebase-varᴸ rb) sc
       (CTI2.⊢↓-sealˣ source∈) prem q)
 
@@ -1361,8 +1382,11 @@ source-spine-strip-worker-cast-step-over-seal-star
       {Xᴸ = Xᴸ} {X₂ = X} {Y = Y} {c = c}
       {p₂ = rebase-pivot-obligation link} {q = q}
       (sv-seal sv) inert vU mono rb sc source∈ target∈
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok (CTI2.plain-target CTI2.not-↓))
+      (CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok
+          (right-var-obligation-nonstar
+            {W = Wᵢ} {R = Rᵢ} {Y = Y} pᵤ)
+          CTI2.not-↓)
         monoᵢ (CTI2.tag-rebase-varᴸ link) scᵢ
         (CTI2.⊢↓-sealˣ X∈) prem
         (rebase-pivot-obligation link))
@@ -1441,8 +1465,11 @@ source-spine-strip-worker-cast-step-over-seal-name
       {Xᴸ = Xᴸ} {X₂ = X} {Y = Y} {c = c}
       {p₂ = rebase-pivot-obligation link} {q = q}
       (sv-seal sv) inert vU mono rb sc source∈ target∈
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok (CTI2.plain-target CTI2.not-↓))
+      (CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok
+          (right-var-obligation-nonstar
+            {W = Wᵢ} {R = Rᵢ} {Y = Y} pᵤ)
+          CTI2.not-↓)
         monoᵢ (CTI2.tag-rebase-varᴸ link) scᵢ
         (CTI2.⊢↓-sealˣ X∈) prem
         (rebase-pivot-obligation link))

--- a/GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/SourceStripWorkerProof.agda
@@ -1710,10 +1710,24 @@ source-spine-strip-worker-seal-nonvar
     (tagged-target-nonvar-nonstar-spine-⊥ (sv-Λ sv)
       nonvar-all nonstar-∀ D)
 source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-Λ sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      D@(CTI2.Λ⊑² Anv z∈A liftγ vV target⊢ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ (sv-Λ sv)
+      nonvar-all nonstar-∀ D)
+source-spine-strip-worker-seal-nonvar
     (sv-seal (sv-reveal-fun sv)) vU mono rb sc source∈ target∈
     (CTI2.conceal⊑²
       (CTI2.seal-partner-ok CTI2.name-protected-target)
       monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.reveal⊑² monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
+      nonstar-⇒ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-reveal-fun sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
       (CTI2.reveal⊑² monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
   ⊥-elim
     (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
@@ -1728,10 +1742,41 @@ source-spine-strip-worker-seal-nonvar
     (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
       nonstar-⇒ prem)
 source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-conceal-fun sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²
+      (CTI2.seal-partner-ok CTI2.name-protected-target)
+      monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑²-source-ok ok monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
+      nonstar-⇒ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-conceal-fun sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑² okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
+      nonstar-⇒ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-conceal-fun sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑²-source-ok
+        okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
+      nonstar-⇒ prem)
+source-spine-strip-worker-seal-nonvar
     (sv-seal (sv-reveal-all sv)) vU mono rb sc source∈ target∈
     (CTI2.conceal⊑²
       (CTI2.seal-partner-ok CTI2.name-protected-target)
       monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.reveal⊑² monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
+      nonstar-∀ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-reveal-all sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
       (CTI2.reveal⊑² monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
   ⊥-elim
     (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
@@ -1742,6 +1787,30 @@ source-spine-strip-worker-seal-nonvar
       (CTI2.seal-partner-ok CTI2.name-protected-target)
       monoᵢ rbᵢ scᵢ c⊢
       (CTI2.conceal⊑² ok monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
+      nonstar-∀ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-conceal-all sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²
+      (CTI2.seal-partner-ok CTI2.name-protected-target)
+      monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑²-source-ok ok monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
+      nonstar-∀ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-conceal-all sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑² okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
+      nonstar-∀ prem)
+source-spine-strip-worker-seal-nonvar
+    (sv-seal (sv-conceal-all sv)) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑²-source-ok
+        okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem p) q) =
   ⊥-elim
     (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
       nonstar-∀ prem)
@@ -2076,12 +2145,52 @@ source-spine-strip-worker-seal-D
   source-spine-strip-worker-seal-nonvar (sv-seal sv) vU mono rb sc
     source∈ target∈ D
 source-spine-strip-worker-seal-D
+    D@(CTI2.conceal⊑² ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑²-source-ok
+        okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem pᵢ) p)
+    sv vU mono rb sc source∈ target∈ =
+  source-spine-strip-worker-seal-nonvar (sv-seal sv) vU mono rb sc
+    source∈ target∈ D
+source-spine-strip-worker-seal-D
+    D@(CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.Λ⊑² Anv z∈A liftγ vV target⊢ prem pᵢ) p)
+    sv vU mono rb sc source∈ target∈ =
+  source-spine-strip-worker-seal-nonvar (sv-seal sv) vU mono rb sc
+    source∈ target∈ D
+source-spine-strip-worker-seal-D
+    D@(CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.reveal⊑² monoᵣ rbᵣ scᵣ c⊢ᵣ prem pᵢ) p)
+    sv vU mono rb sc source∈ target∈ =
+  source-spine-strip-worker-seal-nonvar (sv-seal sv) vU mono rb sc
+    source∈ target∈ D
+source-spine-strip-worker-seal-D
+    D@(CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑² okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem pᵢ) p)
+    sv vU mono rb sc source∈ target∈ =
+  source-spine-strip-worker-seal-nonvar (sv-seal sv) vU mono rb sc
+    source∈ target∈ D
+source-spine-strip-worker-seal-D
+    D@(CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢
+      (CTI2.conceal⊑²-source-ok
+        okᵣ monoᵣ rbᵣ scᵣ c⊢ᵣ prem pᵢ) p)
+    sv vU mono rb sc source∈ target∈ =
+  source-spine-strip-worker-seal-nonvar (sv-seal sv) vU mono rb sc
+    source∈ target∈ D
+source-spine-strip-worker-seal-D
     (CTI2.conceal⊑² ok monoᵢ rbᵢ scᵢ
       (CTI2.⊢↓-sealˣ X∈) prem p)
     sv vU mono rb sc source∈ target∈ =
   source-spine-strip-worker-seal-source sv vU mono
     rb sc source∈ target∈ monoᵢ rbᵢ scᵢ X∈ ok prem
-
+source-spine-strip-worker-seal-D
+    (CTI2.conceal⊑²-source-ok
+      (CTI2.seal-nonstar-name-protected-ok Rns aligned)
+      monoᵢ (CTI2.tag-rebase-varᴸ link) scᵢ
+      (CTI2.⊢↓-sealˣ X∈)
+      (CTI2.⊑cast² {p = pᵤ} cY prem p★) p)
+    sv vU mono rb sc source∈ target∈ =
+  source-seal-branch sv vU mono rb sc source∈ target∈
+    monoᵢ link scᵢ X∈ prem
 source-spine-strip-worker-seal : SourceSpineStrip
 {-# NON_COVERING #-}
 source-spine-strip-worker-seal (sv-seal sv) vU mono rb sc
@@ -2114,6 +2223,12 @@ source-spine-strip-worker-conceal-fun (sv-conceal-fun sv) vU mono
   ⊥-elim
     (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
       nonstar-⇒ prem)
+source-spine-strip-worker-conceal-fun (sv-conceal-fun sv) vU mono
+    rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢ prem p) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-fun
+      nonstar-⇒ prem)
 
 source-spine-strip-worker-reveal-all : SourceSpineStrip
 {-# NON_COVERING #-}
@@ -2137,6 +2252,12 @@ source-spine-strip-worker-conceal-all (sv-conceal-all sv) vU mono
 source-spine-strip-worker-conceal-all (sv-conceal-all sv) vU mono
     rb sc source∈ target∈
     (CTI2.conceal⊑² ok monoᵢ rbᵢ scᵢ c⊢ prem p) =
+  ⊥-elim
+    (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
+      nonstar-∀ prem)
+source-spine-strip-worker-conceal-all (sv-conceal-all sv) vU mono
+    rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok monoᵢ rbᵢ scᵢ c⊢ prem p) =
   ⊥-elim
     (tagged-target-nonvar-nonstar-spine-⊥ sv nonvar-all
       nonstar-∀ prem)

--- a/GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
@@ -23,6 +23,7 @@ import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CastTermImprecision2Typing as CTI2T
 import proof.DGG.SealTransferCore as STC
 import proof.DGG.SealPeelToolkit as SPT
+import proof.DGG.Occupancy as Occ
 open import proof.DGG.Inversion.SpineValueDef using
   (sv-cast; sv-seal; sv-reveal-fun; sv-reveal-all; varv-seal;
    var-tag-value-sealed; var-value-view)
@@ -55,6 +56,15 @@ target-source-star-at {W = W} {X = X} {Y = Y}
     {q = q} (sv-seal sv₀) inert vU X∈ Y∈
     (CTI2.conceal⊑² {W′ = Wᵖ} {p = p} ok mono rb sc
       (CTI2.⊢↓-sealˣ X∈′) prem .q) =
+  ⊥-elim
+    (star-source-nonstar-⊥ {W = Wᵖ} {S = ＇ Y}
+      (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ ＇ Y)
+        (store-lookup-unique X∈′ X∈) p)
+      nonstar-X)
+target-source-star-at {W = W} {X = X} {Y = Y}
+    {q = q} (sv-seal sv₀) inert vU X∈ Y∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p}
+      ok mono rb sc (CTI2.⊢↓-sealˣ X∈′) prem .q) =
   ⊥-elim
     (star-source-nonstar-⊥ {W = Wᵖ} {S = ＇ Y}
       (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ ＇ Y)
@@ -96,9 +106,10 @@ target-source-star-at {W = W} {X = X} {S = `∀ A}
       (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ `∀ A)
         (store-lookup-unique X∈′ X∈) p)
       nonstar-∀)
-target-source-star-at {S = ★} {c = c} {q = q} sv inert vU X∈ Y∈ D
+target-source-star-at {X = X} {S = ★} {c = c} {q = q}
+    sv (inj ⦃ Gᵍ = ＇ .X ⦄) vU X∈ Y∈ D
     with STC.seal-transfer sv vU X∈ D
-target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
+target-source-star-at {S = ★} {c = c} {q = q} sv inert vU X∈ Y∈ D
     | STC.seal-transfer-paired {P = P}
         monoᵖ rbᵖ scᵖ source⊢ target⊢ partner prem =
   target-source-star-paired refl monoᵖ rbᵖ scᵖ X∈ Y∈ partner prem
@@ -163,6 +174,58 @@ target-source-star-at {V = V ↓ `∀↓ d₁} {S = ★}
 target-source-star-at {V = V ↓ `∀↓ d₁} {S = ★}
     sv inert vU X∈ Y∈ D
     | st-stripped W₂ γ₂ link mono₂ sc₂ q₂ D₂ | ()
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-seal-star-open no-target monoᵖ rbᵖ scᵖ
+        (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂) =
+  target-source-star-payload refl mono₂ link sc₂ X∈ Y∈ D₂
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok {R = R} Rns nt)
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
+    with store-lookup-unique X∈ᵖ (rebase-source-membership link X∈)
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok {R = R} Rns nt)
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
+    | refl
+    with Rns
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-plain-ok Rns nt)
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
+    | refl
+    | ()
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-name-protected-ok {R = R} Rns aligned)
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
+    with store-lookup-unique X∈ᵖ (rebase-source-membership link X∈)
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-name-protected-ok {R = R} Rns aligned)
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
+    | refl
+    with Rns
+target-source-star-at {X = X} {S = ★} {q = q}
+    sv inert vU X∈ Y∈ D
+    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
+      D₂@(CTI2.conceal⊑²-source-ok
+        (CTI2.seal-nonstar-name-protected-ok Rns aligned)
+        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
+    | refl
+    | ()
 target-source-star-at {X = X} {S = ★} {c = c} {q = q}
     sv (inj ⦃ Gᵍ = ＇ .X ⦄) vU X∈ Y∈ D
     | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
@@ -251,7 +314,7 @@ target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
         (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂) =
   target-source-star-payload refl
     mono₂ link sc₂ X∈ Y∈ D₂
-target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
+target-source-star-at {S = ★} {c = c} {q = q} sv inert vU X∈ Y∈ D
     | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
       D₂@(CTI2.conceal⊑²
         (CTI2.seal-partner-ok
@@ -261,7 +324,8 @@ target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
         (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂) =
   target-source-star-payload refl
     mono₂ link sc₂ X∈ Y∈ D₂
-target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
+target-source-star-at {X = X} {S = ★} {c = c} {q = q}
+    sv inert vU X∈ Y∈ D
     | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
       D₂@(CTI2.conceal⊑²
         (CTI2.seal-partner-ok
@@ -269,22 +333,25 @@ target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
             (CTI2.rep★-round-trip partner)))
         monoᵖ rbᵖ@(CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
         scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
-    with STC.source-star-cast-package-from-source
-      monoᵖ rbᵖ scᵖ X∈ᵖ no-target (CTI2.rep★-round-trip partner)
-      inert prem D₂
-target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
-    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
-      D₂@(CTI2.conceal⊑²
-        (CTI2.seal-partner-ok
-          (CTI2.star-rep-target no-target
-            (CTI2.rep★-round-trip partner)))
-        monoᵖ rbᵖ@(CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
-        scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
-    | pkg , sourcePrem =
+    =
   target-source-star-final
     (STC.emit-tagged-transfer mono₂ link sc₂
       (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
-      pkg sourcePrem)
+      (STC.tagged-transfer-output
+        (CTI2.cast⊑² c D₂ ★⊑★)
+        (STC.premise-partner-from-tag-rebase rbᵖ)
+        (CTI2.matched-seal-star-partner
+          (CTI2.rep★-round-trip {cX = id (＇ X)}
+            (STC.transport-rep★-partner-ok-tag rbᵖ
+              (CTI2.rep★-round-trip partner)))))
+      (CTI2.conceal⊑²-seal-star-open
+        (Occ.tag-rebase-no-target-forwardᴼ rbᵖ no-target)
+        (STC.impEnvMono-refl {W = W₂})
+        (STC.self-tag-rebase-from-tag-rebase rbᵖ)
+        (STC.sameCtx-refl {γ = γ₂})
+        (CTI2.⊢↓-sealˣ X∈ᵖ)
+        (CTI2.cast⊑² c D₂ ★⊑★)
+        q₂))
 target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
     | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
       D₂@(CTI2.conceal⊑²
@@ -739,6 +806,23 @@ target-source-star-chain {W = W} {W′ = W′}
     (sv-seal sv₀) inert vU mono ra sc X∈ Y∈
     (CTI2.conceal⊑² {W′ = Wᵖ} {p = p} ok mono₁ rb₁ sc₁
       (CTI2.⊢↓-sealˣ X∈′) prem .p₂)
+    | refl =
+  ⊥-elim
+    (star-source-nonstar-⊥ {W = Wᵖ} {S = ＇ Y}
+      (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ ＇ Y)
+        (store-lookup-unique X∈′ (rebase-source-membership ra X∈)) p)
+      nonstar-X)
+target-source-star-chain {W = W} {W′ = W′}
+    {Xᴸ = Xᴸ} {X₂ = X₂} {Y = Y} {p₂ = p₂} {q = q}
+    (sv-seal sv₀) inert vU mono ra sc X∈ Y∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p}
+      ok mono₁ rb₁ sc₁ (CTI2.⊢↓-sealˣ X∈′) prem .p₂)
+    with inner-source-pivot-eq ra q p₂
+target-source-star-chain {W = W} {W′ = W′}
+    {Xᴸ = Xᴸ} {Y = Y} {p₂ = p₂} {q = q}
+    (sv-seal sv₀) inert vU mono ra sc X∈ Y∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p}
+      ok mono₁ rb₁ sc₁ (CTI2.⊢↓-sealˣ X∈′) prem .p₂)
     | refl =
   ⊥-elim
     (star-source-nonstar-⊥ {W = Wᵖ} {S = ＇ Y}

--- a/GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
@@ -363,21 +363,8 @@ target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
       D₂@(CTI2.conceal⊑²
         ok@(CTI2.seal-partner-ok CTI2.name-protected-target)
         monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
-    | refl
-    with STC.source-star-cast-package-from-source-name
-      monoᵖ rbᵖ scᵖ (rebase-source-membership link X∈)
-      inert prem D₂
-target-source-star-at {S = ★} {q = q} sv inert vU X∈ Y∈ D
-    | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
-      D₂@(CTI2.conceal⊑²
-        ok@(CTI2.seal-partner-ok CTI2.name-protected-target)
-        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ X∈ᵖ) prem .q₂)
-    | refl
-    | pkg , sourcePrem =
-  target-source-star-final
-    (STC.emit-tagged-transfer mono₂ link sc₂
-      (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
-      pkg sourcePrem)
+    | refl =
+  target-source-star-payload refl mono₂ link sc₂ X∈ Y∈ D₂
 target-source-star-at {S = ★} {c = c} {q = q} sv inert vU X∈ Y∈ D
     | st-stripped W₂ γ₂ link mono₂ sc₂ q₂
       D₂@(CTI2.conceal⊑²

--- a/GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/TargetChainProof.agda
@@ -491,23 +491,8 @@ target-source-star-at
     | varv-seal {W = U₀} vU₀ Y₂∈ refl
     | ._ , refl , aligned
     | target-source-star-residual refl X∈ᵒ Y₂∈ᵒ rbᵒ residualᵒ =
-  target-source-star-final
-    (STC.emit-tagged-transfer mono₂ link sc₂
-      (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
-      (STC.tagged-transfer-output
-        (CTI2.cast⊑² c D₂ ★⊑★)
-        (STC.premise-partner-just aligned)
-        (CTI2.matched-seal-star-partner
-          (CTI2.rep★-var-tag aligned)))
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok CTI2.name-protected-target)
-        (STC.impEnvMono-refl {W = W₂})
-        (CTI2.tag-rebase-varᴸ
-          rbᵒ)
-        (STC.sameCtx-refl {γ = γ₂})
-        (CTI2.⊢↓-sealˣ X∈ᵒ)
-        (CTI2.cast⊑cast² c cᴿ! residualᵒ ★⊑★)
-        q₂))
+  target-source-star-payload refl mono₂ link sc₂ X∈ Y∈
+    (CTI2.⊑cast² cᴿ! residualᵒ q₂)
 target-source-star-at
     {V = V ↓ x}
     {U = U ⟨ _! ⦃ Gᵍ = ＇ Y₂ ⦄ cᴿ ⦃ Ans = Ansᴿ ⦄ ⟩}
@@ -518,22 +503,8 @@ target-source-star-at
     | varv-seal {W = U₀} vU₀ Y₂∈ refl
     | ._ , refl , aligned
     | target-source-star-var-residual refl X∈ᵒ Y₂∈ᵒ rbᵒ residualᵒ =
-  target-source-star-final
-    (STC.emit-tagged-transfer mono₂ link sc₂
-      (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
-      (STC.tagged-transfer-output
-        (CTI2.cast⊑² c D₂ ★⊑★)
-        (STC.premise-partner-just aligned)
-        (CTI2.matched-seal-star-partner
-          (CTI2.rep★-var-tag aligned)))
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok CTI2.name-protected-target)
-        (STC.impEnvMono-refl {W = W₂})
-        (CTI2.tag-rebase-varᴸ rbᵒ)
-        (STC.sameCtx-refl {γ = γ₂})
-        (CTI2.⊢↓-sealˣ X∈ᵒ)
-        (CTI2.cast⊑cast² c cᴿ! residualᵒ ★⊑★)
-        q₂))
+  target-source-star-payload refl mono₂ link sc₂ X∈ Y∈
+    (CTI2.⊑cast² cᴿ! residualᵒ q₂)
 target-source-star-at
     {V = V ↓ x}
     {U = U ⟨ _! ⦃ Gᵍ = ＇ Y₂ ⦄ cᴿ ⦃ Ans = Ansᴿ ⦄ ⟩}
@@ -545,28 +516,12 @@ target-source-star-at
     | ._ , refl , aligned
     | target-source-star-paired refl monoᵒ rbᵒ scᵒ X∈ᵒ Y₂∈ᵒ
         partnerᵒ premᵒ =
-  target-source-star-final
-    (STC.emit-tagged-transfer mono₂ link sc₂
-      (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
-      (STC.tagged-transfer-output
-        (CTI2.cast⊑² c D₂ ★⊑★)
-        (STC.premise-partner-just aligned)
-        (CTI2.matched-seal-star-partner
-          (CTI2.rep★-var-tag aligned)))
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok CTI2.name-protected-target)
-        (STC.impEnvMono-refl {W = W₂})
-        (CTI2.tag-rebase-varᴸ
-          (CTI2.sameWorldRebaseAt aligned
-            (CTI2.RebaseAt.storeRepresentations rbᵒ)))
-        (STC.sameCtx-refl {γ = γ₂})
-        (CTI2.⊢↓-sealˣ X∈ᵒ)
-        (CTI2.cast⊑cast² c cᴿ!
-          (CTI2.conceal⊑conceal² partnerᵒ monoᵒ rbᵒ scᵒ
-            (CTI2.⊢↓-sealˣ X∈ᵒ) (CTI2.⊢↓-sealˣ Y₂∈ᵒ)
-            premᵒ p₂)
-          ★⊑★)
-        q₂))
+  target-source-star-payload refl mono₂ link sc₂ X∈ Y∈
+    (CTI2.⊑cast² cᴿ!
+      (CTI2.conceal⊑conceal² partnerᵒ monoᵒ rbᵒ scᵒ
+        (CTI2.⊢↓-sealˣ X∈ᵒ) (CTI2.⊢↓-sealˣ Y₂∈ᵒ)
+        premᵒ p₂)
+      q₂)
 target-source-star-at
     {V = V ↓ x}
     {U = U ⟨ _! ⦃ Gᵍ = ＇ Y₂ ⦄ cᴿ ⦃ Ans = Ansᴿ ⦄ ⟩}
@@ -578,27 +533,11 @@ target-source-star-at
     | ._ , refl , aligned
     | target-source-star-payload refl monoᵒ rbᵒ scᵒ X∈ᵒ Y₂∈ᵒ
         sourcePremᵒ =
-  target-source-star-final
-    (STC.emit-tagged-transfer mono₂ link sc₂
-      (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
-      (STC.tagged-transfer-output
-        (CTI2.cast⊑² c D₂ ★⊑★)
-        (STC.premise-partner-just aligned)
-        (CTI2.matched-seal-star-partner
-          (CTI2.rep★-var-tag aligned)))
-      (CTI2.conceal⊑²
-        (CTI2.seal-partner-ok CTI2.name-protected-target)
-        (STC.impEnvMono-refl {W = W₂})
-        (CTI2.tag-rebase-varᴸ
-          (CTI2.sameWorldRebaseAt aligned
-            (CTI2.RebaseAt.storeRepresentations rbᵒ)))
-        (STC.sameCtx-refl {γ = γ₂})
-        (CTI2.⊢↓-sealˣ X∈ᵒ)
-        (CTI2.cast⊑cast² c cᴿ!
-          (CTI2.⊑conceal² monoᵒ (CTI2.rebase-varᴿ rbᵒ) scᵒ
-            (CTI2.⊢↓-sealˣ Y₂∈ᵒ) sourcePremᵒ p₂)
-          ★⊑★)
-        q₂))
+  target-source-star-payload refl mono₂ link sc₂ X∈ Y∈
+    (CTI2.⊑cast² cᴿ!
+      (CTI2.⊑conceal² monoᵒ (CTI2.rebase-varᴿ rbᵒ) scᵒ
+        (CTI2.⊢↓-sealˣ Y₂∈ᵒ) sourcePremᵒ p₂)
+      q₂)
 target-source-star-at
     {V = V ↓ x}
     {U = U ⟨ _! ⦃ Gᵍ = ＇ Y₂ ⦄ cᴿ ⦃ Ans = () ⦄ ⟩}

--- a/GTSFImp/proof/DGG/Inversion/TargetStripProof.agda
+++ b/GTSFImp/proof/DGG/Inversion/TargetStripProof.agda
@@ -801,6 +801,15 @@ seal-descent-current-var {Y = Y} (sv-seal sv₀) vU
       (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ ＇ Y)
         (store-lookup-unique source∈′ source∈) p)
       nonstar-X)
+seal-descent-current-var {Y = Y} (sv-seal sv₀) vU
+    source∈ target∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p} ok mono rb sc
+      (CTI2.⊢↓-sealˣ source∈′) prem r) =
+  ⊥-elim
+    (star-source-nonstar-⊥ {W = Wᵖ} {S = ＇ Y}
+      (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ ＇ Y)
+        (store-lookup-unique source∈′ source∈) p)
+      nonstar-X)
 seal-descent-current-var {Y′ = Y′} (sv-seal sv₀) vU
     source∈ target∈
     (CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {p = p} ok mono rb sc
@@ -956,6 +965,29 @@ seal-descent-at-var-＇ {Wʳ = Wʳ} {Xᴸ = Xᴸ} {Y = Y}
         p)
       nonstar-X)
 seal-descent-at-var-＇ {Wʳ = Wʳ} {A = A} {Xᴸ = Xᴸ} {Y = Y}
+    {r = r} (sv-seal sv₀) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p} ok mono₁ rb₁
+      sc₁ (CTI2.⊢↓-sealˣ source∈′) prem .r)
+    with SPT.right-var-obligation-view {W = Wʳ} {R = A} {Y = Y} r
+seal-descent-at-var-＇ {Wʳ = Wʳ} {Xᴸ = Xᴸ} {Y = Y}
+    {r = r} (sv-seal sv₀) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p} ok mono₁ rb₁
+      sc₁ (CTI2.⊢↓-sealˣ source∈′) prem .r)
+    | X₂ , refl , aligned
+    with inner-source-pivot-eqᴿ rb r
+seal-descent-at-var-＇ {Wʳ = Wʳ} {Xᴸ = Xᴸ} {Y = Y}
+    {r = r} (sv-seal sv₀) vU mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok {W′ = Wᵖ} {p = p} ok mono₁ rb₁
+      sc₁ (CTI2.⊢↓-sealˣ source∈′) prem .r)
+    | .Xᴸ , refl , aligned | refl =
+  ⊥-elim
+    (star-source-nonstar-⊥ {W = Wᵖ} {S = ＇ Y}
+      (subst≡ (λ T → T ⊑ᵂ⟨ Wᵖ ⟩ ＇ Y)
+        (store-lookup-unique source∈′
+          (rebase-source-membership rb source∈))
+        p)
+      nonstar-X)
+seal-descent-at-var-＇ {Wʳ = Wʳ} {A = A} {Xᴸ = Xᴸ} {Y = Y}
     {Y′ = Y′} {r = r} (sv-seal sv₀) vU mono rb sc source∈
     target∈
     (CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {p = p} ok mono₁ rb₁ sc₁
@@ -1020,6 +1052,14 @@ seal-descent-at-var-＇ {Wʳ = Wʳ} {Y = Y} (sv-conceal-all sv₀) vU
 seal-descent-at-var-＇ {Wʳ = Wʳ} {Y = Y} (sv-conceal-all sv₀) vU
     mono rb sc source∈ target∈
     (CTI2.conceal⊑² ok mono₁ rb₁ sc₁ c⊢ prem r)
+    | ()
+seal-descent-at-var-＇ {Wʳ = Wʳ} {Y = Y} (sv-conceal-all sv₀) vU
+    mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok mono₁ rb₁ sc₁ c⊢ prem r)
+    with SPT.right-var-obligation-view {W = Wʳ} {Y = Y} r
+seal-descent-at-var-＇ {Wʳ = Wʳ} {Y = Y} (sv-conceal-all sv₀) vU
+    mono rb sc source∈ target∈
+    (CTI2.conceal⊑²-source-ok ok mono₁ rb₁ sc₁ c⊢ prem r)
     | ()
 seal-descent-at-var-＇ {Wʳ = Wʳ} {Y = Y} (sv-conceal-all sv₀) vU
     mono rb sc source∈ target∈
@@ -1556,6 +1596,43 @@ tag-dispatch-at★ {Wᵒ = Wᵒ} {Wᵖ = Wᵖ} {γᵒ = γᵒ}
   resume {U = U} {S = S} refl vU target∈ | Y★ , target∈★ =
     target-strip★-data ((U ↓ seal Y S) ⟨ cY ⟩) Y★ Wᵖ γᵖ
       mono sc rb target∈★ q D (λ _ → D)
+tag-dispatch-at★ {Wᵒ = Wᵒ} {Wᵖ = Wᵖ} {γᵒ = γᵒ}
+    {γᵖ = γᵖ} {V = V ↓ seal X ★} {N = N}
+    {A = ＇ X} {Xᴸ = Xᴸ} {Y = Y} {cY = cY} {p = q}
+    (sv-seal sv) vN mono rb sc source∈
+    D@(CTI2.conceal⊑²-seal-star-open no-target mono₁ rb₁ sc₁ c⊢
+      prem .q) =
+  dispatch-source-fold resume
+  where
+  resume : ∀ {U S}
+    → N ≡ U ↓ seal Y S
+    → Value U
+    → targetStoreʷ Wᵒ ∋ Y ⦂ S
+    → TargetStripAt★Data Wᵒ γᵒ (V ↓ seal X ★) (＇ X)
+        U Xᴸ Y S cY Wᵖ γᵖ q
+  resume {S = S} refl vU target∈
+      with target-star-terminal-entry source∈ rb
+  resume {U = U} {S = S} refl vU target∈ | Y★ , target∈★ =
+    target-strip★-data ((U ↓ seal Y S) ⟨ cY ⟩) Y★ Wᵖ γᵖ
+      mono sc rb target∈★ q D (λ _ → D)
+tag-dispatch-at★ {Wᵒ = Wᵒ} {Wᵖ = Wᵖ} {γᵒ = γᵒ}
+    {γᵖ = γᵖ} {V = V ↓ seal X R} {N = N}
+    {A = ＇ X} {Xᴸ = Xᴸ} {Y = Y} {cY = cY} {p = q}
+    (sv-seal sv) vN mono rb sc source∈
+    D@(CTI2.conceal⊑²-source-ok ok mono₁ rb₁ sc₁ c⊢ prem .q) =
+  dispatch-source-fold resume
+  where
+  resume : ∀ {U S}
+    → N ≡ U ↓ seal Y S
+    → Value U
+    → targetStoreʷ Wᵒ ∋ Y ⦂ S
+    → TargetStripAt★Data Wᵒ γᵒ (V ↓ seal X R) (＇ X)
+        U Xᴸ Y S cY Wᵖ γᵖ q
+  resume {S = S} refl vU target∈
+      with target-star-terminal-entry source∈ rb
+  resume {U = U} {S = S} refl vU target∈ | Y★ , target∈★ =
+    target-strip★-data ((U ↓ seal Y S) ⟨ cY ⟩) Y★ Wᵖ γᵖ
+      mono sc rb target∈★ q D (λ _ → D)
 tag-dispatch-at★ (sv-reveal-fun sv) vN mono rb sc source∈
     D@(CTI2.reveal⊑² mono₁ rb₁ sc₁ c⊢ prem q) =
   tagged-seal-source-fold-⊥ (sv-reveal-fun sv) nonvar-fun
@@ -1564,12 +1641,20 @@ tag-dispatch-at★ (sv-conceal-fun sv) vN mono rb sc source∈
     D@(CTI2.conceal⊑² ok mono₁ rb₁ sc₁ c⊢ prem q) =
   tagged-seal-source-fold-⊥ (sv-conceal-fun sv) nonvar-fun
     nonstar-⇒ D
+tag-dispatch-at★ (sv-conceal-fun sv) vN mono rb sc source∈
+    D@(CTI2.conceal⊑²-source-ok ok mono₁ rb₁ sc₁ c⊢ prem q) =
+  tagged-seal-source-fold-⊥ (sv-conceal-fun sv) nonvar-fun
+    nonstar-⇒ D
 tag-dispatch-at★ (sv-reveal-all sv) vN mono rb sc source∈
     D@(CTI2.reveal⊑² mono₁ rb₁ sc₁ c⊢ prem q) =
   tagged-seal-source-fold-⊥ (sv-reveal-all sv) nonvar-all
     nonstar-∀ D
 tag-dispatch-at★ (sv-conceal-all sv) vN mono rb sc source∈
     D@(CTI2.conceal⊑² ok mono₁ rb₁ sc₁ c⊢ prem q) =
+  tagged-seal-source-fold-⊥ (sv-conceal-all sv) nonvar-all
+    nonstar-∀ D
+tag-dispatch-at★ (sv-conceal-all sv) vN mono rb sc source∈
+    D@(CTI2.conceal⊑²-source-ok ok mono₁ rb₁ sc₁ c⊢ prem q) =
   tagged-seal-source-fold-⊥ (sv-conceal-all sv) nonvar-all
     nonstar-∀ D
 

--- a/GTSFImp/proof/DGG/Inversion/TargetWalkSupport.agda
+++ b/GTSFImp/proof/DGG/Inversion/TargetWalkSupport.agda
@@ -1036,3 +1036,11 @@ tagged-target-nonvar-nonstar-spine-⊥ (sv-conceal-all sv₀)
     Anv Ans (CTI2.conceal⊑² ok mono rb sc c⊢ prem q) =
   tagged-target-nonvar-nonstar-spine-⊥ sv₀ nonvar-all
     nonstar-∀ prem
+tagged-target-nonvar-nonstar-spine-⊥ (sv-conceal-fun sv₀)
+    Anv Ans (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem q) =
+  tagged-target-nonvar-nonstar-spine-⊥ sv₀ nonvar-fun
+    nonstar-⇒ prem
+tagged-target-nonvar-nonstar-spine-⊥ (sv-conceal-all sv₀)
+    Anv Ans (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ prem q) =
+  tagged-target-nonvar-nonstar-spine-⊥ sv₀ nonvar-all
+    nonstar-∀ prem

--- a/GTSFImp/proof/DGG/Inversion/TargetWalkSupport.agda
+++ b/GTSFImp/proof/DGG/Inversion/TargetWalkSupport.agda
@@ -930,8 +930,8 @@ tagged-target-nonvar-nonstar-spine-⊥ : ∀ {Δᴸ Δᴿ Δ}
   → ⊥
 
 target-source-var-chain {Y = Y} {q = q} sv vU mono ra sc X∈ Y∈ D =
-  CTI2.conceal⊑² (CTI2.seal-partner-ok
-      (CTI2.plain-target CTI2.not-↓))
+  CTI2.conceal⊑²-source-ok
+    (CTI2.seal-nonstar-plain-ok nonstar-X CTI2.not-↓)
     mono (CTI2.tag-rebase-varᴸ ra) sc
     (CTI2.⊢↓-sealˣ X∈) D q
 

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -221,6 +221,14 @@ probe-sealed-arg-partner-empty : ∀ {Δ} {W : CTI2.World 1 0 Δ}
 probe-sealed-arg-partner-empty
     (CTI2.seal-partner-ok (CTI2.plain-target ()))
 
+probe-sealed-arg-ok-empty : ∀ {Δ} {W : CTI2.World 1 0 Δ}
+    {P Xᴿ?}
+  → CTI2.SourceConcealOK W
+      P Ex2.example12-source-X-seal Xᴿ?
+      (Ex.c ⟨ CTI2.example12-ℕ! ⟩)
+  → ⊥
+probe-sealed-arg-ok-empty (CTI2.seal-nonstar-plain-ok Rns ())
+
 probe-sealed-arg-empty′ : ∀ {X}
   → (q : ＇ X ⊑ᵂ⟨ probe-world₁ ⟩ ★)
   → probe-world₁ ∣ [] ⊢²
@@ -234,6 +242,9 @@ probe-sealed-arg-empty′ (X⊑★ eq)
 probe-sealed-arg-empty′ q₀
     (CTI2.conceal⊑² ok mono rb sc c⊢ D .q₀) =
   probe-sealed-arg-partner-empty ok
+probe-sealed-arg-empty′ q₀
+    (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ D .q₀) =
+  probe-sealed-arg-ok-empty ok
 
 probe-sealed-arg-empty :
   probe-world₁ ∣ [] ⊢²

--- a/GTSFImp/proof/DGG/LambdaImpProbe.agda
+++ b/GTSFImp/proof/DGG/LambdaImpProbe.agda
@@ -212,15 +212,6 @@ probe-checkpoint₁ :
     Ex2.ℕ⊑★² {W = probe-world₁}
 probe-checkpoint₁ = CTI2.·⊑·² probe-function₁ probe-argument₁
 
-probe-sealed-arg-partner-empty : ∀ {Δ} {W : CTI2.World 1 0 Δ}
-    {P Xᴿ?}
-  → CTI2.SourceConcealPartnerOK W
-      P Ex2.example12-source-X-seal Xᴿ?
-      (Ex.c ⟨ CTI2.example12-ℕ! ⟩)
-  → ⊥
-probe-sealed-arg-partner-empty
-    (CTI2.seal-partner-ok (CTI2.plain-target ()))
-
 probe-sealed-arg-ok-empty : ∀ {Δ} {W : CTI2.World 1 0 Δ}
     {P Xᴿ?}
   → CTI2.SourceConcealOK W
@@ -240,8 +231,9 @@ probe-sealed-arg-empty′ q₀
 probe-sealed-arg-empty′ (X⊑★ eq)
     (CTI2.⊑cast² {p = p} c′ D .(X⊑★ eq)) | ()
 probe-sealed-arg-empty′ q₀
-    (CTI2.conceal⊑² ok mono rb sc c⊢ D .q₀) =
-  probe-sealed-arg-partner-empty ok
+    (CTI2.conceal⊑²
+      (CTI2.seal-partner-ok (CTI2.plain-target ()))
+      mono rb sc c⊢ D .q₀)
 probe-sealed-arg-empty′ q₀
     (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ D .q₀) =
   probe-sealed-arg-ok-empty ok

--- a/GTSFImp/proof/DGG/SealTransferCore.agda
+++ b/GTSFImp/proof/DGG/SealTransferCore.agda
@@ -677,44 +677,7 @@ seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
     | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ} {M = P}
         (CTI2.matched-seal-star-partner partner)
         monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ Z∈′)
-        (CTI2.⊢↓-sealˣ Y∈) prem .p
-    with dynPayloadTargetRoute vU (CTI2T.target-typing² prem) partner
-seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    (sv-seal sv) vU source★ D
-    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
-    | refl
-    | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ} {M = P}
-        (CTI2.matched-seal-star-partner partner)
-        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ Z∈′)
-        (CTI2.⊢↓-sealˣ Y∈) prem .p
-    | dyn-target-stripped seal-ok =
-  seal-transfer-stripped
-    (dynLink {W = W₁} {Z = Z} {Y = Y}
-      (SVD.variable-obligation-aligns {W = W₁} {X = Z} {Y = Y} p)
-      (CTI2.RebaseAt.storeRepresentations rbᵖ))
-    (dyn-decay-mono {W = W₁})
-    (SVD.decaySameCtxʳ (SPT.dynWorld-decay W₁)
-      (sameCtx-refl {γ = γ₁}))
-    (CTI2.conceal⊑²
-      (CTI2.seal-partner-ok (seal-ok {P = P}))
-      (dyn-mono {W = W₁} {W′ = Wᵖ})
-      (CTI2.tag-rebase-varᴸ
-        (TD.decayRebaseAt (SPT.dynWorld-decay Wᵖ)
-          (SPT.dynWorld-decay W₁) rbᵖ))
-      (WD.decaySameCtx (SPT.dynWorld-decay W₁)
-        (SPT.dynWorld-decay Wᵖ) scᵖ)
-      (CTI2.⊢↓-sealˣ Z∈′)
-      (TD.⊢²-decay (SPT.dynWorld-decay Wᵖ) prem)
-      (dyn-var-star {W = W₁} {X = Z}))
-seal-transfer {W₁ = W₁} {γ₁ = γ₁} {Z = Z} {Y = Y} {p = p}
-    (sv-seal sv) vU source★ D
-    | ⊢conceal (⊢↓-seal Z∈) V₀⊢
-    | refl
-    | CTI2.conceal⊑conceal² {Wᵖ = Wᵖ} {γᵖ = γᵖ} {M = P}
-        (CTI2.matched-seal-star-partner partner)
-        monoᵖ rbᵖ scᵖ (CTI2.⊢↓-sealˣ Z∈′)
-        (CTI2.⊢↓-sealˣ Y∈) prem .p
-    | dyn-target-paired =
+        (CTI2.⊢↓-sealˣ Y∈) prem .p =
   seal-transfer-paired monoᵖ rbᵖ scᵖ
     (CTI2.⊢↓-sealˣ Z∈′) (CTI2.⊢↓-sealˣ Y∈)
     (CTI2.matched-seal-star-partner partner) prem

--- a/GTSFImp/proof/DGG/SealTransferCore.agda
+++ b/GTSFImp/proof/DGG/SealTransferCore.agda
@@ -324,30 +324,6 @@ transport-rep★-partner-ok-tag
       (CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
       partner)
 
-protected-tag-partner-from-cast : ∀ {Δᴸ Δᴿ Δ}
-    {W : World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ} {Y : TyVar Δᴿ}
-    {P : Term Δᴸ} {M : Term Δᴿ} {S : Ty Δᴿ} {μ : Env∼ Δᴿ}
-    {c : μ ⊢ (＇ Y) ∼ ★}
-  → CTI2.CenterAligned W X Y
-  → CTI2.Rep★PartnerOK W X P (just Y)
-      ((M ↓ Conversion.seal Y S) ⟨ c ⟩)
-protected-tag-partner-from-cast {Y = Y}
-    {c = _! {G = ＇ x} ⦃ Gᵍ = ＇ .x ⦄ cY} aligned
-    with cY
-protected-tag-partner-from-cast {Y = Y}
-    {c = _! {G = ＇ .Y} ⦃ Gᵍ = ＇ .Y ⦄ cY} aligned
-    | id (＇ .Y) =
-  CTI2.rep★-var-tag aligned
-protected-tag-partner-from-cast
-    {c = _! ⦃ Gᵍ = ‵ ι ⦄ cY} aligned =
-  CTI2.rep★-nonvar-tag nonvar-base
-protected-tag-partner-from-cast
-    {c = _! ⦃ Gᵍ = ★⇒★ ⦄ cY} aligned =
-  CTI2.rep★-nonvar-tag nonvar-fun
-protected-tag-partner-from-cast
-    {c = _! ⦃ Gᵍ = ∀★ ⦄ cY} aligned =
-  CTI2.rep★-nonvar-tag nonvar-all
-
 tagged-transfer-output-from-transport : ∀ {Δᴸ Δᴿ Δ}
     {Wᵖ W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
     {P : Term Δᴸ} {U : Term Δᴿ}
@@ -425,9 +401,15 @@ source-star-cast-package-from-source : ∀ {Δᴸ Δᴿ Δ}
       (W ∣ γ ⊢²
         ((P ↓ Conversion.seal X ★) ⟨ c ⟩) ↓ Conversion.seal X ★
         ⊑ U ∶ q)
+source-star-cast-package-from-source {W = W} {X = X}
+      {Xᴿ? = just Y} mono (CTI2.tag-rebase-varᴸ rb) sc
+      source∈ no-target partner inert prem sealed =
+  ⊥-elim (no-target (Y , sym (CTI2.RebaseAt.pivotAligned rb)))
 source-star-cast-package-from-source {W = W} {γ = γ} {X = X}
       {c = c}
-      {q = q} mono rb sc source∈ no-target partner
+      {q = q} mono rb@(CTI2.tag-rebase-onlyᴸ to-star disaligned
+        represented)
+      sc source∈ no-target partner
       (inj ⦃ Gᵍ = ＇ .X ⦄) prem sealed =
   tagged-transfer-output
     (CTI2.cast⊑² c sealed ★⊑★)
@@ -435,97 +417,10 @@ source-star-cast-package-from-source {W = W} {γ = γ} {X = X}
     (CTI2.matched-seal-star-partner
       (CTI2.rep★-round-trip
         (transport-rep★-partner-ok-tag rb partner))) ,
-    CTI2.conceal⊑²
-      (CTI2.seal-partner-ok
-        (CTI2.star-rep-target
-          no-target
-          (CTI2.rep★-round-trip
-            (transport-rep★-partner-ok-tag rb partner))))
+    CTI2.conceal⊑²-seal-star-open
+      no-target
     (impEnvMono-refl {W = W})
     (self-tag-rebase-from-tag-rebase rb)
-    (sameCtx-refl {γ = γ})
-    (CTI2.⊢↓-sealˣ source∈)
-    (CTI2.cast⊑² c sealed ★⊑★)
-    q
-
-source-star-cast-package-from-source-plain : ∀ {Δᴸ Δᴿ Δ}
-    {W Wᵖ : World Δᴸ Δᴿ Δ} {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
-    {P : Term Δᴸ} {U : Term Δᴿ}
-    {X : TyVar Δᴸ} {Xᴿ? : Maybe (TyVar Δᴿ)}
-    {ν : Env∼ Δᴸ} {c : ν ⊢ (＇ X) ∼ ★}
-    {p★ : ★ ⊑ᵂ⟨ Wᵖ ⟩ ★}
-    {q : (＇ X) ⊑ᵂ⟨ W ⟩ ★}
-  → CTI2.ImpEnvMono W Wᵖ
-  → CTI2.TagRebaseAtᴸ Wᵖ W (just X) Xᴿ?
-  → CTI2.SameCtx γ γᵖ
-  → CTI2.sourceStoreʷ W ∋ X ⦂ ★
-  → CTI2.NotTopTag U
-  → Inert c
-  → Wᵖ ∣ γᵖ ⊢² P ⊑ U ∶ p★
-  → W ∣ γ ⊢² P ↓ Conversion.seal X ★ ⊑ U ∶ q
-  → Σ[ pkg ∈ TaggedTransferOutput W γ
-        ((P ↓ Conversion.seal X ★) ⟨ c ⟩) U X Xᴿ? ]
-      (W ∣ γ ⊢²
-        ((P ↓ Conversion.seal X ★) ⟨ c ⟩) ↓ Conversion.seal X ★
-        ⊑ U ∶ q)
-source-star-cast-package-from-source-plain {W = W} {γ = γ} {X = X}
-    {c = c} {q = q} mono rb sc source∈
-    nt
-    (inj ⦃ Gᵍ = ＇ .X ⦄) prem sealed =
-  tagged-transfer-output
-    (CTI2.cast⊑² c sealed ★⊑★)
-    (premise-partner-from-tag-rebase rb)
-    (CTI2.matched-seal-star-partner (CTI2.rep★-untagged nt)) ,
-    CTI2.conceal⊑²
-      (CTI2.seal-partner-ok
-        (CTI2.plain-target nt))
-    (impEnvMono-refl {W = W})
-    (self-tag-rebase-from-tag-rebase rb)
-    (sameCtx-refl {γ = γ})
-    (CTI2.⊢↓-sealˣ source∈)
-    (CTI2.cast⊑² c sealed ★⊑★)
-    q
-
-source-star-cast-package-from-source-name : ∀ {Δᴸ Δᴿ Δ}
-    {W Wᵖ : World Δᴸ Δᴿ Δ} {γ : CtxImp W} {γᵖ : CtxImp Wᵖ}
-    {P : Term Δᴸ} {M : Term Δᴿ}
-    {X : TyVar Δᴸ} {Y : TyVar Δᴿ} {S : Ty Δᴿ}
-    {μ : Env∼ Δᴿ} {cY : μ ⊢ (＇ Y) ∼ ★}
-    {ν : Env∼ Δᴸ} {c : ν ⊢ (＇ X) ∼ ★}
-    {p★ : ★ ⊑ᵂ⟨ Wᵖ ⟩ ★}
-    {q : (＇ X) ⊑ᵂ⟨ W ⟩ ★}
-  → CTI2.ImpEnvMono W Wᵖ
-  → CTI2.TagRebaseAtᴸ Wᵖ W (just X) (just Y)
-  → CTI2.SameCtx γ γᵖ
-  → CTI2.sourceStoreʷ W ∋ X ⦂ ★
-  → Inert c
-  → Wᵖ ∣ γᵖ ⊢² P
-      ⊑ (M ↓ Conversion.seal Y S) ⟨ cY ⟩ ∶ p★
-  → W ∣ γ ⊢² P ↓ Conversion.seal X ★
-      ⊑ (M ↓ Conversion.seal Y S) ⟨ cY ⟩ ∶ q
-  → Σ[ pkg ∈ TaggedTransferOutput W γ
-        ((P ↓ Conversion.seal X ★) ⟨ c ⟩)
-        ((M ↓ Conversion.seal Y S) ⟨ cY ⟩) X (just Y) ]
-      (W ∣ γ ⊢²
-        ((P ↓ Conversion.seal X ★) ⟨ c ⟩) ↓ Conversion.seal X ★
-        ⊑ (M ↓ Conversion.seal Y S) ⟨ cY ⟩ ∶ q)
-source-star-cast-package-from-source-name {W = W} {γ = γ} {X = X}
-    {c = c} {q = q} mono (CTI2.tag-rebase-varᴸ rb) sc source∈
-    (inj ⦃ Gᵍ = ＇ .X ⦄) prem sealed =
-  tagged-transfer-output
-    (CTI2.cast⊑² c sealed ★⊑★)
-    (premise-partner-just (CTI2.RebaseAt.pivotAligned rb))
-    (CTI2.matched-seal-star-partner
-      (protected-tag-partner-from-cast
-        (CTI2.RebaseAt.pivotAligned rb))) ,
-    CTI2.conceal⊑²
-      (CTI2.seal-partner-ok
-        CTI2.name-protected-target)
-    (impEnvMono-refl {W = W})
-    (CTI2.tag-rebase-varᴸ
-      (CTI2.sameWorldRebaseAt
-        (CTI2.RebaseAt.pivotAligned rb)
-        (CTI2.RebaseAt.storeRepresentations rb)))
     (sameCtx-refl {γ = γ})
     (CTI2.⊢↓-sealˣ source∈)
     (CTI2.cast⊑² c sealed ★⊑★)

--- a/GTSFImp/proof/DGG/SimBackProof.agda
+++ b/GTSFImp/proof/DGG/SimBackProof.agda
@@ -130,6 +130,8 @@ SourceConcealRel : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
     {A : Ty Δᴸ} {B : Ty Δᴿ} {p : A ⊑ᵂ⟨ W ⟩ B}
   → W ∣ List.[] ⊢² M ⊑ M′ ∶ p → Set
 SourceConcealRel (conceal⊑² _ _ _ _ _ _ _) = ⊤
+SourceConcealRel (conceal⊑²-seal-star-open _ _ _ _ _ _ _) = ⊤
+SourceConcealRel (conceal⊑²-source-ok _ _ _ _ _ _ _) = ⊤
 SourceConcealRel _ = ⊥
 
 PrimitiveRel : ∀ {Δᴸ Δᴿ Δ} {W : World Δᴸ Δᴿ Δ}
@@ -981,6 +983,13 @@ module _
 
   sim-back parked rel@(conceal⊑² partner mono rebase same c⊢ M⊑M′ q)
       step =
+    sim-back-source-conceal-boundary parked rel tt step
+  sim-back parked
+      rel@(conceal⊑²-seal-star-open no-target mono rebase same c⊢ M⊑M′ q)
+      step =
+    sim-back-source-conceal-boundary parked rel tt step
+  sim-back parked
+      rel@(conceal⊑²-source-ok ok mono rebase same c⊢ M⊑M′ q) step =
     sim-back-source-conceal-boundary parked rel tt step
 
   sim-back parked rel@(reveal⊑reveal² mono rebase same c⊢ c′⊢ M⊑M′ q)

--- a/GTSFImp/proof/DGG/SimProof.agda
+++ b/GTSFImp/proof/DGG/SimProof.agda
@@ -793,7 +793,7 @@ module _
       rel@(conceal⊑² partner mono rebase same-[] c⊢ M⊑M′ q)
       step@(pure-step (id-conceal vM))
       | caught =
-    sim-source-conceal-values parked partner mono rebase c⊢
+    sim-source-conceal-values parked id-conceal-ok mono rebase c⊢
       M⊑M′ q vM step caught
   sim
       {Δᴿ = Δᴿ} {W = W} parked
@@ -830,7 +830,7 @@ module _
       rel@(conceal⊑²-source-ok id-conceal-ok mono rebase same-[] c⊢
         M⊑M′ q) step@(pure-step (id-conceal vM))
       | caught =
-    sim-source-conceal-values parked id-conceal-target mono rebase c⊢
+    sim-source-conceal-values parked id-conceal-ok mono rebase c⊢
       M⊑M′ q vM step caught
   sim
       {Δᴿ = Δᴿ} {W = W} parked

--- a/GTSFImp/proof/DGG/SimProof.agda
+++ b/GTSFImp/proof/DGG/SimProof.agda
@@ -808,6 +808,43 @@ module _
       step@(ξ-conceal M→N refl) =
     source-conceal-frame parked rel step
 
+  sim
+      {Δᴿ = Δᴿ} {W = W} parked
+      rel@(conceal⊑²-seal-star-open no-target mono rebase same c⊢ M⊑M′ q)
+      (pure-step blame-conceal) =
+    Δᴿ , [] , _ , _ , W , q ,
+    (_ ∎[]) ,
+    evolve-keepᴸ evolve-refl ,
+    blame⊑² (CTI2T.target-typing² rel) q
+  sim parked
+      rel@(conceal⊑²-seal-star-open no-target mono rebase same c⊢ M⊑M′ q)
+      step@(ξ-conceal M→N refl) =
+    source-conceal-frame parked rel step
+
+  sim parked
+      rel@(conceal⊑²-source-ok id-conceal-ok mono rebase same-[] c⊢
+        M⊑M′ q) step@(pure-step (id-conceal vM))
+      with catchup parked (boundary-source-conceal mono rebase)
+        M⊑M′ vM
+  sim parked
+      rel@(conceal⊑²-source-ok id-conceal-ok mono rebase same-[] c⊢
+        M⊑M′ q) step@(pure-step (id-conceal vM))
+      | caught =
+    sim-source-conceal-values parked id-conceal-target mono rebase c⊢
+      M⊑M′ q vM step caught
+  sim
+      {Δᴿ = Δᴿ} {W = W} parked
+      rel@(conceal⊑²-source-ok ok mono rebase same c⊢ M⊑M′ q)
+      (pure-step blame-conceal) =
+    Δᴿ , [] , _ , _ , W , q ,
+    (_ ∎[]) ,
+    evolve-keepᴸ evolve-refl ,
+    blame⊑² (CTI2T.target-typing² rel) q
+  sim parked
+      rel@(conceal⊑²-source-ok ok mono rebase same c⊢ M⊑M′ q)
+      step@(ξ-conceal M→N refl) =
+    source-conceal-frame parked rel step
+
   sim parked
       rel@(reveal⊑reveal² mono rebase same-[] c⊢ c′⊢ M⊑M′ q)
       step@(pure-step (id-reveal vM))

--- a/GTSFImp/proof/DGG/SimSourceConcealValuesDef.agda
+++ b/GTSFImp/proof/DGG/SimSourceConcealValuesDef.agda
@@ -28,7 +28,7 @@ open import proof.DGG.CatchupToMorePreciseDef
   using (ValueCatchupResult; source-conceal-boundary)
 open CTI2 using
   ( World
-  ; SourceConcealPartnerOK
+  ; SourceConcealOK
   ; ImpEnvMono
   ; TagRebaseAtᴸ
   ; sourceStoreʷ
@@ -48,7 +48,7 @@ SimSourceConcealValuesᵀ =
     {c : Conv↓ Δᴸ A A′}
     {p : A ⊑ᵂ⟨ Wᵖ ⟩ B}
   → ParkedWorld W
-  → SourceConcealPartnerOK Wᵖ V c Xᴿ? M′
+  → SourceConcealOK Wᵖ V c Xᴿ? M′
   → (mono : ImpEnvMono W Wᵖ)
   → TagRebaseAtᴸ Wᵖ W Xᴸ? Xᴿ?
   → sourceStoreʷ W ⊢↓[ Xᴸ? ] c

--- a/GTSFImp/proof/DGG/StarRepChainProbe.agda
+++ b/GTSFImp/proof/DGG/StarRepChainProbe.agda
@@ -183,11 +183,8 @@ base² =
 
 inner-source² : W ∣ [] ⊢² source-inner ⊑ target-core ∶ inner-type
 inner-source² =
-  CTI2.conceal⊑²
-    (CTI2.seal-partner-ok
-      (CTI2.star-rep-target
-        X-no-target-occupant
-        (CTI2.rep★-nonvar-tag nonvar-base)))
+  CTI2.conceal⊑²-seal-star-open
+    X-no-target-occupant
     (λ Z eq → eq) inner-source-only-rebase CTI2.same-[]
     source-X-seal-⊢ base² inner-type
 

--- a/GTSFImp/proof/DGG/TargetBindLift.agda
+++ b/GTSFImp/proof/DGG/TargetBindLift.agda
@@ -309,6 +309,25 @@ private
   moveSourceConcealPartnerOK mv CTI2.id-conceal-target =
     CTI2.id-conceal-target
 
+  moveSourceConcealOK : ∀ {Δᴸ Δᴿ Δ}
+      {W Wᵗ : World Δᴸ Δᴿ Δ}
+      {M : Term Δᴸ} {A A′ : Ty Δᴸ}
+      {c : Conv↓ Δᴸ A A′} {Xᴿ? M′}
+    → TargetStoreMove W Wᵗ
+    → CTI2.SourceConcealOK W M c Xᴿ? M′
+    → CTI2.SourceConcealOK Wᵗ M c Xᴿ? M′
+  moveSourceConcealOK mv (CTI2.seal-nonstar-plain-ok Rns nt) =
+    CTI2.seal-nonstar-plain-ok Rns nt
+  moveSourceConcealOK (target-store-move refl refl same refl hΣ resolve)
+      (CTI2.seal-nonstar-name-protected-ok Rns aligned) =
+    CTI2.seal-nonstar-name-protected-ok Rns aligned
+  moveSourceConcealOK mv CTI2.fun-conceal-ok =
+    CTI2.fun-conceal-ok
+  moveSourceConcealOK mv CTI2.all-conceal-ok =
+    CTI2.all-conceal-ok
+  moveSourceConcealOK mv CTI2.id-conceal-ok =
+    CTI2.id-conceal-ok
+
   moveMatchedConcealPartnerOK : ∀ {Δᴸ Δᴿ Δ}
       {W Wᵗ : World Δᴸ Δᴿ Δ}
       {M : Term Δᴸ} {A A′ : Ty Δᴸ}
@@ -1164,6 +1183,38 @@ source-conceal-move
     | W′ᵗ , mv′ , rb′ =
   CTI2.conceal⊑²
     (moveSourceConcealPartnerOK (baseMove mv′) ok)
+    (moveImpEnvMono (baseMove mv) (baseMove mv′) mono)
+    rb′
+    (moveSameCtx (baseMove mv) (baseMove mv′) sc)
+    (source-conceal-move (baseMove mv) c⊢)
+    (⊢²-target-bind-lift-move mv′ M⊑M′)
+    (move⊑ᵂ (baseMove mv) q)
+⊢²-target-bind-lift-move mv
+    (CTI2.conceal⊑²-seal-star-open {W′ = W′} {p = p}
+      no-target mono rb sc c⊢ M⊑M′ q)
+    with moveTagRebaseAtᴸBackwardBindLift mv mono rb
+⊢²-target-bind-lift-move mv
+    (CTI2.conceal⊑²-seal-star-open {W′ = W′} {p = p}
+      no-target mono rb sc c⊢ M⊑M′ q)
+    | W′ᵗ , mv′ , rb′ =
+  CTI2.conceal⊑²-seal-star-open
+    (moveNoTargetOccupantAtSource (baseMove mv′) no-target)
+    (moveImpEnvMono (baseMove mv) (baseMove mv′) mono)
+    rb′
+    (moveSameCtx (baseMove mv) (baseMove mv′) sc)
+    (source-conceal-move (baseMove mv) c⊢)
+    (⊢²-target-bind-lift-move mv′ M⊑M′)
+    (move⊑ᵂ (baseMove mv) q)
+⊢²-target-bind-lift-move mv
+    (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p}
+      ok mono rb sc c⊢ M⊑M′ q)
+    with moveTagRebaseAtᴸBackwardBindLift mv mono rb
+⊢²-target-bind-lift-move mv
+    (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p}
+      ok mono rb sc c⊢ M⊑M′ q)
+    | W′ᵗ , mv′ , rb′ =
+  CTI2.conceal⊑²-source-ok
+    (moveSourceConcealOK (baseMove mv′) ok)
     (moveImpEnvMono (baseMove mv) (baseMove mv′) mono)
     rb′
     (moveSameCtx (baseMove mv) (baseMove mv′) sc)

--- a/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
+++ b/GTSFImp/proof/DGG/TargetBlameCatchupProof.agda
@@ -112,6 +112,12 @@ target-value-blame-exclusion (vV CastTerms.↑ rv)
 target-value-blame-exclusion (vV CastTerms.↓ cv)
     (CTI2.conceal⊑² ok mono rb same c⊢ prem q) =
   target-value-blame-exclusion vV prem
+target-value-blame-exclusion (vV CastTerms.↓ cv)
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb same c⊢ prem q) =
+  target-value-blame-exclusion vV prem
+target-value-blame-exclusion (vV CastTerms.↓ cv)
+    (CTI2.conceal⊑²-source-ok ok mono rb same c⊢ prem q) =
+  target-value-blame-exclusion vV prem
 
 
 TargetBlameCatchupUnderBoundaryᵀ : Set
@@ -286,6 +292,32 @@ target-blame-catchup-under-boundary target-value-blame-exclusion
 target-blame-catchup-under-boundary target-value-blame-exclusion
     parked boundary
     (CTI2.conceal⊑² ok mono rb CTI2.same-[] c⊢ prem q)
+    | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
+  source-conceal-blame-catchup M↠blame evol
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb CTI2.same-[]
+      c⊢ prem q)
+    with target-blame-catchup-under-boundary
+      target-value-blame-exclusion parked
+      (target-blame-boundary-source-conceal boundary mono rb)
+      prem
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.conceal⊑²-seal-star-open no-target mono rb CTI2.same-[]
+      c⊢ prem q)
+    | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
+  source-conceal-blame-catchup M↠blame evol
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.conceal⊑²-source-ok ok mono rb CTI2.same-[] c⊢ prem q)
+    with target-blame-catchup-under-boundary
+      target-value-blame-exclusion parked
+      (target-blame-boundary-source-conceal boundary mono rb)
+      prem
+target-blame-catchup-under-boundary target-value-blame-exclusion
+    parked boundary
+    (CTI2.conceal⊑²-source-ok ok mono rb CTI2.same-[] c⊢ prem q)
     | Δᴸ′ , χsᴸ , Δ′ , W′ , M↠blame , evol =
   source-conceal-blame-catchup M↠blame evol
 

--- a/GTSFImp/proof/DGG/TargetExtend.agda
+++ b/GTSFImp/proof/DGG/TargetExtend.agda
@@ -2956,6 +2956,30 @@ renameSourceConcealPartnerOK align no-target-map CTI2.all-conceal-target =
 renameSourceConcealPartnerOK align no-target-map CTI2.id-conceal-target =
   CTI2.id-conceal-target
 
+renameSourceConcealOK : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′}
+    {M : Term Δᴸ} {A A′ : Ty Δᴸ}
+    {c : Conv↓ Δᴸ A A′} {Xᴿ? M′}
+  → (∀ {X₀ Y₀}
+      → CTI2.CenterAligned W X₀ Y₀
+      → CTI2.CenterAligned W′ X₀ (toRenameᵗ ρ Y₀))
+  → CTI2.SourceConcealOK W M c Xᴿ? M′
+  → CTI2.SourceConcealOK W′ M c
+      (mapPivot (toRenameᵗ ρ) Xᴿ?) (renameᵗᵐ ρ M′)
+renameSourceConcealOK align
+    (CTI2.seal-nonstar-plain-ok Rns nt) =
+  CTI2.seal-nonstar-plain-ok Rns (notTopTag-rename _ nt)
+renameSourceConcealOK align
+    (CTI2.seal-nonstar-name-protected-ok Rns aligned) =
+  CTI2.seal-nonstar-name-protected-ok Rns (align aligned)
+renameSourceConcealOK align CTI2.fun-conceal-ok =
+  CTI2.fun-conceal-ok
+renameSourceConcealOK align CTI2.all-conceal-ok =
+  CTI2.all-conceal-ok
+renameSourceConcealOK align CTI2.id-conceal-ok =
+  CTI2.id-conceal-ok
+
 renameMatchedConcealPartnerOK : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {W : World Δᴸ Δᴿ Δ} {W′ : World Δᴸ Δᴿ′ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′}
@@ -3540,6 +3564,38 @@ primResultTy-renameᵗ ρ and𝔹 = refl
   CTI2.conceal⊑²
     (renameSourceConcealPartnerOK
       (align-insert insᵖ) (targetInsertNoTargetAtSource insᵖ) ok)
+    (impEnvMono-insert ins insᵖ mono)
+    rb⁺
+    (mapCtxᵀ-same ins insᵖ sc)
+    (source-conceal-insert ins c⊢)
+    (⊢²-target-insert insᵖ M⊑M′)
+    (transport⊑ᵂ ins q)
+⊢²-target-insert {ρ = ρ} ins
+    (CTI2.conceal⊑²-seal-star-open {W′ = W′} {p = p}
+      no-target mono rb sc c⊢ M⊑M′ q)
+    with reverseTagRebaseAtᴸ ins rb
+⊢²-target-insert {ρ = ρ} ins
+    (CTI2.conceal⊑²-seal-star-open {W′ = W′} {p = p}
+      no-target mono rb sc c⊢ M⊑M′ q)
+    | Wᵖ⁺ , insᵖ , rb⁺ =
+  CTI2.conceal⊑²-seal-star-open
+    (targetInsertNoTargetAtSource insᵖ no-target)
+    (impEnvMono-insert ins insᵖ mono)
+    rb⁺
+    (mapCtxᵀ-same ins insᵖ sc)
+    (source-conceal-insert ins c⊢)
+    (⊢²-target-insert insᵖ M⊑M′)
+    (transport⊑ᵂ ins q)
+⊢²-target-insert {ρ = ρ} ins
+    (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p}
+      ok mono rb sc c⊢ M⊑M′ q)
+    with reverseTagRebaseAtᴸ ins rb
+⊢²-target-insert {ρ = ρ} ins
+    (CTI2.conceal⊑²-source-ok {W′ = W′} {p = p}
+      ok mono rb sc c⊢ M⊑M′ q)
+    | Wᵖ⁺ , insᵖ , rb⁺ =
+  CTI2.conceal⊑²-source-ok
+    (renameSourceConcealOK (align-insert insᵖ) ok)
     (impEnvMono-insert ins insᵖ mono)
     rb⁺
     (mapCtxᵀ-same ins insᵖ sc)

--- a/GTSFImp/proof/DGG/TermImpDecay.agda
+++ b/GTSFImp/proof/DGG/TermImpDecay.agda
@@ -416,6 +416,26 @@ private
   decaySourceConcealPartnerOK dec CTI2.id-conceal-target =
     CTI2.id-conceal-target
 
+  decaySourceConcealOK : ∀ {Δᴸ Δᴿ Δ}
+      {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+      {M : Term Δᴸ} {A A′ : Ty Δᴸ}
+      {c : Conv↓ Δᴸ A A′} {Xᴿ? M′}
+    → EnvDecay W Wᵈ
+    → CTI2.SourceConcealOK W M c Xᴿ? M′
+    → CTI2.SourceConcealOK Wᵈ M c Xᴿ? M′
+  decaySourceConcealOK dec
+      (CTI2.seal-nonstar-plain-ok Rns nt) =
+    CTI2.seal-nonstar-plain-ok Rns nt
+  decaySourceConcealOK (env-decay refl refl refl refl mono)
+      (CTI2.seal-nonstar-name-protected-ok Rns aligned) =
+    CTI2.seal-nonstar-name-protected-ok Rns aligned
+  decaySourceConcealOK dec CTI2.fun-conceal-ok =
+    CTI2.fun-conceal-ok
+  decaySourceConcealOK dec CTI2.all-conceal-ok =
+    CTI2.all-conceal-ok
+  decaySourceConcealOK dec CTI2.id-conceal-ok =
+    CTI2.id-conceal-ok
+
   decayMatchedConcealPartnerOK : ∀ {Δᴸ Δᴿ Δ}
       {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
       {M : Term Δᴸ} {A A′ : Ty Δᴸ}
@@ -653,6 +673,61 @@ private
       (CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
       sc c⊢ M⊑M′ q) =
   CTI2.conceal⊑² (decaySourceConcealPartnerOK dec ok)
+    (λ _ eq → eq)
+    (CTI2.tag-rebase-onlyᴸ (mono _ to-star) disaligned
+      (decay⊑ᵂ dec represented))
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑²-seal-star-open no-target rule-mono
+      (CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
+      sc c⊢ M⊑M′ q) =
+  CTI2.conceal⊑²-seal-star-open
+    (decayNoTargetOccupantAtSource dec no-target)
+    (λ _ eq → eq)
+    (CTI2.tag-rebase-onlyᴸ (mono _ to-star) disaligned
+      (decay⊑ᵂ dec represented))
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑²-source-ok ok rule-mono CTI2.tag-rebase-idᴸ
+      sc c⊢ M⊑M′ q) =
+  CTI2.conceal⊑²-source-ok (decaySourceConcealOK dec ok)
+    (λ _ eq → eq) CTI2.tag-rebase-idᴸ
+    (decaySameCtx dec dec sc) c⊢ (⊢²-decay dec M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑²-source-ok {W′ = W′} ok rule-mono
+      (CTI2.tag-rebase-varᴸ rb) sc c⊢ M⊑M′ q) =
+  CTI2.conceal⊑²-source-ok
+    (decaySourceConcealOK
+      (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) ok)
+    (blend-mono {W′ = W′} {Wᵈ = Wᵈ})
+    (CTI2.tag-rebase-varᴸ
+      (decayRebaseAt
+        (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) dec rb))
+    (decaySameCtx dec
+      (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) sc)
+    c⊢
+    (⊢²-decay (blend-decay {W′ = W′} {Wᵈ = Wᵈ}) M⊑M′)
+    (decay⊑ᵂ dec q)
+⊢²-decay
+    {W = CTI2.world ηL ηR μ ΣL ΣR}
+    {Wᵈ = Wᵈ@(CTI2.world ηL′ ηR′ μᵈ ΣL′ ΣR′)}
+    dec@(env-decay refl refl refl refl mono)
+    (CTI2.conceal⊑²-source-ok ok rule-mono
+      (CTI2.tag-rebase-onlyᴸ to-star disaligned represented)
+      sc c⊢ M⊑M′ q) =
+  CTI2.conceal⊑²-source-ok (decaySourceConcealOK dec ok)
     (λ _ eq → eq)
     (CTI2.tag-rebase-onlyᴸ (mono _ to-star) disaligned
       (decay⊑ᵂ dec represented))

--- a/GTSFImp/proof/DGG/TerminusRebuildProbe.agda
+++ b/GTSFImp/proof/DGG/TerminusRebuildProbe.agda
@@ -200,6 +200,12 @@ module InstanceA where
   terminus-input-partner-empty
       (CTI2.seal-partner-ok (CTI2.plain-target ()))
 
+  terminus-input-ok-empty : ∀ {Wᵖ : World 1 1 1} {P Xᴿ?}
+    → CTI2.SourceConcealOK Wᵖ P (seal X ∀X⇒X) Xᴿ? U
+    → ⊥
+  terminus-input-ok-empty
+      (CTI2.seal-nonstar-plain-ok Rns ())
+
   terminus-input-empty′ : ∀ {X′}
     → (q : ＇ X′ ⊑ᵂ⟨ W ⟩ ★)
     → W ∣ [] ⊢² source ⊑ U ∶ q
@@ -211,6 +217,9 @@ module InstanceA where
   terminus-input-empty′ q₀
       (CTI2.conceal⊑² ok mono rb sc c⊢ D .q₀) =
     terminus-input-partner-empty ok
+  terminus-input-empty′ q₀
+      (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ D .q₀) =
+    terminus-input-ok-empty ok
 
   terminus-input-empty : W ∣ [] ⊢² source ⊑ U ∶ X⊑★-W → ⊥
   terminus-input-empty =

--- a/GTSFImp/proof/DGG/TerminusRebuildProbe.agda
+++ b/GTSFImp/proof/DGG/TerminusRebuildProbe.agda
@@ -11,7 +11,8 @@ module proof.DGG.TerminusRebuildProbe where
 --   * Instance B is the S = ＇Y₂ chain template: the input has the
 --     source inert variable cast required by the blocked M3 branch, and
 --     the output pairs at the ★ terminus before re-emitting the outer
---     target-only seal.
+--     target-only seal.  The old occupied source-star/tagged-target
+--     direct witness is now tracked as a D15 migration residual.
 --   * This is the positive counterpart to the refuted tag-peel-first
 --     family documented in `RightInjInversion2Def`: the head is rebuilt
 --     at the target-chain terminus instead of against a right variable.
@@ -194,12 +195,6 @@ module InstanceA where
     CTI2.Λ⊑² nonvar-fun (∈-fun-left var-∈)
       CTI2.liftᴸ-[] (ƛ (` 0)) U-⊢ body-U² source-∀⊑★
 
-  terminus-input-partner-empty : ∀ {Wᵖ : World 1 1 1} {P Xᴿ?}
-    → CTI2.SourceConcealPartnerOK Wᵖ P (seal X ∀X⇒X) Xᴿ? U
-    → ⊥
-  terminus-input-partner-empty
-      (CTI2.seal-partner-ok (CTI2.plain-target ()))
-
   terminus-input-ok-empty : ∀ {Wᵖ : World 1 1 1} {P Xᴿ?}
     → CTI2.SourceConcealOK Wᵖ P (seal X ∀X⇒X) Xᴿ? U
     → ⊥
@@ -215,8 +210,9 @@ module InstanceA where
   terminus-input-empty′ (X⊑★ eq)
       (CTI2.⊑cast² {p = p} c′ D .(X⊑★ eq)) | ()
   terminus-input-empty′ q₀
-      (CTI2.conceal⊑² ok mono rb sc c⊢ D .q₀) =
-    terminus-input-partner-empty ok
+      (CTI2.conceal⊑²
+        (CTI2.seal-partner-ok (CTI2.plain-target ()))
+        mono rb sc c⊢ D .q₀)
   terminus-input-empty′ q₀
       (CTI2.conceal⊑²-source-ok ok mono rb sc c⊢ D .q₀) =
     terminus-input-ok-empty ok
@@ -401,18 +397,6 @@ module InstanceB where
         (CTI2.x⊑x² {p = ★⊑★} CTI2.Zʷ))
       ★⊑★
 
-  inner-source-occupied : CTI2.NoTargetOccupantAtSource Wᵖ X → ⊥
-  inner-source-occupied no-target = no-target (Y₂ , refl)
-
-  inner-source-partner-empty :
-    CTI2.SourceConcealPartnerOK Wᵖ V₀ (seal X ★) (just Y₂) U₀
-    → ⊥
-  inner-source-partner-empty
-      (CTI2.seal-partner-ok (CTI2.star-rep-target no-target _)) =
-    inner-source-occupied no-target
-  inner-source-partner-empty
-      (CTI2.seal-partner-ok (CTI2.plain-target ()))
-
   premise-chain² : W ∣ [] ⊢² V ⊑ target-chain ∶ X⊑Y
   premise-chain² =
     CTI2.⊑conceal² mono-W-Wᵖ (CTI2.rebase-varᴿ rb-chain)
@@ -430,9 +414,7 @@ module InstanceB where
   premise-casts² =
     CTI2.cast⊑cast² X! Y! premise-chain² ★⊑★
 
-  tagged-input : W ∣ [] ⊢² source ⊑ target-tagged ∶ X⊑★-W
-  tagged-input =
-    CTI2.conceal⊑²
-      (CTI2.seal-partner-ok CTI2.name-protected-target)
-      (mono-refl {W = W}) (CTI2.tag-rebase-varᴸ rb-X-Y)
-      CTI2.same-[] source-seal-⊢ premise-casts² X⊑★-W
+  -- D15 M1 residual: the old checked `tagged-input` used the removed
+  -- occupied source-star/name-protected source-only route.  The matched
+  -- chain pieces above remain checked; reassembling this tagged endpoint
+  -- needs the later source-star package migration.

--- a/GTSFImp/proof/DGG/notes/probes/SealStarOpenVarTagShapeProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/SealStarOpenVarTagShapeProbe.agda
@@ -1,0 +1,151 @@
+module SealStarOpenVarTagShapeProbe where
+
+-- Probe for the T14/D15 source-only `seal X ★` open rule.  The world below
+-- has no target occupant at source `X`, while target `Y` is a visible
+-- top-level variable tag at a different center.  The checked result is that
+-- the `★⊑★` premise needed by `conceal⊑²-seal-star-open` cannot be built for
+-- this unrelated target tag.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+open import Data.List using ([])
+open import Data.Maybe using (just; nothing)
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types
+open import TyStore using (TyStore; store-empty; store-bind; _∋_⦂_; Z∋)
+open import Consistency using
+  (Env∼; X∼★; _⊢_∼_; _↪ᵗ_; empty; keep; skip; toRenameᵗ; id; _!)
+open import Conversion using (seal)
+open import Imprecision
+open import CastTerms using (Term; Value; $; _⟨_⟩; _↓_; _《_》; inj)
+open import Primitives using (κℕ)
+import proof.DGG.CastTermImprecision2 as CTI2
+open CTI2 using
+  (World; world; _⊑ᵂ⟨_⟩_; _∣_⊢²_⊑_∶_;
+   TagRebaseAtᴸ; CtxImp; sourceStoreʷ; ⊢↓-sealˣ)
+
+private
+  X : TyVar 1
+  X = Fin.zero
+
+  Y : TyVar 1
+  Y = Fin.zero
+
+  source-store : TyStore 1
+  source-store = store-bind store-empty ★
+
+  target-store : TyStore 1
+  target-store = store-bind store-empty (‵ `ℕ)
+
+  source-X∋ : source-store ∋ X ⦂ ★
+  source-X∋ = Z∋ refl
+
+  target-Y∋ : target-store ∋ Y ⦂ ‵ `ℕ
+  target-Y∋ = Z∋ refl
+
+  source-η : 1 ↪ᵗ 2
+  source-η = keep empty
+
+  target-η : 1 ↪ᵗ 2
+  target-η = skip (keep empty)
+
+  imp-env : ImpEnv 2
+  imp-env Fin.zero = X⊑★
+  imp-env (Fin.suc Fin.zero) = X⊑★
+
+  W : World 1 1 2
+  W = world source-η target-η imp-env source-store target-store
+
+  source-env-tag : Env∼ 1
+  source-env-tag _ = X∼★
+
+  target-env-tag : Env∼ 1
+  target-env-tag _ = X∼★
+
+  ℕ!ˢ : source-env-tag ⊢ (‵ `ℕ) ∼ ★
+  ℕ!ˢ = id (‵ `ℕ) !
+
+  Y! : target-env-tag ⊢ ＇ Y ∼ ★
+  Y! = id (＇ Y) !
+
+  source-dyn-nat : Term 1
+  source-dyn-nat = $ (κℕ 0) ⟨ ℕ!ˢ ⟩
+
+  target-Y-sealed : Term 1
+  target-Y-sealed = $ (κℕ 0) ↓ seal Y (‵ `ℕ)
+
+  target-Y-tagged : Term 1
+  target-Y-tagged = target-Y-sealed ⟨ Y! ⟩
+
+  source-open-term : Term 1
+  source-open-term = source-dyn-nat ↓ seal X ★
+
+  source-dyn-nat-value : Value source-dyn-nat
+  source-dyn-nat-value = $ (κℕ 0) 《 inj 》
+
+  target-Y-sealed-value : Value target-Y-sealed
+  target-Y-sealed-value = $ (κℕ 0) ↓ CastTerms.seal
+
+  target-Y-tagged-value : Value target-Y-tagged
+  target-Y-tagged-value = target-Y-sealed-value 《 inj 》
+
+  source-X-seal-typed : source-store CTI2.⊢↓[ just X ] seal X ★
+  source-X-seal-typed = ⊢↓-sealˣ source-X∋
+
+  no-target-at-X : CTI2.NoTargetOccupantAtSource W X
+  no-target-at-X (Fin.zero , ())
+
+  not-center-aligned-X-Y : CTI2.CenterAligned W X Y → ⊥
+  not-center-aligned-X-Y ()
+
+  no-target-rebase : TagRebaseAtᴸ W W (just X) nothing
+  no-target-rebase =
+    CTI2.tag-rebase-onlyᴸ refl (λ { Fin.zero () }) ★⊑★
+
+  mono-refl : CTI2.ImpEnvMono W W
+  mono-refl Z eq = eq
+
+  qX★ : ＇ X ⊑ᵂ⟨ W ⟩ ★
+  qX★ = X⊑★ refl
+
+  ℕ-not-target-Y : (‵ `ℕ) ⊑ᵂ⟨ W ⟩ ＇ Y → ⊥
+  ℕ-not-target-Y ()
+
+  ★-not-target-Y : ★ ⊑ᵂ⟨ W ⟩ ＇ Y → ⊥
+  ★-not-target-Y ()
+
+  source-nat-target-Y-tagged-empty :
+    W ∣ [] ⊢² $ (κℕ 0) ⊑ target-Y-tagged ∶ ι⊑★ {ι = `ℕ}
+    → ⊥
+  source-nat-target-Y-tagged-empty
+      (CTI2.⊑cast² {p = p} _ _ _) =
+    ℕ-not-target-Y p
+
+  shape-free-open-premise-empty :
+    W ∣ [] ⊢² source-dyn-nat ⊑ target-Y-tagged ∶ ★⊑★
+    → ⊥
+  shape-free-open-premise-empty
+      (CTI2.cast⊑cast² {p = p} _ _ _ _) =
+    ℕ-not-target-Y p
+  shape-free-open-premise-empty
+      (CTI2.cast⊑² {p = p} _ D _)
+      with p
+  shape-free-open-premise-empty
+      (CTI2.cast⊑² {p = p} _ D _)
+      | ι⊑★ {ι = `ℕ} =
+    source-nat-target-Y-tagged-empty D
+  shape-free-open-premise-empty
+      (CTI2.⊑cast² {p = p} _ D _)
+      with p
+  shape-free-open-premise-empty
+      (CTI2.⊑cast² {p = p} _ D _)
+      | ()
+
+ShapeFreeVarTagProbeVerdict : Set
+ShapeFreeVarTagProbeVerdict =
+  W ∣ [] ⊢² source-dyn-nat ⊑ target-Y-tagged ∶ ★⊑★ → ⊥
+
+shape-free-var-tag-probe-verdict : ShapeFreeVarTagProbeVerdict
+shape-free-var-tag-probe-verdict = shape-free-open-premise-empty

--- a/GTSFImp/proof/DGG/notes/t14-m1-residuals.red
+++ b/GTSFImp/proof/DGG/notes/t14-m1-residuals.red
@@ -1,0 +1,40 @@
+# T14 M1 residuals
+
+Scope: D15 migration stage M1, covering the core CTI2-adjacent
+projection/transport tier and the low-level inversion/probe tier only.
+
+## Residual R1. `TerminusRebuildProbe.InstanceB.tagged-input`
+
+The old witness used the removed source-only occupied `seal X ★`
+name-protected route:
+
+```agda
+CTI2.conceal⊑²
+  (CTI2.seal-partner-ok CTI2.name-protected-target)
+  (mono-refl {W = W}) (CTI2.tag-rebase-varᴸ rb-X-Y)
+  CTI2.same-[] source-seal-⊢ premise-casts² X⊑★-W
+```
+
+Under D15, the source-only `seal X ★` opening rule is available only
+through `conceal⊑²-seal-star-open`, which requires
+`NoTargetOccupantAtSource W X`.  Instance B is intentionally occupied:
+`Y` is aligned with source `X` in `W`, so the occupancy gate is closed.
+
+The matched-chain pieces remain checked in `TerminusRebuildProbe`:
+
+- the inner source/target `seal X ★` to `seal Y₂ ★` pairing through
+  `conceal⊑conceal²`;
+- the outer target-only `seal Y (＇ Y₂)` chain through `⊑conceal²`;
+- the casted premise `premise-casts²`.
+
+Reassembling the old final tagged endpoint requires the later
+source-star package migration rather than a narrow M1 transport edit.
+The checked old direct witness was therefore removed from the probe.
+
+## Stage-Deferred Legacy Coverage
+
+The tier-1 transport modules and low-level inversion modules still have
+totality branches for the legacy `conceal⊑²` constructor because the
+constructor itself is not deleted until the final migration stage.  These
+branches preserve coverage only; new M1 construction sites were moved to
+`conceal⊑²-source-ok` or routed to the residual above.

--- a/GTSFImp/proof/DGG/notes/t14-m2-residuals.red
+++ b/GTSFImp/proof/DGG/notes/t14-m2-residuals.red
@@ -1,0 +1,74 @@
+# T14 M2 residuals
+
+Scope: D15 migration stage M2, covering the middle target-chain and
+source-strip consumers plus the catchup structural endpoint helpers.
+
+## Carried residual R1. `TerminusRebuildProbe.InstanceB.tagged-input`
+
+The M1 residual remains blocked after the source-star package pass.  The
+needed endpoint is still an occupied source-only `seal X ★` opening:
+
+```agda
+CTI2.conceal⊑²
+  (CTI2.seal-partner-ok CTI2.name-protected-target)
+  (mono-refl {W = W}) (CTI2.tag-rebase-varᴸ rb-X-Y)
+  CTI2.same-[] source-seal-⊢ premise-casts² X⊑★-W
+```
+
+D15 admits source-only `seal X ★` only through
+`conceal⊑²-seal-star-open`, which requires
+`NoTargetOccupantAtSource W X`.  Instance B intentionally has target
+`Y` aligned with source `X`, so that occupancy premise is false.  The
+matched inner chain remains checked, but it does not reconstruct this
+old occupied source-only wrapper without a different matched-package
+surface.
+
+## Residual R2. `SealTransferCore.seal-transfer`
+
+`seal-transfer` still has a dynamic stripped branch that rebuilds:
+
+```agda
+CTI2.conceal⊑²
+  (CTI2.seal-partner-ok (seal-ok {P = P}))
+```
+
+This branch consumes an abstract `SealPartnerOK` from the target-strip
+route.  The local data are not enough to split it into the D15
+alternatives: source-only `seal X ★` needs an explicit
+`NoTargetOccupantAtSource`, while non-star source seals need a
+`SourceConcealOK` endpoint.  Converting this branch requires a split
+target-strip endpoint interface rather than a constructor swap.
+
+## Residual R3. `TargetChainProof.target-source-star-at`
+
+The direct source-star/name-protected branch now routes to the payload
+case.  Four recursive re-emission branches still synthesize the old
+occupied source-only wrapper around residual target-chain data:
+
+```agda
+CTI2.conceal⊑²
+  (CTI2.seal-partner-ok CTI2.name-protected-target)
+```
+
+These branches are exactly the occupied source-star cases excluded from
+`conceal⊑²-seal-star-open`.  They need a richer matched source-star
+package route that preserves the residual/payload square, not a local
+no-target transport.
+
+## Residual R4. `SourceStripProof.source-tag-seal-core-tagged`
+
+The `★` target-strip data re-emitter still builds the same old
+name-protected source-only wrapper.  The target-strip package exposes
+the boundary, target seal membership, premise, and re-emitter, but it
+does not expose `NoTargetOccupantAtSource`, and `conceal⊑²-source-ok`
+is inapplicable because the source seal payload is `★`.
+
+## Residual R5. Structural name-instantiation source replay
+
+`StructuralCatchupRightDef` now has checked structural catchup helpers
+for `conceal⊑²-seal-star-open` and `conceal⊑²-source-ok`.  The broader
+`StructuralNameInstantiationProof` replay path still has only the old
+abstract `SourceConcealPartnerOK` surface.  Isolated checking of that
+module timed out without diagnostics, so the surface expansion was not
+attempted in M2.  Converting it requires a narrow source-ok/no-target
+surface through `StructuralStrictViewSurfaces`.

--- a/GTSFImp/proof/DGG/notes/t14-m3-deletion-blockers.red
+++ b/GTSFImp/proof/DGG/notes/t14-m3-deletion-blockers.red
@@ -1,0 +1,79 @@
+# T14 M3 deletion blockers
+
+Scope: final D15 deletion attempt for `SealPartnerOK`,
+`SourceConcealPartnerOK`, and the old `conceal⊑²` relation constructor.
+
+## Outcome
+
+Deletion is blocked.  An attempted removal of the two predicates and the
+relation constructor made the remaining dependencies explicit.  The removal
+was reverted because the sites below still construct old-style evidence; they
+are not merely exhaustive matcher branches.
+
+## Live construction sites
+
+### World transport
+
+- `CenterRename.renameSealPartnerOK`,
+  `CenterRename.renameSourceConcealPartnerOK`, and
+  `CenterRename.⊢²-rename-center` rebuild the old partner package and the old
+  relation after center renaming.
+- `TermImpDecay.decaySealPartnerOK`,
+  `TermImpDecay.decaySourceConcealPartnerOK`, and
+  `TermImpDecay.⊢²-decay` rebuild them after world decay.
+- `TargetBindLift.moveSealPartnerOK`,
+  `TargetBindLift.moveSourceConcealPartnerOK`, and
+  `TargetBindLift.⊢²-target-bind-lift-move` rebuild them while lifting a target
+  bind.
+- `TargetExtend.renameSealPartnerOK`,
+  `TargetExtend.renameSourceConcealPartnerOK`, and
+  `TargetExtend.⊢²-target-insert` rebuild them after target insertion.
+
+These functions need split transports for `SourceConcealOK` and the matched
+source-star package, followed by removal of the old relation branch.  The
+source-star half cannot be replaced by a source-only `NoTargetOccupantAtSource`
+builder when the transported endpoint is occupied.
+
+### Inversion replay
+
+- `RightInjInversion2Proof.right-inj-inversion²` and
+  `right-inj-conceal-all-id²` recursively reconstruct `conceal⊑²` with
+  `fun-conceal-target` or `all-conceal-target`.
+- `TagLayerExtractionProof.extract-tag-layer` closes its replay function with
+  the old partner and `conceal⊑²`.
+- `StructuralSourceRebaseReplayProof.structural-conceal-replay` replays the old
+  abstract `SourceConcealPartnerOK` surface.  The new source-ok and source-star
+  replay functions coexist with it, but its remaining callers have not all
+  moved.
+
+These sites require their result/replay surfaces to be split by the D15 source
+case before the old constructor can disappear.
+
+### Catchup endpoint transport
+
+- `ExtraCastRightAtProof` still transports the old predicates through ground,
+  framed, projection, and double-framed target-cast steps in
+  `seal-partner-*-core` and `source-conceal-partner-*-core`.
+- `TargetCastStepInversionProof` still uses
+  `source-conceal-partner-target-id-core` and its framed counterpart.
+- `StructuralCatchupRightDef` still uses
+  `structural-seal-partner-nested-target-cast` and
+  `structural-source-partner-nested-target-cast`.
+- `InstInversionLambdaProof.post-source-conceal-partner-ok` and
+  `Λ-post-prefix-conceal⊑²-base` still construct the old partner/relation for
+  the lambda post-prefix package.
+
+These are live endpoint transformers.  They need parallel D15 transformers for
+the narrow source-ok case and for matched source-star packages, with callers
+migrated before the old versions can be deleted.
+
+## Consequent matcher dependencies
+
+Because the builders above keep the old constructor inhabited, its exhaustive
+matcher branches remain live in source/target strip, target-chain, simulation,
+catchup, and typing projection modules.  Those branches become deletable only
+after the construction families above have moved; deleting matcher coverage
+first would make the current relation consumers partial.
+
+Historical scratch modules under `proof/DGG/notes/` were not counted as live
+construction blockers.

--- a/GTSFImp/proof/DGG/notes/t14-partner-premise-redesign.red
+++ b/GTSFImp/proof/DGG/notes/t14-partner-premise-redesign.red
@@ -1,0 +1,716 @@
+# T14 partner-premise redesign reconnaissance
+
+Scope: this note reconstructs the role of the live
+`SourceConcealPartnerOK` premise in `conceal⊑²`, records the transport
+friction it causes, and compares three replacement designs.
+
+Files read for this pass include:
+
+- `proof/DGG/CastTermImprecision2.agda`
+- `proof/DGG/GroundingMint.agda`
+- `proof/DGG/GroundingPreserve.agda`
+- `proof/DGG/Occupancy.agda`
+- `proof/DGG/SealTransferCore.agda`
+- `proof/DGG/TermImpDecay.agda`
+- `proof/DGG/CenterRename.agda`
+- `proof/DGG/TargetExtend.agda`
+- `proof/DGG/TargetBindLift.agda`
+- `proof/DGG/Catchup/*.agda`
+- `proof/DGG/Inversion/*.agda`
+- `proof/DGG/notes/CTI-TIGHTENING-CALIBRATION.md`
+- `proof/DGG/notes/TIGHTEN3-PREFLIGHT.md`
+- `proof/DGG/notes/PEDIGREE-DESIGN-MEMO.md`
+- `proof/DGG/notes/PHASE3-DEEPDIVE-REPORT.md`
+- `proof/DGG/notes/M5-INST-INVERSION-DESIGN.md`
+- `proof/DGG/notes/m5-inst-inversion-lambda-lifted-target-pivot-blocked.red`
+- `proof/DGG/notes/m5-inst-inversion-source-strip-post-obligation-blocked.red`
+- `proof/DGG/notes/ProjectionMismatchStarRepScratch.agda`
+- origin-only notes on `origin/agent/gtsf-ns4-stage2`:
+  `t5-conceal-equal-partner-proposal.red`,
+  `t5-target-wrapper-strip-proposal.red`,
+  `t5-target-wrapper-strip-stop.red`,
+  and `t5-lambda-strict-one-bind-proposal.red`
+
+## 1. What the partner premise protects
+
+### The live premise
+
+The live source-side conceal rule in `CastTermImprecision2` has the
+following shape:
+
+```agda
+conceal⊑² :
+  SourceConcealPartnerOK W′ M c Xᴿ? M′ →
+  ImpEnvMono W W′ →
+  TagRebaseAtᴸ W′ W Xᴸ? Xᴿ? →
+  SameCtx Γ Γ′ →
+  ...
+  W ∣ Γ ⊢² M ⊑ M′ ∶ p →
+  W′ ∣ Γ′ ⊢² M ↓ c ⊑ M′ ∶ q
+```
+
+The premise is term-shaped, but its source-seal branch is also a world
+occupancy gate:
+
+```agda
+data SourceConcealPartnerOK W P c Xᴿ? M′ where
+  seal-partner-ok :
+    SealPartnerOK W X P R Xᴿ? M′ →
+    SourceConcealPartnerOK W P (seal X R) Xᴿ? M′
+  fun-conceal-target :
+    SourceConcealPartnerOK W P (fun A B) Xᴿ? M′
+  all-conceal-target :
+    SourceConcealPartnerOK W P (all A B) Xᴿ? M′
+  id-conceal-target :
+    SourceConcealPartnerOK W P (id A) Xᴿ? M′
+```
+
+For source seal conceals, the key branch is:
+
+```agda
+star-rep-target :
+  NoTargetOccupantAtSource W X →
+  Rep★PartnerOK W X P Xᴿ? M′ →
+  SealPartnerOK W X P ★ Xᴿ? M′
+```
+
+The shape predicate under `Rep★PartnerOK` distinguishes the cases in
+which a target term may be treated as a legitimate partner for a source
+`seal X ★`:
+
+- `rep★-untagged`: the target is not a top-level tag/projection.
+- `rep★-nonvar-tag`: the target is tagged with a non-variable ground.
+- `rep★-var-tag`: the target is tagged with an aligned target name.
+- `rep★-matched-inner-tags`: source and target both have inner tags,
+  and the inner target tag is aligned with the inner source tag.
+- `rep★-round-trip`: source `seal X ★` followed by source `X!` may be
+  handled recursively.
+
+The critical point is that the apparently syntactic premise is carrying
+two different facts:
+
+1. A source-only see-through window is only available when the source
+   pivot has no target occupant.
+2. If the target is already visibly protected by a tag/seal, the visible
+   protection must be the right kind of protection. An arbitrary top-level
+   target variable projection is not enough.
+
+### Minting
+
+There is no direct `SourceConcealPartnerOK` construction in
+`compile-preserves-embedded²`; grep finds no direct uses of
+`SourceConcealPartnerOK`, `SealPartnerOK`, `MatchedConcealPartnerOK`, or
+`Rep★PartnerOK` in `CompilePreservesImprecision2.agda`. The compile-side
+minting is instead world-level:
+
+- `GroundingMint.agda` records that the initial compile world occupies
+  the centers that already exist on both sides.
+- It also records that a source-only fresh lift has
+  `NoTargetOccupantAtSource` at the new source pivot.
+- Thus compile images do not mint arbitrary term-shape partner evidence;
+  they mint worlds in which the occupancy facts needed by the source
+  seal premise are either present or impossible.
+
+Runtime allocation is where the target occupant is minted:
+
+- `β-inst-allocation-atomic` in `GroundingPreserve.agda` proves that
+  `rightOnlyWorld W ★` immediately occupies target pivot `zero`, and
+  simultaneously exposes the β-inst contractum and its reveal/cast shape.
+- `β-gen-allocation-atomic` proves the analogous fact for
+  `rightOnlyWorld W C`.
+- `Occupancy.agda` contains the lower-level facts
+  `β-inst-allocation-occupies-targetᴼ` and
+  `β-gen-allocation-occupies-targetᴼ`.
+
+This is the important allocation discipline: a target-only allocation
+does not merely extend the target store; it closes the source-only
+see-through window for the corresponding center in the same step that
+creates the generated target representation.
+
+`SealTransferCore.agda` is the main proof-level re-emission site. It
+constructs new partner packages after source seal descent, target
+transport, and dynamic source payload transfer. In particular, its
+source-seal output rebuilds:
+
+```agda
+matched-seal-star-partner
+  (rep★-round-trip (transport-rep★-partner-ok-tag ... partner))
+
+seal-partner-ok
+  (star-rep-target no-target
+    (rep★-round-trip (transport-rep★-partner-ok-tag ... partner)))
+```
+
+So the premise is minted at three layers:
+
+- world occupancy at compile and allocation boundaries;
+- target shape produced by allocation/reveal/cast transfer;
+- explicit relation evidence re-emitted by catch-up and seal-transfer
+  proofs.
+
+### Preservation
+
+The live tree preserves partner evidence by hand across every world and
+term movement that can occur around source conceal:
+
+- `TermImpDecay.agda`:
+  `decayRep★PartnerOK`, `decaySealPartnerOK`,
+  `decaySourceConcealPartnerOK`, and
+  `decayMatchedConcealPartnerOK`.
+- `CenterRename.agda`:
+  `renameRep★PartnerOK`, `renameSealPartnerOK`,
+  `renameSourceConcealPartnerOK`, and
+  `renameMatchedConcealPartnerOK`.
+- `TargetExtend.agda`:
+  target insertion/extension versions of the same partner transports.
+- `TargetBindLift.agda`:
+  `moveRep★PartnerOK`, `moveNoTargetOccupantAtSource`,
+  `moveSealPartnerOK`, `moveSourceConcealPartnerOK`, and
+  `moveMatchedConcealPartnerOK`.
+- `SealTransferCore.agda`:
+  `transport-rep★-partner-ok`,
+  `transport-rep★-partner-ok-dyn`,
+  `premise-partner-from-tag-rebase`,
+  `transport-rep★-partner-ok-tag`, and the dynamic payload partner
+  constructors.
+- `Catchup/StructuralCatchupRightDef.agda`:
+  endpoint fields such as `source-conceal-endpoint-partner`, plus
+  nested target-cast partner transformers.
+- `Catchup/TargetCastStepInversionProof.agda` and
+  `Catchup/ExtraCastRightAtProof.agda`:
+  case-specific target-step inversions that either rebuild or refute
+  partner evidence.
+
+The preservation burden is not incidental. `SourceConcealPartnerOK`
+depends simultaneously on:
+
+- the premise world, because alignment and occupancy are world-indexed;
+- the target endpoint term, because `NotTopTag`, top-level target tags,
+  and name-protected target seals are syntactic;
+- the source pivot, because `NoTargetOccupantAtSource W X` is destroyed
+  by target allocation at the same center.
+
+### Consumers
+
+Grep over the proof tree shows that the premise is consumed far beyond
+the declaration site. The largest direct users are:
+
+- `Catchup/ExtraCastRightAtProof.agda`
+- `Catchup/StructuralCatchupRightDef.agda`
+- `CenterRename.agda`
+- `TargetChainProof.agda`
+- `SourceStripWorkerProof.agda`
+- `SealTransferCore.agda`
+- `TargetBindLift.agda`
+- `TargetExtend.agda`
+- `TermImpDecay.agda`
+- `TargetWalkSupport.agda`
+- `SourceStripColumnView.agda`
+- `Inversion/RightInjInversion2Proof.agda`
+
+The important consumer patterns are:
+
+- `TargetWalkSupport` turns partner evidence into source-seal and
+  target-seal views.
+- `TargetChainProof` case-splits on `star-rep-target`,
+  `plain-target`, `name-protected-target`, every `Rep★PartnerOK`
+  constructor, and `matched-seal-star-partner`.
+- `SourceStripColumnView` and `SourceStripWorkerProof` use the partner
+  cases to decide whether a source seal may be stripped or must be
+  routed to a protected target shape.
+- `RightInjInversion2Proof` reconstructs source conceal partners when
+  peeling target injections.
+- `ExtraCastRightAtProof` uses the premise to reject projection-mismatch
+  target steps.
+
+So a redesign of the premise is not localized to `conceal⊑²`; it changes
+the interface for source-strip, target-walk, target-chain, target-step
+inversion, and seal-transfer proofs.
+
+### The motivating bad square
+
+The checked scratch module
+`proof/DGG/notes/ProjectionMismatchStarRepScratch.agda` reconstructs the
+bad square that the live premise rules out.
+
+The setup is a one-cell world in which source `X` and target `Y` are
+center-aligned, and both stores represent the center by `★`. The source
+has a sealed star representation:
+
+```agda
+source-term =
+  (($ (κℕ 0)) ⟨ ℕ!ˢ ⟩) ↓ seal X ★
+```
+
+The target is only an `ℕ`-tagged payload:
+
+```agda
+target-tagged =
+  ($ (κℕ 0)) ⟨ ℕ! ⟩
+```
+
+The tempting, unsound relation is:
+
+```agda
+probe-world ∣ [] ⊢²
+  source-term ⟨ X! ⟩ ⟨ X? ⟩
+  ⊑
+  target-tagged ⟨ Y? ⟩
+  ∶ probe-q
+```
+
+where `probe-q` is the precise endpoint relation
+`＇ X ⊑ᵂ⟨ probe-world ⟩ ＇ Y`.
+
+Without the partner premise on `conceal⊑²`, the source-side
+`seal X ★` could be related to the bare target `target-tagged`, and the
+outer source `X! ; X?` could then be related to target `Y?`. That creates
+an unearned target-name pairing: the type endpoint says `X` and `Y`, but
+the target term is really protected by `ℕ!`, not by a `Y` seal/tag.
+
+Diagram:
+
+    source-term ⟨ X! ⟩ ⟨ X? ⟩     ⊑     target-tagged ⟨ Y? ⟩
+              |                                     |
+              | tag/untag returns                   | tag/untag bad
+              v                                     v
+          source-term                         blame
+
+The scratch proves both sides of the operational behavior:
+
+- `source-projection-returns`: the source side reduces back to
+  `source-term`.
+- `mismatch-steps-to-blame`: the target side reduces to `blame`.
+
+It also proves that the live relation cannot derive the bad input:
+
+- `target-tagged-partner-empty`
+- `source-sealed-target-tagged-empty`
+- `source-tagged-target-tagged-empty`
+- `source-projected-target-tagged-empty`
+- `projection-mismatch-empty`
+
+The decisive live check is that the one-cell world is occupied:
+
+```agda
+one-center-occupied :
+  NoTargetOccupantAtSource probe-world X → ⊥
+```
+
+Therefore the only plausible `SealPartnerOK` branch for source
+`seal X ★`, namely `star-rep-target`, is impossible. The other branches
+cannot match the top-level target projection shape. This is exactly the
+protection provided by the premise.
+
+`CTI-TIGHTENING-CALIBRATION.md` records the same conclusion in the S-OCC
+calibration:
+
+- in the pre-occupied state, source-only see-through is allowed;
+- in the aligned-occupied state, `NoTargetOccupantAtSource` is empty;
+- the bad square is underivable;
+- a pure world-only tightening was checked insufficient because the same
+  world can still be paired with a bad target term if the target term
+  shape is ignored.
+
+## 2. Why the premise hurts
+
+### Transport is both world-indexed and endpoint-indexed
+
+`SourceConcealPartnerOK` is not just an invariant about a world. It also
+mentions the target endpoint term. This means a proof that changes the
+target endpoint by reduction, stripping, insertion, decay, or rebase must
+produce a new partner proof for the new endpoint.
+
+The LG-3 notes record the failure of a generic transformer:
+
+- `lg3i-source-conceal-endpoint-partner-resister.red` says source-conceal
+  replay needs an endpoint-specific partner
+  `SourceConcealPartnerOK child.W′ M c ... child.N′`.
+- `lg3af-target-conversion-endpoint-partner-resister.red` records a
+  checked counterexample: `plain-target not-↑` can justify a wrapper
+  target `M′ ↑ id↑ A`, but there need not be any partner proof for the
+  reduct `M′`.
+
+So generic target conversion does not preserve the premise. The current
+solution is to thread exact endpoint partner continuations through
+structural catch-up results.
+
+### D4 / higher-order lift friction
+
+`PHASE3-DEEPDIVE-REPORT.md` reconstructs the D4 higher-order shared-arg
+allocation trace. The important shape is:
+
+- old shared pivots must keep their center images;
+- fresh allocating pivots must appear at zero on the allocating side;
+- wrapper descent may use same-world rebase at the fresh pivot;
+- parked extensions must not accidentally move an old target pivot.
+
+This is already difficult for type/world transport. Partner evidence adds
+another layer because source-seal premises carry both occupancy and target
+endpoint shape. Even when the target/store rebase is right, the partner
+proof may no longer mention the endpoint term at the right lifted world.
+
+`m5-inst-inversion-lambda-lifted-target-pivot-blocked.red` shows the same
+shape in the positive left-lift depth setting. The direct prefix route
+puts the abstract target pivot at `suc zero`, while the recursive caller
+wants the generated target pivot at `suc (suc zero)`. Existing
+`TargetStoreMove` and `CenterRename` machinery cannot reorder target
+embeddings past source-only binders. Any partner evidence indexed by those
+embeddings inherits the same blocked transport problem.
+
+### T5d / stage2 target-wrapper strip friction
+
+The origin-only `agent/gtsf-ns4-stage2` notes show the current in-flight
+lift drafts hitting the premise in two places:
+
+- `t5-conceal-equal-partner-proposal.red`:
+  the source-conceal equal branch needs
+  `SourceConcealPartnerOK` after structural target catch-up. The world
+  part is produced by `structural-tag-rebase-atᴸ`, but the target package
+  does not carry enough endpoint partner information.
+- `t5-target-wrapper-strip-stop.red`:
+  a wrapper target can be justified by `plain-target not-↑` or
+  `plain-target not-↓`, but after β-reveal/β-conceal strip the child
+  endpoint is arbitrary `⇑ᵗᵐ V`. There is no constructor that turns
+  `plain-target not-↑` into a partner proof for that child endpoint.
+
+This is the same endpoint-index problem in a stricter setting: the
+premise is easy to satisfy for the wrapper, but the proof needs it for
+the reduct.
+
+### Premise-world pedigree and index drift
+
+`PEDIGREE-DESIGN-MEMO.md` records the earlier pedigree tension:
+
+- freed pedigree was unsound;
+- anchored-inner solved some cases but still allowed arbitrary packages;
+- the conservative repair was premise-world protection.
+
+The addendum notes that live indices once drifted between premise-world
+and conclusion-world target pivots. That is the structural reason many
+transport proofs are delicate: the premise wants to be anchored at the
+world where the target endpoint was inspected, while the conclusion wants
+the post-rebase world and type witness.
+
+### Blast radius
+
+The current premise creates a large re-proof surface because many modules
+case directly on its constructors. A redesign touches at least:
+
+- `CastTermImprecision2`: constructors and rule statements.
+- `SealTransferCore`: dynamic source-payload transfer and source-seal
+  re-emission.
+- `TargetWalkSupport`, `TargetChainProof`, `TargetDescent*`: partner
+  inversion/view logic.
+- `SourceStripColumnView`, `SourceStripProof`, `SourceStripWorkerProof`:
+  source-strip routing.
+- `Catchup/StructuralCatchupRightDef`,
+  `Catchup/TargetCastStepInversionProof`,
+  `Catchup/ExtraCastRightAtProof`: endpoint partner transformation and
+  target-step inversion.
+- `TermImpDecay`, `CenterRename`, `TargetExtend`, `TargetBindLift`:
+  mechanical transports.
+
+The pain is therefore real, but it is pain around a live soundness
+condition, not accidental proof ornamentation.
+
+## 3. Alternative designs
+
+### A. World-level pairing
+
+Move the source/target seal-pairing invariant into the world. Today the
+world tracks left and right embeddings, imprecision environment, and both
+stores. A world-level redesign would add a cell invariant for centers:
+
+```agda
+data SealCell W X : Set where
+  source-open :
+    NoTargetOccupantAtSource W X →
+    SealCell W X
+
+  paired :
+    (Y : TyVar Δᴿ) →
+    CenterAligned W X Y →
+    StoreRepImp W X Y →
+    SealCell W X
+```
+
+or equivalently a world field:
+
+```agda
+sealCellʷ : (X : TyVar Δᴸ) → SealCell W X
+```
+
+Then source-seal conceal could be stated without a target-shape premise:
+
+```agda
+conceal⊑² :
+  SealCell W′ X →
+  ImpEnvMono W W′ →
+  TagRebaseAtᴸ W′ W Xᴸ? Xᴿ? →
+  ...
+  W ∣ Γ ⊢² M ⊑ M′ ∶ p →
+  W′ ∣ Γ′ ⊢² M ↓ seal X R ⊑ M′ ∶ q
+```
+
+The allocation discipline would be built into the world constructors:
+
+- source-only lift mints `source-open`;
+- right-only allocation converts the relevant fresh center to `paired`
+  or otherwise marks it occupied;
+- both-bind allocation mints an aligned `paired` cell;
+- rebase/lift/decay constructors must preserve or transform the cell
+  invariant.
+
+Transport story:
+
+- Good: rebases and lifts can preserve the invariant by construction if
+  all world-evolution constructors carry cell actions.
+- Bad: this only transports world occupancy. It does not, by itself,
+  inspect the target term. The S-WORLD calibration already checked that a
+  pure world-only repair still admits the projection-mismatch bad square
+  when paired with an arbitrary bad target term in the same world.
+
+Proof mass:
+
+- Very high. This changes `World`, every `liftWorld*`,
+  `leftOnlyWorld`, `rightOnlyWorld`, `bothBindWorld`, world renaming,
+  target extension, decay, compile image worlds, and every theorem that
+  transports `_⊑ᵂ⟨ W ⟩_`.
+- It can delete some explicit partner-transport lemmas only after the
+  same work is reintroduced as world-evolution obligations.
+
+Soundness risk:
+
+- High if this is interpreted as "world pairing replaces term shape."
+  World occupancy is necessary, but the counterexample target has the
+  same world and the wrong target term shape.
+- Moderate if the world stores only the occupancy/gating part and the
+  matched/generated target shape remains in target-chain or matched
+  conceal evidence.
+
+Assessment: useful as an internal representation of occupancy, but not a
+complete replacement for the partner premise unless paired with a separate
+target-shape/provenance discipline.
+
+### B. Witness-level pairing
+
+Fold the pairing into `_⊑ᵂ⟨ W ⟩_` itself. The current definition erases to
+the underlying type imprecision relation:
+
+```agda
+A ⊑ᵂ⟨ W ⟩ B =
+  impEnvʷ W ⊢ embedᴸ A ⊑ embedᴿ B
+```
+
+A witness-level redesign would replace this with an indexed relation that
+carries the world facts at variable endpoints:
+
+```agda
+data _⊑ᵂ⟨_⟩_ : Ty Δᴸ → World Δᴸ Δᴿ → Ty Δᴿ → Set where
+  var-star-open :
+    NoTargetOccupantAtSource W X →
+    ＇ X ⊑ᵂ⟨ W ⟩ ★
+
+  var-var-paired :
+    (Y : TyVar Δᴿ) →
+    CenterAligned W X Y →
+    StoreRepImp W X Y →
+    PairOK W X Y →
+    ＇ X ⊑ᵂ⟨ W ⟩ ＇ Y
+
+  fun :
+    B₁ ⊑ᵂ⟨ W ⟩ A₁ →
+    A₂ ⊑ᵂ⟨ W ⟩ B₂ →
+    A₁ ⇒ A₂ ⊑ᵂ⟨ W ⟩ B₁ ⇒ B₂
+
+  all :
+    ... →
+    `∀ A ⊑ᵂ⟨ W ⟩ `∀ B
+
+  ...
+```
+
+Then `conceal⊑²` would get the needed source-open or paired fact from
+the type witness `q`/`p`, instead of a separate
+`SourceConcealPartnerOK` argument.
+
+Transport story:
+
+- Good: once every rebase/lift/decay theorem is by induction on enriched
+  `_⊑ᵂ⟨ W ⟩_`, partner preservation travels with type-witness
+  preservation. There is no separate partner proof to keep aligned.
+- Bad: all type-imprecision transport lemmas now become partner
+  transport lemmas. This moves the proof mass rather than removing it.
+
+Proof mass:
+
+- Very high. This changes the public shape of `_⊑ᵂ⟨ W ⟩_` and affects
+  every proof that pattern matches on type imprecision, including
+  substitution/transport, rebase, monotonicity, compile preservation,
+  source-id equality, and cast/reveal/conceal typing congruences.
+
+Soundness risk:
+
+- Type witnesses still do not see target term shape. If this design
+  drops `Rep★PartnerOK` completely, it repeats the world-only failure:
+  the witness can say `＇ X ⊑ᵂ ＇ Y`, while the target term is protected
+  by `ℕ!`.
+- To be sound, the witness would need to carry term provenance or the
+  term relation would still need matched/generated target-shape evidence.
+  Carrying term provenance in type imprecision is conceptually awkward
+  and would make `_⊑ᵂ⟨ W ⟩_` less canonical.
+
+Assessment: elegant only if the desired invariant is purely type/world
+level. The live bad square is not purely type/world level, so this
+redesign is probably too invasive for too little simplification.
+
+### C. Occupancy-style gating
+
+Keep the S-OCC insight, but make it the visible rule premise instead of
+burying it under the full source-conceal partner enumeration.
+
+The current source-seal branch is:
+
+```agda
+star-rep-target :
+  NoTargetOccupantAtSource W X →
+  Rep★PartnerOK W X P Xᴿ? M′ →
+  SealPartnerOK W X P ★ Xᴿ? M′
+```
+
+An occupancy-style redesign would split source-seal see-through from
+matched/generated target-shape cases:
+
+```agda
+data SourceConcealOK W P c Xᴿ? M′ : Set where
+  seal-star-open :
+    NoTargetOccupantAtSource W X →
+    SourceConcealOK W P (seal X ★) Xᴿ? M′
+
+  seal-nonstar-plain :
+    NotTopTag M′ →
+    SourceConcealOK W P (seal X R) Xᴿ? M′
+
+  seal-name-protected :
+    CenterAligned W X Y →
+    SourceConcealOK W P (seal X R) (just Y)
+      ((M′ ↓ seal Y S) ⟨ c ⟩)
+
+  fun-conceal-target :
+    SourceConcealOK W P (fun A B) Xᴿ? M′
+
+  all-conceal-target :
+    SourceConcealOK W P (all A B) Xᴿ? M′
+
+  id-conceal-target :
+    SourceConcealOK W P (id A) Xᴿ? M′
+```
+
+The stricter variant is to allow `seal-star-open` only in genuinely
+source-only worlds and require occupied/matched source-seal behavior to
+go through `conceal⊑conceal²` or `packaged-seal-star²`:
+
+```agda
+conceal⊑²-seal-star-open :
+  NoTargetOccupantAtSource W′ X →
+  ...
+  W ∣ Γ ⊢² M ⊑ M′ ∶ p →
+  W′ ∣ Γ′ ⊢² M ↓ seal X ★ ⊑ M′ ∶ q
+
+conceal⊑conceal² :
+  MatchedConcealPartnerOK W M (seal X ★) Xᴿ? M′ →
+  ...
+  W′ ∣ Γ′ ⊢² M ↓ seal X ★ ⊑ M′ ↓ seal Y R ∶ q
+```
+
+The important difference from the live rule is not that all target shape
+disappears. It is that the source-only see-through case is governed by a
+negative world fact, while matched/generated target-shape facts are kept
+with the rules that actually introduce or inspect matched target
+protection.
+
+Transport story:
+
+- Good: `NoTargetOccupantAtSource` already has a substantial transport
+  library in `Occupancy.agda`: left lift, right-only old-cell transport,
+  rebase/tag-rebase transport, center rename, target insert, decay, and
+  smart lift facts.
+- Good: target endpoint reductions no longer need to preserve a
+  `Rep★PartnerOK` proof for the source-only `seal X ★` case if that case
+  is stated only as a world no-target premise.
+- Remaining pain: non-star plain target and name-protected target cases
+  still depend on endpoint shape if they remain in `SourceConcealOK`.
+  The T5 wrapper-strip notes show that these should probably be carried
+  as endpoint-specific structural continuations, not as a generic global
+  transport theorem.
+
+Proof mass:
+
+- Moderate. This still changes the rule surface and the consumers that
+  currently case on `SourceConcealPartnerOK`, but it does not change
+  `World` or `_⊑ᵂ⟨ W ⟩_`.
+- Existing S-OCC lemmas become the main transport substrate, so several
+  current `Rep★PartnerOK` transports can be deleted or narrowed.
+- `SealTransferCore`, `TargetChainProof`, source-strip proofs, and
+  catch-up endpoint packages still need edits because they currently
+  expose the live constructors.
+
+Soundness risk:
+
+- Low if the design keeps the live S-OCC restriction: source `seal X ★`
+  may see through only when there is no target occupant at source `X`;
+  occupied or matched states must use matched/generated target evidence.
+- High if "occupancy-style" is read as "drop all target shape." The
+  projection-mismatch scratch rules out that interpretation.
+
+Assessment: this is the least disruptive design that addresses the
+actual pain. It keeps the checked soundness invariant and moves the
+transport-heavy part onto the world occupancy facts that already
+transport well.
+
+## 4. Recommendation
+
+Do not drop `SourceConcealPartnerOK` without a replacement. The premise
+protects a real DGG failure: it prevents a source `seal X ★` from being
+related to a target term whose visible protection is an unrelated tag,
+then later treating that target as though it were protected by target
+name `Y`.
+
+The best redesign target is the occupancy-style split:
+
+1. Make the source-only `seal X ★` see-through rule require the negative
+   world fact directly:
+
+   ```agda
+   NoTargetOccupantAtSource W′ X
+   ```
+
+2. Keep matched source/target seal behavior in `conceal⊑conceal²` and
+   `packaged-seal-star²`, with whatever matched/generated target
+   evidence those rules genuinely need.
+
+3. Do not try to prove a generic endpoint transformer from wrapper
+   partners to child partners. The checked LG-3 and T5 notes show that
+   such a theorem is false. Instead, endpoint-specific structural
+   catch-up results should carry the exact child partner evidence they
+   produce.
+
+This design keeps the user-visible intent of S-OCC: source-only
+see-through is an occupancy gate, not a broad syntactic target-shape
+enumeration. It should transport under rebases and lifts better because
+the hard premise becomes `NoTargetOccupantAtSource`, which already has
+transport infrastructure. It also avoids the two larger rewrites:
+
+- world-level pairing, which is attractive for occupancy but unsound if
+  it replaces target-term shape entirely;
+- witness-level pairing, which makes every type-imprecision transport
+  theorem a partner-transport theorem and still cannot inspect the target
+  term.
+
+The practical next design step should be a preflight that introduces a
+new source-open rule beside the current rules, rewrites exactly one
+source-strip or target-chain consumer to use the no-target premise
+directly, and checks whether the remaining `plain-target` and
+`name-protected-target` cases can be moved into structural endpoint
+packages rather than preserved globally.

--- a/GTSFImp/proof/DGG/notes/t14-partner-premise-redesign.red
+++ b/GTSFImp/proof/DGG/notes/t14-partner-premise-redesign.red
@@ -520,7 +520,7 @@ data _⊑ᵂ⟨_⟩_ : Ty Δᴸ → World Δᴸ Δᴿ → Ty Δᴿ → Set where
     ＇ X ⊑ᵂ⟨ W ⟩ ＇ Y
 
   fun :
-    B₁ ⊑ᵂ⟨ W ⟩ A₁ →
+    A₁ ⊑ᵂ⟨ W ⟩ B₁ →
     A₂ ⊑ᵂ⟨ W ⟩ B₂ →
     A₁ ⇒ A₂ ⊑ᵂ⟨ W ⟩ B₁ ⇒ B₂
 
@@ -530,6 +530,10 @@ data _⊑ᵂ⟨_⟩_ : Ty Δᴸ → World Δᴸ Δᴿ → Ty Δᴿ → Set where
 
   ...
 ```
+
+PR #171 review P2 fixed this sketch to match the live
+`Imprecision.agda` rule: `⇒⊑⇒` is covariant in both the domain and
+codomain positions.
 
 Then `conceal⊑²` would get the needed source-open or paired fact from
 the type witness `q`/`p`, instead of a separate
@@ -629,6 +633,29 @@ disappears. It is that the source-only see-through case is governed by a
 negative world fact, while matched/generated target-shape facts are kept
 with the rules that actually introduce or inspect matched target
 protection.
+
+PR #171 review P1 asked whether this shape-free open branch accidentally
+admits an unrelated top-level target variable tag in a no-occupant world,
+because the S-OCC calibration retained `Rep★PartnerOK`. The checked probe
+`proof/DGG/notes/probes/SealStarOpenVarTagShapeProbe.agda` rules out that
+specific square. Its world maps source `X` and target `Y` to different
+centers, proves `NoTargetOccupantAtSource W X` and
+`CenterAligned W X Y → ⊥`, and then proves:
+
+```agda
+shape-free-var-tag-probe-verdict :
+  W ∣ [] ⊢² source-dyn-nat ⊑ target-Y-tagged ∶ ★⊑★ → ⊥
+```
+
+So the unrelated `Y!` target cannot supply the `p : ★ ⊑ᵂ⟨ W ⟩ B`
+premise that `conceal⊑²-seal-star-open` needs. This is an EXCLUDED
+verdict for the review candidate, not a new bad square. It is consistent
+with `CTI-TIGHTENING-CALIBRATION.md`: S-OCC still uses
+`Rep★PartnerOK` as the syntactic classifier for matched/generated target
+packages and for the old calibrated `star-rep-target` shape, but the D15
+source-only open rule does not need that classifier as an additional
+endpoint-shape premise once the `★⊑★` premise itself excludes the
+unrelated top-level variable-tag case.
 
 Transport story:
 

--- a/GTSFImp/proof/DGG/notes/t14-partner-premise-redesign.red
+++ b/GTSFImp/proof/DGG/notes/t14-partner-premise-redesign.red
@@ -584,7 +584,11 @@ star-rep-target :
 ```
 
 An occupancy-style redesign would split source-seal see-through from
-matched/generated target-shape cases:
+matched/generated target-shape cases.  The shape question here is settled by
+the checked
+`proof/DGG/notes/probes/SealStarOpenVarTagShapeProbe.agda`: in a no-occupant
+world, an unrelated variable-tag target cannot supply the `★⊑★` premise, so
+the shape-free open rule is justified.
 
 ```agda
 data SourceConcealOK W P c Xᴿ? M′ : Set where

--- a/GTSFImp/proof/DGG/notes/t14-preflight-report.red
+++ b/GTSFImp/proof/DGG/notes/t14-preflight-report.red
@@ -1,0 +1,212 @@
+# T14 D15 preflight report
+
+Decision D15 uses the stricter occupancy-style split: source-only
+`seal X ★` see-through is gated directly by
+`NoTargetOccupantAtSource`; occupied/matched source-seal behavior stays
+with `conceal⊑conceal²` and `packaged-seal-star²`.
+
+This preflight added rules beside the old `conceal⊑²`; no old predicate
+or old rule was removed.
+
+## New checked surface
+
+Classifier added beside `SourceConcealPartnerOK`:
+
+```agda
+-- D15 preflight: the source-only `seal X ★` case is a direct
+-- occupancy gate in the term rule below.  This slim classifier covers
+-- only the non-`★` source-seal and non-seal source-conceal cases that
+-- still need endpoint-shape side conditions beside the old rules.
+
+data SourceConcealOK {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ) :
+    Term Δᴸ → {A A′ : Ty Δᴸ} → Conv↓ Δᴸ A A′
+    → Maybe (TyVar Δᴿ) → Term Δᴿ → Set where
+  seal-nonstar-plain-ok : ∀ {P X R Xᴿ? M′}
+    → NonStar R
+    → NotTopTag M′
+      ----------------------------------------------------
+    → SourceConcealOK W P (seal X R) Xᴿ? M′
+
+  seal-nonstar-name-protected-ok : ∀ {P X R Y S M μ}
+      {c : μ ⊢ (＇ Y) ∼ ★}
+    → NonStar R
+    → CenterAligned W X Y
+      ----------------------------------------------------
+    → SourceConcealOK W P (seal X R) (just Y)
+        ((M ↓ seal Y S) ⟨ c ⟩)
+
+  fun-conceal-ok : ∀ {P A A′ B B′ Xᴿ? M′}
+      {c : Conv↑ Δᴸ A′ A} {d : Conv↓ Δᴸ B B′}
+      ----------------------------------------------------
+    → SourceConcealOK W P (c ↦↓ d) Xᴿ? M′
+
+  all-conceal-ok : ∀ {P A B Xᴿ? M′}
+      {c : Conv↓ (Nat.suc Δᴸ) A B}
+      ----------------------------------------------------
+    → SourceConcealOK W P (`∀↓ c) Xᴿ? M′
+
+  id-conceal-ok : ∀ {P A Xᴿ? M′}
+      ----------------------------------------------------
+    → SourceConcealOK W P (id↓ A) Xᴿ? M′
+```
+
+Term-imprecision rules added beside the old `conceal⊑²`:
+
+```agda
+  -- D15 preflight rules: source-only `seal X ★` sees through only under
+  -- `NoTargetOccupantAtSource`; remaining non-`★`/non-seal cases use the
+  -- slim `SourceConcealOK` classifier above.  The old `conceal⊑²` rule is
+  -- deliberately left intact during the preflight.
+  conceal⊑²-seal-star-open : ∀ {W′ : World Δᴸ Δᴿ Δ}
+      {γ′ : CtxImp W′} {M M′ B X}
+      {p : ★ ⊑ᵂ⟨ W′ ⟩ B}
+    → NoTargetOccupantAtSource W′ X
+    → ImpEnvMono W W′
+    → TagRebaseAtᴸ W′ W (just X) nothing
+    → SameCtx γ γ′
+    → sourceStoreʷ W ⊢↓[ just X ] seal X ★
+    → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
+    → (q : (＇ X) ⊑ᵂ⟨ W ⟩ B)
+      -----------------------------
+    → W ∣ γ ⊢² M ↓ seal X ★ ⊑ M′ ∶ q
+
+  conceal⊑²-source-ok : ∀ {W′ : World Δᴸ Δᴿ Δ}
+      {γ′ : CtxImp W′} {M M′ A A′ B Xᴸ? Xᴿ?}
+      {p : A ⊑ᵂ⟨ W′ ⟩ B} {c : Conv↓ Δᴸ A A′}
+    → SourceConcealOK W′ M c Xᴿ? M′
+    → ImpEnvMono W W′
+    → TagRebaseAtᴸ W′ W Xᴸ? Xᴿ?
+    → SameCtx γ γ′
+    → sourceStoreʷ W ⊢↓[ Xᴸ? ] c
+    → W′ ∣ γ′ ⊢² M ⊑ M′ ∶ p
+    → (q : A′ ⊑ᵂ⟨ W ⟩ B)
+      -----------------------------
+    → W ∣ γ ⊢² M ↓ c ⊑ M′ ∶ q
+```
+
+## Converted consumer
+
+Converted exactly one substantive consumer path:
+`Inversion/TargetChainProof.agda`, the `target-source-star-at`
+`star-rep-target` branch for `rep★-round-trip` under
+`tag-rebase-onlyᴸ`.
+
+Before, the branch asked `SealTransferCore` to manufacture both the
+target package and a source premise from the old nested partner:
+
+```agda
+with STC.source-star-cast-package-from-source
+  monoᵖ rbᵖ scᵖ X∈ᵖ no-target (CTI2.rep★-round-trip partner)
+  inert prem D₂
+...
+| pkg , sourcePrem =
+target-source-star-final
+  (STC.emit-tagged-transfer mono₂ link sc₂
+    (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
+    pkg sourcePrem)
+```
+
+After, the branch keeps matched/generated target-shape evidence in the
+target package and rebuilds the source side with the new source-open
+rule.  The old transport pain point is replaced by the existing
+occupancy transport lemma `Occ.tag-rebase-no-target-forwardᴼ`.
+
+```agda
+target-source-star-final
+  (STC.emit-tagged-transfer mono₂ link sc₂
+    (CTI2.⊢↓-sealˣ X∈) (CTI2.⊢↓-sealˣ Y∈)
+    (STC.tagged-transfer-output
+      (CTI2.cast⊑² c D₂ ★⊑★)
+      (STC.premise-partner-from-tag-rebase rbᵖ)
+      (CTI2.matched-seal-star-partner
+        (CTI2.rep★-round-trip {cX = id (＇ X)}
+          (STC.transport-rep★-partner-ok-tag rbᵖ
+            (CTI2.rep★-round-trip partner)))))
+    (CTI2.conceal⊑²-seal-star-open
+      (Occ.tag-rebase-no-target-forwardᴼ rbᵖ no-target)
+      (STC.impEnvMono-refl {W = W₂})
+      (STC.self-tag-rebase-from-tag-rebase rbᵖ)
+      (STC.sameCtx-refl {γ = γ₂})
+      (CTI2.⊢↓-sealˣ X∈ᵖ)
+      (CTI2.cast⊑² c D₂ ★⊑★)
+      q₂))
+```
+
+## Relocation table
+
+| Old constructor path | D15 destination |
+| --- | --- |
+| `seal-partner-ok (star-rep-target no-target rep★-untagged)` | Source-only see-through uses `conceal⊑²-seal-star-open no-target`; the untagged target fact remains endpoint/package evidence as `rep★-untagged` under `matched-seal-star-partner` when a matched target seal is emitted. |
+| `seal-partner-ok (star-rep-target no-target (rep★-nonvar-tag ...))` | Source-only see-through uses `conceal⊑²-seal-star-open no-target`; generated non-variable tag shape belongs to matched/generated target packages, not to the source-open premise. |
+| `seal-partner-ok (star-rep-target no-target (rep★-var-tag aligned))` | Source-only see-through uses `conceal⊑²-seal-star-open no-target`; the aligned target-name tag belongs to `matched-seal-star-partner` and target package construction. |
+| `seal-partner-ok (star-rep-target no-target (rep★-matched-inner-tags ...))` | Source-open keeps only `NoTargetOccupantAtSource`; matched inner tag evidence belongs to `matched-seal-star-partner` and structural endpoint packages. |
+| `seal-partner-ok (star-rep-target no-target (rep★-round-trip partner))` | Converted branch validates the split: source side uses `conceal⊑²-seal-star-open` with transported no-target evidence; recursive partner remains in the matched target package. |
+| `seal-partner-ok (plain-target nt)` | Non-star source seals use `conceal⊑²-source-ok (seal-nonstar-plain-ok Rns nt)`. For source `seal X ★`, plain/untagged target shape is package evidence rather than source-open evidence. |
+| `seal-partner-ok (name-protected-target ...)` | Non-star source seals use `conceal⊑²-source-ok (seal-nonstar-name-protected-ok Rns aligned)`, retaining `CenterAligned`. For source `seal X ★`, occupied/name-protected behavior belongs to `conceal⊑conceal²` or `packaged-seal-star²`. |
+| `fun-conceal-target` | `conceal⊑²-source-ok fun-conceal-ok`. |
+| `all-conceal-target` | `conceal⊑²-source-ok all-conceal-ok`. |
+| `id-conceal-target` | `conceal⊑²-source-ok id-conceal-ok`. |
+
+## Surprises
+
+- Adding relation constructors required totality coverage in transport,
+  inversion, catchup, and simulation modules even though only one
+  consumer path was substantively converted. These were mechanical
+  branches preserving the old behavior.
+- The existing `Occupancy.agda` lemma
+  `tag-rebase-no-target-forwardᴼ` was enough for the converted
+  `rep★-round-trip` transport point.
+- Two endpoint cases collapsed by shape: name-protected source-ok is
+  impossible under the target-id stripper, and the `Λ` post-prefix case
+  only needs the plain non-star constructor (`not-↑`).
+
+## Full migration worklist
+
+Dependency order:
+
+1. Core relation projections and structural transports:
+   `CastTermImprecision2Typing`, `TermImpDecay`, `CenterRename`,
+   `TargetExtend`, `TargetBindLift`.
+2. Low-level inversion/probe coverage:
+   `TargetWalkSupport`, `TargetStripProof`, `LambdaImpProbe`,
+   `TerminusRebuildProbe`, `ExtraCastRight2Counterexample`.
+3. Target-chain/source-strip consumers:
+   `SealTransferCore`, `TargetChainProof`,
+   `SourceStripColumnView`, `SourceStripProof`,
+   `SourceStripWorkerProof`, `RightInjInversion2Proof`.
+4. Catchup and structural endpoints:
+   `ValueCatchupRightDef`, `TargetCastStepInversionProof`,
+   `TagLayerExtractionProof`, `StructuralCatchupRightDef`,
+   `StructuralStrictViewSurfaceDef`,
+   `StructuralSourceRebaseReplayProof`,
+   `StructuralNameInstantiationProof`,
+   `StructuralValueInstantiationViewProof`,
+   `InstInversionLambdaProof`, `ExtraCastRightAtProof`.
+5. Simulation surface:
+   `SimSourceConcealValuesDef`, `SimSourceConcealValuesProof`,
+   `SimProof`, then any `MultiSim`/DGG aggregators that expose the old
+   source-conceal closing interface.
+6. Examples and probes:
+   `Examples2`, `ChainRideProbe`, `StarRepChainProbe`.
+
+The actual old-constructor grep also finds historical scratch notes
+under `proof/DGG/notes/`; those should be updated or retired only if the
+full migration includes note hygiene.
+
+## Gate
+
+Command:
+
+```sh
+cd GTSFImp
+AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+```
+
+Final pre-commit result:
+
+```text
+agda --safe -v0 All.agda
+agda -v0 LegacyAll.agda
+postulate-check: OK (no postulates; NON_COVERING at legacy baseline)
+```

--- a/GTSFImp/proof/DGG/notes/t14-preflight-report.red
+++ b/GTSFImp/proof/DGG/notes/t14-preflight-report.red
@@ -148,6 +148,35 @@ target-source-star-final
 | `all-conceal-target` | `conceal⊑²-source-ok all-conceal-ok`. |
 | `id-conceal-target` | `conceal⊑²-source-ok id-conceal-ok`. |
 
+## Review probe outcome
+
+P1 asked whether the shape-free `conceal⊑²-seal-star-open` branch needs
+to retain `Rep★PartnerOK`, because the S-OCC calibration kept that
+classifier and `rep★-var-tag` only admits a top-level target variable tag
+under `CenterAligned`.
+
+Checked artifact:
+
+```text
+proof/DGG/notes/probes/SealStarOpenVarTagShapeProbe.agda
+```
+
+Verdict: EXCLUDED. In the probe world, source `X` has no target occupant,
+target `Y` is at a different center, and `CenterAligned W X Y → ⊥`.
+The unrelated top-level `Y!` target cannot be supplied as the premise to
+the source-open rule:
+
+```agda
+shape-free-var-tag-probe-verdict :
+  W ∣ [] ⊢² source-dyn-nat ⊑ target-Y-tagged ∶ ★⊑★ → ⊥
+```
+
+Therefore the live source-open rule is left unchanged. `Rep★PartnerOK`
+remains the syntactic target-shape classifier for matched/generated
+endpoint packages and occupied behavior, but the no-occupant source-open
+branch does not need it as an extra endpoint-shape premise for this P1
+candidate.
+
 ## Surprises
 
 - Adding relation constructors required totality coverage in transport,
@@ -203,7 +232,16 @@ cd GTSFImp
 AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
 ```
 
-Final pre-commit result:
+Additional standalone review-probe check:
+
+```sh
+cd GTSFImp
+AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home \
+  agda --safe -v0 -i . -i proof/DGG/notes/probes \
+  proof/DGG/notes/probes/SealStarOpenVarTagShapeProbe.agda
+```
+
+Final review-update result:
 
 ```text
 agda --safe -v0 All.agda

--- a/GTSFImp/proof/DGG/notes/t14-preflight-report.red
+++ b/GTSFImp/proof/DGG/notes/t14-preflight-report.red
@@ -223,13 +223,58 @@ The actual old-constructor grep also finds historical scratch notes
 under `proof/DGG/notes/`; those should be updated or retired only if the
 full migration includes note hygiene.
 
+### M3 final status
+
+1. Core projections and transports: **carried as deletion blockers**.  Their
+   new-rule coverage remains checked, but the old rename/decay/target-lift
+   builders still construct `SourceConcealPartnerOK` and `conceal⊑²`; see
+   `t14-m3-deletion-blockers.red`.
+2. Low-level inversion and probes: **converted** for the M3 examples/probes
+   tier.  `Examples2`, `ChainRideProbe`, and `StarRepChainProbe` now use the
+   D15 source-ok or source-star-open rules.  The intentionally occupied
+   `TerminusRebuildProbe.InstanceB.tagged-input` remains excluded as residual
+   R1.
+3. Target-chain and source-strip consumers: **converted**.  `SealTransferCore`
+   preserves the matched partner and premise in `seal-transfer-paired`;
+   `TargetChainProof` carries the richer source-star payload through recursive
+   target contexts; `SourceStripProof` no longer promises the obsolete
+   occupied source-only re-emitter.
+4. Catchup and structural endpoints: **simulation-facing surface converted**.
+   `StructuralStrictViewSurfaceDef`,
+   `StructuralSourceRebaseReplayProof`, and
+   `StructuralNameInstantiationProof` expose and consume separate source-ok
+   and source-star-open replay routes.  The isolated
+   `StructuralNameInstantiationProof` check completed successfully.  Broader
+   legacy endpoint transformers remain deletion blockers.
+5. Simulation surface: **converted**.  The source-conceal value interface uses
+   `SourceConcealOK`, and `SimProof` supplies `id-conceal-ok`; no simulation
+   construction site requires an old partner constructor.
+6. Examples and probes: **converted and checked** as described in item 2.
+
+Residual disposition:
+
+- R1: **carried as a negative regression**.  Its requested occupied
+  source-only `seal X ★` wrapper is deliberately not derivable under D15; its
+  matched inner chain remains checked.
+- R2: **discharged** by preserving the paired matched package in
+  `SealTransferCore`.
+- R3: **discharged** by the richer `TargetChainProof` source-star payload route.
+- R4: **discharged** by removing the obsolete source-strip core re-emitter
+  contract.
+- R5: **discharged** by the split structural replay surface; the isolated check
+  completed in approximately 106 seconds, below the five-minute timebox.
+
+Deletion result: **blocked**, with the exact live construction families and
+required redesign recorded in `t14-m3-deletion-blockers.red`.  The attempted
+definition removal was reverted; no half-deleted relation state remains.
+
 ## Gate
 
 Command:
 
 ```sh
 cd GTSFImp
-AGDA_DIR=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda-home make check
+PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH make check
 ```
 
 Additional standalone review-probe check:


### PR DESCRIPTION
Design memo (notes/t14-partner-premise-redesign.red) answering the user's suspicion that conceal⊑²'s SourceConcealPartnerOK premise wants a more elegant mechanism. Contents: the protection story with the concrete counterexample (the checked ProjectionMismatchStarRepScratch square — unearned seal pairing where the source resurfaces a sealed value while the target's ℕ!;Y? path blames), the minting/preservation/consumption trace, the friction inventory (endpoint-term dependence makes generic transport false; the D4/T5d lift gaps), and a three-way alternatives analysis. RECOMMENDATION: occupancy-style split — source-only seal X ★ see-through gated directly by NoTargetOccupantAtSource (the LG-1 infrastructure, which already transports), matched/generated evidence retained in conceal⊑conceal²/packaged-seal-star²; world-level and witness-level variants analyzed and rejected with reasons. Decision ask D15 on #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)