### PR TITLE
T15: D16 World-invariants design (drafted record, pressure points, kill-check)

### DIFF
--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -35,6 +35,7 @@ import proof.DGG.CastConsistencyViews
 import proof.DGG.Inversion.SpineValueProof
 import proof.DGG.Parked.ParkedWorldLemma
 import proof.DGG.Parked.ParkedD4CheckpointLemma
+import proof.DGG.WorldInvariants
 
 ------------------------------------------------------------------------
 -- Current frontier (M4/M5: catch-up lemmas, higher-order)

--- a/GTSFImp/TyStore.agda
+++ b/GTSFImp/TyStore.agda
@@ -7,7 +7,7 @@ module TyStore where
 --   * Exposes direct total lookup and relates type variables to their
 --     representation types in a store.
 
-open import Agda.Builtin.Equality using (_≡_)
+open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Nat using (zero; suc)
 open import Data.Fin using (zero; suc)
 
@@ -60,3 +60,10 @@ data _∋_⦂_ : ∀ {Δ} → TyStore Δ → TyVar Δ → Ty Δ → Set where
     → B ≡ ⇑ᵗ A
       ----------------------------------
     → store-bind Σ C ∋ suc X ⦂ B
+
+lookupStore-∋ : ∀ {Δ} {Σ : TyStore Δ} {X : TyVar Δ} {A : Ty Δ}
+  → Σ ∋ X ⦂ A
+  → lookupStore Σ X ≡ A
+lookupStore-∋ (Z∋ refl) = refl
+lookupStore-∋ (S-lift∋ X∈ refl) rewrite lookupStore-∋ X∈ = refl
+lookupStore-∋ (S-bind∋ X∈ refl) rewrite lookupStore-∋ X∈ = refl

--- a/GTSFImp/TyStore.agda
+++ b/GTSFImp/TyStore.agda
@@ -4,7 +4,8 @@ module TyStore where
 --   * Intrinsically well-scoped type stores.
 --   * Makes type-binder lifting and fresh runtime allocation the only ways to
 --     extend a store.
---   * Relates type variables to their representation types in a store.
+--   * Exposes direct total lookup and relates type variables to their
+--     representation types in a store.
 
 open import Agda.Builtin.Equality using (_≡_)
 open import Data.Nat using (zero; suc)
@@ -26,6 +27,16 @@ data TyStore : TyCtx → Set where
     → Ty Δ
       -------------------
     → TyStore (suc Δ)
+
+-- The direct entry for every store variable.  A structural lift represents
+-- its fresh variable by that variable itself; a runtime bind exposes exactly
+-- the bound type and does not follow variable indirection.
+
+lookupStore : ∀ {Δ} → TyStore Δ → TyVar Δ → Ty Δ
+lookupStore (store-lift Σ) zero = ＇ zero
+lookupStore (store-lift Σ) (suc X) = ⇑ᵗ (lookupStore Σ X)
+lookupStore (store-bind Σ A) zero = ⇑ᵗ A
+lookupStore (store-bind Σ A) (suc X) = ⇑ᵗ (lookupStore Σ X)
 
 infix 4 _∋_⦂_
 

--- a/GTSFImp/proof/DGG/Example12Worlds.agda
+++ b/GTSFImp/proof/DGG/Example12Worlds.agda
@@ -295,9 +295,9 @@ example12-left-path-target-store : TyStore 1
 example12-left-path-target-store = store-bind store-empty ★
 
 example12-left-path-imp-env : ImpEnv 3
-example12-left-path-imp-env Fin.zero = X⊑X
-example12-left-path-imp-env (Fin.suc Fin.zero) = X⊑X
-example12-left-path-imp-env (Fin.suc (Fin.suc Fin.zero)) = X⊑X
+example12-left-path-imp-env Fin.zero = X⊑★
+example12-left-path-imp-env (Fin.suc Fin.zero) = X⊑★
+example12-left-path-imp-env (Fin.suc (Fin.suc Fin.zero)) = X⊑★
 
 example12-left-path-ηᴸ : 3 ↪ᵗ 3
 example12-left-path-ηᴸ = keep (keep (keep empty))

--- a/GTSFImp/proof/DGG/Example12Worlds.agda
+++ b/GTSFImp/proof/DGG/Example12Worlds.agda
@@ -299,6 +299,11 @@ example12-left-path-imp-env Fin.zero = X⊑★
 example12-left-path-imp-env (Fin.suc Fin.zero) = X⊑★
 example12-left-path-imp-env (Fin.suc (Fin.suc Fin.zero)) = X⊑★
 
+example12-left-path-Z-imp-env : ImpEnv 3
+example12-left-path-Z-imp-env Fin.zero = X⊑★
+example12-left-path-Z-imp-env (Fin.suc Fin.zero) = X⊑★
+example12-left-path-Z-imp-env (Fin.suc (Fin.suc Fin.zero)) = X⊑X
+
 example12-left-path-ηᴸ : 3 ↪ᵗ 3
 example12-left-path-ηᴸ = keep (keep (keep empty))
 
@@ -328,7 +333,7 @@ example12-left-path-world-Y =
 example12-left-path-world-Z : World 3 1 3
 example12-left-path-world-Z =
   world example12-left-path-ηᴸ example12-left-path-ηᴿ-Z
-    example12-left-path-imp-env
+    example12-left-path-Z-imp-env
     example12-left-path-source-store
     example12-left-path-target-store
 

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -1278,7 +1278,12 @@ left-path-target-ηᴿ-XZ = keep (skip (keep empty))
 left-path-imp-env-XZ : ImpEnv 3
 left-path-imp-env-XZ Fin.zero = X⊑★
 left-path-imp-env-XZ (Fin.suc Fin.zero) = X⊑★
-left-path-imp-env-XZ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+left-path-imp-env-XZ (Fin.suc (Fin.suc Fin.zero)) = X⊑X
+
+left-path-imp-env-YZ : ImpEnv 3
+left-path-imp-env-YZ Fin.zero = X⊑★
+left-path-imp-env-YZ (Fin.suc Fin.zero) = X⊑★
+left-path-imp-env-YZ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
 
 -- The XZ checkpoints align source X and Z directly.  Their target fixture
 -- therefore exposes literal dynamic entries at both aligned cells instead of
@@ -1326,14 +1331,14 @@ left-path-world₃-YZ :
   World (Δ′ Ex.right-step₂) (Δ′ left-path-target-step₂)
     (Δ′ Ex.right-step₂)
 left-path-world₃-YZ =
-  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-XZ
+  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-YZ
     Ex.right-store₃ left-path-target-store₃
 
 left-path-world₄-YZ :
   World (Δ′ Ex.right-step₃) (Δ′ left-path-target-step₃)
     (Δ′ Ex.right-step₃)
 left-path-world₄-YZ =
-  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-XZ
+  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-YZ
     Ex.right-store₄ left-path-target-store₄
 
 left-path-ℕ⊑★₀ :
@@ -1896,22 +1901,10 @@ left-path-Z⇒Z⊑Z⇒Z-YZ₃ :
 left-path-Z⇒Z⊑Z⇒Z-YZ₃ =
   ⇒⊑⇒ left-path-Z-var⊑YZ₃ left-path-Z-var⊑YZ₃
 
-left-path-Z-var⊑★-XZ₃ :
-  ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₃ ⟩ ★
-left-path-Z-var⊑★-XZ₃ =
-  Imprecision.X⊑★ {X = Fin.suc (Fin.suc Fin.zero)} refl
-
 left-path-Z-var⊑★-YZ₃ :
   ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₃-YZ ⟩ ★
 left-path-Z-var⊑★-YZ₃ =
   Imprecision.X⊑★ {X = Fin.suc (Fin.suc Fin.zero)} refl
-
-left-path-Z⇒Z⊑★⇒★-XZ₃ :
-  (＇ (Fin.suc (Fin.suc Fin.zero))
-    ⇒ ＇ (Fin.suc (Fin.suc Fin.zero)))
-    ⊑ᵂ⟨ left-path-world₃ ⟩ (★ ⇒ ★)
-left-path-Z⇒Z⊑★⇒★-XZ₃ =
-  ⇒⊑⇒ left-path-Z-var⊑★-XZ₃ left-path-Z-var⊑★-XZ₃
 
 left-path-Z⇒Z⊑★⇒★-YZ₃ :
   (＇ (Fin.suc (Fin.suc Fin.zero))
@@ -2583,11 +2576,6 @@ left-path-Z-var⊑YZ₄ :
     ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ (Fin.suc Fin.zero)
 left-path-Z-var⊑YZ₄ =
   Imprecision.X⊑X {X = Fin.suc (Fin.suc Fin.zero)}
-
-left-path-Z-var⊑★-XZ₄ :
-  ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₄ ⟩ ★
-left-path-Z-var⊑★-XZ₄ =
-  Imprecision.X⊑★ {X = Fin.suc (Fin.suc Fin.zero)} refl
 
 left-path-Z-var⊑★-YZ₄ :
   ＇ (Fin.suc (Fin.suc Fin.zero)) ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ★

--- a/GTSFImp/proof/DGG/Examples2.agda
+++ b/GTSFImp/proof/DGG/Examples2.agda
@@ -1277,8 +1277,15 @@ left-path-target-ηᴿ-XZ = keep (skip (keep empty))
 
 left-path-imp-env-XZ : ImpEnv 3
 left-path-imp-env-XZ Fin.zero = X⊑★
-left-path-imp-env-XZ (Fin.suc Fin.zero) = X⊑X
+left-path-imp-env-XZ (Fin.suc Fin.zero) = X⊑★
 left-path-imp-env-XZ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+
+-- The XZ checkpoints align source X and Z directly.  Their target fixture
+-- therefore exposes literal dynamic entries at both aligned cells instead of
+-- retaining the reduction trace's intermediate Y-to-Z alias.
+
+left-path-target-store-XZ : TyStore 2
+left-path-target-store-XZ = store-bind (store-bind store-empty ★) ★
 
 left-path-world₁ :
   World (Δ′ Ex.right-step₀) (Δ′ left-path-target-step₀)
@@ -1299,21 +1306,21 @@ left-path-world₃ :
     (Δ′ Ex.right-step₂)
 left-path-world₃ =
   world id↪ᵗ left-path-target-ηᴿ-XZ left-path-imp-env-XZ
-    Ex.right-store₃ left-path-target-store₃
+    Ex.right-store₃ left-path-target-store-XZ
 
 left-path-world₄ :
   World (Δ′ Ex.right-step₃) (Δ′ left-path-target-step₃)
     (Δ′ Ex.right-step₃)
 left-path-world₄ =
   world id↪ᵗ left-path-target-ηᴿ-XZ left-path-imp-env-XZ
-    Ex.right-store₄ left-path-target-store₄
+    Ex.right-store₄ left-path-target-store-XZ
 
 left-path-world₅ :
   World (Δ′ Ex.right-step₄) (Δ′ left-path-target-step₄)
     (Δ′ Ex.right-step₄)
 left-path-world₅ =
   world id↪ᵗ left-path-target-ηᴿ-XZ left-path-imp-env-XZ
-    Ex.right-store₅ left-path-target-store₅
+    Ex.right-store₅ left-path-target-store-XZ
 
 left-path-world₃-YZ :
   World (Δ′ Ex.right-step₂) (Δ′ left-path-target-step₂)

--- a/GTSFImp/proof/DGG/GroundingPreserve.agda
+++ b/GTSFImp/proof/DGG/GroundingPreserve.agda
@@ -17,6 +17,8 @@ open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 
 open import Types using (TyCtx; Ty; TyVar; NonVar; _∈ᵗ_; ＇_; ★; ⇑ᵗ)
+open import TyStore using (lookupStore)
+open import Imprecision using (X⊑★)
 open import Consistency using
   (Env∼; _⊢_∼_; instᵐ; genᵐ; inst_; gen_; ↑ᶜ_; close-instᶜ;
    toRenameᵗ)
@@ -26,6 +28,7 @@ open import Conversion using (〖_,_↑_〗)
 open import Reduction using
   (bind; applyBody; _—→[_]_; β-inst; β-gen)
 import proof.DGG.CtxImp as CTI2
+import proof.DGG.WorldInvariants as WI
 open import proof.DGG.Occupancy using
   ( β-inst-allocation-occupies-targetᴼ
   ; β-gen-allocation-occupies-targetᴼ
@@ -102,11 +105,13 @@ open import proof.DGG.Occupancy using
 occupied-see-through-empty : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ}
   → (X : TyVar Δᴸ)
+  → WI.WorldInvariants W
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
   → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X)
-  → CTI2.NoTargetOccupantAtSource W X
   → ⊥
-occupied-see-through-empty X occupied no-target =
-  no-target occupied
+occupied-see-through-empty X inv mark entry occupied =
+  WI.world-invariants-d17c-occupancy inv mark entry occupied
 
 record RelatedReductionGroundingKnot : Set₁ where
   field
@@ -118,7 +123,9 @@ record RelatedReductionGroundingKnot : Set₁ where
           → CTI2.Occupied W′ (toRenameᵗ (CTI2.ηᴸʷ W′) X))
       → (X : TyVar Δᴸ)
       → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X)
-      → CTI2.NoTargetOccupantAtSource W′ X
+      → WI.WorldInvariants W′
+      → CTI2.impEnvʷ W′ (toRenameᵗ (CTI2.ηᴸʷ W′) X) ≡ X⊑★
+      → lookupStore (CTI2.sourceStoreʷ W′) X ≡ ★
       → ⊥
 
     β-inst-new-cell-grounded :
@@ -169,8 +176,9 @@ record RelatedReductionGroundingKnot : Set₁ where
 grounding-preservation-knot : RelatedReductionGroundingKnot
 grounding-preservation-knot = record
   { preserves-old-occupied-see-through-empty =
-      λ occ-at-source-forward X occupied no-target′ →
-        no-target′ (occ-at-source-forward X occupied)
+      λ occ-at-source-forward X occupied inv′ mark′ entry′ →
+        WI.world-invariants-d17c-occupancy inv′ mark′ entry′
+          (occ-at-source-forward X occupied)
   ; β-inst-new-cell-grounded =
       λ {Δᴸ} {Δᴿ} {Δ} {W} {V} {μ} {A} {B} {c}
           ⦃ Anv ⦄ ⦃ z∈A ⦄ vV B≢★ →

--- a/GTSFImp/proof/DGG/SealTransferCore.agda
+++ b/GTSFImp/proof/DGG/SealTransferCore.agda
@@ -23,6 +23,7 @@ open import Imprecision
 open import Conversion using (⊢↓-seal)
 open import CastTerms
 open import TyStore using (_∋_⦂_; Z∋; S-lift∋; S-bind∋)
+open import TyStore using (lookupStore-∋)
 open import Consistency using (Env∼; _⊢_∼_; id; _!; toRenameᵗ)
 open import Primitives using (κℕ; κ𝔹)
 import Conversion as Conv
@@ -33,6 +34,7 @@ import proof.DGG.Inversion.SpineValueDef as SVD
 import proof.DGG.SealPeelToolkit as SPT
 import proof.DGG.TermImpDecay as TD
 import proof.DGG.WorldDecay as WD
+import proof.DGG.WorldInvariants as WI
 open import proof.ImprecisionConsistency using (toRenameᵗ-injective)
 open CTX using
   (World;
@@ -355,7 +357,7 @@ source-star-cast-package-from-source : ∀ {Δᴸ Δᴿ Δ}
     → CTX.TagRebaseAtᴸ Wᵖ W (just X) Xᴿ?
     → CTX.SameCtx γ γᵖ
     → CTX.sourceStoreʷ W ∋ X ⦂ ★
-    → CTX.NoTargetOccupantAtSource W X
+    → WI.WorldInvariants W
     → CTX.Rep★PartnerOK Wᵖ X P Xᴿ? U
     → Inert c
     → Wᵖ ∣ γᵖ ⊢² P ⊑ U ∶ p★
@@ -366,14 +368,17 @@ source-star-cast-package-from-source : ∀ {Δᴸ Δᴿ Δ}
         ((P ↓ Conversion.seal X ★) ⟨ c ⟩) ↓ Conversion.seal X ★
         ⊑ U ∶ q)
 source-star-cast-package-from-source {W = W} {X = X}
-      {Xᴿ? = just Y} mono (CTX.tag-rebase-varᴸ rb) sc
-      source∈ no-target partner inert prem sealed =
-  ⊥-elim (no-target (Y , sym (CTX.RebaseAt.pivotAligned rb)))
+      {Xᴿ? = just Y} {q = X⊑★ mark} mono
+      (CTX.tag-rebase-varᴸ rb) sc source∈ inv partner inert prem sealed =
+  ⊥-elim
+    (WI.world-invariants-no-target-at-dynamic-star inv mark
+      (lookupStore-∋ source∈)
+      (Y , sym (CTX.RebaseAt.pivotAligned rb)))
 source-star-cast-package-from-source {W = W} {γ = γ} {X = X}
-      {c = c}
-      {q = q} mono rb@(CTX.tag-rebase-onlyᴸ to-star disaligned
+      {c = c} {q = q} mono
+      rb@(CTX.tag-rebase-onlyᴸ to-star disaligned
         represented)
-      sc source∈ no-target partner
+      sc source∈ inv partner
       (inj ⦃ Gᵍ = ＇ .X ⦄) prem sealed =
   tagged-transfer-output
     (CTI2.cast⊑² c sealed ★⊑★)
@@ -382,7 +387,8 @@ source-star-cast-package-from-source {W = W} {γ = γ} {X = X}
       (CTX.rep★-round-trip
         (transport-rep★-partner-ok-tag rb partner))) ,
     CTI2.conceal⊑²-seal-star-open
-      no-target
+      (WI.world-invariants-see-through-premise inv rb
+        (Conv.⊢↓-sealˣ source∈))
     (impEnvMono-refl {W = W})
     (self-tag-rebase-from-tag-rebase rb)
     (sameCtx-refl {γ = γ})

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -8,8 +8,9 @@ module proof.DGG.WorldInvariants where
 --     builders without changing World or requiring it from consumers.
 --   * Derives variable-entry chain coherence from direct representations.
 
-open import Data.Empty using (⊥-elim)
+open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
+open import Data.Maybe using (just; nothing)
 import Data.Nat as Nat
 open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Relation.Binary.PropositionalEquality using
@@ -20,7 +21,7 @@ open import Types
 open import TyStore using
   (TyStore; store-empty; store-lift; store-bind; lookupStore)
 open import Consistency using
-  (_↪ᵗ_; empty; keep; skip; id↪ᵗ; toRenameᵗ)
+  (_↪ᵗ_; empty; keep; skip; id↪ᵗ; wk↪ᵗ; toRenameᵗ)
 open import Imprecision
 import Reduction as R
 import proof.DGG.CastTermImprecision2 as CTI2
@@ -28,12 +29,13 @@ import proof.DGG.CenterRename as CR
 import proof.DGG.CompilePreservesImprecision2 as CPI2
 import proof.DGG.Parked.ParkedWorldDef as PWD
 import proof.DGG.SealPeelToolkit as SPT
+import proof.DGG.TargetBindLift as TBL
 import proof.DGG.TargetExtend as TE
 import proof.DGG.WorldDecay as WD
 open import proof.ImprecisionConsistency using
   (refl⊑; rename-⊑; toRenameᵗ-injective)
 open import proof.TypeInTermSubst using
-  (toRename-id-eq; toRename-keep-eq)
+  (renameᵗ-wk-eq; toRename-id-eq; toRename-keep-eq; toRename-wk-eq)
 
 
 record WorldInvariants {Δᴸ Δᴿ Δ}
@@ -497,14 +499,6 @@ parked-right-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants (CTI2.rightOnlyWorld W B)
 parked-right-bind-invariants {B = B} = rightOnlyWorld-invariants B
 
-parked-structural-right-insert-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-  → PWD.ParkedWorld W
-  → WorldInvariants W
-  → WorldInvariants W
-parked-structural-right-insert-invariants parked inv = inv
-
-
 parkedEvolve-end-invariants : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
     {χsᴸ : R.StoreChanges Δᴸ Δᴸ′}
     {χsᴿ : R.StoreChanges Δᴿ Δᴿ′}
@@ -632,3 +626,401 @@ dynWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (SPT.dynWorld W)
 dynWorld-invariants {W = W} = decay-invariants (SPT.dynWorld-decay W)
+
+
+targetStoreAs-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (Σᴿ : TyStore Δᴿ)
+  → WorldInvariants W
+  → (∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+      → CTI2.impEnvʷ W ⊢
+          renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
+            (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
+          ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W)) (lookupStore Σᴿ Xᴿ))
+  → (∀ (Xᴿ : TyVar Δᴿ)
+      → (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+      → lookupStore Σᴿ Xᴿ ≡ ★)
+  → WorldInvariants (TBL.targetStoreAs W Σᴿ)
+targetStoreAs-invariants Σᴿ inv reps unmatched =
+  world-invariants (preciseMarksAligned inv) reps unmatched
+
+
+record TargetInsertDirect {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    (ins : TE.TargetInsert ρ π W W′) : Set where
+  constructor target-insert-direct
+  field
+    targetLookup-insert : ∀ Xᴿ
+      → lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ)
+        ≡ renameᵗ (toRenameᵗ ρ)
+            (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+
+    targetLookup-off : ∀ Xᴿ′
+      → CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) ≡ nothing
+      → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+
+open TargetInsertDirect public
+
+
+targetInsert-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → TargetInsertDirect ins
+  → WorldInvariants W
+  → WorldInvariants W′
+targetInsert-invariants {ρ = ρ} {π = π} {W = W} {W′ = W′} ins direct inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → CTI2.impEnvʷ W′ (toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ′ ∈ TyVar _ ]
+        toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′
+          ≡ toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ
+  precise Xᴸ mark with preciseMarksAligned inv Xᴸ old-mark
+    where
+    old-mark :
+      CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+    old-mark = trans
+      (sym (TE.impEnv-insert ins (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)))
+      (subst≡ (λ Z → CTI2.impEnvʷ W′ Z ≡ X⊑X)
+        (TE.source-insert ins Xᴸ) mark)
+  precise Xᴸ mark | Xᴿ , aligned =
+    toRenameᵗ ρ Xᴿ , sym (TE.align-insert ins (sym aligned))
+
+  reps : ∀ {Xᴸ Xᴿ′}
+    → CTI2.CenterAligned W′ Xᴸ Xᴿ′
+    → CTI2.impEnvʷ W′ ⊢
+        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′))
+          (lookupStore (CTI2.sourceStoreʷ W′) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′))
+          (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′)
+  reps {Xᴸ} {Xᴿ′} aligned
+      with TE.target-source-reflect ins aligned
+  reps {Xᴸ} {Xᴿ′} aligned | Xᴿ , refl , old-aligned =
+    imprecision-cong source-eq target-eq
+      (TE.transport⊑ᵂ ins (representationsImprecise inv old-aligned))
+    where
+    source-eq :
+      renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′))
+          (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
+        ≡ renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′))
+          (lookupStore (CTI2.sourceStoreʷ W′) Xᴸ)
+    source-eq = cong (renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′)))
+      (sym (cong (λ Σ → lookupStore Σ Xᴸ) (TE.sourceStore-kept ins)))
+
+    target-eq :
+      renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′))
+          (renameᵗ (toRenameᵗ _) (lookupStore (CTI2.targetStoreʷ W) Xᴿ))
+        ≡ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′))
+          (lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ _ Xᴿ))
+    target-eq = cong (renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′)))
+      (sym (targetLookup-insert direct Xᴿ))
+
+  unmatched : ∀ Xᴿ′
+    → (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Xᴿ′ → ⊥)
+    → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+  unmatched Xᴿ′ no-source
+      with CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) in pre
+  unmatched Xᴿ′ no-source | nothing =
+    targetLookup-off direct Xᴿ′ pre
+  unmatched Xᴿ′ no-source | just Z
+      with TE.target-center-reflect ins (CR.preimage?-sound π pre)
+  unmatched Xᴿ′ no-source | just Z
+      | Xᴿ , xᴿ′-eq , old-center =
+    subst≡ (λ Y → lookupStore (CTI2.targetStoreʷ W′) Y ≡ ★)
+      (sym xᴿ′-eq)
+      (trans (targetLookup-insert direct Xᴿ)
+        (cong (renameᵗ (toRenameᵗ ρ))
+          (unmatchedTargetsDynamic inv Xᴿ old-no-source)))
+    where
+    old-no-source : ∀ Xᴸ → CTI2.CenterAligned W Xᴸ Xᴿ → ⊥
+    old-no-source Xᴸ aligned = no-source Xᴸ
+      (subst≡ (CTI2.CenterAligned W′ Xᴸ) (sym xᴿ′-eq)
+        (TE.align-insert ins aligned))
+
+
+parked-structural-right-insert-invariants : ∀ {Δᴸ Δᴿ Δ Δ₁}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {B : Ty Δᴿ} {π : Δ ↪ᵗ Δ₁}
+  → PWD.ParkedWorld W
+  → (ins : TE.TargetInsert wk↪ᵗ π W W₁)
+  → TargetInsertDirect ins
+  → CTI2.targetStoreʷ W₁ ≡ R.applyStore (R.bind B) (CTI2.targetStoreʷ W)
+  → WorldInvariants W
+  → WorldInvariants W₁
+parked-structural-right-insert-invariants parked ins direct follows inv =
+  targetInsert-invariants ins direct inv
+
+
+rightBindTargetInsert-direct : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+  → ⇑ᵗ B ≡ ★
+  → TargetInsertDirect (TE.rightBindTargetInsert {W = W} {B = B})
+rightBindTargetInsert-direct {W = W} {B = B} fresh-dynamic =
+  target-insert-direct old-entry fresh-entry
+  where
+  ins = TE.rightBindTargetInsert {W = W} {B = B}
+
+  old-entry : ∀ Xᴿ
+    → lookupStore (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B))
+        (toRenameᵗ wk↪ᵗ Xᴿ)
+      ≡ renameᵗ (toRenameᵗ wk↪ᵗ)
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+  old-entry Xᴿ =
+    trans (cong (lookupStore (store-bind (CTI2.targetStoreʷ W) B))
+      (toRename-wk-eq Xᴿ))
+      (sym (renameᵗ-wk-eq (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+
+  fresh-entry : ∀ Xᴿ′
+    → CR.preimage? wk↪ᵗ
+        (toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) Xᴿ′)
+        ≡ nothing
+    → lookupStore (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B)) Xᴿ′
+        ≡ ★
+  fresh-entry Fin.zero off = fresh-dynamic
+  fresh-entry (Fin.suc Xᴿ) off = ⊥-elim (CR.just≢nothing impossible)
+    where
+    center-eq :
+      toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) (Fin.suc Xᴿ)
+        ≡ toRenameᵗ wk↪ᵗ (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+    center-eq = trans
+      (cong (toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)))
+        (sym (toRename-wk-eq Xᴿ)))
+      (TE.target-insert ins Xᴿ)
+
+    impossible : just (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ) ≡ nothing
+    impossible = trans
+      (sym (CR.preimage?-image wk↪ᵗ
+        (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)))
+      (trans (cong (CR.preimage? wk↪ᵗ) (sym center-eq)) off)
+
+
+liftBothTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′} {v : VarImp}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → TargetInsertDirect ins
+  → TargetInsertDirect (TE.liftBothTargetInsert {v = v} ins)
+liftBothTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
+    {v = v} ins direct = target-insert-direct old-entry fresh-entry
+  where
+  old-entry : ∀ Xᴿ
+    → lookupStore
+        (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′))
+        (toRenameᵗ (keep ρ) Xᴿ)
+      ≡ renameᵗ (toRenameᵗ (keep ρ))
+          (lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W)) Xᴿ)
+  old-entry Fin.zero = refl
+  old-entry (Fin.suc Xᴿ) =
+    trans (cong ⇑ᵗ (targetLookup-insert direct Xᴿ))
+      (sym (renameᵗ-keep-shift ρ
+        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+
+  fresh-entry : ∀ Xᴿ′
+    → CR.preimage? (keep π)
+        (toRenameᵗ (CTI2.ηᴿʷ (CTI2.liftWorldBoth v W′)) Xᴿ′)
+        ≡ nothing
+    → lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′)) Xᴿ′
+        ≡ ★
+  fresh-entry Fin.zero ()
+  fresh-entry (Fin.suc Xᴿ′) off =
+    cong ⇑ᵗ (targetLookup-off direct Xᴿ′
+      (CR.sucMaybe-nothing _ off))
+
+
+liftLeftTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′} {v : VarImp}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → TargetInsertDirect ins
+  → TargetInsertDirect (TE.liftLeftTargetInsert {v = v} ins)
+liftLeftTargetInsert-direct {π = π} {W′ = W′} {v = v} ins direct =
+  target-insert-direct (targetLookup-insert direct) fresh-entry
+  where
+  fresh-entry : ∀ Xᴿ′
+    → CR.preimage? (keep π)
+        (toRenameᵗ (CTI2.ηᴿʷ (CTI2.liftWorldLeft v W′)) Xᴿ′)
+        ≡ nothing
+    → lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldLeft v W′)) Xᴿ′
+        ≡ ★
+  fresh-entry Xᴿ′ off =
+    targetLookup-off direct Xᴿ′ (CR.sucMaybe-nothing _ off)
+
+
+smartAliasTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → (guard : CTI2.SmartAliasMergeGuard W Wᵐ β α)
+  → TargetInsertDirect ins
+  → TargetInsertDirect (TE.smartAliasTargetInsert ins guard)
+smartAliasTargetInsert-direct {ρ = ρ} {W = W} {Wᵐ = Wᵐ} ins guard direct =
+  target-insert-direct old-entry (targetLookup-off direct)
+  where
+  old-entry : ∀ Xᴿ
+    → lookupStore
+        (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ))
+        (toRenameᵗ ρ Xᴿ)
+      ≡ renameᵗ (toRenameᵗ ρ) (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
+  old-entry Xᴿ = trans (targetLookup-insert direct Xᴿ)
+    (cong (renameᵗ (toRenameᵗ ρ))
+      (sym (cong (λ Σ → lookupStore Σ Xᴿ)
+        (CTI2.SmartAliasMergeGuard.targetStore-same guard))))
+
+smartAliasInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → (guard : CTI2.SmartAliasMergeGuard W Wᵐ β α)
+  → TargetInsertDirect ins
+  → WorldInvariants Wᵐ
+  → WorldInvariants (TE.smartAliasInsertWorld ins Wᵐ)
+smartAliasInsertWorld-invariants ins guard direct inv =
+  targetInsert-invariants (TE.smartAliasTargetInsert ins guard)
+    (smartAliasTargetInsert-direct ins guard direct) inv
+
+
+smartFreshTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′ Δᵐ}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δᵐ}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → (guard : CTI2.SmartFreshBehindGuard W Wᵐ)
+  → TargetInsertDirect ins
+  → TargetInsertDirect (TE.smartFreshTargetInsert ins guard)
+smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
+    {Wᵐ = Wᵐ} ins guard direct = target-insert-direct old-entry fresh-entry
+  where
+  old = CTI2.SmartFreshBehindGuard.oldCenters guard
+  po = CR.embeddingPushout π old
+  πᵐ = CR.EmbeddingPushout.premise po
+
+  old-entry : ∀ Xᴿ
+    → lookupStore
+        (CTI2.targetStoreʷ (TE.smartFreshInsertWorld ins guard))
+        (toRenameᵗ ρ Xᴿ)
+      ≡ renameᵗ (toRenameᵗ ρ) (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
+  old-entry Xᴿ = trans (targetLookup-insert direct Xᴿ)
+    (cong (renameᵗ (toRenameᵗ ρ))
+      (sym (cong (λ Σ → lookupStore Σ Xᴿ)
+        (CTI2.SmartFreshBehindGuard.targetStore-same guard))))
+
+  input-center-off : ∀ Xᴿ′
+    → CR.preimage? ρ Xᴿ′ ≡ nothing
+    → CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) ≡ nothing
+  input-center-off Xᴿ′ no-old
+      with CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) in preπ
+  input-center-off Xᴿ′ no-old | nothing = refl
+  input-center-off Xᴿ′ no-old | just Z
+      with TE.target-center-reflect ins (CR.preimage?-sound π preπ)
+  input-center-off Xᴿ′ no-old | just Z
+      | Xᴿ , xᴿ′-eq , old-center = ⊥-elim (CR.just≢nothing impossible)
+    where
+    impossible : just Xᴿ ≡ nothing
+    impossible = trans
+      (sym (CR.preimage?-image ρ Xᴿ))
+      (trans (cong (CR.preimage? ρ) (sym xᴿ′-eq)) no-old)
+
+  fresh-entry : ∀ Xᴿ′
+    → CR.preimage? πᵐ
+        (toRenameᵗ
+          (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′)
+        ≡ nothing
+    → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+  fresh-entry Xᴿ′ off with CR.preimage? ρ Xᴿ′ in preρ
+  fresh-entry Xᴿ′ off | just Xᴿ = ⊥-elim (CR.just≢nothing impossible)
+    where
+    xᴿ′-eq : Xᴿ′ ≡ toRenameᵗ ρ Xᴿ
+    xᴿ′-eq = CR.preimage?-sound ρ preρ
+
+    center-eq :
+      toRenameᵗ (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′
+        ≡ toRenameᵗ πᵐ (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ)
+    center-eq = trans
+      (cong (toRenameᵗ
+        (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard))) xᴿ′-eq)
+      (TE.smartFresh-target-insert ins guard Xᴿ)
+
+    impossible :
+      just (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ) ≡ nothing
+    impossible = trans
+      (sym (CR.preimage?-image πᵐ
+        (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ)))
+      (trans (cong (CR.preimage? πᵐ) (sym center-eq)) off)
+  fresh-entry Xᴿ′ off | nothing =
+    targetLookup-off direct Xᴿ′ (input-center-off Xᴿ′ preρ)
+
+
+smartFreshInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′ Δᵐ}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δᵐ}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → (guard : CTI2.SmartFreshBehindGuard W Wᵐ)
+  → TargetInsertDirect ins
+  → WorldInvariants Wᵐ
+  → WorldInvariants (TE.smartFreshInsertWorld ins guard)
+smartFreshInsertWorld-invariants ins guard direct inv =
+  targetInsert-invariants (TE.smartFreshTargetInsert ins guard)
+    (smartFreshTargetInsert-direct ins guard direct) inv
+
+
+keepRightBindTargetInsert-direct : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ} {v : VarImp}
+  → ⇑ᵗ B ≡ ★
+  → TargetInsertDirect (TE.keepRightBindTargetInsert {W = W} {B = B} {v = v})
+keepRightBindTargetInsert-direct {W = W} {B = B} {v = v} fresh-dynamic =
+  liftBothTargetInsert-direct
+    (TE.rightBindTargetInsert {W = W} {B = B})
+    (rightBindTargetInsert-direct fresh-dynamic)
+
+
+insertRebaseTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {W⁺ : CTI2.World Δᴸ Δᴿ′ Δ′} {Xᴸ Xᴿ}
+  → (ins : TE.TargetInsert ρ π W W⁺)
+  → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
+  → TargetInsertDirect ins
+  → TargetInsertDirect (TE.insertRebaseTargetInsert ins rb)
+insertRebaseTargetInsert-direct {ρ = ρ} {W = W} {Wᵖ = Wᵖ}
+    ins rb direct = target-insert-direct old-entry (targetLookup-off direct)
+  where
+  old-entry : ∀ Yᴿ
+    → lookupStore
+        (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ))
+        (toRenameᵗ ρ Yᴿ)
+      ≡ renameᵗ (toRenameᵗ ρ) (lookupStore (CTI2.targetStoreʷ Wᵖ) Yᴿ)
+  old-entry Yᴿ = trans (targetLookup-insert direct Yᴿ)
+    (cong (renameᵗ (toRenameᵗ ρ))
+      (sym (cong (λ Σ → lookupStore Σ Yᴿ)
+        (CTI2.SameRuntime.targetStore-same
+          (CTI2.RebaseAt.sameRuntime rb)))))
+
+
+insertRebaseWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
+    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
+    {W⁺ : CTI2.World Δᴸ Δᴿ′ Δ′} {Xᴸ Xᴿ}
+  → (ins : TE.TargetInsert ρ π W W⁺)
+  → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
+  → TargetInsertDirect ins
+  → WorldInvariants Wᵖ
+  → WorldInvariants (TE.insertRebaseWorld ins Wᵖ)
+insertRebaseWorld-invariants ins rb direct inv =
+  targetInsert-invariants (TE.insertRebaseTargetInsert ins rb)
+    (insertRebaseTargetInsert-direct ins rb direct) inv

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -22,7 +22,14 @@ open import TyStore using
 open import Consistency using
   (_↪ᵗ_; empty; keep; skip; id↪ᵗ; toRenameᵗ)
 open import Imprecision
+import Reduction as R
 import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CenterRename as CR
+import proof.DGG.CompilePreservesImprecision2 as CPI2
+import proof.DGG.Parked.ParkedWorldDef as PWD
+import proof.DGG.SealPeelToolkit as SPT
+import proof.DGG.TargetExtend as TE
+import proof.DGG.WorldDecay as WD
 open import proof.ImprecisionConsistency using
   (refl⊑; rename-⊑; toRenameᵗ-injective)
 open import proof.TypeInTermSubst using
@@ -134,6 +141,29 @@ initialWorld-invariants μ = world-invariants precise reps unmatched
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
     → lookupStore (emptyStore _) Xᴿ ≡ ★
+  unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
+
+identityWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ) (Σ : TyStore Δ)
+  → WorldInvariants (CTI2.world id↪ᵗ id↪ᵗ μ Σ Σ)
+identityWorld-invariants μ Σ = world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → μ (toRenameᵗ id↪ᵗ Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ id↪ᵗ Xᴿ ≡ toRenameᵗ id↪ᵗ Xᴸ
+  precise Xᴸ mark = Xᴸ , refl
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ id↪ᵗ Xᴸ ≡ toRenameᵗ id↪ᵗ Xᴿ
+    → μ ⊢ renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore Σ Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore Σ Xᴿ)
+  reps {Xᴸ = Xᴸ} aligned
+      with toRenameᵗ-injective id↪ᵗ aligned
+  reps {Xᴸ = Xᴸ} aligned | refl = refl⊑ _
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
+    → lookupStore Σ Xᴿ ≡ ★
   unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
 
 
@@ -439,3 +469,166 @@ bothBindWorld-invariants {W = W} v A B A⊑B inv =
         ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
     old-no-source Xᴸ aligned =
       no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+
+
+parked-initial-invariants : ∀ {Δ} {μ : ImpEnv Δ} {Σ : TyStore Δ}
+  → WorldInvariants (CPI2.initialWorld μ Σ)
+parked-initial-invariants {μ = μ} {Σ = Σ} = identityWorld-invariants μ Σ
+
+parked-both-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → A CTI2.⊑ᵂ⟨ W ⟩ B
+  → WorldInvariants W
+  → WorldInvariants (CTI2.bothBindWorld X⊑X W A B)
+parked-both-bind-invariants {A = A} {B = B} =
+  bothBindWorld-invariants X⊑X A B
+
+parked-left-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ}
+  → WorldInvariants W
+  → WorldInvariants (CTI2.leftOnlyWorld X⊑★ W A)
+parked-left-bind-invariants {A = A} =
+  leftOnlyWorld-invariants X⊑★ A refl
+
+parked-right-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+  → ⇑ᵗ B ≡ ★
+  → WorldInvariants W
+  → WorldInvariants (CTI2.rightOnlyWorld W B)
+parked-right-bind-invariants {B = B} = rightOnlyWorld-invariants B
+
+parked-structural-right-insert-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → PWD.ParkedWorld W
+  → WorldInvariants W
+  → WorldInvariants W
+parked-structural-right-insert-invariants parked inv = inv
+
+
+parkedEvolve-end-invariants : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
+    {χsᴸ : R.StoreChanges Δᴸ Δᴸ′}
+    {χsᴿ : R.StoreChanges Δᴿ Δᴿ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ′ Δᴿ′ Δ′}
+  → PWD.ParkedEvolve χsᴸ χsᴿ W W′
+  → WorldInvariants W′
+  → WorldInvariants W′
+parkedEvolve-end-invariants PWD.evolve-refl inv = inv
+parkedEvolve-end-invariants (PWD.evolve-keepᴸ evol) inv = inv
+parkedEvolve-end-invariants (PWD.evolve-keepᴿ evol) inv = inv
+parkedEvolve-end-invariants (PWD.evolve-both-bind evol) inv = inv
+parkedEvolve-end-invariants (PWD.evolve-left-bind evol) inv = inv
+parkedEvolve-end-invariants (PWD.evolve-right-bind evol) inv = inv
+parkedEvolve-end-invariants
+    (PWD.evolve-structural-right-bind ins follows evol) inv = inv
+
+
+renameWorld-invariants : ∀ {Δᴸ Δᴿ Δ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (π : Δ ↪ᵗ Δ′)
+  → WorldInvariants W
+  → WorldInvariants (CR.renameWorld π W)
+renameWorld-invariants {W = W} π inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → CR.renameEnv π (CTI2.impEnvʷ W)
+        (toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ
+          ≡ toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
+  precise Xᴸ mark with preciseMarksAligned inv Xᴸ old-mark
+    where
+    old-mark :
+      CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+    old-mark =
+      trans (sym (CR.renameEnv-image π (CTI2.impEnvʷ W)
+          (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)))
+        (trans (cong (CR.renameEnv π (CTI2.impEnvʷ W))
+          (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))) mark)
+  precise Xᴸ mark | Xᴿ , aligned =
+    Xᴿ , trans (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ)
+      (trans (cong (toRenameᵗ π) aligned)
+        (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ)))
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
+        ≡ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ
+    → CR.renameEnv π (CTI2.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W))
+          (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W))
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+  reps {Xᴸ} {Xᴿ} aligned =
+    CR.rename-⊑ᵂ {W = W}
+      {A = lookupStore (CTI2.sourceStoreʷ W) Xᴸ}
+      {B = lookupStore (CTI2.targetStoreʷ W) Xᴿ}
+      π (representationsImprecise inv old-aligned)
+    where
+    old-aligned : CenterAligned W Xᴸ Xᴿ
+    old-aligned = toRenameᵗ-injective π
+      (trans (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))
+        (trans aligned
+          (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ)))
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+        → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
+          ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ)
+    → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+  unmatched Xᴿ no-source = unmatchedTargetsDynamic inv Xᴿ old-no-source
+    where
+    old-no-source : ∀ Xᴸ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+    old-no-source Xᴸ aligned = no-source Xᴸ
+      (trans (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ)
+        (trans (cong (toRenameᵗ π) aligned)
+          (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ))))
+
+
+decay-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+  → WD.EnvDecay W Wᵈ
+  → WorldInvariants W
+  → WorldInvariants Wᵈ
+decay-invariants
+    {W = CTI2.world ηᴸ ηᴿ μ Σᴸ Σᴿ}
+    {Wᵈ = CTI2.world .ηᴸ .ηᴿ μᵈ .Σᴸ .Σᴿ}
+    (WD.env-decay refl refl refl refl mono) inv =
+  world-invariants precise reps (unmatchedTargetsDynamic inv)
+  where
+  precise : ∀ Xᴸ
+    → μᵈ (toRenameᵗ ηᴸ Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ ηᴿ Xᴿ ≡ toRenameᵗ ηᴸ Xᴸ
+  precise Xᴸ preciseᵈ with μ (toRenameᵗ ηᴸ Xᴸ) in old-mark
+  precise Xᴸ preciseᵈ | X⊑X = preciseMarksAligned inv Xᴸ old-mark
+  precise Xᴸ preciseᵈ | X⊑★
+      with trans (sym (mono (toRenameᵗ ηᴸ Xᴸ) old-mark)) preciseᵈ
+  precise Xᴸ preciseᵈ | X⊑★ | ()
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ ηᴸ Xᴸ ≡ toRenameᵗ ηᴿ Xᴿ
+    → μᵈ ⊢ renameᵗ (toRenameᵗ ηᴸ) (lookupStore Σᴸ Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ ηᴿ) (lookupStore Σᴿ Xᴿ)
+  reps aligned = WD.⊑-env-mono mono (representationsImprecise inv aligned)
+
+
+blendWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W′ Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+  → WorldInvariants W′
+  → WorldInvariants (WD.blendWorld W′ Wᵈ)
+blendWorld-invariants {W′ = W′} {Wᵈ = Wᵈ} =
+  decay-invariants (WD.blend-decay {W′ = W′} {Wᵈ = Wᵈ})
+
+honestify-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → WorldInvariants W
+  → WorldInvariants (WD.honestify W)
+honestify-invariants {W = W} = decay-invariants (WD.honestify-decay {W = W})
+
+dynWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → WorldInvariants W
+  → WorldInvariants (SPT.dynWorld W)
+dynWorld-invariants {W = W} = decay-invariants (SPT.dynWorld-decay W)

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -27,6 +27,7 @@ import Reduction as R
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CenterRename as CR
 import proof.DGG.CompilePreservesImprecision2 as CPI2
+import proof.DGG.Examples2 as Ex2
 import proof.DGG.Parked.ParkedWorldDef as PWD
 import proof.DGG.SealPeelToolkit as SPT
 import proof.DGG.TargetBindLift as TBL
@@ -1024,3 +1025,142 @@ insertRebaseWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
 insertRebaseWorld-invariants ins rb direct inv =
   targetInsert-invariants (TE.insertRebaseTargetInsert ins rb)
     (insertRebaseTargetInsert-direct ins rb direct) inv
+
+
+example12-left-path-world-X-invariants :
+  WorldInvariants CTI2.example12-left-path-world-X
+example12-left-path-world-X-invariants =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → CTI2.impEnvʷ CTI2.example12-left-path-world-X
+        (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar 1 ]
+        toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X) Xᴿ
+          ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Fin.zero) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) ()
+
+  reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
+    → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ
+    → CTI2.impEnvʷ CTI2.example12-left-path-world-X ⊢
+        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X))
+          (lookupStore (CTI2.sourceStoreʷ CTI2.example12-left-path-world-X) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X))
+          (lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ)
+  reps {Fin.zero} {Fin.zero} refl = ι⊑★
+  reps {Fin.suc Fin.zero} {Fin.zero} ()
+  reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ → ⊥)
+    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ ≡ ★
+  unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
+
+
+example12-left-path-world-Y-invariants :
+  WorldInvariants CTI2.example12-left-path-world-Y
+example12-left-path-world-Y-invariants =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → CTI2.impEnvʷ CTI2.example12-left-path-world-Y
+        (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar 1 ]
+        toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y) Xᴿ
+          ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Fin.zero) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) ()
+
+  reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
+    → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ
+    → CTI2.impEnvʷ CTI2.example12-left-path-world-Y ⊢
+        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y))
+          (lookupStore (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Y) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y))
+          (lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ)
+  reps {Fin.zero} {Fin.zero} ()
+  reps {Fin.suc Fin.zero} {Fin.zero} refl = X⊑★ refl
+  reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ → ⊥)
+    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ ≡ ★
+  unmatched Fin.zero no-source =
+    ⊥-elim (no-source (Fin.suc Fin.zero) refl)
+
+
+example12-left-path-world-Z-invariants :
+  WorldInvariants CTI2.example12-left-path-world-Z
+example12-left-path-world-Z-invariants =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → CTI2.impEnvʷ CTI2.example12-left-path-world-Z
+        (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar 1 ]
+        toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z) Xᴿ
+          ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Fin.zero) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) ()
+
+  reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
+    → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ
+    → CTI2.impEnvʷ CTI2.example12-left-path-world-Z ⊢
+        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z))
+          (lookupStore (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Z) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z))
+          (lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ)
+  reps {Fin.zero} {Fin.zero} ()
+  reps {Fin.suc Fin.zero} {Fin.zero} ()
+  reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} refl = ★⊑★
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ → ⊥)
+    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ ≡ ★
+  unmatched Fin.zero no-source =
+    ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
+
+
+examples2-left-path-world₃-invariants : WorldInvariants Ex2.left-path-world₃
+examples2-left-path-world₃-invariants = world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → CTI2.impEnvʷ Ex2.left-path-world₃
+        (toRenameᵗ (CTI2.ηᴸʷ Ex2.left-path-world₃) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar 2 ]
+        toRenameᵗ (CTI2.ηᴿʷ Ex2.left-path-world₃) Xᴿ
+          ≡ toRenameᵗ (CTI2.ηᴸʷ Ex2.left-path-world₃) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Fin.zero) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) ()
+
+  reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 2}
+    → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ
+    → CTI2.impEnvʷ Ex2.left-path-world₃ ⊢
+        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ Ex2.left-path-world₃))
+          (lookupStore (CTI2.sourceStoreʷ Ex2.left-path-world₃) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ Ex2.left-path-world₃))
+          (lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ)
+  reps {Fin.zero} {Fin.zero} refl = ι⊑★
+  reps {Fin.zero} {Fin.suc Fin.zero} ()
+  reps {Fin.suc Fin.zero} {Fin.zero} ()
+  reps {Fin.suc Fin.zero} {Fin.suc Fin.zero} ()
+  reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
+  reps {Fin.suc (Fin.suc Fin.zero)} {Fin.suc Fin.zero} refl = ★⊑★
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ → ⊥)
+    → lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ ≡ ★
+  unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
+  unmatched (Fin.suc Fin.zero) no-source =
+    ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
+
+examples2-left-path-world₄-invariants : WorldInvariants Ex2.left-path-world₄
+examples2-left-path-world₄-invariants = examples2-left-path-world₃-invariants
+
+examples2-left-path-world₅-invariants : WorldInvariants Ex2.left-path-world₅
+examples2-left-path-world₅-invariants = examples2-left-path-world₃-invariants

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -25,9 +25,10 @@ open import Consistency using
   (_↪ᵗ_; empty; keep; skip; id↪ᵗ; wk↪ᵗ; toRenameᵗ)
 open import Imprecision
 import Reduction as R
-import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.CenterRename as CR
 import proof.DGG.CompilePreservesImprecision2 as CPI2
+import proof.DGG.CtxImp as CTX
+import proof.DGG.Example12Worlds as Ex12
 import proof.DGG.Examples2 as Ex2
 import proof.DGG.Parked.ParkedWorldDef as PWD
 import proof.DGG.SealPeelToolkit as SPT
@@ -41,48 +42,48 @@ open import proof.TypeInTermSubst using
 
 
 record WorldInvariants {Δᴸ Δᴿ Δ}
-    (W : CTI2.World Δᴸ Δᴿ Δ) : Set where
+    (W : CTX.World Δᴸ Δᴿ Δ) : Set where
   constructor world-invariants
   field
     preciseMarksAligned :
       ∀ (Xᴸ : TyVar Δᴸ)
-      → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+      → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
       → Σ[ Xᴿ ∈ TyVar Δᴿ ]
-          toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-            ≡ toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+          toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+            ≡ toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
 
     representationsImprecise :
       ∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-          ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-      → CTI2.impEnvʷ W ⊢
-          renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
-            (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
-          ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W))
-            (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+      → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+          ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+      → CTX.impEnvʷ W ⊢
+          renameᵗ (toRenameᵗ (CTX.ηᴸʷ W))
+            (lookupStore (CTX.sourceStoreʷ W) Xᴸ)
+          ⊑ renameᵗ (toRenameᵗ (CTX.ηᴿʷ W))
+            (lookupStore (CTX.targetStoreʷ W) Xᴿ)
 
     unmatchedTargetsDynamic :
       ∀ (Xᴿ : TyVar Δᴿ)
       → (∀ (Xᴸ : TyVar Δᴸ)
-          → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-            ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
-      → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+          → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+            ≢ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ)
+      → lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ★
         ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
-            (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+            (lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
           × (∀ (Xᴸ : TyVar Δᴸ)
-              → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-                ≢ toRenameᵗ (CTI2.ηᴿʷ W) Yᴿ)
+              → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+                ≢ toRenameᵗ (CTX.ηᴿʷ W) Yᴿ)
 
 open WorldInvariants public
 
 
 CenterAligned : ∀ {Δᴸ Δᴿ Δ}
-  → CTI2.World Δᴸ Δᴿ Δ
+  → CTX.World Δᴸ Δᴿ Δ
   → TyVar Δᴸ
   → TyVar Δᴿ
   → Set
 CenterAligned W Xᴸ Xᴿ =
-  toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+  toRenameᵗ (CTX.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
 
 imprecision-cong : ∀ {Δ} {μ : ImpEnv Δ} {A A′ B B′ : Ty Δ}
   → A ≡ A′
@@ -97,18 +98,18 @@ variableHeadsAlign : ∀ {Δ} {μ : ImpEnv Δ} {X Y : TyVar Δ}
 variableHeadsAlign X⊑X = refl
 
 variableEntryChainCoherence : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
     {Xᴸ Yᴸ : TyVar Δᴸ} {Xᴿ Yᴿ : TyVar Δᴿ}
   → WorldInvariants W
   → CenterAligned W Xᴸ Xᴿ
-  → lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ＇ Yᴸ
-  → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ
+  → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ＇ Yᴸ
+  → lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ
   → CenterAligned W Yᴸ Yᴿ
-    × (CTI2.impEnvʷ W ⊢
-        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
-          (lookupStore (CTI2.sourceStoreʷ W) Yᴸ)
-        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W))
-          (lookupStore (CTI2.targetStoreʷ W) Yᴿ))
+    × (CTX.impEnvʷ W ⊢
+        renameᵗ (toRenameᵗ (CTX.ηᴸʷ W))
+          (lookupStore (CTX.sourceStoreʷ W) Yᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTX.ηᴿʷ W))
+          (lookupStore (CTX.targetStoreʷ W) Yᴿ))
 variableEntryChainCoherence {W = W} {Yᴸ = Yᴸ} {Yᴿ = Yᴿ}
     inv aligned source-entry target-entry =
   heads-aligned , representationsImprecise inv heads-aligned
@@ -116,8 +117,8 @@ variableEntryChainCoherence {W = W} {Yᴸ = Yᴸ} {Yᴿ = Yᴿ}
   heads-aligned : CenterAligned W Yᴸ Yᴿ
   heads-aligned = variableHeadsAlign
     (imprecision-cong
-      (cong (renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))) source-entry)
-      (cong (renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W))) target-entry)
+      (cong (renameᵗ (toRenameᵗ (CTX.ηᴸʷ W))) source-entry)
+      (cong (renameᵗ (toRenameᵗ (CTX.ηᴿʷ W))) target-entry)
       (representationsImprecise inv aligned))
 
 
@@ -125,9 +126,9 @@ emptyStore : (Δ : TyCtx) → TyStore Δ
 emptyStore Nat.zero = store-empty
 emptyStore (Nat.suc Δ) = store-lift (emptyStore Δ)
 
-initialWorld : ∀ {Δ} → ImpEnv Δ → CTI2.World Δ Δ Δ
+initialWorld : ∀ {Δ} → ImpEnv Δ → CTX.World Δ Δ Δ
 initialWorld {Δ} μ =
-  CTI2.world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
+  CTX.world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
 
 initialWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ)
   → WorldInvariants (initialWorld μ)
@@ -158,7 +159,7 @@ initialWorld-invariants μ = world-invariants precise reps unmatched
   unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
 
 identityWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ) (Σ : TyStore Δ)
-  → WorldInvariants (CTI2.world id↪ᵗ id↪ᵗ μ Σ Σ)
+  → WorldInvariants (CTX.world id↪ᵗ id↪ᵗ μ Σ Σ)
 identityWorld-invariants μ Σ = world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
@@ -223,53 +224,53 @@ private
 
 
 liftWorldBoth-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp)
+    {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp)
   → WorldInvariants W
-  → WorldInvariants (CTI2.liftWorldBoth v W)
+  → WorldInvariants (CTX.liftWorldBoth v W)
 liftWorldBoth-invariants {W = W} v inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → extendᵐ v (CTI2.impEnvʷ W)
-        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → extendᵐ v (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
-        toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
-          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
   precise Fin.zero mark = Fin.zero , refl
   precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
   precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
     Fin.suc Xᴿ , cong Fin.suc aligned
 
   reps : ∀ {Xᴸ Xᴿ}
-    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≡ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
-    → extendᵐ v (CTI2.impEnvʷ W) ⊢
-        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
-          (lookupStore (store-lift (CTI2.sourceStoreʷ W)) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (keep (CTI2.ηᴿʷ W)))
-          (lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ)
+    → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+    → extendᵐ v (CTX.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTX.ηᴸʷ W)))
+          (lookupStore (store-lift (CTX.sourceStoreʷ W)) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (keep (CTX.ηᴿʷ W)))
+          (lookupStore (store-lift (CTX.targetStoreʷ W)) Xᴿ)
   reps {Fin.zero} {Fin.zero} aligned = X⊑X
   reps {Fin.zero} {Fin.suc Xᴿ} ()
   reps {Fin.suc Xᴸ} {Fin.zero} ()
   reps {Fin.suc Xᴸ} {Fin.suc Xᴿ} aligned =
     imprecision-cong
-      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
-        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
-      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W)
-        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴸʷ W)
+        (lookupStore (CTX.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴿʷ W)
+        (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
       (lift-old-representation (representationsImprecise inv
         (fin-suc-injective aligned)))
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-          ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
-    → lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ ≡ ★
+        → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ)
+    → lookupStore (store-lift (CTX.targetStoreʷ W)) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
-          (lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ ≡ ＇ Yᴿ)
+          (lookupStore (store-lift (CTX.targetStoreʷ W)) Xᴿ ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-              ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
+            → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Yᴿ)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
   unmatched (Fin.suc Xᴿ) no-source
       with unmatchedTargetsDynamic inv Xᴿ
@@ -282,60 +283,60 @@ liftWorldBoth-invariants {W = W} v inv =
     inj₂ (Fin.suc Yᴿ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Yᴿ)
+      → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) (Fin.suc Yᴿ)
     lifted-head-no-source Fin.zero ()
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 liftWorldLeft-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp)
+    {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp)
   → v ≡ X⊑★
   → WorldInvariants W
-  → WorldInvariants (CTI2.liftWorldLeft v W)
+  → WorldInvariants (CTX.liftWorldLeft v W)
 liftWorldLeft-invariants {W = W} .X⊑★ refl inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → instᵐ (CTI2.impEnvʷ W)
-        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → instᵐ (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
-        toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
-          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
   precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
     Xᴿ , cong Fin.suc aligned
 
   reps : ∀ {Xᴸ Xᴿ}
-    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≡ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
-    → instᵐ (CTI2.impEnvʷ W) ⊢
-        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
-          (lookupStore (store-lift (CTI2.sourceStoreʷ W)) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (skip (CTI2.ηᴿʷ W)))
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+    → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ
+    → instᵐ (CTX.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTX.ηᴸʷ W)))
+          (lookupStore (store-lift (CTX.sourceStoreʷ W)) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (skip (CTX.ηᴿʷ W)))
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ)
   reps {Fin.zero} {Xᴿ} ()
   reps {Fin.suc Xᴸ} {Xᴿ} aligned =
     imprecision-cong
-      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
-        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
-      (sym (renameᵗ-skip (CTI2.ηᴿʷ W)
-        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴸʷ W)
+        (lookupStore (CTX.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-skip (CTX.ηᴿʷ W)
+        (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
       (inst-old-representation (representationsImprecise inv
         (fin-suc-injective aligned)))
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-          ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ)
-    → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+        → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ)
+    → lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-              ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ)
+            → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (skip (CTX.ηᴿʷ W)) Yᴿ)
   unmatched Xᴿ no-source
       with unmatchedTargetsDynamic inv Xᴿ
         (λ Xᴸ aligned →
@@ -345,60 +346,60 @@ liftWorldLeft-invariants {W = W} .X⊑★ refl inv =
     inj₂ (Yᴿ , entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ
+      → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (skip (CTX.ηᴿʷ W)) Yᴿ
     lifted-head-no-source Fin.zero ()
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 leftOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp) (A : Ty Δᴸ)
+    {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp) (A : Ty Δᴸ)
   → v ≡ X⊑★
   → WorldInvariants W
-  → WorldInvariants (CTI2.leftOnlyWorld v W A)
+  → WorldInvariants (CTX.leftOnlyWorld v W A)
 leftOnlyWorld-invariants {W = W} .X⊑★ A refl inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → instᵐ (CTI2.impEnvʷ W)
-        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → instᵐ (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
-        toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
-          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
   precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
     Xᴿ , cong Fin.suc aligned
 
   reps : ∀ {Xᴸ Xᴿ}
-    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≡ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
-    → instᵐ (CTI2.impEnvʷ W) ⊢
-        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
-          (lookupStore (store-bind (CTI2.sourceStoreʷ W) A) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (skip (CTI2.ηᴿʷ W)))
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+    → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ
+    → instᵐ (CTX.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTX.ηᴸʷ W)))
+          (lookupStore (store-bind (CTX.sourceStoreʷ W) A) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (skip (CTX.ηᴿʷ W)))
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ)
   reps {Fin.zero} {Xᴿ} ()
   reps {Fin.suc Xᴸ} {Xᴿ} aligned =
     imprecision-cong
-      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
-        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
-      (sym (renameᵗ-skip (CTI2.ηᴿʷ W)
-        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴸʷ W)
+        (lookupStore (CTX.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-skip (CTX.ηᴿʷ W)
+        (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
       (inst-old-representation (representationsImprecise inv
         (fin-suc-injective aligned)))
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-          ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ)
-    → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+        → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ)
+    → lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-              ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ)
+            → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (skip (CTX.ηᴿʷ W)) Yᴿ)
   unmatched Xᴿ no-source
       with unmatchedTargetsDynamic inv Xᴿ
         (λ Xᴸ aligned →
@@ -408,65 +409,65 @@ leftOnlyWorld-invariants {W = W} .X⊑★ A refl inv =
     inj₂ (Yᴿ , entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ
+      → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (skip (CTX.ηᴿʷ W)) Yᴿ
     lifted-head-no-source Fin.zero ()
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
+    {W : CTX.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
   → ⇑ᵗ B ≡ ★
     ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
         (⇑ᵗ B ≡ ＇ Yᴿ)
       × (∀ (Xᴸ : TyVar Δᴸ)
-          → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-            ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
+          → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+            ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Yᴿ)
   → WorldInvariants W
-  → WorldInvariants (CTI2.rightOnlyWorld W B)
+  → WorldInvariants (CTX.rightOnlyWorld W B)
 rightOnlyWorld-invariants {W = W} B fresh-classification inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → instᵐ (CTI2.impEnvʷ W)
-        (toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → instᵐ (CTX.impEnvʷ W)
+        (toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
-        toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
-          ≡ toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+        toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
   precise Xᴸ mark with preciseMarksAligned inv Xᴸ mark
   precise Xᴸ mark | Xᴿ , aligned =
     Fin.suc Xᴿ , cong Fin.suc aligned
 
   reps : ∀ {Xᴸ Xᴿ}
-    → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-        ≡ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
-    → instᵐ (CTI2.impEnvʷ W) ⊢
-        renameᵗ (toRenameᵗ (skip (CTI2.ηᴸʷ W)))
-          (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (keep (CTI2.ηᴿʷ W)))
-          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ)
+    → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+    → instᵐ (CTX.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (skip (CTX.ηᴸʷ W)))
+          (lookupStore (CTX.sourceStoreʷ W) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (keep (CTX.ηᴿʷ W)))
+          (lookupStore (store-bind (CTX.targetStoreʷ W) B) Xᴿ)
   reps {Xᴸ} {Fin.zero} ()
   reps {Xᴸ} {Fin.suc Xᴿ} aligned =
     imprecision-cong
-      (sym (renameᵗ-skip (CTI2.ηᴸʷ W)
-        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
-      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W)
-        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (sym (renameᵗ-skip (CTX.ηᴸʷ W)
+        (lookupStore (CTX.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴿʷ W)
+        (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
       (inst-old-representation (representationsImprecise inv
         (fin-suc-injective aligned)))
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-          ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
-    → lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ ≡ ★
+        → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ)
+    → lookupStore (store-bind (CTX.targetStoreʷ W) B) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
-          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ
+          (lookupStore (store-bind (CTX.targetStoreʷ W) B) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-              ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
+            → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Yᴿ)
   unmatched Fin.zero no-source = fresh-classification
   unmatched (Fin.suc Xᴿ) no-source
       with unmatchedTargetsDynamic inv Xᴿ
@@ -478,101 +479,101 @@ rightOnlyWorld-invariants {W = W} B fresh-classification inv =
     inj₂ (Fin.suc Yᴿ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-        ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Yᴿ)
+      → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) (Fin.suc Yᴿ)
     lifted-head-no-source Xᴸ aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 rightOnlyWorld-star-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W
-  → WorldInvariants (CTI2.rightOnlyWorld W ★)
+  → WorldInvariants (CTX.rightOnlyWorld W ★)
 rightOnlyWorld-star-invariants =
   rightOnlyWorld-invariants ★ (inj₁ refl)
 
 rightOnlyWorld-alias-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (Xᴿ : TyVar Δᴿ)
+    {W : CTX.World Δᴸ Δᴿ Δ} (Xᴿ : TyVar Δᴿ)
   → (∀ (Xᴸ : TyVar Δᴸ)
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+      → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ)
   → WorldInvariants W
-  → WorldInvariants (CTI2.rightOnlyWorld W (＇ Xᴿ))
+  → WorldInvariants (CTX.rightOnlyWorld W (＇ Xᴿ))
 rightOnlyWorld-alias-invariants {W = W} Xᴿ head-no-source =
   rightOnlyWorld-invariants (＇ Xᴿ)
     (inj₂ (Fin.suc Xᴿ , refl , lifted-head-no-source))
   where
   lifted-head-no-source : ∀ Xᴸ
-    → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-      ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Xᴿ)
+    → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+      ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) (Fin.suc Xᴿ)
   lifted-head-no-source Xᴸ aligned =
     head-no-source Xᴸ (fin-suc-injective aligned)
 
 rightOnlyWorld-star-then-zero-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants
-      (CTI2.rightOnlyWorld (CTI2.rightOnlyWorld W ★) (＇ Fin.zero))
+      (CTX.rightOnlyWorld (CTX.rightOnlyWorld W ★) (＇ Fin.zero))
 rightOnlyWorld-star-then-zero-invariants inv =
   rightOnlyWorld-alias-invariants Fin.zero (λ Xᴸ ())
     (rightOnlyWorld-star-invariants inv)
 
 
 bothBindWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp)
+    {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp)
     (A : Ty Δᴸ) (B : Ty Δᴿ)
-  → A CTI2.⊑ᵂ⟨ W ⟩ B
+  → A CTX.⊑ᵂ⟨ W ⟩ B
   → WorldInvariants W
-  → WorldInvariants (CTI2.bothBindWorld v W A B)
+  → WorldInvariants (CTX.bothBindWorld v W A B)
 bothBindWorld-invariants {W = W} v A B A⊑B inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → extendᵐ v (CTI2.impEnvʷ W)
-        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → extendᵐ v (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
-        toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
-          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
   precise Fin.zero mark = Fin.zero , refl
   precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
   precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
     Fin.suc Xᴿ , cong Fin.suc aligned
 
   reps : ∀ {Xᴸ Xᴿ}
-    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≡ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
-    → extendᵐ v (CTI2.impEnvʷ W) ⊢
-        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
-          (lookupStore (store-bind (CTI2.sourceStoreʷ W) A) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (keep (CTI2.ηᴿʷ W)))
-          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ)
+    → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+    → extendᵐ v (CTX.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTX.ηᴸʷ W)))
+          (lookupStore (store-bind (CTX.sourceStoreʷ W) A) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (keep (CTX.ηᴿʷ W)))
+          (lookupStore (store-bind (CTX.targetStoreʷ W) B) Xᴿ)
   reps {Fin.zero} {Fin.zero} aligned =
     imprecision-cong
-      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W) A))
-      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W) B))
+      (sym (renameᵗ-keep-shift (CTX.ηᴸʷ W) A))
+      (sym (renameᵗ-keep-shift (CTX.ηᴿʷ W) B))
       (lift-old-representation A⊑B)
   reps {Fin.zero} {Fin.suc Xᴿ} ()
   reps {Fin.suc Xᴸ} {Fin.zero} ()
   reps {Fin.suc Xᴸ} {Fin.suc Xᴿ} aligned =
     imprecision-cong
-      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
-        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
-      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W)
-        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴸʷ W)
+        (lookupStore (CTX.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-keep-shift (CTX.ηᴿʷ W)
+        (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
       (lift-old-representation (representationsImprecise inv
         (fin-suc-injective aligned)))
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-          ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
-    → lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ ≡ ★
+        → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ)
+    → lookupStore (store-bind (CTX.targetStoreʷ W) B) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
-          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ
+          (lookupStore (store-bind (CTX.targetStoreʷ W) B) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-              ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
+            → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Yᴿ)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
   unmatched (Fin.suc Xᴿ) no-source
       with unmatchedTargetsDynamic inv Xᴿ
@@ -585,8 +586,8 @@ bothBindWorld-invariants {W = W} v A B A⊑B inv =
     inj₂ (Fin.suc Yᴿ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
-        ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Yᴿ)
+      → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) (Fin.suc Yᴿ)
     lifted-head-no-source Fin.zero ()
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
@@ -597,37 +598,37 @@ parked-initial-invariants : ∀ {Δ} {μ : ImpEnv Δ} {Σ : TyStore Δ}
 parked-initial-invariants {μ = μ} {Σ = Σ} = identityWorld-invariants μ Σ
 
 parked-both-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ} {B : Ty Δᴿ}
-  → A CTI2.⊑ᵂ⟨ W ⟩ B
+    {W : CTX.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ} {B : Ty Δᴿ}
+  → A CTX.⊑ᵂ⟨ W ⟩ B
   → WorldInvariants W
-  → WorldInvariants (CTI2.bothBindWorld X⊑X W A B)
+  → WorldInvariants (CTX.bothBindWorld X⊑X W A B)
 parked-both-bind-invariants {A = A} {B = B} =
   bothBindWorld-invariants X⊑X A B
 
 parked-left-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ}
   → WorldInvariants W
-  → WorldInvariants (CTI2.leftOnlyWorld X⊑★ W A)
+  → WorldInvariants (CTX.leftOnlyWorld X⊑★ W A)
 parked-left-bind-invariants {A = A} =
   leftOnlyWorld-invariants X⊑★ A refl
 
 parked-right-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
   → ⇑ᵗ B ≡ ★
     ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
         (⇑ᵗ B ≡ ＇ Yᴿ)
       × (∀ (Xᴸ : TyVar Δᴸ)
-          → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
-            ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
+          → toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+            ≢ toRenameᵗ (keep (CTX.ηᴿʷ W)) Yᴿ)
   → WorldInvariants W
-  → WorldInvariants (CTI2.rightOnlyWorld W B)
+  → WorldInvariants (CTX.rightOnlyWorld W B)
 parked-right-bind-invariants {B = B} = rightOnlyWorld-invariants B
 
 parkedEvolve-end-invariants : ∀ {Δᴸ Δᴸ′ Δᴿ Δᴿ′ Δ Δ′}
     {χsᴸ : R.StoreChanges Δᴸ Δᴸ′}
     {χsᴿ : R.StoreChanges Δᴿ Δᴿ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ′ Δᴿ′ Δ′}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ′ Δᴿ′ Δ′}
   → PWD.ParkedEvolve χsᴸ χsᴿ W W′
   → WorldInvariants W′
   → WorldInvariants W′
@@ -642,91 +643,91 @@ parkedEvolve-end-invariants
 
 
 renameWorld-invariants : ∀ {Δᴸ Δᴿ Δ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (π : Δ ↪ᵗ Δ′)
+    {W : CTX.World Δᴸ Δᴿ Δ} (π : Δ ↪ᵗ Δ′)
   → WorldInvariants W
   → WorldInvariants (CR.renameWorld π W)
 renameWorld-invariants {W = W} π inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → CR.renameEnv π (CTI2.impEnvʷ W)
-        (toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+    → CR.renameEnv π (CTX.impEnvʷ W)
+        (toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
-        toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ
-          ≡ toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
+        toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W) Xᴿ
+          ≡ toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ
   precise Xᴸ mark with preciseMarksAligned inv Xᴸ old-mark
     where
     old-mark :
-      CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+      CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
     old-mark =
-      trans (sym (CR.renameEnv-image π (CTI2.impEnvʷ W)
-          (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)))
-        (trans (cong (CR.renameEnv π (CTI2.impEnvʷ W))
-          (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))) mark)
+      trans (sym (CR.renameEnv-image π (CTX.impEnvʷ W)
+          (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)))
+        (trans (cong (CR.renameEnv π (CTX.impEnvʷ W))
+          (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))) mark)
   precise Xᴸ mark | Xᴿ , aligned =
-    Xᴿ , trans (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ)
+    Xᴿ , trans (CR.toRenameᵗ-∘ π (CTX.ηᴿʷ W) Xᴿ)
       (trans (cong (toRenameᵗ π) aligned)
-        (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ)))
+        (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ)))
 
   reps : ∀ {Xᴸ Xᴿ}
-    → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
-        ≡ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ
-    → CR.renameEnv π (CTI2.impEnvʷ W) ⊢
-        renameᵗ (toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W))
-          (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W))
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+    → toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ
+        ≡ toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W) Xᴿ
+    → CR.renameEnv π (CTX.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W))
+          (lookupStore (CTX.sourceStoreʷ W) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W))
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ)
   reps {Xᴸ} {Xᴿ} aligned =
     CR.rename-⊑ᵂ {W = W}
-      {A = lookupStore (CTI2.sourceStoreʷ W) Xᴸ}
-      {B = lookupStore (CTI2.targetStoreʷ W) Xᴿ}
+      {A = lookupStore (CTX.sourceStoreʷ W) Xᴸ}
+      {B = lookupStore (CTX.targetStoreʷ W) Xᴿ}
       π (representationsImprecise inv old-aligned)
     where
     old-aligned : CenterAligned W Xᴸ Xᴿ
     old-aligned = toRenameᵗ-injective π
-      (trans (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))
+      (trans (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))
         (trans aligned
-          (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ)))
+          (CR.toRenameᵗ-∘ π (CTX.ηᴿʷ W) Xᴿ)))
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
-          ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ)
-    → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+        → toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ
+          ≢ toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W) Xᴿ)
+    → lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
-              ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Yᴿ)
+            → toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ
+              ≢ toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W) Yᴿ)
   unmatched Xᴿ no-source
       with unmatchedTargetsDynamic inv Xᴿ
         (λ Xᴸ aligned → no-source Xᴸ
-          (trans (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ)
+          (trans (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ)
             (trans (cong (toRenameᵗ π) aligned)
-              (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ)))))
+              (sym (CR.toRenameᵗ-∘ π (CTX.ηᴿʷ W) Xᴿ)))))
   unmatched Xᴿ no-source | inj₁ dynamic = inj₁ dynamic
   unmatched Xᴿ no-source | inj₂ (Yᴿ , entry , head-no-source) =
     inj₂ (Yᴿ , entry , renamed-head-no-source)
     where
     renamed-head-no-source : ∀ Xᴸ
-      → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Yᴿ
+      → toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W) Yᴿ
     renamed-head-no-source Xᴸ aligned =
       head-no-source Xᴸ
         (toRenameᵗ-injective π
-          (trans (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))
+          (trans (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))
             (trans aligned
-              (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Yᴿ))))
+              (CR.toRenameᵗ-∘ π (CTX.ηᴿʷ W) Yᴿ))))
 
 
 decay-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+    {W Wᵈ : CTX.World Δᴸ Δᴿ Δ}
   → WD.EnvDecay W Wᵈ
   → WorldInvariants W
   → WorldInvariants Wᵈ
 decay-invariants
-    {W = CTI2.world ηᴸ ηᴿ μ Σᴸ Σᴿ}
-    {Wᵈ = CTI2.world .ηᴸ .ηᴿ μᵈ .Σᴸ .Σᴿ}
+    {W = CTX.world ηᴸ ηᴿ μ Σᴸ Σᴿ}
+    {Wᵈ = CTX.world .ηᴸ .ηᴿ μᵈ .Σᴸ .Σᴿ}
     (WD.env-decay refl refl refl refl mono) inv =
   world-invariants precise reps (unmatchedTargetsDynamic inv)
   where
@@ -748,45 +749,45 @@ decay-invariants
 
 
 blendWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W′ Wᵈ : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ Wᵈ : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W′
   → WorldInvariants (WD.blendWorld W′ Wᵈ)
 blendWorld-invariants {W′ = W′} {Wᵈ = Wᵈ} =
   decay-invariants (WD.blend-decay {W′ = W′} {Wᵈ = Wᵈ})
 
 honestify-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (WD.honestify W)
 honestify-invariants {W = W} = decay-invariants (WD.honestify-decay {W = W})
 
 dynWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (SPT.dynWorld W)
 dynWorld-invariants {W = W} = decay-invariants (SPT.dynWorld-decay W)
 
 
 targetStoreAs-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (Σᴿ : TyStore Δᴿ)
+    {W : CTX.World Δᴸ Δᴿ Δ} (Σᴿ : TyStore Δᴿ)
   → WorldInvariants W
   → (∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-      → CTI2.impEnvʷ W ⊢
-          renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
-            (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
-          ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W)) (lookupStore Σᴿ Xᴿ))
+      → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+        ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+      → CTX.impEnvʷ W ⊢
+          renameᵗ (toRenameᵗ (CTX.ηᴸʷ W))
+            (lookupStore (CTX.sourceStoreʷ W) Xᴸ)
+          ⊑ renameᵗ (toRenameᵗ (CTX.ηᴿʷ W)) (lookupStore Σᴿ Xᴿ))
   → (∀ (Xᴿ : TyVar Δᴿ)
       → (∀ (Xᴸ : TyVar Δᴸ)
-          → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-            ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+          → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+            ≢ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ)
       → lookupStore Σᴿ Xᴿ ≡ ★
         ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
             (lookupStore Σᴿ Xᴿ ≡ ＇ Yᴿ)
           × (∀ (Xᴸ : TyVar Δᴸ)
-              → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-                ≢ toRenameᵗ (CTI2.ηᴿʷ W) Yᴿ))
+              → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+                ≢ toRenameᵗ (CTX.ηᴿʷ W) Yᴿ))
   → WorldInvariants (TBL.targetStoreAs W Σᴿ)
 targetStoreAs-invariants Σᴿ inv reps unmatched =
   world-invariants (preciseMarksAligned inv) reps unmatched
@@ -794,23 +795,23 @@ targetStoreAs-invariants Σᴿ inv reps unmatched =
 
 record TargetInsertDirect {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
     (ins : TE.TargetInsert ρ π W W′) : Set where
   constructor target-insert-direct
   field
     targetLookup-insert : ∀ Xᴿ
-      → lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ)
+      → lookupStore (CTX.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ)
         ≡ renameᵗ (toRenameᵗ ρ)
-            (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+            (lookupStore (CTX.targetStoreʷ W) Xᴿ)
 
     targetLookup-off : ∀ Xᴿ′
-      → CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) ≡ nothing
-      → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+      → CR.preimage? π (toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′) ≡ nothing
+      → lookupStore (CTX.targetStoreʷ W′) Xᴿ′ ≡ ★
         ⊎ Σ[ Yᴿ′ ∈ TyVar Δᴿ′ ]
-            (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
+            (lookupStore (CTX.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
           × (∀ (Xᴸ : TyVar Δᴸ)
-              → CTI2.CenterAligned W′ Xᴸ Yᴿ′
+              → CTX.CenterAligned W′ Xᴸ Yᴿ′
               → ⊥)
 
 open TargetInsertDirect public
@@ -818,8 +819,8 @@ open TargetInsertDirect public
 
 targetInsert-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
   → (ins : TE.TargetInsert ρ π W W′)
   → TargetInsertDirect ins
   → WorldInvariants W
@@ -829,28 +830,28 @@ targetInsert-invariants
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → CTI2.impEnvʷ W′ (toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ) ≡ X⊑X
+    → CTX.impEnvʷ W′ (toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ′ ∈ TyVar _ ]
-        toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′
-          ≡ toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ
+        toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′
+          ≡ toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ
   precise Xᴸ mark with preciseMarksAligned inv Xᴸ old-mark
     where
     old-mark :
-      CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+      CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
     old-mark = trans
-      (sym (TE.impEnv-insert ins (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)))
-      (subst≡ (λ Z → CTI2.impEnvʷ W′ Z ≡ X⊑X)
+      (sym (TE.impEnv-insert ins (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)))
+      (subst≡ (λ Z → CTX.impEnvʷ W′ Z ≡ X⊑X)
         (TE.source-insert ins Xᴸ) mark)
   precise Xᴸ mark | Xᴿ , aligned =
     toRenameᵗ ρ Xᴿ , sym (TE.align-insert ins (sym aligned))
 
   reps : ∀ {Xᴸ Xᴿ′}
-    → CTI2.CenterAligned W′ Xᴸ Xᴿ′
-    → CTI2.impEnvʷ W′ ⊢
-        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′))
-          (lookupStore (CTI2.sourceStoreʷ W′) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′))
-          (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′)
+    → CTX.CenterAligned W′ Xᴸ Xᴿ′
+    → CTX.impEnvʷ W′ ⊢
+        renameᵗ (toRenameᵗ (CTX.ηᴸʷ W′))
+          (lookupStore (CTX.sourceStoreʷ W′) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTX.ηᴿʷ W′))
+          (lookupStore (CTX.targetStoreʷ W′) Xᴿ′)
   reps {Xᴸ} {Xᴿ′} aligned
       with TE.target-source-reflect ins aligned
   reps {Xᴸ} {Xᴿ′} aligned | Xᴿ , refl , old-aligned =
@@ -858,29 +859,29 @@ targetInsert-invariants
       (TE.transport⊑ᵂ ins (representationsImprecise inv old-aligned))
     where
     source-eq :
-      renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′))
-          (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
-        ≡ renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′))
-          (lookupStore (CTI2.sourceStoreʷ W′) Xᴸ)
-    source-eq = cong (renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W′)))
+      renameᵗ (toRenameᵗ (CTX.ηᴸʷ W′))
+          (lookupStore (CTX.sourceStoreʷ W) Xᴸ)
+        ≡ renameᵗ (toRenameᵗ (CTX.ηᴸʷ W′))
+          (lookupStore (CTX.sourceStoreʷ W′) Xᴸ)
+    source-eq = cong (renameᵗ (toRenameᵗ (CTX.ηᴸʷ W′)))
       (sym (cong (λ Σ → lookupStore Σ Xᴸ) (TE.sourceStore-kept ins)))
 
     target-eq :
-      renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′))
-          (renameᵗ (toRenameᵗ _) (lookupStore (CTI2.targetStoreʷ W) Xᴿ))
-        ≡ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′))
-          (lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ _ Xᴿ))
-    target-eq = cong (renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W′)))
+      renameᵗ (toRenameᵗ (CTX.ηᴿʷ W′))
+          (renameᵗ (toRenameᵗ _) (lookupStore (CTX.targetStoreʷ W) Xᴿ))
+        ≡ renameᵗ (toRenameᵗ (CTX.ηᴿʷ W′))
+          (lookupStore (CTX.targetStoreʷ W′) (toRenameᵗ _ Xᴿ))
+    target-eq = cong (renameᵗ (toRenameᵗ (CTX.ηᴿʷ W′)))
       (sym (targetLookup-insert direct Xᴿ))
 
   unmatched : ∀ Xᴿ′
-    → (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Xᴿ′ → ⊥)
-    → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+    → (∀ Xᴸ → CTX.CenterAligned W′ Xᴸ Xᴿ′ → ⊥)
+    → lookupStore (CTX.targetStoreʷ W′) Xᴿ′ ≡ ★
       ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
-          (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
-        × (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Yᴿ′ → ⊥)
+          (lookupStore (CTX.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ → CTX.CenterAligned W′ Xᴸ Yᴿ′ → ⊥)
   unmatched Xᴿ′ no-source
-      with CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) in pre
+      with CR.preimage? π (toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′) in pre
   unmatched Xᴿ′ no-source | nothing =
     targetLookup-off direct Xᴿ′ pre
   unmatched Xᴿ′ no-source | just Z
@@ -889,23 +890,23 @@ targetInsert-invariants
       | Xᴿ , xᴿ′-eq , old-center =
     subst≡
       (λ Y →
-        lookupStore (CTI2.targetStoreʷ W′) Y ≡ ★
+        lookupStore (CTX.targetStoreʷ W′) Y ≡ ★
         ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
-            (lookupStore (CTI2.targetStoreʷ W′) Y ≡ ＇ Yᴿ′)
-          × (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Yᴿ′ → ⊥))
+            (lookupStore (CTX.targetStoreʷ W′) Y ≡ ＇ Yᴿ′)
+          × (∀ Xᴸ → CTX.CenterAligned W′ Xᴸ Yᴿ′ → ⊥))
       (sym xᴿ′-eq) old-result
     where
-    old-no-source : ∀ Xᴸ → CTI2.CenterAligned W Xᴸ Xᴿ → ⊥
+    old-no-source : ∀ Xᴸ → CTX.CenterAligned W Xᴸ Xᴿ → ⊥
     old-no-source Xᴸ aligned = no-source Xᴸ
-      (subst≡ (CTI2.CenterAligned W′ Xᴸ) (sym xᴿ′-eq)
+      (subst≡ (CTX.CenterAligned W′ Xᴸ) (sym xᴿ′-eq)
         (TE.align-insert ins aligned))
 
     old-result :
-      lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ) ≡ ★
+      lookupStore (CTX.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ) ≡ ★
       ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
-          (lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ)
+          (lookupStore (CTX.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ)
             ≡ ＇ Yᴿ′)
-        × (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Yᴿ′ → ⊥)
+        × (∀ Xᴸ → CTX.CenterAligned W′ Xᴸ Yᴿ′ → ⊥)
     old-result with unmatchedTargetsDynamic inv Xᴿ old-no-source
     old-result | inj₁ dynamic =
       inj₁
@@ -919,25 +920,25 @@ targetInsert-invariants
         , inserted-head-no-source )
       where
       inserted-head-no-source : ∀ Xᴸ
-        → CTI2.CenterAligned W′ Xᴸ (toRenameᵗ ρ Yᴿ)
+        → CTX.CenterAligned W′ Xᴸ (toRenameᵗ ρ Yᴿ)
         → ⊥
       inserted-head-no-source Xᴸ aligned
           with TE.target-source-reflect ins aligned
       inserted-head-no-source Xᴸ aligned
           | Yᴿ′ , mapped-eq , old-aligned =
         head-no-source Xᴸ
-          (subst≡ (CTI2.CenterAligned W Xᴸ)
+          (subst≡ (CTX.CenterAligned W Xᴸ)
             (sym (toRenameᵗ-injective ρ mapped-eq)) old-aligned)
 
 
 parked-structural-right-insert-invariants : ∀ {Δᴸ Δᴿ Δ Δ₁}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W₁ : CTI2.World Δᴸ (Nat.suc Δᴿ) Δ₁}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W₁ : CTX.World Δᴸ (Nat.suc Δᴿ) Δ₁}
     {B : Ty Δᴿ} {π : Δ ↪ᵗ Δ₁}
   → PWD.ParkedWorld W
   → (ins : TE.TargetInsert wk↪ᵗ π W W₁)
   → TargetInsertDirect ins
-  → CTI2.targetStoreʷ W₁ ≡ R.applyStore (R.bind B) (CTI2.targetStoreʷ W)
+  → CTX.targetStoreʷ W₁ ≡ R.applyStore (R.bind B) (CTX.targetStoreʷ W)
   → WorldInvariants W
   → WorldInvariants W₁
 parked-structural-right-insert-invariants parked ins direct follows inv =
@@ -945,12 +946,12 @@ parked-structural-right-insert-invariants parked ins direct follows inv =
 
 
 rightBindTargetInsert-direct : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
   → ⇑ᵗ B ≡ ★
     ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
         (⇑ᵗ B ≡ ＇ Yᴿ)
       × (∀ (Xᴸ : TyVar Δᴸ)
-          → CTI2.CenterAligned (CTI2.rightOnlyWorld W B) Xᴸ Yᴿ
+          → CTX.CenterAligned (CTX.rightOnlyWorld W B) Xᴸ Yᴿ
           → ⊥)
   → TargetInsertDirect (TE.rightBindTargetInsert {W = W} {B = B})
 rightBindTargetInsert-direct {W = W} {B = B} fresh-classification =
@@ -959,57 +960,57 @@ rightBindTargetInsert-direct {W = W} {B = B} fresh-classification =
   ins = TE.rightBindTargetInsert {W = W} {B = B}
 
   old-entry : ∀ Xᴿ
-    → lookupStore (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B))
+    → lookupStore (CTX.targetStoreʷ (CTX.rightOnlyWorld W B))
         (toRenameᵗ wk↪ᵗ Xᴿ)
       ≡ renameᵗ (toRenameᵗ wk↪ᵗ)
-          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+          (lookupStore (CTX.targetStoreʷ W) Xᴿ)
   old-entry Xᴿ =
-    trans (cong (lookupStore (store-bind (CTI2.targetStoreʷ W) B))
+    trans (cong (lookupStore (store-bind (CTX.targetStoreʷ W) B))
       (toRename-wk-eq Xᴿ))
-      (sym (renameᵗ-wk-eq (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (sym (renameᵗ-wk-eq (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
 
   fresh-entry : ∀ Xᴿ′
     → CR.preimage? wk↪ᵗ
-        (toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) Xᴿ′)
+        (toRenameᵗ (CTX.ηᴿʷ (CTX.rightOnlyWorld W B)) Xᴿ′)
         ≡ nothing
-    → lookupStore (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B)) Xᴿ′
+    → lookupStore (CTX.targetStoreʷ (CTX.rightOnlyWorld W B)) Xᴿ′
         ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar _ ]
           (lookupStore
-            (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B)) Xᴿ′
+            (CTX.targetStoreʷ (CTX.rightOnlyWorld W B)) Xᴿ′
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CTI2.CenterAligned (CTI2.rightOnlyWorld W B) Xᴸ Yᴿ
+            → CTX.CenterAligned (CTX.rightOnlyWorld W B) Xᴸ Yᴿ
             → ⊥)
   fresh-entry Fin.zero off = fresh-classification
   fresh-entry (Fin.suc Xᴿ) off = ⊥-elim (CR.just≢nothing impossible)
     where
     center-eq :
-      toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) (Fin.suc Xᴿ)
-        ≡ toRenameᵗ wk↪ᵗ (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+      toRenameᵗ (CTX.ηᴿʷ (CTX.rightOnlyWorld W B)) (Fin.suc Xᴿ)
+        ≡ toRenameᵗ wk↪ᵗ (toRenameᵗ (CTX.ηᴿʷ W) Xᴿ)
     center-eq = trans
-      (cong (toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)))
+      (cong (toRenameᵗ (CTX.ηᴿʷ (CTX.rightOnlyWorld W B)))
         (sym (toRename-wk-eq Xᴿ)))
       (TE.target-insert ins Xᴿ)
 
-    impossible : just (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ) ≡ nothing
+    impossible : just (toRenameᵗ (CTX.ηᴿʷ W) Xᴿ) ≡ nothing
     impossible = trans
       (sym (CR.preimage?-image wk↪ᵗ
-        (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)))
+        (toRenameᵗ (CTX.ηᴿʷ W) Xᴿ)))
       (trans (cong (CR.preimage? wk↪ᵗ) (sym center-eq)) off)
 
 
 rightBindTargetInsert-star-direct : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
   → TargetInsertDirect
       (TE.rightBindTargetInsert {W = W} {B = ★})
 rightBindTargetInsert-star-direct =
   rightBindTargetInsert-direct (inj₁ refl)
 
 rightBindTargetInsert-alias-direct : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (Xᴿ : TyVar Δᴿ)
+    {W : CTX.World Δᴸ Δᴿ Δ} (Xᴿ : TyVar Δᴿ)
   → (∀ (Xᴸ : TyVar Δᴸ)
-      → CTI2.CenterAligned W Xᴸ Xᴿ
+      → CTX.CenterAligned W Xᴸ Xᴿ
       → ⊥)
   → TargetInsertDirect
       (TE.rightBindTargetInsert {W = W} {B = ＇ Xᴿ})
@@ -1018,7 +1019,7 @@ rightBindTargetInsert-alias-direct {W = W} Xᴿ head-no-source =
     (inj₂ (Fin.suc Xᴿ , refl , lifted-head-no-source))
   where
   lifted-head-no-source : ∀ Xᴸ
-    → CTI2.CenterAligned (CTI2.rightOnlyWorld W (＇ Xᴿ))
+    → CTX.CenterAligned (CTX.rightOnlyWorld W (＇ Xᴿ))
         Xᴸ (Fin.suc Xᴿ)
     → ⊥
   lifted-head-no-source Xᴸ aligned =
@@ -1027,8 +1028,8 @@ rightBindTargetInsert-alias-direct {W = W} Xᴿ head-no-source =
 
 liftBothTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′} {v : VarImp}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′} {v : VarImp}
   → (ins : TE.TargetInsert ρ π W W′)
   → TargetInsertDirect ins
   → TargetInsertDirect (TE.liftBothTargetInsert {v = v} ins)
@@ -1037,28 +1038,28 @@ liftBothTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
   where
   old-entry : ∀ Xᴿ
     → lookupStore
-        (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′))
+        (CTX.targetStoreʷ (CTX.liftWorldBoth v W′))
         (toRenameᵗ (keep ρ) Xᴿ)
       ≡ renameᵗ (toRenameᵗ (keep ρ))
-          (lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W)) Xᴿ)
+          (lookupStore (CTX.targetStoreʷ (CTX.liftWorldBoth v W)) Xᴿ)
   old-entry Fin.zero = refl
   old-entry (Fin.suc Xᴿ) =
     trans (cong ⇑ᵗ (targetLookup-insert direct Xᴿ))
       (sym (renameᵗ-keep-shift ρ
-        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+        (lookupStore (CTX.targetStoreʷ W) Xᴿ)))
 
   fresh-entry : ∀ Xᴿ′
     → CR.preimage? (keep π)
-        (toRenameᵗ (CTI2.ηᴿʷ (CTI2.liftWorldBoth v W′)) Xᴿ′)
+        (toRenameᵗ (CTX.ηᴿʷ (CTX.liftWorldBoth v W′)) Xᴿ′)
         ≡ nothing
-    → lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′)) Xᴿ′
+    → lookupStore (CTX.targetStoreʷ (CTX.liftWorldBoth v W′)) Xᴿ′
         ≡ ★
       ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
           (lookupStore
-            (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′)) Xᴿ′
+            (CTX.targetStoreʷ (CTX.liftWorldBoth v W′)) Xᴿ′
             ≡ ＇ Yᴿ′)
         × (∀ Xᴸ
-            → CTI2.CenterAligned (CTI2.liftWorldBoth v W′) Xᴸ Yᴿ′
+            → CTX.CenterAligned (CTX.liftWorldBoth v W′) Xᴸ Yᴿ′
             → ⊥)
   fresh-entry Fin.zero ()
   fresh-entry (Fin.suc Xᴿ′) off
@@ -1071,8 +1072,8 @@ liftBothTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
     inj₂ (Fin.suc Yᴿ′ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → CTI2.CenterAligned
-          (CTI2.liftWorldBoth v W′) Xᴸ (Fin.suc Yᴿ′)
+      → CTX.CenterAligned
+          (CTX.liftWorldBoth v W′) Xᴸ (Fin.suc Yᴿ′)
       → ⊥
     lifted-head-no-source Fin.zero ()
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
@@ -1081,8 +1082,8 @@ liftBothTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
 
 liftLeftTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′} {v : VarImp}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′} {v : VarImp}
   → (ins : TE.TargetInsert ρ π W W′)
   → TargetInsertDirect ins
   → TargetInsertDirect (TE.liftLeftTargetInsert {v = v} ins)
@@ -1091,16 +1092,16 @@ liftLeftTargetInsert-direct {π = π} {W′ = W′} {v = v} ins direct =
   where
   fresh-entry : ∀ Xᴿ′
     → CR.preimage? (keep π)
-        (toRenameᵗ (CTI2.ηᴿʷ (CTI2.liftWorldLeft v W′)) Xᴿ′)
+        (toRenameᵗ (CTX.ηᴿʷ (CTX.liftWorldLeft v W′)) Xᴿ′)
         ≡ nothing
-    → lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldLeft v W′)) Xᴿ′
+    → lookupStore (CTX.targetStoreʷ (CTX.liftWorldLeft v W′)) Xᴿ′
         ≡ ★
       ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
           (lookupStore
-            (CTI2.targetStoreʷ (CTI2.liftWorldLeft v W′)) Xᴿ′
+            (CTX.targetStoreʷ (CTX.liftWorldLeft v W′)) Xᴿ′
             ≡ ＇ Yᴿ′)
         × (∀ Xᴸ
-            → CTI2.CenterAligned (CTI2.liftWorldLeft v W′) Xᴸ Yᴿ′
+            → CTX.CenterAligned (CTX.liftWorldLeft v W′) Xᴸ Yᴿ′
             → ⊥)
   fresh-entry Xᴿ′ off
       with targetLookup-off direct Xᴿ′ (CR.sucMaybe-nothing _ off)
@@ -1109,7 +1110,7 @@ liftLeftTargetInsert-direct {π = π} {W′ = W′} {v = v} ins direct =
     inj₂ (Yᴿ′ , entry , lifted-head-no-source)
     where
     lifted-head-no-source : ∀ Xᴸ
-      → CTI2.CenterAligned (CTI2.liftWorldLeft v W′) Xᴸ Yᴿ′
+      → CTX.CenterAligned (CTX.liftWorldLeft v W′) Xᴸ Yᴿ′
       → ⊥
     lifted-head-no-source Fin.zero ()
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
@@ -1118,11 +1119,11 @@ liftLeftTargetInsert-direct {π = π} {W′ = W′} {v = v} ins direct =
 
 smartAliasTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
-    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTX.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
   → (ins : TE.TargetInsert ρ π W W′)
-  → (guard : CTI2.SmartAliasMergeGuard W Wᵐ β α)
+  → (guard : CTX.SmartAliasMergeGuard W Wᵐ β α)
   → TargetInsertDirect ins
   → WorldInvariants Wᵐ
   → TargetInsertDirect (TE.smartAliasTargetInsert ins guard)
@@ -1134,60 +1135,60 @@ smartAliasTargetInsert-direct {ρ = ρ} {π = π} {W = W} {Wᵐ = Wᵐ}
 
   old-entry : ∀ Xᴿ
     → lookupStore
-        (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ))
+        (CTX.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ))
         (toRenameᵗ ρ Xᴿ)
       ≡ renameᵗ (toRenameᵗ ρ)
-          (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
+          (lookupStore (CTX.targetStoreʷ Wᵐ) Xᴿ)
   old-entry Xᴿ = trans (targetLookup-insert direct Xᴿ)
     (cong (renameᵗ (toRenameᵗ ρ))
       (sym (cong (λ Σ → lookupStore Σ Xᴿ)
-        (CTI2.SmartAliasMergeGuard.targetStore-same guard))))
+        (CTX.SmartAliasMergeGuard.targetStore-same guard))))
 
   impossible-invariant : ⊥
   impossible-invariant = variable≢star variable-equals-star
     where
-    fresh-aligned : CTI2.CenterAligned Wᵐ Fin.zero β
+    fresh-aligned : CTX.CenterAligned Wᵐ Fin.zero β
     fresh-aligned =
-      trans (CTI2.SmartAliasMergeGuard.pending-at-alias guard)
-        (sym (CTI2.SmartAliasMergeGuard.target-frozen guard β))
+      trans (CTX.SmartAliasMergeGuard.pending-at-alias guard)
+        (sym (CTX.SmartAliasMergeGuard.target-frozen guard β))
 
-    source-entry : lookupStore (CTI2.sourceStoreʷ Wᵐ) Fin.zero
+    source-entry : lookupStore (CTX.sourceStoreʷ Wᵐ) Fin.zero
         ≡ ＇ Fin.zero
     source-entry = cong (λ Σ → lookupStore Σ Fin.zero)
-      (CTI2.SmartAliasMergeGuard.sourceStore-lifted guard)
+      (CTX.SmartAliasMergeGuard.sourceStore-lifted guard)
 
-    target-entry : lookupStore (CTI2.targetStoreʷ Wᵐ) β ≡ ＇ α
+    target-entry : lookupStore (CTX.targetStoreʷ Wᵐ) β ≡ ＇ α
     target-entry =
       trans
         (cong (λ Σ → lookupStore Σ β)
-          (CTI2.SmartAliasMergeGuard.targetStore-same guard))
-        (lookupStore-∋ (CTI2.SmartAliasMergeGuard.β:=＇α guard))
+          (CTX.SmartAliasMergeGuard.targetStore-same guard))
+        (lookupStore-∋ (CTX.SmartAliasMergeGuard.β:=＇α guard))
 
     heads-equal :
-      toRenameᵗ (CTI2.ηᴸʷ Wᵐ) Fin.zero
-        ≡ toRenameᵗ (CTI2.ηᴿʷ Wᵐ) α
+      toRenameᵗ (CTX.ηᴸʷ Wᵐ) Fin.zero
+        ≡ toRenameᵗ (CTX.ηᴿʷ Wᵐ) α
     heads-equal = variableHeadsAlign
       (imprecision-cong
-        (cong (renameᵗ (toRenameᵗ (CTI2.ηᴸʷ Wᵐ))) source-entry)
-        (cong (renameᵗ (toRenameᵗ (CTI2.ηᴿʷ Wᵐ))) target-entry)
+        (cong (renameᵗ (toRenameᵗ (CTX.ηᴸʷ Wᵐ))) source-entry)
+        (cong (renameᵗ (toRenameᵗ (CTX.ηᴿʷ Wᵐ))) target-entry)
         (representationsImprecise inv fresh-aligned))
 
     β-equals-α : β ≡ α
-    β-equals-α = toRenameᵗ-injective (CTI2.ηᴿʷ Wᵐ)
+    β-equals-α = toRenameᵗ-injective (CTX.ηᴿʷ Wᵐ)
       (trans (sym fresh-aligned) heads-equal)
 
-    β-entry : lookupStore (CTI2.targetStoreʷ W) β ≡ ＇ α
+    β-entry : lookupStore (CTX.targetStoreʷ W) β ≡ ＇ α
     β-entry = lookupStore-∋
-      (CTI2.SmartAliasMergeGuard.β:=＇α guard)
+      (CTX.SmartAliasMergeGuard.β:=＇α guard)
 
-    α-entry : lookupStore (CTI2.targetStoreʷ W) α ≡ ★
+    α-entry : lookupStore (CTX.targetStoreʷ W) α ≡ ★
     α-entry = lookupStore-∋
-      (CTI2.SmartAliasMergeGuard.α:=★ guard)
+      (CTX.SmartAliasMergeGuard.α:=★ guard)
 
     variable-equals-star : ＇ α ≡ ★
     variable-equals-star =
       trans (sym β-entry)
-        (trans (cong (lookupStore (CTI2.targetStoreʷ W)) β-equals-α)
+        (trans (cong (lookupStore (CTX.targetStoreʷ W)) β-equals-α)
           α-entry)
 
     variable≢star : ＇ α ≢ ★
@@ -1196,17 +1197,17 @@ smartAliasTargetInsert-direct {ρ = ρ} {π = π} {W = W} {Wᵐ = Wᵐ}
   fresh-entry : ∀ Xᴿ′
     → CR.preimage? π
         (toRenameᵗ
-          (CTI2.ηᴿʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′)
+          (CTX.ηᴿʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′)
         ≡ nothing
     → lookupStore
-        (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′
+        (CTX.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′
         ≡ ★
       ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
           (lookupStore
-            (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′
+            (CTX.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′
             ≡ ＇ Yᴿ′)
         × (∀ Xᴸ
-            → CTI2.CenterAligned
+            → CTX.CenterAligned
                 (TE.smartAliasInsertWorld ins Wᵐ) Xᴸ Yᴿ′
             → ⊥)
   fresh-entry Xᴿ′ off with targetLookup-off direct Xᴿ′ off
@@ -1215,23 +1216,23 @@ smartAliasTargetInsert-direct {ρ = ρ} {π = π} {W = W} {Wᵐ = Wᵐ}
     inj₂ (Yᴿ′ , entry , inserted-head-no-source)
     where
     inserted-head-no-source : ∀ Xᴸ
-      → CTI2.CenterAligned
+      → CTX.CenterAligned
           (TE.smartAliasInsertWorld ins Wᵐ) Xᴸ Yᴿ′
       → ⊥
     inserted-head-no-source Fin.zero aligned = impossible-invariant
     inserted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ
         (trans
-          (sym (CTI2.SmartAliasMergeGuard.old-source-frozen guard′ Xᴸ))
+          (sym (CTX.SmartAliasMergeGuard.old-source-frozen guard′ Xᴸ))
           aligned)
 
 smartAliasInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
-    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTX.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
   → (ins : TE.TargetInsert ρ π W W′)
-  → (guard : CTI2.SmartAliasMergeGuard W Wᵐ β α)
+  → (guard : CTX.SmartAliasMergeGuard W Wᵐ β α)
   → TargetInsertDirect ins
   → WorldInvariants Wᵐ
   → WorldInvariants (TE.smartAliasInsertWorld ins Wᵐ)
@@ -1242,36 +1243,36 @@ smartAliasInsertWorld-invariants ins guard direct inv =
 
 smartFreshTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′ Δᵐ}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
-    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δᵐ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTX.World (Nat.suc Δᴸ) Δᴿ Δᵐ}
   → (ins : TE.TargetInsert ρ π W W′)
-  → (guard : CTI2.SmartFreshBehindGuard W Wᵐ)
+  → (guard : CTX.SmartFreshBehindGuard W Wᵐ)
   → TargetInsertDirect ins
   → TargetInsertDirect (TE.smartFreshTargetInsert ins guard)
 smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
     {Wᵐ = Wᵐ} ins guard direct = target-insert-direct old-entry fresh-entry
   where
-  old = CTI2.SmartFreshBehindGuard.oldCenters guard
+  old = CTX.SmartFreshBehindGuard.oldCenters guard
   po = CR.embeddingPushout π old
   πᵐ = CR.EmbeddingPushout.premise po
 
   old-entry : ∀ Xᴿ
     → lookupStore
-        (CTI2.targetStoreʷ (TE.smartFreshInsertWorld ins guard))
+        (CTX.targetStoreʷ (TE.smartFreshInsertWorld ins guard))
         (toRenameᵗ ρ Xᴿ)
       ≡ renameᵗ (toRenameᵗ ρ)
-          (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
+          (lookupStore (CTX.targetStoreʷ Wᵐ) Xᴿ)
   old-entry Xᴿ = trans (targetLookup-insert direct Xᴿ)
     (cong (renameᵗ (toRenameᵗ ρ))
       (sym (cong (λ Σ → lookupStore Σ Xᴿ)
-        (CTI2.SmartFreshBehindGuard.targetStore-same guard))))
+        (CTX.SmartFreshBehindGuard.targetStore-same guard))))
 
   input-center-off : ∀ Xᴿ′
     → CR.preimage? ρ Xᴿ′ ≡ nothing
-    → CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) ≡ nothing
+    → CR.preimage? π (toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′) ≡ nothing
   input-center-off Xᴿ′ no-old
-      with CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) in preπ
+      with CR.preimage? π (toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′) in preπ
   input-center-off Xᴿ′ no-old | nothing = refl
   input-center-off Xᴿ′ no-old | just Z
       with TE.target-center-reflect ins (CR.preimage?-sound π preπ)
@@ -1286,13 +1287,13 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
   fresh-entry : ∀ Xᴿ′
     → CR.preimage? πᵐ
         (toRenameᵗ
-          (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′)
+          (CTX.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′)
         ≡ nothing
-    → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+    → lookupStore (CTX.targetStoreʷ W′) Xᴿ′ ≡ ★
       ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
-          (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
+          (lookupStore (CTX.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
         × (∀ Xᴸ
-            → CTI2.CenterAligned
+            → CTX.CenterAligned
                 (TE.smartFreshInsertWorld ins guard) Xᴸ Yᴿ′
             → ⊥)
   fresh-entry Xᴿ′ off with CR.preimage? ρ Xᴿ′ in preρ
@@ -1302,18 +1303,18 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
     xᴿ′-eq = CR.preimage?-sound ρ preρ
 
     center-eq :
-      toRenameᵗ (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′
-        ≡ toRenameᵗ πᵐ (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ)
+      toRenameᵗ (CTX.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′
+        ≡ toRenameᵗ πᵐ (toRenameᵗ (CTX.ηᴿʷ Wᵐ) Xᴿ)
     center-eq = trans
       (cong (toRenameᵗ
-        (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard))) xᴿ′-eq)
+        (CTX.ηᴿʷ (TE.smartFreshInsertWorld ins guard))) xᴿ′-eq)
       (TE.smartFresh-target-insert ins guard Xᴿ)
 
     impossible :
-      just (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ) ≡ nothing
+      just (toRenameᵗ (CTX.ηᴿʷ Wᵐ) Xᴿ) ≡ nothing
     impossible = trans
       (sym (CR.preimage?-image πᵐ
-        (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ)))
+        (toRenameᵗ (CTX.ηᴿʷ Wᵐ) Xᴿ)))
       (trans (cong (CR.preimage? πᵐ) (sym center-eq)) off)
   fresh-entry Xᴿ′ off | nothing
       with targetLookup-off direct Xᴿ′ (input-center-off Xᴿ′ preρ)
@@ -1323,7 +1324,7 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
     inj₂ (Yᴿ′ , entry , inserted-head-no-source)
     where
     inserted-head-no-source : ∀ Xᴸ
-      → CTI2.CenterAligned
+      → CTX.CenterAligned
           (TE.smartFreshInsertWorld ins guard) Xᴸ Yᴿ′
       → ⊥
     inserted-head-no-source Xᴸ aligned
@@ -1331,29 +1332,29 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
           (TE.smartFreshTargetInsert ins guard) aligned
     inserted-head-no-source Fin.zero aligned
         | Yᴿ , yᴿ′-eq , source-aligned =
-      CTI2.SmartFreshBehindGuard.fresh-not-target guard Yᴿ
+      CTX.SmartFreshBehindGuard.fresh-not-target guard Yᴿ
         (sym source-aligned)
     inserted-head-no-source (Fin.suc Xᴸ) aligned
         | Yᴿ , yᴿ′-eq , source-aligned =
       head-no-source Xᴸ
-        (subst≡ (CTI2.CenterAligned W′ Xᴸ) (sym yᴿ′-eq)
+        (subst≡ (CTX.CenterAligned W′ Xᴸ) (sym yᴿ′-eq)
           (TE.align-insert ins old-aligned))
       where
-      old-aligned : CTI2.CenterAligned W Xᴸ Yᴿ
+      old-aligned : CTX.CenterAligned W Xᴸ Yᴿ
       old-aligned = toRenameᵗ-injective old
         (trans
-          (sym (CTI2.SmartFreshBehindGuard.old-source-frozen guard Xᴸ))
+          (sym (CTX.SmartFreshBehindGuard.old-source-frozen guard Xᴸ))
           (trans source-aligned
-            (CTI2.SmartFreshBehindGuard.target-frozen guard Yᴿ)))
+            (CTX.SmartFreshBehindGuard.target-frozen guard Yᴿ)))
 
 
 smartFreshInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′ Δᵐ}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
-    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δᵐ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
+    {Wᵐ : CTX.World (Nat.suc Δᴸ) Δᴿ Δᵐ}
   → (ins : TE.TargetInsert ρ π W W′)
-  → (guard : CTI2.SmartFreshBehindGuard W Wᵐ)
+  → (guard : CTX.SmartFreshBehindGuard W Wᵐ)
   → TargetInsertDirect ins
   → WorldInvariants Wᵐ
   → WorldInvariants (TE.smartFreshInsertWorld ins guard)
@@ -1363,12 +1364,12 @@ smartFreshInsertWorld-invariants ins guard direct inv =
 
 
 keepRightBindTargetInsert-direct : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ} {v : VarImp}
+    {W : CTX.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ} {v : VarImp}
   → ⇑ᵗ B ≡ ★
     ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
         (⇑ᵗ B ≡ ＇ Yᴿ)
       × (∀ (Xᴸ : TyVar Δᴸ)
-          → CTI2.CenterAligned (CTI2.rightOnlyWorld W B) Xᴸ Yᴿ
+          → CTX.CenterAligned (CTX.rightOnlyWorld W B) Xᴸ Yᴿ
           → ⊥)
   → TargetInsertDirect (TE.keepRightBindTargetInsert {W = W} {B = B} {v = v})
 keepRightBindTargetInsert-direct {W = W} {B = B} {v = v}
@@ -1380,25 +1381,25 @@ keepRightBindTargetInsert-direct {W = W} {B = B} {v = v}
 
 insertRebaseTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
-    {W⁺ : CTI2.World Δᴸ Δᴿ′ Δ′} {Xᴸ Xᴿ}
+    {W Wᵖ : CTX.World Δᴸ Δᴿ Δ}
+    {W⁺ : CTX.World Δᴸ Δᴿ′ Δ′} {Xᴸ Xᴿ}
   → (ins : TE.TargetInsert ρ π W W⁺)
-  → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
+  → (rb : CTX.RebaseAt W Wᵖ Xᴸ Xᴿ)
   → TargetInsertDirect ins
   → (∀ Yᴿ′
       → CR.preimage? π
           (toRenameᵗ
-            (CTI2.ηᴿʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′)
+            (CTX.ηᴿʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′)
           ≡ nothing
       → lookupStore
-          (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+          (CTX.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
           ≡ ★
         ⊎ Σ[ Zᴿ′ ∈ TyVar Δᴿ′ ]
             (lookupStore
-              (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+              (CTX.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
               ≡ ＇ Zᴿ′)
           × (∀ (Yᴸ : TyVar Δᴸ)
-              → CTI2.CenterAligned
+              → CTX.CenterAligned
                   (TE.insertRebaseWorld ins Wᵖ) Yᴸ Zᴿ′
               → ⊥))
   → TargetInsertDirect (TE.insertRebaseTargetInsert ins rb)
@@ -1407,38 +1408,38 @@ insertRebaseTargetInsert-direct {ρ = ρ} {W = W} {Wᵖ = Wᵖ}
   where
   old-entry : ∀ Yᴿ
     → lookupStore
-        (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ))
+        (CTX.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ))
         (toRenameᵗ ρ Yᴿ)
       ≡ renameᵗ (toRenameᵗ ρ)
-          (lookupStore (CTI2.targetStoreʷ Wᵖ) Yᴿ)
+          (lookupStore (CTX.targetStoreʷ Wᵖ) Yᴿ)
   old-entry Yᴿ = trans (targetLookup-insert direct Yᴿ)
     (cong (renameᵗ (toRenameᵗ ρ))
       (sym (cong (λ Σ → lookupStore Σ Yᴿ)
-        (CTI2.SameRuntime.targetStore-same
-          (CTI2.RebaseAt.sameRuntime rb)))))
+        (CTX.SameRuntime.targetStore-same
+          (CTX.RebaseAt.sameRuntime rb)))))
 
 
 insertRebaseWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
-    {W Wᵖ : CTI2.World Δᴸ Δᴿ Δ}
-    {W⁺ : CTI2.World Δᴸ Δᴿ′ Δ′} {Xᴸ Xᴿ}
+    {W Wᵖ : CTX.World Δᴸ Δᴿ Δ}
+    {W⁺ : CTX.World Δᴸ Δᴿ′ Δ′} {Xᴸ Xᴿ}
   → (ins : TE.TargetInsert ρ π W W⁺)
-  → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
+  → (rb : CTX.RebaseAt W Wᵖ Xᴸ Xᴿ)
   → TargetInsertDirect ins
   → (∀ Yᴿ′
       → CR.preimage? π
           (toRenameᵗ
-            (CTI2.ηᴿʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′)
+            (CTX.ηᴿʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′)
           ≡ nothing
       → lookupStore
-          (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+          (CTX.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
           ≡ ★
         ⊎ Σ[ Zᴿ′ ∈ TyVar Δᴿ′ ]
             (lookupStore
-              (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+              (CTX.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
               ≡ ＇ Zᴿ′)
           × (∀ (Yᴸ : TyVar Δᴸ)
-              → CTI2.CenterAligned
+              → CTX.CenterAligned
                   (TE.insertRebaseWorld ins Wᵖ) Yᴸ Zᴿ′
               → ⊥))
   → WorldInvariants Wᵖ
@@ -1449,143 +1450,143 @@ insertRebaseWorld-invariants ins rb direct off-entry inv =
 
 
 example12-left-path-world-X-invariants :
-  WorldInvariants CTI2.example12-left-path-world-X
+  WorldInvariants Ex12.example12-left-path-world-X
 example12-left-path-world-X-invariants =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → CTI2.impEnvʷ CTI2.example12-left-path-world-X
+    → CTX.impEnvʷ Ex12.example12-left-path-world-X
         (toRenameᵗ
-          (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ)
+          (CTX.ηᴸʷ Ex12.example12-left-path-world-X) Xᴸ)
         ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 1 ]
-        toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X) Xᴿ
-          ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ
+        toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-X) Xᴿ
+          ≡ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-X) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Fin.zero) ()
   precise (Fin.suc (Fin.suc Fin.zero)) ()
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
-    → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ
-    → CTI2.impEnvʷ CTI2.example12-left-path-world-X ⊢
-        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X))
+    → CenterAligned Ex12.example12-left-path-world-X Xᴸ Xᴿ
+    → CTX.impEnvʷ Ex12.example12-left-path-world-X ⊢
+        renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-X))
           (lookupStore
-            (CTI2.sourceStoreʷ CTI2.example12-left-path-world-X) Xᴸ)
+            (CTX.sourceStoreʷ Ex12.example12-left-path-world-X) Xᴸ)
         ⊑ renameᵗ
-          (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X))
+          (toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-X))
           (lookupStore
-            (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ)
+            (CTX.targetStoreʷ Ex12.example12-left-path-world-X) Xᴿ)
   reps {Fin.zero} {Fin.zero} refl = ι⊑★
   reps {Fin.suc Fin.zero} {Fin.zero} ()
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ
+        → CenterAligned Ex12.example12-left-path-world-X Xᴸ Xᴿ
         → ⊥)
-    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ
+    → lookupStore (CTX.targetStoreʷ Ex12.example12-left-path-world-X) Xᴿ
         ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar 1 ]
           (lookupStore
-            (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ
+            (CTX.targetStoreʷ Ex12.example12-left-path-world-X) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CenterAligned CTI2.example12-left-path-world-X Xᴸ Yᴿ
+            → CenterAligned Ex12.example12-left-path-world-X Xᴸ Yᴿ
             → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
 
 
 example12-left-path-world-Y-invariants :
-  WorldInvariants CTI2.example12-left-path-world-Y
+  WorldInvariants Ex12.example12-left-path-world-Y
 example12-left-path-world-Y-invariants =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → CTI2.impEnvʷ CTI2.example12-left-path-world-Y
+    → CTX.impEnvʷ Ex12.example12-left-path-world-Y
         (toRenameᵗ
-          (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ)
+          (CTX.ηᴸʷ Ex12.example12-left-path-world-Y) Xᴸ)
         ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 1 ]
-        toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y) Xᴿ
-          ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ
+        toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-Y) Xᴿ
+          ≡ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Y) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Fin.zero) ()
   precise (Fin.suc (Fin.suc Fin.zero)) ()
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
-    → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ
-    → CTI2.impEnvʷ CTI2.example12-left-path-world-Y ⊢
-        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y))
+    → CenterAligned Ex12.example12-left-path-world-Y Xᴸ Xᴿ
+    → CTX.impEnvʷ Ex12.example12-left-path-world-Y ⊢
+        renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Y))
           (lookupStore
-            (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Y) Xᴸ)
+            (CTX.sourceStoreʷ Ex12.example12-left-path-world-Y) Xᴸ)
         ⊑ renameᵗ
-          (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y))
+          (toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-Y))
           (lookupStore
-            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ)
+            (CTX.targetStoreʷ Ex12.example12-left-path-world-Y) Xᴿ)
   reps {Fin.zero} {Fin.zero} ()
   reps {Fin.suc Fin.zero} {Fin.zero} refl = X⊑★ refl
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ
+        → CenterAligned Ex12.example12-left-path-world-Y Xᴸ Xᴿ
         → ⊥)
-    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ
+    → lookupStore (CTX.targetStoreʷ Ex12.example12-left-path-world-Y) Xᴿ
         ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar 1 ]
           (lookupStore
-            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ
+            (CTX.targetStoreʷ Ex12.example12-left-path-world-Y) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Yᴿ
+            → CenterAligned Ex12.example12-left-path-world-Y Xᴸ Yᴿ
             → ⊥)
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc Fin.zero) refl)
 
 
 example12-left-path-world-Z-invariants :
-  WorldInvariants CTI2.example12-left-path-world-Z
+  WorldInvariants Ex12.example12-left-path-world-Z
 example12-left-path-world-Z-invariants =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → CTI2.impEnvʷ CTI2.example12-left-path-world-Z
+    → CTX.impEnvʷ Ex12.example12-left-path-world-Z
         (toRenameᵗ
-          (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ)
+          (CTX.ηᴸʷ Ex12.example12-left-path-world-Z) Xᴸ)
         ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 1 ]
-        toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z) Xᴿ
-          ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ
+        toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-Z) Xᴿ
+          ≡ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Z) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Fin.zero) ()
   precise (Fin.suc (Fin.suc Fin.zero)) ()
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
-    → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ
-    → CTI2.impEnvʷ CTI2.example12-left-path-world-Z ⊢
-        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z))
+    → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
+    → CTX.impEnvʷ Ex12.example12-left-path-world-Z ⊢
+        renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Z))
           (lookupStore
-            (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Z) Xᴸ)
+            (CTX.sourceStoreʷ Ex12.example12-left-path-world-Z) Xᴸ)
         ⊑ renameᵗ
-          (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z))
+          (toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-Z))
           (lookupStore
-            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ)
+            (CTX.targetStoreʷ Ex12.example12-left-path-world-Z) Xᴿ)
   reps {Fin.zero} {Fin.zero} ()
   reps {Fin.suc Fin.zero} {Fin.zero} ()
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} refl = ★⊑★
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ
+        → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
         → ⊥)
-    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ
+    → lookupStore (CTX.targetStoreʷ Ex12.example12-left-path-world-Z) Xᴿ
         ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar 1 ]
           (lookupStore
-            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ
+            (CTX.targetStoreʷ Ex12.example12-left-path-world-Z) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Yᴿ
+            → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Yᴿ
             → ⊥)
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
@@ -1596,22 +1597,22 @@ examples2-left-path-world₃-invariants =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
-    → CTI2.impEnvʷ Ex2.left-path-world₃
-        (toRenameᵗ (CTI2.ηᴸʷ Ex2.left-path-world₃) Xᴸ) ≡ X⊑X
+    → CTX.impEnvʷ Ex2.left-path-world₃
+        (toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 2 ]
-        toRenameᵗ (CTI2.ηᴿʷ Ex2.left-path-world₃) Xᴿ
-          ≡ toRenameᵗ (CTI2.ηᴸʷ Ex2.left-path-world₃) Xᴸ
+        toRenameᵗ (CTX.ηᴿʷ Ex2.left-path-world₃) Xᴿ
+          ≡ toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Fin.zero) ()
   precise (Fin.suc (Fin.suc Fin.zero)) ()
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 2}
     → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ
-    → CTI2.impEnvʷ Ex2.left-path-world₃ ⊢
-        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ Ex2.left-path-world₃))
-          (lookupStore (CTI2.sourceStoreʷ Ex2.left-path-world₃) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ Ex2.left-path-world₃))
-          (lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ)
+    → CTX.impEnvʷ Ex2.left-path-world₃ ⊢
+        renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃))
+          (lookupStore (CTX.sourceStoreʷ Ex2.left-path-world₃) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTX.ηᴿʷ Ex2.left-path-world₃))
+          (lookupStore (CTX.targetStoreʷ Ex2.left-path-world₃) Xᴿ)
   reps {Fin.zero} {Fin.zero} refl = ι⊑★
   reps {Fin.zero} {Fin.suc Fin.zero} ()
   reps {Fin.suc Fin.zero} {Fin.zero} ()
@@ -1621,9 +1622,9 @@ examples2-left-path-world₃-invariants =
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ → ⊥)
-    → lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ ≡ ★
+    → lookupStore (CTX.targetStoreʷ Ex2.left-path-world₃) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
-          (lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ
+          (lookupStore (CTX.targetStoreʷ Ex2.left-path-world₃) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Yᴿ → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -2,8 +2,8 @@ module proof.DGG.WorldInvariants where
 
 -- File Charter:
 --   * Defines the D16 Stage 1 companion invariants for five-field worlds.
---   * Uses direct store entries and the strict literal-dynamic condition for
---     unmatched targets.
+--   * Uses direct store entries and the chain-permissive condition for
+--     unmatched targets after the recorded strict fallback test.
 --   * Establishes the companion for the empty initial world and core world
 --     builders without changing World or requiring it from consumers.
 --   * Derives variable-entry chain coherence from direct representations.
@@ -13,13 +13,14 @@ import Data.Fin as Fin
 open import Data.Maybe using (just; nothing)
 import Data.Nat as Nat
 open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; _≢_; refl; sym; trans; cong)
   renaming (subst to subst≡)
 
 open import Types
 open import TyStore using
-  (TyStore; store-empty; store-lift; store-bind; lookupStore)
+  (TyStore; store-empty; store-lift; store-bind; lookupStore; lookupStore-∋)
 open import Consistency using
   (_↪ᵗ_; empty; keep; skip; id↪ᵗ; wk↪ᵗ; toRenameᵗ)
 open import Imprecision
@@ -66,6 +67,11 @@ record WorldInvariants {Δᴸ Δᴿ Δ}
           → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
             ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
       → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+        ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
+            (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+          × (∀ (Xᴸ : TyVar Δᴸ)
+              → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+                ≢ toRenameᵗ (CTI2.ηᴿʷ W) Yᴿ)
 
 open WorldInvariants public
 
@@ -135,7 +141,8 @@ initialWorld-invariants μ = world-invariants precise reps unmatched
 
   reps : ∀ {Xᴸ Xᴿ}
     → toRenameᵗ id↪ᵗ Xᴸ ≡ toRenameᵗ id↪ᵗ Xᴿ
-    → μ ⊢ renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore (emptyStore _) Xᴸ)
+    → μ ⊢
+        renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore (emptyStore _) Xᴸ)
         ⊑ renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore (emptyStore _) Xᴿ)
   reps {Xᴸ = Xᴸ} aligned
       with toRenameᵗ-injective id↪ᵗ aligned
@@ -144,6 +151,10 @@ initialWorld-invariants μ = world-invariants precise reps unmatched
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
     → lookupStore (emptyStore _) Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (emptyStore _) Xᴿ ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Yᴿ)
   unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
 
 identityWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ) (Σ : TyStore Δ)
@@ -167,6 +178,10 @@ identityWorld-invariants μ Σ = world-invariants precise reps unmatched
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
     → lookupStore Σ Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore Σ Xᴿ ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Yᴿ)
   unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
 
 
@@ -250,15 +265,28 @@ liftWorldBoth-invariants {W = W} v inv =
         → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
           ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
     → lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
-  unmatched (Fin.suc Xᴿ) no-source =
-    cong ⇑ᵗ (unmatchedTargetsDynamic inv Xᴿ old-no-source)
+  unmatched (Fin.suc Xᴿ) no-source
+      with unmatchedTargetsDynamic inv Xᴿ
+        (λ Xᴸ aligned →
+          no-source (Fin.suc Xᴸ) (cong Fin.suc aligned))
+  unmatched (Fin.suc Xᴿ) no-source | inj₁ dynamic =
+    inj₁ (cong ⇑ᵗ dynamic)
+  unmatched (Fin.suc Xᴿ) no-source
+      | inj₂ (Yᴿ , entry , head-no-source) =
+    inj₂ (Fin.suc Yᴿ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
-    old-no-source : ∀ Xᴸ
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-    old-no-source Xᴸ aligned =
-      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+    lifted-head-no-source : ∀ Xᴸ
+      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Yᴿ)
+    lifted-head-no-source Fin.zero ()
+    lifted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 liftWorldLeft-invariants : ∀ {Δᴸ Δᴿ Δ}
@@ -303,13 +331,25 @@ liftWorldLeft-invariants {W = W} .X⊑★ refl inv =
         → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
           ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ)
     → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
-  unmatched Xᴿ no-source = unmatchedTargetsDynamic inv Xᴿ old-no-source
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ)
+  unmatched Xᴿ no-source
+      with unmatchedTargetsDynamic inv Xᴿ
+        (λ Xᴸ aligned →
+          no-source (Fin.suc Xᴸ) (cong Fin.suc aligned))
+  unmatched Xᴿ no-source | inj₁ dynamic = inj₁ dynamic
+  unmatched Xᴿ no-source | inj₂ (Yᴿ , entry , head-no-source) =
+    inj₂ (Yᴿ , entry , lifted-head-no-source)
     where
-    old-no-source : ∀ Xᴸ
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-    old-no-source Xᴸ aligned =
-      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+    lifted-head-no-source : ∀ Xᴸ
+      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ
+    lifted-head-no-source Fin.zero ()
+    lifted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 leftOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
@@ -354,21 +394,38 @@ leftOnlyWorld-invariants {W = W} .X⊑★ A refl inv =
         → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
           ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ)
     → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
-  unmatched Xᴿ no-source = unmatchedTargetsDynamic inv Xᴿ old-no-source
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ)
+  unmatched Xᴿ no-source
+      with unmatchedTargetsDynamic inv Xᴿ
+        (λ Xᴸ aligned →
+          no-source (Fin.suc Xᴸ) (cong Fin.suc aligned))
+  unmatched Xᴿ no-source | inj₁ dynamic = inj₁ dynamic
+  unmatched Xᴿ no-source | inj₂ (Yᴿ , entry , head-no-source) =
+    inj₂ (Yᴿ , entry , lifted-head-no-source)
     where
-    old-no-source : ∀ Xᴸ
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-    old-no-source Xᴸ aligned =
-      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+    lifted-head-no-source : ∀ Xᴸ
+      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Yᴿ
+    lifted-head-no-source Fin.zero ()
+    lifted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
   → ⇑ᵗ B ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
+        (⇑ᵗ B ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+            ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
   → WorldInvariants W
   → WorldInvariants (CTI2.rightOnlyWorld W B)
-rightOnlyWorld-invariants {W = W} B fresh-dynamic inv =
+rightOnlyWorld-invariants {W = W} B fresh-classification inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
@@ -404,14 +461,61 @@ rightOnlyWorld-invariants {W = W} B fresh-dynamic inv =
         → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
           ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
     → lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ ≡ ★
-  unmatched Fin.zero no-source = fresh-dynamic
-  unmatched (Fin.suc Xᴿ) no-source =
-    cong ⇑ᵗ (unmatchedTargetsDynamic inv Xᴿ old-no-source)
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
+  unmatched Fin.zero no-source = fresh-classification
+  unmatched (Fin.suc Xᴿ) no-source
+      with unmatchedTargetsDynamic inv Xᴿ
+        (λ Xᴸ aligned → no-source Xᴸ (cong Fin.suc aligned))
+  unmatched (Fin.suc Xᴿ) no-source | inj₁ dynamic =
+    inj₁ (cong ⇑ᵗ dynamic)
+  unmatched (Fin.suc Xᴿ) no-source
+      | inj₂ (Yᴿ , entry , head-no-source) =
+    inj₂ (Fin.suc Yᴿ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
-    old-no-source : ∀ Xᴸ
+    lifted-head-no-source : ∀ Xᴸ
+      → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Yᴿ)
+    lifted-head-no-source Xᴸ aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
+
+
+rightOnlyWorld-star-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → WorldInvariants W
+  → WorldInvariants (CTI2.rightOnlyWorld W ★)
+rightOnlyWorld-star-invariants =
+  rightOnlyWorld-invariants ★ (inj₁ refl)
+
+rightOnlyWorld-alias-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (Xᴿ : TyVar Δᴿ)
+  → (∀ (Xᴸ : TyVar Δᴸ)
       → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-    old-no-source Xᴸ aligned = no-source Xᴸ (cong Fin.suc aligned)
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+  → WorldInvariants W
+  → WorldInvariants (CTI2.rightOnlyWorld W (＇ Xᴿ))
+rightOnlyWorld-alias-invariants {W = W} Xᴿ head-no-source =
+  rightOnlyWorld-invariants (＇ Xᴿ)
+    (inj₂ (Fin.suc Xᴿ , refl , lifted-head-no-source))
+  where
+  lifted-head-no-source : ∀ Xᴸ
+    → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+      ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Xᴿ)
+  lifted-head-no-source Xᴸ aligned =
+    head-no-source Xᴸ (fin-suc-injective aligned)
+
+rightOnlyWorld-star-then-zero-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → WorldInvariants W
+  → WorldInvariants
+      (CTI2.rightOnlyWorld (CTI2.rightOnlyWorld W ★) (＇ Fin.zero))
+rightOnlyWorld-star-then-zero-invariants inv =
+  rightOnlyWorld-alias-invariants Fin.zero (λ Xᴸ ())
+    (rightOnlyWorld-star-invariants inv)
 
 
 bothBindWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
@@ -463,15 +567,29 @@ bothBindWorld-invariants {W = W} v A B A⊑B inv =
         → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
           ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
     → lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+              ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
-  unmatched (Fin.suc Xᴿ) no-source =
-    cong ⇑ᵗ (unmatchedTargetsDynamic inv Xᴿ old-no-source)
+  unmatched (Fin.suc Xᴿ) no-source
+      with unmatchedTargetsDynamic inv Xᴿ
+        (λ Xᴸ aligned →
+          no-source (Fin.suc Xᴸ) (cong Fin.suc aligned))
+  unmatched (Fin.suc Xᴿ) no-source | inj₁ dynamic =
+    inj₁ (cong ⇑ᵗ dynamic)
+  unmatched (Fin.suc Xᴿ) no-source
+      | inj₂ (Yᴿ , entry , head-no-source) =
+    inj₂ (Fin.suc Yᴿ , cong ⇑ᵗ entry , lifted-head-no-source)
     where
-    old-no-source : ∀ Xᴸ
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-    old-no-source Xᴸ aligned =
-      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+    lifted-head-no-source : ∀ Xᴸ
+      → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) (Fin.suc Yᴿ)
+    lifted-head-no-source Fin.zero ()
+    lifted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 parked-initial-invariants : ∀ {Δ} {μ : ImpEnv Δ} {Σ : TyStore Δ}
@@ -496,6 +614,11 @@ parked-left-bind-invariants {A = A} =
 parked-right-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
   → ⇑ᵗ B ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
+        (⇑ᵗ B ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+            ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Yᴿ)
   → WorldInvariants W
   → WorldInvariants (CTI2.rightOnlyWorld W B)
 parked-right-bind-invariants {B = B} = rightOnlyWorld-invariants B
@@ -570,15 +693,30 @@ renameWorld-invariants {W = W} π inv =
         → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
           ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Xᴿ)
     → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
-  unmatched Xᴿ no-source = unmatchedTargetsDynamic inv Xᴿ old-no-source
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
+              ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Yᴿ)
+  unmatched Xᴿ no-source
+      with unmatchedTargetsDynamic inv Xᴿ
+        (λ Xᴸ aligned → no-source Xᴸ
+          (trans (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ)
+            (trans (cong (toRenameᵗ π) aligned)
+              (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ)))))
+  unmatched Xᴿ no-source | inj₁ dynamic = inj₁ dynamic
+  unmatched Xᴿ no-source | inj₂ (Yᴿ , entry , head-no-source) =
+    inj₂ (Yᴿ , entry , renamed-head-no-source)
     where
-    old-no-source : ∀ Xᴸ
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
-        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-    old-no-source Xᴸ aligned = no-source Xᴸ
-      (trans (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ)
-        (trans (cong (toRenameᵗ π) aligned)
-          (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Xᴿ))))
+    renamed-head-no-source : ∀ Xᴸ
+      → toRenameᵗ (π CR.∘↪ CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (π CR.∘↪ CTI2.ηᴿʷ W) Yᴿ
+    renamed-head-no-source Xᴸ aligned =
+      head-no-source Xᴸ
+        (toRenameᵗ-injective π
+          (trans (sym (CR.toRenameᵗ-∘ π (CTI2.ηᴸʷ W) Xᴸ))
+            (trans aligned
+              (CR.toRenameᵗ-∘ π (CTI2.ηᴿʷ W) Yᴿ))))
 
 
 decay-invariants : ∀ {Δᴸ Δᴿ Δ}
@@ -633,15 +771,22 @@ targetStoreAs-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} (Σᴿ : TyStore Δᴿ)
   → WorldInvariants W
   → (∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
-      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
       → CTI2.impEnvʷ W ⊢
           renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
             (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
           ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W)) (lookupStore Σᴿ Xᴿ))
   → (∀ (Xᴿ : TyVar Δᴿ)
       → (∀ (Xᴸ : TyVar Δᴸ)
-          → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
-      → lookupStore Σᴿ Xᴿ ≡ ★)
+          → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+            ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+      → lookupStore Σᴿ Xᴿ ≡ ★
+        ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
+            (lookupStore Σᴿ Xᴿ ≡ ＇ Yᴿ)
+          × (∀ (Xᴸ : TyVar Δᴸ)
+              → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+                ≢ toRenameᵗ (CTI2.ηᴿʷ W) Yᴿ))
   → WorldInvariants (TBL.targetStoreAs W Σᴿ)
 targetStoreAs-invariants Σᴿ inv reps unmatched =
   world-invariants (preciseMarksAligned inv) reps unmatched
@@ -662,6 +807,11 @@ record TargetInsertDirect {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     targetLookup-off : ∀ Xᴿ′
       → CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) ≡ nothing
       → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+        ⊎ Σ[ Yᴿ′ ∈ TyVar Δᴿ′ ]
+            (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
+          × (∀ (Xᴸ : TyVar Δᴸ)
+              → CTI2.CenterAligned W′ Xᴸ Yᴿ′
+              → ⊥)
 
 open TargetInsertDirect public
 
@@ -674,7 +824,8 @@ targetInsert-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → TargetInsertDirect ins
   → WorldInvariants W
   → WorldInvariants W′
-targetInsert-invariants {ρ = ρ} {π = π} {W = W} {W′ = W′} ins direct inv =
+targetInsert-invariants
+    {ρ = ρ} {π = π} {W = W} {W′ = W′} ins direct inv =
   world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
@@ -725,6 +876,9 @@ targetInsert-invariants {ρ = ρ} {π = π} {W = W} {W′ = W′} ins direct inv
   unmatched : ∀ Xᴿ′
     → (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Xᴿ′ → ⊥)
     → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+      ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+          (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Yᴿ′ → ⊥)
   unmatched Xᴿ′ no-source
       with CR.preimage? π (toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′) in pre
   unmatched Xᴿ′ no-source | nothing =
@@ -733,16 +887,47 @@ targetInsert-invariants {ρ = ρ} {π = π} {W = W} {W′ = W′} ins direct inv
       with TE.target-center-reflect ins (CR.preimage?-sound π pre)
   unmatched Xᴿ′ no-source | just Z
       | Xᴿ , xᴿ′-eq , old-center =
-    subst≡ (λ Y → lookupStore (CTI2.targetStoreʷ W′) Y ≡ ★)
-      (sym xᴿ′-eq)
-      (trans (targetLookup-insert direct Xᴿ)
-        (cong (renameᵗ (toRenameᵗ ρ))
-          (unmatchedTargetsDynamic inv Xᴿ old-no-source)))
+    subst≡
+      (λ Y →
+        lookupStore (CTI2.targetStoreʷ W′) Y ≡ ★
+        ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+            (lookupStore (CTI2.targetStoreʷ W′) Y ≡ ＇ Yᴿ′)
+          × (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Yᴿ′ → ⊥))
+      (sym xᴿ′-eq) old-result
     where
     old-no-source : ∀ Xᴸ → CTI2.CenterAligned W Xᴸ Xᴿ → ⊥
     old-no-source Xᴸ aligned = no-source Xᴸ
       (subst≡ (CTI2.CenterAligned W′ Xᴸ) (sym xᴿ′-eq)
         (TE.align-insert ins aligned))
+
+    old-result :
+      lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ) ≡ ★
+      ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+          (lookupStore (CTI2.targetStoreʷ W′) (toRenameᵗ ρ Xᴿ)
+            ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ → CTI2.CenterAligned W′ Xᴸ Yᴿ′ → ⊥)
+    old-result with unmatchedTargetsDynamic inv Xᴿ old-no-source
+    old-result | inj₁ dynamic =
+      inj₁
+        (trans (targetLookup-insert direct Xᴿ)
+          (cong (renameᵗ (toRenameᵗ ρ)) dynamic))
+    old-result | inj₂ (Yᴿ , entry , head-no-source) =
+      inj₂
+        ( toRenameᵗ ρ Yᴿ
+        , trans (targetLookup-insert direct Xᴿ)
+            (cong (renameᵗ (toRenameᵗ ρ)) entry)
+        , inserted-head-no-source )
+      where
+      inserted-head-no-source : ∀ Xᴸ
+        → CTI2.CenterAligned W′ Xᴸ (toRenameᵗ ρ Yᴿ)
+        → ⊥
+      inserted-head-no-source Xᴸ aligned
+          with TE.target-source-reflect ins aligned
+      inserted-head-no-source Xᴸ aligned
+          | Yᴿ′ , mapped-eq , old-aligned =
+        head-no-source Xᴸ
+          (subst≡ (CTI2.CenterAligned W Xᴸ)
+            (sym (toRenameᵗ-injective ρ mapped-eq)) old-aligned)
 
 
 parked-structural-right-insert-invariants : ∀ {Δᴸ Δᴿ Δ Δ₁}
@@ -762,8 +947,13 @@ parked-structural-right-insert-invariants parked ins direct follows inv =
 rightBindTargetInsert-direct : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ}
   → ⇑ᵗ B ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
+        (⇑ᵗ B ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar Δᴸ)
+          → CTI2.CenterAligned (CTI2.rightOnlyWorld W B) Xᴸ Yᴿ
+          → ⊥)
   → TargetInsertDirect (TE.rightBindTargetInsert {W = W} {B = B})
-rightBindTargetInsert-direct {W = W} {B = B} fresh-dynamic =
+rightBindTargetInsert-direct {W = W} {B = B} fresh-classification =
   target-insert-direct old-entry fresh-entry
   where
   ins = TE.rightBindTargetInsert {W = W} {B = B}
@@ -784,7 +974,14 @@ rightBindTargetInsert-direct {W = W} {B = B} fresh-dynamic =
         ≡ nothing
     → lookupStore (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B)) Xᴿ′
         ≡ ★
-  fresh-entry Fin.zero off = fresh-dynamic
+      ⊎ Σ[ Yᴿ ∈ TyVar _ ]
+          (lookupStore
+            (CTI2.targetStoreʷ (CTI2.rightOnlyWorld W B)) Xᴿ′
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → CTI2.CenterAligned (CTI2.rightOnlyWorld W B) Xᴸ Yᴿ
+            → ⊥)
+  fresh-entry Fin.zero off = fresh-classification
   fresh-entry (Fin.suc Xᴿ) off = ⊥-elim (CR.just≢nothing impossible)
     where
     center-eq :
@@ -800,6 +997,32 @@ rightBindTargetInsert-direct {W = W} {B = B} fresh-dynamic =
       (sym (CR.preimage?-image wk↪ᵗ
         (toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)))
       (trans (cong (CR.preimage? wk↪ᵗ) (sym center-eq)) off)
+
+
+rightBindTargetInsert-star-direct : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+  → TargetInsertDirect
+      (TE.rightBindTargetInsert {W = W} {B = ★})
+rightBindTargetInsert-star-direct =
+  rightBindTargetInsert-direct (inj₁ refl)
+
+rightBindTargetInsert-alias-direct : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (Xᴿ : TyVar Δᴿ)
+  → (∀ (Xᴸ : TyVar Δᴸ)
+      → CTI2.CenterAligned W Xᴸ Xᴿ
+      → ⊥)
+  → TargetInsertDirect
+      (TE.rightBindTargetInsert {W = W} {B = ＇ Xᴿ})
+rightBindTargetInsert-alias-direct {W = W} Xᴿ head-no-source =
+  rightBindTargetInsert-direct
+    (inj₂ (Fin.suc Xᴿ , refl , lifted-head-no-source))
+  where
+  lifted-head-no-source : ∀ Xᴸ
+    → CTI2.CenterAligned (CTI2.rightOnlyWorld W (＇ Xᴿ))
+        Xᴸ (Fin.suc Xᴿ)
+    → ⊥
+  lifted-head-no-source Xᴸ aligned =
+    head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 liftBothTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -830,10 +1053,30 @@ liftBothTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
         ≡ nothing
     → lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′)) Xᴿ′
         ≡ ★
+      ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+          (lookupStore
+            (CTI2.targetStoreʷ (CTI2.liftWorldBoth v W′)) Xᴿ′
+            ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ
+            → CTI2.CenterAligned (CTI2.liftWorldBoth v W′) Xᴸ Yᴿ′
+            → ⊥)
   fresh-entry Fin.zero ()
-  fresh-entry (Fin.suc Xᴿ′) off =
-    cong ⇑ᵗ (targetLookup-off direct Xᴿ′
-      (CR.sucMaybe-nothing _ off))
+  fresh-entry (Fin.suc Xᴿ′) off
+      with targetLookup-off direct Xᴿ′
+        (CR.sucMaybe-nothing _ off)
+  fresh-entry (Fin.suc Xᴿ′) off | inj₁ dynamic =
+    inj₁ (cong ⇑ᵗ dynamic)
+  fresh-entry (Fin.suc Xᴿ′) off
+      | inj₂ (Yᴿ′ , entry , head-no-source) =
+    inj₂ (Fin.suc Yᴿ′ , cong ⇑ᵗ entry , lifted-head-no-source)
+    where
+    lifted-head-no-source : ∀ Xᴸ
+      → CTI2.CenterAligned
+          (CTI2.liftWorldBoth v W′) Xᴸ (Fin.suc Yᴿ′)
+      → ⊥
+    lifted-head-no-source Fin.zero ()
+    lifted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 liftLeftTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -852,8 +1095,25 @@ liftLeftTargetInsert-direct {π = π} {W′ = W′} {v = v} ins direct =
         ≡ nothing
     → lookupStore (CTI2.targetStoreʷ (CTI2.liftWorldLeft v W′)) Xᴿ′
         ≡ ★
-  fresh-entry Xᴿ′ off =
-    targetLookup-off direct Xᴿ′ (CR.sucMaybe-nothing _ off)
+      ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+          (lookupStore
+            (CTI2.targetStoreʷ (CTI2.liftWorldLeft v W′)) Xᴿ′
+            ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ
+            → CTI2.CenterAligned (CTI2.liftWorldLeft v W′) Xᴸ Yᴿ′
+            → ⊥)
+  fresh-entry Xᴿ′ off
+      with targetLookup-off direct Xᴿ′ (CR.sucMaybe-nothing _ off)
+  fresh-entry Xᴿ′ off | inj₁ dynamic = inj₁ dynamic
+  fresh-entry Xᴿ′ off | inj₂ (Yᴿ′ , entry , head-no-source) =
+    inj₂ (Yᴿ′ , entry , lifted-head-no-source)
+    where
+    lifted-head-no-source : ∀ Xᴸ
+      → CTI2.CenterAligned (CTI2.liftWorldLeft v W′) Xᴸ Yᴿ′
+      → ⊥
+    lifted-head-no-source Fin.zero ()
+    lifted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ (fin-suc-injective aligned)
 
 
 smartAliasTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -864,19 +1124,106 @@ smartAliasTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → (ins : TE.TargetInsert ρ π W W′)
   → (guard : CTI2.SmartAliasMergeGuard W Wᵐ β α)
   → TargetInsertDirect ins
+  → WorldInvariants Wᵐ
   → TargetInsertDirect (TE.smartAliasTargetInsert ins guard)
-smartAliasTargetInsert-direct {ρ = ρ} {W = W} {Wᵐ = Wᵐ} ins guard direct =
-  target-insert-direct old-entry (targetLookup-off direct)
+smartAliasTargetInsert-direct {ρ = ρ} {π = π} {W = W} {Wᵐ = Wᵐ}
+    {β = β} {α = α} ins guard direct inv =
+  target-insert-direct old-entry fresh-entry
   where
+  guard′ = TE.smartAliasGuardInsert ins guard
+
   old-entry : ∀ Xᴿ
     → lookupStore
         (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ))
         (toRenameᵗ ρ Xᴿ)
-      ≡ renameᵗ (toRenameᵗ ρ) (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
+      ≡ renameᵗ (toRenameᵗ ρ)
+          (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
   old-entry Xᴿ = trans (targetLookup-insert direct Xᴿ)
     (cong (renameᵗ (toRenameᵗ ρ))
       (sym (cong (λ Σ → lookupStore Σ Xᴿ)
         (CTI2.SmartAliasMergeGuard.targetStore-same guard))))
+
+  impossible-invariant : ⊥
+  impossible-invariant = variable≢star variable-equals-star
+    where
+    fresh-aligned : CTI2.CenterAligned Wᵐ Fin.zero β
+    fresh-aligned =
+      trans (CTI2.SmartAliasMergeGuard.pending-at-alias guard)
+        (sym (CTI2.SmartAliasMergeGuard.target-frozen guard β))
+
+    source-entry : lookupStore (CTI2.sourceStoreʷ Wᵐ) Fin.zero
+        ≡ ＇ Fin.zero
+    source-entry = cong (λ Σ → lookupStore Σ Fin.zero)
+      (CTI2.SmartAliasMergeGuard.sourceStore-lifted guard)
+
+    target-entry : lookupStore (CTI2.targetStoreʷ Wᵐ) β ≡ ＇ α
+    target-entry =
+      trans
+        (cong (λ Σ → lookupStore Σ β)
+          (CTI2.SmartAliasMergeGuard.targetStore-same guard))
+        (lookupStore-∋ (CTI2.SmartAliasMergeGuard.β:=＇α guard))
+
+    heads-equal :
+      toRenameᵗ (CTI2.ηᴸʷ Wᵐ) Fin.zero
+        ≡ toRenameᵗ (CTI2.ηᴿʷ Wᵐ) α
+    heads-equal = variableHeadsAlign
+      (imprecision-cong
+        (cong (renameᵗ (toRenameᵗ (CTI2.ηᴸʷ Wᵐ))) source-entry)
+        (cong (renameᵗ (toRenameᵗ (CTI2.ηᴿʷ Wᵐ))) target-entry)
+        (representationsImprecise inv fresh-aligned))
+
+    β-equals-α : β ≡ α
+    β-equals-α = toRenameᵗ-injective (CTI2.ηᴿʷ Wᵐ)
+      (trans (sym fresh-aligned) heads-equal)
+
+    β-entry : lookupStore (CTI2.targetStoreʷ W) β ≡ ＇ α
+    β-entry = lookupStore-∋
+      (CTI2.SmartAliasMergeGuard.β:=＇α guard)
+
+    α-entry : lookupStore (CTI2.targetStoreʷ W) α ≡ ★
+    α-entry = lookupStore-∋
+      (CTI2.SmartAliasMergeGuard.α:=★ guard)
+
+    variable-equals-star : ＇ α ≡ ★
+    variable-equals-star =
+      trans (sym β-entry)
+        (trans (cong (lookupStore (CTI2.targetStoreʷ W)) β-equals-α)
+          α-entry)
+
+    variable≢star : ＇ α ≢ ★
+    variable≢star ()
+
+  fresh-entry : ∀ Xᴿ′
+    → CR.preimage? π
+        (toRenameᵗ
+          (CTI2.ηᴿʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′)
+        ≡ nothing
+    → lookupStore
+        (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′
+        ≡ ★
+      ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+          (lookupStore
+            (CTI2.targetStoreʷ (TE.smartAliasInsertWorld ins Wᵐ)) Xᴿ′
+            ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ
+            → CTI2.CenterAligned
+                (TE.smartAliasInsertWorld ins Wᵐ) Xᴸ Yᴿ′
+            → ⊥)
+  fresh-entry Xᴿ′ off with targetLookup-off direct Xᴿ′ off
+  fresh-entry Xᴿ′ off | inj₁ dynamic = inj₁ dynamic
+  fresh-entry Xᴿ′ off | inj₂ (Yᴿ′ , entry , head-no-source) =
+    inj₂ (Yᴿ′ , entry , inserted-head-no-source)
+    where
+    inserted-head-no-source : ∀ Xᴸ
+      → CTI2.CenterAligned
+          (TE.smartAliasInsertWorld ins Wᵐ) Xᴸ Yᴿ′
+      → ⊥
+    inserted-head-no-source Fin.zero aligned = impossible-invariant
+    inserted-head-no-source (Fin.suc Xᴸ) aligned =
+      head-no-source Xᴸ
+        (trans
+          (sym (CTI2.SmartAliasMergeGuard.old-source-frozen guard′ Xᴸ))
+          aligned)
 
 smartAliasInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ ↪ᵗ Δᴿ′} {π : Δ ↪ᵗ Δ′}
@@ -890,7 +1237,7 @@ smartAliasInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → WorldInvariants (TE.smartAliasInsertWorld ins Wᵐ)
 smartAliasInsertWorld-invariants ins guard direct inv =
   targetInsert-invariants (TE.smartAliasTargetInsert ins guard)
-    (smartAliasTargetInsert-direct ins guard direct) inv
+    (smartAliasTargetInsert-direct ins guard direct inv) inv
 
 
 smartFreshTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′ Δᵐ}
@@ -913,7 +1260,8 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
     → lookupStore
         (CTI2.targetStoreʷ (TE.smartFreshInsertWorld ins guard))
         (toRenameᵗ ρ Xᴿ)
-      ≡ renameᵗ (toRenameᵗ ρ) (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
+      ≡ renameᵗ (toRenameᵗ ρ)
+          (lookupStore (CTI2.targetStoreʷ Wᵐ) Xᴿ)
   old-entry Xᴿ = trans (targetLookup-insert direct Xᴿ)
     (cong (renameᵗ (toRenameᵗ ρ))
       (sym (cong (λ Σ → lookupStore Σ Xᴿ)
@@ -941,6 +1289,12 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
           (CTI2.ηᴿʷ (TE.smartFreshInsertWorld ins guard)) Xᴿ′)
         ≡ nothing
     → lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ★
+      ⊎ Σ[ Yᴿ′ ∈ TyVar _ ]
+          (lookupStore (CTI2.targetStoreʷ W′) Xᴿ′ ≡ ＇ Yᴿ′)
+        × (∀ Xᴸ
+            → CTI2.CenterAligned
+                (TE.smartFreshInsertWorld ins guard) Xᴸ Yᴿ′
+            → ⊥)
   fresh-entry Xᴿ′ off with CR.preimage? ρ Xᴿ′ in preρ
   fresh-entry Xᴿ′ off | just Xᴿ = ⊥-elim (CR.just≢nothing impossible)
     where
@@ -961,8 +1315,36 @@ smartFreshTargetInsert-direct {ρ = ρ} {π = π} {W = W} {W′ = W′}
       (sym (CR.preimage?-image πᵐ
         (toRenameᵗ (CTI2.ηᴿʷ Wᵐ) Xᴿ)))
       (trans (cong (CR.preimage? πᵐ) (sym center-eq)) off)
-  fresh-entry Xᴿ′ off | nothing =
-    targetLookup-off direct Xᴿ′ (input-center-off Xᴿ′ preρ)
+  fresh-entry Xᴿ′ off | nothing
+      with targetLookup-off direct Xᴿ′ (input-center-off Xᴿ′ preρ)
+  fresh-entry Xᴿ′ off | nothing | inj₁ dynamic = inj₁ dynamic
+  fresh-entry Xᴿ′ off | nothing
+      | inj₂ (Yᴿ′ , entry , head-no-source) =
+    inj₂ (Yᴿ′ , entry , inserted-head-no-source)
+    where
+    inserted-head-no-source : ∀ Xᴸ
+      → CTI2.CenterAligned
+          (TE.smartFreshInsertWorld ins guard) Xᴸ Yᴿ′
+      → ⊥
+    inserted-head-no-source Xᴸ aligned
+        with TE.target-source-reflect
+          (TE.smartFreshTargetInsert ins guard) aligned
+    inserted-head-no-source Fin.zero aligned
+        | Yᴿ , yᴿ′-eq , source-aligned =
+      CTI2.SmartFreshBehindGuard.fresh-not-target guard Yᴿ
+        (sym source-aligned)
+    inserted-head-no-source (Fin.suc Xᴸ) aligned
+        | Yᴿ , yᴿ′-eq , source-aligned =
+      head-no-source Xᴸ
+        (subst≡ (CTI2.CenterAligned W′ Xᴸ) (sym yᴿ′-eq)
+          (TE.align-insert ins old-aligned))
+      where
+      old-aligned : CTI2.CenterAligned W Xᴸ Yᴿ
+      old-aligned = toRenameᵗ-injective old
+        (trans
+          (sym (CTI2.SmartFreshBehindGuard.old-source-frozen guard Xᴸ))
+          (trans source-aligned
+            (CTI2.SmartFreshBehindGuard.target-frozen guard Yᴿ)))
 
 
 smartFreshInsertWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′ Δᵐ}
@@ -983,11 +1365,17 @@ smartFreshInsertWorld-invariants ins guard direct inv =
 keepRightBindTargetInsert-direct : ∀ {Δᴸ Δᴿ Δ}
     {W : CTI2.World Δᴸ Δᴿ Δ} {B : Ty Δᴿ} {v : VarImp}
   → ⇑ᵗ B ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar (Nat.suc Δᴿ) ]
+        (⇑ᵗ B ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar Δᴸ)
+          → CTI2.CenterAligned (CTI2.rightOnlyWorld W B) Xᴸ Yᴿ
+          → ⊥)
   → TargetInsertDirect (TE.keepRightBindTargetInsert {W = W} {B = B} {v = v})
-keepRightBindTargetInsert-direct {W = W} {B = B} {v = v} fresh-dynamic =
+keepRightBindTargetInsert-direct {W = W} {B = B} {v = v}
+    fresh-classification =
   liftBothTargetInsert-direct
     (TE.rightBindTargetInsert {W = W} {B = B})
-    (rightBindTargetInsert-direct fresh-dynamic)
+    (rightBindTargetInsert-direct fresh-classification)
 
 
 insertRebaseTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -997,15 +1385,32 @@ insertRebaseTargetInsert-direct : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → (ins : TE.TargetInsert ρ π W W⁺)
   → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
   → TargetInsertDirect ins
+  → (∀ Yᴿ′
+      → CR.preimage? π
+          (toRenameᵗ
+            (CTI2.ηᴿʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′)
+          ≡ nothing
+      → lookupStore
+          (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+          ≡ ★
+        ⊎ Σ[ Zᴿ′ ∈ TyVar Δᴿ′ ]
+            (lookupStore
+              (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+              ≡ ＇ Zᴿ′)
+          × (∀ (Yᴸ : TyVar Δᴸ)
+              → CTI2.CenterAligned
+                  (TE.insertRebaseWorld ins Wᵖ) Yᴸ Zᴿ′
+              → ⊥))
   → TargetInsertDirect (TE.insertRebaseTargetInsert ins rb)
 insertRebaseTargetInsert-direct {ρ = ρ} {W = W} {Wᵖ = Wᵖ}
-    ins rb direct = target-insert-direct old-entry (targetLookup-off direct)
+    ins rb direct off-entry = target-insert-direct old-entry off-entry
   where
   old-entry : ∀ Yᴿ
     → lookupStore
         (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ))
         (toRenameᵗ ρ Yᴿ)
-      ≡ renameᵗ (toRenameᵗ ρ) (lookupStore (CTI2.targetStoreʷ Wᵖ) Yᴿ)
+      ≡ renameᵗ (toRenameᵗ ρ)
+          (lookupStore (CTI2.targetStoreʷ Wᵖ) Yᴿ)
   old-entry Yᴿ = trans (targetLookup-insert direct Yᴿ)
     (cong (renameᵗ (toRenameᵗ ρ))
       (sym (cong (λ Σ → lookupStore Σ Yᴿ)
@@ -1020,11 +1425,27 @@ insertRebaseWorld-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → (ins : TE.TargetInsert ρ π W W⁺)
   → (rb : CTI2.RebaseAt W Wᵖ Xᴸ Xᴿ)
   → TargetInsertDirect ins
+  → (∀ Yᴿ′
+      → CR.preimage? π
+          (toRenameᵗ
+            (CTI2.ηᴿʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′)
+          ≡ nothing
+      → lookupStore
+          (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+          ≡ ★
+        ⊎ Σ[ Zᴿ′ ∈ TyVar Δᴿ′ ]
+            (lookupStore
+              (CTI2.targetStoreʷ (TE.insertRebaseWorld ins Wᵖ)) Yᴿ′
+              ≡ ＇ Zᴿ′)
+          × (∀ (Yᴸ : TyVar Δᴸ)
+              → CTI2.CenterAligned
+                  (TE.insertRebaseWorld ins Wᵖ) Yᴸ Zᴿ′
+              → ⊥))
   → WorldInvariants Wᵖ
   → WorldInvariants (TE.insertRebaseWorld ins Wᵖ)
-insertRebaseWorld-invariants ins rb direct inv =
+insertRebaseWorld-invariants ins rb direct off-entry inv =
   targetInsert-invariants (TE.insertRebaseTargetInsert ins rb)
-    (insertRebaseTargetInsert-direct ins rb direct) inv
+    (insertRebaseTargetInsert-direct ins rb direct off-entry) inv
 
 
 example12-left-path-world-X-invariants :
@@ -1034,7 +1455,9 @@ example12-left-path-world-X-invariants =
   where
   precise : ∀ Xᴸ
     → CTI2.impEnvʷ CTI2.example12-left-path-world-X
-        (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ) ≡ X⊑X
+        (toRenameᵗ
+          (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ)
+        ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 1 ]
         toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X) Xᴿ
           ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X) Xᴸ
@@ -1046,16 +1469,29 @@ example12-left-path-world-X-invariants =
     → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ
     → CTI2.impEnvʷ CTI2.example12-left-path-world-X ⊢
         renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-X))
-          (lookupStore (CTI2.sourceStoreʷ CTI2.example12-left-path-world-X) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X))
-          (lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ)
+          (lookupStore
+            (CTI2.sourceStoreʷ CTI2.example12-left-path-world-X) Xᴸ)
+        ⊑ renameᵗ
+          (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-X))
+          (lookupStore
+            (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ)
   reps {Fin.zero} {Fin.zero} refl = ι⊑★
   reps {Fin.suc Fin.zero} {Fin.zero} ()
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
 
   unmatched : ∀ Xᴿ
-    → (∀ Xᴸ → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ → ⊥)
-    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ ≡ ★
+    → (∀ Xᴸ
+        → CenterAligned CTI2.example12-left-path-world-X Xᴸ Xᴿ
+        → ⊥)
+    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ
+        ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 1 ]
+          (lookupStore
+            (CTI2.targetStoreʷ CTI2.example12-left-path-world-X) Xᴿ
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → CenterAligned CTI2.example12-left-path-world-X Xᴸ Yᴿ
+            → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
 
 
@@ -1066,7 +1502,9 @@ example12-left-path-world-Y-invariants =
   where
   precise : ∀ Xᴸ
     → CTI2.impEnvʷ CTI2.example12-left-path-world-Y
-        (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ) ≡ X⊑X
+        (toRenameᵗ
+          (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ)
+        ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 1 ]
         toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y) Xᴿ
           ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y) Xᴸ
@@ -1078,16 +1516,29 @@ example12-left-path-world-Y-invariants =
     → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ
     → CTI2.impEnvʷ CTI2.example12-left-path-world-Y ⊢
         renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Y))
-          (lookupStore (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Y) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y))
-          (lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ)
+          (lookupStore
+            (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Y) Xᴸ)
+        ⊑ renameᵗ
+          (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Y))
+          (lookupStore
+            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ)
   reps {Fin.zero} {Fin.zero} ()
   reps {Fin.suc Fin.zero} {Fin.zero} refl = X⊑★ refl
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
 
   unmatched : ∀ Xᴿ
-    → (∀ Xᴸ → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ → ⊥)
-    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ ≡ ★
+    → (∀ Xᴸ
+        → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Xᴿ
+        → ⊥)
+    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ
+        ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 1 ]
+          (lookupStore
+            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Y) Xᴿ
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → CenterAligned CTI2.example12-left-path-world-Y Xᴸ Yᴿ
+            → ⊥)
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc Fin.zero) refl)
 
@@ -1099,7 +1550,9 @@ example12-left-path-world-Z-invariants =
   where
   precise : ∀ Xᴸ
     → CTI2.impEnvʷ CTI2.example12-left-path-world-Z
-        (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ) ≡ X⊑X
+        (toRenameᵗ
+          (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ)
+        ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar 1 ]
         toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z) Xᴿ
           ≡ toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z) Xᴸ
@@ -1111,22 +1564,36 @@ example12-left-path-world-Z-invariants =
     → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ
     → CTI2.impEnvʷ CTI2.example12-left-path-world-Z ⊢
         renameᵗ (toRenameᵗ (CTI2.ηᴸʷ CTI2.example12-left-path-world-Z))
-          (lookupStore (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Z) Xᴸ)
-        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z))
-          (lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ)
+          (lookupStore
+            (CTI2.sourceStoreʷ CTI2.example12-left-path-world-Z) Xᴸ)
+        ⊑ renameᵗ
+          (toRenameᵗ (CTI2.ηᴿʷ CTI2.example12-left-path-world-Z))
+          (lookupStore
+            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ)
   reps {Fin.zero} {Fin.zero} ()
   reps {Fin.suc Fin.zero} {Fin.zero} ()
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} refl = ★⊑★
 
   unmatched : ∀ Xᴿ
-    → (∀ Xᴸ → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ → ⊥)
-    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ ≡ ★
+    → (∀ Xᴸ
+        → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Xᴿ
+        → ⊥)
+    → lookupStore (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ
+        ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 1 ]
+          (lookupStore
+            (CTI2.targetStoreʷ CTI2.example12-left-path-world-Z) Xᴿ
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ
+            → CenterAligned CTI2.example12-left-path-world-Z Xᴸ Yᴿ
+            → ⊥)
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
 
 
 examples2-left-path-world₃-invariants : WorldInvariants Ex2.left-path-world₃
-examples2-left-path-world₃-invariants = world-invariants precise reps unmatched
+examples2-left-path-world₃-invariants =
+  world-invariants precise reps unmatched
   where
   precise : ∀ Xᴸ
     → CTI2.impEnvʷ Ex2.left-path-world₃
@@ -1155,12 +1622,18 @@ examples2-left-path-world₃-invariants = world-invariants precise reps unmatche
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ → ⊥)
     → lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+          (lookupStore (CTI2.targetStoreʷ Ex2.left-path-world₃) Xᴿ
+            ≡ ＇ Yᴿ)
+        × (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Yᴿ → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
   unmatched (Fin.suc Fin.zero) no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
 
 examples2-left-path-world₄-invariants : WorldInvariants Ex2.left-path-world₄
-examples2-left-path-world₄-invariants = examples2-left-path-world₃-invariants
+examples2-left-path-world₄-invariants =
+  examples2-left-path-world₃-invariants
 
 examples2-left-path-world₅-invariants : WorldInvariants Ex2.left-path-world₅
-examples2-left-path-world₅-invariants = examples2-left-path-world₃-invariants
+examples2-left-path-world₅-invariants =
+  examples2-left-path-world₃-invariants

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -1,0 +1,441 @@
+module proof.DGG.WorldInvariants where
+
+-- File Charter:
+--   * Defines the D16 Stage 1 companion invariants for five-field worlds.
+--   * Uses direct store entries and the strict literal-dynamic condition for
+--     unmatched targets.
+--   * Establishes the companion for the empty initial world and core world
+--     builders without changing World or requiring it from consumers.
+--   * Derives variable-entry chain coherence from direct representations.
+
+open import Data.Empty using (⊥-elim)
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Relation.Binary.PropositionalEquality using
+  (_≡_; _≢_; refl; sym; trans; cong)
+  renaming (subst to subst≡)
+
+open import Types
+open import TyStore using
+  (TyStore; store-empty; store-lift; store-bind; lookupStore)
+open import Consistency using
+  (_↪ᵗ_; empty; keep; skip; id↪ᵗ; toRenameᵗ)
+open import Imprecision
+import proof.DGG.CastTermImprecision2 as CTI2
+open import proof.ImprecisionConsistency using
+  (refl⊑; rename-⊑; toRenameᵗ-injective)
+open import proof.TypeInTermSubst using
+  (toRename-id-eq; toRename-keep-eq)
+
+
+record WorldInvariants {Δᴸ Δᴿ Δ}
+    (W : CTI2.World Δᴸ Δᴿ Δ) : Set where
+  constructor world-invariants
+  field
+    preciseMarksAligned :
+      ∀ (Xᴸ : TyVar Δᴸ)
+      → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑X
+      → Σ[ Xᴿ ∈ TyVar Δᴿ ]
+          toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+            ≡ toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+
+    representationsImprecise :
+      ∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+          ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+      → CTI2.impEnvʷ W ⊢
+          renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
+            (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
+          ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W))
+            (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+
+    unmatchedTargetsDynamic :
+      ∀ (Xᴿ : TyVar Δᴿ)
+      → (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+            ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ)
+      → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+
+open WorldInvariants public
+
+
+CenterAligned : ∀ {Δᴸ Δᴿ Δ}
+  → CTI2.World Δᴸ Δᴿ Δ
+  → TyVar Δᴸ
+  → TyVar Δᴿ
+  → Set
+CenterAligned W Xᴸ Xᴿ =
+  toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+
+imprecision-cong : ∀ {Δ} {μ : ImpEnv Δ} {A A′ B B′ : Ty Δ}
+  → A ≡ A′
+  → B ≡ B′
+  → μ ⊢ A ⊑ B
+  → μ ⊢ A′ ⊑ B′
+imprecision-cong refl refl A⊑B = A⊑B
+
+variableHeadsAlign : ∀ {Δ} {μ : ImpEnv Δ} {X Y : TyVar Δ}
+  → μ ⊢ ＇ X ⊑ ＇ Y
+  → X ≡ Y
+variableHeadsAlign X⊑X = refl
+
+variableEntryChainCoherence : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {Xᴸ Yᴸ : TyVar Δᴸ} {Xᴿ Yᴿ : TyVar Δᴿ}
+  → WorldInvariants W
+  → CenterAligned W Xᴸ Xᴿ
+  → lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ＇ Yᴸ
+  → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ
+  → CenterAligned W Yᴸ Yᴿ
+    × (CTI2.impEnvʷ W ⊢
+        renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))
+          (lookupStore (CTI2.sourceStoreʷ W) Yᴸ)
+        ⊑ renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W))
+          (lookupStore (CTI2.targetStoreʷ W) Yᴿ))
+variableEntryChainCoherence {W = W} {Yᴸ = Yᴸ} {Yᴿ = Yᴿ}
+    inv aligned source-entry target-entry =
+  heads-aligned , representationsImprecise inv heads-aligned
+  where
+  heads-aligned : CenterAligned W Yᴸ Yᴿ
+  heads-aligned = variableHeadsAlign
+    (imprecision-cong
+      (cong (renameᵗ (toRenameᵗ (CTI2.ηᴸʷ W))) source-entry)
+      (cong (renameᵗ (toRenameᵗ (CTI2.ηᴿʷ W))) target-entry)
+      (representationsImprecise inv aligned))
+
+
+emptyStore : (Δ : TyCtx) → TyStore Δ
+emptyStore Nat.zero = store-empty
+emptyStore (Nat.suc Δ) = store-lift (emptyStore Δ)
+
+initialWorld : ∀ {Δ} → ImpEnv Δ → CTI2.World Δ Δ Δ
+initialWorld {Δ} μ =
+  CTI2.world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
+
+initialWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ)
+  → WorldInvariants (initialWorld μ)
+initialWorld-invariants μ = world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → μ (toRenameᵗ id↪ᵗ Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ id↪ᵗ Xᴿ ≡ toRenameᵗ id↪ᵗ Xᴸ
+  precise Xᴸ mark = Xᴸ , refl
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ id↪ᵗ Xᴸ ≡ toRenameᵗ id↪ᵗ Xᴿ
+    → μ ⊢ renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore (emptyStore _) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ id↪ᵗ) (lookupStore (emptyStore _) Xᴿ)
+  reps {Xᴸ = Xᴸ} aligned
+      with toRenameᵗ-injective id↪ᵗ aligned
+  reps {Xᴸ = Xᴸ} aligned | refl = refl⊑ _
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
+    → lookupStore (emptyStore _) Xᴿ ≡ ★
+  unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
+
+
+private
+  fin-suc-injective : ∀ {n} {X Y : Fin.Fin n}
+    → Fin.suc X ≡ Fin.suc Y
+    → X ≡ Y
+  fin-suc-injective refl = refl
+
+  renameᵗ-keep-shift : ∀ {Δ₀ Δ} (η : Δ₀ ↪ᵗ Δ) (A : Ty Δ₀)
+    → renameᵗ (toRenameᵗ (keep η)) (⇑ᵗ A)
+      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) A)
+  renameᵗ-keep-shift η A =
+    trans (renameᵗ-cong (⇑ᵗ A) (toRename-keep-eq η))
+      (renameᵗ-shift (toRenameᵗ η) A)
+
+  renameᵗ-skip : ∀ {Δ₀ Δ} (η : Δ₀ ↪ᵗ Δ) (A : Ty Δ₀)
+    → renameᵗ (toRenameᵗ (skip η)) A
+      ≡ ⇑ᵗ (renameᵗ (toRenameᵗ η) A)
+  renameᵗ-skip η A =
+    trans (renameᵗ-cong A (λ X → refl))
+      (sym (renameᵗ-comp (toRenameᵗ η) Fin.suc A))
+
+  lift-old-representation : ∀ {Δ} {μ : ImpEnv Δ} {v}
+      {A : Ty Δ} {B : Ty Δ}
+    → μ ⊢ A ⊑ B
+    → extendᵐ v μ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ B
+  lift-old-representation {v = v} A⊑B =
+    rename-⊑ Fin.suc fin-suc-injective
+      (λ X eq → eq) A⊑B
+
+  inst-old-representation : ∀ {Δ} {μ : ImpEnv Δ}
+      {A : Ty Δ} {B : Ty Δ}
+    → μ ⊢ A ⊑ B
+    → instᵐ μ ⊢ ⇑ᵗ A ⊑ ⇑ᵗ B
+  inst-old-representation A⊑B =
+    rename-⊑ Fin.suc fin-suc-injective
+      (λ X eq → eq) A⊑B
+
+
+liftWorldBoth-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp)
+  → WorldInvariants W
+  → WorldInvariants (CTI2.liftWorldBoth v W)
+liftWorldBoth-invariants {W = W} v inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → extendᵐ v (CTI2.impEnvʷ W)
+        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+  precise Fin.zero mark = Fin.zero , refl
+  precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
+  precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
+    Fin.suc Xᴿ , cong Fin.suc aligned
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
+    → extendᵐ v (CTI2.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
+          (lookupStore (store-lift (CTI2.sourceStoreʷ W)) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (keep (CTI2.ηᴿʷ W)))
+          (lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ)
+  reps {Fin.zero} {Fin.zero} aligned = X⊑X
+  reps {Fin.zero} {Fin.suc Xᴿ} ()
+  reps {Fin.suc Xᴸ} {Fin.zero} ()
+  reps {Fin.suc Xᴸ} {Fin.suc Xᴿ} aligned =
+    imprecision-cong
+      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
+        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W)
+        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (lift-old-representation (representationsImprecise inv
+        (fin-suc-injective aligned)))
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
+    → lookupStore (store-lift (CTI2.targetStoreʷ W)) Xᴿ ≡ ★
+  unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
+  unmatched (Fin.suc Xᴿ) no-source =
+    cong ⇑ᵗ (unmatchedTargetsDynamic inv Xᴿ old-no-source)
+    where
+    old-no-source : ∀ Xᴸ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+    old-no-source Xᴸ aligned =
+      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+
+
+liftWorldLeft-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp)
+  → v ≡ X⊑★
+  → WorldInvariants W
+  → WorldInvariants (CTI2.liftWorldLeft v W)
+liftWorldLeft-invariants {W = W} .X⊑★ refl inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → instᵐ (CTI2.impEnvʷ W)
+        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
+  precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
+    Xᴿ , cong Fin.suc aligned
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
+    → instᵐ (CTI2.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
+          (lookupStore (store-lift (CTI2.sourceStoreʷ W)) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (skip (CTI2.ηᴿʷ W)))
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+  reps {Fin.zero} {Xᴿ} ()
+  reps {Fin.suc Xᴸ} {Xᴿ} aligned =
+    imprecision-cong
+      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
+        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-skip (CTI2.ηᴿʷ W)
+        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (inst-old-representation (representationsImprecise inv
+        (fin-suc-injective aligned)))
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ)
+    → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+  unmatched Xᴿ no-source = unmatchedTargetsDynamic inv Xᴿ old-no-source
+    where
+    old-no-source : ∀ Xᴸ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+    old-no-source Xᴸ aligned =
+      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+
+
+leftOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp) (A : Ty Δᴸ)
+  → v ≡ X⊑★
+  → WorldInvariants W
+  → WorldInvariants (CTI2.leftOnlyWorld v W A)
+leftOnlyWorld-invariants {W = W} .X⊑★ A refl inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → instᵐ (CTI2.impEnvʷ W)
+        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
+  precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
+    Xᴿ , cong Fin.suc aligned
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ
+    → instᵐ (CTI2.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
+          (lookupStore (store-bind (CTI2.sourceStoreʷ W) A) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (skip (CTI2.ηᴿʷ W)))
+          (lookupStore (CTI2.targetStoreʷ W) Xᴿ)
+  reps {Fin.zero} {Xᴿ} ()
+  reps {Fin.suc Xᴸ} {Xᴿ} aligned =
+    imprecision-cong
+      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
+        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-skip (CTI2.ηᴿʷ W)
+        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (inst-old-representation (representationsImprecise inv
+        (fin-suc-injective aligned)))
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (skip (CTI2.ηᴿʷ W)) Xᴿ)
+    → lookupStore (CTI2.targetStoreʷ W) Xᴿ ≡ ★
+  unmatched Xᴿ no-source = unmatchedTargetsDynamic inv Xᴿ old-no-source
+    where
+    old-no-source : ∀ Xᴸ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+    old-no-source Xᴸ aligned =
+      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)
+
+
+rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
+  → ⇑ᵗ B ≡ ★
+  → WorldInvariants W
+  → WorldInvariants (CTI2.rightOnlyWorld W B)
+rightOnlyWorld-invariants {W = W} B fresh-dynamic inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → instᵐ (CTI2.impEnvʷ W)
+        (toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+  precise Xᴸ mark with preciseMarksAligned inv Xᴸ mark
+  precise Xᴸ mark | Xᴿ , aligned =
+    Fin.suc Xᴿ , cong Fin.suc aligned
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
+    → instᵐ (CTI2.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (skip (CTI2.ηᴸʷ W)))
+          (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (keep (CTI2.ηᴿʷ W)))
+          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ)
+  reps {Xᴸ} {Fin.zero} ()
+  reps {Xᴸ} {Fin.suc Xᴿ} aligned =
+    imprecision-cong
+      (sym (renameᵗ-skip (CTI2.ηᴸʷ W)
+        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W)
+        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (inst-old-representation (representationsImprecise inv
+        (fin-suc-injective aligned)))
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+        → toRenameᵗ (skip (CTI2.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
+    → lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ ≡ ★
+  unmatched Fin.zero no-source = fresh-dynamic
+  unmatched (Fin.suc Xᴿ) no-source =
+    cong ⇑ᵗ (unmatchedTargetsDynamic inv Xᴿ old-no-source)
+    where
+    old-no-source : ∀ Xᴸ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+    old-no-source Xᴸ aligned = no-source Xᴸ (cong Fin.suc aligned)
+
+
+bothBindWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (v : VarImp)
+    (A : Ty Δᴸ) (B : Ty Δᴿ)
+  → A CTI2.⊑ᵂ⟨ W ⟩ B
+  → WorldInvariants W
+  → WorldInvariants (CTI2.bothBindWorld v W A B)
+bothBindWorld-invariants {W = W} v A B A⊑B inv =
+  world-invariants precise reps unmatched
+  where
+  precise : ∀ Xᴸ
+    → extendᵐ v (CTI2.impEnvʷ W)
+        (toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar _ ]
+        toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
+          ≡ toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+  precise Fin.zero mark = Fin.zero , refl
+  precise (Fin.suc Xᴸ) mark with preciseMarksAligned inv Xᴸ mark
+  precise (Fin.suc Xᴸ) mark | Xᴿ , aligned =
+    Fin.suc Xᴿ , cong Fin.suc aligned
+
+  reps : ∀ {Xᴸ Xᴿ}
+    → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+        ≡ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ
+    → extendᵐ v (CTI2.impEnvʷ W) ⊢
+        renameᵗ (toRenameᵗ (keep (CTI2.ηᴸʷ W)))
+          (lookupStore (store-bind (CTI2.sourceStoreʷ W) A) Xᴸ)
+        ⊑ renameᵗ (toRenameᵗ (keep (CTI2.ηᴿʷ W)))
+          (lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ)
+  reps {Fin.zero} {Fin.zero} aligned =
+    imprecision-cong
+      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W) A))
+      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W) B))
+      (lift-old-representation A⊑B)
+  reps {Fin.zero} {Fin.suc Xᴿ} ()
+  reps {Fin.suc Xᴸ} {Fin.zero} ()
+  reps {Fin.suc Xᴸ} {Fin.suc Xᴿ} aligned =
+    imprecision-cong
+      (sym (renameᵗ-keep-shift (CTI2.ηᴸʷ W)
+        (lookupStore (CTI2.sourceStoreʷ W) Xᴸ)))
+      (sym (renameᵗ-keep-shift (CTI2.ηᴿʷ W)
+        (lookupStore (CTI2.targetStoreʷ W) Xᴿ)))
+      (lift-old-representation (representationsImprecise inv
+        (fin-suc-injective aligned)))
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+        → toRenameᵗ (keep (CTI2.ηᴸʷ W)) Xᴸ
+          ≢ toRenameᵗ (keep (CTI2.ηᴿʷ W)) Xᴿ)
+    → lookupStore (store-bind (CTI2.targetStoreʷ W) B) Xᴿ ≡ ★
+  unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
+  unmatched (Fin.suc Xᴿ) no-source =
+    cong ⇑ᵗ (unmatchedTargetsDynamic inv Xᴿ old-no-source)
+    where
+    old-no-source : ∀ Xᴸ
+      → toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+    old-no-source Xᴸ aligned =
+      no-source (Fin.suc Xᴸ) (cong Fin.suc aligned)

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -1,12 +1,13 @@
 module proof.DGG.WorldInvariants where
 
 -- File Charter:
---   * Defines the D16 Stage 1 companion invariants for five-field worlds.
+--   * Defines the D16 companion invariants for five-field worlds.
 --   * Uses direct store entries and the chain-permissive condition for
 --     unmatched targets after the recorded strict fallback test.
 --   * Establishes the companion for the empty initial world and core world
 --     builders without changing World or requiring it from consumers.
---   * Derives variable-entry chain coherence from direct representations.
+--   * Derives variable-entry chain coherence and target non-occupancy from
+--     the four fields.
 
 open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
@@ -17,12 +18,15 @@ open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; _≢_; refl; sym; trans; cong)
   renaming (subst to subst≡)
+open import Relation.Nullary using (yes; no)
 
 open import Types
 open import TyStore using
   (TyStore; store-empty; store-lift; store-bind; lookupStore; lookupStore-∋)
 open import Consistency using
   (_↪ᵗ_; empty; keep; skip; id↪ᵗ; wk↪ᵗ; toRenameᵗ)
+open import Conversion using (seal)
+import Conversion as Conv
 open import Imprecision
 import Reduction as R
 import proof.DGG.CenterRename as CR
@@ -74,6 +78,14 @@ record WorldInvariants {Δᴸ Δᴿ Δ}
               → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
                 ≢ toRenameᵗ (CTX.ηᴿʷ W) Yᴿ)
 
+    dynamicStarSourcesUnoccupied :
+      ∀ (Xᴸ : TyVar Δᴸ)
+      → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+      → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+      → ∀ (Xᴿ : TyVar Δᴿ)
+      → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+        ≢ toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+
 open WorldInvariants public
 
 
@@ -121,10 +133,51 @@ variableEntryChainCoherence {W = W} {Yᴸ = Yᴸ} {Yᴿ = Yᴿ}
       (cong (renameᵗ (toRenameᵗ (CTX.ηᴿʷ W))) target-entry)
       (representationsImprecise inv aligned))
 
+world-invariants-no-target-at-dynamic-star : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTX.sourceStoreʷ W) X ≡ ★
+  → CTX.NoTargetOccupantAtSource W X
+world-invariants-no-target-at-dynamic-star {X = X} inv mark entry
+    (Xᴿ , aligned) =
+  dynamicStarSourcesUnoccupied inv X mark entry Xᴿ aligned
+
+world-invariants-see-through-premise : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W′
+  → CTX.TagRebaseAtᴸ W′ W (just X) nothing
+  → CTX.sourceStoreʷ W Conv.⊢↓[ just X ] seal X ★
+  → CTX.NoTargetOccupantAtSource W′ X
+world-invariants-see-through-premise inv
+    (CTX.tag-rebase-onlyᴸ mark disaligned represented)
+    (Conv.⊢↓-sealˣ source∋) =
+  world-invariants-no-target-at-dynamic-star inv mark
+    (lookupStore-∋ source∋)
+
+world-invariants-d17c-occupancy : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTX.sourceStoreʷ W) X ≡ ★
+  → CTX.Occupied W (toRenameᵗ (CTX.ηᴸʷ W) X) → ⊥
+world-invariants-d17c-occupancy inv mark entry =
+  world-invariants-no-target-at-dynamic-star inv mark entry
+
 
 emptyStore : (Δ : TyCtx) → TyStore Δ
 emptyStore Nat.zero = store-empty
 emptyStore (Nat.suc Δ) = store-lift (emptyStore Δ)
+
+emptyStore-lookup-variable : ∀ {Δ} (X : TyVar Δ)
+  → lookupStore (emptyStore Δ) X ≡ ＇ X
+emptyStore-lookup-variable {Nat.suc Δ} Fin.zero = refl
+emptyStore-lookup-variable {Nat.suc Δ} (Fin.suc X) =
+  cong ⇑ᵗ (emptyStore-lookup-variable X)
+
+variable≢star : ∀ {Δ} {X : TyVar Δ}
+  → _≡_ {A = Ty Δ} (＇ X) ★ → ⊥
+variable≢star ()
 
 initialWorld : ∀ {Δ} → ImpEnv Δ → CTX.World Δ Δ Δ
 initialWorld {Δ} μ =
@@ -132,7 +185,8 @@ initialWorld {Δ} μ =
 
 initialWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ)
   → WorldInvariants (initialWorld μ)
-initialWorld-invariants μ = world-invariants precise reps unmatched
+initialWorld-invariants {Δ = Δ} μ =
+  world-invariants precise reps unmatched no-dynamic-star-source
   where
   precise : ∀ Xᴸ
     → μ (toRenameᵗ id↪ᵗ Xᴸ) ≡ X⊑X
@@ -158,9 +212,24 @@ initialWorld-invariants μ = world-invariants precise reps unmatched
             → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Yᴿ)
   unmatched Xᴿ no-source = ⊥-elim (no-source Xᴿ refl)
 
+  no-dynamic-star-source : ∀ Xᴸ
+    → μ (toRenameᵗ id↪ᵗ Xᴸ) ≡ X⊑★
+    → lookupStore (emptyStore Δ) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ id↪ᵗ Xᴿ ≢ toRenameᵗ id↪ᵗ Xᴸ
+  no-dynamic-star-source Xᴸ mark entry Xᴿ aligned =
+    variable≢star
+      (trans (sym (emptyStore-lookup-variable Xᴸ)) entry)
+
 identityWorld-invariants : ∀ {Δ} (μ : ImpEnv Δ) (Σ : TyStore Δ)
+  → (∀ X
+      → μ (toRenameᵗ id↪ᵗ X) ≡ X⊑★
+      → lookupStore Σ X ≡ ★
+      → ∀ Y
+      → toRenameᵗ id↪ᵗ Y ≢ toRenameᵗ id↪ᵗ X)
   → WorldInvariants (CTX.world id↪ᵗ id↪ᵗ μ Σ Σ)
-identityWorld-invariants μ Σ = world-invariants precise reps unmatched
+identityWorld-invariants μ Σ no-dynamic-star-source =
+  world-invariants precise reps unmatched no-dynamic-star-source
   where
   precise : ∀ Xᴸ
     → μ (toRenameᵗ id↪ᵗ Xᴸ) ≡ X⊑X
@@ -222,13 +291,22 @@ private
     rename-⊑ Fin.suc fin-suc-injective
       (λ X eq → eq) A⊑B
 
+  unshift-star : ∀ {Δ} {A : Ty Δ}
+    → ⇑ᵗ A ≡ ★
+    → A ≡ ★
+  unshift-star {A = ＇ X} ()
+  unshift-star {A = ‵ ι} ()
+  unshift-star {A = ★} refl = refl
+  unshift-star {A = A ⇒ B} ()
+  unshift-star {A = `∀ A} ()
+
 
 liftWorldBoth-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp)
   → WorldInvariants W
   → WorldInvariants (CTX.liftWorldBoth v W)
 liftWorldBoth-invariants {W = W} v inv =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → extendᵐ v (CTX.impEnvʷ W)
@@ -289,6 +367,19 @@ liftWorldBoth-invariants {W = W} v inv =
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
+  unoccupied : ∀ Xᴸ
+    → extendᵐ v (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑★
+    → lookupStore (store-lift (CTX.sourceStoreʷ W)) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+      ≢ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+  unoccupied Fin.zero mark entry Xᴿ aligned = variable≢star entry
+  unoccupied (Fin.suc Xᴸ) mark entry Fin.zero ()
+  unoccupied (Fin.suc Xᴸ) mark entry (Fin.suc Xᴿ) aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark (unshift-star entry) Xᴿ
+      (fin-suc-injective aligned)
+
 
 liftWorldLeft-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp)
@@ -296,7 +387,7 @@ liftWorldLeft-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (CTX.liftWorldLeft v W)
 liftWorldLeft-invariants {W = W} .X⊑★ refl inv =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → instᵐ (CTX.impEnvʷ W)
@@ -352,6 +443,18 @@ liftWorldLeft-invariants {W = W} .X⊑★ refl inv =
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
+  unoccupied : ∀ Xᴸ
+    → instᵐ (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑★
+    → lookupStore (store-lift (CTX.sourceStoreʷ W)) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ
+      ≢ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+  unoccupied Fin.zero mark entry Xᴿ aligned = variable≢star entry
+  unoccupied (Fin.suc Xᴸ) mark entry Xᴿ aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark (unshift-star entry) Xᴿ
+      (fin-suc-injective aligned)
+
 
 leftOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp) (A : Ty Δᴸ)
@@ -359,7 +462,7 @@ leftOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (CTX.leftOnlyWorld v W A)
 leftOnlyWorld-invariants {W = W} .X⊑★ A refl inv =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → instᵐ (CTX.impEnvʷ W)
@@ -415,6 +518,18 @@ leftOnlyWorld-invariants {W = W} .X⊑★ A refl inv =
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
+  unoccupied : ∀ Xᴸ
+    → instᵐ (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑★
+    → lookupStore (store-bind (CTX.sourceStoreʷ W) A) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (skip (CTX.ηᴿʷ W)) Xᴿ
+      ≢ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+  unoccupied Fin.zero mark entry Xᴿ ()
+  unoccupied (Fin.suc Xᴸ) mark entry Xᴿ aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark (unshift-star entry) Xᴿ
+      (fin-suc-injective aligned)
+
 
 rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
@@ -427,7 +542,7 @@ rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (CTX.rightOnlyWorld W B)
 rightOnlyWorld-invariants {W = W} B fresh-classification inv =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → instᵐ (CTX.impEnvʷ W)
@@ -484,6 +599,18 @@ rightOnlyWorld-invariants {W = W} B fresh-classification inv =
     lifted-head-no-source Xᴸ aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
+  unoccupied : ∀ Xᴸ
+    → instᵐ (CTX.impEnvʷ W)
+        (toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+      ≢ toRenameᵗ (skip (CTX.ηᴸʷ W)) Xᴸ
+  unoccupied Xᴸ mark entry Fin.zero ()
+  unoccupied Xᴸ mark entry (Fin.suc Xᴿ) aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark entry Xᴿ
+      (fin-suc-injective aligned)
+
 
 rightOnlyWorld-star-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ}
@@ -522,14 +649,15 @@ rightOnlyWorld-star-then-zero-invariants inv =
 bothBindWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} (v : VarImp)
     (A : Ty Δᴸ) (B : Ty Δᴿ)
+  → v ≡ X⊑X
   → A CTX.⊑ᵂ⟨ W ⟩ B
   → WorldInvariants W
   → WorldInvariants (CTX.bothBindWorld v W A B)
-bothBindWorld-invariants {W = W} v A B A⊑B inv =
-  world-invariants precise reps unmatched
+bothBindWorld-invariants {W = W} .X⊑X A B refl A⊑B inv =
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
-    → extendᵐ v (CTX.impEnvʷ W)
+    → extendᵐ X⊑X (CTX.impEnvʷ W)
         (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑X
     → Σ[ Xᴿ ∈ TyVar _ ]
         toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
@@ -542,7 +670,7 @@ bothBindWorld-invariants {W = W} v A B A⊑B inv =
   reps : ∀ {Xᴸ Xᴿ}
     → toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
         ≡ toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
-    → extendᵐ v (CTX.impEnvʷ W) ⊢
+    → extendᵐ X⊑X (CTX.impEnvʷ W) ⊢
         renameᵗ (toRenameᵗ (keep (CTX.ηᴸʷ W)))
           (lookupStore (store-bind (CTX.sourceStoreʷ W) A) Xᴸ)
         ⊑ renameᵗ (toRenameᵗ (keep (CTX.ηᴿʷ W)))
@@ -592,10 +720,29 @@ bothBindWorld-invariants {W = W} v A B A⊑B inv =
     lifted-head-no-source (Fin.suc Xᴸ) aligned =
       head-no-source Xᴸ (fin-suc-injective aligned)
 
+  unoccupied : ∀ Xᴸ
+    → extendᵐ X⊑X (CTX.impEnvʷ W)
+        (toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ) ≡ X⊑★
+    → lookupStore (store-bind (CTX.sourceStoreʷ W) A) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (keep (CTX.ηᴿʷ W)) Xᴿ
+      ≢ toRenameᵗ (keep (CTX.ηᴸʷ W)) Xᴸ
+  unoccupied Fin.zero () entry Xᴿ aligned
+  unoccupied (Fin.suc Xᴸ) mark entry Fin.zero ()
+  unoccupied (Fin.suc Xᴸ) mark entry (Fin.suc Xᴿ) aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark (unshift-star entry) Xᴿ
+      (fin-suc-injective aligned)
+
 
 parked-initial-invariants : ∀ {Δ} {μ : ImpEnv Δ} {Σ : TyStore Δ}
+  → (∀ X
+      → μ (toRenameᵗ id↪ᵗ X) ≡ X⊑★
+      → lookupStore Σ X ≡ ★
+      → ∀ Y
+      → toRenameᵗ id↪ᵗ Y ≢ toRenameᵗ id↪ᵗ X)
   → WorldInvariants (CPI2.initialWorld μ Σ)
-parked-initial-invariants {μ = μ} {Σ = Σ} = identityWorld-invariants μ Σ
+parked-initial-invariants {μ = μ} {Σ = Σ} =
+  identityWorld-invariants μ Σ
 
 parked-both-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ} {B : Ty Δᴿ}
@@ -603,7 +750,7 @@ parked-both-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (CTX.bothBindWorld X⊑X W A B)
 parked-both-bind-invariants {A = A} {B = B} =
-  bothBindWorld-invariants X⊑X A B
+  bothBindWorld-invariants X⊑X A B refl
 
 parked-left-bind-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ} {A : Ty Δᴸ}
@@ -647,7 +794,7 @@ renameWorld-invariants : ∀ {Δᴸ Δᴿ Δ Δ′}
   → WorldInvariants W
   → WorldInvariants (CR.renameWorld π W)
 renameWorld-invariants {W = W} π inv =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → CR.renameEnv π (CTX.impEnvʷ W)
@@ -719,17 +866,48 @@ renameWorld-invariants {W = W} π inv =
             (trans aligned
               (CR.toRenameᵗ-∘ π (CTX.ηᴿʷ W) Yᴿ))))
 
+  unoccupied : ∀ Xᴸ
+    → CR.renameEnv π (CTX.impEnvʷ W)
+        (toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (π CR.∘↪ CTX.ηᴿʷ W) Xᴿ
+      ≢ toRenameᵗ (π CR.∘↪ CTX.ηᴸʷ W) Xᴸ
+  unoccupied Xᴸ mark entry Xᴿ aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ old-mark entry Xᴿ
+      (sym old-aligned)
+    where
+    old-mark :
+      CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    old-mark = trans
+      (sym (CR.renameEnv-image π (CTX.impEnvʷ W)
+        (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)))
+      (trans (cong (CR.renameEnv π (CTX.impEnvʷ W))
+        (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))) mark)
+
+    old-aligned : CenterAligned W Xᴸ Xᴿ
+    old-aligned = toRenameᵗ-injective π
+      (trans (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))
+        (trans (sym aligned)
+          (CR.toRenameᵗ-∘ π (CTX.ηᴿʷ W) Xᴿ)))
+
 
 decay-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W Wᵈ : CTX.World Δᴸ Δᴿ Δ}
   → WD.EnvDecay W Wᵈ
   → WorldInvariants W
+  → (∀ Xᴸ
+      → CTX.impEnvʷ Wᵈ (toRenameᵗ (CTX.ηᴸʷ Wᵈ) Xᴸ) ≡ X⊑★
+      → lookupStore (CTX.sourceStoreʷ Wᵈ) Xᴸ ≡ ★
+      → ∀ Xᴿ
+      → toRenameᵗ (CTX.ηᴿʷ Wᵈ) Xᴿ
+        ≢ toRenameᵗ (CTX.ηᴸʷ Wᵈ) Xᴸ)
   → WorldInvariants Wᵈ
 decay-invariants
     {W = CTX.world ηᴸ ηᴿ μ Σᴸ Σᴿ}
     {Wᵈ = CTX.world .ηᴸ .ηᴿ μᵈ .Σᴸ .Σᴿ}
-    (WD.env-decay refl refl refl refl mono) inv =
-  world-invariants precise reps (unmatchedTargetsDynamic inv)
+    (WD.env-decay refl refl refl refl mono) inv unoccupied =
+  world-invariants precise reps (unmatchedTargetsDynamic inv) unoccupied
   where
   precise : ∀ Xᴸ
     → μᵈ (toRenameᵗ ηᴸ Xᴸ) ≡ X⊑X
@@ -751,6 +929,13 @@ decay-invariants
 blendWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W′ Wᵈ : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W′
+  → (∀ Xᴸ
+      → CTX.impEnvʷ (WD.blendWorld W′ Wᵈ)
+          (toRenameᵗ (CTX.ηᴸʷ (WD.blendWorld W′ Wᵈ)) Xᴸ) ≡ X⊑★
+      → lookupStore (CTX.sourceStoreʷ (WD.blendWorld W′ Wᵈ)) Xᴸ ≡ ★
+      → ∀ Xᴿ
+      → toRenameᵗ (CTX.ηᴿʷ (WD.blendWorld W′ Wᵈ)) Xᴿ
+        ≢ toRenameᵗ (CTX.ηᴸʷ (WD.blendWorld W′ Wᵈ)) Xᴸ)
   → WorldInvariants (WD.blendWorld W′ Wᵈ)
 blendWorld-invariants {W′ = W′} {Wᵈ = Wᵈ} =
   decay-invariants (WD.blend-decay {W′ = W′} {Wᵈ = Wᵈ})
@@ -759,13 +944,35 @@ honestify-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W
   → WorldInvariants (WD.honestify W)
-honestify-invariants {W = W} = decay-invariants (WD.honestify-decay {W = W})
+honestify-invariants {W = W} inv =
+  decay-invariants (WD.honestify-decay {W = W}) inv unoccupied
+  where
+  unoccupied : ∀ Xᴸ
+    → WD.honestEnv (CTX.ηᴿʷ W) (CTX.impEnvʷ W)
+        (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
+  unoccupied Xᴸ mark entry Xᴿ aligned
+      with WD.alignedᴿ? (CTX.ηᴿʷ W)
+        (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)
+  unoccupied Xᴸ mark entry Xᴿ aligned | yes (Yᴿ , occupied) =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark entry Xᴿ aligned
+  unoccupied Xᴸ mark entry Xᴿ aligned | no no-target =
+    no-target (Xᴿ , aligned)
 
 dynWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ}
   → WorldInvariants W
+  → (∀ Xᴸ
+      → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+      → CTX.NoTargetOccupantAtSource W Xᴸ)
   → WorldInvariants (SPT.dynWorld W)
-dynWorld-invariants {W = W} = decay-invariants (SPT.dynWorld-decay W)
+dynWorld-invariants {W = W} inv no-dynamic-source =
+  decay-invariants (SPT.dynWorld-decay W) inv
+    (λ Xᴸ mark entry Xᴿ aligned →
+      no-dynamic-source Xᴸ entry (Xᴿ , aligned))
 
 
 targetStoreAs-invariants : ∀ {Δᴸ Δᴿ Δ}
@@ -791,6 +998,7 @@ targetStoreAs-invariants : ∀ {Δᴸ Δᴿ Δ}
   → WorldInvariants (TBL.targetStoreAs W Σᴿ)
 targetStoreAs-invariants Σᴿ inv reps unmatched =
   world-invariants (preciseMarksAligned inv) reps unmatched
+    (dynamicStarSourcesUnoccupied inv)
 
 
 record TargetInsertDirect {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
@@ -827,7 +1035,7 @@ targetInsert-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
   → WorldInvariants W′
 targetInsert-invariants
     {ρ = ρ} {π = π} {W = W} {W′ = W′} ins direct inv =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → CTX.impEnvʷ W′ (toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ) ≡ X⊑X
@@ -929,6 +1137,31 @@ targetInsert-invariants
         head-no-source Xᴸ
           (subst≡ (CTX.CenterAligned W Xᴸ)
             (sym (toRenameᵗ-injective ρ mapped-eq)) old-aligned)
+
+  unoccupied : ∀ Xᴸ
+    → CTX.impEnvʷ W′ (toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ W′) Xᴸ ≡ ★
+    → ∀ Xᴿ′
+    → toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′
+      ≢ toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ
+  unoccupied Xᴸ mark entry Xᴿ′ aligned
+      with TE.target-source-reflect ins (sym aligned)
+  unoccupied Xᴸ mark entry Xᴿ′ aligned
+      | Xᴿ , Xᴿ′-eq , old-aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ old-mark old-entry Xᴿ
+      (sym old-aligned)
+    where
+    old-mark :
+      CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    old-mark = trans
+      (sym (TE.impEnv-insert ins (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)))
+      (trans
+        (cong (CTX.impEnvʷ W′) (sym (TE.source-insert ins Xᴸ))) mark)
+
+    old-entry : lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+    old-entry = trans
+      (sym (cong (λ Σ → lookupStore Σ Xᴸ) (TE.sourceStore-kept ins)))
+      entry
 
 
 parked-structural-right-insert-invariants : ∀ {Δᴸ Δᴿ Δ Δ₁}
@@ -1191,9 +1424,6 @@ smartAliasTargetInsert-direct {ρ = ρ} {π = π} {W = W} {Wᵐ = Wᵐ}
         (trans (cong (lookupStore (CTX.targetStoreʷ W)) β-equals-α)
           α-entry)
 
-    variable≢star : ＇ α ≢ ★
-    variable≢star ()
-
   fresh-entry : ∀ Xᴿ′
     → CR.preimage? π
         (toRenameᵗ
@@ -1452,7 +1682,7 @@ insertRebaseWorld-invariants ins rb direct off-entry inv =
 example12-left-path-world-X-invariants :
   WorldInvariants Ex12.example12-left-path-world-X
 example12-left-path-world-X-invariants =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → CTX.impEnvʷ Ex12.example12-left-path-world-X
@@ -1495,11 +1725,24 @@ example12-left-path-world-X-invariants =
             → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
 
+  unoccupied : ∀ Xᴸ
+    → CTX.impEnvʷ Ex12.example12-left-path-world-X
+        (toRenameᵗ
+          (CTX.ηᴸʷ Ex12.example12-left-path-world-X) Xᴸ) ≡ X⊑★
+    → lookupStore
+        (CTX.sourceStoreʷ Ex12.example12-left-path-world-X) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-X) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-X) Xᴸ
+  unoccupied Fin.zero mark () Xᴿ aligned
+  unoccupied (Fin.suc Fin.zero) mark () Xᴿ aligned
+  unoccupied (Fin.suc (Fin.suc Fin.zero)) mark entry Fin.zero ()
+
 
 example12-left-path-world-Y-invariants :
   WorldInvariants Ex12.example12-left-path-world-Y
 example12-left-path-world-Y-invariants =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → CTX.impEnvʷ Ex12.example12-left-path-world-Y
@@ -1543,11 +1786,24 @@ example12-left-path-world-Y-invariants =
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc Fin.zero) refl)
 
+  unoccupied : ∀ Xᴸ
+    → CTX.impEnvʷ Ex12.example12-left-path-world-Y
+        (toRenameᵗ
+          (CTX.ηᴸʷ Ex12.example12-left-path-world-Y) Xᴸ) ≡ X⊑★
+    → lookupStore
+        (CTX.sourceStoreʷ Ex12.example12-left-path-world-Y) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-Y) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Y) Xᴸ
+  unoccupied Fin.zero mark () Xᴿ aligned
+  unoccupied (Fin.suc Fin.zero) mark () Xᴿ aligned
+  unoccupied (Fin.suc (Fin.suc Fin.zero)) mark entry Fin.zero ()
+
 
 example12-left-path-world-Z-invariants :
   WorldInvariants Ex12.example12-left-path-world-Z
 example12-left-path-world-Z-invariants =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → CTX.impEnvʷ Ex12.example12-left-path-world-Z
@@ -1559,7 +1815,7 @@ example12-left-path-world-Z-invariants =
           ≡ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Z) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Fin.zero) ()
-  precise (Fin.suc (Fin.suc Fin.zero)) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) mark = Fin.zero , refl
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
     → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
@@ -1591,10 +1847,23 @@ example12-left-path-world-Z-invariants =
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
 
+  unoccupied : ∀ Xᴸ
+    → CTX.impEnvʷ Ex12.example12-left-path-world-Z
+        (toRenameᵗ
+          (CTX.ηᴸʷ Ex12.example12-left-path-world-Z) Xᴸ) ≡ X⊑★
+    → lookupStore
+        (CTX.sourceStoreʷ Ex12.example12-left-path-world-Z) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTX.ηᴿʷ Ex12.example12-left-path-world-Z) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Z) Xᴸ
+  unoccupied Fin.zero mark () Xᴿ aligned
+  unoccupied (Fin.suc Fin.zero) mark () Xᴿ aligned
+  unoccupied (Fin.suc (Fin.suc Fin.zero)) () entry Xᴿ aligned
+
 
 examples2-left-path-world₃-invariants : WorldInvariants Ex2.left-path-world₃
 examples2-left-path-world₃-invariants =
-  world-invariants precise reps unmatched
+  world-invariants precise reps unmatched unoccupied
   where
   precise : ∀ Xᴸ
     → CTX.impEnvʷ Ex2.left-path-world₃
@@ -1604,7 +1873,8 @@ examples2-left-path-world₃-invariants =
           ≡ toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃) Xᴸ
   precise Fin.zero ()
   precise (Fin.suc Fin.zero) ()
-  precise (Fin.suc (Fin.suc Fin.zero)) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) mark =
+    Fin.suc Fin.zero , refl
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 2}
     → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ
@@ -1630,6 +1900,17 @@ examples2-left-path-world₃-invariants =
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
   unmatched (Fin.suc Fin.zero) no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
+
+  unoccupied : ∀ Xᴸ
+    → CTX.impEnvʷ Ex2.left-path-world₃
+        (toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ Ex2.left-path-world₃) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTX.ηᴿʷ Ex2.left-path-world₃) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃) Xᴸ
+  unoccupied Fin.zero mark () Xᴿ aligned
+  unoccupied (Fin.suc Fin.zero) mark () Xᴿ aligned
+  unoccupied (Fin.suc (Fin.suc Fin.zero)) () entry Xᴿ aligned
 
 examples2-left-path-world₄-invariants : WorldInvariants Ex2.left-path-world₄
 examples2-left-path-world₄-invariants =

--- a/GTSFImp/proof/DGG/WorldInvariants.agda
+++ b/GTSFImp/proof/DGG/WorldInvariants.agda
@@ -89,14 +89,6 @@ record WorldInvariants {Δᴸ Δᴿ Δ}
 open WorldInvariants public
 
 
-CenterAligned : ∀ {Δᴸ Δᴿ Δ}
-  → CTX.World Δᴸ Δᴿ Δ
-  → TyVar Δᴸ
-  → TyVar Δᴿ
-  → Set
-CenterAligned W Xᴸ Xᴿ =
-  toRenameᵗ (CTX.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
-
 imprecision-cong : ∀ {Δ} {μ : ImpEnv Δ} {A A′ B B′ : Ty Δ}
   → A ≡ A′
   → B ≡ B′
@@ -113,10 +105,10 @@ variableEntryChainCoherence : ∀ {Δᴸ Δᴿ Δ}
     {W : CTX.World Δᴸ Δᴿ Δ}
     {Xᴸ Yᴸ : TyVar Δᴸ} {Xᴿ Yᴿ : TyVar Δᴿ}
   → WorldInvariants W
-  → CenterAligned W Xᴸ Xᴿ
+  → CTX.CenterAligned W Xᴸ Xᴿ
   → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ＇ Yᴸ
   → lookupStore (CTX.targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ
-  → CenterAligned W Yᴸ Yᴿ
+  → CTX.CenterAligned W Yᴸ Yᴿ
     × (CTX.impEnvʷ W ⊢
         renameᵗ (toRenameᵗ (CTX.ηᴸʷ W))
           (lookupStore (CTX.sourceStoreʷ W) Yᴸ)
@@ -126,7 +118,7 @@ variableEntryChainCoherence {W = W} {Yᴸ = Yᴸ} {Yᴿ = Yᴿ}
     inv aligned source-entry target-entry =
   heads-aligned , representationsImprecise inv heads-aligned
   where
-  heads-aligned : CenterAligned W Yᴸ Yᴿ
+  heads-aligned : CTX.CenterAligned W Yᴸ Yᴿ
   heads-aligned = variableHeadsAlign
     (imprecision-cong
       (cong (renameᵗ (toRenameᵗ (CTX.ηᴸʷ W))) source-entry)
@@ -830,7 +822,7 @@ renameWorld-invariants {W = W} π inv =
       {B = lookupStore (CTX.targetStoreʷ W) Xᴿ}
       π (representationsImprecise inv old-aligned)
     where
-    old-aligned : CenterAligned W Xᴸ Xᴿ
+    old-aligned : CTX.CenterAligned W Xᴸ Xᴿ
     old-aligned = toRenameᵗ-injective π
       (trans (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))
         (trans aligned
@@ -885,7 +877,7 @@ renameWorld-invariants {W = W} π inv =
       (trans (cong (CR.renameEnv π (CTX.impEnvʷ W))
         (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))) mark)
 
-    old-aligned : CenterAligned W Xᴸ Xᴿ
+    old-aligned : CTX.CenterAligned W Xᴸ Xᴿ
     old-aligned = toRenameᵗ-injective π
       (trans (sym (CR.toRenameᵗ-∘ π (CTX.ηᴸʷ W) Xᴸ))
         (trans (sym aligned)
@@ -1697,7 +1689,7 @@ example12-left-path-world-X-invariants =
   precise (Fin.suc (Fin.suc Fin.zero)) ()
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
-    → CenterAligned Ex12.example12-left-path-world-X Xᴸ Xᴿ
+    → CTX.CenterAligned Ex12.example12-left-path-world-X Xᴸ Xᴿ
     → CTX.impEnvʷ Ex12.example12-left-path-world-X ⊢
         renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-X))
           (lookupStore
@@ -1712,7 +1704,7 @@ example12-left-path-world-X-invariants =
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → CenterAligned Ex12.example12-left-path-world-X Xᴸ Xᴿ
+        → CTX.CenterAligned Ex12.example12-left-path-world-X Xᴸ Xᴿ
         → ⊥)
     → lookupStore (CTX.targetStoreʷ Ex12.example12-left-path-world-X) Xᴿ
         ≡ ★
@@ -1721,7 +1713,7 @@ example12-left-path-world-X-invariants =
             (CTX.targetStoreʷ Ex12.example12-left-path-world-X) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CenterAligned Ex12.example12-left-path-world-X Xᴸ Yᴿ
+            → CTX.CenterAligned Ex12.example12-left-path-world-X Xᴸ Yᴿ
             → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
 
@@ -1757,7 +1749,7 @@ example12-left-path-world-Y-invariants =
   precise (Fin.suc (Fin.suc Fin.zero)) ()
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
-    → CenterAligned Ex12.example12-left-path-world-Y Xᴸ Xᴿ
+    → CTX.CenterAligned Ex12.example12-left-path-world-Y Xᴸ Xᴿ
     → CTX.impEnvʷ Ex12.example12-left-path-world-Y ⊢
         renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Y))
           (lookupStore
@@ -1772,7 +1764,7 @@ example12-left-path-world-Y-invariants =
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → CenterAligned Ex12.example12-left-path-world-Y Xᴸ Xᴿ
+        → CTX.CenterAligned Ex12.example12-left-path-world-Y Xᴸ Xᴿ
         → ⊥)
     → lookupStore (CTX.targetStoreʷ Ex12.example12-left-path-world-Y) Xᴿ
         ≡ ★
@@ -1781,7 +1773,7 @@ example12-left-path-world-Y-invariants =
             (CTX.targetStoreʷ Ex12.example12-left-path-world-Y) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CenterAligned Ex12.example12-left-path-world-Y Xᴸ Yᴿ
+            → CTX.CenterAligned Ex12.example12-left-path-world-Y Xᴸ Yᴿ
             → ⊥)
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc Fin.zero) refl)
@@ -1818,7 +1810,7 @@ example12-left-path-world-Z-invariants =
   precise (Fin.suc (Fin.suc Fin.zero)) mark = Fin.zero , refl
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 1}
-    → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
+    → CTX.CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
     → CTX.impEnvʷ Ex12.example12-left-path-world-Z ⊢
         renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex12.example12-left-path-world-Z))
           (lookupStore
@@ -1833,7 +1825,7 @@ example12-left-path-world-Z-invariants =
 
   unmatched : ∀ Xᴿ
     → (∀ Xᴸ
-        → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
+        → CTX.CenterAligned Ex12.example12-left-path-world-Z Xᴸ Xᴿ
         → ⊥)
     → lookupStore (CTX.targetStoreʷ Ex12.example12-left-path-world-Z) Xᴿ
         ≡ ★
@@ -1842,7 +1834,7 @@ example12-left-path-world-Z-invariants =
             (CTX.targetStoreʷ Ex12.example12-left-path-world-Z) Xᴿ
             ≡ ＇ Yᴿ)
         × (∀ Xᴸ
-            → CenterAligned Ex12.example12-left-path-world-Z Xᴸ Yᴿ
+            → CTX.CenterAligned Ex12.example12-left-path-world-Z Xᴸ Yᴿ
             → ⊥)
   unmatched Fin.zero no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
@@ -1877,7 +1869,7 @@ examples2-left-path-world₃-invariants =
     Fin.suc Fin.zero , refl
 
   reps : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 2}
-    → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ
+    → CTX.CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ
     → CTX.impEnvʷ Ex2.left-path-world₃ ⊢
         renameᵗ (toRenameᵗ (CTX.ηᴸʷ Ex2.left-path-world₃))
           (lookupStore (CTX.sourceStoreʷ Ex2.left-path-world₃) Xᴸ)
@@ -1891,12 +1883,12 @@ examples2-left-path-world₃-invariants =
   reps {Fin.suc (Fin.suc Fin.zero)} {Fin.suc Fin.zero} refl = ★⊑★
 
   unmatched : ∀ Xᴿ
-    → (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ → ⊥)
+    → (∀ Xᴸ → CTX.CenterAligned Ex2.left-path-world₃ Xᴸ Xᴿ → ⊥)
     → lookupStore (CTX.targetStoreʷ Ex2.left-path-world₃) Xᴿ ≡ ★
       ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
           (lookupStore (CTX.targetStoreʷ Ex2.left-path-world₃) Xᴿ
             ≡ ＇ Yᴿ)
-        × (∀ Xᴸ → CenterAligned Ex2.left-path-world₃ Xᴸ Yᴿ → ⊥)
+        × (∀ Xᴸ → CTX.CenterAligned Ex2.left-path-world₃ Xᴸ Yᴿ → ⊥)
   unmatched Fin.zero no-source = ⊥-elim (no-source Fin.zero refl)
   unmatched (Fin.suc Fin.zero) no-source =
     ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)

--- a/GTSFImp/proof/DGG/notes/D16StrictFallback.md
+++ b/GTSFImp/proof/DGG/notes/D16StrictFallback.md
@@ -1,0 +1,58 @@
+# D16 strict fallback record
+
+Date: 2026-08-18
+
+The strict form of `unmatchedTargetsDynamic` was tested at the live
+target-`Λ` minting site before changing the invariant.  In
+`spine-typed-Λ-child`, the child world is
+`rightOnlyWorld W (＇ X)`.  Its newly allocated target entry is used directly
+by both
+
+`structural-reveal-typing B (Z∋ refl)`
+
+and
+
+`spine-typed-map-bindʷ (＇ X) refl typed`.
+
+Thus the fresh target lookup must satisfy
+
+$$
+\mathsf{lookupStore}\;(\mathsf{storeBind}\;\Sigma^R\;(\mathord{\＇}X))\;0
+  = \mathord{\＇}(\mathsf{suc}\;X),
+$$
+
+not `★`.  This is operational rather than a proof-only alias: the same site
+maps the child spine through `bind (＇ X)` and transports its type with
+`replace-zero-open B (＇ X)`.
+
+## Strict flattening test
+
+For the test, only the two child-world occurrences in
+`spine-typed-Λ-child` were changed temporarily from
+`rightOnlyWorld W (＇ X)` to `rightOnlyWorld W ★`; the conversion and spine
+were deliberately left unchanged.  Agda 2.8 rejected
+`structural-reveal-typing B (Z∋ refl)` with exit code 42:
+
+> `(＇ Fin.suc X) != ★` when checking that `refl` has type
+> `⇑ᵗ (＇ X) ≡ ⇑ᵗ ★`.
+
+The source edit was then restored.  Flattening the entry would change the
+instantiated endpoint from `B [ ＇ X ]ᵗ` to `B [ ★ ]ᵗ`, so it cannot
+preserve this reduction/type derivation.
+
+## Concrete `★`-then-`＇0` route
+
+The concrete route occurs as
+
+`rightOnlyWorld (rightOnlyWorld W ★) (＇ Fin.zero)`
+
+with store changes `bind ★ ∷ bind (＇ Fin.zero) ∷ []`, notably in
+`InstInversionDef`, `InstInversionProof`, `InstInversionLambdaProof`, and
+`TargetBindLift`.  Its second entry is the same required variable-indirection
+shape.  Here `＇ Fin.zero` points to the immediately preceding unmatched `★`
+entry, so this route satisfies the chain-permissive fallback exactly.
+
+Conclusion: the recorded live minting site genuinely requires variable
+indirection.  D16 stage 1 must use the previously specified chain-permissive
+fallback for unmatched target entries: a direct `★`, or a direct variable
+whose target head is itself unmatched.

--- a/GTSFImp/proof/DGG/notes/D16StrictFallback.md
+++ b/GTSFImp/proof/DGG/notes/D16StrictFallback.md
@@ -56,3 +56,10 @@ Conclusion: the recorded live minting site genuinely requires variable
 indirection.  D16 stage 1 must use the previously specified chain-permissive
 fallback for unmatched target entries: a direct `★`, or a direct variable
 whose target head is itself unmatched.
+
+This does not validate the unrestricted generic `rightOnlyWorld W (＇ X)`
+surface.  The fallback additionally requires old `X` to be unmatched, and
+`spine-typed-Λ-child` plus the structural target `Λ`/conversion/`gen` sites do
+not currently expose that fact.  Stage 1 therefore leaves the classification
+as an explicit builder premise; stage 2 must either supply it at each caller
+or redesign that generic allocation surface.

--- a/GTSFImp/proof/DGG/notes/d16-5b-paired-seal-first-try.red
+++ b/GTSFImp/proof/DGG/notes/d16-5b-paired-seal-first-try.red
@@ -1,0 +1,37 @@
+# D16 Stage 2: 5b paired-seal first-try exception
+
+Date: 2026-08-19
+
+## Verdict
+
+The live YZ paired-seal derivation worlds in `proof/DGG/Examples2.agda`
+genuinely require the matched Z center to retain the `X⊑★` mark.  They cannot
+be recalibrated to `X⊑X` without changing the intermediate type-imprecision
+judgment.  Invariant (5) is not weakened; these worlds are left outside the
+`WorldInvariants` companion.
+
+The XZ calibration worlds do not use the dynamic matched-Z judgments.  Their
+matched Z cell now carries `X⊑X`, and their companion proofs remain live.
+
+## Checked sites
+
+In `left-path-target-Z-revealed₃-YZ`, the target-only reveal step uses
+`CTI2.⊑reveal²` and has the intermediate conclusion
+
+`＇ Zᴸ ⊑ᵂ⟨ left-path-world₃-YZ ⟩ ★`.
+
+This is witnessed by `left-path-Z-var⊑★-YZ₃`, whose only applicable variable
+rule requires
+
+`impEnvʷ left-path-world₃-YZ Z ≡ X⊑★`.
+
+The same requirement recurs in `left-path-target-Z-revealed₈-YZ`,
+`left-path-target-Z-unsealed₉-YZ`, and
+`left-path-target-Z-unsealed₁₀-YZ`, through
+`left-path-Z-var⊑★-YZ₄`.  These are whole-term paired-seal/reveal derivation
+checkpoints, not unused calibration lemmas.
+
+Changing the matched Z mark to `X⊑X` makes Agda reject the first witness with
+`X⊑X != X⊑★`.  The tested edit was replaced by separate XZ and YZ environments:
+the valid XZ worlds use `X⊑X`, while the live YZ derivation worlds retain
+`X⊑★`.

--- a/GTSFImp/proof/DGG/notes/d16-5b-paired-seal-first-try.red
+++ b/GTSFImp/proof/DGG/notes/d16-5b-paired-seal-first-try.red
@@ -1,37 +1,561 @@
-# D16 Stage 2: 5b paired-seal first-try exception
+# D16 Stage 2: 5b paired-seal first-try exception and 5c recalibration
 
 Date: 2026-08-19
 
-## Verdict
+## Decision status
 
-The live YZ paired-seal derivation worlds in `proof/DGG/Examples2.agda`
-genuinely require the matched Z center to retain the `X⊑★` mark.  They cannot
-be recalibrated to `X⊑X` without changing the intermediate type-imprecision
-judgment.  Invariant (5) is not weakened; these worlds are left outside the
-`WorldInvariants` companion.
+The live YZ paired-seal derivations require a variable-to-dynamic type
+judgment at the matched Z center.  With the live type-imprecision relation,
+that judgment is derivable exactly when the Z center is marked `X⊑★`.
+Changing only that mark to `X⊑X` therefore breaks four live whole-term
+derivations.
 
-The XZ calibration worlds do not use the dynamic matched-Z judgments.  Their
-matched Z cell now carries `X⊑X`, and their companion proofs remain live.
+There is nevertheless a real recalibration design available: make
+variable-to-dynamic imprecision store-mediated.  At this fixture the source Z
+cell directly contains `★`, so such a rule derives `＇ Zᴸ ⊑ ★` while the center
+remains `X⊑X`; the recalibrated world then satisfies all four landed
+`WorldInvariants` fields, including invariant (5).  This is a relation redesign,
+not a fixture-only edit.  Its global proof cost and semantic admissibility have
+not been established.
 
-## Checked sites
+A seal-boundary mark-transition exception also reconstructs the local type
+step, but its conclusion world restores `X⊑★` at an occupied source-`★` center.
+That world is rejected by invariant (5), so this candidate does not solve 5c.
+A raw rule allowing every `X⊑X` variable to relate to `★` is too broad and is
+rejected below.
 
-In `left-path-target-Z-revealed₃-YZ`, the target-only reveal step uses
-`CTI2.⊑reveal²` and has the intermediate conclusion
+No live relation or proof module was changed.  The checked probe is
+`proof/DGG/notes/probes/D16PairedSealRecalibrationProbe.agda`.
 
-`＇ Zᴸ ⊑ᵂ⟨ left-path-world₃-YZ ⟩ ★`.
+## Self-contained YZ paired-seal fixture
 
-This is witnessed by `left-path-Z-var⊑★-YZ₃`, whose only applicable variable
-rule requires
+### Names and indices
 
-`impEnvʷ left-path-world₃-YZ Z ≡ X⊑★`.
+The source has three cells and the target has two.  These are the variable
+names used below:
 
-The same requirement recurs in `left-path-target-Z-revealed₈-YZ`,
-`left-path-target-Z-unsealed₉-YZ`, and
-`left-path-target-Z-unsealed₁₀-YZ`, through
-`left-path-Z-var⊑★-YZ₄`.  These are whole-term paired-seal/reveal derivation
-checkpoints, not unused calibration lemmas.
+| Side | Name | Agda index |
+| --- | --- | --- |
+| source | `Xᴸ` | `Fin.zero` |
+| source | `Yᴸ` | `Fin.suc Fin.zero` |
+| source | `Zᴸ` | `Fin.suc (Fin.suc Fin.zero)` |
+| target | `Yᴿ` | `Fin.zero` |
+| target | `Zᴿ` | `Fin.suc Fin.zero` |
 
-Changing the matched Z mark to `X⊑X` makes Agda reject the first witness with
-`X⊑X != X⊑★`.  The tested edit was replaced by separate XZ and YZ environments:
-the valid XZ worlds use `X⊑X`, while the live YZ derivation worlds retain
-`X⊑★`.
+The shared center also has three cells, named X, Y, and Z at `Fin.zero`,
+`Fin.suc Fin.zero`, and `Fin.suc (Fin.suc Fin.zero)` respectively.
+
+### Full stores
+
+Here is the complete constructor data.  `Examples2` stores these behind
+`store-after`; the four expansion equalities
+`examples2-source-store₃-expanded`, `examples2-source-store₄-expanded`,
+`examples2-target-store₃-expanded`, and
+`examples2-target-store₄-expanded` are all checked by `refl`.
+
+```agda
+-- Source cells after lookup in the final three-cell scope:
+--   Xᴸ = Fin.zero                         ↦ ‵ `ℕ
+--   Yᴸ = Fin.suc Fin.zero               ↦ ＇ Zᴸ
+--   Zᴸ = Fin.suc (Fin.suc Fin.zero)     ↦ ★
+yz-source-store : TyStore 3
+yz-source-store =
+  store-bind (store-bind (store-bind store-empty ★) (＇ Fin.zero)) (‵ `ℕ)
+
+-- Target cells after lookup in the final two-cell scope:
+--   Yᴿ = Fin.zero                       ↦ ＇ Zᴿ
+--   Zᴿ = Fin.suc Fin.zero               ↦ ★
+yz-target-store : TyStore 2
+yz-target-store = store-bind (store-bind store-empty ★) (＇ Fin.zero)
+```
+
+Thus the direct store data is:
+
+```text
+sourceStore[Xᴸ] = ‵ `ℕ       targetStore has no X cell
+sourceStore[Yᴸ] = ＇ Zᴸ      targetStore[Yᴿ] = ＇ Zᴿ
+sourceStore[Zᴸ] = ★          targetStore[Zᴿ] = ★
+```
+
+`left-path-world₃-YZ` uses `Ex.right-store₃` and
+`left-path-target-store₃`; `left-path-world₄-YZ` uses the corresponding
+stage-4 names.  Both pairs reduce definitionally to the two stores above.
+The reduction from checkpoint 3 to checkpoint 4 changes the term, not either
+store.
+
+### Full embeddings
+
+The source embedding is identity on the three centers.  The target embedding
+skips the unmatched X center:
+
+```agda
+yz-source-η : 3 ↪ᵗ 3
+yz-source-η = keep (keep (keep empty))
+
+yz-target-η : 2 ↪ᵗ 3
+yz-target-η = skip (keep (keep empty))
+```
+
+Consequently:
+
+```text
+toRenameᵗ yz-source-η Xᴸ = X
+toRenameᵗ yz-source-η Yᴸ = Y
+toRenameᵗ yz-source-η Zᴸ = Z
+
+toRenameᵗ yz-target-η Yᴿ = Y
+toRenameᵗ yz-target-η Zᴿ = Z
+```
+
+The live `Examples2` spelling is verbatim:
+
+```agda
+left-path-target-ηᴿ-YZ : 2 ↪ᵗ 3
+left-path-target-ηᴿ-YZ = skip id↪ᵗ
+
+left-path-world₃-YZ =
+  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-YZ
+    Ex.right-store₃ left-path-target-store₃
+
+left-path-world₄-YZ =
+  world id↪ᵗ left-path-target-ηᴿ-YZ left-path-imp-env-YZ
+    Ex.right-store₄ left-path-target-store₄
+```
+
+### Full imprecision environment
+
+The live environment is:
+
+```agda
+left-path-imp-env-YZ : ImpEnv 3
+left-path-imp-env-YZ Fin.zero = X⊑★
+left-path-imp-env-YZ (Fin.suc Fin.zero) = X⊑★
+left-path-imp-env-YZ (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+```
+
+The proposed recalibration changes only the last equation:
+
+```agda
+yz-precise-Z-env : ImpEnv 3
+yz-precise-Z-env Fin.zero = X⊑★
+yz-precise-Z-env (Fin.suc Fin.zero) = X⊑★
+yz-precise-Z-env (Fin.suc (Fin.suc Fin.zero)) = X⊑X
+```
+
+Diagram:
+
+    source store             shared center / mark              target store
+
+    Xᴸ : ‵ `ℕ  ----------->  X : X⊑★
+
+    Yᴸ : ＇ Zᴸ  ----------->  Y : X⊑★  <-----------  Yᴿ : ＇ Zᴿ
+          |                                             |
+          | direct alias                                | direct alias
+          v                                             v
+    Zᴸ : ★     ----------->  Z : X⊑★  <-----------  Zᴿ : ★
+                                  |
+                                  `-- 5c proposal: X⊑X
+
+The Y and Z pairs are center-aligned.  X is source-only.  In particular, Z is
+not an unmatched source cell: invariant (5) rejects the live Z data because it
+combines source entry `★`, center mark `X⊑★`, and the aligned target occupant
+`Zᴿ`.
+
+## The forcing chain
+
+The forcing point occurs once in `left-path-world₃-YZ` and is then reused at
+three checkpoint families in `left-path-world₄-YZ`.  `Imprecision.X⊑X` is
+unconditional, so the variable-to-variable steps below do not inspect the
+center mark.  Only the variable-to-`★` step does.
+
+### Checkpoint 3: paired Y reveal, then target-only Z reveal
+
+The live type-imprecision chain is:
+
+```text
+＇ Yᴸ ⊑ᵂ⟨ left-path-world₃-YZ ⟩ ＇ Yᴿ
+  left-path-Y-var⊑YZ₃
+
+(＇ Yᴸ ⇒ ＇ Yᴸ)
+  ⊑ᵂ⟨ left-path-world₃-YZ ⟩
+(＇ Yᴿ ⇒ ＇ Yᴿ)
+  left-path-Y⇒Y⊑Y⇒Y-YZ₃
+
+(＇ Zᴸ ⇒ ＇ Zᴸ)
+  ⊑ᵂ⟨ left-path-world₃-YZ ⟩
+(＇ Zᴿ ⇒ ＇ Zᴿ)
+  left-path-Z⇒Z⊑Z⇒Z-YZ₃
+```
+
+The second judgment is the lambda relation.  The paired Y reveal changes its
+endpoint types from Y to the direct store entries Z, producing the third
+judgment.  The target then reveals `Zᴿ`, whose store entry is `★`.  Its two
+function components require two copies of:
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₃-YZ ⟩ ★
+  left-path-Z-var⊑★-YZ₃
+```
+
+Those two leaves feed:
+
+```text
+(＇ Zᴸ ⇒ ＇ Zᴸ)
+  ⊑ᵂ⟨ left-path-world₃-YZ ⟩
+(★ ⇒ ★)
+  left-path-Z⇒Z⊑★⇒★-YZ₃
+```
+
+That final type judgment is the conclusion index supplied to
+`CTI2.⊑reveal²` by `left-path-target-Z-revealed₃-YZ`.
+
+### Checkpoint 8: paired Z seal, then target-only Z unseal
+
+The stage-4 shared prelude is:
+
+```text
+＇ Yᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Yᴿ
+  left-path-Y-var⊑YZ₄
+
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Zᴿ
+  left-path-Z-var⊑YZ₄
+
+(＇ Zᴸ ⇒ ＇ Zᴸ)
+  ⊑ᵂ⟨ left-path-world₄-YZ ⟩
+(＇ Zᴿ ⇒ ＇ Zᴿ)
+  left-path-Z⇒Z⊑Z⇒Z-YZ₄
+```
+
+The paired Z seals in `left-path-argument-Z₈-YZ` retain
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Zᴿ.
+```
+
+Application with `left-path-Y-revealed₄-YZ` makes
+`left-path-application₈-YZ`, also indexed by
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Zᴿ.
+```
+
+The target-only Z unseal then requires:
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ★
+  left-path-Z-var⊑★-YZ₄
+```
+
+That is the conclusion index of `left-path-target-Z-revealed₈-YZ`.
+
+### Checkpoint 9: paired Y seal/unseal, then target-only Z unseal
+
+Starting from `left-path-argument-Z₈-YZ`, paired Y seals produce:
+
+```text
+＇ Yᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Yᴿ
+  left-path-argument-Y₉-YZ
+```
+
+Application retains the same judgment:
+
+```text
+＇ Yᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Yᴿ
+  left-path-application₉-YZ
+```
+
+The paired Y unseals return to the direct Y-store entries:
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Zᴿ
+  left-path-Y-unsealed₉-YZ
+```
+
+The target-only Z unseal again requires:
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ★
+  left-path-Z-var⊑★-YZ₄
+```
+
+That is the conclusion index of `left-path-target-Z-unsealed₉-YZ`.
+
+### Checkpoint 10: value-side paired Y unseal, then target-only Z unseal
+
+The value-side branch reuses the same paired-seal chain:
+
+```text
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Zᴿ
+  left-path-argument-Z₈-YZ
+
+＇ Yᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Yᴿ
+  left-path-argument-Y₉-YZ
+
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ＇ Zᴿ
+  left-path-Y-unsealed₁₀-YZ
+
+＇ Zᴸ ⊑ᵂ⟨ left-path-world₄-YZ ⟩ ★
+  left-path-Z-var⊑★-YZ₄
+```
+
+The last judgment is the conclusion index of
+`left-path-target-Z-unsealed₁₀-YZ`.
+
+### Exact rule and exact failure
+
+Both live leaf proofs are applications of the same rule:
+
+```agda
+X⊑★ : ∀ {X}
+  → μ X ≡ X⊑★
+  → μ ⊢ ＇ X ⊑ ★
+```
+
+At Z, its only premise is:
+
+```text
+left-path-imp-env-YZ (Fin.suc (Fin.suc Fin.zero)) ≡ X⊑★.
+```
+
+Under the proposed edit this normalizes to `X⊑X ≡ X⊑★`.  This is the first
+and precise failure.  The earlier `＇ Yᴸ ⊑ ＇ Yᴿ`, `＇ Zᴸ ⊑ ＇ Zᴿ`, paired-seal,
+and paired-Y-unseal judgments remain inhabited.
+
+The probe records the failure as checked emptiness, both at the leaf and at
+the function judgment:
+
+```agda
+yz-Z-to-star-precise-empty :
+  (＇ (Fin.suc (Fin.suc Fin.zero)))
+    CTX.⊑ᵂ⟨ yz-precise-Z-world ⟩ ★
+  → ⊥
+yz-Z-to-star-precise-empty (I.X⊑★ ())
+
+yz-Z-function-to-star-precise-empty
+    (I.⇒⊑⇒ Z-domain-to-star Z-codomain-to-star) =
+  yz-Z-to-star-precise-empty Z-domain-to-star
+```
+
+The empty pattern is Agda's checked rejection of the impossible constructor
+premise `X⊑X ≡ X⊑★`.  A direct attempted live proof reports the same mismatch
+as `X⊑X != X⊑★`.
+
+## Recalibration candidates
+
+### Candidate A: store-mediated `X⊑X` variable-to-`★`
+
+Draft the new world-indexed clause verbatim as:
+
+```agda
+X⊑★-store : ∀ {W : CTX.World Δᴸ Δᴿ Δ} {Xᴸ : TyVar Δᴸ}
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
+  → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+  → (＇ Xᴸ) ⊑ˢ⟨ W ⟩ ★
+```
+
+The probe's `_⊑ˢ⟨_⟩_` is a note-local draft relation.  It also contains the
+ordinary live judgments and structural function closure:
+
+```agda
+live : A CTX.⊑ᵂ⟨ W ⟩ B → A ⊑ˢ⟨ W ⟩ B
+
+⇒⊑⇒-store :
+  A ⊑ˢ⟨ W ⟩ A′
+  → B ⊑ˢ⟨ W ⟩ B′
+  → (A ⇒ B) ⊑ˢ⟨ W ⟩ (A′ ⇒ B′)
+```
+
+At the fixture, both premises of `X⊑★-store` are `refl`: Z's center mark is
+`X⊑X` and `sourceStore[Zᴸ] = ★`.  The checked witnesses are
+`yz-Z-to-star-store-mediated` and
+`yz-Z-function-to-star-store-mediated`.  This reconstructs every missing
+type index identified above: checkpoint 3 uses the function closure; checkpoints
+8, 9, and 10 use the leaf.
+
+Consequences: implementing this candidate cannot be a new constructor of the
+current store-free `Imprecision._⊢_⊑_`, because that relation has no store or
+embedding parameters.  Either `_⊑ᵂ⟨_⟩_` must become an inductive enriched
+relation or the core relation must acquire explicit representation evidence.
+`CastTermImprecision` and all type-indexed term rules would then migrate to the
+enriched relation.  Existing inversion arguments that use “an `X⊑X` occurrence
+cannot widen to `★`” must be restated with store evidence; the immediate sites
+include `proof.Imprecision.occurs-not-star`, `source-path-same`, `⊑-unique`,
+and downstream uses of uniqueness in simulation, transport, center rename,
+target extension, and target bind lift.  The fixture probe establishes local
+sufficiency, not global soundness or preservation.
+
+The D8a/T10 invariant-(4) kill-checks survive unchanged: this candidate does
+not alter embeddings, stores, or invariant (4).  Both D8a endpoints are still
+rejected for their unmatched non-`★`, non-variable target entries, while both
+T10 Probe 1 endpoints still pass invariant (4) because those entries are `★`.
+
+Invariant (5) does cover the recalibrated YZ family.  The probe constructs the
+complete value
+
+```text
+yz-precise-Z-world-invariants :
+  WI.WorldInvariants yz-precise-Z-world
+```
+
+The Z case of invariant (5) is vacuous because its mark is `X⊑X`; the X and Y
+cases cannot have both a dynamic mark and direct source entry `★`.  Invariants
+(2)--(4) also hold: precise Z has aligned target `Zᴿ`, the aligned direct Z
+entries are `★ ⊑ ★`, and both target cells are aligned.
+
+Verdict: **fixture-sufficient and compatible with invariant (5), but a global
+relation redesign whose metatheory is still open.**
+
+### Candidate B: target-unseal mark-transition exception
+
+The current `ImpEnvMono W Wᵖ` requires every `X⊑★` mark in the conclusion
+world `W` to remain `X⊑★` in the premise world `Wᵖ`.  A target-unseal
+exception could instead permit the target pivot alone to have been `X⊑X` in
+the premise.  The checked draft is verbatim:
+
+```agda
+RevealMarkTransition W Wᵖ Xᴿ = ∀ Z
+  → CTX.impEnvʷ W Z ≡ X⊑★
+  → CTX.impEnvʷ Wᵖ Z ≡ X⊑★
+    ⊎ (Z ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+      × CTX.impEnvʷ Wᵖ Z ≡ X⊑X)
+```
+
+The corresponding rule delta would be:
+
+```agda
+⊑reveal²-boundary :
+  RevealMarkTransition W Wᵖ Xᴿ
+  → RebaseAtᴿ W Wᵖ (just Xᴿ)
+  → SameCtx γ γᵖ
+  → targetStoreʷ W ⊢↑[ just Xᴿ ] c′
+  → Wᵖ ∣ γᵖ ⊢² M ⊑ M′ ∶ p
+  → (q : A ⊑ᵂ⟨ W ⟩ B′)
+  → W ∣ γ ⊢² M ⊑ M′ ↑ c′ ∶ q
+```
+
+At the fixture, take `Wᵖ = yz-precise-Z-world` and
+`W = yz-dynamic-world`.  The X and Y marks pass through unchanged, while Z
+uses the exception.  `yz-target-Z-unseal-transition` checks this exact
+transition.  The premise has `＇ Zᴸ ⊑ ＇ Zᴿ` under `X⊑X`; the conclusion has
+the live `＇ Zᴸ ⊑ ★` under `X⊑★`.
+
+Consequences: this needs either a specialized target-unseal constructor or a
+new pivot-indexed alternative to `ImpEnvMono`.  Every proof that transports,
+decays, or inverts target reveal steps must handle the exceptional pivot; a
+global replacement would touch the target-reveal callers and mark-transport
+layers in `CastTermImprecision`, `TermImpDecay`, `TargetExtend`,
+`CenterRename`, and the term-imprecision transport proofs.  A specialized
+constructor limits the syntactic edit but does not remove the invariant
+problem.
+
+The conclusion world is checkably illegal under invariant (5):
+
+```agda
+yz-dynamic-world-rejects-invariant5 :
+  WI.WorldInvariants yz-dynamic-world → ⊥
+```
+
+Its witness selects source `Zᴸ`, target `Zᴿ`, direct entry `★`, dynamic mark
+`X⊑★`, and their center equality.  Therefore invariant (5) cannot cover the
+whole YZ derivation if this transition is used.  The D8a/T10 invariant-(4)
+classifications are textually unchanged, but their force would be undermined
+if term rules were allowed to cross through endpoints lacking
+`WorldInvariants`; requiring valid endpoints preserves the kill-checks and
+simultaneously makes this fixture transition unavailable.
+
+Verdict: **locally inhabited, but not a 5c solution because its needed
+conclusion world violates invariant (5).**
+
+### Candidate C: reinterpret every `X⊑X` variable as dynamic
+
+The smallest core-relation edit would be:
+
+```agda
+X⊑★-precise : ∀ {X}
+  → μ X ≡ X⊑X
+  → μ ⊢ ＇ X ⊑ ★
+```
+
+The probe models that clause verbatim at world level as:
+
+```agda
+X⊑★-raw :
+  CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
+  → (＇ Xᴸ) ⊑ʳ⟨ W ⟩ ★
+```
+
+This reconstructs the missing YZ leaf, but it ignores the reason Z can be
+viewed dynamically.  `raw-rule-ignores-nondynamic-store` checks a one-cell
+identity world whose source entry is `ℕ` and whose mark is `X⊑X`; the raw rule
+still derives `＇ zero ⊑ ★`.  The same problem appears at precise polymorphic
+binders created by `liftWorldBoth X⊑X`.
+
+Consequences: `proof.Imprecision.occurs-not-star` and `source-path-same` become
+false as stated, not merely incomplete by a new constructor case.  Proofs
+using `X⊑X` as the certificate that a variable occurrence retains its endpoint
+spine lose their premise.  The D8a/T10 structural invariant-(4) verdicts remain
+unchanged, and the recalibrated YZ world still satisfies invariant (5), but
+that is not a safety argument: invariant (5) is deliberately silent at
+`X⊑X`, so it cannot constrain this newly broad rule.
+
+Verdict: **checkably overbroad and rejected.**
+
+## Comparative result
+
+| Candidate | Restores all four missing YZ type indices at Z=`X⊑X`? | Complete recalibrated YZ `WorldInvariants`? | D8a/T10 invariant-(4) kill-check | Result |
+| --- | --- | --- | --- | --- |
+| A. Store-mediated variable rule | Yes, checked at the leaf and function levels. | Yes, checked. | Unchanged. | Viable design investigation; global proof cost open. |
+| B. Target-unseal mark transition | Locally, by using an `X⊑★` conclusion world. | No; that conclusion world is rejected by (5). | Preserved only if all rule endpoints must be valid. | Not a 5c solution. |
+| C. Raw `X⊑X`-to-`★` rule | Yes. | The fixture world passes, but (5) is blind to the overbroad rule. | Structurally unchanged. | Rejected. |
+
+## Validation record
+
+The new probe contains no postulates, holes, or option pragmas.  It was
+spot-checked with Agda 2.8 using:
+
+```text
+agda --safe -v0 -i . -i proof/DGG/notes -i proof/DGG/notes/probes \
+  proof/DGG/notes/probes/D16PairedSealRecalibrationProbe.agda
+```
+
+The command exited 0.  Its checked facts cover the expanded stores, original
+dynamic derivability, `X⊑X` emptiness, candidates A--C, the complete
+recalibrated world invariant, and the invariant-(5) rejection of candidate
+B's dynamic conclusion world.
+
+The unchanged D8a/T10 invariant-(4) results remain checked in
+`T15WorldInvariantsDesignProbe.agda`: `d8a-W-violates-invariant4` and
+`d8a-Wᵖ-violates-invariant4` reject D8a; `t10-W`, `t10-Wᵖ`, and
+`t10-probe1-worlds-satisfy` retain the T10 representation result.
+
+The required final repository gate was:
+
+```text
+PATH=.../scratchpad/agda28/bin:$PATH make check
+```
+
+It exited 0.
+
+## Sharpened 5c decision menu
+
+1. **5c-E: keep the checked exception.**  Keep `X⊑★` in the four live YZ
+   derivation worlds, leave them outside `WorldInvariants`, keep the XZ worlds
+   recalibrated to `X⊑X`, and make no relation change.  Choose this if 5c is a
+   world-classification step rather than a demand that every legacy fixture be
+   admitted.
+
+2. **5c-S: open a store-mediated relation redesign.**  Adopt candidate A as
+   the intended direction, keep Z at `X⊑X`, and require an implementation arc
+   to migrate the world-indexed type relation and reprove inversion,
+   uniqueness, transport, and simulation before landing it.  This is the only
+   checked candidate that both reconstructs the YZ forcing chain and admits
+   the fixture under invariant (5).
+
+3. **5c-B: allow boundary-local dynamization.**  Adopt candidate B and accept
+   that at least the target-Z-unseal conclusion world lies outside invariant
+   (5).  This does not achieve full world-invariant coverage and is therefore
+   strictly weaker than 5c-S while adding a new mark-transition case.
+
+4. **5c-R: reinterpret `X⊑X` globally.**  Adopt candidate C.  Do not choose
+   this: the checked non-dynamic-store witness shows that it erases the
+   semantic distinction carried by `X⊑X`.

--- a/GTSFImp/proof/DGG/notes/d16-5c-wide-exploration.red
+++ b/GTSFImp/proof/DGG/notes/d16-5c-wide-exploration.red
@@ -1,0 +1,756 @@
+# D16 5c wide exploration: marks, representations, and pairing history
+
+Date: 2026-08-19
+
+Status: DESIGN RECONNAISSANCE ONLY.  No live relation, world, store,
+reduction, or proof definition is changed.  The checked audit probe is
+`proof/DGG/notes/probes/D16WideMarkIndependenceProbe.agda`.
+
+This memo deliberately does not select a direction.  It widens the search
+beyond the rejected fixture-mark edit, invariant-(5) refinement, and local
+store-mediated judgment.  The rankings in Section 6 report two different
+axes--frictions removed and risk--and are not a recommendation.
+
+Files and internal branch material read for this pass include:
+
+- `Imprecision.agda`, `TyStore.agda`, and `Reduction.agda`;
+- `proof/DGG/CtxImp.agda`, `WorldInvariants.agda`, `WorldDecay.agda`,
+  `CenterRename.agda`, `TargetBindLift.agda`, and `TargetExtend.agda`;
+- `proof/DGG/Example12Worlds.agda`, `Examples2.agda`,
+  `SmartCommaWitness.agda`, and the live finite world probes;
+- `proof/DGG/notes/d16-5b-paired-seal-first-try.red` and
+  `d16-smart-alias-invariant-blocked.red`;
+- `proof/DGG/notes/t14-partner-premise-redesign.red`;
+- `proof/DGG/notes/CTI-TIGHTENING-CALIBRATION.md` and its provenance
+  scratches;
+- `proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda`,
+  `T15Invariant5ReconProbe.agda`, and
+  `D16PairedSealRecalibrationProbe.agda`;
+- the repository-internal D18 policy note and probe at
+  `agent/gtsf-dispatcher-residuals:GTSFImp/proof/DGG/notes/`
+  `d18-rebase-tightening-design.red` and
+  `probes/D18RebaseTighteningProbe.agda`.
+
+## 0. World-display notation
+
+Worlds are displayed in the canonical `worldSnapshot` cell notation from
+the repository's world-grid branch:
+
+```text
+<center>: <source pivot and direct entry, or ─>
+          ⊑[<mark>]
+          <target pivot and direct entry, or ─>
+```
+
+Cells are ordered by the shared center.  For example,
+
+```text
+⟨C: X↦ℕ ⊑[X⊑X] Y↦ℕ⟩
+```
+
+means that source `X` and target `Y` are aligned at center `C`, both direct
+entries are `ℕ`, and `impEnv C = X⊑X`.  Displays below are rendered by hand
+because `WorldSnapshot.agda` is not on this branch.
+
+## 1. Disease diagnosis
+
+### 1.1 The three pieces of per-variable data
+
+The live world stores three logically different facts around a source
+variable:
+
+1. **The mark.**  `impEnvʷ W Z : VarImp` is one of:
+
+   ```agda
+   data VarImp : Set where
+     X⊑X : VarImp
+     X⊑★ : VarImp
+   ```
+
+   The core type relation consults it only at the widening leaf:
+
+   ```agda
+   X⊑X : μ ⊢ ＇ X ⊑ ＇ X
+
+   X⊑★ : μ X ≡ X⊑★
+     → μ ⊢ ＇ X ⊑ ★
+   ```
+
+2. **The two direct store entries.**  For aligned endpoint variables
+   `Xᴸ` and `Xᴿ`, `lookupStore` exposes one source representation and one
+   target representation.  It does not follow a variable chain.
+
+3. **Alignment.**  The two embeddings decide whether endpoint variables
+   occupy the same shared center:
+
+   ```agda
+   CenterAligned W Xᴸ Xᴿ =
+     toRenameᵗ (ηᴸʷ W) Xᴸ ≡ toRenameᵗ (ηᴿʷ W) Xᴿ
+   ```
+
+The landed companion connects the three through two mark-sensitive fields:
+
+```agda
+preciseMarksAligned :
+  impEnvʷ W (center Xᴸ) ≡ X⊑X
+  → Σ[ Xᴿ ∈ TyVar Δᴿ ] CenterAligned W Xᴸ Xᴿ
+
+dynamicStarSourcesUnoccupied :
+  impEnvʷ W (center Xᴸ) ≡ X⊑★
+  → lookupStore (sourceStoreʷ W) Xᴸ ≡ ★
+  → NoTargetOccupantAtSource W Xᴸ
+```
+
+The representation field is deliberately independent of the mark:
+
+```agda
+representationsImprecise :
+  CenterAligned W Xᴸ Xᴿ
+  → impEnvʷ W ⊢ embedᴸ (lookupStore sourceStore Xᴸ)
+                  ⊑ embedᴿ (lookupStore targetStore Xᴿ)
+```
+
+Thus the current design gives the bit three jobs:
+
+- **type capability:** may this variable occurrence widen to `★`?
+- **allocation/occupancy phase:** is a direct source-`★` cell still open, or
+  may it have a target occupant?
+- **temporal proof state:** did a rule decay/honestify this center, and which
+  origin world did a rebase come from?
+
+Those jobs coincide in simple source-only and paired-bind worlds.  They do
+not coincide in the YZ chain.
+
+### 1.2 The YZ exception is the collision, not the cause
+
+The complete live checkpoint-3/4 layout is:
+
+```text
+⟨X: Xᴸ↦ℕ    ⊑[X⊑★] ─
+ │ Y: Yᴸ↦＇Zᴸ  ⊑[X⊑★] Yᴿ↦＇Zᴿ
+ │ Z: Zᴸ↦★    ⊑[X⊑★] Zᴿ↦★⟩
+```
+
+The constructor data is, in full:
+
+```agda
+sourceStore =
+  store-bind (store-bind (store-bind store-empty ★)
+    (＇ Fin.zero)) (‵ `ℕ)
+
+targetStore =
+  store-bind (store-bind store-empty ★) (＇ Fin.zero)
+
+ηᴸ = keep (keep (keep empty))
+ηᴿ = skip (keep (keep empty))
+
+μ X = X⊑★
+μ Y = X⊑★
+μ Z = X⊑★
+```
+
+The paired Y reveal follows the two direct variable entries and leaves the
+term relation at `＇ Zᴸ ⊑ ＇ Zᴿ`.  The subsequent target-only Z reveal
+uses `targetStore[Zᴿ] = ★` and requires:
+
+```text
+＇ Zᴸ ⊑ᵂ⟨W⟩ ★.
+```
+
+The live `X⊑★` rule obtains that leaf only from the mark at center Z.  It
+does not inspect `sourceStore[Zᴸ] = ★`.  This leaf is used twice at
+checkpoint 3 and once at checkpoints 8, 9, and 10, as audited in
+`d16-5b-paired-seal-first-try.red`.
+
+Invariant (5), however, reads the same local state in the other direction:
+
+```text
+mark Z = X⊑★  +  sourceStore[Zᴸ] = ★
+  ==> no target occupant at Z.
+```
+
+The actual world has target occupant `Zᴿ`.  Changing Z to `X⊑X` satisfies
+the occupancy reading but destroys the widening capability.  The rejected
+narrow proposals tried to decide which reading wins.  The disease is that
+one bit is being used for both readings.
+
+### 1.3 The projection mismatch shows why the bit cannot simply favor YZ
+
+The projection-mismatch calibration has the complete one-cell layout:
+
+```text
+⟨C: X↦★ ⊑[X⊑★] Y↦★⟩
+```
+
+Its stores are both `store-bind store-empty ★`; both embeddings are
+`keep empty`; the environment is the constant `X⊑★` environment.  The bad
+whole-term square is:
+
+```text
+source sealed/tagged/projected at X   ⊑   target ℕ-tag projected at Y
+                  |                                  |
+                  | returns                          | blame
+                  v                                  v
+             source value                          blame
+```
+
+This local cell has exactly the same source entry, target entry, alignment,
+and live mark as the Z cell above.  The difference is term/cast ancestry and,
+in the YZ world, the incoming paired alias chain through Y.  A local
+two-entry classifier cannot distinguish them.  A whole-world classifier can
+notice the incoming Y chain, but it still cannot reconstruct the static
+binder choice in the general case; the next subsection checks that fact.
+
+### 1.4 Checked answer: marks are independent information today
+
+The new probe constructs these two worlds:
+
+```text
+precise-world = ⟨C: X↦ℕ ⊑[X⊑X] Y↦ℕ⟩
+dynamic-world = ⟨C: X↦ℕ ⊑[X⊑★] Y↦ℕ⟩
+```
+
+Both have identity embeddings and the same source and target store
+`store-bind store-empty ℕ`.  Both satisfy all four fields of the landed
+`WorldInvariants` companion:
+
+```agda
+precise-world-invariants : WorldInvariants precise-world
+dynamic-world-invariants : WorldInvariants dynamic-world
+```
+
+For the dynamic world, invariant (5)'s direct-source-`★` antecedent is
+false.  The probe then refutes the strongest reconstruction principle that
+identical valid layouts determine pointwise-equal environments:
+
+```agda
+valid-layouts-do-not-determine-marks :
+  ValidLayoutsDetermineMarks → ⊥
+```
+
+This establishes two different conclusions:
+
+- In the **current design**, `impEnv` is genuinely independent data.  It is
+  not recoverable even from entries, alignment, and all landed invariants.
+- A future design may **choose** a computed classification, but it will be a
+  semantic policy change.  It will not be recovering information already
+  present in the two stores and embeddings.
+
+## 2. Complete builder and fixture audit
+
+The audit distinguishes “chosen by the builder's history” from “uniquely
+forced by the completed layout.”  Only the latter would support eliminating
+`impEnv` without a semantic change.
+
+### 2.1 Every live world builder
+
+| Builder | How the output mark is obtained | Determined by output entries + alignment? |
+| --- | --- | --- |
+| Raw `CtxImp.world` | Takes an arbitrary `ImpEnv` as its third field. | **No by definition.** This is the independent-data surface. |
+| `CompilePreservesImprecision2.initialWorld μ Σ`; duplicate `Occupancy.initialWorldᴼ`; `WorldInvariants.initialWorld μ` | Uses caller-supplied `μ`; the first two also accept an arbitrary common store, while the D16 version uses `emptyStore`. | **No.** Identity alignment and equal stores do not select a mark; the checked one-cell pair is the finite counterexample. |
+| `Examples2.reflWorld Σ` | Chooses `idᵐ`, hence `X⊑X`, for every center. | **Policy-fixed, not layout-derived.** Replacing `idᵐ` by a dynamic environment on a non-`★` common entry can still satisfy all four invariants. |
+| `CtxImp.liftWorldBoth v W` | Inserts caller-supplied `v`; both fresh store entries are structural self variables and the fresh endpoints are aligned. | **No.** `v = X⊑X` and `v = X⊑★` have the same output layout. `WorldInvariants.liftWorldBoth-invariants` accepts both. |
+| `CtxImp.liftWorldLeft v W` | Inserts caller-supplied `v`; fresh source is unaligned and has a structural self entry. | **Raw: no. Valid companion: fresh mark forced dynamic.** `WorldInvariants.liftWorldLeft-invariants` requires `v ≡ X⊑★` because invariant (2) rejects a precise unaligned source. Old marks remain inherited, not recomputed. |
+| `CtxImp.leftOnlyWorld v W A` | Inserts caller-supplied `v`; fresh source is unaligned and has direct entry `A`. | **Raw: no. Valid companion: fresh mark forced dynamic.** `leftOnlyWorld-invariants` has the same `v ≡ X⊑★` restriction, independently of `A`; old marks are inherited. |
+| `CtxImp.rightOnlyWorld W B` | `instᵐ` inserts `X⊑★` at the fresh target-only center and shifts old marks. | **Chosen by the right-only allocation event.** It is not inferred from `B`; `B` may be `★`, an alias, or a generic type on the raw surface. |
+| `CtxImp.bothBindWorld v W A B` | Inserts caller-supplied `v` at a fresh aligned pair. | **Raw: no.** The landed live invariant theorem specializes to `v ≡ X⊑X`, but the output layout alone does not make that choice for non-`★` entries. |
+| `CenterRename.renameWorld π W` | Copies old marks through `renameEnv`; every center outside `π`'s image is filled with `X⊑★`. | **No.** The answer depends on old/fresh center provenance, not on final entries and alignment. |
+| `WorldDecay.blendWorld W′ Wᵈ` | Keeps `W′`'s embeddings and stores, but takes each mark from `W′` unless it is precise, in which case it may take `Wᵈ`'s mark. | **Explicitly no.** A second world changes the marks while the output layout is fixed. |
+| `WorldDecay.honestify W` | Preserves marks at target-occupied centers and changes unoccupied centers to `X⊑★`. | **Partly geometry-computed, partly inherited.** Aligned centers retain independent history. |
+| `SealPeelToolkit.dynWorld W` | Replaces every mark by `X⊑★` and leaves both stores and embeddings unchanged. | **No.** `dynWorld-invariants` needs an extra no-forbidden-source premise precisely because the layout does not justify this blanket choice. |
+| Generic `EnvDecay W Wᵈ` endpoints | `Wᵈ` is caller-supplied with identical embeddings/stores and a monotone environment. | **No.** Decay is the public relation witnessing allowed independent mark change. |
+| `TargetBindLift.ΛLiftToBindFreshWorld v W` and `ΛLiftToBindFreshWorldᴸ v W` | Compose `instᵐ`, `extendᵐ v`, and another `instᵐ`; the target store is the `★`-then-`＇ zero` tower. | **No.** The middle `v` is an explicit history parameter; the other fresh marks encode target allocation steps. |
+| `TargetBindLift.targetStoreAs W Σᴿ` | Copies embeddings and marks from `W` while replacing the target store. | **No, decisively.** The current target entries can change without changing any mark. Validity therefore needs separate representation/classification premises. |
+| `TargetExtend.smartAliasInsertWorld`, `smartFreshInsertWorld`, and `insertRebaseWorld` | Rename marks from `Wᵐ` or `Wᵖ`, while mixing them with target embeddings/stores from another insertion world. | **No.** Their marks follow premise/rebase provenance. The final store pair is assembled from different inputs. |
+| `Inversion.TargetStripProof.lowerLiftWorldLeft` | Drops the fresh center and copies the tail of `Wᴸ`'s environment. | **No.** This is inverse history reconstruction, not output-layout classification. |
+| `Catchup.InstInversionLambdaProof.ΛPostMidWorld` and `ΛRouteOneMidWorldAt` | The former applies `instᵐ` three times; the latter copies the environment of `liftWorldLeft X⊑★ W₂` while rebuilding embeddings. | **No.** Both encode the selected allocation schedule explicitly. |
+
+Records such as `TargetInsert`, `RebaseAt`, `ParkedWorld`, and
+`ParkedEvolve` relate already constructed worlds.  They are not additional
+world builders.  Their consumers may constrain marks, but they do not make
+marks a function of entries and alignment.
+
+### 2.2 Every live fixture family
+
+This table covers direct named fixture worlds outside `proof/DGG/notes/` and
+the three required note-level kill fixtures.  Builder-composed fixtures are
+listed in the last row and inherit the builder verdict above.
+
+| Fixture family and names | Mark data and layout fact | Audit verdict |
+| --- | --- | --- |
+| `Example12Worlds.example12-world-X/Y/Z` | One source `ℕ` cell is moved among target `X↦ℕ`, `Y↦＇Z`, and `Z↦★`; `example12-imp-env` is independently all `X⊑★`. | **Not determined.** The same environment is reused across three different alignments. D16 direct-entry invariants accept X and reject the skewed Y/Z layouts for store reasons, not because the environment was computed. |
+| `example12-nat-chain-world-X/Y` | Target is `Y↦＇X, X↦ℕ`; source `ℕ` is aligned first with X, then Y; both marks are independently `X⊑X`. | **Not determined.** The mark environment is held fixed while alignment changes; the Y layout is rejected by the direct-entry invariant. |
+| `example12-left-path-world-X/Y/Z` | Source is `X↦ℕ, Y↦＇Z, Z↦★`, target is one `★` cell moved X→Y→Z. X/Y use all dynamic marks; Z changes only center Z to `X⊑X`. | **Mixed policy.** The Z repair is forced by invariant (5), while X/Y retain dynamic capability needed by their direct/chain relations. It is a hand-selected global policy, not a uniform local classifier. |
+| `Examples2.reflWorld`, `left-path-world₁/₂`, and `left-path-world₃/₄/₅` | The first three identity-style worlds choose `idᵐ`. The XZ checkpoints use `⟨X: Xᴸ↦ℕ ⊑[X⊑★] Xᴿ↦★ │ Y: Yᴸ↦＇Z ⊑[X⊑★] ─ │ Z: Zᴸ↦★ ⊑[X⊑X] Zᴿ↦★⟩`. | **Policy-fixed, not generally derived.** XZ's Z mark is the invariant-(5) repair; its X mark remains dynamic because `ℕ ⊑ ★`. |
+| `Examples2.left-path-world₃-YZ/₄-YZ` | Exact YZ snapshot from Section 1.2; both worlds reuse the same stores and all-dynamic environment. | **Contradictory demands.** Z must be dynamic for the live relation and precise for invariant (5). This is the motivating exception. |
+| `ExtraCastRight2Counterexample.pre-world`, `post-world`, and `dyn-premise-world` | The stores are fixed while the source pivot is displaced. `pre/post` reuse a precise mark; `post` is explicitly not `WFWorld`; `dyn-premise-world` changes only the mark to dynamic. | **Not determined.** This family is itself a mark-history counterexample and the reason for `ImpEnvMono`/honestify. |
+| `SmartCommaWitness.base-world`, `d1-outer-smart-world`, `a3-d1-alias-world`, and `a3-d1-name-world` | Base is empty. The other worlds use the all-dynamic environment with target `β↦＇α, α↦★`; alias and name worlds place the fresh structural source at β and α respectively. | **Not determined.** The environment is fixed by the route. The alias world's direct entries contradict `representationsImprecise` even though its guard requires the dynamic mark. |
+| `CenterCrossingProbe.W/W′/Wᵖ`, `ChainRideProbe.W₁/Wₗ/W₂`, `MovedLinkProbe.probe-W₁/W₄/W₅/W₆`, `TagBoundaryProbe.probe-W₁/W₄/W₅`, `SealPeelProbe.probe-W/W′/W₄/Wᵖ`, `StarRepChainProbe.W`, and `SourceStarProbe.W₀` | Each family declares stores and embeddings separately and then applies one all-`X⊑★` `probe-μ` to every placement. Most stores contain direct `★` or alias-to-`★` cells. | **Not determined.** Marks are held fixed while pivots move. Several positive raw fixtures are intentionally outside invariant (5); they remain relation probes until world validity becomes mandatory. |
+| `TerminusRebuildProbe.InstanceA.W` and `InstanceB.W/Wᵖ` | Instance A is `⟨C: X↦∀X.X⇒X ⊑[X⊑★] Y↦★⟩`. Instance B has source `X↦★`, target `Y↦＇Y₂, Y₂↦★`, all dynamic, and moves X from Y to Y₂. | **Not determined.** D16 kills both Instance-B endpoints; D18 uses their two rebases as the checked obstruction to unrestricted functional origins. |
+| Required D8a worlds | `W = ⟨F: ─ ⊑[X⊑★] Yf↦ℕ │ O: X↦ℕ ⊑[X⊑X] Yo↦ℕ⟩`; `Wᵖ = ⟨F: X↦ℕ ⊑[X⊑★] Yf↦ℕ │ O: ─ ⊑[X⊑X] Yo↦ℕ⟩`. | **History-selected and invalid.** Both are rejected by unmatched-target invariant (4), independently of marks. |
+| Required T10 Probe-1 worlds | Same geometry/marks as D8a with every direct `ℕ` changed to `★`: `W = ⟨F: ─ ⊑[X⊑★] Yf↦★ │ O: X↦★ ⊑[X⊑X] Yo↦★⟩`; `Wᵖ = ⟨F: X↦★ ⊑[X⊑★] Yf↦★ │ O: ─ ⊑[X⊑X] Yo↦★⟩`. | **Mixed.** Invariant (4) accepts both; invariant (5) accepts W and rejects Wᵖ. The fresh/old allocation history, not entries alone, tells why the two centers have different marks. |
+| Required projection mismatch | `⟨C: X↦★ ⊑[X⊑★] Y↦★⟩`, with the term square from Section 1.3. | **Invalid under (5), but locally indistinguishable from YZ's Z cell.** Term/cast ancestry is what distinguishes the executions. |
+| Builder-composed operational fixtures in `Phase3DeepDives`, `LambdaImpProbe`, parked D4, and instantiation catch-up | Constructed only through `initialWorld`, paired `bothBindWorld X⊑X`, `leftOnlyWorld X⊑★`, right-only allocation, rename, and the Λ tower builders. | **They inherit builder history.** Their marks are not re-derived after construction. |
+
+The audit answer is therefore unambiguous: marks are sometimes *constrained*
+by entries and alignment, but they are not *determined* by them.  Invariant
+(5) makes aligned direct `★/★` cells precise, while the YZ execution needs
+one such cell to retain dynamic widening capability.  The missing discriminator
+is history/provenance or a redesigned semantics, not another equation over the
+existing two-point bit.
+
+## 3. Full mark-system friction inventory
+
+| ID | Open friction | What the mark is asked to mean | Store/alignment facts already present | Exact collision |
+| --- | --- | --- | --- | --- |
+| F1 | YZ paired-seal exception | `X⊑★` authorizes `＇Zᴸ ⊑ ★`. | Z is paired and both direct entries are `★`; Y provides an incoming aligned alias chain. | Invariant (5) interprets the same `X⊑★ + source ★` as necessarily unoccupied. |
+| F2 | Smart-alias blocker | `SmartAliasMergeGuard.alias-mark-dynamic` and `transport⊑ᵂ` require the fresh source/target-β center to be `X⊑★`. | Fresh source direct entry is its structural self variable; target β directly points to α, and target α is `★`. | Direct `representationsImprecise` forces β = α, contradicting the two target entries. Changing the mark to precise breaks the guard before repairing the entries. |
+| F3 | `liftWorldLeft` / `leftOnlyWorld` stage-1 restriction | Generic APIs accept `v`, but a fresh source-only `X⊑X` would claim precision without a target alignment. | Fresh source is visibly unoccupied; `store-lift` gives a self variable and `store-bind` gives A. | `preciseMarksAligned` forces the valid invariant theorems to require `v ≡ X⊑★`; raw APIs remain broader. |
+| F4 | Decay and `ImpEnvMono` | A proof may weaken `X⊑X` to `X⊑★` while leaving embeddings and stores fixed. | Runtime layout is unchanged. | Validity is not monotone: decay can create the forbidden `X⊑★ + source ★ + occupied` combination. `WorldInvariants.decay-invariants` therefore needs a no-new-forbidden-cell premise. |
+| F5 | `honestify`, `blendWorld`, and `dynWorld` | `honestify` dynamizes only unaligned centers; blend imports marks from a second world; `dynWorld` dynamizes all centers. | Each operation keeps the output runtime layout fixed (blend uses the first world's layout). | Mark transformation is history-sensitive. Honestify is valid, blend/decay need premises, and `dynWorld` needs a premise for every direct source `★`. |
+| F6 | Invariant (5) itself | `X⊑★` at a direct source `★` is used as an “open source-only cell” certificate. | Occupancy is already directly decidable from embeddings; both entries are also available. | The condition is stronger than mark honesty: it kills the bad mismatch world, but also all good matched-seal uses inside the same aligned all-dynamic calibration and the live YZ Z cell. |
+| F7 | D18 origin-policy mark coherence | Two rule-facing rebases with the same destination and pivots must have exactly the same origin, hence the same origin `impEnv`. Origin-to-destination marks may still decay. | D18's proposed `origin-determined : W ≡ originAt policy W′ X Y` pins the whole origin record. | Exact origin equality derives `origin-marks-unique`; equating origin and destination marks would be too strong. Any mark redesign must preserve this two-level distinction and commute with rename/decay/insertion. |
+
+## 4. Structurally different directions
+
+### Direction A: compute marks from layout and delete independent `impEnv`
+
+Split the raw layout from its computed classification:
+
+```agda
+record WorldLayout (Δᴸ Δᴿ Δ : TyCtx) : Set where
+  field
+    ηᴸ : Δᴸ ↪ᵗ Δ
+    ηᴿ : Δᴿ ↪ᵗ Δ
+    sourceStore : TyStore Δᴸ
+    targetStore : TyStore Δᴿ
+
+classify : WorldLayout Δᴸ Δᴿ Δ → TyVar Δ → VarImp
+
+record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
+  field
+    layout : WorldLayout Δᴸ Δᴿ Δ
+
+impEnvʷ W = classify (layout W)
+```
+
+A purely local `classify` has no satisfactory YZ choice.  Classifying aligned
+`★/★` as precise preserves invariant (5) and rejects the mismatch world but
+breaks YZ.  Classifying it dynamic restores YZ but admits the mismatch layout.
+A whole-layout classifier could add an incoming-paired-alias condition:
+
+```agda
+classify L Z = X⊑★
+  if source-only L Z
+  or incoming-aligned-alias-to L Z
+  else X⊑X
+```
+
+That distinguishes the concrete YZ and one-cell mismatch layouts.  It still
+does not reconstruct the general binder choice: the checked `ℕ/ℕ` worlds and
+`liftWorldBoth v` have identical layouts and valid inhabitants at both marks.
+Adopting the classifier therefore removes one of those semantics.
+
+Consequences:
+
+- `ImpEnvMono`, `EnvDecay`, blend, honestify, and mark fields on guards become
+  equations about `classify` under layout transformations.
+- `liftWorld*`, bind worlds, rename, target insertion, and rebase must prove
+  classifier stability instead of choosing marks.
+- Static source imprecision that is not encoded in stores must either be
+  discarded or moved into new provenance--which turns this into Direction D.
+
+Kill checks:
+
+- D8a remains rejected by unmatched non-`★`, non-variable target entries.
+- T10 W/Wᵖ depends on the chosen global classifier; a local classifier cannot
+  recover the intended fresh-versus-old distinction from the two `★` entries.
+- ProjectionMismatch is unsafe if the classifier makes every aligned
+  `★/★` cell dynamic.  Incoming-alias classification excludes the concrete
+  one-cell probe but needs a new spoofing/laundering battery.
+
+One-line verdict: **removes the independent bit and much transition plumbing,
+but the checked independence probe proves this is a semantics choice, and a
+layout-only policy has no uniform YZ/mismatch/binder answer.**
+
+### Direction B: enrich the mark lattice
+
+Separate an open dynamic cell from a paired cell whose representation is
+dynamic:
+
+```agda
+data VarImp : Set where
+  X⊑X       : VarImp
+  X⊑★-open  : VarImp
+  X⊑★-paired : VarImp
+
+data CanWiden : VarImp → Set where
+  open-widen   : CanWiden X⊑★-open
+  paired-widen : CanWiden X⊑★-paired
+
+X⊑★ : CanWiden (μ X) → μ ⊢ ＇ X ⊑ ★
+```
+
+The world conditions become:
+
+```agda
+openStarSourcesUnoccupied :
+  μ (center Xᴸ) ≡ X⊑★-open
+  → lookupStore sourceStore Xᴸ ≡ ★
+  → NoTargetOccupantAtSource W Xᴸ
+
+pairedDynamicRepresentations :
+  μ (center Xᴸ) ≡ X⊑★-paired
+  → Σ[ Xᴿ ∈ TyVar Δᴿ ]
+      CenterAligned W Xᴸ Xᴿ
+    × lookupStore sourceStore Xᴸ ≡ ★
+    × lookupStore targetStore Xᴿ ≡ ★
+```
+
+YZ marks Z `X⊑★-paired`; source-only seal windows use `X⊑★-open`;
+ordinary paired binders use `X⊑X`.
+
+Consequences:
+
+- All pattern matches on `VarImp`, `extendᵐ`, `instᵐ`, environment rename,
+  decay, and mark guards gain a case.
+- Decay is no longer a two-point order.  At minimum it needs
+  `X⊑X -> X⊑★-open` and `X⊑X -> X⊑★-paired`, selected by world state.
+- Smart alias remains blocked: its direct structural-source/alias-target
+  mismatch is not repaired by naming the mark more accurately.
+- D18 can still pin exact origin marks, but every policy naturality theorem
+  must preserve the three-way classification.
+
+Kill checks:
+
+- D8a invariant (4) is unchanged.
+- T10 Wᵖ must not acquire `X⊑★-paired` merely from alignment; its target-only
+  occupant was not born as the source's partner.
+- ProjectionMismatch also has aligned direct `★/★`.  If the new mark can be
+  minted from those facts alone, it reopens the bad world.  Either the term
+  partner premise must remain the soundness guard or the paired mark needs
+  ancestry, converging on Direction D.
+
+One-line verdict: **directly expresses the YZ state and resolves the literal
+invariant-(5) contradiction, but it does not explain who may mint the third
+point and leaves smart alias, decay selection, and provenance risk open.**
+
+### Direction C: flatten representation chains at allocation time
+
+Make runtime bind store the current terminal representative rather than the
+syntax supplied by the reduction:
+
+```agda
+bindFlat : TyStore Δ → Ty Δ → TyStore (suc Δ)
+bindFlat Σ A = store-bind Σ (resolveRep Σ A)
+
+applyStore keep Σ = Σ
+applyStore (bind A) Σ = bindFlat Σ A
+```
+
+The canonical resolver would have to move from `CtxImp` into the core store
+layer.  Every world builder corresponding to `bind` must use `bindFlat`.
+
+The YZ stores then become:
+
+```text
+⟨X: Xᴸ↦ℕ ⊑[X⊑★] ─
+ │ Y: Yᴸ↦★ ⊑[X⊑X] Yᴿ↦★
+ │ Z: Zᴸ↦★ ⊑[X⊑X] Zᴿ↦★⟩
+```
+
+The paired Y reveal reaches `★ ⊑ ★` directly.  There is no later
+`＇Zᴸ ⊑ ★` leaf and no Y-to-Z chain.  Both paired direct-`★` centers may
+remain precise.
+
+This also makes the smart-alias target shape `β↦＇α, α↦★` unmintable:
+β is stored as `★`.  The current smart-alias guard and branch disappear or are
+replaced by a flat fresh bind.  That is a semantic simplification, not merely
+a proof repair.
+
+Consequences:
+
+- `Reduction.applyStore`, preservation, `Eval`, conversion typing, all
+  `store-bind` equality proofs, and all Example-12 chain fixtures change.
+- Generated casts still mention the syntactic argument A.  Preservation must
+  prove those casts well typed against the flattened store entry or regenerate
+  them from `resolveRep Σ A`.
+- Representation-chain theorems and the chain-permissive unmatched-target
+  invariant become obsolete or collapse to one-step facts.
+- Polymorphic generativity may depend on retaining name indirection; flattening
+  must be checked against sealing/unsealing semantics, not just DGG proofs.
+
+Kill checks:
+
+- D8a's direct `ℕ` entries are already flat, so invariant (4) still kills it.
+- T10 and ProjectionMismatch are already all-`★`/flat; their verdicts are
+  unchanged.  Invariant (5) or term partner/provenance remains necessary.
+
+One-line verdict: **removes the concrete YZ chain and the smart-alias store
+shape at their source, at the cost of changing the operational representation
+discipline and potentially the calculus's generative-name semantics.**
+
+### Direction D: make pair provenance first-class and derive marks from it
+
+Record how each center was born and which older cell an alias descends from:
+
+```agda
+data CellBirth (Δ : TyCtx) : Set where
+  structural : CellBirth Δ
+  paired-bind : CellBirth Δ
+  source-bind : CellBirth Δ
+  target-bind : CellBirth Δ
+  alias-bind : TyVar Δ → CellBirth Δ
+
+record CellHistory (W : World Δᴸ Δᴿ Δ) (Z : TyVar Δ) : Set where
+  field
+    birth : CellBirth Δ
+    sourcePivot : Maybe (TyVar Δᴸ)
+    targetPivot : Maybe (TyVar Δᴿ)
+    partnerAncestor : Maybe (TyVar Δ)
+    castAncestry : CastAncestry W Z
+```
+
+The production version should index constructors tightly enough that invalid
+combinations are unconstructible; the loose record above only shows the data.
+The world stores one history per center, and the current mark becomes a
+projection:
+
+```agda
+impEnvʷ W Z = capabilityMark (historyʷ W Z)
+```
+
+For YZ, Z's history says it is a paired dynamic-representation ancestor of
+the paired Y aliases.  It may widen while occupied.  ProjectionMismatch lacks
+the incoming allocation/cast ancestry.  Smart alias can be admitted only if
+the fresh source and target β share an ancestry path to α; otherwise the branch
+is rejected for the real reason instead of a direct-entry accident.
+
+This is the fresh-partner-ancestry direction anticipated by the D8a.4
+discussion and the earlier S-PROV calibration.  The calibration's richer
+version separates birth origin, use capability, occupancy/allocation
+ancestry, and cast ancestry; its term-shaped projection checks block the bad
+ProjectionMismatch square.
+
+Consequences:
+
+- Every allocating world builder mints a constructor; rename, target insert,
+  rebase, bind lift, and parked evolution transport histories.
+- Decay changes a current observation/capability state but cannot erase birth
+  or cast ancestry.  Honestify becomes a derived view over history.
+- The smart-alias guard is replaced by an ancestry-producing allocation rule,
+  or the branch becomes uninhabited explicitly.
+- D18's `originAt` can be keyed by the same event/partner ancestry.  Exact
+  origin mark coherence follows because both marks are projections of the
+  same selected origin history; origin-to-destination decay remains separate.
+
+Kill checks:
+
+- The checked S-PROV CORE calibration blocks ProjectionMismatch while keeping
+  matching and residual controls.
+- D8a's unmatched `ℕ` target has no legitimate paired ancestry and remains
+  rejected; T10 Wᵖ's target-only cell was not born as X's partner and remains
+  rejected.
+- The risk is underspecifying or forgeably transporting ancestry.  Every
+  rebase/shortcut producer needs a laundering check, especially the D18
+  proof-local-chain split.
+
+One-line verdict: **has enough information to distinguish all known cells and
+can subsume marks, but it moves allocation and cast history through nearly the
+entire DGG development.**
+
+### Direction E: redesign `_⊑ᵂ⟨_⟩_` as a store-aware inductive relation
+
+Replace the current abbreviation
+
+```agda
+A ⊑ᵂ⟨ W ⟩ B = impEnvʷ W ⊢ embedᴸ W A ⊑ embedᴿ W B
+```
+
+with a relation whose every constructor is world-indexed:
+
+```agda
+data _⊑ᵂ⟨_⟩_ : Ty Δᴸ → World Δᴸ Δᴿ Δ → Ty Δᴿ → Set where
+  ★⊑★ : ★ ⊑ᵂ⟨ W ⟩ ★
+  ι⊑ι : ‵ ι ⊑ᵂ⟨ W ⟩ ‵ ι
+
+  var⊑var :
+    CenterAligned W Xᴸ Xᴿ
+    → ＇ Xᴸ ⊑ᵂ⟨ W ⟩ ＇ Xᴿ
+
+  var⊑★-open :
+    NoTargetOccupantAtSource W Xᴸ
+    → lookupStore (sourceStoreʷ W) Xᴸ ≡ ★
+    → ＇ Xᴸ ⊑ᵂ⟨ W ⟩ ★
+
+  var⊑★-represented :
+    DynamicRepresentation W Xᴸ
+    → ＇ Xᴸ ⊑ᵂ⟨ W ⟩ ★
+
+  ⇒⊑⇒ : A ⊑ᵂ⟨ W ⟩ A′ → B ⊑ᵂ⟨ W ⟩ B′
+    → A ⇒ B ⊑ᵂ⟨ W ⟩ A′ ⇒ B′
+
+  ∀⊑∀ : ...
+```
+
+Unlike the rejected narrow store-mediated leaf, this direction migrates the
+whole relation: variable equality uses alignment directly, binder rules
+choose their lifted world explicitly, and every rename/substitution/decay
+theorem is proved by induction over world-aware evidence.
+
+`DynamicRepresentation` may be only a resolved source-`★` fact, or a
+stronger paired-chain witness.  The weak choice reconstructs YZ but also
+reconstructs the one-cell mismatch type boundary; the existing term partner
+discipline must then remain.  The strong choice needs ancestry and approaches
+Direction D.
+
+Consequences:
+
+- Every `⊑ᵂ` constructor use, inversion, uniqueness proof, context entry,
+  compile theorem, center rename, target extension, bind lift, and term rule
+  index changes.
+- `proof.Imprecision.occurs-not-star`, `source-path-same`, and `⊑-unique`
+  require world/store-aware restatements; uniqueness may need proof
+  irrelevance for representation evidence.
+- YZ can keep Z precise in `impEnv` because the widening fact is carried by
+  the witness.  That resolves the local invariant-(5) collision without
+  eliminating all other mark uses.
+- Smart alias remains blocked unless `DynamicRepresentation` also validates
+  its structural-source/alias-target path and invariant (3) is redesigned.
+
+Kill checks:
+
+- Keeping invariants (3)--(5) leaves the D8a and T10 verdicts unchanged.
+- ProjectionMismatch remains excluded only if the term partner premise stays,
+  or if `DynamicRepresentation` contains the checked cast ancestry from
+  S-PROV.
+
+One-line verdict: **gives the type witness the store facts it actually uses
+and restores YZ, but a ground-up migration is large and does not by itself
+solve smart alias or term-level projection ancestry.**
+
+### Direction F: compare terminal representations and remove variable marks
+
+Normalize endpoint types through their own stores before comparing them:
+
+```agda
+normalizeᴸ : World Δᴸ Δᴿ Δ → Ty Δᴸ → Ty Δ
+normalizeᴿ : World Δᴸ Δᴿ Δ → Ty Δᴿ → Ty Δ
+
+A ⊑ʳ⟨ W ⟩ B =
+  baseEnv ⊢ normalizeᴸ W A ⊑ normalizeᴿ W B
+```
+
+Here `normalize` recursively replaces a variable by `resolveVar` and embeds
+the result.  If variable widening is entirely determined after resolution,
+`VarImp` and `impEnv` can disappear.
+
+YZ's Z normalizes to `★` on both sides, and its target-only reveal uses
+`★ ⊑ ★`.  Smart alias's target β resolves through α to `★`; a dynamic
+fresh source can also be interpreted through its runtime role, so the direct
+head mismatch no longer blocks it.  Decay/honestify and D18 mark coherence
+disappear as named problems.
+
+Consequences:
+
+- This changes what a type variable denotes in imprecision.  Distinct names
+  with equal terminal representations become indistinguishable to the type
+  relation.
+- The current direct-entry invariant was introduced specifically to reject
+  chain-depth skew hidden by terminal resolution.  That protection is lost or
+  must be reintroduced as separate ancestry evidence.
+- Universal binders, structural `store-lift` variables, opening, and
+  substitution need a scope-correct normalization relation, not merely a
+  function over closed stores.
+- The term relation still needs name/tag/cast ancestry.  Terminal equality
+  cannot justify a target projection bearing the wrong visible tag.
+
+Kill checks:
+
+- D8a remains rejected only if unmatched-target invariant (4) stays direct.
+- Without a replacement occupancy/provenance invariant, T10 Wᵖ becomes hard
+  to distinguish from a legitimate paired terminal-`★` world.
+- ProjectionMismatch becomes easier to type because both variables resolve
+  to `★`; the live partner discipline or Direction-D ancestry is mandatory.
+
+One-line verdict: **removes nearly every mark-specific friction by quotienting
+through runtime representation, but also removes distinctions that D16 and
+the projection-mismatch discipline were built to protect.**
+
+## 5. Cross-direction kill-check matrix
+
+| Direction | YZ exception | Smart alias | D8a | T10 W / Wᵖ | ProjectionMismatch |
+| --- | --- | --- | --- | --- | --- |
+| A. Computed mark | Conditional: only a nonlocal classifier notices Y ancestry. | Direct entry contradiction remains. | Invariant (4) still rejects both. | Classifier must reconstruct allocation age; local entries cannot. | Aligned-`★/★` classifier is unsafe; incoming-alias variant needs new laundering checks. |
+| B. Three-point lattice | Yes via `X⊑★-paired`. | No. | Unchanged rejection. | W stays; Wᵖ is unsafe if paired mark is forgeable from alignment. | Term partner or ancestry still required. |
+| C. Flat allocation | Yes; problematic chain is not minted. | Current alias branch becomes unmintable. | Unchanged rejection. | Unchanged because stores are already flat. | Unchanged because its stores are already flat. |
+| D. First-class provenance | Yes via paired ancestor capability. | Either justified by ancestry or explicitly rejected. | Rejected by missing legitimate target ancestry. | W retained; Wᵖ rejected as target-only, not born partner. | Checked S-PROV-style term ancestry blocks it. |
+| E. Store-aware `⊑ᵂ` | Yes via represented-variable constructor. | Not without broadening representation invariants. | Unchanged if D16 invariants remain. | Unchanged if D16 invariants remain. | Existing term partner must remain, or witness gains cast ancestry. |
+| F. Terminal quotient | Yes by normalization. | Direct mismatch dissolves. | Only direct invariant (4) preserves the kill. | Needs a new occupancy/history discriminator. | High risk: terminal equality erases the visible-name mismatch. |
+
+## 6. Honest rankings
+
+The friction count uses F1--F7 from Section 3.  “Dissolves” means the
+friction ceases to be a separate proof obligation in the direction's stated
+form; moving the same obligation into a stronger provenance predicate does not
+count unless the direction provides that predicate.
+
+### 6.1 Rank by number of mark frictions dissolved
+
+| Rank | Direction | Definite frictions dissolved | Count | Frictions left or conditional |
+| ---: | --- | --- | ---: | --- |
+| 1= | D. First-class provenance | F1 YZ, F2 smart-alias explanation, F3 lift minting, F4 decay split, F5 honestify/blend, F6 invariant (5), F7 D18 mark source | 7 | Soundness depends on unforgeable ancestry and term-shaped cast provenance. |
+| 1= | F. Terminal quotient | F1--F7 disappear as mark-specific obligations. | 7 | Occupancy, visible tag, and chain-skew obligations do not disappear semantically; they need replacement relations. |
+| 3 | A. Computed mark | F3, F4, F5, F6, F7 become classifier equations. | 5 | F1 is conditional on a nonlocal policy; F2's direct entry mismatch remains. |
+| 4 | C. Flat allocation | F1, F2's current store shape, and the YZ instance of F6. | 3 | Source-only lifts, decay/honestify, general occupancy, and D18 remain. |
+| 5= | B. Three-point lattice | F1 and the YZ contradiction in F6. | 2 | F2--F5 and F7 remain, often with another mark case. |
+| 5= | E. Store-aware `⊑ᵂ` | F1 and the YZ contradiction in F6. | 2 | Other world-mark mechanics remain unless this direction is combined with A or D. |
+
+### 6.2 Rank by combined soundness and implementation risk
+
+This is a low-to-high risk ordering, with engineering blast shown separately
+so a semantically disciplined but large design is not conflated with a small
+but unsound shortcut.
+
+| Risk rank | Direction | Soundness risk | Engineering blast | Basis |
+| ---: | --- | --- | --- | --- |
+| 1 | B. Three-point lattice | **Medium.** Existing relation shape and term partner can remain; the main risk is forgeable paired marks. | **High.** Every mark/decay match gains a case. | Smallest semantic delta, but it names rather than proves provenance. |
+| 2 | E. Store-aware `⊑ᵂ` | **Medium.** Keeping term partner and D16 invariants preserves known kills. | **Very high.** The public type-witness relation and all transports change. | The narrow local probe is checked; the full inductive migration is not. |
+| 3 | D. First-class provenance | **Medium.** Rich ancestry has the strongest existing ProjectionMismatch checks, but transport can launder it if underspecified. | **Extreme.** World construction, allocation, casts, rebase, decay, and simulation all thread it. | S-PROV CORE provides positive evidence; D18 and every shortcut producer add obligations. |
+| 4 | C. Flat allocation | **High.** May change generative sealing/name semantics and cast typing. | **Very high.** Core reduction/store action and all chain fixtures change. | Structural kills survive cheaply, but operational equivalence is unproved. |
+| 5 | A. Computed mark | **High.** The checked probe proves layout is insufficient; any classifier discards a currently valid semantic distinction. | **Very high.** Every builder/transport proves classifier equations. | Concrete YZ/mismatch distinction requires an ad hoc global condition or hidden provenance. |
+| 6 | F. Terminal quotient | **Very high.** It erases name and chain-depth distinctions used by current soundness checks. | **Extreme.** Core imprecision, binders, stores, invariants, and term proofs change. | Known mismatch types become easier to relate; replacement ancestry is mandatory. |
+
+Neither table implies that the first row is preferable.  Direction D removes
+the most frictions while carrying extreme implementation cost; Direction B
+has the lowest combined risk while removing only two; Direction F scores high
+on deletion precisely because it discards the most semantic structure.
+
+## 7. Validation record
+
+The new probe contains no postulates, holes, or option pragmas.  It was
+spot-checked with Agda 2.8 using:
+
+```text
+agda --safe -v0 -i . -i proof/DGG/notes -i proof/DGG/notes/probes \
+  proof/DGG/notes/probes/D16WideMarkIndependenceProbe.agda
+```
+
+The command exited 0.  It checks both complete `WorldInvariants` values and
+the refutation of mark reconstruction from identical valid layouts.
+
+Existing cheap kill evidence was reused rather than duplicated:
+
+- `D16PairedSealRecalibrationProbe`: YZ forcing leaf, precise-Z emptiness,
+  local store-aware reconstruction, and invariant-(5) checks;
+- `T15WorldInvariantsDesignProbe`: D8a invariant-(4) rejections and T10
+  invariant-(4) controls;
+- `T15Invariant5ReconProbe`: ProjectionMismatch and T10-style occupied
+  dynamic-source-`★` rejection;
+- `ProjectionMismatchStarRepScratch` and the S-PROV probes cited by
+  `CTI-TIGHTENING-CALIBRATION.md`: operational mismatch and ancestry controls;
+- the D18 branch probe: exact origin, source-pivot and origin-mark equality,
+  plus the Instance-B collision for unrestricted origins.
+
+The final repository gate is recorded in the commit handoff after it exits
+zero.

--- a/GTSFImp/proof/DGG/notes/d16-smart-alias-invariant-blocked.red
+++ b/GTSFImp/proof/DGG/notes/d16-smart-alias-invariant-blocked.red
@@ -55,3 +55,20 @@ companion at smart-alias consumers:
 3. remove the smart-alias branch in favor of the fresh-behind construction.
 
 No such change is part of D16 stage 1.
+
+## Stage 2 5b revisit
+
+The `X⊑X` discipline does not resolve this blocker.  The live alias guard is
+not merely missing a chosen mark: `SmartAliasMergeGuard.alias-mark-dynamic`
+requires the center shared by fresh source zero and target `β` to carry
+`X⊑★`.  Its `transport⊑ᵂ` field also transports from
+`liftWorldLeft X⊑★ W`; the live `SmartCommaWitness.d1-inner-smart-p` uses that
+transport for a fresh source variable related to target `★`.
+
+Changing that aligned center to `X⊑X` therefore rejects the live transport
+before it could repair `representationsImprecise`.  Leaving it at `X⊑★`
+preserves the original contradiction between the direct entries `＇ zero` and
+`＇ α` described above.  The smart-alias route still needs its own valid-input
+premise and a redesign capable of satisfying it; 5b supplies neither.  The
+checked `smartAliasInsertWorld-invariants` surface consequently retains its
+explicit `WorldInvariants Wᵐ` premise.

--- a/GTSFImp/proof/DGG/notes/d16-smart-alias-invariant-blocked.red
+++ b/GTSFImp/proof/DGG/notes/d16-smart-alias-invariant-blocked.red
@@ -1,0 +1,57 @@
+# D16 stage 1: smart-alias input invariant blocker
+
+Date: 2026-08-19
+
+## Status
+
+The chain-permissive fallback repairs the live target-only
+`★`-then-`＇ zero` world.  It does not make a
+`SmartAliasMergeGuard W Wᵐ β α` compatible with `WorldInvariants Wᵐ`.
+Consequently `smartAliasInsertWorld-invariants` is a checked preservation
+theorem, but its `WorldInvariants Wᵐ` premise makes the smart-alias branch
+uninhabited.  This is a stage-2 caller-supply blocker, not authorization to
+change the selected invariant or the smart-alias semantics during stage 1.
+
+## Contradiction
+
+The guard supplies
+
+`sourceStoreʷ Wᵐ ≡ store-lift (sourceStoreʷ W)`,
+
+`targetStoreʷ Wᵐ ≡ targetStoreʷ W`,
+
+`targetStoreʷ W ∋ β ⦂ ＇ α`,
+
+and the fresh source center is aligned with target `β`.  Direct lookup
+therefore gives
+
+$$
+\mathsf{lookupStore}\;\Sigma^L_{W^m}\;0 = \mathord{\＇}0
+\qquad\text{and}\qquad
+\mathsf{lookupStore}\;\Sigma^R_{W^m}\;\beta = \mathord{\＇}\alpha.
+$$
+
+`representationsImprecise` at that aligned pair forces the two variable heads
+to be center-aligned.  Since the source head is already the center of `β`,
+injectivity of `ηᴿʷ Wᵐ` yields `β ≡ α`.  But the same guard also
+supplies
+
+`targetStoreʷ W ∋ α ⦂ ★`,
+
+so direct lookup would give `＇ α ≡ ★`, a constructor contradiction.
+
+The contradiction is checked locally inside
+`smartAliasTargetInsert-direct`; no postulate, hole, or termination pragma is
+used.
+
+## Proposal boundary
+
+A future stage must choose one of these design changes before requiring the
+companion at smart-alias consumers:
+
+1. change the smart-alias source representation so its fresh direct entry is
+   aligned with the direct representation at `β`;
+2. weaken or redesign `representationsImprecise`; or
+3. remove the smart-alias branch in favor of the fresh-behind construction.
+
+No such change is part of D16 stage 1.

--- a/GTSFImp/proof/DGG/notes/d19-bprime-recon.red
+++ b/GTSFImp/proof/DGG/notes/d19-bprime-recon.red
@@ -1,0 +1,360 @@
+D19 B-prime reconnaissance
+============================
+
+Date: 2026-08-19
+
+Status: RECONNAISSANCE ONLY.  This note and its probe do not change the live
+term-imprecision relation, reduction, world, store, or proof definitions.
+The checked probe is
+`proof/DGG/notes/probes/D19BPrimeReconProbe.agda`.
+
+
+Decision under survey
+---------------------
+
+D19 has selected B-prime:
+
+* a paired beta-instantiation mints its new center variable at `X⊑X`;
+* a one-sided beta-instantiation mints its new center variable at `X⊑★`;
+* whenever both terms carry the same wrapper, the two-sided relation rule is
+  canonical.
+
+“Matched” below means that both embeddings hit the center:
+
+```agda
+CenterAligned W X Y =
+  toRenameᵗ (ηᴸʷ W) X ≡ toRenameᵗ (ηᴿʷ W) Y
+```
+
+A dynamic mark at a matched center is not, by itself, a B-prime violation.
+It is valid when a one-sided event minted the center and the other execution
+later caught up to it.  The violation is forgetting that provenance and
+changing a center minted by a paired event from `X⊑X` to `X⊑★`.
+
+Verdict vocabulary:
+
+* **B′-SAFE**: preserves a paired mint, or writes/requires `X⊑★` only at a
+  center whose one-sided provenance is established by the same interface.
+* **B′-BREAKS**: the current definition demonstrably permits a paired mint to
+  be changed to `X⊑★`.
+* **B′-NEEDS-CHANGE**: the surface is too generic to express the distinction,
+  or a proof consumer relies on a breaking transformer.
+
+
+The self-contained YZ fixture and async window
+----------------------------------------------
+
+The source store has three variables and the target store has two.  With
+newest variables written first, their direct entries are
+
+```text
+source: X ↦ ℕ,  Y ↦ ＇Z,  Z ↦ ★
+target:          Y ↦ ＇Z,  Z ↦ ★
+```
+
+The center context has three variables.  The embeddings and B-prime marks are
+
+```agda
+ηᴸ = keep (keep (keep empty))
+ηᴿ = skip (keep (keep empty))
+
+μ Fin.zero                         = X⊑★  -- X, source-only
+μ (Fin.suc Fin.zero)               = X⊑★  -- Y, one-sided alias history
+μ (Fin.suc (Fin.suc Fin.zero))     = X⊑X  -- Z, paired beta-inst mint
+```
+
+Thus source/target Y meet at center 1 and source/target Z meet at center 2.
+This is exactly the `left-path-world₄-precise-Z` fixture reconstructed in
+`D19PairedRevealReparseProbe`; the live `Examples2.left-path-world₄-YZ`
+differs only in marking Z `X⊑★`.
+
+For the terms below define the complete wrapper vocabulary:
+
+```text
+cYᴸ = seal 1 (＇ 2) ↦↑ unseal 1 (＇ 2)
+cZᴸ = seal 2 ★     ↦↑ unseal 2 ★
+cYᴿ = seal 0 (＇ 1) ↦↑ unseal 0 (＇ 1)
+cZᴿ = seal 1 ★     ↦↑ unseal 1 ★
+sX  = seal 0 ℕ
+uX  = unseal 0 ℕ
+
+Fᴸ = ((ƛ (` 0)) ↑ cYᴸ) ↑ cZᴸ
+Fᴿ = (ƛ renameᵗᵐ (keep wk↪ᵗ) (` 0) ↑ cYᴿ) ↑ cZᴿ
+aᴸ = (($ (κℕ 7) ↓ sX) ⟨ X! ⟩)
+aᴿ = $ (κℕ 7) ⟨ ℕ! ⟩
+
+iₐ = the argument-side `id ★` conversion
+iᵣ = the result-side `id ★` conversion
+i⇒ = iₐ ↦ iᵣ
+iₜ = the target result-side `id ★` conversion
+gX = the source result conversion `★ ? X`
+```
+
+The two requested out-of-phase source states and the fixed target state are
+therefore, without relying on the `Examples2` names,
+
+```text
+right₅  = (((Fᴸ ⟨ i⇒ ⟩) · aᴸ) ⟨ gX ⟩) ↑ uX
+right₆  = (((Fᴸ · (aᴸ ⟨ iₐ ⟩)) ⟨ iᵣ ⟩) ⟨ gX ⟩) ↑ uX
+target₄ = ((Fᴿ · aᴿ) ⟨ iₜ ⟩)
+```
+
+The async window keeps the target fixed while the source takes three pure
+steps:
+
+```text
+(right₄ , target₄)
+  -- source beta-function pushes its outer cast
+(right₅ , target₄)
+  -- source beta-function pushes its second cast
+(right₆ , target₄)
+  -- source beta-id removes iₐ
+(right₇ , target₄)
+```
+
+At `right₅`, the commented `Examples2` derivation records these interior
+one-sided judgments: the paired-Z function with only source `i⇒`; the X-sealed
+argument with only source `X!`; their application; then only target `iₜ`; then
+only source `gX`.  At `right₆` it records: the bare paired-Z function; the
+X-sealed argument with `X!` and source-only `iₐ`; their application; paired
+source `iᵣ`/target `iₜ`; then source-only `gX`.  In formula order:
+
+```text
+Fᴸ ⟨i⇒⟩      ⊑ Fᴿ
+aᴸ            ⊑ aᴿ
+Fᴸ ⟨i⇒⟩ · aᴸ ⊑ Fᴿ · aᴿ
+Fᴸ ⟨i⇒⟩ · aᴸ ⊑ (Fᴿ · aᴿ) ⟨iₜ⟩
+(Fᴸ ⟨i⇒⟩ · aᴸ) ⟨gX⟩ ⊑ (Fᴿ · aᴿ) ⟨iₜ⟩
+
+Fᴸ                 ⊑ Fᴿ
+aᴸ ⟨iₐ⟩            ⊑ aᴿ
+Fᴸ · (aᴸ ⟨iₐ⟩)     ⊑ Fᴿ · aᴿ
+(Fᴸ · (aᴸ ⟨iₐ⟩)) ⟨iᵣ⟩ ⊑ (Fᴿ · aᴿ) ⟨iₜ⟩
+((Fᴸ · (aᴸ ⟨iₐ⟩)) ⟨iᵣ⟩) ⟨gX⟩ ⊑ (Fᴿ · aᴿ) ⟨iₜ⟩
+```
+
+These are not alternative Z parses.  The D19 paired-reparse probe checks every
+Z site in checkpoints 3--9 at `X⊑X`; the stale whole checkpoints 4--9 fail
+earlier at the independent one-sided X conceal.  The window nevertheless
+shows why preservation needs atomic peel/keep re-association: canonical
+two-sided wrappers cannot describe every intermediate state after only one
+program has taken its keep step.
+
+
+1. Mark-transformer audit
+-------------------------
+
+The table covers the live world builders, the relations that constrain marks
+between worlds, and the mark-sensitive proof transformers reached by the DGG.
+Raw `world` records and hand-authored example fixtures are inputs rather than
+transformers, so they are not additional rows.
+
+| Site | File:line | Verdict | One-line reason |
+| --- | --- | --- | --- |
+| `liftWorldBoth v` | `proof/DGG/CtxImp.agda:78` | **B′-NEEDS-CHANGE** | Both fresh embeddings hit center zero, but the raw API accepts `v = X⊑★`; the canonical `Λ⊑Λ²` caller correctly supplies `X⊑X`. |
+| `liftWorldLeft v` | `proof/DGG/CtxImp.agda:92` | **B′-SAFE** | The fresh source center is outside the target image; invariant-facing callers require `v = X⊑★`. |
+| `leftOnlyWorld v` | `proof/DGG/CtxImp.agda:102` | **B′-SAFE** | Like `liftWorldLeft`, it creates only a source center; `leftOnlyWorld-invariants` requires `X⊑★`. |
+| `rightOnlyWorld` | `proof/DGG/CtxImp.agda:113` | **B′-SAFE** | `instᵐ` writes `X⊑★` at a fresh target-only center and shifts every old mark unchanged. |
+| `bothBindWorld v` | `proof/DGG/CtxImp.agda:123` | **B′-NEEDS-CHANGE** | The raw API accepts a dynamic matched head, although all operational paired-bind callers and `bothBindWorld-invariants` use `X⊑X`. |
+| `ImpEnvMono` | `proof/DGG/CtxImp.agda:152` | **B′-BREAKS** | It constrains only old dynamic marks; hence a conclusion `X⊑X` may become premise `X⊑★` even when both embeddings still hit the center. |
+| `WFWorld` / `WorldInvariants.preciseMarksAligned` | `proof/DGG/CtxImp.agda:163`, `proof/DGG/WorldInvariants.agda:48` | **B′-NEEDS-CHANGE** | They say precise implies matched but do not remember paired-mint provenance; a dynamic matched head still satisfies the live invariant. |
+| paired and one-sided invariant builders | `proof/DGG/WorldInvariants.agda:296-764` | **B′-NEEDS-CHANGE** | `liftWorldBoth-invariants` accepts either mark at a matched head, whereas `liftWorldLeft`/`leftOnly` require `X⊑★` and `bothBindWorld` requires `X⊑X`; the paired lift must acquire the same canonical constraint. |
+| `SmartFreshBehindGuard` mark fields | `proof/DGG/CtxImp.agda:261` | **B′-SAFE** | `fresh-not-target` proves the required dynamic head is source-only; old/target fields merely preserve already-dynamic marks. |
+| `SmartAliasMergeGuard` mark fields | `proof/DGG/CtxImp.agda:293` | **B′-SAFE** | `pending-at-alias` makes the new head matched and `alias-mark-dynamic` requires `X⊑★`, but the enclosing smart-comma premise is a source-only binder event. |
+| `RebaseAt` and the paired `RebaseAtᴸ`/`RebaseAtᴿ`/`TagRebaseAtᴸ` cases | `proof/DGG/CtxImp.agda:396-648` | **B′-BREAKS** | Despite the comment that the environment stays fixed, the record has no mark-equality field; it admits the checked precise-to-dynamic matched rebase `generic-rebase-decays-matched`. |
+| `sameWorldRebaseAt` and the three id-rebase constructors | `proof/DGG/CtxImp.agda:409-431`, `:615`, `:644` | **B′-SAFE** | Their source and destination world are definitionally the same, so every mark is unchanged. |
+| `rebase-onlyᴸ` / `tag-rebase-onlyᴸ` | `proof/DGG/CtxImp.agda:441`, `:623` | **B′-SAFE** | Each requires `X⊑★` only together with an explicit proof that no target embedding hits the source center, so the center cannot be matched. |
+| `EnvDecay` / `decay⊑ᵂ` | `proof/DGG/WorldDecay.agda:81` | **B′-BREAKS** | Stores and embeddings are equal while the embedded `ImpEnvMono` may erase any paired precise mark. |
+| `blendWorld` | `proof/DGG/WorldDecay.agda:145` | **B′-BREAKS** | At a precise cell in its first world it imports the second world's mark without checking matched-center provenance. |
+| `honestEnv` / `honestify` | `proof/DGG/WorldDecay.agda:207` | **B′-SAFE** | It preserves every target-occupied center, hence every matched center, and dynamizes only centers outside the target image. |
+| `renameEnv` / `renameWorld` | `proof/DGG/CenterRename.agda:317`, `:348` | **B′-SAFE** | Image marks are copied exactly; `X⊑★` is written only outside the shared renamed image, where neither endpoint can be matched. |
+| `dynWorld` | `proof/DGG/SealPeelToolkit.agda:170` | **B′-BREAKS** | It writes `X⊑★` at every center while preserving both embeddings, including paired matched centers. |
+| `decay-invariants`, `blendWorld-invariants`, `dynWorld-invariants` | `proof/DGG/WorldInvariants.agda:887-965` | **B′-NEEDS-CHANGE** | These validate the breaking decay family using only the older star-source occupancy side condition, which does not distinguish paired from one-sided provenance. |
+| `honestify-invariants`, `renameWorld-invariants`, `targetInsert-invariants` | `proof/DGG/WorldInvariants.agda:784`, `:935`, `:1020` | **B′-SAFE** | Their underlying transformations preserve matched marks; the invariant proofs add no matched-center `X⊑★` requirement. |
+| `TargetInsert.impEnv-insert` / `impEnv-off-insert` | `proof/DGG/TargetExtend.agda:76` | **B′-SAFE** | Image marks are equal; off-image marks are dynamic, and `target-source-reflect` prevents a newly matched source/target pair from hiding off the old image. |
+| `smartAliasInsertWorld` plus alias `smartStar` | `proof/DGG/TargetExtend.agda:894`, `:1082` | **B′-SAFE** | Rename preserves inherited marks; the `Fin.zero` `smartStar` case uses the source-only alias mint, and the tail uses `old-star` only to preserve an existing dynamic mark. |
+| `smartFreshInsertWorld` plus fresh `smartStar` | `proof/DGG/TargetExtend.agda:1243`, `:1482` | **B′-SAFE** | The fresh head is proved outside the target image; `old-star` at line 1514 transports only inherited dynamic marks. |
+| `insertRebaseWorld` | `proof/DGG/TargetExtend.agda:1688` | **B′-SAFE** | It renames premise marks exactly; any inserted off-image target center has one-sided target-allocation provenance before a later rebase can meet it. |
+| `ΛLiftToBindFreshWorld` / `ΛLiftToBindFreshWorldᴸ` | `proof/DGG/TargetBindLift.agda:75`, `:88` | **B′-NEEDS-CHANGE** | Their middle `v` is a matched slot; live route-one callers use `X⊑★` only after erasing the paired `Λ⊑Λ²` head, while the surrounding `instᵐ` slots are genuinely one-sided. |
+| `TargetStoreMove` / `targetStoreAs` | `proof/DGG/TargetBindLift.agda:180`, `:456` | **B′-SAFE** | Both require pointwise mark equality and therefore cannot decay a paired mark. |
+| `TargetBindLiftMove.target-pivot-star` | `proof/DGG/TargetBindLift.agda:370` | **B′-NEEDS-CHANGE** | The pivot may be matched, so the unconditional `X⊑★` premise needs one-sided provenance or a separate precise paired branch. |
+| `liftTargetBindMove*`, `smartAliasPivotStar`, `smartFreshPivotStar` | `proof/DGG/TargetBindLift.agda:421-583` | **B′-SAFE** | These preserve an existing pivot-star obligation and do not choose a new mark; the alias-β case inherits the source-only smart-alias mint. |
+| `liftBothBinderDecay` | `proof/DGG/TermImpDecay.agda:50` | **B′-BREAKS** | This is the explicit witness from `liftWorldBoth X⊑X W` to the identical matched world marked `X⊑★` at its new head. |
+| smart-guard decay (`decaySmartFreshBehindGuard`, `decaySmartAliasMergeGuard`) | `proof/DGG/TermImpDecay.agda:155`, `:232` | **B′-BREAKS** | Both replace the complete smart premise by `dynWorld Wᵐ`, erasing every paired mark inherited inside it. |
+| `lowerLiftWorldLeft` | `proof/DGG/Inversion/TargetStripProof.agda:309` | **B′-SAFE** | It drops the one-sided head and copies every tail mark exactly; its reconstructed lifted head is again source-only `X⊑★`. |
+| `ΛPostMidWorld` | `proof/DGG/Catchup/InstInversionLambdaProof.agda:427` | **B′-NEEDS-CHANGE** | Three `instᵐ`s make its source head match a target center dynamically; the route is currently fed by `liftBothBinderDecay`, not a one-sided mint certificate. |
+| `ΛRouteOneFreshWorldAt` / `ΛRouteOneMidWorldAt` | `proof/DGG/Catchup/InstInversionLambdaProof.agda:1031`, `:1056` | **B′-NEEDS-CHANGE** | They preserve route-one allocation marks, but their live input contains `liftWorldBoth X⊑★`; the paired slot must remain precise while genuinely one-sided window slots stay dynamic. |
+| the eight `ImpEnvMono` premises in `⊑reveal²`, `⊑conceal²`, `reveal⊑²`, both `conceal⊑²` rules, `reveal⊑reveal²`, `conceal⊑conceal²`, and `packaged-seal-star²` | `proof/DGG/CastTermImprecision.agda:177-296` | **B′-NEEDS-CHANGE** | Every wrapper constructor accepts the breaking generic star-map; B′ needs a provenance-preserving/matched-preserving transformer, with canonical two-sided rules retaining paired heads. |
+| `ImpEnvMono` rename/move/insert and strip/walk/catchup consumers | `proof/DGG/CenterRename.agda:760`, `proof/DGG/TargetBindLift.agda:241`, `proof/DGG/TargetExtend.agda:2568`, `proof/DGG/Catchup/StructuralWorldExtendDef.agda:171-290` | **B′-NEEDS-CHANGE** | These are parametric transports of the same generic relation, not independent mark writers; each must transport whatever provenance-preserving replacement the eight rules use. |
+| `CompileImageWorld` mint constructors | `proof/DGG/GroundingMint.agda:49` | **B′-SAFE** | The compile image already distinguishes `liftWorldBoth X⊑X` from `liftWorldLeft X⊑★` exactly as B′ requires. |
+
+The probe checks the cheap positive and negative rows directly:
+`generic-mono-decays-matched`, `generic-env-decay-decays-matched`,
+`blend-decays-matched`, `dyn-world-decays-matched`,
+`honestify-keeps-matched`, `dynamic-lift-passes-live-invariants`,
+`generic-rebase-decays-matched`, the builder head/occupancy facts,
+`paired-binder-decay`, rename preservation, target-store preservation, and the
+smart guard geometry.
+
+The operationally decisive break is not merely the permissive raw builder.
+`Λ⊑Λ²-route1-entry-p` in
+`Catchup/InstInversionLambdaProof.agda:105-127` starts from the paired body
+world `liftWorldBoth X⊑X W`, applies a target insertion with `v = X⊑X`, and
+then invokes `liftBothBinderDecay` to obtain `liftWorldBoth X⊑★ ...`.  Under
+B-prime that exact middle step must disappear or be replaced by an async
+re-association that keeps the paired head precise.
+
+
+2. Smart-alias recheck (F2)
+--------------------------------
+
+| Site | Sidedness and matchedness | B′ verdict | Exact consequence |
+| --- | --- | --- | --- |
+| `Λ⊑²-smart-comma` selects `SmartCommaLiftᴸ` | Source-only: the source has the pending binder while the target term/context is unchanged. | **B′-SAFE** | The event mints `X⊑★`, as required for a one-sided beta-instantiation. |
+| `SmartAliasMergeGuard.pending-at-alias` + `alias-mark-dynamic` | The new source `Fin.zero` is matched with existing target `β`, and that center is required to be `X⊑★`. | **B′-SAFE** | Matching happens by catching the source up to a target alias center; it does not retroactively turn the original one-sided mint into a paired mint. |
+| Alias `old-star` in `smartAliasGuardInsert` | `TargetExtend.agda:1099` reflects an already-dynamic inserted old center back to `W`; it is not the pending head. | **B′-SAFE** | No mark is minted or decayed; the premise remains `impEnvʷ W Z ≡ X⊑★`. |
+| Fresh `old-star` in `smartFreshGuardInsert` | `TargetExtend.agda:1514` is the analogous inherited-tail fact; the fresh head is separately proved unmatched. | **B′-SAFE** | No change under B′. |
+| Alias/fresh `smartStar Fin.zero` | Alias uses `alias-mark′`; fresh uses `fresh-mark′`; both establish `＇center ⊑ ★` for transport out of `liftWorldLeft X⊑★ W′`. | **B′-SAFE** for the live one-sided constructor. | Both proofs continue to close unchanged when generic decay is not invoked. |
+| Counterfactual paired smart-alias constructor | Both terms would carry the binder wrapper, so the new matched center would be a paired mint. | **B′-NEEDS-CHANGE** | `alias-mark-dynamic` would have to become `impEnvʷ Wᵐ (toRenameᵗ (ηᴿʷ W) β) ≡ X⊑X`; the current `smartStar Fin.zero = X⊑★ alias-mark′` would then fail, so the surrounding proof would need a `liftWorldBoth X⊑X` transport mapping the two fresh variables to each other rather than mapping the source variable to `★`. `name-mark-dynamic` and inherited `old-star` facts need not change. |
+
+The live alias-creation site is therefore one-sided.  No F2 change is needed
+for B-prime itself.  The probe lemmas `smart-alias-pending-matched` and
+`smart-alias-pending-mark-dynamic` check the apparently paradoxical pair of
+facts, and `smart-fresh-pending-unmatched` checks the other smart branch.
+
+
+3. Async-window lemma inventory
+--------------------------------
+
+The B-prime preservation proof needs four narrow continuation statements to
+cross one async keep window while retaining canonical two-sided rules.  These
+are statements only; this reconnaissance neither proves nor postulates them.
+
+| Statement | Role in one async window | Existing equivalent | Counterexample status |
+| --- | --- | --- | --- |
+| `PairedConcealRevealPeelᵀ` | When both endpoints still carry matching seal/unseal wrappers, consume both keep steps atomically and return the payload relation at the same `q`. | Exact live statement in `proof/DGG/SimConcealRevealPeel.agda:22`; packaged, but not inhabited, by `Catchup/LeftSourceOperationsDef.agda:211`. `SealPeelToolkit` has no relation-level equivalent. | Not refuted. `T10Probe3TargetKeepSameQ` refutes taking only the target step; its checked `after-both-peel-same-q` is this endpoint shape. |
+| `SourceOnlyConcealRevealPeelᵀ` | After the target keep happened first, use explicit evidence of that opening and consume the remaining source keep without reconstructing an impossible sealed target relation. | Exact live statement in `proof/DGG/SimConcealRevealPeel.agda:49`; packaged, but not inhabited, by `Catchup/LeftSourceOperationsDef.agda:211`. No `SealPeelToolkit` equivalent. | Not refuted. `T10Probe2SourceRevealStillSealed` refutes the weaker version with a still-sealed target; `TargetOpenedByConcealReveal` excludes it. |
+| `PairedIdConcealPeelᵀ` | When both endpoints carry identity conceal wrappers, consume both `id-conceal` keep steps atomically. | Statement-equivalent field only in `notes/probes/T12TwoSidedPeelRestatementProbe.agda:336`; `Catchup/StructuralFrameOutcomeProof.agda:53` classifies each runtime step but does not peel the relation. No `SealPeelToolkit` equivalent. | No existing counterexample refutes these assumptions. |
+| `SourceOpenedIdConcealPeelᵀ` | After the target identity conceal has already stepped, consume the remaining source `id-conceal` wrapper and return the payload relation. | Statement-equivalent field only in `notes/probes/T12TwoSidedPeelRestatementProbe.agda:351`; runtime classification alone exists in `Catchup/StructuralFrameOutcomeProof.agda:53`. No `SealPeelToolkit` equivalent. | No existing counterexample refutes these assumptions. |
+
+Here are the full statements checked against the current live definitions.
+
+### `PairedConcealRevealPeelᵀ`
+
+```agda
+PairedConcealRevealPeelᵀ : Set
+PairedConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → ((V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′) —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+### `TargetOpenedByConcealReveal`
+
+This is genuine evidence used by the next statement, not an abbreviation for
+part of its conclusion.
+
+```agda
+record TargetOpenedByConcealReveal {Δᴿ : TyCtx}
+    (N : Term Δᴿ) (X : TyVar Δᴿ) (R′ : Ty Δᴿ)
+    (V′ : Term Δᴿ) : Set where
+  field
+    opened-value : Value V′
+    opened-step :
+      ((N ↓ seal X R′) ↑ unseal X R′) —→[ keep ] V′
+```
+
+### `SourceOnlyConcealRevealPeelᵀ`
+
+```agda
+SourceOnlyConcealRevealPeelᵀ : Set
+SourceOnlyConcealRevealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {N′ V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → TargetOpenedByConcealReveal N′ Xᴿ R′ V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R)
+      ⊑ V₀′ ∶ q
+  → ((V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R) —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+### `PairedIdConcealPeelᵀ`
+
+```agda
+PairedIdConcealPeelᵀ : Set
+PairedIdConcealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢² (V₀ ↓ id↓ A) ⊑ (V₀′ ↓ id↓ B) ∶ q
+  → (V₀ ↓ id↓ A) —→[ keep ] V₀
+  → (V₀′ ↓ id↓ B) —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+### `SourceOpenedIdConcealPeelᵀ`
+
+```agda
+SourceOpenedIdConcealPeelᵀ : Set
+SourceOpenedIdConcealPeelᵀ =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢² (V₀ ↓ id↓ A) ⊑ V₀′ ∶ q
+  → (V₀ ↓ id↓ A) —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+No statement asks for either counterexample endpoint
+`source-revealed ⊑ target-sealed` or
+`source-revealed ⊑ target-payload` after only the target step.  That is the
+essential narrowing inherited from T12.
+
+
+Checked artifacts
+-----------------
+
+Focused probe command:
+
+```text
+PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH \
+  agda --safe -v0 -i . -i proof/DGG/notes/probes \
+  proof/DGG/notes/probes/D19BPrimeReconProbe.agda
+```
+
+Result: exit 0.
+
+Repository-wide final gate:
+
+```text
+cd GTSFImp && \
+  PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH \
+  make check
+```
+
+Result: exit 0 on 2026-08-19.

--- a/GTSFImp/proof/DGG/notes/probes/D16PairedSealRecalibrationProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D16PairedSealRecalibrationProbe.agda
@@ -1,0 +1,264 @@
+module D16PairedSealRecalibrationProbe where
+
+-- File Charter:
+--   * Expands the live Examples2 YZ paired-seal stores and alignment.
+--   * Checks that changing only the Z center from X⊑★ to X⊑X makes
+--     the live variable-to-dynamic type-imprecision judgment empty.
+--   * Drafts store-mediated and seal-boundary recalibration candidates
+--     without changing the live type- or term-imprecision relations.
+--   * Checks the recalibrated fixture against all four landed world
+--     invariants and records why boundary dynamization fails invariant (5).
+
+open import Data.Empty using (⊥; ⊥-elim)
+import Data.Fin as Fin
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ‵_; `ℕ; _⇒_)
+open import TyStore using
+  (TyStore; store-empty; store-bind; lookupStore)
+open import Consistency using
+  (_↪ᵗ_; empty; keep; skip; toRenameᵗ)
+open import Imprecision using
+  (ImpEnv; X⊑X; X⊑★; ★⊑★; ⇒⊑⇒)
+import Imprecision as I
+import proof.DGG.CtxImp as CTX
+import proof.DGG.ExampleTerms as Ex
+import proof.DGG.Examples2 as Ex2
+import proof.DGG.WorldInvariants as WI
+
+------------------------------------------------------------------------
+-- The fully expanded YZ fixture at Examples2 checkpoints 3 and 4
+------------------------------------------------------------------------
+
+yz-source-store : TyStore 3
+yz-source-store =
+  store-bind (store-bind (store-bind store-empty ★) (＇ Fin.zero)) (‵ `ℕ)
+
+yz-target-store : TyStore 2
+yz-target-store = store-bind (store-bind store-empty ★) (＇ Fin.zero)
+
+examples2-source-store₃-expanded : Ex.right-store₃ ≡ yz-source-store
+examples2-source-store₃-expanded = refl
+
+examples2-source-store₄-expanded : Ex.right-store₄ ≡ yz-source-store
+examples2-source-store₄-expanded = refl
+
+examples2-target-store₃-expanded :
+  Ex2.left-path-target-store₃ ≡ yz-target-store
+examples2-target-store₃-expanded = refl
+
+examples2-target-store₄-expanded :
+  Ex2.left-path-target-store₄ ≡ yz-target-store
+examples2-target-store₄-expanded = refl
+
+yz-source-η : 3 ↪ᵗ 3
+yz-source-η = keep (keep (keep empty))
+
+yz-target-η : 2 ↪ᵗ 3
+yz-target-η = skip (keep (keep empty))
+
+yz-dynamic-env : ImpEnv 3
+yz-dynamic-env Fin.zero = X⊑★
+yz-dynamic-env (Fin.suc Fin.zero) = X⊑★
+yz-dynamic-env (Fin.suc (Fin.suc Fin.zero)) = X⊑★
+
+yz-precise-Z-env : ImpEnv 3
+yz-precise-Z-env Fin.zero = X⊑★
+yz-precise-Z-env (Fin.suc Fin.zero) = X⊑★
+yz-precise-Z-env (Fin.suc (Fin.suc Fin.zero)) = X⊑X
+
+yz-dynamic-world : CTX.World 3 2 3
+yz-dynamic-world =
+  CTX.world yz-source-η yz-target-η yz-dynamic-env
+    yz-source-store yz-target-store
+
+yz-precise-Z-world : CTX.World 3 2 3
+yz-precise-Z-world =
+  CTX.world yz-source-η yz-target-η yz-precise-Z-env
+    yz-source-store yz-target-store
+
+------------------------------------------------------------------------
+-- The forcing judgment
+------------------------------------------------------------------------
+
+yz-Z-to-star-dynamic :
+  (＇ (Fin.suc (Fin.suc Fin.zero)))
+    CTX.⊑ᵂ⟨ yz-dynamic-world ⟩ ★
+yz-Z-to-star-dynamic = I.X⊑★ refl
+
+yz-Z-function-to-star-dynamic :
+  ((＇ (Fin.suc (Fin.suc Fin.zero)))
+    ⇒ (＇ (Fin.suc (Fin.suc Fin.zero))))
+    CTX.⊑ᵂ⟨ yz-dynamic-world ⟩ (★ ⇒ ★)
+yz-Z-function-to-star-dynamic =
+  ⇒⊑⇒ yz-Z-to-star-dynamic yz-Z-to-star-dynamic
+
+yz-Z-to-star-precise-empty :
+  (＇ (Fin.suc (Fin.suc Fin.zero)))
+    CTX.⊑ᵂ⟨ yz-precise-Z-world ⟩ ★
+  → ⊥
+yz-Z-to-star-precise-empty (I.X⊑★ ())
+
+yz-Z-function-to-star-precise-empty :
+  ((＇ (Fin.suc (Fin.suc Fin.zero)))
+    ⇒ (＇ (Fin.suc (Fin.suc Fin.zero))))
+    CTX.⊑ᵂ⟨ yz-precise-Z-world ⟩ (★ ⇒ ★)
+  → ⊥
+yz-Z-function-to-star-precise-empty
+    (I.⇒⊑⇒ Z-domain-to-star Z-codomain-to-star) =
+  yz-Z-to-star-precise-empty Z-domain-to-star
+
+------------------------------------------------------------------------
+-- Candidate A: store-mediated variable-to-dynamic imprecision
+------------------------------------------------------------------------
+
+infix 4 _⊑ˢ⟨_⟩_
+
+data _⊑ˢ⟨_⟩_ { Δᴸ Δᴿ Δ : TyCtx}
+    : Ty Δᴸ → CTX.World Δᴸ Δᴿ Δ → Ty Δᴿ → Set where
+  live : ∀ {A B} {W : CTX.World Δᴸ Δᴿ Δ}
+    → A CTX.⊑ᵂ⟨ W ⟩ B
+    → A ⊑ˢ⟨ W ⟩ B
+
+  ⇒⊑⇒-store : ∀ {A A′ B B′} {W : CTX.World Δᴸ Δᴿ Δ}
+    → A ⊑ˢ⟨ W ⟩ A′
+    → B ⊑ˢ⟨ W ⟩ B′
+    → (A ⇒ B) ⊑ˢ⟨ W ⟩ (A′ ⇒ B′)
+
+  X⊑★-store : ∀ {W : CTX.World Δᴸ Δᴿ Δ} {Xᴸ : TyVar Δᴸ}
+    → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
+    → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
+    → (＇ Xᴸ) ⊑ˢ⟨ W ⟩ ★
+
+yz-Z-to-star-store-mediated :
+  (＇ (Fin.suc (Fin.suc Fin.zero)))
+    ⊑ˢ⟨ yz-precise-Z-world ⟩ ★
+yz-Z-to-star-store-mediated = X⊑★-store refl refl
+
+yz-Z-function-to-star-store-mediated :
+  ((＇ (Fin.suc (Fin.suc Fin.zero)))
+    ⇒ (＇ (Fin.suc (Fin.suc Fin.zero))))
+    ⊑ˢ⟨ yz-precise-Z-world ⟩ (★ ⇒ ★)
+yz-Z-function-to-star-store-mediated =
+  ⇒⊑⇒-store yz-Z-to-star-store-mediated yz-Z-to-star-store-mediated
+
+------------------------------------------------------------------------
+-- Candidate B: a target-unseal exception to mark monotonicity
+------------------------------------------------------------------------
+
+RevealMarkTransition : ∀ { Δᴸ Δᴿ Δ}
+  → CTX.World Δᴸ Δᴿ Δ
+  → CTX.World Δᴸ Δᴿ Δ
+  → TyVar Δᴿ
+  → Set
+RevealMarkTransition W Wᵖ Xᴿ = ∀ Z
+  → CTX.impEnvʷ W Z ≡ X⊑★
+  → CTX.impEnvʷ Wᵖ Z ≡ X⊑★
+    ⊎ (Z ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+      × CTX.impEnvʷ Wᵖ Z ≡ X⊑X)
+
+yz-target-Z-unseal-transition :
+  RevealMarkTransition yz-dynamic-world yz-precise-Z-world
+    (Fin.suc Fin.zero)
+yz-target-Z-unseal-transition Fin.zero refl = inj₁ refl
+yz-target-Z-unseal-transition (Fin.suc Fin.zero) refl = inj₁ refl
+yz-target-Z-unseal-transition (Fin.suc (Fin.suc Fin.zero)) refl =
+  inj₂ (refl , refl)
+
+yz-dynamic-world-rejects-invariant5 :
+  WI.WorldInvariants yz-dynamic-world → ⊥
+yz-dynamic-world-rejects-invariant5 inv =
+  WI.dynamicStarSourcesUnoccupied inv
+    (Fin.suc (Fin.suc Fin.zero)) refl refl
+    (Fin.suc Fin.zero) refl
+
+------------------------------------------------------------------------
+-- The X⊑X recalibration satisfies all four live world invariants
+------------------------------------------------------------------------
+
+yz-precise-Z-world-invariants : WI.WorldInvariants yz-precise-Z-world
+yz-precise-Z-world-invariants =
+  WI.world-invariants precise representations unmatched no-dynamic-star
+  where
+  precise : ∀ Xᴸ
+    → CTX.impEnvʷ yz-precise-Z-world
+        (toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ) ≡ X⊑X
+    → Σ[ Xᴿ ∈ TyVar 2 ]
+        toRenameᵗ (CTX.ηᴿʷ yz-precise-Z-world) Xᴿ ≡
+        toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ
+  precise Fin.zero ()
+  precise (Fin.suc Fin.zero) ()
+  precise (Fin.suc (Fin.suc Fin.zero)) refl =
+    Fin.suc Fin.zero , refl
+
+  representations : ∀ {Xᴸ : TyVar 3} {Xᴿ : TyVar 2}
+    → toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ ≡
+        toRenameᵗ (CTX.ηᴿʷ yz-precise-Z-world) Xᴿ
+    → I._⊢_⊑_ (CTX.impEnvʷ yz-precise-Z-world)
+        (CTX.embedᴸ yz-precise-Z-world
+          (lookupStore (CTX.sourceStoreʷ yz-precise-Z-world) Xᴸ))
+        (CTX.embedᴿ yz-precise-Z-world
+          (lookupStore (CTX.targetStoreʷ yz-precise-Z-world) Xᴿ))
+  representations {Fin.zero} {Fin.zero} ()
+  representations {Fin.zero} {Fin.suc Fin.zero} ()
+  representations {Fin.suc Fin.zero} {Fin.zero} refl = I.X⊑X
+  representations {Fin.suc Fin.zero} {Fin.suc Fin.zero} ()
+  representations {Fin.suc (Fin.suc Fin.zero)} {Fin.zero} ()
+  representations {Fin.suc (Fin.suc Fin.zero)}
+      {Fin.suc Fin.zero} refl = ★⊑★
+
+  unmatched : ∀ Xᴿ
+    → (∀ Xᴸ
+      → toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ
+        ≢ toRenameᵗ (CTX.ηᴿʷ yz-precise-Z-world) Xᴿ)
+    → lookupStore (CTX.targetStoreʷ yz-precise-Z-world) Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+          lookupStore (CTX.targetStoreʷ yz-precise-Z-world) Xᴿ
+            ≡ ＇ Yᴿ
+        × (∀ Xᴸ
+          → toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ
+            ≢ toRenameᵗ (CTX.ηᴿʷ yz-precise-Z-world) Yᴿ)
+  unmatched Fin.zero no-source =
+    ⊥-elim (no-source (Fin.suc Fin.zero) refl)
+  unmatched (Fin.suc Fin.zero) no-source =
+    ⊥-elim (no-source (Fin.suc (Fin.suc Fin.zero)) refl)
+
+  no-dynamic-star : ∀ Xᴸ
+    → CTX.impEnvʷ yz-precise-Z-world
+        (toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ yz-precise-Z-world) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTX.ηᴿʷ yz-precise-Z-world) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ yz-precise-Z-world) Xᴸ
+  no-dynamic-star Fin.zero refl () Xᴿ
+  no-dynamic-star (Fin.suc Fin.zero) refl () Xᴿ
+  no-dynamic-star (Fin.suc (Fin.suc Fin.zero)) () entry Xᴿ
+
+------------------------------------------------------------------------
+-- Candidate C: raw reinterpretation of X⊑X (rejected by the probe)
+------------------------------------------------------------------------
+
+infix 4 _⊑ʳ⟨_⟩_
+
+data _⊑ʳ⟨_⟩_ { Δᴸ Δᴿ Δ : TyCtx}
+    : Ty Δᴸ → CTX.World Δᴸ Δᴿ Δ → Ty Δᴿ → Set where
+  X⊑★-raw : ∀ {W : CTX.World Δᴸ Δᴿ Δ} {Xᴸ : TyVar Δᴸ}
+    → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑X
+    → (＇ Xᴸ) ⊑ʳ⟨ W ⟩ ★
+
+raw-precise-env : ImpEnv 1
+raw-precise-env Fin.zero = X⊑X
+
+raw-counterexample-world : CTX.World 1 1 1
+raw-counterexample-world =
+  CTX.world (keep empty) (keep empty) raw-precise-env
+    (store-bind store-empty (‵ `ℕ))
+    (store-bind store-empty (‵ `ℕ))
+
+raw-rule-ignores-nondynamic-store :
+  (＇ Fin.zero) ⊑ʳ⟨ raw-counterexample-world ⟩ ★
+  × lookupStore (CTX.sourceStoreʷ raw-counterexample-world) Fin.zero
+      ≡ ‵ `ℕ
+raw-rule-ignores-nondynamic-store = X⊑★-raw refl , refl

--- a/GTSFImp/proof/DGG/notes/probes/D16WideMarkIndependenceProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D16WideMarkIndependenceProbe.agda
@@ -1,0 +1,85 @@
+module D16WideMarkIndependenceProbe where
+
+-- File Charter:
+--   * Checks that stores and center alignment do not determine impEnv marks,
+--     even after all four landed D16 WorldInvariants fields are required.
+--   * Uses two one-cell worlds with identical embeddings and stores and with
+--     different marks as the minimal counterexample to mark reconstruction.
+--   * Changes no live definition and depends only on the landed D16 layer.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types
+open import TyStore using (TyStore; store-empty; store-bind)
+open import Consistency using (id↪ᵗ; toRenameᵗ)
+open import Imprecision using (ImpEnv; X⊑X; X⊑★)
+import proof.DGG.CtxImp as CTX
+import proof.DGG.WorldInvariants as WI
+
+
+------------------------------------------------------------------------
+-- Same layout, two valid mark choices
+------------------------------------------------------------------------
+
+nat-store : TyStore 1
+nat-store = store-bind store-empty (‵ `ℕ)
+
+precise-env : ImpEnv 1
+precise-env Fin.zero = X⊑X
+
+dynamic-env : ImpEnv 1
+dynamic-env Fin.zero = X⊑★
+
+precise-world : CTX.World 1 1 1
+precise-world = CTX.world id↪ᵗ id↪ᵗ precise-env nat-store nat-store
+
+dynamic-world : CTX.World 1 1 1
+dynamic-world = CTX.world id↪ᵗ id↪ᵗ dynamic-env nat-store nat-store
+
+precise-world-invariants : WI.WorldInvariants precise-world
+precise-world-invariants =
+  WI.identityWorld-invariants precise-env nat-store no-dynamic-star
+  where
+  no-dynamic-star : ∀ X
+    → precise-env (toRenameᵗ id↪ᵗ X) ≡ X⊑★
+    → TyStore.lookupStore nat-store X ≡ ★
+    → ∀ Y
+    → toRenameᵗ id↪ᵗ Y ≢ toRenameᵗ id↪ᵗ X
+  no-dynamic-star Fin.zero () entry Y aligned
+
+dynamic-world-invariants : WI.WorldInvariants dynamic-world
+dynamic-world-invariants =
+  WI.identityWorld-invariants dynamic-env nat-store no-dynamic-star
+  where
+  no-dynamic-star : ∀ X
+    → dynamic-env (toRenameᵗ id↪ᵗ X) ≡ X⊑★
+    → TyStore.lookupStore nat-store X ≡ ★
+    → ∀ Y
+    → toRenameᵗ id↪ᵗ Y ≢ toRenameᵗ id↪ᵗ X
+  no-dynamic-star Fin.zero mark () Y aligned
+
+
+------------------------------------------------------------------------
+-- Refutation of reconstruction from valid layouts
+------------------------------------------------------------------------
+
+ValidLayoutsDetermineMarks : Set
+ValidLayoutsDetermineMarks =
+  ∀ {W W′ : CTX.World 1 1 1}
+  → WI.WorldInvariants W
+  → WI.WorldInvariants W′
+  → CTX.ηᴸʷ W ≡ CTX.ηᴸʷ W′
+  → CTX.ηᴿʷ W ≡ CTX.ηᴿʷ W′
+  → CTX.sourceStoreʷ W ≡ CTX.sourceStoreʷ W′
+  → CTX.targetStoreʷ W ≡ CTX.targetStoreʷ W′
+  → ∀ Z
+  → CTX.impEnvʷ W Z ≡ CTX.impEnvʷ W′ Z
+
+valid-layouts-do-not-determine-marks :
+  ValidLayoutsDetermineMarks → ⊥
+valid-layouts-do-not-determine-marks determines
+    with determines precise-world-invariants dynamic-world-invariants
+      refl refl refl refl Fin.zero
+valid-layouts-do-not-determine-marks determines | ()

--- a/GTSFImp/proof/DGG/notes/probes/D19BPrimeReconProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D19BPrimeReconProbe.agda
@@ -1,0 +1,300 @@
+module D19BPrimeReconProbe where
+
+-- File Charter:
+--   * Checks D19 B-prime reconnaissance facts without changing live code.
+--   * Exhibits matched-center decay in the current generic mark machinery.
+--   * Checks that smart-alias's dynamic matched center is born in a
+--     source-only smart-comma world.
+--   * Type-checks, but does not prove, the four async-window peel statements.
+
+open import Data.List using ([])
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+open import Data.Nat using (suc)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans; cong)
+
+open import Types using (Ty; TyCtx; TyVar; ＇_)
+open import TyStore using (TyStore; store-empty; store-lift)
+import Consistency as C
+open import Imprecision using (ImpEnv; X⊑X; X⊑★)
+import Imprecision as I
+import Conversion as Conv
+open import CastTerms using (Term; Value; _↑_; _↓_)
+open import Reduction using (keep; _—→[_]_)
+import proof.DGG.CastTermImprecision as CTI2
+import proof.DGG.CenterRename as CR
+import proof.DGG.CtxImp as CTX
+import proof.DGG.SealPeelToolkit as SPT
+import proof.DGG.SimConcealRevealPeel as Peel
+import proof.DGG.TargetBindLift as TBL
+import proof.DGG.TermImpDecay as TID
+import proof.DGG.WorldDecay as WD
+import proof.DGG.WorldInvariants as WI
+
+open CTX using (World; CtxImp; _⊑ᵂ⟨_⟩_)
+open CTI2 using (_∣_⊢²_⊑_∶_)
+
+
+------------------------------------------------------------------------
+-- One matched center: generic decay really can erase a paired mark
+------------------------------------------------------------------------
+
+precise-env : ImpEnv 1
+precise-env Fin.zero = X⊑X
+
+dynamic-env : ImpEnv 1
+dynamic-env Fin.zero = X⊑★
+
+one-cell-store : TyStore 1
+one-cell-store = store-lift store-empty
+
+precise-world : World 1 1 1
+precise-world =
+  CTX.world (C.keep C.empty) (C.keep C.empty) precise-env
+    one-cell-store one-cell-store
+
+dynamic-world : World 1 1 1
+dynamic-world =
+  CTX.world (C.keep C.empty) (C.keep C.empty) dynamic-env
+    one-cell-store one-cell-store
+
+precise-center-matched :
+  CTX.CenterAligned precise-world Fin.zero Fin.zero
+precise-center-matched = refl
+
+dynamic-center-matched :
+  CTX.CenterAligned dynamic-world Fin.zero Fin.zero
+dynamic-center-matched = refl
+
+generic-mono-decays-matched : CTX.ImpEnvMono precise-world dynamic-world
+generic-mono-decays-matched Fin.zero ()
+
+generic-env-decay-decays-matched : WD.EnvDecay precise-world dynamic-world
+generic-env-decay-decays-matched =
+  WD.env-decay refl refl refl refl generic-mono-decays-matched
+
+blend-decays-matched :
+  CTX.impEnvʷ (WD.blendWorld precise-world dynamic-world) Fin.zero ≡ X⊑★
+blend-decays-matched = refl
+
+dyn-world-decays-matched :
+  CTX.impEnvʷ (SPT.dynWorld precise-world) Fin.zero ≡ X⊑★
+dyn-world-decays-matched = refl
+
+honestify-keeps-matched :
+  CTX.impEnvʷ (WD.honestify precise-world) Fin.zero ≡ X⊑X
+honestify-keeps-matched = refl
+
+precise-world-invariants : WI.WorldInvariants precise-world
+precise-world-invariants = WI.initialWorld-invariants precise-env
+
+dynamic-lift-passes-live-invariants :
+  WI.WorldInvariants (CTX.liftWorldBoth X⊑★ precise-world)
+dynamic-lift-passes-live-invariants =
+  WI.liftWorldBoth-invariants X⊑★ precise-world-invariants
+
+generic-rebase-decays-matched :
+  CTX.RebaseAt precise-world dynamic-world Fin.zero Fin.zero
+generic-rebase-decays-matched =
+  CTX.rebase-at (CTX.same-runtime refl refl)
+    (λ neq → refl) (λ _ → refl) refl
+    (CTX.store-rep-imp I.X⊑X)
+
+
+------------------------------------------------------------------------
+-- Builders and the explicit paired-binder decay
+------------------------------------------------------------------------
+
+lift-both-precise-head :
+  CTX.impEnvʷ (CTX.liftWorldBoth X⊑X precise-world) Fin.zero ≡ X⊑X
+lift-both-precise-head = refl
+
+lift-both-dynamic-head :
+  CTX.impEnvʷ (CTX.liftWorldBoth X⊑★ precise-world) Fin.zero ≡ X⊑★
+lift-both-dynamic-head = refl
+
+lift-both-head-matched :
+  CTX.CenterAligned (CTX.liftWorldBoth X⊑★ precise-world)
+    Fin.zero Fin.zero
+lift-both-head-matched = refl
+
+lift-left-dynamic-head :
+  CTX.impEnvʷ (CTX.liftWorldLeft X⊑★ precise-world) Fin.zero ≡ X⊑★
+lift-left-dynamic-head = refl
+
+lift-left-head-not-target : ∀ Y
+  → C.toRenameᵗ
+      (CTX.ηᴿʷ (CTX.liftWorldLeft X⊑★ precise-world)) Y
+    ≢ C.toRenameᵗ
+      (CTX.ηᴸʷ (CTX.liftWorldLeft X⊑★ precise-world)) Fin.zero
+lift-left-head-not-target Fin.zero ()
+
+right-only-dynamic-head :
+  CTX.impEnvʷ (CTX.rightOnlyWorld precise-world (＇ Fin.zero))
+    Fin.zero ≡ X⊑★
+right-only-dynamic-head = refl
+
+right-only-head-not-source : ∀ X
+  → C.toRenameᵗ
+      (CTX.ηᴸʷ (CTX.rightOnlyWorld precise-world (＇ Fin.zero))) X
+    ≢ C.toRenameᵗ
+      (CTX.ηᴿʷ (CTX.rightOnlyWorld precise-world (＇ Fin.zero)))
+        Fin.zero
+right-only-head-not-source Fin.zero ()
+
+both-bind-precise-head :
+  CTX.impEnvʷ
+    (CTX.bothBindWorld X⊑X precise-world (＇ Fin.zero) (＇ Fin.zero))
+    Fin.zero ≡ X⊑X
+both-bind-precise-head = refl
+
+paired-binder-decay :
+  WD.EnvDecay
+    (CTX.liftWorldBoth X⊑X precise-world)
+    (CTX.liftWorldBoth X⊑★ precise-world)
+paired-binder-decay = TID.liftBothBinderDecay
+
+paired-binder-decay-erases-head :
+  CTX.impEnvʷ (CTX.liftWorldBoth X⊑★ precise-world) Fin.zero ≡ X⊑★
+paired-binder-decay-erases-head = refl
+
+
+------------------------------------------------------------------------
+-- Rename and target-store movement preserve old marks
+------------------------------------------------------------------------
+
+rename-preserves-old-paired-mark :
+  CTX.impEnvʷ (CR.renameWorld C.wk↪ᵗ precise-world)
+    (Fin.suc Fin.zero) ≡ X⊑X
+rename-preserves-old-paired-mark = refl
+
+rename-fresh-center-is-dynamic :
+  CTX.impEnvʷ (CR.renameWorld C.wk↪ᵗ precise-world) Fin.zero ≡ X⊑★
+rename-fresh-center-is-dynamic = refl
+
+target-store-as-preserves-mark :
+  CTX.impEnvʷ (TBL.targetStoreAs precise-world one-cell-store)
+    Fin.zero ≡ X⊑X
+target-store-as-preserves-mark = refl
+
+
+------------------------------------------------------------------------
+-- Smart alias: matched and dynamic, but created by a source-only lift
+------------------------------------------------------------------------
+
+smart-alias-pending-matched : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+    {Wᵐ : World (suc Δᴸ) Δᴿ Δ}
+    {β α : TyVar Δᴿ}
+  → (guard : CTX.SmartAliasMergeGuard W Wᵐ β α)
+  → CTX.CenterAligned Wᵐ Fin.zero β
+smart-alias-pending-matched {β = β} guard =
+  trans (CTX.SmartAliasMergeGuard.pending-at-alias guard)
+    (sym (CTX.SmartAliasMergeGuard.target-frozen guard β))
+
+smart-alias-pending-mark-dynamic : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+    {Wᵐ : World (suc Δᴸ) Δᴿ Δ}
+    {β α : TyVar Δᴿ}
+  → (guard : CTX.SmartAliasMergeGuard W Wᵐ β α)
+  → CTX.impEnvʷ Wᵐ (C.toRenameᵗ (CTX.ηᴸʷ Wᵐ) Fin.zero) ≡ X⊑★
+smart-alias-pending-mark-dynamic {Wᵐ = Wᵐ} guard =
+  trans
+    (cong (CTX.impEnvʷ Wᵐ)
+      (CTX.SmartAliasMergeGuard.pending-at-alias guard))
+    (CTX.SmartAliasMergeGuard.alias-mark-dynamic guard)
+
+smart-fresh-pending-unmatched : ∀ {Δᴸ Δᴿ Δ Δᵐ}
+    {W : World Δᴸ Δᴿ Δ}
+    {Wᵐ : World (suc Δᴸ) Δᴿ Δᵐ}
+  → CTX.SmartFreshBehindGuard W Wᵐ
+  → ∀ Y
+  → CTX.CenterAligned Wᵐ Fin.zero Y
+  → ⊥
+smart-fresh-pending-unmatched guard Y aligned =
+  CTX.SmartFreshBehindGuard.fresh-not-target guard Y (sym aligned)
+
+
+------------------------------------------------------------------------
+-- The target-bind tower exposes the current matched-dynamic middle slot
+------------------------------------------------------------------------
+
+tower-middle-matched :
+  CTX.CenterAligned (TBL.ΛLiftToBindFreshWorld X⊑★ precise-world)
+    Fin.zero Fin.zero
+tower-middle-matched = refl
+
+tower-middle-dynamic :
+  CTX.impEnvʷ (TBL.ΛLiftToBindFreshWorld X⊑★ precise-world)
+    (Fin.suc Fin.zero) ≡ X⊑★
+tower-middle-dynamic = refl
+
+
+------------------------------------------------------------------------
+-- Statement-only async-window inventory
+------------------------------------------------------------------------
+
+PairedConcealRevealPeelStatement : Set
+PairedConcealRevealPeelStatement =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ Conv.seal Xᴸ R) ↑ Conv.unseal Xᴸ R)
+      ⊑ ((V₀′ ↓ Conv.seal Xᴿ R′) ↑ Conv.unseal Xᴿ R′) ∶ q
+  → ((V₀ ↓ Conv.seal Xᴸ R) ↑ Conv.unseal Xᴸ R)
+      —→[ keep ] V₀
+  → ((V₀′ ↓ Conv.seal Xᴿ R′) ↑ Conv.unseal Xᴿ R′)
+      —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+SourceOnlyConcealRevealPeelStatement : Set
+SourceOnlyConcealRevealPeelStatement =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {N′ V₀′ : Term Δᴿ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    {R : Ty Δᴸ} {R′ : Ty Δᴿ}
+    {q : R ⊑ᵂ⟨ W ⟩ R′}
+  → Value V₀
+  → Peel.TargetOpenedByConcealReveal N′ Xᴿ R′ V₀′
+  → W ∣ γ ⊢²
+      ((V₀ ↓ Conv.seal Xᴸ R) ↑ Conv.unseal Xᴸ R)
+      ⊑ V₀′ ∶ q
+  → ((V₀ ↓ Conv.seal Xᴸ R) ↑ Conv.unseal Xᴸ R)
+      —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+PairedIdConcealPeelStatement : Set
+PairedIdConcealPeelStatement =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢²
+      (V₀ ↓ Conv.id↓ A) ⊑ (V₀′ ↓ Conv.id↓ B) ∶ q
+  → (V₀ ↓ Conv.id↓ A) —→[ keep ] V₀
+  → (V₀′ ↓ Conv.id↓ B) —→[ keep ] V₀′
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q
+
+SourceOpenedIdConcealPeelStatement : Set
+SourceOpenedIdConcealPeelStatement =
+  ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
+    {V₀ : Term Δᴸ} {V₀′ : Term Δᴿ}
+    {A : Ty Δᴸ} {B : Ty Δᴿ}
+    {q : A ⊑ᵂ⟨ W ⟩ B}
+  → Value V₀
+  → Value V₀′
+  → W ∣ γ ⊢² (V₀ ↓ Conv.id↓ A) ⊑ V₀′ ∶ q
+  → (V₀ ↓ Conv.id↓ A) —→[ keep ] V₀
+  → W ∣ γ ⊢² V₀ ⊑ V₀′ ∶ q

--- a/GTSFImp/proof/DGG/notes/probes/D19PairedRevealReparseProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D19PairedRevealReparseProbe.agda
@@ -1,0 +1,701 @@
+module D19PairedRevealReparseProbe where
+
+-- File Charter:
+--   * Tests D19's sync-first hypothesis without changing any live definition.
+--   * Rebuilds the Examples2 YZ worlds with the aligned Z center marked X⊑X.
+--   * Re-parses aligned Z reveals with CTI2.reveal⊑reveal² and retains the
+--     existing paired Z conceal in the checkpoint-9 argument.
+--   * Classifies each YZ Z-site as PAIRED-OK or ASYNC-FORCED, and records the
+--     independent live X-side obstruction to the stale checkpoint 4--9 code.
+
+open import Data.Empty using (⊥)
+open import Data.List using ([])
+open import Data.Maybe using (just; nothing)
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality using (refl)
+
+open import Types
+import Consistency as C
+open C using (_⊢_∼_; id; renameEnv∼; wk↪ᵗ; idᶜ)
+import Conversion as Conv
+open import Conversion using (Conv↑; Conv↓; seal; unseal)
+open import Imprecision using
+  (ImpEnv; X⊑X; X⊑★; ★⊑★; ⇒⊑⇒)
+import Imprecision as I
+open import CastTerms
+open import Primitives using (κℕ)
+open import Reduction using (bind; applyEnv)
+import proof.DGG.CastTermImprecision as CTI2
+import proof.DGG.CtxImp as CTX
+import proof.DGG.ExampleTerms as Ex
+import proof.DGG.Examples2 as Ex2
+
+open CTX using (World; _⊑ᵂ⟨_⟩_)
+open CTI2 using (_∣_⊢²_⊑_∶_)
+
+
+------------------------------------------------------------------------
+-- Precise-Z variants of the two YZ worlds
+------------------------------------------------------------------------
+
+yz-precise-Z-env : ImpEnv 3
+yz-precise-Z-env Fin.zero = X⊑★
+yz-precise-Z-env (Fin.suc Fin.zero) = X⊑★
+yz-precise-Z-env (Fin.suc (Fin.suc Fin.zero)) = X⊑X
+
+left-path-world₃-precise-Z : World 3 2 3
+left-path-world₃-precise-Z =
+  CTX.world Ex2.id↪ᵗ Ex2.left-path-target-ηᴿ-YZ yz-precise-Z-env
+    Ex.right-store₃ Ex2.left-path-target-store₃
+
+left-path-world₄-precise-Z : World 3 2 3
+left-path-world₄-precise-Z =
+  CTX.world Ex2.id↪ᵗ Ex2.left-path-target-ηᴿ-YZ yz-precise-Z-env
+    Ex.right-store₄ Ex2.left-path-target-store₄
+
+
+------------------------------------------------------------------------
+-- Shared indices and rebases
+------------------------------------------------------------------------
+
+left-path-ℕ⊑★₃-precise-Z :
+  (‵ `ℕ) ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩ ★
+left-path-ℕ⊑★₃-precise-Z =
+  Ex2.ℕ⊑★² {W = left-path-world₃-precise-Z}
+
+left-path-ℕ⊑★₄-precise-Z :
+  (‵ `ℕ) ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ ★
+left-path-ℕ⊑★₄-precise-Z =
+  Ex2.ℕ⊑★² {W = left-path-world₄-precise-Z}
+
+left-path-Y-var⊑YZ₃-precise-Z :
+  ＇ (Fin.suc Fin.zero) ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩ ＇ Fin.zero
+left-path-Y-var⊑YZ₃-precise-Z = I.X⊑X
+
+left-path-Z-var⊑YZ₃-precise-Z :
+  ＇ (Fin.suc (Fin.suc Fin.zero))
+    ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩ ＇ (Fin.suc Fin.zero)
+left-path-Z-var⊑YZ₃-precise-Z = I.X⊑X
+
+left-path-Y⇒Y⊑Y⇒Y-YZ₃-precise-Z :
+  (＇ (Fin.suc Fin.zero) ⇒ ＇ (Fin.suc Fin.zero))
+    ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩ (＇ Fin.zero ⇒ ＇ Fin.zero)
+left-path-Y⇒Y⊑Y⇒Y-YZ₃-precise-Z =
+  ⇒⊑⇒ left-path-Y-var⊑YZ₃-precise-Z left-path-Y-var⊑YZ₃-precise-Z
+
+left-path-Z⇒Z⊑Z⇒Z-YZ₃-precise-Z :
+  (＇ (Fin.suc (Fin.suc Fin.zero))
+    ⇒ ＇ (Fin.suc (Fin.suc Fin.zero)))
+    ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩
+      (＇ (Fin.suc Fin.zero) ⇒ ＇ (Fin.suc Fin.zero))
+left-path-Z⇒Z⊑Z⇒Z-YZ₃-precise-Z =
+  ⇒⊑⇒ left-path-Z-var⊑YZ₃-precise-Z left-path-Z-var⊑YZ₃-precise-Z
+
+left-path-X-var⊑★-YZ₃-precise-Z :
+  ＇ Fin.zero ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩ ★
+left-path-X-var⊑★-YZ₃-precise-Z = I.X⊑★ refl
+
+left-path-X⇒X⊑★⇒★-YZ₃-precise-Z :
+  (＇ Fin.zero ⇒ ＇ Fin.zero)
+    ⊑ᵂ⟨ left-path-world₃-precise-Z ⟩ (★ ⇒ ★)
+left-path-X⇒X⊑★⇒★-YZ₃-precise-Z =
+  ⇒⊑⇒ left-path-X-var⊑★-YZ₃-precise-Z
+    left-path-X-var⊑★-YZ₃-precise-Z
+
+left-path-Y-rep₃-precise-Z :
+  CTX.StoreRepImp left-path-world₃-precise-Z
+    (Fin.suc Fin.zero) Fin.zero
+left-path-Y-rep₃-precise-Z = CTX.store-rep-imp ★⊑★
+
+left-path-Z-rep₃-precise-Z :
+  CTX.StoreRepImp left-path-world₃-precise-Z
+    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
+left-path-Z-rep₃-precise-Z = CTX.store-rep-imp ★⊑★
+
+left-path-rebase-Y-YZ₃-precise-Z :
+  CTX.RebaseAt left-path-world₃-precise-Z left-path-world₃-precise-Z
+    (Fin.suc Fin.zero) Fin.zero
+left-path-rebase-Y-YZ₃-precise-Z =
+  CTX.sameWorldRebaseAt refl left-path-Y-rep₃-precise-Z
+
+left-path-rebase-Z-YZ₃-precise-Z :
+  CTX.RebaseAt left-path-world₃-precise-Z left-path-world₃-precise-Z
+    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
+left-path-rebase-Z-YZ₃-precise-Z =
+  CTX.sameWorldRebaseAt refl left-path-Z-rep₃-precise-Z
+
+left-path-rebase-X-YZ₃-precise-Zᴸ :
+  CTX.RebaseAtᴸ left-path-world₃-precise-Z left-path-world₃-precise-Z
+    (just Fin.zero)
+left-path-rebase-X-YZ₃-precise-Zᴸ =
+  CTX.rebase-onlyᴸ refl
+    (λ { Fin.zero (); (Fin.suc Fin.zero) () })
+    left-path-ℕ⊑★₃-precise-Z
+
+
+------------------------------------------------------------------------
+-- Checkpoint 3: PAIRED-OK
+------------------------------------------------------------------------
+
+left-path-lambda₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢²
+    ƛ (` 0) ⊑ Ex2.left-path-target-lambda₃ ∶
+      left-path-Y⇒Y⊑Y⇒Y-YZ₃-precise-Z
+left-path-lambda₃-precise-Z =
+  CTI2.ƛ⊑ƛ²
+    {A = ＇ (Fin.suc Fin.zero)} {A′ = ＇ Fin.zero}
+    {B = ＇ (Fin.suc Fin.zero)} {B′ = ＇ Fin.zero}
+    {pA = left-path-Y-var⊑YZ₃-precise-Z}
+    {pB = left-path-Y-var⊑YZ₃-precise-Z}
+    (CTI2.x⊑x² {p = left-path-Y-var⊑YZ₃-precise-Z} CTX.Zʷ)
+
+left-path-Y-revealed₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢²
+    (ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal
+    ⊑ Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂ ∶
+      left-path-Z⇒Z⊑Z⇒Z-YZ₃-precise-Z
+left-path-Y-revealed₃-precise-Z =
+  CTI2.reveal⊑reveal² (λ _ eq → eq)
+    left-path-rebase-Y-YZ₃-precise-Z CTX.same-[]
+    Ex2.left-path-source-Y-reveal₃-⊢ˣ
+    Ex2.left-path-target-Y-reveal₃-⊢ˣ
+    left-path-lambda₃-precise-Z left-path-Z⇒Z⊑Z⇒Z-YZ₃-precise-Z
+
+-- Paired-Z derivation head (checkpoint 3):
+--   CTI2.reveal⊑reveal² (λ _ eq → eq)
+--     left-path-rebase-Z-YZ₃-precise-Z CTX.same-[]
+left-path-both-Z-revealed₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢²
+    ((ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal)
+      ↑ Ex2.example12-target-Z-reveal
+    ⊑ (Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂)
+        ↑ Ex2.left-path-Z-reveal₂ ∶
+      Ex2.★⇒★⊑★⇒★² {W = left-path-world₃-precise-Z}
+left-path-both-Z-revealed₃-precise-Z =
+  CTI2.reveal⊑reveal² (λ _ eq → eq)
+    left-path-rebase-Z-YZ₃-precise-Z CTX.same-[]
+    Ex2.left-path-source-Z-reveal₃-⊢ˣ
+    Ex2.left-path-target-Z-reveal₃-⊢ˣ
+    left-path-Y-revealed₃-precise-Z
+    (Ex2.★⇒★⊑★⇒★² {W = left-path-world₃-precise-Z})
+
+left-path-source-id₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢²
+    (((ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal)
+      ↑ Ex2.example12-target-Z-reveal)
+      ⟨ Ex2.example12-target-id★↦id★ ⟩
+    ⊑ (Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂)
+        ↑ Ex2.left-path-Z-reveal₂ ∶
+      Ex2.★⇒★⊑★⇒★² {W = left-path-world₃-precise-Z}
+left-path-source-id₃-precise-Z =
+  CTI2.cast⊑² Ex2.example12-target-id★↦id★
+    left-path-both-Z-revealed₃-precise-Z
+    (Ex2.★⇒★⊑★⇒★² {W = left-path-world₃-precise-Z})
+
+left-path-source-X?₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢²
+    ((((ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal)
+      ↑ Ex2.example12-target-Z-reveal)
+      ⟨ Ex2.example12-target-id★↦id★ ⟩)
+      ⟨ Ex2.example12-target-X?↦X? ⟩
+    ⊑ (Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂)
+        ↑ Ex2.left-path-Z-reveal₂ ∶
+      left-path-X⇒X⊑★⇒★-YZ₃-precise-Z
+left-path-source-X?₃-precise-Z =
+  CTI2.cast⊑² Ex2.example12-target-X?↦X?
+    left-path-source-id₃-precise-Z left-path-X⇒X⊑★⇒★-YZ₃-precise-Z
+
+left-path-function₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢²
+    (((((ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal)
+      ↑ Ex2.example12-target-Z-reveal)
+      ⟨ Ex2.example12-target-id★↦id★ ⟩)
+      ⟨ Ex2.example12-target-X?↦X? ⟩)
+      ↑ Ex2.example12-target-X-reveal
+    ⊑ (Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂)
+        ↑ Ex2.left-path-Z-reveal₂ ∶
+      Ex2.ℕ⇒ℕ⊑★⇒★² {W = left-path-world₃-precise-Z}
+left-path-function₃-precise-Z =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    left-path-rebase-X-YZ₃-precise-Zᴸ CTX.same-[]
+    Ex2.left-path-source-X-reveal₃-⊢ˣ left-path-source-X?₃-precise-Z
+    (Ex2.ℕ⇒ℕ⊑★⇒★² {W = left-path-world₃-precise-Z})
+
+left-path-argument₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢² $ (κℕ 7)
+    ⊑ ($ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩)
+        ⟨ C.sym∼ Ex2.left-path-target-result-id★₃ ⟩ ∶
+      left-path-ℕ⊑★₃-precise-Z
+left-path-argument₃-precise-Z =
+  CTI2.⊑cast² (C.sym∼ Ex2.left-path-target-result-id★₃)
+    (CTI2.⊑cast² Ex2.left-path-ℕ!₂
+      (CTI2.κ⊑κ² (κℕ 7)
+        (Ex2.ℕ⊑ℕ² {W = left-path-world₃-precise-Z}))
+      left-path-ℕ⊑★₃-precise-Z)
+    left-path-ℕ⊑★₃-precise-Z
+
+left-path-checkpoint₃-precise-Z :
+  left-path-world₃-precise-Z ∣ [] ⊢² Ex.right₃
+    ⊑ Ex2.left-path-target₃ ∶ left-path-ℕ⊑★₃-precise-Z
+left-path-checkpoint₃-precise-Z =
+  CTI2.⊑cast² Ex2.left-path-target-result-id★₃
+    (CTI2.·⊑·² left-path-function₃-precise-Z
+      left-path-argument₃-precise-Z)
+    left-path-ℕ⊑★₃-precise-Z
+
+
+------------------------------------------------------------------------
+-- Checked failure of the old asynchronous Z index
+------------------------------------------------------------------------
+
+left-path-Z-to-star-precise-empty :
+  ＇ (Fin.suc (Fin.suc Fin.zero))
+    ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ ★
+  → ⊥
+left-path-Z-to-star-precise-empty (I.X⊑★ ())
+
+
+------------------------------------------------------------------------
+-- Stage-4 shared paired function stack
+------------------------------------------------------------------------
+
+left-path-Y-var⊑YZ₄-precise-Z :
+  ＇ (Fin.suc Fin.zero) ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ ＇ Fin.zero
+left-path-Y-var⊑YZ₄-precise-Z = I.X⊑X
+
+left-path-Z-var⊑YZ₄-precise-Z :
+  ＇ (Fin.suc (Fin.suc Fin.zero))
+    ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ ＇ (Fin.suc Fin.zero)
+left-path-Z-var⊑YZ₄-precise-Z = I.X⊑X
+
+left-path-X-var⊑★-YZ₄-precise-Z :
+  ＇ Fin.zero ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ ★
+left-path-X-var⊑★-YZ₄-precise-Z = I.X⊑★ refl
+
+left-path-Y⇒Y⊑Y⇒Y-YZ₄-precise-Z :
+  (＇ (Fin.suc Fin.zero) ⇒ ＇ (Fin.suc Fin.zero))
+    ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ (＇ Fin.zero ⇒ ＇ Fin.zero)
+left-path-Y⇒Y⊑Y⇒Y-YZ₄-precise-Z =
+  ⇒⊑⇒ left-path-Y-var⊑YZ₄-precise-Z left-path-Y-var⊑YZ₄-precise-Z
+
+left-path-Z⇒Z⊑Z⇒Z-YZ₄-precise-Z :
+  (＇ (Fin.suc (Fin.suc Fin.zero))
+    ⇒ ＇ (Fin.suc (Fin.suc Fin.zero)))
+    ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩
+      (＇ (Fin.suc Fin.zero) ⇒ ＇ (Fin.suc Fin.zero))
+left-path-Z⇒Z⊑Z⇒Z-YZ₄-precise-Z =
+  ⇒⊑⇒ left-path-Z-var⊑YZ₄-precise-Z left-path-Z-var⊑YZ₄-precise-Z
+
+left-path-X⇒X⊑★⇒★-YZ₄-precise-Z :
+  (＇ Fin.zero ⇒ ＇ Fin.zero)
+    ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ (★ ⇒ ★)
+left-path-X⇒X⊑★⇒★-YZ₄-precise-Z =
+  ⇒⊑⇒ left-path-X-var⊑★-YZ₄-precise-Z
+    left-path-X-var⊑★-YZ₄-precise-Z
+
+left-path-Y-rep₄-precise-Z :
+  CTX.StoreRepImp left-path-world₄-precise-Z
+    (Fin.suc Fin.zero) Fin.zero
+left-path-Y-rep₄-precise-Z = CTX.store-rep-imp ★⊑★
+
+left-path-Z-rep₄-precise-Z :
+  CTX.StoreRepImp left-path-world₄-precise-Z
+    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
+left-path-Z-rep₄-precise-Z = CTX.store-rep-imp ★⊑★
+
+left-path-rebase-Y-YZ₄-precise-Z :
+  CTX.RebaseAt left-path-world₄-precise-Z left-path-world₄-precise-Z
+    (Fin.suc Fin.zero) Fin.zero
+left-path-rebase-Y-YZ₄-precise-Z =
+  CTX.sameWorldRebaseAt refl left-path-Y-rep₄-precise-Z
+
+left-path-rebase-Z-YZ₄-precise-Z :
+  CTX.RebaseAt left-path-world₄-precise-Z left-path-world₄-precise-Z
+    (Fin.suc (Fin.suc Fin.zero)) (Fin.suc Fin.zero)
+left-path-rebase-Z-YZ₄-precise-Z =
+  CTX.sameWorldRebaseAt refl left-path-Z-rep₄-precise-Z
+
+left-path-rebase-X-YZ₄-precise-Zᴸ :
+  CTX.RebaseAtᴸ left-path-world₄-precise-Z left-path-world₄-precise-Z
+    (just Fin.zero)
+left-path-rebase-X-YZ₄-precise-Zᴸ =
+  CTX.rebase-onlyᴸ refl
+    (λ { Fin.zero (); (Fin.suc Fin.zero) () })
+    left-path-ℕ⊑★₄-precise-Z
+
+left-path-lambda₄-precise-Z :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ƛ (` 0) ⊑ Ex2.left-path-target-lambda₃ ∶
+      left-path-Y⇒Y⊑Y⇒Y-YZ₄-precise-Z
+left-path-lambda₄-precise-Z =
+  CTI2.ƛ⊑ƛ²
+    {A = ＇ (Fin.suc Fin.zero)} {A′ = ＇ Fin.zero}
+    {B = ＇ (Fin.suc Fin.zero)} {B′ = ＇ Fin.zero}
+    {pA = left-path-Y-var⊑YZ₄-precise-Z}
+    {pB = left-path-Y-var⊑YZ₄-precise-Z}
+    (CTI2.x⊑x² {p = left-path-Y-var⊑YZ₄-precise-Z} CTX.Zʷ)
+
+left-path-Y-revealed₄-precise-Z :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    (ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal
+    ⊑ Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂ ∶
+      left-path-Z⇒Z⊑Z⇒Z-YZ₄-precise-Z
+left-path-Y-revealed₄-precise-Z =
+  CTI2.reveal⊑reveal² (λ _ eq → eq)
+    left-path-rebase-Y-YZ₄-precise-Z CTX.same-[]
+    Ex2.left-path-source-Y-reveal₃-⊢ˣ
+    Ex2.left-path-target-Y-reveal₃-⊢ˣ
+    left-path-lambda₄-precise-Z left-path-Z⇒Z⊑Z⇒Z-YZ₄-precise-Z
+
+-- Paired-Z derivation head (checkpoints 5--7):
+--   CTI2.reveal⊑reveal² (λ _ eq → eq)
+--     left-path-rebase-Z-YZ₄-precise-Z CTX.same-[]
+left-path-both-Z-revealed₄-precise-Z :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((ƛ (` 0)) ↑ Ex2.example12-target-Y-reveal)
+      ↑ Ex2.example12-target-Z-reveal
+    ⊑ (Ex2.left-path-target-lambda₃ ↑ Ex2.left-path-Y-reveal₂)
+        ↑ Ex2.left-path-Z-reveal₂ ∶
+      Ex2.★⇒★⊑★⇒★² {W = left-path-world₄-precise-Z}
+left-path-both-Z-revealed₄-precise-Z =
+  CTI2.reveal⊑reveal² (λ _ eq → eq)
+    left-path-rebase-Z-YZ₄-precise-Z CTX.same-[]
+    Ex2.left-path-source-Z-reveal₃-⊢ˣ
+    Ex2.left-path-target-Z-reveal₃-⊢ˣ
+    left-path-Y-revealed₄-precise-Z
+    (Ex2.★⇒★⊑★⇒★² {W = left-path-world₄-precise-Z})
+
+
+------------------------------------------------------------------------
+-- Checkpoints 5--8: paired Z, but a pre-existing X-side block
+------------------------------------------------------------------------
+
+left-path-argument₄-precise-Z :
+  left-path-world₄-precise-Z ∣ [] ⊢² $ (κℕ 7)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶
+      left-path-ℕ⊑★₄-precise-Z
+left-path-argument₄-precise-Z =
+  CTI2.⊑cast² Ex2.left-path-ℕ!₂
+    (CTI2.κ⊑κ² (κℕ 7)
+      (Ex2.ℕ⊑ℕ² {W = left-path-world₄-precise-Z}))
+    left-path-ℕ⊑★₄-precise-Z
+
+-- Every attempted whole-program reconstruction of checkpoints 5--8 reaches
+-- the same source-only `seal X ℕ` comparison before its paired Z node.  The
+-- live side condition rejects the intended target, independently of Z's mark.
+
+left-path-X-seal-source-ok-empty-precise-Z :
+  ∀ {W : World 3 2 3} {P Xᴿ?}
+  → CTX.SourceConcealOK W P Ex2.example12-target-X-seal Xᴿ?
+      ($ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩)
+  → ⊥
+left-path-X-seal-source-ok-empty-precise-Z
+    (CTX.seal-nonstar-plain-ok _ ())
+
+left-path-X-to-ℕ-precise-empty : ∀ {W : World 3 2 3}
+  → ＇ Fin.zero ⊑ᵂ⟨ W ⟩ ‵ `ℕ
+  → ⊥
+left-path-X-to-ℕ-precise-empty ()
+
+left-path-star-to-ℕ-precise-empty : ∀ {W : World 3 2 3}
+  → ★ ⊑ᵂ⟨ W ⟩ ‵ `ℕ
+  → ⊥
+left-path-star-to-ℕ-precise-empty ()
+
+left-path-X-sealed-vs-tagged-empty :
+  ∀ {p : ＇ Fin.zero ⊑ᵂ⟨ left-path-world₄-precise-Z ⟩ ★}
+  → left-path-world₄-precise-Z ∣ [] ⊢²
+    ($ (κℕ 7)) ↓ Ex2.example12-target-X-seal
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶
+      p
+  → ⊥
+left-path-X-sealed-vs-tagged-empty
+    (CTI2.⊑cast² {p = p} c′ D q) =
+  left-path-X-to-ℕ-precise-empty
+    {W = left-path-world₄-precise-Z} p
+left-path-X-sealed-vs-tagged-empty
+    (CTI2.conceal⊑²-source-ok {W′ = W′}
+      ok mono rb sc c⊢ D q) =
+  left-path-X-seal-source-ok-empty-precise-Z {W = W′} ok
+
+left-path-X-core-empty :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → ⊥
+left-path-X-core-empty
+    (CTI2.cast⊑cast² {p = p} c c′ D q) =
+  left-path-X-to-ℕ-precise-empty
+    {W = left-path-world₄-precise-Z} p
+left-path-X-core-empty
+    (CTI2.⊑cast² {p = p} c′ D q) =
+  left-path-star-to-ℕ-precise-empty
+    {W = left-path-world₄-precise-Z} p
+left-path-X-core-empty
+    (CTI2.cast⊑² {p = p} c D q) =
+  left-path-X-sealed-vs-tagged-empty {p = p} D
+
+left-path-source-arg-id★₆ :
+  C.flipᵐ
+    (renameEnv∼ (C.skip Ex2.id↪ᵗ)
+      (applyEnv (bind (＇ Fin.zero))
+        (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0}))))
+    ⊢ ★ ∼ ★
+left-path-source-arg-id★₆ = id ★
+
+left-path-source-result-id★₆ :
+  renameEnv∼ (C.skip Ex2.id↪ᵗ)
+    (applyEnv (bind (＇ Fin.zero))
+      (renameEnv∼ wk↪ᵗ (idᶜ {Δ = 0})))
+    ⊢ ★ ∼ ★
+left-path-source-result-id★₆ = id ★
+
+-- The following three implications check every Z step and every outer wrapper
+-- of checkpoints 5--7.  Their sole hypothesis is exactly the unavailable
+-- post-X-seal argument judgment isolated above.
+
+left-path-checkpoint₄-from-X-seal-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ($ (κℕ 7)) ↓ Ex2.example12-target-X-seal
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶
+      left-path-X-var⊑★-YZ₄-precise-Z
+  → left-path-world₄-precise-Z ∣ [] ⊢² Ex.right₄
+      ⊑ Ex2.left-path-target₄ ∶ left-path-ℕ⊑★₄-precise-Z
+left-path-checkpoint₄-from-X-seal-core D =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    left-path-rebase-X-YZ₄-precise-Zᴸ CTX.same-[]
+    Ex2.left-path-source-X-unseal₄-⊢ˣ
+    (CTI2.⊑cast² Ex2.left-path-target-result-id★₃
+      (CTI2.·⊑·²
+        (CTI2.cast⊑² Ex2.example12-target-X?↦X?
+          (CTI2.cast⊑² Ex2.example12-target-id★↦id★
+            left-path-both-Z-revealed₄-precise-Z
+            (Ex2.★⇒★⊑★⇒★² {W = left-path-world₄-precise-Z}))
+          left-path-X⇒X⊑★⇒★-YZ₄-precise-Z)
+        D)
+      left-path-X-var⊑★-YZ₄-precise-Z)
+    left-path-ℕ⊑★₄-precise-Z
+
+left-path-checkpoint₅-from-X-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → left-path-world₄-precise-Z ∣ [] ⊢² Ex.right₅
+      ⊑ Ex2.left-path-target₄ ∶ left-path-ℕ⊑★₄-precise-Z
+left-path-checkpoint₅-from-X-core D =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    left-path-rebase-X-YZ₄-precise-Zᴸ CTX.same-[]
+    Ex2.left-path-source-X-unseal₄-⊢ˣ
+    (CTI2.cast⊑² Ex2.example12-target-★?X
+      (CTI2.⊑cast² Ex2.left-path-target-result-id★₃
+        (CTI2.·⊑·²
+          (CTI2.cast⊑² Ex2.example12-target-id★↦id★
+            left-path-both-Z-revealed₄-precise-Z
+            (Ex2.★⇒★⊑★⇒★² {W = left-path-world₄-precise-Z}))
+          D)
+        ★⊑★)
+      left-path-X-var⊑★-YZ₄-precise-Z)
+    left-path-ℕ⊑★₄-precise-Z
+
+left-path-checkpoint₆-from-X-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → left-path-world₄-precise-Z ∣ [] ⊢² Ex.right₆
+      ⊑ Ex2.left-path-target₄ ∶ left-path-ℕ⊑★₄-precise-Z
+left-path-checkpoint₆-from-X-core D =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    left-path-rebase-X-YZ₄-precise-Zᴸ CTX.same-[]
+    Ex2.left-path-source-X-unseal₄-⊢ˣ
+    (CTI2.cast⊑² Ex2.example12-target-★?X
+      (CTI2.cast⊑cast² left-path-source-result-id★₆
+        Ex2.left-path-target-result-id★₃
+        (CTI2.·⊑·² left-path-both-Z-revealed₄-precise-Z
+          (CTI2.cast⊑² left-path-source-arg-id★₆ D ★⊑★))
+        ★⊑★)
+      left-path-X-var⊑★-YZ₄-precise-Z)
+    left-path-ℕ⊑★₄-precise-Z
+
+left-path-checkpoint₇-from-X-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → left-path-world₄-precise-Z ∣ [] ⊢² Ex.right₇
+      ⊑ Ex2.left-path-target₄ ∶ left-path-ℕ⊑★₄-precise-Z
+left-path-checkpoint₇-from-X-core D =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    left-path-rebase-X-YZ₄-precise-Zᴸ CTX.same-[]
+    Ex2.left-path-source-X-unseal₄-⊢ˣ
+    (CTI2.cast⊑² Ex2.example12-target-★?X
+      (CTI2.cast⊑cast² left-path-source-result-id★₆
+        Ex2.left-path-target-result-id★₃
+        (CTI2.·⊑·² left-path-both-Z-revealed₄-precise-Z D)
+        ★⊑★)
+      left-path-X-var⊑★-YZ₄-precise-Z)
+    left-path-ℕ⊑★₄-precise-Z
+
+
+------------------------------------------------------------------------
+-- Checkpoint 8's paired result reveal and checkpoint 9's paired argument
+------------------------------------------------------------------------
+
+left-path-target-Z-seal₂ : Conv↓ 2 ★ (＇ (Fin.suc Fin.zero))
+left-path-target-Z-seal₂ = seal (Fin.suc Fin.zero) ★
+
+left-path-target-Z-unseal₂ : Conv↑ 2 (＇ (Fin.suc Fin.zero)) ★
+left-path-target-Z-unseal₂ = unseal (Fin.suc Fin.zero) ★
+
+left-path-target-Y-seal₂ :
+  Conv↓ 2 (＇ (Fin.suc Fin.zero)) (＇ Fin.zero)
+left-path-target-Y-seal₂ = seal Fin.zero (＇ (Fin.suc Fin.zero))
+
+left-path-source-Z-seal₄-⊢ˣ :
+  Ex.right-store₄ Conv.⊢↓[ just (Fin.suc (Fin.suc Fin.zero)) ]
+    Ex2.example12-target-Z-seal
+left-path-source-Z-seal₄-⊢ˣ =
+  Conv.⊢↓-sealˣ Ex2.left-path-source-Z∋₃
+
+left-path-target-Z-seal₄-⊢ˣ :
+  Ex2.left-path-target-store₄ Conv.⊢↓[ just (Fin.suc Fin.zero) ]
+    left-path-target-Z-seal₂
+left-path-target-Z-seal₄-⊢ˣ =
+  Conv.⊢↓-sealˣ Ex2.left-path-target-Z∋₃
+
+left-path-source-Z-unseal₄-⊢ˣ :
+  Ex.right-store₄ Conv.⊢↑[ just (Fin.suc (Fin.suc Fin.zero)) ]
+    Ex2.example12-target-Z-unseal
+left-path-source-Z-unseal₄-⊢ˣ =
+  Conv.⊢↑-unsealˣ Ex2.left-path-source-Z∋₃
+
+left-path-target-Z-unseal₄-⊢ˣ :
+  Ex2.left-path-target-store₄ Conv.⊢↑[ just (Fin.suc Fin.zero) ]
+    left-path-target-Z-unseal₂
+left-path-target-Z-unseal₄-⊢ˣ =
+  Conv.⊢↑-unsealˣ Ex2.left-path-target-Z∋₃
+
+left-path-source-Y-seal₄-⊢ˣ :
+  Ex.right-store₄ Conv.⊢↓[ just (Fin.suc Fin.zero) ]
+    Ex2.example12-target-Y-seal
+left-path-source-Y-seal₄-⊢ˣ =
+  Conv.⊢↓-sealˣ Ex2.left-path-source-Y∋₃
+
+left-path-target-Y-seal₄-⊢ˣ :
+  Ex2.left-path-target-store₄ Conv.⊢↓[ just Fin.zero ]
+    left-path-target-Y-seal₂
+left-path-target-Y-seal₄-⊢ˣ =
+  Conv.⊢↓-sealˣ Ex2.left-path-target-Y∋₃
+
+left-path-argument-Z₈-from-X-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → left-path-world₄-precise-Z ∣ [] ⊢²
+      ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+        ⟨ Ex2.example12-target-X! ⟩)
+        ↓ Ex2.example12-target-Z-seal
+      ⊑ ($ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩)
+          ↓ left-path-target-Z-seal₂ ∶
+        left-path-Z-var⊑YZ₄-precise-Z
+left-path-argument-Z₈-from-X-core D =
+  CTI2.conceal⊑conceal²
+    (CTX.matched-seal-star-partner
+      (CTX.rep★-nonvar-tag nonvar-base))
+    (λ _ eq → eq) left-path-rebase-Z-YZ₄-precise-Z CTX.same-[]
+    left-path-source-Z-seal₄-⊢ˣ left-path-target-Z-seal₄-⊢ˣ D
+    left-path-Z-var⊑YZ₄-precise-Z
+
+-- Paired-Z derivation head (checkpoint 8 result unseals):
+--   CTI2.reveal⊑reveal² (λ _ eq → eq)
+--     left-path-rebase-Z-YZ₄-precise-Z CTX.same-[]
+left-path-checkpoint₈-from-X-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → left-path-world₄-precise-Z ∣ [] ⊢² Ex.right₈
+      ⊑ Ex2.left-path-target₅ ∶ left-path-ℕ⊑★₄-precise-Z
+left-path-checkpoint₈-from-X-core D =
+  CTI2.reveal⊑² (λ _ eq → eq)
+    left-path-rebase-X-YZ₄-precise-Zᴸ CTX.same-[]
+    Ex2.left-path-source-X-unseal₄-⊢ˣ
+    (CTI2.cast⊑² Ex2.example12-target-★?X
+      (CTI2.cast⊑cast² left-path-source-result-id★₆
+        Ex2.left-path-target-result-id★₃
+        (CTI2.reveal⊑reveal² (λ _ eq → eq)
+          left-path-rebase-Z-YZ₄-precise-Z CTX.same-[]
+          left-path-source-Z-unseal₄-⊢ˣ
+          left-path-target-Z-unseal₄-⊢ˣ
+          (CTI2.·⊑·² left-path-Y-revealed₄-precise-Z
+            (left-path-argument-Z₈-from-X-core D))
+          ★⊑★)
+        ★⊑★)
+      left-path-X-var⊑★-YZ₄-precise-Z)
+    left-path-ℕ⊑★₄-precise-Z
+
+left-path-argument-Y₉-from-X-core :
+  left-path-world₄-precise-Z ∣ [] ⊢²
+    ((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+      ⟨ Ex2.example12-target-X! ⟩)
+    ⊑ $ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩ ∶ ★⊑★
+  → left-path-world₄-precise-Z ∣ [] ⊢²
+      ((((($ (κℕ 7)) ↓ Ex2.example12-target-X-seal)
+        ⟨ Ex2.example12-target-X! ⟩)
+        ↓ Ex2.example12-target-Z-seal)
+        ↓ Ex2.example12-target-Y-seal)
+      ⊑ ((($ (κℕ 7) ⟨ Ex2.left-path-ℕ!₂ ⟩)
+          ↓ left-path-target-Z-seal₂)
+          ↓ left-path-target-Y-seal₂) ∶
+        left-path-Y-var⊑YZ₄-precise-Z
+left-path-argument-Y₉-from-X-core D =
+  CTI2.conceal⊑conceal²
+    (CTX.matched-seal-nonstar nonstar-X)
+    (λ _ eq → eq) left-path-rebase-Y-YZ₄-precise-Z CTX.same-[]
+    left-path-source-Y-seal₄-⊢ˣ left-path-target-Y-seal₄-⊢ˣ
+    (left-path-argument-Z₈-from-X-core D)
+    left-path-Y-var⊑YZ₄-precise-Z
+
+
+------------------------------------------------------------------------
+-- D19 classification
+------------------------------------------------------------------------
+
+data Classification : Set where
+  PAIRED-OK ASYNC-FORCED : Classification
+
+-- Checkpoint 3                  -> PAIRED-OK (whole judgment checked).
+-- Checkpoint 4                  -> PAIRED-OK at Z; whole blocked earlier at X.
+-- Checkpoints 5, 6, 7          -> PAIRED-OK at Z; whole blocked earlier at X.
+-- Checkpoint 8                  -> PAIRED-OK at Z; whole blocked earlier at X.
+-- Checkpoint 9 argument         -> PAIRED-OK at Z; blocked earlier at X.
+-- ASYNC-FORCED                  -> no checkpoint in the swept set.
+--
+-- Consequently, the requested two-way classification is total for the Z
+-- sites, but not for the whole stale checkpoint-5--9 fixtures: their X-side
+-- premise is already rejected by the current live relation.  Calling those
+-- whole judgments ASYNC-FORCED would falsely attribute the failure to Z.
+
+checkpoint₃-Z-classification : Classification
+checkpoint₃-Z-classification = PAIRED-OK
+
+checkpoint₄-Z-classification : Classification
+checkpoint₄-Z-classification = PAIRED-OK
+
+checkpoint₅-Z-classification : Classification
+checkpoint₅-Z-classification = PAIRED-OK
+
+checkpoint₆-Z-classification : Classification
+checkpoint₆-Z-classification = PAIRED-OK
+
+checkpoint₇-Z-classification : Classification
+checkpoint₇-Z-classification = PAIRED-OK
+
+checkpoint₈-Z-classification : Classification
+checkpoint₈-Z-classification = PAIRED-OK
+
+checkpoint₉-argument-Z-classification : Classification
+checkpoint₉-argument-Z-classification = PAIRED-OK

--- a/GTSFImp/proof/DGG/notes/probes/D19ThreePointLatticeProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D19ThreePointLatticeProbe.agda
@@ -1,0 +1,225 @@
+module D19ThreePointLatticeProbe where
+
+-- File Charter:
+--   * Models D19 direction B with sandbox copies of marks, worlds, and the
+--     variable-to-dynamic type-imprecision leaf; no live definition changes.
+--   * Rescopes invariant (5) to the unannotated dynamic mark and requires the
+--     paired-dynamic mark to have been formed by the paired-seal case.
+--   * Checks the expanded YZ fixture with a paired-dynamic Z cell.
+--   * Checks that ProjectionMismatch has no admissible widening-capable mark.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+open import Data.Product using (_×_; _,_)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ‵_; `ℕ; renameᵗ)
+open import TyStore using
+  (TyStore; store-empty; store-bind; lookupStore)
+open import Consistency using (_↪ᵗ_; empty; keep; skip; toRenameᵗ)
+
+
+------------------------------------------------------------------------
+-- Direction B sandbox
+------------------------------------------------------------------------
+
+data ThreePointMark : Set where
+  X⊑X  : ThreePointMark
+  X⊑★ᵖ : ThreePointMark
+  X⊑★  : ThreePointMark
+
+ThreePointEnv : TyCtx → Set
+ThreePointEnv Δ = TyVar Δ → ThreePointMark
+
+data CanWiden : ThreePointMark → Set where
+  paired-widen      : CanWiden X⊑★ᵖ
+  unannotated-widen : CanWiden X⊑★
+
+infix 4 _⊢³_⊑_
+
+data _⊢³_⊑_ {Δ : TyCtx} (μ : ThreePointEnv Δ)
+    : Ty Δ → Ty Δ → Set where
+  X⊑★-sandbox : ∀ {X}
+    → CanWiden (μ X)
+    → μ ⊢³ ＇ X ⊑ ★
+
+-- This is history supplied by the sandbox fixture, not a reconstruction from
+-- the two stores.  In particular, aligned direct ★/★ entries do not imply
+-- paired-seal formation.
+
+data CellFormation : Set where
+  source-only-formation  : CellFormation
+  paired-alias-formation : CellFormation
+  paired-seal-formation  : CellFormation
+  projection-formation   : CellFormation
+
+data PairedSealFormed : CellFormation → Set where
+  paired-seal-formed : PairedSealFormed paired-seal-formation
+
+record ThreePointWorld (Δᴸ Δᴿ Δ : TyCtx) : Set where
+  constructor three-point-world
+  field
+    ηᴸʷ : Δᴸ ↪ᵗ Δ
+    ηᴿʷ : Δᴿ ↪ᵗ Δ
+    impEnvʷ : ThreePointEnv Δ
+    sourceStoreʷ : TyStore Δᴸ
+    targetStoreʷ : TyStore Δᴿ
+    formationʷ : TyVar Δ → CellFormation
+
+open ThreePointWorld public
+
+embedᴸ : ∀ {Δᴸ Δᴿ Δ}
+  → ThreePointWorld Δᴸ Δᴿ Δ
+  → Ty Δᴸ
+  → Ty Δ
+embedᴸ W = renameᵗ (toRenameᵗ (ηᴸʷ W))
+
+embedᴿ : ∀ {Δᴸ Δᴿ Δ}
+  → ThreePointWorld Δᴸ Δᴿ Δ
+  → Ty Δᴿ
+  → Ty Δ
+embedᴿ W = renameᵗ (toRenameᵗ (ηᴿʷ W))
+
+infix 4 _⊑³⟨_⟩_
+
+_⊑³⟨_⟩_ : ∀ {Δᴸ Δᴿ Δ}
+  → Ty Δᴸ
+  → ThreePointWorld Δᴸ Δᴿ Δ
+  → Ty Δᴿ
+  → Set
+A ⊑³⟨ W ⟩ B = impEnvʷ W ⊢³ embedᴸ W A ⊑ embedᴿ W B
+
+-- Invariant (5) mentions only the unannotated X⊑★ point.  A source-★
+-- cell carrying X⊑★ᵖ may therefore have an aligned target occupant.
+
+RescopedInvariant5 : ∀ {Δᴸ Δᴿ Δ}
+  → ThreePointWorld Δᴸ Δᴿ Δ
+  → Set
+RescopedInvariant5 {Δᴸ} {Δᴿ} W = ∀ (Xᴸ : TyVar Δᴸ)
+  → impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ) ≡ X⊑★
+  → lookupStore (sourceStoreʷ W) Xᴸ ≡ ★
+  → ∀ (Xᴿ : TyVar Δᴿ)
+  → toRenameᵗ (ηᴿʷ W) Xᴿ ≢ toRenameᵗ (ηᴸʷ W) Xᴸ
+
+-- Minting X⊑★ᵖ requires explicit paired-seal formation history.  Layout
+-- facts such as alignment and direct ★/★ entries are intentionally absent.
+
+PairedMarkMintingDiscipline : ∀ {Δᴸ Δᴿ Δ}
+  → ThreePointWorld Δᴸ Δᴿ Δ
+  → Set
+PairedMarkMintingDiscipline W = ∀ Z
+  → impEnvʷ W Z ≡ X⊑★ᵖ
+  → PairedSealFormed (formationʷ W Z)
+
+Admissible : ∀ {Δᴸ Δᴿ Δ}
+  → ThreePointWorld Δᴸ Δᴿ Δ
+  → Set
+Admissible W = RescopedInvariant5 W × PairedMarkMintingDiscipline W
+
+
+------------------------------------------------------------------------
+-- Inlined YZ fixture
+------------------------------------------------------------------------
+
+yz-source-store : TyStore 3
+yz-source-store =
+  store-bind (store-bind (store-bind store-empty ★) (＇ Fin.zero)) (‵ `ℕ)
+
+yz-target-store : TyStore 2
+yz-target-store = store-bind (store-bind store-empty ★) (＇ Fin.zero)
+
+yz-source-η : 3 ↪ᵗ 3
+yz-source-η = keep (keep (keep empty))
+
+yz-target-η : 2 ↪ᵗ 3
+yz-target-η = skip (keep (keep empty))
+
+yz-env : ThreePointEnv 3
+yz-env Fin.zero = X⊑★
+yz-env (Fin.suc Fin.zero) = X⊑★
+yz-env (Fin.suc (Fin.suc Fin.zero)) = X⊑★ᵖ
+
+yz-formation : TyVar 3 → CellFormation
+yz-formation Fin.zero = source-only-formation
+yz-formation (Fin.suc Fin.zero) = paired-alias-formation
+yz-formation (Fin.suc (Fin.suc Fin.zero)) = paired-seal-formation
+
+yz-world : ThreePointWorld 3 2 3
+yz-world =
+  three-point-world yz-source-η yz-target-η yz-env
+    yz-source-store yz-target-store yz-formation
+
+yz-rescoped-invariant5 : RescopedInvariant5 yz-world
+yz-rescoped-invariant5 Fin.zero refl () Xᴿ
+yz-rescoped-invariant5 (Fin.suc Fin.zero) refl () Xᴿ
+yz-rescoped-invariant5 (Fin.suc (Fin.suc Fin.zero)) () entry Xᴿ
+
+yz-paired-mark-minted : PairedMarkMintingDiscipline yz-world
+yz-paired-mark-minted Fin.zero ()
+yz-paired-mark-minted (Fin.suc Fin.zero) ()
+yz-paired-mark-minted (Fin.suc (Fin.suc Fin.zero)) refl =
+  paired-seal-formed
+
+yz-admissible : Admissible yz-world
+yz-admissible = yz-rescoped-invariant5 , yz-paired-mark-minted
+
+-- This is the live relation's variable-to-dynamic leaf, copied with CanWiden
+-- as its sole mark change.  The paired Z point still licenses the needed leaf.
+
+yz-Z-to-star :
+  (＇ (Fin.suc (Fin.suc Fin.zero))) ⊑³⟨ yz-world ⟩ ★
+yz-Z-to-star = X⊑★-sandbox paired-widen
+
+
+------------------------------------------------------------------------
+-- Inlined ProjectionMismatch fixture
+------------------------------------------------------------------------
+
+projection-mismatch-store : TyStore 1
+projection-mismatch-store = store-bind store-empty ★
+
+projection-mismatch-env : ThreePointMark → ThreePointEnv 1
+projection-mismatch-env mark Fin.zero = mark
+
+projection-mismatch-formation : TyVar 1 → CellFormation
+projection-mismatch-formation Fin.zero = projection-formation
+
+projection-mismatch-world : ThreePointMark → ThreePointWorld 1 1 1
+projection-mismatch-world mark =
+  three-point-world (keep empty) (keep empty)
+    (projection-mismatch-env mark)
+    projection-mismatch-store projection-mismatch-store
+    projection-mismatch-formation
+
+projection-paired-world : ThreePointWorld 1 1 1
+projection-paired-world = projection-mismatch-world X⊑★ᵖ
+
+projection-unannotated-world : ThreePointWorld 1 1 1
+projection-unannotated-world = projection-mismatch-world X⊑★
+
+projection-not-paired-seal-formed :
+  PairedSealFormed projection-formation → ⊥
+projection-not-paired-seal-formed ()
+
+projection-paired-cannot-be-minted :
+  PairedMarkMintingDiscipline projection-paired-world → ⊥
+projection-paired-cannot-be-minted discipline =
+  projection-not-paired-seal-formed (discipline Fin.zero refl)
+
+projection-unannotated-rejected-by-invariant5 :
+  RescopedInvariant5 projection-unannotated-world → ⊥
+projection-unannotated-rejected-by-invariant5 invariant5 =
+  invariant5 Fin.zero refl refl Fin.zero refl
+
+-- These are the only two marks with CanWiden evidence.  The unannotated case
+-- violates rescoped (5); the paired case violates the minting discipline.
+
+projection-mismatch-still-rejected : ∀ {mark}
+  → CanWiden mark
+  → Admissible (projection-mismatch-world mark)
+  → ⊥
+projection-mismatch-still-rejected unannotated-widen
+    (invariant5 , minting) =
+  projection-unannotated-rejected-by-invariant5 invariant5
+projection-mismatch-still-rejected paired-widen (invariant5 , minting) =
+  projection-paired-cannot-be-minted minting

--- a/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
@@ -22,31 +22,30 @@ open import TyStore using
 open import Consistency using
   (_↪ᵗ_; empty; keep; id↪ᵗ; toRenameᵗ)
 open import Conversion using (seal)
+import Conversion as Conv
 open import Imprecision using (ImpEnv; X⊑★)
-import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.CtxImp as CTX
 import proof.DGG.TargetExtend as TE
 import proof.DGG.WorldInvariants as WI
 open import proof.ImprecisionConsistency using (fin-suc-injective)
-import CTIOccLiveFaithfulScratch as SOcc
-import CTITighteningNarrowScratch as Narrow
 
 ------------------------------------------------------------------------
 -- Proposed Stage 1 companion
 ------------------------------------------------------------------------
 
 record WorldInvariants {Δᴸ Δᴿ Δ}
-    (W : CTI2.World Δᴸ Δᴿ Δ) : Set where
+    (W : CTX.World Δᴸ Δᴿ Δ) : Set where
   constructor world-invariants
   field
     stage1 : WI.WorldInvariants W
 
     dynamicStarSourcesUnoccupied :
       ∀ (Xᴸ : TyVar Δᴸ)
-      → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑★
-      → lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ★
+      → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+      → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
       → ∀ (Xᴿ : TyVar Δᴿ)
-      → toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-        ≢ toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+      → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+        ≢ toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
 
 open WorldInvariants public
 
@@ -82,22 +81,22 @@ initialWorld-invariants {Δ = Δ} mu = world-invariants
 ------------------------------------------------------------------------
 
 rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
-  → WI.WorldInvariants (CTI2.rightOnlyWorld W B)
+    {W : CTX.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
+  → WI.WorldInvariants (CTX.rightOnlyWorld W B)
   → WorldInvariants W
-  → WorldInvariants (CTI2.rightOnlyWorld W B)
+  → WorldInvariants (CTX.rightOnlyWorld W B)
 rightOnlyWorld-invariants {W = W} B stage1′ inv =
   world-invariants stage1′ preserve
   where
   preserve : ∀ Xᴸ
-    → CTI2.impEnvʷ (CTI2.rightOnlyWorld W B)
-        (toRenameᵗ (CTI2.ηᴸʷ (CTI2.rightOnlyWorld W B)) Xᴸ)
+    → CTX.impEnvʷ (CTX.rightOnlyWorld W B)
+        (toRenameᵗ (CTX.ηᴸʷ (CTX.rightOnlyWorld W B)) Xᴸ)
         ≡ X⊑★
     → lookupStore
-        (CTI2.sourceStoreʷ (CTI2.rightOnlyWorld W B)) Xᴸ ≡ ★
+        (CTX.sourceStoreʷ (CTX.rightOnlyWorld W B)) Xᴸ ≡ ★
     → ∀ Xᴿ
-    → toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) Xᴿ
-      ≢ toRenameᵗ (CTI2.ηᴸʷ (CTI2.rightOnlyWorld W B)) Xᴸ
+    → toRenameᵗ (CTX.ηᴿʷ (CTX.rightOnlyWorld W B)) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ (CTX.rightOnlyWorld W B)) Xᴸ
   preserve Xᴸ mark entry Fin.zero ()
   preserve Xᴸ mark entry (Fin.suc Xᴿ) aligned =
     dynamicStarSourcesUnoccupied inv Xᴸ mark entry Xᴿ
@@ -105,8 +104,8 @@ rightOnlyWorld-invariants {W = W} B stage1′ inv =
 
 targetInsert-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
     {ρ : Δᴿ Consistency.↪ᵗ Δᴿ′} {π : Δ Consistency.↪ᵗ Δ′}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : CTX.World Δᴸ Δᴿ′ Δ′}
   → (ins : TE.TargetInsert ρ π W W′)
   → WI.WorldInvariants W′
   → WorldInvariants W
@@ -115,11 +114,11 @@ targetInsert-invariants {W = W} {W′ = W′} ins stage1′ inv =
   world-invariants stage1′ preserve
   where
   preserve : ∀ Xᴸ
-    → CTI2.impEnvʷ W′ (toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ) ≡ X⊑★
-    → lookupStore (CTI2.sourceStoreʷ W′) Xᴸ ≡ ★
+    → CTX.impEnvʷ W′ (toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ W′) Xᴸ ≡ ★
     → ∀ Xᴿ′
-    → toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′
-      ≢ toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ
+    → toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ′
+      ≢ toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ
   preserve Xᴸ mark entry Xᴿ′ aligned
       with TE.target-source-reflect ins (sym aligned)
   preserve Xᴸ mark entry Xᴿ′ aligned
@@ -128,27 +127,27 @@ targetInsert-invariants {W = W} {W′ = W′} ins stage1′ inv =
       (sym old-aligned)
     where
     old-mark :
-      CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑★
+      CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
     old-mark = trans
-      (sym (TE.impEnv-insert ins (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)))
+      (sym (TE.impEnv-insert ins (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)))
       (trans
-        (cong (CTI2.impEnvʷ W′) (sym (TE.source-insert ins Xᴸ))) mark)
+        (cong (CTX.impEnvʷ W′) (sym (TE.source-insert ins Xᴸ))) mark)
 
-    old-entry : lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ★
+    old-entry : lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
     old-entry = trans
       (sym (cong (λ Σ → lookupStore Σ Xᴸ) (TE.sourceStore-kept ins)))
       entry
 
 smartAlias-fresh-source-not-star : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ}
-    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
-  → CTI2.SmartAliasMergeGuard W Wᵐ β α
-  → lookupStore (CTI2.sourceStoreʷ Wᵐ) Fin.zero ≢ ★
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {Wᵐ : CTX.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
+  → CTX.SmartAliasMergeGuard W Wᵐ β α
+  → lookupStore (CTX.sourceStoreʷ Wᵐ) Fin.zero ≢ ★
 smartAlias-fresh-source-not-star guard entry =
   variable≢star
     (trans
       (sym (cong (λ Σ → lookupStore Σ Fin.zero)
-        (CTI2.SmartAliasMergeGuard.sourceStore-lifted guard)))
+        (CTX.SmartAliasMergeGuard.sourceStore-lifted guard)))
       entry)
 
 ------------------------------------------------------------------------
@@ -156,33 +155,33 @@ smartAlias-fresh-source-not-star guard entry =
 ------------------------------------------------------------------------
 
 world-invariants-no-target-at-dynamic-star : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
   → WorldInvariants W
-  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
-  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
-  → CTI2.NoTargetOccupantAtSource W X
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTX.sourceStoreʷ W) X ≡ ★
+  → CTX.NoTargetOccupantAtSource W X
 world-invariants-no-target-at-dynamic-star {X = X} inv mark entry
     (Xᴿ , aligned) =
   dynamicStarSourcesUnoccupied inv X mark entry Xᴿ aligned
 
 world-invariants-see-through-premise : ∀ {Δᴸ Δᴿ Δ}
-    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
   → WorldInvariants W′
-  → CTI2.TagRebaseAtᴸ W′ W (just X) nothing
-  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] seal X ★
-  → CTI2.NoTargetOccupantAtSource W′ X
+  → CTX.TagRebaseAtᴸ W′ W (just X) nothing
+  → CTX.sourceStoreʷ W Conv.⊢↓[ just X ] seal X ★
+  → CTX.NoTargetOccupantAtSource W′ X
 world-invariants-see-through-premise inv
-    (CTI2.tag-rebase-onlyᴸ mark disaligned represented)
-    (CTI2.⊢↓-sealˣ source∋) =
+    (CTX.tag-rebase-onlyᴸ mark disaligned represented)
+    (Conv.⊢↓-sealˣ source∋) =
   world-invariants-no-target-at-dynamic-star inv mark
     (lookupStore-∋ source∋)
 
 world-invariants-d17c-occupancy : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
   → WorldInvariants W
-  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
-  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
-  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X) → ⊥
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTX.sourceStoreʷ W) X ≡ ★
+  → CTX.Occupied W (toRenameᵗ (CTX.ηᴸʷ W) X) → ⊥
 world-invariants-d17c-occupancy inv mark entry =
   world-invariants-no-target-at-dynamic-star inv mark entry
 
@@ -196,9 +195,9 @@ projection-mismatch-store = store-bind store-empty ★
 projection-mismatch-env : ImpEnv 1
 projection-mismatch-env Fin.zero = X⊑★
 
-projection-mismatch-world : CTI2.World 1 1 1
+projection-mismatch-world : CTX.World 1 1 1
 projection-mismatch-world =
-  CTI2.world (keep empty) (keep empty) projection-mismatch-env
+  CTX.world (keep empty) (keep empty) projection-mismatch-env
     projection-mismatch-store projection-mismatch-store
 
 projection-mismatch-stage1 : WI.WorldInvariants projection-mismatch-world
@@ -211,30 +210,35 @@ projection-mismatch-rejects-invariant5 :
 projection-mismatch-rejects-invariant5 inv =
   dynamicStarSourcesUnoccupied inv Fin.zero refl refl Fin.zero refl
 
-s-occ-aligned-stage1 : WI.WorldInvariants Narrow.W
-s-occ-aligned-stage1 =
-  WI.identityWorld-invariants Narrow.imp-env-dyn Narrow.source-store
+s-occ-aligned-stage1 : WI.WorldInvariants projection-mismatch-world
+s-occ-aligned-stage1 = projection-mismatch-stage1
 
-s-occ-aligned-rejects-invariant5 : WorldInvariants Narrow.W → ⊥
+s-occ-aligned-rejects-invariant5 :
+  WorldInvariants projection-mismatch-world → ⊥
 s-occ-aligned-rejects-invariant5 inv =
   dynamicStarSourcesUnoccupied inv Fin.zero refl refl Fin.zero refl
 
-s-occ-prealignment-stage1 : WI.WorldInvariants SOcc.Wᵖ
+s-occ-prealignment-world : CTX.World 1 0 1
+s-occ-prealignment-world =
+  CTX.world (keep empty) empty (λ { Fin.zero → X⊑★ })
+    (store-bind store-empty ★) store-empty
+
+s-occ-prealignment-stage1 : WI.WorldInvariants s-occ-prealignment-world
 s-occ-prealignment-stage1 =
   WI.world-invariants
     (λ { Fin.zero () })
     (λ { {Xᴿ = ()} })
     (λ ())
 
-s-occ-prealignment-invariants : WorldInvariants SOcc.Wᵖ
+s-occ-prealignment-invariants : WorldInvariants s-occ-prealignment-world
 s-occ-prealignment-invariants =
   world-invariants s-occ-prealignment-stage1 no-target
   where
   no-target : ∀ Xᴸ
-    → CTI2.impEnvʷ SOcc.Wᵖ
-        (toRenameᵗ (CTI2.ηᴸʷ SOcc.Wᵖ) Xᴸ) ≡ X⊑★
-    → lookupStore (CTI2.sourceStoreʷ SOcc.Wᵖ) Xᴸ ≡ ★
+    → CTX.impEnvʷ s-occ-prealignment-world
+        (toRenameᵗ (CTX.ηᴸʷ s-occ-prealignment-world) Xᴸ) ≡ X⊑★
+    → lookupStore (CTX.sourceStoreʷ s-occ-prealignment-world) Xᴸ ≡ ★
     → ∀ Xᴿ
-    → toRenameᵗ (CTI2.ηᴿʷ SOcc.Wᵖ) Xᴿ
-      ≢ toRenameᵗ (CTI2.ηᴸʷ SOcc.Wᵖ) Xᴸ
+    → toRenameᵗ (CTX.ηᴿʷ s-occ-prealignment-world) Xᴿ
+      ≢ toRenameᵗ (CTX.ηᴸʷ s-occ-prealignment-world) Xᴸ
   no-target Fin.zero mark entry ()

--- a/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
@@ -11,6 +11,7 @@ module T15Invariant5ReconProbe where
 open import Data.Empty using (⊥)
 import Data.Fin as Fin
 import Data.Nat as Nat
+open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; _≢_; refl; sym; trans; cong)
 
@@ -19,7 +20,9 @@ open import TyStore using (lookupStore)
 open import Consistency using (id↪ᵗ; toRenameᵗ)
 open import Imprecision using (ImpEnv; X⊑★)
 import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.TargetExtend as TE
 import proof.DGG.WorldInvariants as WI
+open import proof.ImprecisionConsistency using (fin-suc-injective)
 
 ------------------------------------------------------------------------
 -- Proposed Stage 1 companion
@@ -67,3 +70,77 @@ initialWorld-invariants {Δ = Δ} mu = world-invariants
     → toRenameᵗ id↪ᵗ Xᴿ ≢ toRenameᵗ id↪ᵗ Xᴸ
   no-dynamic-star-source Xᴸ mark entry Xᴿ aligned =
     variable≢star (trans (sym (emptyStore-lookup-variable Xᴸ)) entry)
+
+------------------------------------------------------------------------
+-- Preservation deltas at target-only builders
+------------------------------------------------------------------------
+
+rightOnlyWorld-invariants : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} (B : Ty Δᴿ)
+  → WI.WorldInvariants (CTI2.rightOnlyWorld W B)
+  → WorldInvariants W
+  → WorldInvariants (CTI2.rightOnlyWorld W B)
+rightOnlyWorld-invariants {W = W} B stage1′ inv =
+  world-invariants stage1′ preserve
+  where
+  preserve : ∀ Xᴸ
+    → CTI2.impEnvʷ (CTI2.rightOnlyWorld W B)
+        (toRenameᵗ (CTI2.ηᴸʷ (CTI2.rightOnlyWorld W B)) Xᴸ)
+        ≡ X⊑★
+    → lookupStore
+        (CTI2.sourceStoreʷ (CTI2.rightOnlyWorld W B)) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTI2.ηᴿʷ (CTI2.rightOnlyWorld W B)) Xᴿ
+      ≢ toRenameᵗ (CTI2.ηᴸʷ (CTI2.rightOnlyWorld W B)) Xᴸ
+  preserve Xᴸ mark entry Fin.zero ()
+  preserve Xᴸ mark entry (Fin.suc Xᴿ) aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ mark entry Xᴿ
+      (fin-suc-injective aligned)
+
+targetInsert-invariants : ∀ {Δᴸ Δᴿ Δᴿ′ Δ Δ′}
+    {ρ : Δᴿ Consistency.↪ᵗ Δᴿ′} {π : Δ Consistency.↪ᵗ Δ′}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {W′ : CTI2.World Δᴸ Δᴿ′ Δ′}
+  → (ins : TE.TargetInsert ρ π W W′)
+  → WI.WorldInvariants W′
+  → WorldInvariants W
+  → WorldInvariants W′
+targetInsert-invariants {W = W} {W′ = W′} ins stage1′ inv =
+  world-invariants stage1′ preserve
+  where
+  preserve : ∀ Xᴸ
+    → CTI2.impEnvʷ W′ (toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ) ≡ X⊑★
+    → lookupStore (CTI2.sourceStoreʷ W′) Xᴸ ≡ ★
+    → ∀ Xᴿ′
+    → toRenameᵗ (CTI2.ηᴿʷ W′) Xᴿ′
+      ≢ toRenameᵗ (CTI2.ηᴸʷ W′) Xᴸ
+  preserve Xᴸ mark entry Xᴿ′ aligned
+      with TE.target-source-reflect ins (sym aligned)
+  preserve Xᴸ mark entry Xᴿ′ aligned
+      | Xᴿ , Xᴿ′-eq , old-aligned =
+    dynamicStarSourcesUnoccupied inv Xᴸ old-mark old-entry Xᴿ
+      (sym old-aligned)
+    where
+    old-mark :
+      CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    old-mark = trans
+      (sym (TE.impEnv-insert ins (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ)))
+      (trans
+        (cong (CTI2.impEnvʷ W′) (sym (TE.source-insert ins Xᴸ))) mark)
+
+    old-entry : lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ★
+    old-entry = trans
+      (sym (cong (λ Σ → lookupStore Σ Xᴸ) (TE.sourceStore-kept ins)))
+      entry
+
+smartAlias-fresh-source-not-star : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ}
+    {Wᵐ : CTI2.World (Nat.suc Δᴸ) Δᴿ Δ} {β α}
+  → CTI2.SmartAliasMergeGuard W Wᵐ β α
+  → lookupStore (CTI2.sourceStoreʷ Wᵐ) Fin.zero ≢ ★
+smartAlias-fresh-source-not-star guard entry =
+  variable≢star
+    (trans
+      (sym (cong (λ Σ → lookupStore Σ Fin.zero)
+        (CTI2.SmartAliasMergeGuard.sourceStore-lifted guard)))
+      entry)

--- a/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
@@ -10,14 +10,16 @@ module T15Invariant5ReconProbe where
 
 open import Data.Empty using (⊥)
 import Data.Fin as Fin
+open import Data.Maybe using (just; nothing)
 import Data.Nat as Nat
 open import Data.Product using (Σ-syntax; _×_; _,_)
 open import Relation.Binary.PropositionalEquality using
   (_≡_; _≢_; refl; sym; trans; cong)
 
 open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ⇑ᵗ)
-open import TyStore using (lookupStore)
+open import TyStore using (lookupStore; lookupStore-∋)
 open import Consistency using (id↪ᵗ; toRenameᵗ)
+open import Conversion using (seal)
 open import Imprecision using (ImpEnv; X⊑★)
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.TargetExtend as TE
@@ -144,3 +146,38 @@ smartAlias-fresh-source-not-star guard entry =
       (sym (cong (λ Σ → lookupStore Σ Fin.zero)
         (CTI2.SmartAliasMergeGuard.sourceStore-lifted guard)))
       entry)
+
+------------------------------------------------------------------------
+-- Rule-premise payoff
+------------------------------------------------------------------------
+
+world-invariants-no-target-at-dynamic-star : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
+  → CTI2.NoTargetOccupantAtSource W X
+world-invariants-no-target-at-dynamic-star {X = X} inv mark entry
+    (Xᴿ , aligned) =
+  dynamicStarSourcesUnoccupied inv X mark entry Xᴿ aligned
+
+world-invariants-see-through-premise : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W′
+  → CTI2.TagRebaseAtᴸ W′ W (just X) nothing
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] seal X ★
+  → CTI2.NoTargetOccupantAtSource W′ X
+world-invariants-see-through-premise inv
+    (CTI2.tag-rebase-onlyᴸ mark disaligned represented)
+    (CTI2.⊢↓-sealˣ source∋) =
+  world-invariants-no-target-at-dynamic-star inv mark
+    (lookupStore-∋ source∋)
+
+world-invariants-d17c-occupancy : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
+  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X) → ⊥
+world-invariants-d17c-occupancy inv mark entry =
+  world-invariants-no-target-at-dynamic-star inv mark entry

--- a/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
@@ -1,0 +1,69 @@
+module T15Invariant5ReconProbe where
+
+-- File Charter:
+--   * Drafts D16 invariant (5) as an extension of the live Stage 1
+--     WorldInvariants companion, without changing the live relation.
+--   * Uses total direct store lookup, matching the three landed fields.
+--   * Checks preservation pressure points, payoff lemmas, and kill checks
+--     added by the T15 recon addendum.
+--   * Contains no implementation of the eventual World migration.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality using
+  (_≡_; _≢_; refl; sym; trans; cong)
+
+open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ⇑ᵗ)
+open import TyStore using (lookupStore)
+open import Consistency using (id↪ᵗ; toRenameᵗ)
+open import Imprecision using (ImpEnv; X⊑★)
+import proof.DGG.CastTermImprecision2 as CTI2
+import proof.DGG.WorldInvariants as WI
+
+------------------------------------------------------------------------
+-- Proposed Stage 1 companion
+------------------------------------------------------------------------
+
+record WorldInvariants {Δᴸ Δᴿ Δ}
+    (W : CTI2.World Δᴸ Δᴿ Δ) : Set where
+  constructor world-invariants
+  field
+    stage1 : WI.WorldInvariants W
+
+    dynamicStarSourcesUnoccupied :
+      ∀ (Xᴸ : TyVar Δᴸ)
+      → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑★
+      → lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ★
+      → ∀ (Xᴿ : TyVar Δᴿ)
+      → toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+        ≢ toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+
+open WorldInvariants public
+
+------------------------------------------------------------------------
+-- Empty initial world
+------------------------------------------------------------------------
+
+emptyStore-lookup-variable : ∀ {Δ} (X : TyVar Δ)
+  → lookupStore (WI.emptyStore Δ) X ≡ ＇ X
+emptyStore-lookup-variable {Nat.suc Δ} Fin.zero = refl
+emptyStore-lookup-variable {Nat.suc Δ} (Fin.suc X) =
+  cong ⇑ᵗ (emptyStore-lookup-variable X)
+
+variable≢star : ∀ {Δ} {X : TyVar Δ}
+  → _≡_ {A = Ty Δ} (＇ X) ★ → ⊥
+variable≢star ()
+
+initialWorld-invariants : ∀ {Δ} (mu : ImpEnv Δ)
+  → WorldInvariants (WI.initialWorld mu)
+initialWorld-invariants {Δ = Δ} mu = world-invariants
+  (WI.initialWorld-invariants mu) no-dynamic-star-source
+  where
+  no-dynamic-star-source : ∀ (Xᴸ : TyVar Δ)
+    → mu (toRenameᵗ id↪ᵗ Xᴸ) ≡ X⊑★
+    → lookupStore (WI.emptyStore Δ) Xᴸ ≡ ★
+    → ∀ (Xᴿ : TyVar Δ)
+    → toRenameᵗ id↪ᵗ Xᴿ ≢ toRenameᵗ id↪ᵗ Xᴸ
+  no-dynamic-star-source Xᴸ mark entry Xᴿ aligned =
+    variable≢star (trans (sym (emptyStore-lookup-variable Xᴸ)) entry)

--- a/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
@@ -17,14 +17,18 @@ open import Relation.Binary.PropositionalEquality using
   (_≡_; _≢_; refl; sym; trans; cong)
 
 open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ⇑ᵗ)
-open import TyStore using (lookupStore; lookupStore-∋)
-open import Consistency using (id↪ᵗ; toRenameᵗ)
+open import TyStore using
+  (TyStore; store-empty; store-bind; lookupStore; lookupStore-∋)
+open import Consistency using
+  (_↪ᵗ_; empty; keep; id↪ᵗ; toRenameᵗ)
 open import Conversion using (seal)
 open import Imprecision using (ImpEnv; X⊑★)
 import proof.DGG.CastTermImprecision2 as CTI2
 import proof.DGG.TargetExtend as TE
 import proof.DGG.WorldInvariants as WI
 open import proof.ImprecisionConsistency using (fin-suc-injective)
+import CTIOccLiveFaithfulScratch as SOcc
+import CTITighteningNarrowScratch as Narrow
 
 ------------------------------------------------------------------------
 -- Proposed Stage 1 companion
@@ -181,3 +185,56 @@ world-invariants-d17c-occupancy : ∀ {Δᴸ Δᴿ Δ}
   → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X) → ⊥
 world-invariants-d17c-occupancy inv mark entry =
   world-invariants-no-target-at-dynamic-star inv mark entry
+
+------------------------------------------------------------------------
+-- Kill checks
+------------------------------------------------------------------------
+
+projection-mismatch-store : TyStore 1
+projection-mismatch-store = store-bind store-empty ★
+
+projection-mismatch-env : ImpEnv 1
+projection-mismatch-env Fin.zero = X⊑★
+
+projection-mismatch-world : CTI2.World 1 1 1
+projection-mismatch-world =
+  CTI2.world (keep empty) (keep empty) projection-mismatch-env
+    projection-mismatch-store projection-mismatch-store
+
+projection-mismatch-stage1 : WI.WorldInvariants projection-mismatch-world
+projection-mismatch-stage1 =
+  WI.identityWorld-invariants projection-mismatch-env
+    projection-mismatch-store
+
+projection-mismatch-rejects-invariant5 :
+  WorldInvariants projection-mismatch-world → ⊥
+projection-mismatch-rejects-invariant5 inv =
+  dynamicStarSourcesUnoccupied inv Fin.zero refl refl Fin.zero refl
+
+s-occ-aligned-stage1 : WI.WorldInvariants Narrow.W
+s-occ-aligned-stage1 =
+  WI.identityWorld-invariants Narrow.imp-env-dyn Narrow.source-store
+
+s-occ-aligned-rejects-invariant5 : WorldInvariants Narrow.W → ⊥
+s-occ-aligned-rejects-invariant5 inv =
+  dynamicStarSourcesUnoccupied inv Fin.zero refl refl Fin.zero refl
+
+s-occ-prealignment-stage1 : WI.WorldInvariants SOcc.Wᵖ
+s-occ-prealignment-stage1 =
+  WI.world-invariants
+    (λ { Fin.zero () })
+    (λ { {Xᴿ = ()} })
+    (λ ())
+
+s-occ-prealignment-invariants : WorldInvariants SOcc.Wᵖ
+s-occ-prealignment-invariants =
+  world-invariants s-occ-prealignment-stage1 no-target
+  where
+  no-target : ∀ Xᴸ
+    → CTI2.impEnvʷ SOcc.Wᵖ
+        (toRenameᵗ (CTI2.ηᴸʷ SOcc.Wᵖ) Xᴸ) ≡ X⊑★
+    → lookupStore (CTI2.sourceStoreʷ SOcc.Wᵖ) Xᴸ ≡ ★
+    → ∀ Xᴿ
+    → toRenameᵗ (CTI2.ηᴿʷ SOcc.Wᵖ) Xᴿ
+      ≢ toRenameᵗ (CTI2.ηᴸʷ SOcc.Wᵖ) Xᴸ
+  no-target Fin.zero mark entry ()

--- a/GTSFImp/proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
@@ -1,17 +1,17 @@
 module T15WorldInvariantsDesignProbe where
 
 -- File Charter:
---   * Type-checks the D16 seven-field World record and empty-store
+--   * Type-checks the D16 eight-field World record and empty-store
 --     initialWorld draft without changing the live relation.
 --   * Reconstructs the D8a and T10 Probe 1 rebase worlds and checks whether
---     their representation pairs satisfy the drafted invariant.
+--     their representation pairs satisfy all three drafted additions.
 --   * Contains no implementation of the World migration.
 
-open import Data.Empty using (⊥)
+open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
 import Data.Nat as Nat
 open import Data.Product using (Σ-syntax; _×_; _,_)
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
 
 open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ‵_; `ℕ; renameᵗ)
 open import TyStore using (TyStore; store-empty; store-lift; store-bind)
@@ -49,6 +49,12 @@ record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
             (resolveRep sourceStoreʷ (＇ Xᴸ))
           ⊑ renameᵗ (toRenameᵗ ηᴿʷ)
             (resolveRep targetStoreʷ (＇ Xᴿ))
+
+    unmatchedTargetsDynamicʷ :
+      ∀ (Xᴿ : TyVar Δᴿ)
+      → (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Xᴿ)
+      → resolveRep targetStoreʷ (＇ Xᴿ) ≡ ★
 
 open World public
 
@@ -95,11 +101,18 @@ initialRepresentations {Xᴸ = Xᴸ} aligned
     with toRenameᵗ-injective id↪ᵗ aligned
 initialRepresentations {Xᴸ = Xᴸ} aligned | refl = refl⊑ _
 
+initialUnmatchedTargets : ∀ {Δ} (Xᴿ : TyVar Δ)
+  → (∀ (Xᴸ : TyVar Δ)
+      → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
+  → resolveRep (emptyStore Δ) (＇ Xᴿ) ≡ ★
+initialUnmatchedTargets Xᴿ unmatched =
+  ⊥-elim (unmatched Xᴿ refl)
+
 initialWorld : ∀ {Δ} → ImpEnv Δ → World Δ Δ Δ
 initialWorld {Δ} μ =
   world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
     (λ Xᴸ precise → Xᴸ , refl)
-    initialRepresentations
+    initialRepresentations initialUnmatchedTargets
 
 initialWorld-source-empty : ∀ {Δ} (μ : ImpEnv Δ)
   → sourceStoreʷ (initialWorld μ) ≡ emptyStore Δ
@@ -114,7 +127,7 @@ emptyStore-under-binder : ∀ {Δ}
 emptyStore-under-binder = refl
 
 ------------------------------------------------------------------------
--- D8a reconstruction: both rebase endpoints satisfy the invariant
+-- D8a reconstruction: both rebase endpoints violate invariant (4)
 ------------------------------------------------------------------------
 
 empty-μ : ImpEnv 0
@@ -161,10 +174,21 @@ d8a-W-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
 d8a-W-representations {Fin.zero} {Fin.zero} ()
 d8a-W-representations {Fin.zero} {Fin.suc Fin.zero} refl = ι⊑ι
 
-d8a-W : World 1 2 2
-d8a-W =
-  world source-η-old target-η-id μ₂ d8a-source-store d8a-target-store
-    d8a-W-precise d8a-W-representations
+d8a-W-fresh-unmatched : ∀ (Xᴸ : TyVar 1)
+  → toRenameᵗ source-η-old Xᴸ
+      ≢ toRenameᵗ target-η-id Fin.zero
+d8a-W-fresh-unmatched Fin.zero ()
+
+d8a-W-violates-invariant4 :
+  (∀ (Xᴿ : TyVar 2)
+    → (∀ (Xᴸ : TyVar 1)
+        → toRenameᵗ source-η-old Xᴸ
+          ≢ toRenameᵗ target-η-id Xᴿ)
+    → resolveRep d8a-target-store (＇ Xᴿ) ≡ ★)
+  → ⊥
+d8a-W-violates-invariant4 invariant
+    with invariant Fin.zero d8a-W-fresh-unmatched
+d8a-W-violates-invariant4 invariant | ()
 
 d8a-Wᵖ-precise :
   ∀ (Xᴸ : TyVar 1)
@@ -183,16 +207,21 @@ d8a-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
 d8a-Wᵖ-representations {Fin.zero} {Fin.zero} refl = ι⊑ι
 d8a-Wᵖ-representations {Fin.zero} {Fin.suc Fin.zero} ()
 
-d8a-Wᵖ : World 1 2 2
-d8a-Wᵖ =
-  world source-η-fresh target-η-id μ₂
-    d8a-source-store d8a-target-store
-    d8a-Wᵖ-precise d8a-Wᵖ-representations
+d8a-Wᵖ-old-unmatched : ∀ (Xᴸ : TyVar 1)
+  → toRenameᵗ source-η-fresh Xᴸ
+      ≢ toRenameᵗ target-η-id (Fin.suc Fin.zero)
+d8a-Wᵖ-old-unmatched Fin.zero ()
 
-d8a-refuting-worlds-satisfy :
-  RepresentationInvariant d8a-W × RepresentationInvariant d8a-Wᵖ
-d8a-refuting-worlds-satisfy =
-  representationInvariant d8a-W , representationInvariant d8a-Wᵖ
+d8a-Wᵖ-violates-invariant4 :
+  (∀ (Xᴿ : TyVar 2)
+    → (∀ (Xᴸ : TyVar 1)
+        → toRenameᵗ source-η-fresh Xᴸ
+          ≢ toRenameᵗ target-η-id Xᴿ)
+    → resolveRep d8a-target-store (＇ Xᴿ) ≡ ★)
+  → ⊥
+d8a-Wᵖ-violates-invariant4 invariant
+    with invariant (Fin.suc Fin.zero) d8a-Wᵖ-old-unmatched
+d8a-Wᵖ-violates-invariant4 invariant | ()
 
 ------------------------------------------------------------------------
 -- T10 Probe 1 reconstruction: the same geometry with ★ representations
@@ -214,10 +243,19 @@ t10-W-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
 t10-W-representations {Fin.zero} {Fin.zero} ()
 t10-W-representations {Fin.zero} {Fin.suc Fin.zero} refl = ★⊑★
 
+t10-W-unmatched-targets : ∀ (Xᴿ : TyVar 2)
+  → (∀ (Xᴸ : TyVar 1)
+      → toRenameᵗ source-η-old Xᴸ
+        ≢ toRenameᵗ target-η-id Xᴿ)
+  → resolveRep t10-target-store (＇ Xᴿ) ≡ ★
+t10-W-unmatched-targets Fin.zero unmatched = refl
+t10-W-unmatched-targets (Fin.suc Fin.zero) unmatched =
+  ⊥-elim (unmatched Fin.zero refl)
+
 t10-W : World 1 2 2
 t10-W =
   world source-η-old target-η-id μ₂ t10-source-store t10-target-store
-    d8a-W-precise t10-W-representations
+    d8a-W-precise t10-W-representations t10-W-unmatched-targets
 
 t10-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
   → toRenameᵗ source-η-fresh Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
@@ -229,14 +267,22 @@ t10-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
 t10-Wᵖ-representations {Fin.zero} {Fin.zero} refl = ★⊑★
 t10-Wᵖ-representations {Fin.zero} {Fin.suc Fin.zero} ()
 
+t10-Wᵖ-unmatched-targets : ∀ (Xᴿ : TyVar 2)
+  → (∀ (Xᴸ : TyVar 1)
+      → toRenameᵗ source-η-fresh Xᴸ
+        ≢ toRenameᵗ target-η-id Xᴿ)
+  → resolveRep t10-target-store (＇ Xᴿ) ≡ ★
+t10-Wᵖ-unmatched-targets Fin.zero unmatched =
+  ⊥-elim (unmatched Fin.zero refl)
+t10-Wᵖ-unmatched-targets (Fin.suc Fin.zero) unmatched = refl
+
 t10-Wᵖ : World 1 2 2
 t10-Wᵖ =
   world source-η-fresh target-η-id μ₂
     t10-source-store t10-target-store
-    d8a-Wᵖ-precise t10-Wᵖ-representations
+    d8a-Wᵖ-precise t10-Wᵖ-representations t10-Wᵖ-unmatched-targets
 
 t10-probe1-worlds-satisfy :
   RepresentationInvariant t10-W × RepresentationInvariant t10-Wᵖ
 t10-probe1-worlds-satisfy =
   representationInvariant t10-W , representationInvariant t10-Wᵖ
-

--- a/GTSFImp/proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
@@ -3,6 +3,8 @@ module T15WorldInvariantsDesignProbe where
 -- File Charter:
 --   * Type-checks the D16 eight-field World record and empty-store
 --     initialWorld draft without changing the live relation.
+--   * States the strict and chain-permissive direct-entry alternatives for
+--     unmatched target pivots and checks the recommended permissive form.
 --   * Reconstructs the D8a and T10 Probe 1 rebase worlds and checks whether
 --     their representation pairs satisfy all three drafted additions.
 --   * Contains no implementation of the World migration.
@@ -11,16 +13,33 @@ open import Data.Empty using (⊥; ⊥-elim)
 import Data.Fin as Fin
 import Data.Nat as Nat
 open import Data.Product using (Σ-syntax; _×_; _,_)
-open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Relation.Binary.PropositionalEquality using
+  (_≡_; _≢_; refl; cong)
 
-open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ‵_; `ℕ; renameᵗ)
+open import Types using
+  (TyCtx; Ty; TyVar; ★; ＇_; ‵_; `ℕ; renameᵗ; ⇑ᵗ)
 open import TyStore using (TyStore; store-empty; store-lift; store-bind)
-open import Consistency using (_↪ᵗ_; empty; keep; skip; id↪ᵗ; toRenameᵗ)
+open import Consistency using
+  (_↪ᵗ_; empty; keep; skip; id↪ᵗ; toRenameᵗ)
 open import Imprecision using
   (ImpEnv; X⊑X; X⊑★; extendᵐ; instᵐ; _⊢_⊑_; ★⊑★; ι⊑ι)
 open import proof.ImprecisionConsistency using
   (refl⊑; toRenameᵗ-injective)
-open import proof.DGG.CastTermImprecision2 using (resolveRep)
+
+------------------------------------------------------------------------
+-- Total, one-step store lookup
+------------------------------------------------------------------------
+
+-- TyStore's relational lookup has no entry for a structurally lifted zero.
+-- This total view treats that zero as its own one-step representation and
+-- otherwise returns exactly the direct entry, lifted into the current scope.
+
+lookupStore : ∀ {Δ} → TyStore Δ → TyVar Δ → Ty Δ
+lookupStore (store-lift Σ) Fin.zero = ＇ Fin.zero
+lookupStore (store-lift Σ) (Fin.suc X) = ⇑ᵗ (lookupStore Σ X)
+lookupStore (store-bind Σ A) Fin.zero = ⇑ᵗ A
+lookupStore (store-bind Σ A) (Fin.suc X) = ⇑ᵗ (lookupStore Σ X)
 
 ------------------------------------------------------------------------
 -- Draft record
@@ -46,15 +65,19 @@ record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
       → toRenameᵗ ηᴸʷ Xᴸ ≡ toRenameᵗ ηᴿʷ Xᴿ
       → impEnvʷ ⊢
           renameᵗ (toRenameᵗ ηᴸʷ)
-            (resolveRep sourceStoreʷ (＇ Xᴸ))
+            (lookupStore sourceStoreʷ Xᴸ)
           ⊑ renameᵗ (toRenameᵗ ηᴿʷ)
-            (resolveRep targetStoreʷ (＇ Xᴿ))
+            (lookupStore targetStoreʷ Xᴿ)
 
     unmatchedTargetsDynamicʷ :
       ∀ (Xᴿ : TyVar Δᴿ)
       → (∀ (Xᴸ : TyVar Δᴸ)
           → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Xᴿ)
-      → resolveRep targetStoreʷ (＇ Xᴿ) ≡ ★
+      → lookupStore targetStoreʷ Xᴿ ≡ ★
+        ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
+            (lookupStore targetStoreʷ Xᴿ ≡ ＇ Yᴿ)
+          × (∀ (Xᴸ : TyVar Δᴸ)
+              → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Yᴿ)
 
 open World public
 
@@ -73,14 +96,77 @@ RepresentationInvariant W =
   ∀ {Xᴸ Xᴿ} → CenterAligned W Xᴸ Xᴿ
   → impEnvʷ W ⊢
       renameᵗ (toRenameᵗ (ηᴸʷ W))
-        (resolveRep (sourceStoreʷ W) (＇ Xᴸ))
+        (lookupStore (sourceStoreʷ W) Xᴸ)
       ⊑ renameᵗ (toRenameᵗ (ηᴿʷ W))
-        (resolveRep (targetStoreʷ W) (＇ Xᴿ))
+        (lookupStore (targetStoreʷ W) Xᴿ)
 
 representationInvariant : ∀ {Δᴸ Δᴿ Δ}
     (W : World Δᴸ Δᴿ Δ)
   → RepresentationInvariant W
 representationInvariant W = representationsImpreciseʷ W
+
+-- When related direct entries are both variables, type-imprecision forces
+-- their heads to share a center.  Applying the field again supplies the next
+-- direct-entry relation; finite store age then supports induction down a
+-- complete representation chain.
+
+imprecision-cong : ∀ {Δ} {μ : ImpEnv Δ} {A A′ B B′ : Ty Δ}
+  → A ≡ A′
+  → B ≡ B′
+  → μ ⊢ A ⊑ B
+  → μ ⊢ A′ ⊑ B′
+imprecision-cong refl refl A⊑B = A⊑B
+
+variableHeadsAlign : ∀ {Δ} {μ : ImpEnv Δ} {X Y : TyVar Δ}
+  → μ ⊢ ＇ X ⊑ ＇ Y
+  → X ≡ Y
+variableHeadsAlign X⊑X = refl
+
+variableEntryChainCoherence : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ)
+    {Xᴸ Yᴸ : TyVar Δᴸ} {Xᴿ Yᴿ : TyVar Δᴿ}
+  → CenterAligned W Xᴸ Xᴿ
+  → lookupStore (sourceStoreʷ W) Xᴸ ≡ ＇ Yᴸ
+  → lookupStore (targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ
+  → CenterAligned W Yᴸ Yᴿ
+    × (impEnvʷ W ⊢
+        renameᵗ (toRenameᵗ (ηᴸʷ W))
+          (lookupStore (sourceStoreʷ W) Yᴸ)
+        ⊑ renameᵗ (toRenameᵗ (ηᴿʷ W))
+          (lookupStore (targetStoreʷ W) Yᴿ))
+variableEntryChainCoherence W {Yᴸ = Yᴸ} {Yᴿ = Yᴿ}
+    aligned source-entry target-entry =
+  heads-aligned , representationsImpreciseʷ W heads-aligned
+  where
+  heads-aligned : CenterAligned W Yᴸ Yᴿ
+  heads-aligned = variableHeadsAlign
+    (imprecision-cong
+      (cong (renameᵗ (toRenameᵗ (ηᴸʷ W))) source-entry)
+      (cong (renameᵗ (toRenameᵗ (ηᴿʷ W))) target-entry)
+      (representationsImpreciseʷ W aligned))
+
+-- The strict candidate is stronger than the record's recommended
+-- chain-permissive field.
+
+strictImpliesChainPermissive : ∀ {Δᴸ Δᴿ Δ}
+    {W : World Δᴸ Δᴿ Δ}
+  → (∀ (Xᴿ : TyVar Δᴿ)
+      → (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ (ηᴸʷ W) Xᴸ
+            ≢ toRenameᵗ (ηᴿʷ W) Xᴿ)
+      → lookupStore (targetStoreʷ W) Xᴿ ≡ ★)
+  → ∀ (Xᴿ : TyVar Δᴿ)
+  → (∀ (Xᴸ : TyVar Δᴸ)
+      → toRenameᵗ (ηᴸʷ W) Xᴸ
+        ≢ toRenameᵗ (ηᴿʷ W) Xᴿ)
+  → lookupStore (targetStoreʷ W) Xᴿ ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
+        (lookupStore (targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ (ηᴸʷ W) Xᴸ
+            ≢ toRenameᵗ (ηᴿʷ W) Yᴿ)
+strictImpliesChainPermissive strict Xᴿ unmatched =
+  inj₁ (strict Xᴿ unmatched)
 
 ------------------------------------------------------------------------
 -- Empty compilation stores and the amended initial world
@@ -94,9 +180,9 @@ initialRepresentations : ∀ {Δ} {μ : ImpEnv Δ} {Xᴸ Xᴿ : TyVar Δ}
   → toRenameᵗ id↪ᵗ Xᴸ ≡ toRenameᵗ id↪ᵗ Xᴿ
   → μ ⊢
       renameᵗ (toRenameᵗ id↪ᵗ)
-        (resolveRep (emptyStore Δ) (＇ Xᴸ))
+        (lookupStore (emptyStore Δ) Xᴸ)
       ⊑ renameᵗ (toRenameᵗ id↪ᵗ)
-        (resolveRep (emptyStore Δ) (＇ Xᴿ))
+        (lookupStore (emptyStore Δ) Xᴿ)
 initialRepresentations {Xᴸ = Xᴸ} aligned
     with toRenameᵗ-injective id↪ᵗ aligned
 initialRepresentations {Xᴸ = Xᴸ} aligned | refl = refl⊑ _
@@ -104,7 +190,11 @@ initialRepresentations {Xᴸ = Xᴸ} aligned | refl = refl⊑ _
 initialUnmatchedTargets : ∀ {Δ} (Xᴿ : TyVar Δ)
   → (∀ (Xᴸ : TyVar Δ)
       → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Xᴿ)
-  → resolveRep (emptyStore Δ) (＇ Xᴿ) ≡ ★
+  → lookupStore (emptyStore Δ) Xᴿ ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar Δ ]
+        (lookupStore (emptyStore Δ) Xᴿ ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar Δ)
+          → toRenameᵗ id↪ᵗ Xᴸ ≢ toRenameᵗ id↪ᵗ Yᴿ)
 initialUnmatchedTargets Xᴿ unmatched =
   ⊥-elim (unmatched Xᴿ refl)
 
@@ -145,6 +235,9 @@ source-η-fresh = keep empty
 target-η-id : 2 ↪ᵗ 2
 target-η-id = keep (keep empty)
 
+source-η-empty : 0 ↪ᵗ 2
+source-η-empty = skip (skip empty)
+
 ℕ₀ : Ty 0
 ℕ₀ = ‵ `ℕ
 
@@ -157,6 +250,68 @@ d8a-source-store = store-bind store-empty ℕ₀
 d8a-target-store : TyStore 2
 d8a-target-store = store-bind (store-bind store-empty ℕ₀) ℕ₁
 
+d8a-fresh-direct-entry :
+  lookupStore d8a-target-store Fin.zero ≡ ‵ `ℕ
+d8a-fresh-direct-entry = refl
+
+d8a-old-direct-entry :
+  lookupStore d8a-target-store (Fin.suc Fin.zero) ≡ ‵ `ℕ
+d8a-old-direct-entry = refl
+
+------------------------------------------------------------------------
+-- The live ★-then-variable route needs chain-permissive unmatched targets
+------------------------------------------------------------------------
+
+alias-chain-target-store : TyStore 2
+alias-chain-target-store =
+  store-bind (store-bind store-empty ★) (＇ Fin.zero)
+
+alias-chain-precise :
+  ∀ (Xᴸ : TyVar 0)
+  → μ₂ (toRenameᵗ source-η-empty Xᴸ) ≡ X⊑X
+  → Σ[ Xᴿ ∈ TyVar 2 ]
+      toRenameᵗ target-η-id Xᴿ ≡ toRenameᵗ source-η-empty Xᴸ
+alias-chain-precise ()
+
+alias-chain-representations : ∀ {Xᴸ : TyVar 0} {Xᴿ : TyVar 2}
+  → toRenameᵗ source-η-empty Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
+  → μ₂ ⊢
+      renameᵗ (toRenameᵗ source-η-empty)
+        (lookupStore store-empty Xᴸ)
+      ⊑ renameᵗ (toRenameᵗ target-η-id)
+        (lookupStore alias-chain-target-store Xᴿ)
+alias-chain-representations {()}
+
+alias-chain-unmatched-targets : ∀ (Xᴿ : TyVar 2)
+  → (∀ (Xᴸ : TyVar 0)
+      → toRenameᵗ source-η-empty Xᴸ
+        ≢ toRenameᵗ target-η-id Xᴿ)
+  → lookupStore alias-chain-target-store Xᴿ ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+        (lookupStore alias-chain-target-store Xᴿ ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar 0)
+          → toRenameᵗ source-η-empty Xᴸ
+            ≢ toRenameᵗ target-η-id Yᴿ)
+alias-chain-unmatched-targets Fin.zero unmatched =
+  inj₂ (Fin.suc Fin.zero , refl , (λ ()))
+alias-chain-unmatched-targets (Fin.suc Fin.zero) unmatched = inj₁ refl
+
+alias-chain-world : World 0 2 2
+alias-chain-world =
+  world source-η-empty target-η-id μ₂ store-empty
+    alias-chain-target-store alias-chain-precise
+    alias-chain-representations alias-chain-unmatched-targets
+
+alias-chain-rejects-strict :
+  (∀ (Xᴿ : TyVar 2)
+    → (∀ (Xᴸ : TyVar 0)
+        → toRenameᵗ source-η-empty Xᴸ
+          ≢ toRenameᵗ target-η-id Xᴿ)
+    → lookupStore alias-chain-target-store Xᴿ ≡ ★)
+  → ⊥
+alias-chain-rejects-strict strict with strict Fin.zero (λ ())
+alias-chain-rejects-strict strict | ()
+
 d8a-W-precise :
   ∀ (Xᴸ : TyVar 1)
   → μ₂ (toRenameᵗ source-η-old Xᴸ) ≡ X⊑X
@@ -168,9 +323,9 @@ d8a-W-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
   → toRenameᵗ source-η-old Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
   → μ₂ ⊢
       renameᵗ (toRenameᵗ source-η-old)
-        (resolveRep d8a-source-store (＇ Xᴸ))
+        (lookupStore d8a-source-store Xᴸ)
       ⊑ renameᵗ (toRenameᵗ target-η-id)
-        (resolveRep d8a-target-store (＇ Xᴿ))
+        (lookupStore d8a-target-store Xᴿ)
 d8a-W-representations {Fin.zero} {Fin.zero} ()
 d8a-W-representations {Fin.zero} {Fin.suc Fin.zero} refl = ι⊑ι
 
@@ -184,11 +339,17 @@ d8a-W-violates-invariant4 :
     → (∀ (Xᴸ : TyVar 1)
         → toRenameᵗ source-η-old Xᴸ
           ≢ toRenameᵗ target-η-id Xᴿ)
-    → resolveRep d8a-target-store (＇ Xᴿ) ≡ ★)
+    → lookupStore d8a-target-store Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+          (lookupStore d8a-target-store Xᴿ ≡ ＇ Yᴿ)
+        × (∀ (Xᴸ : TyVar 1)
+            → toRenameᵗ source-η-old Xᴸ
+              ≢ toRenameᵗ target-η-id Yᴿ))
   → ⊥
 d8a-W-violates-invariant4 invariant
     with invariant Fin.zero d8a-W-fresh-unmatched
-d8a-W-violates-invariant4 invariant | ()
+d8a-W-violates-invariant4 invariant | inj₁ ()
+d8a-W-violates-invariant4 invariant | inj₂ (Yᴿ , () , Yᴿ-unmatched)
 
 d8a-Wᵖ-precise :
   ∀ (Xᴸ : TyVar 1)
@@ -201,9 +362,9 @@ d8a-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
   → toRenameᵗ source-η-fresh Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
   → μ₂ ⊢
       renameᵗ (toRenameᵗ source-η-fresh)
-        (resolveRep d8a-source-store (＇ Xᴸ))
+        (lookupStore d8a-source-store Xᴸ)
       ⊑ renameᵗ (toRenameᵗ target-η-id)
-        (resolveRep d8a-target-store (＇ Xᴿ))
+        (lookupStore d8a-target-store Xᴿ)
 d8a-Wᵖ-representations {Fin.zero} {Fin.zero} refl = ι⊑ι
 d8a-Wᵖ-representations {Fin.zero} {Fin.suc Fin.zero} ()
 
@@ -217,11 +378,17 @@ d8a-Wᵖ-violates-invariant4 :
     → (∀ (Xᴸ : TyVar 1)
         → toRenameᵗ source-η-fresh Xᴸ
           ≢ toRenameᵗ target-η-id Xᴿ)
-    → resolveRep d8a-target-store (＇ Xᴿ) ≡ ★)
+    → lookupStore d8a-target-store Xᴿ ≡ ★
+      ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+          (lookupStore d8a-target-store Xᴿ ≡ ＇ Yᴿ)
+        × (∀ (Xᴸ : TyVar 1)
+            → toRenameᵗ source-η-fresh Xᴸ
+              ≢ toRenameᵗ target-η-id Yᴿ))
   → ⊥
 d8a-Wᵖ-violates-invariant4 invariant
     with invariant (Fin.suc Fin.zero) d8a-Wᵖ-old-unmatched
-d8a-Wᵖ-violates-invariant4 invariant | ()
+d8a-Wᵖ-violates-invariant4 invariant | inj₁ ()
+d8a-Wᵖ-violates-invariant4 invariant | inj₂ (Yᴿ , () , Yᴿ-unmatched)
 
 ------------------------------------------------------------------------
 -- T10 Probe 1 reconstruction: the same geometry with ★ representations
@@ -237,9 +404,9 @@ t10-W-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
   → toRenameᵗ source-η-old Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
   → μ₂ ⊢
       renameᵗ (toRenameᵗ source-η-old)
-        (resolveRep t10-source-store (＇ Xᴸ))
+        (lookupStore t10-source-store Xᴸ)
       ⊑ renameᵗ (toRenameᵗ target-η-id)
-        (resolveRep t10-target-store (＇ Xᴿ))
+        (lookupStore t10-target-store Xᴿ)
 t10-W-representations {Fin.zero} {Fin.zero} ()
 t10-W-representations {Fin.zero} {Fin.suc Fin.zero} refl = ★⊑★
 
@@ -247,8 +414,13 @@ t10-W-unmatched-targets : ∀ (Xᴿ : TyVar 2)
   → (∀ (Xᴸ : TyVar 1)
       → toRenameᵗ source-η-old Xᴸ
         ≢ toRenameᵗ target-η-id Xᴿ)
-  → resolveRep t10-target-store (＇ Xᴿ) ≡ ★
-t10-W-unmatched-targets Fin.zero unmatched = refl
+  → lookupStore t10-target-store Xᴿ ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+        (lookupStore t10-target-store Xᴿ ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar 1)
+          → toRenameᵗ source-η-old Xᴸ
+            ≢ toRenameᵗ target-η-id Yᴿ)
+t10-W-unmatched-targets Fin.zero unmatched = inj₁ refl
 t10-W-unmatched-targets (Fin.suc Fin.zero) unmatched =
   ⊥-elim (unmatched Fin.zero refl)
 
@@ -261,9 +433,9 @@ t10-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
   → toRenameᵗ source-η-fresh Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
   → μ₂ ⊢
       renameᵗ (toRenameᵗ source-η-fresh)
-        (resolveRep t10-source-store (＇ Xᴸ))
+        (lookupStore t10-source-store Xᴸ)
       ⊑ renameᵗ (toRenameᵗ target-η-id)
-        (resolveRep t10-target-store (＇ Xᴿ))
+        (lookupStore t10-target-store Xᴿ)
 t10-Wᵖ-representations {Fin.zero} {Fin.zero} refl = ★⊑★
 t10-Wᵖ-representations {Fin.zero} {Fin.suc Fin.zero} ()
 
@@ -271,10 +443,15 @@ t10-Wᵖ-unmatched-targets : ∀ (Xᴿ : TyVar 2)
   → (∀ (Xᴸ : TyVar 1)
       → toRenameᵗ source-η-fresh Xᴸ
         ≢ toRenameᵗ target-η-id Xᴿ)
-  → resolveRep t10-target-store (＇ Xᴿ) ≡ ★
+  → lookupStore t10-target-store Xᴿ ≡ ★
+    ⊎ Σ[ Yᴿ ∈ TyVar 2 ]
+        (lookupStore t10-target-store Xᴿ ≡ ＇ Yᴿ)
+      × (∀ (Xᴸ : TyVar 1)
+          → toRenameᵗ source-η-fresh Xᴸ
+            ≢ toRenameᵗ target-η-id Yᴿ)
 t10-Wᵖ-unmatched-targets Fin.zero unmatched =
   ⊥-elim (unmatched Fin.zero refl)
-t10-Wᵖ-unmatched-targets (Fin.suc Fin.zero) unmatched = refl
+t10-Wᵖ-unmatched-targets (Fin.suc Fin.zero) unmatched = inj₁ refl
 
 t10-Wᵖ : World 1 2 2
 t10-Wᵖ =

--- a/GTSFImp/proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
@@ -1,0 +1,242 @@
+module T15WorldInvariantsDesignProbe where
+
+-- File Charter:
+--   * Type-checks the D16 seven-field World record and empty-store
+--     initialWorld draft without changing the live relation.
+--   * Reconstructs the D8a and T10 Probe 1 rebase worlds and checks whether
+--     their representation pairs satisfy the drafted invariant.
+--   * Contains no implementation of the World migration.
+
+open import Data.Empty using (⊥)
+import Data.Fin as Fin
+import Data.Nat as Nat
+open import Data.Product using (Σ-syntax; _×_; _,_)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types using (TyCtx; Ty; TyVar; ★; ＇_; ‵_; `ℕ; renameᵗ)
+open import TyStore using (TyStore; store-empty; store-lift; store-bind)
+open import Consistency using (_↪ᵗ_; empty; keep; skip; id↪ᵗ; toRenameᵗ)
+open import Imprecision using
+  (ImpEnv; X⊑X; X⊑★; extendᵐ; instᵐ; _⊢_⊑_; ★⊑★; ι⊑ι)
+open import proof.ImprecisionConsistency using
+  (refl⊑; toRenameᵗ-injective)
+open import proof.DGG.CastTermImprecision2 using (resolveRep)
+
+------------------------------------------------------------------------
+-- Draft record
+------------------------------------------------------------------------
+
+record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
+  constructor world
+  field
+    ηᴸʷ : Δᴸ ↪ᵗ Δ
+    ηᴿʷ : Δᴿ ↪ᵗ Δ
+    impEnvʷ : ImpEnv Δ
+    sourceStoreʷ : TyStore Δᴸ
+    targetStoreʷ : TyStore Δᴿ
+
+    preciseMarksAlignedʷ :
+      ∀ (Xᴸ : TyVar Δᴸ)
+      → impEnvʷ (toRenameᵗ ηᴸʷ Xᴸ) ≡ X⊑X
+      → Σ[ Xᴿ ∈ TyVar Δᴿ ]
+          toRenameᵗ ηᴿʷ Xᴿ ≡ toRenameᵗ ηᴸʷ Xᴸ
+
+    representationsImpreciseʷ :
+      ∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+      → toRenameᵗ ηᴸʷ Xᴸ ≡ toRenameᵗ ηᴿʷ Xᴿ
+      → impEnvʷ ⊢
+          renameᵗ (toRenameᵗ ηᴸʷ)
+            (resolveRep sourceStoreʷ (＇ Xᴸ))
+          ⊑ renameᵗ (toRenameᵗ ηᴿʷ)
+            (resolveRep targetStoreʷ (＇ Xᴿ))
+
+open World public
+
+CenterAligned : ∀ {Δᴸ Δᴿ Δ}
+  → World Δᴸ Δᴿ Δ
+  → TyVar Δᴸ
+  → TyVar Δᴿ
+  → Set
+CenterAligned W Xᴸ Xᴿ =
+  toRenameᵗ (ηᴸʷ W) Xᴸ ≡ toRenameᵗ (ηᴿʷ W) Xᴿ
+
+RepresentationInvariant : ∀ {Δᴸ Δᴿ Δ}
+  → World Δᴸ Δᴿ Δ
+  → Set
+RepresentationInvariant W =
+  ∀ {Xᴸ Xᴿ} → CenterAligned W Xᴸ Xᴿ
+  → impEnvʷ W ⊢
+      renameᵗ (toRenameᵗ (ηᴸʷ W))
+        (resolveRep (sourceStoreʷ W) (＇ Xᴸ))
+      ⊑ renameᵗ (toRenameᵗ (ηᴿʷ W))
+        (resolveRep (targetStoreʷ W) (＇ Xᴿ))
+
+representationInvariant : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ)
+  → RepresentationInvariant W
+representationInvariant W = representationsImpreciseʷ W
+
+------------------------------------------------------------------------
+-- Empty compilation stores and the amended initial world
+------------------------------------------------------------------------
+
+emptyStore : (Δ : TyCtx) → TyStore Δ
+emptyStore Nat.zero = store-empty
+emptyStore (Nat.suc Δ) = store-lift (emptyStore Δ)
+
+initialRepresentations : ∀ {Δ} {μ : ImpEnv Δ} {Xᴸ Xᴿ : TyVar Δ}
+  → toRenameᵗ id↪ᵗ Xᴸ ≡ toRenameᵗ id↪ᵗ Xᴿ
+  → μ ⊢
+      renameᵗ (toRenameᵗ id↪ᵗ)
+        (resolveRep (emptyStore Δ) (＇ Xᴸ))
+      ⊑ renameᵗ (toRenameᵗ id↪ᵗ)
+        (resolveRep (emptyStore Δ) (＇ Xᴿ))
+initialRepresentations {Xᴸ = Xᴸ} aligned
+    with toRenameᵗ-injective id↪ᵗ aligned
+initialRepresentations {Xᴸ = Xᴸ} aligned | refl = refl⊑ _
+
+initialWorld : ∀ {Δ} → ImpEnv Δ → World Δ Δ Δ
+initialWorld {Δ} μ =
+  world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
+    (λ Xᴸ precise → Xᴸ , refl)
+    initialRepresentations
+
+initialWorld-source-empty : ∀ {Δ} (μ : ImpEnv Δ)
+  → sourceStoreʷ (initialWorld μ) ≡ emptyStore Δ
+initialWorld-source-empty μ = refl
+
+initialWorld-target-empty : ∀ {Δ} (μ : ImpEnv Δ)
+  → targetStoreʷ (initialWorld μ) ≡ emptyStore Δ
+initialWorld-target-empty μ = refl
+
+emptyStore-under-binder : ∀ {Δ}
+  → emptyStore (Nat.suc Δ) ≡ store-lift (emptyStore Δ)
+emptyStore-under-binder = refl
+
+------------------------------------------------------------------------
+-- D8a reconstruction: both rebase endpoints satisfy the invariant
+------------------------------------------------------------------------
+
+empty-μ : ImpEnv 0
+empty-μ ()
+
+μ₂ : ImpEnv 2
+μ₂ = instᵐ (extendᵐ X⊑X empty-μ)
+
+source-η-old : 1 ↪ᵗ 2
+source-η-old = skip (keep empty)
+
+source-η-fresh : 1 ↪ᵗ 2
+source-η-fresh = keep empty
+
+target-η-id : 2 ↪ᵗ 2
+target-η-id = keep (keep empty)
+
+ℕ₀ : Ty 0
+ℕ₀ = ‵ `ℕ
+
+ℕ₁ : Ty 1
+ℕ₁ = ‵ `ℕ
+
+d8a-source-store : TyStore 1
+d8a-source-store = store-bind store-empty ℕ₀
+
+d8a-target-store : TyStore 2
+d8a-target-store = store-bind (store-bind store-empty ℕ₀) ℕ₁
+
+d8a-W-precise :
+  ∀ (Xᴸ : TyVar 1)
+  → μ₂ (toRenameᵗ source-η-old Xᴸ) ≡ X⊑X
+  → Σ[ Xᴿ ∈ TyVar 2 ]
+      toRenameᵗ target-η-id Xᴿ ≡ toRenameᵗ source-η-old Xᴸ
+d8a-W-precise Fin.zero precise = Fin.suc Fin.zero , refl
+
+d8a-W-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
+  → toRenameᵗ source-η-old Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
+  → μ₂ ⊢
+      renameᵗ (toRenameᵗ source-η-old)
+        (resolveRep d8a-source-store (＇ Xᴸ))
+      ⊑ renameᵗ (toRenameᵗ target-η-id)
+        (resolveRep d8a-target-store (＇ Xᴿ))
+d8a-W-representations {Fin.zero} {Fin.zero} ()
+d8a-W-representations {Fin.zero} {Fin.suc Fin.zero} refl = ι⊑ι
+
+d8a-W : World 1 2 2
+d8a-W =
+  world source-η-old target-η-id μ₂ d8a-source-store d8a-target-store
+    d8a-W-precise d8a-W-representations
+
+d8a-Wᵖ-precise :
+  ∀ (Xᴸ : TyVar 1)
+  → μ₂ (toRenameᵗ source-η-fresh Xᴸ) ≡ X⊑X
+  → Σ[ Xᴿ ∈ TyVar 2 ]
+      toRenameᵗ target-η-id Xᴿ ≡ toRenameᵗ source-η-fresh Xᴸ
+d8a-Wᵖ-precise Fin.zero ()
+
+d8a-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
+  → toRenameᵗ source-η-fresh Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
+  → μ₂ ⊢
+      renameᵗ (toRenameᵗ source-η-fresh)
+        (resolveRep d8a-source-store (＇ Xᴸ))
+      ⊑ renameᵗ (toRenameᵗ target-η-id)
+        (resolveRep d8a-target-store (＇ Xᴿ))
+d8a-Wᵖ-representations {Fin.zero} {Fin.zero} refl = ι⊑ι
+d8a-Wᵖ-representations {Fin.zero} {Fin.suc Fin.zero} ()
+
+d8a-Wᵖ : World 1 2 2
+d8a-Wᵖ =
+  world source-η-fresh target-η-id μ₂
+    d8a-source-store d8a-target-store
+    d8a-Wᵖ-precise d8a-Wᵖ-representations
+
+d8a-refuting-worlds-satisfy :
+  RepresentationInvariant d8a-W × RepresentationInvariant d8a-Wᵖ
+d8a-refuting-worlds-satisfy =
+  representationInvariant d8a-W , representationInvariant d8a-Wᵖ
+
+------------------------------------------------------------------------
+-- T10 Probe 1 reconstruction: the same geometry with ★ representations
+------------------------------------------------------------------------
+
+t10-source-store : TyStore 1
+t10-source-store = store-bind store-empty ★
+
+t10-target-store : TyStore 2
+t10-target-store = store-bind (store-bind store-empty ★) ★
+
+t10-W-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
+  → toRenameᵗ source-η-old Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
+  → μ₂ ⊢
+      renameᵗ (toRenameᵗ source-η-old)
+        (resolveRep t10-source-store (＇ Xᴸ))
+      ⊑ renameᵗ (toRenameᵗ target-η-id)
+        (resolveRep t10-target-store (＇ Xᴿ))
+t10-W-representations {Fin.zero} {Fin.zero} ()
+t10-W-representations {Fin.zero} {Fin.suc Fin.zero} refl = ★⊑★
+
+t10-W : World 1 2 2
+t10-W =
+  world source-η-old target-η-id μ₂ t10-source-store t10-target-store
+    d8a-W-precise t10-W-representations
+
+t10-Wᵖ-representations : ∀ {Xᴸ : TyVar 1} {Xᴿ : TyVar 2}
+  → toRenameᵗ source-η-fresh Xᴸ ≡ toRenameᵗ target-η-id Xᴿ
+  → μ₂ ⊢
+      renameᵗ (toRenameᵗ source-η-fresh)
+        (resolveRep t10-source-store (＇ Xᴸ))
+      ⊑ renameᵗ (toRenameᵗ target-η-id)
+        (resolveRep t10-target-store (＇ Xᴿ))
+t10-Wᵖ-representations {Fin.zero} {Fin.zero} refl = ★⊑★
+t10-Wᵖ-representations {Fin.zero} {Fin.suc Fin.zero} ()
+
+t10-Wᵖ : World 1 2 2
+t10-Wᵖ =
+  world source-η-fresh target-η-id μ₂
+    t10-source-store t10-target-store
+    d8a-Wᵖ-precise t10-Wᵖ-representations
+
+t10-probe1-worlds-satisfy :
+  RepresentationInvariant t10-W × RepresentationInvariant t10-Wᵖ
+t10-probe1-worlds-satisfy =
+  representationInvariant t10-W , representationInvariant t10-Wᵖ
+

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -367,8 +367,9 @@ A low-risk LG-1-style sequence is:
 
 1. Add the total one-step `lookupStore` to `TyStore`.  Against the existing
    five-field record, introduce a temporary, non-public `WorldInvariants W`
-   companion containing exactly the three drafted fields.  Prove preservation
-   for the core builders and require the companion at theorem boundaries.
+   companion containing the three original drafted fields plus addendum (5).
+   Prove preservation for the core builders and require the companion at
+   theorem boundaries.
 2. Strengthen `rightOnlyWorld` and `rightBindTargetInsert` with the selected
    direct-entry classification.  Thread it through `evolve-right-bind`, the
    generic `B₀` surfaces, parked constructors, and smart wrappers.  Under the
@@ -380,7 +381,7 @@ A low-risk LG-1-style sequence is:
    replacement and insertion/rebase, and repair or retire invalid fixtures.
    Use invariant (4) to reject non-`★` repark outputs.
 4. After D15 lands, merge the companion fields into `World` atomically, change
-   constructor calls and patterns to the eight-field shape, replace `WFWorld`
+   constructor calls and patterns to the nine-field shape, replace `WFWorld`
    arguments by the projection, and delete both `WFWorld` and the temporary
    companion.  Do not retain a compatibility alias in this closed-world repo.
 5. Derive chain coherence by store-age induction, remove
@@ -545,21 +546,27 @@ only the bad term derivation inside an otherwise valid aligned world.
 
 ## Validation
 
-The standalone probe is safe, has no postulates, holes, or option pragmas, and
-is checked with Agda 2.8 using:
+Both standalone probes are safe and have no postulates, holes, or option
+pragmas.  The original design probe is checked with Agda 2.8 using:
 
 ```text
 agda --safe -v0 -i . -i proof/DGG/notes/probes \
   proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
 ```
 
-This command exited 0.  The required repository gate was then run exactly as:
+This command exited 0.  The invariant-(5) addendum is checked with the
+additional notes include:
+
+```text
+agda --safe -v0 -i . -i proof/DGG/notes -i proof/DGG/notes/probes \
+  proof/DGG/notes/probes/T15Invariant5ReconProbe.agda
+```
+
+This command exited 0 after checking the field, builder deltas, derivability
+lemmas, and kill-checks.  After all commits, the repository gate is:
 
 ```text
 cd GTSFImp && \
   PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH \
   make check
 ```
-
-It exited 0 after checking `All.agda`, `LegacyAll.agda`, and reporting
-`postulate-check: OK (no postulates; NON_COVERING at legacy baseline)`.

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -246,7 +246,7 @@ Under the recommended form, an unmatched variable entry is also accepted only
 when its head is unmatched.  A non-variable, non-`★` direct entry must be
 center-aligned with a source pivot in that exact world.
 
-Directness sharpens the `CastTermImprecision2` Example 12 audit:
+Directness sharpens the `Example12Worlds` audit:
 
 * `example12-world-X` directly aligns `ℕ` with `ℕ`; its unmatched `Y`
   points to unmatched `Z`, whose entry is `★`.  It satisfies both direct fields
@@ -279,7 +279,7 @@ otherwise deleted under the repository's completed-arc policy.
 
 There are three deliberate failures of the merged `WFWorld` field:
 
-* The Example 12 left-path worlds in `CastTermImprecision2` mark source centers
+* The Example 12 left-path worlds in `Example12Worlds` mark source centers
   precise that are not occupied by their one-variable target embedding.
 * `Examples2`'s `left-path-world₃/₄/₅` with the `XZ` target omit the
   precise source center occupied only by the `YZ` variant.
@@ -346,7 +346,7 @@ values, with `t10-probe1-worlds-satisfy` retaining the representation proof.
 
 ## Migration and blast radius
 
-Direct record construction occurs in `CastTermImprecision2`,
+Direct record construction occurs in `CtxImp`,
 `CompilePreservesImprecision2`, `Occupancy`, `Examples2`, `CenterRename`,
 `WorldDecay`, `SealPeelToolkit`, `TargetBindLift`, `TargetExtend`, and the
 finite proof/probe worlds listed above.  Direct constructor pattern matching is
@@ -355,7 +355,7 @@ consumers largely survive the field addition, while every constructor call and
 constructor pattern changes arity.
 
 The current live users of external `WFWorld` are
-`CastTermImprecision2`, `ExtraCastRight2Counterexample`,
+`CastTermImprecision`, `ExtraCastRight2Counterexample`,
 `SmartCommaWitness`, `MovedLinkProbe`, `TagBoundaryProbe`,
 `SealPeelToolkit`, `WorldDecay`, and `SealPeelProbe`.  Their evidence becomes a
 projection or disappears.  Initial-world users in
@@ -389,9 +389,9 @@ A low-risk LG-1-style sequence is:
    `initialWorldᴼ` into the canonical empty-store constructor.
 
 PR #171 (`agent/gtsf-partner-redesign`, fetched head `faec619c`) changes 43
-`GTSFImp` files and touches `CastTermImprecision2`, `TargetExtend`,
+`GTSFImp` files and touches `CastTermImprecision`, `TargetExtend`,
 `CenterRename`, `TargetBindLift`, `TermImpDecay`, and many downstream inversion
-and catchup modules.  Its direct change to `CastTermImprecision2` is the D15
+and catchup modules.  Its direct change to `CastTermImprecision` is the D15
 partner/conceal surface rather than this record, but its semantic and arity
 blast overlaps almost every migration site.  Land D15 first, then rebase D16
 and perform step 4.  The temporary companion work can be prepared before that
@@ -408,11 +408,11 @@ ninth field of `World`.  The checked draft in
 ```agda
     dynamicStarSourcesUnoccupied :
       ∀ (Xᴸ : TyVar Δᴸ)
-      → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑★
-      → lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ★
+      → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+      → lookupStore (CTX.sourceStoreʷ W) Xᴸ ≡ ★
       → ∀ (Xᴿ : TyVar Δᴿ)
-      → toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
-        ≢ toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+      → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+        ≢ toRenameᵗ (CTX.ηᴸʷ W) Xᴸ
 ```
 
 This is deliberately a direct-source-entry condition.  It neither follows a
@@ -462,11 +462,11 @@ dynamic mark and direct source entry are known.  The checked general lemma is:
 
 ```agda
 world-invariants-no-target-at-dynamic-star : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
   → WorldInvariants W
-  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
-  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
-  → CTI2.NoTargetOccupantAtSource W X
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTX.sourceStoreʷ W) X ≡ ★
+  → CTX.NoTargetOccupantAtSource W X
 ```
 
 For the source `seal X ★` see-through rule, no new rule input is needed.
@@ -478,11 +478,11 @@ The existing conversion typing supplies `sourceStoreʷ W ∋ X ⦂ ★`, and
 
 ```agda
 world-invariants-see-through-premise : ∀ {Δᴸ Δᴿ Δ}
-    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
   → WorldInvariants W′
-  → CTI2.TagRebaseAtᴸ W′ W (just X) nothing
-  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] seal X ★
-  → CTI2.NoTargetOccupantAtSource W′ X
+  → CTX.TagRebaseAtᴸ W′ W (just X) nothing
+  → CTX.sourceStoreʷ W Conversion.⊢↓[ just X ] seal X ★
+  → CTX.NoTargetOccupantAtSource W′ X
 ```
 
 D17(c)'s classifier occupancy premise is the same proposition written out as
@@ -491,11 +491,11 @@ dynamic mark and direct `★` source entry, world validity derives it:
 
 ```agda
 world-invariants-d17c-occupancy : ∀ {Δᴸ Δᴿ Δ}
-    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+    {W : CTX.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
   → WorldInvariants W
-  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
-  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
-  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X) → ⊥
+  → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTX.sourceStoreʷ W) X ≡ ★
+  → CTX.Occupied W (toRenameᵗ (CTX.ηᴸʷ W) X) → ⊥
 ```
 
 At Stage 3, after validities and the local mark/direct-entry facts are

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -427,32 +427,100 @@ new premise beyond the premises already recorded for invariants (2)--(4).
 
 | Builder or transformation | Invariant-(5) verdict |
 | --- | --- |
-| Amended empty-store `initialWorld` | **Free and checked.** Its direct source entries are variables.  The old arbitrary-store `CompilePreservesImprecision2.initialWorld mu Sigma`, `Examples2.reflWorld Sigma`, and `Occupancy.initialWorldO` are **not** free: a shared `★` cell marked `X⊑★` is an immediate counterexample.  They must use the amended empty store or receive (5) as a premise. |
+| Amended empty-store `initialWorld` | **Free and checked.** Its direct source entries are variables.  The old arbitrary-store `CompilePreservesImprecision2.initialWorld μ Σ`, `Examples2.reflWorld Σ`, and `Occupancy.initialWorldᴼ` are **not** free: a shared `★` cell marked `X⊑★` is an immediate counterexample.  They must use the amended empty store or receive (5) as a premise. |
 | `liftWorldBoth v W` and `liftWorldLeft v W` | **Free.** The fresh direct source entry under `store-lift` is `＇ zero`, not `★`; old cells shift injectively. |
 | `leftOnlyWorld v W A` | **Free.** The fresh source center has no target image, while every old alignment reflects to `W`.  This is independent of `A` and of the separate precise-mark premise required by invariant (2). |
 | `rightOnlyWorld W B`, including `★` and alias routes | **Free and checked generically.** Its fresh target is at center zero while every source center is shifted; an old aligned target reflects injectively to `W`.  Thus invariant (5) adds no classification premise for `B`; invariant (4) still does. |
 | `bothBindWorld v W A B` | **Needs a premise in the generic API:** if `v = X⊑★` and `⇑ᵗ A = ★`, the fresh source is exactly the forbidden occupied cell.  The live parked/compile builder uses `v = X⊑X`, so that specialization is **free**. |
 | Parked initial/both/left/right builders and `ParkedEvolve` endpoints | Inherit the preceding verdicts.  The parked initial world must change to the empty-store constructor; parked both/left/right add no new premise at their live marks.  Evolution eliminators do not mint their endpoint. |
 | `CenterRename.renameWorld` | **Free.** Center renaming is injective and leaves both stores unchanged. |
-| Generic `EnvDecay W Wd` | **Needs a premise.** Decay may change an aligned, direct-source-`★` center from `X⊑X` to `X⊑★`.  Geometry-only occupancy transport does not establish validity. |
-| `blendWorld W' Wd` | **Needs the same no-new-forbidden-cell premise.** It can select an `X⊑★` mark from `Wd` at a center whose geometry and stores come from `W'`. |
+| Generic `EnvDecay W Wᵈ` | **Needs a premise.** Decay may change an aligned, direct-source-`★` center from `X⊑X` to `X⊑★`.  Geometry-only occupancy transport does not establish validity. |
+| `blendWorld W′ Wᵈ` | **Needs the same no-new-forbidden-cell premise.** It can select an `X⊑★` mark from `Wᵈ` at a center whose geometry and stores come from `W′`. |
 | `honestify W` | **Free.** It changes a mark to `X⊑★` only when that center is already outside the target image; aligned centers retain their old mark. |
 | `dynWorld W` | **Needs a premise for every direct source `★` entry**, because it changes every center mark to `X⊑★`. |
-| `targetStoreAs W SigmaR` and target-store moves with fixed geometry | **Free.** Invariant (5) mentions the source store, marks, and embeddings, but not target entries. |
-| A genuine `TargetInsert rho pi W W'` | **Free and checked.** `target-source-reflect` maps every output aligned occupant back to an input aligned occupant; `sourceStore-kept`, `source-insert`, and `impEnv-insert` reflect the other antecedents. |
-| `smartAliasInsertWorld`, `smartFreshInsertWorld`, and their `TargetInsert` packages | **Free at the output once the smart input world is valid.** They are genuine target inserts.  A guard alone does not validate an arbitrary `Wm`; the Stage-1 signatures correctly require `WorldInvariants Wm`. |
-| `insertRebaseWorld ins Wp`, forward/reverse/pullback variants | **Free at the insertion output once `WorldInvariants Wp` is supplied.** `insertRebaseTargetInsert` proves target-source reflection even at the rebase pivot.  The pressure is at reparking: a candidate `Wp` that newly aligns an `X⊑★`, direct-source-`★` pivot is illegal and cannot supply the input invariant.  Invariant (4)'s off-entry premise remains separate. |
+| `targetStoreAs W Σᴿ` and target-store moves with fixed geometry | **Free.** Invariant (5) mentions the source store, marks, and embeddings, but not target entries. |
+| A genuine `TargetInsert ρ π W W′` | **Free and checked.** `target-source-reflect` maps every output aligned occupant back to an input aligned occupant; `sourceStore-kept`, `source-insert`, and `impEnv-insert` reflect the other antecedents. |
+| `smartAliasInsertWorld`, `smartFreshInsertWorld`, and their `TargetInsert` packages | **Free at the output once the smart input world is valid.** They are genuine target inserts.  A guard alone does not validate an arbitrary `Wᵐ`; the Stage-1 signatures correctly require `WorldInvariants Wᵐ`. |
+| `insertRebaseWorld ins Wᵖ`, forward/reverse/pullback variants | **Free at the insertion output once `WorldInvariants Wᵖ` is supplied.** `insertRebaseTargetInsert` proves target-source reflection even at the rebase pivot.  The pressure is at reparking: a candidate `Wᵖ` that newly aligns an `X⊑★`, direct-source-`★` pivot is illegal and cannot supply the input invariant.  Invariant (4)'s off-entry premise remains separate. |
 | `rightBindTargetInsert`, keep/lift wrappers, and the other insert packages | **No new invariant-(5) premise.** They inherit `rightOnlyWorld` or generic target-insert preservation; their existing invariant-(4) classification remains. |
 | Direct fixture worlds | Must prove the field case by case.  The checked kill-check below identifies the affected D16/S-OCC fixtures. |
 | `RebaseAt`, `SameRuntime`, `EnvDecay` evidence records, and constructor-pattern consumers | They do not themselves mint worlds.  Any separately constructed endpoint must be valid; generic decay is the non-free constructor listed above. |
 
 The smart-ALIAS Stage-2 blocker is **neither sharpened nor resolved**.  Its
-fresh source is aligned with target `beta`, but
+fresh source is aligned with target `β`, but
 `sourceStore-lifted` makes its direct entry `＇ zero`, not `★`; the probe
 checks `smartAlias-fresh-source-not-star`.  Therefore (5) does not reject that
 fresh alignment.  The recorded contradiction still comes solely from
-`representationsImprecise`: it forces `beta = alpha`, conflicting with the
-guard's distinct direct entries `＇ alpha` and `★`.
+`representationsImprecise`: it forces `β = α`, conflicting with the
+guard's distinct direct entries `＇ α` and `★`.
+
+### Payoff: occupancy premises become derived
+
+Invariant (5) is exactly the negative target-occupancy proposition once the
+dynamic mark and direct source entry are known.  The checked general lemma is:
+
+```agda
+world-invariants-no-target-at-dynamic-star : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
+  → CTI2.NoTargetOccupantAtSource W X
+```
+
+For the source `seal X ★` see-through rule, no new rule input is needed.
+The indexed `TagRebaseAtᴸ W′ W (just X) nothing` can only be
+`tag-rebase-onlyᴸ`, which identifies the worlds and supplies the `X⊑★` mark.
+The existing conversion typing supplies `sourceStoreʷ W ∋ X ⦂ ★`, and
+`lookupStore-∋` turns that into the direct-entry equality.  Thus its present
+`NoTargetOccupantAtSource W′ X` argument is derivable by the checked lemma:
+
+```agda
+world-invariants-see-through-premise : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W′
+  → CTI2.TagRebaseAtᴸ W′ W (just X) nothing
+  → CTI2.sourceStoreʷ W CTI2.⊢↓[ just X ] seal X ★
+  → CTI2.NoTargetOccupantAtSource W′ X
+```
+
+D17(c)'s classifier occupancy premise is the same proposition written out as
+an emptiness function.  Once that classifier carries its already required
+dynamic mark and direct `★` source entry, world validity derives it:
+
+```agda
+world-invariants-d17c-occupancy : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTI2.World Δᴸ Δᴿ Δ} {X : TyVar Δᴸ}
+  → WorldInvariants W
+  → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) X) ≡ X⊑★
+  → lookupStore (CTI2.sourceStoreʷ W) X ≡ ★
+  → CTI2.Occupied W (toRenameᵗ (CTI2.ηᴸʷ W) X) → ⊥
+```
+
+At Stage 3, after validities and the local mark/direct-entry facts are
+available at each rule endpoint, the rule-facing no-target transport layer can
+be deleted and the premise rederived locally.  The retirement set is:
+
+- `Occupancy.liftWorldLeft-old-no-target-at-sourceᴼ`,
+  `rightOnly-old-no-target-at-sourceᴼ`,
+  `decay-no-target-at-source-forwardᴼ`,
+  `rename-no-target-at-sourceᴼ`, and
+  `target-insert-no-target-at-sourceᴼ`;
+- `Occupancy.smartFreshBehind-old-no-target-at-sourceᴼ`,
+  `smartAliasMerge-old-no-target-at-sourceᴼ`, and
+  `smartCommaLift-old-no-target-at-sourceᴼ`;
+- the rule-facing uses of `rebase-no-target-forwardᴼ`,
+  `rebaseᴸ-no-target-forwardᴼ`, `rebaseᴿ-no-target-forwardᴼ`, and
+  `tag-rebase-no-target-forwardᴼ`, including the current
+  `TargetChainProof` call;
+- the duplicates `CenterRename.renameNoTargetOccupantAtSource`,
+  `TermImpDecay.decayNoTargetOccupantAtSource`, and
+  `TargetBindLift.moveNoTargetOccupantAtSource`.
+
+The positive `Occupied` lemmas remain useful for allocation/classification,
+and generic occupancy transport can remain if it has non-rule consumers.  The
+claim here is specifically that no target-absence fact needs to be threaded
+merely to reconstruct the see-through or D17(c) premise.
 
 ## Validation
 

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -1,0 +1,262 @@
+# T15: D16 world invariants design
+
+Status: recon and checked declarations only.  No live definition or proof was
+changed.  The declarations and counterexample checks in this note are checked
+by `proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda`.
+
+## Decision
+
+The invariant belongs directly in `World`.  It does not require a two-layer
+`RawWorld` definition because its conclusion can use the raw, environment-
+indexed type-imprecision relation.  The proposed record is:
+
+```agda
+record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
+  constructor world
+  field
+    ηᴸʷ : Δᴸ ↪ᵗ Δ
+    ηᴿʷ : Δᴿ ↪ᵗ Δ
+    impEnvʷ : ImpEnv Δ
+    sourceStoreʷ : TyStore Δᴸ
+    targetStoreʷ : TyStore Δᴿ
+
+    preciseMarksAlignedʷ :
+      ∀ (Xᴸ : TyVar Δᴸ)
+      → impEnvʷ (toRenameᵗ ηᴸʷ Xᴸ) ≡ X⊑X
+      → Σ[ Xᴿ ∈ TyVar Δᴿ ]
+          toRenameᵗ ηᴿʷ Xᴿ ≡ toRenameᵗ ηᴸʷ Xᴸ
+
+    representationsImpreciseʷ :
+      ∀ {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+      → toRenameᵗ ηᴸʷ Xᴸ ≡ toRenameᵗ ηᴿʷ Xᴿ
+      → impEnvʷ ⊢
+          renameᵗ (toRenameᵗ ηᴸʷ)
+            (resolveRep sourceStoreʷ (＇ Xᴸ))
+          ⊑ renameᵗ (toRenameᵗ ηᴿʷ)
+            (resolveRep targetStoreʷ (＇ Xᴿ))
+```
+
+`preciseMarksAlignedʷ` is exactly the current `WFWorld` judgment, now a
+field.  `representationsImpreciseʷ` is deliberately unconditional on the
+center mark.  A `RebaseAt` pivot may be center-aligned at `X⊑★`, and its
+store representations still have to be related.  Conditioning the field on
+`X⊑X` would leave precisely that runtime alignment unchecked.
+
+The conclusion uses raw `_ ⊢_ ⊑_`, not `_ ⊑ᵂ⟨_⟩_`.  After the record
+exists it is definitionally the intended world relation:
+
+```agda
+impEnvʷ W ⊢ embedᴸ W (resolveRep (sourceStoreʷ W) (＇ Xᴸ))
+          ⊑ embedᴿ W (resolveRep (targetStoreʷ W) (＇ Xᴿ))
+```
+
+but spelling out the embeddings avoids a recursive dependency from `World` to
+a relation defined by projections from `World`.  In the live migration,
+`resolveVar` and `resolveRep` must be moved above `World`; they are currently
+declared later in `CastTermImprecision2.agda`.  This is declaration staging,
+not a change to type imprecision.
+
+## Empty initial compilation world
+
+An empty store at an intrinsic type context has only structural lifts and no
+runtime binding:
+
+```agda
+emptyStore : (Δ : TyCtx) → TyStore Δ
+emptyStore Nat.zero = store-empty
+emptyStore (Nat.suc Δ) = store-lift (emptyStore Δ)
+
+initialWorld : ∀ {Δ} → ImpEnv Δ → World Δ Δ Δ
+initialWorld {Δ} μ =
+  world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
+    (λ Xᴸ precise → Xᴸ , refl)
+    initialRepresentations
+```
+
+The probe checks both invariant fields, including
+`emptyStore (Nat.suc Δ) ≡ store-lift (emptyStore Δ)` by `refl`.
+
+The recursive `compile-preserves-embedded²` proof already compiles from
+`sourceStoreʷ W`; it tolerates this initial world.  The public
+`compile-preserves-imprecision²-statement` does not tolerate the change
+unchanged: it currently quantifies an arbitrary `Σ`, calls
+`initialWorld μ Σ`, and elaborates both inputs from `Σ`.  Its statement and
+wrapper must instead elaborate from `emptyStore Δ` and call `initialWorld μ`.
+The closed DGG entry at context zero remains definitionally at `store-empty`.
+`initialCtx`, the two identity embeddings, and `SourceId` are unaffected.
+
+## Minting and preservation inventory
+
+“In hand” means the current site has enough data or a nearby proved transport
+lemma; it does not mean the seven-field constructor has been implemented.
+
+| Builder or transformation | New obligations | Evidence at the site |
+| --- | --- | --- |
+| `CompilePreservesImprecision2.initialWorld` | Identity precise alignment; reflexive representations in two empty stores. | **In hand and checked.** Remove the arbitrary-store parameter from its public callers. |
+| `Examples2.reflWorld` | Identity alignment and reflexivity for the same store on both sides. | **In hand.** |
+| `Occupancy.initialWorldᴼ` | Same as canonical `initialWorld`. | **In hand, but obsolete.** Delete this duplicate rather than preserve an alias. |
+| `liftWorldBoth v W` | Lift both old invariants; relate the two fresh structural variables. | **In hand.** The fresh pair is `＇ zero ⊑ ＇ zero`; old pairs lift. |
+| `liftWorldLeft v W` | Lift old pairs; a precise fresh source mark must have a target occupant. | **Not in hand for generic `v`.** Current compile use is `X⊑★`. Restrict it to a non-precise mark or add a premise ruling out `X⊑X`. |
+| `leftOnlyWorld v W A` | Transport old pairs through the source bind; handle the unpaired fresh source. | **Not in hand for generic `v`.** Live parked uses pass `X⊑★`; the signature should expose that requirement. |
+| `rightOnlyWorld W B` | Transport old pairs through the target bind; no source maps to the new target-only center. | **In hand.** Existing right-bind store-representation transport has the required shape. |
+| `bothBindWorld v W A B` | Transport old pairs and relate the canonical representations of the fresh aligned `A` and `B` cells. | **Not in hand in the builder.** Its arguments contain no `A₀⊑B₀`/resolved-representation witness. This is the principal allocation pressure point. |
+| `parked-initial`, `parked-both-bind`, `parked-left-bind`, and `parked-right-bind` | Classify worlds minted by the initial and three bind builders. | **In hand after the builders are strengthened.** `parked-initial` drops `Σ`; `parked-both-bind` must accept and thread the fresh representation witness. |
+| `parked-structural-right-insert` | Classify a caller-supplied `TargetInsert` output as parked. | **In hand.** The result is already a valid `World`; the insert and store-following premises add no new field obligation. |
+| `evolve-refl`, `evolve-keepᴸ`, and `evolve-keepᴿ` | Reindex a trace without constructing a world. | **No new obligation.** The endpoint worlds already carry both fields. |
+| `evolve-both-bind`, `evolve-left-bind`, and `evolve-right-bind` | Remove a leading allocation from an evolution whose starting world was produced by a bind builder. | **In hand after the builders are strengthened.** Only the both-bind surface needs the fresh representation witness. |
+| `evolve-structural-right-bind` | Remove a structural target allocation backed by `TargetInsert`. | **In hand.** Its intermediate and final endpoints are already valid worlds. |
+| `BothBindTransport²ᵀ` and paired allocation callers | Supply the fresh canonical-representation relation to `bothBindWorld`. | **Partly in hand at callers.** Paired allocation has an `A₀⊑B₀` premise, but the current transport surface passes only the trivial fresh-variable witness `＇ zero ⊑ ＇ zero`. A lemma must turn the allocation premise plus the old invariant into the resolved-representation witness. |
+| `CenterRename.renameWorld` | Rename both invariant conclusions and preserve center equality. | **In hand.** Existing `rename-⊑`, `renameStoreRep`, and embedding injectivity provide the ingredients. |
+| `WorldDecay.blendWorld` | Use the geometry/stores of the premise world and weaken representation proofs to the blended environment. | **In hand.** An output `X⊑X` mark comes from the premise world; raw imprecision is monotone under the environment decay. |
+| `WorldDecay.honestify` | Preserve all aligned store representations while changing only marks; establish precise alignment. | **In hand.** Existing alignment and mark-decay lemmas provide the two fields. |
+| `SealPeelToolkit.dynWorld` | Preserve geometry/stores under the all-`X⊑★` environment. | **In hand.** Precise alignment is vacuous and representation proofs weaken to the all-dynamic environment. |
+| `TargetBindLift.targetStoreAs W Σᴿ` | Prove the invariant after replacing the target store arbitrarily. | **Not in hand for the raw helper.** Current callers pair it with `TargetStoreMove`/`TargetBindLiftMove`, and `moveStoreRepBindLift` supplies pointwise evidence. Make the raw helper private or require that movement evidence. |
+| `TargetExtend.smartAliasInsertWorld` | Transport both invariants through alias insertion. | **In hand.** `TargetInsert` alignment/reflection and resolved-store transport cover old and inserted centers. |
+| `TargetExtend.smartFreshInsertWorld` | Transport both invariants through fresh insertion. | **In hand.** The smart guard plus `TargetInsert` transport covers the new geometry. |
+| `TargetExtend.insertRebaseWorld ins Wᵖ` | Mix `Wᵖ`'s source/environment/store with the inserted target of another world. | **Not in hand for arbitrary `Wᵖ`.** Require `RebaseAt`/frozen-target evidence tying `Wᵖ` to the insertion source, or replace the raw constructor with a checked builder. |
+| `liftBothTargetInsert` and `liftLeftTargetInsert` | Lift a `TargetInsert` across the corresponding world builders. | **In hand after those builders are valid.** These records relate already constructed endpoints. |
+| `smartAliasTargetInsert` and `smartFreshTargetInsert` | Package the two smart inserted worlds as `TargetInsert` results. | **In hand with their builders.** Their current geometry, resolve, and environment transport is exactly the preservation evidence. |
+| `rightBindTargetInsert` and `keepRightBindTargetInsert` | Package `rightOnlyWorld`, optionally under `liftWorldBoth`. | **In hand with those builders.** |
+| `insertRebaseTargetInsert`, its reverse and pullback variants, and their commuting result packages | Package `insertRebaseWorld` endpoints as `TargetInsert` results. | **Blocked exactly where `insertRebaseWorld` is blocked.** Once that builder requires rebase/frozen-target evidence, these functions already receive or derive it. |
+| Other `TargetInsert` results | Relate an input and an already constructed output world. | **No extra minting obligation.** Once outputs are valid `World`s, existing alignment and resolve transport explain preservation. |
+| `sameWorldRebaseAt`, rename/move/insert/right-bind `RebaseAt` transformers, and `RebaseAtᴸ`/`ᴿ`/tag wrappers | Relate already valid worlds and identify or transport a pivot. | **No global minting obligation.** `RebaseAt.storeRepresentations` becomes derivable from `representationsImpreciseʷ` and `pivotAligned`; keep it only during staged migration, then remove the redundancy. |
+| `EnvDecay`, `decayRebaseAt`, `SameRuntime` | Transport relations between already valid worlds. | **In hand.** `decayRebaseAt` already transports the pivot representation proof. |
+| `TermImpDecay` world patterns | Destructure a `World` while transporting derivations. | **Mechanical blast only.** Constructor patterns must bind or ignore two more fields; no new world is minted there. |
+
+### Direct worlds and fixtures
+
+Every direct `world` application must prove both fields.  The finite probes in
+`SmartCommaWitness`, `MovedLinkProbe`, `TagBoundaryProbe`, `SealPeelProbe`,
+`CenterCrossingProbe`, `ChainRideProbe`, `SourceStarProbe`,
+`StarRepChainProbe`, and `TerminusRebuildProbe` already carry alignment and/or
+pivot representation facts from which the fields can be proved by finite case
+analysis.  `CastTermImprecision2`'s Example 12 dynamic and natural-number chain
+worlds are likewise locally supported.
+
+The remaining live direct constructors are the named builders in the table,
+`Examples2.reflWorld`, the two initial-world definitions, and the concrete
+fixture families just listed.  Scratch and archived probe modules below
+`proof/DGG/notes/` also contain five-field snapshots; they are not additional
+minting APIs and should be updated only if retained in the extra notes include,
+otherwise deleted under the repository's completed-arc policy.
+
+There are three deliberate failures of the merged `WFWorld` field:
+
+* The Example 12 left-path worlds in `CastTermImprecision2` mark source centers
+  precise that are not occupied by their one-variable target embedding.
+* `Examples2`'s `left-path-world₃/₄/₅` with the `XZ` target omit the
+  precise source center occupied only by the `YZ` variant.
+* `ExtraCastRight2Counterexample.post-world` is explicitly proved not to be a
+  `WFWorld` today.
+
+Those worlds become unconstructible.  The first two fixture families must be
+decayed at the unoccupied centers or redesigned; the counterexample post-world
+should disappear.  `ExtraCastRight2Counterexample.pre-world` and its decayed
+variant already have the required local facts.
+
+### Pressure points
+
+1. `bothBindWorld` needs a fresh resolved-representation witness.  It cannot be
+   manufactured from its present parameters.
+2. Generic `liftWorldLeft v` and `leftOnlyWorld v` cannot preserve precise-mark
+   alignment when `v = X⊑X`; their interfaces must exclude that case or gain a
+   target occupant.
+3. `insertRebaseWorld` needs an explicit relation between its independently
+   supplied premise world and the world being target-inserted.
+4. `targetStoreAs` cannot accept an arbitrary replacement store; movement
+   evidence must be part of the checked construction path.
+5. The live Example 12 left-path and `Examples2` `XZ` worlds already violate
+   the invariant being merged from `WFWorld`.
+6. The public compile theorem and all parked/occupancy initial-world surfaces
+   must drop their arbitrary initial store, even though the recursive compiler
+   proof itself is compatible.
+
+## Kill-check
+
+The branch `agent/gtsf-beta-closings` was fetched and the D8a caller-supply and
+occurrence-feasibility probes were reconstructed.  T10 Probe 1 was reconstructed
+from `T10Probe1ParkedWorldPreservation.agda`.  The checked verdict is negative:
+
+| Configuration | Aligned source/target | Resolved representations | Verdict |
+| --- | --- | --- | --- |
+| D8a `W` | source `X` / old target `Y` | `ℕ ⊑ ℕ` by `ι⊑ι` | Satisfies both new fields. |
+| D8a `Wᵖ` | source `X` / fresh target `Y` at `X⊑★` | `ℕ ⊑ ℕ` by `ι⊑ι` | Satisfies both new fields. |
+| T10 Probe 1 `W` | source `X` / old target `Y` | `★ ⊑ ★` by `★⊑★` | Satisfies both new fields. |
+| T10 Probe 1 `Wᵖ` | source `X` / fresh target `Y` at `X⊑★` | `★ ⊑ ★` by `★⊑★` | Satisfies both new fields. |
+
+Thus **none of the D8a or T10 substitution counterexamples dies under this
+local World invariant**.  Each endpoint world is locally representation-
+coherent.  The failure is cross-world: a value related to the old target
+occupant at `W` cannot be retargeted to that old occupant after the source
+pivot is reparked onto a fresh target occupant at `Wᵖ`.  Killing these
+counterexamples requires a rebase/evolution stability invariant, provenance,
+or a restriction on changing the source-to-target partner, not merely local
+representation imprecision.
+
+The probe exports the checked witnesses
+`d8a-refuting-worlds-satisfy` and `t10-probe1-worlds-satisfy`.
+
+## Migration and blast radius
+
+Direct record construction occurs in `CastTermImprecision2`,
+`CompilePreservesImprecision2`, `Occupancy`, `Examples2`, `CenterRename`,
+`WorldDecay`, `SealPeelToolkit`, `TargetBindLift`, `TargetExtend`, and the
+finite proof/probe worlds listed above.  Direct constructor pattern matching is
+concentrated in `WorldDecay` and especially `TermImpDecay`.  Projection-only
+consumers largely survive the field addition, while every constructor call and
+constructor pattern changes arity.
+
+The current live users of external `WFWorld` are
+`CastTermImprecision2`, `ExtraCastRight2Counterexample`,
+`SmartCommaWitness`, `MovedLinkProbe`, `TagBoundaryProbe`,
+`SealPeelToolkit`, `WorldDecay`, and `SealPeelProbe`.  Their evidence becomes a
+projection or disappears.  Initial-world users in
+`CompilePreservesImprecision2`, `DynamicGradualGuaranteeProof`,
+`GroundingMint`, `Occupancy`, `ParkedWorldDef`, and `Phase3DeepDives` must move
+to the empty-store signature.
+
+A low-risk LG-1-style sequence is:
+
+1. Hoist `resolveVar`/`resolveRep`.  Against the existing five-field record,
+   introduce a temporary, non-public `WorldInvariants W` companion containing
+   exactly the two drafted fields.  Prove preservation for the core builders
+   and require the companion at theorem boundaries, so failures are visible.
+2. Resolve the pressure points: strengthen both-bind allocation, restrict
+   left-only minting, guard store replacement and insertion/rebase, and repair
+   or retire invalid fixture worlds.
+3. After D15 lands, merge the companion fields into `World` atomically, change
+   constructor calls and patterns to the seven-field shape, replace `WFWorld`
+   arguments by the projection, and delete both `WFWorld` and the temporary
+   companion.  Do not retain a compatibility alias in this closed-world repo.
+4. Remove `RebaseAt.storeRepresentations` once all callers use the world field,
+   and consolidate `initialWorldᴼ` into the canonical empty-store constructor.
+
+PR #171 (`agent/gtsf-partner-redesign`, fetched head `faec619c`) changes 43
+`GTSFImp` files and touches `CastTermImprecision2`, `TargetExtend`,
+`CenterRename`, `TargetBindLift`, `TermImpDecay`, and many downstream inversion
+and catchup modules.  Its direct change to `CastTermImprecision2` is the D15
+partner/conceal surface rather than this record, but its semantic and arity
+blast overlaps almost every migration site.  Land D15 first, then rebase D16
+and perform step 3.  The temporary companion work can be prepared before that
+merge, but it must not become a second permanent world API.
+
+## Validation
+
+The standalone probe is safe, has no postulates, holes, or option pragmas, and
+is checked with Agda 2.8 using:
+
+```text
+agda --safe -v0 -i . -i proof/DGG/notes/probes \
+  proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda
+```
+
+This command exited 0.  The required repository gate was then run exactly as:
+
+```text
+cd GTSFImp && \
+  PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH \
+  make check
+```
+
+It exited 0 after checking `All.agda`, `LegacyAll.agda`, and reporting
+`postulate-check: OK (no postulates; NON_COVERING at legacy baseline)`.

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -420,6 +420,40 @@ says exactly that the source center has no target occupant.  The probe also
 checks the field for the amended empty-store `initialWorld`: every direct
 entry in `emptyStore` is its structurally bound variable, never `★`.
 
+### Invariant-(5) minting and preservation deltas
+
+This table is the delta over the Stage-1 builder table above.  “Free” means no
+new premise beyond the premises already recorded for invariants (2)--(4).
+
+| Builder or transformation | Invariant-(5) verdict |
+| --- | --- |
+| Amended empty-store `initialWorld` | **Free and checked.** Its direct source entries are variables.  The old arbitrary-store `CompilePreservesImprecision2.initialWorld mu Sigma`, `Examples2.reflWorld Sigma`, and `Occupancy.initialWorldO` are **not** free: a shared `★` cell marked `X⊑★` is an immediate counterexample.  They must use the amended empty store or receive (5) as a premise. |
+| `liftWorldBoth v W` and `liftWorldLeft v W` | **Free.** The fresh direct source entry under `store-lift` is `＇ zero`, not `★`; old cells shift injectively. |
+| `leftOnlyWorld v W A` | **Free.** The fresh source center has no target image, while every old alignment reflects to `W`.  This is independent of `A` and of the separate precise-mark premise required by invariant (2). |
+| `rightOnlyWorld W B`, including `★` and alias routes | **Free and checked generically.** Its fresh target is at center zero while every source center is shifted; an old aligned target reflects injectively to `W`.  Thus invariant (5) adds no classification premise for `B`; invariant (4) still does. |
+| `bothBindWorld v W A B` | **Needs a premise in the generic API:** if `v = X⊑★` and `⇑ᵗ A = ★`, the fresh source is exactly the forbidden occupied cell.  The live parked/compile builder uses `v = X⊑X`, so that specialization is **free**. |
+| Parked initial/both/left/right builders and `ParkedEvolve` endpoints | Inherit the preceding verdicts.  The parked initial world must change to the empty-store constructor; parked both/left/right add no new premise at their live marks.  Evolution eliminators do not mint their endpoint. |
+| `CenterRename.renameWorld` | **Free.** Center renaming is injective and leaves both stores unchanged. |
+| Generic `EnvDecay W Wd` | **Needs a premise.** Decay may change an aligned, direct-source-`★` center from `X⊑X` to `X⊑★`.  Geometry-only occupancy transport does not establish validity. |
+| `blendWorld W' Wd` | **Needs the same no-new-forbidden-cell premise.** It can select an `X⊑★` mark from `Wd` at a center whose geometry and stores come from `W'`. |
+| `honestify W` | **Free.** It changes a mark to `X⊑★` only when that center is already outside the target image; aligned centers retain their old mark. |
+| `dynWorld W` | **Needs a premise for every direct source `★` entry**, because it changes every center mark to `X⊑★`. |
+| `targetStoreAs W SigmaR` and target-store moves with fixed geometry | **Free.** Invariant (5) mentions the source store, marks, and embeddings, but not target entries. |
+| A genuine `TargetInsert rho pi W W'` | **Free and checked.** `target-source-reflect` maps every output aligned occupant back to an input aligned occupant; `sourceStore-kept`, `source-insert`, and `impEnv-insert` reflect the other antecedents. |
+| `smartAliasInsertWorld`, `smartFreshInsertWorld`, and their `TargetInsert` packages | **Free at the output once the smart input world is valid.** They are genuine target inserts.  A guard alone does not validate an arbitrary `Wm`; the Stage-1 signatures correctly require `WorldInvariants Wm`. |
+| `insertRebaseWorld ins Wp`, forward/reverse/pullback variants | **Free at the insertion output once `WorldInvariants Wp` is supplied.** `insertRebaseTargetInsert` proves target-source reflection even at the rebase pivot.  The pressure is at reparking: a candidate `Wp` that newly aligns an `X⊑★`, direct-source-`★` pivot is illegal and cannot supply the input invariant.  Invariant (4)'s off-entry premise remains separate. |
+| `rightBindTargetInsert`, keep/lift wrappers, and the other insert packages | **No new invariant-(5) premise.** They inherit `rightOnlyWorld` or generic target-insert preservation; their existing invariant-(4) classification remains. |
+| Direct fixture worlds | Must prove the field case by case.  The checked kill-check below identifies the affected D16/S-OCC fixtures. |
+| `RebaseAt`, `SameRuntime`, `EnvDecay` evidence records, and constructor-pattern consumers | They do not themselves mint worlds.  Any separately constructed endpoint must be valid; generic decay is the non-free constructor listed above. |
+
+The smart-ALIAS Stage-2 blocker is **neither sharpened nor resolved**.  Its
+fresh source is aligned with target `beta`, but
+`sourceStore-lifted` makes its direct entry `＇ zero`, not `★`; the probe
+checks `smartAlias-fresh-source-not-star`.  Therefore (5) does not reject that
+fresh alignment.  The recorded contradiction still comes solely from
+`representationsImprecise`: it forces `beta = alpha`, conflicting with the
+guard's distinct direct entries `＇ alpha` and `★`.
+
 ## Validation
 
 The standalone probe is safe, has no postulates, holes, or option pragmas, and

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -34,6 +34,12 @@ record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
             (resolveRep sourceStoreʷ (＇ Xᴸ))
           ⊑ renameᵗ (toRenameᵗ ηᴿʷ)
             (resolveRep targetStoreʷ (＇ Xᴿ))
+
+    unmatchedTargetsDynamicʷ :
+      ∀ (Xᴿ : TyVar Δᴿ)
+      → (∀ (Xᴸ : TyVar Δᴸ)
+          → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Xᴿ)
+      → resolveRep targetStoreʷ (＇ Xᴿ) ≡ ★
 ```
 
 `preciseMarksAlignedʷ` is exactly the current `WFWorld` judgment, now a
@@ -41,6 +47,13 @@ field.  `representationsImpreciseʷ` is deliberately unconditional on the
 center mark.  A `RebaseAt` pivot may be center-aligned at `X⊑★`, and its
 store representations still have to be related.  Conditioning the field on
 `X⊑X` would leave precisely that runtime alignment unchecked.
+
+`unmatchedTargetsDynamicʷ` says exactly that a target pivot with no
+center-aligned source pivot resolves to `★`.  Equality is the right conclusion,
+not a second representation-path predicate: `resolveRep` is already the
+canonical transitive path resolver.  This leaves matched pivots unrestricted;
+in particular, the checked paths ending at `ℕ` remain legal while their target
+pivot has a source partner.
 
 The conclusion uses raw `_ ⊢_ ⊑_`, not `_ ⊑ᵂ⟨_⟩_`.  After the record
 exists it is definitionally the intended world relation:
@@ -71,9 +84,10 @@ initialWorld {Δ} μ =
   world id↪ᵗ id↪ᵗ μ (emptyStore Δ) (emptyStore Δ)
     (λ Xᴸ precise → Xᴸ , refl)
     initialRepresentations
+    (λ Xᴿ unmatched → ⊥-elim (unmatched Xᴿ refl))
 ```
 
-The probe checks both invariant fields, including
+The probe checks all three invariant fields, including
 `emptyStore (Nat.suc Δ) ≡ store-lift (emptyStore Δ)` by `refl`.
 
 The recursive `compile-preserves-embedded²` proof already compiles from
@@ -88,50 +102,89 @@ The closed DGG entry at context zero remains definitionally at `store-empty`.
 ## Minting and preservation inventory
 
 “In hand” means the current site has enough data or a nearby proved transport
-lemma; it does not mean the seven-field constructor has been implemented.
+lemma; it does not mean the eight-field constructor has been implemented.
 
 | Builder or transformation | New obligations | Evidence at the site |
 | --- | --- | --- |
-| `CompilePreservesImprecision2.initialWorld` | Identity precise alignment; reflexive representations in two empty stores. | **In hand and checked.** Remove the arbitrary-store parameter from its public callers. |
-| `Examples2.reflWorld` | Identity alignment and reflexivity for the same store on both sides. | **In hand.** |
+| `CompilePreservesImprecision2.initialWorld` | Identity precise alignment; reflexive representations in two empty stores; no unmatched target. | **In hand and checked.** Remove the arbitrary-store parameter from its public callers. |
+| `Examples2.reflWorld` | Identity alignment and reflexivity for the same store on both sides; no unmatched target. | **In hand.** |
 | `Occupancy.initialWorldᴼ` | Same as canonical `initialWorld`. | **In hand, but obsolete.** Delete this duplicate rather than preserve an alias. |
-| `liftWorldBoth v W` | Lift both old invariants; relate the two fresh structural variables. | **In hand.** The fresh pair is `＇ zero ⊑ ＇ zero`; old pairs lift. |
+| `liftWorldBoth v W` | Lift all old invariants; relate the fresh structural pair. | **In hand.** The fresh target is matched, and old unmatched targets remain unmatched with lifted `★` representations. |
 | `liftWorldLeft v W` | Lift old pairs; a precise fresh source mark must have a target occupant. | **Not in hand for generic `v`.** Current compile use is `X⊑★`. Restrict it to a non-precise mark or add a premise ruling out `X⊑X`. |
 | `leftOnlyWorld v W A` | Transport old pairs through the source bind; handle the unpaired fresh source. | **Not in hand for generic `v`.** Live parked uses pass `X⊑★`; the signature should expose that requirement. |
-| `rightOnlyWorld W B` | Transport old pairs through the target bind; no source maps to the new target-only center. | **In hand.** Existing right-bind store-representation transport has the required shape. |
-| `bothBindWorld v W A B` | Transport old pairs and relate the canonical representations of the fresh aligned `A` and `B` cells. | **Not in hand in the builder.** Its arguments contain no `A₀⊑B₀`/resolved-representation witness. This is the principal allocation pressure point. |
-| `parked-initial`, `parked-both-bind`, `parked-left-bind`, and `parked-right-bind` | Classify worlds minted by the initial and three bind builders. | **In hand after the builders are strengthened.** `parked-initial` drops `Σ`; `parked-both-bind` must accept and thread the fresh representation witness. |
+| `rightOnlyWorld W B` | Transport old pairs; prove the fresh unmatched target resolves to `★`. | **Not in hand for generic `B`.** Require `resolveRep (targetStoreʷ W) B ≡ ★`. It is definitional for `B = ★` and for `B = ＇ zero` immediately after binding `★`. |
+| `bothBindWorld v W A B` | Transport old pairs and relate the canonical representations of the fresh aligned `A` and `B` cells. | **Not in hand in the builder for representation imprecision.** Its fresh target is matched, so invariant (4) adds no obligation. |
+| `parked-initial`, `parked-both-bind`, `parked-left-bind`, and `parked-right-bind` | Classify worlds minted by the initial and three bind builders. | **In hand after the builders are strengthened.** `parked-right-bind` inherits the new resolved-`★` premise. |
 | `parked-structural-right-insert` | Classify a caller-supplied `TargetInsert` output as parked. | **In hand.** The result is already a valid `World`; the insert and store-following premises add no new field obligation. |
-| `evolve-refl`, `evolve-keepᴸ`, and `evolve-keepᴿ` | Reindex a trace without constructing a world. | **No new obligation.** The endpoint worlds already carry both fields. |
-| `evolve-both-bind`, `evolve-left-bind`, and `evolve-right-bind` | Remove a leading allocation from an evolution whose starting world was produced by a bind builder. | **In hand after the builders are strengthened.** Only the both-bind surface needs the fresh representation witness. |
-| `evolve-structural-right-bind` | Remove a structural target allocation backed by `TargetInsert`. | **In hand.** Its intermediate and final endpoints are already valid worlds. |
+| `evolve-refl`, `evolve-keepᴸ`, and `evolve-keepᴿ` | Reindex a trace without constructing a world. | **No new obligation.** The endpoint worlds already carry all three fields. |
+| `evolve-both-bind`, `evolve-left-bind`, and `evolve-right-bind` | Remove a leading allocation from an evolution whose starting world was produced by a bind builder. | `evolve-right-bind` must expose the same resolved-`★` premise as `rightOnlyWorld`; the other two add no invariant-(4) work. |
+| `evolve-structural-right-bind` | Remove a structural target allocation backed by `TargetInsert`. | **In hand at this consumer.** `W₁` is already a valid `World`; its projection proves the fresh target is `★`. The minting burden remains at the `TargetInsert` output builder. |
 | `BothBindTransport²ᵀ` and paired allocation callers | Supply the fresh canonical-representation relation to `bothBindWorld`. | **Partly in hand at callers.** Paired allocation has an `A₀⊑B₀` premise, but the current transport surface passes only the trivial fresh-variable witness `＇ zero ⊑ ＇ zero`. A lemma must turn the allocation premise plus the old invariant into the resolved-representation witness. |
-| `CenterRename.renameWorld` | Rename both invariant conclusions and preserve center equality. | **In hand.** Existing `rename-⊑`, `renameStoreRep`, and embedding injectivity provide the ingredients. |
-| `WorldDecay.blendWorld` | Use the geometry/stores of the premise world and weaken representation proofs to the blended environment. | **In hand.** An output `X⊑X` mark comes from the premise world; raw imprecision is monotone under the environment decay. |
-| `WorldDecay.honestify` | Preserve all aligned store representations while changing only marks; establish precise alignment. | **In hand.** Existing alignment and mark-decay lemmas provide the two fields. |
-| `SealPeelToolkit.dynWorld` | Preserve geometry/stores under the all-`X⊑★` environment. | **In hand.** Precise alignment is vacuous and representation proofs weaken to the all-dynamic environment. |
-| `TargetBindLift.targetStoreAs W Σᴿ` | Prove the invariant after replacing the target store arbitrarily. | **Not in hand for the raw helper.** Current callers pair it with `TargetStoreMove`/`TargetBindLiftMove`, and `moveStoreRepBindLift` supplies pointwise evidence. Make the raw helper private or require that movement evidence. |
-| `TargetExtend.smartAliasInsertWorld` | Transport both invariants through alias insertion. | **In hand.** `TargetInsert` alignment/reflection and resolved-store transport cover old and inserted centers. |
-| `TargetExtend.smartFreshInsertWorld` | Transport both invariants through fresh insertion. | **In hand.** The smart guard plus `TargetInsert` transport covers the new geometry. |
-| `TargetExtend.insertRebaseWorld ins Wᵖ` | Mix `Wᵖ`'s source/environment/store with the inserted target of another world. | **Not in hand for arbitrary `Wᵖ`.** Require `RebaseAt`/frozen-target evidence tying `Wᵖ` to the insertion source, or replace the raw constructor with a checked builder. |
+| `CenterRename.renameWorld` | Rename all invariant conclusions and preserve center equality. | **In hand.** Existing `rename-⊑`, `renameStoreRep`, and embedding injectivity provide the ingredients. |
+| `WorldDecay.blendWorld` | Use the geometry/stores of the premise world and weaken representation proofs to the blended environment. | **In hand.** An output `X⊑X` mark comes from the premise world; raw imprecision is monotone under the environment decay. Invariant (4) is unchanged because geometry and stores are unchanged. |
+| `WorldDecay.honestify` | Preserve all aligned store representations while changing only marks; establish precise alignment. | **In hand.** Existing alignment and mark-decay lemmas provide the first two fields; invariant (4) is unchanged because geometry and stores are unchanged. |
+| `SealPeelToolkit.dynWorld` | Preserve geometry/stores under the all-`X⊑★` environment. | **In hand.** Precise alignment is vacuous and representation proofs weaken to the all-dynamic environment; invariant (4) is inherited unchanged. |
+| `TargetBindLift.targetStoreAs W Σᴿ` | Prove the invariants after replacing the target store arbitrarily. | **Not in hand for the raw helper.** Besides pairwise representation evidence, movement must preserve `resolveRep ... (＇ Xᴿ) ≡ ★` for every unmatched target. Make the raw helper private or require the movement evidence. |
+| `TargetExtend.smartAliasInsertWorld` | Transport all invariants through alias insertion. | **In hand after the input insert is valid.** Old-source freezing reflects any unmatched output target back to the smart premise world. |
+| `TargetExtend.smartFreshInsertWorld` | Transport all invariants through fresh insertion. | **In hand after the input insert is valid.** Old-source freezing and target reflection provide the invariant-(4) transport. |
+| `TargetExtend.insertRebaseWorld ins Wᵖ` | Mix `Wᵖ`'s source/environment/store with the inserted target of another world. | **Not in hand for arbitrary `Wᵖ`, and invariant (4) exposes the exact failure.** A repark can make a non-`★` old target newly unmatched. Require a checked rebase premise that rules this out. |
 | `liftBothTargetInsert` and `liftLeftTargetInsert` | Lift a `TargetInsert` across the corresponding world builders. | **In hand after those builders are valid.** These records relate already constructed endpoints. |
 | `smartAliasTargetInsert` and `smartFreshTargetInsert` | Package the two smart inserted worlds as `TargetInsert` results. | **In hand with their builders.** Their current geometry, resolve, and environment transport is exactly the preservation evidence. |
-| `rightBindTargetInsert` and `keepRightBindTargetInsert` | Package `rightOnlyWorld`, optionally under `liftWorldBoth`. | **In hand with those builders.** |
+| `rightBindTargetInsert` and `keepRightBindTargetInsert` | Package `rightOnlyWorld`, optionally under `liftWorldBoth`. | **Not in hand at the root for generic `B`.** Strengthen `rightBindTargetInsert` with the same resolved-`★` premise as `rightOnlyWorld`; `keepRightBindTargetInsert` then transports it. |
 | `insertRebaseTargetInsert`, its reverse and pullback variants, and their commuting result packages | Package `insertRebaseWorld` endpoints as `TargetInsert` results. | **Blocked exactly where `insertRebaseWorld` is blocked.** Once that builder requires rebase/frozen-target evidence, these functions already receive or derive it. |
 | Other `TargetInsert` results | Relate an input and an already constructed output world. | **No extra minting obligation.** Once outputs are valid `World`s, existing alignment and resolve transport explain preservation. |
 | `sameWorldRebaseAt`, rename/move/insert/right-bind `RebaseAt` transformers, and `RebaseAtᴸ`/`ᴿ`/tag wrappers | Relate already valid worlds and identify or transport a pivot. | **No global minting obligation.** `RebaseAt.storeRepresentations` becomes derivable from `representationsImpreciseʷ` and `pivotAligned`; keep it only during staged migration, then remove the redundancy. |
 | `EnvDecay`, `decayRebaseAt`, `SameRuntime` | Transport relations between already valid worlds. | **In hand.** `decayRebaseAt` already transports the pivot representation proof. |
-| `TermImpDecay` world patterns | Destructure a `World` while transporting derivations. | **Mechanical blast only.** Constructor patterns must bind or ignore two more fields; no new world is minted there. |
+| `TermImpDecay` world patterns | Destructure a `World` while transporting derivations. | **Mechanical blast only.** Constructor patterns must bind or ignore three more fields; no new world is minted there. |
+
+### Invariant-(4) right-only minting inventory
+
+For `rightOnlyWorld W B`, the fresh target variable is `Fin.zero`.  No source
+variable maps to its fresh center, and its representation computes to
+
+```agda
+resolveRep (store-bind (targetStoreʷ W) B) (＇ Fin.zero)
+  ≡ ⇑ᵗ (resolveRep (targetStoreʷ W) B).
+```
+
+Consequently the strengthened builder must receive
+`resolveRep (targetStoreʷ W) B ≡ ★` (or the immediately lifted equality).
+The current generic signature cannot prove it.
+
+| Catch-up minting path | What it binds | Is resolved `★` in hand? |
+| --- | --- | --- |
+| `structural-target-inst-step`; `inst-cast-alloc-prefix`; `GroundingPreserve.β-inst-*` | `★` | **Yes, definitionally.** |
+| Concrete `Λ⊑Λ²` two-bind route, including smart-alias, smart-fresh, and rebase transport | First `★`, then `＇ Fin.zero` pointing to that first cell | **Yes.** Both resolutions are definitional in the concrete route, and `ΛRouteOneWindowFacts.firstTargetZeroResolves` / `targetZeroResolves` already carry them for caller-supplied and transported plans. |
+| `AllValueViewStepCatalogᵀ` when coupled to the right-only world extension | `β-Λ`, `β-reveal-∀`, and `β-conceal-∀` bind arbitrary `A`; `β-gen` binds arbitrary `C`; `β-∀` is `keep` | **Not in hand for the allocating cases.** The reduction catalog alone gives no resolved-`★` proof; the catch-up world extension must obtain one from a narrowed structural case or an added premise. |
+| `StructuralTargetGenStepProof`, `StructuralTargetLambdaStepProof`, `StructuralTargetConversionStepProof`, `StructuralGenDescentProof`, and `spine-typed-Λ-child` | `＇ X` for an arbitrary old target pivot `X` | **VIOLATING SURFACE.** No premise says `resolveRep (targetStoreʷ W) (＇ X) ≡ ★`.  A matched `X` may legally resolve to `ℕ`, so invariant (4) rejects the newly minted alias. |
+| `GroundingPreserve.β-gen-*` | Arbitrary argument `C` | **VIOLATING SURFACE.** Occupancy/atomicity does not imply that `C` resolves to `★`. |
+| `RightBindWorldExtendᴿᵀ`, `RightBindKeepWorldExtendᴿᵀ`, `RightBindRightBindWorldExtendᴿᵀ`, `right-bind-under-left-lift`, and the smart alias/fresh bind helpers | Generic `B`/`C` | **VIOLATING AS GENERIC APIs.** Their safe concrete calls are the `★` then `＇ zero` route above; the signatures must nevertheless thread a resolved-`★` witness. |
+| `TransportTermImprecisionProof.mapCtxᴾ-right-bind`, its `evolve-right-bind` case, and other `B₀` callers | Generic `B₀` already named in `rightOnlyWorld W B₀` | **Not locally derivable.** Thread the strengthened builder's witness through these surfaces. |
+| `StructuralWorldExtendᴿ.structural-bind`, `StructuralNamePostPlan.target-bind-child`, `structural-target-bind-step`, peel/descent packages, `parked-structural-right-insert`, and `evolve-structural-right-bind` | A caller-supplied `TargetInsert` plus `targetStoreʷ W₁ ≡ store-bind ... B` | **In hand at the consumer, not at the mint.** `W₁ : World` supplies invariant (4) after migration.  Every constructor of that `W₁` must prove it; `TargetInsert` plus the store equation alone does not manufacture the fact. |
+| `rightBindTargetInsert`, `rightBindTargetWindowInsert`, `keepRightBindTargetInsert`, and right-bind rebase/insert wrappers | Whatever the underlying `rightOnlyWorld` binds | **Same flag as the underlying bind.** Strengthen the root `rightBindTargetInsert` with the resolved-`★` witness; wrappers only transport it. |
+
+The structural `TargetInsert` consumers therefore need no redundant new
+premise once `World` contains the field.  The direct `rightOnlyWorld` and
+`rightBindTargetInsert` constructors do need the premise, and the variable-
+alias call sites above must either derive it from a genuine representation
+fact or stop using a right-only world for that allocation.
 
 ### Direct worlds and fixtures
 
-Every direct `world` application must prove both fields.  The finite probes in
-`SmartCommaWitness`, `MovedLinkProbe`, `TagBoundaryProbe`, `SealPeelProbe`,
-`CenterCrossingProbe`, `ChainRideProbe`, `SourceStarProbe`,
-`StarRepChainProbe`, and `TerminusRebuildProbe` already carry alignment and/or
-pivot representation facts from which the fields can be proved by finite case
-analysis.  `CastTermImprecision2`'s Example 12 dynamic and natural-number chain
-worlds are likewise locally supported.
+Every direct `world` application must prove all three fields.  Fixtures whose
+target stores resolve only to `★` can prove invariant (4) by finite case
+analysis.  Non-`★` fixtures need an occupancy audit: every target pivot with
+that representation must be center-aligned with a source pivot in that exact
+world.
+
+This audit newly rejects several `CastTermImprecision2` Example 12 fixtures.
+`example12-world-X` keeps its `ℕ` target matched and can satisfy invariant (4),
+but `example12-world-Y` and `example12-world-Z` leave that target unmatched.
+Both `example12-nat-chain-world-X` and `example12-nat-chain-world-Y` have two
+target pivots resolving to `ℕ` and only one source pivot, so each leaves one
+non-`★` target unmatched.  These are the same reparking shape exposed by the
+D8a probe and must be retired or redesigned.  The all-`★` finite probes remain
+locally supported.
 
 The remaining live direct constructors are the named builders in the table,
 `Examples2.reflWorld`, the two initial-world definitions, and the concrete
@@ -158,43 +211,51 @@ variant already have the required local facts.
 
 1. `bothBindWorld` needs a fresh resolved-representation witness.  It cannot be
    manufactured from its present parameters.
-2. Generic `liftWorldLeft v` and `leftOnlyWorld v` cannot preserve precise-mark
+2. `rightOnlyWorld` and `rightBindTargetInsert` need the bound type to resolve
+   to `★`.  Generic `B`/`B₀` catch-up surfaces and the `＇ X` structural
+   allocation sites do not currently carry that evidence.
+3. Generic `liftWorldLeft v` and `leftOnlyWorld v` cannot preserve precise-mark
    alignment when `v = X⊑X`; their interfaces must exclude that case or gain a
    target occupant.
-3. `insertRebaseWorld` needs an explicit relation between its independently
-   supplied premise world and the world being target-inserted.
-4. `targetStoreAs` cannot accept an arbitrary replacement store; movement
-   evidence must be part of the checked construction path.
-5. The live Example 12 left-path and `Examples2` `XZ` worlds already violate
-   the invariant being merged from `WFWorld`.
-6. The public compile theorem and all parked/occupancy initial-world surfaces
+4. `insertRebaseWorld` needs an explicit relation between its independently
+   supplied premise world and the world being target-inserted; invariant (4)
+   must remain true when a source pivot changes partners.
+5. `targetStoreAs` cannot accept an arbitrary replacement store; movement
+   evidence must preserve both pairwise representations and unmatched `★`
+   resolutions.
+6. The live Example 12 left-path and `Examples2` `XZ` worlds violate the
+   invariant being merged from `WFWorld`; the Example 12 `Y`/`Z` and
+   natural-number chain worlds additionally violate invariant (4).
+7. The public compile theorem and all parked/occupancy initial-world surfaces
    must drop their arbitrary initial store, even though the recursive compiler
    proof itself is compatible.
 
 ## Kill-check
 
-The branch `agent/gtsf-beta-closings` was fetched and the D8a caller-supply and
-occurrence-feasibility probes were reconstructed.  T10 Probe 1 was reconstructed
-from `T10Probe1ParkedWorldPreservation.agda`.  The checked verdict is negative:
+The D8a and T10 Probe 1 geometries were rechecked with invariant (4) as an
+actual field of the probe's eight-field `World`.
 
-| Configuration | Aligned source/target | Resolved representations | Verdict |
-| --- | --- | --- | --- |
-| D8a `W` | source `X` / old target `Y` | `ℕ ⊑ ℕ` by `ι⊑ι` | Satisfies both new fields. |
-| D8a `Wᵖ` | source `X` / fresh target `Y` at `X⊑★` | `ℕ ⊑ ℕ` by `ι⊑ι` | Satisfies both new fields. |
-| T10 Probe 1 `W` | source `X` / old target `Y` | `★ ⊑ ★` by `★⊑★` | Satisfies both new fields. |
-| T10 Probe 1 `Wᵖ` | source `X` / fresh target `Y` at `X⊑★` | `★ ⊑ ★` by `★⊑★` | Satisfies both new fields. |
+| Configuration | Matched target | Unmatched target | Resolved unmatched representation | Verdict under (4) |
+| --- | --- | --- | --- | --- |
+| D8a `W` | old target `Fin.suc Fin.zero` | fresh target `Fin.zero` | `ℕ` | **Rejected.** |
+| D8a `Wᵖ` | fresh target `Fin.zero` | old target `Fin.suc Fin.zero` | `ℕ` | **Rejected.** The old occupant loses its source partner and is non-`★`. |
+| T10 Probe 1 `W` | old target `Fin.suc Fin.zero` | fresh target `Fin.zero` | `★` | **Accepted.** |
+| T10 Probe 1 `Wᵖ` | fresh target `Fin.zero` | old target `Fin.suc Fin.zero` | `★` | **Accepted.** The old occupant loses its partner but already resolves to `★`. |
 
-Thus **none of the D8a or T10 substitution counterexamples dies under this
-local World invariant**.  Each endpoint world is locally representation-
-coherent.  The failure is cross-world: a value related to the old target
-occupant at `W` cannot be retargeted to that old occupant after the source
-pivot is reparked onto a fresh target occupant at `Wᵖ`.  Killing these
-counterexamples requires a rebase/evolution stability invariant, provenance,
-or a restriction on changing the source-to-target partner, not merely local
-representation imprecision.
+**INVARIANT (4) KILLS THE D8a COUNTEREXAMPLE.**  In particular, the reparked
+`Wᵖ` cannot be constructed because its old target occupant is unmatched and
+resolves to `ℕ`.  This resolves the D8a.4 groundedness question: a non-`★`
+old occupant cannot survive as an ungrounded leftover after the source pivot
+reparks.  The probe proves the stronger fact that D8a's other endpoint `W` is
+also invalid, because the then-fresh non-`★` occupant is unmatched there.
 
-The probe exports the checked witnesses
-`d8a-refuting-worlds-satisfy` and `t10-probe1-worlds-satisfy`.
+**Invariant (4) does not kill T10 Probe 1.**  Both unmatched occupants resolve
+to `★`, so both endpoint worlds satisfy all three added fields and the
+cross-world T10 failure remains.
+
+The checked negative witnesses are `d8a-W-violates-invariant4` and
+`d8a-Wᵖ-violates-invariant4`; `t10-W` and `t10-Wᵖ` are checked full `World`
+values, with `t10-probe1-worlds-satisfy` retaining the representation proof.
 
 ## Migration and blast radius
 
@@ -219,16 +280,22 @@ A low-risk LG-1-style sequence is:
 
 1. Hoist `resolveVar`/`resolveRep`.  Against the existing five-field record,
    introduce a temporary, non-public `WorldInvariants W` companion containing
-   exactly the two drafted fields.  Prove preservation for the core builders
+   exactly the three drafted fields.  Prove preservation for the core builders
    and require the companion at theorem boundaries, so failures are visible.
-2. Resolve the pressure points: strengthen both-bind allocation, restrict
-   left-only minting, guard store replacement and insertion/rebase, and repair
-   or retire invalid fixture worlds.
-3. After D15 lands, merge the companion fields into `World` atomically, change
-   constructor calls and patterns to the seven-field shape, replace `WFWorld`
+2. Strengthen `rightOnlyWorld` and `rightBindTargetInsert` with a resolved-`★`
+   premise.  Thread it through `evolve-right-bind`, the generic `B₀` transport
+   surfaces, parked constructors, and smart wrappers.  Keep the `★` then
+   `＇ zero` route; add real evidence or redesign the arbitrary `＇ X`, `C`,
+   and generic-`B` sites.
+3. Resolve the remaining pressure points: strengthen both-bind allocation,
+   restrict left-only minting, guard store replacement and insertion/rebase,
+   and repair or retire invalid fixture worlds.  Use invariant (4), rather
+   than a cross-world compatibility alias, to reject non-`★` repark outputs.
+4. After D15 lands, merge the companion fields into `World` atomically, change
+   constructor calls and patterns to the eight-field shape, replace `WFWorld`
    arguments by the projection, and delete both `WFWorld` and the temporary
    companion.  Do not retain a compatibility alias in this closed-world repo.
-4. Remove `RebaseAt.storeRepresentations` once all callers use the world field,
+5. Remove `RebaseAt.storeRepresentations` once all callers use the world field,
    and consolidate `initialWorldᴼ` into the canonical empty-store constructor.
 
 PR #171 (`agent/gtsf-partner-redesign`, fetched head `faec619c`) changes 43
@@ -237,7 +304,7 @@ PR #171 (`agent/gtsf-partner-redesign`, fetched head `faec619c`) changes 43
 and catchup modules.  Its direct change to `CastTermImprecision2` is the D15
 partner/conceal surface rather than this record, but its semantic and arity
 blast overlaps almost every migration site.  Land D15 first, then rebase D16
-and perform step 3.  The temporary companion work can be prepared before that
+and perform step 4.  The temporary companion work can be prepared before that
 merge, but it must not become a second permanent world API.
 
 ## Validation

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -8,7 +8,24 @@ by `proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda`.
 
 The invariant belongs directly in `World`.  It does not require a two-layer
 `RawWorld` definition because its conclusion can use the raw, environment-
-indexed type-imprecision relation.  The proposed record is:
+indexed type-imprecision relation.
+
+`TyStore` currently exposes the relational lookup `_∋_⦂_`, but that
+relation intentionally has no entry for `Fin.zero` under `store-lift`.  D16
+needs a total one-step view, including structural binders, so the probe drafts
+the following canonical `lookupStore` primitive:
+
+```agda
+lookupStore : ∀ {Δ} → TyStore Δ → TyVar Δ → Ty Δ
+lookupStore (store-lift Σ) Fin.zero = ＇ Fin.zero
+lookupStore (store-lift Σ) (Fin.suc X) = ⇑ᵗ (lookupStore Σ X)
+lookupStore (store-bind Σ A) Fin.zero = ⇑ᵗ A
+lookupStore (store-bind Σ A) (Fin.suc X) = ⇑ᵗ (lookupStore Σ X)
+```
+
+This returns exactly one direct store entry, lifted into the store's current
+scope; it never follows a variable entry.  The recommended record uses the
+chain-permissive form of invariant (4):
 
 ```agda
 record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
@@ -31,15 +48,19 @@ record World (Δᴸ Δᴿ Δ : TyCtx) : Set where
       → toRenameᵗ ηᴸʷ Xᴸ ≡ toRenameᵗ ηᴿʷ Xᴿ
       → impEnvʷ ⊢
           renameᵗ (toRenameᵗ ηᴸʷ)
-            (resolveRep sourceStoreʷ (＇ Xᴸ))
+            (lookupStore sourceStoreʷ Xᴸ)
           ⊑ renameᵗ (toRenameᵗ ηᴿʷ)
-            (resolveRep targetStoreʷ (＇ Xᴿ))
+            (lookupStore targetStoreʷ Xᴿ)
 
     unmatchedTargetsDynamicʷ :
       ∀ (Xᴿ : TyVar Δᴿ)
       → (∀ (Xᴸ : TyVar Δᴸ)
           → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Xᴿ)
-      → resolveRep targetStoreʷ (＇ Xᴿ) ≡ ★
+      → lookupStore targetStoreʷ Xᴿ ≡ ★
+        ⊎ Σ[ Yᴿ ∈ TyVar Δᴿ ]
+            (lookupStore targetStoreʷ Xᴿ ≡ ＇ Yᴿ)
+          × (∀ (Xᴸ : TyVar Δᴸ)
+              → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Yᴿ)
 ```
 
 `preciseMarksAlignedʷ` is exactly the current `WFWorld` judgment, now a
@@ -48,26 +69,73 @@ center mark.  A `RebaseAt` pivot may be center-aligned at `X⊑★`, and its
 store representations still have to be related.  Conditioning the field on
 `X⊑X` would leave precisely that runtime alignment unchecked.
 
-`unmatchedTargetsDynamicʷ` says exactly that a target pivot with no
-center-aligned source pivot resolves to `★`.  Equality is the right conclusion,
-not a second representation-path predicate: `resolveRep` is already the
-canonical transitive path resolver.  This leaves matched pivots unrestricted;
-in particular, the checked paths ending at `ℕ` remain legal while their target
-pivot has a source partner.
+The direct field makes chain coherence derivable rather than primitive.  If
+aligned `Xᴸ` and `Xᴿ` have variable entries `＇ Yᴸ` and `＇ Yᴿ`, their direct
+entries are related.  The only imprecision derivation between two variables
+identifies their embedded heads, so `Yᴸ` and `Yᴿ` are center-aligned and the
+field applies again.  Induction on decreasing store age repeats this argument
+down the chain.  The probe checks the induction step with this statement:
+
+```agda
+variableEntryChainCoherence : ∀ {Δᴸ Δᴿ Δ}
+    (W : World Δᴸ Δᴿ Δ)
+    {Xᴸ Yᴸ : TyVar Δᴸ} {Xᴿ Yᴿ : TyVar Δᴿ}
+  → CenterAligned W Xᴸ Xᴿ
+  → lookupStore (sourceStoreʷ W) Xᴸ ≡ ＇ Yᴸ
+  → lookupStore (targetStoreʷ W) Xᴿ ≡ ＇ Yᴿ
+  → CenterAligned W Yᴸ Yᴿ
+    × (impEnvʷ W ⊢
+        renameᵗ (toRenameᵗ (ηᴸʷ W))
+          (lookupStore (sourceStoreʷ W) Yᴸ)
+        ⊑ renameᵗ (toRenameᵗ (ηᴿʷ W))
+          (lookupStore (targetStoreʷ W) Yᴿ))
+```
+
+### Design sub-question: strict or chain-permissive (4)?
+
+The two direct-entry candidates are:
+
+1. **STRICT**
+
+   ```agda
+   unmatchedTargetsDynamicʷ :
+     ∀ (Xᴿ : TyVar Δᴿ)
+     → (∀ (Xᴸ : TyVar Δᴸ)
+         → toRenameᵗ ηᴸʷ Xᴸ ≢ toRenameᵗ ηᴿʷ Xᴿ)
+     → lookupStore targetStoreʷ Xᴿ ≡ ★
+   ```
+
+2. **CHAIN-PERMISSIVE** (shown in the proposed record): the entry is literally
+   `★`, or it is `＇ Yᴿ` and `Yᴿ` is itself unmatched.  Since a bound variable
+   can mention only an older variable, repeated use terminates at literal `★`.
+
+**Recommendation: choose CHAIN-PERMISSIVE.**  The live `Λ⊑Λ²` catch-up route
+first right-binds `★` and then right-binds `＇ Fin.zero`.  Both fresh cells are
+unmatched at bind time: `rightOnlyWorld` skips every source center and keeps the
+fresh target center.  The second cell points to the first, still-unmatched `★`
+cell.  The strict form rejects this established safe route, while the permissive
+form accepts it and still derives `★` termination.  The probe constructs
+`alias-chain-world` under the permissive field and proves
+`alias-chain-rejects-strict`.
+
+The other structural `＇ X` bind sites are also fresh unmatched cells, not
+matched cells.  However, their arbitrary old head `X` may already be matched;
+none of their signatures says it is unmatched.  Therefore even the permissive
+form correctly leaves those generic sites unproved.
 
 The conclusion uses raw `_ ⊢_ ⊑_`, not `_ ⊑ᵂ⟨_⟩_`.  After the record
 exists it is definitionally the intended world relation:
 
 ```agda
-impEnvʷ W ⊢ embedᴸ W (resolveRep (sourceStoreʷ W) (＇ Xᴸ))
-          ⊑ embedᴿ W (resolveRep (targetStoreʷ W) (＇ Xᴿ))
+impEnvʷ W ⊢ embedᴸ W (lookupStore (sourceStoreʷ W) Xᴸ)
+          ⊑ embedᴿ W (lookupStore (targetStoreʷ W) Xᴿ)
 ```
 
 but spelling out the embeddings avoids a recursive dependency from `World` to
 a relation defined by projections from `World`.  In the live migration,
-`resolveVar` and `resolveRep` must be moved above `World`; they are currently
-declared later in `CastTermImprecision2.agda`.  This is declaration staging,
-not a change to type imprecision.
+`lookupStore` belongs in `TyStore`; no representation-chain resolver must be
+moved above `World`, and the live resolver remains available to consumers that
+actually need a transitive representative.
 
 ## Empty initial compilation world
 
@@ -109,82 +177,98 @@ lemma; it does not mean the eight-field constructor has been implemented.
 | `CompilePreservesImprecision2.initialWorld` | Identity precise alignment; reflexive representations in two empty stores; no unmatched target. | **In hand and checked.** Remove the arbitrary-store parameter from its public callers. |
 | `Examples2.reflWorld` | Identity alignment and reflexivity for the same store on both sides; no unmatched target. | **In hand.** |
 | `Occupancy.initialWorldᴼ` | Same as canonical `initialWorld`. | **In hand, but obsolete.** Delete this duplicate rather than preserve an alias. |
-| `liftWorldBoth v W` | Lift all old invariants; relate the fresh structural pair. | **In hand.** The fresh target is matched, and old unmatched targets remain unmatched with lifted `★` representations. |
+| `liftWorldBoth v W` | Lift all old invariants; relate the fresh structural pair. | **In hand.** The fresh target is matched.  Each old direct entry is merely shifted; a variable head and its unmatched proof shift pointwise. |
 | `liftWorldLeft v W` | Lift old pairs; a precise fresh source mark must have a target occupant. | **Not in hand for generic `v`.** Current compile use is `X⊑★`. Restrict it to a non-precise mark or add a premise ruling out `X⊑X`. |
 | `leftOnlyWorld v W A` | Transport old pairs through the source bind; handle the unpaired fresh source. | **Not in hand for generic `v`.** Live parked uses pass `X⊑★`; the signature should expose that requirement. |
-| `rightOnlyWorld W B` | Transport old pairs; prove the fresh unmatched target resolves to `★`. | **Not in hand for generic `B`.** Require `resolveRep (targetStoreʷ W) B ≡ ★`. It is definitional for `B = ★` and for `B = ＇ zero` immediately after binding `★`. |
-| `bothBindWorld v W A B` | Transport old pairs and relate the canonical representations of the fresh aligned `A` and `B` cells. | **Not in hand in the builder for representation imprecision.** Its fresh target is matched, so invariant (4) adds no obligation. |
-| `parked-initial`, `parked-both-bind`, `parked-left-bind`, and `parked-right-bind` | Classify worlds minted by the initial and three bind builders. | **In hand after the builders are strengthened.** `parked-right-bind` inherits the new resolved-`★` premise. |
+| `rightOnlyWorld W B` | Transport old pairs; classify the fresh unmatched direct entry `⇑ᵗ B`. | **Not in hand for generic `B`.** Under the recommended form, accept `B = ★`, or `B = ＇ X` when `X` is proved unmatched in `W`. Strict accepts only the first case. |
+| `bothBindWorld v W A B` | Transport old pairs and relate the direct entries of the fresh aligned `A` and `B` cells. | **Simplified and in hand when the allocation premise relates `A` and `B`.** Rename that premise through the fresh center; no chain-resolution bridge is needed.  Its fresh target is matched, so invariant (4) adds no obligation. |
+| `parked-initial`, `parked-both-bind`, `parked-left-bind`, and `parked-right-bind` | Classify worlds minted by the initial and three bind builders. | **In hand after the builders are strengthened.** `parked-right-bind` inherits the new direct-entry classification premise. |
 | `parked-structural-right-insert` | Classify a caller-supplied `TargetInsert` output as parked. | **In hand.** The result is already a valid `World`; the insert and store-following premises add no new field obligation. |
 | `evolve-refl`, `evolve-keepᴸ`, and `evolve-keepᴿ` | Reindex a trace without constructing a world. | **No new obligation.** The endpoint worlds already carry all three fields. |
-| `evolve-both-bind`, `evolve-left-bind`, and `evolve-right-bind` | Remove a leading allocation from an evolution whose starting world was produced by a bind builder. | `evolve-right-bind` must expose the same resolved-`★` premise as `rightOnlyWorld`; the other two add no invariant-(4) work. |
-| `evolve-structural-right-bind` | Remove a structural target allocation backed by `TargetInsert`. | **In hand at this consumer.** `W₁` is already a valid `World`; its projection proves the fresh target is `★`. The minting burden remains at the `TargetInsert` output builder. |
-| `BothBindTransport²ᵀ` and paired allocation callers | Supply the fresh canonical-representation relation to `bothBindWorld`. | **Partly in hand at callers.** Paired allocation has an `A₀⊑B₀` premise, but the current transport surface passes only the trivial fresh-variable witness `＇ zero ⊑ ＇ zero`. A lemma must turn the allocation premise plus the old invariant into the resolved-representation witness. |
-| `CenterRename.renameWorld` | Rename all invariant conclusions and preserve center equality. | **In hand.** Existing `rename-⊑`, `renameStoreRep`, and embedding injectivity provide the ingredients. |
+| `evolve-both-bind`, `evolve-left-bind`, and `evolve-right-bind` | Remove a leading allocation from an evolution whose starting world was produced by a bind builder. | `evolve-right-bind` must expose the same direct-entry classification premise as `rightOnlyWorld`; the other two add no invariant-(4) work. |
+| `evolve-structural-right-bind` | Remove a structural target allocation backed by `TargetInsert`. | **In hand at this consumer.** `W₁` is already a valid `World`; its projection classifies the fresh direct entry. The minting burden remains at the `TargetInsert` output builder. |
+| `BothBindTransport²ᵀ` and paired allocation callers | Supply the fresh direct-entry relation to `bothBindWorld`. | **Simplified.** The existing allocation premise `A₀⊑B₀` transports pointwise to the fresh entries.  The old resolved-representation bridge and its dependence on the old invariant disappear. |
+| `CenterRename.renameWorld` | Rename all invariant conclusions and preserve center equality. | **Simplified.** Prove one `lookupStore`/store-renaming commutation lemma and apply `rename-⊑` pointwise; no transitive representative transport is needed. |
 | `WorldDecay.blendWorld` | Use the geometry/stores of the premise world and weaken representation proofs to the blended environment. | **In hand.** An output `X⊑X` mark comes from the premise world; raw imprecision is monotone under the environment decay. Invariant (4) is unchanged because geometry and stores are unchanged. |
 | `WorldDecay.honestify` | Preserve all aligned store representations while changing only marks; establish precise alignment. | **In hand.** Existing alignment and mark-decay lemmas provide the first two fields; invariant (4) is unchanged because geometry and stores are unchanged. |
 | `SealPeelToolkit.dynWorld` | Preserve geometry/stores under the all-`X⊑★` environment. | **In hand.** Precise alignment is vacuous and representation proofs weaken to the all-dynamic environment; invariant (4) is inherited unchanged. |
-| `TargetBindLift.targetStoreAs W Σᴿ` | Prove the invariants after replacing the target store arbitrarily. | **Not in hand for the raw helper.** Besides pairwise representation evidence, movement must preserve `resolveRep ... (＇ Xᴿ) ≡ ★` for every unmatched target. Make the raw helper private or require the movement evidence. |
-| `TargetExtend.smartAliasInsertWorld` | Transport all invariants through alias insertion. | **In hand after the input insert is valid.** Old-source freezing reflects any unmatched output target back to the smart premise world. |
-| `TargetExtend.smartFreshInsertWorld` | Transport all invariants through fresh insertion. | **In hand after the input insert is valid.** Old-source freezing and target reflection provide the invariant-(4) transport. |
+| `TargetBindLift.targetStoreAs W Σᴿ` | Prove the invariants after replacing the target store arbitrarily. | **Not in hand for the raw helper, but the premise is simpler.** Require pointwise direct-entry imprecision plus preservation of the literal-`★`/unmatched-head classification; no path equality is needed. Make the raw helper private or require that evidence. |
+| `TargetExtend.smartAliasInsertWorld` | Transport all invariants through alias insertion. | **Simplified after the input insert is valid.** Lookup commutes pointwise with the insertion; old-source freezing reflects both an unmatched target and an unmatched variable head back to the premise world. |
+| `TargetExtend.smartFreshInsertWorld` | Transport all invariants through fresh insertion. | **Simplified after the input insert is valid.** Pointwise lookup transport plus old-source freezing and target reflection preserve both branches of invariant (4). |
 | `TargetExtend.insertRebaseWorld ins Wᵖ` | Mix `Wᵖ`'s source/environment/store with the inserted target of another world. | **Not in hand for arbitrary `Wᵖ`, and invariant (4) exposes the exact failure.** A repark can make a non-`★` old target newly unmatched. Require a checked rebase premise that rules this out. |
 | `liftBothTargetInsert` and `liftLeftTargetInsert` | Lift a `TargetInsert` across the corresponding world builders. | **In hand after those builders are valid.** These records relate already constructed endpoints. |
-| `smartAliasTargetInsert` and `smartFreshTargetInsert` | Package the two smart inserted worlds as `TargetInsert` results. | **In hand with their builders.** Their current geometry, resolve, and environment transport is exactly the preservation evidence. |
-| `rightBindTargetInsert` and `keepRightBindTargetInsert` | Package `rightOnlyWorld`, optionally under `liftWorldBoth`. | **Not in hand at the root for generic `B`.** Strengthen `rightBindTargetInsert` with the same resolved-`★` premise as `rightOnlyWorld`; `keepRightBindTargetInsert` then transports it. |
+| `smartAliasTargetInsert` and `smartFreshTargetInsert` | Package the two smart inserted worlds as `TargetInsert` results. | **In hand with their builders.** Their geometry and pointwise lookup transport provide the preservation evidence. |
+| `rightBindTargetInsert` and `keepRightBindTargetInsert` | Package `rightOnlyWorld`, optionally under `liftWorldBoth`. | **Not in hand at the root for generic `B`.** Strengthen `rightBindTargetInsert` with the same direct-entry classification premise as `rightOnlyWorld`; `keepRightBindTargetInsert` then shifts it. |
 | `insertRebaseTargetInsert`, its reverse and pullback variants, and their commuting result packages | Package `insertRebaseWorld` endpoints as `TargetInsert` results. | **Blocked exactly where `insertRebaseWorld` is blocked.** Once that builder requires rebase/frozen-target evidence, these functions already receive or derive it. |
-| Other `TargetInsert` results | Relate an input and an already constructed output world. | **No extra minting obligation.** Once outputs are valid `World`s, existing alignment and resolve transport explain preservation. |
-| `sameWorldRebaseAt`, rename/move/insert/right-bind `RebaseAt` transformers, and `RebaseAtᴸ`/`ᴿ`/tag wrappers | Relate already valid worlds and identify or transport a pivot. | **No global minting obligation.** `RebaseAt.storeRepresentations` becomes derivable from `representationsImpreciseʷ` and `pivotAligned`; keep it only during staged migration, then remove the redundancy. |
+| Other `TargetInsert` results | Relate an input and an already constructed output world. | **No extra minting obligation.** Once outputs are valid `World`s, the fields and pointwise lookup transport explain preservation. |
+| `sameWorldRebaseAt`, rename/move/insert/right-bind `RebaseAt` transformers, and `RebaseAtᴸ`/`ᴿ`/tag wrappers | Relate already valid worlds and identify or transport a pivot. | **No global minting obligation.** `RebaseAt.storeRepresentations` follows by the derived chain-coherence induction from `representationsImpreciseʷ` and `pivotAligned`; keep it only during staged migration, then remove it. |
 | `EnvDecay`, `decayRebaseAt`, `SameRuntime` | Transport relations between already valid worlds. | **In hand.** `decayRebaseAt` already transports the pivot representation proof. |
 | `TermImpDecay` world patterns | Destructure a `World` while transporting derivations. | **Mechanical blast only.** Constructor patterns must bind or ignore three more fields; no new world is minted there. |
 
 ### Invariant-(4) right-only minting inventory
 
 For `rightOnlyWorld W B`, the fresh target variable is `Fin.zero`.  No source
-variable maps to its fresh center, and its representation computes to
+variable maps to its fresh center, and its direct entry computes to
 
 ```agda
-resolveRep (store-bind (targetStoreʷ W) B) (＇ Fin.zero)
-  ≡ ⇑ᵗ (resolveRep (targetStoreʷ W) B).
+lookupStore (store-bind (targetStoreʷ W) B) Fin.zero ≡ ⇑ᵗ B
 ```
 
-Consequently the strengthened builder must receive
-`resolveRep (targetStoreʷ W) B ≡ ★` (or the immediately lifted equality).
-The current generic signature cannot prove it.
+Consequently strict requires `⇑ᵗ B ≡ ★`.  Chain-permissive requires that
+equality or `⇑ᵗ B ≡ ＇ Yᴿ` with `Yᴿ` unmatched in the new world.  For
+`B = ＇ X`, the latter reduces to the old pivot `X` being unmatched in `W`;
+the new head is `Fin.suc X`.  The current generic signature proves neither
+classification.
 
-| Catch-up minting path | What it binds | Is resolved `★` in hand? |
+| Catch-up minting path | What it binds | Is the direct obligation in hand? |
 | --- | --- | --- |
 | `structural-target-inst-step`; `inst-cast-alloc-prefix`; `GroundingPreserve.β-inst-*` | `★` | **Yes, definitionally.** |
-| Concrete `Λ⊑Λ²` two-bind route, including smart-alias, smart-fresh, and rebase transport | First `★`, then `＇ Fin.zero` pointing to that first cell | **Yes.** Both resolutions are definitional in the concrete route, and `ΛRouteOneWindowFacts.firstTargetZeroResolves` / `targetZeroResolves` already carry them for caller-supplied and transported plans. |
-| `AllValueViewStepCatalogᵀ` when coupled to the right-only world extension | `β-Λ`, `β-reveal-∀`, and `β-conceal-∀` bind arbitrary `A`; `β-gen` binds arbitrary `C`; `β-∀` is `keep` | **Not in hand for the allocating cases.** The reduction catalog alone gives no resolved-`★` proof; the catch-up world extension must obtain one from a narrowed structural case or an added premise. |
-| `StructuralTargetGenStepProof`, `StructuralTargetLambdaStepProof`, `StructuralTargetConversionStepProof`, `StructuralGenDescentProof`, and `spine-typed-Λ-child` | `＇ X` for an arbitrary old target pivot `X` | **VIOLATING SURFACE.** No premise says `resolveRep (targetStoreʷ W) (＇ X) ≡ ★`.  A matched `X` may legally resolve to `ℕ`, so invariant (4) rejects the newly minted alias. |
-| `GroundingPreserve.β-gen-*` | Arbitrary argument `C` | **VIOLATING SURFACE.** Occupancy/atomicity does not imply that `C` resolves to `★`. |
-| `RightBindWorldExtendᴿᵀ`, `RightBindKeepWorldExtendᴿᵀ`, `RightBindRightBindWorldExtendᴿᵀ`, `right-bind-under-left-lift`, and the smart alias/fresh bind helpers | Generic `B`/`C` | **VIOLATING AS GENERIC APIs.** Their safe concrete calls are the `★` then `＇ zero` route above; the signatures must nevertheless thread a resolved-`★` witness. |
-| `TransportTermImprecisionProof.mapCtxᴾ-right-bind`, its `evolve-right-bind` case, and other `B₀` callers | Generic `B₀` already named in `rightOnlyWorld W B₀` | **Not locally derivable.** Thread the strengthened builder's witness through these surfaces. |
-| `StructuralWorldExtendᴿ.structural-bind`, `StructuralNamePostPlan.target-bind-child`, `structural-target-bind-step`, peel/descent packages, `parked-structural-right-insert`, and `evolve-structural-right-bind` | A caller-supplied `TargetInsert` plus `targetStoreʷ W₁ ≡ store-bind ... B` | **In hand at the consumer, not at the mint.** `W₁ : World` supplies invariant (4) after migration.  Every constructor of that `W₁` must prove it; `TargetInsert` plus the store equation alone does not manufacture the fact. |
-| `rightBindTargetInsert`, `rightBindTargetWindowInsert`, `keepRightBindTargetInsert`, and right-bind rebase/insert wrappers | Whatever the underlying `rightOnlyWorld` binds | **Same flag as the underlying bind.** Strengthen the root `rightBindTargetInsert` with the resolved-`★` witness; wrappers only transport it. |
+| Concrete `Λ⊑Λ²` two-bind route, including smart-alias, smart-fresh, and rebase transport | First `★`, then `＇ Fin.zero` pointing to that first cell | **Yes only under CHAIN-PERMISSIVE.** The first cell is literal `★`; the second points to that still-unmatched first cell. Strict rejects the second bind. Existing resolver equalities can be replaced by direct entry equalities plus the unmatched-head proof. |
+| `AllValueViewStepCatalogᵀ` when coupled to the right-only world extension | `β-Λ`, `β-reveal-∀`, and `β-conceal-∀` bind arbitrary `A`; `β-gen` binds arbitrary `C`; `β-∀` is `keep` | **Not in hand for the allocating cases.** The catalog does not classify the direct entry; the catch-up extension needs a narrowed case or an added premise. |
+| `StructuralTargetGenStepProof`, `StructuralTargetLambdaStepProof`, `StructuralTargetConversionStepProof`, `StructuralGenDescentProof`, and `spine-typed-Λ-child` | `＇ X` for an arbitrary old target pivot `X` | **VIOLATING SURFACE under both choices.** The fresh alias cell is definitely unmatched because it is made by `rightOnlyWorld`; its head `Fin.suc X` is unmatched exactly when old `X` was unmatched. No premise supplies that fact, and `X` may be matched. |
+| `GroundingPreserve.β-gen-*` | Arbitrary argument `C` | **VIOLATING SURFACE.** Occupancy/atomicity does not classify `⇑ᵗ C` as literal `★` or an unmatched variable. |
+| `RightBindWorldExtendᴿᵀ`, `RightBindKeepWorldExtendᴿᵀ`, `RightBindRightBindWorldExtendᴿᵀ`, `right-bind-under-left-lift`, and the smart alias/fresh bind helpers | Generic `B`/`C` | **VIOLATING AS GENERIC APIs.** Thread the direct-entry classification.  The safe `★`-then-`＇ zero` calls use the two different permissive branches. |
+| `TransportTermImprecisionProof.mapCtxᴾ-right-bind`, its `evolve-right-bind` case, and other `B₀` callers | Generic `B₀` already named in `rightOnlyWorld W B₀` | **Not locally derivable.** Thread the strengthened builder's direct classification through these surfaces; this is pointwise and no longer mentions a resolved path. |
+| `StructuralWorldExtendᴿ.structural-bind`, `StructuralNamePostPlan.target-bind-child`, `structural-target-bind-step`, peel/descent packages, `parked-structural-right-insert`, and `evolve-structural-right-bind` | A caller-supplied `TargetInsert` plus `targetStoreʷ W₁ ≡ store-bind ... B` | **In hand at the consumer, not at the mint.** `W₁ : World` supplies the direct classification.  Every constructor of `W₁` must prove it; `TargetInsert` plus the store equation alone does not. |
+| `rightBindTargetInsert`, `rightBindTargetWindowInsert`, `keepRightBindTargetInsert`, and right-bind rebase/insert wrappers | Whatever the underlying `rightOnlyWorld` binds | **Same flag as the underlying bind.** Strengthen the root with the direct classification; wrappers transport it pointwise. |
 
 The structural `TargetInsert` consumers therefore need no redundant new
 premise once `World` contains the field.  The direct `rightOnlyWorld` and
 `rightBindTargetInsert` constructors do need the premise, and the variable-
-alias call sites above must either derive it from a genuine representation
-fact or stop using a right-only world for that allocation.
+alias call sites above must prove that the old head is unmatched or stop using
+a right-only world for that allocation.
 
 ### Direct worlds and fixtures
 
 Every direct `world` application must prove all three fields.  Fixtures whose
-target stores resolve only to `★` can prove invariant (4) by finite case
-analysis.  Non-`★` fixtures need an occupancy audit: every target pivot with
-that representation must be center-aligned with a source pivot in that exact
-world.
+unmatched target entries are literal `★` can prove invariant (4) immediately.
+Under the recommended form, an unmatched variable entry is also accepted only
+when its head is unmatched.  A non-variable, non-`★` direct entry must be
+center-aligned with a source pivot in that exact world.
 
-This audit newly rejects several `CastTermImprecision2` Example 12 fixtures.
-`example12-world-X` keeps its `ℕ` target matched and can satisfy invariant (4),
-but `example12-world-Y` and `example12-world-Z` leave that target unmatched.
-Both `example12-nat-chain-world-X` and `example12-nat-chain-world-Y` have two
-target pivots resolving to `ℕ` and only one source pivot, so each leaves one
-non-`★` target unmatched.  These are the same reparking shape exposed by the
-D8a probe and must be retired or redesigned.  The all-`★` finite probes remain
-locally supported.
+Directness sharpens the `CastTermImprecision2` Example 12 audit:
+
+* `example12-world-X` directly aligns `ℕ` with `ℕ`; its unmatched `Y`
+  points to unmatched `Z`, whose entry is `★`.  It satisfies both direct fields
+  under CHAIN-PERMISSIVE, but strict would reject the `Y` indirection.
+* `example12-world-Y` directly aligns source `ℕ` with target entry `＇ Z`, so
+  it already fails `representationsImpreciseʷ`; it also leaves direct `ℕ` at
+  `X` unmatched.
+* `example12-world-Z` directly aligns `ℕ ⊑ ★`, but leaves direct `ℕ` at
+  `X` unmatched.  Its unmatched `Y` also points to the now-matched `Z`, which
+  the permissive form deliberately rejects.
+* `example12-nat-chain-world-X` has valid direct `ℕ ⊑ ℕ` at `X`, but its
+  unmatched `Y` points to that matched `X`; invariant (4) rejects it.
+  `example12-nat-chain-world-Y` additionally tries to align direct `ℕ` with
+  `＇ X`, and leaves direct `ℕ` at `X` unmatched.
+* In the left-path family, direct entries validate the `X` and `Z` pairings,
+  while the `Y` pairing changes from a transitively valid `★ ⊑ ★` to an
+  invalid direct `＇ Z ⊑ ★` under its precise mark.  All three worlds still
+  fail the separate `preciseMarksAlignedʷ` audit described below.
+
+Thus direct lookup rejects chain-depth-skewed pairings instead of hiding the
+skew behind a terminal representative.  The all-literal-`★` finite probes
+remain locally supported.
 
 The remaining live direct constructors are the named builders in the table,
 `Examples2.reflWorld`, the two initial-world definitions, and the concrete
@@ -209,11 +293,13 @@ variant already have the required local facts.
 
 ### Pressure points
 
-1. `bothBindWorld` needs a fresh resolved-representation witness.  It cannot be
-   manufactured from its present parameters.
-2. `rightOnlyWorld` and `rightBindTargetInsert` need the bound type to resolve
-   to `★`.  Generic `B`/`B₀` catch-up surfaces and the `＇ X` structural
-   allocation sites do not currently carry that evidence.
+1. `bothBindWorld` now needs only the fresh direct-entry relation.  Existing
+   paired allocation premises can supply it pointwise; the old chain transport
+   surface should be deleted rather than adapted.
+2. `rightOnlyWorld` and `rightBindTargetInsert` need a direct classification of
+   the bound entry.  Generic `B`/`B₀` surfaces do not carry it.  The structural
+   `＇ X` sites specifically need `X` to be unmatched, which is not currently a
+   premise.
 3. Generic `liftWorldLeft v` and `leftOnlyWorld v` cannot preserve precise-mark
    alignment when `v = X⊑X`; their interfaces must exclude that case or gain a
    target occupant.
@@ -221,11 +307,12 @@ variant already have the required local facts.
    supplied premise world and the world being target-inserted; invariant (4)
    must remain true when a source pivot changes partners.
 5. `targetStoreAs` cannot accept an arbitrary replacement store; movement
-   evidence must preserve both pairwise representations and unmatched `★`
-   resolutions.
+   evidence must preserve direct pairwise entries and both branches of the
+   unmatched-target classification.
 6. The live Example 12 left-path and `Examples2` `XZ` worlds violate the
-   invariant being merged from `WFWorld`; the Example 12 `Y`/`Z` and
-   natural-number chain worlds additionally violate invariant (4).
+   invariant being merged from `WFWorld`.  Directness also rejects the
+   chain-depth-skewed Example 12 `Y` pairings; the unmatched direct-entry audit
+   rejects the `Y`/`Z` and natural-number chain worlds as detailed above.
 7. The public compile theorem and all parked/occupancy initial-world surfaces
    must drop their arbitrary initial store, even though the recursive compiler
    proof itself is compatible.
@@ -235,23 +322,23 @@ variant already have the required local facts.
 The D8a and T10 Probe 1 geometries were rechecked with invariant (4) as an
 actual field of the probe's eight-field `World`.
 
-| Configuration | Matched target | Unmatched target | Resolved unmatched representation | Verdict under (4) |
+| Configuration | Matched target | Unmatched target | Direct unmatched entry | Verdict under strict / permissive (4) |
 | --- | --- | --- | --- | --- |
 | D8a `W` | old target `Fin.suc Fin.zero` | fresh target `Fin.zero` | `ℕ` | **Rejected.** |
-| D8a `Wᵖ` | fresh target `Fin.zero` | old target `Fin.suc Fin.zero` | `ℕ` | **Rejected.** The old occupant loses its source partner and is non-`★`. |
+| D8a `Wᵖ` | fresh target `Fin.zero` | old target `Fin.suc Fin.zero` | `ℕ` | **Rejected.** The old occupant loses its source partner and its direct entry is neither `★` nor a variable. |
 | T10 Probe 1 `W` | old target `Fin.suc Fin.zero` | fresh target `Fin.zero` | `★` | **Accepted.** |
-| T10 Probe 1 `Wᵖ` | fresh target `Fin.zero` | old target `Fin.suc Fin.zero` | `★` | **Accepted.** The old occupant loses its partner but already resolves to `★`. |
+| T10 Probe 1 `Wᵖ` | fresh target `Fin.zero` | old target `Fin.suc Fin.zero` | `★` | **Accepted.** The old occupant loses its partner but its entry is literally `★`. |
 
-**INVARIANT (4) KILLS THE D8a COUNTEREXAMPLE.**  In particular, the reparked
-`Wᵖ` cannot be constructed because its old target occupant is unmatched and
-resolves to `ℕ`.  This resolves the D8a.4 groundedness question: a non-`★`
-old occupant cannot survive as an ungrounded leftover after the source pivot
-reparks.  The probe proves the stronger fact that D8a's other endpoint `W` is
-also invalid, because the then-fresh non-`★` occupant is unmatched there.
+**BOTH DIRECT FORMS OF INVARIANT (4) KILL BOTH D8a WORLDS.**  In `W`, the
+fresh unmatched occupant has direct entry `ℕ`; in `Wᵖ`, the old unmatched
+occupant also has direct entry `ℕ`.  Neither failure depends on following a
+chain.  The checked definitional equalities are `d8a-fresh-direct-entry` and
+`d8a-old-direct-entry`, and the negative witnesses use the weaker,
+chain-permissive field.  Therefore the strict field rejects them a fortiori.
 
-**Invariant (4) does not kill T10 Probe 1.**  Both unmatched occupants resolve
-to `★`, so both endpoint worlds satisfy all three added fields and the
-cross-world T10 failure remains.
+**Invariant (4) does not kill T10 Probe 1.**  Both unmatched occupants have
+literal `★` direct entries, so both endpoint worlds satisfy all three added
+fields and the cross-world T10 failure remains.
 
 The checked negative witnesses are `d8a-W-violates-invariant4` and
 `d8a-Wᵖ-violates-invariant4`; `t10-W` and `t10-Wᵖ` are checked full `World`
@@ -278,25 +365,27 @@ to the empty-store signature.
 
 A low-risk LG-1-style sequence is:
 
-1. Hoist `resolveVar`/`resolveRep`.  Against the existing five-field record,
-   introduce a temporary, non-public `WorldInvariants W` companion containing
-   exactly the three drafted fields.  Prove preservation for the core builders
-   and require the companion at theorem boundaries, so failures are visible.
-2. Strengthen `rightOnlyWorld` and `rightBindTargetInsert` with a resolved-`★`
-   premise.  Thread it through `evolve-right-bind`, the generic `B₀` transport
-   surfaces, parked constructors, and smart wrappers.  Keep the `★` then
-   `＇ zero` route; add real evidence or redesign the arbitrary `＇ X`, `C`,
-   and generic-`B` sites.
-3. Resolve the remaining pressure points: strengthen both-bind allocation,
-   restrict left-only minting, guard store replacement and insertion/rebase,
-   and repair or retire invalid fixture worlds.  Use invariant (4), rather
-   than a cross-world compatibility alias, to reject non-`★` repark outputs.
+1. Add the total one-step `lookupStore` to `TyStore`.  Against the existing
+   five-field record, introduce a temporary, non-public `WorldInvariants W`
+   companion containing exactly the three drafted fields.  Prove preservation
+   for the core builders and require the companion at theorem boundaries.
+2. Strengthen `rightOnlyWorld` and `rightBindTargetInsert` with the selected
+   direct-entry classification.  Thread it through `evolve-right-bind`, the
+   generic `B₀` surfaces, parked constructors, and smart wrappers.  Under the
+   recommended form, retain the `★`-then-`＇ zero` route; add unmatched-head
+   evidence or redesign the arbitrary `＇ X`, `C`, and generic-`B` sites.
+3. Replace resolved-representation transport with pointwise lookup transport:
+   use the allocation premise directly in both-bind, add lookup commutation for
+   center renaming/insertion, restrict left-only minting, guard store
+   replacement and insertion/rebase, and repair or retire invalid fixtures.
+   Use invariant (4) to reject non-`★` repark outputs.
 4. After D15 lands, merge the companion fields into `World` atomically, change
    constructor calls and patterns to the eight-field shape, replace `WFWorld`
    arguments by the projection, and delete both `WFWorld` and the temporary
    companion.  Do not retain a compatibility alias in this closed-world repo.
-5. Remove `RebaseAt.storeRepresentations` once all callers use the world field,
-   and consolidate `initialWorldᴼ` into the canonical empty-store constructor.
+5. Derive chain coherence by store-age induction, remove
+   `RebaseAt.storeRepresentations` once callers use that lemma, and consolidate
+   `initialWorldᴼ` into the canonical empty-store constructor.
 
 PR #171 (`agent/gtsf-partner-redesign`, fetched head `faec619c`) changes 43
 `GTSFImp` files and touches `CastTermImprecision2`, `TargetExtend`,

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -522,6 +522,27 @@ and generic occupancy transport can remain if it has non-rule consumers.  The
 claim here is specifically that no target-absence fact needs to be threaded
 merely to reconstruct the see-through or D17(c) premise.
 
+### Invariant-(5) kill-check
+
+The recon probe imports the live-faithful S-OCC calibration worlds and
+reconstructs `ProjectionMismatchStarRepScratch.probe-world` exactly (the old
+scratch itself no longer passes coverage against the expanded live relation).
+It checks the first three Stage-1 fields separately from invariant (5).
+
+| World | Direct source entry / mark / occupancy | Verdict under (5) |
+| --- | --- | --- |
+| `ProjectionMismatchStarRepScratch.probe-world` | `★` / `X⊑★` / target `zero` center-aligned | **Illegal.** `projection-mismatch-stage1` checks that invariants (2)--(4) hold, while `projection-mismatch-rejects-invariant5` derives `⊥` from any extended validity. |
+| S-OCC aligned world `CTITighteningNarrowScratch.W` | `★` / `X⊑★` / target `zero` center-aligned | **Illegal.** `s-occ-aligned-stage1` checks the old fields and `s-occ-aligned-rejects-invariant5` checks the new rejection.  This is the concrete world underlying `aligned-occ`. |
+| S-OCC source-only world `CTIOccLiveFaithfulScratch.Wᵖ` | `★` / `X⊑★` / target context empty | **Legal.** `s-occ-prealignment-invariants` constructs the complete extended companion.  This is the concrete world underlying `pre-occ`. |
+
+The `CellOccupancy` values `aligned-occ` and `pre-occ` are calibration tags,
+not worlds; the verdicts above concern their actual `World` arguments.  The
+new invariant therefore kills the bad projection world, but it also removes
+the calibration's aligned world wholesale, including its good matched-seal
+examples.  The pre-alignment see-through world remains legal.  Stage 2 must
+account for that stronger semantic choice; it cannot claim that (5) isolates
+only the bad term derivation inside an otherwise valid aligned world.
+
 ## Validation
 
 The standalone probe is safe, has no postulates, holes, or option pragmas, and

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -396,6 +396,30 @@ blast overlaps almost every migration site.  Land D15 first, then rebase D16
 and perform step 4.  The temporary companion work can be prepared before that
 merge, but it must not become a second permanent world API.
 
+## Recon addendum: invariant (5)
+
+The user's additional runtime discipline is compatible with the direct-entry
+design above.  During Stage 1 it should be a fourth field of the temporary
+`WorldInvariants` companion; when the companion is merged, it becomes the
+ninth field of `World`.  The checked draft in
+`notes/probes/T15Invariant5ReconProbe.agda` is:
+
+```agda
+    dynamicStarSourcesUnoccupied :
+      ∀ (Xᴸ : TyVar Δᴸ)
+      → CTI2.impEnvʷ W (toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ) ≡ X⊑★
+      → lookupStore (CTI2.sourceStoreʷ W) Xᴸ ≡ ★
+      → ∀ (Xᴿ : TyVar Δᴿ)
+      → toRenameᵗ (CTI2.ηᴿʷ W) Xᴿ
+        ≢ toRenameᵗ (CTI2.ηᴸʷ W) Xᴸ
+```
+
+This is deliberately a direct-source-entry condition.  It neither follows a
+source representation chain nor inspects the target store.  The conclusion
+says exactly that the source center has no target occupant.  The probe also
+checks the field for the amended empty-store `initialWorld`: every direct
+entry in `emptyStore` is its structurally bound variable, never `★`.
+
 ## Validation
 
 The standalone probe is safe, has no postulates, holes, or option pragmas, and

--- a/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
+++ b/GTSFImp/proof/DGG/notes/t15-world-invariants-design.red
@@ -1,8 +1,16 @@
 # T15: D16 world invariants design
 
-Status: recon and checked declarations only.  No live definition or proof was
-changed.  The declarations and counterexample checks in this note are checked
-by `proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda`.
+Migration status:
+
+- **LANDED:** the `WorldInvariants` companion module and its import from
+  `All.agda`, preservation proofs for the core world builders, the `TyStore`
+  extension, fixture repairs, and the Stage-2 additions.
+- **STILL PROPOSED:** the Stage-3 atomic merge of the companion fields into the
+  `World` record.  Until that merge, `World` remains the five-field record and
+  the invariants remain in the companion.
+
+The declarations and counterexample checks that motivated the migration are
+checked by `proof/DGG/notes/probes/T15WorldInvariantsDesignProbe.agda`.
 
 ## Decision
 


### PR DESCRIPTION
Recon+draft for the user's D16 directive. Drafted (type-checked): the seven-field World — the five current fields plus merged WFWorld (preciseAligned) and the representation-imprecision field (raw env-indexed imprecision, avoiding the ⊑ᵂ circularity; resolveRep hoisted above World; unconditional on the center mark), and the EMPTY-STORE initialWorld (compile-preserves-embedded² tolerates it; the public compile statement drops the arbitrary Σ). Six pressure points inventoried — notably bothBindWorld lacking the fresh-rep witness (callers have it, builder doesn't expose it), generic liftWorldLeft/leftOnlyWorld failing precise-alignment at X⊑X, and TWO EXAMPLE WORLDS THAT ALREADY VIOLATE merged WFWorld (latent incoherences the invariant would outlaw). KILL-CHECK: the D8a/T10 counterexample worlds SATISFY invariants (1)-(3) — each endpoint is locally coherent; the failure is cross-world partner stability under REPARKING. Staging: companion-record first (LG-1 style), atomic field merge after; #171-overlap noted (now merged, so the rebase order resolved itself). Invariant (4) (unmatched target ⟹ rep ★, added by the user after dispatch) is being folded in next — it plausibly targets EXACTLY the reparked configuration (the old target occupant loses its source partner and keeps a non-★ rep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)