### PR TITLE
Strong System F: module split — CtxMorph.agda (morphism, ⊢ᵐ, dual, scope move) and Conversion.agda §4 (minted conversions) out of Terms/Reduction

### DIFF
--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -49,6 +49,6 @@ open import strong.Eval
 -- THE WALL.  The search for an INVARIANT grounding the premise
 -- `interior Θ₂ Δ ⊢ᵗ A` — the one the old CancelR/IdPush contracta needed —
 -- is recorded in notes/DECISIONS.md (2026-09-06 entries).  The SCOPE MOVE
--- (strong.Reduction §2b) removes the need, so the development carries no
+-- (strong.CtxMorph §4) removes the need, so the development carries no
 -- module for it; the two surviving artifacts are proof/MaskFacts.mask-only
 -- and Examples §12/§12b.

--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -8,6 +8,7 @@ open import strong.Types
 open import strong.TypeSubst
 open import strong.Ctx
 open import strong.Conversion
+open import strong.CtxMorph
 open import strong.Terms
 open import strong.TermSubst
 open import strong.Reduction

--- a/SystemF/agda/strong/Conversion.agda
+++ b/SystemF/agda/strong/Conversion.agda
@@ -25,10 +25,11 @@ module strong.Conversion where
 -- below hypothesis-free.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Relation.Nullary using (yes; no)
 open import Data.List using (List; []; _∷_)
 open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; sym; cong; trans)
+  using (_≡_; refl; sym; cong; trans; cong₂; subst)
 
 open import strong.Types
   using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Var; Renameᵗ; renameᵗ; extᵗ; ⇑ᵗ)
@@ -124,7 +125,80 @@ mkId-⊢ (wf-⇒ wA wB) = conv-fun (mkId-⊢ wA) (mkId-⊢ wB)
 mkId-⊢ (wf-∀ wA)    = conv-all (mkId-⊢ wA)
 
 ------------------------------------------------------------------------
--- 4.  TRANSPORT I — type context renaming (the ⊢renameᵗ analogue)
+-- 4.  The canonical conversions at a slot
+------------------------------------------------------------------------
+
+-- Unseal every occurrence of X where the conversion runs covariantly /
+-- seal it back where it runs contravariantly.  These are what the
+-- boundary rules mint at a fresh binder; they are DERIVED FROM THE TYPE,
+-- not from stored knowledge, and they carry only the NAME X.
+mutual
+  reveal : ℕ → Ty → Conv
+  reveal X (` Y) with X ≟ℕ Y
+  ... | yes _ = unseal X
+  ... | no  _ = id (` Y)
+  reveal X `ℕ      = id `ℕ
+  reveal X `𝔹      = id `𝔹
+  reveal X (A ⇒ B) = conceal X A ↦ reveal X B
+  reveal X (`∀ A)  = `∀ (reveal (suc X) A)
+
+  conceal : ℕ → Ty → Conv
+  conceal X (` Y) with X ≟ℕ Y
+  ... | yes _ = seal X
+  ... | no  _ = id (` Y)
+  conceal X `ℕ      = id `ℕ
+  conceal X `𝔹      = id `𝔹
+  conceal X (A ⇒ B) = reveal X A ↦ conceal X B
+  conceal X (`∀ A)  = `∀ (conceal (suc X) A)
+
+-- THE SAME MINT, APPLIED TO A CONVERSION (the TyPeelR repair,
+-- notes/RuleRepairs-TyPeelR-CancelR.md §1).  When a boundary whose
+-- conversion is a `` `∀ `` is instantiated, the boundary's frame gains
+-- a BINDER at slot 0 — the slot the conversion's `` `∀ `` had left
+-- ABSTRACT.  Every leaf of the conversion that reads that slot is an
+-- identity (`id (` 0)`, because an abstract slot has no binder to seal or
+-- unseal at), and each such leaf must become the instantiation step:
+-- `unseal 0` where the conversion runs covariantly, `seal 0` where it
+-- runs contravariantly.  That is exactly `reveal`/`conceal`, pushed
+-- through a CONVERSION instead of through a type — and on an identity
+-- conversion the two agree (`instReveal-mkId` below).
+mutual
+  instReveal : ℕ → Conv → Conv
+  instReveal X (id A)     = reveal X A
+  instReveal X (seal Y)   = seal Y
+  instReveal X (unseal Y) = unseal Y
+  instReveal X (s ↦ t)    = instConceal X s ↦ instReveal X t
+  instReveal X (`∀ s)     = `∀ (instReveal (suc X) s)
+
+  instConceal : ℕ → Conv → Conv
+  instConceal X (id A)     = conceal X A
+  instConceal X (seal Y)   = seal Y
+  instConceal X (unseal Y) = unseal Y
+  instConceal X (s ↦ t)    = instReveal X s ↦ instConceal X t
+  instConceal X (`∀ s)     = `∀ (instConceal (suc X) s)
+
+-- TyBeta's minted conversion IS this operation at an identity
+-- conversion: the type version is the conversion version on `mkId`.  (So
+-- TyPeelR's reveal case really is TyBeta's mint, one ∀ inside.)
+mutual
+  instReveal-mkId : (X : ℕ) (B : Ty) → instReveal X (mkId B) ≡ reveal X B
+  instReveal-mkId X (` Y)   = refl
+  instReveal-mkId X `ℕ      = refl
+  instReveal-mkId X `𝔹      = refl
+  instReveal-mkId X (A ⇒ B) =
+    cong₂ _↦_ (instConceal-mkId X A) (instReveal-mkId X B)
+  instReveal-mkId X (`∀ A)  = cong `∀ (instReveal-mkId (suc X) A)
+
+  instConceal-mkId : (X : ℕ) (B : Ty) → instConceal X (mkId B) ≡ conceal X B
+  instConceal-mkId X (` Y)   = refl
+  instConceal-mkId X `ℕ      = refl
+  instConceal-mkId X `𝔹      = refl
+  instConceal-mkId X (A ⇒ B) =
+    cong₂ _↦_ (instReveal-mkId X A) (instConceal-mkId X B)
+  instConceal-mkId X (`∀ A)  = cong `∀ (instConceal-mkId (suc X) A)
+
+------------------------------------------------------------------------
+-- 5.  TRANSPORT I — type context renaming (the ⊢renameᵗ analogue)
 ------------------------------------------------------------------------
 
 -- A context-indexed conversion typing moves along ANY type context renaming, with NO
@@ -145,7 +219,7 @@ conv-ren r (conv-fun s t)    = conv-fun (conv-ren r s) (conv-ren r t)
 conv-ren r (conv-all s)      = conv-all (conv-ren (ren-ext r) s)
 
 ------------------------------------------------------------------------
--- 5.  TRANSPORT II — knowledge refinement (the ⊢retag analogue)
+-- 6.  TRANSPORT II — knowledge refinement (the ⊢retag analogue)
 ------------------------------------------------------------------------
 
 -- Knowledge refinement preserves conversion typing with the SOURCE AND
@@ -162,7 +236,7 @@ conv-⊑ ls (conv-fun s t)   = conv-fun (conv-⊑ ls s) (conv-⊑ ls t)
 conv-⊑ ls (conv-all s)     = conv-all (conv-⊑ (le∷ le-aa ls) s)
 
 ------------------------------------------------------------------------
--- 6.  Conversion inversions
+-- 7.  Conversion inversions
 ------------------------------------------------------------------------
 
 -- Every rep a conversion mentions IS the binder's rep — there is no second
@@ -205,7 +279,7 @@ conv-all-inv : ∀ {s A B} → Δ ⊢ `∀ s ∶ A ⇝ B
 conv-all-inv (conv-all ⊢s) = _ , _ , refl , refl , ⊢s
 
 ------------------------------------------------------------------------
--- 7.  THE TYPES ARE A FUNCTION OF THE CONVERSION AND THE TYPE CONTEXT
+-- 8.  THE TYPES ARE A FUNCTION OF THE CONVERSION AND THE TYPE CONTEXT
 ------------------------------------------------------------------------
 
 -- A conversion determines BOTH its types: `id` carries its own, a

--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -622,16 +622,16 @@ mask-∋lk (E , d , v) =
 ------------------------------------------------------------------------
 
 -- The `bind` entries of a boundary, pushed on as ordinary de Bruijn
--- binders.  The head of the list is interior slot 0; a rep is a type over
--- the PLAIN exterior, so it is lifted past the binders INSIDE it and past
--- nothing else (SIMULTANEITY: boundary entries never interfere).
+-- binders.  The head of the list is interior slot 0; a rep uses the
+-- exterior's slots, so it is lifted past the binders INSIDE it and past
+-- nothing else — a bind is never blocked by its own frame's locks, and
+-- sibling binds never interfere.
 pushBinds : List Ty → Ctxᵗ → Ctxᵗ
 pushBinds []       Δ = Δ
 pushBinds (A ∷ As) Δ = bind (shiftBy (length As) A) ∷ pushBinds As Δ
 
--- SIMULTANEITY, as a well-formedness fact: a type over the plain exterior
--- is a type inside the bind prefix, lifted past exactly the binders in
--- that prefix.
+-- As a well-formedness fact: a type over the exterior is a type inside
+-- the bind prefix, lifted past exactly the binders in that prefix.
 wf-shiftBy-pushBinds : (As : List Ty) → Δ ⊢ᵗ A
   → pushBinds As Δ ⊢ᵗ shiftBy (length As) A
 wf-shiftBy-pushBinds []       w = w

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -17,11 +17,14 @@ module strong.CtxMorph where
 --
 -- This module defines the morphism, the type contexts it induces
 -- (`scope`, `unlockedScope`, `interior`, `convCtx`), their refinement
--- transports, and the well-formedness judgement `Δ ⊢ᵐ Θ`.  Terms and
--- typing are in strong.Terms, which re-exports this module.
+-- transports, the well-formedness judgement `Δ ⊢ᵐ Θ`, and the two
+-- derived morphisms the reduction rules use: the DUAL of a crossed
+-- boundary (`dual`, for Peel) and the SCOPE MOVE (`rewind`, `_⋉_`, for
+-- IdPush and CancelR).  Terms and typing are in strong.Terms, which
+-- re-exports this module.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
-open import Data.List using (List; []; _∷_; map; length)
+open import Data.List using (List; []; _∷_; _++_; map; length)
 open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; sym; cong; cong₂; trans; subst)
@@ -166,7 +169,7 @@ interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ �
 --             the frame's own locks — it is read where the CONVERSION is
 --             read, outside the masking the boundary itself performs —
 --             and it may name what the tail unlocked, which is what makes
---             the scope move (`_⋉_`, strong.Reduction) well formed.
+--             the scope move (`_⋉_`, §4 below) well formed.
 --
 -- Note the distinction the mask discipline forces: `unlock X`/`lock X`
 -- NAME a masked index — that is an ENTRY, not a type — while `Δ ⊢ᵗ ` X`
@@ -194,3 +197,110 @@ data _⊢ᵐ_ : Ctxᵗ → CtxMorph → Set where
   mw-l (⊑-tv (⊑-scope Θ (⊑ᵃ→⊑ ls)) tv) (⊢ᵐ-⊑ᵃ ls b)
 ⊢ᵐ-⊑ᵃ {Θ = unlock X ∷ Θ} ls (mw-u lk b) =
   mw-u (⊑ᵃ-lk (⊑ᵃ-scope Θ ls) lk) (⊢ᵐ-⊑ᵃ ls b)
+
+------------------------------------------------------------------------
+-- 3.  The dual of a crossed boundary
+------------------------------------------------------------------------
+
+-- THE DUAL, in full.  It mints ONLY name-carrying entries: a `lock` for each
+-- of the crossed boundary's binders (the argument may not see them) and an
+-- `unlock` for each of its conceals (the argument came from outside, where they
+-- were nameable).  Nothing is copied, nothing is guarded, nothing is
+-- demoted; the old design's `entᴳ` has no analogue.
+hideBinds : ℕ → CtxMorph
+hideBinds zero    = []
+hideBinds (suc k) = lock k ∷ hideBinds k
+
+-- THE DUAL IS AN INVERSE, AND AN INVERSE RUNS BACKWARDS (2026-09-06).
+--
+-- The mini-core DROPPED the `unlock` case, on the reading that an
+-- `unlock` "claims nothing".  It claims plenty: it UNMASKS, and a dual
+-- that does not re-mask hands the crossing argument a frame STRICTLY MORE
+-- NAMEABLE than the exterior — `Peel` GAINS SCOPE, machine-checked in
+-- proof/DualTightness.agda.  So `unlock X ↦ lock (n + X)`, and the
+-- restoring `lock` is sound exactly because `mw-u` (strong.Terms) refuses
+-- a VACUOUS unlock: `mask ∘ unmask` is the identity at a LOCKED slot
+-- (`mask-unmask`, strong.Ctx) and nowhere else.
+--
+-- AND THE LIST IS REVERSED.  `scope` applies its list HEAD-LAST, so
+-- undoing it runs the entries BACK TO FRONT; a same-order dual is not an
+-- inverse at a frame that toggles one slot twice (`Θ = ↥X ∷ ↧X ∷ []`,
+-- which the judgement admits).  With both repairs the frame identity is
+-- EXACT (proof/PeelDual, `interior-dual`): the crossing argument's frame
+-- is the exterior itself, one bind prefix in, and it crosses by
+-- `⊢rename` alone — no `⊢retag`, no `le-mu`.
+dualScope : ℕ → CtxMorph → CtxMorph
+dualScope n []             = []
+dualScope n (bind A ∷ Θ)   = dualScope n Θ
+dualScope n (unlock X ∷ Θ) = dualScope n Θ ++ (lock   (n + X) ∷ [])
+dualScope n (lock X ∷ Θ)   = dualScope n Θ ++ (unlock (n + X) ∷ [])
+
+dual : CtxMorph → CtxMorph
+dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
+
+-- (The old Cancel residue `repsOf→bind` — a frame that rebinds Θ₂'s binders
+-- and nothing else — is GONE with the rule that wrote it: the repaired
+-- CancelR keeps both frames and mints none.)
+
+------------------------------------------------------------------------
+-- 4.  THE SCOPE MOVE — the outer frame's locks go INTO the inner one
+------------------------------------------------------------------------
+
+-- JEREMY'S MOVE (2026-09-06).  CancelR and IdPush both SWAP the two
+-- conversions: the inner boundary stops presenting the abstract name
+-- `` ` Y `` and starts presenting Y's REP.  A rep is read on the outer
+-- boundary's CONVERSION CONTEXT (its locks lifted), so it is nameable
+-- there and NOT, in general, inside the outer boundary's own locks — that
+-- was the wall (the old proof/PreserveObstruct §4).
+--
+-- The repair is not a side condition but a FRAME MOVE: the outer frame's
+-- whole SCOPE travels into the inner frame's TAIL, where `scope` applies
+-- it FIRST — exactly where it applied before — and what stays outside is
+-- the frame with its own scope REWOUND (`rewind Θ₂`), whose net effect on
+-- the exterior is its BIND PREFIX alone.  The rep is then presented
+-- OUTSIDE the locks, where it is nameable, and the locks still stand
+-- between the value and the world.
+--
+-- WHY THE UNLOCKS TRAVEL TOO.  `scope` applies its list HEAD-LAST, so
+-- moving only the LOCKS past a same-slot `unlock` reorders a mask/unmask
+-- pair, and the value's frame is then not refined but CORRUPTED — a slot
+-- it may name is masked in the contractum and was not in the redex
+-- (`¬frame-locksOnly`, proof/MoveScope §4b, at the ⊢ᵐ-legal
+-- `Θ₂ = unlock 0 ∷ lock 0 ∷ []`).  Moving the WHOLE scope keeps the
+-- order, and then the value's frame is preserved ON THE NOSE: the two
+-- frame lemmas are EQUALITIES, no `⊢retag` appears in either case, and
+-- there is no premise about Θ₂'s shape for Progress to supply.
+
+-- The outer frame's scope entries, lifted past its own binders.
+scopeOf : ℕ → CtxMorph → CtxMorph
+scopeOf n []             = []
+scopeOf n (bind A ∷ Θ)   = scopeOf n Θ
+scopeOf n (unlock X ∷ Θ) = unlock (n + X) ∷ scopeOf n Θ
+scopeOf n (lock X ∷ Θ)   = lock (n + X) ∷ scopeOf n Θ
+
+-- WHAT IS LEFT OF THE OUTER FRAME: the frame with its OWN SCOPE REWOUND.
+--
+-- `rewind Θ` is Θ with its inverse scope run on top, so its net effect on
+-- the exterior is the BIND PREFIX ALONE:
+--
+--     scope    (rewind Θ) Δ ≡ Δ                       (given Δ ⊢ᵐ Θ)
+--     interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ
+--
+-- which is what makes the moved scope reproduce the redex's frame ON THE
+-- NOSE (`interior-⋉-rewind`, proof/MoveScope) — no `⊢retag` and no
+-- `le-mu` anywhere in the two cases.
+--
+-- IT IS NOT `bindsOnly Θ`, AND THAT IS THE POINT.  Simply DELETING Θ's
+-- scope has the same effect on the type context but loses the frame's own
+-- `⊢ᵐ`: Θ's bind reps are read on `unlockedScope Θ′ Δ` (strong.Terms,
+-- `mw-b`) and a rep naming a slot Θ's tail UNLOCKED is not well formed on
+-- the plain Δ.  Keeping the entries and rewinding them keeps every rep
+-- exactly where it was read.
+rewind : CtxMorph → CtxMorph
+rewind Θ = dualScope 0 Θ ++ Θ
+
+-- The inner frame, with the outer frame's scope moved in at its TAIL.
+-- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁`: the move carries no binder.
+infixl 5 _⋉_
+_⋉_ : CtxMorph → CtxMorph → CtxMorph
+Θ₁ ⋉ Θ₂ = Θ₁ ++ scopeOf (numBinds Θ₂) Θ₂

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -163,11 +163,10 @@ interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ �
 --             `lock` needs (`mask-unmask`, strong.Ctx).
 --   bind A    A is a type over `unlockedScope Θ′ Δ` — the tail's UNMASKS
 --             applied and its LOCKS lifted.  A rep is never blocked by
---             the frame's own locks (that is the simultaneity law: a rep
---             is read where the CONVERSION is read, outside the masking
---             the boundary itself performs), and it may name what the
---             tail unlocked — which is what makes the scope move
---             (`_⋉_`, strong.Reduction) well formed.
+--             the frame's own locks — it is read where the CONVERSION is
+--             read, outside the masking the boundary itself performs —
+--             and it may name what the tail unlocked, which is what makes
+--             the scope move (`_⋉_`, strong.Reduction) well formed.
 --
 -- Note the distinction the mask discipline forces: `unlock X`/`lock X`
 -- NAME a masked index — that is an ENTRY, not a type — while `Δ ⊢ᵗ ` X`

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -1,0 +1,197 @@
+module strong.CtxMorph where
+
+-- Strong System F — the BOUNDARY'S CONTEXT MORPHISM and its well-formedness.
+--
+-- A boundary is  M ⟪ Θ , c ⟫  (strong.Terms) with ONE frame change:
+--
+--   Θ : CtxMorph   the context morphism, rep-free except for binders
+--        bind A   BINDS a fresh interior slot; A is its representation, read
+--                on `unlockedScope Θ′ Δ` (the tail's unmasks applied, its
+--                locks lifted — where the conversion is read).  The only
+--                rep-carrying form; born once, bound once.
+--        lock X   MASKS exterior slot X: the interior may not NAME it.  The
+--                entry is RETAINED on the type context — nothing is dropped
+--                and nothing is re-spelled, so there is no demotion.
+--        unlock X UNMASKS exterior slot X; it claims nothing but that X IS
+--                masked where it acts (no vacuous unlocks).
+--
+-- This module defines the morphism, the type contexts it induces
+-- (`scope`, `unlockedScope`, `interior`, `convCtx`), their refinement
+-- transports, and the well-formedness judgement `Δ ⊢ᵐ Θ`.  Terms and
+-- typing are in strong.Terms, which re-exports this module.
+
+open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.List using (List; []; _∷_; map; length)
+open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong; cong₂; trans; subst)
+
+open import strong.Types
+  using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Var; Renameᵗ; renameᵗ; extᵗ; ⇑ᵗ; _[_]ᵗ)
+open import strong.Ctx
+
+private
+  variable
+    Δ Δ′ : Ctxᵗ
+    A B : Ty
+    X Y : ℕ
+
+------------------------------------------------------------------------
+-- 1.  The boundary context morphism
+------------------------------------------------------------------------
+
+data MorphEnt : Set where
+  bind : Ty → MorphEnt      -- BINDS a fresh slot at rep A (A over the exterior)
+  unlock : ℕ → MorphEnt       -- unmask exterior slot X   (name only)
+  lock : ℕ → MorphEnt       -- mask   exterior slot X   (name only)
+
+CtxMorph : Set
+CtxMorph = List MorphEnt
+
+repsOf : CtxMorph → List Ty
+repsOf []             = []
+repsOf (bind A ∷ Θ)   = A ∷ repsOf Θ
+repsOf (unlock X ∷ Θ) = repsOf Θ
+repsOf (lock X ∷ Θ)   = repsOf Θ
+
+-- `numBinds` is the boundary's FRAME EXTENSION: the number of binders it
+-- adds.  It is the only surviving list arithmetic; cmax/dropN have no
+-- analogue, because conceal masks in place.
+numBinds : CtxMorph → ℕ
+numBinds Θ = length (repsOf Θ)
+
+-- The masks (`lock`) and unmasks (`unlock`), applied in place.
+scope : CtxMorph → Ctxᵗ → Ctxᵗ
+scope []             Δ = Δ
+scope (bind A ∷ Θ)   Δ = scope Θ Δ
+scope (unlock X ∷ Θ) Δ = unmask X (scope Θ Δ)
+scope (lock X ∷ Θ)   Δ = mask X (scope Θ Δ)
+
+-- The CONVERSION CONTEXT's slots: like `scope` but WITHOUT the conceal
+-- masks, so a `seal X` can resolve X at its binder.  This is
+-- binder-syntactic lookup: the licence is read on the type context that
+-- encloses the boundary, never inside it.
+unlockedScope : CtxMorph → Ctxᵗ → Ctxᵗ
+unlockedScope []             Δ = Δ
+unlockedScope (bind A ∷ Θ)   Δ = unlockedScope Θ Δ
+unlockedScope (unlock X ∷ Θ) Δ = unmask X (unlockedScope Θ Δ)
+unlockedScope (lock X ∷ Θ)   Δ = unlockedScope Θ Δ
+
+-- What replaces `intOf`: the same slot list, the interior mask, and the
+-- binder extension.  Nothing is dropped and no rep is recomputed.
+interior : CtxMorph → Ctxᵗ → Ctxᵗ
+interior Θ Δ = pushBinds (repsOf Θ) (scope Θ Δ)
+
+convCtx : CtxMorph → Ctxᵗ → Ctxᵗ
+convCtx Θ Δ = pushBinds (repsOf Θ) (unlockedScope Θ Δ)
+
+-- The interior type context is the conversion context with Θ's bind
+-- masks on, so anything well formed inside is well formed on the
+-- conversion context.
+scope⊑unlockedScope : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → scope Θ Δ ⊑ unlockedScope Θ Δ
+scope⊑unlockedScope []             Δ = ⊑-refl Δ
+scope⊑unlockedScope (bind A ∷ Θ)   Δ = scope⊑unlockedScope Θ Δ
+scope⊑unlockedScope (unlock X ∷ Θ) Δ =
+  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono
+    (scope⊑unlockedScope Θ Δ)
+scope⊑unlockedScope (lock X ∷ Θ)   Δ = mask-⊑ X (scope⊑unlockedScope Θ Δ)
+
+interior⊑convCtx : (Θ : CtxMorph) (Δ : Ctxᵗ) → interior Θ Δ ⊑ convCtx Θ Δ
+interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ Δ)
+
+-- The CONVERSION CONTEXT only ever ADDS nameability to the plain
+-- exterior: `unlockedScope` skips the binds and the locks, and an
+-- `unlock` merely restores.  (`scope` would not do — masking is what a
+-- lock is for.)
+Δ⊑unlockedScope : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊑ unlockedScope Θ Δ
+Δ⊑unlockedScope []             Δ = ⊑-refl Δ
+Δ⊑unlockedScope (bind A ∷ Θ)   Δ = Δ⊑unlockedScope Θ Δ
+Δ⊑unlockedScope (unlock X ∷ Θ) Δ =
+  ⊑-trans (Δ⊑unlockedScope Θ Δ) (unmask-⊑ X (unlockedScope Θ Δ))
+Δ⊑unlockedScope (lock X ∷ Θ)   Δ = Δ⊑unlockedScope Θ Δ
+
+⊑-scope : (Θ : CtxMorph) → Δ ⊑ Δ′ → scope Θ Δ ⊑ scope Θ Δ′
+⊑-scope []             ls = ls
+⊑-scope (bind A ∷ Θ)   ls = ⊑-scope Θ ls
+⊑-scope (unlock X ∷ Θ) ls =
+  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-scope Θ ls)
+⊑-scope (lock X ∷ Θ)   ls =
+  ⊑-updateAt masked masked-comm masked-mono (⊑-scope Θ ls)
+
+⊑-unlockedScope : (Θ : CtxMorph) → Δ ⊑ Δ′
+  → unlockedScope Θ Δ ⊑ unlockedScope Θ Δ′
+⊑-unlockedScope []             ls = ls
+⊑-unlockedScope (bind A ∷ Θ)   ls = ⊑-unlockedScope Θ ls
+⊑-unlockedScope (unlock X ∷ Θ) ls =
+  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-unlockedScope Θ ls)
+⊑-unlockedScope (lock X ∷ Θ)   ls = ⊑-unlockedScope Θ ls
+
+⊑-interior : (Θ : CtxMorph) → Δ ⊑ Δ′ → interior Θ Δ ⊑ interior Θ Δ′
+⊑-interior Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-scope Θ ls)
+
+-- … and the same three transports for the LOCK-PRESERVING refinement,
+-- the one a TERM travels along.
+⊑ᵃ-scope : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → scope Θ Δ ⊑ᵃ scope Θ Δ′
+⊑ᵃ-scope []             ls = ls
+⊑ᵃ-scope (bind A ∷ Θ)   ls = ⊑ᵃ-scope Θ ls
+⊑ᵃ-scope (unlock X ∷ Θ) ls =
+  ⊑ᵃ-updateAt unmaskEnt unmaskEnt-monoᵃ (⊑ᵃ-scope Θ ls)
+⊑ᵃ-scope (lock X ∷ Θ)   ls =
+  ⊑ᵃ-updateAt masked masked-monoᵃ (⊑ᵃ-scope Θ ls)
+
+⊑ᵃ-interior : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → interior Θ Δ ⊑ᵃ interior Θ Δ′
+⊑ᵃ-interior Θ ls = ⊑ᵃ-pushBinds (repsOf Θ) (⊑ᵃ-scope Θ ls)
+
+⊑-convCtx : (Θ : CtxMorph) → Δ ⊑ Δ′ → convCtx Θ Δ ⊑ convCtx Θ Δ′
+⊑-convCtx Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-unlockedScope Θ ls)
+
+------------------------------------------------------------------------
+-- 2.  Boundary well-formedness
+------------------------------------------------------------------------
+
+-- EVERY PREMISE IS READ ON THE FRAME THE ENTRY ACTS ON — the judgement is
+-- SEQUENTIAL, in the order `scope` applies the list (head-LAST).  For the
+-- tail Θ′ of the entry:
+--
+--   lock X    X is NAMEABLE in `scope Θ′ Δ`  (you may only mask what is
+--             visible: no double masking, so `Locked` is one mask deep)
+--   unlock X  X is LOCKED   in `scope Θ′ Δ`  (`Δ ∋lk X`: masked over a
+--             nameable entry).  A VACUOUS UNLOCK — `↥X` at a slot the
+--             frame leaves visible — IS REFUSED; it is the premise the
+--             judgement used to drop, and the one the dual's restoring
+--             `lock` needs (`mask-unmask`, strong.Ctx).
+--   bind A    A is a type over `unlockedScope Θ′ Δ` — the tail's UNMASKS
+--             applied and its LOCKS lifted.  A rep is never blocked by
+--             the frame's own locks (that is the simultaneity law: a rep
+--             is read where the CONVERSION is read, outside the masking
+--             the boundary itself performs), and it may name what the
+--             tail unlocked — which is what makes the scope move
+--             (`_⋉_`, strong.Reduction) well formed.
+--
+-- Note the distinction the mask discipline forces: `unlock X`/`lock X`
+-- NAME a masked index — that is an ENTRY, not a type — while `Δ ⊢ᵗ ` X`
+-- at a masked slot is refused.  Tightness is about USE in a type, not
+-- about mentioning the index in the context morphism.
+--
+-- `Δ ⊢ᵐ Θ` — the context morphism Θ is WELL FORMED over Δ.  An infix
+-- judgement in the family of `Δ ⊢ᵗ A` (strong.Ctx) and `Δ ⊢ c ∶ A ⇝ B`
+-- (strong.Conversion).
+infix 4 _⊢ᵐ_
+data _⊢ᵐ_ : Ctxᵗ → CtxMorph → Set where
+  mw[] : Δ ⊢ᵐ []
+  mw-b : ∀ {A Θ} → unlockedScope Θ Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
+  mw-l : ∀ {X Θ} → scope Θ Δ ∋tv X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
+  mw-u : ∀ {X Θ} → scope Θ Δ ∋lk X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
+
+-- THE TERM TRANSPORT IS `_⊑ᵃ_`, NOT `_⊑_`.  An `unlock X` CLAIMS that X
+-- is locked, and `le-mu` — the clause that re-exposes a concealed slot —
+-- destroys the claim; `_⊑ᵃ_` (strong.Ctx §4b) is `_⊑_` without it.
+⊢ᵐ-⊑ᵃ : ∀ {Θ} → Δ ⊑ᵃ Δ′ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ Θ
+⊢ᵐ-⊑ᵃ {Θ = []}           ls mw[]        = mw[]
+⊢ᵐ-⊑ᵃ {Θ = bind A ∷ Θ}   ls (mw-b w b)  =
+  mw-b (⊑-wf (⊑-unlockedScope Θ (⊑ᵃ→⊑ ls)) w) (⊢ᵐ-⊑ᵃ ls b)
+⊢ᵐ-⊑ᵃ {Θ = lock X ∷ Θ}   ls (mw-l tv b) =
+  mw-l (⊑-tv (⊑-scope Θ (⊑ᵃ→⊑ ls)) tv) (⊢ᵐ-⊑ᵃ ls b)
+⊢ᵐ-⊑ᵃ {Θ = unlock X ∷ Θ} ls (mw-u lk b) =
+  mw-u (⊑ᵃ-lk (⊑ᵃ-scope Θ ls) lk) (⊢ᵐ-⊑ᵃ ls b)

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -181,7 +181,7 @@ makes exactly one frame change, described by `Θ`, and carries exactly one
 conversion `c`.  Its interior `M` is **term-closed**: `env` types it at
 the empty term context.
 
-### Context morphisms (`strong.Terms`)
+### Context morphisms (`strong.CtxMorph`)
 
 `Θ : CtxMorph` is a list of **morphism entries**, Jeremy's *context
 morphism*: it maps the type context outside the boundary to the type
@@ -199,7 +199,7 @@ read in the **exterior**, never through `Θ`'s other entries
 (§8, simultaneity).  `lock` and `unlock` carry a name and nothing else.
 The list is applied **head-last**: in `↥Y , ↓Y` the `↓Y` acts first.
 
-Two derived numbers, both in `strong.Terms`:
+Two derived numbers, both in `strong.CtxMorph`:
 
     repsOf   : CtxMorph → List Ty     -- the bind entries' reps, in order
     numBinds : CtxMorph → ℕ            -- numBinds Θ = length (repsOf Θ)
@@ -448,7 +448,7 @@ representations on as binders*, `numBinds` = *number of binds*, `shiftBy` =
 *shift past n binders*.
 
 
-## 4. Typing (`strong.Terms`, `strong.Conversion`)
+## 4. Typing (`strong.CtxMorph`, `strong.Terms`, `strong.Conversion`)
 
 ### 4.1 Well-formed types
 

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -645,7 +645,7 @@ question the value can answer now (reveal a binder's representation, or
 drop a base identity over a numeral).
 
 
-## 6. Reduction (`strong.Reduction`)
+## 6. Reduction (`strong.Reduction`; the minted conversions `reveal`/`conceal`/`instReveal`/`instConceal` are in `strong.Conversion` §4)
 
 The relation is `Δ ⊢ M -→ M′`, indexed by the type context only — there
 is no term context, and there cannot be one (§7).  `Δ ⊢ M -→* M′` is its

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -370,8 +370,8 @@ run-Tᵣ = push-Tᵣ
 
 -- ── Tₘ (IdLayerProbe §4b): Θ₂ re-exposes a masked slot (`unlock 0`) and the
 -- id-layer masks it again (`lock 0`).  The merged context morphism computed both
--- type contexts correctly and yet the SIMULTANEOUS `_⊢ᵐ_` refused it,
--- because it checked every entry against the PLAIN exterior.  The
+-- type contexts correctly and yet the FORMER, simultaneous `_⊢ᵐ_` refused
+-- it, because it checked every entry against the plain exterior.  The
 -- SEQUENTIAL judgement checks each entry on the frame it acts on, and
 -- accepts it.  Again: IdPush merges nothing.
 
@@ -2456,8 +2456,9 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ bind `ℕ ∷ [] , id `ℕ ↦ unseal 0 
 --
 -- E₃ is the old design's fourth line, and E₄ is where the two designs
 -- part: `↑Z:=Y , ↓X` is a boundary that MASKS X and BINDS a fresh Z at
--- the rep Y — no type is pushed into the sealed body, and Y is read in
--- the plain exterior, where it is in scope.
+-- the rep Y — no type is pushed into the sealed body, and Y is read at
+-- the boundary's exterior (there are no unlocks, so that is
+-- `unlockedScope Θ Δ`), where it is in scope.
 
 -- ── the source ─────────────────────────────────────────────────────────
 

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -57,6 +57,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.TermSubst
 open import strong.Reduction
 

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -1846,7 +1846,7 @@ _ = refl
 ------------------------------------------------------------------------
 
 -- §12 asked whether the wall CONFIGURATION is reachable.  The scope move
--- (strong.Reduction §2b, 2026-09-06) makes the question moot: the
+-- (strong.CtxMorph §4, 2026-09-06) makes the question moot: the
 -- configuration is fine.  Here is the hand-built witness itself
 -- (proof/PreserveObstruct §4) — `Δi = X := Y , Y := ℕ`, where X's rep
 -- NAMES Y, under an outer boundary that LOCKS Y — taking its step.

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -43,7 +43,7 @@ module strong.Preservation where
 --   IDPUSH    PROVEN (proof/MoveScope.preserve-IdPush).
 --
 -- WHAT CLOSED THE LAST TWO: THE SCOPE MOVE (Jeremy, 2026-09-06;
--- strong.Reduction §2b).  Both rules swap the two conversions, so the
+-- strong.CtxMorph §4).  Both rules swap the two conversions, so the
 -- inner boundary stops presenting the abstract name and starts presenting
 -- the BINDER'S REP — and `env`'s last premise then asks for that rep to be
 -- well formed INSIDE the outer frame, where its own `lock`s may have
@@ -76,7 +76,7 @@ open import strong.TermSubst using (_[_]ᵐ; wkᴹ; preserve-Beta)
 open import strong.Reduction
   using (_⊢_-→_; _⊢_-→*_; reveal; instReveal)
 
-open import strong.Reduction using (_⋉_; rewind)
+open import strong.CtxMorph using (_⋉_; rewind)
 open import strong.proof.Preserve
   using (preserve-TyBeta; preserve-Drop$; preserve-TyPeelR;
          ⊢ᵗ-of; CtxWf-[])

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -70,11 +70,10 @@ open import strong.Types
 open import strong.Ctx
   using (Ctxᵗ; Ent; abst; bind; masked; Base; _⊢ᵗ_; _∋_:=_; shiftBy)
 open import strong.Conversion
-  using (Conv; id; seal; unseal; _↦_; `∀; mkId; _⊢_∶_⇝_)
+  using (Conv; id; seal; unseal; _↦_; `∀; mkId; _⊢_∶_⇝_; reveal; instReveal)
 open import strong.Terms
 open import strong.TermSubst using (_[_]ᵐ; wkᴹ; preserve-Beta)
-open import strong.Reduction
-  using (_⊢_-→_; _⊢_-→*_; reveal; instReveal)
+open import strong.Reduction using (_⊢_-→_; _⊢_-→*_)
 
 open import strong.CtxMorph using (_⋉_; rewind)
 open import strong.proof.Preserve

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -75,7 +75,7 @@ open import strong.Terms
 open import strong.TermSubst using (_[_]ᵐ; wkᴹ; preserve-Beta)
 open import strong.Reduction using (_⊢_-→_; _⊢_-→*_)
 
-open import strong.CtxMorph using (_⋉_; rewind)
+open import strong.CtxMorph
 open import strong.proof.Preserve
   using (preserve-TyBeta; preserve-Drop$; preserve-TyPeelR;
          ⊢ᵗ-of; CtxWf-[])

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -58,7 +58,8 @@ driver: type-checking it type-checks the whole thing.
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
 | `Ctx.agda` | **the type context**: entries `abst` / `bind A` / `masked E`, lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑`), injective renamings, in-place `mask`/`unmask`, and the bind prefix `pushBinds` with `shiftBy` |
 | `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, and `conv-types-unique` |
-| `Terms.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`, `scope`, `unlockedScope`, `interior`, `convCtx`), `_⊢ᵐ_`, terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` |
+| `CtxMorph.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the type contexts it induces (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and the well-formedness judgement `Δ ⊢ᵐ Θ` |
+| `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
 | `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), term substitution, `⊢subst`, `preserve-Beta` |
 | `Reduction.agda` | `reveal`/`conceal` and their conversion analogues, `dual`, the scope move (`scopeOf`, `dropLocks`, `_⋉_`), the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
 | `Progress.agda` | the statement `Progress` and `progress`, a one-line wrapper around `proof.Progress.progress` |

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -57,7 +57,7 @@ driver: type-checking it type-checks the whole thing.
 | `Types.agda` | System F types in de Bruijn form; renaming and parallel substitution; `_[_]ᵗ` and the at-a-slot substitution `_[_:=_]ᵗ` |
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
 | `Ctx.agda` | **the type context**: entries `abst` / `bind A` / `masked E`, lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑`), injective renamings, in-place `mask`/`unmask`, and the bind prefix `pushBinds` with `shiftBy` |
-| `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, and `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
+| `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
 | `CtxMorph.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the type contexts it induces (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and the well-formedness judgement `Δ ⊢ᵐ Θ`, and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
 | `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), term substitution, `⊢subst`, `preserve-Beta` |

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -57,11 +57,11 @@ driver: type-checking it type-checks the whole thing.
 | `Types.agda` | System F types in de Bruijn form; renaming and parallel substitution; `_[_]ᵗ` and the at-a-slot substitution `_[_:=_]ᵗ` |
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
 | `Ctx.agda` | **the type context**: entries `abst` / `bind A` / `masked E`, lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑`), injective renamings, in-place `mask`/`unmask`, and the bind prefix `pushBinds` with `shiftBy` |
-| `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, and `conv-types-unique` |
+| `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, and `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
 | `CtxMorph.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the type contexts it induces (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and the well-formedness judgement `Δ ⊢ᵐ Θ`, and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
 | `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), term substitution, `⊢subst`, `preserve-Beta` |
-| `Reduction.agda` | `reveal`/`conceal` and their conversion analogues, the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
+| `Reduction.agda` | the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
 | `Progress.agda` | the statement `Progress` and `progress`, a one-line wrapper around `proof.Progress.progress` |
 | `Preservation.agda` | `preservation` / `preservation*` as `proof.Preserve.Impl` instantiated at the three downstream cases, plus the per-rule statements and `⊢ᵗ-of-closed` |
 | `TypeSafety.agda` | the public theorem surface: the six theorems above, stated in full |

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -58,10 +58,10 @@ driver: type-checking it type-checks the whole thing.
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
 | `Ctx.agda` | **the type context**: entries `abst` / `bind A` / `masked E`, lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑`), injective renamings, in-place `mask`/`unmask`, and the bind prefix `pushBinds` with `shiftBy` |
 | `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, and `conv-types-unique` |
-| `CtxMorph.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the type contexts it induces (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and the well-formedness judgement `Δ ⊢ᵐ Θ` |
+| `CtxMorph.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the type contexts it induces (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and the well-formedness judgement `Δ ⊢ᵐ Θ`, and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
 | `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), term substitution, `⊢subst`, `preserve-Beta` |
-| `Reduction.agda` | `reveal`/`conceal` and their conversion analogues, `dual`, the scope move (`scopeOf`, `dropLocks`, `_⋉_`), the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
+| `Reduction.agda` | `reveal`/`conceal` and their conversion analogues, the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
 | `Progress.agda` | the statement `Progress` and `progress`, a one-line wrapper around `proof.Progress.progress` |
 | `Preservation.agda` | `preservation` / `preservation*` as `proof.Preserve.Impl` instantiated at the three downstream cases, plus the per-rule statements and `⊢ᵗ-of-closed` |
 | `TypeSafety.agda` | the public theorem surface: the six theorems above, stated in full |

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -36,6 +36,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.TermSubst
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -112,114 +112,7 @@ mutual
   instConceal-mkId X (`∀ A)  = cong `∀ (instConceal-mkId (suc X) A)
 
 ------------------------------------------------------------------------
--- 2.  The dual of a crossed boundary
-------------------------------------------------------------------------
-
--- THE DUAL, in full.  It mints ONLY name-carrying entries: a `lock` for each
--- of the crossed boundary's binders (the argument may not see them) and an
--- `unlock` for each of its conceals (the argument came from outside, where they
--- were nameable).  Nothing is copied, nothing is guarded, nothing is
--- demoted; the old design's `entᴳ` has no analogue.
-hideBinds : ℕ → CtxMorph
-hideBinds zero    = []
-hideBinds (suc k) = lock k ∷ hideBinds k
-
--- THE DUAL IS AN INVERSE, AND AN INVERSE RUNS BACKWARDS (2026-09-06).
---
--- The mini-core DROPPED the `unlock` case, on the reading that an
--- `unlock` "claims nothing".  It claims plenty: it UNMASKS, and a dual
--- that does not re-mask hands the crossing argument a frame STRICTLY MORE
--- NAMEABLE than the exterior — `Peel` GAINS SCOPE, machine-checked in
--- proof/DualTightness.agda.  So `unlock X ↦ lock (n + X)`, and the
--- restoring `lock` is sound exactly because `mw-u` (strong.Terms) refuses
--- a VACUOUS unlock: `mask ∘ unmask` is the identity at a LOCKED slot
--- (`mask-unmask`, strong.Ctx) and nowhere else.
---
--- AND THE LIST IS REVERSED.  `scope` applies its list HEAD-LAST, so
--- undoing it runs the entries BACK TO FRONT; a same-order dual is not an
--- inverse at a frame that toggles one slot twice (`Θ = ↥X ∷ ↧X ∷ []`,
--- which the judgement admits).  With both repairs the frame identity is
--- EXACT (proof/PeelDual, `interior-dual`): the crossing argument's frame
--- is the exterior itself, one bind prefix in, and it crosses by
--- `⊢rename` alone — no `⊢retag`, no `le-mu`.
-dualScope : ℕ → CtxMorph → CtxMorph
-dualScope n []             = []
-dualScope n (bind A ∷ Θ)   = dualScope n Θ
-dualScope n (unlock X ∷ Θ) = dualScope n Θ ++ (lock   (n + X) ∷ [])
-dualScope n (lock X ∷ Θ)   = dualScope n Θ ++ (unlock (n + X) ∷ [])
-
-dual : CtxMorph → CtxMorph
-dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
-
--- (The old Cancel residue `repsOf→bind` — a frame that rebinds Θ₂'s binders
--- and nothing else — is GONE with the rule that wrote it: the repaired
--- CancelR keeps both frames and mints none.)
-
-------------------------------------------------------------------------
--- 2b.  THE SCOPE MOVE — the outer frame's locks go INTO the inner one
-------------------------------------------------------------------------
-
--- JEREMY'S MOVE (2026-09-06).  CancelR and IdPush both SWAP the two
--- conversions: the inner boundary stops presenting the abstract name
--- `` ` Y `` and starts presenting Y's REP.  A rep is read on the outer
--- boundary's CONVERSION CONTEXT (its locks lifted), so it is nameable
--- there and NOT, in general, inside the outer boundary's own locks — that
--- was the wall (the old proof/PreserveObstruct §4).
---
--- The repair is not a side condition but a FRAME MOVE: the outer frame's
--- whole SCOPE travels into the inner frame's TAIL, where `scope` applies
--- it FIRST — exactly where it applied before — and what stays outside is
--- the frame with its own scope REWOUND (`rewind Θ₂`), whose net effect on
--- the exterior is its BIND PREFIX alone.  The rep is then presented
--- OUTSIDE the locks, where it is nameable, and the locks still stand
--- between the value and the world.
---
--- WHY THE UNLOCKS TRAVEL TOO.  `scope` applies its list HEAD-LAST, so
--- moving only the LOCKS past a same-slot `unlock` reorders a mask/unmask
--- pair, and the value's frame is then not refined but CORRUPTED — a slot
--- it may name is masked in the contractum and was not in the redex
--- (`¬frame-locksOnly`, proof/MoveScope §4b, at the ⊢ᵐ-legal
--- `Θ₂ = unlock 0 ∷ lock 0 ∷ []`).  Moving the WHOLE scope keeps the
--- order, and then the value's frame is preserved ON THE NOSE: the two
--- frame lemmas are EQUALITIES, no `⊢retag` appears in either case, and
--- there is no premise about Θ₂'s shape for Progress to supply.
-
--- The outer frame's scope entries, lifted past its own binders.
-scopeOf : ℕ → CtxMorph → CtxMorph
-scopeOf n []             = []
-scopeOf n (bind A ∷ Θ)   = scopeOf n Θ
-scopeOf n (unlock X ∷ Θ) = unlock (n + X) ∷ scopeOf n Θ
-scopeOf n (lock X ∷ Θ)   = lock (n + X) ∷ scopeOf n Θ
-
--- WHAT IS LEFT OF THE OUTER FRAME: the frame with its OWN SCOPE REWOUND.
---
--- `rewind Θ` is Θ with its inverse scope run on top, so its net effect on
--- the exterior is the BIND PREFIX ALONE:
---
---     scope    (rewind Θ) Δ ≡ Δ                       (given Δ ⊢ᵐ Θ)
---     interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ
---
--- which is what makes the moved scope reproduce the redex's frame ON THE
--- NOSE (`interior-⋉-rewind`, proof/MoveScope) — no `⊢retag` and no
--- `le-mu` anywhere in the two cases.
---
--- IT IS NOT `bindsOnly Θ`, AND THAT IS THE POINT.  Simply DELETING Θ's
--- scope has the same effect on the type context but loses the frame's own
--- `⊢ᵐ`: Θ's bind reps are read on `unlockedScope Θ′ Δ` (strong.Terms,
--- `mw-b`) and a rep naming a slot Θ's tail UNLOCKED is not well formed on
--- the plain Δ.  Keeping the entries and rewinding them keeps every rep
--- exactly where it was read.
-rewind : CtxMorph → CtxMorph
-rewind Θ = dualScope 0 Θ ++ Θ
-
--- The inner frame, with the outer frame's scope moved in at its TAIL.
--- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁`: the move carries no binder.
-infixl 5 _⋉_
-_⋉_ : CtxMorph → CtxMorph → CtxMorph
-Θ₁ ⋉ Θ₂ = Θ₁ ++ scopeOf (numBinds Θ₂) Θ₂
-
-------------------------------------------------------------------------
--- 3.  The rules
+-- 2.  The rules
 ------------------------------------------------------------------------
 
 infix 2 _⊢_-→_
@@ -358,7 +251,7 @@ data _⊢_-→*_ : Ctxᵗ → Term → Term → Set where
 infixr 2 _then_
 
 ------------------------------------------------------------------------
--- 4.  VALUES DON'T STEP
+-- 3.  VALUES DON'T STEP
 ------------------------------------------------------------------------
 
 -- With V-Λ's `Value N` premise this holds on the nose.  (In the mini-core it
@@ -369,7 +262,7 @@ value-¬step (V-⟪⟫ v ic)    (ξ-⟪⟫ st) = value-¬step v st
 value-¬step (V-Λ v)        (ξ-Λ st)  = value-¬step v st
 
 ------------------------------------------------------------------------
--- 5.  DETERMINISM
+-- 4.  DETERMINISM
 ------------------------------------------------------------------------
 
 det : ∀ {Δ M M₁ M₂} → Δ ⊢ M -→ M₁ → Δ ⊢ M -→ M₂ → M₁ ≡ M₂

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -39,80 +39,7 @@ open import strong.Terms
 open import strong.TermSubst
 
 ------------------------------------------------------------------------
--- 1.  The canonical conversion at a slot
-------------------------------------------------------------------------
-
--- Unseal every occurrence of X where the conversion runs covariantly /
--- seal it back where it runs contravariantly.  These are what the
--- boundary rules mint at a fresh binder; they are DERIVED FROM THE TYPE,
--- not from stored knowledge, and they carry only the NAME X.
-mutual
-  reveal : ℕ → Ty → Conv
-  reveal X (` Y) with X ≟ℕ Y
-  ... | yes _ = unseal X
-  ... | no  _ = id (` Y)
-  reveal X `ℕ      = id `ℕ
-  reveal X `𝔹      = id `𝔹
-  reveal X (A ⇒ B) = conceal X A ↦ reveal X B
-  reveal X (`∀ A)  = `∀ (reveal (suc X) A)
-
-  conceal : ℕ → Ty → Conv
-  conceal X (` Y) with X ≟ℕ Y
-  ... | yes _ = seal X
-  ... | no  _ = id (` Y)
-  conceal X `ℕ      = id `ℕ
-  conceal X `𝔹      = id `𝔹
-  conceal X (A ⇒ B) = reveal X A ↦ conceal X B
-  conceal X (`∀ A)  = `∀ (conceal (suc X) A)
-
--- THE SAME MINT, APPLIED TO A CONVERSION (the TyPeelR repair,
--- notes/RuleRepairs-TyPeelR-CancelR.md §1).  When a boundary whose
--- conversion is a `` `∀ `` is instantiated, the boundary's frame gains
--- a BINDER at slot 0 — the slot the conversion's `` `∀ `` had left
--- ABSTRACT.  Every leaf of the conversion that reads that slot is an
--- identity (`id (` 0)`, because an abstract slot has no binder to seal or
--- unseal at), and each such leaf must become the instantiation step:
--- `unseal 0` where the conversion runs covariantly, `seal 0` where it
--- runs contravariantly.  That is exactly `reveal`/`conceal`, pushed
--- through a CONVERSION instead of through a type — and on an identity
--- conversion the two agree (`instReveal-mkId` below).
-mutual
-  instReveal : ℕ → Conv → Conv
-  instReveal X (id A)     = reveal X A
-  instReveal X (seal Y)   = seal Y
-  instReveal X (unseal Y) = unseal Y
-  instReveal X (s ↦ t)    = instConceal X s ↦ instReveal X t
-  instReveal X (`∀ s)     = `∀ (instReveal (suc X) s)
-
-  instConceal : ℕ → Conv → Conv
-  instConceal X (id A)     = conceal X A
-  instConceal X (seal Y)   = seal Y
-  instConceal X (unseal Y) = unseal Y
-  instConceal X (s ↦ t)    = instReveal X s ↦ instConceal X t
-  instConceal X (`∀ s)     = `∀ (instConceal (suc X) s)
-
--- TyBeta's minted conversion IS this operation at an identity
--- conversion: the type version is the conversion version on `mkId`.  (So
--- TyPeelR's reveal case really is TyBeta's mint, one ∀ inside.)
-mutual
-  instReveal-mkId : (X : ℕ) (B : Ty) → instReveal X (mkId B) ≡ reveal X B
-  instReveal-mkId X (` Y)   = refl
-  instReveal-mkId X `ℕ      = refl
-  instReveal-mkId X `𝔹      = refl
-  instReveal-mkId X (A ⇒ B) =
-    cong₂ _↦_ (instConceal-mkId X A) (instReveal-mkId X B)
-  instReveal-mkId X (`∀ A)  = cong `∀ (instReveal-mkId (suc X) A)
-
-  instConceal-mkId : (X : ℕ) (B : Ty) → instConceal X (mkId B) ≡ conceal X B
-  instConceal-mkId X (` Y)   = refl
-  instConceal-mkId X `ℕ      = refl
-  instConceal-mkId X `𝔹      = refl
-  instConceal-mkId X (A ⇒ B) =
-    cong₂ _↦_ (instReveal-mkId X A) (instConceal-mkId X B)
-  instConceal-mkId X (`∀ A)  = cong `∀ (instConceal-mkId (suc X) A)
-
-------------------------------------------------------------------------
--- 2.  The rules
+-- 1.  The rules
 ------------------------------------------------------------------------
 
 infix 2 _⊢_-→_
@@ -251,7 +178,7 @@ data _⊢_-→*_ : Ctxᵗ → Term → Term → Set where
 infixr 2 _then_
 
 ------------------------------------------------------------------------
--- 3.  VALUES DON'T STEP
+-- 2.  VALUES DON'T STEP
 ------------------------------------------------------------------------
 
 -- With V-Λ's `Value N` premise this holds on the nose.  (In the mini-core it
@@ -262,7 +189,7 @@ value-¬step (V-⟪⟫ v ic)    (ξ-⟪⟫ st) = value-¬step v st
 value-¬step (V-Λ v)        (ξ-Λ st)  = value-¬step v st
 
 ------------------------------------------------------------------------
--- 4.  DETERMINISM
+-- 3.  DETERMINISM
 ------------------------------------------------------------------------
 
 det : ∀ {Δ M M₁ M₂} → Δ ⊢ M -→ M₁ → Δ ⊢ M -→ M₂ → M₁ ≡ M₂

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -161,9 +161,9 @@ dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
 
 -- JEREMY'S MOVE (2026-09-06).  CancelR and IdPush both SWAP the two
 -- conversions: the inner boundary stops presenting the abstract name
--- `` ` Y `` and starts presenting Y's REP.  A rep is a type over the
--- PLAIN exterior, so it is nameable on the outer boundary's CONVERSION
--- CONTEXT and NOT, in general, inside the outer boundary's own locks — that
+-- `` ` Y `` and starts presenting Y's REP.  A rep is read on the outer
+-- boundary's CONVERSION CONTEXT (its locks lifted), so it is nameable
+-- there and NOT, in general, inside the outer boundary's own locks — that
 -- was the wall (the old proof/PreserveObstruct §4).
 --
 -- The repair is not a side condition but a FRAME MOVE: the outer frame's

--- a/SystemF/agda/strong/Show.agda
+++ b/SystemF/agda/strong/Show.agda
@@ -42,9 +42,8 @@ open import Data.Product using (_×_; _,_; proj₁)
 open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀)
 open import strong.Ctx using (Ent; abst; bind; masked; Ctxᵗ)
 open import strong.Conversion using (Conv; id; seal; unseal; _↦_; `∀)
-open import strong.Terms
-  using (Term; `_; $_; ƛ_∙_; _·_; Λ_; _·[_,_]; _⟪_,_⟫;
-         CtxMorph; MorphEnt; bind; unlock; lock; numBinds)
+open import strong.Terms using (Term; `_; $_; ƛ_∙_; _·_; Λ_; _·[_,_]; _⟪_,_⟫)
+open import strong.CtxMorph
 
 Supply : Set
 Supply = ℕ → String

--- a/SystemF/agda/strong/Show.agda
+++ b/SystemF/agda/strong/Show.agda
@@ -18,8 +18,9 @@ module strong.Show where
 --     inner supply — the old `cmax` correction has no analogue, and the
 --     interior supply and the CONVERSION-CONTEXT supply coincide
 --     (`interior` and `convCtx` differ in blocking, not in slot layout).
---   * a BINDER's rep is shown under `ext` — a rep is a type over the PLAIN
---     exterior (simultaneity);
+--   * a BINDER's rep is shown under `ext` — a rep uses the exterior's
+--     slots (the judgement reads it on `unlockedScope Θ′ Δ`, which has the
+--     same slot layout as Δ);
 --   * a `lock X` / `unlock X` names an EXTERIOR slot, so it is shown under
 --     `ext`; neither carries a rep, which is the whole point of the
 --     redesign;
@@ -145,7 +146,7 @@ tl []       = []
 tl (s ∷ ss) = ss
 
 -- `on` is the binder-name list still to be consumed; `ext` names exterior
--- slots.  A binder's rep is read in the PLAIN exterior; `lock`/`unlock` carry
+-- slots.  A binder's rep uses the exterior's slots; `lock`/`unlock` carry
 -- a name only.
 showEnts : ℕ → List String → Supply → CtxMorph → String
 showEnts d on ext [] = ""

--- a/SystemF/agda/strong/TermSubst.agda
+++ b/SystemF/agda/strong/TermSubst.agda
@@ -41,6 +41,7 @@ open import strong.TypeSubst using (rename-[]ᵗ-commute)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 
 private
   variable

--- a/SystemF/agda/strong/Terms.agda
+++ b/SystemF/agda/strong/Terms.agda
@@ -1,25 +1,20 @@
 module strong.Terms where
 
--- Strong System F — the BOUNDARY and the TERMS.
+-- Strong System F — the TERMS, the typing judgement, and values.
 --
 -- A boundary is  M ⟪ Θ , c ⟫  with ONE frame change:
 --
---   Θ : CtxMorph   the SCOPE SKELETON, rep-free except for binders
---        bind A   BINDS a fresh interior slot; A is its representation, read
---                in the PLAIN EXTERIOR (simultaneity: never through Θ's
---                other entries).  The only rep-carrying form; born once,
---                bound once.
---        lock X   MASKS exterior slot X: the interior may not NAME it.  The
---                entry is RETAINED on the type context — nothing is dropped and
---                nothing is re-spelled, so there is no demotion to perform.
---        unlock X   UNMASKS exterior slot X; it claims nothing, it merely
---                restores nameability.
---   c : Conv     the CONVERSION, checked on the CONVERSION CONTEXT (the
---                interior type context with Θ's bind masks lifted), where a
---                `seal X` can still resolve X at its binder.
+--   Θ : CtxMorph   the context morphism (strong.CtxMorph, re-exported
+--                here): `bind A` binds a fresh interior slot with
+--                representation A, `lock X` masks exterior slot X,
+--                `unlock X` unmasks it.  `interior Θ Δ` is the type
+--                context the interior is typed in, `convCtx Θ Δ` the one
+--                the conversion is checked in, `Δ ⊢ᵐ Θ` its well-
+--                formedness.
+--   c : Conv     the CONVERSION (strong.Conversion), from the interior
+--                type to the exterior type shifted past Θ's binders.
 --
--- Frames change ONLY at binders: `interior Θ Δ` is `Δ` with the masks applied
--- and Θ's binders pushed on.  There is no dropN, no cmax, no swapᵇ.
+-- Frames change ONLY at binders: there is no dropN, no cmax, no swapᵇ.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; map; length)
@@ -34,6 +29,7 @@ open import strong.Types
   using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Var; Renameᵗ; renameᵗ; extᵗ; ⇑ᵗ; _[_]ᵗ)
 open import strong.Ctx
 open import strong.Conversion
+open import strong.CtxMorph public
 
 private
   variable
@@ -42,167 +38,7 @@ private
     X Y : ℕ
 
 ------------------------------------------------------------------------
--- 1.  The boundary context morphism
-------------------------------------------------------------------------
-
-data MorphEnt : Set where
-  bind : Ty → MorphEnt      -- BINDS a fresh slot at rep A (A over the exterior)
-  unlock : ℕ → MorphEnt       -- unmask exterior slot X   (name only)
-  lock : ℕ → MorphEnt       -- mask   exterior slot X   (name only)
-
-CtxMorph : Set
-CtxMorph = List MorphEnt
-
-repsOf : CtxMorph → List Ty
-repsOf []             = []
-repsOf (bind A ∷ Θ)   = A ∷ repsOf Θ
-repsOf (unlock X ∷ Θ) = repsOf Θ
-repsOf (lock X ∷ Θ)   = repsOf Θ
-
--- `numBinds` is the boundary's FRAME EXTENSION: the number of binders it
--- adds.  It is the only surviving list arithmetic; cmax/dropN have no
--- analogue, because conceal masks in place.
-numBinds : CtxMorph → ℕ
-numBinds Θ = length (repsOf Θ)
-
--- The masks (`lock`) and unmasks (`unlock`), applied in place.
-scope : CtxMorph → Ctxᵗ → Ctxᵗ
-scope []             Δ = Δ
-scope (bind A ∷ Θ)   Δ = scope Θ Δ
-scope (unlock X ∷ Θ) Δ = unmask X (scope Θ Δ)
-scope (lock X ∷ Θ)   Δ = mask X (scope Θ Δ)
-
--- The CONVERSION CONTEXT's slots: like `scope` but WITHOUT the conceal
--- masks, so a `seal X` can resolve X at its binder.  This is
--- binder-syntactic lookup: the licence is read on the type context that
--- encloses the boundary, never inside it.
-unlockedScope : CtxMorph → Ctxᵗ → Ctxᵗ
-unlockedScope []             Δ = Δ
-unlockedScope (bind A ∷ Θ)   Δ = unlockedScope Θ Δ
-unlockedScope (unlock X ∷ Θ) Δ = unmask X (unlockedScope Θ Δ)
-unlockedScope (lock X ∷ Θ)   Δ = unlockedScope Θ Δ
-
--- What replaces `intOf`: the same slot list, the interior mask, and the
--- binder extension.  Nothing is dropped and no rep is recomputed.
-interior : CtxMorph → Ctxᵗ → Ctxᵗ
-interior Θ Δ = pushBinds (repsOf Θ) (scope Θ Δ)
-
-convCtx : CtxMorph → Ctxᵗ → Ctxᵗ
-convCtx Θ Δ = pushBinds (repsOf Θ) (unlockedScope Θ Δ)
-
--- The interior type context is the conversion context with Θ's bind
--- masks on, so anything well formed inside is well formed on the
--- conversion context.
-scope⊑unlockedScope : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → scope Θ Δ ⊑ unlockedScope Θ Δ
-scope⊑unlockedScope []             Δ = ⊑-refl Δ
-scope⊑unlockedScope (bind A ∷ Θ)   Δ = scope⊑unlockedScope Θ Δ
-scope⊑unlockedScope (unlock X ∷ Θ) Δ =
-  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono
-    (scope⊑unlockedScope Θ Δ)
-scope⊑unlockedScope (lock X ∷ Θ)   Δ = mask-⊑ X (scope⊑unlockedScope Θ Δ)
-
-interior⊑convCtx : (Θ : CtxMorph) (Δ : Ctxᵗ) → interior Θ Δ ⊑ convCtx Θ Δ
-interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ Δ)
-
--- The CONVERSION CONTEXT only ever ADDS nameability to the plain
--- exterior: `unlockedScope` skips the binds and the locks, and an
--- `unlock` merely restores.  (`scope` would not do — masking is what a
--- lock is for.)
-Δ⊑unlockedScope : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊑ unlockedScope Θ Δ
-Δ⊑unlockedScope []             Δ = ⊑-refl Δ
-Δ⊑unlockedScope (bind A ∷ Θ)   Δ = Δ⊑unlockedScope Θ Δ
-Δ⊑unlockedScope (unlock X ∷ Θ) Δ =
-  ⊑-trans (Δ⊑unlockedScope Θ Δ) (unmask-⊑ X (unlockedScope Θ Δ))
-Δ⊑unlockedScope (lock X ∷ Θ)   Δ = Δ⊑unlockedScope Θ Δ
-
-⊑-scope : (Θ : CtxMorph) → Δ ⊑ Δ′ → scope Θ Δ ⊑ scope Θ Δ′
-⊑-scope []             ls = ls
-⊑-scope (bind A ∷ Θ)   ls = ⊑-scope Θ ls
-⊑-scope (unlock X ∷ Θ) ls =
-  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-scope Θ ls)
-⊑-scope (lock X ∷ Θ)   ls =
-  ⊑-updateAt masked masked-comm masked-mono (⊑-scope Θ ls)
-
-⊑-unlockedScope : (Θ : CtxMorph) → Δ ⊑ Δ′
-  → unlockedScope Θ Δ ⊑ unlockedScope Θ Δ′
-⊑-unlockedScope []             ls = ls
-⊑-unlockedScope (bind A ∷ Θ)   ls = ⊑-unlockedScope Θ ls
-⊑-unlockedScope (unlock X ∷ Θ) ls =
-  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-unlockedScope Θ ls)
-⊑-unlockedScope (lock X ∷ Θ)   ls = ⊑-unlockedScope Θ ls
-
-⊑-interior : (Θ : CtxMorph) → Δ ⊑ Δ′ → interior Θ Δ ⊑ interior Θ Δ′
-⊑-interior Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-scope Θ ls)
-
--- … and the same three transports for the LOCK-PRESERVING refinement,
--- the one a TERM travels along.
-⊑ᵃ-scope : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → scope Θ Δ ⊑ᵃ scope Θ Δ′
-⊑ᵃ-scope []             ls = ls
-⊑ᵃ-scope (bind A ∷ Θ)   ls = ⊑ᵃ-scope Θ ls
-⊑ᵃ-scope (unlock X ∷ Θ) ls =
-  ⊑ᵃ-updateAt unmaskEnt unmaskEnt-monoᵃ (⊑ᵃ-scope Θ ls)
-⊑ᵃ-scope (lock X ∷ Θ)   ls =
-  ⊑ᵃ-updateAt masked masked-monoᵃ (⊑ᵃ-scope Θ ls)
-
-⊑ᵃ-interior : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → interior Θ Δ ⊑ᵃ interior Θ Δ′
-⊑ᵃ-interior Θ ls = ⊑ᵃ-pushBinds (repsOf Θ) (⊑ᵃ-scope Θ ls)
-
-⊑-convCtx : (Θ : CtxMorph) → Δ ⊑ Δ′ → convCtx Θ Δ ⊑ convCtx Θ Δ′
-⊑-convCtx Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-unlockedScope Θ ls)
-
-------------------------------------------------------------------------
--- 2.  Boundary well-formedness
-------------------------------------------------------------------------
-
--- EVERY PREMISE IS READ ON THE FRAME THE ENTRY ACTS ON — the judgement is
--- SEQUENTIAL, in the order `scope` applies the list (head-LAST).  For the
--- tail Θ′ of the entry:
---
---   lock X    X is NAMEABLE in `scope Θ′ Δ`  (you may only mask what is
---             visible: no double masking, so `Locked` is one mask deep)
---   unlock X  X is LOCKED   in `scope Θ′ Δ`  (`Δ ∋lk X`: masked over a
---             nameable entry).  A VACUOUS UNLOCK — `↥X` at a slot the
---             frame leaves visible — IS REFUSED; it is the premise the
---             judgement used to drop, and the one the dual's restoring
---             `lock` needs (`mask-unmask`, strong.Ctx).
---   bind A    A is a type over `unlockedScope Θ′ Δ` — the tail's UNMASKS
---             applied and its LOCKS lifted.  A rep is never blocked by
---             the frame's own locks (that is the simultaneity law: a rep
---             is read where the CONVERSION is read, outside the masking
---             the boundary itself performs), and it may name what the
---             tail unlocked — which is what makes the scope move
---             (`_⋉_`, strong.Reduction) well formed.
---
--- Note the distinction the mask discipline forces: `unlock X`/`lock X`
--- NAME a masked index — that is an ENTRY, not a type — while `Δ ⊢ᵗ ` X`
--- at a masked slot is refused.  Tightness is about USE in a type, not
--- about mentioning the index in the context morphism.
---
--- `Δ ⊢ᵐ Θ` — the context morphism Θ is WELL FORMED over Δ.  An infix
--- judgement in the family of `Δ ⊢ᵗ A` (strong.Ctx) and `Δ ⊢ c ∶ A ⇝ B`
--- (strong.Conversion).
-infix 4 _⊢ᵐ_
-data _⊢ᵐ_ : Ctxᵗ → CtxMorph → Set where
-  mw[] : Δ ⊢ᵐ []
-  mw-b : ∀ {A Θ} → unlockedScope Θ Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
-  mw-l : ∀ {X Θ} → scope Θ Δ ∋tv X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
-  mw-u : ∀ {X Θ} → scope Θ Δ ∋lk X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
-
--- THE TERM TRANSPORT IS `_⊑ᵃ_`, NOT `_⊑_`.  An `unlock X` CLAIMS that X
--- is locked, and `le-mu` — the clause that re-exposes a concealed slot —
--- destroys the claim; `_⊑ᵃ_` (strong.Ctx §4b) is `_⊑_` without it.
-⊢ᵐ-⊑ᵃ : ∀ {Θ} → Δ ⊑ᵃ Δ′ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ Θ
-⊢ᵐ-⊑ᵃ {Θ = []}           ls mw[]        = mw[]
-⊢ᵐ-⊑ᵃ {Θ = bind A ∷ Θ}   ls (mw-b w b)  =
-  mw-b (⊑-wf (⊑-unlockedScope Θ (⊑ᵃ→⊑ ls)) w) (⊢ᵐ-⊑ᵃ ls b)
-⊢ᵐ-⊑ᵃ {Θ = lock X ∷ Θ}   ls (mw-l tv b) =
-  mw-l (⊑-tv (⊑-scope Θ (⊑ᵃ→⊑ ls)) tv) (⊢ᵐ-⊑ᵃ ls b)
-⊢ᵐ-⊑ᵃ {Θ = unlock X ∷ Θ} ls (mw-u lk b) =
-  mw-u (⊑ᵃ-lk (⊑ᵃ-scope Θ ls) lk) (⊢ᵐ-⊑ᵃ ls b)
-
-------------------------------------------------------------------------
--- 3.  Terms
+-- 1.  Terms
 ------------------------------------------------------------------------
 
 infix  9 `_
@@ -232,7 +68,7 @@ data _∋_⦂_ : Ctx → ℕ → Ty → Set where
 ⤊ Γ = map ⇑ᵗ Γ
 
 ------------------------------------------------------------------------
--- 4.  The typing judgment
+-- 2.  The typing judgment
 ------------------------------------------------------------------------
 
 infix 3 _∣_⊢_⦂_
@@ -267,7 +103,7 @@ data _∣_⊢_⦂_ : Ctxᵗ → Ctx → Term → Ty → Set where
       → Δ ∣ Γ ⊢ M ⟪ Θ , c ⟫ ⦂ Bₑ
 
 ------------------------------------------------------------------------
--- 5.  Classification — ACTIVE / INERT, by the CONVERSION constructor
+-- 3.  Classification — ACTIVE / INERT, by the CONVERSION constructor
 ------------------------------------------------------------------------
 
 -- Inert  = { s ↦ t , ∀ s , seal X , id-at-a-variable }
@@ -299,7 +135,7 @@ act-not-inert (A-idb ()) I-idv
 act-not-inert A-unseal ()
 
 ------------------------------------------------------------------------
--- 6.  Values
+-- 4.  Values
 ------------------------------------------------------------------------
 
 -- V-Λ carries `Value N`.  Reduction goes UNDER Λ (ξ-Λ in strong.Reduction),

--- a/SystemF/agda/strong/Terms.agda
+++ b/SystemF/agda/strong/Terms.agda
@@ -29,7 +29,7 @@ open import strong.Types
   using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Var; Renameᵗ; renameᵗ; extᵗ; ⇑ᵗ; _[_]ᵗ)
 open import strong.Ctx
 open import strong.Conversion
-open import strong.CtxMorph public
+open import strong.CtxMorph
 
 private
   variable

--- a/SystemF/agda/strong/proof/Adversary.agda
+++ b/SystemF/agda/strong/proof/Adversary.agda
@@ -19,6 +19,7 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; ⇑ᵗ)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 
 ------------------------------------------------------------------------
 -- 1.  The gate

--- a/SystemF/agda/strong/proof/Canonical.agda
+++ b/SystemF/agda/strong/proof/Canonical.agda
@@ -36,6 +36,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 
 private
   variable

--- a/SystemF/agda/strong/proof/Canonicity.agda
+++ b/SystemF/agda/strong/proof/Canonicity.agda
@@ -37,6 +37,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.TermSubst
 open import strong.Reduction
 open import strong.Examples

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -12,7 +12,7 @@ module strong.proof.DualTightness where
 -- THROUGH THE BOUNDARY: the redex below is ILL TYPED at Δᵤ (its argument
 -- W names a slot MASKED at Δᵤ) and its `Peel` contractum was WELL TYPED.
 --
--- THE REPAIR, in two coupled halves (strong.Reduction §2, strong.Terms):
+-- THE REPAIR, in two coupled halves (strong.CtxMorph §3, `_⊢ᵐ_` in §2):
 --
 --   (1) `mw-u` demands `scope Θ Δ ∋lk X` — the slot must be LOCKED.  A
 --       VACUOUS unlock is REFUSED (§5 below); it is the premise the

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -35,6 +35,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.Reduction
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/proof/IdLayer.agda
+++ b/SystemF/agda/strong/proof/IdLayer.agda
@@ -24,6 +24,7 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 
 ------------------------------------------------------------------------
 -- §1  THE NAMES ARE FORCED

--- a/SystemF/agda/strong/proof/MaskFacts.agda
+++ b/SystemF/agda/strong/proof/MaskFacts.agda
@@ -22,6 +22,7 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; Renameᵗ)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 
 mask-retains : ∀ {Δ X Y A} → Δ ∋ X := A
   → (mask Y Δ ∋ X := A) ⊎ (mask Y Δ ∋e X , masked (bind A))

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -3,7 +3,7 @@ module strong.proof.MoveScope where
 -- THE SCOPE MOVE — its frame algebra, and the TWO preservation cases it
 -- settles (CancelR and IdPush), UNCONDITIONALLY.
 --
--- THE MOVE (strong.Reduction §2b).  Both rules SWAP the two conversions
+-- THE MOVE (strong.CtxMorph §4).  Both rules SWAP the two conversions
 -- of a two-layer wrapper, so the INNER boundary stops presenting the
 -- abstract name `` ` Y `` and starts presenting Y's REP.  A rep is a type
 -- over the exterior; inside Θ₂'s LOCKS it need not be nameable at all,
@@ -59,7 +59,7 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; ⇑ᵗ)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
-open import strong.Reduction using (scopeOf; rewind; dualScope; _⋉_)
+open import strong.CtxMorph using (scopeOf; rewind; dualScope; _⋉_)
 open import strong.proof.Preserve using (CancelRCase; IdPushCase)
 open import strong.proof.PeelDual
   using (⊢ᵐ-++; scope-++; unlockedScope-++; scope-dualScope; ⊢ᵐ-dualScope;

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -59,7 +59,7 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; ⇑ᵗ)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
-open import strong.CtxMorph using (scopeOf; rewind; dualScope; _⋉_)
+open import strong.CtxMorph
 open import strong.proof.Preserve using (CancelRCase; IdPushCase)
 open import strong.proof.PeelDual
   using (⊢ᵐ-++; scope-++; unlockedScope-++; scope-dualScope; ⊢ᵐ-dualScope;

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -49,6 +49,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.Reduction
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -15,7 +15,7 @@ module strong.proof.PeelDual where
 -- whenever Θ unlocked a slot Δ masked, and `Peel` related a term the
 -- exterior REFUSES to one it accepts (proof/DualTightness).
 --
--- The two repairs (strong.Reduction §2) that buy it:
+-- The two repairs (strong.CtxMorph §3) that buy it:
 --   `unlock X ↦ lock (n + X)`  the dual RESTORES what Θ unlocked, sound
 --                              because `mw-u` refuses a vacuous unlock
 --                              (`mask-unmask`, strong.Ctx §6b);
@@ -43,7 +43,7 @@ open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
 open import strong.TermSubst
-open import strong.Reduction using (hideBinds; dualScope; dual)
+open import strong.CtxMorph using (hideBinds; dualScope; dual)
 open import strong.proof.Preserve using (PeelCase; ⊢ᵗ-of; CtxWf-[])
 open import strong.proof.Canonical using (shiftBy-⇒; conv-tgt≡)
 

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -43,7 +43,7 @@ open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
 open import strong.TermSubst
-open import strong.CtxMorph using (hideBinds; dualScope; dual)
+open import strong.CtxMorph
 open import strong.proof.Preserve using (PeelCase; ⊢ᵗ-of; CtxWf-[])
 open import strong.proof.Canonical using (shiftBy-⇒; conv-tgt≡)
 

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -41,6 +41,7 @@ open import strong.TypeSubst
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.TermSubst
 open import strong.Reduction
 

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -281,8 +281,8 @@ substᵉ-⇑ n R (masked E)  = cong masked (substᵉ-⇑ n R E)
 -- WHAT THE OTHER SLOTS OWE.  Every entry of `abstN n (abst ∷ Ψ)` is
 -- either ABSTRACT (the prefix, and slot n itself) or an entry of Ψ read
 -- past `n+1` binders — and such an entry names no slot ≤ n, so the mint
--- at slot n leaves it alone.  This is SIMULTANEITY again: a rep is a type
--- over the plain exterior, lifted past the binders inside it.
+-- at slot n leaves it alone: a rep is lifted past exactly the binders
+-- inside it, so it never names a slot of the bind prefix.
 abstN-ent : ∀ {Ψ A} (n : ℕ) {Y E}
   → abstN n (abst ∷ Ψ) ∋e Y , E
     ------------------------------------------------------------

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -39,6 +39,7 @@ open import strong.Types
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.TermSubst
 open import strong.Reduction
 open import strong.proof.Preserve using (preserve-TyPeelR)

--- a/SystemF/agda/strong/proof/Progress.agda
+++ b/SystemF/agda/strong/proof/Progress.agda
@@ -48,6 +48,7 @@ open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
+open import strong.CtxMorph
 open import strong.TermSubst
 open import strong.Reduction
 open import strong.proof.Canonical


### PR DESCRIPTION
Mechanical refactor requested by Jeremy.

* Terms.agda §1–2 → strong/CtxMorph.agda §1–2: the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the induced type contexts (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and `Δ ⊢ᵐ Θ`.
* Reduction.agda §2/§2b → CtxMorph.agda §3–4: `hideBinds`, `dualScope`, `dual` (Peel's crossing frame) and `scopeOf`, `rewind`, `_⋉_` (the scope move for IdPush/CancelR).
* Reduction.agda §1 → Conversion.agda §4: the conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`, and their `mkId` lemmas); Conversion §4–7 renumbered §5–8; Preservation.agda's import repointed. Reduction.agda is now the rules, `-→*`, `value-¬step`, `det` only.
* No compatibility re-export (Codex review): every module that uses the morphism imports `strong.CtxMorph` directly; All.agda, README module map and Design.md/comment pointers updated.
* Obsolete "simultaneity / plain exterior" comments retired across the live development (reps are read on `unlockedScope Θ′ Δ`; the surviving half — lifted past exactly the binders inside it — is stated as such).

Cold `make -C strong check` green, no postulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

