### PR TITLE
Strong System F: Ent = Binding + at most one lock (masked no longer recursive)

### DIFF
--- a/SystemF/agda/strong/Conversion.agda
+++ b/SystemF/agda/strong/Conversion.agda
@@ -102,7 +102,7 @@ data _⊢_∶_⇝_ : Ctxᵗ → Conv → Ty → Ty → Set where
       ----------------------------------------------
     → Δ ⊢ s ↦ t ∶ (A ⇒ B) ⇝ (A′ ⇒ B′)
 
-  conv-all : ∀ {s} → (abst ∷ Δ) ⊢ s ∶ A ⇝ B
+  conv-all : ∀ {s} → (unmasked abst ∷ Δ) ⊢ s ∶ A ⇝ B
       --------------------------------------
     → Δ ⊢ `∀ s ∶ `∀ A ⇝ `∀ B
 
@@ -233,7 +233,8 @@ conv-⊑ ls (conv-idv tv)    = conv-idv (⊑-tv ls tv)
 conv-⊑ ls (conv-unseal d)  = conv-unseal (⊑-kn ls d)
 conv-⊑ ls (conv-seal d)    = conv-seal (⊑-kn ls d)
 conv-⊑ ls (conv-fun s t)   = conv-fun (conv-⊑ ls s) (conv-⊑ ls t)
-conv-⊑ ls (conv-all s)     = conv-all (conv-⊑ (le∷ le-aa ls) s)
+conv-⊑ ls (conv-all s)     =
+  conv-all (conv-⊑ (le∷ (le-uu le-aa) ls) s)
 
 ------------------------------------------------------------------------
 -- 7.  Conversion inversions
@@ -275,7 +276,7 @@ conv-id-refl (conv-idv _) = refl
 -- than by matching `conv-all` directly.
 conv-all-inv : ∀ {s A B} → Δ ⊢ `∀ s ∶ A ⇝ B
   → Σ[ A₀ ∈ Ty ] Σ[ B₀ ∈ Ty ]
-      ((A ≡ `∀ A₀) × (B ≡ `∀ B₀) × ((abst ∷ Δ) ⊢ s ∶ A₀ ⇝ B₀))
+      ((A ≡ `∀ A₀) × (B ≡ `∀ B₀) × ((unmasked abst ∷ Δ) ⊢ s ∶ A₀ ⇝ B₀))
 conv-all-inv (conv-all ⊢s) = _ , _ , refl , refl , ⊢s
 
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -486,10 +486,11 @@ updateAt f (suc X) (E ∷ Δ) = E ∷ updateAt f X Δ
 
 -- SETTING THE LOCK, AND CLEARING IT.  Both are TOTAL and IDEMPOTENT:
 -- there is only one lock to set or clear.  `maskEnt` is never applied to
--- an already-masked slot in a well-formed term — `sw-l` (strong.CtxMorph)
--- and `mw-l` demand that the slot be NAMEABLE — but the function does not
--- have to know that, and that is the point: nothing has to rule out a
--- second mask, because a second mask is not expressible.
+-- an already-masked slot in a well-formed term — `sw-l`
+-- (strong.CtxMorph), the change half of `Δ ⊢ᵐ Θ`, admits `lock X` only at
+-- a NAMEABLE slot — but the function does not have to know that, and that
+-- is the point: nothing has to rule out a second mask, because a second
+-- mask is not expressible.
 maskEnt : Ent → Ent
 maskEnt (unmasked b) = masked b
 maskEnt (masked b)   = masked b

--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -232,10 +232,6 @@ ren-kn r d = ren∋ r d
 ren-tv : Ren ρ Δ Δ′ → Δ ∋tv X → Δ′ ∋tv ρ X
 ren-tv r (E , d , v) = renᵉ _ E , ren∋ r d , renᵉ-Nameable v
 
--- Which entry is at a nameable slot: the lock layer is `unmasked`.
-∋tv-unmasked : Δ ∋tv X → ∃[ b ] (Δ ∋e X , unmasked b)
-∋tv-unmasked (unmasked b , d , nameable) = b , d
-
 ren-ext : Ren ρ Δ Δ′ → Ren (extᵗ ρ) (F ∷ Δ) (renᵉ ρ F ∷ Δ′)
 ren-ext {ρ = ρ} {Δ = Δ} {Δ′ = Δ′} {F = F} r = mkRen go
   where
@@ -579,8 +575,9 @@ maskEnt-mono (le-uu l) = le-mm l
 maskEnt-mono (le-mm l) = le-mm l
 maskEnt-mono (le-mu l) = le-mm l
 
--- Masking a slot only LOSES nameability, so a masked type context refines to the
--- unmasked one.  (There is no converse: that is the deleted demotion.)
+-- Masking a slot only LOSES nameability, so a masked type context refines
+-- to the unmasked one.  (There is no converse: that is the deleted
+-- demotion.)
 -- Every clause is now ONE lock step, with no recursion and no `Nameable`
 -- witness to invent — the target's lock is read off its constructor.
 maskEnt-le : E ⊑ᵉ E′ → maskEnt E ⊑ᵉ E′

--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -2,7 +2,9 @@ module strong.Ctx where
 
 -- Strong System F — THE TYPE CONTEXT (type contexts) and its transports.
 --
--- A type context entry is one of
+-- AN ENTRY IS TWO LAYERS: WHAT THE SLOT BINDS, AND WHETHER IT IS HIDDEN.
+--
+-- The inner layer is a `Binding` — the knowledge at the slot:
 --
 --   abst      a Λ-bound variable — no representation, and none can be
 --             invented.
@@ -10,10 +12,22 @@ module strong.Ctx where
 --             representation, stored ONCE, as a type over this entry's
 --             bind tail.  Every inner boundary that talks about this
 --             variable carries only its NAME.
---   masked E  the slot is CONCEALED here: it may not be NAMED
---             (tightness), but its entry E is RETAINED, so the knowledge
---             is still on the type context for a later re-exposure
---             (`unlock`) to point back at.
+--
+-- The outer layer is the LOCK, and there is AT MOST ONE OF IT:
+--
+--   unmasked b  the slot may be NAMED.
+--   masked b    the slot is CONCEALED here: it may not be NAMED
+--               (tightness), but its binding b is RETAINED, so the
+--               knowledge is still on the type context for a later
+--               re-exposure (`unlock`) to point back at.
+--
+-- SPLITTING THE ENTRY THIS WAY MAKES "AT MOST ONE MASK" TRUE BY
+-- CONSTRUCTION.  `masked` no longer takes an entry, so `masked (masked …)`
+-- is not a term; `Nameable`/`Locked` are then the two constructors' own
+-- discriminations, each with ONE clause and NO premise, and every lemma
+-- that used to reason about a stack of masks (`Locked`'s `Nameable`
+-- premise, `mask-unmask`'s side condition, `⊑ᵉ-trans`'s le-mu/le-mm
+-- interplay, `unmaskEnt-nameable`) either shrinks or disappears.
 --
 -- Under Jeremy's Q1 ruling (BINDER-SYNTACTIC, 2026-09-05) a variable's
 -- representation lives ONLY at its binder; every conversion and every
@@ -61,10 +75,15 @@ map-length f (x ∷ xs) = cong suc (map-length f xs)
 -- 1.  The type context:  type contexts with BINDER entries and BLOCKED entries
 ------------------------------------------------------------------------
 
+-- WHAT A SLOT BINDS.  No lock lives here.
+data Binding : Set where
+  abst : Binding
+  bind : Ty → Binding
+
+-- A TYPE-CONTEXT ENTRY: a binding, plus AT MOST ONE lock.
 data Ent : Set where
-  abst   : Ent
-  bind   : Ty → Ent
-  masked : Ent → Ent
+  unmasked : Binding → Ent
+  masked   : Binding → Ent
 
 Ctxᵗ : Set
 Ctxᵗ = List Ent
@@ -73,23 +92,33 @@ private
   variable
     Δ Δ′ Δ″ : Ctxᵗ
     E E′ E″ F : Ent
+    b b′ b″ : Binding
     A A′ B B′ C : Ty
     X Y Z : ℕ
     ρ ρ′ : Renameᵗ
 
+-- Renaming acts on the BINDING — the lock carries no spelling — and
+-- `renᵉ` is that action lifted through the lock layer.
+renᵇ : Renameᵗ → Binding → Binding
+renᵇ ρ abst     = abst
+renᵇ ρ (bind A) = bind (renameᵗ ρ A)
+
 renᵉ : Renameᵗ → Ent → Ent
-renᵉ ρ abst       = abst
-renᵉ ρ (bind A)   = bind (renameᵗ ρ A)
-renᵉ ρ (masked E) = masked (renᵉ ρ E)
+renᵉ ρ (unmasked b) = unmasked (renᵇ ρ b)
+renᵉ ρ (masked b)   = masked (renᵇ ρ b)
 
 ⇑ᵉ : Ent → Ent
 ⇑ᵉ = renᵉ suc
 
+renᵇ-⇑-comm : (ρ : Renameᵗ) (b : Binding)
+  → renᵇ (extᵗ ρ) (renᵇ suc b) ≡ renᵇ suc (renᵇ ρ b)
+renᵇ-⇑-comm ρ abst     = refl
+renᵇ-⇑-comm ρ (bind A) = cong bind (ren-⇑-comm ρ A)
+
 renᵉ-⇑-comm : (ρ : Renameᵗ) (E : Ent)
   → renᵉ (extᵗ ρ) (⇑ᵉ E) ≡ ⇑ᵉ (renᵉ ρ E)
-renᵉ-⇑-comm ρ abst       = refl
-renᵉ-⇑-comm ρ (bind A)   = cong bind (ren-⇑-comm ρ A)
-renᵉ-⇑-comm ρ (masked E) = cong masked (renᵉ-⇑-comm ρ E)
+renᵉ-⇑-comm ρ (unmasked b) = cong unmasked (renᵇ-⇑-comm ρ b)
+renᵉ-⇑-comm ρ (masked b)   = cong masked (renᵇ-⇑-comm ρ b)
 
 -- Entry lookup.  The entry is returned SHIFTED into the ambient context, so
 -- `Δ ∋e X , bind A` means "slot X is a binder whose rep, read in Δ, is A".
@@ -99,41 +128,41 @@ data _∋e_,_ : Ctxᵗ → ℕ → Ent → Set where
   ez : (E ∷ Δ) ∋e zero , ⇑ᵉ E
   es : Δ ∋e X , E → (F ∷ Δ) ∋e suc X , ⇑ᵉ E
 
--- A slot may be NAMED iff its entry is not masked.  This is the whole of
+-- A slot may be NAMED iff its entry is UNMASKED.  This is the whole of
 -- the tightness discipline: `masked` is unnameable in types and in terms.
+-- The predicate is now a pure discrimination on the lock layer — it says
+-- NOTHING about the binding, so there is one constructor and no premise.
 data Nameable : Ent → Set where
-  nameable-a : Nameable abst
-  nameable-b : Nameable (bind A)
+  nameable : Nameable (unmasked b)
 
 renᵉ-Nameable : Nameable E → Nameable (renᵉ ρ E)
-renᵉ-Nameable nameable-a = nameable-a
-renᵉ-Nameable nameable-b = nameable-b
+renᵉ-Nameable nameable = nameable
 
 infix 4 _∋tv_
 _∋tv_ : Ctxᵗ → ℕ → Set
 Δ ∋tv X = ∃[ E ] ((Δ ∋e X , E) × Nameable E)
 
 -- THE COMPLEMENT OF `Nameable`, and the whole of what an `unlock` may
--- restore: an entry masked ONCE over a nameable one.  `Locked` is what
--- `sw-u` (strong.CtxMorph) demands and what makes `mask ∘ unmask` the
--- identity at the slot (`mask-unmask`) — the fact the dual's restoring
--- `lock` needs.  A doubly masked entry is NOT `Locked`, and no
--- `Δ ⊢ᵐ Θ` ever produces one (`sw-l` masks only a nameable slot).
+-- restore.  `Locked` is what `sw-u` (strong.CtxMorph) demands and what
+-- makes `mask ∘ unmask` the identity at the slot (`mask-unmask`) — the
+-- fact the dual's restoring `lock` needs.  IT NEEDS NO `Nameable`
+-- PREMISE ANY MORE: "masked over a nameable entry" is the only shape a
+-- masked entry HAS, because `masked` takes a `Binding`.  The
+-- one-mask-deep property that the premise used to enforce is now BY
+-- CONSTRUCTION, so `Locked` is exactly the complement of `Nameable`.
 data Locked : Ent → Set where
-  locked : Nameable E → Locked (masked E)
+  locked : Locked (masked b)
 
 renᵉ-Locked : Locked E → Locked (renᵉ ρ E)
-renᵉ-Locked (locked v) = locked (renᵉ-Nameable v)
+renᵉ-Locked locked = locked
 
 renᵉ-Nameable⁻ : Nameable (renᵉ ρ E) → Nameable E
-renᵉ-Nameable⁻ {E = abst}     v = nameable-a
-renᵉ-Nameable⁻ {E = bind A}   v = nameable-b
-renᵉ-Nameable⁻ {E = masked E} ()
+renᵉ-Nameable⁻ {E = unmasked b} v = nameable
+renᵉ-Nameable⁻ {E = masked b}   ()
 
 Locked-ren⁻ : Locked (renᵉ ρ E) → Locked E
-Locked-ren⁻ {E = abst}     ()
-Locked-ren⁻ {E = bind A}   ()
-Locked-ren⁻ {E = masked E} (locked v) = locked (renᵉ-Nameable⁻ v)
+Locked-ren⁻ {E = unmasked b} ()
+Locked-ren⁻ {E = masked b}   locked = locked
 
 infix 4 _∋lk_
 _∋lk_ : Ctxᵗ → ℕ → Set
@@ -142,10 +171,10 @@ _∋lk_ : Ctxᵗ → ℕ → Set
 -- BINDER-SYNTACTIC LOOKUP.  This is the only way any rep is ever read.
 infix 4 _∋_:=_
 _∋_:=_ : Ctxᵗ → ℕ → Ty → Set
-Δ ∋ X := A = Δ ∋e X , bind A
+Δ ∋ X := A = Δ ∋e X , unmasked (bind A)
 
 ∋:=→∋tv : Δ ∋ X := A → Δ ∋tv X
-∋:=→∋tv d = bind _ , d , nameable-b
+∋:=→∋tv d = unmasked (bind _) , d , nameable
 
 -- Lookup is a partial FUNCTION, which is what makes every rule that mints an
 -- identity conversion at a looked-up rep deterministic.
@@ -153,7 +182,7 @@ _∋_:=_ : Ctxᵗ → ℕ → Ty → Set
 ∋e-det ez     ez      = refl
 ∋e-det (es d) (es d′) = cong ⇑ᵉ (∋e-det d d′)
 
-bind-inj : _≡_ {A = Ent} (bind A) (bind B) → A ≡ B
+bind-inj : _≡_ {A = Ent} (unmasked (bind A)) (unmasked (bind B)) → A ≡ B
 bind-inj refl = refl
 
 ∋:=-det : Δ ∋ X := A → Δ ∋ X := B → A ≡ B
@@ -169,7 +198,7 @@ data _⊢ᵗ_ : Ctxᵗ → Ty → Set where
   wf-ℕ   : Δ ⊢ᵗ `ℕ
   wf-𝔹   : Δ ⊢ᵗ `𝔹
   wf-⇒   : Δ ⊢ᵗ A → Δ ⊢ᵗ B → Δ ⊢ᵗ (A ⇒ B)
-  wf-∀   : (abst ∷ Δ) ⊢ᵗ A → Δ ⊢ᵗ (`∀ A)
+  wf-∀   : (unmasked abst ∷ Δ) ⊢ᵗ A → Δ ⊢ᵗ (`∀ A)
 
 data Base : Ty → Set where
   base-ℕ : Base `ℕ
@@ -203,6 +232,10 @@ ren-kn r d = ren∋ r d
 ren-tv : Ren ρ Δ Δ′ → Δ ∋tv X → Δ′ ∋tv ρ X
 ren-tv r (E , d , v) = renᵉ _ E , ren∋ r d , renᵉ-Nameable v
 
+-- Which entry is at a nameable slot: the lock layer is `unmasked`.
+∋tv-unmasked : Δ ∋tv X → ∃[ b ] (Δ ∋e X , unmasked b)
+∋tv-unmasked (unmasked b , d , nameable) = b , d
+
 ren-ext : Ren ρ Δ Δ′ → Ren (extᵗ ρ) (F ∷ Δ) (renᵉ ρ F ∷ Δ′)
 ren-ext {ρ = ρ} {Δ = Δ} {Δ′ = Δ′} {F = F} r = mkRen go
   where
@@ -222,42 +255,55 @@ wf-ren r (wf-∀ wA)    = wf-∀ (wf-ren (ren-ext r) wA)
 -- 4.  TRANSPORT II — type context growth / knowledge refinement
 ------------------------------------------------------------------------
 
--- E ⊑ᵉ E′ : E′ knows at least what E knows.  Each constructor's two
--- letters are the two entries it relates — `a` = abst, `b` = bind,
--- `m` = masked — with `u` for "unmasked, whatever it is".
+-- b ⊑ᵇ b′ : b′ knows at least what b knows, AT THE BINDING LAYER.  Each
+-- constructor's two letters are the two bindings it relates — `a` = abst,
+-- `b` = bind.
 --   le-aa : abst stays abst
 --   le-ab : a Λ-bound slot may become a binder              (TyBeta)
 --   le-bb : a binder keeps its rep
+-- There is NO clause in the other direction: a binder never loses its rep.
+data _⊑ᵇ_ : Binding → Binding → Set where
+  le-aa : abst ⊑ᵇ abst
+  le-ab : abst ⊑ᵇ bind A
+  le-bb : bind A ⊑ᵇ bind A
+
+-- … and E ⊑ᵉ E′ lifts it through the LOCK LAYER.  `u` = unmasked,
+-- `m` = masked; the pair of letters is the pair of locks.
+--   le-uu : a nameable slot stays nameable
 --   le-mm : concealment is monotone in what it hides
 --   le-mu : a concealed slot may be re-exposed              (Cancel)
--- There is NO clause in the other direction: a binder never loses its rep.
+-- There is no `le-um`: refinement never hides.
 data _⊑ᵉ_ : Ent → Ent → Set where
-  le-aa : abst ⊑ᵉ abst
-  le-ab : abst ⊑ᵉ bind A
-  le-bb : bind A ⊑ᵉ bind A
-  le-mm : E ⊑ᵉ E′ → masked E ⊑ᵉ masked E′
-  le-mu : E ⊑ᵉ E′ → Nameable E′ → masked E ⊑ᵉ E′
+  le-uu : b ⊑ᵇ b′ → unmasked b ⊑ᵉ unmasked b′
+  le-mm : b ⊑ᵇ b′ → masked b   ⊑ᵉ masked b′
+  le-mu : b ⊑ᵇ b′ → masked b   ⊑ᵉ unmasked b′
 
 infix 4 _⊑_
 data _⊑_ : Ctxᵗ → Ctxᵗ → Set where
   le[] : [] ⊑ []
   le∷  : E ⊑ᵉ E′ → Δ ⊑ Δ′ → (E ∷ Δ) ⊑ (E′ ∷ Δ′)
 
+⊑ᵇ-refl : (b : Binding) → b ⊑ᵇ b
+⊑ᵇ-refl abst     = le-aa
+⊑ᵇ-refl (bind A) = le-bb
+
 ⊑ᵉ-refl : (E : Ent) → E ⊑ᵉ E
-⊑ᵉ-refl abst    = le-aa
-⊑ᵉ-refl (bind A) = le-bb
-⊑ᵉ-refl (masked E) = le-mm (⊑ᵉ-refl E)
+⊑ᵉ-refl (unmasked b) = le-uu (⊑ᵇ-refl b)
+⊑ᵉ-refl (masked b)   = le-mm (⊑ᵇ-refl b)
 
 ⊑-refl : (Δ : Ctxᵗ) → Δ ⊑ Δ
 ⊑-refl []      = le[]
 ⊑-refl (E ∷ Δ) = le∷ (⊑ᵉ-refl E) (⊑-refl Δ)
 
+⊑ᵇ-⇑ : b ⊑ᵇ b′ → renᵇ ρ b ⊑ᵇ renᵇ ρ b′
+⊑ᵇ-⇑ le-aa = le-aa
+⊑ᵇ-⇑ le-ab = le-ab
+⊑ᵇ-⇑ le-bb = le-bb
+
 ⊑ᵉ-⇑ : E ⊑ᵉ E′ → ⇑ᵉ E ⊑ᵉ ⇑ᵉ E′
-⊑ᵉ-⇑ le-aa        = le-aa
-⊑ᵉ-⇑ le-ab        = le-ab
-⊑ᵉ-⇑ le-bb        = le-bb
-⊑ᵉ-⇑ (le-mm l)    = le-mm (⊑ᵉ-⇑ l)
-⊑ᵉ-⇑ (le-mu l v)  = le-mu (⊑ᵉ-⇑ l) (renᵉ-Nameable v)
+⊑ᵉ-⇑ (le-uu l) = le-uu (⊑ᵇ-⇑ l)
+⊑ᵉ-⇑ (le-mm l) = le-mm (⊑ᵇ-⇑ l)
+⊑ᵉ-⇑ (le-mu l) = le-mu (⊑ᵇ-⇑ l)
 
 ⊑-∋e : Δ ⊑ Δ′ → Δ ∋e X , E → ∃[ E′ ] ((Δ′ ∋e X , E′) × E ⊑ᵉ E′)
 ⊑-∋e (le∷ l ls) ez     = _ , ez , ⊑ᵉ-⇑ l
@@ -265,11 +311,9 @@ data _⊑_ : Ctxᵗ → Ctxᵗ → Set where
 ... | E′ , d′ , l′ = _ , es d′ , ⊑ᵉ-⇑ l′
 
 nameable-mono : E ⊑ᵉ E′ → Nameable E → Nameable E′
-nameable-mono le-aa        nameable-a = nameable-a
-nameable-mono le-ab        nameable-a = nameable-b
-nameable-mono le-bb        nameable-b = nameable-b
-nameable-mono (le-mm _)    ()
-nameable-mono (le-mu _ _)  ()
+nameable-mono (le-uu _) nameable = nameable
+nameable-mono (le-mm _) ()
+nameable-mono (le-mu _) ()
 
 ⊑-tv : Δ ⊑ Δ′ → Δ ∋tv X → Δ′ ∋tv X
 ⊑-tv ls (E , d , v) with ⊑-∋e ls d
@@ -279,18 +323,21 @@ nameable-mono (le-mu _ _)  ()
 -- source is `bind A` is `le-bb`.  This is the deleted demotion, as a theorem.
 ⊑-kn : Δ ⊑ Δ′ → Δ ∋ X := A → Δ′ ∋ X := A
 ⊑-kn ls d with ⊑-∋e ls d
-... | bind A , d′ , le-bb = d′
+... | unmasked (bind A) , d′ , le-uu le-bb = d′
 
--- Refinement composes.  (The only clause that has to think is `le-mu`:
--- an entry that stops being blocked stays unblocked, and `nameable-mono`
--- carries its visibility along the second step.)
+-- Refinement composes.  Transitivity is now the LOCK LAYER's four legal
+-- compositions over `⊑ᵇ-trans`, and no clause has to carry a `Nameable`
+-- witness: the second step's lock is read off its constructor.
+⊑ᵇ-trans : b ⊑ᵇ b′ → b′ ⊑ᵇ b″ → b ⊑ᵇ b″
+⊑ᵇ-trans le-aa l′    = l′
+⊑ᵇ-trans le-ab le-bb = le-ab
+⊑ᵇ-trans le-bb le-bb = le-bb
+
 ⊑ᵉ-trans : E ⊑ᵉ E′ → E′ ⊑ᵉ E″ → E ⊑ᵉ E″
-⊑ᵉ-trans le-aa       l′           = l′
-⊑ᵉ-trans le-ab       le-bb        = le-ab
-⊑ᵉ-trans le-bb       le-bb        = le-bb
-⊑ᵉ-trans (le-mm l)   (le-mm l′)   = le-mm (⊑ᵉ-trans l l′)
-⊑ᵉ-trans (le-mm l)   (le-mu l′ v) = le-mu (⊑ᵉ-trans l l′) v
-⊑ᵉ-trans (le-mu l v) l′           = le-mu (⊑ᵉ-trans l l′) (nameable-mono l′ v)
+⊑ᵉ-trans (le-uu l) (le-uu l′) = le-uu (⊑ᵇ-trans l l′)
+⊑ᵉ-trans (le-mm l) (le-mm l′) = le-mm (⊑ᵇ-trans l l′)
+⊑ᵉ-trans (le-mm l) (le-mu l′) = le-mu (⊑ᵇ-trans l l′)
+⊑ᵉ-trans (le-mu l) (le-uu l′) = le-mu (⊑ᵇ-trans l l′)
 
 ⊑-trans : Δ ⊑ Δ′ → Δ′ ⊑ Δ″ → Δ ⊑ Δ″
 ⊑-trans le[]       le[]         = le[]
@@ -301,7 +348,7 @@ nameable-mono (le-mu _ _)  ()
 ⊑-wf ls wf-ℕ         = wf-ℕ
 ⊑-wf ls wf-𝔹         = wf-𝔹
 ⊑-wf ls (wf-⇒ wA wB) = wf-⇒ (⊑-wf ls wA) (⊑-wf ls wB)
-⊑-wf ls (wf-∀ wA)    = wf-∀ (⊑-wf (le∷ le-aa ls) wA)
+⊑-wf ls (wf-∀ wA)    = wf-∀ (⊑-wf (le∷ (le-uu le-aa) ls) wA)
 
 ------------------------------------------------------------------------
 -- 4b.  TRANSPORT IIa — refinement THAT DOES NOT RE-EXPOSE
@@ -314,11 +361,12 @@ nameable-mono (le-mu _ _)  ()
 -- (`sw-u`, strong.CtxMorph) and `le-mu` destroys the claim.  Types and
 -- conversions keep the full `_⊑_` (`⊑-wf`, `conv-⊑`): a TYPE claims
 -- nameability, which only grows.
+-- The BINDING layer is shared with `_⊑ᵉ_` — learning a rep at an
+-- abstract slot is legal for both.  Only the LOCK layer differs: the two
+-- locks must AGREE.
 data _⊑ᵃᵉ_ : Ent → Ent → Set where
-  la-aa : abst ⊑ᵃᵉ abst
-  la-ab : abst ⊑ᵃᵉ bind A
-  la-bb : bind A ⊑ᵃᵉ bind A
-  la-mm : E ⊑ᵃᵉ E′ → masked E ⊑ᵃᵉ masked E′
+  la-uu : b ⊑ᵇ b′ → unmasked b ⊑ᵃᵉ unmasked b′
+  la-mm : b ⊑ᵇ b′ → masked b   ⊑ᵃᵉ masked b′
 
 infix 4 _⊑ᵃ_
 data _⊑ᵃ_ : Ctxᵗ → Ctxᵗ → Set where
@@ -326,29 +374,24 @@ data _⊑ᵃ_ : Ctxᵗ → Ctxᵗ → Set where
   la∷  : E ⊑ᵃᵉ E′ → Δ ⊑ᵃ Δ′ → (E ∷ Δ) ⊑ᵃ (E′ ∷ Δ′)
 
 ⊑ᵃᵉ→⊑ᵉ : E ⊑ᵃᵉ E′ → E ⊑ᵉ E′
-⊑ᵃᵉ→⊑ᵉ la-aa     = le-aa
-⊑ᵃᵉ→⊑ᵉ la-ab     = le-ab
-⊑ᵃᵉ→⊑ᵉ la-bb     = le-bb
-⊑ᵃᵉ→⊑ᵉ (la-mm l) = le-mm (⊑ᵃᵉ→⊑ᵉ l)
+⊑ᵃᵉ→⊑ᵉ (la-uu l) = le-uu l
+⊑ᵃᵉ→⊑ᵉ (la-mm l) = le-mm l
 
 ⊑ᵃ→⊑ : Δ ⊑ᵃ Δ′ → Δ ⊑ Δ′
 ⊑ᵃ→⊑ la[]        = le[]
 ⊑ᵃ→⊑ (la∷ l ls)  = le∷ (⊑ᵃᵉ→⊑ᵉ l) (⊑ᵃ→⊑ ls)
 
 ⊑ᵃᵉ-refl : (E : Ent) → E ⊑ᵃᵉ E
-⊑ᵃᵉ-refl abst       = la-aa
-⊑ᵃᵉ-refl (bind A)   = la-bb
-⊑ᵃᵉ-refl (masked E) = la-mm (⊑ᵃᵉ-refl E)
+⊑ᵃᵉ-refl (unmasked b) = la-uu (⊑ᵇ-refl b)
+⊑ᵃᵉ-refl (masked b)   = la-mm (⊑ᵇ-refl b)
 
 ⊑ᵃ-refl : (Δ : Ctxᵗ) → Δ ⊑ᵃ Δ
 ⊑ᵃ-refl []      = la[]
 ⊑ᵃ-refl (E ∷ Δ) = la∷ (⊑ᵃᵉ-refl E) (⊑ᵃ-refl Δ)
 
 ⊑ᵃᵉ-⇑ : E ⊑ᵃᵉ E′ → ⇑ᵉ E ⊑ᵃᵉ ⇑ᵉ E′
-⊑ᵃᵉ-⇑ la-aa     = la-aa
-⊑ᵃᵉ-⇑ la-ab     = la-ab
-⊑ᵃᵉ-⇑ la-bb     = la-bb
-⊑ᵃᵉ-⇑ (la-mm l) = la-mm (⊑ᵃᵉ-⇑ l)
+⊑ᵃᵉ-⇑ (la-uu l) = la-uu (⊑ᵇ-⇑ l)
+⊑ᵃᵉ-⇑ (la-mm l) = la-mm (⊑ᵇ-⇑ l)
 
 ⊑ᵃ-∋e : Δ ⊑ᵃ Δ′ → Δ ∋e X , E → ∃[ E′ ] ((Δ′ ∋e X , E′) × E ⊑ᵃᵉ E′)
 ⊑ᵃ-∋e (la∷ l ls) ez     = _ , ez , ⊑ᵃᵉ-⇑ l
@@ -358,7 +401,8 @@ data _⊑ᵃ_ : Ctxᵗ → Ctxᵗ → Set where
 -- THE CLAUSE THAT MAKES `⊑ᵃ` THE RIGHT TRANSPORT FOR A BOUNDARY: a
 -- LOCKED slot stays locked.  (Under `_⊑_` it need not — that is `le-mu`.)
 ⊑ᵃᵉ-Locked : E ⊑ᵃᵉ E′ → Locked E → Locked E′
-⊑ᵃᵉ-Locked (la-mm l) (locked v) = locked (nameable-mono (⊑ᵃᵉ→⊑ᵉ l) v)
+⊑ᵃᵉ-Locked (la-uu l) ()
+⊑ᵃᵉ-Locked (la-mm l) locked = locked
 
 ⊑ᵃ-tv : Δ ⊑ᵃ Δ′ → Δ ∋tv X → Δ′ ∋tv X
 ⊑ᵃ-tv ls tv = ⊑-tv (⊑ᵃ→⊑ ls) tv
@@ -437,31 +481,41 @@ base≢var n base-𝔹 eq with trans (sym (shiftBy-base n base-𝔹)) eq
 -- 6.  Masking a slot in place  (the conceal/alias mechanism)
 ------------------------------------------------------------------------
 
--- One entry update at one slot: `mask = updateAt masked` and
+-- One entry update at one slot: `mask = updateAt maskEnt` and
 -- `unmask = updateAt unmaskEnt`.
 updateAt : (Ent → Ent) → ℕ → Ctxᵗ → Ctxᵗ
 updateAt f X       []      = []
 updateAt f zero    (E ∷ Δ) = f E ∷ Δ
 updateAt f (suc X) (E ∷ Δ) = E ∷ updateAt f X Δ
 
+-- SETTING THE LOCK, AND CLEARING IT.  Both are TOTAL and IDEMPOTENT:
+-- there is only one lock to set or clear.  `maskEnt` is never applied to
+-- an already-masked slot in a well-formed term — `sw-l` (strong.CtxMorph)
+-- and `mw-l` demand that the slot be NAMEABLE — but the function does not
+-- have to know that, and that is the point: nothing has to rule out a
+-- second mask, because a second mask is not expressible.
+maskEnt : Ent → Ent
+maskEnt (unmasked b) = masked b
+maskEnt (masked b)   = masked b
+
 unmaskEnt : Ent → Ent
-unmaskEnt abst       = abst
-unmaskEnt (bind A)   = bind A
-unmaskEnt (masked E) = E
+unmaskEnt (unmasked b) = unmasked b
+unmaskEnt (masked b)   = unmasked b
 
 mask unmask : ℕ → Ctxᵗ → Ctxᵗ
-mask   = updateAt masked
+mask   = updateAt maskEnt
 unmask = updateAt unmaskEnt
 
 -- Both update functions commute with renaming — they touch no spelling.
-masked-comm : (ρ : Renameᵗ) (E : Ent) → renᵉ ρ (masked E) ≡ masked (renᵉ ρ E)
-masked-comm ρ E = refl
+maskEnt-comm : (ρ : Renameᵗ) (E : Ent)
+  → renᵉ ρ (maskEnt E) ≡ maskEnt (renᵉ ρ E)
+maskEnt-comm ρ (unmasked b) = refl
+maskEnt-comm ρ (masked b)   = refl
 
 unmaskEnt-comm : (ρ : Renameᵗ) (E : Ent)
   → renᵉ ρ (unmaskEnt E) ≡ unmaskEnt (renᵉ ρ E)
-unmaskEnt-comm ρ abst       = refl
-unmaskEnt-comm ρ (bind A)   = refl
-unmaskEnt-comm ρ (masked E) = refl
+unmaskEnt-comm ρ (unmasked b) = refl
+unmaskEnt-comm ρ (masked b)   = refl
 
 _≟ℕ_ : (X Y : ℕ) → Dec (X ≡ Y)
 zero  ≟ℕ zero  = yes refl
@@ -520,64 +574,58 @@ module _ (f : Ent → Ent)
   ⊑-updateAt {suc X} fm (le∷ l ls) = le∷ l (⊑-updateAt fm ls)
   ⊑-updateAt         fm le[]       = le[]
 
-masked-mono : E ⊑ᵉ E′ → masked E ⊑ᵉ masked E′
-masked-mono = le-mm
+maskEnt-mono : E ⊑ᵉ E′ → maskEnt E ⊑ᵉ maskEnt E′
+maskEnt-mono (le-uu l) = le-mm l
+maskEnt-mono (le-mm l) = le-mm l
+maskEnt-mono (le-mu l) = le-mm l
 
 -- Masking a slot only LOSES nameability, so a masked type context refines to the
 -- unmasked one.  (There is no converse: that is the deleted demotion.)
-masked-le : E ⊑ᵉ E′ → masked E ⊑ᵉ E′
-masked-le le-aa       = le-mu le-aa nameable-a
-masked-le le-ab       = le-mu le-ab nameable-b
-masked-le le-bb       = le-mu le-bb nameable-b
-masked-le (le-mm l)   = le-mm (masked-le l)
-masked-le (le-mu l v) = le-mu (le-mu l v) v
-
-unmaskEnt-nameable : E ⊑ᵉ E′ → Nameable E′ → E ⊑ᵉ unmaskEnt E′
-unmaskEnt-nameable l nameable-a = l
-unmaskEnt-nameable l nameable-b = l
+-- Every clause is now ONE lock step, with no recursion and no `Nameable`
+-- witness to invent — the target's lock is read off its constructor.
+maskEnt-le : E ⊑ᵉ E′ → maskEnt E ⊑ᵉ E′
+maskEnt-le (le-uu l) = le-mu l
+maskEnt-le (le-mm l) = le-mm l
+maskEnt-le (le-mu l) = le-mu l
 
 unmaskEnt-mono : E ⊑ᵉ E′ → unmaskEnt E ⊑ᵉ unmaskEnt E′
-unmaskEnt-mono le-aa       = le-aa
-unmaskEnt-mono le-ab       = le-ab
-unmaskEnt-mono le-bb       = le-bb
-unmaskEnt-mono (le-mm l)   = l
-unmaskEnt-mono (le-mu l v) = unmaskEnt-nameable l v
+unmaskEnt-mono (le-uu l) = le-uu l
+unmaskEnt-mono (le-mm l) = le-uu l
+unmaskEnt-mono (le-mu l) = le-uu l
 
 ren-mask : Ren ρ Δ Δ′ → Inj ρ → Ren ρ (mask X Δ) (mask (ρ X) Δ′)
-ren-mask = ren-updateAt masked masked-comm
+ren-mask = ren-updateAt maskEnt maskEnt-comm
 
 ren-unmask : Ren ρ Δ Δ′ → Inj ρ → Ren ρ (unmask X Δ) (unmask (ρ X) Δ′)
 ren-unmask = ren-updateAt unmaskEnt unmaskEnt-comm
 
 mask-⊑ : (Y : ℕ) → Δ ⊑ Δ′ → mask Y Δ ⊑ Δ′
 mask-⊑ Y       le[]        = le[]
-mask-⊑ zero    (le∷ l ls)  = le∷ (masked-le l) ls
+mask-⊑ zero    (le∷ l ls)  = le∷ (maskEnt-le l) ls
 mask-⊑ (suc Y) (le∷ l ls)  = le∷ l (mask-⊑ Y ls)
 
 -- Unmasking only ADDS nameability, so the type context refines to its own
--- unmasking.  (The `masked` clause is `masked-le` at reflexivity: peeling one
--- `masked` is the ⊑ᵉ step `le-mu`.)
+-- unmasking.  (The `masked` clause is the ⊑ᵉ step `le-mu` itself: there
+-- is exactly one lock to clear.)
 ⊑ᵉ-unmaskEnt : (E : Ent) → E ⊑ᵉ unmaskEnt E
-⊑ᵉ-unmaskEnt abst        = le-aa
-⊑ᵉ-unmaskEnt (bind A)    = le-bb
-⊑ᵉ-unmaskEnt (masked E)  = masked-le (⊑ᵉ-refl E)
+⊑ᵉ-unmaskEnt (unmasked b) = le-uu (⊑ᵇ-refl b)
+⊑ᵉ-unmaskEnt (masked b)   = le-mu (⊑ᵇ-refl b)
 
 unmask-⊑ : (Y : ℕ) (Δ : Ctxᵗ) → Δ ⊑ unmask Y Δ
 unmask-⊑ Y       []      = le[]
 unmask-⊑ zero    (E ∷ Δ) = le∷ (⊑ᵉ-unmaskEnt E) (⊑-refl Δ)
 unmask-⊑ (suc Y) (E ∷ Δ) = le∷ (⊑ᵉ-refl E) (unmask-⊑ Y Δ)
 
--- The `_⊑ᵃ_` transport of a one-slot update.  Both `masked` and
--- `unmaskEnt` are monotone for it — and `unmaskEnt` is TOTAL here only
--- because `_⊑ᵃᵉ_` has no `le-mu` clause to think about.
-masked-monoᵃ : E ⊑ᵃᵉ E′ → masked E ⊑ᵃᵉ masked E′
-masked-monoᵃ = la-mm
+-- The `_⊑ᵃ_` transport of a one-slot update.  Both `maskEnt` and
+-- `unmaskEnt` are monotone for it: each simply rewrites the LOCK layER
+-- and passes the binding step through.
+maskEnt-monoᵃ : E ⊑ᵃᵉ E′ → maskEnt E ⊑ᵃᵉ maskEnt E′
+maskEnt-monoᵃ (la-uu l) = la-mm l
+maskEnt-monoᵃ (la-mm l) = la-mm l
 
 unmaskEnt-monoᵃ : E ⊑ᵃᵉ E′ → unmaskEnt E ⊑ᵃᵉ unmaskEnt E′
-unmaskEnt-monoᵃ la-aa     = la-aa
-unmaskEnt-monoᵃ la-ab     = la-ab
-unmaskEnt-monoᵃ la-bb     = la-bb
-unmaskEnt-monoᵃ (la-mm l) = l
+unmaskEnt-monoᵃ (la-uu l) = la-uu l
+unmaskEnt-monoᵃ (la-mm l) = la-uu l
 
 ⊑ᵃ-updateAt : (f : Ent → Ent) → (∀ {E E′} → E ⊑ᵃᵉ E′ → f E ⊑ᵃᵉ f E′)
   → ∀ {X Δ Δ′} → Δ ⊑ᵃ Δ′ → updateAt f X Δ ⊑ᵃ updateAt f X Δ′
@@ -589,18 +637,32 @@ unmaskEnt-monoᵃ (la-mm l) = l
 -- 6b.  Locking and unlocking are EXACT INVERSES at a LOCKED slot
 ------------------------------------------------------------------------
 
--- Unmasking undoes masking, always: `masked` is injective.
-unmask-mask : (X : ℕ) (Δ : Ctxᵗ) → unmask X (mask X Δ) ≡ Δ
-unmask-mask X       []      = refl
-unmask-mask zero    (E ∷ Δ) = refl
-unmask-mask (suc X) (E ∷ Δ) = cong (E ∷_) (unmask-mask X Δ)
+-- THE TWO INVERSES ARE NOW SYMMETRIC, and each carries the one-clause
+-- premise its own direction needs.
+--
+-- Unmasking undoes masking ONLY AT A NAMEABLE SLOT.  This is the ONE
+-- place the two-layer entry costs something: with a stack of masks,
+-- `unmask ∘ mask` was the identity everywhere (`masked` was injective and
+-- the extra lock was simply popped); with one lock, `maskEnt` is
+-- IDEMPOTENT, so at an already-masked slot `unmask (mask X Δ)` exposes
+-- what Δ had hidden.  The premise is always at hand: `sw-l`
+-- (strong.CtxMorph) admits `lock X` only at a `∋tv` slot, which is
+-- exactly the discipline that made double masking unreachable before.
+unmaskEnt-maskEnt : Nameable E → unmaskEnt (maskEnt E) ≡ E
+unmaskEnt-maskEnt nameable = refl
+
+unmask-mask : ∀ {Δ X} → Δ ∋tv X → unmask X (mask X Δ) ≡ Δ
+unmask-mask (_ , ez   , v) =
+  cong (_∷ _) (unmaskEnt-maskEnt (renᵉ-Nameable⁻ v))
+unmask-mask (_ , es d , v) =
+  cong (_ ∷_) (unmask-mask (_ , d , renᵉ-Nameable⁻ v))
 
 -- Masking undoes unmasking ONLY at a LOCKED slot — which is exactly what
 -- `sw-u` (strong.CtxMorph) demands of every `unlock`, and exactly why a
 -- vacuous unlock had to be refused: at an already-nameable slot the
 -- restoring `lock` of the dual would mask what the exterior left visible.
-maskEnt-unmask : Locked E → masked (unmaskEnt E) ≡ E
-maskEnt-unmask (locked v) = refl
+maskEnt-unmask : Locked E → maskEnt (unmaskEnt E) ≡ E
+maskEnt-unmask locked = refl
 
 mask-unmask : ∀ {Δ X} → Δ ∋lk X → mask X (unmask X Δ) ≡ Δ
 mask-unmask (_ , ez     , lk) =
@@ -610,12 +672,12 @@ mask-unmask (_ , es d   , lk) =
 
 -- The two entry-level moves the dual performs, as lookup facts.
 unmask-∋tv : ∀ {Δ X} → Δ ∋lk X → unmask X Δ ∋tv X
-unmask-∋tv (E , d , locked v) =
-  _ , updateAt-hit unmaskEnt unmaskEnt-comm d , v
+unmask-∋tv (masked b , d , locked) =
+  _ , updateAt-hit unmaskEnt unmaskEnt-comm d , nameable
 
 mask-∋lk : ∀ {Δ X} → Δ ∋tv X → mask X Δ ∋lk X
-mask-∋lk (E , d , v) =
-  _ , updateAt-hit masked masked-comm d , locked v
+mask-∋lk (unmasked b , d , nameable) =
+  _ , updateAt-hit maskEnt maskEnt-comm d , locked
 
 ------------------------------------------------------------------------
 -- 7.  The bind prefix
@@ -628,7 +690,8 @@ mask-∋lk (E , d , v) =
 -- sibling binds never interfere.
 pushBinds : List Ty → Ctxᵗ → Ctxᵗ
 pushBinds []       Δ = Δ
-pushBinds (A ∷ As) Δ = bind (shiftBy (length As) A) ∷ pushBinds As Δ
+pushBinds (A ∷ As) Δ =
+  unmasked (bind (shiftBy (length As) A)) ∷ pushBinds As Δ
 
 -- As a well-formedness fact: a type over the exterior is a type inside
 -- the bind prefix, lifted past exactly the binders in that prefix.
@@ -649,7 +712,8 @@ updateAt-pushBinds : (f : Ent → Ent) (As : List Ty) (X : ℕ) (Δ : Ctxᵗ)
   → updateAt f (length As + X) (pushBinds As Δ) ≡ pushBinds As (updateAt f X Δ)
 updateAt-pushBinds f []       X Δ = refl
 updateAt-pushBinds f (C ∷ As) X Δ =
-  cong (bind (shiftBy (length As) C) ∷_) (updateAt-pushBinds f As X Δ)
+  cong (unmasked (bind (shiftBy (length As) C)) ∷_)
+       (updateAt-pushBinds f As X Δ)
 
 -- A well-formed variable type IS a visible slot.
 wf-var⁻ : Δ ⊢ᵗ ` X → Δ ∋tv X
@@ -657,11 +721,11 @@ wf-var⁻ (wf-var tv) = tv
 
 ⊑-pushBinds : (As : List Ty) → Δ ⊑ Δ′ → pushBinds As Δ ⊑ pushBinds As Δ′
 ⊑-pushBinds []       ls = ls
-⊑-pushBinds (A ∷ As) ls = le∷ le-bb (⊑-pushBinds As ls)
+⊑-pushBinds (A ∷ As) ls = le∷ (le-uu le-bb) (⊑-pushBinds As ls)
 
 ⊑ᵃ-pushBinds : (As : List Ty) → Δ ⊑ᵃ Δ′ → pushBinds As Δ ⊑ᵃ pushBinds As Δ′
 ⊑ᵃ-pushBinds []       ls = ls
-⊑ᵃ-pushBinds (A ∷ As) ls = la∷ la-bb (⊑ᵃ-pushBinds As ls)
+⊑ᵃ-pushBinds (A ∷ As) ls = la∷ (la-uu le-bb) (⊑ᵃ-pushBinds As ls)
 
 -- The bind prefix transports the three entry-level lookups the boundary
 -- judgement reads: a rep, a nameable slot, and a LOCKED slot.

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -145,7 +145,7 @@ interior⊑convCtx Θ Δ =
 ⊑-applyChanges (unlock X ∷ S) ls =
   ⊑-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-mono (⊑-applyChanges S ls)
 ⊑-applyChanges (lock X ∷ S)   ls =
-  ⊑-updateAt masked masked-comm masked-mono (⊑-applyChanges S ls)
+  ⊑-updateAt maskEnt maskEnt-comm maskEnt-mono (⊑-applyChanges S ls)
 
 ⊑-applyUnlocks : (S : List Change) → Δ ⊑ Δ′
   → applyUnlocks S Δ ⊑ applyUnlocks S Δ′
@@ -172,7 +172,7 @@ interior⊑convCtx Θ Δ =
 ⊑ᵃ-applyChanges (unlock X ∷ S) ls =
   ⊑ᵃ-updateAt unmaskEnt unmaskEnt-monoᵃ (⊑ᵃ-applyChanges S ls)
 ⊑ᵃ-applyChanges (lock X ∷ S)   ls =
-  ⊑ᵃ-updateAt masked masked-monoᵃ (⊑ᵃ-applyChanges S ls)
+  ⊑ᵃ-updateAt maskEnt maskEnt-monoᵃ (⊑ᵃ-applyChanges S ls)
 
 ⊑ᵃ-scope : (Θ : CtxMorph) → Δ ⊑ᵃ Δ′ → scope Θ Δ ⊑ᵃ scope Θ Δ′
 ⊑ᵃ-scope Θ ls = ⊑ᵃ-applyChanges (changes Θ) ls

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -194,8 +194,10 @@ interior⊑convCtx Θ Δ =
 -- For the tail S′ of the entry:
 --
 --   lock X    X is NAMEABLE in `applyChanges S′ Δ`  (you may only mask
---             what is visible: no double masking, so `Locked` is one mask
---             deep)
+--             what is visible; `Locked` is one mask deep BY
+--             CONSTRUCTION now — strong.Ctx §1 — but the premise still
+--             earns its keep: it is what makes `unmask ∘ mask` the
+--             identity at the slot, `unmask-mask`, strong.Ctx §6b)
 --   unlock X  X is LOCKED   in `applyChanges S′ Δ`  (`∋lk`: masked over a
 --             nameable entry).  A VACUOUS UNLOCK — `↥X` at a slot the
 --             frame leaves visible — IS REFUSED; it is the premise the

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -948,7 +948,7 @@ It is repaired, in two coupled halves — the restoring, reversed
 The frame identity is then **exact**:
 
     (†)  interior (dual Θ) (interior Θ Δ)
-           ≡ map masked (pushBinds (binds Θ) []) ++ Δ       given Δ ⊢ᵐ Θ
+           ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ      given Δ ⊢ᵐ Θ
 
 *the crossing argument's frame IS the exterior*, one (masked) bind prefix
 in — so the argument crosses by `⊢rename (wkN (numBinds Θ))` alone, with
@@ -960,7 +960,7 @@ its frame.
 ### 6.4 `TyPeelR` — a `∀` conversion meets a type application
 
     TyPeelR : Value V
-      → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+      → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
       → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
           -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
@@ -1149,9 +1149,9 @@ reorders a mask/unmask pair, and the value's frame is then not refined
 but **corrupted** — a slot it may name in the redex is masked in the
 contractum.  The refutation is in tree
 (`proof/MoveScope` §4b, `¬frame-locksOnly`) at the `_⊢ᵐ_`-legal witness
-`Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])` over `Δ✗ = bind ℕ ∷ []`, where
-`interior Θ✗ Δ✗ ≡ bind ℕ ∷ []` but the lock-only contractum's interior is
-`masked (bind ℕ) ∷ []`.  Moving the whole scope keeps the order, and then
+`Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])` over `Δ✗ = unmasked (bind ℕ) ∷ []`,
+where `interior Θ✗ Δ✗ ≡ unmasked (bind ℕ) ∷ []` but the lock-only
+contractum's interior is `masked (bind ℕ) ∷ []`.  Moving the whole scope keeps the order, and then
 the value's frame is preserved **on the nose**: with `rewind` outside,
 both frame lemmas are equalities,
 
@@ -1182,12 +1182,12 @@ and three `Drop$` steps finish.
     ξ-·-l : Δ ⊢ L -→ L′            → Δ ⊢ L · M -→ L′ · M
     ξ-·-r : Value V → Δ ⊢ M -→ M′  → Δ ⊢ V · M -→ V · M′
     ξ-·[] : Δ ⊢ L -→ L′            → Δ ⊢ L ·[ B , A ] -→ L′ ·[ B , A ]
-    ξ-Λ   : (abst ∷ Δ) ⊢ N -→ N′   → Δ ⊢ Λ N -→ Λ N′
+    ξ-Λ   : (unmasked abst ∷ Δ) ⊢ N -→ N′   → Δ ⊢ Λ N -→ Λ N′
     ξ-⟪⟫  : interior Θ Δ ⊢ M -→ M′     → Δ ⊢ M ⟪ Θ , c ⟫ -→ M′ ⟪ Θ , c ⟫
 
 Left-to-right, call-by-value, and **under `Λ`** — which is why `V-Λ` and
 `TyBeta` both carry `Value N`.  Note the two index changes: `ξ-Λ` steps
-in `abst ∷ Δ`, and `ξ-⟪⟫` steps in the *interior* type context
+in `unmasked abst ∷ Δ`, and `ξ-⟪⟫` steps in the *interior* type context
 `interior Θ Δ`.  A boundary is not a barrier to reduction; it is a barrier to
 *naming*.
 
@@ -1260,8 +1260,8 @@ exactly the two that the id-layer rules consume.
 Induction on the step, with the rule cases distributed:
 
 * **`TyBeta`** (`proof/Preserve.preserve-TyBeta`) — the mint.  The new
-  binder is the `abst ⊑ᵉ bind A` refinement of the `Λ`'s own slot
-  (`le-ab`), so the interior retypes by `⊢retag`; the minted conversion
+  binder is the `unmasked abst ⊑ᵃᵉ unmasked (bind A)` refinement of the
+  `Λ`'s own slot (`la-uu le-ab`), so the interior retypes by `⊢retag`; the minted conversion
   types by `⊢reveal`/`⊢conceal`, and its exterior type is the
   instantiated body by `subst-at-0`.  The exterior premise is `⊢·[]`'s
   own two premises through `wf-[]ᵗ`, and `interior (morph (A ∷ []) []) Δ` is
@@ -1270,7 +1270,7 @@ Induction on the step, with the rule cases distributed:
 * **`Peel`** (`proof/PeelDual.preserve-Peel`) — the two context
   identities are what carries it: (†)
   `interior (dual Θ) (interior Θ Δ)
-  ≡ map masked (pushBinds (binds Θ) []) ++ Δ` (given `Δ ⊢ᵐ Θ`)
+  ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ` (given `Δ ⊢ᵐ Θ`)
   and `convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ`.  The crossing
   argument, typed in `Δ`, retypes one bind frame deeper by
   `⊢rename (wkN (numBinds Θ))` and **nothing else** — the tail is `Δ`
@@ -1336,9 +1336,9 @@ is a known function of the old one:
 
 | rule | the moved subterm's new frame |
 |------|-------------------------------|
-| `TyBeta` | `interior (morph (A ∷ []) []) Δ ≡ bind A ∷ Δ` — `Δ` on the nose, one refinement (`abst ⊑ᵃᵉ bind A`) at the slot the rule reveals |
+| `TyBeta` | `interior (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ` — `Δ` on the nose, one refinement (`unmasked abst ⊑ᵃᵉ unmasked (bind A)`, i.e. `la-uu le-ab`) at the slot the rule reveals |
 | `TyPeelR` | `interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ` — the redex's frame, one binder in, which `wkᴹ 1` matches |
-| `Peel` | (†) `interior (dual Θ) (interior Θ Δ) ≡ map masked (pushBinds (binds Θ) []) ++ Δ`, given `Δ ⊢ᵐ Θ` (`proof/PeelDual.interior-dual`) |
+| `Peel` | (†) `interior (dual Θ) (interior Θ Δ) ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ`, given `Δ ⊢ᵐ Θ` (`proof/PeelDual.interior-dual`) |
 | `CancelR`, `IdPush` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)`, given `Δ ⊢ᵐ Θ₂` (`proof/MoveScope.interior-⋉-rewind`) |
 | `Beta` | `Δ` — no frame changes |
 

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -282,7 +282,12 @@ than only at a reveal one (`proof/Preserve.preserve-TyPeelR`).
 
 ### Entries
 
-    E ::= abst | bind A | masked E
+An entry is **two layers**: what the slot *binds*, and whether the slot
+is *hidden*.  The inner layer carries every type; the outer layer is the
+lock, and there is **at most one of it** (Jeremy, 2026-09-08).
+
+    b ::= abst | bind A                       -- Binding
+    E ::= unmasked b | masked b               -- Ent
 
     Δ ::= · | E , Δ            -- Ctxᵗ = List Ent
 
@@ -290,21 +295,46 @@ than only at a reveal one (`proof/Preserve.preserve-TyPeelR`).
   invented.
 * `bind A` — the **binder** of an instantiation event; `A` is the
   representation, stored once, as a type over this entry's tail.
-* `masked E` — the slot is **masked** here: it may not be *named*, but its
-  entry `E` is **retained**, so a later `unlock` has something to point
+* `unmasked b` — the slot may be **named**.
+* `masked b` — the slot is **masked** here: it may not be *named*, but its
+  binding `b` is **retained**, so a later `unlock` has something to point
   back at.
+
+Splitting the entry this way makes *at most one mask* true **by
+construction**: `masked` takes a `Binding`, so `masked (masked …)` is not
+a term.  Nothing in the development has to rule a second lock out any
+more — see the lemma deltas at the end of this section.
 
 Lookup returns the entry shifted into the ambient context:
 
     Δ ∋e X , E                   -- slot X has entry E
     Δ ∋tv X    = ∃ E. (Δ ∋e X , E) × Nameable E
-    Δ ∋ X := A = Δ ∋e X , bind A
+    Δ ∋ X := A = Δ ∋e X , unmasked (bind A)
 
-`Nameable` holds of `abst` and of `bind A`, and never of `masked E`.  That
-is the whole of the tightness discipline: `` wf-var : Δ ∋tv X → Δ ⊢ᵗ ` X ``, so
-a masked slot has no well-formed variable type.  Lookup is a partial
-*function* (`∋e-det`, `∋:=-det`), which is what makes every rule that
-mints an identity conversion at a looked-up representation deterministic.
+`Nameable` and `Locked` are now the two constructors' own
+discriminations — one clause each, **no premise**:
+
+    nameable : Nameable (unmasked b)
+    locked   : Locked   (masked b)
+
+so `Locked` is exactly the complement of `Nameable`, and "masked over a
+nameable entry" is the only shape a masked entry *has*.  `Nameable` reads
+only the lock layer; it never looks at the `Binding`, let alone a bind's
+type (`unlock-mentions-no-rep`, `proof/Adversary`).  That is the whole of
+the tightness discipline: `` wf-var : Δ ∋tv X → Δ ⊢ᵗ ` X ``, so a masked
+slot has no well-formed variable type.  Lookup is a partial *function*
+(`∋e-det`, `∋:=-det`), which is what makes every rule that mints an
+identity conversion at a looked-up representation deterministic.
+
+Renaming and the instantiation mint both act on the **binding** and are
+lifted through the lock layer — a lock carries no spelling:
+
+    renᵇ ρ abst     = abst              renᵉ ρ (unmasked b) = unmasked (renᵇ ρ b)
+    renᵇ ρ (bind A) = bind (renameᵗ ρ A)   renᵉ ρ (masked b) = masked (renᵇ ρ b)
+
+(and the same shape for `substᵇ`/`substᵉ` in `proof/Preserve` §2a, and
+for `showBinding`/`showEntry` in `strong.Show`, whose rendered strings
+are unchanged: `X := A`, `X Λ-bound`, `⌷[…]`).
 
 Note the distinction the mask discipline forces: `↓X` and `↥X` **name**
 a possibly masked index — that is an entry, not a type — whereas
@@ -313,16 +343,22 @@ type*, not about mentioning the index in a context morphism.
 
 ### Refinement
 
-`E ⊑ᵉ E′` says `E′` knows at least what `E` knows:
+Refinement splits along the same two layers.  `b ⊑ᵇ b′` says `b′` knows
+at least what `b` knows:
 
-    abst ⊑ᵉ abst          abst ⊑ᵉ bind A          bind A ⊑ᵉ bind A
+    abst ⊑ᵇ abst          abst ⊑ᵇ bind A          bind A ⊑ᵇ bind A
       le-aa                  le-ab                   le-bb
-    E ⊑ᵉ E′ ⇒ masked E ⊑ᵉ masked E′                            le-mm
-    E ⊑ᵉ E′ and Nameable E′ ⇒ masked E ⊑ᵉ E′                   le-mu
 
-Each constructor's two letters are the two entries it relates —
-`a` = `abst`, `b` = `bind`, `m` = `masked`, with `u` for "unmasked,
-whatever it is" (Jeremy, 2026-09-06).  With `Δ ⊑ Δ′` pointwise.  There is **no** clause whose source is
+and `E ⊑ᵉ E′` lifts it through the lock layer:
+
+    b ⊑ᵇ b′ ⇒ unmasked b ⊑ᵉ unmasked b′                        le-uu
+    b ⊑ᵇ b′ ⇒ masked b   ⊑ᵉ masked b′                          le-mm
+    b ⊑ᵇ b′ ⇒ masked b   ⊑ᵉ unmasked b′                        le-mu
+
+Each constructor's two letters are the two things it relates —
+`a` = `abst`, `b` = `bind` at the binding layer; `u` = `unmasked`,
+`m` = `masked` at the lock layer (Jeremy, 2026-09-06/08).  There is no
+`le-um`: refinement never hides.  With `Δ ⊑ Δ′` pointwise.  There is **no** clause whose source is
 `bind A` other than reflexivity: a binder never loses its representation.
 That is the deleted v1 demotion, stated as the theorem
 `⊑-kn : Δ ⊑ Δ′ → Δ ∋ X := A → Δ′ ∋ X := A`.  Masking only loses
@@ -333,22 +369,32 @@ or a CONVERSION transports along `⊑` unchanged (`⊑-wf`, `conv-⊑`).
 (§4.2), and `le-mu` is precisely the clause that unmasks — so `⊢retag`
 runs along the `le-mu`-free refinement
 
-    abst ⊑ᵃᵉ abst    abst ⊑ᵃᵉ bind A    bind A ⊑ᵃᵉ bind A
-      la-aa              la-ab               la-bb
-    E ⊑ᵃᵉ E′ ⇒ masked E ⊑ᵃᵉ masked E′                     la-mm
+    b ⊑ᵇ b′ ⇒ unmasked b ⊑ᵃᵉ unmasked b′                  la-uu
+    b ⊑ᵇ b′ ⇒ masked b   ⊑ᵃᵉ masked b′                    la-mm
 
-with `Δ ⊑ᵃ Δ′` pointwise and `⊑ᵃ→⊑` the embedding.  Its one content is
-`⊑ᵃᵉ-Locked : E ⊑ᵃᵉ E′ → Locked E → Locked E′` — *a locked slot stays
-locked* — which is what `⊢ˢ-⊑ᵃ` needs at `sw-u`.  Every call site is
-covered: `preserve-TyBeta` refines an `abst` to a `bind` (`la-ab`), and
+— the *same* `⊑ᵇ` on the binding layer, with the two locks forced to
+agree.  With `Δ ⊑ᵃ Δ′` pointwise and `⊑ᵃ→⊑` the embedding.  Its one
+content is `⊑ᵃᵉ-Locked : E ⊑ᵃᵉ E′ → Locked E → Locked E′` — *a locked
+slot stays locked* — which is what `⊢ˢ-⊑ᵃ` needs at `sw-u`.  Every call
+site is covered: `preserve-TyBeta` refines an `abst` to a `bind`
+(`la-uu le-ab`), and
 the two former `le-mu` sites — the Peel crossing and the scope move — are
 now exact identities and use no retagging at all (§6.3, §6.7).
 
 ### The three operations a boundary uses
 
-    mask X Δ    = updateAt masked X Δ         -- masks slot X in place
-    unmask X Δ  = updateAt unmaskEnt X Δ       -- peels one masked at slot X
+    mask X Δ    = updateAt maskEnt X Δ        -- sets the lock at slot X
+    unmask X Δ  = updateAt unmaskEnt X Δ      -- clears the lock at slot X
     pushBinds As Δ                    -- pushes the reps As as binders
+
+    maskEnt (unmasked b) = masked b      unmaskEnt (unmasked b) = unmasked b
+    maskEnt (masked b)   = masked b      unmaskEnt (masked b)   = unmasked b
+
+Both are **total** and **idempotent**: there is only one lock to set or
+clear.  `maskEnt` is never applied to an already-masked slot in a
+well-formed term — `sw-l` (§4.2) admits `lock X` only at a nameable
+slot — but the function does not have to know that, and that is the
+point.
 
 `updateAt f X` replaces the entry at slot `X` and leaves the rest alone, so
 masking is *positional* — which is why the renaming transports carry
@@ -358,7 +404,8 @@ no representation at all.
 `pushBinds` deserves its own line, because it is where **simultaneity** lives:
 
     pushBinds []       Δ = Δ
-    pushBinds (A ∷ As) Δ = bind (shiftBy (length As) A) ∷ pushBinds As Δ
+    pushBinds (A ∷ As) Δ =
+      unmasked (bind (shiftBy (length As) A)) ∷ pushBinds As Δ
 
 The head of the list is interior slot 0.  A representation is a type over
 the *exterior*, so it is lifted past exactly the binders **inside** it and
@@ -447,7 +494,7 @@ Diagram:
                                                  |  the lock, lifted
     conversion      convCtx Θ Δ             Y := X ,   X := ℕ
 
-`⌷[…]` is the renderer's mark for `masked`.  Read the two bottom rows: the
+`⌷[…]` is the renderer's mark for the lock.  Read the two bottom rows: the
 interior may name `Y` but **not** `X` — that is the type abstraction the
 lock enforces — while the conversion is checked one row down, where `X`
 is live, so `seal X` can cite `X`'s binder.  The conversion typed there is
@@ -463,6 +510,46 @@ Indices: everything inside the boundary is `numBinds Θ` slots deeper than
 outside, so an exterior type `Bₑ` is read inside as `shiftBy (numBinds Θ) Bₑ`.
 `lock X` / `unlock X` name **exterior** slots, and the rules that move a
 morphism inward lift those names by the bind count (`shiftScope`, §6.7).
+
+### What the one-mask entry costs, and what it buys
+
+*Bought* (each of these used to be an induction over the mask stack, or a
+premise carried only to keep the stack one deep):
+
+| before | after |
+|--------|-------|
+| `locked : Nameable E → Locked (masked E)` | `locked : Locked (masked b)` — no premise |
+| `nameable-a`, `nameable-b` | one `nameable` |
+| `⊑ᵉ-trans`, 6 clauses, `le-mu` calling `nameable-mono` | `⊑ᵇ-trans` 3 + `⊑ᵉ-trans` 4, no witness threading |
+| `le-mu : E ⊑ᵉ E′ → Nameable E′ → masked E ⊑ᵉ E′` | `le-mu : b ⊑ᵇ b′ → masked b ⊑ᵉ unmasked b′` |
+| `unmaskEnt-nameable` (a lemma, only to feed `le-mu`) | **gone** |
+| `masked-le`, recursive on the mask stack | `maskEnt-le`, 3 non-recursive clauses |
+| `⊑ᵃᵉ-Locked` via `nameable-mono` | `⊑ᵃᵉ-Locked (la-mm l) locked = locked` |
+| `maskEnt-unmask (locked v) = refl` | `maskEnt-unmask locked = refl` |
+| `core`, `core-ren`, `core-nameable`, `core-masked`, `core-unmaskEnt` (`proof/MaskFacts`) | `core` **is** `unmaskEnt`; the five collapse to three one-line case splits |
+| `renᵉ-id`, `renᵉ-comp`, `substᵉ`, `substᵉ-0-⇑`, `substᵉ-⇑`, `showEntry` — all recursive | each is a `Binding` function plus a two-clause lift |
+| `renᵉ-Nameable⁻`, `Locked-ren⁻` — 3 clauses each | 2 clauses each |
+
+*Cost* — exactly one place.  `maskEnt` is **idempotent**, so
+
+    unmask-mask : Δ ∋tv X → unmask X (mask X Δ) ≡ Δ
+
+now carries a nameability premise; with a stack of masks the identity
+held unconditionally, because a second lock was simply popped.  The
+premise is always at hand — `sw-l` admits `lock X` only at a `∋tv` slot
+(§4.2), which is the discipline that made double masking unreachable in
+the first place — and it is threaded through exactly two lemmas:
+`proof/PeelDual.applyUnlocks-dualScope` and
+`proof/PeelDual.convCtx-dual`, each of which gains a `Δ ⊢ˢ S` /
+`Δ ⊢ˢ changes Θ` argument that its one call site already has (`mwᵥ` in
+`preserve-Peel`).  `mask-unmask : Δ ∋lk X → mask X (unmask X Δ) ≡ Δ` is
+unchanged, so the two inverses are now symmetric: each holds at the slots
+its own direction is applied to, and nowhere else.
+
+`proof/DualTightness.¬⊢ᵐ-double-lock` survives, with a different job: it
+is no longer the fact that keeps `Locked` one mask deep — that is by
+construction — but the fact that the judgement still refuses a vacuous
+re-lock, which is what keeps `unmask-mask`'s premise available.
 
 ### Vocabulary
 
@@ -519,9 +606,11 @@ the change acts on, i.e. on the context the changes to its right (which
 whole change list's unmasks applied, all of its locks lifted.
 
 A `lock` names a slot that is **still visible** where it acts — so a slot
-is never masked twice, and `Locked` is one mask deep.  An `unlock` names
-a slot that is **LOCKED** there: `Δ ∋lk X` is `∃E. (Δ ∋e X , E) ×
-Locked E`, with `Locked (masked E)` for a *nameable* `E`.  It is the
+is never masked twice.  (`Locked` is one mask deep by *construction*
+now, §3, but the premise still earns its keep: it is what makes
+`unmask ∘ mask` the identity at the slot, `unmask-mask`.)  An `unlock`
+names a slot that is **LOCKED** there: `Δ ∋lk X` is `∃E. (Δ ∋e X , E) ×
+Locked E`, with `Locked (masked b)` for any binding `b`.  It is the
 mirror of `Δ ∋tv X`, and it mentions no representation at all — an
 `unlock` still claims no knowledge; the knowledge claim lives in the
 conversion, where `seal X` must cite a live binder.
@@ -1489,9 +1578,14 @@ The morphism's `bind` entry became the `binds` field on 2026-09-06.
 | `shiftBy n A` | shift a type past `n` binders |
 | `shiftBodyBy n B` | the same, read under one binder |
 | `updateAt f X Δ` | one-slot entry update |
-| `masked E` | the retained, unnameable entry |
-| `unmaskEnt E` | peel one mask |
-| `Nameable E` | the entry may be named in a type |
+| `Binding` | what a slot binds: `abst` or `bind A` — no lock |
+| `unmasked b` | the nameable entry at binding `b` |
+| `masked b` | the retained, unnameable entry at binding `b` |
+| `renᵇ ρ b` | rename inside a binding (the lock carries no spelling) |
+| `maskEnt E` | set the lock (total, idempotent) |
+| `unmaskEnt E` | clear the lock (total, idempotent) |
+| `Nameable E` | the entry is `unmasked` — may be named in a type |
+| `b ⊑ᵇ b′` | refinement at the BINDING layer (`le-aa`/`le-ab`/`le-bb`) |
 | `Δ ⊢ᵐ Θ` | the morphism is well formed over Δ — a PAIR of halves |
 | `Δ ⊢ʳ Bs` | the parallel rep half: every rep well formed on ONE Δ |
 | `Δ ⊢ˢ S` | the sequential change half |
@@ -1508,7 +1602,7 @@ The morphism's `bind` entry became the `binds` field on 2026-09-06.
 | `applyUnlocks S Δ` | `Δ` with only `S`'s unlocks applied |
 | `rewind Θ` | `Θ` with its own changes undone |
 | `Θ₁ ⋉ Θ₂` | `Θ₁` with `Θ₂`'s changes moved into its tail |
-| `Locked E` | the entry is masked over a nameable one |
+| `Locked E` | the entry is `masked` — the complement of `Nameable` |
 | `Δ ∋lk X` | slot `X` is LOCKED at `Δ` — what an `unlock` cites |
 | `Δ ⊑ᵃ Δ′` | refinement WITHOUT `le-mu`: the transport a TERM travels |
 | `Inj ρ` | the renaming does not confuse two slots |
@@ -1516,14 +1610,18 @@ The morphism's `bind` entry became the `binds` field on 2026-09-06.
 The `_⊑ᵉ_` constructors were relettered on the same ruling so that each
 name spells the two entries it relates (§3, *Refinement*):
 `le-ao` → `le-ab`, `le-oo` → `le-bb`, `le-bb` → `le-mm`,
-`le-bu` → `le-mu`; `le-aa` unchanged.
+`le-bu` → `le-mu`; `le-aa` unchanged.  With the two-layer entry
+(2026-09-08) the letters split by layer: `le-aa`/`le-ab`/`le-bb` are the
+`_⊑ᵇ_` constructors, and `le-uu`/`le-mm`/`le-mu` (and `la-uu`/`la-mm`)
+lift them through the lock; `la-aa`/`la-ab`/`la-bb` are gone, subsumed by
+`la-uu` over `_⊑ᵇ_`.
 
 Two identities worth stating, because they are what the names are meant
 to make obvious:
 
     interior (rewind Θ) Δ ≡ pushBinds (binds Θ) Δ       given Δ ⊢ᵐ Θ
     interior (dual Θ) (interior Θ Δ)
-      ≡ map masked (pushBinds (binds Θ) []) ++ Δ        given Δ ⊢ᵐ Θ
+      ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ       given Δ ⊢ᵐ Θ
 
 The first is `proof/MoveScope.interior-rewind` — *a rewound frame leaves
 its bind prefix and nothing else* — and it is the identity that retired

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -211,7 +211,8 @@ SA = unmasked (bind (` 0)) ∷ S₆₂            -- the interior type context o
              (wf-var (unmasked (bind `ℕ) , es (es ez) , nameable))
 
 ⊢LA : S₆₂ ∣ [] ⊢ LA ⦂ ` 1
-⊢LA = env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[]) ⊢LA-in
+⊢LA = env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[])
+          ⊢LA-in
           (conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable))
           (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
@@ -358,7 +359,9 @@ _ = refl
 
 ⊢Tᵣ : [] ∣ [] ⊢ Tᵣ ⦂ `ℕ
 ⊢Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
-          (env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[]) ⊢Vᵣ
+          (env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[])
+                   sw[])
+               ⊢Vᵣ
                (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
                (wf-var (unmasked (bind `ℕ) , ez , nameable)))
           (conv-unseal ez) wf-ℕ
@@ -368,9 +371,9 @@ push-Tᵣ = IdPush (V-⟪⟫ V-$ I-seal) ez
 
 ⊢push-Tᵣ : [] ∣ [] ⊢ (Vᵣ ⟪ Θᵣ₁ , unseal 1 ⟫) ⟪ Θᵣ₂ , id `ℕ ⟫ ⦂ `ℕ
 ⊢push-Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
-               (env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[])
-                 ⊢Vᵣ
-                    (conv-unseal (es ez)) wf-ℕ)
+               (env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable))
+                              rw[]) sw[])
+                    ⊢Vᵣ (conv-unseal (es ez)) wf-ℕ)
                (conv-id base-ℕ) wf-ℕ
 
 run-Tᵣ : [] ⊢ Tᵣ -→* $ 7
@@ -484,13 +487,18 @@ _ = ez
 Θ2 = morph ((` 0) ∷ []) (lock 2 ∷ [])
 
 -- ONE frame change: the binder is pushed on, V is MASKED IN PLACE (the entry
--- `bind `ℕ` survives as `masked (bind `ℕ)`), nothing is dropped.
-_ : interior Θ2 Δd ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ unmasked abst ∷ masked (bind `ℕ) ∷ []
+-- `unmasked (bind `ℕ)` survives as `masked (bind `ℕ)`), nothing is
+-- dropped.
+_ : interior Θ2 Δd
+      ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0))
+      ∷ unmasked abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 -- the CONVERSION CONTEXT keeps every slot live, so a conceal's licence
 -- resolves.
-_ : convCtx Θ2 Δd ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ unmasked abst ∷ unmasked (bind `ℕ) ∷ []
+_ : convCtx Θ2 Δd
+      ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0))
+      ∷ unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 cΘ2 : Conv                      -- (X⇒X)⇒ℕ  ⇝  (W⇒W)⇒ℕ
@@ -589,7 +597,8 @@ _ = refl
 Θ1b : CtxMorph
 Θ1b = morph ((` 0) ∷ []) (lock 1 ∷ [])
 
-_ : interior Θ1b Δ1b ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ masked abst ∷ []
+_ : interior Θ1b Δ1b
+      ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ masked abst ∷ []
 _ = refl
 
 V1b W1b : Term
@@ -689,7 +698,8 @@ _ = ez
 Θ★ : CtxMorph
 Θ★ = morph ((` 0) ∷ []) (lock 1 ∷ [])
 
-_ : interior Θ★ Γ★ ≡ unmasked (bind (` 0)) ∷ unmasked abst ∷ masked (bind `ℕ) ∷ []
+_ : interior Θ★ Γ★
+      ≡ unmasked (bind (` 0)) ∷ unmasked abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 _ : dual Θ★ ≡ morph [] (lock 0 ∷ unlock 2 ∷ [])
@@ -774,13 +784,15 @@ step₂ = Peel V-ƛ V-$
 
 -- the crossing argument, typed INSIDE: 7 is sealed at the new binder, so the
 -- interior sees it at the abstract name X.
-⊢arg₂ : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
+⊢arg₂ : (unmasked (bind `ℕ) ∷ []) ∣ []
+          ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
 ⊢arg₂ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])) ⊢$
             (conv-seal ez) (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢P₂ : [] ∣ [] ⊢ P₂ ⦂ `ℕ
 ⊢P₂ = env (mw (rw-b wf-ℕ rw[]) sw[])
-          (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here)) ⊢arg₂)
+          (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here))
+               ⊢arg₂)
           (conv-unseal ez) wf-ℕ
 
 -- ── STEP 3 — BETA, under the boundary.  This is the step ⊢subst pays for:
@@ -798,9 +810,11 @@ _ = refl
 step₃ : [] ⊢ P₂ -→ P₃
 step₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
-⊢P₃-in : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
+⊢P₃-in : (unmasked (bind `ℕ) ∷ []) ∣ []
+           ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
 ⊢P₃-in = preserve-Beta
-           (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here)) ⊢arg₂)
+           (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here))
+                ⊢arg₂)
 
 ⊢P₃ : [] ∣ [] ⊢ P₃ ⦂ `ℕ
 ⊢P₃ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢P₃-in (conv-unseal ez) wf-ℕ
@@ -818,7 +832,8 @@ P₄ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []
 step₄ : [] ⊢ P₃ -→ P₄
 step₄ = CancelR V-$ ez
 
-⊢P₄-in : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
+⊢P₄-in : (unmasked (bind `ℕ) ∷ []) ∣ []
+           ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
 ⊢P₄-in = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[]))
               ⊢$ (conv-id base-ℕ) wf-ℕ
 
@@ -893,7 +908,8 @@ Wₛ = ($ 7) ⟪ morph [] [] , seal 0 ⟫
 Nₛ = Λ (` 0)
 
 ⊢Wₛ : Δₛ ∣ [] ⊢ Wₛ ⦂ ` 0
-⊢Wₛ = env (mw rw[] sw[]) ⊢$ (conv-seal ez) (wf-var (unmasked (bind `ℕ) , ez , nameable))
+⊢Wₛ = env (mw rw[] sw[]) ⊢$ (conv-seal ez)
+          (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢Nₛ : Δₛ ∣ (` 0 ∷ []) ⊢ Nₛ ⦂ `∀ (` 1)
 ⊢Nₛ = ⊢Λ (⊢` here)
@@ -1119,8 +1135,9 @@ qstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
 ⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ
   ] ⦂ ` 0
-⊢Q₃-in = preservation-Beta (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) ⊢Qbody₁)
-                              ⊢QS₇)
+⊢Q₃-in = preservation-Beta
+           (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) ⊢Qbody₁)
+                ⊢QS₇)
 
 ⊢Q₃ : [] ∣ [] ⊢ Q₃ ⦂ `ℕ
 ⊢Q₃ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₃-in (conv-unseal ez) wf-ℕ
@@ -1141,7 +1158,8 @@ qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
 
 ⊢Qseal₇ : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
 ⊢Qseal₇ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[])) ⊢$
-               (conv-seal (es ez)) (wf-var (unmasked (bind `ℕ) , es ez , nameable))
+               (conv-seal (es ez))
+               (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢Q₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
                       ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
@@ -1364,8 +1382,9 @@ run-D₀ = dstep₁ then dstep₂ then dstep₃ then dstep₄ then dstep₅
 -- ── BOTH IDPUSH CONTRACTA TYPE ─────────────────────────────────────────
 
 ⊢Dseal₇ : QΞ₃ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
-⊢Dseal₇ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es (es ez) , nameable) sw[])) ⊢$
-               (conv-seal (es (es ez)))
+⊢Dseal₇ = env (mw rw[]
+                 (sw-l (unmasked (bind `ℕ) , es (es ez) , nameable) sw[]))
+               ⊢$ (conv-seal (es (es ez)))
                (wf-var (unmasked (bind `ℕ) , es (es ez) , nameable))
 
 ⊢Did₂ : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
@@ -1429,13 +1448,16 @@ Rfun  = Λ (ƛ (` 0) ∙ Rbody)
 R₀    = (Rfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 
 ⊢Qfun-any : ∀ {Δ Γ} → Δ ∣ Γ ⊢ Qfun ⦂ `∀ (` 0 ⇒ ` 0)
-⊢Qfun-any = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) (⊢·[] (⊢Λ (⊢` here)) wf-ℕ))
+⊢Qfun-any =
+  ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
+         (⊢·[] (⊢Λ (⊢` here)) wf-ℕ))
 
 ⊢Rbody : (unmasked abst ∷ []) ∣ (` 0 ∷ []) ⊢ Rbody ⦂ ` 0
 ⊢Rbody = ⊢· (⊢·[] ⊢Qfun-any (wf-var (unmasked abst , ez , nameable))) (⊢` here)
 
 ⊢R₀ : [] ∣ [] ⊢ R₀ ⦂ `ℕ
-⊢R₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Rbody)) wf-ℕ) ⊢$
+⊢R₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Rbody))
+               wf-ℕ) ⊢$
 
 -- the three type contexts the chained run works in
 RΞ RΞ′ RΞ″ : Ctxᵗ
@@ -1628,7 +1650,8 @@ G₀    = (Gfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 ⊢Gbody = ⊢·[] (⊢·[] (⊢Λ (⊢Λ (⊢` here))) wf-ℕ) wf-ℕ
 
 ⊢G₀ : [] ∣ [] ⊢ G₀ ⦂ `ℕ
-⊢G₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Gbody)) wf-ℕ) ⊢$
+⊢G₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Gbody))
+               wf-ℕ) ⊢$
 
 _ : reveal 0 (`∀ (` 2)) ≡ `∀ (id (` 2))
 _ = refl
@@ -1660,7 +1683,8 @@ gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ (V-⟪⟫ V-$ I-seal))))
 -- the TyPeelR step, whose contractum is the wanted `numBinds Θ₁ ≡ 2` layer.
 -- Its conversion premise is the redex's own, one `` `∀ `` inside —
 -- here the identity at the OUTER binder, read under the ∀-binder.
-⊢Gconv : (unmasked abst ∷ convCtx (morph (`ℕ ∷ []) []) QΔ₁) ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
+⊢Gconv : (unmasked abst ∷ convCtx (morph (`ℕ ∷ []) []) QΔ₁)
+           ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
 ⊢Gconv = conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable)
 
 gstep₅ : [] ⊢ G₄ -→ G₅
@@ -1688,10 +1712,11 @@ _ = refl
 -- — the `renᴮ suc Θ` double-shift that made `¬⊢G₅` true is gone.  So
 -- variant (i) now HAS a well-typed closed-source instance.
 ⊢G₅-Λ : QΞ₃ ∣ [] ⊢ Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫) ⦂ `∀ (` 3)
-⊢G₅-Λ = ⊢Λ (env (mw rw[] (sw-l (unmasked (bind `ℕ) , es (es (es ez)) , nameable) sw[]))
-  ⊢$
-                (conv-seal (es (es (es ez))))
-                (wf-var (unmasked (bind `ℕ) , es (es (es ez)) , nameable)))
+⊢G₅-Λ =
+  ⊢Λ (env (mw rw[]
+             (sw-l (unmasked (bind `ℕ) , es (es (es ez)) , nameable) sw[]))
+           ⊢$ (conv-seal (es (es (es ez))))
+           (wf-var (unmasked (bind `ℕ) , es (es (es ez)) , nameable)))
 
 ⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , `
   0 ])
@@ -1750,8 +1775,8 @@ kstep = IdPush (V-⟪⟫ V-$ I-seal) ez
 -- REP `A` inside `Θ₂`'s interior, which fails when `Θ₂` LOCKS a slot that
 -- `A` names.  The `¬IdPushCase` witness (proof/PreserveObstruct §4) is
 -- exactly that: `Δi = bind (` 0) ∷ bind ℕ ∷ []`, `Θ₂ = lock 1 ∷ []`, so
--- `interior Θ₂ Δi = bind (` 0) ∷ masked (bind ℕ) ∷ []` — the binder at slot
--- 0 has rep ` 1, and slot 1 is blocked.
+-- `interior Θ₂ Δi = unmasked (bind (` 0)) ∷ masked (bind ℕ) ∷ []` — the
+-- binder at slot 0 has rep ` 1, and slot 1 is blocked.
 --
 -- The retired §10 recorded the verdict "NOT reachable" (the hunt itself is
 -- in notes/DECISIONS.md, 2026-09-06).  THIS SECTION SHARPENS IT.
@@ -1781,7 +1806,8 @@ L₀    = (Lfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 ⊢Lbody = ⊢·[] (⊢Λ (⊢` here)) (wf-var (unmasked abst , ez , nameable))
 
 ⊢L₀ : [] ∣ [] ⊢ L₀ ⦂ `ℕ
-⊢L₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Lbody)) wf-ℕ) ⊢$
+⊢L₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Lbody))
+               wf-ℕ) ⊢$
 
 -- THE WITNESS CONTEXTS, verbatim from proof/PreserveObstruct §4.
 LΔ LΞ : Ctxᵗ
@@ -2018,8 +2044,9 @@ J₀    = ((Jfun ·[ JB , `ℕ ]) · ($ 7)) · Wt
 
 ⊢Jfun : [] ∣ [] ⊢ Jfun ⦂ `∀ JB
 ⊢Jfun = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
-               (⊢ƛ ⊢JT (⊢· (⊢·[] (⊢` here) (wf-var (unmasked abst , ez , nameable)))
-                           (⊢` (there here)))))
+               (⊢ƛ ⊢JT (⊢· (⊢·[] (⊢` here)
+                                 (wf-var (unmasked abst , ez , nameable)))
+                            (⊢` (there here)))))
 
 ⊢J₀ : [] ∣ [] ⊢ J₀ ⦂ `ℕ
 ⊢J₀ = ⊢· (⊢· (⊢·[] ⊢Jfun wf-ℕ) ⊢$) ⊢Wt
@@ -2279,7 +2306,8 @@ H₀   = ((Hfun ·[ HB , `ℕ ]) · ($ 7)) ·[ ` 0 ⇒ `ℕ , `ℕ ]
 
 ⊢Hfun : [] ∣ [] ⊢ Hfun ⦂ `∀ HB
 ⊢Hfun = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
-               (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) (⊢` (there here)))))
+               (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
+                       (⊢` (there here)))))
 
 ⊢H₀ : [] ∣ [] ⊢ H₀ ⦂ (`ℕ ⇒ `ℕ)
 ⊢H₀ = ⊢·[] (⊢· (⊢·[] ⊢Hfun wf-ℕ) ⊢$) wf-ℕ
@@ -2314,7 +2342,8 @@ hstep₃ = ξ-·[] (ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal)))
 -- `` `∀ `` inside.
 ⊢Hconv : (unmasked abst ∷ convCtx (morph (`ℕ ∷ []) []) []) ⊢ id (` 0) ↦ unseal 1
            ∶ (` 0 ⇒ ` 1) ⇝ (` 0 ⇒ `ℕ)
-⊢Hconv = conv-fun (conv-idv (unmasked abst , ez , nameable)) (conv-unseal (es ez))
+⊢Hconv = conv-fun (conv-idv (unmasked abst , ez , nameable))
+                  (conv-unseal (es ez))
 
 -- the mint: the inserted `seal 0` conceals the binder this rule
 -- introduces, under an `unseal 1` that reveals the crossed boundary's.
@@ -2337,7 +2366,8 @@ _ = refl
 
 ⊢HV : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ HV ⦂ `∀ (` 0 ⇒ ` 1)
 ⊢HV = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
-             (env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[])) ⊢$
+             (env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
+               ⊢$
                   (conv-seal (es ez))
                   (wf-var (unmasked (bind `ℕ) , es ez , nameable))))
 
@@ -2410,7 +2440,8 @@ Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph (binds Θt) (unlock 0 ∷ changes �
               (sw-u (_ , ez , locked)
                     (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])))
           (⊢·[] ⊢Wt (wf-var (unmasked (bind `ℕ) , ez , nameable)))
-          (conv-fun (conv-idv (unmasked (bind `ℕ) , ez , nameable)) (conv-seal ez))
+          (conv-fun (conv-idv (unmasked (bind `ℕ) , ez , nameable))
+            (conv-seal ez))
           (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable))
                 (wf-var (unmasked (bind `ℕ) , ez , nameable)))
 
@@ -2422,7 +2453,8 @@ Cr = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph [] [] , id (` 0) ↦ seal 0 ⟫
 ⊢Cr : Δt ∣ [] ⊢ Cr ⦂ (` 0 ⇒ ` 0)
 ⊢Cr = env (mw rw[] sw[])
           (⊢·[] ⊢Wt (wf-var (unmasked (bind `ℕ) , ez , nameable)))
-          (conv-fun (conv-idv (unmasked (bind `ℕ) , ez , nameable)) (conv-seal ez))
+          (conv-fun (conv-idv (unmasked (bind `ℕ) , ez , nameable))
+            (conv-seal ez))
           (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable))
                 (wf-var (unmasked (bind `ℕ) , ez , nameable)))
 
@@ -2757,8 +2789,8 @@ interior-TyBeta : (A : Ty) (Δ : Ctxᵗ)
 interior-TyBeta A Δ = refl
 
 interior-TyPeelR : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ unmasked (bind (shiftBy (numBinds Θ) A))
-    ∷ interior Θ Δ
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+      ≡ unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ
 interior-TyPeelR A Θ Δ = refl
 
 ------------------------------------------------------------------------
@@ -2766,10 +2798,11 @@ interior-TyPeelR A Θ Δ = refl
 --       moves
 ------------------------------------------------------------------------
 
--- `TyBeta` types its body `N` at `abst ∷ Δ` (that is `⊢Λ`) and the
--- contractum types it at `interior (morph (A ∷ []) []) Δ`.  Those two type
--- contexts differ AT SLOT 0 ONLY, and there the change is a REFINEMENT
--- (`abst ⊑ᵃᵉ bind A`, `la-ab`) — which is intended: TyBeta REVEALS, it
+-- `TyBeta` types its body `N` at `unmasked abst ∷ Δ` (that is `⊢Λ`) and
+-- the contractum types it at `interior (morph (A ∷ []) []) Δ`.  Those two
+-- type contexts differ AT SLOT 0 ONLY, and there the change is a
+-- REFINEMENT (`abst ⊑ᵇ bind A` under `la-uu`) — intended: TyBeta REVEALS,
+-- it
 -- is the rule that installs a representation.  Every OTHER slot is `Δ`
 -- itself, on the nose.  So a body that names a slot Δ masks is refused
 -- on both sides.
@@ -2785,7 +2818,7 @@ Rᵃ : Term
 Rᵃ = (Λ Nᵃ) ·[ (`ℕ ⇒ `ℕ) , `ℕ ]
 
 -- THE FAULT, LOCALIZED: `⊢·[]`'s `Δ ⊢ᵗ A` at `` ` 1 `` = X, which
--- `abst ∷ Δ✦` masks.
+-- `unmasked abst ∷ Δ✦` masks.
 ¬⊢Nᵃ-abst : ∀ {Γ A} → ¬ ((unmasked abst ∷ Δ✦) ∣ Γ ⊢ Nᵃ ⦂ A)
 ¬⊢Nᵃ-abst (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
@@ -2893,14 +2926,16 @@ stepᵇ = TyPeelR val-prb ⊢sᵇ
 _ : wkᴹ 1 Vᵇ ≡ prb 1
 _ = refl
 
-_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ unmasked (bind `ℕ) ∷ interior Θᵇ Δᵇ
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ
+      ≡ unmasked (bind `ℕ) ∷ interior Θᵇ Δᵇ
 _ = interior-TyPeelR `ℕ Θᵇ Δᵇ
 
-_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ unmasked (bind `ℕ) ∷ masked (bind
-  `ℕ) ∷ []
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ
+      ≡ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
-¬⊢wkVᵇ : ∀ {Γ A} → ¬ ((unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
+¬⊢wkVᵇ : ∀ {Γ A}
+  → ¬ ((unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
 ¬⊢wkVᵇ (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ¬⊢Cᵇ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Cᵇ ⦂ A)
@@ -2961,7 +2996,8 @@ _ = refl
 -- V NAMES THE SLOT Θ₂ LOCKS (Y, exterior slot 1; interior slot 2 past
 -- Θ₁'s binder Z).
 ¬⊢Vᶜ : ∀ {Γ A}
-  → ¬ ((unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ Vᶜ ⦂ A)
+  → ¬ ((unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ [])
+         ∣ Γ ⊢ Vᶜ ⦂ A)
 ¬⊢Vᶜ (⊢ƛ _ (⊢·[] _ (wf-var (_ , es (es ez) , ()))))
 
 -- the lookup premise both rules carry

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -80,9 +80,9 @@ open import strong.Reduction
 -- stepping interior.  The middle wrapper is the "transparent layer".
 
 Δ₆ S₆₁ S₆₂ : Ctxᵗ
-Δ₆  = bind `ℕ ∷ []
-S₆₁ = bind `ℕ ∷ Δ₆
-S₆₂ = bind `ℕ ∷ S₆₁
+Δ₆  = unmasked (bind `ℕ) ∷ []
+S₆₁ = unmasked (bind `ℕ) ∷ Δ₆
+S₆₂ = unmasked (bind `ℕ) ∷ S₆₁
 
 W₆₀ W₆₁ T₆ : Term
 W₆₀ = ($ 7) ⟪ morph [] [] , seal 1 ⟫
@@ -91,12 +91,12 @@ T₆  = W₆₁ ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 ⊢W₆₀ : S₆₂ ∣ [] ⊢ W₆₀ ⦂ ` 1
 ⊢W₆₀ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
-           (wf-var (bind `ℕ , es ez , nameable-b))
+           (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢W₆₁ : S₆₁ ∣ [] ⊢ W₆₁ ⦂ ` 0
 ⊢W₆₁ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢W₆₀
-           (conv-idv (bind `ℕ , es ez , nameable-b))
-           (wf-var (bind `ℕ , ez , nameable-b))
+           (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
+           (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢T₆ : Δ₆ ∣ [] ⊢ T₆ ⦂ `ℕ
 ⊢T₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢W₆₁ (conv-unseal ez) wf-ℕ
@@ -166,8 +166,8 @@ cancelTm = (($ 7) ⟪ Θ↓ , seal 0 ⟫) ⟪ Θ↑ , unseal 0 ⟫
 ⊢cancelTm : [] ∣ [] ⊢ cancelTm ⦂ `ℕ
 ⊢cancelTm =
   env (mw (rw-b wf-ℕ rw[]) sw[])
-      (env (mw rw[] (sw-l (_ , ez , nameable-b) sw[])) ⊢$
-           (conv-seal ez) (wf-var (_ , ez , nameable-b)))
+      (env (mw rw[] (sw-l (_ , ez , nameable) sw[])) ⊢$
+           (conv-seal ez) (wf-var (_ , ez , nameable)))
       (conv-unseal ez)
       wf-ℕ
 
@@ -204,21 +204,21 @@ LB = LA ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫
 T₈ = LB ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 SA : Ctxᵗ
-SA = bind (` 0) ∷ S₆₂            -- the interior type context of LA
+SA = unmasked (bind (` 0)) ∷ S₆₂            -- the interior type context of LA
 
 ⊢LA-in : SA ∣ [] ⊢ ($ 7) ⟪ morph [] [] , seal 2 ⟫ ⦂ ` 2
 ⊢LA-in = env (mw rw[] sw[]) ⊢$ (conv-seal (es (es ez)))
-             (wf-var (bind `ℕ , es (es ez) , nameable-b))
+             (wf-var (unmasked (bind `ℕ) , es (es ez) , nameable))
 
 ⊢LA : S₆₂ ∣ [] ⊢ LA ⦂ ` 1
-⊢LA = env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]) ⊢LA-in
-          (conv-idv (bind `ℕ , es (es ez) , nameable-b))
-          (wf-var (bind `ℕ , es ez , nameable-b))
+⊢LA = env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[]) ⊢LA-in
+          (conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable))
+          (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢LB : S₆₁ ∣ [] ⊢ LB ⦂ ` 0
 ⊢LB = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢LA
-          (conv-idv (bind `ℕ , es ez , nameable-b))
-          (wf-var (bind `ℕ , ez , nameable-b))
+          (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
+          (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢T₈ : Δ₆ ∣ [] ⊢ T₈ ⦂ `ℕ
 ⊢T₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢LB (conv-unseal ez) wf-ℕ
@@ -261,17 +261,17 @@ run-T₈ = push-T₈
 _ : reveal 0 (` 1) ≡ id (` 1)
 _ = refl
 
-⊢W₆₀Λ : (abst ∷ S₆₁) ∣ [] ⊢ W₆₀ ⦂ ` 1
+⊢W₆₀Λ : (unmasked abst ∷ S₆₁) ∣ [] ⊢ W₆₀ ⦂ ` 1
 ⊢W₆₀Λ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
-            (wf-var (bind `ℕ , es ez , nameable-b))
+            (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 Pkg : Term
 Pkg = (Λ W₆₀) ⟪ morph [] [] , `∀ (id (` 1)) ⟫
 
 ⊢Pkg : S₆₁ ∣ [] ⊢ Pkg ⦂ `∀ (` 1)
 ⊢Pkg = env (mw rw[] sw[]) (⊢Λ ⊢W₆₀Λ)
-           (conv-all (conv-idv (bind `ℕ , es ez , nameable-b)))
-           (wf-∀ (wf-var (bind `ℕ , es ez , nameable-b)))
+           (conv-all (conv-idv (unmasked (bind `ℕ) , es ez , nameable)))
+           (wf-∀ (wf-var (unmasked (bind `ℕ) , es ez , nameable)))
 
 T₉ : Term
 T₉ = (Pkg ·[ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
@@ -288,8 +288,8 @@ Pk-1 : Term
 Pk-1 = ((Λ (($ 7) ⟪ morph [] [] , seal 2 ⟫)) ·[ ` 2 , ` 0 ])
          ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫
 
-⊢Pk-conv : (abst ∷ convCtx (morph [] []) S₆₁) ⊢ id (` 1) ∶ ` 1 ⇝ ` 1
-⊢Pk-conv = conv-idv (bind `ℕ , es ez , nameable-b)
+⊢Pk-conv : (unmasked abst ∷ convCtx (morph [] []) S₆₁) ⊢ id (` 1) ∶ ` 1 ⇝ ` 1
+⊢Pk-conv = conv-idv (unmasked (bind `ℕ) , es ez , nameable)
 
 typeel-T₉ : Δ₆ ⊢ T₉ -→ Pk-1 ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 typeel-T₉ = ξ-⟪⟫ (TyPeelR (V-Λ (V-⟪⟫ V-$ I-seal)) ⊢Pk-conv)
@@ -343,7 +343,7 @@ run-Ωt = body-first then then-tybeta then Drop$ base-ℕ then done
 Θᵣ₂ = morph (`ℕ ∷ []) []
 
 Sᵣ : Ctxᵗ
-Sᵣ = bind (` 0) ∷ bind `ℕ ∷ []
+Sᵣ = unmasked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
 
 Vᵣ Tᵣ : Term
 Vᵣ = ($ 7) ⟪ morph [] [] , seal 1 ⟫
@@ -354,13 +354,13 @@ _ = refl
 
 ⊢Vᵣ : Sᵣ ∣ [] ⊢ Vᵣ ⦂ ` 1
 ⊢Vᵣ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
-          (wf-var (bind `ℕ , es ez , nameable-b))
+          (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢Tᵣ : [] ∣ [] ⊢ Tᵣ ⦂ `ℕ
 ⊢Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
-          (env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]) ⊢Vᵣ
-               (conv-idv (bind `ℕ , es ez , nameable-b))
-               (wf-var (bind `ℕ , ez , nameable-b)))
+          (env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[]) ⊢Vᵣ
+               (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
+               (wf-var (unmasked (bind `ℕ) , ez , nameable)))
           (conv-unseal ez) wf-ℕ
 
 push-Tᵣ : [] ⊢ Tᵣ -→ (Vᵣ ⟪ Θᵣ₁ , unseal 1 ⟫) ⟪ Θᵣ₂ , id `ℕ ⟫
@@ -368,7 +368,7 @@ push-Tᵣ = IdPush (V-⟪⟫ V-$ I-seal) ez
 
 ⊢push-Tᵣ : [] ∣ [] ⊢ (Vᵣ ⟪ Θᵣ₁ , unseal 1 ⟫) ⟪ Θᵣ₂ , id `ℕ ⟫ ⦂ `ℕ
 ⊢push-Tᵣ = env (mw (rw-b wf-ℕ rw[]) sw[])
-               (env (mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[])
+               (env (mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[])
                  ⊢Vᵣ
                     (conv-unseal (es ez)) wf-ℕ)
                (conv-id base-ℕ) wf-ℕ
@@ -389,8 +389,8 @@ run-Tᵣ = push-Tᵣ
 -- accepts it.  Again: IdPush merges nothing.
 
 Δₘ Mₘ : Ctxᵗ
-Δₘ = masked (bind `𝔹) ∷ bind `ℕ ∷ []
-Mₘ = bind `𝔹 ∷ bind `ℕ ∷ []
+Δₘ = masked (bind `𝔹) ∷ unmasked (bind `ℕ) ∷ []
+Mₘ = unmasked (bind `𝔹) ∷ unmasked (bind `ℕ) ∷ []
 
 Θₘ₁ Θₘ₂ : CtxMorph
 Θₘ₁ = morph [] (lock 0 ∷ [])
@@ -405,13 +405,13 @@ _ = refl
 
 ⊢Vₘ : Δₘ ∣ [] ⊢ Vₘ ⦂ ` 1
 ⊢Vₘ = env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
-          (wf-var (bind `ℕ , es ez , nameable-b))
+          (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢Tₘ : Δₘ ∣ [] ⊢ Tₘ ⦂ `ℕ
-⊢Tₘ = env (mw rw[] (sw-u (_ , ez , locked nameable-b) sw[]))
-          (env (mw rw[] (sw-l (bind `𝔹 , ez , nameable-b) sw[])) ⊢Vₘ
-               (conv-idv (bind `ℕ , es ez , nameable-b))
-               (wf-var (bind `ℕ , es ez , nameable-b)))
+⊢Tₘ = env (mw rw[] (sw-u (_ , ez , locked) sw[]))
+          (env (mw rw[] (sw-l (unmasked (bind `𝔹) , ez , nameable) sw[])) ⊢Vₘ
+               (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
+               (wf-var (unmasked (bind `ℕ) , es ez , nameable)))
           (conv-unseal (es ez)) wf-ℕ
 
 -- THE SCOPE MOVE IS VISIBLE HERE, and this is the one run on which it
@@ -439,8 +439,8 @@ _ = refl
 
 ⊢ᵐΘₘ₁′ : Δₘ ⊢ᵐ Θₘ₁′
 ⊢ᵐΘₘ₁′ = mw rw[]
-            (sw-l (bind `𝔹 , ez , nameable-b)
-                  (sw-u (_ , ez , locked nameable-b) sw[]))
+            (sw-l (unmasked (bind `𝔹) , ez , nameable)
+                  (sw-u (_ , ez , locked) sw[]))
 
 push-Tₘ : Δₘ ⊢ Tₘ -→ (Vₘ ⟪ Θₘ₁′ , unseal 1 ⟫) ⟪ rewind Θₘ₂ , id `ℕ ⟫
 push-Tₘ = IdPush (V-⟪⟫ V-$ I-seal) (es ez)
@@ -474,7 +474,7 @@ Ren-suc = mkRen (λ d → es d)
 --   Λ-bound X; the old dual DEMOTED W and the crossing value's licence died.
 
 Δd : Ctxᵗ                       -- W:=X , X abstract , V:=ℕ
-Δd = bind (` 0) ∷ abst ∷ bind `ℕ ∷ []
+Δd = unmasked (bind (` 0)) ∷ unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 
 -- W's rep, read on Δd, is the Λ-bound X — the chained spelling that broke.
 _ : Δd ∋ 0 := ` 1
@@ -485,12 +485,12 @@ _ = ez
 
 -- ONE frame change: the binder is pushed on, V is MASKED IN PLACE (the entry
 -- `bind `ℕ` survives as `masked (bind `ℕ)`), nothing is dropped.
-_ : interior Θ2 Δd ≡ bind (` 0) ∷ bind (` 0) ∷ abst ∷ masked (bind `ℕ) ∷ []
+_ : interior Θ2 Δd ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ unmasked abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 -- the CONVERSION CONTEXT keeps every slot live, so a conceal's licence
 -- resolves.
-_ : convCtx Θ2 Δd ≡ bind (` 0) ∷ bind (` 0) ∷ abst ∷ bind `ℕ ∷ []
+_ : convCtx Θ2 Δd ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 cΘ2 : Conv                      -- (X⇒X)⇒ℕ  ⇝  (W⇒W)⇒ℕ
@@ -504,26 +504,26 @@ Wd = (ƛ (` 1) ∙ (` 0)) ⟪ morph [] (lock 0 ∷ []) , unseal 0 ↦ seal 0 ⟫
 ⊢cΘ2 = conv-fun (conv-fun (conv-unseal ez) (conv-seal ez)) (conv-id base-ℕ)
 
 ⊢Fnd : Δd ∣ [] ⊢ Vd ⟪ Θ2 , cΘ2 ⟫ ⦂ ((` 0 ⇒ ` 0) ⇒ `ℕ)
-⊢Fnd = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
-               (sw-l (_ , es (es ez) , nameable-b) sw[]))
-           (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
-                     (wf-var (_ , ez , nameable-b))) ⊢$)
+⊢Fnd = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[])
+               (sw-l (_ , es (es ez) , nameable) sw[]))
+           (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable))
+                     (wf-var (_ , ez , nameable))) ⊢$)
            ⊢cΘ2
-           (wf-⇒ (wf-⇒ (wf-var (_ , ez , nameable-b))
-                       (wf-var (_ , ez , nameable-b))) wf-ℕ)
+           (wf-⇒ (wf-⇒ (wf-var (_ , ez , nameable))
+                       (wf-var (_ , ez , nameable))) wf-ℕ)
 
 -- THE CROSSING VALUE.  Its bind boundary masks W and seals at it: the licence
 -- `seal 0` cites the binder at slot 0 of Δd, whose rep is X = ` 1.
 _ : interior (morph [] (lock 0 ∷ [])) Δd
-      ≡ masked (bind (` 0)) ∷ abst ∷ bind `ℕ ∷ []
+      ≡ masked (bind (` 0)) ∷ unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 ⊢Wd : Δd ∣ [] ⊢ Wd ⦂ (` 0 ⇒ ` 0)
-⊢Wd = env (mw rw[] (sw-l (_ , ez , nameable-b) sw[]))
-          (⊢ƛ (wf-var (_ , es ez , nameable-a)) (⊢` here))
+⊢Wd = env (mw rw[] (sw-l (_ , ez , nameable) sw[]))
+          (⊢ƛ (wf-var (_ , es ez , nameable)) (⊢` here))
           (conv-fun (conv-unseal ez) (conv-seal ez))
-          (wf-⇒ (wf-var (_ , ez , nameable-b))
-                (wf-var (_ , ez , nameable-b)))
+          (wf-⇒ (wf-var (_ , ez , nameable))
+                (wf-var (_ , ez , nameable)))
 
 Wd-value : Value Wd
 Wd-value = V-⟪⟫ V-ƛ I-fun
@@ -556,10 +556,10 @@ _ = refl
   Δd ∣ [] ⊢ (Vd · (wkᴹ 1 Wd ⟪ dual Θ2 , unseal 0 ↦ seal 0 ⟫))
               ⟪ Θ2 , id `ℕ ⟫ ⦂ `ℕ
 ⊢contractumd =
-  env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
-          (sw-l (_ , es (es ez) , nameable-b) sw[]))
-      (⊢· (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
-                    (wf-var (_ , ez , nameable-b))) ⊢$)
+  env (mw (rw-b (wf-var (_ , ez , nameable)) rw[])
+          (sw-l (_ , es (es ez) , nameable) sw[]))
+      (⊢· (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable))
+                    (wf-var (_ , ez , nameable))) ⊢$)
           ⊢Wd-crossed)
       (conv-id base-ℕ)
       wf-ℕ
@@ -572,24 +572,24 @@ _ = refl
                   ⦂ (` 0 ⇒ ` 0)
   ⊢Wd-crossed =
     env (mw rw[]
-            (sw-l (_ , ez , nameable-b)
-                  (sw-u (_ , es (es (es ez)) , locked nameable-b) sw[])))
+            (sw-l (_ , ez , nameable)
+                  (sw-u (_ , es (es (es ez)) , locked) sw[])))
         ⊢Wd-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
-        (wf-⇒ (wf-var (_ , ez , nameable-b))
-              (wf-var (_ , ez , nameable-b)))
+        (wf-⇒ (wf-var (_ , ez , nameable))
+              (wf-var (_ , ez , nameable)))
 
 -- ── n1b (the break, minimized) ─────────────────────────────────────────
 -- The chain X:=Y over a Λ-bound Y, with the ambient's third slot and the
 -- rep-carrying conceal both removed.
 
 Δ1b : Ctxᵗ
-Δ1b = bind (` 0) ∷ abst ∷ []
+Δ1b = unmasked (bind (` 0)) ∷ unmasked abst ∷ []
 
 Θ1b : CtxMorph
 Θ1b = morph ((` 0) ∷ []) (lock 1 ∷ [])
 
-_ : interior Θ1b Δ1b ≡ bind (` 0) ∷ bind (` 0) ∷ masked abst ∷ []
+_ : interior Θ1b Δ1b ≡ unmasked (bind (` 0)) ∷ unmasked (bind (` 0)) ∷ masked abst ∷ []
 _ = refl
 
 V1b W1b : Term
@@ -600,21 +600,21 @@ cΘ1b : Conv
 cΘ1b = (unseal 0 ↦ seal 0) ↦ id `ℕ
 
 ⊢W1b : Δ1b ∣ [] ⊢ W1b ⦂ (` 0 ⇒ ` 0)
-⊢W1b = env (mw rw[] (sw-l (_ , ez , nameable-b) sw[]))
-           (⊢ƛ (wf-var (_ , es ez , nameable-a)) (⊢` here))
+⊢W1b = env (mw rw[] (sw-l (_ , ez , nameable) sw[]))
+           (⊢ƛ (wf-var (_ , es ez , nameable)) (⊢` here))
            (conv-fun (conv-unseal ez) (conv-seal ez))
-           (wf-⇒ (wf-var (_ , ez , nameable-b))
-                 (wf-var (_ , ez , nameable-b)))
+           (wf-⇒ (wf-var (_ , ez , nameable))
+                 (wf-var (_ , ez , nameable)))
 
 ⊢Fn1b : Δ1b ∣ [] ⊢ V1b ⟪ Θ1b , cΘ1b ⟫ ⦂ ((` 0 ⇒ ` 0) ⇒ `ℕ)
-⊢Fn1b = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
-                (sw-l (_ , es ez , nameable-a) sw[]))
-            (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
-                      (wf-var (_ , ez , nameable-b))) ⊢$)
+⊢Fn1b = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[])
+                (sw-l (_ , es ez , nameable) sw[]))
+            (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable))
+                      (wf-var (_ , ez , nameable))) ⊢$)
             (conv-fun (conv-fun (conv-unseal ez) (conv-seal ez))
                       (conv-id base-ℕ))
-            (wf-⇒ (wf-⇒ (wf-var (_ , ez , nameable-b))
-                        (wf-var (_ , ez , nameable-b))) wf-ℕ)
+            (wf-⇒ (wf-⇒ (wf-var (_ , ez , nameable))
+                        (wf-var (_ , ez , nameable))) wf-ℕ)
 
 ⊢Redex1b : Δ1b ∣ [] ⊢ (V1b ⟪ Θ1b , cΘ1b ⟫) · W1b ⦂ `ℕ
 ⊢Redex1b = ⊢· ⊢Fn1b ⊢W1b
@@ -640,10 +640,10 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
   Δ1b ∣ [] ⊢ (V1b · (wkᴹ 1 W1b ⟪ dual Θ1b , unseal 0 ↦ seal 0 ⟫))
                ⟪ Θ1b , id `ℕ ⟫ ⦂ `ℕ
 ⊢contractum1b =
-  env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[])
-          (sw-l (_ , es ez , nameable-a) sw[]))
-      (⊢· (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable-b))
-                    (wf-var (_ , ez , nameable-b))) ⊢$)
+  env (mw (rw-b (wf-var (_ , ez , nameable)) rw[])
+          (sw-l (_ , es ez , nameable) sw[]))
+      (⊢· (⊢ƛ (wf-⇒ (wf-var (_ , ez , nameable))
+                    (wf-var (_ , ez , nameable))) ⊢$)
           ⊢W1b-crossed)
       (conv-id base-ℕ)
       wf-ℕ
@@ -655,11 +655,11 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
                    ⦂ (` 0 ⇒ ` 0)
   ⊢W1b-crossed =
     env (mw rw[]
-            (sw-l (_ , ez , nameable-b)
-                  (sw-u (_ , es (es ez) , locked nameable-a) sw[])))
+            (sw-l (_ , ez , nameable)
+                  (sw-u (_ , es (es ez) , locked) sw[])))
         ⊢W1b-in
         (conv-fun (conv-unseal ez) (conv-seal ez))
-        (wf-⇒ (wf-var (_ , ez , nameable-b)) (wf-var (_ , ez , nameable-b)))
+        (wf-⇒ (wf-var (_ , ez , nameable)) (wf-var (_ , ez , nameable)))
 
 -- ── n4 (the x-alias break) ─────────────────────────────────────────────
 -- There is no x-entry and no rep-less reveal to alias: a conceal cites a
@@ -672,7 +672,7 @@ peel-1b = Peel V-ƛ (V-⟪⟫ V-ƛ I-fun)
 Θ4 : CtxMorph                        -- re-expose it
 Θ4 = morph [] (unlock 0 ∷ [])
 
-_ : interior Θ4 Δ4 ≡ bind `ℕ ∷ []
+_ : interior Θ4 Δ4 ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 -- the alias RESTORES NAMEABILITY, and with it the binder's knowledge — the
@@ -684,12 +684,12 @@ _ = ez
 -- ── E★′ (the shape-IV survivor) ────────────────────────────────────────
 
 Γ★ : Ctxᵗ
-Γ★ = abst ∷ bind `ℕ ∷ []
+Γ★ = unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 
 Θ★ : CtxMorph
 Θ★ = morph ((` 0) ∷ []) (lock 1 ∷ [])
 
-_ : interior Θ★ Γ★ ≡ bind (` 0) ∷ abst ∷ masked (bind `ℕ) ∷ []
+_ : interior Θ★ Γ★ ≡ unmasked (bind (` 0)) ∷ unmasked abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 _ : dual Θ★ ≡ morph [] (lock 0 ∷ unlock 2 ∷ [])
@@ -721,7 +721,7 @@ polyid : Term
 polyid = Λ (ƛ (` 0) ∙ (` 0))
 
 ⊢polyid : [] ∣ [] ⊢ polyid ⦂ `∀ (` 0 ⇒ ` 0)
-⊢polyid = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) (⊢` here))
+⊢polyid = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) (⊢` here))
 
 P₀ : Term
 P₀ = (polyid ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
@@ -745,7 +745,7 @@ step₁ = ξ-·-l (TyBeta V-ƛ)
 ⊢fn₁ : [] ∣ [] ⊢ (ƛ (` 0) ∙ (` 0)) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫
          ⦂ (`ℕ ⇒ `ℕ)
 ⊢fn₁ = env (mw (rw-b wf-ℕ rw[]) sw[])
-           (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) (⊢` here))
+           (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here))
            (conv-fun (conv-seal ez) (conv-unseal ez))
            (wf-⇒ wf-ℕ wf-ℕ)
 
@@ -774,13 +774,13 @@ step₂ = Peel V-ƛ V-$
 
 -- the crossing argument, typed INSIDE: 7 is sealed at the new binder, so the
 -- interior sees it at the abstract name X.
-⊢arg₂ : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
-⊢arg₂ = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[])) ⊢$
-            (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
+⊢arg₂ : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
+⊢arg₂ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])) ⊢$
+            (conv-seal ez) (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢P₂ : [] ∣ [] ⊢ P₂ ⦂ `ℕ
 ⊢P₂ = env (mw (rw-b wf-ℕ rw[]) sw[])
-          (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) (⊢` here)) ⊢arg₂)
+          (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here)) ⊢arg₂)
           (conv-unseal ez) wf-ℕ
 
 -- ── STEP 3 — BETA, under the boundary.  This is the step ⊢subst pays for:
@@ -798,9 +798,9 @@ _ = refl
 step₃ : [] ⊢ P₂ -→ P₃
 step₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
-⊢P₃-in : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
+⊢P₃-in : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ⦂ ` 0
 ⊢P₃-in = preserve-Beta
-           (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) (⊢` here)) ⊢arg₂)
+           (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) (⊢` here)) ⊢arg₂)
 
 ⊢P₃ : [] ∣ [] ⊢ P₃ ⦂ `ℕ
 ⊢P₃ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢P₃-in (conv-unseal ez) wf-ℕ
@@ -818,8 +818,8 @@ P₄ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []
 step₄ : [] ⊢ P₃ -→ P₄
 step₄ = CancelR V-$ ez
 
-⊢P₄-in : (bind `ℕ ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
-⊢P₄-in = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[]))
+⊢P₄-in : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
+⊢P₄-in = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[]))
               ⊢$ (conv-id base-ℕ) wf-ℕ
 
 ⊢P₄ : [] ∣ [] ⊢ P₄ ⦂ `ℕ
@@ -886,14 +886,14 @@ _ = refl
 -- `conv-seal` has no binder to cite.
 
 Δₛ : Ctxᵗ
-Δₛ = bind `ℕ ∷ []
+Δₛ = unmasked (bind `ℕ) ∷ []
 
 Wₛ Nₛ : Term
 Wₛ = ($ 7) ⟪ morph [] [] , seal 0 ⟫
 Nₛ = Λ (` 0)
 
 ⊢Wₛ : Δₛ ∣ [] ⊢ Wₛ ⦂ ` 0
-⊢Wₛ = env (mw rw[] sw[]) ⊢$ (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
+⊢Wₛ = env (mw rw[] sw[]) ⊢$ (conv-seal ez) (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢Nₛ : Δₛ ∣ (` 0 ∷ []) ⊢ Nₛ ⦂ `∀ (` 1)
 ⊢Nₛ = ⊢Λ (⊢` here)
@@ -1040,11 +1040,11 @@ Qbody = Qvac ·[ ` 1 , `ℕ ]               -- (ΛZ. x) [ℕ]
 Qfun  = Λ (ƛ (` 0) ∙ Qbody)              -- ΛY. λx:Y. (ΛZ. x) [ℕ]
 Q₀    = (Qfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 
-⊢Qbody : (abst ∷ []) ∣ (` 0 ∷ []) ⊢ Qbody ⦂ ` 0
+⊢Qbody : (unmasked abst ∷ []) ∣ (` 0 ∷ []) ⊢ Qbody ⦂ ` 0
 ⊢Qbody = ⊢·[] (⊢Λ (⊢` here)) wf-ℕ
 
 ⊢Qfun : [] ∣ [] ⊢ Qfun ⦂ `∀ (` 0 ⇒ ` 0)
-⊢Qfun = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) ⊢Qbody)
+⊢Qfun = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Qbody)
 
 ⊢Q₀ : [] ∣ [] ⊢ Q₀ ⦂ `ℕ
 ⊢Q₀ = ⊢· (⊢·[] ⊢Qfun wf-ℕ) ⊢$
@@ -1052,8 +1052,8 @@ Q₀    = (Qfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 -- The two type contexts the run works in: the outer boundary's interior,
 -- and the id-layer's interior.
 QΔ₁ QΞ₂ : Ctxᵗ
-QΔ₁ = bind `ℕ ∷ []
-QΞ₂ = bind `ℕ ∷ bind `ℕ ∷ []
+QΔ₁ = unmasked (bind `ℕ) ∷ []
+QΞ₂ = unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
 
 _ : interior (morph (`ℕ ∷ []) []) [] ≡ QΔ₁
 _ = refl
@@ -1094,8 +1094,8 @@ qstep₂ : [] ⊢ Q₁ -→ Q₂
 qstep₂ = Peel V-ƛ V-$
 
 ⊢QS₇ : QΔ₁ ∣ [] ⊢ QS₇ ⦂ ` 0
-⊢QS₇ = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[])) ⊢$
-            (conv-seal ez) (wf-var (bind `ℕ , ez , nameable-b))
+⊢QS₇ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])) ⊢$
+            (conv-seal ez) (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢Q₂ : [] ∣ [] ⊢ Q₂ ⦂ `ℕ
 ⊢Q₂ = preserve-Peel V-ƛ V-$ ⊢Q₁
@@ -1119,7 +1119,7 @@ qstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
 ⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ
   ] ⦂ ` 0
-⊢Q₃-in = preservation-Beta (⊢· (⊢ƛ (wf-var (bind `ℕ , ez , nameable-b)) ⊢Qbody₁)
+⊢Q₃-in = preservation-Beta (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) ⊢Qbody₁)
                               ⊢QS₇)
 
 ⊢Q₃ : [] ∣ [] ⊢ Q₃ ⦂ `ℕ
@@ -1140,8 +1140,8 @@ qstep₄ : [] ⊢ Q₃ -→ Q₄
 qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
 
 ⊢Qseal₇ : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
-⊢Qseal₇ = env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[])) ⊢$
-               (conv-seal (es ez)) (wf-var (bind `ℕ , es ez , nameable-b))
+⊢Qseal₇ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[])) ⊢$
+               (conv-seal (es ez)) (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢Q₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
                       ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
@@ -1183,7 +1183,7 @@ qstep₆ : [] ⊢ Q₅ -→ Q₆
 qstep₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
 
 ⊢Q₆-in2 : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₆-in2 = env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[]))
+⊢Q₆-in2 = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
                ⊢$ (conv-id base-ℕ) wf-ℕ
 
 ⊢Q₆-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
@@ -1279,17 +1279,17 @@ Dbody  = Dinner ·[ ` 1 , `ℕ ]               -- (ΛZ. …) [ℕ]
 Dfun   = Λ (ƛ (` 0) ∙ Dbody)
 D₀     = (Dfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 
-⊢Dbody : (abst ∷ []) ∣ (` 0 ∷ []) ⊢ Dbody ⦂ ` 0
+⊢Dbody : (unmasked abst ∷ []) ∣ (` 0 ∷ []) ⊢ Dbody ⦂ ` 0
 ⊢Dbody = ⊢·[] (⊢Λ (⊢·[] (⊢Λ (⊢` here)) wf-ℕ)) wf-ℕ
 
 ⊢Dfun : [] ∣ [] ⊢ Dfun ⦂ `∀ (` 0 ⇒ ` 0)
-⊢Dfun = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) ⊢Dbody)
+⊢Dfun = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Dbody)
 
 ⊢D₀ : [] ∣ [] ⊢ D₀ ⦂ `ℕ
 ⊢D₀ = ⊢· (⊢·[] ⊢Dfun wf-ℕ) ⊢$
 
 QΞ₃ : Ctxᵗ
-QΞ₃ = bind `ℕ ∷ QΞ₂
+QΞ₃ = unmasked (bind `ℕ) ∷ QΞ₂
 
 D₁ D₂ D₃ D₄ D₅ D₆ D₇ D₈ D₉ D₁₀ D₁₁ : Term
 D₁  = ((ƛ (` 0) ∙ Dbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
@@ -1364,22 +1364,22 @@ run-D₀ = dstep₁ then dstep₂ then dstep₃ then dstep₄ then dstep₅
 -- ── BOTH IDPUSH CONTRACTA TYPE ─────────────────────────────────────────
 
 ⊢Dseal₇ : QΞ₃ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
-⊢Dseal₇ = env (mw rw[] (sw-l (bind `ℕ , es (es ez) , nameable-b) sw[])) ⊢$
+⊢Dseal₇ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es (es ez) , nameable) sw[])) ⊢$
                (conv-seal (es (es ez)))
-               (wf-var (bind `ℕ , es (es ez) , nameable-b))
+               (wf-var (unmasked (bind `ℕ) , es (es ez) , nameable))
 
 ⊢Did₂ : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
                      ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 1
 ⊢Did₂ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Dseal₇
-             (conv-idv (bind `ℕ , es (es ez) , nameable-b))
-             (wf-var (bind `ℕ , es ez , nameable-b))
+             (conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable))
+             (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 ⊢D₅-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
                         ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
                        ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
 ⊢D₅-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Did₂
-              (conv-idv (bind `ℕ , es ez , nameable-b))
-              (wf-var (bind `ℕ , ez , nameable-b))
+              (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
+              (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢D₅ : [] ∣ [] ⊢ D₅ ⦂ `ℕ
 ⊢D₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₅-in (conv-unseal ez) wf-ℕ
@@ -1429,19 +1429,19 @@ Rfun  = Λ (ƛ (` 0) ∙ Rbody)
 R₀    = (Rfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 
 ⊢Qfun-any : ∀ {Δ Γ} → Δ ∣ Γ ⊢ Qfun ⦂ `∀ (` 0 ⇒ ` 0)
-⊢Qfun-any = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) (⊢·[] (⊢Λ (⊢` here)) wf-ℕ))
+⊢Qfun-any = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) (⊢·[] (⊢Λ (⊢` here)) wf-ℕ))
 
-⊢Rbody : (abst ∷ []) ∣ (` 0 ∷ []) ⊢ Rbody ⦂ ` 0
-⊢Rbody = ⊢· (⊢·[] ⊢Qfun-any (wf-var (abst , ez , nameable-a))) (⊢` here)
+⊢Rbody : (unmasked abst ∷ []) ∣ (` 0 ∷ []) ⊢ Rbody ⦂ ` 0
+⊢Rbody = ⊢· (⊢·[] ⊢Qfun-any (wf-var (unmasked abst , ez , nameable))) (⊢` here)
 
 ⊢R₀ : [] ∣ [] ⊢ R₀ ⦂ `ℕ
-⊢R₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) ⊢Rbody)) wf-ℕ) ⊢$
+⊢R₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Rbody)) wf-ℕ) ⊢$
 
 -- the three type contexts the chained run works in
 RΞ RΞ′ RΞ″ : Ctxᵗ
-RΞ  = bind (` 0) ∷ bind `ℕ ∷ []
-RΞ′ = bind `ℕ ∷ RΞ
-RΞ″ = bind `ℕ ∷ masked (bind (` 0)) ∷ bind `ℕ ∷ []
+RΞ  = unmasked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
+RΞ′ = unmasked (bind `ℕ) ∷ RΞ
+RΞ″ = unmasked (bind `ℕ) ∷ masked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
 
 _ : interior (morph ((` 0) ∷ []) []) QΔ₁ ≡ RΞ
 _ = refl
@@ -1458,7 +1458,7 @@ Rchain : convCtx (morph ((` 0) ∷ []) []) QΔ₁ ∋ 0 := ` 1
 Rchain = ez
 
 Rchain-scoped : interior (morph ((` 0) ∷ []) []) QΔ₁ ⊢ᵗ ` 1
-Rchain-scoped = wf-var (_ , es ez , nameable-b)
+Rchain-scoped = wf-var (_ , es ez , nameable)
 
 -- ── the states ─────────────────────────────────────────────────────────
 
@@ -1548,22 +1548,22 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
 -- ── THE CHAINED IDPUSH REDEX AND ITS CONTRACTUM BOTH TYPE ──────────────
 
 ⊢RV₂ : RΞ″ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
-⊢RV₂ = env (mw rw[] (sw-l (_ , es (es ez) , nameable-b) sw[])) ⊢$
-            (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable-b))
+⊢RV₂ = env (mw rw[] (sw-l (_ , es (es ez) , nameable) sw[])) ⊢$
+            (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable))
 
 ⊢RS↑ : RΞ′ ∣ [] ⊢ RS↑ ⦂ ` 1
-⊢RS↑ = env (mw rw[] (sw-l (_ , es ez , nameable-b) sw[])) ⊢RV₂
-            (conv-seal (es ez)) (wf-var (_ , es ez , nameable-b))
+⊢RS↑ = env (mw rw[] (sw-l (_ , es ez , nameable) sw[])) ⊢RV₂
+            (conv-seal (es ez)) (wf-var (_ , es ez , nameable))
 
 ⊢Rlayer : RΞ ∣ [] ⊢ RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
 ⊢Rlayer = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢RS↑
-               (conv-idv (_ , es ez , nameable-b))
-               (wf-var (_ , ez , nameable-b))
+               (conv-idv (_ , es ez , nameable))
+               (wf-var (_ , ez , nameable))
 
 ⊢R₇-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
                        ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫ ⦂ ` 0
-⊢R₇-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢Rlayer
-              (conv-unseal ez) (wf-var (_ , ez , nameable-b))
+⊢R₇-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Rlayer
+              (conv-unseal ez) (wf-var (_ , ez , nameable))
 
 ⊢R₇ : [] ∣ [] ⊢ R₇ ⦂ `ℕ
 ⊢R₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢R₇-in (conv-unseal ez) wf-ℕ
@@ -1576,8 +1576,8 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
 
 ⊢R₈-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
                        ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
-⊢R₈-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢R₈-mid
-              (conv-idv (_ , es ez , nameable-b)) (wf-var (_ , ez , nameable-b))
+⊢R₈-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢R₈-mid
+              (conv-idv (_ , es ez , nameable)) (wf-var (_ , ez , nameable))
 
 ⊢R₈ : [] ∣ [] ⊢ R₈ ⦂ `ℕ
 ⊢R₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢R₈-in (conv-unseal ez) wf-ℕ
@@ -1624,11 +1624,11 @@ Gbody = (Gpoly ·[ `∀ (` 2) , `ℕ ]) ·[ ` 1 , `ℕ ]
 Gfun  = Λ (ƛ (` 0) ∙ Gbody)
 G₀    = (Gfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 
-⊢Gbody : (abst ∷ []) ∣ (` 0 ∷ []) ⊢ Gbody ⦂ ` 0
+⊢Gbody : (unmasked abst ∷ []) ∣ (` 0 ∷ []) ⊢ Gbody ⦂ ` 0
 ⊢Gbody = ⊢·[] (⊢·[] (⊢Λ (⊢Λ (⊢` here))) wf-ℕ) wf-ℕ
 
 ⊢G₀ : [] ∣ [] ⊢ G₀ ⦂ `ℕ
-⊢G₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) ⊢Gbody)) wf-ℕ) ⊢$
+⊢G₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Gbody)) wf-ℕ) ⊢$
 
 _ : reveal 0 (`∀ (` 2)) ≡ `∀ (id (` 2))
 _ = refl
@@ -1660,8 +1660,8 @@ gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ (V-⟪⟫ V-$ I-seal))))
 -- the TyPeelR step, whose contractum is the wanted `numBinds Θ₁ ≡ 2` layer.
 -- Its conversion premise is the redex's own, one `` `∀ `` inside —
 -- here the identity at the OUTER binder, read under the ∀-binder.
-⊢Gconv : (abst ∷ convCtx (morph (`ℕ ∷ []) []) QΔ₁) ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
-⊢Gconv = conv-idv (bind `ℕ , es (es ez) , nameable-b)
+⊢Gconv : (unmasked abst ∷ convCtx (morph (`ℕ ∷ []) []) QΔ₁) ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
+⊢Gconv = conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable)
 
 gstep₅ : [] ⊢ G₄ -→ G₅
 gstep₅ = ξ-⟪⟫ (TyPeelR (V-Λ (V-⟪⟫ V-$ I-seal)) ⊢Gconv)
@@ -1671,13 +1671,13 @@ _ = refl
 
 -- G₄ IS WELL TYPED …
 ⊢GV : QΞ₂ ∣ [] ⊢ GV ⦂ `∀ (` 2)
-⊢GV = ⊢Λ (env (mw rw[] (sw-l (_ , es (es ez) , nameable-b) sw[])) ⊢$
-               (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable-b)))
+⊢GV = ⊢Λ (env (mw rw[] (sw-l (_ , es (es ez) , nameable) sw[])) ⊢$
+               (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable)))
 
 ⊢Gpkg : QΔ₁ ∣ [] ⊢ GV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 2)) ⟫ ⦂ `∀ (` 1)
 ⊢Gpkg = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢GV
-             (conv-all (conv-idv (_ , es (es ez) , nameable-b)))
-             (wf-∀ (wf-var (_ , es ez , nameable-b)))
+             (conv-all (conv-idv (_ , es (es ez) , nameable)))
+             (wf-∀ (wf-var (_ , es ez , nameable)))
 
 ⊢G₄ : [] ∣ [] ⊢ G₄ ⦂ `ℕ
 ⊢G₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) (⊢·[] ⊢Gpkg wf-ℕ) (conv-unseal ez) wf-ℕ
@@ -1688,18 +1688,18 @@ _ = refl
 -- — the `renᴮ suc Θ` double-shift that made `¬⊢G₅` true is gone.  So
 -- variant (i) now HAS a well-typed closed-source instance.
 ⊢G₅-Λ : QΞ₃ ∣ [] ⊢ Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫) ⦂ `∀ (` 3)
-⊢G₅-Λ = ⊢Λ (env (mw rw[] (sw-l (bind `ℕ , es (es (es ez)) , nameable-b) sw[]))
+⊢G₅-Λ = ⊢Λ (env (mw rw[] (sw-l (unmasked (bind `ℕ) , es (es (es ez)) , nameable) sw[]))
   ⊢$
                 (conv-seal (es (es (es ez))))
-                (wf-var (bind `ℕ , es (es (es ez)) , nameable-b)))
+                (wf-var (unmasked (bind `ℕ) , es (es (es ez)) , nameable)))
 
 ⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , `
   0 ])
                       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 0
 ⊢G₅-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[])
-              (⊢·[] ⊢G₅-Λ (wf-var (bind `ℕ , ez , nameable-b)))
-              (conv-idv (bind `ℕ , es (es ez) , nameable-b))
-              (wf-var (bind `ℕ , ez , nameable-b))
+              (⊢·[] ⊢G₅-Λ (wf-var (unmasked (bind `ℕ) , ez , nameable)))
+              (conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable))
+              (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 ⊢G₅ : [] ∣ [] ⊢ G₅ ⦂ `ℕ
 ⊢G₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢G₅-in (conv-unseal ez) wf-ℕ
@@ -1724,8 +1724,8 @@ _ = refl
 ⊢K₀-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
                        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 0
 ⊢K₀-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[]) ⊢Dseal₇
-              (conv-idv (_ , es (es ez) , nameable-b))
-              (wf-var (_ , ez , nameable-b))
+              (conv-idv (_ , es (es ez) , nameable))
+              (wf-var (_ , ez , nameable))
 
 ⊢K₀ : [] ∣ [] ⊢ K₀ ⦂ `ℕ
 ⊢K₀ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢K₀-in (conv-unseal ez) wf-ℕ
@@ -1777,16 +1777,16 @@ Lbody = (Λ (` 0)) ·[ ` 1 , ` 0 ]         -- (ΛZ. x) [Y]
 Lfun  = Λ (ƛ (` 0) ∙ Lbody)
 L₀    = (Lfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 
-⊢Lbody : (abst ∷ []) ∣ (` 0 ∷ []) ⊢ Lbody ⦂ ` 0
-⊢Lbody = ⊢·[] (⊢Λ (⊢` here)) (wf-var (abst , ez , nameable-a))
+⊢Lbody : (unmasked abst ∷ []) ∣ (` 0 ∷ []) ⊢ Lbody ⦂ ` 0
+⊢Lbody = ⊢·[] (⊢Λ (⊢` here)) (wf-var (unmasked abst , ez , nameable))
 
 ⊢L₀ : [] ∣ [] ⊢ L₀ ⦂ `ℕ
-⊢L₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) ⊢Lbody)) wf-ℕ) ⊢$
+⊢L₀ = ⊢· (⊢·[] (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢Lbody)) wf-ℕ) ⊢$
 
 -- THE WITNESS CONTEXTS, verbatim from proof/PreserveObstruct §4.
 LΔ LΞ : Ctxᵗ
-LΔ = bind (` 0) ∷ bind `ℕ ∷ []
-LΞ = bind (` 0) ∷ masked (bind `ℕ) ∷ []
+LΔ = unmasked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
+LΞ = unmasked (bind (` 0)) ∷ masked (bind `ℕ) ∷ []
 
 _ : interior (morph ((` 0) ∷ []) []) QΔ₁ ≡ LΔ
 _ = refl
@@ -1854,20 +1854,20 @@ _ = refl
 -- ── every state on the run TYPES, including the two the wall touches ───
 
 ⊢Lseal₇ : LΔ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
-⊢Lseal₇ = env (mw rw[] (sw-l (_ , es ez , nameable-b) sw[])) ⊢$
-               (conv-seal (es ez)) (wf-var (_ , es ez , nameable-b))
+⊢Lseal₇ = env (mw rw[] (sw-l (_ , es ez , nameable) sw[])) ⊢$
+               (conv-seal (es ez)) (wf-var (_ , es ez , nameable))
 
 ⊢L₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
                        ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
-⊢L₄-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢Lseal₇
-              (conv-idv (_ , es ez , nameable-b)) (wf-var (_ , ez , nameable-b))
+⊢L₄-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Lseal₇
+              (conv-idv (_ , es ez , nameable)) (wf-var (_ , ez , nameable))
 
 ⊢L₄ : [] ∣ [] ⊢ L₄ ⦂ `ℕ
 ⊢L₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢L₄-in (conv-unseal ez) wf-ℕ
 
 ⊢L₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
                        ⟪ morph ((` 0) ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
-⊢L₅-in = env (mw (rw-b (wf-var (_ , ez , nameable-b)) rw[]) sw[]) ⊢Lseal₇
+⊢L₅-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Lseal₇
               (conv-unseal (es ez)) wf-ℕ
 
 ⊢L₅ : [] ∣ [] ⊢ L₅ ⦂ `ℕ
@@ -2012,13 +2012,13 @@ Jbody = ƛ JT ∙ (((` 0) ·[ ` 0 ⇒ ` 1 , ` 0 ]) · (` 1))
 Jfun  = Λ (ƛ (` 0) ∙ Jbody)
 J₀    = ((Jfun ·[ JB , `ℕ ]) · ($ 7)) · Wt
 
-⊢JT : ∀ {Δ} → (abst ∷ Δ) ⊢ᵗ JT
-⊢JT = wf-∀ (wf-⇒ (wf-var (abst , ez , nameable-a))
-                 (wf-var (abst , es ez , nameable-a)))
+⊢JT : ∀ {Δ} → (unmasked abst ∷ Δ) ⊢ᵗ JT
+⊢JT = wf-∀ (wf-⇒ (wf-var (unmasked abst , ez , nameable))
+                 (wf-var (unmasked abst , es ez , nameable)))
 
 ⊢Jfun : [] ∣ [] ⊢ Jfun ⦂ `∀ JB
-⊢Jfun = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a))
-               (⊢ƛ ⊢JT (⊢· (⊢·[] (⊢` here) (wf-var (abst , ez , nameable-a)))
+⊢Jfun = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
+               (⊢ƛ ⊢JT (⊢· (⊢·[] (⊢` here) (wf-var (unmasked abst , ez , nameable)))
                            (⊢` (there here)))))
 
 ⊢J₀ : [] ∣ [] ⊢ J₀ ⦂ `ℕ
@@ -2103,7 +2103,7 @@ _ = refl
 J-convCtx : Ctxᵗ
 J-convCtx = convCtx (morph ((` 0) ∷ binds Θt) (changes Θt)) Δt
 
-_ : J-convCtx ≡ bind (` 0) ∷ bind `ℕ ∷ []
+_ : J-convCtx ≡ unmasked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 -- EACH LEAF CONCEALS AT ITS OWN BINDER, and that is the whole content …
@@ -2278,8 +2278,8 @@ Hfun = Λ (ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1))))
 H₀   = ((Hfun ·[ HB , `ℕ ]) · ($ 7)) ·[ ` 0 ⇒ `ℕ , `ℕ ]
 
 ⊢Hfun : [] ∣ [] ⊢ Hfun ⦂ `∀ HB
-⊢Hfun = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a))
-               (⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) (⊢` (there here)))))
+⊢Hfun = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
+               (⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) (⊢` (there here)))))
 
 ⊢H₀ : [] ∣ [] ⊢ H₀ ⦂ (`ℕ ⇒ `ℕ)
 ⊢H₀ = ⊢·[] (⊢· (⊢·[] ⊢Hfun wf-ℕ) ⊢$) wf-ℕ
@@ -2312,9 +2312,9 @@ hstep₃ = ξ-·[] (ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal)))
 
 -- THE CONVERSION PREMISE, read off the redex's own `env`, one
 -- `` `∀ `` inside.
-⊢Hconv : (abst ∷ convCtx (morph (`ℕ ∷ []) []) []) ⊢ id (` 0) ↦ unseal 1
+⊢Hconv : (unmasked abst ∷ convCtx (morph (`ℕ ∷ []) []) []) ⊢ id (` 0) ↦ unseal 1
            ∶ (` 0 ⇒ ` 1) ⇝ (` 0 ⇒ `ℕ)
-⊢Hconv = conv-fun (conv-idv (abst , ez , nameable-a)) (conv-unseal (es ez))
+⊢Hconv = conv-fun (conv-idv (unmasked abst , ez , nameable)) (conv-unseal (es ez))
 
 -- the mint: the inserted `seal 0` conceals the binder this rule
 -- introduces, under an `unseal 1` that reveals the crossed boundary's.
@@ -2335,16 +2335,16 @@ _ = refl
 
 -- ── AND THE CONTRACTUM TYPES — by the theorem, not by hand ─────────────
 
-⊢HV : (bind `ℕ ∷ []) ∣ [] ⊢ HV ⦂ `∀ (` 0 ⇒ ` 1)
-⊢HV = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a))
-             (env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[])) ⊢$
+⊢HV : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ HV ⦂ `∀ (` 0 ⇒ ` 1)
+⊢HV = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
+             (env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[])) ⊢$
                   (conv-seal (es ez))
-                  (wf-var (bind `ℕ , es ez , nameable-b))))
+                  (wf-var (unmasked (bind `ℕ) , es ez , nameable))))
 
 ⊢H₃ : [] ∣ [] ⊢ H₃ ⦂ (`ℕ ⇒ `ℕ)
 ⊢H₃ = ⊢·[] (env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢HV
                 (conv-all ⊢Hconv)
-                (wf-∀ (wf-⇒ (wf-var (abst , ez , nameable-a)) wf-ℕ)))
+                (wf-∀ (wf-⇒ (wf-var (unmasked abst , ez , nameable)) wf-ℕ)))
            wf-ℕ
 
 ⊢H₄ : [] ∣ [] ⊢ H₄ ⦂ (`ℕ ⇒ `ℕ)
@@ -2407,12 +2407,12 @@ Cu = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph (binds Θt) (unlock 0 ∷ changes �
 
 ⊢Cu : Δt ∣ [] ⊢ Cu ⦂ (` 0 ⇒ ` 0)
 ⊢Cu = env (mw rw[]
-              (sw-u (_ , ez , locked nameable-b)
-                    (sw-l (bind `ℕ , ez , nameable-b) sw[])))
-          (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
-          (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
-          (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
-                (wf-var (bind `ℕ , ez , nameable-b)))
+              (sw-u (_ , ez , locked)
+                    (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])))
+          (⊢·[] ⊢Wt (wf-var (unmasked (bind `ℕ) , ez , nameable)))
+          (conv-fun (conv-idv (unmasked (bind `ℕ) , ez , nameable)) (conv-seal ez))
+          (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable))
+                (wf-var (unmasked (bind `ℕ) , ez , nameable)))
 
 -- (iv) or the lock simply REMOVED (a lock binds nothing, so dropping it
 --      is shift-free).  TYPES — but it discards the crossing's mask.
@@ -2421,10 +2421,10 @@ Cr = (Wt ·[ ` 0 ⇒ `ℕ , ` 0 ]) ⟪ morph [] [] , id (` 0) ↦ seal 0 ⟫
 
 ⊢Cr : Δt ∣ [] ⊢ Cr ⦂ (` 0 ⇒ ` 0)
 ⊢Cr = env (mw rw[] sw[])
-          (⊢·[] ⊢Wt (wf-var (bind `ℕ , ez , nameable-b)))
-          (conv-fun (conv-idv (bind `ℕ , ez , nameable-b)) (conv-seal ez))
-          (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
-                (wf-var (bind `ℕ , ez , nameable-b)))
+          (⊢·[] ⊢Wt (wf-var (unmasked (bind `ℕ) , ez , nameable)))
+          (conv-fun (conv-idv (unmasked (bind `ℕ) , ez , nameable)) (conv-seal ez))
+          (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable))
+                (wf-var (unmasked (bind `ℕ) , ez , nameable)))
 
 -- (v) OPTION B: instantiate the interior at the RESOLVED argument (X's
 --     own rep ℕ), keep Θ, and mint the conversion by `conceal` on the
@@ -2437,11 +2437,11 @@ _ : conceal 0 (` 0 ⇒ ` 0) ≡ unseal 0 ↦ seal 0
 _ = refl
 
 ⊢Cb : Δt ∣ [] ⊢ Cb ⦂ (` 0 ⇒ ` 0)
-⊢Cb = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[]))
+⊢Cb = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[]))
           (⊢·[] ⊢Wt wf-ℕ)
           (conv-fun (conv-unseal ez) (conv-seal ez))
-          (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b))
-                (wf-var (bind `ℕ , ez , nameable-b)))
+          (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable))
+                (wf-var (unmasked (bind `ℕ) , ez , nameable)))
 
 -- (vi) Option B's REVEAL mirror, on §13b's H: no lock is in the way, so
 --      the resolve variant lands on the same shape the theorem gives.
@@ -2526,16 +2526,16 @@ Ebody = Λ ((` 0) ·[ ` 0 ⇒ ` 0 , ` 0 ])   -- ΛY. f [Y]
 Efun  = Λ (ƛ EID ∙ Ebody)                -- ΛX. λf:(∀Z.Z⇒Z). ΛY. f [Y]
 E₀    = (Efun ·[ EBod , `ℕ ]) · Earg
 
-⊢EID : ∀ {Δ} → (abst ∷ Δ) ⊢ᵗ EID
-⊢EID = wf-∀ (wf-⇒ (wf-var (abst , ez , nameable-a))
-                  (wf-var (abst , ez , nameable-a)))
+⊢EID : ∀ {Δ} → (unmasked abst ∷ Δ) ⊢ᵗ EID
+⊢EID = wf-∀ (wf-⇒ (wf-var (unmasked abst , ez , nameable))
+                  (wf-var (unmasked abst , ez , nameable)))
 
 ⊢Earg : ∀ {Δ Γ} → Δ ∣ Γ ⊢ Earg ⦂ EID
-⊢Earg = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) (⊢` here))
+⊢Earg = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) (⊢` here))
 
 ⊢Efun : [] ∣ [] ⊢ Efun ⦂ `∀ EBod
 ⊢Efun = ⊢Λ (⊢ƛ ⊢EID
-               (⊢Λ (⊢·[] (⊢` here) (wf-var (abst , ez , nameable-a)))))
+               (⊢Λ (⊢·[] (⊢` here) (wf-var (unmasked abst , ez , nameable)))))
 
 ⊢E₀ : [] ∣ [] ⊢ E₀ ⦂ EID
 ⊢E₀ = ⊢· (⊢·[] ⊢Efun wf-ℕ) ⊢Earg
@@ -2604,9 +2604,9 @@ estep₃ = ξ-⟪⟫ (Beta val-EW)
 -- was born.  Here are the two type contexts, at that redex.
 
 EΔ₃ : Ctxᵗ                       -- the ambient: Y abstract, X := ℕ
-EΔ₃ = abst ∷ bind `ℕ ∷ []
+EΔ₃ = unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 
-_ : interior (morph (`ℕ ∷ []) []) [] ≡ bind `ℕ ∷ []
+_ : interior (morph (`ℕ ∷ []) []) [] ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 E-int E-ext : Ctxᵗ
@@ -2621,7 +2621,7 @@ E-ext = convCtx (morph [] (lock 1 ∷ [])) EΔ₃
 --   E-int   Y Λ-bound , ⌷[X := ℕ]
 --   E-ext   Y Λ-bound , X := ℕ
 --
-_ : E-int ≡ abst ∷ masked (bind `ℕ) ∷ []
+_ : E-int ≡ unmasked abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 _ : E-ext ≡ EΔ₃
@@ -2629,7 +2629,7 @@ _ = refl
 
 -- Y is still nameable inside …
 E-Y-inside : E-int ⊢ᵗ ` 0
-E-Y-inside = wf-var (abst , ez , nameable-a)
+E-Y-inside = wf-var (unmasked abst , ez , nameable)
 
 -- … and X still is not: the mask does its job.
 E-X-hidden : ¬ (E-int ⊢ᵗ ` 1)
@@ -2642,11 +2642,11 @@ E-X-hidden (wf-var (_ , es ez , ()))
 -- the instantiation step.
 
 E-convCtx : Ctxᵗ
-E-convCtx = abst ∷ convCtx (morph [] (lock 1 ∷ [])) EΔ₃
+E-convCtx = unmasked abst ∷ convCtx (morph [] (lock 1 ∷ [])) EΔ₃
 
 ⊢Es : E-convCtx ⊢ id (` 0) ↦ id (` 0) ∶ (` 0 ⇒ ` 0) ⇝ (` 0 ⇒ ` 0)
-⊢Es = conv-fun (conv-idv (abst , ez , nameable-a))
-               (conv-idv (abst , ez , nameable-a))
+⊢Es = conv-fun (conv-idv (unmasked abst , ez , nameable))
+               (conv-idv (unmasked abst , ez , nameable))
 
 _ : instReveal 0 (id (` 0) ↦ id (` 0)) ≡ seal 0 ↦ unseal 0
 _ = refl
@@ -2753,11 +2753,11 @@ val-prb = V-ƛ
 -- and a bind contributes to the BIND half alone, leaving `scope`
 -- untouched.
 interior-TyBeta : (A : Ty) (Δ : Ctxᵗ)
-  → interior (morph (A ∷ []) []) Δ ≡ bind A ∷ Δ
+  → interior (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ
 interior-TyBeta A Δ = refl
 
 interior-TyPeelR : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A)
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ unmasked (bind (shiftBy (numBinds Θ) A))
     ∷ interior Θ Δ
 interior-TyPeelR A Θ Δ = refl
 
@@ -2786,7 +2786,7 @@ Rᵃ = (Λ Nᵃ) ·[ (`ℕ ⇒ `ℕ) , `ℕ ]
 
 -- THE FAULT, LOCALIZED: `⊢·[]`'s `Δ ⊢ᵗ A` at `` ` 1 `` = X, which
 -- `abst ∷ Δ✦` masks.
-¬⊢Nᵃ-abst : ∀ {Γ A} → ¬ ((abst ∷ Δ✦) ∣ Γ ⊢ Nᵃ ⦂ A)
+¬⊢Nᵃ-abst : ∀ {Γ A} → ¬ ((unmasked abst ∷ Δ✦) ∣ Γ ⊢ Nᵃ ⦂ A)
 ¬⊢Nᵃ-abst (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ¬⊢Rᵃ : ∀ {A} → ¬ (Δ✦ ∣ [] ⊢ Rᵃ ⦂ A)
@@ -2801,11 +2801,11 @@ stepᵃ : Δ✦ ⊢ Rᵃ -→ Cᵃ
 stepᵃ = TyBeta val-prb
 
 -- THE FRAME IDENTITY, at this Δ.
-_ : interior (morph (`ℕ ∷ []) []) Δ✦ ≡ bind `ℕ ∷ Δ✦
+_ : interior (morph (`ℕ ∷ []) []) Δ✦ ≡ unmasked (bind `ℕ) ∷ Δ✦
 _ = interior-TyBeta `ℕ Δ✦
 
 -- … and X is masked there too.
-¬⊢Nᵃ-bind : ∀ {Γ A} → ¬ ((bind `ℕ ∷ Δ✦) ∣ Γ ⊢ Nᵃ ⦂ A)
+¬⊢Nᵃ-bind : ∀ {Γ A} → ¬ ((unmasked (bind `ℕ) ∷ Δ✦) ∣ Γ ⊢ Nᵃ ⦂ A)
 ¬⊢Nᵃ-bind (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ¬⊢Cᵃ : ∀ {A} → ¬ (Δ✦ ∣ [] ⊢ Cᵃ ⦂ A)
@@ -2814,8 +2814,8 @@ _ = interior-TyBeta `ℕ Δ✦
 -- THE REFINEMENT THE RULE DOES MAKE, and its exact extent: slot 0 gains
 -- a representation, slot 1 keeps its mask.  This is preservation's ONE
 -- `⊢retag` call site (`Design.md` §7).
-_ : (abst ∷ Δ✦) ⊑ᵃ (bind `ℕ ∷ Δ✦)
-_ = la∷ la-ab (la∷ (la-mm la-bb) la[])
+_ : (unmasked abst ∷ Δ✦) ⊑ᵃ (unmasked (bind `ℕ) ∷ Δ✦)
+_ = la∷ (la-uu le-ab) (la∷ (la-mm le-bb) la[])
 
 -- THE ABSENT COMPANION.  A slot that exists in NEITHER type context
 -- still exists in neither.  (Not rendered: `Show` names a free slot from
@@ -2824,10 +2824,10 @@ _ = la∷ la-ab (la∷ (la-mm la-bb) la[])
 Nᵃ∅ : Term
 Nᵃ∅ = prb 2
 
-¬⊢Nᵃ∅-abst : ∀ {Γ A} → ¬ ((abst ∷ Δ✦) ∣ Γ ⊢ Nᵃ∅ ⦂ A)
+¬⊢Nᵃ∅-abst : ∀ {Γ A} → ¬ ((unmasked abst ∷ Δ✦) ∣ Γ ⊢ Nᵃ∅ ⦂ A)
 ¬⊢Nᵃ∅-abst (⊢ƛ _ (⊢·[] _ (wf-var (_ , es (es ()) , _))))
 
-¬⊢Nᵃ∅-bind : ∀ {Γ A} → ¬ ((bind `ℕ ∷ Δ✦) ∣ Γ ⊢ Nᵃ∅ ⦂ A)
+¬⊢Nᵃ∅-bind : ∀ {Γ A} → ¬ ((unmasked (bind `ℕ) ∷ Δ✦) ∣ Γ ⊢ Nᵃ∅ ⦂ A)
 ¬⊢Nᵃ∅-bind (⊢ƛ _ (⊢·[] _ (wf-var (_ , es (es ()) , _))))
 
 stepᵃ∅ : Δ✦ ⊢ (Λ Nᵃ∅) ·[ (`ℕ ⇒ `ℕ) , `ℕ ]
@@ -2850,7 +2850,7 @@ stepᵃ∅ = TyBeta val-prb
 --   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξb′  =  Y := ℕ , ⌷[X := ℕ]
 
 Δᵇ : Ctxᵗ
-Δᵇ = bind `ℕ ∷ []
+Δᵇ = unmasked (bind `ℕ) ∷ []
 
 Θᵇ : CtxMorph
 Θᵇ = morph [] (lock 0 ∷ [])
@@ -2858,7 +2858,7 @@ stepᵃ∅ = TyBeta val-prb
 _ : interior Θᵇ Δᵇ ≡ masked (bind `ℕ) ∷ []
 _ = refl
 
-_ : convCtx Θᵇ Δᵇ ≡ bind `ℕ ∷ []
+_ : convCtx Θᵇ Δᵇ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 Vᵇ : Term
@@ -2876,7 +2876,7 @@ Rᵇ = (Vᵇ ⟪ Θᵇ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
 ¬⊢Rᵇ (⊢·[] (env _ ⊢V _ _) _) = ¬⊢Vᵇ-int ⊢V
 
 -- the rule's conversion-typing premise, read under one `abst`
-⊢sᵇ : (abst ∷ convCtx Θᵇ Δᵇ) ⊢ id `ℕ ∶ `ℕ ⇝ `ℕ
+⊢sᵇ : (unmasked abst ∷ convCtx Θᵇ Δᵇ) ⊢ id `ℕ ∶ `ℕ ⇝ `ℕ
 ⊢sᵇ = conv-id base-ℕ
 
 -- showTmIn 1 Cᵇ  =
@@ -2893,14 +2893,14 @@ stepᵇ = TyPeelR val-prb ⊢sᵇ
 _ : wkᴹ 1 Vᵇ ≡ prb 1
 _ = refl
 
-_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ interior Θᵇ Δᵇ
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ unmasked (bind `ℕ) ∷ interior Θᵇ Δᵇ
 _ = interior-TyPeelR `ℕ Θᵇ Δᵇ
 
-_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ bind `ℕ ∷ masked (bind
+_ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ ≡ unmasked (bind `ℕ) ∷ masked (bind
   `ℕ) ∷ []
 _ = refl
 
-¬⊢wkVᵇ : ∀ {Γ A} → ¬ ((bind `ℕ ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
+¬⊢wkVᵇ : ∀ {Γ A} → ¬ ((unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
 ¬⊢wkVᵇ (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ¬⊢Cᵇ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Cᵇ ⦂ A)
@@ -2924,7 +2924,7 @@ _ = refl
 --     =  Z := ℕ , X := ℕ , ⌷[Y := ℕ]
 
 Δᶜ : Ctxᵗ
-Δᶜ = bind `ℕ ∷ bind `ℕ ∷ []
+Δᶜ = unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
 
 Θᶜ₂ : CtxMorph
 Θᶜ₂ = morph [] (lock 1 ∷ [])
@@ -2933,7 +2933,7 @@ _ = refl
 Θᶜ₁ = morph (`ℕ ∷ []) []
 
 ⊢ᵐΘᶜ₂ : Δᶜ ⊢ᵐ Θᶜ₂
-⊢ᵐΘᶜ₂ = (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[]))
+⊢ᵐΘᶜ₂ = (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
 
 -- the move, spelled out at this configuration
 _ : _≡_ {A = CtxMorph} (Θᶜ₁ ⋉ Θᶜ₂) (morph (`ℕ ∷ []) (lock 1 ∷ []))
@@ -2955,13 +2955,13 @@ Vᶜ : Term
 Vᶜ = prb 2
 
 _ : interior Θᶜ₁ (interior Θᶜ₂ Δᶜ)
-      ≡ bind `ℕ ∷ bind `ℕ ∷ masked (bind `ℕ) ∷ []
+      ≡ unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 -- V NAMES THE SLOT Θ₂ LOCKS (Y, exterior slot 1; interior slot 2 past
 -- Θ₁'s binder Z).
 ¬⊢Vᶜ : ∀ {Γ A}
-  → ¬ ((bind `ℕ ∷ bind `ℕ ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ Vᶜ ⦂ A)
+  → ¬ ((unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ Vᶜ ⦂ A)
 ¬⊢Vᶜ (⊢ƛ _ (⊢·[] _ (wf-var (_ , es (es ez) , ()))))
 
 -- the lookup premise both rules carry
@@ -3127,7 +3127,7 @@ _ = refl
 -- … so (†) reads, at this Θ: the crossing frame is Δ✦ under one MASKED
 -- bind.
 _ : interior (dual Θᵉ) (interior Θᵉ Δ✦)
-      ≡ map masked (pushBinds (binds Θᵉ) []) ++ Δ✦
+      ≡ map maskEnt (pushBinds (binds Θᵉ) []) ++ Δ✦
 _ = interior-dual Θᵉ Δ✦ ⊢ᵐΘᵉ
 
 _ : interior (dual Θᵉ) (interior Θᵉ Δ✦)

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -68,7 +68,8 @@ open import Relation.Nullary using (¬_)
 open import strong.Types
   using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; _[_]ᵗ; renameᵗ; extᵗ)
 open import strong.Ctx
-  using (Ctxᵗ; Ent; abst; bind; masked; Base; _⊢ᵗ_; _∋_:=_; shiftBy)
+  using (Ctxᵗ; Ent; Binding; unmasked; masked; abst; bind; Base; _⊢ᵗ_;
+         _∋_:=_; shiftBy)
 open import strong.Conversion
   using (Conv; id; seal; unseal; _↦_; `∀; mkId; _⊢_∶_⇝_; reveal; instReveal)
 open import strong.Terms
@@ -156,7 +157,7 @@ preservation-Drop$ = preserve-Drop$
 -- the conversion is the mint at the binder the rule introduces.
 preservation-TyPeelR : ∀ {V Θ s B Bᵢ Bₑ}
   → Value V
-  → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
   → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
     -----------------------------------------------------
   → Δ ∣ [] ⊢ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])

--- a/SystemF/agda/strong/Progress.agda
+++ b/SystemF/agda/strong/Progress.agda
@@ -12,7 +12,7 @@ module strong.Progress where
 --   redex, so the theorem is false outright.
 --
 -- * THE TYPE CONTEXT IS ARBITRARY.  Reduction goes UNDER Λ and under a
---   boundary, so the theorem is used at `abst ∷ Δ` and at
+--   boundary, so the theorem is used at `unmasked abst ∷ Δ` and at
 --   `interior Θ Δ`; nothing about Δ is assumed, and in particular there
 --   is no context well-formedness premise.
 --

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -10,7 +10,7 @@ conversion `c` says leaf by leaf which side of the boundary may see the
 representation.  A variable's representation is stored exactly once, at
 the entry that binds it, and every other mention resolves it by looking
 the **name** up along the enclosing type context.  A masked slot is never
-dropped or re-spelled — its entry is retained (`masked`), so weakening with
+dropped or re-spelled — its binding is retained (`masked b`), so weakening with
 respect to type variables is never used; that is what "strong" means.
 This is **v2**, the conversion-boundary design.  **v1** — one combined
 boundary `M ⟪ Θ , B₀ ⟫` carrying a list of reveals and conceals together
@@ -66,7 +66,7 @@ driver: type-checking it type-checks the whole thing.
 |------|----------|
 | `Types.agda` | System F types in de Bruijn form; renaming and parallel substitution; `_[_]ᵗ` and the at-a-slot substitution `_[_:=_]ᵗ` |
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
-| `Ctx.agda` | **the type context**: entries `abst` / `bind A` / `masked E`, lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑`), injective renamings, in-place `mask`/`unmask`, and the bind prefix `pushBinds` with `shiftBy` |
+| `Ctx.agda` | **the type context**: entries in two layers — a `Binding` (`abst` / `bind A`) under at most one lock (`unmasked b` / `masked b`), so `Nameable`/`Locked` are one-clause discriminations and double masking is unrepresentable — lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑` over `⊑ᵇ`), injective renamings, in-place `mask`/`unmask` (`maskEnt`/`unmaskEnt`, total and idempotent), and the bind prefix `pushBinds` with `shiftBy` |
 | `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
 | `CtxMorph.agda` | the context morphism as a **pair** — `record CtxMorph = morph (binds : List Ty) (changes : List Change)`, the binds a PARALLEL block and the changes a SEQUENTIAL `lock`/`unlock` list — with `numBinds`, the type contexts it induces (`applyChanges`/`applyUnlocks` at the list, `scope`/`unlockedScope`/`interior`/`convCtx` at the morphism) and their refinement transports, the well-formedness judgement `Δ ⊢ᵐ Θ` as a pair of halves (`_⊢ʳ_` reps, `_⊢ˢ_` changes), and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -95,7 +95,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- `` ` 0 `` where `env` demands the instantiated
   -- `shiftBy (numBinds Θ + 1) (Bₑ [ A ])`.
   TyPeelR : ∀ {Δ V Θ s B A Bᵢ Bₑ} → Value V
-    → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
     → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
         -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
              ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
@@ -169,7 +169,7 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   ξ-·-l : ∀ {Δ L L′ M} → Δ ⊢ L -→ L′ → Δ ⊢ L · M -→ L′ · M
   ξ-·-r : ∀ {Δ V M M′} → Value V → Δ ⊢ M -→ M′ → Δ ⊢ V · M -→ V · M′
   ξ-·[] : ∀ {Δ L L′ B A} → Δ ⊢ L -→ L′ → Δ ⊢ L ·[ B , A ] -→ L′ ·[ B , A ]
-  ξ-Λ   : ∀ {Δ N N′} → (abst ∷ Δ) ⊢ N -→ N′ → Δ ⊢ Λ N -→ Λ N′
+  ξ-Λ   : ∀ {Δ N N′} → (unmasked abst ∷ Δ) ⊢ N -→ N′ → Δ ⊢ Λ N -→ Λ N′
   ξ-⟪⟫  : ∀ {Δ M M′ Θ c} → interior Θ Δ ⊢ M -→ M′
         → Δ ⊢ M ⟪ Θ , c ⟫ -→ M′ ⟪ Θ , c ⟫
 

--- a/SystemF/agda/strong/Show.agda
+++ b/SystemF/agda/strong/Show.agda
@@ -43,7 +43,8 @@ open import Data.String using (String; _++_)
 open import Data.Product using (_×_; _,_; proj₁)
 
 open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀)
-open import strong.Ctx using (Ent; abst; bind; masked; Ctxᵗ)
+open import strong.Ctx
+  using (Ent; Binding; unmasked; masked; abst; bind; Ctxᵗ)
 open import strong.Conversion using (Conv; id; seal; unseal; _↦_; `∀)
 open import strong.Terms using (Term; `_; $_; ƛ_∙_; _·_; Λ_; _·[_,_]; _⟪_,_⟫)
 open import strong.CtxMorph
@@ -238,10 +239,16 @@ showTm td xd tys tms M = proj₁ (showTmF td tys tms (mkSt td xd) M)
 -- type contexts (entries named newest-first: slot 0 = X)
 ------------------------------------------------------------------------
 
+-- The binding layer renders the slot; the lock layer wraps it in `⌷[…]`.
+-- The rendered strings are exactly as before — `X := A`, `X Λ-bound`,
+-- `⌷[…]` — but the recursion is gone: one lock, one wrap.
+showBinding : ℕ → Supply → String → Binding → String
+showBinding d sup nm abst     = nm ++ " Λ-bound"
+showBinding d sup nm (bind A) = nm ++ " := " ++ showTy d sup A
+
 showEntry : ℕ → Supply → String → Ent → String
-showEntry d sup nm abst       = nm ++ " Λ-bound"
-showEntry d sup nm (bind A)   = nm ++ " := " ++ showTy d sup A
-showEntry d sup nm (masked E) = "⌷[" ++ showEntry d sup nm E ++ "]"
+showEntry d sup nm (unmasked b) = showBinding d sup nm b
+showEntry d sup nm (masked b)   = "⌷[" ++ showBinding d sup nm b ++ "]"
 
 showTCtxAt : ℕ → ℕ → Supply → Ctxᵗ → String
 showTCtxAt d i sup [] = "·"

--- a/SystemF/agda/strong/TermSubst.agda
+++ b/SystemF/agda/strong/TermSubst.agda
@@ -207,7 +207,7 @@ renΓ ρ Γ = map (renameᵗ ρ) Γ
 ⊢retag ls ⊢$           = ⊢$
 ⊢retag ls (⊢ƛ w ⊢N)    = ⊢ƛ (⊑-wf (⊑ᵃ→⊑ ls) w) (⊢retag ls ⊢N)
 ⊢retag ls (⊢· ⊢L ⊢M)   = ⊢· (⊢retag ls ⊢L) (⊢retag ls ⊢M)
-⊢retag ls (⊢Λ ⊢N)      = ⊢Λ (⊢retag (la∷ la-aa ls) ⊢N)
+⊢retag ls (⊢Λ ⊢N)      = ⊢Λ (⊢retag (la∷ (la-uu le-aa) ls) ⊢N)
 ⊢retag ls (⊢·[] ⊢L w)  = ⊢·[] (⊢retag ls ⊢L) (⊑-wf (⊑ᵃ→⊑ ls) w)
 ⊢retag ls (env {Θ = Θ} mwᵥ ⊢M ⊢c wE) =
   env (⊢ᵐ-⊑ᵃ ls mwᵥ)
@@ -333,7 +333,7 @@ Ren-wk = mkRen es
 ⇑ᴹ-⊢ : ∀ {σ : ℕ → Term} {Δ Γ Γ′}
   → (∀ {x B} → Γ ∋ x ⦂ B → Δ ∣ Γ′ ⊢ σ x ⦂ B)
     --------------------------------------------------------------------
-  → (∀ {x B} → ⤊ Γ ∋ x ⦂ B → (abst ∷ Δ) ∣ ⤊ Γ′ ⊢ ⇑ᴹ (σ x) ⦂ B)
+  → (∀ {x B} → ⤊ Γ ∋ x ⦂ B → (unmasked abst ∷ Δ) ∣ ⤊ Γ′ ⊢ ⇑ᴹ (σ x) ⦂ B)
 ⇑ᴹ-⊢ h d with ∋⦂-map⁻ d
 ... | A , refl , q = ⊢rename Ren-wk Inj-suc (h q)
 

--- a/SystemF/agda/strong/Terms.agda
+++ b/SystemF/agda/strong/Terms.agda
@@ -85,7 +85,7 @@ data _∣_⊢_⦂_ : Ctxᵗ → Ctx → Term → Ty → Set where
   ⊢· : ∀ {Δ Γ A B L M} → Δ ∣ Γ ⊢ L ⦂ (A ⇒ B) → Δ ∣ Γ ⊢ M ⦂ A
      → Δ ∣ Γ ⊢ L · M ⦂ B
 
-  ⊢Λ : ∀ {Δ Γ C N} → (abst ∷ Δ) ∣ ⤊ Γ ⊢ N ⦂ C → Δ ∣ Γ ⊢ Λ N ⦂ `∀ C
+  ⊢Λ : ∀ {Δ Γ C N} → (unmasked abst ∷ Δ) ∣ ⤊ Γ ⊢ N ⦂ C → Δ ∣ Γ ⊢ Λ N ⦂ `∀ C
 
   ⊢·[] : ∀ {Δ Γ A B L} → Δ ∣ Γ ⊢ L ⦂ `∀ B → Δ ⊢ᵗ A
        → Δ ∣ Γ ⊢ L ·[ B , A ] ⦂ B [ A ]ᵗ

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2546,3 +2546,18 @@ morphism has all binds before all changes); the one lemma that pays is
 lemmas deleted, 3 numBinds lemmas became refl, ⊢ᵐ-++ vanished (⊢ˢ-++ is
 rep-free), 26 change-list inductions lost their bind case.  Rendering
 unchanged.  Branch morph-pair, PR to follow.
+
+### Entries are a binding plus at most one lock (Jeremy, 2026-09-08)
+
+Jeremy: "Split it into two types so that masked is no longer recursive.
+I don't want to allow more than one masked."  LANDED (branch ent-binding):
+`data Binding = abst | bind A` and `data Ent = unmasked Binding | masked
+Binding`.  One-mask-deep is now BY CONSTRUCTION: `Locked (masked b)` has
+no Nameable premise, `_⊑ᵉ_`/`_⊑ᵃᵉ_` are lifts of one `_⊑ᵇ_` on bindings
+(la-aa/la-ab/la-bb subsumed), `unmaskEnt-nameable` and MaskFacts' `core`
+family vanished, a dozen recursive entry lemmas became two-clause lifts.
+The one honest cost: `maskEnt` is idempotent, so `unmask X (mask X Δ) ≡ Δ`
+needs `Δ ∋tv X` (witness: Δ = masked abst ∷ [], X = 0) — the premise `sw-l`
+always has; threaded into applyUnlocks-dualScope and convCtx-dual.  The
+two mask inverses are now symmetric (`mask-unmask : Δ ∋lk X → …`,
+`unmask-mask : Δ ∋tv X → …`).  Rendering unchanged.

--- a/SystemF/agda/strong/notes/PR-ent-binding.md
+++ b/SystemF/agda/strong/notes/PR-ent-binding.md
@@ -1,0 +1,190 @@
+# Split `Ent` into `Binding` + one lock
+
+Branch `ent-binding`.  `make -C SystemF/agda/strong check` passes cold
+(exit 0, `postulate-check: OK`).
+
+## What changed
+
+`strong.Ctx`'s entry type was recursive in its mask:
+
+```agda
+data Ent : Set where
+  abst   : Ent
+  bind   : Ty → Ent
+  masked : Ent → Ent        -- masked (masked (bind A)) is a term
+```
+
+It is now two layers — what the slot **binds**, and whether the slot is
+**hidden** — with **at most one lock**:
+
+```agda
+data Binding : Set where          -- what a slot binds
+  abst : Binding                  -- Λ-bound, no representation
+  bind : Ty → Binding             -- bound by a boundary, rep A
+
+data Ent : Set where              -- a type-context entry
+  unmasked : Binding → Ent        -- nameable
+  masked   : Binding → Ent        -- hidden by a lock
+```
+
+`masked` no longer takes an `Ent`, so `masked (masked …)` is not a term:
+**"at most one mask" is true by construction**, not by a premise, not by
+an invariant, and not by an induction over a stack.
+
+Everything else follows.  `Nameable`/`Locked` become the two
+constructors' own discriminations — one clause each, **no premise**:
+
+```agda
+data Nameable : Ent → Set where
+  nameable : Nameable (unmasked b)
+
+data Locked : Ent → Set where
+  locked : Locked (masked b)      -- was: locked : Nameable E → Locked (masked E)
+```
+
+`Nameable` was kept as a predicate (rather than inlined as
+`E ≡ unmasked b`) because `_∋tv_`, `_∋lk_` and their transports read as
+before and the several hundred lookup triples in `Examples.agda` keep
+their arity; the whole content of the old two-constructor version was the
+`abst`/`bind` split, which now lives one layer down where it belongs.
+
+Setting and clearing the lock are total and idempotent:
+
+```agda
+maskEnt : Ent → Ent               unmaskEnt : Ent → Ent
+maskEnt (unmasked b) = masked b   unmaskEnt (unmasked b) = unmasked b
+maskEnt (masked b)   = masked b   unmaskEnt (masked b)   = unmasked b
+
+mask   = updateAt maskEnt         unmask = updateAt unmaskEnt
+```
+
+(`maskEnt` is never applied to an already-masked slot in a well-formed
+term — `sw-l` demands a nameable slot — but the function does not have to
+know that, and that is the point.)
+
+Renaming, the instantiation mint and the renderer all become a `Binding`
+operation lifted through the lock layer, with no recursion:
+
+```agda
+renᵇ ρ abst     = abst                 renᵉ ρ (unmasked b) = unmasked (renᵇ ρ b)
+renᵇ ρ (bind A) = bind (renameᵗ ρ A)   renᵉ ρ (masked b)   = masked (renᵇ ρ b)
+```
+
+and likewise `substᵇ`/`substᵉ` (`proof/Preserve` §2a),
+`renᵇ-id`/`renᵉ-id`, `renᵇ-comp`/`renᵉ-comp` (`proof/PeelDual` §3a),
+`showBinding`/`showEntry` (`strong.Show`).
+
+Refinement splits the same way.  `_⊑ᵇ_` carries the knowledge order and
+`_⊑ᵉ_`/`_⊑ᵃᵉ_` lift it through the lock:
+
+```agda
+data _⊑ᵇ_ : Binding → Binding → Set where
+  le-aa : abst ⊑ᵇ abst
+  le-ab : abst ⊑ᵇ bind A
+  le-bb : bind A ⊑ᵇ bind A
+
+data _⊑ᵉ_ : Ent → Ent → Set where
+  le-uu : b ⊑ᵇ b′ → unmasked b ⊑ᵉ unmasked b′
+  le-mm : b ⊑ᵇ b′ → masked b   ⊑ᵉ masked b′
+  le-mu : b ⊑ᵇ b′ → masked b   ⊑ᵉ unmasked b′     -- no Nameable premise
+
+data _⊑ᵃᵉ_ : Ent → Ent → Set where               -- the TERM transport
+  la-uu : b ⊑ᵇ b′ → unmasked b ⊑ᵃᵉ unmasked b′
+  la-mm : b ⊑ᵇ b′ → masked b   ⊑ᵃᵉ masked b′
+```
+
+`_⊑ᵃᵉ_` reuses `_⊑ᵇ_` verbatim — the `abst → bind` step is legal for
+both relations; only the locks differ — so `la-aa`/`la-ab`/`la-bb` are
+gone, subsumed by `la-uu`.
+
+## Lemma deltas
+
+Gone:
+
+* `unmaskEnt-nameable : E ⊑ᵉ E′ → Nameable E′ → E ⊑ᵉ unmaskEnt E′` — it
+  existed only to manufacture the `Nameable` argument `le-mu` used to
+  demand.
+* `la-aa`, `la-ab`, `la-bb` — replaced by `la-uu` over `_⊑ᵇ_`.
+* `core`, `core-ren`, `core-nameable`, `core-masked`, `core-unmaskEnt`
+  (`proof/MaskFacts`) — with one lock per entry the "core" of an entry
+  **is** `unmaskEnt`.  The five are replaced by three one-line case
+  splits (`unmaskEnt-nameable`, `unmaskEnt-maskEnt-core`,
+  `unmaskEnt-idem`), and `core-ren`'s induction becomes
+  `sym (unmaskEnt-comm suc E)`.
+
+Shrunk (no recursion, no witness threading):
+
+| lemma | before | after |
+|-------|--------|-------|
+| `⊑ᵉ-trans` | 6 clauses; `le-mu` calls `nameable-mono` | `⊑ᵇ-trans` 3 + `⊑ᵉ-trans` 4 |
+| `nameable-mono` | 5 clauses | 3 |
+| `masked-le` → `maskEnt-le` | recursive over the stack | 3 clauses |
+| `unmaskEnt-mono` | 5 clauses, one calling a helper | 3 clauses |
+| `⊑ᵉ-refl`, `⊑ᵃᵉ-refl`, `⊑ᵉ-⇑`, `⊑ᵃᵉ-⇑` | recursive | `⊑ᵇ-refl`/`⊑ᵇ-⇑` + 2-clause lift |
+| `⊑ᵃᵉ-Locked` | rebuilds via `nameable-mono` | `(la-mm l) locked = locked` |
+| `maskEnt-unmask` | `(locked v) = refl` | `locked = refl` |
+| `renᵉ-Nameable⁻`, `Locked-ren⁻` | 3 clauses each | 2 each |
+| `⊑ᵉ-unmaskEnt` | `masked` case via `masked-le` | 2 clauses, `le-uu`/`le-mu` |
+| `renᵉ-⇑-comm`, `renᵉ-Nameable`, `renᵉ-Locked` | recursive / 2 clauses | 2 / 1 / 1 |
+
+Grew — **one** place, and it is the honest cost of an idempotent mask:
+
+```agda
+-- was: unmask-mask : (X : ℕ) (Δ : Ctxᵗ) → unmask X (mask X Δ) ≡ Δ
+unmask-mask : Δ ∋tv X → unmask X (mask X Δ) ≡ Δ
+```
+
+With a stack of masks, `mask` at an already-masked slot pushed a second
+lock which `unmask` popped, so the identity held everywhere.  With one
+lock, `maskEnt` is idempotent, so at an already-masked slot `unmask (mask
+X Δ)` *exposes* what `Δ` had hidden.  Counterexample:
+`Δ = masked abst ∷ []`, `X = 0` — `mask 0 Δ ≡ Δ` and
+`unmask 0 (mask 0 Δ) ≡ unmasked abst ∷ [] ≢ Δ`.
+
+The premise is always at hand: `sw-l` admits `lock X` only at a `∋tv`
+slot, which is exactly the discipline that made double masking
+unreachable before.  It is threaded through two lemmas, each of which
+gains an argument its single call site already has:
+
+* `proof/PeelDual.applyUnlocks-dualScope` gains `Δ ⊢ˢ S`;
+* `proof/PeelDual.convCtx-dual` gains `Δ ⊢ˢ changes Θ`, supplied at its
+  one use site by `mw-changes mwᵥ` in `preserve-Peel`.
+
+No theorem statement was weakened otherwise; `mask-unmask : Δ ∋lk X →
+mask X (unmask X Δ) ≡ Δ` is unchanged, so the two inverses are now
+**symmetric** — each holds exactly at the slots its own direction is
+applied to.
+
+`proof/DualTightness.¬⊢ᵐ-double-lock` survives with a different job: it
+is no longer what keeps `Locked` one mask deep (that is by construction),
+but the fact that the judgement still refuses a vacuous re-lock — which
+is what keeps `unmask-mask`'s premise available.
+
+## Rendering deltas
+
+None.  `showEntry` was split into `showBinding` (the slot) and
+`showEntry` (the `⌷[…]` wrap), and the strings are byte-identical:
+`X := A`, `X Λ-bound`, `⌷[X := A]`.  Every `Examples.agda` rendering
+example still checks by `refl`.
+
+## Mechanical rewrite
+
+Every pattern match on an entry across the development was rewritten:
+`abst` → `unmasked abst`, `bind A` → `unmasked (bind A)` in `Ent`
+position, `masked (bind A)` unchanged (its argument is now a `Binding`),
+`masked` in function position → `maskEnt`, `nameable-a`/`nameable-b` →
+`nameable`, `locked v` → `locked`.  `Examples.agda` carries the bulk:
+about 290 lines mentioning an entry constructor, most of them lookup
+triples of the form `(unmasked (bind ℕ) , ez , nameable)`; ~30 of them
+then had to be re-wrapped to stay under 80 columns.  Files touched: `Ctx`,
+`Conversion`, `CtxMorph`, `Terms`, `TermSubst`, `Reduction`, `Progress`,
+`Preservation`, `Show`, `Examples`, and `proof/{Adversary, DualTightness,
+IdLayer, MaskFacts, MoveScope, MwUObstruct, PeelDual, Preserve,
+PreserveObstruct, Progress}`.
+
+## Docs
+
+`Design.md` §3 (*Entries*, *Refinement*, *The three operations*, plus a
+new *What the one-mask entry costs, and what it buys*), §4.2 (the `lock`
+premise's new job), Appendix A (`Binding`, `unmasked`, `maskEnt`, `⊑ᵇ`,
+the reletter note); `README.md`'s `Ctx.agda` row.

--- a/SystemF/agda/strong/proof/Adversary.agda
+++ b/SystemF/agda/strong/proof/Adversary.agda
@@ -39,11 +39,11 @@ unlock-claims-a-lock : ∀ {Δ X S} → applyChanges S Δ ∋lk X → Δ ⊢ˢ S
   → Δ ⊢ˢ (unlock X ∷ S)
 unlock-claims-a-lock = sw-u
 
--- The claim mentions no representation: all it hands back is a
--- NAMEABLE entry under one mask, and `Nameable` is `abst` or `bind`
--- without reading the bind's type.
+-- The claim mentions no representation: all it hands back is the entry
+-- with its ONE lock cleared, and `Nameable` reads only the lock layer —
+-- it never looks at the `Binding`, let alone a bind's type.
 unlock-mentions-no-rep : ∀ {Δ X} → Δ ∋lk X → ∃[ E ] Nameable E
-unlock-mentions-no-rep (masked E , _ , locked v) = E , v
+unlock-mentions-no-rep (masked b , _ , locked) = unmasked b , nameable
 
 ------------------------------------------------------------------------
 -- 2.  THE ADVERSARY (the old ⊢3n-adv): a conceal asserting false knowledge
@@ -56,7 +56,7 @@ unlock-mentions-no-rep (masked E , _ , locked v) = E , v
 -- (`unlock-claims-a-lock`).
 
 Δadv : Ctxᵗ
-Δadv = abst ∷ []
+Δadv = unmasked abst ∷ []
 
 ¬know-adv : ∀ {A} → Δadv ∋ 0 := A → ⊥
 ¬know-adv ()
@@ -79,7 +79,7 @@ unlock-mentions-no-rep (masked E , _ , locked v) = E , v
 ∀ZZ = `∀ (` 0 ⇒ ` 0)
 
 Δbad : Ctxᵗ
-Δbad = bind ∀ZZ ∷ []
+Δbad = unmasked (bind ∀ZZ) ∷ []
 
 seal-bad-conv : ∀ {A B} → Δbad ⊢ seal 0 ∶ A ⇝ B → A ≡ ⇑ᵗ ∀ZZ
 seal-bad-conv (conv-seal ez) = refl

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -7,7 +7,7 @@ module strong.proof.DualTightness where
 -- `unlock` entries, so a boundary whose morphism UNMASKS an exterior slot
 -- handed its crossing argument a frame in which that slot was STILL
 -- unmasked: `interior (dual Θ) (interior Θ Δ)` was
--- `map masked (bind prefix) ++ unlockedScope Θ Δ`, STRICTLY MORE
+-- `map maskEnt (bind prefix) ++ unlockedScope Θ Δ`, STRICTLY MORE
 -- NAMEABLE than Δ whenever Θ unlocked a slot Δ masked.  SCOPE WAS GAINED
 -- THROUGH THE BOUNDARY: the redex below is ILL TYPED at Δᵤ (its argument
 -- W names a slot MASKED at Δᵤ) and its `Peel` contractum was WELL TYPED.
@@ -21,7 +21,7 @@ module strong.proof.DualTightness where
 --       — the dual RESTORES what Θ unlocked, and the list is REVERSED,
 --       because `scope` applies it HEAD-LAST.
 --
--- With both, `interior (dual Θ) (interior Θ Δ) ≡ map masked (bind prefix)
+-- With both, `interior (dual Θ) (interior Θ Δ) ≡ map maskEnt (bind prefix)
 -- ++ Δ` EXACTLY (proof/PeelDual, `interior-dual`), the crossing is
 -- `⊢rename` alone, and the contractum below is REFUSED — §3.
 
@@ -89,7 +89,8 @@ W = ƛ `ℕ ∙ ((Λ ($ 3)) ·[ `ℕ , ` 0 ])
 -- The boundary ALONE is well typed at Δᵤ …
 ⊢Vb : Δᵤ ∣ [] ⊢ V ⟪ Θᵤ , cᵤ ⟫ ⦂ ((`ℕ ⇒ `ℕ) ⇒ (`ℕ ⇒ `ℕ))
 ⊢Vb = env (mw rw[] (sw-u ∋lk-Δᵤ sw[]))
-          (⊢ƛ (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable)) wf-ℕ) (⊢` here))
+          (⊢ƛ (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable)) wf-ℕ)
+              (⊢` here))
           (conv-fun (conv-fun (conv-unseal ez) (conv-id base-ℕ))
                     (conv-fun (conv-seal ez) (conv-id base-ℕ)))
           (wf-⇒ (wf-⇒ wf-ℕ wf-ℕ) (wf-⇒ wf-ℕ wf-ℕ))
@@ -178,7 +179,11 @@ _ = refl
 ¬⊢ᵐΘᵥ : ¬ (Δᵥ ⊢ᵐ Θᵥ)              -- … and is REFUSED
 ¬⊢ᵐΘᵥ (mw _ (sw-u (_ , ez , ()) _))
 
--- A DOUBLE LOCK IS REFUSED TOO — which is what keeps `Locked` one mask
--- deep, and hence `unmaskEnt` an exact inverse of `masked`.
+-- A DOUBLE LOCK IS REFUSED TOO.  With the two-layer entry (strong.Ctx
+-- §1) it is no longer the fact that keeps `Locked` one mask deep — that
+-- is by construction — but it is still what makes `unmaskEnt` an exact
+-- inverse of `maskEnt` where it is applied: `mask` is idempotent, so
+-- `unmask ∘ mask` is the identity only at a NAMEABLE slot
+-- (`unmask-mask`), and `sw-l` never masks any other kind.
 ¬⊢ᵐ-double-lock : ¬ (Δᵥ ⊢ᵐ morph [] (lock 0 ∷ lock 0 ∷ []))
 ¬⊢ᵐ-double-lock (mw _ (sw-l (_ , ez , ()) _))

--- a/SystemF/agda/strong/proof/DualTightness.agda
+++ b/SystemF/agda/strong/proof/DualTightness.agda
@@ -53,7 +53,7 @@ open import strong.Reduction
 
 -- … but it IS locked, so an `unlock` may cite it.
 ∋lk-Δᵤ : Δᵤ ∋lk 0
-∋lk-Δᵤ = masked (bind `ℕ) , ez , locked nameable-b
+∋lk-Δᵤ = masked (bind `ℕ) , ez , locked
 
 -- The boundary's morphism UNMASKS U for its interior (the
 -- crossing-of-crossing shape: an inner region re-exposes what an outer
@@ -61,7 +61,7 @@ open import strong.Reduction
 Θᵤ : CtxMorph
 Θᵤ = morph [] (unlock 0 ∷ [])
 
-_ : interior Θᵤ Δᵤ ≡ bind `ℕ ∷ []
+_ : interior Θᵤ Δᵤ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 ------------------------------------------------------------------------
@@ -89,7 +89,7 @@ W = ƛ `ℕ ∙ ((Λ ($ 3)) ·[ `ℕ , ` 0 ])
 -- The boundary ALONE is well typed at Δᵤ …
 ⊢Vb : Δᵤ ∣ [] ⊢ V ⟪ Θᵤ , cᵤ ⟫ ⦂ ((`ℕ ⇒ `ℕ) ⇒ (`ℕ ⇒ `ℕ))
 ⊢Vb = env (mw rw[] (sw-u ∋lk-Δᵤ sw[]))
-          (⊢ƛ (wf-⇒ (wf-var (bind `ℕ , ez , nameable-b)) wf-ℕ) (⊢` here))
+          (⊢ƛ (wf-⇒ (wf-var (unmasked (bind `ℕ) , ez , nameable)) wf-ℕ) (⊢` here))
           (conv-fun (conv-fun (conv-unseal ez) (conv-id base-ℕ))
                     (conv-fun (conv-seal ez) (conv-id base-ℕ)))
           (wf-⇒ (wf-⇒ wf-ℕ wf-ℕ) (wf-⇒ wf-ℕ wf-ℕ))
@@ -141,7 +141,7 @@ _ = refl
 -- Θˡ locks it; the dual unlocks it again, and the argument's frame inside
 -- is Δ with the bind prefix masked — Z still nameable.
 Δˡ : Ctxᵗ
-Δˡ = bind `ℕ ∷ []
+Δˡ = unmasked (bind `ℕ) ∷ []
 
 Θˡ : CtxMorph
 Θˡ = morph [] (lock 0 ∷ [])
@@ -153,7 +153,7 @@ _ : dual Θˡ ≡ morph [] (unlock 0 ∷ [])
 _ = refl
 
 -- the crossing frame is Δˡ back: Z is nameable, exactly as at the exterior
-_ : interior (dual Θˡ) (interior Θˡ Δˡ) ≡ bind `ℕ ∷ []
+_ : interior (dual Θˡ) (interior Θˡ Δˡ) ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 ------------------------------------------------------------------------
@@ -167,7 +167,7 @@ _ = refl
 -- what the exterior left visible — so the judgement must refuse it, and
 -- does.
 Δᵥ : Ctxᵗ
-Δᵥ = bind `ℕ ∷ []
+Δᵥ = unmasked (bind `ℕ) ∷ []
 
 Θᵥ : CtxMorph
 Θᵥ = morph [] (unlock 0 ∷ [])

--- a/SystemF/agda/strong/proof/IdLayer.agda
+++ b/SystemF/agda/strong/proof/IdLayer.agda
@@ -88,7 +88,7 @@ convCtx-lock Θ Δ = refl
 -- V's licence cites a slot Δ does not even have.
 
 Δₑ : Ctxᵗ
-Δₑ = bind `ℕ ∷ []
+Δₑ = unmasked (bind `ℕ) ∷ []
 
 Δₑ-no-1 : ∀ {E} → Δₑ ∋e 1 , E → ⊥
 Δₑ-no-1 (es ())

--- a/SystemF/agda/strong/proof/MaskFacts.agda
+++ b/SystemF/agda/strong/proof/MaskFacts.agda
@@ -59,8 +59,8 @@ lock-then-unlock = refl
 
 -- `interior Θ Δ` and `convCtx Θ Δ` differ ONLY by masking: `scope` applies the
 -- `lock` masks, `unlockedScope` skips them, and both do the same binds and the
--- same unmasks.  Masking never turns an `abst` into a `bind` — it only
--- wraps and unwraps `masked` — so a slot that is VISIBLE inside and a BINDER
+-- same unmasks.  Masking never touches the BINDING layer — it only sets
+-- and clears the lock — so a slot that is VISIBLE inside and a BINDER
 -- outside is that same binder inside.  This is the one structural step
 -- the old IdPush side-condition proof and CancelR's preservation case
 -- consume; here it is a theorem, not an interface.

--- a/SystemF/agda/strong/proof/MaskFacts.agda
+++ b/SystemF/agda/strong/proof/MaskFacts.agda
@@ -27,8 +27,8 @@ open import strong.CtxMorph
 mask-retains : ∀ {Δ X Y A} → Δ ∋ X := A
   → (mask Y Δ ∋ X := A) ⊎ (mask Y Δ ∋e X , masked (bind A))
 mask-retains {X = X} {Y = Y} d with Y ≟ℕ X
-... | yes refl = inj₂ (updateAt-hit masked masked-comm d)
-... | no ne    = inj₁ (updateAt-miss masked masked-comm ne d)
+... | yes refl = inj₂ (updateAt-hit maskEnt maskEnt-comm d)
+... | no ne    = inj₁ (updateAt-miss maskEnt maskEnt-comm ne d)
 
 unlock-recovers : ∀ {Δ X A} → Δ ∋e X , masked (bind A) → unmask X Δ ∋ X := A
 unlock-recovers d = updateAt-hit unmaskEnt unmaskEnt-comm d
@@ -37,8 +37,8 @@ unlock-recovers d = updateAt-hit unmaskEnt unmaskEnt-comm d
 -- itself and then looks again is harmless and typeable.
 lock-then-unlock :
   interior (morph [] (unlock 0 ∷ []))
-    (interior (morph [] (lock 0 ∷ [])) (bind `ℕ ∷ []))
-    ≡ bind `ℕ ∷ []
+    (interior (morph [] (lock 0 ∷ [])) (unmasked (bind `ℕ) ∷ []))
+    ≡ unmasked (bind `ℕ) ∷ []
 lock-then-unlock = refl
 
 ------------------------------------------------------------------------
@@ -66,40 +66,38 @@ lock-then-unlock = refl
 -- consume; here it is a theorem, not an interface.
 --
 -- The invariant that carries it: the CORE of an entry — what it is once
--- every conceal is peeled — is untouched by `masked` and by `unmaskEnt` alike.
+-- every conceal is peeled — is untouched by `maskEnt` and by `unmaskEnt`
+-- alike.
+--
+-- WITH ONE LOCK PER ENTRY THE CORE IS `unmaskEnt` ITSELF.  The old design
+-- needed a separate recursive `core` (with `core-ren`, `core-masked` and
+-- `core-unmaskEnt` proved by induction over the mask stack) precisely
+-- because `unmaskEnt` peeled ONE mask and a core had to peel all of them.
+-- There is only ever one, so `core ≡ unmaskEnt` and the three inductive
+-- lemmas below are one-line case splits.
 
-core : Ent → Ent
-core abst        = abst
-core (bind A)    = bind A
-core (masked E)  = core E
+unmaskEnt-nameable : ∀ {E} → Nameable E → unmaskEnt E ≡ E
+unmaskEnt-nameable nameable = refl
 
-core-ren : (ρ : Renameᵗ) (E : Ent) → core (renᵉ ρ E) ≡ renᵉ ρ (core E)
-core-ren ρ abst        = refl
-core-ren ρ (bind A)    = refl
-core-ren ρ (masked E)  = core-ren ρ E
+unmaskEnt-maskEnt-core : (E : Ent) → unmaskEnt (maskEnt E) ≡ unmaskEnt E
+unmaskEnt-maskEnt-core (unmasked b) = refl
+unmaskEnt-maskEnt-core (masked b)   = refl
 
-core-nameable : ∀ {E} → Nameable E → core E ≡ E
-core-nameable nameable-a = refl
-core-nameable nameable-b = refl
-
-core-masked : (E : Ent) → core (masked E) ≡ core E
-core-masked E = refl
-
-core-unmaskEnt : (E : Ent) → core (unmaskEnt E) ≡ core E
-core-unmaskEnt abst        = refl
-core-unmaskEnt (bind A)    = refl
-core-unmaskEnt (masked E)  = refl
+unmaskEnt-idem : (E : Ent) → unmaskEnt (unmaskEnt E) ≡ unmaskEnt E
+unmaskEnt-idem (unmasked b) = refl
+unmaskEnt-idem (masked b)   = refl
 
 -- Two type contexts agree UP TO CONCEALMENT at every slot.
 CoreEq : Ctxᵗ → Ctxᵗ → Set
-CoreEq Δ Δ′ = ∀ {Y E E′} → Δ ∋e Y , E → Δ′ ∋e Y , E′ → core E ≡ core E′
+CoreEq Δ Δ′ =
+  ∀ {Y E E′} → Δ ∋e Y , E → Δ′ ∋e Y , E′ → unmaskEnt E ≡ unmaskEnt E′
 
 CoreEq-refl : (Δ : Ctxᵗ) → CoreEq Δ Δ
-CoreEq-refl Δ d d′ = cong core (∋e-det d d′)
+CoreEq-refl Δ d d′ = cong unmaskEnt (∋e-det d d′)
 
 module _ (f : Ent → Ent)
          (fc : ∀ ρ E → renᵉ ρ (f E) ≡ f (renᵉ ρ E))
-         (fcore : ∀ E → core (f E) ≡ core E) where
+         (fcore : ∀ E → unmaskEnt (f E) ≡ unmaskEnt E) where
 
   -- one update on the LEFT only (the `lock` case: `scope` masks,
   -- `unlockedScope` skips)
@@ -125,9 +123,10 @@ CoreEq-applyChanges : (S : List Change) (Δ : Ctxᵗ)
   → CoreEq (applyChanges S Δ) (applyUnlocks S Δ)
 CoreEq-applyChanges []             Δ = CoreEq-refl Δ
 CoreEq-applyChanges (lock X ∷ S)   Δ =
-  CoreEq-updateAtˡ masked masked-comm core-masked (CoreEq-applyChanges S Δ)
+  CoreEq-updateAtˡ maskEnt maskEnt-comm unmaskEnt-maskEnt-core
+    (CoreEq-applyChanges S Δ)
 CoreEq-applyChanges (unlock X ∷ S) Δ =
-  CoreEq-updateAt unmaskEnt unmaskEnt-comm core-unmaskEnt
+  CoreEq-updateAt unmaskEnt unmaskEnt-comm unmaskEnt-idem
     (CoreEq-applyChanges S Δ)
 
 CoreEq-scope : (Θ : CtxMorph) (Δ : Ctxᵗ)
@@ -139,15 +138,15 @@ CoreEq-pushBinds : ∀ {Δ Δ′} (As : List Ty)
 CoreEq-pushBinds []       ce d      d′       = ce d d′
 CoreEq-pushBinds (A ∷ As) ce ez     ez       = refl
 CoreEq-pushBinds (A ∷ As) ce (es {E = E} d) (es {E = E′} d′) =
-  trans (core-ren suc E)
+  trans (sym (unmaskEnt-comm suc E))
         (trans (cong ⇑ᵉ (CoreEq-pushBinds As ce d d′))
-               (sym (core-ren suc E′)))
+               (unmaskEnt-comm suc E′))
 
 -- THE FACT.
 mask-only : ∀ (Θ : CtxMorph) (Δ : Ctxᵗ) {Y A}
   → interior Θ Δ ∋tv Y → convCtx Θ Δ ∋ Y := A → interior Θ Δ ∋ Y := A
 mask-only Θ Δ (E , d , v) df =
   subst (λ F → interior Θ Δ ∋e _ , F)
-        (trans (sym (core-nameable v))
+        (trans (sym (unmaskEnt-nameable v))
                (CoreEq-pushBinds (binds Θ) (CoreEq-scope Θ Δ) d df))
         d

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -121,7 +121,7 @@ applyChanges-shiftScope As (unlock X ∷ S) Δ =
         (updateAt-pushBinds unmaskEnt As X (applyChanges S Δ))
 applyChanges-shiftScope As (lock X ∷ S)   Δ =
   trans (cong (mask (length As + X)) (applyChanges-shiftScope As S Δ))
-        (updateAt-pushBinds masked As X (applyChanges S Δ))
+        (updateAt-pushBinds maskEnt As X (applyChanges S Δ))
 
 applyUnlocks-shiftScope : (As : List Ty) (S : List Change) (Δ : Ctxᵗ)
   → applyUnlocks (shiftScope (length As) S) (pushBinds As Δ)
@@ -267,17 +267,17 @@ locksOnly n (lock X ∷ S)   = lock (n + X) ∷ locksOnly n S
 Θ✗ = morph [] (unlock 0 ∷ lock 0 ∷ [])
 
 Δ✗ : Ctxᵗ
-Δ✗ = bind `ℕ ∷ []
+Δ✗ = unmasked (bind `ℕ) ∷ []
 
 ⊢ᵐ-Θ✗ : Δ✗ ⊢ᵐ Θ✗
 ⊢ᵐ-Θ✗ = mw rw[]
-           (sw-u (masked (bind `ℕ) , ez , locked nameable-b)
-                 (sw-l (bind `ℕ , ez , nameable-b) sw[]))
+           (sw-u (masked (bind `ℕ) , ez , locked)
+                 (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[]))
 
-_ : interior Θ✗ Δ✗ ≡ bind `ℕ ∷ []
+_ : interior Θ✗ Δ✗ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
-_ : interior (rewind Θ✗) Δ✗ ≡ bind `ℕ ∷ []
+_ : interior (rewind Θ✗) Δ✗ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 -- … but the lock-only contractum's interior BLOCKS it.

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -179,7 +179,8 @@ _ = refl
 -- entry is a `lock`, which `applyUnlocks` skips, so the context is
 -- literally the same.)
 ⊢ᵐ-rewind-Θ₂ : Δ₆ ⊢ᵐ rewind Θ₂
-⊢ᵐ-rewind-Θ₂ = mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) (mw-changes ⊢ᵐΘ₂))
+⊢ᵐ-rewind-Θ₂ = mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable)
+                            (mw-changes ⊢ᵐΘ₂))
 
 ⊢ᵐ-rewind-Θ₆ : Δ₆ ⊢ᵐ rewind Θ₆
 ⊢ᵐ-rewind-Θ₆ = mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[])

--- a/SystemF/agda/strong/proof/MwUObstruct.agda
+++ b/SystemF/agda/strong/proof/MwUObstruct.agda
@@ -94,9 +94,9 @@ bindsOnly Θ = morph (binds Θ) []
 Θ₂ = morph [] (unlock 0 ∷ [])
 
 ⊢ᵐΘ₂ : Δ₆ ⊢ᵐ Θ₂
-⊢ᵐΘ₂ = mw rw[] (sw-u (masked (bind `ℕ) , ez , locked nameable-b) sw[])
+⊢ᵐΘ₂ = mw rw[] (sw-u (masked (bind `ℕ) , ez , locked) sw[])
 
-_ : interior Θ₂ Δ₆ ≡ bind `ℕ ∷ []
+_ : interior Θ₂ Δ₆ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 -- An inner frame that BINDS a rep naming that slot — legal at Θ₂'s
@@ -105,7 +105,7 @@ _ = refl
 Θ₁ = morph (` 0 ∷ []) []
 
 ⊢ᵐΘ₁ : interior Θ₂ Δ₆ ⊢ᵐ Θ₁
-⊢ᵐΘ₁ = mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[]) sw[]
+⊢ᵐΘ₁ = mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[]) sw[]
 
 -- THE MERGED FRAME the scope move builds.  Θ₂ carries no binder, so the
 -- moved change keeps its index.
@@ -118,8 +118,8 @@ _ = refl
 -- It is well formed over Δ₆ — its rep is read past its OWN change list,
 -- i.e. past the unlock, which is where the redex read it.
 ⊢ᵐΘ₆ : Δ₆ ⊢ᵐ Θ₆
-⊢ᵐΘ₆ = mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[])
-          (sw-u (masked (bind `ℕ) , ez , locked nameable-b) sw[])
+⊢ᵐΘ₆ = mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[])
+          (sw-u (masked (bind `ℕ) , ez , locked) sw[])
 
 ------------------------------------------------------------------------
 -- §2  `dropLocks` REFUTED — the moved unlock goes vacuous
@@ -131,7 +131,7 @@ _ = refl
 _ : _≡_ {A = CtxMorph} (dropLocks Θ₂) Θ₂
 _ = refl
 
-_ : interior (dropLocks Θ₂) Δ₆ ≡ bind `ℕ ∷ []
+_ : interior (dropLocks Θ₂) Δ₆ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 -- The merged frame is read there, and its `unlock 0` has no premise.
@@ -179,11 +179,11 @@ _ = refl
 -- entry is a `lock`, which `applyUnlocks` skips, so the context is
 -- literally the same.)
 ⊢ᵐ-rewind-Θ₂ : Δ₆ ⊢ᵐ rewind Θ₂
-⊢ᵐ-rewind-Θ₂ = mw rw[] (sw-l (bind `ℕ , ez , nameable-b) (mw-changes ⊢ᵐΘ₂))
+⊢ᵐ-rewind-Θ₂ = mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) (mw-changes ⊢ᵐΘ₂))
 
 ⊢ᵐ-rewind-Θ₆ : Δ₆ ⊢ᵐ rewind Θ₆
-⊢ᵐ-rewind-Θ₆ = mw (rw-b (wf-var (bind `ℕ , ez , nameable-b)) rw[])
-                  (sw-l (bind `ℕ , ez , nameable-b) (mw-changes ⊢ᵐΘ₆))
+⊢ᵐ-rewind-Θ₆ = mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[])
+                  (sw-l (unmasked (bind `ℕ) , ez , nameable) (mw-changes ⊢ᵐΘ₆))
 
 -- THE MERGED FRAME IS WELL FORMED OVER IT.
 ⊢ᵐ-merged : interior (rewind Θ₂) Δ₆ ⊢ᵐ (Θ₁ ⋉ Θ₂)
@@ -197,4 +197,4 @@ _ = refl
 -- locks — `applyUnlocks`, not `applyChanges`) is what makes both the move
 -- and TyPeelR's prepended bind well formed at once.
 ⊢ᵗ-rep-past-changes : applyUnlocks (unlock 0 ∷ []) Δ₆ ⊢ᵗ ` 0
-⊢ᵗ-rep-past-changes = wf-var (bind `ℕ , ez , nameable-b)
+⊢ᵗ-rep-past-changes = wf-var (unmasked (bind `ℕ) , ez , nameable)

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -132,12 +132,12 @@ applyChanges-dualScope As (lock X ∷ S)   {Δ = Δ} (sw-l tv b)
                           (unlock (length As + X) ∷ [])
                           (pushBinds As (mask X (applyChanges S Δ)))
         | updateAt-pushBinds unmaskEnt As X (mask X (applyChanges S Δ))
-        | unmask-mask X (applyChanges S Δ) = applyChanges-dualScope As S b
+        | unmask-mask tv = applyChanges-dualScope As S b
 applyChanges-dualScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b)
   rewrite applyChanges-++ (dualScope (length As) S)
                           (lock (length As + X) ∷ [])
                           (pushBinds As (unmask X (applyChanges S Δ)))
-        | updateAt-pushBinds masked As X (unmask X (applyChanges S Δ))
+        | updateAt-pushBinds maskEnt As X (unmask X (applyChanges S Δ))
         | mask-unmask lk = applyChanges-dualScope As S b
 
 -- … AND IT IS WELL FORMED WHERE IT LANDS.  S's `lock X` becomes an
@@ -156,7 +156,7 @@ applyChanges-dualScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b)
   eq : unmask (length As + X) (pushBinds As (mask X (applyChanges S Δ)))
          ≡ pushBinds As (applyChanges S Δ)
   eq = trans (updateAt-pushBinds unmaskEnt As X (mask X (applyChanges S Δ)))
-             (cong (pushBinds As) (unmask-mask X (applyChanges S Δ)))
+             (cong (pushBinds As) (unmask-mask tv))
 ⊢ˢ-dualScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b) =
   ⊢ˢ-++ (dualScope (length As) S) (lock (length As + X) ∷ [])
         (subst (λ Ξ → Ξ ⊢ˢ dualScope (length As) S) (sym eq)
@@ -165,7 +165,7 @@ applyChanges-dualScope As (unlock X ∷ S) {Δ = Δ} (sw-u lk b)
   where
   eq : mask (length As + X) (pushBinds As (unmask X (applyChanges S Δ)))
          ≡ pushBinds As (applyChanges S Δ)
-  eq = trans (updateAt-pushBinds masked As X (unmask X (applyChanges S Δ)))
+  eq = trans (updateAt-pushBinds maskEnt As X (unmask X (applyChanges S Δ)))
              (cong (pushBinds As) (mask-unmask lk))
 
 -- THE CONVERSION CONTEXT sees only the dual's UNLOCKS, i.e. only S's
@@ -186,24 +186,30 @@ dualScope-unmask-comm m (lock X ∷ S)   Y Ξ
         | updateAt-updateAt-comm unmaskEnt (m + X) Y Ξ =
   dualScope-unmask-comm m S Y (unmask (m + X) Ξ)
 
-applyUnlocks-dualScope : (As : List Ty) (S : List Change) (Δ : Ctxᵗ)
+-- THE ONE PLACE THE ONE-LOCK ENTRY COSTS A PREMISE.  `unmask ∘ mask` is
+-- the identity only AT A NAMEABLE SLOT (`unmask-mask`, strong.Ctx §6b) —
+-- with a stack of masks it held everywhere — so the `lock X` case needs
+-- S's own `sw-l` premise, which is exactly where the nameability of X in
+-- `applyChanges S Δ` is recorded.  Nothing else changes: the premise was
+-- already threaded through `applyChanges-dualScope` next door.
+applyUnlocks-dualScope : (As : List Ty) (S : List Change) (Δ : Ctxᵗ) → Δ ⊢ˢ S
   → applyUnlocks (dualScope (length As) S) (pushBinds As (applyChanges S Δ))
       ≡ pushBinds As (applyUnlocks S Δ)
-applyUnlocks-dualScope As []             Δ = refl
-applyUnlocks-dualScope As (lock X ∷ S)   Δ
+applyUnlocks-dualScope As []             Δ sw[]        = refl
+applyUnlocks-dualScope As (lock X ∷ S)   Δ (sw-l tv b)
   rewrite applyUnlocks-++ (dualScope (length As) S)
                           (unlock (length As + X) ∷ [])
                           (pushBinds As (mask X (applyChanges S Δ)))
         | updateAt-pushBinds unmaskEnt As X (mask X (applyChanges S Δ))
-        | unmask-mask X (applyChanges S Δ) = applyUnlocks-dualScope As S Δ
-applyUnlocks-dualScope As (unlock X ∷ S) Δ
+        | unmask-mask tv = applyUnlocks-dualScope As S Δ b
+applyUnlocks-dualScope As (unlock X ∷ S) Δ (sw-u lk b)
   rewrite applyUnlocks-++ (dualScope (length As) S)
                           (lock (length As + X) ∷ [])
                           (pushBinds As (unmask X (applyChanges S Δ)))
         | sym (updateAt-pushBinds unmaskEnt As X (applyChanges S Δ))
         | dualScope-unmask-comm (length As) S (length As + X)
                                 (pushBinds As (applyChanges S Δ))
-        | applyUnlocks-dualScope As S Δ =
+        | applyUnlocks-dualScope As S Δ b =
   updateAt-pushBinds unmaskEnt As X (applyUnlocks S Δ)
 
 ------------------------------------------------------------------------
@@ -213,13 +219,13 @@ applyUnlocks-dualScope As (unlock X ∷ S) Δ
 -- `hideBinds` masks the whole bind prefix.
 hideBinds-cons : (k : ℕ) (E : Ent) (Ξ : Ctxᵗ)
   → applyChanges (hideBinds (suc k)) (E ∷ Ξ)
-      ≡ masked E ∷ applyChanges (hideBinds k) Ξ
+      ≡ maskEnt E ∷ applyChanges (hideBinds k) Ξ
 hideBinds-cons zero    E Ξ = refl
 hideBinds-cons (suc k) E Ξ
   rewrite hideBinds-cons k E Ξ = refl
 
 stepB : (Ow Δ : Ctxᵗ)
-  → applyChanges (hideBinds (length Ow)) (Ow ++ Δ) ≡ map masked Ow ++ Δ
+  → applyChanges (hideBinds (length Ow)) (Ow ++ Δ) ≡ map maskEnt Ow ++ Δ
 stepB []       Δ = refl
 stepB (E ∷ Ow) Δ
   rewrite hideBinds-cons (length Ow) E (Ow ++ Δ)
@@ -235,7 +241,7 @@ numBinds-dual Θ = refl
 -- (†) THE CROSSING FRAME IS THE EXTERIOR, ONE BIND PREFIX IN.
 interior-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ
   → interior (dual Θ) (interior Θ Δ)
-      ≡ map masked (pushBinds (binds Θ) []) ++ Δ
+      ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ
 interior-dual Θ Δ mwΘ = go
   where
   Ow : Ctxᵗ
@@ -243,7 +249,7 @@ interior-dual Θ Δ mwΘ = go
   lenOw : length Ow ≡ numBinds Θ
   lenOw = length-pushBinds (binds Θ)
   go : applyChanges (changes (dual Θ)) (pushBinds (binds Θ) (scope Θ Δ))
-         ≡ map masked Ow ++ Δ
+         ≡ map maskEnt Ow ++ Δ
   go rewrite applyChanges-++ (hideBinds (numBinds Θ))
                              (dualScope (numBinds Θ) (changes Θ))
                              (pushBinds (binds Θ) (scope Θ Δ))
@@ -257,16 +263,16 @@ applyUnlocks-hideBinds : (k : ℕ) (Ξ : Ctxᵗ) → applyUnlocks (hideBinds k) 
 applyUnlocks-hideBinds zero    Ξ = refl
 applyUnlocks-hideBinds (suc k) Ξ = applyUnlocks-hideBinds k Ξ
 
-convCtx-dual : (Θ : CtxMorph) (Δ : Ctxᵗ)
+convCtx-dual : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ˢ changes Θ
   → convCtx (dual Θ) (interior Θ Δ) ≡ convCtx Θ Δ
-convCtx-dual Θ Δ
+convCtx-dual Θ Δ b
   rewrite applyUnlocks-++ (hideBinds (numBinds Θ))
                           (dualScope (numBinds Θ) (changes Θ))
                           (pushBinds (binds Θ) (scope Θ Δ))
         | applyUnlocks-hideBinds (numBinds Θ)
             (applyUnlocks (dualScope (numBinds Θ) (changes Θ))
                           (pushBinds (binds Θ) (scope Θ Δ))) =
-  applyUnlocks-dualScope (binds Θ) (changes Θ) Δ
+  applyUnlocks-dualScope (binds Θ) (changes Θ) Δ b
 
 ------------------------------------------------------------------------
 -- §4  The crossing, and `preserve-Peel`
@@ -275,7 +281,7 @@ convCtx-dual Θ Δ
 -- binder slots of a pushBinds are visible
 pushBinds-∋tv-lt : (As : List Ty) (Ξ : Ctxᵗ) (j : ℕ)
   → j < length As → pushBinds As Ξ ∋tv j
-pushBinds-∋tv-lt (A ∷ As) Ξ zero    (s≤s _)  = bind _ , ez , nameable-b
+pushBinds-∋tv-lt (A ∷ As) Ξ zero    (s≤s _)  = unmasked (bind _) , ez , nameable
 pushBinds-∋tv-lt (A ∷ As) Ξ (suc j) (s≤s lt) with pushBinds-∋tv-lt As Ξ j lt
 ... | E , d , v = _ , es d , renᵉ-Nameable v
 
@@ -284,7 +290,7 @@ hideBinds-∋tv : (k : ℕ) {Ξ : Ctxᵗ} {Y : ℕ} → k ≤ Y → Ξ ∋tv Y
   → applyChanges (hideBinds k) Ξ ∋tv Y
 hideBinds-∋tv zero    le tv = tv
 hideBinds-∋tv (suc k) le tv with hideBinds-∋tv k (≤-trans (n≤1+n k) le) tv
-... | E , d , v = E , updateAt-miss masked masked-comm (<⇒≢ le) d , v
+... | E , d , v = E , updateAt-miss maskEnt maskEnt-comm (<⇒≢ le) d , v
 
 ⊢ˢ-hideBinds : (k : ℕ) (Ξ : Ctxᵗ)
   → ((j : ℕ) → j < k → Ξ ∋tv j) → Ξ ⊢ˢ hideBinds k
@@ -322,16 +328,25 @@ renameᵗ-id (`∀ a)  =
   ext-id zero    = refl
   ext-id (suc X) = refl
 
+-- Both facts are BINDING facts, lifted through the lock layer: the two
+-- `Ent` clauses just re-apply the constructor they matched.
+renᵇ-id : (b : Binding) → renᵇ (λ X → X) b ≡ b
+renᵇ-id abst     = refl
+renᵇ-id (bind A) = cong bind (renameᵗ-id A)
+
 renᵉ-id : (E : Ent) → renᵉ (λ X → X) E ≡ E
-renᵉ-id abst        = refl
-renᵉ-id (bind A)    = cong bind (renameᵗ-id A)
-renᵉ-id (masked E)  = cong masked (renᵉ-id E)
+renᵉ-id (unmasked b) = cong unmasked (renᵇ-id b)
+renᵉ-id (masked b)   = cong masked (renᵇ-id b)
+
+renᵇ-comp : (ρ₁ ρ₂ : Renameᵗ) (b : Binding)
+  → renᵇ ρ₂ (renᵇ ρ₁ b) ≡ renᵇ (λ X → ρ₂ (ρ₁ X)) b
+renᵇ-comp ρ₁ ρ₂ abst     = refl
+renᵇ-comp ρ₁ ρ₂ (bind A) = cong bind (rename-rename-commute ρ₁ ρ₂ A)
 
 renᵉ-comp : (ρ₁ ρ₂ : Renameᵗ) (E : Ent)
   → renᵉ ρ₂ (renᵉ ρ₁ E) ≡ renᵉ (λ X → ρ₂ (ρ₁ X)) E
-renᵉ-comp ρ₁ ρ₂ abst        = refl
-renᵉ-comp ρ₁ ρ₂ (bind A)    = cong bind (rename-rename-commute ρ₁ ρ₂ A)
-renᵉ-comp ρ₁ ρ₂ (masked E)  = cong masked (renᵉ-comp ρ₁ ρ₂ E)
+renᵉ-comp ρ₁ ρ₂ (unmasked b) = cong unmasked (renᵇ-comp ρ₁ ρ₂ b)
+renᵉ-comp ρ₁ ρ₂ (masked b)   = cong masked (renᵇ-comp ρ₁ ρ₂ b)
 
 renᵗ-wkN : (n : ℕ) (A : Ty) → renameᵗ (wkN n) A ≡ shiftBy n A
 renᵗ-wkN zero    A = renameᵗ-id A
@@ -374,9 +389,9 @@ crossing Θ {Δ} {W} {A} mwΘ ⊢W =
   Ow : Ctxᵗ
   Ow = pushBinds (binds Θ) []
   Ξ : Ctxᵗ
-  Ξ = map masked Ow
+  Ξ = map maskEnt Ow
   len-eq : length Ξ ≡ numBinds Θ
-  len-eq = trans (map-length masked Ow) (length-pushBinds (binds Θ))
+  len-eq = trans (map-length maskEnt Ow) (length-pushBinds (binds Θ))
   step0 : (Ξ ++ Δ) ∣ [] ⊢ renᴹ (wkN (length Ξ)) W ⦂ renameᵗ (wkN (length Ξ)) A
   step0 = ⊢rename (Ren-wkN Ξ) (Inj-wkN (length Ξ)) ⊢W
   step1 : (Ξ ++ Δ) ∣ [] ⊢ renᴹ (wkN (length Ξ)) W ⦂ shiftBy (length Ξ) A
@@ -405,7 +420,7 @@ preserve-Peel {Δ} {V} {W} {Θ} {s} {t} {C} vV vW
   ⊢s-tr : convCtx (dual Θ) (interior Θ Δ) ⊢ s
             ∶ shiftBy (numBinds Θ) _ ⇝ shiftBy (numBinds (dual Θ)) _
   ⊢s-tr = subst (λ Ct → Ct ⊢ s ∶ shiftBy (numBinds Θ) _ ⇝ _)
-                (sym (convCtx-dual Θ Δ)) ⊢s
+                (sym (convCtx-dual Θ Δ (mw-changes mwᵥ))) ⊢s
   ⊢argcross : interior Θ Δ ∣ [] ⊢ wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫ ⦂ _
   ⊢argcross = env (⊢ᵐ-dual Θ Δ mwᵥ)
                   (crossing Θ mwᵥ ⊢W) ⊢s-tr wAᵈ

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -61,9 +61,8 @@ private
 -- if the entry was.  (`masked` is the only unnameable shape, and `renᵉ`
 -- keeps it.)
 Nameable-ren⁻ : ∀ {E} → Nameable (renᵉ ρ E) → Nameable E
-Nameable-ren⁻ {E = abst}   v  = nameable-a
-Nameable-ren⁻ {E = bind A} v  = nameable-b
-Nameable-ren⁻ {E = masked E}  ()
+Nameable-ren⁻ {E = unmasked b} v = nameable
+Nameable-ren⁻ {E = masked b}   ()
 
 ∋tv-tail : ∀ {E} → (E ∷ Δ) ∋tv suc X → Δ ∋tv X
 ∋tv-tail (_ , es d , v) = _ , d , Nameable-ren⁻ v
@@ -73,8 +72,9 @@ Nameable-ren⁻ {E = masked E}  ()
 SubWf : Ctxᵗ → Ctxᵗ → Substᵗ → Set
 SubWf Δ Δ′ σ = ∀ {X} → Δ ∋tv X → Δ′ ⊢ᵗ σ X
 
-SubWf-ext : ∀ {σ} → SubWf Δ Δ′ σ → SubWf (abst ∷ Δ) (abst ∷ Δ′) (extsᵗ σ)
-SubWf-ext h {zero}  tv = wf-var (abst , ez , nameable-a)
+SubWf-ext : ∀ {σ} → SubWf Δ Δ′ σ
+  → SubWf (unmasked abst ∷ Δ) (unmasked abst ∷ Δ′) (extsᵗ σ)
+SubWf-ext h {zero}  tv = wf-var (unmasked abst , ez , nameable)
 SubWf-ext h {suc X} tv = wf-ren Ren-wk (h (∋tv-tail tv))
 
 wf-substᵗ : ∀ {σ} → SubWf Δ Δ′ σ → Δ ⊢ᵗ A → Δ′ ⊢ᵗ substᵗ σ A
@@ -84,7 +84,7 @@ wf-substᵗ h wf-𝔹         = wf-𝔹
 wf-substᵗ h (wf-⇒ wA wB) = wf-⇒ (wf-substᵗ h wA) (wf-substᵗ h wB)
 wf-substᵗ h (wf-∀ wA)    = wf-∀ (wf-substᵗ (SubWf-ext h) wA)
 
-wf-[]ᵗ : (abst ∷ Δ) ⊢ᵗ B → Δ ⊢ᵗ A → Δ ⊢ᵗ B [ A ]ᵗ
+wf-[]ᵗ : (unmasked abst ∷ Δ) ⊢ᵗ B → Δ ⊢ᵗ A → Δ ⊢ᵗ B [ A ]ᵗ
 wf-[]ᵗ {A = A} wB wA = wf-substᵗ h wB
   where
   h : SubWf _ _ (singleTyEnv A)
@@ -102,7 +102,7 @@ CtxWf-∷ : Δ ⊢ᵗ A → CtxWf Δ Γ → CtxWf Δ (A ∷ Γ)
 CtxWf-∷ w h here      = w
 CtxWf-∷ w h (there d) = h d
 
-CtxWf-⤊ : CtxWf Δ Γ → CtxWf (abst ∷ Δ) (⤊ Γ)
+CtxWf-⤊ : CtxWf Δ Γ → CtxWf (unmasked abst ∷ Δ) (⤊ Γ)
 CtxWf-⤊ h d with ∋⦂-map⁻ d
 ... | A , refl , q = wf-ren Ren-wk (h q)
 
@@ -251,33 +251,48 @@ ren-suc-[0] T =
 -- one entry, `n` binders in.
 abstN : ℕ → Ctxᵗ → Ctxᵗ
 abstN zero    Ξ = Ξ
-abstN (suc n) Ξ = abst ∷ abstN n Ξ
+abstN (suc n) Ξ = unmasked abst ∷ abstN n Ξ
 
-abstN-binder : ∀ {Ψ A} (n : ℕ) → abstN n (bind A ∷ Ψ) ∋ n := shiftBy (suc n) A
+abstN-binder : ∀ {Ψ A} (n : ℕ)
+  → abstN n (unmasked (bind A) ∷ Ψ) ∋ n := shiftBy (suc n) A
 abstN-binder zero    = ez
 abstN-binder (suc n) = es (abstN-binder n)
 
-abstN-⊑ : ∀ {Ψ A} (n : ℕ) → abstN n (abst ∷ Ψ) ⊑ abstN n (bind A ∷ Ψ)
-abstN-⊑ {Ψ = Ψ} zero = le∷ le-ab (⊑-refl Ψ)
-abstN-⊑ (suc n)      = le∷ le-aa (abstN-⊑ n)
+abstN-⊑ : ∀ {Ψ A} (n : ℕ)
+  → abstN n (unmasked abst ∷ Ψ) ⊑ abstN n (unmasked (bind A) ∷ Ψ)
+abstN-⊑ {Ψ = Ψ} zero = le∷ (le-uu le-ab) (⊑-refl Ψ)
+abstN-⊑ (suc n)      = le∷ (le-uu le-aa) (abstN-⊑ n)
 
 -- The mint, applied to a whole ENTRY (the form the lookup transport
--- needs, since `∋e` returns entries and only `bind` carries a rep).
+-- needs, since `∋e` returns entries and only `bind` carries a rep).  It
+-- is a BINDING operation lifted through the lock layer: the mint never
+-- touches a lock, and with one lock per entry that is one clause each,
+-- no recursion.
+substᵇ : ℕ → Ty → Binding → Binding
+substᵇ n R abst     = abst
+substᵇ n R (bind A) = bind (A [ n := R ]ᵗ)
+
 substᵉ : ℕ → Ty → Ent → Ent
-substᵉ n R abst        = abst
-substᵉ n R (bind A)    = bind (A [ n := R ]ᵗ)
-substᵉ n R (masked E)  = masked (substᵉ n R E)
+substᵉ n R (unmasked b) = unmasked (substᵇ n R b)
+substᵉ n R (masked b)   = masked (substᵇ n R b)
+
+substᵇ-0-⇑ : (R : Ty) (b : Binding) → substᵇ 0 R (renᵇ suc b) ≡ renᵇ suc b
+substᵇ-0-⇑ R abst     = refl
+substᵇ-0-⇑ R (bind A) = cong bind (subst-at-0-⇑ R A)
 
 substᵉ-0-⇑ : (R : Ty) (E : Ent) → substᵉ 0 R (⇑ᵉ E) ≡ ⇑ᵉ E
-substᵉ-0-⇑ R abst        = refl
-substᵉ-0-⇑ R (bind A)    = cong bind (subst-at-0-⇑ R A)
-substᵉ-0-⇑ R (masked E)  = cong masked (substᵉ-0-⇑ R E)
+substᵉ-0-⇑ R (unmasked b) = cong unmasked (substᵇ-0-⇑ R b)
+substᵉ-0-⇑ R (masked b)   = cong masked (substᵇ-0-⇑ R b)
+
+substᵇ-⇑ : (n : ℕ) (R : Ty) (b : Binding)
+  → substᵇ (suc n) (⇑ᵗ R) (renᵇ suc b) ≡ renᵇ suc (substᵇ n R b)
+substᵇ-⇑ n R abst     = refl
+substᵇ-⇑ n R (bind A) = cong bind (subst-at-⇑ n R A)
 
 substᵉ-⇑ : (n : ℕ) (R : Ty) (E : Ent)
   → substᵉ (suc n) (⇑ᵗ R) (⇑ᵉ E) ≡ ⇑ᵉ (substᵉ n R E)
-substᵉ-⇑ n R abst        = refl
-substᵉ-⇑ n R (bind A)    = cong bind (subst-at-⇑ n R A)
-substᵉ-⇑ n R (masked E)  = cong masked (substᵉ-⇑ n R E)
+substᵉ-⇑ n R (unmasked b) = cong unmasked (substᵇ-⇑ n R b)
+substᵉ-⇑ n R (masked b)   = cong masked (substᵇ-⇑ n R b)
 
 -- WHAT THE OTHER SLOTS OWE.  Every entry of `abstN n (abst ∷ Ψ)` is
 -- either ABSTRACT (the prefix, and slot n itself) or an entry of Ψ read
@@ -285,10 +300,10 @@ substᵉ-⇑ n R (masked E)  = cong masked (substᵉ-⇑ n R E)
 -- at slot n leaves it alone: a rep is lifted past exactly the binders
 -- inside it, so it never names a slot of the bind prefix.
 abstN-ent : ∀ {Ψ A} (n : ℕ) {Y E}
-  → abstN n (abst ∷ Ψ) ∋e Y , E
+  → abstN n (unmasked abst ∷ Ψ) ∋e Y , E
     ------------------------------------------------------------
-  → (E ≡ abst)
-  ⊎ ((abstN n (bind A ∷ Ψ) ∋e Y , E)
+  → (E ≡ unmasked abst)
+  ⊎ ((abstN n (unmasked (bind A) ∷ Ψ) ∋e Y , E)
      × (substᵉ n (shiftBy (suc n) A) E ≡ E))
 abstN-ent zero ez                = inj₁ refl
 abstN-ent {A = A} zero (es {E = E} d) =
@@ -300,9 +315,9 @@ abstN-ent {A = A} (suc n) (es {E = E} d) with abstN-ent {A = A} n d
   inj₂ (es d′ , trans (substᵉ-⇑ n (shiftBy (suc n) A) E) (cong ⇑ᵉ eq))
 
 abstN-kn : ∀ {Ψ A} (n : ℕ) {Y B}
-  → abstN n (abst ∷ Ψ) ∋ Y := B
+  → abstN n (unmasked abst ∷ Ψ) ∋ Y := B
     -------------------------------------------------------
-  → (abstN n (bind A ∷ Ψ) ∋ Y := B)
+  → (abstN n (unmasked (bind A) ∷ Ψ) ∋ Y := B)
     × (B [ n := shiftBy (suc n) A ]ᵗ ≡ B)
 abstN-kn {A = A} n d with abstN-ent {A = A} n d
 ... | inj₁ ()
@@ -313,11 +328,13 @@ abstN-kn {A = A} n d with abstN-ent {A = A} n d
 -- index used to rule out (a `seal` under `instReveal`, an `unseal`
 -- under `instConceal`): such a leaf cites a BINDER, and slot n has
 -- none.
-abstN-abst : ∀ {Ψ E} (n : ℕ) → abstN n (abst ∷ Ψ) ∋e n , E → E ≡ abst
+abstN-abst : ∀ {Ψ E} (n : ℕ)
+  → abstN n (unmasked abst ∷ Ψ) ∋e n , E → E ≡ unmasked abst
 abstN-abst zero    ez     = refl
 abstN-abst (suc n) (es d) = cong ⇑ᵉ (abstN-abst n d)
 
-abstN-≢ : ∀ {Ψ B Y} (n : ℕ) → abstN n (abst ∷ Ψ) ∋ Y := B → ¬ (n ≡ Y)
+abstN-≢ : ∀ {Ψ B Y} (n : ℕ)
+  → abstN n (unmasked abst ∷ Ψ) ∋ Y := B → ¬ (n ≡ Y)
 abstN-≢ n d refl with abstN-abst n d
 ... | ()
 
@@ -334,9 +351,9 @@ abstN-≢ n d refl with abstN-abst n d
 -- not the terms.
 mutual
   ⊢instReveal : ∀ {Ψ A s Bᵢ Bₑ} (n : ℕ)
-    → abstN n (abst ∷ Ψ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → abstN n (unmasked abst ∷ Ψ) ⊢ s ∶ Bᵢ ⇝ Bₑ
       ------------------------------------------------------------
-    → abstN n (bind A ∷ Ψ) ⊢ instReveal n s
+    → abstN n (unmasked (bind A) ∷ Ψ) ⊢ instReveal n s
         ∶ Bᵢ ⇝ Bₑ [ n := shiftBy (suc n) A ]ᵗ
   ⊢instReveal n (conv-id base-ℕ) = conv-id base-ℕ
   ⊢instReveal n (conv-id base-𝔹) = conv-id base-𝔹
@@ -357,9 +374,9 @@ mutual
       conv-all (⊢instReveal (suc n) ⊢s)
 
   ⊢instConceal : ∀ {Ψ A s Bᵢ Bₑ} (n : ℕ)
-    → abstN n (abst ∷ Ψ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → abstN n (unmasked abst ∷ Ψ) ⊢ s ∶ Bᵢ ⇝ Bₑ
       ------------------------------------------------------------
-    → abstN n (bind A ∷ Ψ) ⊢ instConceal n s
+    → abstN n (unmasked (bind A) ∷ Ψ) ⊢ instConceal n s
         ∶ Bᵢ [ n := shiftBy (suc n) A ]ᵗ ⇝ Bₑ
   ⊢instConceal n (conv-id base-ℕ) = conv-id base-ℕ
   ⊢instConceal n (conv-id base-𝔹) = conv-id base-𝔹
@@ -413,10 +430,10 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
       conv
       (wf-[]ᵗ wB wA)
   where
-  refine : (abst ∷ Δ) ⊑ᵃ (bind A ∷ Δ)
-  refine = la∷ la-ab (⊑ᵃ-refl Δ)
+  refine : (unmasked abst ∷ Δ) ⊑ᵃ (unmasked (bind A) ∷ Δ)
+  refine = la∷ (la-uu le-ab) (⊑ᵃ-refl Δ)
 
-  conv : (bind A ∷ Δ) ⊢ reveal 0 B ∶ B ⇝ shiftBy 1 (B [ A ]ᵗ)
+  conv : (unmasked (bind A) ∷ Δ) ⊢ reveal 0 B ∶ B ⇝ shiftBy 1 (B [ A ]ᵗ)
   conv rewrite sym (subst-at-0 A B) = ⊢reveal ez (⊑-wf (⊑ᵃ→⊑ refine) wB)
 
 -- ── TYPEELR, AT ANY ∀ CONVERSION ───────────────────────────────────────
@@ -445,7 +462,7 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
 -- typing (`⊢instReveal`, §2b) is total, and so is this case.
 TyPeelRCase : Set
 TyPeelRCase = ∀ {Δ V Θ s B A C Bᵢ Bₑ} → Value V
-  → (abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
   → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
   → Δ ∣ [] ⊢ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
@@ -453,7 +470,7 @@ TyPeelRCase = ∀ {Δ V Θ s B A C Bᵢ Bₑ} → Value V
 ∀-inj : ∀ {A B} → _≡_ {A = Ty} (`∀ A) (`∀ B) → A ≡ B
 ∀-inj refl = refl
 
-wf-∀⁻ : Δ ⊢ᵗ `∀ A → (abst ∷ Δ) ⊢ᵗ A
+wf-∀⁻ : Δ ⊢ᵗ `∀ A → (unmasked abst ∷ Δ) ⊢ᵗ A
 wf-∀⁻ (wf-∀ w) = w
 
 -- The exterior body, lifted: `shiftBodyBy` and the instantiation commute.
@@ -482,7 +499,8 @@ preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
   eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
   eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
 
-  ⊢wkV : (bind A′ ∷ interior Θ Δ) ∣ [] ⊢ wkᴹ 1 V ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
+  ⊢wkV : (unmasked (bind A′) ∷ interior Θ Δ) ∣ []
+           ⊢ wkᴹ 1 V ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
   ⊢wkV = ⊢rename Ren-wk Inj-suc ⊢V
 
   int : interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
@@ -491,7 +509,7 @@ preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
     subst (λ T → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
                    ⊢ wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ] ⦂ T)
           (ren-suc-[0] Bᵢ)
-          (⊢·[] ⊢wkV (wf-var (bind (⇑ᵗ A′) , ez , nameable-b)))
+          (⊢·[] ⊢wkV (wf-var (unmasked (bind (⇑ᵗ A′)) , ez , nameable)))
 
   eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
   eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -294,7 +294,7 @@ substᵉ-⇑ : (n : ℕ) (R : Ty) (E : Ent)
 substᵉ-⇑ n R (unmasked b) = cong unmasked (substᵇ-⇑ n R b)
 substᵉ-⇑ n R (masked b)   = cong masked (substᵇ-⇑ n R b)
 
--- WHAT THE OTHER SLOTS OWE.  Every entry of `abstN n (abst ∷ Ψ)` is
+-- WHAT THE OTHER SLOTS OWE.  Every entry of `abstN n (unmasked abst ∷ Ψ)` is
 -- either ABSTRACT (the prefix, and slot n itself) or an entry of Ψ read
 -- past `n+1` binders — and such an entry names no slot ≤ n, so the mint
 -- at slot n leaves it alone: a rep is lifted past exactly the binders
@@ -440,7 +440,7 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
 -- Four moves, one per premise of the contractum's `env`:
 --
 --   FRAME       one bind prepended to Θ, whose interior is
---               `bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`
+--               `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ`
 --               DEFINITIONALLY — the shift `renᴮ suc Θ` used to add is
 --               the one `pushBinds` already performs.
 --   INTERIOR    `wkᴹ 1 V` (⊢rename at `Ren-wk`) instantiated at the new

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -63,14 +63,14 @@ Vc = ƛ `ℕ ∙ (($ 5) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
 
 -- V's home: Θ₁'s binder over Θ₂'s binder over the empty type context.
 Ξc : Ctxᵗ
-Ξc = bind `𝔹 ∷ bind (`ℕ ⇒ `ℕ) ∷ []
+Ξc = unmasked (bind `𝔹) ∷ unmasked (bind (`ℕ ⇒ `ℕ)) ∷ []
 
 _ : interior Θc₁ (interior Θc₂ []) ≡ Ξc
 _ = refl
 
 ⊢Vc : Ξc ∣ [] ⊢ Vc ⦂ (`ℕ ⇒ `ℕ)
 ⊢Vc = ⊢ƛ wf-ℕ
-        (env (mw rw[] (sw-l (bind (`ℕ ⇒ `ℕ) , es ez , nameable-b) sw[]))
+        (env (mw rw[] (sw-l (unmasked (bind (`ℕ ⇒ `ℕ)) , es ez , nameable) sw[]))
              ⊢$ (conv-id base-ℕ) wf-ℕ)
 
 val-Vc : Value Vc
@@ -83,7 +83,7 @@ Rc = (Vc ⟪ Θc₁ , seal 1 ⟫) ⟪ Θc₂ , unseal 0 ⟫
 ⊢Rc = env (mw (rw-b (wf-⇒ wf-ℕ wf-ℕ) rw[]) sw[])
           (env (mw (rw-b wf-𝔹 rw[]) sw[]) ⊢Vc
                (conv-seal (es ez))
-               (wf-var (bind (`ℕ ⇒ `ℕ) , ez , nameable-b)))
+               (wf-var (unmasked (bind (`ℕ ⇒ `ℕ)) , ez , nameable)))
           (conv-unseal ez) (wf-⇒ wf-ℕ wf-ℕ)
 
 step-c : [] ⊢ Rc
@@ -139,7 +139,7 @@ _ = refl
 
 -- the crossed boundary's interior — the binder X := ℕ
 Δt : Ctxᵗ
-Δt = bind `ℕ ∷ []
+Δt = unmasked (bind `ℕ) ∷ []
 
 -- the polymorphic ARGUMENT, closed and plain: ΛY. λy:Y. 3
 Wt : Term
@@ -149,7 +149,7 @@ val-Wt : Value Wt
 val-Wt = V-Λ V-ƛ
 
 ⊢Wt : ∀ {Δ Γ} → Δ ∣ Γ ⊢ Wt ⦂ `∀ (` 0 ⇒ `ℕ)
-⊢Wt = ⊢Λ (⊢ƛ (wf-var (abst , ez , nameable-a)) ⊢$)
+⊢Wt = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable)) ⊢$)
 
 -- the CONCEALING ∀ conversion a Peel hands it: `conceal 0 (∀Y. Y ⇒ X)`
 Θt : CtxMorph
@@ -162,23 +162,23 @@ _ : conceal 0 (`∀ (` 0 ⇒ ` 1)) ≡ `∀ st
 _ = refl
 
 -- the premise TyPeelR carries, at THIS redex.
-⊢st : (abst ∷ convCtx Θt Δt) ⊢ st ∶ (` 0 ⇒ `ℕ) ⇝ (` 0 ⇒ ` 1)
-⊢st = conv-fun (conv-idv (abst , ez , nameable-a)) (conv-seal (es ez))
+⊢st : (unmasked abst ∷ convCtx Θt Δt) ⊢ st ∶ (` 0 ⇒ `ℕ) ⇝ (` 0 ⇒ ` 1)
+⊢st = conv-fun (conv-idv (unmasked abst , ez , nameable)) (conv-seal (es ez))
 
 Wft : Term
 Wft = Wt ⟪ Θt , `∀ st ⟫
 
 ⊢Wft : Δt ∣ [] ⊢ Wft ⦂ `∀ (` 0 ⇒ ` 1)
-⊢Wft = env (mw rw[] (sw-l (bind `ℕ , ez , nameable-b) sw[])) ⊢Wt
+⊢Wft = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])) ⊢Wt
            (conv-all ⊢st)
-           (wf-∀ (wf-⇒ (wf-var (abst , ez , nameable-a))
-                       (wf-var (bind `ℕ , es ez , nameable-b))))
+           (wf-∀ (wf-⇒ (wf-var (unmasked abst , ez , nameable))
+                       (wf-var (unmasked (bind `ℕ) , es ez , nameable))))
 
 Rt : Term
 Rt = Wft ·[ ` 0 ⇒ ` 1 , ` 0 ]
 
 ⊢Rt : Δt ∣ [] ⊢ Rt ⦂ (` 0 ⇒ ` 0)
-⊢Rt = ⊢·[] ⊢Wft (wf-var (bind `ℕ , ez , nameable-b))
+⊢Rt = ⊢·[] ⊢Wft (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
 step-t : Δt ⊢ Rt
        -→ (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
@@ -197,7 +197,7 @@ _ = refl
 t-convCtx : Ctxᵗ
 t-convCtx = convCtx (morph (` 0 ∷ binds Θt) (changes Θt)) Δt
 
-_ : t-convCtx ≡ bind (` 0) ∷ bind `ℕ ∷ []
+_ : t-convCtx ≡ unmasked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
 _ = refl
 
 t-dom : t-convCtx ⊢ seal 0 ∶ ` 1 ⇝ ` 0
@@ -239,13 +239,13 @@ t-cod = conv-seal (es ez)
 -- demands it be well formed INSIDE, where slot 1 is blocked.
 
 Δi : Ctxᵗ
-Δi = bind (` 0) ∷ bind `ℕ ∷ []
+Δi = unmasked (bind (` 0)) ∷ unmasked (bind `ℕ) ∷ []
 
 Θi : CtxMorph
 Θi = morph [] (lock 1 ∷ [])
 
 Ξi : Ctxᵗ
-Ξi = bind (` 0) ∷ masked (bind `ℕ) ∷ []
+Ξi = unmasked (bind (` 0)) ∷ masked (bind `ℕ) ∷ []
 
 _ : interior Θi Δi ≡ Ξi
 _ = refl
@@ -261,11 +261,11 @@ Vi : Term
 Vi = (($ 7) ⟪ morph [] [] , seal 1 ⟫) ⟪ morph [] (unlock 1 ∷ []) , seal 0 ⟫
 
 ⊢Vi : Ξi ∣ [] ⊢ Vi ⦂ ` 0
-⊢Vi = env (mw rw[] (sw-u (_ , es ez , locked nameable-b) sw[]))
+⊢Vi = env (mw rw[] (sw-u (_ , es ez , locked) sw[]))
           (env (mw rw[] sw[]) ⊢$ (conv-seal (es ez))
-               (wf-var (bind `ℕ , es ez , nameable-b)))
+               (wf-var (unmasked (bind `ℕ) , es ez , nameable)))
           (conv-seal ez)
-          (wf-var (_ , ez , nameable-b))
+          (wf-var (_ , ez , nameable))
 
 val-Vi : Value Vi
 val-Vi = V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal
@@ -274,12 +274,12 @@ Ri : Term
 Ri = (Vi ⟪ morph [] [] , id (` 0) ⟫) ⟪ Θi , unseal 0 ⟫
 
 ⊢Ri : Δi ∣ [] ⊢ Ri ⦂ ` 1
-⊢Ri = env (mw rw[] (sw-l (bind `ℕ , es ez , nameable-b) sw[]))
+⊢Ri = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
           (env (mw rw[] sw[]) ⊢Vi
-               (conv-idv (_ , ez , nameable-b))
-               (wf-var (_ , ez , nameable-b)))
+               (conv-idv (_ , ez , nameable))
+               (wf-var (_ , ez , nameable)))
           (conv-unseal ez)
-          (wf-var (bind `ℕ , es ez , nameable-b))
+          (wf-var (unmasked (bind `ℕ) , es ez , nameable))
 
 -- THE STEP, AT THE MOVED SCOPE.  `Θ₂ = lock 1 ∷ []` is binder-free, so
 -- the move is `morph [] [] ⋉ Θi ≡ morph [] (lock 1 ∷ [])`, and the outer

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -70,7 +70,8 @@ _ = refl
 
 ⊢Vc : Ξc ∣ [] ⊢ Vc ⦂ (`ℕ ⇒ `ℕ)
 ⊢Vc = ⊢ƛ wf-ℕ
-        (env (mw rw[] (sw-l (unmasked (bind (`ℕ ⇒ `ℕ)) , es ez , nameable) sw[]))
+        (env (mw rw[]
+               (sw-l (unmasked (bind (`ℕ ⇒ `ℕ)) , es ez , nameable) sw[]))
              ⊢$ (conv-id base-ℕ) wf-ℕ)
 
 val-Vc : Value Vc

--- a/SystemF/agda/strong/proof/Progress.agda
+++ b/SystemF/agda/strong/proof/Progress.agda
@@ -109,7 +109,7 @@ progress-env v ⊢M ⊢c | inj₁ A-unseal | W , Θ₁ , Z , vW , inj₂ refl =
 -- inversion without having to see through `env`'s `shiftBy`.
 ∀-conv-premise : ∀ {Δ W Θ s B} → Δ ∣ [] ⊢ W ⟪ Θ , `∀ s ⟫ ⦂ `∀ B
   → Σ[ Bᵢ ∈ Ty ] Σ[ Bₑ ∈ Ty ]
-      ((abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ)
+      ((unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ)
 ∀-conv-premise (env mwᵥ ⊢W ⊢c wE) with conv-all-inv ⊢c
 ∀-conv-premise (env mwᵥ ⊢W ⊢c wE) | Bᵢ , Bₑ , eqᵢ , eqₑ , ⊢s =
   Bᵢ , Bₑ , ⊢s


### PR DESCRIPTION
# Split `Ent` into `Binding` + one lock

Branch `ent-binding`.  `make -C SystemF/agda/strong check` passes cold
(exit 0, `postulate-check: OK`).

## What changed

`strong.Ctx`'s entry type was recursive in its mask:

```agda
data Ent : Set where
  abst   : Ent
  bind   : Ty → Ent
  masked : Ent → Ent        -- masked (masked (bind A)) is a term
```

It is now two layers — what the slot **binds**, and whether the slot is
**hidden** — with **at most one lock**:

```agda
data Binding : Set where          -- what a slot binds
  abst : Binding                  -- Λ-bound, no representation
  bind : Ty → Binding             -- bound by a boundary, rep A

data Ent : Set where              -- a type-context entry
  unmasked : Binding → Ent        -- nameable
  masked   : Binding → Ent        -- hidden by a lock
```

`masked` no longer takes an `Ent`, so `masked (masked …)` is not a term:
**"at most one mask" is true by construction**, not by a premise, not by
an invariant, and not by an induction over a stack.

Everything else follows.  `Nameable`/`Locked` become the two
constructors' own discriminations — one clause each, **no premise**:

```agda
data Nameable : Ent → Set where
  nameable : Nameable (unmasked b)

data Locked : Ent → Set where
  locked : Locked (masked b)      -- was: locked : Nameable E → Locked (masked E)
```

`Nameable` was kept as a predicate (rather than inlined as
`E ≡ unmasked b`) because `_∋tv_`, `_∋lk_` and their transports read as
before and the several hundred lookup triples in `Examples.agda` keep
their arity; the whole content of the old two-constructor version was the
`abst`/`bind` split, which now lives one layer down where it belongs.

Setting and clearing the lock are total and idempotent:

```agda
maskEnt : Ent → Ent               unmaskEnt : Ent → Ent
maskEnt (unmasked b) = masked b   unmaskEnt (unmasked b) = unmasked b
maskEnt (masked b)   = masked b   unmaskEnt (masked b)   = unmasked b

mask   = updateAt maskEnt         unmask = updateAt unmaskEnt
```

(`maskEnt` is never applied to an already-masked slot in a well-formed
term — `sw-l` demands a nameable slot — but the function does not have to
know that, and that is the point.)

Renaming, the instantiation mint and the renderer all become a `Binding`
operation lifted through the lock layer, with no recursion:

```agda
renᵇ ρ abst     = abst                 renᵉ ρ (unmasked b) = unmasked (renᵇ ρ b)
renᵇ ρ (bind A) = bind (renameᵗ ρ A)   renᵉ ρ (masked b)   = masked (renᵇ ρ b)
```

and likewise `substᵇ`/`substᵉ` (`proof/Preserve` §2a),
`renᵇ-id`/`renᵉ-id`, `renᵇ-comp`/`renᵉ-comp` (`proof/PeelDual` §3a),
`showBinding`/`showEntry` (`strong.Show`).

Refinement splits the same way.  `_⊑ᵇ_` carries the knowledge order and
`_⊑ᵉ_`/`_⊑ᵃᵉ_` lift it through the lock:

```agda
data _⊑ᵇ_ : Binding → Binding → Set where
  le-aa : abst ⊑ᵇ abst
  le-ab : abst ⊑ᵇ bind A
  le-bb : bind A ⊑ᵇ bind A

data _⊑ᵉ_ : Ent → Ent → Set where
  le-uu : b ⊑ᵇ b′ → unmasked b ⊑ᵉ unmasked b′
  le-mm : b ⊑ᵇ b′ → masked b   ⊑ᵉ masked b′
  le-mu : b ⊑ᵇ b′ → masked b   ⊑ᵉ unmasked b′     -- no Nameable premise

data _⊑ᵃᵉ_ : Ent → Ent → Set where               -- the TERM transport
  la-uu : b ⊑ᵇ b′ → unmasked b ⊑ᵃᵉ unmasked b′
  la-mm : b ⊑ᵇ b′ → masked b   ⊑ᵃᵉ masked b′
```

`_⊑ᵃᵉ_` reuses `_⊑ᵇ_` verbatim — the `abst → bind` step is legal for
both relations; only the locks differ — so `la-aa`/`la-ab`/`la-bb` are
gone, subsumed by `la-uu`.

## Lemma deltas

Gone:

* `unmaskEnt-nameable : E ⊑ᵉ E′ → Nameable E′ → E ⊑ᵉ unmaskEnt E′` — it
  existed only to manufacture the `Nameable` argument `le-mu` used to
  demand.
* `la-aa`, `la-ab`, `la-bb` — replaced by `la-uu` over `_⊑ᵇ_`.
* `core`, `core-ren`, `core-nameable`, `core-masked`, `core-unmaskEnt`
  (`proof/MaskFacts`) — with one lock per entry the "core" of an entry
  **is** `unmaskEnt`.  The five are replaced by three one-line case
  splits (`unmaskEnt-nameable`, `unmaskEnt-maskEnt-core`,
  `unmaskEnt-idem`), and `core-ren`'s induction becomes
  `sym (unmaskEnt-comm suc E)`.

Shrunk (no recursion, no witness threading):

| lemma | before | after |
|-------|--------|-------|
| `⊑ᵉ-trans` | 6 clauses; `le-mu` calls `nameable-mono` | `⊑ᵇ-trans` 3 + `⊑ᵉ-trans` 4 |
| `nameable-mono` | 5 clauses | 3 |
| `masked-le` → `maskEnt-le` | recursive over the stack | 3 clauses |
| `unmaskEnt-mono` | 5 clauses, one calling a helper | 3 clauses |
| `⊑ᵉ-refl`, `⊑ᵃᵉ-refl`, `⊑ᵉ-⇑`, `⊑ᵃᵉ-⇑` | recursive | `⊑ᵇ-refl`/`⊑ᵇ-⇑` + 2-clause lift |
| `⊑ᵃᵉ-Locked` | rebuilds via `nameable-mono` | `(la-mm l) locked = locked` |
| `maskEnt-unmask` | `(locked v) = refl` | `locked = refl` |
| `renᵉ-Nameable⁻`, `Locked-ren⁻` | 3 clauses each | 2 each |
| `⊑ᵉ-unmaskEnt` | `masked` case via `masked-le` | 2 clauses, `le-uu`/`le-mu` |
| `renᵉ-⇑-comm`, `renᵉ-Nameable`, `renᵉ-Locked` | recursive / 2 clauses | 2 / 1 / 1 |

Grew — **one** place, and it is the honest cost of an idempotent mask:

```agda
-- was: unmask-mask : (X : ℕ) (Δ : Ctxᵗ) → unmask X (mask X Δ) ≡ Δ
unmask-mask : Δ ∋tv X → unmask X (mask X Δ) ≡ Δ
```

With a stack of masks, `mask` at an already-masked slot pushed a second
lock which `unmask` popped, so the identity held everywhere.  With one
lock, `maskEnt` is idempotent, so at an already-masked slot `unmask (mask
X Δ)` *exposes* what `Δ` had hidden.  Counterexample:
`Δ = masked abst ∷ []`, `X = 0` — `mask 0 Δ ≡ Δ` and
`unmask 0 (mask 0 Δ) ≡ unmasked abst ∷ [] ≢ Δ`.

The premise is always at hand: `sw-l` admits `lock X` only at a `∋tv`
slot, which is exactly the discipline that made double masking
unreachable before.  It is threaded through two lemmas, each of which
gains an argument its single call site already has:

* `proof/PeelDual.applyUnlocks-dualScope` gains `Δ ⊢ˢ S`;
* `proof/PeelDual.convCtx-dual` gains `Δ ⊢ˢ changes Θ`, supplied at its
  one use site by `mw-changes mwᵥ` in `preserve-Peel`.

No theorem statement was weakened otherwise; `mask-unmask : Δ ∋lk X →
mask X (unmask X Δ) ≡ Δ` is unchanged, so the two inverses are now
**symmetric** — each holds exactly at the slots its own direction is
applied to.

`proof/DualTightness.¬⊢ᵐ-double-lock` survives with a different job: it
is no longer what keeps `Locked` one mask deep (that is by construction),
but the fact that the judgement still refuses a vacuous re-lock — which
is what keeps `unmask-mask`'s premise available.

## Rendering deltas

None.  `showEntry` was split into `showBinding` (the slot) and
`showEntry` (the `⌷[…]` wrap), and the strings are byte-identical:
`X := A`, `X Λ-bound`, `⌷[X := A]`.  Every `Examples.agda` rendering
example still checks by `refl`.

## Mechanical rewrite

Every pattern match on an entry across the development was rewritten:
`abst` → `unmasked abst`, `bind A` → `unmasked (bind A)` in `Ent`
position, `masked (bind A)` unchanged (its argument is now a `Binding`),
`masked` in function position → `maskEnt`, `nameable-a`/`nameable-b` →
`nameable`, `locked v` → `locked`.  `Examples.agda` carries the bulk:
about 290 lines mentioning an entry constructor, most of them lookup
triples of the form `(unmasked (bind ℕ) , ez , nameable)`; ~30 of them
then had to be re-wrapped to stay under 80 columns.  Files touched: `Ctx`,
`Conversion`, `CtxMorph`, `Terms`, `TermSubst`, `Reduction`, `Progress`,
`Preservation`, `Show`, `Examples`, and `proof/{Adversary, DualTightness,
IdLayer, MaskFacts, MoveScope, MwUObstruct, PeelDual, Preserve,
PreserveObstruct, Progress}`.

## Docs

`Design.md` §3 (*Entries*, *Refinement*, *The three operations*, plus a
new *What the one-mask entry costs, and what it buys*), §4.2 (the `lock`
premise's new job), Appendix A (`Binding`, `unmasked`, `maskEnt`, `⊑ᵇ`,
the reletter note); `README.md`'s `Ctx.agda` row.
