### PR TITLE
Strong System F: Peel's dual is not tight for unlock entries (finding + refuted repair)

### DIFF
--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -26,6 +26,11 @@ open import strong.proof.MoveScope
 open import strong.proof.TypeSafety
 open import strong.proof.PreserveObstruct
 
+-- the TIGHTNESS OF THE DUAL: the defect (`Peel` gains scope) and the
+-- refutation of the three-part repair proposed for it
+open import strong.proof.DualTightness
+open import strong.proof.MwUObstruct
+
 -- the regression corpus and the renderer
 open import strong.Examples
 open import strong.Show

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -463,6 +463,20 @@ and an unlock at an unmasked slot is a no-op.  An `unlock` claims nothing
 and a `lock` claims nothing either; the claim lives in the conversion,
 where `seal X` must cite a live binder.
 
+**The cost of `mw-u`'s permissiveness, and why it cannot simply be
+raised** (2026-09-06).  Because an `unlock` claims nothing, a *vacuous*
+unlock — one at an already-unmasked slot — is well formed, and `dual`
+therefore cannot restore it (§6.3: the tightness defect).  Strengthening
+the premise to `Δ ∋e X , masked E` is **refuted** in
+`proof/MwUObstruct.agda`.  The reason is structural: `_⊢ᵐ_` is
+**simultaneous** (design law 4) while `scope` is **sequential** (the list
+is applied head-last).  Under the strengthened premise `mw-l` and `mw-u`
+become exact complements — a lock names a *nameable* slot, an unlock a
+*masked* one — so no simultaneous `_⊢ᵐ_` can hold of a list that both
+locks and unlocks one slot.  The scope move `_⋉_` (§6.7) builds exactly
+such lists, and `⊢retag` (which carries `_⊢ᵐ_` along `⊑`, whose `le-mu`
+clause *unmasks*) loses its `env` case as well.
+
 ### 4.3 Terms
 
     ⊢`  : Γ ∋ x ⦂ A → Δ ∣ Γ ⊢ x ⦂ A
@@ -721,6 +735,27 @@ Example (`Examples` §6, `P₁ → P₂`), with
 The `7` has crossed inward and is now sealed at the new binder, so the
 interior sees it at the abstract name `X` — which is exactly what
 `λx:X. x` demands.
+
+**OPEN: `Peel` is not tight** (Jeremy's test, 2026-09-06;
+`proof/DualTightness.agda`).  `dualScope` **drops** `Θ`'s `unlock`
+entries, so a boundary that unmasks an exterior slot hands its crossing
+argument a frame in which that slot is *still* unmasked:
+`interior (dual Θ) (interior Θ Δ)` is the masked bind prefix over
+`unlockedScope Θ Δ`, which is strictly more nameable than `Δ`.  The
+machine-checked witness — `Δᵤ = ↓U`, `Θᵤ = ↥U`, `W = λy:ℕ. (ΛZ. 3)[U]` —
+takes an **ill-typed** redex to a **well-typed** contractum: scope is
+gained through the boundary.  This is not a preservation failure (the
+redex is not well typed, and `preserve-Peel` is a theorem); it is a
+failure of design law 2 for the *reduction relation*.
+
+The repair — restore what `Θ` unlocked, `dualScope n (unlock X ∷ Θ) =
+lock (n + X) ∷ dualScope n Θ`, with an `mw-u` that forbids vacuous
+unlocks — is **refuted** in `proof/MwUObstruct.agda` (see §4.2): the
+restored lock is only correct when the slot really was masked, so the
+two changes are coupled, and the strengthened `mw-u` is incompatible with
+both the scope move and `⊢retag`.  The two readings of `_⊢ᵐ_` that
+survive §3/§4 (sequential premises, or a cancelling merge) are design
+decisions, not repairs; §5/§6 of that module price the sequential one.
 
 ### 6.4 `TyPeelR` — a `∀` conversion meets a type application
 
@@ -1120,7 +1155,11 @@ machine-checked consequence in tree.
 2. **Tightness, for terms and for scope.**  A masked slot may not be
    named in any type; `Nameable` and `wf-var` are the whole enforcement.  But
    *mentioning* a masked index in a morphism entry (`↓X`, `↥X`) is not a
-   use, and `_⊢ᵐ_` permits it.
+   use, and `_⊢ᵐ_` permits it.  **The law is currently broken for the
+   reduction relation**: `Peel`'s `dual` drops `unlock` entries, so the
+   crossing frame can be *more* nameable than the exterior
+   (`proof/DualTightness.agda`; the repair is refuted in
+   `proof/MwUObstruct.agda`, and §4.2/§6.3 say why).
 3. **No term type-shifts.**  Shift types, not terms.  The only index
    arithmetic in the design is ordinary de Bruijn binder offsets:
    `numBinds Θ`, `shiftBy`, and the `n + X` lift in `scopeOf` and `dualScope`.

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -83,6 +83,8 @@ driver: type-checking it type-checks the whole thing.
 | `MaskFacts.agda` | no boundary operation can take a binder away (masking retains, unlocking recovers); the old cancel residue is not well formed |
 | `Adversary.agda` | the soundness gate: a conceal must cite a live binder, and v1's adversaries refuted by that one inversion |
 | `PreserveObstruct.agda` | the four refutation witnesses, three of which now record the **positive** fact after the repairs (§2 `TyPeelR`, §4 the wall witness) |
+| `DualTightness.agda` | **the tightness defect**: `dual` drops `unlock` entries, so `Peel` takes an **ill-typed** redex to a **well-typed** contractum — scope is gained through the boundary (Jeremy's test, 2026-09-06), plus the positive control at a `lock` |
+| `MwUObstruct.agda` | the three-part repair for it (masked-only `mw-u`, `unlock ↦ lock` in `dualScope`, a binds-only outer frame), **refuted**: §1 why (2) forces (1), §2 (1) kills `⊢retag`, §3/§4 (1) kills the scope move `_⋉_` at a well-typed `IdPush` redex, §5/§6 what a sequential `_⊢ᵐ_` would additionally cost |
 | `TypeSafety.agda` | `type-safety` = `progress ∘ preservation*` |
 
 **The invariant hunt** — the search for a side condition that would

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2453,3 +2453,37 @@ The `_⊑ᵉ_` constructors lose their owner/blocked initials: le-ao → le-ab
 (abst ⊑ bind), le-oo → le-bb (bind ⊑ bind), and the masked pair le-bb →
 le-mm, le-bu → le-mu; le-aa stays.  Then the PR is marked ready for
 review.
+
+### Peel's dual is NOT tight for `unlock` entries (Jeremy's test, 2026-09-06)
+
+Jeremy: "I don't fully understand the definition of dual and not sure I
+trust it … create an example program that takes a Peel step, and the
+program should have an ill-formed type in the argument W, and after the
+reduction step, W wrapped in the dual boundary should still be
+ill-formed."  RESULT (proof/DualTightness.agda): bind entries are tight
+(wkᴹ shifts W's indices past them) but `dualScope` DROPS unlocks, so with
+exterior ⌷[X := ℕ], Θ = ↥X, W = λx:ℕ. (ΛY. 3)[X] (names the masked X;
+ill-typed), the redex `(V ⟪ ↥X , c ⟫) · W` is ill-typed and its Peel
+contractum is WELL-TYPED (W's frame inside is bind ℕ: X visible).  Scope
+is gained through the boundary — design law 2 fails for the RELATION
+(not a preservation failure: the redex is ill-typed).
+
+PROBED FIX, REFUTED (proof/MwUObstruct.agda): (1) mw-u requires a masked
+slot, (2) dualScope maps unlock ↦ lock, (3) the scope move's outer frame
+becomes bindsOnly.  (3) alone is GOOD: interior-⋉-bindsOnly and
+convCtx-⋉-bindsOnly are EQUALITIES (frame-move's ⊑ was an artifact of the
+retained unlocks).  But (2) forces (1) (a vacuous unlock, legal today,
+makes preserve-Peel false under dual′), and (1) kills ⊢ᵐ-⊑ hence ⊢retag
+(le-mu: Cancel's own refinement unmasks a slot an unlock cites) and kills
+⊢ᵐ-⋉ (⋉ builds lists that lock AND unlock one slot; under (1) mw-l and
+mw-u are exact complements so no SIMULTANEOUS ⊢ᵐ can hold — §3/§4 mirror
+witnesses).  Structural reason: `_⊢ᵐ_` is simultaneous (law 4), `scope`
+is sequential.  Sequential ⊢ᵐ (§5/§6) would force dualScope to reverse
+and mw-b's rep to be read sequentially — colliding with simultaneity.
+NEXT CANDIDATE (δ), to probe: leave ⊢ᵐ alone and make the dual read the
+EXTERIOR: `dual Δ Θ` maps `unlock X ↦ lock X` only when X is masked in Δ
+(reduction is Δ-indexed, so Peel may inspect Δ; simultaneity respected —
+one read on the plain Δ).  Then vacuous unlocks add nothing (preserve-Peel
+survives), non-vacuous ones are re-locked (the leak closes), and
+`interior (dual Δ Θ) (interior Θ Δ) ≡ masked binds ++ Δ` should be exact
+with no change to the scope move.

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2487,3 +2487,22 @@ one read on the plain Δ).  Then vacuous unlocks add nothing (preserve-Peel
 survives), non-vacuous ones are re-locked (the leak closes), and
 `interior (dual Δ Θ) (interior Θ Δ) ≡ masked binds ++ Δ` should be exact
 with no change to the scope move.
+
+### RULING: vacuous unlocks are wrong and unreachable (Jeremy, 2026-09-06)
+
+Jeremy: "why do we allow ↥X over X := ℕ visible?  That feels wrong … and
+unreachable."  RULED: the judgment must refuse them (mw-u's slot must be
+masked).  Hint for the probe: "my feeling is you're missing a few
+premises … look for places where information is dropped."  Two probes
+run in parallel, both non-landing: (δ) branch dual-relock — a Δ-dependent
+dual that re-locks only non-vacuous unlocks, leaving `_⊢ᵐ_` alone; and
+the PRINCIPLED package, branch dual-principled — audit of dropped
+information (mw-u's maskedness, dualScope dropping unlocks, the scope
+move's dropped entries, `_⊢ᵐ_` reading scope premises on the plain Δ and
+so dropping order, le-mu forgetting maskedness, Peel's crossing retype,
+mw-b's rep independence from the same morphism's unlocks), then:
+masked-only mw-u with SEQUENTIAL scope premises (reps stay on the plain
+Δ — simultaneity), dualScope restoring unlock ↦ lock, ⊢retag over the
+non-unmasking refinement only, scope move with bindsOnly outer frame
+(frame lemmas as equalities).  Expected sticking point: Θ₁'s bind reps
+under the move (MwUObstruct §6) — the missing premise, if any, is there.

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -1,0 +1,162 @@
+module strong.proof.DualTightness where
+
+-- TIGHTNESS OF THE DUAL — Jeremy's test (2026-09-06), MACHINE-CHECKED.
+--
+-- THE DEFECT.  `dualScope` (strong.Reduction §2) DROPS the crossed
+-- boundary's `unlock` entries.  So a boundary whose morphism UNMASKS an
+-- exterior slot hands its crossing argument a frame in which that slot is
+-- STILL unmasked: `interior (dual Θ) (interior Θ Δ)` is
+-- `map masked (bind prefix) ++ unlockedScope Θ Δ` (proof/PeelDual,
+-- `interior-dual`), and `unlockedScope Θ Δ` is STRICTLY MORE NAMEABLE than
+-- Δ whenever Θ unlocks a slot Δ masks.  SCOPE IS GAINED THROUGH THE
+-- BOUNDARY.
+--
+-- The witness below exhibits the gain as a rule-level fact: a redex that
+-- is ILL TYPED at Δ (its argument W names a slot MASKED at Δ) whose `Peel`
+-- contractum is WELL TYPED.  `Peel` therefore does not preserve the
+-- exterior's scope discipline; the crossing is not tight.
+--
+-- Nothing here contradicts preservation — `Peel`'s preservation case is
+-- proven (proof/PeelDual.preserve-Peel) and only ever runs on a
+-- WELL-TYPED redex, which this one is not.  What fails is TIGHTNESS: the
+-- REDUCTION RELATION relates a term the exterior refuses to a term it
+-- accepts.
+--
+-- The repair Jeremy proposes — `dualScope n (unlock X ∷ Θ) =
+-- lock (n + X) ∷ dualScope n Θ`, together with an `mw-u` that requires the
+-- slot to be MASKED — is REFUTED in proof/MwUObstruct.agda: it is
+-- incompatible with the scope move (`_⋉_`) and with `⊢retag`.
+
+open import Data.Nat using (ℕ)
+open import Data.List using ([]; _∷_)
+open import Data.Product using (_,_)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import strong.Types
+open import strong.Ctx
+open import strong.Conversion
+open import strong.Terms
+open import strong.Reduction
+
+------------------------------------------------------------------------
+-- §1  The exterior: one MASKED binder
+------------------------------------------------------------------------
+
+-- Δᵤ = ↓U (one slot U, a binder at ℕ, CONCEALED: we sit inside a region
+-- that masks it).
+Δᵤ : Ctxᵗ
+Δᵤ = masked (bind `ℕ) ∷ []
+
+-- U is not nameable at the exterior — that is the whole of tightness.
+¬∋tv-Δᵤ : ¬ (Δᵤ ∋tv 0)
+¬∋tv-Δᵤ (_ , ez , ())
+
+-- The boundary's morphism UNMASKS U for its interior (the
+-- crossing-of-crossing shape: an inner region re-exposes what an outer
+-- one concealed).
+Θᵤ : CtxMorph
+Θᵤ = unlock 0 ∷ []
+
+_ : interior Θᵤ Δᵤ ≡ bind `ℕ ∷ []
+_ = refl
+
+------------------------------------------------------------------------
+-- §2  The redex
+------------------------------------------------------------------------
+
+-- V = λx:(U ⇒ ℕ). x
+--   scripts/render_term.sh 'showTmIn 1 V'  =  (λx:(X⇒ℕ). x)
+V : Term
+V = ƛ (` 0 ⇒ `ℕ) ∙ (` 0)
+
+-- the conversion: (U⇒ℕ)⇒(U⇒ℕ) inside  ⇝  (ℕ⇒ℕ)⇒(ℕ⇒ℕ) outside
+cᵤ : Conv
+cᵤ = (unseal 0 ↦ id `ℕ) ↦ (seal 0 ↦ id `ℕ)
+
+-- W = λy:ℕ. (ΛZ. 3)[U] : ℕ ⇒ ℕ — a VALUE, and ILL TYPED at the exterior,
+-- because its type argument NAMES U, which Δᵤ masks.
+--   scripts/render_term.sh 'showTmIn 1 W'  =  (λx:ℕ. (ΛY. 3) [X])
+W : Term
+W = ƛ `ℕ ∙ ((Λ ($ 3)) ·[ `ℕ , ` 0 ])
+
+¬⊢W-ext : ∀ {Γ A} → ¬ (Δᵤ ∣ Γ ⊢ W ⦂ A)
+¬⊢W-ext (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
+
+-- The boundary ALONE is well typed at Δᵤ …
+⊢Vb : Δᵤ ∣ [] ⊢ V ⟪ Θᵤ , cᵤ ⟫ ⦂ ((`ℕ ⇒ `ℕ) ⇒ (`ℕ ⇒ `ℕ))
+⊢Vb = env (mw-u ez mw[])
+          (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
+          (conv-fun (conv-fun (conv-unseal ez) (conv-id base-ℕ))
+                    (conv-fun (conv-seal ez) (conv-id base-ℕ)))
+          (wf-⇒ (wf-⇒ wf-ℕ wf-ℕ) (wf-⇒ wf-ℕ wf-ℕ))
+
+-- … so the redex is ill typed ONLY because of W.
+--   scripts/render_term.sh 'showTmIn 1 Redex'  =
+--     (((λx:(X⇒ℕ). x) ⟪ ↥X , ((unseal X ↦ id ℕ) ↦ (seal X ↦ id ℕ)) ⟫)
+--        · (λx:ℕ. (ΛY. 3) [X]))
+Redex : Term
+Redex = (V ⟪ Θᵤ , cᵤ ⟫) · W
+
+¬⊢Redex : ∀ {A} → ¬ (Δᵤ ∣ [] ⊢ Redex ⦂ A)
+¬⊢Redex (⊢· _ ⊢W) = ¬⊢W-ext ⊢W
+
+------------------------------------------------------------------------
+-- §3  The step, and the WELL-TYPED contractum
+------------------------------------------------------------------------
+
+-- THE DUAL DROPS THE UNLOCK.
+_ : dual Θᵤ ≡ []
+_ = refl
+
+--   scripts/render_term.sh 'showTmIn 1 Contractum'  =
+--     (((λx:(X⇒ℕ). x) · ((λx:ℕ. (ΛY. 3) [X]) ⟪ (unseal X ↦ id ℕ) ⟫))
+--        ⟪ ↥X , (seal X ↦ id ℕ) ⟫)
+-- — note the crossing argument's frame is EMPTY (`dual Θᵤ ≡ []`).
+Contractum : Term
+Contractum = (V · (W ⟪ dual Θᵤ , unseal 0 ↦ id `ℕ ⟫)) ⟪ Θᵤ , seal 0 ↦ id `ℕ ⟫
+
+step-u : Δᵤ ⊢ Redex -→ Contractum
+step-u = Peel V-ƛ V-ƛ
+
+-- W's frame INSIDE the crossing is `bind ℕ ∷ []` — U is nameable there,
+-- because the dual restored nothing.
+_ : interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ bind `ℕ ∷ []
+_ = refl
+
+-- … and so the contractum TYPES.  SCOPE WAS GAINED.
+⊢Contractum : Δᵤ ∣ [] ⊢ Contractum ⦂ (`ℕ ⇒ `ℕ)
+⊢Contractum =
+  env (mw-u ez mw[])
+      (⊢· (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
+          (env mw[]
+               (⊢ƛ wf-ℕ (⊢·[] (⊢Λ ⊢$) (wf-var (bind `ℕ , ez , nameable-b))))
+               (conv-fun (conv-unseal ez) (conv-id base-ℕ))
+               (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ)))
+      (conv-fun (conv-seal ez) (conv-id base-ℕ))
+      (wf-⇒ wf-ℕ wf-ℕ)
+
+------------------------------------------------------------------------
+-- §4  THE POSITIVE CONTROL
+------------------------------------------------------------------------
+
+-- The same shape with a Θ-LOCKED slot behaves correctly: `dual` DOES mint
+-- an `unlock` for a `lock`, so a crossing argument that names a slot the
+-- boundary locked keeps its frame.  Δ has ONE nameable binder Z; Θˡ locks
+-- it; the dual unlocks it again, and the argument's frame inside is Δ with
+-- the bind prefix masked — Z still nameable.
+Δˡ : Ctxᵗ
+Δˡ = bind `ℕ ∷ []
+
+Θˡ : CtxMorph
+Θˡ = lock 0 ∷ []
+
+_ : interior Θˡ Δˡ ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+_ : dual Θˡ ≡ unlock 0 ∷ []
+_ = refl
+
+-- the crossing frame is Δˡ back: Z is nameable, exactly as at the exterior
+_ : interior (dual Θˡ) (interior Θˡ Δˡ) ≡ bind `ℕ ∷ []
+_ = refl

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -1,0 +1,430 @@
+module strong.proof.MwUObstruct where
+
+-- THE PROPOSED TIGHTNESS REPAIR, REFUTED — with witnesses.
+--
+-- proof/DualTightness.agda machine-checks the defect: `dualScope` DROPS
+-- the crossed boundary's `unlock` entries, so `Peel` GAINS SCOPE.  The
+-- repair on the table (Jeremy, 2026-09-06) is three coupled changes:
+--
+--   (1) `mw-u` requires the slot to be MASKED —
+--       `mw-u : Δ ∋e X , masked E → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)`
+--       (no vacuous unlocks);
+--   (2) `dualScope n (unlock X ∷ Θ) = lock (n + X) ∷ dualScope n Θ`
+--       (restore what Θ unlocked);
+--   (3) the outer boundary of CancelR/IdPush becomes BINDS-ONLY
+--       (`bindsOnly Θ₂` in place of `dropLocks Θ₂`), so the moved scope
+--       duplicates no unlock.
+--
+-- THIS MODULE ESTABLISHES:
+--
+--   §1  (2) FORCES (1).  With (2) alone, `Peel` OVER-masks at a vacuous
+--       unlock and `preserve-Peel` is FALSE — witness: a WELL-TYPED redex
+--       whose contractum is ill typed.
+--   §2  (1) REFUTES `⊢ᵐ-⊑`, hence `⊢retag` (strong.TermSubst) — the
+--       transport `Δ ⊑ Δ′` cannot carry an `unlock` across a refinement
+--       that UNMASKS the slot it names.
+--   §3  (1) REFUTES THE SCOPE MOVE, at `Θ₂` locking what `Θ₁` unlocks:
+--       a WELL-TYPED IdPush redex whose contractum's merged frame
+--       `Θ₁ ⋉ Θ₂ = unlock 1 ∷ lock 1 ∷ []` is read over a type context
+--       where slot 1 is a PLAIN BINDER.  Both candidate outer frames
+--       (`dropLocks Θ₂` and `bindsOnly Θ₂`) fail on it.
+--   §4  … and the MIRROR, at `Θ₂` unlocking what `Θ₁` locks.
+--   §5  IF `⊢ᵐ` were made SEQUENTIAL (the only reading of §3/§4 that
+--       survives), THEN `dualScope` must also REVERSE its list: the
+--       same-order dual is not an inverse.
+--   §6  … and `bindsOnly`'s own `⊢ᵐ` then fails, because a `bind`'s rep is
+--       read on the PLAIN exterior (simultaneity) while the move needs it
+--       read past the frame's own unlocks.
+--
+-- THE SHAPE OF THE OBSTRUCTION, in one line: `⊢ᵐ` is SIMULTANEOUS (every
+-- entry's premise is read on the PLAIN exterior Δ) while `scope` is
+-- SEQUENTIAL (the list is applied head-last).  Under (1) `mw-l` and `mw-u`
+-- become EXACT COMPLEMENTS — a lock names a NAMEABLE slot, an unlock a
+-- MASKED one — so no simultaneous `⊢ᵐ` can hold of a list that both locks
+-- and unlocks the same slot.  The scope move `_⋉_` builds exactly such
+-- lists.
+
+open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.List using (List; []; _∷_; _++_; length)
+open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
+open import Data.Empty using (⊥)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong; trans)
+
+open import strong.Types
+open import strong.Ctx
+open import strong.Conversion
+open import strong.Terms
+open import strong.TermSubst using (wkᴹ)
+open import strong.Reduction
+open import strong.proof.DualTightness using (Δᵤ; Θᵤ)
+open import strong.proof.MoveScope using (interior-⋉; convCtx-⋉; scope-scopeOf)
+
+------------------------------------------------------------------------
+-- §0  The three proposed definitions, LOCALLY
+------------------------------------------------------------------------
+
+-- (2): the dual RESTORES what Θ unlocked, keeping `lock ↦ unlock`.
+dualScope′ : ℕ → CtxMorph → CtxMorph
+dualScope′ n []             = []
+dualScope′ n (bind A ∷ Θ)   = dualScope′ n Θ
+dualScope′ n (unlock X ∷ Θ) = lock   (n + X) ∷ dualScope′ n Θ
+dualScope′ n (lock X ∷ Θ)   = unlock (n + X) ∷ dualScope′ n Θ
+
+dual′ : CtxMorph → CtxMorph
+dual′ Θ = hideBinds (numBinds Θ) ++ dualScope′ (numBinds Θ) Θ
+
+-- (3): the outer boundary keeps ONLY the binds.
+bindsOnly : CtxMorph → CtxMorph
+bindsOnly []             = []
+bindsOnly (bind A ∷ Θ)   = bind A ∷ bindsOnly Θ
+bindsOnly (unlock X ∷ Θ) = bindsOnly Θ
+bindsOnly (lock X ∷ Θ)   = bindsOnly Θ
+
+------------------------------------------------------------------------
+-- §1  (2) FORCES (1):  the vacuous unlock, and preserve-Peel REFUTED
+------------------------------------------------------------------------
+
+-- ON JEREMY'S WITNESS (proof/DualTightness) THE REPAIR WORKS.  Θᵤ unlocks
+-- a slot Δᵤ MASKS, so the restored lock lands where it should and the
+-- crossing frame is Δᵤ EXACTLY — the contractum's argument is refused,
+-- which is tightness.
+_ : dual′ Θᵤ ≡ lock 0 ∷ []
+_ = refl
+
+_ : interior (dual′ Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ
+_ = refl
+
+-- BUT `mw-u` AS IT STANDS PERMITS A VACUOUS UNLOCK — a slot that is NOT
+-- masked — and there the restored lock MASKS A SLOT THE EXTERIOR LEFT
+-- NAMEABLE.  Δᵥ has one PLAIN binder; Θᵥ unlocks it for nothing.
+Δᵥ : Ctxᵗ
+Δᵥ = bind `ℕ ∷ []
+
+Θᵥ : CtxMorph
+Θᵥ = unlock 0 ∷ []
+
+⊢ᵐΘᵥ : Δᵥ ⊢ᵐ Θᵥ                  -- legal today: an unlock claims nothing
+⊢ᵐΘᵥ = mw-u ez mw[]
+
+_ : interior Θᵥ Δᵥ ≡ Δᵥ          -- and does nothing
+_ = refl
+
+-- V₀ = λx:ℕ. 7,  crossed at  (ℕ⇒ℕ) inside  ⇝  (Z⇒ℕ) outside
+V₀ : Term
+V₀ = ƛ `ℕ ∙ ($ 7)
+
+c₀ : Conv
+c₀ = unseal 0 ↦ id `ℕ
+
+-- W₀ = 3 sealed at Z's binder: a VALUE of type ` 0 at Δᵥ
+W₀ : Term
+W₀ = ($ 3) ⟪ [] , seal 0 ⟫
+
+⊢W₀ : Δᵥ ∣ [] ⊢ W₀ ⦂ ` 0
+⊢W₀ = env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
+
+Redexᵥ : Term
+Redexᵥ = (V₀ ⟪ Θᵥ , c₀ ⟫) · W₀
+
+-- THE REDEX IS WELL TYPED.
+⊢Redexᵥ : Δᵥ ∣ [] ⊢ Redexᵥ ⦂ `ℕ
+⊢Redexᵥ =
+  ⊢· (env ⊢ᵐΘᵥ (⊢ƛ wf-ℕ ⊢$)
+          (conv-fun (conv-unseal ez) (conv-id base-ℕ))
+          (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ))
+     ⊢W₀
+
+stepᵥ : Δᵥ ⊢ Redexᵥ -→ (V₀ · (wkᴹ 0 W₀ ⟪ dual Θᵥ , unseal 0 ⟫)) ⟪ Θᵥ , id `ℕ ⟫
+stepᵥ = Peel V-ƛ (V-⟪⟫ V-$ I-seal)
+
+-- UNDER (2) THE CROSSING FRAME MASKS Z, WHICH Δᵥ DID NOT.
+_ : dual′ Θᵥ ≡ lock 0 ∷ []
+_ = refl
+
+_ : interior (dual′ Θᵥ) (interior Θᵥ Δᵥ) ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+-- … so the crossing argument does not retype, and the contractum is ILL
+-- TYPED.  `preserve-Peel` is FALSE under (2) alone: hence (1).
+¬⊢W₀-inside : ∀ {A} → ¬ (masked (bind `ℕ) ∷ [] ∣ [] ⊢ W₀ ⦂ A)
+¬⊢W₀-inside (env _ _ _ (wf-var (_ , ez , ())))
+
+------------------------------------------------------------------------
+-- §2  (1) REFUTES `⊢ᵐ-⊑`, HENCE `⊢retag`
+------------------------------------------------------------------------
+
+-- `⊢retag : Δ ⊑ Δ′ → Δ ∣ Γ ⊢ M ⦂ A → Δ′ ∣ Γ ⊢ M ⦂ A` (strong.TermSubst)
+-- runs `⊢ᵐ-⊑` on every boundary it crosses.  Under (1) an `unlock X`
+-- CLAIMS that X is masked, and `le-mu` — the ⊑ᵉ clause that RE-EXPOSES a
+-- concealed slot (Cancel's own refinement) — destroys the claim.
+Δₘ Δₙ : Ctxᵗ
+Δₘ = masked (bind `ℕ) ∷ []
+Δₙ = bind `ℕ ∷ []
+
+refine-mn : Δₘ ⊑ Δₙ
+refine-mn = le∷ (le-mu le-bb nameable-b) le[]
+
+M₂ : Term
+M₂ = ($ 3) ⟪ unlock 0 ∷ [] , id `ℕ ⟫
+
+⊢M₂ : Δₘ ∣ [] ⊢ M₂ ⦂ `ℕ
+⊢M₂ = env (mw-u ez mw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+
+-- but slot 0 of Δₙ is a PLAIN binder, so `mw-u` under (1) has no premise
+-- to offer, and `Δₙ ⊢ᵐ (unlock 0 ∷ [])` is not derivable.
+no-masked-Δₙ : ∀ {E} → ¬ (Δₙ ∋e 0 , masked E)
+no-masked-Δₙ ()
+
+------------------------------------------------------------------------
+-- §3  (1) REFUTES THE SCOPE MOVE — Θ₂ LOCKS WHAT Θ₁ UNLOCKS
+------------------------------------------------------------------------
+
+-- Δᵢ: slot 0 a binder at ℕ, slot 1 a binder at 𝔹.
+Δᵢ : Ctxᵗ
+Δᵢ = bind `ℕ ∷ bind `𝔹 ∷ []
+
+Θ₂ᵢ : CtxMorph          -- the OUTER frame LOCKS slot 1
+Θ₂ᵢ = lock 1 ∷ []
+
+Θ₁ᵢ : CtxMorph          -- the INNER frame UNLOCKS it again
+Θ₁ᵢ = unlock 1 ∷ []
+
+_ : interior Θ₂ᵢ Δᵢ ≡ bind `ℕ ∷ masked (bind `𝔹) ∷ []
+_ = refl
+
+-- LEGAL UNDER (1): the inner unlock names a slot its OWN exterior masks.
+⊢ᵐΘ₁ᵢ : interior Θ₂ᵢ Δᵢ ⊢ᵐ Θ₁ᵢ
+⊢ᵐΘ₁ᵢ = mw-u (es ez) mw[]
+
+_ : interior Θ₁ᵢ (interior Θ₂ᵢ Δᵢ) ≡ bind `ℕ ∷ bind `𝔹 ∷ []
+_ = refl
+
+-- a value of type ` 0: a numeral sealed at slot 0's binder
+Vᵢ : Term
+Vᵢ = ($ 5) ⟪ [] , seal 0 ⟫
+
+Redexᵢ : Term
+Redexᵢ = (Vᵢ ⟪ Θ₁ᵢ , id (` 0) ⟫) ⟪ Θ₂ᵢ , unseal 0 ⟫
+
+-- THE REDEX IS WELL TYPED.
+⊢Redexᵢ : Δᵢ ∣ [] ⊢ Redexᵢ ⦂ `ℕ
+⊢Redexᵢ =
+  env (mw-l (bind `𝔹 , es ez , nameable-b) mw[])
+      (env ⊢ᵐΘ₁ᵢ
+           (env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b)))
+           (conv-idv (bind `ℕ , ez , nameable-b))
+           (wf-var (bind `ℕ , ez , nameable-b)))
+      (conv-unseal ez)
+      wf-ℕ
+
+stepᵢ : Δᵢ ⊢ Redexᵢ -→ (Vᵢ ⟪ Θ₁ᵢ ⋉ Θ₂ᵢ , unseal 0 ⟫) ⟪ dropLocks Θ₂ᵢ , mkId `ℕ ⟫
+stepᵢ = IdPush (V-⟪⟫ V-$ I-seal) ez
+
+-- THE MERGED FRAME both unlocks and locks slot 1 …
+_ : _≡_ {A = CtxMorph} (Θ₁ᵢ ⋉ Θ₂ᵢ) (unlock 1 ∷ lock 1 ∷ [])
+_ = refl
+
+-- … and BOTH candidate outer frames leave it read over Δᵢ, where slot 1
+-- is a PLAIN binder.  (Θ₂ᵢ has neither binds nor unlocks, so `dropLocks`
+-- and `bindsOnly` agree here.)
+_ : _≡_ {A = CtxMorph} (dropLocks Θ₂ᵢ) []
+_ = refl
+
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₂ᵢ) []
+_ = refl
+
+_ : interior (dropLocks Θ₂ᵢ) Δᵢ ≡ Δᵢ
+_ = refl
+
+-- THE OBSTRUCTION: under (1) `Δᵢ ⊢ᵐ (unlock 1 ∷ lock 1 ∷ [])` has no
+-- derivation, because `mw-u` would need slot 1 of Δᵢ to be MASKED.
+no-masked-Δᵢ : ∀ {E} → ¬ (Δᵢ ∋e 1 , masked E)
+no-masked-Δᵢ d with ∋e-det d (es ez)
+... | ()
+
+-- (The frame ITSELF is right: the merged frame's interior is the redex's
+-- interior on the nose.  It is only `⊢ᵐ`, read simultaneously, that
+-- refuses it.)
+_ : interior (Θ₁ᵢ ⋉ Θ₂ᵢ) (interior (dropLocks Θ₂ᵢ) Δᵢ)
+      ≡ interior Θ₁ᵢ (interior Θ₂ᵢ Δᵢ)
+_ = refl
+
+------------------------------------------------------------------------
+-- §3b  WHAT (3) *DOES* BUY — the frame lemmas become EQUALITIES
+------------------------------------------------------------------------
+
+-- The positive half of the proposal, proven in general and independent of
+-- `_⊢ᵐ_`: with a BINDS-ONLY outer frame the move is EXACT.  `frame-move`
+-- (proof/MoveScope) is a ⊑ only because `dropLocks` retains Θ₂'s unlocks
+-- and so applies them twice; drop them and the two frames coincide on the
+-- nose, and the value crosses by `subst` with no `⊢retag` at all.
+repsOf-bindsOnly : (Θ : CtxMorph) → repsOf (bindsOnly Θ) ≡ repsOf Θ
+repsOf-bindsOnly []             = refl
+repsOf-bindsOnly (bind A ∷ Θ)   = cong (A ∷_) (repsOf-bindsOnly Θ)
+repsOf-bindsOnly (unlock X ∷ Θ) = repsOf-bindsOnly Θ
+repsOf-bindsOnly (lock X ∷ Θ)   = repsOf-bindsOnly Θ
+
+scope-bindsOnly : (Θ : CtxMorph) (Δ : Ctxᵗ) → scope (bindsOnly Θ) Δ ≡ Δ
+scope-bindsOnly []             Δ = refl
+scope-bindsOnly (bind A ∷ Θ)   Δ = scope-bindsOnly Θ Δ
+scope-bindsOnly (unlock X ∷ Θ) Δ = scope-bindsOnly Θ Δ
+scope-bindsOnly (lock X ∷ Θ)   Δ = scope-bindsOnly Θ Δ
+
+interior-bindsOnly : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (bindsOnly Θ) Δ ≡ pushBinds (repsOf Θ) Δ
+interior-bindsOnly Θ Δ
+  rewrite repsOf-bindsOnly Θ | scope-bindsOnly Θ Δ = refl
+
+-- (b), FIRST HALF: the value's frame is preserved EXACTLY.
+interior-⋉-bindsOnly : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (Θ₁ ⋉ Θ₂) (interior (bindsOnly Θ₂) Δ)
+      ≡ interior Θ₁ (interior Θ₂ Δ)
+interior-⋉-bindsOnly Θ₁ Θ₂ Δ
+  rewrite interior-bindsOnly Θ₂ Δ =
+  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (repsOf Θ₁) (scope Θ₁ Ξ))
+              (scope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+
+-- (b), SECOND HALF: the conversion context of the moved frame is the
+-- redex's own inner conversion context with Θ₂'s LOCKS lifted off — which
+-- is the whole point of the move (the rep the swapped conversion presents
+-- is read OUTSIDE those locks).
+unlockedScope-scopeOf : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → unlockedScope (scopeOf (length As) Θ) (pushBinds As Δ)
+      ≡ pushBinds As (unlockedScope Θ Δ)
+unlockedScope-scopeOf As []             Δ = refl
+unlockedScope-scopeOf As (bind A ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
+unlockedScope-scopeOf As (lock X ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
+unlockedScope-scopeOf As (unlock X ∷ Θ) Δ =
+  trans (cong (unmask (length As + X)) (unlockedScope-scopeOf As Θ Δ))
+        (updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ))
+
+convCtx-⋉-bindsOnly : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
+  → convCtx (Θ₁ ⋉ Θ₂) (interior (bindsOnly Θ₂) Δ)
+      ≡ convCtx Θ₁ (convCtx Θ₂ Δ)
+convCtx-⋉-bindsOnly Θ₁ Θ₂ Δ
+  rewrite interior-bindsOnly Θ₂ Δ =
+  trans (convCtx-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (repsOf Θ₁) (unlockedScope Θ₁ Ξ))
+              (unlockedScope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+
+-- SO THE ONLY CASUALTY IS `⊢ᵐ-⋉`.  §3 and §4 are exactly that: the two
+-- frames the move builds are semantically right and `_⊢ᵐ_`-illegal.
+
+------------------------------------------------------------------------
+-- §4  THE MIRROR — Θ₂ UNLOCKS WHAT Θ₁ LOCKS
+------------------------------------------------------------------------
+
+-- Δⱼ: slot 0 a MASKED binder at ℕ, slot 1 a plain binder at ℕ.
+Δⱼ : Ctxᵗ
+Δⱼ = masked (bind `ℕ) ∷ bind `ℕ ∷ []
+
+Θ₂ⱼ : CtxMorph          -- the OUTER frame UNLOCKS slot 0 …
+Θ₂ⱼ = unlock 0 ∷ []
+
+Θ₁ⱼ : CtxMorph          -- … and the INNER frame LOCKS it again
+Θ₁ⱼ = lock 0 ∷ []
+
+_ : interior Θ₂ⱼ Δⱼ ≡ bind `ℕ ∷ bind `ℕ ∷ []
+_ = refl
+
+Vⱼ : Term
+Vⱼ = ($ 5) ⟪ [] , seal 1 ⟫
+
+Redexⱼ : Term
+Redexⱼ = (Vⱼ ⟪ Θ₁ⱼ , id (` 1) ⟫) ⟪ Θ₂ⱼ , unseal 1 ⟫
+
+⊢Redexⱼ : Δⱼ ∣ [] ⊢ Redexⱼ ⦂ `ℕ
+⊢Redexⱼ =
+  env (mw-u ez mw[])
+      (env (mw-l (bind `ℕ , ez , nameable-b) mw[])
+           (env mw[] ⊢$ (conv-seal (es ez))
+                (wf-var (bind `ℕ , es ez , nameable-b)))
+           (conv-idv (bind `ℕ , es ez , nameable-b))
+           (wf-var (bind `ℕ , es ez , nameable-b)))
+      (conv-unseal (es ez))
+      wf-ℕ
+
+stepⱼ : Δⱼ ⊢ Redexⱼ -→ (Vⱼ ⟪ Θ₁ⱼ ⋉ Θ₂ⱼ , unseal 1 ⟫) ⟪ dropLocks Θ₂ⱼ , mkId `ℕ ⟫
+stepⱼ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
+
+_ : _≡_ {A = CtxMorph} (Θ₁ⱼ ⋉ Θ₂ⱼ) (lock 0 ∷ unlock 0 ∷ [])
+_ = refl
+
+-- WITH `bindsOnly` the merged frame is read over Δⱼ, where slot 0 is
+-- MASKED — so its `lock 0` has no `mw-l` premise …
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₂ⱼ) []
+_ = refl
+
+¬∋tv-Δⱼ : ¬ (Δⱼ ∋tv 0)
+¬∋tv-Δⱼ (_ , ez , ())
+
+-- … and WITH `dropLocks` it is read over `convCtx Θ₂ⱼ Δⱼ`, where slot 0 is
+-- a PLAIN binder — so its `unlock 0` has no `mw-u` premise under (1).
+_ : interior (dropLocks Θ₂ⱼ) Δⱼ ≡ bind `ℕ ∷ bind `ℕ ∷ []
+_ = refl
+
+no-masked-cc : ∀ {E} → ¬ (interior (dropLocks Θ₂ⱼ) Δⱼ ∋e 0 , masked E)
+no-masked-cc ()
+
+------------------------------------------------------------------------
+-- §5  IF `⊢ᵐ` WERE SEQUENTIAL, `dualScope` MUST ALSO REVERSE
+------------------------------------------------------------------------
+
+-- §3/§4 fail only because `⊢ᵐ` reads every entry on the PLAIN exterior.
+-- The reading that survives them checks each entry against `scope Θ Δ` —
+-- the type context the LATER entries have already produced, which is the
+-- order `scope` applies them.  Under that reading a frame may toggle one
+-- slot repeatedly, and then a SAME-ORDER dual is no longer an inverse:
+-- `scope` applies its list HEAD-LAST, so undoing it must run the entries
+-- BACK TO FRONT.
+Θᵣ : CtxMorph
+Θᵣ = unlock 0 ∷ lock 0 ∷ []
+
+Δᵣ : Ctxᵗ
+Δᵣ = bind `ℕ ∷ []
+
+_ : scope Θᵣ Δᵣ ≡ Δᵣ                       -- lock then unlock: a no-op
+_ = refl
+
+-- the SAME-ORDER dual OVER-masks …
+_ : scope (dualScope′ 0 Θᵣ) (scope Θᵣ Δᵣ) ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+¬inverse-same-order : ¬ (scope (dualScope′ 0 Θᵣ) (scope Θᵣ Δᵣ) ≡ Δᵣ)
+¬inverse-same-order ()
+
+-- … while the REVERSED one is exact.
+_ : scope (unlock 0 ∷ lock 0 ∷ []) (scope Θᵣ Δᵣ) ≡ Δᵣ
+_ = refl
+
+------------------------------------------------------------------------
+-- §6  … AND THEN `bindsOnly` LOSES ITS OWN `⊢ᵐ`
+------------------------------------------------------------------------
+
+-- A sequential `⊢ᵐ` must read `mw-b`'s rep sequentially too — otherwise
+-- the moved frame `Θ₁ ⋉ Θ₂` has no `mw-b` premise for Θ₁'s own binders,
+-- whose reps the redex only ever checked on `interior Θ₂ Δ`.  But then
+-- `bindsOnly Θ₂` has no `⊢ᵐ` either: its binds are read on the PLAIN Δ,
+-- where a rep naming a slot Θ₂ UNLOCKED is not well formed.
+Δ₆ : Ctxᵗ
+Δ₆ = masked (bind `ℕ) ∷ []
+
+Θ₆ : CtxMorph
+Θ₆ = bind (` 0) ∷ unlock 0 ∷ []
+
+-- the rep IS well formed past the frame's own unlock …
+_ : scope (unlock 0 ∷ []) Δ₆ ≡ bind `ℕ ∷ []
+_ = refl
+
+⊢ᵗ-rep-seq : scope (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
+⊢ᵗ-rep-seq = wf-var (bind `ℕ , ez , nameable-b)
+
+-- … and NOT on the plain exterior, which is where `bindsOnly Θ₆` reads it.
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₆) (bind (` 0) ∷ [])
+_ = refl
+
+¬⊢ᵗ-rep-plain : ¬ (Δ₆ ⊢ᵗ ` 0)
+¬⊢ᵗ-rep-plain (wf-var (_ , ez , ()))


### PR DESCRIPTION
Jeremy's tightness test for `dual`, machine-checked (proof/DualTightness.agda): with exterior ⌷[X := ℕ] and Θ = ↥X, an ill-typed argument W = λx:ℕ. (ΛY. 3)[X] (names the masked X) Peels to a WELL-TYPED contractum — `dualScope` drops unlocks, so scope is gained through the boundary. Bind entries are tight (wkᴹ shifts past them). Not a preservation failure (the redex is ill-typed); a failure of design law 2 for the relation.

The first repair (mw-u requires a masked slot; dualScope maps unlock ↦ lock; the scope move's outer frame becomes bindsOnly) is REFUTED with witnesses in proof/MwUObstruct.agda: (2) forces (1); (1) kills ⊢ᵐ-⊑/⊢retag and ⊢ᵐ-⋉ (a simultaneous ⊢ᵐ cannot hold of a list that locks and unlocks one slot). The bindsOnly frame lemmas ARE equalities (kept as a positive result). Design.md marks Peel tightness OPEN; DECISIONS records the finding and the next candidate (a Δ-dependent dual that re-locks only non-vacuous unlocks), being probed on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)