### PR TITLE
Strong System F: design map — D51, the pair

### DIFF
--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -1449,7 +1449,7 @@ is `notes/DesignSpace.md`, with `notes/DesignPoints.md` as its glossary.
     read past the unlocks, and design **law 4 is reduced to its
     surviving half** (§8): no interference from the frame's own entries;
     the "every premise on the plain exterior" half is retired.
-* **The pair** (Jeremy, 2026-09-06, branch `morph-pair`).  The
+* **The pair** (Jeremy, 2026-09-06; PR #195, `3f080fdb`).  The
   ratification left `_⊢ᵐ_` reading a rep past its own TAIL's unlocks,
   which is a sequential statement about something that is not sequential.
   The morphism became a PAIR — `morph (binds : List Ty)

--- a/SystemF/agda/strong/notes/DesignPoints.md
+++ b/SystemF/agda/strong/notes/DesignPoints.md
@@ -603,3 +603,19 @@ tests that came out of the episode are `proof/DualTightness` (the
 `unlock` half of `Peel`) and `Examples` §15 (every other rule that moves
 a subterm into a new frame, with the five frame identities collected in
 §15f and tabulated in `Design.md` §7).
+
+**D51 — the morphism is a pair: parallel binds, sequential changes.**
+Jeremy, reading `dual`, asked whether treating binds specially
+(`hideBinds` at the front, reps read outside all of them) while
+lock/unlock are sequential was essential, and whether the binds should
+then live in their own list.  The special treatment is essential — it is
+the half of simultaneity that survived `D18`, and the fully sequential
+composition was the first design (`D02`) — but the interleaving was not:
+only `mw-b`'s tail-dependent rep frame ever looked at bind-vs-change
+order.  `CtxMorph` became `record morph { binds : List Ty ; changes :
+List Change }` with `Δ ⊢ᵐ Θ` a record of `unlockedScope Θ Δ ⊢ʳ binds Θ`
+and `Δ ⊢ˢ changes Θ`; a rep is now read past all of the morphism's
+unlocks, which no example needed and no theorem felt, and `repsOf`,
+eight filtering lemmas and `⊢ᵐ-++` vanished.  Rendering unchanged.  PR
+#195 (`3f080fdb`); `notes/DECISIONS.md` "The context morphism becomes a
+PAIR".

--- a/SystemF/agda/strong/notes/DesignSpace.md
+++ b/SystemF/agda/strong/notes/DesignSpace.md
@@ -74,6 +74,7 @@ subgraph Dv2["D. v2 — conversion boundaries — 2026-09-05/06"]
   D48["D48 masked-only mw-u, unconditional relock, bindsOnly"]
   D49["D49 Δ-dependent dual: relock on scope Θ′ Δ"]
   D50["D50 sequential ⊢ᵐ, exact dual, rewind, reps on unlockedScope"]
+  D51["D51 the morphism is a pair: parallel binds, sequential changes"]
 end
 
 D01 -->|"Example 6: revealing Y:=X⇒X injects X into Γ₂, so L2 fails"| D02
@@ -152,6 +153,8 @@ D13 -.->|"retired: towers, not merges — Q5a, F8/F9"| D35
 D26 -.->|"reinstated as CancelR"| D43
 D47 -.->|"design law 2 restated for the RELATION, then tested rule by rule — Examples §15"| D50
 D18 -.->|"law 4 reduced to its surviving half: a rep is never blocked by its own frame's locks"| D50
+D50 -->|"Jeremy, reading dual: binds are a hidden block, changes are sequential — make the type say so"| D51
+D18 -.->|"what survived of simultaneity — a PARALLEL block of binders — is now a record field"| D51
 
 classDef current fill:#d8f3e0,stroke:#137333,stroke-width:2px,color:#0b3d1a;
 classDef refuted fill:#fdecea,stroke:#b3261e,stroke-width:1.5px,stroke-dasharray:5 3,color:#5f1512;
@@ -161,7 +164,7 @@ classDef ruling fill:#e5eeff,stroke:#1a56b8,stroke-width:2px,color:#0f2f66;
 class D01,D02,D03,D04,D05,D06,D07,D08,D09,D10,D11,D12,D14,D15,D16,D17,D19,D20,D22,D23,D24,D28,D29,D30,D38,D41,D44,D47,D48 refuted;
 class D13,D18,D21,D26,D36,D37,D42,D49 reverted;
 class D25,D27,D31,D32,D33 ruling;
-class D34,D35,D39,D40,D43,D45,D46,D50 current;
+class D34,D35,D39,D40,D43,D45,D46,D50,D51 current;
 ```
 
 ---


### PR DESCRIPTION
Docs only: notes/DesignSpace.md gains node D51 (the context morphism as a pair of parallel binds and sequential changes) with its edges from D50 and D18, and DesignPoints.md the glossary entry; Design.md §9's pair bullet now cites the merged PR #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)