### PR TITLE
Add REALLMS agentic Agda proof-grinding harness

### DIFF
--- a/scripts/REALLMS.md
+++ b/scripts/REALLMS.md
@@ -1,0 +1,131 @@
+# REALLMS Agda proof-grinding harness
+
+Offload the token-heavy, mechanical part of Agda proof work to IU's free
+**REALLMS** LLM service, while Claude (or you) orchestrates: pick the goal,
+supply insight when needed, and let the model do the reading / editing /
+type-checking on **free** REALLMS tokens. Agda is the oracle — a candidate
+"passes" only if the whole file type-checks with no errors and no holes.
+
+## The service
+
+REALLMS is an OpenAI-compatible API (LiteLLM router + vLLM backend), hosted
+on-prem at IU, free for IU researchers.
+
+- Base URL: `https://reallms.rescloud.iu.edu/direct/v1`
+- KB: <https://servicenow.iu.edu/kb?id=kb_article_view&sysparm_article=KB0027272>
+- Get a key via RT Projects (create a project + REALLMS allocation, then make a
+  key on the allocation page).
+
+### API key
+
+Both scripts read the key from, in order:
+
+1. `$REALLMS_API_KEY`
+2. an `export REALLMS_API_KEY=...` line in `~/.zshrc`
+
+The key is never printed. Do **not** commit it.
+
+### Live text models (as of 2026-08)
+
+`glm-5.2`, `gpt-oss-120b`, `Qwen3-Coder-Next`, `gemma-4-31B-it`
+(plus embeddings/rerank/audio/image models not used here).
+
+## Which model?
+
+Benchmarked on reconstructing a real inductive proof (`renameᵗ-compose` in
+`GTPLC/proof/TypeInTypeSubst.agda`) that requires one genuine insight (a
+propositional-not-definitional commutation, closed with `renameᵗ-cong` + a local
+`where` lemma):
+
+| Model | Result |
+|---|---|
+| **glm-5.2** | solved with **no hint**, first `check_solution` |
+| **gpt-oss-120b** | solved with **no hint**, first `check_solution` |
+| Qwen3-Coder-Next | needed two corrective hints (weakest, despite "coder") |
+
+**Default to `glm-5.2` or `gpt-oss-120b`.** The "coder" model was the weakest on
+insight steps. (Caveat: that hole had a close in-file analog; genuinely novel
+holes will be harder.)
+
+## The two tools
+
+### `reallms_agent.py` — agentic worker (preferred)
+
+Gives the model its own tools so it finds its **own** context and iterates:
+
+- `grep(pattern, path?, max_results?)` — ripgrep over `*.agda` in the repo
+- `read_file(path, start?, end?)` — read any repo file (read-only)
+- `check_solution(code)` — splice `code` into the target region, run `agda`,
+  return `{ok, errors}`. This IS the feedback loop; the model calls it until
+  `ok`.
+
+Only a **compact** JSON report goes to stdout (final code, solved?, step/tool
+counts, short error) so the orchestrator's context stays tiny; the full
+blow-by-blow goes to `--log`.
+
+```bash
+python3.13 scripts/reallms_agent.py \
+  --model glm-5.2 \
+  --file GTPLC/proof/TypeInTypeSubst.agda \
+  --start 133 --end 133 \
+  --repo-root . \
+  --goal "Fill the hole: prove <signature>. Induct on A." \
+  --hint "optional one-line steer from the orchestrator" \
+  --max-steps 24 \
+  --log /tmp/agent.log
+```
+
+- `--start/--end` are the 1-based line range to replace (a hole line, or a whole
+  clause/lemma). Blank the target to a single `... = {!!}` first if you want the
+  model to reconstruct from scratch (otherwise it can read the existing proof).
+- `--hint` is the cheap "hybrid" lever: a sentence of insight from the
+  orchestrator, when the model stalls on the non-mechanical step.
+- The Agda project root is auto-detected from the file's `module A.B.C` line;
+  override with `--agda-root` if needed.
+
+### `reallms_grind.py` — scripted single-region loop
+
+No tool use: sends the whole file, asks for replacement code for a line range,
+splices, type-checks, and feeds the Agda error back for `--max-iters` rounds.
+Simpler, but the model only sees the one file — it cannot discover definitions
+in other files. Use `reallms_agent.py` unless you specifically want the model
+boxed to a single file.
+
+```bash
+python3.13 scripts/reallms_grind.py \
+  --file <path> --start N --end M --model glm-5.2 \
+  --max-iters 6 --instructions "curated context / strategy" --show-candidate
+```
+
+## Gotchas learned the hard way
+
+- **`reasoning_content`.** These vLLM models often leave `content` empty and put
+  the whole reply (final answer included) in a `reasoning_content` field. Both
+  scripts read both.
+- **Streaming is required.** Plain buffered reads hit `IncompleteRead` on long
+  reasoning responses; the agent streams SSE and assembles `tool_calls` from the
+  deltas. `gemma-4-31B-it` emits malformed tool-call JSON — avoid it for tool use.
+- **Agda project root.** Run `agda` with cwd = the module root (the dir the
+  dotted module name is relative to), not the repo root, or you get
+  "top level module does not match the file name". Auto-detected from the
+  `module` line.
+- **Verdict = no errors AND no unsolved metas.** A file with a hole still
+  "type-checks" with a warning, so both scripts explicitly reject
+  `Unsolved interaction metas` / `Unsolved metas`.
+
+## Orchestration pattern
+
+1. Read the proof state; classify each goal as *grind-friendly* (mechanical /
+   has an analog) vs *insight-heavy*.
+2. Grind-friendly → hand to `reallms_agent.py` with just a goal.
+3. Insight-heavy → design the key step yourself, then delegate the mechanical
+   remainder (or pass the insight as `--hint`).
+4. Apply what type-checks; re-scope or add a sharper hint when it stalls; escalate
+   model (`glm-5.2` → `gpt-oss-120b`) or step count as needed.
+
+## Safety
+
+The agent's file access is read-only except for the single target region, which
+it only writes transiently during `check_solution` (the original is always
+restored). It runs only `agda` and `rg`, and all paths are confined to
+`--repo-root`.

--- a/scripts/REALLMS.md
+++ b/scripts/REALLMS.md
@@ -22,8 +22,12 @@ Both scripts read the key from, in order:
 
 1. `$REALLMS_API_KEY`
 2. an `export REALLMS_API_KEY=...` line in `~/.zshrc`
+3. a `~/.reallms_key` file holding just the key
 
-The key is never printed. Do **not** commit it.
+The file is checked last so a working zshrc export is never shadowed by a stale
+file; it's the convenient option on a host without the export (e.g. after
+copying the key file to another machine). The key is never printed. Do **not**
+commit it.
 
 ### Live text models (as of 2026-08)
 

--- a/scripts/reallms_agent.py
+++ b/scripts/reallms_agent.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3.13
+"""
+Agentic REALLMS Agda worker.
+
+Give a REALLMS model its own tools (grep, read_file, check_solution) so it
+explores the repo, finds its OWN context, and iterates against `agda` feedback
+-- all on free REALLMS tokens, in its own context. Only a COMPACT result comes
+back on stdout (final code + pass/fail + short error), so the orchestrator's
+(Claude's) scarce token budget is barely touched. The full blow-by-blow
+transcript goes to --log for optional inspection.
+
+The worker's job: produce replacement Agda code for a region [start,end] of a
+target file so the whole file type-checks (no errors, no holes).
+
+Tools exposed to the model:
+  grep(pattern, path?, max_results?)   ripgrep over the repo (read-only)
+  read_file(path, start?, end?)        read a slice of any repo file
+  check_solution(code)                 splice code into the target region,
+                                       run agda, return ok + trimmed errors
+                                       (repeatable: this IS the feedback loop)
+
+Key is read from $REALLMS_API_KEY or ~/.zshrc; never printed.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+import urllib.error
+
+BASE_URL = "https://reallms.rescloud.iu.edu/direct/v1"
+
+
+def read_key() -> str:
+    k = os.environ.get("REALLMS_API_KEY")
+    if k:
+        return k.strip()
+    try:
+        with open(os.path.expanduser("~/.zshrc")) as f:
+            for line in f:
+                m = re.match(r'\s*export\s+REALLMS_API_KEY=(.*)', line)
+                if m:
+                    return m.group(1).strip().strip('"').strip("'")
+    except FileNotFoundError:
+        pass
+    sys.exit("No REALLMS_API_KEY found")
+
+
+def detect_agda_root(file_path: str) -> str:
+    mod = None
+    with open(file_path) as f:
+        for line in f:
+            m = re.match(r'\s*module\s+([\w.Ā-￿]+)\s+where', line)
+            if m:
+                mod = m.group(1)
+                break
+    d = os.path.dirname(os.path.abspath(file_path))
+    if mod:
+        for _ in range(mod.count(".")):
+            d = os.path.dirname(d)
+    return d
+
+
+# ---------- API (streaming, assembles tool_calls from deltas) ----------
+
+def chat(model, messages, key, tools, temperature=0.2):
+    payload = json.dumps({
+        "model": model, "messages": messages, "tools": tools,
+        "tool_choice": "auto", "temperature": temperature,
+        "max_tokens": 16384, "stream": True,
+    }).encode()
+    req = urllib.request.Request(
+        f"{BASE_URL}/chat/completions", data=payload,
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"}, method="POST")
+    content, reasoning = [], []
+    tool_calls = {}  # index -> {id, name, args}
+    finish = None
+    with urllib.request.urlopen(req, timeout=1200) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[len("data:"):].strip()
+            if data == "[DONE]":
+                break
+            try:
+                chunk = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            ch = (chunk.get("choices") or [{}])[0]
+            delta = ch.get("delta") or {}
+            if ch.get("finish_reason"):
+                finish = ch["finish_reason"]
+            if delta.get("content"):
+                content.append(delta["content"])
+            if delta.get("reasoning_content"):
+                reasoning.append(delta["reasoning_content"])
+            for tc in (delta.get("tool_calls") or []):
+                idx = tc.get("index", 0)
+                slot = tool_calls.setdefault(idx, {"id": None, "name": "", "args": ""})
+                if tc.get("id"):
+                    slot["id"] = tc["id"]
+                fn = tc.get("function") or {}
+                if fn.get("name"):
+                    slot["name"] = fn["name"]
+                if fn.get("arguments"):
+                    slot["args"] += fn["arguments"]
+    calls = [tool_calls[i] for i in sorted(tool_calls)]
+    return {"content": "".join(content), "reasoning": "".join(reasoning),
+            "tool_calls": calls, "finish": finish}
+
+
+# ---------- Tools ----------
+
+def trim_agda(out: str) -> str:
+    lines = [ln for ln in out.splitlines() if not ln.lstrip().startswith("Checking ")]
+    return "\n".join(lines).strip()[:2500]
+
+
+class Worker:
+    def __init__(self, repo_root, target, start, end, agda_root, log):
+        self.repo_root = os.path.abspath(repo_root)
+        self.target = os.path.abspath(target)
+        self.start, self.end = start, end
+        self.agda_root = agda_root
+        self.log = log
+        with open(self.target) as f:
+            self.original = f.read()
+        self.src_lines = self.original.splitlines(keepends=True)
+        self.counts = {"grep": 0, "read_file": 0, "check_solution": 0}
+        self.last_code = None
+        self.last_ok = False
+        self.last_errors = None
+
+    def _safe(self, path):
+        p = os.path.abspath(os.path.join(self.repo_root, path))
+        if not p.startswith(self.repo_root):
+            raise ValueError("path escapes repo root")
+        return p
+
+    def grep(self, pattern, path=None, max_results=40):
+        self.counts["grep"] += 1
+        target = self._safe(path) if path else self.repo_root
+        try:
+            proc = subprocess.run(
+                ["rg", "-n", "--no-heading", "-g", "*.agda", pattern, target],
+                capture_output=True, text=True, timeout=60)
+            lines = proc.stdout.splitlines()[:max_results]
+            rel = [ln.replace(self.repo_root + "/", "") for ln in lines]
+            return "\n".join(rel) if rel else "(no matches)"
+        except Exception as e:
+            return f"(grep error: {e})"
+
+    def read_file(self, path, start=None, end=None):
+        self.counts["read_file"] += 1
+        p = self._safe(path)
+        try:
+            with open(p) as f:
+                lines = f.readlines()
+        except Exception as e:
+            return f"(read error: {e})"
+        s = max(1, start or 1)
+        e = min(len(lines), end or len(lines))
+        chunk = "".join(f"{i}\t{lines[i-1]}" for i in range(s, e + 1))
+        return chunk[:6000]
+
+    def check_solution(self, code):
+        self.counts["check_solution"] += 1
+        self.last_code = code
+        new_lines = (self.src_lines[:self.start - 1] + [code + "\n"]
+                     + self.src_lines[self.end:])
+        try:
+            with open(self.target, "w") as f:
+                f.write("".join(new_lines))
+            proc = subprocess.run(["agda", self.target], cwd=self.agda_root,
+                                  capture_output=True, text=True)
+            out = proc.stdout + proc.stderr
+        finally:
+            with open(self.target, "w") as f:
+                f.write(self.original)
+        ok = (proc.returncode == 0
+              and "Unsolved interaction metas" not in out
+              and "Unsolved metas" not in out)
+        self.last_ok = ok
+        self.last_errors = "" if ok else trim_agda(out)
+        return {"ok": ok, "errors": self.last_errors}
+
+    def dispatch(self, name, args):
+        if name == "grep":
+            return self.grep(args.get("pattern", ""), args.get("path"),
+                             int(args.get("max_results", 40)))
+        if name == "read_file":
+            return self.read_file(args["path"], args.get("start"), args.get("end"))
+        if name == "check_solution":
+            return self.check_solution(args["code"])
+        return f"(unknown tool: {name})"
+
+
+TOOLS = [
+    {"type": "function", "function": {
+        "name": "grep",
+        "description": "Search *.agda files in the repo for a regex pattern (ripgrep). "
+                       "Returns matching 'relpath:line:text' lines. Use to find "
+                       "datatypes, lemmas, reduction rules, and usage examples.",
+        "parameters": {"type": "object", "properties": {
+            "pattern": {"type": "string"},
+            "path": {"type": "string", "description": "optional subdir/file to limit search"},
+            "max_results": {"type": "integer"}},
+            "required": ["pattern"]}}},
+    {"type": "function", "function": {
+        "name": "read_file",
+        "description": "Read a slice of a repo file (relative path). Returns "
+                       "line-numbered text. Use start/end to read just the region "
+                       "you need (definitions, sibling proofs, helper signatures).",
+        "parameters": {"type": "object", "properties": {
+            "path": {"type": "string"},
+            "start": {"type": "integer"}, "end": {"type": "integer"}},
+            "required": ["path"]}}},
+    {"type": "function", "function": {
+        "name": "check_solution",
+        "description": "Splice your candidate Agda code into the target region and "
+                       "type-check the whole file with agda. Returns {ok, errors}. "
+                       "Call this as many times as needed -- it is your feedback "
+                       "loop. When ok is true you are DONE.",
+        "parameters": {"type": "object", "properties": {
+            "code": {"type": "string", "description": "replacement code for the target region"}},
+            "required": ["code"]}}},
+]
+
+
+def logline(fh, s):
+    if fh:
+        fh.write(s + "\n")
+        fh.flush()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--file", required=True, help="target file (absolute)")
+    ap.add_argument("--start", type=int, required=True)
+    ap.add_argument("--end", type=int, required=True)
+    ap.add_argument("--goal", required=True, help="what to prove/produce")
+    ap.add_argument("--hint", default="", help="optional cheap steer from orchestrator")
+    ap.add_argument("--repo-root", default=os.getcwd())
+    ap.add_argument("--agda-root", default=None)
+    ap.add_argument("--max-steps", type=int, default=24)
+    ap.add_argument("--temperature", type=float, default=0.2)
+    ap.add_argument("--log", default=None)
+    args = ap.parse_args()
+
+    key = read_key()
+    target = os.path.abspath(args.file)
+    agda_root = args.agda_root or detect_agda_root(target)
+    w = Worker(args.repo_root, target, args.start, args.end, agda_root, args.log)
+    fh = open(args.log, "w") if args.log else None
+
+    region = "".join(w.src_lines[args.start - 1:args.end])
+    system = (
+        "You are an autonomous Agda proof engineer working inside a repository. "
+        "You have tools to grep and read any file, and a check_solution tool that "
+        "type-checks your candidate against the real agda compiler. Your job: "
+        "replace the indicated region of the target file so the whole file "
+        "type-checks with NO errors and NO holes. Explore the repo to find the "
+        "definitions, reduction rules, and sibling proofs you need -- do not guess "
+        "when you can look. Iterate with check_solution until ok=true. Be "
+        "thorough; token cost is not a concern. When check_solution returns "
+        "ok=true, stop and give a one-line summary."
+    )
+    user = (
+        f"Target file: {os.path.relpath(target, w.repo_root)}\n"
+        f"Region to replace: lines {args.start}-{args.end}, currently:\n\n"
+        f"```agda\n{region}\n```\n\n"
+        f"Goal: {args.goal}\n"
+        + (f"\nOrchestrator hint: {args.hint}\n" if args.hint else "")
+        + "\nProduce replacement code for exactly that region and verify it with "
+          "check_solution."
+    )
+    messages = [{"role": "system", "content": system},
+                {"role": "user", "content": user}]
+
+    status = "incomplete"
+    for step in range(1, args.max_steps + 1):
+        try:
+            r = chat(args.model, messages, key, TOOLS, args.temperature)
+        except Exception as e:
+            status = f"api_error: {e}"
+            break
+        logline(fh, f"\n===== step {step} =====")
+        if r["reasoning"]:
+            logline(fh, "[reasoning]\n" + r["reasoning"])
+        if r["content"]:
+            logline(fh, "[content]\n" + r["content"])
+
+        calls = r["tool_calls"]
+        # Build the assistant message to append (with tool_calls if any).
+        assistant_msg = {"role": "assistant", "content": r["content"] or ""}
+        if calls:
+            assistant_msg["tool_calls"] = [
+                {"id": c["id"] or f"call_{step}_{i}", "type": "function",
+                 "function": {"name": c["name"], "arguments": c["args"]}}
+                for i, c in enumerate(calls)]
+        messages.append(assistant_msg)
+
+        if not calls:
+            # No tool call: model thinks it's done or is chatting. Stop if solved.
+            logline(fh, "[no tool calls -> stopping]")
+            status = "solved" if w.last_ok else "gave_up"
+            break
+
+        for i, c in enumerate(calls):
+            cid = assistant_msg["tool_calls"][i]["id"]
+            try:
+                cargs = json.loads(c["args"]) if c["args"].strip() else {}
+            except json.JSONDecodeError as e:
+                result = f"(bad tool arguments JSON: {e})"
+                messages.append({"role": "tool", "tool_call_id": cid,
+                                 "name": c["name"], "content": result})
+                logline(fh, f"[tool {c['name']}] BAD ARGS: {c['args'][:200]}")
+                continue
+            result = w.dispatch(c["name"], cargs)
+            rendered = result if isinstance(result, str) else json.dumps(result)
+            logline(fh, f"[tool {c['name']}({json.dumps(cargs)[:200]})] -> "
+                        f"{rendered[:400]}")
+            messages.append({"role": "tool", "tool_call_id": cid,
+                             "name": c["name"], "content": rendered})
+            if c["name"] == "check_solution" and w.last_ok:
+                status = "solved"
+        if status == "solved":
+            break
+
+    # Compact report to stdout (this is all the orchestrator ingests).
+    report = {
+        "model": args.model,
+        "status": status,
+        "solved": w.last_ok,
+        "steps": step,
+        "tool_calls": w.counts,
+        "final_code": w.last_code,
+        "short_error": (w.last_errors or "")[:600] if not w.last_ok else "",
+        "log": args.log,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if fh:
+        logline(fh, "\n===== REPORT =====\n" + json.dumps(report, indent=2, ensure_ascii=False))
+        fh.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reallms_agent.py
+++ b/scripts/reallms_agent.py
@@ -34,18 +34,33 @@ BASE_URL = "https://reallms.rescloud.iu.edu/direct/v1"
 
 
 def read_key() -> str:
+    # 1. explicit env override
     k = os.environ.get("REALLMS_API_KEY")
-    if k:
+    if k and k.strip():
         return k.strip()
+    # 2. an `export REALLMS_API_KEY=...` line in ~/.zshrc
     try:
         with open(os.path.expanduser("~/.zshrc")) as f:
             for line in f:
                 m = re.match(r'\s*export\s+REALLMS_API_KEY=(.*)', line)
                 if m:
-                    return m.group(1).strip().strip('"').strip("'")
+                    v = m.group(1).strip().strip('"').strip("'")
+                    if v:
+                        return v
     except FileNotFoundError:
         pass
-    sys.exit("No REALLMS_API_KEY found")
+    # 3. a ~/.reallms_key file holding just the key (handy on a host without
+    #    the export, e.g. copied over to another machine). Ordered last so a
+    #    working zshrc export is never shadowed by a stale file.
+    try:
+        with open(os.path.expanduser("~/.reallms_key")) as f:
+            v = f.read().strip()
+            if v:
+                return v
+    except FileNotFoundError:
+        pass
+    sys.exit("No REALLMS_API_KEY found (checked $REALLMS_API_KEY, ~/.zshrc, "
+             "~/.reallms_key)")
 
 
 def detect_agda_root(file_path: str) -> str:
@@ -136,8 +151,11 @@ class Worker:
         self.last_errors = None
 
     def _safe(self, path):
-        p = os.path.abspath(os.path.join(self.repo_root, path))
-        if not p.startswith(self.repo_root):
+        # Resolve symlinks and use component-aware containment so a sibling
+        # like `<repo>-secret` or a symlink cannot escape the repo root.
+        root = os.path.realpath(self.repo_root)
+        p = os.path.realpath(os.path.join(root, path))
+        if p != root and os.path.commonpath([root, p]) != root:
             raise ValueError("path escapes repo root")
         return p
 
@@ -328,7 +346,10 @@ def main():
             messages.append({"role": "tool", "tool_call_id": cid,
                              "name": c["name"], "content": rendered})
             if c["name"] == "check_solution" and w.last_ok:
+                # Stop immediately: a later failing call in the same turn would
+                # otherwise overwrite the verified solution (last_code/last_ok).
                 status = "solved"
+                break
         if status == "solved":
             break
 

--- a/scripts/reallms_grind.py
+++ b/scripts/reallms_grind.py
@@ -29,19 +29,30 @@ BASE_URL = "https://reallms.rescloud.iu.edu/direct/v1"
 
 
 def read_key() -> str:
+    # env override, then an export in ~/.zshrc, then a ~/.reallms_key file
+    # (last, so a working zshrc export is never shadowed by a stale file).
     k = os.environ.get("REALLMS_API_KEY")
-    if k:
+    if k and k.strip():
         return k.strip()
-    zshrc = os.path.expanduser("~/.zshrc")
     try:
-        with open(zshrc) as f:
+        with open(os.path.expanduser("~/.zshrc")) as f:
             for line in f:
                 m = re.match(r'\s*export\s+REALLMS_API_KEY=(.*)', line)
                 if m:
-                    return m.group(1).strip().strip('"').strip("'")
+                    v = m.group(1).strip().strip('"').strip("'")
+                    if v:
+                        return v
     except FileNotFoundError:
         pass
-    sys.exit("No REALLMS_API_KEY found in env or ~/.zshrc")
+    try:
+        with open(os.path.expanduser("~/.reallms_key")) as f:
+            v = f.read().strip()
+            if v:
+                return v
+    except FileNotFoundError:
+        pass
+    sys.exit("No REALLMS_API_KEY found (checked $REALLMS_API_KEY, ~/.zshrc, "
+             "~/.reallms_key)")
 
 
 def chat(model: str, messages: list, key: str, temperature: float = 0.2):

--- a/scripts/reallms_grind.py
+++ b/scripts/reallms_grind.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3.13
+"""
+REALLMS Agda grinding harness.
+
+Given an Agda file and a line range to replace, ask a REALLMS model to produce
+replacement code, splice it in, type-check with the real `agda` binary, then
+restore the original file. Agda is the oracle: a clause succeeds iff type-check
+reports no errors and no "Unsolved interaction metas".
+
+The API key is read from (in priority order):
+  1. $REALLMS_API_KEY
+  2. the `export REALLMS_API_KEY=...` line in ~/.zshrc
+The key is never printed.
+
+Usage:
+  reallms_grind.py --file PATH --start N --end M --model NAME [--agda-root DIR]
+                   [--instructions TEXT] [--max-iters K] [--show-candidate]
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+import urllib.error
+
+BASE_URL = "https://reallms.rescloud.iu.edu/direct/v1"
+
+
+def read_key() -> str:
+    k = os.environ.get("REALLMS_API_KEY")
+    if k:
+        return k.strip()
+    zshrc = os.path.expanduser("~/.zshrc")
+    try:
+        with open(zshrc) as f:
+            for line in f:
+                m = re.match(r'\s*export\s+REALLMS_API_KEY=(.*)', line)
+                if m:
+                    return m.group(1).strip().strip('"').strip("'")
+    except FileNotFoundError:
+        pass
+    sys.exit("No REALLMS_API_KEY found in env or ~/.zshrc")
+
+
+def chat(model: str, messages: list, key: str, temperature: float = 0.2):
+    """Stream a chat completion (SSE) and return (content, reasoning).
+
+    Streaming avoids the IncompleteRead failures that plain urllib hits on these
+    long reasoning responses, and lets long generations complete reliably.
+    """
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": 16384,
+        "stream": True,
+    }).encode()
+    req = urllib.request.Request(
+        f"{BASE_URL}/chat/completions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    content_parts, reasoning_parts = [], []
+    try:
+        with urllib.request.urlopen(req, timeout=1200) as resp:
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[len("data:"):].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                choices = chunk.get("choices") or []
+                if not choices:
+                    continue
+                delta = choices[0].get("delta") or {}
+                if delta.get("content"):
+                    content_parts.append(delta["content"])
+                if delta.get("reasoning_content"):
+                    reasoning_parts.append(delta["reasoning_content"])
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        raise RuntimeError(f"HTTP {e.code}: {body[:500]}")
+    return "".join(content_parts), "".join(reasoning_parts)
+
+
+def extract_code(content: str, reasoning: str) -> str:
+    """Pull the LAST fenced code block, preferring `content` over `reasoning`.
+
+    The last block is the model's final answer (earlier blocks are drafts it
+    reconsidered). If neither has a fence, use whichever text is non-empty.
+    """
+    for text in (content, reasoning):
+        blocks = re.findall(r"```(?:agda)?\s*\n(.*?)```", text, re.DOTALL)
+        if blocks:
+            return blocks[-1].rstrip("\n")
+    return (content or reasoning).strip()
+
+
+def detect_agda_root(file_path: str) -> str:
+    """Infer the Agda include root from the file's `module A.B.C` declaration:
+    strip (len parts - 1) directory components off the file's directory."""
+    mod = None
+    with open(file_path) as f:
+        for line in f:
+            m = re.match(r'\s*module\s+([\w.Ā-￿]+)\s+where', line)
+            if m:
+                mod = m.group(1)
+                break
+    d = os.path.dirname(os.path.abspath(file_path))
+    if mod:
+        for _ in range(mod.count(".")):
+            d = os.path.dirname(d)
+    return d
+
+
+def typecheck(agda_root: str, file_path: str) -> tuple[bool, str]:
+    """Return (ok, output). ok iff no errors and no unsolved interaction metas."""
+    proc = subprocess.run(
+        ["agda", file_path],
+        cwd=agda_root,
+        capture_output=True,
+        text=True,
+    )
+    out = proc.stdout + proc.stderr
+    ok = (proc.returncode == 0) and ("Unsolved interaction metas" not in out) \
+        and ("Unsolved metas" not in out)
+    return ok, out
+
+
+def relevant_output(out: str, file_path: str) -> str:
+    """Trim the type-checker log to the interesting tail (errors/warnings)."""
+    lines = out.splitlines()
+    # Drop the "Checking X (...)" progress spam.
+    keep = [ln for ln in lines if not ln.lstrip().startswith("Checking ")]
+    tail = "\n".join(keep).strip()
+    return tail if tail else out[-2000:]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file", required=True, help="Agda file (absolute path)")
+    ap.add_argument("--start", type=int, required=True, help="1-based first line to replace")
+    ap.add_argument("--end", type=int, required=True, help="1-based last line to replace")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--agda-root", default=None,
+                    help="cwd for agda (defaults to file's dir chain root guess)")
+    ap.add_argument("--instructions", default="")
+    ap.add_argument("--max-iters", type=int, default=1,
+                    help="feedback iterations: re-prompt with the type error")
+    ap.add_argument("--temperature", type=float, default=0.2)
+    ap.add_argument("--show-candidate", action="store_true")
+    args = ap.parse_args()
+
+    key = read_key()
+    file_path = os.path.abspath(args.file)
+    agda_root = args.agda_root or detect_agda_root(file_path)
+
+    with open(file_path) as f:
+        original = f.read()
+    src_lines = original.splitlines(keepends=True)
+    region = "".join(src_lines[args.start - 1:args.end])
+
+    system = (
+        "You are an expert Agda proof engineer. You will be given a complete Agda "
+        "source file and asked to replace one specific region (a clause or a hole) "
+        "so that the whole file type-checks with no errors and no remaining holes. "
+        "Study the sibling clauses in the file and mirror their style exactly. "
+        "You MUST return ONLY the replacement Agda code for the indicated region, "
+        "inside a single ```agda code block, with no commentary. Do not include the "
+        "rest of the file. Preserve indentation appropriate to the region."
+    )
+    user = (
+        f"Here is the full file `{os.path.basename(file_path)}`:\n\n"
+        f"```agda\n{original}\n```\n\n"
+        f"Replace lines {args.start}-{args.end}, which currently are:\n\n"
+        f"```agda\n{region}\n```\n\n"
+        f"{args.instructions}\n\n"
+        "Return ONLY the replacement code for those lines, in one ```agda block."
+    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+    result = {"model": args.model, "ok": False, "iters": 0, "candidate": None,
+              "error": None, "agda_tail": None}
+    try:
+        for it in range(1, args.max_iters + 1):
+            result["iters"] = it
+            content, reasoning = chat(args.model, messages, key, args.temperature)
+            reply = content or reasoning
+            candidate = extract_code(content, reasoning)
+            result["candidate"] = candidate
+            # Splice: replace the region lines with candidate.
+            new_lines = (src_lines[:args.start - 1]
+                         + [candidate + "\n"]
+                         + src_lines[args.end:])
+            try:
+                with open(file_path, "w") as f:
+                    f.write("".join(new_lines))
+                ok, out = typecheck(agda_root, file_path)
+            finally:
+                with open(file_path, "w") as f:
+                    f.write(original)
+            tail = relevant_output(out, file_path)
+            result["agda_tail"] = tail
+            if ok:
+                result["ok"] = True
+                break
+            # Feedback for next iteration.
+            messages.append({"role": "assistant", "content": reply})
+            messages.append({
+                "role": "user",
+                "content": (
+                    "That did not type-check. Agda reported:\n\n"
+                    f"```\n{tail[:3000]}\n```\n\n"
+                    "Fix it. Return ONLY the corrected replacement code for the "
+                    "same region, in one ```agda block."
+                ),
+            })
+    except Exception as e:
+        result["error"] = str(e)
+
+    if not args.show_candidate:
+        result_print = dict(result)
+        result_print["candidate"] = (result["candidate"] or "")[:0] or None
+        print(json.dumps({k: result[k] for k in
+                          ["model", "ok", "iters", "error"]}, indent=2))
+        if result["agda_tail"]:
+            print("--- agda tail ---")
+            print(result["agda_tail"][:1500])
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Tooling to offload the mechanical part of Agda proof work to IU's free **REALLMS** LLM service (`https://reallms.rescloud.iu.edu/direct/v1`, OpenAI-compatible), while an orchestrator (Claude, or you) supplies goals and occasional insight. **Agda is the oracle** — a candidate passes only if the whole file type-checks with no errors and no holes.

- **`scripts/reallms_agent.py`** — agentic worker. Gives the model its own `grep` / `read_file` / `check_solution` tools so it finds its **own** context (definitions, sibling proofs, reduction rules) and iterates against real `agda` feedback — all on **free** REALLMS tokens. Only a compact JSON report goes to stdout; the full transcript goes to `--log`. Streams SSE and assembles `tool_calls` from deltas.
- **`scripts/reallms_grind.py`** — simpler single-region `propose → typecheck → feed-error-back` loop (the model sees only the one file).
- **`scripts/REALLMS.md`** — usage, model ranking, and the gotchas.

## Why

Motivated by token economics: the orchestrator's tokens are scarce; REALLMS tokens are free. So push the token-heavy reading/exploration/iteration onto REALLMS and keep results flowing back terse.

## Findings from validation

Reconstructed a real inductive proof (`renameᵗ-compose` in `GTPLC/proof/TypeInTypeSubst.agda`) end-to-end with the agentic worker, all exploration on free tokens.

**Model ranking** (on an insight-requiring goal): **`glm-5.2`** and **`gpt-oss-120b`** both solved with *no hint* on the first `check_solution`; `Qwen3-Coder-Next` (the "coder" model) was weakest, needing two corrective hints. Prefer `glm-5.2` / `gpt-oss-120b`. `gemma-4-31B-it` emits malformed tool-call JSON — avoid for tool use.

**Gotchas** (documented in `REALLMS.md`): these vLLM models often put the reply in `reasoning_content` with empty `content`; streaming is required to avoid `IncompleteRead` on long responses; `agda` must run with cwd = the module root (auto-detected).

## Notes

- API key is read from `~/.reallms_key`, never printed or committed.
- The agent's file access is read-only except the single target region (always restored); it runs only `agda` and `rg`, confined to `--repo-root`.
- No existing files changed; three new files under `scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)