### PR TITLE
Explore alternative reduction rules and type system for GTSFImp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,3 +577,16 @@ Prefer exhaustive case splits.
 Never add a postulate whose type (the logical formula) is the same as
 another theorem or postulate. This can lead to wasting time on
 circular reasoning during proof development.
+
+## Use the Agda MCP server for the inner loop (from 2026-08-22)
+
+An `agda` MCP server is configured for codex in this container
+(agda-mcp, `--dynamic-workspaces`). Use it for the edit-recheck inner
+loop instead of batch `agda` invocations: warm rechecks of an edited
+file are 1–2 orders of magnitude faster than a cold batch run, and the
+server also answers goal, context, refine, and case-split queries. Big
+loads return async jobs — await them with `agda_job_await`; the full
+result (including the workspace handle) is in `structuredContent`, not
+the compact text. Batch `make check` (or a direct `agda --safe -v0`)
+remains the FINAL gate before committing — the MCP server is for
+iteration, not for the gate.

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -30,6 +30,7 @@ import alt.Store
 import alt.Conversion
 import alt.Terms
 import alt.Reduction
+import alt.GeneratorEndpoint
 
 ------------------------------------------------------------------------
 -- Source language and compilation

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -35,3 +35,4 @@ import Compile
 ------------------------------------------------------------------------
 
 import ConsistencyExamples
+import alt.probes.EscapeReentryProbe

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -2,184 +2,36 @@ module All where
 
 -- File Charter:
 --   * Type-checking this module type-checks the whole development.
---   * Import policy: list the TOP-LEVEL modules only — the finished
---     baseline metatheory, the finished major lemmas (their public
---     Lemma/theorem modules), and the current proof frontier. Helper
---     modules (Def/Proof internals, Support files, workers) are
---     checked transitively and are deliberately NOT listed here.
---   * Leaf gates: files that nothing imports (probes, example suites,
---     catalogs, counterexample records, and checked-but-unconsumed
---     libraries) must be listed in the "Leaf gates" section below or
---     they silently leave the gate.
-------------------------------------------------------------------------
--- Baseline metatheory (finished)
-------------------------------------------------------------------------
-
-import proof.TypeSafety.Progress
-import proof.TypeSafety.Preservation
-import GradualTypeCheck
-import proof.ImprecisionConsistency
-import proof.Imprecision
-import proof.Consistency
-import proof.Consistency2
-import proof.Reduction
+--   * This branch explores an alternative reduction/typing design; the
+--     proof/ directory and everything depending on it (TypeSafety,
+--     Eval, Example, GradualTypeCheck, DGG) are removed from the gate
+--     and will be re-added as they are rebuilt against the new design.
 
 ------------------------------------------------------------------------
--- Major lemmas (finished)
+-- Core definitions
 ------------------------------------------------------------------------
 
-import proof.DGG.CompilePreservesImprecision2
-import proof.DGG.GroundingMint
-import proof.DGG.GroundingPreserve
-import proof.DGG.CastConsistencyViews
-import proof.DGG.Inversion.SpineValueProof
-import proof.DGG.Parked.ParkedWorldLemma
-import proof.DGG.Parked.ParkedD4CheckpointLemma
+import Types
+import TyStore
+import TermCtx
+import Primitives
+import Imprecision
+import Consistency
+import Consistency2
+import Conversion
+import CastTerms
+import Reduction
 
 ------------------------------------------------------------------------
--- Current frontier (M4/M5: catch-up lemmas, higher-order)
+-- Source language and compilation
 ------------------------------------------------------------------------
 
-import proof.DGG.Catchup.InstCatchupRightProof
-import proof.DGG.Catchup.InstCatchupRightRelProof
-import proof.DGG.Catchup.InstInversionDef
-import proof.DGG.Catchup.InstInversionProof
-import proof.DGG.Catchup.InstInversionLambdaProof
-import proof.DGG.Catchup.StructuralValueInstantiationStateDef
-import proof.DGG.Catchup.StructuralValueInstantiationCastMassDef
-import proof.DGG.Catchup.StructuralValueInstantiationRankDef
-import proof.DGG.Catchup.StructuralValueInstantiationRankProof
-import proof.DGG.Catchup.StructuralValueInstantiationCastMassProof
-import proof.DGG.Catchup.StructuralValueInstantiationValueCastMassProof
-import proof.DGG.Catchup.StructuralValueInstantiationSpineCastMassProof
-import proof.DGG.Catchup.StructuralValueInstantiationPendingCastMassProof
-import proof.DGG.Catchup.StructuralValueInstantiationGenCastMassProof
-import proof.DGG.Catchup.StructuralValueInstantiationInstCastMassProof
-import proof.DGG.Catchup.StructuralValueInstantiationAllCastMassProof
-import proof.DGG.Catchup.StructuralFrameOutcomeDef
-import proof.DGG.Catchup.StructuralFrameOutcomeProof
-import proof.DGG.Catchup.StructuralValueInstantiationReductionProof
-import proof.DGG.Catchup.StructuralValueInstantiationViewDef
-import proof.DGG.Catchup.StructuralValueInstantiationViewProof
-import proof.DGG.Catchup.StructuralValueInstantiationCastProof
-import proof.DGG.Catchup.StructuralGeneratedFrameGeometryDef
-import proof.DGG.Catchup.StructuralTargetFrameAbsorptionDef
-import proof.DGG.Catchup.StructuralSpineTypingDef
-import proof.DGG.Catchup.StructuralStrictViewSurfaceDef
-import proof.DGG.Catchup.StructuralWorldExtendDef
-import proof.DGG.Catchup.StructuralWorldExtendProof
-import proof.DGG.Catchup.StructuralRightParkedEvolveProof
-import proof.DGG.Catchup.BoundaryValueAdaptersProof
-import proof.DGG.Catchup.StructuralWorldRebaseProof
-import proof.DGG.Catchup.StructuralWorldTagRebaseDef
-import proof.DGG.Catchup.StructuralWorldTagRebaseProof
-import proof.DGG.Catchup.StructuralWorldSmartLiftDef
-import proof.DGG.Catchup.StructuralWorldSmartLiftProof
-import proof.DGG.Catchup.StructuralWorldLiftLeftProof
-import proof.DGG.Catchup.StructuralWorldEvidenceProof
-import proof.DGG.Catchup.StructuralSourceLambdaReplayProof
-import proof.DGG.Catchup.StructuralSourceRebaseReplayProof
-import proof.DGG.Catchup.StructuralTargetInstantiationDef
-import proof.DGG.Catchup.StructuralTargetInstantiationProof
-import proof.DGG.Catchup.StructuralTargetPeelSupportProof
-import proof.DGG.Catchup.StructuralTargetSpineStepInversionProof
-import proof.DGG.Catchup.StructuralTargetFrameDecompositionProof
-import proof.DGG.Catchup.StructuralTargetSourceTransportProof
-import proof.DGG.Catchup.StructuralTargetLambdaStepProof
-import proof.DGG.Catchup.StructuralTargetGenStepProof
-import proof.DGG.Catchup.StructuralTargetInstStepProof
-import proof.DGG.Catchup.StructuralTargetInstPeelProof
-import proof.DGG.Catchup.StructuralTargetConversionStepProof
-import proof.DGG.Catchup.StructuralTargetAllStepProof
-import proof.DGG.Catchup.StructuralTargetAllPeelProof
-import proof.DGG.Catchup.StructuralTargetLambdaPeelProof
-import proof.DGG.Catchup.StructuralTargetGenPeelProof
-import proof.DGG.Catchup.StructuralTargetRevealPeelProof
-import proof.DGG.Catchup.StructuralTargetConcealPeelProof
-import proof.DGG.Catchup.StructuralInstantiationDescentDef
-import proof.DGG.Catchup.StructuralInstantiationDescentProof
-import proof.DGG.Catchup.StructuralAllDescentProof
-import proof.DGG.Catchup.StructuralGenDescentProof
-import proof.DGG.Catchup.StructuralInstDescentProof
-import proof.DGG.Catchup.StructuralNameInstantiationProof
-
-------------------------------------------------------------------------
--- Current frontier (M6: value catch-up foundation)
-------------------------------------------------------------------------
-
-import proof.DGG.Catchup.ValueCatchupRightDef
-import proof.DGG.Catchup.FuelSupportProof
-import proof.DGG.Catchup.GeneratedProjectionReplacementProof
-import proof.DGG.Catchup.TargetCastStepInversionProof
-import proof.DGG.Catchup.TagLayerExtractionProof
-import proof.DGG.Catchup.ExtraCastRightAtProof
-import proof.DGG.Catchup.ValueCatchupRightProof
-import proof.DGG.Catchup.StructuralValueKeepProof
-import proof.DGG.Catchup.StructuralValueDispatcherProof
-import proof.DGG.Catchup.StructuralExtraCastDispatcherProof
-import proof.DGG.Catchup.FuelKnotProof
-import proof.DGG.Catchup.FuelDischargeProof
-import proof.DGG.Catchup.LeftBoundaryCatchupDef
-import proof.DGG.Catchup.LeftValueCatchupDef
-import proof.DGG.Catchup.LeftSourceOperationsDef
-import proof.DGG.Catchup.LeftBlameLiftProof
-import proof.DGG.Catchup.LeftValueCatchupProof
-
-------------------------------------------------------------------------
--- Current frontier (M8: higher-order DGG assembly)
-------------------------------------------------------------------------
-
-import proof.DGG.SimPrimitiveValuesProof
-import proof.DGG.SimCastLayerInversion
-import proof.DGG.SimSourceCastValuesProof
-import proof.DGG.SimPairedCastValuesProof
-import proof.DGG.SimConcealRevealPeel
-import proof.DGG.SimSourceRevealValuesProof
-import proof.DGG.SimPairedRevealValuesProof
-import proof.DGG.SimSourceConcealValuesProof
-import proof.DGG.SimPairedConcealValuesProof
-import proof.DGG.TransportTermImprecisionProof
-import proof.DGG.SimProof
-import proof.DGG.SimBackProof
-import proof.DGG.MultiSimProof
-import proof.DGG.MultiSimBackProof
-import proof.DGG.TargetBlameCatchupProof
-import proof.DGG.SimConcealRevealPeel
-import proof.DGG.CatchupToLessPreciseProof
-import proof.DGG.DynamicGradualGuaranteeProof
+import GradualTerms
+import GradualTermImprecision
+import Compile
 
 ------------------------------------------------------------------------
 -- Leaf gates: nothing imports these; listed so they stay checked
 ------------------------------------------------------------------------
 
--- Example suites and catalogs
-import proof.DGG.WorldSnapshot
-import proof.DGG.ImpLadder
-import proof.DGG.Example12Worlds
-import Example
-import GradualTypeCheckExamples
 import ConsistencyExamples
-import SourceConsistencyExamples
-import proof.DGG.ReachabilityCatalog
-import proof.DGG.CompileImageShape
-import proof.DGG.Phase3DeepDives
-import proof.DGG.GroundCastTargetExamples
-import proof.DGG.SmartCommaWitness
-
--- Probes and counterexample records (design decisions, kept checked)
-import proof.DGG.SourceStarProbe
-import proof.DGG.CenterCrossingProbe
-import proof.DGG.TerminusRebuildProbe
-import proof.DGG.StarRepChainProbe
-import proof.DGG.SealPeelProbe
-import proof.DGG.LambdaImpProbe
-import proof.DGG.MovedLinkProbe
-import proof.DGG.ChainRideProbe
-import proof.DGG.TagBoundaryProbe
-
--- Checked libraries currently without consumers (candidates for M7+)
-import proof.DGG.CenterRename
-import proof.DGG.Occupancy
-import proof.DGG.WorldSupport
-import proof.DGG.TargetExtend
-import proof.DGG.TargetBindLift

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -31,6 +31,7 @@ import alt.Conversion
 import alt.Terms
 import alt.Reduction
 import alt.GeneratorEndpoint
+import alt.Exchange
 
 ------------------------------------------------------------------------
 -- Source language and compilation

--- a/GTSFImp/All.agda
+++ b/GTSFImp/All.agda
@@ -23,6 +23,15 @@ import CastTerms
 import Reduction
 
 ------------------------------------------------------------------------
+-- Alternative shift-free core (exploration)
+------------------------------------------------------------------------
+
+import alt.Store
+import alt.Conversion
+import alt.Terms
+import alt.Reduction
+
+------------------------------------------------------------------------
 -- Source language and compilation
 ------------------------------------------------------------------------
 

--- a/GTSFImp/alt/Conversion.agda
+++ b/GTSFImp/alt/Conversion.agda
@@ -1,24 +1,22 @@
 module alt.Conversion where
 
 -- File Charter:
---   * Defines intrinsically endpoint-typed shift-free conversions.
---   * Identity leaves are restricted to atoms.
---   * Pivot strictness states that every seal or unseal leaf uses one
---     supplied scoped variable; an all-identity delimiter is permitted.
+--   * Defines raw, endpoint-free reveal and conceal conversion shapes.
+--   * Defines the self-contained scoped conversion-typing judgments.
+--   * Provides type-directed shape generators and their typing proofs.
+--   * Depends only on Types: stores, anchors, and classifiers are node data.
 
-import Data.Fin as Fin
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Fin.Properties using (_≟_)
-open import Data.Nat using (ℕ)
 import Data.Nat as Nat
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality using (refl)
 open import Relation.Nullary using (yes; no)
 
 open import Types
 
 private
   variable
-    Δ Δ′ : TyCtx
+    Δ : TyCtx
 
 ------------------------------------------------------------------------
 -- Inserting one scoped-variable slot
@@ -46,175 +44,159 @@ replaceTy X R (A ⇒ B) = replaceTy X R A ⇒ replaceTy X R B
 replaceTy X R (`∀ A) = `∀ (replaceTy (suc X) (⇑ᵗ R) A)
 
 ------------------------------------------------------------------------
--- Intrinsically endpoint-typed conversions
+-- Raw conversion shapes
 ------------------------------------------------------------------------
 
 infixr 7 _↦↑_ _↦↓_
 
 mutual
-  data Conv↑ (Δ : TyCtx) : Ty Δ → Ty Δ → Set where
-    unseal : (X : TyVar Δ) (R : Ty Δ) → Conv↑ Δ (＇ X) R
+  data Conv↑ : Set where
+    unseal : Conv↑
+    _↦↑_ : Conv↓ → Conv↑ → Conv↑
+    `∀↑_ : Conv↑ → Conv↑
+    id↑ : Conv↑
 
-    _↦↑_ : ∀ {A A′ B B′}
-      → Conv↓ Δ A′ A
-      → Conv↑ Δ B B′
-      → Conv↑ Δ (A ⇒ B) (A′ ⇒ B′)
+  data Conv↓ : Set where
+    seal : Conv↓
+    _↦↓_ : Conv↑ → Conv↓ → Conv↓
+    `∀↓_ : Conv↓ → Conv↓
+    id↓ : Conv↓
 
-    `∀↑_ : ∀ {A B}
-      → Conv↑ (Nat.suc Δ) A B
-      → Conv↑ Δ (`∀ A) (`∀ B)
+------------------------------------------------------------------------
+-- Scoped conversion typing
+------------------------------------------------------------------------
 
-    id↑ : ∀ {A}
+-- Read `⊢↑[ X ⦂ R ] c ⦂ A ↝ B` as: at pivot X, whose scoped
+-- representation is R, the raw reveal shape c converts A to B.  The
+-- conceal judgment is dual.  Neither judgment mentions a store, anchor,
+-- or scoped-variable classifier.
+
+infix 4 ⊢↑[_⦂_]_⦂_↝_ ⊢↓[_⦂_]_⦂_↝_
+
+mutual
+  data ⊢↑[_⦂_]_⦂_↝_ {Δ : TyCtx} :
+      TyVar Δ → Ty Δ → Conv↑ → Ty Δ → Ty Δ → Set where
+    ⊢unseal : ∀ {X R}
+      → ⊢↑[ X ⦂ R ] unseal ⦂ ＇ X ↝ R
+
+    ⊢↑-⇒ : ∀ {X R c d A A′ B B′}
+      → ⊢↓[ X ⦂ R ] c ⦂ A′ ↝ A
+      → ⊢↑[ X ⦂ R ] d ⦂ B ↝ B′
+      → ⊢↑[ X ⦂ R ] c ↦↑ d ⦂ A ⇒ B ↝ A′ ⇒ B′
+
+    ⊢↑-∀ : ∀ {X R c A B}
+      → ⊢↑[ suc X ⦂ ⇑ᵗ R ] c ⦂ A ↝ B
+      → ⊢↑[ X ⦂ R ] `∀↑ c ⦂ `∀ A ↝ `∀ B
+
+    ⊢id↑ : ∀ {X R A}
       → Atom A
-      → Conv↑ Δ A A
+      → ⊢↑[ X ⦂ R ] id↑ ⦂ A ↝ A
 
-  data Conv↓ (Δ : TyCtx) : Ty Δ → Ty Δ → Set where
-    seal : (X : TyVar Δ) (R : Ty Δ) → Conv↓ Δ R (＇ X)
+  data ⊢↓[_⦂_]_⦂_↝_ {Δ : TyCtx} :
+      TyVar Δ → Ty Δ → Conv↓ → Ty Δ → Ty Δ → Set where
+    ⊢seal : ∀ {X R}
+      → ⊢↓[ X ⦂ R ] seal ⦂ R ↝ ＇ X
 
-    _↦↓_ : ∀ {A A′ B B′}
-      → Conv↑ Δ A′ A
-      → Conv↓ Δ B B′
-      → Conv↓ Δ (A ⇒ B) (A′ ⇒ B′)
+    ⊢↓-⇒ : ∀ {X R c d A A′ B B′}
+      → ⊢↑[ X ⦂ R ] c ⦂ A′ ↝ A
+      → ⊢↓[ X ⦂ R ] d ⦂ B ↝ B′
+      → ⊢↓[ X ⦂ R ] c ↦↓ d ⦂ A ⇒ B ↝ A′ ⇒ B′
 
-    `∀↓_ : ∀ {A B}
-      → Conv↓ (Nat.suc Δ) A B
-      → Conv↓ Δ (`∀ A) (`∀ B)
+    ⊢↓-∀ : ∀ {X R c A B}
+      → ⊢↓[ suc X ⦂ ⇑ᵗ R ] c ⦂ A ↝ B
+      → ⊢↓[ X ⦂ R ] `∀↓ c ⦂ `∀ A ↝ `∀ B
 
-    id↓ : ∀ {A}
+    ⊢id↓ : ∀ {X R A}
       → Atom A
-      → Conv↓ Δ A A
+      → ⊢↓[ X ⦂ R ] id↓ ⦂ A ↝ A
 
 ------------------------------------------------------------------------
 -- Structural conversion generation
 ------------------------------------------------------------------------
 
 mutual
-  〖_,_↑_〗 : (X : TyVar Δ) (R B : Ty Δ)
-    → Conv↑ Δ B (replaceTy X R B)
+  〖_,_↑_〗 : TyVar Δ → Ty Δ → Ty Δ → Conv↑
   〖 X , R ↑ (＇ Y) 〗 with X ≟ Y
-  〖 X , R ↑ (＇ .X) 〗 | yes refl = unseal X R
-  〖 X , R ↑ (＇ Y) 〗 | no X≠Y = id↑ (＇ Y)
-  〖 X , R ↑ (‵ ι) 〗 = id↑ (‵ ι)
-  〖 X , R ↑ ★ 〗 = id↑ ★
+  〖 X , R ↑ (＇ .X) 〗 | yes refl = unseal
+  〖 X , R ↑ (＇ Y) 〗 | no X≠Y = id↑
+  〖 X , R ↑ (‵ ι) 〗 = id↑
+  〖 X , R ↑ ★ 〗 = id↑
   〖 X , R ↑ (A ⇒ B) 〗 =
     makeConceal X R A ↦↑ 〖 X , R ↑ B 〗
   〖 X , R ↑ (`∀ A) 〗 = `∀↑ 〖 suc X , ⇑ᵗ R ↑ A 〗
 
-  makeConceal : (X : TyVar Δ) (R B : Ty Δ)
-    → Conv↓ Δ (replaceTy X R B) B
+  makeConceal : TyVar Δ → Ty Δ → Ty Δ → Conv↓
   makeConceal X R (＇ Y) with X ≟ Y
-  makeConceal X R (＇ .X) | yes refl = seal X R
-  makeConceal X R (＇ Y) | no X≠Y = id↓ (＇ Y)
-  makeConceal X R (‵ ι) = id↓ (‵ ι)
-  makeConceal X R ★ = id↓ ★
+  makeConceal X R (＇ .X) | yes refl = seal
+  makeConceal X R (＇ Y) | no X≠Y = id↓
+  makeConceal X R (‵ ι) = id↓
+  makeConceal X R ★ = id↓
   makeConceal X R (A ⇒ B) =
     〖 X , R ↑ A 〗 ↦↓ makeConceal X R B
   makeConceal X R (`∀ A) =
-    `∀↓ (makeConceal (suc X) (⇑ᵗ R) A)
+    `∀↓ makeConceal (suc X) (⇑ᵗ R) A
+
+mutual
+  generator-typed↑ : (X : TyVar Δ) (R B : Ty Δ)
+    → ⊢↑[ X ⦂ R ] 〖 X , R ↑ B 〗 ⦂ B ↝ replaceTy X R B
+  generator-typed↑ X R (＇ Y) with X ≟ Y
+  generator-typed↑ X R (＇ .X) | yes refl = ⊢unseal
+  generator-typed↑ X R (＇ Y) | no X≠Y = ⊢id↑ (＇ Y)
+  generator-typed↑ X R (‵ ι) = ⊢id↑ (‵ ι)
+  generator-typed↑ X R ★ = ⊢id↑ ★
+  generator-typed↑ X R (A ⇒ B) =
+    ⊢↑-⇒ (generator-typed↓ X R A) (generator-typed↑ X R B)
+  generator-typed↑ X R (`∀ B) =
+    ⊢↑-∀ (generator-typed↑ (suc X) (⇑ᵗ R) B)
+
+  generator-typed↓ : (X : TyVar Δ) (R B : Ty Δ)
+    → ⊢↓[ X ⦂ R ] makeConceal X R B ⦂ replaceTy X R B ↝ B
+  generator-typed↓ X R (＇ Y) with X ≟ Y
+  generator-typed↓ X R (＇ .X) | yes refl = ⊢seal
+  generator-typed↓ X R (＇ Y) | no X≠Y = ⊢id↓ (＇ Y)
+  generator-typed↓ X R (‵ ι) = ⊢id↓ (‵ ι)
+  generator-typed↓ X R ★ = ⊢id↓ ★
+  generator-typed↓ X R (A ⇒ B) =
+    ⊢↓-⇒ (generator-typed↑ X R A) (generator-typed↓ X R B)
+  generator-typed↓ X R (`∀ B) =
+    ⊢↓-∀ (generator-typed↓ (suc X) (⇑ᵗ R) B)
 
 ------------------------------------------------------------------------
 -- Structural delimiters
 ------------------------------------------------------------------------
 
 mutual
-  δ↑ : (A : Ty Δ) → Conv↑ Δ A A
-  δ↑ (＇ X) = id↑ (＇ X)
-  δ↑ (‵ ι) = id↑ (‵ ι)
-  δ↑ ★ = id↑ ★
+  δ↑ : Ty Δ → Conv↑
+  δ↑ (＇ X) = id↑
+  δ↑ (‵ ι) = id↑
+  δ↑ ★ = id↑
   δ↑ (A ⇒ B) = δ↓ A ↦↑ δ↑ B
   δ↑ (`∀ A) = `∀↑ δ↑ A
 
-  δ↓ : (A : Ty Δ) → Conv↓ Δ A A
-  δ↓ (＇ X) = id↓ (＇ X)
-  δ↓ (‵ ι) = id↓ (‵ ι)
-  δ↓ ★ = id↓ ★
+  δ↓ : Ty Δ → Conv↓
+  δ↓ (＇ X) = id↓
+  δ↓ (‵ ι) = id↓
+  δ↓ ★ = id↓
   δ↓ (A ⇒ B) = δ↑ A ↦↓ δ↓ B
   δ↓ (`∀ A) = `∀↓ δ↓ A
 
-------------------------------------------------------------------------
--- Type-variable renaming
-------------------------------------------------------------------------
-
 mutual
-  rename↑ : ∀ (ρ : Δ ⇒ʳ Δ′) {A B}
-    → Conv↑ Δ A B
-    → Conv↑ Δ′ (renameᵗ ρ A) (renameᵗ ρ B)
-  rename↑ ρ (unseal X R) = unseal (ρ X) (renameᵗ ρ R)
-  rename↑ ρ (c ↦↑ d) = rename↓ ρ c ↦↑ rename↑ ρ d
-  rename↑ ρ (`∀↑ c) = `∀↑ (rename↑ (extᵗ ρ) c)
-  rename↑ ρ (id↑ a) = id↑ (renameAtom ρ a)
+  delimiter-typed↑ : (X : TyVar Δ) (R A : Ty Δ)
+    → ⊢↑[ X ⦂ R ] δ↑ A ⦂ A ↝ A
+  delimiter-typed↑ X R (＇ Y) = ⊢id↑ (＇ Y)
+  delimiter-typed↑ X R (‵ ι) = ⊢id↑ (‵ ι)
+  delimiter-typed↑ X R ★ = ⊢id↑ ★
+  delimiter-typed↑ X R (A ⇒ B) =
+    ⊢↑-⇒ (delimiter-typed↓ X R A) (delimiter-typed↑ X R B)
+  delimiter-typed↑ X R (`∀ A) =
+    ⊢↑-∀ (delimiter-typed↑ (suc X) (⇑ᵗ R) A)
 
-  rename↓ : ∀ (ρ : Δ ⇒ʳ Δ′) {A B}
-    → Conv↓ Δ A B
-    → Conv↓ Δ′ (renameᵗ ρ A) (renameᵗ ρ B)
-  rename↓ ρ (seal X R) = seal (ρ X) (renameᵗ ρ R)
-  rename↓ ρ (c ↦↓ d) = rename↑ ρ c ↦↓ rename↓ ρ d
-  rename↓ ρ (`∀↓ c) = `∀↓ (rename↓ (extᵗ ρ) c)
-  rename↓ ρ (id↓ a) = id↓ (renameAtom ρ a)
-
-  renameAtom : ∀ (ρ : Δ ⇒ʳ Δ′) {A}
-    → Atom A
-    → Atom (renameᵗ ρ A)
-  renameAtom ρ (＇ X) = ＇ (ρ X)
-  renameAtom ρ (‵ ι) = ‵ ι
-  renameAtom ρ ★ = ★
-
-------------------------------------------------------------------------
--- Pivot strictness
-------------------------------------------------------------------------
-
-mutual
-  data PivotStrict↑ {Δ : TyCtx} (X : TyVar Δ) :
-      ∀ {A B} → Conv↑ Δ A B → Set where
-    strict-unseal : ∀ {R}
-      → PivotStrict↑ X (unseal X R)
-
-    strict-↑⇒ : ∀ {A A′ B B′}
-        {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
-      → PivotStrict↓ X c
-      → PivotStrict↑ X d
-      → PivotStrict↑ X (c ↦↑ d)
-
-    strict-↑∀ : ∀ {A B} {c : Conv↑ (Nat.suc Δ) A B}
-      → PivotStrict↑ (suc X) c
-      → PivotStrict↑ X (`∀↑ c)
-
-    strict-id↑ : ∀ {A} {a : Atom A}
-      → PivotStrict↑ X (id↑ a)
-
-  data PivotStrict↓ {Δ : TyCtx} (X : TyVar Δ) :
-      ∀ {A B} → Conv↓ Δ A B → Set where
-    strict-seal : ∀ {R}
-      → PivotStrict↓ X (seal X R)
-
-    strict-↓⇒ : ∀ {A A′ B B′}
-        {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
-      → PivotStrict↑ X c
-      → PivotStrict↓ X d
-      → PivotStrict↓ X (c ↦↓ d)
-
-    strict-↓∀ : ∀ {A B} {c : Conv↓ (Nat.suc Δ) A B}
-      → PivotStrict↓ (suc X) c
-      → PivotStrict↓ X (`∀↓ c)
-
-    strict-id↓ : ∀ {A} {a : Atom A}
-      → PivotStrict↓ X (id↓ a)
-
-mutual
-  δ-strict↑ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
-    → PivotStrict↑ X (δ↑ A)
-  δ-strict↑ X (＇ Y) = strict-id↑
-  δ-strict↑ X (‵ ι) = strict-id↑
-  δ-strict↑ X ★ = strict-id↑
-  δ-strict↑ X (A ⇒ B) =
-    strict-↑⇒ (δ-strict↓ X A) (δ-strict↑ X B)
-  δ-strict↑ X (`∀ A) = strict-↑∀ (δ-strict↑ (suc X) A)
-
-  δ-strict↓ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
-    → PivotStrict↓ X (δ↓ A)
-  δ-strict↓ X (＇ Y) = strict-id↓
-  δ-strict↓ X (‵ ι) = strict-id↓
-  δ-strict↓ X ★ = strict-id↓
-  δ-strict↓ X (A ⇒ B) =
-    strict-↓⇒ (δ-strict↑ X A) (δ-strict↓ X B)
-  δ-strict↓ X (`∀ A) = strict-↓∀ (δ-strict↓ (suc X) A)
+  delimiter-typed↓ : (X : TyVar Δ) (R A : Ty Δ)
+    → ⊢↓[ X ⦂ R ] δ↓ A ⦂ A ↝ A
+  delimiter-typed↓ X R (＇ Y) = ⊢id↓ (＇ Y)
+  delimiter-typed↓ X R (‵ ι) = ⊢id↓ (‵ ι)
+  delimiter-typed↓ X R ★ = ⊢id↓ ★
+  delimiter-typed↓ X R (A ⇒ B) =
+    ⊢↓-⇒ (delimiter-typed↑ X R A) (delimiter-typed↓ X R B)
+  delimiter-typed↓ X R (`∀ A) =
+    ⊢↓-∀ (delimiter-typed↓ (suc X) (⇑ᵗ R) A)

--- a/GTSFImp/alt/Conversion.agda
+++ b/GTSFImp/alt/Conversion.agda
@@ -50,17 +50,17 @@ replaceTy X R (`∀ A) = `∀ (replaceTy (suc X) (⇑ᵗ R) A)
 infixr 7 _↦↑_ _↦↓_
 
 mutual
-  data Conv↑ : Set where
-    unseal : Conv↑
-    _↦↑_ : Conv↓ → Conv↑ → Conv↑
-    `∀↑_ : Conv↑ → Conv↑
-    id↑ : Conv↑
+  data Reveal : Set where
+    unseal : Reveal
+    _↦↑_ : Conceal → Reveal → Reveal
+    `∀↑_ : Reveal → Reveal
+    id↑ : Reveal
 
-  data Conv↓ : Set where
-    seal : Conv↓
-    _↦↓_ : Conv↑ → Conv↓ → Conv↓
-    `∀↓_ : Conv↓ → Conv↓
-    id↓ : Conv↓
+  data Conceal : Set where
+    seal : Conceal
+    _↦↓_ : Reveal → Conceal → Conceal
+    `∀↓_ : Conceal → Conceal
+    id↓ : Conceal
 
 ------------------------------------------------------------------------
 -- Scoped conversion typing
@@ -75,7 +75,7 @@ infix 4 ⊢↑[_⦂_]_⦂_↝_ ⊢↓[_⦂_]_⦂_↝_
 
 mutual
   data ⊢↑[_⦂_]_⦂_↝_ {Δ : TyCtx} :
-      TyVar Δ → Ty Δ → Conv↑ → Ty Δ → Ty Δ → Set where
+      TyVar Δ → Ty Δ → Reveal → Ty Δ → Ty Δ → Set where
     ⊢unseal : ∀ {X R}
       → ⊢↑[ X ⦂ R ] unseal ⦂ ＇ X ↝ R
 
@@ -93,7 +93,7 @@ mutual
       → ⊢↑[ X ⦂ R ] id↑ ⦂ A ↝ A
 
   data ⊢↓[_⦂_]_⦂_↝_ {Δ : TyCtx} :
-      TyVar Δ → Ty Δ → Conv↓ → Ty Δ → Ty Δ → Set where
+      TyVar Δ → Ty Δ → Conceal → Ty Δ → Ty Δ → Set where
     ⊢seal : ∀ {X R}
       → ⊢↓[ X ⦂ R ] seal ⦂ R ↝ ＇ X
 
@@ -115,7 +115,7 @@ mutual
 ------------------------------------------------------------------------
 
 mutual
-  〖_,_↑_〗 : TyVar Δ → Ty Δ → Ty Δ → Conv↑
+  〖_,_↑_〗 : TyVar Δ → Ty Δ → Ty Δ → Reveal
   〖 X , R ↑ (＇ Y) 〗 with X ≟ Y
   〖 X , R ↑ (＇ .X) 〗 | yes refl = unseal
   〖 X , R ↑ (＇ Y) 〗 | no X≠Y = id↑
@@ -125,7 +125,7 @@ mutual
     makeConceal X R A ↦↑ 〖 X , R ↑ B 〗
   〖 X , R ↑ (`∀ A) 〗 = `∀↑ 〖 suc X , ⇑ᵗ R ↑ A 〗
 
-  makeConceal : TyVar Δ → Ty Δ → Ty Δ → Conv↓
+  makeConceal : TyVar Δ → Ty Δ → Ty Δ → Conceal
   makeConceal X R (＇ Y) with X ≟ Y
   makeConceal X R (＇ .X) | yes refl = seal
   makeConceal X R (＇ Y) | no X≠Y = id↓
@@ -166,14 +166,14 @@ mutual
 ------------------------------------------------------------------------
 
 mutual
-  δ↑ : Ty Δ → Conv↑
+  δ↑ : Ty Δ → Reveal
   δ↑ (＇ X) = id↑
   δ↑ (‵ ι) = id↑
   δ↑ ★ = id↑
   δ↑ (A ⇒ B) = δ↓ A ↦↑ δ↑ B
   δ↑ (`∀ A) = `∀↑ δ↑ A
 
-  δ↓ : Ty Δ → Conv↓
+  δ↓ : Ty Δ → Conceal
   δ↓ (＇ X) = id↓
   δ↓ (‵ ι) = id↓
   δ↓ ★ = id↓

--- a/GTSFImp/alt/Conversion.agda
+++ b/GTSFImp/alt/Conversion.agda
@@ -117,19 +117,19 @@ mutual
 ------------------------------------------------------------------------
 
 mutual
-  delimiter↑ : (A : Ty Δ) → Conv↑ Δ A A
-  delimiter↑ (＇ X) = id↑ (＇ X)
-  delimiter↑ (‵ ι) = id↑ (‵ ι)
-  delimiter↑ ★ = id↑ ★
-  delimiter↑ (A ⇒ B) = delimiter↓ A ↦↑ delimiter↑ B
-  delimiter↑ (`∀ A) = `∀↑ delimiter↑ A
+  δ↑ : (A : Ty Δ) → Conv↑ Δ A A
+  δ↑ (＇ X) = id↑ (＇ X)
+  δ↑ (‵ ι) = id↑ (‵ ι)
+  δ↑ ★ = id↑ ★
+  δ↑ (A ⇒ B) = δ↓ A ↦↑ δ↑ B
+  δ↑ (`∀ A) = `∀↑ δ↑ A
 
-  delimiter↓ : (A : Ty Δ) → Conv↓ Δ A A
-  delimiter↓ (＇ X) = id↓ (＇ X)
-  delimiter↓ (‵ ι) = id↓ (‵ ι)
-  delimiter↓ ★ = id↓ ★
-  delimiter↓ (A ⇒ B) = delimiter↑ A ↦↓ delimiter↓ B
-  delimiter↓ (`∀ A) = `∀↓ delimiter↓ A
+  δ↓ : (A : Ty Δ) → Conv↓ Δ A A
+  δ↓ (＇ X) = id↓ (＇ X)
+  δ↓ (‵ ι) = id↓ (‵ ι)
+  δ↓ ★ = id↓ ★
+  δ↓ (A ⇒ B) = δ↑ A ↦↓ δ↓ B
+  δ↓ (`∀ A) = `∀↓ δ↓ A
 
 ------------------------------------------------------------------------
 -- Type-variable renaming
@@ -201,20 +201,20 @@ mutual
       → PivotStrict↓ X (id↓ a)
 
 mutual
-  delimiter-strict↑ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
-    → PivotStrict↑ X (delimiter↑ A)
-  delimiter-strict↑ X (＇ Y) = strict-id↑
-  delimiter-strict↑ X (‵ ι) = strict-id↑
-  delimiter-strict↑ X ★ = strict-id↑
-  delimiter-strict↑ X (A ⇒ B) =
-    strict-↑⇒ (delimiter-strict↓ X A) (delimiter-strict↑ X B)
-  delimiter-strict↑ X (`∀ A) = strict-↑∀ (delimiter-strict↑ (suc X) A)
+  δ-strict↑ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
+    → PivotStrict↑ X (δ↑ A)
+  δ-strict↑ X (＇ Y) = strict-id↑
+  δ-strict↑ X (‵ ι) = strict-id↑
+  δ-strict↑ X ★ = strict-id↑
+  δ-strict↑ X (A ⇒ B) =
+    strict-↑⇒ (δ-strict↓ X A) (δ-strict↑ X B)
+  δ-strict↑ X (`∀ A) = strict-↑∀ (δ-strict↑ (suc X) A)
 
-  delimiter-strict↓ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
-    → PivotStrict↓ X (delimiter↓ A)
-  delimiter-strict↓ X (＇ Y) = strict-id↓
-  delimiter-strict↓ X (‵ ι) = strict-id↓
-  delimiter-strict↓ X ★ = strict-id↓
-  delimiter-strict↓ X (A ⇒ B) =
-    strict-↓⇒ (delimiter-strict↑ X A) (delimiter-strict↓ X B)
-  delimiter-strict↓ X (`∀ A) = strict-↓∀ (delimiter-strict↓ (suc X) A)
+  δ-strict↓ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
+    → PivotStrict↓ X (δ↓ A)
+  δ-strict↓ X (＇ Y) = strict-id↓
+  δ-strict↓ X (‵ ι) = strict-id↓
+  δ-strict↓ X ★ = strict-id↓
+  δ-strict↓ X (A ⇒ B) =
+    strict-↓⇒ (δ-strict↑ X A) (δ-strict↓ X B)
+  δ-strict↓ X (`∀ A) = strict-↓∀ (δ-strict↓ (suc X) A)

--- a/GTSFImp/alt/Conversion.agda
+++ b/GTSFImp/alt/Conversion.agda
@@ -1,0 +1,220 @@
+module alt.Conversion where
+
+-- File Charter:
+--   * Defines intrinsically endpoint-typed shift-free conversions.
+--   * Identity leaves are restricted to atoms.
+--   * Pivot strictness states that every seal or unseal leaf uses one
+--     supplied scoped variable; an all-identity delimiter is permitted.
+
+import Data.Fin as Fin
+open import Data.Fin using (Fin; zero; suc)
+open import Data.Fin.Properties using (_≟_)
+open import Data.Nat using (ℕ)
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Nullary using (yes; no)
+
+open import Types
+
+private
+  variable
+    Δ Δ′ : TyCtx
+
+------------------------------------------------------------------------
+-- Inserting one scoped-variable slot
+------------------------------------------------------------------------
+
+punchIn : ∀ {Δ} → Fin (Nat.suc Δ) → Fin Δ → Fin (Nat.suc Δ)
+punchIn zero Y = suc Y
+punchIn (suc X) zero = zero
+punchIn (suc X) (suc Y) = suc (punchIn X Y)
+
+wkᵗ : ∀ {Δ} → Fin (Nat.suc Δ) → Ty Δ → Ty (Nat.suc Δ)
+wkᵗ X = renameᵗ (punchIn X)
+
+------------------------------------------------------------------------
+-- Replacing one abstract type by its representation
+------------------------------------------------------------------------
+
+replaceTy : TyVar Δ → Ty Δ → Ty Δ → Ty Δ
+replaceTy X R (＇ Y) with X ≟ Y
+replaceTy X R (＇ .X) | yes refl = R
+replaceTy X R (＇ Y) | no X≠Y = ＇ Y
+replaceTy X R (‵ ι) = ‵ ι
+replaceTy X R ★ = ★
+replaceTy X R (A ⇒ B) = replaceTy X R A ⇒ replaceTy X R B
+replaceTy X R (`∀ A) = `∀ (replaceTy (suc X) (⇑ᵗ R) A)
+
+------------------------------------------------------------------------
+-- Intrinsically endpoint-typed conversions
+------------------------------------------------------------------------
+
+infixr 7 _↦↑_ _↦↓_
+
+mutual
+  data Conv↑ (Δ : TyCtx) : Ty Δ → Ty Δ → Set where
+    unseal : (X : TyVar Δ) (R : Ty Δ) → Conv↑ Δ (＇ X) R
+
+    _↦↑_ : ∀ {A A′ B B′}
+      → Conv↓ Δ A′ A
+      → Conv↑ Δ B B′
+      → Conv↑ Δ (A ⇒ B) (A′ ⇒ B′)
+
+    `∀↑_ : ∀ {A B}
+      → Conv↑ (Nat.suc Δ) A B
+      → Conv↑ Δ (`∀ A) (`∀ B)
+
+    id↑ : ∀ {A}
+      → Atom A
+      → Conv↑ Δ A A
+
+  data Conv↓ (Δ : TyCtx) : Ty Δ → Ty Δ → Set where
+    seal : (X : TyVar Δ) (R : Ty Δ) → Conv↓ Δ R (＇ X)
+
+    _↦↓_ : ∀ {A A′ B B′}
+      → Conv↑ Δ A′ A
+      → Conv↓ Δ B B′
+      → Conv↓ Δ (A ⇒ B) (A′ ⇒ B′)
+
+    `∀↓_ : ∀ {A B}
+      → Conv↓ (Nat.suc Δ) A B
+      → Conv↓ Δ (`∀ A) (`∀ B)
+
+    id↓ : ∀ {A}
+      → Atom A
+      → Conv↓ Δ A A
+
+------------------------------------------------------------------------
+-- Structural conversion generation
+------------------------------------------------------------------------
+
+mutual
+  〖_,_↑_〗 : (X : TyVar Δ) (R B : Ty Δ)
+    → Conv↑ Δ B (replaceTy X R B)
+  〖 X , R ↑ (＇ Y) 〗 with X ≟ Y
+  〖 X , R ↑ (＇ .X) 〗 | yes refl = unseal X R
+  〖 X , R ↑ (＇ Y) 〗 | no X≠Y = id↑ (＇ Y)
+  〖 X , R ↑ (‵ ι) 〗 = id↑ (‵ ι)
+  〖 X , R ↑ ★ 〗 = id↑ ★
+  〖 X , R ↑ (A ⇒ B) 〗 =
+    makeConceal X R A ↦↑ 〖 X , R ↑ B 〗
+  〖 X , R ↑ (`∀ A) 〗 = `∀↑ 〖 suc X , ⇑ᵗ R ↑ A 〗
+
+  makeConceal : (X : TyVar Δ) (R B : Ty Δ)
+    → Conv↓ Δ (replaceTy X R B) B
+  makeConceal X R (＇ Y) with X ≟ Y
+  makeConceal X R (＇ .X) | yes refl = seal X R
+  makeConceal X R (＇ Y) | no X≠Y = id↓ (＇ Y)
+  makeConceal X R (‵ ι) = id↓ (‵ ι)
+  makeConceal X R ★ = id↓ ★
+  makeConceal X R (A ⇒ B) =
+    〖 X , R ↑ A 〗 ↦↓ makeConceal X R B
+  makeConceal X R (`∀ A) =
+    `∀↓ (makeConceal (suc X) (⇑ᵗ R) A)
+
+------------------------------------------------------------------------
+-- Structural delimiters
+------------------------------------------------------------------------
+
+mutual
+  delimiter↑ : (A : Ty Δ) → Conv↑ Δ A A
+  delimiter↑ (＇ X) = id↑ (＇ X)
+  delimiter↑ (‵ ι) = id↑ (‵ ι)
+  delimiter↑ ★ = id↑ ★
+  delimiter↑ (A ⇒ B) = delimiter↓ A ↦↑ delimiter↑ B
+  delimiter↑ (`∀ A) = `∀↑ delimiter↑ A
+
+  delimiter↓ : (A : Ty Δ) → Conv↓ Δ A A
+  delimiter↓ (＇ X) = id↓ (＇ X)
+  delimiter↓ (‵ ι) = id↓ (‵ ι)
+  delimiter↓ ★ = id↓ ★
+  delimiter↓ (A ⇒ B) = delimiter↑ A ↦↓ delimiter↓ B
+  delimiter↓ (`∀ A) = `∀↓ delimiter↓ A
+
+------------------------------------------------------------------------
+-- Type-variable renaming
+------------------------------------------------------------------------
+
+mutual
+  rename↑ : ∀ (ρ : Δ ⇒ʳ Δ′) {A B}
+    → Conv↑ Δ A B
+    → Conv↑ Δ′ (renameᵗ ρ A) (renameᵗ ρ B)
+  rename↑ ρ (unseal X R) = unseal (ρ X) (renameᵗ ρ R)
+  rename↑ ρ (c ↦↑ d) = rename↓ ρ c ↦↑ rename↑ ρ d
+  rename↑ ρ (`∀↑ c) = `∀↑ (rename↑ (extᵗ ρ) c)
+  rename↑ ρ (id↑ a) = id↑ (renameAtom ρ a)
+
+  rename↓ : ∀ (ρ : Δ ⇒ʳ Δ′) {A B}
+    → Conv↓ Δ A B
+    → Conv↓ Δ′ (renameᵗ ρ A) (renameᵗ ρ B)
+  rename↓ ρ (seal X R) = seal (ρ X) (renameᵗ ρ R)
+  rename↓ ρ (c ↦↓ d) = rename↑ ρ c ↦↓ rename↓ ρ d
+  rename↓ ρ (`∀↓ c) = `∀↓ (rename↓ (extᵗ ρ) c)
+  rename↓ ρ (id↓ a) = id↓ (renameAtom ρ a)
+
+  renameAtom : ∀ (ρ : Δ ⇒ʳ Δ′) {A}
+    → Atom A
+    → Atom (renameᵗ ρ A)
+  renameAtom ρ (＇ X) = ＇ (ρ X)
+  renameAtom ρ (‵ ι) = ‵ ι
+  renameAtom ρ ★ = ★
+
+------------------------------------------------------------------------
+-- Pivot strictness
+------------------------------------------------------------------------
+
+mutual
+  data PivotStrict↑ {Δ : TyCtx} (X : TyVar Δ) :
+      ∀ {A B} → Conv↑ Δ A B → Set where
+    strict-unseal : ∀ {R}
+      → PivotStrict↑ X (unseal X R)
+
+    strict-↑⇒ : ∀ {A A′ B B′}
+        {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
+      → PivotStrict↓ X c
+      → PivotStrict↑ X d
+      → PivotStrict↑ X (c ↦↑ d)
+
+    strict-↑∀ : ∀ {A B} {c : Conv↑ (Nat.suc Δ) A B}
+      → PivotStrict↑ (suc X) c
+      → PivotStrict↑ X (`∀↑ c)
+
+    strict-id↑ : ∀ {A} {a : Atom A}
+      → PivotStrict↑ X (id↑ a)
+
+  data PivotStrict↓ {Δ : TyCtx} (X : TyVar Δ) :
+      ∀ {A B} → Conv↓ Δ A B → Set where
+    strict-seal : ∀ {R}
+      → PivotStrict↓ X (seal X R)
+
+    strict-↓⇒ : ∀ {A A′ B B′}
+        {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
+      → PivotStrict↑ X c
+      → PivotStrict↓ X d
+      → PivotStrict↓ X (c ↦↓ d)
+
+    strict-↓∀ : ∀ {A B} {c : Conv↓ (Nat.suc Δ) A B}
+      → PivotStrict↓ (suc X) c
+      → PivotStrict↓ X (`∀↓ c)
+
+    strict-id↓ : ∀ {A} {a : Atom A}
+      → PivotStrict↓ X (id↓ a)
+
+mutual
+  delimiter-strict↑ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
+    → PivotStrict↑ X (delimiter↑ A)
+  delimiter-strict↑ X (＇ Y) = strict-id↑
+  delimiter-strict↑ X (‵ ι) = strict-id↑
+  delimiter-strict↑ X ★ = strict-id↑
+  delimiter-strict↑ X (A ⇒ B) =
+    strict-↑⇒ (delimiter-strict↓ X A) (delimiter-strict↑ X B)
+  delimiter-strict↑ X (`∀ A) = strict-↑∀ (delimiter-strict↑ (suc X) A)
+
+  delimiter-strict↓ : ∀ {Δ} (X : TyVar Δ) (A : Ty Δ)
+    → PivotStrict↓ X (delimiter↓ A)
+  delimiter-strict↓ X (＇ Y) = strict-id↓
+  delimiter-strict↓ X (‵ ι) = strict-id↓
+  delimiter-strict↓ X ★ = strict-id↓
+  delimiter-strict↓ X (A ⇒ B) =
+    strict-↓⇒ (delimiter-strict↑ X A) (delimiter-strict↓ X B)
+  delimiter-strict↓ X (`∀ A) = strict-↓∀ (delimiter-strict↓ (suc X) A)

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -252,3 +252,138 @@ design motivation needs revisiting before the new calculus is built.
   exact rule shape is to be settled in Agda.
 - **Blame.** `tag-untag-bad` compares anchors; blame across regions of
   distinct allocations must still be derivable through the merge rule.
+
+## Mechanization notes
+
+The following are the statement-level resolutions and deviations in the first
+`alt.*` core.  They are recorded here as revised statements so later work does
+not accidentally rely on the prose sketch where the checked Agda interface is
+different.
+
+### The store length is explicit in typing contexts
+
+The checked context record is
+
+```agda
+⟨ Δ , n , κ , Σ , Γ ⟩
+```
+
+where `Σ : Store n` and `κ : TyVar Δ → Binding n`.  The extra displayed `n`
+is the index needed by Agda to make the existential store length available to
+the dependent projections `κᵉ` and `Σᵉ`; it adds no semantic component.
+
+`Binding n` contains either `∀-bound` or `anchored α` with `α : Fin n`.
+The raw stable name carried by terms is a natural number.  A premise
+`α ⦂ R ∈ Σ` resolves that raw name to the corresponding `Fin n` used in the
+classifier.
+
+### Reduction carries the scoped-variable classifier
+
+The checked one-step judgment is
+
+```agda
+Σ ∣ κ ⊢ M —→[ χ ] M′
+```
+
+with `M M′ : Term Δ`, `Σ : Store n`,
+`κ : TyVar Δ → Binding n`, and `χ : StoreΔ n n′`.  This refines the sketched
+`Σ ∣ M —→ Σ′ ∣ M′`: reduction needs `κ` both to translate an allocating type
+argument to a name-scoped store representation and to compare variable tags by
+anchor.  If `χ = bind R`, the next multi-step premise uses the pointwise
+weakening of `κ` from `Fin n` to `Fin (suc n)`; terms are unchanged.
+
+### Representation transport is relational
+
+The checked crossing premises are, for the lookup `p : α ⦂ R ∈ Σ`,
+
+```agda
+Reps↑ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
+Reps↓ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
+```
+
+respectively.  `Transport` is structural on types.  An anchored scoped
+variable transports to its anchor name, a type-local `∀` variable transports
+to the corresponding type-local variable, and a `∀-bound` entry in `κ` has no
+transport constructor.  Under a conversion `∀`, both the variable relation
+and `R` are weakened once.  Thus every `seal` or `unseal` representation is
+checked against the current weakened store entry without defining a partial
+transport function.
+
+### Ordinary lambda beta is omitted
+
+There is currently no constructor with the old statement
+
+```agda
+(ƛ N) · V —→ N [ V ]
+```
+
+The old context-free substitution cannot be defined at a conceal node
+`M ↓⟨ X ≔ α ⟩ c`: `M` lives in `Term Δ`, but a substitution supplied for the
+surrounding `Term (suc Δ)` produces replacement terms in the larger scope and
+those terms may mention `X`.  Erasing that slot is not total, and wrapping the
+replacement in a reveal requires its typing derivation and type, neither of
+which is present in the extrinsic `Term` syntax.  The settled grammar has no
+explicit-substitution form that could defer this operation.  Consequently the
+rule is omitted rather than given an unsound partial or nondeterministic
+substitution.
+
+### `β-Λ` and `β-gen` take an endpoint-correct exit conversion
+
+The checked allocation rules are
+
+```agda
+β-Λ :
+  Value V → Transport (BindingRel κ) A R →
+  Σ ∣ κ ⊢ (Λ V) ⦂∀ B [ A ] —→[ bind R ]
+    V ↑⟨ 0 ≔ n ⟩ d
+```
+
+where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ A ]ᵗ))`, and
+
+```agda
+β-gen :
+  Value V → (A ≢ ★) → GenSafe c →
+  Transport (BindingRel κ) C R →
+  Σ ∣ κ ⊢ (V ⟨ gen c ⟩) ⦂∀ B [ C ] —→[ bind R ]
+    (((V ↓⟨ 0 ≔ n ⟩ delimiter↓ (⇑ᵗ A)) ⟨ c ⟩)
+      ↑⟨ 0 ≔ n ⟩ d)
+```
+
+where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ C ]ᵗ))`.  This makes the entry
+anti-binder and exit reveal explicit and performs no term renaming.  The
+literal generator `〖 0 , ⇑ᵗ C ↑ B 〗` computes the extensionally equal target
+`replaceTy 0 (⇑ᵗ C) B`; that target is not definitionally equal to
+`wkᵗ 0 (B [ C ]ᵗ)`, especially under nested `∀`.  A future endpoint theorem
+can replace the supplied `d` by the literal generator without changing the
+term or store behavior.
+
+### Three allocation rules remain omitted
+
+There are currently no `β-inst`, `β-reveal-∀`, or `β-conceal-∀`
+constructors.  In `β-inst`, the body of the source `∀` uses slot `0` for its
+type binder, while the freshly entered region also uses crossing slot `0`.
+After the entry anti-binder, these are two distinct slots and the body must be
+transported across their exchange before it can be type-applied at the region
+variable.  The same exchange appears when type application crosses a
+structural `∀` reveal or conceal.  Neither `Types` nor the settled term syntax
+provides this typed exchange, and choosing an order silently changes the
+displayed rule.  The three rules are therefore omitted pending an explicit
+exchange statement.
+
+### Tag cancellation uses an explicit anchor relation
+
+The checked tag rules replace syntactic ground equality and inequality by
+
+```agda
+TagMatch κ G H
+TagMismatch κ G H
+```
+
+For variable grounds, `TagMatch` requires both classifier entries to be
+`anchored α` for the same `α`; `TagMismatch` requires distinct anchors.  Base,
+function, and universal ground tags retain their structural comparison.  This
+is the statement needed for two distinct scoped names anchored at one
+allocation to cancel.
+
+The projection-into-`★`-delimiter merge rule remains deferred exactly as
+allowed in the task; its intended location is marked in `alt.Reduction`.

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -50,21 +50,38 @@ checked against.
 
 ## Reveal is a binder, conceal is an anti-binder
 
-The crossing constructors change the term's context index:
+The term grammar replaces the live same-context conversion forms
+`M ↑ c` and `M ↓ c` with anchored crossing forms:
 
-```agda
-_↑_ : Term (suc Δ) → Conv↑ (suc Δ) A B → Term Δ      -- binder
-_↓_ : Term Δ → Conv↓ (suc Δ) A B → Term (suc Δ)      -- anti-binder
+```text
+M, N ::= …                        -- all other forms as in CastTerms.agda
+       | M ↑⟨ X ≔ α ⟩ c           -- reveal: binds slot X, anchored at α
+       | M ↓⟨ X ≔ α ⟩ c           -- conceal: anti-binds slot X, anchored at α
 ```
 
+Beside its conversion, a node carries two pieces of data: the **slot
+position** `X` — the de Bruijn position being removed from (reveal) or
+inserted into (conceal) scope; a genuine binder position, since an
+all-identity delimiter conversion does not determine it — and the
+**anchor** `α`, the store name the slot is connected to. Store names are
+drawn from the append-only store; the typing rule's lookup premise is
+their only well-formedness check. In the intrinsic syntax the
+constructors cross the context index:
+
+```agda
+_↑⟨_≔_⟩_ : Term (suc Δ) → (X : TyVar (suc Δ)) → (α : Name)
+  → Conv↑ (suc Δ) A (wkᵗ X B) → Term Δ                    -- binder
+_↓⟨_≔_⟩_ : Term Δ → (X : TyVar (suc Δ)) → (α : Name)
+  → Conv↓ (suc Δ) (wkᵗ X A) B → Term (suc Δ)              -- anti-binder
+```
+
+with `wkᵗ X = renameᵗ (punchIn X)` the type-level slot insertion and
+`wkᶜ X` the same on term contexts; shift-by-1 is the slot `X = 0`.
 A reveal *binds* its scoped variable over its subterm: inside, `X` is in
 scope; outside, the node's type is `X`-free. A conceal is the dual hole:
 its subterm lives *outside* the scope of `X` even though the node sits
-inside it. (The rules below are written with the slot at position `0`
-for readability; the mechanization takes an arbitrary slot position
-`X : TyVar (suc Δ)`, with `wkᵗ X = renameᵗ (punchIn X)` the induced
-type-level slot insertion, `wkᶜ X` the same on term contexts, and the
-node's typing quantifying over the position. Shift-by-1 is `X = 0`.)
+inside it. Displays later in this document abbreviate `↑⟨ X ≔ α ⟩ c` to
+`↑ c ⟨α⟩` when the slot is `0` or clear from context.
 
 Typing, with `α ⦂ R ∈ Σ` the anchor's store entry and the context
 recording the connection `X ≔ α`:
@@ -74,15 +91,15 @@ recording the connection `X ≔ α`:
   → α ⦂ R ∈ Σ
   → c pivot-strict at X, representations at R
   → ⟨ Δ , Σ , Γ ⟩ ⊢ M ⦂ A                     -- M unshifted, X-free
-    -----------------------------------------------------
-  → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ↓ c ⦂ B
+    -----------------------------------------------------------
+  → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
 
 ⊢reveal : {c : Conv↑ (suc Δ) A (wkᵗ X B)}
   → α ⦂ R ∈ Σ
   → c pivot-strict at X, representations at R
   → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ⦂ A
-    -----------------------------------------------------
-  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑ c ⦂ B                 -- result leaves X's scope
+    -----------------------------------------------------------
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑⟨ X ≔ α ⟩ c ⦂ B        -- result leaves X's scope
 ```
 
 **Pivot strictness.** The conversion under a crossing node mentions at

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -1,63 +1,224 @@
-# GTSFImp Alternative Semantics — Design Scaffold
+# GTSFImp Alternative Semantics — Shift-Free Reduction
 
-This directory hosts an exploration of alternative reduction rules and an
-alternative type system for GTSFImp, kept separate from the live
-development at [`GTSFImp/`](../). Nothing here is imported by the live
-`All.agda`; once a direction stabilizes it will get its own `All.agda`
-and `Makefile` following the usual per-directory `make check` shape.
+This document records the design settled in discussion on the PR (2026-08-21/22).
+It replaces the earlier candidate menu. Status: design statements agreed,
+mechanization not yet started; expect bookkeeping revisions once Agda pushes
+back. Notation follows the live development
+([`Types.agda`](../Types.agda), [`Conversion.agda`](../Conversion.agda),
+[`CastTerms.agda`](../CastTerms.agda), [`Reduction.agda`](../Reduction.agda)).
 
-## What the live system commits to
+## Goal
 
-The choices under re-examination, with their rationale entries in
-[`Rationale.md`](../Rationale.md):
+Remove all shifting of terms during reduction. In the live calculus every
+allocation step renames terms:
 
-- **Eager allocation conversion.** Every allocation rule wraps the
-  exposed polymorphic body in the recursive upward conversion
-  `〖 X ↑ A 〗`, inserting unsealing in positive positions and sealing
-  in negative positions ("Allocation reveals the instantiated result").
-- **Instantiation closes consistency at `★`.** `β-inst` substitutes `★`
-  for the bound variable in the consistency evidence
-  (`c [ ★ /0 ]ᶜ`), so the inst-bound variable is mediated entirely by
-  `seal`/`unseal` conversions and never survives as a consistency cast
-  ("Instantiation closes consistency at star").
-- **Binder-directed `gen`/`inst` split.** `gen` fresh variables remain
-  as runtime ground *tags* (variable injections are inert values,
-  compared by the ordinary tag/untag rules), while `inst` fresh
-  variables are eliminated in favor of conversions
-  ("Generalization uses fresh-name tags").
-- **Typed consistency evidence in the term syntax.** Cast terms carry
-  fully typed consistency derivations; the endpoint types live in the
-  raw syntax rather than in a separate typing judgment.
+- `β-inst`, `β-gen`, `β-reveal-∀`, `β-conceal-∀` shift the exposed value
+  (`⇑ᵗᵐ V`, an O(|V|) traversal);
+- every ξ-frame rule shifts the untouched sibling (`M′ ≡ χ ▷ᵀ M`);
+- consistency evidence in frames is transported (`c′ ≡ χ ▷ᶜ c`), and
+  `β-inst` shifts its closed evidence (`↑ᶜ (c [ ★ /0 ]ᶜ)`).
 
-These choices are internally coherent, but they are also the source of
-most of the administrative-wrapper burden documented in
-[`Rationale.md`](../Rationale.md) and carried by the DGG proofs (the
-one-sided reveal/conceal rules, pivot-local rebasing, world support,
-seal peeling).
+All of these exist because the fresh type variable is bound at de Bruijn
+index `0` of the ambient context, so `bind` re-indexes everything.
+Shifting up by 1 is the special case of inserting a slot at position `0`;
+the design generalizes to inserting or removing a slot at an arbitrary
+position, and then arranges that the *ambient* context never needs a slot
+inserted at all.
 
-## Candidate directions
+## Two classes of type variable
 
-- **A. Contextual coercions.** Promote the probes in
-  [`../experimental/`](../experimental/README.md) to a full alternative
-  system: raw coercions (`inst-out X`, `inst-in X`, endpoint-free `id`,
-  `inst`, `gen`) typed against a cast context whose entries carry a
-  `pending`/`active` allocation phase. `β-inst` then switches the phase
-  of the bound variable instead of substituting `★` into the evidence,
-  so allocation is a context update rather than a term rewrite.
-- **B. Lazy sealing.** Drop the eager `〖 X ↑ A 〗` conversion at
-  allocation; seal and unseal on demand when a value actually crosses a
-  variable-type boundary. Fewer administrative wrappers in reduced
-  terms, at the cost of new canonical-forms analysis at variable type.
-- **C. Symmetric `gen`/`inst`.** Remove the binder-directed asymmetry:
-  either treat `gen` fresh variables by conversions too (no variable
-  ground tags), or treat both by tags. Changes which tag/untag and
-  seal/unseal cancellation rules exist and how blame is reported across
-  fresh names.
-- **D. Grounded-invariant typing.** Fold the store/world invariants
-  that the DGG proofs currently reconstruct (mark honesty, alignment,
-  canonical store representations) into the type system itself, so they
-  are minted by `compile` and preserved by reduction rather than proved
-  as companion predicates.
+**Store names** `α` live in a global, append-only type store
+`Σ : StoreCtx → Set`-style, mapping each name to its representation type.
+Allocation (`bind`) extends this store and nothing else. Because the store
+is append-only and store names are not de Bruijn indices of terms or
+types, allocation re-indexes nothing.
 
-These are starting points, not a menu with a committed winner; the
-direction for this branch is an open decision-ask on the PR.
+**Scoped variables** `X` are the de Bruijn indices of `Ty Δ` and
+`Term Δ`, introduced only by binders: `∀`/`Λ` as before, and now the
+reveal/conceal nodes. Scoped variables are term-local; which scoped
+variables exist at a subterm is controlled entirely by the binders above
+it, never by allocation.
+
+A reveal/conceal node carries an **anchor**: the store name `α` its
+scoped variable is connected to. One store name may anchor many
+reveal/conceal nodes — `β-reveal-⇒` splits one boundary into two, and
+disconnected regions of the same allocation arise when values escape
+(see the escape example below). The typing context therefore tracks, for
+each in-scope crossing variable, its anchor; the store lookup at the
+anchor supplies the representation type that the node's conversion is
+checked against.
+
+## Reveal is a binder, conceal is an anti-binder
+
+The crossing constructors change the term's context index:
+
+```agda
+_↑_ : Term (suc Δ) → Conv↑ (suc Δ) A B → Term Δ      -- binder
+_↓_ : Term Δ → Conv↓ (suc Δ) A B → Term (suc Δ)      -- anti-binder
+```
+
+A reveal *binds* its scoped variable over its subterm: inside, `X` is in
+scope; outside, the node's type is `X`-free. A conceal is the dual hole:
+its subterm lives *outside* the scope of `X` even though the node sits
+inside it. (The rules below are written with the slot at position `0`
+for readability; the mechanization takes an arbitrary slot position
+`X : TyVar (suc Δ)`, with `wkᵗ X = renameᵗ (punchIn X)` the induced
+type-level slot insertion, `wkᶜ X` the same on term contexts, and the
+node's typing quantifying over the position. Shift-by-1 is `X = 0`.)
+
+Typing, with `α ⦂ R ∈ Σ` the anchor's store entry and the context
+recording the connection `X ≔ α`:
+
+```agda
+⊢conceal : {c : Conv↓ (suc Δ) (wkᵗ X A) B}
+  → α ⦂ R ∈ Σ
+  → c pivot-strict at X, representations at R
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ⦂ A                     -- M unshifted, X-free
+    -----------------------------------------------------
+  → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ↓ c ⦂ B
+
+⊢reveal : {c : Conv↑ (suc Δ) A (wkᵗ X B)}
+  → α ⦂ R ∈ Σ
+  → c pivot-strict at X, representations at R
+  → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ⦂ A
+    -----------------------------------------------------
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑ c ⦂ B                 -- result leaves X's scope
+```
+
+**Pivot strictness.** The conversion under a crossing node mentions at
+most one scoped variable — the node's own `X` — at `seal X`/`unseal X`
+leaves; every other leaf is an identity. This is what makes the rules
+well-formed: it forces the outer endpoint to be an image of `wkᵗ X`, so
+the term on the far side can live in the context without `X`. There is
+no `Maybe` pivot and no `PivotJoin`: the anchor is node data, so a
+conversion whose leaves are all identities (a pure *delimiter*) still
+names its variable. This closes, in the syntax itself, the
+retype-an-identity-at-any-pivot loophole that the DGG's version-2
+imprecision rules had to close externally
+([`Rationale.md`](../Rationale.md), "Identity reveals").
+
+**Identities are atomic.** `id↑`/`id↓` are restricted to `Atom` types
+(`＇Y`, `‵ι`, `★`), matching the consistency layer's `id : Atom A → …`.
+Conversions are then structural down to atoms. The generators
+`〖_,_↑_〗`/`makeConceal` already conform — they recurse through `⇒`/`∀`
+unconditionally and emit identities only at atomic leaves. Consequences:
+
+- a delimiter at `A ⇒ B` is necessarily `id↓ A ↦↑ id↑ B`, which the
+  existing `β-reveal-⇒` splits at application — no new commuting rules
+  for composite delimiters;
+- "mentions the pivot" is a plain syntactic property of the leaf set;
+- inversion never faces an identity of arbitrary shape.
+
+## Delimiters persist; `id-reveal` is restricted
+
+The live rules `id-reveal`/`id-conceal` discard identity wrappers
+unconditionally. In this design an identity-conversion reveal anchored
+at `α` is the closing delimiter of its region and must not be discarded
+while `X`-mentioning syntax lives beneath it. The rules become:
+
+```agda
+id-reveal : Value V
+  → V ≡ insertᵗᵐ X V₀            -- pivot does not occur in the value
+    ------------------------------
+  → V ↑ id↑ a ⟨α⟩ —→ V₀
+```
+
+and dually for `id-conceal`. At base atoms the premise is always
+satisfiable (the value inside is a constant), so delimiters never pile
+up on first-order data. At `★` the delimiter is a value when the premise
+fails; the projection then commutes into the region to meet the tag:
+
+```agda
+(V ↑ id↑ ★ ⟨α⟩) ⟨ ？ H ⟩ —→ (V ⟨ ？ H ⟩′) ↑ id↑ … ⟨α⟩
+```
+
+with tag comparison by **anchor equality**: two regions anchored at the
+same `α` may have different scoped names for the same allocation, and
+the tag/untag rules compare anchors, not scoped indices. This is the
+same-anchor *merge* — the one genuinely new rule family.
+
+## Reduction never shifts
+
+The reduction judgment becomes
+
+```text
+Σ ∣ M —→ Σ′ ∣ M′        M, M′ : Term Δ,  Σ′ = Σ or Σ, α ⦂ R
+```
+
+with the ambient `Δ` fixed across every step. What dissolves from
+[`Reduction.agda`](../Reduction.agda): `StoreChange`'s action on terms
+and evidence (`applyTerm`/`▷ᵀ`, `applyConsistency`/`▷ᶜ`,
+`applyBody`/`▷ᵇ`, and their `▶` iterations), all ξ-frame shift premises,
+every `⇑ᵗᵐ`, and the `↑ᶜ` on `β-inst`'s closed evidence — its endpoints
+are `X`-free, so it sits outside the reveal at ambient `Δ` unchanged.
+
+Sketch of `β-inst` (slot at `0`, anchors written `⟨α⟩`):
+
+```text
+Σ ∣ V ⟨ (inst c) B≢★ ⟩ —→ Σ, α ⦂ ★ ∣
+  ((V ↓ δ∀ ⟨α⟩) ⦂∀ … [ ＇ 0 ]) ↑ 〖 0 , ★ ↑ A 〗⟨α⟩ ⟨ c [ ★ /0 ]ᶜ ⟩
+```
+
+`V` enters the region through an anti-binder delimiter `δ∀` (structural,
+all-atomic-identity, anchored at `α`), is type-applied at the scoped
+variable, revealed through the generated conversion (binder, closing the
+region), and cast by the *unshifted* closed evidence. The composition
+properties hold on the existing rules: `β-reveal-⇒` sends
+`(V ↑ (c ↦↑ d)⟨α⟩) · W` to `(V · (W ↓ c ⟨α⟩)) ↑ d ⟨α⟩`, which pairs the
+binder with a fresh anti-binder so all context indices line up, and
+`conceal-reveal` cancellation `(V ↓ seal ⟨α⟩) ↑ unseal ⟨α⟩ —→ V` has both
+sides at ambient `Δ`.
+
+## Why escapees must stay live: the re-entry example
+
+Sealed-and-tagged values escape their region through positive-`★`
+channels: with `B = ＇X ⇒ ★`, applying the generalized dynamic identity
+yields the free-floating package `(7 ↓ seal ⟨α⟩) ⟨ tag ⟨α⟩ ⟩ ⦂ ★` after
+the region's delimiter would (in the live calculus) be erased by
+`id-reveal` — the delimiter restriction exists precisely to keep the
+package closed.
+
+Such packages are not dead. With
+
+```text
+B = ＇X ⇒ ((★ ⇒ ★) ⇒ ＇X)          W = ƛx. ƛj. j · x
+
+(ƛh. h · 9 · (ƛu. (ƛw. u) · (h · 5 · (ƛv. u)))) · ((W ⟨ gen c ⟩) ⦂∀ B [ ℕ ])
+```
+
+the instantiation fires `β-gen` once (CBV argument), so both uses of `h`
+share one allocation. The outer call leaks its tagged argument `t₉` to
+user code through the identity-conversion `(★ ⇒ ★)` channel; the inner
+sibling call `h · 5 · (ƛv. u)` routes the captured `t₉` to its own
+positive-`＇X` exit, where the projection meets the tag — same
+allocation, tags match, unseal returns `9`. The whole program reduces to
+`$ 9` with no blame: an escaped package was consumed by a *different*
+region of the same allocation. Hence: escapees keep their anchors, the
+merge rule is by anchor equality, and no design may neuter or eagerly
+blame an escaped package. (When the generalized type has no positive
+occurrence of the bound variable, no projection site exists and packages
+are inert forever — ordinary uninspected `★` values.)
+
+A mechanized `—↠` derivation of this program in the *live* calculus is
+queued as a baseline probe; if the trace does not hold as claimed, the
+design motivation needs revisiting before the new calculus is built.
+
+## Open bookkeeping (expected mechanization friction)
+
+- **`β-inst` binder/slot exchange.** Reusing the `inst` body `A`
+  verbatim inside the region relies on the pun between the consistency
+  binder and the slot position; the exact de Bruijn exchange between the
+  `∀`-binder and the inserted slot inside `δ∀` needs to be worked out in
+  Agda, and slot positions other than `0` appear as soon as regions
+  nest.
+- **Conceal orientation cases.** The anti-binder form covers values
+  entering a region; whether any rule still needs a same-context conceal
+  (or reveal) is to be discovered by the mechanization, not assumed.
+- **Store monotonicity.** The one new lemma obligation: typing is
+  preserved under store extension (`Σ ⊆ Σ′`) — a lookup lemma, not a
+  term traversal.
+- **`GenSafe` and value forms.** `RevealValue`/`ConcealValue` gain the
+  atomic-delimiter cases; `GenSafe`'s interaction with anchored
+  suspended casts needs restating.
+- **Blame.** `tag-untag-bad` compares anchors; blame across regions of
+  distinct allocations must still be derivable through the merge rule.

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -56,8 +56,8 @@ The term grammar replaces the live same-context conversion forms
 ```text
 M, N ::= …                        -- all other forms as in CastTerms.agda
        | ƛ A ˙ N                    -- lambda, annotated by its domain
-       | M ↑⟨ X ≔ α ⟩ c           -- reveal: binds slot X, anchored at α
-       | M ↓⟨ X ≔ α ⟩ c           -- conceal: anti-binds slot X, anchored at α
+       | M ↑[ X ≔ α ] c           -- reveal: binds slot X, anchored at α
+       | M ↓[ X ≔ α ] c           -- conceal: anti-binds slot X, anchored at α
 ```
 
 The dot in `ƛ A ˙ N` distinguishes the domain annotation from the body;
@@ -74,9 +74,9 @@ their only well-formedness check. In the intrinsic syntax the
 constructors cross the context index:
 
 ```agda
-_↑⟨_≔_⟩_ : Term (suc Δ) → (X : TyVar (suc Δ)) → (α : Name)
+_↑[_≔_]_ : Term (suc Δ) → (X : TyVar (suc Δ)) → (α : Name)
   → Conv↑ (suc Δ) A (wkᵗ X B) → Term Δ                    -- binder
-_↓⟨_≔_⟩_ : Term Δ → (X : TyVar (suc Δ)) → (α : Name)
+_↓[_≔_]_ : Term Δ → (X : TyVar (suc Δ)) → (α : Name)
   → Conv↓ (suc Δ) (wkᵗ X A) B → Term (suc Δ)              -- anti-binder
 ```
 
@@ -85,7 +85,7 @@ shift-by-1 is the slot `X = 0`. A reveal *binds* its scoped variable over
 its subterm: inside, `X` is in scope; outside, the node's type is `X`-free.
 A conceal is the dual hole: its subterm lives *outside* the scope of `X`
 even though the node sits inside it. Both interiors are term-closed. Displays
-later in this document abbreviate `↑⟨ X ≔ α ⟩ c` to `↑ c ⟨α⟩` when the slot
+later in this document abbreviate `↑[ X ≔ α ] c` to `↑ c ⟨α⟩` when the slot
 is `0` or clear from context.
 
 Typing, with `α ⦂ R ∈ Σ` the anchor's store entry and the context
@@ -97,14 +97,14 @@ recording the connection `X ≔ α`:
   → c pivot-strict at X, representations at R
   → ⟨ Δ , Σ , ∅ ⟩ ⊢ M ⦂ A                     -- closed and X-free
     -----------------------------------------------------------
-  → ⟨ suc Δ [X ≔ α] , Σ , Γ′ ⟩ ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
+  → ⟨ suc Δ [X ≔ α] , Σ , Γ′ ⟩ ⊢ M ↓[ X ≔ α ] c ⦂ B
 
 ⊢reveal : {c : Conv↑ (suc Δ) A (wkᵗ X B)}
   → α ⦂ R ∈ Σ
   → c pivot-strict at X, representations at R
   → ⟨ suc Δ [X ≔ α] , Σ , ∅ ⟩ ⊢ M ⦂ A
     -----------------------------------------------------------
-  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑⟨ X ≔ α ⟩ c ⦂ B        -- result leaves X's scope
+  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑[ X ≔ α ] c ⦂ B        -- result leaves X's scope
 ```
 
 Here `Γ` and `Γ′` are arbitrary. The crossing changes the scoped-type context
@@ -355,8 +355,8 @@ allocation, and no allocation or evaluation-frame rule traverses a term.
 Substitution stops at both crossing nodes:
 
 ```agda
-(M ↑⟨ X ≔ α ⟩ c) [ V ] = M ↑⟨ X ≔ α ⟩ c
-(M ↓⟨ X ≔ α ⟩ c) [ V ] = M ↓⟨ X ≔ α ⟩ c
+(M ↑[ X ≔ α ] c) [ V ] = M ↑[ X ≔ α ] c
+(M ↓[ X ≔ α ] c) [ V ] = M ↓[ X ≔ α ] c
 ```
 
 This is sound directly from the closed-interior premises of `⊢reveal` and
@@ -374,7 +374,7 @@ The checked allocation rules are
 β-Λ :
   Value V → Transport (BindingRel κ) A R →
   Σ ∣ κ ⊢ (Λ V) ⦂∀ B [ A ] —→[ bind R ]
-    V ↑⟨ 0 ≔ n ⟩ d
+    V ↑[ 0 ≔ n ] d
 ```
 
 where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ A ]ᵗ))`, and
@@ -384,8 +384,8 @@ where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ A ]ᵗ))`, and
   Value V → (A ≢ ★) → GenSafe c →
   Transport (BindingRel κ) C R →
   Σ ∣ κ ⊢ (V ⟨ gen c ⟩) ⦂∀ B [ C ] —→[ bind R ]
-    (((V ↓⟨ 0 ≔ n ⟩ δ↓ (⇑ᵗ A)) ⟨ c ⟩)
-      ↑⟨ 0 ≔ n ⟩ d)
+    (((V ↓[ 0 ≔ n ] δ↓ (⇑ᵗ A)) ⟨ c ⟩)
+      ↑[ 0 ≔ n ] d)
 ```
 
 where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ C ]ᵗ))`.  This makes the entry

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -1,0 +1,63 @@
+# GTSFImp Alternative Semantics — Design Scaffold
+
+This directory hosts an exploration of alternative reduction rules and an
+alternative type system for GTSFImp, kept separate from the live
+development at [`GTSFImp/`](../). Nothing here is imported by the live
+`All.agda`; once a direction stabilizes it will get its own `All.agda`
+and `Makefile` following the usual per-directory `make check` shape.
+
+## What the live system commits to
+
+The choices under re-examination, with their rationale entries in
+[`Rationale.md`](../Rationale.md):
+
+- **Eager allocation conversion.** Every allocation rule wraps the
+  exposed polymorphic body in the recursive upward conversion
+  `〖 X ↑ A 〗`, inserting unsealing in positive positions and sealing
+  in negative positions ("Allocation reveals the instantiated result").
+- **Instantiation closes consistency at `★`.** `β-inst` substitutes `★`
+  for the bound variable in the consistency evidence
+  (`c [ ★ /0 ]ᶜ`), so the inst-bound variable is mediated entirely by
+  `seal`/`unseal` conversions and never survives as a consistency cast
+  ("Instantiation closes consistency at star").
+- **Binder-directed `gen`/`inst` split.** `gen` fresh variables remain
+  as runtime ground *tags* (variable injections are inert values,
+  compared by the ordinary tag/untag rules), while `inst` fresh
+  variables are eliminated in favor of conversions
+  ("Generalization uses fresh-name tags").
+- **Typed consistency evidence in the term syntax.** Cast terms carry
+  fully typed consistency derivations; the endpoint types live in the
+  raw syntax rather than in a separate typing judgment.
+
+These choices are internally coherent, but they are also the source of
+most of the administrative-wrapper burden documented in
+[`Rationale.md`](../Rationale.md) and carried by the DGG proofs (the
+one-sided reveal/conceal rules, pivot-local rebasing, world support,
+seal peeling).
+
+## Candidate directions
+
+- **A. Contextual coercions.** Promote the probes in
+  [`../experimental/`](../experimental/README.md) to a full alternative
+  system: raw coercions (`inst-out X`, `inst-in X`, endpoint-free `id`,
+  `inst`, `gen`) typed against a cast context whose entries carry a
+  `pending`/`active` allocation phase. `β-inst` then switches the phase
+  of the bound variable instead of substituting `★` into the evidence,
+  so allocation is a context update rather than a term rewrite.
+- **B. Lazy sealing.** Drop the eager `〖 X ↑ A 〗` conversion at
+  allocation; seal and unseal on demand when a value actually crosses a
+  variable-type boundary. Fewer administrative wrappers in reduced
+  terms, at the cost of new canonical-forms analysis at variable type.
+- **C. Symmetric `gen`/`inst`.** Remove the binder-directed asymmetry:
+  either treat `gen` fresh variables by conversions too (no variable
+  ground tags), or treat both by tags. Changes which tag/untag and
+  seal/unseal cancellation rules exist and how blame is reported across
+  fresh names.
+- **D. Grounded-invariant typing.** Fold the store/world invariants
+  that the DGG proofs currently reconstruct (mark honesty, alignment,
+  canonical store representations) into the type system itself, so they
+  are minted by `compile` and preserved by reduction rather than proved
+  as companion predicates.
+
+These are starting points, not a menu with a committed winner; the
+direction for this branch is an open decision-ask on the PR.

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -1,9 +1,9 @@
 # GTSFImp Alternative Semantics — Shift-Free Reduction
 
 This document records the design settled in discussion on the PR (2026-08-21/22).
-It replaces the earlier candidate menu. Status: design statements agreed,
-mechanization not yet started; expect bookkeeping revisions once Agda pushes
-back. Notation follows the live development
+It replaces the earlier candidate menu. The checked `alt.*` core and its
+statement-level bookkeeping revisions are recorded below. Notation follows the
+live development
 ([`Types.agda`](../Types.agda), [`Conversion.agda`](../Conversion.agda),
 [`CastTerms.agda`](../CastTerms.agda), [`Reduction.agda`](../Reduction.agda)).
 
@@ -80,13 +80,13 @@ _↓⟨_≔_⟩_ : Term Δ → (X : TyVar (suc Δ)) → (α : Name)
   → Conv↓ (suc Δ) (wkᵗ X A) B → Term (suc Δ)              -- anti-binder
 ```
 
-with `wkᵗ X = renameᵗ (punchIn X)` the type-level slot insertion and
-`wkᶜ X` the same on term contexts; shift-by-1 is the slot `X = 0`.
-A reveal *binds* its scoped variable over its subterm: inside, `X` is in
-scope; outside, the node's type is `X`-free. A conceal is the dual hole:
-its subterm lives *outside* the scope of `X` even though the node sits
-inside it. Displays later in this document abbreviate `↑⟨ X ≔ α ⟩ c` to
-`↑ c ⟨α⟩` when the slot is `0` or clear from context.
+with `wkᵗ X = renameᵗ (punchIn X)` the type-level slot insertion;
+shift-by-1 is the slot `X = 0`. A reveal *binds* its scoped variable over
+its subterm: inside, `X` is in scope; outside, the node's type is `X`-free.
+A conceal is the dual hole: its subterm lives *outside* the scope of `X`
+even though the node sits inside it. Both interiors are term-closed. Displays
+later in this document abbreviate `↑⟨ X ≔ α ⟩ c` to `↑ c ⟨α⟩` when the slot
+is `0` or clear from context.
 
 Typing, with `α ⦂ R ∈ Σ` the anchor's store entry and the context
 recording the connection `X ≔ α`:
@@ -95,17 +95,21 @@ recording the connection `X ≔ α`:
 ⊢conceal : {c : Conv↓ (suc Δ) (wkᵗ X A) B}
   → α ⦂ R ∈ Σ
   → c pivot-strict at X, representations at R
-  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ⦂ A                     -- M unshifted, X-free
+  → ⟨ Δ , Σ , ∅ ⟩ ⊢ M ⦂ A                     -- closed and X-free
     -----------------------------------------------------------
-  → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
+  → ⟨ suc Δ [X ≔ α] , Σ , Γ′ ⟩ ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
 
 ⊢reveal : {c : Conv↑ (suc Δ) A (wkᵗ X B)}
   → α ⦂ R ∈ Σ
   → c pivot-strict at X, representations at R
-  → ⟨ suc Δ [X ≔ α] , Σ , wkᶜ X Γ ⟩ ⊢ M ⦂ A
+  → ⟨ suc Δ [X ≔ α] , Σ , ∅ ⟩ ⊢ M ⦂ A
     -----------------------------------------------------------
   → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑⟨ X ≔ α ⟩ c ⦂ B        -- result leaves X's scope
 ```
+
+Here `Γ` and `Γ′` are arbitrary. The crossing changes the scoped-type context
+and classifier but does not transport a surrounding term context into its
+interior.
 
 **Pivot strictness.** The conversion under a crossing node mentions at
 most one scoped variable — the node's own `X` — at `seal X`/`unseal X`
@@ -118,6 +122,25 @@ names its variable. This closes, in the syntax itself, the
 retype-an-identity-at-any-pivot loophole that the DGG's version-2
 imprecision rules had to close externally
 ([`Rationale.md`](../Rationale.md), "Identity reveals").
+
+## Reachability invariant: crossing interiors are closed
+
+Every reveal or conceal interior reachable from a closed compiled program is
+typed in the empty term context. The typing rules above bake this invariant
+into all well-typed syntax, rather than asking substitution and preservation
+to recover it after the fact.
+
+The reachability argument is an induction on evaluation. In the base case,
+compilation emits no crossing nodes. For the step case, reduction mints a
+crossing only at an evaluation position; evaluation positions in a closed
+program are term-closed because evaluation never descends beneath a term
+binder. Ordinary call-by-value substitution deposits only closed values beneath
+binders, so it cannot introduce a free term variable into an existing crossing
+interior. Finally, reduction never grows the ambient scoped-type context: a
+closed source program and every program reachable from it remain `Term 0`.
+Runtime packages created by crossings are therefore term-closed. Packages that
+escape a local crossing have ambient types in `Ty 0` and are type-closed; their
+representation types are type-closed through the global store as well.
 
 **Identities are atomic.** `id↑`/`id↓` are restricted to `Atom` types
 (`＇Y`, `‵ι`, `★`), matching the consistency layer's `id : Atom A → …`.
@@ -314,13 +337,13 @@ and `R` are weakened once.  Thus every `seal` or `unseal` representation is
 checked against the current weakened store entry without defining a partial
 transport function.
 
-### Ordinary lambda beta uses type-directed substitution
+### Ordinary lambda beta uses substitution that stops at crossings
 
 Lambdas carry their domain type, and the checked single substitution is
 
 ```agda
-_[_⦂_] : Term Δ → Term Δ → Ty Δ → Term Δ
-β : Value V → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ⦂ A ]
+_[_] : Term Δ → Term Δ → Term Δ
+β : Value V → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ]
 ```
 
 The implementation generalizes internally to substitution at an arbitrary
@@ -329,30 +352,19 @@ the term-variable renaming `rename suc`.  Under `Λ`, the replacement is
 weakened across that existing lexical type binder; this is unrelated to store
 allocation, and no allocation or evaluation-frame rule traverses a term.
 
-At a reveal, substitution carries the replacement into the larger scoped-type
-context through a conceal delimiter:
+Substitution stops at both crossing nodes:
 
 ```agda
-(M ↑⟨ X ≔ α ⟩ c) [ V ⦂ A ] =
-  (M [ V ↓⟨ X ≔ α ⟩ δ↓ (wkᵗ X A) ⦂ wkᵗ X A ]) ↑⟨ X ≔ α ⟩ c
+(M ↑⟨ X ≔ α ⟩ c) [ V ] = M ↑⟨ X ≔ α ⟩ c
+(M ↓⟨ X ≔ α ⟩ c) [ V ] = M ↓⟨ X ≔ α ⟩ c
 ```
 
-At a conceal, `strengthenAt X` inspects only the tracked type.  When it returns
-`A = wkᵗ X B`, substitution carries the replacement into the smaller context
-through a reveal delimiter:
-
-```agda
-(M ↓⟨ X ≔ α ⟩ c) [ V ⦂ wkᵗ X B ] =
-  (M [ V ↑⟨ X ≔ α ⟩ δ↑ (wkᵗ X B) ⦂ B ]) ↓⟨ X ≔ α ⟩ c
-```
-
-The type view is total.  On raw syntax where strengthening fails, `dropAt`
-still decrements variables above the removed term binder but leaves the target
-occurrences under that conceal unsubstituted.  This branch cannot contain such
-an occurrence in a well-typed redex: the `⊢conceal` premise types its subterm in
-the unweakened term context, so the corresponding tracked entry outside the
-subterm is necessarily a `wkᵗ X` image.  Constants and `blame` are unchanged;
-all other same-context constructors are traversed structurally.
+This is sound directly from the closed-interior premises of `⊢reveal` and
+`⊢conceal`: a variable supplied by an enclosing lambda cannot occur free below
+either node. Constants and `blame` are unchanged, and every other constructor
+is traversed structurally. The lambda domain annotation is retained by design
+because it remains useful for typing inversion, not because substitution needs
+to track the type.
 
 ### `β-Λ` and `β-gen` take an endpoint-correct exit conversion
 

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -109,24 +109,32 @@ unconditionally and emit identities only at atomic leaves. Consequences:
 - "mentions the pivot" is a plain syntactic property of the leaf set;
 - inversion never faces an identity of arbitrary shape.
 
-## Delimiters persist; `id-reveal` is restricted
+## Delimiters persist; `id-reveal` drops at base types only
 
 The live rules `id-reveal`/`id-conceal` discard identity wrappers
 unconditionally. In this design an identity-conversion reveal anchored
-at `α` is the closing delimiter of its region and must not be discarded
-while `X`-mentioning syntax lives beneath it. The rules become:
+at `α` is the closing delimiter of its region, and the drop rule is
+restricted to base atoms, where the canonical inhabitants are constants
+and a constant inhabits every context:
 
 ```agda
-id-reveal : Value V
-  → V ≡ insertᵗᵐ X V₀            -- pivot does not occur in the value
-    ------------------------------
-  → V ↑ id↑ a ⟨α⟩ —→ V₀
+id-reveal : ($ κ) ↑ id↑ (‵ ι) ⟨α⟩ —→ $ κ
 ```
 
-and dually for `id-conceal`. At base atoms the premise is always
-satisfiable (the value inside is a constant), so delimiters never pile
-up on first-order data. At `★` the delimiter is a value when the premise
-fails; the projection then commutes into the region to meet the tag:
+No premise, no strengthening operation. (An earlier draft guarded the
+drop with a "pivot does not occur in the value" strengthening premise
+at every atom; that makes value-hood at `★` undecidable by pattern —
+a delimited `★`-value would be a value or a redex depending on a
+term-level occurrence check — and the drop rule would overlap with the
+projection-merge rule below. Base-only drop keeps `Value`, progress,
+and determinism syntax-directed.)
+
+At `★` and at foreign variables `＇Y` a delimiter is always a value;
+delimiter spines on `★`-values are consumed by elimination, never by
+garbage collection. An `id`-conceal never drops at any type — its
+subterm lives in the smaller context — and is consumed only by
+`conceal-reveal` cancellation at its matching reveal. When a projection
+meets a `★`-delimiter, it commutes into the region to meet the tag:
 
 ```agda
 (V ↑ id↑ ★ ⟨α⟩) ⟨ ？ H ⟩ —→ (V ⟨ ？ H ⟩′) ↑ id↑ … ⟨α⟩
@@ -218,7 +226,12 @@ design motivation needs revisiting before the new calculus is built.
   preserved under store extension (`Σ ⊆ Σ′`) — a lookup lemma, not a
   term traversal.
 - **`GenSafe` and value forms.** `RevealValue`/`ConcealValue` gain the
-  atomic-delimiter cases; `GenSafe`'s interaction with anchored
+  atomic-delimiter cases (`★` and `＇Y` delimiters are always values;
+  base delimiters never are); `GenSafe`'s interaction with anchored
   suspended casts needs restating.
+- **Delimiters at foreign variables.** A reveal delimiter at `＇Y` is
+  eliminated by commuting past `Y`'s consuming unseal — a node-local
+  reveal-past-reveal swap that renumbers the two slot positions; the
+  exact rule shape is to be settled in Agda.
 - **Blame.** `tag-untag-bad` compares anchors; blame across regions of
   distinct allocations must still be derivable through the merge rule.

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -55,9 +55,14 @@ The term grammar replaces the live same-context conversion forms
 
 ```text
 M, N ::= …                        -- all other forms as in CastTerms.agda
+       | ƛ A ˙ N                    -- lambda, annotated by its domain
        | M ↑⟨ X ≔ α ⟩ c           -- reveal: binds slot X, anchored at α
        | M ↓⟨ X ≔ α ⟩ c           -- conceal: anti-binds slot X, anchored at α
 ```
+
+The dot in `ƛ A ˙ N` distinguishes the domain annotation from the body;
+the annotation is syntax and the `⊢ƛ` rule requires it to be the domain of the
+resulting arrow type.
 
 Beside its conversion, a node carries two pieces of data: the **slot
 position** `X` — the de Bruijn position being removed from (reveal) or
@@ -309,23 +314,45 @@ and `R` are weakened once.  Thus every `seal` or `unseal` representation is
 checked against the current weakened store entry without defining a partial
 transport function.
 
-### Ordinary lambda beta is omitted
+### Ordinary lambda beta uses type-directed substitution
 
-There is currently no constructor with the old statement
+Lambdas carry their domain type, and the checked single substitution is
 
 ```agda
-(ƛ N) · V —→ N [ V ]
+_[_⦂_] : Term Δ → Term Δ → Ty Δ → Term Δ
+β : Value V → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ⦂ A ]
 ```
 
-The old context-free substitution cannot be defined at a conceal node
-`M ↓⟨ X ≔ α ⟩ c`: `M` lives in `Term Δ`, but a substitution supplied for the
-surrounding `Term (suc Δ)` produces replacement terms in the larger scope and
-those terms may mention `X`.  Erasing that slot is not total, and wrapping the
-replacement in a reveal requires its typing derivation and type, neither of
-which is present in the extrinsic `Term` syntax.  The settled grammar has no
-explicit-substitution form that could defer this operation.  Consequently the
-rule is omitted rather than given an unsound partial or nondeterministic
-substitution.
+The implementation generalizes internally to substitution at an arbitrary
+term index.  Under `ƛ`, that index is incremented and `V` is weakened only by
+the term-variable renaming `rename suc`.  Under `Λ`, the replacement is
+weakened across that existing lexical type binder; this is unrelated to store
+allocation, and no allocation or evaluation-frame rule traverses a term.
+
+At a reveal, substitution carries the replacement into the larger scoped-type
+context through a conceal delimiter:
+
+```agda
+(M ↑⟨ X ≔ α ⟩ c) [ V ⦂ A ] =
+  (M [ V ↓⟨ X ≔ α ⟩ δ↓ (wkᵗ X A) ⦂ wkᵗ X A ]) ↑⟨ X ≔ α ⟩ c
+```
+
+At a conceal, `strengthenAt X` inspects only the tracked type.  When it returns
+`A = wkᵗ X B`, substitution carries the replacement into the smaller context
+through a reveal delimiter:
+
+```agda
+(M ↓⟨ X ≔ α ⟩ c) [ V ⦂ wkᵗ X B ] =
+  (M [ V ↑⟨ X ≔ α ⟩ δ↑ (wkᵗ X B) ⦂ B ]) ↓⟨ X ≔ α ⟩ c
+```
+
+The type view is total.  On raw syntax where strengthening fails, `dropAt`
+still decrements variables above the removed term binder but leaves the target
+occurrences under that conceal unsubstituted.  This branch cannot contain such
+an occurrence in a well-typed redex: the `⊢conceal` premise types its subterm in
+the unweakened term context, so the corresponding tracked entry outside the
+subterm is necessarily a `wkᵗ X` image.  Constants and `blame` are unchanged;
+all other same-context constructors are traversed structurally.
 
 ### `β-Λ` and `β-gen` take an endpoint-correct exit conversion
 
@@ -345,7 +372,7 @@ where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ A ]ᵗ))`, and
   Value V → (A ≢ ★) → GenSafe c →
   Transport (BindingRel κ) C R →
   Σ ∣ κ ⊢ (V ⟨ gen c ⟩) ⦂∀ B [ C ] —→[ bind R ]
-    (((V ↓⟨ 0 ≔ n ⟩ delimiter↓ (⇑ᵗ A)) ⟨ c ⟩)
+    (((V ↓⟨ 0 ≔ n ⟩ δ↓ (⇑ᵗ A)) ⟨ c ⟩)
       ↑⟨ 0 ≔ n ⟩ d)
 ```
 

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -45,17 +45,17 @@ context, endpoint, pivot, representation, store name, or leaf data.
 
 ```agda
 mutual
-  data Conv↑ : Set where
-    unseal : Conv↑
-    _↦↑_   : Conv↓ → Conv↑ → Conv↑
-    `∀↑_   : Conv↑ → Conv↑
-    id↑    : Conv↑
+  data Reveal : Set where
+    unseal : Reveal
+    _↦↑_   : Conceal → Reveal → Reveal
+    `∀↑_   : Reveal → Reveal
+    id↑    : Reveal
 
-  data Conv↓ : Set where
-    seal  : Conv↓
-    _↦↓_  : Conv↑ → Conv↓ → Conv↓
-    `∀↓_  : Conv↓ → Conv↓
-    id↓   : Conv↓
+  data Conceal : Set where
+    seal  : Conceal
+    _↦↓_  : Reveal → Conceal → Conceal
+    `∀↓_  : Conceal → Conceal
+    id↓   : Conceal
 ```
 
 Endpoints and the old `PivotStrict` and `Reps` obligations are subsumed by
@@ -108,8 +108,8 @@ shape. If the deferred merge rule eventually needs mixed aliases, that is the
 point at which to revisit the restriction.
 
 The generators are ordinary shape functions. For example,
-`〖 X , R′ ↑ B 〗 : Conv↑` recursively emits `unseal` exactly at `＇ X`, and
-`makeConceal X R′ B : Conv↓` is dual. Their endpoint facts are proofs:
+`〖 X , R′ ↑ B 〗 : Reveal` recursively emits `unseal` exactly at `＇ X`, and
+`makeConceal X R′ B : Conceal` is dual. Their endpoint facts are proofs:
 
 ```agda
 generator-typed↑ :
@@ -128,8 +128,8 @@ The delimiters `δ↑ A` and `δ↓ A` likewise return shapes, with separate
 The term grammar contains anchored crossings with raw conversions:
 
 ```agda
-_↑[_≔_]_ : Term (suc Δ) → TyVar (suc Δ) → Name → Conv↑ → Term Δ
-_↓[_≔_]_ : Term Δ → TyVar (suc Δ) → Name → Conv↓ → Term (suc Δ)
+_↑[_≔_]_ : Term (suc Δ) → TyVar (suc Δ) → Name → Reveal → Term Δ
+_↓[_≔_]_ : Term Δ → TyVar (suc Δ) → Name → Conceal → Term (suc Δ)
 ```
 
 A reveal binds slot `X` over its interior and removes that slot outside. A

--- a/GTSFImp/alt/Design.md
+++ b/GTSFImp/alt/Design.md
@@ -1,127 +1,171 @@
 # GTSFImp Alternative Semantics — Shift-Free Reduction
 
-This document records the design settled in discussion on the PR (2026-08-21/22).
-It replaces the earlier candidate menu. The checked `alt.*` core and its
-statement-level bookkeeping revisions are recorded below. Notation follows the
-live development
-([`Types.agda`](../Types.agda), [`Conversion.agda`](../Conversion.agda),
-[`CastTerms.agda`](../CastTerms.agda), [`Reduction.agda`](../Reduction.agda)).
+This document records the checked alternative core settled in discussion on
+the PR (2026-08-21/22). Notation follows the live development where the
+alternative does not deliberately differ.
 
 ## Goal
 
 Remove all shifting of terms during reduction. In the live calculus every
-allocation step renames terms:
+allocation step renames terms, every allocating ξ-frame shifts its untouched
+sibling, and consistency and conversion evidence must move with the term.
+Those traversals exist because allocation adds a de Bruijn type slot to the
+ambient context.
 
-- `β-inst`, `β-gen`, `β-reveal-∀`, `β-conceal-∀` shift the exposed value
-  (`⇑ᵗᵐ V`, an O(|V|) traversal);
-- every ξ-frame rule shifts the untouched sibling (`M′ ≡ χ ▷ᵀ M`);
-- consistency evidence in frames is transported (`c′ ≡ χ ▷ᶜ c`), and
-  `β-inst` shifts its closed evidence (`↑ᶜ (c [ ★ /0 ]ᶜ)`).
-
-All of these exist because the fresh type variable is bound at de Bruijn
-index `0` of the ambient context, so `bind` re-indexes everything.
-Shifting up by 1 is the special case of inserting a slot at position `0`;
-the design generalizes to inserting or removing a slot at an arbitrary
-position, and then arranges that the *ambient* context never needs a slot
-inserted at all.
+The alternative separates runtime store names from lexically scoped type
+variables. Allocation extends only an append-only store, while reveal and
+conceal nodes manage scoped slots locally. The ambient type context of a
+reduction step therefore stays fixed.
 
 ## Two classes of type variable
 
-**Store names** `α` live in a global, append-only type store
-`Σ : StoreCtx → Set`-style, mapping each name to its representation type.
-Allocation (`bind`) extends this store and nothing else. Because the store
-is append-only and store names are not de Bruijn indices of terms or
-types, allocation re-indexes nothing.
+**Store names** `α` live in a global append-only `Store n`. A store entry is a
+representation type scoped by earlier store names. Allocation extends this
+store and nothing else, so it reindexes no term or scoped type.
 
-**Scoped variables** `X` are the de Bruijn indices of `Ty Δ` and
-`Term Δ`, introduced only by binders: `∀`/`Λ` as before, and now the
-reveal/conceal nodes. Scoped variables are term-local; which scoped
-variables exist at a subterm is controlled entirely by the binders above
-it, never by allocation.
+**Scoped variables** `X` are the de Bruijn indices of `Ty Δ` and `Term Δ`.
+They are introduced by `∀`/`Λ` and by reveal/conceal crossings. A crossing
+carries an anchor `α`, connecting its scoped pivot to a store entry. Several
+crossings may use one anchor.
 
-A reveal/conceal node carries an **anchor**: the store name `α` its
-scoped variable is connected to. One store name may anchor many
-reveal/conceal nodes — `β-reveal-⇒` splits one boundary into two, and
-disconnected regions of the same allocation arise when values escape
-(see the escape example below). The typing context therefore tracks, for
-each in-scope crossing variable, its anchor; the store lookup at the
-anchor supplies the representation type that the node's conversion is
-checked against.
+The checked typing context is
+
+```agda
+⟨ Δ , n , κ , Σ , Γ ⟩
+```
+
+where `Σ : Store n` and `κ : TyVar Δ → Binding n`. A binding is either
+`∀-bound` or `anchored α`. The explicit `n` lets Agda expose the indices of
+`κ` and `Σ`; it adds no semantic component.
+
+## Raw conversion shapes
+
+Conversions carry only their structural direction. They contain no type
+context, endpoint, pivot, representation, store name, or leaf data.
+
+```agda
+mutual
+  data Conv↑ : Set where
+    unseal : Conv↑
+    _↦↑_   : Conv↓ → Conv↑ → Conv↑
+    `∀↑_   : Conv↑ → Conv↑
+    id↑    : Conv↑
+
+  data Conv↓ : Set where
+    seal  : Conv↓
+    _↦↓_  : Conv↑ → Conv↓ → Conv↓
+    `∀↓_  : Conv↓ → Conv↓
+    id↓   : Conv↓
+```
+
+Endpoints and the old `PivotStrict` and `Reps` obligations are subsumed by
+one self-contained typing judgment per direction:
+
+```agda
+⊢↑[ X ⦂ R′ ] c ⦂ A ↝ B
+⊢↓[ X ⦂ R′ ] c ⦂ A ↝ B
+```
+
+Here `X : TyVar Δ` and `R′ A B : Ty Δ`. The representation `R′` is scoped in
+the same context as the conversion endpoints. These judgments mention no
+store, anchor, classifier, or transport relation.
+
+Their rules are:
+
+```agda
+⊢unseal : ⊢↑[ X ⦂ R′ ] unseal ⦂ ＇ X ↝ R′
+⊢seal   : ⊢↓[ X ⦂ R′ ] seal ⦂ R′ ↝ ＇ X
+
+⊢↑-⇒ : ⊢↓[ X ⦂ R′ ] c ⦂ A′ ↝ A
+      → ⊢↑[ X ⦂ R′ ] d ⦂ B ↝ B′
+      → ⊢↑[ X ⦂ R′ ] c ↦↑ d ⦂ A ⇒ B ↝ A′ ⇒ B′
+
+⊢↓-⇒ : ⊢↑[ X ⦂ R′ ] c ⦂ A′ ↝ A
+      → ⊢↓[ X ⦂ R′ ] d ⦂ B ↝ B′
+      → ⊢↓[ X ⦂ R′ ] c ↦↓ d ⦂ A ⇒ B ↝ A′ ⇒ B′
+
+⊢↑-∀ : ⊢↑[ suc X ⦂ ⇑ᵗ R′ ] c ⦂ A ↝ B
+      → ⊢↑[ X ⦂ R′ ] `∀↑ c ⦂ `∀ A ↝ `∀ B
+
+⊢↓-∀ : ⊢↓[ suc X ⦂ ⇑ᵗ R′ ] c ⦂ A ↝ B
+      → ⊢↓[ X ⦂ R′ ] `∀↓ c ⦂ `∀ A ↝ `∀ B
+
+⊢id↑ : Atom A → ⊢↑[ X ⦂ R′ ] id↑ ⦂ A ↝ A
+⊢id↓ : Atom A → ⊢↓[ X ⦂ R′ ] id↓ ⦂ A ↝ A
+```
+
+Thus `seal` and `unseal` are the only rules that can touch a variable, and
+they can touch only the supplied pivot. Pivot strictness and representation
+agreement are structural consequences of a conversion-typing derivation,
+not separate predicates. Identities are restricted to atoms by their typing
+rules rather than by syntax.
+
+One passed-down `R′` also means that every `seal` or `unseal` leaf in one
+conversion uses the same scoped representation, modulo weakening beneath
+`∀`. A mixed-alias conversion, whose leaves use different scoped aliases of
+one allocation, is deliberately untypeable. No reduction rule mints such a
+shape. If the deferred merge rule eventually needs mixed aliases, that is the
+point at which to revisit the restriction.
+
+The generators are ordinary shape functions. For example,
+`〖 X , R′ ↑ B 〗 : Conv↑` recursively emits `unseal` exactly at `＇ X`, and
+`makeConceal X R′ B : Conv↓` is dual. Their endpoint facts are proofs:
+
+```agda
+generator-typed↑ :
+  ⊢↑[ X ⦂ R′ ] 〖 X , R′ ↑ B 〗 ⦂ B ↝ replaceTy X R′ B
+
+generator-typed↓ :
+  ⊢↓[ X ⦂ R′ ] makeConceal X R′ B
+    ⦂ replaceTy X R′ B ↝ B
+```
+
+The delimiters `δ↑ A` and `δ↓ A` likewise return shapes, with separate
+`delimiter-typed↑` and `delimiter-typed↓` proofs.
 
 ## Reveal is a binder, conceal is an anti-binder
 
-The term grammar replaces the live same-context conversion forms
-`M ↑ c` and `M ↓ c` with anchored crossing forms:
-
-```text
-M, N ::= …                        -- all other forms as in CastTerms.agda
-       | ƛ A ˙ N                    -- lambda, annotated by its domain
-       | M ↑[ X ≔ α ] c           -- reveal: binds slot X, anchored at α
-       | M ↓[ X ≔ α ] c           -- conceal: anti-binds slot X, anchored at α
-```
-
-The dot in `ƛ A ˙ N` distinguishes the domain annotation from the body;
-the annotation is syntax and the `⊢ƛ` rule requires it to be the domain of the
-resulting arrow type.
-
-Beside its conversion, a node carries two pieces of data: the **slot
-position** `X` — the de Bruijn position being removed from (reveal) or
-inserted into (conceal) scope; a genuine binder position, since an
-all-identity delimiter conversion does not determine it — and the
-**anchor** `α`, the store name the slot is connected to. Store names are
-drawn from the append-only store; the typing rule's lookup premise is
-their only well-formedness check. In the intrinsic syntax the
-constructors cross the context index:
+The term grammar contains anchored crossings with raw conversions:
 
 ```agda
-_↑[_≔_]_ : Term (suc Δ) → (X : TyVar (suc Δ)) → (α : Name)
-  → Conv↑ (suc Δ) A (wkᵗ X B) → Term Δ                    -- binder
-_↓[_≔_]_ : Term Δ → (X : TyVar (suc Δ)) → (α : Name)
-  → Conv↓ (suc Δ) (wkᵗ X A) B → Term (suc Δ)              -- anti-binder
+_↑[_≔_]_ : Term (suc Δ) → TyVar (suc Δ) → Name → Conv↑ → Term Δ
+_↓[_≔_]_ : Term Δ → TyVar (suc Δ) → Name → Conv↓ → Term (suc Δ)
 ```
 
-with `wkᵗ X = renameᵗ (punchIn X)` the type-level slot insertion;
-shift-by-1 is the slot `X = 0`. A reveal *binds* its scoped variable over
-its subterm: inside, `X` is in scope; outside, the node's type is `X`-free.
-A conceal is the dual hole: its subterm lives *outside* the scope of `X`
-even though the node sits inside it. Both interiors are term-closed. Displays
-later in this document abbreviate `↑[ X ≔ α ] c` to `↑ c ⟨α⟩` when the slot
-is `0` or clear from context.
+A reveal binds slot `X` over its interior and removes that slot outside. A
+conceal is the dual hole: its interior is outside the scope of `X`, while the
+whole node is inside. Both interiors are closed in the term-variable context.
+The explicit slot remains necessary because an all-identity delimiter does
+not determine a pivot.
 
-Typing, with `α ⦂ R ∈ Σ` the anchor's store entry and the context
-recording the connection `X ≔ α`:
+Let `p : α ⦂ R ∈ Σ` be the anchor lookup. The checked rules have exactly one
+node-level transport premise and one conversion-typing premise:
 
 ```agda
-⊢conceal : {c : Conv↓ (suc Δ) (wkᵗ X A) B}
-  → α ⦂ R ∈ Σ
-  → c pivot-strict at X, representations at R
-  → ⟨ Δ , Σ , ∅ ⟩ ⊢ M ⦂ A                     -- closed and X-free
-    -----------------------------------------------------------
-  → ⟨ suc Δ [X ≔ α] , Σ , Γ′ ⟩ ⊢ M ↓[ X ≔ α ] c ⦂ B
+⊢reveal :
+  (p : α ⦂ R ∈ Σ)
+  → Transport (BindingRel (κ (cross-ctx Γ X p))) R′ R
+  → ⊢↑[ X ⦂ R′ ] c ⦂ A ↝ wkᵗ X B
+  → cross-ctx Γ X p ⊢ M ⦂ A
+  → Γ ⊢ M ↑[ X ≔ α ] c ⦂ B
 
-⊢reveal : {c : Conv↑ (suc Δ) A (wkᵗ X B)}
-  → α ⦂ R ∈ Σ
-  → c pivot-strict at X, representations at R
-  → ⟨ suc Δ [X ≔ α] , Σ , ∅ ⟩ ⊢ M ⦂ A
-    -----------------------------------------------------------
-  → ⟨ Δ , Σ , Γ ⟩ ⊢ M ↑[ X ≔ α ] c ⦂ B        -- result leaves X's scope
+⊢conceal :
+  (p : α ⦂ R ∈ Σ)
+  → Transport (BindingRel (κ (cross-ctx Γ X p))) R′ R
+  → ⊢↓[ X ⦂ R′ ] c ⦂ wkᵗ X A ↝ B
+  → ⟨ Δ , n , κ , Σ , [] ⟩ ⊢ M ⦂ A
+  → ⟨ suc Δ , n , κ (cross-ctx Γ X p) , Σ , Γ′ ⟩
+      ⊢ M ↓[ X ≔ α ] c ⦂ B
 ```
 
-Here `Γ` and `Γ′` are arbitrary. The crossing changes the scoped-type context
-and classifier but does not transport a surrounding term context into its
-interior.
+The displays abbreviate the record projections used in Agda. `κ` occurs only
+in the node-level `BindingRel` transport (and in allocation-rule transport),
+never in conversion typing.
 
-**Pivot strictness.** The conversion under a crossing node mentions at
-most one scoped variable — the node's own `X` — at `seal X`/`unseal X`
-leaves; every other leaf is an identity. This is what makes the rules
-well-formed: it forces the outer endpoint to be an image of `wkᵗ X`, so
-the term on the far side can live in the context without `X`. There is
-no `Maybe` pivot and no `PivotJoin`: the anchor is node data, so a
-conversion whose leaves are all identities (a pure *delimiter*) still
-names its variable. This closes, in the syntax itself, the
-retype-an-identity-at-any-pivot loophole that the DGG's version-2
-imprecision rules had to close externally
-([`Rationale.md`](../Rationale.md), "Identity reveals").
+`Transport` is relational and structural on types. An anchored scoped
+variable maps to its anchor name, a type-local `∀` variable maps to the
+corresponding store-local variable through `LiftRel`, and a `∀-bound` entry in
+`κ` has no `BindingRel` constructor.
 
 ## Reachability invariant: crossing interiors are closed
 
@@ -134,178 +178,111 @@ The reachability argument is an induction on evaluation. In the base case,
 compilation emits no crossing nodes. For the step case, reduction mints a
 crossing only at an evaluation position; evaluation positions in a closed
 program are term-closed because evaluation never descends beneath a term
-binder. Ordinary call-by-value substitution deposits only closed values beneath
-binders, so it cannot introduce a free term variable into an existing crossing
-interior. Finally, reduction never grows the ambient scoped-type context: a
-closed source program and every program reachable from it remain `Term 0`.
-Runtime packages created by crossings are therefore term-closed. Packages that
-escape a local crossing have ambient types in `Ty 0` and are type-closed; their
-representation types are type-closed through the global store as well.
+binder. Ordinary call-by-value substitution deposits only closed values
+beneath binders, so it cannot introduce a free term variable into an existing
+crossing interior. Finally, reduction never grows the ambient scoped-type
+context: a closed source program and every program reachable from it remain
+`Term 0`. Runtime packages created by crossings are therefore term-closed.
+Packages that escape a local crossing have ambient types in `Ty 0` and are
+type-closed; their representation types are type-closed through the global
+store as well.
 
-**Identities are atomic.** `id↑`/`id↓` are restricted to `Atom` types
-(`＇Y`, `‵ι`, `★`), matching the consistency layer's `id : Atom A → …`.
-Conversions are then structural down to atoms. The generators
-`〖_,_↑_〗`/`makeConceal` already conform — they recurse through `⇒`/`∀`
-unconditionally and emit identities only at atomic leaves. Consequences:
+Term substitution consequently stops at both crossing nodes. Type-context
+weakening still renumbers the explicit crossing slots, but leaves each raw
+conversion shape unchanged.
 
-- a delimiter at `A ⇒ B` is necessarily `id↓ A ↦↑ id↑ B`, which the
-  existing `β-reveal-⇒` splits at application — no new commuting rules
-  for composite delimiters;
-- "mentions the pivot" is a plain syntactic property of the leaf set;
-- inversion never faces an identity of arbitrary shape.
+## Canonical interiors and delimiter values
 
-## Delimiters persist; `id-reveal` drops at base types only
+Raw identity shapes do not record the atom at which they are used. Valuehood
+therefore follows the interior's positive syntax rather than a negative type
+or occurrence test.
 
-The live rules `id-reveal`/`id-conceal` discard identity wrappers
-unconditionally. In this design an identity-conversion reveal anchored
-at `α` is the closing delimiter of its region, and the drop rule is
-restricted to base atoms, where the canonical inhabitants are constants
-and a constant inhabits every context:
+`CanonicalInterior V` has three shapes:
+
+- a tagged value `W ⟨ (idᵍ G) ! ⟩`;
+- a sealed value `W ↓[ X ≔ α ] seal`;
+- an identity reveal delimiter `W ↑[ X ≔ α ] id↑` whose own interior is
+  canonical.
+
+Each base case carries the needed `Value W` evidence. Consequently it also
+entails `Value V`. On well-typed terms, these are exactly the canonical
+interiors at `★` and at scoped variables; constants at base types are absent.
+
+The mutually defined `RevealValue` and `ConcealValue` gates are:
+
+- arrow and `∀` reveal/conceal shapes preserve an interior value;
+- `seal` concealments preserve an interior value;
+- an `id↓` concealment is a value only around a `CanonicalInterior`;
+- an `id↑` reveal is a value only around a `CanonicalInterior`;
+- `unseal` reveals are never values.
+
+Typing turns the positive syntax check into the intended atom distinction. An
+identity concealment at `★` or a foreign variable is a value whenever its
+interior is a value; an identity concealment around a base constant is not.
+An identity reveal delimiter is a value exactly around a tag, a seal, or a
+further valid delimiter, and never around a base constant or an identity
+concealment. Hence none of the following redexes is also a value.
+
+## Delimiter and cancellation rules
+
+The base drops are symmetric and raw:
 
 ```agda
-id-reveal : ($ κ) ↑ id↑ (‵ ι) ⟨α⟩ —→ $ κ
+id-reveal  : ($ κ₀) ↑[ X ≔ α ] id↑ —→[ keep ] $ κ₀
+id-conceal : ($ κ₀) ↓[ X ≔ α ] id↓ —→[ keep ] $ κ₀
 ```
 
-No premise, no strengthening operation. (An earlier draft guarded the
-drop with a "pivot does not occur in the value" strengthening premise
-at every atom; that makes value-hood at `★` undecidable by pattern —
-a delimited `★`-value would be a value or a redex depending on a
-term-level occurrence check — and the drop rule would overlap with the
-projection-merge rule below. Base-only drop keeps `Value`, progress,
-and determinism syntax-directed.)
-
-At `★` and at foreign variables `＇Y` a delimiter is always a value;
-delimiter spines on `★`-values are consumed by elimination, never by
-garbage collection. An `id`-conceal never drops at any type — its
-subterm lives in the smaller context — and is consumed only by
-`conceal-reveal` cancellation at its matching reveal. When a projection
-meets a `★`-delimiter, it commutes into the region to meet the tag:
+Non-base identity cancellation is deliberately loose in node data:
 
 ```agda
-(V ↑ id↑ ★ ⟨α⟩) ⟨ ？ H ⟩ —→ (V ⟨ ？ H ⟩′) ↑ id↑ … ⟨α⟩
+id-cancel :
+  CanonicalInterior V
+  → (V ↓[ X ≔ α ] id↓) ↑[ Y ≔ β ] id↑ —→[ keep ] V
 ```
 
-with tag comparison by **anchor equality**: two regions anchored at the
-same `α` may have different scoped names for the same allocation, and
-the tag/untag rules compare anchors, not scoped indices. This is the
-same-anchor *merge* — the one genuinely new rule family.
+Using the positive `CanonicalInterior` refinement of `Value V` makes
+`id-cancel` disjoint from both constant drop rules without putting types back
+into raw syntax. Typed instances are precisely the non-base atomic cases.
+
+Seal/unseal cancellation is also loose:
+
+```agda
+conceal-reveal :
+  Value V
+  → (V ↓[ X ≔ α ] seal) ↑[ Y ≔ β ] unseal —→[ keep ] V
+```
+
+Typing inversion forces `X = Y` and `α = β`: the conceal produces `＇ X`,
+the reveal consumes `＇ Y` in the same scoped context, and classifier
+agreement at that slot identifies the anchors. Preservation may extract those
+equalities; reduction does not carry them.
+
+The loose `id-cancel` formulation is intentionally open for review if
+`Bindings` becomes a first-order `Vec`. In that representation,
+mismatched-insertion classifier coincidences may make loose mismatched nodes
+typeable at `★` or foreign atoms. This task does not choose the future rule.
+
+## Syntactic tag comparison
+
+Tag cancellation follows the live calculus and compares ground types
+syntactically. There are no `TagMatch` or `TagMismatch` relations and the
+classifier does not appear in either rule:
+
+```agda
+tag-untag :
+  Value V
+  → V ⟨ (idᵍ G) ! ⟩ ⟨ ？ (idᵍ G) ⟩ —→[ keep ] V
+
+tag-untag-bad :
+  Value V
+  → G ≢ H
+  → V ⟨ (idᵍ G) ! ⟩ ⟨ ？ (idᵍ H) ⟩ —→[ keep ] blame
+```
+
+Cross-region behavior that cannot be expressed by syntactic tag equality
+belongs to the still-deferred merge rule, not to tag comparison.
 
 ## Reduction never shifts
-
-The reduction judgment becomes
-
-```text
-Σ ∣ M —→ Σ′ ∣ M′        M, M′ : Term Δ,  Σ′ = Σ or Σ, α ⦂ R
-```
-
-with the ambient `Δ` fixed across every step. What dissolves from
-[`Reduction.agda`](../Reduction.agda): `StoreChange`'s action on terms
-and evidence (`applyTerm`/`▷ᵀ`, `applyConsistency`/`▷ᶜ`,
-`applyBody`/`▷ᵇ`, and their `▶` iterations), all ξ-frame shift premises,
-every `⇑ᵗᵐ`, and the `↑ᶜ` on `β-inst`'s closed evidence — its endpoints
-are `X`-free, so it sits outside the reveal at ambient `Δ` unchanged.
-
-Sketch of `β-inst` (slot at `0`, anchors written `⟨α⟩`):
-
-```text
-Σ ∣ V ⟨ (inst c) B≢★ ⟩ —→ Σ, α ⦂ ★ ∣
-  ((V ↓ δ∀ ⟨α⟩) ⦂∀ … [ ＇ 0 ]) ↑ 〖 0 , ★ ↑ A 〗⟨α⟩ ⟨ c [ ★ /0 ]ᶜ ⟩
-```
-
-`V` enters the region through an anti-binder delimiter `δ∀` (structural,
-all-atomic-identity, anchored at `α`), is type-applied at the scoped
-variable, revealed through the generated conversion (binder, closing the
-region), and cast by the *unshifted* closed evidence. The composition
-properties hold on the existing rules: `β-reveal-⇒` sends
-`(V ↑ (c ↦↑ d)⟨α⟩) · W` to `(V · (W ↓ c ⟨α⟩)) ↑ d ⟨α⟩`, which pairs the
-binder with a fresh anti-binder so all context indices line up, and
-`conceal-reveal` cancellation `(V ↓ seal ⟨α⟩) ↑ unseal ⟨α⟩ —→ V` has both
-sides at ambient `Δ`.
-
-## Why escapees must stay live: the re-entry example
-
-Sealed-and-tagged values escape their region through positive-`★`
-channels: with `B = ＇X ⇒ ★`, applying the generalized dynamic identity
-yields the free-floating package `(7 ↓ seal ⟨α⟩) ⟨ tag ⟨α⟩ ⟩ ⦂ ★` after
-the region's delimiter would (in the live calculus) be erased by
-`id-reveal` — the delimiter restriction exists precisely to keep the
-package closed.
-
-Such packages are not dead. With
-
-```text
-B = ＇X ⇒ ((★ ⇒ ★) ⇒ ＇X)          W = ƛx. ƛj. j · x
-
-(ƛh. h · 9 · (ƛu. (ƛw. u) · (h · 5 · (ƛv. u)))) · ((W ⟨ gen c ⟩) ⦂∀ B [ ℕ ])
-```
-
-the instantiation fires `β-gen` once (CBV argument), so both uses of `h`
-share one allocation. The outer call leaks its tagged argument `t₉` to
-user code through the identity-conversion `(★ ⇒ ★)` channel; the inner
-sibling call `h · 5 · (ƛv. u)` routes the captured `t₉` to its own
-positive-`＇X` exit, where the projection meets the tag — same
-allocation, tags match, unseal returns `9`. The whole program reduces to
-`$ 9` with no blame: an escaped package was consumed by a *different*
-region of the same allocation. Hence: escapees keep their anchors, the
-merge rule is by anchor equality, and no design may neuter or eagerly
-blame an escaped package. (When the generalized type has no positive
-occurrence of the bound variable, no projection site exists and packages
-are inert forever — ordinary uninspected `★` values.)
-
-A mechanized `—↠` derivation of this program in the *live* calculus is
-queued as a baseline probe; if the trace does not hold as claimed, the
-design motivation needs revisiting before the new calculus is built.
-
-## Open bookkeeping (expected mechanization friction)
-
-- **`β-inst` binder/slot exchange.** Reusing the `inst` body `A`
-  verbatim inside the region relies on the pun between the consistency
-  binder and the slot position; the exact de Bruijn exchange between the
-  `∀`-binder and the inserted slot inside `δ∀` needs to be worked out in
-  Agda, and slot positions other than `0` appear as soon as regions
-  nest.
-- **Conceal orientation cases.** The anti-binder form covers values
-  entering a region; whether any rule still needs a same-context conceal
-  (or reveal) is to be discovered by the mechanization, not assumed.
-- **Store monotonicity.** The one new lemma obligation: typing is
-  preserved under store extension (`Σ ⊆ Σ′`) — a lookup lemma, not a
-  term traversal.
-- **`GenSafe` and value forms.** `RevealValue`/`ConcealValue` gain the
-  atomic-delimiter cases (`★` and `＇Y` delimiters are always values;
-  base delimiters never are); `GenSafe`'s interaction with anchored
-  suspended casts needs restating.
-- **Delimiters at foreign variables.** A reveal delimiter at `＇Y` is
-  eliminated by commuting past `Y`'s consuming unseal — a node-local
-  reveal-past-reveal swap that renumbers the two slot positions; the
-  exact rule shape is to be settled in Agda.
-- **Blame.** `tag-untag-bad` compares anchors; blame across regions of
-  distinct allocations must still be derivable through the merge rule.
-
-## Mechanization notes
-
-The following are the statement-level resolutions and deviations in the first
-`alt.*` core.  They are recorded here as revised statements so later work does
-not accidentally rely on the prose sketch where the checked Agda interface is
-different.
-
-### The store length is explicit in typing contexts
-
-The checked context record is
-
-```agda
-⟨ Δ , n , κ , Σ , Γ ⟩
-```
-
-where `Σ : Store n` and `κ : TyVar Δ → Binding n`.  The extra displayed `n`
-is the index needed by Agda to make the existential store length available to
-the dependent projections `κᵉ` and `Σᵉ`; it adds no semantic component.
-
-`Binding n` contains either `∀-bound` or `anchored α` with `α : Fin n`.
-The raw stable name carried by terms is a natural number.  A premise
-`α ⦂ R ∈ Σ` resolves that raw name to the corresponding `Fin n` used in the
-classifier.
-
-### Reduction carries the scoped-variable classifier
 
 The checked one-step judgment is
 
@@ -313,116 +290,79 @@ The checked one-step judgment is
 Σ ∣ κ ⊢ M —→[ χ ] M′
 ```
 
-with `M M′ : Term Δ`, `Σ : Store n`,
-`κ : TyVar Δ → Binding n`, and `χ : StoreΔ n n′`.  This refines the sketched
-`Σ ∣ M —→ Σ′ ∣ M′`: reduction needs `κ` both to translate an allocating type
-argument to a name-scoped store representation and to compare variable tags by
-anchor.  If `χ = bind R`, the next multi-step premise uses the pointwise
-weakening of `κ` from `Fin n` to `Fin (suc n)`; terms are unchanged.
+where `χ` is `keep` or `bind R`. If a step allocates, the next multi-step
+premise weakens only `κ` and the store; `M` and `M′` remain in the same scoped
+type context. Evaluation frames never traverse an untouched sibling.
 
-### Representation transport is relational
-
-The checked crossing premises are, for the lookup `p : α ⦂ R ∈ Σ`,
-
-```agda
-Reps↑ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
-Reps↓ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
-```
-
-respectively.  `Transport` is structural on types.  An anchored scoped
-variable transports to its anchor name, a type-local `∀` variable transports
-to the corresponding type-local variable, and a `∀-bound` entry in `κ` has no
-transport constructor.  Under a conversion `∀`, both the variable relation
-and `R` are weakened once.  Thus every `seal` or `unseal` representation is
-checked against the current weakened store entry without defining a partial
-transport function.
-
-### Ordinary lambda beta uses substitution that stops at crossings
-
-Lambdas carry their domain type, and the checked single substitution is
-
-```agda
-_[_] : Term Δ → Term Δ → Term Δ
-β : Value V → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ]
-```
-
-The implementation generalizes internally to substitution at an arbitrary
-term index.  Under `ƛ`, that index is incremented and `V` is weakened only by
-the term-variable renaming `rename suc`.  Under `Λ`, the replacement is
-weakened across that existing lexical type binder; this is unrelated to store
-allocation, and no allocation or evaluation-frame rule traverses a term.
-
-Substitution stops at both crossing nodes:
-
-```agda
-(M ↑[ X ≔ α ] c) [ V ] = M ↑[ X ≔ α ] c
-(M ↓[ X ≔ α ] c) [ V ] = M ↓[ X ≔ α ] c
-```
-
-This is sound directly from the closed-interior premises of `⊢reveal` and
-`⊢conceal`: a variable supplied by an enclosing lambda cannot occur free below
-either node. Constants and `blame` are unchanged, and every other constructor
-is traversed structurally. The lambda domain annotation is retained by design
-because it remains useful for typing inversion, not because substitution needs
-to track the type.
-
-### `β-Λ` and `β-gen` take an endpoint-correct exit conversion
-
-The checked allocation rules are
+Allocation rules now carry literal raw generator shapes. In particular,
 
 ```agda
 β-Λ :
-  Value V → Transport (BindingRel κ) A R →
-  Σ ∣ κ ⊢ (Λ V) ⦂∀ B [ A ] —→[ bind R ]
-    V ↑[ 0 ≔ n ] d
-```
+  Value V
+  → Transport (BindingRel κ) A R
+  → (Λ V) ⦂∀ B [ A ] —→[ bind R ]
+      V ↑[ 0 ≔ n ] 〖 0 , ⇑ᵗ A ↑ B 〗
 
-where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ A ]ᵗ))`, and
-
-```agda
 β-gen :
-  Value V → (A ≢ ★) → GenSafe c →
-  Transport (BindingRel κ) C R →
-  Σ ∣ κ ⊢ (V ⟨ gen c ⟩) ⦂∀ B [ C ] —→[ bind R ]
-    (((V ↓[ 0 ≔ n ] δ↓ (⇑ᵗ A)) ⟨ c ⟩)
-      ↑[ 0 ≔ n ] d)
+  Value V
+  → A ≢ ★
+  → GenSafe c
+  → Transport (BindingRel κ) C R
+  → (V ⟨ gen c ⟩) ⦂∀ B [ C ] —→[ bind R ]
+      ((V ↓[ 0 ≔ n ] δ↓ (⇑ᵗ A)) ⟨ c ⟩)
+        ↑[ 0 ≔ n ] 〖 0 , ⇑ᵗ C ↑ B 〗
 ```
 
-where `d : Conv↑ (suc Δ) B (wkᵗ 0 (B [ C ]ᵗ))`.  This makes the entry
-anti-binder and exit reveal explicit and performs no term renaming.  The
-literal generator `〖 0 , ⇑ᵗ C ↑ B 〗` computes the extensionally equal target
-`replaceTy 0 (⇑ᵗ C) B`; that target is not definitionally equal to
-`wkᵗ 0 (B [ C ]ᵗ)`, especially under nested `∀`.  A future endpoint theorem
-can replace the supplied `d` by the literal generator without changing the
-term or store behavior.
-
-### Three allocation rules remain omitted
-
-There are currently no `β-inst`, `β-reveal-∀`, or `β-conceal-∀`
-constructors.  In `β-inst`, the body of the source `∀` uses slot `0` for its
-type binder, while the freshly entered region also uses crossing slot `0`.
-After the entry anti-binder, these are two distinct slots and the body must be
-transported across their exchange before it can be type-applied at the region
-variable.  The same exchange appears when type application crosses a
-structural `∀` reveal or conceal.  Neither `Types` nor the settled term syntax
-provides this typed exchange, and choosing an order silently changes the
-displayed rule.  The three rules are therefore omitted pending an explicit
-exchange statement.
-
-### Tag cancellation uses an explicit anchor relation
-
-The checked tag rules replace syntactic ground equality and inequality by
+There is no endpoint-correct conversion parameter to choose, so the earlier
+nondeterministic deviation has dissolved. `alt.GeneratorEndpoint` retains the
+pure type theorem
 
 ```agda
-TagMatch κ G H
-TagMismatch κ G H
+replaceTy 0 (⇑ᵗ C) B ≡ ⇑ᵗ (B [ C ]ᵗ)
 ```
 
-For variable grounds, `TagMatch` requires both classifier entries to be
-`anchored α` for the same `α`; `TagMismatch` requires distinct anchors.  Base,
-function, and universal ground tags retain their structural comparison.  This
-is the statement needed for two distinct scoped names anchored at one
-allocation to cancel.
+and uses it to transport `generator-typed↑` to the endpoint required by
+preservation. This evidence is proof infrastructure, not rule data.
 
-The projection-into-`★`-delimiter merge rule remains deferred exactly as
-allowed in the task; its intended location is marked in `alt.Reduction`.
+## Deferred forall allocation rules and exchange
+
+`β-inst`, `β-reveal-∀`, and `β-conceal-∀` are still absent from
+`_—→[_]_`. Their proposed raw redexes and contracta, plus typing validations,
+live in `alt.Exchange` pending user sign-off.
+
+The two newest scoped slots are exchanged only in types and classifiers. Raw
+conversion shapes mention no variables, so conversion-level `swap↑`/`swap↓`
+functions have vanished. Opening a structural `∀` transports only the
+conversion-typing endpoint proof; the shape is unchanged. All three proposed
+contracta use literal generator shapes.
+
+The two nested-crossing validations still take `BindingsExtensionality`
+explicitly. Inserting the fresh crossing before the old crossing and inserting
+the old crossing after the fresh one are pointwise equal functions, but Agda
+needs this restricted extensionality principle to turn that fact into context
+equality. No postulate is introduced.
+
+The validations also expose the node-level `Transport` evidence needed after
+store weakening and crossing exchange. General transport-weakening lemmas are
+not yet part of the alt core; preservation may later derive these premises
+from the allocating rule's original transport proof.
+
+## Mechanization notes
+
+- `Binding`, `Bindings`, `BindingRel`, `LiftRel`, and `Transport` remain in
+  `alt.Terms`. `alt.Conversion` imports only `Types`.
+- Conversion renaming, endpoint indices, `PivotStrict↑/↓`, and `Reps↑/↓` have
+  been deleted. Type-context weakening changes crossing slots but reuses the
+  raw shape verbatim.
+- Ordinary lambda beta uses structural single substitution. Substitution
+  stops at crossings because their interiors are typed in the empty term
+  context.
+- `RevealValue`, `ConcealValue`, `Value`, and `CanonicalInterior` are mutually
+  defined so the progress gates are positive and syntax-directed.
+- Reduction still carries `κ` to step under anchored crossings and to state
+  allocation `Transport` premises. Tag rules do not inspect it.
+- The projection-into-`★`-delimiter merge rule remains deferred. Its intended
+  location is marked in `alt.Reduction`.
+- Refactoring `Bindings` to `Vec` remains a separate pending decision.
+- No `β-inst`, `β-reveal-∀`, or `β-conceal-∀` constructor has been added to
+  reduction; only their checked statements remain in `alt.Exchange`.

--- a/GTSFImp/alt/Exchange.agda
+++ b/GTSFImp/alt/Exchange.agda
@@ -19,16 +19,15 @@ module alt.Exchange where
 --     crossing after the fresh one give pointwise equal `Bindings`; this
 --     assumption turns that finite pointwise proof into function equality.
 --     No postulate is introduced, and all exchanged inner typing is derived
---     below.
+--     below; crossing term-context components are definitionally empty.
 
 open import Data.Fin using (Fin; fromℕ; inject₁; zero; suc)
-open import Data.List using ([]; _∷_)
+open import Data.List using ([])
 open import Data.Nat using (suc)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; cong; sym; trans; subst)
 
 open import Types
-open import TermCtx using (TermCtx)
 open import Consistency
 open import alt.Store
 open import alt.Conversion
@@ -234,13 +233,6 @@ weakenBindings-insert {Δ = suc Δ} (suc X) b κ zero = refl
 weakenBindings-insert {Δ = suc Δ} (suc X) b κ (suc Y) =
   weakenBindings-insert X b (λ Z → κ (suc Z)) Y
 
-wkᶜ-exchange : ∀ {Δ} (X : Fin (suc Δ)) (Γ : TermCtx Δ)
-  → wkᶜ zero (wkᶜ X Γ) ≡ wkᶜ (suc X) (wkᶜ zero Γ)
-wkᶜ-exchange X [] = refl
-wkᶜ-exchange X (A ∷ Γ)
-    rewrite wk-exchange X A | wkᶜ-exchange X Γ =
-  refl
-
 BindingsExtensionality : Set
 BindingsExtensionality = ∀ {n Δ} {κ κ′ : Bindings Δ n}
   → (∀ X → κ X ≡ κ′ X)
@@ -293,8 +285,7 @@ cross-ctx-exchange ext {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩}
     {S = S} {X = X} p
     rewrite
       cross-bindings-exchange ext X (anchored (fromℕ n))
-        (anchored (inject₁ (lookup-name p))) (weakenBindings κ)
-    | wkᶜ-exchange X Γ =
+        (anchored (inject₁ (lookup-name p))) (weakenBindings κ) =
   refl
 
 allocation-cross-ctx : BindingsExtensionality
@@ -321,8 +312,7 @@ allocation-cross-ctx-exchange ext
     {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩} {S = S} {X = X} p
     rewrite
       allocation-cross-bindings-exchange ext X (anchored (fromℕ n))
-        (anchored (lookup-name p)) κ
-    | wkᶜ-exchange X Γ =
+        (anchored (lookup-name p)) κ =
   refl
 
 cross-ctx-exchange-typing : BindingsExtensionality
@@ -342,8 +332,7 @@ cross-ctx-exchange-typing ext
     {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩} {S = S} {X = X} p M⊢
     rewrite
       cross-bindings-exchange ext X (anchored (fromℕ n))
-        (anchored (inject₁ (lookup-name p))) (weakenBindings κ)
-    | wkᶜ-exchange X Γ =
+        (anchored (inject₁ (lookup-name p))) (weakenBindings κ) =
   M⊢
 
 allocation-cross-ctx-exchange-typing : BindingsExtensionality
@@ -362,8 +351,7 @@ allocation-cross-ctx-exchange-typing ext
     {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩} {S = S} {X = X} p M⊢
     rewrite
       allocation-cross-bindings-exchange ext X (anchored (fromℕ n))
-        (anchored (lookup-name p)) κ
-    | wkᶜ-exchange X Γ =
+        (anchored (lookup-name p)) κ =
   M⊢
 
 mutual
@@ -398,7 +386,7 @@ mutual
 ∀-entry-application-typed : ∀ {Γ} {V : Term (Δᵉ Γ)}
     {A : Ty (suc (Δᵉ Γ))} {α : Name} {R : Ty (sizeᵉ Γ)}
   → (p : α ⦂ R ∈ Σᵉ Γ)
-  → Γ ⊢ V ⦂ `∀ A
+  → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ V ⦂ `∀ A
   → cross-ctx Γ zero p ⊢ ∀-entry-application α V A ⦂ A
 ∀-entry-application-typed {Γ} {V = V} {A = A} {α = α} {R = R} p V⊢ =
   subst
@@ -409,7 +397,8 @@ mutual
       V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A))
       ⦂ wkᵗ zero (`∀ A)
   entered⊢ =
-    ⊢conceal p (δ-strict↓ zero (wkᵗ zero (`∀ A)))
+    ⊢conceal {Γ = Γ} {Γ′ = []} p
+      (δ-strict↓ zero (wkᵗ zero (`∀ A)))
       (delimiter-reps↓
         (BindingRel (κᵉ (cross-ctx Γ zero p))) R
         (wkᵗ zero (`∀ A))) V⊢
@@ -458,7 +447,8 @@ mutual
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (Δᵉ Γ)} {V : Term (Δᵉ Γ)}
     {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
     {d : Conv↑ (suc (Δᵉ Γ)) A (wkᵗ zero (A [ ★ ]ᵗ))}
-  → allocCtx Γ ★ ⊢ V ⦂ `∀ A
+  → ⟨ Δᵉ Γ , suc (sizeᵉ Γ) , weakenBindings (κᵉ Γ) ,
+      bind (Σᵉ Γ) ★ , [] ⟩ ⊢ V ⦂ `∀ A
   → PivotStrict↑ zero d
   → Reps↑
       (BindingRel
@@ -474,7 +464,7 @@ mutual
 
   applied⊢ : cross-ctx Γ⁺ zero p ⊢
       ∀-entry-application (sizeᵉ Γ) V A ⦂ A
-  applied⊢ = ∀-entry-application-typed p V⊢
+  applied⊢ = ∀-entry-application-typed {Γ = Γ⁺} p V⊢
 
   revealed⊢ : Γ⁺ ⊢
       (∀-entry-application (sizeᵉ Γ) V A)
@@ -612,11 +602,12 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   inner-left⊢ : cross-ctx oldΓ zero fresh ⊢
       ∀-entry-application (sizeᵉ Γ) V C ⦂ C
-  inner-left⊢ = ∀-entry-application-typed fresh V⊢
+  inner-left⊢ = ∀-entry-application-typed {Γ = oldΓ} fresh V⊢
 
   inner-right⊢ : cross-ctx freshΓ (suc X) old ⊢
       ∀-entry-application (sizeᵉ Γ) V C ⦂ C
-  inner-right⊢ = cross-ctx-exchange-typing ext p inner-left⊢
+  inner-right⊢ =
+    cross-ctx-exchange-typing ext {Γ = Γ} p inner-left⊢
 
   old-revealed⊢ : freshΓ ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
@@ -668,11 +659,12 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → PivotStrict↓ (suc X) c
   → Reps↓ (LiftRel (BindingRel (κᵉ (cross-ctx Γ X p))))
       (⇑ᵗ R) c
-  → Γ ⊢ V ⦂ `∀ C
+  → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ V ⦂ `∀ C
   → cross-ctx Γ X p ⊢
       β-conceal-∀-redex α V X c A ⦂ B [ A ]ᵗ
-β-conceal-∀-redex-typed p c-strict c-reps V⊢ =
-  ⊢• (⊢conceal p (strict-↓∀ c-strict) (reps-↓∀ c-reps) V⊢)
+β-conceal-∀-redex-typed {Γ} p c-strict c-reps V⊢ =
+  ⊢• (⊢conceal {Γ = Γ} {Γ′ = []} p (strict-↓∀ c-strict)
+    (reps-↓∀ c-reps) V⊢)
 
 β-conceal-∀-result-typed : ∀ {Γ}
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
@@ -684,7 +676,8 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
            (wkᵗ zero (B [ A ]ᵗ))}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → BindingsExtensionality
-  → allocCtx Γ S ⊢ V ⦂ `∀ C
+  → ⟨ Δᵉ Γ , suc (sizeᵉ Γ) , weakenBindings (κᵉ Γ) ,
+      bind (Σᵉ Γ) S , [] ⟩ ⊢ V ⦂ `∀ C
   → Reps↓
       (BindingRel
         (κᵉ
@@ -715,14 +708,14 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   applied⊢ : freshΓ ⊢
       ∀-entry-application (sizeᵉ Γ) V C ⦂ C
-  applied⊢ = ∀-entry-application-typed fresh V⊢
+  applied⊢ = ∀-entry-application-typed {Γ = Γ⁺} fresh V⊢
 
   concealed-right⊢ : cross-ctx freshΓ (suc X) old ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
         ↓⟨ suc X ≔ α ⟩ open-∀↓ c
       ⦂ B
   concealed-right⊢ =
-    ⊢conceal old
+    ⊢conceal {Γ = freshΓ} {Γ′ = []} old
       (cast↓-source-strict (wk-under-∀ X C) c-strict)
       (cast↓-source-reps (wk-under-∀ X C) c-reps)
       applied⊢
@@ -732,4 +725,4 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
         ↓⟨ suc X ≔ α ⟩ open-∀↓ c
       ⦂ B
   concealed-left⊢ =
-    allocation-cross-ctx-exchange-typing ext p concealed-right⊢
+    allocation-cross-ctx-exchange-typing ext {Γ = Γ} p concealed-right⊢

--- a/GTSFImp/alt/Exchange.agda
+++ b/GTSFImp/alt/Exchange.agda
@@ -397,7 +397,7 @@ allocation-cross-ctx-exchange-typing ext
 ------------------------------------------------------------------------
 
 open-∀↑-typed : ∀ {Δ} {X : Fin (suc Δ)} {R C}
-    {B : Ty (suc Δ)} {c : Conv↑}
+    {B : Ty (suc Δ)} {c : Reveal}
   → ⊢↑[ suc X ⦂ R ] c ⦂ C ↝ renameᵗ (extᵗ (punchIn X)) B
   → ⊢↑[ suc X ⦂ R ] c ⦂ C ↝ wkᵗ (suc X) B
 open-∀↑-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
@@ -405,7 +405,7 @@ open-∀↑-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
     (wk-under-∀ X B) c⊢
 
 open-∀↓-typed : ∀ {Δ} {X : Fin (suc Δ)} {R C}
-    {B : Ty (suc Δ)} {c : Conv↓}
+    {B : Ty (suc Δ)} {c : Conceal}
   → ⊢↓[ suc X ⦂ R ] c ⦂ renameᵗ (extᵗ (punchIn X)) B ↝ C
   → ⊢↓[ suc X ⦂ R ] c ⦂ wkᵗ (suc X) B ↝ C
 open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
@@ -420,7 +420,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
   → Name
   → Term (suc Δ)
   → (X : Fin (suc Δ))
-  → Conv↑
+  → Reveal
   → Ty Δ
   → Term Δ
 β-reveal-∀-redex {B = B} α V X c A =
@@ -431,7 +431,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
   → Name
   → (X : Fin (suc Δ))
   → Term (suc Δ)
-  → Conv↑
+  → Reveal
   → Term Δ
 β-reveal-∀-result {A = A} {B = B} {C = C} fresh α X V c =
   (((∀-entry-application fresh V C)
@@ -442,7 +442,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
     {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
     {V : Term (suc (Δᵉ Γ))} {X : Fin (suc (Δᵉ Γ))}
     {α : Name} {R : Ty (sizeᵉ Γ)} {R′ : Ty (suc (Δᵉ Γ))}
-    {c : Conv↑}
+    {c : Reveal}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → Transport (BindingRel (κᵉ (cross-ctx Γ X p))) R′ R
   → ⊢↑[ suc X ⦂ ⇑ᵗ R′ ] c ⦂ C
@@ -456,7 +456,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
     {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
     {V : Term (suc (Δᵉ Γ))} {X : Fin (suc (Δᵉ Γ))}
     {α : Name} {R S : Ty (sizeᵉ Γ)} {R′ : Ty (suc (Δᵉ Γ))}
-    {Q : Ty (suc (suc (Δᵉ Γ)))} {c : Conv↑}
+    {Q : Ty (suc (suc (Δᵉ Γ)))} {c : Reveal}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → BindingsExtensionality
   → cross-ctx (allocCtx Γ S) X (weaken-lookup p) ⊢ V ⦂ `∀ C
@@ -518,7 +518,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
   → Name
   → Term Δ
   → (X : Fin (suc Δ))
-  → Conv↓
+  → Conceal
   → Ty (suc Δ)
   → Term (suc Δ)
 β-conceal-∀-redex {B = B} α V X c A =
@@ -530,7 +530,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
   → Name
   → (X : Fin (suc Δ))
   → Term Δ
-  → Conv↓
+  → Conceal
   → Term (suc Δ)
 β-conceal-∀-result {A = A} {B = B} {C = C} fresh α X V c =
   (((∀-entry-application fresh V C)
@@ -541,7 +541,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
     {C : Ty (suc (Δᵉ Γ))} {V : Term (Δᵉ Γ)}
     {X : Fin (suc (Δᵉ Γ))} {α : Name} {R : Ty (sizeᵉ Γ)}
-    {R′ : Ty (suc (Δᵉ Γ))} {c : Conv↓}
+    {R′ : Ty (suc (Δᵉ Γ))} {c : Conceal}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → Transport (BindingRel (κᵉ (cross-ctx Γ X p))) R′ R
   → ⊢↓[ suc X ⦂ ⇑ᵗ R′ ] c
@@ -556,7 +556,7 @@ open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
     {C : Ty (suc (Δᵉ Γ))} {V : Term (Δᵉ Γ)}
     {X : Fin (suc (Δᵉ Γ))} {α : Name} {R S : Ty (sizeᵉ Γ)}
-    {R′ Q : Ty (suc (Δᵉ Γ))} {c : Conv↓}
+    {R′ Q : Ty (suc (Δᵉ Γ))} {c : Conceal}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → BindingsExtensionality
   → ⟨ Δᵉ Γ , suc (sizeᵉ Γ) , weakenBindings (κᵉ Γ) ,

--- a/GTSFImp/alt/Exchange.agda
+++ b/GTSFImp/alt/Exchange.agda
@@ -1,0 +1,735 @@
+module alt.Exchange where
+
+-- File Charter:
+--   * Defines the exchange of the two newest scoped-type slots and lifts it
+--     to reveal and conceal conversions, including pivot strictness.
+--   * States the omitted β-inst, β-reveal-∀, and β-conceal-∀ redexes and
+--     shift-free contracta, then validates the contracta against explicit
+--     typing components.
+--   * The exchange is deliberately the top-two transposition, rather than a
+--     general adjacent transposition: all three rules allocate their fresh
+--     crossing at slot zero, immediately below a source `∀` binder.  Nested
+--     pre-existing crossings move from X to suc X by ordinary `punchIn`.
+--   * Compared with the Design.md sketch, endpoint-correct entry and exit
+--     conversions are explicit parameters when propositional endpoint
+--     equality is not definitional, following the checked β-Λ/β-gen rules.
+--     For β-reveal-∀ and β-conceal-∀ the validation takes the restricted
+--     `BindingsExtensionality` principle explicitly.  Inserting the fresh
+--     crossing before an existing crossing and inserting the existing
+--     crossing after the fresh one give pointwise equal `Bindings`; this
+--     assumption turns that finite pointwise proof into function equality.
+--     No postulate is introduced, and all exchanged inner typing is derived
+--     below.
+
+open import Data.Fin using (Fin; fromℕ; inject₁; zero; suc)
+open import Data.List using ([]; _∷_)
+open import Data.Nat using (suc)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; cong; sym; trans; subst)
+
+open import Types
+open import TermCtx using (TermCtx)
+open import Consistency
+open import alt.Store
+open import alt.Conversion
+open import alt.Terms
+
+------------------------------------------------------------------------
+-- Exchange of the two newest scoped slots
+------------------------------------------------------------------------
+
+swap : ∀ {Δ} → Fin (suc (suc Δ)) → Fin (suc (suc Δ))
+swap zero = suc zero
+swap (suc zero) = zero
+swap (suc (suc X)) = suc (suc X)
+
+swapᵗ : ∀ {Δ} → Ty (suc (suc Δ)) → Ty (suc (suc Δ))
+swapᵗ = renameᵗ swap
+
+swap-involutive : ∀ {Δ} (X : Fin (suc (suc Δ)))
+  → swap (swap X) ≡ X
+swap-involutive zero = refl
+swap-involutive (suc zero) = refl
+swap-involutive (suc (suc X)) = refl
+
+renameᵗ-id : ∀ {Δ} (A : Ty Δ) → renameᵗ (λ X → X) A ≡ A
+renameᵗ-id (＇ X) = refl
+renameᵗ-id (‵ ι) = refl
+renameᵗ-id ★ = refl
+renameᵗ-id (A ⇒ B) rewrite renameᵗ-id A | renameᵗ-id B = refl
+renameᵗ-id (`∀ A) = cong `∀
+  (trans (renameᵗ-cong A ext-id) (renameᵗ-id A))
+  where
+  ext-id : ∀ X → extᵗ (λ Y → Y) X ≡ X
+  ext-id zero = refl
+  ext-id (suc X) = refl
+
+swapᵗ-involutive : ∀ {Δ} (A : Ty (suc (suc Δ)))
+  → swapᵗ (swapᵗ A) ≡ A
+swapᵗ-involutive A =
+  trans (renameᵗ-comp swap swap A)
+        (trans (renameᵗ-cong A swap-involutive)
+               (renameᵗ-id A))
+
+swap-shift : ∀ {Δ} (A : Ty (suc Δ))
+  → swapᵗ (⇑ᵗ A) ≡ renameᵗ (extᵗ suc) A
+swap-shift A =
+  trans (renameᵗ-comp suc swap A)
+        (renameᵗ-cong A swap-after-shift)
+  where
+  swap-after-shift : ∀ X → swap (suc X) ≡ extᵗ suc X
+  swap-after-shift zero = refl
+  swap-after-shift (suc X) = refl
+
+swap-double-wk : ∀ {Δ} (A : Ty Δ)
+  → swapᵗ (wkᵗ zero (wkᵗ zero A)) ≡ wkᵗ zero (wkᵗ zero A)
+swap-double-wk {Δ} A =
+  trans (renameᵗ-comp (punchIn zero) swap (wkᵗ zero A))
+        (trans (renameᵗ-comp (punchIn zero) swap-after-punch A)
+               (trans (renameᵗ-cong A same-double-punch)
+                      (sym (renameᵗ-comp (punchIn zero)
+                                          (punchIn zero) A))))
+  where
+  swap-after-punch : Fin (suc Δ) → Fin (suc (suc Δ))
+  swap-after-punch X = swap (punchIn zero X)
+
+  same-double-punch : ∀ X
+    → swap-after-punch (punchIn zero X)
+      ≡ punchIn zero (punchIn zero X)
+  same-double-punch X = refl
+
+punchIn-exchange : ∀ {Δ} (X : Fin (suc Δ)) (Y : Fin Δ)
+  → punchIn zero (punchIn X Y) ≡ punchIn (suc X) (punchIn zero Y)
+punchIn-exchange zero Y = refl
+punchIn-exchange (suc X) zero = refl
+punchIn-exchange (suc X) (suc Y) = refl
+
+wk-exchange : ∀ {Δ} (X : Fin (suc Δ)) (A : Ty Δ)
+  → wkᵗ zero (wkᵗ X A) ≡ wkᵗ (suc X) (wkᵗ zero A)
+wk-exchange X A =
+  trans (renameᵗ-comp (punchIn X) (punchIn zero) A)
+        (trans (renameᵗ-cong A (punchIn-exchange X))
+               (sym (renameᵗ-comp (punchIn zero)
+                                   (punchIn (suc X)) A)))
+
+substSecondᵗ : ∀ {Δ} → Ty (suc Δ) → Fin (suc (suc Δ)) → Ty (suc Δ)
+substSecondᵗ B zero = ＇ zero
+substSecondᵗ B (suc zero) = B
+substSecondᵗ B (suc (suc X)) = ＇ (suc X)
+
+swap-open : ∀ {Δ} (A : Ty (suc (suc Δ))) (B : Ty (suc Δ))
+  → (swapᵗ A) [ B ]ᵗ ≡ substᵗ (substSecondᵗ B) A
+swap-open A B =
+  trans (substᵗ-rename (singleSubᵗ B) swap A)
+        (substᵗ-cong A after-swap)
+  where
+  after-swap : ∀ X → singleSubᵗ B (swap X) ≡ substSecondᵗ B X
+  after-swap zero = refl
+  after-swap (suc zero) = refl
+  after-swap (suc (suc X)) = refl
+
+swap-shift-open-zero : ∀ {Δ} (A : Ty (suc Δ))
+  → (swapᵗ (⇑ᵗ A)) [ ＇ zero ]ᵗ ≡ A
+swap-shift-open-zero A =
+  trans (swap-open (⇑ᵗ A) (＇ zero))
+        (trans (substᵗ-rename (substSecondᵗ (＇ zero)) suc A)
+               (trans (substᵗ-cong A second-after-shift)
+                      (substᵗ-id A)))
+  where
+  second-after-shift : ∀ X
+    → substSecondᵗ (＇ zero) (suc X) ≡ ＇ X
+  second-after-shift zero = refl
+  second-after-shift (suc X) = refl
+
+wk-under-∀ : ∀ {Δ} (X : Fin (suc Δ)) (A : Ty (suc Δ))
+  → renameᵗ (extᵗ (punchIn X)) A ≡ wkᵗ (suc X) A
+wk-under-∀ X A = renameᵗ-cong A under-∀
+  where
+  under-∀ : ∀ Y → extᵗ (punchIn X) Y ≡ punchIn (suc X) Y
+  under-∀ zero = refl
+  under-∀ (suc Y) = refl
+
+wk-zero-∀-swap : ∀ {Δ} (A : Ty (suc Δ))
+  → wkᵗ zero (`∀ A) ≡ `∀ (swapᵗ (⇑ᵗ A))
+wk-zero-∀-swap A = cong `∀ (sym (swap-shift A))
+
+------------------------------------------------------------------------
+-- Exchange lifted to conversions and pivot strictness
+------------------------------------------------------------------------
+
+swap↑ : ∀ {Δ} {A B : Ty (suc (suc Δ))}
+  → Conv↑ (suc (suc Δ)) A B
+  → Conv↑ (suc (suc Δ)) (swapᵗ A) (swapᵗ B)
+swap↑ = rename↑ swap
+
+swap↓ : ∀ {Δ} {A B : Ty (suc (suc Δ))}
+  → Conv↓ (suc (suc Δ)) A B
+  → Conv↓ (suc (suc Δ)) (swapᵗ A) (swapᵗ B)
+swap↓ = rename↓ swap
+
+mutual
+  rename-strict↑ : ∀ {Δ Δ′} (ρ : Δ ⇒ʳ Δ′) {X A B}
+      {c : Conv↑ Δ A B}
+    → PivotStrict↑ X c
+    → PivotStrict↑ (ρ X) (rename↑ ρ c)
+  rename-strict↑ ρ strict-unseal = strict-unseal
+  rename-strict↑ ρ (strict-↑⇒ c-strict d-strict) =
+    strict-↑⇒ (rename-strict↓ ρ c-strict) (rename-strict↑ ρ d-strict)
+  rename-strict↑ ρ (strict-↑∀ c-strict) =
+    strict-↑∀ (rename-strict↑ (extᵗ ρ) c-strict)
+  rename-strict↑ ρ strict-id↑ = strict-id↑
+
+  rename-strict↓ : ∀ {Δ Δ′} (ρ : Δ ⇒ʳ Δ′) {X A B}
+      {c : Conv↓ Δ A B}
+    → PivotStrict↓ X c
+    → PivotStrict↓ (ρ X) (rename↓ ρ c)
+  rename-strict↓ ρ strict-seal = strict-seal
+  rename-strict↓ ρ (strict-↓⇒ c-strict d-strict) =
+    strict-↓⇒ (rename-strict↑ ρ c-strict) (rename-strict↓ ρ d-strict)
+  rename-strict↓ ρ (strict-↓∀ c-strict) =
+    strict-↓∀ (rename-strict↓ (extᵗ ρ) c-strict)
+  rename-strict↓ ρ strict-id↓ = strict-id↓
+
+swap-strict↑ : ∀ {Δ} {X : Fin (suc (suc Δ))} {A B}
+    {c : Conv↑ (suc (suc Δ)) A B}
+  → PivotStrict↑ X c
+  → PivotStrict↑ (swap X) (swap↑ c)
+swap-strict↑ = rename-strict↑ swap
+
+swap-strict↓ : ∀ {Δ} {X : Fin (suc (suc Δ))} {A B}
+    {c : Conv↓ (suc (suc Δ)) A B}
+  → PivotStrict↓ X c
+  → PivotStrict↓ (swap X) (swap↓ c)
+swap-strict↓ = rename-strict↓ swap
+
+------------------------------------------------------------------------
+-- Allocation contexts and structural-delimiter representation evidence
+------------------------------------------------------------------------
+
+weakenBinding : ∀ {n} → Binding n → Binding (suc n)
+weakenBinding ∀-bound = ∀-bound
+weakenBinding (anchored α) = anchored (inject₁ α)
+
+weakenBindings : ∀ {n Δ} → Bindings Δ n → Bindings Δ (suc n)
+weakenBindings κ X = weakenBinding (κ X)
+
+insertBinding-exchange : ∀ {n Δ} (X : Fin (suc Δ))
+    (fresh old : Binding n) (κ : Bindings Δ n)
+    (Y : Fin (suc (suc Δ)))
+  → insertBinding zero fresh (insertBinding X old κ) Y
+    ≡ insertBinding (suc X) old (insertBinding zero fresh κ) Y
+insertBinding-exchange zero fresh old κ zero = refl
+insertBinding-exchange zero fresh old κ (suc zero) = refl
+insertBinding-exchange zero fresh old κ (suc (suc Y)) = refl
+insertBinding-exchange (suc X) fresh old κ zero = refl
+insertBinding-exchange (suc X) fresh old κ (suc Y) = refl
+
+weakenBindings-insert : ∀ {n Δ} (X : Fin (suc Δ))
+    (b : Binding n) (κ : Bindings Δ n) (Y : Fin (suc Δ))
+  → weakenBindings (insertBinding X b κ) Y
+    ≡ insertBinding X (weakenBinding b) (weakenBindings κ) Y
+weakenBindings-insert zero b κ zero = refl
+weakenBindings-insert zero b κ (suc Y) = refl
+weakenBindings-insert {Δ = suc Δ} (suc X) b κ zero = refl
+weakenBindings-insert {Δ = suc Δ} (suc X) b κ (suc Y) =
+  weakenBindings-insert X b (λ Z → κ (suc Z)) Y
+
+wkᶜ-exchange : ∀ {Δ} (X : Fin (suc Δ)) (Γ : TermCtx Δ)
+  → wkᶜ zero (wkᶜ X Γ) ≡ wkᶜ (suc X) (wkᶜ zero Γ)
+wkᶜ-exchange X [] = refl
+wkᶜ-exchange X (A ∷ Γ)
+    rewrite wk-exchange X A | wkᶜ-exchange X Γ =
+  refl
+
+BindingsExtensionality : Set
+BindingsExtensionality = ∀ {n Δ} {κ κ′ : Bindings Δ n}
+  → (∀ X → κ X ≡ κ′ X)
+  → κ ≡ κ′
+
+cross-bindings-exchange : BindingsExtensionality
+  → ∀ {n Δ} (X : Fin (suc Δ))
+    (fresh old : Binding n) (κ : Bindings Δ n)
+  → insertBinding zero fresh (insertBinding X old κ)
+    ≡ insertBinding (suc X) old (insertBinding zero fresh κ)
+cross-bindings-exchange ext X fresh old κ =
+  ext (insertBinding-exchange X fresh old κ)
+
+allocation-bindings-exchange : BindingsExtensionality
+  → ∀ {n Δ} (X : Fin (suc Δ))
+    (b : Binding n) (κ : Bindings Δ n)
+  → weakenBindings (insertBinding X b κ)
+    ≡ insertBinding X (weakenBinding b) (weakenBindings κ)
+allocation-bindings-exchange ext X b κ =
+  ext (weakenBindings-insert X b κ)
+
+allocation-cross-bindings-exchange : BindingsExtensionality
+  → ∀ {n Δ} (X : Fin (suc Δ))
+    (fresh : Binding (suc n)) (old : Binding n) (κ : Bindings Δ n)
+  → insertBinding zero fresh
+      (weakenBindings (insertBinding X old κ))
+    ≡ insertBinding (suc X) (weakenBinding old)
+      (insertBinding zero fresh (weakenBindings κ))
+allocation-cross-bindings-exchange ext X fresh old κ =
+  trans
+    (cong (insertBinding zero fresh)
+      (allocation-bindings-exchange ext X old κ))
+    (cross-bindings-exchange ext X fresh
+      (weakenBinding old) (weakenBindings κ))
+
+allocCtx : (Γ : Ctx) → Ty (sizeᵉ Γ) → Ctx
+allocCtx ⟨ Δ , n , κ , Σ , Γ ⟩ R =
+  ⟨ Δ , suc n , weakenBindings κ , bind Σ R , Γ ⟩
+
+cross-ctx-exchange : BindingsExtensionality
+  → ∀ {Γ} {S : Ty (sizeᵉ Γ)} {X : Fin (suc (Δᵉ Γ))}
+      {α : Name} {R : Ty (sizeᵉ Γ)}
+    (p : α ⦂ R ∈ Σᵉ Γ)
+  → cross-ctx
+      (cross-ctx (allocCtx Γ S) X (weaken-lookup p)) zero fresh-lookup
+    ≡ cross-ctx
+      (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+      (suc X) (weaken-lookup p)
+cross-ctx-exchange ext {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩}
+    {S = S} {X = X} p
+    rewrite
+      cross-bindings-exchange ext X (anchored (fromℕ n))
+        (anchored (inject₁ (lookup-name p))) (weakenBindings κ)
+    | wkᶜ-exchange X Γ =
+  refl
+
+allocation-cross-ctx : BindingsExtensionality
+  → ∀ {Γ} {S : Ty (sizeᵉ Γ)} {X : Fin (suc (Δᵉ Γ))}
+      {α : Name} {R : Ty (sizeᵉ Γ)}
+    (p : α ⦂ R ∈ Σᵉ Γ)
+  → allocCtx (cross-ctx Γ X p) S
+    ≡ cross-ctx (allocCtx Γ S) X (weaken-lookup p)
+allocation-cross-ctx ext {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩}
+    {S = S} {X = X} p
+    rewrite allocation-bindings-exchange ext X
+      (anchored (lookup-name p)) κ =
+  refl
+
+allocation-cross-ctx-exchange : BindingsExtensionality
+  → ∀ {Γ} {S : Ty (sizeᵉ Γ)} {X : Fin (suc (Δᵉ Γ))}
+      {α : Name} {R : Ty (sizeᵉ Γ)}
+    (p : α ⦂ R ∈ Σᵉ Γ)
+  → cross-ctx (allocCtx (cross-ctx Γ X p) S) zero fresh-lookup
+    ≡ cross-ctx
+      (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+      (suc X) (weaken-lookup p)
+allocation-cross-ctx-exchange ext
+    {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩} {S = S} {X = X} p
+    rewrite
+      allocation-cross-bindings-exchange ext X (anchored (fromℕ n))
+        (anchored (lookup-name p)) κ
+    | wkᶜ-exchange X Γ =
+  refl
+
+cross-ctx-exchange-typing : BindingsExtensionality
+  → ∀ {Γ} {S : Ty (sizeᵉ Γ)} {X : Fin (suc (Δᵉ Γ))}
+      {α : Name} {R : Ty (sizeᵉ Γ)}
+      {M : Term (suc (suc (Δᵉ Γ)))}
+      {A : Ty (suc (suc (Δᵉ Γ)))}
+    (p : α ⦂ R ∈ Σᵉ Γ)
+  → cross-ctx
+      (cross-ctx (allocCtx Γ S) X (weaken-lookup p)) zero fresh-lookup
+      ⊢ M ⦂ A
+  → cross-ctx
+      (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+      (suc X) (weaken-lookup p)
+      ⊢ M ⦂ A
+cross-ctx-exchange-typing ext
+    {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩} {S = S} {X = X} p M⊢
+    rewrite
+      cross-bindings-exchange ext X (anchored (fromℕ n))
+        (anchored (inject₁ (lookup-name p))) (weakenBindings κ)
+    | wkᶜ-exchange X Γ =
+  M⊢
+
+allocation-cross-ctx-exchange-typing : BindingsExtensionality
+  → ∀ {Γ} {S : Ty (sizeᵉ Γ)} {X : Fin (suc (Δᵉ Γ))}
+      {α : Name} {R : Ty (sizeᵉ Γ)}
+      {M : Term (suc (suc (Δᵉ Γ)))}
+      {A : Ty (suc (suc (Δᵉ Γ)))}
+    (p : α ⦂ R ∈ Σᵉ Γ)
+  → cross-ctx
+      (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+      (suc X) (weaken-lookup p)
+      ⊢ M ⦂ A
+  → cross-ctx (allocCtx (cross-ctx Γ X p) S) zero fresh-lookup
+      ⊢ M ⦂ A
+allocation-cross-ctx-exchange-typing ext
+    {Γ = ⟨ Δ , n , κ , Σ , Γ ⟩} {S = S} {X = X} p M⊢
+    rewrite
+      allocation-cross-bindings-exchange ext X (anchored (fromℕ n))
+        (anchored (lookup-name p)) κ
+    | wkᶜ-exchange X Γ =
+  M⊢
+
+mutual
+  delimiter-reps↑ : ∀ {Δ n} (ρ : VarRel Δ n) (S : Ty n)
+      (A : Ty Δ)
+    → Reps↑ ρ S (delimiter↑ A)
+  delimiter-reps↑ ρ S (＇ X) = reps-id↑
+  delimiter-reps↑ ρ S (‵ ι) = reps-id↑
+  delimiter-reps↑ ρ S ★ = reps-id↑
+  delimiter-reps↑ ρ S (A ⇒ B) =
+    reps-↑⇒ (delimiter-reps↓ ρ S A) (delimiter-reps↑ ρ S B)
+  delimiter-reps↑ ρ S (`∀ A) =
+    reps-↑∀ (delimiter-reps↑ (LiftRel ρ) (⇑ᵗ S) A)
+
+  delimiter-reps↓ : ∀ {Δ n} (ρ : VarRel Δ n) (S : Ty n)
+      (A : Ty Δ)
+    → Reps↓ ρ S (delimiter↓ A)
+  delimiter-reps↓ ρ S (＇ X) = reps-id↓
+  delimiter-reps↓ ρ S (‵ ι) = reps-id↓
+  delimiter-reps↓ ρ S ★ = reps-id↓
+  delimiter-reps↓ ρ S (A ⇒ B) =
+    reps-↓⇒ (delimiter-reps↑ ρ S A) (delimiter-reps↓ ρ S B)
+  delimiter-reps↓ ρ S (`∀ A) =
+    reps-↓∀ (delimiter-reps↓ (LiftRel ρ) (⇑ᵗ S) A)
+
+∀-entry-application : ∀ {Δ} → Name → Term Δ → Ty (suc Δ)
+  → Term (suc Δ)
+∀-entry-application α V A =
+  (V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A)))
+    ⦂∀ swapᵗ (⇑ᵗ A) [ ＇ zero ]
+
+∀-entry-application-typed : ∀ {Γ} {V : Term (Δᵉ Γ)}
+    {A : Ty (suc (Δᵉ Γ))} {α : Name} {R : Ty (sizeᵉ Γ)}
+  → (p : α ⦂ R ∈ Σᵉ Γ)
+  → Γ ⊢ V ⦂ `∀ A
+  → cross-ctx Γ zero p ⊢ ∀-entry-application α V A ⦂ A
+∀-entry-application-typed {Γ} {V = V} {A = A} {α = α} {R = R} p V⊢ =
+  subst
+    (λ T → cross-ctx Γ zero p ⊢ ∀-entry-application α V A ⦂ T)
+    (swap-shift-open-zero A) (⊢• exchanged⊢)
+  where
+  entered⊢ : cross-ctx Γ zero p ⊢
+      V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A))
+      ⦂ wkᵗ zero (`∀ A)
+  entered⊢ =
+    ⊢conceal p (delimiter-strict↓ zero (wkᵗ zero (`∀ A)))
+      (delimiter-reps↓
+        (BindingRel (κᵉ (cross-ctx Γ zero p))) R
+        (wkᵗ zero (`∀ A))) V⊢
+
+  exchanged⊢ : cross-ctx Γ zero p ⊢
+      V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A))
+      ⦂ `∀ (swapᵗ (⇑ᵗ A))
+  exchanged⊢ =
+    subst
+      (λ T → cross-ctx Γ zero p ⊢
+        V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A)) ⦂ T)
+      (wk-zero-∀-swap A) entered⊢
+
+------------------------------------------------------------------------
+-- β-inst: redex, exchanged contractum, and typing validation
+------------------------------------------------------------------------
+
+β-inst-redex : ∀ {Δ} {μ : Env∼ Δ} {A : Ty (suc Δ)} {B : Ty Δ}
+    ⦃ Anv : NonVar A ⦄ ⦃ z∈A : zero ∈ᵗ A ⦄
+  → Term Δ
+  → instᵐ μ ⊢ A ∼ ⇑ᵗ B
+  → B ≢ ★
+  → Term Δ
+β-inst-redex V c B≢★ = V ⟨ (inst c) B≢★ ⟩
+
+β-inst-result : ∀ {Δ} {μ : Env∼ Δ} {A : Ty (suc Δ)} {B : Ty Δ}
+  → Name
+  → Term Δ
+  → (c : instᵐ μ ⊢ A ∼ ⇑ᵗ B)
+  → Conv↑ (suc Δ) A (wkᵗ zero (A [ ★ ]ᵗ))
+  → Term Δ
+β-inst-result {A = A} α V c d =
+  ((∀-entry-application α V A) ↑⟨ zero ≔ α ⟩ d)
+  ⟨ c [ ★/0 ]ᶜ ⟩
+
+β-inst-redex-typed : ∀ {Γ} {μ : Env∼ (Δᵉ Γ)}
+    {A : Ty (suc (Δᵉ Γ))} {B : Ty (Δᵉ Γ)} {V : Term (Δᵉ Γ)}
+    {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
+    ⦃ Anv : NonVar A ⦄ ⦃ z∈A : zero ∈ᵗ A ⦄
+  → Γ ⊢ V ⦂ `∀ A
+  → (B≢★ : B ≢ ★)
+  → Γ ⊢ β-inst-redex V c B≢★ ⦂ B
+β-inst-redex-typed {c = c} V⊢ B≢★ = ⊢⟨⟩ V⊢ ((inst c) B≢★)
+
+β-inst-result-typed : ∀ {Γ} {μ : Env∼ (Δᵉ Γ)}
+    {A : Ty (suc (Δᵉ Γ))} {B : Ty (Δᵉ Γ)} {V : Term (Δᵉ Γ)}
+    {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
+    {d : Conv↑ (suc (Δᵉ Γ)) A (wkᵗ zero (A [ ★ ]ᵗ))}
+  → allocCtx Γ ★ ⊢ V ⦂ `∀ A
+  → PivotStrict↑ zero d
+  → Reps↑
+      (BindingRel
+        (κᵉ (cross-ctx (allocCtx Γ ★) zero fresh-lookup)))
+      (⇑ᵗ ★) d
+  → allocCtx Γ ★ ⊢ β-inst-result (sizeᵉ Γ) V c d ⦂ B
+β-inst-result-typed {Γ} {A = A} {V = V} {c = c} {d = d}
+    V⊢ d-strict d-reps =
+  ⊢⟨⟩ revealed⊢ (c [ ★/0 ]ᶜ)
+  where
+  Γ⁺ = allocCtx Γ ★
+  p = fresh-lookup {Σ = Σᵉ Γ} {R = ★}
+
+  applied⊢ : cross-ctx Γ⁺ zero p ⊢
+      ∀-entry-application (sizeᵉ Γ) V A ⦂ A
+  applied⊢ = ∀-entry-application-typed p V⊢
+
+  revealed⊢ : Γ⁺ ⊢
+      (∀-entry-application (sizeᵉ Γ) V A)
+        ↑⟨ zero ≔ sizeᵉ Γ ⟩ d
+      ⦂ A [ ★ ]ᵗ
+  revealed⊢ = ⊢reveal p d-strict d-reps applied⊢
+
+------------------------------------------------------------------------
+-- Endpoint transport for opening a structural `∀` crossing
+------------------------------------------------------------------------
+
+cast↑-target : ∀ {Δ} {A B B′ : Ty Δ}
+  → B ≡ B′
+  → Conv↑ Δ A B
+  → Conv↑ Δ A B′
+cast↑-target refl c = c
+
+cast↓-source : ∀ {Δ} {A A′ B : Ty Δ}
+  → A ≡ A′
+  → Conv↓ Δ A B
+  → Conv↓ Δ A′ B
+cast↓-source refl c = c
+
+cast↑-target-strict : ∀ {Δ} {A B B′ : Ty Δ} {X}
+    (eq : B ≡ B′) {c : Conv↑ Δ A B}
+  → PivotStrict↑ X c
+  → PivotStrict↑ X (cast↑-target eq c)
+cast↑-target-strict refl c-strict = c-strict
+
+cast↓-source-strict : ∀ {Δ} {A A′ B : Ty Δ} {X}
+    (eq : A ≡ A′) {c : Conv↓ Δ A B}
+  → PivotStrict↓ X c
+  → PivotStrict↓ X (cast↓-source eq c)
+cast↓-source-strict refl c-strict = c-strict
+
+cast↑-target-reps : ∀ {Δ n} {ρ : VarRel Δ n} {S : Ty n}
+    {A B B′ : Ty Δ} (eq : B ≡ B′) {c : Conv↑ Δ A B}
+  → Reps↑ ρ S c
+  → Reps↑ ρ S (cast↑-target eq c)
+cast↑-target-reps refl c-reps = c-reps
+
+cast↓-source-reps : ∀ {Δ n} {ρ : VarRel Δ n} {S : Ty n}
+    {A A′ B : Ty Δ} (eq : A ≡ A′) {c : Conv↓ Δ A B}
+  → Reps↓ ρ S c
+  → Reps↓ ρ S (cast↓-source eq c)
+cast↓-source-reps refl c-reps = c-reps
+
+open-∀↑ : ∀ {Δ} {X : Fin (suc Δ)} {B : Ty (suc Δ)} {C}
+  → Conv↑ (suc (suc Δ)) C (renameᵗ (extᵗ (punchIn X)) B)
+  → Conv↑ (suc (suc Δ)) C (wkᵗ (suc X) B)
+open-∀↑ {X = X} {B} = cast↑-target (wk-under-∀ X B)
+
+open-∀↓ : ∀ {Δ} {X : Fin (suc Δ)} {B : Ty (suc Δ)} {C}
+  → Conv↓ (suc (suc Δ)) (renameᵗ (extᵗ (punchIn X)) B) C
+  → Conv↓ (suc (suc Δ)) (wkᵗ (suc X) B) C
+open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
+
+------------------------------------------------------------------------
+-- β-reveal-∀: redex, exchanged contractum, and typing validation
+------------------------------------------------------------------------
+
+β-reveal-∀-redex : ∀ {Δ} {B : Ty (suc Δ)} {C}
+  → Name
+  → Term (suc Δ)
+  → (X : Fin (suc Δ))
+  → Conv↑ (suc (suc Δ)) C (renameᵗ (extᵗ (punchIn X)) B)
+  → Ty Δ
+  → Term Δ
+β-reveal-∀-redex {B = B} α V X c A =
+  (V ↑⟨ X ≔ α ⟩ `∀↑ c) ⦂∀ B [ A ]
+
+β-reveal-∀-result : ∀ {Δ} {A : Ty Δ} {B : Ty (suc Δ)} {C}
+  → Name
+  → Name
+  → (X : Fin (suc Δ))
+  → Term (suc Δ)
+  → (c : Conv↑ (suc (suc Δ)) C
+          (renameᵗ (extᵗ (punchIn X)) B))
+  → Conv↑ (suc Δ) B (wkᵗ zero (B [ A ]ᵗ))
+  → Term Δ
+β-reveal-∀-result {C = C} fresh α X V c d =
+  (((∀-entry-application fresh V C)
+      ↑⟨ suc X ≔ α ⟩ open-∀↑ c)
+  ↑⟨ zero ≔ fresh ⟩ d)
+
+β-reveal-∀-redex-typed : ∀ {Γ} {A : Ty (Δᵉ Γ)}
+    {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
+    {V : Term (suc (Δᵉ Γ))} {X : Fin (suc (Δᵉ Γ))}
+    {α : Name} {R : Ty (sizeᵉ Γ)}
+    {c : Conv↑ (suc (suc (Δᵉ Γ))) C
+           (renameᵗ (extᵗ (punchIn X)) B)}
+  → (p : α ⦂ R ∈ Σᵉ Γ)
+  → PivotStrict↑ (suc X) c
+  → Reps↑ (LiftRel (BindingRel (κᵉ (cross-ctx Γ X p))))
+      (⇑ᵗ R) c
+  → cross-ctx Γ X p ⊢ V ⦂ `∀ C
+  → Γ ⊢ β-reveal-∀-redex α V X c A ⦂ B [ A ]ᵗ
+β-reveal-∀-redex-typed {B = B} {X = X} p c-strict c-reps V⊢ =
+  ⊢• (⊢reveal p (strict-↑∀ c-strict) (reps-↑∀ c-reps) V⊢)
+
+β-reveal-∀-result-typed : ∀ {Γ} {A : Ty (Δᵉ Γ)}
+    {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
+    {V : Term (suc (Δᵉ Γ))} {X : Fin (suc (Δᵉ Γ))}
+    {α : Name} {R S : Ty (sizeᵉ Γ)}
+    {c : Conv↑ (suc (suc (Δᵉ Γ))) C
+           (renameᵗ (extᵗ (punchIn X)) B)}
+    {d : Conv↑ (suc (Δᵉ Γ)) B (wkᵗ zero (B [ A ]ᵗ))}
+  → (p : α ⦂ R ∈ Σᵉ Γ)
+  → BindingsExtensionality
+  → cross-ctx (allocCtx Γ S) X (weaken-lookup p) ⊢ V ⦂ `∀ C
+  → Reps↑
+      (BindingRel
+        (κᵉ
+          (cross-ctx (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+            (suc X) (weaken-lookup p))))
+      (⇑ᵗ R) c
+  → PivotStrict↑ (suc X) c
+  → Reps↑
+      (BindingRel
+        (κᵉ (cross-ctx (allocCtx Γ S) zero fresh-lookup)))
+      (⇑ᵗ S) d
+  → PivotStrict↑ zero d
+  → allocCtx Γ S ⊢
+      β-reveal-∀-result (sizeᵉ Γ) α X V c d ⦂ B [ A ]ᵗ
+β-reveal-∀-result-typed {Γ} {B = B} {C = C} {V = V} {X = X}
+    {α = α} {S = S} {c = c} {d = d}
+    p ext V⊢ c-reps c-strict d-reps d-strict =
+  ⊢reveal fresh d-strict d-reps old-revealed⊢
+  where
+  Γ⁺ = allocCtx Γ S
+  fresh = fresh-lookup {Σ = Σᵉ Γ} {R = S}
+  freshΓ = cross-ctx Γ⁺ zero fresh
+  old = weaken-lookup p
+  oldΓ = cross-ctx Γ⁺ X old
+
+  inner-left⊢ : cross-ctx oldΓ zero fresh ⊢
+      ∀-entry-application (sizeᵉ Γ) V C ⦂ C
+  inner-left⊢ = ∀-entry-application-typed fresh V⊢
+
+  inner-right⊢ : cross-ctx freshΓ (suc X) old ⊢
+      ∀-entry-application (sizeᵉ Γ) V C ⦂ C
+  inner-right⊢ = cross-ctx-exchange-typing ext p inner-left⊢
+
+  old-revealed⊢ : freshΓ ⊢
+      (∀-entry-application (sizeᵉ Γ) V C)
+        ↑⟨ suc X ≔ α ⟩ open-∀↑ c
+      ⦂ B
+  old-revealed⊢ =
+    ⊢reveal old
+      (cast↑-target-strict (wk-under-∀ X B) c-strict)
+      (cast↑-target-reps (wk-under-∀ X B) c-reps)
+      inner-right⊢
+
+------------------------------------------------------------------------
+-- β-conceal-∀: redex, exchanged contractum, and typing validation
+------------------------------------------------------------------------
+
+β-conceal-∀-redex : ∀ {Δ} {B : Ty (suc (suc Δ))}
+    {C : Ty (suc Δ)}
+  → Name
+  → Term Δ
+  → (X : Fin (suc Δ))
+  → Conv↓ (suc (suc Δ)) (renameᵗ (extᵗ (punchIn X)) C) B
+  → Ty (suc Δ)
+  → Term (suc Δ)
+β-conceal-∀-redex {B = B} α V X c A =
+  (V ↓⟨ X ≔ α ⟩ `∀↓ c) ⦂∀ B [ A ]
+
+β-conceal-∀-result : ∀ {Δ} {A : Ty (suc Δ)}
+    {B : Ty (suc (suc Δ))} {C : Ty (suc Δ)}
+  → Name
+  → Name
+  → (X : Fin (suc Δ))
+  → Term Δ
+  → (c : Conv↓ (suc (suc Δ))
+          (renameᵗ (extᵗ (punchIn X)) C) B)
+  → Conv↑ (suc (suc Δ)) B (wkᵗ zero (B [ A ]ᵗ))
+  → Term (suc Δ)
+β-conceal-∀-result {C = C} fresh α X V c d =
+  (((∀-entry-application fresh V C)
+    ↓⟨ suc X ≔ α ⟩ open-∀↓ c)
+  ↑⟨ zero ≔ fresh ⟩ d)
+
+β-conceal-∀-redex-typed : ∀ {Γ}
+    {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
+    {C : Ty (suc (Δᵉ Γ))} {V : Term (Δᵉ Γ)}
+    {X : Fin (suc (Δᵉ Γ))} {α : Name} {R : Ty (sizeᵉ Γ)}
+    {c : Conv↓ (suc (suc (Δᵉ Γ)))
+           (renameᵗ (extᵗ (punchIn X)) C) B}
+  → (p : α ⦂ R ∈ Σᵉ Γ)
+  → PivotStrict↓ (suc X) c
+  → Reps↓ (LiftRel (BindingRel (κᵉ (cross-ctx Γ X p))))
+      (⇑ᵗ R) c
+  → Γ ⊢ V ⦂ `∀ C
+  → cross-ctx Γ X p ⊢
+      β-conceal-∀-redex α V X c A ⦂ B [ A ]ᵗ
+β-conceal-∀-redex-typed p c-strict c-reps V⊢ =
+  ⊢• (⊢conceal p (strict-↓∀ c-strict) (reps-↓∀ c-reps) V⊢)
+
+β-conceal-∀-result-typed : ∀ {Γ}
+    {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
+    {C : Ty (suc (Δᵉ Γ))} {V : Term (Δᵉ Γ)}
+    {X : Fin (suc (Δᵉ Γ))} {α : Name} {R S : Ty (sizeᵉ Γ)}
+    {c : Conv↓ (suc (suc (Δᵉ Γ)))
+           (renameᵗ (extᵗ (punchIn X)) C) B}
+    {d : Conv↑ (suc (suc (Δᵉ Γ))) B
+           (wkᵗ zero (B [ A ]ᵗ))}
+  → (p : α ⦂ R ∈ Σᵉ Γ)
+  → BindingsExtensionality
+  → allocCtx Γ S ⊢ V ⦂ `∀ C
+  → Reps↓
+      (BindingRel
+        (κᵉ
+          (cross-ctx (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+            (suc X) (weaken-lookup p))))
+      (⇑ᵗ R) c
+  → PivotStrict↓ (suc X) c
+  → Reps↑
+      (BindingRel
+        (κᵉ
+          (cross-ctx (allocCtx (cross-ctx Γ X p) S) zero fresh-lookup)))
+      (⇑ᵗ S) d
+  → PivotStrict↑ zero d
+  → allocCtx (cross-ctx Γ X p) S ⊢
+      β-conceal-∀-result (sizeᵉ Γ) α X V c d ⦂ B [ A ]ᵗ
+β-conceal-∀-result-typed {Γ} {B = B} {C = C} {V = V} {X = X}
+    {α = α} {S = S} {c = c} {d = d}
+    p ext V⊢ c-reps c-strict d-reps d-strict =
+  ⊢reveal fresh-final d-strict d-reps concealed-left⊢
+  where
+  Γ⁺ = allocCtx Γ S
+  fresh = fresh-lookup {Σ = Σᵉ Γ} {R = S}
+  freshΓ = cross-ctx Γ⁺ zero fresh
+  old = weaken-lookup p
+  oldΓ = cross-ctx Γ X p
+  oldΓ⁺ = allocCtx oldΓ S
+  fresh-final = fresh-lookup {Σ = Σᵉ oldΓ} {R = S}
+
+  applied⊢ : freshΓ ⊢
+      ∀-entry-application (sizeᵉ Γ) V C ⦂ C
+  applied⊢ = ∀-entry-application-typed fresh V⊢
+
+  concealed-right⊢ : cross-ctx freshΓ (suc X) old ⊢
+      (∀-entry-application (sizeᵉ Γ) V C)
+        ↓⟨ suc X ≔ α ⟩ open-∀↓ c
+      ⦂ B
+  concealed-right⊢ =
+    ⊢conceal old
+      (cast↓-source-strict (wk-under-∀ X C) c-strict)
+      (cast↓-source-reps (wk-under-∀ X C) c-reps)
+      applied⊢
+
+  concealed-left⊢ : cross-ctx oldΓ⁺ zero fresh-final ⊢
+      (∀-entry-application (sizeᵉ Γ) V C)
+        ↓⟨ suc X ≔ α ⟩ open-∀↓ c
+      ⦂ B
+  concealed-left⊢ =
+    allocation-cross-ctx-exchange-typing ext p concealed-right⊢

--- a/GTSFImp/alt/Exchange.agda
+++ b/GTSFImp/alt/Exchange.agda
@@ -369,7 +369,7 @@ allocation-cross-ctx-exchange-typing ext
 mutual
   delimiter-reps↑ : ∀ {Δ n} (ρ : VarRel Δ n) (S : Ty n)
       (A : Ty Δ)
-    → Reps↑ ρ S (delimiter↑ A)
+    → Reps↑ ρ S (δ↑ A)
   delimiter-reps↑ ρ S (＇ X) = reps-id↑
   delimiter-reps↑ ρ S (‵ ι) = reps-id↑
   delimiter-reps↑ ρ S ★ = reps-id↑
@@ -380,7 +380,7 @@ mutual
 
   delimiter-reps↓ : ∀ {Δ n} (ρ : VarRel Δ n) (S : Ty n)
       (A : Ty Δ)
-    → Reps↓ ρ S (delimiter↓ A)
+    → Reps↓ ρ S (δ↓ A)
   delimiter-reps↓ ρ S (＇ X) = reps-id↓
   delimiter-reps↓ ρ S (‵ ι) = reps-id↓
   delimiter-reps↓ ρ S ★ = reps-id↓
@@ -392,7 +392,7 @@ mutual
 ∀-entry-application : ∀ {Δ} → Name → Term Δ → Ty (suc Δ)
   → Term (suc Δ)
 ∀-entry-application α V A =
-  (V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A)))
+  (V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A)))
     ⦂∀ swapᵗ (⇑ᵗ A) [ ＇ zero ]
 
 ∀-entry-application-typed : ∀ {Γ} {V : Term (Δᵉ Γ)}
@@ -406,21 +406,21 @@ mutual
     (swap-shift-open-zero A) (⊢• exchanged⊢)
   where
   entered⊢ : cross-ctx Γ zero p ⊢
-      V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A))
+      V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A))
       ⦂ wkᵗ zero (`∀ A)
   entered⊢ =
-    ⊢conceal p (delimiter-strict↓ zero (wkᵗ zero (`∀ A)))
+    ⊢conceal p (δ-strict↓ zero (wkᵗ zero (`∀ A)))
       (delimiter-reps↓
         (BindingRel (κᵉ (cross-ctx Γ zero p))) R
         (wkᵗ zero (`∀ A))) V⊢
 
   exchanged⊢ : cross-ctx Γ zero p ⊢
-      V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A))
+      V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A))
       ⦂ `∀ (swapᵗ (⇑ᵗ A))
   exchanged⊢ =
     subst
       (λ T → cross-ctx Γ zero p ⊢
-        V ↓⟨ zero ≔ α ⟩ delimiter↓ (wkᵗ zero (`∀ A)) ⦂ T)
+        V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A)) ⦂ T)
       (wk-zero-∀-swap A) entered⊢
 
 ------------------------------------------------------------------------

--- a/GTSFImp/alt/Exchange.agda
+++ b/GTSFImp/alt/Exchange.agda
@@ -380,7 +380,7 @@ mutual
 ∀-entry-application : ∀ {Δ} → Name → Term Δ → Ty (suc Δ)
   → Term (suc Δ)
 ∀-entry-application α V A =
-  (V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A)))
+  (V ↓[ zero ≔ α ] δ↓ (wkᵗ zero (`∀ A)))
     ⦂∀ swapᵗ (⇑ᵗ A) [ ＇ zero ]
 
 ∀-entry-application-typed : ∀ {Γ} {V : Term (Δᵉ Γ)}
@@ -394,7 +394,7 @@ mutual
     (swap-shift-open-zero A) (⊢• exchanged⊢)
   where
   entered⊢ : cross-ctx Γ zero p ⊢
-      V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A))
+      V ↓[ zero ≔ α ] δ↓ (wkᵗ zero (`∀ A))
       ⦂ wkᵗ zero (`∀ A)
   entered⊢ =
     ⊢conceal {Γ = Γ} {Γ′ = []} p
@@ -404,12 +404,12 @@ mutual
         (wkᵗ zero (`∀ A))) V⊢
 
   exchanged⊢ : cross-ctx Γ zero p ⊢
-      V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A))
+      V ↓[ zero ≔ α ] δ↓ (wkᵗ zero (`∀ A))
       ⦂ `∀ (swapᵗ (⇑ᵗ A))
   exchanged⊢ =
     subst
       (λ T → cross-ctx Γ zero p ⊢
-        V ↓⟨ zero ≔ α ⟩ δ↓ (wkᵗ zero (`∀ A)) ⦂ T)
+        V ↓[ zero ≔ α ] δ↓ (wkᵗ zero (`∀ A)) ⦂ T)
       (wk-zero-∀-swap A) entered⊢
 
 ------------------------------------------------------------------------
@@ -431,7 +431,7 @@ mutual
   → Conv↑ (suc Δ) A (wkᵗ zero (A [ ★ ]ᵗ))
   → Term Δ
 β-inst-result {A = A} α V c d =
-  ((∀-entry-application α V A) ↑⟨ zero ≔ α ⟩ d)
+  ((∀-entry-application α V A) ↑[ zero ≔ α ] d)
   ⟨ c [ ★/0 ]ᶜ ⟩
 
 β-inst-redex-typed : ∀ {Γ} {μ : Env∼ (Δᵉ Γ)}
@@ -468,7 +468,7 @@ mutual
 
   revealed⊢ : Γ⁺ ⊢
       (∀-entry-application (sizeᵉ Γ) V A)
-        ↑⟨ zero ≔ sizeᵉ Γ ⟩ d
+        ↑[ zero ≔ sizeᵉ Γ ] d
       ⦂ A [ ★ ]ᵗ
   revealed⊢ = ⊢reveal p d-strict d-reps applied⊢
 
@@ -534,7 +534,7 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → Ty Δ
   → Term Δ
 β-reveal-∀-redex {B = B} α V X c A =
-  (V ↑⟨ X ≔ α ⟩ `∀↑ c) ⦂∀ B [ A ]
+  (V ↑[ X ≔ α ] `∀↑ c) ⦂∀ B [ A ]
 
 β-reveal-∀-result : ∀ {Δ} {A : Ty Δ} {B : Ty (suc Δ)} {C}
   → Name
@@ -547,8 +547,8 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → Term Δ
 β-reveal-∀-result {C = C} fresh α X V c d =
   (((∀-entry-application fresh V C)
-      ↑⟨ suc X ≔ α ⟩ open-∀↑ c)
-  ↑⟨ zero ≔ fresh ⟩ d)
+      ↑[ suc X ≔ α ] open-∀↑ c)
+  ↑[ zero ≔ fresh ] d)
 
 β-reveal-∀-redex-typed : ∀ {Γ} {A : Ty (Δᵉ Γ)}
     {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
@@ -611,7 +611,7 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   old-revealed⊢ : freshΓ ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
-        ↑⟨ suc X ≔ α ⟩ open-∀↑ c
+        ↑[ suc X ≔ α ] open-∀↑ c
       ⦂ B
   old-revealed⊢ =
     ⊢reveal old
@@ -632,7 +632,7 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → Ty (suc Δ)
   → Term (suc Δ)
 β-conceal-∀-redex {B = B} α V X c A =
-  (V ↓⟨ X ≔ α ⟩ `∀↓ c) ⦂∀ B [ A ]
+  (V ↓[ X ≔ α ] `∀↓ c) ⦂∀ B [ A ]
 
 β-conceal-∀-result : ∀ {Δ} {A : Ty (suc Δ)}
     {B : Ty (suc (suc Δ))} {C : Ty (suc Δ)}
@@ -646,8 +646,8 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → Term (suc Δ)
 β-conceal-∀-result {C = C} fresh α X V c d =
   (((∀-entry-application fresh V C)
-    ↓⟨ suc X ≔ α ⟩ open-∀↓ c)
-  ↑⟨ zero ≔ fresh ⟩ d)
+    ↓[ suc X ≔ α ] open-∀↓ c)
+  ↑[ zero ≔ fresh ] d)
 
 β-conceal-∀-redex-typed : ∀ {Γ}
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
@@ -712,7 +712,7 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   concealed-right⊢ : cross-ctx freshΓ (suc X) old ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
-        ↓⟨ suc X ≔ α ⟩ open-∀↓ c
+        ↓[ suc X ≔ α ] open-∀↓ c
       ⦂ B
   concealed-right⊢ =
     ⊢conceal {Γ = freshΓ} {Γ′ = []} old
@@ -722,7 +722,7 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   concealed-left⊢ : cross-ctx oldΓ⁺ zero fresh-final ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
-        ↓⟨ suc X ≔ α ⟩ open-∀↓ c
+        ↓[ suc X ≔ α ] open-∀↓ c
       ⦂ B
   concealed-left⊢ =
     allocation-cross-ctx-exchange-typing ext {Γ = Γ} p concealed-right⊢

--- a/GTSFImp/alt/Exchange.agda
+++ b/GTSFImp/alt/Exchange.agda
@@ -1,19 +1,16 @@
 module alt.Exchange where
 
 -- File Charter:
---   * Defines the exchange of the two newest scoped-type slots and lifts it
---     to reveal and conceal conversions, including pivot strictness.
+--   * Defines the exchange of the two newest scoped-type slots.
 --   * States the omitted β-inst, β-reveal-∀, and β-conceal-∀ redexes and
---     shift-free contracta, then validates the contracta against explicit
---     typing components.
+--     raw-shape contracta, then validates both sides against explicit
+--     node-level transport and conversion-typing components.
 --   * The exchange is deliberately the top-two transposition, rather than a
 --     general adjacent transposition: all three rules allocate their fresh
 --     crossing at slot zero, immediately below a source `∀` binder.  Nested
 --     pre-existing crossings move from X to suc X by ordinary `punchIn`.
---   * Compared with the Design.md sketch, endpoint-correct entry and exit
---     conversions are explicit parameters when propositional endpoint
---     equality is not definitional, following the checked β-Λ/β-gen rules.
---     For β-reveal-∀ and β-conceal-∀ the validation takes the restricted
+--   * Raw conversion shapes are unchanged by exchange.  For β-reveal-∀ and
+--     β-conceal-∀ the validation takes the restricted
 --     `BindingsExtensionality` principle explicitly.  Inserting the fresh
 --     crossing before an existing crossing and inserting the existing
 --     crossing after the fresh one give pointwise equal `Bindings`; this
@@ -32,6 +29,7 @@ open import Consistency
 open import alt.Store
 open import alt.Conversion
 open import alt.Terms
+open import alt.GeneratorEndpoint
 
 ------------------------------------------------------------------------
 -- Exchange of the two newest scoped slots
@@ -153,56 +151,7 @@ wk-zero-∀-swap : ∀ {Δ} (A : Ty (suc Δ))
 wk-zero-∀-swap A = cong `∀ (sym (swap-shift A))
 
 ------------------------------------------------------------------------
--- Exchange lifted to conversions and pivot strictness
-------------------------------------------------------------------------
-
-swap↑ : ∀ {Δ} {A B : Ty (suc (suc Δ))}
-  → Conv↑ (suc (suc Δ)) A B
-  → Conv↑ (suc (suc Δ)) (swapᵗ A) (swapᵗ B)
-swap↑ = rename↑ swap
-
-swap↓ : ∀ {Δ} {A B : Ty (suc (suc Δ))}
-  → Conv↓ (suc (suc Δ)) A B
-  → Conv↓ (suc (suc Δ)) (swapᵗ A) (swapᵗ B)
-swap↓ = rename↓ swap
-
-mutual
-  rename-strict↑ : ∀ {Δ Δ′} (ρ : Δ ⇒ʳ Δ′) {X A B}
-      {c : Conv↑ Δ A B}
-    → PivotStrict↑ X c
-    → PivotStrict↑ (ρ X) (rename↑ ρ c)
-  rename-strict↑ ρ strict-unseal = strict-unseal
-  rename-strict↑ ρ (strict-↑⇒ c-strict d-strict) =
-    strict-↑⇒ (rename-strict↓ ρ c-strict) (rename-strict↑ ρ d-strict)
-  rename-strict↑ ρ (strict-↑∀ c-strict) =
-    strict-↑∀ (rename-strict↑ (extᵗ ρ) c-strict)
-  rename-strict↑ ρ strict-id↑ = strict-id↑
-
-  rename-strict↓ : ∀ {Δ Δ′} (ρ : Δ ⇒ʳ Δ′) {X A B}
-      {c : Conv↓ Δ A B}
-    → PivotStrict↓ X c
-    → PivotStrict↓ (ρ X) (rename↓ ρ c)
-  rename-strict↓ ρ strict-seal = strict-seal
-  rename-strict↓ ρ (strict-↓⇒ c-strict d-strict) =
-    strict-↓⇒ (rename-strict↑ ρ c-strict) (rename-strict↓ ρ d-strict)
-  rename-strict↓ ρ (strict-↓∀ c-strict) =
-    strict-↓∀ (rename-strict↓ (extᵗ ρ) c-strict)
-  rename-strict↓ ρ strict-id↓ = strict-id↓
-
-swap-strict↑ : ∀ {Δ} {X : Fin (suc (suc Δ))} {A B}
-    {c : Conv↑ (suc (suc Δ)) A B}
-  → PivotStrict↑ X c
-  → PivotStrict↑ (swap X) (swap↑ c)
-swap-strict↑ = rename-strict↑ swap
-
-swap-strict↓ : ∀ {Δ} {X : Fin (suc (suc Δ))} {A B}
-    {c : Conv↓ (suc (suc Δ)) A B}
-  → PivotStrict↓ X c
-  → PivotStrict↓ (swap X) (swap↓ c)
-swap-strict↓ = rename-strict↓ swap
-
-------------------------------------------------------------------------
--- Allocation contexts and structural-delimiter representation evidence
+-- Allocation contexts and classifier exchange
 ------------------------------------------------------------------------
 
 weakenBinding : ∀ {n} → Binding n → Binding (suc n)
@@ -354,29 +303,6 @@ allocation-cross-ctx-exchange-typing ext
         (anchored (lookup-name p)) κ =
   M⊢
 
-mutual
-  delimiter-reps↑ : ∀ {Δ n} (ρ : VarRel Δ n) (S : Ty n)
-      (A : Ty Δ)
-    → Reps↑ ρ S (δ↑ A)
-  delimiter-reps↑ ρ S (＇ X) = reps-id↑
-  delimiter-reps↑ ρ S (‵ ι) = reps-id↑
-  delimiter-reps↑ ρ S ★ = reps-id↑
-  delimiter-reps↑ ρ S (A ⇒ B) =
-    reps-↑⇒ (delimiter-reps↓ ρ S A) (delimiter-reps↑ ρ S B)
-  delimiter-reps↑ ρ S (`∀ A) =
-    reps-↑∀ (delimiter-reps↑ (LiftRel ρ) (⇑ᵗ S) A)
-
-  delimiter-reps↓ : ∀ {Δ n} (ρ : VarRel Δ n) (S : Ty n)
-      (A : Ty Δ)
-    → Reps↓ ρ S (δ↓ A)
-  delimiter-reps↓ ρ S (＇ X) = reps-id↓
-  delimiter-reps↓ ρ S (‵ ι) = reps-id↓
-  delimiter-reps↓ ρ S ★ = reps-id↓
-  delimiter-reps↓ ρ S (A ⇒ B) =
-    reps-↓⇒ (delimiter-reps↑ ρ S A) (delimiter-reps↓ ρ S B)
-  delimiter-reps↓ ρ S (`∀ A) =
-    reps-↓∀ (delimiter-reps↓ (LiftRel ρ) (⇑ᵗ S) A)
-
 ∀-entry-application : ∀ {Δ} → Name → Term Δ → Ty (suc Δ)
   → Term (suc Δ)
 ∀-entry-application α V A =
@@ -385,10 +311,13 @@ mutual
 
 ∀-entry-application-typed : ∀ {Γ} {V : Term (Δᵉ Γ)}
     {A : Ty (suc (Δᵉ Γ))} {α : Name} {R : Ty (sizeᵉ Γ)}
+    {R′ : Ty (suc (Δᵉ Γ))}
   → (p : α ⦂ R ∈ Σᵉ Γ)
+  → Transport (BindingRel (κᵉ (cross-ctx Γ zero p))) R′ R
   → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ V ⦂ `∀ A
   → cross-ctx Γ zero p ⊢ ∀-entry-application α V A ⦂ A
-∀-entry-application-typed {Γ} {V = V} {A = A} {α = α} {R = R} p V⊢ =
+∀-entry-application-typed {Γ} {V = V} {A = A} {α = α}
+    {R′ = R′} p R′↝R V⊢ =
   subst
     (λ T → cross-ctx Γ zero p ⊢ ∀-entry-application α V A ⦂ T)
     (swap-shift-open-zero A) (⊢• exchanged⊢)
@@ -397,11 +326,8 @@ mutual
       V ↓[ zero ≔ α ] δ↓ (wkᵗ zero (`∀ A))
       ⦂ wkᵗ zero (`∀ A)
   entered⊢ =
-    ⊢conceal {Γ = Γ} {Γ′ = []} p
-      (δ-strict↓ zero (wkᵗ zero (`∀ A)))
-      (delimiter-reps↓
-        (BindingRel (κᵉ (cross-ctx Γ zero p))) R
-        (wkᵗ zero (`∀ A))) V⊢
+    ⊢conceal {Γ = Γ} {Γ′ = []} p R′↝R
+      (delimiter-typed↓ zero R′ (wkᵗ zero (`∀ A))) V⊢
 
   exchanged⊢ : cross-ctx Γ zero p ⊢
       V ↓[ zero ≔ α ] δ↓ (wkᵗ zero (`∀ A))
@@ -428,10 +354,10 @@ mutual
   → Name
   → Term Δ
   → (c : instᵐ μ ⊢ A ∼ ⇑ᵗ B)
-  → Conv↑ (suc Δ) A (wkᵗ zero (A [ ★ ]ᵗ))
   → Term Δ
-β-inst-result {A = A} α V c d =
-  ((∀-entry-application α V A) ↑[ zero ≔ α ] d)
+β-inst-result {A = A} α V c =
+  ((∀-entry-application α V A)
+    ↑[ zero ≔ α ] 〖 zero , ⇑ᵗ ★ ↑ A 〗)
   ⟨ c [ ★/0 ]ᶜ ⟩
 
 β-inst-redex-typed : ∀ {Γ} {μ : Env∼ (Δᵉ Γ)}
@@ -446,17 +372,10 @@ mutual
 β-inst-result-typed : ∀ {Γ} {μ : Env∼ (Δᵉ Γ)}
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (Δᵉ Γ)} {V : Term (Δᵉ Γ)}
     {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
-    {d : Conv↑ (suc (Δᵉ Γ)) A (wkᵗ zero (A [ ★ ]ᵗ))}
   → ⟨ Δᵉ Γ , suc (sizeᵉ Γ) , weakenBindings (κᵉ Γ) ,
       bind (Σᵉ Γ) ★ , [] ⟩ ⊢ V ⦂ `∀ A
-  → PivotStrict↑ zero d
-  → Reps↑
-      (BindingRel
-        (κᵉ (cross-ctx (allocCtx Γ ★) zero fresh-lookup)))
-      (⇑ᵗ ★) d
-  → allocCtx Γ ★ ⊢ β-inst-result (sizeᵉ Γ) V c d ⦂ B
-β-inst-result-typed {Γ} {A = A} {V = V} {c = c} {d = d}
-    V⊢ d-strict d-reps =
+  → allocCtx Γ ★ ⊢ β-inst-result (sizeᵉ Γ) V c ⦂ B
+β-inst-result-typed {Γ} {A = A} {V = V} {c = c} V⊢ =
   ⊢⟨⟩ revealed⊢ (c [ ★/0 ]ᶜ)
   where
   Γ⁺ = allocCtx Γ ★
@@ -464,73 +383,44 @@ mutual
 
   applied⊢ : cross-ctx Γ⁺ zero p ⊢
       ∀-entry-application (sizeᵉ Γ) V A ⦂ A
-  applied⊢ = ∀-entry-application-typed {Γ = Γ⁺} p V⊢
+  applied⊢ =
+    ∀-entry-application-typed {Γ = Γ⁺} p transport-star V⊢
 
   revealed⊢ : Γ⁺ ⊢
       (∀-entry-application (sizeᵉ Γ) V A)
-        ↑[ zero ≔ sizeᵉ Γ ] d
+        ↑[ zero ≔ sizeᵉ Γ ] 〖 zero , ⇑ᵗ ★ ↑ A 〗
       ⦂ A [ ★ ]ᵗ
-  revealed⊢ = ⊢reveal p d-strict d-reps applied⊢
+  revealed⊢ = ⊢reveal p transport-star (generator-typed A ★) applied⊢
 
 ------------------------------------------------------------------------
 -- Endpoint transport for opening a structural `∀` crossing
 ------------------------------------------------------------------------
 
-cast↑-target : ∀ {Δ} {A B B′ : Ty Δ}
-  → B ≡ B′
-  → Conv↑ Δ A B
-  → Conv↑ Δ A B′
-cast↑-target refl c = c
+open-∀↑-typed : ∀ {Δ} {X : Fin (suc Δ)} {R C}
+    {B : Ty (suc Δ)} {c : Conv↑}
+  → ⊢↑[ suc X ⦂ R ] c ⦂ C ↝ renameᵗ (extᵗ (punchIn X)) B
+  → ⊢↑[ suc X ⦂ R ] c ⦂ C ↝ wkᵗ (suc X) B
+open-∀↑-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
+  subst (λ T → ⊢↑[ suc X ⦂ R ] c ⦂ C ↝ T)
+    (wk-under-∀ X B) c⊢
 
-cast↓-source : ∀ {Δ} {A A′ B : Ty Δ}
-  → A ≡ A′
-  → Conv↓ Δ A B
-  → Conv↓ Δ A′ B
-cast↓-source refl c = c
-
-cast↑-target-strict : ∀ {Δ} {A B B′ : Ty Δ} {X}
-    (eq : B ≡ B′) {c : Conv↑ Δ A B}
-  → PivotStrict↑ X c
-  → PivotStrict↑ X (cast↑-target eq c)
-cast↑-target-strict refl c-strict = c-strict
-
-cast↓-source-strict : ∀ {Δ} {A A′ B : Ty Δ} {X}
-    (eq : A ≡ A′) {c : Conv↓ Δ A B}
-  → PivotStrict↓ X c
-  → PivotStrict↓ X (cast↓-source eq c)
-cast↓-source-strict refl c-strict = c-strict
-
-cast↑-target-reps : ∀ {Δ n} {ρ : VarRel Δ n} {S : Ty n}
-    {A B B′ : Ty Δ} (eq : B ≡ B′) {c : Conv↑ Δ A B}
-  → Reps↑ ρ S c
-  → Reps↑ ρ S (cast↑-target eq c)
-cast↑-target-reps refl c-reps = c-reps
-
-cast↓-source-reps : ∀ {Δ n} {ρ : VarRel Δ n} {S : Ty n}
-    {A A′ B : Ty Δ} (eq : A ≡ A′) {c : Conv↓ Δ A B}
-  → Reps↓ ρ S c
-  → Reps↓ ρ S (cast↓-source eq c)
-cast↓-source-reps refl c-reps = c-reps
-
-open-∀↑ : ∀ {Δ} {X : Fin (suc Δ)} {B : Ty (suc Δ)} {C}
-  → Conv↑ (suc (suc Δ)) C (renameᵗ (extᵗ (punchIn X)) B)
-  → Conv↑ (suc (suc Δ)) C (wkᵗ (suc X) B)
-open-∀↑ {X = X} {B} = cast↑-target (wk-under-∀ X B)
-
-open-∀↓ : ∀ {Δ} {X : Fin (suc Δ)} {B : Ty (suc Δ)} {C}
-  → Conv↓ (suc (suc Δ)) (renameᵗ (extᵗ (punchIn X)) B) C
-  → Conv↓ (suc (suc Δ)) (wkᵗ (suc X) B) C
-open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
+open-∀↓-typed : ∀ {Δ} {X : Fin (suc Δ)} {R C}
+    {B : Ty (suc Δ)} {c : Conv↓}
+  → ⊢↓[ suc X ⦂ R ] c ⦂ renameᵗ (extᵗ (punchIn X)) B ↝ C
+  → ⊢↓[ suc X ⦂ R ] c ⦂ wkᵗ (suc X) B ↝ C
+open-∀↓-typed {X = X} {R = R} {C = C} {B = B} {c = c} c⊢ =
+  subst (λ T → ⊢↓[ suc X ⦂ R ] c ⦂ T ↝ C)
+    (wk-under-∀ X B) c⊢
 
 ------------------------------------------------------------------------
 -- β-reveal-∀: redex, exchanged contractum, and typing validation
 ------------------------------------------------------------------------
 
-β-reveal-∀-redex : ∀ {Δ} {B : Ty (suc Δ)} {C}
+β-reveal-∀-redex : ∀ {Δ} {B : Ty (suc Δ)}
   → Name
   → Term (suc Δ)
   → (X : Fin (suc Δ))
-  → Conv↑ (suc (suc Δ)) C (renameᵗ (extᵗ (punchIn X)) B)
+  → Conv↑
   → Ty Δ
   → Term Δ
 β-reveal-∀-redex {B = B} α V X c A =
@@ -541,58 +431,61 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → Name
   → (X : Fin (suc Δ))
   → Term (suc Δ)
-  → (c : Conv↑ (suc (suc Δ)) C
-          (renameᵗ (extᵗ (punchIn X)) B))
-  → Conv↑ (suc Δ) B (wkᵗ zero (B [ A ]ᵗ))
+  → Conv↑
   → Term Δ
-β-reveal-∀-result {C = C} fresh α X V c d =
+β-reveal-∀-result {A = A} {B = B} {C = C} fresh α X V c =
   (((∀-entry-application fresh V C)
-      ↑[ suc X ≔ α ] open-∀↑ c)
-  ↑[ zero ≔ fresh ] d)
+      ↑[ suc X ≔ α ] c)
+  ↑[ zero ≔ fresh ] 〖 zero , ⇑ᵗ A ↑ B 〗)
 
 β-reveal-∀-redex-typed : ∀ {Γ} {A : Ty (Δᵉ Γ)}
     {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
     {V : Term (suc (Δᵉ Γ))} {X : Fin (suc (Δᵉ Γ))}
-    {α : Name} {R : Ty (sizeᵉ Γ)}
-    {c : Conv↑ (suc (suc (Δᵉ Γ))) C
-           (renameᵗ (extᵗ (punchIn X)) B)}
+    {α : Name} {R : Ty (sizeᵉ Γ)} {R′ : Ty (suc (Δᵉ Γ))}
+    {c : Conv↑}
   → (p : α ⦂ R ∈ Σᵉ Γ)
-  → PivotStrict↑ (suc X) c
-  → Reps↑ (LiftRel (BindingRel (κᵉ (cross-ctx Γ X p))))
-      (⇑ᵗ R) c
+  → Transport (BindingRel (κᵉ (cross-ctx Γ X p))) R′ R
+  → ⊢↑[ suc X ⦂ ⇑ᵗ R′ ] c ⦂ C
+      ↝ renameᵗ (extᵗ (punchIn X)) B
   → cross-ctx Γ X p ⊢ V ⦂ `∀ C
-  → Γ ⊢ β-reveal-∀-redex α V X c A ⦂ B [ A ]ᵗ
-β-reveal-∀-redex-typed {B = B} {X = X} p c-strict c-reps V⊢ =
-  ⊢• (⊢reveal p (strict-↑∀ c-strict) (reps-↑∀ c-reps) V⊢)
+  → Γ ⊢ β-reveal-∀-redex {B = B} α V X c A ⦂ B [ A ]ᵗ
+β-reveal-∀-redex-typed {B = B} {X = X} p R′↝R c⊢ V⊢ =
+  ⊢• (⊢reveal p R′↝R (⊢↑-∀ c⊢) V⊢)
 
 β-reveal-∀-result-typed : ∀ {Γ} {A : Ty (Δᵉ Γ)}
     {B : Ty (suc (Δᵉ Γ))} {C : Ty (suc (suc (Δᵉ Γ)))}
     {V : Term (suc (Δᵉ Γ))} {X : Fin (suc (Δᵉ Γ))}
-    {α : Name} {R S : Ty (sizeᵉ Γ)}
-    {c : Conv↑ (suc (suc (Δᵉ Γ))) C
-           (renameᵗ (extᵗ (punchIn X)) B)}
-    {d : Conv↑ (suc (Δᵉ Γ)) B (wkᵗ zero (B [ A ]ᵗ))}
+    {α : Name} {R S : Ty (sizeᵉ Γ)} {R′ : Ty (suc (Δᵉ Γ))}
+    {Q : Ty (suc (suc (Δᵉ Γ)))} {c : Conv↑}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → BindingsExtensionality
   → cross-ctx (allocCtx Γ S) X (weaken-lookup p) ⊢ V ⦂ `∀ C
-  → Reps↑
+  → Transport
       (BindingRel
-        (κᵉ
-          (cross-ctx (cross-ctx (allocCtx Γ S) zero fresh-lookup)
-            (suc X) (weaken-lookup p))))
-      (⇑ᵗ R) c
-  → PivotStrict↑ (suc X) c
-  → Reps↑
+        (κᵉ (cross-ctx
+          (cross-ctx (allocCtx Γ S) X (weaken-lookup p))
+          zero fresh-lookup)))
+      Q (⇑ᵗ S)
+  → Transport
+      (BindingRel
+        (κᵉ (cross-ctx
+          (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+          (suc X) (weaken-lookup p))))
+      (⇑ᵗ R′) (⇑ᵗ R)
+  → Transport
       (BindingRel
         (κᵉ (cross-ctx (allocCtx Γ S) zero fresh-lookup)))
-      (⇑ᵗ S) d
-  → PivotStrict↑ zero d
+      (⇑ᵗ A) (⇑ᵗ S)
+  → ⊢↑[ suc X ⦂ ⇑ᵗ R′ ] c ⦂ C
+      ↝ renameᵗ (extᵗ (punchIn X)) B
   → allocCtx Γ S ⊢
-      β-reveal-∀-result (sizeᵉ Γ) α X V c d ⦂ B [ A ]ᵗ
-β-reveal-∀-result-typed {Γ} {B = B} {C = C} {V = V} {X = X}
-    {α = α} {S = S} {c = c} {d = d}
-    p ext V⊢ c-reps c-strict d-reps d-strict =
-  ⊢reveal fresh d-strict d-reps old-revealed⊢
+      β-reveal-∀-result {A = A} {B = B} {C = C}
+        (sizeᵉ Γ) α X V c ⦂ B [ A ]ᵗ
+β-reveal-∀-result-typed {Γ} {A = A} {B = B} {C = C}
+    {V = V} {X = X}
+    {α = α} {S = S} {R′ = R′} {c = c}
+    p ext V⊢ entry-transport old-transport fresh-transport c⊢ =
+  ⊢reveal fresh fresh-transport (generator-typed B A) old-revealed⊢
   where
   Γ⁺ = allocCtx Γ S
   fresh = fresh-lookup {Σ = Σᵉ Γ} {R = S}
@@ -602,7 +495,8 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   inner-left⊢ : cross-ctx oldΓ zero fresh ⊢
       ∀-entry-application (sizeᵉ Γ) V C ⦂ C
-  inner-left⊢ = ∀-entry-application-typed {Γ = oldΓ} fresh V⊢
+  inner-left⊢ =
+    ∀-entry-application-typed {Γ = oldΓ} fresh entry-transport V⊢
 
   inner-right⊢ : cross-ctx freshΓ (suc X) old ⊢
       ∀-entry-application (sizeᵉ Γ) V C ⦂ C
@@ -611,24 +505,20 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   old-revealed⊢ : freshΓ ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
-        ↑[ suc X ≔ α ] open-∀↑ c
+        ↑[ suc X ≔ α ] c
       ⦂ B
   old-revealed⊢ =
-    ⊢reveal old
-      (cast↑-target-strict (wk-under-∀ X B) c-strict)
-      (cast↑-target-reps (wk-under-∀ X B) c-reps)
-      inner-right⊢
+    ⊢reveal old old-transport (open-∀↑-typed c⊢) inner-right⊢
 
 ------------------------------------------------------------------------
 -- β-conceal-∀: redex, exchanged contractum, and typing validation
 ------------------------------------------------------------------------
 
 β-conceal-∀-redex : ∀ {Δ} {B : Ty (suc (suc Δ))}
-    {C : Ty (suc Δ)}
   → Name
   → Term Δ
   → (X : Fin (suc Δ))
-  → Conv↓ (suc (suc Δ)) (renameᵗ (extᵗ (punchIn X)) C) B
+  → Conv↓
   → Ty (suc Δ)
   → Term (suc Δ)
 β-conceal-∀-redex {B = B} α V X c A =
@@ -640,63 +530,63 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
   → Name
   → (X : Fin (suc Δ))
   → Term Δ
-  → (c : Conv↓ (suc (suc Δ))
-          (renameᵗ (extᵗ (punchIn X)) C) B)
-  → Conv↑ (suc (suc Δ)) B (wkᵗ zero (B [ A ]ᵗ))
+  → Conv↓
   → Term (suc Δ)
-β-conceal-∀-result {C = C} fresh α X V c d =
+β-conceal-∀-result {A = A} {B = B} {C = C} fresh α X V c =
   (((∀-entry-application fresh V C)
-    ↓[ suc X ≔ α ] open-∀↓ c)
-  ↑[ zero ≔ fresh ] d)
+    ↓[ suc X ≔ α ] c)
+  ↑[ zero ≔ fresh ] 〖 zero , ⇑ᵗ A ↑ B 〗)
 
 β-conceal-∀-redex-typed : ∀ {Γ}
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
     {C : Ty (suc (Δᵉ Γ))} {V : Term (Δᵉ Γ)}
     {X : Fin (suc (Δᵉ Γ))} {α : Name} {R : Ty (sizeᵉ Γ)}
-    {c : Conv↓ (suc (suc (Δᵉ Γ)))
-           (renameᵗ (extᵗ (punchIn X)) C) B}
+    {R′ : Ty (suc (Δᵉ Γ))} {c : Conv↓}
   → (p : α ⦂ R ∈ Σᵉ Γ)
-  → PivotStrict↓ (suc X) c
-  → Reps↓ (LiftRel (BindingRel (κᵉ (cross-ctx Γ X p))))
-      (⇑ᵗ R) c
+  → Transport (BindingRel (κᵉ (cross-ctx Γ X p))) R′ R
+  → ⊢↓[ suc X ⦂ ⇑ᵗ R′ ] c
+      ⦂ renameᵗ (extᵗ (punchIn X)) C ↝ B
   → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ V ⦂ `∀ C
   → cross-ctx Γ X p ⊢
-      β-conceal-∀-redex α V X c A ⦂ B [ A ]ᵗ
-β-conceal-∀-redex-typed {Γ} p c-strict c-reps V⊢ =
-  ⊢• (⊢conceal {Γ = Γ} {Γ′ = []} p (strict-↓∀ c-strict)
-    (reps-↓∀ c-reps) V⊢)
+      β-conceal-∀-redex {B = B} α V X c A ⦂ B [ A ]ᵗ
+β-conceal-∀-redex-typed {Γ} p R′↝R c⊢ V⊢ =
+  ⊢• (⊢conceal {Γ = Γ} {Γ′ = []} p R′↝R (⊢↓-∀ c⊢) V⊢)
 
 β-conceal-∀-result-typed : ∀ {Γ}
     {A : Ty (suc (Δᵉ Γ))} {B : Ty (suc (suc (Δᵉ Γ)))}
     {C : Ty (suc (Δᵉ Γ))} {V : Term (Δᵉ Γ)}
     {X : Fin (suc (Δᵉ Γ))} {α : Name} {R S : Ty (sizeᵉ Γ)}
-    {c : Conv↓ (suc (suc (Δᵉ Γ)))
-           (renameᵗ (extᵗ (punchIn X)) C) B}
-    {d : Conv↑ (suc (suc (Δᵉ Γ))) B
-           (wkᵗ zero (B [ A ]ᵗ))}
+    {R′ Q : Ty (suc (Δᵉ Γ))} {c : Conv↓}
   → (p : α ⦂ R ∈ Σᵉ Γ)
   → BindingsExtensionality
   → ⟨ Δᵉ Γ , suc (sizeᵉ Γ) , weakenBindings (κᵉ Γ) ,
       bind (Σᵉ Γ) S , [] ⟩ ⊢ V ⦂ `∀ C
-  → Reps↓
+  → Transport
       (BindingRel
-        (κᵉ
-          (cross-ctx (cross-ctx (allocCtx Γ S) zero fresh-lookup)
-            (suc X) (weaken-lookup p))))
-      (⇑ᵗ R) c
-  → PivotStrict↓ (suc X) c
-  → Reps↑
+        (κᵉ (cross-ctx (allocCtx Γ S) zero fresh-lookup)))
+      Q (⇑ᵗ S)
+  → Transport
       (BindingRel
-        (κᵉ
-          (cross-ctx (allocCtx (cross-ctx Γ X p) S) zero fresh-lookup)))
-      (⇑ᵗ S) d
-  → PivotStrict↑ zero d
+        (κᵉ (cross-ctx
+          (cross-ctx (allocCtx Γ S) zero fresh-lookup)
+          (suc X) (weaken-lookup p))))
+      (⇑ᵗ R′) (⇑ᵗ R)
+  → Transport
+      (BindingRel
+        (κᵉ (cross-ctx
+          (allocCtx (cross-ctx Γ X p) S) zero fresh-lookup)))
+      (⇑ᵗ A) (⇑ᵗ S)
+  → ⊢↓[ suc X ⦂ ⇑ᵗ R′ ] c
+      ⦂ renameᵗ (extᵗ (punchIn X)) C ↝ B
   → allocCtx (cross-ctx Γ X p) S ⊢
-      β-conceal-∀-result (sizeᵉ Γ) α X V c d ⦂ B [ A ]ᵗ
-β-conceal-∀-result-typed {Γ} {B = B} {C = C} {V = V} {X = X}
-    {α = α} {S = S} {c = c} {d = d}
-    p ext V⊢ c-reps c-strict d-reps d-strict =
-  ⊢reveal fresh-final d-strict d-reps concealed-left⊢
+      β-conceal-∀-result {A = A} {B = B} {C = C}
+        (sizeᵉ Γ) α X V c ⦂ B [ A ]ᵗ
+β-conceal-∀-result-typed {Γ} {A = A} {B = B} {C = C}
+    {V = V} {X = X}
+    {α = α} {S = S} {R′ = R′} {c = c}
+    p ext V⊢ entry-transport old-transport fresh-transport c⊢ =
+  ⊢reveal fresh-final fresh-transport (generator-typed B A)
+    concealed-left⊢
   where
   Γ⁺ = allocCtx Γ S
   fresh = fresh-lookup {Σ = Σᵉ Γ} {R = S}
@@ -708,21 +598,20 @@ open-∀↓ {X = X} {B} = cast↓-source (wk-under-∀ X B)
 
   applied⊢ : freshΓ ⊢
       ∀-entry-application (sizeᵉ Γ) V C ⦂ C
-  applied⊢ = ∀-entry-application-typed {Γ = Γ⁺} fresh V⊢
+  applied⊢ =
+    ∀-entry-application-typed {Γ = Γ⁺} fresh entry-transport V⊢
 
   concealed-right⊢ : cross-ctx freshΓ (suc X) old ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
-        ↓[ suc X ≔ α ] open-∀↓ c
+        ↓[ suc X ≔ α ] c
       ⦂ B
   concealed-right⊢ =
-    ⊢conceal {Γ = freshΓ} {Γ′ = []} old
-      (cast↓-source-strict (wk-under-∀ X C) c-strict)
-      (cast↓-source-reps (wk-under-∀ X C) c-reps)
-      applied⊢
+    ⊢conceal {Γ = freshΓ} {Γ′ = []} old old-transport
+      (open-∀↓-typed c⊢) applied⊢
 
   concealed-left⊢ : cross-ctx oldΓ⁺ zero fresh-final ⊢
       (∀-entry-application (sizeᵉ Γ) V C)
-        ↓[ suc X ≔ α ] open-∀↓ c
+        ↓[ suc X ≔ α ] c
       ⦂ B
   concealed-left⊢ =
     allocation-cross-ctx-exchange-typing ext {Γ = Γ} p concealed-right⊢

--- a/GTSFImp/alt/GeneratorEndpoint.agda
+++ b/GTSFImp/alt/GeneratorEndpoint.agda
@@ -3,9 +3,7 @@ module alt.GeneratorEndpoint where
 -- File Charter:
 --   * Proves that the structural generator at the newest type slot has the
 --     weakened open-type endpoint required by allocating reduction rules.
---   * Defines the canonical endpoint-correct exit conversion.
---   * Proves that structural generators, and hence the canonical exit, are
---     pivot-strict.
+--   * Reindexes the raw generator's typing proof to that endpoint.
 --   * Depends only on Types and alt.Conversion.
 
 import Data.Fin as Fin
@@ -55,7 +53,7 @@ replaceTy-subst X R (`∀ B) =
       (substᵗ-cong B (replaceEnv-ext X R)))
 
 ------------------------------------------------------------------------
--- Endpoint-correct structural exit
+-- Endpoint-correct structural-exit typing
 ------------------------------------------------------------------------
 
 generator-endpoint : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
@@ -71,52 +69,12 @@ generator-endpoint B C =
   env-eq Fin.zero = refl
   env-eq (Fin.suc X) = refl
 
--- Unfolding d-canonical exposes exactly one endpoint transport around the
--- literal generator.  Also, wkᵗ Fin.zero computes to ⇑ᵗ, so no separate
--- weakening equality is hidden in this definition.
-d-canonical : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
-  → Conv↑ (Nat.suc Δ) B (wkᵗ Fin.zero (B [ C ]ᵗ))
-d-canonical {Δ = Δ} B C =
-  subst≡ (Conv↑ (Nat.suc Δ) B) (generator-endpoint B C)
-    〖 Fin.zero , ⇑ᵗ C ↑ B 〗
-
-------------------------------------------------------------------------
--- Pivot strictness
-------------------------------------------------------------------------
-
-mutual
-  generator-strict↑ : (X : TyVar Δ) (R B : Ty Δ)
-    → PivotStrict↑ X 〖 X , R ↑ B 〗
-  generator-strict↑ X R (＇ Y) with X ≟ Y
-  generator-strict↑ X R (＇ .X) | yes refl = strict-unseal
-  generator-strict↑ X R (＇ Y) | no X≠Y = strict-id↑
-  generator-strict↑ X R (‵ ι) = strict-id↑
-  generator-strict↑ X R ★ = strict-id↑
-  generator-strict↑ X R (A ⇒ B) =
-    strict-↑⇒ (generator-strict↓ X R A) (generator-strict↑ X R B)
-  generator-strict↑ X R (`∀ B) =
-    strict-↑∀ (generator-strict↑ (Fin.suc X) (⇑ᵗ R) B)
-
-  generator-strict↓ : (X : TyVar Δ) (R B : Ty Δ)
-    → PivotStrict↓ X (makeConceal X R B)
-  generator-strict↓ X R (＇ Y) with X ≟ Y
-  generator-strict↓ X R (＇ .X) | yes refl = strict-seal
-  generator-strict↓ X R (＇ Y) | no X≠Y = strict-id↓
-  generator-strict↓ X R (‵ ι) = strict-id↓
-  generator-strict↓ X R ★ = strict-id↓
-  generator-strict↓ X R (A ⇒ B) =
-    strict-↓⇒ (generator-strict↑ X R A) (generator-strict↓ X R B)
-  generator-strict↓ X R (`∀ B) =
-    strict-↓∀ (generator-strict↓ (Fin.suc X) (⇑ᵗ R) B)
-
-subst-strict↑ : ∀ {X : TyVar Δ} {A B B′ : Ty Δ}
-    {c : Conv↑ Δ A B} (eq : B ≡ B′)
-  → PivotStrict↑ X c
-  → PivotStrict↑ X (subst≡ (Conv↑ Δ A) eq c)
-subst-strict↑ refl strict = strict
-
-d-canonical-strict : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
-  → PivotStrict↑ Fin.zero (d-canonical B C)
-d-canonical-strict B C =
-  subst-strict↑ (generator-endpoint B C)
-    (generator-strict↑ Fin.zero (⇑ᵗ C) B)
+generator-typed : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
+  → ⊢↑[ Fin.zero ⦂ ⇑ᵗ C ] 〖 Fin.zero , ⇑ᵗ C ↑ B 〗
+      ⦂ B ↝ wkᵗ Fin.zero (B [ C ]ᵗ)
+generator-typed B C =
+  subst≡
+    (λ T → ⊢↑[ Fin.zero ⦂ ⇑ᵗ C ] 〖 Fin.zero , ⇑ᵗ C ↑ B 〗
+      ⦂ B ↝ T)
+    (generator-endpoint B C)
+    (generator-typed↑ Fin.zero (⇑ᵗ C) B)

--- a/GTSFImp/alt/GeneratorEndpoint.agda
+++ b/GTSFImp/alt/GeneratorEndpoint.agda
@@ -1,0 +1,122 @@
+module alt.GeneratorEndpoint where
+
+-- File Charter:
+--   * Proves that the structural generator at the newest type slot has the
+--     weakened open-type endpoint required by allocating reduction rules.
+--   * Defines the canonical endpoint-correct exit conversion.
+--   * Proves that structural generators, and hence the canonical exit, are
+--     pivot-strict.
+--   * Depends only on Types and alt.Conversion.
+
+import Data.Fin as Fin
+open import Data.Fin.Properties using (_≟_)
+import Data.Nat as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; cong; sym; trans)
+  renaming (subst to subst≡)
+open import Relation.Nullary using (yes; no)
+
+open import Types
+open import alt.Conversion
+
+private
+  variable
+    Δ : TyCtx
+
+------------------------------------------------------------------------
+-- Replacement as parallel substitution
+------------------------------------------------------------------------
+
+replaceEnv : ∀ {Δ} → TyVar Δ → Ty Δ → Δ ⇒ˢ Δ
+replaceEnv X R Y with X ≟ Y
+replaceEnv X R .X | yes refl = R
+replaceEnv X R Y | no X≠Y = ＇ Y
+
+replaceEnv-ext : ∀ {Δ} (X : TyVar Δ) (R : Ty Δ)
+    (Y : TyVar (Nat.suc Δ))
+  → replaceEnv (Fin.suc X) (⇑ᵗ R) Y ≡ extsᵗ (replaceEnv X R) Y
+replaceEnv-ext X R Fin.zero = refl
+replaceEnv-ext X R (Fin.suc Y) with X ≟ Y
+replaceEnv-ext X R (Fin.suc .X) | yes refl = refl
+replaceEnv-ext X R (Fin.suc Y) | no X≠Y = refl
+
+replaceTy-subst : ∀ {Δ} (X : TyVar Δ) (R B : Ty Δ)
+  → replaceTy X R B ≡ substᵗ (replaceEnv X R) B
+replaceTy-subst X R (＇ Y) with X ≟ Y
+replaceTy-subst X R (＇ .X) | yes refl = refl
+replaceTy-subst X R (＇ Y) | no X≠Y = refl
+replaceTy-subst X R (‵ ι) = refl
+replaceTy-subst X R ★ = refl
+replaceTy-subst X R (A ⇒ B)
+  rewrite replaceTy-subst X R A | replaceTy-subst X R B = refl
+replaceTy-subst X R (`∀ B) =
+  cong `∀
+    (trans (replaceTy-subst (Fin.suc X) (⇑ᵗ R) B)
+      (substᵗ-cong B (replaceEnv-ext X R)))
+
+------------------------------------------------------------------------
+-- Endpoint-correct structural exit
+------------------------------------------------------------------------
+
+generator-endpoint : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
+  → replaceTy Fin.zero (⇑ᵗ C) B ≡ ⇑ᵗ (B [ C ]ᵗ)
+generator-endpoint B C =
+  trans (replaceTy-subst Fin.zero (⇑ᵗ C) B)
+    (trans (substᵗ-cong B env-eq)
+      (sym (renameᵗ-subst Fin.suc (singleSubᵗ C) B)))
+  where
+  env-eq : ∀ X
+    → replaceEnv Fin.zero (⇑ᵗ C) X
+      ≡ renameᵗ Fin.suc (singleSubᵗ C X)
+  env-eq Fin.zero = refl
+  env-eq (Fin.suc X) = refl
+
+-- Unfolding d-canonical exposes exactly one endpoint transport around the
+-- literal generator.  Also, wkᵗ Fin.zero computes to ⇑ᵗ, so no separate
+-- weakening equality is hidden in this definition.
+d-canonical : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
+  → Conv↑ (Nat.suc Δ) B (wkᵗ Fin.zero (B [ C ]ᵗ))
+d-canonical {Δ = Δ} B C =
+  subst≡ (Conv↑ (Nat.suc Δ) B) (generator-endpoint B C)
+    〖 Fin.zero , ⇑ᵗ C ↑ B 〗
+
+------------------------------------------------------------------------
+-- Pivot strictness
+------------------------------------------------------------------------
+
+mutual
+  generator-strict↑ : (X : TyVar Δ) (R B : Ty Δ)
+    → PivotStrict↑ X 〖 X , R ↑ B 〗
+  generator-strict↑ X R (＇ Y) with X ≟ Y
+  generator-strict↑ X R (＇ .X) | yes refl = strict-unseal
+  generator-strict↑ X R (＇ Y) | no X≠Y = strict-id↑
+  generator-strict↑ X R (‵ ι) = strict-id↑
+  generator-strict↑ X R ★ = strict-id↑
+  generator-strict↑ X R (A ⇒ B) =
+    strict-↑⇒ (generator-strict↓ X R A) (generator-strict↑ X R B)
+  generator-strict↑ X R (`∀ B) =
+    strict-↑∀ (generator-strict↑ (Fin.suc X) (⇑ᵗ R) B)
+
+  generator-strict↓ : (X : TyVar Δ) (R B : Ty Δ)
+    → PivotStrict↓ X (makeConceal X R B)
+  generator-strict↓ X R (＇ Y) with X ≟ Y
+  generator-strict↓ X R (＇ .X) | yes refl = strict-seal
+  generator-strict↓ X R (＇ Y) | no X≠Y = strict-id↓
+  generator-strict↓ X R (‵ ι) = strict-id↓
+  generator-strict↓ X R ★ = strict-id↓
+  generator-strict↓ X R (A ⇒ B) =
+    strict-↓⇒ (generator-strict↑ X R A) (generator-strict↓ X R B)
+  generator-strict↓ X R (`∀ B) =
+    strict-↓∀ (generator-strict↓ (Fin.suc X) (⇑ᵗ R) B)
+
+subst-strict↑ : ∀ {X : TyVar Δ} {A B B′ : Ty Δ}
+    {c : Conv↑ Δ A B} (eq : B ≡ B′)
+  → PivotStrict↑ X c
+  → PivotStrict↑ X (subst≡ (Conv↑ Δ A) eq c)
+subst-strict↑ refl strict = strict
+
+d-canonical-strict : (B : Ty (Nat.suc Δ)) (C : Ty Δ)
+  → PivotStrict↑ Fin.zero (d-canonical B C)
+d-canonical-strict B C =
+  subst-strict↑ (generator-endpoint B C)
+    (generator-strict↑ Fin.zero (⇑ᵗ C) B)

--- a/GTSFImp/alt/Reduction.agda
+++ b/GTSFImp/alt/Reduction.agda
@@ -5,7 +5,7 @@ module alt.Reduction where
 --   * Store allocation changes only the global store; the term type context
 --     is fixed by every step and evaluation frames leave siblings untouched.
 --   * Restores ordinary beta with annotated, structural substitution.
---   * Provides store-indexed multi-step traces and anchored tag comparison.
+--   * Provides store-indexed multi-step traces and syntactic tag comparison.
 
 open import Data.Fin using (inject₁; zero)
 open import Data.Nat using (ℕ; suc)
@@ -61,59 +61,6 @@ applyBindingss : ∀ {n n′ Δ}
   → Bindings Δ n′
 applyBindingss [] κ = κ
 applyBindingss (χ ∷ χs) κ = applyBindingss χs (applyBindings χ κ)
-
-------------------------------------------------------------------------
--- Ground-tag comparison through anchors
-------------------------------------------------------------------------
-
-data TagMatch {Δ n} (κ : Bindings Δ n) : Ty Δ → Ty Δ → Set where
-  match-var : ∀ {X Y α}
-    → κ X ≡ anchored α
-    → κ Y ≡ anchored α
-    → TagMatch κ (＇ X) (＇ Y)
-
-  match-base : ∀ {ι}
-    → TagMatch κ (‵ ι) (‵ ι)
-
-  match-fun : TagMatch κ (★ ⇒ ★) (★ ⇒ ★)
-
-  match-all : TagMatch κ (`∀ ★) (`∀ ★)
-
-data TagMismatch {Δ n} (κ : Bindings Δ n) : Ty Δ → Ty Δ → Set where
-  mismatch-var : ∀ {X Y α β}
-    → κ X ≡ anchored α
-    → κ Y ≡ anchored β
-    → α ≢ β
-    → TagMismatch κ (＇ X) (＇ Y)
-
-  mismatch-var-base : ∀ {X ι}
-    → TagMismatch κ (＇ X) (‵ ι)
-  mismatch-var-fun : ∀ {X}
-    → TagMismatch κ (＇ X) (★ ⇒ ★)
-  mismatch-var-all : ∀ {X}
-    → TagMismatch κ (＇ X) (`∀ ★)
-
-  mismatch-base-var : ∀ {ι X}
-    → TagMismatch κ (‵ ι) (＇ X)
-  mismatch-base : ∀ {ι ι′}
-    → ι ≢ ι′
-    → TagMismatch κ (‵ ι) (‵ ι′)
-  mismatch-base-fun : ∀ {ι}
-    → TagMismatch κ (‵ ι) (★ ⇒ ★)
-  mismatch-base-all : ∀ {ι}
-    → TagMismatch κ (‵ ι) (`∀ ★)
-
-  mismatch-fun-var : ∀ {X}
-    → TagMismatch κ (★ ⇒ ★) (＇ X)
-  mismatch-fun-base : ∀ {ι}
-    → TagMismatch κ (★ ⇒ ★) (‵ ι)
-  mismatch-fun-all : TagMismatch κ (★ ⇒ ★) (`∀ ★)
-
-  mismatch-all-var : ∀ {X}
-    → TagMismatch κ (`∀ ★) (＇ X)
-  mismatch-all-base : ∀ {ι}
-    → TagMismatch κ (`∀ ★) (‵ ι)
-  mismatch-all-fun : TagMismatch κ (`∀ ★) (★ ⇒ ★)
 
 ------------------------------------------------------------------------
 -- One-step reduction
@@ -179,13 +126,12 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
         V ⟨ ？ (idᵍ Gᵍ) ⟩ ⟨ c ⟩
 
   tag-untag : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
-      {V : Term Δ} {μ ν : Env∼ Δ} {G H : Ty Δ}
-      ⦃ Gᵍ : Ground G ⦄ ⦃ Hᵍ : Ground H ⦄
-      ⦃ G∼★ : μ ⊢ G ∼★ ⦄ ⦃ ★∼H : ν ⊢★∼ H ⦄
-      ⦃ Gns : NonStar G ⦄ ⦃ Hns : NonStar H ⦄
+      {V : Term Δ} {μ ν : Env∼ Δ} {G : Ty Δ}
+      ⦃ Gᵍ : Ground G ⦄
+      ⦃ G∼★ : μ ⊢ G ∼★ ⦄ ⦃ ★∼G : ν ⊢★∼ G ⦄
+      ⦃ Gns : NonStar G ⦄
     → Value V
-    → TagMatch κ G H
-    → Σ ∣ κ ⊢ V ⟨ (idᵍ Gᵍ) ! ⟩ ⟨ ？ (idᵍ Hᵍ) ⟩
+    → Σ ∣ κ ⊢ V ⟨ (idᵍ Gᵍ) ! ⟩ ⟨ ？ (idᵍ Gᵍ) ⟩
         —→[ keep ] V
 
   tag-untag-bad : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
@@ -194,7 +140,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
       ⦃ G∼★ : μ ⊢ G ∼★ ⦄ ⦃ ★∼H : ν ⊢★∼ H ⦄
       ⦃ Gns : NonStar G ⦄ ⦃ Hns : NonStar H ⦄
     → Value V
-    → TagMismatch κ G H
+    → G ≢ H
     → Σ ∣ κ ⊢ V ⟨ (idᵍ Gᵍ) ! ⟩ ⟨ ？ (idᵍ Hᵍ) ⟩
         —→[ keep ] blame
 
@@ -204,11 +150,9 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Σ ∣ κ ⊢ V ⟨ bot-intro {μ = μ} ⟩ —→[ keep ] blame
 
   β-reveal-⇒ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
-      {V : Term (suc Δ)} {W : Term Δ} {A₀ B₀ : Ty Δ}
-      {A B : Ty (suc Δ)}
+      {V : Term (suc Δ)} {W : Term Δ}
       {X : TyVar (suc Δ)} {α : Name}
-      {c : Conv↓ (suc Δ) (wkᵗ X A₀) A}
-      {d : Conv↑ (suc Δ) B (wkᵗ X B₀)}
+      {c : Conv↓} {d : Conv↑}
     → Value V
     → Value W
     → Σ ∣ κ ⊢ (V ↑[ X ≔ α ] (c ↦↑ d)) · W —→[ keep ]
@@ -216,27 +160,36 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
 
   β-conceal-⇒ : ∀ {n Δ} {Σ : Store n}
       {κ : Bindings (suc Δ) n}
-      {V : Term Δ} {W : Term (suc Δ)} {A₀ B₀ : Ty Δ}
-      {A′ B′ : Ty (suc Δ)}
+      {V : Term Δ} {W : Term (suc Δ)}
       {X : TyVar (suc Δ)} {α : Name}
-      {c : Conv↑ (suc Δ) A′ (wkᵗ X A₀)}
-      {d : Conv↓ (suc Δ) (wkᵗ X B₀) B′}
+      {c : Conv↑} {d : Conv↓}
     → Value V
     → Value W
     → Σ ∣ κ ⊢ (V ↓[ X ≔ α ] (c ↦↓ d)) · W —→[ keep ]
         (V · (W ↑[ X ≔ α ] c)) ↓[ X ≔ α ] d
 
   id-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
-      {X : TyVar (suc Δ)} {α : Name} {ι κ₀}
-    → Σ ∣ κ ⊢ ($ κ₀) ↑[ X ≔ α ] id↑ (‵ ι)
+      {X : TyVar (suc Δ)} {α : Name} {κ₀}
+    → Σ ∣ κ ⊢ ($ κ₀) ↑[ X ≔ α ] id↑
         —→[ keep ] $ κ₀
 
+  id-conceal : ∀ {n Δ} {Σ : Store n}
+      {κ : Bindings (suc Δ) n}
+      {X : TyVar (suc Δ)} {α : Name} {κ₀}
+    → Σ ∣ κ ⊢ ($ κ₀) ↓[ X ≔ α ] id↓
+        —→[ keep ] $ κ₀
+
+  id-cancel : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {X Y : TyVar (suc Δ)} {α β : Name}
+    → CanonicalInterior V
+    → Σ ∣ κ ⊢ (V ↓[ X ≔ α ] id↓) ↑[ Y ≔ β ] id↑
+        —→[ keep ] V
+
   conceal-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
-      {V : Term Δ} {A : Ty Δ} {X : TyVar (suc Δ)} {α : Name}
+      {V : Term Δ} {X Y : TyVar (suc Δ)} {α β : Name}
     → Value V
     → Σ ∣ κ ⊢
-        (V ↓[ X ≔ α ] alt.Conversion.seal X (wkᵗ X A))
-          ↑[ X ≔ α ] unseal X (wkᵗ X A)
+        (V ↓[ X ≔ α ] alt.Conversion.seal) ↑[ Y ≔ β ] unseal
         —→[ keep ] V
 
   blame-·₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
@@ -257,13 +210,11 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Σ ∣ κ ⊢ blame ⟨ c ⟩ —→[ keep ] blame
 
   blame-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
-      {A : Ty (suc Δ)} {B : Ty Δ} {X : TyVar (suc Δ)}
-      {α : Name} {c : Conv↑ (suc Δ) A (wkᵗ X B)}
+      {X : TyVar (suc Δ)} {α : Name} {c : Conv↑}
     → Σ ∣ κ ⊢ blame ↑[ X ≔ α ] c —→[ keep ] blame
 
   blame-conceal : ∀ {n Δ} {Σ : Store n} {κ : Bindings (suc Δ) n}
-      {A : Ty Δ} {B : Ty (suc Δ)} {X : TyVar (suc Δ)}
-      {α : Name} {c : Conv↓ (suc Δ) (wkᵗ X A) B}
+      {X : TyVar (suc Δ)} {α : Name} {c : Conv↓}
     → Σ ∣ κ ⊢ blame ↓[ X ≔ α ] c —→[ keep ] blame
 
   blame-⊕₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
@@ -275,25 +226,17 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Value V
     → Σ ∣ κ ⊢ V ⊕[ op ] blame —→[ keep ] blame
 
-  -- DEVIATION: β-Λ accepts the already endpoint-correct crossing
-  -- conversion as data.  The literal generator has an extensionally equal
-  -- endpoint whose equality to wkᵗ zero (B [ A ]ᵗ) is not definitional.
   β-Λ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {A : Ty Δ} {B : Ty (suc Δ)} {R : Ty n}
       {V : Term (suc Δ)}
-      {d : Conv↑ (suc Δ) B (wkᵗ zero (B [ A ]ᵗ))}
     → Value V
     → Transport (BindingRel κ) A R
     → Σ ∣ κ ⊢ (Λ V) ⦂∀ B [ A ] —→[ bind R ]
-        V ↑[ zero ≔ n ] d
+        V ↑[ zero ≔ n ] 〖 zero , ⇑ᵗ A ↑ B 〗
 
-  -- DEVIATION: as for β-Λ, β-gen takes the endpoint-correct exit
-  -- conversion as data.  Its entry delimiter is explicit and no term is
-  -- renamed when the store grows.
   β-gen : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {V : Term Δ} {μ : Env∼ Δ} {A C : Ty Δ} {B : Ty (suc Δ)}
       {R : Ty n} {c : genᵐ μ ⊢ ⇑ᵗ A ∼ B}
-      {d : Conv↑ (suc Δ) B (wkᵗ zero (B [ C ]ᵗ))}
       ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : zero ∈ᵗ B ⦄
     → Value V
     → (A≢★ : A ≢ ★)
@@ -302,11 +245,10 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Σ ∣ κ ⊢ (V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ]
         —→[ bind R ]
         ((V ↓[ zero ≔ n ] δ↓ (⇑ᵗ A)) ⟨ c ⟩)
-          ↑[ zero ≔ n ] d
+          ↑[ zero ≔ n ] 〖 zero , ⇑ᵗ C ↑ B 〗
 
-  -- DEVIATION: β-inst, β-reveal-∀, and β-conceal-∀ are omitted.  Their
-  -- source forall slot and crossing slot require a typed exchange operation
-  -- not present in the settled syntax.  See alt/Design.md.
+  -- DEFERRED: β-inst, β-reveal-∀, and β-conceal-∀ are validated in
+  -- alt.Exchange but remain absent here pending user sign-off.
 
   ξ-·₁ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {L L′ M : Term Δ}
@@ -333,8 +275,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
 
   ξ-reveal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {M M′ : Term (suc Δ)}
-      {A : Ty (suc Δ)} {B : Ty Δ} {X : TyVar (suc Δ)}
-      {α : Name} {R : Ty n} {c : Conv↑ (suc Δ) A (wkᵗ X B)}
+      {X : TyVar (suc Δ)} {α : Name} {R : Ty n} {c : Conv↑}
     → (p : α ⦂ R ∈ Σ)
     → Σ ∣ insertBinding X (anchored (lookup-name p)) κ
         ⊢ M —→[ χ ] M′
@@ -343,8 +284,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
 
   ξ-conceal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {M M′ : Term Δ}
-      {A : Ty Δ} {B : Ty (suc Δ)} {X : TyVar (suc Δ)}
-      {α : Name} {R : Ty n} {c : Conv↓ (suc Δ) (wkᵗ X A) B}
+      {X : TyVar (suc Δ)} {α : Name} {R : Ty n} {c : Conv↓}
     → (p : α ⦂ R ∈ Σ)
     → Σ ∣ κ ⊢ M —→[ χ ] M′
     → Σ ∣ insertBinding X (anchored (lookup-name p)) κ

--- a/GTSFImp/alt/Reduction.agda
+++ b/GTSFImp/alt/Reduction.agda
@@ -1,0 +1,392 @@
+module alt.Reduction where
+
+-- File Charter:
+--   * Defines shift-free call-by-value reduction for alt.Terms.
+--   * Store allocation changes only the global store; the term type context
+--     is fixed by every step and evaluation frames leave siblings untouched.
+--   * Provides store-indexed multi-step traces and anchored tag comparison.
+
+open import Data.Fin using (inject₁; zero)
+open import Data.Nat using (ℕ; suc)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types
+open import Consistency
+open import Primitives
+open import alt.Store hiding (bind)
+open import alt.Conversion
+open import alt.Terms
+
+------------------------------------------------------------------------
+-- Store changes
+------------------------------------------------------------------------
+
+data StoreΔ : ℕ → ℕ → Set where
+  keep : ∀ {n} → StoreΔ n n
+  bind : ∀ {n} → Ty n → StoreΔ n (suc n)
+
+applyStore : ∀ {n n′} → StoreΔ n n′ → Store n → Store n′
+applyStore keep Σ = Σ
+applyStore (bind R) Σ = alt.Store.bind Σ R
+
+applyBinding : ∀ {n n′} → StoreΔ n n′ → Binding n → Binding n′
+applyBinding keep ∀-bound = ∀-bound
+applyBinding keep (anchored α) = anchored α
+applyBinding (bind R) ∀-bound = ∀-bound
+applyBinding (bind R) (anchored α) = anchored (inject₁ α)
+
+applyBindings : ∀ {n n′ Δ}
+  → StoreΔ n n′
+  → Bindings Δ n
+  → Bindings Δ n′
+applyBindings χ κ X = applyBinding χ (κ X)
+
+data StoreΔs : ℕ → ℕ → Set where
+  [] : ∀ {n} → StoreΔs n n
+  _∷_ : ∀ {n n′ n″}
+    → StoreΔ n n′
+    → StoreΔs n′ n″
+    → StoreΔs n n″
+
+infixr 5 _∷_
+
+applyStores : ∀ {n n′} → StoreΔs n n′ → Store n → Store n′
+applyStores [] Σ = Σ
+applyStores (χ ∷ χs) Σ = applyStores χs (applyStore χ Σ)
+
+applyBindingss : ∀ {n n′ Δ}
+  → StoreΔs n n′
+  → Bindings Δ n
+  → Bindings Δ n′
+applyBindingss [] κ = κ
+applyBindingss (χ ∷ χs) κ = applyBindingss χs (applyBindings χ κ)
+
+------------------------------------------------------------------------
+-- Ground-tag comparison through anchors
+------------------------------------------------------------------------
+
+data TagMatch {Δ n} (κ : Bindings Δ n) : Ty Δ → Ty Δ → Set where
+  match-var : ∀ {X Y α}
+    → κ X ≡ anchored α
+    → κ Y ≡ anchored α
+    → TagMatch κ (＇ X) (＇ Y)
+
+  match-base : ∀ {ι}
+    → TagMatch κ (‵ ι) (‵ ι)
+
+  match-fun : TagMatch κ (★ ⇒ ★) (★ ⇒ ★)
+
+  match-all : TagMatch κ (`∀ ★) (`∀ ★)
+
+data TagMismatch {Δ n} (κ : Bindings Δ n) : Ty Δ → Ty Δ → Set where
+  mismatch-var : ∀ {X Y α β}
+    → κ X ≡ anchored α
+    → κ Y ≡ anchored β
+    → α ≢ β
+    → TagMismatch κ (＇ X) (＇ Y)
+
+  mismatch-var-base : ∀ {X ι}
+    → TagMismatch κ (＇ X) (‵ ι)
+  mismatch-var-fun : ∀ {X}
+    → TagMismatch κ (＇ X) (★ ⇒ ★)
+  mismatch-var-all : ∀ {X}
+    → TagMismatch κ (＇ X) (`∀ ★)
+
+  mismatch-base-var : ∀ {ι X}
+    → TagMismatch κ (‵ ι) (＇ X)
+  mismatch-base : ∀ {ι ι′}
+    → ι ≢ ι′
+    → TagMismatch κ (‵ ι) (‵ ι′)
+  mismatch-base-fun : ∀ {ι}
+    → TagMismatch κ (‵ ι) (★ ⇒ ★)
+  mismatch-base-all : ∀ {ι}
+    → TagMismatch κ (‵ ι) (`∀ ★)
+
+  mismatch-fun-var : ∀ {X}
+    → TagMismatch κ (★ ⇒ ★) (＇ X)
+  mismatch-fun-base : ∀ {ι}
+    → TagMismatch κ (★ ⇒ ★) (‵ ι)
+  mismatch-fun-all : TagMismatch κ (★ ⇒ ★) (`∀ ★)
+
+  mismatch-all-var : ∀ {X}
+    → TagMismatch κ (`∀ ★) (＇ X)
+  mismatch-all-base : ∀ {ι}
+    → TagMismatch κ (`∀ ★) (‵ ι)
+  mismatch-all-fun : TagMismatch κ (`∀ ★) (★ ⇒ ★)
+
+------------------------------------------------------------------------
+-- One-step reduction
+------------------------------------------------------------------------
+
+infix 2 _∣_⊢_—→[_]_
+
+data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
+    → Store n
+    → Bindings Δ n
+    → Term Δ
+    → StoreΔ n n′
+    → Term Δ
+    → Set where
+
+  δ-⊕ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {op κ₁ κ₂ κ₃}
+    → δ op κ₁ κ₂ κ₃
+    → Σ ∣ κ ⊢ $ κ₁ ⊕[ op ] $ κ₂ —→[ keep ] $ κ₃
+
+  -- DEVIATION: the ordinary lambda beta rule is omitted.  The old untyped
+  -- substitution cannot cross a conceal anti-binder: its replacement term
+  -- lives in the larger scope and need not be removable at the concealed
+  -- slot.  See "Mechanization notes" in alt/Design.md.
+
+  β-id : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ : Env∼ Δ} {A : Ty Δ} {a : Atom A}
+    → Value V
+    → Σ ∣ κ ⊢ V ⟨ id {μ = μ} a ⟩ —→[ keep ] V
+
+  β-⇒ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V W : Term Δ} {μ : Env∼ Δ} {A A′ B B′ : Ty Δ}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
+    → Value V
+    → Value W
+    → Σ ∣ κ ⊢ (V ⟨ c ↦ d ⟩) · W —→[ keep ]
+        (V · (W ⟨ c ⟩)) ⟨ d ⟩
+
+  β-∀ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ : Env∼ Δ} {A B : Ty (suc Δ)} {C : Ty Δ}
+      {c : extᵐ μ ⊢ A ∼ B} {d : μ ⊢ A [ C ]ᵗ ∼ B [ C ]ᵗ}
+    → Value V
+    → d ≡ c [ C ]ᶜ
+    → Σ ∣ κ ⊢ (V ⟨ ∀ᶜ c ⟩) ⦂∀ B [ C ] —→[ keep ]
+        (V ⦂∀ A [ C ]) ⟨ d ⟩
+
+  ground : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ : Env∼ Δ} {A G : Ty Δ}
+      ⦃ Gᵍ : Ground G ⦄ ⦃ G∼★ : μ ⊢ G ∼★ ⦄
+      {c : μ ⊢ A ∼ G} ⦃ Ans : NonStar A ⦄ ⦃ Gns : NonStar G ⦄
+    → Value V
+    → A ≢ G
+    → Σ ∣ κ ⊢ V ⟨ c ! ⟩ —→[ keep ]
+        V ⟨ c ⟩ ⟨ (idᵍ Gᵍ) ! ⟩
+
+  expand : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ : Env∼ Δ} {G B : Ty Δ}
+      ⦃ Gᵍ : Ground G ⦄ ⦃ ★∼G : μ ⊢★∼ G ⦄
+      {c : μ ⊢ G ∼ B} ⦃ Bns : NonStar B ⦄ ⦃ Gns : NonStar G ⦄
+    → Value V
+    → G ≢ B
+    → Σ ∣ κ ⊢ V ⟨ ？ c ⟩ —→[ keep ]
+        V ⟨ ？ (idᵍ Gᵍ) ⟩ ⟨ c ⟩
+
+  tag-untag : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ ν : Env∼ Δ} {G H : Ty Δ}
+      ⦃ Gᵍ : Ground G ⦄ ⦃ Hᵍ : Ground H ⦄
+      ⦃ G∼★ : μ ⊢ G ∼★ ⦄ ⦃ ★∼H : ν ⊢★∼ H ⦄
+      ⦃ Gns : NonStar G ⦄ ⦃ Hns : NonStar H ⦄
+    → Value V
+    → TagMatch κ G H
+    → Σ ∣ κ ⊢ V ⟨ (idᵍ Gᵍ) ! ⟩ ⟨ ？ (idᵍ Hᵍ) ⟩
+        —→[ keep ] V
+
+  tag-untag-bad : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ ν : Env∼ Δ} {G H : Ty Δ}
+      ⦃ Gᵍ : Ground G ⦄ ⦃ Hᵍ : Ground H ⦄
+      ⦃ G∼★ : μ ⊢ G ∼★ ⦄ ⦃ ★∼H : ν ⊢★∼ H ⦄
+      ⦃ Gns : NonStar G ⦄ ⦃ Hns : NonStar H ⦄
+    → Value V
+    → TagMismatch κ G H
+    → Σ ∣ κ ⊢ V ⟨ (idᵍ Gᵍ) ! ⟩ ⟨ ？ (idᵍ Hᵍ) ⟩
+        —→[ keep ] blame
+
+  blame-bot-intro : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ : Env∼ Δ}
+    → Value V
+    → Σ ∣ κ ⊢ V ⟨ bot-intro {μ = μ} ⟩ —→[ keep ] blame
+
+  β-reveal-⇒ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term (suc Δ)} {W : Term Δ} {A₀ B₀ : Ty Δ}
+      {A B : Ty (suc Δ)}
+      {X : TyVar (suc Δ)} {α : Name}
+      {c : Conv↓ (suc Δ) (wkᵗ X A₀) A}
+      {d : Conv↑ (suc Δ) B (wkᵗ X B₀)}
+    → Value V
+    → Value W
+    → Σ ∣ κ ⊢ (V ↑⟨ X ≔ α ⟩ (c ↦↑ d)) · W —→[ keep ]
+        (V · (W ↓⟨ X ≔ α ⟩ c)) ↑⟨ X ≔ α ⟩ d
+
+  β-conceal-⇒ : ∀ {n Δ} {Σ : Store n}
+      {κ : Bindings (suc Δ) n}
+      {V : Term Δ} {W : Term (suc Δ)} {A₀ B₀ : Ty Δ}
+      {A′ B′ : Ty (suc Δ)}
+      {X : TyVar (suc Δ)} {α : Name}
+      {c : Conv↑ (suc Δ) A′ (wkᵗ X A₀)}
+      {d : Conv↓ (suc Δ) (wkᵗ X B₀) B′}
+    → Value V
+    → Value W
+    → Σ ∣ κ ⊢ (V ↓⟨ X ≔ α ⟩ (c ↦↓ d)) · W —→[ keep ]
+        (V · (W ↑⟨ X ≔ α ⟩ c)) ↓⟨ X ≔ α ⟩ d
+
+  id-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {X : TyVar (suc Δ)} {α : Name} {ι κ₀}
+    → Σ ∣ κ ⊢ ($ κ₀) ↑⟨ X ≔ α ⟩ id↑ (‵ ι)
+        —→[ keep ] $ κ₀
+
+  conceal-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {A : Ty Δ} {X : TyVar (suc Δ)} {α : Name}
+    → Value V
+    → Σ ∣ κ ⊢
+        (V ↓⟨ X ≔ α ⟩ alt.Conversion.seal X (wkᵗ X A))
+          ↑⟨ X ≔ α ⟩ unseal X (wkᵗ X A)
+        —→[ keep ] V
+
+  blame-·₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {M : Term Δ}
+    → Σ ∣ κ ⊢ blame · M —→[ keep ] blame
+
+  blame-·₂ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ}
+    → Value V
+    → Σ ∣ κ ⊢ V · blame —→[ keep ] blame
+
+  blame-• : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {A : Ty Δ} {B : Ty (suc Δ)}
+    → Σ ∣ κ ⊢ blame ⦂∀ B [ A ] —→[ keep ] blame
+
+  blame-⟨⟩ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {μ : Env∼ Δ} {A B : Ty Δ} {c : μ ⊢ A ∼ B}
+    → Σ ∣ κ ⊢ blame ⟨ c ⟩ —→[ keep ] blame
+
+  blame-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {A : Ty (suc Δ)} {B : Ty Δ} {X : TyVar (suc Δ)}
+      {α : Name} {c : Conv↑ (suc Δ) A (wkᵗ X B)}
+    → Σ ∣ κ ⊢ blame ↑⟨ X ≔ α ⟩ c —→[ keep ] blame
+
+  blame-conceal : ∀ {n Δ} {Σ : Store n} {κ : Bindings (suc Δ) n}
+      {A : Ty Δ} {B : Ty (suc Δ)} {X : TyVar (suc Δ)}
+      {α : Name} {c : Conv↓ (suc Δ) (wkᵗ X A) B}
+    → Σ ∣ κ ⊢ blame ↓⟨ X ≔ α ⟩ c —→[ keep ] blame
+
+  blame-⊕₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {M : Term Δ} {op : Prim}
+    → Σ ∣ κ ⊢ blame ⊕[ op ] M —→[ keep ] blame
+
+  blame-⊕₂ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {op : Prim}
+    → Value V
+    → Σ ∣ κ ⊢ V ⊕[ op ] blame —→[ keep ] blame
+
+  -- DEVIATION: β-Λ accepts the already endpoint-correct crossing
+  -- conversion as data.  The literal generator has an extensionally equal
+  -- endpoint whose equality to wkᵗ zero (B [ A ]ᵗ) is not definitional.
+  β-Λ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {A : Ty Δ} {B : Ty (suc Δ)} {R : Ty n}
+      {V : Term (suc Δ)}
+      {d : Conv↑ (suc Δ) B (wkᵗ zero (B [ A ]ᵗ))}
+    → Value V
+    → Transport (BindingRel κ) A R
+    → Σ ∣ κ ⊢ (Λ V) ⦂∀ B [ A ] —→[ bind R ]
+        V ↑⟨ zero ≔ n ⟩ d
+
+  -- DEVIATION: as for β-Λ, β-gen takes the endpoint-correct exit
+  -- conversion as data.  Its entry delimiter is explicit and no term is
+  -- renamed when the store grows.
+  β-gen : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V : Term Δ} {μ : Env∼ Δ} {A C : Ty Δ} {B : Ty (suc Δ)}
+      {R : Ty n} {c : genᵐ μ ⊢ ⇑ᵗ A ∼ B}
+      {d : Conv↑ (suc Δ) B (wkᵗ zero (B [ C ]ᵗ))}
+      ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : zero ∈ᵗ B ⦄
+    → Value V
+    → (A≢★ : A ≢ ★)
+    → GenSafe c
+    → Transport (BindingRel κ) C R
+    → Σ ∣ κ ⊢ (V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ]
+        —→[ bind R ]
+        ((V ↓⟨ zero ≔ n ⟩ delimiter↓ (⇑ᵗ A)) ⟨ c ⟩)
+          ↑⟨ zero ≔ n ⟩ d
+
+  -- DEVIATION: β-inst, β-reveal-∀, and β-conceal-∀ are omitted.  Their
+  -- source forall slot and crossing slot require a typed exchange operation
+  -- not present in the settled syntax.  See alt/Design.md.
+
+  ξ-·₁ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {L L′ M : Term Δ}
+    → Σ ∣ κ ⊢ L —→[ χ ] L′
+    → Σ ∣ κ ⊢ L · M —→[ χ ] L′ · M
+
+  ξ-·₂ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {V M M′ : Term Δ}
+    → Value V
+    → Σ ∣ κ ⊢ M —→[ χ ] M′
+    → Σ ∣ κ ⊢ V · M —→[ χ ] V · M′
+
+  ξ-• : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {M M′ : Term Δ}
+      {A : Ty Δ} {B : Ty (suc Δ)}
+    → Σ ∣ κ ⊢ M —→[ χ ] M′
+    → Σ ∣ κ ⊢ M ⦂∀ B [ A ] —→[ χ ] M′ ⦂∀ B [ A ]
+
+  ξ-⟨⟩ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {M M′ : Term Δ} {μ : Env∼ Δ}
+      {A B : Ty Δ} {c : μ ⊢ A ∼ B}
+    → Σ ∣ κ ⊢ M —→[ χ ] M′
+    → Σ ∣ κ ⊢ M ⟨ c ⟩ —→[ χ ] M′ ⟨ c ⟩
+
+  ξ-reveal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {M M′ : Term (suc Δ)}
+      {A : Ty (suc Δ)} {B : Ty Δ} {X : TyVar (suc Δ)}
+      {α : Name} {R : Ty n} {c : Conv↑ (suc Δ) A (wkᵗ X B)}
+    → (p : α ⦂ R ∈ Σ)
+    → Σ ∣ insertBinding X (anchored (lookup-name p)) κ
+        ⊢ M —→[ χ ] M′
+    → Σ ∣ κ ⊢ M ↑⟨ X ≔ α ⟩ c
+        —→[ χ ] M′ ↑⟨ X ≔ α ⟩ c
+
+  ξ-conceal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {M M′ : Term Δ}
+      {A : Ty Δ} {B : Ty (suc Δ)} {X : TyVar (suc Δ)}
+      {α : Name} {R : Ty n} {c : Conv↓ (suc Δ) (wkᵗ X A) B}
+    → (p : α ⦂ R ∈ Σ)
+    → Σ ∣ κ ⊢ M —→[ χ ] M′
+    → Σ ∣ insertBinding X (anchored (lookup-name p)) κ
+        ⊢ M ↓⟨ X ≔ α ⟩ c —→[ χ ] M′ ↓⟨ X ≔ α ⟩ c
+
+  ξ-⊕₁ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {L L′ M : Term Δ} {op : Prim}
+    → Σ ∣ κ ⊢ L —→[ χ ] L′
+    → Σ ∣ κ ⊢ L ⊕[ op ] M —→[ χ ] L′ ⊕[ op ] M
+
+  ξ-⊕₂ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {χ : StoreΔ n n′} {V M M′ : Term Δ} {op : Prim}
+    → Value V
+    → Σ ∣ κ ⊢ M —→[ χ ] M′
+    → Σ ∣ κ ⊢ V ⊕[ op ] M —→[ χ ] V ⊕[ op ] M′
+
+  -- DEFERRED: merge rule
+
+------------------------------------------------------------------------
+-- Multi-step reduction
+------------------------------------------------------------------------
+
+infix 2 _∣_⊢_—↠[_]_
+
+data _∣_⊢_—↠[_]_ : ∀ {n Δ n′}
+    → Store n
+    → Bindings Δ n
+    → Term Δ
+    → StoreΔs n n′
+    → Term Δ
+    → Set where
+  ↠-refl : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n} {M : Term Δ}
+    → Σ ∣ κ ⊢ M —↠[ [] ] M
+
+  ↠-step : ∀ {n n′ n″ Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {M N P : Term Δ} {χ : StoreΔ n n′} {χs : StoreΔs n′ n″}
+    → Σ ∣ κ ⊢ M —→[ χ ] N
+    → applyStore χ Σ ∣ applyBindings χ κ ⊢ N —↠[ χs ] P
+    → Σ ∣ κ ⊢ M —↠[ χ ∷ χs ] P
+
+infix 3 _∎[]
+pattern _∎[] M = ↠-refl {M = M}
+
+infixr 2 _—→[_]⟨_⟩_
+pattern _—→[_]⟨_⟩_ L χ L—→M M—↠N =
+  ↠-step {M = L} {χ = χ} L—→M M—↠N

--- a/GTSFImp/alt/Reduction.agda
+++ b/GTSFImp/alt/Reduction.agda
@@ -211,8 +211,8 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
       {d : Conv↑ (suc Δ) B (wkᵗ X B₀)}
     → Value V
     → Value W
-    → Σ ∣ κ ⊢ (V ↑⟨ X ≔ α ⟩ (c ↦↑ d)) · W —→[ keep ]
-        (V · (W ↓⟨ X ≔ α ⟩ c)) ↑⟨ X ≔ α ⟩ d
+    → Σ ∣ κ ⊢ (V ↑[ X ≔ α ] (c ↦↑ d)) · W —→[ keep ]
+        (V · (W ↓[ X ≔ α ] c)) ↑[ X ≔ α ] d
 
   β-conceal-⇒ : ∀ {n Δ} {Σ : Store n}
       {κ : Bindings (suc Δ) n}
@@ -223,20 +223,20 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
       {d : Conv↓ (suc Δ) (wkᵗ X B₀) B′}
     → Value V
     → Value W
-    → Σ ∣ κ ⊢ (V ↓⟨ X ≔ α ⟩ (c ↦↓ d)) · W —→[ keep ]
-        (V · (W ↑⟨ X ≔ α ⟩ c)) ↓⟨ X ≔ α ⟩ d
+    → Σ ∣ κ ⊢ (V ↓[ X ≔ α ] (c ↦↓ d)) · W —→[ keep ]
+        (V · (W ↑[ X ≔ α ] c)) ↓[ X ≔ α ] d
 
   id-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {X : TyVar (suc Δ)} {α : Name} {ι κ₀}
-    → Σ ∣ κ ⊢ ($ κ₀) ↑⟨ X ≔ α ⟩ id↑ (‵ ι)
+    → Σ ∣ κ ⊢ ($ κ₀) ↑[ X ≔ α ] id↑ (‵ ι)
         —→[ keep ] $ κ₀
 
   conceal-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {V : Term Δ} {A : Ty Δ} {X : TyVar (suc Δ)} {α : Name}
     → Value V
     → Σ ∣ κ ⊢
-        (V ↓⟨ X ≔ α ⟩ alt.Conversion.seal X (wkᵗ X A))
-          ↑⟨ X ≔ α ⟩ unseal X (wkᵗ X A)
+        (V ↓[ X ≔ α ] alt.Conversion.seal X (wkᵗ X A))
+          ↑[ X ≔ α ] unseal X (wkᵗ X A)
         —→[ keep ] V
 
   blame-·₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
@@ -259,12 +259,12 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
   blame-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {A : Ty (suc Δ)} {B : Ty Δ} {X : TyVar (suc Δ)}
       {α : Name} {c : Conv↑ (suc Δ) A (wkᵗ X B)}
-    → Σ ∣ κ ⊢ blame ↑⟨ X ≔ α ⟩ c —→[ keep ] blame
+    → Σ ∣ κ ⊢ blame ↑[ X ≔ α ] c —→[ keep ] blame
 
   blame-conceal : ∀ {n Δ} {Σ : Store n} {κ : Bindings (suc Δ) n}
       {A : Ty Δ} {B : Ty (suc Δ)} {X : TyVar (suc Δ)}
       {α : Name} {c : Conv↓ (suc Δ) (wkᵗ X A) B}
-    → Σ ∣ κ ⊢ blame ↓⟨ X ≔ α ⟩ c —→[ keep ] blame
+    → Σ ∣ κ ⊢ blame ↓[ X ≔ α ] c —→[ keep ] blame
 
   blame-⊕₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {M : Term Δ} {op : Prim}
@@ -285,7 +285,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Value V
     → Transport (BindingRel κ) A R
     → Σ ∣ κ ⊢ (Λ V) ⦂∀ B [ A ] —→[ bind R ]
-        V ↑⟨ zero ≔ n ⟩ d
+        V ↑[ zero ≔ n ] d
 
   -- DEVIATION: as for β-Λ, β-gen takes the endpoint-correct exit
   -- conversion as data.  Its entry delimiter is explicit and no term is
@@ -301,8 +301,8 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Transport (BindingRel κ) C R
     → Σ ∣ κ ⊢ (V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ]
         —→[ bind R ]
-        ((V ↓⟨ zero ≔ n ⟩ δ↓ (⇑ᵗ A)) ⟨ c ⟩)
-          ↑⟨ zero ≔ n ⟩ d
+        ((V ↓[ zero ≔ n ] δ↓ (⇑ᵗ A)) ⟨ c ⟩)
+          ↑[ zero ≔ n ] d
 
   -- DEVIATION: β-inst, β-reveal-∀, and β-conceal-∀ are omitted.  Their
   -- source forall slot and crossing slot require a typed exchange operation
@@ -338,8 +338,8 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → (p : α ⦂ R ∈ Σ)
     → Σ ∣ insertBinding X (anchored (lookup-name p)) κ
         ⊢ M —→[ χ ] M′
-    → Σ ∣ κ ⊢ M ↑⟨ X ≔ α ⟩ c
-        —→[ χ ] M′ ↑⟨ X ≔ α ⟩ c
+    → Σ ∣ κ ⊢ M ↑[ X ≔ α ] c
+        —→[ χ ] M′ ↑[ X ≔ α ] c
 
   ξ-conceal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {M M′ : Term Δ}
@@ -348,7 +348,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → (p : α ⦂ R ∈ Σ)
     → Σ ∣ κ ⊢ M —→[ χ ] M′
     → Σ ∣ insertBinding X (anchored (lookup-name p)) κ
-        ⊢ M ↓⟨ X ≔ α ⟩ c —→[ χ ] M′ ↓⟨ X ≔ α ⟩ c
+        ⊢ M ↓[ X ≔ α ] c —→[ χ ] M′ ↓[ X ≔ α ] c
 
   ξ-⊕₁ : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {L L′ M : Term Δ} {op : Prim}

--- a/GTSFImp/alt/Reduction.agda
+++ b/GTSFImp/alt/Reduction.agda
@@ -4,6 +4,7 @@ module alt.Reduction where
 --   * Defines shift-free call-by-value reduction for alt.Terms.
 --   * Store allocation changes only the global store; the term type context
 --     is fixed by every step and evaluation frames leave siblings untouched.
+--   * Restores ordinary beta with annotated, type-directed substitution.
 --   * Provides store-indexed multi-step traces and anchored tag comparison.
 
 open import Data.Fin using (inject₁; zero)
@@ -133,10 +134,10 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → δ op κ₁ κ₂ κ₃
     → Σ ∣ κ ⊢ $ κ₁ ⊕[ op ] $ κ₂ —→[ keep ] $ κ₃
 
-  -- DEVIATION: the ordinary lambda beta rule is omitted.  The old untyped
-  -- substitution cannot cross a conceal anti-binder: its replacement term
-  -- lives in the larger scope and need not be removable at the concealed
-  -- slot.  See "Mechanization notes" in alt/Design.md.
+  β : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
+      {V N : Term Δ} {A : Ty Δ}
+    → Value V
+    → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ⦂ A ]
 
   β-id : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {V : Term Δ} {μ : Env∼ Δ} {A : Ty Δ} {a : Atom A}
@@ -300,7 +301,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Transport (BindingRel κ) C R
     → Σ ∣ κ ⊢ (V ⟨ (gen c) A≢★ ⟩) ⦂∀ B [ C ]
         —→[ bind R ]
-        ((V ↓⟨ zero ≔ n ⟩ delimiter↓ (⇑ᵗ A)) ⟨ c ⟩)
+        ((V ↓⟨ zero ≔ n ⟩ δ↓ (⇑ᵗ A)) ⟨ c ⟩)
           ↑⟨ zero ≔ n ⟩ d
 
   -- DEVIATION: β-inst, β-reveal-∀, and β-conceal-∀ are omitted.  Their

--- a/GTSFImp/alt/Reduction.agda
+++ b/GTSFImp/alt/Reduction.agda
@@ -152,7 +152,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
   β-reveal-⇒ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {V : Term (suc Δ)} {W : Term Δ}
       {X : TyVar (suc Δ)} {α : Name}
-      {c : Conv↓} {d : Conv↑}
+      {c : Conceal} {d : Reveal}
     → Value V
     → Value W
     → Σ ∣ κ ⊢ (V ↑[ X ≔ α ] (c ↦↑ d)) · W —→[ keep ]
@@ -162,7 +162,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
       {κ : Bindings (suc Δ) n}
       {V : Term Δ} {W : Term (suc Δ)}
       {X : TyVar (suc Δ)} {α : Name}
-      {c : Conv↑} {d : Conv↓}
+      {c : Reveal} {d : Conceal}
     → Value V
     → Value W
     → Σ ∣ κ ⊢ (V ↓[ X ≔ α ] (c ↦↓ d)) · W —→[ keep ]
@@ -210,11 +210,11 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
     → Σ ∣ κ ⊢ blame ⟨ c ⟩ —→[ keep ] blame
 
   blame-reveal : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
-      {X : TyVar (suc Δ)} {α : Name} {c : Conv↑}
+      {X : TyVar (suc Δ)} {α : Name} {c : Reveal}
     → Σ ∣ κ ⊢ blame ↑[ X ≔ α ] c —→[ keep ] blame
 
   blame-conceal : ∀ {n Δ} {Σ : Store n} {κ : Bindings (suc Δ) n}
-      {X : TyVar (suc Δ)} {α : Name} {c : Conv↓}
+      {X : TyVar (suc Δ)} {α : Name} {c : Conceal}
     → Σ ∣ κ ⊢ blame ↓[ X ≔ α ] c —→[ keep ] blame
 
   blame-⊕₁ : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
@@ -275,7 +275,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
 
   ξ-reveal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {M M′ : Term (suc Δ)}
-      {X : TyVar (suc Δ)} {α : Name} {R : Ty n} {c : Conv↑}
+      {X : TyVar (suc Δ)} {α : Name} {R : Ty n} {c : Reveal}
     → (p : α ⦂ R ∈ Σ)
     → Σ ∣ insertBinding X (anchored (lookup-name p)) κ
         ⊢ M —→[ χ ] M′
@@ -284,7 +284,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
 
   ξ-conceal : ∀ {n n′ Δ} {Σ : Store n} {κ : Bindings Δ n}
       {χ : StoreΔ n n′} {M M′ : Term Δ}
-      {X : TyVar (suc Δ)} {α : Name} {R : Ty n} {c : Conv↓}
+      {X : TyVar (suc Δ)} {α : Name} {R : Ty n} {c : Conceal}
     → (p : α ⦂ R ∈ Σ)
     → Σ ∣ κ ⊢ M —→[ χ ] M′
     → Σ ∣ insertBinding X (anchored (lookup-name p)) κ

--- a/GTSFImp/alt/Reduction.agda
+++ b/GTSFImp/alt/Reduction.agda
@@ -4,7 +4,7 @@ module alt.Reduction where
 --   * Defines shift-free call-by-value reduction for alt.Terms.
 --   * Store allocation changes only the global store; the term type context
 --     is fixed by every step and evaluation frames leave siblings untouched.
---   * Restores ordinary beta with annotated, type-directed substitution.
+--   * Restores ordinary beta with annotated, structural substitution.
 --   * Provides store-indexed multi-step traces and anchored tag comparison.
 
 open import Data.Fin using (inject₁; zero)
@@ -137,7 +137,7 @@ data _∣_⊢_—→[_]_ : ∀ {n Δ n′}
   β : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {V N : Term Δ} {A : Ty Δ}
     → Value V
-    → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ⦂ A ]
+    → Σ ∣ κ ⊢ (ƛ A ˙ N) · V —→[ keep ] N [ V ]
 
   β-id : ∀ {n Δ} {Σ : Store n} {κ : Bindings Δ n}
       {V : Term Δ} {μ : Env∼ Δ} {A : Ty Δ} {a : Atom A}

--- a/GTSFImp/alt/Store.agda
+++ b/GTSFImp/alt/Store.agda
@@ -1,0 +1,49 @@
+module alt.Store where
+
+-- File Charter:
+--   * Defines the append-only store of runtime type names.
+--   * Store entries are scoped only by names allocated earlier in the store.
+--   * Lookup exposes entries weakened to the current store length; appending
+--     weakens existing lookups without traversing any term.
+
+open import Data.Fin using (Fin; fromℕ; inject₁)
+open import Data.Nat using (ℕ; suc)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types
+
+Name : Set
+Name = ℕ
+
+data Store : ℕ → Set where
+  empty : Store 0
+  bind : ∀ {n} → Store n → Ty n → Store (suc n)
+
+infix 4 _⦂_∈_
+
+data _⦂_∈_ : ∀ {n} → Name → Ty n → Store n → Set where
+  here : ∀ {n} {Σ : Store n} {R : Ty n} {S : Ty (suc n)}
+    → S ≡ ⇑ᵗ R
+      -------------------
+    → n ⦂ S ∈ bind Σ R
+
+  there : ∀ {n α} {Σ : Store n} {R A : Ty n} {B : Ty (suc n)}
+    → α ⦂ A ∈ Σ
+    → B ≡ ⇑ᵗ A
+      -------------------
+    → α ⦂ B ∈ bind Σ R
+
+lookup-name : ∀ {n α} {Σ : Store n} {R : Ty n}
+  → α ⦂ R ∈ Σ
+  → Fin n
+lookup-name (here refl) = fromℕ _
+lookup-name (there p refl) = inject₁ (lookup-name p)
+
+weaken-lookup : ∀ {n α} {Σ : Store n} {R A : Ty n}
+  → α ⦂ A ∈ Σ
+  → α ⦂ ⇑ᵗ A ∈ bind Σ R
+weaken-lookup p = there p refl
+
+fresh-lookup : ∀ {n} {Σ : Store n} {R : Ty n}
+  → n ⦂ ⇑ᵗ R ∈ bind Σ R
+fresh-lookup = here refl

--- a/GTSFImp/alt/Terms.agda
+++ b/GTSFImp/alt/Terms.agda
@@ -14,7 +14,7 @@ open import Data.List using ([]; _∷_)
 open import Data.Nat using (ℕ; zero; suc)
 import Data.Nat.Properties as Nat
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; _≢_; refl; cong; subst; sym; trans)
+  using (_≡_; _≢_; refl)
 open import Relation.Nullary using (yes; no)
 
 open import Types
@@ -55,19 +55,11 @@ data Term : TyCtx → Set where
   _⟨_⟩    : Term Δ → {μ : Env∼ Δ} {A B : Ty Δ}
     → μ ⊢ A ∼ B → Term Δ
 
-  _↑[_≔_]_ : ∀ {A : Ty (suc Δ)} {B : Ty Δ}
-    → Term (suc Δ)
-    → (X : TyVar (suc Δ))
-    → Name
-    → Conv↑ (suc Δ) A (wkᵗ X B)
-    → Term Δ
+  _↑[_≔_]_ : Term (suc Δ)
+    → TyVar (suc Δ) → Name → Conv↑ → Term Δ
 
-  _↓[_≔_]_ : ∀ {A : Ty Δ} {B : Ty (suc Δ)}
-    → Term Δ
-    → (X : TyVar (suc Δ))
-    → Name
-    → Conv↓ (suc Δ) (wkᵗ X A) B
-    → Term (suc Δ)
+  _↓[_≔_]_ : Term Δ
+    → TyVar (suc Δ) → Name → Conv↓ → Term (suc Δ)
 
   blame   : Term Δ
 
@@ -135,27 +127,6 @@ weakenRevealSlot (suc X) zero = zero
 weakenRevealSlot {n = suc n} (suc X) (suc Y) =
   suc (weakenRevealSlot X Y)
 
-reveal-punch-square : ∀ {n} (X Y : Fin (suc n)) (z : Fin n)
-  → punchIn (underReveal X Y) (punchIn Y z)
-    ≡ punchIn (weakenRevealSlot X Y) (punchIn X z)
-reveal-punch-square zero zero z = refl
-reveal-punch-square {n = suc n} zero (suc Y) zero = refl
-reveal-punch-square {n = suc n} zero (suc Y) (suc z) = refl
-reveal-punch-square {n = suc n} (suc X) zero zero = refl
-reveal-punch-square {n = suc n} (suc X) zero (suc z) = refl
-reveal-punch-square {n = suc n} (suc X) (suc Y) zero = refl
-reveal-punch-square {n = suc n} (suc X) (suc Y) (suc z) =
-  cong suc (reveal-punch-square X Y z)
-
-wkᵗ-reveal-square : ∀ {n} (X Y : Fin (suc n)) (A : Ty n)
-  → wkᵗ (underReveal X Y) (wkᵗ Y A)
-    ≡ wkᵗ (weakenRevealSlot X Y) (wkᵗ X A)
-wkᵗ-reveal-square X Y A =
-  trans (renameᵗ-comp (punchIn Y) (punchIn (underReveal X Y)) A)
-    (trans (renameᵗ-cong A (reveal-punch-square X Y))
-      (sym (renameᵗ-comp (punchIn X)
-        (punchIn (weakenRevealSlot X Y)) A)))
-
 -- Commuting an insertion outward across a conceal.  The inserted slot is
 -- placed before the conceal slot when they meet at the same outer gap.
 outsideConceal : ∀ {n}
@@ -171,30 +142,6 @@ weakenConcealSlot (suc X) zero = zero
 weakenConcealSlot {n = suc n} (suc X) (suc Y) =
   suc (weakenConcealSlot X Y)
 
-conceal-punch-square : ∀ {n} (X : Fin (suc (suc n)))
-    (Y : Fin (suc n)) (z : Fin n)
-  → punchIn X (punchIn Y z)
-    ≡ punchIn (weakenConcealSlot X Y) (punchIn (outsideConceal X Y) z)
-conceal-punch-square {n = suc n} zero zero zero = refl
-conceal-punch-square {n = suc n} zero zero (suc z) = refl
-conceal-punch-square {n = suc n} zero (suc Y) zero = refl
-conceal-punch-square {n = suc n} zero (suc Y) (suc z) = refl
-conceal-punch-square {n = suc n} (suc X) zero zero = refl
-conceal-punch-square {n = suc n} (suc X) zero (suc z) = refl
-conceal-punch-square {n = suc n} (suc X) (suc Y) zero = refl
-conceal-punch-square {n = suc n} (suc X) (suc Y) (suc z) =
-  cong suc (conceal-punch-square X Y z)
-
-wkᵗ-conceal-square : ∀ {n} (X : Fin (suc (suc n)))
-    (Y : Fin (suc n)) (A : Ty n)
-  → wkᵗ X (wkᵗ Y A)
-    ≡ wkᵗ (weakenConcealSlot X Y) (wkᵗ (outsideConceal X Y) A)
-wkᵗ-conceal-square X Y A =
-  trans (renameᵗ-comp (punchIn Y) (punchIn X) A)
-    (trans (renameᵗ-cong A (conceal-punch-square X Y))
-      (sym (renameᵗ-comp (punchIn (outsideConceal X Y))
-        (punchIn (weakenConcealSlot X Y)) A)))
-
 weakenᵗᵐ : ∀ {n} (X : TyVar (suc n)) → Term n → Term (suc n)
 weakenᵗᵐ X (` x) = ` x
 weakenᵗᵐ X (ƛ A ˙ M) = ƛ wkᵗ X A ˙ weakenᵗᵐ X M
@@ -206,11 +153,9 @@ weakenᵗᵐ X ($ κ) = $ κ
 weakenᵗᵐ X (L ⊕[ op ] M) = weakenᵗᵐ X L ⊕[ op ] weakenᵗᵐ X M
 weakenᵗᵐ X (M ⟨ c ⟩) = weakenᵗᵐ X M ⟨ weakenConsistency X c ⟩
 weakenᵗᵐ X (M ↑[ Y ≔ α ] c) =
-  weakenᵗᵐ (underReveal X Y) M ↑[ weakenRevealSlot X Y ≔ α ]
-    subst (Conv↑ _ _) (wkᵗ-reveal-square X Y _) (rename↑ _ c)
+  weakenᵗᵐ (underReveal X Y) M ↑[ weakenRevealSlot X Y ≔ α ] c
 weakenᵗᵐ X (M ↓[ Y ≔ α ] c) =
-  weakenᵗᵐ (outsideConceal X Y) M ↓[ weakenConcealSlot X Y ≔ α ]
-    subst (λ A → Conv↓ _ A _) (wkᵗ-conceal-square X Y _) (rename↓ _ c)
+  weakenᵗᵐ (outsideConceal X Y) M ↓[ weakenConcealSlot X Y ≔ α ] c
 weakenᵗᵐ X blame = blame
 
 removeVar : Var → Var → Var
@@ -291,65 +236,83 @@ data Inert : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
     → GenSafe c
     → Inert ((gen c) A≢★)
 
-data RevealValue : ∀ {Δ A B} → Conv↑ Δ A B → Set where
-  fun : ∀ {Δ A A′ B B′}
-      {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
-    → RevealValue (c ↦↑ d)
+mutual
+  data RevealValue {Δ : TyCtx} (V : Term Δ) : Conv↑ → Set where
+    fun : ∀ {c d}
+      → RevealValue V (c ↦↑ d)
 
-  all : ∀ {Δ A B} {c : Conv↑ (suc Δ) A B}
-    → RevealValue (`∀↑ c)
+    all : ∀ {c}
+      → RevealValue V (`∀↑ c)
 
-  delimiter-var : ∀ {Δ} {X : TyVar Δ}
-    → RevealValue (id↑ (＇ X))
+    delimiter : CanonicalInterior V
+      → RevealValue V id↑
 
-  delimiter-star : ∀ {Δ}
-    → RevealValue (id↑ (★ {Δ}))
+  data ConcealValue {Δ : TyCtx} (V : Term Δ) : Conv↓ → Set where
+    seal : ConcealValue V alt.Conversion.seal
 
-data ConcealValue : ∀ {Δ A B} → Conv↓ Δ A B → Set where
-  seal : ∀ {Δ} {X : TyVar Δ} {R : Ty Δ}
-    → ConcealValue (alt.Conversion.seal X R)
+    fun : ∀ {c d}
+      → ConcealValue V (c ↦↓ d)
 
-  fun : ∀ {Δ A A′ B B′}
-      {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
-    → ConcealValue (c ↦↓ d)
+    all : ∀ {c}
+      → ConcealValue V (`∀↓ c)
 
-  all : ∀ {Δ A B} {c : Conv↓ (suc Δ) A B}
-    → ConcealValue (`∀↓ c)
+    delimiter : CanonicalInterior V
+      → ConcealValue V id↓
 
-  delimiter-var : ∀ {Δ} {X : TyVar Δ}
-    → ConcealValue (id↓ (＇ X))
+  data Value : ∀ {Δ : TyCtx} → Term Δ → Set where
+    ƛ_˙_ : ∀ {Δ} (A : Ty Δ) (N : Term Δ) → Value (ƛ A ˙ N)
+    Λ_ : ∀ {Δ} {V : Term (suc Δ)} → Value V → Value (Λ V)
+    $ : ∀ {Δ} (κ : Const) → Value {Δ = Δ} ($ κ)
 
-  delimiter-star : ∀ {Δ}
-    → ConcealValue (id↓ (★ {Δ}))
+    _《_》 : ∀ {Δ} {V : Term Δ} {μ : Env∼ Δ} {A B : Ty Δ}
+        {c : μ ⊢ A ∼ B}
+      → Value V
+      → Inert c
+      → Value (V ⟨ c ⟩)
 
-data Value : ∀ {Δ : TyCtx} → Term Δ → Set where
-  ƛ_˙_ : ∀ {Δ} (A : Ty Δ) (N : Term Δ) → Value (ƛ A ˙ N)
-  Λ_ : ∀ {Δ} {V : Term (suc Δ)} → Value V → Value (Λ V)
-  $ : ∀ {Δ} (κ : Const) → Value {Δ = Δ} ($ κ)
+    _↑[_≔_]_ : ∀ {Δ} {V : Term (suc Δ)}
+      → Value V
+      → (X : TyVar (suc Δ))
+      → (α : Name)
+      → {c : Conv↑}
+      → RevealValue V c
+      → Value (V ↑[ X ≔ α ] c)
 
-  _《_》 : ∀ {Δ} {V : Term Δ} {μ : Env∼ Δ} {A B : Ty Δ}
-      {c : μ ⊢ A ∼ B}
-    → Value V
-    → Inert c
-    → Value (V ⟨ c ⟩)
+    _↓[_≔_]_ : ∀ {Δ} {V : Term Δ}
+      → Value V
+      → (X : TyVar (suc Δ))
+      → (α : Name)
+      → {c : Conv↓}
+      → ConcealValue V c
+      → Value (V ↓[ X ≔ α ] c)
 
-  _↑[_≔_]_ : ∀ {Δ} {V : Term (suc Δ)} {A : Ty (suc Δ)}
-      {B : Ty Δ}
-    → Value V
-    → (X : TyVar (suc Δ))
-    → (α : Name)
-    → {c : Conv↑ (suc Δ) A (wkᵗ X B)}
-    → RevealValue c
-    → Value (V ↑[ X ≔ α ] c)
+  -- These are precisely the syntactic value shapes that can inhabit a
+  -- non-base atomic region interior: a tag at ★, a seal at a scoped
+  -- variable, or another identity reveal delimiter around either shape.
+  data CanonicalInterior : ∀ {Δ : TyCtx} → Term Δ → Set where
+    tagged : ∀ {Δ} {V : Term Δ} {μ : Env∼ Δ} {G : Ty Δ}
+        ⦃ Gᵍ : Ground G ⦄ ⦃ G∼★ : μ ⊢ G ∼★ ⦄
+        ⦃ Gns : NonStar G ⦄
+      → Value V
+      → CanonicalInterior (V ⟨ (idᵍ Gᵍ) ! ⟩)
 
-  _↓[_≔_]_ : ∀ {Δ′ : TyCtx} {V : Term Δ′} {A : Ty Δ′}
-      {B : Ty (suc Δ′)}
-    → Value V
-    → (X : TyVar (suc Δ′))
-    → (α : Name)
-    → {c : Conv↓ (suc Δ′) (wkᵗ X A) B}
-    → ConcealValue c
-    → Value (V ↓[ X ≔ α ] c)
+    sealed : ∀ {Δ} {V : Term Δ}
+      → Value V
+      → (X : TyVar (suc Δ))
+      → (α : Name)
+      → CanonicalInterior (V ↓[ X ≔ α ] alt.Conversion.seal)
+
+    delimited : ∀ {Δ} {V : Term (suc Δ)}
+      → CanonicalInterior V
+      → (X : TyVar (suc Δ))
+      → (α : Name)
+      → CanonicalInterior (V ↑[ X ≔ α ] id↑)
+
+canonical-value : ∀ {Δ} {V : Term Δ} → CanonicalInterior V → Value V
+canonical-value (tagged Vᵥ) = Vᵥ 《 inj 》
+canonical-value (sealed Vᵥ X α) = Vᵥ ↓[ X ≔ α ] seal
+canonical-value (delimited Vᶜ X α) =
+  canonical-value Vᶜ ↑[ X ≔ α ] delimiter Vᶜ
 
 ------------------------------------------------------------------------
 -- Scoped-variable classifications and contexts
@@ -414,49 +377,6 @@ data Transport {Δ n} (ρ : VarRel Δ n) : Ty Δ → Ty n → Set where
   transport-all : ∀ {A B}
     → Transport (LiftRel ρ) A B
     → Transport ρ (`∀ A) (`∀ B)
-
-------------------------------------------------------------------------
--- Every recorded representation denotes the anchor's store entry
-------------------------------------------------------------------------
-
-mutual
-  data Reps↑ {Δ n} (ρ : VarRel Δ n) (S : Ty n) :
-      ∀ {A B} → Conv↑ Δ A B → Set where
-    reps-unseal : ∀ {X R}
-      → Transport ρ R S
-      → Reps↑ ρ S (unseal X R)
-
-    reps-↑⇒ : ∀ {A A′ B B′}
-        {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
-      → Reps↓ ρ S c
-      → Reps↑ ρ S d
-      → Reps↑ ρ S (c ↦↑ d)
-
-    reps-↑∀ : ∀ {A B} {c : Conv↑ (suc Δ) A B}
-      → Reps↑ (LiftRel ρ) (⇑ᵗ S) c
-      → Reps↑ ρ S (`∀↑ c)
-
-    reps-id↑ : ∀ {A} {a : Atom A}
-      → Reps↑ ρ S (id↑ a)
-
-  data Reps↓ {Δ n} (ρ : VarRel Δ n) (S : Ty n) :
-      ∀ {A B} → Conv↓ Δ A B → Set where
-    reps-seal : ∀ {X R}
-      → Transport ρ R S
-      → Reps↓ ρ S (alt.Conversion.seal X R)
-
-    reps-↓⇒ : ∀ {A A′ B B′}
-        {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
-      → Reps↑ ρ S c
-      → Reps↓ ρ S d
-      → Reps↓ ρ S (c ↦↓ d)
-
-    reps-↓∀ : ∀ {A B} {c : Conv↓ (suc Δ) A B}
-      → Reps↓ (LiftRel ρ) (⇑ᵗ S) c
-      → Reps↓ ρ S (`∀↓ c)
-
-    reps-id↓ : ∀ {A} {a : Atom A}
-      → Reps↓ ρ S (id↓ a)
 
 ------------------------------------------------------------------------
 -- Typing
@@ -536,20 +456,18 @@ data _⊢_⦂_ : (Γ : Ctx) → Term (Δᵉ Γ) → Ty (Δᵉ Γ) → Set where
     → (c : μ ⊢ A ∼ B)
     → Γ ⊢ M ⟨ c ⟩ ⦂ B
 
-  ⊢reveal : ∀ {Γ M A B X α R}
-      {c : Conv↑ (suc (Δᵉ Γ)) A (wkᵗ X B)}
+  ⊢reveal : ∀ {Γ M A B X α R R′ c}
     → (p : α ⦂ R ∈ Σᵉ Γ)
-    → PivotStrict↑ X c
-    → Reps↑ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
+    → Transport (BindingRel (κᵉ (cross-ctx Γ X p))) R′ R
+    → ⊢↑[ X ⦂ R′ ] c ⦂ A ↝ wkᵗ X B
     → cross-ctx Γ X p ⊢ M ⦂ A
     → Γ ⊢ M ↑[ X ≔ α ] c ⦂ B
 
   ⊢conceal : ∀ {Γ} {Γ′ : TermCtx (suc (Δᵉ Γ))}
-      {M A B X α R}
-      {c : Conv↓ (suc (Δᵉ Γ)) (wkᵗ X A) B}
+      {M A B X α R R′ c}
     → (p : α ⦂ R ∈ Σᵉ Γ)
-    → PivotStrict↓ X c
-    → Reps↓ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
+    → Transport (BindingRel (κᵉ (cross-ctx Γ X p))) R′ R
+    → ⊢↓[ X ⦂ R′ ] c ⦂ wkᵗ X A ↝ B
     → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ M ⦂ A
     → ⟨ suc (Δᵉ Γ) , sizeᵉ Γ , κᵉ (cross-ctx Γ X p) ,
         Σᵉ Γ , Γ′ ⟩ ⊢ M ↓[ X ≔ α ] c ⦂ B

--- a/GTSFImp/alt/Terms.agda
+++ b/GTSFImp/alt/Terms.agda
@@ -1,0 +1,378 @@
+module alt.Terms where
+
+-- File Charter:
+--   * Defines the shift-free term syntax with anchored reveal binders and
+--     conceal anti-binders.
+--   * Defines values, scoped-variable classifications, representation
+--     transport, and typing against the global append-only store.
+--   * Keeps forall-bound scoped variables out of store representations.
+
+open import Data.Fin using (Fin; zero; suc)
+open import Data.List using (_∷_)
+open import Data.Nat using (ℕ; suc)
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+open import Types
+open import TermCtx
+open import Primitives
+open import Consistency
+open import alt.Store
+open import alt.Conversion
+
+------------------------------------------------------------------------
+-- Terms
+------------------------------------------------------------------------
+
+infix  5 ƛ_
+infixl 7 _·_
+infix  5 Λ_
+infixl 7 _⦂∀_[_]
+infixl 7 _⟨_⟩
+infixl 7 _↑⟨_≔_⟩_ _↓⟨_≔_⟩_
+infixl 6 _⊕[_]_
+infix  9 `_
+
+Var : Set
+Var = ℕ
+
+private
+  variable
+    Δ : TyCtx
+
+data Term : TyCtx → Set where
+  `_      : Var → Term Δ
+  ƛ_      : Term Δ → Term Δ
+  _·_     : Term Δ → Term Δ → Term Δ
+  Λ_      : Term (suc Δ) → Term Δ
+  _⦂∀_[_] : Term Δ → Ty (suc Δ) → Ty Δ → Term Δ
+  $       : Const → Term Δ
+  _⊕[_]_  : Term Δ → Prim → Term Δ → Term Δ
+  _⟨_⟩    : Term Δ → {μ : Env∼ Δ} {A B : Ty Δ}
+    → μ ⊢ A ∼ B → Term Δ
+
+  _↑⟨_≔_⟩_ : ∀ {A : Ty (suc Δ)} {B : Ty Δ}
+    → Term (suc Δ)
+    → (X : TyVar (suc Δ))
+    → Name
+    → Conv↑ (suc Δ) A (wkᵗ X B)
+    → Term Δ
+
+  _↓⟨_≔_⟩_ : ∀ {A : Ty Δ} {B : Ty (suc Δ)}
+    → Term Δ
+    → (X : TyVar (suc Δ))
+    → Name
+    → Conv↓ (suc Δ) (wkᵗ X A) B
+    → Term (suc Δ)
+
+  blame   : Term Δ
+
+------------------------------------------------------------------------
+-- Values
+------------------------------------------------------------------------
+
+data GenSafe : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
+    → μ ⊢ A ∼ B → Set where
+  safe-⇒ : ∀ {Δ μ} {A A′ B B′ : Ty Δ}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
+    → GenSafe (c ↦ d)
+
+  safe-∀ : ∀ {Δ μ} {A B : Ty (suc Δ)}
+      {c : extᵐ μ ⊢ A ∼ B}
+    → GenSafe (∀ᶜ c)
+
+  safe-inst : ∀ {Δ μ} {A : Ty (suc Δ)} {B : Ty Δ}
+      {c : instᵐ μ ⊢ A ∼ ⇑ᵗ B}
+      ⦃ Anv : NonVar A ⦄ ⦃ z∈A : zero ∈ᵗ A ⦄
+    → (B≢★ : B ≢ ★)
+    → GenSafe ((inst c) B≢★)
+
+  safe-gen : ∀ {Δ μ} {A : Ty Δ} {B : Ty (suc Δ)}
+      {c : genᵐ μ ⊢ ⇑ᵗ A ∼ B}
+      ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : zero ∈ᵗ B ⦄
+    → (A≢★ : A ≢ ★)
+    → GenSafe c
+    → GenSafe ((gen c) A≢★)
+
+data Inert : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
+    → μ ⊢ A ∼ B → Set where
+  inj : ∀ {Δ} {μ : Env∼ Δ} {G : Ty Δ}
+      ⦃ Gᵍ : Ground G ⦄ ⦃ G∼★ : μ ⊢ G ∼★ ⦄
+      ⦃ Gns : NonStar G ⦄
+    → Inert {μ = μ} ((idᵍ {μ = μ} Gᵍ) !)
+
+  fun : ∀ {Δ} {μ : Env∼ Δ} {A A′ B B′ : Ty Δ}
+      {c : flipᵐ μ ⊢ A′ ∼ A} {d : μ ⊢ B ∼ B′}
+    → Inert (c ↦ d)
+
+  all : ∀ {Δ} {μ : Env∼ Δ} {A B : Ty (suc Δ)}
+      {c : extᵐ μ ⊢ A ∼ B}
+    → Inert (∀ᶜ c)
+
+  genᵥ : ∀ {Δ} {μ : Env∼ Δ} {A : Ty Δ}
+      {B : Ty (suc Δ)} {c : genᵐ μ ⊢ ⇑ᵗ A ∼ B}
+      ⦃ Bnv : NonVar B ⦄ ⦃ z∈B : zero ∈ᵗ B ⦄
+    → (A≢★ : A ≢ ★)
+    → GenSafe c
+    → Inert ((gen c) A≢★)
+
+data RevealValue : ∀ {Δ A B} → Conv↑ Δ A B → Set where
+  fun : ∀ {Δ A A′ B B′}
+      {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
+    → RevealValue (c ↦↑ d)
+
+  all : ∀ {Δ A B} {c : Conv↑ (suc Δ) A B}
+    → RevealValue (`∀↑ c)
+
+  delimiter-var : ∀ {Δ} {X : TyVar Δ}
+    → RevealValue (id↑ (＇ X))
+
+  delimiter-star : ∀ {Δ}
+    → RevealValue (id↑ (★ {Δ}))
+
+data ConcealValue : ∀ {Δ A B} → Conv↓ Δ A B → Set where
+  seal : ∀ {Δ} {X : TyVar Δ} {R : Ty Δ}
+    → ConcealValue (alt.Conversion.seal X R)
+
+  fun : ∀ {Δ A A′ B B′}
+      {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
+    → ConcealValue (c ↦↓ d)
+
+  all : ∀ {Δ A B} {c : Conv↓ (suc Δ) A B}
+    → ConcealValue (`∀↓ c)
+
+  delimiter-var : ∀ {Δ} {X : TyVar Δ}
+    → ConcealValue (id↓ (＇ X))
+
+  delimiter-star : ∀ {Δ}
+    → ConcealValue (id↓ (★ {Δ}))
+
+data Value : ∀ {Δ : TyCtx} → Term Δ → Set where
+  ƛ_ : ∀ {Δ} (N : Term Δ) → Value (ƛ N)
+  Λ_ : ∀ {Δ} {V : Term (suc Δ)} → Value V → Value (Λ V)
+  $ : ∀ {Δ} (κ : Const) → Value {Δ = Δ} ($ κ)
+
+  _《_》 : ∀ {Δ} {V : Term Δ} {μ : Env∼ Δ} {A B : Ty Δ}
+      {c : μ ⊢ A ∼ B}
+    → Value V
+    → Inert c
+    → Value (V ⟨ c ⟩)
+
+  _↑⟨_≔_⟩_ : ∀ {Δ} {V : Term (suc Δ)} {A : Ty (suc Δ)}
+      {B : Ty Δ}
+    → Value V
+    → (X : TyVar (suc Δ))
+    → (α : Name)
+    → {c : Conv↑ (suc Δ) A (wkᵗ X B)}
+    → RevealValue c
+    → Value (V ↑⟨ X ≔ α ⟩ c)
+
+  _↓⟨_≔_⟩_ : ∀ {Δ′ : TyCtx} {V : Term Δ′} {A : Ty Δ′}
+      {B : Ty (suc Δ′)}
+    → Value V
+    → (X : TyVar (suc Δ′))
+    → (α : Name)
+    → {c : Conv↓ (suc Δ′) (wkᵗ X A) B}
+    → ConcealValue c
+    → Value (V ↓⟨ X ≔ α ⟩ c)
+
+------------------------------------------------------------------------
+-- Scoped-variable classifications and contexts
+------------------------------------------------------------------------
+
+data Binding (n : ℕ) : Set where
+  ∀-bound : Binding n
+  anchored : Fin n → Binding n
+
+Bindings : TyCtx → ℕ → Set
+Bindings Δ n = TyVar Δ → Binding n
+
+insertBinding : ∀ {Δ n}
+  → (X : TyVar (suc Δ))
+  → Binding n
+  → Bindings Δ n
+  → Bindings (suc Δ) n
+insertBinding zero b κ zero = b
+insertBinding zero b κ (suc Y) = κ Y
+insertBinding {Δ = suc Δ} (suc X) b κ zero = κ zero
+insertBinding {Δ = suc Δ} (suc X) b κ (suc Y) =
+  insertBinding X b (λ Z → κ (suc Z)) Y
+
+wkᶜ : ∀ {Δ} → TyVar (suc Δ) → TermCtx Δ → TermCtx (suc Δ)
+wkᶜ X = renameCtx (punchIn X)
+
+------------------------------------------------------------------------
+-- Relational transport from scoped variables to global names
+------------------------------------------------------------------------
+
+VarRel : TyCtx → ℕ → Set₁
+VarRel Δ n = TyVar Δ → Ty n → Set
+
+data BindingRel {Δ n} (κ : Bindings Δ n) : VarRel Δ n where
+  map-anchor : ∀ {X α}
+    → κ X ≡ anchored α
+    → BindingRel κ X (＇ α)
+
+data LiftRel {Δ n} (ρ : VarRel Δ n) : VarRel (suc Δ) (suc n) where
+  map-zero : LiftRel ρ zero (＇ zero)
+
+  map-suc : ∀ {X A B}
+    → ρ X A
+    → B ≡ ⇑ᵗ A
+    → LiftRel ρ (suc X) B
+
+data Transport {Δ n} (ρ : VarRel Δ n) : Ty Δ → Ty n → Set where
+  transport-var : ∀ {X A}
+    → ρ X A
+    → Transport ρ (＇ X) A
+
+  transport-base : ∀ {ι}
+    → Transport ρ (‵ ι) (‵ ι)
+
+  transport-star : Transport ρ ★ ★
+
+  transport-fun : ∀ {A B A′ B′}
+    → Transport ρ A A′
+    → Transport ρ B B′
+    → Transport ρ (A ⇒ B) (A′ ⇒ B′)
+
+  transport-all : ∀ {A B}
+    → Transport (LiftRel ρ) A B
+    → Transport ρ (`∀ A) (`∀ B)
+
+------------------------------------------------------------------------
+-- Every recorded representation denotes the anchor's store entry
+------------------------------------------------------------------------
+
+mutual
+  data Reps↑ {Δ n} (ρ : VarRel Δ n) (S : Ty n) :
+      ∀ {A B} → Conv↑ Δ A B → Set where
+    reps-unseal : ∀ {X R}
+      → Transport ρ R S
+      → Reps↑ ρ S (unseal X R)
+
+    reps-↑⇒ : ∀ {A A′ B B′}
+        {c : Conv↓ Δ A′ A} {d : Conv↑ Δ B B′}
+      → Reps↓ ρ S c
+      → Reps↑ ρ S d
+      → Reps↑ ρ S (c ↦↑ d)
+
+    reps-↑∀ : ∀ {A B} {c : Conv↑ (suc Δ) A B}
+      → Reps↑ (LiftRel ρ) (⇑ᵗ S) c
+      → Reps↑ ρ S (`∀↑ c)
+
+    reps-id↑ : ∀ {A} {a : Atom A}
+      → Reps↑ ρ S (id↑ a)
+
+  data Reps↓ {Δ n} (ρ : VarRel Δ n) (S : Ty n) :
+      ∀ {A B} → Conv↓ Δ A B → Set where
+    reps-seal : ∀ {X R}
+      → Transport ρ R S
+      → Reps↓ ρ S (alt.Conversion.seal X R)
+
+    reps-↓⇒ : ∀ {A A′ B B′}
+        {c : Conv↑ Δ A′ A} {d : Conv↓ Δ B B′}
+      → Reps↑ ρ S c
+      → Reps↓ ρ S d
+      → Reps↓ ρ S (c ↦↓ d)
+
+    reps-↓∀ : ∀ {A B} {c : Conv↓ (suc Δ) A B}
+      → Reps↓ (LiftRel ρ) (⇑ᵗ S) c
+      → Reps↓ ρ S (`∀↓ c)
+
+    reps-id↓ : ∀ {A} {a : Atom A}
+      → Reps↓ ρ S (id↓ a)
+
+------------------------------------------------------------------------
+-- Typing
+------------------------------------------------------------------------
+
+record Ctx : Set where
+  constructor ⟨_,_,_,_,_⟩
+  field
+    Δᵉ : TyCtx
+    sizeᵉ : ℕ
+    κᵉ : Bindings Δᵉ sizeᵉ
+    Σᵉ : Store sizeᵉ
+    Γᵉ : TermCtx Δᵉ
+
+open Ctx public
+
+infixl 5 _,ᶜ_
+
+_,ᶜ_ : (Γ : Ctx) → Ty (Δᵉ Γ) → Ctx
+⟨ Δ , n , κ , Σ , Γ ⟩ ,ᶜ A =
+  ⟨ Δ , n , κ , Σ , A ∷ Γ ⟩
+
+∀-ctx : Ctx → Ctx
+∀-ctx ⟨ Δ , n , κ , Σ , Γ ⟩ =
+  ⟨ suc Δ , n , insertBinding zero ∀-bound κ , Σ , wkᶜ zero Γ ⟩
+
+cross-ctx : (Γ : Ctx) (X : TyVar (suc (Δᵉ Γ))) {α : Name}
+    {R : Ty (sizeᵉ Γ)}
+  → α ⦂ R ∈ Σᵉ Γ
+  → Ctx
+cross-ctx ⟨ Δ , n , κ , Σ , Γ ⟩ X p =
+  ⟨ suc Δ , n , insertBinding X (anchored (lookup-name p)) κ ,
+    Σ , wkᶜ X Γ ⟩
+
+infix 4 _∋ᵗ_⦂_
+infix 4 _⊢_⦂_
+
+_∋ᵗ_⦂_ : (Γ : Ctx) → Var → Ty (Δᵉ Γ) → Set
+Γ ∋ᵗ x ⦂ A = TermCtx._∋_⦂_ (Γᵉ Γ) x A
+
+data _⊢_⦂_ : (Γ : Ctx) → Term (Δᵉ Γ) → Ty (Δᵉ Γ) → Set where
+  ⊢` : ∀ {Γ x A}
+    → Γ ∋ᵗ x ⦂ A
+    → Γ ⊢ (` x) ⦂ A
+
+  ⊢ƛ : ∀ {Γ A B M}
+    → Γ ,ᶜ A ⊢ M ⦂ B
+    → Γ ⊢ (ƛ M) ⦂ (A ⇒ B)
+
+  ⊢· : ∀ {Γ A B L M}
+    → Γ ⊢ L ⦂ (A ⇒ B)
+    → Γ ⊢ M ⦂ A
+    → Γ ⊢ (L · M) ⦂ B
+
+  ⊢Λ : ∀ {Γ A M}
+    → Value M
+    → ∀-ctx Γ ⊢ M ⦂ A
+    → Γ ⊢ (Λ M) ⦂ (`∀ A)
+
+  ⊢• : ∀ {Γ C A L}
+    → Γ ⊢ L ⦂ `∀ C
+    → Γ ⊢ L ⦂∀ C [ A ] ⦂ C [ A ]ᵗ
+
+  ⊢$ : ∀ {Γ} (κ : Const)
+    → Γ ⊢ ($ κ) ⦂ constTy κ
+
+  ⊢⊕ : ∀ {Γ L M}
+    → (op : Prim)
+    → Γ ⊢ L ⦂ primArgTy op
+    → Γ ⊢ M ⦂ primArgTy op
+    → Γ ⊢ (L ⊕[ op ] M) ⦂ primResultTy op
+
+  ⊢⟨⟩ : ∀ {Γ M A B μ}
+    → Γ ⊢ M ⦂ A
+    → (c : μ ⊢ A ∼ B)
+    → Γ ⊢ M ⟨ c ⟩ ⦂ B
+
+  ⊢reveal : ∀ {Γ M A B X α R}
+      {c : Conv↑ (suc (Δᵉ Γ)) A (wkᵗ X B)}
+    → (p : α ⦂ R ∈ Σᵉ Γ)
+    → PivotStrict↑ X c
+    → Reps↑ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
+    → cross-ctx Γ X p ⊢ M ⦂ A
+    → Γ ⊢ M ↑⟨ X ≔ α ⟩ c ⦂ B
+
+  ⊢conceal : ∀ {Γ M A B X α R}
+      {c : Conv↓ (suc (Δᵉ Γ)) (wkᵗ X A) B}
+    → (p : α ⦂ R ∈ Σᵉ Γ)
+    → PivotStrict↓ X c
+    → Reps↓ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
+    → Γ ⊢ M ⦂ A
+    → cross-ctx Γ X p ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
+
+  ⊢blame : ∀ {Γ A}
+    → Γ ⊢ blame ⦂ A

--- a/GTSFImp/alt/Terms.agda
+++ b/GTSFImp/alt/Terms.agda
@@ -5,12 +5,16 @@ module alt.Terms where
 --     conceal anti-binders.
 --   * Defines values, scoped-variable classifications, representation
 --     transport, and typing against the global append-only store.
+--   * Provides annotated lambdas and type-directed single substitution.
 --   * Keeps forall-bound scoped variables out of store representations.
 
 open import Data.Fin using (Fin; zero; suc)
 open import Data.List using (_∷_)
-open import Data.Nat using (ℕ; suc)
-open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+open import Data.Nat using (ℕ; zero; suc)
+import Data.Nat.Properties as Nat
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; cong; subst; sym; trans)
+open import Relation.Nullary using (yes; no)
 
 open import Types
 open import TermCtx
@@ -23,7 +27,7 @@ open import alt.Conversion
 -- Terms
 ------------------------------------------------------------------------
 
-infix  5 ƛ_
+infix  5 ƛ_˙_
 infixl 7 _·_
 infix  5 Λ_
 infixl 7 _⦂∀_[_]
@@ -41,7 +45,7 @@ private
 
 data Term : TyCtx → Set where
   `_      : Var → Term Δ
-  ƛ_      : Term Δ → Term Δ
+  ƛ_˙_    : Ty Δ → Term Δ → Term Δ
   _·_     : Term Δ → Term Δ → Term Δ
   Λ_      : Term (suc Δ) → Term Δ
   _⦂∀_[_] : Term Δ → Ty (suc Δ) → Ty Δ → Term Δ
@@ -65,6 +69,259 @@ data Term : TyCtx → Set where
     → Term (suc Δ)
 
   blame   : Term Δ
+
+------------------------------------------------------------------------
+-- Term-variable renaming
+------------------------------------------------------------------------
+
+Rename : Set
+Rename = Var → Var
+
+ext : Rename → Rename
+ext ρ zero = zero
+ext ρ (suc x) = suc (ρ x)
+
+rename : Rename → Term Δ → Term Δ
+rename ρ (` x) = ` (ρ x)
+rename ρ (ƛ A ˙ M) = ƛ A ˙ rename (ext ρ) M
+rename ρ (L · M) = rename ρ L · rename ρ M
+rename ρ (Λ M) = Λ (rename ρ M)
+rename ρ (L ⦂∀ C [ A ]) = rename ρ L ⦂∀ C [ A ]
+rename ρ ($ κ) = $ κ
+rename ρ (L ⊕[ op ] M) = rename ρ L ⊕[ op ] rename ρ M
+rename ρ (M ⟨ c ⟩) = rename ρ M ⟨ c ⟩
+rename ρ (M ↑⟨ X ≔ α ⟩ c) = rename ρ M ↑⟨ X ≔ α ⟩ c
+rename ρ (M ↓⟨ X ≔ α ⟩ c) = rename ρ M ↓⟨ X ≔ α ⟩ c
+rename ρ blame = blame
+
+------------------------------------------------------------------------
+-- Removing one scoped-variable slot from a tracked type
+------------------------------------------------------------------------
+
+data Unpunch {n : ℕ} (X : Fin (suc n)) : Fin (suc n) → Set where
+  pivot : Unpunch X X
+  image : (Y : Fin n) → Unpunch X (punchIn X Y)
+
+unpunch : ∀ {n} (X Y : Fin (suc n)) → Unpunch X Y
+unpunch zero zero = pivot
+unpunch zero (suc Y) = image Y
+unpunch {n = suc n} (suc X) zero = image zero
+unpunch {n = suc n} (suc X) (suc Y) with unpunch X Y
+unpunch {n = suc n} (suc X) (suc .X) | pivot = pivot
+unpunch {n = suc n} (suc X) (suc .(punchIn X Y)) | image Y =
+  image (suc Y)
+
+data StrengthenedAt {n : ℕ} (X : TyVar (suc n)) :
+    Ty (suc n) → Set where
+  strengthened : (A : Ty n) → StrengthenedAt X (wkᵗ X A)
+  blocked : ∀ {A} → StrengthenedAt X A
+
+wkᵗ-all : ∀ {n} (X : TyVar (suc n)) (A : Ty (suc n))
+  → wkᵗ X (`∀ A) ≡ `∀ (wkᵗ (suc X) A)
+wkᵗ-all X A = cong `∀ (renameᵗ-cong A pointwise)
+  where
+  pointwise : ∀ Y → extᵗ (punchIn X) Y ≡ punchIn (suc X) Y
+  pointwise zero = refl
+  pointwise (suc Y) = refl
+
+strengthenAt : ∀ {n} (X : TyVar (suc n)) (A : Ty (suc n))
+  → StrengthenedAt X A
+strengthenAt X (＇ Y) with unpunch X Y
+strengthenAt X (＇ .X) | pivot = blocked
+strengthenAt X (＇ .(punchIn X Y)) | image Y = strengthened (＇ Y)
+strengthenAt X (‵ ι) = strengthened (‵ ι)
+strengthenAt X ★ = strengthened ★
+strengthenAt X (A ⇒ B) with strengthenAt X A | strengthenAt X B
+strengthenAt X (.(wkᵗ X A) ⇒ .(wkᵗ X B))
+  | strengthened A | strengthened B = strengthened (A ⇒ B)
+strengthenAt X (.(wkᵗ X A) ⇒ B) | strengthened A | blocked = blocked
+strengthenAt X (A ⇒ .(wkᵗ X B)) | blocked | strengthened B = blocked
+strengthenAt X (A ⇒ B) | blocked | blocked = blocked
+strengthenAt X (`∀ A) with strengthenAt (suc X) A
+strengthenAt X (`∀ .(wkᵗ (suc X) A)) | strengthened A =
+  subst (StrengthenedAt X) (wkᵗ-all X A) (strengthened (`∀ A))
+strengthenAt X (`∀ A) | blocked = blocked
+
+------------------------------------------------------------------------
+-- Type-context weakening used only beneath an existing `Λ`
+------------------------------------------------------------------------
+
+insertEnv : ∀ {n} → TyVar (suc n) → Env∼ n → Env∼ (suc n)
+insertEnv zero μ zero = X∼X
+insertEnv zero μ (suc Y) = μ Y
+insertEnv {n = suc n} (suc X) μ zero = μ zero
+insertEnv {n = suc n} (suc X) μ (suc Y) =
+  insertEnv X (λ Z → μ (suc Z)) Y
+
+insertEnv-punchIn : ∀ {n} (X : TyVar (suc n)) (μ : Env∼ n) Y
+  → insertEnv X μ (punchIn X Y) ≡ μ Y
+insertEnv-punchIn zero μ Y = refl
+insertEnv-punchIn {n = suc n} (suc X) μ zero = refl
+insertEnv-punchIn {n = suc n} (suc X) μ (suc Y) =
+  insertEnv-punchIn X (λ Z → μ (suc Z)) Y
+
+weakenConsistency : ∀ {n} {μ : Env∼ n} {A B : Ty n}
+  → (X : TyVar (suc n))
+  → μ ⊢ A ∼ B
+  → insertEnv X μ ⊢ wkᵗ X A ∼ wkᵗ X B
+weakenConsistency {μ = μ} X c =
+  rename∼ (punchIn X) (insertEnv-punchIn X μ) c
+
+-- Commuting an ambient insertion inward across a reveal.  At equal slots,
+-- the reveal's own slot comes first.
+underReveal : ∀ {n} → Fin (suc n) → Fin (suc n) → Fin (suc (suc n))
+underReveal zero zero = suc zero
+underReveal zero (suc Y) = zero
+underReveal (suc X) zero = suc (suc X)
+underReveal {n = suc n} (suc X) (suc Y) = suc (underReveal X Y)
+
+weakenRevealSlot : ∀ {n}
+  → Fin (suc n) → Fin (suc n) → Fin (suc (suc n))
+weakenRevealSlot zero zero = zero
+weakenRevealSlot zero (suc Y) = suc (suc Y)
+weakenRevealSlot (suc X) zero = zero
+weakenRevealSlot {n = suc n} (suc X) (suc Y) =
+  suc (weakenRevealSlot X Y)
+
+reveal-punch-square : ∀ {n} (X Y : Fin (suc n)) (z : Fin n)
+  → punchIn (underReveal X Y) (punchIn Y z)
+    ≡ punchIn (weakenRevealSlot X Y) (punchIn X z)
+reveal-punch-square zero zero z = refl
+reveal-punch-square {n = suc n} zero (suc Y) zero = refl
+reveal-punch-square {n = suc n} zero (suc Y) (suc z) = refl
+reveal-punch-square {n = suc n} (suc X) zero zero = refl
+reveal-punch-square {n = suc n} (suc X) zero (suc z) = refl
+reveal-punch-square {n = suc n} (suc X) (suc Y) zero = refl
+reveal-punch-square {n = suc n} (suc X) (suc Y) (suc z) =
+  cong suc (reveal-punch-square X Y z)
+
+wkᵗ-reveal-square : ∀ {n} (X Y : Fin (suc n)) (A : Ty n)
+  → wkᵗ (underReveal X Y) (wkᵗ Y A)
+    ≡ wkᵗ (weakenRevealSlot X Y) (wkᵗ X A)
+wkᵗ-reveal-square X Y A =
+  trans (renameᵗ-comp (punchIn Y) (punchIn (underReveal X Y)) A)
+    (trans (renameᵗ-cong A (reveal-punch-square X Y))
+      (sym (renameᵗ-comp (punchIn X)
+        (punchIn (weakenRevealSlot X Y)) A)))
+
+-- Commuting an insertion outward across a conceal.  The inserted slot is
+-- placed before the conceal slot when they meet at the same outer gap.
+outsideConceal : ∀ {n}
+  → Fin (suc (suc n)) → Fin (suc n) → Fin (suc n)
+outsideConceal zero Y = zero
+outsideConceal (suc X) zero = X
+outsideConceal {n = suc n} (suc X) (suc Y) = suc (outsideConceal X Y)
+
+weakenConcealSlot : ∀ {n}
+  → Fin (suc (suc n)) → Fin (suc n) → Fin (suc (suc n))
+weakenConcealSlot zero Y = suc Y
+weakenConcealSlot (suc X) zero = zero
+weakenConcealSlot {n = suc n} (suc X) (suc Y) =
+  suc (weakenConcealSlot X Y)
+
+conceal-punch-square : ∀ {n} (X : Fin (suc (suc n)))
+    (Y : Fin (suc n)) (z : Fin n)
+  → punchIn X (punchIn Y z)
+    ≡ punchIn (weakenConcealSlot X Y) (punchIn (outsideConceal X Y) z)
+conceal-punch-square {n = suc n} zero zero zero = refl
+conceal-punch-square {n = suc n} zero zero (suc z) = refl
+conceal-punch-square {n = suc n} zero (suc Y) zero = refl
+conceal-punch-square {n = suc n} zero (suc Y) (suc z) = refl
+conceal-punch-square {n = suc n} (suc X) zero zero = refl
+conceal-punch-square {n = suc n} (suc X) zero (suc z) = refl
+conceal-punch-square {n = suc n} (suc X) (suc Y) zero = refl
+conceal-punch-square {n = suc n} (suc X) (suc Y) (suc z) =
+  cong suc (conceal-punch-square X Y z)
+
+wkᵗ-conceal-square : ∀ {n} (X : Fin (suc (suc n)))
+    (Y : Fin (suc n)) (A : Ty n)
+  → wkᵗ X (wkᵗ Y A)
+    ≡ wkᵗ (weakenConcealSlot X Y) (wkᵗ (outsideConceal X Y) A)
+wkᵗ-conceal-square X Y A =
+  trans (renameᵗ-comp (punchIn Y) (punchIn X) A)
+    (trans (renameᵗ-cong A (conceal-punch-square X Y))
+      (sym (renameᵗ-comp (punchIn (outsideConceal X Y))
+        (punchIn (weakenConcealSlot X Y)) A)))
+
+weakenᵗᵐ : ∀ {n} (X : TyVar (suc n)) → Term n → Term (suc n)
+weakenᵗᵐ X (` x) = ` x
+weakenᵗᵐ X (ƛ A ˙ M) = ƛ wkᵗ X A ˙ weakenᵗᵐ X M
+weakenᵗᵐ X (L · M) = weakenᵗᵐ X L · weakenᵗᵐ X M
+weakenᵗᵐ X (Λ M) = Λ (weakenᵗᵐ (suc X) M)
+weakenᵗᵐ X (L ⦂∀ C [ A ]) =
+  weakenᵗᵐ X L ⦂∀ wkᵗ (suc X) C [ wkᵗ X A ]
+weakenᵗᵐ X ($ κ) = $ κ
+weakenᵗᵐ X (L ⊕[ op ] M) = weakenᵗᵐ X L ⊕[ op ] weakenᵗᵐ X M
+weakenᵗᵐ X (M ⟨ c ⟩) = weakenᵗᵐ X M ⟨ weakenConsistency X c ⟩
+weakenᵗᵐ X (M ↑⟨ Y ≔ α ⟩ c) =
+  weakenᵗᵐ (underReveal X Y) M ↑⟨ weakenRevealSlot X Y ≔ α ⟩
+    subst (Conv↑ _ _) (wkᵗ-reveal-square X Y _) (rename↑ _ c)
+weakenᵗᵐ X (M ↓⟨ Y ≔ α ⟩ c) =
+  weakenᵗᵐ (outsideConceal X Y) M ↓⟨ weakenConcealSlot X Y ≔ α ⟩
+    subst (λ A → Conv↓ _ A _) (wkᵗ-conceal-square X Y _) (rename↓ _ c)
+weakenᵗᵐ X blame = blame
+
+------------------------------------------------------------------------
+-- Term-variable deletion when a replacement cannot cross a conceal
+------------------------------------------------------------------------
+
+removeVar : Var → Var → Var
+removeVar zero zero = zero
+removeVar zero (suc y) = y
+removeVar (suc x) zero = zero
+removeVar (suc x) (suc y) = suc (removeVar x y)
+
+dropAt : Var → Term Δ → Term Δ
+dropAt x (` y) with Nat._≟_ x y
+dropAt x (` .x) | yes refl = ` x
+dropAt x (` y) | no x≠y = ` removeVar x y
+dropAt x (ƛ A ˙ M) = ƛ A ˙ dropAt (suc x) M
+dropAt x (L · M) = dropAt x L · dropAt x M
+dropAt x (Λ M) = Λ (dropAt x M)
+dropAt x (L ⦂∀ C [ A ]) = dropAt x L ⦂∀ C [ A ]
+dropAt x ($ κ) = $ κ
+dropAt x (L ⊕[ op ] M) = dropAt x L ⊕[ op ] dropAt x M
+dropAt x (M ⟨ c ⟩) = dropAt x M ⟨ c ⟩
+dropAt x (M ↑⟨ X ≔ α ⟩ c) = dropAt x M ↑⟨ X ≔ α ⟩ c
+dropAt x (M ↓⟨ X ≔ α ⟩ c) = dropAt x M ↓⟨ X ≔ α ⟩ c
+dropAt x blame = blame
+
+------------------------------------------------------------------------
+-- Type-directed single substitution
+------------------------------------------------------------------------
+
+substAt : Var → Term Δ → Ty Δ → Term Δ → Term Δ
+substAt x V A (` y) with Nat._≟_ x y
+substAt x V A (` .x) | yes refl = V
+substAt x V A (` y) | no x≠y = ` removeVar x y
+substAt x V A (ƛ B ˙ M) =
+  ƛ B ˙ substAt (suc x) (rename suc V) A M
+substAt x V A (L · M) = substAt x V A L · substAt x V A M
+substAt x V A (Λ M) = Λ (substAt x (weakenᵗᵐ zero V) (⇑ᵗ A) M)
+substAt x V A (L ⦂∀ C [ B ]) = substAt x V A L ⦂∀ C [ B ]
+substAt x V A ($ κ) = $ κ
+substAt x V A (L ⊕[ op ] M) =
+  substAt x V A L ⊕[ op ] substAt x V A M
+substAt x V A (M ⟨ c ⟩) = substAt x V A M ⟨ c ⟩
+substAt x V A (M ↑⟨ X ≔ α ⟩ c) =
+  substAt x (V ↓⟨ X ≔ α ⟩ δ↓ (wkᵗ X A)) (wkᵗ X A) M
+    ↑⟨ X ≔ α ⟩ c
+substAt x V A (M ↓⟨ X ≔ α ⟩ c) with strengthenAt X A
+substAt x V .(wkᵗ X B) (M ↓⟨ X ≔ α ⟩ c) | strengthened B =
+  substAt x (V ↑⟨ X ≔ α ⟩ δ↑ (wkᵗ X B)) B M
+    ↓⟨ X ≔ α ⟩ c
+-- In a well-typed redex the substituted context entry beneath a conceal is
+-- typed in the unweakened context, so its tracked type at the node is
+-- necessarily `wkᵗ X B`.  If raw, ill-typed syntax violates that invariant,
+-- leave just its target occurrences in place; `dropAt` still adjusts every
+-- other de Bruijn index for the binder removed by substitution.
+substAt x V A (M ↓⟨ X ≔ α ⟩ c) | blocked =
+  dropAt x M ↓⟨ X ≔ α ⟩ c
+substAt x V A blame = blame
+
+infixl 8 _[_⦂_]
+_[_⦂_] : Term Δ → Term Δ → Ty Δ → Term Δ
+M [ V ⦂ A ] = substAt zero V A M
 
 ------------------------------------------------------------------------
 -- Values
@@ -147,7 +404,7 @@ data ConcealValue : ∀ {Δ A B} → Conv↓ Δ A B → Set where
     → ConcealValue (id↓ (★ {Δ}))
 
 data Value : ∀ {Δ : TyCtx} → Term Δ → Set where
-  ƛ_ : ∀ {Δ} (N : Term Δ) → Value (ƛ N)
+  ƛ_˙_ : ∀ {Δ} (A : Ty Δ) (N : Term Δ) → Value (ƛ A ˙ N)
   Λ_ : ∀ {Δ} {V : Term (suc Δ)} → Value V → Value (Λ V)
   $ : ∀ {Δ} (κ : Const) → Value {Δ = Δ} ($ κ)
 
@@ -328,7 +585,7 @@ data _⊢_⦂_ : (Γ : Ctx) → Term (Δᵉ Γ) → Ty (Δᵉ Γ) → Set where
 
   ⊢ƛ : ∀ {Γ A B M}
     → Γ ,ᶜ A ⊢ M ⦂ B
-    → Γ ⊢ (ƛ M) ⦂ (A ⇒ B)
+    → Γ ⊢ (ƛ A ˙ M) ⦂ (A ⇒ B)
 
   ⊢· : ∀ {Γ A B L M}
     → Γ ⊢ L ⦂ (A ⇒ B)

--- a/GTSFImp/alt/Terms.agda
+++ b/GTSFImp/alt/Terms.agda
@@ -5,11 +5,12 @@ module alt.Terms where
 --     conceal anti-binders.
 --   * Defines values, scoped-variable classifications, representation
 --     transport, and typing against the global append-only store.
---   * Provides annotated lambdas and type-directed single substitution.
+--   * Provides annotated lambdas and structural single substitution that
+--     stops at closed crossing interiors.
 --   * Keeps forall-bound scoped variables out of store representations.
 
 open import Data.Fin using (Fin; zero; suc)
-open import Data.List using (_∷_)
+open import Data.List using ([]; _∷_)
 open import Data.Nat using (ℕ; zero; suc)
 import Data.Nat.Properties as Nat
 open import Relation.Binary.PropositionalEquality
@@ -94,55 +95,6 @@ rename ρ (M ↑⟨ X ≔ α ⟩ c) = rename ρ M ↑⟨ X ≔ α ⟩ c
 rename ρ (M ↓⟨ X ≔ α ⟩ c) = rename ρ M ↓⟨ X ≔ α ⟩ c
 rename ρ blame = blame
 
-------------------------------------------------------------------------
--- Removing one scoped-variable slot from a tracked type
-------------------------------------------------------------------------
-
-data Unpunch {n : ℕ} (X : Fin (suc n)) : Fin (suc n) → Set where
-  pivot : Unpunch X X
-  image : (Y : Fin n) → Unpunch X (punchIn X Y)
-
-unpunch : ∀ {n} (X Y : Fin (suc n)) → Unpunch X Y
-unpunch zero zero = pivot
-unpunch zero (suc Y) = image Y
-unpunch {n = suc n} (suc X) zero = image zero
-unpunch {n = suc n} (suc X) (suc Y) with unpunch X Y
-unpunch {n = suc n} (suc X) (suc .X) | pivot = pivot
-unpunch {n = suc n} (suc X) (suc .(punchIn X Y)) | image Y =
-  image (suc Y)
-
-data StrengthenedAt {n : ℕ} (X : TyVar (suc n)) :
-    Ty (suc n) → Set where
-  strengthened : (A : Ty n) → StrengthenedAt X (wkᵗ X A)
-  blocked : ∀ {A} → StrengthenedAt X A
-
-wkᵗ-all : ∀ {n} (X : TyVar (suc n)) (A : Ty (suc n))
-  → wkᵗ X (`∀ A) ≡ `∀ (wkᵗ (suc X) A)
-wkᵗ-all X A = cong `∀ (renameᵗ-cong A pointwise)
-  where
-  pointwise : ∀ Y → extᵗ (punchIn X) Y ≡ punchIn (suc X) Y
-  pointwise zero = refl
-  pointwise (suc Y) = refl
-
-strengthenAt : ∀ {n} (X : TyVar (suc n)) (A : Ty (suc n))
-  → StrengthenedAt X A
-strengthenAt X (＇ Y) with unpunch X Y
-strengthenAt X (＇ .X) | pivot = blocked
-strengthenAt X (＇ .(punchIn X Y)) | image Y = strengthened (＇ Y)
-strengthenAt X (‵ ι) = strengthened (‵ ι)
-strengthenAt X ★ = strengthened ★
-strengthenAt X (A ⇒ B) with strengthenAt X A | strengthenAt X B
-strengthenAt X (.(wkᵗ X A) ⇒ .(wkᵗ X B))
-  | strengthened A | strengthened B = strengthened (A ⇒ B)
-strengthenAt X (.(wkᵗ X A) ⇒ B) | strengthened A | blocked = blocked
-strengthenAt X (A ⇒ .(wkᵗ X B)) | blocked | strengthened B = blocked
-strengthenAt X (A ⇒ B) | blocked | blocked = blocked
-strengthenAt X (`∀ A) with strengthenAt (suc X) A
-strengthenAt X (`∀ .(wkᵗ (suc X) A)) | strengthened A =
-  subst (StrengthenedAt X) (wkᵗ-all X A) (strengthened (`∀ A))
-strengthenAt X (`∀ A) | blocked = blocked
-
-------------------------------------------------------------------------
 -- Type-context weakening used only beneath an existing `Λ`
 ------------------------------------------------------------------------
 
@@ -261,67 +213,34 @@ weakenᵗᵐ X (M ↓⟨ Y ≔ α ⟩ c) =
     subst (λ A → Conv↓ _ A _) (wkᵗ-conceal-square X Y _) (rename↓ _ c)
 weakenᵗᵐ X blame = blame
 
-------------------------------------------------------------------------
--- Term-variable deletion when a replacement cannot cross a conceal
-------------------------------------------------------------------------
-
 removeVar : Var → Var → Var
 removeVar zero zero = zero
 removeVar zero (suc y) = y
 removeVar (suc x) zero = zero
 removeVar (suc x) (suc y) = suc (removeVar x y)
 
-dropAt : Var → Term Δ → Term Δ
-dropAt x (` y) with Nat._≟_ x y
-dropAt x (` .x) | yes refl = ` x
-dropAt x (` y) | no x≠y = ` removeVar x y
-dropAt x (ƛ A ˙ M) = ƛ A ˙ dropAt (suc x) M
-dropAt x (L · M) = dropAt x L · dropAt x M
-dropAt x (Λ M) = Λ (dropAt x M)
-dropAt x (L ⦂∀ C [ A ]) = dropAt x L ⦂∀ C [ A ]
-dropAt x ($ κ) = $ κ
-dropAt x (L ⊕[ op ] M) = dropAt x L ⊕[ op ] dropAt x M
-dropAt x (M ⟨ c ⟩) = dropAt x M ⟨ c ⟩
-dropAt x (M ↑⟨ X ≔ α ⟩ c) = dropAt x M ↑⟨ X ≔ α ⟩ c
-dropAt x (M ↓⟨ X ≔ α ⟩ c) = dropAt x M ↓⟨ X ≔ α ⟩ c
-dropAt x blame = blame
-
 ------------------------------------------------------------------------
--- Type-directed single substitution
+-- Structural single substitution
 ------------------------------------------------------------------------
 
-substAt : Var → Term Δ → Ty Δ → Term Δ → Term Δ
-substAt x V A (` y) with Nat._≟_ x y
-substAt x V A (` .x) | yes refl = V
-substAt x V A (` y) | no x≠y = ` removeVar x y
-substAt x V A (ƛ B ˙ M) =
-  ƛ B ˙ substAt (suc x) (rename suc V) A M
-substAt x V A (L · M) = substAt x V A L · substAt x V A M
-substAt x V A (Λ M) = Λ (substAt x (weakenᵗᵐ zero V) (⇑ᵗ A) M)
-substAt x V A (L ⦂∀ C [ B ]) = substAt x V A L ⦂∀ C [ B ]
-substAt x V A ($ κ) = $ κ
-substAt x V A (L ⊕[ op ] M) =
-  substAt x V A L ⊕[ op ] substAt x V A M
-substAt x V A (M ⟨ c ⟩) = substAt x V A M ⟨ c ⟩
-substAt x V A (M ↑⟨ X ≔ α ⟩ c) =
-  substAt x (V ↓⟨ X ≔ α ⟩ δ↓ (wkᵗ X A)) (wkᵗ X A) M
-    ↑⟨ X ≔ α ⟩ c
-substAt x V A (M ↓⟨ X ≔ α ⟩ c) with strengthenAt X A
-substAt x V .(wkᵗ X B) (M ↓⟨ X ≔ α ⟩ c) | strengthened B =
-  substAt x (V ↑⟨ X ≔ α ⟩ δ↑ (wkᵗ X B)) B M
-    ↓⟨ X ≔ α ⟩ c
--- In a well-typed redex the substituted context entry beneath a conceal is
--- typed in the unweakened context, so its tracked type at the node is
--- necessarily `wkᵗ X B`.  If raw, ill-typed syntax violates that invariant,
--- leave just its target occurrences in place; `dropAt` still adjusts every
--- other de Bruijn index for the binder removed by substitution.
-substAt x V A (M ↓⟨ X ≔ α ⟩ c) | blocked =
-  dropAt x M ↓⟨ X ≔ α ⟩ c
-substAt x V A blame = blame
+substAt : Var → Term Δ → Term Δ → Term Δ
+substAt x V (` y) with Nat._≟_ x y
+substAt x V (` .x) | yes refl = V
+substAt x V (` y) | no x≠y = ` removeVar x y
+substAt x V (ƛ A ˙ M) = ƛ A ˙ substAt (suc x) (rename suc V) M
+substAt x V (L · M) = substAt x V L · substAt x V M
+substAt x V (Λ M) = Λ (substAt x (weakenᵗᵐ zero V) M)
+substAt x V (L ⦂∀ C [ A ]) = substAt x V L ⦂∀ C [ A ]
+substAt x V ($ κ) = $ κ
+substAt x V (L ⊕[ op ] M) = substAt x V L ⊕[ op ] substAt x V M
+substAt x V (M ⟨ c ⟩) = substAt x V M ⟨ c ⟩
+substAt x V (M ↑⟨ X ≔ α ⟩ c) = M ↑⟨ X ≔ α ⟩ c
+substAt x V (M ↓⟨ X ≔ α ⟩ c) = M ↓⟨ X ≔ α ⟩ c
+substAt x V blame = blame
 
-infixl 8 _[_⦂_]
-_[_⦂_] : Term Δ → Term Δ → Ty Δ → Term Δ
-M [ V ⦂ A ] = substAt zero V A M
+infixl 8 _[_]
+_[_] : Term Δ → Term Δ → Term Δ
+M [ V ] = substAt zero V M
 
 ------------------------------------------------------------------------
 -- Values
@@ -564,13 +483,15 @@ _,ᶜ_ : (Γ : Ctx) → Ty (Δᵉ Γ) → Ctx
 ∀-ctx ⟨ Δ , n , κ , Σ , Γ ⟩ =
   ⟨ suc Δ , n , insertBinding zero ∀-bound κ , Σ , wkᶜ zero Γ ⟩
 
+-- The classifier and store are extended beneath a crossing, but its interior
+-- is always closed in the term context.
 cross-ctx : (Γ : Ctx) (X : TyVar (suc (Δᵉ Γ))) {α : Name}
     {R : Ty (sizeᵉ Γ)}
   → α ⦂ R ∈ Σᵉ Γ
   → Ctx
 cross-ctx ⟨ Δ , n , κ , Σ , Γ ⟩ X p =
   ⟨ suc Δ , n , insertBinding X (anchored (lookup-name p)) κ ,
-    Σ , wkᶜ X Γ ⟩
+    Σ , [] ⟩
 
 infix 4 _∋ᵗ_⦂_
 infix 4 _⊢_⦂_
@@ -623,13 +544,15 @@ data _⊢_⦂_ : (Γ : Ctx) → Term (Δᵉ Γ) → Ty (Δᵉ Γ) → Set where
     → cross-ctx Γ X p ⊢ M ⦂ A
     → Γ ⊢ M ↑⟨ X ≔ α ⟩ c ⦂ B
 
-  ⊢conceal : ∀ {Γ M A B X α R}
+  ⊢conceal : ∀ {Γ} {Γ′ : TermCtx (suc (Δᵉ Γ))}
+      {M A B X α R}
       {c : Conv↓ (suc (Δᵉ Γ)) (wkᵗ X A) B}
     → (p : α ⦂ R ∈ Σᵉ Γ)
     → PivotStrict↓ X c
     → Reps↓ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
-    → Γ ⊢ M ⦂ A
-    → cross-ctx Γ X p ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
+    → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ M ⦂ A
+    → ⟨ suc (Δᵉ Γ) , sizeᵉ Γ , κᵉ (cross-ctx Γ X p) ,
+        Σᵉ Γ , Γ′ ⟩ ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
 
   ⊢blame : ∀ {Γ A}
     → Γ ⊢ blame ⦂ A

--- a/GTSFImp/alt/Terms.agda
+++ b/GTSFImp/alt/Terms.agda
@@ -33,7 +33,7 @@ infixl 7 _·_
 infix  5 Λ_
 infixl 7 _⦂∀_[_]
 infixl 7 _⟨_⟩
-infixl 7 _↑⟨_≔_⟩_ _↓⟨_≔_⟩_
+infixl 7 _↑[_≔_]_ _↓[_≔_]_
 infixl 6 _⊕[_]_
 infix  9 `_
 
@@ -55,14 +55,14 @@ data Term : TyCtx → Set where
   _⟨_⟩    : Term Δ → {μ : Env∼ Δ} {A B : Ty Δ}
     → μ ⊢ A ∼ B → Term Δ
 
-  _↑⟨_≔_⟩_ : ∀ {A : Ty (suc Δ)} {B : Ty Δ}
+  _↑[_≔_]_ : ∀ {A : Ty (suc Δ)} {B : Ty Δ}
     → Term (suc Δ)
     → (X : TyVar (suc Δ))
     → Name
     → Conv↑ (suc Δ) A (wkᵗ X B)
     → Term Δ
 
-  _↓⟨_≔_⟩_ : ∀ {A : Ty Δ} {B : Ty (suc Δ)}
+  _↓[_≔_]_ : ∀ {A : Ty Δ} {B : Ty (suc Δ)}
     → Term Δ
     → (X : TyVar (suc Δ))
     → Name
@@ -91,8 +91,8 @@ rename ρ (L ⦂∀ C [ A ]) = rename ρ L ⦂∀ C [ A ]
 rename ρ ($ κ) = $ κ
 rename ρ (L ⊕[ op ] M) = rename ρ L ⊕[ op ] rename ρ M
 rename ρ (M ⟨ c ⟩) = rename ρ M ⟨ c ⟩
-rename ρ (M ↑⟨ X ≔ α ⟩ c) = rename ρ M ↑⟨ X ≔ α ⟩ c
-rename ρ (M ↓⟨ X ≔ α ⟩ c) = rename ρ M ↓⟨ X ≔ α ⟩ c
+rename ρ (M ↑[ X ≔ α ] c) = rename ρ M ↑[ X ≔ α ] c
+rename ρ (M ↓[ X ≔ α ] c) = rename ρ M ↓[ X ≔ α ] c
 rename ρ blame = blame
 
 -- Type-context weakening used only beneath an existing `Λ`
@@ -205,11 +205,11 @@ weakenᵗᵐ X (L ⦂∀ C [ A ]) =
 weakenᵗᵐ X ($ κ) = $ κ
 weakenᵗᵐ X (L ⊕[ op ] M) = weakenᵗᵐ X L ⊕[ op ] weakenᵗᵐ X M
 weakenᵗᵐ X (M ⟨ c ⟩) = weakenᵗᵐ X M ⟨ weakenConsistency X c ⟩
-weakenᵗᵐ X (M ↑⟨ Y ≔ α ⟩ c) =
-  weakenᵗᵐ (underReveal X Y) M ↑⟨ weakenRevealSlot X Y ≔ α ⟩
+weakenᵗᵐ X (M ↑[ Y ≔ α ] c) =
+  weakenᵗᵐ (underReveal X Y) M ↑[ weakenRevealSlot X Y ≔ α ]
     subst (Conv↑ _ _) (wkᵗ-reveal-square X Y _) (rename↑ _ c)
-weakenᵗᵐ X (M ↓⟨ Y ≔ α ⟩ c) =
-  weakenᵗᵐ (outsideConceal X Y) M ↓⟨ weakenConcealSlot X Y ≔ α ⟩
+weakenᵗᵐ X (M ↓[ Y ≔ α ] c) =
+  weakenᵗᵐ (outsideConceal X Y) M ↓[ weakenConcealSlot X Y ≔ α ]
     subst (λ A → Conv↓ _ A _) (wkᵗ-conceal-square X Y _) (rename↓ _ c)
 weakenᵗᵐ X blame = blame
 
@@ -234,8 +234,8 @@ substAt x V (L ⦂∀ C [ A ]) = substAt x V L ⦂∀ C [ A ]
 substAt x V ($ κ) = $ κ
 substAt x V (L ⊕[ op ] M) = substAt x V L ⊕[ op ] substAt x V M
 substAt x V (M ⟨ c ⟩) = substAt x V M ⟨ c ⟩
-substAt x V (M ↑⟨ X ≔ α ⟩ c) = M ↑⟨ X ≔ α ⟩ c
-substAt x V (M ↓⟨ X ≔ α ⟩ c) = M ↓⟨ X ≔ α ⟩ c
+substAt x V (M ↑[ X ≔ α ] c) = M ↑[ X ≔ α ] c
+substAt x V (M ↓[ X ≔ α ] c) = M ↓[ X ≔ α ] c
 substAt x V blame = blame
 
 infixl 8 _[_]
@@ -333,23 +333,23 @@ data Value : ∀ {Δ : TyCtx} → Term Δ → Set where
     → Inert c
     → Value (V ⟨ c ⟩)
 
-  _↑⟨_≔_⟩_ : ∀ {Δ} {V : Term (suc Δ)} {A : Ty (suc Δ)}
+  _↑[_≔_]_ : ∀ {Δ} {V : Term (suc Δ)} {A : Ty (suc Δ)}
       {B : Ty Δ}
     → Value V
     → (X : TyVar (suc Δ))
     → (α : Name)
     → {c : Conv↑ (suc Δ) A (wkᵗ X B)}
     → RevealValue c
-    → Value (V ↑⟨ X ≔ α ⟩ c)
+    → Value (V ↑[ X ≔ α ] c)
 
-  _↓⟨_≔_⟩_ : ∀ {Δ′ : TyCtx} {V : Term Δ′} {A : Ty Δ′}
+  _↓[_≔_]_ : ∀ {Δ′ : TyCtx} {V : Term Δ′} {A : Ty Δ′}
       {B : Ty (suc Δ′)}
     → Value V
     → (X : TyVar (suc Δ′))
     → (α : Name)
     → {c : Conv↓ (suc Δ′) (wkᵗ X A) B}
     → ConcealValue c
-    → Value (V ↓⟨ X ≔ α ⟩ c)
+    → Value (V ↓[ X ≔ α ] c)
 
 ------------------------------------------------------------------------
 -- Scoped-variable classifications and contexts
@@ -542,7 +542,7 @@ data _⊢_⦂_ : (Γ : Ctx) → Term (Δᵉ Γ) → Ty (Δᵉ Γ) → Set where
     → PivotStrict↑ X c
     → Reps↑ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
     → cross-ctx Γ X p ⊢ M ⦂ A
-    → Γ ⊢ M ↑⟨ X ≔ α ⟩ c ⦂ B
+    → Γ ⊢ M ↑[ X ≔ α ] c ⦂ B
 
   ⊢conceal : ∀ {Γ} {Γ′ : TermCtx (suc (Δᵉ Γ))}
       {M A B X α R}
@@ -552,7 +552,7 @@ data _⊢_⦂_ : (Γ : Ctx) → Term (Δᵉ Γ) → Ty (Δᵉ Γ) → Set where
     → Reps↓ (BindingRel (κᵉ (cross-ctx Γ X p))) R c
     → ⟨ Δᵉ Γ , sizeᵉ Γ , κᵉ Γ , Σᵉ Γ , [] ⟩ ⊢ M ⦂ A
     → ⟨ suc (Δᵉ Γ) , sizeᵉ Γ , κᵉ (cross-ctx Γ X p) ,
-        Σᵉ Γ , Γ′ ⟩ ⊢ M ↓⟨ X ≔ α ⟩ c ⦂ B
+        Σᵉ Γ , Γ′ ⟩ ⊢ M ↓[ X ≔ α ] c ⦂ B
 
   ⊢blame : ∀ {Γ A}
     → Γ ⊢ blame ⦂ A

--- a/GTSFImp/alt/Terms.agda
+++ b/GTSFImp/alt/Terms.agda
@@ -56,10 +56,10 @@ data Term : TyCtx → Set where
     → μ ⊢ A ∼ B → Term Δ
 
   _↑[_≔_]_ : Term (suc Δ)
-    → TyVar (suc Δ) → Name → Conv↑ → Term Δ
+    → TyVar (suc Δ) → Name → Reveal → Term Δ
 
   _↓[_≔_]_ : Term Δ
-    → TyVar (suc Δ) → Name → Conv↓ → Term (suc Δ)
+    → TyVar (suc Δ) → Name → Conceal → Term (suc Δ)
 
   blame   : Term Δ
 
@@ -237,7 +237,7 @@ data Inert : ∀ {Δ : TyCtx} {μ : Env∼ Δ} {A B : Ty Δ}
     → Inert ((gen c) A≢★)
 
 mutual
-  data RevealValue {Δ : TyCtx} (V : Term Δ) : Conv↑ → Set where
+  data RevealValue {Δ : TyCtx} (V : Term Δ) : Reveal → Set where
     fun : ∀ {c d}
       → RevealValue V (c ↦↑ d)
 
@@ -247,7 +247,7 @@ mutual
     delimiter : CanonicalInterior V
       → RevealValue V id↑
 
-  data ConcealValue {Δ : TyCtx} (V : Term Δ) : Conv↓ → Set where
+  data ConcealValue {Δ : TyCtx} (V : Term Δ) : Conceal → Set where
     seal : ConcealValue V alt.Conversion.seal
 
     fun : ∀ {c d}
@@ -274,7 +274,7 @@ mutual
       → Value V
       → (X : TyVar (suc Δ))
       → (α : Name)
-      → {c : Conv↑}
+      → {c : Reveal}
       → RevealValue V c
       → Value (V ↑[ X ≔ α ] c)
 
@@ -282,7 +282,7 @@ mutual
       → Value V
       → (X : TyVar (suc Δ))
       → (α : Name)
-      → {c : Conv↓}
+      → {c : Conceal}
       → ConcealValue V c
       → Value (V ↓[ X ≔ α ] c)
 

--- a/GTSFImp/alt/probes/EscapeReentryProbe.agda
+++ b/GTSFImp/alt/probes/EscapeReentryProbe.agda
@@ -6,7 +6,7 @@ module alt.probes.EscapeReentryProbe where
 --   * Records the generated consistency evidence, typing, evaluation traces,
 --     and the escaped sealed-and-tagged value.
 
--- BLOCKED:
+-- SPEC DEVIATION (not a blocker):
 -- The two requested trace types with index `bind (‵ `ℕ) ∷ []` are not
 -- derivable using the live `Reduction._—↠[_]_`.  Its `↠-step` constructor
 -- records one `StoreChange` per reduction step, while `pure-step` embeds a

--- a/GTSFImp/alt/probes/EscapeReentryProbe.agda
+++ b/GTSFImp/alt/probes/EscapeReentryProbe.agda
@@ -1,0 +1,325 @@
+module alt.probes.EscapeReentryProbe where
+
+-- File Charter:
+--   * Checks the escape/re-entry example from alt/Design.md against the live
+--     GTSFImp calculus.
+--   * Records the generated consistency evidence, typing, evaluation traces,
+--     and the escaped sealed-and-tagged value.
+
+-- BLOCKED:
+-- The two requested trace types with index `bind (‵ `ℕ) ∷ []` are not
+-- derivable using the live `Reduction._—↠[_]_`.  Its `↠-step` constructor
+-- records one `StoreChange` per reduction step, while `pure-step` embeds a
+-- pure reduction with change `keep`.  The escape needs five pure steps after
+-- `β-gen`, so its checked index is `bind (‵ `ℕ) ∷ keepSteps 5`;
+-- re-entry needs
+-- 32 pure steps, so its checked index is
+-- `bind (‵ `ℕ) ∷ keepSteps 32`.  In both traces `β-gen` is the sole
+-- `bind`;
+-- all remaining steps are `pure-step`.  The behavioral claim itself is
+-- confirmed below, including the sibling variable-ground `tag-untag`.
+
+open import Data.List using ([]; _∷_)
+open import Data.Maybe using (Maybe; just; nothing)
+open import Data.Nat using (ℕ; suc)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import Types
+open import TyStore using (TyStore; store-empty)
+open import Consistency
+open import Conversion
+open import Primitives
+open import CastTerms
+open import Reduction
+open import Eval
+import TermCtx
+import proof.DGG.OneStep as Step
+
+------------------------------------------------------------------------
+-- Shared closed context and constants
+------------------------------------------------------------------------
+
+∅ : Ctx
+∅ = ⟨ 0 , store-empty , [] ⟩
+
+ℕᵗ : Ty 0
+ℕᵗ = ‵ `ℕ
+
+$9 $7 $5 : Term 0
+$9 = $ (κℕ 9)
+$7 = $ (κℕ 7)
+$5 = $ (κℕ 5)
+
+keepSteps : ∀ {Δ} → ℕ → StoreChanges Δ Δ
+keepSteps 0 = []
+keepSteps (suc n) = keep ∷ keepSteps n
+
+------------------------------------------------------------------------
+-- Part 1: escape a sealed-and-tagged value through a positive ★ channel
+------------------------------------------------------------------------
+
+B₁ : Ty 1
+B₁ = ＇ 0 ⇒ ★
+
+instance
+  0∈B₁-instance : 0 ∈ᵗ B₁
+  0∈B₁-instance = ∈-fun-left var-∈
+
+W₁ : Term 0
+W₁ = ƛ (` 0)
+
+c₁ : genᵐ (idᶜ {Δ = 0}) ⊢ ⇑ᵗ (★ ⇒ ★) ∼ B₁
+c₁ = (id (＇ 0) !) ↦ id ★
+
+c₁-safe : GenSafe c₁
+c₁-safe = safe-⇒
+
+escape : Term 0
+escape = ((W₁ ⟨ (gen c₁) (λ ()) ⟩) ⦂∀ B₁ [ ℕᵗ ]) · $7
+
+escape-after-bind : Term 1
+escape-after-bind =
+  (⇑ᵗᵐ W₁ ⟨ c₁ ⟩ ↑ (seal 0 (‵ `ℕ) ↦↑ id↑ ★))
+    · $ (κℕ 7)
+
+escape-allocation : escape —→[ bind ℕᵗ ] escape-after-bind
+escape-allocation = ξ-·₁ (β-gen (ƛ (` 0)) (λ ()) c₁-safe) refl
+
+escape-endpoint : Term 1
+escape-endpoint =
+  (($ (κℕ 7) ↓ seal 0 (‵ `ℕ))
+    ⟨ id {μ = flipᵐ (genᵐ (idᶜ {Δ = 0}))} (＇ 0) ! ⟩)
+
+escape-endpoint-value : Value escape-endpoint
+escape-endpoint-value = (($ (κℕ 7)) ↓ seal) 《 inj 》
+
+------------------------------------------------------------------------
+-- Part 2: re-enter the sibling region created by the same allocation
+------------------------------------------------------------------------
+
+B : Ty 1
+B = ＇ 0 ⇒ ((★ ⇒ ★) ⇒ ＇ 0)
+
+instance
+  0∈B-instance : 0 ∈ᵗ B
+  0∈B-instance = ∈-fun-left var-∈
+
+W : Term 0
+W = ƛ (ƛ ((` 0) · (` 1)))
+
+c : genᵐ (idᶜ {Δ = 0})
+    ⊢ ⇑ᵗ (★ ⇒ ((★ ⇒ ★) ⇒ ★)) ∼ B
+c = (id (＇ 0) !) ↦ ((id ★ ↦ id ★) ↦ ？ (id (＇ 0)))
+
+c-safe : GenSafe c
+c-safe = safe-⇒
+
+P : Term 0
+P =
+  (ƛ (((` 0) · $9) ·
+    (ƛ ((ƛ (` 1)) · (((` 1) · $5) · (ƛ (` 1)))))))
+  · ((W ⟨ (gen c) (λ ()) ⟩) ⦂∀ B [ ℕᵗ ])
+
+P-after-bind : Term 1
+P-after-bind =
+  ⇑ᵗᵐ
+    (ƛ (((` 0) · $9) ·
+      (ƛ ((ƛ (` 1)) · (((` 1) · $5) · (ƛ (` 1)))))))
+  · (⇑ᵗᵐ W ⟨ c ⟩ ↑
+      (seal 0 (‵ `ℕ) ↦↑
+        ((id↑ ★ ↦↓ id↓ ★) ↦↑ unseal 0 (‵ `ℕ))))
+
+P-allocation : P —→[ bind ℕᵗ ] P-after-bind
+P-allocation =
+  ξ-·₂
+    (ƛ (((` 0) · $9) ·
+      (ƛ ((ƛ (` 1)) · (((` 1) · $5) · (ƛ (` 1)))))))
+    (β-gen (ƛ (ƛ ((` 0) · (` 1)))) (λ ()) c-safe)
+    refl
+
+P-⊢ : ∅ ⊢ P ⦂ ℕᵗ
+P-⊢ =
+  ⊢·
+    (⊢ƛ
+      (⊢·
+        (⊢· (⊢` TermCtx.Z) (⊢$ (κℕ 9)))
+        (⊢ƛ
+          (⊢·
+            (⊢ƛ (⊢` (TermCtx.S TermCtx.Z)))
+            (⊢·
+              (⊢· (⊢` (TermCtx.S TermCtx.Z)) (⊢$ (κℕ 5)))
+              (⊢ƛ (⊢` (TermCtx.S TermCtx.Z))))))))
+    (⊢• (⊢⟨⟩
+      (⊢ƛ (⊢ƛ (⊢· (⊢` TermCtx.Z)
+                      (⊢` (TermCtx.S TermCtx.Z)))))
+      ((gen c) (λ ()))))
+
+------------------------------------------------------------------------
+-- Executable, proof-producing baseline checks
+------------------------------------------------------------------------
+
+private
+  returned-result : ∀ {M : Term 0} {gas : ℕ} {r : EvalResult M}
+    → eval gas M ≡ just (returned r)
+    → EvalResult M
+  returned-result {r = r} eq = r
+
+escape-result : EvalResult escape
+escape-result = returned-result {gas = 100} refl
+
+escape-final : term escape-result ≡ escape-endpoint
+escape-final = refl
+
+escape-reduction : escape —↠[ changes escape-result ] escape-endpoint
+escape-reduction rewrite escape-final = trace escape-result
+
+P-result : EvalResult P
+P-result = returned-result {gas = 100} refl
+
+P-final : term P-result ≡ $ (κℕ 9)
+P-final = refl
+
+P-final-value : Value $9
+P-final-value = $ (κℕ 9)
+
+P-reduction : P —↠[ changes P-result ] $ (κℕ 9)
+P-reduction rewrite P-final = trace P-result
+
+escape-changes : changes escape-result ≡ bind ℕᵗ ∷ keepSteps 5
+escape-changes = refl
+
+escape-live-reduction :
+  escape —↠[ bind ℕᵗ ∷ keepSteps 5 ] escape-endpoint
+escape-live-reduction rewrite escape-changes = escape-reduction
+
+P-changes : changes P-result ≡ bind ℕᵗ ∷ keepSteps 32
+P-changes = refl
+
+P-live-reduction : P —↠[ bind ℕᵗ ∷ keepSteps 32 ] $ (κℕ 9)
+P-live-reduction rewrite P-changes = P-reduction
+
+------------------------------------------------------------------------
+-- The essential sibling re-entry step
+------------------------------------------------------------------------
+
+record Prefix {Δ : TyCtx} (Σ : TyStore Δ) (M : Term Δ) : Set where
+  constructor prefix
+  field
+    prefixCtx : TyCtx
+    prefixChanges : StoreChanges Δ prefixCtx
+    prefixTerm : Term prefixCtx
+    prefixTrace : M —↠[ prefixChanges ] prefixTerm
+
+open Prefix public
+
+runSteps : ∀ {Δ} → ℕ → (Σ : TyStore Δ) → (M : Term Δ)
+  → Maybe (Prefix Σ M)
+runSteps 0 Σ M = just (prefix _ [] M (M ∎[]))
+runSteps (suc n) Σ M with step? Σ M
+runSteps (suc n) Σ M | nothing = nothing
+runSteps (suc n) Σ M | just (step-result χ N M→N)
+    with runSteps n (χ ▷ˢ Σ) N
+runSteps (suc n) Σ M | just (step-result χ N M→N) | nothing = nothing
+runSteps (suc n) Σ M | just (step-result χ N M→N)
+    | just (prefix Δ′ χs P′ N↠P′) =
+  just (prefix Δ′ (χ ∷ χs) P′ (↠-step M→N N↠P′))
+
+private
+  prefix-result : ∀ {Δ} {n : ℕ} {Σ : TyStore Δ} {M : Term Δ}
+      {r : Prefix Σ M}
+    → runSteps n Σ M ≡ just r
+    → Prefix Σ M
+  prefix-result {r = r} eq = r
+
+-- One allocation and the first 25 pure steps lead to the source of the
+-- sibling call's matching variable-ground tag/projection cancellation.
+reentry-prefix : Prefix store-empty P
+reentry-prefix = prefix-result {n = 26} refl
+
+reentry-prefix-changes :
+  prefixChanges reentry-prefix ≡ bind ℕᵗ ∷ keepSteps 25
+reentry-prefix-changes = refl
+
+reentry-moment : Term (prefixCtx reentry-prefix)
+reentry-moment = prefixTerm reentry-prefix
+
+reentry-moment-reached :
+  P —↠[ prefixChanges reentry-prefix ] reentry-moment
+reentry-moment-reached = prefixTrace reentry-prefix
+
+reentry-context : prefixCtx reentry-prefix ≡ 1
+reentry-context = refl
+
+reentry-step :
+  Step.OneStep
+    (prefixChanges reentry-prefix ▶ˢ store-empty)
+    reentry-moment
+reentry-step =
+  Step.from-just-step
+    (step? (prefixChanges reentry-prefix ▶ˢ store-empty) reentry-moment)
+    refl
+
+reentry-step-is-pure : Step.change reentry-step ≡ keep
+reentry-step-is-pure = refl
+
+data VariableTagUntagStep : ∀ {Δ Δ′} {M : Term Δ}
+    {χ : StoreChange Δ Δ′} {N : Term Δ′}
+  → M —→[ χ ] N
+  → Set where
+
+  variable-tag-untag : ∀ {Δ} {V : Term Δ} {μ ν : Env∼ Δ}
+      {X : TyVar Δ}
+      ⦃ X∼★ : μ ⊢ ＇ X ∼★ ⦄ ⦃ ★∼X : ν ⊢★∼ ＇ X ⦄
+    → (vV : Value V)
+    → VariableTagUntagStep
+        (pure-step
+          (tag-untag {μ = μ} {ν = ν} {G = ＇ X}
+            ⦃ G∼★ = X∼★ ⦄ ⦃ ★∼G = ★∼X ⦄ vV))
+
+  under-·₂ : ∀ {Δ Δ′} {χ : StoreChange Δ Δ′}
+      {V M : Term Δ} {V′ M′ : Term Δ′}
+      {vV : Value V} {M→M′ : M —→[ χ ] M′}
+      {eq : V′ ≡ χ ▷ᵀ V}
+    → VariableTagUntagStep M→M′
+    → VariableTagUntagStep (ξ-·₂ vV M→M′ eq)
+
+  under-cast : ∀ {Δ Δ′} {χ : StoreChange Δ Δ′}
+      {M : Term Δ} {M′ : Term Δ′} {μ : Env∼ Δ}
+      {A B : Ty Δ} {c₀ : μ ⊢ A ∼ B}
+      {c₀′ : χ ▷ᵉ μ ⊢ χ ▷ᵗ A ∼ χ ▷ᵗ B}
+      {M→M′ : M —→[ χ ] M′} {eq : c₀′ ≡ χ ▷ᶜ c₀}
+    → VariableTagUntagStep M→M′
+    → VariableTagUntagStep (ξ-⟨⟩ M→M′ eq)
+
+  under-reveal : ∀ {Δ Δ′} {χ : StoreChange Δ Δ′}
+      {M : Term Δ} {M′ : Term Δ′} {A B : Ty Δ}
+      {c₀ : Conv↑ Δ A B}
+      {c₀′ : Conv↑ Δ′
+        (renameᵗ (λ X → χ ▷ᵛ X) A)
+        (renameᵗ (λ X → χ ▷ᵛ X) B)}
+      {M→M′ : M —→[ χ ] M′}
+      {eq : c₀′ ≡ rename↑ (λ X → χ ▷ᵛ X) c₀}
+    → VariableTagUntagStep M→M′
+    → VariableTagUntagStep (ξ-reveal M→M′ eq)
+
+  under-conceal : ∀ {Δ Δ′} {χ : StoreChange Δ Δ′}
+      {M : Term Δ} {M′ : Term Δ′} {A B : Ty Δ}
+      {c₀ : Conv↓ Δ A B}
+      {c₀′ : Conv↓ Δ′
+        (renameᵗ (λ X → χ ▷ᵛ X) A)
+        (renameᵗ (λ X → χ ▷ᵛ X) B)}
+      {M→M′ : M —→[ χ ] M′}
+      {eq : c₀′ ≡ rename↓ (λ X → χ ▷ᵛ X) c₀}
+    → VariableTagUntagStep M→M′
+    → VariableTagUntagStep (ξ-conceal M→M′ eq)
+
+reentry-is-variable-tag-untag :
+  VariableTagUntagStep (Step.reduction reentry-step)
+reentry-is-variable-tag-untag =
+  under-reveal
+    (under-cast
+      (under-cast
+        (under-conceal
+          (under-·₂
+            (under-reveal
+              (variable-tag-untag (($ (κℕ 9)) ↓ seal)))))))


### PR DESCRIPTION
## Purpose

An exploration branch for alternative reduction rules and an alternative type system for GTSFImp, kept isolated under `GTSFImp/alt/` so the live development and the DGG work are untouched. The scaffold design note (`GTSFImp/alt/Design.md`) records which commitments of the live system are under re-examination and lists candidate directions.

## Live-system commitments under re-examination

- Eager allocation conversion `〖 X ↑ A 〗` at every allocation rule
- `β-inst` closing consistency at `★` via `c [ ★ /0 ]ᶜ`
- The binder-directed `gen`-tags / `inst`-conversions asymmetry
- Fully typed consistency evidence carried in the cast-term syntax

## Candidate directions (open decision-ask)

- **A. Contextual coercions** — promote the `experimental/` probes: endpoint-free raw coercions typed against a cast context with `pending`/`active` phases; `β-inst` switches phase instead of rewriting evidence
- **B. Lazy sealing** — drop the eager allocation conversion; seal/unseal on demand at variable-type boundaries
- **C. Symmetric `gen`/`inst`** — remove the tag/conversion asymmetry in one direction or the other
- **D. Grounded-invariant typing** — fold the world/store invariants the DGG reconstructs into the type system itself (minted by `compile`, preserved by reduction)

Direction to be settled in comments before any Agda lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)