### PR TITLE
Dispatcher residuals: packaged seal-★ discharged (D11 route 2); T12 world-cycle obstruction recorded (D18)

### DIFF
--- a/GTSFImp/proof/DGG/Catchup/StructuralValueDispatcherProof.agda
+++ b/GTSFImp/proof/DGG/Catchup/StructuralValueDispatcherProof.agda
@@ -4,22 +4,27 @@ module proof.DGG.Catchup.StructuralValueDispatcherProof where
 --   * Assembles the structural value-catch-up dispatcher from the checked
 --     base, source-frame, and target-cast rows.
 --   * Exposes the remaining source-Λ and conversion-frame heads as named,
---     syntax-pinned residuals.
+--     syntax-pinned residuals; discharges packaged `seal ★` by D11 route 2.
 --   * Uses direct structural recursion on the CTI derivation; recursive
 --     calls are never passed as higher-order arguments.
 
+open import Data.Empty using (⊥-elim)
+open import Data.Maybe using (just)
 open import Data.Nat using (ℕ; suc; _<_)
 open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality using (sym)
   renaming (subst to subst≡)
 
 open import Types using (Ty)
+open import TyStore using (TyStore)
 open import Consistency using (Env∼; _⊢_∼_)
 open import Conversion using (Conv↑; Conv↓; seal)
+import Conversion as Conv
 import CastTerms as CT
 open import CastTerms using (Term; Value; _《_》; _↑_; _↓_; Λ_)
 open import Reduction using (applyConsistencies)
 open import proof.Reduction using (castSize-applyConsistencies)
+open import proof.Reduction.ValueIrreducibleProof using (value-no-step)
 
 import proof.DGG.CastTermImprecision as CTI2
 import proof.DGG.CtxImp as CTX
@@ -34,8 +39,20 @@ open import proof.DGG.Catchup.StructuralCatchupRightDef using
   (StructuralCatchupRightResult; StructuralExtraCastRightAt;
    StructuralValueCatchupRightAt; structural-catchup-refl;
    structural-catchup-source-cast; structural-catchup-source-reveal;
+   structural-catchup-target-conceal; structural-target-conceal-just;
    structural-catchup-compose-target-cast;
    structural-catchup-compose-paired-target-cast)
+open import proof.DGG.Catchup.StructuralFrameOutcomeDef using
+  (structural-frame-value)
+
+
+pivoted-conceal-value : ∀ {Δ} {Σ : TyStore Δ}
+    {X : Types.TyVar Δ} {A B : Ty Δ} {c : Conv↓ Δ A B}
+  → Σ Conv.⊢↓[ just X ] c
+  → CT.ConcealValue c
+pivoted-conceal-value (Conv.⊢↓-sealˣ X∈) = CT.seal
+pivoted-conceal-value (Conv.⊢↓-⇒ˣ join c⊢ d⊢) = CT.fun
+pivoted-conceal-value (Conv.⊢↓-∀ˣ c⊢) = CT.all
 
 
 record StructuralValueCatchupResiduals (fuel : ℕ) : Set₁ where
@@ -111,19 +128,6 @@ record StructuralValueCatchupResiduals (fuel : ℕ) : Set₁ where
       → (rel : W ∣ γ ⊢² M ↓ c ⊑ N ↓ c′ ∶ q)
       → TargetCastBound fuel rel
       → StructuralCatchupRightResult W γ (M ↓ c) (N ↓ c′) q
-
-    packaged-seal-star : ∀ {Δᴸ Δᴿ Δ}
-        {W : World Δᴸ Δᴿ Δ} {γ : CtxImp W}
-        {M : Term Δᴸ} {N : Term Δᴿ}
-        {Xᴸ : Types.TyVar Δᴸ} {Xᴿ : Types.TyVar Δᴿ}
-        {q : Types.＇ Xᴸ ⊑ᵂ⟨ W ⟩ Types.＇ Xᴿ}
-      → Value (M ↓ seal Xᴸ Types.★)
-      → (rel : W ∣ γ ⊢² M ↓ seal Xᴸ Types.★
-          ⊑ N ↓ seal Xᴿ Types.★ ∶ q)
-      → TargetCastBound fuel rel
-      → StructuralCatchupRightResult W γ
-          (M ↓ seal Xᴸ Types.★) (N ↓ seal Xᴿ Types.★) q
-
 
 structural-value-catchup-right-at : ∀ {fuel}
   → StructuralValueCatchupResiduals fuel
@@ -217,6 +221,25 @@ structural-value-catchup-right-at residuals extra-worker
     vM rel@(CTI2.conceal⊑conceal² _ _ _ _ _ _ _ _) bound =
   StructuralValueCatchupResiduals.paired-conceal residuals vM rel bound
 structural-value-catchup-right-at residuals extra-worker
-    vM rel@(CTI2.packaged-seal-star² _ _ _ _ _ _ _ _ _) bound =
-  StructuralValueCatchupResiduals.packaged-seal-star
-    residuals vM rel bound
+    vM (CTI2.packaged-seal-star² {Xᴿ = Xᴿ}
+      partner mono rb sc c⊢ c′⊢ rel pkg-rel q)
+    (bound , pkg-bound) =
+  structural-catchup-target-conceal mono (CTX.rebase-varᴿ rb) sc c′⊢
+    child (structural-frame-value sealed-value)
+    (λ plan frame-rel step finalV →
+      ⊥-elim (value-no-step sealed-value step))
+  where
+  child = structural-value-catchup-right-at residuals extra-worker
+    vM pkg-rel pkg-bound
+  plan = StructuralCatchupRightResult.structural-ext child
+  premise-c′⊢ =
+    subst≡
+      (λ Σ → Σ Conv.⊢↓[ just Xᴿ ] seal Xᴿ Types.★)
+      (CTX.SameRuntime.targetStore-same
+        (CTX.RebaseAt.sameRuntime rb))
+      c′⊢
+  applied-conceal-value = pivoted-conceal-value
+    (structural-target-conceal-just plan premise-c′⊢)
+  sealed-value =
+    StructuralCatchupRightResult.final-value child CT.↓
+      applied-conceal-value

--- a/GTSFImp/proof/DGG/notes/d18-rebase-tightening-design.red
+++ b/GTSFImp/proof/DGG/notes/d18-rebase-tightening-design.red
@@ -1,0 +1,722 @@
+D18 rebase tightening design
+=============================
+
+Date: 2026-08-19
+
+Status: RECON + DRAFT ONLY.  The live relation and every existing source file
+are unchanged.  The declaration probe is
+`proof/DGG/notes/probes/D18RebaseTighteningProbe.agda`.
+
+D18 chooses the functional-origin direction from option 2: for the rule-facing
+paired rebase, the destination world and the two pivots select one exact origin
+world.  This is the strongest useful condition: it pins the origin's source
+pivot and marks as well as its already-frozen fields, and it gives the exact
+`W ≡ Wcore` needed by the T12 synchronized peel.
+
+The recon also finds a real migration conflict.  The current, unrestricted
+relation cannot itself satisfy global origin uniqueness.  The checked T6
+Instance-B pair contains both
+
+```agda
+rb-X-Y : RebaseAt W W X Y
+rb-chain : RebaseAt Wᵖ W X Y
+```
+
+and `W ≢ Wᵖ`.  The probe checks this as
+`current-global-origin-uniqueness-refuted`.  These two worlds are also rejected
+by the decided D16 occupancy invariant, so this conflict is a kill check, not a
+reason to weaken D18 before D16 lands.  Generic strip/chain composition is the
+remaining live design question: any genuinely reachable version that emits
+both an immediate edge and a shortcut with the same destination and pivots
+must be split into rule-facing functional rebases and proof-local chain links.
+
+
+1. Current definitions and field audit
+--------------------------------------
+
+The current `RebaseAt` definition below is copied verbatim from
+`proof/DGG/CtxImp.agda`:
+
+```agda
+record RebaseAt {Δᴸ Δᴿ Δ} (W W′ : World Δᴸ Δᴿ Δ)
+    (Xᴸ : TyVar Δᴸ) (Xᴿ : TyVar Δᴿ) : Set where
+  constructor rebase-at
+  field
+    sameRuntime : SameRuntime W W′
+    ηᴸ-off-pivot : ∀ {Y} → Y ≢ Xᴸ
+      → toRenameᵗ (ηᴸʷ W′) Y ≡ toRenameᵗ (ηᴸʷ W) Y
+    ηᴿ-frozen : ∀ Y
+      → toRenameᵗ (ηᴿʷ W′) Y ≡ toRenameᵗ (ηᴿʷ W) Y
+    pivotAligned : toRenameᵗ (ηᴸʷ W′) Xᴸ ≡ toRenameᵗ (ηᴿʷ W′) Xᴿ
+    storeRepresentations : StoreRepImp W′ Xᴸ Xᴿ
+```
+
+Field-by-field:
+
+| Field | Determined now | Used by | Freedom left now | D18 disposition |
+|---|---|---|---|---|
+| `sameRuntime` | Source and target stores of `W` and `W′` are equal. | Conversion typing, typing extraction, decay, bind-lift/target-extension transport, strip/chain composition. | It says nothing about either embedding or either mark environment. | Keep as a local legality check.  `origin-determined` also pins the exact origin stores, but this field still states the intended edge invariant at the use site. |
+| `ηᴸ-off-pivot` | Every source variable except `Xᴸ` has the same center in destination and origin. | Source-strip, target-strip/descent/walk, seal-transfer composition, occupancy, rename/extension transports. | The origin center of `Xᴸ` is completely unconstrained.  This is the precise W/Wcore hole. | Keep, and additionally determine the entire origin world.  The origin pivot is then pinned, not merely the off-pivot fragment. |
+| `ηᴿ-frozen` | Every old target center is fixed. | Target pivot uniqueness, partner transport, center-crossing refutations, all inversion chains and transports. | No target-embedding freedom remains. | Keep verbatim. |
+| `pivotAligned` | In `W′`, `Xᴸ` and `Xᴿ` share a center. | Partner classifiers, tag pedigree, source/target seal transfer, same-world rebuilds. | It constrains only the destination.  It neither says where `Xᴸ` was in `W` nor who occupied that old center. | Keep; origin selection adds the missing predecessor fact. |
+| `storeRepresentations` | The canonical representations of the destination pivots are related in `W′`. | Typing, source-star packages, decay, chain and tag transfer. | It does not select an origin.  Several source placements can share the same stores and destination representation proof. | Keep.  D16 supplies the global representation/occupancy invariants; D18 does not duplicate them. |
+
+The current one-sided source wrapper is copied verbatim because it explains the
+`nothing` and unmatched cases:
+
+```agda
+data RebaseAtᴸ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Set where
+  rebase-idᴸ : ∀ {W}
+      ------------------------
+    → RebaseAtᴸ W W nothing
+
+  rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt W W′ Xᴸ Xᴿ
+      ---------------------------
+    → RebaseAtᴸ W W′ (just Xᴸ)
+
+  -- A source pivot with no aligned target variable.  The target views
+  -- the pivot's center as dynamic, so its canonical representation
+  -- must sit below ★; there is no alignment to change, so the world
+  -- stays fixed.  Type imprecision has no rule with a bare variable on
+  -- the imprecise side, so RebaseAtᴿ needs no mirror constructor.
+  -- The disalignment premise makes "no aligned target variable"
+  -- explicit: no target variable embeds at the pivot's center, which
+  -- lets inversion refute the X⊑X view of a concealed pivot.
+  rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (ηᴿʷ W) Xᴿ ≢ toRenameᵗ (ηᴸʷ W) Xᴸ)
+    → resolveVar (sourceStoreʷ W) Xᴸ ⊑ᵂ⟨ W ⟩ ★
+      -------------------------
+    → RebaseAtᴸ W W (just Xᴸ)
+```
+
+The current tagged source wrapper is copied verbatim:
+
+```agda
+data TagRebaseAtᴸ {Δᴸ Δᴿ Δ}
+    : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Maybe (TyVar Δᴿ) → Set where
+  tag-rebase-idᴸ : ∀ {W}
+      ----------------------------------
+    → TagRebaseAtᴸ W W nothing nothing
+
+  tag-rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt W W′ Xᴸ Xᴿ
+      ---------------------------------------
+    → TagRebaseAtᴸ W W′ (just Xᴸ) (just Xᴿ)
+
+  tag-rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → impEnvʷ W (toRenameᵗ (ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (ηᴿʷ W) Xᴿ
+            ≢ toRenameᵗ (ηᴸʷ W) Xᴸ)
+    → resolveVar (sourceStoreʷ W) Xᴸ ⊑ᵂ⟨ W ⟩ ★
+      -------------------------------------------------
+    → TagRebaseAtᴸ W W (just Xᴸ) nothing
+```
+
+The current target wrapper is copied verbatim:
+
+```agda
+data RebaseAtᴿ {Δᴸ Δᴿ Δ} : World Δᴸ Δᴿ Δ → World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴿ) → Set where
+  rebase-idᴿ : ∀ {W}
+      ------------------------
+    → RebaseAtᴿ W W nothing
+
+  rebase-varᴿ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt W W′ Xᴸ Xᴿ
+      ---------------------------
+    → RebaseAtᴿ W W′ (just Xᴿ)
+```
+
+The identity and source-only constructors already determine both worlds by
+their indices.  D18 changes only their policy parameter and leaves their
+geometry intact.  The paired `var` constructors inherit functional origin
+selection from `RebaseAt`.
+
+The current freedoms that are actually exercised are:
+
+- moving the source pivot while every target center stays frozen;
+- allowing different mark environments across an edge, governed by the rule's
+  separate `ImpEnvMono` premise;
+- decaying the origin and destination by different, explicitly supplied decay
+  proofs;
+- composing two local source movements into a proof-local shortcut; and
+- rebuilding the edge under center renaming, target insertion, bind lift, and
+  smart-comma worlds.
+
+The freedoms never used as semantic choices are arbitrary store change,
+arbitrary target movement, or arbitrary off-pivot source movement.  Every
+producer proves those components fixed.  The origin pivot and origin marks are
+chosen by surrounding history, but that history is not recorded in the
+relation.  D18 records exactly that missing choice.
+
+
+2. Necessity inventory: all rule premises
+-----------------------------------------
+
+All live `⊢²` constructors with a rebase premise are:
+
+| Constructor | Rebase premise and direction | What the rule determines | Current unused freedom relevant to D18 |
+|---|---|---|---|
+| `⊑reveal²` | `RebaseAtᴿ W W′ Xᴿ?` | Conclusion `W`, premise `W′`, target conversion pivot, stores and `ImpEnvMono W W′`.  In the `just` branch inversion recovers a hidden source pivot. | The same `(W′, Xᴸ, Xᴿ)` can currently accept another origin. |
+| `⊑conceal²` | `RebaseAtᴿ W′ W Xᴿ?` | Conclusion is the rebase destination; premise is its origin.  The conversion fixes the target pivot. | No fact says this premise is the origin selected by a surrounding matching reveal. |
+| `reveal⊑²` | `RebaseAtᴸ W W′ Xᴸ?` | Source reveal fixes `Xᴸ?`; the paired branch recovers `Xᴿ`, while `nothing` is identity and `rebase-onlyᴸ` is same-world unmatched. | In the paired branch, the old source-pivot center and marks are not recoverable from `W′`. |
+| `conceal⊑²-seal-star-open` (D15) | `TagRebaseAtᴸ W′ W (just X) nothing` | No target occupant, dynamic mark, representation below `★`, and same world by constructor. | None: `tag-rebase-onlyᴸ` already forces `W′ ≡ W`. |
+| `conceal⊑²-source-ok` (D17) | `TagRebaseAtᴸ W′ W Xᴸ? Xᴿ?` | The classifier fixes the allowed source/target head shape and the tag pivot pedigree.  `nothing/nothing` and unmatched `just/nothing` are same-world. | Only the paired `just/just` branch has the missing origin choice. |
+| `reveal⊑reveal²` | `RebaseAt W Wᵖ Xᴸ Xᴿ` | Both conversions expose the same indexed pivots; destination alignment and representation are explicit. | This outer edge does not identify its origin with the origin of an immediately nested inverse conceal. |
+| `conceal⊑conceal²` | `RebaseAt Wᵖ W Xᴸ Xᴿ` | Both seals and the matched partner use the same pivots. | When used as the immediate premise of the matching reveal, `Wᵖ` may currently be any legal origin of `W`. |
+| `packaged-seal-star²` | `RebaseAt Wᵖ W Xᴸ Xᴿ` | Same paired seal geometry, plus both the `★` payload and source-sealed package in `Wᵖ`. | Same missing origin choice as ordinary paired conceal. |
+
+There are no other `⊢²` rebase-carrying constructors in
+`CastTermImprecision.agda`.  `cast⊑cast²`, `⊑cast²`, and `cast⊑²` stay in one
+world and carry no rebase.
+
+
+3. Necessity inventory: proof scenarios
+---------------------------------------
+
+### Catch-up replay and structural extension
+
+`Catchup/StructuralSourceRebaseReplayProof.agda` replays source reveal and both
+source-conceal rows after `StructuralWorldRebaseProof` or
+`StructuralWorldTagRebaseProof` extends the target.  The input boundary stack
+determines the old origin, the target-extension plan determines both new
+worlds, and the conversion determines the pivot.  The proof does not choose a
+second origin for the same replay.  D18 therefore needs policy naturality under
+each structural target extension; it does not need origin ambiguity.
+
+`Catchup/StructuralCatchupRightDef.agda` performs the analogous pullbacks for
+all source/target/paired wrapper cases.  Again, its result record determines
+both worlds.  The only unavailable datum is a proof that `originAt` commutes
+with the extension or pullback.
+
+`Catchup/InstInversionLambdaProof.agda:784,805,2572,2699` constructs four
+route-1 rebases from explicit generated worlds.  Every current field is
+derived.  These sites can nominate their exact origin, but must be checked for
+schedule-key collisions after D16 invalid worlds are removed.
+
+### Target-blame boundary stack
+
+`TargetBlameCatchupProof.TargetBlameBoundary` stores each source reveal as
+`TagRebaseAtᴸ W₀ W₁` and each source conceal as the reverse-shaped
+`TagRebaseAtᴸ W₁ W₀`.  `SimProof` and `SimBackProof` push the same evidence via
+`toTagRebaseAtᴸ` or `tag-rebase-varᴸ`; they do not mint an alternative origin.
+The stack therefore determines the origin from its predecessor node.  D18
+keeps the stack.  Migration adds the selected policy and proves that the
+forward and reverse uses refer to the same scheduled edge.
+
+Crucially, D18 does not add `impEnvʷ W ≡ impEnvʷ W′`.  The boundary stack needs
+its separate `ImpEnvMono`, and decay may change marks.  Exact mark coherence is
+only between two alleged origins for the same scheduled destination/pivots.
+
+### Strip, descent, walk, and chain inversions
+
+The following helpers reconstruct `rebase-at` values:
+
+- `Inversion/SourceStripWorkerProof.agda:118`;
+- `Inversion/TargetDescentProof.agda:99`;
+- `Inversion/TargetStripProof.agda:125,213,357`;
+- `Inversion/TargetWalkSupport.agda:148,684,745,778`; and
+- `SealTransferCore.agda:64`.
+
+They determine stores by transitivity, target embeddings by repeated
+`ηᴿ-frozen`, off-pivot source embeddings by case analysis, destination
+alignment from the outer link, and destination representations from the outer
+link.  Several deliberately choose the earliest/accumulator world as the new
+origin.  This is not unused freedom: `composeSourceRebase` consumes
+`Wₗ → W₁` and `W₂ → Wₗ` and emits `W₂ → W₁` at the outer pivots.
+
+Consequently these outputs cannot automatically be rule-facing functional
+rebases if the immediate `Wₗ → W₁` edge remains live with the same destination
+and pivots.  The migration must do one of the following, in order of
+preference:
+
+1. show the conflicting composed output is unreachable once D16-valid worlds
+   are required;
+2. keep it as a proof-local `RebaseChainAt`/link witness that is not accepted by
+   `⊢²` constructors; or
+3. enrich the functional key with genuine wrapper ancestry and make matching
+   synchronized wrappers carry the same ancestry key.
+
+Weakening D18 back to arbitrary origins would reopen T12 and is not an option.
+
+The numerous `sameWorldRebaseAt` calls in source/target strip and target-chain
+proofs select the currently aligned world.  Under D18 they require the explicit
+fixed-point equation `W ≡ originAt policy W X Y`; alignment plus a
+representation proof alone no longer mints a scheduled edge.
+
+### Rename, decay, bind-lift, and target-extension transports
+
+`CenterRename.renameRebaseAt` maps both endpoints through one center OPE.
+It determines the renamed origin exactly.  D18 requires the naturality law
+
+```agda
+originAt policy (renameWorld π W′) X Y
+  ≡ renameWorld π (originAt policy W′ X Y).
+```
+
+`TermImpDecay.decayRebaseAt` accepts independent decays for the origin and
+destination.  D18 permits a result only when those decays respect the origin
+schedule.  Existing uses that dynamize only one side must either prove the
+scheduled origin is exactly that dynamized world or return a proof-local link.
+This is why destination/origin mark equality was not added to `RebaseAt`.
+
+`TargetBindLift` rebuilds four base rebases at
+`:813,836,968,992`; `TargetExtend` rebuilds/pulls back base rebases at
+`:2083,2140,2298,2458,3158`.  Both transformed worlds are explicit, so these
+sites need policy commutation laws, not additional geometric freedom.
+
+### T10 and T6 worlds
+
+T10 Probe 1 determines every current field explicitly:
+
+- `forward-rebase : RebaseAt W Wᵖ X Y-fresh` moves the source pivot from the
+  old paired center to the target-only center;
+- `reversed-rebase : RebaseAt Wᵖ W X Y-old` moves it back; and
+- `sameWorldRebaseAt` could also mint the destination-fixed edge at an aligned
+  endpoint.
+
+Under D16 invariant (5), `Wᵖ` is invalid: `X` has direct representation `★`,
+its center is marked `X⊑★`, and `Y-fresh` occupies that center.  `W` survives:
+the source is precise at its aligned old center, while the unmatched fresh
+target has representation `★`.  D18 therefore keeps `W` and kills `Wᵖ` plus
+the four parked-preservation counterclaims based on it.
+
+T6/`TerminusRebuildProbe.InstanceB` is the checked stronger collision.  Both
+`W` and `Wᵖ` mark the source center `X⊑★`, the source has direct representation
+`★`, and an aligned target (`Y` or `Y₂`) occupies that center.  D16 invariant
+(5) kills both worlds.  Before that kill, the live facts `rb-X-Y` and
+`rb-chain` refute unqualified origin uniqueness; the D18 probe proves the
+refutation without any assumption.
+
+The T6 wrong-pedigree laundering result remains a useful negative fixture, but
+it cannot remain a positive D16-valid runtime world.
+
+
+4. D18 tightened declarations
+------------------------------
+
+The following is the core draft verbatim from the checked probe.  The policy is
+a declaration parameter in the probe, not an asserted global inhabitant.  In
+the implementation it must be computed from the D16-valid world/provenance
+construction; it must not become an arbitrary caller-supplied escape hatch.
+
+```agda
+record OriginPolicy : Set₁ where
+  field
+    originAt : ∀ {Δᴸ Δᴿ Δ}
+      → CTX.World Δᴸ Δᴿ Δ
+      → TyVar Δᴸ
+      → TyVar Δᴿ
+      → CTX.World Δᴸ Δᴿ Δ
+
+open OriginPolicy public
+
+record RebaseAt (policy : OriginPolicy) {Δᴸ Δᴿ Δ}
+    (W W′ : CTX.World Δᴸ Δᴿ Δ)
+    (Xᴸ : TyVar Δᴸ) (Xᴿ : TyVar Δᴿ) : Set where
+  constructor rebase-at
+  field
+    origin-determined : W ≡ originAt policy W′ Xᴸ Xᴿ
+    sameRuntime : CTX.SameRuntime W W′
+    ηᴸ-off-pivot : ∀ {Y} → Y ≢ Xᴸ
+      → toRenameᵗ (CTX.ηᴸʷ W′) Y ≡ toRenameᵗ (CTX.ηᴸʷ W) Y
+    ηᴿ-frozen : ∀ Y
+      → toRenameᵗ (CTX.ηᴿʷ W′) Y ≡ toRenameᵗ (CTX.ηᴿʷ W) Y
+    pivotAligned :
+      toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ ≡
+        toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ
+    storeRepresentations : CTX.StoreRepImp W′ Xᴸ Xᴿ
+```
+
+This is maximal in the required direction.  `origin-determined` pins the whole
+origin record, so it includes:
+
+- the origin source-pivot embedding;
+- every off-pivot source embedding;
+- the target embedding;
+- both runtime stores; and
+- the entire origin imprecision environment.
+
+It deliberately does not equate the origin with the destination.  Moving
+source rebases remain possible, and the origin/destination marks may differ.
+
+The checked same-world constructor is:
+
+```agda
+sameWorldRebaseAt : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → W ≡ originAt policy W Xᴸ Xᴿ
+  → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ ≡
+      toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+  → CTX.StoreRepImp W Xᴸ Xᴿ
+  → RebaseAt policy W W Xᴸ Xᴿ
+sameWorldRebaseAt origin aligned reps =
+  rebase-at origin (CTX.same-runtime refl refl)
+    (λ _ → refl) (λ _ → refl) aligned reps
+```
+
+The one-sided and tagged draft is verbatim:
+
+```agda
+data RebaseAtᴸ (policy : OriginPolicy) {Δᴸ Δᴿ Δ} :
+    CTX.World Δᴸ Δᴿ Δ → CTX.World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Set where
+  rebase-idᴸ : ∀ {W}
+    → RebaseAtᴸ policy W W nothing
+
+  rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt policy W W′ Xᴸ Xᴿ
+    → RebaseAtᴸ policy W W′ (just Xᴸ)
+
+  rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ ≢
+          toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)
+    → CTX.resolveVar (CTX.sourceStoreʷ W) Xᴸ CTX.⊑ᵂ⟨ W ⟩ ★
+    → RebaseAtᴸ policy W W (just Xᴸ)
+
+data TagRebaseAtᴸ (policy : OriginPolicy) {Δᴸ Δᴿ Δ} :
+    CTX.World Δᴸ Δᴿ Δ → CTX.World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Maybe (TyVar Δᴿ) → Set where
+  tag-rebase-idᴸ : ∀ {W}
+    → TagRebaseAtᴸ policy W W nothing nothing
+
+  tag-rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt policy W W′ Xᴸ Xᴿ
+    → TagRebaseAtᴸ policy W W′ (just Xᴸ) (just Xᴿ)
+
+  tag-rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ ≢
+          toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)
+    → CTX.resolveVar (CTX.sourceStoreʷ W) Xᴸ CTX.⊑ᵂ⟨ W ⟩ ★
+    → TagRebaseAtᴸ policy W W (just Xᴸ) nothing
+
+forgetTagRebaseᴸ : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+  → TagRebaseAtᴸ policy W W′ Xᴸ? Xᴿ?
+  → RebaseAtᴸ policy W W′ Xᴸ?
+forgetTagRebaseᴸ tag-rebase-idᴸ = rebase-idᴸ
+forgetTagRebaseᴸ (tag-rebase-varᴸ rb) = rebase-varᴸ rb
+forgetTagRebaseᴸ (tag-rebase-onlyᴸ to-star disaligned represented) =
+  rebase-onlyᴸ to-star disaligned represented
+
+data RebaseAtᴿ (policy : OriginPolicy) {Δᴸ Δᴿ Δ} :
+    CTX.World Δᴸ Δᴿ Δ → CTX.World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴿ) → Set where
+  rebase-idᴿ : ∀ {W}
+    → RebaseAtᴿ policy W W nothing
+
+  rebase-varᴿ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt policy W W′ Xᴸ Xᴿ
+    → RebaseAtᴿ policy W W′ (just Xᴿ)
+```
+
+The rule migration is mechanical at the declaration level: add one implicit
+`policy` shared by the whole `⊢²` development and replace each premise by its
+policy-indexed form.  It is not sufficient to let each constructor choose its
+own policy; the synchronized outer and inner rules must use the same policy.
+
+
+5. Checked world-cycle closure
+------------------------------
+
+The probe checks the requested theorem:
+
+```agda
+origin-unique : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → RebaseAt policy W Wmid Xᴸ Xᴿ
+  → RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+  → W ≡ Wcore
+origin-unique outer inner =
+  trans (origin-determined outer) (sym (origin-determined inner))
+```
+
+It also checks the two important projections:
+
+```agda
+origin-source-pivot-unique : ...
+origin-marks-unique : ...
+```
+
+and the dependent transport actually needed by T12:
+
+```agda
+world-cycle-close : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    (P : CTX.World Δᴸ Δᴿ Δ → Set)
+  → RebaseAt policy W Wmid Xᴸ Xᴿ
+  → RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+  → P Wcore
+  → P W
+world-cycle-close P outer inner payload =
+  subst P (sym (origin-unique outer inner)) payload
+```
+
+Status: CHECKED, no holes or assumptions.  The exact command exited zero:
+
+```sh
+cd GTSFImp
+PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH \
+  agda -i . -i proof/DGG/notes/probes -v0 \
+  proof/DGG/notes/probes/D18RebaseTighteningProbe.agda
+```
+
+
+6. Mint check
+-------------
+
+`git grep` finds rebase declarations, constructors, eliminations, or transports
+in 64 live Agda modules (16 under `Catchup/`, 13 under `Inversion/`, and 35
+elsewhere).  The raw base-mint sites are finite; wrappers such as
+`rebase-varᴸ`, `rebase-varᴿ`, and `tag-rebase-varᴸ` merely preserve a base
+rebase and add no origin choice.
+
+The reproducible broad count, excluding notes and probes, is:
+
+```sh
+rg -l --glob '*.agda' --glob '!proof/DGG/notes/**' \
+  'RebaseAt|TagRebaseAt' . | wc -l
+# 64
+rg -n --glob '*.agda' --glob '!proof/DGG/notes/**' \
+  'RebaseAt|TagRebaseAt' . | wc -l
+# 1037
+```
+
+Verdict legend:
+
+- KEEP: the site has an exact origin and has no known conflicting key;
+- LAW: the site needs a proved `originAt` commutation law;
+- FLAG: the current producer can conflict with functional origin selection;
+- KILL: D16 rejects the fixture world; and
+- SAME: locally possible only after supplying the new fixed-point equation.
+
+### Direct `rebase-at` producers
+
+| Live sites | Count | Verdict | Required D18 evidence |
+|---|---:|---|---|
+| `CtxImp.sameWorldRebaseAt:415` | 1 | SAME | Add `W ≡ originAt policy W X Y`; alignment and representation no longer suffice alone. |
+| `Example12Worlds:122,129,257`; `Examples2:234` | 4 | KEEP/FLAG | The explicit origin is known.  `example12-rebase-X-to-Y` conflicts by key with the exercised `example12-rebase-Z-to-Y`; grep shows the former has no use, so delete it during migration.  Schedule the other chain edges. |
+| `CenterCrossingProbe:190`; `MovedLinkProbe:185`; `TagBoundaryProbe:171,181` | 4 | KEEP as calibration | Each finite world identifies its origin.  Retain only instances whose worlds satisfy D16; otherwise turn them into negative fixtures. |
+| `TerminusRebuildProbe:312` | 1 | KILL/FLAG | This is `InstanceB.rb-chain`, conflicting with `rb-X-Y`.  Both endpoint worlds violate D16 invariant (5). |
+| `SmartCommaWitness:176,192` | 2 | KEEP pending collision check | Generated source and target worlds determine the origin.  Mint the corresponding policy entries when smart-comma worlds are created. |
+| `Catchup/InstInversionLambdaProof:784,805,2572,2699` | 4 | KEEP pending collision check | Route evidence determines both endpoints.  Thread a policy equation out of the route facts. |
+| `CenterRename:593` | 1 schema | LAW | Prove `originAt` commutes with `renameWorld`. |
+| `TermImpDecay:349` | 1 schema | LAW/FLAG | Require coherent endpoint decays.  Independently chosen decays do not automatically preserve a scheduled origin. |
+| `TargetBindLift:813,836,968,992` | 4 schemata | LAW | Prove policy commutation with `targetStoreAs`/bind lift in forward and backward directions. |
+| `TargetExtend:2083,2140,2298,2458,3158` | 5 schemata | LAW | Prove policy preservation/reflection under insert, pullback, and lifted-world construction. |
+| `SourceStripWorkerProof:118`; `TargetDescentProof:99`; `TargetStripProof:125,213,357`; `TargetWalkSupport:148,684,745,778`; `SealTransferCore:64` | 10 schemata | FLAG | These include composition/shortcut producers.  They can return functional rebases only if their chosen origin equals the schedule.  Otherwise return a proof-local chain/link witness. |
+
+The input-pattern occurrences at `CenterRename:592`, `TargetBindLift:810,833,
+964,988`, `TargetExtend:3155`, and `TermImpDecay:347` invert an existing
+rebase; they are not additional mints.
+
+### `sameWorldRebaseAt` producers
+
+All calls need the new fixed-point equation.  The complete live call groups are:
+
+- `CenterCrossingProbe:199`;
+- `ChainRideProbe:173,176`;
+- `Examples2:437,971,1431,1497,1503,1784,1790,1804,1810,2076,2404,2410,2416`;
+- `Inversion/SourceStripProof:98`;
+- `Inversion/SourceStripWorkerProof:208,244`;
+- `Inversion/TargetChainProof:436,447,459,474,528,539,554,675,692,720`;
+- `Inversion/TargetStripProof:1527,1536`;
+- `MovedLinkProbe:198`;
+- `Parked/ParkedD4CheckpointProof:54`;
+- `Phase3DeepDives:127,469`;
+- `SealPeelProbe:216`;
+- `SealTransferCore:259,430`;
+- `SourceStarProbe:110,113`;
+- `StarRepChainProbe:166`;
+- `TagBoundaryProbe:191,195`; and
+- `TerminusRebuildProbe:145,305,308`.
+
+Most finite example calls are KEEP/SAME: their world builder should mint a
+fixed-point policy entry for that pivot pair.  The generic inversion calls are
+FLAG/SAME because they derive a same-world rebase from arbitrary input
+alignment.  D18 forbids that derivation unless the input policy selects the
+same world.  The T6 calls at `TerminusRebuildProbe:305,308` are KILL with the
+invalid Instance-B worlds.
+
+### Identity and unmatched one-sided mints
+
+`rebase-idᴸ`, `rebase-idᴿ`, and `tag-rebase-idᴸ` remain KEEP: their indices
+force the same world and they carry no paired origin.
+
+`rebase-onlyᴸ` and `tag-rebase-onlyᴸ` also remain KEEP.  Their constructors
+already require the same world, a dynamic mark, no target occupant, and the
+source representation below `★`.  Direct positive sites occur in
+`LambdaImpProbe`, `Examples2`, and `StarRepChainProbe`; rename, decay,
+target-extension, bind-lift, structural-world, and right-injection code only
+transports or re-emits that same evidence.  None needs `originAt`.
+
+### Wrapping and inversion-only sites
+
+Every `rebase-varᴸ`, `rebase-varᴿ`, or `tag-rebase-varᴸ` construction is KEEP
+iff its base rebase passes the table above.  `forgetTagRebaseᴸ`,
+`toTagRebaseAtᴸ`, `toTagRebaseAtᴿ`, target-pivot/source-pivot projection,
+typing extraction, occupancy, and the blame stack only invert or rewrap the
+base witness; they introduce no new freedom.
+
+
+7. Kill/keep and T12 verdicts
+--------------------------------
+
+### D16 fixture worlds
+
+The current branch contains the D16 directive in `PLAN.md`, not the separate
+PR #177 world-record implementation.  Against the exact decided invariants:
+
+| Fixture | Verdict | Reason |
+|---|---|---|
+| T10 `W` | KEEP | Its source is precise and aligned at the old center; its unmatched fresh target resolves to `★`. |
+| T10 `Wᵖ` | KILL | Dynamic direct-`★` source `X` has aligned target occupant `Y-fresh`, violating D16 invariant (5). |
+| T6/Terminus Instance-B `W` | KILL | Dynamic direct-`★` source `X` is aligned with `Y`. |
+| T6/Terminus Instance-B `Wᵖ` | KILL | Dynamic direct-`★` source `X` is aligned with `Y₂`. |
+| T6 laundering inhabitants built from these worlds | KILL as runtime fixtures | They may remain negative relation-calibration records, but are not D16-valid worlds. |
+
+This is a design-level verdict.  Once PR #177's actual record is joined, its
+constructors must be applied to these fixtures and type-checked again.
+
+### T12 two-sided peels
+
+Paired ordinary conceal/reveal: PROVABLE after the rule migration.  Inversion
+gives
+
+```agda
+outer : RebaseAt policy W Wmid Xᴸ Xᴿ
+inner : RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+```
+
+so `origin-unique outer inner : W ≡ Wcore`.  After rewriting, compose the two
+`SameCtx` values, use the existing same-context transport (proof witnesses are
+unique by `proof.Imprecision.⊑-unique`), and retarget the endpoint witness.
+
+Paired packaged `seal ★`: PROVABLE by the same equality.  The packaged row
+already contains both payload derivations in `Wcore`; D18 supplies the missing
+world rewrite.
+
+Source-only conceal/reveal: PROVABLE in both constructor shapes after
+inversion.  A `just/just` paired branch uses `origin-unique`; the identity and
+`just/nothing` unmatched branches already force the worlds equal.  The D17
+partner pedigree must remain the same across the two inverted wrappers.
+
+Independent T12 gap: KEEP OPEN.  Plain target-only heads `⊑reveal²` and
+`⊑conceal²` still do not match the approved source-wrapper continuation fields,
+as recorded by `t1-direct-target-frame-certificate-proposal.red`.  D18 closes
+the W/Wcore cycle only; it does not invent those continuation cases.
+
+### Target-blame boundary stack
+
+KEEP.  The stack records the actual predecessor at every source wrapper and
+already carries `ImpEnvMono`.  It needs policy threading and naturality through
+the transports used by catch-up, but no rule or recursive case becomes
+semantically invalid.  Do not equate origin and destination marks: that would
+break this stack's decay discipline.
+
+
+8. Migration plan and blast radius
+----------------------------------
+
+The grep blast radius is 64 live modules and 1,037 raw matching lines for
+`RebaseAt|TagRebaseAt` after excluding `proof/DGG/notes/`.  Most changes are
+signature threading; the semantic hotspots are the raw mint table above.
+
+### Stage 0. Land D16 validity first
+
+Join the D16 world-record work, enforce invariants at every world constructor,
+and delete or move the invalid T10/T6 positive fixtures.  Re-run their negative
+checks in the D16 record.  This removes the checked functional-origin
+collision before D18 is made live.
+
+### Stage 1. Define the canonical origin schedule
+
+Implement `originAt` from real world/provenance construction, not as a freely
+chosen API argument.  State fixed-point rules for stationary paired worlds and
+edge rules for every moving world builder.  Prove that the selected origin has
+the current `SameRuntime`, frozen-target, off-pivot, alignment, and
+representation properties.
+
+### Stage 2. Pre-flight every base mint
+
+Copy the probe relation into a temporary notes pre-flight, instantiate the
+schedule for finite examples, and add the `origin-determined` proof to every
+raw producer in Section 6.  Delete unused
+`Example12Worlds.example12-rebase-X-to-Y` rather than keeping a compatibility
+fixture.
+
+Stop at every FLAG.  For strip/chain shortcuts, either prove D16
+unreachability or introduce a genuine proof-local chain relation that cannot
+be passed to `⊢²`.  Do not add an alias that silently recovers the old broad
+relation.
+
+### Stage 3. Prove policy transport laws
+
+In this order:
+
+1. center rename;
+2. coherent world decay;
+3. target insertion/pullback;
+4. target bind lift/store move;
+5. structural catch-up extension; and
+6. smart-comma generated worlds.
+
+Restrict the old independent-decay API if its two supplied endpoints do not
+respect the schedule.
+
+### Stage 4. Migrate the relation declarations
+
+Add the one shared policy to `RebaseAt`, `RebaseAtᴸ`, `TagRebaseAtᴸ`, and
+`RebaseAtᴿ`, then migrate all eight `⊢²` constructors from Section 2.  Update
+typing and simple projections first, then rename/decay, inversion, catch-up,
+simulation, examples, and catalogs.  Keep the full claim visible in rule
+statements; do not hide the policy in compatibility wrappers.
+
+### Stage 5. Land the T12 peels
+
+Implement paired, packaged, and source-only conceal/reveal peels using
+`origin-unique`, composed `SameCtx`, same-context transport, and endpoint
+retargeting.  Wire them into `LeftTwoSidedPeelPackage`.  Treat the independent
+plain-target continuation gap separately.
+
+### Stage 6. Delete obsolete broad machinery
+
+Delete the old unrestricted relation, any old arbitrary-decay or shortcut
+constructor that cannot prove `origin-determined`, and invalid fixtures.  Keep
+only a separately named chain/link judgment when it represents a genuine
+internal proof concept.
+
+### Stage 7. Gate
+
+Spot-check after each stage.  At the end run the requested full gate until it
+exits zero:
+
+```sh
+cd GTSFImp
+PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH make check
+```
+
+
+Bottom line
+-----------
+
+D18's exact functional-origin field is sufficient and checked.  It closes the
+T12 world cycle and pins origin pivot and marks without forbidding legitimate
+mark decay between origin and destination.  The current broad relation cannot
+be globally functional, but its concrete checked collision is eliminated by
+D16.  The only remaining reason to retain extra freedom is proof-local
+strip/chain composition; that freedom must be moved out of the rule-facing
+`RebaseAt`, not allowed to weaken synchronized origin uniqueness.

--- a/GTSFImp/proof/DGG/notes/d18-stage12-preflight.red
+++ b/GTSFImp/proof/DGG/notes/d18-stage12-preflight.red
@@ -1,0 +1,302 @@
+D18 Stage 1/2 origin-schedule pre-flight
+==========================================
+
+Date: 2026-08-19
+
+Status: NOTES-LEVEL PRE-FLIGHT ONLY.  D18 is signed off in the functional-
+origin direction.  This record and
+`probes/D18OriginSchedulePreflight.agda` do not change `CtxImp.World`, the
+live `CtxImp.RebaseAt`, or the live term-imprecision relation.  Nothing live
+was deleted.  In particular, `example12-rebase-X-to-Y` remains present until
+the live migration after D16 (#177).
+
+
+1. Stage 1 construction schedule
+--------------------------------
+
+The schedule is construction provenance, not a caller-supplied
+`OriginPolicy`.  A scheduled world contains its raw live `World` and an
+inductive `OriginSchedule` produced alongside that world.  `stationary` is
+the default fixed point.  `edge builder rb rest` records the predecessor of a
+moving paired pivot at the point where a real world builder creates that
+edge.  Lookup is deterministic: the first construction entry for the queried
+pivot pair wins, and an absent key falls through to the stationary world.
+Consequently, evidence composed later by strip or chain code cannot become a
+rule-facing edge merely by satisfying the old geometric fields.
+
+The sandbox deliberately has no free schedule function and no alias for the
+old broad relation.  Its only edge payload is the existing live geometric
+record, used as construction evidence so the pre-flight tests the actual
+`SameRuntime`, source/target embedding, alignment, and representation fields.
+The live version must hide schedule extension behind the D16-valid world
+builders; the public relation must only inspect the schedule.
+
+The `originAt` definition is verbatim from the checked probe (including its
+recursive lookup helper):
+
+```agda
+originAtSchedule : ∀ {Δᴸ Δᴿ Δ} {W′ : CTX.World Δᴸ Δᴿ Δ}
+  → OriginSchedule W′
+  → TyVar Δᴸ
+  → TyVar Δᴿ
+  → CTX.World Δᴸ Δᴿ Δ
+originAtSchedule {W′ = W′} stationary Xᴸ Xᴿ = W′
+originAtSchedule (edge {W = W} {Xᴸ = X₀ᴸ} {Xᴿ = X₀ᴿ}
+    builder rb rest) Xᴸ Xᴿ
+    with Fin._≟_ Xᴸ X₀ᴸ | Fin._≟_ Xᴿ X₀ᴿ
+originAtSchedule (edge {W = W} builder rb rest) ._ ._
+    | yes refl | yes refl = W
+originAtSchedule (edge builder rb rest) Xᴸ Xᴿ
+    | yes Xᴸ≡X₀ᴸ | no Xᴿ≢X₀ᴿ = originAtSchedule rest Xᴸ Xᴿ
+originAtSchedule (edge builder rb rest) Xᴸ Xᴿ
+    | no Xᴸ≢X₀ᴸ | yes Xᴿ≡X₀ᴿ = originAtSchedule rest Xᴸ Xᴿ
+originAtSchedule (edge builder rb rest) Xᴸ Xᴿ
+    | no Xᴸ≢X₀ᴸ | no Xᴿ≢X₀ᴿ = originAtSchedule rest Xᴸ Xᴿ
+
+originAt : ∀ {Δᴸ Δᴿ Δ}
+  → ScheduledWorld Δᴸ Δᴿ Δ
+  → TyVar Δᴸ
+  → TyVar Δᴿ
+  → CTX.World Δᴸ Δᴿ Δ
+originAt (scheduled W provenance) Xᴸ Xᴿ =
+  originAtSchedule provenance Xᴸ Xᴿ
+```
+
+The fixed-point rule is checked by `originAt-stationary` and consumed by
+`stationaryRebaseAt`:
+
+```agda
+originAt (stationaryWorld W) Xᴸ Xᴿ ≡ W
+```
+
+The head-edge equation is checked once for every construction tag by
+`originAt-edge` and `edgeRebaseAt`:
+
+```agda
+originAt (scheduled W′ (edge builder rb rest)) Xᴸ Xᴿ ≡ W
+```
+
+### Complete `CtxImp.agda` world-builder inventory
+
+The inventory is exhaustive for declarations in `CtxImp.agda` that return a
+`World`.  `SmartCommaLiftᴸ` is evidence relating caller-supplied worlds, not
+another `World`-valued builder.
+
+| Live construction | Schedule tag | Checked edge rule |
+|---|---|---|
+| raw `world` constructor | `world-builder` | `world-edge` |
+| `liftWorldBoth` | `liftWorldBoth-builder` | `liftWorldBoth-edge` |
+| `liftWorldLeft` | `liftWorldLeft-builder` | `liftWorldLeft-edge` |
+| `leftOnlyWorld` | `leftOnlyWorld-builder` | `leftOnlyWorld-edge` |
+| `rightOnlyWorld` | `rightOnlyWorld-builder` | `rightOnlyWorld-edge` |
+| `bothBindWorld` | `bothBindWorld-builder` | `bothBindWorld-edge` |
+
+These are construction-edge rules, not the Stage 3 naturality theorems.
+Center rename, decay, target insertion/pullback, bind lift, structural
+extension, and smart-comma transport must later prove that their output
+construction carries the corresponding tag and predecessor.  They may not
+create an arbitrary schedule after the fact.
+
+### Selected-origin properties
+
+The sandbox relation retains the exact D18 field
+`origin-determined : W ≡ originAt W′ Xᴸ Xᴿ`.  `edgeRebaseAt` constructs
+all six builder cases from `originAt-edge` and the real live record.  The
+following checked theorems then state the requested properties of the
+selected origin, rather than only of an independently supplied `W`:
+
+| Property | Checked theorem |
+|---|---|
+| source/target runtime stores agree | `selected-origin-sameRuntime` |
+| every non-pivot source center is frozen | `selected-origin-off-pivot` |
+| every target center is frozen | `selected-origin-target-frozen` |
+| destination pivots are aligned | `selected-origin-pivot-aligned` |
+| destination canonical representations are related | `selected-origin-representations` |
+
+
+2. Stage 2 finite instantiations
+--------------------------------
+
+The probe imports the live Example12 worlds rather than replacing them with
+abstract fixtures.  The scheduled finite path is
+
+$$
+
+  W_X \xrightarrow{(X,Z)} W_Z \xrightarrow{(X,Y)} W_Y.
+
+$$
+
+The corresponding checked tightened edges and origin equations are:
+
+```agda
+example12-rebase-X-to-Zᵀ
+example12-X-to-Z-origin-determined
+
+example12-rebase-Z-to-Yᵀ
+example12-Z-to-Y-origin-determined
+```
+
+The independent representation-to-`ℕ` example is also instantiated:
+
+```agda
+example12-nat-rebase-X-to-Yᵀ
+example12-nat-X-to-Y-origin-determined
+```
+
+The `W_Y, X, Y` key selects `W_Z`.  Therefore the unused live shortcut from
+`W_X` to `W_Y` is not merely omitted: the probe proves
+`example12-X-to-Y-not-origin-determined`.  No compatibility constructor or
+old-relation alias restores it.
+
+The two SmartComma raw target-wrapper mints are instantiated through the
+construction-only `target-producer-preflight` adapter.  The checked equations
+are `smart-comma-outer-origin-determined` and
+`smart-comma-inner-origin-determined`.
+
+
+3. Per-producer Stage 2 status
+------------------------------
+
+`PROVEN-IN-SANDBOX` means the producer's explicit predecessor is either the
+stationary fixed point or a construction edge and hence obtains
+`origin-determined` by `stationaryRebaseAt`, `edgeRebaseAt`, or
+`target-producer-preflight`.  This status is about D18 origin selection; it
+does not pre-approve a fixture under the not-yet-joined D16 `World` record.
+
+`FLAG:chain` means the output is composed after construction or otherwise
+lacks schedule coherence.  It must become a proof-local chain/link that no
+`⊢²` constructor accepts, unless a later D16 proof makes the branch
+unreachable.  `FLAG:D16-blocked` cites a concrete violation of D16 invariant
+(5): a runtime source name marked `X⊑★`, with direct representation `★`,
+has a center-aligned target occupant.
+
+### Direct `rebase-at` producers
+
+| Raw producer | Status | Sandbox evidence or verdict |
+|---|---|---|
+| `CtxImp.sameWorldRebaseAt:415` | PROVEN-IN-SANDBOX | `originAt-stationary`, `stationaryRebaseAt`. |
+| `Example12Worlds:122` (`X→Z`) | PROVEN-IN-SANDBOX | `example12-X-to-Z-origin-determined`. |
+| `Example12Worlds:129` (`X→Y`) | FLAG:chain | `example12-X-to-Y-not-origin-determined`; the scheduled origin of `(W_Y,X,Y)` is `W_Z`.  Delete this unused shortcut during the live migration. |
+| `Example12Worlds:257` (nat `X→Y`) | PROVEN-IN-SANDBOX | `example12-nat-X-to-Y-origin-determined`. |
+| `Examples2:234` (`Z→Y`) | PROVEN-IN-SANDBOX | `example12-Z-to-Y-origin-determined`. |
+| `CenterCrossingProbe:190` | FLAG:D16-blocked | In the destination, dynamic direct-`★` source `X₁` is aligned with target occupant `Y₀`; D16 invariant (5). |
+| `MovedLinkProbe:185` | FLAG:D16-blocked | Dynamic direct-`★` source `X` is aligned with a target occupant at each endpoint; D16 invariant (5). |
+| `TagBoundaryProbe:171,181` | FLAG:D16-blocked | Dynamic direct-`★` source `X` is aligned with `Y`/`Y′`; D16 invariant (5). |
+| `TerminusRebuildProbe:312` | FLAG:D16-blocked | `rb-chain`; both Instance-B endpoints violate D16 invariant (5).  `terminus-chain-not-origin-determined` independently checks the schedule conflict. |
+| `SmartCommaWitness:176,192` | PROVEN-IN-SANDBOX | `smart-comma-{outer,inner}-origin-determined`; the source cells are `store-lift` names, not direct-`★` source cells. |
+| `InstInversionLambdaProof:784,805,2572,2699` | PROVEN-IN-SANDBOX | Each `RebaseAtᴿ (just Y)` output feeds `target-producer-preflight`; route facts already determine both endpoint worlds.  Live target-insert naturality remains Stage 3. |
+| `CenterRename:593` | PROVEN-IN-SANDBOX | The renamed output is a construction edge and receives `origin-determined` via `edgeRebaseAt`; live `originAt`/`renameWorld` commutation remains Stage 3. |
+| `TermImpDecay:349`, coherent endpoints | PROVEN-IN-SANDBOX | The output construction records the coherently decayed predecessor and `edgeRebaseAt` applies. |
+| `TermImpDecay:349`, independently chosen endpoints | FLAG:chain | The current API does not prove that the decayed origin is the scheduled origin.  Restrict it to coherent decay or return a proof-local link. |
+| `TargetBindLift:813,836,968,992` | PROVEN-IN-SANDBOX | Explicit output endpoint pairs use the applicable builder edge.  Live forward/backward bind-lift naturality remains Stage 3. |
+| `TargetExtend:2083,2140,2298,2458,3158` | PROVEN-IN-SANDBOX | Explicit inserted/pulled-back endpoint pairs use the applicable builder edge.  Live insertion/reflection naturality remains Stage 3. |
+| `SourceStripWorkerProof:118` | FLAG:chain | Composed/shortcut producer; no construction edge. |
+| `TargetDescentProof:99` | FLAG:chain | Composed/shortcut producer; no construction edge. |
+| `TargetStripProof:125,213,357` | FLAG:chain | Composed/lifted shortcuts; retain a proof-local chain/link unless D16 proves a branch unreachable. |
+| `TargetWalkSupport:148,684,745,778` | FLAG:chain | Lift/composition shortcuts; no construction-origin proof. |
+| `SealTransferCore:64` | FLAG:chain | `composeSourceRebase` chooses an accumulator/earliest origin after construction. |
+
+The input-pattern occurrences called out in the D18 design remain
+eliminations, not mints.
+
+### `sameWorldRebaseAt` producers
+
+| Raw producer group | Status | Sandbox evidence or verdict |
+|---|---|---|
+| finite `Examples2` calls at `437,971,1431,1497,1503,1784,1790,1804,1810,2076,2404,2410,2416` | PROVEN-IN-SANDBOX | Mint a stationary construction key and use `stationaryRebaseAt`; D16 fixture validation still waits for Stage 0. |
+| `ChainRideProbe:173,176`; `Parked/ParkedD4CheckpointProof:54`; `Phase3DeepDives:127,469` | PROVEN-IN-SANDBOX | Finite stationary keys; `stationaryRebaseAt`.  D16 fixture validation still waits for Stage 0. |
+| `CenterCrossingProbe:199`; `MovedLinkProbe:198`; `TagBoundaryProbe:191,195` | FLAG:D16-blocked | Each aligned stationary world has a dynamic direct-`★` source and target occupant; D16 invariant (5). |
+| `SourceStarProbe:110,113`; `StarRepChainProbe:166`; `SealPeelProbe:216` | FLAG:D16-blocked | The paired stationary edge aligns a dynamic direct-`★` source with a target occupant; D16 invariant (5).  Source-only unmatched constructors are unaffected. |
+| `TerminusRebuildProbe:305,308` | FLAG:D16-blocked | Instance-B `W` and `Wᵖ`; D16 invariant (5). |
+| `Inversion/SourceStripProof:98`; `Inversion/SourceStripWorkerProof:208,244` | FLAG:chain | Generic alignment does not establish a scheduled stationary key. |
+| `Inversion/TargetChainProof:436,447,459,474,528,539,554,675,692,720` | FLAG:chain | Generic chain shortcut; requires the proof-local chain relation. |
+| `Inversion/TargetStripProof:1527,1536`; `SealTransferCore:259,430` | FLAG:chain | Generic strip/composition shortcut; requires the proof-local chain relation. |
+
+The remaining finite calls `MovedLinkProbe:198`, `TagBoundaryProbe:191,195`,
+and the other named calibration rows are not assigned both statuses: the
+concrete D16-blocked verdict takes precedence over their structurally valid
+stationary equation.
+
+### Identity, unmatched, and wrappers
+
+| Producer | Status | Reason |
+|---|---|---|
+| `rebase-idᴸ`, `rebase-idᴿ`, `tag-rebase-idᴸ` | PROVEN-IN-SANDBOX | Indices force one stationary world; there is no paired key. |
+| `rebase-onlyᴸ`, `tag-rebase-onlyᴸ` | PROVEN-IN-SANDBOX | Indices force one world and no aligned target occupant; `originAt` is not used. |
+| `rebase-varᴸ`, `rebase-varᴿ`, `tag-rebase-varᴸ` and inversion/rewrap helpers | same as wrapped base producer | They add no origin choice. |
+
+
+4. FLAG ledger
+--------------
+
+Every Stage 2 stop is recorded here; none was bypassed with an old-relation
+alias.
+
+1. `FLAG:chain` -- `Example12Worlds.example12-rebase-X-to-Y`.  The finite
+   schedule selects `W_Z`, and the probe refutes the required equation for
+   `W_X`.  It is unused and is to be deleted only in the live migration.
+2. `FLAG:chain` -- incoherent `TermImpDecay.decayRebaseAt`.  Independently
+   chosen endpoint decays do not determine the scheduled predecessor.
+3. `FLAG:chain` -- the ten direct strip/descent/walk/seal-transfer producer
+   schemata listed above.  No D16 invariant currently proves these generic
+   branches unreachable; use a proof-local `RebaseChainAt`/link relation with
+   no conversion to rule-facing `RebaseAt`.
+4. `FLAG:chain` -- the generic same-world producers in source strip, target
+   chain, target strip, and seal transfer.  Alignment plus representation is
+   not a stationary schedule proof.
+5. `FLAG:D16-blocked` -- `TerminusRebuildProbe.InstanceB.rb-chain`, its two
+   stationary edges, and both endpoint worlds.  D16 invariant (5) kills them:
+   dynamic direct-`★` source `X` has aligned target occupant `Y` or `Y₂`.
+6. `FLAG:D16-blocked` -- the CenterCrossing, MovedLink, and TagBoundary
+   calibration mints.  Their explicit direct-`★`, `X⊑★`, aligned-target
+   placements violate D16 invariant (5); keep them only as negative fixtures.
+7. `FLAG:D16-blocked` -- paired stationary direct-`★` fixtures in
+   SourceStar, StarRepChain, and SealPeel.  D16 invariant (5) kills the paired
+   edge; their unmatched/no-target cases are not implicated.
+
+
+5. Exact Stage 0 wait list
+--------------------------
+
+The following items intentionally remain unimplemented until D16 (#177)
+lands.  This is the complete Stage 0 dependency list for this pre-flight.
+
+1. Put schedule provenance and the computed `originAt` behind the live
+   D16-valid `World` construction surface.  The notes constructor must not
+   become a public caller-supplied policy or schedule-extension escape hatch.
+2. Re-express the six builder tags against the actual D16 constructors and
+   prove each constructor preserves all joined world invariants: embedded
+   `WFWorld`, aligned representation imprecision, unmatched-target `★`
+   representation, and invariant (5) occupancy.
+3. Re-run the D16 record constructors on T10 `W`/`Wᵖ`, Terminus Instance-B
+   `W`/`Wᵖ`, CenterCrossing, MovedLink, TagBoundary, SourceStar,
+   StarRepChain, and SealPeel.  Move or retain rejected worlds only as
+   negative fixtures.
+4. Decide D16 reachability for each generic strip/chain branch.  Until a
+   branch is proved unreachable, introduce the proof-local chain/link
+   relation; do not admit its shortcut as a scheduled functional edge.
+5. Delete live `Example12Worlds.example12-rebase-X-to-Y` only after the D16
+   join and before the D18 relation migration.  Nothing is deleted in this
+   pre-flight.
+6. Prove the Stage 3 naturality laws for center rename, coherent decay,
+   target insertion/pullback, target bind lift/store move, structural
+   extension, and smart-comma construction against the final D16 schedule.
+7. Only after items 1--6, begin Stage 4+: add the functional-origin field to
+   the live rebase declarations, thread it through the eight `⊢²` rules, land
+   the T12 peels, and delete obsolete broad machinery.
+
+
+6. Check record
+---------------
+
+The notes probe was spot-checked with:
+
+```sh
+cd GTSFImp
+PATH=/tmp/claude-26597/-home-runner-AI-for-pl/47ee78a9-f010-4f54-9a3a-aed5287dbe12/scratchpad/agda28/bin:$PATH \
+  agda -i . -i proof/DGG/notes/probes -v0 \
+  proof/DGG/notes/probes/D18OriginSchedulePreflight.agda
+```
+
+Result: exit 0, no holes or postulates.  The full gate result is recorded in
+the commit handoff after the requested final `make check` run.

--- a/GTSFImp/proof/DGG/notes/dispatcher-extra-cast-extractor-obstruction.red
+++ b/GTSFImp/proof/DGG/notes/dispatcher-extra-cast-extractor-obstruction.red
@@ -1,0 +1,125 @@
+Extra-cast dispatcher extractor obstruction after D15+D17
+==========================================================
+
+Date: 2026-08-19
+
+Status: proposal note only.  No relation definition was changed.
+
+
+D17 prerequisite audit
+----------------------
+
+The attempted direct use of D17's shape-only classifier does not inhabit
+`OccupiedNonStarSourceSealResidual`.  That residual starts with:
+
+```agda
+prem : W′ ∣ γ′ ⊢² V ⊑ U ↓ seal Y S ∶ p₂
+```
+
+and asks for a source conceal while keeping that already concealed target:
+
+```agda
+W ∣ γ ⊢² V ↓ seal Xᴸ (＇ X₂) ⊑ U ↓ seal Y S ∶ q
+```
+
+Using `conceal⊑conceal² (matched-seal-nonstar nonstar-X)` would add a
+second target conceal and therefore requires its premise target to be `U`,
+not `U ↓ seal Y S`.  The source-only D17 name-protected classifier instead
+requires a target tag outside the conceal, which is also absent here.  The
+focused full legacy check reports the resulting mismatch as
+`(＇ Y) != S` when the paired rule is attempted.
+
+Therefore `RightInjInversion2Lemma.right-inj-inversion²` correctly remains
+conditional on `OccupiedNonStarSourceSealResidual`; target projection still
+cannot consume it as a total theorem.
+
+
+The live residual surface is broader than an active target head
+------------------------------------------------------------
+
+The two fields in `StructuralExtraCastResiduals` consume a whole relation:
+
+```agda
+W ∣ γ ⊢² M ⊑ N ⟨ cᴿ ⟩ ∶ q
+```
+
+They do not require that the relation is headed by `⊑cast²` or
+`cast⊑cast²`.  Consequently a legal input may still be headed by any
+source-only wrapper whose target premise happens to be `N ⟨ cᴿ ⟩`.
+In particular, `Λ⊑²` and `Λ⊑²-smart-comma` are possible heads.  Solving
+either case requires precisely the strict-cells source-Λ replay wave that this
+task explicitly leaves residual.  The extra-cast dispatcher receives neither
+that residual nor a current-fuel value worker, so it cannot discharge those
+heads independently.
+
+The assembled value dispatcher calls the extra worker only after recursively
+solving the child and explicitly rebuilding one of these exposed heads:
+
+```agda
+⊑cast² cᴿ child q
+cast⊑cast² cᴸ cᴿ child q
+```
+
+That call-site invariant is not represented by the current
+`StructuralExtraCastRightAt` type.
+
+
+Exposed paired endpoint gap
+---------------------------
+
+Even after narrowing to the two exposed heads, the target-only case is the
+only immediately complete route.  For injection, `to-ground` classifies the
+identity tag versus the strict ground step and
+`structural-ground-extra-cast-right-at` consumes the peeled `⊑cast²`
+premise.  For projection, `canonical-★`, a supplied `RightInjInversion²`,
+and the checked project-same/project-expand rows provide the corresponding
+target-only route.  The inversion's occupied residual remains an additional
+prerequisite for a concrete factory.
+
+The general paired injection head instead supplies:
+
+```agda
+cast⊑cast² cᴸ (_! cᴿ) prem q★
+
+prem : C ⊑ B
+cᴸ   : C ∼ A
+cᴿ   : B ∼ G
+q★   : A ⊑ ★
+```
+
+The checked stuttering row requires the re-attachment endpoint `A ⊑ G`.
+That endpoint is not a constructor field.  The paired projection head has the
+dual problem: its checked tag replacement needs a supplied `C ⊑ G`; the
+constructor gives `C ⊑ ★` and the post-source endpoint `A ⊑ B`.
+`RightInjInversion²` removes a matching tag only after the caller supplies the
+ground endpoint, so supplying its occupied premise would not manufacture
+either witness.
+
+The premise-first midpoint repair is not available: the repository's checked
+`LG3EndpointTransportCounterexampleScratch.agda` inhabits the paired
+function/expand cell while refuting that midpoint.  The live row combinators
+therefore correctly use stuttering re-attachment, but their factory still
+needs an endpoint-producing extractor.
+
+
+Proposed surface decision
+-------------------------
+
+Represent the actual call-site invariant by splitting
+`StructuralExtraCastRightAt` into exposed target-only and exposed paired
+entries, with the paired entry carrying the appropriate re-attachment
+endpoint/core package.  The value dispatcher already has exactly these two
+heads after child catch-up and can supply the package when a future approved
+paired endpoint inversion exists.  Source wrappers, especially source Λ,
+should remain the value dispatcher's responsibility rather than being hidden
+inside the extra-cast factory.
+
+Alternatively, approve a new whole-relation, wrapper-aware active-cast
+extractor.  Such a theorem necessarily includes the deferred source-Λ wave
+and a new paired endpoint inversion, so it is larger than the decided LG-3
+tag machinery.
+
+Without one of those decisions, changing the residual fields or introducing
+the endpoint extractor would be a genuinely new major lemma/surface.  The
+target injection and target projection residuals therefore remain live in
+this pass.

--- a/GTSFImp/proof/DGG/notes/dispatcher-t12-world-cycle-obstruction.red
+++ b/GTSFImp/proof/DGG/notes/dispatcher-t12-world-cycle-obstruction.red
@@ -1,0 +1,96 @@
+Dispatcher T12 peel world-cycle obstruction
+============================================
+
+Date: 2026-08-19
+
+Status: proposal note only.  No relation definition was changed.
+
+The approved `PairedConcealRevealPeelᵀ` and
+`SourceOnlyConcealRevealPeelᵀ` statements are well formed, but direct
+inversion of the migrated `⊢²` relation does not prove them.  The obstruction
+is now independent of the removed partner premise.
+
+
+Paired inversion
+----------------
+
+Inverting the exact synchronized source/target term first exposes
+`reveal⊑reveal²`; inverting its premise exposes `conceal⊑conceal²` (or the
+specialized packaged row in the `seal ★` cell).  In the ordinary paired cell
+the payload has the following worlds:
+
+```agda
+outer-rebase : RebaseAt W Wmid Xᴸ Xᴿ
+inner-rebase : RebaseAt Wcore Wmid Xᴸ Xᴿ
+payload      : Wcore ∣ γcore ⊢² V₀ ⊑ V₀′ ∶ pcore
+goal         : W     ∣ γ     ⊢² V₀ ⊑ V₀′ ∶ q
+```
+
+The two `RebaseAt` values have a common destination; they are not inverse
+rebases.  `RebaseAt` freezes the target embedding and the source embedding
+away from `Xᴸ`, but deliberately leaves the source-pivot embedding in each
+origin unconstrained.  Consequently neither `Wcore ≡ W` nor an existing
+`EnvDecay Wcore W` follows.
+
+The minimal attempted clause was:
+
+```agda
+paired-conceal-reveal-peel vV vV′
+    (reveal⊑reveal² mono outer-rebase sc c⊢ c′⊢
+      (conceal⊑conceal² partner monoᵖ inner-rebase scᵖ
+        c₀⊢ c₀′⊢ payload qᵖ)
+      q)
+    (pure-step (conceal-reveal _))
+    (pure-step (conceal-reveal _)) = payload
+```
+
+Agda rejects the right-hand side because `Wcore != W`.  Retargeting changes
+only the proof index in one fixed world and therefore does not repair this
+mismatch.
+
+Diagram:
+
+    (V₀ ↓ seal Xᴸ R) ↑ unseal Xᴸ R   ⊑   (V₀′ ↓ seal Xᴿ R′) ↑ unseal Xᴿ R′
+                    |                                      |
+                    | 1                                    | 1
+                    v                                      v
+                   V₀                  ⊑                  V₀′
+
+The top relation is in `W`, while inversion supplies the requested bottom
+payload only in `Wcore`.
+
+
+Source-only inversion
+---------------------
+
+The source-only statement has the same geometry.  `reveal⊑²` exposes a
+premise in `Wmid`; its source conceal constructor exposes the payload in
+`Wcore`.  The supplied target keep step fixes the target term shape but carries
+no world transport, so it cannot turn the payload into a relation in `W`.
+
+
+Required decision
+-----------------
+
+One of the following new major interfaces is required before these peels can
+be inhabited:
+
+1. strengthen each peel with an explicit transport from the payload world to
+   the outer world (including context and imprecision-index transport); or
+2. tighten the synchronized relation rules so the two rebases determine the
+   same origin, which is a change to the live relation and therefore requires
+   explicit user permission; or
+3. restate the dispatcher continuation to consume the payload in its actual
+   premise world and perform wrapper replay before returning to the outer
+   world.
+
+The current `RestatedDispatcherKeepOutcomesᵀ` also has no field applicable
+to the plain target-only heads `⊑reveal²` and `⊑conceal²`: those rows have a
+plain source value, whereas every approved continuation requires a matching
+source wrapper.  That independent surface gap remains recorded in
+`t1-direct-target-frame-certificate-proposal.red`.
+
+Accordingly the target reveal/conceal, source conceal, and paired
+reveal/conceal dispatcher residuals remain live.  Implementing a world-cycle
+transport theorem or changing either approved statement here would exceed the
+decided set, so this pass stops those rows at this proposal note.

--- a/GTSFImp/proof/DGG/notes/probes/D18OriginSchedulePreflight.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D18OriginSchedulePreflight.agda
@@ -1,0 +1,502 @@
+module D18OriginSchedulePreflight where
+
+-- File Charter:
+--   * Pre-flights D18 Stage 1 and Stage 2 without changing the live World or
+--     RebaseAt declarations.
+--   * Computes originAt from an inductive world-construction schedule, with
+--     one edge form for each World builder exported by CtxImp.
+--   * Checks the tightened edge fields, stationary fixed points, the finite
+--     Example12 schedule, and the two known conflicting shortcuts.
+--   * Does not provide a broad rebase alias or a chain-to-rebase coercion.
+
+open import Data.Empty using (⊥-elim)
+import Data.Fin as Fin
+open import Data.Maybe using (just)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans; cong; subst)
+open import Relation.Nullary using (¬_; yes; no)
+
+open import Types using (TyCtx; TyVar)
+open import Consistency using (toRenameᵗ)
+import proof.DGG.CtxImp as CTX
+import proof.DGG.Example12Worlds as Ex12
+import proof.DGG.Examples2 as Ex2
+import proof.DGG.SmartCommaWitness as Smart
+import proof.DGG.TerminusRebuildProbe as T6
+
+
+------------------------------------------------------------------------
+-- Construction provenance and the computed origin schedule
+------------------------------------------------------------------------
+
+-- This list is exhaustive for definitions in CtxImp.agda that construct a
+-- World: the raw `world` constructor and its five named World-valued builders.
+-- SmartCommaLiftᴸ is evidence about caller-supplied worlds, not an additional
+-- World-valued builder.
+
+data WorldBuilder : Set where
+  world-builder : WorldBuilder
+  liftWorldBoth-builder : WorldBuilder
+  liftWorldLeft-builder : WorldBuilder
+  leftOnlyWorld-builder : WorldBuilder
+  rightOnlyWorld-builder : WorldBuilder
+  bothBindWorld-builder : WorldBuilder
+
+-- An edge is admitted only as construction provenance.  Its raw geometric
+-- evidence is the current live record, so this probe tests the real fields.
+-- Later evidence-composition code cannot extend this schedule.
+
+data OriginSchedule {Δᴸ Δᴿ Δ}
+    (W′ : CTX.World Δᴸ Δᴿ Δ) : Set where
+  stationary : OriginSchedule W′
+
+  edge : ∀ {W : CTX.World Δᴸ Δᴿ Δ}
+      {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    → WorldBuilder
+    → CTX.RebaseAt W W′ Xᴸ Xᴿ
+    → OriginSchedule W′
+    → OriginSchedule W′
+
+originAtSchedule : ∀ {Δᴸ Δᴿ Δ} {W′ : CTX.World Δᴸ Δᴿ Δ}
+  → OriginSchedule W′
+  → TyVar Δᴸ
+  → TyVar Δᴿ
+  → CTX.World Δᴸ Δᴿ Δ
+originAtSchedule {W′ = W′} stationary Xᴸ Xᴿ = W′
+originAtSchedule (edge {W = W} {Xᴸ = X₀ᴸ} {Xᴿ = X₀ᴿ}
+    builder rb rest) Xᴸ Xᴿ
+    with Fin._≟_ Xᴸ X₀ᴸ | Fin._≟_ Xᴿ X₀ᴿ
+originAtSchedule (edge {W = W} builder rb rest) ._ ._
+    | yes refl | yes refl = W
+originAtSchedule (edge builder rb rest) Xᴸ Xᴿ
+    | yes Xᴸ≡X₀ᴸ | no Xᴿ≢X₀ᴿ = originAtSchedule rest Xᴸ Xᴿ
+originAtSchedule (edge builder rb rest) Xᴸ Xᴿ
+    | no Xᴸ≢X₀ᴸ | yes Xᴿ≡X₀ᴿ = originAtSchedule rest Xᴸ Xᴿ
+originAtSchedule (edge builder rb rest) Xᴸ Xᴿ
+    | no Xᴸ≢X₀ᴸ | no Xᴿ≢X₀ᴿ = originAtSchedule rest Xᴸ Xᴿ
+
+record ScheduledWorld (Δᴸ Δᴿ Δ : TyCtx) : Set where
+  constructor scheduled
+  field
+    rawWorld : CTX.World Δᴸ Δᴿ Δ
+    provenance : OriginSchedule rawWorld
+
+open ScheduledWorld public
+
+originAt : ∀ {Δᴸ Δᴿ Δ}
+  → ScheduledWorld Δᴸ Δᴿ Δ
+  → TyVar Δᴸ
+  → TyVar Δᴿ
+  → CTX.World Δᴸ Δᴿ Δ
+originAt (scheduled W provenance) Xᴸ Xᴿ =
+  originAtSchedule provenance Xᴸ Xᴿ
+
+stationaryWorld : ∀ {Δᴸ Δᴿ Δ}
+  → CTX.World Δᴸ Δᴿ Δ
+  → ScheduledWorld Δᴸ Δᴿ Δ
+stationaryWorld W = scheduled W stationary
+
+originAt-stationary : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → originAt (stationaryWorld W) Xᴸ Xᴿ ≡ W
+originAt-stationary = refl
+
+originAt-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (builder : WorldBuilder)
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → originAt (scheduled W′ (edge builder rb rest)) Xᴸ Xᴿ ≡ W
+originAt-edge {Xᴸ = Xᴸ} {Xᴿ = Xᴿ} builder rb rest
+    with Fin._≟_ Xᴸ Xᴸ | Fin._≟_ Xᴿ Xᴿ
+originAt-edge builder rb rest | yes refl | yes refl = refl
+originAt-edge builder rb rest | yes Xᴸ≡Xᴸ | no Xᴿ≢Xᴿ =
+  ⊥-elim (Xᴿ≢Xᴿ refl)
+originAt-edge builder rb rest | no Xᴸ≢Xᴸ | yes Xᴿ≡Xᴿ =
+  ⊥-elim (Xᴸ≢Xᴸ refl)
+originAt-edge builder rb rest | no Xᴸ≢Xᴸ | no Xᴿ≢Xᴿ =
+  ⊥-elim (Xᴸ≢Xᴸ refl)
+
+
+------------------------------------------------------------------------
+-- Tightened sandbox relation and selected-origin properties
+------------------------------------------------------------------------
+
+record RebaseAt {Δᴸ Δᴿ Δ}
+    (W : CTX.World Δᴸ Δᴿ Δ)
+    (W′ : ScheduledWorld Δᴸ Δᴿ Δ)
+    (Xᴸ : TyVar Δᴸ) (Xᴿ : TyVar Δᴿ) : Set where
+  constructor rebase-at
+  field
+    origin-determined : W ≡ originAt W′ Xᴸ Xᴿ
+    sameRuntime : CTX.SameRuntime W (rawWorld W′)
+    ηᴸ-off-pivot : ∀ {Y} → Y ≢ Xᴸ
+      → toRenameᵗ (CTX.ηᴸʷ (rawWorld W′)) Y
+        ≡ toRenameᵗ (CTX.ηᴸʷ W) Y
+    ηᴿ-frozen : ∀ Y
+      → toRenameᵗ (CTX.ηᴿʷ (rawWorld W′)) Y
+        ≡ toRenameᵗ (CTX.ηᴿʷ W) Y
+    pivotAligned :
+      toRenameᵗ (CTX.ηᴸʷ (rawWorld W′)) Xᴸ
+        ≡ toRenameᵗ (CTX.ηᴿʷ (rawWorld W′)) Xᴿ
+    storeRepresentations : CTX.StoreRepImp (rawWorld W′) Xᴸ Xᴿ
+
+open RebaseAt public
+
+edgeRebaseAt : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (builder : WorldBuilder)
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W (scheduled W′ (edge builder rb rest)) Xᴸ Xᴿ
+edgeRebaseAt builder rb rest =
+  rebase-at (sym (originAt-edge builder rb rest))
+    (CTX.RebaseAt.sameRuntime rb)
+    (CTX.RebaseAt.ηᴸ-off-pivot rb)
+    (CTX.RebaseAt.ηᴿ-frozen rb)
+    (CTX.RebaseAt.pivotAligned rb)
+    (CTX.RebaseAt.storeRepresentations rb)
+
+stationaryRebaseAt : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ ≡ toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+  → CTX.StoreRepImp W Xᴸ Xᴿ
+  → RebaseAt W (stationaryWorld W) Xᴸ Xᴿ
+stationaryRebaseAt aligned reps =
+  rebase-at refl (CTX.same-runtime refl refl)
+    (λ _ → refl) (λ _ → refl) aligned reps
+
+selected-origin-sameRuntime : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : ScheduledWorld Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : RebaseAt W W′ Xᴸ Xᴿ)
+  → CTX.SameRuntime (originAt W′ Xᴸ Xᴿ) (rawWorld W′)
+selected-origin-sameRuntime rb =
+  subst (λ O → CTX.SameRuntime O _) (origin-determined rb)
+    (sameRuntime rb)
+
+selected-origin-off-pivot : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : ScheduledWorld Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ} {Y : TyVar Δᴸ}
+  → (rb : RebaseAt W W′ Xᴸ Xᴿ)
+  → Y ≢ Xᴸ
+  → toRenameᵗ (CTX.ηᴸʷ (rawWorld W′)) Y
+    ≡ toRenameᵗ (CTX.ηᴸʷ (originAt W′ Xᴸ Xᴿ)) Y
+selected-origin-off-pivot {W′ = W′} {Y = Y} rb Y≢Xᴸ =
+  subst
+    (λ O → toRenameᵗ (CTX.ηᴸʷ (rawWorld W′)) Y
+      ≡ toRenameᵗ (CTX.ηᴸʷ O) Y)
+    (origin-determined rb) (ηᴸ-off-pivot rb Y≢Xᴸ)
+
+selected-origin-target-frozen : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : ScheduledWorld Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ Y : TyVar Δᴿ}
+  → (rb : RebaseAt W W′ Xᴸ Xᴿ)
+  → toRenameᵗ (CTX.ηᴿʷ (rawWorld W′)) Y
+    ≡ toRenameᵗ (CTX.ηᴿʷ (originAt W′ Xᴸ Xᴿ)) Y
+selected-origin-target-frozen {W′ = W′} {Y = Y} rb =
+  subst
+    (λ O → toRenameᵗ (CTX.ηᴿʷ (rawWorld W′)) Y
+      ≡ toRenameᵗ (CTX.ηᴿʷ O) Y)
+    (origin-determined rb) (ηᴿ-frozen rb _)
+
+selected-origin-pivot-aligned : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : ScheduledWorld Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → RebaseAt W W′ Xᴸ Xᴿ
+  → toRenameᵗ (CTX.ηᴸʷ (rawWorld W′)) Xᴸ
+    ≡ toRenameᵗ (CTX.ηᴿʷ (rawWorld W′)) Xᴿ
+selected-origin-pivot-aligned = pivotAligned
+
+selected-origin-representations : ∀ {Δᴸ Δᴿ Δ}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {W′ : ScheduledWorld Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → RebaseAt W W′ Xᴸ Xᴿ
+  → CTX.StoreRepImp (rawWorld W′) Xᴸ Xᴿ
+selected-origin-representations = storeRepresentations
+
+
+------------------------------------------------------------------------
+-- One checked edge rule per CtxImp World builder
+------------------------------------------------------------------------
+
+world-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W (scheduled W′ (edge world-builder rb rest)) Xᴸ Xᴿ
+world-edge = edgeRebaseAt world-builder
+
+liftWorldBoth-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W
+      (scheduled W′ (edge liftWorldBoth-builder rb rest)) Xᴸ Xᴿ
+liftWorldBoth-edge = edgeRebaseAt liftWorldBoth-builder
+
+liftWorldLeft-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W
+      (scheduled W′ (edge liftWorldLeft-builder rb rest)) Xᴸ Xᴿ
+liftWorldLeft-edge = edgeRebaseAt liftWorldLeft-builder
+
+leftOnlyWorld-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W
+      (scheduled W′ (edge leftOnlyWorld-builder rb rest)) Xᴸ Xᴿ
+leftOnlyWorld-edge = edgeRebaseAt leftOnlyWorld-builder
+
+rightOnlyWorld-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W
+      (scheduled W′ (edge rightOnlyWorld-builder rb rest)) Xᴸ Xᴿ
+rightOnlyWorld-edge = edgeRebaseAt rightOnlyWorld-builder
+
+bothBindWorld-edge : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → (rb : CTX.RebaseAt W W′ Xᴸ Xᴿ)
+  → (rest : OriginSchedule W′)
+  → RebaseAt W
+      (scheduled W′ (edge bothBindWorld-builder rb rest)) Xᴸ Xᴿ
+bothBindWorld-edge = edgeRebaseAt bothBindWorld-builder
+
+
+------------------------------------------------------------------------
+-- Raw target-wrapper producer adapter used only at construction mints
+------------------------------------------------------------------------
+
+record TargetProducerPreflight {Δᴸ Δᴿ Δ}
+    (W W′ : CTX.World Δᴸ Δᴿ Δ) (Xᴿ : TyVar Δᴿ) : Set where
+  constructor target-producer
+  field
+    producer-Xᴸ : TyVar Δᴸ
+    producer-raw : CTX.RebaseAt W W′ producer-Xᴸ Xᴿ
+    producer-tightened :
+      RebaseAt W
+        (scheduled W′ (edge world-builder producer-raw stationary))
+        producer-Xᴸ Xᴿ
+
+open TargetProducerPreflight public
+
+target-producer-preflight : ∀ {Δᴸ Δᴿ Δ}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ} {Xᴿ : TyVar Δᴿ}
+  → CTX.RebaseAtᴿ W W′ (just Xᴿ)
+  → TargetProducerPreflight W W′ Xᴿ
+target-producer-preflight (CTX.rebase-varᴿ rb) =
+  target-producer _ rb (world-edge rb stationary)
+
+smart-comma-outer-preflight :
+  TargetProducerPreflight Smart.a3-d1-alias-world
+    Smart.a3-d1-name-world Smart.target-α
+smart-comma-outer-preflight =
+  target-producer-preflight Smart.a3-d1-outer-rebaseᴿ
+
+smart-comma-inner-preflight :
+  TargetProducerPreflight Smart.a3-d1-name-world
+    Smart.a3-d1-alias-world Smart.target-β
+smart-comma-inner-preflight =
+  target-producer-preflight Smart.a3-d1-inner-rebaseᴿ
+
+smart-comma-outer-origin-determined :
+  Smart.a3-d1-alias-world ≡
+    originAt
+      (scheduled Smart.a3-d1-name-world
+        (edge world-builder
+          (producer-raw smart-comma-outer-preflight) stationary))
+      (producer-Xᴸ smart-comma-outer-preflight) Smart.target-α
+smart-comma-outer-origin-determined =
+  origin-determined (producer-tightened smart-comma-outer-preflight)
+
+smart-comma-inner-origin-determined :
+  Smart.a3-d1-name-world ≡
+    originAt
+      (scheduled Smart.a3-d1-alias-world
+        (edge world-builder
+          (producer-raw smart-comma-inner-preflight) stationary))
+      (producer-Xᴸ smart-comma-inner-preflight) Smart.target-β
+smart-comma-inner-origin-determined =
+  origin-determined (producer-tightened smart-comma-inner-preflight)
+
+
+------------------------------------------------------------------------
+-- Stage 2 finite schedule: Example12 X/Z/Y and the nat chain
+------------------------------------------------------------------------
+
+example12-world-Zᵀ : ScheduledWorld 1 3 3
+example12-world-Zᵀ =
+  scheduled Ex12.example12-world-Z
+    (edge world-builder Ex12.example12-rebase-X-to-Z stationary)
+
+example12-rebase-X-to-Zᵀ :
+  RebaseAt Ex12.example12-world-X example12-world-Zᵀ
+    Fin.zero (Fin.suc (Fin.suc Fin.zero))
+example12-rebase-X-to-Zᵀ =
+  world-edge Ex12.example12-rebase-X-to-Z stationary
+
+example12-world-Yᵀ : ScheduledWorld 1 3 3
+example12-world-Yᵀ =
+  scheduled Ex12.example12-world-Y
+    (edge world-builder Ex2.example12-rebase-Z-to-Y stationary)
+
+example12-rebase-Z-to-Yᵀ :
+  RebaseAt Ex12.example12-world-Z example12-world-Yᵀ
+    Fin.zero (Fin.suc Fin.zero)
+example12-rebase-Z-to-Yᵀ =
+  world-edge Ex2.example12-rebase-Z-to-Y stationary
+
+example12-nat-world-Yᵀ : ScheduledWorld 1 2 2
+example12-nat-world-Yᵀ =
+  scheduled Ex12.example12-nat-chain-world-Y
+    (edge world-builder Ex12.example12-nat-chain-rebase-X-to-Y stationary)
+
+example12-nat-rebase-X-to-Yᵀ :
+  RebaseAt Ex12.example12-nat-chain-world-X example12-nat-world-Yᵀ
+    Fin.zero Fin.zero
+example12-nat-rebase-X-to-Yᵀ =
+  world-edge Ex12.example12-nat-chain-rebase-X-to-Y stationary
+
+example12-X-to-Z-origin-determined :
+  Ex12.example12-world-X ≡
+    originAt example12-world-Zᵀ Fin.zero (Fin.suc (Fin.suc Fin.zero))
+example12-X-to-Z-origin-determined =
+  origin-determined example12-rebase-X-to-Zᵀ
+
+example12-Z-to-Y-origin-determined :
+  Ex12.example12-world-Z ≡
+    originAt example12-world-Yᵀ Fin.zero (Fin.suc Fin.zero)
+example12-Z-to-Y-origin-determined =
+  origin-determined example12-rebase-Z-to-Yᵀ
+
+example12-nat-X-to-Y-origin-determined :
+  Ex12.example12-nat-chain-world-X ≡
+    originAt example12-nat-world-Yᵀ Fin.zero Fin.zero
+example12-nat-X-to-Y-origin-determined =
+  origin-determined example12-nat-rebase-X-to-Yᵀ
+
+
+------------------------------------------------------------------------
+-- Flags: no shortcut is inserted into the construction schedule
+------------------------------------------------------------------------
+
+zero≢suc : ∀ {n} {X : Fin.Fin n} → Fin.zero ≢ Fin.suc X
+zero≢suc ()
+
+example12-X≢Z : Ex12.example12-world-X ≢ Ex12.example12-world-Z
+example12-X≢Z eq =
+  zero≢suc
+    (cong
+      (λ W → toRenameᵗ (CTX.ηᴸʷ W) Fin.zero)
+      eq)
+
+example12-X-to-Y-not-origin-determined :
+  ¬ (Ex12.example12-world-X ≡
+    originAt example12-world-Yᵀ Fin.zero (Fin.suc Fin.zero))
+example12-X-to-Y-not-origin-determined eq =
+  example12-X≢Z
+    (trans eq
+      (originAt-edge world-builder Ex2.example12-rebase-Z-to-Y stationary))
+
+terminus-stationary-Wᵀ : ScheduledWorld 1 2 2
+terminus-stationary-Wᵀ = stationaryWorld T6.InstanceB.W
+
+terminus-W≢Wᵖ : T6.InstanceB.W ≢ T6.InstanceB.Wᵖ
+terminus-W≢Wᵖ eq =
+  zero≢suc
+    (cong
+      (λ W → toRenameᵗ (CTX.ηᴸʷ W) T6.InstanceB.X)
+      eq)
+
+terminus-chain-not-origin-determined :
+  ¬ (T6.InstanceB.Wᵖ ≡
+    originAt terminus-stationary-Wᵀ T6.InstanceB.X T6.InstanceB.Y)
+terminus-chain-not-origin-determined eq =
+  terminus-W≢Wᵖ
+    (sym (trans eq
+      (originAt-stationary {W = T6.InstanceB.W}
+        {Xᴸ = T6.InstanceB.X} {Xᴿ = T6.InstanceB.Y})))
+
+
+------------------------------------------------------------------------
+-- Machine-readable Stage 2 verdict ledger
+------------------------------------------------------------------------
+
+data ProducerStatus : Set where
+  PROVEN-IN-SANDBOX : ProducerStatus
+  FLAG:chain : ProducerStatus
+  FLAG:D16-blocked : ProducerStatus
+
+same-world-constructor-status : ProducerStatus
+same-world-constructor-status = PROVEN-IN-SANDBOX
+
+example12-X-to-Z-status : ProducerStatus
+example12-X-to-Z-status = PROVEN-IN-SANDBOX
+
+example12-Z-to-Y-status : ProducerStatus
+example12-Z-to-Y-status = PROVEN-IN-SANDBOX
+
+example12-nat-X-to-Y-status : ProducerStatus
+example12-nat-X-to-Y-status = PROVEN-IN-SANDBOX
+
+example12-X-to-Y-status : ProducerStatus
+example12-X-to-Y-status = FLAG:chain
+
+calibration-direct-producers-status : ProducerStatus
+calibration-direct-producers-status = FLAG:D16-blocked
+
+terminus-chain-status : ProducerStatus
+terminus-chain-status = FLAG:D16-blocked
+
+smart-comma-producers-status : ProducerStatus
+smart-comma-producers-status = PROVEN-IN-SANDBOX
+
+inst-inversion-route-producers-status : ProducerStatus
+inst-inversion-route-producers-status = PROVEN-IN-SANDBOX
+
+center-rename-producer-status : ProducerStatus
+center-rename-producer-status = PROVEN-IN-SANDBOX
+
+coherent-decay-producer-status : ProducerStatus
+coherent-decay-producer-status = PROVEN-IN-SANDBOX
+
+independent-decay-producer-status : ProducerStatus
+independent-decay-producer-status = FLAG:chain
+
+target-bind-lift-producers-status : ProducerStatus
+target-bind-lift-producers-status = PROVEN-IN-SANDBOX
+
+target-extend-producers-status : ProducerStatus
+target-extend-producers-status = PROVEN-IN-SANDBOX
+
+strip-chain-direct-producers-status : ProducerStatus
+strip-chain-direct-producers-status = FLAG:chain
+
+finite-same-world-producers-status : ProducerStatus
+finite-same-world-producers-status = PROVEN-IN-SANDBOX
+
+generic-strip-same-world-producers-status : ProducerStatus
+generic-strip-same-world-producers-status = FLAG:chain
+
+terminus-same-world-producers-status : ProducerStatus
+terminus-same-world-producers-status = FLAG:D16-blocked

--- a/GTSFImp/proof/DGG/notes/probes/D18RebaseTighteningProbe.agda
+++ b/GTSFImp/proof/DGG/notes/probes/D18RebaseTighteningProbe.agda
@@ -1,0 +1,199 @@
+module D18RebaseTighteningProbe where
+
+-- File Charter:
+--   * Drafts D18's functional-origin version of RebaseAt and its one-sided
+--     wrappers without changing the live DGG relation.
+--   * Checks exact origin uniqueness, source-pivot and mark coherence, and
+--     the generic transport that closes the T12 W/Wcore cycle.
+--   * Checks that unqualified functional origin determination cannot retain
+--     both live Instance-B rebases, identifying the required migration split.
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Maybe using (Maybe; just; nothing)
+import Data.Fin as Fin
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; trans; cong; subst)
+
+open import Types using (TyCtx; TyVar; ★)
+open import Consistency using (toRenameᵗ)
+open import Imprecision using (X⊑★)
+import proof.DGG.CtxImp as CTX
+import proof.DGG.TerminusRebuildProbe as T6
+
+
+------------------------------------------------------------------------
+-- Functional origin schedule
+------------------------------------------------------------------------
+
+record OriginPolicy : Set₁ where
+  field
+    originAt : ∀ {Δᴸ Δᴿ Δ}
+      → CTX.World Δᴸ Δᴿ Δ
+      → TyVar Δᴸ
+      → TyVar Δᴿ
+      → CTX.World Δᴸ Δᴿ Δ
+
+open OriginPolicy public
+
+
+------------------------------------------------------------------------
+-- Verbatim D18 draft surface
+------------------------------------------------------------------------
+
+record RebaseAt (policy : OriginPolicy) {Δᴸ Δᴿ Δ}
+    (W W′ : CTX.World Δᴸ Δᴿ Δ)
+    (Xᴸ : TyVar Δᴸ) (Xᴿ : TyVar Δᴿ) : Set where
+  constructor rebase-at
+  field
+    origin-determined : W ≡ originAt policy W′ Xᴸ Xᴿ
+    sameRuntime : CTX.SameRuntime W W′
+    ηᴸ-off-pivot : ∀ {Y} → Y ≢ Xᴸ
+      → toRenameᵗ (CTX.ηᴸʷ W′) Y ≡ toRenameᵗ (CTX.ηᴸʷ W) Y
+    ηᴿ-frozen : ∀ Y
+      → toRenameᵗ (CTX.ηᴿʷ W′) Y ≡ toRenameᵗ (CTX.ηᴿʷ W) Y
+    pivotAligned :
+      toRenameᵗ (CTX.ηᴸʷ W′) Xᴸ ≡
+        toRenameᵗ (CTX.ηᴿʷ W′) Xᴿ
+    storeRepresentations : CTX.StoreRepImp W′ Xᴸ Xᴿ
+
+open RebaseAt public
+
+sameWorldRebaseAt : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → W ≡ originAt policy W Xᴸ Xᴿ
+  → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ ≡
+      toRenameᵗ (CTX.ηᴿʷ W) Xᴿ
+  → CTX.StoreRepImp W Xᴸ Xᴿ
+  → RebaseAt policy W W Xᴸ Xᴿ
+sameWorldRebaseAt origin aligned reps =
+  rebase-at origin (CTX.same-runtime refl refl)
+    (λ _ → refl) (λ _ → refl) aligned reps
+
+data RebaseAtᴸ (policy : OriginPolicy) {Δᴸ Δᴿ Δ} :
+    CTX.World Δᴸ Δᴿ Δ → CTX.World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Set where
+  rebase-idᴸ : ∀ {W}
+    → RebaseAtᴸ policy W W nothing
+
+  rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt policy W W′ Xᴸ Xᴿ
+    → RebaseAtᴸ policy W W′ (just Xᴸ)
+
+  rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ ≢
+          toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)
+    → CTX.resolveVar (CTX.sourceStoreʷ W) Xᴸ CTX.⊑ᵂ⟨ W ⟩ ★
+    → RebaseAtᴸ policy W W (just Xᴸ)
+
+data TagRebaseAtᴸ (policy : OriginPolicy) {Δᴸ Δᴿ Δ} :
+    CTX.World Δᴸ Δᴿ Δ → CTX.World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴸ) → Maybe (TyVar Δᴿ) → Set where
+  tag-rebase-idᴸ : ∀ {W}
+    → TagRebaseAtᴸ policy W W nothing nothing
+
+  tag-rebase-varᴸ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt policy W W′ Xᴸ Xᴿ
+    → TagRebaseAtᴸ policy W W′ (just Xᴸ) (just Xᴿ)
+
+  tag-rebase-onlyᴸ : ∀ {W} {Xᴸ : TyVar Δᴸ}
+    → CTX.impEnvʷ W (toRenameᵗ (CTX.ηᴸʷ W) Xᴸ) ≡ X⊑★
+    → (∀ (Xᴿ : TyVar Δᴿ)
+        → toRenameᵗ (CTX.ηᴿʷ W) Xᴿ ≢
+          toRenameᵗ (CTX.ηᴸʷ W) Xᴸ)
+    → CTX.resolveVar (CTX.sourceStoreʷ W) Xᴸ CTX.⊑ᵂ⟨ W ⟩ ★
+    → TagRebaseAtᴸ policy W W (just Xᴸ) nothing
+
+forgetTagRebaseᴸ : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W W′ : CTX.World Δᴸ Δᴿ Δ} {Xᴸ? Xᴿ?}
+  → TagRebaseAtᴸ policy W W′ Xᴸ? Xᴿ?
+  → RebaseAtᴸ policy W W′ Xᴸ?
+forgetTagRebaseᴸ tag-rebase-idᴸ = rebase-idᴸ
+forgetTagRebaseᴸ (tag-rebase-varᴸ rb) = rebase-varᴸ rb
+forgetTagRebaseᴸ (tag-rebase-onlyᴸ to-star disaligned represented) =
+  rebase-onlyᴸ to-star disaligned represented
+
+data RebaseAtᴿ (policy : OriginPolicy) {Δᴸ Δᴿ Δ} :
+    CTX.World Δᴸ Δᴿ Δ → CTX.World Δᴸ Δᴿ Δ
+    → Maybe (TyVar Δᴿ) → Set where
+  rebase-idᴿ : ∀ {W}
+    → RebaseAtᴿ policy W W nothing
+
+  rebase-varᴿ : ∀ {W W′ Xᴸ Xᴿ}
+    → RebaseAt policy W W′ Xᴸ Xᴿ
+    → RebaseAtᴿ policy W W′ (just Xᴿ)
+
+
+------------------------------------------------------------------------
+-- Checked D18 payoffs
+------------------------------------------------------------------------
+
+origin-unique : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → RebaseAt policy W Wmid Xᴸ Xᴿ
+  → RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+  → W ≡ Wcore
+origin-unique outer inner =
+  trans (origin-determined outer) (sym (origin-determined inner))
+
+origin-source-pivot-unique : ∀ {Δᴸ Δᴿ Δ}
+    {policy : OriginPolicy}
+    {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → RebaseAt policy W Wmid Xᴸ Xᴿ
+  → RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+  → toRenameᵗ (CTX.ηᴸʷ W) Xᴸ ≡
+      toRenameᵗ (CTX.ηᴸʷ Wcore) Xᴸ
+origin-source-pivot-unique outer inner =
+  cong (λ W′ → toRenameᵗ (CTX.ηᴸʷ W′) _)
+    (origin-unique outer inner)
+
+origin-marks-unique : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+  → RebaseAt policy W Wmid Xᴸ Xᴿ
+  → RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+  → CTX.impEnvʷ W ≡ CTX.impEnvʷ Wcore
+origin-marks-unique outer inner =
+  cong CTX.impEnvʷ (origin-unique outer inner)
+
+world-cycle-close : ∀ {Δᴸ Δᴿ Δ} {policy : OriginPolicy}
+    {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+    {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    (P : CTX.World Δᴸ Δᴿ Δ → Set)
+  → RebaseAt policy W Wmid Xᴸ Xᴿ
+  → RebaseAt policy Wcore Wmid Xᴸ Xᴿ
+  → P Wcore
+  → P W
+world-cycle-close P outer inner payload =
+  subst P (sym (origin-unique outer inner)) payload
+
+
+------------------------------------------------------------------------
+-- Checked obstruction to applying the global form without migration
+------------------------------------------------------------------------
+
+zero≢suc : ∀ {n} {X : Fin.Fin n} → Fin.zero ≢ Fin.suc X
+zero≢suc ()
+
+instance-B-worlds-differ : T6.InstanceB.W ≢ T6.InstanceB.Wᵖ
+instance-B-worlds-differ eq =
+  zero≢suc
+    (cong
+      (λ W → toRenameᵗ (CTX.ηᴸʷ W) T6.InstanceB.X)
+      eq)
+
+current-global-origin-uniqueness-refuted :
+  (∀ {Δᴸ Δᴿ Δ}
+      {W Wcore Wmid : CTX.World Δᴸ Δᴿ Δ}
+      {Xᴸ : TyVar Δᴸ} {Xᴿ : TyVar Δᴿ}
+    → CTX.RebaseAt W Wmid Xᴸ Xᴿ
+    → CTX.RebaseAt Wcore Wmid Xᴸ Xᴿ
+    → W ≡ Wcore)
+  → ⊥
+current-global-origin-uniqueness-refuted unique =
+  instance-B-worlds-differ
+    (unique T6.InstanceB.rb-X-Y T6.InstanceB.rb-chain)


### PR DESCRIPTION
Residual-discharge wave against the assembled dispatchers. DISCHARGED: the packaged seal-★ row via D11 ROUTE 2 (package premise caught up, target rewrapped through target-conceal) — StructuralValueDispatcherProof.agda. BLOCKED with recorded notes: (a) all four reveal/conceal keep rows on a single shared obstruction — the approved T12 peel returns the payload relation at the peel's inner world Wcore while the dispatcher theorem requires it at W, and the rebases do not identify those worlds (notes/dispatcher-t12-world-cycle-obstruction.red) — this is D18 material: either the T12 surface conclusions need world transport built in, or a world-identification/bridging lemma is needed (possibly derivable from the D16 invariants); (b) extra-cast injection/projection need a post-source ground endpoint the exposed paired casts lack, plus one occupied source-seal premise in RightInjInversion² that D17 does not discharge (notes/dispatcher-extra-cast-extractor-obstruction.red). Remaining factory residuals enumerated in the report. Gate green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)