### PR TITLE
Strong F: TyPeelR split into TyPeelR-Λ / TyPeelR-⟪⟫ — closes the last frame leak (audit fix (b)+(b′))

### DIFF
--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -48,9 +48,11 @@ open import strong.Eval
 
 -- THE SHIFT AUDIT (2026-09-08).  Every rule that MOVES a subterm,
 -- checked against frame exactness: the frame identity per site, the ONE
--- LEAK (TyPeelR's moved value gains the new binder's slot, UNMASKED),
--- the refutation of the wrap repair (it loops), and the prototype of the
--- repair that works — a TyBeta-like Λ case, PROVEN exact.
+-- LEAK it found (the single TyPeelR's moved value gained the new
+-- binder's slot, UNMASKED) with its witness, the refutation of the wrap
+-- repair (it LOOPS), and — for the two clauses that replaced the rule —
+-- their frame exactness and the tower measure that makes the wrapper
+-- clause terminate.  The repair is INSTALLED (strong.Reduction).
 open import strong.proof.ShiftAudit
 
 -- THE WALL.  The search for an INVARIANT grounding the premise

--- a/SystemF/agda/strong/All.agda
+++ b/SystemF/agda/strong/All.agda
@@ -46,6 +46,13 @@ open import strong.Progress
 -- preservation, and a Trace stores the step derivations it took
 open import strong.Eval
 
+-- THE SHIFT AUDIT (2026-09-08).  Every rule that MOVES a subterm,
+-- checked against frame exactness: the frame identity per site, the ONE
+-- LEAK (TyPeelR's moved value gains the new binder's slot, UNMASKED),
+-- the refutation of the wrap repair (it loops), and the prototype of the
+-- repair that works — a TyBeta-like Λ case, PROVEN exact.
+open import strong.proof.ShiftAudit
+
 -- THE WALL.  The search for an INVARIANT grounding the premise
 -- `interior Θ₂ Δ ⊢ᵗ A` — the one the old CancelR/IdPush contracta needed —
 -- is recorded in notes/DECISIONS.md (2026-09-06 entries).  The SCOPE MOVE

--- a/SystemF/agda/strong/Conversion.agda
+++ b/SystemF/agda/strong/Conversion.agda
@@ -16,7 +16,7 @@ module strong.Conversion where
 -- on the interior side of a leaf, and a BOUND X is not in the image of
 -- `shiftBy`, so it cannot sit on the exterior side.  Dropping `p` is what
 -- makes TyPeelR's preservation case a theorem at every ∀ conversion
--- rather than only at a reveal one (proof/Preserve.preserve-TyPeelR).
+-- rather than only at a reveal one (proof/Preserve.preserve-TyPeelR-Λ).
 --
 -- Conversions are REP-FREE by construction: `seal` and `unseal` carry a
 -- NAME, never a spelling, and the rep is read by a BINDER LOOKUP on the
@@ -179,7 +179,10 @@ mutual
 
 -- TyBeta's minted conversion IS this operation at an identity
 -- conversion: the type version is the conversion version on `mkId`.  (So
--- TyPeelR's reveal case really is TyBeta's mint, one ∀ inside.)
+-- TyPeelR's reveal case really is TyBeta's mint, one ∀ inside — and
+-- since the 2026-09-08 split that is literal: `TyPeelR-Λ` moves nothing
+-- and refines the `Λ`'s own slot into the boundary's binder, exactly as
+-- TyBeta does.)
 mutual
   instReveal-mkId : (X : ℕ) (B : Ty) → instReveal X (mkId B) ≡ reveal X B
   instReveal-mkId X (` Y)   = refl

--- a/SystemF/agda/strong/CtxMorph.agda
+++ b/SystemF/agda/strong/CtxMorph.agda
@@ -32,9 +32,10 @@ module strong.CtxMorph where
 -- (`scope`, `unlockedScope`, `interior`, `convCtx`), their refinement
 -- transports, the well-formedness judgement `Δ ⊢ᵐ Θ`, and the two
 -- derived morphisms the reduction rules use: the DUAL of a crossed
--- boundary (`dual`, for Peel) and the SCOPE MOVE (`rewind`, `_⋉_`, for
--- IdPush and CancelR).  Terms and typing are in strong.Terms, which
--- re-exports this module.
+-- boundary (`dual`, for Peel), the SCOPE MOVE (`rewind`, `_⋉_`, for
+-- IdPush and CancelR) and the APPENDED LOCK (`addLock0`, for
+-- TyPeelR-⟪⟫).  Terms and typing are in strong.Terms, which re-exports
+-- this module.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; _++_; map; length)
@@ -90,6 +91,26 @@ applyUnlocks : List Change → Ctxᵗ → Ctxᵗ
 applyUnlocks []             Δ = Δ
 applyUnlocks (unlock X ∷ S) Δ = unmask X (applyUnlocks S Δ)
 applyUnlocks (lock X ∷ S)   Δ = applyUnlocks S Δ
+
+-- APPENDING A CHANGE LIST.  Both functions apply their list HEAD-LAST, so
+-- in `S₁ ++ S₂` it is S₂ that runs FIRST.  This is the fact behind every
+-- rule that appends to a change list — the dual's two blocks
+-- (strong.CtxMorph §3), the scope move's travelling list (§4) and the
+-- appended lock of §5.
+applyChanges-++ : (S₁ S₂ : List Change) (Δ : Ctxᵗ)
+  → applyChanges (S₁ ++ S₂) Δ ≡ applyChanges S₁ (applyChanges S₂ Δ)
+applyChanges-++ []              S₂ Δ = refl
+applyChanges-++ (unlock X ∷ S₁) S₂ Δ =
+  cong (unmask X) (applyChanges-++ S₁ S₂ Δ)
+applyChanges-++ (lock X ∷ S₁)   S₂ Δ =
+  cong (mask X) (applyChanges-++ S₁ S₂ Δ)
+
+applyUnlocks-++ : (S₁ S₂ : List Change) (Δ : Ctxᵗ)
+  → applyUnlocks (S₁ ++ S₂) Δ ≡ applyUnlocks S₁ (applyUnlocks S₂ Δ)
+applyUnlocks-++ []              S₂ Δ = refl
+applyUnlocks-++ (unlock X ∷ S₁) S₂ Δ =
+  cong (unmask X) (applyUnlocks-++ S₁ S₂ Δ)
+applyUnlocks-++ (lock X ∷ S₁)   S₂ Δ = applyUnlocks-++ S₁ S₂ Δ
 
 -- THE TWO INDUCED CONTEXTS, at the morphism.
 scope : CtxMorph → Ctxᵗ → Ctxᵗ
@@ -231,6 +252,22 @@ data _⊢ˢ_ : Ctxᵗ → List Change → Set where
   sw-l : ∀ {S} → applyChanges S Δ ∋tv X → Δ ⊢ˢ S → Δ ⊢ˢ (lock X ∷ S)
   sw-u : ∀ {S} → applyChanges S Δ ∋lk X → Δ ⊢ˢ S → Δ ⊢ˢ (unlock X ∷ S)
 
+-- THE SEQUENTIAL JUDGEMENT OF AN APPEND.  `applyChanges` applies its
+-- list HEAD-LAST, so in `S ++ T` it is T that runs FIRST: S is judged
+-- over `applyChanges T Δ`, T over Δ.  Both premises land ON THE NOSE.
+-- Consumed by the dual (proof/PeelDual), the scope move
+-- (proof/MoveScope) and the appended lock (`⊢addLock0-cross`,
+-- strong.TermSubst).
+⊢ˢ-++ : (S T : List Change) {Δ : Ctxᵗ}
+  → applyChanges T Δ ⊢ˢ S → Δ ⊢ˢ T → Δ ⊢ˢ (S ++ T)
+⊢ˢ-++ []             T sw[]        bT = bT
+⊢ˢ-++ (lock X ∷ S)   T {Δ = Δ} (sw-l tv b) bT =
+  sw-l (subst (λ Ξ → Ξ ∋tv X) (sym (applyChanges-++ S T Δ)) tv)
+       (⊢ˢ-++ S T b bT)
+⊢ˢ-++ (unlock X ∷ S) T {Δ = Δ} (sw-u lk b) bT =
+  sw-u (subst (λ Ξ → Ξ ∋lk X) (sym (applyChanges-++ S T Δ)) lk)
+       (⊢ˢ-++ S T b bT)
+
 -- `Δ ⊢ᵐ Θ` — the context morphism Θ is WELL FORMED over Δ.  An infix
 -- judgement in the family of `Δ ⊢ᵗ A` (strong.Ctx) and `Δ ⊢ c ∶ A ⇝ B`
 -- (strong.Conversion).
@@ -340,6 +377,19 @@ shiftScope n []             = []
 shiftScope n (unlock X ∷ S) = unlock (n + X) ∷ shiftScope n S
 shiftScope n (lock X ∷ S)   = lock (n + X) ∷ shiftScope n S
 
+-- A change list LIFTED BY ONE steps PAST ONE ENTRY: the entry is
+-- untouched — MASKED entries included — and the list acts on the tail.
+-- (`applyChanges-shiftScope`, proof/MoveScope, is this past a whole
+-- `pushBinds` prefix; here the prefix is one arbitrary entry, which is
+-- what a boundary crossing ONE new bind slot needs.)
+applyChanges-shiftScope1 : (S : List Change) (E : Ent) (Δ : Ctxᵗ)
+  → applyChanges (shiftScope 1 S) (E ∷ Δ) ≡ E ∷ applyChanges S Δ
+applyChanges-shiftScope1 []             E Δ = refl
+applyChanges-shiftScope1 (unlock X ∷ S) E Δ =
+  cong (unmask (suc X)) (applyChanges-shiftScope1 S E Δ)
+applyChanges-shiftScope1 (lock X ∷ S)   E Δ =
+  cong (mask (suc X)) (applyChanges-shiftScope1 S E Δ)
+
 -- WHAT IS LEFT OF THE OUTER FRAME: the frame with its OWN CHANGES
 -- REWOUND.
 --
@@ -370,3 +420,58 @@ infixl 5 _⋉_
 _⋉_ : CtxMorph → CtxMorph → CtxMorph
 Θ₁ ⋉ Θ₂ =
   morph (binds Θ₁) (changes Θ₁ ++ shiftScope (numBinds Θ₂) (changes Θ₂))
+
+------------------------------------------------------------------------
+-- 5.  THE APPENDED LOCK — a boundary value moved under a NEW BIND
+------------------------------------------------------------------------
+
+-- WHAT IT IS.  `addLock0 Θ` is Θ with ONE `lock 0` appended to its own
+-- change list, at the TAIL — where `applyChanges` runs it FIRST, exactly
+-- the position the scope move `_⋉_` (§4) puts its travelling changes in.
+-- No bind is added and no rep is touched: `numBinds (addLock0 Θ)` is
+-- `numBinds Θ` by REFLEXIVITY.
+--
+-- WHY IT EXISTS.  FRAME EXACTNESS for a BOUNDARY VALUE MOVED UNDER A NEW
+-- BIND — `TyPeelR-⟪⟫` (strong.Reduction).  That rule pushes a type
+-- application inward past the binder it introduces, and the moved
+-- subterm is itself a boundary; without the appended lock the moved
+-- boundary's interior is offered the new slot UNMASKED, a slot it could
+-- not name before and cannot use after (notes/ShiftAudit.md §3).  A
+-- boundary carries its OWN change list, so the new binder can be masked
+-- for it with no second wrapper minted — which is what separates this
+-- repair from the one that loops (proof/ShiftAudit §4).
+--
+-- The frame it produces is the shape the other crossings produce: the
+-- moved subterm's BIRTH frame with the crossed binder MASKED — (†) for
+-- Peel (`interior-dual`) and `interior-Beta-Λ` for Beta.  The identity
+-- below says it in general; `interior-addLock0-cross` (strong.TermSubst)
+-- says it at the shift the rule performs.
+addLock0 : CtxMorph → CtxMorph
+addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
+
+numBinds-addLock0 : (Θ : CtxMorph) → numBinds (addLock0 Θ) ≡ numBinds Θ
+numBinds-addLock0 Θ = refl
+
+-- THE INDUCED CONTEXTS.  On the INTERIOR the appended lock acts FIRST, so
+-- it is exactly `mask 0` of the exterior — nothing else about the frame
+-- changes.
+scope-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → scope (addLock0 Θ) Δ ≡ scope Θ (mask 0 Δ)
+scope-addLock0 Θ Δ = applyChanges-++ (changes Θ) (lock 0 ∷ []) Δ
+
+interior-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (addLock0 Θ) Δ ≡ interior Θ (mask 0 Δ)
+interior-addLock0 Θ Δ = cong (pushBinds (binds Θ)) (scope-addLock0 Θ Δ)
+
+-- … and on the CONVERSION CONTEXT it acts NOT AT ALL: `applyUnlocks`
+-- skips locks, so the appended lock is LIFTED and the conversion is read
+-- exactly where it was.  This is what makes the repair free — the moved
+-- boundary's conversion re-types by `conv-ren` alone.
+unlockedScope-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → unlockedScope (addLock0 Θ) Δ ≡ unlockedScope Θ Δ
+unlockedScope-addLock0 Θ Δ = applyUnlocks-++ (changes Θ) (lock 0 ∷ []) Δ
+
+convCtx-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → convCtx (addLock0 Θ) Δ ≡ convCtx Θ Δ
+convCtx-addLock0 Θ Δ =
+  cong (pushBinds (binds Θ)) (unlockedScope-addLock0 Θ Δ)

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -1417,6 +1417,7 @@ is a known function of the old one:
 | `CancelR`, `IdPush` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)`, given `Δ ⊢ᵐ Θ₂` (`proof/MoveScope.interior-⋉-rewind`) |
 | `Beta` | `Δ` where no binder is crossed — no frame changes |
 | `Beta`, under a `Λ` | `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` — the image's BIRTH frame with the crossed `Λ`'s slot masked (`Examples.interior-Beta-Λ`) |
+| **`TyPeelR` (V's frame)** — **OPEN** | the identity above holds, but the new slot 0 arrives **UNMASKED**: `V` could not name it before and the frame offers it after.  A **LEAK** by the criterion, machine-checked in `proof/ShiftAudit` §3 (`TyPeelR-slot0-nameable` — the frame has it; `TyPeelR-V-tight` — `V`'s own `⊢rename` goes through at the MASKED entry; `TyPeelR-node-needs-slot0` — the pushed-in `·[ … , ` 0 ]` is what needs it, and it shares `V`'s frame; `TyPeelR-leak-¬⊑ᵃ` — the difference is one `le-mu`, the step a TERM may not travel).  It is not a scope gain (`wkᴹ 1` sends the fault one slot up, `Examples` §15b) — the frame simply does not say the truth.  Verdict, candidate fixes and the recommendation: `notes/ShiftAudit.md`; the repair, proven for the `Λ` case and frame-checked for the wrapper case, is `proof/ShiftAudit` §5/§5b. |
 
 The `Beta` row used to read `Δ` and nothing else, and it was the one
 INEXACT row: `substᵐ` shifted the image under the `Λ` without recording
@@ -1436,6 +1437,20 @@ gain**: `Beta` at an erasing body — `(λx:ℕ⇒ℕ. 3) · W` with `W` ill typ
 steps to `3`, which types.  Substitution may *drop* its argument, and a
 dropped subterm crosses nowhere; what is left was already typed inside
 the redex (`Examples` §15d).
+
+**The shift audit (2026-09-08)** re-read the table against the stronger
+question Jeremy asked after #199 — not "does the relation gain scope?"
+but "**does the frame say the truth about what the moved subterm may
+name?**" — and found **one open item**, the `TyPeelR` row above.  It is
+the only rule that puts a moved subterm under an **unmasked** new binder:
+`Peel` masks its whole bind prefix ((†)), frame-exact `Beta` masks the
+crossed `Λ`, and `TyBeta` introduces no new slot at all.  `Drop$` moves a
+numeral into a strictly *more* nameable frame, which is vacuous because a
+numeral names no type variable and no other term can take the step
+(`proof/ShiftAudit` §9).  The full site-by-site table, the witness, the
+candidate fixes with their hazards (the wrap repair **loops**; the resolve
+variant trades a scope leak for a **knowledge** leak) and the
+recommendation are in `notes/ShiftAudit.md`.
 
 ### `type-safety`
 

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -1417,7 +1417,7 @@ is a known function of the old one:
 | `CancelR`, `IdPush` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)`, given `Δ ⊢ᵐ Θ₂` (`proof/MoveScope.interior-⋉-rewind`) |
 | `Beta` | `Δ` where no binder is crossed — no frame changes |
 | `Beta`, under a `Λ` | `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` — the image's BIRTH frame with the crossed `Λ`'s slot masked (`Examples.interior-Beta-Λ`) |
-| **`TyPeelR` (V's frame)** — **OPEN** | the identity above holds, but the new slot 0 arrives **UNMASKED**: `V` could not name it before and the frame offers it after.  A **LEAK** by the criterion, machine-checked in `proof/ShiftAudit` §3 (`TyPeelR-slot0-nameable` — the frame has it; `TyPeelR-V-tight` — `V`'s own `⊢rename` goes through at the MASKED entry; `TyPeelR-node-needs-slot0` — the pushed-in `·[ … , ` 0 ]` is what needs it, and it shares `V`'s frame; `TyPeelR-leak-¬⊑ᵃ` — the difference is one `le-mu`, the step a TERM may not travel).  It is not a scope gain (`wkᴹ 1` sends the fault one slot up, `Examples` §15b) — the frame simply does not say the truth.  Verdict, candidate fixes and the recommendation: `notes/ShiftAudit.md`; the repair, proven for the `Λ` case and frame-checked for the wrapper case, is `proof/ShiftAudit` §5/§5b. |
+| **`TyPeelR` (V's frame)** — **OPEN** | the identity above holds, but the new slot 0 arrives **UNMASKED**: `V` could not name it before and the frame offers it after.  A **LEAK** by the criterion, machine-checked in `proof/ShiftAudit` §3 (`TyPeelR-slot0-nameable` — the frame has it; `TyPeelR-V-tight` — `V`'s own `⊢rename` goes through at the MASKED entry; `TyPeelR-node-needs-slot0` — the pushed-in `·[ … , ` 0 ]` is what needs it, and it shares `V`'s frame; `TyPeelR-leak-¬⊑ᵃ` — the difference is one `le-mu`, the step a TERM may not travel).  It is not a scope gain (`wkᴹ 1` sends the fault one slot up, `Examples` §15b) — the frame simply does not say the truth.  Verdict, candidate fixes and the recommendation: `notes/ShiftAudit.md`.  **A PROVEN REPAIR EXISTS ON THE PROBE BRANCH** — `proof/ShiftAudit` §5/§5b/§5c: the prototype relation `_⊢_-→ᵇ_` splits `TyPeelR` on the interior (`canon-∀`), the `Λ` case instantiating at once (no shift at all, the frame move is `TyBeta`'s own refinement) and the wrapper case appending `lock 0` to the moved boundary's **own** change list, so its new slot is MASKED (`TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-slot-locked`).  Preservation (`preserve-TyPeelR-Λ`, `preserve-TyPeelR-⟪⟫`), determinism (`detᵇ`), progress (`progressᵇ-·[]`, total over canonical `∀`-values, so the pair REPLACES the live rule), termination on a strictly decreasing tower measure (`TyPeelR-⟪⟫-height`) and a closed two-deep run are all machine-checked, with no premise added.  **STILL OPEN until installed** in `Reduction.agda`. |
 
 The `Beta` row used to read `Δ` and nothing else, and it was the one
 INEXACT row: `substᵐ` shifted the image under the `Λ` without recording
@@ -1449,8 +1449,9 @@ numeral into a strictly *more* nameable frame, which is vacuous because a
 numeral names no type variable and no other term can take the step
 (`proof/ShiftAudit` §9).  The full site-by-site table, the witness, the
 candidate fixes with their hazards (the wrap repair **loops**; the resolve
-variant trades a scope leak for a **knowledge** leak) and the
-recommendation are in `notes/ShiftAudit.md`.
+variant trades a scope leak for a **knowledge** leak), the repair that
+works — the `canon-∀` split, proven for both halves on the probe relation
+— and the recommendation are in `notes/ShiftAudit.md`.
 
 ### `type-safety`
 

--- a/SystemF/agda/strong/Design.md
+++ b/SystemF/agda/strong/Design.md
@@ -95,8 +95,9 @@ not typeable at any type.
    **list** — a context morphism — and not a single reveal-or-conceal.
 
 **The same program today.**  `Examples` §14 runs it, machine-rendered;
-`run-E` is the run, `⊢E₆` types the answer by `preservation*`, and
-`edet₁ … edet₆` pin every state as the only successor of its predecessor.
+`run-E` is the run, `⊢E₅` types the answer by `preservation*`, and
+`edet₁ … edet₅` pin every state as the only successor of its predecessor
+(`edet-E₅` says `E₅` has none).
 
 Diagram:
 
@@ -121,25 +122,21 @@ Diagram:
                  ⟪ ↓Y , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
         |
-        |  TyPeelR on the Beta-minted wrapper, lifted through
-        |  ⟪ ↑X:=ℕ , … ⟫ and ΛY
+        |  TyPeelR-⟪⟫ on the Beta-minted wrapper, lifted through
+        |  ⟪ ↑X:=ℕ , … ⟫ and ΛY — the moved boundary's change list gains
+        |  the new binder's lock, ↓X becomes ↓X , ↓Z (§6.4)
         v
-    E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
+    E₄  ((ΛY. (((ΛX′. (λx:X′. x))
+                   ⟪ ↓X , ↓Z , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
                  ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
         |
-        |  TyPeelR again, on the value's OWN Peel-minted wrapper —
-        |  the line the pre-boundary design died on
+        |  TyPeelR-Λ on the value's OWN Peel-minted wrapper — the line
+        |  the pre-boundary design died on.  The tower is exhausted, so
+        |  the Λ clause fires and instantiates on the spot
         v
-    E₅  ((ΛY. (((ΛY′. (λx:Y′. x)) [X′]
-                   ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
-                 ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
-          ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
-        |
-        |  TyBeta, inside the boundary TyPeelR just grew
-        v
-    E₆  ((ΛY. ((((λx:Y′. x) ⟪ ↑Y′:=X′ , (seal Y′ ↦ unseal Y′) ⟫)
-                   ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
+    E₅  ((ΛY. (((λx:X′. x)
+                   ⟪ ↑X′:=Z , ↓X , ↓Z , (seal X′ ↦ unseal X′) ⟫)
                  ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
           ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)                    a VALUE
 
@@ -165,8 +162,9 @@ Peel-minted wrapper the frames are
 nameable (`E-X-hidden`) and nothing was TRUNCATED — lesson 1.  And the
 argument `Y` is not written into the sealed body — `↑Z:=Y` binds a fresh
 `Z` at the representation `Y`, read in the *exterior* `E-dual-ext` where
-it is nameable, and the interior instantiates at `Z`: lesson 2.  Both
-contracta type by `preservation-TyPeelR`.
+it is nameable, and the interior instantiates at `Z`: lesson 2.  The two
+contracta type by `preservation-TyPeelR-⟪⟫` and
+`preservation-TyPeelR-Λ`.
 
 v1 took lesson 2 only — one combined boundary and a `TyWrap` that recorded
 the argument as a reveal representation; that is the "Example 8" entry of
@@ -290,13 +288,13 @@ type contexts.  A locked `X` is masked in the interior context, so it
 cannot appear on the interior side of a leaf; a bound `X` is not in the
 image of `shiftBy`, so it cannot appear on the exterior side.  A single
 global `p` is uniform only for single-kind morphisms, and it breaks the
-first time a rule mints a mixed one: `TyPeelR`'s frame, one bind
+first time a rule mints a mixed one: `TyPeelR-Λ`'s frame, one bind
 prepended to `Θ = morph [] (lock 0 ∷ [])`, produces the conversion
 `seal 0 ↦ seal 1`, whose two
 leaves cite *different* binders and demand opposite values of one `p`
 (`Examples` §13a, `¬seal↦seal` in the record).  Dropping `p` is what
 makes `TyPeelR` preservation a theorem at every `∀`-conversion rather
-than only at a reveal one (`proof/Preserve.preserve-TyPeelR`).
+than only at a reveal one (`proof/Preserve.preserve-TyPeelR-Λ`).
 
 
 ## 3. Type contexts and the mask discipline (`strong.Ctx`)
@@ -880,6 +878,22 @@ unconditionally (`proof/PeelDual.agda`).
 Note `numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁` and
 `numBinds (rewind Θ) ≡ numBinds Θ`: neither operation carries a binder.
 
+**The appended lock** (§6.4, `strong.CtxMorph` §5):
+
+    addLock0 Θ = morph (binds Θ) (changes Θ ++ [ lock 0 ])
+
+one `lock 0` at the **tail** of a boundary's own change list, where
+`applyChanges` runs it **first** — exactly the position `_⋉_` puts its
+travelling changes in.  It carries no binder
+(`numBinds (addLock0 Θ) ≡ numBinds Θ`, by reflexivity) and it is
+invisible on the conversion context
+(`convCtx (addLock0 Θ) Δ ≡ convCtx Θ Δ`, because `applyUnlocks` skips
+locks), so a boundary that acquires it re-types its conversion by
+`conv-ren` alone.  On the interior it is exactly `mask 0`:
+`interior (addLock0 Θ) Δ ≡ interior Θ (mask 0 Δ)`.  `TyPeelR-⟪⟫` is its
+only user: it is how a moved boundary masks the new bind slot in its own
+frame instead of under a minted wrapper.
+
 
 ### 6.1 `TyBeta` — the boundary is born
 
@@ -1032,18 +1046,37 @@ is now REFUSED (`¬⊢Contractum`), and the positive control still passes:
 at a Θ-**locked** slot the dual unlocks it again and the argument keeps
 its frame.
 
-### 6.4 `TyPeelR` — a `∀` conversion meets a type application
+### 6.4 `TyPeelR-Λ` / `TyPeelR-⟪⟫` — a `∀` conversion meets a type application
 
-    TyPeelR : Value V
+`canon-∀` (`proof/Canonical`) says a closed value at a `∀` type is a `Λ`
+over a value **or** a wrapper with a `∀` conversion, and nothing else, so
+the rule is **two clauses**, split on the crossed boundary's interior
+(2026-09-08, the shift audit; `notes/ShiftAudit.md`).  Together they are
+total over canonical `∀`-values, so the pair *replaces* the single rule
+rather than supplementing it.
+
+    TyPeelR-Λ : Value N
       → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-      → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-          -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+      → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+          -→ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+    TyPeelR-⟪⟫ : Value W
+      → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+      → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+          -→ ((renᴹ (extN (numBinds Θ′) suc) W
+                 ⟪ addLock0 (renᴮ suc Θ′)
+                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
-Named: `(V ⟪ Θ , ∀X. s ⟫) [B, A] → (V [Bᵢ, X]) ⟪ ↑X:=A , Θ , instReveal X s ⟫`
+Named: the `Λ` clause is
+`((ΛX. N) ⟪ Θ , ∀X. s ⟫) [B, A] → N ⟪ ↑X:=A , Θ , instReveal X s ⟫`, and
+the wrapper clause is
+`((W ⟪ Θ′ , ∀X. s′ ⟫) ⟪ Θ , ∀X. s ⟫) [B, A]
+   → ((W ⟪ ↓X , Θ′ , ∀X. s′ ⟫) [Bᵢ, X]) ⟪ ↑X:=A , Θ , instReveal X s ⟫`,
 where `Bᵢ` is the interior `∀`-body determined by the premise.
 
-**Bookkeeping**, three moves:
+**Bookkeeping**, shared by both clauses:
 
 1. **A new binder is prepended.**  The frame becomes
    `morph (A ∷ binds Θ) (changes Θ)` — plain
@@ -1051,16 +1084,7 @@ where `Bᵢ` is the interior `∀`-body determined by the premise.
    past the prepended binder:
    `interior (morph (A ∷ binds Θ) (changes Θ)) Δ
     ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`.
-2. **The interior is instantiated at the new binder's name**, `` ` 0 ``,
-   not at `A`.  The pushed-in body annotation must be the **interior**
-   `∀`-body `Bᵢ`, which is what the interior's own `⊢·[]` demands and
-   which differs from the exterior body at every non-identity leaf.  `Bᵢ`
-   is not syntactically recoverable from a representation-free conversion
-   (a `seal`'s source is a binder's representation), so the rule carries
-   the conversion typing as a **premise**.  `Progress` supplies it for
-   free by inverting the redex's own `env` (`conv-all-inv`), and
-   determinism is `conv-types-unique`.
-3. **The conversion is re-minted at the new slot.**  Slot 0 of `s`'s body
+2. **The conversion is re-minted at the new slot.**  Slot 0 of `s`'s body
    was `abst` and is now the binder this rule introduces, so every leaf
    that reads it must become the instantiation step: `unseal 0` where the
    conversion runs covariantly, `seal 0` where it runs contravariantly —
@@ -1068,11 +1092,79 @@ where `Bᵢ` is the interior `∀`-body determined by the premise.
    still mentions `` ` 0 `` where `env` demands the instantiated
    `shiftBy (numBinds Θ + 1) (Bₑ [ A ])` (`Examples` §13a, `¬⊢J-plain`).
 
-Example, the **reveal** side (`Examples` §13b, `H₃ → H₄`):
+**What the `Λ` clause does.**  Nothing moves.  The `Λ`'s `abst` slot
+*becomes* the boundary's `bind` slot, so the body's frame move is a
+refinement `abst → bind` at a slot it could already name — `la-uu le-ab`,
+legal for `_⊑ᵃ_`, which is `TyBeta`'s own step one `∀` inside.  There is
+no `wkᴹ`, no `⊢rename`, and the contractum does not mention `Bᵢ` at all,
+so it is determined by the redex without `conv-src-unique`.
+
+**What the wrapper clause does.**  The type application is pushed inward
+one layer, exactly as the single rule pushed it, and the moved subterm is
+shifted by `wkᴹ 1` — which on a boundary renames its interior at
+`extN (numBinds Θ′) suc`, its frame by `renᴮ suc` and its conversion body
+at `extᵗ (extN (numBinds Θ′) suc)`.  On top of that, `lock 0` is
+**appended to the moved boundary's own change list** (`addLock0`, §5's
+`_⋉_` position: at the tail, where `applyChanges` runs it first).  The
+pushed-in body annotation must be the **interior** `∀`-body `Bᵢ`, which
+is what the interior's own `⊢·[]` demands and which differs from the
+exterior body at every non-identity leaf.  `Bᵢ` is not syntactically
+recoverable from a representation-free conversion (a `seal`'s source is a
+binder's representation), so the rule carries the conversion typing as a
+**premise**.  `Progress` supplies it for free by inverting the redex's own
+`env` (`conv-all-inv`), and determinism is `conv-src-unique`.
+
+**Why the appended lock.**  Without it the moved boundary's interior is
+offered the new bind slot **unmasked** — a slot it could not name before
+and cannot use after, because `wkᴹ 1` sends every index to ≥ 1.  The tight
+frame and the offered one differ by exactly one `le-mu`, the re-exposure
+clause, which is precisely the step `_⊑ᵃ_` refuses; that was the audit's
+one leak (`notes/ShiftAudit.md` §3).  With the lock the moved boundary's
+frame is its **birth frame with the crossed binder masked** —
+`proof/ShiftAudit.TyPeelR-⟪⟫-frame`, the same shape `(†)` gives `Peel`'s
+crossing argument and `interior-Beta-Λ` gives `Beta`'s.
+
+**Why the wrapper clause terminates.**  Its contractum's inner
+application is again a redex, but the `∀`-value's **tower height** — the
+number of nested boundaries above the `Λ` — strictly decreases
+(`TyPeelR-⟪⟫-height`), because the clause *consumes* a boundary that was
+already there.  A tower of height `h` therefore takes `h − 1` wrapper
+steps and then exactly one `Λ` step.  The rejected repair — wrap the
+moved value in the new binder's dual — *mints* a boundary instead, so its
+measure stalls and it loops: an identity conversion at a `∀` is
+necessarily a `` `∀ `` conversion, hence inert, hence the wrapped value
+under `·[ … ]` is itself a redex (`fixA-height-stalls`, and the run
+`T₀ -→ᵃ T₁ -→ᵃ T₂` in `proof/ShiftAudit` §4a).
+
+**Example — both clauses, on a two-deep tower** (`proof/ShiftAudit` §5c₃,
+machine-rendered; the outer frame binds `X := ℕ` and the inner one locks
+it, so the moved boundary really does carry a change list for the
+appended lock to join):
+
+    (((ΛY. 3) ⟪ ↓X , (∀Y. id ℕ) ⟫) ⟪ ↑X:=ℕ , (∀Y. id ℕ) ⟫) [ℕ]
+      →  TyPeelR-⟪⟫   (tower height 2 → 1)
+    (((ΛZ. 3) ⟪ ↓X , ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
+      →  TyPeelR-Λ    (tower exhausted)
+    ((3 ⟪ ↑Z:=Y , ↓X , ↓Y , id ℕ ⟫) ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
+
+Read the moved boundary's change list across the first step: `↓X` becomes
+`↓X , ↓Y` — the shifted original lock and the new lock, appended at the
+tail.  Nothing else about that boundary changes, and no wrapper appears.
+The frames confirm it:
+
+    showTCtxAt 9 0 (λ _ → "X") Ξᵈ₁                    =  ⌷[X := ℕ]
+    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵈ₃
+      =  ⌷[Y := ℕ] , ⌷[X := ℕ]
+
+`Ξᵈ₁` is `W`'s birth frame and `Ξᵈ₃` its frame in the contractum: the same
+frame with the new binder `Y` inserted **masked**.  Exact.
+
+**Example — the mint, at both conversions.**  The **reveal** side
+(`Examples` §13b, `H₃ → H₄`):
 
     ((ΛY. (λx:Y. (7 ⟪ ↓X , seal X ⟫)))
        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ unseal X)) ⟫) [ℕ]
-      →  ((ΛZ. (λx:Z. (7 ⟪ ↓X , seal X ⟫))) [Y]
+      →  ((λx:Y. (7 ⟪ ↓X , seal X ⟫))
             ⟪ ↑Y:=ℕ , ↑X:=ℕ , (seal Y ↦ unseal X) ⟫)
 
 with `` instReveal 0 (id (` 0) ↦ unseal 1) ≡ seal 0 ↦ unseal 1 ``: the
@@ -1082,13 +1174,19 @@ inserted `seal Y` conceals the binder this rule introduced, under an
 
     ((((ΛY. (λx:Y. 3)) ⟪ ↓X , (∀Y. (id Y ↦ seal X)) ⟫) [X]
         · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
-      →  ((((ΛZ. (λx:Z. 3)) [Y] ⟪ ↑Y:=X , ↓X , (seal Y ↦ seal X) ⟫)
+      →  ((((λx:Y. 3) ⟪ ↑Y:=X , ↓X , (seal Y ↦ seal X) ⟫)
             · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
 
 Here `instReveal 0 s ≡ seal 0 ↦ seal 1` — the two-conceal tree of §3's
 diagram, the one no single polarity could type.  Both examples reach
-their redex from closed, plain System F source, and both contracta type
-by `preservation-TyPeelR`.
+their redex from closed, plain System F source, both are `Λ`-clause
+steps, and both contracta type by `preservation-TyPeelR-Λ`.  Note that
+both contracta are one boundary shallower than the single rule's: the
+`Λ` clause performs the instantiation itself, so no
+`(Λ …) ·[ … , ` 0 ]` is left behind for `TyBeta` to consume, and one type
+instantiation mints **one** binder where the old rule pair minted two.
+That is why the `J` run is eleven steps rather than fourteen and the `E`
+run of `Examples` §14 is five rather than six.
 
 ### 6.5 `Drop$`
 
@@ -1351,11 +1449,20 @@ Induction on the step, with the rule cases distributed:
   `⊢rename (wkN (numBinds Θ))` and **nothing else** — the tail is `Δ`
   itself, so no `⊢retag` and no `le-mu` — and the conversion `s`
   transplants verbatim through the second identity.
-* **`TyPeelR`** (`proof/Preserve.preserve-TyPeelR`) — at **every**
-  `∀`-conversion, once polarity is gone.  The interior instantiation
-  lands at the fresh binder's name, `ren-suc-[0]` undoes the annotation
-  shift, and the minted `instReveal 0 s` types leaf by leaf, each leaf
-  citing its own binder.
+* **`TyPeelR-Λ`** (`proof/Preserve.preserve-TyPeelR-Λ`) — at **every**
+  `∀`-conversion, once polarity is gone.  The body is `⊢retag`ged along
+  `la∷ (la-uu le-ab) (⊑ᵃ-refl _)` — the `Λ`'s slot becoming the
+  boundary's binder — and the minted `instReveal 0 s` types leaf by leaf,
+  each leaf citing its own binder.  Nothing is renamed.
+* **`TyPeelR-⟪⟫`** (`proof/Preserve.preserve-TyPeelR-⟪⟫`) — the same
+  outer `env`, with the moved boundary crossing by `⊢addLock0-cross`
+  (`strong.TermSubst`): its reps by `⊢ʳ-ren`, its changes by `⊢ˢ-++`
+  (`⊢ˢ-ren` plus `sw-l` for the appended lock, whose slot **is**
+  nameable), its interior by `⊢rename` at `Ren-addLock0` **alone**, and
+  its conversion by `conv-ren` — the appended lock is lifted on the
+  conversion context (`convCtx-addLock0`), so nothing about the
+  conversion changes.  The interior instantiation lands at the fresh
+  binder's name and `ren-suc-[0]` undoes the annotation shift.
 * **`Drop$`** — one inversion: `conv-id-refl` plus `shiftBy-ℕ⁻` force the
   exterior type to be the base type.
 * **`CancelR`, `IdPush`** (`proof/MoveScope`) — the scope move, §6.7.
@@ -1386,8 +1493,12 @@ the whole preservation proof — `TyBeta`'s `abst ⊑ᵃᵉ bind A`.
 case analysis on the two steps; the interesting entries are the rules
 whose contracta are not syntactically determined by the redex:
 
-* `TyPeelR`'s pushed-in annotation is premise-determined, and the two
-  premises give the same annotation by `conv-types-unique` (§4.4);
+* `TyPeelR-⟪⟫`'s pushed-in annotation is premise-determined, and the two
+  premises give the same annotation by `conv-src-unique` (§4.4).
+  `TyPeelR-Λ` needs no such appeal: its contractum does not mention the
+  annotation at all, so it is determined by the redex outright.  The two
+  clauses' patterns are disjoint (a `Λ` is not a boundary), so no cross
+  case arises;
 * `CancelR` and `IdPush` mint identity conversions at a looked-up
   representation, and the two lookups agree by `∋:=-det`.
 
@@ -1412,12 +1523,12 @@ is a known function of the old one:
 | rule | the moved subterm's new frame |
 |------|-------------------------------|
 | `TyBeta` | `interior (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ` — `Δ` on the nose, one refinement (`unmasked abst ⊑ᵃᵉ unmasked (bind A)`, i.e. `la-uu le-ab`) at the slot the rule reveals |
-| `TyPeelR` | `interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ` — the redex's frame, one binder in, which `wkᴹ 1` matches |
+| `TyPeelR-Λ` | `interior (morph (A ∷ binds Θ) (changes Θ)) Δ ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ` — the redex's frame, one binder in, and the body is **not moved**: its slot 0 was `unmasked abst` and is now `unmasked (bind …)`, the same `la-uu le-ab` refinement `TyBeta` performs, at a slot it could already name.  No shift at all (`proof/ShiftAudit.TyPeelR-Λ-refinement`, `TyPeelR-Λ-no-shift`) |
+| `TyPeelR-⟪⟫` | `interior (addLock0 (renᴮ suc Θ′)) (interior (morph (A ∷ binds Θ) (changes Θ)) Δ) ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind (shiftBy (numBinds Θ) A)) ∷ scope Θ′ (interior Θ Δ))` — the moved boundary's **birth frame** with the new binder inserted **masked** below its bind prefix, the same shape `(†)` gives `Peel` and `interior-Beta-Λ` gives `Beta` (`proof/ShiftAudit.TyPeelR-⟪⟫-frame` and `-slot-locked`, from `strong.TermSubst.interior-addLock0-cross`); it crosses by `⊢rename` alone, at `Ren-addLock0` |
 | `Peel` | (†) `interior (dual Θ) (interior Θ Δ) ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ`, given `Δ ⊢ᵐ Θ` (`proof/PeelDual.interior-dual`) |
 | `CancelR`, `IdPush` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)`, given `Δ ⊢ᵐ Θ₂` (`proof/MoveScope.interior-⋉-rewind`) |
 | `Beta` | `Δ` where no binder is crossed — no frame changes |
 | `Beta`, under a `Λ` | `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` — the image's BIRTH frame with the crossed `Λ`'s slot masked (`Examples.interior-Beta-Λ`) |
-| **`TyPeelR` (V's frame)** — **OPEN** | the identity above holds, but the new slot 0 arrives **UNMASKED**: `V` could not name it before and the frame offers it after.  A **LEAK** by the criterion, machine-checked in `proof/ShiftAudit` §3 (`TyPeelR-slot0-nameable` — the frame has it; `TyPeelR-V-tight` — `V`'s own `⊢rename` goes through at the MASKED entry; `TyPeelR-node-needs-slot0` — the pushed-in `·[ … , ` 0 ]` is what needs it, and it shares `V`'s frame; `TyPeelR-leak-¬⊑ᵃ` — the difference is one `le-mu`, the step a TERM may not travel).  It is not a scope gain (`wkᴹ 1` sends the fault one slot up, `Examples` §15b) — the frame simply does not say the truth.  Verdict, candidate fixes and the recommendation: `notes/ShiftAudit.md`.  **A PROVEN REPAIR EXISTS ON THE PROBE BRANCH** — `proof/ShiftAudit` §5/§5b/§5c: the prototype relation `_⊢_-→ᵇ_` splits `TyPeelR` on the interior (`canon-∀`), the `Λ` case instantiating at once (no shift at all, the frame move is `TyBeta`'s own refinement) and the wrapper case appending `lock 0` to the moved boundary's **own** change list, so its new slot is MASKED (`TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-slot-locked`).  Preservation (`preserve-TyPeelR-Λ`, `preserve-TyPeelR-⟪⟫`), determinism (`detᵇ`), progress (`progressᵇ-·[]`, total over canonical `∀`-values, so the pair REPLACES the live rule), termination on a strictly decreasing tower measure (`TyPeelR-⟪⟫-height`) and a closed two-deep run are all machine-checked, with no premise added.  **STILL OPEN until installed** in `Reduction.agda`. |
 
 The `Beta` row used to read `Δ` and nothing else, and it was the one
 INEXACT row: `substᵐ` shifted the image under the `Λ` without recording
@@ -1427,10 +1538,11 @@ exact.  The dual wrapper of §6.2 closes it, and `Examples` §15d₂ runs the
 test on the closed case.
 
 The first two rows and the last are `refl` (`Examples.interior-TyBeta`,
-`interior-TyPeelR`, `interior-Beta-Λ`); the `Peel` and scope-move rows are
-the theorems whose `Δ ⊢ᵐ Θ` premise is where the sequential judgement pays
-for itself (§4.2).  `Drop$` and the five congruences move nothing into a
-new frame.
+`interior-TyPeelR`, `interior-Beta-Λ`); the `TyPeelR-⟪⟫` row is
+`applyChanges-++` plus `applyChanges-shiftScope1` (`strong.CtxMorph` §5,
+`strong.TermSubst`), and the `Peel` and scope-move rows are the theorems
+whose `Δ ⊢ᵐ Θ` premise is where the sequential judgement pays for itself
+(§4.2).  `Drop$` and the five congruences move nothing into a new frame.
 
 Every rule passes.  **The one exception is recorded and is not a scope
 gain**: `Beta` at an erasing body — `(λx:ℕ⇒ℕ. 3) · W` with `W` ill typed
@@ -1441,17 +1553,31 @@ the redex (`Examples` §15d).
 **The shift audit (2026-09-08)** re-read the table against the stronger
 question Jeremy asked after #199 — not "does the relation gain scope?"
 but "**does the frame say the truth about what the moved subterm may
-name?**" — and found **one open item**, the `TyPeelR` row above.  It is
-the only rule that puts a moved subterm under an **unmasked** new binder:
-`Peel` masks its whole bind prefix ((†)), frame-exact `Beta` masks the
-crossed `Λ`, and `TyBeta` introduces no new slot at all.  `Drop$` moves a
-numeral into a strictly *more* nameable frame, which is vacuous because a
-numeral names no type variable and no other term can take the step
-(`proof/ShiftAudit` §9).  The full site-by-site table, the witness, the
-candidate fixes with their hazards (the wrap repair **loops**; the resolve
-variant trades a scope leak for a **knowledge** leak), the repair that
-works — the `canon-∀` split, proven for both halves on the probe relation
-— and the recommendation are in `notes/ShiftAudit.md`.
+name?**" — and found **one** offending row, the old single `TyPeelR`.  It
+was the only rule that put a moved subterm under an **unmasked** new
+binder: the identity above held, but the new slot 0 arrived unmasked, so
+the frame offered `V` a slot `V` could not name before and cannot use
+after (`wkᴹ 1` sends every index to ≥ 1).  Machine-checked in
+`proof/ShiftAudit` §3 — `TyPeelR-slot0-nameable` (the frame has it),
+`TyPeelR-V-tight` (`V`'s own `⊢rename` goes through at the **masked**
+entry), `TyPeelR-node-needs-slot0` (the pushed-in `·[ … , ` 0 ]` is what
+needs it, and it shares `V`'s frame) and `TyPeelR-leak-¬⊑ᵃ` (the
+difference is exactly one `le-mu`, the step a **term** may not travel).
+It was never a scope gain — the frame simply did not say the truth.
+
+**That row is now closed.**  The split of §6.4 is installed, and the two
+clauses give the two exact rows above: `Peel` masks its whole bind prefix
+((†)), frame-exact `Beta` masks the crossed `Λ`, `TyBeta` introduces no
+new slot at all, `TyPeelR-Λ` moves nothing, and `TyPeelR-⟪⟫` masks the
+new binder in the moved boundary's own change list.  **Every rule that
+moves a subterm masks what it introduces, and the table has no
+exceptions.**  `Drop$` moves a numeral into a strictly *more* nameable
+frame, which is vacuous because a numeral names no type variable and no
+other term can take the step (`proof/ShiftAudit` §9).  The full
+site-by-site table, the witness of what the leak was, and the candidate
+fixes with their hazards — the wrap repair **loops** (`proof/ShiftAudit`
+§4/§4a, still recorded as a refutation), the resolve variant trades a
+scope leak for a **knowledge** leak — are in `notes/ShiftAudit.md`.
 
 ### `type-safety`
 
@@ -1665,6 +1791,29 @@ is `notes/DesignSpace.md`, with `notes/DesignPoints.md` as its glossary.
   The tests that came out of it are `proof/DualTightness` (the `unlock`
   half) and `Examples` §15 (every other rule that moves a subterm), with
   the frame-identity table in §7.
+* **The shift audit, and the `TyPeelR` split** (Jeremy, 2026-09-08; this
+  PR).  "Frame exactness is the main point of Strong System F" — so after
+  #199 made `Beta` exact Jeremy asked for an audit of *every* place a
+  rule moves a subterm, against the stronger question: does the frame say
+  the truth about what the moved subterm may name?  `proof/ShiftAudit`
+  answers it site by site (§7's table), and found **one** leak: the
+  single `TyPeelR` moved its value into a frame with a new **unmasked**
+  bind slot.  The candidates and their fates are in
+  `notes/ShiftAudit.md` — wrapping the moved value in the new binder's
+  dual **loops** (machine-refuted, `proof/ShiftAudit` §4/§4a, kept as a
+  record), and the resolve variant trades a scope leak for a *knowledge*
+  leak, which the binder-syntactic design exists to forbid.  What landed
+  is the `canon-∀` **split**: `TyPeelR-Λ` instantiates a `Λ` interior on
+  the spot (no shift at all; the `Λ`'s slot becomes the boundary's
+  binder, `TyBeta`'s own refinement one `∀` inside) and `TyPeelR-⟪⟫`
+  pushes inward past a boundary interior, masking the new binder in the
+  moved boundary's **own** change list (`addLock0`, `strong.CtxMorph`
+  §5).  No premise was added; the pair is total over canonical
+  `∀`-values, so it replaces the single rule.  Its descent terminates on
+  the `∀`-value's tower height, the measure the wrap repair leaves fixed.
+  Side effect: one type instantiation now mints **one** binder where the
+  old rule pair minted two, so runs get shorter (`Examples` §13a's `J`
+  eleven steps rather than fourteen, §14's `E` five rather than six).
 
 
 ## Appendix A. Names

--- a/SystemF/agda/strong/Eval.agda
+++ b/SystemF/agda/strong/Eval.agda
@@ -59,7 +59,7 @@ open import strong.Ctx using (Ctxᵗ)
 open import strong.Terms using (Term; Value; _∣_⊢_⦂_)
 open import strong.Reduction
   using (_⊢_-→_; _⊢_-→*_; done; _then_; det;
-         TyBeta; Beta; Peel; TyPeelR; CancelR; Drop$; IdPush;
+         TyBeta; Beta; Peel; TyPeelR-Λ; TyPeelR-⟪⟫; CancelR; Drop$; IdPush;
          ξ-·-l; ξ-·-r; ξ-·[]; ξ-Λ; ξ-⟪⟫)
 open import strong.Progress using (progress)
 open import strong.Preservation using (preservation; preservation*)
@@ -186,7 +186,8 @@ ruleName : ∀ {Δ M M′} → Δ ⊢ M -→ M′ → String
 ruleName (TyBeta v)     = "TyBeta"
 ruleName (Beta w)       = "Beta"
 ruleName (Peel v w)     = "Peel"
-ruleName (TyPeelR v ⊢s) = "TyPeelR"
+ruleName (TyPeelR-Λ v ⊢s)  = "TyPeelR-Λ"
+ruleName (TyPeelR-⟪⟫ v ⊢s) = "TyPeelR-⟪⟫"
 ruleName (CancelR v d)  = "CancelR"
 ruleName (Drop$ b)      = "Drop$"
 ruleName (IdPush v d)   = "IdPush"

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -4,7 +4,9 @@ module strong.Examples where
 --
 -- §1  T₆ — the transparent-layer (β2) family — RUNS TO 7 under IdPush.
 -- §2  the cancel pair (Cancel + Drop$).
--- §3  T₈ — stacked id-layers — and its birth story (TyPeelR ⨟ TyBeta).
+-- §3  T₈ — stacked id-layers — and its birth story (`TyPeelR-Λ`, which
+--     since the 2026-09-08 split IS the fused TyPeelR ⨟ TyBeta, so the
+--     story is one step and lands on `T₈′`).
 -- §4  Tᵣ and Tₘ — the two adversaries the retired `⊳` could NOT clear —
 --     both run to 7 under IdPush.
 -- §5  the three preservation BREAKS of the previous design (c10/c11, n1b,
@@ -40,13 +42,14 @@ module strong.Examples where
 --     two type contexts inside its own Peel-minted wrapper.
 -- §15 TIGHTNESS, RULE BY RULE — Jeremy's test (proof/DualTightness)
 --     applied to EVERY rule that moves a subterm into a new frame:
---     `TyBeta` (§15a), `TyPeelR` (§15b), `IdPush`/`CancelR` (§15c),
+--     `TyBeta` (§15a), `TyPeelR-Λ` and `TyPeelR-⟪⟫` (§15b),
+--     `IdPush`/`CancelR` (§15c),
 --     `Beta` (§15d, with the one expected exception — ERASURE; §15d₂ is
 --     the UNDER-Λ case frame-exact Beta added), `Peel`'s `bind` half and
 --     `hideBinds` (§15e; the `unlock` half is proof/DualTightness).
 --     Every redex below is ILL TYPED and every contractum is REFUSED for
---     the same localized reason.  §15f collects the six frame identities
---     that make the section a theorem rather than six anecdotes.
+--     the same localized reason.  §15f collects the seven frame identities
+--     that make the section a theorem rather than seven anecdotes.
 --
 -- Every `_ : … ≡ …` in this file is a machine-checked frame computation.
 --
@@ -72,6 +75,28 @@ module strong.Examples where
 --   E₀  5 → 6    (+1 TyPeelR — §14's `estep₅`)
 --   G   5 → 5    (`gstep₁ … gstep₅`; the layers land under the Λs,
 --                 unevaluated)
+--
+-- STEP COUNTS AFTER THE TYPEELR SPLIT (2026-09-08).  A run gets SHORTER
+-- wherever a `TyPeelR` step used to be followed by the `TyBeta` on the
+-- `(Λ …) ·[ … , ` 0 ]` it left behind: `TyPeelR-Λ` does that
+-- instantiation itself, so one type instantiation now mints ONE boundary
+-- instead of two, and the Peel/Drop$ that walked the second boundary
+-- never happen either.
+--
+--   P₀  6 → 6    (no TyPeelR step)
+--   Q₀  11 → 11  (no TyPeelR step)
+--   R₀  6 → 6    (§11's variant (ii); no TyPeelR step)
+--   L₀  11 → 11  (no TyPeelR step)
+--   Ri  2 → 2    (hand-built)
+--   J₀  14 → 11  (−1 TyBeta, −1 Peel, −1 Drop$ — the boundary the fused
+--                 TyBeta used to mint is gone, and so is its unwinding)
+--   H₀  4 → 4    (the length is unchanged, but H₄ is now a VALUE: the
+--                 fifth step, a TyBeta, is fused into `hstep₄`)
+--   E₀  6 → 5    (−1 TyBeta — §14's old step 6)
+--   G   5 → 5    (`gstep₅` is now `TyPeelR-Λ`; its contractum is one
+--                 boundary shallower, and the run ends there either way)
+--   T₉  2 → 1    (§3's birth story: one step, and it reaches `T₈′`, T₈
+--                 with the fused layer gone)
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; _++_; length; map)
@@ -2410,9 +2435,21 @@ _ = refl
 -- The Λ clause does the instantiation itself, so that whole layer never
 -- exists.
 --
--- RENDERED (scripts/render_term.sh, `showTmIn 0`):
+-- RENDERED (scripts/render_term.sh 'showTrace 0 (eval 12 ⊢J₀)'):
 --
--- (re-measured below, §16's `showTrace`)
+--  J₆  ((((λx:Y. 3) ⟪ ↑Y:=X , ↓X , (seal Y ↦ seal X) ⟫)
+--         · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
+--        --[Peel]-->
+--  J₇  ((((λx:Y. 3) · ((7 ⟪ ↓X , seal X ⟫) ⟪ ↓Y , ↥X , seal Y ⟫))
+--         ⟪ ↑Y:=X , ↓X , seal X ⟫) ⟪ ↑X:=ℕ , unseal X ⟫)
+--        --[Beta]-->
+--  J₈  ((3 ⟪ ↑Y:=X , ↓X , seal X ⟫) ⟪ ↑X:=ℕ , unseal X ⟫)
+--        --[CancelR]-->
+--  J₉  ((3 ⟪ ↑Y:=X , ↓X , id ℕ ⟫) ⟪ ↑X:=ℕ , id ℕ ⟫)
+--        --[Drop$]-->
+--  J₁₀ (3 ⟪ ↑X:=ℕ , id ℕ ⟫)
+--        --[Drop$]-->
+--   →  3
 
 -- the dual the ONE remaining Peel mints
 _ : dual (morph ((` 0) ∷ binds Θt) (changes Θt))
@@ -2710,30 +2747,30 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ uns
 --      at the fresh NAME `` ` 0 ``; that is why the boundary is a LIST —
 --      a context morphism — and not a single reveal-or-conceal.
 --
--- Below: the SAME closed program, in v2, run to a VALUE in SIX steps,
+-- Below: the SAME closed program, in v2, run to a VALUE in FIVE steps,
 -- with every step pinned by `det`.  Step 5 is the one that used to die.
 --
 -- RENDERED (scripts/render_term.sh 'showTrace 0 (eval 6 ⊢E₀)'):
 --
 --  E₀  ((ΛX. (λx:(∀Y. (Y⇒Y)). (ΛY. x [Y]))) [ℕ] · (ΛZ. (λx:Z. x)))
+--        --[TyBeta]-->
 --  E₁  (((λx:(∀Y. (Y⇒Y)). (ΛY. x [Y]))
 --         ⟪ ↑X:=ℕ , ((∀Y. (id Y ↦ id Y)) ↦ (∀Y. (id Y ↦ id Y))) ⟫)
 --        · (ΛZ. (λx:Z. x)))
+--        --[Peel]-->
 --  E₂  (((λx:(∀Y. (Y⇒Y)). (ΛY. x [Y]))
 --         · ((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Y. (id Y ↦ id Y)) ⟫))
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
+--        --[Beta]-->
 --  E₃  ((ΛY. (((ΛZ. (λx:Z. x)) ⟪ ↓X , (∀Z. (id Z ↦ id Z)) ⟫)
 --               ⟪ ↓Y , (∀Z. (id Z ↦ id Z)) ⟫) [Y])
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
---  E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , (∀X′. (id X′ ↦ id X′)) ⟫) [Z]
---               ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
+--        --[TyPeelR-⟪⟫]-->
+--  E₄  ((ΛY. (((ΛX′. (λx:X′. x)) ⟪ ↓X , ↓Z , (∀X′. (id X′ ↦ id X′)) ⟫)
+--                [Z] ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
---  E₅  ((ΛY. (((ΛY′. (λx:Y′. x)) [X′]
---                 ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
---               ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
---        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
---  E₆  ((ΛY. ((((λx:Y′. x) ⟪ ↑Y′:=X′ , (seal Y′ ↦ unseal Y′) ⟫)
---                 ⟪ ↑X′:=Z , ↓X , (seal X′ ↦ unseal X′) ⟫)
+--        --[TyPeelR-Λ]-->
+--  E₅  ((ΛY. (((λx:X′. x) ⟪ ↑X′:=Z , ↓X , ↓Z , (seal X′ ↦ unseal X′) ⟫)
 --               ⟪ ↑Z:=Y , ↓Y , (seal Z ↦ unseal Z) ⟫))
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)                      -- a VALUE
 --
@@ -2745,9 +2782,17 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ uns
 --        ⟪ ↑X:=ℕ , (∀Y. (id Y ↦ id Y)) ⟫)
 --
 -- — the crossed value planted under ΛY with NOTHING saying that ΛY's slot
--- is not in its frame.  Now it carries ΛY's dual `↓Y`, the run peels the
--- two wrappers in turn (steps 4 and 5), and it is six steps rather than
--- five.
+-- is not in its frame.  Now it carries ΛY's dual `↓Y`, and the run peels
+-- the two wrappers in turn (steps 4 and 5).
+--
+-- AND THE `↓Z` IN E₄ IS THE TYPEELR SPLIT'S (2026-09-08).  Step 4 moves
+-- the value's OWN Peel-minted boundary under the binder `Z` it
+-- introduces, so `TyPeelR-⟪⟫` appends that binder's lock to the moved
+-- boundary's change list: `↓X` becomes `↓X , ↓Z`.  Step 5 then finds a
+-- `Λ` interior, so `TyPeelR-Λ` instantiates it on the spot — which is why
+-- E₅ is a VALUE and the run is FIVE steps.  Before the split the single
+-- rule left a `(ΛY′. …) ·[ … , ` 0 ]` behind and a sixth step, a TyBeta,
+-- was needed.
 --
 -- E₃ is the old design's fourth line, and E₄/E₅ are where the two designs
 -- part: `↑Z:=Y , ↓Y` and `↑X′:=Z , ↓X` are boundaries that MASK the outer
@@ -3072,7 +3117,7 @@ val-prb = V-ƛ
 Δ✦ : Ctxᵗ
 Δ✦ = masked (bind `ℕ) ∷ []
 
--- THE THREE FRAME IDENTITIES THAT HAD NO NAME (§15f collects all six).
+-- THE THREE FRAME IDENTITIES THAT HAD NO NAME (§15f collects all seven).
 -- All three are `refl`: `interior Θ Δ` is `pushBinds (binds Θ) (scope Θ Δ)`,
 -- a bind contributes to the BIND half alone (leaving `scope` untouched),
 -- and a lone `lock 0` is one `maskEnt` at the head.
@@ -3648,9 +3693,25 @@ _ = refl
 --   TyBeta   interior (morph (A ∷ []) []) Δ ≡ bind A ∷ Δ
 --              — `Δ` on the nose, one REFINEMENT (abst → bind) at the
 --                slot the rule is there to reveal
---   TyPeelR  interior (morph (A ∷ binds Θ) (changes Θ)) Δ
---              ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
---              — the redex's frame, one binder in; `wkᴹ 1` matches it
+--   TyPeelR- interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+--   Λ          ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ
+--              — the redex's frame, one binder in, and the body is NOT
+--                MOVED: its slot 0 was `unmasked abst` and is now
+--                `unmasked (bind …)`, a REFINEMENT (`⊑ᵃ`) at a slot it
+--                could already name.  No shift at all.
+--   TyPeelR- interior (addLock0 (renᴮ suc Θ′))
+--   ⟪⟫         (interior (morph (A ∷ binds Θ) (changes Θ)) Δ)
+--              ≡ pushBinds (map ⇑ᵗ (binds Θ′))
+--                  (masked (bind (shiftBy (numBinds Θ) A))
+--                     ∷ scope Θ′ (interior Θ Δ))
+--              — proof/ShiftAudit.TyPeelR-⟪⟫-frame, from
+--                strong.TermSubst.interior-addLock0-cross: the moved
+--                boundary's BIRTH frame with the new binder inserted
+--                MASKED below the bind prefix.  This is the identity the
+--                2026-09-08 split buys; the single rule left the moved
+--                boundary's change list alone, so the new slot was
+--                offered UNMASKED — the audit's one leak
+--                (notes/ShiftAudit.md §3).  §15b runs the test on it.
 --   Peel     interior (dual Θ) (interior Θ Δ)
 --              ≡ map masked (pushBinds (binds Θ) []) ++ Δ   (Δ ⊢ᵐ Θ)
 --              — (†), proof/PeelDual.interior-dual: THE CROSSING FRAME

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -302,24 +302,51 @@ T₉ = (Pkg ·[ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 -- TyPeelR mints the id-layer no matter what TyBeta does.  On an IDENTITY
 -- ∀ conversion the mint is the conversion itself
--- (`instReveal 0 (id (` 1)) = id (` 1)`, since slot 1 is not the new
--- binder) and the pushed-in annotation is the interior ∀-body, SHIFTED
--- past the binder the rule introduces: `` ` 2 `` rather than `` ` 1 ``.
-Pk-1 : Term
-Pk-1 = ((Λ (($ 7) ⟪ morph [] [] , seal 2 ⟫)) ·[ ` 2 , ` 0 ])
-         ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫
+-- (`instReveal 0 (id (` 1)) = reveal 0 (` 1) = id (` 1)`, since slot 1 is
+-- not the new binder).
+--
+-- AFTER THE 2026-09-08 SPLIT the interior is a `Λ`, so it is `TyPeelR-Λ`
+-- that fires and the story is ONE STEP, not two: the `Λ`'s abst slot
+-- BECOMES the boundary's bind slot, so the body is instantiated on the
+-- spot and no `(Λ …) ·[ … , ` 0 ]` is left behind for TyBeta to consume.
+-- One type instantiation therefore mints ONE binder, where the old rule
+-- pair minted two — which is why the story now reaches `T₈′`, T₈'s stack
+-- with the fused layer gone, instead of T₈ itself.  (T₈ is still a typed
+-- term with the run above; only its provenance is one layer shallower.)
+T₈′ : Term
+T₈′ = (W₆₀ ⟪ morph (`ℕ ∷ []) [] , id (` 1) ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 ⊢Pk-conv : (unmasked abst ∷ convCtx (morph [] []) S₆₁) ⊢ id (` 1) ∶ ` 1 ⇝ ` 1
 ⊢Pk-conv = conv-idv (unmasked (bind `ℕ) , es ez , nameable)
 
-typeel-T₉ : Δ₆ ⊢ T₉ -→ Pk-1 ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-typeel-T₉ = ξ-⟪⟫ (TyPeelR (V-Λ (V-⟪⟫ V-$ I-seal)) ⊢Pk-conv)
+typeel-T₉ : Δ₆ ⊢ T₉ -→ T₈′
+typeel-T₉ = ξ-⟪⟫ (TyPeelR-Λ (V-⟪⟫ V-$ I-seal) ⊢Pk-conv)
 
--- and TyBeta then mints exactly T₈'s inner layer.
-reaches-T₈ : Δ₆ ⊢ T₉ -→* T₈
-reaches-T₈ = typeel-T₉
-        then ξ-⟪⟫ (ξ-⟪⟫ (TyBeta (V-⟪⟫ V-$ I-seal)))
-        then done
+reaches-T₈′ : Δ₆ ⊢ T₉ -→* T₈′
+reaches-T₈′ = typeel-T₉ then done
+
+-- … and the id-layer really is stacked over the seal, so the same
+-- IdPush ⨟ CancelR ⨟ Drop$ resolution runs on it, to the answer.
+T₈′-1 T₈′-2 : Term
+T₈′-1 = ((($ 7) ⟪ morph [] [] , seal 1 ⟫) ⟪ morph (`ℕ ∷ []) [] , unseal 1 ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+T₈′-2 = ((($ 7) ⟪ morph [] [] , id `ℕ ⟫) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫)
+          ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+
+push-T₈′-1 : Δ₆ ⊢ T₈′ -→ T₈′-1
+push-T₈′-1 = IdPush (V-⟪⟫ V-$ I-seal) ez
+
+cancel-T₈′ : Δ₆ ⊢ T₈′-1 -→ T₈′-2
+cancel-T₈′ = ξ-⟪⟫ (CancelR V-$ (es ez))
+
+run-T₈′ : Δ₆ ⊢ T₈′ -→* $ 7
+run-T₈′ = push-T₈′-1
+     then cancel-T₈′
+     then ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
+     then ξ-⟪⟫ (Drop$ base-ℕ)
+     then Drop$ base-ℕ
+     then done
 
 -- ── why TyBeta needs its Value premise (repair 5) ──────────────────────
 -- This calculus reduces UNDER Λ, so a Λ-body can be a redex and `Λ N` is
@@ -1797,14 +1824,18 @@ rstep-chained = IdPush (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal) Rchain
 -- Variant (i) asks for an IdPush redex whose INNER frame Θ₁ binds more
 -- than one binder.  WHICH RULE COULD EVER MINT ONE?  Exactly one:
 --
---   TyBeta   mints `morph (A ∷ []) []`                       numBinds 1
---   Peel     mints `dual Θ`, which is ALL locks/unlocks numBinds 0
---   CancelR  mints NO frame (both are carried over)
---   IdPush   mints NO frame (both are carried over)
---   TyPeelR  prepends one bind          numBinds = 1 + numBinds Θ
+--   TyBeta       mints `morph (A ∷ []) []`                   numBinds 1
+--   Peel         mints `dual Θ`, all locks/unlocks           numBinds 0
+--   CancelR      mints NO frame (both are carried over)
+--   IdPush       mints NO frame (both are carried over)
+--   TyPeelR-Λ    prepends one bind        numBinds = 1 + numBinds Θ
+--   TyPeelR-⟪⟫   prepends one bind        numBinds = 1 + numBinds Θ
+--                and appends one LOCK to the MOVED boundary's frame,
+--                which adds no bind at all (`numBinds-addLock0`)
 --
--- so `numBinds Θ ≥ 2` is reachable ONLY through TyPeelR.  Those facts,
--- machine-checked:
+-- so `numBinds Θ ≥ 2` is reachable ONLY through the TyPeelR clauses —
+-- which mint the SAME frame, the split being about the moved subterm and
+-- not about the boundary that is born.  Those facts, machine-checked:
 
 numBinds-TyBeta : (A : Ty) → numBinds (morph (A ∷ []) []) ≡ 1
 numBinds-TyBeta A = refl
@@ -1812,9 +1843,14 @@ numBinds-TyBeta A = refl
 numBinds-dual : (Θ : CtxMorph) → numBinds (dual Θ) ≡ 0
 numBinds-dual Θ = refl
 
-numBinds-TyPeelR : (A : Ty) (Θ : CtxMorph)
+numBinds-TyPeelR-Λ : (A : Ty) (Θ : CtxMorph)
   → numBinds (morph (A ∷ binds Θ) (changes Θ)) ≡ suc (numBinds Θ)
-numBinds-TyPeelR A Θ = refl
+numBinds-TyPeelR-Λ A Θ = refl
+
+numBinds-TyPeelR-⟪⟫ : (A : Ty) (Θ Θ′ : CtxMorph)
+  → (numBinds (morph (A ∷ binds Θ) (changes Θ)) ≡ suc (numBinds Θ))
+    × (numBinds (addLock0 (renᴮ suc Θ′)) ≡ numBinds Θ′)
+numBinds-TyPeelR-⟪⟫ A Θ Θ′ = refl , numBinds-ren suc Θ′
 
 -- ── A CLOSED SOURCE THAT REACHES TYPEELR ───────────────────────────────
 --
@@ -1853,8 +1889,7 @@ G₃ = (((Λ GV) ·[ `∀ (` 2) , `ℕ ]) ·[ ` 1 , `ℕ ])
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 G₄ = ((GV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 2)) ⟫) ·[ ` 1 , `ℕ ])
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-G₅ = ((wkᴹ 1 GV) ·[ ` 3 , ` 0 ])
-       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫
+G₅ = (DS₇ ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id (` 2) ⟫)
        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
 -- the moved value, spelled out: every NAME shifts, the innermost `lock 0`
@@ -1879,13 +1914,17 @@ gstep₄ = ξ-⟪⟫ (ξ-·[] (TyBeta (V-Λ val-DS₇)))
 
 -- the TyPeelR step, whose contractum is the wanted `numBinds Θ₁ ≡ 2` layer.
 -- Its conversion premise is the redex's own, one `` `∀ `` inside —
--- here the identity at the OUTER binder, read under the ∀-binder.
+-- here the identity at the OUTER binder, read under the ∀-binder.  The
+-- interior is `Λ DS₇`, so it is the Λ CLAUSE that fires (2026-09-08): the
+-- planted value is instantiated ON THE SPOT, with NO `wkᴹ 1` and no
+-- pushed-in `·[ ]` — and the frame the boundary is born with is
+-- unchanged, which is what §11c is about.
 ⊢Gconv : (unmasked abst ∷ convCtx (morph (`ℕ ∷ []) []) QΔ₁)
            ⊢ id (` 2) ∶ ` 2 ⇝ ` 2
 ⊢Gconv = conv-idv (unmasked (bind `ℕ) , es (es ez) , nameable)
 
 gstep₅ : [] ⊢ G₄ -→ G₅
-gstep₅ = ξ-⟪⟫ (TyPeelR (V-Λ val-DS₇) ⊢Gconv)
+gstep₅ = ξ-⟪⟫ (TyPeelR-Λ val-DS₇ ⊢Gconv)
 
 _ : numBinds (morph (`ℕ ∷ `ℕ ∷ []) []) ≡ 2
 _ = refl
@@ -2205,7 +2244,7 @@ val-wallR₂ = V-⟪⟫ (V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-idv) I-idv) 
 -- Under the polarity index that difference decided TYPEABILITY; now it
 -- decides only which binder each minted leaf cites.
 
-open import strong.Preservation using (preservation-TyPeelR)
+open import strong.Preservation using (preservation-TyPeelR-Λ)
 open import strong.proof.PreserveObstruct
   using (Δt; Wt; val-Wt; ⊢Wt; Θt; st; ⊢st; Wft; ⊢Wft; Rt; ⊢Rt; step-t;
          ⊢t-contractum)
@@ -2297,7 +2336,7 @@ _ = refl
 ⊢J₅-head = ⊢Rt
 
 J₆head J₆ : Term
-J₆head = (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
+J₆head = (ƛ (` 0) ∙ ($ 3))
            ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , instReveal 0 st ⟫
 J₆     = (J₆head · QS₇) ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
 
@@ -2313,9 +2352,9 @@ jstep₆ = ξ-⟪⟫ (ξ-·-l step-t)
 -- `` ` 1 `` (the new binder's rep, read inside) to `` ` 0 ``, and an
 -- identity converts a type to ITSELF (`conv-id-refl`).
 ¬⊢J-plain :
-  ¬ (Δt ∣ [] ⊢ (wkᴹ 1 Wt ·[ ` 0 ⇒ `ℕ , ` 0 ])
+  ¬ (Δt ∣ [] ⊢ (ƛ (` 0) ∙ ($ 3))
                  ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , st ⟫ ⦂ (` 0 ⇒ ` 0))
-¬⊢J-plain (env _ (⊢·[] _ _) (conv-fun ⊢s ⊢t) _) with conv-id-refl ⊢s
+¬⊢J-plain (env _ (⊢ƛ _ _) (conv-fun ⊢s ⊢t) _) with conv-id-refl ⊢s
 ... | ()
 
 -- ── FACT (ii): THE MINT TYPES ──────────────────────────────────────────
@@ -2349,7 +2388,7 @@ J-cod = conv-seal (es ez)
 
 -- HENCE THE LANDED CONTRACTUM TYPES, by the theorem — the head of J₆.
 ⊢J₆head : Δt ∣ [] ⊢ J₆head ⦂ (` 0 ⇒ ` 0)
-⊢J₆head = preservation-TyPeelR val-Wt ⊢st ⊢Rt
+⊢J₆head = preservation-TyPeelR-Λ V-ƛ ⊢st ⊢Rt
 
 _ : ⊢J₆head ≡ ⊢t-contractum
 _ = refl
@@ -2360,127 +2399,76 @@ _ = refl
 
 -- ── THE RUN CONTINUES, TO A VALUE ──────────────────────────────────────
 --
--- Eight more steps: the TyBeta the peel exposed (the interior ∀ is now
--- instantiated at the binder TyPeelR bound), TWO Peels — the argument `7`
--- crosses both of the boundaries the run has stacked — a Beta, and then
--- the four transparent layers unwinding, Drop$ ⨟ CancelR ⨟ Drop$ ⨟ Drop$.
--- The answer is 3: `ΛY. λy:Y. 3` ignores its argument.
+-- Five more steps: ONE Peel — the argument `7` crosses the boundary the
+-- TyPeelR step was born as — a Beta, and then the transparent layers
+-- unwinding, CancelR ⨟ Drop$ ⨟ Drop$.  The answer is 3: `ΛY. λy:Y. 3`
+-- ignores its argument.
+--
+-- Before the 2026-09-08 split this tail was EIGHT steps: the single rule
+-- left a `(ΛZ. …) ·[ … , ` 0 ]` behind, so a TyBeta had to fire, and the
+-- boundary that TyBeta minted then needed a Peel and a Drop$ of its own.
+-- The Λ clause does the instantiation itself, so that whole layer never
+-- exists.
 --
 -- RENDERED (scripts/render_term.sh, `showTmIn 0`):
 --
---  J₆  ((((ΛZ. (λx:Z. 3)) [Y] ⟪ ↑Y:=X , ↓X , (seal Y ↦ seal X) ⟫)
---         · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
---  J₇  (((((λx:Z. 3) ⟪ ↑Z:=Y , (seal Z ↦ id ℕ) ⟫)
---          ⟪ ↑Y:=X , ↓X , (seal Y ↦ seal X) ⟫)
---         · (7 ⟪ ↓X , seal X ⟫)) ⟪ ↑X:=ℕ , unseal X ⟫)
---  J₈  (((((λx:Z. 3) ⟪ ↑Z:=Y , (seal Z ↦ id ℕ) ⟫)
---          · ((7 ⟪ ↓X , seal X ⟫) ⟪ ↓Y , ↥X , seal Y ⟫))
---         ⟪ ↑Y:=X , ↓X , seal X ⟫) ⟪ ↑X:=ℕ , unseal X ⟫)
---  J₉  (((((λx:Z. 3)
---          · (((7 ⟪ ↓X , seal X ⟫) ⟪ ↓Y , ↥X , seal Y ⟫) ⟪ ↓Z , seal Z ⟫))
---          ⟪ ↑Z:=Y , id ℕ ⟫) ⟪ ↑Y:=X , ↓X , seal X ⟫)
---         ⟪ ↑X:=ℕ , unseal X ⟫)
---  J₁₀ (((3 ⟪ ↑Z:=Y , id ℕ ⟫) ⟪ ↑Y:=X , ↓X , seal X ⟫)
---         ⟪ ↑X:=ℕ , unseal X ⟫)
---  J₁₁ ((3 ⟪ ↑Y:=X , ↓X , seal X ⟫) ⟪ ↑X:=ℕ , unseal X ⟫)
---  J₁₂ ((3 ⟪ ↑Y:=X , ↓X , id ℕ ⟫) ⟪ ↑X:=ℕ , id ℕ ⟫)
---  J₁₃ (3 ⟪ ↑X:=ℕ , id ℕ ⟫)
---   →  3
+-- (re-measured below, §16's `showTrace`)
 
-_ : wkᴹ 1 Wt ≡ Wt
+-- the dual the ONE remaining Peel mints
+_ : dual (morph ((` 0) ∷ binds Θt) (changes Θt))
+      ≡ morph [] (lock 0 ∷ unlock 1 ∷ [])
 _ = refl
 
--- TyBeta's mint at the new binder: a conceal on the domain, a transparent
--- base identity on the codomain.
-_ : reveal 0 (` 0 ⇒ `ℕ) ≡ seal 0 ↦ id `ℕ
-_ = refl
+JW : Term                      -- `7` after the crossing
+JW = wkᴹ 1 QS₇ ⟪ dual (morph ((` 0) ∷ binds Θt) (changes Θt)) , seal 0 ⟫
 
-JV : Term                      -- λy. 3, behind the freshly born boundary
-JV = (ƛ (` 0) ∙ ($ 3)) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ id `ℕ ⟫
-
-val-JV : Value JV
-val-JV = V-⟪⟫ V-ƛ I-fun
-
--- the two duals the two Peels mint
-_ : dual (morph ((` 0) ∷ binds Θt) (changes Θt)) ≡ morph [] (lock 0 ∷ unlock 1 ∷
-  [])
-_ = refl
-
-_ : dual (morph ((` 0) ∷ []) []) ≡ morph [] (lock 0 ∷ [])
-_ = refl
-
-JW JW′ : Term                  -- `7` after the first / the second crossing
-JW  = wkᴹ 1 QS₇ ⟪ dual (morph ((` 0) ∷ binds Θt) (changes Θt)) , seal 0 ⟫
-JW′ = wkᴹ 1 JW ⟪ dual (morph ((` 0) ∷ []) []) , seal 0 ⟫
-
-_ : JW ≡ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫) ⟪ morph [] (lock 0 ∷ unlock
-  1 ∷ []) , seal 0 ⟫
+_ : JW ≡ (($ 7) ⟪ morph [] (lock 1 ∷ []) , seal 1 ⟫)
+           ⟪ morph [] (lock 0 ∷ unlock 1 ∷ []) , seal 0 ⟫
 _ = refl
 
 val-JW : Value JW
 val-JW = V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal
 
-val-JW′ : Value JW′
-val-JW′ = V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-$ I-seal) I-seal) I-seal
-
-J₇ J₈ J₉ J₁₀ J₁₁ J₁₂ J₁₃ : Term
-J₇  = ((JV ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 0 ↦ seal 1 ⟫) · QS₇)
-        ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₈  = ((JV · JW) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ
-  ∷ []) [] , unseal 0 ⟫
-J₉  = ((((ƛ (` 0) ∙ ($ 3)) · JW′) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫)
+J₇ J₈ J₉ J₁₀ : Term
+J₇  = (((ƛ (` 0) ∙ ($ 3)) · JW)
          ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₁₀ = ((($ 3) ⟪ morph ((` 0) ∷ []) [] , id `ℕ ⟫) ⟪ morph ((` 0) ∷ binds Θt)
-  (changes Θt) , seal 1 ⟫)
+J₈  = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫)
         ⟪ morph (`ℕ ∷ []) [] , unseal 0 ⟫
-J₁₁ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , seal 1 ⟫) ⟪ morph (`ℕ ∷
-  []) [] , unseal 0 ⟫
-J₁₂ = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id `ℕ ⟫) ⟪ morph (`ℕ ∷
-  []) [] , id `ℕ ⟫
-J₁₃ = ($ 3) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+J₉  = (($ 3) ⟪ morph ((` 0) ∷ binds Θt) (changes Θt) , id `ℕ ⟫)
+        ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+J₁₀ = ($ 3) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
 
 jstep₇ : [] ⊢ J₆ -→ J₇
-jstep₇ = ξ-⟪⟫ (ξ-·-l (ξ-⟪⟫ (TyBeta V-ƛ)))
+jstep₇ = ξ-⟪⟫ (Peel V-ƛ (V-⟪⟫ V-$ I-seal))
 
 jstep₈ : [] ⊢ J₇ -→ J₈
-jstep₈ = ξ-⟪⟫ (Peel val-JV (V-⟪⟫ V-$ I-seal))
-
-jstep₉ : [] ⊢ J₈ -→ J₉
-jstep₉ = ξ-⟪⟫ (ξ-⟪⟫ (Peel V-ƛ val-JW))
-
-jstep₁₀ : [] ⊢ J₉ -→ J₁₀
-jstep₁₀ = ξ-⟪⟫ (ξ-⟪⟫ (ξ-⟪⟫ (Beta val-JW′)))
-
-jstep₁₁ : [] ⊢ J₁₀ -→ J₁₁
-jstep₁₁ = ξ-⟪⟫ (ξ-⟪⟫ (Drop$ base-ℕ))
+jstep₈ = ξ-⟪⟫ (ξ-⟪⟫ (Beta val-JW))
 
 -- the CANCEL: the inner conceal at the binder the TyPeelR-born frame
 -- carries, directly under the reveal that owns it (X ≡ numBinds Θ₁ + Y).
-jstep₁₂ : [] ⊢ J₁₁ -→ J₁₂
-jstep₁₂ = CancelR V-$ ez
+jstep₉ : [] ⊢ J₈ -→ J₉
+jstep₉ = CancelR V-$ ez
 
-jstep₁₃ : [] ⊢ J₁₂ -→ J₁₃
-jstep₁₃ = ξ-⟪⟫ (Drop$ base-ℕ)
+jstep₁₀ : [] ⊢ J₉ -→ J₁₀
+jstep₁₀ = ξ-⟪⟫ (Drop$ base-ℕ)
 
-jstep₁₄ : [] ⊢ J₁₃ -→ $ 3
-jstep₁₄ = Drop$ base-ℕ
+jstep₁₁ : [] ⊢ J₁₀ -→ $ 3
+jstep₁₁ = Drop$ base-ℕ
 
 run-J₆ : [] ⊢ J₆ -→* $ 3
-run-J₆ = jstep₇ then jstep₈ then jstep₉ then jstep₁₀ then jstep₁₁
-    then jstep₁₂ then jstep₁₃ then jstep₁₄ then done
+run-J₆ = jstep₇ then jstep₈ then jstep₉ then jstep₁₀ then jstep₁₁ then done
 
 -- THE WHOLE RUN, from closed plain source to the answer.
 run-J : [] ⊢ J₀ -→* $ 3
 run-J = jstep₁ then jstep₂ then jstep₃ then jstep₄ then jstep₅
    then jstep₆ then run-J₆
 
--- … and the generated run agrees on all fourteen steps, TyPeelR (J₅ → J₆)
+-- … and the generated run agrees on all eleven steps, TyPeelR-Λ (J₅ → J₆)
 -- included: the rule the retired polarity index refused is the step the
 -- machine takes.
-_ : evalTerms 14 ⊢J₀
-      ≡ J₀ ∷ J₁ ∷ J₂ ∷ J₃ ∷ J₄ ∷ J₅ ∷ J₆ ∷ J₇ ∷ J₈ ∷ J₉ ∷ J₁₀ ∷ J₁₁
-      ∷ J₁₂ ∷ J₁₃ ∷ ($ 3) ∷ []
+_ : evalTerms 11 ⊢J₀
+      ≡ J₀ ∷ J₁ ∷ J₂ ∷ J₃ ∷ J₄ ∷ J₅ ∷ J₆ ∷ J₇ ∷ J₈ ∷ J₉ ∷ J₁₀ ∷ ($ 3) ∷ []
 _ = refl
 
 ------------------------------------------------------------------------
@@ -2517,12 +2505,9 @@ _ = refl
 -- FRAME-EXACT BETA (2026-09-08): the crossed 7 is planted under ΛY (and
 -- then under a ƛ, which changes no frame), so it carries ΛY's dual.  The
 -- RUN LENGTH IS UNCHANGED — the layer sits inside a ƛ body, where nothing
--- evaluates it — only the states' spelling changes.  `QS₇↑′` is the same
--- value again, moved past the binder TyPeelR introduces.
-QS₇↑′ : Term
-QS₇↑′ = (($ 7) ⟪ morph [] (lock 2 ∷ []) , seal 2 ⟫)
-          ⟪ morph [] (lock 0 ∷ []) , id (` 2) ⟫
-
+-- evaluates it — only the states' spelling changes.  And after the
+-- TyPeelR SPLIT the planted value is not even respelled: the Λ clause
+-- performs NO SHIFT, so `QS₇↑` crosses into H₄ verbatim.
 HV H₁ H₂ H₃ H₄ : Term
 HV = Λ (ƛ (` 0) ∙ QS₇↑)
 H₁ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1))))
@@ -2531,11 +2516,8 @@ H₁ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1))))
 H₂ = (((ƛ (` 0) ∙ (Λ (ƛ (` 0) ∙ (` 1)))) · QS₇)
         ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
 H₃ = (HV ⟪ morph (`ℕ ∷ []) [] , `∀ (id (` 0) ↦ unseal 1) ⟫) ·[ ` 0 ⇒ `ℕ , `ℕ ]
-H₄ = ((Λ (ƛ (` 0) ∙ QS₇↑′)) ·[ ` 0 ⇒ ` 2 , ` 0 ])
+H₄ = (ƛ (` 0) ∙ QS₇↑)
        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
-
-_ : wkᴹ 1 HV ≡ Λ (ƛ (` 0) ∙ QS₇↑′)
-_ = refl
 
 hstep₁ : [] ⊢ H₀ -→ H₁
 hstep₁ = ξ-·[] (ξ-·-l (TyBeta V-ƛ))
@@ -2559,14 +2541,14 @@ _ : instReveal 0 (id (` 0) ↦ unseal 1) ≡ seal 0 ↦ unseal 1
 _ = refl
 
 hstep₄ : [] ⊢ H₃ -→ H₄
-hstep₄ = TyPeelR (V-Λ V-ƛ) ⊢Hconv
+hstep₄ = TyPeelR-Λ V-ƛ ⊢Hconv
 
 run-H₀ : [] ⊢ H₀ -→* H₄
 run-H₀ = hstep₁ then hstep₂ then hstep₃ then hstep₄ then done
 
--- … and the generated run agrees.  Four steps is exactly `run-H₀`'s
--- length, so the trace stops OUT OF FUEL at H₄ — which is right: H₄ is
--- not a value, and `hstep₅` below is its next step.
+-- … and the generated run agrees.  H₄ IS A VALUE (the Λ clause instantiates
+-- on the spot, so the TyBeta that used to follow is fused into it), and the
+-- run is four steps.
 _ : evalTerms 4 ⊢H₀ ≡ H₀ ∷ H₁ ∷ H₂ ∷ H₃ ∷ H₄ ∷ []
 _ = refl
 
@@ -2592,19 +2574,14 @@ _ = refl
            wf-ℕ
 
 ⊢H₄ : [] ∣ [] ⊢ H₄ ⦂ (`ℕ ⇒ `ℕ)
-⊢H₄ = preservation-TyPeelR (V-Λ V-ƛ) ⊢Hconv ⊢H₃
+⊢H₄ = preservation-TyPeelR-Λ V-ƛ ⊢Hconv ⊢H₃
 
--- and H₄ is ONE TyBeta from a value, so the repaired rule does not
--- strand the run either.
-H₅ : Term
-H₅ = ((ƛ (` 0) ∙ QS₇↑′) ⟪ morph ((` 0) ∷ []) [] , reveal 0 (` 0 ⇒ ` 2) ⟫)
-       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , seal 0 ↦ unseal 1 ⟫
-
-hstep₅ : [] ⊢ H₄ -→ H₅
-hstep₅ = ξ-⟪⟫ (TyBeta V-ƛ)
-
-val-H₅ : Value H₅
-val-H₅ = V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun
+-- and H₄ IS a value, so the repaired rule does not strand the run either.
+-- (Before the split the run needed one more step, a TyBeta on the
+-- `(Λ …) ·[ … , ` 0 ]` the single rule left behind; the Λ clause does that
+-- work itself.)
+val-H₄ : Value H₄
+val-H₄ = V-⟪⟫ V-ƛ I-fun
 
 ------------------------------------------------------------------------
 -- §13c  JEREMY'S CANDIDATE AND ITS NEIGHBOURS
@@ -2968,10 +2945,21 @@ _ = ⊢Es
 _ : instReveal 0 (id (` 0) ↦ id (` 0)) ≡ seal 0 ↦ unseal 0
 _ = refl
 
-EW↑₂ : Term                      -- the value, moved past TyPeelR's binder
-EW↑₂ = Earg ⟪ morph [] (lock 2 ∷ []) , Eid∀ ⟫
+-- The moved subterm here is the value's OWN Peel-minted BOUNDARY, so it
+-- is the WRAPPER CLAUSE that fires, and the new binder is masked in that
+-- boundary's own change list: `lock 1` becomes `lock 2 , lock 0` — the
+-- SHIFTED original lock (X, now one slot out) and the NEW lock (the
+-- binder this step introduces), appended at the tail where
+-- `applyChanges` runs it first.  Without it the moved boundary's interior
+-- would be offered the new slot UNMASKED (notes/ShiftAudit.md §3).
+EW↑₂ : Term            -- the value, moved past TyPeelR-⟪⟫'s binder
+EW↑₂ = Earg ⟪ morph [] (lock 2 ∷ lock 0 ∷ []) , Eid∀ ⟫
 
-_ : wkᴹ 1 EW↑ ≡ EW↑₂
+-- … and it IS `wkᴹ 1` plus that one lock, on the nose.
+_ : EW↑₂ ≡ renᴹ (extN (numBinds (morph [] (lock 1 ∷ []))) suc) Earg
+             ⟪ addLock0 (renᴮ suc (morph [] (lock 1 ∷ [])))
+             , `∀ (renᶜ (extᵗ (extN (numBinds (morph [] (lock 1 ∷ []))) suc))
+                        (id (` 0) ↦ id (` 0))) ⟫
 _ = refl
 
 E₄ : Term
@@ -2980,53 +2968,45 @@ E₄ = (Λ ((EW↑₂ ·[ ` 0 ⇒ ` 0 , ` 0 ])
        ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
 estep₄ : [] ⊢ E₃ -→ E₄
-estep₄ = ξ-⟪⟫ (ξ-Λ (TyPeelR (V-⟪⟫ (V-Λ V-ƛ) I-all) ⊢Es))
+estep₄ = ξ-⟪⟫ (ξ-Λ (TyPeelR-⟪⟫ (V-Λ V-ƛ) ⊢Es))
 
--- ── STEP 5 — TYPEELR AGAIN, one layer in: the value's OWN Peel-minted
--- wrapper.  THIS IS THE STEP FRAME-EXACT BETA ADDS, and it is the step
--- the old design died on: the crossed value type-applied to a variable
--- bound after the boundary was born.
-
-E₅ : Term
-E₅ = (Λ (((Earg ·[ ` 0 ⇒ ` 0 , ` 0 ])
-            ⟪ morph ((` 0) ∷ []) (lock 2 ∷ []) , seal 0 ↦ unseal 0 ⟫)
-           ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , seal 0 ↦ unseal 0 ⟫))
-       ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
-
-estep₅ : [] ⊢ E₄ -→ E₅
-estep₅ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (TyPeelR (V-Λ V-ƛ) ⊢Es)))
-
--- ── STEP 6 — TYBETA, inside.  The ΛZ is consumed against the bind
--- TyPeelR just made, and the result is a VALUE.
+-- ── STEP 5 — TYPEELR AGAIN, one layer in: now the interior IS the `ΛZ`,
+-- so it is the Λ CLAUSE that fires.  THIS IS THE STEP FRAME-EXACT BETA
+-- ADDS, and it is the step the old design died on: the crossed value
+-- type-applied to a variable bound after the boundary was born.
+--
+-- The tower is exhausted here (`towerHeight` 1 → 0, proof/ShiftAudit
+-- §5c₂), and the Λ clause neither shifts nor locks anything: the `ΛZ`'s
+-- abst slot simply becomes the boundary's bind slot.  So E₅ is a VALUE —
+-- the TyBeta that used to be step 6 is fused into this step.
 
 _ : reveal 0 (` 0 ⇒ ` 0) ≡ seal 0 ↦ unseal 0
 _ = refl
 
-E₆ : Term
-E₆ = (Λ ((((ƛ (` 0) ∙ (` 0)) ⟪ morph ((` 0) ∷ []) [] , seal 0 ↦ unseal 0 ⟫)
-             ⟪ morph ((` 0) ∷ []) (lock 2 ∷ []) , seal 0 ↦ unseal 0 ⟫)
-            ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , seal 0 ↦ unseal 0 ⟫))
+E₅ : Term
+E₅ = (Λ (((ƛ (` 0) ∙ (` 0))
+             ⟪ morph ((` 0) ∷ []) (lock 2 ∷ lock 0 ∷ [])
+             , seal 0 ↦ unseal 0 ⟫)
+           ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , seal 0 ↦ unseal 0 ⟫))
        ⟪ morph (`ℕ ∷ []) [] , Eid∀ ⟫
 
-estep₆ : [] ⊢ E₅ -→ E₆
-estep₆ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (ξ-⟪⟫ (TyBeta V-ƛ))))
+estep₅ : [] ⊢ E₄ -→ E₅
+estep₅ = ξ-⟪⟫ (ξ-Λ (ξ-⟪⟫ (TyPeelR-Λ V-ƛ ⊢Es)))
 
-val-E₆ : Value E₆
-val-E₆ =
-  V-⟪⟫ (V-Λ (V-⟪⟫ (V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun) I-fun)) I-all
+val-E₅ : Value E₅
+val-E₅ = V-⟪⟫ (V-Λ (V-⟪⟫ (V-⟪⟫ V-ƛ I-fun) I-fun)) I-all
 
-run-E : [] ⊢ E₀ -→* E₆
-run-E = estep₁ then estep₂ then estep₃ then estep₄ then estep₅
-    then estep₆ then done
+run-E : [] ⊢ E₀ -→* E₅
+run-E = estep₁ then estep₂ then estep₃ then estep₄ then estep₅ then done
 
 -- … and the generated run agrees, the step the OLD design died on (now
 -- step 5) included.
-_ : evalTerms 6 ⊢E₀ ≡ E₀ ∷ E₁ ∷ E₂ ∷ E₃ ∷ E₄ ∷ E₅ ∷ E₆ ∷ []
+_ : evalTerms 5 ⊢E₀ ≡ E₀ ∷ E₁ ∷ E₂ ∷ E₃ ∷ E₄ ∷ E₅ ∷ []
 _ = refl
 
 -- THE ANSWER TYPES, at the source's own type ∀Y. Y ⇒ Y.
-⊢E₆ : [] ∣ [] ⊢ E₆ ⦂ EID
-⊢E₆ = preservation* ⊢E₀ run-E
+⊢E₅ : [] ∣ [] ⊢ E₅ ⦂ EID
+⊢E₅ = preservation* ⊢E₀ run-E
 
 -- ── DETERMINISM PINS: the run above is THE run.
 
@@ -3045,8 +3025,9 @@ edet₄ st = det st estep₄
 edet₅ : ∀ {M′} → [] ⊢ E₄ -→ M′ → M′ ≡ E₅
 edet₅ st = det st estep₅
 
-edet₆ : ∀ {M′} → [] ⊢ E₅ -→ M′ → M′ ≡ E₆
-edet₆ st = det st estep₆
+-- … and E₅ is a value, so nothing follows it.
+edet-E₅ : ∀ {M′} → [] ⊢ E₅ -→ M′ → ⊥
+edet-E₅ st = value-¬step val-E₅ st
 
 ------------------------------------------------------------------------
 -- §15  TIGHTNESS, RULE BY RULE — JEREMY'S TEST APPLIED TO EVERY RULE
@@ -3187,19 +3168,27 @@ stepᵃ∅ : Δ✦ ⊢ (Λ Nᵃ∅) ·[ (`ℕ ⇒ `ℕ) , `ℕ ]
 stepᵃ∅ = TyBeta val-prb
 
 ------------------------------------------------------------------------
--- §15b  TYPEELR — the value moves one bind deeper, and its `wkᴹ` shift
---       tracks it
+-- §15b  TYPEELR, BOTH CLAUSES — the moved subterm's frame gains a slot,
+--       and the slot is MASKED
 ------------------------------------------------------------------------
 
--- `V` moves from `interior Θ Δ` into
--- `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which is
--- that type context with ONE binder prepended — and the rule shifts `V`
--- by `wkᴹ 1` to match.  A slot Θ MASKS is therefore masked on both
--- sides, one index apart.
+-- The boundary that is BORN is the same in both clauses: its frame is
+-- `morph (A ∷ binds Θ) (changes Θ)`, whose interior is `interior Θ Δ`
+-- with ONE binder prepended.  What differs is what the moved subterm
+-- gets:
+--
+--   TyPeelR-Λ    the body is NOT MOVED — its slot 0 was `abst` and is now
+--                the boundary's `bind`, a REFINEMENT (`⊑ᵃ`), so a name it
+--                could not use it still cannot use, at the SAME index.
+--   TyPeelR-⟪⟫   the moved BOUNDARY is shifted by `wkᴹ 1`, which sends the
+--                fault one index out, AND the new slot is MASKED in its
+--                own change list (`addLock0`) — so the frame gains the
+--                slot without offering it.
+--
+-- The frames, machine-rendered:
 --
 --   showTCtx Δᵇ                                   =  X := ℕ
---   showTCtxAt 9 0 (λ _ → "X") Ξb                 =  ⌷[X := ℕ]
---   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξb′  =  Y := ℕ , ⌷[X := ℕ]
+--   showTCtxAt 9 0 (λ _ → "X") (interior Θᵇ Δᵇ)   =  ⌷[X := ℕ]
 
 Δᵇ : Ctxᵗ
 Δᵇ = unmasked (bind `ℕ) ∷ []
@@ -3213,38 +3202,36 @@ _ = refl
 _ : convCtx Θᵇ Δᵇ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
-Vᵇ : Term
-Vᵇ = prb 0
-
--- showTmIn 1 Rᵇ  =
---   ((λx:ℕ. (ΛY. 3) [X]) ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
-Rᵇ : Term
-Rᵇ = (Vᵇ ⟪ Θᵇ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
-
-¬⊢Vᵇ-int : ∀ {Γ A} → ¬ ((masked (bind `ℕ) ∷ []) ∣ Γ ⊢ Vᵇ ⦂ A)
-¬⊢Vᵇ-int (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
-
-¬⊢Rᵇ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Rᵇ ⦂ A)
-¬⊢Rᵇ (⊢·[] (env _ ⊢V _ _) _) = ¬⊢Vᵇ-int ⊢V
-
--- the rule's conversion-typing premise, read under one `abst`
+-- the conversion-typing premise both clauses carry, read under one `abst`
 ⊢sᵇ : (unmasked abst ∷ convCtx Θᵇ Δᵇ) ⊢ id `ℕ ∶ `ℕ ⇝ `ℕ
 ⊢sᵇ = conv-id base-ℕ
 
--- showTmIn 1 Cᵇ  =
---   ((λx:ℕ. (ΛZ. 3) [X]) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
-Cᵇ : Term
-Cᵇ = (wkᴹ 1 Vᵇ ·[ renameᵗ (extᵗ suc) `ℕ , ` 0 ])
-       ⟪ morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ) , instReveal 0 (id `ℕ) ⟫
+-- ── THE Λ CLAUSE ───────────────────────────────────────────────────────
+-- The probe sits under the `Λ`, naming the slot the boundary MASKS
+-- (X, at index 1 from inside the Λ).
+--
+--   showTmIn 1 Rᵇ
+--     = ((ΛY. (λx:ℕ. (ΛZ. 3) [X])) ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
+--   showTmIn 1 Cᵇ
+--     = ((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
+
+Rᵇ Cᵇ : Term
+Rᵇ = ((Λ (prb 1)) ⟪ Θᵇ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
+Cᵇ = prb 1 ⟪ morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ) , instReveal 0 (id `ℕ) ⟫
 
 stepᵇ : Δᵇ ⊢ Rᵇ -→ Cᵇ
-stepᵇ = TyPeelR val-prb ⊢sᵇ
+stepᵇ = TyPeelR-Λ val-prb ⊢sᵇ
 
--- THE SHIFT AND THE FRAME MOVE TOGETHER: `wkᴹ 1` sends the fault from
--- slot 0 to slot 1, and `interior` puts the new binder at slot 0.
-_ : wkᴹ 1 Vᵇ ≡ prb 1
-_ = refl
+-- the fault, in the redex: the body reads X one `abst` in, and Θᵇ masks it
+¬⊢prb1-abst : ∀ {Γ A}
+  → ¬ ((unmasked abst ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
+¬⊢prb1-abst (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
+¬⊢Rᵇ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Rᵇ ⦂ A)
+¬⊢Rᵇ (⊢·[] (env _ (⊢Λ ⊢N) _ _) _) = ¬⊢prb1-abst ⊢N
+
+-- THE FRAME MOVE IS THE REFINEMENT AND NOTHING ELSE: slot 0 goes from
+-- `abst` to `bind ℕ`, and X stays masked at slot 1.  No index moves.
 _ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ
       ≡ unmasked (bind `ℕ) ∷ interior Θᵇ Δᵇ
 _ = interior-TyPeelR `ℕ Θᵇ Δᵇ
@@ -3253,12 +3240,87 @@ _ : interior (morph (`ℕ ∷ binds Θᵇ) (changes Θᵇ)) Δᵇ
       ≡ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
-¬⊢wkVᵇ : ∀ {Γ A}
+¬⊢prb1-bind : ∀ {Γ A}
   → ¬ ((unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
-¬⊢wkVᵇ (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
+¬⊢prb1-bind (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ¬⊢Cᵇ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Cᵇ ⦂ A)
-¬⊢Cᵇ (env _ (⊢·[] ⊢V _) _ _) = ¬⊢wkVᵇ ⊢V
+¬⊢Cᵇ (env _ ⊢N _ _) = ¬⊢prb1-bind ⊢N
+
+-- ── THE WRAPPER CLAUSE (proof/ShiftAudit §5c₄) ─────────────────────────
+-- Now the probe sits inside a SECOND boundary, so it is the moved
+-- boundary's own frame that has to mask the new binder.  The outer frame
+-- locks X and the inner frame does nothing, so `prb 0` names the locked
+-- slot.
+--
+--   showTmIn 1 Rᵇ′
+--     = (((λx:ℕ. (ΛY. 3) [X]) ⟪ (∀Y. id ℕ) ⟫) ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
+--   showTmIn 1 Cᵇ′
+--     = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
+--
+-- The `↓Y` on the moved boundary is the whole repair, and it is the
+-- difference between a frame that lies and one that does not:
+--
+--   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵇ-single
+--     =  Y := ℕ , ⌷[X := ℕ]        ← the LEAK the single rule had
+--   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵇ-split
+--     =  ⌷[Y := ℕ] , ⌷[X := ℕ]     ← TyPeelR-⟪⟫: Y is masked
+
+Θᵇ′ : CtxMorph
+Θᵇ′ = morph [] []                     -- the INNER frame: nothing
+
+_ : interior Θᵇ′ (interior Θᵇ Δᵇ) ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+Rᵇ′ Cᵇ′ : Term
+Rᵇ′ = ((prb 0 ⟪ Θᵇ′ , `∀ (id `ℕ) ⟫) ⟪ Θᵇ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
+Cᵇ′ = ((prb 1 ⟪ morph [] (lock 0 ∷ []) , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ])
+        ⟪ morph (`ℕ ∷ []) (lock 0 ∷ []) , id `ℕ ⟫
+
+stepᵇ′ : Δᵇ ⊢ Rᵇ′ -→ Cᵇ′
+stepᵇ′ = TyPeelR-⟪⟫ val-prb ⊢sᵇ
+
+-- the fault, in the redex: `⊢·[]`'s `Δ ⊢ᵗ A` at slot 0, which the outer
+-- frame masks
+¬⊢prb0 : ∀ {Δ′ Γ A b} → ¬ ((masked b ∷ Δ′) ∣ Γ ⊢ prb 0 ⦂ A)
+¬⊢prb0 (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
+
+¬⊢Rᵇ′ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Rᵇ′ ⦂ A)
+¬⊢Rᵇ′ (⊢·[] (env _ (env _ ⊢W _ _) _ _) _) = ¬⊢prb0 ⊢W
+
+-- THE TWO FRAMES FOR THE MOVED BOUNDARY, side by side.  The single rule
+-- left the moved boundary's change list alone, so the new binder (slot 0)
+-- was UNMASKED; `addLock0` appends the lock, so it is MASKED.  The old
+-- fault (X) has moved to slot 1 with the shift and is masked in both.
+Ξᵇ-single Ξᵇ-split : Ctxᵗ
+Ξᵇ-single = interior Θᵇ′ (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵇ)
+Ξᵇ-split  = interior (addLock0 (renᴮ suc Θᵇ′))
+                     (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵇ)
+
+_ : Ξᵇ-single ≡ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ = refl
+
+_ : Ξᵇ-split ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ = refl
+
+-- A VALUE THAT NAMES THE NEW SLOT types at the single rule's frame and is
+-- REFUSED at the split's — the leak, and the leak closed, on this
+-- example.
+⊢prb0-single : Ξᵇ-single ∣ [] ⊢ prb 0 ⦂ (`ℕ ⇒ `ℕ)
+⊢prb0-single =
+  ⊢ƛ wf-ℕ (⊢·[] (⊢Λ ⊢$) (wf-var (unmasked (bind `ℕ) , ez , nameable)))
+
+¬⊢prb0-split : ∀ {Γ A} → ¬ (Ξᵇ-split ∣ Γ ⊢ prb 0 ⦂ A)
+¬⊢prb0-split = ¬⊢prb0
+
+-- … and the tightness test itself: the ILL-TYPED value stays ill typed,
+-- for the same localized reason, one index further out.
+¬⊢Cᵇ′ : ∀ {A} → ¬ (Δᵇ ∣ [] ⊢ Cᵇ′ ⦂ A)
+¬⊢Cᵇ′ (env _ (⊢·[] (env _ ⊢W _ _) _) _ _) = ¬⊢prb1-int ⊢W
+  where
+  ¬⊢prb1-int : ∀ {Δ′ Γ A E b}
+    → ¬ ((E ∷ masked b ∷ Δ′) ∣ Γ ⊢ prb 1 ⦂ A)
+  ¬⊢prb1-int (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ------------------------------------------------------------------------
 -- §15c  IDPUSH and CANCELR — the scope move preserves the frame ON THE

--- a/SystemF/agda/strong/Examples.agda
+++ b/SystemF/agda/strong/Examples.agda
@@ -2715,7 +2715,22 @@ CbH = (HV ·[ ` 0 ⇒ ` 1 , `ℕ ]) ⟪ morph (`ℕ ∷ []) [] , id `ℕ ↦ uns
 -- but each pays with the boundary's own discipline — (iii)/(iv) weaken
 -- the mask the crossing installed, (v)/(vi) resolve the binder inside.
 -- The landed rule keeps the frame and the mask and mints
--- `instReveal 0 s`, which types by `preservation-TyPeelR` (§13a).
+-- `instReveal 0 s`, which types by `preservation-TyPeelR-Λ` (§13a).
+--
+-- (v)/(vi) ARE the "resolve variant" the 2026-09-08 shift audit weighed
+-- again as a fix for the frame leak (notes/ShiftAudit.md, candidate (c)),
+-- and they were refused for the reason recorded here: they trade a SCOPE
+-- leak for a KNOWLEDGE leak, and knowledge is what the binder-syntactic
+-- design exists to keep out.  The split (`TyPeelR-Λ`, `TyPeelR-⟪⟫`)
+-- resolves nothing.
+--
+-- Note that the shapes above are written with the SINGLE rule's
+-- contractum in mind — `wkᴹ 1 Wt` type-applied to the fresh name — which
+-- is what the alternatives were compared against at the time.  With the
+-- split, `Wt` is a `Λ` and the Λ clause instantiates it on the spot, so
+-- §13a's landed contractum has no `·[ ]` in it at all; the refutations
+-- (i)/(ii) are unaffected, since they are statements about the
+-- conversion each candidate carries.
 
 ------------------------------------------------------------------------
 -- §14  THE PRE-BOUNDARY COUNTEREXAMPLE, RUN IN v2

--- a/SystemF/agda/strong/Preservation.agda
+++ b/SystemF/agda/strong/Preservation.agda
@@ -28,8 +28,9 @@ module strong.Preservation where
 --   BETA      PROVEN (strong.TermSubst.preserve-Beta).
 --   PEEL      PROVEN (proof/PeelDual.preserve-Peel), since `dualScope` drops
 --             the `unlock` case.
---   TYPEELR   REPAIRED and PROVEN, at EVERY ∀ CONVERSION
---             (proof/Preserve.preserve-TyPeelR).  The rule pushes in the
+--   TYPEELR   REPAIRED and PROVEN, at EVERY ∀ CONVERSION, in BOTH
+--             CLAUSES (proof/Preserve.preserve-TyPeelR-Λ and
+--             .preserve-TyPeelR-⟪⟫).  The rule pushes in the
 --             premise-determined interior ∀-body, keeps the frame plain,
 --             and mints the conversion `instReveal 0 s`.  Under the
 --             retired POLARITY index this held only at a REVEALING
@@ -37,7 +38,10 @@ module strong.Preservation where
 --             a global `p` refused it; per variable each leaf cites its
 --             own binder, and `env`'s frame checks are what keep the two
 --             apart.  Examples §13 runs both directions from closed
---             plain source.
+--             plain source.  The SPLIT (2026-09-08, notes/ShiftAudit.md)
+--             is what makes both clauses FRAME-EXACT: the Λ clause moves
+--             nothing at all, and the wrapper clause masks the new bind
+--             slot in the moved boundary's own change list.
 --   DROP$     PROVEN (proof/Preserve.preserve-Drop$).
 --   CANCELR   PROVEN (proof/MoveScope.preserve-CancelR).
 --   IDPUSH    PROVEN (proof/MoveScope.preserve-IdPush).
@@ -69,16 +73,19 @@ open import strong.Types
   using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; _[_]ᵗ; renameᵗ; extᵗ)
 open import strong.Ctx
   using (Ctxᵗ; Ent; Binding; unmasked; masked; abst; bind; Base; _⊢ᵗ_;
-         _∋_:=_; shiftBy)
+         _∋_:=_; shiftBy; extN)
 open import strong.Conversion
-  using (Conv; id; seal; unseal; _↦_; `∀; mkId; _⊢_∶_⇝_; reveal; instReveal)
+  using (Conv; id; seal; unseal; _↦_; `∀; mkId; _⊢_∶_⇝_; reveal;
+         instReveal; renᶜ)
 open import strong.Terms
-open import strong.TermSubst using (_[_∶_]ᵐ; wkᴹ; preserve-Beta)
+open import strong.TermSubst
+  using (_[_∶_]ᵐ; wkᴹ; renᴹ; renᴮ; preserve-Beta)
 open import strong.Reduction using (_⊢_-→_; _⊢_-→*_)
 
 open import strong.CtxMorph
 open import strong.proof.Preserve
-  using (preserve-TyBeta; preserve-Drop$; preserve-TyPeelR;
+  using (preserve-TyBeta; preserve-Drop$;
+         preserve-TyPeelR-Λ; preserve-TyPeelR-⟪⟫;
          ⊢ᵗ-of; CtxWf-[])
 import strong.proof.Preserve as P
 open import strong.proof.PeelDual using (preserve-Peel)
@@ -155,17 +162,36 @@ preservation-Drop$ : ∀ {n Θ}
   → Δ ∣ [] ⊢ $ n ⦂ C
 preservation-Drop$ = preserve-Drop$
 
--- TYPEELR AT ANY ∀ CONVERSION — the repaired rule, unconditionally.  The
+-- TYPEELR AT ANY ∀ CONVERSION, BOTH CLAUSES, unconditionally.  The
 -- pushed-in annotation is the interior ∀-body the premise determines, and
 -- the conversion is the mint at the binder the rule introduces.
-preservation-TyPeelR : ∀ {V Θ s B Bᵢ Bₑ}
-  → Value V
+--
+-- THE Λ CLAUSE — the boundary is born on the spot, with NO SHIFT: the
+-- `Λ`'s abst slot becomes the boundary's bind slot, TyBeta's own
+-- refinement one `∀` inside.
+preservation-TyPeelR-Λ : ∀ {N Θ s B Bᵢ Bₑ}
+  → Value N
   → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-  → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-    -----------------------------------------------------
-  → Δ ∣ [] ⊢ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+  → Δ ∣ [] ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+    ---------------------------------------------------------------
+  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
+preservation-TyPeelR-Λ = preserve-TyPeelR-Λ
+
+-- THE WRAPPER CLAUSE — the type application is pushed inward one layer,
+-- and the new binder is MASKED in the moved boundary's own change list
+-- (`addLock0`), so the moved boundary crosses by `⊢rename` alone
+-- (strong.TermSubst, `⊢addLock0-cross`).
+preservation-TyPeelR-⟪⟫ : ∀ {W Θ′ s′ Θ s B Bᵢ Bₑ}
+  → Value W
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → Δ ∣ [] ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+    -------------------------------------------------------------------
+  → Δ ∣ [] ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                 ⟪ addLock0 (renᴮ suc Θ′)
+                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
-preservation-TyPeelR = preserve-TyPeelR
+preservation-TyPeelR-⟪⟫ = preserve-TyPeelR-⟪⟫
 
 -- CANCELR — at the moved scope, unconditionally.
 preservation-CancelR : ∀ {V Θ₁ Θ₂ X Y}

--- a/SystemF/agda/strong/Progress.agda
+++ b/SystemF/agda/strong/Progress.agda
@@ -22,8 +22,10 @@ module strong.Progress where
 -- — the whole content — split out there as `progress-env`, which runs
 -- the induction hypothesis on the interior and then classifies the
 -- conversion by `act-or-inert`, keeping the active branches' own
--- premises.  TyPeelR's conversion-typing premise is read off the redex's
--- own `env` by `∀-conv-premise`.
+-- premises.  The TyPeelR SPLIT (`TyPeelR-Λ` / `TyPeelR-⟪⟫`) is decided
+-- there by a second `canon-∀`, on the crossed boundary's interior, and
+-- the same inversion reads the clauses' conversion-typing premise off
+-- the redex's own `env` (`progress-·[]-∀conv`).
 --
 -- No parameters, no postulates, no holes (--safe).
 

--- a/SystemF/agda/strong/README.md
+++ b/SystemF/agda/strong/README.md
@@ -40,14 +40,14 @@ no holes**, under `agda --safe`:
 Beyond the six, the development carries a **tightness** result about the
 reduction relation itself — reduction never takes a term the exterior
 refuses to one it accepts (design law 2, `Design.md` §8).  It is not a
-theorem statement but a rule-by-rule check backed by six frame
+theorem statement but a rule-by-rule check backed by seven frame
 identities: `proof/DualTightness` for `Peel`'s `unlock` half, `Examples`
 §15 for every other rule that moves a subterm into a new frame, and the
 frame-identity table in `Design.md` §7.  Every rule passes; the one
 recorded exception, `Beta` at an *erasing* body, is a dropped argument
 rather than a scope gain.
 
-Since 2026-09-08 the identities are also **exact**, not merely sound:
+Since 2026-09-08 the identities are also **exact**, not merely sound.
 `Beta` used to plant its argument under a `Λ` by shifting it, which left
 the argument's frame one entry wider than the frame it was born in.  It
 now wraps every image that crosses a `Λ` in that binder's DUAL —
@@ -55,6 +55,17 @@ now wraps every image that crosses a `Λ` in that binder's DUAL —
 so the substitution carries the argument's type (`N [ W ∶ A ]ᵐ`) and the
 frame identity `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡
 masked abst ∷ Δ` holds by `refl` (`Design.md` §6.2, `Examples` §15d₂).
+
+The **shift audit** that followed (`notes/ShiftAudit.md`,
+`proof/ShiftAudit`) re-read every site against the sharper question —
+does the frame say the truth about what the moved subterm may *name*? —
+and found one leak, which is now closed: `TyPeelR` is **two clauses**,
+`TyPeelR-Λ` (a `Λ` interior is instantiated on the spot, with no shift at
+all) and `TyPeelR-⟪⟫` (a boundary interior is pushed inward one layer,
+with the new binder masked in the moved boundary's own change list,
+`addLock0`).  Every rule that moves a subterm now masks what it
+introduces, and the §7 table has no exceptions (`Design.md` §6.4,
+`Examples` §15b).
 
 The gate, run **cold**, from `SystemF/agda`:
 
@@ -77,10 +88,10 @@ driver: type-checking it type-checks the whole thing.
 | `TypeSubst.agda` | the type-level renaming/substitution algebra (`rename-cong`, `rename-rename-commute`, and friends) |
 | `Ctx.agda` | **the type context**: entries in two layers — a `Binding` (`abst` / `bind A`) under at most one lock (`unmasked b` / `masked b`), so `Nameable`/`Locked` are one-clause discriminations and double masking is unrepresentable — lookup (`∋e`, `∋tv`, `∋ X := A`), well-formed types, the two transports (`Ren`, `⊑` over `⊑ᵇ`), injective renamings, in-place `mask`/`unmask` (`maskEnt`/`unmaskEnt`, total and idempotent), and the bind prefix `pushBinds` with `shiftBy` |
 | `Conversion.agda` | conversions `id` / `seal` / `unseal` / `_↦_` / `` `∀ ``, the judgment `Δ ⊢ c ∶ A ⇝ B`, `mkId`, both transports, the inversions, `conv-types-unique`, and the canonical conversions minted at a slot (`reveal`/`conceal`, `instReveal`/`instConceal`) |
-| `CtxMorph.agda` | the context morphism as a **pair** — `record CtxMorph = morph (binds : List Ty) (changes : List Change)`, the binds a PARALLEL block and the changes a SEQUENTIAL `lock`/`unlock` list — with `numBinds`, the type contexts it induces (`applyChanges`/`applyUnlocks` at the list, `scope`/`unlockedScope`/`interior`/`convCtx` at the morphism) and their refinement transports, the well-formedness judgement `Δ ⊢ᵐ Θ` as a pair of halves (`_⊢ʳ_` reps, `_⊢ˢ_` changes), and the derived morphisms `dual` (Peel) and `rewind`/`_⋉_` (the scope move) |
+| `CtxMorph.agda` | the context morphism as a **pair** — `record CtxMorph = morph (binds : List Ty) (changes : List Change)`, the binds a PARALLEL block and the changes a SEQUENTIAL `lock`/`unlock` list — with `numBinds`, the type contexts it induces (`applyChanges`/`applyUnlocks` at the list, with their append lemmas and `⊢ˢ-++`; `scope`/`unlockedScope`/`interior`/`convCtx` at the morphism) and their refinement transports, the well-formedness judgement `Δ ⊢ᵐ Θ` as a pair of halves (`_⊢ʳ_` reps, `_⊢ˢ_` changes), and the derived morphisms `dual` (Peel), `rewind`/`_⋉_` (the scope move) and `addLock0` (`TyPeelR-⟪⟫`) |
 | `Terms.agda` | terms, the typing judgment with `env`, `Inert`/`Active` + `act-or-inert`, and `Value` (re-exports `CtxMorph`) |
-| `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), FRAME-EXACT term substitution (`Img`, `crossΛ`, `substᵐ`, `_[_∶_]ᵐ`), `⊢weakenⁿ`, `⊢crossΛ`, `⊢substᵐ`, `⊢subst`, `preserve-Beta` |
-| `Reduction.agda` | the seven rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
+| `TermSubst.agda` | `renᴮ`/`renᴹ`/`wkᴹ`, `⊢rename` (with `Inj ρ`), `⊢retag` (along `⊑`), FRAME-EXACT term substitution (`Img`, `crossΛ`, `substᵐ`, `_[_∶_]ᵐ`), `⊢weakenⁿ`, the two crossings of one new bind slot — `⊢crossΛ` (a value under the binder's dual) and `⊢addLock0-cross` (a boundary masking the binder in its own frame, at `Ren-addLock0` / `interior-addLock0-cross`) — `⊢substᵐ`, `⊢subst`, `preserve-Beta` |
+| `Reduction.agda` | the eight rules plus five congruences, `_-→*_`, `value-¬step`, `det` |
 | `Progress.agda` | the statement `Progress` and `progress`, a one-line wrapper around `proof.Progress.progress` |
 | `Preservation.agda` | `preservation` / `preservation*` as `proof.Preserve.Impl` instantiated at the three downstream cases, plus the per-rule statements and `⊢ᵗ-of-closed` |
 | `TypeSafety.agda` | the public theorem surface: the six theorems above, stated in full |
@@ -93,10 +104,10 @@ driver: type-checking it type-checks the whole thing.
 
 | file | one line |
 |------|----------|
-| `Preserve.agda` | the preservation induction: `⊢ᵗ-of` (which replaces a context well-formedness premise), the minted-conversion typings `⊢reveal`/`⊢conceal`/`⊢instReveal`/`⊢instConceal`, `preserve-TyBeta`, `preserve-Drop$`, `preserve-TyPeelR`, the three case statements, and `module Impl` |
+| `Preserve.agda` | the preservation induction: `⊢ᵗ-of` (which replaces a context well-formedness premise), the minted-conversion typings `⊢reveal`/`⊢conceal`/`⊢instReveal`/`⊢instConceal`, `preserve-TyBeta`, `preserve-Drop$`, `preserve-TyPeelR-Λ`, `preserve-TyPeelR-⟪⟫`, the three case statements, and `module Impl` |
 | `PeelDual.agda` | the `Peel` case: `interior-dual` and `convCtx-dual` in general, and `preserve-Peel` |
 | `MoveScope.agda` | **the scope move**: the list algebra of `shiftScope`/`rewind`/`_⋉_`, `interior-rewind`, the frame **equalities** `interior-⋉-rewind`/`convCtx-⋉-rewind` (with `convCtx-move` the one surviving `⊑`), `move-∋`, `⊢ᵐ-rewind`, `⊢ᵐ-⋉`, the lock-only refutation `¬frame-locksOnly`, and `preserve-CancelR` / `preserve-IdPush` |
-| `Progress.agda` | the progress induction: the boundary case split out as `progress-env`, `TyPeelR`'s premise read off the redex (`∀-conv-premise`), and `progress` itself |
+| `Progress.agda` | the progress induction: the boundary case split out as `progress-env`, the TyPeelR split decided by a second `canon-∀` on the boundary's interior (`progress-·[]-∀conv`, which also reads the clauses' conversion premise off the redex), and `progress` itself |
 | `Canonical.agda` | canonical forms: `canon-base`, `canon-ℕ`, `canon-⇒`, `canon-∀`, `canon-var` |
 | `Canonicity.agda` | the canonical conversion family (`reveal`/`conceal`/`mkId` subtrees) and its closure under the rules |
 | `IdLayer.agda` | why `IdPush` and `CancelR` need no name-relating premise: typing forces `X ≡ numBinds Θ₁ + Y` (`idpush-name`, `cancel-name`), and `unseal` is the only active conversion those left-hand sides meet |
@@ -105,6 +116,7 @@ driver: type-checking it type-checks the whole thing.
 | `PreserveObstruct.agda` | the four refutation witnesses, three of which now record the **positive** fact after the repairs (§2 `TyPeelR`, §4 the wall witness) |
 | `DualTightness.agda` | **tightness of the crossing**, Jeremy's test (2026-09-06) and its repair: the redex that is ill typed at the exterior now has an ill-typed contractum too (`¬⊢Contractum`), (†) `interior (dual Θᵤ) (interior Θᵤ Δᵤ) ≡ Δᵤ`, the positive control at a `lock`, and the VACUOUS UNLOCK refused (`¬⊢ᵐΘᵥ`).  The same test at every other rule that moves a subterm is `Examples` §15 |
 | `MwUObstruct.agda` | which outer frame the scope move may use, on one configuration: `dropLocks Θ₂` **refuted** (the moved unlock goes vacuous), `bindsOnly Θ₂` **refuted** (the frame's own rep loses its unlock), `rewind Θ₂` does both jobs — and why the rep half reads its reps on `unlockedScope Θ Δ` rather than on the plain exterior |
+| `ShiftAudit.agda` | **the shift audit** (2026-09-08): every rule that moves a subterm, checked against frame exactness — the frame identity per site, the witness of the ONE leak the audit found (the old single `TyPeelR`), the machine refutation of the wrap repair (it **loops**, `-→ᵃ` and the run `T₀ -→ᵃ T₁ -→ᵃ T₂`), and, for the two clauses that replaced it, `TyPeelR-Λ-refinement`, `TyPeelR-⟪⟫-frame`/`-slot-locked`, the tower measure `towerHeight` with `TyPeelR-⟪⟫-height` against `fixA-height-stalls`, and a closed two-deep run with every state typed |
 | `TypeSafety.agda` | `type-safety` = `progress ∘ preservation*` |
 
 **The invariant hunt** — the search for a side condition that would
@@ -153,7 +165,7 @@ cycle `x`, `y`, `z`, `f`, `g`, `h`, then primes; `V` and `W` are reserved
 for value metavariables and never generated.  Type binder names are
 **globally unique across one rendered term** — two sibling `Λ`s never
 both print as `ΛX` — and binds are named oldest-first so an older bind
-keeps its name when `TyPeelR` prepends a newer one.  Morphism entries
+keeps its name when a `TyPeelR` clause prepends a newer one.  Morphism entries
 print as `↑X:=A` (`bind`), `↓X` (`lock`), `↥X` (`unlock`); a `masked` entry
 prints as `⌷[…]`.
 
@@ -169,6 +181,7 @@ prints as `⌷[…]`.
 | `BoundarySurvey.md` | the empirical record of v1's boundary bookkeeping: the master table plus the bookkeeping-independent requirements the redesign had to meet |
 | `RedesignAdvice.md` | survey data → design advice; the four answers (central rep storage, keep simultaneity, use Conversion, definitional cancel) |
 | `RuleRepairs-TyPeelR-CancelR.md` | the proposed repairs to those two rules, before/after, run on the breaking examples |
+| `ShiftAudit.md` | **the shift audit** (Jeremy, 2026-09-08): the criterion, the site-by-site verdict table, the one leak in detail with its witness, the four candidate fixes with their hazards, and the verdict — the `canon-∀` split, now INSTALLED as `TyPeelR-Λ` / `TyPeelR-⟪⟫` |
 | `BoundaryRules.md` | the earlier decision memo on boundary-manipulation rules (v1-era) |
 | `DualLicenseDesign.md` | the v1 dual-conceal licence, fully ruled (v1-era) |
 | `PreservationEndgame.md` | the v1 preservation endgame plan (v1-era) |

--- a/SystemF/agda/strong/Reduction.agda
+++ b/SystemF/agda/strong/Reduction.agda
@@ -6,7 +6,10 @@ module strong.Reduction where
 -- notes/DECISIONS.md ("Id-layer RULING", 2026-09-05) applied:
 --
 --   (1) V-Λ carries `Value N` (in strong.Terms) — reduction goes under Λ.
---   (2) TyPeelR shifts its type annotation.
+--   (2) TyPeelR shifts its type annotation.  It is also SPLIT IN TWO —
+--       `TyPeelR-Λ` and `TyPeelR-⟪⟫` — by the shift audit
+--       (notes/ShiftAudit.md, 2026-09-08), so that no moved subterm is
+--       offered a slot it could not name before.
 --   (3) CancelR drops the `hideBinds` residue, carries the BINDER-LOOKUP
 --       premise that determines its `mkId` conversion, and names its two
 --       conversions separately (the single-name presumption, examined
@@ -74,22 +77,72 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
         -→ (V · (wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫)) ⟪ Θ , t ⟫
 
   -- TYPEEL — the ∀-conversion analogue; the new binder is prepended and the
-  -- elimination instantiates at the new binder's bind name.
+  -- elimination instantiates at the new binder's bind name.  IT IS TWO
+  -- CLAUSES, split on the crossed boundary's INTERIOR (2026-09-08, the
+  -- shift audit; notes/ShiftAudit.md).
   --
-  -- THE ANNOTATION REPAIR (2a).  The pushed-in `·[ _ , ` 0 ]` must carry
+  -- WHAT EACH CLAUSE DOES.  `canon-∀` (proof/Canonical) says a closed
+  -- value at a `∀` type is a `Λ` over a value or a WRAPPER with a `∀`
+  -- conversion, and nothing else.  So:
+  --
+  --   TyPeelR-Λ    the interior is `Λ N`: INSTANTIATE AT ONCE.  N moves
+  --                nowhere, gains no shift, and the boundary is born on
+  --                the spot.
+  --   TyPeelR-⟪⟫   the interior is a boundary: PUSH THE TYPE APPLICATION
+  --                INWARD one layer, exactly as the single rule did, and
+  --                mask the new binder in the MOVED BOUNDARY'S OWN change
+  --                list (`addLock0`, strong.CtxMorph §5).
+  --
+  -- Together they are TOTAL over canonical `∀`-values, so the split
+  -- REPLACES the single rule (`progress`, proof/Progress) rather than
+  -- supplementing it.
+  --
+  -- WHY V'S FRAME MUST NOT GAIN THE UNMASKED BIND SLOT.  The single rule
+  -- moved its value V by `wkᴹ 1` into
+  -- `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ` — V's old
+  -- frame with ONE NEW SLOT, offered UNMASKED.  V neither had that slot
+  -- nor could use it (`wkᴹ 1` sends every index to ≥ 1), so the frame
+  -- said more than the truth: the tight frame and the live one differed
+  -- by exactly one `le-mu`, the RE-EXPOSURE clause — the one step `_⊑ᵃ_`,
+  -- the refinement a TERM may travel along, REFUSES (proof/ShiftAudit §3,
+  -- `TyPeelR-leak-⊑` / `TyPeelR-leak-¬⊑ᵃ`).  Every other rule masks what
+  -- it introduces (Peel by (†), Beta by `crossΛ`), so this was the one
+  -- exception, and the audit closed it.
+  --
+  -- WHY THE Λ CLAUSE NEEDS NO SHIFT.  The `Λ`'s abst slot BECOMES the
+  -- boundary's bind slot: N already lives one `abst` binder in (`⊢Λ`), so
+  -- the frame move is `unmasked abst → unmasked (bind …)` at a slot N
+  -- COULD ALREADY NAME — `la-uu le-ab`, `⊑ᵃ`-legal, which is TyBeta's own
+  -- refinement, one `∀` inside.  Hence no `wkᴹ`, no `⊢rename`, and the
+  -- contractum does not mention `Bᵢ` at all.
+  --
+  -- WHY THE WRAPPER CLAUSE TERMINATES.  Its contractum's inner
+  -- application is again a redex, but the `∀`-value's TOWER HEIGHT — the
+  -- number of nested boundaries above the `Λ` — strictly DECREASES
+  -- (`TyPeelR-⟪⟫-height`, proof/ShiftAudit §5c₂), because the clause
+  -- CONSUMES a boundary that was already there.  The rejected repair
+  -- (wrap the moved value in the new binder's dual) MINTS one instead, so
+  -- its measure stalls and it loops: an identity conversion at a `∀` is
+  -- necessarily a `` `∀ `` conversion, hence inert, hence the wrapped
+  -- value under `·[ … ]` is itself a redex (`fixA-height-stalls` and the
+  -- run `T₀ -→ᵃ T₁ -→ᵃ T₂`, proof/ShiftAudit §4/§4a).  A tower of height
+  -- `h` therefore takes `h − 1` `TyPeelR-⟪⟫` steps and then exactly one
+  -- `TyPeelR-Λ` step.
+  --
+  -- THE ANNOTATION PREMISE (2a).  The pushed-in `·[ _ , ` 0 ]` must carry
   -- the INTERIOR ∀-body — what the interior's own `⊢·[]` demands — not the
   -- exterior body `B`, from which it differs at every non-identity leaf.
   -- The interior body is not syntactic (a `seal`'s source is a binder's
   -- rep, which the rep-free conversion does not carry) but it IS
-  -- DETERMINED by the conversion typing, so the rule carries that typing
-  -- as a PREMISE — the same move already ruled for the `mkId`
+  -- DETERMINED by the conversion typing, so both clauses carry that
+  -- typing as a PREMISE — the same move already ruled for the `mkId`
   -- conversions.  It is read at the ∀-body, i.e. under one `abst`, and
   -- Progress derives it for free by inverting the redex's own `env`
-  -- (`conv-all-inv`).  Determinism is `conv-types-unique`
-  -- (strong.Conversion), exactly as it is `∋:=-det` for the lookup-carrying
-  -- rules.
+  -- (`conv-all-inv`).  Determinism is `conv-src-unique`
+  -- (strong.Conversion) for the wrapper clause, exactly as it is `∋:=-det`
+  -- for the lookup-carrying rules; the Λ clause needs neither.
   --
-  -- THE SHIFT REPAIR (2b).  `renᴮ suc Θ` double-counts: `interior` already
+  -- THE SHIFT (2b).  `renᴮ suc Θ` would double-count: `interior` already
   -- lifts Θ's reps past the binder A prepended here
   -- (`interior (morph (A ∷ binds Θ) (changes Θ)) Δ
   --   ≡ bind (shiftBy (numBinds Θ) A) ∷ interior Θ Δ`), so the CHANGES are
@@ -102,10 +155,28 @@ data _⊢_-→_ : Ctxᵗ → Term → Term → Set where
   -- Keeping `s` itself is ill-typed — its TARGET body still mentions
   -- `` ` 0 `` where `env` demands the instantiated
   -- `shiftBy (numBinds Θ + 1) (Bₑ [ A ])`.
-  TyPeelR : ∀ {Δ V Θ s B A Bᵢ Bₑ} → Value V
+  TyPeelR-Λ : ∀ {Δ N Θ s B A Bᵢ Bₑ} → Value N
     → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-    → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-        -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+    → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+        -→ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+  -- The moved boundary is SHIFTED exactly as the single rule shifted it —
+  -- `wkᴹ 1` on a boundary is `renᴹ (extN (numBinds Θ′) suc)` on its
+  -- interior, `renᴮ suc` on its frame and
+  -- `renᶜ (extᵗ (extN (numBinds Θ′) suc))` on its `∀`-conversion body —
+  -- and then `lock 0` is APPENDED to its own (shifted) change list.  So
+  -- the contractum is the single rule's, with `addLock0` on the moved
+  -- boundary and nothing else changed: same outer frame, same minted
+  -- conversion `instReveal 0 s`, same pushed-in annotation, same type
+  -- argument `` ` 0 `` (`TyPeelR-⟪⟫-wkᴹ`,
+  -- `TyPeelR-⟪⟫-outer-unchanged`, proof/ShiftAudit §5c).
+  TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A Bᵢ Bₑ} → Value W
+    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+        -→ ((renᴹ (extN (numBinds Θ′) suc) W
+               ⟪ addLock0 (renᴮ suc Θ′)
+               , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+              ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
              ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
   -- CANCEL — a conceal directly under the binder it names.  The
@@ -224,16 +295,32 @@ det (Peel v w)   (ξ-·-r u st) = ⊥-elim (value-¬step w st)
 det (ξ-·-l st)   (Peel v w)   = ⊥-elim (value-¬step (V-⟪⟫ v I-fun) st)
 det (ξ-·-r u st) (Peel v w)   = ⊥-elim (value-¬step w st)
 
--- TyPeelR — the two contracta agree because the SOURCE AND TARGET TYPES
--- are a function of the conversion and the type context
--- (`conv-types-unique`), so the two premises determine the SAME pushed-in
--- annotation.
-det (TyPeelR {V = V} {Θ = Θ} {s = s} {A = A} v ⊢s) (TyPeelR v′ ⊢s′) =
-  cong (λ T → (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) T , ` 0 ])
+-- TyPeelR — the two clauses' patterns are DISJOINT (a `Λ` is not a
+-- boundary), so no cross case arises.
+--
+-- The Λ clause is determined by the redex OUTRIGHT: its contractum does
+-- not mention `Bᵢ`, so `conv-src-unique` is not needed at all.
+det (TyPeelR-Λ v ⊢s) (TyPeelR-Λ v′ ⊢s′) = refl
+det (TyPeelR-Λ v ⊢s) (ξ-·[] st) =
+  ⊥-elim (value-¬step (V-⟪⟫ (V-Λ v) I-all) st)
+det (ξ-·[] st) (TyPeelR-Λ v ⊢s) =
+  ⊥-elim (value-¬step (V-⟪⟫ (V-Λ v) I-all) st)
+
+-- The wrapper clause's two contracta agree because the SOURCE type is a
+-- function of the conversion and the type context (`conv-src-unique`), so
+-- the two premises determine the SAME pushed-in annotation.
+det (TyPeelR-⟪⟫ {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s} {A = A} v ⊢s)
+    (TyPeelR-⟪⟫ v′ ⊢s′) =
+  cong (λ T → ((renᴹ (extN (numBinds Θ′) suc) W
+                  ⟪ addLock0 (renᴮ suc Θ′)
+                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                 ·[ renameᵗ (extᵗ suc) T , ` 0 ])
                 ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫)
        (conv-src-unique ⊢s ⊢s′)
-det (TyPeelR v ⊢s) (ξ-·[] st)     = ⊥-elim (value-¬step (V-⟪⟫ v I-all) st)
-det (ξ-·[] st)     (TyPeelR v ⊢s) = ⊥-elim (value-¬step (V-⟪⟫ v I-all) st)
+det (TyPeelR-⟪⟫ v ⊢s) (ξ-·[] st) =
+  ⊥-elim (value-¬step (V-⟪⟫ (V-⟪⟫ v I-all) I-all) st)
+det (ξ-·[] st) (TyPeelR-⟪⟫ v ⊢s) =
+  ⊥-elim (value-¬step (V-⟪⟫ (V-⟪⟫ v I-all) I-all) st)
 
 -- CancelR — the two contracta agree because the lookup is a function.
 det (CancelR {V = V} {Θ₁ = Θ₁} {Θ₂ = Θ₂} v d) (CancelR v′ d′) =

--- a/SystemF/agda/strong/TermSubst.agda
+++ b/SystemF/agda/strong/TermSubst.agda
@@ -34,6 +34,12 @@ module strong.TermSubst where
 --          `Ren-wk`/`Inj-suc` plus `mkId-⊢` (`⊢crossΛ`, §6).  No knowledge
 --          premise appears, because a boundary carries NAMES, never
 --          spellings.
+--
+-- §6 also carries the OTHER crossing of one new bind slot,
+-- `⊢addLock0-cross`, which `TyPeelR-⟪⟫` consumes: there the moved subterm
+-- is itself a BOUNDARY, so the new slot is masked in its OWN change list
+-- (`addLock0`, strong.CtxMorph §5) instead of under a minted wrapper —
+-- and the crossing is again `⊢rename` alone, at `Ren-addLock0`.
 
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.List using (List; []; _∷_; map; length)
@@ -71,6 +77,16 @@ renᴮ ρ Θ = morph (map (renameᵗ ρ) (binds Θ)) (map (renᶠ ρ) (changes �
 
 numBinds-ren : (ρ : Renameᵗ) (Θ : CtxMorph) → numBinds (renᴮ ρ Θ) ≡ numBinds Θ
 numBinds-ren ρ Θ = map-length (renameᵗ ρ) (binds Θ)
+
+-- Renaming a change list at `suc` IS lifting it by one: `renᶠ` moves the
+-- one exterior name a change carries, which is all `shiftScope 1` does.
+map-renᶠ-shiftScope : (S : List Change)
+  → map (renᶠ suc) S ≡ shiftScope 1 S
+map-renᶠ-shiftScope []             = refl
+map-renᶠ-shiftScope (unlock X ∷ S) =
+  cong (unlock (suc X) ∷_) (map-renᶠ-shiftScope S)
+map-renᶠ-shiftScope (lock X ∷ S)   =
+  cong (lock (suc X) ∷_) (map-renᶠ-shiftScope S)
 
 renᴹ : Renameᵗ → Term → Term
 renᴹ ρ (` x)          = ` x
@@ -397,6 +413,36 @@ extⁿ-∋ h (there d) = there (h d)
 Ren-wk : ∀ {Δ E} → Ren suc Δ (E ∷ Δ)
 Ren-wk = mkRen es
 
+-- THE SAME RENAMING, THROUGH A BOUNDARY.  `wkᴹ 1` on a boundary renames
+-- its interior at `extN (numBinds Θ′) suc` (`renᴹ`'s wrapper clause), and
+-- that is exactly the renaming from the moved boundary's BIRTH frame
+-- `interior Θ′ Δ` into the frame one entry out.  It holds for EVERY entry
+-- E — the masked one included, which is what `addLock0` puts there, and
+-- what makes the crossing `⊢rename` ALONE, with no `⊢retag`.
+Ren-addLock0 : ∀ {Δ} (Θ′ : CtxMorph) (E : Ent)
+  → Ren (extN (numBinds Θ′) suc) (interior Θ′ Δ)
+        (pushBinds (map ⇑ᵗ (binds Θ′)) (E ∷ scope Θ′ Δ))
+Ren-addLock0 Θ′ E = ren-pushBinds (binds Θ′) suc (mkRen es)
+
+-- THE FRAME IDENTITY AT THAT CROSSING.  `interior-addLock0`
+-- (strong.CtxMorph §5) says the appended lock is `mask 0`; here the
+-- masked slot is the NEW BIND the crossing introduces, and the shifted
+-- change list steps over it (`applyChanges-shiftScope1`).  So the moved
+-- boundary's interior is its BIRTH frame with the new binder inserted
+-- BELOW the bind prefix and MASKED — the shape (†) gives Peel's crossing
+-- argument (proof/PeelDual, `interior-dual`) and `interior-Beta-Λ` gives
+-- Beta's.  Nothing gained, nothing lost.
+interior-addLock0-cross : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
+  → interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
+      ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
+interior-addLock0-cross Θ′ C Δ =
+  trans (interior-addLock0 (renᴮ suc Θ′) (unmasked (bind C) ∷ Δ))
+        (cong (pushBinds (map ⇑ᵗ (binds Θ′)))
+              (trans (cong (λ S → applyChanges S (masked (bind C) ∷ Δ))
+                           (map-renᶠ-shiftScope (changes Θ′)))
+                     (applyChanges-shiftScope1 (changes Θ′)
+                                               (masked (bind C)) Δ)))
+
 -- Term-variable renaming AT THE IDENTITY renaming is the identity.  This
 -- is what makes the CLOSED-TERM weakening below a corollary of `⊢renⁿ`
 -- rather than a second induction.
@@ -457,6 +503,83 @@ data _∣_⊢ⁱ_⦂_ : Ctxᵗ → Ctx → Img → Ty → Set where
       (⊢rename Ren-wk Inj-suc ⊢W)
       (mkId-⊢ (wf-ren Ren-wk w))
       (wf-ren Ren-wk w)
+
+-- (‡‡) THE OTHER CROSSING OF ONE NEW BIND SLOT — the (b′) analogue of
+-- (‡) above and of PeelDual's `crossing`, for a subterm that is ITSELF A
+-- BOUNDARY.  `TyPeelR-⟪⟫` (strong.Reduction) moves the inner boundary of
+-- a ∀-value tower under the binder it introduces; the new slot is masked
+-- in the moved boundary's OWN change list (`addLock0`), so no second
+-- wrapper is minted.  Every premise is one move `⊢rename`'s (env) case
+-- already makes:
+--
+--   FRAME     reps by `⊢ʳ-ren` at `ren-unlockedScope` — the appended lock
+--             is LIFTED (`unlockedScope-addLock0`); changes by `⊢ˢ-++`,
+--             i.e. `⊢ˢ-ren` for the shifted list over the frame the
+--             appended lock leaves, and `sw-l` for the lock itself, whose
+--             slot IS nameable at the outer position.
+--   INTERIOR  `⊢rename` at `Ren-addLock0` ALONE — no `⊢retag`, no
+--             `le-mu`.
+--   CONV      `conv-ren` at `ren-convCtx`, plus `shiftBy-ren` and
+--             `numBinds-ren` arithmetic; the conversion context is the
+--             plainly renamed one (`convCtx-addLock0`).
+--   EXTERIOR  `wf-ren Ren-wk`.
+--
+-- NO EXTRA PREMISE: everything comes off the redex's own derivation.
+⊢addLock0-cross : ∀ {Δ Γ C W Θ′ c Bᵥ Bₑ}
+  → Δ ⊢ᵐ Θ′
+  → interior Θ′ Δ ∣ [] ⊢ W ⦂ Bᵥ
+  → convCtx Θ′ Δ ⊢ c ∶ Bᵥ ⇝ shiftBy (numBinds Θ′) Bₑ
+  → Δ ⊢ᵗ Bₑ
+    -------------------------------------------------------------------
+  → (unmasked (bind C) ∷ Δ) ∣ Γ
+      ⊢ renᴹ (extN (numBinds Θ′) suc) W
+          ⟪ addLock0 (renᴮ suc Θ′) , renᶜ (extN (numBinds Θ′) suc) c ⟫
+      ⦂ ⇑ᵗ Bₑ
+⊢addLock0-cross {Δ = Δ} {C = C} {W = W} {Θ′ = Θ′} {c = c} {Bᵥ = Bᵥ}
+                {Bₑ = Bₑ} mw′ ⊢W ⊢c wE =
+  env (mw reps chs) intW convW (wf-ren Ren-wk wE)
+  where
+  n′ : ℕ
+  n′ = numBinds Θ′
+
+  Δ⁺ : Ctxᵗ
+  Δ⁺ = unmasked (bind C) ∷ Δ
+
+  Θ″ : CtxMorph
+  Θ″ = addLock0 (renᴮ suc Θ′)
+
+  reps : unlockedScope Θ″ Δ⁺ ⊢ʳ binds Θ″
+  reps = subst (λ Ξ → Ξ ⊢ʳ map (renameᵗ suc) (binds Θ′))
+               (sym (unlockedScope-addLock0 (renᴮ suc Θ′) Δ⁺))
+               (⊢ʳ-ren (ren-unlockedScope Θ′ Ren-wk Inj-suc)
+                       (mw-reps mw′))
+
+  chs : Δ⁺ ⊢ˢ changes Θ″
+  chs = ⊢ˢ-++ (map (renᶠ suc) (changes Θ′)) (lock 0 ∷ [])
+              (⊢ˢ-ren Ren-wk Inj-suc (mw-changes mw′))
+              (sw-l (unmasked (bind (⇑ᵗ C)) , ez , nameable) sw[])
+
+  intW : interior Θ″ Δ⁺ ∣ [] ⊢ renᴹ (extN n′ suc) W
+           ⦂ renameᵗ (extN n′ suc) Bᵥ
+  intW = subst (λ Ξ → Ξ ∣ [] ⊢ renᴹ (extN n′ suc) W
+                        ⦂ renameᵗ (extN n′ suc) Bᵥ)
+               (sym (interior-addLock0-cross Θ′ C Δ))
+               (⊢rename (Ren-addLock0 Θ′ (masked (bind C)))
+                        (Inj-extN n′ Inj-suc) ⊢W)
+
+  convW : convCtx Θ″ Δ⁺ ⊢ renᶜ (extN n′ suc) c
+            ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ shiftBy (numBinds Θ″) (⇑ᵗ Bₑ)
+  convW =
+    subst (λ Ξ → Ξ ⊢ renᶜ (extN n′ suc) c ∶ renameᵗ (extN n′ suc) Bᵥ
+                   ⇝ shiftBy (numBinds Θ″) (⇑ᵗ Bₑ))
+          (sym (convCtx-addLock0 (renᴮ suc Θ′) Δ⁺))
+      (subst (λ n → convCtx (renᴮ suc Θ′) Δ⁺ ⊢ renᶜ (extN n′ suc) c
+                      ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ shiftBy n (⇑ᵗ Bₑ))
+             (sym (numBinds-ren suc Θ′))
+        (subst (λ T → convCtx (renᴮ suc Θ′) Δ⁺ ⊢ renᶜ (extN n′ suc) c
+                        ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ T)
+               (shiftBy-ren n′ suc Bₑ)
+               (conv-ren (ren-convCtx Θ′ suc Ren-wk Inj-suc) ⊢c)))
 
 -- Weakening an image: a variable image moves by `there`, a value image is
 -- CLOSED and moves by nothing at all.

--- a/SystemF/agda/strong/notes/DECISIONS.md
+++ b/SystemF/agda/strong/notes/DECISIONS.md
@@ -2586,3 +2586,48 @@ costs one extra Drop$.  Step-count deltas: Q 9→11, D 12→16, R 18→21,
 L 9→11, E 5→6; P₀, G, J, H, Ri unchanged.  Alternatives costed in
 notes/PR-exact-beta.md (extend an existing wrapper's changes; one
 composed dual per substitution path).  Awaiting Jeremy's ruling.
+
+### RULING: TyPeelR split into TyPeelR-Λ / TyPeelR-⟪⟫ (Jeremy, 2026-09-08)
+
+THE PROBLEM (shift audit after #199, PR #201).  The live TyPeelR shifted
+its value `V` by `wkᴹ 1` under the new bind slot `X := A`, which is
+UNMASKED in V's frame although V was authored where it did not exist.
+The §15b index test cannot see this — the shift makes the slot
+unreachable from V — but the frame does not tell the truth: the live
+frame and the tight frame differ by exactly one `le-mu`, the
+re-exposure step `⊑ᵃ` refuses (ShiftAudit `TyPeelR-leak-⊑`).  Jeremy
+first read the "V" as another subterm and called it not a tightness
+problem, then confirmed: "I see the problem now".  Every other shift
+site (Peel, TyBeta, Beta with crossΛ, CancelR/IdPush, Drop$, ξ) is
+frame-exact by a machine-checked identity.
+
+THE CANDIDATES, on the §15b example, machine-checked in
+proof/ShiftAudit.agda:
+  (a) wrap V in the binder's dual `⟪ ↓X , ∀ id ⟫` — REFUTED: the only
+      identity at a ∀ type is `∀ (mkId …)`, inert, so the wrapper is a
+      TyPeelR redex again; `fixA-loop-step` proves the regress, a closed
+      run adds one boundary per step and TyBeta never fires.
+  (b) split on the canonical form of V.  For `Λ N` the contractum is
+      `N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫`: NO
+      shift, the Λ's abst slot becomes the boundary's bind slot
+      (TyBeta's own refinement).
+  (b′) for a nested `W ⟪ Θ′ , ∀ s′ ⟫`: the moved inner boundary gets
+      `lock 0` appended at the TAIL of its own shifted change list
+      (`addLock0`), no wrapper minted; contractum = the live one with
+      `addLock0ᵛ` on the moved value (`TyPeelR-⟪⟫-wkᴹ`, refl).  Inner
+      interior ≡ birth frame with the new slot inserted MASKED.
+      Terminates: tower height drops by one per step, height 0 is a Λ.
+  (c) resolve A inside the interior — exact for V but writes the
+      exterior's representation into the interior: a KNOWLEDGE leak.
+      Rejected.
+
+RULING.  Install (b)+(b′), replacing TyPeelR by the pair (canon-∀ makes
+the pair total, so progress's single TyPeelR case becomes a two-way
+split).  Jeremy asked "do we have Progress?" — answered: the probe
+proved only the `·[]` case; the full theorems are re-checked by the
+install gate.
+INSTALLED on branch typeelr-split (PR "TyPeelR split").  Side effect
+measured in Examples: the Λ clause performs the instantiation itself,
+so one type instantiation mints ONE binder where TyPeelR ⨟ TyBeta minted
+two — J₀ 14 → 11 steps, E₀ 6 → 5 (ends in a value), T₉'s birth story
+2 → 1 step; P₀ Q₀ R₀ L₀ Ri G unchanged.

--- a/SystemF/agda/strong/notes/ShiftAudit.md
+++ b/SystemF/agda/strong/notes/ShiftAudit.md
@@ -1,0 +1,265 @@
+# The shift audit — every place a rule moves a subterm
+
+**Jeremy, 2026-09-08.**  "Frame exactness is the main point of Strong
+System F!"  (PR #199: `Beta` now wraps every value crossing a `Λ` in that
+binder's dual, `crossΛ`.)  Request: *audit all places that shift a term to
+see if we have forgotten to mask type variables in other places.*
+
+Machine-checked companion: `proof/ShiftAudit.agda` (in `All.agda`; the
+gate `make -C strong check` is green).  The frame-identity table it feeds
+is `Design.md` §7; the per-rule tightness tests are `Examples` §15 and
+`proof/DualTightness`.
+
+## The criterion
+
+Whenever a rule **moves a subterm** to a new position, the subterm's type
+context at the new position must be **exactly** its context at the old
+position, up to
+
+1. the **index shift** past the binders it crossed, and
+2. **refinement** `abst → bind` of a slot it **could already name**
+   (TyBeta's reveal; `instReveal`'s slot).
+
+Any slot the subterm **could not name before and can name after** is a
+**frame leak** — even when the subterm's shifted indices cannot reach it.
+The frame must *say the truth* about what the subterm may name.
+
+## The table
+
+| site | what shifts | frame before | frame after | verdict |
+|------|-------------|--------------|-------------|---------|
+| **Peel** | `wkᴹ (numBinds Θ) W` under `dual Θ` | `Δ` | `map maskEnt (pushBinds (binds Θ) []) ++ Δ` — (†) `proof/PeelDual.interior-dual` | **exact**.  Every new slot is `masked` (`Peel-slot0-locked`), and `wkᴹ (numBinds Θ)` lands past exactly them.  Criterion 1 alone. |
+| **Peel** (`V`) | nothing | `interior Θ Δ` | `interior Θ Δ` | **exact** — identical context, no shift. |
+| **TyPeelR** (`V`) | `wkᴹ 1 V` | `interior Θ Δ` | `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ` — `interior-TyPeelR` | ****LEAK****.  The new slot 0 is offered **unmasked**; `V` neither had it nor uses it. |
+| **TyBeta** | nothing (`N` stays) | `unmasked abst ∷ Δ` (`⊢Λ`) | `unmasked (bind A) ∷ Δ` — `interior-TyBeta` | **exact up to refinement**.  `la-uu le-ab` at a slot `N` could already name: criterion 2, `⊑ᵃ`-legal. |
+| **TyBeta** (the type `B`) | nothing | `unmasked abst ∷ Δ` | `convCtx (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ` | **exact up to refinement** — same step. |
+| **Beta**, no binder crossed | `substᵐ` | `Δ` | `Δ` | **exact**.  (The one recorded exception is **erasure** — a dropped argument crosses nowhere; `Examples` §15d.) |
+| **Beta**, crossing a `Λ` | `crossΛ W A = ⇑ᴹ W ⟪ morph [] (lock 0 ∷ []) , mkId (⇑ᵗ A) ⟫` | `Δ` | `interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ` — `interior-Beta-Λ` | **exact** (PR #199).  Slot 0 is refused (`Beta-Λ-slot0-locked`). |
+| **Beta**, crossing a `ƛ` | `shiftᴵ` | `Δ` | `Δ` | **exact, vacuous**.  A `ƛ` binds a *term* variable; `shiftᴵ` is the identity on a value image because the image is **term-closed**, and it stays term-closed after #199 (`crossΛ W A` is a boundary, and `env` types its interior at `Γ = []`).  The two crossings commute on the nose (`⇑ᴵ-shiftᴵ-comm`) — the no-interference law. |
+| **CancelR / IdPush** (`V`) | nothing | `interior Θ₁ (interior Θ₂ Δ)` | `interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ)` — `proof/MoveScope.interior-⋉-rewind` | **exact** — an *equality*, which is why neither case needs `⊢retag`. |
+| **CancelR / IdPush** (outer) | nothing | `interior Θ₂ Δ` | `interior (rewind Θ₂) Δ ≡ pushBinds (binds Θ₂) Δ` | **exact**.  Only the inner boundary node sits there, and `_⋉_` **reapplies** Θ₂'s whole change list at the tail, where `applyChanges` runs it first.  Both conversions are **re-minted** (`mkId`/`unseal`), not transported.  `numBinds` is unchanged on both sides (`refl`). |
+| **Drop$** | the numeral leaves its frame | `interior Θ Δ` | `Δ` | **vacuous**.  This is a frame change in the *other* direction — the bind prefix disappears and Θ's locks lift, so the new frame is strictly *more* nameable — but a numeral names no type variable: `⊢$` types it at every type context (`Drop$-vacuous`).  No other term can take the step: the rule's LHS interior is the **numeral itself** (`Drop$-only-numerals`), and progress needs no more because a closed value at a base type *is* a numeral (`canon-base`). |
+| **ξ-Λ / ξ-⟪⟫ / ξ-·-l / ξ-·-r / ξ-·[]** | nothing | — | — | **exact**.  Each reduces a subterm *in place*, at the very context the corresponding typing rule reads it on: `unmasked abst ∷ Δ` is `⊢Λ`'s premise context, `interior Θ Δ` is `env`'s.  Both `refl`. |
+
+Not rules, and therefore not sites: `⊢rename`, `⊢retag`, `Ren-wk`,
+`renᴹ`, `renⁿ`, `⊢renⁿ`, `⊢weakenⁿ`, `canon-renᴹ`/`canon-renⁿ`.  These are
+transports the cases above are *proved with*; each one's `Ren`/`⊑ᵃ`
+argument is supplied at the site.  `Eval` constructs no terms (`step` is
+`progress`), and `Show` is a printer.
+
+**Dead machinery.**  `shiftᵐ = renⁿ suc` (`TermSubst` §5) and
+`canon-shiftᵐ` (`proof/Canonicity`) have **no consumers** after #199:
+frame-exact substitution weakens an image with `shiftᴵ`, which is `there`
+on a variable image and the identity on a value image, so the
+term-variable shift is never applied to a term.  `renⁿ` itself is live —
+`⊢renⁿ` at the identity renaming is what proves `⊢weakenⁿ`.  *Recorded,
+not deleted; an audit proposes.*
+
+## The TyPeelR leak, in detail
+
+The rule:
+
+    TyPeelR : Value V
+      → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+      → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+          -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+`V` moves from `interior Θ Δ` to
+`interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which `interior-TyPeelR`
+says is that same context with **one new entry at slot 0** — and the entry
+is `unmasked (bind (shiftBy (numBinds Θ) A))`.
+
+Four machine-checked facts pin the verdict:
+
+* `TyPeelR-slot0-nameable` — the new frame **has** the slot, nameably
+  (`∋tv 0`), so `TyPeelR-slot0-typeable` gives `⊢ᵗ ` 0` at V's position.
+* `TyPeelR-V-tight` — **V does not need it.**  The live proof's own
+  `⊢wkV = ⊢rename Ren-wk Inj-suc ⊢V` goes through **verbatim** with the
+  head entry `masked (bind C)`, because `Ren-wk : Ren suc Δ (E ∷ Δ)` holds
+  for *every* entry `E`.  So the `unmasked` is strictly more than V uses.
+* `TyPeelR-node-needs-slot0` — **the instantiation node does.**  With the
+  slot masked, `·[ … , ` 0 ]`'s `⊢·[]` premise `⊢ᵗ ` 0` is refused.  V and
+  the node share one frame, so *no repair is possible without changing the
+  contractum's shape*.
+* `TyPeelR-leak-⊑` / `TyPeelR-leak-¬⊑ᵃ` — the sharpest form.  The tight
+  frame and the live frame differ by exactly one **`le-mu`**, the
+  re-exposure clause, which is precisely the step `_⊑ᵃ_` — the refinement
+  a **term** may travel along — refuses.  TyPeelR moves V along a frame
+  change that is `⊑` but not `⊑ᵃ`.
+
+**The witness** (`§3a`, Examples-style, at `Δᵃ = unmasked (bind ℕ) ∷ []`,
+`Θᵃ = morph [] (lock 0 ∷ [])`).  V's frames are
+
+    Ξold   = masked (bind ℕ) ∷ []
+    Ξnew   = unmasked (bind ℕ) ∷ masked (bind ℕ) ∷ []      (the live rule)
+    Ξtight = masked   (bind ℕ) ∷ masked (bind ℕ) ∷ []      (what V needs)
+
+and `nmᵃ = ƛ X. x` at `X = ` 0` **types at `Ξnew`** (`⊢nmᵃ`) and is
+**refused at `Ξtight`** for the one localized `wf-var` reason (`¬⊢nmᵃ`) —
+Jeremy's tightness test, run on the *frame* instead of the rule.  And
+`wkᴹ1-misses-nmᵃ : ∀ V → wkᴹ 1 V ≢ nmᵃ`: **no moved value can be it.**  So
+the extra nameability the frame grants is nameability that nothing at that
+position can use.  The frame does not say the truth.
+
+Note this is **not** a scope gain for the relation: `Examples` §15b already
+checks that an ill-typed V stays ill-typed, because `wkᴹ 1` sends the fault
+from slot 0 to slot 1.  The leak is about **what the frame authorizes**,
+which is what Jeremy asked for.
+
+TyPeelR is the **only** rule that puts a moved subterm under an *unmasked*
+new binder.  Peel masks its whole bind prefix ((†)); frame-exact Beta masks
+the crossed `Λ` (`interior-Beta-Λ`); TyBeta introduces no new slot at all.
+
+## The candidate fixes
+
+### (a) Wrap V in the new binder's dual — **REFUTED, it loops**
+
+    (wkᴹ 1 V ⟪ morph [] (lock 0 ∷ []) , mkId (`∀ Bᵢ↑) ⟫) ·[ Bᵢ↑ , ` 0 ]
+
+The frame identity would be exact (`morph [] (lock 0 ∷ [])` *is*
+`dual (morph (A ∷ []) [])`, the shape `crossΛ` mints), and the node keeps
+its nameable slot.
+
+**The hazard is structural.**  An identity conversion at a `∀` type is
+*necessarily* a `` `∀ `` conversion: `conv-id` wants a base type and
+`conv-idv` a variable, so `mkId (`∀ B) ≡ `∀ (mkId B)` (`mkId-∀`) is the
+only spelling.  Hence the inserted layer is inert `I-all`
+(`mkId-∀-inert`), hence the wrapped value under `·[ … ]` **is itself a
+TyPeelR redex**.
+
+Machine-checked in `§4`/`§4a` on the prototype relation `_⊢_-→ᵃ_`:
+
+* `fixA-loop-step` — **in general**, a `loopShape` term steps to a
+  `loopShape` term under one more boundary.  Both premises regenerate:
+  `Value (wkᴹ 1 V)` is `value-wkᴹ`, and the conversion typing is `mkId-⊢`
+  from the type's well-formedness alone.  **So the answer to "does TyPeelR
+  require anything of `s` that `mkId` fails?" is NO** — `mkId` is exactly
+  what the wrapper carries, and `mkId-⊢` types it wherever the type is well
+  formed, which the wrapper's own `env` premise guarantees.
+* `T₀ -→ᵃ T₁ -→ᵃ T₂` on the closed instance
+  `((ΛY. 3) ⟪ · , (∀Y. id ℕ) ⟫) [ℕ]`: the `Λ` is still buried under a
+  fresh `morph [] (lock 0 ∷ [])` layer at `T₂`, so `TyBeta` never fires
+  and the term grows by one boundary per step.
+
+Excluding identity conversions from TyPeelR is not an option: the
+classification is by **conversion constructor** and inspects no type
+(`Design.md` §5), and progress needs *some* rule for an `I-all` layer under
+`·[]`.
+
+### (b) Split on the interior — **the Λ half is exact, and proven**
+
+`proof/Canonical.canon-∀` says a closed value at a `∀` type is a `Λ` over
+a value **or** a wrapper with a `∀` conversion, nothing else.  So TyPeelR
+can split (prototype `_⊢_-→ᵇ_`, `§5`):
+
+    TyPeelR-Λ  : Value N
+      → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+      → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+          -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+**Frame verdict: exact up to refinement — TyBeta's own step.**  `N`
+already lives one `abst` binder in (`⊢Λ`), so the new `bind` slot is a slot
+`N` **could already name**: the move is
+`TyPeelR-Λ-refinement : (unmasked abst ∷ interior Θ Δ) ⊑ᵃ interior (morph (A ∷ binds Θ) (changes Θ)) Δ`
+— `la-uu le-ab`, **`⊑ᵃ`-legal**, in flat contrast to the live rule's
+`le-mu`.  And **there is no shift at all**: no `wkᴹ`, no `⊢rename`, no
+`ren-suc-[0]`.
+
+* **Preservation: PROVEN** (`preserve-TyPeelR-Λ`).  It is the live proof
+  with `int` replaced by `⊢retag (TyPeelR-Λ-refinement …) ⊢N`; the frame,
+  conversion and exterior premises are the live proof **verbatim**.  The
+  repair costs nothing.
+* **Determinism: PROVEN** (`detᵇ`).  The two patterns are disjoint (a `Λ`
+  is not a boundary).  Bonus: `TyPeelR-Λ`'s contractum does not mention
+  `Bᵢ`, so it is determined by the redex **without** `conv-src-unique` —
+  the live rule needs that lemma only because its pushed-in annotation is
+  premise-determined.
+* **Progress: PROVEN** (`progressᵇ-·[]`).  `canon-∀` hands the split
+  exactly its two patterns; the premises come off the redex's own
+  derivation (`canon-∀` for the value, `conv-all-inv` for the conversion
+  typing), as `proof/Progress.∀-conv-premise` already does.
+* **Value/ξ overlap: unchanged.**  `(Λ N) ⟪ Θ , `∀ s ⟫` is a value iff
+  `Value N`, and the rule carries `Value N` — the same guard the live rule
+  and `TyBeta` carry.
+
+**But (b) alone is partial.**  In the wrapper case the moved subterm is the
+boundary `W ⟪ Θ′ , `∀ s′ ⟫`, and §3 applies to it verbatim: it too is put
+under the unmasked new bind.  The tower is finite and bottoms out at the
+`Λ`, so the leak recurs at most `height` times — it does not grow, but it
+is still there.
+
+### (b′) The wrapper half, closed the same way — **frame identity exact, machine-checked**
+
+`canon-∀` says the thing being moved in the wrapper case **is a boundary**,
+and a boundary carries its own change list.  So mask the new binder in the
+moved boundary's **own** frame — no second wrapper (which loops), nothing
+resolved (which is (c)'s price):
+
+    addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
+
+appended at the **tail**, where `applyChanges` runs it **first** — exactly
+the position the scope move `_⋉_` puts its travelling changes in.  Then
+(`§5b`):
+
+    interior-addLock0 :
+      interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
+        ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
+
+i.e. the moved boundary's frame is its **birth frame** with the new binder
+inserted below the bind prefix and **masked** — the shape (†) gives Peel
+and `interior-Beta-Λ` gives Beta.  And it crosses by `⊢rename` **alone**:
+
+    Ren-addLock0 : Ren (extN (numBinds Θ′) suc) (interior Θ′ Δ)
+                       (pushBinds (map ⇑ᵗ (binds Θ′)) (E ∷ scope Θ′ Δ))
+
+which is exactly the renaming `wkᴹ 1` performs on a boundary
+(`renᴹ`'s wrapper clause).  The appended `lock 0` is legal where it acts
+because slot 0 of the new frame is nameable (`addLock0-sw-l`) — *the
+leak's own slot is what authorizes the lock that closes it*.
+
+What remains to land (b′) as a rule: `Δ ⊢ᵐ addLock0 (renᴮ suc Θ′)` (reps by
+`⊢ʳ-ren`, changes by `⊢ˢ-ren` + `addLock0-sw-l` + `⊢ˢ-++`) and the moved
+boundary's conversion re-typed at `convCtx (addLock0 (renᴮ suc Θ′)) …`,
+where the appended lock is **lifted** (`applyUnlocks` skips locks), so
+`conv-ren` suffices.  Neither is new machinery: both are moves
+`⊢rename`'s own (env) case already makes.
+
+### (c) The resolve variant — exact for V, but it spells a representation inside
+
+`Design.md` §9 / `Examples` §13c, options (v)/(vi) — already weighed and
+recorded when the polarity index still stood:
+
+    (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]  →  (V ·[ Bᵢ , A ]) ⟪ Θ , conceal/reveal … ⟫
+
+No new bind, no shift, so **V's frame is unchanged: exact**.  It **types**
+(`⊢Cb`, `⊢CbH` in `Examples` §13c are machine-checked).  The price is the
+one §13c already names: it **resolves the binder**, writing the exterior's
+representation `A` into the interior, which the interior may not see.  That
+trades a *scope* leak for a *knowledge* leak — and knowledge is the thing
+the binder-syntactic design (`Design.md` §3, Q1) exists to keep out.  The
+grounded-invariants law says representations live only at their binder;
+(c) copies one inward.  **Worse than the leak it fixes.**
+
+## Recommendation
+
+1. **Land (b) — the `Λ` split.**  It is written and proven in
+   `proof/ShiftAudit.agda` (`TyPeelR-Λ`, `preserve-TyPeelR-Λ`, `detᵇ`,
+   `progressᵇ-·[]`), it costs nothing (the live preservation proof minus
+   the `⊢rename`), it removes the shift entirely from the case where the
+   instantiation actually happens, and it makes TyPeelR's `Λ` case *the
+   same step as TyBeta* — which is what §6.4's own commentary says it
+   morally is ("TyPeelR's reveal case really is TyBeta's mint, one `∀`
+   inside").
+2. **Then land (b′) — the wrapper split.**  The frame identity and the
+   crossing renaming are machine-checked (`§5b`); what is left is the `⊢ᵐ`
+   for `addLock0` and one `conv-ren`.  With (b) and (b′) together,
+   **every rule that moves a subterm masks what it introduces**, and the
+   §7 table has no exceptions.
+3. **Do not take (a)** — machine-refuted, it loops — and **do not take
+   (c)** — it converts a scope leak into a knowledge leak, which the
+   design forbids.
+4. Optionally delete `shiftᵐ`/`canon-shiftᵐ` (dead after #199).
+
+Until (b)/(b′) land, `Design.md` §7 carries the **TyPeelR (V's frame)** row
+as the open item.

--- a/SystemF/agda/strong/notes/ShiftAudit.md
+++ b/SystemF/agda/strong/notes/ShiftAudit.md
@@ -30,7 +30,7 @@ The frame must *say the truth* about what the subterm may name.
 |------|-------------|--------------|-------------|---------|
 | **Peel** | `wkᴹ (numBinds Θ) W` under `dual Θ` | `Δ` | `map maskEnt (pushBinds (binds Θ) []) ++ Δ` — (†) `proof/PeelDual.interior-dual` | **exact**.  Every new slot is `masked` (`Peel-slot0-locked`), and `wkᴹ (numBinds Θ)` lands past exactly them.  Criterion 1 alone. |
 | **Peel** (`V`) | nothing | `interior Θ Δ` | `interior Θ Δ` | **exact** — identical context, no shift. |
-| **TyPeelR** (`V`) | `wkᴹ 1 V` | `interior Θ Δ` | `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ` — `interior-TyPeelR` | ****LEAK****.  The new slot 0 is offered **unmasked**; `V` neither had it nor uses it. |
+| **TyPeelR** (`V`) | `wkᴹ 1 V` | `interior Θ Δ` | `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ` — `interior-TyPeelR` | ****LEAK****.  The new slot 0 is offered **unmasked**; `V` neither had it nor uses it.  *Repaired on the probe branch — (b)+(b′) below, `proof/ShiftAudit` §5c.* |
 | **TyBeta** | nothing (`N` stays) | `unmasked abst ∷ Δ` (`⊢Λ`) | `unmasked (bind A) ∷ Δ` — `interior-TyBeta` | **exact up to refinement**.  `la-uu le-ab` at a slot `N` could already name: criterion 2, `⊑ᵃ`-legal. |
 | **TyBeta** (the type `B`) | nothing | `unmasked abst ∷ Δ` | `convCtx (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ` | **exact up to refinement** — same step. |
 | **Beta**, no binder crossed | `substᵐ` | `Δ` | `Δ` | **exact**.  (The one recorded exception is **erasure** — a dropped argument crosses nowhere; `Examples` §15d.) |
@@ -183,13 +183,14 @@ already lives one `abst` binder in (`⊢Λ`), so the new `bind` slot is a slot
   `Value N`, and the rule carries `Value N` — the same guard the live rule
   and `TyBeta` carry.
 
-**But (b) alone is partial.**  In the wrapper case the moved subterm is the
-boundary `W ⟪ Θ′ , `∀ s′ ⟫`, and §3 applies to it verbatim: it too is put
-under the unmasked new bind.  The tower is finite and bottoms out at the
-`Λ`, so the leak recurs at most `height` times — it does not grow, but it
-is still there.
+**(b) alone would be partial.**  In the wrapper case the moved subterm is
+the boundary `W ⟪ Θ′ , `∀ s′ ⟫`, and §3 applies to it verbatim: it too is
+put under the unmasked new bind.  The tower is finite and bottoms out at
+the `Λ`, so the leak would recur at most `height` times — it would not
+grow, but it would still be there.  (b′) below closes that half, so the
+pair is a complete repair.
 
-### (b′) The wrapper half, closed the same way — **frame identity exact, machine-checked**
+### (b′) The wrapper half, closed the same way — **PROVEN, and it WORKS**
 
 `canon-∀` says the thing being moved in the wrapper case **is a boundary**,
 and a boundary carries its own change list.  So mask the new binder in the
@@ -218,12 +219,155 @@ which is exactly the renaming `wkᴹ 1` performs on a boundary
 because slot 0 of the new frame is nameable (`addLock0-sw-l`) — *the
 leak's own slot is what authorizes the lock that closes it*.
 
-What remains to land (b′) as a rule: `Δ ⊢ᵐ addLock0 (renᴮ suc Θ′)` (reps by
-`⊢ʳ-ren`, changes by `⊢ˢ-ren` + `addLock0-sw-l` + `⊢ˢ-++`) and the moved
-boundary's conversion re-typed at `convCtx (addLock0 (renᴮ suc Θ′)) …`,
-where the appended lock is **lifted** (`applyUnlocks` skips locks), so
-`conv-ren` suffices.  Neither is new machinery: both are moves
-`⊢rename`'s own (env) case already makes.
+#### The rule, as it type-checked (`proof/ShiftAudit` §5, `_⊢_-→ᵇ_`)
+
+    TyPeelR-⟪⟫ : Value W
+      → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+      → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+          -→ᵇ ((renᴹ (extN (numBinds Θ′) suc) W
+                  ⟪ addLock0 (renᴮ suc Θ′)
+                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                 ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+**No extra premise.**  `Value W` and the conversion typing are the live
+rule's own two premises, and `Value W` is what `canon-∀` hands progress.
+
+**It is `wkᴹ 1` plus one lock, on the nose.**  With `addLock0ᵛ` the
+change-list append lifted to a term (`addLock0ᵛ (M ⟪ Θ , c ⟫) = M ⟪ addLock0 Θ , c ⟫`),
+
+    TyPeelR-⟪⟫-wkᴹ : addLock0ᵛ (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫))
+                       ≡ renᴹ (extN (numBinds Θ′) suc) W
+                           ⟪ addLock0 (renᴮ suc Θ′)
+                           , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫
+
+is `refl`, and
+
+    TyPeelR-⟪⟫-outer-unchanged
+
+says the whole contractum is the **live** contractum with `addLock0ᵛ`
+applied to the moved value: same outer frame `morph (A ∷ binds Θ) (changes Θ)`,
+same minted conversion `instReveal 0 s`, same pushed-in annotation
+`renameᵗ (extᵗ suc) Bᵢ`, same type argument `` ` 0 ``.
+
+#### The rule on an example
+
+The tightness redex of §5c₄ (`Δᵛ = X := ℕ`; the outer frame locks `X`, the
+inner frame is trivial), machine-rendered:
+
+    showTmIn 1 Rᵛ
+      = (((λx:ℕ. (ΛY. 3) [X]) ⟪ (∀Y. id ℕ) ⟫) ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
+
+    showTmIn 1 Cᵛ-live                              -- the LIVE rule
+      = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
+
+    showTmIn 1 Cᵛ                                   -- fix (b′)
+      = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
+
+The entire repair is the `↓Y` on the moved boundary, and it is the
+difference between a frame that lies and one that does not:
+
+    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-live
+      =  Y := ℕ , ⌷[X := ℕ]           ← the LEAK: Y is offered
+    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-new
+      =  ⌷[Y := ℕ] , ⌷[X := ℕ]        ← (b′): Y is masked
+
+`⊢prb0-live` types a value that **names** the new slot `Y` at the live
+frame; `¬⊢prb0-new` refuses the same value at (b′)'s.  That is §3a's
+`nmᵃ` test, run at the position the moved boundary's interior actually
+occupies.  And the §15b test itself passes: `¬⊢Rᵛ` and `¬⊢Cᵛ` refuse the
+redex and the contractum for the **same** localized reason (`wf-var` at a
+masked slot), one index apart.
+
+#### What is proven
+
+| lemma | claim |
+|-------|-------|
+| `TyPeelR-⟪⟫-wkᴹ` | the contractum's inner value is `addLock0ᵛ (wkᴹ 1 …)`, `refl` |
+| `applyUnlocks-++`, `unlockedScope-addLock0`, `convCtx-addLock0` | the appended lock is **lifted**: the conversion context is the plainly renamed one |
+| `⊢addLock0-cross` | **the crossing lemma** — a boundary crosses one new bind slot, masking it in its own frame.  Reps by `⊢ʳ-ren`, changes by `⊢ˢ-++` (`⊢ˢ-ren` over the frame the lock leaves, `sw-l` for the lock), interior by `⊢rename` at `Ren-addLock0` **alone**, conversion by `conv-ren` at `ren-convCtx`.  The (b′) analogue of `⊢crossΛ` |
+| `preserve-TyPeelR-⟪⟫` | **preservation** — the live proof with `⊢wkV = ⊢rename Ren-wk Inj-suc` replaced by `⊢addLock0-cross`; the outer `env` is verbatim |
+| `preserveᵇ` | preservation for the whole prototype, both clauses and `ξᵇ-⟪⟫` |
+| `detᵇ` | **determinism** over all three clauses.  The two `TyPeelR` patterns are disjoint (a `Λ` is not a boundary); the wrapper case needs `conv-src-unique`, exactly as the live rule does |
+| `progressᵇ-·[]` | **progress** — `canon-∀` hands the split exactly its two patterns, so the pair is TOTAL over canonical `∀`-values: the live rule is **replaced**, not supplemented |
+| `TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-birth` | **frame exactness** — the moved boundary's interior is its birth frame `pushBinds (binds Θ′) (scope Θ′ (interior Θ Δ))` with the reps lifted (`map ⇑ᵗ`) and the new slot inserted **masked** below the bind prefix |
+| `TyPeelR-⟪⟫-slot-locked` | the new slot is **unnameable** there (`∋lk-¬∋tv`, `pushBinds-∋lk0`) |
+| `TyPeelR-⟪⟫-outer-unchanged` | the outer boundary is the live rule's, untouched |
+| `towerHeight`, `towerHeight-renᴹ`, `TyPeelR-⟪⟫-height` | **termination** (below) |
+| `canon-∀-height`, `progressᵇ-Λ-at-0` | at tower height 0 the interior is a `Λ`, so `TyPeelR-Λ` fires |
+| `U₀ -→ᵇ U₁ -→ᵇ U₂`, `⊢U₀`/`⊢U₁`/`⊢U₂` | the closed two-deep run, every state typed |
+
+#### Termination — it is not (a)'s regress
+
+The contractum's inner application
+
+    (… ⟪ addLock0 … , `∀ s″ ⟫) ·[ … , ` 0 ]
+
+*is* again a `-→ᵇ` redex.  The measure that separates it from fix (a) is
+the `∀`-value's **tower height** — the number of nested boundaries above
+the `Λ`:
+
+    towerHeight (M ⟪ Θ , c ⟫) = suc (towerHeight M)      towerHeight _ = 0
+
+`towerHeight-renᴹ` says the shift does not change it (both candidates
+shift), and then
+
+    TyPeelR-⟪⟫-height : towerHeight (contractum's inner ∀-value)
+                          ≡ towerHeight (redex's ∀-value) ∸ 1
+    fixA-height-stalls : towerHeight (fix (a)'s inner ∀-value)
+                          ≡ towerHeight (redex's ∀-value)
+
+(b′) **consumes** a boundary that was already there; (a) **mints** a new
+one, so its measure stalls — and §4a's `T₀ -→ᵃ T₁ -→ᵃ T₂` is that stall,
+twice.  So a redex of tower height `h` takes `h − 1` `TyPeelR-⟪⟫` steps
+and then exactly one `TyPeelR-Λ` step (`canon-∀-height`: a `∀`-value of
+height 0 is a `Λ`, `canon-∀` has no third shape), and `TyPeelR-Λ` neither
+shifts nor locks anything.
+
+#### The closed run (§5c₃)
+
+The outer frame binds `X := ℕ` and the inner frame locks it, so the moved
+boundary really does carry a change list for the appended lock to join:
+
+    Θᵈ  = morph (`ℕ ∷ []) []        the OUTER frame
+    Θᵈ′ = morph [] (lock 0 ∷ [])    the INNER frame
+
+Machine-rendered:
+
+    showTmIn 0 U₀
+      = (((ΛY. 3) ⟪ ↓X , (∀Y. id ℕ) ⟫) ⟪ ↑X:=ℕ , (∀Y. id ℕ) ⟫) [ℕ]
+                      │ TyPeelR-⟪⟫          tower height 2 → 1
+                      ▼
+    showTmIn 0 U₁
+      = (((ΛZ. 3) ⟪ ↓X , ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
+                      │ ξᵇ-⟪⟫ (TyPeelR-Λ)   tower exhausted
+                      ▼
+    showTmIn 0 U₂
+      = ((3 ⟪ ↑Z:=Y , ↓X , ↓Y , id ℕ ⟫) ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
+
+Read the moved boundary's change list across step 1: `↓X` becomes
+`↓X , ↓Y` — the **shifted** original lock and the **new** lock, appended
+at the tail.  Nothing else about the boundary changes and no wrapper
+appears.  The frames:
+
+    showTCtxAt 9 0 (λ _ → "X") Ξᵈ₁                    =  ⌷[X := ℕ]
+    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵈ₃
+      =  ⌷[Y := ℕ] , ⌷[X := ℕ]
+
+`Ξᵈ₁` is `W`'s birth frame and `Ξᵈ₃` its frame in the contractum: the same
+frame with the new binder `Y` inserted **masked**.  Exact.
+
+#### Verdict
+
+**(b) + (b′) WORKS.**  Preservation, determinism and progress all hold for
+the pair; the two clauses are total over canonical `∀`-values, so the live
+`TyPeelR` is *replaced*, not supplemented; both new frames are exact (the
+`Λ` case up to `TyBeta`'s own refinement, the wrapper case up to the index
+shift alone); the descent terminates on a strictly decreasing measure that
+fix (a) leaves fixed; and tightness holds for both clauses.  No premise
+had to be added, and nothing in `Reduction.agda`, `Preservation.agda`,
+`Progress.agda` or `TypeSafety.agda` was touched — the probe lives
+entirely in `proof/ShiftAudit.agda` §5/§5b/§5c.
 
 ### (c) The resolve variant — exact for V, but it spells a representation inside
 
@@ -251,9 +395,11 @@ grounded-invariants law says representations live only at their binder;
    same step as TyBeta* — which is what §6.4's own commentary says it
    morally is ("TyPeelR's reveal case really is TyBeta's mint, one `∀`
    inside").
-2. **Then land (b′) — the wrapper split.**  The frame identity and the
-   crossing renaming are machine-checked (`§5b`); what is left is the `⊢ᵐ`
-   for `addLock0` and one `conv-ren`.  With (b) and (b′) together,
+2. **Then land (b′) — the wrapper split.  It is now PROVEN too** (`§5c`):
+   `preserve-TyPeelR-⟪⟫`, `detᵇ`, `progressᵇ-·[]`, the frame identity
+   (`TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-slot-locked`), the terminating measure
+   (`TyPeelR-⟪⟫-height` against `fixA-height-stalls`) and a closed
+   two-deep run with every state typed.  With (b) and (b′) together,
    **every rule that moves a subterm masks what it introduces**, and the
    §7 table has no exceptions.
 3. **Do not take (a)** — machine-refuted, it loops — and **do not take
@@ -261,5 +407,6 @@ grounded-invariants law says representations live only at their binder;
    design forbids.
 4. Optionally delete `shiftᵐ`/`canon-shiftᵐ` (dead after #199).
 
-Until (b)/(b′) land, `Design.md` §7 carries the **TyPeelR (V's frame)** row
-as the open item.
+Until (b)/(b′) land in `Reduction.agda`, `Design.md` §7 carries the
+**TyPeelR (V's frame)** row as the open item — the repair is proven on the
+probe relation `_⊢_-→ᵇ_`, not installed in the live rules.

--- a/SystemF/agda/strong/notes/ShiftAudit.md
+++ b/SystemF/agda/strong/notes/ShiftAudit.md
@@ -5,10 +5,17 @@ System F!"  (PR #199: `Beta` now wraps every value crossing a `Λ` in that
 binder's dual, `crossΛ`.)  Request: *audit all places that shift a term to
 see if we have forgotten to mask type variables in other places.*
 
+**VERDICT: one leak, and it is INSTALLED-FIXED.**  The audit found exactly
+one — the single `TyPeelR` moved its value under a **new unmasked bind
+slot** — and the repair `(b)+(b′)` is now in the live calculus: the rule
+is the two clauses `TyPeelR-Λ` and `TyPeelR-⟪⟫` (`Reduction.agda`, and
+`Design.md` §6.4).  **Every rule that moves a subterm masks what it
+introduces, and the table below has no exceptions.**
+
 Machine-checked companion: `proof/ShiftAudit.agda` (in `All.agda`; the
 gate `make -C strong check` is green).  The frame-identity table it feeds
-is `Design.md` §7; the per-rule tightness tests are `Examples` §15 and
-`proof/DualTightness`.
+is `Design.md` §7; the per-rule tightness tests are `Examples` §15 —
+§15b for the two `TyPeelR` clauses — and `proof/DualTightness`.
 
 ## The criterion
 
@@ -30,7 +37,9 @@ The frame must *say the truth* about what the subterm may name.
 |------|-------------|--------------|-------------|---------|
 | **Peel** | `wkᴹ (numBinds Θ) W` under `dual Θ` | `Δ` | `map maskEnt (pushBinds (binds Θ) []) ++ Δ` — (†) `proof/PeelDual.interior-dual` | **exact**.  Every new slot is `masked` (`Peel-slot0-locked`), and `wkᴹ (numBinds Θ)` lands past exactly them.  Criterion 1 alone. |
 | **Peel** (`V`) | nothing | `interior Θ Δ` | `interior Θ Δ` | **exact** — identical context, no shift. |
-| **TyPeelR** (`V`) | `wkᴹ 1 V` | `interior Θ Δ` | `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ` — `interior-TyPeelR` | ****LEAK****.  The new slot 0 is offered **unmasked**; `V` neither had it nor uses it.  *Repaired on the probe branch — (b)+(b′) below, `proof/ShiftAudit` §5c.* |
+| **TyPeelR** (`V`), the SINGLE rule — *replaced* | `wkᴹ 1 V` | `interior Θ Δ` | `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ` — `interior-TyPeelR` | ****LEAK****.  The new slot 0 was offered **unmasked**; `V` neither had it nor uses it.  This is the rule the split replaced; the record of the leak is `proof/ShiftAudit` §3/§3a. |
+| **TyPeelR-Λ** (`N`) | nothing | `unmasked abst ∷ interior Θ Δ` | `interior (morph (A ∷ binds Θ) (changes Θ)) Δ` — `interior-TyPeelR` | **exact up to refinement**.  The `Λ`'s abst slot BECOMES the boundary's bind slot: `la-uu le-ab` at a slot `N` could already name, criterion 2, `⊑ᵃ`-legal (`TyPeelR-Λ-refinement`).  **No shift at all** — no `wkᴹ`, no `⊢rename`. |
+| **TyPeelR-⟪⟫** (the moved boundary) | `wkᴹ 1`, plus `lock 0` appended to its own change list | `interior Θ′ (interior Θ Δ)` | `pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind (shiftBy (numBinds Θ) A)) ∷ scope Θ′ (interior Θ Δ))` — `TyPeelR-⟪⟫-frame`, from `strong.TermSubst.interior-addLock0-cross` | **exact**.  The moved boundary's BIRTH frame with the new binder inserted **masked** below its bind prefix — the shape (†) gives Peel and `interior-Beta-Λ` gives Beta.  Criterion 1 alone; the new slot is unnameable there (`TyPeelR-⟪⟫-slot-locked`), and it crosses by `⊢rename` at `Ren-addLock0` **alone**. |
 | **TyBeta** | nothing (`N` stays) | `unmasked abst ∷ Δ` (`⊢Λ`) | `unmasked (bind A) ∷ Δ` — `interior-TyBeta` | **exact up to refinement**.  `la-uu le-ab` at a slot `N` could already name: criterion 2, `⊑ᵃ`-legal. |
 | **TyBeta** (the type `B`) | nothing | `unmasked abst ∷ Δ` | `convCtx (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ` | **exact up to refinement** — same step. |
 | **Beta**, no binder crossed | `substᵐ` | `Δ` | `Δ` | **exact**.  (The one recorded exception is **erasure** — a dropped argument crosses nowhere; `Examples` §15d.) |
@@ -42,10 +51,11 @@ The frame must *say the truth* about what the subterm may name.
 | **ξ-Λ / ξ-⟪⟫ / ξ-·-l / ξ-·-r / ξ-·[]** | nothing | — | — | **exact**.  Each reduces a subterm *in place*, at the very context the corresponding typing rule reads it on: `unmasked abst ∷ Δ` is `⊢Λ`'s premise context, `interior Θ Δ` is `env`'s.  Both `refl`. |
 
 Not rules, and therefore not sites: `⊢rename`, `⊢retag`, `Ren-wk`,
-`renᴹ`, `renⁿ`, `⊢renⁿ`, `⊢weakenⁿ`, `canon-renᴹ`/`canon-renⁿ`.  These are
-transports the cases above are *proved with*; each one's `Ren`/`⊑ᵃ`
-argument is supplied at the site.  `Eval` constructs no terms (`step` is
-`progress`), and `Show` is a printer.
+`Ren-addLock0`, `renᴹ`, `renⁿ`, `⊢renⁿ`, `⊢weakenⁿ`,
+`canon-renᴹ`/`canon-renⁿ`.  These are transports the cases above are
+*proved with*; each one's `Ren`/`⊑ᵃ` argument is supplied at the site.
+`Eval` constructs no terms (`step` is `progress`), and `Show` is a
+printer.
 
 **Dead machinery.**  `shiftᵐ = renⁿ suc` (`TermSubst` §5) and
 `canon-shiftᵐ` (`proof/Canonicity`) have **no consumers** after #199:
@@ -55,9 +65,9 @@ term-variable shift is never applied to a term.  `renⁿ` itself is live —
 `⊢renⁿ` at the identity renaming is what proves `⊢weakenⁿ`.  *Recorded,
 not deleted; an audit proposes.*
 
-## The TyPeelR leak, in detail
+## The TyPeelR leak, in detail — what was there before the split
 
-The rule:
+The rule, as it stood:
 
     TyPeelR : Value V
       → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
@@ -65,51 +75,53 @@ The rule:
           -→ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
-`V` moves from `interior Θ Δ` to
+`V` moved from `interior Θ Δ` to
 `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which `interior-TyPeelR`
 says is that same context with **one new entry at slot 0** — and the entry
-is `unmasked (bind (shiftBy (numBinds Θ) A))`.
+was `unmasked (bind (shiftBy (numBinds Θ) A))`.
 
-Four machine-checked facts pin the verdict:
+Four machine-checked facts pinned the verdict, and all four still stand as
+statements about frames:
 
 * `TyPeelR-slot0-nameable` — the new frame **has** the slot, nameably
   (`∋tv 0`), so `TyPeelR-slot0-typeable` gives `⊢ᵗ ` 0` at V's position.
-* `TyPeelR-V-tight` — **V does not need it.**  The live proof's own
+* `TyPeelR-V-tight` — **V did not need it.**  The old proof's own
   `⊢wkV = ⊢rename Ren-wk Inj-suc ⊢V` goes through **verbatim** with the
   head entry `masked (bind C)`, because `Ren-wk : Ren suc Δ (E ∷ Δ)` holds
-  for *every* entry `E`.  So the `unmasked` is strictly more than V uses.
-* `TyPeelR-node-needs-slot0` — **the instantiation node does.**  With the
+  for *every* entry `E`.  So the `unmasked` was strictly more than V uses.
+* `TyPeelR-node-needs-slot0` — **the instantiation node did.**  With the
   slot masked, `·[ … , ` 0 ]`'s `⊢·[]` premise `⊢ᵗ ` 0` is refused.  V and
-  the node share one frame, so *no repair is possible without changing the
-  contractum's shape*.
+  the node shared one frame, so *no repair was possible without changing
+  the contractum's shape* — which is why the fix is a split and not a
+  side condition.
 * `TyPeelR-leak-⊑` / `TyPeelR-leak-¬⊑ᵃ` — the sharpest form.  The tight
-  frame and the live frame differ by exactly one **`le-mu`**, the
+  frame and the offered frame differ by exactly one **`le-mu`**, the
   re-exposure clause, which is precisely the step `_⊑ᵃ_` — the refinement
-  a **term** may travel along — refuses.  TyPeelR moves V along a frame
-  change that is `⊑` but not `⊑ᵃ`.
+  a **term** may travel along — refuses.  The single rule moved V along a
+  frame change that is `⊑` but not `⊑ᵃ`.
 
 **The witness** (`§3a`, Examples-style, at `Δᵃ = unmasked (bind ℕ) ∷ []`,
-`Θᵃ = morph [] (lock 0 ∷ [])`).  V's frames are
+`Θᵃ = morph [] (lock 0 ∷ [])`).  V's frames were
 
     Ξold   = masked (bind ℕ) ∷ []
-    Ξnew   = unmasked (bind ℕ) ∷ masked (bind ℕ) ∷ []      (the live rule)
+    Ξnew   = unmasked (bind ℕ) ∷ masked (bind ℕ) ∷ []      (the single rule)
     Ξtight = masked   (bind ℕ) ∷ masked (bind ℕ) ∷ []      (what V needs)
 
 and `nmᵃ = ƛ X. x` at `X = ` 0` **types at `Ξnew`** (`⊢nmᵃ`) and is
 **refused at `Ξtight`** for the one localized `wf-var` reason (`¬⊢nmᵃ`) —
 Jeremy's tightness test, run on the *frame* instead of the rule.  And
-`wkᴹ1-misses-nmᵃ : ∀ V → wkᴹ 1 V ≢ nmᵃ`: **no moved value can be it.**  So
-the extra nameability the frame grants is nameability that nothing at that
-position can use.  The frame does not say the truth.
+`wkᴹ1-misses-nmᵃ : ∀ V → wkᴹ 1 V ≢ nmᵃ`: **no moved value could be it.**
+So the extra nameability the frame granted was nameability that nothing at
+that position could use.  The frame did not say the truth.
 
-Note this is **not** a scope gain for the relation: `Examples` §15b already
-checks that an ill-typed V stays ill-typed, because `wkᴹ 1` sends the fault
-from slot 0 to slot 1.  The leak is about **what the frame authorizes**,
-which is what Jeremy asked for.
+Note this was **not** a scope gain for the relation: an ill-typed V stayed
+ill-typed, because `wkᴹ 1` sent the fault from slot 0 to slot 1.  The leak
+was about **what the frame authorizes**, which is what Jeremy asked for.
 
-TyPeelR is the **only** rule that puts a moved subterm under an *unmasked*
-new binder.  Peel masks its whole bind prefix ((†)); frame-exact Beta masks
-the crossed `Λ` (`interior-Beta-Λ`); TyBeta introduces no new slot at all.
+The single `TyPeelR` was the **only** rule that put a moved subterm under
+an *unmasked* new binder.  Peel masks its whole bind prefix ((†));
+frame-exact Beta masks the crossed `Λ` (`interior-Beta-Λ`); TyBeta
+introduces no new slot at all.
 
 ## The candidate fixes
 
@@ -128,7 +140,8 @@ only spelling.  Hence the inserted layer is inert `I-all`
 (`mkId-∀-inert`), hence the wrapped value under `·[ … ]` **is itself a
 TyPeelR redex**.
 
-Machine-checked in `§4`/`§4a` on the prototype relation `_⊢_-→ᵃ_`:
+Machine-checked in `§4`/`§4a` on the prototype relation `_⊢_-→ᵃ_`, which
+is **kept** in `proof/ShiftAudit.agda` as a refutation record:
 
 * `fixA-loop-step` — **in general**, a `loopShape` term steps to a
   `loopShape` term under one more boundary.  Both premises regenerate:
@@ -147,50 +160,49 @@ classification is by **conversion constructor** and inspects no type
 (`Design.md` §5), and progress needs *some* rule for an `I-all` layer under
 `·[]`.
 
-### (b) Split on the interior — **the Λ half is exact, and proven**
+### (b) Split on the interior — **the Λ half, INSTALLED as `TyPeelR-Λ`**
 
 `proof/Canonical.canon-∀` says a closed value at a `∀` type is a `Λ` over
 a value **or** a wrapper with a `∀` conversion, nothing else.  So TyPeelR
-can split (prototype `_⊢_-→ᵇ_`, `§5`):
+splits, and the `Λ` half is now the live rule:
 
     TyPeelR-Λ  : Value N
       → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
       → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-          -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+          -→ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
 **Frame verdict: exact up to refinement — TyBeta's own step.**  `N`
 already lives one `abst` binder in (`⊢Λ`), so the new `bind` slot is a slot
 `N` **could already name**: the move is
 `TyPeelR-Λ-refinement : (unmasked abst ∷ interior Θ Δ) ⊑ᵃ interior (morph (A ∷ binds Θ) (changes Θ)) Δ`
-— `la-uu le-ab`, **`⊑ᵃ`-legal**, in flat contrast to the live rule's
+— `la-uu le-ab`, **`⊑ᵃ`-legal**, in flat contrast to the old rule's
 `le-mu`.  And **there is no shift at all**: no `wkᴹ`, no `⊢rename`, no
 `ren-suc-[0]`.
 
-* **Preservation: PROVEN** (`preserve-TyPeelR-Λ`).  It is the live proof
-  with `int` replaced by `⊢retag (TyPeelR-Λ-refinement …) ⊢N`; the frame,
-  conversion and exterior premises are the live proof **verbatim**.  The
+* **Preservation** (`proof/Preserve.preserve-TyPeelR-Λ`).  It is the old
+  proof with `int` replaced by `⊢retag (refine …) ⊢N`; the frame,
+  conversion and exterior premises are the old proof **verbatim**.  The
   repair costs nothing.
-* **Determinism: PROVEN** (`detᵇ`).  The two patterns are disjoint (a `Λ`
-  is not a boundary).  Bonus: `TyPeelR-Λ`'s contractum does not mention
-  `Bᵢ`, so it is determined by the redex **without** `conv-src-unique` —
-  the live rule needs that lemma only because its pushed-in annotation is
-  premise-determined.
-* **Progress: PROVEN** (`progressᵇ-·[]`).  `canon-∀` hands the split
-  exactly its two patterns; the premises come off the redex's own
+* **Determinism** (`Reduction.det`).  The two clauses' patterns are
+  disjoint (a `Λ` is not a boundary).  Bonus: `TyPeelR-Λ`'s contractum
+  does not mention `Bᵢ`, so it is determined by the redex **without**
+  `conv-src-unique`.
+* **Progress** (`proof/Progress.progress-·[]-∀conv`).  `canon-∀` hands the
+  split exactly its two patterns; the premises come off the redex's own
   derivation (`canon-∀` for the value, `conv-all-inv` for the conversion
-  typing), as `proof/Progress.∀-conv-premise` already does.
+  typing), in one inversion.
 * **Value/ξ overlap: unchanged.**  `(Λ N) ⟪ Θ , `∀ s ⟫` is a value iff
-  `Value N`, and the rule carries `Value N` — the same guard the live rule
-  and `TyBeta` carry.
+  `Value N`, and the rule carries `Value N` — the same guard `TyBeta`
+  carries.
 
 **(b) alone would be partial.**  In the wrapper case the moved subterm is
-the boundary `W ⟪ Θ′ , `∀ s′ ⟫`, and §3 applies to it verbatim: it too is
-put under the unmasked new bind.  The tower is finite and bottoms out at
-the `Λ`, so the leak would recur at most `height` times — it would not
-grow, but it would still be there.  (b′) below closes that half, so the
-pair is a complete repair.
+the boundary `W ⟪ Θ′ , `∀ s′ ⟫`, and the leak above applies to it
+verbatim: it too would be put under the unmasked new bind.  The tower is
+finite and bottoms out at the `Λ`, so the leak would recur at most
+`height` times — it would not grow, but it would still be there.  (b′)
+closes that half, so the pair is a complete repair.
 
-### (b′) The wrapper half, closed the same way — **PROVEN, and it WORKS**
+### (b′) The wrapper half, closed the same way — **INSTALLED as `TyPeelR-⟪⟫`**
 
 `canon-∀` says the thing being moved in the wrapper case **is a boundary**,
 and a boundary carries its own change list.  So mask the new binder in the
@@ -200,12 +212,15 @@ resolved (which is (c)'s price):
     addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
 
 appended at the **tail**, where `applyChanges` runs it **first** — exactly
-the position the scope move `_⋉_` puts its travelling changes in.  Then
-(`§5b`):
+the position the scope move `_⋉_` puts its travelling changes in.  It
+lives in `strong.CtxMorph` §5, with its induced-context identities:
+`interior (addLock0 Θ) Δ ≡ interior Θ (mask 0 Δ)` and
+`convCtx (addLock0 Θ) Δ ≡ convCtx Θ Δ` (the lock is **lifted** on the
+conversion context, which is what makes the repair free).  At the shift
+the rule performs (`strong.TermSubst.interior-addLock0-cross`):
 
-    interior-addLock0 :
-      interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
-        ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
+    interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
+      ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
 
 i.e. the moved boundary's frame is its **birth frame** with the new binder
 inserted below the bind prefix and **masked** — the shape (†) gives Peel
@@ -219,18 +234,18 @@ which is exactly the renaming `wkᴹ 1` performs on a boundary
 because slot 0 of the new frame is nameable (`addLock0-sw-l`) — *the
 leak's own slot is what authorizes the lock that closes it*.
 
-#### The rule, as it type-checked (`proof/ShiftAudit` §5, `_⊢_-→ᵇ_`)
+#### The rule, as installed (`Reduction.agda`)
 
     TyPeelR-⟪⟫ : Value W
       → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
       → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-          -→ᵇ ((renᴹ (extN (numBinds Θ′) suc) W
-                  ⟪ addLock0 (renᴮ suc Θ′)
-                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-                 ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+          -→ ((renᴹ (extN (numBinds Θ′) suc) W
+                 ⟪ addLock0 (renᴮ suc Θ′)
+                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
-**No extra premise.**  `Value W` and the conversion typing are the live
+**No extra premise.**  `Value W` and the conversion typing are the old
 rule's own two premises, and `Value W` is what `canon-∀` hands progress.
 
 **It is `wkᴹ 1` plus one lock, on the nose.**  With `addLock0ᵛ` the
@@ -241,69 +256,66 @@ change-list append lifted to a term (`addLock0ᵛ (M ⟪ Θ , c ⟫) = M ⟪ add
                            ⟪ addLock0 (renᴮ suc Θ′)
                            , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫
 
-is `refl`, and
+is `refl`, and `TyPeelR-⟪⟫-outer-unchanged` says the whole contractum is
+the old contractum with `addLock0ᵛ` applied to the moved value: same outer
+frame `morph (A ∷ binds Θ) (changes Θ)`, same minted conversion
+`instReveal 0 s`, same pushed-in annotation `renameᵗ (extᵗ suc) Bᵢ`, same
+type argument `` ` 0 ``.
 
-    TyPeelR-⟪⟫-outer-unchanged
+#### The two clauses on an example
 
-says the whole contractum is the **live** contractum with `addLock0ᵛ`
-applied to the moved value: same outer frame `morph (A ∷ binds Θ) (changes Θ)`,
-same minted conversion `instReveal 0 s`, same pushed-in annotation
-`renameᵗ (extᵗ suc) Bᵢ`, same type argument `` ` 0 ``.
+The tightness redex of `Examples` §15b (`Δᵇ = X := ℕ`; the outer frame
+locks `X`, the inner frame is trivial), machine-rendered:
 
-#### The rule on an example
-
-The tightness redex of §5c₄ (`Δᵛ = X := ℕ`; the outer frame locks `X`, the
-inner frame is trivial), machine-rendered:
-
-    showTmIn 1 Rᵛ
+    showTmIn 1 Rᵇ′
       = (((λx:ℕ. (ΛY. 3) [X]) ⟪ (∀Y. id ℕ) ⟫) ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
 
-    showTmIn 1 Cᵛ-live                              -- the LIVE rule
-      = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
-
-    showTmIn 1 Cᵛ                                   -- fix (b′)
+    showTmIn 1 Cᵇ′                                  -- TyPeelR-⟪⟫
       = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
 
-The entire repair is the `↓Y` on the moved boundary, and it is the
-difference between a frame that lies and one that does not:
+Against the old rule's contractum at that redex the entire repair is the
+`↓Y` on the moved boundary, and it is the difference between a frame that
+lies and one that does not:
 
-    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-live
+    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵇ-single
       =  Y := ℕ , ⌷[X := ℕ]           ← the LEAK: Y is offered
-    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-new
-      =  ⌷[Y := ℕ] , ⌷[X := ℕ]        ← (b′): Y is masked
+    showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵇ-split
+      =  ⌷[Y := ℕ] , ⌷[X := ℕ]        ← TyPeelR-⟪⟫: Y is masked
 
-`⊢prb0-live` types a value that **names** the new slot `Y` at the live
-frame; `¬⊢prb0-new` refuses the same value at (b′)'s.  That is §3a's
-`nmᵃ` test, run at the position the moved boundary's interior actually
-occupies.  And the §15b test itself passes: `¬⊢Rᵛ` and `¬⊢Cᵛ` refuse the
-redex and the contractum for the **same** localized reason (`wf-var` at a
-masked slot), one index apart.
+`⊢prb0-single` types a value that **names** the new slot `Y` at the old
+frame; `¬⊢prb0-split` refuses the same value at the split's.  That is
+§3a's `nmᵃ` test, run at the position the moved boundary's interior
+actually occupies.  And the tightness test itself passes: `¬⊢Rᵇ′` and
+`¬⊢Cᵇ′` refuse the redex and the contractum for the **same** localized
+reason (`wf-var` at a masked slot), one index apart.  The `Λ` clause gets
+the same treatment at `Rᵇ`/`Cᵇ` (`¬⊢Rᵇ`, `¬⊢Cᵇ`), where no index moves at
+all.
 
-#### What is proven
+#### What is proven, and where it lives
 
-| lemma | claim |
-|-------|-------|
-| `TyPeelR-⟪⟫-wkᴹ` | the contractum's inner value is `addLock0ᵛ (wkᴹ 1 …)`, `refl` |
-| `applyUnlocks-++`, `unlockedScope-addLock0`, `convCtx-addLock0` | the appended lock is **lifted**: the conversion context is the plainly renamed one |
-| `⊢addLock0-cross` | **the crossing lemma** — a boundary crosses one new bind slot, masking it in its own frame.  Reps by `⊢ʳ-ren`, changes by `⊢ˢ-++` (`⊢ˢ-ren` over the frame the lock leaves, `sw-l` for the lock), interior by `⊢rename` at `Ren-addLock0` **alone**, conversion by `conv-ren` at `ren-convCtx`.  The (b′) analogue of `⊢crossΛ` |
-| `preserve-TyPeelR-⟪⟫` | **preservation** — the live proof with `⊢wkV = ⊢rename Ren-wk Inj-suc` replaced by `⊢addLock0-cross`; the outer `env` is verbatim |
-| `preserveᵇ` | preservation for the whole prototype, both clauses and `ξᵇ-⟪⟫` |
-| `detᵇ` | **determinism** over all three clauses.  The two `TyPeelR` patterns are disjoint (a `Λ` is not a boundary); the wrapper case needs `conv-src-unique`, exactly as the live rule does |
-| `progressᵇ-·[]` | **progress** — `canon-∀` hands the split exactly its two patterns, so the pair is TOTAL over canonical `∀`-values: the live rule is **replaced**, not supplemented |
-| `TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-birth` | **frame exactness** — the moved boundary's interior is its birth frame `pushBinds (binds Θ′) (scope Θ′ (interior Θ Δ))` with the reps lifted (`map ⇑ᵗ`) and the new slot inserted **masked** below the bind prefix |
-| `TyPeelR-⟪⟫-slot-locked` | the new slot is **unnameable** there (`∋lk-¬∋tv`, `pushBinds-∋lk0`) |
-| `TyPeelR-⟪⟫-outer-unchanged` | the outer boundary is the live rule's, untouched |
-| `towerHeight`, `towerHeight-renᴹ`, `TyPeelR-⟪⟫-height` | **termination** (below) |
-| `canon-∀-height`, `progressᵇ-Λ-at-0` | at tower height 0 the interior is a `Λ`, so `TyPeelR-Λ` fires |
-| `U₀ -→ᵇ U₁ -→ᵇ U₂`, `⊢U₀`/`⊢U₁`/`⊢U₂` | the closed two-deep run, every state typed |
+| lemma | where | claim |
+|-------|-------|-------|
+| `addLock0`, `interior-addLock0`, `unlockedScope-addLock0`, `convCtx-addLock0`, `numBinds-addLock0` | `strong.CtxMorph` §5 | the appended lock is `mask 0` on the interior and **invisible** on the conversion context |
+| `Ren-addLock0`, `interior-addLock0-cross`, `map-renᶠ-shiftScope` | `strong.TermSubst` | the crossing renaming and the frame identity at the shift the rule performs |
+| `⊢addLock0-cross` | `strong.TermSubst` §6 | **the crossing lemma** — a boundary crosses one new bind slot, masking it in its own frame.  Reps by `⊢ʳ-ren`, changes by `⊢ˢ-++` (`⊢ˢ-ren` over the frame the lock leaves, `sw-l` for the lock), interior by `⊢rename` at `Ren-addLock0` **alone**, conversion by `conv-ren` at `ren-convCtx`.  The (b′) analogue of `⊢crossΛ` |
+| `preserve-TyPeelR-Λ`, `preserve-TyPeelR-⟪⟫` | `proof/Preserve` §3 | **preservation** for the two clauses — the Λ clause is the old proof with `⊢retag` for `int`, the wrapper clause is the old proof with `⊢addLock0-cross` for `⊢wkV`; the outer `env` is verbatim in both |
+| `preservation-TyPeelR-Λ`, `preservation-TyPeelR-⟪⟫` | `strong.Preservation` | the public per-rule statements |
+| `det` | `strong.Reduction` | **determinism** over the whole rule set.  The two `TyPeelR` patterns are disjoint (a `Λ` is not a boundary); the wrapper case needs `conv-src-unique`, exactly as the old rule did, and the Λ case needs nothing |
+| `progress-·[]-∀conv` | `proof/Progress` | **progress** — `canon-∀` hands the split exactly its two patterns, so the pair is TOTAL over canonical `∀`-values: the old rule is **replaced**, not supplemented |
+| `TyPeelR-Λ-refinement`, `TyPeelR-Λ-no-shift`, `TyPeelR-Λ-slot0-old` | `proof/ShiftAudit` §5 | **frame exactness** of the Λ clause: criterion 2 alone, criterion 1 vacuous |
+| `TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-birth`, `TyPeelR-⟪⟫-slot-locked` | `proof/ShiftAudit` §5c₁ | **frame exactness** of the wrapper clause, and that the new slot is **unnameable** there (`∋lk-¬∋tv`, `pushBinds-∋lk0`) |
+| `TyPeelR-⟪⟫-wkᴹ`, `TyPeelR-⟪⟫-outer-unchanged` | `proof/ShiftAudit` §5c/§5c₁ | the contractum is the old one with `addLock0ᵛ` on the moved value and nothing else changed |
+| `towerHeight`, `towerHeight-renᴹ`, `TyPeelR-⟪⟫-height`, `fixA-height-stalls`, `canon-∀-height`, `progress-Λ-at-0` | `proof/ShiftAudit` §5c₂ | **termination** (below) |
+| `U₀ -→ U₁ -→ U₂`, `⊢U₀`/`⊢U₁`/`⊢U₂` | `proof/ShiftAudit` §5c₃ | the closed two-deep run, every state typed |
+| `Rᵇ`/`Cᵇ`, `Rᵇ′`/`Cᵇ′` and their refutations | `Examples` §15b | the tightness tests for both clauses |
 
 #### Termination — it is not (a)'s regress
 
-The contractum's inner application
+The wrapper clause's contractum contains
 
     (… ⟪ addLock0 … , `∀ s″ ⟫) ·[ … , ` 0 ]
 
-*is* again a `-→ᵇ` redex.  The measure that separates it from fix (a) is
+which *is* again a redex.  The measure that separates it from fix (a) is
 the `∀`-value's **tower height** — the number of nested boundaries above
 the `Λ`:
 
@@ -317,12 +329,12 @@ shift), and then
     fixA-height-stalls : towerHeight (fix (a)'s inner ∀-value)
                           ≡ towerHeight (redex's ∀-value)
 
-(b′) **consumes** a boundary that was already there; (a) **mints** a new
-one, so its measure stalls — and §4a's `T₀ -→ᵃ T₁ -→ᵃ T₂` is that stall,
-twice.  So a redex of tower height `h` takes `h − 1` `TyPeelR-⟪⟫` steps
-and then exactly one `TyPeelR-Λ` step (`canon-∀-height`: a `∀`-value of
-height 0 is a `Λ`, `canon-∀` has no third shape), and `TyPeelR-Λ` neither
-shifts nor locks anything.
+`TyPeelR-⟪⟫` **consumes** a boundary that was already there; (a) **mints**
+a new one, so its measure stalls — and §4a's `T₀ -→ᵃ T₁ -→ᵃ T₂` is that
+stall, twice.  So a redex of tower height `h` takes `h − 1`
+`TyPeelR-⟪⟫` steps and then exactly one `TyPeelR-Λ` step
+(`canon-∀-height`: a `∀`-value of height 0 is a `Λ`, `canon-∀` has no
+third shape), and `TyPeelR-Λ` neither shifts nor locks anything.
 
 #### The closed run (§5c₃)
 
@@ -340,7 +352,7 @@ Machine-rendered:
                       ▼
     showTmIn 0 U₁
       = (((ΛZ. 3) ⟪ ↓X , ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
-                      │ ξᵇ-⟪⟫ (TyPeelR-Λ)   tower exhausted
+                      │ ξ-⟪⟫ (TyPeelR-Λ)    tower exhausted
                       ▼
     showTmIn 0 U₂
       = ((3 ⟪ ↑Z:=Y , ↓X , ↓Y , id ℕ ⟫) ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
@@ -356,18 +368,6 @@ appears.  The frames:
 
 `Ξᵈ₁` is `W`'s birth frame and `Ξᵈ₃` its frame in the contractum: the same
 frame with the new binder `Y` inserted **masked**.  Exact.
-
-#### Verdict
-
-**(b) + (b′) WORKS.**  Preservation, determinism and progress all hold for
-the pair; the two clauses are total over canonical `∀`-values, so the live
-`TyPeelR` is *replaced*, not supplemented; both new frames are exact (the
-`Λ` case up to `TyBeta`'s own refinement, the wrapper case up to the index
-shift alone); the descent terminates on a strictly decreasing measure that
-fix (a) leaves fixed; and tightness holds for both clauses.  No premise
-had to be added, and nothing in `Reduction.agda`, `Preservation.agda`,
-`Progress.agda` or `TypeSafety.agda` was touched — the probe lives
-entirely in `proof/ShiftAudit.agda` §5/§5b/§5c.
 
 ### (c) The resolve variant — exact for V, but it spells a representation inside
 
@@ -385,28 +385,27 @@ the binder-syntactic design (`Design.md` §3, Q1) exists to keep out.  The
 grounded-invariants law says representations live only at their binder;
 (c) copies one inward.  **Worse than the leak it fixes.**
 
-## Recommendation
+## What landed
 
-1. **Land (b) — the `Λ` split.**  It is written and proven in
-   `proof/ShiftAudit.agda` (`TyPeelR-Λ`, `preserve-TyPeelR-Λ`, `detᵇ`,
-   `progressᵇ-·[]`), it costs nothing (the live preservation proof minus
-   the `⊢rename`), it removes the shift entirely from the case where the
-   instantiation actually happens, and it makes TyPeelR's `Λ` case *the
-   same step as TyBeta* — which is what §6.4's own commentary says it
-   morally is ("TyPeelR's reveal case really is TyBeta's mint, one `∀`
-   inside").
-2. **Then land (b′) — the wrapper split.  It is now PROVEN too** (`§5c`):
-   `preserve-TyPeelR-⟪⟫`, `detᵇ`, `progressᵇ-·[]`, the frame identity
-   (`TyPeelR-⟪⟫-frame`, `TyPeelR-⟪⟫-slot-locked`), the terminating measure
-   (`TyPeelR-⟪⟫-height` against `fixA-height-stalls`) and a closed
-   two-deep run with every state typed.  With (b) and (b′) together,
-   **every rule that moves a subterm masks what it introduces**, and the
-   §7 table has no exceptions.
-3. **Do not take (a)** — machine-refuted, it loops — and **do not take
-   (c)** — it converts a scope leak into a knowledge leak, which the
-   design forbids.
-4. Optionally delete `shiftᵐ`/`canon-shiftᵐ` (dead after #199).
+1. **(b), the `Λ` split** — `TyPeelR-Λ`.  It costs nothing (the old
+   preservation proof minus the `⊢rename`), it removes the shift entirely
+   from the case where the instantiation actually happens, and it makes
+   TyPeelR's `Λ` case *the same step as TyBeta* — which is what §6.4's own
+   commentary always said it morally was ("TyPeelR's reveal case really is
+   TyBeta's mint, one `∀` inside").
+2. **(b′), the wrapper split** — `TyPeelR-⟪⟫`.  With (b) and (b′)
+   together, **every rule that moves a subterm masks what it introduces**,
+   and the §7 table has no exceptions.
+3. **(a) was not taken** — machine-refuted, it loops; the refutation
+   (`_⊢_-→ᵃ_`, `fixA-loop-step`, `T₀ -→ᵃ T₁ -→ᵃ T₂`) is kept in
+   `proof/ShiftAudit` §4/§4a.  **(c) was not taken** — it converts a scope
+   leak into a knowledge leak, which the design forbids.
+4. Optionally delete `shiftᵐ`/`canon-shiftᵐ` (dead after #199).  Not done.
 
-Until (b)/(b′) land in `Reduction.agda`, `Design.md` §7 carries the
-**TyPeelR (V's frame)** row as the open item — the repair is proven on the
-probe relation `_⊢_-→ᵇ_`, not installed in the live rules.
+**One side effect worth recording.**  The `Λ` clause performs the
+instantiation itself, so no `(Λ …) ·[ … , ` 0 ]` is left behind for
+`TyBeta` to consume: one type instantiation now mints **one** binder where
+the old rule pair minted two.  Runs therefore get shorter — `Examples`
+§13a's `J` is eleven steps rather than fourteen, §14's `E` five rather
+than six, and §3's birth story is one step, landing on `T₈′` (T₈ with the
+fused layer gone) instead of on `T₈`.

--- a/SystemF/agda/strong/proof/Canonicity.agda
+++ b/SystemF/agda/strong/proof/Canonicity.agda
@@ -269,14 +269,18 @@ canon-subst cN cW =
 --   Beta     substitutes — §7, wrappers are opaque to `substᵐ`.
 --   Peel     DECOMPOSES `s ↦ t`; the argument is `wkᴹ`-renamed (§4) and
 --            takes the domain `s` at the SAME binder.
---   TyPeelR  DECOMPOSES `∀ s`, RENAMES the moved value (`wkᴹ 1`), and
---            MINTS `instReveal 0 s` on the body — the ONE case that is not
---            unconditional, because the mint puts leaves at slot 0
---            ALONGSIDE the conversion's own, so the result cites TWO
---            binders; hence the hypothesis `CanonTyPeelR` below, which
---            is REFUTED.  (This is NOT a leftover of the polarity
---            index: it survives the index's retirement, for the
---            two-binder reason.)
+--   TyPeelR-Λ / TyPeelR-⟪⟫
+--            both DECOMPOSE `∀ s` and MINT `instReveal 0 s` on the body —
+--            the ONE case that is not unconditional, because the mint
+--            puts leaves at slot 0 ALONGSIDE the conversion's own, so the
+--            result cites TWO binders; hence the hypothesis
+--            `CanonTyPeelR` below, which is REFUTED.  (This is NOT a
+--            leftover of the polarity index: it survives the index's
+--            retirement, for the two-binder reason.)  The Λ clause moves
+--            nothing; the wrapper clause RENAMES the moved boundary
+--            (`renᴹ (extN (numBinds Θ′) suc)`, i.e. `wkᴹ 1` on a
+--            boundary) and appends a lock to its frame, which touches no
+--            conversion at all.
 --   CancelR  MINTS `mkId A` at the looked-up rep — a LEAF of the family
 --            (`canonAt-mkId`), canonical at every name.
 --   IdPush   MINTS BOTH conversions: the pushed `unseal X` (binder X) and
@@ -295,7 +299,7 @@ CanonTyPeelR = ∀ {s : Conv} → CanonC (`∀ s) → CanonC (instReveal 0 s)
 -- conversion cites the ONE binder X (slot 1 under the `` `∀ ``), but its
 -- mint `seal 0 ↦ seal 1` cites TWO: the binder TyPeelR just bound at slot 0
 -- and the crossed boundary's at slot 1.  The mint TYPES (proof/Preserve.
--- preserve-TyPeelR; the tree was untypeable only under the retired polarity
+-- preserve-TyPeelR-Λ; the tree was untypeable only under the retired
 -- index) — it is the SINGLE-BINDER reading that it leaves.
 canonC-∀conv : CanonC (`∀ (id (` 0) ↦ seal 1))
 canonC-∀conv = 0 , ca-all (ca-fun ca-id ca-seal)
@@ -316,8 +320,13 @@ canon-step tp (ct-· (ct-ƛ cN) cW) (Beta _) = canon-subst cN cW
 canon-step tp (ct-· (ct-⟪⟫ cV cst) cW) (Peel {Θ = Θ} _ _) =
   ct-⟪⟫ (ct-· cV (ct-⟪⟫ (canon-wkᴹ (numBinds Θ) cW) (canonC-fun-dom cst)))
         (canonC-fun-cod cst)
-canon-step tp (ct-·[] (ct-⟪⟫ cV cs)) (TyPeelR _ _) =
-  ct-⟪⟫ (ct-·[] (canon-wkᴹ 1 cV)) (tp cs)
+canon-step tp (ct-·[] (ct-⟪⟫ (ct-Λ cN) cs)) (TyPeelR-Λ _ _) =
+  ct-⟪⟫ cN (tp cs)
+canon-step tp (ct-·[] (ct-⟪⟫ (ct-⟪⟫ cW cs′) cs))
+              (TyPeelR-⟪⟫ {Θ′ = Θ′} _ _) =
+  ct-⟪⟫ (ct-·[] (ct-⟪⟫ (canon-renᴹ (extN (numBinds Θ′) suc) cW)
+                       (canonC-ren (extN (numBinds Θ′) suc) cs′)))
+        (tp cs)
 canon-step tp (ct-⟪⟫ (ct-⟪⟫ cV _) _) (CancelR {Θ₁ = Θ₁} {A = A} _ _) =
   ct-⟪⟫ (ct-⟪⟫ cV (canonC-mkId (shiftBy (numBinds Θ₁) A))) (canonC-mkId A)
 canon-step tp (ct-⟪⟫ _ _) (Drop$ _) = ct-lit

--- a/SystemF/agda/strong/proof/MoveScope.agda
+++ b/SystemF/agda/strong/proof/MoveScope.agda
@@ -62,8 +62,7 @@ open import strong.Terms
 open import strong.CtxMorph
 open import strong.proof.Preserve using (CancelRCase; IdPushCase)
 open import strong.proof.PeelDual
-  using (⊢ˢ-++; applyChanges-++; applyUnlocks-++;
-         applyChanges-dualScope; ⊢ˢ-dualScope)
+  using (applyChanges-dualScope; ⊢ˢ-dualScope)
 
 ------------------------------------------------------------------------
 -- §1  Lookup transports

--- a/SystemF/agda/strong/proof/PeelDual.agda
+++ b/SystemF/agda/strong/proof/PeelDual.agda
@@ -26,8 +26,6 @@ module strong.proof.PeelDual where
 -- REFLEXIVITY and the four `repsOf-…` filtering lemmas this module used
 -- to need are gone.
 --
---   §1  `⊢ˢ-++` — the SEQUENTIAL judgement of an append (also used by
---       proof/MoveScope)
 --   §2  the dual's change list: the frame identity, its `⊢ˢ`, and the
 --       conversion-context identity
 --   §3  (†) and `convCtx-dual`
@@ -56,21 +54,6 @@ open import strong.proof.Canonical using (shiftBy-⇒; conv-tgt≡)
 -- Structural helpers
 ------------------------------------------------------------------------
 
-applyChanges-++ : (S₁ S₂ : List Change) (Δ : Ctxᵗ)
-  → applyChanges (S₁ ++ S₂) Δ ≡ applyChanges S₁ (applyChanges S₂ Δ)
-applyChanges-++ []              S₂ Δ = refl
-applyChanges-++ (unlock X ∷ S₁) S₂ Δ =
-  cong (unmask X) (applyChanges-++ S₁ S₂ Δ)
-applyChanges-++ (lock X ∷ S₁)   S₂ Δ =
-  cong (mask X) (applyChanges-++ S₁ S₂ Δ)
-
-applyUnlocks-++ : (S₁ S₂ : List Change) (Δ : Ctxᵗ)
-  → applyUnlocks (S₁ ++ S₂) Δ ≡ applyUnlocks S₁ (applyUnlocks S₂ Δ)
-applyUnlocks-++ []              S₂ Δ = refl
-applyUnlocks-++ (unlock X ∷ S₁) S₂ Δ =
-  cong (unmask X) (applyUnlocks-++ S₁ S₂ Δ)
-applyUnlocks-++ (lock X ∷ S₁)   S₂ Δ = applyUnlocks-++ S₁ S₂ Δ
-
 pushBinds-++ : (As : List Ty) (Δ : Ctxᵗ) → pushBinds As Δ ≡ pushBinds As [] ++ Δ
 pushBinds-++ []       Δ = refl
 pushBinds-++ (A ∷ As) Δ rewrite pushBinds-++ As Δ | pushBinds-++ As [] = refl
@@ -94,25 +77,6 @@ updateAt-app-tail : (f : Ent → Ent) (Ow : Ctxᵗ) (X : ℕ) (Δ : Ctxᵗ)
   → updateAt f (length Ow + X) (Ow ++ Δ) ≡ Ow ++ updateAt f X Δ
 updateAt-app-tail f []       X Δ = refl
 updateAt-app-tail f (E ∷ Ow) X Δ = cong (E ∷_) (updateAt-app-tail f Ow X Δ)
-
-------------------------------------------------------------------------
--- §1  `⊢ˢ-++` — the sequential judgement of an APPEND
-------------------------------------------------------------------------
-
--- `applyChanges` applies its list HEAD-LAST, so in `S ++ T` it is T that
--- runs FIRST: S is judged over `applyChanges T Δ`, T over Δ.  Both
--- premises land ON THE NOSE.  Under the interleaved list this lemma also
--- had to move a REP from `scope Ψ Δ` to `unlockedScope Ψ Δ` along
--- `⊑-wf`; with the pair there is no rep in it at all.
-⊢ˢ-++ : (S T : List Change) {Δ : Ctxᵗ}
-  → applyChanges T Δ ⊢ˢ S → Δ ⊢ˢ T → Δ ⊢ˢ (S ++ T)
-⊢ˢ-++ []             T sw[]        bT = bT
-⊢ˢ-++ (lock X ∷ S)   T {Δ = Δ} (sw-l tv b) bT =
-  sw-l (subst (λ Ξ → Ξ ∋tv X) (sym (applyChanges-++ S T Δ)) tv)
-       (⊢ˢ-++ S T b bT)
-⊢ˢ-++ (unlock X ∷ S) T {Δ = Δ} (sw-u lk b) bT =
-  sw-u (subst (λ Ξ → Ξ ∋lk X) (sym (applyChanges-++ S T Δ)) lk)
-       (⊢ˢ-++ S T b bT)
 
 ------------------------------------------------------------------------
 -- §2  The dual's change list

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -471,22 +471,6 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
 -- contravariantly and `unseal 0` covariantly and one of the two always
 -- sat where the index refused it.  With the index retired the mint's
 -- typing (`⊢instReveal`, §2b) is total, and so are both cases.
-TyPeelRΛCase : Set
-TyPeelRΛCase = ∀ {Δ N Θ s B A C Bᵢ Bₑ} → Value N
-  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-  → Δ ∣ [] ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
-
-TyPeelR⟪⟫Case : Set
-TyPeelR⟪⟫Case = ∀ {Δ W Θ′ s′ Θ s B A C Bᵢ Bₑ} → Value W
-  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-  → Δ ∣ [] ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-  → Δ ∣ [] ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
-                 ⟪ addLock0 (renᴮ suc Θ′)
-                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
-
 ∀-inj : ∀ {A B} → _≡_ {A = Ty} (`∀ A) (`∀ B) → A ≡ B
 ∀-inj refl = refl
 
@@ -504,7 +488,10 @@ shiftBy-[]ᵗ (suc n) B A =
 -- THE Λ CLAUSE.  The interior is not moved at all — it is RETAGGED along
 -- the one refinement the `Λ`'s own slot undergoes.  Every other premise
 -- is the single rule's, verbatim: the repair costs nothing.
-preserve-TyPeelR-Λ : TyPeelRΛCase
+preserve-TyPeelR-Λ : ∀ {Δ N Θ s B A C Bᵢ Bₑ} → Value N
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → Δ ∣ [] ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
 preserve-TyPeelR-Λ {Δ = Δ} {N = N} {Θ = Θ} {s = s} {B = B} {A = A}
                    {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
                    (⊢·[] (env mwᵥ (⊢Λ ⊢N) ⊢c wE) wA)
@@ -547,7 +534,14 @@ preserve-TyPeelR-Λ {Δ = Δ} {N = N} {Θ = Θ} {s = s} {B = B} {A = A}
 -- moved boundary masks the new bind slot in ITS OWN change list, so it
 -- crosses by `⊢rename` alone and its frame is its birth frame with the
 -- new binder inserted MASKED.  The outer `env` is verbatim.
-preserve-TyPeelR-⟪⟫ : TyPeelR⟪⟫Case
+preserve-TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A C Bᵢ Bₑ} → Value W
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → Δ ∣ [] ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+  → Δ ∣ [] ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                 ⟪ addLock0 (renᴮ suc Θ′)
+                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
 preserve-TyPeelR-⟪⟫ {Δ = Δ} {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s}
                     {B = B} {A = A} {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
                     (⊢·[] (env mwᵥ (env mw′ ⊢W ⊢c′ wE′) ⊢c wE) wA)
@@ -627,7 +621,7 @@ PeelCase = ∀ {Δ V W Θ s t C} → Value V → Value W
   → Δ ∣ [] ⊢ (V ⟪ Θ , s ↦ t ⟫) · W ⦂ C
   → Δ ∣ [] ⊢ (V · (wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫)) ⟪ Θ , t ⟫ ⦂ C
 
--- (`TyPeelRΛCase` and `TyPeelR⟪⟫Case` are stated and PROVEN in §3.)
+-- (`preserve-TyPeelR-Λ` and `preserve-TyPeelR-⟪⟫` are PROVEN in §3.)
 
 -- CANCELR, at the repaired rule (both frames kept, both conversions
 -- neutralised, Θ₂'s scope MOVED IN).  PROVEN in proof/MoveScope.

--- a/SystemF/agda/strong/proof/Preserve.agda
+++ b/SystemF/agda/strong/proof/Preserve.agda
@@ -18,8 +18,8 @@ module strong.proof.Preserve where
 --     conversion-level analogue of §2.  Since the polarity index was
 --     retired (strong.Conversion) both directions are TOTAL.
 --
--- §3  the per-rule cases that hold, one lemma each — TyBeta, TyPeelR at
---     ANY ∀ conversion, and Drop$.
+-- §3  the per-rule cases that hold, one lemma each — TyBeta, the TWO
+--     TyPeelR clauses at ANY ∀ conversion, and Drop$.
 --
 -- §4  `preserve`, over a module parameterized by the three cases whose
 --     proofs live downstream: Peel (proof/PeelDual) and CancelR/IdPush
@@ -436,35 +436,55 @@ preserve-TyBeta {Δ = Δ} {N = N} {B = B} {A = A} (⊢·[] (⊢Λ ⊢N) wA)
   conv : (unmasked (bind A) ∷ Δ) ⊢ reveal 0 B ∶ B ⇝ shiftBy 1 (B [ A ]ᵗ)
   conv rewrite sym (subst-at-0 A B) = ⊢reveal ez (⊑-wf (⊑ᵃ→⊑ refine) wB)
 
--- ── TYPEELR, AT ANY ∀ CONVERSION ───────────────────────────────────────
--- Four moves, one per premise of the contractum's `env`:
+-- ── TYPEELR, AT ANY ∀ CONVERSION — THE TWO CLAUSES ────────────────────
+-- Both clauses share three of the four moves, one per premise of the
+-- contractum's `env`:
 --
 --   FRAME       one bind prepended to Θ, whose interior is
 --               `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ`
 --               DEFINITIONALLY — the shift `renᴮ suc Θ` used to add is
 --               the one `pushBinds` already performs.
---   INTERIOR    `wkᴹ 1 V` (⊢rename at `Ren-wk`) instantiated at the new
---               binder's own name; the annotation is the INTERIOR
---               ∀-body, shifted, and `ren-suc-[0]` returns it unchanged.
 --   CONVERSION  `instReveal 0 s` (§2b), whose TARGET type is its SOURCE
 --               with slot 0 replaced by the binder's rep — which is the
 --               instantiated exterior body, by `subst-at-0`.
 --   EXTERIOR    `wf-[]ᵗ`, i.e. `⊢·[]`'s own two premises.
 --
+-- The INTERIOR is where they differ, and it is the whole content of the
+-- 2026-09-08 split (notes/ShiftAudit.md):
+--
+--   TyPeelR-Λ    `⊢retag` along `la∷ (la-uu le-ab) (⊑ᵃ-refl _)` — the
+--                `Λ`'s abst slot BECOMES the boundary's bind slot, which
+--                is TyBeta's own refinement.  No `⊢rename`, no `wkᴹ`, no
+--                `ren-suc-[0]`.
+--   TyPeelR-⟪⟫   `⊢addLock0-cross` (strong.TermSubst §6) in place of the
+--                single rule's `⊢rename Ren-wk Inj-suc`, then `⊢·[]` at
+--                the new binder's own name; the annotation is the
+--                INTERIOR ∀-body, shifted, and `ren-suc-[0]` returns it
+--                unchanged.
+--
 -- The premise `⊢s` and the redex's own conversion derivation agree, by
 -- `conv-types-unique`: that is what makes the pushed-in annotation a
 -- function of the redex (and hence `det` true).
 --
--- THE CASE IS NOW GENERAL.  Under the polarity index this was a theorem
+-- THE CASES ARE GENERAL.  Under the polarity index this was a theorem
 -- only at a REVEAL ∀ conversion, because the mint inserts `seal 0`
 -- contravariantly and `unseal 0` covariantly and one of the two always
 -- sat where the index refused it.  With the index retired the mint's
--- typing (`⊢instReveal`, §2b) is total, and so is this case.
-TyPeelRCase : Set
-TyPeelRCase = ∀ {Δ V Θ s B A C Bᵢ Bₑ} → Value V
+-- typing (`⊢instReveal`, §2b) is total, and so are both cases.
+TyPeelRΛCase : Set
+TyPeelRΛCase = ∀ {Δ N Θ s B A C Bᵢ Bₑ} → Value N
   → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-  → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-  → Δ ∣ [] ⊢ (wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+  → Δ ∣ [] ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
+
+TyPeelR⟪⟫Case : Set
+TyPeelR⟪⟫Case = ∀ {Δ W Θ′ s′ Θ s B A C Bᵢ Bₑ} → Value W
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → Δ ∣ [] ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+  → Δ ∣ [] ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                 ⟪ addLock0 (renᴮ suc Θ′)
+                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
 
 ∀-inj : ∀ {A B} → _≡_ {A = Ty} (`∀ A) (`∀ B) → A ≡ B
@@ -481,35 +501,95 @@ shiftBy-[]ᵗ (suc n) B A =
   trans (cong ⇑ᵗ (shiftBy-[]ᵗ n B A))
         (rename-[]ᵗ-commute suc (shiftBodyBy n B) (shiftBy n A))
 
-preserve-TyPeelR : TyPeelRCase
-preserve-TyPeelR {Δ = Δ} {V = V} {Θ = Θ} {s = s} {B = B} {A = A}
-                 {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA)
+-- THE Λ CLAUSE.  The interior is not moved at all — it is RETAGGED along
+-- the one refinement the `Λ`'s own slot undergoes.  Every other premise
+-- is the single rule's, verbatim: the repair costs nothing.
+preserve-TyPeelR-Λ : TyPeelRΛCase
+preserve-TyPeelR-Λ {Δ = Δ} {N = N} {Θ = Θ} {s = s} {B = B} {A = A}
+                   {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
+                   (⊢·[] (env mwᵥ (⊢Λ ⊢N) ⊢c wE) wA)
   with conv-all-inv ⊢c
 ... | A₀ , B₀ , refl , eqE , ⊢s₀
   with conv-types-unique ⊢s ⊢s₀
 ... | refl , refl =
   env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
-          (mw-changes mwᵥ)) int conv
+          (mw-changes mwᵥ))
+      (⊢retag refine ⊢N)
+      conv
       (wf-[]ᵗ (wf-∀⁻ wE) wA)
   where
   A′ : Ty
   A′ = shiftBy (numBinds Θ) A
 
-  -- the exterior ∀-body, read on the boundary's conversion context
+  -- THE `Λ`'S ABST SLOT BECOMES THE BOUNDARY'S BIND SLOT.  `la-uu le-ab`
+  -- at a slot N COULD ALREADY NAME — `⊑ᵃ`-legal, in flat contrast to the
+  -- single rule's `le-mu` (proof/ShiftAudit §3).
+  refine : (unmasked abst ∷ interior Θ Δ)
+             ⊑ᵃ interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+  refine = la∷ (la-uu le-ab) (⊑ᵃ-refl (interior Θ Δ))
+
   eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
   eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
 
-  ⊢wkV : (unmasked (bind A′) ∷ interior Θ Δ) ∣ []
-           ⊢ wkᴹ 1 V ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
-  ⊢wkV = ⊢rename Ren-wk Inj-suc ⊢V
+  eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
+  eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)
+              (trans (subst-at-0 A′ (shiftBodyBy (numBinds Θ) B))
+                     (cong ⇑ᵗ (sym (shiftBy-[]ᵗ (numBinds Θ) B A))))
+
+  conv : convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ instReveal 0 s
+           ∶ Bᵢ ⇝ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
+  conv = subst (λ T → convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ
+                        ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
+               eqT (⊢instReveal {A = A′} 0 ⊢s)
+
+-- THE WRAPPER CLAUSE.  The single rule's proof with
+-- `⊢wkV = ⊢rename Ren-wk Inj-suc` replaced by `⊢addLock0-cross`: the
+-- moved boundary masks the new bind slot in ITS OWN change list, so it
+-- crosses by `⊢rename` alone and its frame is its birth frame with the
+-- new binder inserted MASKED.  The outer `env` is verbatim.
+preserve-TyPeelR-⟪⟫ : TyPeelR⟪⟫Case
+preserve-TyPeelR-⟪⟫ {Δ = Δ} {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s}
+                    {B = B} {A = A} {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
+                    (⊢·[] (env mwᵥ (env mw′ ⊢W ⊢c′ wE′) ⊢c wE) wA)
+  with conv-all-inv ⊢c
+... | A₀ , B₀ , refl , eqE , ⊢s₀
+  with conv-types-unique ⊢s ⊢s₀
+... | refl , refl =
+  env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
+          (mw-changes mwᵥ))
+      int
+      conv
+      (wf-[]ᵗ (wf-∀⁻ wE) wA)
+  where
+  A′ : Ty
+  A′ = shiftBy (numBinds Θ) A
+
+  ⊢INNER : (unmasked (bind A′) ∷ interior Θ Δ) ∣ []
+             ⊢ (renᴹ (extN (numBinds Θ′) suc) W
+                  ⟪ addLock0 (renᴮ suc Θ′)
+                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+             ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
+  ⊢INNER = ⊢addLock0-cross mw′ ⊢W ⊢c′ wE′
 
   int : interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
-          ⊢ wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ] ⦂ Bᵢ
+          ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                ⟪ addLock0 (renᴮ suc Θ′)
+                , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+               ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+          ⦂ Bᵢ
   int =
     subst (λ T → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
-                   ⊢ wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ] ⦂ T)
+                   ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                         ⟪ addLock0 (renᴮ suc Θ′)
+                         , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                        ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+                   ⦂ T)
           (ren-suc-[0] Bᵢ)
-          (⊢·[] ⊢wkV (wf-var (unmasked (bind (⇑ᵗ A′)) , ez , nameable)))
+          (⊢·[] ⊢INNER
+                (wf-var (unmasked (bind (⇑ᵗ A′)) , ez , nameable)))
+
+  eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
+  eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
 
   eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
   eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)
@@ -547,7 +627,7 @@ PeelCase = ∀ {Δ V W Θ s t C} → Value V → Value W
   → Δ ∣ [] ⊢ (V ⟪ Θ , s ↦ t ⟫) · W ⦂ C
   → Δ ∣ [] ⊢ (V · (wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫)) ⟪ Θ , t ⟫ ⦂ C
 
--- (`TyPeelRCase` is stated and PROVEN in §3.)
+-- (`TyPeelRΛCase` and `TyPeelR⟪⟫Case` are stated and PROVEN in §3.)
 
 -- CANCELR, at the repaired rule (both frames kept, both conversions
 -- neutralised, Θ₂'s scope MOVED IN).  PROVEN in proof/MoveScope.
@@ -584,7 +664,8 @@ module Impl
   preserve ⊢M (TyBeta v)             = preserve-TyBeta ⊢M
   preserve ⊢M (Beta w)               = preserve-Beta ⊢M
   preserve ⊢M (Peel v w)             = peel v w ⊢M
-  preserve ⊢M (TyPeelR v ⊢s)         = preserve-TyPeelR v ⊢s ⊢M
+  preserve ⊢M (TyPeelR-Λ v ⊢s)       = preserve-TyPeelR-Λ v ⊢s ⊢M
+  preserve ⊢M (TyPeelR-⟪⟫ v ⊢s)      = preserve-TyPeelR-⟪⟫ v ⊢s ⊢M
   preserve ⊢M (CancelR v d)          = cancel v d ⊢M
   preserve ⊢M (Drop$ b)              = preserve-Drop$ b ⊢M
   preserve ⊢M (IdPush v d)           = idpush v d ⊢M

--- a/SystemF/agda/strong/proof/PreserveObstruct.agda
+++ b/SystemF/agda/strong/proof/PreserveObstruct.agda
@@ -14,7 +14,7 @@ module strong.proof.PreserveObstruct where
 --               premise-determined interior ∀-body, the frame is plain
 --               `Θ`, and the minted conversion `instReveal 0 s` types at
 --               EVERY ∀ conversion once the polarity index is gone
---               (proof/Preserve.preserve-TyPeelR).  §2 keeps the old
+--               (proof/Preserve.preserve-TyPeelR-Λ / -⟪⟫).  §2 keeps the old
 --               counterexample's witness and records the POSITIVE fact on
 --               it; Examples §13 reaches it from closed plain source.
 --   §3 Peel     REPAIRED and PROVEN (proof/PeelDual); refutation removed.
@@ -42,7 +42,7 @@ open import strong.Terms
 open import strong.CtxMorph
 open import strong.TermSubst
 open import strong.Reduction
-open import strong.proof.Preserve using (preserve-TyPeelR)
+open import strong.proof.Preserve using (preserve-TyPeelR-Λ)
 open import strong.proof.MoveScope using (preserve-IdPush)
 
 ------------------------------------------------------------------------
@@ -181,10 +181,13 @@ Rt = Wft ·[ ` 0 ⇒ ` 1 , ` 0 ]
 ⊢Rt : Δt ∣ [] ⊢ Rt ⦂ (` 0 ⇒ ` 0)
 ⊢Rt = ⊢·[] ⊢Wft (wf-var (unmasked (bind `ℕ) , ez , nameable))
 
+-- The interior is a `Λ`, so it is the Λ CLAUSE that fires (the 2026-09-08
+-- split, strong.Reduction): the body is instantiated ON THE SPOT, with no
+-- shift and no pushed-in annotation.
 step-t : Δt ⊢ Rt
-       -→ (wkᴹ 1 Wt ·[ renameᵗ (extᵗ suc) (` 0 ⇒ `ℕ) , ` 0 ])
+       -→ (ƛ (` 0) ∙ ($ 3))
             ⟪ morph (` 0 ∷ binds Θt) (changes Θt) , instReveal 0 st ⟫
-step-t = TyPeelR val-Wt ⊢st
+step-t = TyPeelR-Λ V-ƛ ⊢st
 
 -- THE MINTED CONVERSION, computed: the inserted leaf is the DOMAIN
 -- `seal 0`.
@@ -213,10 +216,10 @@ t-cod = conv-seal (es ez)
 
 -- THE CONTRACTUM TYPES, by the theorem — no hand-built derivation.
 ⊢t-contractum :
-  Δt ∣ [] ⊢ (wkᴹ 1 Wt ·[ ` 0 ⇒ `ℕ , ` 0 ])
+  Δt ∣ [] ⊢ (ƛ (` 0) ∙ ($ 3))
               ⟪ morph (` 0 ∷ binds Θt) (changes Θt) , seal 0 ↦ seal 1 ⟫
               ⦂ (` 0 ⇒ ` 0)
-⊢t-contractum = preserve-TyPeelR val-Wt ⊢st ⊢Rt
+⊢t-contractum = preserve-TyPeelR-Λ V-ƛ ⊢st ⊢Rt
 
 ------------------------------------------------------------------------
 -- §3  Peel — REPAIRED (refutation removed)

--- a/SystemF/agda/strong/proof/Progress.agda
+++ b/SystemF/agda/strong/proof/Progress.agda
@@ -7,7 +7,10 @@ module strong.proof.Progress where
 --     a closed, well-typed term is a VALUE or it STEPS.
 --
 -- The three ordinary cases (application, type application, Λ) are the
--- usual ones, decided by strong.proof.Canonical.  The boundary case is
+-- usual ones, decided by strong.proof.Canonical — type application at a
+-- ∀-conversion wrapper takes ONE MORE `canon-∀`, on the boundary's
+-- interior, because TyPeelR is split on it (`progress-·[]-∀conv`).  The
+-- boundary case is
 -- the whole content of the theorem, and it is a two-step argument:
 --
 --   1. run the induction hypothesis on the INTERIOR, at `interior Θ Δ`
@@ -99,20 +102,34 @@ progress-env v ⊢M ⊢c | inj₁ A-unseal | W , Θ₁ , Z , vW , inj₂ refl =
   inj₂ (_ , IdPush vW (unseal-target-is-rep ⊢c))
 
 ------------------------------------------------------------------------
--- TYPEELR'S CONVERSION PREMISE, READ OFF THE REDEX
+-- THE TYPEELR SPLIT, DECIDED BY `canon-∀`
 ------------------------------------------------------------------------
 
--- TyPeelR's pushed-in annotation is the INTERIOR ∀-body, which the rule
--- carries as a conversion-typing premise (strong.Reduction, repair 2a).
--- Progress supplies it for FREE: it is the redex's own `env` conversion,
--- one `` `∀ `` inside.  `conv-all-inv` (strong.Conversion) does the
--- inversion without having to see through `env`'s `shiftBy`.
-∀-conv-premise : ∀ {Δ W Θ s B} → Δ ∣ [] ⊢ W ⟪ Θ , `∀ s ⟫ ⦂ `∀ B
-  → Σ[ Bᵢ ∈ Ty ] Σ[ Bₑ ∈ Ty ]
-      ((unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ)
-∀-conv-premise (env mwᵥ ⊢W ⊢c wE) with conv-all-inv ⊢c
-∀-conv-premise (env mwᵥ ⊢W ⊢c wE) | Bᵢ , Bₑ , eqᵢ , eqₑ , ⊢s =
-  Bᵢ , Bₑ , ⊢s
+-- TyPeelR is TWO CLAUSES (strong.Reduction, 2026-09-08), split on the
+-- crossed boundary's INTERIOR, and `canon-∀` hands the split EXACTLY its
+-- two patterns — a `Λ` over a value, or a wrapper with a `∀` conversion.
+-- So the pair is TOTAL over canonical `∀`-values: it REPLACES the single
+-- rule rather than supplementing it.
+--
+-- Both clauses' premises come off the redex's own derivation, and ONE
+-- inversion supplies both: `conv-all-inv` gives the conversion typing
+-- `⊢s` (TyPeelR's pushed-in annotation is the INTERIOR ∀-body, which the
+-- rule carries as a premise — strong.Reduction, repair 2a) and pins the
+-- interior's type to `` `∀ A₀ ``, which is what lets `canon-∀` run on the
+-- interior at all.
+progress-·[]-∀conv : ∀ {Δ V Θ s B A C} → Value V
+  → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+    -----------------------------------------------------------
+  → Σ[ M ∈ Term ] (Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] -→ M)
+progress-·[]-∀conv v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) with conv-all-inv ⊢c
+progress-·[]-∀conv v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA)
+  | A₀ , B₀ , refl , eqₑ , ⊢s with canon-∀ v ⊢V
+progress-·[]-∀conv v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA)
+  | A₀ , B₀ , refl , eqₑ , ⊢s | inj₁ (N , vN , refl) =
+  _ , TyPeelR-Λ vN ⊢s
+progress-·[]-∀conv v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA)
+  | A₀ , B₀ , refl , eqₑ , ⊢s | inj₂ (W , Θ′ , s′ , vW , refl) =
+  _ , TyPeelR-⟪⟫ vW ⊢s
 
 ------------------------------------------------------------------------
 -- THE THEOREM
@@ -147,16 +164,16 @@ progress (⊢· ⊢L ⊢M) | inj₁ vL | inj₁ vM
   | inj₂ (W , Θ , s , t , vW , refl) = inj₂ (_ , Peel vW vM)
 
 -- L ·[ B , A ] — TyBeta at a Λ (whose body is a value: V-Λ's premise IS
--- TyBeta's premise), TyPeelR at a ∀-conversion wrapper.
+-- TyBeta's premise), and at a ∀-conversion wrapper the TyPeelR SPLIT,
+-- which `progress-·[]-∀conv` decides by a second `canon-∀`, on the
+-- boundary's interior.
 progress (⊢·[] ⊢L wA) with progress ⊢L
 progress (⊢·[] ⊢L wA) | inj₂ (L′ , st) = inj₂ (L′ ·[ _ , _ ] , ξ-·[] st)
 progress (⊢·[] ⊢L wA) | inj₁ vL with canon-∀ vL ⊢L
 progress (⊢·[] ⊢L wA) | inj₁ vL | inj₁ (N , vN , refl) =
   inj₂ (_ , TyBeta vN)
-progress (⊢·[] ⊢L wA) | inj₁ vL | inj₂ (W , Θ , s , vW , refl)
-  with ∀-conv-premise ⊢L
-progress (⊢·[] ⊢L wA) | inj₁ vL | inj₂ (W , Θ , s , vW , refl)
-  | Bᵢ , Bₑ , ⊢s = inj₂ (_ , TyPeelR vW ⊢s)
+progress (⊢·[] ⊢L wA) | inj₁ vL | inj₂ (W , Θ , s , vW , refl) =
+  inj₂ (progress-·[]-∀conv vW (⊢·[] ⊢L wA))
 
 -- M ⟪ Θ , c ⟫ — the boundary.  The interior is typed at `interior Θ Δ`; an
 -- interior step lifts by ξ-⟪⟫, an interior value goes to `progress-env`.

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -21,6 +21,7 @@ module strong.proof.ShiftAudit where
 --   §3  TyPeelR (V's frame)   — ****  LEAK  ****
 --   §4  fix (a), "wrap V in the new binder's dual" — LOOPS
 --   §5  fix (b), "split on the interior" — the Λ half, PROVEN EXACT
+--   §5b fix (b′), the wrapper half — the frame identity, EXACT
 --   §6  TyBeta                — exact up to refinement
 --   §7  Beta                  — exact (crossΛ), and the `ƛ` clause
 --   §8  CancelR / IdPush      — exact, inner AND outer
@@ -53,7 +54,7 @@ open import strong.Reduction
 open import strong.proof.Preserve
   using (⊢instReveal; wf-[]ᵗ; wf-∀⁻; ∀-inj; subst-at-0; shiftBy-[]ᵗ
         ; ren-suc-[0])
-open import strong.proof.PeelDual using (interior-dual)
+open import strong.proof.PeelDual using (interior-dual; applyChanges-++)
 open import strong.proof.MoveScope using (interior-rewind; interior-⋉-rewind)
 open import strong.proof.Canonical using (canon-∀)
 open import strong.Examples
@@ -511,6 +512,82 @@ TyPeelR-Λ-no-shift = interior-TyPeelR
 TyPeelR-Λ-slot0-old : (Θ : CtxMorph) (Δ : Ctxᵗ)
   → (unmasked abst ∷ interior Θ Δ) ∋tv 0
 TyPeelR-Λ-slot0-old Θ Δ = _ , ez , nameable
+
+------------------------------------------------------------------------
+-- §5b  FIX (b′) — CLOSING THE WRAPPER CASE TOO: THE NEW BINDER IS
+--      MASKED IN THE MOVED BOUNDARY'S OWN FRAME
+------------------------------------------------------------------------
+
+-- `canon-∀` says the thing TyPeelR moves in the non-Λ case is A BOUNDARY.
+-- A boundary carries its own change list — so the new binder can be
+-- masked for it WITHOUT a second wrapper (which is what loops, §4) and
+-- WITHOUT resolving anything (which is what fix (c) pays, §13c of
+-- Examples): append `lock 0` to the moved boundary's OWN changes, at the
+-- TAIL, where `applyChanges` runs it FIRST — exactly the position the
+-- SCOPE MOVE `_⋉_` puts the travelling changes in.
+addLock0 : CtxMorph → CtxMorph
+addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
+
+-- the two list facts the frame identity needs
+map-renᶠ-shiftScope : (S : List Change)
+  → map (renᶠ suc) S ≡ shiftScope 1 S
+map-renᶠ-shiftScope []             = refl
+map-renᶠ-shiftScope (unlock X ∷ S) =
+  cong (unlock (suc X) ∷_) (map-renᶠ-shiftScope S)
+map-renᶠ-shiftScope (lock X ∷ S)   =
+  cong (lock (suc X) ∷_) (map-renᶠ-shiftScope S)
+
+-- `shiftScope 1` steps a change list PAST ONE ENTRY: the entry is
+-- untouched and the list acts on the tail.  (`applyChanges-shiftScope`,
+-- proof/MoveScope, is this past a whole `pushBinds` prefix; here the
+-- prefix is one arbitrary entry, MASKED included.)
+applyChanges-shift1 : (S : List Change) (E : Ent) (Δ : Ctxᵗ)
+  → applyChanges (shiftScope 1 S) (E ∷ Δ) ≡ E ∷ applyChanges S Δ
+applyChanges-shift1 []             E Δ = refl
+applyChanges-shift1 (unlock X ∷ S) E Δ =
+  cong (unmask (suc X)) (applyChanges-shift1 S E Δ)
+applyChanges-shift1 (lock X ∷ S)   E Δ =
+  cong (mask (suc X)) (applyChanges-shift1 S E Δ)
+
+-- THE FRAME IDENTITY.  The moved boundary's interior frame is its BIRTH
+-- frame with the new binder inserted BELOW the bind prefix and MASKED —
+-- the very shape (†) gives Peel's crossing argument and `interior-Beta-Λ`
+-- gives Beta's.  Nothing gained, nothing lost.
+interior-addLock0 : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
+  → interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
+      ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
+interior-addLock0 Θ′ C Δ =
+  cong (pushBinds (map ⇑ᵗ (binds Θ′)))
+       (trans (applyChanges-++ (map (renᶠ suc) (changes Θ′)) (lock 0 ∷ [])
+                               (unmasked (bind C) ∷ Δ))
+              (trans (cong (λ S → applyChanges S (masked (bind C) ∷ Δ))
+                           (map-renᶠ-shiftScope (changes Θ′)))
+                     (applyChanges-shift1 (changes Θ′) (masked (bind C)) Δ)))
+
+-- … AND THE MOVED BOUNDARY CROSSES BY `⊢rename` ALONE.  `wkᴹ 1` on a
+-- boundary renames its interior at `extN (numBinds Θ′) suc`
+-- (strong.TermSubst, `renᴹ`'s wrapper clause), and that is exactly the
+-- renaming from the birth frame into the frame above — no `⊢retag`, no
+-- `le-mu`.  This is what makes (b′) exact.
+Ren-addLock0 : (Θ′ : CtxMorph) (E : Ent) (Δ : Ctxᵗ)
+  → Ren (extN (numBinds Θ′) suc) (interior Θ′ Δ)
+        (pushBinds (map ⇑ᵗ (binds Θ′)) (E ∷ scope Θ′ Δ))
+Ren-addLock0 Θ′ E Δ = ren-pushBinds (binds Θ′) suc (mkRen es)
+
+-- The `lock 0` is LEGAL where it acts: slot 0 of the new frame is
+-- nameable (§3's `TyPeelR-slot0-nameable` — the leak's own slot is
+-- exactly what authorizes the lock that closes it), so `sw-l` applies.
+addLock0-sw-l : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ˢ (lock 0 ∷ [])
+addLock0-sw-l A Θ Δ = sw-l (TyPeelR-slot0-nameable A Θ Δ) sw[]
+
+-- WHAT REMAINS for (b′) to land as a rule: `Δ ⊢ᵐ addLock0 (renᴮ suc Θ′)`
+-- (the reps by `⊢ʳ-ren`, the changes by `⊢ˢ-ren` plus `addLock0-sw-l`
+-- and `⊢ˢ-++`), and the moved boundary's CONVERSION re-typed at
+-- `convCtx (addLock0 (renᴮ suc Θ′)) …` — where the appended lock is
+-- LIFTED (`applyUnlocks` skips locks), so the conversion context is the
+-- renamed one and `conv-ren` suffices.  Neither is new machinery; both
+-- are the moves `⊢rename`'s own (env) case already makes.
 
 ------------------------------------------------------------------------
 -- §6  TYBETA — exact up to refinement

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -1,0 +1,684 @@
+module strong.proof.ShiftAudit where
+
+-- THE SHIFT AUDIT — every place a rule MOVES A SUBTERM, checked against
+-- FRAME EXACTNESS (Jeremy, 2026-09-08: "frame exactness is the main point
+-- of Strong System F").
+--
+-- THE CRITERION.  Whenever a rule moves a subterm to a new position, the
+-- subterm's TYPE CONTEXT at the new position must be EXACTLY its context
+-- at the old position, up to
+--
+--   (i)  the index shift past the binders it CROSSED, and
+--   (ii) refinement `abst → bind` of a slot it could ALREADY NAME
+--        (TyBeta's reveal, TyPeelR's `instReveal`).
+--
+-- Any slot the subterm COULD NOT NAME before and CAN NAME after is a
+-- FRAME LEAK, even when the subterm's shifted indices cannot reach it:
+-- the frame must SAY THE TRUTH about what the subterm may name.
+--
+--   §1  the site table (comment)
+--   §2  Peel                  — EXACT, by (†)
+--   §3  TyPeelR (V's frame)   — ****  LEAK  ****
+--   §4  fix (a), "wrap V in the new binder's dual" — LOOPS
+--   §5  fix (b), "split on the interior" — the Λ half, PROVEN EXACT
+--   §6  TyBeta                — exact up to refinement
+--   §7  Beta                  — exact (crossΛ), and the `ƛ` clause
+--   §8  CancelR / IdPush      — exact, inner AND outer
+--   §9  Drop$                 — vacuous (a numeral has no type variables)
+--   §10 the ξ rules           — nothing moves
+--   §11 dead shift machinery
+--
+-- The verdict table with the fix candidates and their hazards is
+-- notes/ShiftAudit.md; the frame-identity table it feeds is Design.md §7.
+
+open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.List using (List; []; _∷_; _++_; map; length)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+open import Data.Product using (Σ; Σ-syntax; _×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Data.Empty using (⊥; ⊥-elim)
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; _≢_; refl; sym; cong; cong₂; trans; subst)
+
+open import strong.Types
+  using (Ty; `_; `ℕ; `𝔹; _⇒_; `∀; Renameᵗ; renameᵗ; extᵗ; ⇑ᵗ; _[_]ᵗ
+        ; _[_:=_]ᵗ)
+open import strong.Ctx
+open import strong.Conversion
+open import strong.Terms
+open import strong.CtxMorph
+open import strong.TermSubst
+open import strong.Reduction
+
+open import strong.proof.Preserve
+  using (⊢instReveal; wf-[]ᵗ; wf-∀⁻; ∀-inj; subst-at-0; shiftBy-[]ᵗ
+        ; ren-suc-[0])
+open import strong.proof.PeelDual using (interior-dual)
+open import strong.proof.MoveScope using (interior-rewind; interior-⋉-rewind)
+open import strong.proof.Canonical using (canon-∀)
+open import strong.Examples
+  using (interior-TyBeta; interior-TyPeelR; interior-Beta-Λ)
+
+private
+  variable
+    Δ Δ′ : Ctxᵗ
+    Γ : Ctx
+    A B C : Ty
+    X Y : ℕ
+    Θ Θ₁ Θ₂ : CtxMorph
+
+------------------------------------------------------------------------
+-- §1  THE SITES
+------------------------------------------------------------------------
+
+-- Every place in the live development where a TERM is renamed, shifted or
+-- substituted (`grep wkᴹ ⇑ᴹ renᴹ renⁿ shiftᵐ crossΛ substᵐ`):
+--
+--   RULES that move a subterm
+--     Peel      `wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫`          §2  EXACT
+--     TyPeelR   `wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ]`   §3  LEAK
+--     TyBeta    `N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫`       §6  refinement
+--     Beta      `N [ W ∶ A ]ᵐ`, i.e. `substᵐ`/`crossΛ`       §7  EXACT
+--     CancelR   `V ⟪ Θ₁ ⋉ Θ₂ , … ⟫ ⟪ rewind Θ₂ , … ⟫`        §8  EXACT
+--     IdPush    (same two frames)                            §8  EXACT
+--     Drop$     `($ n) ⟪ Θ , id A ⟫ → $ n`                   §9  vacuous
+--     ξ-*       nothing moves                                §10 —
+--
+--   TRANSPORTS, not rules (no term is moved by a reduction; these are the
+--   lemmas the cases above are PROVED with, and each one's `Ren`/`⊑ᵃ`
+--   argument is supplied at the site):
+--     `⊢rename`, `⊢retag`, `Ren-wk`, `renᴹ`, `renⁿ`, `⊢renⁿ`,
+--     `⊢weakenⁿ`, `canon-renᴹ`/`canon-renⁿ` (proof/Canonicity).
+--
+--   DEAD after PR #199: `shiftᵐ` and `canon-shiftᵐ` (§11).
+
+------------------------------------------------------------------------
+-- §2  PEEL — the crossing argument's frame is the EXTERIOR, under a
+--     MASKED bind prefix
+------------------------------------------------------------------------
+
+-- W's frame, before: `Δ`.  After: `interior (dual Θ) (interior Θ Δ)`,
+-- which (†) says is `Δ` with `numBinds Θ` MASKED bind entries in front —
+-- and `wkᴹ (numBinds Θ)` shifts W past exactly those.  Criterion (i),
+-- nothing else: EXACT.
+Peel-frame : (Θ : CtxMorph) (Δ : Ctxᵗ) → Δ ⊢ᵐ Θ
+  → interior (dual Θ) (interior Θ Δ)
+      ≡ map maskEnt (pushBinds (binds Θ) []) ++ Δ
+Peel-frame = interior-dual
+
+-- … and the new slots are UNNAMEABLE, which is what makes (i) the whole
+-- story: the crossing argument may not name a slot it could not name
+-- before.  (At `binds Θ ≡ []` there is no new slot at all and the frame
+-- is `Δ` on the nose.)
+Peel-slot0-locked : (As : List Ty) (Δ : Ctxᵗ)
+  → ¬ ((map maskEnt (pushBinds (A ∷ As) []) ++ Δ) ∋tv 0)
+Peel-slot0-locked As Δ (_ , ez , ())
+
+------------------------------------------------------------------------
+-- §3  TYPEELR — THE LEAK
+------------------------------------------------------------------------
+
+-- THE MOVE.  `V`, the interior of the crossed boundary, is typed at
+-- `interior Θ Δ` in the redex and at
+--
+--   interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+--     ≡ unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ
+--
+-- in the contractum (`interior-TyPeelR`, Examples §15).  So V's frame
+-- gains ONE ENTRY at slot 0, and it gains it UNMASKED.  V is shifted by
+-- `wkᴹ 1`, so V's own indices land at ≥ 1 and cannot reach the new slot —
+-- the rule is SOUND, and Examples §15b checks that an ill-typed V stays
+-- ill-typed.  But by the criterion the FRAME LIES: it offers V a slot V
+-- could not name before.
+--
+-- THE THREE FACTS.  (a) the frame HAS the slot, nameably; (b) V DOES NOT
+-- NEED it — the very `⊢rename` the live proof uses works at the MASKED
+-- entry, because `Ren-wk` is `Ren suc Δ (E ∷ Δ)` for EVERY entry E;
+-- (c) the INSTANTIATION NODE `·[ … , ` 0 ]` does need it, and it shares
+-- V's frame.  (a)+(b) is the leak; (c) is why no repair is possible
+-- WITHOUT CHANGING THE CONTRACTUM'S SHAPE (§4, §5).
+
+-- (a) the new slot is NAMEABLE in the moved value's frame
+TyPeelR-slot0-nameable : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∋tv 0
+TyPeelR-slot0-nameable A Θ Δ = _ , ez , nameable
+
+-- … so a TYPE at V's position may name it
+TyPeelR-slot0-typeable : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ᵗ ` 0
+TyPeelR-slot0-typeable A Θ Δ = wf-var (TyPeelR-slot0-nameable A Θ Δ)
+
+-- (b) V IS INDIFFERENT TO THE LOCK.  This is the live proof's own
+-- `⊢wkV`, with `unmasked` replaced by `masked`: the derivation goes
+-- through unchanged, so the `unmasked` in the live rule's frame is
+-- STRICTLY MORE THAN V USES.
+TyPeelR-V-tight : ∀ {V Bᵥ}
+  → interior Θ Δ ∣ [] ⊢ V ⦂ Bᵥ
+    ---------------------------------------------------------------
+  → (masked (bind C) ∷ interior Θ Δ) ∣ [] ⊢ wkᴹ 1 V ⦂ ⇑ᵗ Bᵥ
+TyPeelR-V-tight ⊢V = ⊢rename Ren-wk Inj-suc ⊢V
+
+-- (c) THE NODE IS NOT.  With the slot masked the pushed-in
+-- `·[ … , ` 0 ]` has no well-formed type argument, so V and the node
+-- CANNOT both be served by one frame.
+TyPeelR-node-needs-slot0 : ¬ ((masked (bind C) ∷ Δ) ⊢ᵗ ` 0)
+TyPeelR-node-needs-slot0 (wf-var (_ , ez , ()))
+
+-- THE LEAK, AS A REFINEMENT STEP.  The frame the moved value needs and
+-- the frame the rule gives it differ by exactly ONE `le-mu` — the
+-- RE-EXPOSURE clause, the one step `_⊑ᵃ_` (the refinement a TERM may
+-- travel along, strong.Ctx §4b) REFUSES.  That is the sharpest statement
+-- of the leak: TyPeelR moves V along a frame change that is `_⊑_` but not
+-- `_⊑ᵃ_`.
+TyPeelR-leak-⊑ : (C : Ty) (Δ : Ctxᵗ)
+  → (masked (bind C) ∷ Δ) ⊑ (unmasked (bind C) ∷ Δ)
+TyPeelR-leak-⊑ C Δ = le∷ (le-mu le-bb) (⊑-refl Δ)
+
+TyPeelR-leak-¬⊑ᵃ : (C : Ty) (Δ : Ctxᵗ)
+  → ¬ ((masked (bind C) ∷ Δ) ⊑ᵃ (unmasked (bind C) ∷ Δ))
+TyPeelR-leak-¬⊑ᵃ C Δ (la∷ () _)
+
+-- CONTRAST — the two rules that DO mask what they introduce.  Peel is
+-- §2 above; frame-exact Beta's Λ crossing is `interior-Beta-Λ`, and its
+-- slot 0 is REFUSED:
+Beta-Λ-slot0-locked : (Δ : Ctxᵗ)
+  → ¬ (interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ∋tv 0)
+Beta-Λ-slot0-locked Δ (_ , ez , ())
+
+------------------------------------------------------------------------
+-- §3a  THE WITNESS — the frame authorizes strictly more than the move
+--      can produce
+------------------------------------------------------------------------
+
+-- Examples §15b's redex, one binder in.  `Θᵃ` masks the single exterior
+-- binder, so V's frame in the redex is `masked (bind `ℕ) ∷ []` and in the
+-- contractum `unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []`.
+Δᵃ : Ctxᵗ
+Δᵃ = unmasked (bind `ℕ) ∷ []
+
+Θᵃ : CtxMorph
+Θᵃ = morph [] (lock 0 ∷ [])
+
+-- the redex's frame for V, and the contractum's
+Ξold Ξnew Ξtight : Ctxᵗ
+Ξold   = interior Θᵃ Δᵃ
+Ξnew   = interior (morph (`ℕ ∷ binds Θᵃ) (changes Θᵃ)) Δᵃ
+Ξtight = masked (bind `ℕ) ∷ Ξold
+
+_ : Ξold ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+_ : Ξnew ≡ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ = refl
+
+_ : Ξnew ≡ unmasked (bind `ℕ) ∷ Ξold
+_ = interior-TyPeelR `ℕ Θᵃ Δᵃ
+
+-- THE WITNESS TERM: a value whose annotation NAMES the new slot.
+nmᵃ : Term
+nmᵃ = ƛ (` 0) ∙ (` 0)
+
+-- It types at the frame the rule hands V …
+⊢nmᵃ : Ξnew ∣ [] ⊢ nmᵃ ⦂ ((` 0) ⇒ (` 0))
+⊢nmᵃ = ⊢ƛ (wf-var (_ , ez , nameable)) (⊢` here)
+
+-- … and is REFUSED at the tight frame, for the one localized reason
+-- (`wf-var` at a masked slot) — Jeremy's tightness test, run on the
+-- FRAME rather than on the rule.
+¬⊢nmᵃ : ∀ {T} → ¬ (Ξtight ∣ [] ⊢ nmᵃ ⦂ T)
+¬⊢nmᵃ (⊢ƛ (wf-var (_ , ez , ())) _)
+
+-- AND NO MOVED VALUE CAN BE IT.  `wkᴹ 1` never produces a term that
+-- names slot 0, so the extra nameability the frame grants is nameability
+-- NOTHING AT THAT POSITION CAN USE — the frame does not say the truth.
+wkᴹ1-misses-nmᵃ : (V : Term) → wkᴹ 1 V ≢ nmᵃ
+wkᴹ1-misses-nmᵃ (` x)          ()
+wkᴹ1-misses-nmᵃ ($ n)          ()
+wkᴹ1-misses-nmᵃ (ƛ (` X) ∙ N)  ()
+wkᴹ1-misses-nmᵃ (ƛ `ℕ ∙ N)     ()
+wkᴹ1-misses-nmᵃ (ƛ `𝔹 ∙ N)     ()
+wkᴹ1-misses-nmᵃ (ƛ (A ⇒ B) ∙ N) ()
+wkᴹ1-misses-nmᵃ (ƛ (`∀ A) ∙ N) ()
+wkᴹ1-misses-nmᵃ (L · M)        ()
+wkᴹ1-misses-nmᵃ (Λ N)          ()
+wkᴹ1-misses-nmᵃ (L ·[ B , A ]) ()
+wkᴹ1-misses-nmᵃ (M ⟪ Θ , c ⟫)  ()
+
+------------------------------------------------------------------------
+-- §4  FIX (a) — WRAP V IN THE NEW BINDER'S DUAL.  IT LOOPS.
+------------------------------------------------------------------------
+
+-- THE CANDIDATE.  Give the moved value its own boundary, whose frame is
+-- the new binder's DUAL — `dual (morph (A ∷ []) []) ≡ morph [] (lock 0 ∷ [])`,
+-- the same shape frame-exact Beta mints at a crossed `Λ` — and whose
+-- conversion is the identity at V's own (shifted) type:
+--
+--   (wkᴹ 1 V ⟪ morph [] (lock 0 ∷ []) , mkId (`∀ Bᵢ↑) ⟫) ·[ Bᵢ↑ , ` 0 ]
+--
+-- The frame identity is then exact (`interior-Beta-Λ`'s shape at a `bind`
+-- head), and the instantiation node keeps the nameable slot it needs.
+--
+-- THE HAZARD.  An identity conversion at a `∀` type is NECESSARILY a
+-- `` `∀ `` conversion — `conv-id` wants a base type and `conv-idv` a
+-- variable, so `mkId` has no other spelling — hence the inserted layer is
+-- INERT `I-all`, hence the wrapped value sitting under `·[ … ]` is ITSELF
+-- A TYPEELR REDEX.  Fix (a) does not converge: it inserts one layer per
+-- step, forever.
+
+-- the identity at a `∀` is a `` `∀ `` conversion, by definition
+mkId-∀ : (B : Ty) → mkId (`∀ B) ≡ `∀ (mkId B)
+mkId-∀ B = refl
+
+-- … and is therefore INERT at `I-all`
+mkId-∀-inert : (B : Ty) → Inert (mkId (`∀ B))
+mkId-∀-inert B = I-all
+
+-- Values survive the shift the rule performs, and so does inertness —
+-- which is what makes the regress below SELF-FEEDING.
+inert-renᶜ : ∀ {c} (ρ : Renameᵗ) → Inert c → Inert (renᶜ ρ c)
+inert-renᶜ ρ I-idv  = I-idv
+inert-renᶜ ρ I-seal = I-seal
+inert-renᶜ ρ I-fun  = I-fun
+inert-renᶜ ρ I-all  = I-all
+
+value-renᴹ : ∀ {M} (ρ : Renameᵗ) → Value M → Value (renᴹ ρ M)
+value-renᴹ ρ V-$          = V-$
+value-renᴹ ρ V-ƛ          = V-ƛ
+value-renᴹ ρ (V-Λ v)      = V-Λ (value-renᴹ (extᵗ ρ) v)
+value-renᴹ ρ (V-⟪⟫ v ic)  = V-⟪⟫ (value-renᴹ _ v) (inert-renᶜ _ ic)
+
+value-wkᴹ : ∀ {M} (n : ℕ) → Value M → Value (wkᴹ n M)
+value-wkᴹ n v = value-renᴹ (wkN n) v
+
+-- The shape fix (a) creates: a value under the new binder's dual,
+-- applied to the new binder's name.
+loopShape : Term → Ty → Ty → Term
+loopShape V Bᵢ A = (V ⟪ morph [] (lock 0 ∷ []) , mkId (`∀ Bᵢ) ⟫) ·[ Bᵢ , A ]
+
+-- THE PROTOTYPE RULE SET — fix (a), NOT the live rule.  Only the two
+-- rules the regress needs: the repaired TyPeelR and the congruence that
+-- lets it fire under the boundary it just built.
+infix 2 _⊢_-→ᵃ_
+data _⊢_-→ᵃ_ : Ctxᵗ → Term → Term → Set where
+
+  TyPeelR-a : ∀ {Δ V Θ s B A Bᵢ Bₑ} → Value V
+    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+        -→ᵃ (loopShape (wkᴹ 1 V) (renameᵗ (extᵗ suc) Bᵢ) (` 0))
+              ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+  ξᵃ-⟪⟫ : ∀ {Δ M M′ Θ c} → interior Θ Δ ⊢ M -→ᵃ M′
+        → Δ ⊢ M ⟪ Θ , c ⟫ -→ᵃ M′ ⟪ Θ , c ⟫
+
+-- THE REGRESS, IN GENERAL.  A `loopShape` term steps to a `loopShape`
+-- term UNDER ONE MORE BOUNDARY: the fresh dual layer fix (a) inserts is
+-- a `` `∀ `` conversion over a value, so the descent never bottoms out at
+-- the `Λ` — a new layer is planted on top of it at every step.
+--
+-- THE TWO PREMISES REGENERATE.  `Value (wkᴹ 1 V)` is `value-wkᴹ`, and
+-- the conversion typing is `mkId-⊢` from the type's well-formedness
+-- ALONE.  So the answer to "does TyPeelR require anything of `s` that
+-- `mkId` fails?" is NO — `mkId` is exactly what the wrapper carries, and
+-- `mkId-⊢` types it wherever the type is well formed, which the
+-- wrapper's own `env` premise guarantees.
+fixA-loop-step : ∀ {Δ V} (Bᵢ A : Ty) → Value V
+  → (unmasked abst ∷ convCtx (morph [] (lock 0 ∷ [])) Δ) ⊢ᵗ Bᵢ
+    -----------------------------------------------------------------
+  → Δ ⊢ loopShape V Bᵢ A
+      -→ᵃ (loopShape (wkᴹ 1 V) (renameᵗ (extᵗ suc) Bᵢ) (` 0))
+            ⟪ morph (A ∷ []) (lock 0 ∷ []) , instReveal 0 (mkId Bᵢ) ⟫
+fixA-loop-step Bᵢ A v w = TyPeelR-a v (mkId-⊢ w)
+
+------------------------------------------------------------------------
+-- §4a  THE LOOP, ON A CLOSED EXAMPLE
+------------------------------------------------------------------------
+
+-- The smallest instance: a vacuous `Λ` over a numeral, behind a trivial
+-- boundary with a `∀` identity conversion, instantiated at `ℕ.
+--
+--   T₀ = ((ΛY. 3) ⟪ · , (∀Y. id ℕ) ⟫) [ℕ]
+Vᵃ : Term
+Vᵃ = Λ ($ 3)
+
+valVᵃ : Value Vᵃ
+valVᵃ = V-Λ V-$
+
+T₀ : Term
+T₀ = (Vᵃ ⟪ morph [] [] , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
+
+⊢T₀ : [] ∣ [] ⊢ T₀ ⦂ `ℕ
+⊢T₀ = ⊢·[] (env (mw rw[] sw[]) (⊢Λ ⊢$) (conv-all (conv-id base-ℕ))
+                (wf-∀ wf-ℕ))
+            wf-ℕ
+
+-- STEP 1 — fix (a) fires and inserts the first dual layer.
+T₁ : Term
+T₁ = (loopShape (wkᴹ 1 Vᵃ) `ℕ (` 0))
+       ⟪ morph (`ℕ ∷ []) [] , instReveal 0 (id `ℕ) ⟫
+
+stepᵃ₁ : [] ⊢ T₀ -→ᵃ T₁
+stepᵃ₁ = TyPeelR-a valVᵃ (conv-id base-ℕ)
+
+-- `wkᴹ` is the identity on this value and `instReveal 0 (id `ℕ)` is
+-- `id `ℕ`, so T₁ is literally the first layer:
+_ : T₁ ≡ ((Λ ($ 3)) ⟪ morph [] (lock 0 ∷ []) , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ]
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+_ = refl
+
+-- STEP 2 — and again, INSIDE the boundary step 1 built.  The interior is
+-- a `loopShape` term, so `fixA-loop-step` applies verbatim.
+T₂ : Term
+T₂ = ((loopShape (wkᴹ 1 (wkᴹ 1 Vᵃ)) (renameᵗ (extᵗ suc) `ℕ) (` 0))
+        ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , instReveal 0 (mkId `ℕ) ⟫)
+       ⟪ morph (`ℕ ∷ []) [] , instReveal 0 (id `ℕ) ⟫
+
+stepᵃ₂ : [] ⊢ T₁ -→ᵃ T₂
+stepᵃ₂ = ξᵃ-⟪⟫ (fixA-loop-step `ℕ (` 0) (value-wkᴹ 1 valVᵃ) wf-ℕ)
+
+-- THE VERDICT.  T₂ is T₁'s redex REPRODUCED under one more boundary: the
+-- `Λ` is still buried under a fresh `morph [] (lock 0 ∷ [])` layer with a
+-- `` `∀ `` identity conversion, so `TyBeta` never gets to fire and the
+-- term grows by one boundary per step.  `fixA-loop-step` applies to T₂'s
+-- interior exactly as it applied to T₁'s, and its two premises
+-- (`value-wkᴹ`, `mkId-⊢`) are available at every iteration.  Fix (a) has
+-- no normal form.  ****  FIX (a) IS REFUTED.  ****
+_ : T₂ ≡ (((Λ ($ 3)) ⟪ morph [] (lock 0 ∷ []) , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ]
+            ⟪ morph ((` 0) ∷ []) (lock 0 ∷ []) , id `ℕ ⟫)
+           ⟪ morph (`ℕ ∷ []) [] , id `ℕ ⟫
+_ = refl
+
+------------------------------------------------------------------------
+-- §5  FIX (b) — SPLIT ON THE INTERIOR.  THE Λ HALF IS EXACT, AND PROVEN.
+------------------------------------------------------------------------
+
+-- CANONICAL FORMS AT `∀` (proof/Canonical.canon-∀) say the interior of a
+-- `∀`-conversion boundary is a `Λ` over a value or a WRAPPER with a `∀`
+-- conversion — nothing else.  So TyPeelR can SPLIT:
+--
+--   Λ case      instantiate IMMEDIATELY.  The body N already lives one
+--               `abst` binder in (`⊢Λ`), so the new `bind` slot is a slot
+--               N COULD ALREADY NAME: the frame move is a REFINEMENT
+--               `abst → bind`, exactly TyBeta's, and THERE IS NO SHIFT.
+--   wrapper     push the type application inward, as the live rule does.
+--               The tower is finite and bottoms out at a `Λ`.
+--
+-- The Λ case is the one that matters — it is where the instantiation
+-- actually happens — and it is EXACT.  Below: the prototype rule, its
+-- frame identity, and its PRESERVATION.
+
+-- THE FRAME MOVE IS TyBeta's.  `⊑ᵃ`, not just `⊑`: the term transport
+-- accepts it (contrast §3's `TyPeelR-leak-¬⊑ᵃ`).
+TyPeelR-Λ-refinement : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → (unmasked abst ∷ interior Θ Δ)
+      ⊑ᵃ interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+TyPeelR-Λ-refinement A Θ Δ = la∷ (la-uu le-ab) (⊑ᵃ-refl (interior Θ Δ))
+
+-- THE PROTOTYPE RULE SET (fix (b)), NOT the live rule.
+infix 2 _⊢_-→ᵇ_
+data _⊢_-→ᵇ_ : Ctxᵗ → Term → Term → Set where
+
+  -- the Λ interior: instantiate at once, frame REFINED not extended
+  TyPeelR-Λ : ∀ {Δ N Θ s B A Bᵢ Bₑ} → Value N
+    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+        -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+  -- the wrapper interior: the live rule, restricted.  THE LEAK SURVIVES
+  -- HERE (§3 applies verbatim to `W ⟪ Θ′ , `∀ s′ ⟫`), which is why fix
+  -- (b) is a PARTIAL repair — see notes/ShiftAudit.md.
+  TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A Bᵢ Bₑ} → Value W
+    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+    → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+        -→ᵇ (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫) ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+              ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+-- THE Λ CASE PRESERVES TYPES.  The live proof, with `int` replaced by
+-- `⊢retag` along the refinement above — no `⊢rename`, no `wkᴹ`, no
+-- `ren-suc-[0]`.  Every other premise is the live proof verbatim, which
+-- is the point: the repair costs nothing.
+preserve-TyPeelR-Λ : ∀ {Δ N Θ s B A C Bᵢ Bₑ} → Value N
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → Δ ∣ [] ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+    ---------------------------------------------------------------------
+  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
+preserve-TyPeelR-Λ {Δ = Δ} {N = N} {Θ = Θ} {s = s} {B = B} {A = A}
+                   {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
+                   (⊢·[] (env mwᵥ (⊢Λ ⊢N) ⊢c wE) wA)
+  with conv-all-inv ⊢c
+... | A₀ , B₀ , refl , eqE , ⊢s₀
+  with conv-types-unique ⊢s ⊢s₀
+... | refl , refl =
+  env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
+          (mw-changes mwᵥ))
+      (⊢retag (TyPeelR-Λ-refinement A Θ Δ) ⊢N)
+      conv
+      (wf-[]ᵗ (wf-∀⁻ wE) wA)
+  where
+  A′ : Ty
+  A′ = shiftBy (numBinds Θ) A
+
+  eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
+  eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
+
+  eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
+  eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)
+              (trans (subst-at-0 A′ (shiftBodyBy (numBinds Θ) B))
+                     (cong ⇑ᵗ (sym (shiftBy-[]ᵗ (numBinds Θ) B A))))
+
+  conv : convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ instReveal 0 s
+           ∶ Bᵢ ⇝ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
+  conv = subst (λ T → convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ
+                        ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
+               eqT (⊢instReveal {A = A′} 0 ⊢s)
+
+-- DETERMINISM.  The two patterns are DISJOINT — a `Λ` is not a
+-- boundary — and each contractum is a function of the redex.  Note what
+-- the Λ case buys: its contractum does not mention `Bᵢ` at all, so it is
+-- determined by the redex WITHOUT `conv-src-unique`.  (The live rule
+-- needs it, because the pushed-in annotation is premise-determined.)
+detᵇ : ∀ {Δ M M₁ M₂} → Δ ⊢ M -→ᵇ M₁ → Δ ⊢ M -→ᵇ M₂ → M₁ ≡ M₂
+detᵇ (TyPeelR-Λ v ⊢s)  (TyPeelR-Λ v′ ⊢s′)  = refl
+detᵇ (TyPeelR-⟪⟫ {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s} {A = A} v ⊢s)
+     (TyPeelR-⟪⟫ v′ ⊢s′) =
+  cong (λ T → (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫) ·[ renameᵗ (extᵗ suc) T , ` 0 ])
+                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫)
+       (conv-src-unique ⊢s ⊢s′)
+
+-- PROGRESS.  `canon-∀` (proof/Canonical) hands the prototype EXACTLY its
+-- two patterns — a `Λ` over a value, or a wrapper with a `∀` conversion —
+-- so the split is total on a typed redex, and each rule's premises come
+-- off the redex's own derivation (the value from `canon-∀`, the
+-- conversion typing from `conv-all-inv`, as proof/Progress already does
+-- for the live rule).
+progressᵇ-·[] : ∀ {Δ V Θ s B A C} → Value V
+  → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+    ----------------------------------------------------------
+  → Σ[ M ∈ Term ] (Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] -→ᵇ M)
+progressᵇ-·[] v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) with conv-all-inv ⊢c
+... | A₀ , B₀ , refl , eqₑ , ⊢s with canon-∀ v ⊢V
+... | inj₁ (N , vN , refl)          = _ , TyPeelR-Λ vN ⊢s
+... | inj₂ (W , Θ′ , s′ , vW , refl) = _ , TyPeelR-⟪⟫ vW ⊢s
+
+-- THE Λ CASE IS FRAME-EXACT.  Two facts, side by side: the body is NOT
+-- SHIFTED (it stays where `⊢Λ` put it), and the slot it gains was
+-- ALREADY THERE as `abst` — criterion (ii) alone, with (i) vacuous.
+TyPeelR-Λ-no-shift : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (morph (A ∷ binds Θ) (changes Θ)) Δ
+      ≡ unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ
+TyPeelR-Λ-no-shift = interior-TyPeelR
+
+-- and the slot the body could already name, in the redex
+TyPeelR-Λ-slot0-old : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → (unmasked abst ∷ interior Θ Δ) ∋tv 0
+TyPeelR-Λ-slot0-old Θ Δ = _ , ez , nameable
+
+------------------------------------------------------------------------
+-- §6  TYBETA — exact up to refinement
+------------------------------------------------------------------------
+
+-- N's frame, before: `unmasked abst ∷ Δ` (that is `⊢Λ`).  After:
+-- `interior (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ`.  No shift,
+-- one refinement at slot 0, and it is a slot N COULD ALREADY NAME:
+-- criterion (ii) exactly.
+TyBeta-frame : (A : Ty) (Δ : Ctxᵗ)
+  → interior (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ
+TyBeta-frame = interior-TyBeta
+
+TyBeta-refinement : (A : Ty) (Δ : Ctxᵗ)
+  → (unmasked abst ∷ Δ) ⊑ᵃ interior (morph (A ∷ []) []) Δ
+TyBeta-refinement A Δ = la∷ (la-uu le-ab) (⊑ᵃ-refl Δ)
+
+-- The moved TYPE annotation travels the same step: `B` is read at
+-- `unmasked abst ∷ Δ` in the redex (`⊢·[]`'s `∀ B`) and the minted
+-- `reveal 0 B` is checked at `convCtx (morph (A ∷ []) []) Δ`, which IS
+-- `unmasked (bind A) ∷ Δ`.
+TyBeta-convCtx : (A : Ty) (Δ : Ctxᵗ)
+  → convCtx (morph (A ∷ []) []) Δ ≡ unmasked (bind A) ∷ Δ
+TyBeta-convCtx A Δ = refl
+
+------------------------------------------------------------------------
+-- §7  BETA — exact, and the `ƛ` clause
+------------------------------------------------------------------------
+
+-- THE Λ CROSSING (PR #199).  `interior-Beta-Λ`: the image's frame is its
+-- BIRTH frame with the crossed slot MASKED.  §3's `Beta-Λ-slot0-locked`
+-- is the tightness half.
+Beta-Λ-frame : (Δ : Ctxᵗ)
+  → interior (morph [] (lock 0 ∷ [])) (unmasked abst ∷ Δ) ≡ masked abst ∷ Δ
+Beta-Λ-frame = interior-Beta-Λ
+
+-- THE `ƛ` CLAUSE.  A `ƛ` binds a TERM variable, so no type frame changes
+-- and `shiftᴵ` must not shift the type side at all.  It does not: on a
+-- value image it is the IDENTITY, which is correct because a value image
+-- is TERM-CLOSED — and it stays term-closed after PR #199, because
+-- `crossΛ W A` is a BOUNDARY and `env` types its interior at `Γ = []`.
+-- So `shiftᴵ-⊢` still has no premise to discharge, at the crossed image
+-- as much as at the original.
+Beta-ƛ-no-shift : ∀ {W A} → shiftᴵ (ival W A) ≡ ival W A
+Beta-ƛ-no-shift = refl
+
+Beta-ƛ-crossed-no-shift : ∀ {W A} → shiftᴵ (⇑ᴵ (ival W A)) ≡ ⇑ᴵ (ival W A)
+Beta-ƛ-crossed-no-shift = refl
+
+-- … and the two crossings DO NOT INTERFERE (design law: simultaneity).
+-- Crossing a `ƛ` then a `Λ` is crossing a `Λ` then a `ƛ`, on the nose,
+-- for EVERY image — which is what makes the two clauses of `substᵐ`
+-- independent after the crossΛ change.
+⇑ᴵ-shiftᴵ-comm : (i : Img) → ⇑ᴵ (shiftᴵ i) ≡ shiftᴵ (⇑ᴵ i)
+⇑ᴵ-shiftᴵ-comm (ivar x)   = refl
+⇑ᴵ-shiftᴵ-comm (ival W A) = refl
+
+-- THE `ƛ` CASE OF `⊢substᵐ`, RE-CONFIRMED: the type context is untouched
+-- and the value image is carried through unchanged.  (This IS
+-- `shiftᴵ-⊢`; it is restated to record that the `ival` clause needs no
+-- weakening after the wrapper was introduced.)
+Beta-ƛ-image : ∀ {W} → Δ ⊢ᵗ A → Δ ∣ [] ⊢ W ⦂ A
+  → Δ ∣ (B ∷ Γ) ⊢ⁱ shiftᴵ (ival W A) ⦂ A
+Beta-ƛ-image w ⊢W = shiftᴵ-⊢ (⊢ival w ⊢W)
+
+-- The crossed image, one `Λ` in, then under a `ƛ`: still term-closed,
+-- still frame-exact.
+Beta-Λƛ-image : ∀ {W} → Δ ⊢ᵗ A → Δ ∣ [] ⊢ W ⦂ A
+  → (unmasked abst ∷ Δ) ∣ (B ∷ ⤊ Γ) ⊢ⁱ shiftᴵ (⇑ᴵ (ival W A)) ⦂ ⇑ᵗ A
+Beta-Λƛ-image w ⊢W = shiftᴵ-⊢ (⇑ᴵ-⊢1 (⊢ival w ⊢W))
+
+------------------------------------------------------------------------
+-- §8  CANCELR / IDPUSH — exact, inner AND outer
+------------------------------------------------------------------------
+
+-- THE INNER FRAME (the one V lives in) is preserved ON THE NOSE.
+Move-inner-frame : (Θ₁ Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
+  → interior (Θ₁ ⋉ Θ₂) (interior (rewind Θ₂) Δ) ≡ interior Θ₁ (interior Θ₂ Δ)
+Move-inner-frame = interior-⋉-rewind
+
+-- THE OUTER FRAME.  The outer boundary's interior — the position the
+-- INNER BOUNDARY node occupies — becomes `interior (rewind Θ₂) Δ`, which
+-- is Θ₂'s BIND BLOCK over the plain exterior: the locks have travelled
+-- inward.  Nothing but the inner boundary sits there, and the inner
+-- boundary REAPPLIES them (`_⋉_` puts Θ₂'s whole change list at the tail
+-- of Θ₁'s, where `applyChanges` runs it FIRST), which is exactly why the
+-- composite above is an equality.  Nothing else moves: both conversions
+-- are RE-MINTED (`mkId` / `unseal`), not transported.
+Move-outer-frame : (Θ₂ : CtxMorph) {Δ : Ctxᵗ} → Δ ⊢ᵐ Θ₂
+  → interior (rewind Θ₂) Δ ≡ pushBinds (binds Θ₂) Δ
+Move-outer-frame = interior-rewind
+
+-- … and the outer frame adds no binder beyond Θ₂'s own: `rewind` carries
+-- Θ₂'s binds and only rewinds its changes.
+Move-outer-numBinds : (Θ₂ : CtxMorph) → numBinds (rewind Θ₂) ≡ numBinds Θ₂
+Move-outer-numBinds Θ₂ = refl
+
+Move-inner-numBinds : (Θ₁ Θ₂ : CtxMorph) → numBinds (Θ₁ ⋉ Θ₂) ≡ numBinds Θ₁
+Move-inner-numBinds Θ₁ Θ₂ = refl
+
+------------------------------------------------------------------------
+-- §9  DROP$ — the frame change in the OTHER direction, and why it is
+--     vacuous
+------------------------------------------------------------------------
+
+-- `($ n) ⟪ Θ , id A ⟫ → $ n` moves the numeral from `interior Θ Δ` OUT to
+-- `Δ`: the bind prefix disappears and Θ's locks are lifted, so the new
+-- frame is STRICTLY MORE NAMEABLE.  That is a frame gain in the direction
+-- the criterion also forbids — but it is VACUOUS, because a numeral
+-- names no type variable at all: `⊢$` types it at EVERY type context and
+-- at every term context.
+Drop$-vacuous : (n : ℕ) (Δ : Ctxᵗ) (Γ : Ctx) → Δ ∣ Γ ⊢ ($ n) ⦂ `ℕ
+Drop$-vacuous n Δ Γ = ⊢$
+
+-- AND NO OTHER TERM CAN TAKE THE STEP.  The rule's left-hand side is the
+-- NUMERAL ITSELF — `Drop$` is the only rule whose interior pattern is a
+-- constructor rather than a variable — so there is nothing to generalize.
+-- Progress needs no more: a closed value at a base type IS a numeral
+-- (proof/Canonical.canon-base), which is why the syntactic restriction
+-- costs nothing.
+Drop$-only-numerals : ∀ {Δ M M′} → Δ ⊢ M -→ M′
+  → (∀ {n Θ A} → M ≡ ($ n) ⟪ Θ , id A ⟫ → M′ ≡ $ n)
+Drop$-only-numerals (TyBeta v)  ()
+Drop$-only-numerals (Beta w)    ()
+Drop$-only-numerals (Peel v w)  ()
+Drop$-only-numerals (TyPeelR v ⊢s) ()
+Drop$-only-numerals (CancelR v d)  ()
+Drop$-only-numerals (Drop$ b)      refl = refl
+Drop$-only-numerals (IdPush v d)   ()
+Drop$-only-numerals (ξ-·-l st)     ()
+Drop$-only-numerals (ξ-·-r v st)   ()
+Drop$-only-numerals (ξ-·[] st)     ()
+Drop$-only-numerals (ξ-Λ st)       ()
+Drop$-only-numerals (ξ-⟪⟫ st)      refl = ⊥-elim (numeral-¬step st)
+  where
+  numeral-¬step : ∀ {Δ n M′} → Δ ⊢ ($ n) -→ M′ → ⊥
+  numeral-¬step ()
+
+------------------------------------------------------------------------
+-- §10  THE ξ RULES — nothing moves, and the frames are the binder's own
+------------------------------------------------------------------------
+
+-- Each congruence reduces a subterm IN PLACE, at the very type context
+-- the corresponding TYPING rule reads it on.  Both facts are `refl`:
+--
+--   ξ-Λ    premise at `unmasked abst ∷ Δ`  =  `⊢Λ`'s premise context
+--   ξ-⟪⟫   premise at `interior Θ Δ`       =  `env`'s premise context
+--
+-- (`ξ-·-l`, `ξ-·-r`, `ξ-·[]` do not change the context at all.)
+ξ-Λ-frame : (Δ : Ctxᵗ) → (unmasked abst ∷ Δ) ≡ (unmasked abst ∷ Δ)
+ξ-Λ-frame Δ = refl
+
+ξ-⟪⟫-frame : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → interior Θ Δ ≡ pushBinds (binds Θ) (scope Θ Δ)
+ξ-⟪⟫-frame Θ Δ = refl
+
+------------------------------------------------------------------------
+-- §11  DEAD SHIFT MACHINERY
+------------------------------------------------------------------------
+
+-- `shiftᵐ = renⁿ suc` (strong.TermSubst §5) and `canon-shiftᵐ`
+-- (proof/Canonicity) have NO CONSUMERS after PR #199: frame-exact
+-- substitution weakens an image with `shiftᴵ`, which is `there` on a
+-- variable image and the IDENTITY on a value image (§7), so the
+-- term-variable shift is never applied to a term.  `renⁿ` itself is
+-- LIVE — `⊢renⁿ` at the identity renaming is what proves `⊢weakenⁿ`, the
+-- lemma that lets a term-closed image type at an arbitrary term context.
+--
+-- Recorded, not deleted: an audit proposes, it does not land.
+shiftᵐ-is-renⁿ : (M : Term) → shiftᵐ M ≡ renⁿ suc M
+shiftᵐ-is-renⁿ M = refl

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -16,14 +16,22 @@ module strong.proof.ShiftAudit where
 -- FRAME LEAK, even when the subterm's shifted indices cannot reach it:
 -- the frame must SAY THE TRUTH about what the subterm may name.
 --
+-- THE REPAIR IS INSTALLED (2026-09-08).  The one leak the audit found —
+-- TyPeelR's moved value gained the new binder's slot UNMASKED — is closed
+-- in the LIVE rules: `TyPeelR` is now the two clauses `TyPeelR-Λ` and
+-- `TyPeelR-⟪⟫` (strong.Reduction).  So this module records the audit's
+-- FINDINGS against the live rule set: the per-site frame identities, the
+-- witness of what the leak was, the machine refutation of the repair that
+-- LOOPS, and the tower measure that makes the installed one terminate.
+--
 --   §1  the site table (comment)
 --   §2  Peel                  — EXACT, by (†)
---   §3  TyPeelR (V's frame)   — ****  LEAK  ****
---   §4  fix (a), "wrap V in the new binder's dual" — LOOPS
---   §5  fix (b), "split on the interior" — the Λ half, PROVEN EXACT
---   §5b fix (b′), the wrapper half — the frame identity, EXACT
---   §5c fix (b′) AS A RULE — preservation, determinism, progress, frame
---       exactness, the tower measure, and a closed two-deep run
+--   §3  TyPeelR (V's frame)   — the LEAK, as it stood, and its witness
+--   §4  fix (a), "wrap V in the new binder's dual" — REFUTED, it LOOPS
+--   §5  TyPeelR-Λ             — the live clause: EXACT, no shift at all
+--   §5b TyPeelR-⟪⟫            — the live clause: `wkᴹ 1` plus one lock
+--   §5c the frame exactness of the two clauses, the tower measure, and a
+--       closed two-deep run with every state typed
 --   §6  TyBeta                — exact up to refinement
 --   §7  Beta                  — exact (crossΛ), and the `ƛ` clause
 --   §8  CancelR / IdPush      — exact, inner AND outer
@@ -31,8 +39,9 @@ module strong.proof.ShiftAudit where
 --   §10 the ξ rules           — nothing moves
 --   §11 dead shift machinery
 --
--- The verdict table with the fix candidates and their hazards is
+-- The verdict table, with the fix candidates and their hazards, is
 -- notes/ShiftAudit.md; the frame-identity table it feeds is Design.md §7.
+-- The tightness tests for the two clauses are Examples §15b.
 
 open import Data.Nat using (ℕ; zero; suc; _+_; _∸_)
 open import Data.List using (List; []; _∷_; _++_; map; length)
@@ -56,12 +65,12 @@ open import strong.Reduction
 open import strong.proof.Preserve
   using (⊢instReveal; wf-[]ᵗ; wf-∀⁻; ∀-inj; subst-at-0; shiftBy-[]ᵗ
         ; ren-suc-[0])
-open import strong.proof.PeelDual
-  using (interior-dual; applyChanges-++; ⊢ˢ-++)
+open import strong.Preservation using (preservation)
+open import strong.proof.PeelDual using (interior-dual)
 open import strong.proof.MoveScope using (interior-rewind; interior-⋉-rewind)
 open import strong.proof.Canonical using (canon-∀)
 open import strong.Examples
-  using (interior-TyBeta; interior-TyPeelR; interior-Beta-Λ; prb; val-prb)
+  using (interior-TyBeta; interior-TyPeelR; interior-Beta-Λ)
 
 private
   variable
@@ -79,14 +88,18 @@ private
 -- substituted (`grep wkᴹ ⇑ᴹ renᴹ renⁿ shiftᵐ crossΛ substᵐ`):
 --
 --   RULES that move a subterm
---     Peel      `wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫`          §2  EXACT
---     TyPeelR   `wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ]`   §3  LEAK
---     TyBeta    `N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫`       §6  refinement
---     Beta      `N [ W ∶ A ]ᵐ`, i.e. `substᵐ`/`crossΛ`       §7  EXACT
---     CancelR   `V ⟪ Θ₁ ⋉ Θ₂ , … ⟫ ⟪ rewind Θ₂ , … ⟫`        §8  EXACT
---     IdPush    (same two frames)                            §8  EXACT
---     Drop$     `($ n) ⟪ Θ , id A ⟫ → $ n`                   §9  vacuous
---     ξ-*       nothing moves                                §10 —
+--     Peel        `wkᴹ (numBinds Θ) W ⟪ dual Θ , s ⟫`        §2  EXACT
+--     TyPeelR     `wkᴹ 1 V ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ]`
+--                 the SINGLE rule, now REPLACED                §3  LEAK
+--     TyPeelR-Λ   `N ⟪ morph (A ∷ binds Θ) (changes Θ) , … ⟫` §5  EXACT
+--     TyPeelR-⟪⟫  `wkᴹ 1` on the moved boundary, plus
+--                 `addLock0` on its own change list           §5b EXACT
+--     TyBeta      `N ⟪ morph (A ∷ []) [] , reveal 0 B ⟫`      §6  refinement
+--     Beta        `N [ W ∶ A ]ᵐ`, i.e. `substᵐ`/`crossΛ`      §7  EXACT
+--     CancelR     `V ⟪ Θ₁ ⋉ Θ₂ , … ⟫ ⟪ rewind Θ₂ , … ⟫`       §8  EXACT
+--     IdPush      (same two frames)                           §8  EXACT
+--     Drop$       `($ n) ⟪ Θ , id A ⟫ → $ n`                  §9  vacuous
+--     ξ-*         nothing moves                               §10 —
 --
 --   TRANSPORTS, not rules (no term is moved by a reduction; these are the
 --   lemmas the cases above are PROVED with, and each one's `Ren`/`⊑ᵃ`
@@ -119,10 +132,16 @@ Peel-slot0-locked : (As : List Ty) (Δ : Ctxᵗ)
 Peel-slot0-locked As Δ (_ , ez , ())
 
 ------------------------------------------------------------------------
--- §3  TYPEELR — THE LEAK
+-- §3  TYPEELR — THE LEAK, AS IT STOOD BEFORE THE SPLIT
 ------------------------------------------------------------------------
 
--- THE MOVE.  `V`, the interior of the crossed boundary, is typed at
+-- The single rule is GONE (strong.Reduction carries `TyPeelR-Λ` and
+-- `TyPeelR-⟪⟫` instead), so this section is the RECORD of what the leak
+-- was and of what closing it required.  Everything below is a statement
+-- about FRAMES, and every frame here is still a frame the live clauses
+-- produce, so nothing in it is stale.
+
+-- THE MOVE.  `V`, the interior of the crossed boundary, was typed at
 -- `interior Θ Δ` in the redex and at
 --
 --   interior (morph (A ∷ binds Θ) (changes Θ)) Δ
@@ -392,146 +411,39 @@ _ : T₂ ≡ (((Λ ($ 3)) ⟪ morph [] (lock 0 ∷ []) , `∀ (id `ℕ) ⟫) ·[
 _ = refl
 
 ------------------------------------------------------------------------
--- §5  FIX (b) — SPLIT ON THE INTERIOR.  THE Λ HALF IS EXACT, AND PROVEN.
+-- §5  TYPEELR-Λ — THE LIVE CLAUSE.  EXACT, AND THERE IS NO SHIFT.
 ------------------------------------------------------------------------
 
 -- CANONICAL FORMS AT `∀` (proof/Canonical.canon-∀) say the interior of a
 -- `∀`-conversion boundary is a `Λ` over a value or a WRAPPER with a `∀`
--- conversion — nothing else.  So TyPeelR can SPLIT:
+-- conversion — nothing else.  That is what lets TyPeelR SPLIT, and the
+-- split is what closes §3's leak:
 --
---   Λ case      instantiate IMMEDIATELY.  The body N already lives one
---               `abst` binder in (`⊢Λ`), so the new `bind` slot is a slot
---               N COULD ALREADY NAME: the frame move is a REFINEMENT
---               `abst → bind`, exactly TyBeta's, and THERE IS NO SHIFT.
---   wrapper     push the type application inward, as the live rule does.
---               The tower is finite and bottoms out at a `Λ`.
+--   TyPeelR-Λ    instantiate IMMEDIATELY.  The body N already lives one
+--                `abst` binder in (`⊢Λ`), so the new `bind` slot is a
+--                slot N COULD ALREADY NAME: the frame move is a
+--                REFINEMENT `abst → bind`, exactly TyBeta's, and THERE
+--                IS NO SHIFT AT ALL.
+--   TyPeelR-⟪⟫   push the type application inward, as the single rule
+--                did, and mask the new binder in the MOVED BOUNDARY's
+--                own change list (§5b).  The tower is finite and bottoms
+--                out at the `Λ`, so the descent terminates (§5c₂).
 --
--- The Λ case is the one that matters — it is where the instantiation
--- actually happens — and it is EXACT.  Below: the prototype rule, its
--- frame identity, and its PRESERVATION.
+-- Preservation, determinism and progress for the pair live where they
+-- belong: proof/Preserve (`preserve-TyPeelR-Λ`, `preserve-TyPeelR-⟪⟫`),
+-- strong.Reduction (`det`) and proof/Progress (`progress-·[]-∀conv`).
+-- What this module keeps is the FRAME arithmetic behind them.
 
--- THE FRAME MOVE IS TyBeta's.  `⊑ᵃ`, not just `⊑`: the term transport
--- accepts it (contrast §3's `TyPeelR-leak-¬⊑ᵃ`).
+-- THE Λ CLAUSE'S FRAME MOVE IS TyBeta's.  `⊑ᵃ`, not just `⊑`: the term
+-- transport accepts it, in flat contrast to §3's `TyPeelR-leak-¬⊑ᵃ`.
+-- This is `preserve-TyPeelR-Λ`'s own `refine`, stated on its own.
 TyPeelR-Λ-refinement : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
   → (unmasked abst ∷ interior Θ Δ)
       ⊑ᵃ interior (morph (A ∷ binds Θ) (changes Θ)) Δ
 TyPeelR-Λ-refinement A Θ Δ = la∷ (la-uu le-ab) (⊑ᵃ-refl (interior Θ Δ))
 
--- THE MOVED BOUNDARY'S OWN LOCK (fix (b′), §5b).  `lock 0` is appended
--- at the TAIL of the boundary's own change list, where `applyChanges`
--- runs it FIRST — the position the scope move `_⋉_` puts its travelling
--- changes in.  The definition sits here because the rule below mentions
--- it; §5b is where the choice is justified and the frame identity proved.
-addLock0 : CtxMorph → CtxMorph
-addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
-
--- THE PROTOTYPE RULE SET (fix (b) + fix (b′)), NOT the live rule.
-infix 2 _⊢_-→ᵇ_
-data _⊢_-→ᵇ_ : Ctxᵗ → Term → Term → Set where
-
-  -- the Λ interior: instantiate at once, frame REFINED not extended
-  TyPeelR-Λ : ∀ {Δ N Θ s B A Bᵢ Bₑ} → Value N
-    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-    → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-        -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
-
-  -- THE WRAPPER INTERIOR, REPAIRED (fix (b′)).  The moved boundary is
-  -- SHIFTED exactly as the live rule shifts it — `wkᴹ 1` on a boundary is
-  -- `renᴹ (extN (numBinds Θ′) suc)` on its interior, `renᴮ suc` on its
-  -- frame and `renᶜ (extN (numBinds Θ′) suc)` on its conversion — and
-  -- then `lock 0` is APPENDED to its own (shifted) change list.  NO NEW
-  -- WRAPPER IS MINTED, which is what makes this not fix (a) (§4).
-  -- `TyPeelR-⟪⟫-wkᴹ` (§5c) is the equation relating the contractum's
-  -- inner value to `wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫)`.
-  TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A Bᵢ Bₑ} → Value W
-    → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-    → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-        -→ᵇ ((renᴹ (extN (numBinds Θ′) suc) W
-                ⟪ addLock0 (renᴮ suc Θ′)
-                , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-               ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-              ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
-
-  -- the ONE congruence the tower run needs: the next redex sits inside
-  -- the boundary the previous step built
-  ξᵇ-⟪⟫ : ∀ {Δ M M′ Θ c} → interior Θ Δ ⊢ M -→ᵇ M′
-        → Δ ⊢ M ⟪ Θ , c ⟫ -→ᵇ M′ ⟪ Θ , c ⟫
-
--- THE Λ CASE PRESERVES TYPES.  The live proof, with `int` replaced by
--- `⊢retag` along the refinement above — no `⊢rename`, no `wkᴹ`, no
--- `ren-suc-[0]`.  Every other premise is the live proof verbatim, which
--- is the point: the repair costs nothing.
-preserve-TyPeelR-Λ : ∀ {Δ N Θ s B A C Bᵢ Bₑ} → Value N
-  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-  → Δ ∣ [] ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-    ---------------------------------------------------------------------
-  → Δ ∣ [] ⊢ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
-preserve-TyPeelR-Λ {Δ = Δ} {N = N} {Θ = Θ} {s = s} {B = B} {A = A}
-                   {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
-                   (⊢·[] (env mwᵥ (⊢Λ ⊢N) ⊢c wE) wA)
-  with conv-all-inv ⊢c
-... | A₀ , B₀ , refl , eqE , ⊢s₀
-  with conv-types-unique ⊢s ⊢s₀
-... | refl , refl =
-  env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
-          (mw-changes mwᵥ))
-      (⊢retag (TyPeelR-Λ-refinement A Θ Δ) ⊢N)
-      conv
-      (wf-[]ᵗ (wf-∀⁻ wE) wA)
-  where
-  A′ : Ty
-  A′ = shiftBy (numBinds Θ) A
-
-  eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
-  eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
-
-  eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
-  eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)
-              (trans (subst-at-0 A′ (shiftBodyBy (numBinds Θ) B))
-                     (cong ⇑ᵗ (sym (shiftBy-[]ᵗ (numBinds Θ) B A))))
-
-  conv : convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ instReveal 0 s
-           ∶ Bᵢ ⇝ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
-  conv = subst (λ T → convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ
-                        ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
-               eqT (⊢instReveal {A = A′} 0 ⊢s)
-
--- DETERMINISM.  The three patterns are DISJOINT — a `Λ` is not a
--- boundary, and neither TyPeelR pattern is a boundary at the top — and
--- each contractum is a function of the redex.  Note what the Λ case
--- buys: its contractum does not mention `Bᵢ` at all, so it is determined
--- by the redex WITHOUT `conv-src-unique`.  (The live rule needs it,
--- because the pushed-in annotation is premise-determined; so does the
--- repaired wrapper case, for exactly the same reason.)
-detᵇ : ∀ {Δ M M₁ M₂} → Δ ⊢ M -→ᵇ M₁ → Δ ⊢ M -→ᵇ M₂ → M₁ ≡ M₂
-detᵇ (TyPeelR-Λ v ⊢s)  (TyPeelR-Λ v′ ⊢s′)  = refl
-detᵇ (TyPeelR-⟪⟫ {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s} {A = A} v ⊢s)
-     (TyPeelR-⟪⟫ v′ ⊢s′) =
-  cong (λ T → ((renᴹ (extN (numBinds Θ′) suc) W
-                  ⟪ addLock0 (renᴮ suc Θ′)
-                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-                 ·[ renameᵗ (extᵗ suc) T , ` 0 ])
-                ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫)
-       (conv-src-unique ⊢s ⊢s′)
-detᵇ (ξᵇ-⟪⟫ st) (ξᵇ-⟪⟫ st′) = cong (λ M → M ⟪ _ , _ ⟫) (detᵇ st st′)
-
--- PROGRESS.  `canon-∀` (proof/Canonical) hands the prototype EXACTLY its
--- two patterns — a `Λ` over a value, or a wrapper with a `∀` conversion —
--- so the split is total on a typed redex, and each rule's premises come
--- off the redex's own derivation (the value from `canon-∀`, the
--- conversion typing from `conv-all-inv`, as proof/Progress already does
--- for the live rule).
-progressᵇ-·[] : ∀ {Δ V Θ s B A C} → Value V
-  → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-    ----------------------------------------------------------
-  → Σ[ M ∈ Term ] (Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] -→ᵇ M)
-progressᵇ-·[] v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) with conv-all-inv ⊢c
-... | A₀ , B₀ , refl , eqₑ , ⊢s with canon-∀ v ⊢V
-... | inj₁ (N , vN , refl)          = _ , TyPeelR-Λ vN ⊢s
-... | inj₂ (W , Θ′ , s′ , vW , refl) = _ , TyPeelR-⟪⟫ vW ⊢s
-
--- THE Λ CASE IS FRAME-EXACT.  Two facts, side by side: the body is NOT
--- SHIFTED (it stays where `⊢Λ` put it), and the slot it gains was
+-- … AND THE BODY IS NOT SHIFTED.  Two facts side by side: the frame it
+-- lands in is its old frame with ONE entry in front, and that entry was
 -- ALREADY THERE as `abst` — criterion (ii) alone, with (i) vacuous.
 TyPeelR-Λ-no-shift : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
   → interior (morph (A ∷ binds Θ) (changes Θ)) Δ
@@ -544,97 +456,50 @@ TyPeelR-Λ-slot0-old : (Θ : CtxMorph) (Δ : Ctxᵗ)
 TyPeelR-Λ-slot0-old Θ Δ = _ , ez , nameable
 
 ------------------------------------------------------------------------
--- §5b  FIX (b′) — CLOSING THE WRAPPER CASE TOO: THE NEW BINDER IS
---      MASKED IN THE MOVED BOUNDARY'S OWN FRAME
+-- §5b  TYPEELR-⟪⟫ — THE LIVE CLAUSE.  THE NEW BINDER IS MASKED IN THE
+--      MOVED BOUNDARY'S OWN FRAME.
 ------------------------------------------------------------------------
 
 -- `canon-∀` says the thing TyPeelR moves in the non-Λ case is A BOUNDARY.
 -- A boundary carries its own change list — so the new binder can be
 -- masked for it WITHOUT a second wrapper (which is what loops, §4) and
--- WITHOUT resolving anything (which is what fix (c) pays, §13c of
--- Examples): append `lock 0` to the moved boundary's OWN changes, at the
--- TAIL, where `applyChanges` runs it FIRST — exactly the position the
--- SCOPE MOVE `_⋉_` puts the travelling changes in.  (`addLock0` itself is
--- defined in §5 above, where the rule that uses it is stated.)
+-- WITHOUT resolving anything (which is what fix (c) pays; Design.md §9
+-- and Examples §13c): append `lock 0` to the moved boundary's OWN
+-- changes, at the TAIL, where `applyChanges` runs it FIRST — exactly the
+-- position the SCOPE MOVE `_⋉_` puts the travelling changes in.
+--
+-- `addLock0` and its induced-context identities are strong.CtxMorph §5;
+-- the crossing itself is `⊢addLock0-cross` at `Ren-addLock0`
+-- (strong.TermSubst §6), and the frame identity at the shift the rule
+-- performs is `interior-addLock0-cross`.  Restated here at the rule's own
+-- two contexts:
 
--- the two list facts the frame identity needs
-map-renᶠ-shiftScope : (S : List Change)
-  → map (renᶠ suc) S ≡ shiftScope 1 S
-map-renᶠ-shiftScope []             = refl
-map-renᶠ-shiftScope (unlock X ∷ S) =
-  cong (unlock (suc X) ∷_) (map-renᶠ-shiftScope S)
-map-renᶠ-shiftScope (lock X ∷ S)   =
-  cong (lock (suc X) ∷_) (map-renᶠ-shiftScope S)
-
--- `shiftScope 1` steps a change list PAST ONE ENTRY: the entry is
--- untouched and the list acts on the tail.  (`applyChanges-shiftScope`,
--- proof/MoveScope, is this past a whole `pushBinds` prefix; here the
--- prefix is one arbitrary entry, MASKED included.)
-applyChanges-shift1 : (S : List Change) (E : Ent) (Δ : Ctxᵗ)
-  → applyChanges (shiftScope 1 S) (E ∷ Δ) ≡ E ∷ applyChanges S Δ
-applyChanges-shift1 []             E Δ = refl
-applyChanges-shift1 (unlock X ∷ S) E Δ =
-  cong (unmask (suc X)) (applyChanges-shift1 S E Δ)
-applyChanges-shift1 (lock X ∷ S)   E Δ =
-  cong (mask (suc X)) (applyChanges-shift1 S E Δ)
-
--- THE FRAME IDENTITY.  The moved boundary's interior frame is its BIRTH
--- frame with the new binder inserted BELOW the bind prefix and MASKED —
--- the very shape (†) gives Peel's crossing argument and `interior-Beta-Λ`
--- gives Beta's.  Nothing gained, nothing lost.
-interior-addLock0 : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
-  → interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
-      ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
-interior-addLock0 Θ′ C Δ =
-  cong (pushBinds (map ⇑ᵗ (binds Θ′)))
-       (trans (applyChanges-++ (map (renᶠ suc) (changes Θ′)) (lock 0 ∷ [])
-                               (unmasked (bind C) ∷ Δ))
-              (trans (cong (λ S → applyChanges S (masked (bind C) ∷ Δ))
-                           (map-renᶠ-shiftScope (changes Θ′)))
-                     (applyChanges-shift1 (changes Θ′) (masked (bind C)) Δ)))
-
--- … AND THE MOVED BOUNDARY CROSSES BY `⊢rename` ALONE.  `wkᴹ 1` on a
--- boundary renames its interior at `extN (numBinds Θ′) suc`
--- (strong.TermSubst, `renᴹ`'s wrapper clause), and that is exactly the
--- renaming from the birth frame into the frame above — no `⊢retag`, no
--- `le-mu`.  This is what makes (b′) exact.
-Ren-addLock0 : (Θ′ : CtxMorph) (E : Ent) (Δ : Ctxᵗ)
-  → Ren (extN (numBinds Θ′) suc) (interior Θ′ Δ)
-        (pushBinds (map ⇑ᵗ (binds Θ′)) (E ∷ scope Θ′ Δ))
-Ren-addLock0 Θ′ E Δ = ren-pushBinds (binds Θ′) suc (mkRen es)
-
--- The `lock 0` is LEGAL where it acts: slot 0 of the new frame is
--- nameable (§3's `TyPeelR-slot0-nameable` — the leak's own slot is
--- exactly what authorizes the lock that closes it), so `sw-l` applies.
+-- The appended `lock 0` is LEGAL where it acts: slot 0 of the new frame
+-- is nameable (§3's `TyPeelR-slot0-nameable` — THE LEAK'S OWN SLOT IS
+-- EXACTLY WHAT AUTHORIZES THE LOCK THAT CLOSES IT), so `sw-l` applies.
 addLock0-sw-l : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
   → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ˢ (lock 0 ∷ [])
 addLock0-sw-l A Θ Δ = sw-l (TyPeelR-slot0-nameable A Θ Δ) sw[]
 
--- WHAT THAT LEAVES: `Δ ⊢ᵐ addLock0 (renᴮ suc Θ′)` (the reps by `⊢ʳ-ren`,
--- the changes by `⊢ˢ-ren` plus `addLock0-sw-l` and `⊢ˢ-++`), and the
--- moved boundary's CONVERSION re-typed at
--- `convCtx (addLock0 (renᴮ suc Θ′)) …` — where the appended lock is
--- LIFTED (`applyUnlocks` skips locks), so the conversion context is the
--- renamed one and `conv-ren` suffices.  Neither is new machinery; both
--- are the moves `⊢rename`'s own (env) case already makes.  BOTH ARE NOW
--- DONE: §5c assembles them into `⊢addLock0-cross` and lands (b′) as a
--- rule.
+-- THE FRAME IDENTITY.  The moved boundary's interior frame is its BIRTH
+-- frame with the new binder inserted BELOW the bind prefix and MASKED —
+-- the very shape (†) gives Peel's crossing argument and
+-- `interior-Beta-Λ` gives Beta's.  Nothing gained, nothing lost.
+interior-addLock0-shift : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
+  → interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
+      ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
+interior-addLock0-shift = interior-addLock0-cross
 
 ------------------------------------------------------------------------
--- §5c  FIX (b′) AS A RULE — the shift is `wkᴹ 1`'s own, plus one lock
+-- §5c  IT IS `wkᴹ 1` PLUS ONE LOCK, ON THE NOSE
 ------------------------------------------------------------------------
 
--- THE RULE IS `TyPeelR-⟪⟫` IN §5.  This section (i) relates its
--- contractum to `wkᴹ 1`, (ii) proves its PRESERVATION, (iii) records its
--- FRAME EXACTNESS, (iv) gives the TOWER MEASURE that separates it from
--- fix (a)'s regress, and (v) runs it on a closed two-deep tower.
-
--- (i) THE EQUATION.  The contractum's inner value IS `wkᴹ 1` of the
--- redex's inner value, with `lock 0` appended to the moved boundary's own
--- change list — nothing else.  `wkᴹ 1` on a boundary renames the interior
--- at `extN (numBinds Θ′) suc`, the frame by `renᴮ suc` and the conversion
--- at `extN (numBinds Θ′) suc` (`renᴹ`'s wrapper clause), and that is
--- exactly what the rule writes.
+-- The contractum's inner value IS `wkᴹ 1` of the redex's inner value,
+-- with `lock 0` appended to the moved boundary's own change list —
+-- nothing else.  `wkᴹ 1` on a boundary renames the interior at
+-- `extN (numBinds Θ′) suc`, the frame by `renᴮ suc` and the conversion at
+-- `extN (numBinds Θ′) suc` (`renᴹ`'s wrapper clause), and that is exactly
+-- what the rule writes.
 addLock0ᵛ : Term → Term
 addLock0ᵛ (` x)          = ` x
 addLock0ᵛ ($ n)          = $ n
@@ -651,184 +516,14 @@ TyPeelR-⟪⟫-wkᴹ : (W : Term) (Θ′ : CtxMorph) (s′ : Conv)
            , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
 TyPeelR-⟪⟫-wkᴹ W Θ′ s′ = refl
 
--- (ii) PRESERVATION.  Two facts about `applyUnlocks` first: the appended
--- lock is LIFTED, so the CONVERSION CONTEXT is the plainly renamed one
--- and `conv-ren` suffices.  This is what makes the repair free.
-applyUnlocks-++ : (S T : List Change) (Δ : Ctxᵗ)
-  → applyUnlocks (S ++ T) Δ ≡ applyUnlocks S (applyUnlocks T Δ)
-applyUnlocks-++ []             T Δ = refl
-applyUnlocks-++ (unlock X ∷ S) T Δ =
-  cong (unmask X) (applyUnlocks-++ S T Δ)
-applyUnlocks-++ (lock X ∷ S)   T Δ = applyUnlocks-++ S T Δ
-
-unlockedScope-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → unlockedScope (addLock0 Θ) Δ ≡ unlockedScope Θ Δ
-unlockedScope-addLock0 Θ Δ = applyUnlocks-++ (changes Θ) (lock 0 ∷ []) Δ
-
-convCtx-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
-  → convCtx (addLock0 Θ) Δ ≡ convCtx Θ Δ
-convCtx-addLock0 Θ Δ =
-  cong (pushBinds (binds Θ)) (unlockedScope-addLock0 Θ Δ)
-
--- THE CROSSING LEMMA — the (b′) analogue of `⊢crossΛ` (strong.TermSubst)
--- and of PeelDual's `crossing`.  A boundary crosses ONE NEW BIND SLOT,
--- masking it in its own frame.  Every premise is one move `⊢rename`'s
--- (env) case already makes:
---
---   FRAME     reps by `⊢ʳ-ren` at `ren-unlockedScope` (the appended lock
---             is lifted); changes by `⊢ˢ-++` — `⊢ˢ-ren` for the shifted
---             list, over the frame the appended lock leaves, and `sw-l`
---             for the lock itself, whose slot IS nameable.
---   INTERIOR  `⊢rename` at `Ren-addLock0` (§5b) ALONE — no `⊢retag`.
---   CONV      `conv-ren` at `ren-convCtx`, plus `shiftBy-ren` and
---             `numBinds-ren` arithmetic.
---   EXTERIOR  `wf-ren Ren-wk`.
---
--- NO EXTRA PREMISE.  Everything comes off the redex's own derivation.
-⊢addLock0-cross : ∀ {Δ Γ C W Θ′ c Bᵥ Bₑ}
-  → Δ ⊢ᵐ Θ′
-  → interior Θ′ Δ ∣ [] ⊢ W ⦂ Bᵥ
-  → convCtx Θ′ Δ ⊢ c ∶ Bᵥ ⇝ shiftBy (numBinds Θ′) Bₑ
-  → Δ ⊢ᵗ Bₑ
-    -------------------------------------------------------------------
-  → (unmasked (bind C) ∷ Δ) ∣ Γ
-      ⊢ renᴹ (extN (numBinds Θ′) suc) W
-          ⟪ addLock0 (renᴮ suc Θ′) , renᶜ (extN (numBinds Θ′) suc) c ⟫
-      ⦂ ⇑ᵗ Bₑ
-⊢addLock0-cross {Δ = Δ} {C = C} {W = W} {Θ′ = Θ′} {c = c} {Bᵥ = Bᵥ}
-                {Bₑ = Bₑ} mw′ ⊢W ⊢c wE =
-  env (mw reps chs) intW convW (wf-ren Ren-wk wE)
-  where
-  n′ : ℕ
-  n′ = numBinds Θ′
-
-  Δ⁺ : Ctxᵗ
-  Δ⁺ = unmasked (bind C) ∷ Δ
-
-  Θ″ : CtxMorph
-  Θ″ = addLock0 (renᴮ suc Θ′)
-
-  reps : unlockedScope Θ″ Δ⁺ ⊢ʳ binds Θ″
-  reps = subst (λ Ξ → Ξ ⊢ʳ map (renameᵗ suc) (binds Θ′))
-               (sym (unlockedScope-addLock0 (renᴮ suc Θ′) Δ⁺))
-               (⊢ʳ-ren (ren-unlockedScope Θ′ Ren-wk Inj-suc)
-                       (mw-reps mw′))
-
-  chs : Δ⁺ ⊢ˢ changes Θ″
-  chs = ⊢ˢ-++ (map (renᶠ suc) (changes Θ′)) (lock 0 ∷ [])
-              (⊢ˢ-ren Ren-wk Inj-suc (mw-changes mw′))
-              (sw-l (unmasked (bind (⇑ᵗ C)) , ez , nameable) sw[])
-
-  intW : interior Θ″ Δ⁺ ∣ [] ⊢ renᴹ (extN n′ suc) W
-           ⦂ renameᵗ (extN n′ suc) Bᵥ
-  intW = subst (λ Ξ → Ξ ∣ [] ⊢ renᴹ (extN n′ suc) W
-                        ⦂ renameᵗ (extN n′ suc) Bᵥ)
-               (sym (interior-addLock0 Θ′ C Δ))
-               (⊢rename (Ren-addLock0 Θ′ (masked (bind C)) Δ)
-                        (Inj-extN n′ Inj-suc) ⊢W)
-
-  convW : convCtx Θ″ Δ⁺ ⊢ renᶜ (extN n′ suc) c
-            ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ shiftBy (numBinds Θ″) (⇑ᵗ Bₑ)
-  convW =
-    subst (λ Ξ → Ξ ⊢ renᶜ (extN n′ suc) c ∶ renameᵗ (extN n′ suc) Bᵥ
-                   ⇝ shiftBy (numBinds Θ″) (⇑ᵗ Bₑ))
-          (sym (convCtx-addLock0 (renᴮ suc Θ′) Δ⁺))
-      (subst (λ n → convCtx (renᴮ suc Θ′) Δ⁺ ⊢ renᶜ (extN n′ suc) c
-                      ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ shiftBy n (⇑ᵗ Bₑ))
-             (sym (numBinds-ren suc Θ′))
-        (subst (λ T → convCtx (renᴮ suc Θ′) Δ⁺ ⊢ renᶜ (extN n′ suc) c
-                        ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ T)
-               (shiftBy-ren n′ suc Bₑ)
-               (conv-ren (ren-convCtx Θ′ suc Ren-wk Inj-suc) ⊢c)))
-
--- THE WRAPPER CASE PRESERVES TYPES.  It is the live proof
--- (proof/Preserve.preserve-TyPeelR) with `⊢wkV = ⊢rename Ren-wk Inj-suc`
--- replaced by `⊢addLock0-cross` — the OUTER `env` (frame, conversion,
--- exterior) is the live proof VERBATIM, exactly as in the Λ case.
-preserve-TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A C Bᵢ Bₑ} → Value W
-  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
-  → Δ ∣ [] ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
-    ---------------------------------------------------------------------
-  → Δ ∣ [] ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
-                 ⟪ addLock0 (renᴮ suc Θ′)
-                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
-preserve-TyPeelR-⟪⟫ {Δ = Δ} {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s}
-                    {B = B} {A = A} {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
-                    (⊢·[] (env mwᵥ (env mw′ ⊢W ⊢c′ wE′) ⊢c wE) wA)
-  with conv-all-inv ⊢c
-... | A₀ , B₀ , refl , eqE , ⊢s₀
-  with conv-types-unique ⊢s ⊢s₀
-... | refl , refl =
-  env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
-          (mw-changes mwᵥ))
-      int
-      conv
-      (wf-[]ᵗ (wf-∀⁻ wE) wA)
-  where
-  A′ : Ty
-  A′ = shiftBy (numBinds Θ) A
-
-  ⊢INNER : (unmasked (bind A′) ∷ interior Θ Δ) ∣ []
-             ⊢ (renᴹ (extN (numBinds Θ′) suc) W
-                  ⟪ addLock0 (renᴮ suc Θ′)
-                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-             ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
-  ⊢INNER = ⊢addLock0-cross mw′ ⊢W ⊢c′ wE′
-
-  int : interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
-          ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
-                ⟪ addLock0 (renᴮ suc Θ′)
-                , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-               ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-          ⦂ Bᵢ
-  int =
-    subst (λ T → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
-                   ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
-                         ⟪ addLock0 (renᴮ suc Θ′)
-                         , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
-                        ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
-                   ⦂ T)
-          (ren-suc-[0] Bᵢ)
-          (⊢·[] ⊢INNER
-                (wf-var (unmasked (bind (⇑ᵗ A′)) , ez , nameable)))
-
-  eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
-  eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
-
-  eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
-  eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)
-              (trans (subst-at-0 A′ (shiftBodyBy (numBinds Θ) B))
-                     (cong ⇑ᵗ (sym (shiftBy-[]ᵗ (numBinds Θ) B A))))
-
-  conv : convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ instReveal 0 s
-           ∶ Bᵢ ⇝ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
-  conv = subst (λ T → convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ
-                        ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
-               eqT (⊢instReveal {A = A′} 0 ⊢s)
-
--- PRESERVATION FOR THE WHOLE PROTOTYPE.  With both clauses proven the
--- relation `_⊢_-→ᵇ_` preserves types outright, which is what lets the
--- run in §5c₃ type every state.
-preserveᵇ : ∀ {Δ M M′ C}
-  → Δ ∣ [] ⊢ M ⦂ C
-  → Δ ⊢ M -→ᵇ M′
-    ---------------
-  → Δ ∣ [] ⊢ M′ ⦂ C
-preserveᵇ ⊢M (TyPeelR-Λ v ⊢s)  = preserve-TyPeelR-Λ v ⊢s ⊢M
-preserveᵇ ⊢M (TyPeelR-⟪⟫ v ⊢s) = preserve-TyPeelR-⟪⟫ v ⊢s ⊢M
-preserveᵇ (env mwᵥ ⊢M ⊢c wE) (ξᵇ-⟪⟫ st) =
-  env mwᵥ (preserveᵇ ⊢M st) ⊢c wE
-
 ------------------------------------------------------------------------
--- §5c₁  FRAME EXACTNESS OF THE NEW CLAUSE
+-- §5c₁  FRAME EXACTNESS OF THE TWO CLAUSES
 ------------------------------------------------------------------------
 
--- (iii) THE MOVED BOUNDARY'S INTERIOR IS ITS BIRTH FRAME WITH THE NEW
--- SLOT INSERTED MASKED, BELOW THE INNER BINDS.  `interior-addLock0`
--- (§5b), instantiated at the rule's own two contexts: the redex reads
--- the moved boundary at `interior Θ Δ` and the contractum at
+-- THE MOVED BOUNDARY'S INTERIOR IS ITS BIRTH FRAME WITH THE NEW SLOT
+-- INSERTED MASKED, BELOW THE INNER BINDS.  `interior-addLock0-cross`
+-- (strong.TermSubst), instantiated at the rule's own two contexts: the
+-- redex reads the moved boundary at `interior Θ Δ` and the contractum at
 -- `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which IS
 -- `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ`
 -- (`interior-TyPeelR`, `refl`).
@@ -839,7 +534,7 @@ TyPeelR-⟪⟫-frame : (A : Ty) (Θ Θ′ : CtxMorph) (Δ : Ctxᵗ)
           (masked (bind (shiftBy (numBinds Θ) A))
              ∷ scope Θ′ (interior Θ Δ))
 TyPeelR-⟪⟫-frame A Θ Θ′ Δ =
-  interior-addLock0 Θ′ (shiftBy (numBinds Θ) A) (interior Θ Δ)
+  interior-addLock0-cross Θ′ (shiftBy (numBinds Θ) A) (interior Θ Δ)
 
 -- … and the BIRTH frame, for comparison: the same `pushBinds` over the
 -- same `scope`, with the binds UNLIFTED and no new slot.  So the move is
@@ -872,14 +567,14 @@ TyPeelR-⟪⟫-slot-locked : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
          ∋tv numBinds (renᴮ suc Θ′))
 TyPeelR-⟪⟫-slot-locked Θ′ C Δ =
   ∋lk-¬∋tv (subst (λ Ξ → Ξ ∋lk numBinds (renᴮ suc Θ′))
-                  (sym (interior-addLock0 Θ′ C Δ))
+                  (sym (interior-addLock0-cross Θ′ C Δ))
                   (pushBinds-∋lk0 (map ⇑ᵗ (binds Θ′)) (masked (bind C))
                                   (scope Θ′ Δ) locked))
 
--- THE OUTER BOUNDARY IS THE LIVE RULE'S, UNTOUCHED.  Sharpest form: the
--- (b′) contractum is the LIVE contractum with `addLock0ᵛ` applied to the
--- moved value and NOTHING ELSE CHANGED — same outer frame
--- `morph (A ∷ binds Θ) (changes Θ)`, same minted conversion
+-- THE OUTER BOUNDARY IS THE SINGLE RULE'S, UNTOUCHED.  Sharpest form: the
+-- wrapper clause's contractum is the single rule's contractum with
+-- `addLock0ᵛ` applied to the moved value and NOTHING ELSE CHANGED — same
+-- outer frame `morph (A ∷ binds Θ) (changes Θ)`, same minted conversion
 -- `instReveal 0 s`, same pushed-in annotation `renameᵗ (extᵗ suc) Bᵢ`,
 -- same type argument `` ` 0 ``.
 TyPeelR-⟪⟫-outer-unchanged : (W : Term) (Θ′ Θ : CtxMorph) (s′ s : Conv)
@@ -898,8 +593,11 @@ TyPeelR-⟪⟫-outer-unchanged W Θ′ Θ s′ s A Bᵢ = refl
 -- §5c₂  TERMINATION — THE TOWER MEASURE, AND WHY THIS IS NOT FIX (a)
 ------------------------------------------------------------------------
 
--- (iv) The contractum's inner `(… ⟪ addLock0 … , `∀ s″ ⟫) ·[ … , ` 0 ]`
--- IS AGAIN A `-→ᵇ` REDEX.  It is NOT fix (a)'s regress, and the measure
+-- The wrapper clause's contractum contains
+--
+--    (… ⟪ addLock0 … , `∀ s″ ⟫) ·[ … , ` 0 ]
+--
+-- which IS again a redex.  It is NOT fix (a)'s regress, and the measure
 -- says why: the number of nested boundaries above the `Λ`.
 towerHeight : Term → ℕ
 towerHeight (` x)          = 0
@@ -937,8 +635,9 @@ TyPeelR-⟪⟫-height W Θ′ Θ s′ s =
 -- FIX (a) STALLS AT THE SAME MEASURE.  Its contractum's inner ∀-value is
 -- `wkᴹ 1 V` under a FRESH boundary, so the height is the redex's height
 -- again: nothing is consumed, and §4a's `T₀ -→ᵃ T₁ -→ᵃ T₂` is that
--- stall, twice.  THIS is the difference between (a) and (b′): (b′)
--- CONSUMES a boundary that was already there, (a) MINTS a new one.
+-- stall, twice.  THIS is the difference between (a) and the installed
+-- clause: `TyPeelR-⟪⟫` CONSUMES a boundary that was already there, (a)
+-- MINTS a new one.
 fixA-height-stalls : (V : Term) (Θ : CtxMorph) (s : Conv) (Bᵢ : Ty)
   → towerHeight (wkᴹ 1 V ⟪ morph [] (lock 0 ∷ []) , mkId (`∀ Bᵢ) ⟫)
       ≡ towerHeight (V ⟪ Θ , `∀ s ⟫)
@@ -947,8 +646,8 @@ fixA-height-stalls V Θ s Bᵢ = cong suc (towerHeight-renᴹ (wkN 1) V)
 -- WHERE THE DESCENT STOPS.  A `∀`-value of tower height 0 is a `Λ`
 -- (`canon-∀` has no third shape), so once `TyPeelR-⟪⟫` has consumed the
 -- tower it is `TyPeelR-Λ` that fires — and `TyPeelR-Λ` neither shifts nor
--- locks anything (§5).  So the run is `height` wrapper steps then one Λ
--- step, and never more.
+-- locks anything (§5).  So the run is `height − 1` wrapper steps then one
+-- Λ step, and never more.
 canon-∀-height : ∀ {Δ V C} → Value V → Δ ∣ [] ⊢ V ⦂ `∀ C
   → towerHeight V ≡ 0
   → Σ[ N ∈ Term ] (Value N × (V ≡ Λ N))
@@ -957,26 +656,26 @@ canon-∀-height v ⊢V eq with canon-∀ v ⊢V
 canon-∀-height v ⊢V ()
     | inj₂ (W , Θ′ , s′ , vW , refl)
 
--- … stated as the progress clause it decides.  At tower height 0 the
--- step is `TyPeelR-Λ`, with the contractum named.
-progressᵇ-Λ-at-0 : ∀ {Δ V Θ s B A C} → Value V
+-- … stated as the progress clause it decides, against the LIVE relation.
+-- At tower height 0 the step is `TyPeelR-Λ`, with the contractum named.
+progress-Λ-at-0 : ∀ {Δ V Θ s B A C} → Value V
   → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
   → towerHeight V ≡ 0
     ----------------------------------------------------------------
   → Σ[ N ∈ Term ]
       ((V ≡ Λ N)
        × (Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-            -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫))
-progressᵇ-Λ-at-0 v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) eq with conv-all-inv ⊢c
+            -→ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫))
+progress-Λ-at-0 v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) eq with conv-all-inv ⊢c
 ... | A₀ , B₀ , refl , eqₑ , ⊢s with canon-∀-height v ⊢V eq
 ... | N , vN , refl = N , refl , TyPeelR-Λ vN ⊢s
 
 ------------------------------------------------------------------------
--- §5c₃  THE RULE ON A CLOSED TWO-DEEP TOWER
+-- §5c₃  THE TWO CLAUSES ON A CLOSED TWO-DEEP TOWER
 ------------------------------------------------------------------------
 
--- (v) A CLOSED redex whose ∀-value is a two-boundary tower over a `Λ`.
--- The inner frame LOCKS the outer frame's binder, so the moved boundary
+-- A CLOSED redex whose ∀-value is a two-boundary tower over a `Λ`.  The
+-- inner frame LOCKS the outer frame's binder, so the moved boundary
 -- really does carry a change list for the appended lock to join.
 --
 --   Θᵈ  = morph (`ℕ ∷ []) []          the OUTER frame: binds X := ℕ
@@ -995,7 +694,7 @@ progressᵇ-Λ-at-0 v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) eq with conv-all-inv
 --     = (((ΛZ. 3) ⟪ ↓X , ↓Y , (∀Z. id ℕ) ⟫) [Y]
 --          ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
 --
---                     │  ξᵇ-⟪⟫ (TyPeelR-Λ)   (tower exhausted)
+--                     │  ξ-⟪⟫ (TyPeelR-Λ)   (tower exhausted)
 --                     ▼
 --   showTmIn 0 U₂
 --     = ((3 ⟪ ↑Z:=Y , ↓X , ↓Y , id ℕ ⟫) ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
@@ -1061,11 +760,11 @@ U₁ = (((Λ ($ 3)) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , `∀ (id `ℕ) ⟫
         ·[ `ℕ , ` 0 ])
        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id `ℕ ⟫
 
-stepᵈ₁ : [] ⊢ U₀ -→ᵇ U₁
+stepᵈ₁ : [] ⊢ U₀ -→ U₁
 stepᵈ₁ = TyPeelR-⟪⟫ (V-Λ V-$) (conv-id base-ℕ)
 
 ⊢U₁ : [] ∣ [] ⊢ U₁ ⦂ `ℕ
-⊢U₁ = preserveᵇ ⊢U₀ stepᵈ₁
+⊢U₁ = preservation ⊢U₀ stepᵈ₁
 
 -- THE FRAME, AT THIS STEP.  The moved boundary's interior has BOTH slots
 -- masked: X (shifted to slot 1) as it was in the redex, and the new
@@ -1076,9 +775,9 @@ _ = refl
 _ : Ξᵈ₃ ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
--- … and it is the frame identity `interior-addLock0` at this instance
--- (the birth frame `masked (bind `ℕ) ∷ []`, with the new slot inserted
--- MASKED below the — empty — bind prefix).
+-- … and it is the frame identity `interior-addLock0-cross` at this
+-- instance (the birth frame `masked (bind `ℕ) ∷ []`, with the new slot
+-- inserted MASKED below the — empty — bind prefix).
 _ : interior (addLock0 (renᴮ suc Θᵈ′))
              (interior (morph (`ℕ ∷ binds Θᵈ) (changes Θᵈ)) [])
       ≡ pushBinds (map ⇑ᵗ (binds Θᵈ′))
@@ -1091,11 +790,11 @@ U₂ : Term
 U₂ = (($ 3) ⟪ morph ((` 0) ∷ []) (lock 1 ∷ lock 0 ∷ []) , id `ℕ ⟫)
        ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id `ℕ ⟫
 
-stepᵈ₂ : [] ⊢ U₁ -→ᵇ U₂
-stepᵈ₂ = ξᵇ-⟪⟫ (TyPeelR-Λ V-$ (conv-id base-ℕ))
+stepᵈ₂ : [] ⊢ U₁ -→ U₂
+stepᵈ₂ = ξ-⟪⟫ (TyPeelR-Λ V-$ (conv-id base-ℕ))
 
 ⊢U₂ : [] ∣ [] ⊢ U₂ ⦂ `ℕ
-⊢U₂ = preserveᵇ ⊢U₁ stepᵈ₂
+⊢U₂ = preservation ⊢U₁ stepᵈ₂
 
 -- THE MEASURE, ON THIS RUN: 2 → 1, and at 1 the interior is a `Λ`.
 _ : towerHeight outerᵈ ≡ 2
@@ -1109,113 +808,13 @@ _ : towerHeight ((Λ ($ 3)) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , `∀ (id `
       ≡ towerHeight outerᵈ ∸ 1
 _ = TyPeelR-⟪⟫-height Wᵈ Θᵈ′ Θᵈ (id `ℕ) (id `ℕ)
 
-------------------------------------------------------------------------
--- §5c₄  TIGHTNESS OF THE NEW CLAUSE (Examples §15b, for the wrapper)
-------------------------------------------------------------------------
+-- TIGHTNESS OF THE TWO CLAUSES is Examples §15b: an ILL-TYPED subterm —
+-- ill typed for exactly one localized reason, `wf-var` at a masked slot —
+-- stays ill typed in each contractum, and the wrapper clause's frame
+-- REFUSES the value that the single rule's frame accepted (`⊢prb0-single`
+-- against `¬⊢prb0-split`).  That is §3a's `nmᵃ` test, run at the position
+-- a moved boundary's interior actually occupies.
 
--- Jeremy's test, on the repaired clause.  An ILL-TYPED `W` — ill typed
--- for exactly one localized reason, `wf-var` at a masked slot — must stay
--- ill typed in the contractum.  Here the OUTER frame locks X and the
--- INNER frame does nothing, so `prb 0` names the locked slot.
---
---   showTmIn 1 Rᵛ
---     = (((λx:ℕ. (ΛY. 3) [X]) ⟪ (∀Y. id ℕ) ⟫)
---          ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
---
--- the LIVE rule's contractum and (b′)'s, at that redex:
---
---   showTmIn 1 Cᵛ-live
---     = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ (∀Z. id ℕ) ⟫) [Y]
---          ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
---   showTmIn 1 Cᵛ
---     = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↓Y , (∀Z. id ℕ) ⟫) [Y]
---          ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
---
--- ONE CHARACTER PAIR OF DIFFERENCE — `↓Y` — and it is the whole repair:
---
---   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-live
---     =  Y := ℕ , ⌷[X := ℕ]          ← the LEAK: Y is offered
---   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-new
---     =  ⌷[Y := ℕ] , ⌷[X := ℕ]       ← (b′): Y is masked
-Δᵛ Ξᵛ₀ : Ctxᵗ
-Δᵛ  = unmasked (bind `ℕ) ∷ []
-Ξᵛ₀ = masked (bind `ℕ) ∷ []       -- W's BIRTH frame: X is locked
-
-Θᵛ Θᵛ′ : CtxMorph
-Θᵛ  = morph [] (lock 0 ∷ [])          -- the OUTER frame: locks X
-Θᵛ′ = morph [] []                     -- the INNER frame: nothing
-
-_ : interior Θᵛ Δᵛ ≡ Ξᵛ₀
-_ = refl
-
-_ : interior Θᵛ′ (interior Θᵛ Δᵛ) ≡ Ξᵛ₀
-_ = refl
-
-Rᵛ Cᵛ : Term
-Rᵛ = ((prb 0 ⟪ Θᵛ′ , `∀ (id `ℕ) ⟫) ⟪ Θᵛ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
-Cᵛ = ((prb 1 ⟪ morph [] (lock 0 ∷ []) , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ])
-       ⟪ morph (`ℕ ∷ []) (lock 0 ∷ []) , id `ℕ ⟫
-
-stepᵛ : Δᵛ ⊢ Rᵛ -→ᵇ Cᵛ
-stepᵛ = TyPeelR-⟪⟫ val-prb (conv-id base-ℕ)
-
--- THE FAULT, in the redex: `⊢·[]`'s `Δ ⊢ᵗ A` at slot 0, which the outer
--- frame masks.
-¬⊢prb0 : ∀ {Δ Γ A b} → ¬ ((masked b ∷ Δ) ∣ Γ ⊢ prb 0 ⦂ A)
-¬⊢prb0 (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
-
-¬⊢Rᵛ : ∀ {A} → ¬ (Δᵛ ∣ [] ⊢ Rᵛ ⦂ A)
-¬⊢Rᵛ (⊢·[] (env _ (env _ ⊢W _ _) _ _) _) = ¬⊢prb0 ⊢W
-
--- THE TWO CONTRACTA'S FRAMES FOR THE MOVED BOUNDARY, side by side.  The
--- LIVE rule leaves the moved boundary's change list alone, so the new
--- binder (slot 0) is UNMASKED — §3's leak, on this example.  (b′) appends
--- the lock, so it is MASKED.  The old fault (X) has moved to slot 1 with
--- the shift and is masked in both.
-Ξᵛ-live Ξᵛ-new : Ctxᵗ
-Ξᵛ-live = interior Θᵛ′ (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵛ)
-Ξᵛ-new  = interior (addLock0 (renᴮ suc Θᵛ′))
-                   (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵛ)
-
-_ : Ξᵛ-live ≡ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
-_ = refl
-
-_ : Ξᵛ-new ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
-_ = refl
-
--- the frame-exact point, as the general lemma at this instance: slot 0 —
--- the slot the live rule offered UNMASKED (§3) — is unnameable
-_ : ¬ (Ξᵛ-new ∋tv 0)
-_ = TyPeelR-⟪⟫-slot-locked Θᵛ′ `ℕ (interior Θᵛ Δᵛ)
-
--- THE LEAK, CLOSED, ON THIS EXAMPLE.  A value that NAMES THE NEW SLOT
--- types at the live rule's frame and is REFUSED at (b′)'s — and this is
--- §3a's `nmᵃ` test, now run at the position a moved boundary's interior
--- actually occupies.
-⊢prb0-live : Ξᵛ-live ∣ [] ⊢ prb 0 ⦂ (`ℕ ⇒ `ℕ)
-⊢prb0-live =
-  ⊢ƛ wf-ℕ (⊢·[] (⊢Λ ⊢$) (wf-var (unmasked (bind `ℕ) , ez , nameable)))
-
-¬⊢prb0-new : ∀ {Γ A} → ¬ (Ξᵛ-new ∣ Γ ⊢ prb 0 ⦂ A)
-¬⊢prb0-new = ¬⊢prb0
-
--- … and the tightness test itself: the ILL-TYPED value stays ill typed,
--- for the same localized reason, one index further out.
-¬⊢prb1 : ∀ {Δ Γ A E b} → ¬ ((E ∷ masked b ∷ Δ) ∣ Γ ⊢ prb 1 ⦂ A)
-¬⊢prb1 (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
-
-¬⊢Cᵛ : ∀ {A} → ¬ (Δᵛ ∣ [] ⊢ Cᵛ ⦂ A)
-¬⊢Cᵛ (env _ (⊢·[] (env _ ⊢W _ _) _) _ _) = ¬⊢prb1 ⊢W
-
--- THE LIVE RULE AT THE SAME REDEX, for the diff.  Same outer boundary,
--- same pushed-in annotation, same type argument; the ONE difference is
--- the moved boundary's change list.
-Cᵛ-live : Term
-Cᵛ-live = ((prb 1 ⟪ morph [] [] , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ])
-            ⟪ morph (`ℕ ∷ []) (lock 0 ∷ []) , id `ℕ ⟫
-
-stepᵛ-live : Δᵛ ⊢ Rᵛ -→ Cᵛ-live
-stepᵛ-live = TyPeelR (V-⟪⟫ val-prb I-all) (conv-id base-ℕ)
 
 ------------------------------------------------------------------------
 -- §6  TYBETA — exact up to refinement
@@ -1341,7 +940,8 @@ Drop$-only-numerals : ∀ {Δ M M′} → Δ ⊢ M -→ M′
 Drop$-only-numerals (TyBeta v)  ()
 Drop$-only-numerals (Beta w)    ()
 Drop$-only-numerals (Peel v w)  ()
-Drop$-only-numerals (TyPeelR v ⊢s) ()
+Drop$-only-numerals (TyPeelR-Λ v ⊢s)  ()
+Drop$-only-numerals (TyPeelR-⟪⟫ v ⊢s) ()
 Drop$-only-numerals (CancelR v d)  ()
 Drop$-only-numerals (Drop$ b)      refl = refl
 Drop$-only-numerals (IdPush v d)   ()

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -981,6 +981,40 @@ progressᵇ-Λ-at-0 v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) eq with conv-all-inv
 --
 --   Θᵈ  = morph (`ℕ ∷ []) []          the OUTER frame: binds X := ℕ
 --   Θᵈ′ = morph [] (lock 0 ∷ [])      the INNER frame: locks X
+--
+-- THE RUN, MACHINE-RENDERED (scripts/render_term.sh, importing this
+-- module).  Every line below is the renderer's output, not a
+-- transcription.
+--
+--   showTmIn 0 U₀
+--     = (((ΛY. 3) ⟪ ↓X , (∀Y. id ℕ) ⟫) ⟪ ↑X:=ℕ , (∀Y. id ℕ) ⟫) [ℕ]
+--
+--                     │  TyPeelR-⟪⟫   (tower height 2 → 1)
+--                     ▼
+--   showTmIn 0 U₁
+--     = (((ΛZ. 3) ⟪ ↓X , ↓Y , (∀Z. id ℕ) ⟫) [Y]
+--          ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
+--
+--                     │  ξᵇ-⟪⟫ (TyPeelR-Λ)   (tower exhausted)
+--                     ▼
+--   showTmIn 0 U₂
+--     = ((3 ⟪ ↑Z:=Y , ↓X , ↓Y , id ℕ ⟫) ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)
+--
+-- READ THE MOVED BOUNDARY'S CHANGE LIST ACROSS STEP 1: `↓X` becomes
+-- `↓X , ↓Y` — the SHIFTED original lock and the NEW lock, appended at the
+-- tail.  Nothing else about the boundary changes, and no wrapper appears.
+--
+-- THE FRAMES:
+--
+--   showTCtxAt 9 0 (λ _ → "X") Ξᵈ₀                  =  X := ℕ
+--   showTCtxAt 9 0 (λ _ → "X") Ξᵈ₁                  =  ⌷[X := ℕ]
+--   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵈ₂
+--     =  Y := ℕ , X := ℕ
+--   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵈ₃
+--     =  ⌷[Y := ℕ] , ⌷[X := ℕ]
+--
+-- `Ξᵈ₁` is W's BIRTH frame and `Ξᵈ₃` is its frame in the contractum: the
+-- same frame with the new binder Y inserted MASKED.  Exact.
 Θᵈ Θᵈ′ : CtxMorph
 Θᵈ  = morph (`ℕ ∷ []) []
 Θᵈ′ = morph [] (lock 0 ∷ [])
@@ -994,11 +1028,17 @@ U₀     = outerᵈ ·[ `ℕ , `ℕ ]
 valᵈ : Value outerᵈ
 valᵈ = V-⟪⟫ (V-⟪⟫ (V-Λ V-$) I-all) I-all
 
--- the frames, spelled out
-_ : interior Θᵈ [] ≡ unmasked (bind `ℕ) ∷ []
+-- the frames, spelled out and named so the renderer can print them
+Ξᵈ₀ Ξᵈ₁ Ξᵈ₂ Ξᵈ₃ : Ctxᵗ
+Ξᵈ₀ = interior Θᵈ []                                  -- the outer bind
+Ξᵈ₁ = interior Θᵈ′ Ξᵈ₀                                -- W's BIRTH frame
+Ξᵈ₂ = interior (morph (`ℕ ∷ `ℕ ∷ []) []) []           -- after step 1
+Ξᵈ₃ = interior (morph [] (lock 1 ∷ lock 0 ∷ [])) Ξᵈ₂  -- W's NEW frame
+
+_ : Ξᵈ₀ ≡ unmasked (bind `ℕ) ∷ []
 _ = refl
 
-_ : interior Θᵈ′ (interior Θᵈ []) ≡ masked (bind `ℕ) ∷ []
+_ : Ξᵈ₁ ≡ masked (bind `ℕ) ∷ []
 _ = refl
 
 ⊢innerᵈ : interior Θᵈ [] ∣ [] ⊢ innerᵈ ⦂ `∀ `ℕ
@@ -1030,13 +1070,10 @@ stepᵈ₁ = TyPeelR-⟪⟫ (V-Λ V-$) (conv-id base-ℕ)
 -- THE FRAME, AT THIS STEP.  The moved boundary's interior has BOTH slots
 -- masked: X (shifted to slot 1) as it was in the redex, and the new
 -- binder (slot 0) by the appended lock.  Nothing gained.
-_ : interior (morph (`ℕ ∷ `ℕ ∷ [])  []) []
-      ≡ unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
+_ : Ξᵈ₂ ≡ unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
 _ = refl
 
-_ : interior (morph [] (lock 1 ∷ lock 0 ∷ []))
-             (interior (morph (`ℕ ∷ `ℕ ∷ []) []) [])
-      ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ : Ξᵈ₃ ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 -- … and it is the frame identity `interior-addLock0` at this instance
@@ -1080,18 +1117,38 @@ _ = TyPeelR-⟪⟫-height Wᵈ Θᵈ′ Θᵈ (id `ℕ) (id `ℕ)
 -- for exactly one localized reason, `wf-var` at a masked slot — must stay
 -- ill typed in the contractum.  Here the OUTER frame locks X and the
 -- INNER frame does nothing, so `prb 0` names the locked slot.
-Δᵛ Θᵛ-ext : Ctxᵗ
-Δᵛ      = unmasked (bind `ℕ) ∷ []
-Θᵛ-ext  = masked (bind `ℕ) ∷ []
+--
+--   showTmIn 1 Rᵛ
+--     = (((λx:ℕ. (ΛY. 3) [X]) ⟪ (∀Y. id ℕ) ⟫)
+--          ⟪ ↓X , (∀Y. id ℕ) ⟫) [ℕ]
+--
+-- the LIVE rule's contractum and (b′)'s, at that redex:
+--
+--   showTmIn 1 Cᵛ-live
+--     = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ (∀Z. id ℕ) ⟫) [Y]
+--          ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
+--   showTmIn 1 Cᵛ
+--     = (((λx:ℕ. (ΛZ. 3) [X]) ⟪ ↓Y , (∀Z. id ℕ) ⟫) [Y]
+--          ⟪ ↑Y:=ℕ , ↓X , id ℕ ⟫)
+--
+-- ONE CHARACTER PAIR OF DIFFERENCE — `↓Y` — and it is the whole repair:
+--
+--   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-live
+--     =  Y := ℕ , ⌷[X := ℕ]          ← the LEAK: Y is offered
+--   showTCtxAt 9 0 (λ { 0 → "Y" ; _ → "X" }) Ξᵛ-new
+--     =  ⌷[Y := ℕ] , ⌷[X := ℕ]       ← (b′): Y is masked
+Δᵛ Ξᵛ₀ : Ctxᵗ
+Δᵛ  = unmasked (bind `ℕ) ∷ []
+Ξᵛ₀ = masked (bind `ℕ) ∷ []       -- W's BIRTH frame: X is locked
 
 Θᵛ Θᵛ′ : CtxMorph
 Θᵛ  = morph [] (lock 0 ∷ [])          -- the OUTER frame: locks X
 Θᵛ′ = morph [] []                     -- the INNER frame: nothing
 
-_ : interior Θᵛ Δᵛ ≡ Θᵛ-ext
+_ : interior Θᵛ Δᵛ ≡ Ξᵛ₀
 _ = refl
 
-_ : interior Θᵛ′ (interior Θᵛ Δᵛ) ≡ Θᵛ-ext
+_ : interior Θᵛ′ (interior Θᵛ Δᵛ) ≡ Ξᵛ₀
 _ = refl
 
 Rᵛ Cᵛ : Term
@@ -1104,34 +1161,61 @@ stepᵛ = TyPeelR-⟪⟫ val-prb (conv-id base-ℕ)
 
 -- THE FAULT, in the redex: `⊢·[]`'s `Δ ⊢ᵗ A` at slot 0, which the outer
 -- frame masks.
-¬⊢prb0 : ∀ {Γ A} → ¬ ((masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 0 ⦂ A)
+¬⊢prb0 : ∀ {Δ Γ A b} → ¬ ((masked b ∷ Δ) ∣ Γ ⊢ prb 0 ⦂ A)
 ¬⊢prb0 (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
 
 ¬⊢Rᵛ : ∀ {A} → ¬ (Δᵛ ∣ [] ⊢ Rᵛ ⦂ A)
 ¬⊢Rᵛ (⊢·[] (env _ (env _ ⊢W _ _) _ _) _) = ¬⊢prb0 ⊢W
 
--- THE CONTRACTUM'S FRAME.  The new slot is at 0 and it is MASKED (the
--- appended lock); the old fault has moved to slot 1 with the shift and is
--- masked there as it was.  BOTH masks are visible in one context.
-_ : interior (morph [] (lock 0 ∷ []))
-             (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵛ)
-      ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+-- THE TWO CONTRACTA'S FRAMES FOR THE MOVED BOUNDARY, side by side.  The
+-- LIVE rule leaves the moved boundary's change list alone, so the new
+-- binder (slot 0) is UNMASKED — §3's leak, on this example.  (b′) appends
+-- the lock, so it is MASKED.  The old fault (X) has moved to slot 1 with
+-- the shift and is masked in both.
+Ξᵛ-live Ξᵛ-new : Ctxᵗ
+Ξᵛ-live = interior Θᵛ′ (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵛ)
+Ξᵛ-new  = interior (addLock0 (renᴮ suc Θᵛ′))
+                   (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵛ)
+
+_ : Ξᵛ-live ≡ unmasked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ = refl
+
+_ : Ξᵛ-new ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
 _ = refl
 
 -- the frame-exact point, as the general lemma at this instance: slot 0 —
 -- the slot the live rule offered UNMASKED (§3) — is unnameable
-_ : ¬ (interior (addLock0 (renᴮ suc Θᵛ′))
-                (unmasked (bind `ℕ) ∷ interior Θᵛ Δᵛ)
-         ∋tv 0)
+_ : ¬ (Ξᵛ-new ∋tv 0)
 _ = TyPeelR-⟪⟫-slot-locked Θᵛ′ `ℕ (interior Θᵛ Δᵛ)
 
--- … so the contractum is REFUSED, for the same localized reason.
-¬⊢prb1 : ∀ {Γ A}
-  → ¬ ((masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
+-- THE LEAK, CLOSED, ON THIS EXAMPLE.  A value that NAMES THE NEW SLOT
+-- types at the live rule's frame and is REFUSED at (b′)'s — and this is
+-- §3a's `nmᵃ` test, now run at the position a moved boundary's interior
+-- actually occupies.
+⊢prb0-live : Ξᵛ-live ∣ [] ⊢ prb 0 ⦂ (`ℕ ⇒ `ℕ)
+⊢prb0-live =
+  ⊢ƛ wf-ℕ (⊢·[] (⊢Λ ⊢$) (wf-var (unmasked (bind `ℕ) , ez , nameable)))
+
+¬⊢prb0-new : ∀ {Γ A} → ¬ (Ξᵛ-new ∣ Γ ⊢ prb 0 ⦂ A)
+¬⊢prb0-new = ¬⊢prb0
+
+-- … and the tightness test itself: the ILL-TYPED value stays ill typed,
+-- for the same localized reason, one index further out.
+¬⊢prb1 : ∀ {Δ Γ A E b} → ¬ ((E ∷ masked b ∷ Δ) ∣ Γ ⊢ prb 1 ⦂ A)
 ¬⊢prb1 (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
 
 ¬⊢Cᵛ : ∀ {A} → ¬ (Δᵛ ∣ [] ⊢ Cᵛ ⦂ A)
 ¬⊢Cᵛ (env _ (⊢·[] (env _ ⊢W _ _) _) _ _) = ¬⊢prb1 ⊢W
+
+-- THE LIVE RULE AT THE SAME REDEX, for the diff.  Same outer boundary,
+-- same pushed-in annotation, same type argument; the ONE difference is
+-- the moved boundary's change list.
+Cᵛ-live : Term
+Cᵛ-live = ((prb 1 ⟪ morph [] [] , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ])
+            ⟪ morph (`ℕ ∷ []) (lock 0 ∷ []) , id `ℕ ⟫
+
+stepᵛ-live : Δᵛ ⊢ Rᵛ -→ Cᵛ-live
+stepᵛ-live = TyPeelR (V-⟪⟫ val-prb I-all) (conv-id base-ℕ)
 
 ------------------------------------------------------------------------
 -- §6  TYBETA — exact up to refinement

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -481,14 +481,11 @@ addLock0-sw-l : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
   → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ˢ (lock 0 ∷ [])
 addLock0-sw-l A Θ Δ = sw-l (TyPeelR-slot0-nameable A Θ Δ) sw[]
 
--- THE FRAME IDENTITY.  The moved boundary's interior frame is its BIRTH
--- frame with the new binder inserted BELOW the bind prefix and MASKED —
--- the very shape (†) gives Peel's crossing argument and
--- `interior-Beta-Λ` gives Beta's.  Nothing gained, nothing lost.
-interior-addLock0-shift : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
-  → interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
-      ≡ pushBinds (map ⇑ᵗ (binds Θ′)) (masked (bind C) ∷ scope Θ′ Δ)
-interior-addLock0-shift = interior-addLock0-cross
+-- THE FRAME IDENTITY is `interior-addLock0-cross`: the moved boundary's
+-- interior frame is its BIRTH frame with the new binder inserted BELOW
+-- the bind prefix and MASKED — the very shape (†) gives Peel's crossing
+-- argument and `interior-Beta-Λ` gives Beta's.  Nothing gained, nothing
+-- lost.  §5c₁ instantiates it at the rule's own two contexts.
 
 ------------------------------------------------------------------------
 -- §5c  IT IS `wkᴹ 1` PLUS ONE LOCK, ON THE NOSE

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -22,6 +22,8 @@ module strong.proof.ShiftAudit where
 --   §4  fix (a), "wrap V in the new binder's dual" — LOOPS
 --   §5  fix (b), "split on the interior" — the Λ half, PROVEN EXACT
 --   §5b fix (b′), the wrapper half — the frame identity, EXACT
+--   §5c fix (b′) AS A RULE — preservation, determinism, progress, frame
+--       exactness, the tower measure, and a closed two-deep run
 --   §6  TyBeta                — exact up to refinement
 --   §7  Beta                  — exact (crossΛ), and the `ƛ` clause
 --   §8  CancelR / IdPush      — exact, inner AND outer
@@ -32,7 +34,7 @@ module strong.proof.ShiftAudit where
 -- The verdict table with the fix candidates and their hazards is
 -- notes/ShiftAudit.md; the frame-identity table it feeds is Design.md §7.
 
-open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.Nat using (ℕ; zero; suc; _+_; _∸_)
 open import Data.List using (List; []; _∷_; _++_; map; length)
 open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Data.Product using (Σ; Σ-syntax; _×_; _,_; proj₁; proj₂; ∃-syntax)
@@ -54,11 +56,12 @@ open import strong.Reduction
 open import strong.proof.Preserve
   using (⊢instReveal; wf-[]ᵗ; wf-∀⁻; ∀-inj; subst-at-0; shiftBy-[]ᵗ
         ; ren-suc-[0])
-open import strong.proof.PeelDual using (interior-dual; applyChanges-++)
+open import strong.proof.PeelDual
+  using (interior-dual; applyChanges-++; ⊢ˢ-++)
 open import strong.proof.MoveScope using (interior-rewind; interior-⋉-rewind)
 open import strong.proof.Canonical using (canon-∀)
 open import strong.Examples
-  using (interior-TyBeta; interior-TyPeelR; interior-Beta-Λ)
+  using (interior-TyBeta; interior-TyPeelR; interior-Beta-Λ; prb; val-prb)
 
 private
   variable
@@ -414,7 +417,15 @@ TyPeelR-Λ-refinement : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
       ⊑ᵃ interior (morph (A ∷ binds Θ) (changes Θ)) Δ
 TyPeelR-Λ-refinement A Θ Δ = la∷ (la-uu le-ab) (⊑ᵃ-refl (interior Θ Δ))
 
--- THE PROTOTYPE RULE SET (fix (b)), NOT the live rule.
+-- THE MOVED BOUNDARY'S OWN LOCK (fix (b′), §5b).  `lock 0` is appended
+-- at the TAIL of the boundary's own change list, where `applyChanges`
+-- runs it FIRST — the position the scope move `_⋉_` puts its travelling
+-- changes in.  The definition sits here because the rule below mentions
+-- it; §5b is where the choice is justified and the frame identity proved.
+addLock0 : CtxMorph → CtxMorph
+addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
+
+-- THE PROTOTYPE RULE SET (fix (b) + fix (b′)), NOT the live rule.
 infix 2 _⊢_-→ᵇ_
 data _⊢_-→ᵇ_ : Ctxᵗ → Term → Term → Set where
 
@@ -424,14 +435,27 @@ data _⊢_-→ᵇ_ : Ctxᵗ → Term → Term → Set where
     → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
         -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
 
-  -- the wrapper interior: the live rule, restricted.  THE LEAK SURVIVES
-  -- HERE (§3 applies verbatim to `W ⟪ Θ′ , `∀ s′ ⟫`), which is why fix
-  -- (b) is a PARTIAL repair — see notes/ShiftAudit.md.
+  -- THE WRAPPER INTERIOR, REPAIRED (fix (b′)).  The moved boundary is
+  -- SHIFTED exactly as the live rule shifts it — `wkᴹ 1` on a boundary is
+  -- `renᴹ (extN (numBinds Θ′) suc)` on its interior, `renᴮ suc` on its
+  -- frame and `renᶜ (extN (numBinds Θ′) suc)` on its conversion — and
+  -- then `lock 0` is APPENDED to its own (shifted) change list.  NO NEW
+  -- WRAPPER IS MINTED, which is what makes this not fix (a) (§4).
+  -- `TyPeelR-⟪⟫-wkᴹ` (§5c) is the equation relating the contractum's
+  -- inner value to `wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫)`.
   TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A Bᵢ Bₑ} → Value W
     → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
     → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
-        -→ᵇ (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫) ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+        -→ᵇ ((renᴹ (extN (numBinds Θ′) suc) W
+                ⟪ addLock0 (renᴮ suc Θ′)
+                , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+               ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+
+  -- the ONE congruence the tower run needs: the next redex sits inside
+  -- the boundary the previous step built
+  ξᵇ-⟪⟫ : ∀ {Δ M M′ Θ c} → interior Θ Δ ⊢ M -→ᵇ M′
+        → Δ ⊢ M ⟪ Θ , c ⟫ -→ᵇ M′ ⟪ Θ , c ⟫
 
 -- THE Λ CASE PRESERVES TYPES.  The live proof, with `int` replaced by
 -- `⊢retag` along the refinement above — no `⊢rename`, no `wkᴹ`, no
@@ -472,18 +496,24 @@ preserve-TyPeelR-Λ {Δ = Δ} {N = N} {Θ = Θ} {s = s} {B = B} {A = A}
                         ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
                eqT (⊢instReveal {A = A′} 0 ⊢s)
 
--- DETERMINISM.  The two patterns are DISJOINT — a `Λ` is not a
--- boundary — and each contractum is a function of the redex.  Note what
--- the Λ case buys: its contractum does not mention `Bᵢ` at all, so it is
--- determined by the redex WITHOUT `conv-src-unique`.  (The live rule
--- needs it, because the pushed-in annotation is premise-determined.)
+-- DETERMINISM.  The three patterns are DISJOINT — a `Λ` is not a
+-- boundary, and neither TyPeelR pattern is a boundary at the top — and
+-- each contractum is a function of the redex.  Note what the Λ case
+-- buys: its contractum does not mention `Bᵢ` at all, so it is determined
+-- by the redex WITHOUT `conv-src-unique`.  (The live rule needs it,
+-- because the pushed-in annotation is premise-determined; so does the
+-- repaired wrapper case, for exactly the same reason.)
 detᵇ : ∀ {Δ M M₁ M₂} → Δ ⊢ M -→ᵇ M₁ → Δ ⊢ M -→ᵇ M₂ → M₁ ≡ M₂
 detᵇ (TyPeelR-Λ v ⊢s)  (TyPeelR-Λ v′ ⊢s′)  = refl
 detᵇ (TyPeelR-⟪⟫ {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s} {A = A} v ⊢s)
      (TyPeelR-⟪⟫ v′ ⊢s′) =
-  cong (λ T → (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫) ·[ renameᵗ (extᵗ suc) T , ` 0 ])
+  cong (λ T → ((renᴹ (extN (numBinds Θ′) suc) W
+                  ⟪ addLock0 (renᴮ suc Θ′)
+                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                 ·[ renameᵗ (extᵗ suc) T , ` 0 ])
                 ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫)
        (conv-src-unique ⊢s ⊢s′)
+detᵇ (ξᵇ-⟪⟫ st) (ξᵇ-⟪⟫ st′) = cong (λ M → M ⟪ _ , _ ⟫) (detᵇ st st′)
 
 -- PROGRESS.  `canon-∀` (proof/Canonical) hands the prototype EXACTLY its
 -- two patterns — a `Λ` over a value, or a wrapper with a `∀` conversion —
@@ -524,9 +554,8 @@ TyPeelR-Λ-slot0-old Θ Δ = _ , ez , nameable
 -- WITHOUT resolving anything (which is what fix (c) pays, §13c of
 -- Examples): append `lock 0` to the moved boundary's OWN changes, at the
 -- TAIL, where `applyChanges` runs it FIRST — exactly the position the
--- SCOPE MOVE `_⋉_` puts the travelling changes in.
-addLock0 : CtxMorph → CtxMorph
-addLock0 Θ = morph (binds Θ) (changes Θ ++ (lock 0 ∷ []))
+-- SCOPE MOVE `_⋉_` puts the travelling changes in.  (`addLock0` itself is
+-- defined in §5 above, where the rule that uses it is stated.)
 
 -- the two list facts the frame identity needs
 map-renᶠ-shiftScope : (S : List Change)
@@ -581,13 +610,216 @@ addLock0-sw-l : (A : Ty) (Θ : CtxMorph) (Δ : Ctxᵗ)
   → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ˢ (lock 0 ∷ [])
 addLock0-sw-l A Θ Δ = sw-l (TyPeelR-slot0-nameable A Θ Δ) sw[]
 
--- WHAT REMAINS for (b′) to land as a rule: `Δ ⊢ᵐ addLock0 (renᴮ suc Θ′)`
--- (the reps by `⊢ʳ-ren`, the changes by `⊢ˢ-ren` plus `addLock0-sw-l`
--- and `⊢ˢ-++`), and the moved boundary's CONVERSION re-typed at
+-- WHAT THAT LEAVES: `Δ ⊢ᵐ addLock0 (renᴮ suc Θ′)` (the reps by `⊢ʳ-ren`,
+-- the changes by `⊢ˢ-ren` plus `addLock0-sw-l` and `⊢ˢ-++`), and the
+-- moved boundary's CONVERSION re-typed at
 -- `convCtx (addLock0 (renᴮ suc Θ′)) …` — where the appended lock is
 -- LIFTED (`applyUnlocks` skips locks), so the conversion context is the
 -- renamed one and `conv-ren` suffices.  Neither is new machinery; both
--- are the moves `⊢rename`'s own (env) case already makes.
+-- are the moves `⊢rename`'s own (env) case already makes.  BOTH ARE NOW
+-- DONE: §5c assembles them into `⊢addLock0-cross` and lands (b′) as a
+-- rule.
+
+------------------------------------------------------------------------
+-- §5c  FIX (b′) AS A RULE — the shift is `wkᴹ 1`'s own, plus one lock
+------------------------------------------------------------------------
+
+-- THE RULE IS `TyPeelR-⟪⟫` IN §5.  This section (i) relates its
+-- contractum to `wkᴹ 1`, (ii) proves its PRESERVATION, (iii) records its
+-- FRAME EXACTNESS, (iv) gives the TOWER MEASURE that separates it from
+-- fix (a)'s regress, and (v) runs it on a closed two-deep tower.
+
+-- (i) THE EQUATION.  The contractum's inner value IS `wkᴹ 1` of the
+-- redex's inner value, with `lock 0` appended to the moved boundary's own
+-- change list — nothing else.  `wkᴹ 1` on a boundary renames the interior
+-- at `extN (numBinds Θ′) suc`, the frame by `renᴮ suc` and the conversion
+-- at `extN (numBinds Θ′) suc` (`renᴹ`'s wrapper clause), and that is
+-- exactly what the rule writes.
+addLock0ᵛ : Term → Term
+addLock0ᵛ (` x)          = ` x
+addLock0ᵛ ($ n)          = $ n
+addLock0ᵛ (ƛ A ∙ N)      = ƛ A ∙ N
+addLock0ᵛ (L · M)        = L · M
+addLock0ᵛ (Λ N)          = Λ N
+addLock0ᵛ (L ·[ B , A ]) = L ·[ B , A ]
+addLock0ᵛ (M ⟪ Θ , c ⟫)  = M ⟪ addLock0 Θ , c ⟫
+
+TyPeelR-⟪⟫-wkᴹ : (W : Term) (Θ′ : CtxMorph) (s′ : Conv)
+  → addLock0ᵛ (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫))
+      ≡ (renᴹ (extN (numBinds Θ′) suc) W
+           ⟪ addLock0 (renᴮ suc Θ′)
+           , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+TyPeelR-⟪⟫-wkᴹ W Θ′ s′ = refl
+
+-- (ii) PRESERVATION.  Two facts about `applyUnlocks` first: the appended
+-- lock is LIFTED, so the CONVERSION CONTEXT is the plainly renamed one
+-- and `conv-ren` suffices.  This is what makes the repair free.
+applyUnlocks-++ : (S T : List Change) (Δ : Ctxᵗ)
+  → applyUnlocks (S ++ T) Δ ≡ applyUnlocks S (applyUnlocks T Δ)
+applyUnlocks-++ []             T Δ = refl
+applyUnlocks-++ (unlock X ∷ S) T Δ =
+  cong (unmask X) (applyUnlocks-++ S T Δ)
+applyUnlocks-++ (lock X ∷ S)   T Δ = applyUnlocks-++ S T Δ
+
+unlockedScope-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → unlockedScope (addLock0 Θ) Δ ≡ unlockedScope Θ Δ
+unlockedScope-addLock0 Θ Δ = applyUnlocks-++ (changes Θ) (lock 0 ∷ []) Δ
+
+convCtx-addLock0 : (Θ : CtxMorph) (Δ : Ctxᵗ)
+  → convCtx (addLock0 Θ) Δ ≡ convCtx Θ Δ
+convCtx-addLock0 Θ Δ =
+  cong (pushBinds (binds Θ)) (unlockedScope-addLock0 Θ Δ)
+
+-- THE CROSSING LEMMA — the (b′) analogue of `⊢crossΛ` (strong.TermSubst)
+-- and of PeelDual's `crossing`.  A boundary crosses ONE NEW BIND SLOT,
+-- masking it in its own frame.  Every premise is one move `⊢rename`'s
+-- (env) case already makes:
+--
+--   FRAME     reps by `⊢ʳ-ren` at `ren-unlockedScope` (the appended lock
+--             is lifted); changes by `⊢ˢ-++` — `⊢ˢ-ren` for the shifted
+--             list, over the frame the appended lock leaves, and `sw-l`
+--             for the lock itself, whose slot IS nameable.
+--   INTERIOR  `⊢rename` at `Ren-addLock0` (§5b) ALONE — no `⊢retag`.
+--   CONV      `conv-ren` at `ren-convCtx`, plus `shiftBy-ren` and
+--             `numBinds-ren` arithmetic.
+--   EXTERIOR  `wf-ren Ren-wk`.
+--
+-- NO EXTRA PREMISE.  Everything comes off the redex's own derivation.
+⊢addLock0-cross : ∀ {Δ Γ C W Θ′ c Bᵥ Bₑ}
+  → Δ ⊢ᵐ Θ′
+  → interior Θ′ Δ ∣ [] ⊢ W ⦂ Bᵥ
+  → convCtx Θ′ Δ ⊢ c ∶ Bᵥ ⇝ shiftBy (numBinds Θ′) Bₑ
+  → Δ ⊢ᵗ Bₑ
+    -------------------------------------------------------------------
+  → (unmasked (bind C) ∷ Δ) ∣ Γ
+      ⊢ renᴹ (extN (numBinds Θ′) suc) W
+          ⟪ addLock0 (renᴮ suc Θ′) , renᶜ (extN (numBinds Θ′) suc) c ⟫
+      ⦂ ⇑ᵗ Bₑ
+⊢addLock0-cross {Δ = Δ} {C = C} {W = W} {Θ′ = Θ′} {c = c} {Bᵥ = Bᵥ}
+                {Bₑ = Bₑ} mw′ ⊢W ⊢c wE =
+  env (mw reps chs) intW convW (wf-ren Ren-wk wE)
+  where
+  n′ : ℕ
+  n′ = numBinds Θ′
+
+  Δ⁺ : Ctxᵗ
+  Δ⁺ = unmasked (bind C) ∷ Δ
+
+  Θ″ : CtxMorph
+  Θ″ = addLock0 (renᴮ suc Θ′)
+
+  reps : unlockedScope Θ″ Δ⁺ ⊢ʳ binds Θ″
+  reps = subst (λ Ξ → Ξ ⊢ʳ map (renameᵗ suc) (binds Θ′))
+               (sym (unlockedScope-addLock0 (renᴮ suc Θ′) Δ⁺))
+               (⊢ʳ-ren (ren-unlockedScope Θ′ Ren-wk Inj-suc)
+                       (mw-reps mw′))
+
+  chs : Δ⁺ ⊢ˢ changes Θ″
+  chs = ⊢ˢ-++ (map (renᶠ suc) (changes Θ′)) (lock 0 ∷ [])
+              (⊢ˢ-ren Ren-wk Inj-suc (mw-changes mw′))
+              (sw-l (unmasked (bind (⇑ᵗ C)) , ez , nameable) sw[])
+
+  intW : interior Θ″ Δ⁺ ∣ [] ⊢ renᴹ (extN n′ suc) W
+           ⦂ renameᵗ (extN n′ suc) Bᵥ
+  intW = subst (λ Ξ → Ξ ∣ [] ⊢ renᴹ (extN n′ suc) W
+                        ⦂ renameᵗ (extN n′ suc) Bᵥ)
+               (sym (interior-addLock0 Θ′ C Δ))
+               (⊢rename (Ren-addLock0 Θ′ (masked (bind C)) Δ)
+                        (Inj-extN n′ Inj-suc) ⊢W)
+
+  convW : convCtx Θ″ Δ⁺ ⊢ renᶜ (extN n′ suc) c
+            ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ shiftBy (numBinds Θ″) (⇑ᵗ Bₑ)
+  convW =
+    subst (λ Ξ → Ξ ⊢ renᶜ (extN n′ suc) c ∶ renameᵗ (extN n′ suc) Bᵥ
+                   ⇝ shiftBy (numBinds Θ″) (⇑ᵗ Bₑ))
+          (sym (convCtx-addLock0 (renᴮ suc Θ′) Δ⁺))
+      (subst (λ n → convCtx (renᴮ suc Θ′) Δ⁺ ⊢ renᶜ (extN n′ suc) c
+                      ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ shiftBy n (⇑ᵗ Bₑ))
+             (sym (numBinds-ren suc Θ′))
+        (subst (λ T → convCtx (renᴮ suc Θ′) Δ⁺ ⊢ renᶜ (extN n′ suc) c
+                        ∶ renameᵗ (extN n′ suc) Bᵥ ⇝ T)
+               (shiftBy-ren n′ suc Bₑ)
+               (conv-ren (ren-convCtx Θ′ suc Ren-wk Inj-suc) ⊢c)))
+
+-- THE WRAPPER CASE PRESERVES TYPES.  It is the live proof
+-- (proof/Preserve.preserve-TyPeelR) with `⊢wkV = ⊢rename Ren-wk Inj-suc`
+-- replaced by `⊢addLock0-cross` — the OUTER `env` (frame, conversion,
+-- exterior) is the live proof VERBATIM, exactly as in the Λ case.
+preserve-TyPeelR-⟪⟫ : ∀ {Δ W Θ′ s′ Θ s B A C Bᵢ Bₑ} → Value W
+  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
+  → Δ ∣ [] ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+    ---------------------------------------------------------------------
+  → Δ ∣ [] ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                 ⟪ addLock0 (renᴮ suc Θ′)
+                 , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+               ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫ ⦂ C
+preserve-TyPeelR-⟪⟫ {Δ = Δ} {W = W} {Θ′ = Θ′} {s′ = s′} {Θ = Θ} {s = s}
+                    {B = B} {A = A} {Bᵢ = Bᵢ} {Bₑ = Bₑ} v ⊢s
+                    (⊢·[] (env mwᵥ (env mw′ ⊢W ⊢c′ wE′) ⊢c wE) wA)
+  with conv-all-inv ⊢c
+... | A₀ , B₀ , refl , eqE , ⊢s₀
+  with conv-types-unique ⊢s ⊢s₀
+... | refl , refl =
+  env (mw (rw-b (⊑-wf (Δ⊑unlockedScope Θ Δ) wA) (mw-reps mwᵥ))
+          (mw-changes mwᵥ))
+      int
+      conv
+      (wf-[]ᵗ (wf-∀⁻ wE) wA)
+  where
+  A′ : Ty
+  A′ = shiftBy (numBinds Θ) A
+
+  ⊢INNER : (unmasked (bind A′) ∷ interior Θ Δ) ∣ []
+             ⊢ (renᴹ (extN (numBinds Θ′) suc) W
+                  ⟪ addLock0 (renᴮ suc Θ′)
+                  , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+             ⦂ `∀ (renameᵗ (extᵗ suc) Bᵢ)
+  ⊢INNER = ⊢addLock0-cross mw′ ⊢W ⊢c′ wE′
+
+  int : interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
+          ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                ⟪ addLock0 (renᴮ suc Θ′)
+                , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+               ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+          ⦂ Bᵢ
+  int =
+    subst (λ T → interior (morph (A ∷ binds Θ) (changes Θ)) Δ ∣ []
+                   ⊢ ((renᴹ (extN (numBinds Θ′) suc) W
+                         ⟪ addLock0 (renᴮ suc Θ′)
+                         , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+                        ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+                   ⦂ T)
+          (ren-suc-[0] Bᵢ)
+          (⊢·[] ⊢INNER
+                (wf-var (unmasked (bind (⇑ᵗ A′)) , ez , nameable)))
+
+  eqB : Bₑ ≡ shiftBodyBy (numBinds Θ) B
+  eqB = sym (∀-inj (trans (sym (shiftBy-shiftBodyBy (numBinds Θ) B)) eqE))
+
+  eqT : Bₑ [ 0 := ⇑ᵗ A′ ]ᵗ ≡ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
+  eqT = trans (cong (λ T → T [ 0 := ⇑ᵗ A′ ]ᵗ) eqB)
+              (trans (subst-at-0 A′ (shiftBodyBy (numBinds Θ) B))
+                     (cong ⇑ᵗ (sym (shiftBy-[]ᵗ (numBinds Θ) B A))))
+
+  conv : convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ ⊢ instReveal 0 s
+           ∶ Bᵢ ⇝ shiftBy (suc (numBinds Θ)) (B [ A ]ᵗ)
+  conv = subst (λ T → convCtx (morph (A ∷ binds Θ) (changes Θ)) Δ
+                        ⊢ instReveal 0 s ∶ Bᵢ ⇝ T)
+               eqT (⊢instReveal {A = A′} 0 ⊢s)
+
+-- PRESERVATION FOR THE WHOLE PROTOTYPE.  With both clauses proven the
+-- relation `_⊢_-→ᵇ_` preserves types outright, which is what lets the
+-- run in §5c₃ type every state.
+preserveᵇ : ∀ {Δ M M′ C}
+  → Δ ∣ [] ⊢ M ⦂ C
+  → Δ ⊢ M -→ᵇ M′
+    ---------------
+  → Δ ∣ [] ⊢ M′ ⦂ C
+preserveᵇ ⊢M (TyPeelR-Λ v ⊢s)  = preserve-TyPeelR-Λ v ⊢s ⊢M
+preserveᵇ ⊢M (TyPeelR-⟪⟫ v ⊢s) = preserve-TyPeelR-⟪⟫ v ⊢s ⊢M
+preserveᵇ (env mwᵥ ⊢M ⊢c wE) (ξᵇ-⟪⟫ st) =
+  env mwᵥ (preserveᵇ ⊢M st) ⊢c wE
 
 ------------------------------------------------------------------------
 -- §6  TYBETA — exact up to refinement

--- a/SystemF/agda/strong/proof/ShiftAudit.agda
+++ b/SystemF/agda/strong/proof/ShiftAudit.agda
@@ -822,6 +822,318 @@ preserveᵇ (env mwᵥ ⊢M ⊢c wE) (ξᵇ-⟪⟫ st) =
   env mwᵥ (preserveᵇ ⊢M st) ⊢c wE
 
 ------------------------------------------------------------------------
+-- §5c₁  FRAME EXACTNESS OF THE NEW CLAUSE
+------------------------------------------------------------------------
+
+-- (iii) THE MOVED BOUNDARY'S INTERIOR IS ITS BIRTH FRAME WITH THE NEW
+-- SLOT INSERTED MASKED, BELOW THE INNER BINDS.  `interior-addLock0`
+-- (§5b), instantiated at the rule's own two contexts: the redex reads
+-- the moved boundary at `interior Θ Δ` and the contractum at
+-- `interior (morph (A ∷ binds Θ) (changes Θ)) Δ`, which IS
+-- `unmasked (bind (shiftBy (numBinds Θ) A)) ∷ interior Θ Δ`
+-- (`interior-TyPeelR`, `refl`).
+TyPeelR-⟪⟫-frame : (A : Ty) (Θ Θ′ : CtxMorph) (Δ : Ctxᵗ)
+  → interior (addLock0 (renᴮ suc Θ′))
+             (interior (morph (A ∷ binds Θ) (changes Θ)) Δ)
+      ≡ pushBinds (map ⇑ᵗ (binds Θ′))
+          (masked (bind (shiftBy (numBinds Θ) A))
+             ∷ scope Θ′ (interior Θ Δ))
+TyPeelR-⟪⟫-frame A Θ Θ′ Δ =
+  interior-addLock0 Θ′ (shiftBy (numBinds Θ) A) (interior Θ Δ)
+
+-- … and the BIRTH frame, for comparison: the same `pushBinds` over the
+-- same `scope`, with the binds UNLIFTED and no new slot.  So the move is
+-- criterion (i) — the index shift past ONE crossed binder, which
+-- `map ⇑ᵗ` performs on the reps and `renᴹ (extN (numBinds Θ′) suc)`
+-- performs on the interior — AND NOTHING ELSE.
+TyPeelR-⟪⟫-birth : (Θ′ : CtxMorph) (Ξ : Ctxᵗ)
+  → interior Θ′ Ξ ≡ pushBinds (binds Θ′) (scope Θ′ Ξ)
+TyPeelR-⟪⟫-birth Θ′ Ξ = refl
+
+-- THE NEW SLOT IS UNNAMEABLE THERE — the leak, closed.  (Contrast §3's
+-- `TyPeelR-slot0-nameable`, which is the leak itself; the slot is still
+-- nameable at the OUTER position, which is what authorizes the lock and
+-- what the instantiation node needs.)
+Locked-¬Nameable : ∀ {E} → Locked E → ¬ Nameable E
+Locked-¬Nameable locked ()
+
+∋lk-¬∋tv : ∀ {Δ X} → Δ ∋lk X → ¬ (Δ ∋tv X)
+∋lk-¬∋tv (E , d , lk) (E′ , d′ , nm) with ∋e-det d d′
+... | refl = Locked-¬Nameable lk nm
+
+pushBinds-∋lk0 : (As : List Ty) (E : Ent) (Δ : Ctxᵗ) → Locked E
+  → pushBinds As (E ∷ Δ) ∋lk length As
+pushBinds-∋lk0 []       E Δ lk = _ , ez , renᵉ-Locked lk
+pushBinds-∋lk0 (A ∷ As) E Δ lk with pushBinds-∋lk0 As E Δ lk
+... | _ , d , l = _ , es d , renᵉ-Locked l
+
+TyPeelR-⟪⟫-slot-locked : (Θ′ : CtxMorph) (C : Ty) (Δ : Ctxᵗ)
+  → ¬ (interior (addLock0 (renᴮ suc Θ′)) (unmasked (bind C) ∷ Δ)
+         ∋tv numBinds (renᴮ suc Θ′))
+TyPeelR-⟪⟫-slot-locked Θ′ C Δ =
+  ∋lk-¬∋tv (subst (λ Ξ → Ξ ∋lk numBinds (renᴮ suc Θ′))
+                  (sym (interior-addLock0 Θ′ C Δ))
+                  (pushBinds-∋lk0 (map ⇑ᵗ (binds Θ′)) (masked (bind C))
+                                  (scope Θ′ Δ) locked))
+
+-- THE OUTER BOUNDARY IS THE LIVE RULE'S, UNTOUCHED.  Sharpest form: the
+-- (b′) contractum is the LIVE contractum with `addLock0ᵛ` applied to the
+-- moved value and NOTHING ELSE CHANGED — same outer frame
+-- `morph (A ∷ binds Θ) (changes Θ)`, same minted conversion
+-- `instReveal 0 s`, same pushed-in annotation `renameᵗ (extᵗ suc) Bᵢ`,
+-- same type argument `` ` 0 ``.
+TyPeelR-⟪⟫-outer-unchanged : (W : Term) (Θ′ Θ : CtxMorph) (s′ s : Conv)
+    (A Bᵢ : Ty)
+  → (addLock0ᵛ (wkᴹ 1 (W ⟪ Θ′ , `∀ s′ ⟫))
+       ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+      ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+      ≡ ((renᴹ (extN (numBinds Θ′) suc) W
+            ⟪ addLock0 (renᴮ suc Θ′)
+            , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+           ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
+          ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
+TyPeelR-⟪⟫-outer-unchanged W Θ′ Θ s′ s A Bᵢ = refl
+
+------------------------------------------------------------------------
+-- §5c₂  TERMINATION — THE TOWER MEASURE, AND WHY THIS IS NOT FIX (a)
+------------------------------------------------------------------------
+
+-- (iv) The contractum's inner `(… ⟪ addLock0 … , `∀ s″ ⟫) ·[ … , ` 0 ]`
+-- IS AGAIN A `-→ᵇ` REDEX.  It is NOT fix (a)'s regress, and the measure
+-- says why: the number of nested boundaries above the `Λ`.
+towerHeight : Term → ℕ
+towerHeight (` x)          = 0
+towerHeight ($ n)          = 0
+towerHeight (ƛ A ∙ N)      = 0
+towerHeight (L · M)        = 0
+towerHeight (Λ N)          = 0
+towerHeight (L ·[ B , A ]) = 0
+towerHeight (M ⟪ Θ , c ⟫)  = suc (towerHeight M)
+
+-- The shift does not change it — which is what makes the measure usable
+-- at all, since both candidate repairs shift the moved value.
+towerHeight-renᴹ : (ρ : Renameᵗ) (M : Term)
+  → towerHeight (renᴹ ρ M) ≡ towerHeight M
+towerHeight-renᴹ ρ (` x)          = refl
+towerHeight-renᴹ ρ ($ n)          = refl
+towerHeight-renᴹ ρ (ƛ A ∙ N)      = refl
+towerHeight-renᴹ ρ (L · M)        = refl
+towerHeight-renᴹ ρ (Λ N)          = refl
+towerHeight-renᴹ ρ (L ·[ B , A ]) = refl
+towerHeight-renᴹ ρ (M ⟪ Θ , c ⟫)  =
+  cong suc (towerHeight-renᴹ (extN (numBinds Θ) ρ) M)
+
+-- THE MEASURE STRICTLY DECREASES.  The ∀-value the contractum's inner
+-- `·[]` instantiates is ONE BOUNDARY SHORTER than the one the redex's
+-- `·[]` instantiated.
+TyPeelR-⟪⟫-height : (W : Term) (Θ′ Θ : CtxMorph) (s′ s : Conv)
+  → towerHeight (renᴹ (extN (numBinds Θ′) suc) W
+                   ⟪ addLock0 (renᴮ suc Θ′)
+                   , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
+      ≡ towerHeight ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ∸ 1
+TyPeelR-⟪⟫-height W Θ′ Θ s′ s =
+  cong suc (towerHeight-renᴹ (extN (numBinds Θ′) suc) W)
+
+-- FIX (a) STALLS AT THE SAME MEASURE.  Its contractum's inner ∀-value is
+-- `wkᴹ 1 V` under a FRESH boundary, so the height is the redex's height
+-- again: nothing is consumed, and §4a's `T₀ -→ᵃ T₁ -→ᵃ T₂` is that
+-- stall, twice.  THIS is the difference between (a) and (b′): (b′)
+-- CONSUMES a boundary that was already there, (a) MINTS a new one.
+fixA-height-stalls : (V : Term) (Θ : CtxMorph) (s : Conv) (Bᵢ : Ty)
+  → towerHeight (wkᴹ 1 V ⟪ morph [] (lock 0 ∷ []) , mkId (`∀ Bᵢ) ⟫)
+      ≡ towerHeight (V ⟪ Θ , `∀ s ⟫)
+fixA-height-stalls V Θ s Bᵢ = cong suc (towerHeight-renᴹ (wkN 1) V)
+
+-- WHERE THE DESCENT STOPS.  A `∀`-value of tower height 0 is a `Λ`
+-- (`canon-∀` has no third shape), so once `TyPeelR-⟪⟫` has consumed the
+-- tower it is `TyPeelR-Λ` that fires — and `TyPeelR-Λ` neither shifts nor
+-- locks anything (§5).  So the run is `height` wrapper steps then one Λ
+-- step, and never more.
+canon-∀-height : ∀ {Δ V C} → Value V → Δ ∣ [] ⊢ V ⦂ `∀ C
+  → towerHeight V ≡ 0
+  → Σ[ N ∈ Term ] (Value N × (V ≡ Λ N))
+canon-∀-height v ⊢V eq with canon-∀ v ⊢V
+... | inj₁ p                          = p
+canon-∀-height v ⊢V ()
+    | inj₂ (W , Θ′ , s′ , vW , refl)
+
+-- … stated as the progress clause it decides.  At tower height 0 the
+-- step is `TyPeelR-Λ`, with the contractum named.
+progressᵇ-Λ-at-0 : ∀ {Δ V Θ s B A C} → Value V
+  → Δ ∣ [] ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ] ⦂ C
+  → towerHeight V ≡ 0
+    ----------------------------------------------------------------
+  → Σ[ N ∈ Term ]
+      ((V ≡ Λ N)
+       × (Δ ⊢ (V ⟪ Θ , `∀ s ⟫) ·[ B , A ]
+            -→ᵇ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫))
+progressᵇ-Λ-at-0 v (⊢·[] (env mwᵥ ⊢V ⊢c wE) wA) eq with conv-all-inv ⊢c
+... | A₀ , B₀ , refl , eqₑ , ⊢s with canon-∀-height v ⊢V eq
+... | N , vN , refl = N , refl , TyPeelR-Λ vN ⊢s
+
+------------------------------------------------------------------------
+-- §5c₃  THE RULE ON A CLOSED TWO-DEEP TOWER
+------------------------------------------------------------------------
+
+-- (v) A CLOSED redex whose ∀-value is a two-boundary tower over a `Λ`.
+-- The inner frame LOCKS the outer frame's binder, so the moved boundary
+-- really does carry a change list for the appended lock to join.
+--
+--   Θᵈ  = morph (`ℕ ∷ []) []          the OUTER frame: binds X := ℕ
+--   Θᵈ′ = morph [] (lock 0 ∷ [])      the INNER frame: locks X
+Θᵈ Θᵈ′ : CtxMorph
+Θᵈ  = morph (`ℕ ∷ []) []
+Θᵈ′ = morph [] (lock 0 ∷ [])
+
+Wᵈ innerᵈ outerᵈ U₀ : Term
+Wᵈ     = Λ ($ 3)
+innerᵈ = Wᵈ ⟪ Θᵈ′ , `∀ (id `ℕ) ⟫
+outerᵈ = innerᵈ ⟪ Θᵈ , `∀ (id `ℕ) ⟫
+U₀     = outerᵈ ·[ `ℕ , `ℕ ]
+
+valᵈ : Value outerᵈ
+valᵈ = V-⟪⟫ (V-⟪⟫ (V-Λ V-$) I-all) I-all
+
+-- the frames, spelled out
+_ : interior Θᵈ [] ≡ unmasked (bind `ℕ) ∷ []
+_ = refl
+
+_ : interior Θᵈ′ (interior Θᵈ []) ≡ masked (bind `ℕ) ∷ []
+_ = refl
+
+⊢innerᵈ : interior Θᵈ [] ∣ [] ⊢ innerᵈ ⦂ `∀ `ℕ
+⊢innerᵈ = env (mw rw[] (sw-l (unmasked (bind `ℕ) , ez , nameable) sw[]))
+               (⊢Λ ⊢$) (conv-all (conv-id base-ℕ)) (wf-∀ wf-ℕ)
+
+⊢outerᵈ : [] ∣ [] ⊢ outerᵈ ⦂ `∀ `ℕ
+⊢outerᵈ = env (mw (rw-b wf-ℕ rw[]) sw[]) ⊢innerᵈ
+               (conv-all (conv-id base-ℕ)) (wf-∀ wf-ℕ)
+
+⊢U₀ : [] ∣ [] ⊢ U₀ ⦂ `ℕ
+⊢U₀ = ⊢·[] ⊢outerᵈ wf-ℕ
+
+-- STEP 1 — `TyPeelR-⟪⟫`.  The moved boundary's own change list grows by
+-- `lock 0` at the TAIL: `lock 0 ∷ []` becomes `lock 1 ∷ lock 0 ∷ []` —
+-- the SHIFTED original lock (X, now one slot out) and the NEW lock (the
+-- binder this step introduces).  No wrapper is minted.
+U₁ : Term
+U₁ = (((Λ ($ 3)) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , `∀ (id `ℕ) ⟫)
+        ·[ `ℕ , ` 0 ])
+       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id `ℕ ⟫
+
+stepᵈ₁ : [] ⊢ U₀ -→ᵇ U₁
+stepᵈ₁ = TyPeelR-⟪⟫ (V-Λ V-$) (conv-id base-ℕ)
+
+⊢U₁ : [] ∣ [] ⊢ U₁ ⦂ `ℕ
+⊢U₁ = preserveᵇ ⊢U₀ stepᵈ₁
+
+-- THE FRAME, AT THIS STEP.  The moved boundary's interior has BOTH slots
+-- masked: X (shifted to slot 1) as it was in the redex, and the new
+-- binder (slot 0) by the appended lock.  Nothing gained.
+_ : interior (morph (`ℕ ∷ `ℕ ∷ [])  []) []
+      ≡ unmasked (bind `ℕ) ∷ unmasked (bind `ℕ) ∷ []
+_ = refl
+
+_ : interior (morph [] (lock 1 ∷ lock 0 ∷ []))
+             (interior (morph (`ℕ ∷ `ℕ ∷ []) []) [])
+      ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ = refl
+
+-- … and it is the frame identity `interior-addLock0` at this instance
+-- (the birth frame `masked (bind `ℕ) ∷ []`, with the new slot inserted
+-- MASKED below the — empty — bind prefix).
+_ : interior (addLock0 (renᴮ suc Θᵈ′))
+             (interior (morph (`ℕ ∷ binds Θᵈ) (changes Θᵈ)) [])
+      ≡ pushBinds (map ⇑ᵗ (binds Θᵈ′))
+          (masked (bind `ℕ) ∷ scope Θᵈ′ (interior Θᵈ []))
+_ = TyPeelR-⟪⟫-frame `ℕ Θᵈ Θᵈ′ []
+
+-- STEP 2 — the tower is exhausted, so `TyPeelR-Λ` fires, INSIDE the
+-- boundary step 1 built.  No shift, no lock: TyBeta's own step.
+U₂ : Term
+U₂ = (($ 3) ⟪ morph ((` 0) ∷ []) (lock 1 ∷ lock 0 ∷ []) , id `ℕ ⟫)
+       ⟪ morph (`ℕ ∷ `ℕ ∷ []) [] , id `ℕ ⟫
+
+stepᵈ₂ : [] ⊢ U₁ -→ᵇ U₂
+stepᵈ₂ = ξᵇ-⟪⟫ (TyPeelR-Λ V-$ (conv-id base-ℕ))
+
+⊢U₂ : [] ∣ [] ⊢ U₂ ⦂ `ℕ
+⊢U₂ = preserveᵇ ⊢U₁ stepᵈ₂
+
+-- THE MEASURE, ON THIS RUN: 2 → 1, and at 1 the interior is a `Λ`.
+_ : towerHeight outerᵈ ≡ 2
+_ = refl
+
+_ : towerHeight ((Λ ($ 3)) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , `∀ (id `ℕ) ⟫)
+      ≡ 1
+_ = refl
+
+_ : towerHeight ((Λ ($ 3)) ⟪ morph [] (lock 1 ∷ lock 0 ∷ []) , `∀ (id `ℕ) ⟫)
+      ≡ towerHeight outerᵈ ∸ 1
+_ = TyPeelR-⟪⟫-height Wᵈ Θᵈ′ Θᵈ (id `ℕ) (id `ℕ)
+
+------------------------------------------------------------------------
+-- §5c₄  TIGHTNESS OF THE NEW CLAUSE (Examples §15b, for the wrapper)
+------------------------------------------------------------------------
+
+-- Jeremy's test, on the repaired clause.  An ILL-TYPED `W` — ill typed
+-- for exactly one localized reason, `wf-var` at a masked slot — must stay
+-- ill typed in the contractum.  Here the OUTER frame locks X and the
+-- INNER frame does nothing, so `prb 0` names the locked slot.
+Δᵛ Θᵛ-ext : Ctxᵗ
+Δᵛ      = unmasked (bind `ℕ) ∷ []
+Θᵛ-ext  = masked (bind `ℕ) ∷ []
+
+Θᵛ Θᵛ′ : CtxMorph
+Θᵛ  = morph [] (lock 0 ∷ [])          -- the OUTER frame: locks X
+Θᵛ′ = morph [] []                     -- the INNER frame: nothing
+
+_ : interior Θᵛ Δᵛ ≡ Θᵛ-ext
+_ = refl
+
+_ : interior Θᵛ′ (interior Θᵛ Δᵛ) ≡ Θᵛ-ext
+_ = refl
+
+Rᵛ Cᵛ : Term
+Rᵛ = ((prb 0 ⟪ Θᵛ′ , `∀ (id `ℕ) ⟫) ⟪ Θᵛ , `∀ (id `ℕ) ⟫) ·[ `ℕ , `ℕ ]
+Cᵛ = ((prb 1 ⟪ morph [] (lock 0 ∷ []) , `∀ (id `ℕ) ⟫) ·[ `ℕ , ` 0 ])
+       ⟪ morph (`ℕ ∷ []) (lock 0 ∷ []) , id `ℕ ⟫
+
+stepᵛ : Δᵛ ⊢ Rᵛ -→ᵇ Cᵛ
+stepᵛ = TyPeelR-⟪⟫ val-prb (conv-id base-ℕ)
+
+-- THE FAULT, in the redex: `⊢·[]`'s `Δ ⊢ᵗ A` at slot 0, which the outer
+-- frame masks.
+¬⊢prb0 : ∀ {Γ A} → ¬ ((masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 0 ⦂ A)
+¬⊢prb0 (⊢ƛ _ (⊢·[] _ (wf-var (_ , ez , ()))))
+
+¬⊢Rᵛ : ∀ {A} → ¬ (Δᵛ ∣ [] ⊢ Rᵛ ⦂ A)
+¬⊢Rᵛ (⊢·[] (env _ (env _ ⊢W _ _) _ _) _) = ¬⊢prb0 ⊢W
+
+-- THE CONTRACTUM'S FRAME.  The new slot is at 0 and it is MASKED (the
+-- appended lock); the old fault has moved to slot 1 with the shift and is
+-- masked there as it was.  BOTH masks are visible in one context.
+_ : interior (morph [] (lock 0 ∷ []))
+             (interior (morph (`ℕ ∷ []) (lock 0 ∷ [])) Δᵛ)
+      ≡ masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []
+_ = refl
+
+-- the frame-exact point, as the general lemma at this instance: slot 0 —
+-- the slot the live rule offered UNMASKED (§3) — is unnameable
+_ : ¬ (interior (addLock0 (renᴮ suc Θᵛ′))
+                (unmasked (bind `ℕ) ∷ interior Θᵛ Δᵛ)
+         ∋tv 0)
+_ = TyPeelR-⟪⟫-slot-locked Θᵛ′ `ℕ (interior Θᵛ Δᵛ)
+
+-- … so the contractum is REFUSED, for the same localized reason.
+¬⊢prb1 : ∀ {Γ A}
+  → ¬ ((masked (bind `ℕ) ∷ masked (bind `ℕ) ∷ []) ∣ Γ ⊢ prb 1 ⦂ A)
+¬⊢prb1 (⊢ƛ _ (⊢·[] _ (wf-var (_ , es ez , ()))))
+
+¬⊢Cᵛ : ∀ {A} → ¬ (Δᵛ ∣ [] ⊢ Cᵛ ⦂ A)
+¬⊢Cᵛ (env _ (⊢·[] (env _ ⊢W _ _) _) _ _) = ¬⊢prb1 ⊢W
+
+------------------------------------------------------------------------
 -- §6  TYBETA — exact up to refinement
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Installs the repair for the one frame leak the shift audit (PR #201) found. Contains #201's commits (branch based on shift-audit); if #201 merges first the diff shrinks to the install.

**The leak.** TyPeelR shifted its value `V` by `wkᴹ 1` under the new bind slot `X := A`, unmasked in V's frame though V was authored where the slot did not exist. Unreachable by index (so §15b could not see it), but the frame did not tell the truth: live and tight frames differ by exactly one `le-mu`.

**The repair: TyPeelR is replaced by two clauses**, total over canonical ∀-values (`canon-∀`):

```agda
TyPeelR-Λ : Value N
  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
  → Δ ⊢ ((Λ N) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
      -→ N ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫

TyPeelR-⟪⟫ : Value W
  → (unmasked abst ∷ convCtx Θ Δ) ⊢ s ∶ Bᵢ ⇝ Bₑ
  → Δ ⊢ ((W ⟪ Θ′ , `∀ s′ ⟫) ⟪ Θ , `∀ s ⟫) ·[ B , A ]
      -→ ((renᴹ (extN (numBinds Θ′) suc) W
             ⟪ addLock0 (renᴮ suc Θ′)
             , `∀ (renᶜ (extᵗ (extN (numBinds Θ′) suc)) s′) ⟫)
            ·[ renameᵗ (extᵗ suc) Bᵢ , ` 0 ])
          ⟪ morph (A ∷ binds Θ) (changes Θ) , instReveal 0 s ⟫
```

* Λ clause: NO shift; the Λ's `abst` slot becomes the boundary's `bind A` slot (TyBeta's own refinement).
* Wrapper clause: the moved inner boundary gets `lock 0` appended at the TAIL of its own shifted change list (`addLock0`, CtxMorph §5); no wrapper minted. Contractum = the live one with `addLock0ᵛ` on the moved value (`TyPeelR-⟪⟫-wkᴹ`, refl). Inner interior ≡ birth frame with the new slot inserted MASKED (`TyPeelR-⟪⟫-frame`/`-slot-locked`). Terminates: `towerHeight` drops by one per step (`TyPeelR-⟪⟫-height`); the wrap-in-dual alternative stalls the measure (`fixA-height-stalls`) — that was the loop.

**Theorems** (TypeSafety.agda, parameter-free, --safe): progress (the single TyPeelR case is now the two-way split, `progress-·[]-∀conv`), preservation (`preserve-TyPeelR-Λ`, `preserve-TyPeelR-⟪⟫` via the crossing lemma `⊢addLock0-cross`, TermSubst §6 next to `⊢crossΛ`), determinism, type safety — all re-checked.

**Measured effect** (Examples, pins re-measured with the renderer, no hand edits): one type instantiation now mints ONE binder where TyPeelR ⨟ TyBeta minted two. J₀ 14 → 11 steps; E₀ 6 → 5 (ends in a value); T₉'s birth story 2 → 1 step; P₀ Q₀ R₀ L₀ Ri G unchanged. §15b now also shows the new slot masked in the contractum (`Ξᵇ-single` vs `Ξᵇ-split`). Two-deep closed run in `proof/ShiftAudit.agda` §5c₃:

```
(((ΛY. 3) ⟪ ↓X , (∀Y. id ℕ) ⟫) ⟪ ↑X:=ℕ , (∀Y. id ℕ) ⟫) [ℕ]
  → (((ΛZ. 3) ⟪ ↓X , ↓Y , (∀Z. id ℕ) ⟫) [Y] ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)      TyPeelR-⟪⟫
  → ((3 ⟪ ↑Z:=Y , ↓X , ↓Y , id ℕ ⟫) ⟪ ↑Y:=ℕ , ↑X:=ℕ , id ℕ ⟫)               ξ TyPeelR-Λ
```

**Housekeeping.** `proof/ShiftAudit.agda`'s prototype relation is deleted; the refutation of fix (a) and the frame identities are restated against the live rules. `applyChanges-++`/`applyUnlocks-++`/`⊢ˢ-++` moved from proof/PeelDual up to CtxMorph. Design.md §6.4 rewritten around the two clauses, §7 table all exact (no OPEN row), §9 history; README rule count eight; notes/ShiftAudit.md verdict updated; DECISIONS entry. Note for #200 (normalize-changes): its §16 growth pins will need re-measuring after this lands.

`make -C strong check`: exit 0, postulate-check OK.
