### PR TITLE
Strong System F: the context morphism is a pair — parallel binds, sequential changes

### DIFF
--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -115,10 +115,10 @@ _∋tv_ : Ctxᵗ → ℕ → Set
 
 -- THE COMPLEMENT OF `Nameable`, and the whole of what an `unlock` may
 -- restore: an entry masked ONCE over a nameable one.  `Locked` is what
--- `mw-u` (strong.Terms) demands and what makes `mask ∘ unmask` the
+-- `sw-u` (strong.CtxMorph) demands and what makes `mask ∘ unmask` the
 -- identity at the slot (`mask-unmask`) — the fact the dual's restoring
 -- `lock` needs.  A doubly masked entry is NOT `Locked`, and no
--- `Δ ⊢ᵐ Θ` ever produces one (`mw-l` masks only a nameable slot).
+-- `Δ ⊢ᵐ Θ` ever produces one (`sw-l` masks only a nameable slot).
 data Locked : Ent → Set where
   locked : Nameable E → Locked (masked E)
 
@@ -311,7 +311,7 @@ nameable-mono (le-mu _ _)  ()
 -- abstract slot, but it may NOT un-mask a slot.  This is the transport a
 -- TERM may travel along (`⊢retag`, strong.TermSubst), and it has to be,
 -- because an `unlock X` in a boundary CLAIMS that X is locked
--- (`mw-u`, strong.Terms) and `le-mu` destroys the claim.  Types and
+-- (`sw-u`, strong.CtxMorph) and `le-mu` destroys the claim.  Types and
 -- conversions keep the full `_⊑_` (`⊑-wf`, `conv-⊑`): a TYPE claims
 -- nameability, which only grows.
 data _⊑ᵃᵉ_ : Ent → Ent → Set where
@@ -596,7 +596,7 @@ unmask-mask zero    (E ∷ Δ) = refl
 unmask-mask (suc X) (E ∷ Δ) = cong (E ∷_) (unmask-mask X Δ)
 
 -- Masking undoes unmasking ONLY at a LOCKED slot — which is exactly what
--- `mw-u` (strong.Terms) demands of every `unlock`, and exactly why a
+-- `sw-u` (strong.CtxMorph) demands of every `unlock`, and exactly why a
 -- vacuous unlock had to be refused: at an already-nameable slot the
 -- restoring `lock` of the dual would mask what the exterior left visible.
 maskEnt-unmask : Locked E → masked (unmaskEnt E) ≡ E
@@ -644,7 +644,7 @@ wf-shiftBy-pushBinds (C ∷ As) w =
 -- A one-slot update PAST the bind prefix is the update on the tail: the
 -- prefix has `length As` entries and neither of them is touched.  This is
 -- what lets a boundary's own masking be re-indexed INTO an inner frame
--- (strong.Reduction, `scopeOf`).
+-- (strong.CtxMorph, `shiftScope`).
 updateAt-pushBinds : (f : Ent → Ent) (As : List Ty) (X : ℕ) (Δ : Ctxᵗ)
   → updateAt f (length As + X) (pushBinds As Δ) ≡ pushBinds As (updateAt f X Δ)
 updateAt-pushBinds f []       X Δ = refl

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -2,18 +2,31 @@ module strong.CtxMorph where
 
 -- Strong System F — the BOUNDARY'S CONTEXT MORPHISM and its well-formedness.
 --
--- A boundary is  M ⟪ Θ , c ⟫  (strong.Terms) with ONE frame change:
+-- A boundary is  M ⟪ Θ , c ⟫  (strong.Terms) with ONE frame change.  THE
+-- MORPHISM IS A PAIR (Jeremy, 2026-09-06), because its two halves are not
+-- the same kind of thing:
 --
---   Θ : CtxMorph   the context morphism, rep-free except for binders
---        bind A   BINDS a fresh interior slot; A is its representation, read
---                on `unlockedScope Θ′ Δ` (the tail's unmasks applied, its
---                locks lifted — where the conversion is read).  The only
---                rep-carrying form; born once, bound once.
---        lock X   MASKS exterior slot X: the interior may not NAME it.  The
---                entry is RETAINED on the type context — nothing is dropped
---                and nothing is re-spelled, so there is no demotion.
---        unlock X UNMASKS exterior slot X; it claims nothing but that X IS
---                masked where it acts (no vacuous unlocks).
+--   Θ = morph B S
+--     B : List Ty     the BINDS — a PARALLEL block of binders.  Each entry
+--                is one fresh interior slot's representation, a type over
+--                the exterior read OUTSIDE all of them (and outside every
+--                lock the boundary itself performs); binds never see one
+--                another.
+--     S : List Change the SCOPE CHANGES — a SEQUENTIAL list of name-only
+--                entries, applied head-LAST:
+--                lock X   MASKS exterior slot X: the interior may not NAME
+--                        it.  The entry is RETAINED on the type context —
+--                        nothing is dropped and nothing is re-spelled, so
+--                        there is no demotion.
+--                unlock X UNMASKS exterior slot X; it claims nothing but
+--                        that X IS masked where it acts (no vacuous
+--                        unlocks).
+--
+-- The old interleaved `List MorphEnt` said neither thing: it made the
+-- binds look sequential (a bind's rep was read past its own TAIL only) and
+-- it let a lock sit between two binds, where it had no meaning.  The pair
+-- says exactly what is true, and the list arithmetic that used to project
+-- the two halves apart (`repsOf`, `scope-++` at a bind, …) is gone.
 --
 -- This module defines the morphism, the type contexts it induces
 -- (`scope`, `unlockedScope`, `interior`, `convCtx`), their refinement
@@ -43,171 +56,219 @@ private
 -- 1.  The boundary context morphism
 ------------------------------------------------------------------------
 
-data MorphEnt : Set where
-  bind : Ty → MorphEnt      -- BINDS a fresh slot at rep A (A over the exterior)
-  unlock : ℕ → MorphEnt       -- unmask exterior slot X   (name only)
-  lock : ℕ → MorphEnt       -- mask   exterior slot X   (name only)
+-- A SCOPE CHANGE carries a name only — an EXTERIOR index, unshifted by the
+-- morphism's own binds.  That is the whole point of the redesign: no scope
+-- change carries a representation.
+data Change : Set where
+  lock   : ℕ → Change        -- mask   exterior slot X
+  unlock : ℕ → Change        -- unmask exterior slot X
 
-CtxMorph : Set
-CtxMorph = List MorphEnt
-
-repsOf : CtxMorph → List Ty
-repsOf []             = []
-repsOf (bind A ∷ Θ)   = A ∷ repsOf Θ
-repsOf (unlock X ∷ Θ) = repsOf Θ
-repsOf (lock X ∷ Θ)   = repsOf Θ
+record CtxMorph : Set where
+  constructor morph
+  field
+    binds   : List Ty        -- PARALLEL: reps read outside all of them
+    changes : List Change    -- SEQUENTIAL: applied head-LAST
+open CtxMorph public
 
 -- `numBinds` is the boundary's FRAME EXTENSION: the number of binders it
 -- adds.  It is the only surviving list arithmetic; cmax/dropN have no
 -- analogue, because conceal masks in place.
 numBinds : CtxMorph → ℕ
-numBinds Θ = length (repsOf Θ)
+numBinds Θ = length (binds Θ)
 
--- The masks (`lock`) and unmasks (`unlock`), applied in place.
-scope : CtxMorph → Ctxᵗ → Ctxᵗ
-scope []             Δ = Δ
-scope (bind A ∷ Θ)   Δ = scope Θ Δ
-scope (unlock X ∷ Θ) Δ = unmask X (scope Θ Δ)
-scope (lock X ∷ Θ)   Δ = mask X (scope Θ Δ)
+-- The masks (`lock`) and unmasks (`unlock`), applied in place, head-LAST.
+applyChanges : List Change → Ctxᵗ → Ctxᵗ
+applyChanges []             Δ = Δ
+applyChanges (unlock X ∷ S) Δ = unmask X (applyChanges S Δ)
+applyChanges (lock X ∷ S)   Δ = mask X (applyChanges S Δ)
 
--- The CONVERSION CONTEXT's slots: like `scope` but WITHOUT the conceal
--- masks, so a `seal X` can resolve X at its binder.  This is
+-- The CONVERSION CONTEXT's slots: like `applyChanges` but WITHOUT the
+-- conceal masks, so a `seal X` can resolve X at its binder.  This is
 -- binder-syntactic lookup: the licence is read on the type context that
 -- encloses the boundary, never inside it.
+applyUnlocks : List Change → Ctxᵗ → Ctxᵗ
+applyUnlocks []             Δ = Δ
+applyUnlocks (unlock X ∷ S) Δ = unmask X (applyUnlocks S Δ)
+applyUnlocks (lock X ∷ S)   Δ = applyUnlocks S Δ
+
+-- THE TWO INDUCED CONTEXTS, at the morphism.
+scope : CtxMorph → Ctxᵗ → Ctxᵗ
+scope Θ Δ = applyChanges (changes Θ) Δ
+
 unlockedScope : CtxMorph → Ctxᵗ → Ctxᵗ
-unlockedScope []             Δ = Δ
-unlockedScope (bind A ∷ Θ)   Δ = unlockedScope Θ Δ
-unlockedScope (unlock X ∷ Θ) Δ = unmask X (unlockedScope Θ Δ)
-unlockedScope (lock X ∷ Θ)   Δ = unlockedScope Θ Δ
+unlockedScope Θ Δ = applyUnlocks (changes Θ) Δ
 
 -- What replaces `intOf`: the same slot list, the interior mask, and the
 -- binder extension.  Nothing is dropped and no rep is recomputed.
 interior : CtxMorph → Ctxᵗ → Ctxᵗ
-interior Θ Δ = pushBinds (repsOf Θ) (scope Θ Δ)
+interior Θ Δ = pushBinds (binds Θ) (scope Θ Δ)
 
 convCtx : CtxMorph → Ctxᵗ → Ctxᵗ
-convCtx Θ Δ = pushBinds (repsOf Θ) (unlockedScope Θ Δ)
+convCtx Θ Δ = pushBinds (binds Θ) (unlockedScope Θ Δ)
 
--- The interior type context is the conversion context with Θ's bind
--- masks on, so anything well formed inside is well formed on the
+-- The interior type context is the conversion context with the changes'
+-- locks on, so anything well formed inside is well formed on the
 -- conversion context.
+applyChanges⊑applyUnlocks : (S : List Change) (Δ : Ctxᵗ)
+  → applyChanges S Δ ⊑ applyUnlocks S Δ
+applyChanges⊑applyUnlocks []             Δ = ⊑-refl Δ
+applyChanges⊑applyUnlocks (unlock X ∷ S) Δ =
+  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono
+    (applyChanges⊑applyUnlocks S Δ)
+applyChanges⊑applyUnlocks (lock X ∷ S)   Δ =
+  mask-⊑ X (applyChanges⊑applyUnlocks S Δ)
+
 scope⊑unlockedScope : (Θ : CtxMorph) (Δ : Ctxᵗ)
   → scope Θ Δ ⊑ unlockedScope Θ Δ
-scope⊑unlockedScope []             Δ = ⊑-refl Δ
-scope⊑unlockedScope (bind A ∷ Θ)   Δ = scope⊑unlockedScope Θ Δ
-scope⊑unlockedScope (unlock X ∷ Θ) Δ =
-  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono
-    (scope⊑unlockedScope Θ Δ)
-scope⊑unlockedScope (lock X ∷ Θ)   Δ = mask-⊑ X (scope⊑unlockedScope Θ Δ)
+scope⊑unlockedScope Θ Δ = applyChanges⊑applyUnlocks (changes Θ) Δ
 
 interior⊑convCtx : (Θ : CtxMorph) (Δ : Ctxᵗ) → interior Θ Δ ⊑ convCtx Θ Δ
-interior⊑convCtx Θ Δ = ⊑-pushBinds (repsOf Θ) (scope⊑unlockedScope Θ Δ)
+interior⊑convCtx Θ Δ =
+  ⊑-pushBinds (binds Θ) (scope⊑unlockedScope Θ Δ)
 
 -- The CONVERSION CONTEXT only ever ADDS nameability to the plain
--- exterior: `unlockedScope` skips the binds and the locks, and an
--- `unlock` merely restores.  (`scope` would not do — masking is what a
--- lock is for.)
+-- exterior: `applyUnlocks` skips the locks, and an `unlock` merely
+-- restores.  (`applyChanges` would not do — masking is what a lock is
+-- for.)
+Δ⊑applyUnlocks : (S : List Change) (Δ : Ctxᵗ) → Δ ⊑ applyUnlocks S Δ
+Δ⊑applyUnlocks []             Δ = ⊑-refl Δ
+Δ⊑applyUnlocks (unlock X ∷ S) Δ =
+  ⊑-trans (Δ⊑applyUnlocks S Δ) (unmask-⊑ X (applyUnlocks S Δ))
+Δ⊑applyUnlocks (lock X ∷ S)   Δ = Δ⊑applyUnlocks S Δ
+
 Δ⊑unlockedScope : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊑ unlockedScope Θ Δ
-Δ⊑unlockedScope []             Δ = ⊑-refl Δ
-Δ⊑unlockedScope (bind A ∷ Θ)   Δ = Δ⊑unlockedScope Θ Δ
-Δ⊑unlockedScope (unlock X ∷ Θ) Δ =
-  ⊑-trans (Δ⊑unlockedScope Θ Δ) (unmask-⊑ X (unlockedScope Θ Δ))
-Δ⊑unlockedScope (lock X ∷ Θ)   Δ = Δ⊑unlockedScope Θ Δ
+Δ⊑unlockedScope Θ Δ = Δ⊑applyUnlocks (changes Θ) Δ
+
+⊑-applyChanges : (S : List Change) → Δ ⊑ Δ′
+  → applyChanges S Δ ⊑ applyChanges S Δ′
+⊑-applyChanges []             ls = ls
+⊑-applyChanges (unlock X ∷ S) ls =
+  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-applyChanges S ls)
+⊑-applyChanges (lock X ∷ S)   ls =
+  ⊑-updateAt masked masked-comm masked-mono (⊑-applyChanges S ls)
+
+⊑-applyUnlocks : (S : List Change) → Δ ⊑ Δ′
+  → applyUnlocks S Δ ⊑ applyUnlocks S Δ′
+⊑-applyUnlocks []             ls = ls
+⊑-applyUnlocks (unlock X ∷ S) ls =
+  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-applyUnlocks S ls)
+⊑-applyUnlocks (lock X ∷ S)   ls = ⊑-applyUnlocks S ls
 
 ⊑-scope : (Θ : CtxMorph) → Δ ⊑ Δ′ → scope Θ Δ ⊑ scope Θ Δ′
-⊑-scope []             ls = ls
-⊑-scope (bind A ∷ Θ)   ls = ⊑-scope Θ ls
-⊑-scope (unlock X ∷ Θ) ls =
-  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-scope Θ ls)
-⊑-scope (lock X ∷ Θ)   ls =
-  ⊑-updateAt masked masked-comm masked-mono (⊑-scope Θ ls)
+⊑-scope Θ ls = ⊑-applyChanges (changes Θ) ls
 
 ⊑-unlockedScope : (Θ : CtxMorph) → Δ ⊑ Δ′
   → unlockedScope Θ Δ ⊑ unlockedScope Θ Δ′
-⊑-unlockedScope []             ls = ls
-⊑-unlockedScope (bind A ∷ Θ)   ls = ⊑-unlockedScope Θ ls
-⊑-unlockedScope (unlock X ∷ Θ) ls =
-  ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-unlockedScope Θ ls)
-⊑-unlockedScope (lock X ∷ Θ)   ls = ⊑-unlockedScope Θ ls
+⊑-unlockedScope Θ ls = ⊑-applyUnlocks (changes Θ) ls
 
 ⊑-interior : (Θ : CtxMorph) → Δ ⊑ Δ′ → interior Θ Δ ⊑ interior Θ Δ′
-⊑-interior Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-scope Θ ls)
+⊑-interior Θ ls = ⊑-pushBinds (binds Θ) (⊑-scope Θ ls)
 
 -- … and the same three transports for the LOCK-PRESERVING refinement,
 -- the one a TERM travels along.
+⊑ᵃ-applyChanges : (S : List Change) → Δ ⊑ᵃ Δ′
+  → applyChanges S Δ ⊑ᵃ applyChanges S Δ′
+⊑ᵃ-applyChanges []             ls = ls
+⊑ᵃ-applyChanges (unlock X ∷ S) ls =
+  ⊑ᵃ-updateAt unmaskEnt unmaskEnt-monoᵃ (⊑ᵃ-applyChanges S ls)
+⊑ᵃ-applyChanges (lock X ∷ S)   ls =
+  ⊑ᵃ-updateAt masked masked-monoᵃ (⊑ᵃ-applyChanges S ls)
+
 ⊑ᵃ-scope : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → scope Θ Δ ⊑ᵃ scope Θ Δ′
-⊑ᵃ-scope []             ls = ls
-⊑ᵃ-scope (bind A ∷ Θ)   ls = ⊑ᵃ-scope Θ ls
-⊑ᵃ-scope (unlock X ∷ Θ) ls =
-  ⊑ᵃ-updateAt unmaskEnt unmaskEnt-monoᵃ (⊑ᵃ-scope Θ ls)
-⊑ᵃ-scope (lock X ∷ Θ)   ls =
-  ⊑ᵃ-updateAt masked masked-monoᵃ (⊑ᵃ-scope Θ ls)
+⊑ᵃ-scope Θ ls = ⊑ᵃ-applyChanges (changes Θ) ls
 
 ⊑ᵃ-interior : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → interior Θ Δ ⊑ᵃ interior Θ Δ′
-⊑ᵃ-interior Θ ls = ⊑ᵃ-pushBinds (repsOf Θ) (⊑ᵃ-scope Θ ls)
+⊑ᵃ-interior Θ ls = ⊑ᵃ-pushBinds (binds Θ) (⊑ᵃ-scope Θ ls)
 
 ⊑-convCtx : (Θ : CtxMorph) → Δ ⊑ Δ′ → convCtx Θ Δ ⊑ convCtx Θ Δ′
-⊑-convCtx Θ ls = ⊑-pushBinds (repsOf Θ) (⊑-unlockedScope Θ ls)
+⊑-convCtx Θ ls = ⊑-pushBinds (binds Θ) (⊑-unlockedScope Θ ls)
 
 ------------------------------------------------------------------------
 -- 2.  Boundary well-formedness
 ------------------------------------------------------------------------
 
--- EVERY PREMISE IS READ ON THE FRAME THE ENTRY ACTS ON — the judgement is
--- SEQUENTIAL, in the order `scope` applies the list (head-LAST).  For the
--- tail Θ′ of the entry:
+-- THE JUDGEMENT IS A PAIR, BECAUSE THE MORPHISM IS.
 --
---   lock X    X is NAMEABLE in `scope Θ′ Δ`  (you may only mask what is
---             visible: no double masking, so `Locked` is one mask deep)
---   unlock X  X is LOCKED   in `scope Θ′ Δ`  (`Δ ∋lk X`: masked over a
+-- THE CHANGES half is SEQUENTIAL — every premise is read on the frame the
+-- entry acts on, in the order `applyChanges` applies the list (head-LAST).
+-- For the tail S′ of the entry:
+--
+--   lock X    X is NAMEABLE in `applyChanges S′ Δ`  (you may only mask
+--             what is visible: no double masking, so `Locked` is one mask
+--             deep)
+--   unlock X  X is LOCKED   in `applyChanges S′ Δ`  (`∋lk`: masked over a
 --             nameable entry).  A VACUOUS UNLOCK — `↥X` at a slot the
 --             frame leaves visible — IS REFUSED; it is the premise the
 --             judgement used to drop, and the one the dual's restoring
 --             `lock` needs (`mask-unmask`, strong.Ctx).
---   bind A    A is a type over `unlockedScope Θ′ Δ` — the tail's UNMASKS
---             applied and its LOCKS lifted.  A rep is never blocked by
---             the frame's own locks — it is read where the CONVERSION is
---             read, outside the masking the boundary itself performs —
---             and it may name what the tail unlocked, which is what makes
---             the scope move (`_⋉_`, §4 below) well formed.
+--
+-- THE BINDS half is PARALLEL: every rep is a type over
+-- `applyUnlocks S Δ` — the WHOLE change list's unmasks applied and ALL of
+-- its locks lifted.  A rep is never blocked by the frame's own locks (it
+-- is read where the CONVERSION is read, outside the masking the boundary
+-- itself performs), and it may name whatever the frame unlocks, which is
+-- what makes the scope move (`_⋉_`, §4 below) well formed.  Binds do not
+-- see one another: the block is one simultaneous event.
 --
 -- Note the distinction the mask discipline forces: `unlock X`/`lock X`
--- NAME a masked index — that is an ENTRY, not a type — while `Δ ⊢ᵗ ` X`
+-- NAME a masked index — that is a CHANGE, not a type — while `Δ ⊢ᵗ ` X`
 -- at a masked slot is refused.  Tightness is about USE in a type, not
 -- about mentioning the index in the context morphism.
---
+
+-- The BINDS half, as a list judgement: every rep well formed, all on the
+-- SAME type context (that is what "parallel" means).
+infix 4 _⊢ʳ_
+data _⊢ʳ_ : Ctxᵗ → List Ty → Set where
+  rw[] : Δ ⊢ʳ []
+  rw-b : ∀ {Bs} → Δ ⊢ᵗ A → Δ ⊢ʳ Bs → Δ ⊢ʳ (A ∷ Bs)
+
+-- The CHANGES half, as a sequential judgement.
+infix 4 _⊢ˢ_
+data _⊢ˢ_ : Ctxᵗ → List Change → Set where
+  sw[] : Δ ⊢ˢ []
+  sw-l : ∀ {S} → applyChanges S Δ ∋tv X → Δ ⊢ˢ S → Δ ⊢ˢ (lock X ∷ S)
+  sw-u : ∀ {S} → applyChanges S Δ ∋lk X → Δ ⊢ˢ S → Δ ⊢ˢ (unlock X ∷ S)
+
 -- `Δ ⊢ᵐ Θ` — the context morphism Θ is WELL FORMED over Δ.  An infix
 -- judgement in the family of `Δ ⊢ᵗ A` (strong.Ctx) and `Δ ⊢ c ∶ A ⇝ B`
 -- (strong.Conversion).
 infix 4 _⊢ᵐ_
-data _⊢ᵐ_ : Ctxᵗ → CtxMorph → Set where
-  mw[] : Δ ⊢ᵐ []
-  mw-b : ∀ {A Θ} → unlockedScope Θ Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
-  mw-l : ∀ {X Θ} → scope Θ Δ ∋tv X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
-  mw-u : ∀ {X Θ} → scope Θ Δ ∋lk X → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
+record _⊢ᵐ_ (Δ : Ctxᵗ) (Θ : CtxMorph) : Set where
+  constructor mw
+  field
+    mw-reps    : unlockedScope Θ Δ ⊢ʳ binds Θ
+    mw-changes : Δ ⊢ˢ changes Θ
+open _⊢ᵐ_ public
+
+⊢ʳ-⊑ : ∀ {Bs} → Δ ⊑ Δ′ → Δ ⊢ʳ Bs → Δ′ ⊢ʳ Bs
+⊢ʳ-⊑ ls rw[]        = rw[]
+⊢ʳ-⊑ ls (rw-b w ws) = rw-b (⊑-wf ls w) (⊢ʳ-⊑ ls ws)
 
 -- THE TERM TRANSPORT IS `_⊑ᵃ_`, NOT `_⊑_`.  An `unlock X` CLAIMS that X
 -- is locked, and `le-mu` — the clause that re-exposes a concealed slot —
 -- destroys the claim; `_⊑ᵃ_` (strong.Ctx §4b) is `_⊑_` without it.
+⊢ˢ-⊑ᵃ : ∀ {S} → Δ ⊑ᵃ Δ′ → Δ ⊢ˢ S → Δ′ ⊢ˢ S
+⊢ˢ-⊑ᵃ ls sw[] = sw[]
+⊢ˢ-⊑ᵃ {S = lock X ∷ S}   ls (sw-l tv b) =
+  sw-l (⊑-tv (⊑-applyChanges S (⊑ᵃ→⊑ ls)) tv) (⊢ˢ-⊑ᵃ ls b)
+⊢ˢ-⊑ᵃ {S = unlock X ∷ S} ls (sw-u lk b) =
+  sw-u (⊑ᵃ-lk (⊑ᵃ-applyChanges S ls) lk) (⊢ˢ-⊑ᵃ ls b)
+
 ⊢ᵐ-⊑ᵃ : ∀ {Θ} → Δ ⊑ᵃ Δ′ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ Θ
-⊢ᵐ-⊑ᵃ {Θ = []}           ls mw[]        = mw[]
-⊢ᵐ-⊑ᵃ {Θ = bind A ∷ Θ}   ls (mw-b w b)  =
-  mw-b (⊑-wf (⊑-unlockedScope Θ (⊑ᵃ→⊑ ls)) w) (⊢ᵐ-⊑ᵃ ls b)
-⊢ᵐ-⊑ᵃ {Θ = lock X ∷ Θ}   ls (mw-l tv b) =
-  mw-l (⊑-tv (⊑-scope Θ (⊑ᵃ→⊑ ls)) tv) (⊢ᵐ-⊑ᵃ ls b)
-⊢ᵐ-⊑ᵃ {Θ = unlock X ∷ Θ} ls (mw-u lk b) =
-  mw-u (⊑ᵃ-lk (⊑ᵃ-scope Θ ls) lk) (⊢ᵐ-⊑ᵃ ls b)
+⊢ᵐ-⊑ᵃ {Θ = Θ} ls (mw ws bs) =
+  mw (⊢ʳ-⊑ (⊑-unlockedScope Θ (⊑ᵃ→⊑ ls)) ws) (⊢ˢ-⊑ᵃ ls bs)
 
 ------------------------------------------------------------------------
 -- 3.  The dual of a crossed boundary
 ------------------------------------------------------------------------
 
--- THE DUAL, in full.  It mints ONLY name-carrying entries: a `lock` for each
--- of the crossed boundary's binders (the argument may not see them) and an
--- `unlock` for each of its conceals (the argument came from outside, where they
--- were nameable).  Nothing is copied, nothing is guarded, nothing is
--- demoted; the old design's `entᴳ` has no analogue.
-hideBinds : ℕ → CtxMorph
+-- THE DUAL, in full.  It mints ONLY scope changes — it has NO BINDS at
+-- all: a `lock` for each of the crossed boundary's binders (the argument
+-- may not see them) and an `unlock` for each of its conceals (the
+-- argument came from outside, where they were nameable).  Nothing is
+-- copied, nothing is guarded, nothing is demoted; the old design's `entᴳ`
+-- has no analogue.
+hideBinds : ℕ → List Change
 hideBinds zero    = []
 hideBinds (suc k) = lock k ∷ hideBinds k
 
@@ -218,29 +279,29 @@ hideBinds (suc k) = lock k ∷ hideBinds k
 -- that does not re-mask hands the crossing argument a frame STRICTLY MORE
 -- NAMEABLE than the exterior — `Peel` GAINS SCOPE, machine-checked in
 -- proof/DualTightness.agda.  So `unlock X ↦ lock (n + X)`, and the
--- restoring `lock` is sound exactly because `mw-u` (strong.Terms) refuses
--- a VACUOUS unlock: `mask ∘ unmask` is the identity at a LOCKED slot
+-- restoring `lock` is sound exactly because `sw-u` refuses a VACUOUS
+-- unlock: `mask ∘ unmask` is the identity at a LOCKED slot
 -- (`mask-unmask`, strong.Ctx) and nowhere else.
 --
--- AND THE LIST IS REVERSED.  `scope` applies its list HEAD-LAST, so
+-- AND THE LIST IS REVERSED.  `applyChanges` applies its list HEAD-LAST, so
 -- undoing it runs the entries BACK TO FRONT; a same-order dual is not an
--- inverse at a frame that toggles one slot twice (`Θ = ↥X ∷ ↧X ∷ []`,
+-- inverse at a frame that toggles one slot twice (`S = ↥X ∷ ↧X ∷ []`,
 -- which the judgement admits).  With both repairs the frame identity is
 -- EXACT (proof/PeelDual, `interior-dual`): the crossing argument's frame
 -- is the exterior itself, one bind prefix in, and it crosses by
 -- `⊢rename` alone — no `⊢retag`, no `le-mu`.
-dualScope : ℕ → CtxMorph → CtxMorph
+dualScope : ℕ → List Change → List Change
 dualScope n []             = []
-dualScope n (bind A ∷ Θ)   = dualScope n Θ
-dualScope n (unlock X ∷ Θ) = dualScope n Θ ++ (lock   (n + X) ∷ [])
-dualScope n (lock X ∷ Θ)   = dualScope n Θ ++ (unlock (n + X) ∷ [])
+dualScope n (unlock X ∷ S) = dualScope n S ++ (lock   (n + X) ∷ [])
+dualScope n (lock X ∷ S)   = dualScope n S ++ (unlock (n + X) ∷ [])
 
 dual : CtxMorph → CtxMorph
-dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
+dual Θ =
+  morph [] (hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) (changes Θ))
 
--- (The old Cancel residue `repsOf→bind` — a frame that rebinds Θ₂'s binders
--- and nothing else — is GONE with the rule that wrote it: the repaired
--- CancelR keeps both frames and mints none.)
+-- (The old Cancel residue `repsOf→bind` — a frame that rebinds Θ₂'s
+-- binders and nothing else — is GONE with the rule that wrote it: the
+-- repaired CancelR keeps both frames and mints none.)
 
 ------------------------------------------------------------------------
 -- 4.  THE SCOPE MOVE — the outer frame's locks go INTO the inner one
@@ -254,53 +315,56 @@ dual Θ = hideBinds (numBinds Θ) ++ dualScope (numBinds Θ) Θ
 -- was the wall (the old proof/PreserveObstruct §4).
 --
 -- The repair is not a side condition but a FRAME MOVE: the outer frame's
--- whole SCOPE travels into the inner frame's TAIL, where `scope` applies
--- it FIRST — exactly where it applied before — and what stays outside is
--- the frame with its own scope REWOUND (`rewind Θ₂`), whose net effect on
--- the exterior is its BIND PREFIX alone.  The rep is then presented
--- OUTSIDE the locks, where it is nameable, and the locks still stand
--- between the value and the world.
+-- whole change list travels into the inner frame's TAIL, where
+-- `applyChanges` applies it FIRST — exactly where it applied before — and
+-- what stays outside is the frame with its own changes REWOUND
+-- (`rewind Θ₂`), whose net effect on the exterior is its BIND BLOCK
+-- alone.  The rep is then presented OUTSIDE the locks, where it is
+-- nameable, and the locks still stand between the value and the world.
 --
--- WHY THE UNLOCKS TRAVEL TOO.  `scope` applies its list HEAD-LAST, so
--- moving only the LOCKS past a same-slot `unlock` reorders a mask/unmask
--- pair, and the value's frame is then not refined but CORRUPTED — a slot
--- it may name is masked in the contractum and was not in the redex
--- (`¬frame-locksOnly`, proof/MoveScope §4b, at the ⊢ᵐ-legal
--- `Θ₂ = unlock 0 ∷ lock 0 ∷ []`).  Moving the WHOLE scope keeps the
--- order, and then the value's frame is preserved ON THE NOSE: the two
+-- WHY THE UNLOCKS TRAVEL TOO.  `applyChanges` applies its list HEAD-LAST,
+-- so moving only the LOCKS past a same-slot `unlock` reorders a
+-- mask/unmask pair, and the value's frame is then not refined but
+-- CORRUPTED — a slot it may name is masked in the contractum and was not
+-- in the redex (`¬frame-locksOnly`, proof/MoveScope §4b, at the ⊢ᵐ-legal
+-- `Θ₂ = morph [] (unlock 0 ∷ lock 0 ∷ [])`).  Moving the WHOLE list keeps
+-- the order, and then the value's frame is preserved ON THE NOSE: the two
 -- frame lemmas are EQUALITIES, no `⊢retag` appears in either case, and
 -- there is no premise about Θ₂'s shape for Progress to supply.
 
--- The outer frame's scope entries, lifted past its own binders.
-scopeOf : ℕ → CtxMorph → CtxMorph
-scopeOf n []             = []
-scopeOf n (bind A ∷ Θ)   = scopeOf n Θ
-scopeOf n (unlock X ∷ Θ) = unlock (n + X) ∷ scopeOf n Θ
-scopeOf n (lock X ∷ Θ)   = lock (n + X) ∷ scopeOf n Θ
+-- The outer frame's changes, lifted past its own binders.
+shiftScope : ℕ → List Change → List Change
+shiftScope n []             = []
+shiftScope n (unlock X ∷ S) = unlock (n + X) ∷ shiftScope n S
+shiftScope n (lock X ∷ S)   = lock (n + X) ∷ shiftScope n S
 
--- WHAT IS LEFT OF THE OUTER FRAME: the frame with its OWN SCOPE REWOUND.
+-- WHAT IS LEFT OF THE OUTER FRAME: the frame with its OWN CHANGES
+-- REWOUND.
 --
--- `rewind Θ` is Θ with its inverse scope run on top, so its net effect on
--- the exterior is the BIND PREFIX ALONE:
+-- `rewind Θ` is Θ with its inverse change list run on top, so its net
+-- effect on the exterior is the BIND BLOCK ALONE:
 --
---     scope    (rewind Θ) Δ ≡ Δ                       (given Δ ⊢ᵐ Θ)
---     interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ
+--     scope    (rewind Θ) Δ ≡ Δ                     (given Δ ⊢ᵐ Θ)
+--     interior (rewind Θ) Δ ≡ pushBinds (binds Θ) Δ
 --
--- which is what makes the moved scope reproduce the redex's frame ON THE
--- NOSE (`interior-⋉-rewind`, proof/MoveScope) — no `⊢retag` and no
+-- which is what makes the moved changes reproduce the redex's frame ON
+-- THE NOSE (`interior-⋉-rewind`, proof/MoveScope) — no `⊢retag` and no
 -- `le-mu` anywhere in the two cases.
 --
--- IT IS NOT `bindsOnly Θ`, AND THAT IS THE POINT.  Simply DELETING Θ's
--- scope has the same effect on the type context but loses the frame's own
--- `⊢ᵐ`: Θ's bind reps are read on `unlockedScope Θ′ Δ` (strong.Terms,
--- `mw-b`) and a rep naming a slot Θ's tail UNLOCKED is not well formed on
--- the plain Δ.  Keeping the entries and rewinding them keeps every rep
--- exactly where it was read.
+-- IT IS NOT `morph (binds Θ) []`, AND THAT IS THE POINT.  Simply DELETING
+-- Θ's changes has the same effect on the type context but loses the
+-- frame's own `⊢ᵐ`: Θ's bind reps are read on `unlockedScope Θ Δ` and a
+-- rep naming a slot Θ UNLOCKED is not well formed on the plain Δ.
+-- Keeping the entries and rewinding them keeps every rep exactly where it
+-- was read.
 rewind : CtxMorph → CtxMorph
-rewind Θ = dualScope 0 Θ ++ Θ
+rewind Θ = morph (binds Θ) (dualScope 0 (changes Θ) ++ changes Θ)
 
--- The inner frame, with the outer frame's scope moved in at its TAIL.
--- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁`: the move carries no binder.
+-- The inner frame, with the outer frame's changes moved in at its TAIL.
+-- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` DEFINITIONALLY: the move carries no
+-- binder, and with the pair that is a fact about the constructor, not a
+-- lemma about a filtered list.
 infixl 5 _⋉_
 _⋉_ : CtxMorph → CtxMorph → CtxMorph
-Θ₁ ⋉ Θ₂ = Θ₁ ++ scopeOf (numBinds Θ₂) Θ₂
+Θ₁ ⋉ Θ₂ =
+  morph (binds Θ₁) (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -89,7 +89,7 @@ not typeable at any type.
    the boundary's **current** position — `interior Θ Δ` is a function of
    the ambient `Δ` — never remembered from the boundary's birth.
 2. **A type argument is never pushed into a concealed body.**  `TyPeelR`
-   records it as a **new bind** on the boundary, `bind A ∷ Θ`, and
+   records it as a **new bind** on the boundary (one bind prepended), and
    instantiates the interior at the fresh *name* `` ` 0 `` (§6.4).  So a
    boundary has to carry a bind and a lock at the same time: it is a
    **list** — a context morphism — and not a single reveal-or-conceal.
@@ -183,29 +183,53 @@ the empty term context.
 
 ### Context morphisms (`strong.CtxMorph`)
 
-`Θ : CtxMorph` is a list of **morphism entries**, Jeremy's *context
-morphism*: it maps the type context outside the boundary to the type
-context inside it.  There are three entries, written here in the form
-the renderer prints:
+`Θ : CtxMorph` is Jeremy's *context morphism*: it maps the type context
+outside the boundary to the type context inside it.  **It is a PAIR**
+(2026-09-06), because its two halves are not the same kind of thing:
 
-| entry     | rendered | what it does                                   |
+```agda
+data Change : Set where
+  lock unlock : ℕ → Change          -- EXTERIOR indices, name only
+
+record CtxMorph : Set where
+  constructor morph
+  field
+    binds   : List Ty               -- PARALLEL block of binders
+    changes : List Change           -- SEQUENTIAL, applied head-LAST
+```
+
+| half      | rendered | what it does                                   |
 |-----------|----------|------------------------------------------------|
-| `bind A`  | `↑X:=A`  | binds a **fresh** interior slot at rep `A`     |
+| a `binds` entry `A` | `↑X:=A`  | binds a **fresh** interior slot at rep `A` |
 | `lock X`  | `↓X`     | **masks** exterior slot `X`                    |
 | `unlock X`| `↥X`     | **unmasks** exterior slot `X`                  |
 
-Only `bind` carries a type, and that type — the *representation* — is
-read in the **exterior**, never through `Θ`'s other entries
-(§8, simultaneity).  `lock` and `unlock` carry a name and nothing else.
-The list is applied **head-last**: in `↥Y , ↓Y` the `↓Y` acts first.
+The renderer prints the pair in its own order — binds first, then
+changes, then the conversion:  `⟪ ↑X:=A , ↓Y , ↥Z , c ⟫`.
 
-Two derived numbers, both in `strong.CtxMorph`:
+**The binds are PARALLEL.**  They are one simultaneous event: no bind
+sees another, and every rep is read on the same type context — the
+exterior with the whole change list's *unmasks* applied and *all* of its
+locks lifted (§4.2).  A representation is therefore never blocked by the
+frame's own locks (§8, simultaneity).
 
-    repsOf   : CtxMorph → List Ty     -- the bind entries' reps, in order
-    numBinds : CtxMorph → ℕ            -- numBinds Θ = length (repsOf Θ)
+**The changes are SEQUENTIAL.**  They carry a name and nothing else, and
+the list is applied **head-last**: in `↥Y , ↓Y` the `↓Y` acts first.  A
+change's index is an *exterior* index, unshifted by the morphism's own
+binds.
+
+The old shape was one interleaved `List MorphEnt` with a `bind`
+constructor mixed in among `lock`/`unlock`.  It said neither thing: it
+made the binds look sequential (a rep was read past its own *tail* only)
+and it let a lock sit between two binds, where a lock has no meaning.
+
+One derived number, in `strong.CtxMorph`:
+
+    numBinds : CtxMorph → ℕ            -- numBinds Θ = length (binds Θ)
 
 `numBinds Θ` is the boundary's **frame extension**: the number of binders
-it adds.  It is the only list arithmetic that survives from v1.
+it adds.  It is the only list arithmetic that survives from v1.  (The
+projection `repsOf` is gone: it *is* the field `binds`.)
 
 ### Conversions (`strong.Conversion`)
 
@@ -245,8 +269,9 @@ type contexts.  A locked `X` is masked in the interior context, so it
 cannot appear on the interior side of a leaf; a bound `X` is not in the
 image of `shiftBy`, so it cannot appear on the exterior side.  A single
 global `p` is uniform only for single-kind morphisms, and it breaks the
-first time a rule mints a mixed one: `TyPeelR`'s frame `bind A ∷ Θ` at
-`Θ = lock 0 ∷ []` produces the conversion `seal 0 ↦ seal 1`, whose two
+first time a rule mints a mixed one: `TyPeelR`'s frame, one bind
+prepended to `Θ = morph [] (lock 0 ∷ [])`, produces the conversion
+`seal 0 ↦ seal 1`, whose two
 leaves cite *different* binders and demand opposite values of one `p`
 (`Examples` §13a, `¬seal↦seal` in the record).  Dropping `p` is what
 makes `TyPeelR` preservation a theorem at every `∀`-conversion rather
@@ -314,7 +339,7 @@ runs along the `le-mu`-free refinement
 
 with `Δ ⊑ᵃ Δ′` pointwise and `⊑ᵃ→⊑` the embedding.  Its one content is
 `⊑ᵃᵉ-Locked : E ⊑ᵃᵉ E′ → Locked E → Locked E′` — *a locked slot stays
-locked* — which is what `⊢ᵐ-⊑ᵃ` needs at `mw-u`.  Every call site is
+locked* — which is what `⊢ˢ-⊑ᵃ` needs at `sw-u`.  Every call site is
 covered: `preserve-TyBeta` refines an `abst` to a `bind` (`la-ab`), and
 the two former `le-mu` sites — the Peel crossing and the scope move — are
 now exact identities and use no retagging at all (§6.3, §6.7).
@@ -347,16 +372,19 @@ As a well-formedness fact:
 Write `Δ` for the **exterior** — the type context in which the whole
 term `M ⟪ Θ , c ⟫` is typed.  A boundary induces two more:
 
-    scope  Θ Δ           -- Δ with Θ's locks AND unlocks applied, in order
-    unlockedScope Θ Δ    -- Δ with only Θ's unlocks applied (locks skipped)
+    applyChanges S Δ     -- Δ with S's locks AND unlocks applied, in order
+    applyUnlocks S Δ     -- Δ with only S's unlocks applied (locks skipped)
 
-    interior Θ Δ = pushBinds (repsOf Θ) (scope Θ Δ)
+    scope         Θ Δ = applyChanges (changes Θ) Δ
+    unlockedScope Θ Δ = applyUnlocks (changes Θ) Δ
+
+    interior Θ Δ = pushBinds (binds Θ) (scope Θ Δ)
                                         -- THE INTERIOR context
-    convCtx  Θ Δ = pushBinds (repsOf Θ) (unlockedScope Θ Δ)
+    convCtx  Θ Δ = pushBinds (binds Θ) (unlockedScope Θ Δ)
                                         -- THE CONVERSION context
 
 `interior Θ Δ` is where `M` is typed: `Θ`'s masks are applied and `Θ`'s
-`bind` entries are pushed on.  Why the conversion needs a context of its
+binds are pushed on.  Why the conversion needs a context of its
 *own* — why `c : Bᵢ ⇝ Bₑ` can be checked neither inside nor outside — is
 the question this section answers, on `Examples` §13a's inner boundary
 
@@ -382,8 +410,8 @@ name it.
 So the conversion needs the binders **and** the locked slots: binds
 pushed, locks lifted.  That is `convCtx Θ Δ`, the smallest context in
 which both leaves resolve.  It is not a third *construction* but the same
-one with the locks skipped: `unlockedScope` is `scope` minus its `lock`
-clause, so **the conversion context is the interior of the same boundary
+one with the locks skipped: `applyUnlocks` is `applyChanges` minus its
+`lock` clause, so **the conversion context is the interior of the same boundary
 with its locks removed**.  (As an *operation* on frames, removing the
 locks — `dropLocks` — is retired: it cannot be the outer frame of the
 scope move, §6.7, and it survives only as a local definition in
@@ -434,7 +462,7 @@ polarity index could type the tree.
 Indices: everything inside the boundary is `numBinds Θ` slots deeper than
 outside, so an exterior type `Bₑ` is read inside as `shiftBy (numBinds Θ) Bₑ`.
 `lock X` / `unlock X` name **exterior** slots, and the rules that move a
-morphism inward lift those names by the bind count (`scopeOf`, §6.7).
+morphism inward lift those names by the bind count (`shiftScope`, §6.7).
 
 ### Vocabulary
 
@@ -442,8 +470,10 @@ This note uses the Agda names throughout; they are the plain-English ones,
 and Appendix A lists them all.  The ones used most here:
 `interior` = *interior type context*, `convCtx` = *conversion context,
 the one the conversion is checked in*, `scope` = *scope*,
-`unlockedScope` = *scope with the locks lifted*, `pushBinds` = *push the
-representations on as binders*, `numBinds` = *number of binds*, `shiftBy` =
+`unlockedScope` = *scope with the locks lifted*, `binds` = *the parallel
+block of representations*, `changes` = *the sequential lock/unlock list*,
+`pushBinds` = *push the representations on as binders*,
+`numBinds` = *number of binds*, `shiftBy` =
 *shift past n binders*.
 
 
@@ -462,15 +492,31 @@ masked slot is unnameable, and a `∀` pushes `abst`, never a `bind`.
 ### 4.2 Well-formed context morphisms — `Δ ⊢ᵐ Θ`
 
 Read "the context morphism `Θ` is well formed over `Δ`"; an infix
-judgement in the family of `Δ ⊢ᵗ A` and `Δ ⊢ c ∶ A ⇝ B`.  The judgement
-is **sequential**: every premise is read on the frame the entry acts on,
-i.e. on the context the entries to its right (which `scope` applies
-first) have already built.
+judgement in the family of `Δ ⊢ᵗ A` and `Δ ⊢ c ∶ A ⇝ B`.  **It is a pair,
+because the morphism is** — one judgement per half:
 
-    mw[] : Δ ⊢ᵐ []
-    mw-b : unlockedScope Θ Δ ⊢ᵗ A → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (bind A ∷ Θ)
-    mw-l : scope Θ Δ ∋tv X        → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (lock X ∷ Θ)
-    mw-u : scope Θ Δ ∋lk X        → Δ ⊢ᵐ Θ → Δ ⊢ᵐ (unlock X ∷ Θ)
+```agda
+data _⊢ʳ_ : Ctxᵗ → List Ty → Set where        -- the PARALLEL reps
+  rw[] : Δ ⊢ʳ []
+  rw-b : Δ ⊢ᵗ A → Δ ⊢ʳ Bs → Δ ⊢ʳ (A ∷ Bs)
+
+data _⊢ˢ_ : Ctxᵗ → List Change → Set where    -- the SEQUENTIAL changes
+  sw[] : Δ ⊢ˢ []
+  sw-l : applyChanges S Δ ∋tv X → Δ ⊢ˢ S → Δ ⊢ˢ (lock X ∷ S)
+  sw-u : applyChanges S Δ ∋lk X → Δ ⊢ˢ S → Δ ⊢ˢ (unlock X ∷ S)
+
+record _⊢ᵐ_ (Δ : Ctxᵗ) (Θ : CtxMorph) : Set where
+  constructor mw
+  field
+    mw-reps    : unlockedScope Θ Δ ⊢ʳ binds Θ
+    mw-changes : Δ ⊢ˢ changes Θ
+```
+
+The **changes** half is *sequential*: every premise is read on the frame
+the change acts on, i.e. on the context the changes to its right (which
+`applyChanges` applies first) have already built.  The **reps** half is
+*parallel*: every rep is read on ONE context, `unlockedScope Θ Δ` — the
+whole change list's unmasks applied, all of its locks lifted.
 
 A `lock` names a slot that is **still visible** where it acts — so a slot
 is never masked twice, and `Locked` is one mask deep.  An `unlock` names
@@ -493,21 +539,32 @@ plain `Δ`.**  This is the surviving half of simultaneity, and it is
 forced from both sides:
 
 * not on `scope Θ Δ` — a rep must never be blocked by the frame's *own*
-  locks, or `TyPeelR`'s new frame `bind A ∷ Θ` would be ill formed
-  whenever `Θ` locks a slot the type argument `A` names;
+  locks, or `TyPeelR`'s new frame (one bind prepended to `Θ`) would be
+  ill formed whenever `Θ` locks a slot the type argument `A` names;
 * not on the plain `Δ` — the scope move `_⋉_` (§6.7) merges an inner
-  frame's binds with an enclosing frame's scope, and the inner frame's
+  frame's binds with an enclosing frame's changes, and the inner frame's
   reps were read past that enclosing frame's *unlocks*.  With a
-  plain-`Δ` `mw-b` the merged frame has no derivation
-  (`proof/MwUObstruct` §4, at `Θ₁ ⋉ Θ₂ = bind (` 0) ∷ unlock 0 ∷ []`
-  over an exterior that masks slot 0).
+  plain-`Δ` rep half the merged frame has no derivation
+  (`proof/MwUObstruct` §4, at
+  `Θ₁ ⋉ Θ₂ = morph (` 0 ∷ []) (unlock 0 ∷ [])` over an exterior that
+  masks slot 0).
 
-**What the strengthened `mw-u` costs, and how it is paid.**  Under it
-`mw-l` and `mw-u` are exact complements — a lock names a *nameable* slot,
-an unlock a *locked* one — so no *simultaneous* `_⊢ᵐ_` could hold of a
-list that both locks and unlocks one slot, and the scope move builds
-exactly such lists.  The sequential reading above is what admits them.
-Two further consequences:
+**The one semantic move the pair makes.**  The interleaved list read a
+rep past *its own tail only*: in `bind A ∷ ↥X ∷ []` the rep `A` saw the
+`↥X`, but in `↥X ∷ bind A ∷ []` it did not.  The pair reads **every** rep
+past the **whole** change list, which is strictly more permissive — a rep
+may now name a slot an unlock to its *left* re-exposes.  That is what
+"the binds are a parallel block" means: there is no left and no right
+among them, and none of them is nested inside a change.  Nothing in the
+development depended on the tighter reading: every `⊢ᵐ` derivation in
+`Examples` and in `proof/` goes through unchanged (§9).
+
+**What the strengthened `sw-u` costs, and how it is paid.**  Under it
+`sw-l` and `sw-u` are exact complements — a lock names a *nameable* slot,
+an unlock a *locked* one — so no *simultaneous* change judgement could
+hold of a list that both locks and unlocks one slot, and the scope move
+builds exactly such lists.  The sequential reading above is what admits
+them.  Two further consequences:
 
 * `⊢retag` no longer runs along `⊑`: `le-mu` *unmasks*, which destroys an
   `unlock`'s claim.  Terms travel along `_⊑ᵃ_`, the `le-mu`-free
@@ -536,8 +593,9 @@ and the boundary rule, in full:
 Premise by premise:
 
 1. **`Δ ⊢ᵐ Θ`** — the morphism is well formed over the exterior
-   (§4.2).  This is the only place the morphism's own entries are
-   checked, and they are all checked *simultaneously*, against `Δ`.
+   (§4.2).  This is the only place the morphism's own halves are
+   checked: the binds *simultaneously*, against `unlockedScope Θ Δ`; the
+   changes *sequentially*, each against the frame it acts on.
 2. **`interior Θ Δ ∣ [] ⊢ M ⦂ Bᵢ`** — the interior is typed in the interior
    type context, at the **empty term context**: a boundary is
    term-closed.  `Bᵢ` is the **interior type**, a type of the interior
@@ -686,9 +744,10 @@ each of its unlocks (the argument came from outside, where those were
 * **it must restore the unlocks.**  Dropping the `unlock` case is the
   tightness defect of §6.3: the crossing argument then gets a frame
   strictly more nameable than the exterior.  Restoring is sound because
-  `mw-u` refuses a vacuous unlock, so `mask ∘ unmask` really is the
+  `sw-u` refuses a vacuous unlock, so `mask ∘ unmask` really is the
   identity at the slot;
-* **it must run backwards.**  `scope` applies its list head-last, so an
+* **it must run backwards.**  `applyChanges` applies its list head-last,
+  so an
   inverse must undo the entries in reverse order — hence the append at
   the end of each clause.  A same-order dual is not an inverse at a frame
   that toggles one slot twice (`↥X , ↓X`, which the judgement admits).
@@ -698,14 +757,15 @@ unconditionally (`proof/PeelDual.agda`).
 
 **The scope move** (§6.7):
 
-    scopeOf n []           = []           -- Θ's SCOPE, indices lifted by n
-    scopeOf n (bind A , Θ) = scopeOf n Θ
-    scopeOf n (unlock X , Θ) = unlock (n+X) , scopeOf n Θ
-    scopeOf n (lock X , Θ)   = lock   (n+X) , scopeOf n Θ
+    shiftScope n []             = []      -- the CHANGES, indices lifted by n
+    shiftScope n (unlock X , S) = unlock (n+X) , shiftScope n S
+    shiftScope n (lock X , S)   = lock   (n+X) , shiftScope n S
 
-    rewind Θ = dualScope 0 Θ ++ Θ        -- Θ with its own SCOPE undone
+    rewind Θ = morph (binds Θ)           -- Θ with its own CHANGES undone
+                     (dualScope 0 (changes Θ) ++ changes Θ)
 
-    Θ₁ ⋉ Θ₂ = Θ₁ ++ scopeOf (numBinds Θ₂) Θ₂
+    Θ₁ ⋉ Θ₂ = morph (binds Θ₁)
+                    (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))
 
 Note `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` and
 `numBinds (rewind Θ) ≡ numBinds Θ`: neither operation carries a binder.
@@ -714,7 +774,7 @@ Note `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` and
 ### 6.1 `TyBeta` — the boundary is born
 
     TyBeta : Value N
-      → Δ ⊢ (Λ N) ·[ B , A ] -→ N ⟪ bind A ∷ [] , reveal 0 B ⟫
+      → Δ ⊢ (Λ N) ·[ B , A ] -→ N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫
 
 Named:  `(ΛX. N) [B, A]  →  N ⟪ ↑X:=A , reveal X B ⟫`, `N` a value.
 
@@ -774,7 +834,7 @@ outside, where they were nameable).  `wkᴹ (numBinds Θ)` re-indexes the
 argument one bind frame deeper.
 
 Example (`Examples` §6, `P₁ → P₂`), with
-`dual (bind ℕ ∷ []) ≡ lock 0 ∷ []`:
+`dual (morph (ℕ ∷ []) []) ≡ morph [] (lock 0 ∷ [])`:
 
     (((λx:X. x) ⟪ ↑X:=ℕ , (seal X ↦ unseal X) ⟫) · 7)
       →  (((λx:X. x) · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
@@ -795,11 +855,11 @@ gained through the boundary.  That is a failure of design law 2 for the
 *reduction relation* (not of preservation: the redex is not well typed).
 
 It is repaired, in two coupled halves — the restoring, reversed
-`dualScope` above and the `mw-u` that refuses a vacuous unlock (§4.2).
+`dualScope` above and the `sw-u` that refuses a vacuous unlock (§4.2).
 The frame identity is then **exact**:
 
     (†)  interior (dual Θ) (interior Θ Δ)
-           ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ      given Δ ⊢ᵐ Θ
+           ≡ map masked (pushBinds (binds Θ) []) ++ Δ       given Δ ⊢ᵐ Θ
 
 *the crossing argument's frame IS the exterior*, one (masked) bind prefix
 in — so the argument crosses by `⊢rename (wkN (numBinds Θ))` alone, with
@@ -814,17 +874,19 @@ its frame.
       → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
       → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
           -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-               ⟪ bind A ∷ Θ , instReveal 0 s ⟫
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
 Named: `(V ⟪ Θ , ∀X. s ⟫) [B, A] → (V [Bᵢ, X]) ⟪ ↑X:=A , Θ , instReveal X s ⟫`
 where `Bᵢ` is the interior `∀`-body determined by the premise.
 
 **Bookkeeping**, three moves:
 
-1. **A new binder is prepended.**  The frame becomes `bind A ∷ Θ` — plain
+1. **A new binder is prepended.**  The frame becomes
+   `morph (A ∷ binds Θ) (changes Θ)` — plain
    `Θ`, not shifted, because `interior` already lifts `Θ`'s representations
    past the prepended binder:
-   `interior (bind A ∷ Θ) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`.
+   `interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+    ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`.
 2. **The interior is instantiated at the new binder's name**, `` ` 0 ``,
    not at `A`.  The pushed-in body annotation must be the **interior**
    `∀`-body `Bᵢ`, which is what the interior's own `⊢·[]` demands and
@@ -935,17 +997,17 @@ The repair is not a side condition but a **frame move** (Jeremy,
 order, lifted past its own binders — travels into the inner frame's tail
 (`Θ₁ ⋉ Θ₂`), where `scope` applies it **first**, exactly where it applied
 before; and what stays outside is the frame with its own scope **rewound**
-(`rewind Θ₂ = dualScope 0 Θ₂ ++ Θ₂`), whose net effect on the exterior is
+(`rewind Θ₂`, its changes prefixed by their inverse), whose net effect is
 its bind prefix alone:
 
     scope    (rewind Θ₂) Δ ≡ Δ                      given Δ ⊢ᵐ Θ₂
-    interior (rewind Θ₂) Δ ≡ pushBinds (repsOf Θ₂) Δ
+    interior (rewind Θ₂) Δ ≡ pushBinds (binds Θ₂) Δ
 
 The representation is then presented outside the locks, where it is
 nameable, and the locks still stand between the value and the world.
 
 **Why `rewind`, and not the two cheaper frames.**  All three of
-`rewind Θ₂`, `dropLocks Θ₂` and `bindsOnly Θ₂` (delete the scope
+`rewind Θ₂`, `dropLocks Θ₂` and `morph (binds Θ₂) []` (delete the changes
 outright) leave the same type context.  Only `rewind` keeps its own
 `_⊢ᵐ_`, and both alternatives are refuted on ONE configuration
 (`proof/MwUObstruct`): `Δ₆ = ↓U`, `Θ₂ = ↥U`, `Θ₁ = ↑V:=U`, so that
@@ -953,9 +1015,9 @@ outright) leave the same type context.  Only `rewind` keeps its own
 
 * `dropLocks Θ₂` KEEPS `Θ₂`'s unlocks, so the *moved copy* of the same
   unlock lands where the slot is already nameable — a vacuous unlock,
-  which `mw-u` refuses (`¬⊢ᵐ-dropLocks`);
-* `bindsOnly Θ₂` DELETES them, and then `Θ₂`'s *own* bind representation
-  — read on `unlockedScope Θ₂′ Δ`, i.e. past that very unlock — is
+  which `sw-u` refuses (`¬⊢ᵐ-dropLocks`);
+* `morph (binds Θ₂) []` DELETES them, and then `Θ₂`'s *own* bind representation
+  — read on `unlockedScope Θ₂ Δ`, i.e. past that very unlock — is
   stranded on the plain exterior (`¬⊢ᵐ-bindsOnly`);
 * `rewind Θ₂` keeps every entry and rewinds it, so every premise is read
   exactly where the redex read it (`⊢ᵐ-rewind`).
@@ -998,7 +1060,7 @@ reorders a mask/unmask pair, and the value's frame is then not refined
 but **corrupted** — a slot it may name in the redex is masked in the
 contractum.  The refutation is in tree
 (`proof/MoveScope` §4b, `¬frame-locksOnly`) at the `_⊢ᵐ_`-legal witness
-`Θ✗ = unlock 0 ∷ lock 0 ∷ []` over `Δ✗ = bind ℕ ∷ []`, where
+`Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])` over `Δ✗ = bind ℕ ∷ []`, where
 `interior Θ✗ Δ✗ ≡ bind ℕ ∷ []` but the lock-only contractum's interior is
 `masked (bind ℕ) ∷ []`.  Moving the whole scope keeps the order, and then
 the value's frame is preserved **on the nose**: with `rewind` outside,
@@ -1113,13 +1175,13 @@ Induction on the step, with the rule cases distributed:
   (`le-ab`), so the interior retypes by `⊢retag`; the minted conversion
   types by `⊢reveal`/`⊢conceal`, and its exterior type is the
   instantiated body by `subst-at-0`.  The exterior premise is `⊢·[]`'s
-  own two premises through `wf-[]ᵗ`, and `interior (bind A ∷ []) Δ` is
+  own two premises through `wf-[]ᵗ`, and `interior (morph (A ∷ []) []) Δ` is
   definitional.
 * **`Beta`** — `⊢subst` (`strong.TermSubst`).
 * **`Peel`** (`proof/PeelDual.preserve-Peel`) — the two context
   identities are what carries it: (†)
   `interior (dual Θ) (interior Θ Δ)
-  ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ` (given `Δ ⊢ᵐ Θ`)
+  ≡ map masked (pushBinds (binds Θ) []) ++ Δ` (given `Δ ⊢ᵐ Θ`)
   and `convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ`.  The crossing
   argument, typed in `Δ`, retypes one bind frame deeper by
   `⊢rename (wkN (numBinds Θ))` and **nothing else** — the tail is `Δ`
@@ -1139,11 +1201,12 @@ Induction on the step, with the rule cases distributed:
   binder that `move-∋` transports; and the exterior premise is
   `moved-scoped`, the one the wall used to deny — which is now just
   `wf-shiftBy-pushBinds` on the redex's own exterior type, because
-  `interior (rewind Θ₂) Δ ≡ pushBinds (repsOf Θ₂) Δ`
+  `interior (rewind Θ₂) Δ ≡ pushBinds (binds Θ₂) Δ`
   and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's `C`.
   The two frame lemmas are **equalities** (§6.7), so neither case uses
   `⊢retag`.  `⊢ᵐ-⋉` is where the sequential judgement pays for itself:
-  `⊢ᵐ-++` splits the merged list at the move, `⊢ᵐ-scopeOf` re-reads `Θ₂`'s
+  `⊢ˢ-++` splits the merged change list at the move, `⊢ˢ-shiftScope`
+  re-reads `Θ₂`'s
   entries one bind prefix in, and `Θ₁` is then read over exactly
   `interior Θ₂ Δ` — its own exterior in the redex.
 * the five `ξ` rules — structural, using the same `env` node.
@@ -1184,9 +1247,9 @@ is a known function of the old one:
 
 | rule | the moved subterm's new frame |
 |------|-------------------------------|
-| `TyBeta` | `interior (bind A ∷ []) Δ ≡ bind A ∷ Δ` — `Δ` on the nose, one refinement (`abst ⊑ᵃᵉ bind A`) at the slot the rule reveals |
-| `TyPeelR` | `interior (bind A ∷ Θ) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ` — the redex's frame, one binder in, which `wkᴹ 1` matches |
-| `Peel` | (†) `interior (dual Θ) (interior Θ Δ) ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ`, given `Δ ⊢ᵐ Θ` (`proof/PeelDual.interior-dual`) |
+| `TyBeta` | `interior (morph (A ∷ []) []) Δ ≡ bind A ∷ Δ` — `Δ` on the nose, one refinement (`abst ⊑ᵃᵉ bind A`) at the slot the rule reveals |
+| `TyPeelR` | `interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ` — the redex's frame, one binder in, which `wkᴹ 1` matches |
+| `Peel` | (†) `interior (dual Θ) (interior Θ Δ) ≡ map masked (pushBinds (binds Θ) []) ++ Δ`, given `Δ ⊢ᵐ Θ` (`proof/PeelDual.interior-dual`) |
 | `CancelR`, `IdPush` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)`, given `Δ ⊢ᵐ Θ₂` (`proof/MoveScope.interior-⋉-rewind`) |
 | `Beta` | `Δ` — no frame changes |
 
@@ -1284,22 +1347,26 @@ machine-checked consequence in tree.
    argument.
 3. **No term type-shifts.**  Shift types, not terms.  The only index
    arithmetic in the design is ordinary de Bruijn binder offsets:
-   `numBinds Θ`, `shiftBy`, and the `n + X` lift in `scopeOf` and `dualScope`.
+   `numBinds Θ`, `shiftBy`, and the `n + X` lift in `shiftScope` and
+   `dualScope`.
    `cmax`, `dropN`, `swapᵇ`, `shiftReps` have no analogue.
-4. **Simultaneity, as far as it goes.**  `pushBinds` lifts a
-   representation past exactly the binders inside it and past nothing
-   else — that half is untouched, and the telescopic variant stays
-   reverted (`notes/DECISIONS.md`, "RULING … telescopic (mwf-↑)
-   REVERTED").  The other half — *every* premise read on the plain
-   exterior — did not survive the tightness repair, and could not: with
-   an `mw-u` that refuses a vacuous unlock, `mw-l` and `mw-u` are exact
-   complements, so a simultaneous judgement cannot hold of a list that
-   both locks and unlocks one slot, and the scope move builds exactly
-   such lists (§4.2).  What replaces it is precise rather than weaker:
-   a REP is read on `unlockedScope Θ′ Δ` — never blocked by the frame's
-   OWN locks (that is the part of simultaneity that mattered: no
-   interference from the entries the frame itself installs) — while a
-   NAME is read on `scope Θ′ Δ`, the frame it actually acts on.
+4. **Simultaneity, as far as it goes — and the pair says which far.**
+   `pushBinds` lifts a representation past exactly the binders inside it
+   and past nothing else — that half is untouched, and the telescopic
+   variant stays reverted (`notes/DECISIONS.md`, "RULING … telescopic
+   (mwf-↑) REVERTED").  The other half — *every* premise read on the
+   plain exterior — did not survive the tightness repair, and could not:
+   with an `sw-u` that refuses a vacuous unlock, `sw-l` and `sw-u` are
+   exact complements, so a simultaneous judgement cannot hold of a change
+   list that both locks and unlocks one slot, and the scope move builds
+   exactly such lists (§4.2).  The PAIR is what makes the surviving
+   statement exact: the BINDS are simultaneous — one block, every rep
+   read on the same `unlockedScope Θ Δ`, never blocked by the frame's OWN
+   locks — while the CHANGES are sequential, each read on
+   `applyChanges S′ Δ`, the frame it actually acts on.  The interleaved
+   list could only approximate this by reading a rep past its own tail;
+   the pair drops the tail dependence outright (§4.2, "the one semantic
+   move").
 5. **Determinism.**  Reduction is a partial function.  This is what forces
    `Value` premises on `V-Λ`, `TyBeta` and `Beta`, and what forces every
    rule that mints an identity at a looked-up representation to carry the
@@ -1362,7 +1429,7 @@ is `notes/DesignSpace.md`, with `notes/DesignPoints.md` as its glossary.
     produced one where the contractum **typed**.  Design law 2 was false
     for the reduction relation.
   * *the refuted package* — same section, "PROBED FIX, REFUTED"
-    (`proof/MwUObstruct`): masked-only `mw-u` + unconditional
+    (`proof/MwUObstruct`): masked-only `sw-u` + unconditional
     `unlock ↦ lock` + `bindsOnly` as the outer frame.  Under a
     **simultaneous** `_⊢ᵐ_` it kills `⊢retag` (`le-mu` unmasks a slot an
     `unlock` cites) and `⊢ᵐ-⋉` (the merged list both locks and unlocks
@@ -1379,9 +1446,22 @@ is `notes/DesignSpace.md`, with `notes/DesignPoints.md` as its glossary.
     lemmas become equalities and (†) becomes exact.
   * *the ratification* — "RATIFIED: representations read past the tail's
     unlocks; PR #193 merged (Jeremy, 2026-09-06)".  A representation is
-    read on `unlockedScope Θ′ Δ`, and design **law 4 is reduced to its
+    read past the unlocks, and design **law 4 is reduced to its
     surviving half** (§8): no interference from the frame's own entries;
     the "every premise on the plain exterior" half is retired.
+* **The pair** (Jeremy, 2026-09-06, branch `morph-pair`).  The
+  ratification left `_⊢ᵐ_` reading a rep past its own TAIL's unlocks,
+  which is a sequential statement about something that is not sequential.
+  The morphism became a PAIR — `morph (binds : List Ty)
+  (changes : List Change)` — so the type says what is true: the binds are
+  a parallel block, the changes a sequential list.  The rep reading loses
+  its tail dependence (every rep past the WHOLE change list); no
+  derivation in the development needed the tighter reading.  What the
+  pair buys, mechanically: `repsOf` and every filtering lemma about it
+  vanish (`numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁`, `numBinds (rewind Θ) ≡
+  numBinds Θ`, `numBinds (dual Θ) ≡ 0` all become `refl`), the bind cases
+  disappear from the change inductions and the change cases from the rep
+  inductions, and `⊢ᵐ-++` splits into a rep-free `⊢ˢ-++`.
 
   The tests that came out of it are `proof/DualTightness` (the `unlock`
   half) and `Examples` §15 (every other rule that moves a subterm), with
@@ -1392,8 +1472,9 @@ is `notes/DesignSpace.md`, with `notes/DesignPoints.md` as its glossary.
 
 Jeremy ruled on the helper names on 2026-09-06 and the Agda now spells
 them out in full.  Names ruled on earlier and kept as they were:
-`Θ` = *context morphism*; the morphism entries `bind` / `lock` / `unlock`;
+`Θ` = *context morphism*; the change constructors `lock` / `unlock`;
 the type-context entries `abst` / `bind` / `masked`; `dual`; `Inj`.
+The morphism's `bind` entry became the `binds` field on 2026-09-06.
 
 | name | reading |
 |------|---------|
@@ -1402,7 +1483,8 @@ the type-context entries `abst` / `bind` / `masked`; `dual`; `Inj`.
 | `scope Θ Δ` | `Δ` with `Θ`'s masks and unmasks applied |
 | `unlockedScope Θ Δ` | `Δ` with only `Θ`'s unmasks applied |
 | `pushBinds As Δ` | push the representations on as binders |
-| `repsOf Θ` | the `bind` entries' representations |
+| `binds Θ` | the parallel block of representations (a record field) |
+| `changes Θ` | the sequential lock/unlock list (a record field) |
 | `numBinds Θ` | how many binders the boundary adds |
 | `shiftBy n A` | shift a type past `n` binders |
 | `shiftBodyBy n B` | the same, read under one binder |
@@ -1410,18 +1492,22 @@ the type-context entries `abst` / `bind` / `masked`; `dual`; `Inj`.
 | `masked E` | the retained, unnameable entry |
 | `unmaskEnt E` | peel one mask |
 | `Nameable E` | the entry may be named in a type |
-| `Δ ⊢ᵐ Θ` | the morphism is well formed over Δ |
+| `Δ ⊢ᵐ Θ` | the morphism is well formed over Δ — a PAIR of halves |
+| `Δ ⊢ʳ Bs` | the parallel rep half: every rep well formed on ONE Δ |
+| `Δ ⊢ˢ S` | the sequential change half |
 | `mkId A` | the identity conversion at any type |
 | `reveal X A` | mint: reveal `X` through `A` |
 | `conceal X A` | mint: conceal `X` through `A` |
 | `instReveal X s` | the same mint, on a conversion |
 | `instConceal X s` | its contravariant partner |
 | `dual Θ` | the frame a crossing argument acquires |
-| `dualScope n Θ` | its scope half: `Θ`'s scope inverted and reversed |
+| `dualScope n S` | the change list `S`, inverted and reversed |
 | `hideBinds n` | lock the crossed boundary's own binders |
-| `scopeOf n Θ` | `Θ`'s scope, indices lifted by `n` |
-| `rewind Θ` | `Θ` with its own scope undone: `dualScope 0 Θ ++ Θ` |
-| `Θ₁ ⋉ Θ₂` | `Θ₁` with `Θ₂`'s scope moved into its tail |
+| `shiftScope n S` | the change list `S`, indices lifted by `n` |
+| `applyChanges S Δ` | `Δ` with `S`'s locks and unlocks applied, head-last |
+| `applyUnlocks S Δ` | `Δ` with only `S`'s unlocks applied |
+| `rewind Θ` | `Θ` with its own changes undone |
+| `Θ₁ ⋉ Θ₂` | `Θ₁` with `Θ₂`'s changes moved into its tail |
 | `Locked E` | the entry is masked over a nameable one |
 | `Δ ∋lk X` | slot `X` is LOCKED at `Δ` — what an `unlock` cites |
 | `Δ ⊑ᵃ Δ′` | refinement WITHOUT `le-mu`: the transport a TERM travels |
@@ -1435,9 +1521,9 @@ name spells the two entries it relates (§3, *Refinement*):
 Two identities worth stating, because they are what the names are meant
 to make obvious:
 
-    interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ      given Δ ⊢ᵐ Θ
+    interior (rewind Θ) Δ ≡ pushBinds (binds Θ) Δ       given Δ ⊢ᵐ Θ
     interior (dual Θ) (interior Θ Δ)
-      ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ       given Δ ⊢ᵐ Θ
+      ≡ map masked (pushBinds (binds Θ) []) ++ Δ        given Δ ⊢ᵐ Θ
 
 The first is `proof/MoveScope.interior-rewind` — *a rewound frame leaves
 its bind prefix and nothing else* — and it is the identity that retired

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -131,8 +131,8 @@ T₆-2 = ((($ 7) ⟪ morph [] [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id 
 cancel-T₆ : Δ₆ ⊢ T₆-1 -→ T₆-2
 cancel-T₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
 
-⊢T₆-2-in : S₆₁ ∣ [] ⊢ ($ 7) ⟪ morph [] [] , id `ℕ ⟫ ⟪ morph (`ℕ ∷ []) [] , id `ℕ
-  ⟫ ⦂ `ℕ
+⊢T₆-2-in : S₆₁ ∣ []
+         ⊢ ($ 7) ⟪ morph [] [] , id `ℕ ⟫ ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
 ⊢T₆-2-in = env (mw (rw-b wf-ℕ rw[]) sw[])
                 (env (mw rw[] sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ)
                 (conv-id base-ℕ) wf-ℕ
@@ -353,8 +353,8 @@ _ : interior Θᵣ₁ (interior Θᵣ₂ []) ≡ Sᵣ
 _ = refl
 
 ⊢Vᵣ : Sᵣ ∣ [] ⊢ Vᵣ ⦂ ` 1
-⊢Vᵣ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez ,
-  nameable-b))
+⊢Vᵣ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
+          (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢Tᵣ : [] ∣ [] ⊢ Tᵣ ⦂ `ℕ
 ⊢Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
@@ -404,8 +404,8 @@ _ : interior Θₘ₂ Δₘ ≡ Mₘ
 _ = refl
 
 ⊢Vₘ : Δₘ ∣ [] ⊢ Vₘ ⦂ ` 1
-⊢Vₘ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez ,
-  nameable-b))
+⊢Vₘ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
+          (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢Tₘ : Δₘ ∣ [] ⊢ Tₘ ⦂ `ℕ
 ⊢Tₘ = env (mw rw[] (sw-u (_ , ez , locked nameable-b) sw[]))
@@ -438,9 +438,9 @@ _ : interior Θₘ₁′ (interior (rewind Θₘ₂) Δₘ) ≡ interior Θₘ�
 _ = refl
 
 ⊢ᵐΘₘ₁′ : Δₘ ⊢ᵐ Θₘ₁′
-⊢ᵐΘₘ₁′ = (mw rw[]
-             (sw-l (bind `𝔹 , ez , nameable-b) (sw-u (_ , ez , locked
-               nameable-b) sw[])))
+⊢ᵐΘₘ₁′ = mw rw[]
+            (sw-l (bind `𝔹 , ez , nameable-b)
+                  (sw-u (_ , ez , locked nameable-b) sw[]))
 
 push-Tₘ : Δₘ ⊢ Tₘ -→ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ rewind Θₘ₂ , id `ℕ ⟫
 push-Tₘ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
@@ -514,8 +514,8 @@ Wd = (ƛ (` 1) ∙ (` 0)) ⟪ morph [] (lock 0 ∷ []) , unseal 0 ↦ seal 0 ⟫
 
 -- THE CROSSING VALUE.  Its bind boundary masks W and seals at it: the licence
 -- `seal 0` cites the binder at slot 0 of Δd, whose rep is X = ` 1.
-_ : interior (morph [] (lock 0 ∷ [])) Δd ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ
-  ∷ []
+_ : interior (morph [] (lock 0 ∷ [])) Δd
+      ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ ∷ []
 _ = refl
 
 ⊢Wd : Δd ∣ [] ⊢ Wd ⦂ (` 0 ⇒ ` 0)
@@ -572,8 +572,8 @@ _ = refl
                   ⦂ (` 0 ⇒ ` 0)
   ⊢Wd-crossed =
     env (mw rw[]
-            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es (es ez)) , locked
-              nameable-b) sw[])))
+            (sw-l (_ , ez , nameable-b)
+                  (sw-u (_ , es (es (es ez)) , locked nameable-b) sw[])))
         ⊢Wd-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b))
@@ -655,8 +655,8 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
                    ⦂ (` 0 ⇒ ` 0)
   ⊢W1b-crossed =
     env (mw rw[]
-            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es ez) , locked
-              nameable-a) sw[])))
+            (sw-l (_ , ez , nameable-b)
+                  (sw-u (_ , es (es ez) , locked nameable-a) sw[])))
         ⊢W1b-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b)) (wf-var (_ , ez , nameable-b)))
@@ -788,8 +788,8 @@ step₂ = Peel V-ƛ V-$
 -- i.e. ⊢subst applied to the interior redex.
 
 P₃ : Term
-P₃ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0
-  ⟫
+P₃ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 _ : (` 0) [ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ]ᵐ
       ≡ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
@@ -1308,8 +1308,8 @@ D₆  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ 
 D₇  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] ,
   unseal 2 ⟫)
           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₈  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ
-  ⟫)
+D₈  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 D₉  = ((($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
         ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
@@ -1493,8 +1493,8 @@ R₇  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph ((` 0) ∷ 
 R₈  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (`
   1) ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₉  = (RW ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0
-  ⟫
+R₉  = (RW ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 rstep₁ : [] ⊢ R₀ -→ R₁
 rstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1712,8 +1712,8 @@ _ = refl
 
 K₀ K₁ : Term
 K₀ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0
-          ⟫
+        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 K₁ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
         ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , unseal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
@@ -1804,8 +1804,8 @@ L₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ [
 L₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] ,
   unseal 1 ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-L₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫) ⟪ morph ((` 0) ∷ []) [] , id `ℕ
-  ⟫)
+L₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
+       ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 L₇ = (($ 7) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 L₈ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
@@ -2405,8 +2405,8 @@ Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph (binds Θt) (unlock 0 ∷ changes �
 
 ⊢Cu : Δt ∣ [] ⊢ Cu ⦂ (` 0 ⇒ ` 0)
 ⊢Cu = env (mw rw[]
-              (sw-u (_ , ez , locked nameable-b) (sw-l (bind `ℕ , ez ,
-                nameable-b) sw[])))
+              (sw-u (_ , ez , locked nameable-b)
+                    (sw-l (bind `ℕ , ez , nameable-b) sw[])))
           (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
           (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
           (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -131,7 +131,8 @@ T₆-2 = ((($ 7) ⟪ morph [] [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id 
 cancel-T₆ : Δ₆ ⊢ T₆-1 -→ T₆-2
 cancel-T₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
 
-⊢T₆-2-in : S₆₁ ∣ [] ⊢ ($ 7) ⟪ morph [] [] , id `ℕ ⟫ ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
+⊢T₆-2-in : S₆₁ ∣ [] ⊢ ($ 7) ⟪ morph [] [] , id `ℕ ⟫ ⟪ morph (`ℕ ∷ []) [] , id `ℕ
+  ⟫ ⦂ `ℕ
 ⊢T₆-2-in = env (mw (rw-b wf-ℕ rw[]) sw[])
                 (env (mw rw[] sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ)
                 (conv-id base-ℕ) wf-ℕ
@@ -352,7 +353,8 @@ _ : interior Θᵣ₁ (interior Θᵣ₂ []) ≡ Sᵣ
 _ = refl
 
 ⊢Vᵣ : Sᵣ ∣ [] ⊢ Vᵣ ⦂ ` 1
-⊢Vᵣ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
+⊢Vᵣ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez ,
+  nameable-b))
 
 ⊢Tᵣ : [] ∣ [] ⊢ Tᵣ ⦂ `ℕ
 ⊢Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
@@ -366,7 +368,8 @@ push-Tᵣ = IdPush (V-⟪⟫ V-$ I-seal) ez
 
 ⊢push-Tᵣ : [] ∣ [] ⊢ (Vᵣ ⟪ Θᵣ₁ , unseal 1 ⟫) ⟪ Θᵣ₂ , id `ℕ ⟫ ⦂ `ℕ
 ⊢push-Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
-               (env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]) ⊢Vᵣ
+               (env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[])
+                 ⊢Vᵣ
                     (conv-unseal (es ez)) wf-ℕ)
                (conv-id base-ℕ) wf-ℕ
 
@@ -401,7 +404,8 @@ _ : interior Θₘ₂ Δₘ ≡ Mₘ
 _ = refl
 
 ⊢Vₘ : Δₘ ∣ [] ⊢ Vₘ ⦂ ` 1
-⊢Vₘ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
+⊢Vₘ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez ,
+  nameable-b))
 
 ⊢Tₘ : Δₘ ∣ [] ⊢ Tₘ ⦂ `ℕ
 ⊢Tₘ = env (mw rw[] (sw-u (_ , ez , locked nameable-b) sw[]))
@@ -435,7 +439,8 @@ _ = refl
 
 ⊢ᵐΘₘ₁′ : Δₘ ⊢ᵐ Θₘ₁′
 ⊢ᵐΘₘ₁′ = (mw rw[]
-             (sw-l (bind `𝔹 , ez , nameable-b) (sw-u (_ , ez , locked nameable-b) sw[])))
+             (sw-l (bind `𝔹 , ez , nameable-b) (sw-u (_ , ez , locked
+               nameable-b) sw[])))
 
 push-Tₘ : Δₘ ⊢ Tₘ -→ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ rewind Θₘ₂ , id `ℕ ⟫
 push-Tₘ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
@@ -509,7 +514,8 @@ Wd = (ƛ (` 1) ∙ (` 0)) ⟪ morph [] (lock 0 ∷ []) , unseal 0 ↦ seal 0 ⟫
 
 -- THE CROSSING VALUE.  Its bind boundary masks W and seals at it: the licence
 -- `seal 0` cites the binder at slot 0 of Δd, whose rep is X = ` 1.
-_ : interior (morph [] (lock 0 ∷ [])) Δd ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ ∷ []
+_ : interior (morph [] (lock 0 ∷ [])) Δd ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ
+  ∷ []
 _ = refl
 
 ⊢Wd : Δd ∣ [] ⊢ Wd ⦂ (` 0 ⇒ ` 0)
@@ -566,7 +572,8 @@ _ = refl
                   ⦂ (` 0 ⇒ ` 0)
   ⊢Wd-crossed =
     env (mw rw[]
-            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es (es ez)) , locked nameable-b) sw[])))
+            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es (es ez)) , locked
+              nameable-b) sw[])))
         ⊢Wd-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b))
@@ -648,7 +655,8 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
                    ⦂ (` 0 ⇒ ` 0)
   ⊢W1b-crossed =
     env (mw rw[]
-            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es ez) , locked nameable-a) sw[])))
+            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es ez) , locked
+              nameable-a) sw[])))
         ⊢W1b-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b)) (wf-var (_ , ez , nameable-b)))
@@ -780,7 +788,8 @@ step₂ = Peel V-ƛ V-$
 -- i.e. ⊢subst applied to the interior redex.
 
 P₃ : Term
-P₃ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+P₃ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0
+  ⟫
 
 _ : (` 0) [ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ]ᵐ
       ≡ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
@@ -1097,7 +1106,8 @@ qstep₂ = Peel V-ƛ V-$
 _ : ⇑ᴹ QS₇ ≡ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
 _ = refl
 
-_ : Qbody [ QS₇ ]ᵐ ≡ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ]
+_ : Qbody [ QS₇ ]ᵐ ≡ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ
+  ]
 _ = refl
 
 Q₃ : Term
@@ -1107,7 +1117,8 @@ Q₃ = ((Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ])
 qstep₃ : [] ⊢ Q₂ -→ Q₃
 qstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
-⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ] ⦂ ` 0
+⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ
+  ] ⦂ ` 0
 ⊢Q₃-in = preservation-Beta (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) ⊢Qbody₁)
                               ⊢QS₇)
 
@@ -1121,7 +1132,8 @@ _ : reveal 0 (` 1) ≡ id (` 1)
 _ = refl
 
 Q₄ : Term
-Q₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
+Q₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (`
+  1) ⟫)
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 qstep₄ : [] ⊢ Q₃ -→ Q₄
@@ -1143,7 +1155,8 @@ qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
 -- only the two conversions swap.
 
 Q₅ : Term
-Q₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
+Q₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal
+  1 ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₅ : [] ⊢ Q₄ -→ Q₅
@@ -1286,13 +1299,17 @@ D₃  = ((Λ ((Λ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)) ·[ ` 2 , `
 D₄  = ((Λ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
               ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)) ·[ ` 1 , `ℕ ])
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-D₅  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+D₅  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (`
+  2) ⟫)
           ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-D₆  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+D₆  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (`
+  2) ⟫)
           ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₇  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫)
+D₇  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] ,
+  unseal 2 ⟫)
           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₈  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+D₈  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ
+  ⟫)
           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 D₉  = ((($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
         ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
@@ -1446,9 +1463,12 @@ Rchain-scoped = wf-var (_ , es ez , nameable-b)
 -- ── the states ─────────────────────────────────────────────────────────
 
 RS RS↑ RW : Term
-RS  = (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
-RS↑ = (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
-RW  = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) , id (` 2) ⟫)
+RS  = (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ []) ,
+  seal 0 ⟫
+RS↑ = (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) ,
+  seal 1 ⟫
+RW  = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) , id
+  (` 2) ⟫)
         ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫
 
 _ : wkᴹ 1 QS₇ ≡ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
@@ -1467,11 +1487,14 @@ R₅  = (((ƛ (` 0) ∙ Qbody) · RS) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 R₆  = (((Λ RS↑) ·[ ` 1 , `ℕ ]) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₇  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
+R₇  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal
+  0 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₈  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
+R₈  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (`
+  1) ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₉  = (RW ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₉  = (RW ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0
+  ⟫
 
 rstep₁ : [] ⊢ R₀ -→ R₁
 rstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1566,7 +1589,7 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
 -- Variant (i) asks for an IdPush redex whose INNER frame Θ₁ binds more
 -- than one binder.  WHICH RULE COULD EVER MINT ONE?  Exactly one:
 --
---   TyBeta   mints `bind A ∷ []`                       numBinds 1
+--   TyBeta   mints `morph (A ∷ []) []`                       numBinds 1
 --   Peel     mints `dual Θ`, which is ALL locks/unlocks numBinds 0
 --   CancelR  mints NO frame (both are carried over)
 --   IdPush   mints NO frame (both are carried over)
@@ -1665,11 +1688,13 @@ _ = refl
 -- — the `renᴮ suc Θ` double-shift that made `¬⊢G₅` true is gone.  So
 -- variant (i) now HAS a well-typed closed-source instance.
 ⊢G₅-Λ : QΞ₃ ∣ [] ⊢ Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫) ⦂ `∀ (` 3)
-⊢G₅-Λ = ⊢Λ (env (mw rw[] (sw-l (bind `ℕ , es (es (es ez)) , nameable-b) sw[])) ⊢$
+⊢G₅-Λ = ⊢Λ (env (mw rw[] (sw-l (bind `ℕ , es (es (es ez)) , nameable-b) sw[]))
+  ⊢$
                 (conv-seal (es (es (es ez))))
                 (wf-var (bind `ℕ , es (es (es ez)) , nameable-b)))
 
-⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , ` 0 ])
+⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , `
+  0 ])
                       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 0
 ⊢G₅-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[])
               (⊢·[] ⊢G₅-Λ (wf-var (bind `ℕ , ez , nameable-b)))
@@ -1681,13 +1706,14 @@ _ = refl
 
 -- ── AND THE MULTI-BIND ID-LAYER IT DELIVERS ────────────────────────────
 -- The same shape, hand-built at the frame the repaired rule produces
--- (`bind A ∷ Θ`, no double shift): IdPush fires at `numBinds Θ₁ ≡ 2` and the
+-- (one bind prepended, no double shift): IdPush fires at `numBinds Θ₁ ≡ 2` and the
 -- contractum TYPES.  So the multi-bind case is not itself an obstruction
 -- — the lifting `shiftBy 2` is exactly absorbed by `pushBinds`.
 
 K₀ K₁ : Term
 K₀ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0
+          ⟫
 K₁ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
         ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , unseal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
@@ -1772,11 +1798,14 @@ L₁ = ((ƛ (` 0) ∙ Lbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 �
 L₂ = ((ƛ (` 0) ∙ Lbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 L₃ = ((Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , ` 0 ])
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-L₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
+L₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id
+  (` 1) ⟫)
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-L₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal 1 ⟫)
+L₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] ,
+  unseal 1 ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-L₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
+L₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫) ⟪ morph ((` 0) ∷ []) [] , id `ℕ
+  ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 L₇ = (($ 7) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 L₈ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
@@ -2147,7 +2176,8 @@ val-JV : Value JV
 val-JV = V-⟪⟫ V-ƛ I-fun
 
 -- the two duals the two Peels mint
-_ : dual (morph ((` 0) ∷ binds Θt) (changes Θt)) ≡ morph [] (lock 0 ∷ unlock 1 ∷ [])
+_ : dual (morph ((` 0) ∷ binds Θt) (changes Θt)) ≡ morph [] (lock 0 ∷ unlock 1 ∷
+  [])
 _ = refl
 
 _ : dual (morph ((` 0) ∷ []) []) ≡ morph [] (lock 0 ∷ [])
@@ -2157,7 +2187,8 @@ JW JW′ : Term                  -- `7` after the first / the second crossing
 JW  = wkᴹ 1 QS₇ ⟪ dual (morph ((` 0) ∷ binds Θt) (changes Θt)) , seal 0 ⟫
 JW′ = wkᴹ 1 JW ⟪ dual (morph ((` 0) ∷ []) []) , seal 0 ⟫
 
-_ : JW ≡ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ unlock 1 ∷ []) , seal 0 ⟫
+_ : JW ≡ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ unlock
+  1 ∷ []) , seal 0 ⟫
 _ = refl
 
 val-JW : Value JW
@@ -2169,14 +2200,18 @@ val-JW′ = V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal) I-seal
 J₇ J₈ J₉ J₁₀ J₁₁ J₁₂ J₁₃ : Term
 J₇  = ((JV ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 0 ↦ seal 1 ⟫) · QS₇)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₈  = ((JV · JW) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₈  = ((JV · JW) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ
+  ∷ []) [] , unseal 0 ⟫
 J₉  = ((((ƛ (` 0) ∙ ($ 3)) · JW′) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
          ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₁₀ = ((($ 3) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫)
+J₁₀ = ((($ 3) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph ((` 0) ∷ binds Θt)
+  (changes Θt) , seal 1 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₁₁ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₁₂ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+J₁₁ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ ∷
+  []) [] , unseal 0 ⟫
+J₁₂ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id `ℕ ⟫) ⟪ morph (`ℕ ∷
+  []) [] , id `ℕ ⟫
 J₁₃ = ($ 3) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 jstep₇ : [] ⊢ J₆ -→ J₇
@@ -2260,7 +2295,8 @@ H₁ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1))))
 H₂ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1)))) · QS₇)
         ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
 H₃ = (HV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
-H₄ = ((Λ (ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))) ·[ ` 0 ⇒ ` 2 , ` 0 ])
+H₄ = ((Λ (ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))) ·[ ` 0 ⇒ ` 2 ,
+  ` 0 ])
        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
 
 hstep₁ : [] ⊢ H₀ -→ H₁
@@ -2364,11 +2400,13 @@ Cj2 = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 1 ])
 --       X visible inside).  TYPES — but it un-masks what the crossing
 --       masked.
 Cu : Term
-Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph (binds Θt) (unlock 0 ∷ changes Θt) , id (` 0) ↦ seal 0 ⟫
+Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph (binds Θt) (unlock 0 ∷ changes Θt) , id (`
+  0) ↦ seal 0 ⟫
 
 ⊢Cu : Δt ∣ [] ⊢ Cu ⦂ (` 0 ⇒ ` 0)
 ⊢Cu = env (mw rw[]
-              (sw-u (_ , ez , locked nameable-b) (sw-l (bind `ℕ , ez , nameable-b) sw[])))
+              (sw-u (_ , ez , locked nameable-b) (sw-l (bind `ℕ , ez ,
+                nameable-b) sw[])))
           (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
           (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
           (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
@@ -2444,7 +2482,7 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ uns
 --
 --  (2) A TYPE ARGUMENT IS NEVER PUSHED IN.  TyWrapCncl wrote the spelled
 --      argument into the sealed body.  `TyPeelR` records it as a NEW
---      BIND on the boundary (`bind A ∷ Θ`) and instantiates the interior
+--      BIND on the boundary (one bind prepended) and instantiates the interior
 --      at the fresh NAME `` ` 0 ``; that is why the boundary is a LIST —
 --      a context morphism — and not a single reveal-or-conceal.
 --
@@ -2717,7 +2755,8 @@ interior-TyBeta : (A : Ty) (Δ : Ctxᵗ)
 interior-TyBeta A Δ = refl
 
 interior-TyPeelR : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A)
+    ∷ interior Θ Δ
 interior-TyPeelR A Θ Δ = refl
 
 ------------------------------------------------------------------------
@@ -2726,7 +2765,7 @@ interior-TyPeelR A Θ Δ = refl
 ------------------------------------------------------------------------
 
 -- `TyBeta` types its body `N` at `abst ∷ Δ` (that is `⊢Λ`) and the
--- contractum types it at `interior (bind A ∷ []) Δ`.  Those two type
+-- contractum types it at `interior (morph (A ∷ []) []) Δ`.  Those two type
 -- contexts differ AT SLOT 0 ONLY, and there the change is a REFINEMENT
 -- (`abst ⊑ᵃᵉ bind A`, `la-ab`) — which is intended: TyBeta REVEALS, it
 -- is the rule that installs a representation.  Every OTHER slot is `Δ`
@@ -2798,7 +2837,7 @@ stepᵃ∅ = TyBeta val-prb
 --       tracks it
 ------------------------------------------------------------------------
 
--- `V` moves from `interior Θ Δ` into `interior (bind A ∷ Θ) Δ`, which is
+-- `V` moves from `interior Θ Δ` into `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which is
 -- that type context with ONE binder prepended — and the rule shifts `V`
 -- by `wkᴹ 1` to match.  A slot Θ MASKS is therefore masked on both
 -- sides, one index apart.
@@ -2854,7 +2893,8 @@ _ = refl
 _ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ interior Θᵇ Δᵇ
 _ = interior-TyPeelR `ℕ Θᵇ Δᵇ
 
-_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ masked (bind `ℕ) ∷ []
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ masked (bind
+  `ℕ) ∷ []
 _ = refl
 
 ¬⊢wkVᵇ : ∀ {Γ A} → ¬ ((bind `ℕ ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
@@ -3135,10 +3175,10 @@ _ = refl
 -- Each example above exhibits, at one point, an identity that holds
 -- everywhere.  Collected, with the rule each one serves:
 --
---   TyBeta   interior (bind A ∷ []) Δ ≡ bind A ∷ Δ
+--   TyBeta   interior (morph (A ∷ []) []) Δ ≡ bind A ∷ Δ
 --              — `Δ` on the nose, one REFINEMENT (abst → bind) at the
 --                slot the rule is there to reveal
---   TyPeelR  interior (bind A ∷ Θ) Δ
+--   TyPeelR  interior (morph (A ∷ binds Θ) (changes Θ)) Δ
 --              ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
 --              — the redex's frame, one binder in; `wkᴹ 1` matches it
 --   Peel     interior (dual Θ) (interior Θ Δ)
@@ -3160,7 +3200,7 @@ _ = refl
 -- because `interior` is `pushBinds ∘ binds` over `scope` and a bind
 -- entry touches `scope` not at all.  The other two are theorems with
 -- a `Δ ⊢ᵐ Θ` premise, and that premise is exactly where the sequential
--- judgement pays: (†) needs `mw-u`'s LOCKED slot for the dual's
+-- judgement pays: (†) needs `sw-u`'s LOCKED slot for the dual's
 -- restoring `lock` to be `mask ∘ unmask` at that slot (`mask-unmask`,
--- strong.Ctx §6b), and the scope move needs `mw-b`'s rep read past the
+-- strong.Ctx §6b), and the scope move needs the rep half read past the
 -- tail's unlocks (proof/MwUObstruct §4).

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -85,21 +85,21 @@ S₆₁ = bind `ℕ ∷ Δ₆
 S₆₂ = bind `ℕ ∷ S₆₁
 
 W₆₀ W₆₁ T₆ : Term
-W₆₀ = ($ 7) ⟪ [] , seal 1 ⟫
-W₆₁ = W₆₀ ⟪ bind `ℕ ∷ [] , id (` 1) ⟫
-T₆  = W₆₁ ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+W₆₀ = ($ 7) ⟪ morph [] [] , seal 1 ⟫
+W₆₁ = W₆₀ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫
+T₆  = W₆₁ ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 ⊢W₆₀ : S₆₂ ∣ [] ⊢ W₆₀ ⦂ ` 1
-⊢W₆₀ = env mw[] ⊢$ (conv-seal (es ez))
+⊢W₆₀ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
            (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢W₆₁ : S₆₁ ∣ [] ⊢ W₆₁ ⦂ ` 0
-⊢W₆₁ = env (mw-b wf-ℕ mw[]) ⊢W₆₀
+⊢W₆₁ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢W₆₀
            (conv-idv (bind `ℕ , es ez , nameable-b))
            (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢T₆ : Δ₆ ∣ [] ⊢ T₆ ⦂ `ℕ
-⊢T₆ = env (mw-b wf-ℕ mw[]) ⊢W₆₁ (conv-unseal ez) wf-ℕ
+⊢T₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢W₆₁ (conv-unseal ez) wf-ℕ
 
 ¬val-T₆ : ¬ Value T₆
 ¬val-T₆ (V-⟪⟫ _ ())
@@ -109,35 +109,35 @@ T₆  = W₆₁ ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
 -- (proof/IdLayer.agda, `idpush-name`), and the residue conversion is the
 -- identity at the LOOKED-UP rep — the lookup premise, exactly as ruled.
 T₆-1 : Term
-T₆-1 = (W₆₀ ⟪ bind `ℕ ∷ [] , unseal 1 ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+T₆-1 = (W₆₀ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 push-T₆ : Δ₆ ⊢ T₆ -→ T₆-1
 push-T₆ = IdPush (V-⟪⟫ V-$ I-seal) ez
 
-⊢T₆-1-in : S₆₁ ∣ [] ⊢ W₆₀ ⟪ bind `ℕ ∷ [] , unseal 1 ⟫ ⦂ `ℕ
-⊢T₆-1-in = env (mw-b wf-ℕ mw[]) ⊢W₆₀ (conv-unseal (es ez)) wf-ℕ
+⊢T₆-1-in : S₆₁ ∣ [] ⊢ W₆₀ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
+⊢T₆-1-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢W₆₀ (conv-unseal (es ez)) wf-ℕ
 
 ⊢T₆-1 : Δ₆ ∣ [] ⊢ T₆-1 ⦂ `ℕ
-⊢T₆-1 = env (mw-b wf-ℕ mw[]) ⊢T₆-1-in (conv-id base-ℕ) wf-ℕ
+⊢T₆-1 = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢T₆-1-in (conv-id base-ℕ) wf-ℕ
 
 -- STEP 2 — the seal/unseal pair is now ADJACENT: the ordinary cancel
 -- fires.  BOTH FRAMES STAY (the repaired rule) and both conversions
 -- become the identity at the looked-up rep, so the seal's own (here
 -- empty) frame survives as one more transparent layer.
 T₆-2 : Term
-T₆-2 = ((($ 7) ⟪ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫)
-         ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+T₆-2 = ((($ 7) ⟪ morph [] [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+         ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 cancel-T₆ : Δ₆ ⊢ T₆-1 -→ T₆-2
 cancel-T₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
 
-⊢T₆-2-in : S₆₁ ∣ [] ⊢ ($ 7) ⟪ [] , id `ℕ ⟫ ⟪ bind `ℕ ∷ [] , id `ℕ ⟫ ⦂ `ℕ
-⊢T₆-2-in = env (mw-b wf-ℕ mw[])
-                (env mw[] ⊢$ (conv-id base-ℕ) wf-ℕ)
+⊢T₆-2-in : S₆₁ ∣ [] ⊢ ($ 7) ⟪ morph [] [] , id `ℕ ⟫ ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
+⊢T₆-2-in = env (mw (rw-b wf-ℕ rw[]) sw[])
+                (env (mw rw[] sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ)
                 (conv-id base-ℕ) wf-ℕ
 
 ⊢T₆-2 : Δ₆ ∣ [] ⊢ T₆-2 ⦂ `ℕ
-⊢T₆-2 = env (mw-b wf-ℕ mw[]) ⊢T₆-2-in (conv-id base-ℕ) wf-ℕ
+⊢T₆-2 = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢T₆-2-in (conv-id base-ℕ) wf-ℕ
 
 -- STEPS 3, 4, 5 — base conversions over a numeral, innermost first.
 run-T₆ : Δ₆ ⊢ T₆ -→* $ 7
@@ -156,16 +156,16 @@ run-T₆ = push-T₆
 -- inner INERT, read straight off the conversion constructors.
 
 Θ↑ Θ↓ : CtxMorph
-Θ↑ = bind `ℕ ∷ []
-Θ↓ = lock 0 ∷ []
+Θ↑ = morph (`ℕ ∷ []) []
+Θ↓ = morph [] (lock 0 ∷ [])
 
 cancelTm : Term
 cancelTm = (($ 7) ⟪ Θ↓ , seal 0 ⟫) ⟪ Θ↑ , unseal 0 ⟫
 
 ⊢cancelTm : [] ∣ [] ⊢ cancelTm ⦂ `ℕ
 ⊢cancelTm =
-  env (mw-b wf-ℕ mw[])
-      (env (mw-l (_ , ez , nameable-b) mw[]) ⊢$
+  env (mw (rw-b wf-ℕ rw[]) sw[])
+      (env (mw rw[] (sw-l (_ , ez , nameable-b) sw[])) ⊢$
            (conv-seal ez) (wf-var (_ , ez , nameable-b)))
       (conv-unseal ez)
       wf-ℕ
@@ -198,29 +198,29 @@ _ = refl
 ------------------------------------------------------------------------
 
 LA LB T₈ : Term
-LA = (($ 7) ⟪ [] , seal 2 ⟫) ⟪ bind (` 0) ∷ [] , id (` 2) ⟫
-LB = LA ⟪ bind `ℕ ∷ [] , id (` 1) ⟫
-T₈ = LB ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+LA = (($ 7) ⟪ morph [] [] , seal 2 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (` 2) ⟫
+LB = LA ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫
+T₈ = LB ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 SA : Ctxᵗ
 SA = bind (` 0) ∷ S₆₂            -- the interior type context of LA
 
-⊢LA-in : SA ∣ [] ⊢ ($ 7) ⟪ [] , seal 2 ⟫ ⦂ ` 2
-⊢LA-in = env mw[] ⊢$ (conv-seal (es (es ez)))
+⊢LA-in : SA ∣ [] ⊢ ($ 7) ⟪ morph [] [] , seal 2 ⟫ ⦂ ` 2
+⊢LA-in = env (mw rw[] sw[]) ⊢$ (conv-seal (es (es ez)))
              (wf-var (bind `ℕ , es (es ez) , nameable-b))
 
 ⊢LA : S₆₂ ∣ [] ⊢ LA ⦂ ` 1
-⊢LA = env (mw-b (wf-var (bind `ℕ , ez , nameable-b)) mw[]) ⊢LA-in
+⊢LA = env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]) ⊢LA-in
           (conv-idv (bind `ℕ , es (es ez) , nameable-b))
           (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢LB : S₆₁ ∣ [] ⊢ LB ⦂ ` 0
-⊢LB = env (mw-b wf-ℕ mw[]) ⊢LA
+⊢LB = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢LA
           (conv-idv (bind `ℕ , es ez , nameable-b))
           (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢T₈ : Δ₆ ∣ [] ⊢ T₈ ⦂ `ℕ
-⊢T₈ = env (mw-b wf-ℕ mw[]) ⊢LB (conv-unseal ez) wf-ℕ
+⊢T₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢LB (conv-unseal ez) wf-ℕ
 
 -- The stack resolves ONE LAYER PER STEP, outermost first: each IdPush moves
 -- the active conversion one layer inward toward the seal, so any depth
@@ -228,11 +228,11 @@ SA = bind (` 0) ∷ S₆₂            -- the interior type context of LA
 -- this one — the inner layer's context morphism `bind (` 0)` names the next layer's
 -- binder, IdLayerProbe §4c.  IdPush touches no frame.)
 T₈-1 T₈-2 T₈-3 : Term
-T₈-1 = (LA ⟪ bind `ℕ ∷ [] , unseal 1 ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-T₈-2 = (((($ 7) ⟪ [] , seal 2 ⟫) ⟪ bind (` 0) ∷ [] , unseal 2 ⟫)
-          ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-T₈-3 = (((($ 7) ⟪ [] , id `ℕ ⟫) ⟪ bind (` 0) ∷ [] , id `ℕ ⟫)
-          ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+T₈-1 = (LA ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+T₈-2 = (((($ 7) ⟪ morph [] [] , seal 2 ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal 2 ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+T₈-3 = (((($ 7) ⟪ morph [] [] , id `ℕ ⟫) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 push-T₈  : Δ₆ ⊢ T₈ -→ T₈-1
 push-T₈  = IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) ez
@@ -261,22 +261,22 @@ _ : reveal 0 (` 1) ≡ id (` 1)
 _ = refl
 
 ⊢W₆₀Λ : (abst ∷ S₆₁) ∣ [] ⊢ W₆₀ ⦂ ` 1
-⊢W₆₀Λ = env mw[] ⊢$ (conv-seal (es ez))
+⊢W₆₀Λ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
             (wf-var (bind `ℕ , es ez , nameable-b))
 
 Pkg : Term
-Pkg = (Λ W₆₀) ⟪ [] , `∀ (id (` 1)) ⟫
+Pkg = (Λ W₆₀) ⟪ morph [] [] , `∀ (id (` 1)) ⟫
 
 ⊢Pkg : S₆₁ ∣ [] ⊢ Pkg ⦂ `∀ (` 1)
-⊢Pkg = env mw[] (⊢Λ ⊢W₆₀Λ)
+⊢Pkg = env (mw rw[] sw[]) (⊢Λ ⊢W₆₀Λ)
            (conv-all (conv-idv (bind `ℕ , es ez , nameable-b)))
            (wf-∀ (wf-var (bind `ℕ , es ez , nameable-b)))
 
 T₉ : Term
-T₉ = (Pkg ·[ ` 1 , `ℕ ]) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+T₉ = (Pkg ·[ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 ⊢T₉ : Δ₆ ∣ [] ⊢ T₉ ⦂ `ℕ
-⊢T₉ = env (mw-b wf-ℕ mw[]) (⊢·[] ⊢Pkg wf-ℕ) (conv-unseal ez) wf-ℕ
+⊢T₉ = env (mw (rw-b wf-ℕ rw[]) sw[]) (⊢·[] ⊢Pkg wf-ℕ) (conv-unseal ez) wf-ℕ
 
 -- TyPeelR mints the id-layer no matter what TyBeta does.  On an IDENTITY
 -- ∀ conversion the mint is the conversion itself
@@ -284,13 +284,13 @@ T₉ = (Pkg ·[ ` 1 , `ℕ ]) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
 -- binder) and the pushed-in annotation is the interior ∀-body, SHIFTED
 -- past the binder the rule introduces: `` ` 2 `` rather than `` ` 1 ``.
 Pk-1 : Term
-Pk-1 = ((Λ (($ 7) ⟪ [] , seal 2 ⟫)) ·[ ` 2 , ` 0 ])
-         ⟪ bind `ℕ ∷ [] , id (` 1) ⟫
+Pk-1 = ((Λ (($ 7) ⟪ morph [] [] , seal 2 ⟫)) ·[ ` 2 , ` 0 ])
+         ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫
 
-⊢Pk-conv : (abst ∷ convCtx [] S₆₁) ⊢ id (` 1) ∶ ` 1 ⇝ ` 1
+⊢Pk-conv : (abst ∷ convCtx (morph [] []) S₆₁) ⊢ id (` 1) ∶ ` 1 ⇝ ` 1
 ⊢Pk-conv = conv-idv (bind `ℕ , es ez , nameable-b)
 
-typeel-T₉ : Δ₆ ⊢ T₉ -→ Pk-1 ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+typeel-T₉ : Δ₆ ⊢ T₉ -→ Pk-1 ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 typeel-T₉ = ξ-⟪⟫ (TyPeelR (V-Λ (V-⟪⟫ V-$ I-seal)) ⊢Pk-conv)
 
 -- and TyBeta then mints exactly T₈'s inner layer.
@@ -322,7 +322,7 @@ body-first = ξ-·[] (ξ-Λ (Beta V-$))
 
 -- … and only then is the (now valuable) package instantiated.
 then-tybeta : [] ⊢ (Λ ($ 1)) ·[ `ℕ , `ℕ ]
-                -→ ($ 1) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+                -→ ($ 1) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 then-tybeta = TyBeta V-$
 
 run-Ωt : [] ⊢ Ωt ·[ `ℕ , `ℕ ] -→* $ 1
@@ -338,25 +338,25 @@ run-Ωt = body-first then then-tybeta then Drop$ base-ℕ then done
 -- IdPush touches no frame, so the instance is ordinary.
 
 Θᵣ₁ Θᵣ₂ : CtxMorph
-Θᵣ₁ = bind (` 0) ∷ []
-Θᵣ₂ = bind `ℕ ∷ []
+Θᵣ₁ = morph ((` 0) ∷ []) []
+Θᵣ₂ = morph (`ℕ ∷ []) []
 
 Sᵣ : Ctxᵗ
 Sᵣ = bind (` 0) ∷ bind `ℕ ∷ []
 
 Vᵣ Tᵣ : Term
-Vᵣ = ($ 7) ⟪ [] , seal 1 ⟫
+Vᵣ = ($ 7) ⟪ morph [] [] , seal 1 ⟫
 Tᵣ = (Vᵣ ⟪ Θᵣ₁ , id (` 1) ⟫) ⟪ Θᵣ₂ , unseal 0 ⟫
 
 _ : interior Θᵣ₁ (interior Θᵣ₂ []) ≡ Sᵣ
 _ = refl
 
 ⊢Vᵣ : Sᵣ ∣ [] ⊢ Vᵣ ⦂ ` 1
-⊢Vᵣ = env mw[] ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
+⊢Vᵣ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢Tᵣ : [] ∣ [] ⊢ Tᵣ ⦂ `ℕ
-⊢Tᵣ = env (mw-b wf-ℕ mw[])
-          (env (mw-b (wf-var (bind `ℕ , ez , nameable-b)) mw[]) ⊢Vᵣ
+⊢Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
+          (env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]) ⊢Vᵣ
                (conv-idv (bind `ℕ , es ez , nameable-b))
                (wf-var (bind `ℕ , ez , nameable-b)))
           (conv-unseal ez) wf-ℕ
@@ -365,8 +365,8 @@ push-Tᵣ : [] ⊢ Tᵣ -→ (Vᵣ ⟪ Θᵣ₁ , unseal 1 ⟫) ⟪ Θᵣ₂ , i
 push-Tᵣ = IdPush (V-⟪⟫ V-$ I-seal) ez
 
 ⊢push-Tᵣ : [] ∣ [] ⊢ (Vᵣ ⟪ Θᵣ₁ , unseal 1 ⟫) ⟪ Θᵣ₂ , id `ℕ ⟫ ⦂ `ℕ
-⊢push-Tᵣ = env (mw-b wf-ℕ mw[])
-               (env (mw-b (wf-var (bind `ℕ , ez , nameable-b)) mw[]) ⊢Vᵣ
+⊢push-Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
+               (env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]) ⊢Vᵣ
                     (conv-unseal (es ez)) wf-ℕ)
                (conv-id base-ℕ) wf-ℕ
 
@@ -390,22 +390,22 @@ run-Tᵣ = push-Tᵣ
 Mₘ = bind `𝔹 ∷ bind `ℕ ∷ []
 
 Θₘ₁ Θₘ₂ : CtxMorph
-Θₘ₁ = lock 0 ∷ []
-Θₘ₂ = unlock 0 ∷ []
+Θₘ₁ = morph [] (lock 0 ∷ [])
+Θₘ₂ = morph [] (unlock 0 ∷ [])
 
 Vₘ Tₘ : Term
-Vₘ = ($ 7) ⟪ [] , seal 1 ⟫
+Vₘ = ($ 7) ⟪ morph [] [] , seal 1 ⟫
 Tₘ = (Vₘ ⟪ Θₘ₁ , id (` 1) ⟫) ⟪ Θₘ₂ , unseal 1 ⟫
 
 _ : interior Θₘ₂ Δₘ ≡ Mₘ
 _ = refl
 
 ⊢Vₘ : Δₘ ∣ [] ⊢ Vₘ ⦂ ` 1
-⊢Vₘ = env mw[] ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
+⊢Vₘ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
 
 ⊢Tₘ : Δₘ ∣ [] ⊢ Tₘ ⦂ `ℕ
-⊢Tₘ = env (mw-u (_ , ez , locked nameable-b) mw[])
-          (env (mw-l (bind `𝔹 , ez , nameable-b) mw[]) ⊢Vₘ
+⊢Tₘ = env (mw rw[] (sw-u (_ , ez , locked nameable-b) sw[]))
+          (env (mw rw[] (sw-l (bind `𝔹 , ez , nameable-b) sw[])) ⊢Vₘ
                (conv-idv (bind `ℕ , es ez , nameable-b))
                (wf-var (bind `ℕ , es ez , nameable-b)))
           (conv-unseal (es ez)) wf-ℕ
@@ -417,7 +417,7 @@ _ = refl
 -- REWINDS it (`rewind Θₘ₂ ≡ lock 0 ∷ unlock 0 ∷ []`), which on this run
 -- is literally the same list as the merged inner frame.
 Θₘ₁′ : CtxMorph
-Θₘ₁′ = lock 0 ∷ unlock 0 ∷ []
+Θₘ₁′ = morph [] (lock 0 ∷ unlock 0 ∷ [])
 
 _ : _≡_ {A = CtxMorph} (Θₘ₁ ⋉ Θₘ₂) Θₘ₁′
 _ = refl
@@ -434,8 +434,8 @@ _ : interior Θₘ₁′ (interior (rewind Θₘ₂) Δₘ) ≡ interior Θₘ�
 _ = refl
 
 ⊢ᵐΘₘ₁′ : Δₘ ⊢ᵐ Θₘ₁′
-⊢ᵐΘₘ₁′ = mw-l (bind `𝔹 , ez , nameable-b)
-              (mw-u (_ , ez , locked nameable-b) mw[])
+⊢ᵐΘₘ₁′ = (mw rw[]
+             (sw-l (bind `𝔹 , ez , nameable-b) (sw-u (_ , ez , locked nameable-b) sw[])))
 
 push-Tₘ : Δₘ ⊢ Tₘ -→ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ rewind Θₘ₂ , id `ℕ ⟫
 push-Tₘ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
@@ -476,7 +476,7 @@ _ : Δd ∋ 0 := ` 1
 _ = ez
 
 Θ2 : CtxMorph                       -- bind(W) , conceal V
-Θ2 = bind (` 0) ∷ lock 2 ∷ []
+Θ2 = morph ((` 0) ∷ []) (lock 2 ∷ [])
 
 -- ONE frame change: the binder is pushed on, V is MASKED IN PLACE (the entry
 -- `bind `ℕ` survives as `masked (bind `ℕ)`), nothing is dropped.
@@ -493,14 +493,14 @@ cΘ2 = (unseal 0 ↦ seal 0) ↦ id `ℕ
 
 Vd Wd : Term
 Vd = ƛ (` 0 ⇒ ` 0) ∙ ($ 5)
-Wd = (ƛ (` 1) ∙ (` 0)) ⟪ lock 0 ∷ [] , unseal 0 ↦ seal 0 ⟫
+Wd = (ƛ (` 1) ∙ (` 0)) ⟪ morph [] (lock 0 ∷ []) , unseal 0 ↦ seal 0 ⟫
 
 ⊢cΘ2 : convCtx Θ2 Δd ⊢ cΘ2 ∶ ((` 0 ⇒ ` 0) ⇒ `ℕ) ⇝ ((` 1 ⇒ ` 1) ⇒ `ℕ)
 ⊢cΘ2 = conv-fun (conv-fun (conv-unseal ez) (conv-seal ez)) (conv-id base-ℕ)
 
 ⊢Fnd : Δd ∣ [] ⊢ Vd ⟪ Θ2 , cΘ2 ⟫ ⦂ ((` 0 ⇒ ` 0) ⇒ `ℕ)
-⊢Fnd = env (mw-b (wf-var (_ , ez , nameable-b))
-                 (mw-l (_ , es (es ez) , nameable-b) mw[]))
+⊢Fnd = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
+               (sw-l (_ , es (es ez) , nameable-b) sw[]))
            (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
                      (wf-var (_ , ez , nameable-b))) ⊢$)
            ⊢cΘ2
@@ -509,11 +509,11 @@ Wd = (ƛ (` 1) ∙ (` 0)) ⟪ lock 0 ∷ [] , unseal 0 ↦ seal 0 ⟫
 
 -- THE CROSSING VALUE.  Its bind boundary masks W and seals at it: the licence
 -- `seal 0` cites the binder at slot 0 of Δd, whose rep is X = ` 1.
-_ : interior (lock 0 ∷ []) Δd ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ ∷ []
+_ : interior (morph [] (lock 0 ∷ [])) Δd ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ ∷ []
 _ = refl
 
 ⊢Wd : Δd ∣ [] ⊢ Wd ⦂ (` 0 ⇒ ` 0)
-⊢Wd = env (mw-l (_ , ez , nameable-b) mw[])
+⊢Wd = env (mw rw[] (sw-l (_ , ez , nameable-b) sw[]))
           (⊢ƛ (wf-var (_ , es ez , nameable-a)) (⊢` here))
           (conv-fun (conv-unseal ez) (conv-seal ez))
           (wf-⇒ (wf-var (_ , ez , nameable-b))
@@ -531,7 +531,7 @@ peel-d : Δd ⊢ (Vd ⟪ Θ2 , cΘ2 ⟫) · Wd
 peel-d = Peel V-ƛ Wd-value
 
 -- THE DUAL is two names and nothing else: mask the binder, re-expose V.
-_ : dual Θ2 ≡ lock 0 ∷ unlock 3 ∷ []
+_ : dual Θ2 ≡ morph [] (lock 0 ∷ unlock 3 ∷ [])
 _ = refl
 
 -- THE REPOINTING.  The dual's interior is Δd with ONE masked slot in front:
@@ -550,8 +550,8 @@ _ = refl
   Δd ∣ [] ⊢ (Vd · (wkᴹ 1 Wd ⟪ dual Θ2 , unseal 0 ↦ seal 0 ⟫))
               ⟪ Θ2 , id `ℕ ⟫ ⦂ `ℕ
 ⊢contractumd =
-  env (mw-b (wf-var (_ , ez , nameable-b))
-            (mw-l (_ , es (es ez) , nameable-b) mw[]))
+  env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
+          (sw-l (_ , es (es ez) , nameable-b) sw[]))
       (⊢· (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
                     (wf-var (_ , ez , nameable-b))) ⊢$)
           ⊢Wd-crossed)
@@ -565,8 +565,8 @@ _ = refl
                   ⊢ wkᴹ 1 Wd ⟪ dual Θ2 , unseal 0 ↦ seal 0 ⟫
                   ⦂ (` 0 ⇒ ` 0)
   ⊢Wd-crossed =
-    env (mw-l (_ , ez , nameable-b)
-              (mw-u (_ , es (es (es ez)) , locked nameable-b) mw[]))
+    env (mw rw[]
+            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es (es ez)) , locked nameable-b) sw[])))
         ⊢Wd-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b))
@@ -580,28 +580,28 @@ _ = refl
 Δ1b = bind (` 0) ∷ abst ∷ []
 
 Θ1b : CtxMorph
-Θ1b = bind (` 0) ∷ lock 1 ∷ []
+Θ1b = morph ((` 0) ∷ []) (lock 1 ∷ [])
 
 _ : interior Θ1b Δ1b ≡ bind (` 0) ∷ bind (` 0) ∷ masked abst ∷ []
 _ = refl
 
 V1b W1b : Term
 V1b = ƛ (` 0 ⇒ ` 0) ∙ ($ 5)
-W1b = (ƛ (` 1) ∙ (` 0)) ⟪ lock 0 ∷ [] , unseal 0 ↦ seal 0 ⟫
+W1b = (ƛ (` 1) ∙ (` 0)) ⟪ morph [] (lock 0 ∷ []) , unseal 0 ↦ seal 0 ⟫
 
 cΘ1b : Conv
 cΘ1b = (unseal 0 ↦ seal 0) ↦ id `ℕ
 
 ⊢W1b : Δ1b ∣ [] ⊢ W1b ⦂ (` 0 ⇒ ` 0)
-⊢W1b = env (mw-l (_ , ez , nameable-b) mw[])
+⊢W1b = env (mw rw[] (sw-l (_ , ez , nameable-b) sw[]))
            (⊢ƛ (wf-var (_ , es ez , nameable-a)) (⊢` here))
            (conv-fun (conv-unseal ez) (conv-seal ez))
            (wf-⇒ (wf-var (_ , ez , nameable-b))
                  (wf-var (_ , ez , nameable-b)))
 
 ⊢Fn1b : Δ1b ∣ [] ⊢ V1b ⟪ Θ1b , cΘ1b ⟫ ⦂ ((` 0 ⇒ ` 0) ⇒ `ℕ)
-⊢Fn1b = env (mw-b (wf-var (_ , ez , nameable-b))
-                  (mw-l (_ , es ez , nameable-a) mw[]))
+⊢Fn1b = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
+                (sw-l (_ , es ez , nameable-a) sw[]))
             (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
                       (wf-var (_ , ez , nameable-b))) ⊢$)
             (conv-fun (conv-fun (conv-unseal ez) (conv-seal ez))
@@ -612,7 +612,7 @@ cΘ1b = (unseal 0 ↦ seal 0) ↦ id `ℕ
 ⊢Redex1b : Δ1b ∣ [] ⊢ (V1b ⟪ Θ1b , cΘ1b ⟫) · W1b ⦂ `ℕ
 ⊢Redex1b = ⊢· ⊢Fn1b ⊢W1b
 
-_ : dual Θ1b ≡ lock 0 ∷ unlock 2 ∷ []
+_ : dual Θ1b ≡ morph [] (lock 0 ∷ unlock 2 ∷ [])
 _ = refl
 
 -- the repointing again: nothing dropped, nothing demoted …
@@ -633,7 +633,8 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
   Δ1b ∣ [] ⊢ (V1b · (wkᴹ 1 W1b ⟪ dual Θ1b , unseal 0 ↦ seal 0 ⟫))
                ⟪ Θ1b , id `ℕ ⟫ ⦂ `ℕ
 ⊢contractum1b =
-  env (mw-b (wf-var (_ , ez , nameable-b)) (mw-l (_ , es ez , nameable-a) mw[]))
+  env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
+          (sw-l (_ , es ez , nameable-a) sw[]))
       (⊢· (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
                     (wf-var (_ , ez , nameable-b))) ⊢$)
           ⊢W1b-crossed)
@@ -646,8 +647,8 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
                    ⊢ wkᴹ 1 W1b ⟪ dual Θ1b , unseal 0 ↦ seal 0 ⟫
                    ⦂ (` 0 ⇒ ` 0)
   ⊢W1b-crossed =
-    env (mw-l (_ , ez , nameable-b)
-              (mw-u (_ , es (es ez) , locked nameable-a) mw[]))
+    env (mw rw[]
+            (sw-l (_ , ez , nameable-b) (sw-u (_ , es (es ez) , locked nameable-a) sw[])))
         ⊢W1b-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
         (wf-⇒ (wf-var (_ , ez , nameable-b)) (wf-var (_ , ez , nameable-b)))
@@ -661,7 +662,7 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
 Δ4 = masked (bind `ℕ) ∷ []          -- a slot masked by an enclosing boundary
 
 Θ4 : CtxMorph                        -- re-expose it
-Θ4 = unlock 0 ∷ []
+Θ4 = morph [] (unlock 0 ∷ [])
 
 _ : interior Θ4 Δ4 ≡ bind `ℕ ∷ []
 _ = refl
@@ -678,12 +679,12 @@ _ = ez
 Γ★ = abst ∷ bind `ℕ ∷ []
 
 Θ★ : CtxMorph
-Θ★ = bind (` 0) ∷ lock 1 ∷ []
+Θ★ = morph ((` 0) ∷ []) (lock 1 ∷ [])
 
 _ : interior Θ★ Γ★ ≡ bind (` 0) ∷ abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
-_ : dual Θ★ ≡ lock 0 ∷ unlock 2 ∷ []
+_ : dual Θ★ ≡ morph [] (lock 0 ∷ unlock 2 ∷ [])
 _ = refl
 
 _ : interior (dual Θ★) (interior Θ★ Γ★) ≡ masked (bind (` 0)) ∷ Γ★
@@ -728,14 +729,14 @@ _ : reveal 0 (` 0 ⇒ ` 0) ≡ seal 0 ↦ unseal 0
 _ = refl
 
 P₁ : Term
-P₁ = ((ƛ (` 0) ∙ (` 0)) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
+P₁ = ((ƛ (` 0) ∙ (` 0)) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
 
 step₁ : [] ⊢ P₀ -→ P₁
 step₁ = ξ-·-l (TyBeta V-ƛ)
 
-⊢fn₁ : [] ∣ [] ⊢ (ƛ (` 0) ∙ (` 0)) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫
+⊢fn₁ : [] ∣ [] ⊢ (ƛ (` 0) ∙ (` 0)) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫
          ⦂ (`ℕ ⇒ `ℕ)
-⊢fn₁ = env (mw-b wf-ℕ mw[])
+⊢fn₁ = env (mw (rw-b wf-ℕ rw[]) sw[])
            (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) (⊢` here))
            (conv-fun (conv-seal ez) (conv-unseal ez))
            (wf-⇒ wf-ℕ wf-ℕ)
@@ -749,28 +750,28 @@ step₁ = ξ-·-l (TyBeta V-ƛ)
 -- transplanted VERBATIM — the dual's CONVERSION CONTEXT IS the crossed
 -- boundary's.
 
-_ : dual (bind `ℕ ∷ []) ≡ lock 0 ∷ []
+_ : dual (morph (`ℕ ∷ []) []) ≡ morph [] (lock 0 ∷ [])
 _ = refl
 
-_ : convCtx (dual (bind `ℕ ∷ [])) (interior (bind `ℕ ∷ []) [])
-      ≡ convCtx (bind `ℕ ∷ []) []
+_ : convCtx (dual (morph (`ℕ ∷ []) [])) (interior (morph (`ℕ ∷ []) []) [])
+      ≡ convCtx (morph (`ℕ ∷ []) []) []
 _ = refl
 
 P₂ : Term
-P₂ = ((ƛ (` 0) ∙ (` 0)) · (($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫))
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+P₂ = ((ƛ (` 0) ∙ (` 0)) · (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫))
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 step₂ : [] ⊢ P₁ -→ P₂
 step₂ = Peel V-ƛ V-$
 
 -- the crossing argument, typed INSIDE: 7 is sealed at the new binder, so the
 -- interior sees it at the abstract name X.
-⊢arg₂ : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫ ⦂ ` 0
-⊢arg₂ = env (mw-l (bind `ℕ , ez , nameable-b) mw[]) ⊢$
+⊢arg₂ : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
+⊢arg₂ = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[])) ⊢$
             (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢P₂ : [] ∣ [] ⊢ P₂ ⦂ `ℕ
-⊢P₂ = env (mw-b wf-ℕ mw[])
+⊢P₂ = env (mw (rw-b wf-ℕ rw[]) sw[])
           (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) (⊢` here)) ⊢arg₂)
           (conv-unseal ez) wf-ℕ
 
@@ -779,21 +780,21 @@ step₂ = Peel V-ƛ V-$
 -- i.e. ⊢subst applied to the interior redex.
 
 P₃ : Term
-P₃ = (($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+P₃ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
-_ : (` 0) [ ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫ ]ᵐ
-      ≡ ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫
+_ : (` 0) [ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ]ᵐ
+      ≡ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
 _ = refl
 
 step₃ : [] ⊢ P₂ -→ P₃
 step₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
-⊢P₃-in : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫ ⦂ ` 0
+⊢P₃-in : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
 ⊢P₃-in = preserve-Beta
            (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) (⊢` here)) ⊢arg₂)
 
 ⊢P₃ : [] ∣ [] ⊢ P₃ ⦂ `ℕ
-⊢P₃ = env (mw-b wf-ℕ mw[]) ⊢P₃-in (conv-unseal ez) wf-ℕ
+⊢P₃ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢P₃-in (conv-unseal ez) wf-ℕ
 
 -- ── STEP 4 — CANCEL.  The seal minted by Peel and the unseal minted by
 -- TyBeta are now adjacent and cite THE SAME ENTRY, so the type match is
@@ -803,28 +804,28 @@ step₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 -- right.
 
 P₄ : Term
-P₄ = (($ 7) ⟪ lock 0 ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+P₄ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 step₄ : [] ⊢ P₃ -→ P₄
 step₄ = CancelR V-$ ez
 
-⊢P₄-in : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ lock 0 ∷ [] , id `ℕ ⟫ ⦂ `ℕ
-⊢P₄-in = env (mw-l (bind `ℕ , ez , nameable-b) mw[])
+⊢P₄-in : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
+⊢P₄-in = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[]))
               ⊢$ (conv-id base-ℕ) wf-ℕ
 
 ⊢P₄ : [] ∣ [] ⊢ P₄ ⦂ `ℕ
-⊢P₄ = env (mw-b wf-ℕ mw[]) ⊢P₄-in (conv-id base-ℕ) wf-ℕ
+⊢P₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢P₄-in (conv-id base-ℕ) wf-ℕ
 
 -- ── STEPS 5, 6 — the two base conversions over the numeral, and the run.
 
 P₅ : Term
-P₅ = ($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+P₅ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 step₅ : [] ⊢ P₄ -→ P₅
 step₅ = ξ-⟪⟫ (Drop$ base-ℕ)
 
 ⊢P₅ : [] ∣ [] ⊢ P₅ ⦂ `ℕ
-⊢P₅ = env (mw-b wf-ℕ mw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+⊢P₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
 
 step₆ : [] ⊢ P₅ -→ $ 7
 step₆ = Drop$ base-ℕ
@@ -879,16 +880,16 @@ _ = refl
 Δₛ = bind `ℕ ∷ []
 
 Wₛ Nₛ : Term
-Wₛ = ($ 7) ⟪ [] , seal 0 ⟫
+Wₛ = ($ 7) ⟪ morph [] [] , seal 0 ⟫
 Nₛ = Λ (` 0)
 
 ⊢Wₛ : Δₛ ∣ [] ⊢ Wₛ ⦂ ` 0
-⊢Wₛ = env mw[] ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
+⊢Wₛ = env (mw rw[] sw[]) ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢Nₛ : Δₛ ∣ (` 0 ∷ []) ⊢ Nₛ ⦂ `∀ (` 1)
 ⊢Nₛ = ⊢Λ (⊢` here)
 
-_ : Nₛ [ Wₛ ]ᵐ ≡ Λ (($ 7) ⟪ [] , seal 1 ⟫)
+_ : Nₛ [ Wₛ ]ᵐ ≡ Λ (($ 7) ⟪ morph [] [] , seal 1 ⟫)
 _ = refl
 
 ⊢Nₛ[Wₛ] : Δₛ ∣ [] ⊢ Nₛ [ Wₛ ]ᵐ ⦂ `∀ (` 1)
@@ -988,7 +989,7 @@ run-P₀-pres = preservation* ⊢P₀ run-P₀
 -- the stepped interior, and that interior is `preservation-Beta`
 -- (⊢P₃-in above).
 ⊢P₃-pres : [] ∣ [] ⊢ P₃ ⦂ `ℕ
-⊢P₃-pres = env (mw-b wf-ℕ mw[]) ⊢P₃-in (conv-unseal ez) wf-ℕ
+⊢P₃-pres = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢P₃-in (conv-unseal ez) wf-ℕ
 
 -- STEP 6 — Drop$ (step 5 is the same rule, under ξ-⟪⟫).
 ⊢P₆-pres : [] ∣ [] ⊢ $ 7 ⦂ `ℕ
@@ -1020,7 +1021,7 @@ run-P₀-pres = preservation* ⊢P₀ run-P₀
 -- layer around x's value, sitting inside the OUTER package's revealing
 -- wrapper.  That two-wrapper stack IS the IdPush redex.
 
-open import strong.proof.PeelDual using (preserve-Peel; repsOf-dual)
+open import strong.proof.PeelDual using (preserve-Peel)
 
 -- ── the source ─────────────────────────────────────────────────────────
 
@@ -1045,10 +1046,10 @@ QΔ₁ QΞ₂ : Ctxᵗ
 QΔ₁ = bind `ℕ ∷ []
 QΞ₂ = bind `ℕ ∷ bind `ℕ ∷ []
 
-_ : interior (bind `ℕ ∷ []) [] ≡ QΔ₁
+_ : interior (morph (`ℕ ∷ []) []) [] ≡ QΔ₁
 _ = refl
 
-_ : interior (bind `ℕ ∷ []) QΔ₁ ≡ QΞ₂
+_ : interior (morph (`ℕ ∷ []) []) QΔ₁ ≡ QΞ₂
 _ = refl
 
 -- ── STEP 1 — TYBETA (outer).  The binder Y := ℕ is minted.
@@ -1057,7 +1058,7 @@ _ : reveal 0 (` 0 ⇒ ` 0) ≡ seal 0 ↦ unseal 0
 _ = refl
 
 Q₁ : Term
-Q₁ = ((ƛ (` 0) ∙ Qbody) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
+Q₁ = ((ƛ (` 0) ∙ Qbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
 
 qstep₁ : [] ⊢ Q₀ -→ Q₁
 qstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1071,20 +1072,20 @@ qstep₁ = ξ-·-l (TyBeta V-ƛ)
 -- ── STEP 2 — PEEL.  7 crosses; `dual (bind ℕ ∷ []) = lock 0 ∷ []`, so
 -- the argument acquires a concealing wrapper that hides the new binder.
 
-_ : dual (bind `ℕ ∷ []) ≡ lock 0 ∷ []
+_ : dual (morph (`ℕ ∷ []) []) ≡ morph [] (lock 0 ∷ [])
 _ = refl
 
 QS₇ : Term
-QS₇ = ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫
+QS₇ = ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
 
 Q₂ : Term
-Q₂ = ((ƛ (` 0) ∙ Qbody) · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+Q₂ = ((ƛ (` 0) ∙ Qbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 qstep₂ : [] ⊢ Q₁ -→ Q₂
 qstep₂ = Peel V-ƛ V-$
 
 ⊢QS₇ : QΔ₁ ∣ [] ⊢ QS₇ ⦂ ` 0
-⊢QS₇ = env (mw-l (bind `ℕ , ez , nameable-b) mw[]) ⊢$
+⊢QS₇ = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[])) ⊢$
             (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢Q₂ : [] ∣ [] ⊢ Q₂ ⦂ `ℕ
@@ -1093,25 +1094,25 @@ qstep₂ = Peel V-ƛ V-$
 -- ── STEP 3 — BETA, under ξ-⟪⟫.  substᵐ's Λ clause ⇑ᴹ-shifts the sealed 7
 -- past ΛZ: the seal NAME moves (seal 0 ↦ seal 1) and so does the lock.
 
-_ : ⇑ᴹ QS₇ ≡ ($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫
+_ : ⇑ᴹ QS₇ ≡ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
 _ = refl
 
-_ : Qbody [ QS₇ ]ᵐ ≡ (Λ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)) ·[ ` 1 , `ℕ ]
+_ : Qbody [ QS₇ ]ᵐ ≡ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ]
 _ = refl
 
 Q₃ : Term
-Q₃ = ((Λ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)) ·[ ` 1 , `ℕ ])
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+Q₃ = ((Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ])
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 qstep₃ : [] ⊢ Q₂ -→ Q₃
 qstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
-⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)) ·[ ` 1 , `ℕ ] ⦂ ` 0
+⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ] ⦂ ` 0
 ⊢Q₃-in = preservation-Beta (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) ⊢Qbody₁)
                               ⊢QS₇)
 
 ⊢Q₃ : [] ∣ [] ⊢ Q₃ ⦂ `ℕ
-⊢Q₃ = env (mw-b wf-ℕ mw[]) ⊢Q₃-in (conv-unseal ez) wf-ℕ
+⊢Q₃ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₃-in (conv-unseal ez) wf-ℕ
 
 -- ── STEP 4 — TYBETA (inner), under ξ-⟪⟫.  THE ID-LAYER IS BORN: the body
 -- type is the OUTER variable, so the minted conversion is an identity.
@@ -1120,41 +1121,41 @@ _ : reveal 0 (` 1) ≡ id (` 1)
 _ = refl
 
 Q₄ : Term
-Q₄ = ((($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫) ⟪ bind `ℕ ∷ [] , id (` 1) ⟫)
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+Q₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 qstep₄ : [] ⊢ Q₃ -→ Q₄
 qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
 
-⊢Qseal₇ : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫ ⦂ ` 1
-⊢Qseal₇ = env (mw-l (bind `ℕ , es ez , nameable-b) mw[]) ⊢$
+⊢Qseal₇ : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
+⊢Qseal₇ = env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[])) ⊢$
                (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
 
-⊢Q₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)
-                      ⟪ bind `ℕ ∷ [] , id (` 1) ⟫ ⦂ ` 0
+⊢Q₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
+                      ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
 ⊢Q₄-in = preservation-TyBeta ⊢Q₃-in
 
 ⊢Q₄ : [] ∣ [] ⊢ Q₄ ⦂ `ℕ
-⊢Q₄ = env (mw-b wf-ℕ mw[]) ⊢Q₄-in (conv-unseal ez) wf-ℕ
+⊢Q₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₄-in (conv-unseal ez) wf-ℕ
 
 -- ── STEP 5 — THE IDPUSH REDEX, AND IDPUSH.  Θ₁ = Θ₂ = `bind ℕ ∷ []`,
 -- X = 1, Y = 0, A = ℕ (the looked-up rep).  Both frames are untouched;
 -- only the two conversions swap.
 
 Q₅ : Term
-Q₅ = ((($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫) ⟪ bind `ℕ ∷ [] , unseal 1 ⟫)
-       ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+Q₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₅ : [] ⊢ Q₄ -→ Q₅
 qstep₅ = IdPush (V-⟪⟫ V-$ I-seal) ez
 
 -- the contractum TYPES: the rep ℕ is well formed inside Θ₂'s interior.
-⊢Q₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)
-                      ⟪ bind `ℕ ∷ [] , unseal 1 ⟫ ⦂ `ℕ
-⊢Q₅-in = env (mw-b wf-ℕ mw[]) ⊢Qseal₇ (conv-unseal (es ez)) wf-ℕ
+⊢Q₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
+                      ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
+⊢Q₅-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Qseal₇ (conv-unseal (es ez)) wf-ℕ
 
 ⊢Q₅ : [] ∣ [] ⊢ Q₅ ⦂ `ℕ
-⊢Q₅ = env (mw-b wf-ℕ mw[]) ⊢Q₅-in (conv-id base-ℕ) wf-ℕ
+⊢Q₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₅-in (conv-id base-ℕ) wf-ℕ
 
 -- ── STEP 6 — CANCEL, under ξ-⟪⟫.  The seal minted by Peel and the unseal
 -- IdPush just moved inwards are now adjacent.  BOTH FRAMES STAY: the
@@ -1162,43 +1163,43 @@ qstep₅ = IdPush (V-⟪⟫ V-$ I-seal) ez
 -- more transparent layer for Drop$ to finish.
 
 Q₆ : Term
-Q₆ = ((($ 7) ⟪ lock 1 ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫)
-       ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+Q₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₆ : [] ⊢ Q₅ -→ Q₆
 qstep₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
 
-⊢Q₆-in2 : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ lock 1 ∷ [] , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₆-in2 = env (mw-l (bind `ℕ , es ez , nameable-b) mw[])
+⊢Q₆-in2 : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
+⊢Q₆-in2 = env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[]))
                ⊢$ (conv-id base-ℕ) wf-ℕ
 
-⊢Q₆-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 1 ∷ [] , id `ℕ ⟫)
-                      ⟪ bind `ℕ ∷ [] , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₆-in = env (mw-b wf-ℕ mw[]) ⊢Q₆-in2 (conv-id base-ℕ) wf-ℕ
+⊢Q₆-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
+                      ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
+⊢Q₆-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₆-in2 (conv-id base-ℕ) wf-ℕ
 
 ⊢Q₆ : [] ∣ [] ⊢ Q₆ ⦂ `ℕ
-⊢Q₆ = env (mw-b wf-ℕ mw[]) ⊢Q₆-in (conv-id base-ℕ) wf-ℕ
+⊢Q₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₆-in (conv-id base-ℕ) wf-ℕ
 
 -- ── STEPS 7, 8, 9 — the three base conversions over the numeral.
 
 Q₇ Q₈ : Term
-Q₇ = (($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-Q₈ = ($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+Q₇ = (($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+Q₈ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₇ : [] ⊢ Q₆ -→ Q₇
 qstep₇ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
 
-⊢Q₇-in : QΔ₁ ∣ [] ⊢ ($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₇-in = env (mw-b wf-ℕ mw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+⊢Q₇-in : QΔ₁ ∣ [] ⊢ ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
+⊢Q₇-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
 
 ⊢Q₇ : [] ∣ [] ⊢ Q₇ ⦂ `ℕ
-⊢Q₇ = env (mw-b wf-ℕ mw[]) ⊢Q₇-in (conv-id base-ℕ) wf-ℕ
+⊢Q₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₇-in (conv-id base-ℕ) wf-ℕ
 
 qstep₈ : [] ⊢ Q₇ -→ Q₈
 qstep₈ = ξ-⟪⟫ (Drop$ base-ℕ)
 
 ⊢Q₈ : [] ∣ [] ⊢ Q₈ ⦂ `ℕ
-⊢Q₈ = env (mw-b wf-ℕ mw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+⊢Q₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
 
 qstep₉ : [] ⊢ Q₈ -→ $ 7
 qstep₉ = Drop$ base-ℕ
@@ -1278,25 +1279,25 @@ QΞ₃ : Ctxᵗ
 QΞ₃ = bind `ℕ ∷ QΞ₂
 
 D₁ D₂ D₃ D₄ D₅ D₆ D₇ D₈ D₉ D₁₀ D₁₁ : Term
-D₁  = ((ƛ (` 0) ∙ Dbody) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
-D₂  = ((ƛ (` 0) ∙ Dbody) · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-D₃  = ((Λ ((Λ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)) ·[ ` 2 , `ℕ ]))
-         ·[ ` 1 , `ℕ ]) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-D₄  = ((Λ ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-              ⟪ bind `ℕ ∷ [] , id (` 2) ⟫)) ·[ ` 1 , `ℕ ])
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-D₅  = (((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫) ⟪ bind `ℕ ∷ [] , id (` 2) ⟫)
-          ⟪ bind `ℕ ∷ [] , id (` 1) ⟫) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-D₆  = (((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫) ⟪ bind `ℕ ∷ [] , id (` 2) ⟫)
-          ⟪ bind `ℕ ∷ [] , unseal 1 ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-D₇  = (((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫) ⟪ bind `ℕ ∷ [] , unseal 2 ⟫)
-          ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-D₈  = (((($ 7) ⟪ lock 2 ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫)
-          ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-D₉  = ((($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫)
-        ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-D₁₀ = (($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-D₁₁ = ($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+D₁  = ((ƛ (` 0) ∙ Dbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
+D₂  = ((ƛ (` 0) ∙ Dbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+D₃  = ((Λ ((Λ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)) ·[ ` 2 , `ℕ ]))
+         ·[ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+D₄  = ((Λ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+              ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)) ·[ ` 1 , `ℕ ])
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+D₅  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+D₆  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₇  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₈  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₉  = ((($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₀ = (($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₁ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 dstep₁ : [] ⊢ D₀ -→ D₁
 dstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1345,47 +1346,47 @@ run-D₀ = dstep₁ then dstep₂ then dstep₃ then dstep₄ then dstep₅
 
 -- ── BOTH IDPUSH CONTRACTA TYPE ─────────────────────────────────────────
 
-⊢Dseal₇ : QΞ₃ ∣ [] ⊢ ($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫ ⦂ ` 2
-⊢Dseal₇ = env (mw-l (bind `ℕ , es (es ez) , nameable-b) mw[]) ⊢$
+⊢Dseal₇ : QΞ₃ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
+⊢Dseal₇ = env (mw rw[] (sw-l (bind `ℕ , es (es ez) , nameable-b) sw[])) ⊢$
                (conv-seal (es (es ez)))
                (wf-var (bind `ℕ , es (es ez) , nameable-b))
 
-⊢Did₂ : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                     ⟪ bind `ℕ ∷ [] , id (` 2) ⟫ ⦂ ` 1
-⊢Did₂ = env (mw-b wf-ℕ mw[]) ⊢Dseal₇
+⊢Did₂ : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                     ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 1
+⊢Did₂ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Dseal₇
              (conv-idv (bind `ℕ , es (es ez) , nameable-b))
              (wf-var (bind `ℕ , es ez , nameable-b))
 
-⊢D₅-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                        ⟪ bind `ℕ ∷ [] , id (` 2) ⟫)
-                       ⟪ bind `ℕ ∷ [] , id (` 1) ⟫ ⦂ ` 0
-⊢D₅-in = env (mw-b wf-ℕ mw[]) ⊢Did₂
+⊢D₅-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                        ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+                       ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
+⊢D₅-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Did₂
               (conv-idv (bind `ℕ , es ez , nameable-b))
               (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢D₅ : [] ∣ [] ⊢ D₅ ⦂ `ℕ
-⊢D₅ = env (mw-b wf-ℕ mw[]) ⊢D₅-in (conv-unseal ez) wf-ℕ
+⊢D₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₅-in (conv-unseal ez) wf-ℕ
 
-⊢D₆-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                        ⟪ bind `ℕ ∷ [] , id (` 2) ⟫)
-                       ⟪ bind `ℕ ∷ [] , unseal 1 ⟫ ⦂ `ℕ
-⊢D₆-in = env (mw-b wf-ℕ mw[]) ⊢Did₂ (conv-unseal (es ez)) wf-ℕ
+⊢D₆-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                        ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+                       ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
+⊢D₆-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Did₂ (conv-unseal (es ez)) wf-ℕ
 
 ⊢D₆ : [] ∣ [] ⊢ D₆ ⦂ `ℕ
-⊢D₆ = env (mw-b wf-ℕ mw[]) ⊢D₆-in (conv-id base-ℕ) wf-ℕ
+⊢D₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₆-in (conv-id base-ℕ) wf-ℕ
 
-⊢D₇-in2 : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                        ⟪ bind `ℕ ∷ [] , unseal 2 ⟫ ⦂ `ℕ
-⊢D₇-in2 = env (mw-b wf-ℕ mw[]) ⊢Dseal₇
+⊢D₇-in2 : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                        ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫ ⦂ `ℕ
+⊢D₇-in2 = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Dseal₇
                (conv-unseal (es (es ez))) wf-ℕ
 
-⊢D₇-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                        ⟪ bind `ℕ ∷ [] , unseal 2 ⟫)
-                       ⟪ bind `ℕ ∷ [] , id `ℕ ⟫ ⦂ `ℕ
-⊢D₇-in = env (mw-b wf-ℕ mw[]) ⊢D₇-in2 (conv-id base-ℕ) wf-ℕ
+⊢D₇-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                        ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫)
+                       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
+⊢D₇-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₇-in2 (conv-id base-ℕ) wf-ℕ
 
 ⊢D₇ : [] ∣ [] ⊢ D₇ ⦂ `ℕ
-⊢D₇ = env (mw-b wf-ℕ mw[]) ⊢D₇-in (conv-id base-ℕ) wf-ℕ
+⊢D₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₇-in (conv-id base-ℕ) wf-ℕ
 
 ------------------------------------------------------------------------
 -- §11b  VARIANT (ii) — AN ID-LAYER WHOSE CONVERSION REP IS CHAINED
@@ -1425,52 +1426,52 @@ RΞ  = bind (` 0) ∷ bind `ℕ ∷ []
 RΞ′ = bind `ℕ ∷ RΞ
 RΞ″ = bind `ℕ ∷ masked (bind (` 0)) ∷ bind `ℕ ∷ []
 
-_ : interior (bind (` 0) ∷ []) QΔ₁ ≡ RΞ
+_ : interior (morph ((` 0) ∷ []) []) QΔ₁ ≡ RΞ
 _ = refl
 
-_ : interior (bind `ℕ ∷ []) RΞ ≡ RΞ′
+_ : interior (morph (`ℕ ∷ []) []) RΞ ≡ RΞ′
 _ = refl
 
-_ : interior (lock 1 ∷ []) RΞ′ ≡ RΞ″
+_ : interior (morph [] (lock 1 ∷ [])) RΞ′ ≡ RΞ″
 _ = refl
 
 -- THE CHAINED REP, as a lookup: Θ₂'s binder 0 has rep ` 1, which NAMES
 -- the outer binder — and that slot is VISIBLE inside Θ₂ (nothing locks it).
-Rchain : convCtx (bind (` 0) ∷ []) QΔ₁ ∋ 0 := ` 1
+Rchain : convCtx (morph ((` 0) ∷ []) []) QΔ₁ ∋ 0 := ` 1
 Rchain = ez
 
-Rchain-scoped : interior (bind (` 0) ∷ []) QΔ₁ ⊢ᵗ ` 1
+Rchain-scoped : interior (morph ((` 0) ∷ []) []) QΔ₁ ⊢ᵗ ` 1
 Rchain-scoped = wf-var (_ , es ez , nameable-b)
 
 -- ── the states ─────────────────────────────────────────────────────────
 
 RS RS↑ RW : Term
-RS  = (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫) ⟪ lock 0 ∷ [] , seal 0 ⟫
-RS↑ = (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫) ⟪ lock 1 ∷ [] , seal 1 ⟫
-RW  = ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫) ⟪ lock 1 ∷ [] , id (` 2) ⟫)
-        ⟪ bind `ℕ ∷ [] , id (` 2) ⟫
+RS  = (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
+RS↑ = (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
+RW  = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) , id (` 2) ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫
 
-_ : wkᴹ 1 QS₇ ≡ ($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫
+_ : wkᴹ 1 QS₇ ≡ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
 _ = refl
 
 _ : ⇑ᴹ RS ≡ RS↑
 _ = refl
 
 R₁ R₂ R₃ R₄ R₅ R₆ R₇ R₈ R₉ : Term
-R₁  = ((ƛ (` 0) ∙ Rbody) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
-R₂  = ((ƛ (` 0) ∙ Rbody) · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₃  = ((Qfun ·[ ` 0 ⇒ ` 0 , ` 0 ]) · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₄  = (((ƛ (` 0) ∙ Qbody) ⟪ bind (` 0) ∷ [] , seal 0 ↦ unseal 0 ⟫) · QS₇)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₅  = (((ƛ (` 0) ∙ Qbody) · RS) ⟪ bind (` 0) ∷ [] , unseal 0 ⟫)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₆  = (((Λ RS↑) ·[ ` 1 , `ℕ ]) ⟪ bind (` 0) ∷ [] , unseal 0 ⟫)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₇  = ((RS↑ ⟪ bind `ℕ ∷ [] , id (` 1) ⟫) ⟪ bind (` 0) ∷ [] , unseal 0 ⟫)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₈  = ((RS↑ ⟪ bind `ℕ ∷ [] , unseal 1 ⟫) ⟪ bind (` 0) ∷ [] , id (` 1) ⟫)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-R₉  = (RW ⟪ bind (` 0) ∷ [] , id (` 1) ⟫) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+R₁  = ((ƛ (` 0) ∙ Rbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
+R₂  = ((ƛ (` 0) ∙ Rbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₃  = ((Qfun ·[ ` 0 ⇒ ` 0 , ` 0 ]) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₄  = (((ƛ (` 0) ∙ Qbody) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · QS₇)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₅  = (((ƛ (` 0) ∙ Qbody) · RS) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₆  = (((Λ RS↑) ·[ ` 1 , `ℕ ]) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₇  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₈  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+R₉  = (RW ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 rstep₁ : [] ⊢ R₀ -→ R₁
 rstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1523,40 +1524,40 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
 
 -- ── THE CHAINED IDPUSH REDEX AND ITS CONTRACTUM BOTH TYPE ──────────────
 
-⊢RV₂ : RΞ″ ∣ [] ⊢ ($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫ ⦂ ` 2
-⊢RV₂ = env (mw-l (_ , es (es ez) , nameable-b) mw[]) ⊢$
+⊢RV₂ : RΞ″ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
+⊢RV₂ = env (mw rw[] (sw-l (_ , es (es ez) , nameable-b) sw[])) ⊢$
             (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable-b))
 
 ⊢RS↑ : RΞ′ ∣ [] ⊢ RS↑ ⦂ ` 1
-⊢RS↑ = env (mw-l (_ , es ez , nameable-b) mw[]) ⊢RV₂
+⊢RS↑ = env (mw rw[] (sw-l (_ , es ez , nameable-b) sw[])) ⊢RV₂
             (conv-seal (es ez)) (wf-var (_ , es ez , nameable-b))
 
-⊢Rlayer : RΞ ∣ [] ⊢ RS↑ ⟪ bind `ℕ ∷ [] , id (` 1) ⟫ ⦂ ` 0
-⊢Rlayer = env (mw-b wf-ℕ mw[]) ⊢RS↑
+⊢Rlayer : RΞ ∣ [] ⊢ RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
+⊢Rlayer = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢RS↑
                (conv-idv (_ , es ez , nameable-b))
                (wf-var (_ , ez , nameable-b))
 
-⊢R₇-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ bind `ℕ ∷ [] , id (` 1) ⟫)
-                       ⟪ bind (` 0) ∷ [] , unseal 0 ⟫ ⦂ ` 0
-⊢R₇-in = env (mw-b (wf-var (_ , ez , nameable-b)) mw[]) ⊢Rlayer
+⊢R₇-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
+                       ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫ ⦂ ` 0
+⊢R₇-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢Rlayer
               (conv-unseal ez) (wf-var (_ , ez , nameable-b))
 
 ⊢R₇ : [] ∣ [] ⊢ R₇ ⦂ `ℕ
-⊢R₇ = env (mw-b wf-ℕ mw[]) ⊢R₇-in (conv-unseal ez) wf-ℕ
+⊢R₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢R₇-in (conv-unseal ez) wf-ℕ
 
 -- the contractum: the inner wrapper now EXPORTS the chained rep ` 1, and
 -- `env`'s last premise `RΞ ⊢ᵗ ` 1` is exactly `Rchain-scoped`.
-⊢R₈-mid : RΞ ∣ [] ⊢ RS↑ ⟪ bind `ℕ ∷ [] , unseal 1 ⟫ ⦂ ` 1
-⊢R₈-mid = env (mw-b wf-ℕ mw[]) ⊢RS↑
+⊢R₈-mid : RΞ ∣ [] ⊢ RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫ ⦂ ` 1
+⊢R₈-mid = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢RS↑
                (conv-unseal (es ez)) Rchain-scoped
 
-⊢R₈-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ bind `ℕ ∷ [] , unseal 1 ⟫)
-                       ⟪ bind (` 0) ∷ [] , id (` 1) ⟫ ⦂ ` 0
-⊢R₈-in = env (mw-b (wf-var (_ , ez , nameable-b)) mw[]) ⊢R₈-mid
+⊢R₈-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
+                       ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
+⊢R₈-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢R₈-mid
               (conv-idv (_ , es ez , nameable-b)) (wf-var (_ , ez , nameable-b))
 
 ⊢R₈ : [] ∣ [] ⊢ R₈ ⦂ `ℕ
-⊢R₈ = env (mw-b wf-ℕ mw[]) ⊢R₈-in (conv-unseal ez) wf-ℕ
+⊢R₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢R₈-in (conv-unseal ez) wf-ℕ
 
 ------------------------------------------------------------------------
 -- §11c  VARIANT (i) — AN ID-LAYER WITH A NON-TRIVIAL Θ₁
@@ -1569,19 +1570,19 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
 --   Peel     mints `dual Θ`, which is ALL locks/unlocks numBinds 0
 --   CancelR  mints NO frame (both are carried over)
 --   IdPush   mints NO frame (both are carried over)
---   TyPeelR  mints `bind A ∷ Θ`               numBinds = 1 + numBinds Θ
+--   TyPeelR  prepends one bind          numBinds = 1 + numBinds Θ
 --
 -- so `numBinds Θ ≥ 2` is reachable ONLY through TyPeelR.  Those facts,
 -- machine-checked:
 
-numBinds-TyBeta : (A : Ty) → numBinds (bind A ∷ []) ≡ 1
+numBinds-TyBeta : (A : Ty) → numBinds (morph (A ∷ []) []) ≡ 1
 numBinds-TyBeta A = refl
 
 numBinds-dual : (Θ : CtxMorph) → numBinds (dual Θ) ≡ 0
-numBinds-dual Θ = cong length (repsOf-dual Θ)
+numBinds-dual Θ = refl
 
 numBinds-TyPeelR : (A : Ty) (Θ : CtxMorph)
-  → numBinds (bind A ∷ Θ) ≡ suc (numBinds Θ)
+  → numBinds (morph (A ∷ binds Θ) (changes Θ)) ≡ suc (numBinds Θ)
 numBinds-TyPeelR A Θ = refl
 
 -- ── A CLOSED SOURCE THAT REACHES TYPEELR ───────────────────────────────
@@ -1610,16 +1611,16 @@ _ : reveal 0 (`∀ (` 2)) ≡ `∀ (id (` 2))
 _ = refl
 
 GV G₁ G₂ G₃ G₄ G₅ : Term
-GV = Λ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-G₁ = ((ƛ (` 0) ∙ Gbody) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
-G₂ = ((ƛ (` 0) ∙ Gbody) · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+GV = Λ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+G₁ = ((ƛ (` 0) ∙ Gbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
+G₂ = ((ƛ (` 0) ∙ Gbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 G₃ = (((Λ GV) ·[ `∀ (` 2) , `ℕ ]) ·[ ` 1 , `ℕ ])
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-G₄ = ((GV ⟪ bind `ℕ ∷ [] , `∀ (id (` 2)) ⟫) ·[ ` 1 , `ℕ ])
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-G₅ = ((Λ (($ 7) ⟪ lock 3 ∷ [] , seal 3 ⟫)) ·[ ` 3 , ` 0 ])
-       ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , id (` 2) ⟫
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+G₄ = ((GV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 2)) ⟫) ·[ ` 1 , `ℕ ])
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+G₅ = ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , ` 0 ])
+       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 gstep₁ : [] ⊢ G₀ -→ G₁
 gstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1636,47 +1637,47 @@ gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ (V-⟪⟫ V-$ I-seal))))
 -- the TyPeelR step, whose contractum is the wanted `numBinds Θ₁ ≡ 2` layer.
 -- Its conversion premise is the redex's own, one `` `∀ `` inside —
 -- here the identity at the OUTER binder, read under the ∀-binder.
-⊢Gconv : (abst ∷ convCtx (bind `ℕ ∷ []) QΔ₁) ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
+⊢Gconv : (abst ∷ convCtx (morph (`ℕ ∷ []) []) QΔ₁) ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
 ⊢Gconv = conv-idv (bind `ℕ , es (es ez) , nameable-b)
 
 gstep₅ : [] ⊢ G₄ -→ G₅
 gstep₅ = ξ-⟪⟫ (TyPeelR (V-Λ (V-⟪⟫ V-$ I-seal)) ⊢Gconv)
 
-_ : numBinds (bind `ℕ ∷ bind `ℕ ∷ []) ≡ 2
+_ : numBinds (morph (`ℕ ∷ `ℕ ∷ []) []) ≡ 2
 _ = refl
 
 -- G₄ IS WELL TYPED …
 ⊢GV : QΞ₂ ∣ [] ⊢ GV ⦂ `∀ (` 2)
-⊢GV = ⊢Λ (env (mw-l (_ , es (es ez) , nameable-b) mw[]) ⊢$
+⊢GV = ⊢Λ (env (mw rw[] (sw-l (_ , es (es ez) , nameable-b) sw[])) ⊢$
                (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable-b)))
 
-⊢Gpkg : QΔ₁ ∣ [] ⊢ GV ⟪ bind `ℕ ∷ [] , `∀ (id (` 2)) ⟫ ⦂ `∀ (` 1)
-⊢Gpkg = env (mw-b wf-ℕ mw[]) ⊢GV
+⊢Gpkg : QΔ₁ ∣ [] ⊢ GV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 2)) ⟫ ⦂ `∀ (` 1)
+⊢Gpkg = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢GV
              (conv-all (conv-idv (_ , es (es ez) , nameable-b)))
              (wf-∀ (wf-var (_ , es ez , nameable-b)))
 
 ⊢G₄ : [] ∣ [] ⊢ G₄ ⦂ `ℕ
-⊢G₄ = env (mw-b wf-ℕ mw[]) (⊢·[] ⊢Gpkg wf-ℕ) (conv-unseal ez) wf-ℕ
+⊢G₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) (⊢·[] ⊢Gpkg wf-ℕ) (conv-unseal ez) wf-ℕ
 
 -- … AND SO IS ITS TYPEELR CONTRACTUM, with the repaired rule.  The
 -- pushed-in annotation is the INTERIOR ∀-body shifted past the new binder
 -- (`` ` 3 ``, matching `wkᴹ 1 GV : `∀ (` 3)`), and the frame is plain `Θ`
 -- — the `renᴮ suc Θ` double-shift that made `¬⊢G₅` true is gone.  So
 -- variant (i) now HAS a well-typed closed-source instance.
-⊢G₅-Λ : QΞ₃ ∣ [] ⊢ Λ (($ 7) ⟪ lock 3 ∷ [] , seal 3 ⟫) ⦂ `∀ (` 3)
-⊢G₅-Λ = ⊢Λ (env (mw-l (bind `ℕ , es (es (es ez)) , nameable-b) mw[]) ⊢$
+⊢G₅-Λ : QΞ₃ ∣ [] ⊢ Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫) ⦂ `∀ (` 3)
+⊢G₅-Λ = ⊢Λ (env (mw rw[] (sw-l (bind `ℕ , es (es (es ez)) , nameable-b) sw[])) ⊢$
                 (conv-seal (es (es (es ez))))
                 (wf-var (bind `ℕ , es (es (es ez)) , nameable-b)))
 
-⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ lock 3 ∷ [] , seal 3 ⟫)) ·[ ` 3 , ` 0 ])
-                      ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , id (` 2) ⟫ ⦂ ` 0
-⊢G₅-in = env (mw-b wf-ℕ (mw-b wf-ℕ mw[]))
+⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , ` 0 ])
+                      ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 0
+⊢G₅-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[])
               (⊢·[] ⊢G₅-Λ (wf-var (bind `ℕ , ez , nameable-b)))
               (conv-idv (bind `ℕ , es (es ez) , nameable-b))
               (wf-var (bind `ℕ , ez , nameable-b))
 
 ⊢G₅ : [] ∣ [] ⊢ G₅ ⦂ `ℕ
-⊢G₅ = env (mw-b wf-ℕ mw[]) ⊢G₅-in (conv-unseal ez) wf-ℕ
+⊢G₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢G₅-in (conv-unseal ez) wf-ℕ
 
 -- ── AND THE MULTI-BIND ID-LAYER IT DELIVERS ────────────────────────────
 -- The same shape, hand-built at the frame the repaired rule produces
@@ -1685,33 +1686,33 @@ _ = refl
 -- — the lifting `shiftBy 2` is exactly absorbed by `pushBinds`.
 
 K₀ K₁ : Term
-K₀ = ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-        ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , id (` 2) ⟫) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-K₁ = ((($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-        ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , unseal 2 ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+K₀ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+K₁ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , unseal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
-_ : interior (bind `ℕ ∷ bind `ℕ ∷ []) QΔ₁ ≡ QΞ₃
+_ : interior (morph (`ℕ ∷ `ℕ ∷ []) []) QΔ₁ ≡ QΞ₃
 _ = refl
 
-⊢K₀-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                       ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , id (` 2) ⟫ ⦂ ` 0
-⊢K₀-in = env (mw-b wf-ℕ (mw-b wf-ℕ mw[])) ⊢Dseal₇
+⊢K₀-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 0
+⊢K₀-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[]) ⊢Dseal₇
               (conv-idv (_ , es (es ez) , nameable-b))
               (wf-var (_ , ez , nameable-b))
 
 ⊢K₀ : [] ∣ [] ⊢ K₀ ⦂ `ℕ
-⊢K₀ = env (mw-b wf-ℕ mw[]) ⊢K₀-in (conv-unseal ez) wf-ℕ
+⊢K₀ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢K₀-in (conv-unseal ez) wf-ℕ
 
 kstep : [] ⊢ K₀ -→ K₁
 kstep = IdPush (V-⟪⟫ V-$ I-seal) ez
 
-⊢K₁-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫)
-                       ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , unseal 2 ⟫ ⦂ `ℕ
-⊢K₁-in = env (mw-b wf-ℕ (mw-b wf-ℕ mw[])) ⊢Dseal₇
+⊢K₁-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+                       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , unseal 2 ⟫ ⦂ `ℕ
+⊢K₁-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[]) ⊢Dseal₇
               (conv-unseal (es (es ez))) wf-ℕ
 
 ⊢K₁ : [] ∣ [] ⊢ K₁ ⦂ `ℕ
-⊢K₁ = env (mw-b wf-ℕ mw[]) ⊢K₁-in (conv-id base-ℕ) wf-ℕ
+⊢K₁ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢K₁-in (conv-id base-ℕ) wf-ℕ
 
 ------------------------------------------------------------------------
 -- §12  THE WALL, PROBED FOR REACHABILITY POST-REPAIR
@@ -1760,25 +1761,25 @@ LΔ LΞ : Ctxᵗ
 LΔ = bind (` 0) ∷ bind `ℕ ∷ []
 LΞ = bind (` 0) ∷ masked (bind `ℕ) ∷ []
 
-_ : interior (bind (` 0) ∷ []) QΔ₁ ≡ LΔ
+_ : interior (morph ((` 0) ∷ []) []) QΔ₁ ≡ LΔ
 _ = refl
 
-_ : interior (lock 1 ∷ []) LΔ ≡ LΞ
+_ : interior (morph [] (lock 1 ∷ [])) LΔ ≡ LΞ
 _ = refl
 
 L₁ L₂ L₃ L₄ L₅ L₆ L₇ L₈ : Term
-L₁ = ((ƛ (` 0) ∙ Lbody) ⟪ bind `ℕ ∷ [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
-L₂ = ((ƛ (` 0) ∙ Lbody) · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-L₃ = ((Λ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)) ·[ ` 1 , ` 0 ])
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-L₄ = ((($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫) ⟪ bind (` 0) ∷ [] , id (` 1) ⟫)
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-L₅ = ((($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫) ⟪ bind (` 0) ∷ [] , unseal 1 ⟫)
-       ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-L₆ = ((($ 7) ⟪ lock 1 ∷ [] , id `ℕ ⟫) ⟪ bind (` 0) ∷ [] , id `ℕ ⟫)
-       ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-L₇ = (($ 7) ⟪ bind (` 0) ∷ [] , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-L₈ = ($ 7) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+L₁ = ((ƛ (` 0) ∙ Lbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
+L₂ = ((ƛ (` 0) ∙ Lbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+L₃ = ((Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , ` 0 ])
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+L₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+L₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal 1 ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+L₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+L₇ = (($ 7) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+L₈ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 lstep₁ : [] ⊢ L₀ -→ L₁
 lstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1822,25 +1823,25 @@ _ = refl
 
 -- ── every state on the run TYPES, including the two the wall touches ───
 
-⊢Lseal₇ : LΔ ∣ [] ⊢ ($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫ ⦂ ` 1
-⊢Lseal₇ = env (mw-l (_ , es ez , nameable-b) mw[]) ⊢$
+⊢Lseal₇ : LΔ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
+⊢Lseal₇ = env (mw rw[] (sw-l (_ , es ez , nameable-b) sw[])) ⊢$
                (conv-seal (es ez)) (wf-var (_ , es ez , nameable-b))
 
-⊢L₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)
-                       ⟪ bind (` 0) ∷ [] , id (` 1) ⟫ ⦂ ` 0
-⊢L₄-in = env (mw-b (wf-var (_ , ez , nameable-b)) mw[]) ⊢Lseal₇
+⊢L₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
+                       ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
+⊢L₄-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢Lseal₇
               (conv-idv (_ , es ez , nameable-b)) (wf-var (_ , ez , nameable-b))
 
 ⊢L₄ : [] ∣ [] ⊢ L₄ ⦂ `ℕ
-⊢L₄ = env (mw-b wf-ℕ mw[]) ⊢L₄-in (conv-unseal ez) wf-ℕ
+⊢L₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢L₄-in (conv-unseal ez) wf-ℕ
 
-⊢L₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫)
-                       ⟪ bind (` 0) ∷ [] , unseal 1 ⟫ ⦂ `ℕ
-⊢L₅-in = env (mw-b (wf-var (_ , ez , nameable-b)) mw[]) ⊢Lseal₇
+⊢L₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
+                       ⟪ morph ((` 0) ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
+⊢L₅-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢Lseal₇
               (conv-unseal (es ez)) wf-ℕ
 
 ⊢L₅ : [] ∣ [] ⊢ L₅ ⦂ `ℕ
-⊢L₅ = env (mw-b wf-ℕ mw[]) ⊢L₅-in (conv-id base-ℕ) wf-ℕ
+⊢L₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢L₅-in (conv-id base-ℕ) wf-ℕ
 
 -- THE PRECISE READING.  On this run the blocked slot lives inside a
 -- wrapper that is a `Θ₁` (an INERT `seal` conversion, the CancelR
@@ -1877,10 +1878,10 @@ open import strong.proof.PreserveObstruct
   using (Δi; Θi; Vi; Ri; ⊢Ri; step-i)
 
 wallR₁ : Term
-wallR₁ = (Vi ⟪ [] ⋉ Θi , unseal 0 ⟫) ⟪ rewind Θi , mkId (` 1) ⟫
+wallR₁ = (Vi ⟪ morph [] [] ⋉ Θi , unseal 0 ⟫) ⟪ rewind Θi , mkId (` 1) ⟫
 
-_ : wallR₁ ≡ (Vi ⟪ lock 1 ∷ [] , unseal 0 ⟫)
-               ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫
+_ : wallR₁ ≡ (Vi ⟪ morph [] (lock 1 ∷ []) , unseal 0 ⟫)
+               ⟪ morph [] (unlock 1 ∷ lock 1 ∷ []) , id (` 1) ⟫
 _ = refl
 
 -- THE STEP THE OLD RULE COULD NOT TAKE SOUNDLY …
@@ -1892,8 +1893,8 @@ wallstep₁ = step-i
 ⊢wallR₁ = preservation ⊢Ri wallstep₁
 
 -- the value's own frame is untouched by the move
-_ : interior ([] ⋉ Θi) (interior (rewind Θi) Δi)
-      ≡ interior [] (interior Θi Δi)
+_ : interior (morph [] [] ⋉ Θi) (interior (rewind Θi) Δi)
+      ≡ interior (morph [] []) (interior Θi Δi)
 _ = refl
 
 -- AND THE RUN FINISHES.  The move brought the `seal X` of `Vi`'s own
@@ -1904,10 +1905,10 @@ _ = refl
 --
 -- the mask/unmask pair sitting inertly on the frame it was moved into.
 wallR₂ : Term
-wallR₂ = (((($ 7) ⟪ [] , seal 1 ⟫)
-             ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫)
-             ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫)
-             ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫
+wallR₂ = (((($ 7) ⟪ morph [] [] , seal 1 ⟫)
+             ⟪ morph [] (unlock 1 ∷ lock 1 ∷ []) , id (` 1) ⟫)
+             ⟪ morph [] (unlock 1 ∷ lock 1 ∷ []) , id (` 1) ⟫)
+             ⟪ morph [] (unlock 1 ∷ lock 1 ∷ []) , id (` 1) ⟫
 
 wallstep₂ : Δi ⊢ wallR₁ -→ wallR₂
 wallstep₂ = ξ-⟪⟫ (CancelR (V-⟪⟫ V-$ I-seal) ez)
@@ -2003,14 +2004,14 @@ _ = refl
 
 J₁ J₂ J₃ J₄ J₅ : Term
 J₁ = (((ƛ (` 0) ∙ Jbody)
-         ⟪ bind `ℕ ∷ [] , seal 0 ↦ ((`∀ st) ↦ unseal 0) ⟫) · ($ 7)) · Wt
+         ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ ((`∀ st) ↦ unseal 0) ⟫) · ($ 7)) · Wt
 J₂ = (((ƛ (` 0) ∙ Jbody) · QS₇)
-        ⟪ bind `ℕ ∷ [] , (`∀ st) ↦ unseal 0 ⟫) · Wt
+        ⟪ morph (`ℕ ∷ []) [] , (`∀ st) ↦ unseal 0 ⟫) · Wt
 J₃ = ((ƛ JT ∙ (((` 0) ·[ ` 0 ⇒ ` 1 , ` 0 ]) · QS₇))
-        ⟪ bind `ℕ ∷ [] , (`∀ st) ↦ unseal 0 ⟫) · Wt
+        ⟪ morph (`ℕ ∷ []) [] , (`∀ st) ↦ unseal 0 ⟫) · Wt
 J₄ = ((ƛ JT ∙ (((` 0) ·[ ` 0 ⇒ ` 1 , ` 0 ]) · QS₇)) · Wft)
-       ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-J₅ = (Rt · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₅ = (Rt · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 jstep₁ : [] ⊢ J₀ -→ J₁
 jstep₁ = ξ-·-l (ξ-·-l (TyBeta V-ƛ))
@@ -2034,7 +2035,7 @@ run-J₀ = jstep₁ then jstep₂ then jstep₃ then jstep₄ then jstep₅ then
 
 -- J₅'s head IS proof/PreserveObstruct §2's redex, and it is TYPED there.
 _ : J₅ ≡ (((Wt ⟪ Θt , `∀ st ⟫) ·[ ` 0 ⇒ ` 1 , ` 0 ]) · QS₇)
-           ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+           ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 _ = refl
 
 ⊢J₅-head : Δt ∣ [] ⊢ Rt ⦂ (` 0 ⇒ ` 0)
@@ -2042,8 +2043,8 @@ _ = refl
 
 J₆head J₆ : Term
 J₆head = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
-           ⟪ bind (` 0) ∷ Θt , instReveal 0 st ⟫
-J₆     = (J₆head · QS₇) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
+           ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , instReveal 0 st ⟫
+J₆     = (J₆head · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 -- … and TyPeelR fires on it, from this closed source.  (Fact (ii) below
 -- types both `J₆head` and `J₆`.)
@@ -2058,7 +2059,7 @@ jstep₆ = ξ-⟪⟫ (ξ-·-l step-t)
 -- identity converts a type to ITSELF (`conv-id-refl`).
 ¬⊢J-plain :
   ¬ (Δt ∣ [] ⊢ (wkᴹ 1 Wt ·[ ` 0 ⇒ `ℕ , ` 0 ])
-                 ⟪ bind (` 0) ∷ Θt , st ⟫ ⦂ (` 0 ⇒ ` 0))
+                 ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , st ⟫ ⦂ (` 0 ⇒ ` 0))
 ¬⊢J-plain (env _ (⊢·[] _ _) (conv-fun ⊢s ⊢t) _) with conv-id-refl ⊢s
 ... | ()
 
@@ -2069,7 +2070,7 @@ _ : instReveal 0 st ≡ seal 0 ↦ seal 1
 _ = refl
 
 J-convCtx : Ctxᵗ
-J-convCtx = convCtx (bind (` 0) ∷ Θt) Δt
+J-convCtx = convCtx (morph ((` 0) ∷ binds Θt) (changes Θt)) Δt
 
 _ : J-convCtx ≡ bind (` 0) ∷ bind `ℕ ∷ []
 _ = refl
@@ -2100,7 +2101,7 @@ _ = refl
 
 -- … and so does the whole state, one `env` out.
 ⊢J₆ : [] ∣ [] ⊢ J₆ ⦂ `ℕ
-⊢J₆ = env (mw-b wf-ℕ mw[]) (⊢· ⊢J₆head ⊢QS₇) (conv-unseal ez) wf-ℕ
+⊢J₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) (⊢· ⊢J₆head ⊢QS₇) (conv-unseal ez) wf-ℕ
 
 -- ── THE RUN CONTINUES, TO A VALUE ──────────────────────────────────────
 --
@@ -2140,23 +2141,23 @@ _ : reveal 0 (` 0 ⇒ `ℕ) ≡ seal 0 ↦ id `ℕ
 _ = refl
 
 JV : Term                      -- λy. 3, behind the freshly born boundary
-JV = (ƛ (` 0) ∙ ($ 3)) ⟪ bind (` 0) ∷ [] , seal 0 ↦ id `ℕ ⟫
+JV = (ƛ (` 0) ∙ ($ 3)) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ id `ℕ ⟫
 
 val-JV : Value JV
 val-JV = V-⟪⟫ V-ƛ I-fun
 
 -- the two duals the two Peels mint
-_ : dual (bind (` 0) ∷ Θt) ≡ lock 0 ∷ unlock 1 ∷ []
+_ : dual (morph ((` 0) ∷ binds Θt) (changes Θt)) ≡ morph [] (lock 0 ∷ unlock 1 ∷ [])
 _ = refl
 
-_ : dual (bind (` 0) ∷ []) ≡ lock 0 ∷ []
+_ : dual (morph ((` 0) ∷ []) []) ≡ morph [] (lock 0 ∷ [])
 _ = refl
 
 JW JW′ : Term                  -- `7` after the first / the second crossing
-JW  = wkᴹ 1 QS₇ ⟪ dual (bind (` 0) ∷ Θt) , seal 0 ⟫
-JW′ = wkᴹ 1 JW ⟪ dual (bind (` 0) ∷ []) , seal 0 ⟫
+JW  = wkᴹ 1 QS₇ ⟪ dual (morph ((` 0) ∷ binds Θt) (changes Θt)) , seal 0 ⟫
+JW′ = wkᴹ 1 JW ⟪ dual (morph ((` 0) ∷ []) []) , seal 0 ⟫
 
-_ : JW ≡ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫) ⟪ lock 0 ∷ unlock 1 ∷ [] , seal 0 ⟫
+_ : JW ≡ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ unlock 1 ∷ []) , seal 0 ⟫
 _ = refl
 
 val-JW : Value JW
@@ -2166,17 +2167,17 @@ val-JW′ : Value JW′
 val-JW′ = V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal) I-seal
 
 J₇ J₈ J₉ J₁₀ J₁₁ J₁₂ J₁₃ : Term
-J₇  = ((JV ⟪ bind (` 0) ∷ Θt , seal 0 ↦ seal 1 ⟫) · QS₇)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-J₈  = ((JV · JW) ⟪ bind (` 0) ∷ Θt , seal 1 ⟫) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-J₉  = ((((ƛ (` 0) ∙ ($ 3)) · JW′) ⟪ bind (` 0) ∷ [] , id `ℕ ⟫)
-         ⟪ bind (` 0) ∷ Θt , seal 1 ⟫)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-J₁₀ = ((($ 3) ⟪ bind (` 0) ∷ [] , id `ℕ ⟫) ⟪ bind (` 0) ∷ Θt , seal 1 ⟫)
-        ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-J₁₁ = (($ 3) ⟪ bind (` 0) ∷ Θt , seal 1 ⟫) ⟪ bind `ℕ ∷ [] , unseal 0 ⟫
-J₁₂ = (($ 3) ⟪ bind (` 0) ∷ Θt , id `ℕ ⟫) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
-J₁₃ = ($ 3) ⟪ bind `ℕ ∷ [] , id `ℕ ⟫
+J₇  = ((JV ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 0 ↦ seal 1 ⟫) · QS₇)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₈  = ((JV · JW) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₉  = ((((ƛ (` 0) ∙ ($ 3)) · JW′) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
+         ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₁₀ = ((($ 3) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₁₁ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+J₁₂ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+J₁₃ = ($ 3) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 jstep₇ : [] ⊢ J₆ -→ J₇
 jstep₇ = ξ-⟪⟫ (ξ-·-l (ξ-⟪⟫ (TyBeta V-ƛ)))
@@ -2252,15 +2253,15 @@ _ : reveal 0 HB ≡ seal 0 ↦ (`∀ (id (` 0) ↦ unseal 1))
 _ = refl
 
 HV H₁ H₂ H₃ H₄ : Term
-HV = Λ (ƛ (` 0) ∙ (($ 7) ⟪ lock 1 ∷ [] , seal 1 ⟫))
+HV = Λ (ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫))
 H₁ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1))))
-         ⟪ bind `ℕ ∷ [] , seal 0 ↦ (`∀ (id (` 0) ↦ unseal 1)) ⟫) · ($ 7))
+         ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ (`∀ (id (` 0) ↦ unseal 1)) ⟫) · ($ 7))
        ·[ ` 0 ⇒ `ℕ , `ℕ ]
 H₂ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1)))) · QS₇)
-        ⟪ bind `ℕ ∷ [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
-H₃ = (HV ⟪ bind `ℕ ∷ [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
-H₄ = ((Λ (ƛ (` 0) ∙ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫))) ·[ ` 0 ⇒ ` 2 , ` 0 ])
-       ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , seal 0 ↦ unseal 1 ⟫
+        ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
+H₃ = (HV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
+H₄ = ((Λ (ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))) ·[ ` 0 ⇒ ` 2 , ` 0 ])
+       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
 
 hstep₁ : [] ⊢ H₀ -→ H₁
 hstep₁ = ξ-·[] (ξ-·-l (TyBeta V-ƛ))
@@ -2273,7 +2274,7 @@ hstep₃ = ξ-·[] (ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal)))
 
 -- THE CONVERSION PREMISE, read off the redex's own `env`, one
 -- `` `∀ `` inside.
-⊢Hconv : (abst ∷ convCtx (bind `ℕ ∷ []) []) ⊢ id (` 0) ↦ unseal 1
+⊢Hconv : (abst ∷ convCtx (morph (`ℕ ∷ []) []) []) ⊢ id (` 0) ↦ unseal 1
            ∶ (` 0 ⇒ ` 1) ⇝ (` 0 ⇒ `ℕ)
 ⊢Hconv = conv-fun (conv-idv (abst , ez , nameable-a)) (conv-unseal (es ez))
 
@@ -2298,12 +2299,12 @@ _ = refl
 
 ⊢HV : (bind `ℕ ∷ []) ∣ [] ⊢ HV ⦂ `∀ (` 0 ⇒ ` 1)
 ⊢HV = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a))
-             (env (mw-l (bind `ℕ , es ez , nameable-b) mw[]) ⊢$
+             (env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[])) ⊢$
                   (conv-seal (es ez))
                   (wf-var (bind `ℕ , es ez , nameable-b))))
 
 ⊢H₃ : [] ∣ [] ⊢ H₃ ⦂ (`ℕ ⇒ `ℕ)
-⊢H₃ = ⊢·[] (env (mw-b wf-ℕ mw[]) ⊢HV
+⊢H₃ = ⊢·[] (env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢HV
                 (conv-all ⊢Hconv)
                 (wf-∀ (wf-⇒ (wf-var (abst , ez , nameable-a)) wf-ℕ)))
            wf-ℕ
@@ -2314,14 +2315,14 @@ _ = refl
 -- and H₄ is ONE TyBeta from a value, so the repaired rule does not
 -- strand the run either.
 hstep₅ : [] ⊢ H₄
-       -→ ((ƛ (` 0) ∙ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫))
-             ⟪ bind (` 0) ∷ [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
-            ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , seal 0 ↦ unseal 1 ⟫
+       -→ ((ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))
+             ⟪ morph ((` 0) ∷ []) [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
+            ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
 hstep₅ = ξ-⟪⟫ (TyBeta V-ƛ)
 
-val-H₅ : Value (((ƛ (` 0) ∙ (($ 7) ⟪ lock 2 ∷ [] , seal 2 ⟫))
-                   ⟪ bind (` 0) ∷ [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
-                  ⟪ bind `ℕ ∷ bind `ℕ ∷ [] , seal 0 ↦ unseal 1 ⟫)
+val-H₅ : Value (((ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))
+                   ⟪ morph ((` 0) ∷ []) [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
+                  ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫)
 val-H₅ = V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun
 
 ------------------------------------------------------------------------
@@ -2342,7 +2343,7 @@ val-H₅ = V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun
 --     Y, and an identity converts a type to ITSELF.
 Cj1 : Term
 Cj1 = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
-        ⟪ bind (` 0) ∷ Θt , id (` 1) ↦ seal 1 ⟫
+        ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id (` 1) ↦ seal 1 ⟫
 
 ¬⊢Cj1 : ¬ (Δt ∣ [] ⊢ Cj1 ⦂ (` 0 ⇒ ` 0))
 ¬⊢Cj1 (env _ (⊢·[] _ _) (conv-fun ⊢s ⊢t) _) with conv-id-refl ⊢s
@@ -2353,7 +2354,7 @@ Cj1 = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
 --      well-formed type there.
 Cj2 : Term
 Cj2 = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 1 ])
-        ⟪ bind (` 0) ∷ Θt , id (` 1) ↦ seal 1 ⟫
+        ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id (` 1) ↦ seal 1 ⟫
 
 ¬⊢Cj2 : ∀ {B} → ¬ (Δt ∣ [] ⊢ Cj2 ⦂ B)
 ¬⊢Cj2 (env _ (⊢·[] _ (wf-var (_ , es ez , ()))) _ _)
@@ -2363,11 +2364,11 @@ Cj2 = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 1 ])
 --       X visible inside).  TYPES — but it un-masks what the crossing
 --       masked.
 Cu : Term
-Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ unlock 0 ∷ Θt , id (` 0) ↦ seal 0 ⟫
+Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph (binds Θt) (unlock 0 ∷ changes Θt) , id (` 0) ↦ seal 0 ⟫
 
 ⊢Cu : Δt ∣ [] ⊢ Cu ⦂ (` 0 ⇒ ` 0)
-⊢Cu = env (mw-u (_ , ez , locked nameable-b)
-                (mw-l (bind `ℕ , ez , nameable-b) mw[]))
+⊢Cu = env (mw rw[]
+              (sw-u (_ , ez , locked nameable-b) (sw-l (bind `ℕ , ez , nameable-b) sw[])))
           (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
           (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
           (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
@@ -2376,10 +2377,10 @@ Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ unlock 0 ∷ Θt , id (` 0) ↦ seal 0 �
 -- (iv) or the lock simply REMOVED (a lock binds nothing, so dropping it
 --      is shift-free).  TYPES — but it discards the crossing's mask.
 Cr : Term
-Cr = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ [] , id (` 0) ↦ seal 0 ⟫
+Cr = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph [] [] , id (` 0) ↦ seal 0 ⟫
 
 ⊢Cr : Δt ∣ [] ⊢ Cr ⦂ (` 0 ⇒ ` 0)
-⊢Cr = env mw[]
+⊢Cr = env (mw rw[] sw[])
           (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
           (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
           (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
@@ -2396,7 +2397,7 @@ _ : conceal 0 (` 0 ⇒ ` 0) ≡ unseal 0 ↦ seal 0
 _ = refl
 
 ⊢Cb : Δt ∣ [] ⊢ Cb ⦂ (` 0 ⇒ ` 0)
-⊢Cb = env (mw-l (bind `ℕ , ez , nameable-b) mw[])
+⊢Cb = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[]))
           (⊢·[] ⊢Wt wf-ℕ)
           (conv-fun (conv-unseal ez) (conv-seal ez))
           (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
@@ -2405,10 +2406,10 @@ _ = refl
 -- (vi) Option B's REVEAL mirror, on §13b's H: no lock is in the way, so
 --      the resolve variant lands on the same shape the theorem gives.
 CbH : Term
-CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ bind `ℕ ∷ [] , id `ℕ ↦ unseal 0 ⟫
+CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ unseal 0 ⟫
 
 ⊢CbH : [] ∣ [] ⊢ CbH ⦂ (`ℕ ⇒ `ℕ)
-⊢CbH = env (mw-b wf-ℕ mw[]) (⊢·[] ⊢HV wf-ℕ)
+⊢CbH = env (mw (rw-b wf-ℕ rw[]) sw[]) (⊢·[] ⊢HV wf-ℕ)
            (conv-fun (conv-id base-ℕ) (conv-unseal ez)) (wf-⇒ wf-ℕ wf-ℕ)
 
 -- THE VERDICT.  (i) and (ii) are untypeable outright; (iii)–(vi) type,
@@ -2512,27 +2513,27 @@ _ = refl
 -- ── STEP 1 — TYBETA.  The binder X := ℕ is minted.
 
 E₁ : Term
-E₁ = ((ƛ EID ∙ Ebody) ⟪ bind `ℕ ∷ [] , Eid∀ ↦ Eid∀ ⟫) · Earg
+E₁ = ((ƛ EID ∙ Ebody) ⟪ morph (`ℕ ∷ []) [] , Eid∀ ↦ Eid∀ ⟫) · Earg
 
 estep₁ : [] ⊢ E₀ -→ E₁
 estep₁ = ξ-·-l (TyBeta V-ƛ)
 
 -- ── STEP 2 — PEEL.  `ΛZ. λz:Z. z` crosses; the dual masks the new binder.
 
-_ : dual (bind `ℕ ∷ []) ≡ lock 0 ∷ []
+_ : dual (morph (`ℕ ∷ []) []) ≡ morph [] (lock 0 ∷ [])
 _ = refl
 
 _ : wkᴹ 1 Earg ≡ Earg
 _ = refl
 
 EW : Term                        -- the argument, behind the crossing
-EW = Earg ⟪ lock 0 ∷ [] , Eid∀ ⟫
+EW = Earg ⟪ morph [] (lock 0 ∷ []) , Eid∀ ⟫
 
 val-EW : Value EW
 val-EW = V-⟪⟫ (V-Λ V-ƛ) I-all
 
 E₂ : Term
-E₂ = ((ƛ EID ∙ Ebody) · EW) ⟪ bind `ℕ ∷ [] , Eid∀ ⟫
+E₂ = ((ƛ EID ∙ Ebody) · EW) ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₂ : [] ⊢ E₁ -→ E₂
 estep₂ = Peel V-ƛ (V-Λ V-ƛ)
@@ -2542,7 +2543,7 @@ estep₂ = Peel V-ƛ (V-Λ V-ƛ)
 -- else does — a name, not a spelling.
 
 EW↑ : Term
-EW↑ = Earg ⟪ lock 1 ∷ [] , Eid∀ ⟫
+EW↑ = Earg ⟪ morph [] (lock 1 ∷ []) , Eid∀ ⟫
 
 _ : ⇑ᴹ EW ≡ EW↑
 _ = refl
@@ -2551,7 +2552,7 @@ _ : Ebody [ EW ]ᵐ ≡ Λ (EW↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])
 _ = refl
 
 E₃ : Term
-E₃ = (Λ (EW↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])) ⟪ bind `ℕ ∷ [] , Eid∀ ⟫
+E₃ = (Λ (EW↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])) ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₃ : [] ⊢ E₂ -→ E₃
 estep₃ = ξ-⟪⟫ (Beta val-EW)
@@ -2565,12 +2566,12 @@ estep₃ = ξ-⟪⟫ (Beta val-EW)
 EΔ₃ : Ctxᵗ                       -- the ambient: Y abstract, X := ℕ
 EΔ₃ = abst ∷ bind `ℕ ∷ []
 
-_ : interior (bind `ℕ ∷ []) [] ≡ bind `ℕ ∷ []
+_ : interior (morph (`ℕ ∷ []) []) [] ≡ bind `ℕ ∷ []
 _ = refl
 
 E-int E-ext : Ctxᵗ
-E-int = interior (lock 1 ∷ []) EΔ₃
-E-ext = convCtx (lock 1 ∷ []) EΔ₃
+E-int = interior (morph [] (lock 1 ∷ [])) EΔ₃
+E-ext = convCtx (morph [] (lock 1 ∷ [])) EΔ₃
 
 -- THE INTERIOR IS THE EXTERIOR WITH X MASKED — NOT TRUNCATED.  The old
 -- design's interior at this point was Γ↓X = ∅.  RENDERED
@@ -2601,7 +2602,7 @@ E-X-hidden (wf-var (_ , es ez , ()))
 -- the instantiation step.
 
 E-convCtx : Ctxᵗ
-E-convCtx = abst ∷ convCtx (lock 1 ∷ []) EΔ₃
+E-convCtx = abst ∷ convCtx (morph [] (lock 1 ∷ [])) EΔ₃
 
 ⊢Es : E-convCtx ⊢ id (` 0) ↦ id (` 0) ∶ (` 0 ⇒ ` 0) ⇝ (` 0 ⇒ ` 0)
 ⊢Es = conv-fun (conv-idv (abst , ez , nameable-a))
@@ -2612,8 +2613,8 @@ _ = refl
 
 E₄ : Term
 E₄ = (Λ ((Earg ·[ ` 0 ⇒ ` 0 , ` 0 ])
-           ⟪ bind (` 0) ∷ lock 1 ∷ [] , seal 0 ↦ unseal 0 ⟫))
-       ⟪ bind `ℕ ∷ [] , Eid∀ ⟫
+           ⟪ morph ((` 0) ∷ []) (lock 1 ∷ []) , seal 0 ↦ unseal 0 ⟫))
+       ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₄ : [] ⊢ E₃ -→ E₄
 estep₄ = ξ-⟪⟫ (ξ-Λ (TyPeelR (V-Λ V-ƛ) ⊢Es))
@@ -2625,9 +2626,9 @@ _ : reveal 0 (` 0 ⇒ ` 0) ≡ seal 0 ↦ unseal 0
 _ = refl
 
 E₅ : Term
-E₅ = (Λ (((ƛ (` 0) ∙ (` 0)) ⟪ bind (` 0) ∷ [] , seal 0 ↦ unseal 0 ⟫)
-           ⟪ bind (` 0) ∷ lock 1 ∷ [] , seal 0 ↦ unseal 0 ⟫))
-       ⟪ bind `ℕ ∷ [] , Eid∀ ⟫
+E₅ = (Λ (((ƛ (` 0) ∙ (` 0)) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ unseal 0 ⟫)
+           ⟪ morph ((` 0) ∷ []) (lock 1 ∷ []) , seal 0 ↦ unseal 0 ⟫))
+       ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₅ : [] ⊢ E₄ -→ E₅
 estep₅ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (TyBeta V-ƛ)))
@@ -2708,15 +2709,15 @@ val-prb = V-ƛ
 Δ✦ = masked (bind `ℕ) ∷ []
 
 -- THE TWO FRAME IDENTITIES THAT HAD NO NAME (§15f collects all five).
--- Both are `refl`: `interior Θ Δ` is `pushBinds (repsOf Θ) (scope Θ Δ)`
--- and a `bind` entry contributes to `repsOf` alone, leaving `scope`
+-- Both are `refl`: `interior Θ Δ` is `pushBinds (binds Θ) (scope Θ Δ)`
+-- and a bind contributes to the BIND half alone, leaving `scope`
 -- untouched.
 interior-TyBeta : (A : Ty) (Δ : Ctxᵗ)
-  → interior (bind A ∷ []) Δ ≡ bind A ∷ Δ
+  → interior (morph (A ∷ []) []) Δ ≡ bind A ∷ Δ
 interior-TyBeta A Δ = refl
 
 interior-TyPeelR : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (bind A ∷ Θ) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
 interior-TyPeelR A Θ Δ = refl
 
 ------------------------------------------------------------------------
@@ -2753,13 +2754,13 @@ Rᵃ = (Λ Nᵃ) ·[ (`ℕ ⇒ `ℕ) , `ℕ ]
 -- showTmIn 1 Cᵃ  =
 --   ((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↑Y:=ℕ , (id ℕ ↦ id ℕ) ⟫)
 Cᵃ : Term
-Cᵃ = Nᵃ ⟪ bind `ℕ ∷ [] , reveal 0 (`ℕ ⇒ `ℕ) ⟫
+Cᵃ = Nᵃ ⟪ morph (`ℕ ∷ []) [] , reveal 0 (`ℕ ⇒ `ℕ) ⟫
 
 stepᵃ : Δ✦ ⊢ Rᵃ -→ Cᵃ
 stepᵃ = TyBeta val-prb
 
 -- THE FRAME IDENTITY, at this Δ.
-_ : interior (bind `ℕ ∷ []) Δ✦ ≡ bind `ℕ ∷ Δ✦
+_ : interior (morph (`ℕ ∷ []) []) Δ✦ ≡ bind `ℕ ∷ Δ✦
 _ = interior-TyBeta `ℕ Δ✦
 
 -- … and X is masked there too.
@@ -2789,7 +2790,7 @@ Nᵃ∅ = prb 2
 ¬⊢Nᵃ∅-bind (⊢ƛ _ (⊢·[] _ (wf-var (_ , es (es ()) , _))))
 
 stepᵃ∅ : Δ✦ ⊢ (Λ Nᵃ∅) ·[ (`ℕ ⇒ `ℕ) , `ℕ ]
-           -→ Nᵃ∅ ⟪ bind `ℕ ∷ [] , reveal 0 (`ℕ ⇒ `ℕ) ⟫
+           -→ Nᵃ∅ ⟪ morph (`ℕ ∷ []) [] , reveal 0 (`ℕ ⇒ `ℕ) ⟫
 stepᵃ∅ = TyBeta val-prb
 
 ------------------------------------------------------------------------
@@ -2810,7 +2811,7 @@ stepᵃ∅ = TyBeta val-prb
 Δᵇ = bind `ℕ ∷ []
 
 Θᵇ : CtxMorph
-Θᵇ = lock 0 ∷ []
+Θᵇ = morph [] (lock 0 ∷ [])
 
 _ : interior Θᵇ Δᵇ ≡ masked (bind `ℕ) ∷ []
 _ = refl
@@ -2840,7 +2841,7 @@ Rᵇ = (Vᵇ ⟪ Θᵇ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
 --   ((λx:ℕ. (ΛZ. 3) [X]) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
 Cᵇ : Term
 Cᵇ = (wkᴹ 1 Vᵇ ·[ renameᵗ (extᵗ suc) `ℕ , ` 0 ])
-       ⟪ bind `ℕ ∷ Θᵇ , instReveal 0 (id `ℕ) ⟫
+       ⟪ morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ) , instReveal 0 (id `ℕ) ⟫
 
 stepᵇ : Δᵇ ⊢ Rᵇ -→ Cᵇ
 stepᵇ = TyPeelR val-prb ⊢sᵇ
@@ -2850,10 +2851,10 @@ stepᵇ = TyPeelR val-prb ⊢sᵇ
 _ : wkᴹ 1 Vᵇ ≡ prb 1
 _ = refl
 
-_ : interior (bind `ℕ ∷ Θᵇ) Δᵇ ≡ bind `ℕ ∷ interior Θᵇ Δᵇ
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ interior Θᵇ Δᵇ
 _ = interior-TyPeelR `ℕ Θᵇ Δᵇ
 
-_ : interior (bind `ℕ ∷ Θᵇ) Δᵇ ≡ bind `ℕ ∷ masked (bind `ℕ) ∷ []
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 ¬⊢wkVᵇ : ∀ {Γ A} → ¬ ((bind `ℕ ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
@@ -2883,19 +2884,20 @@ _ = refl
 Δᶜ = bind `ℕ ∷ bind `ℕ ∷ []
 
 Θᶜ₂ : CtxMorph
-Θᶜ₂ = lock 1 ∷ []
+Θᶜ₂ = morph [] (lock 1 ∷ [])
 
 Θᶜ₁ : CtxMorph
-Θᶜ₁ = bind `ℕ ∷ []
+Θᶜ₁ = morph (`ℕ ∷ []) []
 
 ⊢ᵐΘᶜ₂ : Δᶜ ⊢ᵐ Θᶜ₂
-⊢ᵐΘᶜ₂ = mw-l (bind `ℕ , es ez , nameable-b) mw[]
+⊢ᵐΘᶜ₂ = (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[]))
 
 -- the move, spelled out at this configuration
-_ : _≡_ {A = CtxMorph} (Θᶜ₁ ⋉ Θᶜ₂) (bind `ℕ ∷ lock 1 ∷ [])
+_ : _≡_ {A = CtxMorph} (Θᶜ₁ ⋉ Θᶜ₂) (morph (`ℕ ∷ []) (lock 1 ∷ []))
 _ = refl
 
-_ : _≡_ {A = CtxMorph} (rewind Θᶜ₂) (unlock 1 ∷ lock 1 ∷ [])
+_ : _≡_ {A = CtxMorph} (rewind Θᶜ₂)
+        (morph [] (unlock 1 ∷ lock 1 ∷ []))
 _ = refl
 
 _ : interior (rewind Θᶜ₂) Δᶜ ≡ Δᶜ
@@ -3047,10 +3049,10 @@ stepᵈ′ = Beta val-prb
 --   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξe  =  ⌷[Y := ℕ] , ⌷[X := ℕ]
 
 Θᵉ : CtxMorph
-Θᵉ = bind `ℕ ∷ []
+Θᵉ = morph (`ℕ ∷ []) []
 
 ⊢ᵐΘᵉ : Δ✦ ⊢ᵐ Θᵉ
-⊢ᵐΘᵉ = mw-b wf-ℕ mw[]
+⊢ᵐΘᵉ = (mw (rw-b wf-ℕ rw[]) sw[])
 
 Vᵉ : Term
 Vᵉ = ƛ `ℕ ∙ (` 0)
@@ -3076,13 +3078,13 @@ stepᵉ : Δ✦ ⊢ Rᵉ -→ Cᵉ
 stepᵉ = Peel V-ƛ val-prb
 
 -- THE DUAL LOCKS THE BOUNDARY'S OWN BINDER …
-_ : _≡_ {A = CtxMorph} (dual Θᵉ) (lock 0 ∷ [])
+_ : _≡_ {A = CtxMorph} (dual Θᵉ) (morph [] (lock 0 ∷ []))
 _ = refl
 
 -- … so (†) reads, at this Θ: the crossing frame is Δ✦ under one MASKED
 -- bind.
 _ : interior (dual Θᵉ) (interior Θᵉ Δ✦)
-      ≡ map masked (pushBinds (repsOf Θᵉ) []) ++ Δ✦
+      ≡ map masked (pushBinds (binds Θᵉ) []) ++ Δ✦
 _ = interior-dual Θᵉ Δ✦ ⊢ᵐΘᵉ
 
 _ : interior (dual Θᵉ) (interior Θᵉ Δ✦)
@@ -3140,7 +3142,7 @@ _ = refl
 --              ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
 --              — the redex's frame, one binder in; `wkᴹ 1` matches it
 --   Peel     interior (dual Θ) (interior Θ Δ)
---              ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ   (Δ ⊢ᵐ Θ)
+--              ≡ map masked (pushBinds (binds Θ) []) ++ Δ   (Δ ⊢ᵐ Θ)
 --              — (†), proof/PeelDual.interior-dual: THE CROSSING FRAME
 --                IS THE EXTERIOR, under a MASKED bind prefix
 --   CancelR  interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
@@ -3155,7 +3157,7 @@ _ = refl
 --
 -- The two identities that had no name are `interior-TyBeta` and
 -- `interior-TyPeelR` at the head of this section; both are `refl`,
--- because `interior` is `pushBinds ∘ repsOf` over `scope` and a `bind`
+-- because `interior` is `pushBinds ∘ binds` over `scope` and a bind
 -- entry touches `scope` not at all.  The other two are theorems with
 -- a `Δ ⊢ᵐ Θ` premise, and that premise is exactly where the sequential
 -- judgement pays: (†) needs `mw-u`'s LOCKED slot for the dual's

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -226,7 +226,7 @@ SA = bind (` 0) ∷ S₆₂            -- the interior type context of LA
 -- The stack resolves ONE LAYER PER STEP, outermost first: each IdPush moves
 -- the active conversion one layer inward toward the seal, so any depth
 -- terminates.  (IdAbsorb needed `⊳` to merge the frames and could not do
--- this one — the inner layer's context morphism `bind (` 0)` names the next layer's
+-- this one — the inner layer's bind `` ` 0 `` names the next layer's
 -- binder, IdLayerProbe §4c.  IdPush touches no frame.)
 T₈-1 T₈-2 T₈-3 : Term
 T₈-1 = (LA ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
@@ -382,7 +382,7 @@ run-Tᵣ = push-Tᵣ
     then done
 
 -- ── Tₘ (IdLayerProbe §4b): Θ₂ re-exposes a masked slot (`unlock 0`) and the
--- id-layer masks it again (`lock 0`).  The merged context morphism computed both
+-- id-layer masks it again (`lock 0`).  The merged morphism computed both
 -- type contexts correctly and yet the FORMER, simultaneous `_⊢ᵐ_` refused
 -- it, because it checked every entry against the plain exterior.  The
 -- SEQUENTIAL judgement checks each entry on the frame it acts on, and
@@ -1706,7 +1706,8 @@ _ = refl
 
 -- ── AND THE MULTI-BIND ID-LAYER IT DELIVERS ────────────────────────────
 -- The same shape, hand-built at the frame the repaired rule produces
--- (one bind prepended, no double shift): IdPush fires at `numBinds Θ₁ ≡ 2` and the
+-- (one bind prepended, no double shift): IdPush fires at
+-- `numBinds Θ₁ ≡ 2` and the
 -- contractum TYPES.  So the multi-bind case is not itself an obstruction
 -- — the lifting `shiftBy 2` is exactly absorbed by `pushBinds`.
 
@@ -1898,7 +1899,8 @@ _ = refl
 -- `unlock 1`.)  READ THE TWO LINES SIDE BY SIDE: `↓Y` has moved from the
 -- OUTER boundary to the INNER one, and the reveal `unseal X` went with
 -- it; what is left outside is the REWOUND frame `↥Y , ↓Y`, whose net
--- effect on the type context is nothing at all.  The rep `Y` the reveal hands back is therefore presented on the
+-- effect on the type context is nothing at all.  The rep `Y` the reveal
+-- hands back is therefore presented on the
 -- outer boundary's own type context — where Y is live — instead of
 -- inside the lock, which is exactly what `env`'s last premise refused.
 -- The value's frame is unchanged, so `V` retypes where it was.
@@ -2837,7 +2839,8 @@ stepᵃ∅ = TyBeta val-prb
 --       tracks it
 ------------------------------------------------------------------------
 
--- `V` moves from `interior Θ Δ` into `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which is
+-- `V` moves from `interior Θ Δ` into
+-- `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which is
 -- that type context with ONE binder prepended — and the rule shifts `V`
 -- by `wkᴹ 1` to match.  A slot Θ MASKS is therefore masked on both
 -- sides, one index apart.

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -133,7 +133,7 @@ preservation* = I.preserve*
 preservation-TyBeta : ∀ {A}
   → Δ ∣ [] ⊢ (Λ N) ·[ B , A ] ⦂ C
     ---------------------------------------------
-  → Δ ∣ [] ⊢ N ⟪ bind A ∷ [] , reveal 0 B ⟫ ⦂ C
+  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫ ⦂ C
 preservation-TyBeta = preserve-TyBeta
 
 -- BETA — the ordinary β step, i.e. the substitution lemma.
@@ -160,7 +160,7 @@ preservation-TyPeelR : ∀ {V Θ s B Bᵢ Bₑ}
   → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
     -----------------------------------------------------
   → Δ ∣ [] ⊢ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-               ⟪ bind A ∷ Θ , instReveal 0 s ⟫ ⦂ C
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
 preservation-TyPeelR = preserve-TyPeelR
 
 -- CANCELR — at the moved scope, unconditionally.

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -68,7 +68,7 @@ driver: type-checking it type-checks the whole thing.
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
 | `Ctx.agda` | **the type context**: entries `abst` / `bind A` / `masked E`, lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑`), injective renamings, in-place `mask`/`unmask`, and the bind prefix `pushBinds` with `shiftBy` |
 | `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
-| `CtxMorph.agda` | the context morphism (`bind`/`lock`/`unlock`, `repsOf`, `numBinds`), the type contexts it induces (`scope`, `unlockedScope`, `interior`, `convCtx`) with their refinement transports, and the well-formedness judgement `Δ ⊢ᵐ Θ`, and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
+| `CtxMorph.agda` | the context morphism as a **pair** — `record CtxMorph = morph (binds : List Ty) (changes : List Change)`, the binds a PARALLEL block and the changes a SEQUENTIAL `lock`/`unlock` list — with `numBinds`, the type contexts it induces (`applyChanges`/`applyUnlocks` at the list, `scope`/`unlockedScope`/`interior`/`convCtx` at the morphism) and their refinement transports, the well-formedness judgement `Δ ⊢ᵐ Θ` as a pair of halves (`_⊢ʳ_` reps, `_⊢ˢ_` changes), and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
 | `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), term substitution, `⊢subst`, `preserve-Beta` |
 | `Reduction.agda` | the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
@@ -86,7 +86,7 @@ driver: type-checking it type-checks the whole thing.
 |------|----------|
 | `Preserve.agda` | the preservation induction: `⊢ᵗ-of` (which replaces a context well-formedness premise), the minted-conversion typings `⊢reveal`/`⊢conceal`/`⊢instReveal`/`⊢instConceal`, `preserve-TyBeta`, `preserve-Drop$`, `preserve-TyPeelR`, the three case statements, and `module Impl` |
 | `PeelDual.agda` | the `Peel` case: `interior-dual` and `convCtx-dual` in general, and `preserve-Peel` |
-| `MoveScope.agda` | **the scope move**: the list algebra of `scopeOf`/`rewind`/`_⋉_`, `interior-rewind`, the frame **equalities** `interior-⋉-rewind`/`convCtx-⋉-rewind` (with `convCtx-move` the one surviving `⊑`), `move-∋`, `⊢ᵐ-rewind`, `⊢ᵐ-⋉`, the lock-only refutation `¬frame-locksOnly`, and `preserve-CancelR` / `preserve-IdPush` |
+| `MoveScope.agda` | **the scope move**: the list algebra of `shiftScope`/`rewind`/`_⋉_`, `interior-rewind`, the frame **equalities** `interior-⋉-rewind`/`convCtx-⋉-rewind` (with `convCtx-move` the one surviving `⊑`), `move-∋`, `⊢ᵐ-rewind`, `⊢ᵐ-⋉`, the lock-only refutation `¬frame-locksOnly`, and `preserve-CancelR` / `preserve-IdPush` |
 | `Progress.agda` | the progress induction: the boundary case split out as `progress-env`, `TyPeelR`'s premise read off the redex (`∀-conv-premise`), and `progress` itself |
 | `Canonical.agda` | canonical forms: `canon-base`, `canon-ℕ`, `canon-⇒`, `canon-∀`, `canon-var` |
 | `Canonicity.agda` | the canonical conversion family (`reveal`/`conceal`/`mkId` subtrees) and its closure under the rules |
@@ -95,7 +95,7 @@ driver: type-checking it type-checks the whole thing.
 | `Adversary.agda` | the soundness gate: a conceal must cite a live binder, and v1's adversaries refuted by that one inversion |
 | `PreserveObstruct.agda` | the four refutation witnesses, three of which now record the **positive** fact after the repairs (§2 `TyPeelR`, §4 the wall witness) |
 | `DualTightness.agda` | **tightness of the crossing**, Jeremy's test (2026-09-06) and its repair: the redex that is ill typed at the exterior now has an ill-typed contractum too (`¬⊢Contractum`), (†) `interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ`, the positive control at a `lock`, and the VACUOUS UNLOCK refused (`¬⊢ᵐΘᵥ`).  The same test at every other rule that moves a subterm is `Examples` §15 |
-| `MwUObstruct.agda` | which outer frame the scope move may use, on one configuration: `dropLocks Θ₂` **refuted** (the moved unlock goes vacuous), `bindsOnly Θ₂` **refuted** (the frame's own rep loses its unlock), `rewind Θ₂` does both jobs — and why `mw-b` reads its rep on `unlockedScope Θ Δ` rather than on the plain exterior |
+| `MwUObstruct.agda` | which outer frame the scope move may use, on one configuration: `dropLocks Θ₂` **refuted** (the moved unlock goes vacuous), `bindsOnly Θ₂` **refuted** (the frame's own rep loses its unlock), `rewind Θ₂` does both jobs — and why the rep half reads its reps on `unlockedScope Θ Δ` rather than on the plain exterior |
 | `TypeSafety.agda` | `type-safety` = `progress ∘ preservation*` |
 
 **The invariant hunt** — the search for a side condition that would

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -108,7 +108,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- THE RESIDUE REPAIR (3a), AS RE-RULED (2026-09-05).  The mini-core
   -- appended `hideBinds (numBinds Θ₂)`, which masks EXTERIOR slots that need
   -- not exist (proof/MaskFacts.agda, `¬⊢ᵐ-cancel-residue`); dropping the
-  -- residue was not enough either, because `repsOf→bind (repsOf Θ₂)` DISCARDS
+  -- residue was not enough either, because `repsOf→bind (binds Θ₂)` DISCARDS
   -- Θ₁'s whole frame, and a `V` that names one of Θ₁'s own binders loses
   -- it (the old proof/PreserveObstruct §1 witness).  The honest form keeps
   -- BOTH FRAMES and neutralises BOTH CONVERSIONS: composition happens
@@ -159,7 +159,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- revealing one, so its exterior type becomes Y's rep `A`.  Θ₂'s LOCKS
   -- travel into the inner frame (§2b) so that the rep is presented
   -- OUTSIDE them, where it is nameable: `interior (rewind Θ₂) Δ` IS
-  -- `pushBinds (repsOf Θ₂) Δ`, and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's own
+  -- `pushBinds (binds Θ₂) Δ`, and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's own
   -- exterior type C.  That is what retires the wall — the case needs no
   -- scoping invariant at all (proof/MoveScope.preserve-IdPush).
   IdPush : ∀ {Δ V Θ₁ Θ₂ X Y A} → Value V → convCtx Θ₂ Δ ∋ Y := A

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -53,7 +53,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- `(Λ N) ·[ B , A ]` with N a redex has TWO distinct steps — this one and
   -- ξ-·[] ⨟ ξ-Λ — and determinism fails.  The premise mirrors Beta's.
   TyBeta : ∀ {Δ B A N} → Value N
-    → Δ ⊢ (Λ N) ·[ B , A ] -→ N ⟪ bind A ∷ [] , reveal 0 B ⟫
+    → Δ ⊢ (Λ N) ·[ B , A ] -→ N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫
 
   Beta : ∀ {Δ A N W} → Value W
     → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ]ᵐ
@@ -82,9 +82,11 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- rules.
   --
   -- THE SHIFT REPAIR (2b).  `renᴮ suc Θ` double-counts: `interior` already
-  -- lifts Θ's reps past the binder `bind A` prepended here
-  -- (`interior (bind A ∷ Θ) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷
-  -- interior Θ Δ`), so the frame is plain `Θ`.
+  -- lifts Θ's reps past the binder A prepended here
+  -- (`interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+  --   ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`), so the CHANGES are
+  -- plain `changes Θ` — a change names an EXTERIOR slot and is unshifted
+  -- by the morphism's own binds.
   --
   -- THE CONVERSION (2c).  Slot 0 of the conversion's body was ABSTRACT
   -- and is now the BINDER this rule introduces, so every leaf of `s` that
@@ -96,7 +98,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
     → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
     → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
         -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-             ⟪ bind A ∷ Θ , instReveal 0 s ⟫
+             ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
   -- CANCEL — a conceal directly under the binder it names.  The
   -- conversion match is DEFINITIONAL: `seal X` and `unseal Y` cite the
@@ -220,7 +222,7 @@ det (ξ-·-r u st) (Peel v w)   = ⊥-elim (value-¬step w st)
 -- annotation.
 det (TyPeelR {V = V} {Θ = Θ} {s = s} {A = A} v ⊢s) (TyPeelR v′ ⊢s′) =
   cong (λ T → (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) T , ` 0 ])
-                ⟪ bind A ∷ Θ , instReveal 0 s ⟫)
+                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫)
        (conv-src-unique ⊢s ⊢s′)
 det (TyPeelR v ⊢s) (ξ-·[] st)     = ⊥-elim (value-¬step (V-⟪⟫ v I-all) st)
 det (ξ-·[] st)     (TyPeelR v ⊢s) = ⊥-elim (value-¬step (V-⟪⟫ v I-all) st)

--- a/SystemF/agda/strong/Show.agda
+++ b/SystemF/agda/strong/Show.agda
@@ -35,7 +35,8 @@ module strong.Show where
 open import Data.Nat using (ℕ; zero; suc; _+_; _∸_; _<ᵇ_)
 open import Data.Nat.Show using (show)
 open import Data.Bool using (Bool; true; false; if_then_else_)
-open import Data.List using (List; []; _∷_)
+open import Data.List using (List; []; _∷_; length)
+open import Data.List using () renaming (_++_ to _l++_)
 open import Data.String using (String; _++_)
 open import Data.Product using (_×_; _,_; proj₁)
 
@@ -114,11 +115,9 @@ showConv d sup (`∀ s)     =
 ------------------------------------------------------------------------
 
 -- one fresh name per BINDER, newest first (binder 0 is interior slot 0)
-bindNames : ℕ → CtxMorph → List String
-bindNames d []               = []
-bindNames d (bind A ∷ Θ)     = tyBinder d ∷ bindNames (suc d) Θ
-bindNames d (unlock X ∷ Θ)   = bindNames d Θ
-bindNames d (lock X ∷ Θ)     = bindNames d Θ
+bindNames : ℕ → List Ty → List String
+bindNames d []       = []
+bindNames d (A ∷ Bs) = tyBinder d ∷ bindNames (suc d) Bs
 
 nth : List String → ℕ → String
 nth []       k       = "?"
@@ -136,34 +135,46 @@ intSup Θ on ext k =
 -- boundary context morphisms
 ------------------------------------------------------------------------
 
-sep : CtxMorph → String
-sep [] = ""
-sep (_ ∷ _) = " , "
-
 tl : List String → List String
 tl []       = []
 tl (s ∷ ss) = ss
 
+-- THE PAIR IS RENDERED IN ITS OWN ORDER: the BINDS first (`↑X:=A`), then
+-- the CHANGES (`↓Y`, `↥Z`), then the conversion — `⟪ ↑X:=A , ↓Y , ↥Z , c ⟫`.
 -- `on` is the binder-name list still to be consumed; `ext` names exterior
 -- slots.  A binder's rep uses the exterior's slots; `lock`/`unlock` carry
 -- a name only.
+bindPieces : ℕ → List String → Supply → List Ty → List String
+bindPieces d on ext []       = []
+bindPieces d on ext (A ∷ Bs) =
+  ("↑" ++ nth on 0 ++ ":=" ++ showTy d ext A) ∷ bindPieces d (tl on) ext Bs
+
+changePieces : Supply → List Change → List String
+changePieces ext []             = []
+changePieces ext (lock X ∷ S)   = ("↓" ++ ext X) ∷ changePieces ext S
+changePieces ext (unlock X ∷ S) = ("↥" ++ ext X) ∷ changePieces ext S
+
+joinC : List String → String
+joinC []                 = ""
+joinC (s ∷ [])           = s
+joinC (s ∷ ss@(_ ∷ _))   = s ++ " , " ++ joinC ss
+
 showEnts : ℕ → List String → Supply → CtxMorph → String
-showEnts d on ext [] = ""
-showEnts d on ext (bind A ∷ Θ) =
-  "↑" ++ nth on 0 ++ ":=" ++ showTy d ext A ++ sep Θ
-      ++ showEnts d (tl on) ext Θ
-showEnts d on ext (lock X ∷ Θ) =
-  "↓" ++ ext X ++ sep Θ ++ showEnts d on ext Θ
-showEnts d on ext (unlock X ∷ Θ) =
-  "↥" ++ ext X ++ sep Θ ++ showEnts d on ext Θ
+showEnts d on ext Θ =
+  joinC (bindPieces d on ext (binds Θ) l++ changePieces ext (changes Θ))
+
+-- the entry block, with its trailing separator — empty for an empty
+-- morphism, so `⟪ c ⟫` still renders with no leading comma
+entBlock : List String → String
+entBlock []             = ""
+entBlock ps@(_ ∷ _)     = joinC ps ++ " , "
 
 showBnd : ℕ → Supply → CtxMorph → Conv → String
-showBnd d ext [] c =
-  "⟪ " ++ showConv d ext c ++ " ⟫"
-showBnd d ext Θ@(_ ∷ _) c =
-  "⟪ " ++ showEnts d on ext Θ ++ " , "
+showBnd d ext Θ c =
+  "⟪ " ++ entBlock (bindPieces d on ext (binds Θ)
+                      l++ changePieces ext (changes Θ))
        ++ showConv (d + numBinds Θ) (intSup Θ on ext) c ++ " ⟫"
-  where on = bindNames d Θ
+  where on = bindNames d (binds Θ)
 
 ------------------------------------------------------------------------
 -- terms
@@ -186,19 +197,16 @@ open St
 -- one fresh name per BINDER (bind), listed newest first (slot 0 first) but
 -- NAMED oldest first, so an older bind keeps its name when a newer one is
 -- prepended (TyPeelR's `bind A ∷ Θ`): the last bind gets tyBinder f.
-bindNamesF : ℕ → CtxMorph → List String
-bindNamesF f []             = []
-bindNamesF f (bind A ∷ Θ)   = tyBinder (f + numBinds Θ) ∷ bindNamesF f Θ
-bindNamesF f (unlock X ∷ Θ) = bindNamesF f Θ
-bindNamesF f (lock X ∷ Θ)   = bindNamesF f Θ
+bindNamesF : ℕ → List Ty → List String
+bindNamesF f []       = []
+bindNamesF f (A ∷ Bs) = tyBinder (f + length Bs) ∷ bindNamesF f Bs
 
 showBndF : ℕ → ℕ → Supply → CtxMorph → Conv → String
-showBndF d f ext [] c =
-  "⟪ " ++ showConv d ext c ++ " ⟫"
-showBndF d f ext Θ@(_ ∷ _) c =
-  "⟪ " ++ showEnts d on ext Θ ++ " , "
+showBndF d f ext Θ c =
+  "⟪ " ++ entBlock (bindPieces d on ext (binds Θ)
+                      l++ changePieces ext (changes Θ))
        ++ showConv (d + numBinds Θ) (intSup Θ on ext) c ++ " ⟫"
-  where on = bindNamesF f Θ
+  where on = bindNamesF f (binds Θ)
 
 showTmF : ℕ → Supply → Supply → St → Term → String × St
 showTmF td tys tms σ (` x)      = tms x , σ
@@ -216,7 +224,7 @@ showTmF td tys tms σ (Λ N) with showTmF (suc td) (extS tys (tyBinder (tf σ)))
 showTmF td tys tms σ (L ·[ B , A ]) with showTmF td tys tms σ L
 ... | l , σ′ = l ++ " [" ++ showTy td tys A ++ "]" , σ′
 showTmF td tys tms σ (M ⟪ Θ , c ⟫)
-  with showTmF (td + numBinds Θ) (intSup Θ (bindNamesF (tf σ) Θ) tys) tms
+  with showTmF (td + numBinds Θ) (intSup Θ (bindNamesF (tf σ) (binds Θ)) tys) tms
                (mkSt (tf σ + numBinds Θ) (xf σ)) M
 ... | body , σ′ =
   "(" ++ body ++ " " ++ showBndF td (tf σ) tys Θ c ++ ")" , σ′

--- a/SystemF/agda/strong/Show.agda
+++ b/SystemF/agda/strong/Show.agda
@@ -19,11 +19,13 @@ module strong.Show where
 --     interior supply and the CONVERSION-CONTEXT supply coincide
 --     (`interior` and `convCtx` differ in blocking, not in slot layout).
 --   * a BINDER's rep is shown under `ext` — a rep uses the exterior's
---     slots (the judgement reads it on `unlockedScope Θ′ Δ`, which has the
+--     slots (the judgement reads it on `unlockedScope Θ Δ`, which has the
 --     same slot layout as Δ);
 --   * a `lock X` / `unlock X` names an EXTERIOR slot, so it is shown under
 --     `ext`; neither carries a rep, which is the whole point of the
---     redesign;
+--     redesign.  THE PAIR IS RENDERED IN ITS OWN ORDER: all the binds,
+--     then all the changes, then the conversion —
+--     `⟪ ↑X:=A , ↓Y , ↥Z , c ⟫`;
 --   * the CONVERSION `c` is shown under that same supply, and its
 --     `seal`/`unseal` names are read there — by their type context, not by a
 --     stored spelling.
@@ -196,7 +198,7 @@ open St
 
 -- one fresh name per BINDER (bind), listed newest first (slot 0 first) but
 -- NAMED oldest first, so an older bind keeps its name when a newer one is
--- prepended (TyPeelR's `bind A ∷ Θ`): the last bind gets tyBinder f.
+-- prepended (TyPeelR prepends one): the last bind gets tyBinder f.
 bindNamesF : ℕ → List Ty → List String
 bindNamesF f []       = []
 bindNamesF f (A ∷ Bs) = tyBinder (f + length Bs) ∷ bindNamesF f Bs

--- a/SystemF/agda/strong/TermSubst.agda
+++ b/SystemF/agda/strong/TermSubst.agda
@@ -52,22 +52,19 @@ private
 -- 1.  Renaming boundaries and terms
 ------------------------------------------------------------------------
 
-renᴮ : Renameᵗ → CtxMorph → CtxMorph
-renᴮ ρ []          = []
-renᴮ ρ (bind A ∷ Θ) = bind (renameᵗ ρ A) ∷ renᴮ ρ Θ
-renᴮ ρ (unlock X ∷ Θ) = unlock (ρ X) ∷ renᴮ ρ Θ
-renᴮ ρ (lock X ∷ Θ) = lock (ρ X) ∷ renᴮ ρ Θ
+-- Renaming a CHANGE moves the exterior name it carries and nothing else.
+renᶠ : Renameᵗ → Change → Change
+renᶠ ρ (unlock X) = unlock (ρ X)
+renᶠ ρ (lock X)   = lock (ρ X)
 
-repsOf-ren : (ρ : Renameᵗ) (Θ : CtxMorph)
-  → repsOf (renᴮ ρ Θ) ≡ map (renameᵗ ρ) (repsOf Θ)
-repsOf-ren ρ []             = refl
-repsOf-ren ρ (bind A ∷ Θ)   = cong (renameᵗ ρ A ∷_) (repsOf-ren ρ Θ)
-repsOf-ren ρ (unlock X ∷ Θ) = repsOf-ren ρ Θ
-repsOf-ren ρ (lock X ∷ Θ)   = repsOf-ren ρ Θ
+-- THE PAIR RENAMES COMPONENTWISE.  `binds (renᴮ ρ Θ) ≡ map (renameᵗ ρ)
+-- (binds Θ)` is now DEFINITIONAL — the old `repsOf-ren` was the filtering
+-- lemma that said it, and it is gone.
+renᴮ : Renameᵗ → CtxMorph → CtxMorph
+renᴮ ρ Θ = morph (map (renameᵗ ρ) (binds Θ)) (map (renᶠ ρ) (changes Θ))
 
 numBinds-ren : (ρ : Renameᵗ) (Θ : CtxMorph) → numBinds (renᴮ ρ Θ) ≡ numBinds Θ
-numBinds-ren ρ Θ =
-  trans (cong length (repsOf-ren ρ Θ)) (map-length (renameᵗ ρ) (repsOf Θ))
+numBinds-ren ρ Θ = map-length (renameᵗ ρ) (binds Θ)
 
 renᴹ : Renameᵗ → Term → Term
 renᴹ ρ (` x)          = ` x
@@ -96,41 +93,51 @@ Inj-wkN (suc n) eq = Inj-wkN n (Inj-suc eq)
 -- 2.  The type context operations transport (the structural half)
 ------------------------------------------------------------------------
 
+ren-applyChanges : (S : List Change) → Ren ρ Δ Δ′ → Inj ρ
+        → Ren ρ (applyChanges S Δ) (applyChanges (map (renᶠ ρ) S) Δ′)
+ren-applyChanges []             r i = r
+ren-applyChanges (unlock X ∷ S) r i = ren-unmask (ren-applyChanges S r i) i
+ren-applyChanges (lock X ∷ S)   r i = ren-mask (ren-applyChanges S r i) i
+
+ren-applyUnlocks : (S : List Change) → Ren ρ Δ Δ′ → Inj ρ
+         → Ren ρ (applyUnlocks S Δ) (applyUnlocks (map (renᶠ ρ) S) Δ′)
+ren-applyUnlocks []             r i = r
+ren-applyUnlocks (unlock X ∷ S) r i = ren-unmask (ren-applyUnlocks S r i) i
+ren-applyUnlocks (lock X ∷ S)   r i = ren-applyUnlocks S r i
+
 ren-scope : (Θ : CtxMorph) → Ren ρ Δ Δ′ → Inj ρ
         → Ren ρ (scope Θ Δ) (scope (renᴮ ρ Θ) Δ′)
-ren-scope []          r i    = r
-ren-scope (bind A ∷ Θ) r i   = ren-scope Θ r i
-ren-scope (unlock X ∷ Θ) r i = ren-unmask (ren-scope Θ r i) i
-ren-scope (lock X ∷ Θ) r i   = ren-mask (ren-scope Θ r i) i
+ren-scope Θ r i = ren-applyChanges (changes Θ) r i
 
 ren-unlockedScope : (Θ : CtxMorph) → Ren ρ Δ Δ′ → Inj ρ
          → Ren ρ (unlockedScope Θ Δ) (unlockedScope (renᴮ ρ Θ) Δ′)
-ren-unlockedScope []          r i    = r
-ren-unlockedScope (bind A ∷ Θ) r i   = ren-unlockedScope Θ r i
-ren-unlockedScope (unlock X ∷ Θ) r i = ren-unmask (ren-unlockedScope Θ r i) i
-ren-unlockedScope (lock X ∷ Θ) r i   = ren-unlockedScope Θ r i
+ren-unlockedScope Θ r i = ren-applyUnlocks (changes Θ) r i
 
 ren-interior : (Θ : CtxMorph) (ρ : Renameᵗ) → Ren ρ Δ Δ′ → Inj ρ
   → Ren (extN (numBinds Θ) ρ) (interior Θ Δ) (interior (renᴮ ρ Θ) Δ′)
-ren-interior Θ ρ r i rewrite repsOf-ren ρ Θ =
-  ren-pushBinds (repsOf Θ) ρ (ren-scope Θ r i)
+ren-interior Θ ρ r i = ren-pushBinds (binds Θ) ρ (ren-scope Θ r i)
 
 ren-convCtx : (Θ : CtxMorph) (ρ : Renameᵗ) → Ren ρ Δ Δ′ → Inj ρ
   → Ren (extN (numBinds Θ) ρ) (convCtx Θ Δ) (convCtx (renᴮ ρ Θ) Δ′)
-ren-convCtx Θ ρ r i rewrite repsOf-ren ρ Θ =
-  ren-pushBinds (repsOf Θ) ρ (ren-unlockedScope Θ r i)
+ren-convCtx Θ ρ r i = ren-pushBinds (binds Θ) ρ (ren-unlockedScope Θ r i)
 
--- Under the SEQUENTIAL judgement each premise is read on the frame the
--- entry acts on, so each transports by the matching type-context
--- transport: `ren-unlockedScope` for a rep, `ren-scope` for a name.
+-- THE PAIR TRANSPORTS BY HALVES: the parallel reps all move by
+-- `ren-unlockedScope`, and each sequential change by `ren-applyChanges`
+-- at its own tail.
+⊢ʳ-ren : ∀ {Bs} → Ren ρ Δ Δ′ → Δ ⊢ʳ Bs → Δ′ ⊢ʳ map (renameᵗ ρ) Bs
+⊢ʳ-ren r rw[]        = rw[]
+⊢ʳ-ren r (rw-b w ws) = rw-b (wf-ren r w) (⊢ʳ-ren r ws)
+
+⊢ˢ-ren : ∀ {S} → Ren ρ Δ Δ′ → Inj ρ → Δ ⊢ˢ S → Δ′ ⊢ˢ map (renᶠ ρ) S
+⊢ˢ-ren r i sw[] = sw[]
+⊢ˢ-ren {S = lock X ∷ S}   r i (sw-l tv b) =
+  sw-l (ren-tv (ren-applyChanges S r i) tv) (⊢ˢ-ren r i b)
+⊢ˢ-ren {S = unlock X ∷ S} r i (sw-u lk b) =
+  sw-u (ren-∋lk (ren-applyChanges S r i) lk) (⊢ˢ-ren r i b)
+
 ⊢ᵐ-ren : ∀ {Θ} → Ren ρ Δ Δ′ → Inj ρ → Δ ⊢ᵐ Θ → Δ′ ⊢ᵐ renᴮ ρ Θ
-⊢ᵐ-ren                     r i mw[]        = mw[]
-⊢ᵐ-ren {Θ = bind A ∷ Θ}    r i (mw-b w b)  =
-  mw-b (wf-ren (ren-unlockedScope Θ r i) w) (⊢ᵐ-ren r i b)
-⊢ᵐ-ren {Θ = lock X ∷ Θ}    r i (mw-l tv b) =
-  mw-l (ren-tv (ren-scope Θ r i) tv) (⊢ᵐ-ren r i b)
-⊢ᵐ-ren {Θ = unlock X ∷ Θ}  r i (mw-u lk b) =
-  mw-u (ren-∋lk (ren-scope Θ r i) lk) (⊢ᵐ-ren r i b)
+⊢ᵐ-ren {Θ = Θ} r i (mw ws bs) =
+  mw (⊢ʳ-ren (ren-unlockedScope Θ r i) ws) (⊢ˢ-ren r i bs)
 
 ------------------------------------------------------------------------
 -- 3.  THE RENAMING TRANSPORT
@@ -163,8 +170,8 @@ renΓ ρ Γ = map (renameᵗ ρ) Γ
   rewrite rename-[]ᵗ-commute ρ B A =
   ⊢·[] (⊢rename r i ⊢L) (wf-ren r w)
 ⊢rename {Δ′ = Δ′} {ρ = ρ} r i
-        (env {Θ = Θ} {c = c} {Bᵢ = Bᵢ} {Bₑ = Bₑ} mw ⊢M ⊢c wE) =
-  env (⊢ᵐ-ren r i mw)
+        (env {Θ = Θ} {c = c} {Bᵢ = Bᵢ} {Bₑ = Bₑ} mwᵥ ⊢M ⊢c wE) =
+  env (⊢ᵐ-ren r i mwᵥ)
       (⊢rename (ren-interior Θ ρ r i) (Inj-extN (numBinds Θ) i) ⊢M)
       cprem
       (wf-ren r wE)
@@ -202,8 +209,8 @@ renΓ ρ Γ = map (renameᵗ ρ) Γ
 ⊢retag ls (⊢· ⊢L ⊢M)   = ⊢· (⊢retag ls ⊢L) (⊢retag ls ⊢M)
 ⊢retag ls (⊢Λ ⊢N)      = ⊢Λ (⊢retag (la∷ la-aa ls) ⊢N)
 ⊢retag ls (⊢·[] ⊢L w)  = ⊢·[] (⊢retag ls ⊢L) (⊑-wf (⊑ᵃ→⊑ ls) w)
-⊢retag ls (env {Θ = Θ} mw ⊢M ⊢c wE) =
-  env (⊢ᵐ-⊑ᵃ ls mw)
+⊢retag ls (env {Θ = Θ} mwᵥ ⊢M ⊢c wE) =
+  env (⊢ᵐ-⊑ᵃ ls mwᵥ)
       (⊢retag (⊑ᵃ-interior Θ ls) ⊢M)
       (conv-⊑ (⊑-convCtx Θ (⊑ᵃ→⊑ ls)) ⊢c)
       (⊑-wf (⊑ᵃ→⊑ ls) wE)
@@ -312,7 +319,7 @@ extⁿ-∋ h (there d) = there (h d)
 ⊢renⁿ h (⊢· ⊢L ⊢M)        = ⊢· (⊢renⁿ h ⊢L) (⊢renⁿ h ⊢M)
 ⊢renⁿ h (⊢Λ ⊢N)           = ⊢Λ (⊢renⁿ (⤊-∋ⁿ h) ⊢N)
 ⊢renⁿ h (⊢·[] ⊢L w)       = ⊢·[] (⊢renⁿ h ⊢L) w
-⊢renⁿ h (env mw ⊢M ⊢c wE) = env mw ⊢M ⊢c wE
+⊢renⁿ h (env mwᵥ ⊢M ⊢c wE) = env mwᵥ ⊢M ⊢c wE
 
 -- The one type-context renaming the substitution lemma needs: pushing a
 -- fresh Λ-bound slot on the front.
@@ -351,7 +358,7 @@ extᵐ-⊢ h (there d) = ⊢renⁿ there (h d)
 ⊢substᵐ h (⊢· ⊢L ⊢M)        = ⊢· (⊢substᵐ h ⊢L) (⊢substᵐ h ⊢M)
 ⊢substᵐ h (⊢Λ ⊢N)           = ⊢Λ (⊢substᵐ (⇑ᴹ-⊢ h) ⊢N)
 ⊢substᵐ h (⊢·[] ⊢L w)       = ⊢·[] (⊢substᵐ h ⊢L) w
-⊢substᵐ h (env mw ⊢M ⊢c wE) = env mw ⊢M ⊢c wE
+⊢substᵐ h (env mwᵥ ⊢M ⊢c wE) = env mwᵥ ⊢M ⊢c wE
 
 -- THE SUBSTITUTION TYPING LEMMA — what Beta's preservation case consumes.
 ⊢subst : ∀ {Δ Γ A B N W}

--- a/SystemF/agda/strong/Terms.agda
+++ b/SystemF/agda/strong/Terms.agda
@@ -5,12 +5,13 @@ module strong.Terms where
 -- A boundary is  M ⟪ Θ , c ⟫  with ONE frame change:
 --
 --   Θ : CtxMorph   the context morphism (strong.CtxMorph, re-exported
---                here): `bind A` binds a fresh interior slot with
---                representation A, `lock X` masks exterior slot X,
---                `unlock X` unmasks it.  `interior Θ Δ` is the type
---                context the interior is typed in, `convCtx Θ Δ` the one
---                the conversion is checked in, `Δ ⊢ᵐ Θ` its well-
---                formedness.
+--                here), a PAIR `morph B S`: each entry of the PARALLEL
+--                block B binds a fresh interior slot at that
+--                representation, and the SEQUENTIAL change list S masks
+--                (`lock X`) and unmasks (`unlock X`) exterior slots.
+--                `interior Θ Δ` is the type context the interior is
+--                typed in, `convCtx Θ Δ` the one the conversion is
+--                checked in, `Δ ⊢ᵐ Θ` its well-formedness.
 --   c : Conv     the CONVERSION (strong.Conversion), from the interior
 --                type to the exterior type shifted past Θ's binders.
 --

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2521,3 +2521,28 @@ retired.  Landed with it: sequential `Δ ⊢ᵐ Θ` (no vacuous unlocks, no
 double locks), the exact dual (†), `rewind Θ₂` as the scope move's outer
 frame, `⊢retag` over `⊑ᵃ`.  Branch dual-relock (Δ-dependent dual) is the
 superseded alternative; PR #192 is contained in #193.
+
+### The context morphism becomes a PAIR (Jeremy, 2026-09-06)
+
+Jeremy, reading `dual`: binds are treated specially (hideBinds, all at the
+front) while lock/unlock are sequential — "is that essential … perhaps
+the main difference between the current design and the very first design
+with single reveal/conceal … should we keep the list of binds separately
+from the list of lock/unlock?"  Analysis: the special treatment IS
+essential (binds are PARALLEL — reps read outside all of the morphism's
+own binders, the surviving half of simultaneity; lock/unlock are
+SEQUENTIAL — the sequential ⊢ᵐ, the reversed dual and rewind depend on
+it; the very first design was the fully sequential composition and died
+on the drifted ↓X), but the INTERLEAVING was not: interior/convCtx/dual/
+rewind/⋉ never used bind-vs-change order; only mw-b's rep frame did
+(tail's unlocks).  RULED: refactor into a record `morph binds changes`
+(field name `changes`, Jeremy's choice; entry type `Change` with
+lock/unlock), `Δ ⊢ᵐ Θ` = `unlockedScope Θ Δ ⊢ʳ binds Θ` × `Δ ⊢ˢ
+changes Θ`.  ONE semantic change: a rep is read past ALL of the
+morphism's unlocks (not just those listed after it) — strictly more
+permissive, no theorem weakened, no example affected (every reachable
+morphism has all binds before all changes); the one lemma that pays is
+⊢ᵐ-rewind (rewind's inverse half adds unmasks).  Lemma deltas: 8 repsOf
+lemmas deleted, 3 numBinds lemmas became refl, ⊢ᵐ-++ vanished (⊢ˢ-++ is
+rep-free), 26 change-list inductions lost their bind case.  Rendering
+unchanged.  Branch morph-pair, PR to follow.

--- a/SystemF/agda/strong/notes/PR-morph-pair.md
+++ b/SystemF/agda/strong/notes/PR-morph-pair.md
@@ -1,0 +1,213 @@
+# PR body draft — the context morphism becomes a PAIR
+
+Branch `morph-pair`, on top of `main` @ `2c092f1e`.
+Gate: `make -C SystemF/agda/strong check` passes, cold, exit 0
+(`--safe`, no postulates/holes/pragmas).
+
+## What changed
+
+Jeremy's ruling (2026-09-06): the boundary's context morphism is not one
+interleaved list.  Its two halves are different kinds of thing —
+**binds are PARALLEL** (a block of binders whose representations are read
+outside all of them) and **lock/unlock are SEQUENTIAL** — so the type
+now says so.
+
+```agda
+data Change : Set where
+  lock unlock : ℕ → Change          -- EXTERIOR indices, name only
+
+record CtxMorph : Set where
+  constructor morph
+  field
+    binds   : List Ty               -- PARALLEL block of binders
+    changes : List Change           -- SEQUENTIAL, applied head-LAST
+```
+
+Field names are Jeremy's (`binds` / `changes`); the constructor is
+`morph`.  The two *induced contexts* keep their old names because
+`Design.md` and the lemma names use them:
+
+```agda
+applyChanges : List Change → Ctxᵗ → Ctxᵗ    -- locks AND unlocks, head-last
+applyUnlocks : List Change → Ctxᵗ → Ctxᵗ    -- unlocks only (locks skipped)
+
+scope         Θ Δ = applyChanges (changes Θ) Δ
+unlockedScope Θ Δ = applyUnlocks (changes Θ) Δ
+interior      Θ Δ = pushBinds (binds Θ) (scope Θ Δ)
+convCtx       Θ Δ = pushBinds (binds Θ) (unlockedScope Θ Δ)
+```
+
+`repsOf` is gone — it *is* the field `binds`.  `scopeOf` became
+`shiftScope`.  The derived morphisms are re-expressed at the pair:
+
+```agda
+dual   Θ = morph [] (hideBinds (numBinds Θ)
+                       ++ dualScope (numBinds Θ) (changes Θ))
+rewind Θ = morph (binds Θ) (dualScope 0 (changes Θ) ++ changes Θ)
+Θ₁ ⋉ Θ₂  = morph (binds Θ₁)
+                 (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))
+```
+
+and the two minting rules: `TyBeta` mints `morph (A ∷ []) []`, `TyPeelR`
+mints `morph (A ∷ binds Θ) (changes Θ)` (change indices are exterior and
+stay unshifted by the morphism's own binds — unchanged).
+
+`Δ ⊢ᵐ Θ` is a **pair of judgements**, one per half:
+
+```agda
+data _⊢ʳ_ : Ctxᵗ → List Ty → Set where        -- the PARALLEL reps
+  rw[] : Δ ⊢ʳ []
+  rw-b : Δ ⊢ᵗ A → Δ ⊢ʳ Bs → Δ ⊢ʳ (A ∷ Bs)
+
+data _⊢ˢ_ : Ctxᵗ → List Change → Set where    -- the SEQUENTIAL changes
+  sw[] : Δ ⊢ˢ []
+  sw-l : applyChanges S Δ ∋tv X → Δ ⊢ˢ S → Δ ⊢ˢ (lock X ∷ S)
+  sw-u : applyChanges S Δ ∋lk X → Δ ⊢ˢ S → Δ ⊢ˢ (unlock X ∷ S)
+
+record _⊢ᵐ_ (Δ : Ctxᵗ) (Θ : CtxMorph) : Set where
+  constructor mw
+  field
+    mw-reps    : unlockedScope Θ Δ ⊢ʳ binds Θ
+    mw-changes : Δ ⊢ˢ changes Θ
+```
+
+## The one semantic change
+
+The interleaved list read a bind's representation past **its own tail's**
+unlocks (`mw-b : unlockedScope Θ′ Δ ⊢ᵗ A → … → Δ ⊢ᵐ (bind A ∷ Θ′)`).  The
+pair reads **every** representation past the **whole** change list.  This
+is the one thing the refactor changes about what is derivable, and it is
+strictly **more permissive** — a rep may now name a slot that an unlock
+*to its left in the old list* re-exposed.  It is also the point: a
+parallel block has no left and no right.
+
+Consequences observed, in full:
+
+* **No `⊢ᵐ` derivation in the development needed the tighter reading, and
+  none needed the looser one.**  Exactly one morphism in the whole tree
+  had a change to the left of a bind under the old order —
+  `rewind Θ₆ = lock 0 ∷ bind (` 0) ∷ unlock 0 ∷ []` in
+  `proof/MwUObstruct` §4 — and there the two readings *coincide*, because
+  the entry to the left is a `lock` and `applyUnlocks` skips locks.
+  Every other morphism has all its binds before all its changes, where
+  the two readings are the same.  So: no example was refused, and none
+  needed the extra permissiveness.
+* **One lemma pays for it:** `proof/MoveScope.⊢ᵐ-rewind`.  A rewound
+  frame's change list is `dualScope 0 (changes Θ) ++ changes Θ`, and the
+  inverse half turns `Θ`'s *locks* into *unlocks* — so under the pair the
+  reps of `rewind Θ` are read on a context with those extra unmasks
+  applied.  That is more nameable, so the proof gains one `⊢ʳ-⊑` step
+  (with a `subst` along `applyUnlocks-++`).  Under the interleaved list
+  the reps sat inside the appended `Θ` tail and were read unchanged.
+* **No theorem is weakened.**  `_⊢ᵐ_` is a premise of `env`, so a more
+  permissive `_⊢ᵐ_` admits a (very slightly) larger set of typed terms;
+  `preservation`, `progress`, `det`, `value-¬step`, tightness and
+  canonicity are all reproved over the new judgement with their
+  statements unchanged.
+
+## Lemma-count deltas
+
+Genuinely **deleted** (8), all of them projection/filtering lemmas about
+`repsOf` that the record field makes definitional:
+
+| module | deleted |
+|--------|---------|
+| `proof/PeelDual` | `repsOf-hideBinds`, `repsOf-++`, `repsOf-dualScope`, `repsOf-dual` |
+| `proof/MoveScope` | `repsOf-scopeOf`, `repsOf-⋉`, `repsOf-rewind` |
+| `TermSubst` | `repsOf-ren` |
+
+Became `refl` (3), and their uses (three `rewrite`s, one `subst`) were
+deleted with them:
+
+    numBinds-dual   Θ     : numBinds (dual Θ)    ≡ 0            -- refl
+    numBinds-⋉      Θ₁ Θ₂ : numBinds (Θ₁ ⋉ Θ₂)  ≡ numBinds Θ₁  -- refl
+    numBinds-rewind Θ     : numBinds (rewind Θ)  ≡ numBinds Θ   -- refl
+
+`numBinds-ren` is now `map-length` directly (it was `trans (cong length
+repsOf-ren) map-length`).  `wf-convCtx-rewind` lost its `subst`;
+`interior-rewind` lost a `rewrite`; `preserve-Peel`'s `⊢s-tr` lost its
+`rewrite numBinds-dual`; `preserve-IdPush`/`preserve-CancelR` lost their
+`rewrite numBinds-⋉`; `MoveScope.moved-conv` lost its
+`rewrite numBinds-rewind`.
+
+**Dead cases removed.**  Every induction over the change list lost its
+`bind` case (26 functions/lemmas: `applyChanges`, `applyUnlocks`,
+`applyChanges⊑applyUnlocks`, `Δ⊑applyUnlocks`, `⊑-applyChanges`,
+`⊑-applyUnlocks`, `⊑ᵃ-applyChanges`, `dualScope`, `shiftScope`,
+`ren-applyChanges`, `ren-applyUnlocks`, `⊢ˢ-⊑ᵃ`, `⊢ˢ-ren`,
+`applyChanges-++`, `applyUnlocks-++`, `applyChanges-dualScope`,
+`⊢ˢ-dualScope`, `dualScope-unmask-comm`, `applyUnlocks-dualScope`,
+`⊢ˢ-++`, `applyChanges-shiftScope`, `applyUnlocks-shiftScope`,
+`⊢ˢ-shiftScope`, `applyUnlocks-∋bind`, `locksOnly`, `dropL`), and every
+induction over the reps lost its `lock`/`unlock` cases (`⊢ʳ-⊑`,
+`⊢ʳ-ren`).
+
+**Split, not added.**  `⊢ᵐ-⊑ᵃ` and `⊢ᵐ-ren` survive with their statements
+unchanged and now delegate to `⊢ʳ-⊑`/`⊢ˢ-⊑ᵃ` and `⊢ʳ-ren`/`⊢ˢ-ren`.
+`⊢ᵐ-++` is gone; the *append* lemma is now the rep-free `⊢ˢ-++`, which is
+where the simplification shows: the old `⊢ᵐ-++` had a `bind` case that
+had to move a rep from `scope Ψ Δ` to `unlockedScope Ψ Δ` along `⊑-wf`,
+and the new one has no rep in it at all.  `⊢ᵐ-hideBinds`/`⊢ᵐ-dualScope`/
+`⊢ᵐ-scopeOf` became `⊢ˢ-hideBinds`/`⊢ˢ-dualScope`/`⊢ˢ-shiftScope` and
+likewise lost their `bind` cases.
+
+Per-module declaration counts (old → new): `CtxMorph` 23 → 30 (five of
+the seven additions are one-line morphism-level wrappers kept so
+`scope Θ Δ`/`unlockedScope Θ Δ` and their transports keep their names),
+`proof/PeelDual` 33 → 29, `proof/MoveScope` 34 → 32, `TermSubst` 35 → 39
+(the four additions are the two `renᶠ`-level list functions and the two
+halves of `⊢ᵐ-ren`).
+
+**Was `⊢ᵐ-⋉` easier, as predicted?**  Half of it.  Its two obligations
+now split cleanly and each is one step: the changes are `⊢ˢ-++` at the
+move (nothing to carry), and the reps are `⊢ʳ-⊑` along
+`⊑-applyUnlocks (changes Θ₁) (⊑-pushBinds (binds Θ₂)
+(applyChanges⊑applyUnlocks (changes Θ₂) Δ))`.  Net length is about the
+same as before: the `⊑-wf` step that used to hide inside `⊢ᵐ-++` is now
+visible at the one place that needs it, which is the honest form.
+
+**Which lemma got harder:** `⊢ᵐ-rewind` (above) — four lines instead of
+one.  Nothing else.
+
+## Rendering deltas
+
+None.  `Show.agda` renders the pair in its own order — all binds, then
+all changes, then the conversion: `⟪ ↑X:=A , ↓Y , ↥Z , c ⟫`.  Every one
+of `Examples`' 26 pinned rendering traces is byte-identical (they are
+`refl` proofs and the module type-checks unchanged); the diff touches no
+`showTmIn` line.  The only morphism in the tree whose old list order
+differed from binds-then-changes is `rewind Θ₆` in `proof/MwUObstruct`,
+which is never rendered.
+
+`scripts/render_term.sh` still works unchanged, e.g.
+
+    scripts/render_term.sh \
+      'showBndIn 1 (morph (`ℕ ∷ []) (lock 0 ∷ unlock 0 ∷ [])) (id `ℕ)' \
+      'open import strong.Types' 'open import strong.Conversion' \
+      'open import strong.CtxMorph' 'open import Data.List using ([]; _∷_)'
+    ⟪ ↑Y:=ℕ , ↓X , ↥X , id ℕ ⟫
+
+## What was re-proved
+
+Everything, with statements unchanged: `proof/PeelDual`
+(`interior-dual` (†), `convCtx-dual`, `⊢ᵐ-dual`, `preserve-Peel`),
+`proof/MoveScope` (the frame equalities, `⊢ᵐ-⋉`, `⊢ᵐ-rewind`,
+`preserve-IdPush`, `preserve-CancelR`, and the lock-only refutation
+`¬frame-locksOnly` on the pair witness
+`Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])`), `proof/Preserve`,
+`strong.Preservation`, `strong.Progress`, `det`, `value-¬step`,
+`proof/Canonicity`, `proof/Adversary`, `proof/IdLayer`,
+`proof/MaskFacts`, `proof/DualTightness`, `proof/MwUObstruct` (its
+`dropLocks`/`bindsOnly` witnesses translated to the pair),
+`proof/PreserveObstruct`, the 7 `evalTerms` regressions, and `Examples`
+§1–§15.
+
+## Docs
+
+`Design.md` §2 (the record, the two halves, the rendering order), §3
+(`applyChanges`/`applyUnlocks` under `scope`/`unlockedScope`), §4.2 (the
+paired judgement, verbatim, and the one semantic move), §4.3 (what
+`env`'s first premise checks), §6.3/§6.7 (`dual`, `rewind`, `⋉`,
+`shiftScope`), §8 law 4 (simultaneity, now stated exactly), §9 (a new
+bullet, *The pair*), Appendix A (names).  `README.md`: the module map
+lines for `CtxMorph.agda`, `MoveScope.agda`, `MwUObstruct.agda`.

--- a/SystemF/agda/strong/proof/Adversary.agda
+++ b/SystemF/agda/strong/proof/Adversary.agda
@@ -31,13 +31,13 @@ seal-cites-binder (conv-seal d) refl = d
 
 -- `unlock` claims NO KNOWLEDGE: it is a NAME with no rep, so it cannot
 -- assert what a slot stands for.  What it now does claim is that the
--- slot is LOCKED (`scope Θ Δ ∋lk X`) — a statement about MASKING, in
+-- slot is LOCKED (`applyChanges S Δ ∋lk X`) — a statement about MASKING, in
 -- which no type occurs, and which is what makes the dual's restoring
 -- `lock` sound (proof/DualTightness).  A VACUOUS unlock, at a slot the
 -- frame leaves nameable, is REFUSED.
-unlock-claims-a-lock : ∀ {Δ X Θ} → scope Θ Δ ∋lk X → Δ ⊢ᵐ Θ
-  → Δ ⊢ᵐ (unlock X ∷ Θ)
-unlock-claims-a-lock = mw-u
+unlock-claims-a-lock : ∀ {Δ X S} → applyChanges S Δ ∋lk X → Δ ⊢ˢ S
+  → Δ ⊢ˢ (unlock X ∷ S)
+unlock-claims-a-lock = sw-u
 
 -- The claim mentions no representation: all it hands back is a
 -- NAMEABLE entry under one mask, and `Nameable` is `abst` or `bind`
@@ -64,8 +64,8 @@ unlock-mentions-no-rep (masked E , _ , locked v) = E , v
 ¬seal-adv : ∀ {A B} → Δadv ⊢ seal 0 ∶ A ⇝ B → ⊥
 ¬seal-adv (conv-seal d) = ¬know-adv d
 
-¬⊢adv : ∀ {Γ} → Δadv ∣ Γ ⊢ ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫ ⦂ ` 0 → ⊥
-¬⊢adv (env mw ⊢M ⊢c wE) = ¬seal-adv ⊢c
+¬⊢adv : ∀ {Γ} → Δadv ∣ Γ ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0 → ⊥
+¬⊢adv (env mwᵥ ⊢M ⊢c wE) = ¬seal-adv ⊢c
 
 ------------------------------------------------------------------------
 -- 3.  `bad`: two spellings of one fact — inexpressible
@@ -84,8 +84,8 @@ unlock-mentions-no-rep (masked E , _ , locked v) = E , v
 seal-bad-conv : ∀ {A B} → Δbad ⊢ seal 0 ∶ A ⇝ B → A ≡ ⇑ᵗ ∀ZZ
 seal-bad-conv (conv-seal ez) = refl
 
-¬⊢bad : ∀ {Γ} → Δbad ∣ Γ ⊢ ($ 7) ⟪ lock 0 ∷ [] , seal 0 ⟫ ⦂ ` 0 → ⊥
-¬⊢bad (env mw ⊢$ ⊢c wE) with seal-bad-conv ⊢c
+¬⊢bad : ∀ {Γ} → Δbad ∣ Γ ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0 → ⊥
+¬⊢bad (env mwᵥ ⊢$ ⊢c wE) with seal-bad-conv ⊢c
 ... | ()
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -14,10 +14,10 @@ module strong.proof.DualTightness where
 --
 -- THE REPAIR, in two coupled halves (strong.CtxMorph §3, `_⊢ᵐ_` in §2):
 --
---   (1) `mw-u` demands `scope Θ Δ ∋lk X` — the slot must be LOCKED.  A
+--   (1) `sw-u` demands `applyChanges S Δ ∋lk X` — the slot must be LOCKED.  A
 --       VACUOUS unlock is REFUSED (§5 below); it is the premise the
 --       judgement used to drop.
---   (2) `dualScope n (unlock X ∷ Θ) = dualScope n Θ ++ lock (n + X) ∷ []`
+--   (2) `dualScope n (unlock X ∷ S) = dualScope n S ++ lock (n + X) ∷ []`
 --       — the dual RESTORES what Θ unlocked, and the list is REVERSED,
 --       because `scope` applies it HEAD-LAST.
 --
@@ -59,7 +59,7 @@ open import strong.Reduction
 -- crossing-of-crossing shape: an inner region re-exposes what an outer
 -- one concealed).
 Θᵤ : CtxMorph
-Θᵤ = unlock 0 ∷ []
+Θᵤ = morph [] (unlock 0 ∷ [])
 
 _ : interior Θᵤ Δᵤ ≡ bind `ℕ ∷ []
 _ = refl
@@ -88,7 +88,7 @@ W = ƛ `ℕ ∙ ((Λ ($ 3)) ·[ `ℕ , ` 0 ])
 
 -- The boundary ALONE is well typed at Δᵤ …
 ⊢Vb : Δᵤ ∣ [] ⊢ V ⟪ Θᵤ , cᵤ ⟫ ⦂ ((`ℕ ⇒ `ℕ) ⇒ (`ℕ ⇒ `ℕ))
-⊢Vb = env (mw-u ∋lk-Δᵤ mw[])
+⊢Vb = env (mw rw[] (sw-u ∋lk-Δᵤ sw[]))
           (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
           (conv-fun (conv-fun (conv-unseal ez) (conv-id base-ℕ))
                     (conv-fun (conv-seal ez) (conv-id base-ℕ)))
@@ -109,7 +109,7 @@ Redex = (V ⟪ Θᵤ , cᵤ ⟫) · W
 ------------------------------------------------------------------------
 
 -- THE DUAL RESTORES THE LOCK.
-_ : dual Θᵤ ≡ lock 0 ∷ []
+_ : dual Θᵤ ≡ morph [] (lock 0 ∷ [])
 _ = refl
 
 --   scripts/render_term.sh 'showTmIn 1 Contractum'  =
@@ -144,12 +144,12 @@ _ = refl
 Δˡ = bind `ℕ ∷ []
 
 Θˡ : CtxMorph
-Θˡ = lock 0 ∷ []
+Θˡ = morph [] (lock 0 ∷ [])
 
 _ : interior Θˡ Δˡ ≡ masked (bind `ℕ) ∷ []
 _ = refl
 
-_ : dual Θˡ ≡ unlock 0 ∷ []
+_ : dual Θˡ ≡ morph [] (unlock 0 ∷ [])
 _ = refl
 
 -- the crossing frame is Δˡ back: Z is nameable, exactly as at the exterior
@@ -170,15 +170,15 @@ _ = refl
 Δᵥ = bind `ℕ ∷ []
 
 Θᵥ : CtxMorph
-Θᵥ = unlock 0 ∷ []
+Θᵥ = morph [] (unlock 0 ∷ [])
 
 _ : interior Θᵥ Δᵥ ≡ Δᵥ            -- the unlock does nothing …
 _ = refl
 
 ¬⊢ᵐΘᵥ : ¬ (Δᵥ ⊢ᵐ Θᵥ)              -- … and is REFUSED
-¬⊢ᵐΘᵥ (mw-u (_ , ez , ()) _)
+¬⊢ᵐΘᵥ (mw _ (sw-u (_ , ez , ()) _))
 
 -- A DOUBLE LOCK IS REFUSED TOO — which is what keeps `Locked` one mask
 -- deep, and hence `unmaskEnt` an exact inverse of `masked`.
-¬⊢ᵐ-double-lock : ¬ (Δᵥ ⊢ᵐ (lock 0 ∷ lock 0 ∷ []))
-¬⊢ᵐ-double-lock (mw-l (_ , ez , ()) _)
+¬⊢ᵐ-double-lock : ¬ (Δᵥ ⊢ᵐ morph [] (lock 0 ∷ lock 0 ∷ []))
+¬⊢ᵐ-double-lock (mw _ (sw-l (_ , ez , ()) _))

--- a/SystemF/agda/strong/proof/IdLayer.agda
+++ b/SystemF/agda/strong/proof/IdLayer.agda
@@ -70,7 +70,7 @@ outer-id-base-untypeable {Θ₁ = Θ₁} bA (env _ (env _ _ ⊢cᵢ _) ⊢cₒ _
 -- the conversion context: `unlockedScope` skips `lock`, so a conversion
 -- never lands on a slot the layer masks.
 convCtx-lock : ∀ {X} (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → convCtx (lock X ∷ Θ) Δ ≡ convCtx Θ Δ
+  → convCtx (morph (binds Θ) (lock X ∷ changes Θ)) Δ ≡ convCtx Θ Δ
 convCtx-lock Θ Δ = refl
 
 -- (2) And a boundary can never conceal the slot its OWN conversion
@@ -93,14 +93,14 @@ convCtx-lock Θ Δ = refl
 Δₑ-no-1 : ∀ {E} → Δₑ ∋e 1 , E → ⊥
 Δₑ-no-1 (es ())
 
-naked-drop-trap : ∀ {C} → ¬ (Δₑ ∣ [] ⊢ ($ 7) ⟪ [] , seal 1 ⟫ ⦂ C)
+naked-drop-trap : ∀ {C} → ¬ (Δₑ ∣ [] ⊢ ($ 7) ⟪ morph [] [] , seal 1 ⟫ ⦂ C)
 naked-drop-trap (env _ _ (conv-seal d) _) = Δₑ-no-1 d
 
 -- THE SOUND SIDE CONDITION: the drop is sound exactly when the boundary
--- changes NO FRAME.  Then `interior [] Δ ≡ Δ` and the identity
+-- changes NO FRAME.  Then `interior (morph [] []) Δ ≡ Δ` and the identity
 -- conversion fixes the type, so the interior derivation is already the
 -- exterior one.
-drop-empty-frame : ∀ {Δ Γ V A B} → Δ ∣ Γ ⊢ V ⟪ [] , id A ⟫ ⦂ B
+drop-empty-frame : ∀ {Δ Γ V A B} → Δ ∣ Γ ⊢ V ⟪ morph [] [] , id A ⟫ ⦂ B
                  → Δ ∣ [] ⊢ V ⦂ B
 drop-empty-frame {Δ = Δ} {V = V} (env _ ⊢V ⊢c _) =
   subst (λ T → Δ ∣ [] ⊢ V ⦂ T) (conv-id-refl ⊢c) ⊢V

--- a/SystemF/agda/strong/proof/MaskFacts.agda
+++ b/SystemF/agda/strong/proof/MaskFacts.agda
@@ -36,7 +36,8 @@ unlock-recovers d = updateAt-hit unmaskEnt unmaskEnt-comm d
 -- The round trip is the identity on the type context: a program that hides from
 -- itself and then looks again is harmless and typeable.
 lock-then-unlock :
-  interior (unlock 0 ∷ []) (interior (lock 0 ∷ []) (bind `ℕ ∷ []))
+  interior (morph [] (unlock 0 ∷ []))
+    (interior (morph [] (lock 0 ∷ [])) (bind `ℕ ∷ []))
     ≡ bind `ℕ ∷ []
 lock-then-unlock = refl
 
@@ -49,8 +50,8 @@ lock-then-unlock = refl
 -- so on
 -- the mini-core's OWN cancel example the residue is not well formed.  This
 -- is why strong.Reduction's CancelR drops it.
-¬⊢ᵐ-cancel-residue : ¬ ([] ⊢ᵐ (bind `ℕ ∷ lock 0 ∷ []))
-¬⊢ᵐ-cancel-residue (mw-b _ (mw-l (_ , () , _) _))
+¬⊢ᵐ-cancel-residue : ¬ ([] ⊢ᵐ morph (`ℕ ∷ []) (lock 0 ∷ []))
+¬⊢ᵐ-cancel-residue (mw _ (sw-l (_ , () , _) _))
 
 ------------------------------------------------------------------------
 -- THE MASK-ONLY FACT, PROVEN
@@ -120,14 +121,18 @@ module _ (f : Ent → Ent)
   CoreEq-updateAt {X = X} ce d d′ | no ne =
     ce (updateAt-miss⁻ f fc ne d) (updateAt-miss⁻ f fc ne d′)
 
+CoreEq-applyChanges : (S : List Change) (Δ : Ctxᵗ)
+  → CoreEq (applyChanges S Δ) (applyUnlocks S Δ)
+CoreEq-applyChanges []             Δ = CoreEq-refl Δ
+CoreEq-applyChanges (lock X ∷ S)   Δ =
+  CoreEq-updateAtˡ masked masked-comm core-masked (CoreEq-applyChanges S Δ)
+CoreEq-applyChanges (unlock X ∷ S) Δ =
+  CoreEq-updateAt unmaskEnt unmaskEnt-comm core-unmaskEnt
+    (CoreEq-applyChanges S Δ)
+
 CoreEq-scope : (Θ : CtxMorph) (Δ : Ctxᵗ)
   → CoreEq (scope Θ Δ) (unlockedScope Θ Δ)
-CoreEq-scope []             Δ = CoreEq-refl Δ
-CoreEq-scope (bind A ∷ Θ)   Δ = CoreEq-scope Θ Δ
-CoreEq-scope (lock X ∷ Θ)   Δ =
-  CoreEq-updateAtˡ masked masked-comm core-masked (CoreEq-scope Θ Δ)
-CoreEq-scope (unlock X ∷ Θ) Δ =
-  CoreEq-updateAt unmaskEnt unmaskEnt-comm core-unmaskEnt (CoreEq-scope Θ Δ)
+CoreEq-scope Θ Δ = CoreEq-applyChanges (changes Θ) Δ
 
 CoreEq-pushBinds : ∀ {Δ Δ′} (As : List Ty)
   → CoreEq Δ Δ′ → CoreEq (pushBinds As Δ) (pushBinds As Δ′)
@@ -144,5 +149,5 @@ mask-only : ∀ (Θ : CtxMorph) (Δ : Ctxᵗ) {Y A}
 mask-only Θ Δ (E , d , v) df =
   subst (λ F → interior Θ Δ ∋e _ , F)
         (trans (sym (core-nameable v))
-               (CoreEq-pushBinds (repsOf Θ) (CoreEq-scope Θ Δ) d df))
+               (CoreEq-pushBinds (binds Θ) (CoreEq-scope Θ Δ) d df))
         d

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -15,33 +15,33 @@ module strong.proof.MoveScope where
 --   (V ⟪ Θ₁ , c ⟫) ⟪ Θ₂ , unseal Y ⟫
 --     -→ (V ⟪ Θ₁ ⋉ Θ₂ , c′ ⟫) ⟪ rewind Θ₂ , mkId A ⟫
 --
--- `Θ₁ ⋉ Θ₂` appends Θ₂'s whole SCOPE (locks AND unlocks, in order,
--- lifted past Θ₂'s binders) at Θ₁'s TAIL, where `scope` applies it
--- FIRST; and `rewind Θ₂` is Θ₂ with its own scope UNDONE, so what is
--- left of the outer frame is the BIND PREFIX, in net effect:
+-- `Θ₁ ⋉ Θ₂` appends Θ₂'s whole CHANGE LIST (locks AND unlocks, in order,
+-- lifted past Θ₂'s binders) at Θ₁'s TAIL, where `applyChanges` applies it
+-- FIRST; and `rewind Θ₂` is Θ₂ with its own changes UNDONE, so what is
+-- left of the outer frame is the BIND BLOCK, in net effect:
 --
 --   scope    (rewind Θ₂) Δ ≡ Δ                          (given Δ ⊢ᵐ Θ₂)
---   interior (rewind Θ₂) Δ ≡ pushBinds (repsOf Θ₂) Δ
+--   interior (rewind Θ₂) Δ ≡ pushBinds (binds Θ₂) Δ
 --
--- WHY `rewind` AND NOT `bindsOnly` / `dropLocks`.  All three have the
--- same net effect on the type context, and only `rewind` keeps its own
--- `⊢ᵐ`:
+-- WHY `rewind` AND NOT `morph (binds Θ₂) []` / `dropLocks`.  All three
+-- have the same net effect on the type context, and only `rewind` keeps
+-- its own `⊢ᵐ`:
 --   `dropLocks Θ₂` KEEPS Θ₂'s unlocks, so the moved copy of the same
---     unlock is then VACUOUS and `mw-u` refuses it;
---   `bindsOnly Θ₂` DELETES them, and then Θ₂'s own bind reps — read on
---     `unlockedScope Θ₂′ Δ` (`mw-b`) — lose the unlock they depend on;
+--     unlock is then VACUOUS and `sw-u` refuses it;
+--   `morph (binds Θ₂) []` DELETES them, and then Θ₂'s own bind reps —
+--     read on `unlockedScope Θ₂ Δ` — lose the unlock they depend on;
 --   `rewind Θ₂` keeps every entry and rewinds it, so every premise is
 --     read exactly where the redex read it.
 --
--- WHY IT WORKS, in one line: the moved scope re-creates Θ₂'s scope one
--- bind prefix in (`scope-scopeOf`), so the value's frame is preserved ON
--- THE NOSE — the two frame lemmas are EQUALITIES, and no `⊢retag`
--- appears in either case — while the rep the swapped conversion presents
--- is read OUTSIDE Θ₂'s locks, where `wf-shiftBy-pushBinds` supplies the
--- premise the wall used to deny.
+-- WHY IT WORKS, in one line: the moved change list re-creates Θ₂'s
+-- changes one bind prefix in (`applyChanges-shiftScope`), so the value's
+-- frame is preserved ON THE NOSE — the two frame lemmas are EQUALITIES,
+-- and no `⊢retag` appears in either case — while the rep the swapped
+-- conversion presents is read OUTSIDE Θ₂'s locks, where
+-- `wf-shiftBy-pushBinds` supplies the premise the wall used to deny.
 --
 --   §1  the lookup transports
---   §2  the list algebra of `scopeOf`/`rewind`/`_⋉_`
+--   §2  the list algebra of `shiftScope`/`rewind`/`_⋉_`
 --   §3  the type-context identities
 --   §4  the FRAME LEMMAS, as EQUALITIES
 --   §4b why the unlocks travel too — the lock-only move, REFUTED
@@ -62,25 +62,29 @@ open import strong.Terms
 open import strong.CtxMorph
 open import strong.proof.Preserve using (CancelRCase; IdPushCase)
 open import strong.proof.PeelDual
-  using (⊢ᵐ-++; scope-++; unlockedScope-++; scope-dualScope; ⊢ᵐ-dualScope;
-         repsOf-++; repsOf-dualScope)
+  using (⊢ˢ-++; applyChanges-++; applyUnlocks-++;
+         applyChanges-dualScope; ⊢ˢ-dualScope)
 
 ------------------------------------------------------------------------
 -- §1  Lookup transports
 ------------------------------------------------------------------------
 
--- A binder survives `unlockedScope`: it only unmasks (`unmaskEnt`, which fixes
--- `bind`) and skips locks, so a `bind` lookup is preserved unchanged.
+-- A binder survives `applyUnlocks`: it only unmasks (`unmaskEnt`, which
+-- fixes `bind`) and skips locks, so a `bind` lookup is preserved
+-- unchanged.
+applyUnlocks-∋bind : ∀ (S : List Change) {Δ Y A}
+  → Δ ∋ Y := A → applyUnlocks S Δ ∋ Y := A
+applyUnlocks-∋bind []              d = d
+applyUnlocks-∋bind (lock Z ∷ S)    d = applyUnlocks-∋bind S d
+applyUnlocks-∋bind (unlock Z ∷ S) {Y = Y} d with Z ≟ℕ Y
+... | yes refl =
+  updateAt-hit  unmaskEnt unmaskEnt-comm    (applyUnlocks-∋bind S d)
+... | no  ne   =
+  updateAt-miss unmaskEnt unmaskEnt-comm ne (applyUnlocks-∋bind S d)
+
 unlockedScope-∋bind : ∀ (Θ : CtxMorph) {Δ Y A}
   → Δ ∋ Y := A → unlockedScope Θ Δ ∋ Y := A
-unlockedScope-∋bind []              d = d
-unlockedScope-∋bind (bind C ∷ Θ)    d = unlockedScope-∋bind Θ d
-unlockedScope-∋bind (lock Z ∷ Θ)    d = unlockedScope-∋bind Θ d
-unlockedScope-∋bind (unlock Z ∷ Θ) {Y = Y} d with Z ≟ℕ Y
-... | yes refl =
-  updateAt-hit  unmaskEnt unmaskEnt-comm    (unlockedScope-∋bind Θ d)
-... | no  ne   =
-  updateAt-miss unmaskEnt unmaskEnt-comm ne (unlockedScope-∋bind Θ d)
+unlockedScope-∋bind Θ d = applyUnlocks-∋bind (changes Θ) d
 
 -- The bind prefix lifts a binder: slot Y in the tail becomes slot
 -- `length As + Y` at the rep lifted past the `length As` prefix binders.
@@ -93,84 +97,78 @@ pushBinds-∋ (C ∷ As) d = es (pushBinds-∋ As d)
 -- §2  The list algebra of the move
 ------------------------------------------------------------------------
 
--- THE MOVE CARRIES NO BINDER: it moves scope entries only.
-repsOf-scopeOf : (n : ℕ) (Θ : CtxMorph) → repsOf (scopeOf n Θ) ≡ []
-repsOf-scopeOf n []             = refl
-repsOf-scopeOf n (bind A ∷ Θ)   = repsOf-scopeOf n Θ
-repsOf-scopeOf n (unlock X ∷ Θ) = repsOf-scopeOf n Θ
-repsOf-scopeOf n (lock X ∷ Θ)   = repsOf-scopeOf n Θ
-
-repsOf-⋉ : (Θ₁ Θ₂ : CtxMorph) → repsOf (Θ₁ ⋉ Θ₂) ≡ repsOf Θ₁
-repsOf-⋉ []             Θ₂  = repsOf-scopeOf (numBinds Θ₂) Θ₂
-repsOf-⋉ (bind A ∷ Θ₁)  Θ₂  = cong (A ∷_) (repsOf-⋉ Θ₁ Θ₂)
-repsOf-⋉ (unlock X ∷ Θ₁) Θ₂ = repsOf-⋉ Θ₁ Θ₂
-repsOf-⋉ (lock X ∷ Θ₁)  Θ₂  = repsOf-⋉ Θ₁ Θ₂
-
+-- THE MOVE CARRIES NO BINDER, AND REWINDING KEEPS THE BINDERS.  With the
+-- PAIR both are facts about the constructor — `refl` — and the five
+-- filtering lemmas the interleaved list needed here (`repsOf-scopeOf`,
+-- `repsOf-⋉`, `repsOf-rewind`, and the two `numBinds` corollaries, which
+-- were `cong length` of them) collapse to these two `refl`s, used
+-- nowhere.
 numBinds-⋉ : (Θ₁ Θ₂ : CtxMorph) → numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁
-numBinds-⋉ Θ₁ Θ₂ = cong length (repsOf-⋉ Θ₁ Θ₂)
-
--- REWINDING KEEPS THE BINDERS: the inverse scope carries none.
-repsOf-rewind : (Θ : CtxMorph) → repsOf (rewind Θ) ≡ repsOf Θ
-repsOf-rewind Θ rewrite repsOf-++ (dualScope 0 Θ) Θ
-                      | repsOf-dualScope 0 Θ = refl
+numBinds-⋉ Θ₁ Θ₂ = refl
 
 numBinds-rewind : (Θ : CtxMorph) → numBinds (rewind Θ) ≡ numBinds Θ
-numBinds-rewind Θ = cong length (repsOf-rewind Θ)
+numBinds-rewind Θ = refl
 
--- THE MOVED SCOPE, APPLIED PAST THE BIND PREFIX, IS THE ORIGINAL SCOPE
--- APPLIED UNDER IT.  This is the whole point of the index lift `n + X`,
--- and it is `updateAt-pushBinds` (strong.Ctx) once per entry.
-scope-scopeOf : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → scope (scopeOf (length As) Θ) (pushBinds As Δ) ≡ pushBinds As (scope Θ Δ)
-scope-scopeOf As []             Δ = refl
-scope-scopeOf As (bind A ∷ Θ)   Δ = scope-scopeOf As Θ Δ
-scope-scopeOf As (unlock X ∷ Θ) Δ =
-  trans (cong (unmask (length As + X)) (scope-scopeOf As Θ Δ))
-        (updateAt-pushBinds unmaskEnt As X (scope Θ Δ))
-scope-scopeOf As (lock X ∷ Θ)   Δ =
-  trans (cong (mask (length As + X)) (scope-scopeOf As Θ Δ))
-        (updateAt-pushBinds masked As X (scope Θ Δ))
+-- THE MOVED CHANGES, APPLIED PAST THE BIND PREFIX, ARE THE ORIGINAL
+-- CHANGES APPLIED UNDER IT.  This is the whole point of the index lift
+-- `n + X`, and it is `updateAt-pushBinds` (strong.Ctx) once per entry.
+applyChanges-shiftScope : (As : List Ty) (S : List Change) (Δ : Ctxᵗ)
+  → applyChanges (shiftScope (length As) S) (pushBinds As Δ)
+      ≡ pushBinds As (applyChanges S Δ)
+applyChanges-shiftScope As []             Δ = refl
+applyChanges-shiftScope As (unlock X ∷ S) Δ =
+  trans (cong (unmask (length As + X)) (applyChanges-shiftScope As S Δ))
+        (updateAt-pushBinds unmaskEnt As X (applyChanges S Δ))
+applyChanges-shiftScope As (lock X ∷ S)   Δ =
+  trans (cong (mask (length As + X)) (applyChanges-shiftScope As S Δ))
+        (updateAt-pushBinds masked As X (applyChanges S Δ))
 
-unlockedScope-scopeOf : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (scopeOf (length As) Θ) (pushBinds As Δ)
-      ≡ pushBinds As (unlockedScope Θ Δ)
-unlockedScope-scopeOf As []             Δ = refl
-unlockedScope-scopeOf As (bind A ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
-unlockedScope-scopeOf As (lock X ∷ Θ)   Δ = unlockedScope-scopeOf As Θ Δ
-unlockedScope-scopeOf As (unlock X ∷ Θ) Δ =
-  trans (cong (unmask (length As + X)) (unlockedScope-scopeOf As Θ Δ))
-        (updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ))
+applyUnlocks-shiftScope : (As : List Ty) (S : List Change) (Δ : Ctxᵗ)
+  → applyUnlocks (shiftScope (length As) S) (pushBinds As Δ)
+      ≡ pushBinds As (applyUnlocks S Δ)
+applyUnlocks-shiftScope As []             Δ = refl
+applyUnlocks-shiftScope As (lock X ∷ S)   Δ = applyUnlocks-shiftScope As S Δ
+applyUnlocks-shiftScope As (unlock X ∷ S) Δ =
+  trans (cong (unmask (length As + X)) (applyUnlocks-shiftScope As S Δ))
+        (updateAt-pushBinds unmaskEnt As X (applyUnlocks S Δ))
 
 ------------------------------------------------------------------------
 -- §3  The type-context identities
 ------------------------------------------------------------------------
 
--- THE HEADLINE IDENTITY.  A rewound frame's SCOPE IS THE IDENTITY — this
--- is `scope-dualScope` (proof/PeelDual) at an empty bind prefix, and it
--- is where the whole design is paid for: the inverse is exact only
--- because `mw-u` refuses a vacuous unlock.
+-- THE HEADLINE IDENTITY.  A rewound frame's CHANGES ARE THE IDENTITY —
+-- this is `applyChanges-dualScope` (proof/PeelDual) at an empty bind
+-- prefix, and it is where the whole design is paid for: the inverse is
+-- exact only because `sw-u` refuses a vacuous unlock.
 scope-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → scope (rewind Θ) Δ ≡ Δ
-scope-rewind Θ {Δ = Δ} mw =
-  trans (scope-++ (dualScope 0 Θ) Θ Δ) (scope-dualScope [] Θ mw)
+scope-rewind Θ {Δ = Δ} mwᵥ =
+  trans (applyChanges-++ (dualScope 0 (changes Θ)) (changes Θ) Δ)
+        (applyChanges-dualScope [] (changes Θ) (mw-changes mwᵥ))
 
 interior-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
-  → interior (rewind Θ) Δ ≡ pushBinds (repsOf Θ) Δ
-interior-rewind Θ mw rewrite repsOf-rewind Θ | scope-rewind Θ mw = refl
+  → interior (rewind Θ) Δ ≡ pushBinds (binds Θ) Δ
+interior-rewind Θ mwᵥ = cong (pushBinds (binds Θ)) (scope-rewind Θ mwᵥ)
 
 -- The two frames of the contractum, unfolded.
 interior-⋉ : (Θ₁ Θ₂ : CtxMorph) (Ξ : Ctxᵗ)
   → interior (Θ₁ ⋉ Θ₂) Ξ
-      ≡ pushBinds (repsOf Θ₁) (scope Θ₁ (scope (scopeOf (numBinds Θ₂) Θ₂) Ξ))
-interior-⋉ Θ₁ Θ₂ Ξ rewrite repsOf-⋉ Θ₁ Θ₂ =
-  cong (pushBinds (repsOf Θ₁)) (scope-++ Θ₁ (scopeOf (numBinds Θ₂) Θ₂) Ξ)
+      ≡ pushBinds (binds Θ₁)
+          (applyChanges (changes Θ₁)
+            (applyChanges (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ))
+interior-⋉ Θ₁ Θ₂ Ξ =
+  cong (pushBinds (binds Θ₁))
+       (applyChanges-++ (changes Θ₁)
+                        (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ)
 
 convCtx-⋉ : (Θ₁ Θ₂ : CtxMorph) (Ξ : Ctxᵗ)
   → convCtx (Θ₁ ⋉ Θ₂) Ξ
-      ≡ pushBinds (repsOf Θ₁)
-          (unlockedScope Θ₁ (unlockedScope (scopeOf (numBinds Θ₂) Θ₂) Ξ))
-convCtx-⋉ Θ₁ Θ₂ Ξ rewrite repsOf-⋉ Θ₁ Θ₂ =
-  cong (pushBinds (repsOf Θ₁))
-       (unlockedScope-++ Θ₁ (scopeOf (numBinds Θ₂) Θ₂) Ξ)
+      ≡ pushBinds (binds Θ₁)
+          (applyUnlocks (changes Θ₁)
+            (applyUnlocks (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ))
+convCtx-⋉ Θ₁ Θ₂ Ξ =
+  cong (pushBinds (binds Θ₁))
+       (applyUnlocks-++ (changes Θ₁)
+                        (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ)
 
 ------------------------------------------------------------------------
 -- §4  THE FRAME LEMMAS — EQUALITIES
@@ -183,28 +181,27 @@ wf-unlockedScope Θ w = ⊑-wf (Δ⊑unlockedScope Θ _) w
 
 wf-convCtx : ∀ {Δ A} (Θ : CtxMorph)
   → Δ ⊢ᵗ A → convCtx Θ Δ ⊢ᵗ shiftBy (numBinds Θ) A
-wf-convCtx Θ w = wf-shiftBy-pushBinds (repsOf Θ) (wf-unlockedScope Θ w)
+wf-convCtx Θ w = wf-shiftBy-pushBinds (binds Θ) (wf-unlockedScope Θ w)
 
--- … and the same at a REWOUND frame, whose bind count is Θ's own.
+-- … and the same at a REWOUND frame, whose bind count IS Θ's own — now
+-- definitionally, so the `subst` the interleaved list needed is gone.
 wf-convCtx-rewind : ∀ {Δ C} (Θ : CtxMorph) → Δ ⊢ᵗ C
   → convCtx (rewind Θ) Δ ⊢ᵗ shiftBy (numBinds Θ) C
-wf-convCtx-rewind {Δ = Δ} {C = C} Θ w =
-  subst (λ n → convCtx (rewind Θ) Δ ⊢ᵗ shiftBy n C)
-        (numBinds-rewind Θ) (wf-convCtx (rewind Θ) w)
+wf-convCtx-rewind Θ w = wf-convCtx (rewind Θ) w
 
 -- THE VALUE'S FRAME IS PRESERVED ON THE NOSE.  Everything Θ₂ masked the
--- moved scope masks again, at the same slots, in the same order, one
--- prefix further in (`scope-scopeOf`); and the outer frame contributes
--- nothing but its binders (`interior-rewind`).  So the value crosses by
--- `subst` — with `dropLocks` this was a ⊑ and needed `⊢retag` along a
--- `le-mu` step, which `mw-u` no longer tolerates.
+-- moved change list masks again, at the same slots, in the same order,
+-- one prefix further in (`applyChanges-shiftScope`); and the outer frame
+-- contributes nothing but its binders (`interior-rewind`).  So the value
+-- crosses by `subst` — with `dropLocks` this was a ⊑ and needed `⊢retag`
+-- along a `le-mu` step, which `sw-u` no longer tolerates.
 interior-⋉-rewind : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
   → interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)
-interior-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mw
-  rewrite interior-rewind Θ₂ mw =
-  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
-        (cong (λ Ξ → pushBinds (repsOf Θ₁) (scope Θ₁ Ξ))
-              (scope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+interior-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mwᵥ
+  rewrite interior-rewind Θ₂ mwᵥ =
+  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (binds Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (binds Θ₁) (applyChanges (changes Θ₁) Ξ))
+              (applyChanges-shiftScope (binds Θ₂) (changes Θ₂) Δ))
 
 -- … and the CONVERSION CONTEXT of the moved frame is the redex's inner
 -- conversion context with Θ₂'s LOCKS lifted off — which is the whole
@@ -212,69 +209,70 @@ interior-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mw
 -- OUTSIDE those locks).
 convCtx-⋉-rewind : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
   → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ convCtx Θ₁ (convCtx Θ₂ Δ)
-convCtx-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mw
-  rewrite interior-rewind Θ₂ mw =
-  trans (convCtx-⋉ Θ₁ Θ₂ (pushBinds (repsOf Θ₂) Δ))
-        (cong (λ Ξ → pushBinds (repsOf Θ₁) (unlockedScope Θ₁ Ξ))
-              (unlockedScope-scopeOf (repsOf Θ₂) Θ₂ Δ))
+convCtx-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mwᵥ
+  rewrite interior-rewind Θ₂ mwᵥ =
+  trans (convCtx-⋉ Θ₁ Θ₂ (pushBinds (binds Θ₂) Δ))
+        (cong (λ Ξ → pushBinds (binds Θ₁) (applyUnlocks (changes Θ₁) Ξ))
+              (applyUnlocks-shiftScope (binds Θ₂) (changes Θ₂) Δ))
 
 -- The one place a ⊑ survives, and it carries a TYPE, not a term: the
 -- inner conversion is read where Θ₂'s locks are not applied at all.
 convCtx-move : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
   → convCtx Θ₁ (interior Θ₂ Δ) ⊑ convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
-convCtx-move Θ₁ Θ₂ {Δ = Δ} mw =
+convCtx-move Θ₁ Θ₂ {Δ = Δ} mwᵥ =
   subst (λ Ξ → convCtx Θ₁ (interior Θ₂ Δ) ⊑ Ξ)
-        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mw))
+        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mwᵥ))
         (⊑-convCtx Θ₁ (interior⊑convCtx Θ₂ Δ))
 
 -- THE BINDER, ON THE CONTRACTUM'S INNER CONVERSION CONTEXT.  The outer
 -- reveal's own lookup — read on `convCtx Θ₂ Δ` — transported past the
--- moved scope, past Θ₁'s unmasks, and past Θ₁'s binders.
+-- moved changes, past Θ₁'s unmasks, and past Θ₁'s binders.
 move-∋ : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} {Y : ℕ} {A : Ty} → Δ ⊢ᵐ Θ₂
   → convCtx Θ₂ Δ ∋ Y := A
   → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
       ∋ (numBinds Θ₁ + Y) := shiftBy (numBinds Θ₁) A
-move-∋ Θ₁ Θ₂ {Δ = Δ} {Y = Y} {A = A} mw d =
+move-∋ Θ₁ Θ₂ {Δ = Δ} {Y = Y} {A = A} mwᵥ d =
   subst (λ Ξ → Ξ ∋ (numBinds Θ₁ + Y) := shiftBy (numBinds Θ₁) A)
-        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mw))
-        (pushBinds-∋ (repsOf Θ₁) (unlockedScope-∋bind Θ₁ d))
+        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mwᵥ))
+        (pushBinds-∋ (binds Θ₁) (unlockedScope-∋bind Θ₁ d))
 
 -- The conversion context of the moved inner frame carries every rep its
 -- own exterior carries — it only ADDS unmasks and the bind prefix.
 wf-convCtx-move : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} {A : Ty} → Δ ⊢ᵐ Θ₂
   → convCtx Θ₂ Δ ⊢ᵗ A
   → convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ⊢ᵗ shiftBy (numBinds Θ₁) A
-wf-convCtx-move Θ₁ Θ₂ {Δ = Δ} {A = A} mw w =
+wf-convCtx-move Θ₁ Θ₂ {Δ = Δ} {A = A} mwᵥ w =
   subst (λ Ξ → Ξ ⊢ᵗ shiftBy (numBinds Θ₁) A)
-        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mw))
-        (wf-shiftBy-pushBinds (repsOf Θ₁) (wf-unlockedScope Θ₁ w))
+        (sym (convCtx-⋉-rewind Θ₁ Θ₂ mwᵥ))
+        (wf-shiftBy-pushBinds (binds Θ₁) (wf-unlockedScope Θ₁ w))
 
 ------------------------------------------------------------------------
 -- §4b  WHY THE UNLOCKS TRAVEL TOO — the lock-only move, REFUTED
 ------------------------------------------------------------------------
 
 -- The obvious cheaper move appends only Θ₂'s LOCKS.  It reorders a
--- same-slot unlock/lock pair, because `scope` applies the list HEAD-LAST,
--- and then the value's frame is not REFINED but CORRUPTED: a slot the
--- value may name in the redex is MASKED in the contractum.
-locksOnly : ℕ → CtxMorph → CtxMorph
+-- same-slot unlock/lock pair, because `applyChanges` applies the list
+-- HEAD-LAST, and then the value's frame is not REFINED but CORRUPTED: a
+-- slot the value may name in the redex is MASKED in the contractum.
+locksOnly : ℕ → List Change → List Change
 locksOnly n []             = []
-locksOnly n (bind A ∷ Θ)   = locksOnly n Θ
-locksOnly n (unlock X ∷ Θ) = locksOnly n Θ
-locksOnly n (lock X ∷ Θ)   = lock (n + X) ∷ locksOnly n Θ
+locksOnly n (unlock X ∷ S) = locksOnly n S
+locksOnly n (lock X ∷ S)   = lock (n + X) ∷ locksOnly n S
 
 -- THE WITNESS.  `Θ✗` masks slot 0 and then re-exposes it — and BOTH
--- entries are legal under the SEQUENTIAL judgement: the lock names a slot
--- visible at Δ✗, the unlock names the slot the lock itself just locked.
+-- entries are legal under the SEQUENTIAL change judgement: the lock names
+-- a slot visible at Δ✗, the unlock names the slot the lock itself just
+-- locked.
 Θ✗ : CtxMorph
-Θ✗ = unlock 0 ∷ lock 0 ∷ []
+Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])
 
 Δ✗ : Ctxᵗ
 Δ✗ = bind `ℕ ∷ []
 
 ⊢ᵐ-Θ✗ : Δ✗ ⊢ᵐ Θ✗
-⊢ᵐ-Θ✗ = mw-u (masked (bind `ℕ) , ez , locked nameable-b)
-             (mw-l (bind `ℕ , ez , nameable-b) mw[])
+⊢ᵐ-Θ✗ = mw rw[]
+           (sw-u (masked (bind `ℕ) , ez , locked nameable-b)
+                 (sw-l (bind `ℕ , ez , nameable-b) sw[]))
 
 _ : interior Θ✗ Δ✗ ≡ bind `ℕ ∷ []
 _ = refl
@@ -283,13 +281,14 @@ _ : interior (rewind Θ✗) Δ✗ ≡ bind `ℕ ∷ []
 _ = refl
 
 -- … but the lock-only contractum's interior BLOCKS it.
-_ : scope (locksOnly (numBinds Θ✗) Θ✗) (interior (rewind Θ✗) Δ✗)
+_ : applyChanges (locksOnly (numBinds Θ✗) (changes Θ✗))
+                 (interior (rewind Θ✗) Δ✗)
       ≡ masked (bind `ℕ) ∷ []
 _ = refl
 
 ¬frame-locksOnly :
-  ¬ (interior [] (interior Θ✗ Δ✗)
-       ≡ interior ([] ++ locksOnly (numBinds Θ✗) Θ✗)
+  ¬ (interior (morph [] []) (interior Θ✗ Δ✗)
+       ≡ interior (morph [] ([] ++ locksOnly (numBinds Θ✗) (changes Θ✗)))
                   (interior (rewind Θ✗) Δ✗))
 ¬frame-locksOnly ()
 
@@ -297,44 +296,77 @@ _ = refl
 -- §5  `_⊢ᵐ_` for the two new frames
 ------------------------------------------------------------------------
 
--- THE REWOUND FRAME.  Θ's own entries are read exactly where they were
--- (they sit at the TAIL of the append), and the inverse scope on top is
--- `⊢ᵐ-dualScope` at an empty bind prefix.
+-- THE REWOUND FRAME.  Its CHANGES are Θ's own with the inverse list on
+-- top (`⊢ˢ-dualScope` at an empty bind prefix); its REPS are Θ's own,
+-- read past the extra unmasks the inverse list adds — MORE nameable, so
+-- `⊢ʳ-⊑` carries them.  (Under the interleaved list the reps sat inside
+-- the appended tail, where they were read unchanged.)
 ⊢ᵐ-rewind : ∀ (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → Δ ⊢ᵐ rewind Θ
-⊢ᵐ-rewind Θ mw = ⊢ᵐ-++ (dualScope 0 Θ) Θ (⊢ᵐ-dualScope [] Θ mw) mw
+⊢ᵐ-rewind Θ {Δ = Δ} mwᵥ =
+  mw (subst (λ Ξ → Ξ ⊢ʳ binds Θ)
+            (sym (applyUnlocks-++ (dualScope 0 (changes Θ)) (changes Θ) Δ))
+            (⊢ʳ-⊑ (Δ⊑applyUnlocks (dualScope 0 (changes Θ))
+                                  (applyUnlocks (changes Θ) Δ))
+                  (mw-reps mwᵥ)))
+     (⊢ˢ-++ (dualScope 0 (changes Θ)) (changes Θ)
+            (⊢ˢ-dualScope [] (changes Θ) (mw-changes mwᵥ))
+            (mw-changes mwᵥ))
 
--- THE MOVED SCOPE IS WELL FORMED WHERE IT LANDS.  Θ₂'s entries are read
--- one bind prefix in, over `pushBinds As (scope Θ₂ᵢ Δ)` — which is where
--- Θ₂'s own premises live, lifted (`scope-scopeOf`).  No refinement step,
--- and no `le-mu`.
-⊢ᵐ-scopeOf : ∀ (As : List Ty) (Θ : CtxMorph) {Δ : Ctxᵗ}
-  → Δ ⊢ᵐ Θ → pushBinds As Δ ⊢ᵐ scopeOf (length As) Θ
-⊢ᵐ-scopeOf As []             mw[]       = mw[]
-⊢ᵐ-scopeOf As (bind A ∷ Θ)   (mw-b _ b) = ⊢ᵐ-scopeOf As Θ b
-⊢ᵐ-scopeOf As (lock X ∷ Θ)   {Δ = Δ} (mw-l tv b) =
-  mw-l (subst (λ Ξ → Ξ ∋tv (length As + X))
-              (sym (scope-scopeOf As Θ Δ)) (pushBinds-∋tv As tv))
-       (⊢ᵐ-scopeOf As Θ b)
-⊢ᵐ-scopeOf As (unlock X ∷ Θ) {Δ = Δ} (mw-u lk b) =
-  mw-u (subst (λ Ξ → Ξ ∋lk (length As + X))
-              (sym (scope-scopeOf As Θ Δ)) (pushBinds-∋lk As lk))
-       (⊢ᵐ-scopeOf As Θ b)
+-- THE MOVED CHANGES ARE WELL FORMED WHERE THEY LAND.  Θ₂'s entries are
+-- read one bind prefix in, over `pushBinds As (applyChanges S′ Δ)` —
+-- which is where Θ₂'s own premises live, lifted
+-- (`applyChanges-shiftScope`).  No refinement step, and no `le-mu`.
+⊢ˢ-shiftScope : ∀ (As : List Ty) (S : List Change) {Δ : Ctxᵗ}
+  → Δ ⊢ˢ S → pushBinds As Δ ⊢ˢ shiftScope (length As) S
+⊢ˢ-shiftScope As []             sw[]       = sw[]
+⊢ˢ-shiftScope As (lock X ∷ S)   {Δ = Δ} (sw-l tv b) =
+  sw-l (subst (λ Ξ → Ξ ∋tv (length As + X))
+              (sym (applyChanges-shiftScope As S Δ)) (pushBinds-∋tv As tv))
+       (⊢ˢ-shiftScope As S b)
+⊢ˢ-shiftScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b) =
+  sw-u (subst (λ Ξ → Ξ ∋lk (length As + X))
+              (sym (applyChanges-shiftScope As S Δ)) (pushBinds-∋lk As lk))
+       (⊢ˢ-shiftScope As S b)
 
--- THE MERGED FRAME.  `⊢ᵐ-++` splits it at the move: Θ₂'s scope is read
--- over `pushBinds (repsOf Θ₂) Δ`, and Θ₁ is then read over exactly
--- `interior Θ₂ Δ` — its own exterior in the redex.  THIS is what the
--- sequential judgement buys: under a SIMULTANEOUS `mw-b`, Θ₁'s reps
--- would have to be well formed on the plain `pushBinds (repsOf Θ₂) Δ`,
--- and a rep naming a slot Θ₂ UNLOCKED is not.
+-- THE MERGED FRAME.  ITS TWO HALVES SPLIT CLEANLY, which is what the
+-- pair buys: the CHANGES are `⊢ˢ-++` at the move (Θ₂'s changes read over
+-- `pushBinds (binds Θ₂) Δ`, then Θ₁'s over exactly `interior Θ₂ Δ` — its
+-- own exterior in the redex), and the REPS are Θ₁'s own, read past ALL of
+-- the merged frame's unlocks, i.e. past Θ₁'s AND Θ₂'s.  That is MORE
+-- nameable than where the redex read them, so `⊢ʳ-⊑` carries them and
+-- nothing has to be re-derived — under a SIMULTANEOUS reading on the
+-- PLAIN exterior neither half would survive.
 ⊢ᵐ-⋉ : ∀ (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ}
   → Δ ⊢ᵐ Θ₂ → interior Θ₂ Δ ⊢ᵐ Θ₁
   → interior (rewind Θ₂) Δ ⊢ᵐ (Θ₁ ⋉ Θ₂)
 ⊢ᵐ-⋉ Θ₁ Θ₂ {Δ = Δ} b₂ b₁ =
   subst (λ Ξ → Ξ ⊢ᵐ (Θ₁ ⋉ Θ₂)) (sym (interior-rewind Θ₂ b₂))
-        (⊢ᵐ-++ Θ₁ (scopeOf (numBinds Θ₂) Θ₂)
-                (subst (λ Ξ → Ξ ⊢ᵐ Θ₁)
-                       (sym (scope-scopeOf (repsOf Θ₂) Θ₂ Δ)) b₁)
-                (⊢ᵐ-scopeOf (repsOf Θ₂) Θ₂ b₂))
+        (mw reps chgs)
+  where
+  S₂ : List Change
+  S₂ = shiftScope (numBinds Θ₂) (changes Θ₂)
+
+  reps : applyUnlocks (changes Θ₁ ++ S₂) (pushBinds (binds Θ₂) Δ)
+           ⊢ʳ binds Θ₁
+  reps =
+    subst (λ Ξ → Ξ ⊢ʳ binds Θ₁)
+          (sym (trans (applyUnlocks-++ (changes Θ₁) S₂
+                        (pushBinds (binds Θ₂) Δ))
+                      (cong (applyUnlocks (changes Θ₁))
+                            (applyUnlocks-shiftScope (binds Θ₂)
+                                                     (changes Θ₂) Δ))))
+          (⊢ʳ-⊑ (⊑-applyUnlocks (changes Θ₁)
+                   (⊑-pushBinds (binds Θ₂)
+                      (applyChanges⊑applyUnlocks (changes Θ₂) Δ)))
+                (mw-reps b₁))
+
+  chgs : pushBinds (binds Θ₂) Δ ⊢ˢ (changes Θ₁ ++ S₂)
+  chgs =
+    ⊢ˢ-++ (changes Θ₁) S₂
+          (subst (λ Ξ → Ξ ⊢ˢ changes Θ₁)
+                 (sym (applyChanges-shiftScope (binds Θ₂) (changes Θ₂) Δ))
+                 (mw-changes b₁))
+          (⊢ˢ-shiftScope (binds Θ₂) (changes Θ₂) (mw-changes b₂))
 
 ------------------------------------------------------------------------
 -- §6  THE TWO CASES
@@ -352,15 +384,14 @@ module _ {Δ : Ctxᵗ} (Θ₂ : CtxMorph) {A C : Ty}
   -- Θ₂'s binders — so this is `wf-shiftBy-pushBinds`, and nothing else.
   moved-scoped : interior (rewind Θ₂) Δ ⊢ᵗ A
   moved-scoped rewrite eqAC | interior-rewind Θ₂ mw₂ =
-    wf-shiftBy-pushBinds (repsOf Θ₂) wE
+    wf-shiftBy-pushBinds (binds Θ₂) wE
 
   moved-conv : convCtx (rewind Θ₂) Δ
                  ⊢ mkId A ∶ A ⇝ shiftBy (numBinds (rewind Θ₂)) C
-  moved-conv rewrite numBinds-rewind Θ₂ | eqAC =
-    mkId-⊢ (wf-convCtx-rewind Θ₂ wE)
+  moved-conv rewrite eqAC = mkId-⊢ (wf-convCtx-rewind Θ₂ wE)
 
 -- ── IDPUSH ─────────────────────────────────────────────────────────────
--- The conversions swap and the scope moves.  Four moves, one per
+-- The conversions swap and the changes move.  Four moves, one per
 -- premise of the contractum's inner `env`:
 --
 --   FRAME       `Θ₁ ⋉ Θ₂`, well formed by §5.
@@ -402,7 +433,7 @@ preserve-IdPush {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = Y
 
   convᵢ : convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
             ⊢ unseal X ∶ ` X ⇝ shiftBy (numBinds (Θ₁ ⋉ Θ₂)) A
-  convᵢ rewrite numBinds-⋉ Θ₁ Θ₂ = conv-unseal dX
+  convᵢ = conv-unseal dX
 
 -- ── CANCELR ────────────────────────────────────────────────────────────
 -- The same four moves, with both conversions neutralised instead of
@@ -446,6 +477,6 @@ preserve-CancelR {Δ = Δ} {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} {X = X} {Y = 
   convᵢ : convCtx (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)
             ⊢ mkId (shiftBy (numBinds Θ₁) A)
             ∶ shiftBy (numBinds Θ₁) A ⇝ shiftBy (numBinds (Θ₁ ⋉ Θ₂)) A
-  convᵢ rewrite numBinds-⋉ Θ₁ Θ₂ =
+  convᵢ =
     mkId-⊢ (wf-convCtx-move Θ₁ Θ₂ mw₂
               (subst (λ T → convCtx Θ₂ Δ ⊢ᵗ T) (sym eqAC) (wf-convCtx Θ₂ wE)))

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -1,24 +1,26 @@
 module strong.proof.MwUObstruct where
 
 -- WHAT LANDED, AND WHAT THE ALTERNATIVES COST — the record of the
--- 2026-09-06 tightness repair.
+-- 2026-09-06 tightness repair, restated on the PAIR morphism.
 --
 -- The repair Jeremy proposed had three parts; this module used to refute
 -- them as a package.  All three LANDED, in the corrected form the
 -- refutations forced:
 --
---   (1) `mw-u` demands the slot be LOCKED — LANDED, and STRENGTHENED to
---       the SEQUENTIAL reading `scope Θ Δ ∋lk X` (the entry is judged on
---       the frame it acts on), with the same reading for `mw-l` and, for
---       a rep, `unlockedScope Θ Δ ⊢ᵗ A`.  The old refutations §2/§3/§4
---       were all artefacts of reading every premise on the PLAIN Δ.
---       `⊢ᵐ-⊑` survives as `⊢ᵐ-⊑ᵃ` over `_⊑ᵃ_`, the refinement WITHOUT
---       `le-mu` (strong.Ctx §4b); `⊢retag` runs on that.
---   (2) `dualScope n (unlock X ∷ Θ) = … ++ lock (n + X) ∷ []` — LANDED,
+--   (1) `sw-u` demands the slot be LOCKED — LANDED, and STRENGTHENED to
+--       the SEQUENTIAL reading `applyChanges S Δ ∋lk X` (the change is
+--       judged on the frame it acts on), with the same reading for
+--       `sw-l`.  A REP is read on `applyUnlocks (changes Θ) Δ` — the
+--       whole change list's unmasks, ALL of its locks lifted.  The old
+--       refutations §2/§3/§4 were all artefacts of reading every premise
+--       on the PLAIN Δ.  `⊢ᵐ-⊑` survives as `⊢ᵐ-⊑ᵃ` over `_⊑ᵃ_`, the
+--       refinement WITHOUT `le-mu` (strong.Ctx §4b); `⊢retag` runs on it.
+--   (2) `dualScope n (unlock X ∷ S) = … ++ lock (n + X) ∷ []` — LANDED,
 --       AND REVERSED (the old §5, which was right).
---   (3) the outer frame of CancelR/IdPush loses its scope — LANDED as
---       `rewind Θ₂ = dualScope 0 Θ₂ ++ Θ₂`, NOT as `bindsOnly Θ₂` and
---       NOT as `dropLocks Θ₂`.
+--   (3) the outer frame of CancelR/IdPush loses its changes — LANDED as
+--       `rewind Θ₂ = morph (binds Θ₂) (dualScope 0 (changes Θ₂) ++
+--       changes Θ₂)`, NOT as `morph (binds Θ₂) []` and NOT as
+--       `dropLocks Θ₂`.
 --
 -- WHAT REMAINS HERE ARE THE THREE REFUTATIONS THAT CHOSE `rewind`, on
 -- ONE running configuration:
@@ -26,13 +28,20 @@ module strong.proof.MwUObstruct where
 --   §1  the exterior Δ₆ masks a slot; Θ₂ UNLOCKS it; the inner frame
 --       BINDS a rep that names it.  All three morphisms are well formed.
 --   §2  `dropLocks Θ₂` as the outer frame: the moved copy of Θ₂'s unlock
---       is then VACUOUS, and `mw-u` refuses it.
+--       is then VACUOUS, and `sw-u` refuses it.
 --   §3  `bindsOnly Θ₂` as the outer frame: Θ₂'s OWN bind rep loses the
---       unlock it was read past, and `mw-b` refuses it.
+--       unlock it was read past, and the rep half of `⊢ᵐ` refuses it.
 --   §4  `rewind Θ₂` does both jobs — and §4 is also the answer to the
---       simultaneity question: under a mw-b read on the PLAIN exterior
+--       simultaneity question: under a rep reading on the PLAIN exterior
 --       the MERGED frame `Θ₁ ⋉ Θ₂` has no derivation, because Θ₁'s rep
---       names a slot the merged frame's own tail unlocks.
+--       names a slot the merged frame's own change list unlocks.
+--
+-- NOTE THE ONE SEMANTIC MOVE THE PAIR MAKES.  The interleaved list read a
+-- rep past its own TAIL only; the pair reads EVERY rep past the WHOLE
+-- change list.  On this configuration the two agree (the frame's only
+-- unlock IS in the rep's tail), and everywhere in Examples they agree
+-- too; the pair reading is the strictly more permissive one, and it is
+-- what makes the binds a PARALLEL block rather than a nested telescope.
 --
 -- The vacuous-unlock witness that used to live in §1 is now
 -- proof/DualTightness §5, where it is REFUSED.
@@ -57,18 +66,17 @@ open import strong.Reduction
 ------------------------------------------------------------------------
 
 -- Θ with its locks removed (it keeps the binds and the unlocks) …
-dropLocks : CtxMorph → CtxMorph
-dropLocks []             = []
-dropLocks (bind A ∷ Θ)   = bind A ∷ dropLocks Θ
-dropLocks (unlock X ∷ Θ) = unlock X ∷ dropLocks Θ
-dropLocks (lock X ∷ Θ)   = dropLocks Θ
+dropL : List Change → List Change
+dropL []             = []
+dropL (unlock X ∷ S) = unlock X ∷ dropL S
+dropL (lock X ∷ S)   = dropL S
 
--- … and Θ with its whole scope deleted.
+dropLocks : CtxMorph → CtxMorph
+dropLocks Θ = morph (binds Θ) (dropL (changes Θ))
+
+-- … and Θ with its whole change list deleted.
 bindsOnly : CtxMorph → CtxMorph
-bindsOnly []             = []
-bindsOnly (bind A ∷ Θ)   = bind A ∷ bindsOnly Θ
-bindsOnly (unlock X ∷ Θ) = bindsOnly Θ
-bindsOnly (lock X ∷ Θ)   = bindsOnly Θ
+bindsOnly Θ = morph (binds Θ) []
 
 -- All three agree on the type context they leave behind — that is why
 -- the choice looks free until `_⊢ᵐ_` is asked.
@@ -83,10 +91,10 @@ bindsOnly (lock X ∷ Θ)   = bindsOnly Θ
 
 -- Θ₂ UNLOCKS it — legal, because the slot really is locked.
 Θ₂ : CtxMorph
-Θ₂ = unlock 0 ∷ []
+Θ₂ = morph [] (unlock 0 ∷ [])
 
 ⊢ᵐΘ₂ : Δ₆ ⊢ᵐ Θ₂
-⊢ᵐΘ₂ = mw-u (masked (bind `ℕ) , ez , locked nameable-b) mw[]
+⊢ᵐΘ₂ = mw rw[] (sw-u (masked (bind `ℕ) , ez , locked nameable-b) sw[])
 
 _ : interior Θ₂ Δ₆ ≡ bind `ℕ ∷ []
 _ = refl
@@ -94,24 +102,24 @@ _ = refl
 -- An inner frame that BINDS a rep naming that slot — legal at Θ₂'s
 -- interior, where the slot is live.
 Θ₁ : CtxMorph
-Θ₁ = bind (` 0) ∷ []
+Θ₁ = morph (` 0 ∷ []) []
 
 ⊢ᵐΘ₁ : interior Θ₂ Δ₆ ⊢ᵐ Θ₁
-⊢ᵐΘ₁ = mw-b (wf-var (bind `ℕ , ez , nameable-b)) mw[]
+⊢ᵐΘ₁ = mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]
 
 -- THE MERGED FRAME the scope move builds.  Θ₂ carries no binder, so the
--- moved scope keeps its index.
+-- moved change keeps its index.
 Θ₆ : CtxMorph
-Θ₆ = bind (` 0) ∷ unlock 0 ∷ []
+Θ₆ = morph (` 0 ∷ []) (unlock 0 ∷ [])
 
 _ : _≡_ {A = CtxMorph} (Θ₁ ⋉ Θ₂) Θ₆
 _ = refl
 
--- It is well formed over Δ₆ — its rep is read past its OWN tail, i.e.
--- past the unlock, which is where the redex read it.
+-- It is well formed over Δ₆ — its rep is read past its OWN change list,
+-- i.e. past the unlock, which is where the redex read it.
 ⊢ᵐΘ₆ : Δ₆ ⊢ᵐ Θ₆
-⊢ᵐΘ₆ = mw-b (wf-var (bind `ℕ , ez , nameable-b))
-            (mw-u (masked (bind `ℕ) , ez , locked nameable-b) mw[])
+⊢ᵐΘ₆ = mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[])
+          (sw-u (masked (bind `ℕ) , ez , locked nameable-b) sw[])
 
 ------------------------------------------------------------------------
 -- §2  `dropLocks` REFUTED — the moved unlock goes vacuous
@@ -128,7 +136,7 @@ _ = refl
 
 -- The merged frame is read there, and its `unlock 0` has no premise.
 ¬⊢ᵐ-dropLocks : ¬ (interior (dropLocks Θ₂) Δ₆ ⊢ᵐ (Θ₁ ⋉ Θ₂))
-¬⊢ᵐ-dropLocks (mw-b _ (mw-u (_ , ez , ()) _))
+¬⊢ᵐ-dropLocks (mw _ (sw-u (_ , ez , ()) _))
 
 ------------------------------------------------------------------------
 -- §3  `bindsOnly` REFUTED — the frame's own rep loses its unlock
@@ -136,51 +144,57 @@ _ = refl
 
 -- Take the MERGED frame Θ₆ as the next redex's outer frame — it is
 -- reachable, being exactly what §1's move just produced.  Deleting its
--- scope strands its bind rep on the plain exterior.
-_ : _≡_ {A = CtxMorph} (bindsOnly Θ₆) (bind (` 0) ∷ [])
+-- change list strands its bind rep on the plain exterior.
+_ : _≡_ {A = CtxMorph} (bindsOnly Θ₆) (morph (` 0 ∷ []) [])
 _ = refl
 
 ¬⊢ᵗ-rep-plain : ¬ (Δ₆ ⊢ᵗ ` 0)
 ¬⊢ᵗ-rep-plain (wf-var (_ , ez , ()))
 
 ¬⊢ᵐ-bindsOnly : ¬ (Δ₆ ⊢ᵐ bindsOnly Θ₆)
-¬⊢ᵐ-bindsOnly (mw-b w _) = ¬⊢ᵗ-rep-plain w
+¬⊢ᵐ-bindsOnly (mw (rw-b w _) _) = ¬⊢ᵗ-rep-plain w
 
 ------------------------------------------------------------------------
 -- §4  `rewind` DOES BOTH JOBS
 ------------------------------------------------------------------------
 
--- It keeps every entry and runs the inverse scope on top, so the type
+-- It keeps every change and runs the inverse list on top, so the type
 -- context it leaves is the bind prefix over the PLAIN exterior …
-_ : _≡_ {A = CtxMorph} (rewind Θ₂) (lock 0 ∷ unlock 0 ∷ [])
+_ : _≡_ {A = CtxMorph} (rewind Θ₂) (morph [] (lock 0 ∷ unlock 0 ∷ []))
 _ = refl
 
 _ : interior (rewind Θ₂) Δ₆ ≡ Δ₆
 _ = refl
 
-_ : _≡_ {A = CtxMorph} (rewind Θ₆) (lock 0 ∷ bind (` 0) ∷ unlock 0 ∷ [])
+_ : _≡_ {A = CtxMorph} (rewind Θ₆)
+        (morph (` 0 ∷ []) (lock 0 ∷ unlock 0 ∷ []))
 _ = refl
 
-_ : interior (rewind Θ₆) Δ₆ ≡ pushBinds (repsOf Θ₆) Δ₆
+_ : interior (rewind Θ₆) Δ₆ ≡ pushBinds (binds Θ₆) Δ₆
 _ = refl
 
--- … and every premise is still read where the redex read it.
+-- … and every premise is still read where the redex read it.  (The rep of
+-- a REWOUND frame is read past the inverse list too, i.e. past one MORE
+-- unmask than before — `⊢ʳ-⊑` in `⊢ᵐ-rewind` carries it; here the extra
+-- entry is a `lock`, which `applyUnlocks` skips, so the context is
+-- literally the same.)
 ⊢ᵐ-rewind-Θ₂ : Δ₆ ⊢ᵐ rewind Θ₂
-⊢ᵐ-rewind-Θ₂ = mw-l (bind `ℕ , ez , nameable-b) ⊢ᵐΘ₂
+⊢ᵐ-rewind-Θ₂ = mw rw[] (sw-l (bind `ℕ , ez , nameable-b) (mw-changes ⊢ᵐΘ₂))
 
 ⊢ᵐ-rewind-Θ₆ : Δ₆ ⊢ᵐ rewind Θ₆
-⊢ᵐ-rewind-Θ₆ = mw-l (bind `ℕ , ez , nameable-b) ⊢ᵐΘ₆
+⊢ᵐ-rewind-Θ₆ = mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[])
+                  (sw-l (bind `ℕ , ez , nameable-b) (mw-changes ⊢ᵐΘ₆))
 
 -- THE MERGED FRAME IS WELL FORMED OVER IT.
 ⊢ᵐ-merged : interior (rewind Θ₂) Δ₆ ⊢ᵐ (Θ₁ ⋉ Θ₂)
 ⊢ᵐ-merged = ⊢ᵐΘ₆
 
--- AND THIS IS WHY `mw-b` READS ITS REP ON `unlockedScope Θ Δ`.  The
--- merged frame's rep `` ` 0 `` is NOT well formed on the plain exterior
--- (`¬⊢ᵗ-rep-plain`) and IS well formed past the frame's own tail — so a
--- SIMULTANEOUS `mw-b`, reading every rep on Δ, would refuse the frame the
--- move builds.  Reading it past the tail's UNMASKS (and never past the
--- tail's locks — `unlockedScope`, not `scope`) is what makes both the
--- move and TyPeelR's `bind A ∷ Θ` well formed at once.
-⊢ᵗ-rep-past-tail : unlockedScope (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
-⊢ᵗ-rep-past-tail = wf-var (bind `ℕ , ez , nameable-b)
+-- AND THIS IS WHY THE REP HALF READS ITS REPS ON `unlockedScope Θ Δ`.
+-- The merged frame's rep `` ` 0 `` is NOT well formed on the plain
+-- exterior (`¬⊢ᵗ-rep-plain`) and IS well formed past the frame's own
+-- change list — so a rep reading on Δ would refuse the frame the move
+-- builds.  Reading it past the change list's UNMASKS (and never past its
+-- locks — `applyUnlocks`, not `applyChanges`) is what makes both the move
+-- and TyPeelR's prepended bind well formed at once.
+⊢ᵗ-rep-past-changes : applyUnlocks (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
+⊢ᵗ-rep-past-changes = wf-var (bind `ℕ , ez , nameable-b)

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -4,7 +4,7 @@ module strong.proof.PeelDual where
 -- EXACT.
 --
 --   interior (dual Θ) (interior Θ Δ)
---     ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ        (given Δ ⊢ᵐ Θ)
+--     ≡ map masked (pushBinds (binds Θ) []) ++ Δ         (given Δ ⊢ᵐ Θ)
 --   convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ
 --
 -- The first is (†): the crossing argument's frame IS THE EXTERIOR, one
@@ -17,13 +17,18 @@ module strong.proof.PeelDual where
 --
 -- The two repairs (strong.CtxMorph §3) that buy it:
 --   `unlock X ↦ lock (n + X)`  the dual RESTORES what Θ unlocked, sound
---                              because `mw-u` refuses a vacuous unlock
+--                              because `sw-u` refuses a vacuous unlock
 --                              (`mask-unmask`, strong.Ctx §6b);
---   the list is REVERSED        because `scope` applies HEAD-LAST.
+--   the list is REVERSED        because `applyChanges` applies HEAD-LAST.
 --
---   §1  `⊢ᵐ-++` — the SEQUENTIAL judgement of an append (also used by
+-- WITH THE PAIR the dual is entirely a CHANGE-LIST construction: it binds
+-- nothing, so `binds (dual Θ) ≡ []` and `numBinds (dual Θ) ≡ 0` hold by
+-- REFLEXIVITY and the four `repsOf-…` filtering lemmas this module used
+-- to need are gone.
+--
+--   §1  `⊢ˢ-++` — the SEQUENTIAL judgement of an append (also used by
 --       proof/MoveScope)
---   §2  the dual's scope: the frame identity, its `⊢ᵐ`, and the
+--   §2  the dual's change list: the frame identity, its `⊢ˢ`, and the
 --       conversion-context identity
 --   §3  (†) and `convCtx-dual`
 --   §4  the crossing, and `preserve-Peel`
@@ -51,20 +56,20 @@ open import strong.proof.Canonical using (shiftBy-⇒; conv-tgt≡)
 -- Structural helpers
 ------------------------------------------------------------------------
 
-scope-++ : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
-  → scope (Θ₁ ++ Θ₂) Δ ≡ scope Θ₁ (scope Θ₂ Δ)
-scope-++ []              Θ₂ Δ = refl
-scope-++ (bind A ∷ Θ₁)   Θ₂ Δ = scope-++ Θ₁ Θ₂ Δ
-scope-++ (unlock X ∷ Θ₁) Θ₂ Δ = cong (unmask X) (scope-++ Θ₁ Θ₂ Δ)
-scope-++ (lock X ∷ Θ₁)   Θ₂ Δ = cong (mask X) (scope-++ Θ₁ Θ₂ Δ)
+applyChanges-++ : (S₁ S₂ : List Change) (Δ : Ctxᵗ)
+  → applyChanges (S₁ ++ S₂) Δ ≡ applyChanges S₁ (applyChanges S₂ Δ)
+applyChanges-++ []              S₂ Δ = refl
+applyChanges-++ (unlock X ∷ S₁) S₂ Δ =
+  cong (unmask X) (applyChanges-++ S₁ S₂ Δ)
+applyChanges-++ (lock X ∷ S₁)   S₂ Δ =
+  cong (mask X) (applyChanges-++ S₁ S₂ Δ)
 
-unlockedScope-++ : (Θ₁ Θ₂ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (Θ₁ ++ Θ₂) Δ ≡ unlockedScope Θ₁ (unlockedScope Θ₂ Δ)
-unlockedScope-++ []              Θ₂ Δ = refl
-unlockedScope-++ (bind A ∷ Θ₁)   Θ₂ Δ = unlockedScope-++ Θ₁ Θ₂ Δ
-unlockedScope-++ (unlock X ∷ Θ₁) Θ₂ Δ =
-  cong (unmask X) (unlockedScope-++ Θ₁ Θ₂ Δ)
-unlockedScope-++ (lock X ∷ Θ₁)   Θ₂ Δ = unlockedScope-++ Θ₁ Θ₂ Δ
+applyUnlocks-++ : (S₁ S₂ : List Change) (Δ : Ctxᵗ)
+  → applyUnlocks (S₁ ++ S₂) Δ ≡ applyUnlocks S₁ (applyUnlocks S₂ Δ)
+applyUnlocks-++ []              S₂ Δ = refl
+applyUnlocks-++ (unlock X ∷ S₁) S₂ Δ =
+  cong (unmask X) (applyUnlocks-++ S₁ S₂ Δ)
+applyUnlocks-++ (lock X ∷ S₁)   S₂ Δ = applyUnlocks-++ S₁ S₂ Δ
 
 pushBinds-++ : (As : List Ty) (Δ : Ctxᵗ) → pushBinds As Δ ≡ pushBinds As [] ++ Δ
 pushBinds-++ []       Δ = refl
@@ -91,118 +96,115 @@ updateAt-app-tail f []       X Δ = refl
 updateAt-app-tail f (E ∷ Ow) X Δ = cong (E ∷_) (updateAt-app-tail f Ow X Δ)
 
 ------------------------------------------------------------------------
--- §1  `⊢ᵐ-++` — the sequential judgement of an APPEND
+-- §1  `⊢ˢ-++` — the sequential judgement of an APPEND
 ------------------------------------------------------------------------
 
--- `scope` applies its list HEAD-LAST, so in `Θ ++ Ψ` it is Ψ that runs
--- FIRST: Θ is judged over `scope Ψ Δ`, Ψ over Δ.  Each of the three
--- premises then lands on the nose except the rep, which moves from
--- `scope Ψ Δ` to `unlockedScope Ψ Δ` — MORE nameable
--- (`scope⊑unlockedScope`), so `⊑-wf` carries it.
-⊢ᵐ-++ : (Θ Ψ : CtxMorph) {Δ : Ctxᵗ}
-  → scope Ψ Δ ⊢ᵐ Θ → Δ ⊢ᵐ Ψ → Δ ⊢ᵐ (Θ ++ Ψ)
-⊢ᵐ-++ []             Ψ mw[]        bΨ = bΨ
-⊢ᵐ-++ (bind A ∷ Θ)   Ψ {Δ = Δ} (mw-b w b)  bΨ =
-  mw-b (subst (λ Ξ → Ξ ⊢ᵗ A) (sym (unlockedScope-++ Θ Ψ Δ))
-              (⊑-wf (⊑-unlockedScope Θ (scope⊑unlockedScope Ψ Δ)) w))
-       (⊢ᵐ-++ Θ Ψ b bΨ)
-⊢ᵐ-++ (lock X ∷ Θ)   Ψ {Δ = Δ} (mw-l tv b) bΨ =
-  mw-l (subst (λ Ξ → Ξ ∋tv X) (sym (scope-++ Θ Ψ Δ)) tv) (⊢ᵐ-++ Θ Ψ b bΨ)
-⊢ᵐ-++ (unlock X ∷ Θ) Ψ {Δ = Δ} (mw-u lk b) bΨ =
-  mw-u (subst (λ Ξ → Ξ ∋lk X) (sym (scope-++ Θ Ψ Δ)) lk) (⊢ᵐ-++ Θ Ψ b bΨ)
+-- `applyChanges` applies its list HEAD-LAST, so in `S ++ T` it is T that
+-- runs FIRST: S is judged over `applyChanges T Δ`, T over Δ.  Both
+-- premises land ON THE NOSE.  Under the interleaved list this lemma also
+-- had to move a REP from `scope Ψ Δ` to `unlockedScope Ψ Δ` along
+-- `⊑-wf`; with the pair there is no rep in it at all.
+⊢ˢ-++ : (S T : List Change) {Δ : Ctxᵗ}
+  → applyChanges T Δ ⊢ˢ S → Δ ⊢ˢ T → Δ ⊢ˢ (S ++ T)
+⊢ˢ-++ []             T sw[]        bT = bT
+⊢ˢ-++ (lock X ∷ S)   T {Δ = Δ} (sw-l tv b) bT =
+  sw-l (subst (λ Ξ → Ξ ∋tv X) (sym (applyChanges-++ S T Δ)) tv)
+       (⊢ˢ-++ S T b bT)
+⊢ˢ-++ (unlock X ∷ S) T {Δ = Δ} (sw-u lk b) bT =
+  sw-u (subst (λ Ξ → Ξ ∋lk X) (sym (applyChanges-++ S T Δ)) lk)
+       (⊢ˢ-++ S T b bT)
 
 ------------------------------------------------------------------------
--- §2  The dual's scope half
+-- §2  The dual's change list
 ------------------------------------------------------------------------
 
--- THE FRAME IDENTITY.  `dualScope` undoes `scope` on the nose — and this
--- is where the two repairs are paid for: the `unlock` case needs
+-- THE FRAME IDENTITY.  `dualScope` undoes `applyChanges` on the nose —
+-- and this is where the two repairs are paid for: the `unlock` case needs
 -- `mask ∘ unmask = id`, which holds AT A LOCKED SLOT AND NOWHERE ELSE
 -- (`mask-unmask`), and the reversal is what puts each inverse entry where
--- `scope` will apply it.
-scope-dualScope : (As : List Ty) (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
-  → scope (dualScope (length As) Θ) (pushBinds As (scope Θ Δ)) ≡ pushBinds As Δ
-scope-dualScope As []             mw[]         = refl
-scope-dualScope As (bind A ∷ Θ)   (mw-b _ b)   = scope-dualScope As Θ b
-scope-dualScope As (lock X ∷ Θ)   {Δ = Δ} (mw-l tv b)
-  rewrite scope-++ (dualScope (length As) Θ) (unlock (length As + X) ∷ [])
-                   (pushBinds As (mask X (scope Θ Δ)))
-        | updateAt-pushBinds unmaskEnt As X (mask X (scope Θ Δ))
-        | unmask-mask X (scope Θ Δ) = scope-dualScope As Θ b
-scope-dualScope As (unlock X ∷ Θ) {Δ = Δ} (mw-u lk b)
-  rewrite scope-++ (dualScope (length As) Θ) (lock (length As + X) ∷ [])
-                   (pushBinds As (unmask X (scope Θ Δ)))
-        | updateAt-pushBinds masked As X (unmask X (scope Θ Δ))
-        | mask-unmask lk = scope-dualScope As Θ b
+-- `applyChanges` will apply it.
+applyChanges-dualScope : (As : List Ty) (S : List Change) {Δ : Ctxᵗ} → Δ ⊢ˢ S
+  → applyChanges (dualScope (length As) S) (pushBinds As (applyChanges S Δ))
+      ≡ pushBinds As Δ
+applyChanges-dualScope As []             sw[]         = refl
+applyChanges-dualScope As (lock X ∷ S)   {Δ = Δ} (sw-l tv b)
+  rewrite applyChanges-++ (dualScope (length As) S)
+                          (unlock (length As + X) ∷ [])
+                          (pushBinds As (mask X (applyChanges S Δ)))
+        | updateAt-pushBinds unmaskEnt As X (mask X (applyChanges S Δ))
+        | unmask-mask X (applyChanges S Δ) = applyChanges-dualScope As S b
+applyChanges-dualScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b)
+  rewrite applyChanges-++ (dualScope (length As) S)
+                          (lock (length As + X) ∷ [])
+                          (pushBinds As (unmask X (applyChanges S Δ)))
+        | updateAt-pushBinds masked As X (unmask X (applyChanges S Δ))
+        | mask-unmask lk = applyChanges-dualScope As S b
 
--- … AND IT IS WELL FORMED WHERE IT LANDS.  Θ's `lock X` becomes an
--- `unlock` at a slot the lock itself just masked (`mask-∋lk`); Θ's
+-- … AND IT IS WELL FORMED WHERE IT LANDS.  S's `lock X` becomes an
+-- `unlock` at a slot the lock itself just masked (`mask-∋lk`); S's
 -- `unlock X` becomes a `lock` at a slot the unlock itself just exposed
--- (`unmask-∋tv`).  Both premises come straight out of Θ's own.
-⊢ᵐ-dualScope : (As : List Ty) (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
-  → pushBinds As (scope Θ Δ) ⊢ᵐ dualScope (length As) Θ
-⊢ᵐ-dualScope As []             mw[]       = mw[]
-⊢ᵐ-dualScope As (bind A ∷ Θ)   (mw-b _ b) = ⊢ᵐ-dualScope As Θ b
-⊢ᵐ-dualScope As (lock X ∷ Θ)   {Δ = Δ} (mw-l tv b) =
-  ⊢ᵐ-++ (dualScope (length As) Θ) (unlock (length As + X) ∷ [])
-        (subst (λ Ξ → Ξ ⊢ᵐ dualScope (length As) Θ) (sym eq)
-               (⊢ᵐ-dualScope As Θ b))
-        (mw-u (pushBinds-∋lk As (mask-∋lk tv)) mw[])
+-- (`unmask-∋tv`).  Both premises come straight out of S's own.
+⊢ˢ-dualScope : (As : List Ty) (S : List Change) {Δ : Ctxᵗ} → Δ ⊢ˢ S
+  → pushBinds As (applyChanges S Δ) ⊢ˢ dualScope (length As) S
+⊢ˢ-dualScope As []             sw[]       = sw[]
+⊢ˢ-dualScope As (lock X ∷ S)   {Δ = Δ} (sw-l tv b) =
+  ⊢ˢ-++ (dualScope (length As) S) (unlock (length As + X) ∷ [])
+        (subst (λ Ξ → Ξ ⊢ˢ dualScope (length As) S) (sym eq)
+               (⊢ˢ-dualScope As S b))
+        (sw-u (pushBinds-∋lk As (mask-∋lk tv)) sw[])
   where
-  eq : unmask (length As + X) (pushBinds As (mask X (scope Θ Δ)))
-         ≡ pushBinds As (scope Θ Δ)
-  eq = trans (updateAt-pushBinds unmaskEnt As X (mask X (scope Θ Δ)))
-             (cong (pushBinds As) (unmask-mask X (scope Θ Δ)))
-⊢ᵐ-dualScope As (unlock X ∷ Θ) {Δ = Δ} (mw-u lk b) =
-  ⊢ᵐ-++ (dualScope (length As) Θ) (lock (length As + X) ∷ [])
-        (subst (λ Ξ → Ξ ⊢ᵐ dualScope (length As) Θ) (sym eq)
-               (⊢ᵐ-dualScope As Θ b))
-        (mw-l (pushBinds-∋tv As (unmask-∋tv lk)) mw[])
+  eq : unmask (length As + X) (pushBinds As (mask X (applyChanges S Δ)))
+         ≡ pushBinds As (applyChanges S Δ)
+  eq = trans (updateAt-pushBinds unmaskEnt As X (mask X (applyChanges S Δ)))
+             (cong (pushBinds As) (unmask-mask X (applyChanges S Δ)))
+⊢ˢ-dualScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b) =
+  ⊢ˢ-++ (dualScope (length As) S) (lock (length As + X) ∷ [])
+        (subst (λ Ξ → Ξ ⊢ˢ dualScope (length As) S) (sym eq)
+               (⊢ˢ-dualScope As S b))
+        (sw-l (pushBinds-∋tv As (unmask-∋tv lk)) sw[])
   where
-  eq : mask (length As + X) (pushBinds As (unmask X (scope Θ Δ)))
-         ≡ pushBinds As (scope Θ Δ)
-  eq = trans (updateAt-pushBinds masked As X (unmask X (scope Θ Δ)))
+  eq : mask (length As + X) (pushBinds As (unmask X (applyChanges S Δ)))
+         ≡ pushBinds As (applyChanges S Δ)
+  eq = trans (updateAt-pushBinds masked As X (unmask X (applyChanges S Δ)))
              (cong (pushBinds As) (mask-unmask lk))
 
--- THE CONVERSION CONTEXT sees only the dual's UNLOCKS, i.e. only Θ's
--- LOCKS undone — so it is Θ's own conversion context, with no premise at
--- all.  (A composition of unmasks commutes, which is why the reversal is
--- invisible here.)
-dualScope-unmask-comm : (m : ℕ) (Ψ : CtxMorph) (Y : ℕ) (Ξ : Ctxᵗ)
-  → unlockedScope (dualScope m Ψ) (unmask Y Ξ)
-      ≡ unmask Y (unlockedScope (dualScope m Ψ) Ξ)
+-- THE CONVERSION CONTEXT sees only the dual's UNLOCKS, i.e. only S's
+-- LOCKS undone — so it is the original conversion context, with no
+-- premise at all.  (A composition of unmasks commutes, which is why the
+-- reversal is invisible here.)
+dualScope-unmask-comm : (m : ℕ) (S : List Change) (Y : ℕ) (Ξ : Ctxᵗ)
+  → applyUnlocks (dualScope m S) (unmask Y Ξ)
+      ≡ unmask Y (applyUnlocks (dualScope m S) Ξ)
 dualScope-unmask-comm m []             Y Ξ = refl
-dualScope-unmask-comm m (bind A ∷ Ψ)   Y Ξ = dualScope-unmask-comm m Ψ Y Ξ
-dualScope-unmask-comm m (unlock X ∷ Ψ) Y Ξ
-  rewrite unlockedScope-++ (dualScope m Ψ) (lock (m + X) ∷ []) (unmask Y Ξ)
-        | unlockedScope-++ (dualScope m Ψ) (lock (m + X) ∷ []) Ξ =
-  dualScope-unmask-comm m Ψ Y Ξ
-dualScope-unmask-comm m (lock X ∷ Ψ)   Y Ξ
-  rewrite unlockedScope-++ (dualScope m Ψ) (unlock (m + X) ∷ []) (unmask Y Ξ)
-        | unlockedScope-++ (dualScope m Ψ) (unlock (m + X) ∷ []) Ξ
+dualScope-unmask-comm m (unlock X ∷ S) Y Ξ
+  rewrite applyUnlocks-++ (dualScope m S) (lock (m + X) ∷ []) (unmask Y Ξ)
+        | applyUnlocks-++ (dualScope m S) (lock (m + X) ∷ []) Ξ =
+  dualScope-unmask-comm m S Y Ξ
+dualScope-unmask-comm m (lock X ∷ S)   Y Ξ
+  rewrite applyUnlocks-++ (dualScope m S) (unlock (m + X) ∷ []) (unmask Y Ξ)
+        | applyUnlocks-++ (dualScope m S) (unlock (m + X) ∷ []) Ξ
         | updateAt-updateAt-comm unmaskEnt (m + X) Y Ξ =
-  dualScope-unmask-comm m Ψ Y (unmask (m + X) Ξ)
+  dualScope-unmask-comm m S Y (unmask (m + X) Ξ)
 
-unlockedScope-dualScope : (As : List Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (dualScope (length As) Θ) (pushBinds As (scope Θ Δ))
-      ≡ pushBinds As (unlockedScope Θ Δ)
-unlockedScope-dualScope As []             Δ = refl
-unlockedScope-dualScope As (bind A ∷ Θ)   Δ = unlockedScope-dualScope As Θ Δ
-unlockedScope-dualScope As (lock X ∷ Θ)   Δ
-  rewrite unlockedScope-++ (dualScope (length As) Θ)
-                           (unlock (length As + X) ∷ [])
-                           (pushBinds As (mask X (scope Θ Δ)))
-        | updateAt-pushBinds unmaskEnt As X (mask X (scope Θ Δ))
-        | unmask-mask X (scope Θ Δ) = unlockedScope-dualScope As Θ Δ
-unlockedScope-dualScope As (unlock X ∷ Θ) Δ
-  rewrite unlockedScope-++ (dualScope (length As) Θ)
-                           (lock (length As + X) ∷ [])
-                           (pushBinds As (unmask X (scope Θ Δ)))
-        | sym (updateAt-pushBinds unmaskEnt As X (scope Θ Δ))
-        | dualScope-unmask-comm (length As) Θ (length As + X)
-                                (pushBinds As (scope Θ Δ))
-        | unlockedScope-dualScope As Θ Δ =
-  updateAt-pushBinds unmaskEnt As X (unlockedScope Θ Δ)
+applyUnlocks-dualScope : (As : List Ty) (S : List Change) (Δ : Ctxᵗ)
+  → applyUnlocks (dualScope (length As) S) (pushBinds As (applyChanges S Δ))
+      ≡ pushBinds As (applyUnlocks S Δ)
+applyUnlocks-dualScope As []             Δ = refl
+applyUnlocks-dualScope As (lock X ∷ S)   Δ
+  rewrite applyUnlocks-++ (dualScope (length As) S)
+                          (unlock (length As + X) ∷ [])
+                          (pushBinds As (mask X (applyChanges S Δ)))
+        | updateAt-pushBinds unmaskEnt As X (mask X (applyChanges S Δ))
+        | unmask-mask X (applyChanges S Δ) = applyUnlocks-dualScope As S Δ
+applyUnlocks-dualScope As (unlock X ∷ S) Δ
+  rewrite applyUnlocks-++ (dualScope (length As) S)
+                          (lock (length As + X) ∷ [])
+                          (pushBinds As (unmask X (applyChanges S Δ)))
+        | sym (updateAt-pushBinds unmaskEnt As X (applyChanges S Δ))
+        | dualScope-unmask-comm (length As) S (length As + X)
+                                (pushBinds As (applyChanges S Δ))
+        | applyUnlocks-dualScope As S Δ =
+  updateAt-pushBinds unmaskEnt As X (applyUnlocks S Δ)
 
 ------------------------------------------------------------------------
 -- §3  (†) and `convCtx-dual`
@@ -210,83 +212,61 @@ unlockedScope-dualScope As (unlock X ∷ Θ) Δ
 
 -- `hideBinds` masks the whole bind prefix.
 hideBinds-cons : (k : ℕ) (E : Ent) (Ξ : Ctxᵗ)
-  → scope (hideBinds (suc k)) (E ∷ Ξ) ≡ masked E ∷ scope (hideBinds k) Ξ
+  → applyChanges (hideBinds (suc k)) (E ∷ Ξ)
+      ≡ masked E ∷ applyChanges (hideBinds k) Ξ
 hideBinds-cons zero    E Ξ = refl
 hideBinds-cons (suc k) E Ξ
   rewrite hideBinds-cons k E Ξ = refl
 
 stepB : (Ow Δ : Ctxᵗ)
-  → scope (hideBinds (length Ow)) (Ow ++ Δ) ≡ map masked Ow ++ Δ
+  → applyChanges (hideBinds (length Ow)) (Ow ++ Δ) ≡ map masked Ow ++ Δ
 stepB []       Δ = refl
 stepB (E ∷ Ow) Δ
   rewrite hideBinds-cons (length Ow) E (Ow ++ Δ)
         | stepB Ow Δ = refl
 
--- dual produces no binders, so its `pushBinds` is the identity.
-repsOf-hideBinds : (k : ℕ) → repsOf (hideBinds k) ≡ []
-repsOf-hideBinds zero    = refl
-repsOf-hideBinds (suc k) = repsOf-hideBinds k
-
-repsOf-++ : (Θ₁ Θ₂ : CtxMorph) → repsOf (Θ₁ ++ Θ₂) ≡ repsOf Θ₁ ++ repsOf Θ₂
-repsOf-++ []              Θ₂ = refl
-repsOf-++ (bind A ∷ Θ₁)   Θ₂ = cong (_ ∷_) (repsOf-++ Θ₁ Θ₂)
-repsOf-++ (unlock X ∷ Θ₁) Θ₂ = repsOf-++ Θ₁ Θ₂
-repsOf-++ (lock X ∷ Θ₁)   Θ₂ = repsOf-++ Θ₁ Θ₂
-
-repsOf-dualScope : (n : ℕ) (Θ : CtxMorph) → repsOf (dualScope n Θ) ≡ []
-repsOf-dualScope n []             = refl
-repsOf-dualScope n (bind A ∷ Θ)   = repsOf-dualScope n Θ
-repsOf-dualScope n (unlock X ∷ Θ)
-  rewrite repsOf-++ (dualScope n Θ) (lock (n + X) ∷ [])
-        | repsOf-dualScope n Θ = refl
-repsOf-dualScope n (lock X ∷ Θ)
-  rewrite repsOf-++ (dualScope n Θ) (unlock (n + X) ∷ [])
-        | repsOf-dualScope n Θ = refl
-
-repsOf-dual : (Θ : CtxMorph) → repsOf (dual Θ) ≡ []
-repsOf-dual Θ rewrite repsOf-++ (hideBinds (numBinds Θ))
-                                (dualScope (numBinds Θ) Θ)
-                   | repsOf-hideBinds (numBinds Θ)
-                   | repsOf-dualScope (numBinds Θ) Θ = refl
-
+-- THE DUAL CARRIES NO BINDS, and with the pair that is a fact about the
+-- constructor: it holds BY REFLEXIVITY.  The interleaved list needed four
+-- filtering lemmas to say it (`repsOf-hideBinds`, `repsOf-++`,
+-- `repsOf-dualScope`, `repsOf-dual`) and they are all gone.
 numBinds-dual : (Θ : CtxMorph) → numBinds (dual Θ) ≡ 0
-numBinds-dual Θ = cong length (repsOf-dual Θ)
+numBinds-dual Θ = refl
 
 -- (†) THE CROSSING FRAME IS THE EXTERIOR, ONE BIND PREFIX IN.
 interior-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ
   → interior (dual Θ) (interior Θ Δ)
-      ≡ map masked (pushBinds (repsOf Θ) []) ++ Δ
-interior-dual Θ Δ mwΘ
-  rewrite repsOf-dual Θ
-  = go
+      ≡ map masked (pushBinds (binds Θ) []) ++ Δ
+interior-dual Θ Δ mwΘ = go
   where
   Ow : Ctxᵗ
-  Ow = pushBinds (repsOf Θ) []
+  Ow = pushBinds (binds Θ) []
   lenOw : length Ow ≡ numBinds Θ
-  lenOw = length-pushBinds (repsOf Θ)
-  go : scope (dual Θ) (pushBinds (repsOf Θ) (scope Θ Δ)) ≡ map masked Ow ++ Δ
-  go rewrite scope-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) Θ)
-                      (pushBinds (repsOf Θ) (scope Θ Δ))
-           | scope-dualScope (repsOf Θ) Θ mwΘ
-           | pushBinds-++ (repsOf Θ) Δ
+  lenOw = length-pushBinds (binds Θ)
+  go : applyChanges (changes (dual Θ)) (pushBinds (binds Θ) (scope Θ Δ))
+         ≡ map masked Ow ++ Δ
+  go rewrite applyChanges-++ (hideBinds (numBinds Θ))
+                             (dualScope (numBinds Θ) (changes Θ))
+                             (pushBinds (binds Θ) (scope Θ Δ))
+           | applyChanges-dualScope (binds Θ) (changes Θ) (mw-changes mwΘ)
+           | pushBinds-++ (binds Θ) Δ
            | sym lenOw = stepB Ow Δ
 
--- unlockedScope skips locks, so hideBinds is invisible to the
+-- `applyUnlocks` skips locks, so `hideBinds` is invisible to the
 -- conversion context.
-unlockedScope-hideBinds : (k : ℕ) (Ξ : Ctxᵗ) → unlockedScope (hideBinds k) Ξ ≡ Ξ
-unlockedScope-hideBinds zero    Ξ = refl
-unlockedScope-hideBinds (suc k) Ξ = unlockedScope-hideBinds k Ξ
+applyUnlocks-hideBinds : (k : ℕ) (Ξ : Ctxᵗ) → applyUnlocks (hideBinds k) Ξ ≡ Ξ
+applyUnlocks-hideBinds zero    Ξ = refl
+applyUnlocks-hideBinds (suc k) Ξ = applyUnlocks-hideBinds k Ξ
 
 convCtx-dual : (Θ : CtxMorph) (Δ : Ctxᵗ)
   → convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ
 convCtx-dual Θ Δ
-  rewrite repsOf-dual Θ
-        | unlockedScope-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) Θ)
-                           (pushBinds (repsOf Θ) (scope Θ Δ))
-        | unlockedScope-hideBinds (numBinds Θ)
-            (unlockedScope (dualScope (numBinds Θ) Θ)
-                           (pushBinds (repsOf Θ) (scope Θ Δ))) =
-  unlockedScope-dualScope (repsOf Θ) Θ Δ
+  rewrite applyUnlocks-++ (hideBinds (numBinds Θ))
+                          (dualScope (numBinds Θ) (changes Θ))
+                          (pushBinds (binds Θ) (scope Θ Δ))
+        | applyUnlocks-hideBinds (numBinds Θ)
+            (applyUnlocks (dualScope (numBinds Θ) (changes Θ))
+                          (pushBinds (binds Θ) (scope Θ Δ))) =
+  applyUnlocks-dualScope (binds Θ) (changes Θ) Δ
 
 ------------------------------------------------------------------------
 -- §4  The crossing, and `preserve-Peel`
@@ -301,26 +281,30 @@ pushBinds-∋tv-lt (A ∷ As) Ξ (suc j) (s≤s lt) with pushBinds-∋tv-lt As �
 
 -- `hideBinds k` masks slots 0 … k-1, so it misses every slot ≥ k.
 hideBinds-∋tv : (k : ℕ) {Ξ : Ctxᵗ} {Y : ℕ} → k ≤ Y → Ξ ∋tv Y
-  → scope (hideBinds k) Ξ ∋tv Y
+  → applyChanges (hideBinds k) Ξ ∋tv Y
 hideBinds-∋tv zero    le tv = tv
 hideBinds-∋tv (suc k) le tv with hideBinds-∋tv k (≤-trans (n≤1+n k) le) tv
 ... | E , d , v = E , updateAt-miss masked masked-comm (<⇒≢ le) d , v
 
-⊢ᵐ-hideBinds : (k : ℕ) (Ξ : Ctxᵗ)
-  → ((j : ℕ) → j < k → Ξ ∋tv j) → Ξ ⊢ᵐ hideBinds k
-⊢ᵐ-hideBinds zero    Ξ h = mw[]
-⊢ᵐ-hideBinds (suc k) Ξ h =
-  mw-l (hideBinds-∋tv k ≤-refl (h k ≤-refl))
-       (⊢ᵐ-hideBinds k Ξ (λ j lt → h j (m≤n⇒m≤1+n lt)))
+⊢ˢ-hideBinds : (k : ℕ) (Ξ : Ctxᵗ)
+  → ((j : ℕ) → j < k → Ξ ∋tv j) → Ξ ⊢ˢ hideBinds k
+⊢ˢ-hideBinds zero    Ξ h = sw[]
+⊢ˢ-hideBinds (suc k) Ξ h =
+  sw-l (hideBinds-∋tv k ≤-refl (h k ≤-refl))
+       (⊢ˢ-hideBinds k Ξ (λ j lt → h j (m≤n⇒m≤1+n lt)))
 
+-- THE DUAL'S OWN `⊢ᵐ`.  Its REP half is EMPTY (`rw[]`) — the dual binds
+-- nothing — so the whole content is the change half.
 ⊢ᵐ-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ → interior Θ Δ ⊢ᵐ dual Θ
 ⊢ᵐ-dual Θ Δ mwΘ =
-  ⊢ᵐ-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) Θ)
-        (subst (λ Ξ → Ξ ⊢ᵐ hideBinds (numBinds Θ))
-               (sym (scope-dualScope (repsOf Θ) Θ mwΘ))
-               (⊢ᵐ-hideBinds (numBinds Θ) (pushBinds (repsOf Θ) Δ)
-                  (λ j lt → pushBinds-∋tv-lt (repsOf Θ) Δ j lt)))
-        (⊢ᵐ-dualScope (repsOf Θ) Θ mwΘ)
+  mw rw[]
+     (⊢ˢ-++ (hideBinds (numBinds Θ)) (dualScope (numBinds Θ) (changes Θ))
+        (subst (λ Ξ → Ξ ⊢ˢ hideBinds (numBinds Θ))
+               (sym (applyChanges-dualScope (binds Θ) (changes Θ)
+                       (mw-changes mwΘ)))
+               (⊢ˢ-hideBinds (numBinds Θ) (pushBinds (binds Θ) Δ)
+                  (λ j lt → pushBinds-∋tv-lt (binds Θ) Δ j lt)))
+        (⊢ˢ-dualScope (binds Θ) (changes Θ) (mw-changes mwΘ)))
 
 ------------------------------------------------------------------------
 -- Renaming identity/composition and wkN = shiftBy
@@ -388,11 +372,11 @@ crossing Θ {Δ} {W} {A} mwΘ ⊢W =
         step2
   where
   Ow : Ctxᵗ
-  Ow = pushBinds (repsOf Θ) []
+  Ow = pushBinds (binds Θ) []
   Ξ : Ctxᵗ
   Ξ = map masked Ow
   len-eq : length Ξ ≡ numBinds Θ
-  len-eq = trans (map-length masked Ow) (length-pushBinds (repsOf Θ))
+  len-eq = trans (map-length masked Ow) (length-pushBinds (binds Θ))
   step0 : (Ξ ++ Δ) ∣ [] ⊢ renᴹ (wkN (length Ξ)) W ⦂ renameᵗ (wkN (length Ξ)) A
   step0 = ⊢rename (Ren-wkN Ξ) (Inj-wkN (length Ξ)) ⊢W
   step1 : (Ξ ++ Δ) ∣ [] ⊢ renᴹ (wkN (length Ξ)) W ⦂ shiftBy (length Ξ) A
@@ -407,20 +391,21 @@ crossing Θ {Δ} {W} {A} mwΘ ⊢W =
 
 preserve-Peel : PeelCase
 preserve-Peel {Δ} {V} {W} {Θ} {s} {t} {C} vV vW
-         (⊢· (env {Bᵢ = Bᵢ} {Bₑ = Aarg⇒C} mw ⊢V ⊢c wE) ⊢W)
+         (⊢· (env {Bᵢ = Bᵢ} {Bₑ = Aarg⇒C} mwᵥ ⊢V ⊢c wE) ⊢W)
   with wE
 ... | wf-⇒ wAarg wC
   with conv-tgt≡ (shiftBy-⇒ (numBinds Θ) _ _) ⊢c
 ...  | conv-fun ⊢s ⊢t
   with ⊢ᵗ-of CtxWf-[] ⊢V
 ...   | wf-⇒ wAᵈ wBᶜ =
-  env mw (⊢· ⊢V ⊢argcross) ⊢t wC
+  env mwᵥ (⊢· ⊢V ⊢argcross) ⊢t wC
   where
+  -- `numBinds (dual Θ)` REDUCES to 0, so no rewrite is needed here any
+  -- more (the interleaved list had to `rewrite numBinds-dual Θ`).
   ⊢s-tr : convCtx (dual Θ) (interior Θ Δ) ⊢ s
             ∶ shiftBy (numBinds Θ) _ ⇝ shiftBy (numBinds (dual Θ)) _
-  ⊢s-tr rewrite numBinds-dual Θ =
-    subst (λ Ct → Ct ⊢ s ∶ shiftBy (numBinds Θ) _ ⇝ _)
-          (sym (convCtx-dual Θ Δ)) ⊢s
+  ⊢s-tr = subst (λ Ct → Ct ⊢ s ∶ shiftBy (numBinds Θ) _ ⇝ _)
+                (sym (convCtx-dual Θ Δ)) ⊢s
   ⊢argcross : interior Θ Δ ∣ [] ⊢ wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫ ⦂ _
-  ⊢argcross = env (⊢ᵐ-dual Θ Δ mw)
-                  (crossing Θ mw ⊢W) ⊢s-tr wAᵈ
+  ⊢argcross = env (⊢ᵐ-dual Θ Δ mwᵥ)
+                  (crossing Θ mwᵥ ⊢W) ⊢s-tr wAᵈ

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -404,11 +404,11 @@ shiftBy-ℕ⁻ (suc n) eq = shiftBy-ℕ⁻ n (ren-ℕ⁻ eq)
 preserve-TyBeta : ∀ {N B A}
   → Δ ∣ [] ⊢ (Λ N) ·[ B , A ] ⦂ C
     ------------------------------------------------------
-  → Δ ∣ [] ⊢ N ⟪ bind A ∷ [] , reveal 0 B ⟫ ⦂ C
+  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫ ⦂ C
 preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
   with ⊢ᵗ-of CtxWf-[] (⊢Λ ⊢N)
 ... | wf-∀ wB =
-  env (mw-b wA mw[])
+  env (mw (rw-b wA rw[]) sw[])
       (⊢retag refine ⊢N)
       conv
       (wf-[]ᵗ wB wA)
@@ -448,7 +448,7 @@ TyPeelRCase = ∀ {Δ V Θ s B A C Bᵢ Bₑ} → Value V
   → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
   → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
   → Δ ∣ [] ⊢ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-               ⟪ bind A ∷ Θ , instReveal 0 s ⟫ ⦂ C
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
 
 ∀-inj : ∀ {A B} → _≡_ {A = Ty} (`∀ A) (`∀ B) → A ≡ B
 ∀-inj refl = refl
@@ -466,12 +466,13 @@ shiftBy-[]ᵗ (suc n) B A =
 
 preserve-TyPeelR : TyPeelRCase
 preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
-                 {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s (⊢·[] (env mw ⊢V ⊢c wE) wA)
+                 {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA)
   with conv-all-inv ⊢c
 ... | A₀ , B₀ , refl , eqE , ⊢s₀
   with conv-types-unique ⊢s ⊢s₀
 ... | refl , refl =
-  env (mw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) mw) int conv
+  env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
+          (mw-changes mwᵥ)) int conv
       (wf-[]ᵗ (wf-∀⁻ wE) wA)
   where
   A′ : Ty
@@ -484,10 +485,10 @@ preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
   ⊢wkV : (bind A′ ∷ interior Θ Δ) ∣ [] ⊢ wkᴹ 1 V ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
   ⊢wkV = ⊢rename Ren-wk Inj-suc ⊢V
 
-  int : interior (bind A ∷ Θ) Δ ∣ []
+  int : interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
           ⊢ wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ] ⦂ Bᵢ
   int =
-    subst (λ T → interior (bind A ∷ Θ) Δ ∣ []
+    subst (λ T → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
                    ⊢ wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ] ⦂ T)
           (ren-suc-[0] Bᵢ)
           (⊢·[] ⊢wkV (wf-var (bind (⇑ᵗ A′) , ez , nameable-b)))
@@ -497,9 +498,10 @@ preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
               (trans (subst-at-0 A′ (shiftBodyBy (numBinds Θ) B))
                      (cong ⇑ᵗ (sym (shiftBy-[]ᵗ (numBinds Θ) B A))))
 
-  conv : convCtx (bind A ∷ Θ) Δ ⊢ instReveal 0 s
+  conv : convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ instReveal 0 s
            ∶ Bᵢ ⇝ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
-  conv = subst (λ T → convCtx (bind A ∷ Θ) Δ ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
+  conv = subst (λ T → convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ
+                        ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
                eqT (⊢instReveal {A = A′} 0 ⊢s)
 
 -- ── DROP$ ──────────────────────────────────────────────────────────────
@@ -510,7 +512,7 @@ preserve-Drop$ : ∀ {n Θ}
   → Δ ∣ [] ⊢ ($ n) ⟪ Θ , id A ⟫ ⦂ C
     -------------------------------
   → Δ ∣ [] ⊢ $ n ⦂ C
-preserve-Drop$ {C = C} bA (env {Θ = Θ} mw ⊢$ ⊢c wE)
+preserve-Drop$ {C = C} bA (env {Θ = Θ} mwᵥ ⊢$ ⊢c wE)
   rewrite shiftBy-ℕ⁻ {A = C} (numBinds Θ) (sym (conv-id-refl ⊢c)) = ⊢$
 
 ------------------------------------------------------------------------
@@ -572,8 +574,8 @@ module Impl
   preserve (⊢· ⊢L ⊢M)   (ξ-·-r v st) = ⊢· ⊢L (preserve ⊢M st)
   preserve (⊢·[] ⊢L w)  (ξ-·[] st)   = ⊢·[] (preserve ⊢L st) w
   preserve (⊢Λ ⊢N)      (ξ-Λ st)     = ⊢Λ (preserve ⊢N st)
-  preserve (env mw ⊢M ⊢c wE) (ξ-⟪⟫ st) =
-    env mw (preserve ⊢M st) ⊢c wE
+  preserve (env mwᵥ ⊢M ⊢c wE) (ξ-⟪⟫ st) =
+    env mwᵥ (preserve ⊢M st) ⊢c wE
 
   preserve* : ∀ {Δ M M′ A}
     → Δ ∣ [] ⊢ M ⦂ A

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -422,7 +422,7 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
 -- ── TYPEELR, AT ANY ∀ CONVERSION ───────────────────────────────────────
 -- Four moves, one per premise of the contractum's `env`:
 --
---   FRAME       `bind A ∷ Θ`, whose interior is
+--   FRAME       one bind prepended to Θ, whose interior is
 --               `bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`
 --               DEFINITIONALLY — the shift `renᴮ suc Θ` used to add is
 --               the one `pushBinds` already performs.

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -55,11 +55,11 @@ open import strong.proof.MoveScope using (preserve-IdPush)
 -- exists.
 
 Θc₁ Θc₂ : CtxMorph
-Θc₁ = bind `𝔹 ∷ []
-Θc₂ = bind (`ℕ ⇒ `ℕ) ∷ []
+Θc₁ = morph (`𝔹 ∷ []) []
+Θc₂ = morph ((`ℕ ⇒ `ℕ) ∷ []) []
 
 Vc : Term
-Vc = ƛ `ℕ ∙ (($ 5) ⟪ lock 1 ∷ [] , id `ℕ ⟫)
+Vc = ƛ `ℕ ∙ (($ 5) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
 
 -- V's home: Θ₁'s binder over Θ₂'s binder over the empty type context.
 Ξc : Ctxᵗ
@@ -70,7 +70,7 @@ _ = refl
 
 ⊢Vc : Ξc ∣ [] ⊢ Vc ⦂ (`ℕ ⇒ `ℕ)
 ⊢Vc = ⊢ƛ wf-ℕ
-        (env (mw-l (bind (`ℕ ⇒ `ℕ) , es ez , nameable-b) mw[])
+        (env (mw rw[] (sw-l (bind (`ℕ ⇒ `ℕ) , es ez , nameable-b) sw[]))
              ⊢$ (conv-id base-ℕ) wf-ℕ)
 
 val-Vc : Value Vc
@@ -80,8 +80,8 @@ Rc : Term
 Rc = (Vc ⟪ Θc₁ , seal 1 ⟫) ⟪ Θc₂ , unseal 0 ⟫
 
 ⊢Rc : [] ∣ [] ⊢ Rc ⦂ (`ℕ ⇒ `ℕ)
-⊢Rc = env (mw-b (wf-⇒ wf-ℕ wf-ℕ) mw[])
-          (env (mw-b wf-𝔹 mw[]) ⊢Vc
+⊢Rc = env (mw (rw-b (wf-⇒ wf-ℕ wf-ℕ) rw[]) sw[])
+          (env (mw (rw-b wf-𝔹 rw[]) sw[]) ⊢Vc
                (conv-seal (es ez))
                (wf-var (bind (`ℕ ⇒ `ℕ) , ez , nameable-b)))
           (conv-unseal ez) (wf-⇒ wf-ℕ wf-ℕ)
@@ -94,8 +94,8 @@ step-c = CancelR val-Vc ez
 -- the contractum, with both identity conversions computed out
 _ : (Vc ⟪ Θc₁ , mkId (shiftBy (numBinds Θc₁) (`ℕ ⇒ `ℕ)) ⟫)
       ⟪ Θc₂ , mkId (`ℕ ⇒ `ℕ) ⟫
-      ≡ (Vc ⟪ bind `𝔹 ∷ [] , id `ℕ ↦ id `ℕ ⟫)
-          ⟪ bind (`ℕ ⇒ `ℕ) ∷ [] , id `ℕ ↦ id `ℕ ⟫
+      ≡ (Vc ⟪ morph (`𝔹 ∷ []) [] , id `ℕ ↦ id `ℕ ⟫)
+          ⟪ morph ((`ℕ ⇒ `ℕ) ∷ []) [] , id `ℕ ↦ id `ℕ ⟫
 _ = refl
 
 -- AND IT TYPES.  The old contractum `V ⟪ repsOf→bind (repsOf Θ₂) , mkId A ⟫`
@@ -103,11 +103,11 @@ _ = refl
 -- existed; the repaired one KEEPS BOTH FRAMES, and `Vc` retypes exactly
 -- where it was — `⊢Vc` is reused verbatim.
 ⊢c-contractum :
-  [] ∣ [] ⊢ (Vc ⟪ bind `𝔹 ∷ [] , id `ℕ ↦ id `ℕ ⟫)
-              ⟪ bind (`ℕ ⇒ `ℕ) ∷ [] , id `ℕ ↦ id `ℕ ⟫ ⦂ (`ℕ ⇒ `ℕ)
+  [] ∣ [] ⊢ (Vc ⟪ morph (`𝔹 ∷ []) [] , id `ℕ ↦ id `ℕ ⟫)
+              ⟪ morph ((`ℕ ⇒ `ℕ) ∷ []) [] , id `ℕ ↦ id `ℕ ⟫ ⦂ (`ℕ ⇒ `ℕ)
 ⊢c-contractum =
-  env (mw-b (wf-⇒ wf-ℕ wf-ℕ) mw[])
-      (env (mw-b wf-𝔹 mw[]) ⊢Vc
+  env (mw (rw-b (wf-⇒ wf-ℕ wf-ℕ) rw[]) sw[])
+      (env (mw (rw-b wf-𝔹 rw[]) sw[]) ⊢Vc
            (conv-fun (conv-id base-ℕ) (conv-id base-ℕ))
            (wf-⇒ wf-ℕ wf-ℕ))
       (conv-fun (conv-id base-ℕ) (conv-id base-ℕ))
@@ -153,7 +153,7 @@ val-Wt = V-Λ V-ƛ
 
 -- the CONCEALING ∀ conversion a Peel hands it: `conceal 0 (∀Y. Y ⇒ X)`
 Θt : CtxMorph
-Θt = lock 0 ∷ []
+Θt = morph [] (lock 0 ∷ [])
 
 st : Conv
 st = id (` 0) ↦ seal 1
@@ -169,7 +169,7 @@ Wft : Term
 Wft = Wt ⟪ Θt , `∀ st ⟫
 
 ⊢Wft : Δt ∣ [] ⊢ Wft ⦂ `∀ (` 0 ⇒ ` 1)
-⊢Wft = env (mw-l (bind `ℕ , ez , nameable-b) mw[]) ⊢Wt
+⊢Wft = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[])) ⊢Wt
            (conv-all ⊢st)
            (wf-∀ (wf-⇒ (wf-var (abst , ez , nameable-a))
                        (wf-var (bind `ℕ , es ez , nameable-b))))
@@ -182,7 +182,7 @@ Rt = Wft ·[ ` 0 ⇒ ` 1 , ` 0 ]
 
 step-t : Δt ⊢ Rt
        -→ (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
-            ⟪ bind (` 0) ∷ Θt , instReveal 0 st ⟫
+            ⟪ morph (` 0 ∷ binds Θt) (changes Θt) , instReveal 0 st ⟫
 step-t = TyPeelR val-Wt ⊢st
 
 -- THE MINTED CONVERSION, computed: the inserted leaf is the DOMAIN
@@ -195,7 +195,7 @@ _ = refl
 -- OWN one conceals ℕ at the crossed boundary's binder.  Per variable each is
 -- exactly the conceal its binder licenses.
 t-convCtx : Ctxᵗ
-t-convCtx = convCtx (bind (` 0) ∷ Θt) Δt
+t-convCtx = convCtx (morph (` 0 ∷ binds Θt) (changes Θt)) Δt
 
 _ : t-convCtx ≡ bind (` 0) ∷ bind `ℕ ∷ []
 _ = refl
@@ -213,7 +213,8 @@ t-cod = conv-seal (es ez)
 -- THE CONTRACTUM TYPES, by the theorem — no hand-built derivation.
 ⊢t-contractum :
   Δt ∣ [] ⊢ (wkᴹ 1 Wt ·[ ` 0 ⇒ `ℕ , ` 0 ])
-              ⟪ bind (` 0) ∷ Θt , seal 0 ↦ seal 1 ⟫ ⦂ (` 0 ⇒ ` 0)
+              ⟪ morph (` 0 ∷ binds Θt) (changes Θt) , seal 0 ↦ seal 1 ⟫
+              ⦂ (` 0 ⇒ ` 0)
 ⊢t-contractum = preserve-TyPeelR val-Wt ⊢st ⊢Rt
 
 ------------------------------------------------------------------------
@@ -240,7 +241,7 @@ t-cod = conv-seal (es ez)
 Δi = bind (` 0) ∷ bind `ℕ ∷ []
 
 Θi : CtxMorph
-Θi = lock 1 ∷ []
+Θi = morph [] (lock 1 ∷ [])
 
 Ξi : Ctxᵗ
 Ξi = bind (` 0) ∷ masked (bind `ℕ) ∷ []
@@ -256,11 +257,11 @@ _ : Δi ∋ 0 := ` 1
 _ = ez
 
 Vi : Term
-Vi = (($ 7) ⟪ [] , seal 1 ⟫) ⟪ unlock 1 ∷ [] , seal 0 ⟫
+Vi = (($ 7) ⟪ morph [] [] , seal 1 ⟫) ⟪ morph [] (unlock 1 ∷ []) , seal 0 ⟫
 
 ⊢Vi : Ξi ∣ [] ⊢ Vi ⦂ ` 0
-⊢Vi = env (mw-u (_ , es ez , locked nameable-b) mw[])
-          (env mw[] ⊢$ (conv-seal (es ez))
+⊢Vi = env (mw rw[] (sw-u (_ , es ez , locked nameable-b) sw[]))
+          (env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
                (wf-var (bind `ℕ , es ez , nameable-b)))
           (conv-seal ez)
           (wf-var (_ , ez , nameable-b))
@@ -269,27 +270,29 @@ val-Vi : Value Vi
 val-Vi = V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal
 
 Ri : Term
-Ri = (Vi ⟪ [] , id (` 0) ⟫) ⟪ Θi , unseal 0 ⟫
+Ri = (Vi ⟪ morph [] [] , id (` 0) ⟫) ⟪ Θi , unseal 0 ⟫
 
 ⊢Ri : Δi ∣ [] ⊢ Ri ⦂ ` 1
-⊢Ri = env (mw-l (bind `ℕ , es ez , nameable-b) mw[])
-          (env mw[] ⊢Vi
+⊢Ri = env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[]))
+          (env (mw rw[] sw[]) ⊢Vi
                (conv-idv (_ , ez , nameable-b))
                (wf-var (_ , ez , nameable-b)))
           (conv-unseal ez)
           (wf-var (bind `ℕ , es ez , nameable-b))
 
 -- THE STEP, AT THE MOVED SCOPE.  `Θ₂ = lock 1 ∷ []` is binder-free, so
--- the move is `[] ⋉ Θi ≡ lock 1 ∷ []`, and the outer frame is Θi with
--- its own lock REWOUND — `rewind Θi ≡ unlock 1 ∷ lock 1 ∷ []`, whose net
+-- the move is `morph [] [] ⋉ Θi ≡ morph [] (lock 1 ∷ [])`, and the outer
+-- frame is Θi with its own lock REWOUND —
+-- `rewind Θi ≡ morph [] (unlock 1 ∷ lock 1 ∷ [])`, whose net
 -- effect on Δi is nothing at all.
-step-i : Δi ⊢ Ri -→ (Vi ⟪ [] ⋉ Θi , unseal 0 ⟫) ⟪ rewind Θi , mkId (` 1) ⟫
+step-i : Δi ⊢ Ri -→ (Vi ⟪ morph [] [] ⋉ Θi , unseal 0 ⟫)
+                      ⟪ rewind Θi , mkId (` 1) ⟫
 step-i = IdPush val-Vi ez
 
-_ : _≡_ {A = CtxMorph} ([] ⋉ Θi) (lock 1 ∷ [])
+_ : _≡_ {A = CtxMorph} (morph [] [] ⋉ Θi) (morph [] (lock 1 ∷ []))
 _ = refl
 
-_ : _≡_ {A = CtxMorph} (rewind Θi) (unlock 1 ∷ lock 1 ∷ [])
+_ : _≡_ {A = CtxMorph} (rewind Θi) (morph [] (unlock 1 ∷ lock 1 ∷ []))
 _ = refl
 
 _ : interior (rewind Θi) Δi ≡ Δi
@@ -306,7 +309,7 @@ _ = refl
 -- there, was untypeable.  This is the refutation that used to stand
 -- here; it is kept because it is what the rule change answers.
 ¬⊢i-old-contractum :
-  ¬ (Δi ∣ [] ⊢ (Vi ⟪ [] , unseal 0 ⟫) ⟪ Θi , id (` 1) ⟫ ⦂ ` 1)
+  ¬ (Δi ∣ [] ⊢ (Vi ⟪ morph [] [] , unseal 0 ⟫) ⟪ Θi , id (` 1) ⟫ ⦂ ` 1)
 ¬⊢i-old-contractum (env _ (env _ _ (conv-unseal ez) w) (conv-idv _) _) =
   ¬wf-i w
 
@@ -315,8 +318,8 @@ _ = refl
 -- slot 1 is live — and the contractum TYPES.  (`ProbeMove.agda` in the
 -- main tree checked this derivation by hand; here it is the theorem.)
 ⊢i-contractum :
-  Δi ∣ [] ⊢ (Vi ⟪ lock 1 ∷ [] , unseal 0 ⟫)
-              ⟪ unlock 1 ∷ lock 1 ∷ [] , id (` 1) ⟫ ⦂ ` 1
+  Δi ∣ [] ⊢ (Vi ⟪ morph [] (lock 1 ∷ []) , unseal 0 ⟫)
+              ⟪ morph [] (unlock 1 ∷ lock 1 ∷ []) , id (` 1) ⟫ ⦂ ` 1
 ⊢i-contractum = preserve-IdPush val-Vi ez ⊢Ri
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -224,7 +224,8 @@ t-cod = conv-seal (es ez)
 -- The old §3 refuted a `dual` that mapped `unlock X ↦ lock (n+X)` while
 -- `sw-u` still admitted a VACUOUS unlock: the restored lock then masked a
 -- slot the exterior left nameable.  Both halves are now repaired
--- TOGETHER — `sw-u` demands `applyChanges S Δ ∋lk X` and `dualScope` restores AND
+-- TOGETHER — `sw-u` demands `applyChanges S Δ ∋lk X` and `dualScope`
+-- restores AND
 -- reverses — so `interior-dual` is an EXACT identity and `PeelCase` is
 -- PROVEN (strong.proof.PeelDual.preserve-Peel).  Refutation gone.
 

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -50,7 +50,7 @@ open import strong.proof.MoveScope using (preserve-IdPush)
 ------------------------------------------------------------------------
 
 -- Θ₁ has ONE `bind`, so the cancelled value V lives two binders deep;
--- the residue `repsOf→bind (repsOf Θ₂)` rebinds only Θ₂'s one binder, and V's
+-- the residue `repsOf→bind (binds Θ₂)` rebinds only Θ₂'s one binder, and V's
 -- `lock 1` — perfectly well formed inside — names a slot that no longer
 -- exists.
 
@@ -222,9 +222,9 @@ t-cod = conv-seal (es ez)
 ------------------------------------------------------------------------
 
 -- The old §3 refuted a `dual` that mapped `unlock X ↦ lock (n+X)` while
--- `mw-u` still admitted a VACUOUS unlock: the restored lock then masked a
+-- `sw-u` still admitted a VACUOUS unlock: the restored lock then masked a
 -- slot the exterior left nameable.  Both halves are now repaired
--- TOGETHER — `mw-u` demands `scope Θ Δ ∋lk X` and `dualScope` restores AND
+-- TOGETHER — `sw-u` demands `applyChanges S Δ ∋lk X` and `dualScope` restores AND
 -- reverses — so `interior-dual` is an EXACT identity and `PeelCase` is
 -- PROVEN (strong.proof.PeelDual.preserve-Peel).  Refutation gone.
 

--- a/SystemF/agda/strong/proof/Progress.agda
+++ b/SystemF/agda/strong/proof/Progress.agda
@@ -110,8 +110,8 @@ progress-env v ⊢M ⊢c | inj₁ A-unseal | W , Θ₁ , Z , vW , inj₂ refl =
 ∀-conv-premise : ∀ {Δ W Θ s B} → Δ ∣ [] ⊢ W ⟪ Θ , `∀ s ⟫ ⦂ `∀ B
   → Σ[ Bᵢ ∈ Ty ] Σ[ Bₑ ∈ Ty ]
       ((abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ)
-∀-conv-premise (env mw ⊢W ⊢c wE) with conv-all-inv ⊢c
-∀-conv-premise (env mw ⊢W ⊢c wE) | Bᵢ , Bₑ , eqᵢ , eqₑ , ⊢s =
+∀-conv-premise (env mwᵥ ⊢W ⊢c wE) with conv-all-inv ⊢c
+∀-conv-premise (env mwᵥ ⊢W ⊢c wE) | Bᵢ , Bₑ , eqᵢ , eqₑ , ⊢s =
   Bᵢ , Bₑ , ⊢s
 
 ------------------------------------------------------------------------
@@ -160,7 +160,7 @@ progress (⊢·[] ⊢L wA) | inj₁ vL | inj₂ (W , Θ , s , vW , refl)
 
 -- M ⟪ Θ , c ⟫ — the boundary.  The interior is typed at `interior Θ Δ`; an
 -- interior step lifts by ξ-⟪⟫, an interior value goes to `progress-env`.
-progress (env mw ⊢M ⊢c wE) with progress ⊢M
-progress (env mw ⊢M ⊢c wE) | inj₂ (M′ , st) =
+progress (env mwᵥ ⊢M ⊢c wE) with progress ⊢M
+progress (env mwᵥ ⊢M ⊢c wE) | inj₂ (M′ , st) =
   inj₂ (M′ ⟪ _ , _ ⟫ , ξ-⟪⟫ st)
-progress (env mw ⊢M ⊢c wE) | inj₁ vM = progress-env vM ⊢M ⊢c
+progress (env mwᵥ ⊢M ⊢c wE) | inj₁ vM = progress-env vM ⊢M ⊢c


### PR DESCRIPTION
# PR body draft — the context morphism becomes a PAIR

Branch `morph-pair`, on top of `main` @ `2c092f1e`.
Gate: `make -C SystemF/agda/strong check` passes, cold, exit 0
(`--safe`, no postulates/holes/pragmas).

## What changed

Jeremy's ruling (2026-09-06): the boundary's context morphism is not one
interleaved list.  Its two halves are different kinds of thing —
**binds are PARALLEL** (a block of binders whose representations are read
outside all of them) and **lock/unlock are SEQUENTIAL** — so the type
now says so.

```agda
data Change : Set where
  lock unlock : ℕ → Change          -- EXTERIOR indices, name only

record CtxMorph : Set where
  constructor morph
  field
    binds   : List Ty               -- PARALLEL block of binders
    changes : List Change           -- SEQUENTIAL, applied head-LAST
```

Field names are Jeremy's (`binds` / `changes`); the constructor is
`morph`.  The two *induced contexts* keep their old names because
`Design.md` and the lemma names use them:

```agda
applyChanges : List Change → Ctxᵗ → Ctxᵗ    -- locks AND unlocks, head-last
applyUnlocks : List Change → Ctxᵗ → Ctxᵗ    -- unlocks only (locks skipped)

scope         Θ Δ = applyChanges (changes Θ) Δ
unlockedScope Θ Δ = applyUnlocks (changes Θ) Δ
interior      Θ Δ = pushBinds (binds Θ) (scope Θ Δ)
convCtx       Θ Δ = pushBinds (binds Θ) (unlockedScope Θ Δ)
```

`repsOf` is gone — it *is* the field `binds`.  `scopeOf` became
`shiftScope`.  The derived morphisms are re-expressed at the pair:

```agda
dual   Θ = morph [] (hideBinds (numBinds Θ)
                       ++ dualScope (numBinds Θ) (changes Θ))
rewind Θ = morph (binds Θ) (dualScope 0 (changes Θ) ++ changes Θ)
Θ₁ ⋉ Θ₂  = morph (binds Θ₁)
                 (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))
```

and the two minting rules: `TyBeta` mints `morph (A ∷ []) []`, `TyPeelR`
mints `morph (A ∷ binds Θ) (changes Θ)` (change indices are exterior and
stay unshifted by the morphism's own binds — unchanged).

`Δ ⊢ᵐ Θ` is a **pair of judgements**, one per half:

```agda
data _⊢ʳ_ : Ctxᵗ → List Ty → Set where        -- the PARALLEL reps
  rw[] : Δ ⊢ʳ []
  rw-b : Δ ⊢ᵗ A → Δ ⊢ʳ Bs → Δ ⊢ʳ (A ∷ Bs)

data _⊢ˢ_ : Ctxᵗ → List Change → Set where    -- the SEQUENTIAL changes
  sw[] : Δ ⊢ˢ []
  sw-l : applyChanges S Δ ∋tv X → Δ ⊢ˢ S → Δ ⊢ˢ (lock X ∷ S)
  sw-u : applyChanges S Δ ∋lk X → Δ ⊢ˢ S → Δ ⊢ˢ (unlock X ∷ S)

record _⊢ᵐ_ (Δ : Ctxᵗ) (Θ : CtxMorph) : Set where
  constructor mw
  field
    mw-reps    : unlockedScope Θ Δ ⊢ʳ binds Θ
    mw-changes : Δ ⊢ˢ changes Θ
```

## The one semantic change

The interleaved list read a bind's representation past **its own tail's**
unlocks (`mw-b : unlockedScope Θ′ Δ ⊢ᵗ A → … → Δ ⊢ᵐ (bind A ∷ Θ′)`).  The
pair reads **every** representation past the **whole** change list.  This
is the one thing the refactor changes about what is derivable, and it is
strictly **more permissive** — a rep may now name a slot that an unlock
*to its left in the old list* re-exposed.  It is also the point: a
parallel block has no left and no right.

Consequences observed, in full:

* **No `⊢ᵐ` derivation in the development needed the tighter reading, and
  none needed the looser one.**  Exactly one morphism in the whole tree
  had a change to the left of a bind under the old order —
  `rewind Θ₆ = lock 0 ∷ bind (` 0) ∷ unlock 0 ∷ []` in
  `proof/MwUObstruct` §4 — and there the two readings *coincide*, because
  the entry to the left is a `lock` and `applyUnlocks` skips locks.
  Every other morphism has all its binds before all its changes, where
  the two readings are the same.  So: no example was refused, and none
  needed the extra permissiveness.
* **One lemma pays for it:** `proof/MoveScope.⊢ᵐ-rewind`.  A rewound
  frame's change list is `dualScope 0 (changes Θ) ++ changes Θ`, and the
  inverse half turns `Θ`'s *locks* into *unlocks* — so under the pair the
  reps of `rewind Θ` are read on a context with those extra unmasks
  applied.  That is more nameable, so the proof gains one `⊢ʳ-⊑` step
  (with a `subst` along `applyUnlocks-++`).  Under the interleaved list
  the reps sat inside the appended `Θ` tail and were read unchanged.
* **No theorem is weakened.**  `_⊢ᵐ_` is a premise of `env`, so a more
  permissive `_⊢ᵐ_` admits a (very slightly) larger set of typed terms;
  `preservation`, `progress`, `det`, `value-¬step`, tightness and
  canonicity are all reproved over the new judgement with their
  statements unchanged.

## Lemma-count deltas

Genuinely **deleted** (8), all of them projection/filtering lemmas about
`repsOf` that the record field makes definitional:

| module | deleted |
|--------|---------|
| `proof/PeelDual` | `repsOf-hideBinds`, `repsOf-++`, `repsOf-dualScope`, `repsOf-dual` |
| `proof/MoveScope` | `repsOf-scopeOf`, `repsOf-⋉`, `repsOf-rewind` |
| `TermSubst` | `repsOf-ren` |

Became `refl` (3), and their uses (three `rewrite`s, one `subst`) were
deleted with them:

    numBinds-dual   Θ     : numBinds (dual Θ)    ≡ 0            -- refl
    numBinds-⋉      Θ₁ Θ₂ : numBinds (Θ₁ ⋉ Θ₂)  ≡ numBinds Θ₁  -- refl
    numBinds-rewind Θ     : numBinds (rewind Θ)  ≡ numBinds Θ   -- refl

`numBinds-ren` is now `map-length` directly (it was `trans (cong length
repsOf-ren) map-length`).  `wf-convCtx-rewind` lost its `subst`;
`interior-rewind` lost a `rewrite`; `preserve-Peel`'s `⊢s-tr` lost its
`rewrite numBinds-dual`; `preserve-IdPush`/`preserve-CancelR` lost their
`rewrite numBinds-⋉`; `MoveScope.moved-conv` lost its
`rewrite numBinds-rewind`.

**Dead cases removed.**  Every induction over the change list lost its
`bind` case (26 functions/lemmas: `applyChanges`, `applyUnlocks`,
`applyChanges⊑applyUnlocks`, `Δ⊑applyUnlocks`, `⊑-applyChanges`,
`⊑-applyUnlocks`, `⊑ᵃ-applyChanges`, `dualScope`, `shiftScope`,
`ren-applyChanges`, `ren-applyUnlocks`, `⊢ˢ-⊑ᵃ`, `⊢ˢ-ren`,
`applyChanges-++`, `applyUnlocks-++`, `applyChanges-dualScope`,
`⊢ˢ-dualScope`, `dualScope-unmask-comm`, `applyUnlocks-dualScope`,
`⊢ˢ-++`, `applyChanges-shiftScope`, `applyUnlocks-shiftScope`,
`⊢ˢ-shiftScope`, `applyUnlocks-∋bind`, `locksOnly`, `dropL`), and every
induction over the reps lost its `lock`/`unlock` cases (`⊢ʳ-⊑`,
`⊢ʳ-ren`).

**Split, not added.**  `⊢ᵐ-⊑ᵃ` and `⊢ᵐ-ren` survive with their statements
unchanged and now delegate to `⊢ʳ-⊑`/`⊢ˢ-⊑ᵃ` and `⊢ʳ-ren`/`⊢ˢ-ren`.
`⊢ᵐ-++` is gone; the *append* lemma is now the rep-free `⊢ˢ-++`, which is
where the simplification shows: the old `⊢ᵐ-++` had a `bind` case that
had to move a rep from `scope Ψ Δ` to `unlockedScope Ψ Δ` along `⊑-wf`,
and the new one has no rep in it at all.  `⊢ᵐ-hideBinds`/`⊢ᵐ-dualScope`/
`⊢ᵐ-scopeOf` became `⊢ˢ-hideBinds`/`⊢ˢ-dualScope`/`⊢ˢ-shiftScope` and
likewise lost their `bind` cases.

Per-module declaration counts (old → new): `CtxMorph` 23 → 30 (five of
the seven additions are one-line morphism-level wrappers kept so
`scope Θ Δ`/`unlockedScope Θ Δ` and their transports keep their names),
`proof/PeelDual` 33 → 29, `proof/MoveScope` 34 → 32, `TermSubst` 35 → 39
(the four additions are the two `renᶠ`-level list functions and the two
halves of `⊢ᵐ-ren`).

**Was `⊢ᵐ-⋉` easier, as predicted?**  Half of it.  Its two obligations
now split cleanly and each is one step: the changes are `⊢ˢ-++` at the
move (nothing to carry), and the reps are `⊢ʳ-⊑` along
`⊑-applyUnlocks (changes Θ₁) (⊑-pushBinds (binds Θ₂)
(applyChanges⊑applyUnlocks (changes Θ₂) Δ))`.  Net length is about the
same as before: the `⊑-wf` step that used to hide inside `⊢ᵐ-++` is now
visible at the one place that needs it, which is the honest form.

**Which lemma got harder:** `⊢ᵐ-rewind` (above) — four lines instead of
one.  Nothing else.

## Rendering deltas

None.  `Show.agda` renders the pair in its own order — all binds, then
all changes, then the conversion: `⟪ ↑X:=A , ↓Y , ↥Z , c ⟫`.  Every one
of `Examples`' 26 pinned rendering traces is byte-identical (they are
`refl` proofs and the module type-checks unchanged); the diff touches no
`showTmIn` line.  The only morphism in the tree whose old list order
differed from binds-then-changes is `rewind Θ₆` in `proof/MwUObstruct`,
which is never rendered.

`scripts/render_term.sh` still works unchanged, e.g.

    scripts/render_term.sh \
      'showBndIn 1 (morph (`ℕ ∷ []) (lock 0 ∷ unlock 0 ∷ [])) (id `ℕ)' \
      'open import strong.Types' 'open import strong.Conversion' \
      'open import strong.CtxMorph' 'open import Data.List using ([]; _∷_)'
    ⟪ ↑Y:=ℕ , ↓X , ↥X , id ℕ ⟫

## What was re-proved

Everything, with statements unchanged: `proof/PeelDual`
(`interior-dual` (†), `convCtx-dual`, `⊢ᵐ-dual`, `preserve-Peel`),
`proof/MoveScope` (the frame equalities, `⊢ᵐ-⋉`, `⊢ᵐ-rewind`,
`preserve-IdPush`, `preserve-CancelR`, and the lock-only refutation
`¬frame-locksOnly` on the pair witness
`Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])`), `proof/Preserve`,
`strong.Preservation`, `strong.Progress`, `det`, `value-¬step`,
`proof/Canonicity`, `proof/Adversary`, `proof/IdLayer`,
`proof/MaskFacts`, `proof/DualTightness`, `proof/MwUObstruct` (its
`dropLocks`/`bindsOnly` witnesses translated to the pair),
`proof/PreserveObstruct`, the 7 `evalTerms` regressions, and `Examples`
§1–§15.

## Docs

`Design.md` §2 (the record, the two halves, the rendering order), §3
(`applyChanges`/`applyUnlocks` under `scope`/`unlockedScope`), §4.2 (the
paired judgement, verbatim, and the one semantic move), §4.3 (what
`env`'s first premise checks), §6.3/§6.7 (`dual`, `rewind`, `⋉`,
`shiftScope`), §8 law 4 (simultaneity, now stated exactly), §9 (a new
bullet, *The pair*), Appendix A (names).  `README.md`: the module map
lines for `CtxMorph.agda`, `MoveScope.agda`, `MwUObstruct.agda`.
