### PR TITLE
Strong System F: tight boundaries — sequential ⊢ᵐ (no vacuous unlocks), exact dual, rewind in the scope move

### DIFF
--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -26,6 +26,11 @@ open import strong.proof.MoveScope
 open import strong.proof.TypeSafety
 open import strong.proof.PreserveObstruct
 
+-- the TIGHTNESS OF THE DUAL: the defect (`Peel` gains scope) and the
+-- refutation of the three-part repair proposed for it
+open import strong.proof.DualTightness
+open import strong.proof.MwUObstruct
+
 -- the regression corpus and the renderer
 open import strong.Examples
 open import strong.Show

--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -26,8 +26,8 @@ open import strong.proof.MoveScope
 open import strong.proof.TypeSafety
 open import strong.proof.PreserveObstruct
 
--- the TIGHTNESS OF THE DUAL: the defect (`Peel` gains scope) and the
--- refutation of the three-part repair proposed for it
+-- the TIGHTNESS OF THE DUAL: the defect (`Peel` gained scope), its
+-- repair, and the frame choice the repair forced
 open import strong.proof.DualTightness
 open import strong.proof.MwUObstruct
 

--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -113,6 +113,32 @@ infix 4 _∋tv_
 _∋tv_ : Ctxᵗ → ℕ → Set
 Δ ∋tv X = ∃[ E ] ((Δ ∋e X , E) × Nameable E)
 
+-- THE COMPLEMENT OF `Nameable`, and the whole of what an `unlock` may
+-- restore: an entry masked ONCE over a nameable one.  `Locked` is what
+-- `mw-u` (strong.Terms) demands and what makes `mask ∘ unmask` the
+-- identity at the slot (`mask-unmask`) — the fact the dual's restoring
+-- `lock` needs.  A doubly masked entry is NOT `Locked`, and no
+-- `Δ ⊢ᵐ Θ` ever produces one (`mw-l` masks only a nameable slot).
+data Locked : Ent → Set where
+  locked : Nameable E → Locked (masked E)
+
+renᵉ-Locked : Locked E → Locked (renᵉ ρ E)
+renᵉ-Locked (locked v) = locked (renᵉ-Nameable v)
+
+renᵉ-Nameable⁻ : Nameable (renᵉ ρ E) → Nameable E
+renᵉ-Nameable⁻ {E = abst}     v = nameable-a
+renᵉ-Nameable⁻ {E = bind A}   v = nameable-b
+renᵉ-Nameable⁻ {E = masked E} ()
+
+Locked-ren⁻ : Locked (renᵉ ρ E) → Locked E
+Locked-ren⁻ {E = abst}     ()
+Locked-ren⁻ {E = bind A}   ()
+Locked-ren⁻ {E = masked E} (locked v) = locked (renᵉ-Nameable⁻ v)
+
+infix 4 _∋lk_
+_∋lk_ : Ctxᵗ → ℕ → Set
+Δ ∋lk X = ∃[ E ] ((Δ ∋e X , E) × Locked E)
+
 -- BINDER-SYNTACTIC LOOKUP.  This is the only way any rep is ever read.
 infix 4 _∋_:=_
 _∋_:=_ : Ctxᵗ → ℕ → Ty → Set
@@ -276,6 +302,70 @@ nameable-mono (le-mu _ _)  ()
 ⊑-wf ls wf-𝔹         = wf-𝔹
 ⊑-wf ls (wf-⇒ wA wB) = wf-⇒ (⊑-wf ls wA) (⊑-wf ls wB)
 ⊑-wf ls (wf-∀ wA)    = wf-∀ (⊑-wf (le∷ le-aa ls) wA)
+
+------------------------------------------------------------------------
+-- 4b.  TRANSPORT IIa — refinement THAT DOES NOT RE-EXPOSE
+------------------------------------------------------------------------
+
+-- `_⊑ᵃ_` is `_⊑_` WITHOUT `le-mu`: the refinement may learn a rep at an
+-- abstract slot, but it may NOT un-mask a slot.  This is the transport a
+-- TERM may travel along (`⊢retag`, strong.TermSubst), and it has to be,
+-- because an `unlock X` in a boundary CLAIMS that X is locked
+-- (`mw-u`, strong.Terms) and `le-mu` destroys the claim.  Types and
+-- conversions keep the full `_⊑_` (`⊑-wf`, `conv-⊑`): a TYPE claims
+-- nameability, which only grows.
+data _⊑ᵃᵉ_ : Ent → Ent → Set where
+  la-aa : abst ⊑ᵃᵉ abst
+  la-ab : abst ⊑ᵃᵉ bind A
+  la-bb : bind A ⊑ᵃᵉ bind A
+  la-mm : E ⊑ᵃᵉ E′ → masked E ⊑ᵃᵉ masked E′
+
+infix 4 _⊑ᵃ_
+data _⊑ᵃ_ : Ctxᵗ → Ctxᵗ → Set where
+  la[] : [] ⊑ᵃ []
+  la∷  : E ⊑ᵃᵉ E′ → Δ ⊑ᵃ Δ′ → (E ∷ Δ) ⊑ᵃ (E′ ∷ Δ′)
+
+⊑ᵃᵉ→⊑ᵉ : E ⊑ᵃᵉ E′ → E ⊑ᵉ E′
+⊑ᵃᵉ→⊑ᵉ la-aa     = le-aa
+⊑ᵃᵉ→⊑ᵉ la-ab     = le-ab
+⊑ᵃᵉ→⊑ᵉ la-bb     = le-bb
+⊑ᵃᵉ→⊑ᵉ (la-mm l) = le-mm (⊑ᵃᵉ→⊑ᵉ l)
+
+⊑ᵃ→⊑ : Δ ⊑ᵃ Δ′ → Δ ⊑ Δ′
+⊑ᵃ→⊑ la[]        = le[]
+⊑ᵃ→⊑ (la∷ l ls)  = le∷ (⊑ᵃᵉ→⊑ᵉ l) (⊑ᵃ→⊑ ls)
+
+⊑ᵃᵉ-refl : (E : Ent) → E ⊑ᵃᵉ E
+⊑ᵃᵉ-refl abst       = la-aa
+⊑ᵃᵉ-refl (bind A)   = la-bb
+⊑ᵃᵉ-refl (masked E) = la-mm (⊑ᵃᵉ-refl E)
+
+⊑ᵃ-refl : (Δ : Ctxᵗ) → Δ ⊑ᵃ Δ
+⊑ᵃ-refl []      = la[]
+⊑ᵃ-refl (E ∷ Δ) = la∷ (⊑ᵃᵉ-refl E) (⊑ᵃ-refl Δ)
+
+⊑ᵃᵉ-⇑ : E ⊑ᵃᵉ E′ → ⇑ᵉ E ⊑ᵃᵉ ⇑ᵉ E′
+⊑ᵃᵉ-⇑ la-aa     = la-aa
+⊑ᵃᵉ-⇑ la-ab     = la-ab
+⊑ᵃᵉ-⇑ la-bb     = la-bb
+⊑ᵃᵉ-⇑ (la-mm l) = la-mm (⊑ᵃᵉ-⇑ l)
+
+⊑ᵃ-∋e : Δ ⊑ᵃ Δ′ → Δ ∋e X , E → ∃[ E′ ] ((Δ′ ∋e X , E′) × E ⊑ᵃᵉ E′)
+⊑ᵃ-∋e (la∷ l ls) ez     = _ , ez , ⊑ᵃᵉ-⇑ l
+⊑ᵃ-∋e (la∷ l ls) (es d) with ⊑ᵃ-∋e ls d
+... | E′ , d′ , l′ = _ , es d′ , ⊑ᵃᵉ-⇑ l′
+
+-- THE CLAUSE THAT MAKES `⊑ᵃ` THE RIGHT TRANSPORT FOR A BOUNDARY: a
+-- LOCKED slot stays locked.  (Under `_⊑_` it need not — that is `le-mu`.)
+⊑ᵃᵉ-Locked : E ⊑ᵃᵉ E′ → Locked E → Locked E′
+⊑ᵃᵉ-Locked (la-mm l) (locked v) = locked (nameable-mono (⊑ᵃᵉ→⊑ᵉ l) v)
+
+⊑ᵃ-tv : Δ ⊑ᵃ Δ′ → Δ ∋tv X → Δ′ ∋tv X
+⊑ᵃ-tv ls tv = ⊑-tv (⊑ᵃ→⊑ ls) tv
+
+⊑ᵃ-lk : Δ ⊑ᵃ Δ′ → Δ ∋lk X → Δ′ ∋lk X
+⊑ᵃ-lk ls (E , d , lk) with ⊑ᵃ-∋e ls d
+... | E′ , d′ , l′ = E′ , d′ , ⊑ᵃᵉ-Locked l′ lk
 
 ------------------------------------------------------------------------
 -- 5.  Injective renamings, iterated extension, iterated lifting
@@ -477,6 +567,56 @@ unmask-⊑ Y       []      = le[]
 unmask-⊑ zero    (E ∷ Δ) = le∷ (⊑ᵉ-unmaskEnt E) (⊑-refl Δ)
 unmask-⊑ (suc Y) (E ∷ Δ) = le∷ (⊑ᵉ-refl E) (unmask-⊑ Y Δ)
 
+-- The `_⊑ᵃ_` transport of a one-slot update.  Both `masked` and
+-- `unmaskEnt` are monotone for it — and `unmaskEnt` is TOTAL here only
+-- because `_⊑ᵃᵉ_` has no `le-mu` clause to think about.
+masked-monoᵃ : E ⊑ᵃᵉ E′ → masked E ⊑ᵃᵉ masked E′
+masked-monoᵃ = la-mm
+
+unmaskEnt-monoᵃ : E ⊑ᵃᵉ E′ → unmaskEnt E ⊑ᵃᵉ unmaskEnt E′
+unmaskEnt-monoᵃ la-aa     = la-aa
+unmaskEnt-monoᵃ la-ab     = la-ab
+unmaskEnt-monoᵃ la-bb     = la-bb
+unmaskEnt-monoᵃ (la-mm l) = l
+
+⊑ᵃ-updateAt : (f : Ent → Ent) → (∀ {E E′} → E ⊑ᵃᵉ E′ → f E ⊑ᵃᵉ f E′)
+  → ∀ {X Δ Δ′} → Δ ⊑ᵃ Δ′ → updateAt f X Δ ⊑ᵃ updateAt f X Δ′
+⊑ᵃ-updateAt f fm {zero}  (la∷ l ls) = la∷ (fm l) ls
+⊑ᵃ-updateAt f fm {suc X} (la∷ l ls) = la∷ l (⊑ᵃ-updateAt f fm ls)
+⊑ᵃ-updateAt f fm         la[]       = la[]
+
+------------------------------------------------------------------------
+-- 6b.  Locking and unlocking are EXACT INVERSES at a LOCKED slot
+------------------------------------------------------------------------
+
+-- Unmasking undoes masking, always: `masked` is injective.
+unmask-mask : (X : ℕ) (Δ : Ctxᵗ) → unmask X (mask X Δ) ≡ Δ
+unmask-mask X       []      = refl
+unmask-mask zero    (E ∷ Δ) = refl
+unmask-mask (suc X) (E ∷ Δ) = cong (E ∷_) (unmask-mask X Δ)
+
+-- Masking undoes unmasking ONLY at a LOCKED slot — which is exactly what
+-- `mw-u` (strong.Terms) demands of every `unlock`, and exactly why a
+-- vacuous unlock had to be refused: at an already-nameable slot the
+-- restoring `lock` of the dual would mask what the exterior left visible.
+maskEnt-unmask : Locked E → masked (unmaskEnt E) ≡ E
+maskEnt-unmask (locked v) = refl
+
+mask-unmask : ∀ {Δ X} → Δ ∋lk X → mask X (unmask X Δ) ≡ Δ
+mask-unmask (_ , ez     , lk) =
+  cong (_∷ _) (maskEnt-unmask (Locked-ren⁻ lk))
+mask-unmask (_ , es d   , lk) =
+  cong (_ ∷_) (mask-unmask (_ , d , Locked-ren⁻ lk))
+
+-- The two entry-level moves the dual performs, as lookup facts.
+unmask-∋tv : ∀ {Δ X} → Δ ∋lk X → unmask X Δ ∋tv X
+unmask-∋tv (E , d , locked v) =
+  _ , updateAt-hit unmaskEnt unmaskEnt-comm d , v
+
+mask-∋lk : ∀ {Δ X} → Δ ∋tv X → mask X Δ ∋lk X
+mask-∋lk (E , d , v) =
+  _ , updateAt-hit masked masked-comm d , locked v
+
 ------------------------------------------------------------------------
 -- 7.  The bind prefix
 ------------------------------------------------------------------------
@@ -518,6 +658,25 @@ wf-var⁻ (wf-var tv) = tv
 ⊑-pushBinds : (As : List Ty) → Δ ⊑ Δ′ → pushBinds As Δ ⊑ pushBinds As Δ′
 ⊑-pushBinds []       ls = ls
 ⊑-pushBinds (A ∷ As) ls = le∷ le-bb (⊑-pushBinds As ls)
+
+⊑ᵃ-pushBinds : (As : List Ty) → Δ ⊑ᵃ Δ′ → pushBinds As Δ ⊑ᵃ pushBinds As Δ′
+⊑ᵃ-pushBinds []       ls = ls
+⊑ᵃ-pushBinds (A ∷ As) ls = la∷ la-bb (⊑ᵃ-pushBinds As ls)
+
+-- The bind prefix transports the three entry-level lookups the boundary
+-- judgement reads: a rep, a nameable slot, and a LOCKED slot.
+pushBinds-∋tv : (As : List Ty) → Δ ∋tv X → pushBinds As Δ ∋tv (length As + X)
+pushBinds-∋tv []       tv = tv
+pushBinds-∋tv (C ∷ As) tv with pushBinds-∋tv As tv
+... | E , d , v = _ , es d , renᵉ-Nameable v
+
+pushBinds-∋lk : (As : List Ty) → Δ ∋lk X → pushBinds As Δ ∋lk (length As + X)
+pushBinds-∋lk []       lk = lk
+pushBinds-∋lk (C ∷ As) lk with pushBinds-∋lk As lk
+... | E , d , l = _ , es d , renᵉ-Locked l
+
+ren-∋lk : Ren ρ Δ Δ′ → Δ ∋lk X → Δ′ ∋lk ρ X
+ren-∋lk r (E , d , l) = renᵉ _ E , ren∋ r d , renᵉ-Locked l
 
 ren-pushBinds : (As : List Ty) (ρ : Renameᵗ) → Ren ρ Δ Δ′
          → Ren (extN (length As) ρ) (pushBinds As Δ)

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -301,8 +301,23 @@ whatever it is" (Jeremy, 2026-09-06).  With `Δ ⊑ Δ′` pointwise.  There is 
 `bind A` other than reflexivity: a binder never loses its representation.
 That is the deleted v1 demotion, stated as the theorem
 `⊑-kn : Δ ⊑ Δ′ → Δ ∋ X := A → Δ′ ∋ X := A`.  Masking only loses
-nameability (`mask-⊑`), unmasking only adds it (`unmask-⊑`), and typing
-transports along `⊑` with the types unchanged (`⊢retag`, `conv-⊑`).
+nameability (`mask-⊑`), unmasking only adds it (`unmask-⊑`), and a TYPE
+or a CONVERSION transports along `⊑` unchanged (`⊑-wf`, `conv-⊑`).
+
+**A TERM does not.**  A boundary's `unlock X` *claims* that `X` is locked
+(§4.2), and `le-mu` is precisely the clause that unmasks — so `⊢retag`
+runs along the `le-mu`-free refinement
+
+    abst ⊑ᵃᵉ abst    abst ⊑ᵃᵉ bind A    bind A ⊑ᵃᵉ bind A
+      la-aa              la-ab               la-bb
+    E ⊑ᵃᵉ E′ ⇒ masked E ⊑ᵃᵉ masked E′                     la-mm
+
+with `Δ ⊑ᵃ Δ′` pointwise and `⊑ᵃ→⊑` the embedding.  Its one content is
+`⊑ᵃᵉ-Locked : E ⊑ᵃᵉ E′ → Locked E → Locked E′` — *a locked slot stays
+locked* — which is what `⊢ᵐ-⊑ᵃ` needs at `mw-u`.  Every call site is
+covered: `preserve-TyBeta` refines an `abst` to a `bind` (`la-ab`), and
+the two former `le-mu` sites — the Peel crossing and the scope move — are
+now exact identities and use no retagging at all (§6.3, §6.7).
 
 ### The three operations a boundary uses
 
@@ -368,10 +383,12 @@ So the conversion needs the binders **and** the locked slots: binds
 pushed, locks lifted.  That is `convCtx Θ Δ`, the smallest context in
 which both leaves resolve.  It is not a third *construction*:
 
-    interior (dropLocks Θ) Δ ≡ convCtx Θ Δ    (proof/MoveScope)
+    scope (dropLocks Θ) Δ ≡ unlockedScope Θ Δ
 
 where `dropLocks Θ` is `Θ` with its locks removed — **the conversion
 context is the interior of the same boundary with its locks removed**.
+(As an *operation* on frames `dropLocks` is retired: it cannot be the
+outer frame of the scope move, §6.7.)
 
 The three contexts are ordered by refinement, in one direction only:
 
@@ -446,36 +463,58 @@ masked slot is unnameable, and a `∀` pushes `abst`, never a `bind`.
 ### 4.2 Well-formed context morphisms — `Δ ⊢ᵐ Θ`
 
 Read "the context morphism `Θ` is well formed over `Δ`"; an infix
-judgement in the family of `Δ ⊢ᵗ A` and `Δ ⊢ c ∶ A ⇝ B`.  Every premise
-is read on the **exterior** `Δ` (simultaneity), never on the context the
-earlier entries build:
+judgement in the family of `Δ ⊢ᵗ A` and `Δ ⊢ c ∶ A ⇝ B`.  The judgement
+is **sequential**: every premise is read on the frame the entry acts on,
+i.e. on the context the entries to its right (which `scope` applies
+first) have already built.
 
     mw[] : Δ ⊢ᵐ []
-    mw-b : Δ ⊢ᵗ A     → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
-    mw-l : Δ ∋tv X    → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
-    mw-u : Δ ∋e X , E → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
+    mw-b : unlockedScope Θ Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
+    mw-l : scope Θ Δ ∋tv X        → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
+    mw-u : scope Θ Δ ∋lk X        → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
 
-A `bind` checks its representation in the exterior.  A `lock` names
-a **visible** slot.  An `unlock` asks only that the slot **exist** — it
-cannot ask that the slot be masked and stay masked under refinement (a
-cancel may already have unmasked it), and it need not: `unmask` is total
-and an unlock at an unmasked slot is a no-op.  An `unlock` claims nothing
-and a `lock` claims nothing either; the claim lives in the conversion,
-where `seal X` must cite a live binder.
+A `lock` names a slot that is **still visible** where it acts — so a slot
+is never masked twice, and `Locked` is one mask deep.  An `unlock` names
+a slot that is **LOCKED** there: `Δ ∋lk X` is `∃E. (Δ ∋e X , E) ×
+Locked E`, with `Locked (masked E)` for a *nameable* `E`.  It is the
+mirror of `Δ ∋tv X`, and it mentions no representation at all — an
+`unlock` still claims no knowledge; the knowledge claim lives in the
+conversion, where `seal X` must cite a live binder.
 
-**The cost of `mw-u`'s permissiveness, and why it cannot simply be
-raised** (2026-09-06).  Because an `unlock` claims nothing, a *vacuous*
-unlock — one at an already-unmasked slot — is well formed, and `dual`
-therefore cannot restore it (§6.3: the tightness defect).  Strengthening
-the premise to `Δ ∋e X , masked E` is **refuted** in
-`proof/MwUObstruct.agda`.  The reason is structural: `_⊢ᵐ_` is
-**simultaneous** (design law 4) while `scope` is **sequential** (the list
-is applied head-last).  Under the strengthened premise `mw-l` and `mw-u`
-become exact complements — a lock names a *nameable* slot, an unlock a
-*masked* one — so no simultaneous `_⊢ᵐ_` can hold of a list that both
-locks and unlocks one slot.  The scope move `_⋉_` (§6.7) builds exactly
-such lists, and `⊢retag` (which carries `_⊢ᵐ_` along `⊑`, whose `le-mu`
-clause *unmasks*) loses its `env` case as well.
+**A VACUOUS UNLOCK IS REFUSED** (Jeremy's ruling, 2026-09-06;
+`proof/DualTightness` §5).  `↥X` over a slot the frame leaves visible is
+not merely useless, it is *wrong*: it is the case on which `dual`'s
+restoring `lock` would mask what the exterior left nameable.  The
+judgement refuses it, and that refusal is exactly what makes
+`mask ∘ unmask` the identity where the dual needs it
+(`mask-unmask`, `Locked`).
+
+**A rep is read on `unlockedScope Θ Δ`, not on `scope Θ Δ` and not on the
+plain `Δ`.**  This is the surviving half of simultaneity, and it is
+forced from both sides:
+
+* not on `scope Θ Δ` — a rep must never be blocked by the frame's *own*
+  locks, or `TyPeelR`'s new frame `bind A ∷ Θ` would be ill formed
+  whenever `Θ` locks a slot the type argument `A` names;
+* not on the plain `Δ` — the scope move `_⋉_` (§6.7) merges an inner
+  frame's binds with an enclosing frame's scope, and the inner frame's
+  reps were read past that enclosing frame's *unlocks*.  With a
+  plain-`Δ` `mw-b` the merged frame has no derivation
+  (`proof/MwUObstruct` §4, at `Θ₁ ⋉ Θ₂ = bind (` 0) ∷ unlock 0 ∷ []`
+  over an exterior that masks slot 0).
+
+**What the strengthened `mw-u` costs, and how it is paid.**  Under it
+`mw-l` and `mw-u` are exact complements — a lock names a *nameable* slot,
+an unlock a *locked* one — so no *simultaneous* `_⊢ᵐ_` could hold of a
+list that both locks and unlocks one slot, and the scope move builds
+exactly such lists.  The sequential reading above is what admits them.
+Two further consequences:
+
+* `⊢retag` no longer runs along `⊑`: `le-mu` *unmasks*, which destroys an
+  `unlock`'s claim.  Terms travel along `_⊑ᵃ_`, the `le-mu`-free
+  refinement (§3); types and conversions keep the full `⊑`.
+* the outer frame of `CancelR`/`IdPush` is `rewind Θ₂`, not
+  `dropLocks Θ₂` (§6.7).
 
 ### 4.3 Terms
 
@@ -632,20 +671,31 @@ they agree: `instReveal X (mkId B) ≡ reveal X B`.
 **The dual of a crossed boundary**:
 
     hideBinds n = lock (n-1) , … , lock 0
-    dualScope n []           = []
-    dualScope n (bind A , Θ) = dualScope n Θ
-    dualScope n (unlock X , Θ) = dualScope n Θ
-    dualScope n (lock X , Θ) = unlock (n + X) , dualScope n Θ
+    dualScope n []             = []
+    dualScope n (bind A , Θ)   = dualScope n Θ
+    dualScope n (unlock X , Θ) = dualScope n Θ ++ [ lock   (n + X) ]
+    dualScope n (lock X , Θ)   = dualScope n Θ ++ [ unlock (n + X) ]
 
     dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
 
 so the dual **locks** each of the crossed boundary's own new binders (the
-crossing argument may not see them) and **unlocks** each of its locks
-(the argument came from outside, where those were nameable).  The
-`unlock` case of `dualScope` is deliberately dropped: mapping
-`unlock X ↦ lock (n+X)` would re-block a no-op unlock and would make a
-same-slot mask/unmask pair fail to cancel.  With it dropped,
-`interior-dual` and `convCtx-dual` hold in general (`proof/PeelDual.agda`).
+crossing argument may not see them), **unlocks** each of its locks (the
+argument came from outside, where those were nameable) and **re-locks**
+each of its unlocks (the argument came from outside, where those were
+*not* nameable).  Two points of care:
+
+* **it must restore the unlocks.**  Dropping the `unlock` case is the
+  tightness defect of §6.3: the crossing argument then gets a frame
+  strictly more nameable than the exterior.  Restoring is sound because
+  `mw-u` refuses a vacuous unlock, so `mask ∘ unmask` really is the
+  identity at the slot;
+* **it must run backwards.**  `scope` applies its list head-last, so an
+  inverse must undo the entries in reverse order — hence the append at
+  the end of each clause.  A same-order dual is not an inverse at a frame
+  that toggles one slot twice (`↥X , ↓X`, which the judgement admits).
+
+With both, `interior-dual` is an EXACT identity and `convCtx-dual` holds
+unconditionally (`proof/PeelDual.agda`).
 
 **The scope move** (§6.7):
 
@@ -654,14 +704,12 @@ same-slot mask/unmask pair fail to cancel.  With it dropped,
     scopeOf n (unlock X , Θ) = unlock (n+X) , scopeOf n Θ
     scopeOf n (lock X , Θ)   = lock   (n+X) , scopeOf n Θ
 
-    dropLocks []           = []          -- Θ with its LOCKS removed
-    dropLocks (bind A , Θ) = bind A , dropLocks Θ
-    dropLocks (unlock X , Θ) = unlock X , dropLocks Θ
-    dropLocks (lock X , Θ)   = dropLocks Θ
+    rewind Θ = dualScope 0 Θ ++ Θ        -- Θ with its own SCOPE undone
 
     Θ₁ ⋉ Θ₂ = Θ₁ ++ scopeOf (numBinds Θ₂) Θ₂
 
-Note `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁`: the move carries no binder.
+Note `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` and
+`numBinds (rewind Θ) ≡ numBinds Θ`: neither operation carries a binder.
 
 
 ### 6.1 `TyBeta` — the boundary is born
@@ -736,26 +784,30 @@ The `7` has crossed inward and is now sealed at the new binder, so the
 interior sees it at the abstract name `X` — which is exactly what
 `λx:X. x` demands.
 
-**OPEN: `Peel` is not tight** (Jeremy's test, 2026-09-06;
-`proof/DualTightness.agda`).  `dualScope` **drops** `Θ`'s `unlock`
-entries, so a boundary that unmasks an exterior slot hands its crossing
-argument a frame in which that slot is *still* unmasked:
-`interior (dual Θ) (interior Θ Δ)` is the masked bind prefix over
-`unlockedScope Θ Δ`, which is strictly more nameable than `Δ`.  The
+**TIGHTNESS OF THE CROSSING** (Jeremy's test, 2026-09-06;
+`proof/DualTightness.agda`).  The mini-core's `dualScope` **dropped**
+`Θ`'s `unlock` entries, so a boundary that unmasks an exterior slot
+handed its crossing argument a frame in which that slot was *still*
+unmasked: `interior (dual Θ) (interior Θ Δ)` was the masked bind prefix
+over `unlockedScope Θ Δ`, strictly more nameable than `Δ`.  The
 machine-checked witness — `Δᵤ = ↓U`, `Θᵤ = ↥U`, `W = λy:ℕ. (ΛZ. 3)[U]` —
-takes an **ill-typed** redex to a **well-typed** contractum: scope is
-gained through the boundary.  This is not a preservation failure (the
-redex is not well typed, and `preserve-Peel` is a theorem); it is a
-failure of design law 2 for the *reduction relation*.
+took an **ill-typed** redex to a **well-typed** contractum: scope was
+gained through the boundary.  That is a failure of design law 2 for the
+*reduction relation* (not of preservation: the redex is not well typed).
 
-The repair — restore what `Θ` unlocked, `dualScope n (unlock X ∷ Θ) =
-lock (n + X) ∷ dualScope n Θ`, with an `mw-u` that forbids vacuous
-unlocks — is **refuted** in `proof/MwUObstruct.agda` (see §4.2): the
-restored lock is only correct when the slot really was masked, so the
-two changes are coupled, and the strengthened `mw-u` is incompatible with
-both the scope move and `⊢retag`.  The two readings of `_⊢ᵐ_` that
-survive §3/§4 (sequential premises, or a cancelling merge) are design
-decisions, not repairs; §5/§6 of that module price the sequential one.
+It is repaired, in two coupled halves — the restoring, reversed
+`dualScope` above and the `mw-u` that refuses a vacuous unlock (§4.2).
+The frame identity is then **exact**:
+
+    (†)  interior (dual Θ) (interior Θ Δ)
+           ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ      given Δ ⊢ᵐ Θ
+
+*the crossing argument's frame IS the exterior*, one (masked) bind prefix
+in — so the argument crosses by `⊢rename (wkN (numBinds Θ))` alone, with
+no `⊢retag` and no `le-mu` anywhere.  On the witness above the contractum
+is now REFUSED (`¬⊢Contractum`), and the positive control still passes:
+at a Θ-**locked** slot the dual unlocks it again and the argument keeps
+its frame.
 
 ### 6.4 `TyPeelR` — a `∀` conversion meets a type application
 
@@ -855,7 +907,7 @@ Two `Drop$` steps then finish the run to `7`.
 
     IdPush : Value V → convCtx Θ₂ Δ ∋ Y := A
       → Δ ⊢ (V ⟪ Θ₁ , id (` X) ⟫) ⟪ Θ₂ , unseal Y ⟫
-          -→ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ dropLocks Θ₂ , mkId A ⟫
+          -→ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ rewind Θ₂ , mkId A ⟫
 
 **Bookkeeping.**  A value under a transparent `` id (` X) `` layer, under an
 active conversion, is not a value and no other rule fires.  Rather than
@@ -880,12 +932,34 @@ the record is in `notes/DECISIONS.md` (2026-09-06 entries), and its two
 surviving artifacts are `proof/MaskFacts.mask-only` and `Examples` §12/§12b.
 
 The repair is not a side condition but a **frame move** (Jeremy,
-2026-09-06).  The outer frame keeps only what binds and what unmasks
-(`dropLocks Θ₂`); its whole **scope** — locks *and* unlocks, in order,
-lifted past its own binders — travels into the inner frame's tail
+2026-09-06).  The outer frame's whole **scope** — locks *and* unlocks, in
+order, lifted past its own binders — travels into the inner frame's tail
 (`Θ₁ ⋉ Θ₂`), where `scope` applies it **first**, exactly where it applied
-before.  The representation is then presented outside the locks, where it
-is nameable, and the locks still stand between the value and the world.
+before; and what stays outside is the frame with its own scope **rewound**
+(`rewind Θ₂ = dualScope 0 Θ₂ ++ Θ₂`), whose net effect on the exterior is
+its bind prefix alone:
+
+    scope    (rewind Θ₂) Δ ≡ Δ                      given Δ ⊢ᵐ Θ₂
+    interior (rewind Θ₂) Δ ≡ pushBinds (repsOf Θ₂) Δ
+
+The representation is then presented outside the locks, where it is
+nameable, and the locks still stand between the value and the world.
+
+**Why `rewind`, and not the two cheaper frames.**  All three of
+`rewind Θ₂`, `dropLocks Θ₂` and `bindsOnly Θ₂` (delete the scope
+outright) leave the same type context.  Only `rewind` keeps its own
+`_⊢ᵐ_`, and both alternatives are refuted on ONE configuration
+(`proof/MwUObstruct`): `Δ₆ = ↓U`, `Θ₂ = ↥U`, `Θ₁ = ↑V:=U`, so that
+`Θ₁ ⋉ Θ₂ = ↑V:=U , ↥U`.
+
+* `dropLocks Θ₂` KEEPS `Θ₂`'s unlocks, so the *moved copy* of the same
+  unlock lands where the slot is already nameable — a vacuous unlock,
+  which `mw-u` refuses (`¬⊢ᵐ-dropLocks`);
+* `bindsOnly Θ₂` DELETES them, and then `Θ₂`'s *own* bind representation
+  — read on `unlockedScope Θ₂′ Δ`, i.e. past that very unlock — is
+  stranded on the plain exterior (`¬⊢ᵐ-bindsOnly`);
+* `rewind Θ₂` keeps every entry and rewinds it, so every premise is read
+  exactly where the redex read it (`⊢ᵐ-rewind`).
 
 Example — the wall witness itself (`Examples` §12b, over
 `Δi = X := Y , Y := ℕ`, so `X`'s representation *names* `Y` and the outer
@@ -895,22 +969,26 @@ Diagram:
 
     R₀   ((((7 ⟪ seal Y ⟫) ⟪ ↥Y , seal X ⟫) ⟪ id X ⟫) ⟪ ↓Y , unseal X ⟫)
       |
-      |  IdPush   (Θ₁ = [] , Θ₂ = ↓Y ;  Θ₁ ⋉ Θ₂ = ↓Y , dropLocks Θ₂ = [])
+      |  IdPush  (Θ₁ = [] , Θ₂ = ↓Y ; Θ₁ ⋉ Θ₂ = ↓Y , rewind Θ₂ = ↥Y , ↓Y)
       v
-    R₁′  ((((7 ⟪ seal Y ⟫) ⟪ ↥Y , seal X ⟫) ⟪ ↓Y , unseal X ⟫) ⟪ id Y ⟫)
+    R₁′  ((((7 ⟪ seal Y ⟫) ⟪ ↥Y , seal X ⟫) ⟪ ↓Y , unseal X ⟫)
+                                                        ⟪ ↥Y , ↓Y , id Y ⟫)
       |
       |  CancelR  lifted through the outer boundary (ξ-⟪⟫)
       v
-    R₂   ((((7 ⟪ seal Y ⟫) ⟪ ↥Y , ↓Y , id Y ⟫) ⟪ id Y ⟫) ⟪ id Y ⟫)
+    R₂   ((((7 ⟪ seal Y ⟫) ⟪ ↥Y , ↓Y , id Y ⟫) ⟪ ↥Y , ↓Y , id Y ⟫)
+                                                        ⟪ ↥Y , ↓Y , id Y ⟫)
 
 Read `R₀` and `R₁′` side by side: `↓Y` has moved from the outer boundary
 to the inner one, and the reveal `unseal X` went with it.  The
 representation `Y` that the reveal hands back is now presented on the
 outer boundary's own type context, where `Y` is live, instead of inside
 the lock, which is what `env`'s last premise refused.  The value's frame
-is unchanged (`interior ([] ⋉ Θi) (interior (dropLocks Θi) Δi)
-≡ interior [] (interior Θi Δi)` is `refl`), so `V` retypes where it was,
-and `R₂` is a **value**.  Under
+is unchanged (`interior ([] ⋉ Θi) (interior (rewind Θi) Δi)
+≡ interior [] (interior Θi Δi)` is `refl`), so `V` retypes where it was —
+by `subst`, not by `⊢retag` — and `R₂` is a **value**.  The `↥Y , ↓Y`
+riding on the outer frames is the rewind: inert on the type context, and
+carrying the premises its own reps were read under.  Under
 the old rule `R₀`'s contractum was untypeable — that refutation was the
 content of `proof/PreserveObstruct` §4, which now records the positive
 fact on the same witness.
@@ -923,11 +1001,15 @@ contractum.  The refutation is in tree
 (`proof/MoveScope` §4b, `¬frame-locksOnly`) at the `_⊢ᵐ_`-legal witness
 `Θ✗ = unlock 0 ∷ lock 0 ∷ []` over `Δ✗ = bind ℕ ∷ []`, where
 `interior Θ✗ Δ✗ ≡ bind ℕ ∷ []` but the lock-only contractum's interior is
-`masked (bind ℕ) ∷ []`.  Moving the whole scope keeps the order, and the
-retained unmasks are harmless: unmasking only *adds* nameability, so the
-value's frame is **refined** and `⊢retag` carries it.  With that, the
-frame lemma is unconditional — no premise about `Θ₂`'s shape, and no side
-condition for `Progress` to supply.
+`masked (bind ℕ) ∷ []`.  Moving the whole scope keeps the order, and then
+the value's frame is preserved **on the nose**: with `rewind` outside,
+both frame lemmas are equalities,
+
+    interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)
+    convCtx  (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ convCtx  Θ₁ (convCtx  Θ₂ Δ)
+
+(both given `Δ ⊢ᵐ Θ₂`), so neither case uses `⊢retag` at all — no premise
+about `Θ₂`'s shape, and no side condition for `Progress` to supply.
 
 A second example, from closed plain source (`Examples` §11,
 `Q = ((ΛY. λx:Y. ((ΛZ. x) [ℕ])) [ℕ]) · 7`, nine steps to `7`).  The
@@ -1036,14 +1118,14 @@ Induction on the step, with the rule cases distributed:
   definitional.
 * **`Beta`** — `⊢subst` (`strong.TermSubst`).
 * **`Peel`** (`proof/PeelDual.preserve-Peel`) — the two context
-  identities are what carries it:
+  identities are what carries it: (†)
   `interior (dual Θ) (interior Θ Δ)
-  ≡ map masked (pushBinds (repsOf Θ) []) ++ unlockedScope Θ Δ`
+  ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ` (given `Δ ⊢ᵐ Θ`)
   and `convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ`.  The crossing
   argument, typed in `Δ`, retypes one bind frame deeper by
-  `⊢rename (wkN (numBinds Θ))` and then `⊢retag` (the tail relaxes along
-  `Δ ⊑ unlockedScope Θ Δ`), and the conversion `s` transplants verbatim
-  through the second identity.
+  `⊢rename (wkN (numBinds Θ))` and **nothing else** — the tail is `Δ`
+  itself, so no `⊢retag` and no `le-mu` — and the conversion `s`
+  transplants verbatim through the second identity.
 * **`TyPeelR`** (`proof/Preserve.preserve-TyPeelR`) — at **every**
   `∀`-conversion, once polarity is gone.  The interior instantiation
   lands at the fresh binder's name, `ren-suc-[0]` undoes the annotation
@@ -1054,22 +1136,23 @@ Induction on the step, with the rule cases distributed:
 * **`CancelR`, `IdPush`** (`proof/MoveScope`) — the scope move, §6.7.
   Four moves each, one per premise of the contractum's inner `env`:
   the frame is `Θ₁ ⋉ Θ₂`, well formed by `⊢ᵐ-⋉`; the interior is `V`,
-  retagged along `frame-move`; the conversion cites the binder that
-  `move-∋` transports; and the exterior premise is `moved-scoped`, the
-  one the wall used to deny — which is now just `wf-shiftBy-pushBinds` on
-  the redex's own exterior type, because
-  `interior (dropLocks Θ₂) Δ ≡ convCtx Θ₂ Δ`
+  moved by `subst` along the frame **equality**; the conversion cites the
+  binder that `move-∋` transports; and the exterior premise is
+  `moved-scoped`, the one the wall used to deny — which is now just
+  `wf-shiftBy-pushBinds` on the redex's own exterior type, because
+  `interior (rewind Θ₂) Δ ≡ pushBinds (repsOf Θ₂) Δ`
   and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's `C`.
-  The two frame lemmas are **refinements**, not equalities —
-  `interior Θ₁ (interior Θ₂ Δ)
-  ⊑ interior (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)` and the
-  same for `convCtx` — because the retained unmasks apply twice; `⊢retag`
-  and `conv-⊑` carry that.
+  The two frame lemmas are **equalities** (§6.7), so neither case uses
+  `⊢retag`.  `⊢ᵐ-⋉` is where the sequential judgement pays for itself:
+  `⊢ᵐ-++` splits the merged list at the move, `⊢ᵐ-scopeOf` re-reads `Θ₂`'s
+  entries one bind prefix in, and `Θ₁` is then read over exactly
+  `interior Θ₂ Δ` — its own exterior in the redex.
 * the five `ξ` rules — structural, using the same `env` node.
 
 The three transports the induction rests on are `⊢rename` (along a
-context renaming, with `Inj ρ`), `⊢retag` (along `⊑`, types unchanged),
-and `⊢subst`.
+context renaming, with `Inj ρ`), `⊢retag` (along `⊑ᵃ`, types unchanged),
+and `⊢subst`.  After the repairs `⊢retag` has exactly one call site in
+the whole preservation proof — `TyBeta`'s `abst ⊑ᵃᵉ bind A`.
 
 ### `det` and `value-¬step`
 
@@ -1153,22 +1236,33 @@ machine-checked consequence in tree.
    of grounding `interior Θ₂ Δ ⊢ᵗ A` with a side condition, the rule was
    changed so that the fact follows from `env`'s own last premise.
 2. **Tightness, for terms and for scope.**  A masked slot may not be
-   named in any type; `Nameable` and `wf-var` are the whole enforcement.  But
-   *mentioning* a masked index in a morphism entry (`↓X`, `↥X`) is not a
-   use, and `_⊢ᵐ_` permits it.  **The law is currently broken for the
-   reduction relation**: `Peel`'s `dual` drops `unlock` entries, so the
-   crossing frame can be *more* nameable than the exterior
-   (`proof/DualTightness.agda`; the repair is refuted in
-   `proof/MwUObstruct.agda`, and §4.2/§6.3 say why).
+   named in any type; `Nameable` and `wf-var` are the whole enforcement.
+   *Mentioning* a masked index in a morphism entry (`↓X`, `↥X`) is not a
+   use, and `_⊢ᵐ_` permits it — but it must be TRUE: `↓X` needs `X`
+   nameable and `↥X` needs `X` LOCKED, where the entry acts.  The law
+   held for typing all along and was **broken for the reduction
+   relation** by a `dual` that dropped `unlock` entries; it is repaired
+   (§4.2, §6.3) and the witness that broke it is now refused
+   (`proof/DualTightness.¬⊢Contractum`).  The frame identity (†) is the
+   law in one line: *the crossing frame IS the exterior*.
 3. **No term type-shifts.**  Shift types, not terms.  The only index
    arithmetic in the design is ordinary de Bruijn binder offsets:
    `numBinds Θ`, `shiftBy`, and the `n + X` lift in `scopeOf` and `dualScope`.
    `cmax`, `dropN`, `swapᵇ`, `shiftReps` have no analogue.
-4. **Simultaneity.**  A boundary's entries never interfere: every `_⊢ᵐ_`
-   premise, and every representation, is read in the **exterior**,
-   and `pushBinds` lifts a representation past exactly the binders inside
-   it.  The telescopic variant was landed and reverted
-   (`notes/DECISIONS.md`, "RULING … telescopic (mwf-↑) REVERTED").
+4. **Simultaneity, as far as it goes.**  `pushBinds` lifts a
+   representation past exactly the binders inside it and past nothing
+   else — that half is untouched, and the telescopic variant stays
+   reverted (`notes/DECISIONS.md`, "RULING … telescopic (mwf-↑)
+   REVERTED").  The other half — *every* premise read on the plain
+   exterior — did not survive the tightness repair, and could not: with
+   an `mw-u` that refuses a vacuous unlock, `mw-l` and `mw-u` are exact
+   complements, so a simultaneous judgement cannot hold of a list that
+   both locks and unlocks one slot, and the scope move builds exactly
+   such lists (§4.2).  What replaces it is precise rather than weaker:
+   a REP is read on `unlockedScope Θ′ Δ` — never blocked by the frame's
+   OWN locks (that is the part of simultaneity that mattered: no
+   interference from the entries the frame itself installs) — while a
+   NAME is read on `scope Θ′ Δ`, the frame it actually acts on.
 5. **Determinism.**  Reduction is a partial function.  This is what forces
    `Value` premises on `V-Λ`, `TyBeta` and `Beta`, and what forces every
    rule that mints an identity at a looked-up representation to carry the
@@ -1251,11 +1345,15 @@ the type-context entries `abst` / `bind` / `masked`; `dual`; `Inj`.
 | `instReveal X s` | the same mint, on a conversion |
 | `instConceal X s` | its contravariant partner |
 | `dual Θ` | the frame a crossing argument acquires |
-| `dualScope n Θ` | its scope half |
+| `dualScope n Θ` | its scope half: `Θ`'s scope inverted and reversed |
 | `hideBinds n` | lock the crossed boundary's own binders |
 | `scopeOf n Θ` | `Θ`'s scope, indices lifted by `n` |
 | `dropLocks Θ` | `Θ` with its locks removed |
+| `rewind Θ` | `Θ` with its own scope undone: `dualScope 0 Θ ++ Θ` |
 | `Θ₁ ⋉ Θ₂` | `Θ₁` with `Θ₂`'s scope moved into its tail |
+| `Locked E` | the entry is masked over a nameable one |
+| `Δ ∋lk X` | slot `X` is LOCKED at `Δ` — what an `unlock` cites |
+| `Δ ⊑ᵃ Δ′` | refinement WITHOUT `le-mu`: the transport a TERM travels |
 | `Inj ρ` | the renaming does not confuse two slots |
 
 The `_⊑ᵉ_` constructors were relettered on the same ruling so that each
@@ -1263,13 +1361,15 @@ name spells the two entries it relates (§3, *Refinement*):
 `le-ao` → `le-ab`, `le-oo` → `le-bb`, `le-bb` → `le-mm`,
 `le-bu` → `le-mu`; `le-aa` unchanged.
 
-Two identities worth stating, because they are what the names are meant to
-make obvious:
+Three identities worth stating, because they are what the names are meant
+to make obvious:
 
     scope (dropLocks Θ) Δ ≡ unlockedScope Θ Δ
-    interior (dropLocks Θ) Δ ≡ convCtx Θ Δ
+    interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ      given Δ ⊢ᵐ Θ
+    interior (dual Θ) (interior Θ Δ)
+      ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ       given Δ ⊢ᵐ Θ
 
-The second is `proof/MoveScope.interior-dropLocks` — *the conversion
-context is the interior of the dropLocks boundary* — and it is the
-identity that retired
-the wall.
+The second is `proof/MoveScope.interior-rewind` — *a rewound frame leaves
+its bind prefix and nothing else* — and it is the identity that retired
+the wall.  The third is (†), `proof/PeelDual.interior-dual`: *the
+crossing frame is the exterior*, which is tightness for `Peel`.

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -463,6 +463,20 @@ and an unlock at an unmasked slot is a no-op.  An `unlock` claims nothing
 and a `lock` claims nothing either; the claim lives in the conversion,
 where `seal X` must cite a live binder.
 
+**The cost of `mw-u`'s permissiveness, and why it cannot simply be
+raised** (2026-09-06).  Because an `unlock` claims nothing, a *vacuous*
+unlock — one at an already-unmasked slot — is well formed, and `dual`
+therefore cannot restore it (§6.3: the tightness defect).  Strengthening
+the premise to `Δ ∋e X , masked E` is **refuted** in
+`proof/MwUObstruct.agda`.  The reason is structural: `_⊢ᵐ_` is
+**simultaneous** (design law 4) while `scope` is **sequential** (the list
+is applied head-last).  Under the strengthened premise `mw-l` and `mw-u`
+become exact complements — a lock names a *nameable* slot, an unlock a
+*masked* one — so no simultaneous `_⊢ᵐ_` can hold of a list that both
+locks and unlocks one slot.  The scope move `_⋉_` (§6.7) builds exactly
+such lists, and `⊢retag` (which carries `_⊢ᵐ_` along `⊑`, whose `le-mu`
+clause *unmasks*) loses its `env` case as well.
+
 ### 4.3 Terms
 
     ⊢`  : Γ ∋ x ⦂ A → Δ ∣ Γ ⊢ x ⦂ A
@@ -721,6 +735,27 @@ Example (`Examples` §6, `P₁ → P₂`), with
 The `7` has crossed inward and is now sealed at the new binder, so the
 interior sees it at the abstract name `X` — which is exactly what
 `λx:X. x` demands.
+
+**OPEN: `Peel` is not tight** (Jeremy's test, 2026-09-06;
+`proof/DualTightness.agda`).  `dualScope` **drops** `Θ`'s `unlock`
+entries, so a boundary that unmasks an exterior slot hands its crossing
+argument a frame in which that slot is *still* unmasked:
+`interior (dual Θ) (interior Θ Δ)` is the masked bind prefix over
+`unlockedScope Θ Δ`, which is strictly more nameable than `Δ`.  The
+machine-checked witness — `Δᵤ = ↓U`, `Θᵤ = ↥U`, `W = λy:ℕ. (ΛZ. 3)[U]` —
+takes an **ill-typed** redex to a **well-typed** contractum: scope is
+gained through the boundary.  This is not a preservation failure (the
+redex is not well typed, and `preserve-Peel` is a theorem); it is a
+failure of design law 2 for the *reduction relation*.
+
+The repair — restore what `Θ` unlocked, `dualScope n (unlock X ∷ Θ) =
+lock (n + X) ∷ dualScope n Θ`, with an `mw-u` that forbids vacuous
+unlocks — is **refuted** in `proof/MwUObstruct.agda` (see §4.2): the
+restored lock is only correct when the slot really was masked, so the
+two changes are coupled, and the strengthened `mw-u` is incompatible with
+both the scope move and `⊢retag`.  The two readings of `_⊢ᵐ_` that
+survive §3/§4 (sequential premises, or a cancelling merge) are design
+decisions, not repairs; §5/§6 of that module price the sequential one.
 
 ### 6.4 `TyPeelR` — a `∀` conversion meets a type application
 
@@ -1120,7 +1155,11 @@ machine-checked consequence in tree.
 2. **Tightness, for terms and for scope.**  A masked slot may not be
    named in any type; `Nameable` and `wf-var` are the whole enforcement.  But
    *mentioning* a masked index in a morphism entry (`↓X`, `↥X`) is not a
-   use, and `_⊢ᵐ_` permits it.
+   use, and `_⊢ᵐ_` permits it.  **The law is currently broken for the
+   reduction relation**: `Peel`'s `dual` drops `unlock` entries, so the
+   crossing frame can be *more* nameable than the exterior
+   (`proof/DualTightness.agda`; the repair is refuted in
+   `proof/MwUObstruct.agda`, and §4.2/§6.3 say why).
 3. **No term type-shifts.**  Shift types, not terms.  The only index
    arithmetic in the design is ordinary de Bruijn binder offsets:
    `numBinds Θ`, `shiftBy`, and the `n + X` lift in `scopeOf` and `dualScope`.

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -370,8 +370,10 @@ run-Tᵣ = push-Tᵣ
 
 -- ── Tₘ (IdLayerProbe §4b): Θ₂ re-exposes a masked slot (`unlock 0`) and the
 -- id-layer masks it again (`lock 0`).  The merged context morphism computed both
--- type contexts correctly and yet `_⊢ᵐ_` refused it, because `_⊢ᵐ_`
--- checks every entry against the PLAIN exterior.  Again: IdPush merges nothing.
+-- type contexts correctly and yet the SIMULTANEOUS `_⊢ᵐ_` refused it,
+-- because it checked every entry against the PLAIN exterior.  The
+-- SEQUENTIAL judgement checks each entry on the frame it acts on, and
+-- accepts it.  Again: IdPush merges nothing.
 
 Δₘ Mₘ : Ctxᵗ
 Δₘ = masked (bind `𝔹) ∷ bind `ℕ ∷ []
@@ -392,7 +394,7 @@ _ = refl
 ⊢Vₘ = env mw[] ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢Tₘ : Δₘ ∣ [] ⊢ Tₘ ⦂ `ℕ
-⊢Tₘ = env (mw-u ez mw[])
+⊢Tₘ = env (mw-u (_ , ez , locked nameable-b) mw[])
           (env (mw-l (bind `𝔹 , ez , nameable-b) mw[]) ⊢Vₘ
                (conv-idv (bind `ℕ , es ez , nameable-b))
                (wf-var (bind `ℕ , es ez , nameable-b)))
@@ -402,28 +404,35 @@ _ = refl
 -- is: `Θₘ₂` is not binds-only (it carries the re-exposing `unlock 0`), so
 -- the contractum's inner frame gains it at the tail — where `scope`
 -- applies it FIRST, exactly where `Θₘ₂` applied it.  The outer frame
--- keeps it too (`dropLocks Θₘ₂ ≡ Θₘ₂`): unmasking twice is unmasking.
+-- REWINDS it (`rewind Θₘ₂ ≡ lock 0 ∷ unlock 0 ∷ []`), which on this run
+-- is literally the same list as the merged inner frame.
 Θₘ₁′ : CtxMorph
 Θₘ₁′ = lock 0 ∷ unlock 0 ∷ []
 
 _ : _≡_ {A = CtxMorph} (Θₘ₁ ⋉ Θₘ₂) Θₘ₁′
 _ = refl
 
-_ : _≡_ {A = CtxMorph} (dropLocks Θₘ₂) Θₘ₂
+_ : _≡_ {A = CtxMorph} (rewind Θₘ₂) Θₘ₁′
+_ = refl
+
+_ : interior (rewind Θₘ₂) Δₘ ≡ Δₘ
 _ = refl
 
 -- … and the value's own frame is unchanged: the moved `unlock 0` is
 -- undone by the `lock 0` that already stood in front of it.
-_ : interior Θₘ₁′ (interior Θₘ₂ Δₘ) ≡ interior Θₘ₁ (interior Θₘ₂ Δₘ)
+_ : interior Θₘ₁′ (interior (rewind Θₘ₂) Δₘ) ≡ interior Θₘ₁ (interior Θₘ₂ Δₘ)
 _ = refl
 
-push-Tₘ : Δₘ ⊢ Tₘ -→ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ Θₘ₂ , id `ℕ ⟫
+⊢ᵐΘₘ₁′ : Δₘ ⊢ᵐ Θₘ₁′
+⊢ᵐΘₘ₁′ = mw-l (bind `𝔹 , ez , nameable-b)
+              (mw-u (_ , ez , locked nameable-b) mw[])
+
+push-Tₘ : Δₘ ⊢ Tₘ -→ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ rewind Θₘ₂ , id `ℕ ⟫
 push-Tₘ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
 
-⊢push-Tₘ : Δₘ ∣ [] ⊢ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ Θₘ₂ , id `ℕ ⟫ ⦂ `ℕ
-⊢push-Tₘ = env (mw-u ez mw[])
-               (env (mw-l (bind `𝔹 , ez , nameable-b) (mw-u ez mw[])) ⊢Vₘ
-                    (conv-unseal (es ez)) wf-ℕ)
+⊢push-Tₘ : Δₘ ∣ [] ⊢ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ Θₘ₁′ , id `ℕ ⟫ ⦂ `ℕ
+⊢push-Tₘ = env ⊢ᵐΘₘ₁′
+               (env ⊢ᵐΘₘ₁′ ⊢Vₘ (conv-unseal (es ez)) wf-ℕ)
                (conv-id base-ℕ) wf-ℕ
 
 run-Tₘ : Δₘ ⊢ Tₘ -→* $ 7
@@ -547,7 +556,7 @@ _ = refl
                   ⦂ (` 0 ⇒ ` 0)
   ⊢Wd-crossed =
     env (mw-l (_ , ez , nameable-b)
-              (mw-u (es (es (es ez))) mw[]))
+              (mw-u (_ , es (es (es ez)) , locked nameable-b) mw[]))
         ⊢Wd-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b))
@@ -627,7 +636,8 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
                    ⊢ wkᴹ 1 W1b ⟪ dual Θ1b , unseal 0 ↦ seal 0 ⟫
                    ⦂ (` 0 ⇒ ` 0)
   ⊢W1b-crossed =
-    env (mw-l (_ , ez , nameable-b) (mw-u (es (es ez)) mw[]))
+    env (mw-l (_ , ez , nameable-b)
+              (mw-u (_ , es (es ez) , locked nameable-a) mw[]))
         ⊢W1b-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b)) (wf-var (_ , ez , nameable-b)))
@@ -1847,7 +1857,8 @@ _ = refl
 -- (rendered by scripts/render_term.sh at `Δi`; `↓Y` is `lock 1`, `↥Y` is
 -- `unlock 1`.)  READ THE TWO LINES SIDE BY SIDE: `↓Y` has moved from the
 -- OUTER boundary to the INNER one, and the reveal `unseal X` went with
--- it.  The rep `Y` the reveal hands back is therefore presented on the
+-- it; what is left outside is the REWOUND frame `↥Y , ↓Y`, whose net
+-- effect on the type context is nothing at all.  The rep `Y` the reveal hands back is therefore presented on the
 -- outer boundary's own type context — where Y is live — instead of
 -- inside the lock, which is exactly what `env`'s last premise refused.
 -- The value's frame is unchanged, so `V` retypes where it was.
@@ -1856,9 +1867,10 @@ open import strong.proof.PreserveObstruct
   using (Δi; Θi; Vi; Ri; ⊢Ri; step-i)
 
 wallR₁ : Term
-wallR₁ = (Vi ⟪ [] ⋉ Θi , unseal 0 ⟫) ⟪ dropLocks Θi , mkId (` 1) ⟫
+wallR₁ = (Vi ⟪ [] ⋉ Θi , unseal 0 ⟫) ⟪ rewind Θi , mkId (` 1) ⟫
 
-_ : wallR₁ ≡ (Vi ⟪ lock 1 ∷ [] , unseal 0 ⟫) ⟪ [] , id (` 1) ⟫
+_ : wallR₁ ≡ (Vi ⟪ lock 1 ∷ [] , unseal 0 ⟫)
+               ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫
 _ = refl
 
 -- THE STEP THE OLD RULE COULD NOT TAKE SOUNDLY …
@@ -1870,7 +1882,7 @@ wallstep₁ = step-i
 ⊢wallR₁ = preservation ⊢Ri wallstep₁
 
 -- the value's own frame is untouched by the move
-_ : interior ([] ⋉ Θi) (interior (dropLocks Θi) Δi)
+_ : interior ([] ⋉ Θi) (interior (rewind Θi) Δi)
       ≡ interior [] (interior Θi Δi)
 _ = refl
 
@@ -1884,7 +1896,8 @@ _ = refl
 wallR₂ : Term
 wallR₂ = (((($ 7) ⟪ [] , seal 1 ⟫)
              ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫)
-             ⟪ [] , id (` 1) ⟫) ⟪ [] , id (` 1) ⟫
+             ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫)
+             ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫
 
 wallstep₂ : Δi ⊢ wallR₁ -→ wallR₂
 wallstep₂ = ξ-⟪⟫ (CancelR (V-⟪⟫ V-$ I-seal) ez)
@@ -2340,7 +2353,8 @@ Cu : Term
 Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ unlock 0 ∷ Θt , id (` 0) ↦ seal 0 ⟫
 
 ⊢Cu : Δt ∣ [] ⊢ Cu ⦂ (` 0 ⇒ ` 0)
-⊢Cu = env (mw-u ez (mw-l (bind `ℕ , ez , nameable-b) mw[]))
+⊢Cu = env (mw-u (_ , ez , locked nameable-b)
+                (mw-l (bind `ℕ , ez , nameable-b) mw[]))
           (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
           (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
           (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -52,10 +52,10 @@ module strong.Preservation where
 -- ground the premise is recorded in notes/DECISIONS.md, 2026-09-06).
 --
 -- The repair is a FRAME MOVE, not a side condition: the outer frame keeps
--- only its binds and unmasks (`dropLocks Θ₂`) and its whole SCOPE travels
+-- only its binds and unmasks (`rewind Θ₂`) and its whole SCOPE travels
 -- into the inner frame's tail (`Θ₁ ⋉ Θ₂`), where `scope` applies it first —
 -- exactly where it applied before.  Then
--- `interior (dropLocks Θ₂) Δ ≡ convCtx Θ₂ Δ`, the rep is presented OUTSIDE the
+-- `interior (rewind Θ₂) Δ ≡ convCtx Θ₂ Δ`, the rep is presented OUTSIDE the
 -- locks, and the missing premise is `wf-shiftBy-pushBinds` on the redex's own
 -- exterior type: the reveal's target IS that type, lifted.  Nothing is
 -- assumed about the world, and the old counterexample now REDUCES to a
@@ -76,7 +76,7 @@ open import strong.TermSubst using (_[_]ᵐ; wkᴹ; preserve-Beta)
 open import strong.Reduction
   using (_⊢_-→_; _⊢_-→*_; reveal; instReveal)
 
-open import strong.Reduction using (_⋉_; dropLocks)
+open import strong.Reduction using (_⋉_; rewind)
 open import strong.proof.Preserve
   using (preserve-TyBeta; preserve-Drop$; preserve-TyPeelR;
          ⊢ᵗ-of; CtxWf-[])
@@ -170,7 +170,7 @@ preservation-CancelR : ∀ {V Θ₁ Θ₂ X Y}
   → Δ ∣ [] ⊢ (V ⟪ Θ₁ , seal X ⟫) ⟪ Θ₂ , unseal Y ⟫ ⦂ C
     ---------------------------------------------------------------
   → Δ ∣ [] ⊢ (V ⟪ Θ₁ ⋉ Θ₂ , mkId (shiftBy (numBinds Θ₁) A) ⟫)
-               ⟪ dropLocks Θ₂ , mkId A ⟫ ⦂ C
+               ⟪ rewind Θ₂ , mkId A ⟫ ⦂ C
 preservation-CancelR = preserve-CancelR
 
 -- IDPUSH — the case the wall used to block, likewise unconditional.
@@ -178,7 +178,7 @@ preservation-IdPush : ∀ {V Θ₁ Θ₂ X Y}
   → Value V → convCtx Θ₂ Δ ∋ Y := A
   → Δ ∣ [] ⊢ (V ⟪ Θ₁ , id (` X) ⟫) ⟪ Θ₂ , unseal Y ⟫ ⦂ C
     ---------------------------------------------------------------
-  → Δ ∣ [] ⊢ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ dropLocks Θ₂ , mkId A ⟫ ⦂ C
+  → Δ ∣ [] ⊢ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ rewind Θ₂ , mkId A ⟫ ⦂ C
 preservation-IdPush = preserve-IdPush
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -83,6 +83,8 @@ driver: type-checking it type-checks the whole thing.
 | `MaskFacts.agda` | no boundary operation can take a binder away (masking retains, unlocking recovers); the old cancel residue is not well formed |
 | `Adversary.agda` | the soundness gate: a conceal must cite a live binder, and v1's adversaries refuted by that one inversion |
 | `PreserveObstruct.agda` | the four refutation witnesses, three of which now record the **positive** fact after the repairs (§2 `TyPeelR`, §4 the wall witness) |
+| `DualTightness.agda` | **the tightness defect**: `dual` drops `unlock` entries, so `Peel` takes an **ill-typed** redex to a **well-typed** contractum — scope is gained through the boundary (Jeremy's test, 2026-09-06), plus the positive control at a `lock` |
+| `MwUObstruct.agda` | the three-part repair for it (masked-only `mw-u`, `unlock ↦ lock` in `dualScope`, a binds-only outer frame), **refuted**: §1 why (2) forces (1), §2 (1) kills `⊢retag`, §3/§4 (1) kills the scope move `_⋉_` at a well-typed `IdPush` redex, §5/§6 what a sequential `_⊢ᵐ_` would additionally cost |
 | `TypeSafety.agda` | `type-safety` = `progress ∘ preservation*` |
 
 **The invariant hunt** — the search for a side condition that would

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -83,8 +83,8 @@ driver: type-checking it type-checks the whole thing.
 | `MaskFacts.agda` | no boundary operation can take a binder away (masking retains, unlocking recovers); the old cancel residue is not well formed |
 | `Adversary.agda` | the soundness gate: a conceal must cite a live binder, and v1's adversaries refuted by that one inversion |
 | `PreserveObstruct.agda` | the four refutation witnesses, three of which now record the **positive** fact after the repairs (§2 `TyPeelR`, §4 the wall witness) |
-| `DualTightness.agda` | **the tightness defect**: `dual` drops `unlock` entries, so `Peel` takes an **ill-typed** redex to a **well-typed** contractum — scope is gained through the boundary (Jeremy's test, 2026-09-06), plus the positive control at a `lock` |
-| `MwUObstruct.agda` | the three-part repair for it (masked-only `mw-u`, `unlock ↦ lock` in `dualScope`, a binds-only outer frame), **refuted**: §1 why (2) forces (1), §2 (1) kills `⊢retag`, §3/§4 (1) kills the scope move `_⋉_` at a well-typed `IdPush` redex, §5/§6 what a sequential `_⊢ᵐ_` would additionally cost |
+| `DualTightness.agda` | **tightness of the crossing**, Jeremy's test (2026-09-06) and its repair: the redex that is ill typed at the exterior now has an ill-typed contractum too (`¬⊢Contractum`), (†) `interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ`, the positive control at a `lock`, and the VACUOUS UNLOCK refused (`¬⊢ᵐΘᵥ`) |
+| `MwUObstruct.agda` | which outer frame the scope move may use, on one configuration: `dropLocks Θ₂` **refuted** (the moved unlock goes vacuous), `bindsOnly Θ₂` **refuted** (the frame's own rep loses its unlock), `rewind Θ₂` does both jobs — and why `mw-b` reads its rep on `unlockedScope Θ Δ` rather than on the plain exterior |
 | `TypeSafety.agda` | `type-safety` = `progress ∘ preservation*` |
 
 **The invariant hunt** — the search for a side condition that would

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -124,21 +124,29 @@ hideBinds : ℕ → CtxMorph
 hideBinds zero    = []
 hideBinds (suc k) = lock k ∷ hideBinds k
 
--- THE UNLOCK CASE IS DROPPED (repair, 2026-09-05).  The old design mapped
--- `unlock X ↦ lock (n + X)`, which (i) re-blocks a NO-OP unlock (a slot the
--- crossed boundary never masked — `mw-u` permits it) and (ii) makes
--- a same-slot mask/unmask pair fail to cancel.  A faithful dual only has to
--- UNDO the crossed boundary's LOCKS (turning `scope Θ Δ` back into
--- `unlockedScope Θ Δ` in the tail) and MASK its binders; an `unlock` in Θ
--- leaves the tail MORE
--- nameable, which the crossing argument absorbs by `⊢retag`.  With this,
--- `interior-dual` and `convCtx-dual` become true in general
--- (proof/PeelDual.agda), and the Peel case is proven.
+-- THE DUAL IS AN INVERSE, AND AN INVERSE RUNS BACKWARDS (2026-09-06).
+--
+-- The mini-core DROPPED the `unlock` case, on the reading that an
+-- `unlock` "claims nothing".  It claims plenty: it UNMASKS, and a dual
+-- that does not re-mask hands the crossing argument a frame STRICTLY MORE
+-- NAMEABLE than the exterior — `Peel` GAINS SCOPE, machine-checked in
+-- proof/DualTightness.agda.  So `unlock X ↦ lock (n + X)`, and the
+-- restoring `lock` is sound exactly because `mw-u` (strong.Terms) refuses
+-- a VACUOUS unlock: `mask ∘ unmask` is the identity at a LOCKED slot
+-- (`mask-unmask`, strong.Ctx) and nowhere else.
+--
+-- AND THE LIST IS REVERSED.  `scope` applies its list HEAD-LAST, so
+-- undoing it runs the entries BACK TO FRONT; a same-order dual is not an
+-- inverse at a frame that toggles one slot twice (`Θ = ↥X ∷ ↧X ∷ []`,
+-- which the judgement admits).  With both repairs the frame identity is
+-- EXACT (proof/PeelDual, `interior-dual`): the crossing argument's frame
+-- is the exterior itself, one bind prefix in, and it crosses by
+-- `⊢rename` alone — no `⊢retag`, no `le-mu`.
 dualScope : ℕ → CtxMorph → CtxMorph
 dualScope n []             = []
 dualScope n (bind A ∷ Θ)   = dualScope n Θ
-dualScope n (unlock X ∷ Θ) = dualScope n Θ
-dualScope n (lock X ∷ Θ)   = unlock (n + X) ∷ dualScope n Θ
+dualScope n (unlock X ∷ Θ) = dualScope n Θ ++ (lock   (n + X) ∷ [])
+dualScope n (lock X ∷ Θ)   = dualScope n Θ ++ (unlock (n + X) ∷ [])
 
 dual : CtxMorph → CtxMorph
 dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
@@ -184,15 +192,26 @@ scopeOf n (bind A ∷ Θ)   = scopeOf n Θ
 scopeOf n (unlock X ∷ Θ) = unlock (n + X) ∷ scopeOf n Θ
 scopeOf n (lock X ∷ Θ)   = lock (n + X) ∷ scopeOf n Θ
 
--- What is LEFT of the outer frame: its binds and its unlocks.  Its
--- interior IS its conversion context (`interior-dropLocks`,
--- proof/MoveScope) — which is exactly why the rep it now presents is
--- well formed there.
-dropLocks : CtxMorph → CtxMorph
-dropLocks []             = []
-dropLocks (bind A ∷ Θ)   = bind A ∷ dropLocks Θ
-dropLocks (unlock X ∷ Θ) = unlock X ∷ dropLocks Θ
-dropLocks (lock X ∷ Θ)   = dropLocks Θ
+-- WHAT IS LEFT OF THE OUTER FRAME: the frame with its OWN SCOPE REWOUND.
+--
+-- `rewind Θ` is Θ with its inverse scope run on top, so its net effect on
+-- the exterior is the BIND PREFIX ALONE:
+--
+--     scope    (rewind Θ) Δ ≡ Δ                       (given Δ ⊢ᵐ Θ)
+--     interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ
+--
+-- which is what makes the moved scope reproduce the redex's frame ON THE
+-- NOSE (`interior-⋉-rewind`, proof/MoveScope) — no `⊢retag` and no
+-- `le-mu` anywhere in the two cases.
+--
+-- IT IS NOT `bindsOnly Θ`, AND THAT IS THE POINT.  Simply DELETING Θ's
+-- scope has the same effect on the type context but loses the frame's own
+-- `⊢ᵐ`: Θ's bind reps are read on `unlockedScope Θ′ Δ` (strong.Terms,
+-- `mw-b`) and a rep naming a slot Θ's tail UNLOCKED is not well formed on
+-- the plain Δ.  Keeping the entries and rewinding them keeps every rep
+-- exactly where it was read.
+rewind : CtxMorph → CtxMorph
+rewind Θ = dualScope 0 Θ ++ Θ
 
 -- The inner frame, with the outer frame's scope moved in at its TAIL.
 -- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁`: the move carries no binder.
@@ -297,7 +316,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   CancelR : ∀ {Δ V Θ₁ Θ₂ X Y A} → Value V → convCtx Θ₂ Δ ∋ Y := A
     → Δ ⊢ (V ⟪ Θ₁ , seal X ⟫) ⟪ Θ₂ , unseal Y ⟫
         -→ (V ⟪ Θ₁ ⋉ Θ₂ , mkId (shiftBy (numBinds Θ₁) A) ⟫)
-             ⟪ dropLocks Θ₂ , mkId A ⟫
+             ⟪ rewind Θ₂ , mkId A ⟫
 
   -- DROP$ — an identity boundary at a base type, over a numeral (`⊢$`
   -- types it anywhere).
@@ -317,13 +336,13 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- THE SCOPE MOVE (2026-09-06).  The swap makes the INNER boundary the
   -- revealing one, so its exterior type becomes Y's rep `A`.  Θ₂'s LOCKS
   -- travel into the inner frame (§2b) so that the rep is presented
-  -- OUTSIDE them, where it is nameable: `interior (dropLocks Θ₂) Δ` IS
-  -- `convCtx Θ₂ Δ`, and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's own
+  -- OUTSIDE them, where it is nameable: `interior (rewind Θ₂) Δ` IS
+  -- `pushBinds (repsOf Θ₂) Δ`, and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's own
   -- exterior type C.  That is what retires the wall — the case needs no
   -- scoping invariant at all (proof/MoveScope.preserve-IdPush).
   IdPush : ∀ {Δ V Θ₁ Θ₂ X Y A} → Value V → convCtx Θ₂ Δ ∋ Y := A
     → Δ ⊢ (V ⟪ Θ₁ , id (` X) ⟫) ⟪ Θ₂ , unseal Y ⟫
-        -→ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ dropLocks Θ₂ , mkId A ⟫
+        -→ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ rewind Θ₂ , mkId A ⟫
 
   ξ-·-l : ∀ {Δ L L′ M} → Δ ⊢ L -→ L′ → Δ ⊢ L · M -→ L′ · M
   ξ-·-r : ∀ {Δ V M M′} → Value V → Δ ⊢ M -→ M′ → Δ ⊢ V · M -→ V · M′
@@ -389,7 +408,7 @@ det (ξ-·[] st)     (TyPeelR v ⊢s) = ⊥-elim (value-¬step (V-⟪⟫ v I-all
 -- CancelR — the two contracta agree because the lookup is a function.
 det (CancelR {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} v d) (CancelR v′ d′) =
   cong (λ T → (V ⟪ Θ₁ ⋉ Θ₂ , mkId (shiftBy (numBinds Θ₁) T) ⟫)
-                ⟪ dropLocks Θ₂ , mkId T ⟫)
+                ⟪ rewind Θ₂ , mkId T ⟫)
        (∋:=-det d d′)
 det (CancelR v d) (ξ-⟪⟫ st) = ⊥-elim (value-¬step (V-⟪⟫ v I-seal) st)
 det (ξ-⟪⟫ st) (CancelR v d) = ⊥-elim (value-¬step (V-⟪⟫ v I-seal) st)

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -166,24 +166,23 @@ dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
 -- CONTEXT and NOT, in general, inside the outer boundary's own locks — that
 -- was the wall (the old proof/PreserveObstruct §4).
 --
--- The repair is not a side condition but a FRAME MOVE: the outer frame
--- keeps only what BINDS and what UNMASKS, and its whole SCOPE part
--- travels into the inner frame's TAIL, where `scope` applies it FIRST —
--- exactly where it applied before.  The rep is then presented OUTSIDE the
--- locks, where it is nameable, and the locks still stand between the
--- value and the world.
+-- The repair is not a side condition but a FRAME MOVE: the outer frame's
+-- whole SCOPE travels into the inner frame's TAIL, where `scope` applies
+-- it FIRST — exactly where it applied before — and what stays outside is
+-- the frame with its own scope REWOUND (`rewind Θ₂`), whose net effect on
+-- the exterior is its BIND PREFIX alone.  The rep is then presented
+-- OUTSIDE the locks, where it is nameable, and the locks still stand
+-- between the value and the world.
 --
--- WHY THE UNLOCKS TRAVEL TOO, AND ARE ALSO RETAINED.  `scope` applies its
--- list HEAD-LAST, so moving only the LOCKS past a same-slot `unlock`
--- reorders a mask/unmask pair, and the value's frame is then not refined
--- but CORRUPTED — a slot it may name is masked in the contractum and was
--- not in the redex (`¬frame-locksOnly`, proof/MoveScope §4b, at the
--- ⊢ᵐ-legal `Θ₂ = unlock 0 ∷ lock 0 ∷ []`).  Moving the WHOLE scope keeps
--- the order, and the retained unmasks are harmless: unmasking only ADDS
--- nameability, so the value's frame is REFINED and `⊢retag` carries it
--- (`frame-move`).  With that the frame lemma is UNCONDITIONAL — no
--- premise about Θ₂'s shape, and no side condition for Progress to
--- supply.
+-- WHY THE UNLOCKS TRAVEL TOO.  `scope` applies its list HEAD-LAST, so
+-- moving only the LOCKS past a same-slot `unlock` reorders a mask/unmask
+-- pair, and the value's frame is then not refined but CORRUPTED — a slot
+-- it may name is masked in the contractum and was not in the redex
+-- (`¬frame-locksOnly`, proof/MoveScope §4b, at the ⊢ᵐ-legal
+-- `Θ₂ = unlock 0 ∷ lock 0 ∷ []`).  Moving the WHOLE scope keeps the
+-- order, and then the value's frame is preserved ON THE NOSE: the two
+-- frame lemmas are EQUALITIES, no `⊢retag` appears in either case, and
+-- there is no premise about Θ₂'s shape for Progress to supply.
 
 -- The outer frame's scope entries, lifted past its own binders.
 scopeOf : ℕ → CtxMorph → CtxMorph

--- a/SystemF/agda/strong/TermSubst.agda
+++ b/SystemF/agda/strong/TermSubst.agda
@@ -119,11 +119,17 @@ ren-convCtx : (Θ : CtxMorph) (ρ : Renameᵗ) → Ren ρ Δ Δ′ → Inj ρ
 ren-convCtx Θ ρ r i rewrite repsOf-ren ρ Θ =
   ren-pushBinds (repsOf Θ) ρ (ren-unlockedScope Θ r i)
 
+-- Under the SEQUENTIAL judgement each premise is read on the frame the
+-- entry acts on, so each transports by the matching type-context
+-- transport: `ren-unlockedScope` for a rep, `ren-scope` for a name.
 ⊢ᵐ-ren : ∀ {Θ} → Ren ρ Δ Δ′ → Inj ρ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ renᴮ ρ Θ
-⊢ᵐ-ren r i mw[]        = mw[]
-⊢ᵐ-ren r i (mw-b w b)  = mw-b (wf-ren r w) (⊢ᵐ-ren r i b)
-⊢ᵐ-ren r i (mw-l tv b) = mw-l (ren-tv r tv) (⊢ᵐ-ren r i b)
-⊢ᵐ-ren r i (mw-u d b)  = mw-u (ren∋ r d) (⊢ᵐ-ren r i b)
+⊢ᵐ-ren                     r i mw[]        = mw[]
+⊢ᵐ-ren {Θ = bind A ∷ Θ}    r i (mw-b w b)  =
+  mw-b (wf-ren (ren-unlockedScope Θ r i) w) (⊢ᵐ-ren r i b)
+⊢ᵐ-ren {Θ = lock X ∷ Θ}    r i (mw-l tv b) =
+  mw-l (ren-tv (ren-scope Θ r i) tv) (⊢ᵐ-ren r i b)
+⊢ᵐ-ren {Θ = unlock X ∷ Θ}  r i (mw-u lk b) =
+  mw-u (ren-∋lk (ren-scope Θ r i) lk) (⊢ᵐ-ren r i b)
 
 ------------------------------------------------------------------------
 -- 3.  THE RENAMING TRANSPORT
@@ -179,22 +185,27 @@ renΓ ρ Γ = map (renameᵗ ρ) Γ
 -- 4.  THE RETAGGING TRANSPORT
 ------------------------------------------------------------------------
 
+-- THE REFINEMENT A TERM TRAVELS ALONG IS `_⊑ᵃ_` (strong.Ctx §4b), NOT
+-- `_⊑_`: a boundary's `unlock X` claims that X is LOCKED, and `le-mu` —
+-- the clause that re-exposes a concealed slot — destroys the claim
+-- (`⊢ᵐ-⊑ᵃ`, strong.Terms).  TYPES and CONVERSIONS still travel along the
+-- full `_⊑_`: `⊑-wf` and `conv-⊑` are applied at `⊑ᵃ→⊑ ls`.
 ⊢retag : ∀ {Δ Δ′ Γ M A}
-  → Δ ⊑ Δ′
+  → Δ ⊑ᵃ Δ′
   → Δ  ∣ Γ ⊢ M ⦂ A
     ---------------
   → Δ′ ∣ Γ ⊢ M ⦂ A
 ⊢retag ls (⊢` d)       = ⊢` d
 ⊢retag ls ⊢$           = ⊢$
-⊢retag ls (⊢ƛ w ⊢N)    = ⊢ƛ (⊑-wf ls w) (⊢retag ls ⊢N)
+⊢retag ls (⊢ƛ w ⊢N)    = ⊢ƛ (⊑-wf (⊑ᵃ→⊑ ls) w) (⊢retag ls ⊢N)
 ⊢retag ls (⊢· ⊢L ⊢M)   = ⊢· (⊢retag ls ⊢L) (⊢retag ls ⊢M)
-⊢retag ls (⊢Λ ⊢N)      = ⊢Λ (⊢retag (le∷ le-aa ls) ⊢N)
-⊢retag ls (⊢·[] ⊢L w)  = ⊢·[] (⊢retag ls ⊢L) (⊑-wf ls w)
+⊢retag ls (⊢Λ ⊢N)      = ⊢Λ (⊢retag (la∷ la-aa ls) ⊢N)
+⊢retag ls (⊢·[] ⊢L w)  = ⊢·[] (⊢retag ls ⊢L) (⊑-wf (⊑ᵃ→⊑ ls) w)
 ⊢retag ls (env {Θ = Θ} mw ⊢M ⊢c wE) =
-  env (⊢ᵐ-⊑ ls mw)
-      (⊢retag (⊑-interior Θ ls) ⊢M)
-      (conv-⊑ (⊑-convCtx Θ ls) ⊢c)
-      (⊑-wf ls wE)
+  env (⊢ᵐ-⊑ᵃ ls mw)
+      (⊢retag (⊑ᵃ-interior Θ ls) ⊢M)
+      (conv-⊑ (⊑-convCtx Θ (⊑ᵃ→⊑ ls)) ⊢c)
+      (⊑-wf (⊑ᵃ→⊑ ls) wE)
 
 ------------------------------------------------------------------------
 -- 5.  Term substitution

--- a/SystemF/agda/strong/Terms.agda
+++ b/SystemF/agda/strong/Terms.agda
@@ -135,6 +135,19 @@ interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ �
 ⊑-interior : (Θ : CtxMorph) → Δ ⊑ Δ′ → interior Θ Δ ⊑ interior Θ Δ′
 ⊑-interior Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-scope Θ ls)
 
+-- … and the same three transports for the LOCK-PRESERVING refinement,
+-- the one a TERM travels along.
+⊑ᵃ-scope : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → scope Θ Δ ⊑ᵃ scope Θ Δ′
+⊑ᵃ-scope []             ls = ls
+⊑ᵃ-scope (bind A ∷ Θ)   ls = ⊑ᵃ-scope Θ ls
+⊑ᵃ-scope (unlock X ∷ Θ) ls =
+  ⊑ᵃ-updateAt unmaskEnt unmaskEnt-monoᵃ (⊑ᵃ-scope Θ ls)
+⊑ᵃ-scope (lock X ∷ Θ)   ls =
+  ⊑ᵃ-updateAt masked masked-monoᵃ (⊑ᵃ-scope Θ ls)
+
+⊑ᵃ-interior : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → interior Θ Δ ⊑ᵃ interior Θ Δ′
+⊑ᵃ-interior Θ ls = ⊑ᵃ-pushBinds (repsOf Θ) (⊑ᵃ-scope Θ ls)
+
 ⊑-convCtx : (Θ : CtxMorph) → Δ ⊑ Δ′ → convCtx Θ Δ ⊑ convCtx Θ Δ′
 ⊑-convCtx Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-unlockedScope Θ ls)
 
@@ -142,34 +155,51 @@ interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ �
 -- 2.  Boundary well-formedness
 ------------------------------------------------------------------------
 
--- Every premise names a slot or checks a rep in the PLAIN exterior.  There
--- is no Reversal≈, no starOnly, no SkelEq, no x-lookup: an `unlock` claims
--- nothing at all, and a `lock` claims nothing either — the claim lives in the
--- CONVERSION (`seal X`, which must cite a live binder).
+-- EVERY PREMISE IS READ ON THE FRAME THE ENTRY ACTS ON — the judgement is
+-- SEQUENTIAL, in the order `scope` applies the list (head-LAST).  For the
+-- tail Θ′ of the entry:
 --
--- An `unlock X` premise asks only that the slot EXISTS.  It cannot ask that the
--- slot be masked and stay stable under refinement (a Cancel may already have
--- un-masked it), and it need not: `unmask` is total and an alias at an
--- un-masked slot is a no-op.  Note the distinction the mask discipline
--- forces: `unlock X`/`lock X` NAME a masked index — that is an ENTRY, not a type
--- — while `Δ ⊢ᵗ ` X` at a masked slot is refused.  Tightness is about USE in
--- a type, not about mentioning the index in the context morphism.
+--   lock X    X is NAMEABLE in `scope Θ′ Δ`  (you may only mask what is
+--             visible: no double masking, so `Locked` is one mask deep)
+--   unlock X  X is LOCKED   in `scope Θ′ Δ`  (`Δ ∋lk X`: masked over a
+--             nameable entry).  A VACUOUS UNLOCK — `↥X` at a slot the
+--             frame leaves visible — IS REFUSED; it is the premise the
+--             judgement used to drop, and the one the dual's restoring
+--             `lock` needs (`mask-unmask`, strong.Ctx).
+--   bind A    A is a type over `unlockedScope Θ′ Δ` — the tail's UNMASKS
+--             applied and its LOCKS lifted.  A rep is never blocked by
+--             the frame's own locks (that is the simultaneity law: a rep
+--             is read where the CONVERSION is read, outside the masking
+--             the boundary itself performs), and it may name what the
+--             tail unlocked — which is what makes the scope move
+--             (`_⋉_`, strong.Reduction) well formed.
+--
+-- Note the distinction the mask discipline forces: `unlock X`/`lock X`
+-- NAME a masked index — that is an ENTRY, not a type — while `Δ ⊢ᵗ ` X`
+-- at a masked slot is refused.  Tightness is about USE in a type, not
+-- about mentioning the index in the context morphism.
+--
 -- `Δ ⊢ᵐ Θ` — the context morphism Θ is WELL FORMED over Δ.  An infix
 -- judgement in the family of `Δ ⊢ᵗ A` (strong.Ctx) and `Δ ⊢ c ∶ A ⇝ B`
 -- (strong.Conversion).
 infix 4 _⊢ᵐ_
 data _⊢ᵐ_ : Ctxᵗ → CtxMorph → Set where
   mw[] : Δ ⊢ᵐ []
-  mw-b : ∀ {A Θ} → Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
-  mw-l : ∀ {X Θ} → Δ ∋tv X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
-  mw-u : ∀ {X E Θ} → Δ ∋e X , E → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
+  mw-b : ∀ {A Θ} → unlockedScope Θ Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
+  mw-l : ∀ {X Θ} → scope Θ Δ ∋tv X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
+  mw-u : ∀ {X Θ} → scope Θ Δ ∋lk X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
 
-⊢ᵐ-⊑ : ∀ {Θ} → Δ ⊑ Δ′ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ Θ
-⊢ᵐ-⊑ ls mw[]        = mw[]
-⊢ᵐ-⊑ ls (mw-b w b)  = mw-b (⊑-wf ls w) (⊢ᵐ-⊑ ls b)
-⊢ᵐ-⊑ ls (mw-l tv b) = mw-l (⊑-tv ls tv) (⊢ᵐ-⊑ ls b)
-⊢ᵐ-⊑ ls (mw-u d b)  with ⊑-∋e ls d
-... | E′ , d′ , _ = mw-u d′ (⊢ᵐ-⊑ ls b)
+-- THE TERM TRANSPORT IS `_⊑ᵃ_`, NOT `_⊑_`.  An `unlock X` CLAIMS that X
+-- is locked, and `le-mu` — the clause that re-exposes a concealed slot —
+-- destroys the claim; `_⊑ᵃ_` (strong.Ctx §4b) is `_⊑_` without it.
+⊢ᵐ-⊑ᵃ : ∀ {Θ} → Δ ⊑ᵃ Δ′ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ Θ
+⊢ᵐ-⊑ᵃ {Θ = []}           ls mw[]        = mw[]
+⊢ᵐ-⊑ᵃ {Θ = bind A ∷ Θ}   ls (mw-b w b)  =
+  mw-b (⊑-wf (⊑-unlockedScope Θ (⊑ᵃ→⊑ ls)) w) (⊢ᵐ-⊑ᵃ ls b)
+⊢ᵐ-⊑ᵃ {Θ = lock X ∷ Θ}   ls (mw-l tv b) =
+  mw-l (⊑-tv (⊑-scope Θ (⊑ᵃ→⊑ ls)) tv) (⊢ᵐ-⊑ᵃ ls b)
+⊢ᵐ-⊑ᵃ {Θ = unlock X ∷ Θ} ls (mw-u lk b) =
+  mw-u (⊑ᵃ-lk (⊑ᵃ-scope Θ ls) lk) (⊢ᵐ-⊑ᵃ ls b)
 
 ------------------------------------------------------------------------
 -- 3.  Terms

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2506,3 +2506,18 @@ masked-only mw-u with SEQUENTIAL scope premises (reps stay on the plain
 non-unmasking refinement only, scope move with bindsOnly outer frame
 (frame lemmas as equalities).  Expected sticking point: Θ₁'s bind reps
 under the move (MwUObstruct §6) — the missing premise, if any, is there.
+
+### RATIFIED: representations read past the tail's unlocks; PR #193 merged (Jeremy, 2026-09-06)
+
+Jeremy ratified item 2 of the tight-boundary package (mw-b reads a
+bind's representation on `unlockedScope Θ′ Δ`, the frame the conversion
+is read on; names in lock/unlock entries are read on `scope Θ′ Δ`) and
+ordered PR #193 merged: "That particular law was not valuable on its own,
+it was just a design idea to try."  Design law 4 ("Simultaneity") is
+thereby reduced to its surviving half — a representation is never blocked
+by its own frame's locks, and `pushBinds` lifts it past exactly the
+binders inside it — and the "every premise on the plain exterior" half is
+retired.  Landed with it: sequential `Δ ⊢ᵐ Θ` (no vacuous unlocks, no
+double locks), the exact dual (†), `rewind Θ₂` as the scope move's outer
+frame, `⊢retag` over `⊑ᵃ`.  Branch dual-relock (Δ-dependent dual) is the
+superseded alternative; PR #192 is contained in #193.

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2453,3 +2453,37 @@ The `_⊑ᵉ_` constructors lose their owner/blocked initials: le-ao → le-ab
 (abst ⊑ bind), le-oo → le-bb (bind ⊑ bind), and the masked pair le-bb →
 le-mm, le-bu → le-mu; le-aa stays.  Then the PR is marked ready for
 review.
+
+### Peel's dual is NOT tight for `unlock` entries (Jeremy's test, 2026-09-06)
+
+Jeremy: "I don't fully understand the definition of dual and not sure I
+trust it … create an example program that takes a Peel step, and the
+program should have an ill-formed type in the argument W, and after the
+reduction step, W wrapped in the dual boundary should still be
+ill-formed."  RESULT (proof/DualTightness.agda): bind entries are tight
+(wkᴹ shifts W's indices past them) but `dualScope` DROPS unlocks, so with
+exterior ⌷[X := ℕ], Θ = ↥X, W = λx:ℕ. (ΛY. 3)[X] (names the masked X;
+ill-typed), the redex `(V ⟪ ↥X , c ⟫) · W` is ill-typed and its Peel
+contractum is WELL-TYPED (W's frame inside is bind ℕ: X visible).  Scope
+is gained through the boundary — design law 2 fails for the RELATION
+(not a preservation failure: the redex is ill-typed).
+
+PROBED FIX, REFUTED (proof/MwUObstruct.agda): (1) mw-u requires a masked
+slot, (2) dualScope maps unlock ↦ lock, (3) the scope move's outer frame
+becomes bindsOnly.  (3) alone is GOOD: interior-⋉-bindsOnly and
+convCtx-⋉-bindsOnly are EQUALITIES (frame-move's ⊑ was an artifact of the
+retained unlocks).  But (2) forces (1) (a vacuous unlock, legal today,
+makes preserve-Peel false under dual′), and (1) kills ⊢ᵐ-⊑ hence ⊢retag
+(le-mu: Cancel's own refinement unmasks a slot an unlock cites) and kills
+⊢ᵐ-⋉ (⋉ builds lists that lock AND unlock one slot; under (1) mw-l and
+mw-u are exact complements so no SIMULTANEOUS ⊢ᵐ can hold — §3/§4 mirror
+witnesses).  Structural reason: `_⊢ᵐ_` is simultaneous (law 4), `scope`
+is sequential.  Sequential ⊢ᵐ (§5/§6) would force dualScope to reverse
+and mw-b's rep to be read sequentially — colliding with simultaneity.
+NEXT CANDIDATE (δ), to probe: leave ⊢ᵐ alone and make the dual read the
+EXTERIOR: `dual Δ Θ` maps `unlock X ↦ lock X` only when X is masked in Δ
+(reduction is Δ-indexed, so Peel may inspect Δ; simultaneity respected —
+one read on the plain Δ).  Then vacuous unlocks add nothing (preserve-Peel
+survives), non-vacuous ones are re-locked (the leak closes), and
+`interior (dual Δ Θ) (interior Θ Δ) ≡ masked binds ++ Δ` should be exact
+with no change to the scope move.

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2487,3 +2487,22 @@ one read on the plain Δ).  Then vacuous unlocks add nothing (preserve-Peel
 survives), non-vacuous ones are re-locked (the leak closes), and
 `interior (dual Δ Θ) (interior Θ Δ) ≡ masked binds ++ Δ` should be exact
 with no change to the scope move.
+
+### RULING: vacuous unlocks are wrong and unreachable (Jeremy, 2026-09-06)
+
+Jeremy: "why do we allow ↥X over X := ℕ visible?  That feels wrong … and
+unreachable."  RULED: the judgment must refuse them (mw-u's slot must be
+masked).  Hint for the probe: "my feeling is you're missing a few
+premises … look for places where information is dropped."  Two probes
+run in parallel, both non-landing: (δ) branch dual-relock — a Δ-dependent
+dual that re-locks only non-vacuous unlocks, leaving `_⊢ᵐ_` alone; and
+the PRINCIPLED package, branch dual-principled — audit of dropped
+information (mw-u's maskedness, dualScope dropping unlocks, the scope
+move's dropped entries, `_⊢ᵐ_` reading scope premises on the plain Δ and
+so dropping order, le-mu forgetting maskedness, Peel's crossing retype,
+mw-b's rep independence from the same morphism's unlocks), then:
+masked-only mw-u with SEQUENTIAL scope premises (reps stay on the plain
+Δ — simultaneity), dualScope restoring unlock ↦ lock, ⊢retag over the
+non-unmasking refinement only, scope move with bindsOnly outer frame
+(frame lemmas as equalities).  Expected sticking point: Θ₁'s bind reps
+under the move (MwUObstruct §6) — the missing premise, if any, is there.

--- a/SystemF/agda/strong/proof/Adversary.agda
+++ b/SystemF/agda/strong/proof/Adversary.agda
@@ -28,12 +28,21 @@ seal-cites-binder : ∀ {Δ X A B c}
   → Δ ⊢ c ∶ A ⇝ B → c ≡ seal X → Δ ∋ X := A
 seal-cites-binder (conv-seal d) refl = d
 
--- `unlock` claims nothing: it is a NAME with no rep, so it cannot assert
--- knowledge.  The boundary context morphism carries no type at an alias,
--- and `Δ ⊢ᵐ Θ`'s alias premise is `Δ ∋e X , E` — pure existence.
-unlock-claims-nothing : ∀ {Δ X E Θ} → Δ ∋e X , E → Δ ⊢ᵐ Θ
+-- `unlock` claims NO KNOWLEDGE: it is a NAME with no rep, so it cannot
+-- assert what a slot stands for.  What it now does claim is that the
+-- slot is LOCKED (`scope Θ Δ ∋lk X`) — a statement about MASKING, in
+-- which no type occurs, and which is what makes the dual's restoring
+-- `lock` sound (proof/DualTightness).  A VACUOUS unlock, at a slot the
+-- frame leaves nameable, is REFUSED.
+unlock-claims-a-lock : ∀ {Δ X Θ} → scope Θ Δ ∋lk X → Δ ⊢ᵐ Θ
   → Δ ⊢ᵐ (unlock X ∷ Θ)
-unlock-claims-nothing = mw-u
+unlock-claims-a-lock = mw-u
+
+-- The claim mentions no representation: all it hands back is a
+-- NAMEABLE entry under one mask, and `Nameable` is `abst` or `bind`
+-- without reading the bind's type.
+unlock-mentions-no-rep : ∀ {Δ X} → Δ ∋lk X → ∃[ E ] Nameable E
+unlock-mentions-no-rep (masked E , _ , locked v) = E , v
 
 ------------------------------------------------------------------------
 -- 2.  THE ADVERSARY (the old ⊢3n-adv): a conceal asserting false knowledge
@@ -43,7 +52,7 @@ unlock-claims-nothing = mw-u
 -- adversary exported `7 : ℕ` at the abstract type.  Here the boundary is
 -- unmintable, because `seal 0` demands `Δ ∋ 0 := `ℕ` and an `abst` slot
 -- has no rep to cite.  Unmasking cannot manufacture one either
--- (`unlock-claims-nothing`).
+-- (`unlock-claims-a-lock`).
 
 Δadv : Ctxᵗ
 Δadv = abst ∷ []

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -1,0 +1,162 @@
+module strong.proof.DualTightness where
+
+-- TIGHTNESS OF THE DUAL — Jeremy's test (2026-09-06), MACHINE-CHECKED.
+--
+-- THE DEFECT.  `dualScope` (strong.Reduction §2) DROPS the crossed
+-- boundary's `unlock` entries.  So a boundary whose morphism UNMASKS an
+-- exterior slot hands its crossing argument a frame in which that slot is
+-- STILL unmasked: `interior (dual Θ) (interior Θ Δ)` is
+-- `map masked (bind prefix) ++ unlockedScope Θ Δ` (proof/PeelDual,
+-- `interior-dual`), and `unlockedScope Θ Δ` is STRICTLY MORE NAMEABLE than
+-- Δ whenever Θ unlocks a slot Δ masks.  SCOPE IS GAINED THROUGH THE
+-- BOUNDARY.
+--
+-- The witness below exhibits the gain as a rule-level fact: a redex that
+-- is ILL TYPED at Δ (its argument W names a slot MASKED at Δ) whose `Peel`
+-- contractum is WELL TYPED.  `Peel` therefore does not preserve the
+-- exterior's scope discipline; the crossing is not tight.
+--
+-- Nothing here contradicts preservation — `Peel`'s preservation case is
+-- proven (proof/PeelDual.preserve-Peel) and only ever runs on a
+-- WELL-TYPED redex, which this one is not.  What fails is TIGHTNESS: the
+-- REDUCTION RELATION relates a term the exterior refuses to a term it
+-- accepts.
+--
+-- The repair Jeremy proposes — `dualScope n (unlock X ∷ Θ) =
+-- lock (n + X) ∷ dualScope n Θ`, together with an `mw-u` that requires the
+-- slot to be MASKED — is REFUTED in proof/MwUObstruct.agda: it is
+-- incompatible with the scope move (`_⋉_`) and with `⊢retag`.
+
+open import Data.Nat using (ℕ)
+open import Data.List using ([]; _∷_)
+open import Data.Product using (_,_)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+open import strong.Types
+open import strong.Ctx
+open import strong.Conversion
+open import strong.Terms
+open import strong.Reduction
+
+------------------------------------------------------------------------
+-- §1  The exterior: one MASKED binder
+------------------------------------------------------------------------
+
+-- Δᵤ = ↓U (one slot U, a binder at ℕ, CONCEALED: we sit inside a region
+-- that masks it).
+Δᵤ : Ctxᵗ
+Δᵤ = masked (bind `ℕ) ∷ []
+
+-- U is not nameable at the exterior — that is the whole of tightness.
+¬∋tv-Δᵤ : ¬ (Δᵤ ∋tv 0)
+¬∋tv-Δᵤ (_ , ez , ())
+
+-- The boundary's morphism UNMASKS U for its interior (the
+-- crossing-of-crossing shape: an inner region re-exposes what an outer
+-- one concealed).
+Θᵤ : CtxMorph
+Θᵤ = unlock 0 ∷ []
+
+_ : interior Θᵤ Δᵤ ≡ bind `ℕ ∷ []
+_ = refl
+
+------------------------------------------------------------------------
+-- §2  The redex
+------------------------------------------------------------------------
+
+-- V = λx:(U ⇒ ℕ). x
+--   scripts/render_term.sh 'showTmIn 1 V'  =  (λx:(X⇒ℕ). x)
+V : Term
+V = ƛ (` 0 ⇒ `ℕ) ∙ (` 0)
+
+-- the conversion: (U⇒ℕ)⇒(U⇒ℕ) inside  ⇝  (ℕ⇒ℕ)⇒(ℕ⇒ℕ) outside
+cᵤ : Conv
+cᵤ = (unseal 0 ↦ id `ℕ) ↦ (seal 0 ↦ id `ℕ)
+
+-- W = λy:ℕ. (ΛZ. 3)[U] : ℕ ⇒ ℕ — a VALUE, and ILL TYPED at the exterior,
+-- because its type argument NAMES U, which Δᵤ masks.
+--   scripts/render_term.sh 'showTmIn 1 W'  =  (λx:ℕ. (ΛY. 3) [X])
+W : Term
+W = ƛ `ℕ ∙ ((Λ ($ 3)) ·[ `ℕ , ` 0 ])
+
+¬⊢W-ext : ∀ {Γ A} → ¬ (Δᵤ ∣ Γ ⊢ W ⦂ A)
+¬⊢W-ext (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
+
+-- The boundary ALONE is well typed at Δᵤ …
+⊢Vb : Δᵤ ∣ [] ⊢ V ⟪ Θᵤ , cᵤ ⟫ ⦂ ((`ℕ ⇒ `ℕ) ⇒ (`ℕ ⇒ `ℕ))
+⊢Vb = env (mw-u ez mw[])
+          (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
+          (conv-fun (conv-fun (conv-unseal ez) (conv-id base-ℕ))
+                    (conv-fun (conv-seal ez) (conv-id base-ℕ)))
+          (wf-⇒ (wf-⇒ wf-ℕ wf-ℕ) (wf-⇒ wf-ℕ wf-ℕ))
+
+-- … so the redex is ill typed ONLY because of W.
+--   scripts/render_term.sh 'showTmIn 1 Redex'  =
+--     (((λx:(X⇒ℕ). x) ⟪ ↥X , ((unseal X ↦ id ℕ) ↦ (seal X ↦ id ℕ)) ⟫)
+--        · (λx:ℕ. (ΛY. 3) [X]))
+Redex : Term
+Redex = (V ⟪ Θᵤ , cᵤ ⟫) · W
+
+¬⊢Redex : ∀ {A} → ¬ (Δᵤ ∣ [] ⊢ Redex ⦂ A)
+¬⊢Redex (⊢· _ ⊢W) = ¬⊢W-ext ⊢W
+
+------------------------------------------------------------------------
+-- §3  The step, and the WELL-TYPED contractum
+------------------------------------------------------------------------
+
+-- THE DUAL DROPS THE UNLOCK.
+_ : dual Θᵤ ≡ []
+_ = refl
+
+--   scripts/render_term.sh 'showTmIn 1 Contractum'  =
+--     (((λx:(X⇒ℕ). x) · ((λx:ℕ. (ΛY. 3) [X]) ⟪ (unseal X ↦ id ℕ) ⟫))
+--        ⟪ ↥X , (seal X ↦ id ℕ) ⟫)
+-- — note the crossing argument's frame is EMPTY (`dual Θᵤ ≡ []`).
+Contractum : Term
+Contractum = (V · (W ⟪ dual Θᵤ , unseal 0 ↦ id `ℕ ⟫)) ⟪ Θᵤ , seal 0 ↦ id `ℕ ⟫
+
+step-u : Δᵤ ⊢ Redex -→ Contractum
+step-u = Peel V-ƛ V-ƛ
+
+-- W's frame INSIDE the crossing is `bind ℕ ∷ []` — U is nameable there,
+-- because the dual restored nothing.
+_ : interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ bind `ℕ ∷ []
+_ = refl
+
+-- … and so the contractum TYPES.  SCOPE WAS GAINED.
+⊢Contractum : Δᵤ ∣ [] ⊢ Contractum ⦂ (`ℕ ⇒ `ℕ)
+⊢Contractum =
+  env (mw-u ez mw[])
+      (⊢· (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
+          (env mw[]
+               (⊢ƛ wf-ℕ (⊢·[] (⊢Λ ⊢$) (wf-var (bind `ℕ , ez , nameable-b))))
+               (conv-fun (conv-unseal ez) (conv-id base-ℕ))
+               (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ)))
+      (conv-fun (conv-seal ez) (conv-id base-ℕ))
+      (wf-⇒ wf-ℕ wf-ℕ)
+
+------------------------------------------------------------------------
+-- §4  THE POSITIVE CONTROL
+------------------------------------------------------------------------
+
+-- The same shape with a Θ-LOCKED slot behaves correctly: `dual` DOES mint
+-- an `unlock` for a `lock`, so a crossing argument that names a slot the
+-- boundary locked keeps its frame.  Δ has ONE nameable binder Z; Θˡ locks
+-- it; the dual unlocks it again, and the argument's frame inside is Δ with
+-- the bind prefix masked — Z still nameable.
+Δˡ : Ctxᵗ
+Δˡ = bind `ℕ ∷ []
+
+Θˡ : CtxMorph
+Θˡ = lock 0 ∷ []
+
+_ : interior Θˡ Δˡ ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+_ : dual Θˡ ≡ unlock 0 ∷ []
+_ = refl
+
+-- the crossing frame is Δˡ back: Z is nameable, exactly as at the exterior
+_ : interior (dual Θˡ) (interior Θˡ Δˡ) ≡ bind `ℕ ∷ []
+_ = refl

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -1,31 +1,29 @@
 module strong.proof.DualTightness where
 
--- TIGHTNESS OF THE DUAL — Jeremy's test (2026-09-06), MACHINE-CHECKED.
+-- TIGHTNESS OF THE DUAL — Jeremy's test (2026-09-06), MACHINE-CHECKED,
+-- AND THE LEAK CLOSED.
 --
--- THE DEFECT.  `dualScope` (strong.Reduction §2) DROPS the crossed
--- boundary's `unlock` entries.  So a boundary whose morphism UNMASKS an
--- exterior slot hands its crossing argument a frame in which that slot is
--- STILL unmasked: `interior (dual Θ) (interior Θ Δ)` is
--- `map masked (bind prefix) ++ unlockedScope Θ Δ` (proof/PeelDual,
--- `interior-dual`), and `unlockedScope Θ Δ` is STRICTLY MORE NAMEABLE than
--- Δ whenever Θ unlocks a slot Δ masks.  SCOPE IS GAINED THROUGH THE
--- BOUNDARY.
+-- THE DEFECT THAT WAS.  `dualScope` DROPPED the crossed boundary's
+-- `unlock` entries, so a boundary whose morphism UNMASKS an exterior slot
+-- handed its crossing argument a frame in which that slot was STILL
+-- unmasked: `interior (dual Θ) (interior Θ Δ)` was
+-- `map masked (bind prefix) ++ unlockedScope Θ Δ`, STRICTLY MORE
+-- NAMEABLE than Δ whenever Θ unlocked a slot Δ masked.  SCOPE WAS GAINED
+-- THROUGH THE BOUNDARY: the redex below is ILL TYPED at Δᵤ (its argument
+-- W names a slot MASKED at Δᵤ) and its `Peel` contractum was WELL TYPED.
 --
--- The witness below exhibits the gain as a rule-level fact: a redex that
--- is ILL TYPED at Δ (its argument W names a slot MASKED at Δ) whose `Peel`
--- contractum is WELL TYPED.  `Peel` therefore does not preserve the
--- exterior's scope discipline; the crossing is not tight.
+-- THE REPAIR, in two coupled halves (strong.Reduction §2, strong.Terms):
 --
--- Nothing here contradicts preservation — `Peel`'s preservation case is
--- proven (proof/PeelDual.preserve-Peel) and only ever runs on a
--- WELL-TYPED redex, which this one is not.  What fails is TIGHTNESS: the
--- REDUCTION RELATION relates a term the exterior refuses to a term it
--- accepts.
+--   (1) `mw-u` demands `scope Θ Δ ∋lk X` — the slot must be LOCKED.  A
+--       VACUOUS unlock is REFUSED (§5 below); it is the premise the
+--       judgement used to drop.
+--   (2) `dualScope n (unlock X ∷ Θ) = dualScope n Θ ++ lock (n + X) ∷ []`
+--       — the dual RESTORES what Θ unlocked, and the list is REVERSED,
+--       because `scope` applies it HEAD-LAST.
 --
--- The repair Jeremy proposes — `dualScope n (unlock X ∷ Θ) =
--- lock (n + X) ∷ dualScope n Θ`, together with an `mw-u` that requires the
--- slot to be MASKED — is REFUTED in proof/MwUObstruct.agda: it is
--- incompatible with the scope move (`_⋉_`) and with `⊢retag`.
+-- With both, `interior (dual Θ) (interior Θ Δ) ≡ map masked (bind prefix)
+-- ++ Δ` EXACTLY (proof/PeelDual, `interior-dual`), the crossing is
+-- `⊢rename` alone, and the contractum below is REFUSED — §3.
 
 open import Data.Nat using (ℕ)
 open import Data.List using ([]; _∷_)
@@ -51,6 +49,10 @@ open import strong.Reduction
 -- U is not nameable at the exterior — that is the whole of tightness.
 ¬∋tv-Δᵤ : ¬ (Δᵤ ∋tv 0)
 ¬∋tv-Δᵤ (_ , ez , ())
+
+-- … but it IS locked, so an `unlock` may cite it.
+∋lk-Δᵤ : Δᵤ ∋lk 0
+∋lk-Δᵤ = masked (bind `ℕ) , ez , locked nameable-b
 
 -- The boundary's morphism UNMASKS U for its interior (the
 -- crossing-of-crossing shape: an inner region re-exposes what an outer
@@ -85,7 +87,7 @@ W = ƛ `ℕ ∙ ((Λ ($ 3)) ·[ `ℕ , ` 0 ])
 
 -- The boundary ALONE is well typed at Δᵤ …
 ⊢Vb : Δᵤ ∣ [] ⊢ V ⟪ Θᵤ , cᵤ ⟫ ⦂ ((`ℕ ⇒ `ℕ) ⇒ (`ℕ ⇒ `ℕ))
-⊢Vb = env (mw-u ez mw[])
+⊢Vb = env (mw-u ∋lk-Δᵤ mw[])
           (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
           (conv-fun (conv-fun (conv-unseal ez) (conv-id base-ℕ))
                     (conv-fun (conv-seal ez) (conv-id base-ℕ)))
@@ -102,49 +104,41 @@ Redex = (V ⟪ Θᵤ , cᵤ ⟫) · W
 ¬⊢Redex (⊢· _ ⊢W) = ¬⊢W-ext ⊢W
 
 ------------------------------------------------------------------------
--- §3  The step, and the WELL-TYPED contractum
+-- §3  The step, and the contractum — NOW REFUSED
 ------------------------------------------------------------------------
 
--- THE DUAL DROPS THE UNLOCK.
-_ : dual Θᵤ ≡ []
+-- THE DUAL RESTORES THE LOCK.
+_ : dual Θᵤ ≡ lock 0 ∷ []
 _ = refl
 
 --   scripts/render_term.sh 'showTmIn 1 Contractum'  =
---     (((λx:(X⇒ℕ). x) · ((λx:ℕ. (ΛY. 3) [X]) ⟪ (unseal X ↦ id ℕ) ⟫))
+--     (((λx:(X⇒ℕ). x) · ((λx:ℕ. (ΛY. 3) [X]) ⟪ ↧X , (unseal X ↦ id ℕ) ⟫))
 --        ⟪ ↥X , (seal X ↦ id ℕ) ⟫)
--- — note the crossing argument's frame is EMPTY (`dual Θᵤ ≡ []`).
 Contractum : Term
 Contractum = (V · (W ⟪ dual Θᵤ , unseal 0 ↦ id `ℕ ⟫)) ⟪ Θᵤ , seal 0 ↦ id `ℕ ⟫
 
 step-u : Δᵤ ⊢ Redex -→ Contractum
 step-u = Peel V-ƛ V-ƛ
 
--- W's frame INSIDE the crossing is `bind ℕ ∷ []` — U is nameable there,
--- because the dual restored nothing.
-_ : interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ bind `ℕ ∷ []
+-- (†) AT THIS Θ: W's frame INSIDE the crossing IS THE EXTERIOR — U is
+-- masked there, exactly as it is outside.  Nothing is gained.
+_ : interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ
 _ = refl
 
--- … and so the contractum TYPES.  SCOPE WAS GAINED.
-⊢Contractum : Δᵤ ∣ [] ⊢ Contractum ⦂ (`ℕ ⇒ `ℕ)
-⊢Contractum =
-  env (mw-u ez mw[])
-      (⊢· (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
-          (env mw[]
-               (⊢ƛ wf-ℕ (⊢·[] (⊢Λ ⊢$) (wf-var (bind `ℕ , ez , nameable-b))))
-               (conv-fun (conv-unseal ez) (conv-id base-ℕ))
-               (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ)))
-      (conv-fun (conv-seal ez) (conv-id base-ℕ))
-      (wf-⇒ wf-ℕ wf-ℕ)
+-- … and so the contractum DOES NOT TYPE.  The reduction relation no
+-- longer relates a term the exterior refuses to one it accepts.
+¬⊢Contractum : ∀ {A} → ¬ (Δᵤ ∣ [] ⊢ Contractum ⦂ A)
+¬⊢Contractum (env _ (⊢· _ (env _ ⊢W _ _)) _ _) = ¬⊢W-ext ⊢W
 
 ------------------------------------------------------------------------
 -- §4  THE POSITIVE CONTROL
 ------------------------------------------------------------------------
 
--- The same shape with a Θ-LOCKED slot behaves correctly: `dual` DOES mint
--- an `unlock` for a `lock`, so a crossing argument that names a slot the
--- boundary locked keeps its frame.  Δ has ONE nameable binder Z; Θˡ locks
--- it; the dual unlocks it again, and the argument's frame inside is Δ with
--- the bind prefix masked — Z still nameable.
+-- The same shape with a Θ-LOCKED slot still behaves correctly: `dual`
+-- mints an `unlock` for a `lock`, so a crossing argument that names a
+-- slot the boundary locked keeps its frame.  Δ has ONE nameable binder Z;
+-- Θˡ locks it; the dual unlocks it again, and the argument's frame inside
+-- is Δ with the bind prefix masked — Z still nameable.
 Δˡ : Ctxᵗ
 Δˡ = bind `ℕ ∷ []
 
@@ -160,3 +154,30 @@ _ = refl
 -- the crossing frame is Δˡ back: Z is nameable, exactly as at the exterior
 _ : interior (dual Θˡ) (interior Θˡ Δˡ) ≡ bind `ℕ ∷ []
 _ = refl
+
+------------------------------------------------------------------------
+-- §5  THE VACUOUS UNLOCK, REFUSED
+------------------------------------------------------------------------
+
+-- The restoring `lock` of §3 is sound ONLY because the slot really was
+-- masked: `mask ∘ unmask` is the identity at a LOCKED slot and nowhere
+-- else (`mask-unmask`, strong.Ctx §6b).  At a slot the exterior leaves
+-- NAMEABLE, an `unlock` does nothing and its restored `lock` would mask
+-- what the exterior left visible — so the judgement must refuse it, and
+-- does.
+Δᵥ : Ctxᵗ
+Δᵥ = bind `ℕ ∷ []
+
+Θᵥ : CtxMorph
+Θᵥ = unlock 0 ∷ []
+
+_ : interior Θᵥ Δᵥ ≡ Δᵥ            -- the unlock does nothing …
+_ = refl
+
+¬⊢ᵐΘᵥ : ¬ (Δᵥ ⊢ᵐ Θᵥ)              -- … and is REFUSED
+¬⊢ᵐΘᵥ (mw-u (_ , ez , ()) _)
+
+-- A DOUBLE LOCK IS REFUSED TOO — which is what keeps `Locked` one mask
+-- deep, and hence `unmaskEnt` an exact inverse of `masked`.
+¬⊢ᵐ-double-lock : ¬ (Δᵥ ⊢ᵐ (lock 0 ∷ lock 0 ∷ []))
+¬⊢ᵐ-double-lock (mw-l (_ , ez , ()) _)

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -3,36 +3,48 @@ module strong.proof.MoveScope where
 -- THE SCOPE MOVE — its frame algebra, and the TWO preservation cases it
 -- settles (CancelR and IdPush), UNCONDITIONALLY.
 --
--- THE MOVE (strong.Reduction §2b, Jeremy 2026-09-06).  Both rules SWAP
--- the two conversions of a two-layer wrapper, so the INNER boundary
--- stops presenting the abstract name `` ` Y `` and starts presenting
--- Y's REP.  A rep is a type over the PLAIN exterior; inside Θ₂'s
--- LOCKS it need not be nameable at all, and `env`'s last premise then
--- fails — that was the wall (the old proof/PreserveObstruct §4
--- refutation, and the invariant hunt recorded in notes/DECISIONS.md,
--- 2026-09-06).
+-- THE MOVE (strong.Reduction §2b).  Both rules SWAP the two conversions
+-- of a two-layer wrapper, so the INNER boundary stops presenting the
+-- abstract name `` ` Y `` and starts presenting Y's REP.  A rep is a type
+-- over the exterior; inside Θ₂'s LOCKS it need not be nameable at all,
+-- and `env`'s last premise then fails — that was the wall (the old
+-- proof/PreserveObstruct §4 refutation).
 --
 -- So the frames move with the conversions:
 --
 --   (V ⟪ Θ₁ , c ⟫) ⟪ Θ₂ , unseal Y ⟫
---     -→ (V ⟪ Θ₁ ⋉ Θ₂ , c′ ⟫) ⟪ dropLocks Θ₂ , mkId A ⟫
+--     -→ (V ⟪ Θ₁ ⋉ Θ₂ , c′ ⟫) ⟪ rewind Θ₂ , mkId A ⟫
 --
--- `dropLocks Θ₂` keeps Θ₂'s binds and unmasks; `Θ₁ ⋉ Θ₂` appends Θ₂'s
--- whole SCOPE (locks AND unlocks, in order, lifted past Θ₂'s binders) at
--- Θ₁'s TAIL, where `scope` applies it FIRST.
+-- `Θ₁ ⋉ Θ₂` appends Θ₂'s whole SCOPE (locks AND unlocks, in order,
+-- lifted past Θ₂'s binders) at Θ₁'s TAIL, where `scope` applies it
+-- FIRST; and `rewind Θ₂` is Θ₂ with its own scope UNDONE, so what is
+-- left of the outer frame is the BIND PREFIX, in net effect:
 --
--- WHY IT WORKS, in one line: `interior (dropLocks Θ₂) Δ ≡ convCtx Θ₂ Δ`
--- (§3), and the rep the outer `unseal Y` hands back IS the redex's own exterior
--- type lifted, `A ≡ shiftBy (numBinds Θ₂) C` with `Δ ⊢ᵗ C` — so
--- `wf-shiftBy-pushBinds` gives the premise the wall used to deny (§6).
+--   scope    (rewind Θ₂) Δ ≡ Δ                          (given Δ ⊢ᵐ Θ₂)
+--   interior (rewind Θ₂) Δ ≡ pushBinds (repsOf Θ₂) Δ
 --
---   §1  the two lookup transports (`unlockedScope-∋bind`, `pushBinds-∋`,
---       and the two entry-level companions the moved scope's `⊢ᵐ`
---       needs)
---   §2  the list algebra of `scopeOf`/`dropLocks`/`_⋉_`
---   §3  the two type-context identities
---   §4  the FRAME LEMMAS: the value's frame and its conversion context
---       are REFINED by the move, unconditionally
+-- WHY `rewind` AND NOT `bindsOnly` / `dropLocks`.  All three have the
+-- same net effect on the type context, and only `rewind` keeps its own
+-- `⊢ᵐ`:
+--   `dropLocks Θ₂` KEEPS Θ₂'s unlocks, so the moved copy of the same
+--     unlock is then VACUOUS and `mw-u` refuses it;
+--   `bindsOnly Θ₂` DELETES them, and then Θ₂'s own bind reps — read on
+--     `unlockedScope Θ₂′ Δ` (`mw-b`) — lose the unlock they depend on;
+--   `rewind Θ₂` keeps every entry and rewinds it, so every premise is
+--     read exactly where the redex read it.
+--
+-- WHY IT WORKS, in one line: the moved scope re-creates Θ₂'s scope one
+-- bind prefix in (`scope-scopeOf`), so the value's frame is preserved ON
+-- THE NOSE — the two frame lemmas are EQUALITIES, and no `⊢retag`
+-- appears in either case — while the rep the swapped conversion presents
+-- is read OUTSIDE Θ₂'s locks, where `wf-shiftBy-pushBinds` supplies the
+-- premise the wall used to deny.
+--
+--   §1  the lookup transports
+--   §2  the list algebra of `scopeOf`/`rewind`/`_⋉_`
+--   §3  the type-context identities
+--   §4  the FRAME LEMMAS, as EQUALITIES
+--   §4b why the unlocks travel too — the lock-only move, REFUTED
 --   §5  `_⊢ᵐ_` for the two new frames
 --   §6  the two cases
 
@@ -47,9 +59,11 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; ⇑ᵗ)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
-open import strong.TermSubst using (⊢retag)
-open import strong.Reduction using (scopeOf; dropLocks; _⋉_)
+open import strong.Reduction using (scopeOf; rewind; dualScope; _⋉_)
 open import strong.proof.Preserve using (CancelRCase; IdPushCase)
+open import strong.proof.PeelDual
+  using (⊢ᵐ-++; scope-++; unlockedScope-++; scope-dualScope; ⊢ᵐ-dualScope;
+         repsOf-++; repsOf-dualScope)
 
 ------------------------------------------------------------------------
 -- §1  Lookup transports
@@ -75,21 +89,6 @@ pushBinds-∋ : ∀ (As : List Ty) {Δ Y A}
 pushBinds-∋ []       d = d
 pushBinds-∋ (C ∷ As) d = es (pushBinds-∋ As d)
 
--- … and the two ENTRY-level companions, which is all a moved `lock` or
--- `unlock` needs: a lock names a VISIBLE slot, an unlock names a slot
--- that merely EXISTS.
-pushBinds-∋tv : ∀ (As : List Ty) {Δ Y}
-  → Δ ∋tv Y → pushBinds As Δ ∋tv (length As + Y)
-pushBinds-∋tv []       tv           = tv
-pushBinds-∋tv (C ∷ As) tv with pushBinds-∋tv As tv
-... | E , d , v = _ , es d , renᵉ-Nameable v
-
-pushBinds-∋e : ∀ (As : List Ty) {Δ Y E} → Δ ∋e Y , E
-        → ∃[ E′ ] (pushBinds As Δ ∋e (length As + Y) , E′)
-pushBinds-∋e []       d = _ , d
-pushBinds-∋e (C ∷ As) d with pushBinds-∋e As d
-... | E′ , d′ = _ , es d′
-
 ------------------------------------------------------------------------
 -- §2  The list algebra of the move
 ------------------------------------------------------------------------
@@ -110,30 +109,13 @@ repsOf-⋉ (lock X ∷ Θ₁)  Θ₂  = repsOf-⋉ Θ₁ Θ₂
 numBinds-⋉ : (Θ₁ Θ₂ : CtxMorph) → numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁
 numBinds-⋉ Θ₁ Θ₂ = cong length (repsOf-⋉ Θ₁ Θ₂)
 
+-- REWINDING KEEPS THE BINDERS: the inverse scope carries none.
+repsOf-rewind : (Θ : CtxMorph) → repsOf (rewind Θ) ≡ repsOf Θ
+repsOf-rewind Θ rewrite repsOf-++ (dualScope 0 Θ) Θ
+                      | repsOf-dualScope 0 Θ = refl
 
--- DROPPING THE LOCKS KEEPS THE BINDERS.
-repsOf-dropLocks : (Θ : CtxMorph) → repsOf (dropLocks Θ) ≡ repsOf Θ
-repsOf-dropLocks []             = refl
-repsOf-dropLocks (bind A ∷ Θ)   = cong (A ∷_) (repsOf-dropLocks Θ)
-repsOf-dropLocks (unlock X ∷ Θ) = repsOf-dropLocks Θ
-repsOf-dropLocks (lock X ∷ Θ)   = repsOf-dropLocks Θ
-
-numBinds-dropLocks : (Θ : CtxMorph) → numBinds (dropLocks Θ) ≡ numBinds Θ
-numBinds-dropLocks Θ = cong length (repsOf-dropLocks Θ)
-
--- `scope`/`unlockedScope` of an append: the tail applies FIRST.
-scope-++ : (Θ Ψ : CtxMorph) (Δ : Ctxᵗ) → scope (Θ ++ Ψ) Δ ≡ scope Θ (scope Ψ Δ)
-scope-++ []             Ψ Δ = refl
-scope-++ (bind A ∷ Θ)   Ψ Δ = scope-++ Θ Ψ Δ
-scope-++ (unlock X ∷ Θ) Ψ Δ = cong (unmask X) (scope-++ Θ Ψ Δ)
-scope-++ (lock X ∷ Θ)   Ψ Δ = cong (mask X) (scope-++ Θ Ψ Δ)
-
-unlockedScope-++ : (Θ Ψ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (Θ ++ Ψ) Δ ≡ unlockedScope Θ (unlockedScope Ψ Δ)
-unlockedScope-++ []             Ψ Δ = refl
-unlockedScope-++ (bind A ∷ Θ)   Ψ Δ = unlockedScope-++ Θ Ψ Δ
-unlockedScope-++ (unlock X ∷ Θ) Ψ Δ = cong (unmask X) (unlockedScope-++ Θ Ψ Δ)
-unlockedScope-++ (lock X ∷ Θ)   Ψ Δ = unlockedScope-++ Θ Ψ Δ
+numBinds-rewind : (Θ : CtxMorph) → numBinds (rewind Θ) ≡ numBinds Θ
+numBinds-rewind Θ = cong length (repsOf-rewind Θ)
 
 -- THE MOVED SCOPE, APPLIED PAST THE BIND PREFIX, IS THE ORIGINAL SCOPE
 -- APPLIED UNDER IT.  This is the whole point of the index lift `n + X`,
@@ -149,37 +131,31 @@ scope-scopeOf As (lock X ∷ Θ)   Δ =
   trans (cong (mask (length As + X)) (scope-scopeOf As Θ Δ))
         (updateAt-pushBinds masked As X (scope Θ Δ))
 
+unlockedScope-scopeOf : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → unlockedScope (scopeOf (length As) Θ) (pushBinds As Δ)
+      ≡ pushBinds As (unlockedScope Θ Δ)
+unlockedScope-scopeOf As []             Δ = refl
+unlockedScope-scopeOf As (bind A ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
+unlockedScope-scopeOf As (lock X ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
+unlockedScope-scopeOf As (unlock X ∷ Θ) Δ =
+  trans (cong (unmask (length As + X)) (unlockedScope-scopeOf As Θ Δ))
+        (updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ))
+
 ------------------------------------------------------------------------
--- §3  The two type-context identities
+-- §3  The type-context identities
 ------------------------------------------------------------------------
 
-scope-dropLocks : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → scope (dropLocks Θ) Δ ≡ unlockedScope Θ Δ
-scope-dropLocks []             Δ = refl
-scope-dropLocks (bind A ∷ Θ)   Δ = scope-dropLocks Θ Δ
-scope-dropLocks (unlock X ∷ Θ) Δ = cong (unmask X) (scope-dropLocks Θ Δ)
-scope-dropLocks (lock X ∷ Θ)   Δ = scope-dropLocks Θ Δ
+-- THE HEADLINE IDENTITY.  A rewound frame's SCOPE IS THE IDENTITY — this
+-- is `scope-dualScope` (proof/PeelDual) at an empty bind prefix, and it
+-- is where the whole design is paid for: the inverse is exact only
+-- because `mw-u` refuses a vacuous unlock.
+scope-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → scope (rewind Θ) Δ ≡ Δ
+scope-rewind Θ {Δ = Δ} mw =
+  trans (scope-++ (dualScope 0 Θ) Θ Δ) (scope-dualScope [] Θ mw)
 
-unlockedScope-dropLocks : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (dropLocks Θ) Δ ≡ unlockedScope Θ Δ
-unlockedScope-dropLocks []             Δ = refl
-unlockedScope-dropLocks (bind A ∷ Θ)   Δ = unlockedScope-dropLocks Θ Δ
-unlockedScope-dropLocks (unlock X ∷ Θ) Δ =
-  cong (unmask X) (unlockedScope-dropLocks Θ Δ)
-unlockedScope-dropLocks (lock X ∷ Θ)   Δ = unlockedScope-dropLocks Θ Δ
-
--- THE HEADLINE IDENTITY.  Once the locks are gone the frame's INTERIOR
--- IS ITS CONVERSION CONTEXT — so a rep the conversion reads is nameable
--- inside, and nothing has to be assumed about the world.
-interior-dropLocks : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (dropLocks Θ) Δ ≡ convCtx Θ Δ
-interior-dropLocks Θ Δ
-  rewrite repsOf-dropLocks Θ | scope-dropLocks Θ Δ = refl
-
-convCtx-dropLocks : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → convCtx (dropLocks Θ) Δ ≡ convCtx Θ Δ
-convCtx-dropLocks Θ Δ
-  rewrite repsOf-dropLocks Θ | unlockedScope-dropLocks Θ Δ = refl
+interior-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
+  → interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ
+interior-rewind Θ mw rewrite repsOf-rewind Θ | scope-rewind Θ mw = refl
 
 -- The two frames of the contractum, unfolded.
 interior-⋉ : (Θ₁ Θ₂ : CtxMorph) (Ξ : Ctxᵗ)
@@ -197,12 +173,11 @@ convCtx-⋉ Θ₁ Θ₂ Ξ rewrite repsOf-⋉ Θ₁ Θ₂ =
        (unlockedScope-++ Θ₁ (scopeOf (numBinds Θ₂) Θ₂) Ξ)
 
 ------------------------------------------------------------------------
--- §4  THE FRAME LEMMAS
+-- §4  THE FRAME LEMMAS — EQUALITIES
 ------------------------------------------------------------------------
 
--- A rep survives `unlockedScope` and the bind prefix (this is
--- `wf-unlockedScope`'s reason for existing: `scope` would not do —
--- masking is what the wall was about).
+-- A rep survives `unlockedScope` and the bind prefix (`scope` would not
+-- do — masking is what the wall was about).
 wf-unlockedScope : ∀ {Δ A} (Θ : CtxMorph) → Δ ⊢ᵗ A → unlockedScope Θ Δ ⊢ᵗ A
 wf-unlockedScope Θ w = ⊑-wf (Δ⊑unlockedScope Θ _) w
 
@@ -210,51 +185,69 @@ wf-convCtx : ∀ {Δ A} (Θ : CtxMorph)
   → Δ ⊢ᵗ A → convCtx Θ Δ ⊢ᵗ shiftBy (numBinds Θ) A
 wf-convCtx Θ w = wf-shiftBy-pushBinds (repsOf Θ) (wf-unlockedScope Θ w)
 
--- THE VALUE'S FRAME IS REFINED BY THE MOVE.  Everything Θ₂ masked, the
--- moved scope masks again — at the same slots, in the same order, one
--- prefix further in (`scope-scopeOf`) — and the RETAINED unmasks only add
--- nameability (`Δ⊑unlockedScope`).  So `⊢retag` carries the value across.
---
--- THIS IS THE LEMMA THAT DECIDES THE DESIGN.  Moving only the LOCKS
--- would need `scope (locks Θ₂) (unlockedScope Θ₂ Δ) ⊒ scope Θ₂ Δ`, which
--- is FALSE at a same-slot `unlock`/`lock` pair
--- (`Θ₂ = unlock 0 ∷ lock 0 ∷ []` over an already-blocked slot).  Moving
--- the WHOLE scope keeps the order, and then the refinement is
--- unconditional.
-frame-move : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
-  → interior Θ₁ (interior Θ₂ Δ) ⊑ interior (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
-frame-move Θ₁ Θ₂ Δ =
-  subst (λ Ξ → interior Θ₁ (interior Θ₂ Δ) ⊑ Ξ) (sym eq)
-        (⊑-interior Θ₁ (⊑-pushBinds (repsOf Θ₂)
-                          (⊑-scope Θ₂ (Δ⊑unlockedScope Θ₂ Δ))))
-  where
-  eq : interior (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
-         ≡ interior Θ₁ (pushBinds (repsOf Θ₂) (scope Θ₂ (unlockedScope Θ₂ Δ)))
-  eq = trans (interior-⋉ Θ₁ Θ₂ (interior (dropLocks Θ₂) Δ))
-             (cong (λ Ξ → pushBinds (repsOf Θ₁) (scope Θ₁ Ξ))
-                   (trans (cong (scope (scopeOf (numBinds Θ₂) Θ₂))
-                                (interior-dropLocks Θ₂ Δ))
-                          (scope-scopeOf (repsOf Θ₂) Θ₂ (unlockedScope Θ₂ Δ))))
+-- … and the same at a REWOUND frame, whose bind count is Θ's own.
+wf-convCtx-rewind : ∀ {Δ C} (Θ : CtxMorph) → Δ ⊢ᵗ C
+  → convCtx (rewind Θ) Δ ⊢ᵗ shiftBy (numBinds Θ) C
+wf-convCtx-rewind {Δ = Δ} {C = C} Θ w =
+  subst (λ n → convCtx (rewind Θ) Δ ⊢ᵗ shiftBy n C)
+        (numBinds-rewind Θ) (wf-convCtx (rewind Θ) w)
 
--- … and so is its CONVERSION CONTEXT, for the same reason plus the one
--- the move exists for: the inner conversion is now read where Θ₂'s
--- locks are not applied at all.
-convCtx-move : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
-  → convCtx Θ₁ (interior Θ₂ Δ) ⊑ convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
-convCtx-move Θ₁ Θ₂ Δ =
-  subst (λ Ξ → convCtx Θ₁ (interior Θ₂ Δ) ⊑ Ξ) (sym eq)
-        (⊑-convCtx Θ₁ (⊑-trans (interior⊑convCtx Θ₂ Δ)
-                          (Δ⊑unlockedScope (scopeOf (numBinds Θ₂) Θ₂)
-                                           (convCtx Θ₂ Δ))))
-  where
-  eq : convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
-         ≡ convCtx Θ₁ (unlockedScope (scopeOf (numBinds Θ₂) Θ₂)
-                                     (convCtx Θ₂ Δ))
-  eq = trans (convCtx-⋉ Θ₁ Θ₂ (interior (dropLocks Θ₂) Δ))
-             (cong (λ Ξ → pushBinds (repsOf Θ₁)
-                            (unlockedScope Θ₁
-                              (unlockedScope (scopeOf (numBinds Θ₂) Θ₂) Ξ)))
-                   (interior-dropLocks Θ₂ Δ))
+-- THE VALUE'S FRAME IS PRESERVED ON THE NOSE.  Everything Θ₂ masked the
+-- moved scope masks again, at the same slots, in the same order, one
+-- prefix further in (`scope-scopeOf`); and the outer frame contributes
+-- nothing but its binders (`interior-rewind`).  So the value crosses by
+-- `subst` — with `dropLocks` this was a ⊑ and needed `⊢retag` along a
+-- `le-mu` step, which `mw-u` no longer tolerates.
+interior-⋉-rewind : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
+  → interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)
+interior-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mw
+  rewrite interior-rewind Θ₂ mw =
+  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (repsOf Θ₁) (scope Θ₁ Ξ))
+              (scope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+
+-- … and the CONVERSION CONTEXT of the moved frame is the redex's inner
+-- conversion context with Θ₂'s LOCKS lifted off — which is the whole
+-- point of the move (the rep the swapped conversion presents is read
+-- OUTSIDE those locks).
+convCtx-⋉-rewind : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
+  → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ convCtx Θ₁ (convCtx Θ₂ Δ)
+convCtx-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mw
+  rewrite interior-rewind Θ₂ mw =
+  trans (convCtx-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (repsOf Θ₁) (unlockedScope Θ₁ Ξ))
+              (unlockedScope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+
+-- The one place a ⊑ survives, and it carries a TYPE, not a term: the
+-- inner conversion is read where Θ₂'s locks are not applied at all.
+convCtx-move : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
+  → convCtx Θ₁ (interior Θ₂ Δ) ⊑ convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
+convCtx-move Θ₁ Θ₂ {Δ = Δ} mw =
+  subst (λ Ξ → convCtx Θ₁ (interior Θ₂ Δ) ⊑ Ξ)
+        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mw))
+        (⊑-convCtx Θ₁ (interior⊑convCtx Θ₂ Δ))
+
+-- THE BINDER, ON THE CONTRACTUM'S INNER CONVERSION CONTEXT.  The outer
+-- reveal's own lookup — read on `convCtx Θ₂ Δ` — transported past the
+-- moved scope, past Θ₁'s unmasks, and past Θ₁'s binders.
+move-∋ : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} {Y : ℕ} {A : Ty} → Δ ⊢ᵐ Θ₂
+  → convCtx Θ₂ Δ ∋ Y := A
+  → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
+      ∋ (numBinds Θ₁ + Y) := shiftBy (numBinds Θ₁) A
+move-∋ Θ₁ Θ₂ {Δ = Δ} {Y = Y} {A = A} mw d =
+  subst (λ Ξ → Ξ ∋ (numBinds Θ₁ + Y) := shiftBy (numBinds Θ₁) A)
+        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mw))
+        (pushBinds-∋ (repsOf Θ₁) (unlockedScope-∋bind Θ₁ d))
+
+-- The conversion context of the moved inner frame carries every rep its
+-- own exterior carries — it only ADDS unmasks and the bind prefix.
+wf-convCtx-move : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} {A : Ty} → Δ ⊢ᵐ Θ₂
+  → convCtx Θ₂ Δ ⊢ᵗ A
+  → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ⊢ᵗ shiftBy (numBinds Θ₁) A
+wf-convCtx-move Θ₁ Θ₂ {Δ = Δ} {A = A} mw w =
+  subst (λ Ξ → Ξ ⊢ᵗ shiftBy (numBinds Θ₁) A)
+        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mw))
+        (wf-shiftBy-pushBinds (repsOf Θ₁) (wf-unlockedScope Θ₁ w))
 
 ------------------------------------------------------------------------
 -- §4b  WHY THE UNLOCKS TRAVEL TOO — the lock-only move, REFUTED
@@ -270,9 +263,9 @@ locksOnly n (bind A ∷ Θ)   = locksOnly n Θ
 locksOnly n (unlock X ∷ Θ) = locksOnly n Θ
 locksOnly n (lock X ∷ Θ)   = lock (n + X) ∷ locksOnly n Θ
 
--- THE WITNESS.  `Θ✗` masks slot 0 and then re-exposes it — both entries
--- are legal at `Δ✗` (a lock names a VISIBLE slot, an unlock a slot
--- that EXISTS) — so the redex's interior leaves slot 0 nameable.
+-- THE WITNESS.  `Θ✗` masks slot 0 and then re-exposes it — and BOTH
+-- entries are legal under the SEQUENTIAL judgement: the lock names a slot
+-- visible at Δ✗, the unlock names the slot the lock itself just locked.
 Θ✗ : CtxMorph
 Θ✗ = unlock 0 ∷ lock 0 ∷ []
 
@@ -280,122 +273,98 @@ locksOnly n (lock X ∷ Θ)   = lock (n + X) ∷ locksOnly n Θ
 Δ✗ = bind `ℕ ∷ []
 
 ⊢ᵐ-Θ✗ : Δ✗ ⊢ᵐ Θ✗
-⊢ᵐ-Θ✗ = mw-u ez (mw-l (bind `ℕ , ez , nameable-b) mw[])
+⊢ᵐ-Θ✗ = mw-u (masked (bind `ℕ) , ez , locked nameable-b)
+             (mw-l (bind `ℕ , ez , nameable-b) mw[])
 
 _ : interior Θ✗ Δ✗ ≡ bind `ℕ ∷ []
 _ = refl
 
+_ : interior (rewind Θ✗) Δ✗ ≡ bind `ℕ ∷ []
+_ = refl
+
 -- … but the lock-only contractum's interior BLOCKS it.
-_ : scope (locksOnly (numBinds Θ✗) Θ✗) (interior (dropLocks Θ✗) Δ✗)
+_ : scope (locksOnly (numBinds Θ✗) Θ✗) (interior (rewind Θ✗) Δ✗)
       ≡ masked (bind `ℕ) ∷ []
 _ = refl
 
 ¬frame-locksOnly :
   ¬ (interior [] (interior Θ✗ Δ✗)
-       ⊑ interior ([] ++ locksOnly (numBinds Θ✗) Θ✗)
-                  (interior (dropLocks Θ✗) Δ✗))
-¬frame-locksOnly (le∷ () ls)
-
--- THE BINDER, ON THE CONTRACTUM'S INNER CONVERSION CONTEXT.  The outer
--- reveal's own lookup — read on `convCtx Θ₂ Δ`, which the move makes
--- the inner boundary's exterior — transported past the moved scope,
--- past Θ₁'s unmasks, and past Θ₁'s binders.  NO `maskOnly` step: the old
--- proof had to push the lookup INSIDE Θ₂'s locks, and this one never
--- does.
-move-∋ : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} {Y : ℕ} {A : Ty}
-  → convCtx Θ₂ Δ ∋ Y := A
-  → convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
-      ∋ (numBinds Θ₁ + Y) := shiftBy (numBinds Θ₁) A
-move-∋ Θ₁ Θ₂ {Δ = Δ} {Y = Y} {A = A} d =
-  subst (λ Ξ → Ξ ∋ (numBinds Θ₁ + Y) := shiftBy (numBinds Θ₁) A)
-        (sym (convCtx-⋉ Θ₁ Θ₂ (interior (dropLocks Θ₂) Δ)))
-        (pushBinds-∋ (repsOf Θ₁)
-          (unlockedScope-∋bind Θ₁
-            (unlockedScope-∋bind (scopeOf (numBinds Θ₂) Θ₂)
-              (subst (λ Ξ → Ξ ∋ Y := A) (sym (interior-dropLocks Θ₂ Δ)) d))))
-
--- The conversion context of the moved inner frame also carries every
--- rep its own exterior carries — it only ADDS unmasks and the bind
--- prefix.
-wf-convCtx-move : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} {A : Ty}
-  → interior (dropLocks Θ₂) Δ ⊢ᵗ A
-  → convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ) ⊢ᵗ shiftBy (numBinds Θ₁) A
-wf-convCtx-move Θ₁ Θ₂ {Δ = Δ} {A = A} w =
-  subst (λ Ξ → Ξ ⊢ᵗ shiftBy (numBinds Θ₁) A)
-        (sym (convCtx-⋉ Θ₁ Θ₂ (interior (dropLocks Θ₂) Δ)))
-        (wf-shiftBy-pushBinds (repsOf Θ₁)
-          (wf-unlockedScope Θ₁ (wf-unlockedScope (scopeOf (numBinds Θ₂) Θ₂) w)))
+       ≡ interior ([] ++ locksOnly (numBinds Θ✗) Θ✗)
+                  (interior (rewind Θ✗) Δ✗))
+¬frame-locksOnly ()
 
 ------------------------------------------------------------------------
 -- §5  `_⊢ᵐ_` for the two new frames
 ------------------------------------------------------------------------
 
--- Every `Δ ⊢ᵐ Θ` premise is read on the PLAIN exterior (simultaneity),
--- so an append is just a pair …
-⊢ᵐ-++ : ∀ {Δ} (Θ Ψ : CtxMorph) → Δ ⊢ᵐ Θ → Δ ⊢ᵐ Ψ
-  → Δ ⊢ᵐ (Θ ++ Ψ)
-⊢ᵐ-++ []             Ψ mw[]        bΨ = bΨ
-⊢ᵐ-++ (bind A ∷ Θ)   Ψ (mw-b w b)  bΨ = mw-b w (⊢ᵐ-++ Θ Ψ b bΨ)
-⊢ᵐ-++ (lock X ∷ Θ)   Ψ (mw-l tv b) bΨ = mw-l tv (⊢ᵐ-++ Θ Ψ b bΨ)
-⊢ᵐ-++ (unlock X ∷ Θ) Ψ (mw-u d b)  bΨ = mw-u d (⊢ᵐ-++ Θ Ψ b bΨ)
+-- THE REWOUND FRAME.  Θ's own entries are read exactly where they were
+-- (they sit at the TAIL of the append), and the inverse scope on top is
+-- `⊢ᵐ-dualScope` at an empty bind prefix.
+⊢ᵐ-rewind : ∀ (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → Δ ⊢ᵐ rewind Θ
+⊢ᵐ-rewind Θ mw = ⊢ᵐ-++ (dualScope 0 Θ) Θ (⊢ᵐ-dualScope [] Θ mw) mw
 
--- … and dropping entries is free.
-⊢ᵐ-dropLocks : ∀ {Δ} (Θ : CtxMorph) → Δ ⊢ᵐ Θ → Δ ⊢ᵐ dropLocks Θ
-⊢ᵐ-dropLocks []             mw[]        = mw[]
-⊢ᵐ-dropLocks (bind A ∷ Θ)   (mw-b w b)  = mw-b w (⊢ᵐ-dropLocks Θ b)
-⊢ᵐ-dropLocks (lock X ∷ Θ)   (mw-l tv b) = ⊢ᵐ-dropLocks Θ b
-⊢ᵐ-dropLocks (unlock X ∷ Θ) (mw-u d b)  = mw-u d (⊢ᵐ-dropLocks Θ b)
+-- THE MOVED SCOPE IS WELL FORMED WHERE IT LANDS.  Θ₂'s entries are read
+-- one bind prefix in, over `pushBinds As (scope Θ₂ᵢ Δ)` — which is where
+-- Θ₂'s own premises live, lifted (`scope-scopeOf`).  No refinement step,
+-- and no `le-mu`.
+⊢ᵐ-scopeOf : ∀ (As : List Ty) (Θ : CtxMorph) {Δ : Ctxᵗ}
+  → Δ ⊢ᵐ Θ → pushBinds As Δ ⊢ᵐ scopeOf (length As) Θ
+⊢ᵐ-scopeOf As []             mw[]       = mw[]
+⊢ᵐ-scopeOf As (bind A ∷ Θ)   (mw-b _ b) = ⊢ᵐ-scopeOf As Θ b
+⊢ᵐ-scopeOf As (lock X ∷ Θ)   {Δ = Δ} (mw-l tv b) =
+  mw-l (subst (λ Ξ → Ξ ∋tv (length As + X))
+              (sym (scope-scopeOf As Θ Δ)) (pushBinds-∋tv As tv))
+       (⊢ᵐ-scopeOf As Θ b)
+⊢ᵐ-scopeOf As (unlock X ∷ Θ) {Δ = Δ} (mw-u lk b) =
+  mw-u (subst (λ Ξ → Ξ ∋lk (length As + X))
+              (sym (scope-scopeOf As Θ Δ)) (pushBinds-∋lk As lk))
+       (⊢ᵐ-scopeOf As Θ b)
 
--- THE MOVED SCOPE IS WELL FORMED WHERE IT LANDS.  A `lock X` of Θ₂ named
--- a VISIBLE slot of Δ; the move reads it at `numBinds Θ₂ + X` on
--- `convCtx Θ₂ Δ`, where Θ₂'s own locks are NOT applied — so the slot is
--- still visible, which is precisely the nameability the move buys.
-⊢ᵐ-scopeOf : ∀ (As : List Ty) (Θ : CtxMorph) {Δ Ξ : Ctxᵗ}
-  → Δ ⊑ Ξ → Δ ⊢ᵐ Θ → pushBinds As Ξ ⊢ᵐ scopeOf (length As) Θ
-⊢ᵐ-scopeOf As []             ls mw[]        = mw[]
-⊢ᵐ-scopeOf As (bind A ∷ Θ)   ls (mw-b w b)  = ⊢ᵐ-scopeOf As Θ ls b
-⊢ᵐ-scopeOf As (lock X ∷ Θ)   ls (mw-l tv b) =
-  mw-l (pushBinds-∋tv As (⊑-tv ls tv)) (⊢ᵐ-scopeOf As Θ ls b)
-⊢ᵐ-scopeOf As (unlock X ∷ Θ) ls (mw-u d b)  with ⊑-∋e ls d
-... | E′ , d′ , _ with pushBinds-∋e As d′
-...   | E″ , d″ = mw-u d″ (⊢ᵐ-scopeOf As Θ ls b)
-
+-- THE MERGED FRAME.  `⊢ᵐ-++` splits it at the move: Θ₂'s scope is read
+-- over `pushBinds (repsOf Θ₂) Δ`, and Θ₁ is then read over exactly
+-- `interior Θ₂ Δ` — its own exterior in the redex.  THIS is what the
+-- sequential judgement buys: under a SIMULTANEOUS `mw-b`, Θ₁'s reps
+-- would have to be well formed on the plain `pushBinds (repsOf Θ₂) Δ`,
+-- and a rep naming a slot Θ₂ UNLOCKED is not.
 ⊢ᵐ-⋉ : ∀ (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ}
-  → interior Θ₂ Δ ⊢ᵐ Θ₁ → Δ ⊢ᵐ Θ₂
-  → interior (dropLocks Θ₂) Δ ⊢ᵐ (Θ₁ ⋉ Θ₂)
-⊢ᵐ-⋉ Θ₁ Θ₂ {Δ = Δ} b₁ b₂ =
-  subst (λ Ξ → Ξ ⊢ᵐ (Θ₁ ⋉ Θ₂)) (sym (interior-dropLocks Θ₂ Δ))
+  → Δ ⊢ᵐ Θ₂ → interior Θ₂ Δ ⊢ᵐ Θ₁
+  → interior (rewind Θ₂) Δ ⊢ᵐ (Θ₁ ⋉ Θ₂)
+⊢ᵐ-⋉ Θ₁ Θ₂ {Δ = Δ} b₂ b₁ =
+  subst (λ Ξ → Ξ ⊢ᵐ (Θ₁ ⋉ Θ₂)) (sym (interior-rewind Θ₂ b₂))
         (⊢ᵐ-++ Θ₁ (scopeOf (numBinds Θ₂) Θ₂)
-                (⊢ᵐ-⊑ (interior⊑convCtx Θ₂ Δ) b₁)
-                (⊢ᵐ-scopeOf (repsOf Θ₂) Θ₂ (Δ⊑unlockedScope Θ₂ Δ) b₂))
+                (subst (λ Ξ → Ξ ⊢ᵐ Θ₁)
+                       (sym (scope-scopeOf (repsOf Θ₂) Θ₂ Δ)) b₁)
+                (⊢ᵐ-scopeOf (repsOf Θ₂) Θ₂ b₂))
 
 ------------------------------------------------------------------------
 -- §6  THE TWO CASES
 ------------------------------------------------------------------------
 
 -- What both share: the outer boundary of the contractum.  Its frame is
--- `dropLocks Θ₂`, its conversion the identity at the rep, and its two
+-- `rewind Θ₂`, its conversion the identity at the rep, and its two
 -- well-formedness obligations are the redex's own exterior type lifted.
 module _ {Δ : Ctxᵗ} (Θ₂ : CtxMorph) {A C : Ty}
-         (wE : Δ ⊢ᵗ C) (eqAC : A ≡ shiftBy (numBinds Θ₂) C) where
+         (mw₂ : Δ ⊢ᵐ Θ₂) (wE : Δ ⊢ᵗ C)
+         (eqAC : A ≡ shiftBy (numBinds Θ₂) C) where
 
-  -- THE PREMISE THE WALL USED TO DENY.  `interior (dropLocks Θ₂) Δ` IS
-  -- `convCtx Θ₂ Δ` (§3), and A is C lifted past Θ₂'s binders — so this is
-  -- `wf-shiftBy-pushBinds` at Θ₂'s reps, and nothing else.
-  moved-scoped : interior (dropLocks Θ₂) Δ ⊢ᵗ A
-  moved-scoped rewrite eqAC | interior-dropLocks Θ₂ Δ = wf-convCtx Θ₂ wE
+  -- THE PREMISE THE WALL USED TO DENY.  `interior (rewind Θ₂) Δ` IS the
+  -- bind prefix over the plain exterior (§3), and A is C lifted past
+  -- Θ₂'s binders — so this is `wf-shiftBy-pushBinds`, and nothing else.
+  moved-scoped : interior (rewind Θ₂) Δ ⊢ᵗ A
+  moved-scoped rewrite eqAC | interior-rewind Θ₂ mw₂ =
+    wf-shiftBy-pushBinds (repsOf Θ₂) wE
 
-  moved-conv : convCtx (dropLocks Θ₂) Δ
-                 ⊢ mkId A ∶ A ⇝ shiftBy (numBinds (dropLocks Θ₂)) C
-  moved-conv rewrite numBinds-dropLocks Θ₂ | convCtx-dropLocks Θ₂ Δ | eqAC =
-    mkId-⊢ (wf-convCtx Θ₂ wE)
+  moved-conv : convCtx (rewind Θ₂) Δ
+                 ⊢ mkId A ∶ A ⇝ shiftBy (numBinds (rewind Θ₂)) C
+  moved-conv rewrite numBinds-rewind Θ₂ | eqAC =
+    mkId-⊢ (wf-convCtx-rewind Θ₂ wE)
 
 -- ── IDPUSH ─────────────────────────────────────────────────────────────
 -- The conversions swap and the scope moves.  Four moves, one per
 -- premise of the contractum's inner `env`:
 --
 --   FRAME       `Θ₁ ⋉ Θ₂`, well formed by §5.
---   INTERIOR    `V`, retagged along `frame-move` (§4).
+--   INTERIOR    `V`, transported by `subst` along the EQUALITY of §4.
 --   CONVERSION  `unseal X` at the binder `move-∋` transports (§4); the
 --               two names are forced equal by the inner identity
 --               conversion's own TARGET type, `X ≡ numBinds Θ₁ + Y`
@@ -405,9 +374,9 @@ preserve-IdPush : IdPushCase
 preserve-IdPush {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = Y}
                 {A = A} {C = C} v d
                 (env mw₂ (env mw₁ ⊢V ⊢cᵢ wE′) (conv-unseal dₒ) wE) =
-  env (⊢ᵐ-dropLocks Θ₂ mw₂)
-      (env (⊢ᵐ-⋉ Θ₁ Θ₂ mw₁ mw₂) ⊢V′ convᵢ (moved-scoped Θ₂ wE eqAC))
-      (moved-conv Θ₂ wE eqAC)
+  env (⊢ᵐ-rewind Θ₂ mw₂)
+      (env (⊢ᵐ-⋉ Θ₁ Θ₂ mw₂ mw₁) ⊢V′ convᵢ (moved-scoped Θ₂ mw₂ wE eqAC))
+      (moved-conv Θ₂ mw₂ wE eqAC)
       wE
   where
   -- The outer `unseal Y`'s rep is `shiftBy (numBinds Θ₂) C`; it IS A.
@@ -419,18 +388,19 @@ preserve-IdPush {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = Y
   eqX : numBinds Θ₁ + Y ≡ X
   eqX = tvar-inj (trans (sym (shiftBy-var (numBinds Θ₁) Y)) (conv-idv-tgt ⊢cᵢ))
 
-  ⊢V′ : interior (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ) ∣ [] ⊢ V ⦂ ` X
-  ⊢V′ = ⊢retag (frame-move Θ₁ Θ₂ Δ)
-          (subst (λ T → interior Θ₁ (interior Θ₂ Δ) ∣ [] ⊢ V ⦂ T)
-                 (conv-idv-src ⊢cᵢ) ⊢V)
+  ⊢V′ : interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ∣ [] ⊢ V ⦂ ` X
+  ⊢V′ = subst (λ Ξ → Ξ ∣ [] ⊢ V ⦂ ` X)
+              (sym (interior-⋉-rewind Θ₁ Θ₂ mw₂))
+              (subst (λ T → interior Θ₁ (interior Θ₂ Δ) ∣ [] ⊢ V ⦂ T)
+                     (conv-idv-src ⊢cᵢ) ⊢V)
 
-  dX : convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
+  dX : convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
          ∋ X := shiftBy (numBinds Θ₁) A
-  dX = subst (λ Z → convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
+  dX = subst (λ Z → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
                       ∋ Z := shiftBy (numBinds Θ₁) A)
-             eqX (move-∋ Θ₁ Θ₂ d)
+             eqX (move-∋ Θ₁ Θ₂ mw₂ d)
 
-  convᵢ : convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
+  convᵢ : convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
             ⊢ unseal X ∶ ` X ⇝ shiftBy (numBinds (Θ₁ ⋉ Θ₂)) A
   convᵢ rewrite numBinds-⋉ Θ₁ Θ₂ = conv-unseal dX
 
@@ -439,16 +409,14 @@ preserve-IdPush {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = Y
 -- swapped.  THE TYPE EQUATION — `V`'s interior type IS the new inner
 -- conversion's SOURCE — is the one piece of content: `seal X`'s source
 -- is X's rep, and X's rep on the contractum's inner CONVERSION CONTEXT
--- is `shiftBy (numBinds Θ₁) A`, so `∋:=-det` closes it.  The old proof
--- had to run that lookup INSIDE Θ₂'s locks (whence `ScopedAtUnseal`);
--- this one runs it on the conversion context.
+-- is `shiftBy (numBinds Θ₁) A`, so `∋:=-det` closes it.
 preserve-CancelR : CancelRCase
 preserve-CancelR {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = Y}
                  {A = A} {C = C} v d
                  (env mw₂ (env mw₁ ⊢V ⊢c₁ wE′) (conv-unseal dₒ) wE) =
-  env (⊢ᵐ-dropLocks Θ₂ mw₂)
-      (env (⊢ᵐ-⋉ Θ₁ Θ₂ mw₁ mw₂) ⊢V′ convᵢ (moved-scoped Θ₂ wE eqAC))
-      (moved-conv Θ₂ wE eqAC)
+  env (⊢ᵐ-rewind Θ₂ mw₂)
+      (env (⊢ᵐ-⋉ Θ₁ Θ₂ mw₂ mw₁) ⊢V′ convᵢ (moved-scoped Θ₂ mw₂ wE eqAC))
+      (moved-conv Θ₂ mw₂ wE eqAC)
       wE
   where
   eqAC : A ≡ shiftBy (numBinds Θ₂) C
@@ -457,25 +425,27 @@ preserve-CancelR {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = 
   eqX : numBinds Θ₁ + Y ≡ X
   eqX = tvar-inj (trans (sym (shiftBy-var (numBinds Θ₁) Y)) (conv-seal-tgt ⊢c₁))
 
-  dX : convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
+  dX : convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
          ∋ X := shiftBy (numBinds Θ₁) A
-  dX = subst (λ Z → convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
+  dX = subst (λ Z → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
                       ∋ Z := shiftBy (numBinds Θ₁) A)
-             eqX (move-∋ Θ₁ Θ₂ d)
+             eqX (move-∋ Θ₁ Θ₂ mw₂ d)
 
   -- `seal X`'s source, read where the move puts it.
   eqV : _ ≡ shiftBy (numBinds Θ₁) A
-  eqV = ∋:=-det (⊑-kn (convCtx-move Θ₁ Θ₂ Δ)
+  eqV = ∋:=-det (⊑-kn (convCtx-move Θ₁ Θ₂ mw₂)
                       (seal-source-is-rep ⊢c₁))
                 dX
 
-  ⊢V′ : interior (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ) ∣ []
+  ⊢V′ : interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ∣ []
           ⊢ V ⦂ shiftBy (numBinds Θ₁) A
-  ⊢V′ = ⊢retag (frame-move Θ₁ Θ₂ Δ)
-          (subst (λ T → interior Θ₁ (interior Θ₂ Δ) ∣ [] ⊢ V ⦂ T) eqV ⊢V)
+  ⊢V′ = subst (λ Ξ → Ξ ∣ [] ⊢ V ⦂ shiftBy (numBinds Θ₁) A)
+              (sym (interior-⋉-rewind Θ₁ Θ₂ mw₂))
+              (subst (λ T → interior Θ₁ (interior Θ₂ Δ) ∣ [] ⊢ V ⦂ T) eqV ⊢V)
 
-  convᵢ : convCtx (Θ₁ ⋉ Θ₂) (interior (dropLocks Θ₂) Δ)
+  convᵢ : convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
             ⊢ mkId (shiftBy (numBinds Θ₁) A)
             ∶ shiftBy (numBinds Θ₁) A ⇝ shiftBy (numBinds (Θ₁ ⋉ Θ₂)) A
   convᵢ rewrite numBinds-⋉ Θ₁ Θ₂ =
-    mkId-⊢ (wf-convCtx-move Θ₁ Θ₂ (moved-scoped Θ₂ wE eqAC))
+    mkId-⊢ (wf-convCtx-move Θ₁ Θ₂ mw₂
+              (subst (λ T → convCtx Θ₂ Δ ⊢ᵗ T) (sym eqAC) (wf-convCtx Θ₂ wE)))

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -1,0 +1,430 @@
+module strong.proof.MwUObstruct where
+
+-- THE PROPOSED TIGHTNESS REPAIR, REFUTED — with witnesses.
+--
+-- proof/DualTightness.agda machine-checks the defect: `dualScope` DROPS
+-- the crossed boundary's `unlock` entries, so `Peel` GAINS SCOPE.  The
+-- repair on the table (Jeremy, 2026-09-06) is three coupled changes:
+--
+--   (1) `mw-u` requires the slot to be MASKED —
+--       `mw-u : Δ ∋e X , masked E → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)`
+--       (no vacuous unlocks);
+--   (2) `dualScope n (unlock X ∷ Θ) = lock (n + X) ∷ dualScope n Θ`
+--       (restore what Θ unlocked);
+--   (3) the outer boundary of CancelR/IdPush becomes BINDS-ONLY
+--       (`bindsOnly Θ₂` in place of `dropLocks Θ₂`), so the moved scope
+--       duplicates no unlock.
+--
+-- THIS MODULE ESTABLISHES:
+--
+--   §1  (2) FORCES (1).  With (2) alone, `Peel` OVER-masks at a vacuous
+--       unlock and `preserve-Peel` is FALSE — witness: a WELL-TYPED redex
+--       whose contractum is ill typed.
+--   §2  (1) REFUTES `⊢ᵐ-⊑`, hence `⊢retag` (strong.TermSubst) — the
+--       transport `Δ ⊑ Δ′` cannot carry an `unlock` across a refinement
+--       that UNMASKS the slot it names.
+--   §3  (1) REFUTES THE SCOPE MOVE, at `Θ₂` locking what `Θ₁` unlocks:
+--       a WELL-TYPED IdPush redex whose contractum's merged frame
+--       `Θ₁ ⋉ Θ₂ = unlock 1 ∷ lock 1 ∷ []` is read over a type context
+--       where slot 1 is a PLAIN BINDER.  Both candidate outer frames
+--       (`dropLocks Θ₂` and `bindsOnly Θ₂`) fail on it.
+--   §4  … and the MIRROR, at `Θ₂` unlocking what `Θ₁` locks.
+--   §5  IF `⊢ᵐ` were made SEQUENTIAL (the only reading of §3/§4 that
+--       survives), THEN `dualScope` must also REVERSE its list: the
+--       same-order dual is not an inverse.
+--   §6  … and `bindsOnly`'s own `⊢ᵐ` then fails, because a `bind`'s rep is
+--       read on the PLAIN exterior (simultaneity) while the move needs it
+--       read past the frame's own unlocks.
+--
+-- THE SHAPE OF THE OBSTRUCTION, in one line: `⊢ᵐ` is SIMULTANEOUS (every
+-- entry's premise is read on the PLAIN exterior Δ) while `scope` is
+-- SEQUENTIAL (the list is applied head-last).  Under (1) `mw-l` and `mw-u`
+-- become EXACT COMPLEMENTS — a lock names a NAMEABLE slot, an unlock a
+-- MASKED one — so no simultaneous `⊢ᵐ` can hold of a list that both locks
+-- and unlocks the same slot.  The scope move `_⋉_` builds exactly such
+-- lists.
+
+open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.List using (List; []; _∷_; _++_; length)
+open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
+open import Data.Empty using (⊥)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong; trans)
+
+open import strong.Types
+open import strong.Ctx
+open import strong.Conversion
+open import strong.Terms
+open import strong.TermSubst using (wkᴹ)
+open import strong.Reduction
+open import strong.proof.DualTightness using (Δᵤ; Θᵤ)
+open import strong.proof.MoveScope using (interior-⋉; convCtx-⋉; scope-scopeOf)
+
+------------------------------------------------------------------------
+-- §0  The three proposed definitions, LOCALLY
+------------------------------------------------------------------------
+
+-- (2): the dual RESTORES what Θ unlocked, keeping `lock ↦ unlock`.
+dualScope′ : ℕ → CtxMorph → CtxMorph
+dualScope′ n []             = []
+dualScope′ n (bind A ∷ Θ)   = dualScope′ n Θ
+dualScope′ n (unlock X ∷ Θ) = lock   (n + X) ∷ dualScope′ n Θ
+dualScope′ n (lock X ∷ Θ)   = unlock (n + X) ∷ dualScope′ n Θ
+
+dual′ : CtxMorph → CtxMorph
+dual′ Θ = hideBinds (numBinds Θ) ++ dualScope′ (numBinds Θ) Θ
+
+-- (3): the outer boundary keeps ONLY the binds.
+bindsOnly : CtxMorph → CtxMorph
+bindsOnly []             = []
+bindsOnly (bind A ∷ Θ)   = bind A ∷ bindsOnly Θ
+bindsOnly (unlock X ∷ Θ) = bindsOnly Θ
+bindsOnly (lock X ∷ Θ)   = bindsOnly Θ
+
+------------------------------------------------------------------------
+-- §1  (2) FORCES (1):  the vacuous unlock, and preserve-Peel REFUTED
+------------------------------------------------------------------------
+
+-- ON JEREMY'S WITNESS (proof/DualTightness) THE REPAIR WORKS.  Θᵤ unlocks
+-- a slot Δᵤ MASKS, so the restored lock lands where it should and the
+-- crossing frame is Δᵤ EXACTLY — the contractum's argument is refused,
+-- which is tightness.
+_ : dual′ Θᵤ ≡ lock 0 ∷ []
+_ = refl
+
+_ : interior (dual′ Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ
+_ = refl
+
+-- BUT `mw-u` AS IT STANDS PERMITS A VACUOUS UNLOCK — a slot that is NOT
+-- masked — and there the restored lock MASKS A SLOT THE EXTERIOR LEFT
+-- NAMEABLE.  Δᵥ has one PLAIN binder; Θᵥ unlocks it for nothing.
+Δᵥ : Ctxᵗ
+Δᵥ = bind `ℕ ∷ []
+
+Θᵥ : CtxMorph
+Θᵥ = unlock 0 ∷ []
+
+⊢ᵐΘᵥ : Δᵥ ⊢ᵐ Θᵥ                  -- legal today: an unlock claims nothing
+⊢ᵐΘᵥ = mw-u ez mw[]
+
+_ : interior Θᵥ Δᵥ ≡ Δᵥ          -- and does nothing
+_ = refl
+
+-- V₀ = λx:ℕ. 7,  crossed at  (ℕ⇒ℕ) inside  ⇝  (Z⇒ℕ) outside
+V₀ : Term
+V₀ = ƛ `ℕ ∙ ($ 7)
+
+c₀ : Conv
+c₀ = unseal 0 ↦ id `ℕ
+
+-- W₀ = 3 sealed at Z's binder: a VALUE of type ` 0 at Δᵥ
+W₀ : Term
+W₀ = ($ 3) ⟪ [] , seal 0 ⟫
+
+⊢W₀ : Δᵥ ∣ [] ⊢ W₀ ⦂ ` 0
+⊢W₀ = env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
+
+Redexᵥ : Term
+Redexᵥ = (V₀ ⟪ Θᵥ , c₀ ⟫) · W₀
+
+-- THE REDEX IS WELL TYPED.
+⊢Redexᵥ : Δᵥ ∣ [] ⊢ Redexᵥ ⦂ `ℕ
+⊢Redexᵥ =
+  ⊢· (env ⊢ᵐΘᵥ (⊢ƛ wf-ℕ ⊢$)
+          (conv-fun (conv-unseal ez) (conv-id base-ℕ))
+          (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ))
+     ⊢W₀
+
+stepᵥ : Δᵥ ⊢ Redexᵥ -→ (V₀ · (wkᴹ 0 W₀ ⟪ dual Θᵥ , unseal 0 ⟫)) ⟪ Θᵥ , id `ℕ ⟫
+stepᵥ = Peel V-ƛ (V-⟪⟫ V-$ I-seal)
+
+-- UNDER (2) THE CROSSING FRAME MASKS Z, WHICH Δᵥ DID NOT.
+_ : dual′ Θᵥ ≡ lock 0 ∷ []
+_ = refl
+
+_ : interior (dual′ Θᵥ) (interior Θᵥ Δᵥ) ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+-- … so the crossing argument does not retype, and the contractum is ILL
+-- TYPED.  `preserve-Peel` is FALSE under (2) alone: hence (1).
+¬⊢W₀-inside : ∀ {A} → ¬ (masked (bind `ℕ) ∷ [] ∣ [] ⊢ W₀ ⦂ A)
+¬⊢W₀-inside (env _ _ _ (wf-var (_ , ez , ())))
+
+------------------------------------------------------------------------
+-- §2  (1) REFUTES `⊢ᵐ-⊑`, HENCE `⊢retag`
+------------------------------------------------------------------------
+
+-- `⊢retag : Δ ⊑ Δ′ → Δ ∣ Γ ⊢ M ⦂ A → Δ′ ∣ Γ ⊢ M ⦂ A` (strong.TermSubst)
+-- runs `⊢ᵐ-⊑` on every boundary it crosses.  Under (1) an `unlock X`
+-- CLAIMS that X is masked, and `le-mu` — the ⊑ᵉ clause that RE-EXPOSES a
+-- concealed slot (Cancel's own refinement) — destroys the claim.
+Δₘ Δₙ : Ctxᵗ
+Δₘ = masked (bind `ℕ) ∷ []
+Δₙ = bind `ℕ ∷ []
+
+refine-mn : Δₘ ⊑ Δₙ
+refine-mn = le∷ (le-mu le-bb nameable-b) le[]
+
+M₂ : Term
+M₂ = ($ 3) ⟪ unlock 0 ∷ [] , id `ℕ ⟫
+
+⊢M₂ : Δₘ ∣ [] ⊢ M₂ ⦂ `ℕ
+⊢M₂ = env (mw-u ez mw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+
+-- but slot 0 of Δₙ is a PLAIN binder, so `mw-u` under (1) has no premise
+-- to offer, and `Δₙ ⊢ᵐ (unlock 0 ∷ [])` is not derivable.
+no-masked-Δₙ : ∀ {E} → ¬ (Δₙ ∋e 0 , masked E)
+no-masked-Δₙ ()
+
+------------------------------------------------------------------------
+-- §3  (1) REFUTES THE SCOPE MOVE — Θ₂ LOCKS WHAT Θ₁ UNLOCKS
+------------------------------------------------------------------------
+
+-- Δᵢ: slot 0 a binder at ℕ, slot 1 a binder at 𝔹.
+Δᵢ : Ctxᵗ
+Δᵢ = bind `ℕ ∷ bind `𝔹 ∷ []
+
+Θ₂ᵢ : CtxMorph          -- the OUTER frame LOCKS slot 1
+Θ₂ᵢ = lock 1 ∷ []
+
+Θ₁ᵢ : CtxMorph          -- the INNER frame UNLOCKS it again
+Θ₁ᵢ = unlock 1 ∷ []
+
+_ : interior Θ₂ᵢ Δᵢ ≡ bind `ℕ ∷ masked (bind `𝔹) ∷ []
+_ = refl
+
+-- LEGAL UNDER (1): the inner unlock names a slot its OWN exterior masks.
+⊢ᵐΘ₁ᵢ : interior Θ₂ᵢ Δᵢ ⊢ᵐ Θ₁ᵢ
+⊢ᵐΘ₁ᵢ = mw-u (es ez) mw[]
+
+_ : interior Θ₁ᵢ (interior Θ₂ᵢ Δᵢ) ≡ bind `ℕ ∷ bind `𝔹 ∷ []
+_ = refl
+
+-- a value of type ` 0: a numeral sealed at slot 0's binder
+Vᵢ : Term
+Vᵢ = ($ 5) ⟪ [] , seal 0 ⟫
+
+Redexᵢ : Term
+Redexᵢ = (Vᵢ ⟪ Θ₁ᵢ , id (` 0) ⟫) ⟪ Θ₂ᵢ , unseal 0 ⟫
+
+-- THE REDEX IS WELL TYPED.
+⊢Redexᵢ : Δᵢ ∣ [] ⊢ Redexᵢ ⦂ `ℕ
+⊢Redexᵢ =
+  env (mw-l (bind `𝔹 , es ez , nameable-b) mw[])
+      (env ⊢ᵐΘ₁ᵢ
+           (env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b)))
+           (conv-idv (bind `ℕ , ez , nameable-b))
+           (wf-var (bind `ℕ , ez , nameable-b)))
+      (conv-unseal ez)
+      wf-ℕ
+
+stepᵢ : Δᵢ ⊢ Redexᵢ -→ (Vᵢ ⟪ Θ₁ᵢ ⋉ Θ₂ᵢ , unseal 0 ⟫) ⟪ dropLocks Θ₂ᵢ , mkId `ℕ ⟫
+stepᵢ = IdPush (V-⟪⟫ V-$ I-seal) ez
+
+-- THE MERGED FRAME both unlocks and locks slot 1 …
+_ : _≡_ {A = CtxMorph} (Θ₁ᵢ ⋉ Θ₂ᵢ) (unlock 1 ∷ lock 1 ∷ [])
+_ = refl
+
+-- … and BOTH candidate outer frames leave it read over Δᵢ, where slot 1
+-- is a PLAIN binder.  (Θ₂ᵢ has neither binds nor unlocks, so `dropLocks`
+-- and `bindsOnly` agree here.)
+_ : _≡_ {A = CtxMorph} (dropLocks Θ₂ᵢ) []
+_ = refl
+
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₂ᵢ) []
+_ = refl
+
+_ : interior (dropLocks Θ₂ᵢ) Δᵢ ≡ Δᵢ
+_ = refl
+
+-- THE OBSTRUCTION: under (1) `Δᵢ ⊢ᵐ (unlock 1 ∷ lock 1 ∷ [])` has no
+-- derivation, because `mw-u` would need slot 1 of Δᵢ to be MASKED.
+no-masked-Δᵢ : ∀ {E} → ¬ (Δᵢ ∋e 1 , masked E)
+no-masked-Δᵢ d with ∋e-det d (es ez)
+... | ()
+
+-- (The frame ITSELF is right: the merged frame's interior is the redex's
+-- interior on the nose.  It is only `⊢ᵐ`, read simultaneously, that
+-- refuses it.)
+_ : interior (Θ₁ᵢ ⋉ Θ₂ᵢ) (interior (dropLocks Θ₂ᵢ) Δᵢ)
+      ≡ interior Θ₁ᵢ (interior Θ₂ᵢ Δᵢ)
+_ = refl
+
+------------------------------------------------------------------------
+-- §3b  WHAT (3) *DOES* BUY — the frame lemmas become EQUALITIES
+------------------------------------------------------------------------
+
+-- The positive half of the proposal, proven in general and independent of
+-- `_⊢ᵐ_`: with a BINDS-ONLY outer frame the move is EXACT.  `frame-move`
+-- (proof/MoveScope) is a ⊑ only because `dropLocks` retains Θ₂'s unlocks
+-- and so applies them twice; drop them and the two frames coincide on the
+-- nose, and the value crosses by `subst` with no `⊢retag` at all.
+repsOf-bindsOnly : (Θ : CtxMorph) → repsOf (bindsOnly Θ) ≡ repsOf Θ
+repsOf-bindsOnly []             = refl
+repsOf-bindsOnly (bind A ∷ Θ)   = cong (A ∷_) (repsOf-bindsOnly Θ)
+repsOf-bindsOnly (unlock X ∷ Θ) = repsOf-bindsOnly Θ
+repsOf-bindsOnly (lock X ∷ Θ)   = repsOf-bindsOnly Θ
+
+scope-bindsOnly : (Θ : CtxMorph) (Δ : Ctxᵗ) → scope (bindsOnly Θ) Δ ≡ Δ
+scope-bindsOnly []             Δ = refl
+scope-bindsOnly (bind A ∷ Θ)   Δ = scope-bindsOnly Θ Δ
+scope-bindsOnly (unlock X ∷ Θ) Δ = scope-bindsOnly Θ Δ
+scope-bindsOnly (lock X ∷ Θ)   Δ = scope-bindsOnly Θ Δ
+
+interior-bindsOnly : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (bindsOnly Θ) Δ ≡ pushBinds (repsOf Θ) Δ
+interior-bindsOnly Θ Δ
+  rewrite repsOf-bindsOnly Θ | scope-bindsOnly Θ Δ = refl
+
+-- (b), FIRST HALF: the value's frame is preserved EXACTLY.
+interior-⋉-bindsOnly : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (Θ₁ ⋉ Θ₂) (interior (bindsOnly Θ₂) Δ)
+      ≡ interior Θ₁ (interior Θ₂ Δ)
+interior-⋉-bindsOnly Θ₁ Θ₂ Δ
+  rewrite interior-bindsOnly Θ₂ Δ =
+  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (repsOf Θ₁) (scope Θ₁ Ξ))
+              (scope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+
+-- (b), SECOND HALF: the conversion context of the moved frame is the
+-- redex's own inner conversion context with Θ₂'s LOCKS lifted off — which
+-- is the whole point of the move (the rep the swapped conversion presents
+-- is read OUTSIDE those locks).
+unlockedScope-scopeOf : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → unlockedScope (scopeOf (length As) Θ) (pushBinds As Δ)
+      ≡ pushBinds As (unlockedScope Θ Δ)
+unlockedScope-scopeOf As []             Δ = refl
+unlockedScope-scopeOf As (bind A ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
+unlockedScope-scopeOf As (lock X ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
+unlockedScope-scopeOf As (unlock X ∷ Θ) Δ =
+  trans (cong (unmask (length As + X)) (unlockedScope-scopeOf As Θ Δ))
+        (updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ))
+
+convCtx-⋉-bindsOnly : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
+  → convCtx (Θ₁ ⋉ Θ₂) (interior (bindsOnly Θ₂) Δ)
+      ≡ convCtx Θ₁ (convCtx Θ₂ Δ)
+convCtx-⋉-bindsOnly Θ₁ Θ₂ Δ
+  rewrite interior-bindsOnly Θ₂ Δ =
+  trans (convCtx-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (repsOf Θ₁) (unlockedScope Θ₁ Ξ))
+              (unlockedScope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+
+-- SO THE ONLY CASUALTY IS `⊢ᵐ-⋉`.  §3 and §4 are exactly that: the two
+-- frames the move builds are semantically right and `_⊢ᵐ_`-illegal.
+
+------------------------------------------------------------------------
+-- §4  THE MIRROR — Θ₂ UNLOCKS WHAT Θ₁ LOCKS
+------------------------------------------------------------------------
+
+-- Δⱼ: slot 0 a MASKED binder at ℕ, slot 1 a plain binder at ℕ.
+Δⱼ : Ctxᵗ
+Δⱼ = masked (bind `ℕ) ∷ bind `ℕ ∷ []
+
+Θ₂ⱼ : CtxMorph          -- the OUTER frame UNLOCKS slot 0 …
+Θ₂ⱼ = unlock 0 ∷ []
+
+Θ₁ⱼ : CtxMorph          -- … and the INNER frame LOCKS it again
+Θ₁ⱼ = lock 0 ∷ []
+
+_ : interior Θ₂ⱼ Δⱼ ≡ bind `ℕ ∷ bind `ℕ ∷ []
+_ = refl
+
+Vⱼ : Term
+Vⱼ = ($ 5) ⟪ [] , seal 1 ⟫
+
+Redexⱼ : Term
+Redexⱼ = (Vⱼ ⟪ Θ₁ⱼ , id (` 1) ⟫) ⟪ Θ₂ⱼ , unseal 1 ⟫
+
+⊢Redexⱼ : Δⱼ ∣ [] ⊢ Redexⱼ ⦂ `ℕ
+⊢Redexⱼ =
+  env (mw-u ez mw[])
+      (env (mw-l (bind `ℕ , ez , nameable-b) mw[])
+           (env mw[] ⊢$ (conv-seal (es ez))
+                (wf-var (bind `ℕ , es ez , nameable-b)))
+           (conv-idv (bind `ℕ , es ez , nameable-b))
+           (wf-var (bind `ℕ , es ez , nameable-b)))
+      (conv-unseal (es ez))
+      wf-ℕ
+
+stepⱼ : Δⱼ ⊢ Redexⱼ -→ (Vⱼ ⟪ Θ₁ⱼ ⋉ Θ₂ⱼ , unseal 1 ⟫) ⟪ dropLocks Θ₂ⱼ , mkId `ℕ ⟫
+stepⱼ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
+
+_ : _≡_ {A = CtxMorph} (Θ₁ⱼ ⋉ Θ₂ⱼ) (lock 0 ∷ unlock 0 ∷ [])
+_ = refl
+
+-- WITH `bindsOnly` the merged frame is read over Δⱼ, where slot 0 is
+-- MASKED — so its `lock 0` has no `mw-l` premise …
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₂ⱼ) []
+_ = refl
+
+¬∋tv-Δⱼ : ¬ (Δⱼ ∋tv 0)
+¬∋tv-Δⱼ (_ , ez , ())
+
+-- … and WITH `dropLocks` it is read over `convCtx Θ₂ⱼ Δⱼ`, where slot 0 is
+-- a PLAIN binder — so its `unlock 0` has no `mw-u` premise under (1).
+_ : interior (dropLocks Θ₂ⱼ) Δⱼ ≡ bind `ℕ ∷ bind `ℕ ∷ []
+_ = refl
+
+no-masked-cc : ∀ {E} → ¬ (interior (dropLocks Θ₂ⱼ) Δⱼ ∋e 0 , masked E)
+no-masked-cc ()
+
+------------------------------------------------------------------------
+-- §5  IF `⊢ᵐ` WERE SEQUENTIAL, `dualScope` MUST ALSO REVERSE
+------------------------------------------------------------------------
+
+-- §3/§4 fail only because `⊢ᵐ` reads every entry on the PLAIN exterior.
+-- The reading that survives them checks each entry against `scope Θ Δ` —
+-- the type context the LATER entries have already produced, which is the
+-- order `scope` applies them.  Under that reading a frame may toggle one
+-- slot repeatedly, and then a SAME-ORDER dual is no longer an inverse:
+-- `scope` applies its list HEAD-LAST, so undoing it must run the entries
+-- BACK TO FRONT.
+Θᵣ : CtxMorph
+Θᵣ = unlock 0 ∷ lock 0 ∷ []
+
+Δᵣ : Ctxᵗ
+Δᵣ = bind `ℕ ∷ []
+
+_ : scope Θᵣ Δᵣ ≡ Δᵣ                       -- lock then unlock: a no-op
+_ = refl
+
+-- the SAME-ORDER dual OVER-masks …
+_ : scope (dualScope′ 0 Θᵣ) (scope Θᵣ Δᵣ) ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+¬inverse-same-order : ¬ (scope (dualScope′ 0 Θᵣ) (scope Θᵣ Δᵣ) ≡ Δᵣ)
+¬inverse-same-order ()
+
+-- … while the REVERSED one is exact.
+_ : scope (unlock 0 ∷ lock 0 ∷ []) (scope Θᵣ Δᵣ) ≡ Δᵣ
+_ = refl
+
+------------------------------------------------------------------------
+-- §6  … AND THEN `bindsOnly` LOSES ITS OWN `⊢ᵐ`
+------------------------------------------------------------------------
+
+-- A sequential `⊢ᵐ` must read `mw-b`'s rep sequentially too — otherwise
+-- the moved frame `Θ₁ ⋉ Θ₂` has no `mw-b` premise for Θ₁'s own binders,
+-- whose reps the redex only ever checked on `interior Θ₂ Δ`.  But then
+-- `bindsOnly Θ₂` has no `⊢ᵐ` either: its binds are read on the PLAIN Δ,
+-- where a rep naming a slot Θ₂ UNLOCKED is not well formed.
+Δ₆ : Ctxᵗ
+Δ₆ = masked (bind `ℕ) ∷ []
+
+Θ₆ : CtxMorph
+Θ₆ = bind (` 0) ∷ unlock 0 ∷ []
+
+-- the rep IS well formed past the frame's own unlock …
+_ : scope (unlock 0 ∷ []) Δ₆ ≡ bind `ℕ ∷ []
+_ = refl
+
+⊢ᵗ-rep-seq : scope (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
+⊢ᵗ-rep-seq = wf-var (bind `ℕ , ez , nameable-b)
+
+-- … and NOT on the plain exterior, which is where `bindsOnly Θ₆` reads it.
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₆) (bind (` 0) ∷ [])
+_ = refl
+
+¬⊢ᵗ-rep-plain : ¬ (Δ₆ ⊢ᵗ ` 0)
+¬⊢ᵗ-rep-plain (wf-var (_ , ez , ()))

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -1,48 +1,41 @@
 module strong.proof.MwUObstruct where
 
--- THE PROPOSED TIGHTNESS REPAIR, REFUTED — with witnesses.
+-- WHAT LANDED, AND WHAT THE ALTERNATIVES COST — the record of the
+-- 2026-09-06 tightness repair.
 --
--- proof/DualTightness.agda machine-checks the defect: `dualScope` DROPS
--- the crossed boundary's `unlock` entries, so `Peel` GAINS SCOPE.  The
--- repair on the table (Jeremy, 2026-09-06) is three coupled changes:
+-- The repair Jeremy proposed had three parts; this module used to refute
+-- them as a package.  All three LANDED, in the corrected form the
+-- refutations forced:
 --
---   (1) `mw-u` requires the slot to be MASKED —
---       `mw-u : Δ ∋e X , masked E → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)`
---       (no vacuous unlocks);
---   (2) `dualScope n (unlock X ∷ Θ) = lock (n + X) ∷ dualScope n Θ`
---       (restore what Θ unlocked);
---   (3) the outer boundary of CancelR/IdPush becomes BINDS-ONLY
---       (`bindsOnly Θ₂` in place of `dropLocks Θ₂`), so the moved scope
---       duplicates no unlock.
+--   (1) `mw-u` demands the slot be LOCKED — LANDED, and STRENGTHENED to
+--       the SEQUENTIAL reading `scope Θ Δ ∋lk X` (the entry is judged on
+--       the frame it acts on), with the same reading for `mw-l` and, for
+--       a rep, `unlockedScope Θ Δ ⊢ᵗ A`.  The old refutations §2/§3/§4
+--       were all artefacts of reading every premise on the PLAIN Δ.
+--       `⊢ᵐ-⊑` survives as `⊢ᵐ-⊑ᵃ` over `_⊑ᵃ_`, the refinement WITHOUT
+--       `le-mu` (strong.Ctx §4b); `⊢retag` runs on that.
+--   (2) `dualScope n (unlock X ∷ Θ) = … ++ lock (n + X) ∷ []` — LANDED,
+--       AND REVERSED (the old §5, which was right).
+--   (3) the outer frame of CancelR/IdPush loses its scope — LANDED as
+--       `rewind Θ₂ = dualScope 0 Θ₂ ++ Θ₂`, NOT as `bindsOnly Θ₂` and
+--       NOT as `dropLocks Θ₂`.
 --
--- THIS MODULE ESTABLISHES:
+-- WHAT REMAINS HERE ARE THE THREE REFUTATIONS THAT CHOSE `rewind`, on
+-- ONE running configuration:
 --
---   §1  (2) FORCES (1).  With (2) alone, `Peel` OVER-masks at a vacuous
---       unlock and `preserve-Peel` is FALSE — witness: a WELL-TYPED redex
---       whose contractum is ill typed.
---   §2  (1) REFUTES `⊢ᵐ-⊑`, hence `⊢retag` (strong.TermSubst) — the
---       transport `Δ ⊑ Δ′` cannot carry an `unlock` across a refinement
---       that UNMASKS the slot it names.
---   §3  (1) REFUTES THE SCOPE MOVE, at `Θ₂` locking what `Θ₁` unlocks:
---       a WELL-TYPED IdPush redex whose contractum's merged frame
---       `Θ₁ ⋉ Θ₂ = unlock 1 ∷ lock 1 ∷ []` is read over a type context
---       where slot 1 is a PLAIN BINDER.  Both candidate outer frames
---       (`dropLocks Θ₂` and `bindsOnly Θ₂`) fail on it.
---   §4  … and the MIRROR, at `Θ₂` unlocking what `Θ₁` locks.
---   §5  IF `⊢ᵐ` were made SEQUENTIAL (the only reading of §3/§4 that
---       survives), THEN `dualScope` must also REVERSE its list: the
---       same-order dual is not an inverse.
---   §6  … and `bindsOnly`'s own `⊢ᵐ` then fails, because a `bind`'s rep is
---       read on the PLAIN exterior (simultaneity) while the move needs it
---       read past the frame's own unlocks.
+--   §1  the exterior Δ₆ masks a slot; Θ₂ UNLOCKS it; the inner frame
+--       BINDS a rep that names it.  All three morphisms are well formed.
+--   §2  `dropLocks Θ₂` as the outer frame: the moved copy of Θ₂'s unlock
+--       is then VACUOUS, and `mw-u` refuses it.
+--   §3  `bindsOnly Θ₂` as the outer frame: Θ₂'s OWN bind rep loses the
+--       unlock it was read past, and `mw-b` refuses it.
+--   §4  `rewind Θ₂` does both jobs — and §4 is also the answer to the
+--       simultaneity question: under a mw-b read on the PLAIN exterior
+--       the MERGED frame `Θ₁ ⋉ Θ₂` has no derivation, because Θ₁'s rep
+--       names a slot the merged frame's own tail unlocks.
 --
--- THE SHAPE OF THE OBSTRUCTION, in one line: `⊢ᵐ` is SIMULTANEOUS (every
--- entry's premise is read on the PLAIN exterior Δ) while `scope` is
--- SEQUENTIAL (the list is applied head-last).  Under (1) `mw-l` and `mw-u`
--- become EXACT COMPLEMENTS — a lock names a NAMEABLE slot, an unlock a
--- MASKED one — so no simultaneous `⊢ᵐ` can hold of a list that both locks
--- and unlocks the same slot.  The scope move `_⋉_` builds exactly such
--- lists.
+-- The vacuous-unlock witness that used to live in §1 is now
+-- proof/DualTightness §5, where it is REFUSED.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; _++_; length)
@@ -56,375 +49,137 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
-open import strong.TermSubst using (wkᴹ)
 open import strong.Reduction
-open import strong.proof.DualTightness using (Δᵤ; Θᵤ)
-open import strong.proof.MoveScope using (interior-⋉; convCtx-⋉; scope-scopeOf)
 
 ------------------------------------------------------------------------
--- §0  The three proposed definitions, LOCALLY
+-- §0  The two REJECTED outer frames, locally
 ------------------------------------------------------------------------
 
--- (2): the dual RESTORES what Θ unlocked, keeping `lock ↦ unlock`.
-dualScope′ : ℕ → CtxMorph → CtxMorph
-dualScope′ n []             = []
-dualScope′ n (bind A ∷ Θ)   = dualScope′ n Θ
-dualScope′ n (unlock X ∷ Θ) = lock   (n + X) ∷ dualScope′ n Θ
-dualScope′ n (lock X ∷ Θ)   = unlock (n + X) ∷ dualScope′ n Θ
+-- Θ with its locks removed (it keeps the binds and the unlocks) …
+dropLocks : CtxMorph → CtxMorph
+dropLocks []             = []
+dropLocks (bind A ∷ Θ)   = bind A ∷ dropLocks Θ
+dropLocks (unlock X ∷ Θ) = unlock X ∷ dropLocks Θ
+dropLocks (lock X ∷ Θ)   = dropLocks Θ
 
-dual′ : CtxMorph → CtxMorph
-dual′ Θ = hideBinds (numBinds Θ) ++ dualScope′ (numBinds Θ) Θ
-
--- (3): the outer boundary keeps ONLY the binds.
+-- … and Θ with its whole scope deleted.
 bindsOnly : CtxMorph → CtxMorph
 bindsOnly []             = []
 bindsOnly (bind A ∷ Θ)   = bind A ∷ bindsOnly Θ
 bindsOnly (unlock X ∷ Θ) = bindsOnly Θ
 bindsOnly (lock X ∷ Θ)   = bindsOnly Θ
 
-------------------------------------------------------------------------
--- §1  (2) FORCES (1):  the vacuous unlock, and preserve-Peel REFUTED
-------------------------------------------------------------------------
-
--- ON JEREMY'S WITNESS (proof/DualTightness) THE REPAIR WORKS.  Θᵤ unlocks
--- a slot Δᵤ MASKS, so the restored lock lands where it should and the
--- crossing frame is Δᵤ EXACTLY — the contractum's argument is refused,
--- which is tightness.
-_ : dual′ Θᵤ ≡ lock 0 ∷ []
-_ = refl
-
-_ : interior (dual′ Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ
-_ = refl
-
--- BUT `mw-u` AS IT STANDS PERMITS A VACUOUS UNLOCK — a slot that is NOT
--- masked — and there the restored lock MASKS A SLOT THE EXTERIOR LEFT
--- NAMEABLE.  Δᵥ has one PLAIN binder; Θᵥ unlocks it for nothing.
-Δᵥ : Ctxᵗ
-Δᵥ = bind `ℕ ∷ []
-
-Θᵥ : CtxMorph
-Θᵥ = unlock 0 ∷ []
-
-⊢ᵐΘᵥ : Δᵥ ⊢ᵐ Θᵥ                  -- legal today: an unlock claims nothing
-⊢ᵐΘᵥ = mw-u ez mw[]
-
-_ : interior Θᵥ Δᵥ ≡ Δᵥ          -- and does nothing
-_ = refl
-
--- V₀ = λx:ℕ. 7,  crossed at  (ℕ⇒ℕ) inside  ⇝  (Z⇒ℕ) outside
-V₀ : Term
-V₀ = ƛ `ℕ ∙ ($ 7)
-
-c₀ : Conv
-c₀ = unseal 0 ↦ id `ℕ
-
--- W₀ = 3 sealed at Z's binder: a VALUE of type ` 0 at Δᵥ
-W₀ : Term
-W₀ = ($ 3) ⟪ [] , seal 0 ⟫
-
-⊢W₀ : Δᵥ ∣ [] ⊢ W₀ ⦂ ` 0
-⊢W₀ = env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
-
-Redexᵥ : Term
-Redexᵥ = (V₀ ⟪ Θᵥ , c₀ ⟫) · W₀
-
--- THE REDEX IS WELL TYPED.
-⊢Redexᵥ : Δᵥ ∣ [] ⊢ Redexᵥ ⦂ `ℕ
-⊢Redexᵥ =
-  ⊢· (env ⊢ᵐΘᵥ (⊢ƛ wf-ℕ ⊢$)
-          (conv-fun (conv-unseal ez) (conv-id base-ℕ))
-          (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ))
-     ⊢W₀
-
-stepᵥ : Δᵥ ⊢ Redexᵥ -→ (V₀ · (wkᴹ 0 W₀ ⟪ dual Θᵥ , unseal 0 ⟫)) ⟪ Θᵥ , id `ℕ ⟫
-stepᵥ = Peel V-ƛ (V-⟪⟫ V-$ I-seal)
-
--- UNDER (2) THE CROSSING FRAME MASKS Z, WHICH Δᵥ DID NOT.
-_ : dual′ Θᵥ ≡ lock 0 ∷ []
-_ = refl
-
-_ : interior (dual′ Θᵥ) (interior Θᵥ Δᵥ) ≡ masked (bind `ℕ) ∷ []
-_ = refl
-
--- … so the crossing argument does not retype, and the contractum is ILL
--- TYPED.  `preserve-Peel` is FALSE under (2) alone: hence (1).
-¬⊢W₀-inside : ∀ {A} → ¬ (masked (bind `ℕ) ∷ [] ∣ [] ⊢ W₀ ⦂ A)
-¬⊢W₀-inside (env _ _ _ (wf-var (_ , ez , ())))
+-- All three agree on the type context they leave behind — that is why
+-- the choice looks free until `_⊢ᵐ_` is asked.
 
 ------------------------------------------------------------------------
--- §2  (1) REFUTES `⊢ᵐ-⊑`, HENCE `⊢retag`
+-- §1  The configuration
 ------------------------------------------------------------------------
 
--- `⊢retag : Δ ⊑ Δ′ → Δ ∣ Γ ⊢ M ⦂ A → Δ′ ∣ Γ ⊢ M ⦂ A` (strong.TermSubst)
--- runs `⊢ᵐ-⊑` on every boundary it crosses.  Under (1) an `unlock X`
--- CLAIMS that X is masked, and `le-mu` — the ⊑ᵉ clause that RE-EXPOSES a
--- concealed slot (Cancel's own refinement) — destroys the claim.
-Δₘ Δₙ : Ctxᵗ
-Δₘ = masked (bind `ℕ) ∷ []
-Δₙ = bind `ℕ ∷ []
-
-refine-mn : Δₘ ⊑ Δₙ
-refine-mn = le∷ (le-mu le-bb nameable-b) le[]
-
-M₂ : Term
-M₂ = ($ 3) ⟪ unlock 0 ∷ [] , id `ℕ ⟫
-
-⊢M₂ : Δₘ ∣ [] ⊢ M₂ ⦂ `ℕ
-⊢M₂ = env (mw-u ez mw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
-
--- but slot 0 of Δₙ is a PLAIN binder, so `mw-u` under (1) has no premise
--- to offer, and `Δₙ ⊢ᵐ (unlock 0 ∷ [])` is not derivable.
-no-masked-Δₙ : ∀ {E} → ¬ (Δₙ ∋e 0 , masked E)
-no-masked-Δₙ ()
-
-------------------------------------------------------------------------
--- §3  (1) REFUTES THE SCOPE MOVE — Θ₂ LOCKS WHAT Θ₁ UNLOCKS
-------------------------------------------------------------------------
-
--- Δᵢ: slot 0 a binder at ℕ, slot 1 a binder at 𝔹.
-Δᵢ : Ctxᵗ
-Δᵢ = bind `ℕ ∷ bind `𝔹 ∷ []
-
-Θ₂ᵢ : CtxMorph          -- the OUTER frame LOCKS slot 1
-Θ₂ᵢ = lock 1 ∷ []
-
-Θ₁ᵢ : CtxMorph          -- the INNER frame UNLOCKS it again
-Θ₁ᵢ = unlock 1 ∷ []
-
-_ : interior Θ₂ᵢ Δᵢ ≡ bind `ℕ ∷ masked (bind `𝔹) ∷ []
-_ = refl
-
--- LEGAL UNDER (1): the inner unlock names a slot its OWN exterior masks.
-⊢ᵐΘ₁ᵢ : interior Θ₂ᵢ Δᵢ ⊢ᵐ Θ₁ᵢ
-⊢ᵐΘ₁ᵢ = mw-u (es ez) mw[]
-
-_ : interior Θ₁ᵢ (interior Θ₂ᵢ Δᵢ) ≡ bind `ℕ ∷ bind `𝔹 ∷ []
-_ = refl
-
--- a value of type ` 0: a numeral sealed at slot 0's binder
-Vᵢ : Term
-Vᵢ = ($ 5) ⟪ [] , seal 0 ⟫
-
-Redexᵢ : Term
-Redexᵢ = (Vᵢ ⟪ Θ₁ᵢ , id (` 0) ⟫) ⟪ Θ₂ᵢ , unseal 0 ⟫
-
--- THE REDEX IS WELL TYPED.
-⊢Redexᵢ : Δᵢ ∣ [] ⊢ Redexᵢ ⦂ `ℕ
-⊢Redexᵢ =
-  env (mw-l (bind `𝔹 , es ez , nameable-b) mw[])
-      (env ⊢ᵐΘ₁ᵢ
-           (env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b)))
-           (conv-idv (bind `ℕ , ez , nameable-b))
-           (wf-var (bind `ℕ , ez , nameable-b)))
-      (conv-unseal ez)
-      wf-ℕ
-
-stepᵢ : Δᵢ ⊢ Redexᵢ -→ (Vᵢ ⟪ Θ₁ᵢ ⋉ Θ₂ᵢ , unseal 0 ⟫) ⟪ dropLocks Θ₂ᵢ , mkId `ℕ ⟫
-stepᵢ = IdPush (V-⟪⟫ V-$ I-seal) ez
-
--- THE MERGED FRAME both unlocks and locks slot 1 …
-_ : _≡_ {A = CtxMorph} (Θ₁ᵢ ⋉ Θ₂ᵢ) (unlock 1 ∷ lock 1 ∷ [])
-_ = refl
-
--- … and BOTH candidate outer frames leave it read over Δᵢ, where slot 1
--- is a PLAIN binder.  (Θ₂ᵢ has neither binds nor unlocks, so `dropLocks`
--- and `bindsOnly` agree here.)
-_ : _≡_ {A = CtxMorph} (dropLocks Θ₂ᵢ) []
-_ = refl
-
-_ : _≡_ {A = CtxMorph} (bindsOnly Θ₂ᵢ) []
-_ = refl
-
-_ : interior (dropLocks Θ₂ᵢ) Δᵢ ≡ Δᵢ
-_ = refl
-
--- THE OBSTRUCTION: under (1) `Δᵢ ⊢ᵐ (unlock 1 ∷ lock 1 ∷ [])` has no
--- derivation, because `mw-u` would need slot 1 of Δᵢ to be MASKED.
-no-masked-Δᵢ : ∀ {E} → ¬ (Δᵢ ∋e 1 , masked E)
-no-masked-Δᵢ d with ∋e-det d (es ez)
-... | ()
-
--- (The frame ITSELF is right: the merged frame's interior is the redex's
--- interior on the nose.  It is only `⊢ᵐ`, read simultaneously, that
--- refuses it.)
-_ : interior (Θ₁ᵢ ⋉ Θ₂ᵢ) (interior (dropLocks Θ₂ᵢ) Δᵢ)
-      ≡ interior Θ₁ᵢ (interior Θ₂ᵢ Δᵢ)
-_ = refl
-
-------------------------------------------------------------------------
--- §3b  WHAT (3) *DOES* BUY — the frame lemmas become EQUALITIES
-------------------------------------------------------------------------
-
--- The positive half of the proposal, proven in general and independent of
--- `_⊢ᵐ_`: with a BINDS-ONLY outer frame the move is EXACT.  `frame-move`
--- (proof/MoveScope) is a ⊑ only because `dropLocks` retains Θ₂'s unlocks
--- and so applies them twice; drop them and the two frames coincide on the
--- nose, and the value crosses by `subst` with no `⊢retag` at all.
-repsOf-bindsOnly : (Θ : CtxMorph) → repsOf (bindsOnly Θ) ≡ repsOf Θ
-repsOf-bindsOnly []             = refl
-repsOf-bindsOnly (bind A ∷ Θ)   = cong (A ∷_) (repsOf-bindsOnly Θ)
-repsOf-bindsOnly (unlock X ∷ Θ) = repsOf-bindsOnly Θ
-repsOf-bindsOnly (lock X ∷ Θ)   = repsOf-bindsOnly Θ
-
-scope-bindsOnly : (Θ : CtxMorph) (Δ : Ctxᵗ) → scope (bindsOnly Θ) Δ ≡ Δ
-scope-bindsOnly []             Δ = refl
-scope-bindsOnly (bind A ∷ Θ)   Δ = scope-bindsOnly Θ Δ
-scope-bindsOnly (unlock X ∷ Θ) Δ = scope-bindsOnly Θ Δ
-scope-bindsOnly (lock X ∷ Θ)   Δ = scope-bindsOnly Θ Δ
-
-interior-bindsOnly : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (bindsOnly Θ) Δ ≡ pushBinds (repsOf Θ) Δ
-interior-bindsOnly Θ Δ
-  rewrite repsOf-bindsOnly Θ | scope-bindsOnly Θ Δ = refl
-
--- (b), FIRST HALF: the value's frame is preserved EXACTLY.
-interior-⋉-bindsOnly : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (Θ₁ ⋉ Θ₂) (interior (bindsOnly Θ₂) Δ)
-      ≡ interior Θ₁ (interior Θ₂ Δ)
-interior-⋉-bindsOnly Θ₁ Θ₂ Δ
-  rewrite interior-bindsOnly Θ₂ Δ =
-  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
-        (cong (λ Ξ → pushBinds (repsOf Θ₁) (scope Θ₁ Ξ))
-              (scope-scopeOf (repsOf Θ₂) Θ₂ Δ))
-
--- (b), SECOND HALF: the conversion context of the moved frame is the
--- redex's own inner conversion context with Θ₂'s LOCKS lifted off — which
--- is the whole point of the move (the rep the swapped conversion presents
--- is read OUTSIDE those locks).
-unlockedScope-scopeOf : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (scopeOf (length As) Θ) (pushBinds As Δ)
-      ≡ pushBinds As (unlockedScope Θ Δ)
-unlockedScope-scopeOf As []             Δ = refl
-unlockedScope-scopeOf As (bind A ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
-unlockedScope-scopeOf As (lock X ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
-unlockedScope-scopeOf As (unlock X ∷ Θ) Δ =
-  trans (cong (unmask (length As + X)) (unlockedScope-scopeOf As Θ Δ))
-        (updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ))
-
-convCtx-⋉-bindsOnly : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
-  → convCtx (Θ₁ ⋉ Θ₂) (interior (bindsOnly Θ₂) Δ)
-      ≡ convCtx Θ₁ (convCtx Θ₂ Δ)
-convCtx-⋉-bindsOnly Θ₁ Θ₂ Δ
-  rewrite interior-bindsOnly Θ₂ Δ =
-  trans (convCtx-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
-        (cong (λ Ξ → pushBinds (repsOf Θ₁) (unlockedScope Θ₁ Ξ))
-              (unlockedScope-scopeOf (repsOf Θ₂) Θ₂ Δ))
-
--- SO THE ONLY CASUALTY IS `⊢ᵐ-⋉`.  §3 and §4 are exactly that: the two
--- frames the move builds are semantically right and `_⊢ᵐ_`-illegal.
-
-------------------------------------------------------------------------
--- §4  THE MIRROR — Θ₂ UNLOCKS WHAT Θ₁ LOCKS
-------------------------------------------------------------------------
-
--- Δⱼ: slot 0 a MASKED binder at ℕ, slot 1 a plain binder at ℕ.
-Δⱼ : Ctxᵗ
-Δⱼ = masked (bind `ℕ) ∷ bind `ℕ ∷ []
-
-Θ₂ⱼ : CtxMorph          -- the OUTER frame UNLOCKS slot 0 …
-Θ₂ⱼ = unlock 0 ∷ []
-
-Θ₁ⱼ : CtxMorph          -- … and the INNER frame LOCKS it again
-Θ₁ⱼ = lock 0 ∷ []
-
-_ : interior Θ₂ⱼ Δⱼ ≡ bind `ℕ ∷ bind `ℕ ∷ []
-_ = refl
-
-Vⱼ : Term
-Vⱼ = ($ 5) ⟪ [] , seal 1 ⟫
-
-Redexⱼ : Term
-Redexⱼ = (Vⱼ ⟪ Θ₁ⱼ , id (` 1) ⟫) ⟪ Θ₂ⱼ , unseal 1 ⟫
-
-⊢Redexⱼ : Δⱼ ∣ [] ⊢ Redexⱼ ⦂ `ℕ
-⊢Redexⱼ =
-  env (mw-u ez mw[])
-      (env (mw-l (bind `ℕ , ez , nameable-b) mw[])
-           (env mw[] ⊢$ (conv-seal (es ez))
-                (wf-var (bind `ℕ , es ez , nameable-b)))
-           (conv-idv (bind `ℕ , es ez , nameable-b))
-           (wf-var (bind `ℕ , es ez , nameable-b)))
-      (conv-unseal (es ez))
-      wf-ℕ
-
-stepⱼ : Δⱼ ⊢ Redexⱼ -→ (Vⱼ ⟪ Θ₁ⱼ ⋉ Θ₂ⱼ , unseal 1 ⟫) ⟪ dropLocks Θ₂ⱼ , mkId `ℕ ⟫
-stepⱼ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
-
-_ : _≡_ {A = CtxMorph} (Θ₁ⱼ ⋉ Θ₂ⱼ) (lock 0 ∷ unlock 0 ∷ [])
-_ = refl
-
--- WITH `bindsOnly` the merged frame is read over Δⱼ, where slot 0 is
--- MASKED — so its `lock 0` has no `mw-l` premise …
-_ : _≡_ {A = CtxMorph} (bindsOnly Θ₂ⱼ) []
-_ = refl
-
-¬∋tv-Δⱼ : ¬ (Δⱼ ∋tv 0)
-¬∋tv-Δⱼ (_ , ez , ())
-
--- … and WITH `dropLocks` it is read over `convCtx Θ₂ⱼ Δⱼ`, where slot 0 is
--- a PLAIN binder — so its `unlock 0` has no `mw-u` premise under (1).
-_ : interior (dropLocks Θ₂ⱼ) Δⱼ ≡ bind `ℕ ∷ bind `ℕ ∷ []
-_ = refl
-
-no-masked-cc : ∀ {E} → ¬ (interior (dropLocks Θ₂ⱼ) Δⱼ ∋e 0 , masked E)
-no-masked-cc ()
-
-------------------------------------------------------------------------
--- §5  IF `⊢ᵐ` WERE SEQUENTIAL, `dualScope` MUST ALSO REVERSE
-------------------------------------------------------------------------
-
--- §3/§4 fail only because `⊢ᵐ` reads every entry on the PLAIN exterior.
--- The reading that survives them checks each entry against `scope Θ Δ` —
--- the type context the LATER entries have already produced, which is the
--- order `scope` applies them.  Under that reading a frame may toggle one
--- slot repeatedly, and then a SAME-ORDER dual is no longer an inverse:
--- `scope` applies its list HEAD-LAST, so undoing it must run the entries
--- BACK TO FRONT.
-Θᵣ : CtxMorph
-Θᵣ = unlock 0 ∷ lock 0 ∷ []
-
-Δᵣ : Ctxᵗ
-Δᵣ = bind `ℕ ∷ []
-
-_ : scope Θᵣ Δᵣ ≡ Δᵣ                       -- lock then unlock: a no-op
-_ = refl
-
--- the SAME-ORDER dual OVER-masks …
-_ : scope (dualScope′ 0 Θᵣ) (scope Θᵣ Δᵣ) ≡ masked (bind `ℕ) ∷ []
-_ = refl
-
-¬inverse-same-order : ¬ (scope (dualScope′ 0 Θᵣ) (scope Θᵣ Δᵣ) ≡ Δᵣ)
-¬inverse-same-order ()
-
--- … while the REVERSED one is exact.
-_ : scope (unlock 0 ∷ lock 0 ∷ []) (scope Θᵣ Δᵣ) ≡ Δᵣ
-_ = refl
-
-------------------------------------------------------------------------
--- §6  … AND THEN `bindsOnly` LOSES ITS OWN `⊢ᵐ`
-------------------------------------------------------------------------
-
--- A sequential `⊢ᵐ` must read `mw-b`'s rep sequentially too — otherwise
--- the moved frame `Θ₁ ⋉ Θ₂` has no `mw-b` premise for Θ₁'s own binders,
--- whose reps the redex only ever checked on `interior Θ₂ Δ`.  But then
--- `bindsOnly Θ₂` has no `⊢ᵐ` either: its binds are read on the PLAIN Δ,
--- where a rep naming a slot Θ₂ UNLOCKED is not well formed.
+-- Δ₆ masks slot 0 (a binder at ℕ).
 Δ₆ : Ctxᵗ
 Δ₆ = masked (bind `ℕ) ∷ []
 
+-- Θ₂ UNLOCKS it — legal, because the slot really is locked.
+Θ₂ : CtxMorph
+Θ₂ = unlock 0 ∷ []
+
+⊢ᵐΘ₂ : Δ₆ ⊢ᵐ Θ₂
+⊢ᵐΘ₂ = mw-u (masked (bind `ℕ) , ez , locked nameable-b) mw[]
+
+_ : interior Θ₂ Δ₆ ≡ bind `ℕ ∷ []
+_ = refl
+
+-- An inner frame that BINDS a rep naming that slot — legal at Θ₂'s
+-- interior, where the slot is live.
+Θ₁ : CtxMorph
+Θ₁ = bind (` 0) ∷ []
+
+⊢ᵐΘ₁ : interior Θ₂ Δ₆ ⊢ᵐ Θ₁
+⊢ᵐΘ₁ = mw-b (wf-var (bind `ℕ , ez , nameable-b)) mw[]
+
+-- THE MERGED FRAME the scope move builds.  Θ₂ carries no binder, so the
+-- moved scope keeps its index.
 Θ₆ : CtxMorph
 Θ₆ = bind (` 0) ∷ unlock 0 ∷ []
 
--- the rep IS well formed past the frame's own unlock …
-_ : scope (unlock 0 ∷ []) Δ₆ ≡ bind `ℕ ∷ []
+_ : _≡_ {A = CtxMorph} (Θ₁ ⋉ Θ₂) Θ₆
 _ = refl
 
-⊢ᵗ-rep-seq : scope (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
-⊢ᵗ-rep-seq = wf-var (bind `ℕ , ez , nameable-b)
+-- It is well formed over Δ₆ — its rep is read past its OWN tail, i.e.
+-- past the unlock, which is where the redex read it.
+⊢ᵐΘ₆ : Δ₆ ⊢ᵐ Θ₆
+⊢ᵐΘ₆ = mw-b (wf-var (bind `ℕ , ez , nameable-b))
+            (mw-u (masked (bind `ℕ) , ez , locked nameable-b) mw[])
 
--- … and NOT on the plain exterior, which is where `bindsOnly Θ₆` reads it.
+------------------------------------------------------------------------
+-- §2  `dropLocks` REFUTED — the moved unlock goes vacuous
+------------------------------------------------------------------------
+
+-- Θ₂ has no locks, so `dropLocks Θ₂` is Θ₂ itself: the outer frame
+-- unmasks the slot, and the merged frame's own copy of that unlock then
+-- names a slot that is already NAMEABLE.
+_ : _≡_ {A = CtxMorph} (dropLocks Θ₂) Θ₂
+_ = refl
+
+_ : interior (dropLocks Θ₂) Δ₆ ≡ bind `ℕ ∷ []
+_ = refl
+
+-- The merged frame is read there, and its `unlock 0` has no premise.
+¬⊢ᵐ-dropLocks : ¬ (interior (dropLocks Θ₂) Δ₆ ⊢ᵐ (Θ₁ ⋉ Θ₂))
+¬⊢ᵐ-dropLocks (mw-b _ (mw-u (_ , ez , ()) _))
+
+------------------------------------------------------------------------
+-- §3  `bindsOnly` REFUTED — the frame's own rep loses its unlock
+------------------------------------------------------------------------
+
+-- Take the MERGED frame Θ₆ as the next redex's outer frame — it is
+-- reachable, being exactly what §1's move just produced.  Deleting its
+-- scope strands its bind rep on the plain exterior.
 _ : _≡_ {A = CtxMorph} (bindsOnly Θ₆) (bind (` 0) ∷ [])
 _ = refl
 
 ¬⊢ᵗ-rep-plain : ¬ (Δ₆ ⊢ᵗ ` 0)
 ¬⊢ᵗ-rep-plain (wf-var (_ , ez , ()))
+
+¬⊢ᵐ-bindsOnly : ¬ (Δ₆ ⊢ᵐ bindsOnly Θ₆)
+¬⊢ᵐ-bindsOnly (mw-b w _) = ¬⊢ᵗ-rep-plain w
+
+------------------------------------------------------------------------
+-- §4  `rewind` DOES BOTH JOBS
+------------------------------------------------------------------------
+
+-- It keeps every entry and runs the inverse scope on top, so the type
+-- context it leaves is the bind prefix over the PLAIN exterior …
+_ : _≡_ {A = CtxMorph} (rewind Θ₂) (lock 0 ∷ unlock 0 ∷ [])
+_ = refl
+
+_ : interior (rewind Θ₂) Δ₆ ≡ Δ₆
+_ = refl
+
+_ : _≡_ {A = CtxMorph} (rewind Θ₆) (lock 0 ∷ bind (` 0) ∷ unlock 0 ∷ [])
+_ = refl
+
+_ : interior (rewind Θ₆) Δ₆ ≡ pushBinds (repsOf Θ₆) Δ₆
+_ = refl
+
+-- … and every premise is still read where the redex read it.
+⊢ᵐ-rewind-Θ₂ : Δ₆ ⊢ᵐ rewind Θ₂
+⊢ᵐ-rewind-Θ₂ = mw-l (bind `ℕ , ez , nameable-b) ⊢ᵐΘ₂
+
+⊢ᵐ-rewind-Θ₆ : Δ₆ ⊢ᵐ rewind Θ₆
+⊢ᵐ-rewind-Θ₆ = mw-l (bind `ℕ , ez , nameable-b) ⊢ᵐΘ₆
+
+-- THE MERGED FRAME IS WELL FORMED OVER IT.
+⊢ᵐ-merged : interior (rewind Θ₂) Δ₆ ⊢ᵐ (Θ₁ ⋉ Θ₂)
+⊢ᵐ-merged = ⊢ᵐΘ₆
+
+-- AND THIS IS WHY `mw-b` READS ITS REP ON `unlockedScope Θ Δ`.  The
+-- merged frame's rep `` ` 0 `` is NOT well formed on the plain exterior
+-- (`¬⊢ᵗ-rep-plain`) and IS well formed past the frame's own tail — so a
+-- SIMULTANEOUS `mw-b`, reading every rep on Δ, would refuse the frame the
+-- move builds.  Reading it past the tail's UNMASKS (and never past the
+-- tail's locks — `unlockedScope`, not `scope`) is what makes both the
+-- move and TyPeelR's `bind A ∷ Θ` well formed at once.
+⊢ᵗ-rep-past-tail : unlockedScope (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
+⊢ᵗ-rep-past-tail = wf-var (bind `ℕ , ez , nameable-b)

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -1,19 +1,35 @@
 module strong.proof.PeelDual where
 
--- THE PEEL REPAIR — with the fixed `dual` (strong.Reduction), `interior-dual`
--- and `convCtx-dual` are TRUE in general and `PeelCase` is PROVEN.
+-- THE PEEL CROSSING — the dual is an INVERSE, and the frame identity is
+-- EXACT.
 --
 --   interior (dual Θ) (interior Θ Δ)
---     ≡ map masked (pushBinds (repsOf Θ) []) ++ unlockedScope Θ Δ
+--     ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ        (given Δ ⊢ᵐ Θ)
 --   convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ
 --
--- The crossing argument (typed in Δ) retypes one bind frame deeper by
--- `⊢rename (wkN (numBinds Θ))` + `⊢retag` (the tail relaxes
--- Δ ⊑ unlockedScope Θ Δ), and the conversion `s` transplants verbatim
--- through `convCtx-dual`.
+-- The first is (†): the crossing argument's frame IS THE EXTERIOR, one
+-- bind prefix in, with the prefix masked.  So the argument (typed at Δ)
+-- crosses by `⊢rename (wkN (numBinds Θ))` ALONE — no `⊢retag`, no
+-- `le-mu`, and no scope is gained.  Under the old dual the right-hand
+-- side was `… ++ unlockedScope Θ Δ`, strictly more nameable than Δ
+-- whenever Θ unlocked a slot Δ masked, and `Peel` related a term the
+-- exterior REFUSES to one it accepts (proof/DualTightness).
+--
+-- The two repairs (strong.Reduction §2) that buy it:
+--   `unlock X ↦ lock (n + X)`  the dual RESTORES what Θ unlocked, sound
+--                              because `mw-u` refuses a vacuous unlock
+--                              (`mask-unmask`, strong.Ctx §6b);
+--   the list is REVERSED        because `scope` applies HEAD-LAST.
+--
+--   §1  `⊢ᵐ-++` — the SEQUENTIAL judgement of an append (also used by
+--       proof/MoveScope)
+--   §2  the dual's scope: the frame identity, its `⊢ᵐ`, and the
+--       conversion-context identity
+--   §3  (†) and `convCtx-dual`
+--   §4  the crossing, and `preserve-Peel`
 
-open import Data.Nat using (ℕ; zero; suc; _+_; _<_; s≤s; z≤n)
-open import Data.Nat.Properties using (≤-refl; m≤n⇒m≤1+n)
+open import Data.Nat using (ℕ; zero; suc; _+_; _≤_; _<_; s≤s; z≤n)
+open import Data.Nat.Properties using (≤-refl; ≤-trans; n≤1+n; m≤n⇒m≤1+n; <⇒≢)
 open import Data.List using (List; []; _∷_; _++_; map; length)
 open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
 open import Data.Empty using (⊥; ⊥-elim)
@@ -74,51 +90,125 @@ updateAt-app-tail : (f : Ent → Ent) (Ow : Ctxᵗ) (X : ℕ) (Δ : Ctxᵗ)
 updateAt-app-tail f []       X Δ = refl
 updateAt-app-tail f (E ∷ Ow) X Δ = cong (E ∷_) (updateAt-app-tail f Ow X Δ)
 
--- Unmasking a slot undoes masking it, on the nose.
-unmask-mask : (a : ℕ) (Ξ : Ctxᵗ) → unmask a (mask a Ξ) ≡ Ξ
-unmask-mask zero    []      = refl
-unmask-mask (suc a) []      = refl
-unmask-mask zero    (E ∷ Ξ) = cong (_∷ Ξ) (unmaskEnt-masked E)
+------------------------------------------------------------------------
+-- §1  `⊢ᵐ-++` — the sequential judgement of an APPEND
+------------------------------------------------------------------------
+
+-- `scope` applies its list HEAD-LAST, so in `Θ ++ Ψ` it is Ψ that runs
+-- FIRST: Θ is judged over `scope Ψ Δ`, Ψ over Δ.  Each of the three
+-- premises then lands on the nose except the rep, which moves from
+-- `scope Ψ Δ` to `unlockedScope Ψ Δ` — MORE nameable
+-- (`scope⊑unlockedScope`), so `⊑-wf` carries it.
+⊢ᵐ-++ : (Θ Ψ : CtxMorph) {Δ : Ctxᵗ}
+  → scope Ψ Δ ⊢ᵐ Θ → Δ ⊢ᵐ Ψ → Δ ⊢ᵐ (Θ ++ Ψ)
+⊢ᵐ-++ []             Ψ mw[]        bΨ = bΨ
+⊢ᵐ-++ (bind A ∷ Θ)   Ψ {Δ = Δ} (mw-b w b)  bΨ =
+  mw-b (subst (λ Ξ → Ξ ⊢ᵗ A) (sym (unlockedScope-++ Θ Ψ Δ))
+              (⊑-wf (⊑-unlockedScope Θ (scope⊑unlockedScope Ψ Δ)) w))
+       (⊢ᵐ-++ Θ Ψ b bΨ)
+⊢ᵐ-++ (lock X ∷ Θ)   Ψ {Δ = Δ} (mw-l tv b) bΨ =
+  mw-l (subst (λ Ξ → Ξ ∋tv X) (sym (scope-++ Θ Ψ Δ)) tv) (⊢ᵐ-++ Θ Ψ b bΨ)
+⊢ᵐ-++ (unlock X ∷ Θ) Ψ {Δ = Δ} (mw-u lk b) bΨ =
+  mw-u (subst (λ Ξ → Ξ ∋lk X) (sym (scope-++ Θ Ψ Δ)) lk) (⊢ᵐ-++ Θ Ψ b bΨ)
+
+------------------------------------------------------------------------
+-- §2  The dual's scope half
+------------------------------------------------------------------------
+
+-- THE FRAME IDENTITY.  `dualScope` undoes `scope` on the nose — and this
+-- is where the two repairs are paid for: the `unlock` case needs
+-- `mask ∘ unmask = id`, which holds AT A LOCKED SLOT AND NOWHERE ELSE
+-- (`mask-unmask`), and the reversal is what puts each inverse entry where
+-- `scope` will apply it.
+scope-dualScope : (As : List Ty) (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
+  → scope (dualScope (length As) Θ) (pushBinds As (scope Θ Δ)) ≡ pushBinds As Δ
+scope-dualScope As []             mw[]         = refl
+scope-dualScope As (bind A ∷ Θ)   (mw-b _ b)   = scope-dualScope As Θ b
+scope-dualScope As (lock X ∷ Θ)   {Δ = Δ} (mw-l tv b)
+  rewrite scope-++ (dualScope (length As) Θ) (unlock (length As + X) ∷ [])
+                   (pushBinds As (mask X (scope Θ Δ)))
+        | updateAt-pushBinds unmaskEnt As X (mask X (scope Θ Δ))
+        | unmask-mask X (scope Θ Δ) = scope-dualScope As Θ b
+scope-dualScope As (unlock X ∷ Θ) {Δ = Δ} (mw-u lk b)
+  rewrite scope-++ (dualScope (length As) Θ) (lock (length As + X) ∷ [])
+                   (pushBinds As (unmask X (scope Θ Δ)))
+        | updateAt-pushBinds masked As X (unmask X (scope Θ Δ))
+        | mask-unmask lk = scope-dualScope As Θ b
+
+-- … AND IT IS WELL FORMED WHERE IT LANDS.  Θ's `lock X` becomes an
+-- `unlock` at a slot the lock itself just masked (`mask-∋lk`); Θ's
+-- `unlock X` becomes a `lock` at a slot the unlock itself just exposed
+-- (`unmask-∋tv`).  Both premises come straight out of Θ's own.
+⊢ᵐ-dualScope : (As : List Ty) (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
+  → pushBinds As (scope Θ Δ) ⊢ᵐ dualScope (length As) Θ
+⊢ᵐ-dualScope As []             mw[]       = mw[]
+⊢ᵐ-dualScope As (bind A ∷ Θ)   (mw-b _ b) = ⊢ᵐ-dualScope As Θ b
+⊢ᵐ-dualScope As (lock X ∷ Θ)   {Δ = Δ} (mw-l tv b) =
+  ⊢ᵐ-++ (dualScope (length As) Θ) (unlock (length As + X) ∷ [])
+        (subst (λ Ξ → Ξ ⊢ᵐ dualScope (length As) Θ) (sym eq)
+               (⊢ᵐ-dualScope As Θ b))
+        (mw-u (pushBinds-∋lk As (mask-∋lk tv)) mw[])
   where
-  unmaskEnt-masked : (E : Ent) → unmaskEnt (masked E) ≡ E
-  unmaskEnt-masked E = refl
-unmask-mask (suc a) (E ∷ Ξ) = cong (E ∷_) (unmask-mask a Ξ)
+  eq : unmask (length As + X) (pushBinds As (mask X (scope Θ Δ)))
+         ≡ pushBinds As (scope Θ Δ)
+  eq = trans (updateAt-pushBinds unmaskEnt As X (mask X (scope Θ Δ)))
+             (cong (pushBinds As) (unmask-mask X (scope Θ Δ)))
+⊢ᵐ-dualScope As (unlock X ∷ Θ) {Δ = Δ} (mw-u lk b) =
+  ⊢ᵐ-++ (dualScope (length As) Θ) (lock (length As + X) ∷ [])
+        (subst (λ Ξ → Ξ ⊢ᵐ dualScope (length As) Θ) (sym eq)
+               (⊢ᵐ-dualScope As Θ b))
+        (mw-l (pushBinds-∋tv As (unmask-∋tv lk)) mw[])
+  where
+  eq : mask (length As + X) (pushBinds As (unmask X (scope Θ Δ)))
+         ≡ pushBinds As (scope Θ Δ)
+  eq = trans (updateAt-pushBinds masked As X (unmask X (scope Θ Δ)))
+             (cong (pushBinds As) (mask-unmask lk))
 
--- dualScope is all-unlock, so its `scope` commutes with any extra unmask.
-dualScope-unmask-comm : (n : ℕ) (Θ : CtxMorph) (Y : ℕ) (Δ : Ctxᵗ)
-  → scope (dualScope n Θ) (unmask Y Δ) ≡ unmask Y (scope (dualScope n Θ) Δ)
-dualScope-unmask-comm n []             Y Δ = refl
-dualScope-unmask-comm n (bind A ∷ Θ)   Y Δ = dualScope-unmask-comm n Θ Y Δ
-dualScope-unmask-comm n (unlock X ∷ Θ) Y Δ = dualScope-unmask-comm n Θ Y Δ
-dualScope-unmask-comm n (lock X ∷ Θ)   Y Δ
-  rewrite dualScope-unmask-comm n Θ Y Δ =
-  updateAt-updateAt-comm unmaskEnt (n + X) Y (scope (dualScope n Θ) Δ)
+-- THE CONVERSION CONTEXT sees only the dual's UNLOCKS, i.e. only Θ's
+-- LOCKS undone — so it is Θ's own conversion context, with no premise at
+-- all.  (A composition of unmasks commutes, which is why the reversal is
+-- invisible here.)
+dualScope-unmask-comm : (m : ℕ) (Ψ : CtxMorph) (Y : ℕ) (Ξ : Ctxᵗ)
+  → unlockedScope (dualScope m Ψ) (unmask Y Ξ)
+      ≡ unmask Y (unlockedScope (dualScope m Ψ) Ξ)
+dualScope-unmask-comm m []             Y Ξ = refl
+dualScope-unmask-comm m (bind A ∷ Ψ)   Y Ξ = dualScope-unmask-comm m Ψ Y Ξ
+dualScope-unmask-comm m (unlock X ∷ Ψ) Y Ξ
+  rewrite unlockedScope-++ (dualScope m Ψ) (lock (m + X) ∷ []) (unmask Y Ξ)
+        | unlockedScope-++ (dualScope m Ψ) (lock (m + X) ∷ []) Ξ =
+  dualScope-unmask-comm m Ψ Y Ξ
+dualScope-unmask-comm m (lock X ∷ Ψ)   Y Ξ
+  rewrite unlockedScope-++ (dualScope m Ψ) (unlock (m + X) ∷ []) (unmask Y Ξ)
+        | unlockedScope-++ (dualScope m Ψ) (unlock (m + X) ∷ []) Ξ
+        | updateAt-updateAt-comm unmaskEnt (m + X) Y Ξ =
+  dualScope-unmask-comm m Ψ Y (unmask (m + X) Ξ)
+
+unlockedScope-dualScope : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → unlockedScope (dualScope (length As) Θ) (pushBinds As (scope Θ Δ))
+      ≡ pushBinds As (unlockedScope Θ Δ)
+unlockedScope-dualScope As []             Δ = refl
+unlockedScope-dualScope As (bind A ∷ Θ)   Δ = unlockedScope-dualScope As Θ Δ
+unlockedScope-dualScope As (lock X ∷ Θ)   Δ
+  rewrite unlockedScope-++ (dualScope (length As) Θ)
+                           (unlock (length As + X) ∷ [])
+                           (pushBinds As (mask X (scope Θ Δ)))
+        | updateAt-pushBinds unmaskEnt As X (mask X (scope Θ Δ))
+        | unmask-mask X (scope Θ Δ) = unlockedScope-dualScope As Θ Δ
+unlockedScope-dualScope As (unlock X ∷ Θ) Δ
+  rewrite unlockedScope-++ (dualScope (length As) Θ)
+                           (lock (length As + X) ∷ [])
+                           (pushBinds As (unmask X (scope Θ Δ)))
+        | sym (updateAt-pushBinds unmaskEnt As X (scope Θ Δ))
+        | dualScope-unmask-comm (length As) Θ (length As + X)
+                                (pushBinds As (scope Θ Δ))
+        | unlockedScope-dualScope As Θ Δ =
+  updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ)
 
 ------------------------------------------------------------------------
--- STEP A: dualScope unmasks exactly Θ's lock positions, turning `scope`
--- into `unlockedScope`.
+-- §3  (†) and `convCtx-dual`
 ------------------------------------------------------------------------
 
-stepA : (Ow : Ctxᵗ) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → scope (dualScope (length Ow) Θ) (Ow ++ scope Θ Δ) ≡ Ow ++ unlockedScope Θ Δ
-stepA Ow []             Δ = refl
-stepA Ow (bind A ∷ Θ)   Δ = stepA Ow Θ Δ
-stepA Ow (unlock X ∷ Θ) Δ
-  rewrite sym (updateAt-app-tail unmaskEnt Ow X (scope Θ Δ))
-        | dualScope-unmask-comm (length Ow) Θ (length Ow + X) (Ow ++ scope Θ Δ)
-        | stepA Ow Θ Δ =
-  updateAt-app-tail unmaskEnt Ow X (unlockedScope Θ Δ)
-stepA Ow (lock X ∷ Θ)   Δ
-  rewrite sym (dualScope-unmask-comm (length Ow) Θ (length Ow + X)
-                 (Ow ++ mask X (scope Θ Δ)))
-        | updateAt-app-tail unmaskEnt Ow X (mask X (scope Θ Δ))
-        | unmask-mask X (scope Θ Δ)
-        | stepA Ow Θ Δ = refl
-
-------------------------------------------------------------------------
--- STEP B: hideBinds masks the whole bind prefix.
-------------------------------------------------------------------------
-
+-- `hideBinds` masks the whole bind prefix.
 hideBinds-cons : (k : ℕ) (E : Ent) (Ξ : Ctxᵗ)
   → scope (hideBinds (suc k)) (E ∷ Ξ) ≡ masked E ∷ scope (hideBinds k) Ξ
 hideBinds-cons zero    E Ξ = refl
@@ -137,17 +227,21 @@ repsOf-hideBinds : (k : ℕ) → repsOf (hideBinds k) ≡ []
 repsOf-hideBinds zero    = refl
 repsOf-hideBinds (suc k) = repsOf-hideBinds k
 
-repsOf-dualScope : (n : ℕ) (Θ : CtxMorph) → repsOf (dualScope n Θ) ≡ []
-repsOf-dualScope n []             = refl
-repsOf-dualScope n (bind A ∷ Θ)   = repsOf-dualScope n Θ
-repsOf-dualScope n (unlock X ∷ Θ) = repsOf-dualScope n Θ
-repsOf-dualScope n (lock X ∷ Θ)   = repsOf-dualScope n Θ
-
 repsOf-++ : (Θ₁ Θ₂ : CtxMorph) → repsOf (Θ₁ ++ Θ₂) ≡ repsOf Θ₁ ++ repsOf Θ₂
 repsOf-++ []              Θ₂ = refl
 repsOf-++ (bind A ∷ Θ₁)   Θ₂ = cong (_ ∷_) (repsOf-++ Θ₁ Θ₂)
 repsOf-++ (unlock X ∷ Θ₁) Θ₂ = repsOf-++ Θ₁ Θ₂
 repsOf-++ (lock X ∷ Θ₁)   Θ₂ = repsOf-++ Θ₁ Θ₂
+
+repsOf-dualScope : (n : ℕ) (Θ : CtxMorph) → repsOf (dualScope n Θ) ≡ []
+repsOf-dualScope n []             = refl
+repsOf-dualScope n (bind A ∷ Θ)   = repsOf-dualScope n Θ
+repsOf-dualScope n (unlock X ∷ Θ)
+  rewrite repsOf-++ (dualScope n Θ) (lock (n + X) ∷ [])
+        | repsOf-dualScope n Θ = refl
+repsOf-dualScope n (lock X ∷ Θ)
+  rewrite repsOf-++ (dualScope n Θ) (unlock (n + X) ∷ [])
+        | repsOf-dualScope n Θ = refl
 
 repsOf-dual : (Θ : CtxMorph) → repsOf (dual Θ) ≡ []
 repsOf-dual Θ rewrite repsOf-++ (hideBinds (numBinds Θ))
@@ -155,42 +249,27 @@ repsOf-dual Θ rewrite repsOf-++ (hideBinds (numBinds Θ))
                    | repsOf-hideBinds (numBinds Θ)
                    | repsOf-dualScope (numBinds Θ) Θ = refl
 
-------------------------------------------------------------------------
--- interior-dual : the honest RHS, PROVEN
-------------------------------------------------------------------------
+numBinds-dual : (Θ : CtxMorph) → numBinds (dual Θ) ≡ 0
+numBinds-dual Θ = cong length (repsOf-dual Θ)
 
-interior-dual : (Θ : CtxMorph) (Δ : Ctxᵗ)
+-- (†) THE CROSSING FRAME IS THE EXTERIOR, ONE BIND PREFIX IN.
+interior-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ
   → interior (dual Θ) (interior Θ Δ)
-      ≡ map masked (pushBinds (repsOf Θ) []) ++ unlockedScope Θ Δ
-interior-dual Θ Δ
+      ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ
+interior-dual Θ Δ mwΘ
   rewrite repsOf-dual Θ
-        | pushBinds-++ (repsOf Θ) (scope Θ Δ)
   = go
   where
   Ow : Ctxᵗ
   Ow = pushBinds (repsOf Θ) []
   lenOw : length Ow ≡ numBinds Θ
   lenOw = length-pushBinds (repsOf Θ)
-  -- interior (dual Θ) Ξ = scope (dual Θ) Ξ  (dual has no binds)
-  go : scope (dual Θ) (Ow ++ scope Θ Δ) ≡ map masked Ow ++ unlockedScope Θ Δ
+  go : scope (dual Θ) (pushBinds (repsOf Θ) (scope Θ Δ)) ≡ map masked Ow ++ Δ
   go rewrite scope-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) Θ)
-                      (Ow ++ scope Θ Δ)
-           | sym lenOw
-           | stepA Ow Θ Δ
-           | stepB Ow (unlockedScope Θ Δ) = refl
-
-------------------------------------------------------------------------
--- convCtx-dual : the conversion context is UNCHANGED by the dual
-------------------------------------------------------------------------
-
--- On an all-unlock morphism (like dualScope), unlockedScope = scope.
-unlockedScope-dualScope : (n : ℕ) (Θ : CtxMorph) (Ξ : Ctxᵗ)
-  → unlockedScope (dualScope n Θ) Ξ ≡ scope (dualScope n Θ) Ξ
-unlockedScope-dualScope n []             Ξ = refl
-unlockedScope-dualScope n (bind A ∷ Θ)   Ξ = unlockedScope-dualScope n Θ Ξ
-unlockedScope-dualScope n (unlock X ∷ Θ) Ξ = unlockedScope-dualScope n Θ Ξ
-unlockedScope-dualScope n (lock X ∷ Θ)   Ξ =
-  cong (unmask (n + X)) (unlockedScope-dualScope n Θ Ξ)
+                      (pushBinds (repsOf Θ) (scope Θ Δ))
+           | scope-dualScope (repsOf Θ) Θ mwΘ
+           | pushBinds-++ (repsOf Θ) Δ
+           | sym lenOw = stepB Ow Δ
 
 -- unlockedScope skips locks, so hideBinds is invisible to the
 -- conversion context.
@@ -202,25 +281,46 @@ convCtx-dual : (Θ : CtxMorph) (Δ : Ctxᵗ)
   → convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ
 convCtx-dual Θ Δ
   rewrite repsOf-dual Θ
-        | pushBinds-++ (repsOf Θ) (scope Θ Δ)
-        | pushBinds-++ (repsOf Θ) (unlockedScope Θ Δ)
-  = go
-  where
-  Ow : Ctxᵗ
-  Ow = pushBinds (repsOf Θ) []
-  lenOw : length Ow ≡ numBinds Θ
-  lenOw = length-pushBinds (repsOf Θ)
-  go : unlockedScope (dual Θ) (Ow ++ scope Θ Δ) ≡ Ow ++ unlockedScope Θ Δ
-  go rewrite unlockedScope-++ (hideBinds (numBinds Θ))
-                              (dualScope (numBinds Θ) Θ)
-                              (Ow ++ scope Θ Δ)
-           | unlockedScope-hideBinds (numBinds Θ)
-               (unlockedScope (dualScope (numBinds Θ) Θ)
-                              (Ow ++ scope Θ Δ))
-           | unlockedScope-dualScope (numBinds Θ) Θ (Ow ++ scope Θ Δ)
-           | sym lenOw
-           | stepA Ow Θ Δ = refl
+        | unlockedScope-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) Θ)
+                           (pushBinds (repsOf Θ) (scope Θ Δ))
+        | unlockedScope-hideBinds (numBinds Θ)
+            (unlockedScope (dualScope (numBinds Θ) Θ)
+                           (pushBinds (repsOf Θ) (scope Θ Δ))) =
+  unlockedScope-dualScope (repsOf Θ) Θ Δ
 
+------------------------------------------------------------------------
+-- §4  The crossing, and `preserve-Peel`
+------------------------------------------------------------------------
+
+-- binder slots of a pushBinds are visible
+pushBinds-∋tv-lt : (As : List Ty) (Ξ : Ctxᵗ) (j : ℕ)
+  → j < length As → pushBinds As Ξ ∋tv j
+pushBinds-∋tv-lt (A ∷ As) Ξ zero    (s≤s _)  = bind _ , ez , nameable-b
+pushBinds-∋tv-lt (A ∷ As) Ξ (suc j) (s≤s lt) with pushBinds-∋tv-lt As Ξ j lt
+... | E , d , v = _ , es d , renᵉ-Nameable v
+
+-- `hideBinds k` masks slots 0 … k-1, so it misses every slot ≥ k.
+hideBinds-∋tv : (k : ℕ) {Ξ : Ctxᵗ} {Y : ℕ} → k ≤ Y → Ξ ∋tv Y
+  → scope (hideBinds k) Ξ ∋tv Y
+hideBinds-∋tv zero    le tv = tv
+hideBinds-∋tv (suc k) le tv with hideBinds-∋tv k (≤-trans (n≤1+n k) le) tv
+... | E , d , v = E , updateAt-miss masked masked-comm (<⇒≢ le) d , v
+
+⊢ᵐ-hideBinds : (k : ℕ) (Ξ : Ctxᵗ)
+  → ((j : ℕ) → j < k → Ξ ∋tv j) → Ξ ⊢ᵐ hideBinds k
+⊢ᵐ-hideBinds zero    Ξ h = mw[]
+⊢ᵐ-hideBinds (suc k) Ξ h =
+  mw-l (hideBinds-∋tv k ≤-refl (h k ≤-refl))
+       (⊢ᵐ-hideBinds k Ξ (λ j lt → h j (m≤n⇒m≤1+n lt)))
+
+⊢ᵐ-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ → interior Θ Δ ⊢ᵐ dual Θ
+⊢ᵐ-dual Θ Δ mwΘ =
+  ⊢ᵐ-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) Θ)
+        (subst (λ Ξ → Ξ ⊢ᵐ hideBinds (numBinds Θ))
+               (sym (scope-dualScope (repsOf Θ) Θ mwΘ))
+               (⊢ᵐ-hideBinds (numBinds Θ) (pushBinds (repsOf Θ) Δ)
+                  (λ j lt → pushBinds-∋tv-lt (repsOf Θ) Δ j lt)))
+        (⊢ᵐ-dualScope (repsOf Θ) Θ mwΘ)
 
 ------------------------------------------------------------------------
 -- Renaming identity/composition and wkN = shiftBy
@@ -256,14 +356,6 @@ renᵗ-wkN (suc m) A =
         (cong ⇑ᵗ (renᵗ-wkN m A))
 
 ------------------------------------------------------------------------
--- ⊑ under a common prefix  (`Δ⊑unlockedScope` itself lives in strong.Terms)
-------------------------------------------------------------------------
-
-⊑-app : (Ξ : Ctxᵗ) {Δ Δ′ : Ctxᵗ} → Δ ⊑ Δ′ → (Ξ ++ Δ) ⊑ (Ξ ++ Δ′)
-⊑-app []       ls = ls
-⊑-app (E ∷ Ξ) ls = le∷ (⊑ᵉ-refl E) (⊑-app Ξ ls)
-
-------------------------------------------------------------------------
 -- Ren (wkN (length Ξ)) Δ (Ξ ++ Δ)
 ------------------------------------------------------------------------
 
@@ -280,87 +372,20 @@ Ren-wkN : (Ξ : Ctxᵗ) {Δ : Ctxᵗ} → Ren (wkN (length Ξ)) Δ (Ξ ++ Δ)
 Ren-wkN Ξ = mkRen (ren∋-wkN Ξ)
 
 ------------------------------------------------------------------------
--- interior Θ Δ ⊢ᵐ dual Θ
+-- The crossing argument retypes inside the dual — BY RENAMING ALONE
 ------------------------------------------------------------------------
 
-⊢ᵐ-++ : ∀ {Δ Θ₁ Θ₂} → Δ ⊢ᵐ Θ₁ → Δ ⊢ᵐ Θ₂ → Δ ⊢ᵐ (Θ₁ ++ Θ₂)
-⊢ᵐ-++ mw[]        b₂ = b₂
-⊢ᵐ-++ (mw-b w b)  b₂ = mw-b w (⊢ᵐ-++ b b₂)
-⊢ᵐ-++ (mw-l tv b) b₂ = mw-l tv (⊢ᵐ-++ b b₂)
-⊢ᵐ-++ (mw-u d b)  b₂ = mw-u d (⊢ᵐ-++ b b₂)
-
--- binder slots of a pushBinds are visible
-pushBinds-∋tv : (As : List Ty) (Ξ : Ctxᵗ) (j : ℕ)
-  → j < length As → pushBinds As Ξ ∋tv j
-pushBinds-∋tv (A ∷ As) Ξ zero    (s≤s _)  = bind _ , ez , nameable-b
-pushBinds-∋tv (A ∷ As) Ξ (suc j) (s≤s lt) with pushBinds-∋tv As Ξ j lt
-... | E , d , v = _ , es d , renᵉ-Nameable v
-
-⊢ᵐ-hideBinds : (k : ℕ) (Ξ : Ctxᵗ)
-  → ((j : ℕ) → j < k → Ξ ∋tv j) → Ξ ⊢ᵐ hideBinds k
-⊢ᵐ-hideBinds zero    Ξ h = mw[]
-⊢ᵐ-hideBinds (suc k) Ξ h =
-  mw-l (h k ≤-refl) (⊢ᵐ-hideBinds k Ξ (λ j lt → h j (m≤n⇒m≤1+n lt)))
-
--- existence of a slot survives an in-place update
-updateAt-∋e-ex : (f : Ent → Ent) (Y : ℕ) {Δ : Ctxᵗ} {X : ℕ} {E : Ent}
-  → Δ ∋e X , E → ∃[ E′ ] (updateAt f Y Δ ∋e X , E′)
-updateAt-∋e-ex f zero    ez        = _ , ez
-updateAt-∋e-ex f (suc Y) ez        = _ , ez
-updateAt-∋e-ex f zero    (es d)    = _ , es d
-updateAt-∋e-ex f (suc Y) (es d) with updateAt-∋e-ex f Y d
-... | E′ , d′ = _ , es d′
-
-scope-∋e-ex : (Θ : CtxMorph) {Δ : Ctxᵗ} {X : ℕ} {E : Ent}
-  → Δ ∋e X , E → ∃[ E′ ] (scope Θ Δ ∋e X , E′)
-scope-∋e-ex []             d = _ , d
-scope-∋e-ex (bind A ∷ Θ)   d = scope-∋e-ex Θ d
-scope-∋e-ex (unlock Y ∷ Θ) d with scope-∋e-ex Θ d
-... | E′ , d′ = updateAt-∋e-ex unmaskEnt Y d′
-scope-∋e-ex (lock Y ∷ Θ)   d with scope-∋e-ex Θ d
-... | E′ , d′ = updateAt-∋e-ex masked Y d′
-
--- a slot of pushBinds(As)Ξ past the binders
-pushBinds-∋e-tail : (As : List Ty) {Ξ : Ctxᵗ} {X : ℕ} {E : Ent}
-  → Ξ ∋e X , E → ∃[ E′ ] (pushBinds As Ξ ∋e (length As + X) , E′)
-pushBinds-∋e-tail As {Ξ} {X} d
-  rewrite pushBinds-++ As Ξ
-        | sym (length-pushBinds As) =
-  _ , ren∋-wkN (pushBinds As []) d
-
-⊢ᵐ-dualScope-self : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ
-  → interior Θ Δ ⊢ᵐ dualScope (numBinds Θ) Θ
-⊢ᵐ-dualScope-self Θ Δ mwΘ = go Θ mwΘ
-  where
-  go : (Ξ : CtxMorph) → Δ ⊢ᵐ Ξ
-     → interior Θ Δ ⊢ᵐ dualScope (numBinds Θ) Ξ
-  go []             _            = mw[]
-  go (bind A ∷ Ξ)   (mw-b _ b)   = go Ξ b
-  go (unlock X ∷ Ξ) (mw-u _ b)   = go Ξ b
-  go (lock X ∷ Ξ)   (mw-l (E , d , v) b)
-    with scope-∋e-ex Θ d
-  ... | E′ , d′ with pushBinds-∋e-tail (repsOf Θ) d′
-  ...   | E″ , d″ = mw-u d″ (go Ξ b)
-
-⊢ᵐ-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ
-  → interior Θ Δ ⊢ᵐ dual Θ
-⊢ᵐ-dual Θ Δ mwΘ =
-  ⊢ᵐ-++ (⊢ᵐ-hideBinds (numBinds Θ) (interior Θ Δ)
-            (λ j lt → pushBinds-∋tv (repsOf Θ) (scope Θ Δ) j lt))
-         (⊢ᵐ-dualScope-self Θ Δ mwΘ)
-
-------------------------------------------------------------------------
--- The crossing argument retypes inside the dual
-------------------------------------------------------------------------
-
-crossing : (Θ : CtxMorph) {Δ : Ctxᵗ} {W : Term} {A : Ty}
+-- THIS IS TIGHTNESS.  The argument was typed at Δ and is typed inside at
+-- Δ, shifted past the crossed boundary's (masked) binders.  Nothing is
+-- relaxed; no slot the exterior refuses becomes nameable.
+crossing : (Θ : CtxMorph) {Δ : Ctxᵗ} {W : Term} {A : Ty} → Δ ⊢ᵐ Θ
   → Δ ∣ [] ⊢ W ⦂ A
   → interior (dual Θ) (interior Θ Δ) ∣ []
       ⊢ wkᴹ (numBinds Θ) W ⦂ shiftBy (numBinds Θ) A
-crossing Θ {Δ} {W} {A} ⊢W =
+crossing Θ {Δ} {W} {A} mwΘ ⊢W =
   subst (λ C → C ∣ [] ⊢ wkᴹ (numBinds Θ) W ⦂ shiftBy (numBinds Θ) A)
-        (sym (interior-dual Θ Δ))
-        step3
+        (sym (interior-dual Θ Δ mwΘ))
+        step2
   where
   Ow : Ctxᵗ
   Ow = pushBinds (repsOf Θ) []
@@ -375,16 +400,10 @@ crossing Θ {Δ} {W} {A} ⊢W =
                 (renᵗ-wkN (length Ξ) A) step0
   step2 : (Ξ ++ Δ) ∣ [] ⊢ wkᴹ (numBinds Θ) W ⦂ shiftBy (numBinds Θ) A
   step2 rewrite sym len-eq = step1
-  step3 : (Ξ ++ unlockedScope Θ Δ) ∣ []
-            ⊢ wkᴹ (numBinds Θ) W ⦂ shiftBy (numBinds Θ) A
-  step3 = ⊢retag (⊑-app Ξ (Δ⊑unlockedScope Θ Δ)) step2
 
 ------------------------------------------------------------------------
 -- PeelCase, PROVEN for dual
 ------------------------------------------------------------------------
-
-numBinds-dual : (Θ : CtxMorph) → numBinds (dual Θ) ≡ 0
-numBinds-dual Θ = cong length (repsOf-dual Θ)
 
 preserve-Peel : PeelCase
 preserve-Peel {Δ} {V} {W} {Θ} {s} {t} {C} vV vW
@@ -404,4 +423,4 @@ preserve-Peel {Δ} {V} {W} {Θ} {s} {t} {C} vV vW
           (sym (convCtx-dual Θ Δ)) ⊢s
   ⊢argcross : interior Θ Δ ∣ [] ⊢ wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫ ⦂ _
   ⊢argcross = env (⊢ᵐ-dual Θ Δ mw)
-                  (crossing Θ ⊢W) ⊢s-tr wAᵈ
+                  (crossing Θ mw ⊢W) ⊢s-tr wAᵈ

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -412,11 +412,11 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
       conv
       (wf-[]ᵗ wB wA)
   where
-  refine : (abst ∷ Δ) ⊑ (bind A ∷ Δ)
-  refine = le∷ le-ab (⊑-refl Δ)
+  refine : (abst ∷ Δ) ⊑ᵃ (bind A ∷ Δ)
+  refine = la∷ la-ab (⊑ᵃ-refl Δ)
 
   conv : (bind A ∷ Δ) ⊢ reveal 0 B ∶ B ⇝ shiftBy 1 (B [ A ]ᵗ)
-  conv rewrite sym (subst-at-0 A B) = ⊢reveal ez (⊑-wf refine wB)
+  conv rewrite sym (subst-at-0 A B) = ⊢reveal ez (⊑-wf (⊑ᵃ→⊑ refine) wB)
 
 -- ── TYPEELR, AT ANY ∀ CONVERSION ───────────────────────────────────────
 -- Four moves, one per premise of the contractum's `env`:
@@ -470,7 +470,8 @@ preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
 ... | A₀ , B₀ , refl , eqE , ⊢s₀
   with conv-types-unique ⊢s ⊢s₀
 ... | refl , refl =
-  env (mw-b wA mw) int conv (wf-[]ᵗ (wf-∀⁻ wE) wA)
+  env (mw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) mw) int conv
+      (wf-[]ᵗ (wf-∀⁻ wE) wA)
   where
   A′ : Ty
   A′ = shiftBy (numBinds Θ) A
@@ -533,14 +534,14 @@ CancelRCase : Set
 CancelRCase = ∀ {Δ V Θ₁ Θ₂ X Y A C} → Value V → convCtx Θ₂ Δ ∋ Y := A
   → Δ ∣ [] ⊢ (V ⟪ Θ₁ , seal X ⟫) ⟪ Θ₂ , unseal Y ⟫ ⦂ C
   → Δ ∣ [] ⊢ (V ⟪ Θ₁ ⋉ Θ₂ , mkId (shiftBy (numBinds Θ₁) A) ⟫)
-               ⟪ dropLocks Θ₂ , mkId A ⟫ ⦂ C
+               ⟪ rewind Θ₂ , mkId A ⟫ ⦂ C
 
 -- IDPUSH, at the moved scope.  PROVEN in proof/MoveScope — the wall the
 -- old contractum ran into is gone with the frame move.
 IdPushCase : Set
 IdPushCase = ∀ {Δ V Θ₁ Θ₂ X Y A C} → Value V → convCtx Θ₂ Δ ∋ Y := A
   → Δ ∣ [] ⊢ (V ⟪ Θ₁ , id (` X) ⟫) ⟪ Θ₂ , unseal Y ⟫ ⦂ C
-  → Δ ∣ [] ⊢ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ dropLocks Θ₂ , mkId A ⟫ ⦂ C
+  → Δ ∣ [] ⊢ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ rewind Θ₂ , mkId A ⟫ ⦂ C
 
 -- THE TERM CONTEXT IS EMPTY, and it has to be.  Reduction carries no term
 -- context (`_⊢_-→_` indexes on the TYPE context alone) and TyBeta's

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -219,13 +219,12 @@ t-cod = conv-seal (es ez)
 -- §3  Peel — REPAIRED (refutation removed)
 ------------------------------------------------------------------------
 
--- The old §3 refuted the OLD `dual` (`unlock X ↦ lock (n+X)`), which
--- re-blocked a no-op `unlock` (`Θ = unlock 0` at an unmasked slot) and
--- failed same-slot cancellation.  strong.Reduction's repaired `dualScope`
--- DROPS the `unlock` case, so `dual (unlock 0 ∷ []) ≡ []` and the
--- crossing no longer masks the binder.  `PeelCase` is now PROVEN
--- (strong.proof.PeelDual.preserve-Peel), with `interior-dual`/`convCtx-dual`
--- true in general — so this refutation is gone.
+-- The old §3 refuted a `dual` that mapped `unlock X ↦ lock (n+X)` while
+-- `mw-u` still admitted a VACUOUS unlock: the restored lock then masked a
+-- slot the exterior left nameable.  Both halves are now repaired
+-- TOGETHER — `mw-u` demands `scope Θ Δ ∋lk X` and `dualScope` restores AND
+-- reverses — so `interior-dual` is an EXACT identity and `PeelCase` is
+-- PROVEN (strong.proof.PeelDual.preserve-Peel).  Refutation gone.
 
 ------------------------------------------------------------------------
 -- §4  IdPush pushes a rep across a lock
@@ -259,7 +258,7 @@ Vi : Term
 Vi = (($ 7) ⟪ [] , seal 1 ⟫) ⟪ unlock 1 ∷ [] , seal 0 ⟫
 
 ⊢Vi : Ξi ∣ [] ⊢ Vi ⦂ ` 0
-⊢Vi = env (mw-u (es ez) mw[])
+⊢Vi = env (mw-u (_ , es ez , locked nameable-b) mw[])
           (env mw[] ⊢$ (conv-seal (es ez))
                (wf-var (bind `ℕ , es ez , nameable-b)))
           (conv-seal ez)
@@ -280,15 +279,19 @@ Ri = (Vi ⟪ [] , id (` 0) ⟫) ⟪ Θi , unseal 0 ⟫
           (wf-var (bind `ℕ , es ez , nameable-b))
 
 -- THE STEP, AT THE MOVED SCOPE.  `Θ₂ = lock 1 ∷ []` is binder-free, so
--- the move is `[] ⋉ Θi ≡ lock 1 ∷ []` and `dropLocks Θi ≡ []`: the lock
--- goes INTO the inner boundary and the outer one keeps nothing.
-step-i : Δi ⊢ Ri -→ (Vi ⟪ [] ⋉ Θi , unseal 0 ⟫) ⟪ dropLocks Θi , mkId (` 1) ⟫
+-- the move is `[] ⋉ Θi ≡ lock 1 ∷ []`, and the outer frame is Θi with
+-- its own lock REWOUND — `rewind Θi ≡ unlock 1 ∷ lock 1 ∷ []`, whose net
+-- effect on Δi is nothing at all.
+step-i : Δi ⊢ Ri -→ (Vi ⟪ [] ⋉ Θi , unseal 0 ⟫) ⟪ rewind Θi , mkId (` 1) ⟫
 step-i = IdPush val-Vi ez
 
 _ : _≡_ {A = CtxMorph} ([] ⋉ Θi) (lock 1 ∷ [])
 _ = refl
 
-_ : _≡_ {A = CtxMorph} (dropLocks Θi) []
+_ : _≡_ {A = CtxMorph} (rewind Θi) (unlock 1 ∷ lock 1 ∷ [])
+_ = refl
+
+_ : interior (rewind Θi) Δi ≡ Δi
 _ = refl
 
 _ : mkId (` 1) ≡ id (` 1)
@@ -311,7 +314,8 @@ _ = refl
 -- slot 1 is live — and the contractum TYPES.  (`ProbeMove.agda` in the
 -- main tree checked this derivation by hand; here it is the theorem.)
 ⊢i-contractum :
-  Δi ∣ [] ⊢ (Vi ⟪ lock 1 ∷ [] , unseal 0 ⟫) ⟪ [] , id (` 1) ⟫ ⦂ ` 1
+  Δi ∣ [] ⊢ (Vi ⟪ lock 1 ∷ [] , unseal 0 ⟫)
+              ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫ ⦂ ` 1
 ⊢i-contractum = preserve-IdPush val-Vi ez ⊢Ri
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Supersedes #192 (whose commits it contains). Jeremy's tightness test showed Peel's dual dropped unlocks (an ill-typed argument crossed into a frame where its masked variable was visible). His hint — look for dropped information — led to three missing premises and one rule change, all machine-checked (cold gate green, seven Eval regressions unchanged):

* `Δ ⊢ᵐ Θ` is SEQUENTIAL: each lock/unlock is checked on the frame it acts on (`scope Θ′ Δ`); `mw-u` requires the slot MASKED (`∋lk`, one mask deep), so vacuous unlocks and double locks are refused.
* `mw-b` reads a bind's representation on `unlockedScope Θ Δ` (the tail's unmasks applied, its locks lifted) — the premise the scope move needed; a rep is read exactly where a conversion is read. This restates design law 4 (reps are never blocked by the frame's own locks; the "plain exterior" half provably could not stand — witness in proof/MwUObstruct).
* `dualScope` restores `unlock ↦ lock` and the list is reversed; (†) `interior (dual Θ) (interior Θ Δ) ≡ masked bind prefix ++ Δ` is EXACT; Peel's crossing is `⊢rename` alone.
* The scope move's outer frame is `rewind Θ₂ = dualScope 0 Θ₂ ++ Θ₂` (no entry dropped); both frame lemmas are equalities; `⊢retag` has one call site left (TyBeta's abst → bind), over `⊑ᵃ` (no le-mu).

proof/DualTightness: `¬⊢Contractum`, the vacuous unlock is `¬⊢ᵐ`, the locked-variable control still crosses. Two pinned contracta changed shape (§4 Tₘ, §12b) because the outer frame is now `rewind Θ₂`. Design.md and README updated. DECISIONS carries the rulings; the branch `dual-relock` (Δ-dependent dual) is the superseded alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)