### PR TITLE
Strong System F: bounded change lists — rewind idempotent, the scope move drops redundant replays (pair cancellation refuted)

### DIFF
--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -32,6 +32,10 @@ open import strong.proof.PreserveObstruct
 open import strong.proof.DualTightness
 open import strong.proof.MwUObstruct
 
+-- NORMALISING THE CHANGE LISTS: the two redundancy tests that landed
+-- (strong.CtxMorph §4) and the contractions that are REFUSED
+open import strong.proof.RewindNorm
+
 -- the regression corpus and the renderer
 open import strong.Examples
 open import strong.Show

--- a/SystemF/agda/strong/Ctx.agda
+++ b/SystemF/agda/strong/Ctx.agda
@@ -678,6 +678,36 @@ mask-∋lk (unmasked b , d , nameable) =
   _ , updateAt-hit maskEnt maskEnt-comm d , locked
 
 ------------------------------------------------------------------------
+-- 6c.  UNMASKING IS IDEMPOTENT AND COMMUTES WITH ITSELF
+------------------------------------------------------------------------
+
+-- `unmaskEnt` CLEARS the lock, so it does not care what it found there:
+-- clearing twice is clearing once, and clearing two slots is
+-- order-independent (AT ANY TWO SLOTS, the same one included — no `X ≢ Y`
+-- premise, because both moves write the same value).
+--
+-- These are what make a change list's UNMASKS a SET: what
+-- `applyUnlocks L` has already exposed, `applyUnlocks M` cannot expose
+-- again (proof/MoveScope, `applyUnlocks-absorb`) — the fact that lets the
+-- scope move DROP a moved copy whose unmasks are already on.
+unmaskEnt-idem : (E : Ent) → unmaskEnt (unmaskEnt E) ≡ unmaskEnt E
+unmaskEnt-idem (unmasked b) = refl
+unmaskEnt-idem (masked b)   = refl
+
+unmask-idem : (X : ℕ) (Δ : Ctxᵗ) → unmask X (unmask X Δ) ≡ unmask X Δ
+unmask-idem X       []      = refl
+unmask-idem zero    (E ∷ Δ) = cong (_∷ Δ) (unmaskEnt-idem E)
+unmask-idem (suc X) (E ∷ Δ) = cong (E ∷_) (unmask-idem X Δ)
+
+unmask-comm : (X Y : ℕ) (Δ : Ctxᵗ)
+  → unmask X (unmask Y Δ) ≡ unmask Y (unmask X Δ)
+unmask-comm X       Y       []      = refl
+unmask-comm zero    zero    (E ∷ Δ) = refl
+unmask-comm zero    (suc Y) (E ∷ Δ) = refl
+unmask-comm (suc X) zero    (E ∷ Δ) = refl
+unmask-comm (suc X) (suc Y) (E ∷ Δ) = cong (E ∷_) (unmask-comm X Y Δ)
+
+------------------------------------------------------------------------
 -- 7.  The bind prefix
 ------------------------------------------------------------------------
 

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -364,7 +364,7 @@ shiftScope n (lock X ∷ S)   = lock (n + X) ∷ shiftScope n S
 -- was read.  (`unlocksOf` alone — replaying only the unmasks the reps
 -- need — loses both halves: `applyChanges` is then NOT the identity, and
 -- the surviving unlock is VACUOUS wherever its own licensing lock was
--- dropped.  Both refuted in proof/RewindNorm §5.)
+-- dropped.  Both refuted in proof/RewindNorm §3.)
 --
 -- REWINDING IS IDEMPOTENT, AND IT HAD BETTER BE (2026-09-08).  The
 -- replay `dualScope 0 S ++ S` DOUBLES the list, and the outer frame of a

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -383,7 +383,8 @@ shiftScope n (lock X ∷ S)   = lock (n + X) ∷ shiftScope n S
 -- own — the reps are read on EXACTLY the same type context, so not even
 -- a `⊢ʳ-⊑` step appears); on `no` they are the replay's, as before.
 
--- The SECOND HALF of a change list: the candidate Q in `S ≡ dualScope 0 Q ++ Q`.
+-- The SECOND HALF of a change list: the candidate Q in
+-- `S ≡ dualScope 0 Q ++ Q`.
 half : ℕ → ℕ
 half zero          = zero
 half (suc zero)    = zero

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -424,7 +424,77 @@ rewind Θ =
 -- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` DEFINITIONALLY: the move carries no
 -- binder, and with the pair that is a fact about the constructor, not a
 -- lemma about a filtered list.
+--
+-- … EXCEPT THAT THE MOVED COPY IS SOMETIMES ALREADY THERE (2026-09-08).
+-- Over a run of scope moves the SAME change list is moved in again and
+-- again — `changes Θ₁` already ends in the very copy the next move
+-- appends — and THAT is the exponential: the inner list roughly doubles
+-- at every pass (Examples §16 measures it).  A moved copy is REDUNDANT
+-- when
+--
+--   (a) `Rewound (changes Θ₂)`: the outer changes are a replay, so
+--       moving them is the IDENTITY on the interior — nothing about
+--       `interior` needs the copy;
+--   (b) every slot the copy UNLOCKS the inner list already unlocks:
+--       `applyUnlocks` is a SET of unmasks (strong.Ctx §6c), and the
+--       inner list runs LAST, so its unmasks subsume the copy's —
+--       nothing about `convCtx` needs the copy either.
+--
+-- Both are decidable, and under them the two frame lemmas stay
+-- EQUALITIES (proof/MoveScope §4) — the copy is dropped, not weakened.
+
+-- The slots a change list UNLOCKS.  (Its locks are irrelevant here: they
+-- are exactly what `applyUnlocks` skips.)
+unlockSlots : List Change → List ℕ
+unlockSlots []             = []
+unlockSlots (lock X ∷ S)   = unlockSlots S
+unlockSlots (unlock X ∷ S) = X ∷ unlockSlots S
+
+infix 4 _∈ᴺ_ _⊆ᴺ_
+data _∈ᴺ_ : ℕ → List ℕ → Set where
+  hereᴺ  : ∀ {X Xs} → X ∈ᴺ (X ∷ Xs)
+  thereᴺ : ∀ {X Y Xs} → X ∈ᴺ Xs → X ∈ᴺ (Y ∷ Xs)
+
+data _⊆ᴺ_ : List ℕ → List ℕ → Set where
+  sub[] : ∀ {Ys} → [] ⊆ᴺ Ys
+  sub∷  : ∀ {X Xs Ys} → X ∈ᴺ Ys → Xs ⊆ᴺ Ys → (X ∷ Xs) ⊆ᴺ Ys
+
+_∈ᴺ?_ : (X : ℕ) (Xs : List ℕ) → Dec (X ∈ᴺ Xs)
+X ∈ᴺ? []       = no λ()
+X ∈ᴺ? (Y ∷ Xs) with X ≟ℕ Y
+... | yes refl = yes hereᴺ
+... | no  ne   with X ∈ᴺ? Xs
+...   | yes i  = yes (thereᴺ i)
+...   | no  ni = no λ { hereᴺ → ne refl ; (thereᴺ i) → ni i }
+
+_⊆ᴺ?_ : (Xs Ys : List ℕ) → Dec (Xs ⊆ᴺ Ys)
+[]       ⊆ᴺ? Ys = yes sub[]
+(X ∷ Xs) ⊆ᴺ? Ys with X ∈ᴺ? Ys
+... | no  ni = no λ { (sub∷ i s) → ni i }
+... | yes i  with Xs ⊆ᴺ? Ys
+...   | yes s = yes (sub∷ i s)
+...   | no  ns = no λ { (sub∷ _ s) → ns s }
+
+-- THE MOVED COPY IS REDUNDANT.
+Redundant : CtxMorph → CtxMorph → Set
+Redundant Θ₁ Θ₂ =
+  Rewound (changes Θ₂)
+    × (unlockSlots (shiftScope (numBinds Θ₂) (changes Θ₂))
+         ⊆ᴺ unlockSlots (changes Θ₁))
+
+redundant? : (Θ₁ Θ₂ : CtxMorph) → Dec (Redundant Θ₁ Θ₂)
+redundant? Θ₁ Θ₂ with rewound? (changes Θ₂)
+... | no ¬r = no λ { (r , _) → ¬r r }
+... | yes r with unlockSlots (shiftScope (numBinds Θ₂) (changes Θ₂))
+                   ⊆ᴺ? unlockSlots (changes Θ₁)
+...   | yes s  = yes (r , s)
+...   | no  ns = no λ { (_ , s) → ns s }
+
+mergeChanges : (Θ₁ Θ₂ : CtxMorph) → Dec (Redundant Θ₁ Θ₂) → List Change
+mergeChanges Θ₁ Θ₂ (yes _) = changes Θ₁
+mergeChanges Θ₁ Θ₂ (no  _) =
+  changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂)
+
 infixl 5 _⋉_
 _⋉_ : CtxMorph → CtxMorph → CtxMorph
-Θ₁ ⋉ Θ₂ =
-  morph (binds Θ₁) (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))
+Θ₁ ⋉ Θ₂ = morph (binds Θ₁) (mergeChanges Θ₁ Θ₂ (redundant? Θ₁ Θ₂))

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -37,8 +37,11 @@ module strong.CtxMorph where
 -- re-exports this module.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
-open import Data.List using (List; []; _∷_; _++_; map; length)
+open import Data.List using (List; []; _∷_; _++_; map; length; drop)
+open import Data.List.Properties using (≡-dec)
 open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Binary.Definitions using (DecidableEquality)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; sym; cong; cong₂; trans; subst)
 
@@ -358,9 +361,64 @@ shiftScope n (lock X ∷ S)   = lock (n + X) ∷ shiftScope n S
 -- frame's own `⊢ᵐ`: Θ's bind reps are read on `unlockedScope Θ Δ` and a
 -- rep naming a slot Θ UNLOCKED is not well formed on the plain Δ.
 -- Keeping the entries and rewinding them keeps every rep exactly where it
--- was read.
+-- was read.  (`unlocksOf` alone — replaying only the unmasks the reps
+-- need — loses both halves: `applyChanges` is then NOT the identity, and
+-- the surviving unlock is VACUOUS wherever its own licensing lock was
+-- dropped.  Both refuted in proof/RewindNorm §5.)
+--
+-- REWINDING IS IDEMPOTENT, AND IT HAD BETTER BE (2026-09-08).  The
+-- replay `dualScope 0 S ++ S` DOUBLES the list, and the outer frame of a
+-- scope move is rewound again on the next pass, so over a run the change
+-- lists grow as `S , S ++ S , (S ++ S) ++ (S ++ S) , …` — the
+-- `↥X , ↓X , ↥X , ↓X , …` blowup Examples §16 measures.  The doubling is
+-- pure waste: `dualScope 0 S ++ S` is ALREADY a rewound list, and a
+-- rewound list is already the identity on the frame
+-- (`applyChanges-dualScope`) with the unmasks its reps need already on
+-- it.  So `rewind` REPLAYS ONLY WHAT IS NOT ALREADY A REPLAY.
+--
+-- A list IS a replay when it is its own second half's dual replay.  The
+-- test is decidable and the two branches are both trivial to discharge:
+-- on `yes` the frame lemmas are the ORIGINAL frame's (`scope` is the
+-- identity by `applyChanges-dualScope` at the second half, `⊢ᵐ` is Θ's
+-- own — the reps are read on EXACTLY the same type context, so not even
+-- a `⊢ʳ-⊑` step appears); on `no` they are the replay's, as before.
+
+-- The SECOND HALF of a change list: the candidate Q in `S ≡ dualScope 0 Q ++ Q`.
+half : ℕ → ℕ
+half zero          = zero
+half (suc zero)    = zero
+half (suc (suc n)) = suc (half n)
+
+secondHalf : List Change → List Change
+secondHalf S = drop (half (length S)) S
+
+-- `S` IS A REPLAY: its first half rewinds its second.
+Rewound : List Change → Set
+Rewound S = dualScope 0 (secondHalf S) ++ secondHalf S ≡ S
+
+_≟ᶜ_ : DecidableEquality Change
+lock X   ≟ᶜ lock Y   with X ≟ℕ Y
+... | yes refl = yes refl
+... | no  ne   = no λ { refl → ne refl }
+lock X   ≟ᶜ unlock Y = no λ()
+unlock X ≟ᶜ lock Y   = no λ()
+unlock X ≟ᶜ unlock Y with X ≟ℕ Y
+... | yes refl = yes refl
+... | no  ne   = no λ { refl → ne refl }
+
+rewound? : (S : List Change) → Dec (Rewound S)
+rewound? S = ≡-dec _≟ᶜ_ (dualScope 0 (secondHalf S) ++ secondHalf S) S
+
+-- The decision is an EXPLICIT ARGUMENT, so that every lemma about the
+-- rewound frame splits on it by ordinary pattern matching (no `with`
+-- abstraction has to find the scrutinee under `rewind`).
+rewindChanges : (S : List Change) → Dec (Rewound S) → List Change
+rewindChanges S (yes _) = S
+rewindChanges S (no  _) = dualScope 0 S ++ S
+
 rewind : CtxMorph → CtxMorph
-rewind Θ = morph (binds Θ) (dualScope 0 (changes Θ) ++ changes Θ)
+rewind Θ =
+  morph (binds Θ) (rewindChanges (changes Θ) (rewound? (changes Θ)))
 
 -- The inner frame, with the outer frame's changes moved in at its TAIL.
 -- `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` DEFINITIONALLY: the move carries no

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -3708,17 +3708,23 @@ sumChanges (M ⟪ Θ , c ⟫)  = length (changes Θ) + sumChanges M
 peak : (Term → ℕ) → List Term → ℕ
 peak f Ms = foldr (λ M n → f M ⊔ n) 0 Ms
 
--- 36 STEPS TO 42.
-_ : traceLen (eval 40 ⊢F₀) ≡ 36
+-- 49 STEPS TO 42 (36 before frame-exact Beta, PR #199: the values that
+-- Beta pushes under ΛY now carry a `↓Y` wrapper, which the later
+-- IdPush/CancelR passes must push through and whose change lists the
+-- scope move duplicates).
+_ : traceLen (eval 60 ⊢F₀) ≡ 49
 _ = refl
 
-_ : traceEnd (eval 40 ⊢F₀) ≡ $ 42
+_ : traceEnd (eval 60 ⊢F₀) ≡ $ 42
 _ = refl
 
--- THE TWO MEASUREMENTS.  Before the redundancy tests these were 130 and
--- 389.
-_ : peak maxChanges (traceTerms (eval 40 ⊢F₀)) ≡ 50
+-- THE TWO MEASUREMENTS, with the redundancy tests of strong.CtxMorph §4.
+-- Before frame-exact Beta they were 50 / 101 (and 130 / 389 without the
+-- redundancy tests); the extra `↓Y` layers compound with the scope move,
+-- so the residue (merges of lists unlocking DIFFERENT slots) now
+-- dominates.  See notes/DECISIONS.md, "Change-list growth".
+_ : peak maxChanges (traceTerms (eval 60 ⊢F₀)) ≡ 248
 _ = refl
 
-_ : peak sumChanges (traceTerms (eval 40 ⊢F₀)) ≡ 101
+_ : peak sumChanges (traceTerms (eval 60 ⊢F₀)) ≡ 518
 _ = refl

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -43,6 +43,12 @@ module strong.Examples where
 --     contractum is REFUSED for the same localized reason.  §15f
 --     collects the five frame identities that make the section a
 --     theorem rather than five anecdotes.
+-- §16 THE CHANGE LISTS, MEASURED — §14's `E₀` instantiated once more and
+--     APPLIED (`F₀`, 36 steps to 42).  This is the run on which the
+--     scope move's replayed and re-moved change lists used to DOUBLE at
+--     every pass; the peak list length and the peak entry count are
+--     pinned by `refl`, before (130 / 389) and after (50 / 101) the two
+--     redundancy tests of strong.CtxMorph §4.
 --
 -- Every `_ : … ≡ …` in this file is a machine-checked frame computation.
 --
@@ -3243,3 +3249,96 @@ _ = refl
 -- restoring `lock` to be `mask ∘ unmask` at that slot (`mask-unmask`,
 -- strong.Ctx §6b), and the scope move needs the rep half read past the
 -- tail's unlocks (proof/MwUObstruct §4).
+
+------------------------------------------------------------------------
+-- §16  THE CHANGE LISTS, MEASURED — `E₀` INSTANTIATED AND APPLIED
+------------------------------------------------------------------------
+
+-- THE PROGRAM (Jeremy, 2026-09-08).  §14's `E₀` runs to a VALUE of type
+-- `∀Y. Y ⇒ Y` in five steps; instantiate it once more and APPLY it, and
+-- the run continues through the whole scope-move machinery — four
+-- crossings (`Peel`), a `CancelR`/`IdPush` cascade, and eight `Drop$`
+-- layers — to the numeral 42, in 36 steps:
+--
+--   F₀ = (E₀ ·[ ` 0 ⇒ ` 0 , `ℕ ]) · $ 42                          : ℕ
+--
+--   TyBeta Peel Beta TyPeelR TyBeta TyPeelR TyBeta
+--   Peel Peel Peel Peel Beta
+--   CancelR IdPush IdPush CancelR IdPush IdPush IdPush IdPush
+--   CancelR IdPush IdPush IdPush IdPush IdPush IdPush CancelR
+--   Drop$ Drop$ Drop$ Drop$ Drop$ Drop$ Drop$ Drop$
+--
+-- THIS IS THE RUN THAT MEASURES THE CHANGE-LIST BLOWUP.  Every
+-- `CancelR`/`IdPush` replays the outer frame's changes (`rewind Θ₂`) and
+-- moves them into the inner frame (`Θ₁ ⋉ Θ₂`), and BOTH used to copy a
+-- list that already carried the same entries, so the lists roughly
+-- DOUBLED at every pass.  The peak state carried, at one boundary,
+--
+--   ↥4 ↧4 ↥4 ↧4 ↥4 ↧4 ↥4 ↧4 ↥4 ↥0 ↧0 ↧4 ↥4 ↥0 ↧0 ↧4 …
+--
+-- 130 entries of it, and 389 change entries across the whole state.
+--
+-- WITH THE TWO REDUNDANCY TESTS (strong.CtxMorph §4) the peak is 50 and
+-- 101, and neither the step count nor the answer moves:
+--
+--   longest change list at one boundary   130 → 50
+--   change entries in one state           389 → 101
+--   steps                                  36 = 36
+--   answer                                  42 = 42
+--
+-- The residue is NOT a replay and NOT a duplicate: it is the merge of two
+-- lists that unlock DIFFERENT slots, which no exact rewriting can shrink
+-- (proof/RewindNorm §2).  Bounding it needs the CANONICAL per-slot form —
+-- at most three entries per slot mentioned, so at most 15 on this run,
+-- where at most five slots are ever named — and the two facts that form
+-- still lacks are stated in proof/RewindNorm §4.
+--
+-- The measurements below are `refl`, so they are pinned: a frame redesign
+-- that changes them fails this section.
+
+F₀ : Term
+F₀ = (E₀ ·[ ` 0 ⇒ ` 0 , `ℕ ]) · ($ 42)
+
+⊢F₀ : [] ∣ [] ⊢ F₀ ⦂ `ℕ
+⊢F₀ = ⊢· (⊢·[] ⊢E₀ wf-ℕ) ⊢$
+
+open import strong.Eval using (eval; traceTerms; traceLen; traceEnd)
+open import Data.Nat using (_⊔_)
+open import Data.List using (foldr)
+
+-- The longest change list at any one boundary of a term, and the total
+-- number of change entries in it.
+maxChanges sumChanges : Term → ℕ
+maxChanges (` x)          = 0
+maxChanges ($ n)          = 0
+maxChanges (ƛ A ∙ N)      = maxChanges N
+maxChanges (L · M)        = maxChanges L ⊔ maxChanges M
+maxChanges (Λ N)          = maxChanges N
+maxChanges (L ·[ B , A ]) = maxChanges L
+maxChanges (M ⟪ Θ , c ⟫)  = length (changes Θ) ⊔ maxChanges M
+
+sumChanges (` x)          = 0
+sumChanges ($ n)          = 0
+sumChanges (ƛ A ∙ N)      = sumChanges N
+sumChanges (L · M)        = sumChanges L + sumChanges M
+sumChanges (Λ N)          = sumChanges N
+sumChanges (L ·[ B , A ]) = sumChanges L
+sumChanges (M ⟪ Θ , c ⟫)  = length (changes Θ) + sumChanges M
+
+peak : (Term → ℕ) → List Term → ℕ
+peak f Ms = foldr (λ M n → f M ⊔ n) 0 Ms
+
+-- 36 STEPS TO 42.
+_ : traceLen (eval 40 ⊢F₀) ≡ 36
+_ = refl
+
+_ : traceEnd (eval 40 ⊢F₀) ≡ $ 42
+_ = refl
+
+-- THE TWO MEASUREMENTS.  Before the redundancy tests these were 130 and
+-- 389.
+_ : peak maxChanges (traceTerms (eval 40 ⊢F₀)) ≡ 50
+_ = refl
+
+_ : peak sumChanges (traceTerms (eval 40 ⊢F₀)) ≡ 101
+_ = refl

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -60,6 +60,12 @@ module strong.Preservation where
 -- exterior type: the reveal's target IS that type, lifted.  Nothing is
 -- assumed about the world, and the old counterexample now REDUCES to a
 -- TYPED term (proof/PreserveObstruct §4, `⊢i-contractum`).
+--
+-- Both frames carry a REDUNDANCY TEST (strong.CtxMorph §4) so that a run
+-- of scope moves does not double its change lists at every pass; the
+-- drops are EXACT, so the two cases below are unchanged by them
+-- (Examples §16 measures the difference, proof/RewindNorm says what
+-- cannot be dropped).
 
 open import Data.Nat using (ℕ; suc)
 open import Data.List using (List; []; _∷_)

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -162,6 +162,13 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- `pushBinds (binds Θ₂) Δ`, and `A ≡ shiftBy (numBinds Θ₂) C` for the redex's own
   -- exterior type C.  That is what retires the wall — the case needs no
   -- scoping invariant at all (proof/MoveScope.preserve-IdPush).
+  --
+  -- NEITHER FRAME COPIES WHAT IS ALREADY THERE (2026-09-08).  `rewind`
+  -- does not replay a list that IS a replay and `_⋉_` drops a moved copy
+  -- whose unmasks the inner list already performs (strong.CtxMorph §4);
+  -- both drops are EXACT, so determinism below is untouched — `rewind`
+  -- and `_⋉_` are still functions of the two frames alone.  Without them
+  -- a run's change lists DOUBLE at every pass (Examples §16).
   IdPush : ∀ {Δ V Θ₁ Θ₂ X Y A} → Value V → convCtx Θ₂ Δ ∋ Y := A
     → Δ ⊢ (V ⟪ Θ₁ , id (` X) ⟫) ⟪ Θ₂ , unseal Y ⟫
         -→ (V ⟪ Θ₁ ⋉ Θ₂ , unseal X ⟫) ⟪ rewind Θ₂ , mkId A ⟫

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2615,3 +2615,19 @@ alone as the outer frame is refuted twice (frame not restored; vacuous
 unlock).  Design note for Jeremy: the rules now carry decidable tests
 (`rewound?`, `redundant?`) — deterministic and computable, but a
 judgement call whether tests belong in rules.  Awaiting ruling.
+
+### RULING: frame exactness is the main point (Jeremy, 2026-09-08); PR #199 merged
+
+"Frame exactness is the main point of strong system F!"  PR #199 (Beta
+wraps every value crossing a Λ in the binder's dual, `crossΛ`) MERGED as
+19a4268a.  Jeremy then asked for an audit of every place that shifts a
+term, to find other unmasked variables (branch shift-audit; the known
+candidate is TyPeelR, whose `wkᴹ 1 V` lands under the new bind slot).
+MEASURED INTERACTION with the change-list growth (PR #200's §16, after
+merging #199): 49 steps to 42 (was 36); peak change list 248 and 518
+entries per state (was 50 / 101 with the redundancy tests, 130 / 389
+without) — the ↓Y layers Beta now mints are extra boundaries the
+IdPush/CancelR passes push through, and their change lists compound in
+the scope move; the residue (merges of lists unlocking different slots)
+now dominates, so the canonical per-slot form (RewindNorm §4) is the
+remaining lever.

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2561,3 +2561,32 @@ needs `Δ ∋tv X` (witness: Δ = masked abst ∷ [], X = 0) — the premise `sw
 always has; threaded into applyUnlocks-dualScope and convCtx-dual.  The
 two mask inverses are now symmetric (`mask-unmask : Δ ∋lk X → …`,
 `unmask-mask : Δ ∋tv X → …`).  Rendering unchanged.
+
+### Change-list growth under IdPush/CancelR (probe, 2026-09-08)
+
+Observed by Jeremy and me on `(E₀ [ℕ]) · 42` (Examples §16, 36 steps to
+42): rewind/⋉ duplicated change lists per pass — peak list 130 entries,
+389 in one state.  Jeremy: "replace rewind with empty?" — refuted in-tree
+(MwUObstruct §3 ¬⊢ᵐ-bindsOnly).  PROBED: (A) cancel adjacent inverse
+pairs — REFUTED by `_⊢ˢ_` in both orientations (proof/RewindNorm §1–2):
+the contractions are exact on the contexts but ↥X ↧X → ↥X leaves a
+vacuous unlock and ↧X ↥X → ↧X leaves a lock on a masked slot; in a
+well-formed list the entries at one slot strictly alternate, so these
+are the only adjacent patterns.  (B) LANDED on branch normalize-changes:
+two REDUNDANCY tests, exact on applyChanges AND applyUnlocks —
+`rewind` replays only if the list is not already a replay
+(`Rewound S = dualScope 0 (secondHalf S) ++ secondHalf S ≡ S`, decided
+by `rewound?`), and `⋉` drops the moved copy when Θ₂'s changes are a
+replay whose unlock slots are already among Θ₁'s (`redundant?`).  All
+theorem statements unchanged (frame lemmas stay equalities; det/
+value-¬step/preservation untouched); every pinned run unchanged (the
+tests never fire on short lists).  §16: peak list 130 → 50, entries per
+state 389 → 101, still 36 steps.  The exponential was mostly in ⋉ (rewind
+alone: 130 → 118).  (C) RESIDUE: merging lists that unlock DIFFERENT
+slots is genuinely new information; bounding it needs the canonical
+per-slot form (≤ 3 entries per slot, table in RewindNorm §4 — stated,
+not proven; needs updateAt commutation at distinct slots).  `unlocksOf`
+alone as the outer frame is refuted twice (frame not restored; vacuous
+unlock).  Design note for Jeremy: the rules now carry decidable tests
+(`rewound?`, `redundant?`) — deterministic and computable, but a
+judgement call whether tests belong in rules.  Awaiting ruling.

--- a/SystemF/agda/strong/proof/MaskFacts.agda
+++ b/SystemF/agda/strong/proof/MaskFacts.agda
@@ -83,9 +83,7 @@ unmaskEnt-maskEnt-core : (E : Ent) → unmaskEnt (maskEnt E) ≡ unmaskEnt E
 unmaskEnt-maskEnt-core (unmasked b) = refl
 unmaskEnt-maskEnt-core (masked b)   = refl
 
-unmaskEnt-idem : (E : Ent) → unmaskEnt (unmaskEnt E) ≡ unmaskEnt E
-unmaskEnt-idem (unmasked b) = refl
-unmaskEnt-idem (masked b)   = refl
+-- (`unmaskEnt-idem` is strong.Ctx §6c, where the unmask ALGEBRA lives.)
 
 -- Two type contexts agree UP TO CONCEALMENT at every slot.
 CoreEq : Ctxᵗ → Ctxᵗ → Set

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -49,9 +49,12 @@ module strong.proof.MoveScope where
 --   §6  the two cases
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
-open import Data.List using (List; []; _∷_; _++_; length)
+open import Data.Nat.Properties using (+-comm; +-suc)
+open import Data.List using (List; []; _∷_; _++_; length; drop)
+open import Data.List.Properties using (length-++)
+open import Data.Empty using (⊥-elim)
 open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary using (¬_; Dec; yes; no)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; sym; cong; trans; subst)
 
@@ -62,7 +65,7 @@ open import strong.Terms
 open import strong.CtxMorph
 open import strong.proof.Preserve using (CancelRCase; IdPushCase)
 open import strong.proof.PeelDual
-  using (⊢ˢ-++; applyChanges-++; applyUnlocks-++;
+  using (⊢ˢ-++; ⊢ˢ-suffix; applyChanges-++; applyUnlocks-++;
          applyChanges-dualScope; ⊢ˢ-dualScope)
 
 ------------------------------------------------------------------------
@@ -109,6 +112,70 @@ numBinds-⋉ Θ₁ Θ₂ = refl
 numBinds-rewind : (Θ : CtxMorph) → numBinds (rewind Θ) ≡ numBinds Θ
 numBinds-rewind Θ = refl
 
+-- REWINDING IS IDEMPOTENT (2026-09-08) — the fact that bounds the change
+-- lists.  It is two list facts and one arithmetic fact:
+--
+--   the dual replay has the SAME LENGTH as what it replays;
+--   `half (n + n) ≡ n`;
+--   `drop (length A) (A ++ B) ≡ B`.
+--
+-- Together they say that `dualScope 0 S ++ S` IS a replay
+-- (`Rewound-replay`), so `rewindChanges` returns it unchanged the next
+-- time round.  Without this, the outer frame of a scope move is replayed
+-- again on every pass and the lists DOUBLE — Examples §16.
+length-dualScope : (n : ℕ) (S : List Change)
+  → length (dualScope n S) ≡ length S
+length-dualScope n []             = refl
+length-dualScope n (lock X ∷ S)   =
+  trans (length-++ (dualScope n S) {unlock (n + X) ∷ []})
+        (trans (+-comm (length (dualScope n S)) 1)
+               (cong suc (length-dualScope n S)))
+length-dualScope n (unlock X ∷ S) =
+  trans (length-++ (dualScope n S) {lock (n + X) ∷ []})
+        (trans (+-comm (length (dualScope n S)) 1)
+               (cong suc (length-dualScope n S)))
+
+half-+ : (n : ℕ) → half (n + n) ≡ n
+half-+ zero    = refl
+half-+ (suc n) =
+  trans (cong (λ m → half (suc m)) (+-suc n n)) (cong suc (half-+ n))
+
+drop-length-++ : (S T : List Change) → drop (length S) (S ++ T) ≡ T
+drop-length-++ []      T = refl
+drop-length-++ (c ∷ S) T = drop-length-++ S T
+
+secondHalf-replay : (S : List Change)
+  → secondHalf (dualScope 0 S ++ S) ≡ S
+secondHalf-replay S =
+  trans (cong (λ n → drop (half n) (dualScope 0 S ++ S))
+              (trans (length-++ (dualScope 0 S) {S})
+                     (cong (_+ length S) (length-dualScope 0 S))))
+        (trans (cong (λ n → drop n (dualScope 0 S ++ S))
+                     (trans (half-+ (length S))
+                            (sym (length-dualScope 0 S))))
+               (drop-length-++ (dualScope 0 S) S))
+
+Rewound-replay : (S : List Change) → Rewound (dualScope 0 S ++ S)
+Rewound-replay S =
+  cong (λ T → dualScope 0 T ++ T) (secondHalf-replay S)
+
+-- A list that IS a replay is left alone, whichever way the test goes.
+rewindChanges-fix : (S : List Change) (d : Dec (Rewound S))
+  → Rewound S → rewindChanges S d ≡ S
+rewindChanges-fix S (yes _) r = refl
+rewindChanges-fix S (no ¬r) r = ⊥-elim (¬r r)
+
+rewind-idem : (Θ : CtxMorph) → rewind (rewind Θ) ≡ rewind Θ
+rewind-idem Θ with rewound? (changes Θ)
+rewind-idem Θ | yes eq =
+  cong (morph (binds Θ))
+       (rewindChanges-fix (changes Θ) (rewound? (changes Θ)) eq)
+rewind-idem Θ | no ¬eq =
+  cong (morph (binds Θ))
+       (rewindChanges-fix (dualScope 0 (changes Θ) ++ changes Θ)
+                          (rewound? (dualScope 0 (changes Θ) ++ changes Θ))
+                          (Rewound-replay (changes Θ)))
+
 -- THE MOVED CHANGES, APPLIED PAST THE BIND PREFIX, ARE THE ORIGINAL
 -- CHANGES APPLIED UNDER IT.  This is the whole point of the index lift
 -- `n + X`, and it is `updateAt-pushBinds` (strong.Ctx) once per entry.
@@ -140,10 +207,33 @@ applyUnlocks-shiftScope As (unlock X ∷ S) Δ =
 -- this is `applyChanges-dualScope` (proof/PeelDual) at an empty bind
 -- prefix, and it is where the whole design is paid for: the inverse is
 -- exact only because `sw-u` refuses a vacuous unlock.
+--
+-- IT HOLDS OF A LIST THAT IS ALREADY A REPLAY, TOO, AND THAT IS WHY
+-- `rewindChanges` MAY LEAVE ONE ALONE (strong.CtxMorph §4): `Rewound S`
+-- says `S ≡ dualScope 0 Q ++ Q` for S's second half Q, `⊢ˢ-suffix` reads
+-- Q's own sequential judgement out of S's, and then it is the SAME lemma
+-- at Q.  So the identity is proved ONCE, of `rewindChanges` in both
+-- branches.
+applyChanges-rewindChanges : (S : List Change) (d : Dec (Rewound S))
+  {Δ : Ctxᵗ} → Δ ⊢ˢ S → applyChanges (rewindChanges S d) Δ ≡ Δ
+applyChanges-rewindChanges S (yes eq) {Δ = Δ} b =
+  trans (cong (λ T → applyChanges T Δ) (sym eq))
+        (trans (applyChanges-++ (dualScope 0 Q) Q Δ)
+               (applyChanges-dualScope [] Q bQ))
+  where
+  Q : List Change
+  Q = secondHalf S
+
+  bQ : Δ ⊢ˢ Q
+  bQ = ⊢ˢ-suffix (dualScope 0 Q) Q (subst (λ T → Δ ⊢ˢ T) (sym eq) b)
+applyChanges-rewindChanges S (no _) {Δ = Δ} b =
+  trans (applyChanges-++ (dualScope 0 S) S Δ)
+        (applyChanges-dualScope [] S b)
+
 scope-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → scope (rewind Θ) Δ ≡ Δ
-scope-rewind Θ {Δ = Δ} mwᵥ =
-  trans (applyChanges-++ (dualScope 0 (changes Θ)) (changes Θ) Δ)
-        (applyChanges-dualScope [] (changes Θ) (mw-changes mwᵥ))
+scope-rewind Θ mwᵥ =
+  applyChanges-rewindChanges (changes Θ) (rewound? (changes Θ))
+                             (mw-changes mwᵥ)
 
 interior-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
   → interior (rewind Θ) Δ ≡ pushBinds (binds Θ) Δ
@@ -301,8 +391,17 @@ _ = refl
 -- read past the extra unmasks the inverse list adds — MORE nameable, so
 -- `⊢ʳ-⊑` carries them.  (Under the interleaved list the reps sat inside
 -- the appended tail, where they were read unchanged.)
-⊢ᵐ-rewind : ∀ (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → Δ ⊢ᵐ rewind Θ
-⊢ᵐ-rewind Θ {Δ = Δ} mwᵥ =
+--
+-- WHEN THE LIST IS ALREADY A REPLAY THERE IS NOTHING TO DO: the frame IS
+-- Θ, so both halves are Θ's own judgement, ON THE NOSE — not even a
+-- `⊢ʳ-⊑` step, because the reps are read on exactly the type context
+-- they were read on.  That is what makes `rewind` IDEMPOTENT
+-- (`rewind-idem` below) and the change lists BOUNDED (Examples §16).
+⊢ᵐ-rewindChanges : ∀ (Θ : CtxMorph) (d : Dec (Rewound (changes Θ)))
+  {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
+  → Δ ⊢ᵐ morph (binds Θ) (rewindChanges (changes Θ) d)
+⊢ᵐ-rewindChanges Θ (yes eq) mwᵥ = mw (mw-reps mwᵥ) (mw-changes mwᵥ)
+⊢ᵐ-rewindChanges Θ (no _) {Δ = Δ} mwᵥ =
   mw (subst (λ Ξ → Ξ ⊢ʳ binds Θ)
             (sym (applyUnlocks-++ (dualScope 0 (changes Θ)) (changes Θ) Δ))
             (⊢ʳ-⊑ (Δ⊑applyUnlocks (dualScope 0 (changes Θ))
@@ -311,6 +410,9 @@ _ = refl
      (⊢ˢ-++ (dualScope 0 (changes Θ)) (changes Θ)
             (⊢ˢ-dualScope [] (changes Θ) (mw-changes mwᵥ))
             (mw-changes mwᵥ))
+
+⊢ᵐ-rewind : ∀ (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ → Δ ⊢ᵐ rewind Θ
+⊢ᵐ-rewind Θ mwᵥ = ⊢ᵐ-rewindChanges Θ (rewound? (changes Θ)) mwᵥ
 
 -- THE MOVED CHANGES ARE WELL FORMED WHERE THEY LAND.  Θ₂'s entries are
 -- read one bind prefix in, over `pushBinds As (applyChanges S′ Δ)` —

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -17,8 +17,9 @@ module strong.proof.MoveScope where
 --
 -- `Θ₁ ⋉ Θ₂` appends Θ₂'s whole CHANGE LIST (locks AND unlocks, in order,
 -- lifted past Θ₂'s binders) at Θ₁'s TAIL, where `applyChanges` applies it
--- FIRST; and `rewind Θ₂` is Θ₂ with its own changes UNDONE, so what is
--- left of the outer frame is the BIND BLOCK, in net effect:
+-- FIRST — unless that copy is redundant, see below; and `rewind Θ₂` is Θ₂
+-- with its own changes UNDONE, so what is left of the outer frame is the
+-- BIND BLOCK, in net effect:
 --
 --   scope    (rewind Θ₂) Δ ≡ Δ                          (given Δ ⊢ᵐ Θ₂)
 --   interior (rewind Θ₂) Δ ≡ pushBinds (binds Θ₂) Δ
@@ -40,9 +41,22 @@ module strong.proof.MoveScope where
 -- conversion presents is read OUTSIDE Θ₂'s locks, where
 -- `wf-shiftBy-pushBinds` supplies the premise the wall used to deny.
 --
+-- AND NEITHER FRAME COPIES WHAT IS ALREADY THERE (2026-09-08).  Both
+-- `rewind` and `_⋉_` carry a REDUNDANCY TEST (strong.CtxMorph §4): a
+-- replay is not replayed again, and a moved copy whose unmasks the inner
+-- list already performs — the outer changes being a replay, so the copy
+-- is the identity on the interior — is DROPPED.  Every lemma below keeps
+-- the statement it had, because both drops are EXACT; what changes is
+-- that each has two branches, and on the redundant one the obligation is
+-- the ORIGINAL frame's, on the nose.  Without the tests the change lists
+-- double at every pass (Examples §16), and what no exact rewriting can
+-- shrink is catalogued in proof/RewindNorm.
+--
 --   §1  the lookup transports
---   §2  the list algebra of `shiftScope`/`rewind`/`_⋉_`
---   §3  the type-context identities
+--   §2  the list algebra of `shiftScope`/`rewind`/`_⋉_`, and
+--       `rewind-idem`
+--   §3  the type-context identities, the unmask SET algebra
+--       (`applyUnlocks-absorb`) and the two merge bridges
 --   §4  the FRAME LEMMAS, as EQUALITIES
 --   §4b why the unlocks travel too — the lock-only move, REFUTED
 --   §5  `_⊢ᵐ_` for the two new frames

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -239,16 +239,100 @@ interior-rewind : (Θ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ
   → interior (rewind Θ) Δ ≡ pushBinds (binds Θ) Δ
 interior-rewind Θ mwᵥ = cong (pushBinds (binds Θ)) (scope-rewind Θ mwᵥ)
 
--- The two frames of the contractum, unfolded.
-interior-⋉ : (Θ₁ Θ₂ : CtxMorph) (Ξ : Ctxᵗ)
-  → interior (Θ₁ ⋉ Θ₂) Ξ
+-- ── THE MERGED LIST DOES WHAT THE FULL APPEND DOES ────────────────────
+--
+-- On `no` it IS the append.  On `yes` it is the inner list ALONE, and the
+-- two halves of `Redundant` (strong.CtxMorph §4) are exactly the two
+-- facts that make dropping the copy EXACT:
+--
+--   `applyChanges` — the dropped copy is the IDENTITY where it would have
+--     acted, because the outer changes are a replay
+--     (`applyChanges-rewindChanges` at its `yes`);
+--   `applyUnlocks` — its unmasks are ALREADY ON, because the inner list
+--     runs LAST and unlocks every slot the copy does
+--     (`applyUnlocks-absorb`).
+--
+-- Neither is a refinement step: both are EQUALITIES, so every lemma below
+-- keeps the shape it had.
+
+-- Every operation `applyUnlocks` performs is an `unmask`, and unmasks
+-- COMMUTE (strong.Ctx §6c) — at any two slots, the same one included.
+applyUnlocks-unmask-comm : (S : List Change) (X : ℕ) (Δ : Ctxᵗ)
+  → applyUnlocks S (unmask X Δ) ≡ unmask X (applyUnlocks S Δ)
+applyUnlocks-unmask-comm []             X Δ = refl
+applyUnlocks-unmask-comm (lock Y ∷ S)   X Δ =
+  applyUnlocks-unmask-comm S X Δ
+applyUnlocks-unmask-comm (unlock Y ∷ S) X Δ =
+  trans (cong (unmask Y) (applyUnlocks-unmask-comm S X Δ))
+        (unmask-comm Y X (applyUnlocks S Δ))
+
+-- … so what a list has already unmasked cannot be unmasked again.
+applyUnlocks-∈-idem : (S : List Change) (X : ℕ) (Δ : Ctxᵗ)
+  → X ∈ᴺ unlockSlots S → unmask X (applyUnlocks S Δ) ≡ applyUnlocks S Δ
+applyUnlocks-∈-idem (lock Y ∷ S)   X Δ i = applyUnlocks-∈-idem S X Δ i
+applyUnlocks-∈-idem (unlock Y ∷ S) X Δ hereᴺ = unmask-idem X (applyUnlocks S Δ)
+applyUnlocks-∈-idem (unlock Y ∷ S) X Δ (thereᴺ i) =
+  trans (unmask-comm X Y (applyUnlocks S Δ))
+        (cong (unmask Y) (applyUnlocks-∈-idem S X Δ i))
+
+-- THE ABSORPTION.  `L` runs LAST, so if it unlocks every slot `M`
+-- unlocks then `M`'s unmasks are invisible: `applyUnlocks` is a SET.
+applyUnlocks-absorb : (L M : List Change) (Δ : Ctxᵗ)
+  → unlockSlots M ⊆ᴺ unlockSlots L
+  → applyUnlocks L (applyUnlocks M Δ) ≡ applyUnlocks L Δ
+applyUnlocks-absorb L []             Δ s          = refl
+applyUnlocks-absorb L (lock X ∷ M)   Δ s          =
+  applyUnlocks-absorb L M Δ s
+applyUnlocks-absorb L (unlock X ∷ M) Δ (sub∷ i s) =
+  trans (applyUnlocks-unmask-comm L X (applyUnlocks M Δ))
+        (trans (cong (unmask X) (applyUnlocks-absorb L M Δ s))
+               (applyUnlocks-∈-idem L X Δ i))
+
+merge-applyChanges : (Θ₁ Θ₂ : CtxMorph) (d : Dec (Redundant Θ₁ Θ₂))
+  {Δ : Ctxᵗ} → Δ ⊢ˢ changes Θ₂
+  → applyChanges (mergeChanges Θ₁ Θ₂ d) (pushBinds (binds Θ₂) Δ)
+      ≡ applyChanges (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))
+                     (pushBinds (binds Θ₂) Δ)
+merge-applyChanges Θ₁ Θ₂ (no _)        b = refl
+merge-applyChanges Θ₁ Θ₂ (yes (r , _)) {Δ = Δ} b =
+  sym (trans (applyChanges-++ (changes Θ₁)
+                              (shiftScope (numBinds Θ₂) (changes Θ₂))
+                              (pushBinds (binds Θ₂) Δ))
+             (cong (applyChanges (changes Θ₁)) copy-id))
+  where
+  copy-id : applyChanges (shiftScope (numBinds Θ₂) (changes Θ₂))
+              (pushBinds (binds Θ₂) Δ) ≡ pushBinds (binds Θ₂) Δ
+  copy-id =
+    trans (applyChanges-shiftScope (binds Θ₂) (changes Θ₂) Δ)
+          (cong (pushBinds (binds Θ₂))
+                (applyChanges-rewindChanges (changes Θ₂) (yes r) b))
+
+merge-applyUnlocks : (Θ₁ Θ₂ : CtxMorph) (d : Dec (Redundant Θ₁ Θ₂))
+  (Ξ : Ctxᵗ)
+  → applyUnlocks (mergeChanges Θ₁ Θ₂ d) Ξ
+      ≡ applyUnlocks (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ
+merge-applyUnlocks Θ₁ Θ₂ (no _)        Ξ = refl
+merge-applyUnlocks Θ₁ Θ₂ (yes (_ , s)) Ξ =
+  sym (trans (applyUnlocks-++ (changes Θ₁)
+                              (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ)
+             (applyUnlocks-absorb (changes Θ₁)
+               (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ s))
+
+-- The two frames of the contractum, unfolded.  (The interior one is read
+-- at the type context the move puts it over — the rewound frame's
+-- interior — because that is where the dropped copy is the identity.)
+interior-⋉ : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ˢ changes Θ₂
+  → interior (Θ₁ ⋉ Θ₂) (pushBinds (binds Θ₂) Δ)
       ≡ pushBinds (binds Θ₁)
           (applyChanges (changes Θ₁)
-            (applyChanges (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ))
-interior-⋉ Θ₁ Θ₂ Ξ =
+            (applyChanges (shiftScope (numBinds Θ₂) (changes Θ₂))
+                          (pushBinds (binds Θ₂) Δ)))
+interior-⋉ Θ₁ Θ₂ {Δ = Δ} b =
   cong (pushBinds (binds Θ₁))
-       (applyChanges-++ (changes Θ₁)
-                        (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ)
+       (trans (merge-applyChanges Θ₁ Θ₂ (redundant? Θ₁ Θ₂) b)
+              (applyChanges-++ (changes Θ₁)
+                               (shiftScope (numBinds Θ₂) (changes Θ₂))
+                               (pushBinds (binds Θ₂) Δ)))
 
 convCtx-⋉ : (Θ₁ Θ₂ : CtxMorph) (Ξ : Ctxᵗ)
   → convCtx (Θ₁ ⋉ Θ₂) Ξ
@@ -257,8 +341,9 @@ convCtx-⋉ : (Θ₁ Θ₂ : CtxMorph) (Ξ : Ctxᵗ)
             (applyUnlocks (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ))
 convCtx-⋉ Θ₁ Θ₂ Ξ =
   cong (pushBinds (binds Θ₁))
-       (applyUnlocks-++ (changes Θ₁)
-                        (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ)
+       (trans (merge-applyUnlocks Θ₁ Θ₂ (redundant? Θ₁ Θ₂) Ξ)
+              (applyUnlocks-++ (changes Θ₁)
+                               (shiftScope (numBinds Θ₂) (changes Θ₂)) Ξ))
 
 ------------------------------------------------------------------------
 -- §4  THE FRAME LEMMAS — EQUALITIES
@@ -289,7 +374,7 @@ interior-⋉-rewind : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
   → interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)
 interior-⋉-rewind Θ₁ Θ₂ {Δ = Δ} mwᵥ
   rewrite interior-rewind Θ₂ mwᵥ =
-  trans (interior-⋉ Θ₁ Θ₂ (pushBinds (binds Θ₂) Δ))
+  trans (interior-⋉ Θ₁ Θ₂ (mw-changes mwᵥ))
         (cong (λ Ξ → pushBinds (binds Θ₁) (applyChanges (changes Θ₁) Ξ))
               (applyChanges-shiftScope (binds Θ₂) (changes Θ₂) Δ))
 
@@ -438,11 +523,25 @@ _ = refl
 -- nameable than where the redex read them, so `⊢ʳ-⊑` carries them and
 -- nothing has to be re-derived — under a SIMULTANEOUS reading on the
 -- PLAIN exterior neither half would survive.
-⊢ᵐ-⋉ : ∀ (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ}
+-- WHEN THE MOVED COPY IS DROPPED, THE MERGED FRAME IS Θ₁ ITSELF, and its
+-- `⊢ᵐ` is Θ₁'s own: the rewound frame's interior IS Θ₂'s interior,
+-- because Θ₂'s changes are a replay.  Both halves travel by `subst`
+-- along that ONE equality — no `⊢ˢ-++`, no `⊢ʳ-⊑`, nothing re-derived.
+⊢ᵐ-⋉ᴰ : ∀ (Θ₁ Θ₂ : CtxMorph) (d : Dec (Redundant Θ₁ Θ₂)) {Δ : Ctxᵗ}
   → Δ ⊢ᵐ Θ₂ → interior Θ₂ Δ ⊢ᵐ Θ₁
-  → interior (rewind Θ₂) Δ ⊢ᵐ (Θ₁ ⋉ Θ₂)
-⊢ᵐ-⋉ Θ₁ Θ₂ {Δ = Δ} b₂ b₁ =
-  subst (λ Ξ → Ξ ⊢ᵐ (Θ₁ ⋉ Θ₂)) (sym (interior-rewind Θ₂ b₂))
+  → interior (rewind Θ₂) Δ ⊢ᵐ morph (binds Θ₁) (mergeChanges Θ₁ Θ₂ d)
+⊢ᵐ-⋉ᴰ Θ₁ Θ₂ (yes (r , _)) {Δ = Δ} b₂ b₁ =
+  subst (λ Ξ → Ξ ⊢ᵐ Θ₁) (sym rewound-interior) b₁
+  where
+  rewound-interior : interior (rewind Θ₂) Δ ≡ interior Θ₂ Δ
+  rewound-interior =
+    trans (interior-rewind Θ₂ b₂)
+          (cong (pushBinds (binds Θ₂))
+                (sym (applyChanges-rewindChanges (changes Θ₂) (yes r)
+                                                 (mw-changes b₂))))
+⊢ᵐ-⋉ᴰ Θ₁ Θ₂ (no _) {Δ = Δ} b₂ b₁ =
+  subst (λ Ξ → Ξ ⊢ᵐ morph (binds Θ₁) (changes Θ₁ ++ S₂))
+        (sym (interior-rewind Θ₂ b₂))
         (mw reps chgs)
   where
   S₂ : List Change
@@ -469,6 +568,11 @@ _ = refl
                  (sym (applyChanges-shiftScope (binds Θ₂) (changes Θ₂) Δ))
                  (mw-changes b₁))
           (⊢ˢ-shiftScope (binds Θ₂) (changes Θ₂) (mw-changes b₂))
+
+⊢ᵐ-⋉ : ∀ (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ}
+  → Δ ⊢ᵐ Θ₂ → interior Θ₂ Δ ⊢ᵐ Θ₁
+  → interior (rewind Θ₂) Δ ⊢ᵐ (Θ₁ ⋉ Θ₂)
+⊢ᵐ-⋉ Θ₁ Θ₂ b₂ b₁ = ⊢ᵐ-⋉ᴰ Θ₁ Θ₂ (redundant? Θ₁ Θ₂) b₂ b₁
 
 ------------------------------------------------------------------------
 -- §6  THE TWO CASES

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -114,6 +114,17 @@ updateAt-app-tail f (E ∷ Ow) X Δ = cong (E ∷_) (updateAt-app-tail f Ow X Δ
   sw-u (subst (λ Ξ → Ξ ∋lk X) (sym (applyChanges-++ S T Δ)) lk)
        (⊢ˢ-++ S T b bT)
 
+-- … and its converse on the TAIL, which is all the sequential reading
+-- gives for free: T runs FIRST, so its own premises are already read
+-- over Δ and nothing has to be transported.  (There is no such lemma for
+-- the HEAD: S's premises are read over `applyChanges T Δ`, not Δ.)  This
+-- is what lets a frame whose change list IS a replay reuse the replayed
+-- half's judgement — `rewindChanges`'s `yes` branch, proof/MoveScope §3.
+⊢ˢ-suffix : (S T : List Change) {Δ : Ctxᵗ} → Δ ⊢ˢ (S ++ T) → Δ ⊢ˢ T
+⊢ˢ-suffix []             T b            = b
+⊢ˢ-suffix (lock X ∷ S)   T (sw-l tv b)  = ⊢ˢ-suffix S T b
+⊢ˢ-suffix (unlock X ∷ S) T (sw-u lk b)  = ⊢ˢ-suffix S T b
+
 ------------------------------------------------------------------------
 -- §2  The dual's change list
 ------------------------------------------------------------------------

--- a/SystemF/agda/strong/proof/RewindNorm.agda
+++ b/SystemF/agda/strong/proof/RewindNorm.agda
@@ -1,0 +1,269 @@
+module strong.proof.RewindNorm where
+
+-- NORMALISING A CHANGE LIST — WHAT IS AVAILABLE, AND WHAT IS REFUSED.
+--
+-- THE PROBLEM (Jeremy, 2026-09-08; measured in Examples §16).  Every
+-- scope move rewrites the outer frame as `rewind Θ₂` and moves Θ₂'s
+-- change list into the inner one, so over a run the SAME entries are
+-- replayed and re-moved and the lists grow as
+--
+--     ↧X , ↥X ↧X , ↥X ↧X ↥X ↧X , …
+--
+-- ending in dozens of adjacent inverse pairs.  Preservation is a theorem
+-- throughout — nothing is unsound — but a 36-step run reached a
+-- 130-entry change list.
+--
+-- WHAT LANDED (strong.CtxMorph §4): the two REDUNDANCY tests.  A replay
+-- is not replayed again (`Rewound`/`rewindChanges`, so `rewind` is
+-- IDEMPOTENT — proof/MoveScope `rewind-idem`), and a moved copy that is
+-- ALREADY THERE is dropped (`Redundant`/`mergeChanges`).  Both are EXACT:
+-- the frame lemmas stay equalities.  130 → 50 on the same run.
+--
+-- WHAT DOES NOT LAND, AND WHY.  The obvious normalisation — CONTRACT an
+-- adjacent inverse pair at one slot — is exact on the two type-context
+-- functions and is REFUSED BY THE SEQUENTIAL JUDGEMENT, in BOTH
+-- orientations, for two DIFFERENT reasons.  That is this module.
+--
+--   §1  the contractions are exact on `applyChanges` (both orientations)
+--       and on `applyUnlocks` (one of them)
+--   §2  … and `_⊢ˢ_` refuses both, with witnesses
+--   §3  `unlocksOf` alone — the cheapest imaginable `rewind`, refuted
+--       twice
+--   §4  what a CANONICAL form would have to be, and the two facts it
+--       still needs
+
+open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.List using (List; []; _∷_; _++_; length)
+open import Data.Product using (Σ; Σ-syntax; _×_; _,_; ∃-syntax)
+open import Data.Empty using (⊥)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; cong; trans)
+
+open import strong.Types using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀)
+open import strong.Ctx
+open import strong.CtxMorph
+
+------------------------------------------------------------------------
+-- §1  THE CONTRACTIONS ARE EXACT ON THE TYPE CONTEXTS
+------------------------------------------------------------------------
+
+-- `maskEnt` and `unmaskEnt` are SETTERS: each WRITES the lock layer
+-- without reading it (strong.Ctx §6), so at one slot the LAST-APPLIED
+-- entry wins.  There is no premise anywhere below — this is entry
+-- algebra, not the discipline.
+unmaskEnt-maskEnt-set : (E : Ent) → unmaskEnt (maskEnt E) ≡ unmaskEnt E
+unmaskEnt-maskEnt-set (unmasked b) = refl
+unmaskEnt-maskEnt-set (masked b)   = refl
+
+maskEnt-unmaskEnt-set : (E : Ent) → maskEnt (unmaskEnt E) ≡ maskEnt E
+maskEnt-unmaskEnt-set (unmasked b) = refl
+maskEnt-unmaskEnt-set (masked b)   = refl
+
+unmask-mask-set : (X : ℕ) (Δ : Ctxᵗ) → unmask X (mask X Δ) ≡ unmask X Δ
+unmask-mask-set X       []      = refl
+unmask-mask-set zero    (E ∷ Δ) = cong (_∷ Δ) (unmaskEnt-maskEnt-set E)
+unmask-mask-set (suc X) (E ∷ Δ) = cong (E ∷_) (unmask-mask-set X Δ)
+
+mask-unmask-set : (X : ℕ) (Δ : Ctxᵗ) → mask X (unmask X Δ) ≡ mask X Δ
+mask-unmask-set X       []      = refl
+mask-unmask-set zero    (E ∷ Δ) = cong (_∷ Δ) (maskEnt-unmaskEnt-set E)
+mask-unmask-set (suc X) (E ∷ Δ) = cong (E ∷_) (mask-unmask-set X Δ)
+
+-- ── THE THREE EXACT CONTRACTIONS ───────────────────────────────────────
+
+-- `↥X ↧X` — drop the LICENSING LOCK.  Exact on BOTH functions: the
+-- surviving unlock does the unmasking either way.
+applyChanges-contract-ul : (X : ℕ) (S : List Change) (Δ : Ctxᵗ)
+  → applyChanges (unlock X ∷ lock X ∷ S) Δ
+      ≡ applyChanges (unlock X ∷ S) Δ
+applyChanges-contract-ul X S Δ = unmask-mask-set X (applyChanges S Δ)
+
+applyUnlocks-contract-ul : (X : ℕ) (S : List Change) (Δ : Ctxᵗ)
+  → applyUnlocks (unlock X ∷ lock X ∷ S) Δ
+      ≡ applyUnlocks (unlock X ∷ S) Δ
+applyUnlocks-contract-ul X S Δ = refl
+
+-- `↧X ↥X` — drop the UNLOCK.  Exact on `applyChanges` …
+applyChanges-contract-lu : (X : ℕ) (S : List Change) (Δ : Ctxᵗ)
+  → applyChanges (lock X ∷ unlock X ∷ S) Δ
+      ≡ applyChanges (lock X ∷ S) Δ
+applyChanges-contract-lu X S Δ = mask-unmask-set X (applyChanges S Δ)
+
+-- … and NOT on `applyUnlocks`, which is the whole point of the
+-- conversion context: the dropped unlock is an unmask the REPS are read
+-- past.  ONE SLOT, ONE MASKED BINDER — and the two contexts differ.
+Δ↧ : Ctxᵗ
+Δ↧ = masked (bind `ℕ) ∷ []
+
+_ : applyUnlocks (lock 0 ∷ unlock 0 ∷ []) Δ↧ ≡ unmasked (bind `ℕ) ∷ []
+_ = refl
+
+_ : applyUnlocks (lock 0 ∷ []) Δ↧ ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+¬applyUnlocks-contract-lu :
+  ¬ (applyUnlocks (lock 0 ∷ unlock 0 ∷ []) Δ↧
+       ≡ applyUnlocks (lock 0 ∷ []) Δ↧)
+¬applyUnlocks-contract-lu ()
+
+-- … and the rep half of `_⊢ᵐ_` sees the difference.  A frame that BINDS
+-- a rep naming the slot is well formed with the pair and not without it.
+Θ↧ Θ↧✗ : CtxMorph
+Θ↧  = morph (` 0 ∷ []) (lock 0 ∷ unlock 0 ∷ [])
+Θ↧✗ = morph (` 0 ∷ []) (lock 0 ∷ [])
+
+⊢ᵐ-Θ↧ : Δ↧ ⊢ᵐ Θ↧
+⊢ᵐ-Θ↧ = mw (rw-b (wf-var (unmasked (bind `ℕ) , ez , nameable)) rw[])
+           (sw-l (unmasked (bind `ℕ) , ez , nameable)
+                 (sw-u (masked (bind `ℕ) , ez , locked) sw[]))
+
+¬⊢ᵐ-contract-lu : ¬ (Δ↧ ⊢ᵐ Θ↧✗)
+¬⊢ᵐ-contract-lu (mw (rw-b (wf-var (_ , ez , ())) _) _)
+
+------------------------------------------------------------------------
+-- §2  `_⊢ˢ_` REFUSES BOTH ORIENTATIONS
+------------------------------------------------------------------------
+
+-- IN A WELL-FORMED LIST THE ENTRIES AT ONE SLOT STRICTLY ALTERNATE:
+-- `sw-l` admits `lock X` only where X is NAMEABLE and `sw-u` admits
+-- `unlock X` only where it is LOCKED, so `↧X ↧X` and `↥X ↥X` have no
+-- derivation at all and the ONLY adjacent same-slot patterns are the two
+-- inverse pairs.  Contracting either one breaks the alternation at the
+-- SURVIVOR, and the survivor's own premise is what fails.
+
+-- ── ORIENTATION `↥X ↧X`: the survivor's licence is gone ────────────────
+--
+-- The slot is NAMEABLE on the exterior; the lock masks it and the unlock
+-- restores it.  Drop the lock and the unlock is VACUOUS — `sw-u` refuses
+-- it, and refusing it is exactly what makes the dual an inverse
+-- (`mask-unmask`, strong.Ctx §6b; proof/DualTightness).
+Δ↥ : Ctxᵗ
+Δ↥ = unmasked (bind `ℕ) ∷ []
+
+⊢ˢ-ul : Δ↥ ⊢ˢ (unlock 0 ∷ lock 0 ∷ [])
+⊢ˢ-ul = sw-u (masked (bind `ℕ) , ez , locked)
+             (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[])
+
+-- the contraction changes NEITHER type context …
+_ : applyChanges (unlock 0 ∷ lock 0 ∷ []) Δ↥
+      ≡ applyChanges (unlock 0 ∷ []) Δ↥
+_ = refl
+
+_ : applyUnlocks (unlock 0 ∷ lock 0 ∷ []) Δ↥
+      ≡ applyUnlocks (unlock 0 ∷ []) Δ↥
+_ = refl
+
+-- … and the contracted list has no derivation.
+¬⊢ˢ-contract-ul : ¬ (Δ↥ ⊢ˢ (unlock 0 ∷ []))
+¬⊢ˢ-contract-ul (sw-u (_ , ez , ()) _)
+
+-- ── ORIENTATION `↧X ↥X`: the survivor lands on a masked slot ───────────
+--
+-- The slot is LOCKED on the exterior; the unlock exposes it and the lock
+-- re-masks it.  Drop the unlock and the lock names a slot that is NOT
+-- nameable — `sw-l` refuses it.  (This orientation also loses an unmask,
+-- §1.)
+⊢ˢ-lu : Δ↧ ⊢ˢ (lock 0 ∷ unlock 0 ∷ [])
+⊢ˢ-lu = sw-l (unmasked (bind `ℕ) , ez , nameable)
+             (sw-u (masked (bind `ℕ) , ez , locked) sw[])
+
+¬⊢ˢ-contract-lu : ¬ (Δ↧ ⊢ˢ (lock 0 ∷ []))
+¬⊢ˢ-contract-lu (sw-l (_ , ez , ()) _)
+
+-- THE VERDICT.  NO adjacent-pair contraction is available: one
+-- orientation is exact on both type contexts and strands its unlock, the
+-- other is exact on the interior, loses an unmask on the conversion
+-- context, and strands its lock.  What CAN be dropped is a WHOLE
+-- redundant replay — which is what `Rewound` and `Redundant`
+-- (strong.CtxMorph §4) test for.
+
+------------------------------------------------------------------------
+-- §3  `unlocksOf` ALONE — REFUTED TWICE
+------------------------------------------------------------------------
+
+-- The cheapest imaginable rewound frame keeps only the unmasks the reps
+-- need: `morph (binds Θ) (unlocksOf (changes Θ))`.  It fails BOTH of
+-- `rewind`'s obligations.
+unlocksOf : List Change → List Change
+unlocksOf []             = []
+unlocksOf (lock X ∷ S)   = unlocksOf S
+unlocksOf (unlock X ∷ S) = unlock X ∷ unlocksOf S
+
+-- (1) THE FRAME IS NOT RESTORED.  `scope-rewind` (proof/MoveScope §3)
+-- says the rewound frame's changes are the IDENTITY on the exterior; the
+-- unlocks alone leave the slot EXPOSED, so the value's frame in the
+-- contractum is strictly more nameable than the redex's.
+_ : applyChanges (unlocksOf (unlock 0 ∷ [])) Δ↧ ≡ unmasked (bind `ℕ) ∷ []
+_ = refl
+
+¬scope-unlocksOf : ¬ (applyChanges (unlocksOf (unlock 0 ∷ [])) Δ↧ ≡ Δ↧)
+¬scope-unlocksOf ()
+
+-- (2) THE SURVIVING UNLOCK GOES VACUOUS, whenever its licence was a lock
+-- of the same list — the §2 configuration again, now reached by
+-- FILTERING rather than by contracting.
+_ : unlocksOf (unlock 0 ∷ lock 0 ∷ []) ≡ unlock 0 ∷ []
+_ = refl
+
+¬⊢ˢ-unlocksOf : ¬ (Δ↥ ⊢ˢ unlocksOf (unlock 0 ∷ lock 0 ∷ []))
+¬⊢ˢ-unlocksOf (sw-u (_ , ez , ()) _)
+
+-- … and re-locking the filtered list does not save it: the replay
+-- `dualScope 0 (unlocksOf S) ++ unlocksOf S` puts the unlock FIRST, on
+-- the plain exterior, where the slot is nameable.
+_ : dualScope 0 (unlocksOf (unlock 0 ∷ lock 0 ∷ []))
+      ++ unlocksOf (unlock 0 ∷ lock 0 ∷ [])
+    ≡ lock 0 ∷ unlock 0 ∷ []
+_ = refl
+
+¬⊢ˢ-replay-unlocksOf : ¬ (Δ↥ ⊢ˢ (lock 0 ∷ unlock 0 ∷ []))
+¬⊢ˢ-replay-unlocksOf (sw-l _ (sw-u (_ , ez , ()) _))
+
+------------------------------------------------------------------------
+-- §4  WHAT A CANONICAL FORM WOULD HAVE TO BE
+------------------------------------------------------------------------
+
+-- §1–§3 pin the normal form down completely.  A change list is, per
+-- slot, an ALTERNATING sequence (§2), and what any later reader can see
+-- of it is only
+--
+--   its NET state at that slot         (`applyChanges`: the LEFTMOST
+--                                       entry wins — head applies LAST)
+--   whether it unmasked it at all      (`applyUnlocks`: a SET of slots,
+--                                       strong.Ctx §6c)
+--
+-- so the canonical list is ONE BLOCK PER SLOT, and the block is fixed by
+-- the net state, the unmask flag, and the slot's state on the EXTERIOR
+-- (which `_⊢ˢ_` forces, and which is itself read off the list: the
+-- RIGHTMOST entry at that slot applies FIRST):
+--
+--   exterior   net      unmasked   block          length
+--   ---------------------------------------------------------
+--   locked     unlock   yes        ↥X                  1
+--   nameable   unlock   yes        ↥X ↧X               2
+--   locked     lock     yes        ↧X ↥X               2
+--   nameable   lock     yes        ↧X ↥X ↧X            3
+--   nameable   lock     no         ↧X                  1
+--   locked     lock     no         (no derivation)     —
+--
+-- so at most THREE entries per slot mentioned — on the Examples §16 run,
+-- at most FIVE slots are ever mentioned, i.e. a bound of 15 against the
+-- 50 the two redundancy tests reach and the 130 they started from.
+--
+-- TWO FACTS ARE STILL MISSING, and neither is in the tree:
+--
+--   (i)  COMMUTATION AT DISTINCT SLOTS.  `updateAt f X` and
+--        `updateAt g Y` commute for `X ≢ Y`; that is what brings one
+--        slot's entries adjacent so the blocks can be read off.  Only
+--        the SAME-setter case is proved (`unmask-comm`, strong.Ctx §6c),
+--        because that is all `applyUnlocks-absorb` needed.
+--   (ii) THE ORIENTATION IS NOT SYNTACTIC IN THE SLOT ALONE.  The block
+--        depends on the slot's EXTERIOR state, so the normaliser must
+--        read the rightmost entry at each slot and prove that the entry's
+--        own `_⊢ˢ_` premise IS the exterior's state — i.e. that
+--        `applyChanges S Δ` agrees with Δ at every slot S does not
+--        mention.
+--
+-- Until they are proved, the exact normalisation of §4 is not available
+-- and the two redundancy tests are what the development carries.


### PR DESCRIPTION
Probe of the change-list growth under IdPush/CancelR (Examples §16: 36 steps, peak list 130 entries before).

* Adjacent-pair cancellation is REFUTED by the sequential judgement in both orientations (proof/RewindNorm §1–2): exact on contexts, but ↥X ↧X → ↥X leaves a vacuous unlock and ↧X ↥X → ↧X a lock on a masked slot; entries at one slot strictly alternate in any well-formed list.
* Landed instead: two redundancy tests, exact on applyChanges and applyUnlocks. `rewind` replays only when the list is not already a replay (`Rewound`, decided by `rewound?`); `_⋉_` drops the moved copy when Θ₂'s changes are a replay whose unlock slots are already in Θ₁'s (`redundant?`). Every theorem statement is unchanged (frame lemmas remain equalities), every pinned run unchanged.
* Effect on §16 (before frame-exact Beta): peak list 130 → 50, entries per state 389 → 101; the growth was mostly in ⋉.
* AFTER merging #199 (frame-exact Beta) into this branch: §16 is 49 steps (was 36), peak list 248, entries per state 518 — the `↓Y` layers Beta mints are extra boundaries the IdPush/CancelR passes push through, and their change lists compound in the scope move. The redundancy tests still hold and still help, but the residue (merges of lists unlocking different slots) now dominates; the canonical per-slot form is the remaining lever.
* Residue: merges of lists unlocking different slots; bounding them needs the canonical per-slot form (≤ 3 entries per slot; stated in RewindNorm §4, not proven). `unlocksOf` as the outer frame refuted twice.
* Design point for the reviewer: the rules now carry decidable tests (`rewound?`, `redundant?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

* AFTER #202 (TyPeelR split) merged in as well: §16 is **25 steps**, peak list **64**, entries per state **130** (history: 130/389 → 50/101 → 248/518 → 64/130). One boundary fewer per type instantiation cuts the growth more than the redundancy tests alone; the residue is still the merges of lists unlocking different slots.
