### PR TITLE
Strong System F: frame-exact Beta — substitution wraps values crossing a Λ in the binder's dual

### DIFF
--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -95,8 +95,8 @@ not typeable at any type.
    **list** — a context morphism — and not a single reveal-or-conceal.
 
 **The same program today.**  `Examples` §14 runs it, machine-rendered;
-`run-E` is the run, `⊢E₅` types the answer by `preservation*`, and
-`edet₁ … edet₅` pin every state as the only successor of its predecessor.
+`run-E` is the run, `⊢E₆` types the answer by `preservation*`, and
+`edet₁ … edet₆` pin every state as the only successor of its predecessor.
 
 Diagram:
 
@@ -114,42 +114,63 @@ Diagram:
            · ((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Y. (id Y ↦ id Y)) ⟫))
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
         |
-        |  Beta, lifted through ⟪ ↑X:=ℕ , … ⟫
+        |  Beta, lifted through ⟪ ↑X:=ℕ , … ⟫ — FRAME-EXACT (§6.2), so
+        |  the crossed value acquires ΛY's dual ↓Y as it is planted
         v
-    E₃  ((ΛY. ((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
+    E₃  ((ΛY. (((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫)
+                 ⟪ ↓Y , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
         |
-        |  TyPeelR, lifted through ⟪ ↑X:=ℕ , … ⟫ and ΛY —
+        |  TyPeelR on the Beta-minted wrapper, lifted through
+        |  ⟪ ↑X:=ℕ , … ⟫ and ΛY
+        v
+    E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
+                 ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
+          ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+        |
+        |  TyPeelR again, on the value's OWN Peel-minted wrapper —
         |  the line the pre-boundary design died on
         v
-    E₄  ((ΛY. ((ΛX′. (λx:X′. x)) [Z]
-                 ⟪ ↑Z:=Y , ↓X , (seal Z ↦ unseal Z) ⟫))
+    E₅  ((ΛY. (((ΛY′. (λx:Y′. x)) [X′]
+                   ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
+                 ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
         |
         |  TyBeta, inside the boundary TyPeelR just grew
         v
-    E₅  ((ΛY. (((λx:X′. x) ⟪ ↑X′:=Z , (seal X′ ↦ unseal X′) ⟫)
-                 ⟪ ↑Z:=Y , ↓X , (seal Z ↦ unseal Z) ⟫))
+    E₆  ((ΛY. ((((λx:Y′. x) ⟪ ↑Y′:=X′ , (seal Y′ ↦ unseal Y′) ⟫)
+                   ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
+                 ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)                    a VALUE
 
-`E₃` *is* the counterexample's third line, and `E₃ → E₄` is where the two
-designs part.  The crossed value's frame is the single lock `↓X`, and its
-two type contexts at that redex are (`Examples` §14, `E-int` / `E-ext`,
-rendered at the trace's own names):
+`E₃` *is* the counterexample's third line, and `E₄ → E₅` is where the two
+designs part.  Read `E₃` first for the FRAMES.  The planted value sits
+inside `↓Y`, whose two type contexts are (`Examples` §14,
+`E-dual-int` / `E-dual-ext`, rendered at the trace's own names):
 
-    interior (↓X) Δ    Y Λ-bound , ⌷[X := ℕ]
-    convCtx (↓X) Δ     Y Λ-bound ,   X := ℕ
+    interior (↓Y) Δ    ⌷[Y Λ-bound] ,   X := ℕ
+    convCtx (↓Y) Δ       Y Λ-bound ,    X := ℕ
 
-where the old design had `∅`.  `Y` is still nameable inside
-(`E-Y-inside`) and `X` still is not (`E-X-hidden`): lesson 1.  And the
+so the value is read at *its birth frame* `X := ℕ`, one masked entry in:
+`Y` is NOT nameable inside it (`E-Y-not-inside`), because the value was
+born before `ΛY` existed.  That is frame-exact `Beta` (§6.2); before
+2026-09-08 there was no `↓Y` and the value was read at `Y Λ-bound ,
+X := ℕ`, one entry wider than its birth frame.  Inside the value's own
+Peel-minted wrapper the frames are
+
+    interior (↓X) (interior (↓Y) Δ)   ⌷[Y Λ-bound] , ⌷[X := ℕ]
+    convCtx (↓X) (interior (↓Y) Δ)    ⌷[Y Λ-bound] ,   X := ℕ
+
+(`E-int` / `E-ext`), where the old design had `∅`: `X` still is not
+nameable (`E-X-hidden`) and nothing was TRUNCATED — lesson 1.  And the
 argument `Y` is not written into the sealed body — `↑Z:=Y` binds a fresh
-`Z` at the representation `Y`, read in the exterior, and the
-interior instantiates at `Z`: lesson 2.  The contractum types by
-`preservation-TyPeelR`.
+`Z` at the representation `Y`, read in the *exterior* `E-dual-ext` where
+it is nameable, and the interior instantiates at `Z`: lesson 2.  Both
+contracta type by `preservation-TyPeelR`.
 
 v1 took lesson 2 only — one combined boundary and a `TyWrap` that recorded
 the argument as a reveal representation; that is the "Example 8" entry of
-`notes/old/notes-v1.md`, whose `↑Z:=Y , ↓X` residue is `E₄`'s inner frame
+`notes/old/notes-v1.md`, whose `↑Z:=Y , ↓X` residue is `E₅`'s inner frame
 here, and it is v1's *copied* representations, not that shape, that
 subject reduction later refuted.  The scope move (§6.7) is the same
 principle one level up: when a rule would leave a representation outside
@@ -882,26 +903,80 @@ Example (`Examples` §6, `P₀ → P₁`, under `ξ-·-l`):
 
 with `reveal 0 (X ⇒ X) ≡ seal 0 ↦ unseal 0`.
 
-### 6.2 `Beta`
+### 6.2 `Beta` — and why the substitution carries a type
 
-    Beta : Value W → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ]ᵐ
+    Beta : Value W → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ∶ A ]ᵐ
 
 Named: `(λx:A. N) · W → N[x:=W]`.  The ordinary β step; its preservation
 case *is* the substitution lemma (`strong.TermSubst.⊢subst`).  Term
 substitution is the identity on boundaries, since a boundary body is
 term-closed.
 
-**Bookkeeping.** None at the boundary level, but `substᵐ`'s `Λ` clause
-shifts the substituted value past the new type binder, and that moves the
+**THE SUBSTITUTION IS FRAME-EXACT** (Jeremy, 2026-09-08).  The old rule
+was `N [ W ]ᵐ`, and `substᵐ`'s `Λ` clause moved the substituted value
+under the binder by *shifting* it (`⇑ᴹ = renᴹ suc`), which moves the
 *names* in its boundaries: in `Examples` §11 the sealed argument
-`(7 ⟪ ↓X , seal X ⟫)` becomes, one binder in, `(7 ⟪ ↓Y , seal Y ⟫)` —
-the lock name and the conversion name move together, and nothing else
-changes.
+`(7 ⟪ ↓X , seal X ⟫)` becomes, one binder in, `(7 ⟪ ↓X , seal X ⟫)` with
+`X` one slot further out.  That is SOUND — the shifted indices cannot
+reach slot 0 — but it is not EXACT: the value's frame silently GAINS the
+`Λ`'s slot, so at `Examples` §14's `E₃` the crossing wrapper was read at
+`Y Λ-bound , ⌷[X := ℕ]`, one entry more than the frame it was born in.
+Every other rule in the table is exact (see the frame identities in §7);
+`Beta` was the one inexact rule.
 
-Example (`Examples` §6, `P₂ → P₃`, under `ξ-⟪⟫`):
+**The repair: what crosses a binder is wrapped in the binder's dual.**  A
+`Λ` is an `abst` binder occupying slot 0 inside, so its dual is
+`morph [] (lock 0 ∷ [])` — no binds, one lock, exactly what
+`dual (morph (A ∷ []) [])` is — and the conversion is the identity at the
+value's own type, shifted past the binder:
+
+    crossΛ W A = ⇑ᴹ W ⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫
+
+The frame identity is then DEFINITIONAL:
+
+    interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ
+
+— the image's BIRTH frame `Δ` with the crossed binder masked: nothing
+gained, nothing lost (`Examples.interior-Beta-Λ`).  It is the same shape
+`Peel` mints for its crossing argument, so `⊢crossΛ`
+(`strong.TermSubst` §6) is proved by the same two moves: `⊢rename` at
+`suc` (`Ren-wk`, `Inj-suc`) for the interior, `mkId-⊢` for the
+conversion.  A `ƛ` needs no wrapper — a term binder changes no type
+frame — and reduction under binders is by the frame-indexed relation
+already, so `ξ-Λ`/`ξ-⟪⟫` are untouched.
+
+**Which is why the rule carries `A`.**  `mkId` needs the value's type, and
+`env` needs the value TERM-CLOSED (it types an interior at `Γ = []`).
+Both live in the substitution's IMAGES (`strong.TermSubst` §5b):
+
+    data Img : Set where
+      ivar : ℕ → Img          -- a term variable: never wrapped
+      ival : Term → Ty → Img  -- the substituted value, at its type
+
+and `⊢ival : Δ ⊢ᵗ A → Δ ∣ [] ⊢ W ⦂ A → Δ ∣ Γ ⊢ⁱ ival W A ⦂ A` records the
+two facts.  `A` is read off the redex (the `ƛ`'s own annotation), so the
+contractum is still a function of the redex alone and `det` is unchanged.
+
+**The cost is one step, sometimes.**  `mkId` is INERT at a variable, a
+function type and a `∀`, so the wrapper is a value; at a BASE type it is
+`id ℕ`, which is ACTIVE, and `7 ⟪ ↓Y , id ℕ ⟫` takes one `Drop$`.  More
+generally the layer is walked through by the `IdPush`/`CancelR`/`Drop$`
+cascade already in the calculus, which is where the step-count deltas in
+`Examples`' header come from (`Q₀` 9 → 11, `D₀` 12 → 16, `E₀` 5 → 6; `P₀`,
+`J₀`, `H₀` unchanged).
+
+Example (`Examples` §6, `P₂ → P₃`, under `ξ-⟪⟫`) — no `Λ` is crossed
+here, so no wrapper is minted:
 
     (((λx:X. x) · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
       →  ((7 ⟪ ↓X , seal X ⟫) ⟪ ↑X:=ℕ , unseal X ⟫)
+
+Example (`Examples` §11, `Q₂ → Q₃`, under `ξ-⟪⟫`) — one `Λ` is crossed,
+and the argument acquires `↓Z`:
+
+    (((λx:X. (ΛZ. x) [ℕ]) · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
+      →  ((ΛZ. ((7 ⟪ ↓X , seal X ⟫) ⟪ ↓Z , id X ⟫)) [ℕ])
+             ⟪ ↑X:=ℕ , unseal X ⟫
 
 ### 6.3 `Peel` — the crossing
 
@@ -1340,12 +1415,21 @@ is a known function of the old one:
 | `TyPeelR` | `interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ` — the redex's frame, one binder in, which `wkᴹ 1` matches |
 | `Peel` | (†) `interior (dual Θ) (interior Θ Δ) ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ`, given `Δ ⊢ᵐ Θ` (`proof/PeelDual.interior-dual`) |
 | `CancelR`, `IdPush` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)`, given `Δ ⊢ᵐ Θ₂` (`proof/MoveScope.interior-⋉-rewind`) |
-| `Beta` | `Δ` — no frame changes |
+| `Beta` | `Δ` where no binder is crossed — no frame changes |
+| `Beta`, under a `Λ` | `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` — the image's BIRTH frame with the crossed `Λ`'s slot masked (`Examples.interior-Beta-Λ`) |
 
-The first two are `refl` (`Examples.interior-TyBeta`,
-`interior-TyPeelR`); the last two are the theorems whose `Δ ⊢ᵐ Θ`
-premise is where the sequential judgement pays for itself (§4.2).
-`Drop$` and the five congruences move nothing into a new frame.
+The `Beta` row used to read `Δ` and nothing else, and it was the one
+INEXACT row: `substᵐ` shifted the image under the `Λ` without recording
+that the new slot is not the image's, so the image's frame was
+`unmasked abst ∷ Δ` — one entry wider than its birth frame, sound but not
+exact.  The dual wrapper of §6.2 closes it, and `Examples` §15d₂ runs the
+test on the closed case.
+
+The first two rows and the last are `refl` (`Examples.interior-TyBeta`,
+`interior-TyPeelR`, `interior-Beta-Λ`); the `Peel` and scope-move rows are
+the theorems whose `Δ ⊢ᵐ Θ` premise is where the sequential judgement pays
+for itself (§4.2).  `Drop$` and the five congruences move nothing into a
+new frame.
 
 Every rule passes.  **The one exception is recorded and is not a scope
 gain**: `Beta` at an erasing body — `(λx:ℕ⇒ℕ. 3) · W` with `W` ill typed
@@ -1434,11 +1518,21 @@ machine-checked consequence in tree.
    (`Examples` §15, and the frame-identity table in §7), with one
    recorded exception that is not a scope gain — `Beta` may *erase* its
    argument.
-3. **No term type-shifts.**  Shift types, not terms.  The only index
-   arithmetic in the design is ordinary de Bruijn binder offsets:
-   `numBinds Θ`, `shiftBy`, and the `n + X` lift in `shiftScope` and
-   `dualScope`.
-   `cmax`, `dropN`, `swapᵇ`, `shiftReps` have no analogue.
+3. **No term type-shifts, and the shifts that remain are AT BINDERS.**
+   Shift types, not terms.  The only index arithmetic in the design is
+   ordinary de Bruijn binder offsets: `numBinds Θ`, `shiftBy`, and the
+   `n + X` lift in `shiftScope` and `dualScope`.  `cmax`, `dropN`,
+   `swapᵇ`, `shiftReps` have no analogue.
+
+   Frame-exact `Beta` (§6.2) does not change this: the shift a substituted
+   image undergoes when it crosses a `Λ` is still `⇑ᴹ = renᴹ suc`, one
+   binder, applied AT that binder — what the repair adds is a WRAPPER
+   beside the shift, not more arithmetic.  The wrapper's morphism
+   `morph [] (lock 0 ∷ [])` names slot 0 and carries no representation,
+   and its conversion `mkId (⇑ᵗ A)` is derived from the type the redex
+   already carries.  The rule of thumb survives: every shift in the
+   development sits at a binder, and no shift is ever applied to a
+   representation twice.
 4. **Simultaneity, as far as it goes — and the pair says which far.**
    `pushBinds` lifts a representation past exactly the binders inside it
    and past nothing else — that half is untouched, and the telescopic

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -68,7 +68,8 @@ module strong.Examples where
 --   J₀  14 → 14  (the substituted variable sits under no Λ)
 --   H₀  4 → 4    (the layer lands inside a ƛ body, unevaluated)
 --   E₀  5 → 6    (+1 TyPeelR — §14's `estep₅`)
---   G   5 → 5    (the layers land under the Λs, unevaluated)
+--   G   5 → 5    (`gstep₁ … gstep₅`; the layers land under the Λs,
+--                 unevaluated)
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; _++_; length; map)
@@ -1637,14 +1638,11 @@ Rchain-scoped = wf-var (_ , es ez , nameable)
 
 -- ── the states ─────────────────────────────────────────────────────────
 
-RS RS↑ RW : Term
+RS RS↑ : Term
 RS  = (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ []) ,
   seal 0 ⟫
 RS↑ = (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) ,
   seal 1 ⟫
-RW  = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph [] (lock 1 ∷ []) , id
-  (` 2) ⟫)
-        ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫
 
 _ : wkᴹ 1 QS₇ ≡ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
 _ = refl

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -803,7 +803,9 @@ P₃ : Term
 P₃ = (($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫)
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
-_ : (` 0) [ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ]ᵐ
+-- NO Λ IS CROSSED HERE (the body is the bare variable), so frame-exact
+-- Beta mints no wrapper and the contractum is the argument itself.
+_ : (` 0) [ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫ ∶ ` 0 ]ᵐ
       ≡ ($ 7) ⟪ morph [] (lock 0 ∷ []) , seal 0 ⟫
 _ = refl
 
@@ -885,7 +887,7 @@ val-P₀ = V-$
 --   7
 --     -- VALUE
 
-open import strong.Eval using (evalTerms)
+open import strong.Eval using (evalTerms; eval-sound)
 
 _ : evalTerms 6 ⊢P₀ ≡ P₀ ∷ P₁ ∷ P₂ ∷ P₃ ∷ P₄ ∷ P₅ ∷ ($ 7) ∷ []
 _ = refl
@@ -894,11 +896,18 @@ _ = refl
 -- §7  Two regressions on substᵐ itself
 ------------------------------------------------------------------------
 
--- ── the Λ clause: an image is TYPE-SHIFTED past the new Λ-bound slot ────
+-- ── the Λ clause: an image crossing a Λ is SHIFTED AND WRAPPED ─────────
 -- Under a Λ the term context is ⤊ Γ, so a term written over Δ must have its
 -- boundary NAMES shifted before it is planted inside.  Here `seal 0` becomes
 -- `seal 1` — and it must, since slot 0 inside the Λ is `abst`, where
 -- `conv-seal` has no binder to cite.
+--
+-- FRAME-EXACT BETA ALSO WRAPS IT (2026-09-08).  Shifting alone leaves the
+-- image's frame one entry LARGER than the frame it was born in — the Λ's
+-- own slot — which is harmless via indices but not exact.  So the image
+-- acquires THE CROSSED BINDER'S DUAL, `morph [] (lock 0 ∷ [])`, under an
+-- identity conversion at its own (shifted) type, and its frame is then its
+-- BIRTH frame with the Λ's slot masked.
 
 Δₛ : Ctxᵗ
 Δₛ = unmasked (bind `ℕ) ∷ []
@@ -914,21 +923,35 @@ Nₛ = Λ (` 0)
 ⊢Nₛ : Δₛ ∣ (` 0 ∷ []) ⊢ Nₛ ⦂ `∀ (` 1)
 ⊢Nₛ = ⊢Λ (⊢` here)
 
-_ : Nₛ [ Wₛ ]ᵐ ≡ Λ (($ 7) ⟪ morph [] [] , seal 1 ⟫)
+-- BEFORE FRAME-EXACT BETA this was `Λ (($ 7) ⟪ morph [] [] , seal 1 ⟫)`:
+-- the shift, and nothing recording that slot 0 is not the image's.
+_ : Nₛ [ Wₛ ∶ ` 0 ]ᵐ
+      ≡ Λ ((($ 7) ⟪ morph [] [] , seal 1 ⟫)
+             ⟪ morph [] (lock 0 ∷ []) , id (` 1) ⟫)
 _ = refl
 
-⊢Nₛ[Wₛ] : Δₛ ∣ [] ⊢ Nₛ [ Wₛ ]ᵐ ⦂ `∀ (` 1)
-⊢Nₛ[Wₛ] = ⊢subst ⊢Nₛ ⊢Wₛ
-
--- ── the ƛ clause: `shiftᵐ` protects the ƛ-bound slot ───────────────────
--- `extᵐ` weakens an image by ONE TERM VARIABLE, so the image's own binders
--- must be skipped: the substituted identity keeps naming its own argument.
-
-_ : (ƛ `ℕ ∙ (` 1)) [ ƛ `ℕ ∙ (` 0) ]ᵐ ≡ ƛ `ℕ ∙ (ƛ `ℕ ∙ (` 0))
+-- THE FRAME IDENTITY THAT MAKES IT EXACT — definitional, at this Δ: the
+-- image is read at Δₛ itself, with the crossed Λ's slot masked.  (The
+-- shifted `seal 1` names Δₛ's binder, one slot further out, exactly as
+-- before.)
+_ : interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δₛ) ≡ masked abst ∷ Δₛ
 _ = refl
 
-_ : [] ∣ [] ⊢ (ƛ `ℕ ∙ (` 1)) [ ƛ `ℕ ∙ (` 0) ]ᵐ ⦂ (`ℕ ⇒ (`ℕ ⇒ `ℕ))
-_ = ⊢subst (⊢ƛ wf-ℕ (⊢` (there here))) (⊢ƛ wf-ℕ (⊢` here))
+⊢Nₛ[Wₛ] : Δₛ ∣ [] ⊢ Nₛ [ Wₛ ∶ ` 0 ]ᵐ ⦂ `∀ (` 1)
+⊢Nₛ[Wₛ] = ⊢subst (wf-var (unmasked (bind `ℕ) , ez , nameable)) ⊢Nₛ ⊢Wₛ
+
+-- ── the ƛ clause: the ƛ-bound slot is PROTECTED, the image is not ───────
+-- `extᴵ` plants `ivar zero` at the ƛ-bound slot and weakens the rest by
+-- one term variable; a VALUE image is term-closed (`⊢ival`), so the
+-- weakening leaves it alone and the substituted identity keeps naming its
+-- own argument.  NO Λ IS CROSSED, so no wrapper is minted.
+
+_ : (ƛ `ℕ ∙ (` 1)) [ ƛ `ℕ ∙ (` 0) ∶ `ℕ ⇒ `ℕ ]ᵐ ≡ ƛ `ℕ ∙ (ƛ `ℕ ∙ (` 0))
+_ = refl
+
+_ : [] ∣ [] ⊢ (ƛ `ℕ ∙ (` 1)) [ ƛ `ℕ ∙ (` 0) ∶ `ℕ ⇒ `ℕ ]ᵐ
+      ⦂ (`ℕ ⇒ (`ℕ ⇒ `ℕ))
+_ = ⊢subst (wf-⇒ wf-ℕ wf-ℕ) (⊢ƛ wf-ℕ (⊢` (there here))) (⊢ƛ wf-ℕ (⊢` here))
 
 ------------------------------------------------------------------------
 -- §8  PROGRESS, on the run of §6
@@ -1116,25 +1139,44 @@ qstep₂ = Peel V-ƛ V-$
 ⊢Q₂ : [] ∣ [] ⊢ Q₂ ⦂ `ℕ
 ⊢Q₂ = preserve-Peel V-ƛ V-$ ⊢Q₁
 
--- ── STEP 3 — BETA, under ξ-⟪⟫.  substᵐ's Λ clause ⇑ᴹ-shifts the sealed 7
--- past ΛZ: the seal NAME moves (seal 0 ↦ seal 1) and so does the lock.
+-- ── STEP 3 — BETA, under ξ-⟪⟫, NOW FRAME-EXACT (2026-09-08).  `substᵐ`'s
+-- Λ clause does two things to the sealed 7 as it crosses ΛZ: it SHIFTS it
+-- (the seal NAME moves, seal 0 ↦ seal 1, and so does the lock) and it
+-- WRAPS it in ΛZ'S DUAL `morph [] (lock 0 ∷ [])`, under the identity
+-- conversion at the argument's own (shifted) type `` ` 1 ``.
+--
+-- BEFORE FRAME-EXACT BETA the contractum was `(Λ QS₇⇑) ·[ ` 1 , `ℕ ]` —
+-- the shift alone — and the run below was TWO STEPS SHORTER (9, not 11):
+-- the new transparent layer is pushed in by a SECOND IdPush (step 6) and
+-- finished by a FOURTH Drop$.
 
-_ : ⇑ᴹ QS₇ ≡ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
+QS₇⇑ QS₇↑ : Term
+QS₇⇑ = ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫
+QS₇↑ = QS₇⇑ ⟪ morph [] (lock 0 ∷ []) , id (` 1) ⟫
+
+_ : ⇑ᴹ QS₇ ≡ QS₇⇑
 _ = refl
 
-_ : Qbody [ QS₇ ]ᵐ ≡ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ
-  ]
+_ : Qbody [ QS₇ ∶ ` 0 ]ᵐ ≡ (Λ QS₇↑) ·[ ` 1 , `ℕ ]
+_ = refl
+
+-- THE FRAME IDENTITY that makes it exact (strong.TermSubst §5b): inside
+-- the new wrapper the argument is read at QΞ₂ with ΛZ's slot MASKED —
+-- that is QΔ₁, its BIRTH frame, one binder in.  It gained nothing by
+-- crossing.
+QΞ₂ᵏ : Ctxᵗ
+QΞ₂ᵏ = masked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
+
+_ : interior (morph [] (lock 0 ∷ [])) QΞ₂ ≡ QΞ₂ᵏ
 _ = refl
 
 Q₃ : Term
-Q₃ = ((Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ ])
-       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+Q₃ = ((Λ QS₇↑) ·[ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 qstep₃ : [] ⊢ Q₂ -→ Q₃
 qstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
-⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , `ℕ
-  ] ⦂ ` 0
+⊢Q₃-in : QΔ₁ ∣ [] ⊢ (Λ QS₇↑) ·[ ` 1 , `ℕ ] ⦂ ` 0
 ⊢Q₃-in = preservation-Beta
            (⊢· (⊢ƛ (wf-var (unmasked (bind `ℕ) , ez , nameable)) ⊢Qbody₁)
                 ⊢QS₇)
@@ -1142,27 +1184,37 @@ qstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 ⊢Q₃ : [] ∣ [] ⊢ Q₃ ⦂ `ℕ
 ⊢Q₃ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₃-in (conv-unseal ez) wf-ℕ
 
+-- THE NEW LAYER, TYPED BY HAND: this is `⊢crossΛ` (strong.TermSubst §6)
+-- on the ground — the `lock 0` is legal because ΛZ's own slot is nameable
+-- (`sw-l`), the interior is the argument at QΞ₂ᵏ, and the conversion is
+-- `conv-idv` at the argument's type, read OUTSIDE the lock.
+
+⊢QS₇⇑ : QΞ₂ᵏ ∣ [] ⊢ QS₇⇑ ⦂ ` 1
+⊢QS₇⇑ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[])) ⊢$
+             (conv-seal (es ez))
+             (wf-var (unmasked (bind `ℕ) , es ez , nameable))
+
+⊢QS₇↑ : QΞ₂ ∣ [] ⊢ QS₇↑ ⦂ ` 1
+⊢QS₇↑ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[]))
+             ⊢QS₇⇑ (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
+             (wf-var (unmasked (bind `ℕ) , es ez , nameable))
+
 -- ── STEP 4 — TYBETA (inner), under ξ-⟪⟫.  THE ID-LAYER IS BORN: the body
 -- type is the OUTER variable, so the minted conversion is an identity.
+-- The value it fires on is now the WRAPPED argument, so its `Value`
+-- witness gains one `V-⟪⟫` at the inert `id (` 1)`.
 
 _ : reveal 0 (` 1) ≡ id (` 1)
 _ = refl
 
 Q₄ : Term
-Q₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (`
-  1) ⟫)
+Q₄ = (QS₇↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 qstep₄ : [] ⊢ Q₃ -→ Q₄
-qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
+qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv))
 
-⊢Qseal₇ : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
-⊢Qseal₇ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[])) ⊢$
-               (conv-seal (es ez))
-               (wf-var (unmasked (bind `ℕ) , es ez , nameable))
-
-⊢Q₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
-                      ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
+⊢Q₄-in : QΔ₁ ∣ [] ⊢ QS₇↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
 ⊢Q₄-in = preservation-TyBeta ⊢Q₃-in
 
 ⊢Q₄ : [] ∣ [] ⊢ Q₄ ⦂ `ℕ
@@ -1171,80 +1223,94 @@ qstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
 -- ── STEP 5 — THE IDPUSH REDEX, AND IDPUSH.  Θ₁ = Θ₂ = `bind ℕ ∷ []`,
 -- X = 1, Y = 0, A = ℕ (the looked-up rep).  Both frames are untouched;
 -- only the two conversions swap.
+--
+-- FROM HERE ON the intermediate typings are taken from PRESERVATION
+-- itself (`preservation ⊢Qᵢ qstepᵢ₊₁`) rather than rebuilt by hand: the
+-- extra transparent layer makes the trees taller without making them say
+-- anything new, and the hand-built `env` derivations that mattered are
+-- the two above.
 
 Q₅ : Term
-Q₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal
-  1 ⟫)
+Q₅ = (QS₇↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₅ : [] ⊢ Q₄ -→ Q₅
-qstep₅ = IdPush (V-⟪⟫ V-$ I-seal) ez
-
--- the contractum TYPES: the rep ℕ is well formed inside Θ₂'s interior.
-⊢Q₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
-                      ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
-⊢Q₅-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Qseal₇ (conv-unseal (es ez)) wf-ℕ
+qstep₅ = IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) ez
 
 ⊢Q₅ : [] ∣ [] ⊢ Q₅ ⦂ `ℕ
-⊢Q₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₅-in (conv-id base-ℕ) wf-ℕ
+⊢Q₅ = preservation ⊢Q₄ qstep₅
 
--- ── STEP 6 — CANCEL, under ξ-⟪⟫.  The seal minted by Peel and the unseal
--- IdPush just moved inwards are now adjacent.  BOTH FRAMES STAY: the
--- crossing's own `lock 1` survives under an identity conversion, one
--- more transparent layer for Drop$ to finish.
+-- ── STEP 6 — IDPUSH AGAIN, under ξ-⟪⟫: THE STEP FRAME-EXACT BETA ADDS.
+-- The layer the substitution minted is itself an `id (` X)` sitting under
+-- an ACTIVE `unseal`, so the same rule fires on it — Θ₁ is ΛZ's dual
+-- `morph [] (lock 0 ∷ [])`, X = Y = 1, A = ℕ.
 
 Q₆ : Term
-Q₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
-       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+Q₆ = ((QS₇⇑ ⟪ morph [] (lock 0 ∷ []) , unseal 1 ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₆ : [] ⊢ Q₅ -→ Q₆
-qstep₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
-
-⊢Q₆-in2 : QΞ₂ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₆-in2 = env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
-               ⊢$ (conv-id base-ℕ) wf-ℕ
-
-⊢Q₆-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
-                      ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₆-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₆-in2 (conv-id base-ℕ) wf-ℕ
+qstep₆ = ξ-⟪⟫ (IdPush (V-⟪⟫ V-$ I-seal) (es ez))
 
 ⊢Q₆ : [] ∣ [] ⊢ Q₆ ⦂ `ℕ
-⊢Q₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₆-in (conv-id base-ℕ) wf-ℕ
+⊢Q₆ = preservation ⊢Q₅ qstep₆
 
--- ── STEPS 7, 8, 9 — the three base conversions over the numeral.
+-- ── STEP 7 — CANCEL, at depth 2.  The seal minted by Peel and the unseal
+-- IdPush moved inwards are now adjacent.  BOTH FRAMES STAY, and the scope
+-- move sends ΛZ's dual `lock 0` into the inner frame's TAIL while the
+-- residue keeps it REWOUND (`unlock 0 ∷ lock 0`).
 
-Q₇ Q₈ : Term
-Q₇ = (($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-Q₈ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+Q₇ Q₈ Q₉ Q₁₀ : Term
+Q₇ = ((((($ 7) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+           ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+         ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+Q₈ = ((($ 7) ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+Q₉ = (($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+Q₁₀ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 qstep₇ : [] ⊢ Q₆ -→ Q₇
-qstep₇ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
-
-⊢Q₇-in : QΔ₁ ∣ [] ⊢ ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
-⊢Q₇-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+qstep₇ = ξ-⟪⟫ (ξ-⟪⟫ (CancelR V-$ (es ez)))
 
 ⊢Q₇ : [] ∣ [] ⊢ Q₇ ⦂ `ℕ
-⊢Q₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Q₇-in (conv-id base-ℕ) wf-ℕ
+⊢Q₇ = preservation ⊢Q₆ qstep₇
+
+-- ── STEPS 8–11 — the FOUR base conversions over the numeral (three,
+-- before frame-exact Beta).
 
 qstep₈ : [] ⊢ Q₇ -→ Q₈
-qstep₈ = ξ-⟪⟫ (Drop$ base-ℕ)
+qstep₈ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ)))
 
 ⊢Q₈ : [] ∣ [] ⊢ Q₈ ⦂ `ℕ
-⊢Q₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢$ (conv-id base-ℕ) wf-ℕ
+⊢Q₈ = preservation ⊢Q₇ qstep₈
 
-qstep₉ : [] ⊢ Q₈ -→ $ 7
-qstep₉ = Drop$ base-ℕ
+qstep₉ : [] ⊢ Q₈ -→ Q₉
+qstep₉ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
 
-⊢Q₉ : [] ∣ [] ⊢ $ 7 ⦂ `ℕ
-⊢Q₉ = preservation-Drop$ base-ℕ ⊢Q₈
+⊢Q₉ : [] ∣ [] ⊢ Q₉ ⦂ `ℕ
+⊢Q₉ = preservation ⊢Q₈ qstep₉
+
+qstep₁₀ : [] ⊢ Q₉ -→ Q₁₀
+qstep₁₀ = ξ-⟪⟫ (Drop$ base-ℕ)
+
+⊢Q₁₀ : [] ∣ [] ⊢ Q₁₀ ⦂ `ℕ
+⊢Q₁₀ = preservation ⊢Q₉ qstep₁₀
+
+qstep₁₁ : [] ⊢ Q₁₀ -→ $ 7
+qstep₁₁ = Drop$ base-ℕ
+
+⊢Q₁₁ : [] ∣ [] ⊢ $ 7 ⦂ `ℕ
+⊢Q₁₁ = preservation-Drop$ base-ℕ ⊢Q₁₀
 
 run-Q₀ : [] ⊢ Q₀ -→* $ 7
 run-Q₀ = qstep₁ then qstep₂ then qstep₃ then qstep₄ then qstep₅
-    then qstep₆ then qstep₇ then qstep₈ then qstep₉ then done
+    then qstep₆ then qstep₇ then qstep₈ then qstep₉ then qstep₁₀
+    then qstep₁₁ then done
 
--- … and the generated run agrees, IdPush state and all.
-_ : evalTerms 9 ⊢Q₀
-      ≡ Q₀ ∷ Q₁ ∷ Q₂ ∷ Q₃ ∷ Q₄ ∷ Q₅ ∷ Q₆ ∷ Q₇ ∷ Q₈ ∷ ($ 7) ∷ []
+-- … and the generated run agrees, both IdPush states and all.
+_ : evalTerms 11 ⊢Q₀
+      ≡ Q₀ ∷ Q₁ ∷ Q₂ ∷ Q₃ ∷ Q₄ ∷ Q₅ ∷ Q₆ ∷ Q₇ ∷ Q₈ ∷ Q₉ ∷ Q₁₀ ∷ ($ 7) ∷ []
 _ = refl
 
 -- ── DETERMINISM PINS.  Each state has exactly ONE successor, so the run
@@ -1274,8 +1340,14 @@ qdet₇ st = det st qstep₇
 qdet₈ : ∀ {M′} → [] ⊢ Q₇ -→ M′ → M′ ≡ Q₈
 qdet₈ st = det st qstep₈
 
-qdet₉ : ∀ {M′} → [] ⊢ Q₈ -→ M′ → M′ ≡ $ 7
+qdet₉ : ∀ {M′} → [] ⊢ Q₈ -→ M′ → M′ ≡ Q₉
 qdet₉ st = det st qstep₉
+
+qdet₁₀ : ∀ {M′} → [] ⊢ Q₉ -→ M′ → M′ ≡ Q₁₀
+qdet₁₀ st = det st qstep₁₀
+
+qdet₁₁ : ∀ {M′} → [] ⊢ Q₁₀ -→ M′ → M′ ≡ $ 7
+qdet₁₁ st = det st qstep₁₁
 
 ------------------------------------------------------------------------
 -- §11a  VARIANT (iii) — IDPUSH FIRING TWICE IN ONE RUN
@@ -1309,30 +1381,72 @@ D₀     = (Dfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 QΞ₃ : Ctxᵗ
 QΞ₃ = unmasked (bind `ℕ) ∷ QΞ₂
 
-D₁ D₂ D₃ D₄ D₅ D₆ D₇ D₈ D₉ D₁₀ D₁₁ : Term
+-- FRAME-EXACT BETA (2026-09-08) plants the crossed 7 under TWO Λs, so it
+-- acquires TWO dual wrappers — ΛY's `↓Y` and, outside it, ΛZ's `↓Z` —
+-- each with an identity conversion at the argument's type at that depth.
+-- BEFORE FRAME-EXACT BETA the planted value was the bare shifted
+-- `($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫` and the run was 12 steps;
+-- it is now 16 — the two extra layers are pushed in by two extra IdPush
+-- steps and finished by two extra Drop$.
+DS₇ : Term
+DS₇ = ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+          ⟪ morph [] (lock 1 ∷ []) , id (` 2) ⟫)
+        ⟪ morph [] (lock 0 ∷ []) , id (` 2) ⟫
+
+val-DS₇ : Value DS₇
+val-DS₇ = V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) I-idv
+
+D₁ D₂ D₃ D₄ D₅ D₆ D₇ D₈ : Term
 D₁  = ((ƛ (` 0) ∙ Dbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
 D₂  = ((ƛ (` 0) ∙ Dbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-D₃  = ((Λ ((Λ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)) ·[ ` 2 , `ℕ ]))
-         ·[ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-D₄  = ((Λ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-              ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)) ·[ ` 1 , `ℕ ])
+D₃  = ((Λ ((Λ DS₇) ·[ ` 2 , `ℕ ])) ·[ ` 1 , `ℕ ])
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-D₅  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (`
-  2) ⟫)
-          ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-D₆  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] , id (`
-  2) ⟫)
-          ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₇  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫) ⟪ morph (`ℕ ∷ []) [] ,
-  unseal 2 ⟫)
-          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₈  = (((($ 7) ⟪ morph [] (lock 2 ∷ []) , id `ℕ ⟫)
-          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
-          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₉  = ((($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+D₄  = ((Λ (DS₇ ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)) ·[ ` 1 , `ℕ ])
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+D₅  = ((DS₇ ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+         ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+D₆  = ((DS₇ ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
+         ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₁₀ = (($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-D₁₁ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₇  = ((DS₇ ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫)
+         ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₈  = (((((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+              ⟪ morph [] (lock 1 ∷ []) , id (` 2) ⟫)
+             ⟪ morph [] (lock 0 ∷ []) , unseal 2 ⟫)
+            ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+
+D₉ D₁₀ D₁₁ D₁₂ D₁₃ D₁₄ D₁₅ : Term
+D₉  = (((((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+              ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , unseal 2 ⟫)
+             ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+            ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₀ = (((((($ 7) ⟪ morph [] (lock 2 ∷ lock 1 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+              ⟪ morph [] (unlock 0 ∷ unlock 1 ∷ lock 1 ∷ lock 0 ∷ [])
+                , id `ℕ ⟫)
+             ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+            ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₁ = ((((($ 7) ⟪ morph [] (unlock 0 ∷ unlock 1 ∷ lock 1 ∷ lock 0 ∷ [])
+                    , id `ℕ ⟫)
+             ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+            ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₂ = (((($ 7) ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+            ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₃ = ((($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₄ = (($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+D₁₅ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 dstep₁ : [] ⊢ D₀ -→ D₁
 dstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1346,83 +1460,105 @@ dstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 -- the INNER vacuous Λ fires first — under ξ-Λ, because `Λ N` is a value
 -- only when N is (V-Λ's premise, repair (1)).
 dstep₄ : [] ⊢ D₃ -→ D₄
-dstep₄ = ξ-⟪⟫ (ξ-·[] (ξ-Λ (TyBeta (V-⟪⟫ V-$ I-seal))))
+dstep₄ = ξ-⟪⟫ (ξ-·[] (ξ-Λ (TyBeta val-DS₇)))
 
 dstep₅ : [] ⊢ D₄ -→ D₅
-dstep₅ = ξ-⟪⟫ (TyBeta (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv))
+dstep₅ = ξ-⟪⟫ (TyBeta (V-⟪⟫ val-DS₇ I-idv))
 
 -- IDPUSH #1 — the outer id-layer.
 dstep₆ : [] ⊢ D₅ -→ D₆
-dstep₆ = IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) ez
+dstep₆ = IdPush (V-⟪⟫ val-DS₇ I-idv) ez
 
 -- IDPUSH #2 — the unseal IdPush #1 pushed inwards meets the NEXT layer.
 dstep₇ : [] ⊢ D₆ -→ D₇
-dstep₇ = ξ-⟪⟫ (IdPush (V-⟪⟫ V-$ I-seal) (es ez))
+dstep₇ = ξ-⟪⟫ (IdPush val-DS₇ (es ez))
 
+-- IDPUSH #3, #4 — THE TWO STEPS FRAME-EXACT BETA ADDS: the two dual
+-- wrappers are themselves `id (` X)` layers, so the same rule walks
+-- through them.
 dstep₈ : [] ⊢ D₇ -→ D₈
-dstep₈ = ξ-⟪⟫ (ξ-⟪⟫ (CancelR V-$ (es (es ez))))
+dstep₈ = ξ-⟪⟫ (ξ-⟪⟫ (IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) (es (es ez))))
 
 dstep₉ : [] ⊢ D₈ -→ D₉
-dstep₉ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ)))
+dstep₉ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (IdPush (V-⟪⟫ V-$ I-seal) (es (es ez)))))
 
 dstep₁₀ : [] ⊢ D₉ -→ D₁₀
-dstep₁₀ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
+dstep₁₀ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (CancelR V-$ (es (es ez))))))
 
 dstep₁₁ : [] ⊢ D₁₀ -→ D₁₁
-dstep₁₁ = ξ-⟪⟫ (Drop$ base-ℕ)
+dstep₁₁ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ)))))
 
-dstep₁₂ : [] ⊢ D₁₁ -→ $ 7
-dstep₁₂ = Drop$ base-ℕ
+dstep₁₂ : [] ⊢ D₁₁ -→ D₁₂
+dstep₁₂ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))))
+
+dstep₁₃ : [] ⊢ D₁₂ -→ D₁₃
+dstep₁₃ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ)))
+
+dstep₁₄ : [] ⊢ D₁₃ -→ D₁₄
+dstep₁₄ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
+
+dstep₁₅ : [] ⊢ D₁₄ -→ D₁₅
+dstep₁₅ = ξ-⟪⟫ (Drop$ base-ℕ)
+
+dstep₁₆ : [] ⊢ D₁₅ -→ $ 7
+dstep₁₆ = Drop$ base-ℕ
 
 run-D₀ : [] ⊢ D₀ -→* $ 7
 run-D₀ = dstep₁ then dstep₂ then dstep₃ then dstep₄ then dstep₅
     then dstep₆ then dstep₇ then dstep₈ then dstep₉ then dstep₁₀
-    then dstep₁₁ then dstep₁₂ then done
+    then dstep₁₁ then dstep₁₂ then dstep₁₃ then dstep₁₄ then dstep₁₅
+    then dstep₁₆ then done
 
--- ── BOTH IDPUSH CONTRACTA TYPE ─────────────────────────────────────────
+-- ── EVERY CONTRACTUM TYPES ─────────────────────────────────────────────
+--
+-- With FOUR IdPush states the hand-built `env` towers say nothing §11's
+-- pair does not, so the typings are taken from PRESERVATION itself.  The
+-- one fact worth pinning by hand is the FRAME the two new wrappers give
+-- the planted value: QΞ₃ with BOTH crossed Λ slots masked — i.e. QΔ₁,
+-- its birth frame, two binders in.
+DΞᵏ : Ctxᵗ
+DΞᵏ = masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
 
+_ : interior (morph [] (lock 1 ∷ [])) (interior (morph [] (lock 0 ∷ [])) QΞ₃)
+      ≡ DΞᵏ
+_ = refl
+
+-- the sealed 7 at the FULL bind prefix — still used by §11c's K
 ⊢Dseal₇ : QΞ₃ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
 ⊢Dseal₇ = env (mw rw[]
                  (sw-l (unmasked (bind `ℕ) , es (es ez) , nameable) sw[]))
                ⊢$ (conv-seal (es (es ez)))
                (wf-var (unmasked (bind `ℕ) , es (es ez) , nameable))
 
-⊢Did₂ : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-                     ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 1
-⊢Did₂ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Dseal₇
-             (conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable))
-             (wf-var (unmasked (bind `ℕ) , es ez , nameable))
+⊢D₁ : [] ∣ [] ⊢ D₁ ⦂ `ℕ
+⊢D₁ = preservation ⊢D₀ dstep₁
 
-⊢D₅-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-                        ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
-                       ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
-⊢D₅-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Did₂
-              (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
-              (wf-var (unmasked (bind `ℕ) , ez , nameable))
+⊢D₂ : [] ∣ [] ⊢ D₂ ⦂ `ℕ
+⊢D₂ = preservation ⊢D₁ dstep₂
+
+⊢D₃ : [] ∣ [] ⊢ D₃ ⦂ `ℕ
+⊢D₃ = preservation ⊢D₂ dstep₃
+
+⊢D₄ : [] ∣ [] ⊢ D₄ ⦂ `ℕ
+⊢D₄ = preservation ⊢D₃ dstep₄
 
 ⊢D₅ : [] ∣ [] ⊢ D₅ ⦂ `ℕ
-⊢D₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₅-in (conv-unseal ez) wf-ℕ
-
-⊢D₆-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-                        ⟪ morph (`ℕ ∷ []) [] , id (` 2) ⟫)
-                       ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
-⊢D₆-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Did₂ (conv-unseal (es ez)) wf-ℕ
+⊢D₅ = preservation ⊢D₄ dstep₅
 
 ⊢D₆ : [] ∣ [] ⊢ D₆ ⦂ `ℕ
-⊢D₆ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₆-in (conv-id base-ℕ) wf-ℕ
-
-⊢D₇-in2 : QΞ₂ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-                        ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫ ⦂ `ℕ
-⊢D₇-in2 = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢Dseal₇
-               (conv-unseal (es (es ez))) wf-ℕ
-
-⊢D₇-in : QΔ₁ ∣ [] ⊢ ((($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-                        ⟪ morph (`ℕ ∷ []) [] , unseal 2 ⟫)
-                       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫ ⦂ `ℕ
-⊢D₇-in = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₇-in2 (conv-id base-ℕ) wf-ℕ
+⊢D₆ = preservation ⊢D₅ dstep₆
 
 ⊢D₇ : [] ∣ [] ⊢ D₇ ⦂ `ℕ
-⊢D₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢D₇-in (conv-id base-ℕ) wf-ℕ
+⊢D₇ = preservation ⊢D₆ dstep₇
+
+⊢D₈ : [] ∣ [] ⊢ D₈ ⦂ `ℕ
+⊢D₈ = preservation ⊢D₇ dstep₈
+
+⊢D₉ : [] ∣ [] ⊢ D₉ ⦂ `ℕ
+⊢D₉ = preservation ⊢D₈ dstep₉
+
+⊢D₁₀ : [] ∣ [] ⊢ D₁₀ ⦂ `ℕ
+⊢D₁₀ = preservation ⊢D₉ dstep₁₀
 
 ------------------------------------------------------------------------
 -- §11b  VARIANT (ii) — AN ID-LAYER WHOSE CONVERSION REP IS CHAINED
@@ -1499,7 +1635,13 @@ _ = refl
 _ : ⇑ᴹ RS ≡ RS↑
 _ = refl
 
-R₁ R₂ R₃ R₄ R₅ R₆ R₇ R₈ R₉ : Term
+-- FRAME-EXACT BETA (2026-09-08): the value planted under ΛZ acquires
+-- ΛZ's dual, with an identity conversion at the argument's type at that
+-- depth (the CHAINED variable ` 1, i.e. Y).
+RS↑↑ : Term
+RS↑↑ = RS↑ ⟪ morph [] (lock 0 ∷ []) , id (` 1) ⟫
+
+R₁ R₂ R₃ R₄ R₅ R₆ : Term
 R₁  = ((ƛ (` 0) ∙ Rbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
 R₂  = ((ƛ (` 0) ∙ Rbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 R₃  = ((Qfun ·[ ` 0 ⇒ ` 0 , ` 0 ]) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
@@ -1507,15 +1649,7 @@ R₄  = (((ƛ (` 0) ∙ Qbody) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ unseal 0
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 R₅  = (((ƛ (` 0) ∙ Qbody) · RS) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₆  = (((Λ RS↑) ·[ ` 1 , `ℕ ]) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
-        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₇  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫) ⟪ morph ((` 0) ∷ []) [] , unseal
-  0 ⟫)
-        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₈  = ((RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id (`
-  1) ⟫)
-        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-R₉  = (RW ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
+R₆  = (((Λ RS↑↑) ·[ ` 1 , `ℕ ]) ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 rstep₁ : [] ⊢ R₀ -→ R₁
@@ -1524,6 +1658,8 @@ rstep₁ = ξ-·-l (TyBeta V-ƛ)
 rstep₂ : [] ⊢ R₁ -→ R₂
 rstep₂ = Peel V-ƛ V-$
 
+-- THIS Beta crosses NO Λ (the variable sits in an argument position), so
+-- it mints no wrapper.
 rstep₃ : [] ⊢ R₂ -→ R₃
 rstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
@@ -1534,40 +1670,35 @@ rstep₄ = ξ-⟪⟫ (ξ-·-l (TyBeta V-ƛ))
 rstep₅ : [] ⊢ R₄ -→ R₅
 rstep₅ = ξ-⟪⟫ (Peel V-ƛ (V-⟪⟫ V-$ I-seal))
 
+-- … and THIS one does: `RS` crosses ΛZ and is wrapped in `↓Z , id Y`.
 rstep₆ : [] ⊢ R₅ -→ R₆
 rstep₆ = ξ-⟪⟫ (ξ-⟪⟫ (Beta (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal)))
 
-rstep₇ : [] ⊢ R₆ -→ R₇
-rstep₇ = ξ-⟪⟫ (ξ-⟪⟫ (TyBeta (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal)))
+_ : evalTerms 6 ⊢R₀ ≡ R₀ ∷ R₁ ∷ R₂ ∷ R₃ ∷ R₄ ∷ R₅ ∷ R₆ ∷ []
+_ = refl
 
--- IDPUSH #1, AT A CHAINED REP.
-rstep₈ : [] ⊢ R₇ -→ R₈
-rstep₈ = ξ-⟪⟫ (IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal) ez)
-
--- CANCEL, at the chained rep.  Both frames stay, so the crossing's own
--- `lock 1` survives as a transparent layer carrying the CHAINED rep ` 2 —
--- which is where the run's remaining id-layers come from.
-rstep₉ : [] ⊢ R₈ -→ R₉
-rstep₉ = ξ-⟪⟫ (ξ-⟪⟫ (CancelR (V-⟪⟫ V-$ I-seal) (es ez)))
-
--- The tail: three more IdPushes (each residue conversion is ITSELF an
--- id-layer), the last seal/unseal pair, and five transparent layers over
--- the numeral.  The states are the ones the rules compute.
+-- The tail is a cascade of IdPushes (each residue conversion is ITSELF an
+-- id-layer), two Cancels and six transparent layers over the numeral.  It
+-- was 15 steps; with the extra layer frame-exact Beta interposes it is 15
+-- from R₆ too — the wrapper is consumed by one of the IdPushes already in
+-- the cascade — for 21 steps in all, against 20 before.  RENDERED
+-- (scripts/render_term.sh 'showTrace 0 (eval 21 ⊢R₀)'), the rule sequence
+-- is
+--
+--   TyBeta Peel Beta TyBeta Peel Beta TyBeta
+--   IdPush IdPush CancelR IdPush IdPush IdPush IdPush CancelR
+--   Drop$ Drop$ Drop$ Drop$ Drop$ Drop$
+--
+-- and the chain is the machine's own (`eval-sound`, strong.Eval), which is
+-- what the states after R₆ are worth: they are what the rules compute.
 run-R₀ : [] ⊢ R₀ -→* $ 7
-run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
-    then rstep₆ then rstep₇ then rstep₈ then rstep₉
-    then IdPush (V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) I-idv) ez
-    then ξ-⟪⟫ (IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) (es ez))
-    then ξ-⟪⟫ (ξ-⟪⟫ (IdPush (V-⟪⟫ V-$ I-seal) (es (es ez))))
-    then ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (CancelR V-$ (es (es ez)))))
-    then ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))))
-    then ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ)))
-    then ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
-    then ξ-⟪⟫ (Drop$ base-ℕ)
-    then Drop$ base-ℕ
-    then done
+run-R₀ = eval-sound 21 ⊢R₀
 
 -- ── THE CHAINED IDPUSH REDEX AND ITS CONTRACTUM BOTH TYPE ──────────────
+--
+-- Stated STANDALONE, on the shape the cascade reaches, at the frame it
+-- reaches it in: what §11b is about is the CHAINED REP, not how many
+-- transparent layers stand between it and the numeral.
 
 ⊢RV₂ : RΞ″ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫ ⦂ ` 2
 ⊢RV₂ = env (mw rw[] (sw-l (_ , es (es ez) , nameable) sw[])) ⊢$
@@ -1582,13 +1713,20 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
                (conv-idv (_ , es ez , nameable))
                (wf-var (_ , ez , nameable))
 
-⊢R₇-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
-                       ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫ ⦂ ` 0
-⊢R₇-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Rlayer
-              (conv-unseal ez) (wf-var (_ , ez , nameable))
+Rchained Rchained′ : Term
+Rchained  = (RS↑ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
+              ⟪ morph ((` 0) ∷ []) [] , unseal 0 ⟫
+Rchained′ = (RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
+              ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫
 
-⊢R₇ : [] ∣ [] ⊢ R₇ ⦂ `ℕ
-⊢R₇ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢R₇-in (conv-unseal ez) wf-ℕ
+⊢Rchained : QΔ₁ ∣ [] ⊢ Rchained ⦂ ` 0
+⊢Rchained = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Rlayer
+                 (conv-unseal ez) (wf-var (_ , ez , nameable))
+
+-- IDPUSH AT A CHAINED REP: `Rchain` is the lookup, `Rchain-scoped` the
+-- premise `env` then asks for.
+rstep-chained : QΔ₁ ⊢ Rchained -→ Rchained′
+rstep-chained = IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal) Rchain
 
 -- the contractum: the inner wrapper now EXPORTS the chained rep ` 1, and
 -- `env`'s last premise `RΞ ⊢ᵗ ` 1` is exactly `Rchain-scoped`.
@@ -1596,13 +1734,10 @@ run-R₀ = rstep₁ then rstep₂ then rstep₃ then rstep₄ then rstep₅
 ⊢R₈-mid = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢RS↑
                (conv-unseal (es ez)) Rchain-scoped
 
-⊢R₈-in : QΔ₁ ∣ [] ⊢ (RS↑ ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
-                       ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
-⊢R₈-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢R₈-mid
-              (conv-idv (_ , es ez , nameable)) (wf-var (_ , ez , nameable))
-
-⊢R₈ : [] ∣ [] ⊢ R₈ ⦂ `ℕ
-⊢R₈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢R₈-in (conv-unseal ez) wf-ℕ
+⊢Rchained′ : QΔ₁ ∣ [] ⊢ Rchained′ ⦂ ` 0
+⊢Rchained′ = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢R₈-mid
+                  (conv-idv (_ , es ez , nameable))
+                  (wf-var (_ , ez , nameable))
 
 ------------------------------------------------------------------------
 -- §11c  VARIANT (i) — AN ID-LAYER WITH A NON-TRIVIAL Θ₁
@@ -1656,17 +1791,28 @@ G₀    = (Gfun ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 7)
 _ : reveal 0 (`∀ (` 2)) ≡ `∀ (id (` 2))
 _ = refl
 
+-- FRAME-EXACT BETA (2026-09-08): the planted 7 crosses BOTH Λs of
+-- `Gpoly`, so it acquires the SAME pair of dual wrappers as §11a's `DS₇`
+-- — the two calculi differ only in where the `·[ ]` sit.
 GV G₁ G₂ G₃ G₄ G₅ : Term
-GV = Λ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+GV = Λ DS₇
 G₁ = ((ƛ (` 0) ∙ Gbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
 G₂ = ((ƛ (` 0) ∙ Gbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 G₃ = (((Λ GV) ·[ `∀ (` 2) , `ℕ ]) ·[ ` 1 , `ℕ ])
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 G₄ = ((GV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 2)) ⟫) ·[ ` 1 , `ℕ ])
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-G₅ = ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , ` 0 ])
+G₅ = ((wkᴹ 1 GV) ·[ ` 3 , ` 0 ])
        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+
+-- the moved value, spelled out: every NAME shifts, the innermost `lock 0`
+-- stays put (it is the value's own crossed Λ, protected by `extᵗ`).
+_ : wkᴹ 1 GV
+      ≡ Λ (((($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)
+                ⟪ morph [] (lock 2 ∷ []) , id (` 3) ⟫)
+               ⟪ morph [] (lock 0 ∷ []) , id (` 3) ⟫)
+_ = refl
 
 gstep₁ : [] ⊢ G₀ -→ G₁
 gstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1678,7 +1824,7 @@ gstep₃ : [] ⊢ G₂ -→ G₃
 gstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 
 gstep₄ : [] ⊢ G₃ -→ G₄
-gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ (V-⟪⟫ V-$ I-seal))))
+gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ val-DS₇)))
 
 -- the TyPeelR step, whose contractum is the wanted `numBinds Θ₁ ≡ 2` layer.
 -- Its conversion premise is the redex's own, one `` `∀ `` inside —
@@ -1688,46 +1834,35 @@ gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ (V-⟪⟫ V-$ I-seal))))
 ⊢Gconv = conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable)
 
 gstep₅ : [] ⊢ G₄ -→ G₅
-gstep₅ = ξ-⟪⟫ (TyPeelR (V-Λ (V-⟪⟫ V-$ I-seal)) ⊢Gconv)
+gstep₅ = ξ-⟪⟫ (TyPeelR (V-Λ val-DS₇) ⊢Gconv)
 
 _ : numBinds (morph (`ℕ ∷ `ℕ ∷ []) []) ≡ 2
 _ = refl
 
--- G₄ IS WELL TYPED …
-⊢GV : QΞ₂ ∣ [] ⊢ GV ⦂ `∀ (` 2)
-⊢GV = ⊢Λ (env (mw rw[] (sw-l (_ , es (es ez) , nameable) sw[])) ⊢$
-               (conv-seal (es (es ez))) (wf-var (_ , es (es ez) , nameable)))
+-- G₄ IS WELL TYPED, AND SO IS ITS TYPEELR CONTRACTUM, with the repaired
+-- rule: the pushed-in annotation is the INTERIOR ∀-body shifted past the
+-- new binder (`` ` 3 ``, matching `wkᴹ 1 GV : `∀ (` 3)`), and the frame is
+-- plain `Θ` — the `renᴮ suc Θ` double-shift that made `¬⊢G₅` true is
+-- gone.  So variant (i) HAS a well-typed closed-source instance.
+--
+-- The typings come from PRESERVATION: with the two dual wrappers the
+-- hand-built `env` towers are three layers taller and say nothing more,
+-- and the frame each wrapper gives the planted value is pinned in §11a
+-- (`DΞᵏ`).
+⊢G₁ : [] ∣ [] ⊢ G₁ ⦂ `ℕ
+⊢G₁ = preservation ⊢G₀ gstep₁
 
-⊢Gpkg : QΔ₁ ∣ [] ⊢ GV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 2)) ⟫ ⦂ `∀ (` 1)
-⊢Gpkg = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢GV
-             (conv-all (conv-idv (_ , es (es ez) , nameable)))
-             (wf-∀ (wf-var (_ , es ez , nameable)))
+⊢G₂ : [] ∣ [] ⊢ G₂ ⦂ `ℕ
+⊢G₂ = preservation ⊢G₁ gstep₂
+
+⊢G₃ : [] ∣ [] ⊢ G₃ ⦂ `ℕ
+⊢G₃ = preservation ⊢G₂ gstep₃
 
 ⊢G₄ : [] ∣ [] ⊢ G₄ ⦂ `ℕ
-⊢G₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) (⊢·[] ⊢Gpkg wf-ℕ) (conv-unseal ez) wf-ℕ
-
--- … AND SO IS ITS TYPEELR CONTRACTUM, with the repaired rule.  The
--- pushed-in annotation is the INTERIOR ∀-body shifted past the new binder
--- (`` ` 3 ``, matching `wkᴹ 1 GV : `∀ (` 3)`), and the frame is plain `Θ`
--- — the `renᴮ suc Θ` double-shift that made `¬⊢G₅` true is gone.  So
--- variant (i) now HAS a well-typed closed-source instance.
-⊢G₅-Λ : QΞ₃ ∣ [] ⊢ Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫) ⦂ `∀ (` 3)
-⊢G₅-Λ =
-  ⊢Λ (env (mw rw[]
-             (sw-l (unmasked (bind `ℕ) , es (es (es ez)) , nameable) sw[]))
-           ⊢$ (conv-seal (es (es (es ez))))
-           (wf-var (unmasked (bind `ℕ) , es (es (es ez)) , nameable)))
-
-⊢G₅-in : QΔ₁ ∣ [] ⊢ ((Λ (($ 7) ⟪ morph [] (lock 3 ∷ []) , seal 3 ⟫)) ·[ ` 3 , `
-  0 ])
-                      ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫ ⦂ ` 0
-⊢G₅-in = env (mw (rw-b wf-ℕ (rw-b wf-ℕ rw[])) sw[])
-              (⊢·[] ⊢G₅-Λ (wf-var (unmasked (bind `ℕ) , ez , nameable)))
-              (conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable))
-              (wf-var (unmasked (bind `ℕ) , ez , nameable))
+⊢G₄ = preservation ⊢G₃ gstep₄
 
 ⊢G₅ : [] ∣ [] ⊢ G₅ ⦂ `ℕ
-⊢G₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢G₅-in (conv-unseal ez) wf-ℕ
+⊢G₅ = preservation ⊢G₄ gstep₅
 
 -- ── AND THE MULTI-BIND ID-LAYER IT DELIVERS ────────────────────────────
 -- The same shape, hand-built at the frame the repaired rule produces
@@ -1820,22 +1955,30 @@ _ = refl
 _ : interior (morph [] (lock 1 ∷ [])) LΔ ≡ LΞ
 _ = refl
 
-L₁ L₂ L₃ L₄ L₅ L₆ L₇ L₈ : Term
+-- FRAME-EXACT BETA (2026-09-08) plants `QS₇↑` (§11) — the crossed 7 with
+-- ΛY's dual on it — where the shift alone used to plant `QS₇⇑`.  The wall
+-- CONTEXT is unchanged: the Peel-minted `lock 1` is still what sits inside
+-- the chained binder.  The run is 11 steps, against 9 before.
+L₁ L₂ L₃ L₄ L₅ : Term
 L₁ = ((ƛ (` 0) ∙ Lbody) ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ unseal 0 ⟫) · ($ 7)
 L₂ = ((ƛ (` 0) ∙ Lbody) · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-L₃ = ((Λ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)) ·[ ` 1 , ` 0 ])
+L₃ = ((Λ QS₇↑) ·[ ` 1 , ` 0 ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
+L₄ = (QS₇↑ ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫)
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-L₄ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] , id
-  (` 1) ⟫)
-       ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-L₅ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph ((` 0) ∷ []) [] ,
-  unseal 1 ⟫)
+L₅ = (QS₇↑ ⟪ morph ((` 0) ∷ []) [] , unseal 1 ⟫)
        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-L₆ = ((($ 7) ⟪ morph [] (lock 1 ∷ []) , id `ℕ ⟫)
-       ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
-       ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-L₇ = (($ 7) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
-L₈ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+
+L₆ L₇ L₈ L₉ L₁₀ : Term
+L₆ = ((QS₇⇑ ⟪ morph [] (lock 0 ∷ []) , unseal 1 ⟫)
+        ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+L₇ = ((((($ 7) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+            ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+           ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+L₈ = ((($ 7) ⟪ morph [] (unlock 0 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+         ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+L₉ = (($ 7) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+L₁₀ = ($ 7) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 lstep₁ : [] ⊢ L₀ -→ L₁
 lstep₁ = ξ-·-l (TyBeta V-ƛ)
@@ -1849,55 +1992,58 @@ lstep₃ = ξ-⟪⟫ (Beta (V-⟪⟫ V-$ I-seal))
 -- THE STEP THAT BUILDS THE WALL CONTEXT: the binder minted here has the
 -- CHAINED rep ` 0, and the Peel-minted `lock 1` sits inside it.
 lstep₄ : [] ⊢ L₃ -→ L₄
-lstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal))
+lstep₄ = ξ-⟪⟫ (TyBeta (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv))
 
 -- … and IdPush still fires, because its Θ₂ (`bind ℕ ∷ []`) is LOCK-FREE.
 lstep₅ : [] ⊢ L₄ -→ L₅
-lstep₅ = IdPush (V-⟪⟫ V-$ I-seal) ez
+lstep₅ = IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) ez
 
+-- IdPush again, on the layer frame-exact Beta added.
 lstep₆ : [] ⊢ L₅ -→ L₆
-lstep₆ = ξ-⟪⟫ (CancelR V-$ (es ez))
+lstep₆ = ξ-⟪⟫ (IdPush (V-⟪⟫ V-$ I-seal) (es ez))
 
 lstep₇ : [] ⊢ L₆ -→ L₇
-lstep₇ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
+lstep₇ = ξ-⟪⟫ (ξ-⟪⟫ (CancelR V-$ (es ez)))
 
 lstep₈ : [] ⊢ L₇ -→ L₈
-lstep₈ = ξ-⟪⟫ (Drop$ base-ℕ)
+lstep₈ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ)))
 
-lstep₉ : [] ⊢ L₈ -→ $ 7
-lstep₉ = Drop$ base-ℕ
+lstep₉ : [] ⊢ L₈ -→ L₉
+lstep₉ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
+
+lstep₁₀ : [] ⊢ L₉ -→ L₁₀
+lstep₁₀ = ξ-⟪⟫ (Drop$ base-ℕ)
+
+lstep₁₁ : [] ⊢ L₁₀ -→ $ 7
+lstep₁₁ = Drop$ base-ℕ
 
 run-L₀ : [] ⊢ L₀ -→* $ 7
 run-L₀ = lstep₁ then lstep₂ then lstep₃ then lstep₄ then lstep₅
-    then lstep₆ then lstep₇ then lstep₈ then lstep₉ then done
+    then lstep₆ then lstep₇ then lstep₈ then lstep₉ then lstep₁₀
+    then lstep₁₁ then done
 
 -- … and the generated run agrees, so the wall CONTEXT really is on the
 -- machine's own trace and not only on a hand-written one.
-_ : evalTerms 9 ⊢L₀
-      ≡ L₀ ∷ L₁ ∷ L₂ ∷ L₃ ∷ L₄ ∷ L₅ ∷ L₆ ∷ L₇ ∷ L₈ ∷ ($ 7) ∷ []
+_ : evalTerms 11 ⊢L₀
+      ≡ L₀ ∷ L₁ ∷ L₂ ∷ L₃ ∷ L₄ ∷ L₅ ∷ L₆ ∷ L₇ ∷ L₈ ∷ L₉ ∷ L₁₀ ∷ ($ 7) ∷ []
 _ = refl
 
 -- ── every state on the run TYPES, including the two the wall touches ───
+--
+-- `⊢Lseal₇` is the wall's own subterm, read at the wall frame `LΔ`; the
+-- run states come from PRESERVATION (the extra transparent layer makes
+-- each `env` tower one deeper and says nothing new).
 
 ⊢Lseal₇ : LΔ ∣ [] ⊢ ($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫ ⦂ ` 1
 ⊢Lseal₇ = env (mw rw[] (sw-l (_ , es ez , nameable) sw[])) ⊢$
                (conv-seal (es ez)) (wf-var (_ , es ez , nameable))
 
-⊢L₄-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
-                       ⟪ morph ((` 0) ∷ []) [] , id (` 1) ⟫ ⦂ ` 0
-⊢L₄-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Lseal₇
-              (conv-idv (_ , es ez , nameable)) (wf-var (_ , ez , nameable))
-
 ⊢L₄ : [] ∣ [] ⊢ L₄ ⦂ `ℕ
-⊢L₄ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢L₄-in (conv-unseal ez) wf-ℕ
-
-⊢L₅-in : QΔ₁ ∣ [] ⊢ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
-                       ⟪ morph ((` 0) ∷ []) [] , unseal 1 ⟫ ⦂ `ℕ
-⊢L₅-in = env (mw (rw-b (wf-var (_ , ez , nameable)) rw[]) sw[]) ⊢Lseal₇
-              (conv-unseal (es ez)) wf-ℕ
+⊢L₄ = preservation (preservation (preservation (preservation ⊢L₀ lstep₁)
+                                               lstep₂) lstep₃) lstep₄
 
 ⊢L₅ : [] ∣ [] ⊢ L₅ ⦂ `ℕ
-⊢L₅ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢L₅-in (conv-id base-ℕ) wf-ℕ
+⊢L₅ = preservation ⊢L₄ lstep₅
 
 -- THE PRECISE READING.  On this run the blocked slot lives inside a
 -- wrapper that is a `Θ₁` (an INERT `seal` conversion, the CancelR
@@ -2317,17 +2463,28 @@ H₀   = ((Hfun ·[ HB , `ℕ ]) · ($ 7)) ·[ ` 0 ⇒ `ℕ , `ℕ ]
 _ : reveal 0 HB ≡ seal 0 ↦ (`∀ (id (` 0) ↦ unseal 1))
 _ = refl
 
+-- FRAME-EXACT BETA (2026-09-08): the crossed 7 is planted under ΛY (and
+-- then under a ƛ, which changes no frame), so it carries ΛY's dual.  The
+-- RUN LENGTH IS UNCHANGED — the layer sits inside a ƛ body, where nothing
+-- evaluates it — only the states' spelling changes.  `QS₇↑′` is the same
+-- value again, moved past the binder TyPeelR introduces.
+QS₇↑′ : Term
+QS₇↑′ = (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
+          ⟪ morph [] (lock 0 ∷ []) , id (` 2) ⟫
+
 HV H₁ H₂ H₃ H₄ : Term
-HV = Λ (ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫))
+HV = Λ (ƛ (` 0) ∙ QS₇↑)
 H₁ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1))))
          ⟪ morph (`ℕ ∷ []) [] , seal 0 ↦ (`∀ (id (` 0) ↦ unseal 1)) ⟫) · ($ 7))
        ·[ ` 0 ⇒ `ℕ , `ℕ ]
 H₂ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1)))) · QS₇)
         ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
 H₃ = (HV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
-H₄ = ((Λ (ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))) ·[ ` 0 ⇒ ` 2 ,
-  ` 0 ])
+H₄ = ((Λ (ƛ (` 0) ∙ QS₇↑′)) ·[ ` 0 ⇒ ` 2 , ` 0 ])
        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
+
+_ : wkᴹ 1 HV ≡ Λ (ƛ (` 0) ∙ QS₇↑′)
+_ = refl
 
 hstep₁ : [] ⊢ H₀ -→ H₁
 hstep₁ = ξ-·[] (ξ-·-l (TyBeta V-ƛ))
@@ -2364,11 +2521,17 @@ _ = refl
 
 -- ── AND THE CONTRACTUM TYPES — by the theorem, not by hand ─────────────
 
+-- the sealed 7 inside ΛY's dual, at ΛY's own frame: this is `⊢crossΛ`
+-- (strong.TermSubst §6) once more, and the `lock 0` is legal because ΛY's
+-- slot is nameable.
 ⊢HV : (unmasked (bind `ℕ) ∷ []) ∣ [] ⊢ HV ⦂ `∀ (` 0 ⇒ ` 1)
 ⊢HV = ⊢Λ (⊢ƛ (wf-var (unmasked abst , ez , nameable))
-             (env (mw rw[] (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
-               ⊢$
-                  (conv-seal (es ez))
+             (env (mw rw[] (sw-l (unmasked abst , ez , nameable) sw[]))
+                  (env (mw rw[]
+                          (sw-l (unmasked (bind `ℕ) , es ez , nameable) sw[]))
+                       ⊢$ (conv-seal (es ez))
+                       (wf-var (unmasked (bind `ℕ) , es ez , nameable)))
+                  (conv-idv (unmasked (bind `ℕ) , es ez , nameable))
                   (wf-var (unmasked (bind `ℕ) , es ez , nameable))))
 
 ⊢H₃ : [] ∣ [] ⊢ H₃ ⦂ (`ℕ ⇒ `ℕ)
@@ -2382,15 +2545,14 @@ _ = refl
 
 -- and H₄ is ONE TyBeta from a value, so the repaired rule does not
 -- strand the run either.
-hstep₅ : [] ⊢ H₄
-       -→ ((ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))
-             ⟪ morph ((` 0) ∷ []) [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
-            ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
+H₅ : Term
+H₅ = ((ƛ (` 0) ∙ QS₇↑′) ⟪ morph ((` 0) ∷ []) [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
+       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
+
+hstep₅ : [] ⊢ H₄ -→ H₅
 hstep₅ = ξ-⟪⟫ (TyBeta V-ƛ)
 
-val-H₅ : Value (((ƛ (` 0) ∙ (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫))
-                   ⟪ morph ((` 0) ∷ []) [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
-                  ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫)
+val-H₅ : Value H₅
 val-H₅ = V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun
 
 ------------------------------------------------------------------------
@@ -2610,9 +2772,20 @@ E₂ = ((ƛ EID ∙ Ebody) · EW) ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 estep₂ : [] ⊢ E₁ -→ E₂
 estep₂ = Peel V-ƛ (V-Λ V-ƛ)
 
--- ── STEP 3 — BETA, under ξ-⟪⟫.  `substᵐ`'s Λ clause shifts the crossed
--- value past ΛY: the LOCK's name moves (lock 0 ↦ lock 1) and nothing
--- else does — a name, not a spelling.
+-- ── STEP 3 — BETA, under ξ-⟪⟫, FRAME-EXACT (2026-09-08).  `substᵐ`'s Λ
+-- clause does two things to the crossed value as it passes ΛY: it SHIFTS
+-- it — the LOCK's name moves, lock 0 ↦ lock 1, and nothing else does, a
+-- name and not a spelling — and it WRAPS it in ΛY's DUAL `↓Y`, under the
+-- identity conversion at the argument's own type.
+--
+-- BEFORE FRAME-EXACT BETA the contractum was `Λ (EW↑ ·[ … ])`: the
+-- shifted value with NOTHING recording that ΛY's slot is not its.  Its
+-- frame at that position was `Y Λ-bound , ⌷[X := ℕ]` (`E-int` below) — one
+-- entry MORE than the frame it was born in.  Harmless via indices (its
+-- shifted names cannot reach slot 0) but not EXACT; every other rule in
+-- the table is exact, and this is the one Jeremy asked to close.  The run
+-- is 6 steps now, against 5 before: the extra layer is consumed by a
+-- second TyPeelR.
 
 EW↑ : Term
 EW↑ = Earg ⟪ morph [] (lock 1 ∷ []) , Eid∀ ⟫
@@ -2620,20 +2793,29 @@ EW↑ = Earg ⟪ morph [] (lock 1 ∷ []) , Eid∀ ⟫
 _ : ⇑ᴹ EW ≡ EW↑
 _ = refl
 
-_ : Ebody [ EW ]ᵐ ≡ Λ (EW↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])
+EW↑↑ : Term                      -- … and the wrapper ΛY's dual adds
+EW↑↑ = EW↑ ⟪ morph [] (lock 0 ∷ []) , Eid∀ ⟫
+
+-- `EID` is a CLOSED type, so `⇑ᵗ EID ≡ EID` and the minted identity
+-- conversion is the one the run already uses: `mkId EID ≡ Eid∀`.
+_ : mkId EID ≡ Eid∀
+_ = refl
+
+_ : Ebody [ EW ∶ EID ]ᵐ ≡ Λ (EW↑↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])
 _ = refl
 
 E₃ : Term
-E₃ = (Λ (EW↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])) ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
+E₃ = (Λ (EW↑↑ ·[ ` 0 ⇒ ` 0 , ` 0 ])) ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₃ : [] ⊢ E₂ -→ E₃
 estep₃ = ξ-⟪⟫ (Beta val-EW)
 
 -- ── THE STEP THE OLD DESIGN DIED ON ────────────────────────────────────
 --
--- E₃'s inner redex is `EW↑ ·[ ` 0 ⇒ ` 0 , ` 0 ]`: the crossed value,
+-- E₃'s inner redex is `EW↑↑ ·[ ` 0 ⇒ ` 0 , ` 0 ]`: the crossed value,
 -- type-applied to the Λ-bound Y — a variable bound AFTER the boundary
--- was born.  Here are the two type contexts, at that redex.
+-- was born.  Here are the two type contexts, at THE SHIFTED VALUE's
+-- position — i.e. one layer in, inside the dual wrapper.
 
 EΔ₃ : Ctxᵗ                       -- the ambient: Y abstract, X := ℕ
 EΔ₃ = unmasked abst ∷ unmasked (bind `ℕ) ∷ []
@@ -2641,84 +2823,139 @@ EΔ₃ = unmasked abst ∷ unmasked (bind `ℕ) ∷ []
 _ : interior (morph (`ℕ ∷ []) []) [] ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
-E-int E-ext : Ctxᵗ
-E-int = interior (morph [] (lock 1 ∷ [])) EΔ₃
-E-ext = convCtx (morph [] (lock 1 ∷ [])) EΔ₃
-
--- THE INTERIOR IS THE EXTERIOR WITH X MASKED — NOT TRUNCATED.  The old
--- design's interior at this point was Γ↓X = ∅.  RENDERED
+-- (a) THE FRAME THE DUAL WRAPPER GIVES THE PLANTED VALUE.  This is the
+-- frame identity of strong.TermSubst §5b at this point: the exterior with
+-- ΛY's slot MASKED — i.e. the value's BIRTH frame `X := ℕ`, one masked
+-- entry in.  Nothing gained, nothing lost.  RENDERED
 -- (`showTCtxAt 99 0 (λ { 0 → "Y" ; _ → "X" })`, so that the names agree
 -- with the trace above):
 --
---   E-int   Y Λ-bound , ⌷[X := ℕ]
---   E-ext   Y Λ-bound , X := ℕ
+--   E-dual-int   ⌷[Y Λ-bound] , X := ℕ
+--   E-dual-ext   Y Λ-bound , X := ℕ
+E-dual-int E-dual-ext : Ctxᵗ
+E-dual-int = interior (morph [] (lock 0 ∷ [])) EΔ₃
+E-dual-ext = convCtx  (morph [] (lock 0 ∷ [])) EΔ₃
+
+_ : E-dual-int ≡ masked abst ∷ unmasked (bind `ℕ) ∷ []
+_ = refl
+
+_ : E-dual-ext ≡ EΔ₃
+_ = refl
+
+-- Y IS NOT NAMEABLE INSIDE, and that is the repair: the value was born
+-- before ΛY existed, and now the frame says so.  BEFORE FRAME-EXACT BETA
+-- the value sat at `EΔ₃` itself, where Y IS nameable — sound (its shifted
+-- indices cannot reach slot 0) but one entry wider than its birth frame.
+E-Y-not-inside : ¬ (E-dual-int ⊢ᵗ ` 0)
+E-Y-not-inside (wf-var (_ , ez , ()))
+
+-- (b) AND INSIDE THE VALUE'S OWN (Peel-minted) WRAPPER: the exterior with
+-- X masked too — NOT TRUNCATED.  The old design's interior at this point
+-- was Γ↓X = ∅.
 --
-_ : E-int ≡ unmasked abst ∷ masked (bind `ℕ) ∷ []
+--   E-int   ⌷[Y Λ-bound] , ⌷[X := ℕ]
+--   E-ext   ⌷[Y Λ-bound] , X := ℕ
+E-int E-ext : Ctxᵗ
+E-int = interior (morph [] (lock 1 ∷ [])) E-dual-int
+E-ext = convCtx  (morph [] (lock 1 ∷ [])) E-dual-int
+
+_ : E-int ≡ masked abst ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
-_ : E-ext ≡ EΔ₃
+_ : E-ext ≡ E-dual-int
 _ = refl
 
--- Y is still nameable inside …
-E-Y-inside : E-int ⊢ᵗ ` 0
-E-Y-inside = wf-var (unmasked abst , ez , nameable)
-
--- … and X still is not: the mask does its job.
+-- X still is not nameable: the mask does its job.
 E-X-hidden : ¬ (E-int ⊢ᵗ ` 1)
 E-X-hidden (wf-var (_ , es ez , ()))
 
--- ── STEP 4 — TYPEELR, under ξ-Λ.  The type argument Y is NOT pushed into
--- the crossed body; it is recorded as a NEW BIND, `bind (` 0)`, and the
--- interior is instantiated at that bind's own name.  The conversion's
--- abstract slot becomes the fresh binder, so each identity leaf becomes
--- the instantiation step.
+-- ── STEP 4 — TYPEELR, under ξ-Λ, ON THE DUAL WRAPPER.  The type argument
+-- Y is NOT pushed into the crossed body; it is recorded as a NEW BIND,
+-- `bind (` 0)`, and the interior is instantiated at that bind's own name.
+-- The conversion's abstract slot becomes the fresh binder, so each
+-- identity leaf becomes the instantiation step.
+--
+-- IT IS NOW THE OUTER (Beta-minted) WRAPPER THAT PEELS FIRST — its
+-- conversion is `mkId EID = Eid∀`, a `` `∀ `` — and the value's own
+-- Peel-minted wrapper peels in step 5.  Y is read where the BIND is
+-- recorded, on the wrapper's conversion context `E-dual-ext`, where it is
+-- nameable; it never has to be nameable inside.
 
 E-convCtx : Ctxᵗ
-E-convCtx = unmasked abst ∷ convCtx (morph [] (lock 1 ∷ [])) EΔ₃
+E-convCtx = unmasked abst ∷ convCtx (morph [] (lock 0 ∷ [])) EΔ₃
 
-⊢Es : E-convCtx ⊢ id (` 0) ↦ id (` 0) ∶ (` 0 ⇒ ` 0) ⇝ (` 0 ⇒ ` 0)
+-- the conversion premise, at ANY conversion context: both leaves read the
+-- ∀-bound slot 0, which is `abst` wherever the `` `∀ `` is.
+⊢Es : ∀ {Δ} → (unmasked abst ∷ Δ)
+    ⊢ id (` 0) ↦ id (` 0) ∶ (` 0 ⇒ ` 0) ⇝ (` 0 ⇒ ` 0)
 ⊢Es = conv-fun (conv-idv (unmasked abst , ez , nameable))
                (conv-idv (unmasked abst , ez , nameable))
+
+_ : E-convCtx ⊢ id (` 0) ↦ id (` 0) ∶ (` 0 ⇒ ` 0) ⇝ (` 0 ⇒ ` 0)
+_ = ⊢Es
 
 _ : instReveal 0 (id (` 0) ↦ id (` 0)) ≡ seal 0 ↦ unseal 0
 _ = refl
 
+EW↑₂ : Term                      -- the value, moved past TyPeelR's binder
+EW↑₂ = Earg ⟪ morph [] (lock 2 ∷ []) , Eid∀ ⟫
+
+_ : wkᴹ 1 EW↑ ≡ EW↑₂
+_ = refl
+
 E₄ : Term
-E₄ = (Λ ((Earg ·[ ` 0 ⇒ ` 0 , ` 0 ])
-           ⟪ morph ((` 0) ∷ []) (lock 1 ∷ []) , seal 0 ↦ unseal 0 ⟫))
+E₄ = (Λ ((EW↑₂ ·[ ` 0 ⇒ ` 0 , ` 0 ])
+           ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , seal 0 ↦ unseal 0 ⟫))
        ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₄ : [] ⊢ E₃ -→ E₄
-estep₄ = ξ-⟪⟫ (ξ-Λ (TyPeelR (V-Λ V-ƛ) ⊢Es))
+estep₄ = ξ-⟪⟫ (ξ-Λ (TyPeelR (V-⟪⟫ (V-Λ V-ƛ) I-all) ⊢Es))
 
--- ── STEP 5 — TYBETA, inside.  The ΛZ is consumed against the bind
+-- ── STEP 5 — TYPEELR AGAIN, one layer in: the value's OWN Peel-minted
+-- wrapper.  THIS IS THE STEP FRAME-EXACT BETA ADDS, and it is the step
+-- the old design died on: the crossed value type-applied to a variable
+-- bound after the boundary was born.
+
+E₅ : Term
+E₅ = (Λ (((Earg ·[ ` 0 ⇒ ` 0 , ` 0 ])
+            ⟪ morph ((` 0) ∷ []) (lock 2 ∷ []) , seal 0 ↦ unseal 0 ⟫)
+           ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , seal 0 ↦ unseal 0 ⟫))
+       ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
+
+estep₅ : [] ⊢ E₄ -→ E₅
+estep₅ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (TyPeelR (V-Λ V-ƛ) ⊢Es)))
+
+-- ── STEP 6 — TYBETA, inside.  The ΛZ is consumed against the bind
 -- TyPeelR just made, and the result is a VALUE.
 
 _ : reveal 0 (` 0 ⇒ ` 0) ≡ seal 0 ↦ unseal 0
 _ = refl
 
-E₅ : Term
-E₅ = (Λ (((ƛ (` 0) ∙ (` 0)) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ unseal 0 ⟫)
-           ⟪ morph ((` 0) ∷ []) (lock 1 ∷ []) , seal 0 ↦ unseal 0 ⟫))
+E₆ : Term
+E₆ = (Λ ((((ƛ (` 0) ∙ (` 0)) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ unseal 0 ⟫)
+             ⟪ morph ((` 0) ∷ []) (lock 2 ∷ []) , seal 0 ↦ unseal 0 ⟫)
+            ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , seal 0 ↦ unseal 0 ⟫))
        ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
-estep₅ : [] ⊢ E₄ -→ E₅
-estep₅ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (TyBeta V-ƛ)))
+estep₆ : [] ⊢ E₅ -→ E₆
+estep₆ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (ξ-⟪⟫ (TyBeta V-ƛ))))
 
-val-E₅ : Value E₅
-val-E₅ = V-⟪⟫ (V-Λ (V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun)) I-all
+val-E₆ : Value E₆
+val-E₆ =
+  V-⟪⟫ (V-Λ (V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun) I-fun)) I-all
 
-run-E : [] ⊢ E₀ -→* E₅
-run-E = estep₁ then estep₂ then estep₃ then estep₄ then estep₅ then done
+run-E : [] ⊢ E₀ -→* E₆
+run-E = estep₁ then estep₂ then estep₃ then estep₄ then estep₅
+    then estep₆ then done
 
--- … and the generated run agrees, step 4 (the one the OLD design died on)
--- included.
-_ : evalTerms 5 ⊢E₀ ≡ E₀ ∷ E₁ ∷ E₂ ∷ E₃ ∷ E₄ ∷ E₅ ∷ []
+-- … and the generated run agrees, the step the OLD design died on (now
+-- step 5) included.
+_ : evalTerms 6 ⊢E₀ ≡ E₀ ∷ E₁ ∷ E₂ ∷ E₃ ∷ E₄ ∷ E₅ ∷ E₆ ∷ []
 _ = refl
 
 -- THE ANSWER TYPES, at the source's own type ∀Y. Y ⇒ Y.
-⊢E₅ : [] ∣ [] ⊢ E₅ ⦂ EID
-⊢E₅ = preservation* ⊢E₀ run-E
+⊢E₆ : [] ∣ [] ⊢ E₆ ⦂ EID
+⊢E₆ = preservation* ⊢E₀ run-E
 
 -- ── DETERMINISM PINS: the run above is THE run.
 
@@ -2736,6 +2973,9 @@ edet₄ st = det st estep₄
 
 edet₅ : ∀ {M′} → [] ⊢ E₄ -→ M′ → M′ ≡ E₅
 edet₅ st = det st estep₅
+
+edet₆ : ∀ {M′} → [] ⊢ E₅ -→ M′ → M′ ≡ E₆
+edet₆ st = det st estep₆
 
 ------------------------------------------------------------------------
 -- §15  TIGHTNESS, RULE BY RULE — JEREMY'S TEST APPLIED TO EVERY RULE
@@ -3075,7 +3315,7 @@ Rᵈ = (ƛ (`ℕ ⇒ `ℕ) ∙ (` 0)) · Wᵈ
 
 -- showTmIn 1 Cᵈ  =  (λx:ℕ. (ΛY. 3) [X])
 Cᵈ : Term
-Cᵈ = (` 0) [ Wᵈ ]ᵐ
+Cᵈ = (` 0) [ Wᵈ ∶ `ℕ ⇒ `ℕ ]ᵐ
 
 _ : Cᵈ ≡ Wᵈ
 _ = refl

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -33,16 +33,18 @@ module strong.Examples where
 -- §14 THE PRE-BOUNDARY COUNTEREXAMPLE: `E`, the closed program that
 --     refuted the per-variable design (v1's historical Example 8), run
 --     in v2 to a VALUE — the step that used to produce an ill-typed
---     term is `estep₄`, and `E-int`/`E-ext` are its two type contexts.
+--     term is `estep₅`, `E-dual-int`/`E-dual-ext` are the frame
+--     FRAME-EXACT BETA gives the crossed value, and `E-int`/`E-ext` the
+--     two type contexts inside its own Peel-minted wrapper.
 -- §15 TIGHTNESS, RULE BY RULE — Jeremy's test (proof/DualTightness)
 --     applied to EVERY rule that moves a subterm into a new frame:
 --     `TyBeta` (§15a), `TyPeelR` (§15b), `IdPush`/`CancelR` (§15c),
---     `Beta` (§15d, with the one expected exception — ERASURE),
---     `Peel`'s `bind` half and `hideBinds` (§15e; the `unlock` half is
---     proof/DualTightness).  Every redex below is ILL TYPED and every
---     contractum is REFUSED for the same localized reason.  §15f
---     collects the five frame identities that make the section a
---     theorem rather than five anecdotes.
+--     `Beta` (§15d, with the one expected exception — ERASURE; §15d₂ is
+--     the UNDER-Λ case frame-exact Beta added), `Peel`'s `bind` half and
+--     `hideBinds` (§15e; the `unlock` half is proof/DualTightness).
+--     Every redex below is ILL TYPED and every contractum is REFUSED for
+--     the same localized reason.  §15f collects the six frame identities
+--     that make the section a theorem rather than six anecdotes.
 --
 -- Every `_ : … ≡ …` in this file is a machine-checked frame computation.
 --
@@ -52,6 +54,21 @@ module strong.Examples where
 -- and the seven runs from closed or hand-built sources (§6 `P₀`,
 -- §11 `Q₀`, §12 `L₀`, §12b `Ri`, §13a `J₀`, §13b `H₀`, §14 `E₀`) each
 -- carry an `evalTerms n ⊢X₀ ≡ …` line that Agda checks by `refl`.
+--
+-- STEP COUNTS AFTER FRAME-EXACT BETA (2026-09-08).  A run changes length
+-- exactly where a `Beta` substitutes under a `Λ`, and then only because
+-- the minted transparent layer has to be walked through:
+--
+--   P₀  6 → 6    (the body is a bare variable: no Λ crossed)
+--   Q₀  9 → 11   (+1 IdPush, +1 Drop$)
+--   D₀  12 → 16  (two Λs crossed: +2 IdPush, +2 Drop$)
+--   R₀  18 → 21  (+1 IdPush, +1 CancelR, +1 Drop$)
+--   L₀  9 → 11   (+1 IdPush, +1 Drop$)
+--   Ri  2 → 2    (hand-built; no Beta)
+--   J₀  14 → 14  (the substituted variable sits under no Λ)
+--   H₀  4 → 4    (the layer lands inside a ƛ body, unevaluated)
+--   E₀  5 → 6    (+1 TyPeelR — §14's `estep₅`)
+--   G   5 → 5    (the layers land under the Λs, unevaluated)
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; _++_; length; map)
@@ -1678,10 +1695,10 @@ _ : evalTerms 6 ⊢R₀ ≡ R₀ ∷ R₁ ∷ R₂ ∷ R₃ ∷ R₄ ∷ R₅ �
 _ = refl
 
 -- The tail is a cascade of IdPushes (each residue conversion is ITSELF an
--- id-layer), two Cancels and six transparent layers over the numeral.  It
--- was 15 steps; with the extra layer frame-exact Beta interposes it is 15
--- from R₆ too — the wrapper is consumed by one of the IdPushes already in
--- the cascade — for 21 steps in all, against 20 before.  RENDERED
+-- id-layer), two Cancels and six transparent layers over the numeral —
+-- 15 steps from R₆, for 21 in all, against 18 before frame-exact Beta
+-- (the extra layer buys one more IdPush, one more CancelR and one more
+-- Drop$).  RENDERED
 -- (scripts/render_term.sh 'showTrace 0 (eval 21 ⊢R₀)'), the rule sequence
 -- is
 --
@@ -2682,10 +2699,10 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ uns
 --      at the fresh NAME `` ` 0 ``; that is why the boundary is a LIST —
 --      a context morphism — and not a single reveal-or-conceal.
 --
--- Below: the SAME closed program, in v2, run to a VALUE in five steps,
--- with every step pinned by `det`.  Step 4 is the one that used to die.
+-- Below: the SAME closed program, in v2, run to a VALUE in SIX steps,
+-- with every step pinned by `det`.  Step 5 is the one that used to die.
 --
--- RENDERED (scripts/render_term.sh, `showTmIn 0`):
+-- RENDERED (scripts/render_term.sh 'showTrace 0 (eval 6 ⊢E₀)'):
 --
 --  E₀  ((ΛX. (λx:(∀Y. (Y⇒Y)). (ΛY. x [Y]))) [ℕ] · (ΛZ. (λx:Z. x)))
 --  E₁  (((λx:(∀Y. (Y⇒Y)). (ΛY. x [Y]))
@@ -2694,19 +2711,39 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ uns
 --  E₂  (((λx:(∀Y. (Y⇒Y)). (ΛY. x [Y]))
 --         · ((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Y. (id Y ↦ id Y)) ⟫))
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+--  E₃  ((ΛY. (((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫)
+--               ⟪ ↓Y , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
+--        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+--  E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
+--               ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
+--        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+--  E₅  ((ΛY. (((ΛY′. (λx:Y′. x)) [X′]
+--                 ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
+--               ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
+--        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+--  E₆  ((ΛY. ((((λx:Y′. x) ⟪ ↑Y′:=X′ , (seal Y′ ↦ unseal Y′) ⟫)
+--                 ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
+--               ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
+--        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)                      -- a VALUE
+--
+-- THE `↓Y` IS FRAME-EXACT BETA'S (2026-09-08).  Before it, E₃ and E₄ read
+--
 --  E₃  ((ΛY. ((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
 --  E₄  ((ΛY. ((ΛX′. (λx:X′. x)) [Z] ⟪ ↑Z:=Y , ↓X , (seal Z ↦ unseal Z) ⟫))
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
---  E₅  ((ΛY. (((λx:X′. x) ⟪ ↑X′:=Z , (seal X′ ↦ unseal X′) ⟫)
---               ⟪ ↑Z:=Y , ↓X , (seal Z ↦ unseal Z) ⟫))
---        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)                      -- a VALUE
 --
--- E₃ is the old design's fourth line, and E₄ is where the two designs
--- part: `↑Z:=Y , ↓X` is a boundary that MASKS X and BINDS a fresh Z at
--- the rep Y — no type is pushed into the sealed body, and Y is read at
--- the boundary's exterior (there are no unlocks, so that is
--- `unlockedScope Θ Δ`), where it is in scope.
+-- — the crossed value planted under ΛY with NOTHING saying that ΛY's slot
+-- is not in its frame.  Now it carries ΛY's dual `↓Y`, the run peels the
+-- two wrappers in turn (steps 4 and 5), and it is six steps rather than
+-- five.
+--
+-- E₃ is the old design's fourth line, and E₄/E₅ are where the two designs
+-- part: `↑Z:=Y , ↓Y` and `↑X′:=Z , ↓X` are boundaries that MASK the outer
+-- name and BIND a fresh one at the rep the exterior offers — no type is
+-- pushed into the sealed body, and the rep is read at the boundary's
+-- exterior (there are no unlocks, so that is `unlockedScope Θ Δ`), where
+-- it is in scope.
 
 -- ── the source ─────────────────────────────────────────────────────────
 
@@ -3020,10 +3057,10 @@ val-prb = V-ƛ
 Δ✦ : Ctxᵗ
 Δ✦ = masked (bind `ℕ) ∷ []
 
--- THE TWO FRAME IDENTITIES THAT HAD NO NAME (§15f collects all five).
--- Both are `refl`: `interior Θ Δ` is `pushBinds (binds Θ) (scope Θ Δ)`
--- and a bind contributes to the BIND half alone, leaving `scope`
--- untouched.
+-- THE THREE FRAME IDENTITIES THAT HAD NO NAME (§15f collects all six).
+-- All three are `refl`: `interior Θ Δ` is `pushBinds (binds Θ) (scope Θ Δ)`,
+-- a bind contributes to the BIND half alone (leaving `scope` untouched),
+-- and a lone `lock 0` is one `maskEnt` at the head.
 interior-TyBeta : (A : Ty) (Δ : Ctxᵗ)
   → interior (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ
 interior-TyBeta A Δ = refl
@@ -3032,6 +3069,14 @@ interior-TyPeelR : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
   → interior (morph (A ∷ binds Θ) (changes Θ)) Δ
       ≡ unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ
 interior-TyPeelR A Θ Δ = refl
+
+-- FRAME-EXACT BETA'S OWN (2026-09-08, strong.TermSubst §5b): the wrapper
+-- an image acquires when it crosses a `Λ` is that binder's DUAL, and its
+-- interior is the image's BIRTH frame with the crossed slot masked.
+interior-Beta-Λ : (Δ : Ctxᵗ)
+  → interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ)
+      ≡ masked abst ∷ Δ
+interior-Beta-Λ Δ = refl
 
 ------------------------------------------------------------------------
 -- §15a  TYBETA — the mint.  `abst` REFINES to `bind`, and nothing else
@@ -3295,9 +3340,12 @@ stepᶜ′ = CancelR val-prb lkᶜ
 -- §15d  BETA — and the ONE EXPECTED EXCEPTION
 ------------------------------------------------------------------------
 
--- `Beta` changes no frame at all: `N [ W ]ᵐ` is read at the redex's own
--- `Δ`, so an argument the exterior refuses is refused wherever it lands.
--- The frame identity is the identity function.
+-- `Beta` changes no frame WHERE NO BINDER IS CROSSED: `N [ W ∶ A ]ᵐ` is
+-- read at the redex's own `Δ`, so an argument the exterior refuses is
+-- refused wherever it lands, and the frame identity is the identity
+-- function.  WHERE A `Λ` IS CROSSED the frame is not Δ but `masked abst ∷
+-- Δ` — `interior-Beta-Λ` above — which is EXACT rather than trivial, and
+-- is the case §15d₂ below runs.
 
 Wᵈ : Term
 Wᵈ = prb 0
@@ -3347,6 +3395,53 @@ stepᵈ′ = Beta val-prb
 
 ⊢Cᵈ′ : Δ✦ ∣ [] ⊢ ($ 3) ⦂ `ℕ
 ⊢Cᵈ′ = ⊢$
+
+------------------------------------------------------------------------
+-- §15d₂  BETA UNDER A Λ — THE FRAME-EXACT CASE
+------------------------------------------------------------------------
+
+-- THE CASE THE TEST HAD NO INSTANCE OF, because before 2026-09-08 there
+-- was nothing to test: the argument was SHIFTED under the Λ and read at
+-- the Λ's own frame, one entry WIDER than its birth frame.  Now it is
+-- wrapped in the crossed binder's DUAL, and the frame it is read at is
+-- `interior-Beta-Λ Δ✦` — Δ✦ with the crossed slot masked, i.e. exactly
+-- its birth frame.  The verdict is the one the test wants: the argument
+-- names a slot Δ✦ MASKS, and it is refused inside for that same reason.
+
+Nᵈ Rᵈ↑ Cᵈ↑ : Term
+Nᵈ  = Λ (` 0)                    -- ΛY. x — the body that crosses a Λ
+Rᵈ↑ = (ƛ (`ℕ ⇒ `ℕ) ∙ Nᵈ) · Wᵈ
+Cᵈ↑ = Nᵈ [ Wᵈ ∶ `ℕ ⇒ `ℕ ]ᵐ
+
+-- the contractum: the shifted probe under ΛY's dual, at the identity
+-- conversion its type gives (`mkId (`ℕ ⇒ `ℕ)`).
+_ : Cᵈ↑ ≡ Λ (prb 1 ⟪ morph [] (lock 0 ∷ []) , id `ℕ ↦ id `ℕ ⟫)
+_ = refl
+
+¬⊢Rᵈ↑ : ∀ {A} → ¬ (Δ✦ ∣ [] ⊢ Rᵈ↑ ⦂ A)
+¬⊢Rᵈ↑ (⊢· _ ⊢W) = ¬⊢Wᵈ ⊢W
+
+stepᵈ↑ : Δ✦ ⊢ Rᵈ↑ -→ Cᵈ↑
+stepᵈ↑ = Beta val-prb
+
+-- THE FRAME IDENTITY, at this Δ — W's BIRTH FRAME, SHIFTED, EXACT.
+_ : interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ✦)
+      ≡ masked abst ∷ Δ✦
+_ = interior-Beta-Λ Δ✦
+
+-- … so the shifted argument is refused inside, and for the SAME
+-- localized reason: slot 1 is the masked binder it names.
+¬⊢shiftWᵈ : ∀ {Γ A} → ¬ ((masked abst ∷ Δ✦) ∣ Γ ⊢ prb 1 ⦂ A)
+¬⊢shiftWᵈ (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
+
+¬⊢Cᵈ↑ : ∀ {A} → ¬ (Δ✦ ∣ [] ⊢ Cᵈ↑ ⦂ A)
+¬⊢Cᵈ↑ (⊢Λ (env _ ⊢W _ _)) = ¬⊢shiftWᵈ ⊢W
+
+-- AND THE CROSSED Λ'S OWN SLOT IS NOT NAMEABLE INSIDE EITHER — which is
+-- what "the frame gained nothing" means, stated as a refusal.
+¬∋tv-crossΛ : ¬ (interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ✦)
+                   ∋tv 0)
+¬∋tv-crossΛ (_ , ez , ())
 
 ------------------------------------------------------------------------
 -- §15e  PEEL — the `bind` half, and `hideBinds`
@@ -3468,14 +3563,25 @@ _ = refl
 --   IdPush     ≡ interior Θ₁ (interior Θ₂ Δ)                 (Δ ⊢ᵐ Θ₂)
 --              — proof/MoveScope.interior-⋉-rewind: preserved ON THE
 --                NOSE, which is why neither case uses `⊢retag`
---   Beta     Δ ≡ Δ — no frame changes; the exception is ERASURE (§15d)
+--   Beta     Δ ≡ Δ where no binder is crossed; the exception is ERASURE
+--              (§15d)
+--   Beta,    interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ)
+--   under Λ    ≡ masked abst ∷ Δ
+--              — `interior-Beta-Λ`: the image's BIRTH frame with the
+--                crossed Λ's slot masked.  This is the identity
+--                frame-exact Beta buys (2026-09-08); before it the image
+--                was read at `unmasked abst ∷ Δ`, one entry WIDER than
+--                the frame it was born in — sound, because its shifted
+--                indices cannot reach slot 0, but not exact.  §15d₂ runs
+--                the test on it.
 --
 -- `Drop$` and the five congruences move nothing into a new frame:
 -- `Drop$`'s contractum is a numeral, and each `ξ` rule reduces a
 -- subterm IN PLACE, at the frame the rule's own premise reads it on.
 --
--- The two identities that had no name are `interior-TyBeta` and
--- `interior-TyPeelR` at the head of this section; both are `refl`,
+-- The three identities that had no name are `interior-TyBeta`,
+-- `interior-TyPeelR` and `interior-Beta-Λ` at the head of this section;
+-- all three are `refl`,
 -- because `interior` is `pushBinds ∘ binds` over `scope` and a bind
 -- entry touches `scope` not at all.  The other two are theorems with
 -- a `Δ ⊢ᵐ Θ` premise, and that premise is exactly where the sequential

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -11,7 +11,9 @@ module strong.Examples where
 --     n4) and the shape-IV survivor E★′: they type, they CROSS, and their
 --     contracta are TYPED.
 -- §6  the first end-to-end run from a CLOSED, PLAIN source program.
--- §7  two regressions on substᵐ; §8 progress on §6; §9 preservation on §6.
+-- §7  three regressions on substᵐ (the Λ clause, the ƛ clause, and what
+--     the Λ-crossing wrapper costs at a base type); §8 progress on §6;
+--     §9 preservation on §6.
 -- (§10 is GONE.  It held the reachability verdict for the old IdPush
 --     contractum's scoping side-condition; the scope move (strong.Reduction
 --     §2b) removed the side-condition, and the invariant hunt behind it is
@@ -911,7 +913,7 @@ _ : evalTerms 6 ⊢P₀ ≡ P₀ ∷ P₁ ∷ P₂ ∷ P₃ ∷ P₄ ∷ P₅ �
 _ = refl
 
 ------------------------------------------------------------------------
--- §7  Two regressions on substᵐ itself
+-- §7  Three regressions on substᵐ itself
 ------------------------------------------------------------------------
 
 -- ── the Λ clause: an image crossing a Λ is SHIFTED AND WRAPPED ─────────
@@ -970,6 +972,40 @@ _ = refl
 _ : [] ∣ [] ⊢ (ƛ `ℕ ∙ (` 1)) [ ƛ `ℕ ∙ (` 0) ∶ `ℕ ⇒ `ℕ ]ᵐ
       ⦂ (`ℕ ⇒ (`ℕ ⇒ `ℕ))
 _ = ⊢subst (wf-⇒ wf-ℕ wf-ℕ) (⊢ƛ wf-ℕ (⊢` (there here))) (⊢ƛ wf-ℕ (⊢` here))
+
+-- ── WHAT THE WRAPPER COSTS AT A BASE TYPE ──────────────────────────────
+-- `mkId` is INERT at a variable, a function type and a `` `∀ `` — there
+-- the wrapper is a VALUE (`V-⟪⟫ … I-idv` / `I-fun` / `I-all`).  At a BASE
+-- type it is `id ℕ`, which is ACTIVE, so the wrapper is NOT a value and
+-- `Drop$` finishes it in one step.  That is the whole price of
+-- frame-exactness at a base-typed argument, and progress is not disturbed
+-- by it: a closed value at `ℕ` is a numeral (no inert conversion targets a
+-- base type), so `Drop$` always applies.
+
+Bᵍ Cᵍ : Term
+Bᵍ = (ƛ `ℕ ∙ (Λ (` 0))) · ($ 7)
+Cᵍ = (Λ (` 0)) [ $ 7 ∶ `ℕ ]ᵐ
+
+_ : Cᵍ ≡ Λ (($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫)
+_ = refl
+
+⊢Bᵍ : [] ∣ [] ⊢ Bᵍ ⦂ `∀ `ℕ
+⊢Bᵍ = ⊢· (⊢ƛ wf-ℕ (⊢Λ (⊢` here))) ⊢$
+
+-- neither the redex's contractum nor `Λ ($ 7)` is reached by one step:
+-- the run is Beta then Drop$, and `Λ ($ 7)` is the value.
+_ : evalTerms 2 ⊢Bᵍ ≡ Bᵍ ∷ Cᵍ ∷ Λ ($ 7) ∷ []
+_ = refl
+
+val-Λ$ : Value (Λ ($ 7))
+val-Λ$ = V-Λ V-$
+
+-- the wrapper itself is NOT a value, and this is the step it takes
+¬val-Cᵍ-in : ¬ Value (($ 7) ⟪ morph [] (lock 0 ∷ []) , id `ℕ ⟫)
+¬val-Cᵍ-in (V-⟪⟫ _ ())
+
+stepᵍ : [] ⊢ Cᵍ -→ Λ ($ 7)
+stepᵍ = ξ-Λ (Drop$ base-ℕ)
 
 ------------------------------------------------------------------------
 -- §8  PROGRESS, on the run of §6

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -73,7 +73,7 @@ open import strong.Ctx
 open import strong.Conversion
   using (Conv; id; seal; unseal; _↦_; `∀; mkId; _⊢_∶_⇝_; reveal; instReveal)
 open import strong.Terms
-open import strong.TermSubst using (_[_]ᵐ; wkᴹ; preserve-Beta)
+open import strong.TermSubst using (_[_∶_]ᵐ; wkᴹ; preserve-Beta)
 open import strong.Reduction using (_⊢_-→_; _⊢_-→*_)
 
 open import strong.CtxMorph
@@ -137,11 +137,14 @@ preservation-TyBeta : ∀ {A}
   → Δ ∣ [] ⊢ N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫ ⦂ C
 preservation-TyBeta = preserve-TyBeta
 
--- BETA — the ordinary β step, i.e. the substitution lemma.
+-- BETA — the ordinary β step, i.e. the substitution lemma, now
+-- FRAME-EXACT: the substitution carries the argument's type, and every
+-- image that crosses a `Λ` in the body is wrapped in that binder's dual
+-- (strong.TermSubst §5b, `⊢crossΛ`).
 preservation-Beta : ∀ {W}
   → Δ ∣ [] ⊢ (ƛ A ∙ N) · W ⦂ C
     --------------------------
-  → Δ ∣ [] ⊢ N [ W ]ᵐ ⦂ C
+  → Δ ∣ [] ⊢ N [ W ∶ A ]ᵐ ⦂ C
 preservation-Beta = preserve-Beta
 
 -- DROP$ — an identity boundary at a base type, over a numeral.

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -40,12 +40,21 @@ no holes**, under `agda --safe`:
 Beyond the six, the development carries a **tightness** result about the
 reduction relation itself — reduction never takes a term the exterior
 refuses to one it accepts (design law 2, `Design.md` §8).  It is not a
-theorem statement but a rule-by-rule check backed by five frame
+theorem statement but a rule-by-rule check backed by six frame
 identities: `proof/DualTightness` for `Peel`'s `unlock` half, `Examples`
 §15 for every other rule that moves a subterm into a new frame, and the
 frame-identity table in `Design.md` §7.  Every rule passes; the one
 recorded exception, `Beta` at an *erasing* body, is a dropped argument
 rather than a scope gain.
+
+Since 2026-09-08 the identities are also **exact**, not merely sound:
+`Beta` used to plant its argument under a `Λ` by shifting it, which left
+the argument's frame one entry wider than the frame it was born in.  It
+now wraps every image that crosses a `Λ` in that binder's DUAL —
+`⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫`, the same shape `Peel` mints —
+so the substitution carries the argument's type (`N [ W ∶ A ]ᵐ`) and the
+frame identity `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡
+masked abst ∷ Δ` holds by `refl` (`Design.md` §6.2, `Examples` §15d₂).
 
 The gate, run **cold**, from `SystemF/agda`:
 
@@ -70,7 +79,7 @@ driver: type-checking it type-checks the whole thing.
 | `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
 | `CtxMorph.agda` | the context morphism as a **pair** — `record CtxMorph = morph (binds : List Ty) (changes : List Change)`, the binds a PARALLEL block and the changes a SEQUENTIAL `lock`/`unlock` list — with `numBinds`, the type contexts it induces (`applyChanges`/`applyUnlocks` at the list, `scope`/`unlockedScope`/`interior`/`convCtx` at the morphism) and their refinement transports, the well-formedness judgement `Δ ⊢ᵐ Θ` as a pair of halves (`_⊢ʳ_` reps, `_⊢ˢ_` changes), and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
-| `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), term substitution, `⊢subst`, `preserve-Beta` |
+| `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), FRAME-EXACT term substitution (`Img`, `crossΛ`, `substᵐ`, `_[_∶_]ᵐ`), `⊢weakenⁿ`, `⊢crossΛ`, `⊢substᵐ`, `⊢subst`, `preserve-Beta` |
 | `Reduction.agda` | the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
 | `Progress.agda` | the statement `Progress` and `progress`, a one-line wrapper around `proof.Progress.progress` |
 | `Preservation.agda` | `preservation` / `preservation*` as `proof.Preserve.Impl` instantiated at the three downstream cases, plus the per-rule statements and `⊢ᵗ-of-closed` |

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -55,8 +55,16 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   TyBeta : ∀ {Δ B A N} → Value N
     → Δ ⊢ (Λ N) ·[ B , A ] -→ N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫
 
+  -- BETA, FRAME-EXACT (2026-09-08).  The substitution CARRIES THE
+  -- ARGUMENT'S TYPE — the ƛ's own annotation A — because every image that
+  -- crosses a `Λ` in the body is wrapped in that binder's DUAL with an
+  -- IDENTITY conversion at the argument's type (strong.TermSubst §5b).
+  -- Shifting alone (the old `N [ W ]ᵐ`) was sound but not frame-exact: the
+  -- argument's frame silently gained the Λ's slot.  Determinism is
+  -- unaffected — A is read off the redex, so the contractum is still a
+  -- function of the redex alone.
   Beta : ∀ {Δ A N W} → Value W
-    → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ]ᵐ
+    → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ∶ A ]ᵐ
 
   -- PEEL — the crossing.  The application is pushed in one layer and the
   -- argument acquires the DUAL.  `s`/`t` are literally ↦'s components: the

--- a/SystemF/agda/strong/TermSubst.agda
+++ b/SystemF/agda/strong/TermSubst.agda
@@ -14,7 +14,7 @@ module strong.TermSubst where
 --             because nothing on the type context is ever destroyed.
 --
 -- §5 defines term-variable renaming (`renⁿ`) and substitution (`substᵐ`,
--- `_[_]ᵐ`); §6 proves them sound (`⊢renⁿ`, `⊢substᵐ`, `⊢subst`), which is
+-- `_[_∶_]ᵐ`); §6 proves them sound (`⊢renⁿ`, `⊢substᵐ`, `⊢subst`), which is
 -- what Beta's preservation case consumes (`preserve-Beta`).  TWO CASES carry
 -- the whole story:
 --
@@ -24,10 +24,16 @@ module strong.TermSubst where
 --          and the case is literally the premises handed back.
 --
 --   ⊢Λ     is the only real work — it types its body at the SHIFTED term
---          context ⤊ Γ, so every image of σ must be shifted past the new
---          Λ-bound slot by ⇑ᴹ = renᴹ suc.  That is `⊢rename` at suc, with
---          `Ren-wk` and `Inj-suc`; no knowledge premise appears, because a
---          boundary carries NAMES, never spellings.
+--          context ⤊ Γ, so every image of σ must cross the new Λ-bound
+--          slot.  SHIFTING BY ⇑ᴹ = renᴹ suc IS NOT ENOUGH: it is sound but
+--          not FRAME-EXACT (the image's frame gains the Λ's slot).  §5b
+--          repairs it — a value image is WRAPPED IN THE BINDER'S DUAL
+--          `⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫`, whose frame
+--          identity `interior … (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` is
+--          DEFINITIONAL — and the case is then `⊢rename` at suc with
+--          `Ren-wk`/`Inj-suc` plus `mkId-⊢` (`⊢crossΛ`, §6).  No knowledge
+--          premise appears, because a boundary carries NAMES, never
+--          spellings.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; map; length)
@@ -248,27 +254,92 @@ renⁿ ρ (M ⟪ Θ , c ⟫)  = M ⟪ Θ , c ⟫
 shiftᵐ : Term → Term
 shiftᵐ = renⁿ suc
 
-extᵐ : (ℕ → Term) → (ℕ → Term)
-extᵐ σ zero    = ` zero
-extᵐ σ (suc x) = shiftᵐ (σ x)
+------------------------------------------------------------------------
+-- 5b.  THE IMAGES OF A SUBSTITUTION — FRAME-EXACT AT EVERY BINDER
+------------------------------------------------------------------------
 
--- THE Λ CLAUSE.  `⊢Λ` types its body at the SHIFTED term context ⤊ Γ, so
--- an image of σ — a term whose annotations, boundary reps and conversion
--- names are written over the EXTERIOR type context — must be shifted
--- past the new Λ-bound slot before it may be planted inside.  (Same
--- clause as v1's `substᵀᵐ`; v2's ⊢Λ shifts Γ exactly as v1's did.)
-substᵐ : (ℕ → Term) → Term → Term
-substᵐ σ (` x)          = σ x
+-- FRAME-EXACT SUBSTITUTION (Jeremy, 2026-09-08).  THE GAP THIS CLOSES.
+--
+-- The old Λ clause was `substᵐ (λ x → ⇑ᴹ (σ x))`: an image was SHIFTED
+-- past the new Λ-bound slot and nothing else.  Shifting is enough for
+-- SOUNDNESS — the image's shifted indices cannot reach slot 0 — but it is
+-- not FRAME-EXACT: the image's frame silently GAINS the Λ's slot, so at
+-- Examples §14's E₃ the crossing wrapper `(ΛZ. λz:Z. z) ⟪ ↓X , … ⟫`,
+-- planted under `ΛY`, was read at `Y Λ-bound , ⌷[X := ℕ]` — one entry
+-- MORE than its birth frame.  Every other rule is exact (`interior-dual`
+-- for Peel, `interior-⋉-rewind` for CancelR/IdPush, TyBeta/TyPeelR by
+-- construction); Beta was the one inexact rule.
+--
+-- THE REPAIR: what crosses a binder is WRAPPED IN THE BINDER'S DUAL.
+-- Crossing a `Λ` is crossing an abst binder that occupies slot 0 inside,
+-- so the dual of the crossing is `morph [] (lock 0 ∷ [])` — no binds, one
+-- lock, exactly what `dual (morph (A ∷ []) [])` is (Examples §11) — and
+-- the conversion is the IDENTITY at the value's own type, shifted past the
+-- binder.  The frame identity is then DEFINITIONAL:
+--
+--   interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ
+--
+-- i.e. the image's frame IS ITS BIRTH FRAME Δ, with the crossed binder
+-- masked: nothing gained, nothing lost.  It is the same shape `Peel`
+-- mints for its crossing argument, so it is proved by the same two
+-- moves — `⊢rename` at `suc` for the interior, `mkId-⊢` for the
+-- conversion.
+--
+-- SUBSTITUTION MUST THEREFORE CARRY THE VALUE'S TYPE (`mkId` needs it),
+-- and it may only wrap a TERM-CLOSED image ((env) types its interior at
+-- Γ = []).  Both facts live in the IMAGE:
+--
+--   ivar x    a term VARIABLE — the identity part of the substitution.
+--             It crosses a Λ untouched (a type binder does not move a
+--             term index) and is never wrapped: a variable is not
+--             term-closed, so `env` would refuse it.
+--   ival W A  the substituted VALUE, at its type.  It is term-CLOSED
+--             (`⊢ival`), which is what makes both the wrapper and the
+--             weakening below legal.
+data Img : Set where
+  ivar : ℕ → Img
+  ival : Term → Ty → Img
+
+imgTm : Img → Term
+imgTm (ivar x)   = ` x
+imgTm (ival W A) = W
+
+-- Weakening an image by one TERM variable.  A value image is CLOSED, so
+-- `shiftᵐ` would be the identity on it and is not applied — which is
+-- exactly why `shiftᴵ-⊢` (§6) has no premise to discharge.
+shiftᴵ : Img → Img
+shiftᴵ (ivar x)   = ivar (suc x)
+shiftᴵ (ival W A) = ival W A
+
+-- THE Λ CROSSING, AS A TERM: the shifted value under the DUAL of the
+-- binder it crossed, with an identity conversion at its own type.
+crossΛ : Term → Ty → Term
+crossΛ W A = ⇑ᴹ W ⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫
+
+-- THE Λ CLAUSE, frame-exact.  A variable image is untouched; a value
+-- image is shifted AND WRAPPED, and its annotation shifts with it.
+⇑ᴵ : Img → Img
+⇑ᴵ (ivar x)   = ivar x
+⇑ᴵ (ival W A) = ival (crossΛ W A) (⇑ᵗ A)
+
+extᴵ : (ℕ → Img) → (ℕ → Img)
+extᴵ σ zero    = ivar zero
+extᴵ σ (suc x) = shiftᴵ (σ x)
+
+substᵐ : (ℕ → Img) → Term → Term
+substᵐ σ (` x)          = imgTm (σ x)
 substᵐ σ ($ n)          = $ n
-substᵐ σ (ƛ A ∙ N)      = ƛ A ∙ substᵐ (extᵐ σ) N
+substᵐ σ (ƛ A ∙ N)      = ƛ A ∙ substᵐ (extᴵ σ) N
 substᵐ σ (L · M)        = substᵐ σ L · substᵐ σ M
-substᵐ σ (Λ N)          = Λ (substᵐ (λ x → ⇑ᴹ (σ x)) N)
+substᵐ σ (Λ N)          = Λ (substᵐ (λ x → ⇑ᴵ (σ x)) N)
 substᵐ σ (L ·[ B , A ]) = substᵐ σ L ·[ B , A ]
 substᵐ σ (M ⟪ Θ , c ⟫)  = M ⟪ Θ , c ⟫
 
-infix 8 _[_]ᵐ
-_[_]ᵐ : Term → Term → Term
-N [ W ]ᵐ = substᵐ (λ { zero → W ; (suc x) → ` x }) N
+-- BETA'S SUBSTITUTION.  The type is the ƛ's own annotation, so the rule
+-- reads it off the redex (strong.Reduction, `Beta`).
+infix 8 _[_∶_]ᵐ
+_[_∶_]ᵐ : Term → Term → Ty → Term
+N [ W ∶ A ]ᵐ = substᵐ (λ { zero → ival W A ; (suc x) → ivar x }) N
 
 ------------------------------------------------------------------------
 -- 6.  THE SUBSTITUTION TYPING LEMMA
@@ -326,53 +397,134 @@ extⁿ-∋ h (there d) = there (h d)
 Ren-wk : ∀ {Δ E} → Ren suc Δ (E ∷ Δ)
 Ren-wk = mkRen es
 
--- Pushing a term substitution under a Λ.  Every image is shifted by ⇑ᴹ,
--- which is `⊢rename` at ρ = suc — `Ren-wk` for the entry transport and
--- `Inj-suc` for the ONE structural hypothesis (positional masking).  No
--- knowledge premise is needed: a name is carried, never a spelling.
-⇑ᴹ-⊢ : ∀ {σ : ℕ → Term} {Δ Γ Γ′}
-  → (∀ {x B} → Γ ∋ x ⦂ B → Δ ∣ Γ′ ⊢ σ x ⦂ B)
-    --------------------------------------------------------------------
-  → (∀ {x B} → ⤊ Γ ∋ x ⦂ B → (unmasked abst ∷ Δ) ∣ ⤊ Γ′ ⊢ ⇑ᴹ (σ x) ⦂ B)
-⇑ᴹ-⊢ h d with ∋⦂-map⁻ d
-... | A , refl , q = ⊢rename Ren-wk Inj-suc (h q)
+-- Term-variable renaming AT THE IDENTITY renaming is the identity.  This
+-- is what makes the CLOSED-TERM weakening below a corollary of `⊢renⁿ`
+-- rather than a second induction.
+renⁿ-id : (ρ : ℕ → ℕ) → (∀ x → ρ x ≡ x) → (M : Term) → renⁿ ρ M ≡ M
+renⁿ-id ρ h (` x)          = cong `_ (h x)
+renⁿ-id ρ h ($ n)          = refl
+renⁿ-id ρ h (ƛ A ∙ N)      = cong (ƛ A ∙_) (renⁿ-id (extⁿ ρ) hext N)
+  where
+  hext : (x : ℕ) → extⁿ ρ x ≡ x
+  hext zero    = refl
+  hext (suc x) = cong suc (h x)
+renⁿ-id ρ h (L · M)        = cong₂ _·_ (renⁿ-id ρ h L) (renⁿ-id ρ h M)
+renⁿ-id ρ h (Λ N)          = cong Λ_ (renⁿ-id ρ h N)
+renⁿ-id ρ h (L ·[ B , A ]) = cong (λ L′ → L′ ·[ B , A ]) (renⁿ-id ρ h L)
+renⁿ-id ρ h (M ⟪ Θ , c ⟫)  = refl
 
-extᵐ-⊢ : ∀ {σ : ℕ → Term} {Δ Γ Γ′ A}
-  → (∀ {x B} → Γ ∋ x ⦂ B → Δ ∣ Γ′ ⊢ σ x ⦂ B)
+-- A TERM-CLOSED term types at ANY term context.  The hypothesis of
+-- `⊢renⁿ` is vacuous at Γ = [] — there is no lookup to move — so the
+-- lemma is `⊢renⁿ` at the identity renaming.
+⊢weakenⁿ : ∀ {Δ Γ M A} → Δ ∣ [] ⊢ M ⦂ A → Δ ∣ Γ ⊢ M ⦂ A
+⊢weakenⁿ {Γ = Γ} {M = M} {A = A} ⊢M =
+  subst (λ N → _ ∣ Γ ⊢ N ⦂ A) (renⁿ-id (λ x → x) (λ x → refl) M)
+        (⊢renⁿ (λ ()) ⊢M)
+
+-- THE IMAGE TYPING JUDGEMENT.  `⊢ival` is where the two things frame-exact
+-- substitution needs are recorded: the value's TYPE (which `mkId` reads)
+-- and its TERM-CLOSEDNESS (which `env` demands of an interior).  Its
+-- conclusion holds at an ARBITRARY term context, exactly as (env)'s does.
+infix 3 _∣_⊢ⁱ_⦂_
+data _∣_⊢ⁱ_⦂_ : Ctxᵗ → Ctx → Img → Ty → Set where
+
+  ⊢ivar : ∀ {Δ Γ x A} → Γ ∋ x ⦂ A → Δ ∣ Γ ⊢ⁱ ivar x ⦂ A
+
+  ⊢ival : ∀ {Δ Γ W A} → Δ ⊢ᵗ A → Δ ∣ [] ⊢ W ⦂ A → Δ ∣ Γ ⊢ⁱ ival W A ⦂ A
+
+⊢imgTm : ∀ {Δ Γ i A} → Δ ∣ Γ ⊢ⁱ i ⦂ A → Δ ∣ Γ ⊢ imgTm i ⦂ A
+⊢imgTm (⊢ivar d)    = ⊢` d
+⊢imgTm (⊢ival w ⊢W) = ⊢weakenⁿ ⊢W
+
+-- (‡) THE Λ CROSSING, TYPED — the Beta analogue of PeelDual's `crossing`.
+-- EVERY PREMISE IS DEFINITIONAL AT THE DUAL:
+--
+--   interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ
+--   convCtx  (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ unmasked abst ∷ Δ
+--   numBinds (morph [] (lock 0 ∷ [])) ≡ 0
+--
+-- so the interior is `⊢rename` at `suc` ALONE (`Ren-wk`, `Inj-suc`) —
+-- W is typed inside at its birth frame, one masked binder in — the
+-- conversion is `mkId-⊢` on the shifted type, and the `lock 0` is well
+-- formed because the Λ's own slot is nameable (`sw-l`).
+⊢crossΛ : ∀ {Δ W A}
+  → Δ ⊢ᵗ A
+  → Δ ∣ [] ⊢ W ⦂ A
+    -----------------------------------------------
+  → (unmasked abst ∷ Δ) ∣ [] ⊢ crossΛ W A ⦂ ⇑ᵗ A
+⊢crossΛ w ⊢W =
+  env (mw rw[] (sw-l (unmasked abst , ez , nameable) sw[]))
+      (⊢rename Ren-wk Inj-suc ⊢W)
+      (mkId-⊢ (wf-ren Ren-wk w))
+      (wf-ren Ren-wk w)
+
+-- Weakening an image: a variable image moves by `there`, a value image is
+-- CLOSED and moves by nothing at all.
+shiftᴵ-⊢ : ∀ {Δ Γ i A B} → Δ ∣ Γ ⊢ⁱ i ⦂ B → Δ ∣ (A ∷ Γ) ⊢ⁱ shiftᴵ i ⦂ B
+shiftᴵ-⊢ (⊢ivar d)    = ⊢ivar (there d)
+shiftᴵ-⊢ (⊢ival w ⊢W) = ⊢ival w ⊢W
+
+extᴵ-⊢ : ∀ {σ : ℕ → Img} {Δ Γ Γ′ A}
+  → (∀ {x B} → Γ ∋ x ⦂ B → Δ ∣ Γ′ ⊢ⁱ σ x ⦂ B)
     ------------------------------------------------------------------
-  → (∀ {x B} → (A ∷ Γ) ∋ x ⦂ B → Δ ∣ (A ∷ Γ′) ⊢ extᵐ σ x ⦂ B)
-extᵐ-⊢ h here      = ⊢` here
-extᵐ-⊢ h (there d) = ⊢renⁿ there (h d)
+  → (∀ {x B} → (A ∷ Γ) ∋ x ⦂ B → Δ ∣ (A ∷ Γ′) ⊢ⁱ extᴵ σ x ⦂ B)
+extᴵ-⊢ h here      = ⊢ivar here
+extᴵ-⊢ h (there d) = shiftᴵ-⊢ (h d)
+
+-- ONE image across one Λ.  A variable's type shifts with the context
+-- (`∋⦂-⤊`); a value acquires the DUAL WRAPPER (‡) and its annotation
+-- shifts.  No knowledge premise appears: a boundary carries NAMES.
+⇑ᴵ-⊢1 : ∀ {Δ Γ i A}
+  → Δ ∣ Γ ⊢ⁱ i ⦂ A
+    ----------------------------------------------------
+  → (unmasked abst ∷ Δ) ∣ ⤊ Γ ⊢ⁱ ⇑ᴵ i ⦂ ⇑ᵗ A
+⇑ᴵ-⊢1 (⊢ivar d)    = ⊢ivar (∋⦂-⤊ d)
+⇑ᴵ-⊢1 (⊢ival w ⊢W) = ⊢ival (wf-ren Ren-wk w) (⊢crossΛ w ⊢W)
+
+-- Pushing a term substitution under a Λ.
+⇑ᴵ-⊢ : ∀ {σ : ℕ → Img} {Δ Γ Γ′}
+  → (∀ {x B} → Γ ∋ x ⦂ B → Δ ∣ Γ′ ⊢ⁱ σ x ⦂ B)
+    ---------------------------------------------------------------------
+  → (∀ {x B} → ⤊ Γ ∋ x ⦂ B → (unmasked abst ∷ Δ) ∣ ⤊ Γ′ ⊢ⁱ ⇑ᴵ (σ x) ⦂ B)
+⇑ᴵ-⊢ h d with ∋⦂-map⁻ d
+... | A , refl , q = ⇑ᴵ-⊢1 (h q)
 
 -- THE SIMULTANEOUS SUBSTITUTION LEMMA.  Two cases carry the whole story:
--- (env) is trivial because a wrapper is term-closed, and ⊢Λ is `⇑ᴹ-⊢`,
--- i.e. `⊢rename` at suc.
-⊢substᵐ : ∀ {σ : ℕ → Term} {Δ Γ Γ′ N B}
-  → (∀ {x A} → Γ ∋ x ⦂ A → Δ ∣ Γ′ ⊢ σ x ⦂ A)
+-- (env) is trivial because a wrapper is term-closed, and ⊢Λ is `⇑ᴵ-⊢`,
+-- i.e. `⊢rename` at suc PLUS THE DUAL WRAPPER (‡).
+⊢substᵐ : ∀ {σ : ℕ → Img} {Δ Γ Γ′ N B}
+  → (∀ {x A} → Γ ∋ x ⦂ A → Δ ∣ Γ′ ⊢ⁱ σ x ⦂ A)
   → Δ ∣ Γ  ⊢ N ⦂ B
     ----------------------------
   → Δ ∣ Γ′ ⊢ substᵐ σ N ⦂ B
-⊢substᵐ h (⊢` d)            = h d
+⊢substᵐ h (⊢` d)            = ⊢imgTm (h d)
 ⊢substᵐ h ⊢$                = ⊢$
-⊢substᵐ h (⊢ƛ w ⊢N)         = ⊢ƛ w (⊢substᵐ (extᵐ-⊢ h) ⊢N)
+⊢substᵐ h (⊢ƛ w ⊢N)         = ⊢ƛ w (⊢substᵐ (extᴵ-⊢ h) ⊢N)
 ⊢substᵐ h (⊢· ⊢L ⊢M)        = ⊢· (⊢substᵐ h ⊢L) (⊢substᵐ h ⊢M)
-⊢substᵐ h (⊢Λ ⊢N)           = ⊢Λ (⊢substᵐ (⇑ᴹ-⊢ h) ⊢N)
+⊢substᵐ h (⊢Λ ⊢N)           = ⊢Λ (⊢substᵐ (⇑ᴵ-⊢ h) ⊢N)
 ⊢substᵐ h (⊢·[] ⊢L w)       = ⊢·[] (⊢substᵐ h ⊢L) w
 ⊢substᵐ h (env mwᵥ ⊢M ⊢c wE) = env mwᵥ ⊢M ⊢c wE
 
 -- THE SUBSTITUTION TYPING LEMMA — what Beta's preservation case consumes.
+-- THE VALUE IS TERM-CLOSED AND ITS TYPE IS CARRIED: both are what the
+-- wrapper minted at a crossed Λ needs, and both are on Beta's redex (the
+-- rule reduces closed terms, and the type is the ƛ's annotation).
 ⊢subst : ∀ {Δ Γ A B N W}
+  → Δ ⊢ᵗ A
   → Δ ∣ (A ∷ Γ) ⊢ N ⦂ B
-  → Δ ∣ Γ ⊢ W ⦂ A
+  → Δ ∣ [] ⊢ W ⦂ A
     -----------------------------
-  → Δ ∣ Γ ⊢ N [ W ]ᵐ ⦂ B
-⊢subst ⊢N ⊢W = ⊢substᵐ (λ { here → ⊢W ; (there d) → ⊢` d }) ⊢N
+  → Δ ∣ Γ ⊢ N [ W ∶ A ]ᵐ ⦂ B
+⊢subst w ⊢N ⊢W =
+  ⊢substᵐ (λ { here → ⊢ival w ⊢W ; (there d) → ⊢ivar d }) ⊢N
 
 -- Beta preservation, ready to be wired into the preservation theorem.
 -- (⊢·) is the only rule that can conclude an application — (env) concludes a
--- wrapper — so the inversion is a single clause.
-preserve-Beta : ∀ {Δ Γ A B N W}
-  → Δ ∣ Γ ⊢ (ƛ A ∙ N) · W ⦂ B
-    ---------------------------
-  → Δ ∣ Γ ⊢ N [ W ]ᵐ ⦂ B
-preserve-Beta (⊢· (⊢ƛ _ ⊢N) ⊢W) = ⊢subst ⊢N ⊢W
+-- wrapper — so the inversion is a single clause, and it hands over BOTH
+-- things `⊢subst` now asks for: the ƛ's `Δ ⊢ᵗ A` and the argument's typing
+-- at Γ = [].
+preserve-Beta : ∀ {Δ A B N W}
+  → Δ ∣ [] ⊢ (ƛ A ∙ N) · W ⦂ B
+    ------------------------------
+  → Δ ∣ [] ⊢ N [ W ∶ A ]ᵐ ⦂ B
+preserve-Beta (⊢· (⊢ƛ w ⊢N) ⊢W) = ⊢subst w ⊢N ⊢W

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2561,3 +2561,28 @@ needs `Δ ∋tv X` (witness: Δ = masked abst ∷ [], X = 0) — the premise `sw
 always has; threaded into applyUnlocks-dualScope and convCtx-dual.  The
 two mask inverses are now symmetric (`mask-unmask : Δ ∋lk X → …`,
 `unmask-mask : Δ ∋tv X → …`).  Rendering unchanged.
+
+### Frame-exact Beta: substitution wraps values crossing a Λ (probe, 2026-09-08)
+
+Jeremy, reading the slide trace of `(ΛX. λf:(∀Z.Z→Z). ΛY. f [Y]) [ℕ] ·
+(ΛZ. λz:Z. z)`: "On the fourth step, is there a missing −Y in the
+boundary around the ΛZ?"  Yes: Beta's substitution moved the crossing
+wrapper under ΛY and its interior became `Y Λ-bound , ⌷[X := ℕ]` — the
+value's frame GAINED Y (harmless via indices, but not frame-exact; every
+other rule is exact).  PROBED and LANDED on branch exact-beta:
+substitution carries the value's type and wraps every value image that
+crosses a Λ in the binder's dual with an identity conversion,
+`crossΛ W A = ⇑ᴹ W ⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫`; Beta is
+`(ƛ A ∙ N) · W -→ N [ W ∶ A ]ᵐ`.  Images are a two-constructor type
+(variable / closed value with its type), since env types a boundary's
+interior at Γ = [].  The boundary-interior half of the gap is VACUOUS:
+substitution never descends into a wrapper (term-closed), and Peel's
+crossing is already exact by (†).  Frame identity `interior (morph []
+(lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` by refl; Examples
+§15 gains the under-Λ Beta case (still refused) and §14 shows the ↓Y
+Jeremy expected at E₃/E₄.  Value/progress/det/canonical forms unchanged;
+at a base type the minted `id ℕ` is active, so a numeral crossing a Λ
+costs one extra Drop$.  Step-count deltas: Q 9→11, D 12→16, R 18→21,
+L 9→11, E 5→6; P₀, G, J, H, Ri unchanged.  Alternatives costed in
+notes/PR-exact-beta.md (extend an existing wrapper's changes; one
+composed dual per substitution path).  Awaiting Jeremy's ruling.

--- a/SystemF/agda/strong/notes/PR-exact-beta.md
+++ b/SystemF/agda/strong/notes/PR-exact-beta.md
@@ -283,6 +283,6 @@ shows up where the extra layers are actually in the way.
 | `Reduction.agda` | `Beta`'s statement and its note |
 | `Preservation.agda` | `preservation-Beta`'s statement |
 | `proof/Canonicity.agda` | `CanonImg`, `canon-shiftᴵ`, `canon-⇑ᴵ`, `canon-extᴵ`, `canon-substᵐ`, `canon-subst` |
-| `Examples.agda` | §7 both regressions; §11 `Q`, §11a `D`, §11b `R`, §11c `G`, §12 `L`, §13b `H`, §14 `E` re-pinned; §15 `interior-Beta-Λ` and the new §15d₂; header step-count table |
+| `Examples.agda` | §7 three regressions (the `Λ` clause, the `ƛ` clause, and the base-type cost `Bᵍ`/`Cᵍ`); §11 `Q`, §11a `D`, §11b `R`, §11c `G`, §12 `L`, §13b `H`, §14 `E` re-pinned; §15 `interior-Beta-Λ` and the new §15d₂; header step-count table |
 | `Design.md` | §1's `E` diagram, §6.2 rewritten, §7's frame-identity table, §8 law 3 |
 | `README.md` | the tightness paragraph and the `TermSubst.agda` row |

--- a/SystemF/agda/strong/notes/PR-exact-beta.md
+++ b/SystemF/agda/strong/notes/PR-exact-beta.md
@@ -1,0 +1,288 @@
+# Frame-exact `Beta`: what crosses a binder is wrapped in the binder's dual
+
+Branch `exact-beta`.  `make -C SystemF/agda/strong check` passes cold
+(exit 0, `postulate-check: OK`).
+
+## The gap
+
+`Beta`'s substitution moves the argument `W` under the binders of the
+body.  Passing under a `Λ`, `substᵐ`'s `Λ` clause shifted the images
+(`⇑ᴹ = renᴹ suc`) and nothing else:
+
+```agda
+substᵐ σ (Λ N) = Λ (substᵐ (λ x → ⇑ᴹ (σ x)) N)     -- before
+```
+
+The shift is SOUND — `W`'s shifted indices cannot reach slot 0 — but it is
+not FRAME-EXACT: the frame `W` is read at GAINED the `Λ`'s slot.  At
+`Examples` §14's `E₃` the crossing wrapper `(ΛZ. λz:Z. z) ⟪ ↓X , … ⟫`,
+planted under `ΛY`, was read at
+
+    Y Λ-bound , ⌷[X := ℕ]
+
+— one entry more than the frame it was born in.  Every other rule in the
+table is exact (`interior-dual` for `Peel`, `interior-⋉-rewind` for
+`CancelR`/`IdPush`, `interior-TyBeta`/`interior-TyPeelR` by `refl`);
+`Beta` was the one inexact rule, and the `Beta` row of the frame-identity
+table in `Design.md` §7 read `Δ` when the truth was `unmasked abst ∷ Δ`.
+
+Passing into a boundary interior is not a second half of the gap: a
+boundary is TERM-CLOSED (`env` types its interior at `Γ = []`), so
+`substᵐ` is the identity on wrappers and never descends into one.  The
+crossing into a boundary interior that DOES happen is `Peel`'s, and it is
+already exact — `(†) interior-dual`, `proof/PeelDual`.
+
+## The repair
+
+Every substituted image that crosses a binder is WRAPPED in a boundary
+whose morphism is the DUAL of what it crossed, with an identity conversion
+at the value's type:
+
+```agda
+crossΛ : Term → Ty → Term
+crossΛ W A = ⇑ᴹ W ⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫
+```
+
+A `Λ` is an `abst` binder occupying slot 0 inside, so its dual is
+`morph [] (lock 0 ∷ [])` — no binds, one lock — which is exactly
+`dual (morph (A ∷ []) [])`, the morphism `Peel` mints.  The frame identity
+is then DEFINITIONAL:
+
+```agda
+interior-Beta-Λ : (Δ : Ctxᵗ)
+  → interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ)
+      ≡ masked abst ∷ Δ
+interior-Beta-Λ Δ = refl
+```
+
+— the image's BIRTH frame `Δ` with the crossed binder masked.  Nothing
+gained, nothing lost.
+
+Term binders (`ƛ`) need no wrapper: a term binder changes no type frame.
+Reduction under binders is by the frame-indexed relation already, so
+`ξ-Λ` and `ξ-⟪⟫` are untouched.
+
+## The substitution carries the argument's type
+
+`mkId` needs the value's type, and `env` needs the value TERM-CLOSED.
+Both facts live in the substitution's IMAGES:
+
+```agda
+data Img : Set where
+  ivar : ℕ → Img          -- a term variable: the identity part of σ
+  ival : Term → Ty → Img  -- the substituted value, at its type
+
+imgTm : Img → Term
+imgTm (ivar x)   = ` x
+imgTm (ival W A) = W
+
+shiftᴵ : Img → Img                 -- weakening by one TERM variable
+shiftᴵ (ivar x)   = ivar (suc x)
+shiftᴵ (ival W A) = ival W A       -- CLOSED: nothing to shift
+
+⇑ᴵ : Img → Img                     -- THE Λ CROSSING
+⇑ᴵ (ivar x)   = ivar x
+⇑ᴵ (ival W A) = ival (crossΛ W A) (⇑ᵗ A)
+
+substᵐ : (ℕ → Img) → Term → Term
+substᵐ σ (` x)          = imgTm (σ x)
+substᵐ σ ($ n)          = $ n
+substᵐ σ (ƛ A ∙ N)      = ƛ A ∙ substᵐ (extᴵ σ) N
+substᵐ σ (L · M)        = substᵐ σ L · substᵐ σ M
+substᵐ σ (Λ N)          = Λ (substᵐ (λ x → ⇑ᴵ (σ x)) N)
+substᵐ σ (L ·[ B , A ]) = substᵐ σ L ·[ B , A ]
+substᵐ σ (M ⟪ Θ , c ⟫)  = M ⟪ Θ , c ⟫
+
+_[_∶_]ᵐ : Term → Term → Ty → Term
+N [ W ∶ A ]ᵐ = substᵐ (λ { zero → ival W A ; (suc x) → ivar x }) N
+```
+
+A VARIABLE image is never wrapped, and it cannot be: a variable is not
+term-closed, so `env` would refuse it.  A VALUE image is closed, which is
+what makes both the wrapper and the (premise-free) weakening legal.
+
+`Beta` becomes
+
+```agda
+Beta : ∀ {Δ A N W} → Value W → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ∶ A ]ᵐ
+```
+
+`A` is read off the redex (the `ƛ`'s own annotation), so the contractum is
+still a function of the redex alone: `det (Beta w) (Beta w′) = refl`,
+unchanged.
+
+## The typing
+
+The image judgement records the two facts, and its conclusion holds at an
+ARBITRARY term context, exactly as `env`'s does:
+
+```agda
+data _∣_⊢ⁱ_⦂_ : Ctxᵗ → Ctx → Img → Ty → Set where
+  ⊢ivar : ∀ {Δ Γ x A} → Γ ∋ x ⦂ A → Δ ∣ Γ ⊢ⁱ ivar x ⦂ A
+  ⊢ival : ∀ {Δ Γ W A} → Δ ⊢ᵗ A → Δ ∣ [] ⊢ W ⦂ A → Δ ∣ Γ ⊢ⁱ ival W A ⦂ A
+```
+
+The whole content of the repair is one lemma, and every premise of its
+`env` is DEFINITIONAL at the dual (`numBinds = 0`,
+`convCtx … (unmasked abst ∷ Δ) ≡ unmasked abst ∷ Δ`,
+`interior … (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ`):
+
+```agda
+⊢crossΛ : ∀ {Δ W A}
+  → Δ ⊢ᵗ A
+  → Δ ∣ [] ⊢ W ⦂ A
+    -----------------------------------------------
+  → (unmasked abst ∷ Δ) ∣ [] ⊢ crossΛ W A ⦂ ⇑ᵗ A
+⊢crossΛ w ⊢W =
+  env (mw rw[] (sw-l (unmasked abst , ez , nameable) sw[]))
+      (⊢rename Ren-wk Inj-suc ⊢W)
+      (mkId-⊢ (wf-ren Ren-wk w))
+      (wf-ren Ren-wk w)
+```
+
+`⊢rename` at `suc` for the interior, `mkId-⊢` for the conversion, `sw-l`
+for the lock (legal because the `Λ`'s own slot is nameable).  No knowledge
+premise appears: a boundary carries NAMES.
+
+Two supporting facts were new.  `shiftᴵ-⊢` has no premise to discharge —
+a value image is closed, so the term-variable weakening leaves it alone —
+and `⊢imgTm` needs a closed term to type at an arbitrary term context:
+
+```agda
+renⁿ-id   : (ρ : ℕ → ℕ) → (∀ x → ρ x ≡ x) → (M : Term) → renⁿ ρ M ≡ M
+⊢weakenⁿ  : ∀ {Δ Γ M A} → Δ ∣ [] ⊢ M ⦂ A → Δ ∣ Γ ⊢ M ⦂ A
+```
+
+`⊢weakenⁿ` is `⊢renⁿ` at the identity renaming, whose hypothesis is
+vacuous at `Γ = []`.
+
+`⊢subst` and `preserve-Beta` gain what the wrapper needs, and the redex
+supplies both:
+
+```agda
+⊢subst : ∀ {Δ Γ A B N W}
+  → Δ ⊢ᵗ A → Δ ∣ (A ∷ Γ) ⊢ N ⦂ B → Δ ∣ [] ⊢ W ⦂ A
+  → Δ ∣ Γ ⊢ N [ W ∶ A ]ᵐ ⦂ B
+
+preserve-Beta : ∀ {Δ A B N W}
+  → Δ ∣ [] ⊢ (ƛ A ∙ N) · W ⦂ B → Δ ∣ [] ⊢ N [ W ∶ A ]ᵐ ⦂ B
+preserve-Beta (⊢· (⊢ƛ w ⊢N) ⊢W) = ⊢subst w ⊢N ⊢W
+```
+
+(`⊢W` at `Γ = []` is not a restriction: `preservation` is stated at
+`Γ = []` and has to be — `_⊢_-→_` carries no term context and `TyBeta`'s
+contractum is a wrapper.)
+
+## What did NOT change
+
+`Reduction.agda`'s `value-¬step`, `det`, `Progress.agda`,
+`proof/Progress.agda`, `proof/Canonical.agda` and `TypeSafety.agda`
+compile **untouched**.  The rule set is the same; only `Beta`'s contractum
+moved, and it moved as a function of the same redex.  In particular:
+
+* `W ⟪ morph [] (lock 0 ∷ []) , mkId A′ ⟫` is a value iff `mkId A′` is
+  inert — at a variable, a function type and a `∀` it is (`I-idv`,
+  `I-fun`, `I-all`), so the wrapper is a value; at a BASE type `mkId` is
+  `id ℕ`, which is ACTIVE, and `7 ⟪ ↓Y , id ℕ ⟫` takes one `Drop$`.  That
+  costs a step and nothing else: a closed value at `ℕ` is a numeral (no
+  inert conversion targets a base type), so `Drop$` always applies and
+  progress is not disturbed.
+* `canon-substᵐ` (`proof/Canonicity` §7) gains one case, `canon-⇑ᴵ`,
+  whose minted conversion is `mkId (⇑ᵗ A)` — a LEAF of the canonical
+  family at every name (`canonC-mkId`).
+
+## Step-count deltas
+
+A run changes length exactly where a `Beta` substitutes under a `Λ`, and
+then only because the minted transparent layer is walked through by the
+`IdPush`/`CancelR`/`Drop$` cascade already in the calculus:
+
+| run | before | after | what the extra steps are |
+|-----|--------|-------|--------------------------|
+| §6 `P₀`   | 6  | 6  | the body is a bare variable: no `Λ` crossed |
+| §11 `Q₀`  | 9  | 11 | +1 `IdPush`, +1 `Drop$` |
+| §11a `D₀` | 12 | 16 | two `Λ`s crossed: +2 `IdPush`, +2 `Drop$` |
+| §11b `R₀` | 18 | 21 | +1 `IdPush`, +1 `CancelR`, +1 `Drop$` |
+| §11c `G`  | 5  | 5  | `gstep₁ … gstep₅` (no pinned full run); the layers land under the `Λ`s, unevaluated |
+| §12 `L₀`  | 9  | 11 | +1 `IdPush`, +1 `Drop$` |
+| §12b `Ri` | 2  | 2  | hand-built; no `Beta` |
+| §13a `J₀` | 14 | 14 | the substituted variable sits under no `Λ` |
+| §13b `H₀` | 4  | 4  | the layer lands inside a `ƛ` body, unevaluated |
+| §14 `E₀`  | 5  | 6  | +1 `TyPeelR` — the new `estep₅` |
+
+`Examples` §14's `E₃`/`E₄` now carry the `↓Y` Jeremy expected:
+
+    E₃  ((ΛY. (((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫)
+                 ⟪ ↓Y , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
+          ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+    E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
+                 ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
+          ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+
+and the two frames at that point are
+
+    E-dual-int   ⌷[Y Λ-bound] ,   X := ℕ      -- the value's BIRTH frame
+    E-dual-ext     Y Λ-bound ,    X := ℕ
+
+so `Y` is NOT nameable inside (`E-Y-not-inside`), which is the whole
+point: the value was born before `ΛY` existed.  `Y` is used where the BIND
+is recorded, on `E-dual-ext`, where it is in scope.
+
+## The tightness test
+
+`Examples` §15d₂ runs Jeremy's test on the case that had no instance
+before, because before there was nothing to test.  The probe
+`prb 0 = λx:ℕ. (ΛY. 3) [X]` names slot 0, which `Δ✦ = ⌷[X := ℕ]` masks;
+the redex `(λx:ℕ⇒ℕ. ΛY. x) · prb 0` is therefore ill typed, for exactly
+one `wf-var`; the contractum is
+
+    Λ (prb 1 ⟪ ↓Y , id ℕ ↦ id ℕ ⟫)
+
+and it is REFUSED for the same reason — `¬⊢shiftWᵈ`, at
+`masked abst ∷ Δ✦`, slot 1 being the masked binder `prb 1` names.  The
+crossed `Λ`'s own slot is not nameable inside either
+(`¬∋tv-crossΛ`), which is "the frame gained nothing" as a refusal.
+
+## Alternatives considered
+
+**(i) A new wrapper per binder crossed** — what landed.  Cost: `k`
+wrappers for a `k`-deep crossing, hence the step deltas above.  Benefit:
+`⊢crossΛ` is four lines and every premise is `refl` at the dual, because
+the wrapper is *literally* the shape `Peel` already mints, so `Peel`'s own
+machinery (`interior-dual`, `convCtx-dual`) is the model for the proof.
+
+**(ii) EXTEND an existing crossing wrapper's changes** when the image is
+already a boundary — append `lock 0` to `changes Θ` instead of adding a
+layer.  Rejected.  It is fewer wrappers (`Q₀` would stay at 9 steps), and
+it types — `applyUnlocks` skips locks, so the inner conversion is still
+read outside the new mask — but it is a SPECIAL CASE (a `ƛ`, a numeral or
+a variable image still needs a fresh wrapper), and the frame identity
+stops being `refl`: `interior (renᴮ suc Θ ⊕ lock 0) (unmasked abst ∷ Δ)`
+has to be related to the shifted original interior by a renaming
+COMPOSITION lemma, and the conversion has to be re-based through it.  That
+is a real proof where (i) has none, for a saving that is only in the step
+count.
+
+**(iii) ONE wrapper at the end of the substitution path**, carrying the
+composed dual of everything crossed (`hideBinds k` for `k` `Λ`s, `dual Θ`
+shifted for a boundary).  Rejected for now, but it is the cheaper
+variant if the step counts ever matter: for a single `Λ` it IS (i), and
+for `k` `Λ`s it gives one `morph [] (lock 0 ∷ … ∷ lock (k−1) ∷ [])` layer
+instead of `k`, with `mkId (shiftBy k A)`.  The cost is that `substᵐ` must
+then thread the accumulated dual (a `CtxMorph` and a shift count) through
+its own recursion rather than composing one binder at a time, and the
+frame identity becomes `applyChanges (hideBinds k) …`, a `stepB`-style
+induction rather than `refl`.  Worth revisiting only if a deep crossing
+shows up where the extra layers are actually in the way.
+
+## Files
+
+| file | change |
+|------|--------|
+| `TermSubst.agda` | §5b `Img`/`crossΛ`/`⇑ᴵ`/`substᵐ`/`_[_∶_]ᵐ`; §6 `renⁿ-id`, `⊢weakenⁿ`, `_∣_⊢ⁱ_⦂_`, `⊢crossΛ`, `shiftᴵ-⊢`, `extᴵ-⊢`, `⇑ᴵ-⊢`, `⊢substᵐ`, `⊢subst`, `preserve-Beta` |
+| `Reduction.agda` | `Beta`'s statement and its note |
+| `Preservation.agda` | `preservation-Beta`'s statement |
+| `proof/Canonicity.agda` | `CanonImg`, `canon-shiftᴵ`, `canon-⇑ᴵ`, `canon-extᴵ`, `canon-substᵐ`, `canon-subst` |
+| `Examples.agda` | §7 both regressions; §11 `Q`, §11a `D`, §11b `R`, §11c `G`, §12 `L`, §13b `H`, §14 `E` re-pinned; §15 `interior-Beta-Λ` and the new §15d₂; header step-count table |
+| `Design.md` | §1's `E` diagram, §6.2 rewritten, §7's frame-identity table, §8 law 3 |
+| `README.md` | the tightness paragraph and the `TermSubst.agda` row |

--- a/SystemF/agda/strong/proof/Canonicity.agda
+++ b/SystemF/agda/strong/proof/Canonicity.agda
@@ -33,7 +33,7 @@ open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; sym; cong; trans)
 
 open import strong.Types
-  using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Renameᵗ; renameᵗ; extᵗ)
+  using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Renameᵗ; renameᵗ; extᵗ; ⇑ᵗ)
 open import strong.Ctx
 open import strong.Conversion
 open import strong.Terms
@@ -50,7 +50,8 @@ private
     X : ℕ
     c s t : Conv
     L M M′ N W : Term
-    σ : ℕ → Term
+    i : Img
+    σ : ℕ → Img
 
 ------------------------------------------------------------------------
 -- 1.  The canonical family
@@ -202,9 +203,14 @@ canon-wkᴹ n cM = canon-renᴹ (wkN n) cM
 -- Boundaries are TERM-CLOSED: `shiftᵐ` and `substᵐ` return a wrapper
 -- untouched (strong.TermSubst).  So no conversion is ever renamed by term
 -- substitution, and canonicity is preserved for free — the only wrappers
--- in the result are those already in N or those carried in by σ.
-CanonSub : (ℕ → Term) → Set
-CanonSub σ = ∀ x → CanonTm (σ x)
+-- in the result are those already in N, those carried in by σ, and THE
+-- DUAL WRAPPER FRAME-EXACT BETA MINTS AT EACH CROSSED Λ, whose conversion
+-- is `mkId` — a LEAF of the family at every name (`canonC-mkId`).
+CanonImg : Img → Set
+CanonImg i = CanonTm (imgTm i)
+
+CanonSub : (ℕ → Img) → Set
+CanonSub σ = ∀ x → CanonImg (σ x)
 
 -- Term-variable renaming touches no conversion (a wrapper is
 -- term-closed), so canonicity passes through renⁿ unconditionally.
@@ -220,22 +226,36 @@ canon-renⁿ ρ (ct-⟪⟫ cM cc) = ct-⟪⟫ cM cc
 canon-shiftᵐ : CanonTm M → CanonTm (shiftᵐ M)
 canon-shiftᵐ = canon-renⁿ suc
 
-canon-extᵐ : CanonSub σ → CanonSub (extᵐ σ)
-canon-extᵐ cσ zero    = ct-var
-canon-extᵐ cσ (suc x) = canon-shiftᵐ (cσ x)
+-- A variable image is canonical outright; a VALUE image is closed, so the
+-- term-variable weakening leaves it alone.
+canon-shiftᴵ : (i : Img) → CanonImg i → CanonImg (shiftᴵ i)
+canon-shiftᴵ (ivar x)   ci = ct-var
+canon-shiftᴵ (ival W A) ci = ci
+
+-- THE Λ CROSSING.  A value image acquires the DUAL WRAPPER, whose
+-- conversion is `mkId (⇑ᵗ A)` — canonical at every name — over the
+-- ⇑ᴹ-renamed value (§6).
+canon-⇑ᴵ : (i : Img) → CanonImg i → CanonImg (⇑ᴵ i)
+canon-⇑ᴵ (ivar x)   ci = ct-var
+canon-⇑ᴵ (ival W A) ci = ct-⟪⟫ (canon-renᴹ suc ci) (canonC-mkId (⇑ᵗ A))
+
+canon-extᴵ : (σ : ℕ → Img) → CanonSub σ → CanonSub (extᴵ σ)
+canon-extᴵ σ cσ zero    = ct-var
+canon-extᴵ σ cσ (suc x) = canon-shiftᴵ (σ x) (cσ x)
 
 canon-substᵐ : CanonSub σ → CanonTm M → CanonTm (substᵐ σ M)
-canon-substᵐ cσ (ct-var {x = x}) = cσ x
-canon-substᵐ cσ ct-lit           = ct-lit
-canon-substᵐ cσ (ct-ƛ cN)        = ct-ƛ (canon-substᵐ (canon-extᵐ cσ) cN)
-canon-substᵐ cσ (ct-· cL cM)     =
+canon-substᵐ cσ (ct-var {x = x})          = cσ x
+canon-substᵐ cσ ct-lit                    = ct-lit
+canon-substᵐ {σ = σ} cσ (ct-ƛ cN)         =
+  ct-ƛ (canon-substᵐ (canon-extᴵ σ cσ) cN)
+canon-substᵐ cσ (ct-· cL cM)              =
   ct-· (canon-substᵐ cσ cL) (canon-substᵐ cσ cM)
-canon-substᵐ cσ (ct-Λ cN)        =
-  ct-Λ (canon-substᵐ (λ x → canon-renᴹ suc (cσ x)) cN)
-canon-substᵐ cσ (ct-·[] cL)      = ct-·[] (canon-substᵐ cσ cL)
-canon-substᵐ cσ (ct-⟪⟫ cM cc)    = ct-⟪⟫ cM cc
+canon-substᵐ {σ = σ} cσ (ct-Λ cN)         =
+  ct-Λ (canon-substᵐ (λ x → canon-⇑ᴵ (σ x) (cσ x)) cN)
+canon-substᵐ cσ (ct-·[] cL)               = ct-·[] (canon-substᵐ cσ cL)
+canon-substᵐ cσ (ct-⟪⟫ cM cc)             = ct-⟪⟫ cM cc
 
-canon-subst : CanonTm N → CanonTm W → CanonTm (N [ W ]ᵐ)
+canon-subst : CanonTm N → CanonTm W → CanonTm (N [ W ∶ A ]ᵐ)
 canon-subst cN cW =
   canon-substᵐ (λ { zero → cW ; (suc x) → ct-var }) cN
 


### PR DESCRIPTION
# Frame-exact `Beta`: what crosses a binder is wrapped in the binder's dual

Branch `exact-beta`.  `make -C SystemF/agda/strong check` passes cold
(exit 0, `postulate-check: OK`).

## The gap

`Beta`'s substitution moves the argument `W` under the binders of the
body.  Passing under a `Λ`, `substᵐ`'s `Λ` clause shifted the images
(`⇑ᴹ = renᴹ suc`) and nothing else:

```agda
substᵐ σ (Λ N) = Λ (substᵐ (λ x → ⇑ᴹ (σ x)) N)     -- before
```

The shift is SOUND — `W`'s shifted indices cannot reach slot 0 — but it is
not FRAME-EXACT: the frame `W` is read at GAINED the `Λ`'s slot.  At
`Examples` §14's `E₃` the crossing wrapper `(ΛZ. λz:Z. z) ⟪ ↓X , … ⟫`,
planted under `ΛY`, was read at

    Y Λ-bound , ⌷[X := ℕ]

— one entry more than the frame it was born in.  Every other rule in the
table is exact (`interior-dual` for `Peel`, `interior-⋉-rewind` for
`CancelR`/`IdPush`, `interior-TyBeta`/`interior-TyPeelR` by `refl`);
`Beta` was the one inexact rule, and the `Beta` row of the frame-identity
table in `Design.md` §7 read `Δ` when the truth was `unmasked abst ∷ Δ`.

Passing into a boundary interior is not a second half of the gap: a
boundary is TERM-CLOSED (`env` types its interior at `Γ = []`), so
`substᵐ` is the identity on wrappers and never descends into one.  The
crossing into a boundary interior that DOES happen is `Peel`'s, and it is
already exact — `(†) interior-dual`, `proof/PeelDual`.

## The repair

Every substituted image that crosses a binder is WRAPPED in a boundary
whose morphism is the DUAL of what it crossed, with an identity conversion
at the value's type:

```agda
crossΛ : Term → Ty → Term
crossΛ W A = ⇑ᴹ W ⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫
```

A `Λ` is an `abst` binder occupying slot 0 inside, so its dual is
`morph [] (lock 0 ∷ [])` — no binds, one lock — which is exactly
`dual (morph (A ∷ []) [])`, the morphism `Peel` mints.  The frame identity
is then DEFINITIONAL:

```agda
interior-Beta-Λ : (Δ : Ctxᵗ)
  → interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ)
      ≡ masked abst ∷ Δ
interior-Beta-Λ Δ = refl
```

— the image's BIRTH frame `Δ` with the crossed binder masked.  Nothing
gained, nothing lost.

Term binders (`ƛ`) need no wrapper: a term binder changes no type frame.
Reduction under binders is by the frame-indexed relation already, so
`ξ-Λ` and `ξ-⟪⟫` are untouched.

## The substitution carries the argument's type

`mkId` needs the value's type, and `env` needs the value TERM-CLOSED.
Both facts live in the substitution's IMAGES:

```agda
data Img : Set where
  ivar : ℕ → Img          -- a term variable: the identity part of σ
  ival : Term → Ty → Img  -- the substituted value, at its type

imgTm : Img → Term
imgTm (ivar x)   = ` x
imgTm (ival W A) = W

shiftᴵ : Img → Img                 -- weakening by one TERM variable
shiftᴵ (ivar x)   = ivar (suc x)
shiftᴵ (ival W A) = ival W A       -- CLOSED: nothing to shift

⇑ᴵ : Img → Img                     -- THE Λ CROSSING
⇑ᴵ (ivar x)   = ivar x
⇑ᴵ (ival W A) = ival (crossΛ W A) (⇑ᵗ A)

substᵐ : (ℕ → Img) → Term → Term
substᵐ σ (` x)          = imgTm (σ x)
substᵐ σ ($ n)          = $ n
substᵐ σ (ƛ A ∙ N)      = ƛ A ∙ substᵐ (extᴵ σ) N
substᵐ σ (L · M)        = substᵐ σ L · substᵐ σ M
substᵐ σ (Λ N)          = Λ (substᵐ (λ x → ⇑ᴵ (σ x)) N)
substᵐ σ (L ·[ B , A ]) = substᵐ σ L ·[ B , A ]
substᵐ σ (M ⟪ Θ , c ⟫)  = M ⟪ Θ , c ⟫

_[_∶_]ᵐ : Term → Term → Ty → Term
N [ W ∶ A ]ᵐ = substᵐ (λ { zero → ival W A ; (suc x) → ivar x }) N
```

A VARIABLE image is never wrapped, and it cannot be: a variable is not
term-closed, so `env` would refuse it.  A VALUE image is closed, which is
what makes both the wrapper and the (premise-free) weakening legal.

`Beta` becomes

```agda
Beta : ∀ {Δ A N W} → Value W → Δ ⊢ (ƛ A ∙ N) · W -→ N [ W ∶ A ]ᵐ
```

`A` is read off the redex (the `ƛ`'s own annotation), so the contractum is
still a function of the redex alone: `det (Beta w) (Beta w′) = refl`,
unchanged.

## The typing

The image judgement records the two facts, and its conclusion holds at an
ARBITRARY term context, exactly as `env`'s does:

```agda
data _∣_⊢ⁱ_⦂_ : Ctxᵗ → Ctx → Img → Ty → Set where
  ⊢ivar : ∀ {Δ Γ x A} → Γ ∋ x ⦂ A → Δ ∣ Γ ⊢ⁱ ivar x ⦂ A
  ⊢ival : ∀ {Δ Γ W A} → Δ ⊢ᵗ A → Δ ∣ [] ⊢ W ⦂ A → Δ ∣ Γ ⊢ⁱ ival W A ⦂ A
```

The whole content of the repair is one lemma, and every premise of its
`env` is DEFINITIONAL at the dual (`numBinds = 0`,
`convCtx … (unmasked abst ∷ Δ) ≡ unmasked abst ∷ Δ`,
`interior … (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ`):

```agda
⊢crossΛ : ∀ {Δ W A}
  → Δ ⊢ᵗ A
  → Δ ∣ [] ⊢ W ⦂ A
    -----------------------------------------------
  → (unmasked abst ∷ Δ) ∣ [] ⊢ crossΛ W A ⦂ ⇑ᵗ A
⊢crossΛ w ⊢W =
  env (mw rw[] (sw-l (unmasked abst , ez , nameable) sw[]))
      (⊢rename Ren-wk Inj-suc ⊢W)
      (mkId-⊢ (wf-ren Ren-wk w))
      (wf-ren Ren-wk w)
```

`⊢rename` at `suc` for the interior, `mkId-⊢` for the conversion, `sw-l`
for the lock (legal because the `Λ`'s own slot is nameable).  No knowledge
premise appears: a boundary carries NAMES.

Two supporting facts were new.  `shiftᴵ-⊢` has no premise to discharge —
a value image is closed, so the term-variable weakening leaves it alone —
and `⊢imgTm` needs a closed term to type at an arbitrary term context:

```agda
renⁿ-id   : (ρ : ℕ → ℕ) → (∀ x → ρ x ≡ x) → (M : Term) → renⁿ ρ M ≡ M
⊢weakenⁿ  : ∀ {Δ Γ M A} → Δ ∣ [] ⊢ M ⦂ A → Δ ∣ Γ ⊢ M ⦂ A
```

`⊢weakenⁿ` is `⊢renⁿ` at the identity renaming, whose hypothesis is
vacuous at `Γ = []`.

`⊢subst` and `preserve-Beta` gain what the wrapper needs, and the redex
supplies both:

```agda
⊢subst : ∀ {Δ Γ A B N W}
  → Δ ⊢ᵗ A → Δ ∣ (A ∷ Γ) ⊢ N ⦂ B → Δ ∣ [] ⊢ W ⦂ A
  → Δ ∣ Γ ⊢ N [ W ∶ A ]ᵐ ⦂ B

preserve-Beta : ∀ {Δ A B N W}
  → Δ ∣ [] ⊢ (ƛ A ∙ N) · W ⦂ B → Δ ∣ [] ⊢ N [ W ∶ A ]ᵐ ⦂ B
preserve-Beta (⊢· (⊢ƛ w ⊢N) ⊢W) = ⊢subst w ⊢N ⊢W
```

(`⊢W` at `Γ = []` is not a restriction: `preservation` is stated at
`Γ = []` and has to be — `_⊢_-→_` carries no term context and `TyBeta`'s
contractum is a wrapper.)

## What did NOT change

`Reduction.agda`'s `value-¬step`, `det`, `Progress.agda`,
`proof/Progress.agda`, `proof/Canonical.agda` and `TypeSafety.agda`
compile **untouched**.  The rule set is the same; only `Beta`'s contractum
moved, and it moved as a function of the same redex.  In particular:

* `W ⟪ morph [] (lock 0 ∷ []) , mkId A′ ⟫` is a value iff `mkId A′` is
  inert — at a variable, a function type and a `∀` it is (`I-idv`,
  `I-fun`, `I-all`), so the wrapper is a value; at a BASE type `mkId` is
  `id ℕ`, which is ACTIVE, and `7 ⟪ ↓Y , id ℕ ⟫` takes one `Drop$`.  That
  costs a step and nothing else: a closed value at `ℕ` is a numeral (no
  inert conversion targets a base type), so `Drop$` always applies and
  progress is not disturbed.
* `canon-substᵐ` (`proof/Canonicity` §7) gains one case, `canon-⇑ᴵ`,
  whose minted conversion is `mkId (⇑ᵗ A)` — a LEAF of the canonical
  family at every name (`canonC-mkId`).

## Step-count deltas

A run changes length exactly where a `Beta` substitutes under a `Λ`, and
then only because the minted transparent layer is walked through by the
`IdPush`/`CancelR`/`Drop$` cascade already in the calculus:

| run | before | after | what the extra steps are |
|-----|--------|-------|--------------------------|
| §6 `P₀`   | 6  | 6  | the body is a bare variable: no `Λ` crossed |
| §11 `Q₀`  | 9  | 11 | +1 `IdPush`, +1 `Drop$` |
| §11a `D₀` | 12 | 16 | two `Λ`s crossed: +2 `IdPush`, +2 `Drop$` |
| §11b `R₀` | 18 | 21 | +1 `IdPush`, +1 `CancelR`, +1 `Drop$` |
| §11c `G`  | 5  | 5  | `gstep₁ … gstep₅` (no pinned full run); the layers land under the `Λ`s, unevaluated |
| §12 `L₀`  | 9  | 11 | +1 `IdPush`, +1 `Drop$` |
| §12b `Ri` | 2  | 2  | hand-built; no `Beta` |
| §13a `J₀` | 14 | 14 | the substituted variable sits under no `Λ` |
| §13b `H₀` | 4  | 4  | the layer lands inside a `ƛ` body, unevaluated |
| §14 `E₀`  | 5  | 6  | +1 `TyPeelR` — the new `estep₅` |

`Examples` §14's `E₃`/`E₄` now carry the `↓Y` Jeremy expected:

    E₃  ((ΛY. (((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫)
                 ⟪ ↓Y , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
          ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
    E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
                 ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
          ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)

and the two frames at that point are

    E-dual-int   ⌷[Y Λ-bound] ,   X := ℕ      -- the value's BIRTH frame
    E-dual-ext     Y Λ-bound ,    X := ℕ

so `Y` is NOT nameable inside (`E-Y-not-inside`), which is the whole
point: the value was born before `ΛY` existed.  `Y` is used where the BIND
is recorded, on `E-dual-ext`, where it is in scope.

## The tightness test

`Examples` §15d₂ runs Jeremy's test on the case that had no instance
before, because before there was nothing to test.  The probe
`prb 0 = λx:ℕ. (ΛY. 3) [X]` names slot 0, which `Δ✦ = ⌷[X := ℕ]` masks;
the redex `(λx:ℕ⇒ℕ. ΛY. x) · prb 0` is therefore ill typed, for exactly
one `wf-var`; the contractum is

    Λ (prb 1 ⟪ ↓Y , id ℕ ↦ id ℕ ⟫)

and it is REFUSED for the same reason — `¬⊢shiftWᵈ`, at
`masked abst ∷ Δ✦`, slot 1 being the masked binder `prb 1` names.  The
crossed `Λ`'s own slot is not nameable inside either
(`¬∋tv-crossΛ`), which is "the frame gained nothing" as a refusal.

## Alternatives considered

**(i) A new wrapper per binder crossed** — what landed.  Cost: `k`
wrappers for a `k`-deep crossing, hence the step deltas above.  Benefit:
`⊢crossΛ` is four lines and every premise is `refl` at the dual, because
the wrapper is *literally* the shape `Peel` already mints, so `Peel`'s own
machinery (`interior-dual`, `convCtx-dual`) is the model for the proof.

**(ii) EXTEND an existing crossing wrapper's changes** when the image is
already a boundary — append `lock 0` to `changes Θ` instead of adding a
layer.  Rejected.  It is fewer wrappers (`Q₀` would stay at 9 steps), and
it types — `applyUnlocks` skips locks, so the inner conversion is still
read outside the new mask — but it is a SPECIAL CASE (a `ƛ`, a numeral or
a variable image still needs a fresh wrapper), and the frame identity
stops being `refl`: `interior (renᴮ suc Θ ⊕ lock 0) (unmasked abst ∷ Δ)`
has to be related to the shifted original interior by a renaming
COMPOSITION lemma, and the conversion has to be re-based through it.  That
is a real proof where (i) has none, for a saving that is only in the step
count.

**(iii) ONE wrapper at the end of the substitution path**, carrying the
composed dual of everything crossed (`hideBinds k` for `k` `Λ`s, `dual Θ`
shifted for a boundary).  Rejected for now, but it is the cheaper
variant if the step counts ever matter: for a single `Λ` it IS (i), and
for `k` `Λ`s it gives one `morph [] (lock 0 ∷ … ∷ lock (k−1) ∷ [])` layer
instead of `k`, with `mkId (shiftBy k A)`.  The cost is that `substᵐ` must
then thread the accumulated dual (a `CtxMorph` and a shift count) through
its own recursion rather than composing one binder at a time, and the
frame identity becomes `applyChanges (hideBinds k) …`, a `stepB`-style
induction rather than `refl`.  Worth revisiting only if a deep crossing
shows up where the extra layers are actually in the way.

## Files

| file | change |
|------|--------|
| `TermSubst.agda` | §5b `Img`/`crossΛ`/`⇑ᴵ`/`substᵐ`/`_[_∶_]ᵐ`; §6 `renⁿ-id`, `⊢weakenⁿ`, `_∣_⊢ⁱ_⦂_`, `⊢crossΛ`, `shiftᴵ-⊢`, `extᴵ-⊢`, `⇑ᴵ-⊢`, `⊢substᵐ`, `⊢subst`, `preserve-Beta` |
| `Reduction.agda` | `Beta`'s statement and its note |
| `Preservation.agda` | `preservation-Beta`'s statement |
| `proof/Canonicity.agda` | `CanonImg`, `canon-shiftᴵ`, `canon-⇑ᴵ`, `canon-extᴵ`, `canon-substᵐ`, `canon-subst` |
| `Examples.agda` | §7 three regressions (the `Λ` clause, the `ƛ` clause, and the base-type cost `Bᵍ`/`Cᵍ`); §11 `Q`, §11a `D`, §11b `R`, §11c `G`, §12 `L`, §13b `H`, §14 `E` re-pinned; §15 `interior-Beta-Λ` and the new §15d₂; header step-count table |
| `Design.md` | §1's `E` diagram, §6.2 rewritten, §7's frame-identity table, §8 law 3 |
| `README.md` | the tightness paragraph and the `TermSubst.agda` row |
